### PR TITLE
Switch Rust aster binding to tree-sitter/go-tree-sitter

### DIFF
--- a/aster/x/rs/ast.go
+++ b/aster/x/rs/ast.go
@@ -1,7 +1,7 @@
 package rs
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 // Node represents a simplified Rust AST node converted from tree-sitter.
@@ -68,10 +68,10 @@ func convert(n *sitter.Node, src []byte, includePos bool) *Node {
 		return nil
 	}
 
-	node := &Node{Kind: n.Type()}
+	node := &Node{Kind: n.Kind()}
 	if includePos {
-		sp := n.StartPoint()
-		ep := n.EndPoint()
+		sp := n.StartPosition()
+		ep := n.EndPosition()
 		node.Start = int(sp.Row) + 1
 		node.End = int(ep.Row) + 1
 		node.StartCol = int(sp.Column)
@@ -79,15 +79,15 @@ func convert(n *sitter.Node, src []byte, includePos bool) *Node {
 	}
 
 	if n.NamedChildCount() == 0 {
-		if isValueNode(n.Type()) {
-			node.Text = n.Content(src)
+		if isValueNode(n.Kind()) {
+			node.Text = n.Utf8Text(src)
 		} else {
 			return nil
 		}
 	}
 
 	for i := 0; i < int(n.NamedChildCount()); i++ {
-		child := convert(n.NamedChild(i), src, includePos)
+		child := convert(n.NamedChild(uint(i)), src, includePos)
 		if child != nil {
 			node.Children = append(node.Children, child)
 		}

--- a/aster/x/rs/inspect.go
+++ b/aster/x/rs/inspect.go
@@ -3,17 +3,18 @@ package rs
 import (
 	"encoding/json"
 
-	sitter "github.com/smacker/go-tree-sitter"
-	rust "github.com/smacker/go-tree-sitter/rust"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	rust "github.com/tree-sitter/tree-sitter-rust/bindings/go"
 )
 
 // Inspect parses the given Rust source code using tree-sitter and returns
 // a Program describing its syntax tree.
 func Inspect(src string, includePos bool) (*Program, error) {
 	p := sitter.NewParser()
-	p.SetLanguage(rust.GetLanguage())
+	lang := sitter.NewLanguage(rust.Language())
+	p.SetLanguage(lang)
 	data := []byte(src)
-	tree := p.Parse(nil, data)
+	tree := p.Parse(data, nil)
 	root := convert(tree.RootNode(), data, includePos)
 	return &Program{Root: (*SourceFile)(root)}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/spf13/cast v1.9.2 // indirect
 	github.com/spf13/pflag v1.0.7 // indirect
 	github.com/tliron/kutil v0.3.27 // indirect
+	github.com/tree-sitter/tree-sitter-rust v0.23.2
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect


### PR DESCRIPTION
## Summary
- use github.com/tree-sitter/go-tree-sitter in `aster/x/rs`
- adapt node conversion to updated API
- add tree-sitter-rust dependency
- regenerate `cross_join.rs.json`

## Testing
- `go test -tags slow ./aster/x/rs -run TestInspect_Golden/cross_join -update`

------
https://chatgpt.com/codex/tasks/task_e_6889f7ec98e08320ba59175b67955706