### PR TITLE
Refactor Python AST parser to new tree-sitter

### DIFF
--- a/aster/x/python/ast.go
+++ b/aster/x/python/ast.go
@@ -1,6 +1,6 @@
 package python
 
-import sitter "github.com/smacker/go-tree-sitter"
+import sitter "github.com/tree-sitter/go-tree-sitter"
 
 // Node represents a simplified Python AST node converted from tree-sitter.
 // The positional fields are omitted from the JSON when zero so callers can
@@ -52,9 +52,9 @@ func toNode(n *sitter.Node, src []byte, withPos bool) *Node {
 		return nil
 	}
 
-	start := n.StartPoint()
-	end := n.EndPoint()
-	node := &Node{Kind: n.Type()}
+	start := n.StartPosition()
+	end := n.EndPosition()
+	node := &Node{Kind: n.Kind()}
 	if withPos {
 		node.Start = int(n.StartByte())
 		node.StartCol = int(start.Column)
@@ -63,14 +63,14 @@ func toNode(n *sitter.Node, src []byte, withPos bool) *Node {
 	}
 
 	if n.NamedChildCount() == 0 {
-		if isValueNode(n.Type()) {
-			node.Text = n.Content(src)
+		if isValueNode(n.Kind()) {
+			node.Text = n.Utf8Text(src)
 		} else {
 			return nil
 		}
 	}
 
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i := uint(0); i < n.NamedChildCount(); i++ {
 		child := n.NamedChild(i)
 		if child == nil {
 			continue

--- a/aster/x/python/inspect.go
+++ b/aster/x/python/inspect.go
@@ -3,8 +3,8 @@ package python
 import (
 	"encoding/json"
 
-	sitter "github.com/smacker/go-tree-sitter"
-	tspython "github.com/smacker/go-tree-sitter/python"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	tspython "github.com/tree-sitter/tree-sitter-python/bindings/go"
 )
 
 // Program represents a parsed Python source file.
@@ -19,9 +19,9 @@ type Program struct {
 // is true the returned AST includes positional information.
 func Inspect(src string, withPos bool) (*Program, error) {
 	p := sitter.NewParser()
-	p.SetLanguage(tspython.GetLanguage())
+	p.SetLanguage(sitter.NewLanguage(tspython.Language()))
 	data := []byte(src)
-	tree := p.Parse(nil, data)
+	tree := p.Parse(data, nil)
 	return &Program{File: (*Module)(toNode(tree.RootNode(), data, withPos))}, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/tree-sitter/go-tree-sitter v0.25.0
 	github.com/tree-sitter/tree-sitter-fsharp v0.1.0
 	github.com/tree-sitter/tree-sitter-haskell v0.23.1
+	github.com/tree-sitter/tree-sitter-python v0.23.6
 	github.com/tree-sitter/tree-sitter-racket v0.24.7
 	github.com/tree-sitter/tree-sitter-scheme v0.24.7
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2


### PR DESCRIPTION
## Summary
- swap to `github.com/tree-sitter/go-tree-sitter` in `aster/x/python`
- update bindings to `github.com/tree-sitter/tree-sitter-python`
- run go mod tidy to add new dependency
- regenerate Python cross_join JSON via golden tests

## Testing
- `go test -tags slow ./aster/x/python -run TestInspect_Golden/cross_join -update`


------
https://chatgpt.com/codex/tasks/task_e_6889f4dac1348320803064265dfffbd7