### PR TITLE
Switch TypeScript parser to official tree-sitter

### DIFF
--- a/aster/x/ts/ast.go
+++ b/aster/x/ts/ast.go
@@ -1,7 +1,7 @@
 package ts
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 // IncludePositions controls whether Start/End position fields are populated.
@@ -33,10 +33,10 @@ func convertNode(n *sitter.Node, src []byte) *Node {
 	if n == nil {
 		return nil
 	}
-	start := n.StartPoint()
-	end := n.EndPoint()
+	start := n.StartPosition()
+	end := n.EndPosition()
 	node := Node{
-		Kind: n.Type(),
+		Kind: n.Kind(),
 	}
 	if IncludePositions {
 		node.Start = int(start.Row) + 1
@@ -47,13 +47,13 @@ func convertNode(n *sitter.Node, src []byte) *Node {
 
 	if n.NamedChildCount() == 0 {
 		if isValueNode(node.Kind) {
-			node.Text = n.Content(src)
+			node.Text = n.Utf8Text(src)
 		} else {
 			return nil
 		}
 	}
 
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i := uint(0); i < n.NamedChildCount(); i++ {
 		child := n.NamedChild(i)
 		if c := convertNode(child, src); c != nil {
 			node.Children = append(node.Children, *c)

--- a/aster/x/ts/inspect.go
+++ b/aster/x/ts/inspect.go
@@ -1,19 +1,19 @@
 package ts
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
-	tstypescript "github.com/smacker/go-tree-sitter/typescript/typescript"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	tstypescript "github.com/tree-sitter/tree-sitter-typescript/bindings/go"
 )
 
 // Inspect parses the given TypeScript source code using tree-sitter and
 // returns its Program structure.
 func Inspect(src string) (*Program, error) {
 	p := sitter.NewParser()
-	p.SetLanguage(tstypescript.GetLanguage())
-	tree := p.Parse(nil, []byte(src))
+	p.SetLanguage(sitter.NewLanguage(tstypescript.LanguageTypescript()))
+	tree := p.Parse([]byte(src), nil)
 	root := tree.RootNode()
 	var stmts []Node
-	for i := 0; i < int(root.NamedChildCount()); i++ {
+	for i := uint(0); i < root.NamedChildCount(); i++ {
 		child := root.NamedChild(i)
 		if n := convertNode(child, []byte(src)); n != nil {
 			stmts = append(stmts, *n)

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/tree-sitter/tree-sitter-haskell v0.23.1
 	github.com/tree-sitter/tree-sitter-racket v0.24.7
 	github.com/tree-sitter/tree-sitter-scheme v0.24.7
+	github.com/tree-sitter/tree-sitter-typescript v0.23.2
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
 	github.com/yuin/gopher-lua v1.1.1
 	github.com/z7zmey/php-parser v0.7.2

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,8 @@ github.com/tree-sitter/tree-sitter-ruby v0.23.1 h1:T/NKHUA+iVbHM440hFx+lzVOzS4dV
 github.com/tree-sitter/tree-sitter-ruby v0.23.1/go.mod h1:kUS4kCCQloFcdX6sdpr8p6r2rogbM6ZjTox5ZOQy8cA=
 github.com/tree-sitter/tree-sitter-rust v0.23.2 h1:6AtoooCW5GqNrRpfnvl0iUhxTAZEovEmLKDbyHlfw90=
 github.com/tree-sitter/tree-sitter-rust v0.23.2/go.mod h1:hfeGWic9BAfgTrc7Xf6FaOAguCFJRo3RBbs7QJ6D7MI=
+github.com/tree-sitter/tree-sitter-typescript v0.23.2 h1:/Odvphn18PniVixb9e97X0DbNVsU6Qocv9mfkyzdXwU=
+github.com/tree-sitter/tree-sitter-typescript v0.23.2/go.mod h1:zjzMXT/Ulffel2xfOcAkQQkiAkmgnbtPGlFQw/5X4xA=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=


### PR DESCRIPTION
## Summary
- refactor `aster/x/ts` to use `github.com/tree-sitter/go-tree-sitter`
- load TypeScript grammar from `github.com/tree-sitter/tree-sitter-typescript`
- add the new dependency to `go.mod`
- update `go.sum`

## Testing
- `go test -tags slow ./aster/x/ts -run TestInspect_Golden -update`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6889f613d3a88320930f202e9ed713d6