### PR TITLE
Use official tree-sitter in aster/x/cpp

### DIFF
--- a/aster/x/cpp/ast.go
+++ b/aster/x/cpp/ast.go
@@ -1,7 +1,7 @@
 package cpp
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 // Node represents a tree-sitter node in a generic form with position
@@ -40,10 +40,10 @@ func convert(n *sitter.Node, src []byte, opts Options) *Node {
 	if n == nil {
 		return nil
 	}
-	node := &Node{Kind: n.Type()}
+	node := &Node{Kind: n.Kind()}
 	if opts.WithPositions {
-		start := n.StartPoint()
-		end := n.EndPoint()
+		start := n.StartPosition()
+		end := n.EndPosition()
 		node.Start = int(start.Row) + 1
 		node.End = int(end.Row) + 1
 		node.StartCol = int(start.Column)
@@ -51,15 +51,15 @@ func convert(n *sitter.Node, src []byte, opts Options) *Node {
 	}
 
 	if n.NamedChildCount() == 0 {
-		if isValueNode(n.Type()) || n.Type() == "comment" {
-			node.Text = n.Content(src)
+		if isValueNode(n.Kind()) || n.Kind() == "comment" {
+			node.Text = n.Utf8Text(src)
 		} else {
 			return nil
 		}
 	}
 
 	for i := 0; i < int(n.NamedChildCount()); i++ {
-		child := n.NamedChild(i)
+		child := n.NamedChild(uint(i))
 		if child == nil {
 			continue
 		}

--- a/aster/x/cpp/inspect.go
+++ b/aster/x/cpp/inspect.go
@@ -1,11 +1,8 @@
 package cpp
 
 import (
-	"context"
-	"fmt"
-
-	sitter "github.com/smacker/go-tree-sitter"
-	ts "github.com/smacker/go-tree-sitter/cpp"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	ts "github.com/tree-sitter/tree-sitter-cpp/bindings/go"
 )
 
 // Program is the root of a parsed C++ translation unit.
@@ -22,11 +19,8 @@ type Program struct {
 // opts.WithPositions is set to true.
 func Inspect(src string, opts ...Options) (*Program, error) {
 	parser := sitter.NewParser()
-	parser.SetLanguage(ts.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
-	if err != nil {
-		return nil, fmt.Errorf("parse: %w", err)
-	}
+	parser.SetLanguage(sitter.NewLanguage(ts.Language()))
+	tree := parser.Parse([]byte(src), nil)
 	var o Options
 	if len(opts) > 0 {
 		o = opts[0]

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/tliron/commonlog v0.2.20
 	github.com/tliron/glsp v0.2.2
 	github.com/tree-sitter/go-tree-sitter v0.25.0
+	github.com/tree-sitter/tree-sitter-cpp v0.23.4
 	github.com/tree-sitter/tree-sitter-fsharp v0.1.0
 	github.com/tree-sitter/tree-sitter-haskell v0.23.1
 	github.com/tree-sitter/tree-sitter-racket v0.24.7


### PR DESCRIPTION
## Summary
- refactor aster/x/cpp to use github.com/tree-sitter/go-tree-sitter
- switch grammar import to tree-sitter/tree-sitter-cpp
- add dependency in go.mod
- regenerate JSON AST for cross_join.cpp (no diff)

## Testing
- `go test -c -tags slow ./aster/x/cpp`
- `go test -tags slow ./aster/x/cpp -run TestInspect_Golden/cross_join$ -update`


------
https://chatgpt.com/codex/tasks/task_e_6889f61880e48320a9f65ea74d3c4bfc