### PR TITLE
Refine PHP json AST

### DIFF
--- a/tests/json-ast/x/php/append_builtin.php.json
+++ b/tests/json-ast/x/php/append_builtin.php.json
@@ -1,791 +1,354 @@
 {
-  "root": [
+  "statements": [
     {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 2,
-        "startTokenPos": 1,
-        "startFilePos": 6,
-        "endLine": 2,
-        "endTokenPos": 11,
-        "endFilePos": 17
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 2,
-          "startTokenPos": 1,
-          "startFilePos": 6,
-          "endLine": 2,
-          "endTokenPos": 10,
-          "endFilePos": 16
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 1,
-            "startFilePos": 6,
-            "endLine": 2,
-            "endTokenPos": 1,
-            "endFilePos": 7
-          },
-          "name": "a"
-        },
-        "expr": {
-          "nodeType": "Expr_Array",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 5,
-            "startFilePos": 11,
-            "endLine": 2,
-            "endTokenPos": 10,
-            "endFilePos": 16,
-            "kind": 2
-          },
-          "items": [
+      "kind": "expression_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
             {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 6,
-                "startFilePos": 12,
-                "endLine": 2,
-                "endTokenPos": 6,
-                "endFilePos": 12
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 6,
-                  "startFilePos": 12,
-                  "endLine": 2,
-                  "endTokenPos": 6,
-                  "endFilePos": 12,
-                  "rawValue": "1",
-                  "kind": 10
-                },
-                "value": 1
-              },
-              "byRef": false,
-              "unpack": false
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "a"
+                }
+              ]
             },
             {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 9,
-                "startFilePos": 15,
-                "endLine": 2,
-                "endTokenPos": 9,
-                "endFilePos": 15
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 9,
-                  "startFilePos": 15,
-                  "endLine": 2,
-                  "endTokenPos": 9,
-                  "endFilePos": 15,
-                  "rawValue": "2",
-                  "kind": 10
+              "kind": "array_creation_expression",
+              "children": [
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "integer",
+                      "text": "1"
+                    }
+                  ]
                 },
-                "value": 2
-              },
-              "byRef": false,
-              "unpack": false
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "integer",
+                      "text": "2"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }
-      }
+      ]
     },
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 3,
-        "startTokenPos": 13,
-        "startFilePos": 19,
-        "endLine": 3,
-        "endTokenPos": 78,
-        "endFilePos": 204
-      },
-      "exprs": [
+      "kind": "echo_statement",
+      "children": [
         {
-          "nodeType": "Expr_FuncCall",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 15,
-            "startFilePos": 24,
-            "endLine": 3,
-            "endTokenPos": 74,
-            "endFilePos": 194
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 3,
-              "startTokenPos": 15,
-              "startFilePos": 24,
-              "endLine": 3,
-              "endTokenPos": 15,
-              "endFilePos": 34
-            },
-            "name": "str_replace"
-          },
-          "args": [
+          "kind": "sequence_expression",
+          "children": [
             {
-              "nodeType": "Arg",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 17,
-                "startFilePos": 36,
-                "endLine": 3,
-                "endTokenPos": 17,
-                "endFilePos": 42
-              },
-              "name": null,
-              "value": {
-                "nodeType": "Scalar_String",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 17,
-                  "startFilePos": 36,
-                  "endLine": 3,
-                  "endTokenPos": 17,
-                  "endFilePos": 42,
-                  "kind": 2,
-                  "rawValue": "\"false\""
+              "kind": "function_call_expression",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "str_replace"
                 },
-                "value": "false"
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "Arg",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 20,
-                "startFilePos": 45,
-                "endLine": 3,
-                "endTokenPos": 20,
-                "endFilePos": 51
-              },
-              "name": null,
-              "value": {
-                "nodeType": "Scalar_String",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 20,
-                  "startFilePos": 45,
-                  "endLine": 3,
-                  "endTokenPos": 20,
-                  "endFilePos": 51,
-                  "kind": 2,
-                  "rawValue": "\"False\""
-                },
-                "value": "False"
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "Arg",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 23,
-                "startFilePos": 54,
-                "endLine": 3,
-                "endTokenPos": 73,
-                "endFilePos": 193
-              },
-              "name": null,
-              "value": {
-                "nodeType": "Expr_FuncCall",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 23,
-                  "startFilePos": 54,
-                  "endLine": 3,
-                  "endTokenPos": 73,
-                  "endFilePos": 193
-                },
-                "name": {
-                  "nodeType": "Name",
-                  "attributes": {
-                    "startLine": 3,
-                    "startTokenPos": 23,
-                    "startFilePos": 54,
-                    "endLine": 3,
-                    "endTokenPos": 23,
-                    "endFilePos": 64
-                  },
-                  "name": "str_replace"
-                },
-                "args": [
-                  {
-                    "nodeType": "Arg",
-                    "attributes": {
-                      "startLine": 3,
-                      "startTokenPos": 25,
-                      "startFilePos": 66,
-                      "endLine": 3,
-                      "endTokenPos": 25,
-                      "endFilePos": 71
-                    },
-                    "name": null,
-                    "value": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 3,
-                        "startTokenPos": 25,
-                        "startFilePos": 66,
-                        "endLine": 3,
-                        "endTokenPos": 25,
-                        "endFilePos": 71,
-                        "kind": 2,
-                        "rawValue": "\"true\""
-                      },
-                      "value": "true"
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  },
-                  {
-                    "nodeType": "Arg",
-                    "attributes": {
-                      "startLine": 3,
-                      "startTokenPos": 28,
-                      "startFilePos": 74,
-                      "endLine": 3,
-                      "endTokenPos": 28,
-                      "endFilePos": 79
-                    },
-                    "name": null,
-                    "value": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 3,
-                        "startTokenPos": 28,
-                        "startFilePos": 74,
-                        "endLine": 3,
-                        "endTokenPos": 28,
-                        "endFilePos": 79,
-                        "kind": 2,
-                        "rawValue": "\"True\""
-                      },
-                      "value": "True"
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  },
-                  {
-                    "nodeType": "Arg",
-                    "attributes": {
-                      "startLine": 3,
-                      "startTokenPos": 31,
-                      "startFilePos": 82,
-                      "endLine": 3,
-                      "endTokenPos": 72,
-                      "endFilePos": 192
-                    },
-                    "name": null,
-                    "value": {
-                      "nodeType": "Expr_FuncCall",
-                      "attributes": {
-                        "startLine": 3,
-                        "startTokenPos": 31,
-                        "startFilePos": 82,
-                        "endLine": 3,
-                        "endTokenPos": 72,
-                        "endFilePos": 192
-                      },
-                      "name": {
-                        "nodeType": "Name",
-                        "attributes": {
-                          "startLine": 3,
-                          "startTokenPos": 31,
-                          "startFilePos": 82,
-                          "endLine": 3,
-                          "endTokenPos": 31,
-                          "endFilePos": 92
-                        },
-                        "name": "str_replace"
-                      },
-                      "args": [
+                {
+                  "kind": "arguments",
+                  "children": [
+                    {
+                      "kind": "argument",
+                      "children": [
                         {
-                          "nodeType": "Arg",
-                          "attributes": {
-                            "startLine": 3,
-                            "startTokenPos": 33,
-                            "startFilePos": 94,
-                            "endLine": 3,
-                            "endTokenPos": 33,
-                            "endFilePos": 97
-                          },
-                          "name": null,
-                          "value": {
-                            "nodeType": "Scalar_String",
-                            "attributes": {
-                              "startLine": 3,
-                              "startTokenPos": 33,
-                              "startFilePos": 94,
-                              "endLine": 3,
-                              "endTokenPos": 33,
-                              "endFilePos": 97,
-                              "kind": 2,
-                              "rawValue": "\"\\\"\""
-                            },
-                            "value": "\""
-                          },
-                          "byRef": false,
-                          "unpack": false
-                        },
-                        {
-                          "nodeType": "Arg",
-                          "attributes": {
-                            "startLine": 3,
-                            "startTokenPos": 36,
-                            "startFilePos": 100,
-                            "endLine": 3,
-                            "endTokenPos": 36,
-                            "endFilePos": 102
-                          },
-                          "name": null,
-                          "value": {
-                            "nodeType": "Scalar_String",
-                            "attributes": {
-                              "startLine": 3,
-                              "startTokenPos": 36,
-                              "startFilePos": 100,
-                              "endLine": 3,
-                              "endTokenPos": 36,
-                              "endFilePos": 102,
-                              "kind": 2,
-                              "rawValue": "\"'\""
-                            },
-                            "value": "'"
-                          },
-                          "byRef": false,
-                          "unpack": false
-                        },
-                        {
-                          "nodeType": "Arg",
-                          "attributes": {
-                            "startLine": 3,
-                            "startTokenPos": 39,
-                            "startFilePos": 105,
-                            "endLine": 3,
-                            "endTokenPos": 71,
-                            "endFilePos": 191
-                          },
-                          "name": null,
-                          "value": {
-                            "nodeType": "Expr_FuncCall",
-                            "attributes": {
-                              "startLine": 3,
-                              "startTokenPos": 39,
-                              "startFilePos": 105,
-                              "endLine": 3,
-                              "endTokenPos": 71,
-                              "endFilePos": 191
-                            },
-                            "name": {
-                              "nodeType": "Name",
-                              "attributes": {
-                                "startLine": 3,
-                                "startTokenPos": 39,
-                                "startFilePos": 105,
-                                "endLine": 3,
-                                "endTokenPos": 39,
-                                "endFilePos": 115
-                              },
-                              "name": "str_replace"
-                            },
-                            "args": [
-                              {
-                                "nodeType": "Arg",
-                                "attributes": {
-                                  "startLine": 3,
-                                  "startTokenPos": 41,
-                                  "startFilePos": 117,
-                                  "endLine": 3,
-                                  "endTokenPos": 41,
-                                  "endFilePos": 119
-                                },
-                                "name": null,
-                                "value": {
-                                  "nodeType": "Scalar_String",
-                                  "attributes": {
-                                    "startLine": 3,
-                                    "startTokenPos": 41,
-                                    "startFilePos": 117,
-                                    "endLine": 3,
-                                    "endTokenPos": 41,
-                                    "endFilePos": 119,
-                                    "kind": 2,
-                                    "rawValue": "\":\""
-                                  },
-                                  "value": ":"
-                                },
-                                "byRef": false,
-                                "unpack": false
-                              },
-                              {
-                                "nodeType": "Arg",
-                                "attributes": {
-                                  "startLine": 3,
-                                  "startTokenPos": 44,
-                                  "startFilePos": 122,
-                                  "endLine": 3,
-                                  "endTokenPos": 44,
-                                  "endFilePos": 125
-                                },
-                                "name": null,
-                                "value": {
-                                  "nodeType": "Scalar_String",
-                                  "attributes": {
-                                    "startLine": 3,
-                                    "startTokenPos": 44,
-                                    "startFilePos": 122,
-                                    "endLine": 3,
-                                    "endTokenPos": 44,
-                                    "endFilePos": 125,
-                                    "kind": 2,
-                                    "rawValue": "\": \""
-                                  },
-                                  "value": ": "
-                                },
-                                "byRef": false,
-                                "unpack": false
-                              },
-                              {
-                                "nodeType": "Arg",
-                                "attributes": {
-                                  "startLine": 3,
-                                  "startTokenPos": 47,
-                                  "startFilePos": 128,
-                                  "endLine": 3,
-                                  "endTokenPos": 70,
-                                  "endFilePos": 190
-                                },
-                                "name": null,
-                                "value": {
-                                  "nodeType": "Expr_FuncCall",
-                                  "attributes": {
-                                    "startLine": 3,
-                                    "startTokenPos": 47,
-                                    "startFilePos": 128,
-                                    "endLine": 3,
-                                    "endTokenPos": 70,
-                                    "endFilePos": 190
-                                  },
-                                  "name": {
-                                    "nodeType": "Name",
-                                    "attributes": {
-                                      "startLine": 3,
-                                      "startTokenPos": 47,
-                                      "startFilePos": 128,
-                                      "endLine": 3,
-                                      "endTokenPos": 47,
-                                      "endFilePos": 138
-                                    },
-                                    "name": "str_replace"
-                                  },
-                                  "args": [
-                                    {
-                                      "nodeType": "Arg",
-                                      "attributes": {
-                                        "startLine": 3,
-                                        "startTokenPos": 49,
-                                        "startFilePos": 140,
-                                        "endLine": 3,
-                                        "endTokenPos": 49,
-                                        "endFilePos": 142
-                                      },
-                                      "name": null,
-                                      "value": {
-                                        "nodeType": "Scalar_String",
-                                        "attributes": {
-                                          "startLine": 3,
-                                          "startTokenPos": 49,
-                                          "startFilePos": 140,
-                                          "endLine": 3,
-                                          "endTokenPos": 49,
-                                          "endFilePos": 142,
-                                          "kind": 2,
-                                          "rawValue": "\",\""
-                                        },
-                                        "value": ","
-                                      },
-                                      "byRef": false,
-                                      "unpack": false
-                                    },
-                                    {
-                                      "nodeType": "Arg",
-                                      "attributes": {
-                                        "startLine": 3,
-                                        "startTokenPos": 52,
-                                        "startFilePos": 145,
-                                        "endLine": 3,
-                                        "endTokenPos": 52,
-                                        "endFilePos": 148
-                                      },
-                                      "name": null,
-                                      "value": {
-                                        "nodeType": "Scalar_String",
-                                        "attributes": {
-                                          "startLine": 3,
-                                          "startTokenPos": 52,
-                                          "startFilePos": 145,
-                                          "endLine": 3,
-                                          "endTokenPos": 52,
-                                          "endFilePos": 148,
-                                          "kind": 2,
-                                          "rawValue": "\", \""
-                                        },
-                                        "value": ", "
-                                      },
-                                      "byRef": false,
-                                      "unpack": false
-                                    },
-                                    {
-                                      "nodeType": "Arg",
-                                      "attributes": {
-                                        "startLine": 3,
-                                        "startTokenPos": 55,
-                                        "startFilePos": 151,
-                                        "endLine": 3,
-                                        "endTokenPos": 69,
-                                        "endFilePos": 189
-                                      },
-                                      "name": null,
-                                      "value": {
-                                        "nodeType": "Expr_FuncCall",
-                                        "attributes": {
-                                          "startLine": 3,
-                                          "startTokenPos": 55,
-                                          "startFilePos": 151,
-                                          "endLine": 3,
-                                          "endTokenPos": 69,
-                                          "endFilePos": 189
-                                        },
-                                        "name": {
-                                          "nodeType": "Name",
-                                          "attributes": {
-                                            "startLine": 3,
-                                            "startTokenPos": 55,
-                                            "startFilePos": 151,
-                                            "endLine": 3,
-                                            "endTokenPos": 55,
-                                            "endFilePos": 161
-                                          },
-                                          "name": "json_encode"
-                                        },
-                                        "args": [
-                                          {
-                                            "nodeType": "Arg",
-                                            "attributes": {
-                                              "startLine": 3,
-                                              "startTokenPos": 57,
-                                              "startFilePos": 163,
-                                              "endLine": 3,
-                                              "endTokenPos": 65,
-                                              "endFilePos": 182
-                                            },
-                                            "name": null,
-                                            "value": {
-                                              "nodeType": "Expr_FuncCall",
-                                              "attributes": {
-                                                "startLine": 3,
-                                                "startTokenPos": 57,
-                                                "startFilePos": 163,
-                                                "endLine": 3,
-                                                "endTokenPos": 65,
-                                                "endFilePos": 182
-                                              },
-                                              "name": {
-                                                "nodeType": "Name",
-                                                "attributes": {
-                                                  "startLine": 3,
-                                                  "startTokenPos": 57,
-                                                  "startFilePos": 163,
-                                                  "endLine": 3,
-                                                  "endTokenPos": 57,
-                                                  "endFilePos": 173
-                                                },
-                                                "name": "array_merge"
-                                              },
-                                              "args": [
-                                                {
-                                                  "nodeType": "Arg",
-                                                  "attributes": {
-                                                    "startLine": 3,
-                                                    "startTokenPos": 59,
-                                                    "startFilePos": 175,
-                                                    "endLine": 3,
-                                                    "endTokenPos": 59,
-                                                    "endFilePos": 176
-                                                  },
-                                                  "name": null,
-                                                  "value": {
-                                                    "nodeType": "Expr_Variable",
-                                                    "attributes": {
-                                                      "startLine": 3,
-                                                      "startTokenPos": 59,
-                                                      "startFilePos": 175,
-                                                      "endLine": 3,
-                                                      "endTokenPos": 59,
-                                                      "endFilePos": 176
-                                                    },
-                                                    "name": "a"
-                                                  },
-                                                  "byRef": false,
-                                                  "unpack": false
-                                                },
-                                                {
-                                                  "nodeType": "Arg",
-                                                  "attributes": {
-                                                    "startLine": 3,
-                                                    "startTokenPos": 62,
-                                                    "startFilePos": 179,
-                                                    "endLine": 3,
-                                                    "endTokenPos": 64,
-                                                    "endFilePos": 181
-                                                  },
-                                                  "name": null,
-                                                  "value": {
-                                                    "nodeType": "Expr_Array",
-                                                    "attributes": {
-                                                      "startLine": 3,
-                                                      "startTokenPos": 62,
-                                                      "startFilePos": 179,
-                                                      "endLine": 3,
-                                                      "endTokenPos": 64,
-                                                      "endFilePos": 181,
-                                                      "kind": 2
-                                                    },
-                                                    "items": [
-                                                      {
-                                                        "nodeType": "ArrayItem",
-                                                        "attributes": {
-                                                          "startLine": 3,
-                                                          "startTokenPos": 63,
-                                                          "startFilePos": 180,
-                                                          "endLine": 3,
-                                                          "endTokenPos": 63,
-                                                          "endFilePos": 180
-                                                        },
-                                                        "key": null,
-                                                        "value": {
-                                                          "nodeType": "Scalar_Int",
-                                                          "attributes": {
-                                                            "startLine": 3,
-                                                            "startTokenPos": 63,
-                                                            "startFilePos": 180,
-                                                            "endLine": 3,
-                                                            "endTokenPos": 63,
-                                                            "endFilePos": 180,
-                                                            "rawValue": "3",
-                                                            "kind": 10
-                                                          },
-                                                          "value": 3
-                                                        },
-                                                        "byRef": false,
-                                                        "unpack": false
-                                                      }
-                                                    ]
-                                                  },
-                                                  "byRef": false,
-                                                  "unpack": false
-                                                }
-                                              ]
-                                            },
-                                            "byRef": false,
-                                            "unpack": false
-                                          },
-                                          {
-                                            "nodeType": "Arg",
-                                            "attributes": {
-                                              "startLine": 3,
-                                              "startTokenPos": 68,
-                                              "startFilePos": 185,
-                                              "endLine": 3,
-                                              "endTokenPos": 68,
-                                              "endFilePos": 188
-                                            },
-                                            "name": null,
-                                            "value": {
-                                              "nodeType": "Scalar_Int",
-                                              "attributes": {
-                                                "startLine": 3,
-                                                "startTokenPos": 68,
-                                                "startFilePos": 185,
-                                                "endLine": 3,
-                                                "endTokenPos": 68,
-                                                "endFilePos": 188,
-                                                "rawValue": "1344",
-                                                "kind": 10
-                                              },
-                                              "value": 1344
-                                            },
-                                            "byRef": false,
-                                            "unpack": false
-                                          }
-                                        ]
-                                      },
-                                      "byRef": false,
-                                      "unpack": false
-                                    }
-                                  ]
-                                },
-                                "byRef": false,
-                                "unpack": false
-                              }
-                            ]
-                          },
-                          "byRef": false,
-                          "unpack": false
+                          "kind": "encapsed_string",
+                          "children": [
+                            {
+                              "kind": "string_content",
+                              "text": "false"
+                            }
+                          ]
                         }
                       ]
                     },
-                    "byRef": false,
-                    "unpack": false
-                  }
-                ]
-              },
-              "byRef": false,
-              "unpack": false
+                    {
+                      "kind": "argument",
+                      "children": [
+                        {
+                          "kind": "encapsed_string",
+                          "children": [
+                            {
+                              "kind": "string_content",
+                              "text": "False"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "argument",
+                      "children": [
+                        {
+                          "kind": "function_call_expression",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "str_replace"
+                            },
+                            {
+                              "kind": "arguments",
+                              "children": [
+                                {
+                                  "kind": "argument",
+                                  "children": [
+                                    {
+                                      "kind": "encapsed_string",
+                                      "children": [
+                                        {
+                                          "kind": "string_content",
+                                          "text": "true"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "argument",
+                                  "children": [
+                                    {
+                                      "kind": "encapsed_string",
+                                      "children": [
+                                        {
+                                          "kind": "string_content",
+                                          "text": "True"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "argument",
+                                  "children": [
+                                    {
+                                      "kind": "function_call_expression",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "str_replace"
+                                        },
+                                        {
+                                          "kind": "arguments",
+                                          "children": [
+                                            {
+                                              "kind": "argument",
+                                              "children": [
+                                                {
+                                                  "kind": "encapsed_string",
+                                                  "children": [
+                                                    {
+                                                      "kind": "string_content",
+                                                      "text": "'"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "argument",
+                                              "children": [
+                                                {
+                                                  "kind": "function_call_expression",
+                                                  "children": [
+                                                    {
+                                                      "kind": "name",
+                                                      "text": "str_replace"
+                                                    },
+                                                    {
+                                                      "kind": "arguments",
+                                                      "children": [
+                                                        {
+                                                          "kind": "argument",
+                                                          "children": [
+                                                            {
+                                                              "kind": "encapsed_string",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "string_content",
+                                                                  "text": ":"
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        },
+                                                        {
+                                                          "kind": "argument",
+                                                          "children": [
+                                                            {
+                                                              "kind": "encapsed_string",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "string_content",
+                                                                  "text": ": "
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        },
+                                                        {
+                                                          "kind": "argument",
+                                                          "children": [
+                                                            {
+                                                              "kind": "function_call_expression",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "name",
+                                                                  "text": "str_replace"
+                                                                },
+                                                                {
+                                                                  "kind": "arguments",
+                                                                  "children": [
+                                                                    {
+                                                                      "kind": "argument",
+                                                                      "children": [
+                                                                        {
+                                                                          "kind": "encapsed_string",
+                                                                          "children": [
+                                                                            {
+                                                                              "kind": "string_content",
+                                                                              "text": ","
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "kind": "argument",
+                                                                      "children": [
+                                                                        {
+                                                                          "kind": "encapsed_string",
+                                                                          "children": [
+                                                                            {
+                                                                              "kind": "string_content",
+                                                                              "text": ", "
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "kind": "argument",
+                                                                      "children": [
+                                                                        {
+                                                                          "kind": "function_call_expression",
+                                                                          "children": [
+                                                                            {
+                                                                              "kind": "name",
+                                                                              "text": "json_encode"
+                                                                            },
+                                                                            {
+                                                                              "kind": "arguments",
+                                                                              "children": [
+                                                                                {
+                                                                                  "kind": "argument",
+                                                                                  "children": [
+                                                                                    {
+                                                                                      "kind": "function_call_expression",
+                                                                                      "children": [
+                                                                                        {
+                                                                                          "kind": "name",
+                                                                                          "text": "array_merge"
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "arguments",
+                                                                                          "children": [
+                                                                                            {
+                                                                                              "kind": "argument",
+                                                                                              "children": [
+                                                                                                {
+                                                                                                  "kind": "variable_name",
+                                                                                                  "children": [
+                                                                                                    {
+                                                                                                      "kind": "name",
+                                                                                                      "text": "a"
+                                                                                                    }
+                                                                                                  ]
+                                                                                                }
+                                                                                              ]
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "argument",
+                                                                                              "children": [
+                                                                                                {
+                                                                                                  "kind": "array_creation_expression",
+                                                                                                  "children": [
+                                                                                                    {
+                                                                                                      "kind": "array_element_initializer",
+                                                                                                      "children": [
+                                                                                                        {
+                                                                                                          "kind": "integer",
+                                                                                                          "text": "3"
+                                                                                                        }
+                                                                                                      ]
+                                                                                                    }
+                                                                                                  ]
+                                                                                                }
+                                                                                              ]
+                                                                                            }
+                                                                                          ]
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  ]
+                                                                                },
+                                                                                {
+                                                                                  "kind": "argument",
+                                                                                  "children": [
+                                                                                    {
+                                                                                      "kind": "integer",
+                                                                                      "text": "1344"
+                                                                                    }
+                                                                                  ]
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
             }
           ]
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 77,
-            "startFilePos": 197,
-            "endLine": 3,
-            "endTokenPos": 77,
-            "endFilePos": 203
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 3,
-              "startTokenPos": 77,
-              "startFilePos": 197,
-              "endLine": 3,
-              "endTokenPos": 77,
-              "endFilePos": 203
-            },
-            "name": "PHP_EOL"
-          }
         }
       ]
     }

--- a/tests/json-ast/x/php/avg_builtin.php.json
+++ b/tests/json-ast/x/php/avg_builtin.php.json
@@ -1,1010 +1,394 @@
 {
-  "root": [
+  "statements": [
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 2,
-        "startTokenPos": 1,
-        "startFilePos": 6,
-        "endLine": 2,
-        "endTokenPos": 104,
-        "endFilePos": 174
-      },
-      "exprs": [
+      "kind": "echo_statement",
+      "children": [
         {
-          "nodeType": "Expr_Ternary",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 4,
-            "startFilePos": 12,
-            "endLine": 2,
-            "endTokenPos": 99,
-            "endFilePos": 163
-          },
-          "cond": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 4,
-              "startFilePos": 12,
-              "endLine": 2,
-              "endTokenPos": 33,
-              "endFilePos": 60
-            },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 4,
-                "startFilePos": 12,
-                "endLine": 2,
-                "endTokenPos": 4,
-                "endFilePos": 19
-              },
-              "name": "is_float"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 6,
-                  "startFilePos": 21,
-                  "endLine": 2,
-                  "endTokenPos": 32,
-                  "endFilePos": 59
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_BinaryOp_Div",
-                  "attributes": {
-                    "startLine": 2,
-                    "startTokenPos": 6,
-                    "startFilePos": 21,
-                    "endLine": 2,
-                    "endTokenPos": 32,
-                    "endFilePos": 59
-                  },
-                  "left": {
-                    "nodeType": "Expr_FuncCall",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 6,
-                      "startFilePos": 21,
-                      "endLine": 2,
-                      "endTokenPos": 17,
-                      "endFilePos": 40
-                    },
-                    "name": {
-                      "nodeType": "Name",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 6,
-                        "startFilePos": 21,
-                        "endLine": 2,
-                        "endTokenPos": 6,
-                        "endFilePos": 29
-                      },
-                      "name": "array_sum"
-                    },
-                    "args": [
-                      {
-                        "nodeType": "Arg",
-                        "attributes": {
-                          "startLine": 2,
-                          "startTokenPos": 8,
-                          "startFilePos": 31,
-                          "endLine": 2,
-                          "endTokenPos": 16,
-                          "endFilePos": 39
-                        },
-                        "name": null,
-                        "value": {
-                          "nodeType": "Expr_Array",
-                          "attributes": {
-                            "startLine": 2,
-                            "startTokenPos": 8,
-                            "startFilePos": 31,
-                            "endLine": 2,
-                            "endTokenPos": 16,
-                            "endFilePos": 39,
-                            "kind": 2
-                          },
-                          "items": [
-                            {
-                              "nodeType": "ArrayItem",
-                              "attributes": {
-                                "startLine": 2,
-                                "startTokenPos": 9,
-                                "startFilePos": 32,
-                                "endLine": 2,
-                                "endTokenPos": 9,
-                                "endFilePos": 32
-                              },
-                              "key": null,
-                              "value": {
-                                "nodeType": "Scalar_Int",
-                                "attributes": {
-                                  "startLine": 2,
-                                  "startTokenPos": 9,
-                                  "startFilePos": 32,
-                                  "endLine": 2,
-                                  "endTokenPos": 9,
-                                  "endFilePos": 32,
-                                  "rawValue": "1",
-                                  "kind": 10
-                                },
-                                "value": 1
-                              },
-                              "byRef": false,
-                              "unpack": false
-                            },
-                            {
-                              "nodeType": "ArrayItem",
-                              "attributes": {
-                                "startLine": 2,
-                                "startTokenPos": 12,
-                                "startFilePos": 35,
-                                "endLine": 2,
-                                "endTokenPos": 12,
-                                "endFilePos": 35
-                              },
-                              "key": null,
-                              "value": {
-                                "nodeType": "Scalar_Int",
-                                "attributes": {
-                                  "startLine": 2,
-                                  "startTokenPos": 12,
-                                  "startFilePos": 35,
-                                  "endLine": 2,
-                                  "endTokenPos": 12,
-                                  "endFilePos": 35,
-                                  "rawValue": "2",
-                                  "kind": 10
-                                },
-                                "value": 2
-                              },
-                              "byRef": false,
-                              "unpack": false
-                            },
-                            {
-                              "nodeType": "ArrayItem",
-                              "attributes": {
-                                "startLine": 2,
-                                "startTokenPos": 15,
-                                "startFilePos": 38,
-                                "endLine": 2,
-                                "endTokenPos": 15,
-                                "endFilePos": 38
-                              },
-                              "key": null,
-                              "value": {
-                                "nodeType": "Scalar_Int",
-                                "attributes": {
-                                  "startLine": 2,
-                                  "startTokenPos": 15,
-                                  "startFilePos": 38,
-                                  "endLine": 2,
-                                  "endTokenPos": 15,
-                                  "endFilePos": 38,
-                                  "rawValue": "3",
-                                  "kind": 10
-                                },
-                                "value": 3
-                              },
-                              "byRef": false,
-                              "unpack": false
-                            }
-                          ]
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      }
-                    ]
-                  },
-                  "right": {
-                    "nodeType": "Expr_FuncCall",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 21,
-                      "startFilePos": 44,
-                      "endLine": 2,
-                      "endTokenPos": 32,
-                      "endFilePos": 59
-                    },
-                    "name": {
-                      "nodeType": "Name",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 21,
-                        "startFilePos": 44,
-                        "endLine": 2,
-                        "endTokenPos": 21,
-                        "endFilePos": 48
-                      },
-                      "name": "count"
-                    },
-                    "args": [
-                      {
-                        "nodeType": "Arg",
-                        "attributes": {
-                          "startLine": 2,
-                          "startTokenPos": 23,
-                          "startFilePos": 50,
-                          "endLine": 2,
-                          "endTokenPos": 31,
-                          "endFilePos": 58
-                        },
-                        "name": null,
-                        "value": {
-                          "nodeType": "Expr_Array",
-                          "attributes": {
-                            "startLine": 2,
-                            "startTokenPos": 23,
-                            "startFilePos": 50,
-                            "endLine": 2,
-                            "endTokenPos": 31,
-                            "endFilePos": 58,
-                            "kind": 2
-                          },
-                          "items": [
-                            {
-                              "nodeType": "ArrayItem",
-                              "attributes": {
-                                "startLine": 2,
-                                "startTokenPos": 24,
-                                "startFilePos": 51,
-                                "endLine": 2,
-                                "endTokenPos": 24,
-                                "endFilePos": 51
-                              },
-                              "key": null,
-                              "value": {
-                                "nodeType": "Scalar_Int",
-                                "attributes": {
-                                  "startLine": 2,
-                                  "startTokenPos": 24,
-                                  "startFilePos": 51,
-                                  "endLine": 2,
-                                  "endTokenPos": 24,
-                                  "endFilePos": 51,
-                                  "rawValue": "1",
-                                  "kind": 10
-                                },
-                                "value": 1
-                              },
-                              "byRef": false,
-                              "unpack": false
-                            },
-                            {
-                              "nodeType": "ArrayItem",
-                              "attributes": {
-                                "startLine": 2,
-                                "startTokenPos": 27,
-                                "startFilePos": 54,
-                                "endLine": 2,
-                                "endTokenPos": 27,
-                                "endFilePos": 54
-                              },
-                              "key": null,
-                              "value": {
-                                "nodeType": "Scalar_Int",
-                                "attributes": {
-                                  "startLine": 2,
-                                  "startTokenPos": 27,
-                                  "startFilePos": 54,
-                                  "endLine": 2,
-                                  "endTokenPos": 27,
-                                  "endFilePos": 54,
-                                  "rawValue": "2",
-                                  "kind": 10
-                                },
-                                "value": 2
-                              },
-                              "byRef": false,
-                              "unpack": false
-                            },
-                            {
-                              "nodeType": "ArrayItem",
-                              "attributes": {
-                                "startLine": 2,
-                                "startTokenPos": 30,
-                                "startFilePos": 57,
-                                "endLine": 2,
-                                "endTokenPos": 30,
-                                "endFilePos": 57
-                              },
-                              "key": null,
-                              "value": {
-                                "nodeType": "Scalar_Int",
-                                "attributes": {
-                                  "startLine": 2,
-                                  "startTokenPos": 30,
-                                  "startFilePos": 57,
-                                  "endLine": 2,
-                                  "endTokenPos": 30,
-                                  "endFilePos": 57,
-                                  "rawValue": "3",
-                                  "kind": 10
-                                },
-                                "value": 3
-                              },
-                              "byRef": false,
-                              "unpack": false
-                            }
-                          ]
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      }
-                    ]
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "if": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 37,
-              "startFilePos": 64,
-              "endLine": 2,
-              "endTokenPos": 69,
-              "endFilePos": 121
-            },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 37,
-                "startFilePos": 64,
-                "endLine": 2,
-                "endTokenPos": 37,
-                "endFilePos": 74
-              },
-              "name": "json_encode"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 39,
-                  "startFilePos": 76,
-                  "endLine": 2,
-                  "endTokenPos": 65,
-                  "endFilePos": 114
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_BinaryOp_Div",
-                  "attributes": {
-                    "startLine": 2,
-                    "startTokenPos": 39,
-                    "startFilePos": 76,
-                    "endLine": 2,
-                    "endTokenPos": 65,
-                    "endFilePos": 114
-                  },
-                  "left": {
-                    "nodeType": "Expr_FuncCall",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 39,
-                      "startFilePos": 76,
-                      "endLine": 2,
-                      "endTokenPos": 50,
-                      "endFilePos": 95
-                    },
-                    "name": {
-                      "nodeType": "Name",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 39,
-                        "startFilePos": 76,
-                        "endLine": 2,
-                        "endTokenPos": 39,
-                        "endFilePos": 84
-                      },
-                      "name": "array_sum"
-                    },
-                    "args": [
-                      {
-                        "nodeType": "Arg",
-                        "attributes": {
-                          "startLine": 2,
-                          "startTokenPos": 41,
-                          "startFilePos": 86,
-                          "endLine": 2,
-                          "endTokenPos": 49,
-                          "endFilePos": 94
-                        },
-                        "name": null,
-                        "value": {
-                          "nodeType": "Expr_Array",
-                          "attributes": {
-                            "startLine": 2,
-                            "startTokenPos": 41,
-                            "startFilePos": 86,
-                            "endLine": 2,
-                            "endTokenPos": 49,
-                            "endFilePos": 94,
-                            "kind": 2
-                          },
-                          "items": [
-                            {
-                              "nodeType": "ArrayItem",
-                              "attributes": {
-                                "startLine": 2,
-                                "startTokenPos": 42,
-                                "startFilePos": 87,
-                                "endLine": 2,
-                                "endTokenPos": 42,
-                                "endFilePos": 87
-                              },
-                              "key": null,
-                              "value": {
-                                "nodeType": "Scalar_Int",
-                                "attributes": {
-                                  "startLine": 2,
-                                  "startTokenPos": 42,
-                                  "startFilePos": 87,
-                                  "endLine": 2,
-                                  "endTokenPos": 42,
-                                  "endFilePos": 87,
-                                  "rawValue": "1",
-                                  "kind": 10
-                                },
-                                "value": 1
-                              },
-                              "byRef": false,
-                              "unpack": false
-                            },
-                            {
-                              "nodeType": "ArrayItem",
-                              "attributes": {
-                                "startLine": 2,
-                                "startTokenPos": 45,
-                                "startFilePos": 90,
-                                "endLine": 2,
-                                "endTokenPos": 45,
-                                "endFilePos": 90
-                              },
-                              "key": null,
-                              "value": {
-                                "nodeType": "Scalar_Int",
-                                "attributes": {
-                                  "startLine": 2,
-                                  "startTokenPos": 45,
-                                  "startFilePos": 90,
-                                  "endLine": 2,
-                                  "endTokenPos": 45,
-                                  "endFilePos": 90,
-                                  "rawValue": "2",
-                                  "kind": 10
-                                },
-                                "value": 2
-                              },
-                              "byRef": false,
-                              "unpack": false
-                            },
-                            {
-                              "nodeType": "ArrayItem",
-                              "attributes": {
-                                "startLine": 2,
-                                "startTokenPos": 48,
-                                "startFilePos": 93,
-                                "endLine": 2,
-                                "endTokenPos": 48,
-                                "endFilePos": 93
-                              },
-                              "key": null,
-                              "value": {
-                                "nodeType": "Scalar_Int",
-                                "attributes": {
-                                  "startLine": 2,
-                                  "startTokenPos": 48,
-                                  "startFilePos": 93,
-                                  "endLine": 2,
-                                  "endTokenPos": 48,
-                                  "endFilePos": 93,
-                                  "rawValue": "3",
-                                  "kind": 10
-                                },
-                                "value": 3
-                              },
-                              "byRef": false,
-                              "unpack": false
-                            }
-                          ]
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      }
-                    ]
-                  },
-                  "right": {
-                    "nodeType": "Expr_FuncCall",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 54,
-                      "startFilePos": 99,
-                      "endLine": 2,
-                      "endTokenPos": 65,
-                      "endFilePos": 114
-                    },
-                    "name": {
-                      "nodeType": "Name",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 54,
-                        "startFilePos": 99,
-                        "endLine": 2,
-                        "endTokenPos": 54,
-                        "endFilePos": 103
-                      },
-                      "name": "count"
-                    },
-                    "args": [
-                      {
-                        "nodeType": "Arg",
-                        "attributes": {
-                          "startLine": 2,
-                          "startTokenPos": 56,
-                          "startFilePos": 105,
-                          "endLine": 2,
-                          "endTokenPos": 64,
-                          "endFilePos": 113
-                        },
-                        "name": null,
-                        "value": {
-                          "nodeType": "Expr_Array",
-                          "attributes": {
-                            "startLine": 2,
-                            "startTokenPos": 56,
-                            "startFilePos": 105,
-                            "endLine": 2,
-                            "endTokenPos": 64,
-                            "endFilePos": 113,
-                            "kind": 2
-                          },
-                          "items": [
-                            {
-                              "nodeType": "ArrayItem",
-                              "attributes": {
-                                "startLine": 2,
-                                "startTokenPos": 57,
-                                "startFilePos": 106,
-                                "endLine": 2,
-                                "endTokenPos": 57,
-                                "endFilePos": 106
-                              },
-                              "key": null,
-                              "value": {
-                                "nodeType": "Scalar_Int",
-                                "attributes": {
-                                  "startLine": 2,
-                                  "startTokenPos": 57,
-                                  "startFilePos": 106,
-                                  "endLine": 2,
-                                  "endTokenPos": 57,
-                                  "endFilePos": 106,
-                                  "rawValue": "1",
-                                  "kind": 10
-                                },
-                                "value": 1
-                              },
-                              "byRef": false,
-                              "unpack": false
-                            },
-                            {
-                              "nodeType": "ArrayItem",
-                              "attributes": {
-                                "startLine": 2,
-                                "startTokenPos": 60,
-                                "startFilePos": 109,
-                                "endLine": 2,
-                                "endTokenPos": 60,
-                                "endFilePos": 109
-                              },
-                              "key": null,
-                              "value": {
-                                "nodeType": "Scalar_Int",
-                                "attributes": {
-                                  "startLine": 2,
-                                  "startTokenPos": 60,
-                                  "startFilePos": 109,
-                                  "endLine": 2,
-                                  "endTokenPos": 60,
-                                  "endFilePos": 109,
-                                  "rawValue": "2",
-                                  "kind": 10
-                                },
-                                "value": 2
-                              },
-                              "byRef": false,
-                              "unpack": false
-                            },
-                            {
-                              "nodeType": "ArrayItem",
-                              "attributes": {
-                                "startLine": 2,
-                                "startTokenPos": 63,
-                                "startFilePos": 112,
-                                "endLine": 2,
-                                "endTokenPos": 63,
-                                "endFilePos": 112
-                              },
-                              "key": null,
-                              "value": {
-                                "nodeType": "Scalar_Int",
-                                "attributes": {
-                                  "startLine": 2,
-                                  "startTokenPos": 63,
-                                  "startFilePos": 112,
-                                  "endLine": 2,
-                                  "endTokenPos": 63,
-                                  "endFilePos": 112,
-                                  "rawValue": "3",
-                                  "kind": 10
-                                },
-                                "value": 3
-                              },
-                              "byRef": false,
-                              "unpack": false
-                            }
-                          ]
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      }
-                    ]
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              },
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 68,
-                  "startFilePos": 117,
-                  "endLine": 2,
-                  "endTokenPos": 68,
-                  "endFilePos": 120
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 2,
-                    "startTokenPos": 68,
-                    "startFilePos": 117,
-                    "endLine": 2,
-                    "endTokenPos": 68,
-                    "endFilePos": 120,
-                    "rawValue": "1344",
-                    "kind": 10
-                  },
-                  "value": 1344
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "else": {
-            "nodeType": "Expr_BinaryOp_Div",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 73,
-              "startFilePos": 125,
-              "endLine": 2,
-              "endTokenPos": 99,
-              "endFilePos": 163
-            },
-            "left": {
-              "nodeType": "Expr_FuncCall",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 73,
-                "startFilePos": 125,
-                "endLine": 2,
-                "endTokenPos": 84,
-                "endFilePos": 144
-              },
-              "name": {
-                "nodeType": "Name",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 73,
-                  "startFilePos": 125,
-                  "endLine": 2,
-                  "endTokenPos": 73,
-                  "endFilePos": 133
-                },
-                "name": "array_sum"
-              },
-              "args": [
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "parenthesized_expression",
+              "children": [
                 {
-                  "nodeType": "Arg",
-                  "attributes": {
-                    "startLine": 2,
-                    "startTokenPos": 75,
-                    "startFilePos": 135,
-                    "endLine": 2,
-                    "endTokenPos": 83,
-                    "endFilePos": 143
-                  },
-                  "name": null,
-                  "value": {
-                    "nodeType": "Expr_Array",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 75,
-                      "startFilePos": 135,
-                      "endLine": 2,
-                      "endTokenPos": 83,
-                      "endFilePos": 143,
-                      "kind": 2
+                  "kind": "conditional_expression",
+                  "children": [
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "is_float"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "function_call_expression",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "array_sum"
+                                        },
+                                        {
+                                          "kind": "arguments",
+                                          "children": [
+                                            {
+                                              "kind": "argument",
+                                              "children": [
+                                                {
+                                                  "kind": "array_creation_expression",
+                                                  "children": [
+                                                    {
+                                                      "kind": "array_element_initializer",
+                                                      "children": [
+                                                        {
+                                                          "kind": "integer",
+                                                          "text": "1"
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "array_element_initializer",
+                                                      "children": [
+                                                        {
+                                                          "kind": "integer",
+                                                          "text": "2"
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "array_element_initializer",
+                                                      "children": [
+                                                        {
+                                                          "kind": "integer",
+                                                          "text": "3"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "function_call_expression",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "count"
+                                        },
+                                        {
+                                          "kind": "arguments",
+                                          "children": [
+                                            {
+                                              "kind": "argument",
+                                              "children": [
+                                                {
+                                                  "kind": "array_creation_expression",
+                                                  "children": [
+                                                    {
+                                                      "kind": "array_element_initializer",
+                                                      "children": [
+                                                        {
+                                                          "kind": "integer",
+                                                          "text": "1"
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "array_element_initializer",
+                                                      "children": [
+                                                        {
+                                                          "kind": "integer",
+                                                          "text": "2"
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "array_element_initializer",
+                                                      "children": [
+                                                        {
+                                                          "kind": "integer",
+                                                          "text": "3"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     },
-                    "items": [
-                      {
-                        "nodeType": "ArrayItem",
-                        "attributes": {
-                          "startLine": 2,
-                          "startTokenPos": 76,
-                          "startFilePos": 136,
-                          "endLine": 2,
-                          "endTokenPos": 76,
-                          "endFilePos": 136
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "json_encode"
                         },
-                        "key": null,
-                        "value": {
-                          "nodeType": "Scalar_Int",
-                          "attributes": {
-                            "startLine": 2,
-                            "startTokenPos": 76,
-                            "startFilePos": 136,
-                            "endLine": 2,
-                            "endTokenPos": 76,
-                            "endFilePos": 136,
-                            "rawValue": "1",
-                            "kind": 10
-                          },
-                          "value": 1
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "function_call_expression",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "array_sum"
+                                        },
+                                        {
+                                          "kind": "arguments",
+                                          "children": [
+                                            {
+                                              "kind": "argument",
+                                              "children": [
+                                                {
+                                                  "kind": "array_creation_expression",
+                                                  "children": [
+                                                    {
+                                                      "kind": "array_element_initializer",
+                                                      "children": [
+                                                        {
+                                                          "kind": "integer",
+                                                          "text": "1"
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "array_element_initializer",
+                                                      "children": [
+                                                        {
+                                                          "kind": "integer",
+                                                          "text": "2"
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "array_element_initializer",
+                                                      "children": [
+                                                        {
+                                                          "kind": "integer",
+                                                          "text": "3"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "function_call_expression",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "count"
+                                        },
+                                        {
+                                          "kind": "arguments",
+                                          "children": [
+                                            {
+                                              "kind": "argument",
+                                              "children": [
+                                                {
+                                                  "kind": "array_creation_expression",
+                                                  "children": [
+                                                    {
+                                                      "kind": "array_element_initializer",
+                                                      "children": [
+                                                        {
+                                                          "kind": "integer",
+                                                          "text": "1"
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "array_element_initializer",
+                                                      "children": [
+                                                        {
+                                                          "kind": "integer",
+                                                          "text": "2"
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "array_element_initializer",
+                                                      "children": [
+                                                        {
+                                                          "kind": "integer",
+                                                          "text": "3"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "integer",
+                                  "text": "1344"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "function_call_expression",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "array_sum"
+                            },
+                            {
+                              "kind": "arguments",
+                              "children": [
+                                {
+                                  "kind": "argument",
+                                  "children": [
+                                    {
+                                      "kind": "array_creation_expression",
+                                      "children": [
+                                        {
+                                          "kind": "array_element_initializer",
+                                          "children": [
+                                            {
+                                              "kind": "integer",
+                                              "text": "1"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "array_element_initializer",
+                                          "children": [
+                                            {
+                                              "kind": "integer",
+                                              "text": "2"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "array_element_initializer",
+                                          "children": [
+                                            {
+                                              "kind": "integer",
+                                              "text": "3"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
                         },
-                        "byRef": false,
-                        "unpack": false
-                      },
-                      {
-                        "nodeType": "ArrayItem",
-                        "attributes": {
-                          "startLine": 2,
-                          "startTokenPos": 79,
-                          "startFilePos": 139,
-                          "endLine": 2,
-                          "endTokenPos": 79,
-                          "endFilePos": 139
-                        },
-                        "key": null,
-                        "value": {
-                          "nodeType": "Scalar_Int",
-                          "attributes": {
-                            "startLine": 2,
-                            "startTokenPos": 79,
-                            "startFilePos": 139,
-                            "endLine": 2,
-                            "endTokenPos": 79,
-                            "endFilePos": 139,
-                            "rawValue": "2",
-                            "kind": 10
-                          },
-                          "value": 2
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      },
-                      {
-                        "nodeType": "ArrayItem",
-                        "attributes": {
-                          "startLine": 2,
-                          "startTokenPos": 82,
-                          "startFilePos": 142,
-                          "endLine": 2,
-                          "endTokenPos": 82,
-                          "endFilePos": 142
-                        },
-                        "key": null,
-                        "value": {
-                          "nodeType": "Scalar_Int",
-                          "attributes": {
-                            "startLine": 2,
-                            "startTokenPos": 82,
-                            "startFilePos": 142,
-                            "endLine": 2,
-                            "endTokenPos": 82,
-                            "endFilePos": 142,
-                            "rawValue": "3",
-                            "kind": 10
-                          },
-                          "value": 3
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      }
-                    ]
-                  },
-                  "byRef": false,
-                  "unpack": false
+                        {
+                          "kind": "function_call_expression",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "count"
+                            },
+                            {
+                              "kind": "arguments",
+                              "children": [
+                                {
+                                  "kind": "argument",
+                                  "children": [
+                                    {
+                                      "kind": "array_creation_expression",
+                                      "children": [
+                                        {
+                                          "kind": "array_element_initializer",
+                                          "children": [
+                                            {
+                                              "kind": "integer",
+                                              "text": "1"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "array_element_initializer",
+                                          "children": [
+                                            {
+                                              "kind": "integer",
+                                              "text": "2"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "array_element_initializer",
+                                          "children": [
+                                            {
+                                              "kind": "integer",
+                                              "text": "3"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             },
-            "right": {
-              "nodeType": "Expr_FuncCall",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 88,
-                "startFilePos": 148,
-                "endLine": 2,
-                "endTokenPos": 99,
-                "endFilePos": 163
-              },
-              "name": {
-                "nodeType": "Name",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 88,
-                  "startFilePos": 148,
-                  "endLine": 2,
-                  "endTokenPos": 88,
-                  "endFilePos": 152
-                },
-                "name": "count"
-              },
-              "args": [
-                {
-                  "nodeType": "Arg",
-                  "attributes": {
-                    "startLine": 2,
-                    "startTokenPos": 90,
-                    "startFilePos": 154,
-                    "endLine": 2,
-                    "endTokenPos": 98,
-                    "endFilePos": 162
-                  },
-                  "name": null,
-                  "value": {
-                    "nodeType": "Expr_Array",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 90,
-                      "startFilePos": 154,
-                      "endLine": 2,
-                      "endTokenPos": 98,
-                      "endFilePos": 162,
-                      "kind": 2
-                    },
-                    "items": [
-                      {
-                        "nodeType": "ArrayItem",
-                        "attributes": {
-                          "startLine": 2,
-                          "startTokenPos": 91,
-                          "startFilePos": 155,
-                          "endLine": 2,
-                          "endTokenPos": 91,
-                          "endFilePos": 155
-                        },
-                        "key": null,
-                        "value": {
-                          "nodeType": "Scalar_Int",
-                          "attributes": {
-                            "startLine": 2,
-                            "startTokenPos": 91,
-                            "startFilePos": 155,
-                            "endLine": 2,
-                            "endTokenPos": 91,
-                            "endFilePos": 155,
-                            "rawValue": "1",
-                            "kind": 10
-                          },
-                          "value": 1
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      },
-                      {
-                        "nodeType": "ArrayItem",
-                        "attributes": {
-                          "startLine": 2,
-                          "startTokenPos": 94,
-                          "startFilePos": 158,
-                          "endLine": 2,
-                          "endTokenPos": 94,
-                          "endFilePos": 158
-                        },
-                        "key": null,
-                        "value": {
-                          "nodeType": "Scalar_Int",
-                          "attributes": {
-                            "startLine": 2,
-                            "startTokenPos": 94,
-                            "startFilePos": 158,
-                            "endLine": 2,
-                            "endTokenPos": 94,
-                            "endFilePos": 158,
-                            "rawValue": "2",
-                            "kind": 10
-                          },
-                          "value": 2
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      },
-                      {
-                        "nodeType": "ArrayItem",
-                        "attributes": {
-                          "startLine": 2,
-                          "startTokenPos": 97,
-                          "startFilePos": 161,
-                          "endLine": 2,
-                          "endTokenPos": 97,
-                          "endFilePos": 161
-                        },
-                        "key": null,
-                        "value": {
-                          "nodeType": "Scalar_Int",
-                          "attributes": {
-                            "startLine": 2,
-                            "startTokenPos": 97,
-                            "startFilePos": 161,
-                            "endLine": 2,
-                            "endTokenPos": 97,
-                            "endFilePos": 161,
-                            "rawValue": "3",
-                            "kind": 10
-                          },
-                          "value": 3
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      }
-                    ]
-                  },
-                  "byRef": false,
-                  "unpack": false
-                }
-              ]
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
             }
-          }
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 103,
-            "startFilePos": 167,
-            "endLine": 2,
-            "endTokenPos": 103,
-            "endFilePos": 173
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 103,
-              "startFilePos": 167,
-              "endLine": 2,
-              "endTokenPos": 103,
-              "endFilePos": 173
-            },
-            "name": "PHP_EOL"
-          }
+          ]
         }
       ]
     }

--- a/tests/json-ast/x/php/basic_compare.php.json
+++ b/tests/json-ast/x/php/basic_compare.php.json
@@ -1,561 +1,284 @@
 {
-  "root": [
+  "statements": [
     {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 2,
-        "startTokenPos": 1,
-        "startFilePos": 6,
-        "endLine": 2,
-        "endTokenPos": 10,
-        "endFilePos": 17
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 2,
-          "startTokenPos": 1,
-          "startFilePos": 6,
-          "endLine": 2,
-          "endTokenPos": 9,
-          "endFilePos": 16
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 1,
-            "startFilePos": 6,
-            "endLine": 2,
-            "endTokenPos": 1,
-            "endFilePos": 7
-          },
-          "name": "a"
-        },
-        "expr": {
-          "nodeType": "Expr_BinaryOp_Minus",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 5,
-            "startFilePos": 11,
-            "endLine": 2,
-            "endTokenPos": 9,
-            "endFilePos": 16
-          },
-          "left": {
-            "nodeType": "Scalar_Int",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 5,
-              "startFilePos": 11,
-              "endLine": 2,
-              "endTokenPos": 5,
-              "endFilePos": 12,
-              "rawValue": "10",
-              "kind": 10
-            },
-            "value": 10
-          },
-          "right": {
-            "nodeType": "Scalar_Int",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 9,
-              "startFilePos": 16,
-              "endLine": 2,
-              "endTokenPos": 9,
-              "endFilePos": 16,
-              "rawValue": "3",
-              "kind": 10
-            },
-            "value": 3
-          }
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 3,
-        "startTokenPos": 12,
-        "startFilePos": 19,
-        "endLine": 3,
-        "endTokenPos": 21,
-        "endFilePos": 29
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 3,
-          "startTokenPos": 12,
-          "startFilePos": 19,
-          "endLine": 3,
-          "endTokenPos": 20,
-          "endFilePos": 28
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 12,
-            "startFilePos": 19,
-            "endLine": 3,
-            "endTokenPos": 12,
-            "endFilePos": 20
-          },
-          "name": "b"
-        },
-        "expr": {
-          "nodeType": "Expr_BinaryOp_Plus",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 16,
-            "startFilePos": 24,
-            "endLine": 3,
-            "endTokenPos": 20,
-            "endFilePos": 28
-          },
-          "left": {
-            "nodeType": "Scalar_Int",
-            "attributes": {
-              "startLine": 3,
-              "startTokenPos": 16,
-              "startFilePos": 24,
-              "endLine": 3,
-              "endTokenPos": 16,
-              "endFilePos": 24,
-              "rawValue": "2",
-              "kind": 10
-            },
-            "value": 2
-          },
-          "right": {
-            "nodeType": "Scalar_Int",
-            "attributes": {
-              "startLine": 3,
-              "startTokenPos": 20,
-              "startFilePos": 28,
-              "endLine": 3,
-              "endTokenPos": 20,
-              "endFilePos": 28,
-              "rawValue": "2",
-              "kind": 10
-            },
-            "value": 2
-          }
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 4,
-        "startTokenPos": 23,
-        "startFilePos": 31,
-        "endLine": 4,
-        "endTokenPos": 48,
-        "endFilePos": 88
-      },
-      "exprs": [
+      "kind": "expression_statement",
+      "children": [
         {
-          "nodeType": "Expr_Ternary",
-          "attributes": {
-            "startLine": 4,
-            "startTokenPos": 26,
-            "startFilePos": 37,
-            "endLine": 4,
-            "endTokenPos": 43,
-            "endFilePos": 77
-          },
-          "cond": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 4,
-              "startTokenPos": 26,
-              "startFilePos": 37,
-              "endLine": 4,
-              "endTokenPos": 29,
-              "endFilePos": 48
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "a"
+                }
+              ]
             },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 4,
-                "startTokenPos": 26,
-                "startFilePos": 37,
-                "endLine": 4,
-                "endTokenPos": 26,
-                "endFilePos": 44
-              },
-              "name": "is_float"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 4,
-                  "startTokenPos": 28,
-                  "startFilePos": 46,
-                  "endLine": 4,
-                  "endTokenPos": 28,
-                  "endFilePos": 47
+            {
+              "kind": "binary_expression",
+              "children": [
+                {
+                  "kind": "integer",
+                  "text": "10"
                 },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_Variable",
-                  "attributes": {
-                    "startLine": 4,
-                    "startTokenPos": 28,
-                    "startFilePos": 46,
-                    "endLine": 4,
-                    "endTokenPos": 28,
-                    "endFilePos": 47
-                  },
-                  "name": "a"
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "if": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 4,
-              "startTokenPos": 33,
-              "startFilePos": 52,
-              "endLine": 4,
-              "endTokenPos": 39,
-              "endFilePos": 72
-            },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 4,
-                "startTokenPos": 33,
-                "startFilePos": 52,
-                "endLine": 4,
-                "endTokenPos": 33,
-                "endFilePos": 62
-              },
-              "name": "json_encode"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 4,
-                  "startTokenPos": 35,
-                  "startFilePos": 64,
-                  "endLine": 4,
-                  "endTokenPos": 35,
-                  "endFilePos": 65
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_Variable",
-                  "attributes": {
-                    "startLine": 4,
-                    "startTokenPos": 35,
-                    "startFilePos": 64,
-                    "endLine": 4,
-                    "endTokenPos": 35,
-                    "endFilePos": 65
-                  },
-                  "name": "a"
-                },
-                "byRef": false,
-                "unpack": false
-              },
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 4,
-                  "startTokenPos": 38,
-                  "startFilePos": 68,
-                  "endLine": 4,
-                  "endTokenPos": 38,
-                  "endFilePos": 71
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 4,
-                    "startTokenPos": 38,
-                    "startFilePos": 68,
-                    "endLine": 4,
-                    "endTokenPos": 38,
-                    "endFilePos": 71,
-                    "rawValue": "1344",
-                    "kind": 10
-                  },
-                  "value": 1344
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "else": {
-            "nodeType": "Expr_Variable",
-            "attributes": {
-              "startLine": 4,
-              "startTokenPos": 43,
-              "startFilePos": 76,
-              "endLine": 4,
-              "endTokenPos": 43,
-              "endFilePos": 77
-            },
-            "name": "a"
-          }
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 4,
-            "startTokenPos": 47,
-            "startFilePos": 81,
-            "endLine": 4,
-            "endTokenPos": 47,
-            "endFilePos": 87
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 4,
-              "startTokenPos": 47,
-              "startFilePos": 81,
-              "endLine": 4,
-              "endTokenPos": 47,
-              "endFilePos": 87
-            },
-            "name": "PHP_EOL"
-          }
+                {
+                  "kind": "integer",
+                  "text": "3"
+                }
+              ]
+            }
+          ]
         }
       ]
     },
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 5,
-        "startTokenPos": 50,
-        "startFilePos": 90,
-        "endLine": 5,
-        "endTokenPos": 70,
-        "endFilePos": 132
-      },
-      "exprs": [
+      "kind": "expression_statement",
+      "children": [
         {
-          "nodeType": "Expr_Ternary",
-          "attributes": {
-            "startLine": 5,
-            "startTokenPos": 53,
-            "startFilePos": 96,
-            "endLine": 5,
-            "endTokenPos": 65,
-            "endFilePos": 121
-          },
-          "cond": {
-            "nodeType": "Expr_BinaryOp_Equal",
-            "attributes": {
-              "startLine": 5,
-              "startTokenPos": 53,
-              "startFilePos": 96,
-              "endLine": 5,
-              "endTokenPos": 57,
-              "endFilePos": 102
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "b"
+                }
+              ]
             },
-            "left": {
-              "nodeType": "Expr_Variable",
-              "attributes": {
-                "startLine": 5,
-                "startTokenPos": 53,
-                "startFilePos": 96,
-                "endLine": 5,
-                "endTokenPos": 53,
-                "endFilePos": 97
-              },
-              "name": "a"
-            },
-            "right": {
-              "nodeType": "Scalar_Int",
-              "attributes": {
-                "startLine": 5,
-                "startTokenPos": 57,
-                "startFilePos": 102,
-                "endLine": 5,
-                "endTokenPos": 57,
-                "endFilePos": 102,
-                "rawValue": "7",
-                "kind": 10
-              },
-              "value": 7
+            {
+              "kind": "binary_expression",
+              "children": [
+                {
+                  "kind": "integer",
+                  "text": "2"
+                },
+                {
+                  "kind": "integer",
+                  "text": "2"
+                }
+              ]
             }
-          },
-          "if": {
-            "nodeType": "Scalar_String",
-            "attributes": {
-              "startLine": 5,
-              "startTokenPos": 61,
-              "startFilePos": 106,
-              "endLine": 5,
-              "endTokenPos": 61,
-              "endFilePos": 111,
-              "kind": 2,
-              "rawValue": "\"True\""
-            },
-            "value": "True"
-          },
-          "else": {
-            "nodeType": "Scalar_String",
-            "attributes": {
-              "startLine": 5,
-              "startTokenPos": 65,
-              "startFilePos": 115,
-              "endLine": 5,
-              "endTokenPos": 65,
-              "endFilePos": 121,
-              "kind": 2,
-              "rawValue": "\"False\""
-            },
-            "value": "False"
-          }
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 5,
-            "startTokenPos": 69,
-            "startFilePos": 125,
-            "endLine": 5,
-            "endTokenPos": 69,
-            "endFilePos": 131
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 5,
-              "startTokenPos": 69,
-              "startFilePos": 125,
-              "endLine": 5,
-              "endTokenPos": 69,
-              "endFilePos": 131
-            },
-            "name": "PHP_EOL"
-          }
+          ]
         }
       ]
     },
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 6,
-        "startTokenPos": 72,
-        "startFilePos": 134,
-        "endLine": 6,
-        "endTokenPos": 92,
-        "endFilePos": 175
-      },
-      "exprs": [
+      "kind": "echo_statement",
+      "children": [
         {
-          "nodeType": "Expr_Ternary",
-          "attributes": {
-            "startLine": 6,
-            "startTokenPos": 75,
-            "startFilePos": 140,
-            "endLine": 6,
-            "endTokenPos": 87,
-            "endFilePos": 164
-          },
-          "cond": {
-            "nodeType": "Expr_BinaryOp_Smaller",
-            "attributes": {
-              "startLine": 6,
-              "startTokenPos": 75,
-              "startFilePos": 140,
-              "endLine": 6,
-              "endTokenPos": 79,
-              "endFilePos": 145
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "parenthesized_expression",
+              "children": [
+                {
+                  "kind": "conditional_expression",
+                  "children": [
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "is_float"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "variable_name",
+                                  "children": [
+                                    {
+                                      "kind": "name",
+                                      "text": "a"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "json_encode"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "variable_name",
+                                  "children": [
+                                    {
+                                      "kind": "name",
+                                      "text": "a"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "integer",
+                                  "text": "1344"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "variable_name",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "a"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             },
-            "left": {
-              "nodeType": "Expr_Variable",
-              "attributes": {
-                "startLine": 6,
-                "startTokenPos": 75,
-                "startFilePos": 140,
-                "endLine": 6,
-                "endTokenPos": 75,
-                "endFilePos": 141
-              },
-              "name": "b"
-            },
-            "right": {
-              "nodeType": "Scalar_Int",
-              "attributes": {
-                "startLine": 6,
-                "startTokenPos": 79,
-                "startFilePos": 145,
-                "endLine": 6,
-                "endTokenPos": 79,
-                "endFilePos": 145,
-                "rawValue": "5",
-                "kind": 10
-              },
-              "value": 5
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
             }
-          },
-          "if": {
-            "nodeType": "Scalar_String",
-            "attributes": {
-              "startLine": 6,
-              "startTokenPos": 83,
-              "startFilePos": 149,
-              "endLine": 6,
-              "endTokenPos": 83,
-              "endFilePos": 154,
-              "kind": 2,
-              "rawValue": "\"True\""
-            },
-            "value": "True"
-          },
-          "else": {
-            "nodeType": "Scalar_String",
-            "attributes": {
-              "startLine": 6,
-              "startTokenPos": 87,
-              "startFilePos": 158,
-              "endLine": 6,
-              "endTokenPos": 87,
-              "endFilePos": 164,
-              "kind": 2,
-              "rawValue": "\"False\""
-            },
-            "value": "False"
-          }
-        },
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "echo_statement",
+      "children": [
         {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 6,
-            "startTokenPos": 91,
-            "startFilePos": 168,
-            "endLine": 6,
-            "endTokenPos": 91,
-            "endFilePos": 174
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 6,
-              "startTokenPos": 91,
-              "startFilePos": 168,
-              "endLine": 6,
-              "endTokenPos": 91,
-              "endFilePos": 174
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "parenthesized_expression",
+              "children": [
+                {
+                  "kind": "conditional_expression",
+                  "children": [
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "a"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "integer",
+                          "text": "7"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "True"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "False"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             },
-            "name": "PHP_EOL"
-          }
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "echo_statement",
+      "children": [
+        {
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "parenthesized_expression",
+              "children": [
+                {
+                  "kind": "conditional_expression",
+                  "children": [
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "b"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "integer",
+                          "text": "5"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "True"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "False"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
+            }
+          ]
         }
       ]
     }

--- a/tests/json-ast/x/php/bench_block.php.json
+++ b/tests/json-ast/x/php/bench_block.php.json
@@ -1,2011 +1,982 @@
 {
-  "root": [
+  "statements": [
     {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 2,
-        "startTokenPos": 1,
-        "startFilePos": 6,
-        "endLine": 2,
-        "endTokenPos": 8,
-        "endFilePos": 35
-      },
-      "expr": {
-        "nodeType": "Expr_FuncCall",
-        "attributes": {
-          "startLine": 2,
-          "startTokenPos": 1,
-          "startFilePos": 6,
-          "endLine": 2,
-          "endTokenPos": 7,
-          "endFilePos": 34
-        },
-        "name": {
-          "nodeType": "Name",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 1,
-            "startFilePos": 6,
-            "endLine": 2,
-            "endTokenPos": 1,
-            "endFilePos": 12
-          },
-          "name": "ini_set"
-        },
-        "args": [
-          {
-            "nodeType": "Arg",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 3,
-              "startFilePos": 14,
-              "endLine": 2,
-              "endTokenPos": 3,
-              "endFilePos": 27
-            },
-            "name": null,
-            "value": {
-              "nodeType": "Scalar_String",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 3,
-                "startFilePos": 14,
-                "endLine": 2,
-                "endTokenPos": 3,
-                "endFilePos": 27,
-                "kind": 1,
-                "rawValue": "'memory_limit'"
-              },
-              "value": "memory_limit"
-            },
-            "byRef": false,
-            "unpack": false
-          },
-          {
-            "nodeType": "Arg",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 6,
-              "startFilePos": 30,
-              "endLine": 2,
-              "endTokenPos": 6,
-              "endFilePos": 33
-            },
-            "name": null,
-            "value": {
-              "nodeType": "Scalar_String",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 6,
-                "startFilePos": 30,
-                "endLine": 2,
-                "endTokenPos": 6,
-                "endFilePos": 33,
-                "kind": 1,
-                "rawValue": "'-1'"
-              },
-              "value": "-1"
-            },
-            "byRef": false,
-            "unpack": false
-          }
-        ]
-      }
-    },
-    {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 3,
-        "startTokenPos": 10,
-        "startFilePos": 37,
-        "endLine": 3,
-        "endTokenPos": 15,
-        "endFilePos": 50
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 3,
-          "startTokenPos": 10,
-          "startFilePos": 37,
-          "endLine": 3,
-          "endTokenPos": 14,
-          "endFilePos": 49
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 10,
-            "startFilePos": 37,
-            "endLine": 3,
-            "endTokenPos": 10,
-            "endFilePos": 45
-          },
-          "name": "now_seed"
-        },
-        "expr": {
-          "nodeType": "Scalar_Int",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 14,
-            "startFilePos": 49,
-            "endLine": 3,
-            "endTokenPos": 14,
-            "endFilePos": 49,
-            "rawValue": "0",
-            "kind": 10
-          },
-          "value": 0
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 4,
-        "startTokenPos": 17,
-        "startFilePos": 52,
-        "endLine": 4,
-        "endTokenPos": 22,
-        "endFilePos": 71
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 4,
-          "startTokenPos": 17,
-          "startFilePos": 52,
-          "endLine": 4,
-          "endTokenPos": 21,
-          "endFilePos": 70
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 4,
-            "startTokenPos": 17,
-            "startFilePos": 52,
-            "endLine": 4,
-            "endTokenPos": 17,
-            "endFilePos": 62
-          },
-          "name": "now_seeded"
-        },
-        "expr": {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 4,
-            "startTokenPos": 21,
-            "startFilePos": 66,
-            "endLine": 4,
-            "endTokenPos": 21,
-            "endFilePos": 70
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 4,
-              "startTokenPos": 21,
-              "startFilePos": 66,
-              "endLine": 4,
-              "endTokenPos": 21,
-              "endFilePos": 70
-            },
-            "name": "false"
-          }
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 5,
-        "startTokenPos": 24,
-        "startFilePos": 73,
-        "endLine": 5,
-        "endTokenPos": 32,
-        "endFilePos": 102
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 5,
-          "startTokenPos": 24,
-          "startFilePos": 73,
-          "endLine": 5,
-          "endTokenPos": 31,
-          "endFilePos": 101
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 5,
-            "startTokenPos": 24,
-            "startFilePos": 73,
-            "endLine": 5,
-            "endTokenPos": 24,
-            "endFilePos": 74
-          },
-          "name": "s"
-        },
-        "expr": {
-          "nodeType": "Expr_FuncCall",
-          "attributes": {
-            "startLine": 5,
-            "startTokenPos": 28,
-            "startFilePos": 78,
-            "endLine": 5,
-            "endTokenPos": 31,
-            "endFilePos": 101
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 5,
-              "startTokenPos": 28,
-              "startFilePos": 78,
-              "endLine": 5,
-              "endTokenPos": 28,
-              "endFilePos": 83
-            },
-            "name": "getenv"
-          },
-          "args": [
-            {
-              "nodeType": "Arg",
-              "attributes": {
-                "startLine": 5,
-                "startTokenPos": 30,
-                "startFilePos": 85,
-                "endLine": 5,
-                "endTokenPos": 30,
-                "endFilePos": 100
-              },
-              "name": null,
-              "value": {
-                "nodeType": "Scalar_String",
-                "attributes": {
-                  "startLine": 5,
-                  "startTokenPos": 30,
-                  "startFilePos": 85,
-                  "endLine": 5,
-                  "endTokenPos": 30,
-                  "endFilePos": 100,
-                  "kind": 1,
-                  "rawValue": "'MOCHI_NOW_SEED'"
-                },
-                "value": "MOCHI_NOW_SEED"
-              },
-              "byRef": false,
-              "unpack": false
-            }
-          ]
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_If",
-      "attributes": {
-        "startLine": 6,
-        "startTokenPos": 34,
-        "startFilePos": 104,
-        "endLine": 9,
-        "endTokenPos": 71,
-        "endFilePos": 189
-      },
-      "cond": {
-        "nodeType": "Expr_BinaryOp_BooleanAnd",
-        "attributes": {
-          "startLine": 6,
-          "startTokenPos": 37,
-          "startFilePos": 108,
-          "endLine": 6,
-          "endTokenPos": 49,
-          "endFilePos": 132
-        },
-        "left": {
-          "nodeType": "Expr_BinaryOp_NotIdentical",
-          "attributes": {
-            "startLine": 6,
-            "startTokenPos": 37,
-            "startFilePos": 108,
-            "endLine": 6,
-            "endTokenPos": 41,
-            "endFilePos": 119
-          },
-          "left": {
-            "nodeType": "Expr_Variable",
-            "attributes": {
-              "startLine": 6,
-              "startTokenPos": 37,
-              "startFilePos": 108,
-              "endLine": 6,
-              "endTokenPos": 37,
-              "endFilePos": 109
-            },
-            "name": "s"
-          },
-          "right": {
-            "nodeType": "Expr_ConstFetch",
-            "attributes": {
-              "startLine": 6,
-              "startTokenPos": 41,
-              "startFilePos": 115,
-              "endLine": 6,
-              "endTokenPos": 41,
-              "endFilePos": 119
-            },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 6,
-                "startTokenPos": 41,
-                "startFilePos": 115,
-                "endLine": 6,
-                "endTokenPos": 41,
-                "endFilePos": 119
-              },
-              "name": "false"
-            }
-          }
-        },
-        "right": {
-          "nodeType": "Expr_BinaryOp_NotIdentical",
-          "attributes": {
-            "startLine": 6,
-            "startTokenPos": 45,
-            "startFilePos": 124,
-            "endLine": 6,
-            "endTokenPos": 49,
-            "endFilePos": 132
-          },
-          "left": {
-            "nodeType": "Expr_Variable",
-            "attributes": {
-              "startLine": 6,
-              "startTokenPos": 45,
-              "startFilePos": 124,
-              "endLine": 6,
-              "endTokenPos": 45,
-              "endFilePos": 125
-            },
-            "name": "s"
-          },
-          "right": {
-            "nodeType": "Scalar_String",
-            "attributes": {
-              "startLine": 6,
-              "startTokenPos": 49,
-              "startFilePos": 131,
-              "endLine": 6,
-              "endTokenPos": 49,
-              "endFilePos": 132,
-              "kind": 1,
-              "rawValue": "''"
-            },
-            "value": ""
-          }
-        }
-      },
-      "stmts": [
+      "kind": "expression_statement",
+      "children": [
         {
-          "nodeType": "Stmt_Expression",
-          "attributes": {
-            "startLine": 7,
-            "startTokenPos": 54,
-            "startFilePos": 141,
-            "endLine": 7,
-            "endTokenPos": 62,
-            "endFilePos": 163
-          },
-          "expr": {
-            "nodeType": "Expr_Assign",
-            "attributes": {
-              "startLine": 7,
-              "startTokenPos": 54,
-              "startFilePos": 141,
-              "endLine": 7,
-              "endTokenPos": 61,
-              "endFilePos": 162
+          "kind": "function_call_expression",
+          "children": [
+            {
+              "kind": "name",
+              "text": "ini_set"
             },
-            "var": {
-              "nodeType": "Expr_Variable",
-              "attributes": {
-                "startLine": 7,
-                "startTokenPos": 54,
-                "startFilePos": 141,
-                "endLine": 7,
-                "endTokenPos": 54,
-                "endFilePos": 149
-              },
-              "name": "now_seed"
-            },
-            "expr": {
-              "nodeType": "Expr_FuncCall",
-              "attributes": {
-                "startLine": 7,
-                "startTokenPos": 58,
-                "startFilePos": 153,
-                "endLine": 7,
-                "endTokenPos": 61,
-                "endFilePos": 162
-              },
-              "name": {
-                "nodeType": "Name",
-                "attributes": {
-                  "startLine": 7,
-                  "startTokenPos": 58,
-                  "startFilePos": 153,
-                  "endLine": 7,
-                  "endTokenPos": 58,
-                  "endFilePos": 158
-                },
-                "name": "intval"
-              },
-              "args": [
+            {
+              "kind": "arguments",
+              "children": [
                 {
-                  "nodeType": "Arg",
-                  "attributes": {
-                    "startLine": 7,
-                    "startTokenPos": 60,
-                    "startFilePos": 160,
-                    "endLine": 7,
-                    "endTokenPos": 60,
-                    "endFilePos": 161
-                  },
-                  "name": null,
-                  "value": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 7,
-                      "startTokenPos": 60,
-                      "startFilePos": 160,
-                      "endLine": 7,
-                      "endTokenPos": 60,
-                      "endFilePos": 161
-                    },
-                    "name": "s"
-                  },
-                  "byRef": false,
-                  "unpack": false
+                  "kind": "argument",
+                  "children": [
+                    {
+                      "kind": "string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "memory_limit"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "argument",
+                  "children": [
+                    {
+                      "kind": "string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "-1"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }
-          }
-        },
-        {
-          "nodeType": "Stmt_Expression",
-          "attributes": {
-            "startLine": 8,
-            "startTokenPos": 64,
-            "startFilePos": 169,
-            "endLine": 8,
-            "endTokenPos": 69,
-            "endFilePos": 187
-          },
-          "expr": {
-            "nodeType": "Expr_Assign",
-            "attributes": {
-              "startLine": 8,
-              "startTokenPos": 64,
-              "startFilePos": 169,
-              "endLine": 8,
-              "endTokenPos": 68,
-              "endFilePos": 186
-            },
-            "var": {
-              "nodeType": "Expr_Variable",
-              "attributes": {
-                "startLine": 8,
-                "startTokenPos": 64,
-                "startFilePos": 169,
-                "endLine": 8,
-                "endTokenPos": 64,
-                "endFilePos": 179
-              },
-              "name": "now_seeded"
-            },
-            "expr": {
-              "nodeType": "Expr_ConstFetch",
-              "attributes": {
-                "startLine": 8,
-                "startTokenPos": 68,
-                "startFilePos": 183,
-                "endLine": 8,
-                "endTokenPos": 68,
-                "endFilePos": 186
-              },
-              "name": {
-                "nodeType": "Name",
-                "attributes": {
-                  "startLine": 8,
-                  "startTokenPos": 68,
-                  "startFilePos": 183,
-                  "endLine": 8,
-                  "endTokenPos": 68,
-                  "endFilePos": 186
-                },
-                "name": "true"
-              }
-            }
-          }
-        }
-      ],
-      "elseifs": [],
-      "else": null
-    },
-    {
-      "nodeType": "Stmt_Function",
-      "attributes": {
-        "startLine": 10,
-        "startTokenPos": 73,
-        "startFilePos": 191,
-        "endLine": 17,
-        "endTokenPos": 133,
-        "endFilePos": 393
-      },
-      "byRef": false,
-      "name": {
-        "nodeType": "Identifier",
-        "attributes": {
-          "startLine": 10,
-          "startTokenPos": 75,
-          "startFilePos": 200,
-          "endLine": 10,
-          "endTokenPos": 75,
-          "endFilePos": 203
-        },
-        "name": "_now"
-      },
-      "params": [],
-      "returnType": null,
-      "stmts": [
-        {
-          "nodeType": "Stmt_Global",
-          "attributes": {
-            "startLine": 11,
-            "startTokenPos": 81,
-            "startFilePos": 213,
-            "endLine": 11,
-            "endTokenPos": 87,
-            "endFilePos": 242
-          },
-          "vars": [
-            {
-              "nodeType": "Expr_Variable",
-              "attributes": {
-                "startLine": 11,
-                "startTokenPos": 83,
-                "startFilePos": 220,
-                "endLine": 11,
-                "endTokenPos": 83,
-                "endFilePos": 228
-              },
-              "name": "now_seed"
-            },
-            {
-              "nodeType": "Expr_Variable",
-              "attributes": {
-                "startLine": 11,
-                "startTokenPos": 86,
-                "startFilePos": 231,
-                "endLine": 11,
-                "endTokenPos": 86,
-                "endFilePos": 241
-              },
-              "name": "now_seeded"
-            }
           ]
-        },
-        {
-          "nodeType": "Stmt_If",
-          "attributes": {
-            "startLine": 12,
-            "startTokenPos": 89,
-            "startFilePos": 248,
-            "endLine": 15,
-            "endTokenPos": 123,
-            "endFilePos": 366
-          },
-          "cond": {
-            "nodeType": "Expr_Variable",
-            "attributes": {
-              "startLine": 12,
-              "startTokenPos": 92,
-              "startFilePos": 252,
-              "endLine": 12,
-              "endTokenPos": 92,
-              "endFilePos": 262
-            },
-            "name": "now_seeded"
-          },
-          "stmts": [
-            {
-              "nodeType": "Stmt_Expression",
-              "attributes": {
-                "startLine": 13,
-                "startTokenPos": 97,
-                "startFilePos": 275,
-                "endLine": 13,
-                "endTokenPos": 116,
-                "endFilePos": 334
-              },
-              "expr": {
-                "nodeType": "Expr_Assign",
-                "attributes": {
-                  "startLine": 13,
-                  "startTokenPos": 97,
-                  "startFilePos": 275,
-                  "endLine": 13,
-                  "endTokenPos": 115,
-                  "endFilePos": 333
-                },
-                "var": {
-                  "nodeType": "Expr_Variable",
-                  "attributes": {
-                    "startLine": 13,
-                    "startTokenPos": 97,
-                    "startFilePos": 275,
-                    "endLine": 13,
-                    "endTokenPos": 97,
-                    "endFilePos": 283
-                  },
-                  "name": "now_seed"
-                },
-                "expr": {
-                  "nodeType": "Expr_BinaryOp_Mod",
-                  "attributes": {
-                    "startLine": 13,
-                    "startTokenPos": 101,
-                    "startFilePos": 287,
-                    "endLine": 13,
-                    "endTokenPos": 115,
-                    "endFilePos": 333
-                  },
-                  "left": {
-                    "nodeType": "Expr_BinaryOp_Plus",
-                    "attributes": {
-                      "startLine": 13,
-                      "startTokenPos": 102,
-                      "startFilePos": 288,
-                      "endLine": 13,
-                      "endTokenPos": 110,
-                      "endFilePos": 319
-                    },
-                    "left": {
-                      "nodeType": "Expr_BinaryOp_Mul",
-                      "attributes": {
-                        "startLine": 13,
-                        "startTokenPos": 102,
-                        "startFilePos": 288,
-                        "endLine": 13,
-                        "endTokenPos": 106,
-                        "endFilePos": 306
-                      },
-                      "left": {
-                        "nodeType": "Expr_Variable",
-                        "attributes": {
-                          "startLine": 13,
-                          "startTokenPos": 102,
-                          "startFilePos": 288,
-                          "endLine": 13,
-                          "endTokenPos": 102,
-                          "endFilePos": 296
-                        },
-                        "name": "now_seed"
-                      },
-                      "right": {
-                        "nodeType": "Scalar_Int",
-                        "attributes": {
-                          "startLine": 13,
-                          "startTokenPos": 106,
-                          "startFilePos": 300,
-                          "endLine": 13,
-                          "endTokenPos": 106,
-                          "endFilePos": 306,
-                          "rawValue": "1664525",
-                          "kind": 10
-                        },
-                        "value": 1664525
-                      }
-                    },
-                    "right": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 13,
-                        "startTokenPos": 110,
-                        "startFilePos": 310,
-                        "endLine": 13,
-                        "endTokenPos": 110,
-                        "endFilePos": 319,
-                        "rawValue": "1013904223",
-                        "kind": 10
-                      },
-                      "value": 1013904223
-                    }
-                  },
-                  "right": {
-                    "nodeType": "Scalar_Int",
-                    "attributes": {
-                      "startLine": 13,
-                      "startTokenPos": 115,
-                      "startFilePos": 324,
-                      "endLine": 13,
-                      "endTokenPos": 115,
-                      "endFilePos": 333,
-                      "rawValue": "2147483647",
-                      "kind": 10
-                    },
-                    "value": 2147483647
-                  }
-                }
-              }
-            },
-            {
-              "nodeType": "Stmt_Return",
-              "attributes": {
-                "startLine": 14,
-                "startTokenPos": 118,
-                "startFilePos": 344,
-                "endLine": 14,
-                "endTokenPos": 121,
-                "endFilePos": 360
-              },
-              "expr": {
-                "nodeType": "Expr_Variable",
-                "attributes": {
-                  "startLine": 14,
-                  "startTokenPos": 120,
-                  "startFilePos": 351,
-                  "endLine": 14,
-                  "endTokenPos": 120,
-                  "endFilePos": 359
-                },
-                "name": "now_seed"
-              }
-            }
-          ],
-          "elseifs": [],
-          "else": null
-        },
-        {
-          "nodeType": "Stmt_Return",
-          "attributes": {
-            "startLine": 16,
-            "startTokenPos": 125,
-            "startFilePos": 372,
-            "endLine": 16,
-            "endTokenPos": 131,
-            "endFilePos": 391
-          },
-          "expr": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 16,
-              "startTokenPos": 127,
-              "startFilePos": 379,
-              "endLine": 16,
-              "endTokenPos": 130,
-              "endFilePos": 390
-            },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 16,
-                "startTokenPos": 127,
-                "startFilePos": 379,
-                "endLine": 16,
-                "endTokenPos": 127,
-                "endFilePos": 384
-              },
-              "name": "hrtime"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 16,
-                  "startTokenPos": 129,
-                  "startFilePos": 386,
-                  "endLine": 16,
-                  "endTokenPos": 129,
-                  "endFilePos": 389
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_ConstFetch",
-                  "attributes": {
-                    "startLine": 16,
-                    "startTokenPos": 129,
-                    "startFilePos": 386,
-                    "endLine": 16,
-                    "endTokenPos": 129,
-                    "endFilePos": 389
-                  },
-                  "name": {
-                    "nodeType": "Name",
-                    "attributes": {
-                      "startLine": 16,
-                      "startTokenPos": 129,
-                      "startFilePos": 386,
-                      "endLine": 16,
-                      "endTokenPos": 129,
-                      "endFilePos": 389
-                    },
-                    "name": "true"
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          }
-        }
-      ],
-      "attrGroups": []
-    },
-    {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 18,
-        "startTokenPos": 135,
-        "startFilePos": 395,
-        "endLine": 18,
-        "endTokenPos": 142,
-        "endFilePos": 428
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 18,
-          "startTokenPos": 135,
-          "startFilePos": 395,
-          "endLine": 18,
-          "endTokenPos": 141,
-          "endFilePos": 427
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 18,
-            "startTokenPos": 135,
-            "startFilePos": 395,
-            "endLine": 18,
-            "endTokenPos": 135,
-            "endFilePos": 406
-          },
-          "name": "__start_mem"
-        },
-        "expr": {
-          "nodeType": "Expr_FuncCall",
-          "attributes": {
-            "startLine": 18,
-            "startTokenPos": 139,
-            "startFilePos": 410,
-            "endLine": 18,
-            "endTokenPos": 141,
-            "endFilePos": 427
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 18,
-              "startTokenPos": 139,
-              "startFilePos": 410,
-              "endLine": 18,
-              "endTokenPos": 139,
-              "endFilePos": 425
-            },
-            "name": "memory_get_usage"
-          },
-          "args": []
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 19,
-        "startTokenPos": 144,
-        "startFilePos": 430,
-        "endLine": 19,
-        "endTokenPos": 151,
-        "endFilePos": 447
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 19,
-          "startTokenPos": 144,
-          "startFilePos": 430,
-          "endLine": 19,
-          "endTokenPos": 150,
-          "endFilePos": 446
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 19,
-            "startTokenPos": 144,
-            "startFilePos": 430,
-            "endLine": 19,
-            "endTokenPos": 144,
-            "endFilePos": 437
-          },
-          "name": "__start"
-        },
-        "expr": {
-          "nodeType": "Expr_FuncCall",
-          "attributes": {
-            "startLine": 19,
-            "startTokenPos": 148,
-            "startFilePos": 441,
-            "endLine": 19,
-            "endTokenPos": 150,
-            "endFilePos": 446
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 19,
-              "startTokenPos": 148,
-              "startFilePos": 441,
-              "endLine": 19,
-              "endTokenPos": 148,
-              "endFilePos": 444
-            },
-            "name": "_now"
-          },
-          "args": []
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 20,
-        "startTokenPos": 153,
-        "startFilePos": 451,
-        "endLine": 20,
-        "endTokenPos": 158,
-        "endFilePos": 460
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 20,
-          "startTokenPos": 153,
-          "startFilePos": 451,
-          "endLine": 20,
-          "endTokenPos": 157,
-          "endFilePos": 459
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 20,
-            "startTokenPos": 153,
-            "startFilePos": 451,
-            "endLine": 20,
-            "endTokenPos": 153,
-            "endFilePos": 452
-          },
-          "name": "n"
-        },
-        "expr": {
-          "nodeType": "Scalar_Int",
-          "attributes": {
-            "startLine": 20,
-            "startTokenPos": 157,
-            "startFilePos": 456,
-            "endLine": 20,
-            "endTokenPos": 157,
-            "endFilePos": 459,
-            "rawValue": "1000",
-            "kind": 10
-          },
-          "value": 1000
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 21,
-        "startTokenPos": 160,
-        "startFilePos": 464,
-        "endLine": 21,
-        "endTokenPos": 165,
-        "endFilePos": 470
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 21,
-          "startTokenPos": 160,
-          "startFilePos": 464,
-          "endLine": 21,
-          "endTokenPos": 164,
-          "endFilePos": 469
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 21,
-            "startTokenPos": 160,
-            "startFilePos": 464,
-            "endLine": 21,
-            "endTokenPos": 160,
-            "endFilePos": 465
-          },
-          "name": "s"
-        },
-        "expr": {
-          "nodeType": "Scalar_Int",
-          "attributes": {
-            "startLine": 21,
-            "startTokenPos": 164,
-            "startFilePos": 469,
-            "endLine": 21,
-            "endTokenPos": 164,
-            "endFilePos": 469,
-            "rawValue": "0",
-            "kind": 10
-          },
-          "value": 0
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_For",
-      "attributes": {
-        "startLine": 22,
-        "startTokenPos": 167,
-        "startFilePos": 474,
-        "endLine": 24,
-        "endTokenPos": 201,
-        "endFilePos": 520
-      },
-      "init": [
-        {
-          "nodeType": "Expr_Assign",
-          "attributes": {
-            "startLine": 22,
-            "startTokenPos": 170,
-            "startFilePos": 479,
-            "endLine": 22,
-            "endTokenPos": 174,
-            "endFilePos": 484
-          },
-          "var": {
-            "nodeType": "Expr_Variable",
-            "attributes": {
-              "startLine": 22,
-              "startTokenPos": 170,
-              "startFilePos": 479,
-              "endLine": 22,
-              "endTokenPos": 170,
-              "endFilePos": 480
-            },
-            "name": "i"
-          },
-          "expr": {
-            "nodeType": "Scalar_Int",
-            "attributes": {
-              "startLine": 22,
-              "startTokenPos": 174,
-              "startFilePos": 484,
-              "endLine": 22,
-              "endTokenPos": 174,
-              "endFilePos": 484,
-              "rawValue": "1",
-              "kind": 10
-            },
-            "value": 1
-          }
-        }
-      ],
-      "cond": [
-        {
-          "nodeType": "Expr_BinaryOp_Smaller",
-          "attributes": {
-            "startLine": 22,
-            "startTokenPos": 177,
-            "startFilePos": 487,
-            "endLine": 22,
-            "endTokenPos": 181,
-            "endFilePos": 493
-          },
-          "left": {
-            "nodeType": "Expr_Variable",
-            "attributes": {
-              "startLine": 22,
-              "startTokenPos": 177,
-              "startFilePos": 487,
-              "endLine": 22,
-              "endTokenPos": 177,
-              "endFilePos": 488
-            },
-            "name": "i"
-          },
-          "right": {
-            "nodeType": "Expr_Variable",
-            "attributes": {
-              "startLine": 22,
-              "startTokenPos": 181,
-              "startFilePos": 492,
-              "endLine": 22,
-              "endTokenPos": 181,
-              "endFilePos": 493
-            },
-            "name": "n"
-          }
-        }
-      ],
-      "loop": [
-        {
-          "nodeType": "Expr_PostInc",
-          "attributes": {
-            "startLine": 22,
-            "startTokenPos": 184,
-            "startFilePos": 496,
-            "endLine": 22,
-            "endTokenPos": 185,
-            "endFilePos": 499
-          },
-          "var": {
-            "nodeType": "Expr_Variable",
-            "attributes": {
-              "startLine": 22,
-              "startTokenPos": 184,
-              "startFilePos": 496,
-              "endLine": 22,
-              "endTokenPos": 184,
-              "endFilePos": 497
-            },
-            "name": "i"
-          }
-        }
-      ],
-      "stmts": [
-        {
-          "nodeType": "Stmt_Expression",
-          "attributes": {
-            "startLine": 23,
-            "startTokenPos": 190,
-            "startFilePos": 506,
-            "endLine": 23,
-            "endTokenPos": 199,
-            "endFilePos": 518
-          },
-          "expr": {
-            "nodeType": "Expr_Assign",
-            "attributes": {
-              "startLine": 23,
-              "startTokenPos": 190,
-              "startFilePos": 506,
-              "endLine": 23,
-              "endTokenPos": 198,
-              "endFilePos": 517
-            },
-            "var": {
-              "nodeType": "Expr_Variable",
-              "attributes": {
-                "startLine": 23,
-                "startTokenPos": 190,
-                "startFilePos": 506,
-                "endLine": 23,
-                "endTokenPos": 190,
-                "endFilePos": 507
-              },
-              "name": "s"
-            },
-            "expr": {
-              "nodeType": "Expr_BinaryOp_Plus",
-              "attributes": {
-                "startLine": 23,
-                "startTokenPos": 194,
-                "startFilePos": 511,
-                "endLine": 23,
-                "endTokenPos": 198,
-                "endFilePos": 517
-              },
-              "left": {
-                "nodeType": "Expr_Variable",
-                "attributes": {
-                  "startLine": 23,
-                  "startTokenPos": 194,
-                  "startFilePos": 511,
-                  "endLine": 23,
-                  "endTokenPos": 194,
-                  "endFilePos": 512
-                },
-                "name": "s"
-              },
-              "right": {
-                "nodeType": "Expr_Variable",
-                "attributes": {
-                  "startLine": 23,
-                  "startTokenPos": 198,
-                  "startFilePos": 516,
-                  "endLine": 23,
-                  "endTokenPos": 198,
-                  "endFilePos": 517
-                },
-                "name": "i"
-              }
-            }
-          }
         }
       ]
     },
     {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 25,
-        "startTokenPos": 203,
-        "startFilePos": 522,
-        "endLine": 25,
-        "endTokenPos": 210,
-        "endFilePos": 537
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 25,
-          "startTokenPos": 203,
-          "startFilePos": 522,
-          "endLine": 25,
-          "endTokenPos": 209,
-          "endFilePos": 536
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 25,
-            "startTokenPos": 203,
-            "startFilePos": 522,
-            "endLine": 25,
-            "endTokenPos": 203,
-            "endFilePos": 527
-          },
-          "name": "__end"
-        },
-        "expr": {
-          "nodeType": "Expr_FuncCall",
-          "attributes": {
-            "startLine": 25,
-            "startTokenPos": 207,
-            "startFilePos": 531,
-            "endLine": 25,
-            "endTokenPos": 209,
-            "endFilePos": 536
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 25,
-              "startTokenPos": 207,
-              "startFilePos": 531,
-              "endLine": 25,
-              "endTokenPos": 207,
-              "endFilePos": 534
-            },
-            "name": "_now"
-          },
-          "args": []
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 26,
-        "startTokenPos": 212,
-        "startFilePos": 539,
-        "endLine": 26,
-        "endTokenPos": 219,
-        "endFilePos": 570
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 26,
-          "startTokenPos": 212,
-          "startFilePos": 539,
-          "endLine": 26,
-          "endTokenPos": 218,
-          "endFilePos": 569
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 26,
-            "startTokenPos": 212,
-            "startFilePos": 539,
-            "endLine": 26,
-            "endTokenPos": 212,
-            "endFilePos": 548
-          },
-          "name": "__end_mem"
-        },
-        "expr": {
-          "nodeType": "Expr_FuncCall",
-          "attributes": {
-            "startLine": 26,
-            "startTokenPos": 216,
-            "startFilePos": 552,
-            "endLine": 26,
-            "endTokenPos": 218,
-            "endFilePos": 569
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 26,
-              "startTokenPos": 216,
-              "startFilePos": 552,
-              "endLine": 26,
-              "endTokenPos": 216,
-              "endFilePos": 567
-            },
-            "name": "memory_get_usage"
-          },
-          "args": []
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 27,
-        "startTokenPos": 221,
-        "startFilePos": 572,
-        "endLine": 27,
-        "endTokenPos": 236,
-        "endFilePos": 617
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 27,
-          "startTokenPos": 221,
-          "startFilePos": 572,
-          "endLine": 27,
-          "endTokenPos": 235,
-          "endFilePos": 616
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 27,
-            "startTokenPos": 221,
-            "startFilePos": 572,
-            "endLine": 27,
-            "endTokenPos": 221,
-            "endFilePos": 582
-          },
-          "name": "__duration"
-        },
-        "expr": {
-          "nodeType": "Expr_FuncCall",
-          "attributes": {
-            "startLine": 27,
-            "startTokenPos": 225,
-            "startFilePos": 586,
-            "endLine": 27,
-            "endTokenPos": 235,
-            "endFilePos": 616
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 27,
-              "startTokenPos": 225,
-              "startFilePos": 586,
-              "endLine": 27,
-              "endTokenPos": 225,
-              "endFilePos": 591
-            },
-            "name": "intdiv"
-          },
-          "args": [
+      "kind": "expression_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
             {
-              "nodeType": "Arg",
-              "attributes": {
-                "startLine": 27,
-                "startTokenPos": 227,
-                "startFilePos": 593,
-                "endLine": 27,
-                "endTokenPos": 231,
-                "endFilePos": 609
-              },
-              "name": null,
-              "value": {
-                "nodeType": "Expr_BinaryOp_Minus",
-                "attributes": {
-                  "startLine": 27,
-                  "startTokenPos": 227,
-                  "startFilePos": 593,
-                  "endLine": 27,
-                  "endTokenPos": 231,
-                  "endFilePos": 609
-                },
-                "left": {
-                  "nodeType": "Expr_Variable",
-                  "attributes": {
-                    "startLine": 27,
-                    "startTokenPos": 227,
-                    "startFilePos": 593,
-                    "endLine": 27,
-                    "endTokenPos": 227,
-                    "endFilePos": 598
-                  },
-                  "name": "__end"
-                },
-                "right": {
-                  "nodeType": "Expr_Variable",
-                  "attributes": {
-                    "startLine": 27,
-                    "startTokenPos": 231,
-                    "startFilePos": 602,
-                    "endLine": 27,
-                    "endTokenPos": 231,
-                    "endFilePos": 609
-                  },
-                  "name": "__start"
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "now_seed"
                 }
-              },
-              "byRef": false,
-              "unpack": false
+              ]
             },
             {
-              "nodeType": "Arg",
-              "attributes": {
-                "startLine": 27,
-                "startTokenPos": 234,
-                "startFilePos": 612,
-                "endLine": 27,
-                "endTokenPos": 234,
-                "endFilePos": 615
-              },
-              "name": null,
-              "value": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 27,
-                  "startTokenPos": 234,
-                  "startFilePos": 612,
-                  "endLine": 27,
-                  "endTokenPos": 234,
-                  "endFilePos": 615,
-                  "rawValue": "1000",
-                  "kind": 10
-                },
-                "value": 1000
-              },
-              "byRef": false,
-              "unpack": false
+              "kind": "integer",
+              "text": "0"
             }
           ]
         }
-      }
+      ]
     },
     {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 28,
-        "startTokenPos": 238,
-        "startFilePos": 619,
-        "endLine": 28,
-        "endTokenPos": 243,
-        "endFilePos": 634
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 28,
-          "startTokenPos": 238,
-          "startFilePos": 619,
-          "endLine": 28,
-          "endTokenPos": 242,
-          "endFilePos": 633
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 28,
-            "startTokenPos": 238,
-            "startFilePos": 619,
-            "endLine": 28,
-            "endTokenPos": 238,
-            "endFilePos": 629
-          },
-          "name": "__mem_diff"
-        },
-        "expr": {
-          "nodeType": "Scalar_Int",
-          "attributes": {
-            "startLine": 28,
-            "startTokenPos": 242,
-            "startFilePos": 633,
-            "endLine": 28,
-            "endTokenPos": 242,
-            "endFilePos": 633,
-            "rawValue": "0",
-            "kind": 10
-          },
-          "value": 0
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 29,
-        "startTokenPos": 245,
-        "startFilePos": 636,
-        "endLine": 29,
-        "endTokenPos": 270,
-        "endFilePos": 728
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 29,
-          "startTokenPos": 245,
-          "startFilePos": 636,
-          "endLine": 29,
-          "endTokenPos": 269,
-          "endFilePos": 727
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 29,
-            "startTokenPos": 245,
-            "startFilePos": 636,
-            "endLine": 29,
-            "endTokenPos": 245,
-            "endFilePos": 643
-          },
-          "name": "__bench"
-        },
-        "expr": {
-          "nodeType": "Expr_Array",
-          "attributes": {
-            "startLine": 29,
-            "startTokenPos": 249,
-            "startFilePos": 647,
-            "endLine": 29,
-            "endTokenPos": 269,
-            "endFilePos": 727,
-            "kind": 2
-          },
-          "items": [
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 29,
-                "startTokenPos": 250,
-                "startFilePos": 648,
-                "endLine": 29,
-                "endTokenPos": 254,
-                "endFilePos": 675
-              },
-              "key": {
-                "nodeType": "Scalar_String",
-                "attributes": {
-                  "startLine": 29,
-                  "startTokenPos": 250,
-                  "startFilePos": 648,
-                  "endLine": 29,
-                  "endTokenPos": 250,
-                  "endFilePos": 660,
-                  "kind": 2,
-                  "rawValue": "\"duration_us\""
-                },
-                "value": "duration_us"
-              },
-              "value": {
-                "nodeType": "Expr_Variable",
-                "attributes": {
-                  "startLine": 29,
-                  "startTokenPos": 254,
-                  "startFilePos": 665,
-                  "endLine": 29,
-                  "endTokenPos": 254,
-                  "endFilePos": 675
-                },
-                "name": "__duration"
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 29,
-                "startTokenPos": 257,
-                "startFilePos": 678,
-                "endLine": 29,
-                "endTokenPos": 261,
-                "endFilePos": 706
-              },
-              "key": {
-                "nodeType": "Scalar_String",
-                "attributes": {
-                  "startLine": 29,
-                  "startTokenPos": 257,
-                  "startFilePos": 678,
-                  "endLine": 29,
-                  "endTokenPos": 257,
-                  "endFilePos": 691,
-                  "kind": 2,
-                  "rawValue": "\"memory_bytes\""
-                },
-                "value": "memory_bytes"
-              },
-              "value": {
-                "nodeType": "Expr_Variable",
-                "attributes": {
-                  "startLine": 29,
-                  "startTokenPos": 261,
-                  "startFilePos": 696,
-                  "endLine": 29,
-                  "endTokenPos": 261,
-                  "endFilePos": 706
-                },
-                "name": "__mem_diff"
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 29,
-                "startTokenPos": 264,
-                "startFilePos": 709,
-                "endLine": 29,
-                "endTokenPos": 268,
-                "endFilePos": 726
-              },
-              "key": {
-                "nodeType": "Scalar_String",
-                "attributes": {
-                  "startLine": 29,
-                  "startTokenPos": 264,
-                  "startFilePos": 709,
-                  "endLine": 29,
-                  "endTokenPos": 264,
-                  "endFilePos": 714,
-                  "kind": 2,
-                  "rawValue": "\"name\""
-                },
-                "value": "name"
-              },
-              "value": {
-                "nodeType": "Scalar_String",
-                "attributes": {
-                  "startLine": 29,
-                  "startTokenPos": 268,
-                  "startFilePos": 719,
-                  "endLine": 29,
-                  "endTokenPos": 268,
-                  "endFilePos": 726,
-                  "kind": 2,
-                  "rawValue": "\"simple\""
-                },
-                "value": "simple"
-              },
-              "byRef": false,
-              "unpack": false
-            }
-          ]
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 30,
-        "startTokenPos": 272,
-        "startFilePos": 730,
-        "endLine": 30,
-        "endTokenPos": 283,
-        "endFilePos": 763
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 30,
-          "startTokenPos": 272,
-          "startFilePos": 730,
-          "endLine": 30,
-          "endTokenPos": 282,
-          "endFilePos": 762
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 30,
-            "startTokenPos": 272,
-            "startFilePos": 730,
-            "endLine": 30,
-            "endTokenPos": 272,
-            "endFilePos": 733
-          },
-          "name": "__j"
-        },
-        "expr": {
-          "nodeType": "Expr_FuncCall",
-          "attributes": {
-            "startLine": 30,
-            "startTokenPos": 276,
-            "startFilePos": 737,
-            "endLine": 30,
-            "endTokenPos": 282,
-            "endFilePos": 762
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 30,
-              "startTokenPos": 276,
-              "startFilePos": 737,
-              "endLine": 30,
-              "endTokenPos": 276,
-              "endFilePos": 747
-            },
-            "name": "json_encode"
-          },
-          "args": [
-            {
-              "nodeType": "Arg",
-              "attributes": {
-                "startLine": 30,
-                "startTokenPos": 278,
-                "startFilePos": 749,
-                "endLine": 30,
-                "endTokenPos": 278,
-                "endFilePos": 756
-              },
-              "name": null,
-              "value": {
-                "nodeType": "Expr_Variable",
-                "attributes": {
-                  "startLine": 30,
-                  "startTokenPos": 278,
-                  "startFilePos": 749,
-                  "endLine": 30,
-                  "endTokenPos": 278,
-                  "endFilePos": 756
-                },
-                "name": "__bench"
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "Arg",
-              "attributes": {
-                "startLine": 30,
-                "startTokenPos": 281,
-                "startFilePos": 759,
-                "endLine": 30,
-                "endTokenPos": 281,
-                "endFilePos": 761
-              },
-              "name": null,
-              "value": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 30,
-                  "startTokenPos": 281,
-                  "startFilePos": 759,
-                  "endLine": 30,
-                  "endTokenPos": 281,
-                  "endFilePos": 761,
-                  "rawValue": "128",
-                  "kind": 10
-                },
-                "value": 128
-              },
-              "byRef": false,
-              "unpack": false
-            }
-          ]
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 31,
-        "startTokenPos": 285,
-        "startFilePos": 765,
-        "endLine": 31,
-        "endTokenPos": 299,
-        "endFilePos": 803
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 31,
-          "startTokenPos": 285,
-          "startFilePos": 765,
-          "endLine": 31,
-          "endTokenPos": 298,
-          "endFilePos": 802
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 31,
-            "startTokenPos": 285,
-            "startFilePos": 765,
-            "endLine": 31,
-            "endTokenPos": 285,
-            "endFilePos": 768
-          },
-          "name": "__j"
-        },
-        "expr": {
-          "nodeType": "Expr_FuncCall",
-          "attributes": {
-            "startLine": 31,
-            "startTokenPos": 289,
-            "startFilePos": 772,
-            "endLine": 31,
-            "endTokenPos": 298,
-            "endFilePos": 802
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 31,
-              "startTokenPos": 289,
-              "startFilePos": 772,
-              "endLine": 31,
-              "endTokenPos": 289,
-              "endFilePos": 782
-            },
-            "name": "str_replace"
-          },
-          "args": [
-            {
-              "nodeType": "Arg",
-              "attributes": {
-                "startLine": 31,
-                "startTokenPos": 291,
-                "startFilePos": 784,
-                "endLine": 31,
-                "endTokenPos": 291,
-                "endFilePos": 789
-              },
-              "name": null,
-              "value": {
-                "nodeType": "Scalar_String",
-                "attributes": {
-                  "startLine": 31,
-                  "startTokenPos": 291,
-                  "startFilePos": 784,
-                  "endLine": 31,
-                  "endTokenPos": 291,
-                  "endFilePos": 789,
-                  "kind": 2,
-                  "rawValue": "\"    \""
-                },
-                "value": "    "
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "Arg",
-              "attributes": {
-                "startLine": 31,
-                "startTokenPos": 294,
-                "startFilePos": 792,
-                "endLine": 31,
-                "endTokenPos": 294,
-                "endFilePos": 795
-              },
-              "name": null,
-              "value": {
-                "nodeType": "Scalar_String",
-                "attributes": {
-                  "startLine": 31,
-                  "startTokenPos": 294,
-                  "startFilePos": 792,
-                  "endLine": 31,
-                  "endTokenPos": 294,
-                  "endFilePos": 795,
-                  "kind": 2,
-                  "rawValue": "\"  \""
-                },
-                "value": "  "
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "Arg",
-              "attributes": {
-                "startLine": 31,
-                "startTokenPos": 297,
-                "startFilePos": 798,
-                "endLine": 31,
-                "endTokenPos": 297,
-                "endFilePos": 801
-              },
-              "name": null,
-              "value": {
-                "nodeType": "Expr_Variable",
-                "attributes": {
-                  "startLine": 31,
-                  "startTokenPos": 297,
-                  "startFilePos": 798,
-                  "endLine": 31,
-                  "endTokenPos": 297,
-                  "endFilePos": 801
-                },
-                "name": "__j"
-              },
-              "byRef": false,
-              "unpack": false
-            }
-          ]
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 32,
-        "startTokenPos": 301,
-        "startFilePos": 805,
-        "endLine": 32,
-        "endTokenPos": 307,
-        "endFilePos": 823
-      },
-      "exprs": [
+      "kind": "expression_statement",
+      "children": [
         {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 32,
-            "startTokenPos": 303,
-            "startFilePos": 810,
-            "endLine": 32,
-            "endTokenPos": 303,
-            "endFilePos": 813
-          },
-          "name": "__j"
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "now_seeded"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "expression_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "s"
+                }
+              ]
+            },
+            {
+              "kind": "function_call_expression",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "getenv"
+                },
+                {
+                  "kind": "arguments",
+                  "children": [
+                    {
+                      "kind": "argument",
+                      "children": [
+                        {
+                          "kind": "string",
+                          "children": [
+                            {
+                              "kind": "string_content",
+                              "text": "MOCHI_NOW_SEED"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "if_statement",
+      "children": [
+        {
+          "kind": "parenthesized_expression",
+          "children": [
+            {
+              "kind": "binary_expression",
+              "children": [
+                {
+                  "kind": "binary_expression",
+                  "children": [
+                    {
+                      "kind": "variable_name",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "s"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "binary_expression",
+                  "children": [
+                    {
+                      "kind": "variable_name",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "s"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "string",
+                      "text": "''"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         },
         {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 32,
-            "startTokenPos": 306,
-            "startFilePos": 816,
-            "endLine": 32,
-            "endTokenPos": 306,
-            "endFilePos": 822
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 32,
-              "startTokenPos": 306,
-              "startFilePos": 816,
-              "endLine": 32,
-              "endTokenPos": 306,
-              "endFilePos": 822
+          "kind": "compound_statement",
+          "children": [
+            {
+              "kind": "expression_statement",
+              "children": [
+                {
+                  "kind": "assignment_expression",
+                  "children": [
+                    {
+                      "kind": "variable_name",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "now_seed"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "intval"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "variable_name",
+                                  "children": [
+                                    {
+                                      "kind": "name",
+                                      "text": "s"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             },
-            "name": "PHP_EOL"
-          }
+            {
+              "kind": "expression_statement",
+              "children": [
+                {
+                  "kind": "assignment_expression",
+                  "children": [
+                    {
+                      "kind": "variable_name",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "now_seeded"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "function_definition",
+      "children": [
+        {
+          "kind": "name",
+          "text": "_now"
+        },
+        {
+          "kind": "compound_statement",
+          "children": [
+            {
+              "kind": "global_declaration",
+              "children": [
+                {
+                  "kind": "variable_name",
+                  "children": [
+                    {
+                      "kind": "name",
+                      "text": "now_seed"
+                    }
+                  ]
+                },
+                {
+                  "kind": "variable_name",
+                  "children": [
+                    {
+                      "kind": "name",
+                      "text": "now_seeded"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "if_statement",
+              "children": [
+                {
+                  "kind": "parenthesized_expression",
+                  "children": [
+                    {
+                      "kind": "variable_name",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "now_seeded"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "compound_statement",
+                  "children": [
+                    {
+                      "kind": "expression_statement",
+                      "children": [
+                        {
+                          "kind": "assignment_expression",
+                          "children": [
+                            {
+                              "kind": "variable_name",
+                              "children": [
+                                {
+                                  "kind": "name",
+                                  "text": "now_seed"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "binary_expression",
+                              "children": [
+                                {
+                                  "kind": "parenthesized_expression",
+                                  "children": [
+                                    {
+                                      "kind": "binary_expression",
+                                      "children": [
+                                        {
+                                          "kind": "binary_expression",
+                                          "children": [
+                                            {
+                                              "kind": "variable_name",
+                                              "children": [
+                                                {
+                                                  "kind": "name",
+                                                  "text": "now_seed"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "integer",
+                                              "text": "1664525"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "integer",
+                                          "text": "1013904223"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "integer",
+                                  "text": "2147483647"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "return_statement",
+                      "children": [
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "now_seed"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "return_statement",
+              "children": [
+                {
+                  "kind": "function_call_expression",
+                  "children": [
+                    {
+                      "kind": "name",
+                      "text": "hrtime"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "expression_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "__start_mem"
+                }
+              ]
+            },
+            {
+              "kind": "function_call_expression",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "memory_get_usage"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "expression_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "__start"
+                }
+              ]
+            },
+            {
+              "kind": "function_call_expression",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "_now"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "expression_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "n"
+                }
+              ]
+            },
+            {
+              "kind": "integer",
+              "text": "1000"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "expression_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "s"
+                }
+              ]
+            },
+            {
+              "kind": "integer",
+              "text": "0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "for_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "i"
+                }
+              ]
+            },
+            {
+              "kind": "integer",
+              "text": "1"
+            }
+          ]
+        },
+        {
+          "kind": "binary_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "i"
+                }
+              ]
+            },
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "n"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "update_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "i"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "compound_statement",
+          "children": [
+            {
+              "kind": "expression_statement",
+              "children": [
+                {
+                  "kind": "assignment_expression",
+                  "children": [
+                    {
+                      "kind": "variable_name",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "s"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "s"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "i"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "expression_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "__end"
+                }
+              ]
+            },
+            {
+              "kind": "function_call_expression",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "_now"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "expression_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "__end_mem"
+                }
+              ]
+            },
+            {
+              "kind": "function_call_expression",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "memory_get_usage"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "expression_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "__duration"
+                }
+              ]
+            },
+            {
+              "kind": "function_call_expression",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "intdiv"
+                },
+                {
+                  "kind": "arguments",
+                  "children": [
+                    {
+                      "kind": "argument",
+                      "children": [
+                        {
+                          "kind": "binary_expression",
+                          "children": [
+                            {
+                              "kind": "variable_name",
+                              "children": [
+                                {
+                                  "kind": "name",
+                                  "text": "__end"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "variable_name",
+                              "children": [
+                                {
+                                  "kind": "name",
+                                  "text": "__start"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "argument",
+                      "children": [
+                        {
+                          "kind": "integer",
+                          "text": "1000"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "expression_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "__mem_diff"
+                }
+              ]
+            },
+            {
+              "kind": "integer",
+              "text": "0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "expression_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "__bench"
+                }
+              ]
+            },
+            {
+              "kind": "array_creation_expression",
+              "children": [
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "duration_us"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "variable_name",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "__duration"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "memory_bytes"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "variable_name",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "__mem_diff"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "name"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "simple"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "expression_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "__j"
+                }
+              ]
+            },
+            {
+              "kind": "function_call_expression",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "json_encode"
+                },
+                {
+                  "kind": "arguments",
+                  "children": [
+                    {
+                      "kind": "argument",
+                      "children": [
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "__bench"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "argument",
+                      "children": [
+                        {
+                          "kind": "integer",
+                          "text": "128"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "expression_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "__j"
+                }
+              ]
+            },
+            {
+              "kind": "function_call_expression",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "str_replace"
+                },
+                {
+                  "kind": "arguments",
+                  "children": [
+                    {
+                      "kind": "argument",
+                      "children": [
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "__j"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "echo_statement",
+      "children": [
+        {
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "__j"
+                }
+              ]
+            },
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
+            }
+          ]
         }
       ]
     }

--- a/tests/json-ast/x/php/bigint_ops.php.json
+++ b/tests/json-ast/x/php/bigint_ops.php.json
@@ -1,1388 +1,748 @@
 {
-  "root": [
+  "statements": [
     {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 2,
-        "startTokenPos": 1,
-        "startFilePos": 6,
-        "endLine": 2,
-        "endTokenPos": 6,
-        "endFilePos": 13
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 2,
-          "startTokenPos": 1,
-          "startFilePos": 6,
-          "endLine": 2,
-          "endTokenPos": 5,
-          "endFilePos": 12
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 1,
-            "startFilePos": 6,
-            "endLine": 2,
-            "endTokenPos": 1,
-            "endFilePos": 7
-          },
-          "name": "a"
-        },
-        "expr": {
-          "nodeType": "Scalar_Int",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 5,
-            "startFilePos": 11,
-            "endLine": 2,
-            "endTokenPos": 5,
-            "endFilePos": 12,
-            "rawValue": "10",
-            "kind": 10
-          },
-          "value": 10
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 3,
-        "startTokenPos": 8,
-        "startFilePos": 15,
-        "endLine": 3,
-        "endTokenPos": 13,
-        "endFilePos": 21
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 3,
-          "startTokenPos": 8,
-          "startFilePos": 15,
-          "endLine": 3,
-          "endTokenPos": 12,
-          "endFilePos": 20
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 8,
-            "startFilePos": 15,
-            "endLine": 3,
-            "endTokenPos": 8,
-            "endFilePos": 16
-          },
-          "name": "b"
-        },
-        "expr": {
-          "nodeType": "Scalar_Int",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 12,
-            "startFilePos": 20,
-            "endLine": 3,
-            "endTokenPos": 12,
-            "endFilePos": 20,
-            "rawValue": "5",
-            "kind": 10
-          },
-          "value": 5
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 4,
-        "startTokenPos": 15,
-        "startFilePos": 23,
-        "endLine": 4,
-        "endTokenPos": 52,
-        "endFilePos": 95
-      },
-      "exprs": [
+      "kind": "expression_statement",
+      "children": [
         {
-          "nodeType": "Expr_Ternary",
-          "attributes": {
-            "startLine": 4,
-            "startTokenPos": 18,
-            "startFilePos": 29,
-            "endLine": 4,
-            "endTokenPos": 47,
-            "endFilePos": 84
-          },
-          "cond": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 4,
-              "startTokenPos": 18,
-              "startFilePos": 29,
-              "endLine": 4,
-              "endTokenPos": 25,
-              "endFilePos": 45
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "a"
+                }
+              ]
             },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 4,
-                "startTokenPos": 18,
-                "startFilePos": 29,
-                "endLine": 4,
-                "endTokenPos": 18,
-                "endFilePos": 36
-              },
-              "name": "is_float"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 4,
-                  "startTokenPos": 20,
-                  "startFilePos": 38,
-                  "endLine": 4,
-                  "endTokenPos": 24,
-                  "endFilePos": 44
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_BinaryOp_Plus",
-                  "attributes": {
-                    "startLine": 4,
-                    "startTokenPos": 20,
-                    "startFilePos": 38,
-                    "endLine": 4,
-                    "endTokenPos": 24,
-                    "endFilePos": 44
-                  },
-                  "left": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 4,
-                      "startTokenPos": 20,
-                      "startFilePos": 38,
-                      "endLine": 4,
-                      "endTokenPos": 20,
-                      "endFilePos": 39
-                    },
-                    "name": "a"
-                  },
-                  "right": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 4,
-                      "startTokenPos": 24,
-                      "startFilePos": 43,
-                      "endLine": 4,
-                      "endTokenPos": 24,
-                      "endFilePos": 44
-                    },
-                    "name": "b"
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "if": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 4,
-              "startTokenPos": 29,
-              "startFilePos": 49,
-              "endLine": 4,
-              "endTokenPos": 39,
-              "endFilePos": 74
-            },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 4,
-                "startTokenPos": 29,
-                "startFilePos": 49,
-                "endLine": 4,
-                "endTokenPos": 29,
-                "endFilePos": 59
-              },
-              "name": "json_encode"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 4,
-                  "startTokenPos": 31,
-                  "startFilePos": 61,
-                  "endLine": 4,
-                  "endTokenPos": 35,
-                  "endFilePos": 67
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_BinaryOp_Plus",
-                  "attributes": {
-                    "startLine": 4,
-                    "startTokenPos": 31,
-                    "startFilePos": 61,
-                    "endLine": 4,
-                    "endTokenPos": 35,
-                    "endFilePos": 67
-                  },
-                  "left": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 4,
-                      "startTokenPos": 31,
-                      "startFilePos": 61,
-                      "endLine": 4,
-                      "endTokenPos": 31,
-                      "endFilePos": 62
-                    },
-                    "name": "a"
-                  },
-                  "right": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 4,
-                      "startTokenPos": 35,
-                      "startFilePos": 66,
-                      "endLine": 4,
-                      "endTokenPos": 35,
-                      "endFilePos": 67
-                    },
-                    "name": "b"
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              },
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 4,
-                  "startTokenPos": 38,
-                  "startFilePos": 70,
-                  "endLine": 4,
-                  "endTokenPos": 38,
-                  "endFilePos": 73
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 4,
-                    "startTokenPos": 38,
-                    "startFilePos": 70,
-                    "endLine": 4,
-                    "endTokenPos": 38,
-                    "endFilePos": 73,
-                    "rawValue": "1344",
-                    "kind": 10
-                  },
-                  "value": 1344
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "else": {
-            "nodeType": "Expr_BinaryOp_Plus",
-            "attributes": {
-              "startLine": 4,
-              "startTokenPos": 43,
-              "startFilePos": 78,
-              "endLine": 4,
-              "endTokenPos": 47,
-              "endFilePos": 84
-            },
-            "left": {
-              "nodeType": "Expr_Variable",
-              "attributes": {
-                "startLine": 4,
-                "startTokenPos": 43,
-                "startFilePos": 78,
-                "endLine": 4,
-                "endTokenPos": 43,
-                "endFilePos": 79
-              },
-              "name": "a"
-            },
-            "right": {
-              "nodeType": "Expr_Variable",
-              "attributes": {
-                "startLine": 4,
-                "startTokenPos": 47,
-                "startFilePos": 83,
-                "endLine": 4,
-                "endTokenPos": 47,
-                "endFilePos": 84
-              },
-              "name": "b"
+            {
+              "kind": "integer",
+              "text": "10"
             }
-          }
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 4,
-            "startTokenPos": 51,
-            "startFilePos": 88,
-            "endLine": 4,
-            "endTokenPos": 51,
-            "endFilePos": 94
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 4,
-              "startTokenPos": 51,
-              "startFilePos": 88,
-              "endLine": 4,
-              "endTokenPos": 51,
-              "endFilePos": 94
-            },
-            "name": "PHP_EOL"
-          }
+          ]
         }
       ]
     },
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 5,
-        "startTokenPos": 54,
-        "startFilePos": 97,
-        "endLine": 5,
-        "endTokenPos": 91,
-        "endFilePos": 169
-      },
-      "exprs": [
+      "kind": "expression_statement",
+      "children": [
         {
-          "nodeType": "Expr_Ternary",
-          "attributes": {
-            "startLine": 5,
-            "startTokenPos": 57,
-            "startFilePos": 103,
-            "endLine": 5,
-            "endTokenPos": 86,
-            "endFilePos": 158
-          },
-          "cond": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 5,
-              "startTokenPos": 57,
-              "startFilePos": 103,
-              "endLine": 5,
-              "endTokenPos": 64,
-              "endFilePos": 119
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "b"
+                }
+              ]
             },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 5,
-                "startTokenPos": 57,
-                "startFilePos": 103,
-                "endLine": 5,
-                "endTokenPos": 57,
-                "endFilePos": 110
-              },
-              "name": "is_float"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 5,
-                  "startTokenPos": 59,
-                  "startFilePos": 112,
-                  "endLine": 5,
-                  "endTokenPos": 63,
-                  "endFilePos": 118
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_BinaryOp_Minus",
-                  "attributes": {
-                    "startLine": 5,
-                    "startTokenPos": 59,
-                    "startFilePos": 112,
-                    "endLine": 5,
-                    "endTokenPos": 63,
-                    "endFilePos": 118
-                  },
-                  "left": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 5,
-                      "startTokenPos": 59,
-                      "startFilePos": 112,
-                      "endLine": 5,
-                      "endTokenPos": 59,
-                      "endFilePos": 113
-                    },
-                    "name": "a"
-                  },
-                  "right": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 5,
-                      "startTokenPos": 63,
-                      "startFilePos": 117,
-                      "endLine": 5,
-                      "endTokenPos": 63,
-                      "endFilePos": 118
-                    },
-                    "name": "b"
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "if": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 5,
-              "startTokenPos": 68,
-              "startFilePos": 123,
-              "endLine": 5,
-              "endTokenPos": 78,
-              "endFilePos": 148
-            },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 5,
-                "startTokenPos": 68,
-                "startFilePos": 123,
-                "endLine": 5,
-                "endTokenPos": 68,
-                "endFilePos": 133
-              },
-              "name": "json_encode"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 5,
-                  "startTokenPos": 70,
-                  "startFilePos": 135,
-                  "endLine": 5,
-                  "endTokenPos": 74,
-                  "endFilePos": 141
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_BinaryOp_Minus",
-                  "attributes": {
-                    "startLine": 5,
-                    "startTokenPos": 70,
-                    "startFilePos": 135,
-                    "endLine": 5,
-                    "endTokenPos": 74,
-                    "endFilePos": 141
-                  },
-                  "left": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 5,
-                      "startTokenPos": 70,
-                      "startFilePos": 135,
-                      "endLine": 5,
-                      "endTokenPos": 70,
-                      "endFilePos": 136
-                    },
-                    "name": "a"
-                  },
-                  "right": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 5,
-                      "startTokenPos": 74,
-                      "startFilePos": 140,
-                      "endLine": 5,
-                      "endTokenPos": 74,
-                      "endFilePos": 141
-                    },
-                    "name": "b"
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              },
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 5,
-                  "startTokenPos": 77,
-                  "startFilePos": 144,
-                  "endLine": 5,
-                  "endTokenPos": 77,
-                  "endFilePos": 147
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 5,
-                    "startTokenPos": 77,
-                    "startFilePos": 144,
-                    "endLine": 5,
-                    "endTokenPos": 77,
-                    "endFilePos": 147,
-                    "rawValue": "1344",
-                    "kind": 10
-                  },
-                  "value": 1344
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "else": {
-            "nodeType": "Expr_BinaryOp_Minus",
-            "attributes": {
-              "startLine": 5,
-              "startTokenPos": 82,
-              "startFilePos": 152,
-              "endLine": 5,
-              "endTokenPos": 86,
-              "endFilePos": 158
-            },
-            "left": {
-              "nodeType": "Expr_Variable",
-              "attributes": {
-                "startLine": 5,
-                "startTokenPos": 82,
-                "startFilePos": 152,
-                "endLine": 5,
-                "endTokenPos": 82,
-                "endFilePos": 153
-              },
-              "name": "a"
-            },
-            "right": {
-              "nodeType": "Expr_Variable",
-              "attributes": {
-                "startLine": 5,
-                "startTokenPos": 86,
-                "startFilePos": 157,
-                "endLine": 5,
-                "endTokenPos": 86,
-                "endFilePos": 158
-              },
-              "name": "b"
+            {
+              "kind": "integer",
+              "text": "5"
             }
-          }
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 5,
-            "startTokenPos": 90,
-            "startFilePos": 162,
-            "endLine": 5,
-            "endTokenPos": 90,
-            "endFilePos": 168
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 5,
-              "startTokenPos": 90,
-              "startFilePos": 162,
-              "endLine": 5,
-              "endTokenPos": 90,
-              "endFilePos": 168
-            },
-            "name": "PHP_EOL"
-          }
+          ]
         }
       ]
     },
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 6,
-        "startTokenPos": 93,
-        "startFilePos": 171,
-        "endLine": 6,
-        "endTokenPos": 130,
-        "endFilePos": 243
-      },
-      "exprs": [
+      "kind": "echo_statement",
+      "children": [
         {
-          "nodeType": "Expr_Ternary",
-          "attributes": {
-            "startLine": 6,
-            "startTokenPos": 96,
-            "startFilePos": 177,
-            "endLine": 6,
-            "endTokenPos": 125,
-            "endFilePos": 232
-          },
-          "cond": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 6,
-              "startTokenPos": 96,
-              "startFilePos": 177,
-              "endLine": 6,
-              "endTokenPos": 103,
-              "endFilePos": 193
-            },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 6,
-                "startTokenPos": 96,
-                "startFilePos": 177,
-                "endLine": 6,
-                "endTokenPos": 96,
-                "endFilePos": 184
-              },
-              "name": "is_float"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 6,
-                  "startTokenPos": 98,
-                  "startFilePos": 186,
-                  "endLine": 6,
-                  "endTokenPos": 102,
-                  "endFilePos": 192
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_BinaryOp_Mul",
-                  "attributes": {
-                    "startLine": 6,
-                    "startTokenPos": 98,
-                    "startFilePos": 186,
-                    "endLine": 6,
-                    "endTokenPos": 102,
-                    "endFilePos": 192
-                  },
-                  "left": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 6,
-                      "startTokenPos": 98,
-                      "startFilePos": 186,
-                      "endLine": 6,
-                      "endTokenPos": 98,
-                      "endFilePos": 187
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "parenthesized_expression",
+              "children": [
+                {
+                  "kind": "conditional_expression",
+                  "children": [
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "is_float"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "a"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "b"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     },
-                    "name": "a"
-                  },
-                  "right": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 6,
-                      "startTokenPos": 102,
-                      "startFilePos": 191,
-                      "endLine": 6,
-                      "endTokenPos": 102,
-                      "endFilePos": 192
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "json_encode"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "a"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "b"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "integer",
+                                  "text": "1344"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     },
-                    "name": "b"
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "if": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 6,
-              "startTokenPos": 107,
-              "startFilePos": 197,
-              "endLine": 6,
-              "endTokenPos": 117,
-              "endFilePos": 222
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "a"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "b"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 6,
-                "startTokenPos": 107,
-                "startFilePos": 197,
-                "endLine": 6,
-                "endTokenPos": 107,
-                "endFilePos": 207
-              },
-              "name": "json_encode"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 6,
-                  "startTokenPos": 109,
-                  "startFilePos": 209,
-                  "endLine": 6,
-                  "endTokenPos": 113,
-                  "endFilePos": 215
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_BinaryOp_Mul",
-                  "attributes": {
-                    "startLine": 6,
-                    "startTokenPos": 109,
-                    "startFilePos": 209,
-                    "endLine": 6,
-                    "endTokenPos": 113,
-                    "endFilePos": 215
-                  },
-                  "left": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 6,
-                      "startTokenPos": 109,
-                      "startFilePos": 209,
-                      "endLine": 6,
-                      "endTokenPos": 109,
-                      "endFilePos": 210
-                    },
-                    "name": "a"
-                  },
-                  "right": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 6,
-                      "startTokenPos": 113,
-                      "startFilePos": 214,
-                      "endLine": 6,
-                      "endTokenPos": 113,
-                      "endFilePos": 215
-                    },
-                    "name": "b"
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              },
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 6,
-                  "startTokenPos": 116,
-                  "startFilePos": 218,
-                  "endLine": 6,
-                  "endTokenPos": 116,
-                  "endFilePos": 221
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 6,
-                    "startTokenPos": 116,
-                    "startFilePos": 218,
-                    "endLine": 6,
-                    "endTokenPos": 116,
-                    "endFilePos": 221,
-                    "rawValue": "1344",
-                    "kind": 10
-                  },
-                  "value": 1344
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "else": {
-            "nodeType": "Expr_BinaryOp_Mul",
-            "attributes": {
-              "startLine": 6,
-              "startTokenPos": 121,
-              "startFilePos": 226,
-              "endLine": 6,
-              "endTokenPos": 125,
-              "endFilePos": 232
-            },
-            "left": {
-              "nodeType": "Expr_Variable",
-              "attributes": {
-                "startLine": 6,
-                "startTokenPos": 121,
-                "startFilePos": 226,
-                "endLine": 6,
-                "endTokenPos": 121,
-                "endFilePos": 227
-              },
-              "name": "a"
-            },
-            "right": {
-              "nodeType": "Expr_Variable",
-              "attributes": {
-                "startLine": 6,
-                "startTokenPos": 125,
-                "startFilePos": 231,
-                "endLine": 6,
-                "endTokenPos": 125,
-                "endFilePos": 232
-              },
-              "name": "b"
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
             }
-          }
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 6,
-            "startTokenPos": 129,
-            "startFilePos": 236,
-            "endLine": 6,
-            "endTokenPos": 129,
-            "endFilePos": 242
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 6,
-              "startTokenPos": 129,
-              "startFilePos": 236,
-              "endLine": 6,
-              "endTokenPos": 129,
-              "endFilePos": 242
-            },
-            "name": "PHP_EOL"
-          }
+          ]
         }
       ]
     },
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 7,
-        "startTokenPos": 132,
-        "startFilePos": 245,
-        "endLine": 7,
-        "endTokenPos": 169,
-        "endFilePos": 317
-      },
-      "exprs": [
+      "kind": "echo_statement",
+      "children": [
         {
-          "nodeType": "Expr_Ternary",
-          "attributes": {
-            "startLine": 7,
-            "startTokenPos": 135,
-            "startFilePos": 251,
-            "endLine": 7,
-            "endTokenPos": 164,
-            "endFilePos": 306
-          },
-          "cond": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 7,
-              "startTokenPos": 135,
-              "startFilePos": 251,
-              "endLine": 7,
-              "endTokenPos": 142,
-              "endFilePos": 267
-            },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 7,
-                "startTokenPos": 135,
-                "startFilePos": 251,
-                "endLine": 7,
-                "endTokenPos": 135,
-                "endFilePos": 258
-              },
-              "name": "is_float"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 7,
-                  "startTokenPos": 137,
-                  "startFilePos": 260,
-                  "endLine": 7,
-                  "endTokenPos": 141,
-                  "endFilePos": 266
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_BinaryOp_Div",
-                  "attributes": {
-                    "startLine": 7,
-                    "startTokenPos": 137,
-                    "startFilePos": 260,
-                    "endLine": 7,
-                    "endTokenPos": 141,
-                    "endFilePos": 266
-                  },
-                  "left": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 7,
-                      "startTokenPos": 137,
-                      "startFilePos": 260,
-                      "endLine": 7,
-                      "endTokenPos": 137,
-                      "endFilePos": 261
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "parenthesized_expression",
+              "children": [
+                {
+                  "kind": "conditional_expression",
+                  "children": [
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "is_float"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "a"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "b"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     },
-                    "name": "a"
-                  },
-                  "right": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 7,
-                      "startTokenPos": 141,
-                      "startFilePos": 265,
-                      "endLine": 7,
-                      "endTokenPos": 141,
-                      "endFilePos": 266
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "json_encode"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "a"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "b"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "integer",
+                                  "text": "1344"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     },
-                    "name": "b"
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "if": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 7,
-              "startTokenPos": 146,
-              "startFilePos": 271,
-              "endLine": 7,
-              "endTokenPos": 156,
-              "endFilePos": 296
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "a"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "b"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 7,
-                "startTokenPos": 146,
-                "startFilePos": 271,
-                "endLine": 7,
-                "endTokenPos": 146,
-                "endFilePos": 281
-              },
-              "name": "json_encode"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 7,
-                  "startTokenPos": 148,
-                  "startFilePos": 283,
-                  "endLine": 7,
-                  "endTokenPos": 152,
-                  "endFilePos": 289
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_BinaryOp_Div",
-                  "attributes": {
-                    "startLine": 7,
-                    "startTokenPos": 148,
-                    "startFilePos": 283,
-                    "endLine": 7,
-                    "endTokenPos": 152,
-                    "endFilePos": 289
-                  },
-                  "left": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 7,
-                      "startTokenPos": 148,
-                      "startFilePos": 283,
-                      "endLine": 7,
-                      "endTokenPos": 148,
-                      "endFilePos": 284
-                    },
-                    "name": "a"
-                  },
-                  "right": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 7,
-                      "startTokenPos": 152,
-                      "startFilePos": 288,
-                      "endLine": 7,
-                      "endTokenPos": 152,
-                      "endFilePos": 289
-                    },
-                    "name": "b"
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              },
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 7,
-                  "startTokenPos": 155,
-                  "startFilePos": 292,
-                  "endLine": 7,
-                  "endTokenPos": 155,
-                  "endFilePos": 295
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 7,
-                    "startTokenPos": 155,
-                    "startFilePos": 292,
-                    "endLine": 7,
-                    "endTokenPos": 155,
-                    "endFilePos": 295,
-                    "rawValue": "1344",
-                    "kind": 10
-                  },
-                  "value": 1344
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "else": {
-            "nodeType": "Expr_BinaryOp_Div",
-            "attributes": {
-              "startLine": 7,
-              "startTokenPos": 160,
-              "startFilePos": 300,
-              "endLine": 7,
-              "endTokenPos": 164,
-              "endFilePos": 306
-            },
-            "left": {
-              "nodeType": "Expr_Variable",
-              "attributes": {
-                "startLine": 7,
-                "startTokenPos": 160,
-                "startFilePos": 300,
-                "endLine": 7,
-                "endTokenPos": 160,
-                "endFilePos": 301
-              },
-              "name": "a"
-            },
-            "right": {
-              "nodeType": "Expr_Variable",
-              "attributes": {
-                "startLine": 7,
-                "startTokenPos": 164,
-                "startFilePos": 305,
-                "endLine": 7,
-                "endTokenPos": 164,
-                "endFilePos": 306
-              },
-              "name": "b"
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
             }
-          }
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 7,
-            "startTokenPos": 168,
-            "startFilePos": 310,
-            "endLine": 7,
-            "endTokenPos": 168,
-            "endFilePos": 316
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 7,
-              "startTokenPos": 168,
-              "startFilePos": 310,
-              "endLine": 7,
-              "endTokenPos": 168,
-              "endFilePos": 316
-            },
-            "name": "PHP_EOL"
-          }
+          ]
         }
       ]
     },
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 8,
-        "startTokenPos": 171,
-        "startFilePos": 319,
-        "endLine": 8,
-        "endTokenPos": 208,
-        "endFilePos": 391
-      },
-      "exprs": [
+      "kind": "echo_statement",
+      "children": [
         {
-          "nodeType": "Expr_Ternary",
-          "attributes": {
-            "startLine": 8,
-            "startTokenPos": 174,
-            "startFilePos": 325,
-            "endLine": 8,
-            "endTokenPos": 203,
-            "endFilePos": 380
-          },
-          "cond": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 8,
-              "startTokenPos": 174,
-              "startFilePos": 325,
-              "endLine": 8,
-              "endTokenPos": 181,
-              "endFilePos": 341
-            },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 8,
-                "startTokenPos": 174,
-                "startFilePos": 325,
-                "endLine": 8,
-                "endTokenPos": 174,
-                "endFilePos": 332
-              },
-              "name": "is_float"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 8,
-                  "startTokenPos": 176,
-                  "startFilePos": 334,
-                  "endLine": 8,
-                  "endTokenPos": 180,
-                  "endFilePos": 340
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_BinaryOp_Mod",
-                  "attributes": {
-                    "startLine": 8,
-                    "startTokenPos": 176,
-                    "startFilePos": 334,
-                    "endLine": 8,
-                    "endTokenPos": 180,
-                    "endFilePos": 340
-                  },
-                  "left": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 8,
-                      "startTokenPos": 176,
-                      "startFilePos": 334,
-                      "endLine": 8,
-                      "endTokenPos": 176,
-                      "endFilePos": 335
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "parenthesized_expression",
+              "children": [
+                {
+                  "kind": "conditional_expression",
+                  "children": [
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "is_float"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "a"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "b"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     },
-                    "name": "a"
-                  },
-                  "right": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 8,
-                      "startTokenPos": 180,
-                      "startFilePos": 339,
-                      "endLine": 8,
-                      "endTokenPos": 180,
-                      "endFilePos": 340
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "json_encode"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "a"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "b"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "integer",
+                                  "text": "1344"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     },
-                    "name": "b"
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "if": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 8,
-              "startTokenPos": 185,
-              "startFilePos": 345,
-              "endLine": 8,
-              "endTokenPos": 195,
-              "endFilePos": 370
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "a"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "b"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 8,
-                "startTokenPos": 185,
-                "startFilePos": 345,
-                "endLine": 8,
-                "endTokenPos": 185,
-                "endFilePos": 355
-              },
-              "name": "json_encode"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 8,
-                  "startTokenPos": 187,
-                  "startFilePos": 357,
-                  "endLine": 8,
-                  "endTokenPos": 191,
-                  "endFilePos": 363
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_BinaryOp_Mod",
-                  "attributes": {
-                    "startLine": 8,
-                    "startTokenPos": 187,
-                    "startFilePos": 357,
-                    "endLine": 8,
-                    "endTokenPos": 191,
-                    "endFilePos": 363
-                  },
-                  "left": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 8,
-                      "startTokenPos": 187,
-                      "startFilePos": 357,
-                      "endLine": 8,
-                      "endTokenPos": 187,
-                      "endFilePos": 358
-                    },
-                    "name": "a"
-                  },
-                  "right": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 8,
-                      "startTokenPos": 191,
-                      "startFilePos": 362,
-                      "endLine": 8,
-                      "endTokenPos": 191,
-                      "endFilePos": 363
-                    },
-                    "name": "b"
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              },
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 8,
-                  "startTokenPos": 194,
-                  "startFilePos": 366,
-                  "endLine": 8,
-                  "endTokenPos": 194,
-                  "endFilePos": 369
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 8,
-                    "startTokenPos": 194,
-                    "startFilePos": 366,
-                    "endLine": 8,
-                    "endTokenPos": 194,
-                    "endFilePos": 369,
-                    "rawValue": "1344",
-                    "kind": 10
-                  },
-                  "value": 1344
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "else": {
-            "nodeType": "Expr_BinaryOp_Mod",
-            "attributes": {
-              "startLine": 8,
-              "startTokenPos": 199,
-              "startFilePos": 374,
-              "endLine": 8,
-              "endTokenPos": 203,
-              "endFilePos": 380
-            },
-            "left": {
-              "nodeType": "Expr_Variable",
-              "attributes": {
-                "startLine": 8,
-                "startTokenPos": 199,
-                "startFilePos": 374,
-                "endLine": 8,
-                "endTokenPos": 199,
-                "endFilePos": 375
-              },
-              "name": "a"
-            },
-            "right": {
-              "nodeType": "Expr_Variable",
-              "attributes": {
-                "startLine": 8,
-                "startTokenPos": 203,
-                "startFilePos": 379,
-                "endLine": 8,
-                "endTokenPos": 203,
-                "endFilePos": 380
-              },
-              "name": "b"
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
             }
-          }
-        },
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "echo_statement",
+      "children": [
         {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 8,
-            "startTokenPos": 207,
-            "startFilePos": 384,
-            "endLine": 8,
-            "endTokenPos": 207,
-            "endFilePos": 390
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 8,
-              "startTokenPos": 207,
-              "startFilePos": 384,
-              "endLine": 8,
-              "endTokenPos": 207,
-              "endFilePos": 390
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "parenthesized_expression",
+              "children": [
+                {
+                  "kind": "conditional_expression",
+                  "children": [
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "is_float"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "a"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "b"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "json_encode"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "a"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "b"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "integer",
+                                  "text": "1344"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "a"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "b"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             },
-            "name": "PHP_EOL"
-          }
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "echo_statement",
+      "children": [
+        {
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "parenthesized_expression",
+              "children": [
+                {
+                  "kind": "conditional_expression",
+                  "children": [
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "is_float"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "a"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "b"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "json_encode"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "a"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "b"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "integer",
+                                  "text": "1344"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "a"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "b"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
+            }
+          ]
         }
       ]
     }

--- a/tests/json-ast/x/php/binary_precedence.php.json
+++ b/tests/json-ast/x/php/binary_precedence.php.json
@@ -1,1382 +1,580 @@
 {
-  "root": [
+  "statements": [
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 2,
-        "startTokenPos": 1,
-        "startFilePos": 6,
-        "endLine": 2,
-        "endTokenPos": 50,
-        "endFilePos": 84
-      },
-      "exprs": [
+      "kind": "echo_statement",
+      "children": [
         {
-          "nodeType": "Expr_Ternary",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 4,
-            "startFilePos": 12,
-            "endLine": 2,
-            "endTokenPos": 45,
-            "endFilePos": 73
-          },
-          "cond": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 4,
-              "startFilePos": 12,
-              "endLine": 2,
-              "endTokenPos": 15,
-              "endFilePos": 30
-            },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 4,
-                "startFilePos": 12,
-                "endLine": 2,
-                "endTokenPos": 4,
-                "endFilePos": 19
-              },
-              "name": "is_float"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 6,
-                  "startFilePos": 21,
-                  "endLine": 2,
-                  "endTokenPos": 14,
-                  "endFilePos": 29
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_BinaryOp_Plus",
-                  "attributes": {
-                    "startLine": 2,
-                    "startTokenPos": 6,
-                    "startFilePos": 21,
-                    "endLine": 2,
-                    "endTokenPos": 14,
-                    "endFilePos": 29
-                  },
-                  "left": {
-                    "nodeType": "Scalar_Int",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 6,
-                      "startFilePos": 21,
-                      "endLine": 2,
-                      "endTokenPos": 6,
-                      "endFilePos": 21,
-                      "rawValue": "1",
-                      "kind": 10
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "parenthesized_expression",
+              "children": [
+                {
+                  "kind": "conditional_expression",
+                  "children": [
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "is_float"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "integer",
+                                      "text": "1"
+                                    },
+                                    {
+                                      "kind": "binary_expression",
+                                      "children": [
+                                        {
+                                          "kind": "integer",
+                                          "text": "2"
+                                        },
+                                        {
+                                          "kind": "integer",
+                                          "text": "3"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     },
-                    "value": 1
-                  },
-                  "right": {
-                    "nodeType": "Expr_BinaryOp_Mul",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 10,
-                      "startFilePos": 25,
-                      "endLine": 2,
-                      "endTokenPos": 14,
-                      "endFilePos": 29
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "json_encode"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "integer",
+                                      "text": "1"
+                                    },
+                                    {
+                                      "kind": "binary_expression",
+                                      "children": [
+                                        {
+                                          "kind": "integer",
+                                          "text": "2"
+                                        },
+                                        {
+                                          "kind": "integer",
+                                          "text": "3"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "integer",
+                                  "text": "1344"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     },
-                    "left": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 10,
-                        "startFilePos": 25,
-                        "endLine": 2,
-                        "endTokenPos": 10,
-                        "endFilePos": 25,
-                        "rawValue": "2",
-                        "kind": 10
-                      },
-                      "value": 2
-                    },
-                    "right": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 14,
-                        "startFilePos": 29,
-                        "endLine": 2,
-                        "endTokenPos": 14,
-                        "endFilePos": 29,
-                        "rawValue": "3",
-                        "kind": 10
-                      },
-                      "value": 3
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "integer",
+                          "text": "1"
+                        },
+                        {
+                          "kind": "binary_expression",
+                          "children": [
+                            {
+                              "kind": "integer",
+                              "text": "2"
+                            },
+                            {
+                              "kind": "integer",
+                              "text": "3"
+                            }
+                          ]
+                        }
+                      ]
                     }
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "if": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 19,
-              "startFilePos": 34,
-              "endLine": 2,
-              "endTokenPos": 33,
-              "endFilePos": 61
+                  ]
+                }
+              ]
             },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 19,
-                "startFilePos": 34,
-                "endLine": 2,
-                "endTokenPos": 19,
-                "endFilePos": 44
-              },
-              "name": "json_encode"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 21,
-                  "startFilePos": 46,
-                  "endLine": 2,
-                  "endTokenPos": 29,
-                  "endFilePos": 54
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_BinaryOp_Plus",
-                  "attributes": {
-                    "startLine": 2,
-                    "startTokenPos": 21,
-                    "startFilePos": 46,
-                    "endLine": 2,
-                    "endTokenPos": 29,
-                    "endFilePos": 54
-                  },
-                  "left": {
-                    "nodeType": "Scalar_Int",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 21,
-                      "startFilePos": 46,
-                      "endLine": 2,
-                      "endTokenPos": 21,
-                      "endFilePos": 46,
-                      "rawValue": "1",
-                      "kind": 10
-                    },
-                    "value": 1
-                  },
-                  "right": {
-                    "nodeType": "Expr_BinaryOp_Mul",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 25,
-                      "startFilePos": 50,
-                      "endLine": 2,
-                      "endTokenPos": 29,
-                      "endFilePos": 54
-                    },
-                    "left": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 25,
-                        "startFilePos": 50,
-                        "endLine": 2,
-                        "endTokenPos": 25,
-                        "endFilePos": 50,
-                        "rawValue": "2",
-                        "kind": 10
-                      },
-                      "value": 2
-                    },
-                    "right": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 29,
-                        "startFilePos": 54,
-                        "endLine": 2,
-                        "endTokenPos": 29,
-                        "endFilePos": 54,
-                        "rawValue": "3",
-                        "kind": 10
-                      },
-                      "value": 3
-                    }
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              },
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 32,
-                  "startFilePos": 57,
-                  "endLine": 2,
-                  "endTokenPos": 32,
-                  "endFilePos": 60
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 2,
-                    "startTokenPos": 32,
-                    "startFilePos": 57,
-                    "endLine": 2,
-                    "endTokenPos": 32,
-                    "endFilePos": 60,
-                    "rawValue": "1344",
-                    "kind": 10
-                  },
-                  "value": 1344
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "else": {
-            "nodeType": "Expr_BinaryOp_Plus",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 37,
-              "startFilePos": 65,
-              "endLine": 2,
-              "endTokenPos": 45,
-              "endFilePos": 73
-            },
-            "left": {
-              "nodeType": "Scalar_Int",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 37,
-                "startFilePos": 65,
-                "endLine": 2,
-                "endTokenPos": 37,
-                "endFilePos": 65,
-                "rawValue": "1",
-                "kind": 10
-              },
-              "value": 1
-            },
-            "right": {
-              "nodeType": "Expr_BinaryOp_Mul",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 41,
-                "startFilePos": 69,
-                "endLine": 2,
-                "endTokenPos": 45,
-                "endFilePos": 73
-              },
-              "left": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 41,
-                  "startFilePos": 69,
-                  "endLine": 2,
-                  "endTokenPos": 41,
-                  "endFilePos": 69,
-                  "rawValue": "2",
-                  "kind": 10
-                },
-                "value": 2
-              },
-              "right": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 45,
-                  "startFilePos": 73,
-                  "endLine": 2,
-                  "endTokenPos": 45,
-                  "endFilePos": 73,
-                  "rawValue": "3",
-                  "kind": 10
-                },
-                "value": 3
-              }
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
             }
-          }
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 49,
-            "startFilePos": 77,
-            "endLine": 2,
-            "endTokenPos": 49,
-            "endFilePos": 83
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 49,
-              "startFilePos": 77,
-              "endLine": 2,
-              "endTokenPos": 49,
-              "endFilePos": 83
-            },
-            "name": "PHP_EOL"
-          }
+          ]
         }
       ]
     },
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 3,
-        "startTokenPos": 52,
-        "startFilePos": 86,
-        "endLine": 3,
-        "endTokenPos": 107,
-        "endFilePos": 170
-      },
-      "exprs": [
+      "kind": "echo_statement",
+      "children": [
         {
-          "nodeType": "Expr_Ternary",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 55,
-            "startFilePos": 92,
-            "endLine": 3,
-            "endTokenPos": 102,
-            "endFilePos": 159
-          },
-          "cond": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 3,
-              "startTokenPos": 55,
-              "startFilePos": 92,
-              "endLine": 3,
-              "endTokenPos": 68,
-              "endFilePos": 112
-            },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 55,
-                "startFilePos": 92,
-                "endLine": 3,
-                "endTokenPos": 55,
-                "endFilePos": 99
-              },
-              "name": "is_float"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 57,
-                  "startFilePos": 101,
-                  "endLine": 3,
-                  "endTokenPos": 67,
-                  "endFilePos": 111
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_BinaryOp_Mul",
-                  "attributes": {
-                    "startLine": 3,
-                    "startTokenPos": 57,
-                    "startFilePos": 101,
-                    "endLine": 3,
-                    "endTokenPos": 67,
-                    "endFilePos": 111
-                  },
-                  "left": {
-                    "nodeType": "Expr_BinaryOp_Plus",
-                    "attributes": {
-                      "startLine": 3,
-                      "startTokenPos": 58,
-                      "startFilePos": 102,
-                      "endLine": 3,
-                      "endTokenPos": 62,
-                      "endFilePos": 106
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "parenthesized_expression",
+              "children": [
+                {
+                  "kind": "conditional_expression",
+                  "children": [
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "is_float"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "parenthesized_expression",
+                                      "children": [
+                                        {
+                                          "kind": "binary_expression",
+                                          "children": [
+                                            {
+                                              "kind": "integer",
+                                              "text": "1"
+                                            },
+                                            {
+                                              "kind": "integer",
+                                              "text": "2"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "integer",
+                                      "text": "3"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     },
-                    "left": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 3,
-                        "startTokenPos": 58,
-                        "startFilePos": 102,
-                        "endLine": 3,
-                        "endTokenPos": 58,
-                        "endFilePos": 102,
-                        "rawValue": "1",
-                        "kind": 10
-                      },
-                      "value": 1
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "json_encode"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "parenthesized_expression",
+                                      "children": [
+                                        {
+                                          "kind": "binary_expression",
+                                          "children": [
+                                            {
+                                              "kind": "integer",
+                                              "text": "1"
+                                            },
+                                            {
+                                              "kind": "integer",
+                                              "text": "2"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "integer",
+                                      "text": "3"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "integer",
+                                  "text": "1344"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     },
-                    "right": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 3,
-                        "startTokenPos": 62,
-                        "startFilePos": 106,
-                        "endLine": 3,
-                        "endTokenPos": 62,
-                        "endFilePos": 106,
-                        "rawValue": "2",
-                        "kind": 10
-                      },
-                      "value": 2
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "parenthesized_expression",
+                          "children": [
+                            {
+                              "kind": "binary_expression",
+                              "children": [
+                                {
+                                  "kind": "integer",
+                                  "text": "1"
+                                },
+                                {
+                                  "kind": "integer",
+                                  "text": "2"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "integer",
+                          "text": "3"
+                        }
+                      ]
                     }
-                  },
-                  "right": {
-                    "nodeType": "Scalar_Int",
-                    "attributes": {
-                      "startLine": 3,
-                      "startTokenPos": 67,
-                      "startFilePos": 111,
-                      "endLine": 3,
-                      "endTokenPos": 67,
-                      "endFilePos": 111,
-                      "rawValue": "3",
-                      "kind": 10
-                    },
-                    "value": 3
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "if": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 3,
-              "startTokenPos": 72,
-              "startFilePos": 116,
-              "endLine": 3,
-              "endTokenPos": 88,
-              "endFilePos": 145
+                  ]
+                }
+              ]
             },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 72,
-                "startFilePos": 116,
-                "endLine": 3,
-                "endTokenPos": 72,
-                "endFilePos": 126
-              },
-              "name": "json_encode"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 74,
-                  "startFilePos": 128,
-                  "endLine": 3,
-                  "endTokenPos": 84,
-                  "endFilePos": 138
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_BinaryOp_Mul",
-                  "attributes": {
-                    "startLine": 3,
-                    "startTokenPos": 74,
-                    "startFilePos": 128,
-                    "endLine": 3,
-                    "endTokenPos": 84,
-                    "endFilePos": 138
-                  },
-                  "left": {
-                    "nodeType": "Expr_BinaryOp_Plus",
-                    "attributes": {
-                      "startLine": 3,
-                      "startTokenPos": 75,
-                      "startFilePos": 129,
-                      "endLine": 3,
-                      "endTokenPos": 79,
-                      "endFilePos": 133
-                    },
-                    "left": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 3,
-                        "startTokenPos": 75,
-                        "startFilePos": 129,
-                        "endLine": 3,
-                        "endTokenPos": 75,
-                        "endFilePos": 129,
-                        "rawValue": "1",
-                        "kind": 10
-                      },
-                      "value": 1
-                    },
-                    "right": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 3,
-                        "startTokenPos": 79,
-                        "startFilePos": 133,
-                        "endLine": 3,
-                        "endTokenPos": 79,
-                        "endFilePos": 133,
-                        "rawValue": "2",
-                        "kind": 10
-                      },
-                      "value": 2
-                    }
-                  },
-                  "right": {
-                    "nodeType": "Scalar_Int",
-                    "attributes": {
-                      "startLine": 3,
-                      "startTokenPos": 84,
-                      "startFilePos": 138,
-                      "endLine": 3,
-                      "endTokenPos": 84,
-                      "endFilePos": 138,
-                      "rawValue": "3",
-                      "kind": 10
-                    },
-                    "value": 3
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              },
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 87,
-                  "startFilePos": 141,
-                  "endLine": 3,
-                  "endTokenPos": 87,
-                  "endFilePos": 144
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 3,
-                    "startTokenPos": 87,
-                    "startFilePos": 141,
-                    "endLine": 3,
-                    "endTokenPos": 87,
-                    "endFilePos": 144,
-                    "rawValue": "1344",
-                    "kind": 10
-                  },
-                  "value": 1344
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "else": {
-            "nodeType": "Expr_BinaryOp_Mul",
-            "attributes": {
-              "startLine": 3,
-              "startTokenPos": 92,
-              "startFilePos": 149,
-              "endLine": 3,
-              "endTokenPos": 102,
-              "endFilePos": 159
-            },
-            "left": {
-              "nodeType": "Expr_BinaryOp_Plus",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 93,
-                "startFilePos": 150,
-                "endLine": 3,
-                "endTokenPos": 97,
-                "endFilePos": 154
-              },
-              "left": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 93,
-                  "startFilePos": 150,
-                  "endLine": 3,
-                  "endTokenPos": 93,
-                  "endFilePos": 150,
-                  "rawValue": "1",
-                  "kind": 10
-                },
-                "value": 1
-              },
-              "right": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 97,
-                  "startFilePos": 154,
-                  "endLine": 3,
-                  "endTokenPos": 97,
-                  "endFilePos": 154,
-                  "rawValue": "2",
-                  "kind": 10
-                },
-                "value": 2
-              }
-            },
-            "right": {
-              "nodeType": "Scalar_Int",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 102,
-                "startFilePos": 159,
-                "endLine": 3,
-                "endTokenPos": 102,
-                "endFilePos": 159,
-                "rawValue": "3",
-                "kind": 10
-              },
-              "value": 3
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
             }
-          }
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 106,
-            "startFilePos": 163,
-            "endLine": 3,
-            "endTokenPos": 106,
-            "endFilePos": 169
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 3,
-              "startTokenPos": 106,
-              "startFilePos": 163,
-              "endLine": 3,
-              "endTokenPos": 106,
-              "endFilePos": 169
-            },
-            "name": "PHP_EOL"
-          }
+          ]
         }
       ]
     },
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 4,
-        "startTokenPos": 109,
-        "startFilePos": 172,
-        "endLine": 4,
-        "endTokenPos": 158,
-        "endFilePos": 250
-      },
-      "exprs": [
+      "kind": "echo_statement",
+      "children": [
         {
-          "nodeType": "Expr_Ternary",
-          "attributes": {
-            "startLine": 4,
-            "startTokenPos": 112,
-            "startFilePos": 178,
-            "endLine": 4,
-            "endTokenPos": 153,
-            "endFilePos": 239
-          },
-          "cond": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 4,
-              "startTokenPos": 112,
-              "startFilePos": 178,
-              "endLine": 4,
-              "endTokenPos": 123,
-              "endFilePos": 196
-            },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 4,
-                "startTokenPos": 112,
-                "startFilePos": 178,
-                "endLine": 4,
-                "endTokenPos": 112,
-                "endFilePos": 185
-              },
-              "name": "is_float"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 4,
-                  "startTokenPos": 114,
-                  "startFilePos": 187,
-                  "endLine": 4,
-                  "endTokenPos": 122,
-                  "endFilePos": 195
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_BinaryOp_Plus",
-                  "attributes": {
-                    "startLine": 4,
-                    "startTokenPos": 114,
-                    "startFilePos": 187,
-                    "endLine": 4,
-                    "endTokenPos": 122,
-                    "endFilePos": 195
-                  },
-                  "left": {
-                    "nodeType": "Expr_BinaryOp_Mul",
-                    "attributes": {
-                      "startLine": 4,
-                      "startTokenPos": 114,
-                      "startFilePos": 187,
-                      "endLine": 4,
-                      "endTokenPos": 118,
-                      "endFilePos": 191
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "parenthesized_expression",
+              "children": [
+                {
+                  "kind": "conditional_expression",
+                  "children": [
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "is_float"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "binary_expression",
+                                      "children": [
+                                        {
+                                          "kind": "integer",
+                                          "text": "2"
+                                        },
+                                        {
+                                          "kind": "integer",
+                                          "text": "3"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "integer",
+                                      "text": "1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     },
-                    "left": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 4,
-                        "startTokenPos": 114,
-                        "startFilePos": 187,
-                        "endLine": 4,
-                        "endTokenPos": 114,
-                        "endFilePos": 187,
-                        "rawValue": "2",
-                        "kind": 10
-                      },
-                      "value": 2
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "json_encode"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "binary_expression",
+                                      "children": [
+                                        {
+                                          "kind": "integer",
+                                          "text": "2"
+                                        },
+                                        {
+                                          "kind": "integer",
+                                          "text": "3"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "integer",
+                                      "text": "1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "integer",
+                                  "text": "1344"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     },
-                    "right": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 4,
-                        "startTokenPos": 118,
-                        "startFilePos": 191,
-                        "endLine": 4,
-                        "endTokenPos": 118,
-                        "endFilePos": 191,
-                        "rawValue": "3",
-                        "kind": 10
-                      },
-                      "value": 3
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "binary_expression",
+                          "children": [
+                            {
+                              "kind": "integer",
+                              "text": "2"
+                            },
+                            {
+                              "kind": "integer",
+                              "text": "3"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "integer",
+                          "text": "1"
+                        }
+                      ]
                     }
-                  },
-                  "right": {
-                    "nodeType": "Scalar_Int",
-                    "attributes": {
-                      "startLine": 4,
-                      "startTokenPos": 122,
-                      "startFilePos": 195,
-                      "endLine": 4,
-                      "endTokenPos": 122,
-                      "endFilePos": 195,
-                      "rawValue": "1",
-                      "kind": 10
-                    },
-                    "value": 1
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "if": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 4,
-              "startTokenPos": 127,
-              "startFilePos": 200,
-              "endLine": 4,
-              "endTokenPos": 141,
-              "endFilePos": 227
+                  ]
+                }
+              ]
             },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 4,
-                "startTokenPos": 127,
-                "startFilePos": 200,
-                "endLine": 4,
-                "endTokenPos": 127,
-                "endFilePos": 210
-              },
-              "name": "json_encode"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 4,
-                  "startTokenPos": 129,
-                  "startFilePos": 212,
-                  "endLine": 4,
-                  "endTokenPos": 137,
-                  "endFilePos": 220
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_BinaryOp_Plus",
-                  "attributes": {
-                    "startLine": 4,
-                    "startTokenPos": 129,
-                    "startFilePos": 212,
-                    "endLine": 4,
-                    "endTokenPos": 137,
-                    "endFilePos": 220
-                  },
-                  "left": {
-                    "nodeType": "Expr_BinaryOp_Mul",
-                    "attributes": {
-                      "startLine": 4,
-                      "startTokenPos": 129,
-                      "startFilePos": 212,
-                      "endLine": 4,
-                      "endTokenPos": 133,
-                      "endFilePos": 216
-                    },
-                    "left": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 4,
-                        "startTokenPos": 129,
-                        "startFilePos": 212,
-                        "endLine": 4,
-                        "endTokenPos": 129,
-                        "endFilePos": 212,
-                        "rawValue": "2",
-                        "kind": 10
-                      },
-                      "value": 2
-                    },
-                    "right": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 4,
-                        "startTokenPos": 133,
-                        "startFilePos": 216,
-                        "endLine": 4,
-                        "endTokenPos": 133,
-                        "endFilePos": 216,
-                        "rawValue": "3",
-                        "kind": 10
-                      },
-                      "value": 3
-                    }
-                  },
-                  "right": {
-                    "nodeType": "Scalar_Int",
-                    "attributes": {
-                      "startLine": 4,
-                      "startTokenPos": 137,
-                      "startFilePos": 220,
-                      "endLine": 4,
-                      "endTokenPos": 137,
-                      "endFilePos": 220,
-                      "rawValue": "1",
-                      "kind": 10
-                    },
-                    "value": 1
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              },
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 4,
-                  "startTokenPos": 140,
-                  "startFilePos": 223,
-                  "endLine": 4,
-                  "endTokenPos": 140,
-                  "endFilePos": 226
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 4,
-                    "startTokenPos": 140,
-                    "startFilePos": 223,
-                    "endLine": 4,
-                    "endTokenPos": 140,
-                    "endFilePos": 226,
-                    "rawValue": "1344",
-                    "kind": 10
-                  },
-                  "value": 1344
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "else": {
-            "nodeType": "Expr_BinaryOp_Plus",
-            "attributes": {
-              "startLine": 4,
-              "startTokenPos": 145,
-              "startFilePos": 231,
-              "endLine": 4,
-              "endTokenPos": 153,
-              "endFilePos": 239
-            },
-            "left": {
-              "nodeType": "Expr_BinaryOp_Mul",
-              "attributes": {
-                "startLine": 4,
-                "startTokenPos": 145,
-                "startFilePos": 231,
-                "endLine": 4,
-                "endTokenPos": 149,
-                "endFilePos": 235
-              },
-              "left": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 4,
-                  "startTokenPos": 145,
-                  "startFilePos": 231,
-                  "endLine": 4,
-                  "endTokenPos": 145,
-                  "endFilePos": 231,
-                  "rawValue": "2",
-                  "kind": 10
-                },
-                "value": 2
-              },
-              "right": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 4,
-                  "startTokenPos": 149,
-                  "startFilePos": 235,
-                  "endLine": 4,
-                  "endTokenPos": 149,
-                  "endFilePos": 235,
-                  "rawValue": "3",
-                  "kind": 10
-                },
-                "value": 3
-              }
-            },
-            "right": {
-              "nodeType": "Scalar_Int",
-              "attributes": {
-                "startLine": 4,
-                "startTokenPos": 153,
-                "startFilePos": 239,
-                "endLine": 4,
-                "endTokenPos": 153,
-                "endFilePos": 239,
-                "rawValue": "1",
-                "kind": 10
-              },
-              "value": 1
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
             }
-          }
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 4,
-            "startTokenPos": 157,
-            "startFilePos": 243,
-            "endLine": 4,
-            "endTokenPos": 157,
-            "endFilePos": 249
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 4,
-              "startTokenPos": 157,
-              "startFilePos": 243,
-              "endLine": 4,
-              "endTokenPos": 157,
-              "endFilePos": 249
-            },
-            "name": "PHP_EOL"
-          }
+          ]
         }
       ]
     },
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 5,
-        "startTokenPos": 160,
-        "startFilePos": 252,
-        "endLine": 5,
-        "endTokenPos": 215,
-        "endFilePos": 336
-      },
-      "exprs": [
+      "kind": "echo_statement",
+      "children": [
         {
-          "nodeType": "Expr_Ternary",
-          "attributes": {
-            "startLine": 5,
-            "startTokenPos": 163,
-            "startFilePos": 258,
-            "endLine": 5,
-            "endTokenPos": 210,
-            "endFilePos": 325
-          },
-          "cond": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 5,
-              "startTokenPos": 163,
-              "startFilePos": 258,
-              "endLine": 5,
-              "endTokenPos": 176,
-              "endFilePos": 278
-            },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 5,
-                "startTokenPos": 163,
-                "startFilePos": 258,
-                "endLine": 5,
-                "endTokenPos": 163,
-                "endFilePos": 265
-              },
-              "name": "is_float"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 5,
-                  "startTokenPos": 165,
-                  "startFilePos": 267,
-                  "endLine": 5,
-                  "endTokenPos": 175,
-                  "endFilePos": 277
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_BinaryOp_Mul",
-                  "attributes": {
-                    "startLine": 5,
-                    "startTokenPos": 165,
-                    "startFilePos": 267,
-                    "endLine": 5,
-                    "endTokenPos": 175,
-                    "endFilePos": 277
-                  },
-                  "left": {
-                    "nodeType": "Scalar_Int",
-                    "attributes": {
-                      "startLine": 5,
-                      "startTokenPos": 165,
-                      "startFilePos": 267,
-                      "endLine": 5,
-                      "endTokenPos": 165,
-                      "endFilePos": 267,
-                      "rawValue": "2",
-                      "kind": 10
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "parenthesized_expression",
+              "children": [
+                {
+                  "kind": "conditional_expression",
+                  "children": [
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "is_float"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "integer",
+                                      "text": "2"
+                                    },
+                                    {
+                                      "kind": "parenthesized_expression",
+                                      "children": [
+                                        {
+                                          "kind": "binary_expression",
+                                          "children": [
+                                            {
+                                              "kind": "integer",
+                                              "text": "3"
+                                            },
+                                            {
+                                              "kind": "integer",
+                                              "text": "1"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     },
-                    "value": 2
-                  },
-                  "right": {
-                    "nodeType": "Expr_BinaryOp_Plus",
-                    "attributes": {
-                      "startLine": 5,
-                      "startTokenPos": 170,
-                      "startFilePos": 272,
-                      "endLine": 5,
-                      "endTokenPos": 174,
-                      "endFilePos": 276
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "json_encode"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "integer",
+                                      "text": "2"
+                                    },
+                                    {
+                                      "kind": "parenthesized_expression",
+                                      "children": [
+                                        {
+                                          "kind": "binary_expression",
+                                          "children": [
+                                            {
+                                              "kind": "integer",
+                                              "text": "3"
+                                            },
+                                            {
+                                              "kind": "integer",
+                                              "text": "1"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "integer",
+                                  "text": "1344"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     },
-                    "left": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 5,
-                        "startTokenPos": 170,
-                        "startFilePos": 272,
-                        "endLine": 5,
-                        "endTokenPos": 170,
-                        "endFilePos": 272,
-                        "rawValue": "3",
-                        "kind": 10
-                      },
-                      "value": 3
-                    },
-                    "right": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 5,
-                        "startTokenPos": 174,
-                        "startFilePos": 276,
-                        "endLine": 5,
-                        "endTokenPos": 174,
-                        "endFilePos": 276,
-                        "rawValue": "1",
-                        "kind": 10
-                      },
-                      "value": 1
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "integer",
+                          "text": "2"
+                        },
+                        {
+                          "kind": "parenthesized_expression",
+                          "children": [
+                            {
+                              "kind": "binary_expression",
+                              "children": [
+                                {
+                                  "kind": "integer",
+                                  "text": "3"
+                                },
+                                {
+                                  "kind": "integer",
+                                  "text": "1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     }
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "if": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 5,
-              "startTokenPos": 180,
-              "startFilePos": 282,
-              "endLine": 5,
-              "endTokenPos": 196,
-              "endFilePos": 311
+                  ]
+                }
+              ]
             },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 5,
-                "startTokenPos": 180,
-                "startFilePos": 282,
-                "endLine": 5,
-                "endTokenPos": 180,
-                "endFilePos": 292
-              },
-              "name": "json_encode"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 5,
-                  "startTokenPos": 182,
-                  "startFilePos": 294,
-                  "endLine": 5,
-                  "endTokenPos": 192,
-                  "endFilePos": 304
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_BinaryOp_Mul",
-                  "attributes": {
-                    "startLine": 5,
-                    "startTokenPos": 182,
-                    "startFilePos": 294,
-                    "endLine": 5,
-                    "endTokenPos": 192,
-                    "endFilePos": 304
-                  },
-                  "left": {
-                    "nodeType": "Scalar_Int",
-                    "attributes": {
-                      "startLine": 5,
-                      "startTokenPos": 182,
-                      "startFilePos": 294,
-                      "endLine": 5,
-                      "endTokenPos": 182,
-                      "endFilePos": 294,
-                      "rawValue": "2",
-                      "kind": 10
-                    },
-                    "value": 2
-                  },
-                  "right": {
-                    "nodeType": "Expr_BinaryOp_Plus",
-                    "attributes": {
-                      "startLine": 5,
-                      "startTokenPos": 187,
-                      "startFilePos": 299,
-                      "endLine": 5,
-                      "endTokenPos": 191,
-                      "endFilePos": 303
-                    },
-                    "left": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 5,
-                        "startTokenPos": 187,
-                        "startFilePos": 299,
-                        "endLine": 5,
-                        "endTokenPos": 187,
-                        "endFilePos": 299,
-                        "rawValue": "3",
-                        "kind": 10
-                      },
-                      "value": 3
-                    },
-                    "right": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 5,
-                        "startTokenPos": 191,
-                        "startFilePos": 303,
-                        "endLine": 5,
-                        "endTokenPos": 191,
-                        "endFilePos": 303,
-                        "rawValue": "1",
-                        "kind": 10
-                      },
-                      "value": 1
-                    }
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              },
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 5,
-                  "startTokenPos": 195,
-                  "startFilePos": 307,
-                  "endLine": 5,
-                  "endTokenPos": 195,
-                  "endFilePos": 310
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 5,
-                    "startTokenPos": 195,
-                    "startFilePos": 307,
-                    "endLine": 5,
-                    "endTokenPos": 195,
-                    "endFilePos": 310,
-                    "rawValue": "1344",
-                    "kind": 10
-                  },
-                  "value": 1344
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "else": {
-            "nodeType": "Expr_BinaryOp_Mul",
-            "attributes": {
-              "startLine": 5,
-              "startTokenPos": 200,
-              "startFilePos": 315,
-              "endLine": 5,
-              "endTokenPos": 210,
-              "endFilePos": 325
-            },
-            "left": {
-              "nodeType": "Scalar_Int",
-              "attributes": {
-                "startLine": 5,
-                "startTokenPos": 200,
-                "startFilePos": 315,
-                "endLine": 5,
-                "endTokenPos": 200,
-                "endFilePos": 315,
-                "rawValue": "2",
-                "kind": 10
-              },
-              "value": 2
-            },
-            "right": {
-              "nodeType": "Expr_BinaryOp_Plus",
-              "attributes": {
-                "startLine": 5,
-                "startTokenPos": 205,
-                "startFilePos": 320,
-                "endLine": 5,
-                "endTokenPos": 209,
-                "endFilePos": 324
-              },
-              "left": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 5,
-                  "startTokenPos": 205,
-                  "startFilePos": 320,
-                  "endLine": 5,
-                  "endTokenPos": 205,
-                  "endFilePos": 320,
-                  "rawValue": "3",
-                  "kind": 10
-                },
-                "value": 3
-              },
-              "right": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 5,
-                  "startTokenPos": 209,
-                  "startFilePos": 324,
-                  "endLine": 5,
-                  "endTokenPos": 209,
-                  "endFilePos": 324,
-                  "rawValue": "1",
-                  "kind": 10
-                },
-                "value": 1
-              }
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
             }
-          }
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 5,
-            "startTokenPos": 214,
-            "startFilePos": 329,
-            "endLine": 5,
-            "endTokenPos": 214,
-            "endFilePos": 335
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 5,
-              "startTokenPos": 214,
-              "startFilePos": 329,
-              "endLine": 5,
-              "endTokenPos": 214,
-              "endFilePos": 335
-            },
-            "name": "PHP_EOL"
-          }
+          ]
         }
       ]
     }

--- a/tests/json-ast/x/php/bool_chain.php.json
+++ b/tests/json-ast/x/php/bool_chain.php.json
@@ -1,777 +1,362 @@
 {
-  "root": [
+  "statements": [
     {
-      "nodeType": "Stmt_Function",
-      "attributes": {
-        "startLine": 2,
-        "startTokenPos": 1,
-        "startFilePos": 6,
-        "endLine": 5,
-        "endTokenPos": 22,
-        "endFilePos": 63
-      },
-      "byRef": false,
-      "name": {
-        "nodeType": "Identifier",
-        "attributes": {
-          "startLine": 2,
-          "startTokenPos": 3,
-          "startFilePos": 15,
-          "endLine": 2,
-          "endTokenPos": 3,
-          "endFilePos": 18
-        },
-        "name": "boom"
-      },
-      "params": [],
-      "returnType": null,
-      "stmts": [
+      "kind": "function_definition",
+      "children": [
         {
-          "nodeType": "Stmt_Echo",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 9,
-            "startFilePos": 26,
-            "endLine": 3,
-            "endTokenPos": 15,
-            "endFilePos": 46
-          },
-          "exprs": [
+          "kind": "name",
+          "text": "boom"
+        },
+        {
+          "kind": "compound_statement",
+          "children": [
             {
-              "nodeType": "Scalar_String",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 11,
-                "startFilePos": 31,
-                "endLine": 3,
-                "endTokenPos": 11,
-                "endFilePos": 36,
-                "kind": 2,
-                "rawValue": "\"boom\""
-              },
-              "value": "boom"
-            },
-            {
-              "nodeType": "Expr_ConstFetch",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 14,
-                "startFilePos": 39,
-                "endLine": 3,
-                "endTokenPos": 14,
-                "endFilePos": 45
-              },
-              "name": {
-                "nodeType": "Name",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 14,
-                  "startFilePos": 39,
-                  "endLine": 3,
-                  "endTokenPos": 14,
-                  "endFilePos": 45
-                },
-                "name": "PHP_EOL"
-              }
+              "kind": "echo_statement",
+              "children": [
+                {
+                  "kind": "sequence_expression",
+                  "children": [
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "boom"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "name",
+                      "text": "PHP_EOL"
+                    }
+                  ]
+                }
+              ]
             }
           ]
-        },
-        {
-          "nodeType": "Stmt_Return",
-          "attributes": {
-            "startLine": 4,
-            "startTokenPos": 17,
-            "startFilePos": 50,
-            "endLine": 4,
-            "endTokenPos": 20,
-            "endFilePos": 61
-          },
-          "expr": {
-            "nodeType": "Expr_ConstFetch",
-            "attributes": {
-              "startLine": 4,
-              "startTokenPos": 19,
-              "startFilePos": 57,
-              "endLine": 4,
-              "endTokenPos": 19,
-              "endFilePos": 60
-            },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 4,
-                "startTokenPos": 19,
-                "startFilePos": 57,
-                "endLine": 4,
-                "endTokenPos": 19,
-                "endFilePos": 60
-              },
-              "name": "true"
-            }
-          }
-        }
-      ],
-      "attrGroups": []
-    },
-    {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 6,
-        "startTokenPos": 24,
-        "startFilePos": 65,
-        "endLine": 6,
-        "endTokenPos": 66,
-        "endFilePos": 129
-      },
-      "exprs": [
-        {
-          "nodeType": "Expr_Ternary",
-          "attributes": {
-            "startLine": 6,
-            "startTokenPos": 27,
-            "startFilePos": 71,
-            "endLine": 6,
-            "endTokenPos": 61,
-            "endFilePos": 118
-          },
-          "cond": {
-            "nodeType": "Expr_BinaryOp_BooleanAnd",
-            "attributes": {
-              "startLine": 6,
-              "startTokenPos": 27,
-              "startFilePos": 71,
-              "endLine": 6,
-              "endTokenPos": 53,
-              "endFilePos": 99
-            },
-            "left": {
-              "nodeType": "Expr_BinaryOp_BooleanAnd",
-              "attributes": {
-                "startLine": 6,
-                "startTokenPos": 27,
-                "startFilePos": 71,
-                "endLine": 6,
-                "endTokenPos": 43,
-                "endFilePos": 88
-              },
-              "left": {
-                "nodeType": "Expr_BinaryOp_Smaller",
-                "attributes": {
-                  "startLine": 6,
-                  "startTokenPos": 28,
-                  "startFilePos": 72,
-                  "endLine": 6,
-                  "endTokenPos": 32,
-                  "endFilePos": 76
-                },
-                "left": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 6,
-                    "startTokenPos": 28,
-                    "startFilePos": 72,
-                    "endLine": 6,
-                    "endTokenPos": 28,
-                    "endFilePos": 72,
-                    "rawValue": "1",
-                    "kind": 10
-                  },
-                  "value": 1
-                },
-                "right": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 6,
-                    "startTokenPos": 32,
-                    "startFilePos": 76,
-                    "endLine": 6,
-                    "endTokenPos": 32,
-                    "endFilePos": 76,
-                    "rawValue": "2",
-                    "kind": 10
-                  },
-                  "value": 2
-                }
-              },
-              "right": {
-                "nodeType": "Expr_BinaryOp_Smaller",
-                "attributes": {
-                  "startLine": 6,
-                  "startTokenPos": 38,
-                  "startFilePos": 83,
-                  "endLine": 6,
-                  "endTokenPos": 42,
-                  "endFilePos": 87
-                },
-                "left": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 6,
-                    "startTokenPos": 38,
-                    "startFilePos": 83,
-                    "endLine": 6,
-                    "endTokenPos": 38,
-                    "endFilePos": 83,
-                    "rawValue": "2",
-                    "kind": 10
-                  },
-                  "value": 2
-                },
-                "right": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 6,
-                    "startTokenPos": 42,
-                    "startFilePos": 87,
-                    "endLine": 6,
-                    "endTokenPos": 42,
-                    "endFilePos": 87,
-                    "rawValue": "3",
-                    "kind": 10
-                  },
-                  "value": 3
-                }
-              }
-            },
-            "right": {
-              "nodeType": "Expr_BinaryOp_Smaller",
-              "attributes": {
-                "startLine": 6,
-                "startTokenPos": 48,
-                "startFilePos": 94,
-                "endLine": 6,
-                "endTokenPos": 52,
-                "endFilePos": 98
-              },
-              "left": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 6,
-                  "startTokenPos": 48,
-                  "startFilePos": 94,
-                  "endLine": 6,
-                  "endTokenPos": 48,
-                  "endFilePos": 94,
-                  "rawValue": "3",
-                  "kind": 10
-                },
-                "value": 3
-              },
-              "right": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 6,
-                  "startTokenPos": 52,
-                  "startFilePos": 98,
-                  "endLine": 6,
-                  "endTokenPos": 52,
-                  "endFilePos": 98,
-                  "rawValue": "4",
-                  "kind": 10
-                },
-                "value": 4
-              }
-            }
-          },
-          "if": {
-            "nodeType": "Scalar_String",
-            "attributes": {
-              "startLine": 6,
-              "startTokenPos": 57,
-              "startFilePos": 103,
-              "endLine": 6,
-              "endTokenPos": 57,
-              "endFilePos": 108,
-              "kind": 2,
-              "rawValue": "\"True\""
-            },
-            "value": "True"
-          },
-          "else": {
-            "nodeType": "Scalar_String",
-            "attributes": {
-              "startLine": 6,
-              "startTokenPos": 61,
-              "startFilePos": 112,
-              "endLine": 6,
-              "endTokenPos": 61,
-              "endFilePos": 118,
-              "kind": 2,
-              "rawValue": "\"False\""
-            },
-            "value": "False"
-          }
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 6,
-            "startTokenPos": 65,
-            "startFilePos": 122,
-            "endLine": 6,
-            "endTokenPos": 65,
-            "endFilePos": 128
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 6,
-              "startTokenPos": 65,
-              "startFilePos": 122,
-              "endLine": 6,
-              "endTokenPos": 65,
-              "endFilePos": 128
-            },
-            "name": "PHP_EOL"
-          }
         }
       ]
     },
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 7,
-        "startTokenPos": 68,
-        "startFilePos": 131,
-        "endLine": 7,
-        "endTokenPos": 106,
-        "endFilePos": 194
-      },
-      "exprs": [
+      "kind": "echo_statement",
+      "children": [
         {
-          "nodeType": "Expr_Ternary",
-          "attributes": {
-            "startLine": 7,
-            "startTokenPos": 71,
-            "startFilePos": 137,
-            "endLine": 7,
-            "endTokenPos": 101,
-            "endFilePos": 183
-          },
-          "cond": {
-            "nodeType": "Expr_BinaryOp_BooleanAnd",
-            "attributes": {
-              "startLine": 7,
-              "startTokenPos": 71,
-              "startFilePos": 137,
-              "endLine": 7,
-              "endTokenPos": 93,
-              "endFilePos": 164
-            },
-            "left": {
-              "nodeType": "Expr_BinaryOp_BooleanAnd",
-              "attributes": {
-                "startLine": 7,
-                "startTokenPos": 71,
-                "startFilePos": 137,
-                "endLine": 7,
-                "endTokenPos": 87,
-                "endFilePos": 154
-              },
-              "left": {
-                "nodeType": "Expr_BinaryOp_Smaller",
-                "attributes": {
-                  "startLine": 7,
-                  "startTokenPos": 72,
-                  "startFilePos": 138,
-                  "endLine": 7,
-                  "endTokenPos": 76,
-                  "endFilePos": 142
-                },
-                "left": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 7,
-                    "startTokenPos": 72,
-                    "startFilePos": 138,
-                    "endLine": 7,
-                    "endTokenPos": 72,
-                    "endFilePos": 138,
-                    "rawValue": "1",
-                    "kind": 10
-                  },
-                  "value": 1
-                },
-                "right": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 7,
-                    "startTokenPos": 76,
-                    "startFilePos": 142,
-                    "endLine": 7,
-                    "endTokenPos": 76,
-                    "endFilePos": 142,
-                    "rawValue": "2",
-                    "kind": 10
-                  },
-                  "value": 2
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "parenthesized_expression",
+              "children": [
+                {
+                  "kind": "conditional_expression",
+                  "children": [
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "binary_expression",
+                          "children": [
+                            {
+                              "kind": "parenthesized_expression",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "integer",
+                                      "text": "1"
+                                    },
+                                    {
+                                      "kind": "integer",
+                                      "text": "2"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "parenthesized_expression",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "integer",
+                                      "text": "2"
+                                    },
+                                    {
+                                      "kind": "integer",
+                                      "text": "3"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "parenthesized_expression",
+                          "children": [
+                            {
+                              "kind": "binary_expression",
+                              "children": [
+                                {
+                                  "kind": "integer",
+                                  "text": "3"
+                                },
+                                {
+                                  "kind": "integer",
+                                  "text": "4"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "True"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "False"
+                        }
+                      ]
+                    }
+                  ]
                 }
-              },
-              "right": {
-                "nodeType": "Expr_BinaryOp_Greater",
-                "attributes": {
-                  "startLine": 7,
-                  "startTokenPos": 82,
-                  "startFilePos": 149,
-                  "endLine": 7,
-                  "endTokenPos": 86,
-                  "endFilePos": 153
-                },
-                "left": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 7,
-                    "startTokenPos": 82,
-                    "startFilePos": 149,
-                    "endLine": 7,
-                    "endTokenPos": 82,
-                    "endFilePos": 149,
-                    "rawValue": "2",
-                    "kind": 10
-                  },
-                  "value": 2
-                },
-                "right": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 7,
-                    "startTokenPos": 86,
-                    "startFilePos": 153,
-                    "endLine": 7,
-                    "endTokenPos": 86,
-                    "endFilePos": 153,
-                    "rawValue": "3",
-                    "kind": 10
-                  },
-                  "value": 3
-                }
-              }
+              ]
             },
-            "right": {
-              "nodeType": "Expr_FuncCall",
-              "attributes": {
-                "startLine": 7,
-                "startTokenPos": 91,
-                "startFilePos": 159,
-                "endLine": 7,
-                "endTokenPos": 93,
-                "endFilePos": 164
-              },
-              "name": {
-                "nodeType": "Name",
-                "attributes": {
-                  "startLine": 7,
-                  "startTokenPos": 91,
-                  "startFilePos": 159,
-                  "endLine": 7,
-                  "endTokenPos": 91,
-                  "endFilePos": 162
-                },
-                "name": "boom"
-              },
-              "args": []
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
             }
-          },
-          "if": {
-            "nodeType": "Scalar_String",
-            "attributes": {
-              "startLine": 7,
-              "startTokenPos": 97,
-              "startFilePos": 168,
-              "endLine": 7,
-              "endTokenPos": 97,
-              "endFilePos": 173,
-              "kind": 2,
-              "rawValue": "\"True\""
-            },
-            "value": "True"
-          },
-          "else": {
-            "nodeType": "Scalar_String",
-            "attributes": {
-              "startLine": 7,
-              "startTokenPos": 101,
-              "startFilePos": 177,
-              "endLine": 7,
-              "endTokenPos": 101,
-              "endFilePos": 183,
-              "kind": 2,
-              "rawValue": "\"False\""
-            },
-            "value": "False"
-          }
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 7,
-            "startTokenPos": 105,
-            "startFilePos": 187,
-            "endLine": 7,
-            "endTokenPos": 105,
-            "endFilePos": 193
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 7,
-              "startTokenPos": 105,
-              "startFilePos": 187,
-              "endLine": 7,
-              "endTokenPos": 105,
-              "endFilePos": 193
-            },
-            "name": "PHP_EOL"
-          }
+          ]
         }
       ]
     },
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 8,
-        "startTokenPos": 108,
-        "startFilePos": 196,
-        "endLine": 8,
-        "endTokenPos": 156,
-        "endFilePos": 270
-      },
-      "exprs": [
+      "kind": "echo_statement",
+      "children": [
         {
-          "nodeType": "Expr_Ternary",
-          "attributes": {
-            "startLine": 8,
-            "startTokenPos": 111,
-            "startFilePos": 202,
-            "endLine": 8,
-            "endTokenPos": 151,
-            "endFilePos": 259
-          },
-          "cond": {
-            "nodeType": "Expr_BinaryOp_BooleanAnd",
-            "attributes": {
-              "startLine": 8,
-              "startTokenPos": 111,
-              "startFilePos": 202,
-              "endLine": 8,
-              "endTokenPos": 143,
-              "endFilePos": 240
-            },
-            "left": {
-              "nodeType": "Expr_BinaryOp_BooleanAnd",
-              "attributes": {
-                "startLine": 8,
-                "startTokenPos": 111,
-                "startFilePos": 202,
-                "endLine": 8,
-                "endTokenPos": 137,
-                "endFilePos": 230
-              },
-              "left": {
-                "nodeType": "Expr_BinaryOp_BooleanAnd",
-                "attributes": {
-                  "startLine": 8,
-                  "startTokenPos": 111,
-                  "startFilePos": 202,
-                  "endLine": 8,
-                  "endTokenPos": 127,
-                  "endFilePos": 219
-                },
-                "left": {
-                  "nodeType": "Expr_BinaryOp_Smaller",
-                  "attributes": {
-                    "startLine": 8,
-                    "startTokenPos": 112,
-                    "startFilePos": 203,
-                    "endLine": 8,
-                    "endTokenPos": 116,
-                    "endFilePos": 207
-                  },
-                  "left": {
-                    "nodeType": "Scalar_Int",
-                    "attributes": {
-                      "startLine": 8,
-                      "startTokenPos": 112,
-                      "startFilePos": 203,
-                      "endLine": 8,
-                      "endTokenPos": 112,
-                      "endFilePos": 203,
-                      "rawValue": "1",
-                      "kind": 10
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "parenthesized_expression",
+              "children": [
+                {
+                  "kind": "conditional_expression",
+                  "children": [
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "binary_expression",
+                          "children": [
+                            {
+                              "kind": "parenthesized_expression",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "integer",
+                                      "text": "1"
+                                    },
+                                    {
+                                      "kind": "integer",
+                                      "text": "2"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "parenthesized_expression",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "integer",
+                                      "text": "2"
+                                    },
+                                    {
+                                      "kind": "integer",
+                                      "text": "3"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "function_call_expression",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "boom"
+                            }
+                          ]
+                        }
+                      ]
                     },
-                    "value": 1
-                  },
-                  "right": {
-                    "nodeType": "Scalar_Int",
-                    "attributes": {
-                      "startLine": 8,
-                      "startTokenPos": 116,
-                      "startFilePos": 207,
-                      "endLine": 8,
-                      "endTokenPos": 116,
-                      "endFilePos": 207,
-                      "rawValue": "2",
-                      "kind": 10
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "True"
+                        }
+                      ]
                     },
-                    "value": 2
-                  }
-                },
-                "right": {
-                  "nodeType": "Expr_BinaryOp_Smaller",
-                  "attributes": {
-                    "startLine": 8,
-                    "startTokenPos": 122,
-                    "startFilePos": 214,
-                    "endLine": 8,
-                    "endTokenPos": 126,
-                    "endFilePos": 218
-                  },
-                  "left": {
-                    "nodeType": "Scalar_Int",
-                    "attributes": {
-                      "startLine": 8,
-                      "startTokenPos": 122,
-                      "startFilePos": 214,
-                      "endLine": 8,
-                      "endTokenPos": 122,
-                      "endFilePos": 214,
-                      "rawValue": "2",
-                      "kind": 10
-                    },
-                    "value": 2
-                  },
-                  "right": {
-                    "nodeType": "Scalar_Int",
-                    "attributes": {
-                      "startLine": 8,
-                      "startTokenPos": 126,
-                      "startFilePos": 218,
-                      "endLine": 8,
-                      "endTokenPos": 126,
-                      "endFilePos": 218,
-                      "rawValue": "3",
-                      "kind": 10
-                    },
-                    "value": 3
-                  }
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "False"
+                        }
+                      ]
+                    }
+                  ]
                 }
-              },
-              "right": {
-                "nodeType": "Expr_BinaryOp_Greater",
-                "attributes": {
-                  "startLine": 8,
-                  "startTokenPos": 132,
-                  "startFilePos": 225,
-                  "endLine": 8,
-                  "endTokenPos": 136,
-                  "endFilePos": 229
-                },
-                "left": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 8,
-                    "startTokenPos": 132,
-                    "startFilePos": 225,
-                    "endLine": 8,
-                    "endTokenPos": 132,
-                    "endFilePos": 225,
-                    "rawValue": "3",
-                    "kind": 10
-                  },
-                  "value": 3
-                },
-                "right": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 8,
-                    "startTokenPos": 136,
-                    "startFilePos": 229,
-                    "endLine": 8,
-                    "endTokenPos": 136,
-                    "endFilePos": 229,
-                    "rawValue": "4",
-                    "kind": 10
-                  },
-                  "value": 4
-                }
-              }
+              ]
             },
-            "right": {
-              "nodeType": "Expr_FuncCall",
-              "attributes": {
-                "startLine": 8,
-                "startTokenPos": 141,
-                "startFilePos": 235,
-                "endLine": 8,
-                "endTokenPos": 143,
-                "endFilePos": 240
-              },
-              "name": {
-                "nodeType": "Name",
-                "attributes": {
-                  "startLine": 8,
-                  "startTokenPos": 141,
-                  "startFilePos": 235,
-                  "endLine": 8,
-                  "endTokenPos": 141,
-                  "endFilePos": 238
-                },
-                "name": "boom"
-              },
-              "args": []
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
             }
-          },
-          "if": {
-            "nodeType": "Scalar_String",
-            "attributes": {
-              "startLine": 8,
-              "startTokenPos": 147,
-              "startFilePos": 244,
-              "endLine": 8,
-              "endTokenPos": 147,
-              "endFilePos": 249,
-              "kind": 2,
-              "rawValue": "\"True\""
-            },
-            "value": "True"
-          },
-          "else": {
-            "nodeType": "Scalar_String",
-            "attributes": {
-              "startLine": 8,
-              "startTokenPos": 151,
-              "startFilePos": 253,
-              "endLine": 8,
-              "endTokenPos": 151,
-              "endFilePos": 259,
-              "kind": 2,
-              "rawValue": "\"False\""
-            },
-            "value": "False"
-          }
-        },
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "echo_statement",
+      "children": [
         {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 8,
-            "startTokenPos": 155,
-            "startFilePos": 263,
-            "endLine": 8,
-            "endTokenPos": 155,
-            "endFilePos": 269
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 8,
-              "startTokenPos": 155,
-              "startFilePos": 263,
-              "endLine": 8,
-              "endTokenPos": 155,
-              "endFilePos": 269
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "parenthesized_expression",
+              "children": [
+                {
+                  "kind": "conditional_expression",
+                  "children": [
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "binary_expression",
+                          "children": [
+                            {
+                              "kind": "binary_expression",
+                              "children": [
+                                {
+                                  "kind": "parenthesized_expression",
+                                  "children": [
+                                    {
+                                      "kind": "binary_expression",
+                                      "children": [
+                                        {
+                                          "kind": "integer",
+                                          "text": "1"
+                                        },
+                                        {
+                                          "kind": "integer",
+                                          "text": "2"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "parenthesized_expression",
+                                  "children": [
+                                    {
+                                      "kind": "binary_expression",
+                                      "children": [
+                                        {
+                                          "kind": "integer",
+                                          "text": "2"
+                                        },
+                                        {
+                                          "kind": "integer",
+                                          "text": "3"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "parenthesized_expression",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "integer",
+                                      "text": "3"
+                                    },
+                                    {
+                                      "kind": "integer",
+                                      "text": "4"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "function_call_expression",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "boom"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "True"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "False"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             },
-            "name": "PHP_EOL"
-          }
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
+            }
+          ]
         }
       ]
     }

--- a/tests/json-ast/x/php/break_continue.php.json
+++ b/tests/json-ast/x/php/break_continue.php.json
@@ -1,731 +1,315 @@
 {
-  "root": [
+  "statements": [
     {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 2,
-        "startTokenPos": 1,
-        "startFilePos": 6,
-        "endLine": 2,
-        "endTokenPos": 32,
-        "endFilePos": 44
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 2,
-          "startTokenPos": 1,
-          "startFilePos": 6,
-          "endLine": 2,
-          "endTokenPos": 31,
-          "endFilePos": 43
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 1,
-            "startFilePos": 6,
-            "endLine": 2,
-            "endTokenPos": 1,
-            "endFilePos": 13
-          },
-          "name": "numbers"
-        },
-        "expr": {
-          "nodeType": "Expr_Array",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 5,
-            "startFilePos": 17,
-            "endLine": 2,
-            "endTokenPos": 31,
-            "endFilePos": 43,
-            "kind": 2
-          },
-          "items": [
+      "kind": "expression_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
             {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 6,
-                "startFilePos": 18,
-                "endLine": 2,
-                "endTokenPos": 6,
-                "endFilePos": 18
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 6,
-                  "startFilePos": 18,
-                  "endLine": 2,
-                  "endTokenPos": 6,
-                  "endFilePos": 18,
-                  "rawValue": "1",
-                  "kind": 10
-                },
-                "value": 1
-              },
-              "byRef": false,
-              "unpack": false
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "numbers"
+                }
+              ]
             },
             {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 9,
-                "startFilePos": 21,
-                "endLine": 2,
-                "endTokenPos": 9,
-                "endFilePos": 21
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 9,
-                  "startFilePos": 21,
-                  "endLine": 2,
-                  "endTokenPos": 9,
-                  "endFilePos": 21,
-                  "rawValue": "2",
-                  "kind": 10
+              "kind": "array_creation_expression",
+              "children": [
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "integer",
+                      "text": "1"
+                    }
+                  ]
                 },
-                "value": 2
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 12,
-                "startFilePos": 24,
-                "endLine": 2,
-                "endTokenPos": 12,
-                "endFilePos": 24
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 12,
-                  "startFilePos": 24,
-                  "endLine": 2,
-                  "endTokenPos": 12,
-                  "endFilePos": 24,
-                  "rawValue": "3",
-                  "kind": 10
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "integer",
+                      "text": "2"
+                    }
+                  ]
                 },
-                "value": 3
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 15,
-                "startFilePos": 27,
-                "endLine": 2,
-                "endTokenPos": 15,
-                "endFilePos": 27
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 15,
-                  "startFilePos": 27,
-                  "endLine": 2,
-                  "endTokenPos": 15,
-                  "endFilePos": 27,
-                  "rawValue": "4",
-                  "kind": 10
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "integer",
+                      "text": "3"
+                    }
+                  ]
                 },
-                "value": 4
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 18,
-                "startFilePos": 30,
-                "endLine": 2,
-                "endTokenPos": 18,
-                "endFilePos": 30
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 18,
-                  "startFilePos": 30,
-                  "endLine": 2,
-                  "endTokenPos": 18,
-                  "endFilePos": 30,
-                  "rawValue": "5",
-                  "kind": 10
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "integer",
+                      "text": "4"
+                    }
+                  ]
                 },
-                "value": 5
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 21,
-                "startFilePos": 33,
-                "endLine": 2,
-                "endTokenPos": 21,
-                "endFilePos": 33
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 21,
-                  "startFilePos": 33,
-                  "endLine": 2,
-                  "endTokenPos": 21,
-                  "endFilePos": 33,
-                  "rawValue": "6",
-                  "kind": 10
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "integer",
+                      "text": "5"
+                    }
+                  ]
                 },
-                "value": 6
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 24,
-                "startFilePos": 36,
-                "endLine": 2,
-                "endTokenPos": 24,
-                "endFilePos": 36
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 24,
-                  "startFilePos": 36,
-                  "endLine": 2,
-                  "endTokenPos": 24,
-                  "endFilePos": 36,
-                  "rawValue": "7",
-                  "kind": 10
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "integer",
+                      "text": "6"
+                    }
+                  ]
                 },
-                "value": 7
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 27,
-                "startFilePos": 39,
-                "endLine": 2,
-                "endTokenPos": 27,
-                "endFilePos": 39
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 27,
-                  "startFilePos": 39,
-                  "endLine": 2,
-                  "endTokenPos": 27,
-                  "endFilePos": 39,
-                  "rawValue": "8",
-                  "kind": 10
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "integer",
+                      "text": "7"
+                    }
+                  ]
                 },
-                "value": 8
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 30,
-                "startFilePos": 42,
-                "endLine": 2,
-                "endTokenPos": 30,
-                "endFilePos": 42
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 30,
-                  "startFilePos": 42,
-                  "endLine": 2,
-                  "endTokenPos": 30,
-                  "endFilePos": 42,
-                  "rawValue": "9",
-                  "kind": 10
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "integer",
+                      "text": "8"
+                    }
+                  ]
                 },
-                "value": 9
-              },
-              "byRef": false,
-              "unpack": false
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "integer",
+                      "text": "9"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }
-      }
+      ]
     },
     {
-      "nodeType": "Stmt_Foreach",
-      "attributes": {
-        "startLine": 3,
-        "startTokenPos": 34,
-        "startFilePos": 46,
-        "endLine": 11,
-        "endTokenPos": 119,
-        "endFilePos": 218
-      },
-      "expr": {
-        "nodeType": "Expr_Variable",
-        "attributes": {
-          "startLine": 3,
-          "startTokenPos": 37,
-          "startFilePos": 55,
-          "endLine": 3,
-          "endTokenPos": 37,
-          "endFilePos": 62
-        },
-        "name": "numbers"
-      },
-      "keyVar": null,
-      "byRef": false,
-      "valueVar": {
-        "nodeType": "Expr_Variable",
-        "attributes": {
-          "startLine": 3,
-          "startTokenPos": 41,
-          "startFilePos": 67,
-          "endLine": 3,
-          "endTokenPos": 41,
-          "endFilePos": 68
-        },
-        "name": "n"
-      },
-      "stmts": [
+      "kind": "foreach_statement",
+      "children": [
         {
-          "nodeType": "Stmt_If",
-          "attributes": {
-            "startLine": 4,
-            "startTokenPos": 46,
-            "startFilePos": 75,
-            "endLine": 6,
-            "endTokenPos": 65,
-            "endFilePos": 106
-          },
-          "cond": {
-            "nodeType": "Expr_BinaryOp_Equal",
-            "attributes": {
-              "startLine": 4,
-              "startTokenPos": 49,
-              "startFilePos": 79,
-              "endLine": 4,
-              "endTokenPos": 57,
-              "endFilePos": 89
-            },
-            "left": {
-              "nodeType": "Expr_BinaryOp_Mod",
-              "attributes": {
-                "startLine": 4,
-                "startTokenPos": 49,
-                "startFilePos": 79,
-                "endLine": 4,
-                "endTokenPos": 53,
-                "endFilePos": 84
-              },
-              "left": {
-                "nodeType": "Expr_Variable",
-                "attributes": {
-                  "startLine": 4,
-                  "startTokenPos": 49,
-                  "startFilePos": 79,
-                  "endLine": 4,
-                  "endTokenPos": 49,
-                  "endFilePos": 80
-                },
-                "name": "n"
-              },
-              "right": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 4,
-                  "startTokenPos": 53,
-                  "startFilePos": 84,
-                  "endLine": 4,
-                  "endTokenPos": 53,
-                  "endFilePos": 84,
-                  "rawValue": "2",
-                  "kind": 10
-                },
-                "value": 2
-              }
-            },
-            "right": {
-              "nodeType": "Scalar_Int",
-              "attributes": {
-                "startLine": 4,
-                "startTokenPos": 57,
-                "startFilePos": 89,
-                "endLine": 4,
-                "endTokenPos": 57,
-                "endFilePos": 89,
-                "rawValue": "0",
-                "kind": 10
-              },
-              "value": 0
-            }
-          },
-          "stmts": [
+          "kind": "variable_name",
+          "children": [
             {
-              "nodeType": "Stmt_Continue",
-              "attributes": {
-                "startLine": 5,
-                "startTokenPos": 62,
-                "startFilePos": 96,
-                "endLine": 5,
-                "endTokenPos": 63,
-                "endFilePos": 104
-              },
-              "num": null
+              "kind": "name",
+              "text": "numbers"
             }
-          ],
-          "elseifs": [],
-          "else": null
+          ]
         },
         {
-          "nodeType": "Stmt_If",
-          "attributes": {
-            "startLine": 7,
-            "startTokenPos": 67,
-            "startFilePos": 110,
-            "endLine": 9,
-            "endTokenPos": 82,
-            "endFilePos": 133
-          },
-          "cond": {
-            "nodeType": "Expr_BinaryOp_Greater",
-            "attributes": {
-              "startLine": 7,
-              "startTokenPos": 70,
-              "startFilePos": 114,
-              "endLine": 7,
-              "endTokenPos": 74,
-              "endFilePos": 119
-            },
-            "left": {
-              "nodeType": "Expr_Variable",
-              "attributes": {
-                "startLine": 7,
-                "startTokenPos": 70,
-                "startFilePos": 114,
-                "endLine": 7,
-                "endTokenPos": 70,
-                "endFilePos": 115
-              },
-              "name": "n"
-            },
-            "right": {
-              "nodeType": "Scalar_Int",
-              "attributes": {
-                "startLine": 7,
-                "startTokenPos": 74,
-                "startFilePos": 119,
-                "endLine": 7,
-                "endTokenPos": 74,
-                "endFilePos": 119,
-                "rawValue": "7",
-                "kind": 10
-              },
-              "value": 7
-            }
-          },
-          "stmts": [
+          "kind": "variable_name",
+          "children": [
             {
-              "nodeType": "Stmt_Break",
-              "attributes": {
-                "startLine": 8,
-                "startTokenPos": 79,
-                "startFilePos": 126,
-                "endLine": 8,
-                "endTokenPos": 80,
-                "endFilePos": 131
-              },
-              "num": null
+              "kind": "name",
+              "text": "n"
             }
-          ],
-          "elseifs": [],
-          "else": null
+          ]
         },
         {
-          "nodeType": "Stmt_Echo",
-          "attributes": {
-            "startLine": 10,
-            "startTokenPos": 84,
-            "startFilePos": 137,
-            "endLine": 10,
-            "endTokenPos": 117,
-            "endFilePos": 216
-          },
-          "exprs": [
+          "kind": "compound_statement",
+          "children": [
             {
-              "nodeType": "Expr_BinaryOp_Concat",
-              "attributes": {
-                "startLine": 10,
-                "startTokenPos": 86,
-                "startFilePos": 142,
-                "endLine": 10,
-                "endTokenPos": 113,
-                "endFilePos": 206
-              },
-              "left": {
-                "nodeType": "Expr_BinaryOp_Concat",
-                "attributes": {
-                  "startLine": 10,
-                  "startTokenPos": 86,
-                  "startFilePos": 142,
-                  "endLine": 10,
-                  "endTokenPos": 90,
-                  "endFilePos": 160
-                },
-                "left": {
-                  "nodeType": "Scalar_String",
-                  "attributes": {
-                    "startLine": 10,
-                    "startTokenPos": 86,
-                    "startFilePos": 142,
-                    "endLine": 10,
-                    "endTokenPos": 86,
-                    "endFilePos": 154,
-                    "kind": 2,
-                    "rawValue": "\"odd number:\""
-                  },
-                  "value": "odd number:"
-                },
-                "right": {
-                  "nodeType": "Scalar_String",
-                  "attributes": {
-                    "startLine": 10,
-                    "startTokenPos": 90,
-                    "startFilePos": 158,
-                    "endLine": 10,
-                    "endTokenPos": 90,
-                    "endFilePos": 160,
-                    "kind": 2,
-                    "rawValue": "\" \""
-                  },
-                  "value": " "
-                }
-              },
-              "right": {
-                "nodeType": "Expr_Ternary",
-                "attributes": {
-                  "startLine": 10,
-                  "startTokenPos": 95,
-                  "startFilePos": 165,
-                  "endLine": 10,
-                  "endTokenPos": 112,
-                  "endFilePos": 205
-                },
-                "cond": {
-                  "nodeType": "Expr_FuncCall",
-                  "attributes": {
-                    "startLine": 10,
-                    "startTokenPos": 95,
-                    "startFilePos": 165,
-                    "endLine": 10,
-                    "endTokenPos": 98,
-                    "endFilePos": 176
-                  },
-                  "name": {
-                    "nodeType": "Name",
-                    "attributes": {
-                      "startLine": 10,
-                      "startTokenPos": 95,
-                      "startFilePos": 165,
-                      "endLine": 10,
-                      "endTokenPos": 95,
-                      "endFilePos": 172
-                    },
-                    "name": "is_float"
-                  },
-                  "args": [
+              "kind": "if_statement",
+              "children": [
+                {
+                  "kind": "parenthesized_expression",
+                  "children": [
                     {
-                      "nodeType": "Arg",
-                      "attributes": {
-                        "startLine": 10,
-                        "startTokenPos": 97,
-                        "startFilePos": 174,
-                        "endLine": 10,
-                        "endTokenPos": 97,
-                        "endFilePos": 175
-                      },
-                      "name": null,
-                      "value": {
-                        "nodeType": "Expr_Variable",
-                        "attributes": {
-                          "startLine": 10,
-                          "startTokenPos": 97,
-                          "startFilePos": 174,
-                          "endLine": 10,
-                          "endTokenPos": 97,
-                          "endFilePos": 175
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "binary_expression",
+                          "children": [
+                            {
+                              "kind": "variable_name",
+                              "children": [
+                                {
+                                  "kind": "name",
+                                  "text": "n"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "integer",
+                              "text": "2"
+                            }
+                          ]
                         },
-                        "name": "n"
-                      },
-                      "byRef": false,
-                      "unpack": false
+                        {
+                          "kind": "integer",
+                          "text": "0"
+                        }
+                      ]
                     }
                   ]
-                },
-                "if": {
-                  "nodeType": "Expr_FuncCall",
-                  "attributes": {
-                    "startLine": 10,
-                    "startTokenPos": 102,
-                    "startFilePos": 180,
-                    "endLine": 10,
-                    "endTokenPos": 108,
-                    "endFilePos": 200
-                  },
-                  "name": {
-                    "nodeType": "Name",
-                    "attributes": {
-                      "startLine": 10,
-                      "startTokenPos": 102,
-                      "startFilePos": 180,
-                      "endLine": 10,
-                      "endTokenPos": 102,
-                      "endFilePos": 190
-                    },
-                    "name": "json_encode"
-                  },
-                  "args": [
-                    {
-                      "nodeType": "Arg",
-                      "attributes": {
-                        "startLine": 10,
-                        "startTokenPos": 104,
-                        "startFilePos": 192,
-                        "endLine": 10,
-                        "endTokenPos": 104,
-                        "endFilePos": 193
-                      },
-                      "name": null,
-                      "value": {
-                        "nodeType": "Expr_Variable",
-                        "attributes": {
-                          "startLine": 10,
-                          "startTokenPos": 104,
-                          "startFilePos": 192,
-                          "endLine": 10,
-                          "endTokenPos": 104,
-                          "endFilePos": 193
-                        },
-                        "name": "n"
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "nodeType": "Arg",
-                      "attributes": {
-                        "startLine": 10,
-                        "startTokenPos": 107,
-                        "startFilePos": 196,
-                        "endLine": 10,
-                        "endTokenPos": 107,
-                        "endFilePos": 199
-                      },
-                      "name": null,
-                      "value": {
-                        "nodeType": "Scalar_Int",
-                        "attributes": {
-                          "startLine": 10,
-                          "startTokenPos": 107,
-                          "startFilePos": 196,
-                          "endLine": 10,
-                          "endTokenPos": 107,
-                          "endFilePos": 199,
-                          "rawValue": "1344",
-                          "kind": 10
-                        },
-                        "value": 1344
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    }
-                  ]
-                },
-                "else": {
-                  "nodeType": "Expr_Variable",
-                  "attributes": {
-                    "startLine": 10,
-                    "startTokenPos": 112,
-                    "startFilePos": 204,
-                    "endLine": 10,
-                    "endTokenPos": 112,
-                    "endFilePos": 205
-                  },
-                  "name": "n"
                 }
-              }
+              ]
             },
             {
-              "nodeType": "Expr_ConstFetch",
-              "attributes": {
-                "startLine": 10,
-                "startTokenPos": 116,
-                "startFilePos": 209,
-                "endLine": 10,
-                "endTokenPos": 116,
-                "endFilePos": 215
-              },
-              "name": {
-                "nodeType": "Name",
-                "attributes": {
-                  "startLine": 10,
-                  "startTokenPos": 116,
-                  "startFilePos": 209,
-                  "endLine": 10,
-                  "endTokenPos": 116,
-                  "endFilePos": 215
-                },
-                "name": "PHP_EOL"
-              }
+              "kind": "if_statement",
+              "children": [
+                {
+                  "kind": "parenthesized_expression",
+                  "children": [
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "n"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "integer",
+                          "text": "7"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "echo_statement",
+              "children": [
+                {
+                  "kind": "sequence_expression",
+                  "children": [
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "binary_expression",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "odd number:"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "parenthesized_expression",
+                          "children": [
+                            {
+                              "kind": "conditional_expression",
+                              "children": [
+                                {
+                                  "kind": "function_call_expression",
+                                  "children": [
+                                    {
+                                      "kind": "name",
+                                      "text": "is_float"
+                                    },
+                                    {
+                                      "kind": "arguments",
+                                      "children": [
+                                        {
+                                          "kind": "argument",
+                                          "children": [
+                                            {
+                                              "kind": "variable_name",
+                                              "children": [
+                                                {
+                                                  "kind": "name",
+                                                  "text": "n"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "function_call_expression",
+                                  "children": [
+                                    {
+                                      "kind": "name",
+                                      "text": "json_encode"
+                                    },
+                                    {
+                                      "kind": "arguments",
+                                      "children": [
+                                        {
+                                          "kind": "argument",
+                                          "children": [
+                                            {
+                                              "kind": "variable_name",
+                                              "children": [
+                                                {
+                                                  "kind": "name",
+                                                  "text": "n"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "argument",
+                                          "children": [
+                                            {
+                                              "kind": "integer",
+                                              "text": "1344"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "variable_name",
+                                  "children": [
+                                    {
+                                      "kind": "name",
+                                      "text": "n"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "name",
+                      "text": "PHP_EOL"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }

--- a/tests/json-ast/x/php/cast_string_to_int.php.json
+++ b/tests/json-ast/x/php/cast_string_to_int.php.json
@@ -1,314 +1,157 @@
 {
-  "root": [
+  "statements": [
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 2,
-        "startTokenPos": 1,
-        "startFilePos": 6,
-        "endLine": 2,
-        "endTokenPos": 35,
-        "endFilePos": 99
-      },
-      "exprs": [
+      "kind": "echo_statement",
+      "children": [
         {
-          "nodeType": "Expr_Ternary",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 4,
-            "startFilePos": 12,
-            "endLine": 2,
-            "endTokenPos": 30,
-            "endFilePos": 88
-          },
-          "cond": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 4,
-              "startFilePos": 12,
-              "endLine": 2,
-              "endTokenPos": 10,
-              "endFilePos": 35
-            },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 4,
-                "startFilePos": 12,
-                "endLine": 2,
-                "endTokenPos": 4,
-                "endFilePos": 19
-              },
-              "name": "is_float"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 6,
-                  "startFilePos": 21,
-                  "endLine": 2,
-                  "endTokenPos": 9,
-                  "endFilePos": 34
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_FuncCall",
-                  "attributes": {
-                    "startLine": 2,
-                    "startTokenPos": 6,
-                    "startFilePos": 21,
-                    "endLine": 2,
-                    "endTokenPos": 9,
-                    "endFilePos": 34
-                  },
-                  "name": {
-                    "nodeType": "Name",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 6,
-                      "startFilePos": 21,
-                      "endLine": 2,
-                      "endTokenPos": 6,
-                      "endFilePos": 26
-                    },
-                    "name": "intval"
-                  },
-                  "args": [
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "parenthesized_expression",
+              "children": [
+                {
+                  "kind": "conditional_expression",
+                  "children": [
                     {
-                      "nodeType": "Arg",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 8,
-                        "startFilePos": 28,
-                        "endLine": 2,
-                        "endTokenPos": 8,
-                        "endFilePos": 33
-                      },
-                      "name": null,
-                      "value": {
-                        "nodeType": "Scalar_String",
-                        "attributes": {
-                          "startLine": 2,
-                          "startTokenPos": 8,
-                          "startFilePos": 28,
-                          "endLine": 2,
-                          "endTokenPos": 8,
-                          "endFilePos": 33,
-                          "kind": 2,
-                          "rawValue": "\"1995\""
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "is_float"
                         },
-                        "value": "1995"
-                      },
-                      "byRef": false,
-                      "unpack": false
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "function_call_expression",
+                                  "children": [
+                                    {
+                                      "kind": "name",
+                                      "text": "intval"
+                                    },
+                                    {
+                                      "kind": "arguments",
+                                      "children": [
+                                        {
+                                          "kind": "argument",
+                                          "children": [
+                                            {
+                                              "kind": "encapsed_string",
+                                              "children": [
+                                                {
+                                                  "kind": "string_content",
+                                                  "text": "1995"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "json_encode"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "function_call_expression",
+                                  "children": [
+                                    {
+                                      "kind": "name",
+                                      "text": "intval"
+                                    },
+                                    {
+                                      "kind": "arguments",
+                                      "children": [
+                                        {
+                                          "kind": "argument",
+                                          "children": [
+                                            {
+                                              "kind": "encapsed_string",
+                                              "children": [
+                                                {
+                                                  "kind": "string_content",
+                                                  "text": "1995"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "integer",
+                                  "text": "1344"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "intval"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "encapsed_string",
+                                  "children": [
+                                    {
+                                      "kind": "string_content",
+                                      "text": "1995"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "if": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 14,
-              "startFilePos": 39,
-              "endLine": 2,
-              "endTokenPos": 23,
-              "endFilePos": 71
+                }
+              ]
             },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 14,
-                "startFilePos": 39,
-                "endLine": 2,
-                "endTokenPos": 14,
-                "endFilePos": 49
-              },
-              "name": "json_encode"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 16,
-                  "startFilePos": 51,
-                  "endLine": 2,
-                  "endTokenPos": 19,
-                  "endFilePos": 64
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_FuncCall",
-                  "attributes": {
-                    "startLine": 2,
-                    "startTokenPos": 16,
-                    "startFilePos": 51,
-                    "endLine": 2,
-                    "endTokenPos": 19,
-                    "endFilePos": 64
-                  },
-                  "name": {
-                    "nodeType": "Name",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 16,
-                      "startFilePos": 51,
-                      "endLine": 2,
-                      "endTokenPos": 16,
-                      "endFilePos": 56
-                    },
-                    "name": "intval"
-                  },
-                  "args": [
-                    {
-                      "nodeType": "Arg",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 18,
-                        "startFilePos": 58,
-                        "endLine": 2,
-                        "endTokenPos": 18,
-                        "endFilePos": 63
-                      },
-                      "name": null,
-                      "value": {
-                        "nodeType": "Scalar_String",
-                        "attributes": {
-                          "startLine": 2,
-                          "startTokenPos": 18,
-                          "startFilePos": 58,
-                          "endLine": 2,
-                          "endTokenPos": 18,
-                          "endFilePos": 63,
-                          "kind": 2,
-                          "rawValue": "\"1995\""
-                        },
-                        "value": "1995"
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    }
-                  ]
-                },
-                "byRef": false,
-                "unpack": false
-              },
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 22,
-                  "startFilePos": 67,
-                  "endLine": 2,
-                  "endTokenPos": 22,
-                  "endFilePos": 70
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 2,
-                    "startTokenPos": 22,
-                    "startFilePos": 67,
-                    "endLine": 2,
-                    "endTokenPos": 22,
-                    "endFilePos": 70,
-                    "rawValue": "1344",
-                    "kind": 10
-                  },
-                  "value": 1344
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "else": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 27,
-              "startFilePos": 75,
-              "endLine": 2,
-              "endTokenPos": 30,
-              "endFilePos": 88
-            },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 27,
-                "startFilePos": 75,
-                "endLine": 2,
-                "endTokenPos": 27,
-                "endFilePos": 80
-              },
-              "name": "intval"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 29,
-                  "startFilePos": 82,
-                  "endLine": 2,
-                  "endTokenPos": 29,
-                  "endFilePos": 87
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Scalar_String",
-                  "attributes": {
-                    "startLine": 2,
-                    "startTokenPos": 29,
-                    "startFilePos": 82,
-                    "endLine": 2,
-                    "endTokenPos": 29,
-                    "endFilePos": 87,
-                    "kind": 2,
-                    "rawValue": "\"1995\""
-                  },
-                  "value": "1995"
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          }
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 34,
-            "startFilePos": 92,
-            "endLine": 2,
-            "endTokenPos": 34,
-            "endFilePos": 98
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 34,
-              "startFilePos": 92,
-              "endLine": 2,
-              "endTokenPos": 34,
-              "endFilePos": 98
-            },
-            "name": "PHP_EOL"
-          }
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
+            }
+          ]
         }
       ]
     }

--- a/tests/json-ast/x/php/cast_struct.php.json
+++ b/tests/json-ast/x/php/cast_struct.php.json
@@ -1,355 +1,189 @@
 {
-  "root": [
+  "statements": [
     {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 2,
-        "startTokenPos": 1,
-        "startFilePos": 6,
-        "endLine": 2,
-        "endTokenPos": 12,
-        "endFilePos": 31
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 2,
-          "startTokenPos": 1,
-          "startFilePos": 6,
-          "endLine": 2,
-          "endTokenPos": 11,
-          "endFilePos": 30
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 1,
-            "startFilePos": 6,
-            "endLine": 2,
-            "endTokenPos": 1,
-            "endFilePos": 10
-          },
-          "name": "todo"
-        },
-        "expr": {
-          "nodeType": "Expr_Array",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 5,
-            "startFilePos": 14,
-            "endLine": 2,
-            "endTokenPos": 11,
-            "endFilePos": 30,
-            "kind": 2
-          },
-          "items": [
+      "kind": "expression_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
             {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 6,
-                "startFilePos": 15,
-                "endLine": 2,
-                "endTokenPos": 10,
-                "endFilePos": 29
-              },
-              "key": {
-                "nodeType": "Scalar_String",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 6,
-                  "startFilePos": 15,
-                  "endLine": 2,
-                  "endTokenPos": 6,
-                  "endFilePos": 21,
-                  "kind": 2,
-                  "rawValue": "\"title\""
-                },
-                "value": "title"
-              },
-              "value": {
-                "nodeType": "Scalar_String",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 10,
-                  "startFilePos": 26,
-                  "endLine": 2,
-                  "endTokenPos": 10,
-                  "endFilePos": 29,
-                  "kind": 2,
-                  "rawValue": "\"hi\""
-                },
-                "value": "hi"
-              },
-              "byRef": false,
-              "unpack": false
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "todo"
+                }
+              ]
+            },
+            {
+              "kind": "array_creation_expression",
+              "children": [
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "title"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "hi"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }
-      }
+      ]
     },
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 3,
-        "startTokenPos": 14,
-        "startFilePos": 33,
-        "endLine": 3,
-        "endTokenPos": 48,
-        "endFilePos": 126
-      },
-      "exprs": [
+      "kind": "echo_statement",
+      "children": [
         {
-          "nodeType": "Expr_Ternary",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 17,
-            "startFilePos": 39,
-            "endLine": 3,
-            "endTokenPos": 43,
-            "endFilePos": 115
-          },
-          "cond": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 3,
-              "startTokenPos": 17,
-              "startFilePos": 39,
-              "endLine": 3,
-              "endTokenPos": 23,
-              "endFilePos": 62
-            },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 17,
-                "startFilePos": 39,
-                "endLine": 3,
-                "endTokenPos": 17,
-                "endFilePos": 46
-              },
-              "name": "is_float"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 19,
-                  "startFilePos": 48,
-                  "endLine": 3,
-                  "endTokenPos": 22,
-                  "endFilePos": 61
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_ArrayDimFetch",
-                  "attributes": {
-                    "startLine": 3,
-                    "startTokenPos": 19,
-                    "startFilePos": 48,
-                    "endLine": 3,
-                    "endTokenPos": 22,
-                    "endFilePos": 61
-                  },
-                  "var": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 3,
-                      "startTokenPos": 19,
-                      "startFilePos": 48,
-                      "endLine": 3,
-                      "endTokenPos": 19,
-                      "endFilePos": 52
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "parenthesized_expression",
+              "children": [
+                {
+                  "kind": "conditional_expression",
+                  "children": [
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "is_float"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "subscript_expression",
+                                  "children": [
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "todo"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "encapsed_string",
+                                      "children": [
+                                        {
+                                          "kind": "string_content",
+                                          "text": "title"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     },
-                    "name": "todo"
-                  },
-                  "dim": {
-                    "nodeType": "Scalar_String",
-                    "attributes": {
-                      "startLine": 3,
-                      "startTokenPos": 21,
-                      "startFilePos": 54,
-                      "endLine": 3,
-                      "endTokenPos": 21,
-                      "endFilePos": 60,
-                      "kind": 2,
-                      "rawValue": "\"title\""
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "json_encode"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "subscript_expression",
+                                  "children": [
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "todo"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "encapsed_string",
+                                      "children": [
+                                        {
+                                          "kind": "string_content",
+                                          "text": "title"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "integer",
+                                  "text": "1344"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     },
-                    "value": "title"
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "if": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 3,
-              "startTokenPos": 27,
-              "startFilePos": 66,
-              "endLine": 3,
-              "endTokenPos": 36,
-              "endFilePos": 98
+                    {
+                      "kind": "subscript_expression",
+                      "children": [
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "todo"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "encapsed_string",
+                          "children": [
+                            {
+                              "kind": "string_content",
+                              "text": "title"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 27,
-                "startFilePos": 66,
-                "endLine": 3,
-                "endTokenPos": 27,
-                "endFilePos": 76
-              },
-              "name": "json_encode"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 29,
-                  "startFilePos": 78,
-                  "endLine": 3,
-                  "endTokenPos": 32,
-                  "endFilePos": 91
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_ArrayDimFetch",
-                  "attributes": {
-                    "startLine": 3,
-                    "startTokenPos": 29,
-                    "startFilePos": 78,
-                    "endLine": 3,
-                    "endTokenPos": 32,
-                    "endFilePos": 91
-                  },
-                  "var": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 3,
-                      "startTokenPos": 29,
-                      "startFilePos": 78,
-                      "endLine": 3,
-                      "endTokenPos": 29,
-                      "endFilePos": 82
-                    },
-                    "name": "todo"
-                  },
-                  "dim": {
-                    "nodeType": "Scalar_String",
-                    "attributes": {
-                      "startLine": 3,
-                      "startTokenPos": 31,
-                      "startFilePos": 84,
-                      "endLine": 3,
-                      "endTokenPos": 31,
-                      "endFilePos": 90,
-                      "kind": 2,
-                      "rawValue": "\"title\""
-                    },
-                    "value": "title"
-                  }
-                },
-                "byRef": false,
-                "unpack": false
-              },
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 35,
-                  "startFilePos": 94,
-                  "endLine": 3,
-                  "endTokenPos": 35,
-                  "endFilePos": 97
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 3,
-                    "startTokenPos": 35,
-                    "startFilePos": 94,
-                    "endLine": 3,
-                    "endTokenPos": 35,
-                    "endFilePos": 97,
-                    "rawValue": "1344",
-                    "kind": 10
-                  },
-                  "value": 1344
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "else": {
-            "nodeType": "Expr_ArrayDimFetch",
-            "attributes": {
-              "startLine": 3,
-              "startTokenPos": 40,
-              "startFilePos": 102,
-              "endLine": 3,
-              "endTokenPos": 43,
-              "endFilePos": 115
-            },
-            "var": {
-              "nodeType": "Expr_Variable",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 40,
-                "startFilePos": 102,
-                "endLine": 3,
-                "endTokenPos": 40,
-                "endFilePos": 106
-              },
-              "name": "todo"
-            },
-            "dim": {
-              "nodeType": "Scalar_String",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 42,
-                "startFilePos": 108,
-                "endLine": 3,
-                "endTokenPos": 42,
-                "endFilePos": 114,
-                "kind": 2,
-                "rawValue": "\"title\""
-              },
-              "value": "title"
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
             }
-          }
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 47,
-            "startFilePos": 119,
-            "endLine": 3,
-            "endTokenPos": 47,
-            "endFilePos": 125
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 3,
-              "startTokenPos": 47,
-              "startFilePos": 119,
-              "endLine": 3,
-              "endTokenPos": 47,
-              "endFilePos": 125
-            },
-            "name": "PHP_EOL"
-          }
+          ]
         }
       ]
     }

--- a/tests/json-ast/x/php/closure.php.json
+++ b/tests/json-ast/x/php/closure.php.json
@@ -1,593 +1,308 @@
 {
-  "root": [
+  "statements": [
     {
-      "nodeType": "Stmt_Function",
-      "attributes": {
-        "startLine": 2,
-        "startTokenPos": 1,
-        "startFilePos": 6,
-        "endLine": 6,
-        "endTokenPos": 37,
-        "endFilePos": 85
-      },
-      "byRef": false,
-      "name": {
-        "nodeType": "Identifier",
-        "attributes": {
-          "startLine": 2,
-          "startTokenPos": 3,
-          "startFilePos": 15,
-          "endLine": 2,
-          "endTokenPos": 3,
-          "endFilePos": 23
-        },
-        "name": "makeAdder"
-      },
-      "params": [
+      "kind": "function_definition",
+      "children": [
         {
-          "nodeType": "Param",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 5,
-            "startFilePos": 25,
-            "endLine": 2,
-            "endTokenPos": 5,
-            "endFilePos": 26
-          },
-          "type": null,
-          "byRef": false,
-          "variadic": false,
-          "var": {
-            "nodeType": "Expr_Variable",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 5,
-              "startFilePos": 25,
-              "endLine": 2,
-              "endTokenPos": 5,
-              "endFilePos": 26
-            },
-            "name": "n"
-          },
-          "default": null,
-          "flags": 0,
-          "attrGroups": [],
-          "hooks": []
-        }
-      ],
-      "returnType": null,
-      "stmts": [
+          "kind": "name",
+          "text": "makeAdder"
+        },
         {
-          "nodeType": "Stmt_Return",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 10,
-            "startFilePos": 33,
-            "endLine": 5,
-            "endTokenPos": 35,
-            "endFilePos": 83
-          },
-          "expr": {
-            "nodeType": "Expr_Closure",
-            "attributes": {
-              "startLine": 3,
-              "startTokenPos": 12,
-              "startFilePos": 40,
-              "endLine": 5,
-              "endTokenPos": 34,
-              "endFilePos": 82
-            },
-            "static": false,
-            "byRef": false,
-            "params": [
-              {
-                "nodeType": "Param",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 14,
-                  "startFilePos": 49,
-                  "endLine": 3,
-                  "endTokenPos": 14,
-                  "endFilePos": 50
-                },
-                "type": null,
-                "byRef": false,
-                "variadic": false,
-                "var": {
-                  "nodeType": "Expr_Variable",
-                  "attributes": {
-                    "startLine": 3,
-                    "startTokenPos": 14,
-                    "startFilePos": 49,
-                    "endLine": 3,
-                    "endTokenPos": 14,
-                    "endFilePos": 50
-                  },
-                  "name": "x"
-                },
-                "default": null,
-                "flags": 0,
-                "attrGroups": [],
-                "hooks": []
-              }
-            ],
-            "uses": [
-              {
-                "nodeType": "ClosureUse",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 20,
-                  "startFilePos": 58,
-                  "endLine": 3,
-                  "endTokenPos": 20,
-                  "endFilePos": 59
-                },
-                "var": {
-                  "nodeType": "Expr_Variable",
-                  "attributes": {
-                    "startLine": 3,
-                    "startTokenPos": 20,
-                    "startFilePos": 58,
-                    "endLine": 3,
-                    "endTokenPos": 20,
-                    "endFilePos": 59
-                  },
-                  "name": "n"
-                },
-                "byRef": false
-              }
-            ],
-            "returnType": null,
-            "stmts": [
-              {
-                "nodeType": "Stmt_Return",
-                "attributes": {
-                  "startLine": 4,
-                  "startTokenPos": 25,
-                  "startFilePos": 66,
-                  "endLine": 4,
-                  "endTokenPos": 32,
-                  "endFilePos": 80
-                },
-                "expr": {
-                  "nodeType": "Expr_BinaryOp_Plus",
-                  "attributes": {
-                    "startLine": 4,
-                    "startTokenPos": 27,
-                    "startFilePos": 73,
-                    "endLine": 4,
-                    "endTokenPos": 31,
-                    "endFilePos": 79
-                  },
-                  "left": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 4,
-                      "startTokenPos": 27,
-                      "startFilePos": 73,
-                      "endLine": 4,
-                      "endTokenPos": 27,
-                      "endFilePos": 74
-                    },
-                    "name": "x"
-                  },
-                  "right": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 4,
-                      "startTokenPos": 31,
-                      "startFilePos": 78,
-                      "endLine": 4,
-                      "endTokenPos": 31,
-                      "endFilePos": 79
-                    },
-                    "name": "n"
-                  }
-                }
-              }
-            ],
-            "attrGroups": []
-          }
-        }
-      ],
-      "attrGroups": []
-    },
-    {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 7,
-        "startTokenPos": 39,
-        "startFilePos": 87,
-        "endLine": 7,
-        "endTokenPos": 47,
-        "endFilePos": 109
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 7,
-          "startTokenPos": 39,
-          "startFilePos": 87,
-          "endLine": 7,
-          "endTokenPos": 46,
-          "endFilePos": 108
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 7,
-            "startTokenPos": 39,
-            "startFilePos": 87,
-            "endLine": 7,
-            "endTokenPos": 39,
-            "endFilePos": 92
-          },
-          "name": "add10"
-        },
-        "expr": {
-          "nodeType": "Expr_FuncCall",
-          "attributes": {
-            "startLine": 7,
-            "startTokenPos": 43,
-            "startFilePos": 96,
-            "endLine": 7,
-            "endTokenPos": 46,
-            "endFilePos": 108
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 7,
-              "startTokenPos": 43,
-              "startFilePos": 96,
-              "endLine": 7,
-              "endTokenPos": 43,
-              "endFilePos": 104
-            },
-            "name": "makeAdder"
-          },
-          "args": [
+          "kind": "formal_parameters",
+          "children": [
             {
-              "nodeType": "Arg",
-              "attributes": {
-                "startLine": 7,
-                "startTokenPos": 45,
-                "startFilePos": 106,
-                "endLine": 7,
-                "endTokenPos": 45,
-                "endFilePos": 107
-              },
-              "name": null,
-              "value": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 7,
-                  "startTokenPos": 45,
-                  "startFilePos": 106,
-                  "endLine": 7,
-                  "endTokenPos": 45,
-                  "endFilePos": 107,
-                  "rawValue": "10",
-                  "kind": 10
-                },
-                "value": 10
-              },
-              "byRef": false,
-              "unpack": false
+              "kind": "simple_parameter",
+              "children": [
+                {
+                  "kind": "variable_name",
+                  "children": [
+                    {
+                      "kind": "name",
+                      "text": "n"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "compound_statement",
+          "children": [
+            {
+              "kind": "return_statement",
+              "children": [
+                {
+                  "kind": "anonymous_function_creation_expression",
+                  "children": [
+                    {
+                      "kind": "formal_parameters",
+                      "children": [
+                        {
+                          "kind": "simple_parameter",
+                          "children": [
+                            {
+                              "kind": "variable_name",
+                              "children": [
+                                {
+                                  "kind": "name",
+                                  "text": "x"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "anonymous_function_use_clause",
+                      "children": [
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "n"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "compound_statement",
+                      "children": [
+                        {
+                          "kind": "return_statement",
+                          "children": [
+                            {
+                              "kind": "binary_expression",
+                              "children": [
+                                {
+                                  "kind": "variable_name",
+                                  "children": [
+                                    {
+                                      "kind": "name",
+                                      "text": "x"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "variable_name",
+                                  "children": [
+                                    {
+                                      "kind": "name",
+                                      "text": "n"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }
-      }
+      ]
     },
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 8,
-        "startTokenPos": 49,
-        "startFilePos": 111,
-        "endLine": 8,
-        "endTokenPos": 83,
-        "endFilePos": 189
-      },
-      "exprs": [
+      "kind": "expression_statement",
+      "children": [
         {
-          "nodeType": "Expr_Ternary",
-          "attributes": {
-            "startLine": 8,
-            "startTokenPos": 52,
-            "startFilePos": 117,
-            "endLine": 8,
-            "endTokenPos": 78,
-            "endFilePos": 178
-          },
-          "cond": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 8,
-              "startTokenPos": 52,
-              "startFilePos": 117,
-              "endLine": 8,
-              "endTokenPos": 58,
-              "endFilePos": 135
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "add10"
+                }
+              ]
             },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 8,
-                "startTokenPos": 52,
-                "startFilePos": 117,
-                "endLine": 8,
-                "endTokenPos": 52,
-                "endFilePos": 124
-              },
-              "name": "is_float"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 8,
-                  "startTokenPos": 54,
-                  "startFilePos": 126,
-                  "endLine": 8,
-                  "endTokenPos": 57,
-                  "endFilePos": 134
+            {
+              "kind": "function_call_expression",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "makeAdder"
                 },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_FuncCall",
-                  "attributes": {
-                    "startLine": 8,
-                    "startTokenPos": 54,
-                    "startFilePos": 126,
-                    "endLine": 8,
-                    "endTokenPos": 57,
-                    "endFilePos": 134
-                  },
-                  "name": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 8,
-                      "startTokenPos": 54,
-                      "startFilePos": 126,
-                      "endLine": 8,
-                      "endTokenPos": 54,
-                      "endFilePos": 131
-                    },
-                    "name": "add10"
-                  },
-                  "args": [
+                {
+                  "kind": "arguments",
+                  "children": [
                     {
-                      "nodeType": "Arg",
-                      "attributes": {
-                        "startLine": 8,
-                        "startTokenPos": 56,
-                        "startFilePos": 133,
-                        "endLine": 8,
-                        "endTokenPos": 56,
-                        "endFilePos": 133
-                      },
-                      "name": null,
-                      "value": {
-                        "nodeType": "Scalar_Int",
-                        "attributes": {
-                          "startLine": 8,
-                          "startTokenPos": 56,
-                          "startFilePos": 133,
-                          "endLine": 8,
-                          "endTokenPos": 56,
-                          "endFilePos": 133,
-                          "rawValue": "7",
-                          "kind": 10
-                        },
-                        "value": 7
-                      },
-                      "byRef": false,
-                      "unpack": false
+                      "kind": "argument",
+                      "children": [
+                        {
+                          "kind": "integer",
+                          "text": "10"
+                        }
+                      ]
                     }
                   ]
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "if": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 8,
-              "startTokenPos": 62,
-              "startFilePos": 139,
-              "endLine": 8,
-              "endTokenPos": 71,
-              "endFilePos": 166
-            },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 8,
-                "startTokenPos": 62,
-                "startFilePos": 139,
-                "endLine": 8,
-                "endTokenPos": 62,
-                "endFilePos": 149
-              },
-              "name": "json_encode"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 8,
-                  "startTokenPos": 64,
-                  "startFilePos": 151,
-                  "endLine": 8,
-                  "endTokenPos": 67,
-                  "endFilePos": 159
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_FuncCall",
-                  "attributes": {
-                    "startLine": 8,
-                    "startTokenPos": 64,
-                    "startFilePos": 151,
-                    "endLine": 8,
-                    "endTokenPos": 67,
-                    "endFilePos": 159
-                  },
-                  "name": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 8,
-                      "startTokenPos": 64,
-                      "startFilePos": 151,
-                      "endLine": 8,
-                      "endTokenPos": 64,
-                      "endFilePos": 156
-                    },
-                    "name": "add10"
-                  },
-                  "args": [
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "echo_statement",
+      "children": [
+        {
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "parenthesized_expression",
+              "children": [
+                {
+                  "kind": "conditional_expression",
+                  "children": [
                     {
-                      "nodeType": "Arg",
-                      "attributes": {
-                        "startLine": 8,
-                        "startTokenPos": 66,
-                        "startFilePos": 158,
-                        "endLine": 8,
-                        "endTokenPos": 66,
-                        "endFilePos": 158
-                      },
-                      "name": null,
-                      "value": {
-                        "nodeType": "Scalar_Int",
-                        "attributes": {
-                          "startLine": 8,
-                          "startTokenPos": 66,
-                          "startFilePos": 158,
-                          "endLine": 8,
-                          "endTokenPos": 66,
-                          "endFilePos": 158,
-                          "rawValue": "7",
-                          "kind": 10
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "is_float"
                         },
-                        "value": 7
-                      },
-                      "byRef": false,
-                      "unpack": false
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "function_call_expression",
+                                  "children": [
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "add10"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "arguments",
+                                      "children": [
+                                        {
+                                          "kind": "argument",
+                                          "children": [
+                                            {
+                                              "kind": "integer",
+                                              "text": "7"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "json_encode"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "function_call_expression",
+                                  "children": [
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "add10"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "arguments",
+                                      "children": [
+                                        {
+                                          "kind": "argument",
+                                          "children": [
+                                            {
+                                              "kind": "integer",
+                                              "text": "7"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "integer",
+                                  "text": "1344"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "add10"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "integer",
+                                  "text": "7"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
-                },
-                "byRef": false,
-                "unpack": false
-              },
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 8,
-                  "startTokenPos": 70,
-                  "startFilePos": 162,
-                  "endLine": 8,
-                  "endTokenPos": 70,
-                  "endFilePos": 165
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 8,
-                    "startTokenPos": 70,
-                    "startFilePos": 162,
-                    "endLine": 8,
-                    "endTokenPos": 70,
-                    "endFilePos": 165,
-                    "rawValue": "1344",
-                    "kind": 10
-                  },
-                  "value": 1344
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "else": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 8,
-              "startTokenPos": 75,
-              "startFilePos": 170,
-              "endLine": 8,
-              "endTokenPos": 78,
-              "endFilePos": 178
+                }
+              ]
             },
-            "name": {
-              "nodeType": "Expr_Variable",
-              "attributes": {
-                "startLine": 8,
-                "startTokenPos": 75,
-                "startFilePos": 170,
-                "endLine": 8,
-                "endTokenPos": 75,
-                "endFilePos": 175
-              },
-              "name": "add10"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 8,
-                  "startTokenPos": 77,
-                  "startFilePos": 177,
-                  "endLine": 8,
-                  "endTokenPos": 77,
-                  "endFilePos": 177
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 8,
-                    "startTokenPos": 77,
-                    "startFilePos": 177,
-                    "endLine": 8,
-                    "endTokenPos": 77,
-                    "endFilePos": 177,
-                    "rawValue": "7",
-                    "kind": 10
-                  },
-                  "value": 7
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          }
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 8,
-            "startTokenPos": 82,
-            "startFilePos": 182,
-            "endLine": 8,
-            "endTokenPos": 82,
-            "endFilePos": 188
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 8,
-              "startTokenPos": 82,
-              "startFilePos": 182,
-              "endLine": 8,
-              "endTokenPos": 82,
-              "endFilePos": 188
-            },
-            "name": "PHP_EOL"
-          }
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
+            }
+          ]
         }
       ]
     }

--- a/tests/json-ast/x/php/count_builtin.php.json
+++ b/tests/json-ast/x/php/count_builtin.php.json
@@ -1,566 +1,226 @@
 {
-  "root": [
+  "statements": [
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 2,
-        "startTokenPos": 1,
-        "startFilePos": 6,
-        "endLine": 2,
-        "endTokenPos": 59,
-        "endFilePos": 105
-      },
-      "exprs": [
+      "kind": "echo_statement",
+      "children": [
         {
-          "nodeType": "Expr_Ternary",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 4,
-            "startFilePos": 12,
-            "endLine": 2,
-            "endTokenPos": 54,
-            "endFilePos": 94
-          },
-          "cond": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 4,
-              "startFilePos": 12,
-              "endLine": 2,
-              "endTokenPos": 18,
-              "endFilePos": 37
-            },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 4,
-                "startFilePos": 12,
-                "endLine": 2,
-                "endTokenPos": 4,
-                "endFilePos": 19
-              },
-              "name": "is_float"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 6,
-                  "startFilePos": 21,
-                  "endLine": 2,
-                  "endTokenPos": 17,
-                  "endFilePos": 36
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_FuncCall",
-                  "attributes": {
-                    "startLine": 2,
-                    "startTokenPos": 6,
-                    "startFilePos": 21,
-                    "endLine": 2,
-                    "endTokenPos": 17,
-                    "endFilePos": 36
-                  },
-                  "name": {
-                    "nodeType": "Name",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 6,
-                      "startFilePos": 21,
-                      "endLine": 2,
-                      "endTokenPos": 6,
-                      "endFilePos": 25
-                    },
-                    "name": "count"
-                  },
-                  "args": [
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "parenthesized_expression",
+              "children": [
+                {
+                  "kind": "conditional_expression",
+                  "children": [
                     {
-                      "nodeType": "Arg",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 8,
-                        "startFilePos": 27,
-                        "endLine": 2,
-                        "endTokenPos": 16,
-                        "endFilePos": 35
-                      },
-                      "name": null,
-                      "value": {
-                        "nodeType": "Expr_Array",
-                        "attributes": {
-                          "startLine": 2,
-                          "startTokenPos": 8,
-                          "startFilePos": 27,
-                          "endLine": 2,
-                          "endTokenPos": 16,
-                          "endFilePos": 35,
-                          "kind": 2
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "is_float"
                         },
-                        "items": [
-                          {
-                            "nodeType": "ArrayItem",
-                            "attributes": {
-                              "startLine": 2,
-                              "startTokenPos": 9,
-                              "startFilePos": 28,
-                              "endLine": 2,
-                              "endTokenPos": 9,
-                              "endFilePos": 28
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "function_call_expression",
+                                  "children": [
+                                    {
+                                      "kind": "name",
+                                      "text": "count"
+                                    },
+                                    {
+                                      "kind": "arguments",
+                                      "children": [
+                                        {
+                                          "kind": "argument",
+                                          "children": [
+                                            {
+                                              "kind": "array_creation_expression",
+                                              "children": [
+                                                {
+                                                  "kind": "array_element_initializer",
+                                                  "children": [
+                                                    {
+                                                      "kind": "integer",
+                                                      "text": "1"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "array_element_initializer",
+                                                  "children": [
+                                                    {
+                                                      "kind": "integer",
+                                                      "text": "2"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "array_element_initializer",
+                                                  "children": [
+                                                    {
+                                                      "kind": "integer",
+                                                      "text": "3"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "json_encode"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "function_call_expression",
+                                  "children": [
+                                    {
+                                      "kind": "name",
+                                      "text": "count"
+                                    },
+                                    {
+                                      "kind": "arguments",
+                                      "children": [
+                                        {
+                                          "kind": "argument",
+                                          "children": [
+                                            {
+                                              "kind": "array_creation_expression",
+                                              "children": [
+                                                {
+                                                  "kind": "array_element_initializer",
+                                                  "children": [
+                                                    {
+                                                      "kind": "integer",
+                                                      "text": "1"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "array_element_initializer",
+                                                  "children": [
+                                                    {
+                                                      "kind": "integer",
+                                                      "text": "2"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "array_element_initializer",
+                                                  "children": [
+                                                    {
+                                                      "kind": "integer",
+                                                      "text": "3"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
                             },
-                            "key": null,
-                            "value": {
-                              "nodeType": "Scalar_Int",
-                              "attributes": {
-                                "startLine": 2,
-                                "startTokenPos": 9,
-                                "startFilePos": 28,
-                                "endLine": 2,
-                                "endTokenPos": 9,
-                                "endFilePos": 28,
-                                "rawValue": "1",
-                                "kind": 10
-                              },
-                              "value": 1
-                            },
-                            "byRef": false,
-                            "unpack": false
-                          },
-                          {
-                            "nodeType": "ArrayItem",
-                            "attributes": {
-                              "startLine": 2,
-                              "startTokenPos": 12,
-                              "startFilePos": 31,
-                              "endLine": 2,
-                              "endTokenPos": 12,
-                              "endFilePos": 31
-                            },
-                            "key": null,
-                            "value": {
-                              "nodeType": "Scalar_Int",
-                              "attributes": {
-                                "startLine": 2,
-                                "startTokenPos": 12,
-                                "startFilePos": 31,
-                                "endLine": 2,
-                                "endTokenPos": 12,
-                                "endFilePos": 31,
-                                "rawValue": "2",
-                                "kind": 10
-                              },
-                              "value": 2
-                            },
-                            "byRef": false,
-                            "unpack": false
-                          },
-                          {
-                            "nodeType": "ArrayItem",
-                            "attributes": {
-                              "startLine": 2,
-                              "startTokenPos": 15,
-                              "startFilePos": 34,
-                              "endLine": 2,
-                              "endTokenPos": 15,
-                              "endFilePos": 34
-                            },
-                            "key": null,
-                            "value": {
-                              "nodeType": "Scalar_Int",
-                              "attributes": {
-                                "startLine": 2,
-                                "startTokenPos": 15,
-                                "startFilePos": 34,
-                                "endLine": 2,
-                                "endTokenPos": 15,
-                                "endFilePos": 34,
-                                "rawValue": "3",
-                                "kind": 10
-                              },
-                              "value": 3
-                            },
-                            "byRef": false,
-                            "unpack": false
-                          }
-                        ]
-                      },
-                      "byRef": false,
-                      "unpack": false
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "integer",
+                                  "text": "1344"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "function_call_expression",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "count"
+                        },
+                        {
+                          "kind": "arguments",
+                          "children": [
+                            {
+                              "kind": "argument",
+                              "children": [
+                                {
+                                  "kind": "array_creation_expression",
+                                  "children": [
+                                    {
+                                      "kind": "array_element_initializer",
+                                      "children": [
+                                        {
+                                          "kind": "integer",
+                                          "text": "1"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "array_element_initializer",
+                                      "children": [
+                                        {
+                                          "kind": "integer",
+                                          "text": "2"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "array_element_initializer",
+                                      "children": [
+                                        {
+                                          "kind": "integer",
+                                          "text": "3"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "if": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 22,
-              "startFilePos": 41,
-              "endLine": 2,
-              "endTokenPos": 39,
-              "endFilePos": 75
+                }
+              ]
             },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 22,
-                "startFilePos": 41,
-                "endLine": 2,
-                "endTokenPos": 22,
-                "endFilePos": 51
-              },
-              "name": "json_encode"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 24,
-                  "startFilePos": 53,
-                  "endLine": 2,
-                  "endTokenPos": 35,
-                  "endFilePos": 68
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_FuncCall",
-                  "attributes": {
-                    "startLine": 2,
-                    "startTokenPos": 24,
-                    "startFilePos": 53,
-                    "endLine": 2,
-                    "endTokenPos": 35,
-                    "endFilePos": 68
-                  },
-                  "name": {
-                    "nodeType": "Name",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 24,
-                      "startFilePos": 53,
-                      "endLine": 2,
-                      "endTokenPos": 24,
-                      "endFilePos": 57
-                    },
-                    "name": "count"
-                  },
-                  "args": [
-                    {
-                      "nodeType": "Arg",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 26,
-                        "startFilePos": 59,
-                        "endLine": 2,
-                        "endTokenPos": 34,
-                        "endFilePos": 67
-                      },
-                      "name": null,
-                      "value": {
-                        "nodeType": "Expr_Array",
-                        "attributes": {
-                          "startLine": 2,
-                          "startTokenPos": 26,
-                          "startFilePos": 59,
-                          "endLine": 2,
-                          "endTokenPos": 34,
-                          "endFilePos": 67,
-                          "kind": 2
-                        },
-                        "items": [
-                          {
-                            "nodeType": "ArrayItem",
-                            "attributes": {
-                              "startLine": 2,
-                              "startTokenPos": 27,
-                              "startFilePos": 60,
-                              "endLine": 2,
-                              "endTokenPos": 27,
-                              "endFilePos": 60
-                            },
-                            "key": null,
-                            "value": {
-                              "nodeType": "Scalar_Int",
-                              "attributes": {
-                                "startLine": 2,
-                                "startTokenPos": 27,
-                                "startFilePos": 60,
-                                "endLine": 2,
-                                "endTokenPos": 27,
-                                "endFilePos": 60,
-                                "rawValue": "1",
-                                "kind": 10
-                              },
-                              "value": 1
-                            },
-                            "byRef": false,
-                            "unpack": false
-                          },
-                          {
-                            "nodeType": "ArrayItem",
-                            "attributes": {
-                              "startLine": 2,
-                              "startTokenPos": 30,
-                              "startFilePos": 63,
-                              "endLine": 2,
-                              "endTokenPos": 30,
-                              "endFilePos": 63
-                            },
-                            "key": null,
-                            "value": {
-                              "nodeType": "Scalar_Int",
-                              "attributes": {
-                                "startLine": 2,
-                                "startTokenPos": 30,
-                                "startFilePos": 63,
-                                "endLine": 2,
-                                "endTokenPos": 30,
-                                "endFilePos": 63,
-                                "rawValue": "2",
-                                "kind": 10
-                              },
-                              "value": 2
-                            },
-                            "byRef": false,
-                            "unpack": false
-                          },
-                          {
-                            "nodeType": "ArrayItem",
-                            "attributes": {
-                              "startLine": 2,
-                              "startTokenPos": 33,
-                              "startFilePos": 66,
-                              "endLine": 2,
-                              "endTokenPos": 33,
-                              "endFilePos": 66
-                            },
-                            "key": null,
-                            "value": {
-                              "nodeType": "Scalar_Int",
-                              "attributes": {
-                                "startLine": 2,
-                                "startTokenPos": 33,
-                                "startFilePos": 66,
-                                "endLine": 2,
-                                "endTokenPos": 33,
-                                "endFilePos": 66,
-                                "rawValue": "3",
-                                "kind": 10
-                              },
-                              "value": 3
-                            },
-                            "byRef": false,
-                            "unpack": false
-                          }
-                        ]
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    }
-                  ]
-                },
-                "byRef": false,
-                "unpack": false
-              },
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 38,
-                  "startFilePos": 71,
-                  "endLine": 2,
-                  "endTokenPos": 38,
-                  "endFilePos": 74
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 2,
-                    "startTokenPos": 38,
-                    "startFilePos": 71,
-                    "endLine": 2,
-                    "endTokenPos": 38,
-                    "endFilePos": 74,
-                    "rawValue": "1344",
-                    "kind": 10
-                  },
-                  "value": 1344
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "else": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 43,
-              "startFilePos": 79,
-              "endLine": 2,
-              "endTokenPos": 54,
-              "endFilePos": 94
-            },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 43,
-                "startFilePos": 79,
-                "endLine": 2,
-                "endTokenPos": 43,
-                "endFilePos": 83
-              },
-              "name": "count"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 45,
-                  "startFilePos": 85,
-                  "endLine": 2,
-                  "endTokenPos": 53,
-                  "endFilePos": 93
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_Array",
-                  "attributes": {
-                    "startLine": 2,
-                    "startTokenPos": 45,
-                    "startFilePos": 85,
-                    "endLine": 2,
-                    "endTokenPos": 53,
-                    "endFilePos": 93,
-                    "kind": 2
-                  },
-                  "items": [
-                    {
-                      "nodeType": "ArrayItem",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 46,
-                        "startFilePos": 86,
-                        "endLine": 2,
-                        "endTokenPos": 46,
-                        "endFilePos": 86
-                      },
-                      "key": null,
-                      "value": {
-                        "nodeType": "Scalar_Int",
-                        "attributes": {
-                          "startLine": 2,
-                          "startTokenPos": 46,
-                          "startFilePos": 86,
-                          "endLine": 2,
-                          "endTokenPos": 46,
-                          "endFilePos": 86,
-                          "rawValue": "1",
-                          "kind": 10
-                        },
-                        "value": 1
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "nodeType": "ArrayItem",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 49,
-                        "startFilePos": 89,
-                        "endLine": 2,
-                        "endTokenPos": 49,
-                        "endFilePos": 89
-                      },
-                      "key": null,
-                      "value": {
-                        "nodeType": "Scalar_Int",
-                        "attributes": {
-                          "startLine": 2,
-                          "startTokenPos": 49,
-                          "startFilePos": 89,
-                          "endLine": 2,
-                          "endTokenPos": 49,
-                          "endFilePos": 89,
-                          "rawValue": "2",
-                          "kind": 10
-                        },
-                        "value": 2
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "nodeType": "ArrayItem",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 52,
-                        "startFilePos": 92,
-                        "endLine": 2,
-                        "endTokenPos": 52,
-                        "endFilePos": 92
-                      },
-                      "key": null,
-                      "value": {
-                        "nodeType": "Scalar_Int",
-                        "attributes": {
-                          "startLine": 2,
-                          "startTokenPos": 52,
-                          "startFilePos": 92,
-                          "endLine": 2,
-                          "endTokenPos": 52,
-                          "endFilePos": 92,
-                          "rawValue": "3",
-                          "kind": 10
-                        },
-                        "value": 3
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    }
-                  ]
-                },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          }
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 58,
-            "startFilePos": 98,
-            "endLine": 2,
-            "endTokenPos": 58,
-            "endFilePos": 104
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 58,
-              "startFilePos": 98,
-              "endLine": 2,
-              "endTokenPos": 58,
-              "endFilePos": 104
-            },
-            "name": "PHP_EOL"
-          }
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
+            }
+          ]
         }
       ]
     }

--- a/tests/json-ast/x/php/cross_join_filter.php.json
+++ b/tests/json-ast/x/php/cross_join_filter.php.json
@@ -1,1193 +1,622 @@
 {
-  "root": [
+  "statements": [
     {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 2,
-        "startTokenPos": 1,
-        "startFilePos": 6,
-        "endLine": 2,
-        "endTokenPos": 14,
-        "endFilePos": 23
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 2,
-          "startTokenPos": 1,
-          "startFilePos": 6,
-          "endLine": 2,
-          "endTokenPos": 13,
-          "endFilePos": 22
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 1,
-            "startFilePos": 6,
-            "endLine": 2,
-            "endTokenPos": 1,
-            "endFilePos": 10
-          },
-          "name": "nums"
-        },
-        "expr": {
-          "nodeType": "Expr_Array",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 5,
-            "startFilePos": 14,
-            "endLine": 2,
-            "endTokenPos": 13,
-            "endFilePos": 22,
-            "kind": 2
-          },
-          "items": [
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 6,
-                "startFilePos": 15,
-                "endLine": 2,
-                "endTokenPos": 6,
-                "endFilePos": 15
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 6,
-                  "startFilePos": 15,
-                  "endLine": 2,
-                  "endTokenPos": 6,
-                  "endFilePos": 15,
-                  "rawValue": "1",
-                  "kind": 10
-                },
-                "value": 1
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 9,
-                "startFilePos": 18,
-                "endLine": 2,
-                "endTokenPos": 9,
-                "endFilePos": 18
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 9,
-                  "startFilePos": 18,
-                  "endLine": 2,
-                  "endTokenPos": 9,
-                  "endFilePos": 18,
-                  "rawValue": "2",
-                  "kind": 10
-                },
-                "value": 2
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 12,
-                "startFilePos": 21,
-                "endLine": 2,
-                "endTokenPos": 12,
-                "endFilePos": 21
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 12,
-                  "startFilePos": 21,
-                  "endLine": 2,
-                  "endTokenPos": 12,
-                  "endFilePos": 21,
-                  "rawValue": "3",
-                  "kind": 10
-                },
-                "value": 3
-              },
-              "byRef": false,
-              "unpack": false
-            }
-          ]
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 3,
-        "startTokenPos": 16,
-        "startFilePos": 25,
-        "endLine": 3,
-        "endTokenPos": 26,
-        "endFilePos": 46
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 3,
-          "startTokenPos": 16,
-          "startFilePos": 25,
-          "endLine": 3,
-          "endTokenPos": 25,
-          "endFilePos": 45
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 16,
-            "startFilePos": 25,
-            "endLine": 3,
-            "endTokenPos": 16,
-            "endFilePos": 32
-          },
-          "name": "letters"
-        },
-        "expr": {
-          "nodeType": "Expr_Array",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 20,
-            "startFilePos": 36,
-            "endLine": 3,
-            "endTokenPos": 25,
-            "endFilePos": 45,
-            "kind": 2
-          },
-          "items": [
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 21,
-                "startFilePos": 37,
-                "endLine": 3,
-                "endTokenPos": 21,
-                "endFilePos": 39
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_String",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 21,
-                  "startFilePos": 37,
-                  "endLine": 3,
-                  "endTokenPos": 21,
-                  "endFilePos": 39,
-                  "kind": 2,
-                  "rawValue": "\"A\""
-                },
-                "value": "A"
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 24,
-                "startFilePos": 42,
-                "endLine": 3,
-                "endTokenPos": 24,
-                "endFilePos": 44
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_String",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 24,
-                  "startFilePos": 42,
-                  "endLine": 3,
-                  "endTokenPos": 24,
-                  "endFilePos": 44,
-                  "kind": 2,
-                  "rawValue": "\"B\""
-                },
-                "value": "B"
-              },
-              "byRef": false,
-              "unpack": false
-            }
-          ]
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 4,
-        "startTokenPos": 28,
-        "startFilePos": 48,
-        "endLine": 4,
-        "endTokenPos": 34,
-        "endFilePos": 59
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 4,
-          "startTokenPos": 28,
-          "startFilePos": 48,
-          "endLine": 4,
-          "endTokenPos": 33,
-          "endFilePos": 58
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 4,
-            "startTokenPos": 28,
-            "startFilePos": 48,
-            "endLine": 4,
-            "endTokenPos": 28,
-            "endFilePos": 53
-          },
-          "name": "pairs"
-        },
-        "expr": {
-          "nodeType": "Expr_Array",
-          "attributes": {
-            "startLine": 4,
-            "startTokenPos": 32,
-            "startFilePos": 57,
-            "endLine": 4,
-            "endTokenPos": 33,
-            "endFilePos": 58,
-            "kind": 2
-          },
-          "items": []
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Foreach",
-      "attributes": {
-        "startLine": 5,
-        "startTokenPos": 36,
-        "startFilePos": 61,
-        "endLine": 11,
-        "endTokenPos": 102,
-        "endFilePos": 188
-      },
-      "expr": {
-        "nodeType": "Expr_Variable",
-        "attributes": {
-          "startLine": 5,
-          "startTokenPos": 39,
-          "startFilePos": 70,
-          "endLine": 5,
-          "endTokenPos": 39,
-          "endFilePos": 74
-        },
-        "name": "nums"
-      },
-      "keyVar": null,
-      "byRef": false,
-      "valueVar": {
-        "nodeType": "Expr_Variable",
-        "attributes": {
-          "startLine": 5,
-          "startTokenPos": 43,
-          "startFilePos": 79,
-          "endLine": 5,
-          "endTokenPos": 43,
-          "endFilePos": 80
-        },
-        "name": "n"
-      },
-      "stmts": [
+      "kind": "expression_statement",
+      "children": [
         {
-          "nodeType": "Stmt_Foreach",
-          "attributes": {
-            "startLine": 6,
-            "startTokenPos": 48,
-            "startFilePos": 87,
-            "endLine": 10,
-            "endTokenPos": 100,
-            "endFilePos": 186
-          },
-          "expr": {
-            "nodeType": "Expr_Variable",
-            "attributes": {
-              "startLine": 6,
-              "startTokenPos": 51,
-              "startFilePos": 96,
-              "endLine": 6,
-              "endTokenPos": 51,
-              "endFilePos": 103
-            },
-            "name": "letters"
-          },
-          "keyVar": null,
-          "byRef": false,
-          "valueVar": {
-            "nodeType": "Expr_Variable",
-            "attributes": {
-              "startLine": 6,
-              "startTokenPos": 55,
-              "startFilePos": 108,
-              "endLine": 6,
-              "endTokenPos": 55,
-              "endFilePos": 109
-            },
-            "name": "l"
-          },
-          "stmts": [
+          "kind": "assignment_expression",
+          "children": [
             {
-              "nodeType": "Stmt_If",
-              "attributes": {
-                "startLine": 7,
-                "startTokenPos": 60,
-                "startFilePos": 118,
-                "endLine": 9,
-                "endTokenPos": 98,
-                "endFilePos": 182
-              },
-              "cond": {
-                "nodeType": "Expr_BinaryOp_Equal",
-                "attributes": {
-                  "startLine": 7,
-                  "startTokenPos": 63,
-                  "startFilePos": 122,
-                  "endLine": 7,
-                  "endTokenPos": 71,
-                  "endFilePos": 132
-                },
-                "left": {
-                  "nodeType": "Expr_BinaryOp_Mod",
-                  "attributes": {
-                    "startLine": 7,
-                    "startTokenPos": 63,
-                    "startFilePos": 122,
-                    "endLine": 7,
-                    "endTokenPos": 67,
-                    "endFilePos": 127
-                  },
-                  "left": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 7,
-                      "startTokenPos": 63,
-                      "startFilePos": 122,
-                      "endLine": 7,
-                      "endTokenPos": 63,
-                      "endFilePos": 123
-                    },
-                    "name": "n"
-                  },
-                  "right": {
-                    "nodeType": "Scalar_Int",
-                    "attributes": {
-                      "startLine": 7,
-                      "startTokenPos": 67,
-                      "startFilePos": 127,
-                      "endLine": 7,
-                      "endTokenPos": 67,
-                      "endFilePos": 127,
-                      "rawValue": "2",
-                      "kind": 10
-                    },
-                    "value": 2
-                  }
-                },
-                "right": {
-                  "nodeType": "Scalar_Int",
-                  "attributes": {
-                    "startLine": 7,
-                    "startTokenPos": 71,
-                    "startFilePos": 132,
-                    "endLine": 7,
-                    "endTokenPos": 71,
-                    "endFilePos": 132,
-                    "rawValue": "0",
-                    "kind": 10
-                  },
-                  "value": 0
-                }
-              },
-              "stmts": [
+              "kind": "variable_name",
+              "children": [
                 {
-                  "nodeType": "Stmt_Expression",
-                  "attributes": {
-                    "startLine": 8,
-                    "startTokenPos": 76,
-                    "startFilePos": 143,
-                    "endLine": 8,
-                    "endTokenPos": 96,
-                    "endFilePos": 176
-                  },
-                  "expr": {
-                    "nodeType": "Expr_Assign",
-                    "attributes": {
-                      "startLine": 8,
-                      "startTokenPos": 76,
-                      "startFilePos": 143,
-                      "endLine": 8,
-                      "endTokenPos": 95,
-                      "endFilePos": 175
-                    },
-                    "var": {
-                      "nodeType": "Expr_ArrayDimFetch",
-                      "attributes": {
-                        "startLine": 8,
-                        "startTokenPos": 76,
-                        "startFilePos": 143,
-                        "endLine": 8,
-                        "endTokenPos": 78,
-                        "endFilePos": 150
-                      },
-                      "var": {
-                        "nodeType": "Expr_Variable",
-                        "attributes": {
-                          "startLine": 8,
-                          "startTokenPos": 76,
-                          "startFilePos": 143,
-                          "endLine": 8,
-                          "endTokenPos": 76,
-                          "endFilePos": 148
-                        },
-                        "name": "pairs"
-                      },
-                      "dim": null
-                    },
-                    "expr": {
-                      "nodeType": "Expr_Array",
-                      "attributes": {
-                        "startLine": 8,
-                        "startTokenPos": 82,
-                        "startFilePos": 154,
-                        "endLine": 8,
-                        "endTokenPos": 95,
-                        "endFilePos": 175,
-                        "kind": 2
-                      },
-                      "items": [
+                  "kind": "name",
+                  "text": "nums"
+                }
+              ]
+            },
+            {
+              "kind": "array_creation_expression",
+              "children": [
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "integer",
+                      "text": "1"
+                    }
+                  ]
+                },
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "integer",
+                      "text": "2"
+                    }
+                  ]
+                },
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "integer",
+                      "text": "3"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "expression_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "letters"
+                }
+              ]
+            },
+            {
+              "kind": "array_creation_expression",
+              "children": [
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
                         {
-                          "nodeType": "ArrayItem",
-                          "attributes": {
-                            "startLine": 8,
-                            "startTokenPos": 83,
-                            "startFilePos": 155,
-                            "endLine": 8,
-                            "endTokenPos": 87,
-                            "endFilePos": 163
-                          },
-                          "key": {
-                            "nodeType": "Scalar_String",
-                            "attributes": {
-                              "startLine": 8,
-                              "startTokenPos": 83,
-                              "startFilePos": 155,
-                              "endLine": 8,
-                              "endTokenPos": 83,
-                              "endFilePos": 157,
-                              "kind": 2,
-                              "rawValue": "\"n\""
-                            },
-                            "value": "n"
-                          },
-                          "value": {
-                            "nodeType": "Expr_Variable",
-                            "attributes": {
-                              "startLine": 8,
-                              "startTokenPos": 87,
-                              "startFilePos": 162,
-                              "endLine": 8,
-                              "endTokenPos": 87,
-                              "endFilePos": 163
-                            },
-                            "name": "n"
-                          },
-                          "byRef": false,
-                          "unpack": false
-                        },
-                        {
-                          "nodeType": "ArrayItem",
-                          "attributes": {
-                            "startLine": 8,
-                            "startTokenPos": 90,
-                            "startFilePos": 166,
-                            "endLine": 8,
-                            "endTokenPos": 94,
-                            "endFilePos": 174
-                          },
-                          "key": {
-                            "nodeType": "Scalar_String",
-                            "attributes": {
-                              "startLine": 8,
-                              "startTokenPos": 90,
-                              "startFilePos": 166,
-                              "endLine": 8,
-                              "endTokenPos": 90,
-                              "endFilePos": 168,
-                              "kind": 2,
-                              "rawValue": "\"l\""
-                            },
-                            "value": "l"
-                          },
-                          "value": {
-                            "nodeType": "Expr_Variable",
-                            "attributes": {
-                              "startLine": 8,
-                              "startTokenPos": 94,
-                              "startFilePos": 173,
-                              "endLine": 8,
-                              "endTokenPos": 94,
-                              "endFilePos": 174
-                            },
-                            "name": "l"
-                          },
-                          "byRef": false,
-                          "unpack": false
+                          "kind": "string_content",
+                          "text": "A"
                         }
                       ]
                     }
-                  }
+                  ]
+                },
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "B"
+                        }
+                      ]
+                    }
+                  ]
                 }
-              ],
-              "elseifs": [],
-              "else": null
+              ]
             }
           ]
         }
       ]
     },
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 13,
-        "startTokenPos": 104,
-        "startFilePos": 191,
-        "endLine": 13,
-        "endTokenPos": 110,
-        "endFilePos": 225
-      },
-      "exprs": [
+      "kind": "expression_statement",
+      "children": [
         {
-          "nodeType": "Scalar_String",
-          "attributes": {
-            "startLine": 13,
-            "startTokenPos": 106,
-            "startFilePos": 196,
-            "endLine": 13,
-            "endTokenPos": 106,
-            "endFilePos": 215,
-            "kind": 2,
-            "rawValue": "\"--- Even pairs ---\""
-          },
-          "value": "--- Even pairs ---"
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 13,
-            "startTokenPos": 109,
-            "startFilePos": 218,
-            "endLine": 13,
-            "endTokenPos": 109,
-            "endFilePos": 224
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 13,
-              "startTokenPos": 109,
-              "startFilePos": 218,
-              "endLine": 13,
-              "endTokenPos": 109,
-              "endFilePos": 224
-            },
-            "name": "PHP_EOL"
-          }
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "pairs"
+                }
+              ]
+            }
+          ]
         }
       ]
     },
     {
-      "nodeType": "Stmt_Foreach",
-      "attributes": {
-        "startLine": 14,
-        "startTokenPos": 112,
-        "startFilePos": 227,
-        "endLine": 16,
-        "endTokenPos": 196,
-        "endFilePos": 395
-      },
-      "expr": {
-        "nodeType": "Expr_Variable",
-        "attributes": {
-          "startLine": 14,
-          "startTokenPos": 115,
-          "startFilePos": 236,
-          "endLine": 14,
-          "endTokenPos": 115,
-          "endFilePos": 241
-        },
-        "name": "pairs"
-      },
-      "keyVar": null,
-      "byRef": false,
-      "valueVar": {
-        "nodeType": "Expr_Variable",
-        "attributes": {
-          "startLine": 14,
-          "startTokenPos": 119,
-          "startFilePos": 246,
-          "endLine": 14,
-          "endTokenPos": 119,
-          "endFilePos": 247
-        },
-        "name": "p"
-      },
-      "stmts": [
+      "kind": "foreach_statement",
+      "children": [
         {
-          "nodeType": "Stmt_Echo",
-          "attributes": {
-            "startLine": 15,
-            "startTokenPos": 124,
-            "startFilePos": 254,
-            "endLine": 15,
-            "endTokenPos": 194,
-            "endFilePos": 393
-          },
-          "exprs": [
+          "kind": "variable_name",
+          "children": [
             {
-              "nodeType": "Expr_BinaryOp_Concat",
-              "attributes": {
-                "startLine": 15,
-                "startTokenPos": 126,
-                "startFilePos": 259,
-                "endLine": 15,
-                "endTokenPos": 190,
-                "endFilePos": 383
-              },
-              "left": {
-                "nodeType": "Expr_BinaryOp_Concat",
-                "attributes": {
-                  "startLine": 15,
-                  "startTokenPos": 126,
-                  "startFilePos": 259,
-                  "endLine": 15,
-                  "endTokenPos": 158,
-                  "endFilePos": 322
-                },
-                "left": {
-                  "nodeType": "Expr_Ternary",
-                  "attributes": {
-                    "startLine": 15,
-                    "startTokenPos": 127,
-                    "startFilePos": 260,
-                    "endLine": 15,
-                    "endTokenPos": 153,
-                    "endFilePos": 315
-                  },
-                  "cond": {
-                    "nodeType": "Expr_FuncCall",
-                    "attributes": {
-                      "startLine": 15,
-                      "startTokenPos": 127,
-                      "startFilePos": 260,
-                      "endLine": 15,
-                      "endTokenPos": 133,
-                      "endFilePos": 276
-                    },
-                    "name": {
-                      "nodeType": "Name",
-                      "attributes": {
-                        "startLine": 15,
-                        "startTokenPos": 127,
-                        "startFilePos": 260,
-                        "endLine": 15,
-                        "endTokenPos": 127,
-                        "endFilePos": 267
-                      },
-                      "name": "is_float"
-                    },
-                    "args": [
-                      {
-                        "nodeType": "Arg",
-                        "attributes": {
-                          "startLine": 15,
-                          "startTokenPos": 129,
-                          "startFilePos": 269,
-                          "endLine": 15,
-                          "endTokenPos": 132,
-                          "endFilePos": 275
-                        },
-                        "name": null,
-                        "value": {
-                          "nodeType": "Expr_ArrayDimFetch",
-                          "attributes": {
-                            "startLine": 15,
-                            "startTokenPos": 129,
-                            "startFilePos": 269,
-                            "endLine": 15,
-                            "endTokenPos": 132,
-                            "endFilePos": 275
-                          },
-                          "var": {
-                            "nodeType": "Expr_Variable",
-                            "attributes": {
-                              "startLine": 15,
-                              "startTokenPos": 129,
-                              "startFilePos": 269,
-                              "endLine": 15,
-                              "endTokenPos": 129,
-                              "endFilePos": 270
-                            },
-                            "name": "p"
-                          },
-                          "dim": {
-                            "nodeType": "Scalar_String",
-                            "attributes": {
-                              "startLine": 15,
-                              "startTokenPos": 131,
-                              "startFilePos": 272,
-                              "endLine": 15,
-                              "endTokenPos": 131,
-                              "endFilePos": 274,
-                              "kind": 2,
-                              "rawValue": "\"n\""
-                            },
-                            "value": "n"
-                          }
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      }
-                    ]
-                  },
-                  "if": {
-                    "nodeType": "Expr_FuncCall",
-                    "attributes": {
-                      "startLine": 15,
-                      "startTokenPos": 137,
-                      "startFilePos": 280,
-                      "endLine": 15,
-                      "endTokenPos": 146,
-                      "endFilePos": 305
-                    },
-                    "name": {
-                      "nodeType": "Name",
-                      "attributes": {
-                        "startLine": 15,
-                        "startTokenPos": 137,
-                        "startFilePos": 280,
-                        "endLine": 15,
-                        "endTokenPos": 137,
-                        "endFilePos": 290
-                      },
-                      "name": "json_encode"
-                    },
-                    "args": [
-                      {
-                        "nodeType": "Arg",
-                        "attributes": {
-                          "startLine": 15,
-                          "startTokenPos": 139,
-                          "startFilePos": 292,
-                          "endLine": 15,
-                          "endTokenPos": 142,
-                          "endFilePos": 298
-                        },
-                        "name": null,
-                        "value": {
-                          "nodeType": "Expr_ArrayDimFetch",
-                          "attributes": {
-                            "startLine": 15,
-                            "startTokenPos": 139,
-                            "startFilePos": 292,
-                            "endLine": 15,
-                            "endTokenPos": 142,
-                            "endFilePos": 298
-                          },
-                          "var": {
-                            "nodeType": "Expr_Variable",
-                            "attributes": {
-                              "startLine": 15,
-                              "startTokenPos": 139,
-                              "startFilePos": 292,
-                              "endLine": 15,
-                              "endTokenPos": 139,
-                              "endFilePos": 293
-                            },
-                            "name": "p"
-                          },
-                          "dim": {
-                            "nodeType": "Scalar_String",
-                            "attributes": {
-                              "startLine": 15,
-                              "startTokenPos": 141,
-                              "startFilePos": 295,
-                              "endLine": 15,
-                              "endTokenPos": 141,
-                              "endFilePos": 297,
-                              "kind": 2,
-                              "rawValue": "\"n\""
-                            },
-                            "value": "n"
-                          }
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      },
-                      {
-                        "nodeType": "Arg",
-                        "attributes": {
-                          "startLine": 15,
-                          "startTokenPos": 145,
-                          "startFilePos": 301,
-                          "endLine": 15,
-                          "endTokenPos": 145,
-                          "endFilePos": 304
-                        },
-                        "name": null,
-                        "value": {
-                          "nodeType": "Scalar_Int",
-                          "attributes": {
-                            "startLine": 15,
-                            "startTokenPos": 145,
-                            "startFilePos": 301,
-                            "endLine": 15,
-                            "endTokenPos": 145,
-                            "endFilePos": 304,
-                            "rawValue": "1344",
-                            "kind": 10
-                          },
-                          "value": 1344
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      }
-                    ]
-                  },
-                  "else": {
-                    "nodeType": "Expr_ArrayDimFetch",
-                    "attributes": {
-                      "startLine": 15,
-                      "startTokenPos": 150,
-                      "startFilePos": 309,
-                      "endLine": 15,
-                      "endTokenPos": 153,
-                      "endFilePos": 315
-                    },
-                    "var": {
-                      "nodeType": "Expr_Variable",
-                      "attributes": {
-                        "startLine": 15,
-                        "startTokenPos": 150,
-                        "startFilePos": 309,
-                        "endLine": 15,
-                        "endTokenPos": 150,
-                        "endFilePos": 310
-                      },
-                      "name": "p"
-                    },
-                    "dim": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 15,
-                        "startTokenPos": 152,
-                        "startFilePos": 312,
-                        "endLine": 15,
-                        "endTokenPos": 152,
-                        "endFilePos": 314,
-                        "kind": 2,
-                        "rawValue": "\"n\""
-                      },
-                      "value": "n"
-                    }
-                  }
-                },
-                "right": {
-                  "nodeType": "Scalar_String",
-                  "attributes": {
-                    "startLine": 15,
-                    "startTokenPos": 158,
-                    "startFilePos": 320,
-                    "endLine": 15,
-                    "endTokenPos": 158,
-                    "endFilePos": 322,
-                    "kind": 2,
-                    "rawValue": "\" \""
-                  },
-                  "value": " "
-                }
-              },
-              "right": {
-                "nodeType": "Expr_Ternary",
-                "attributes": {
-                  "startLine": 15,
-                  "startTokenPos": 163,
-                  "startFilePos": 327,
-                  "endLine": 15,
-                  "endTokenPos": 189,
-                  "endFilePos": 382
-                },
-                "cond": {
-                  "nodeType": "Expr_FuncCall",
-                  "attributes": {
-                    "startLine": 15,
-                    "startTokenPos": 163,
-                    "startFilePos": 327,
-                    "endLine": 15,
-                    "endTokenPos": 169,
-                    "endFilePos": 343
-                  },
-                  "name": {
-                    "nodeType": "Name",
-                    "attributes": {
-                      "startLine": 15,
-                      "startTokenPos": 163,
-                      "startFilePos": 327,
-                      "endLine": 15,
-                      "endTokenPos": 163,
-                      "endFilePos": 334
-                    },
-                    "name": "is_float"
-                  },
-                  "args": [
+              "kind": "name",
+              "text": "nums"
+            }
+          ]
+        },
+        {
+          "kind": "variable_name",
+          "children": [
+            {
+              "kind": "name",
+              "text": "n"
+            }
+          ]
+        },
+        {
+          "kind": "compound_statement",
+          "children": [
+            {
+              "kind": "foreach_statement",
+              "children": [
+                {
+                  "kind": "variable_name",
+                  "children": [
                     {
-                      "nodeType": "Arg",
-                      "attributes": {
-                        "startLine": 15,
-                        "startTokenPos": 165,
-                        "startFilePos": 336,
-                        "endLine": 15,
-                        "endTokenPos": 168,
-                        "endFilePos": 342
-                      },
-                      "name": null,
-                      "value": {
-                        "nodeType": "Expr_ArrayDimFetch",
-                        "attributes": {
-                          "startLine": 15,
-                          "startTokenPos": 165,
-                          "startFilePos": 336,
-                          "endLine": 15,
-                          "endTokenPos": 168,
-                          "endFilePos": 342
-                        },
-                        "var": {
-                          "nodeType": "Expr_Variable",
-                          "attributes": {
-                            "startLine": 15,
-                            "startTokenPos": 165,
-                            "startFilePos": 336,
-                            "endLine": 15,
-                            "endTokenPos": 165,
-                            "endFilePos": 337
-                          },
-                          "name": "p"
-                        },
-                        "dim": {
-                          "nodeType": "Scalar_String",
-                          "attributes": {
-                            "startLine": 15,
-                            "startTokenPos": 167,
-                            "startFilePos": 339,
-                            "endLine": 15,
-                            "endTokenPos": 167,
-                            "endFilePos": 341,
-                            "kind": 2,
-                            "rawValue": "\"l\""
-                          },
-                          "value": "l"
-                        }
-                      },
-                      "byRef": false,
-                      "unpack": false
+                      "kind": "name",
+                      "text": "letters"
                     }
                   ]
                 },
-                "if": {
-                  "nodeType": "Expr_FuncCall",
-                  "attributes": {
-                    "startLine": 15,
-                    "startTokenPos": 173,
-                    "startFilePos": 347,
-                    "endLine": 15,
-                    "endTokenPos": 182,
-                    "endFilePos": 372
-                  },
-                  "name": {
-                    "nodeType": "Name",
-                    "attributes": {
-                      "startLine": 15,
-                      "startTokenPos": 173,
-                      "startFilePos": 347,
-                      "endLine": 15,
-                      "endTokenPos": 173,
-                      "endFilePos": 357
-                    },
-                    "name": "json_encode"
-                  },
-                  "args": [
+                {
+                  "kind": "variable_name",
+                  "children": [
                     {
-                      "nodeType": "Arg",
-                      "attributes": {
-                        "startLine": 15,
-                        "startTokenPos": 175,
-                        "startFilePos": 359,
-                        "endLine": 15,
-                        "endTokenPos": 178,
-                        "endFilePos": 365
-                      },
-                      "name": null,
-                      "value": {
-                        "nodeType": "Expr_ArrayDimFetch",
-                        "attributes": {
-                          "startLine": 15,
-                          "startTokenPos": 175,
-                          "startFilePos": 359,
-                          "endLine": 15,
-                          "endTokenPos": 178,
-                          "endFilePos": 365
-                        },
-                        "var": {
-                          "nodeType": "Expr_Variable",
-                          "attributes": {
-                            "startLine": 15,
-                            "startTokenPos": 175,
-                            "startFilePos": 359,
-                            "endLine": 15,
-                            "endTokenPos": 175,
-                            "endFilePos": 360
-                          },
-                          "name": "p"
-                        },
-                        "dim": {
-                          "nodeType": "Scalar_String",
-                          "attributes": {
-                            "startLine": 15,
-                            "startTokenPos": 177,
-                            "startFilePos": 362,
-                            "endLine": 15,
-                            "endTokenPos": 177,
-                            "endFilePos": 364,
-                            "kind": 2,
-                            "rawValue": "\"l\""
-                          },
-                          "value": "l"
-                        }
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "nodeType": "Arg",
-                      "attributes": {
-                        "startLine": 15,
-                        "startTokenPos": 181,
-                        "startFilePos": 368,
-                        "endLine": 15,
-                        "endTokenPos": 181,
-                        "endFilePos": 371
-                      },
-                      "name": null,
-                      "value": {
-                        "nodeType": "Scalar_Int",
-                        "attributes": {
-                          "startLine": 15,
-                          "startTokenPos": 181,
-                          "startFilePos": 368,
-                          "endLine": 15,
-                          "endTokenPos": 181,
-                          "endFilePos": 371,
-                          "rawValue": "1344",
-                          "kind": 10
-                        },
-                        "value": 1344
-                      },
-                      "byRef": false,
-                      "unpack": false
+                      "kind": "name",
+                      "text": "l"
                     }
                   ]
                 },
-                "else": {
-                  "nodeType": "Expr_ArrayDimFetch",
-                  "attributes": {
-                    "startLine": 15,
-                    "startTokenPos": 186,
-                    "startFilePos": 376,
-                    "endLine": 15,
-                    "endTokenPos": 189,
-                    "endFilePos": 382
-                  },
-                  "var": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 15,
-                      "startTokenPos": 186,
-                      "startFilePos": 376,
-                      "endLine": 15,
-                      "endTokenPos": 186,
-                      "endFilePos": 377
-                    },
-                    "name": "p"
-                  },
-                  "dim": {
-                    "nodeType": "Scalar_String",
-                    "attributes": {
-                      "startLine": 15,
-                      "startTokenPos": 188,
-                      "startFilePos": 379,
-                      "endLine": 15,
-                      "endTokenPos": 188,
-                      "endFilePos": 381,
-                      "kind": 2,
-                      "rawValue": "\"l\""
-                    },
-                    "value": "l"
-                  }
+                {
+                  "kind": "compound_statement",
+                  "children": [
+                    {
+                      "kind": "if_statement",
+                      "children": [
+                        {
+                          "kind": "parenthesized_expression",
+                          "children": [
+                            {
+                              "kind": "binary_expression",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "n"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "integer",
+                                      "text": "2"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "integer",
+                                  "text": "0"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "compound_statement",
+                          "children": [
+                            {
+                              "kind": "expression_statement",
+                              "children": [
+                                {
+                                  "kind": "assignment_expression",
+                                  "children": [
+                                    {
+                                      "kind": "subscript_expression",
+                                      "children": [
+                                        {
+                                          "kind": "variable_name",
+                                          "children": [
+                                            {
+                                              "kind": "name",
+                                              "text": "pairs"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "array_creation_expression",
+                                      "children": [
+                                        {
+                                          "kind": "array_element_initializer",
+                                          "children": [
+                                            {
+                                              "kind": "encapsed_string",
+                                              "children": [
+                                                {
+                                                  "kind": "string_content",
+                                                  "text": "n"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "variable_name",
+                                              "children": [
+                                                {
+                                                  "kind": "name",
+                                                  "text": "n"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "array_element_initializer",
+                                          "children": [
+                                            {
+                                              "kind": "encapsed_string",
+                                              "children": [
+                                                {
+                                                  "kind": "string_content",
+                                                  "text": "l"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "variable_name",
+                                              "children": [
+                                                {
+                                                  "kind": "name",
+                                                  "text": "l"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
                 }
-              }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "echo_statement",
+      "children": [
+        {
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "encapsed_string",
+              "children": [
+                {
+                  "kind": "string_content",
+                  "text": "--- Even pairs ---"
+                }
+              ]
             },
             {
-              "nodeType": "Expr_ConstFetch",
-              "attributes": {
-                "startLine": 15,
-                "startTokenPos": 193,
-                "startFilePos": 386,
-                "endLine": 15,
-                "endTokenPos": 193,
-                "endFilePos": 392
-              },
-              "name": {
-                "nodeType": "Name",
-                "attributes": {
-                  "startLine": 15,
-                  "startTokenPos": 193,
-                  "startFilePos": 386,
-                  "endLine": 15,
-                  "endTokenPos": 193,
-                  "endFilePos": 392
-                },
-                "name": "PHP_EOL"
-              }
+              "kind": "name",
+              "text": "PHP_EOL"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "foreach_statement",
+      "children": [
+        {
+          "kind": "variable_name",
+          "children": [
+            {
+              "kind": "name",
+              "text": "pairs"
+            }
+          ]
+        },
+        {
+          "kind": "variable_name",
+          "children": [
+            {
+              "kind": "name",
+              "text": "p"
+            }
+          ]
+        },
+        {
+          "kind": "compound_statement",
+          "children": [
+            {
+              "kind": "echo_statement",
+              "children": [
+                {
+                  "kind": "sequence_expression",
+                  "children": [
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "binary_expression",
+                          "children": [
+                            {
+                              "kind": "parenthesized_expression",
+                              "children": [
+                                {
+                                  "kind": "conditional_expression",
+                                  "children": [
+                                    {
+                                      "kind": "function_call_expression",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "is_float"
+                                        },
+                                        {
+                                          "kind": "arguments",
+                                          "children": [
+                                            {
+                                              "kind": "argument",
+                                              "children": [
+                                                {
+                                                  "kind": "subscript_expression",
+                                                  "children": [
+                                                    {
+                                                      "kind": "variable_name",
+                                                      "children": [
+                                                        {
+                                                          "kind": "name",
+                                                          "text": "p"
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "encapsed_string",
+                                                      "children": [
+                                                        {
+                                                          "kind": "string_content",
+                                                          "text": "n"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "function_call_expression",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "json_encode"
+                                        },
+                                        {
+                                          "kind": "arguments",
+                                          "children": [
+                                            {
+                                              "kind": "argument",
+                                              "children": [
+                                                {
+                                                  "kind": "subscript_expression",
+                                                  "children": [
+                                                    {
+                                                      "kind": "variable_name",
+                                                      "children": [
+                                                        {
+                                                          "kind": "name",
+                                                          "text": "p"
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "encapsed_string",
+                                                      "children": [
+                                                        {
+                                                          "kind": "string_content",
+                                                          "text": "n"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "argument",
+                                              "children": [
+                                                {
+                                                  "kind": "integer",
+                                                  "text": "1344"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "subscript_expression",
+                                      "children": [
+                                        {
+                                          "kind": "variable_name",
+                                          "children": [
+                                            {
+                                              "kind": "name",
+                                              "text": "p"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "encapsed_string",
+                                          "children": [
+                                            {
+                                              "kind": "string_content",
+                                              "text": "n"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "parenthesized_expression",
+                          "children": [
+                            {
+                              "kind": "conditional_expression",
+                              "children": [
+                                {
+                                  "kind": "function_call_expression",
+                                  "children": [
+                                    {
+                                      "kind": "name",
+                                      "text": "is_float"
+                                    },
+                                    {
+                                      "kind": "arguments",
+                                      "children": [
+                                        {
+                                          "kind": "argument",
+                                          "children": [
+                                            {
+                                              "kind": "subscript_expression",
+                                              "children": [
+                                                {
+                                                  "kind": "variable_name",
+                                                  "children": [
+                                                    {
+                                                      "kind": "name",
+                                                      "text": "p"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "encapsed_string",
+                                                  "children": [
+                                                    {
+                                                      "kind": "string_content",
+                                                      "text": "l"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "function_call_expression",
+                                  "children": [
+                                    {
+                                      "kind": "name",
+                                      "text": "json_encode"
+                                    },
+                                    {
+                                      "kind": "arguments",
+                                      "children": [
+                                        {
+                                          "kind": "argument",
+                                          "children": [
+                                            {
+                                              "kind": "subscript_expression",
+                                              "children": [
+                                                {
+                                                  "kind": "variable_name",
+                                                  "children": [
+                                                    {
+                                                      "kind": "name",
+                                                      "text": "p"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "encapsed_string",
+                                                  "children": [
+                                                    {
+                                                      "kind": "string_content",
+                                                      "text": "l"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "argument",
+                                          "children": [
+                                            {
+                                              "kind": "integer",
+                                              "text": "1344"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "subscript_expression",
+                                  "children": [
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "p"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "encapsed_string",
+                                      "children": [
+                                        {
+                                          "kind": "string_content",
+                                          "text": "l"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "name",
+                      "text": "PHP_EOL"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }

--- a/tests/json-ast/x/php/cross_join_triple.php.json
+++ b/tests/json-ast/x/php/cross_join_triple.php.json
@@ -1,669 +1,40 @@
 {
-  "root": [
+  "statements": [
     {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 2,
-        "startTokenPos": 1,
-        "startFilePos": 6,
-        "endLine": 2,
-        "endTokenPos": 11,
-        "endFilePos": 20
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 2,
-          "startTokenPos": 1,
-          "startFilePos": 6,
-          "endLine": 2,
-          "endTokenPos": 10,
-          "endFilePos": 19
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 1,
-            "startFilePos": 6,
-            "endLine": 2,
-            "endTokenPos": 1,
-            "endFilePos": 10
-          },
-          "name": "nums"
-        },
-        "expr": {
-          "nodeType": "Expr_Array",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 5,
-            "startFilePos": 14,
-            "endLine": 2,
-            "endTokenPos": 10,
-            "endFilePos": 19,
-            "kind": 2
-          },
-          "items": [
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 6,
-                "startFilePos": 15,
-                "endLine": 2,
-                "endTokenPos": 6,
-                "endFilePos": 15
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 6,
-                  "startFilePos": 15,
-                  "endLine": 2,
-                  "endTokenPos": 6,
-                  "endFilePos": 15,
-                  "rawValue": "1",
-                  "kind": 10
-                },
-                "value": 1
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 9,
-                "startFilePos": 18,
-                "endLine": 2,
-                "endTokenPos": 9,
-                "endFilePos": 18
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 9,
-                  "startFilePos": 18,
-                  "endLine": 2,
-                  "endTokenPos": 9,
-                  "endFilePos": 18,
-                  "rawValue": "2",
-                  "kind": 10
-                },
-                "value": 2
-              },
-              "byRef": false,
-              "unpack": false
-            }
-          ]
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 3,
-        "startTokenPos": 13,
-        "startFilePos": 22,
-        "endLine": 3,
-        "endTokenPos": 23,
-        "endFilePos": 43
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 3,
-          "startTokenPos": 13,
-          "startFilePos": 22,
-          "endLine": 3,
-          "endTokenPos": 22,
-          "endFilePos": 42
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 13,
-            "startFilePos": 22,
-            "endLine": 3,
-            "endTokenPos": 13,
-            "endFilePos": 29
-          },
-          "name": "letters"
-        },
-        "expr": {
-          "nodeType": "Expr_Array",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 17,
-            "startFilePos": 33,
-            "endLine": 3,
-            "endTokenPos": 22,
-            "endFilePos": 42,
-            "kind": 2
-          },
-          "items": [
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 18,
-                "startFilePos": 34,
-                "endLine": 3,
-                "endTokenPos": 18,
-                "endFilePos": 36
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_String",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 18,
-                  "startFilePos": 34,
-                  "endLine": 3,
-                  "endTokenPos": 18,
-                  "endFilePos": 36,
-                  "kind": 2,
-                  "rawValue": "\"A\""
-                },
-                "value": "A"
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 21,
-                "startFilePos": 39,
-                "endLine": 3,
-                "endTokenPos": 21,
-                "endFilePos": 41
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_String",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 21,
-                  "startFilePos": 39,
-                  "endLine": 3,
-                  "endTokenPos": 21,
-                  "endFilePos": 41,
-                  "kind": 2,
-                  "rawValue": "\"B\""
-                },
-                "value": "B"
-              },
-              "byRef": false,
-              "unpack": false
-            }
-          ]
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 4,
-        "startTokenPos": 25,
-        "startFilePos": 45,
-        "endLine": 4,
-        "endTokenPos": 35,
-        "endFilePos": 67
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 4,
-          "startTokenPos": 25,
-          "startFilePos": 45,
-          "endLine": 4,
-          "endTokenPos": 34,
-          "endFilePos": 66
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 4,
-            "startTokenPos": 25,
-            "startFilePos": 45,
-            "endLine": 4,
-            "endTokenPos": 25,
-            "endFilePos": 50
-          },
-          "name": "bools"
-        },
-        "expr": {
-          "nodeType": "Expr_Array",
-          "attributes": {
-            "startLine": 4,
-            "startTokenPos": 29,
-            "startFilePos": 54,
-            "endLine": 4,
-            "endTokenPos": 34,
-            "endFilePos": 66,
-            "kind": 2
-          },
-          "items": [
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 4,
-                "startTokenPos": 30,
-                "startFilePos": 55,
-                "endLine": 4,
-                "endTokenPos": 30,
-                "endFilePos": 58
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Expr_ConstFetch",
-                "attributes": {
-                  "startLine": 4,
-                  "startTokenPos": 30,
-                  "startFilePos": 55,
-                  "endLine": 4,
-                  "endTokenPos": 30,
-                  "endFilePos": 58
-                },
-                "name": {
-                  "nodeType": "Name",
-                  "attributes": {
-                    "startLine": 4,
-                    "startTokenPos": 30,
-                    "startFilePos": 55,
-                    "endLine": 4,
-                    "endTokenPos": 30,
-                    "endFilePos": 58
-                  },
-                  "name": "true"
-                }
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 4,
-                "startTokenPos": 33,
-                "startFilePos": 61,
-                "endLine": 4,
-                "endTokenPos": 33,
-                "endFilePos": 65
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Expr_ConstFetch",
-                "attributes": {
-                  "startLine": 4,
-                  "startTokenPos": 33,
-                  "startFilePos": 61,
-                  "endLine": 4,
-                  "endTokenPos": 33,
-                  "endFilePos": 65
-                },
-                "name": {
-                  "nodeType": "Name",
-                  "attributes": {
-                    "startLine": 4,
-                    "startTokenPos": 33,
-                    "startFilePos": 61,
-                    "endLine": 4,
-                    "endTokenPos": 33,
-                    "endFilePos": 65
-                  },
-                  "name": "false"
-                }
-              },
-              "byRef": false,
-              "unpack": false
-            }
-          ]
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 5,
-        "startTokenPos": 37,
-        "startFilePos": 69,
-        "endLine": 5,
-        "endTokenPos": 43,
-        "endFilePos": 81
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 5,
-          "startTokenPos": 37,
-          "startFilePos": 69,
-          "endLine": 5,
-          "endTokenPos": 42,
-          "endFilePos": 80
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 5,
-            "startTokenPos": 37,
-            "startFilePos": 69,
-            "endLine": 5,
-            "endTokenPos": 37,
-            "endFilePos": 75
-          },
-          "name": "combos"
-        },
-        "expr": {
-          "nodeType": "Expr_Array",
-          "attributes": {
-            "startLine": 5,
-            "startTokenPos": 41,
-            "startFilePos": 79,
-            "endLine": 5,
-            "endTokenPos": 42,
-            "endFilePos": 80,
-            "kind": 2
-          },
-          "items": []
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Foreach",
-      "attributes": {
-        "startLine": 6,
-        "startTokenPos": 45,
-        "startFilePos": 83,
-        "endLine": 12,
-        "endTokenPos": 114,
-        "endFilePos": 228
-      },
-      "expr": {
-        "nodeType": "Expr_Variable",
-        "attributes": {
-          "startLine": 6,
-          "startTokenPos": 48,
-          "startFilePos": 92,
-          "endLine": 6,
-          "endTokenPos": 48,
-          "endFilePos": 96
-        },
-        "name": "nums"
-      },
-      "keyVar": null,
-      "byRef": false,
-      "valueVar": {
-        "nodeType": "Expr_Variable",
-        "attributes": {
-          "startLine": 6,
-          "startTokenPos": 52,
-          "startFilePos": 101,
-          "endLine": 6,
-          "endTokenPos": 52,
-          "endFilePos": 102
-        },
-        "name": "n"
-      },
-      "stmts": [
+      "kind": "expression_statement",
+      "children": [
         {
-          "nodeType": "Stmt_Foreach",
-          "attributes": {
-            "startLine": 7,
-            "startTokenPos": 57,
-            "startFilePos": 109,
-            "endLine": 11,
-            "endTokenPos": 112,
-            "endFilePos": 226
-          },
-          "expr": {
-            "nodeType": "Expr_Variable",
-            "attributes": {
-              "startLine": 7,
-              "startTokenPos": 60,
-              "startFilePos": 118,
-              "endLine": 7,
-              "endTokenPos": 60,
-              "endFilePos": 125
-            },
-            "name": "letters"
-          },
-          "keyVar": null,
-          "byRef": false,
-          "valueVar": {
-            "nodeType": "Expr_Variable",
-            "attributes": {
-              "startLine": 7,
-              "startTokenPos": 64,
-              "startFilePos": 130,
-              "endLine": 7,
-              "endTokenPos": 64,
-              "endFilePos": 131
-            },
-            "name": "l"
-          },
-          "stmts": [
+          "kind": "assignment_expression",
+          "children": [
             {
-              "nodeType": "Stmt_Foreach",
-              "attributes": {
-                "startLine": 8,
-                "startTokenPos": 69,
-                "startFilePos": 140,
-                "endLine": 10,
-                "endTokenPos": 110,
-                "endFilePos": 222
-              },
-              "expr": {
-                "nodeType": "Expr_Variable",
-                "attributes": {
-                  "startLine": 8,
-                  "startTokenPos": 72,
-                  "startFilePos": 149,
-                  "endLine": 8,
-                  "endTokenPos": 72,
-                  "endFilePos": 154
-                },
-                "name": "bools"
-              },
-              "keyVar": null,
-              "byRef": false,
-              "valueVar": {
-                "nodeType": "Expr_Variable",
-                "attributes": {
-                  "startLine": 8,
-                  "startTokenPos": 76,
-                  "startFilePos": 159,
-                  "endLine": 8,
-                  "endTokenPos": 76,
-                  "endFilePos": 160
-                },
-                "name": "b"
-              },
-              "stmts": [
+              "kind": "variable_name",
+              "children": [
                 {
-                  "nodeType": "Stmt_Expression",
-                  "attributes": {
-                    "startLine": 9,
-                    "startTokenPos": 81,
-                    "startFilePos": 171,
-                    "endLine": 9,
-                    "endTokenPos": 108,
-                    "endFilePos": 216
-                  },
-                  "expr": {
-                    "nodeType": "Expr_Assign",
-                    "attributes": {
-                      "startLine": 9,
-                      "startTokenPos": 81,
-                      "startFilePos": 171,
-                      "endLine": 9,
-                      "endTokenPos": 107,
-                      "endFilePos": 215
-                    },
-                    "var": {
-                      "nodeType": "Expr_ArrayDimFetch",
-                      "attributes": {
-                        "startLine": 9,
-                        "startTokenPos": 81,
-                        "startFilePos": 171,
-                        "endLine": 9,
-                        "endTokenPos": 83,
-                        "endFilePos": 179
-                      },
-                      "var": {
-                        "nodeType": "Expr_Variable",
-                        "attributes": {
-                          "startLine": 9,
-                          "startTokenPos": 81,
-                          "startFilePos": 171,
-                          "endLine": 9,
-                          "endTokenPos": 81,
-                          "endFilePos": 177
-                        },
-                        "name": "combos"
-                      },
-                      "dim": null
-                    },
-                    "expr": {
-                      "nodeType": "Expr_Array",
-                      "attributes": {
-                        "startLine": 9,
-                        "startTokenPos": 87,
-                        "startFilePos": 183,
-                        "endLine": 9,
-                        "endTokenPos": 107,
-                        "endFilePos": 215,
-                        "kind": 2
-                      },
-                      "items": [
-                        {
-                          "nodeType": "ArrayItem",
-                          "attributes": {
-                            "startLine": 9,
-                            "startTokenPos": 88,
-                            "startFilePos": 184,
-                            "endLine": 9,
-                            "endTokenPos": 92,
-                            "endFilePos": 192
-                          },
-                          "key": {
-                            "nodeType": "Scalar_String",
-                            "attributes": {
-                              "startLine": 9,
-                              "startTokenPos": 88,
-                              "startFilePos": 184,
-                              "endLine": 9,
-                              "endTokenPos": 88,
-                              "endFilePos": 186,
-                              "kind": 2,
-                              "rawValue": "\"n\""
-                            },
-                            "value": "n"
-                          },
-                          "value": {
-                            "nodeType": "Expr_Variable",
-                            "attributes": {
-                              "startLine": 9,
-                              "startTokenPos": 92,
-                              "startFilePos": 191,
-                              "endLine": 9,
-                              "endTokenPos": 92,
-                              "endFilePos": 192
-                            },
-                            "name": "n"
-                          },
-                          "byRef": false,
-                          "unpack": false
-                        },
-                        {
-                          "nodeType": "ArrayItem",
-                          "attributes": {
-                            "startLine": 9,
-                            "startTokenPos": 95,
-                            "startFilePos": 195,
-                            "endLine": 9,
-                            "endTokenPos": 99,
-                            "endFilePos": 203
-                          },
-                          "key": {
-                            "nodeType": "Scalar_String",
-                            "attributes": {
-                              "startLine": 9,
-                              "startTokenPos": 95,
-                              "startFilePos": 195,
-                              "endLine": 9,
-                              "endTokenPos": 95,
-                              "endFilePos": 197,
-                              "kind": 2,
-                              "rawValue": "\"l\""
-                            },
-                            "value": "l"
-                          },
-                          "value": {
-                            "nodeType": "Expr_Variable",
-                            "attributes": {
-                              "startLine": 9,
-                              "startTokenPos": 99,
-                              "startFilePos": 202,
-                              "endLine": 9,
-                              "endTokenPos": 99,
-                              "endFilePos": 203
-                            },
-                            "name": "l"
-                          },
-                          "byRef": false,
-                          "unpack": false
-                        },
-                        {
-                          "nodeType": "ArrayItem",
-                          "attributes": {
-                            "startLine": 9,
-                            "startTokenPos": 102,
-                            "startFilePos": 206,
-                            "endLine": 9,
-                            "endTokenPos": 106,
-                            "endFilePos": 214
-                          },
-                          "key": {
-                            "nodeType": "Scalar_String",
-                            "attributes": {
-                              "startLine": 9,
-                              "startTokenPos": 102,
-                              "startFilePos": 206,
-                              "endLine": 9,
-                              "endTokenPos": 102,
-                              "endFilePos": 208,
-                              "kind": 2,
-                              "rawValue": "\"b\""
-                            },
-                            "value": "b"
-                          },
-                          "value": {
-                            "nodeType": "Expr_Variable",
-                            "attributes": {
-                              "startLine": 9,
-                              "startTokenPos": 106,
-                              "startFilePos": 213,
-                              "endLine": 9,
-                              "endTokenPos": 106,
-                              "endFilePos": 214
-                            },
-                            "name": "b"
-                          },
-                          "byRef": false,
-                          "unpack": false
-                        }
-                      ]
+                  "kind": "name",
+                  "text": "nums"
+                }
+              ]
+            },
+            {
+              "kind": "array_creation_expression",
+              "children": [
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "integer",
+                      "text": "1"
                     }
-                  }
+                  ]
+                },
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "integer",
+                      "text": "2"
+                    }
+                  ]
                 }
               ]
             }
@@ -672,881 +43,735 @@
       ]
     },
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 14,
-        "startTokenPos": 116,
-        "startFilePos": 231,
-        "endLine": 14,
-        "endTokenPos": 122,
-        "endFilePos": 280
-      },
-      "exprs": [
+      "kind": "expression_statement",
+      "children": [
         {
-          "nodeType": "Scalar_String",
-          "attributes": {
-            "startLine": 14,
-            "startTokenPos": 118,
-            "startFilePos": 236,
-            "endLine": 14,
-            "endTokenPos": 118,
-            "endFilePos": 270,
-            "kind": 2,
-            "rawValue": "\"--- Cross Join of three lists ---\""
-          },
-          "value": "--- Cross Join of three lists ---"
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 14,
-            "startTokenPos": 121,
-            "startFilePos": 273,
-            "endLine": 14,
-            "endTokenPos": 121,
-            "endFilePos": 279
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 14,
-              "startTokenPos": 121,
-              "startFilePos": 273,
-              "endLine": 14,
-              "endTokenPos": 121,
-              "endFilePos": 279
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "letters"
+                }
+              ]
             },
-            "name": "PHP_EOL"
-          }
+            {
+              "kind": "array_creation_expression",
+              "children": [
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "A"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "B"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     },
     {
-      "nodeType": "Stmt_Foreach",
-      "attributes": {
-        "startLine": 15,
-        "startTokenPos": 124,
-        "startFilePos": 282,
-        "endLine": 17,
-        "endTokenPos": 244,
-        "endFilePos": 518
-      },
-      "expr": {
-        "nodeType": "Expr_Variable",
-        "attributes": {
-          "startLine": 15,
-          "startTokenPos": 127,
-          "startFilePos": 291,
-          "endLine": 15,
-          "endTokenPos": 127,
-          "endFilePos": 297
-        },
-        "name": "combos"
-      },
-      "keyVar": null,
-      "byRef": false,
-      "valueVar": {
-        "nodeType": "Expr_Variable",
-        "attributes": {
-          "startLine": 15,
-          "startTokenPos": 131,
-          "startFilePos": 302,
-          "endLine": 15,
-          "endTokenPos": 131,
-          "endFilePos": 303
-        },
-        "name": "c"
-      },
-      "stmts": [
+      "kind": "expression_statement",
+      "children": [
         {
-          "nodeType": "Stmt_Echo",
-          "attributes": {
-            "startLine": 16,
-            "startTokenPos": 136,
-            "startFilePos": 310,
-            "endLine": 16,
-            "endTokenPos": 242,
-            "endFilePos": 516
-          },
-          "exprs": [
+          "kind": "assignment_expression",
+          "children": [
             {
-              "nodeType": "Expr_BinaryOp_Concat",
-              "attributes": {
-                "startLine": 16,
-                "startTokenPos": 138,
-                "startFilePos": 315,
-                "endLine": 16,
-                "endTokenPos": 238,
-                "endFilePos": 506
-              },
-              "left": {
-                "nodeType": "Expr_BinaryOp_Concat",
-                "attributes": {
-                  "startLine": 16,
-                  "startTokenPos": 138,
-                  "startFilePos": 315,
-                  "endLine": 16,
-                  "endTokenPos": 206,
-                  "endFilePos": 445
-                },
-                "left": {
-                  "nodeType": "Expr_BinaryOp_Concat",
-                  "attributes": {
-                    "startLine": 16,
-                    "startTokenPos": 138,
-                    "startFilePos": 315,
-                    "endLine": 16,
-                    "endTokenPos": 202,
-                    "endFilePos": 439
-                  },
-                  "left": {
-                    "nodeType": "Expr_BinaryOp_Concat",
-                    "attributes": {
-                      "startLine": 16,
-                      "startTokenPos": 138,
-                      "startFilePos": 315,
-                      "endLine": 16,
-                      "endTokenPos": 170,
-                      "endFilePos": 378
-                    },
-                    "left": {
-                      "nodeType": "Expr_Ternary",
-                      "attributes": {
-                        "startLine": 16,
-                        "startTokenPos": 139,
-                        "startFilePos": 316,
-                        "endLine": 16,
-                        "endTokenPos": 165,
-                        "endFilePos": 371
-                      },
-                      "cond": {
-                        "nodeType": "Expr_FuncCall",
-                        "attributes": {
-                          "startLine": 16,
-                          "startTokenPos": 139,
-                          "startFilePos": 316,
-                          "endLine": 16,
-                          "endTokenPos": 145,
-                          "endFilePos": 332
-                        },
-                        "name": {
-                          "nodeType": "Name",
-                          "attributes": {
-                            "startLine": 16,
-                            "startTokenPos": 139,
-                            "startFilePos": 316,
-                            "endLine": 16,
-                            "endTokenPos": 139,
-                            "endFilePos": 323
-                          },
-                          "name": "is_float"
-                        },
-                        "args": [
-                          {
-                            "nodeType": "Arg",
-                            "attributes": {
-                              "startLine": 16,
-                              "startTokenPos": 141,
-                              "startFilePos": 325,
-                              "endLine": 16,
-                              "endTokenPos": 144,
-                              "endFilePos": 331
-                            },
-                            "name": null,
-                            "value": {
-                              "nodeType": "Expr_ArrayDimFetch",
-                              "attributes": {
-                                "startLine": 16,
-                                "startTokenPos": 141,
-                                "startFilePos": 325,
-                                "endLine": 16,
-                                "endTokenPos": 144,
-                                "endFilePos": 331
-                              },
-                              "var": {
-                                "nodeType": "Expr_Variable",
-                                "attributes": {
-                                  "startLine": 16,
-                                  "startTokenPos": 141,
-                                  "startFilePos": 325,
-                                  "endLine": 16,
-                                  "endTokenPos": 141,
-                                  "endFilePos": 326
-                                },
-                                "name": "c"
-                              },
-                              "dim": {
-                                "nodeType": "Scalar_String",
-                                "attributes": {
-                                  "startLine": 16,
-                                  "startTokenPos": 143,
-                                  "startFilePos": 328,
-                                  "endLine": 16,
-                                  "endTokenPos": 143,
-                                  "endFilePos": 330,
-                                  "kind": 2,
-                                  "rawValue": "\"n\""
-                                },
-                                "value": "n"
-                              }
-                            },
-                            "byRef": false,
-                            "unpack": false
-                          }
-                        ]
-                      },
-                      "if": {
-                        "nodeType": "Expr_FuncCall",
-                        "attributes": {
-                          "startLine": 16,
-                          "startTokenPos": 149,
-                          "startFilePos": 336,
-                          "endLine": 16,
-                          "endTokenPos": 158,
-                          "endFilePos": 361
-                        },
-                        "name": {
-                          "nodeType": "Name",
-                          "attributes": {
-                            "startLine": 16,
-                            "startTokenPos": 149,
-                            "startFilePos": 336,
-                            "endLine": 16,
-                            "endTokenPos": 149,
-                            "endFilePos": 346
-                          },
-                          "name": "json_encode"
-                        },
-                        "args": [
-                          {
-                            "nodeType": "Arg",
-                            "attributes": {
-                              "startLine": 16,
-                              "startTokenPos": 151,
-                              "startFilePos": 348,
-                              "endLine": 16,
-                              "endTokenPos": 154,
-                              "endFilePos": 354
-                            },
-                            "name": null,
-                            "value": {
-                              "nodeType": "Expr_ArrayDimFetch",
-                              "attributes": {
-                                "startLine": 16,
-                                "startTokenPos": 151,
-                                "startFilePos": 348,
-                                "endLine": 16,
-                                "endTokenPos": 154,
-                                "endFilePos": 354
-                              },
-                              "var": {
-                                "nodeType": "Expr_Variable",
-                                "attributes": {
-                                  "startLine": 16,
-                                  "startTokenPos": 151,
-                                  "startFilePos": 348,
-                                  "endLine": 16,
-                                  "endTokenPos": 151,
-                                  "endFilePos": 349
-                                },
-                                "name": "c"
-                              },
-                              "dim": {
-                                "nodeType": "Scalar_String",
-                                "attributes": {
-                                  "startLine": 16,
-                                  "startTokenPos": 153,
-                                  "startFilePos": 351,
-                                  "endLine": 16,
-                                  "endTokenPos": 153,
-                                  "endFilePos": 353,
-                                  "kind": 2,
-                                  "rawValue": "\"n\""
-                                },
-                                "value": "n"
-                              }
-                            },
-                            "byRef": false,
-                            "unpack": false
-                          },
-                          {
-                            "nodeType": "Arg",
-                            "attributes": {
-                              "startLine": 16,
-                              "startTokenPos": 157,
-                              "startFilePos": 357,
-                              "endLine": 16,
-                              "endTokenPos": 157,
-                              "endFilePos": 360
-                            },
-                            "name": null,
-                            "value": {
-                              "nodeType": "Scalar_Int",
-                              "attributes": {
-                                "startLine": 16,
-                                "startTokenPos": 157,
-                                "startFilePos": 357,
-                                "endLine": 16,
-                                "endTokenPos": 157,
-                                "endFilePos": 360,
-                                "rawValue": "1344",
-                                "kind": 10
-                              },
-                              "value": 1344
-                            },
-                            "byRef": false,
-                            "unpack": false
-                          }
-                        ]
-                      },
-                      "else": {
-                        "nodeType": "Expr_ArrayDimFetch",
-                        "attributes": {
-                          "startLine": 16,
-                          "startTokenPos": 162,
-                          "startFilePos": 365,
-                          "endLine": 16,
-                          "endTokenPos": 165,
-                          "endFilePos": 371
-                        },
-                        "var": {
-                          "nodeType": "Expr_Variable",
-                          "attributes": {
-                            "startLine": 16,
-                            "startTokenPos": 162,
-                            "startFilePos": 365,
-                            "endLine": 16,
-                            "endTokenPos": 162,
-                            "endFilePos": 366
-                          },
-                          "name": "c"
-                        },
-                        "dim": {
-                          "nodeType": "Scalar_String",
-                          "attributes": {
-                            "startLine": 16,
-                            "startTokenPos": 164,
-                            "startFilePos": 368,
-                            "endLine": 16,
-                            "endTokenPos": 164,
-                            "endFilePos": 370,
-                            "kind": 2,
-                            "rawValue": "\"n\""
-                          },
-                          "value": "n"
-                        }
-                      }
-                    },
-                    "right": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 16,
-                        "startTokenPos": 170,
-                        "startFilePos": 376,
-                        "endLine": 16,
-                        "endTokenPos": 170,
-                        "endFilePos": 378,
-                        "kind": 2,
-                        "rawValue": "\" \""
-                      },
-                      "value": " "
-                    }
-                  },
-                  "right": {
-                    "nodeType": "Expr_Ternary",
-                    "attributes": {
-                      "startLine": 16,
-                      "startTokenPos": 175,
-                      "startFilePos": 383,
-                      "endLine": 16,
-                      "endTokenPos": 201,
-                      "endFilePos": 438
-                    },
-                    "cond": {
-                      "nodeType": "Expr_FuncCall",
-                      "attributes": {
-                        "startLine": 16,
-                        "startTokenPos": 175,
-                        "startFilePos": 383,
-                        "endLine": 16,
-                        "endTokenPos": 181,
-                        "endFilePos": 399
-                      },
-                      "name": {
-                        "nodeType": "Name",
-                        "attributes": {
-                          "startLine": 16,
-                          "startTokenPos": 175,
-                          "startFilePos": 383,
-                          "endLine": 16,
-                          "endTokenPos": 175,
-                          "endFilePos": 390
-                        },
-                        "name": "is_float"
-                      },
-                      "args": [
-                        {
-                          "nodeType": "Arg",
-                          "attributes": {
-                            "startLine": 16,
-                            "startTokenPos": 177,
-                            "startFilePos": 392,
-                            "endLine": 16,
-                            "endTokenPos": 180,
-                            "endFilePos": 398
-                          },
-                          "name": null,
-                          "value": {
-                            "nodeType": "Expr_ArrayDimFetch",
-                            "attributes": {
-                              "startLine": 16,
-                              "startTokenPos": 177,
-                              "startFilePos": 392,
-                              "endLine": 16,
-                              "endTokenPos": 180,
-                              "endFilePos": 398
-                            },
-                            "var": {
-                              "nodeType": "Expr_Variable",
-                              "attributes": {
-                                "startLine": 16,
-                                "startTokenPos": 177,
-                                "startFilePos": 392,
-                                "endLine": 16,
-                                "endTokenPos": 177,
-                                "endFilePos": 393
-                              },
-                              "name": "c"
-                            },
-                            "dim": {
-                              "nodeType": "Scalar_String",
-                              "attributes": {
-                                "startLine": 16,
-                                "startTokenPos": 179,
-                                "startFilePos": 395,
-                                "endLine": 16,
-                                "endTokenPos": 179,
-                                "endFilePos": 397,
-                                "kind": 2,
-                                "rawValue": "\"l\""
-                              },
-                              "value": "l"
-                            }
-                          },
-                          "byRef": false,
-                          "unpack": false
-                        }
-                      ]
-                    },
-                    "if": {
-                      "nodeType": "Expr_FuncCall",
-                      "attributes": {
-                        "startLine": 16,
-                        "startTokenPos": 185,
-                        "startFilePos": 403,
-                        "endLine": 16,
-                        "endTokenPos": 194,
-                        "endFilePos": 428
-                      },
-                      "name": {
-                        "nodeType": "Name",
-                        "attributes": {
-                          "startLine": 16,
-                          "startTokenPos": 185,
-                          "startFilePos": 403,
-                          "endLine": 16,
-                          "endTokenPos": 185,
-                          "endFilePos": 413
-                        },
-                        "name": "json_encode"
-                      },
-                      "args": [
-                        {
-                          "nodeType": "Arg",
-                          "attributes": {
-                            "startLine": 16,
-                            "startTokenPos": 187,
-                            "startFilePos": 415,
-                            "endLine": 16,
-                            "endTokenPos": 190,
-                            "endFilePos": 421
-                          },
-                          "name": null,
-                          "value": {
-                            "nodeType": "Expr_ArrayDimFetch",
-                            "attributes": {
-                              "startLine": 16,
-                              "startTokenPos": 187,
-                              "startFilePos": 415,
-                              "endLine": 16,
-                              "endTokenPos": 190,
-                              "endFilePos": 421
-                            },
-                            "var": {
-                              "nodeType": "Expr_Variable",
-                              "attributes": {
-                                "startLine": 16,
-                                "startTokenPos": 187,
-                                "startFilePos": 415,
-                                "endLine": 16,
-                                "endTokenPos": 187,
-                                "endFilePos": 416
-                              },
-                              "name": "c"
-                            },
-                            "dim": {
-                              "nodeType": "Scalar_String",
-                              "attributes": {
-                                "startLine": 16,
-                                "startTokenPos": 189,
-                                "startFilePos": 418,
-                                "endLine": 16,
-                                "endTokenPos": 189,
-                                "endFilePos": 420,
-                                "kind": 2,
-                                "rawValue": "\"l\""
-                              },
-                              "value": "l"
-                            }
-                          },
-                          "byRef": false,
-                          "unpack": false
-                        },
-                        {
-                          "nodeType": "Arg",
-                          "attributes": {
-                            "startLine": 16,
-                            "startTokenPos": 193,
-                            "startFilePos": 424,
-                            "endLine": 16,
-                            "endTokenPos": 193,
-                            "endFilePos": 427
-                          },
-                          "name": null,
-                          "value": {
-                            "nodeType": "Scalar_Int",
-                            "attributes": {
-                              "startLine": 16,
-                              "startTokenPos": 193,
-                              "startFilePos": 424,
-                              "endLine": 16,
-                              "endTokenPos": 193,
-                              "endFilePos": 427,
-                              "rawValue": "1344",
-                              "kind": 10
-                            },
-                            "value": 1344
-                          },
-                          "byRef": false,
-                          "unpack": false
-                        }
-                      ]
-                    },
-                    "else": {
-                      "nodeType": "Expr_ArrayDimFetch",
-                      "attributes": {
-                        "startLine": 16,
-                        "startTokenPos": 198,
-                        "startFilePos": 432,
-                        "endLine": 16,
-                        "endTokenPos": 201,
-                        "endFilePos": 438
-                      },
-                      "var": {
-                        "nodeType": "Expr_Variable",
-                        "attributes": {
-                          "startLine": 16,
-                          "startTokenPos": 198,
-                          "startFilePos": 432,
-                          "endLine": 16,
-                          "endTokenPos": 198,
-                          "endFilePos": 433
-                        },
-                        "name": "c"
-                      },
-                      "dim": {
-                        "nodeType": "Scalar_String",
-                        "attributes": {
-                          "startLine": 16,
-                          "startTokenPos": 200,
-                          "startFilePos": 435,
-                          "endLine": 16,
-                          "endTokenPos": 200,
-                          "endFilePos": 437,
-                          "kind": 2,
-                          "rawValue": "\"l\""
-                        },
-                        "value": "l"
-                      }
-                    }
-                  }
-                },
-                "right": {
-                  "nodeType": "Scalar_String",
-                  "attributes": {
-                    "startLine": 16,
-                    "startTokenPos": 206,
-                    "startFilePos": 443,
-                    "endLine": 16,
-                    "endTokenPos": 206,
-                    "endFilePos": 445,
-                    "kind": 2,
-                    "rawValue": "\" \""
-                  },
-                  "value": " "
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "bools"
                 }
-              },
-              "right": {
-                "nodeType": "Expr_Ternary",
-                "attributes": {
-                  "startLine": 16,
-                  "startTokenPos": 211,
-                  "startFilePos": 450,
-                  "endLine": 16,
-                  "endTokenPos": 237,
-                  "endFilePos": 505
-                },
-                "cond": {
-                  "nodeType": "Expr_FuncCall",
-                  "attributes": {
-                    "startLine": 16,
-                    "startTokenPos": 211,
-                    "startFilePos": 450,
-                    "endLine": 16,
-                    "endTokenPos": 217,
-                    "endFilePos": 466
-                  },
-                  "name": {
-                    "nodeType": "Name",
-                    "attributes": {
-                      "startLine": 16,
-                      "startTokenPos": 211,
-                      "startFilePos": 450,
-                      "endLine": 16,
-                      "endTokenPos": 211,
-                      "endFilePos": 457
-                    },
-                    "name": "is_float"
-                  },
-                  "args": [
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "expression_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "combos"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "foreach_statement",
+      "children": [
+        {
+          "kind": "variable_name",
+          "children": [
+            {
+              "kind": "name",
+              "text": "nums"
+            }
+          ]
+        },
+        {
+          "kind": "variable_name",
+          "children": [
+            {
+              "kind": "name",
+              "text": "n"
+            }
+          ]
+        },
+        {
+          "kind": "compound_statement",
+          "children": [
+            {
+              "kind": "foreach_statement",
+              "children": [
+                {
+                  "kind": "variable_name",
+                  "children": [
                     {
-                      "nodeType": "Arg",
-                      "attributes": {
-                        "startLine": 16,
-                        "startTokenPos": 213,
-                        "startFilePos": 459,
-                        "endLine": 16,
-                        "endTokenPos": 216,
-                        "endFilePos": 465
-                      },
-                      "name": null,
-                      "value": {
-                        "nodeType": "Expr_ArrayDimFetch",
-                        "attributes": {
-                          "startLine": 16,
-                          "startTokenPos": 213,
-                          "startFilePos": 459,
-                          "endLine": 16,
-                          "endTokenPos": 216,
-                          "endFilePos": 465
-                        },
-                        "var": {
-                          "nodeType": "Expr_Variable",
-                          "attributes": {
-                            "startLine": 16,
-                            "startTokenPos": 213,
-                            "startFilePos": 459,
-                            "endLine": 16,
-                            "endTokenPos": 213,
-                            "endFilePos": 460
-                          },
-                          "name": "c"
-                        },
-                        "dim": {
-                          "nodeType": "Scalar_String",
-                          "attributes": {
-                            "startLine": 16,
-                            "startTokenPos": 215,
-                            "startFilePos": 462,
-                            "endLine": 16,
-                            "endTokenPos": 215,
-                            "endFilePos": 464,
-                            "kind": 2,
-                            "rawValue": "\"b\""
-                          },
-                          "value": "b"
-                        }
-                      },
-                      "byRef": false,
-                      "unpack": false
+                      "kind": "name",
+                      "text": "letters"
                     }
                   ]
                 },
-                "if": {
-                  "nodeType": "Expr_FuncCall",
-                  "attributes": {
-                    "startLine": 16,
-                    "startTokenPos": 221,
-                    "startFilePos": 470,
-                    "endLine": 16,
-                    "endTokenPos": 230,
-                    "endFilePos": 495
-                  },
-                  "name": {
-                    "nodeType": "Name",
-                    "attributes": {
-                      "startLine": 16,
-                      "startTokenPos": 221,
-                      "startFilePos": 470,
-                      "endLine": 16,
-                      "endTokenPos": 221,
-                      "endFilePos": 480
-                    },
-                    "name": "json_encode"
-                  },
-                  "args": [
+                {
+                  "kind": "variable_name",
+                  "children": [
                     {
-                      "nodeType": "Arg",
-                      "attributes": {
-                        "startLine": 16,
-                        "startTokenPos": 223,
-                        "startFilePos": 482,
-                        "endLine": 16,
-                        "endTokenPos": 226,
-                        "endFilePos": 488
-                      },
-                      "name": null,
-                      "value": {
-                        "nodeType": "Expr_ArrayDimFetch",
-                        "attributes": {
-                          "startLine": 16,
-                          "startTokenPos": 223,
-                          "startFilePos": 482,
-                          "endLine": 16,
-                          "endTokenPos": 226,
-                          "endFilePos": 488
-                        },
-                        "var": {
-                          "nodeType": "Expr_Variable",
-                          "attributes": {
-                            "startLine": 16,
-                            "startTokenPos": 223,
-                            "startFilePos": 482,
-                            "endLine": 16,
-                            "endTokenPos": 223,
-                            "endFilePos": 483
-                          },
-                          "name": "c"
-                        },
-                        "dim": {
-                          "nodeType": "Scalar_String",
-                          "attributes": {
-                            "startLine": 16,
-                            "startTokenPos": 225,
-                            "startFilePos": 485,
-                            "endLine": 16,
-                            "endTokenPos": 225,
-                            "endFilePos": 487,
-                            "kind": 2,
-                            "rawValue": "\"b\""
-                          },
-                          "value": "b"
-                        }
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "nodeType": "Arg",
-                      "attributes": {
-                        "startLine": 16,
-                        "startTokenPos": 229,
-                        "startFilePos": 491,
-                        "endLine": 16,
-                        "endTokenPos": 229,
-                        "endFilePos": 494
-                      },
-                      "name": null,
-                      "value": {
-                        "nodeType": "Scalar_Int",
-                        "attributes": {
-                          "startLine": 16,
-                          "startTokenPos": 229,
-                          "startFilePos": 491,
-                          "endLine": 16,
-                          "endTokenPos": 229,
-                          "endFilePos": 494,
-                          "rawValue": "1344",
-                          "kind": 10
-                        },
-                        "value": 1344
-                      },
-                      "byRef": false,
-                      "unpack": false
+                      "kind": "name",
+                      "text": "l"
                     }
                   ]
                 },
-                "else": {
-                  "nodeType": "Expr_ArrayDimFetch",
-                  "attributes": {
-                    "startLine": 16,
-                    "startTokenPos": 234,
-                    "startFilePos": 499,
-                    "endLine": 16,
-                    "endTokenPos": 237,
-                    "endFilePos": 505
-                  },
-                  "var": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 16,
-                      "startTokenPos": 234,
-                      "startFilePos": 499,
-                      "endLine": 16,
-                      "endTokenPos": 234,
-                      "endFilePos": 500
-                    },
-                    "name": "c"
-                  },
-                  "dim": {
-                    "nodeType": "Scalar_String",
-                    "attributes": {
-                      "startLine": 16,
-                      "startTokenPos": 236,
-                      "startFilePos": 502,
-                      "endLine": 16,
-                      "endTokenPos": 236,
-                      "endFilePos": 504,
-                      "kind": 2,
-                      "rawValue": "\"b\""
-                    },
-                    "value": "b"
-                  }
+                {
+                  "kind": "compound_statement",
+                  "children": [
+                    {
+                      "kind": "foreach_statement",
+                      "children": [
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "bools"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "b"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "compound_statement",
+                          "children": [
+                            {
+                              "kind": "expression_statement",
+                              "children": [
+                                {
+                                  "kind": "assignment_expression",
+                                  "children": [
+                                    {
+                                      "kind": "subscript_expression",
+                                      "children": [
+                                        {
+                                          "kind": "variable_name",
+                                          "children": [
+                                            {
+                                              "kind": "name",
+                                              "text": "combos"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "array_creation_expression",
+                                      "children": [
+                                        {
+                                          "kind": "array_element_initializer",
+                                          "children": [
+                                            {
+                                              "kind": "encapsed_string",
+                                              "children": [
+                                                {
+                                                  "kind": "string_content",
+                                                  "text": "n"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "variable_name",
+                                              "children": [
+                                                {
+                                                  "kind": "name",
+                                                  "text": "n"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "array_element_initializer",
+                                          "children": [
+                                            {
+                                              "kind": "encapsed_string",
+                                              "children": [
+                                                {
+                                                  "kind": "string_content",
+                                                  "text": "l"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "variable_name",
+                                              "children": [
+                                                {
+                                                  "kind": "name",
+                                                  "text": "l"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "array_element_initializer",
+                                          "children": [
+                                            {
+                                              "kind": "encapsed_string",
+                                              "children": [
+                                                {
+                                                  "kind": "string_content",
+                                                  "text": "b"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "variable_name",
+                                              "children": [
+                                                {
+                                                  "kind": "name",
+                                                  "text": "b"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
                 }
-              }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "echo_statement",
+      "children": [
+        {
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "encapsed_string",
+              "children": [
+                {
+                  "kind": "string_content",
+                  "text": "--- Cross Join of three lists ---"
+                }
+              ]
             },
             {
-              "nodeType": "Expr_ConstFetch",
-              "attributes": {
-                "startLine": 16,
-                "startTokenPos": 241,
-                "startFilePos": 509,
-                "endLine": 16,
-                "endTokenPos": 241,
-                "endFilePos": 515
-              },
-              "name": {
-                "nodeType": "Name",
-                "attributes": {
-                  "startLine": 16,
-                  "startTokenPos": 241,
-                  "startFilePos": 509,
-                  "endLine": 16,
-                  "endTokenPos": 241,
-                  "endFilePos": 515
-                },
-                "name": "PHP_EOL"
-              }
+              "kind": "name",
+              "text": "PHP_EOL"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "foreach_statement",
+      "children": [
+        {
+          "kind": "variable_name",
+          "children": [
+            {
+              "kind": "name",
+              "text": "combos"
+            }
+          ]
+        },
+        {
+          "kind": "variable_name",
+          "children": [
+            {
+              "kind": "name",
+              "text": "c"
+            }
+          ]
+        },
+        {
+          "kind": "compound_statement",
+          "children": [
+            {
+              "kind": "echo_statement",
+              "children": [
+                {
+                  "kind": "sequence_expression",
+                  "children": [
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "binary_expression",
+                          "children": [
+                            {
+                              "kind": "binary_expression",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "parenthesized_expression",
+                                      "children": [
+                                        {
+                                          "kind": "conditional_expression",
+                                          "children": [
+                                            {
+                                              "kind": "function_call_expression",
+                                              "children": [
+                                                {
+                                                  "kind": "name",
+                                                  "text": "is_float"
+                                                },
+                                                {
+                                                  "kind": "arguments",
+                                                  "children": [
+                                                    {
+                                                      "kind": "argument",
+                                                      "children": [
+                                                        {
+                                                          "kind": "subscript_expression",
+                                                          "children": [
+                                                            {
+                                                              "kind": "variable_name",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "name",
+                                                                  "text": "c"
+                                                                }
+                                                              ]
+                                                            },
+                                                            {
+                                                              "kind": "encapsed_string",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "string_content",
+                                                                  "text": "n"
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "function_call_expression",
+                                              "children": [
+                                                {
+                                                  "kind": "name",
+                                                  "text": "json_encode"
+                                                },
+                                                {
+                                                  "kind": "arguments",
+                                                  "children": [
+                                                    {
+                                                      "kind": "argument",
+                                                      "children": [
+                                                        {
+                                                          "kind": "subscript_expression",
+                                                          "children": [
+                                                            {
+                                                              "kind": "variable_name",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "name",
+                                                                  "text": "c"
+                                                                }
+                                                              ]
+                                                            },
+                                                            {
+                                                              "kind": "encapsed_string",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "string_content",
+                                                                  "text": "n"
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "argument",
+                                                      "children": [
+                                                        {
+                                                          "kind": "integer",
+                                                          "text": "1344"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "subscript_expression",
+                                              "children": [
+                                                {
+                                                  "kind": "variable_name",
+                                                  "children": [
+                                                    {
+                                                      "kind": "name",
+                                                      "text": "c"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "encapsed_string",
+                                                  "children": [
+                                                    {
+                                                      "kind": "string_content",
+                                                      "text": "n"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "parenthesized_expression",
+                                  "children": [
+                                    {
+                                      "kind": "conditional_expression",
+                                      "children": [
+                                        {
+                                          "kind": "function_call_expression",
+                                          "children": [
+                                            {
+                                              "kind": "name",
+                                              "text": "is_float"
+                                            },
+                                            {
+                                              "kind": "arguments",
+                                              "children": [
+                                                {
+                                                  "kind": "argument",
+                                                  "children": [
+                                                    {
+                                                      "kind": "subscript_expression",
+                                                      "children": [
+                                                        {
+                                                          "kind": "variable_name",
+                                                          "children": [
+                                                            {
+                                                              "kind": "name",
+                                                              "text": "c"
+                                                            }
+                                                          ]
+                                                        },
+                                                        {
+                                                          "kind": "encapsed_string",
+                                                          "children": [
+                                                            {
+                                                              "kind": "string_content",
+                                                              "text": "l"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "function_call_expression",
+                                          "children": [
+                                            {
+                                              "kind": "name",
+                                              "text": "json_encode"
+                                            },
+                                            {
+                                              "kind": "arguments",
+                                              "children": [
+                                                {
+                                                  "kind": "argument",
+                                                  "children": [
+                                                    {
+                                                      "kind": "subscript_expression",
+                                                      "children": [
+                                                        {
+                                                          "kind": "variable_name",
+                                                          "children": [
+                                                            {
+                                                              "kind": "name",
+                                                              "text": "c"
+                                                            }
+                                                          ]
+                                                        },
+                                                        {
+                                                          "kind": "encapsed_string",
+                                                          "children": [
+                                                            {
+                                                              "kind": "string_content",
+                                                              "text": "l"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "argument",
+                                                  "children": [
+                                                    {
+                                                      "kind": "integer",
+                                                      "text": "1344"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "subscript_expression",
+                                          "children": [
+                                            {
+                                              "kind": "variable_name",
+                                              "children": [
+                                                {
+                                                  "kind": "name",
+                                                  "text": "c"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "encapsed_string",
+                                              "children": [
+                                                {
+                                                  "kind": "string_content",
+                                                  "text": "l"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "parenthesized_expression",
+                          "children": [
+                            {
+                              "kind": "conditional_expression",
+                              "children": [
+                                {
+                                  "kind": "function_call_expression",
+                                  "children": [
+                                    {
+                                      "kind": "name",
+                                      "text": "is_float"
+                                    },
+                                    {
+                                      "kind": "arguments",
+                                      "children": [
+                                        {
+                                          "kind": "argument",
+                                          "children": [
+                                            {
+                                              "kind": "subscript_expression",
+                                              "children": [
+                                                {
+                                                  "kind": "variable_name",
+                                                  "children": [
+                                                    {
+                                                      "kind": "name",
+                                                      "text": "c"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "encapsed_string",
+                                                  "children": [
+                                                    {
+                                                      "kind": "string_content",
+                                                      "text": "b"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "function_call_expression",
+                                  "children": [
+                                    {
+                                      "kind": "name",
+                                      "text": "json_encode"
+                                    },
+                                    {
+                                      "kind": "arguments",
+                                      "children": [
+                                        {
+                                          "kind": "argument",
+                                          "children": [
+                                            {
+                                              "kind": "subscript_expression",
+                                              "children": [
+                                                {
+                                                  "kind": "variable_name",
+                                                  "children": [
+                                                    {
+                                                      "kind": "name",
+                                                      "text": "c"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "encapsed_string",
+                                                  "children": [
+                                                    {
+                                                      "kind": "string_content",
+                                                      "text": "b"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "argument",
+                                          "children": [
+                                            {
+                                              "kind": "integer",
+                                              "text": "1344"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "subscript_expression",
+                                  "children": [
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "c"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "encapsed_string",
+                                      "children": [
+                                        {
+                                          "kind": "string_content",
+                                          "text": "b"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "name",
+                      "text": "PHP_EOL"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }

--- a/tests/json-ast/x/php/dataset_sort_take_limit.php.json
+++ b/tests/json-ast/x/php/dataset_sort_take_limit.php.json
@@ -1,1629 +1,807 @@
 {
-  "root": [
+  "statements": [
     {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 2,
-        "startTokenPos": 1,
-        "startFilePos": 6,
-        "endLine": 2,
-        "endTokenPos": 117,
-        "endFilePos": 294
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 2,
-          "startTokenPos": 1,
-          "startFilePos": 6,
-          "endLine": 2,
-          "endTokenPos": 116,
-          "endFilePos": 293
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 1,
-            "startFilePos": 6,
-            "endLine": 2,
-            "endTokenPos": 1,
-            "endFilePos": 14
-          },
-          "name": "products"
-        },
-        "expr": {
-          "nodeType": "Expr_Array",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 5,
-            "startFilePos": 18,
-            "endLine": 2,
-            "endTokenPos": 116,
-            "endFilePos": 293,
-            "kind": 2
-          },
-          "items": [
+      "kind": "expression_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
             {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 6,
-                "startFilePos": 19,
-                "endLine": 2,
-                "endTokenPos": 19,
-                "endFilePos": 55
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Expr_Array",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 6,
-                  "startFilePos": 19,
-                  "endLine": 2,
-                  "endTokenPos": 19,
-                  "endFilePos": 55,
-                  "kind": 2
-                },
-                "items": [
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 7,
-                      "startFilePos": 20,
-                      "endLine": 2,
-                      "endTokenPos": 11,
-                      "endFilePos": 37
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 7,
-                        "startFilePos": 20,
-                        "endLine": 2,
-                        "endTokenPos": 7,
-                        "endFilePos": 25,
-                        "kind": 2,
-                        "rawValue": "\"name\""
-                      },
-                      "value": "name"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 11,
-                        "startFilePos": 30,
-                        "endLine": 2,
-                        "endTokenPos": 11,
-                        "endFilePos": 37,
-                        "kind": 2,
-                        "rawValue": "\"Laptop\""
-                      },
-                      "value": "Laptop"
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  },
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 14,
-                      "startFilePos": 40,
-                      "endLine": 2,
-                      "endTokenPos": 18,
-                      "endFilePos": 54
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 14,
-                        "startFilePos": 40,
-                        "endLine": 2,
-                        "endTokenPos": 14,
-                        "endFilePos": 46,
-                        "kind": 2,
-                        "rawValue": "\"price\""
-                      },
-                      "value": "price"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 18,
-                        "startFilePos": 51,
-                        "endLine": 2,
-                        "endTokenPos": 18,
-                        "endFilePos": 54,
-                        "rawValue": "1500",
-                        "kind": 10
-                      },
-                      "value": 1500
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  }
-                ]
-              },
-              "byRef": false,
-              "unpack": false
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "products"
+                }
+              ]
             },
             {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 22,
-                "startFilePos": 58,
-                "endLine": 2,
-                "endTokenPos": 35,
-                "endFilePos": 97
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Expr_Array",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 22,
-                  "startFilePos": 58,
-                  "endLine": 2,
-                  "endTokenPos": 35,
-                  "endFilePos": 97,
-                  "kind": 2
+              "kind": "array_creation_expression",
+              "children": [
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "array_creation_expression",
+                      "children": [
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "name"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "Laptop"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "price"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "integer",
+                              "text": "1500"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
                 },
-                "items": [
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 23,
-                      "startFilePos": 59,
-                      "endLine": 2,
-                      "endTokenPos": 27,
-                      "endFilePos": 80
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 23,
-                        "startFilePos": 59,
-                        "endLine": 2,
-                        "endTokenPos": 23,
-                        "endFilePos": 64,
-                        "kind": 2,
-                        "rawValue": "\"name\""
-                      },
-                      "value": "name"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 27,
-                        "startFilePos": 69,
-                        "endLine": 2,
-                        "endTokenPos": 27,
-                        "endFilePos": 80,
-                        "kind": 2,
-                        "rawValue": "\"Smartphone\""
-                      },
-                      "value": "Smartphone"
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  },
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 30,
-                      "startFilePos": 83,
-                      "endLine": 2,
-                      "endTokenPos": 34,
-                      "endFilePos": 96
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 30,
-                        "startFilePos": 83,
-                        "endLine": 2,
-                        "endTokenPos": 30,
-                        "endFilePos": 89,
-                        "kind": 2,
-                        "rawValue": "\"price\""
-                      },
-                      "value": "price"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 34,
-                        "startFilePos": 94,
-                        "endLine": 2,
-                        "endTokenPos": 34,
-                        "endFilePos": 96,
-                        "rawValue": "900",
-                        "kind": 10
-                      },
-                      "value": 900
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  }
-                ]
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 38,
-                "startFilePos": 100,
-                "endLine": 2,
-                "endTokenPos": 51,
-                "endFilePos": 135
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Expr_Array",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 38,
-                  "startFilePos": 100,
-                  "endLine": 2,
-                  "endTokenPos": 51,
-                  "endFilePos": 135,
-                  "kind": 2
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "array_creation_expression",
+                      "children": [
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "name"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "Smartphone"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "price"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "integer",
+                              "text": "900"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
                 },
-                "items": [
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 39,
-                      "startFilePos": 101,
-                      "endLine": 2,
-                      "endTokenPos": 43,
-                      "endFilePos": 118
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 39,
-                        "startFilePos": 101,
-                        "endLine": 2,
-                        "endTokenPos": 39,
-                        "endFilePos": 106,
-                        "kind": 2,
-                        "rawValue": "\"name\""
-                      },
-                      "value": "name"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 43,
-                        "startFilePos": 111,
-                        "endLine": 2,
-                        "endTokenPos": 43,
-                        "endFilePos": 118,
-                        "kind": 2,
-                        "rawValue": "\"Tablet\""
-                      },
-                      "value": "Tablet"
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  },
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 46,
-                      "startFilePos": 121,
-                      "endLine": 2,
-                      "endTokenPos": 50,
-                      "endFilePos": 134
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 46,
-                        "startFilePos": 121,
-                        "endLine": 2,
-                        "endTokenPos": 46,
-                        "endFilePos": 127,
-                        "kind": 2,
-                        "rawValue": "\"price\""
-                      },
-                      "value": "price"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 50,
-                        "startFilePos": 132,
-                        "endLine": 2,
-                        "endTokenPos": 50,
-                        "endFilePos": 134,
-                        "rawValue": "600",
-                        "kind": 10
-                      },
-                      "value": 600
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  }
-                ]
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 54,
-                "startFilePos": 138,
-                "endLine": 2,
-                "endTokenPos": 67,
-                "endFilePos": 174
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Expr_Array",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 54,
-                  "startFilePos": 138,
-                  "endLine": 2,
-                  "endTokenPos": 67,
-                  "endFilePos": 174,
-                  "kind": 2
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "array_creation_expression",
+                      "children": [
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "name"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "Tablet"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "price"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "integer",
+                              "text": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
                 },
-                "items": [
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 55,
-                      "startFilePos": 139,
-                      "endLine": 2,
-                      "endTokenPos": 59,
-                      "endFilePos": 157
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 55,
-                        "startFilePos": 139,
-                        "endLine": 2,
-                        "endTokenPos": 55,
-                        "endFilePos": 144,
-                        "kind": 2,
-                        "rawValue": "\"name\""
-                      },
-                      "value": "name"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 59,
-                        "startFilePos": 149,
-                        "endLine": 2,
-                        "endTokenPos": 59,
-                        "endFilePos": 157,
-                        "kind": 2,
-                        "rawValue": "\"Monitor\""
-                      },
-                      "value": "Monitor"
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  },
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 62,
-                      "startFilePos": 160,
-                      "endLine": 2,
-                      "endTokenPos": 66,
-                      "endFilePos": 173
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 62,
-                        "startFilePos": 160,
-                        "endLine": 2,
-                        "endTokenPos": 62,
-                        "endFilePos": 166,
-                        "kind": 2,
-                        "rawValue": "\"price\""
-                      },
-                      "value": "price"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 66,
-                        "startFilePos": 171,
-                        "endLine": 2,
-                        "endTokenPos": 66,
-                        "endFilePos": 173,
-                        "rawValue": "300",
-                        "kind": 10
-                      },
-                      "value": 300
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  }
-                ]
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 70,
-                "startFilePos": 177,
-                "endLine": 2,
-                "endTokenPos": 83,
-                "endFilePos": 214
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Expr_Array",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 70,
-                  "startFilePos": 177,
-                  "endLine": 2,
-                  "endTokenPos": 83,
-                  "endFilePos": 214,
-                  "kind": 2
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "array_creation_expression",
+                      "children": [
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "name"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "Monitor"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "price"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "integer",
+                              "text": "300"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
                 },
-                "items": [
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 71,
-                      "startFilePos": 178,
-                      "endLine": 2,
-                      "endTokenPos": 75,
-                      "endFilePos": 197
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 71,
-                        "startFilePos": 178,
-                        "endLine": 2,
-                        "endTokenPos": 71,
-                        "endFilePos": 183,
-                        "kind": 2,
-                        "rawValue": "\"name\""
-                      },
-                      "value": "name"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 75,
-                        "startFilePos": 188,
-                        "endLine": 2,
-                        "endTokenPos": 75,
-                        "endFilePos": 197,
-                        "kind": 2,
-                        "rawValue": "\"Keyboard\""
-                      },
-                      "value": "Keyboard"
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  },
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 78,
-                      "startFilePos": 200,
-                      "endLine": 2,
-                      "endTokenPos": 82,
-                      "endFilePos": 213
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 78,
-                        "startFilePos": 200,
-                        "endLine": 2,
-                        "endTokenPos": 78,
-                        "endFilePos": 206,
-                        "kind": 2,
-                        "rawValue": "\"price\""
-                      },
-                      "value": "price"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 82,
-                        "startFilePos": 211,
-                        "endLine": 2,
-                        "endTokenPos": 82,
-                        "endFilePos": 213,
-                        "rawValue": "100",
-                        "kind": 10
-                      },
-                      "value": 100
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  }
-                ]
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 86,
-                "startFilePos": 217,
-                "endLine": 2,
-                "endTokenPos": 99,
-                "endFilePos": 250
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Expr_Array",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 86,
-                  "startFilePos": 217,
-                  "endLine": 2,
-                  "endTokenPos": 99,
-                  "endFilePos": 250,
-                  "kind": 2
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "array_creation_expression",
+                      "children": [
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "name"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "Keyboard"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "price"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "integer",
+                              "text": "100"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
                 },
-                "items": [
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 87,
-                      "startFilePos": 218,
-                      "endLine": 2,
-                      "endTokenPos": 91,
-                      "endFilePos": 234
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 87,
-                        "startFilePos": 218,
-                        "endLine": 2,
-                        "endTokenPos": 87,
-                        "endFilePos": 223,
-                        "kind": 2,
-                        "rawValue": "\"name\""
-                      },
-                      "value": "name"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 91,
-                        "startFilePos": 228,
-                        "endLine": 2,
-                        "endTokenPos": 91,
-                        "endFilePos": 234,
-                        "kind": 2,
-                        "rawValue": "\"Mouse\""
-                      },
-                      "value": "Mouse"
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  },
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 94,
-                      "startFilePos": 237,
-                      "endLine": 2,
-                      "endTokenPos": 98,
-                      "endFilePos": 249
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 94,
-                        "startFilePos": 237,
-                        "endLine": 2,
-                        "endTokenPos": 94,
-                        "endFilePos": 243,
-                        "kind": 2,
-                        "rawValue": "\"price\""
-                      },
-                      "value": "price"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 98,
-                        "startFilePos": 248,
-                        "endLine": 2,
-                        "endTokenPos": 98,
-                        "endFilePos": 249,
-                        "rawValue": "50",
-                        "kind": 10
-                      },
-                      "value": 50
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  }
-                ]
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 102,
-                "startFilePos": 253,
-                "endLine": 2,
-                "endTokenPos": 115,
-                "endFilePos": 292
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Expr_Array",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 102,
-                  "startFilePos": 253,
-                  "endLine": 2,
-                  "endTokenPos": 115,
-                  "endFilePos": 292,
-                  "kind": 2
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "array_creation_expression",
+                      "children": [
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "name"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "Mouse"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "price"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "integer",
+                              "text": "50"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
                 },
-                "items": [
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 103,
-                      "startFilePos": 254,
-                      "endLine": 2,
-                      "endTokenPos": 107,
-                      "endFilePos": 275
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 103,
-                        "startFilePos": 254,
-                        "endLine": 2,
-                        "endTokenPos": 103,
-                        "endFilePos": 259,
-                        "kind": 2,
-                        "rawValue": "\"name\""
-                      },
-                      "value": "name"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 107,
-                        "startFilePos": 264,
-                        "endLine": 2,
-                        "endTokenPos": 107,
-                        "endFilePos": 275,
-                        "kind": 2,
-                        "rawValue": "\"Headphones\""
-                      },
-                      "value": "Headphones"
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  },
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 110,
-                      "startFilePos": 278,
-                      "endLine": 2,
-                      "endTokenPos": 114,
-                      "endFilePos": 291
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 110,
-                        "startFilePos": 278,
-                        "endLine": 2,
-                        "endTokenPos": 110,
-                        "endFilePos": 284,
-                        "kind": 2,
-                        "rawValue": "\"price\""
-                      },
-                      "value": "price"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 114,
-                        "startFilePos": 289,
-                        "endLine": 2,
-                        "endTokenPos": 114,
-                        "endFilePos": 291,
-                        "rawValue": "200",
-                        "kind": 10
-                      },
-                      "value": 200
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  }
-                ]
-              },
-              "byRef": false,
-              "unpack": false
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "array_creation_expression",
+                      "children": [
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "name"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "Headphones"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "price"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "integer",
+                              "text": "200"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }
-      }
+      ]
     },
     {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 3,
-        "startTokenPos": 119,
-        "startFilePos": 296,
-        "endLine": 3,
-        "endTokenPos": 125,
-        "endFilePos": 311
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 3,
-          "startTokenPos": 119,
-          "startFilePos": 296,
-          "endLine": 3,
-          "endTokenPos": 124,
-          "endFilePos": 310
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 119,
-            "startFilePos": 296,
-            "endLine": 3,
-            "endTokenPos": 119,
-            "endFilePos": 305
-          },
-          "name": "expensive"
-        },
-        "expr": {
-          "nodeType": "Expr_Array",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 123,
-            "startFilePos": 309,
-            "endLine": 3,
-            "endTokenPos": 124,
-            "endFilePos": 310,
-            "kind": 2
-          },
-          "items": []
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Foreach",
-      "attributes": {
-        "startLine": 4,
-        "startTokenPos": 127,
-        "startFilePos": 313,
-        "endLine": 6,
-        "endTokenPos": 148,
-        "endFilePos": 362
-      },
-      "expr": {
-        "nodeType": "Expr_Variable",
-        "attributes": {
-          "startLine": 4,
-          "startTokenPos": 130,
-          "startFilePos": 322,
-          "endLine": 4,
-          "endTokenPos": 130,
-          "endFilePos": 330
-        },
-        "name": "products"
-      },
-      "keyVar": null,
-      "byRef": false,
-      "valueVar": {
-        "nodeType": "Expr_Variable",
-        "attributes": {
-          "startLine": 4,
-          "startTokenPos": 134,
-          "startFilePos": 335,
-          "endLine": 4,
-          "endTokenPos": 134,
-          "endFilePos": 336
-        },
-        "name": "p"
-      },
-      "stmts": [
+      "kind": "expression_statement",
+      "children": [
         {
-          "nodeType": "Stmt_Expression",
-          "attributes": {
-            "startLine": 5,
-            "startTokenPos": 139,
-            "startFilePos": 343,
-            "endLine": 5,
-            "endTokenPos": 146,
-            "endFilePos": 360
-          },
-          "expr": {
-            "nodeType": "Expr_Assign",
-            "attributes": {
-              "startLine": 5,
-              "startTokenPos": 139,
-              "startFilePos": 343,
-              "endLine": 5,
-              "endTokenPos": 145,
-              "endFilePos": 359
-            },
-            "var": {
-              "nodeType": "Expr_ArrayDimFetch",
-              "attributes": {
-                "startLine": 5,
-                "startTokenPos": 139,
-                "startFilePos": 343,
-                "endLine": 5,
-                "endTokenPos": 141,
-                "endFilePos": 354
-              },
-              "var": {
-                "nodeType": "Expr_Variable",
-                "attributes": {
-                  "startLine": 5,
-                  "startTokenPos": 139,
-                  "startFilePos": 343,
-                  "endLine": 5,
-                  "endTokenPos": 139,
-                  "endFilePos": 352
-                },
-                "name": "expensive"
-              },
-              "dim": null
-            },
-            "expr": {
-              "nodeType": "Expr_Variable",
-              "attributes": {
-                "startLine": 5,
-                "startTokenPos": 145,
-                "startFilePos": 358,
-                "endLine": 5,
-                "endTokenPos": 145,
-                "endFilePos": 359
-              },
-              "name": "p"
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "expensive"
+                }
+              ]
             }
-          }
+          ]
         }
       ]
     },
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 8,
-        "startTokenPos": 150,
-        "startFilePos": 365,
-        "endLine": 8,
-        "endTokenPos": 156,
-        "endFilePos": 428
-      },
-      "exprs": [
+      "kind": "foreach_statement",
+      "children": [
         {
-          "nodeType": "Scalar_String",
-          "attributes": {
-            "startLine": 8,
-            "startTokenPos": 152,
-            "startFilePos": 370,
-            "endLine": 8,
-            "endTokenPos": 152,
-            "endFilePos": 418,
-            "kind": 2,
-            "rawValue": "\"--- Top products (excluding most expensive) ---\""
-          },
-          "value": "--- Top products (excluding most expensive) ---"
+          "kind": "variable_name",
+          "children": [
+            {
+              "kind": "name",
+              "text": "products"
+            }
+          ]
         },
         {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 8,
-            "startTokenPos": 155,
-            "startFilePos": 421,
-            "endLine": 8,
-            "endTokenPos": 155,
-            "endFilePos": 427
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 8,
-              "startTokenPos": 155,
-              "startFilePos": 421,
-              "endLine": 8,
-              "endTokenPos": 155,
-              "endFilePos": 427
-            },
-            "name": "PHP_EOL"
-          }
+          "kind": "variable_name",
+          "children": [
+            {
+              "kind": "name",
+              "text": "p"
+            }
+          ]
+        },
+        {
+          "kind": "compound_statement",
+          "children": [
+            {
+              "kind": "expression_statement",
+              "children": [
+                {
+                  "kind": "assignment_expression",
+                  "children": [
+                    {
+                      "kind": "subscript_expression",
+                      "children": [
+                        {
+                          "kind": "variable_name",
+                          "children": [
+                            {
+                              "kind": "name",
+                              "text": "expensive"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "variable_name",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "p"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     },
     {
-      "nodeType": "Stmt_Foreach",
-      "attributes": {
-        "startLine": 9,
-        "startTokenPos": 158,
-        "startFilePos": 430,
-        "endLine": 11,
-        "endTokenPos": 250,
-        "endFilePos": 662
-      },
-      "expr": {
-        "nodeType": "Expr_Variable",
-        "attributes": {
-          "startLine": 9,
-          "startTokenPos": 161,
-          "startFilePos": 439,
-          "endLine": 9,
-          "endTokenPos": 161,
-          "endFilePos": 448
-        },
-        "name": "expensive"
-      },
-      "keyVar": null,
-      "byRef": false,
-      "valueVar": {
-        "nodeType": "Expr_Variable",
-        "attributes": {
-          "startLine": 9,
-          "startTokenPos": 165,
-          "startFilePos": 453,
-          "endLine": 9,
-          "endTokenPos": 165,
-          "endFilePos": 457
-        },
-        "name": "item"
-      },
-      "stmts": [
+      "kind": "echo_statement",
+      "children": [
         {
-          "nodeType": "Stmt_Echo",
-          "attributes": {
-            "startLine": 10,
-            "startTokenPos": 170,
-            "startFilePos": 464,
-            "endLine": 10,
-            "endTokenPos": 248,
-            "endFilePos": 660
-          },
-          "exprs": [
+          "kind": "sequence_expression",
+          "children": [
             {
-              "nodeType": "Expr_BinaryOp_Concat",
-              "attributes": {
-                "startLine": 10,
-                "startTokenPos": 172,
-                "startFilePos": 469,
-                "endLine": 10,
-                "endTokenPos": 244,
-                "endFilePos": 650
-              },
-              "left": {
-                "nodeType": "Expr_BinaryOp_Concat",
-                "attributes": {
-                  "startLine": 10,
-                  "startTokenPos": 172,
-                  "startFilePos": 469,
-                  "endLine": 10,
-                  "endTokenPos": 212,
-                  "endFilePos": 568
-                },
-                "left": {
-                  "nodeType": "Expr_BinaryOp_Concat",
-                  "attributes": {
-                    "startLine": 10,
-                    "startTokenPos": 172,
-                    "startFilePos": 469,
-                    "endLine": 10,
-                    "endTokenPos": 208,
-                    "endFilePos": 562
-                  },
-                  "left": {
-                    "nodeType": "Expr_BinaryOp_Concat",
-                    "attributes": {
-                      "startLine": 10,
-                      "startTokenPos": 172,
-                      "startFilePos": 469,
-                      "endLine": 10,
-                      "endTokenPos": 204,
-                      "endFilePos": 550
-                    },
-                    "left": {
-                      "nodeType": "Expr_Ternary",
-                      "attributes": {
-                        "startLine": 10,
-                        "startTokenPos": 173,
-                        "startFilePos": 470,
-                        "endLine": 10,
-                        "endTokenPos": 199,
-                        "endFilePos": 543
-                      },
-                      "cond": {
-                        "nodeType": "Expr_FuncCall",
-                        "attributes": {
-                          "startLine": 10,
-                          "startTokenPos": 173,
-                          "startFilePos": 470,
-                          "endLine": 10,
-                          "endTokenPos": 179,
-                          "endFilePos": 492
-                        },
-                        "name": {
-                          "nodeType": "Name",
-                          "attributes": {
-                            "startLine": 10,
-                            "startTokenPos": 173,
-                            "startFilePos": 470,
-                            "endLine": 10,
-                            "endTokenPos": 173,
-                            "endFilePos": 477
-                          },
-                          "name": "is_float"
-                        },
-                        "args": [
-                          {
-                            "nodeType": "Arg",
-                            "attributes": {
-                              "startLine": 10,
-                              "startTokenPos": 175,
-                              "startFilePos": 479,
-                              "endLine": 10,
-                              "endTokenPos": 178,
-                              "endFilePos": 491
-                            },
-                            "name": null,
-                            "value": {
-                              "nodeType": "Expr_ArrayDimFetch",
-                              "attributes": {
-                                "startLine": 10,
-                                "startTokenPos": 175,
-                                "startFilePos": 479,
-                                "endLine": 10,
-                                "endTokenPos": 178,
-                                "endFilePos": 491
-                              },
-                              "var": {
-                                "nodeType": "Expr_Variable",
-                                "attributes": {
-                                  "startLine": 10,
-                                  "startTokenPos": 175,
-                                  "startFilePos": 479,
-                                  "endLine": 10,
-                                  "endTokenPos": 175,
-                                  "endFilePos": 483
-                                },
-                                "name": "item"
-                              },
-                              "dim": {
-                                "nodeType": "Scalar_String",
-                                "attributes": {
-                                  "startLine": 10,
-                                  "startTokenPos": 177,
-                                  "startFilePos": 485,
-                                  "endLine": 10,
-                                  "endTokenPos": 177,
-                                  "endFilePos": 490,
-                                  "kind": 2,
-                                  "rawValue": "\"name\""
-                                },
-                                "value": "name"
-                              }
-                            },
-                            "byRef": false,
-                            "unpack": false
-                          }
-                        ]
-                      },
-                      "if": {
-                        "nodeType": "Expr_FuncCall",
-                        "attributes": {
-                          "startLine": 10,
-                          "startTokenPos": 183,
-                          "startFilePos": 496,
-                          "endLine": 10,
-                          "endTokenPos": 192,
-                          "endFilePos": 527
-                        },
-                        "name": {
-                          "nodeType": "Name",
-                          "attributes": {
-                            "startLine": 10,
-                            "startTokenPos": 183,
-                            "startFilePos": 496,
-                            "endLine": 10,
-                            "endTokenPos": 183,
-                            "endFilePos": 506
-                          },
-                          "name": "json_encode"
-                        },
-                        "args": [
-                          {
-                            "nodeType": "Arg",
-                            "attributes": {
-                              "startLine": 10,
-                              "startTokenPos": 185,
-                              "startFilePos": 508,
-                              "endLine": 10,
-                              "endTokenPos": 188,
-                              "endFilePos": 520
-                            },
-                            "name": null,
-                            "value": {
-                              "nodeType": "Expr_ArrayDimFetch",
-                              "attributes": {
-                                "startLine": 10,
-                                "startTokenPos": 185,
-                                "startFilePos": 508,
-                                "endLine": 10,
-                                "endTokenPos": 188,
-                                "endFilePos": 520
-                              },
-                              "var": {
-                                "nodeType": "Expr_Variable",
-                                "attributes": {
-                                  "startLine": 10,
-                                  "startTokenPos": 185,
-                                  "startFilePos": 508,
-                                  "endLine": 10,
-                                  "endTokenPos": 185,
-                                  "endFilePos": 512
-                                },
-                                "name": "item"
-                              },
-                              "dim": {
-                                "nodeType": "Scalar_String",
-                                "attributes": {
-                                  "startLine": 10,
-                                  "startTokenPos": 187,
-                                  "startFilePos": 514,
-                                  "endLine": 10,
-                                  "endTokenPos": 187,
-                                  "endFilePos": 519,
-                                  "kind": 2,
-                                  "rawValue": "\"name\""
-                                },
-                                "value": "name"
-                              }
-                            },
-                            "byRef": false,
-                            "unpack": false
-                          },
-                          {
-                            "nodeType": "Arg",
-                            "attributes": {
-                              "startLine": 10,
-                              "startTokenPos": 191,
-                              "startFilePos": 523,
-                              "endLine": 10,
-                              "endTokenPos": 191,
-                              "endFilePos": 526
-                            },
-                            "name": null,
-                            "value": {
-                              "nodeType": "Scalar_Int",
-                              "attributes": {
-                                "startLine": 10,
-                                "startTokenPos": 191,
-                                "startFilePos": 523,
-                                "endLine": 10,
-                                "endTokenPos": 191,
-                                "endFilePos": 526,
-                                "rawValue": "1344",
-                                "kind": 10
-                              },
-                              "value": 1344
-                            },
-                            "byRef": false,
-                            "unpack": false
-                          }
-                        ]
-                      },
-                      "else": {
-                        "nodeType": "Expr_ArrayDimFetch",
-                        "attributes": {
-                          "startLine": 10,
-                          "startTokenPos": 196,
-                          "startFilePos": 531,
-                          "endLine": 10,
-                          "endTokenPos": 199,
-                          "endFilePos": 543
-                        },
-                        "var": {
-                          "nodeType": "Expr_Variable",
-                          "attributes": {
-                            "startLine": 10,
-                            "startTokenPos": 196,
-                            "startFilePos": 531,
-                            "endLine": 10,
-                            "endTokenPos": 196,
-                            "endFilePos": 535
-                          },
-                          "name": "item"
-                        },
-                        "dim": {
-                          "nodeType": "Scalar_String",
-                          "attributes": {
-                            "startLine": 10,
-                            "startTokenPos": 198,
-                            "startFilePos": 537,
-                            "endLine": 10,
-                            "endTokenPos": 198,
-                            "endFilePos": 542,
-                            "kind": 2,
-                            "rawValue": "\"name\""
-                          },
-                          "value": "name"
-                        }
-                      }
-                    },
-                    "right": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 10,
-                        "startTokenPos": 204,
-                        "startFilePos": 548,
-                        "endLine": 10,
-                        "endTokenPos": 204,
-                        "endFilePos": 550,
-                        "kind": 2,
-                        "rawValue": "\" \""
-                      },
-                      "value": " "
-                    }
-                  },
-                  "right": {
-                    "nodeType": "Scalar_String",
-                    "attributes": {
-                      "startLine": 10,
-                      "startTokenPos": 208,
-                      "startFilePos": 554,
-                      "endLine": 10,
-                      "endTokenPos": 208,
-                      "endFilePos": 562,
-                      "kind": 2,
-                      "rawValue": "\"costs $\""
-                    },
-                    "value": "costs $"
-                  }
-                },
-                "right": {
-                  "nodeType": "Scalar_String",
-                  "attributes": {
-                    "startLine": 10,
-                    "startTokenPos": 212,
-                    "startFilePos": 566,
-                    "endLine": 10,
-                    "endTokenPos": 212,
-                    "endFilePos": 568,
-                    "kind": 2,
-                    "rawValue": "\" \""
-                  },
-                  "value": " "
+              "kind": "encapsed_string",
+              "children": [
+                {
+                  "kind": "string_content",
+                  "text": "--- Top products (excluding most expensive) ---"
                 }
-              },
-              "right": {
-                "nodeType": "Expr_Ternary",
-                "attributes": {
-                  "startLine": 10,
-                  "startTokenPos": 217,
-                  "startFilePos": 573,
-                  "endLine": 10,
-                  "endTokenPos": 243,
-                  "endFilePos": 649
-                },
-                "cond": {
-                  "nodeType": "Expr_FuncCall",
-                  "attributes": {
-                    "startLine": 10,
-                    "startTokenPos": 217,
-                    "startFilePos": 573,
-                    "endLine": 10,
-                    "endTokenPos": 223,
-                    "endFilePos": 596
-                  },
-                  "name": {
-                    "nodeType": "Name",
-                    "attributes": {
-                      "startLine": 10,
-                      "startTokenPos": 217,
-                      "startFilePos": 573,
-                      "endLine": 10,
-                      "endTokenPos": 217,
-                      "endFilePos": 580
-                    },
-                    "name": "is_float"
-                  },
-                  "args": [
-                    {
-                      "nodeType": "Arg",
-                      "attributes": {
-                        "startLine": 10,
-                        "startTokenPos": 219,
-                        "startFilePos": 582,
-                        "endLine": 10,
-                        "endTokenPos": 222,
-                        "endFilePos": 595
-                      },
-                      "name": null,
-                      "value": {
-                        "nodeType": "Expr_ArrayDimFetch",
-                        "attributes": {
-                          "startLine": 10,
-                          "startTokenPos": 219,
-                          "startFilePos": 582,
-                          "endLine": 10,
-                          "endTokenPos": 222,
-                          "endFilePos": 595
-                        },
-                        "var": {
-                          "nodeType": "Expr_Variable",
-                          "attributes": {
-                            "startLine": 10,
-                            "startTokenPos": 219,
-                            "startFilePos": 582,
-                            "endLine": 10,
-                            "endTokenPos": 219,
-                            "endFilePos": 586
-                          },
-                          "name": "item"
-                        },
-                        "dim": {
-                          "nodeType": "Scalar_String",
-                          "attributes": {
-                            "startLine": 10,
-                            "startTokenPos": 221,
-                            "startFilePos": 588,
-                            "endLine": 10,
-                            "endTokenPos": 221,
-                            "endFilePos": 594,
-                            "kind": 2,
-                            "rawValue": "\"price\""
-                          },
-                          "value": "price"
-                        }
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    }
-                  ]
-                },
-                "if": {
-                  "nodeType": "Expr_FuncCall",
-                  "attributes": {
-                    "startLine": 10,
-                    "startTokenPos": 227,
-                    "startFilePos": 600,
-                    "endLine": 10,
-                    "endTokenPos": 236,
-                    "endFilePos": 632
-                  },
-                  "name": {
-                    "nodeType": "Name",
-                    "attributes": {
-                      "startLine": 10,
-                      "startTokenPos": 227,
-                      "startFilePos": 600,
-                      "endLine": 10,
-                      "endTokenPos": 227,
-                      "endFilePos": 610
-                    },
-                    "name": "json_encode"
-                  },
-                  "args": [
-                    {
-                      "nodeType": "Arg",
-                      "attributes": {
-                        "startLine": 10,
-                        "startTokenPos": 229,
-                        "startFilePos": 612,
-                        "endLine": 10,
-                        "endTokenPos": 232,
-                        "endFilePos": 625
-                      },
-                      "name": null,
-                      "value": {
-                        "nodeType": "Expr_ArrayDimFetch",
-                        "attributes": {
-                          "startLine": 10,
-                          "startTokenPos": 229,
-                          "startFilePos": 612,
-                          "endLine": 10,
-                          "endTokenPos": 232,
-                          "endFilePos": 625
-                        },
-                        "var": {
-                          "nodeType": "Expr_Variable",
-                          "attributes": {
-                            "startLine": 10,
-                            "startTokenPos": 229,
-                            "startFilePos": 612,
-                            "endLine": 10,
-                            "endTokenPos": 229,
-                            "endFilePos": 616
-                          },
-                          "name": "item"
-                        },
-                        "dim": {
-                          "nodeType": "Scalar_String",
-                          "attributes": {
-                            "startLine": 10,
-                            "startTokenPos": 231,
-                            "startFilePos": 618,
-                            "endLine": 10,
-                            "endTokenPos": 231,
-                            "endFilePos": 624,
-                            "kind": 2,
-                            "rawValue": "\"price\""
-                          },
-                          "value": "price"
-                        }
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "nodeType": "Arg",
-                      "attributes": {
-                        "startLine": 10,
-                        "startTokenPos": 235,
-                        "startFilePos": 628,
-                        "endLine": 10,
-                        "endTokenPos": 235,
-                        "endFilePos": 631
-                      },
-                      "name": null,
-                      "value": {
-                        "nodeType": "Scalar_Int",
-                        "attributes": {
-                          "startLine": 10,
-                          "startTokenPos": 235,
-                          "startFilePos": 628,
-                          "endLine": 10,
-                          "endTokenPos": 235,
-                          "endFilePos": 631,
-                          "rawValue": "1344",
-                          "kind": 10
-                        },
-                        "value": 1344
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    }
-                  ]
-                },
-                "else": {
-                  "nodeType": "Expr_ArrayDimFetch",
-                  "attributes": {
-                    "startLine": 10,
-                    "startTokenPos": 240,
-                    "startFilePos": 636,
-                    "endLine": 10,
-                    "endTokenPos": 243,
-                    "endFilePos": 649
-                  },
-                  "var": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 10,
-                      "startTokenPos": 240,
-                      "startFilePos": 636,
-                      "endLine": 10,
-                      "endTokenPos": 240,
-                      "endFilePos": 640
-                    },
-                    "name": "item"
-                  },
-                  "dim": {
-                    "nodeType": "Scalar_String",
-                    "attributes": {
-                      "startLine": 10,
-                      "startTokenPos": 242,
-                      "startFilePos": 642,
-                      "endLine": 10,
-                      "endTokenPos": 242,
-                      "endFilePos": 648,
-                      "kind": 2,
-                      "rawValue": "\"price\""
-                    },
-                    "value": "price"
-                  }
-                }
-              }
+              ]
             },
             {
-              "nodeType": "Expr_ConstFetch",
-              "attributes": {
-                "startLine": 10,
-                "startTokenPos": 247,
-                "startFilePos": 653,
-                "endLine": 10,
-                "endTokenPos": 247,
-                "endFilePos": 659
-              },
-              "name": {
-                "nodeType": "Name",
-                "attributes": {
-                  "startLine": 10,
-                  "startTokenPos": 247,
-                  "startFilePos": 653,
-                  "endLine": 10,
-                  "endTokenPos": 247,
-                  "endFilePos": 659
-                },
-                "name": "PHP_EOL"
-              }
+              "kind": "name",
+              "text": "PHP_EOL"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "foreach_statement",
+      "children": [
+        {
+          "kind": "variable_name",
+          "children": [
+            {
+              "kind": "name",
+              "text": "expensive"
+            }
+          ]
+        },
+        {
+          "kind": "variable_name",
+          "children": [
+            {
+              "kind": "name",
+              "text": "item"
+            }
+          ]
+        },
+        {
+          "kind": "compound_statement",
+          "children": [
+            {
+              "kind": "echo_statement",
+              "children": [
+                {
+                  "kind": "sequence_expression",
+                  "children": [
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "binary_expression",
+                          "children": [
+                            {
+                              "kind": "binary_expression",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "parenthesized_expression",
+                                      "children": [
+                                        {
+                                          "kind": "conditional_expression",
+                                          "children": [
+                                            {
+                                              "kind": "function_call_expression",
+                                              "children": [
+                                                {
+                                                  "kind": "name",
+                                                  "text": "is_float"
+                                                },
+                                                {
+                                                  "kind": "arguments",
+                                                  "children": [
+                                                    {
+                                                      "kind": "argument",
+                                                      "children": [
+                                                        {
+                                                          "kind": "subscript_expression",
+                                                          "children": [
+                                                            {
+                                                              "kind": "variable_name",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "name",
+                                                                  "text": "item"
+                                                                }
+                                                              ]
+                                                            },
+                                                            {
+                                                              "kind": "encapsed_string",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "string_content",
+                                                                  "text": "name"
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "function_call_expression",
+                                              "children": [
+                                                {
+                                                  "kind": "name",
+                                                  "text": "json_encode"
+                                                },
+                                                {
+                                                  "kind": "arguments",
+                                                  "children": [
+                                                    {
+                                                      "kind": "argument",
+                                                      "children": [
+                                                        {
+                                                          "kind": "subscript_expression",
+                                                          "children": [
+                                                            {
+                                                              "kind": "variable_name",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "name",
+                                                                  "text": "item"
+                                                                }
+                                                              ]
+                                                            },
+                                                            {
+                                                              "kind": "encapsed_string",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "string_content",
+                                                                  "text": "name"
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "argument",
+                                                      "children": [
+                                                        {
+                                                          "kind": "integer",
+                                                          "text": "1344"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "subscript_expression",
+                                              "children": [
+                                                {
+                                                  "kind": "variable_name",
+                                                  "children": [
+                                                    {
+                                                      "kind": "name",
+                                                      "text": "item"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "encapsed_string",
+                                                  "children": [
+                                                    {
+                                                      "kind": "string_content",
+                                                      "text": "name"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "encapsed_string",
+                                  "children": [
+                                    {
+                                      "kind": "string_content",
+                                      "text": "costs $"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "parenthesized_expression",
+                          "children": [
+                            {
+                              "kind": "conditional_expression",
+                              "children": [
+                                {
+                                  "kind": "function_call_expression",
+                                  "children": [
+                                    {
+                                      "kind": "name",
+                                      "text": "is_float"
+                                    },
+                                    {
+                                      "kind": "arguments",
+                                      "children": [
+                                        {
+                                          "kind": "argument",
+                                          "children": [
+                                            {
+                                              "kind": "subscript_expression",
+                                              "children": [
+                                                {
+                                                  "kind": "variable_name",
+                                                  "children": [
+                                                    {
+                                                      "kind": "name",
+                                                      "text": "item"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "encapsed_string",
+                                                  "children": [
+                                                    {
+                                                      "kind": "string_content",
+                                                      "text": "price"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "function_call_expression",
+                                  "children": [
+                                    {
+                                      "kind": "name",
+                                      "text": "json_encode"
+                                    },
+                                    {
+                                      "kind": "arguments",
+                                      "children": [
+                                        {
+                                          "kind": "argument",
+                                          "children": [
+                                            {
+                                              "kind": "subscript_expression",
+                                              "children": [
+                                                {
+                                                  "kind": "variable_name",
+                                                  "children": [
+                                                    {
+                                                      "kind": "name",
+                                                      "text": "item"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "encapsed_string",
+                                                  "children": [
+                                                    {
+                                                      "kind": "string_content",
+                                                      "text": "price"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "argument",
+                                          "children": [
+                                            {
+                                              "kind": "integer",
+                                              "text": "1344"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "subscript_expression",
+                                  "children": [
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "item"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "encapsed_string",
+                                      "children": [
+                                        {
+                                          "kind": "string_content",
+                                          "text": "price"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "name",
+                      "text": "PHP_EOL"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }

--- a/tests/json-ast/x/php/dataset_where_filter.php.json
+++ b/tests/json-ast/x/php/dataset_where_filter.php.json
@@ -1,1707 +1,873 @@
 {
-  "root": [
+  "statements": [
     {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 2,
-        "startTokenPos": 1,
-        "startFilePos": 6,
-        "endLine": 2,
-        "endTokenPos": 69,
-        "endFilePos": 152
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 2,
-          "startTokenPos": 1,
-          "startFilePos": 6,
-          "endLine": 2,
-          "endTokenPos": 68,
-          "endFilePos": 151
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 1,
-            "startFilePos": 6,
-            "endLine": 2,
-            "endTokenPos": 1,
-            "endFilePos": 12
-          },
-          "name": "people"
-        },
-        "expr": {
-          "nodeType": "Expr_Array",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 5,
-            "startFilePos": 16,
-            "endLine": 2,
-            "endTokenPos": 68,
-            "endFilePos": 151,
-            "kind": 2
-          },
-          "items": [
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 6,
-                "startFilePos": 17,
-                "endLine": 2,
-                "endTokenPos": 19,
-                "endFilePos": 48
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Expr_Array",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 6,
-                  "startFilePos": 17,
-                  "endLine": 2,
-                  "endTokenPos": 19,
-                  "endFilePos": 48,
-                  "kind": 2
-                },
-                "items": [
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 7,
-                      "startFilePos": 18,
-                      "endLine": 2,
-                      "endTokenPos": 11,
-                      "endFilePos": 34
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 7,
-                        "startFilePos": 18,
-                        "endLine": 2,
-                        "endTokenPos": 7,
-                        "endFilePos": 23,
-                        "kind": 2,
-                        "rawValue": "\"name\""
-                      },
-                      "value": "name"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 11,
-                        "startFilePos": 28,
-                        "endLine": 2,
-                        "endTokenPos": 11,
-                        "endFilePos": 34,
-                        "kind": 2,
-                        "rawValue": "\"Alice\""
-                      },
-                      "value": "Alice"
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  },
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 14,
-                      "startFilePos": 37,
-                      "endLine": 2,
-                      "endTokenPos": 18,
-                      "endFilePos": 47
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 14,
-                        "startFilePos": 37,
-                        "endLine": 2,
-                        "endTokenPos": 14,
-                        "endFilePos": 41,
-                        "kind": 2,
-                        "rawValue": "\"age\""
-                      },
-                      "value": "age"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 18,
-                        "startFilePos": 46,
-                        "endLine": 2,
-                        "endTokenPos": 18,
-                        "endFilePos": 47,
-                        "rawValue": "30",
-                        "kind": 10
-                      },
-                      "value": 30
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  }
-                ]
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 22,
-                "startFilePos": 51,
-                "endLine": 2,
-                "endTokenPos": 35,
-                "endFilePos": 80
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Expr_Array",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 22,
-                  "startFilePos": 51,
-                  "endLine": 2,
-                  "endTokenPos": 35,
-                  "endFilePos": 80,
-                  "kind": 2
-                },
-                "items": [
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 23,
-                      "startFilePos": 52,
-                      "endLine": 2,
-                      "endTokenPos": 27,
-                      "endFilePos": 66
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 23,
-                        "startFilePos": 52,
-                        "endLine": 2,
-                        "endTokenPos": 23,
-                        "endFilePos": 57,
-                        "kind": 2,
-                        "rawValue": "\"name\""
-                      },
-                      "value": "name"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 27,
-                        "startFilePos": 62,
-                        "endLine": 2,
-                        "endTokenPos": 27,
-                        "endFilePos": 66,
-                        "kind": 2,
-                        "rawValue": "\"Bob\""
-                      },
-                      "value": "Bob"
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  },
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 30,
-                      "startFilePos": 69,
-                      "endLine": 2,
-                      "endTokenPos": 34,
-                      "endFilePos": 79
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 30,
-                        "startFilePos": 69,
-                        "endLine": 2,
-                        "endTokenPos": 30,
-                        "endFilePos": 73,
-                        "kind": 2,
-                        "rawValue": "\"age\""
-                      },
-                      "value": "age"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 34,
-                        "startFilePos": 78,
-                        "endLine": 2,
-                        "endTokenPos": 34,
-                        "endFilePos": 79,
-                        "rawValue": "15",
-                        "kind": 10
-                      },
-                      "value": 15
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  }
-                ]
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 38,
-                "startFilePos": 83,
-                "endLine": 2,
-                "endTokenPos": 51,
-                "endFilePos": 116
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Expr_Array",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 38,
-                  "startFilePos": 83,
-                  "endLine": 2,
-                  "endTokenPos": 51,
-                  "endFilePos": 116,
-                  "kind": 2
-                },
-                "items": [
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 39,
-                      "startFilePos": 84,
-                      "endLine": 2,
-                      "endTokenPos": 43,
-                      "endFilePos": 102
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 39,
-                        "startFilePos": 84,
-                        "endLine": 2,
-                        "endTokenPos": 39,
-                        "endFilePos": 89,
-                        "kind": 2,
-                        "rawValue": "\"name\""
-                      },
-                      "value": "name"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 43,
-                        "startFilePos": 94,
-                        "endLine": 2,
-                        "endTokenPos": 43,
-                        "endFilePos": 102,
-                        "kind": 2,
-                        "rawValue": "\"Charlie\""
-                      },
-                      "value": "Charlie"
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  },
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 46,
-                      "startFilePos": 105,
-                      "endLine": 2,
-                      "endTokenPos": 50,
-                      "endFilePos": 115
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 46,
-                        "startFilePos": 105,
-                        "endLine": 2,
-                        "endTokenPos": 46,
-                        "endFilePos": 109,
-                        "kind": 2,
-                        "rawValue": "\"age\""
-                      },
-                      "value": "age"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 50,
-                        "startFilePos": 114,
-                        "endLine": 2,
-                        "endTokenPos": 50,
-                        "endFilePos": 115,
-                        "rawValue": "65",
-                        "kind": 10
-                      },
-                      "value": 65
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  }
-                ]
-              },
-              "byRef": false,
-              "unpack": false
-            },
-            {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 54,
-                "startFilePos": 119,
-                "endLine": 2,
-                "endTokenPos": 67,
-                "endFilePos": 150
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Expr_Array",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 54,
-                  "startFilePos": 119,
-                  "endLine": 2,
-                  "endTokenPos": 67,
-                  "endFilePos": 150,
-                  "kind": 2
-                },
-                "items": [
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 55,
-                      "startFilePos": 120,
-                      "endLine": 2,
-                      "endTokenPos": 59,
-                      "endFilePos": 136
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 55,
-                        "startFilePos": 120,
-                        "endLine": 2,
-                        "endTokenPos": 55,
-                        "endFilePos": 125,
-                        "kind": 2,
-                        "rawValue": "\"name\""
-                      },
-                      "value": "name"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 59,
-                        "startFilePos": 130,
-                        "endLine": 2,
-                        "endTokenPos": 59,
-                        "endFilePos": 136,
-                        "kind": 2,
-                        "rawValue": "\"Diana\""
-                      },
-                      "value": "Diana"
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  },
-                  {
-                    "nodeType": "ArrayItem",
-                    "attributes": {
-                      "startLine": 2,
-                      "startTokenPos": 62,
-                      "startFilePos": 139,
-                      "endLine": 2,
-                      "endTokenPos": 66,
-                      "endFilePos": 149
-                    },
-                    "key": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 62,
-                        "startFilePos": 139,
-                        "endLine": 2,
-                        "endTokenPos": 62,
-                        "endFilePos": 143,
-                        "kind": 2,
-                        "rawValue": "\"age\""
-                      },
-                      "value": "age"
-                    },
-                    "value": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 2,
-                        "startTokenPos": 66,
-                        "startFilePos": 148,
-                        "endLine": 2,
-                        "endTokenPos": 66,
-                        "endFilePos": 149,
-                        "rawValue": "45",
-                        "kind": 10
-                      },
-                      "value": 45
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  }
-                ]
-              },
-              "byRef": false,
-              "unpack": false
-            }
-          ]
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 3,
-        "startTokenPos": 71,
-        "startFilePos": 154,
-        "endLine": 3,
-        "endTokenPos": 77,
-        "endFilePos": 166
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 3,
-          "startTokenPos": 71,
-          "startFilePos": 154,
-          "endLine": 3,
-          "endTokenPos": 76,
-          "endFilePos": 165
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 71,
-            "startFilePos": 154,
-            "endLine": 3,
-            "endTokenPos": 71,
-            "endFilePos": 160
-          },
-          "name": "adults"
-        },
-        "expr": {
-          "nodeType": "Expr_Array",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 75,
-            "startFilePos": 164,
-            "endLine": 3,
-            "endTokenPos": 76,
-            "endFilePos": 165,
-            "kind": 2
-          },
-          "items": []
-        }
-      }
-    },
-    {
-      "nodeType": "Stmt_Foreach",
-      "attributes": {
-        "startLine": 4,
-        "startTokenPos": 79,
-        "startFilePos": 168,
-        "endLine": 8,
-        "endTokenPos": 150,
-        "endFilePos": 340
-      },
-      "expr": {
-        "nodeType": "Expr_Variable",
-        "attributes": {
-          "startLine": 4,
-          "startTokenPos": 82,
-          "startFilePos": 177,
-          "endLine": 4,
-          "endTokenPos": 82,
-          "endFilePos": 183
-        },
-        "name": "people"
-      },
-      "keyVar": null,
-      "byRef": false,
-      "valueVar": {
-        "nodeType": "Expr_Variable",
-        "attributes": {
-          "startLine": 4,
-          "startTokenPos": 86,
-          "startFilePos": 188,
-          "endLine": 4,
-          "endTokenPos": 86,
-          "endFilePos": 194
-        },
-        "name": "person"
-      },
-      "stmts": [
+      "kind": "expression_statement",
+      "children": [
         {
-          "nodeType": "Stmt_If",
-          "attributes": {
-            "startLine": 5,
-            "startTokenPos": 91,
-            "startFilePos": 201,
-            "endLine": 7,
-            "endTokenPos": 148,
-            "endFilePos": 338
-          },
-          "cond": {
-            "nodeType": "Expr_BinaryOp_GreaterOrEqual",
-            "attributes": {
-              "startLine": 5,
-              "startTokenPos": 94,
-              "startFilePos": 205,
-              "endLine": 5,
-              "endTokenPos": 101,
-              "endFilePos": 224
-            },
-            "left": {
-              "nodeType": "Expr_ArrayDimFetch",
-              "attributes": {
-                "startLine": 5,
-                "startTokenPos": 94,
-                "startFilePos": 205,
-                "endLine": 5,
-                "endTokenPos": 97,
-                "endFilePos": 218
-              },
-              "var": {
-                "nodeType": "Expr_Variable",
-                "attributes": {
-                  "startLine": 5,
-                  "startTokenPos": 94,
-                  "startFilePos": 205,
-                  "endLine": 5,
-                  "endTokenPos": 94,
-                  "endFilePos": 211
-                },
-                "name": "person"
-              },
-              "dim": {
-                "nodeType": "Scalar_String",
-                "attributes": {
-                  "startLine": 5,
-                  "startTokenPos": 96,
-                  "startFilePos": 213,
-                  "endLine": 5,
-                  "endTokenPos": 96,
-                  "endFilePos": 217,
-                  "kind": 2,
-                  "rawValue": "\"age\""
-                },
-                "value": "age"
-              }
-            },
-            "right": {
-              "nodeType": "Scalar_Int",
-              "attributes": {
-                "startLine": 5,
-                "startTokenPos": 101,
-                "startFilePos": 223,
-                "endLine": 5,
-                "endTokenPos": 101,
-                "endFilePos": 224,
-                "rawValue": "18",
-                "kind": 10
-              },
-              "value": 18
-            }
-          },
-          "stmts": [
+          "kind": "assignment_expression",
+          "children": [
             {
-              "nodeType": "Stmt_Expression",
-              "attributes": {
-                "startLine": 6,
-                "startTokenPos": 106,
-                "startFilePos": 233,
-                "endLine": 6,
-                "endTokenPos": 146,
-                "endFilePos": 334
-              },
-              "expr": {
-                "nodeType": "Expr_Assign",
-                "attributes": {
-                  "startLine": 6,
-                  "startTokenPos": 106,
-                  "startFilePos": 233,
-                  "endLine": 6,
-                  "endTokenPos": 145,
-                  "endFilePos": 333
-                },
-                "var": {
-                  "nodeType": "Expr_ArrayDimFetch",
-                  "attributes": {
-                    "startLine": 6,
-                    "startTokenPos": 106,
-                    "startFilePos": 233,
-                    "endLine": 6,
-                    "endTokenPos": 108,
-                    "endFilePos": 241
-                  },
-                  "var": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 6,
-                      "startTokenPos": 106,
-                      "startFilePos": 233,
-                      "endLine": 6,
-                      "endTokenPos": 106,
-                      "endFilePos": 239
-                    },
-                    "name": "adults"
-                  },
-                  "dim": null
-                },
-                "expr": {
-                  "nodeType": "Expr_Array",
-                  "attributes": {
-                    "startLine": 6,
-                    "startTokenPos": 112,
-                    "startFilePos": 245,
-                    "endLine": 6,
-                    "endTokenPos": 145,
-                    "endFilePos": 333,
-                    "kind": 2
-                  },
-                  "items": [
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "people"
+                }
+              ]
+            },
+            {
+              "kind": "array_creation_expression",
+              "children": [
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
                     {
-                      "nodeType": "ArrayItem",
-                      "attributes": {
-                        "startLine": 6,
-                        "startTokenPos": 113,
-                        "startFilePos": 246,
-                        "endLine": 6,
-                        "endTokenPos": 120,
-                        "endFilePos": 270
-                      },
-                      "key": {
-                        "nodeType": "Scalar_String",
-                        "attributes": {
-                          "startLine": 6,
-                          "startTokenPos": 113,
-                          "startFilePos": 246,
-                          "endLine": 6,
-                          "endTokenPos": 113,
-                          "endFilePos": 251,
-                          "kind": 2,
-                          "rawValue": "\"name\""
-                        },
-                        "value": "name"
-                      },
-                      "value": {
-                        "nodeType": "Expr_ArrayDimFetch",
-                        "attributes": {
-                          "startLine": 6,
-                          "startTokenPos": 117,
-                          "startFilePos": 256,
-                          "endLine": 6,
-                          "endTokenPos": 120,
-                          "endFilePos": 270
-                        },
-                        "var": {
-                          "nodeType": "Expr_Variable",
-                          "attributes": {
-                            "startLine": 6,
-                            "startTokenPos": 117,
-                            "startFilePos": 256,
-                            "endLine": 6,
-                            "endTokenPos": 117,
-                            "endFilePos": 262
-                          },
-                          "name": "person"
-                        },
-                        "dim": {
-                          "nodeType": "Scalar_String",
-                          "attributes": {
-                            "startLine": 6,
-                            "startTokenPos": 119,
-                            "startFilePos": 264,
-                            "endLine": 6,
-                            "endTokenPos": 119,
-                            "endFilePos": 269,
-                            "kind": 2,
-                            "rawValue": "\"name\""
-                          },
-                          "value": "name"
-                        }
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "nodeType": "ArrayItem",
-                      "attributes": {
-                        "startLine": 6,
-                        "startTokenPos": 123,
-                        "startFilePos": 273,
-                        "endLine": 6,
-                        "endTokenPos": 130,
-                        "endFilePos": 295
-                      },
-                      "key": {
-                        "nodeType": "Scalar_String",
-                        "attributes": {
-                          "startLine": 6,
-                          "startTokenPos": 123,
-                          "startFilePos": 273,
-                          "endLine": 6,
-                          "endTokenPos": 123,
-                          "endFilePos": 277,
-                          "kind": 2,
-                          "rawValue": "\"age\""
-                        },
-                        "value": "age"
-                      },
-                      "value": {
-                        "nodeType": "Expr_ArrayDimFetch",
-                        "attributes": {
-                          "startLine": 6,
-                          "startTokenPos": 127,
-                          "startFilePos": 282,
-                          "endLine": 6,
-                          "endTokenPos": 130,
-                          "endFilePos": 295
-                        },
-                        "var": {
-                          "nodeType": "Expr_Variable",
-                          "attributes": {
-                            "startLine": 6,
-                            "startTokenPos": 127,
-                            "startFilePos": 282,
-                            "endLine": 6,
-                            "endTokenPos": 127,
-                            "endFilePos": 288
-                          },
-                          "name": "person"
-                        },
-                        "dim": {
-                          "nodeType": "Scalar_String",
-                          "attributes": {
-                            "startLine": 6,
-                            "startTokenPos": 129,
-                            "startFilePos": 290,
-                            "endLine": 6,
-                            "endTokenPos": 129,
-                            "endFilePos": 294,
-                            "kind": 2,
-                            "rawValue": "\"age\""
-                          },
-                          "value": "age"
-                        }
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "nodeType": "ArrayItem",
-                      "attributes": {
-                        "startLine": 6,
-                        "startTokenPos": 133,
-                        "startFilePos": 298,
-                        "endLine": 6,
-                        "endTokenPos": 144,
-                        "endFilePos": 332
-                      },
-                      "key": {
-                        "nodeType": "Scalar_String",
-                        "attributes": {
-                          "startLine": 6,
-                          "startTokenPos": 133,
-                          "startFilePos": 298,
-                          "endLine": 6,
-                          "endTokenPos": 133,
-                          "endFilePos": 308,
-                          "kind": 2,
-                          "rawValue": "\"is_senior\""
-                        },
-                        "value": "is_senior"
-                      },
-                      "value": {
-                        "nodeType": "Expr_BinaryOp_GreaterOrEqual",
-                        "attributes": {
-                          "startLine": 6,
-                          "startTokenPos": 137,
-                          "startFilePos": 313,
-                          "endLine": 6,
-                          "endTokenPos": 144,
-                          "endFilePos": 332
-                        },
-                        "left": {
-                          "nodeType": "Expr_ArrayDimFetch",
-                          "attributes": {
-                            "startLine": 6,
-                            "startTokenPos": 137,
-                            "startFilePos": 313,
-                            "endLine": 6,
-                            "endTokenPos": 140,
-                            "endFilePos": 326
-                          },
-                          "var": {
-                            "nodeType": "Expr_Variable",
-                            "attributes": {
-                              "startLine": 6,
-                              "startTokenPos": 137,
-                              "startFilePos": 313,
-                              "endLine": 6,
-                              "endTokenPos": 137,
-                              "endFilePos": 319
+                      "kind": "array_creation_expression",
+                      "children": [
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "name"
+                                }
+                              ]
                             },
-                            "name": "person"
-                          },
-                          "dim": {
-                            "nodeType": "Scalar_String",
-                            "attributes": {
-                              "startLine": 6,
-                              "startTokenPos": 139,
-                              "startFilePos": 321,
-                              "endLine": 6,
-                              "endTokenPos": 139,
-                              "endFilePos": 325,
-                              "kind": 2,
-                              "rawValue": "\"age\""
-                            },
-                            "value": "age"
-                          }
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "Alice"
+                                }
+                              ]
+                            }
+                          ]
                         },
-                        "right": {
-                          "nodeType": "Scalar_Int",
-                          "attributes": {
-                            "startLine": 6,
-                            "startTokenPos": 144,
-                            "startFilePos": 331,
-                            "endLine": 6,
-                            "endTokenPos": 144,
-                            "endFilePos": 332,
-                            "rawValue": "60",
-                            "kind": 10
-                          },
-                          "value": 60
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "age"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "integer",
+                              "text": "30"
+                            }
+                          ]
                         }
-                      },
-                      "byRef": false,
-                      "unpack": false
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "array_creation_expression",
+                      "children": [
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "name"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "Bob"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "age"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "integer",
+                              "text": "15"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "array_creation_expression",
+                      "children": [
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "name"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "Charlie"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "age"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "integer",
+                              "text": "65"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "array_creation_expression",
+                      "children": [
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "name"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "Diana"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "array_element_initializer",
+                          "children": [
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "age"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "integer",
+                              "text": "45"
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
                 }
-              }
+              ]
             }
-          ],
-          "elseifs": [],
-          "else": null
+          ]
         }
       ]
     },
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 10,
-        "startTokenPos": 152,
-        "startFilePos": 343,
-        "endLine": 10,
-        "endTokenPos": 158,
-        "endFilePos": 373
-      },
-      "exprs": [
+      "kind": "expression_statement",
+      "children": [
         {
-          "nodeType": "Scalar_String",
-          "attributes": {
-            "startLine": 10,
-            "startTokenPos": 154,
-            "startFilePos": 348,
-            "endLine": 10,
-            "endTokenPos": 154,
-            "endFilePos": 363,
-            "kind": 2,
-            "rawValue": "\"--- Adults ---\""
-          },
-          "value": "--- Adults ---"
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 10,
-            "startTokenPos": 157,
-            "startFilePos": 366,
-            "endLine": 10,
-            "endTokenPos": 157,
-            "endFilePos": 372
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 10,
-              "startTokenPos": 157,
-              "startFilePos": 366,
-              "endLine": 10,
-              "endTokenPos": 157,
-              "endFilePos": 372
-            },
-            "name": "PHP_EOL"
-          }
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "adults"
+                }
+              ]
+            }
+          ]
         }
       ]
     },
     {
-      "nodeType": "Stmt_Foreach",
-      "attributes": {
-        "startLine": 11,
-        "startTokenPos": 160,
-        "startFilePos": 375,
-        "endLine": 13,
-        "endTokenPos": 273,
-        "endFilePos": 657
-      },
-      "expr": {
-        "nodeType": "Expr_Variable",
-        "attributes": {
-          "startLine": 11,
-          "startTokenPos": 163,
-          "startFilePos": 384,
-          "endLine": 11,
-          "endTokenPos": 163,
-          "endFilePos": 390
-        },
-        "name": "adults"
-      },
-      "keyVar": null,
-      "byRef": false,
-      "valueVar": {
-        "nodeType": "Expr_Variable",
-        "attributes": {
-          "startLine": 11,
-          "startTokenPos": 167,
-          "startFilePos": 395,
-          "endLine": 11,
-          "endTokenPos": 167,
-          "endFilePos": 401
-        },
-        "name": "person"
-      },
-      "stmts": [
+      "kind": "foreach_statement",
+      "children": [
         {
-          "nodeType": "Stmt_Echo",
-          "attributes": {
-            "startLine": 12,
-            "startTokenPos": 172,
-            "startFilePos": 408,
-            "endLine": 12,
-            "endTokenPos": 271,
-            "endFilePos": 655
-          },
-          "exprs": [
+          "kind": "variable_name",
+          "children": [
             {
-              "nodeType": "Expr_BinaryOp_Concat",
-              "attributes": {
-                "startLine": 12,
-                "startTokenPos": 174,
-                "startFilePos": 413,
-                "endLine": 12,
-                "endTokenPos": 267,
-                "endFilePos": 645
-              },
-              "left": {
-                "nodeType": "Expr_BinaryOp_Concat",
-                "attributes": {
-                  "startLine": 12,
-                  "startTokenPos": 174,
-                  "startFilePos": 413,
-                  "endLine": 12,
-                  "endTokenPos": 250,
-                  "endFilePos": 601
-                },
-                "left": {
-                  "nodeType": "Expr_BinaryOp_Concat",
-                  "attributes": {
-                    "startLine": 12,
-                    "startTokenPos": 174,
-                    "startFilePos": 413,
-                    "endLine": 12,
-                    "endTokenPos": 246,
-                    "endFilePos": 595
-                  },
-                  "left": {
-                    "nodeType": "Expr_BinaryOp_Concat",
-                    "attributes": {
-                      "startLine": 12,
-                      "startTokenPos": 174,
-                      "startFilePos": 413,
-                      "endLine": 12,
-                      "endTokenPos": 214,
-                      "endFilePos": 513
-                    },
-                    "left": {
-                      "nodeType": "Expr_BinaryOp_Concat",
-                      "attributes": {
-                        "startLine": 12,
-                        "startTokenPos": 174,
-                        "startFilePos": 413,
-                        "endLine": 12,
-                        "endTokenPos": 210,
-                        "endFilePos": 507
-                      },
-                      "left": {
-                        "nodeType": "Expr_BinaryOp_Concat",
-                        "attributes": {
-                          "startLine": 12,
-                          "startTokenPos": 174,
-                          "startFilePos": 413,
-                          "endLine": 12,
-                          "endTokenPos": 206,
-                          "endFilePos": 500
-                        },
-                        "left": {
-                          "nodeType": "Expr_Ternary",
-                          "attributes": {
-                            "startLine": 12,
-                            "startTokenPos": 175,
-                            "startFilePos": 414,
-                            "endLine": 12,
-                            "endTokenPos": 201,
-                            "endFilePos": 493
-                          },
-                          "cond": {
-                            "nodeType": "Expr_FuncCall",
-                            "attributes": {
-                              "startLine": 12,
-                              "startTokenPos": 175,
-                              "startFilePos": 414,
-                              "endLine": 12,
-                              "endTokenPos": 181,
-                              "endFilePos": 438
-                            },
-                            "name": {
-                              "nodeType": "Name",
-                              "attributes": {
-                                "startLine": 12,
-                                "startTokenPos": 175,
-                                "startFilePos": 414,
-                                "endLine": 12,
-                                "endTokenPos": 175,
-                                "endFilePos": 421
-                              },
-                              "name": "is_float"
-                            },
-                            "args": [
-                              {
-                                "nodeType": "Arg",
-                                "attributes": {
-                                  "startLine": 12,
-                                  "startTokenPos": 177,
-                                  "startFilePos": 423,
-                                  "endLine": 12,
-                                  "endTokenPos": 180,
-                                  "endFilePos": 437
-                                },
-                                "name": null,
-                                "value": {
-                                  "nodeType": "Expr_ArrayDimFetch",
-                                  "attributes": {
-                                    "startLine": 12,
-                                    "startTokenPos": 177,
-                                    "startFilePos": 423,
-                                    "endLine": 12,
-                                    "endTokenPos": 180,
-                                    "endFilePos": 437
-                                  },
-                                  "var": {
-                                    "nodeType": "Expr_Variable",
-                                    "attributes": {
-                                      "startLine": 12,
-                                      "startTokenPos": 177,
-                                      "startFilePos": 423,
-                                      "endLine": 12,
-                                      "endTokenPos": 177,
-                                      "endFilePos": 429
-                                    },
-                                    "name": "person"
-                                  },
-                                  "dim": {
-                                    "nodeType": "Scalar_String",
-                                    "attributes": {
-                                      "startLine": 12,
-                                      "startTokenPos": 179,
-                                      "startFilePos": 431,
-                                      "endLine": 12,
-                                      "endTokenPos": 179,
-                                      "endFilePos": 436,
-                                      "kind": 2,
-                                      "rawValue": "\"name\""
-                                    },
-                                    "value": "name"
-                                  }
-                                },
-                                "byRef": false,
-                                "unpack": false
-                              }
-                            ]
-                          },
-                          "if": {
-                            "nodeType": "Expr_FuncCall",
-                            "attributes": {
-                              "startLine": 12,
-                              "startTokenPos": 185,
-                              "startFilePos": 442,
-                              "endLine": 12,
-                              "endTokenPos": 194,
-                              "endFilePos": 475
-                            },
-                            "name": {
-                              "nodeType": "Name",
-                              "attributes": {
-                                "startLine": 12,
-                                "startTokenPos": 185,
-                                "startFilePos": 442,
-                                "endLine": 12,
-                                "endTokenPos": 185,
-                                "endFilePos": 452
-                              },
-                              "name": "json_encode"
-                            },
-                            "args": [
-                              {
-                                "nodeType": "Arg",
-                                "attributes": {
-                                  "startLine": 12,
-                                  "startTokenPos": 187,
-                                  "startFilePos": 454,
-                                  "endLine": 12,
-                                  "endTokenPos": 190,
-                                  "endFilePos": 468
-                                },
-                                "name": null,
-                                "value": {
-                                  "nodeType": "Expr_ArrayDimFetch",
-                                  "attributes": {
-                                    "startLine": 12,
-                                    "startTokenPos": 187,
-                                    "startFilePos": 454,
-                                    "endLine": 12,
-                                    "endTokenPos": 190,
-                                    "endFilePos": 468
-                                  },
-                                  "var": {
-                                    "nodeType": "Expr_Variable",
-                                    "attributes": {
-                                      "startLine": 12,
-                                      "startTokenPos": 187,
-                                      "startFilePos": 454,
-                                      "endLine": 12,
-                                      "endTokenPos": 187,
-                                      "endFilePos": 460
-                                    },
-                                    "name": "person"
-                                  },
-                                  "dim": {
-                                    "nodeType": "Scalar_String",
-                                    "attributes": {
-                                      "startLine": 12,
-                                      "startTokenPos": 189,
-                                      "startFilePos": 462,
-                                      "endLine": 12,
-                                      "endTokenPos": 189,
-                                      "endFilePos": 467,
-                                      "kind": 2,
-                                      "rawValue": "\"name\""
-                                    },
-                                    "value": "name"
-                                  }
-                                },
-                                "byRef": false,
-                                "unpack": false
-                              },
-                              {
-                                "nodeType": "Arg",
-                                "attributes": {
-                                  "startLine": 12,
-                                  "startTokenPos": 193,
-                                  "startFilePos": 471,
-                                  "endLine": 12,
-                                  "endTokenPos": 193,
-                                  "endFilePos": 474
-                                },
-                                "name": null,
-                                "value": {
-                                  "nodeType": "Scalar_Int",
-                                  "attributes": {
-                                    "startLine": 12,
-                                    "startTokenPos": 193,
-                                    "startFilePos": 471,
-                                    "endLine": 12,
-                                    "endTokenPos": 193,
-                                    "endFilePos": 474,
-                                    "rawValue": "1344",
-                                    "kind": 10
-                                  },
-                                  "value": 1344
-                                },
-                                "byRef": false,
-                                "unpack": false
-                              }
-                            ]
-                          },
-                          "else": {
-                            "nodeType": "Expr_ArrayDimFetch",
-                            "attributes": {
-                              "startLine": 12,
-                              "startTokenPos": 198,
-                              "startFilePos": 479,
-                              "endLine": 12,
-                              "endTokenPos": 201,
-                              "endFilePos": 493
-                            },
-                            "var": {
-                              "nodeType": "Expr_Variable",
-                              "attributes": {
-                                "startLine": 12,
-                                "startTokenPos": 198,
-                                "startFilePos": 479,
-                                "endLine": 12,
-                                "endTokenPos": 198,
-                                "endFilePos": 485
-                              },
-                              "name": "person"
-                            },
-                            "dim": {
-                              "nodeType": "Scalar_String",
-                              "attributes": {
-                                "startLine": 12,
-                                "startTokenPos": 200,
-                                "startFilePos": 487,
-                                "endLine": 12,
-                                "endTokenPos": 200,
-                                "endFilePos": 492,
-                                "kind": 2,
-                                "rawValue": "\"name\""
-                              },
-                              "value": "name"
-                            }
-                          }
-                        },
-                        "right": {
-                          "nodeType": "Scalar_String",
-                          "attributes": {
-                            "startLine": 12,
-                            "startTokenPos": 206,
-                            "startFilePos": 498,
-                            "endLine": 12,
-                            "endTokenPos": 206,
-                            "endFilePos": 500,
-                            "kind": 2,
-                            "rawValue": "\" \""
-                          },
-                          "value": " "
-                        }
-                      },
-                      "right": {
-                        "nodeType": "Scalar_String",
-                        "attributes": {
-                          "startLine": 12,
-                          "startTokenPos": 210,
-                          "startFilePos": 504,
-                          "endLine": 12,
-                          "endTokenPos": 210,
-                          "endFilePos": 507,
-                          "kind": 2,
-                          "rawValue": "\"is\""
-                        },
-                        "value": "is"
-                      }
-                    },
-                    "right": {
-                      "nodeType": "Scalar_String",
-                      "attributes": {
-                        "startLine": 12,
-                        "startTokenPos": 214,
-                        "startFilePos": 511,
-                        "endLine": 12,
-                        "endTokenPos": 214,
-                        "endFilePos": 513,
-                        "kind": 2,
-                        "rawValue": "\" \""
-                      },
-                      "value": " "
-                    }
-                  },
-                  "right": {
-                    "nodeType": "Expr_Ternary",
-                    "attributes": {
-                      "startLine": 12,
-                      "startTokenPos": 219,
-                      "startFilePos": 518,
-                      "endLine": 12,
-                      "endTokenPos": 245,
-                      "endFilePos": 594
-                    },
-                    "cond": {
-                      "nodeType": "Expr_FuncCall",
-                      "attributes": {
-                        "startLine": 12,
-                        "startTokenPos": 219,
-                        "startFilePos": 518,
-                        "endLine": 12,
-                        "endTokenPos": 225,
-                        "endFilePos": 541
-                      },
-                      "name": {
-                        "nodeType": "Name",
-                        "attributes": {
-                          "startLine": 12,
-                          "startTokenPos": 219,
-                          "startFilePos": 518,
-                          "endLine": 12,
-                          "endTokenPos": 219,
-                          "endFilePos": 525
-                        },
-                        "name": "is_float"
-                      },
-                      "args": [
+              "kind": "name",
+              "text": "people"
+            }
+          ]
+        },
+        {
+          "kind": "variable_name",
+          "children": [
+            {
+              "kind": "name",
+              "text": "person"
+            }
+          ]
+        },
+        {
+          "kind": "compound_statement",
+          "children": [
+            {
+              "kind": "if_statement",
+              "children": [
+                {
+                  "kind": "parenthesized_expression",
+                  "children": [
+                    {
+                      "kind": "binary_expression",
+                      "children": [
                         {
-                          "nodeType": "Arg",
-                          "attributes": {
-                            "startLine": 12,
-                            "startTokenPos": 221,
-                            "startFilePos": 527,
-                            "endLine": 12,
-                            "endTokenPos": 224,
-                            "endFilePos": 540
-                          },
-                          "name": null,
-                          "value": {
-                            "nodeType": "Expr_ArrayDimFetch",
-                            "attributes": {
-                              "startLine": 12,
-                              "startTokenPos": 221,
-                              "startFilePos": 527,
-                              "endLine": 12,
-                              "endTokenPos": 224,
-                              "endFilePos": 540
+                          "kind": "subscript_expression",
+                          "children": [
+                            {
+                              "kind": "variable_name",
+                              "children": [
+                                {
+                                  "kind": "name",
+                                  "text": "person"
+                                }
+                              ]
                             },
-                            "var": {
-                              "nodeType": "Expr_Variable",
-                              "attributes": {
-                                "startLine": 12,
-                                "startTokenPos": 221,
-                                "startFilePos": 527,
-                                "endLine": 12,
-                                "endTokenPos": 221,
-                                "endFilePos": 533
-                              },
-                              "name": "person"
-                            },
-                            "dim": {
-                              "nodeType": "Scalar_String",
-                              "attributes": {
-                                "startLine": 12,
-                                "startTokenPos": 223,
-                                "startFilePos": 535,
-                                "endLine": 12,
-                                "endTokenPos": 223,
-                                "endFilePos": 539,
-                                "kind": 2,
-                                "rawValue": "\"age\""
-                              },
-                              "value": "age"
+                            {
+                              "kind": "encapsed_string",
+                              "children": [
+                                {
+                                  "kind": "string_content",
+                                  "text": "age"
+                                }
+                              ]
                             }
-                          },
-                          "byRef": false,
-                          "unpack": false
+                          ]
+                        },
+                        {
+                          "kind": "integer",
+                          "text": "18"
                         }
                       ]
-                    },
-                    "if": {
-                      "nodeType": "Expr_FuncCall",
-                      "attributes": {
-                        "startLine": 12,
-                        "startTokenPos": 229,
-                        "startFilePos": 545,
-                        "endLine": 12,
-                        "endTokenPos": 238,
-                        "endFilePos": 577
-                      },
-                      "name": {
-                        "nodeType": "Name",
-                        "attributes": {
-                          "startLine": 12,
-                          "startTokenPos": 229,
-                          "startFilePos": 545,
-                          "endLine": 12,
-                          "endTokenPos": 229,
-                          "endFilePos": 555
-                        },
-                        "name": "json_encode"
-                      },
-                      "args": [
+                    }
+                  ]
+                },
+                {
+                  "kind": "compound_statement",
+                  "children": [
+                    {
+                      "kind": "expression_statement",
+                      "children": [
                         {
-                          "nodeType": "Arg",
-                          "attributes": {
-                            "startLine": 12,
-                            "startTokenPos": 231,
-                            "startFilePos": 557,
-                            "endLine": 12,
-                            "endTokenPos": 234,
-                            "endFilePos": 570
-                          },
-                          "name": null,
-                          "value": {
-                            "nodeType": "Expr_ArrayDimFetch",
-                            "attributes": {
-                              "startLine": 12,
-                              "startTokenPos": 231,
-                              "startFilePos": 557,
-                              "endLine": 12,
-                              "endTokenPos": 234,
-                              "endFilePos": 570
+                          "kind": "assignment_expression",
+                          "children": [
+                            {
+                              "kind": "subscript_expression",
+                              "children": [
+                                {
+                                  "kind": "variable_name",
+                                  "children": [
+                                    {
+                                      "kind": "name",
+                                      "text": "adults"
+                                    }
+                                  ]
+                                }
+                              ]
                             },
-                            "var": {
-                              "nodeType": "Expr_Variable",
-                              "attributes": {
-                                "startLine": 12,
-                                "startTokenPos": 231,
-                                "startFilePos": 557,
-                                "endLine": 12,
-                                "endTokenPos": 231,
-                                "endFilePos": 563
-                              },
-                              "name": "person"
-                            },
-                            "dim": {
-                              "nodeType": "Scalar_String",
-                              "attributes": {
-                                "startLine": 12,
-                                "startTokenPos": 233,
-                                "startFilePos": 565,
-                                "endLine": 12,
-                                "endTokenPos": 233,
-                                "endFilePos": 569,
-                                "kind": 2,
-                                "rawValue": "\"age\""
-                              },
-                              "value": "age"
+                            {
+                              "kind": "array_creation_expression",
+                              "children": [
+                                {
+                                  "kind": "array_element_initializer",
+                                  "children": [
+                                    {
+                                      "kind": "encapsed_string",
+                                      "children": [
+                                        {
+                                          "kind": "string_content",
+                                          "text": "name"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "subscript_expression",
+                                      "children": [
+                                        {
+                                          "kind": "variable_name",
+                                          "children": [
+                                            {
+                                              "kind": "name",
+                                              "text": "person"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "encapsed_string",
+                                          "children": [
+                                            {
+                                              "kind": "string_content",
+                                              "text": "name"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "array_element_initializer",
+                                  "children": [
+                                    {
+                                      "kind": "encapsed_string",
+                                      "children": [
+                                        {
+                                          "kind": "string_content",
+                                          "text": "age"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "subscript_expression",
+                                      "children": [
+                                        {
+                                          "kind": "variable_name",
+                                          "children": [
+                                            {
+                                              "kind": "name",
+                                              "text": "person"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "encapsed_string",
+                                          "children": [
+                                            {
+                                              "kind": "string_content",
+                                              "text": "age"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "array_element_initializer",
+                                  "children": [
+                                    {
+                                      "kind": "encapsed_string",
+                                      "children": [
+                                        {
+                                          "kind": "string_content",
+                                          "text": "is_senior"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "binary_expression",
+                                      "children": [
+                                        {
+                                          "kind": "subscript_expression",
+                                          "children": [
+                                            {
+                                              "kind": "variable_name",
+                                              "children": [
+                                                {
+                                                  "kind": "name",
+                                                  "text": "person"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "encapsed_string",
+                                              "children": [
+                                                {
+                                                  "kind": "string_content",
+                                                  "text": "age"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "integer",
+                                          "text": "60"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
                             }
-                          },
-                          "byRef": false,
-                          "unpack": false
-                        },
-                        {
-                          "nodeType": "Arg",
-                          "attributes": {
-                            "startLine": 12,
-                            "startTokenPos": 237,
-                            "startFilePos": 573,
-                            "endLine": 12,
-                            "endTokenPos": 237,
-                            "endFilePos": 576
-                          },
-                          "name": null,
-                          "value": {
-                            "nodeType": "Scalar_Int",
-                            "attributes": {
-                              "startLine": 12,
-                              "startTokenPos": 237,
-                              "startFilePos": 573,
-                              "endLine": 12,
-                              "endTokenPos": 237,
-                              "endFilePos": 576,
-                              "rawValue": "1344",
-                              "kind": 10
-                            },
-                            "value": 1344
-                          },
-                          "byRef": false,
-                          "unpack": false
+                          ]
                         }
                       ]
-                    },
-                    "else": {
-                      "nodeType": "Expr_ArrayDimFetch",
-                      "attributes": {
-                        "startLine": 12,
-                        "startTokenPos": 242,
-                        "startFilePos": 581,
-                        "endLine": 12,
-                        "endTokenPos": 245,
-                        "endFilePos": 594
-                      },
-                      "var": {
-                        "nodeType": "Expr_Variable",
-                        "attributes": {
-                          "startLine": 12,
-                          "startTokenPos": 242,
-                          "startFilePos": 581,
-                          "endLine": 12,
-                          "endTokenPos": 242,
-                          "endFilePos": 587
-                        },
-                        "name": "person"
-                      },
-                      "dim": {
-                        "nodeType": "Scalar_String",
-                        "attributes": {
-                          "startLine": 12,
-                          "startTokenPos": 244,
-                          "startFilePos": 589,
-                          "endLine": 12,
-                          "endTokenPos": 244,
-                          "endFilePos": 593,
-                          "kind": 2,
-                          "rawValue": "\"age\""
-                        },
-                        "value": "age"
-                      }
                     }
-                  }
-                },
-                "right": {
-                  "nodeType": "Scalar_String",
-                  "attributes": {
-                    "startLine": 12,
-                    "startTokenPos": 250,
-                    "startFilePos": 599,
-                    "endLine": 12,
-                    "endTokenPos": 250,
-                    "endFilePos": 601,
-                    "kind": 2,
-                    "rawValue": "\" \""
-                  },
-                  "value": " "
+                  ]
                 }
-              },
-              "right": {
-                "nodeType": "Expr_Ternary",
-                "attributes": {
-                  "startLine": 12,
-                  "startTokenPos": 255,
-                  "startFilePos": 606,
-                  "endLine": 12,
-                  "endTokenPos": 266,
-                  "endFilePos": 644
-                },
-                "cond": {
-                  "nodeType": "Expr_ArrayDimFetch",
-                  "attributes": {
-                    "startLine": 12,
-                    "startTokenPos": 255,
-                    "startFilePos": 606,
-                    "endLine": 12,
-                    "endTokenPos": 258,
-                    "endFilePos": 625
-                  },
-                  "var": {
-                    "nodeType": "Expr_Variable",
-                    "attributes": {
-                      "startLine": 12,
-                      "startTokenPos": 255,
-                      "startFilePos": 606,
-                      "endLine": 12,
-                      "endTokenPos": 255,
-                      "endFilePos": 612
-                    },
-                    "name": "person"
-                  },
-                  "dim": {
-                    "nodeType": "Scalar_String",
-                    "attributes": {
-                      "startLine": 12,
-                      "startTokenPos": 257,
-                      "startFilePos": 614,
-                      "endLine": 12,
-                      "endTokenPos": 257,
-                      "endFilePos": 624,
-                      "kind": 2,
-                      "rawValue": "\"is_senior\""
-                    },
-                    "value": "is_senior"
-                  }
-                },
-                "if": {
-                  "nodeType": "Scalar_String",
-                  "attributes": {
-                    "startLine": 12,
-                    "startTokenPos": 262,
-                    "startFilePos": 629,
-                    "endLine": 12,
-                    "endTokenPos": 262,
-                    "endFilePos": 639,
-                    "kind": 2,
-                    "rawValue": "\" (senior)\""
-                  },
-                  "value": " (senior)"
-                },
-                "else": {
-                  "nodeType": "Scalar_String",
-                  "attributes": {
-                    "startLine": 12,
-                    "startTokenPos": 266,
-                    "startFilePos": 643,
-                    "endLine": 12,
-                    "endTokenPos": 266,
-                    "endFilePos": 644,
-                    "kind": 2,
-                    "rawValue": "\"\""
-                  },
-                  "value": ""
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "echo_statement",
+      "children": [
+        {
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "encapsed_string",
+              "children": [
+                {
+                  "kind": "string_content",
+                  "text": "--- Adults ---"
                 }
-              }
+              ]
             },
             {
-              "nodeType": "Expr_ConstFetch",
-              "attributes": {
-                "startLine": 12,
-                "startTokenPos": 270,
-                "startFilePos": 648,
-                "endLine": 12,
-                "endTokenPos": 270,
-                "endFilePos": 654
-              },
-              "name": {
-                "nodeType": "Name",
-                "attributes": {
-                  "startLine": 12,
-                  "startTokenPos": 270,
-                  "startFilePos": 648,
-                  "endLine": 12,
-                  "endTokenPos": 270,
-                  "endFilePos": 654
-                },
-                "name": "PHP_EOL"
-              }
+              "kind": "name",
+              "text": "PHP_EOL"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "foreach_statement",
+      "children": [
+        {
+          "kind": "variable_name",
+          "children": [
+            {
+              "kind": "name",
+              "text": "adults"
+            }
+          ]
+        },
+        {
+          "kind": "variable_name",
+          "children": [
+            {
+              "kind": "name",
+              "text": "person"
+            }
+          ]
+        },
+        {
+          "kind": "compound_statement",
+          "children": [
+            {
+              "kind": "echo_statement",
+              "children": [
+                {
+                  "kind": "sequence_expression",
+                  "children": [
+                    {
+                      "kind": "binary_expression",
+                      "children": [
+                        {
+                          "kind": "binary_expression",
+                          "children": [
+                            {
+                              "kind": "binary_expression",
+                              "children": [
+                                {
+                                  "kind": "binary_expression",
+                                  "children": [
+                                    {
+                                      "kind": "binary_expression",
+                                      "children": [
+                                        {
+                                          "kind": "binary_expression",
+                                          "children": [
+                                            {
+                                              "kind": "parenthesized_expression",
+                                              "children": [
+                                                {
+                                                  "kind": "conditional_expression",
+                                                  "children": [
+                                                    {
+                                                      "kind": "function_call_expression",
+                                                      "children": [
+                                                        {
+                                                          "kind": "name",
+                                                          "text": "is_float"
+                                                        },
+                                                        {
+                                                          "kind": "arguments",
+                                                          "children": [
+                                                            {
+                                                              "kind": "argument",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "subscript_expression",
+                                                                  "children": [
+                                                                    {
+                                                                      "kind": "variable_name",
+                                                                      "children": [
+                                                                        {
+                                                                          "kind": "name",
+                                                                          "text": "person"
+                                                                        }
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "kind": "encapsed_string",
+                                                                      "children": [
+                                                                        {
+                                                                          "kind": "string_content",
+                                                                          "text": "name"
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "function_call_expression",
+                                                      "children": [
+                                                        {
+                                                          "kind": "name",
+                                                          "text": "json_encode"
+                                                        },
+                                                        {
+                                                          "kind": "arguments",
+                                                          "children": [
+                                                            {
+                                                              "kind": "argument",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "subscript_expression",
+                                                                  "children": [
+                                                                    {
+                                                                      "kind": "variable_name",
+                                                                      "children": [
+                                                                        {
+                                                                          "kind": "name",
+                                                                          "text": "person"
+                                                                        }
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "kind": "encapsed_string",
+                                                                      "children": [
+                                                                        {
+                                                                          "kind": "string_content",
+                                                                          "text": "name"
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              ]
+                                                            },
+                                                            {
+                                                              "kind": "argument",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "integer",
+                                                                  "text": "1344"
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "subscript_expression",
+                                                      "children": [
+                                                        {
+                                                          "kind": "variable_name",
+                                                          "children": [
+                                                            {
+                                                              "kind": "name",
+                                                              "text": "person"
+                                                            }
+                                                          ]
+                                                        },
+                                                        {
+                                                          "kind": "encapsed_string",
+                                                          "children": [
+                                                            {
+                                                              "kind": "string_content",
+                                                              "text": "name"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "encapsed_string",
+                                          "children": [
+                                            {
+                                              "kind": "string_content",
+                                              "text": "is"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "parenthesized_expression",
+                                  "children": [
+                                    {
+                                      "kind": "conditional_expression",
+                                      "children": [
+                                        {
+                                          "kind": "function_call_expression",
+                                          "children": [
+                                            {
+                                              "kind": "name",
+                                              "text": "is_float"
+                                            },
+                                            {
+                                              "kind": "arguments",
+                                              "children": [
+                                                {
+                                                  "kind": "argument",
+                                                  "children": [
+                                                    {
+                                                      "kind": "subscript_expression",
+                                                      "children": [
+                                                        {
+                                                          "kind": "variable_name",
+                                                          "children": [
+                                                            {
+                                                              "kind": "name",
+                                                              "text": "person"
+                                                            }
+                                                          ]
+                                                        },
+                                                        {
+                                                          "kind": "encapsed_string",
+                                                          "children": [
+                                                            {
+                                                              "kind": "string_content",
+                                                              "text": "age"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "function_call_expression",
+                                          "children": [
+                                            {
+                                              "kind": "name",
+                                              "text": "json_encode"
+                                            },
+                                            {
+                                              "kind": "arguments",
+                                              "children": [
+                                                {
+                                                  "kind": "argument",
+                                                  "children": [
+                                                    {
+                                                      "kind": "subscript_expression",
+                                                      "children": [
+                                                        {
+                                                          "kind": "variable_name",
+                                                          "children": [
+                                                            {
+                                                              "kind": "name",
+                                                              "text": "person"
+                                                            }
+                                                          ]
+                                                        },
+                                                        {
+                                                          "kind": "encapsed_string",
+                                                          "children": [
+                                                            {
+                                                              "kind": "string_content",
+                                                              "text": "age"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "argument",
+                                                  "children": [
+                                                    {
+                                                      "kind": "integer",
+                                                      "text": "1344"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "subscript_expression",
+                                          "children": [
+                                            {
+                                              "kind": "variable_name",
+                                              "children": [
+                                                {
+                                                  "kind": "name",
+                                                  "text": "person"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "encapsed_string",
+                                              "children": [
+                                                {
+                                                  "kind": "string_content",
+                                                  "text": "age"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "parenthesized_expression",
+                          "children": [
+                            {
+                              "kind": "conditional_expression",
+                              "children": [
+                                {
+                                  "kind": "subscript_expression",
+                                  "children": [
+                                    {
+                                      "kind": "variable_name",
+                                      "children": [
+                                        {
+                                          "kind": "name",
+                                          "text": "person"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "encapsed_string",
+                                      "children": [
+                                        {
+                                          "kind": "string_content",
+                                          "text": "is_senior"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "encapsed_string",
+                                  "children": [
+                                    {
+                                      "kind": "string_content",
+                                      "text": " (senior)"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "encapsed_string",
+                                  "text": "\"\""
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "name",
+                      "text": "PHP_EOL"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }

--- a/tests/json-ast/x/php/exists_builtin.php.json
+++ b/tests/json-ast/x/php/exists_builtin.php.json
@@ -1,566 +1,303 @@
 {
-  "root": [
+  "statements": [
     {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 2,
-        "startTokenPos": 1,
-        "startFilePos": 6,
-        "endLine": 2,
-        "endTokenPos": 11,
-        "endFilePos": 20
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 2,
-          "startTokenPos": 1,
-          "startFilePos": 6,
-          "endLine": 2,
-          "endTokenPos": 10,
-          "endFilePos": 19
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 1,
-            "startFilePos": 6,
-            "endLine": 2,
-            "endTokenPos": 1,
-            "endFilePos": 10
-          },
-          "name": "data"
-        },
-        "expr": {
-          "nodeType": "Expr_Array",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 5,
-            "startFilePos": 14,
-            "endLine": 2,
-            "endTokenPos": 10,
-            "endFilePos": 19,
-            "kind": 2
-          },
-          "items": [
+      "kind": "expression_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
             {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 6,
-                "startFilePos": 15,
-                "endLine": 2,
-                "endTokenPos": 6,
-                "endFilePos": 15
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 6,
-                  "startFilePos": 15,
-                  "endLine": 2,
-                  "endTokenPos": 6,
-                  "endFilePos": 15,
-                  "rawValue": "1",
-                  "kind": 10
-                },
-                "value": 1
-              },
-              "byRef": false,
-              "unpack": false
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "data"
+                }
+              ]
             },
             {
-              "nodeType": "ArrayItem",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 9,
-                "startFilePos": 18,
-                "endLine": 2,
-                "endTokenPos": 9,
-                "endFilePos": 18
-              },
-              "key": null,
-              "value": {
-                "nodeType": "Scalar_Int",
-                "attributes": {
-                  "startLine": 2,
-                  "startTokenPos": 9,
-                  "startFilePos": 18,
-                  "endLine": 2,
-                  "endTokenPos": 9,
-                  "endFilePos": 18,
-                  "rawValue": "2",
-                  "kind": 10
+              "kind": "array_creation_expression",
+              "children": [
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "integer",
+                      "text": "1"
+                    }
+                  ]
                 },
-                "value": 2
-              },
-              "byRef": false,
-              "unpack": false
+                {
+                  "kind": "array_element_initializer",
+                  "children": [
+                    {
+                      "kind": "integer",
+                      "text": "2"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }
-      }
+      ]
     },
     {
-      "nodeType": "Stmt_Expression",
-      "attributes": {
-        "startLine": 3,
-        "startTokenPos": 13,
-        "startFilePos": 22,
-        "endLine": 11,
-        "endTokenPos": 91,
-        "endFilePos": 182
-      },
-      "expr": {
-        "nodeType": "Expr_Assign",
-        "attributes": {
-          "startLine": 3,
-          "startTokenPos": 13,
-          "startFilePos": 22,
-          "endLine": 11,
-          "endTokenPos": 90,
-          "endFilePos": 181
-        },
-        "var": {
-          "nodeType": "Expr_Variable",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 13,
-            "startFilePos": 22,
-            "endLine": 3,
-            "endTokenPos": 13,
-            "endFilePos": 26
-          },
-          "name": "flag"
-        },
-        "expr": {
-          "nodeType": "Expr_BinaryOp_Greater",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 17,
-            "startFilePos": 30,
-            "endLine": 11,
-            "endTokenPos": 90,
-            "endFilePos": 181
-          },
-          "left": {
-            "nodeType": "Expr_FuncCall",
-            "attributes": {
-              "startLine": 3,
-              "startTokenPos": 17,
-              "startFilePos": 30,
-              "endLine": 11,
-              "endTokenPos": 86,
-              "endFilePos": 177
+      "kind": "expression_statement",
+      "children": [
+        {
+          "kind": "assignment_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "flag"
+                }
+              ]
             },
-            "name": {
-              "nodeType": "Name",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 17,
-                "startFilePos": 30,
-                "endLine": 3,
-                "endTokenPos": 17,
-                "endFilePos": 34
-              },
-              "name": "count"
-            },
-            "args": [
-              {
-                "nodeType": "Arg",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 19,
-                  "startFilePos": 36,
-                  "endLine": 11,
-                  "endTokenPos": 85,
-                  "endFilePos": 176
-                },
-                "name": null,
-                "value": {
-                  "nodeType": "Expr_FuncCall",
-                  "attributes": {
-                    "startLine": 3,
-                    "startTokenPos": 19,
-                    "startFilePos": 36,
-                    "endLine": 11,
-                    "endTokenPos": 85,
-                    "endFilePos": 176
-                  },
-                  "name": {
-                    "nodeType": "Expr_Closure",
-                    "attributes": {
-                      "startLine": 3,
-                      "startTokenPos": 20,
-                      "startFilePos": 37,
-                      "endLine": 11,
-                      "endTokenPos": 82,
-                      "endFilePos": 173
+            {
+              "kind": "binary_expression",
+              "children": [
+                {
+                  "kind": "function_call_expression",
+                  "children": [
+                    {
+                      "kind": "name",
+                      "text": "count"
                     },
-                    "static": false,
-                    "byRef": false,
-                    "params": [],
-                    "uses": [
-                      {
-                        "nodeType": "ClosureUse",
-                        "attributes": {
-                          "startLine": 3,
-                          "startTokenPos": 27,
-                          "startFilePos": 53,
-                          "endLine": 3,
-                          "endTokenPos": 27,
-                          "endFilePos": 57
-                        },
-                        "var": {
-                          "nodeType": "Expr_Variable",
-                          "attributes": {
-                            "startLine": 3,
-                            "startTokenPos": 27,
-                            "startFilePos": 53,
-                            "endLine": 3,
-                            "endTokenPos": 27,
-                            "endFilePos": 57
-                          },
-                          "name": "data"
-                        },
-                        "byRef": false
-                      }
-                    ],
-                    "returnType": null,
-                    "stmts": [
-                      {
-                        "nodeType": "Stmt_Expression",
-                        "attributes": {
-                          "startLine": 4,
-                          "startTokenPos": 32,
-                          "startFilePos": 64,
-                          "endLine": 4,
-                          "endTokenPos": 38,
-                          "endFilePos": 76
-                        },
-                        "expr": {
-                          "nodeType": "Expr_Assign",
-                          "attributes": {
-                            "startLine": 4,
-                            "startTokenPos": 32,
-                            "startFilePos": 64,
-                            "endLine": 4,
-                            "endTokenPos": 37,
-                            "endFilePos": 75
-                          },
-                          "var": {
-                            "nodeType": "Expr_Variable",
-                            "attributes": {
-                              "startLine": 4,
-                              "startTokenPos": 32,
-                              "startFilePos": 64,
-                              "endLine": 4,
-                              "endTokenPos": 32,
-                              "endFilePos": 70
-                            },
-                            "name": "result"
-                          },
-                          "expr": {
-                            "nodeType": "Expr_Array",
-                            "attributes": {
-                              "startLine": 4,
-                              "startTokenPos": 36,
-                              "startFilePos": 74,
-                              "endLine": 4,
-                              "endTokenPos": 37,
-                              "endFilePos": 75,
-                              "kind": 2
-                            },
-                            "items": []
-                          }
-                        }
-                      },
-                      {
-                        "nodeType": "Stmt_Foreach",
-                        "attributes": {
-                          "startLine": 5,
-                          "startTokenPos": 40,
-                          "startFilePos": 80,
-                          "endLine": 9,
-                          "endTokenPos": 75,
-                          "endFilePos": 153
-                        },
-                        "expr": {
-                          "nodeType": "Expr_Variable",
-                          "attributes": {
-                            "startLine": 5,
-                            "startTokenPos": 43,
-                            "startFilePos": 89,
-                            "endLine": 5,
-                            "endTokenPos": 43,
-                            "endFilePos": 93
-                          },
-                          "name": "data"
-                        },
-                        "keyVar": null,
-                        "byRef": false,
-                        "valueVar": {
-                          "nodeType": "Expr_Variable",
-                          "attributes": {
-                            "startLine": 5,
-                            "startTokenPos": 47,
-                            "startFilePos": 98,
-                            "endLine": 5,
-                            "endTokenPos": 47,
-                            "endFilePos": 99
-                          },
-                          "name": "x"
-                        },
-                        "stmts": [
-                          {
-                            "nodeType": "Stmt_If",
-                            "attributes": {
-                              "startLine": 6,
-                              "startTokenPos": 52,
-                              "startFilePos": 108,
-                              "endLine": 8,
-                              "endTokenPos": 73,
-                              "endFilePos": 149
-                            },
-                            "cond": {
-                              "nodeType": "Expr_BinaryOp_Equal",
-                              "attributes": {
-                                "startLine": 6,
-                                "startTokenPos": 55,
-                                "startFilePos": 112,
-                                "endLine": 6,
-                                "endTokenPos": 59,
-                                "endFilePos": 118
-                              },
-                              "left": {
-                                "nodeType": "Expr_Variable",
-                                "attributes": {
-                                  "startLine": 6,
-                                  "startTokenPos": 55,
-                                  "startFilePos": 112,
-                                  "endLine": 6,
-                                  "endTokenPos": 55,
-                                  "endFilePos": 113
-                                },
-                                "name": "x"
-                              },
-                              "right": {
-                                "nodeType": "Scalar_Int",
-                                "attributes": {
-                                  "startLine": 6,
-                                  "startTokenPos": 59,
-                                  "startFilePos": 118,
-                                  "endLine": 6,
-                                  "endTokenPos": 59,
-                                  "endFilePos": 118,
-                                  "rawValue": "1",
-                                  "kind": 10
-                                },
-                                "value": 1
-                              }
-                            },
-                            "stmts": [
-                              {
-                                "nodeType": "Stmt_Expression",
-                                "attributes": {
-                                  "startLine": 7,
-                                  "startTokenPos": 64,
-                                  "startFilePos": 129,
-                                  "endLine": 7,
-                                  "endTokenPos": 71,
-                                  "endFilePos": 143
-                                },
-                                "expr": {
-                                  "nodeType": "Expr_Assign",
-                                  "attributes": {
-                                    "startLine": 7,
-                                    "startTokenPos": 64,
-                                    "startFilePos": 129,
-                                    "endLine": 7,
-                                    "endTokenPos": 70,
-                                    "endFilePos": 142
-                                  },
-                                  "var": {
-                                    "nodeType": "Expr_ArrayDimFetch",
-                                    "attributes": {
-                                      "startLine": 7,
-                                      "startTokenPos": 64,
-                                      "startFilePos": 129,
-                                      "endLine": 7,
-                                      "endTokenPos": 66,
-                                      "endFilePos": 137
-                                    },
-                                    "var": {
-                                      "nodeType": "Expr_Variable",
-                                      "attributes": {
-                                        "startLine": 7,
-                                        "startTokenPos": 64,
-                                        "startFilePos": 129,
-                                        "endLine": 7,
-                                        "endTokenPos": 64,
-                                        "endFilePos": 135
-                                      },
-                                      "name": "result"
-                                    },
-                                    "dim": null
-                                  },
-                                  "expr": {
-                                    "nodeType": "Expr_Variable",
-                                    "attributes": {
-                                      "startLine": 7,
-                                      "startTokenPos": 70,
-                                      "startFilePos": 141,
-                                      "endLine": 7,
-                                      "endTokenPos": 70,
-                                      "endFilePos": 142
-                                    },
-                                    "name": "x"
-                                  }
+                    {
+                      "kind": "arguments",
+                      "children": [
+                        {
+                          "kind": "argument",
+                          "children": [
+                            {
+                              "kind": "function_call_expression",
+                              "children": [
+                                {
+                                  "kind": "parenthesized_expression",
+                                  "children": [
+                                    {
+                                      "kind": "anonymous_function_creation_expression",
+                                      "children": [
+                                        {
+                                          "kind": "anonymous_function_use_clause",
+                                          "children": [
+                                            {
+                                              "kind": "variable_name",
+                                              "children": [
+                                                {
+                                                  "kind": "name",
+                                                  "text": "data"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "compound_statement",
+                                          "children": [
+                                            {
+                                              "kind": "expression_statement",
+                                              "children": [
+                                                {
+                                                  "kind": "assignment_expression",
+                                                  "children": [
+                                                    {
+                                                      "kind": "variable_name",
+                                                      "children": [
+                                                        {
+                                                          "kind": "name",
+                                                          "text": "result"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "foreach_statement",
+                                              "children": [
+                                                {
+                                                  "kind": "variable_name",
+                                                  "children": [
+                                                    {
+                                                      "kind": "name",
+                                                      "text": "data"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "variable_name",
+                                                  "children": [
+                                                    {
+                                                      "kind": "name",
+                                                      "text": "x"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "compound_statement",
+                                                  "children": [
+                                                    {
+                                                      "kind": "if_statement",
+                                                      "children": [
+                                                        {
+                                                          "kind": "parenthesized_expression",
+                                                          "children": [
+                                                            {
+                                                              "kind": "binary_expression",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "variable_name",
+                                                                  "children": [
+                                                                    {
+                                                                      "kind": "name",
+                                                                      "text": "x"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                {
+                                                                  "kind": "integer",
+                                                                  "text": "1"
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        },
+                                                        {
+                                                          "kind": "compound_statement",
+                                                          "children": [
+                                                            {
+                                                              "kind": "expression_statement",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "assignment_expression",
+                                                                  "children": [
+                                                                    {
+                                                                      "kind": "subscript_expression",
+                                                                      "children": [
+                                                                        {
+                                                                          "kind": "variable_name",
+                                                                          "children": [
+                                                                            {
+                                                                              "kind": "name",
+                                                                              "text": "result"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "kind": "variable_name",
+                                                                      "children": [
+                                                                        {
+                                                                          "kind": "name",
+                                                                          "text": "x"
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "return_statement",
+                                              "children": [
+                                                {
+                                                  "kind": "variable_name",
+                                                  "children": [
+                                                    {
+                                                      "kind": "name",
+                                                      "text": "result"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
                                 }
-                              }
-                            ],
-                            "elseifs": [],
-                            "else": null
-                          }
-                        ]
-                      },
-                      {
-                        "nodeType": "Stmt_Return",
-                        "attributes": {
-                          "startLine": 10,
-                          "startTokenPos": 77,
-                          "startFilePos": 157,
-                          "endLine": 10,
-                          "endTokenPos": 80,
-                          "endFilePos": 171
-                        },
-                        "expr": {
-                          "nodeType": "Expr_Variable",
-                          "attributes": {
-                            "startLine": 10,
-                            "startTokenPos": 79,
-                            "startFilePos": 164,
-                            "endLine": 10,
-                            "endTokenPos": 79,
-                            "endFilePos": 170
-                          },
-                          "name": "result"
+                              ]
+                            }
+                          ]
                         }
-                      }
-                    ],
-                    "attrGroups": []
-                  },
-                  "args": []
+                      ]
+                    }
+                  ]
                 },
-                "byRef": false,
-                "unpack": false
-              }
-            ]
-          },
-          "right": {
-            "nodeType": "Scalar_Int",
-            "attributes": {
-              "startLine": 11,
-              "startTokenPos": 90,
-              "startFilePos": 181,
-              "endLine": 11,
-              "endTokenPos": 90,
-              "endFilePos": 181,
-              "rawValue": "0",
-              "kind": 10
-            },
-            "value": 0
-          }
+                {
+                  "kind": "integer",
+                  "text": "0"
+                }
+              ]
+            }
+          ]
         }
-      }
+      ]
     },
     {
-      "nodeType": "Stmt_Echo",
-      "attributes": {
-        "startLine": 12,
-        "startTokenPos": 93,
-        "startFilePos": 184,
-        "endLine": 12,
-        "endTokenPos": 109,
-        "endFilePos": 224
-      },
-      "exprs": [
+      "kind": "echo_statement",
+      "children": [
         {
-          "nodeType": "Expr_Ternary",
-          "attributes": {
-            "startLine": 12,
-            "startTokenPos": 96,
-            "startFilePos": 190,
-            "endLine": 12,
-            "endTokenPos": 104,
-            "endFilePos": 213
-          },
-          "cond": {
-            "nodeType": "Expr_Variable",
-            "attributes": {
-              "startLine": 12,
-              "startTokenPos": 96,
-              "startFilePos": 190,
-              "endLine": 12,
-              "endTokenPos": 96,
-              "endFilePos": 194
+          "kind": "sequence_expression",
+          "children": [
+            {
+              "kind": "parenthesized_expression",
+              "children": [
+                {
+                  "kind": "conditional_expression",
+                  "children": [
+                    {
+                      "kind": "variable_name",
+                      "children": [
+                        {
+                          "kind": "name",
+                          "text": "flag"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "true"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "encapsed_string",
+                      "children": [
+                        {
+                          "kind": "string_content",
+                          "text": "false"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             },
-            "name": "flag"
-          },
-          "if": {
-            "nodeType": "Scalar_String",
-            "attributes": {
-              "startLine": 12,
-              "startTokenPos": 100,
-              "startFilePos": 198,
-              "endLine": 12,
-              "endTokenPos": 100,
-              "endFilePos": 203,
-              "kind": 2,
-              "rawValue": "\"true\""
-            },
-            "value": "true"
-          },
-          "else": {
-            "nodeType": "Scalar_String",
-            "attributes": {
-              "startLine": 12,
-              "startTokenPos": 104,
-              "startFilePos": 207,
-              "endLine": 12,
-              "endTokenPos": 104,
-              "endFilePos": 213,
-              "kind": 2,
-              "rawValue": "\"false\""
-            },
-            "value": "false"
-          }
-        },
-        {
-          "nodeType": "Expr_ConstFetch",
-          "attributes": {
-            "startLine": 12,
-            "startTokenPos": 108,
-            "startFilePos": 217,
-            "endLine": 12,
-            "endTokenPos": 108,
-            "endFilePos": 223
-          },
-          "name": {
-            "nodeType": "Name",
-            "attributes": {
-              "startLine": 12,
-              "startTokenPos": 108,
-              "startFilePos": 217,
-              "endLine": 12,
-              "endTokenPos": 108,
-              "endFilePos": 223
-            },
-            "name": "PHP_EOL"
-          }
+            {
+              "kind": "name",
+              "text": "PHP_EOL"
+            }
+          ]
         }
       ]
     }

--- a/tests/json-ast/x/php/for_list_collection.php.json
+++ b/tests/json-ast/x/php/for_list_collection.php.json
@@ -1,314 +1,149 @@
 {
-  "root": [
+  "statements": [
     {
-      "nodeType": "Stmt_Foreach",
-      "attributes": {
-        "startLine": 2,
-        "startTokenPos": 1,
-        "startFilePos": 6,
-        "endLine": 4,
-        "endTokenPos": 48,
-        "endFilePos": 95
-      },
-      "expr": {
-        "nodeType": "Expr_Array",
-        "attributes": {
-          "startLine": 2,
-          "startTokenPos": 4,
-          "startFilePos": 15,
-          "endLine": 2,
-          "endTokenPos": 12,
-          "endFilePos": 23,
-          "kind": 2
-        },
-        "items": [
-          {
-            "nodeType": "ArrayItem",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 5,
-              "startFilePos": 16,
-              "endLine": 2,
-              "endTokenPos": 5,
-              "endFilePos": 16
-            },
-            "key": null,
-            "value": {
-              "nodeType": "Scalar_Int",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 5,
-                "startFilePos": 16,
-                "endLine": 2,
-                "endTokenPos": 5,
-                "endFilePos": 16,
-                "rawValue": "1",
-                "kind": 10
-              },
-              "value": 1
-            },
-            "byRef": false,
-            "unpack": false
-          },
-          {
-            "nodeType": "ArrayItem",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 8,
-              "startFilePos": 19,
-              "endLine": 2,
-              "endTokenPos": 8,
-              "endFilePos": 19
-            },
-            "key": null,
-            "value": {
-              "nodeType": "Scalar_Int",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 8,
-                "startFilePos": 19,
-                "endLine": 2,
-                "endTokenPos": 8,
-                "endFilePos": 19,
-                "rawValue": "2",
-                "kind": 10
-              },
-              "value": 2
-            },
-            "byRef": false,
-            "unpack": false
-          },
-          {
-            "nodeType": "ArrayItem",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 11,
-              "startFilePos": 22,
-              "endLine": 2,
-              "endTokenPos": 11,
-              "endFilePos": 22
-            },
-            "key": null,
-            "value": {
-              "nodeType": "Scalar_Int",
-              "attributes": {
-                "startLine": 2,
-                "startTokenPos": 11,
-                "startFilePos": 22,
-                "endLine": 2,
-                "endTokenPos": 11,
-                "endFilePos": 22,
-                "rawValue": "3",
-                "kind": 10
-              },
-              "value": 3
-            },
-            "byRef": false,
-            "unpack": false
-          }
-        ]
-      },
-      "keyVar": null,
-      "byRef": false,
-      "valueVar": {
-        "nodeType": "Expr_Variable",
-        "attributes": {
-          "startLine": 2,
-          "startTokenPos": 16,
-          "startFilePos": 28,
-          "endLine": 2,
-          "endTokenPos": 16,
-          "endFilePos": 29
-        },
-        "name": "n"
-      },
-      "stmts": [
+      "kind": "foreach_statement",
+      "children": [
         {
-          "nodeType": "Stmt_Echo",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 21,
-            "startFilePos": 36,
-            "endLine": 3,
-            "endTokenPos": 46,
-            "endFilePos": 93
-          },
-          "exprs": [
+          "kind": "array_creation_expression",
+          "children": [
             {
-              "nodeType": "Expr_Ternary",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 24,
-                "startFilePos": 42,
-                "endLine": 3,
-                "endTokenPos": 41,
-                "endFilePos": 82
-              },
-              "cond": {
-                "nodeType": "Expr_FuncCall",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 24,
-                  "startFilePos": 42,
-                  "endLine": 3,
-                  "endTokenPos": 27,
-                  "endFilePos": 53
-                },
-                "name": {
-                  "nodeType": "Name",
-                  "attributes": {
-                    "startLine": 3,
-                    "startTokenPos": 24,
-                    "startFilePos": 42,
-                    "endLine": 3,
-                    "endTokenPos": 24,
-                    "endFilePos": 49
-                  },
-                  "name": "is_float"
-                },
-                "args": [
-                  {
-                    "nodeType": "Arg",
-                    "attributes": {
-                      "startLine": 3,
-                      "startTokenPos": 26,
-                      "startFilePos": 51,
-                      "endLine": 3,
-                      "endTokenPos": 26,
-                      "endFilePos": 52
-                    },
-                    "name": null,
-                    "value": {
-                      "nodeType": "Expr_Variable",
-                      "attributes": {
-                        "startLine": 3,
-                        "startTokenPos": 26,
-                        "startFilePos": 51,
-                        "endLine": 3,
-                        "endTokenPos": 26,
-                        "endFilePos": 52
-                      },
-                      "name": "n"
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  }
-                ]
-              },
-              "if": {
-                "nodeType": "Expr_FuncCall",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 31,
-                  "startFilePos": 57,
-                  "endLine": 3,
-                  "endTokenPos": 37,
-                  "endFilePos": 77
-                },
-                "name": {
-                  "nodeType": "Name",
-                  "attributes": {
-                    "startLine": 3,
-                    "startTokenPos": 31,
-                    "startFilePos": 57,
-                    "endLine": 3,
-                    "endTokenPos": 31,
-                    "endFilePos": 67
-                  },
-                  "name": "json_encode"
-                },
-                "args": [
-                  {
-                    "nodeType": "Arg",
-                    "attributes": {
-                      "startLine": 3,
-                      "startTokenPos": 33,
-                      "startFilePos": 69,
-                      "endLine": 3,
-                      "endTokenPos": 33,
-                      "endFilePos": 70
-                    },
-                    "name": null,
-                    "value": {
-                      "nodeType": "Expr_Variable",
-                      "attributes": {
-                        "startLine": 3,
-                        "startTokenPos": 33,
-                        "startFilePos": 69,
-                        "endLine": 3,
-                        "endTokenPos": 33,
-                        "endFilePos": 70
-                      },
-                      "name": "n"
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  },
-                  {
-                    "nodeType": "Arg",
-                    "attributes": {
-                      "startLine": 3,
-                      "startTokenPos": 36,
-                      "startFilePos": 73,
-                      "endLine": 3,
-                      "endTokenPos": 36,
-                      "endFilePos": 76
-                    },
-                    "name": null,
-                    "value": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 3,
-                        "startTokenPos": 36,
-                        "startFilePos": 73,
-                        "endLine": 3,
-                        "endTokenPos": 36,
-                        "endFilePos": 76,
-                        "rawValue": "1344",
-                        "kind": 10
-                      },
-                      "value": 1344
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  }
-                ]
-              },
-              "else": {
-                "nodeType": "Expr_Variable",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 41,
-                  "startFilePos": 81,
-                  "endLine": 3,
-                  "endTokenPos": 41,
-                  "endFilePos": 82
-                },
-                "name": "n"
-              }
+              "kind": "array_element_initializer",
+              "children": [
+                {
+                  "kind": "integer",
+                  "text": "1"
+                }
+              ]
             },
             {
-              "nodeType": "Expr_ConstFetch",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 45,
-                "startFilePos": 86,
-                "endLine": 3,
-                "endTokenPos": 45,
-                "endFilePos": 92
-              },
-              "name": {
-                "nodeType": "Name",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 45,
-                  "startFilePos": 86,
-                  "endLine": 3,
-                  "endTokenPos": 45,
-                  "endFilePos": 92
-                },
-                "name": "PHP_EOL"
-              }
+              "kind": "array_element_initializer",
+              "children": [
+                {
+                  "kind": "integer",
+                  "text": "2"
+                }
+              ]
+            },
+            {
+              "kind": "array_element_initializer",
+              "children": [
+                {
+                  "kind": "integer",
+                  "text": "3"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "variable_name",
+          "children": [
+            {
+              "kind": "name",
+              "text": "n"
+            }
+          ]
+        },
+        {
+          "kind": "compound_statement",
+          "children": [
+            {
+              "kind": "echo_statement",
+              "children": [
+                {
+                  "kind": "sequence_expression",
+                  "children": [
+                    {
+                      "kind": "parenthesized_expression",
+                      "children": [
+                        {
+                          "kind": "conditional_expression",
+                          "children": [
+                            {
+                              "kind": "function_call_expression",
+                              "children": [
+                                {
+                                  "kind": "name",
+                                  "text": "is_float"
+                                },
+                                {
+                                  "kind": "arguments",
+                                  "children": [
+                                    {
+                                      "kind": "argument",
+                                      "children": [
+                                        {
+                                          "kind": "variable_name",
+                                          "children": [
+                                            {
+                                              "kind": "name",
+                                              "text": "n"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "function_call_expression",
+                              "children": [
+                                {
+                                  "kind": "name",
+                                  "text": "json_encode"
+                                },
+                                {
+                                  "kind": "arguments",
+                                  "children": [
+                                    {
+                                      "kind": "argument",
+                                      "children": [
+                                        {
+                                          "kind": "variable_name",
+                                          "children": [
+                                            {
+                                              "kind": "name",
+                                              "text": "n"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "argument",
+                                      "children": [
+                                        {
+                                          "kind": "integer",
+                                          "text": "1344"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "variable_name",
+                              "children": [
+                                {
+                                  "kind": "name",
+                                  "text": "n"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "name",
+                      "text": "PHP_EOL"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }

--- a/tests/json-ast/x/php/for_loop.php.json
+++ b/tests/json-ast/x/php/for_loop.php.json
@@ -1,305 +1,158 @@
 {
-  "root": [
+  "statements": [
     {
-      "nodeType": "Stmt_For",
-      "attributes": {
-        "startLine": 2,
-        "startTokenPos": 1,
-        "startFilePos": 6,
-        "endLine": 4,
-        "endTokenPos": 51,
-        "endFilePos": 96
-      },
-      "init": [
+      "kind": "for_statement",
+      "children": [
         {
-          "nodeType": "Expr_Assign",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 4,
-            "startFilePos": 11,
-            "endLine": 2,
-            "endTokenPos": 8,
-            "endFilePos": 16
-          },
-          "var": {
-            "nodeType": "Expr_Variable",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 4,
-              "startFilePos": 11,
-              "endLine": 2,
-              "endTokenPos": 4,
-              "endFilePos": 12
-            },
-            "name": "i"
-          },
-          "expr": {
-            "nodeType": "Scalar_Int",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 8,
-              "startFilePos": 16,
-              "endLine": 2,
-              "endTokenPos": 8,
-              "endFilePos": 16,
-              "rawValue": "1",
-              "kind": 10
-            },
-            "value": 1
-          }
-        }
-      ],
-      "cond": [
-        {
-          "nodeType": "Expr_BinaryOp_Smaller",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 11,
-            "startFilePos": 19,
-            "endLine": 2,
-            "endTokenPos": 15,
-            "endFilePos": 24
-          },
-          "left": {
-            "nodeType": "Expr_Variable",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 11,
-              "startFilePos": 19,
-              "endLine": 2,
-              "endTokenPos": 11,
-              "endFilePos": 20
-            },
-            "name": "i"
-          },
-          "right": {
-            "nodeType": "Scalar_Int",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 15,
-              "startFilePos": 24,
-              "endLine": 2,
-              "endTokenPos": 15,
-              "endFilePos": 24,
-              "rawValue": "4",
-              "kind": 10
-            },
-            "value": 4
-          }
-        }
-      ],
-      "loop": [
-        {
-          "nodeType": "Expr_PostInc",
-          "attributes": {
-            "startLine": 2,
-            "startTokenPos": 18,
-            "startFilePos": 27,
-            "endLine": 2,
-            "endTokenPos": 19,
-            "endFilePos": 30
-          },
-          "var": {
-            "nodeType": "Expr_Variable",
-            "attributes": {
-              "startLine": 2,
-              "startTokenPos": 18,
-              "startFilePos": 27,
-              "endLine": 2,
-              "endTokenPos": 18,
-              "endFilePos": 28
-            },
-            "name": "i"
-          }
-        }
-      ],
-      "stmts": [
-        {
-          "nodeType": "Stmt_Echo",
-          "attributes": {
-            "startLine": 3,
-            "startTokenPos": 24,
-            "startFilePos": 37,
-            "endLine": 3,
-            "endTokenPos": 49,
-            "endFilePos": 94
-          },
-          "exprs": [
+          "kind": "assignment_expression",
+          "children": [
             {
-              "nodeType": "Expr_Ternary",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 27,
-                "startFilePos": 43,
-                "endLine": 3,
-                "endTokenPos": 44,
-                "endFilePos": 83
-              },
-              "cond": {
-                "nodeType": "Expr_FuncCall",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 27,
-                  "startFilePos": 43,
-                  "endLine": 3,
-                  "endTokenPos": 30,
-                  "endFilePos": 54
-                },
-                "name": {
-                  "nodeType": "Name",
-                  "attributes": {
-                    "startLine": 3,
-                    "startTokenPos": 27,
-                    "startFilePos": 43,
-                    "endLine": 3,
-                    "endTokenPos": 27,
-                    "endFilePos": 50
-                  },
-                  "name": "is_float"
-                },
-                "args": [
-                  {
-                    "nodeType": "Arg",
-                    "attributes": {
-                      "startLine": 3,
-                      "startTokenPos": 29,
-                      "startFilePos": 52,
-                      "endLine": 3,
-                      "endTokenPos": 29,
-                      "endFilePos": 53
-                    },
-                    "name": null,
-                    "value": {
-                      "nodeType": "Expr_Variable",
-                      "attributes": {
-                        "startLine": 3,
-                        "startTokenPos": 29,
-                        "startFilePos": 52,
-                        "endLine": 3,
-                        "endTokenPos": 29,
-                        "endFilePos": 53
-                      },
-                      "name": "i"
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  }
-                ]
-              },
-              "if": {
-                "nodeType": "Expr_FuncCall",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 34,
-                  "startFilePos": 58,
-                  "endLine": 3,
-                  "endTokenPos": 40,
-                  "endFilePos": 78
-                },
-                "name": {
-                  "nodeType": "Name",
-                  "attributes": {
-                    "startLine": 3,
-                    "startTokenPos": 34,
-                    "startFilePos": 58,
-                    "endLine": 3,
-                    "endTokenPos": 34,
-                    "endFilePos": 68
-                  },
-                  "name": "json_encode"
-                },
-                "args": [
-                  {
-                    "nodeType": "Arg",
-                    "attributes": {
-                      "startLine": 3,
-                      "startTokenPos": 36,
-                      "startFilePos": 70,
-                      "endLine": 3,
-                      "endTokenPos": 36,
-                      "endFilePos": 71
-                    },
-                    "name": null,
-                    "value": {
-                      "nodeType": "Expr_Variable",
-                      "attributes": {
-                        "startLine": 3,
-                        "startTokenPos": 36,
-                        "startFilePos": 70,
-                        "endLine": 3,
-                        "endTokenPos": 36,
-                        "endFilePos": 71
-                      },
-                      "name": "i"
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  },
-                  {
-                    "nodeType": "Arg",
-                    "attributes": {
-                      "startLine": 3,
-                      "startTokenPos": 39,
-                      "startFilePos": 74,
-                      "endLine": 3,
-                      "endTokenPos": 39,
-                      "endFilePos": 77
-                    },
-                    "name": null,
-                    "value": {
-                      "nodeType": "Scalar_Int",
-                      "attributes": {
-                        "startLine": 3,
-                        "startTokenPos": 39,
-                        "startFilePos": 74,
-                        "endLine": 3,
-                        "endTokenPos": 39,
-                        "endFilePos": 77,
-                        "rawValue": "1344",
-                        "kind": 10
-                      },
-                      "value": 1344
-                    },
-                    "byRef": false,
-                    "unpack": false
-                  }
-                ]
-              },
-              "else": {
-                "nodeType": "Expr_Variable",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 44,
-                  "startFilePos": 82,
-                  "endLine": 3,
-                  "endTokenPos": 44,
-                  "endFilePos": 83
-                },
-                "name": "i"
-              }
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "i"
+                }
+              ]
             },
             {
-              "nodeType": "Expr_ConstFetch",
-              "attributes": {
-                "startLine": 3,
-                "startTokenPos": 48,
-                "startFilePos": 87,
-                "endLine": 3,
-                "endTokenPos": 48,
-                "endFilePos": 93
-              },
-              "name": {
-                "nodeType": "Name",
-                "attributes": {
-                  "startLine": 3,
-                  "startTokenPos": 48,
-                  "startFilePos": 87,
-                  "endLine": 3,
-                  "endTokenPos": 48,
-                  "endFilePos": 93
-                },
-                "name": "PHP_EOL"
-              }
+              "kind": "integer",
+              "text": "1"
+            }
+          ]
+        },
+        {
+          "kind": "binary_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "i"
+                }
+              ]
+            },
+            {
+              "kind": "integer",
+              "text": "4"
+            }
+          ]
+        },
+        {
+          "kind": "update_expression",
+          "children": [
+            {
+              "kind": "variable_name",
+              "children": [
+                {
+                  "kind": "name",
+                  "text": "i"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "compound_statement",
+          "children": [
+            {
+              "kind": "echo_statement",
+              "children": [
+                {
+                  "kind": "sequence_expression",
+                  "children": [
+                    {
+                      "kind": "parenthesized_expression",
+                      "children": [
+                        {
+                          "kind": "conditional_expression",
+                          "children": [
+                            {
+                              "kind": "function_call_expression",
+                              "children": [
+                                {
+                                  "kind": "name",
+                                  "text": "is_float"
+                                },
+                                {
+                                  "kind": "arguments",
+                                  "children": [
+                                    {
+                                      "kind": "argument",
+                                      "children": [
+                                        {
+                                          "kind": "variable_name",
+                                          "children": [
+                                            {
+                                              "kind": "name",
+                                              "text": "i"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "function_call_expression",
+                              "children": [
+                                {
+                                  "kind": "name",
+                                  "text": "json_encode"
+                                },
+                                {
+                                  "kind": "arguments",
+                                  "children": [
+                                    {
+                                      "kind": "argument",
+                                      "children": [
+                                        {
+                                          "kind": "variable_name",
+                                          "children": [
+                                            {
+                                              "kind": "name",
+                                              "text": "i"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "argument",
+                                      "children": [
+                                        {
+                                          "kind": "integer",
+                                          "text": "1344"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "variable_name",
+                              "children": [
+                                {
+                                  "kind": "name",
+                                  "text": "i"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "name",
+                      "text": "PHP_EOL"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }

--- a/tools/json-ast/x/php/ast.go
+++ b/tools/json-ast/x/php/ast.go
@@ -27,6 +27,57 @@ type Node struct {
 	Children []*Node `json:"children,omitempty"`
 }
 
+// Typed aliases mirror the tree-sitter named nodes that appear in the
+// converted AST.  They allow Program to expose a slightly more structured API
+// without duplicating the Node fields for each kind.
+type (
+	AnonymousFunctionCreationExpression Node
+	AnonymousFunctionUseClause          Node
+	Argument                            Node
+	Arguments                           Node
+	ArrayCreationExpression             Node
+	ArrayElementInitializer             Node
+	ArrowFunction                       Node
+	AssignmentExpression                Node
+	AugmentedAssignmentExpression       Node
+	BinaryExpression                    Node
+	CastExpression                      Node
+	CompoundStatement                   Node
+	ConditionalExpression               Node
+	EchoStatement                       Node
+	ElseClause                          Node
+	EncapsedString                      Node
+	ExpressionStatement                 Node
+	Float                               Node
+	ForStatement                        Node
+	ForeachStatement                    Node
+	FormalParameters                    Node
+	FunctionCallExpression              Node
+	FunctionDefinition                  Node
+	GlobalDeclaration                   Node
+	IfStatement                         Node
+	Integer                             Node
+	ListLiteral                         Node
+	MatchBlock                          Node
+	MatchConditionList                  Node
+	MatchConditionalExpression          Node
+	MatchDefaultExpression              Node
+	MatchExpression                     Node
+	Name                                Node
+	Pair                                Node
+	ParenthesizedExpression             Node
+	ReturnStatement                     Node
+	SequenceExpression                  Node
+	SimpleParameter                     Node
+	String                              Node
+	StringContent                       Node
+	SubscriptExpression                 Node
+	UnaryOpExpression                   Node
+	UpdateExpression                    Node
+	VariableName                        Node
+	WhileStatement                      Node
+)
+
 // Options configures how the AST is generated.
 type Options struct {
 	// Positions controls whether location information is populated.


### PR DESCRIPTION
## Summary
- adjust PHP AST node to expose `Text` and positions
- add typed node aliases for many PHP constructs
- regenerate first 20 PHP AST golden files using new format

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6889e99e2284832097a4c89a7c2da271