### PR TITLE
Switch OCaml parser to official tree-sitter

### DIFF
--- a/aster/x/ocaml/ast.go
+++ b/aster/x/ocaml/ast.go
@@ -1,7 +1,7 @@
 package ocaml
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 // Node represents a simplified OCaml AST node. Only nodes that carry
@@ -93,10 +93,10 @@ func convert(n *sitter.Node, src []byte, pos bool) *Node {
 	if n == nil {
 		return nil
 	}
-	node := &Node{Kind: n.Type()}
+	node := &Node{Kind: n.Kind()}
 	if pos {
-		sp := n.StartPoint()
-		ep := n.EndPoint()
+		sp := n.StartPosition()
+		ep := n.EndPosition()
 		node.Start = int(sp.Row) + 1
 		node.StartCol = int(sp.Column)
 		node.End = int(ep.Row) + 1
@@ -104,15 +104,15 @@ func convert(n *sitter.Node, src []byte, pos bool) *Node {
 	}
 
 	if n.NamedChildCount() == 0 {
-		if isValueNode(n.Type()) {
-			node.Text = n.Content(src)
+		if isValueNode(n.Kind()) {
+			node.Text = n.Utf8Text(src)
 			return node
 		}
 		return nil
 	}
 
 	for i := 0; i < int(n.NamedChildCount()); i++ {
-		child := convert(n.NamedChild(i), src, pos)
+		child := convert(n.NamedChild(uint(i)), src, pos)
 		if child != nil {
 			node.Children = append(node.Children, *child)
 		}

--- a/aster/x/ocaml/inspect.go
+++ b/aster/x/ocaml/inspect.go
@@ -1,8 +1,8 @@
 package ocaml
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
-	tsocaml "github.com/smacker/go-tree-sitter/ocaml"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	tsocaml "github.com/tree-sitter/tree-sitter-ocaml/bindings/go"
 )
 
 // Inspect parses the given OCaml source code using tree-sitter and returns
@@ -10,9 +10,9 @@ import (
 // omitted; pass an Options value with IncludePositions set to true to retain it.
 func Inspect(src string, opts ...Options) (*Program, error) {
 	p := sitter.NewParser()
-	p.SetLanguage(tsocaml.GetLanguage())
+	p.SetLanguage(sitter.NewLanguage(tsocaml.LanguageOCaml()))
 	data := []byte(src)
-	tree := p.Parse(nil, data)
+	tree := p.Parse(data, nil)
 	var includePos bool
 	if len(opts) > 0 {
 		includePos = opts[0].IncludePositions

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/tree-sitter/tree-sitter-c v0.23.4
 	github.com/tree-sitter/tree-sitter-fsharp v0.1.0
 	github.com/tree-sitter/tree-sitter-haskell v0.23.1
+	github.com/tree-sitter/tree-sitter-ocaml v0.24.2
 	github.com/tree-sitter/tree-sitter-python v0.23.6
 	github.com/tree-sitter/tree-sitter-racket v0.24.7
 	github.com/tree-sitter/tree-sitter-scheme v0.24.7

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,8 @@ github.com/tree-sitter/tree-sitter-javascript v0.23.1 h1:1fWupaRC0ArlHJ/QJzsfQ3I
 github.com/tree-sitter/tree-sitter-javascript v0.23.1/go.mod h1:lmGD1EJdCA+v0S1u2fFgepMg/opzSg/4pgFym2FPGAs=
 github.com/tree-sitter/tree-sitter-json v0.24.8 h1:tV5rMkihgtiOe14a9LHfDY5kzTl5GNUYe6carZBn0fQ=
 github.com/tree-sitter/tree-sitter-json v0.24.8/go.mod h1:F351KK0KGvCaYbZ5zxwx/gWWvZhIDl0eMtn+1r+gQbo=
+github.com/tree-sitter/tree-sitter-ocaml v0.24.2 h1:8tK5RFs0WjO1LvdW+qA6N7oYmLvanaDmPU3Ww7hPq+8=
+github.com/tree-sitter/tree-sitter-ocaml v0.24.2/go.mod h1:18SxqyGRpOHl8CmxfC2oTs5mXRDveWhtCnprYBAT0oc=
 github.com/tree-sitter/tree-sitter-php v0.23.11 h1:iHewsLNDmznh8kgGyfWfujsZxIz1YGbSd2ZTEM0ZiP8=
 github.com/tree-sitter/tree-sitter-php v0.23.11/go.mod h1:T/kbfi+UcCywQfUNAJnGTN/fMSUjnwPXA8k4yoIks74=
 github.com/tree-sitter/tree-sitter-python v0.23.6 h1:qHnWFR5WhtMQpxBZRwiaU5Hk/29vGju6CVtmvu5Haas=

--- a/tests/json-ast/x/ocaml/cross_join.ocaml.json
+++ b/tests/json-ast/x/ocaml/cross_join.ocaml.json
@@ -39,7 +39,7 @@
                                     "kind": "parenthesized_expression",
                                     "children": [
                                       {
-                                        "kind": "product_expression",
+                                        "kind": "tuple_expression",
                                         "children": [
                                           {
                                             "kind": "string",
@@ -62,7 +62,7 @@
                                     "kind": "parenthesized_expression",
                                     "children": [
                                       {
-                                        "kind": "product_expression",
+                                        "kind": "tuple_expression",
                                         "children": [
                                           {
                                             "kind": "string",
@@ -95,7 +95,7 @@
                                     "kind": "parenthesized_expression",
                                     "children": [
                                       {
-                                        "kind": "product_expression",
+                                        "kind": "tuple_expression",
                                         "children": [
                                           {
                                             "kind": "string",
@@ -118,7 +118,7 @@
                                     "kind": "parenthesized_expression",
                                     "children": [
                                       {
-                                        "kind": "product_expression",
+                                        "kind": "tuple_expression",
                                         "children": [
                                           {
                                             "kind": "string",
@@ -151,7 +151,7 @@
                                     "kind": "parenthesized_expression",
                                     "children": [
                                       {
-                                        "kind": "product_expression",
+                                        "kind": "tuple_expression",
                                         "children": [
                                           {
                                             "kind": "string",
@@ -174,7 +174,7 @@
                                     "kind": "parenthesized_expression",
                                     "children": [
                                       {
-                                        "kind": "product_expression",
+                                        "kind": "tuple_expression",
                                         "children": [
                                           {
                                             "kind": "string",
@@ -229,7 +229,7 @@
                                         "kind": "parenthesized_expression",
                                         "children": [
                                           {
-                                            "kind": "product_expression",
+                                            "kind": "tuple_expression",
                                             "children": [
                                               {
                                                 "kind": "string",
@@ -252,7 +252,7 @@
                                         "kind": "parenthesized_expression",
                                         "children": [
                                           {
-                                            "kind": "product_expression",
+                                            "kind": "tuple_expression",
                                             "children": [
                                               {
                                                 "kind": "string",
@@ -275,7 +275,7 @@
                                         "kind": "parenthesized_expression",
                                         "children": [
                                           {
-                                            "kind": "product_expression",
+                                            "kind": "tuple_expression",
                                             "children": [
                                               {
                                                 "kind": "string",
@@ -303,7 +303,7 @@
                                         "kind": "parenthesized_expression",
                                         "children": [
                                           {
-                                            "kind": "product_expression",
+                                            "kind": "tuple_expression",
                                             "children": [
                                               {
                                                 "kind": "string",
@@ -326,7 +326,7 @@
                                         "kind": "parenthesized_expression",
                                         "children": [
                                           {
-                                            "kind": "product_expression",
+                                            "kind": "tuple_expression",
                                             "children": [
                                               {
                                                 "kind": "string",
@@ -349,7 +349,7 @@
                                         "kind": "parenthesized_expression",
                                         "children": [
                                           {
-                                            "kind": "product_expression",
+                                            "kind": "tuple_expression",
                                             "children": [
                                               {
                                                 "kind": "string",
@@ -377,7 +377,7 @@
                                         "kind": "parenthesized_expression",
                                         "children": [
                                           {
-                                            "kind": "product_expression",
+                                            "kind": "tuple_expression",
                                             "children": [
                                               {
                                                 "kind": "string",
@@ -400,7 +400,7 @@
                                         "kind": "parenthesized_expression",
                                         "children": [
                                           {
-                                            "kind": "product_expression",
+                                            "kind": "tuple_expression",
                                             "children": [
                                               {
                                                 "kind": "string",
@@ -423,7 +423,7 @@
                                         "kind": "parenthesized_expression",
                                         "children": [
                                           {
-                                            "kind": "product_expression",
+                                            "kind": "tuple_expression",
                                             "children": [
                                               {
                                                 "kind": "string",
@@ -572,7 +572,7 @@
                                                                                 "kind": "parenthesized_expression",
                                                                                 "children": [
                                                                                   {
-                                                                                    "kind": "product_expression",
+                                                                                    "kind": "tuple_expression",
                                                                                     "children": [
                                                                                       {
                                                                                         "kind": "string",
@@ -637,7 +637,7 @@
                                                                                 "kind": "parenthesized_expression",
                                                                                 "children": [
                                                                                   {
-                                                                                    "kind": "product_expression",
+                                                                                    "kind": "tuple_expression",
                                                                                     "children": [
                                                                                       {
                                                                                         "kind": "string",
@@ -702,7 +702,7 @@
                                                                                 "kind": "parenthesized_expression",
                                                                                 "children": [
                                                                                   {
-                                                                                    "kind": "product_expression",
+                                                                                    "kind": "tuple_expression",
                                                                                     "children": [
                                                                                       {
                                                                                         "kind": "string",
@@ -767,7 +767,7 @@
                                                                                 "kind": "parenthesized_expression",
                                                                                 "children": [
                                                                                   {
-                                                                                    "kind": "product_expression",
+                                                                                    "kind": "tuple_expression",
                                                                                     "children": [
                                                                                       {
                                                                                         "kind": "string",
@@ -1251,175 +1251,26 @@
                                                                         ]
                                                                       },
                                                                       {
-                                                                        "kind": "sequence_expression",
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "string",
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "string_content",
-                                                                                "text": "(customerId:"
-                                                                              }
-                                                                            ]
-                                                                          },
-                                                                          {
-                                                                            "kind": "application_expression",
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "value_path",
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "value_name",
-                                                                                    "text": "string_of_int"
-                                                                                  }
-                                                                                ]
-                                                                              },
-                                                                              {
-                                                                                "kind": "parenthesized_expression",
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "application_expression",
-                                                                                    "children": [
-                                                                                      {
-                                                                                        "kind": "value_path",
-                                                                                        "children": [
-                                                                                          {
-                                                                                            "kind": "module_path",
-                                                                                            "children": [
-                                                                                              {
-                                                                                                "kind": "module_name",
-                                                                                                "text": "List"
-                                                                                              }
-                                                                                            ]
-                                                                                          },
-                                                                                          {
-                                                                                            "kind": "value_name",
-                                                                                            "text": "assoc"
-                                                                                          }
-                                                                                        ]
-                                                                                      },
-                                                                                      {
-                                                                                        "kind": "string",
-                                                                                        "children": [
-                                                                                          {
-                                                                                            "kind": "string_content",
-                                                                                            "text": "orderCustomerId"
-                                                                                          }
-                                                                                        ]
-                                                                                      },
-                                                                                      {
-                                                                                        "kind": "value_path",
-                                                                                        "children": [
-                                                                                          {
-                                                                                            "kind": "value_name",
-                                                                                            "text": "entry"
-                                                                                          }
-                                                                                        ]
-                                                                                      }
-                                                                                    ]
-                                                                                  }
-                                                                                ]
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "sequence_expression",
-                                                            "children": [
-                                                              {
-                                                                "kind": "string",
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "string_content",
-                                                                    "text": ", total: $"
-                                                                  }
-                                                                ]
-                                                              },
-                                                              {
-                                                                "kind": "sequence_expression",
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "application_expression",
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "value_path",
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "value_name",
-                                                                            "text": "string_of_int"
-                                                                          }
-                                                                        ]
-                                                                      },
-                                                                      {
-                                                                        "kind": "parenthesized_expression",
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "application_expression",
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "value_path",
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "module_path",
-                                                                                    "children": [
-                                                                                      {
-                                                                                        "kind": "module_name",
-                                                                                        "text": "List"
-                                                                                      }
-                                                                                    ]
-                                                                                  },
-                                                                                  {
-                                                                                    "kind": "value_name",
-                                                                                    "text": "assoc"
-                                                                                  }
-                                                                                ]
-                                                                              },
-                                                                              {
-                                                                                "kind": "string",
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "string_content",
-                                                                                    "text": "orderTotal"
-                                                                                  }
-                                                                                ]
-                                                                              },
-                                                                              {
-                                                                                "kind": "value_path",
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "value_name",
-                                                                                    "text": "entry"
-                                                                                  }
-                                                                                ]
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  },
-                                                                  {
-                                                                    "kind": "sequence_expression",
-                                                                    "children": [
-                                                                      {
                                                                         "kind": "string",
                                                                         "children": [
                                                                           {
                                                                             "kind": "string_content",
-                                                                            "text": ") paired with"
+                                                                            "text": "(customerId:"
                                                                           }
                                                                         ]
                                                                       },
                                                                       {
-                                                                        "kind": "sequence_expression",
+                                                                        "kind": "application_expression",
                                                                         "children": [
+                                                                          {
+                                                                            "kind": "value_path",
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "value_name",
+                                                                                "text": "string_of_int"
+                                                                              }
+                                                                            ]
+                                                                          },
                                                                           {
                                                                             "kind": "parenthesized_expression",
                                                                             "children": [
@@ -1449,7 +1300,7 @@
                                                                                     "children": [
                                                                                       {
                                                                                         "kind": "string_content",
-                                                                                        "text": "pairedCustomerName"
+                                                                                        "text": "orderCustomerId"
                                                                                       }
                                                                                     ]
                                                                                   },
@@ -1467,6 +1318,130 @@
                                                                             ]
                                                                           }
                                                                         ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "string",
+                                                            "children": [
+                                                              {
+                                                                "kind": "string_content",
+                                                                "text": ", total: $"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "application_expression",
+                                                            "children": [
+                                                              {
+                                                                "kind": "value_path",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "value_name",
+                                                                    "text": "string_of_int"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "parenthesized_expression",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "application_expression",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_path",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "module_path",
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "module_name",
+                                                                                "text": "List"
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "value_name",
+                                                                            "text": "assoc"
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "string",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "string_content",
+                                                                            "text": "orderTotal"
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "value_path",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_name",
+                                                                            "text": "entry"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "string",
+                                                            "children": [
+                                                              {
+                                                                "kind": "string_content",
+                                                                "text": ") paired with"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "parenthesized_expression",
+                                                            "children": [
+                                                              {
+                                                                "kind": "application_expression",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "value_path",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "module_path",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "module_name",
+                                                                            "text": "List"
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "value_name",
+                                                                        "text": "assoc"
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "string",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "string_content",
+                                                                        "text": "pairedCustomerName"
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "value_path",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_name",
+                                                                        "text": "entry"
                                                                       }
                                                                     ]
                                                                   }

--- a/tests/json-ast/x/ocaml/cross_join_filter.ocaml.json
+++ b/tests/json-ast/x/ocaml/cross_join_filter.ocaml.json
@@ -274,7 +274,7 @@
                                                                                                 "kind": "parenthesized_expression",
                                                                                                 "children": [
                                                                                                   {
-                                                                                                    "kind": "product_expression",
+                                                                                                    "kind": "tuple_expression",
                                                                                                     "children": [
                                                                                                       {
                                                                                                         "kind": "string",
@@ -302,7 +302,7 @@
                                                                                                 "kind": "parenthesized_expression",
                                                                                                 "children": [
                                                                                                   {
-                                                                                                    "kind": "product_expression",
+                                                                                                    "kind": "tuple_expression",
                                                                                                     "children": [
                                                                                                       {
                                                                                                         "kind": "string",

--- a/tests/json-ast/x/ocaml/cross_join_triple.ocaml.json
+++ b/tests/json-ast/x/ocaml/cross_join_triple.ocaml.json
@@ -288,7 +288,7 @@
                                                                                                             "kind": "parenthesized_expression",
                                                                                                             "children": [
                                                                                                               {
-                                                                                                                "kind": "product_expression",
+                                                                                                                "kind": "tuple_expression",
                                                                                                                 "children": [
                                                                                                                   {
                                                                                                                     "kind": "string",
@@ -316,7 +316,7 @@
                                                                                                             "kind": "parenthesized_expression",
                                                                                                             "children": [
                                                                                                               {
-                                                                                                                "kind": "product_expression",
+                                                                                                                "kind": "tuple_expression",
                                                                                                                 "children": [
                                                                                                                   {
                                                                                                                     "kind": "string",
@@ -344,7 +344,7 @@
                                                                                                             "kind": "parenthesized_expression",
                                                                                                             "children": [
                                                                                                               {
-                                                                                                                "kind": "product_expression",
+                                                                                                                "kind": "tuple_expression",
                                                                                                                 "children": [
                                                                                                                   {
                                                                                                                     "kind": "string",


### PR DESCRIPTION
## Summary
- switch OCaml analyzer to `github.com/tree-sitter/tree-sitter-ocaml`
- use the new tree-sitter runtime
- regenerate `cross_join` JSON AST fixtures

## Testing
- `go test ./aster/x/ocaml -run TestInspect_Golden/cross_join -tags slow -v`

------
https://chatgpt.com/codex/tasks/task_e_6889f638f6e88320aa4836ef546c6256