### PR TITLE
Switch Scheme parser to tree-sitter/go-tree-sitter

### DIFF
--- a/aster/x/scheme/ast.go
+++ b/aster/x/scheme/ast.go
@@ -1,7 +1,7 @@
 package scheme
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 // IncludePos controls whether the conversion functions record positional
@@ -57,10 +57,10 @@ func convertNode(n *sitter.Node, src []byte) *Node {
 		return nil
 	}
 
-	node := &Node{Kind: n.Type()}
+	node := &Node{Kind: n.Kind()}
 	if IncludePos {
-		sp := n.StartPoint()
-		ep := n.EndPoint()
+		sp := n.StartPosition()
+		ep := n.EndPosition()
 		node.Start = int(sp.Row) + 1
 		node.StartCol = int(sp.Column)
 		node.End = int(ep.Row) + 1
@@ -68,14 +68,14 @@ func convertNode(n *sitter.Node, src []byte) *Node {
 	}
 
 	if n.NamedChildCount() == 0 {
-		if isValueNode(n.Type()) {
-			node.Text = n.Content(src)
+		if isValueNode(n.Kind()) {
+			node.Text = n.Utf8Text(src)
 		} else {
 			return nil
 		}
 	}
 
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i := uint(0); i < n.NamedChildCount(); i++ {
 		if c := convertNode(n.NamedChild(i), src); c != nil {
 			node.Children = append(node.Children, *c)
 		}
@@ -93,7 +93,7 @@ func convertProgram(root *sitter.Node, src []byte) *Program {
 		return &Program{}
 	}
 	var forms []Form
-	for i := 0; i < int(root.NamedChildCount()); i++ {
+	for i := uint(0); i < root.NamedChildCount(); i++ {
 		if n := convertNode(root.NamedChild(i), src); n != nil {
 			forms = append(forms, Form(*n))
 		}

--- a/aster/x/scheme/inspect.go
+++ b/aster/x/scheme/inspect.go
@@ -1,7 +1,7 @@
 package scheme
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 	tsscheme "github.com/tree-sitter/tree-sitter-scheme/bindings/go"
 )
 
@@ -10,6 +10,6 @@ import (
 func Inspect(src string) (*Program, error) {
 	p := sitter.NewParser()
 	p.SetLanguage(sitter.NewLanguage(tsscheme.Language()))
-	tree := p.Parse(nil, []byte(src))
+	tree := p.Parse([]byte(src), nil)
 	return convertProgram(tree.RootNode(), []byte(src)), nil
 }


### PR DESCRIPTION
## Summary
- update Scheme AST and inspector to use `github.com/tree-sitter/go-tree-sitter`
- regenerate golden file for `cross_join.scm` to ensure the parser works (no changes)

## Testing
- `go test ./aster/x/scheme -run TestInspect_Golden/cross_join -tags=slow -update`

------
https://chatgpt.com/codex/tasks/task_e_6889f7efc0dc8320bfde9cf31fc72a65