### PR TITLE
Switch zig parser to official tree-sitter

### DIFF
--- a/aster/x/zig/inspect.go
+++ b/aster/x/zig/inspect.go
@@ -3,11 +3,10 @@
 package zig
 
 import (
-	"context"
-	"fmt"
+	"unsafe"
 
 	tszig "github.com/slimsag/tree-sitter-zig/bindings/go"
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 // Program describes a parsed Zig source file.
@@ -24,11 +23,10 @@ func Inspect(src string, opts ...Options) (*Program, error) {
 		opt = opts[0]
 	}
 	parser := sitter.NewParser()
-	parser.SetLanguage(tszig.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
-	if err != nil {
-		return nil, fmt.Errorf("parse: %w", err)
-	}
+	smackerLang := tszig.GetLanguage()
+	ptr := (*struct{ ptr unsafe.Pointer })(unsafe.Pointer(smackerLang)).ptr
+	parser.SetLanguage(sitter.NewLanguage(ptr))
+	tree := parser.Parse([]byte(src), nil)
 	node, ok := convertNode(tree.RootNode(), []byte(src), opt.Positions)
 	if !ok {
 		return &Program{Root: SourceFile{}}, nil


### PR DESCRIPTION
## Summary
- refactor `aster/x/zig` to use `github.com/tree-sitter/go-tree-sitter`
- update AST conversion helpers

## Testing
- `go test -tags slow ./aster/x/zig -run TestInspect_Golden -update` *(fails: linking conflict between old and new tree-sitter)*

------
https://chatgpt.com/codex/tasks/task_e_6889f7f6e50883209d1d826691bb4756