### PR TITLE
Use official tree-sitter binding for Java

### DIFF
--- a/aster/x/java/ast.go
+++ b/aster/x/java/ast.go
@@ -1,6 +1,6 @@
 package java
 
-import sitter "github.com/smacker/go-tree-sitter"
+import sitter "github.com/tree-sitter/go-tree-sitter"
 
 // IncludePos toggles whether positional information should be populated on
 // nodes produced by this package. When false, the position fields remain zero
@@ -29,10 +29,10 @@ func convert(n *sitter.Node, src []byte) *Node {
 	if n == nil {
 		return nil
 	}
-	node := &Node{Kind: n.Type()}
+	node := &Node{Kind: n.Kind()}
 	if IncludePos {
-		sp := n.StartPoint()
-		ep := n.EndPoint()
+		sp := n.StartPosition()
+		ep := n.EndPosition()
 		node.Start = int(sp.Row) + 1
 		node.StartCol = int(sp.Column)
 		node.End = int(ep.Row) + 1
@@ -41,13 +41,13 @@ func convert(n *sitter.Node, src []byte) *Node {
 
 	if n.NamedChildCount() == 0 {
 		if isValueNode(node.Kind) {
-			node.Text = n.Content(src)
+			node.Text = n.Utf8Text(src)
 		} else {
 			return nil
 		}
 	}
 
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i := uint(0); i < n.NamedChildCount(); i++ {
 		child := n.NamedChild(i)
 		if child == nil {
 			continue

--- a/aster/x/java/inspect.go
+++ b/aster/x/java/inspect.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"fmt"
 
-	sitter "github.com/smacker/go-tree-sitter"
-	javats "github.com/smacker/go-tree-sitter/java"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	javats "github.com/tree-sitter/tree-sitter-java/bindings/go"
 )
 
 // Program represents a parsed Java source file.
@@ -19,10 +19,10 @@ type Program struct {
 // its Program structure.
 func Inspect(src string) (*Program, error) {
 	parser := sitter.NewParser()
-	parser.SetLanguage(javats.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
-	if err != nil {
-		return nil, fmt.Errorf("parse: %w", err)
+	parser.SetLanguage(sitter.NewLanguage(javats.Language()))
+	tree := parser.ParseCtx(context.Background(), []byte(src), nil)
+	if tree == nil {
+		return nil, fmt.Errorf("parse: failed")
 	}
 	root := convert(tree.RootNode(), []byte(src))
 	return &Program{Root: root}, nil

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/tree-sitter/go-tree-sitter v0.25.0
 	github.com/tree-sitter/tree-sitter-fsharp v0.1.0
 	github.com/tree-sitter/tree-sitter-haskell v0.23.1
+	github.com/tree-sitter/tree-sitter-java v0.23.5
 	github.com/tree-sitter/tree-sitter-racket v0.24.7
 	github.com/tree-sitter/tree-sitter-scheme v0.24.7
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2


### PR DESCRIPTION
## Summary
- switch `aster/x/java` to use `github.com/tree-sitter/go-tree-sitter`
- update parser calls for the new API
- add the Java grammar module to `go.mod`

## Testing
- `go test ./aster/x/java -tags slow -run TestInspect_Golden/cross_join$ -update -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6889f62e517c8320bdd419b986259bc4