### PR TITLE
Switch Scala parser to official tree-sitter library

### DIFF
--- a/aster/x/scala/ast.go
+++ b/aster/x/scala/ast.go
@@ -1,7 +1,7 @@
 package scala
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 // Node represents a simplified Scala AST node converted from tree-sitter.
@@ -34,9 +34,9 @@ func convert(n *sitter.Node, src []byte, pos bool) *Node {
 	if n == nil {
 		return nil
 	}
-	start := n.StartPoint()
-	end := n.EndPoint()
-	node := &Node{Kind: n.Type()}
+	start := n.StartPosition()
+	end := n.EndPosition()
+	node := &Node{Kind: n.Kind()}
 	if pos {
 		node.Start = int(start.Row) + 1
 		node.StartCol = int(start.Column)
@@ -45,14 +45,14 @@ func convert(n *sitter.Node, src []byte, pos bool) *Node {
 	}
 
 	if n.NamedChildCount() == 0 {
-		if isValueNode(n.Type()) {
-			node.Text = n.Content(src)
+		if isValueNode(n.Kind()) {
+			node.Text = n.Utf8Text(src)
 		} else {
 			return nil
 		}
 	}
 
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i := uint(0); i < n.NamedChildCount(); i++ {
 		child := convert(n.NamedChild(i), src, pos)
 		if child != nil {
 			node.Children = append(node.Children, child)

--- a/aster/x/scala/inspect.go
+++ b/aster/x/scala/inspect.go
@@ -2,10 +2,9 @@ package scala
 
 import (
 	"context"
-	"fmt"
 
-	sitter "github.com/smacker/go-tree-sitter"
-	tscala "github.com/smacker/go-tree-sitter/scala"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	tscala "github.com/tree-sitter/tree-sitter-scala/bindings/go"
 )
 
 // Inspect parses Scala source code using tree-sitter and returns its AST.
@@ -15,11 +14,9 @@ func Inspect(src string, opts ...bool) (*Program, error) {
 		includePos = opts[0]
 	}
 	parser := sitter.NewParser()
-	parser.SetLanguage(tscala.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
-	if err != nil {
-		return nil, fmt.Errorf("parse: %w", err)
-	}
+	parser.SetLanguage(sitter.NewLanguage(tscala.Language()))
+	tree := parser.ParseCtx(context.Background(), []byte(src), nil)
+
 	n := convert(tree.RootNode(), []byte(src), includePos)
 	if n == nil {
 		return &Program{}, nil

--- a/go.mod
+++ b/go.mod
@@ -23,8 +23,9 @@ require (
 	github.com/tliron/glsp v0.2.2
 	github.com/tree-sitter/go-tree-sitter v0.25.0
 	github.com/tree-sitter/tree-sitter-fsharp v0.1.0
-	github.com/tree-sitter/tree-sitter-haskell v0.23.1
-	github.com/tree-sitter/tree-sitter-python v0.23.6
+       github.com/tree-sitter/tree-sitter-haskell v0.23.1
+       github.com/tree-sitter/tree-sitter-scala v0.23.4
+       github.com/tree-sitter/tree-sitter-python v0.23.6
 	github.com/tree-sitter/tree-sitter-racket v0.24.7
 	github.com/tree-sitter/tree-sitter-scheme v0.24.7
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,8 @@ github.com/tree-sitter/tree-sitter-ruby v0.23.1 h1:T/NKHUA+iVbHM440hFx+lzVOzS4dV
 github.com/tree-sitter/tree-sitter-ruby v0.23.1/go.mod h1:kUS4kCCQloFcdX6sdpr8p6r2rogbM6ZjTox5ZOQy8cA=
 github.com/tree-sitter/tree-sitter-rust v0.23.2 h1:6AtoooCW5GqNrRpfnvl0iUhxTAZEovEmLKDbyHlfw90=
 github.com/tree-sitter/tree-sitter-rust v0.23.2/go.mod h1:hfeGWic9BAfgTrc7Xf6FaOAguCFJRo3RBbs7QJ6D7MI=
+github.com/tree-sitter/tree-sitter-scala v0.23.4 h1:YZvk3rEQVEKnc82Wltq1DdCJsmlN4Q3+UvdtQu8dR+8=
+github.com/tree-sitter/tree-sitter-scala v0.23.4/go.mod h1:BmDV0f9rgsnGuG9QtKXQZnqJvECyR9fM8wVg984ulBo=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=


### PR DESCRIPTION
## Summary
- move Scala aster support to `github.com/tree-sitter/go-tree-sitter`
- use `github.com/tree-sitter/tree-sitter-scala` grammar
- update Go module dependencies

## Testing
- `go test ./aster/x/scala -tags slow -run TestInspect_Golden/cross_join -update -v`

------
https://chatgpt.com/codex/tasks/task_e_6889f7edf0348320bc44c06269919252