### PR TITLE
Switch Dart AST to official tree-sitter bindings

### DIFF
--- a/aster/x/dart/ast.go
+++ b/aster/x/dart/ast.go
@@ -1,7 +1,7 @@
 package dart
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 // Node mirrors a tree-sitter node with optional position information. Only
@@ -81,10 +81,10 @@ func toNode(n *sitter.Node, src []byte, pos bool) *Node {
 	if n == nil {
 		return nil
 	}
-	node := &Node{Kind: n.Type()}
+	node := &Node{Kind: n.Kind()}
 	if pos {
-		start := n.StartPoint()
-		end := n.EndPoint()
+		start := n.StartPosition()
+		end := n.EndPosition()
 		node.Start = int(start.Row) + 1
 		node.StartCol = int(start.Column)
 		node.End = int(end.Row) + 1
@@ -92,15 +92,15 @@ func toNode(n *sitter.Node, src []byte, pos bool) *Node {
 	}
 
 	if n.NamedChildCount() == 0 {
-		if isValueNode(n.Type()) {
-			node.Text = n.Content(src)
+		if isValueNode(n.Kind()) {
+			node.Text = n.Utf8Text(src)
 		} else {
 			// discard pure syntax leaves
 			return nil
 		}
 	}
 
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i := uint(0); i < n.NamedChildCount(); i++ {
 		child := n.NamedChild(i)
 		if c := toNode(child, src, pos); c != nil {
 			node.Children = append(node.Children, c)

--- a/aster/x/dart/inspect.go
+++ b/aster/x/dart/inspect.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 
 	ts "github.com/UserNobody14/tree-sitter-dart/bindings/go"
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 // Program represents a parsed Dart source file.
@@ -23,7 +23,7 @@ func Inspect(src string) (*Program, error) {
 func InspectWithOptions(src string, opts Options) (*Program, error) {
 	parser := sitter.NewParser()
 	parser.SetLanguage(sitter.NewLanguage(ts.Language()))
-	tree := parser.Parse(nil, []byte(src))
+	tree := parser.Parse([]byte(src), nil)
 	root := (*ProgramNode)(toNode(tree.RootNode(), []byte(src), opts.IncludePos))
 	return &Program{Root: root}, nil
 }


### PR DESCRIPTION
## Summary
- use `github.com/tree-sitter/go-tree-sitter` instead of the smacker fork
- adapt AST node handling for the new API
- update parsing call order
- regenerate Dart AST golden tests

## Testing
- `go test ./aster/x/dart -run TestInspect_Golden -tags slow -count=1 -update`


------
https://chatgpt.com/codex/tasks/task_e_6889f61e66fc83208b9b588d0e4b6815