### PR TITLE
Switch PHP aster parser to upstream tree-sitter bindings

### DIFF
--- a/aster/x/php/ast.go
+++ b/aster/x/php/ast.go
@@ -3,8 +3,8 @@ package php
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
-	phpts "github.com/smacker/go-tree-sitter/php"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	phpts "github.com/tree-sitter/tree-sitter-php/bindings/go"
 )
 
 // Node represents a tree-sitter node in PHP's syntax tree.
@@ -92,10 +92,10 @@ func convert(n *sitter.Node, src []byte, opts Options) *Node {
 		return nil
 	}
 
-	node := &Node{Kind: n.Type()}
+	node := &Node{Kind: n.Kind()}
 	if opts.Positions {
-		start := n.StartPoint()
-		end := n.EndPoint()
+		start := n.StartPosition()
+		end := n.EndPosition()
 		node.Start = int(start.Row) + 1
 		node.StartCol = int(start.Column)
 		node.End = int(end.Row) + 1
@@ -103,8 +103,8 @@ func convert(n *sitter.Node, src []byte, opts Options) *Node {
 	}
 
 	if n.NamedChildCount() == 0 {
-		if isValueNode(n.Type()) {
-			text := n.Content(src)
+		if isValueNode(n.Kind()) {
+			text := n.Utf8Text(src)
 			if strings.TrimSpace(text) == "" {
 				return nil
 			}
@@ -114,7 +114,7 @@ func convert(n *sitter.Node, src []byte, opts Options) *Node {
 		}
 	}
 
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i := uint(0); i < n.NamedChildCount(); i++ {
 		child := n.NamedChild(i)
 		if child == nil {
 			continue
@@ -142,6 +142,6 @@ func isValueNode(kind string) bool {
 // newParser returns a tree-sitter parser for PHP.
 func newParser() *sitter.Parser {
 	p := sitter.NewParser()
-	p.SetLanguage(phpts.GetLanguage())
+	p.SetLanguage(sitter.NewLanguage(phpts.LanguagePHP()))
 	return p
 }

--- a/aster/x/php/inspect.go
+++ b/aster/x/php/inspect.go
@@ -12,7 +12,7 @@ type Program struct {
 // If opts is nil, default options are used.
 func Inspect(src string, opts *Options) (*Program, error) {
 	parser := newParser()
-	tree := parser.Parse(nil, []byte(src))
+	tree := parser.Parse([]byte(src), nil)
 	var o Options
 	if opts != nil {
 		o = *opts

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/tree-sitter/go-tree-sitter v0.25.0
 	github.com/tree-sitter/tree-sitter-fsharp v0.1.0
 	github.com/tree-sitter/tree-sitter-haskell v0.23.1
+	github.com/tree-sitter/tree-sitter-php v0.23.11
 	github.com/tree-sitter/tree-sitter-python v0.23.6
 	github.com/tree-sitter/tree-sitter-racket v0.24.7
 	github.com/tree-sitter/tree-sitter-scheme v0.24.7


### PR DESCRIPTION
## Summary
- refactor PHP aster package to use `github.com/tree-sitter/go-tree-sitter`
- set parser language using `tree-sitter-php` bindings
- update go module dependencies
- regenerate and verify PHP AST golden file

## Testing
- `go test ./aster/x/php -tags=slow -run TestInspect_Golden -update`
- `go test ./aster/x/php -tags=slow`


------
https://chatgpt.com/codex/tasks/task_e_6889f7a9366c8320b0443313b35eb0c6