### PR TITLE
Use official tree-sitter bindings for PHP

### DIFF
--- a/aster/x/php/ast.go
+++ b/aster/x/php/ast.go
@@ -1,10 +1,10 @@
 package php
 
 import (
-	"strings"
+        "strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
-	phpts "github.com/smacker/go-tree-sitter/php"
+        sitter "github.com/tree-sitter/go-tree-sitter"
+        phpts "github.com/tree-sitter/tree-sitter-php/bindings/go"
 )
 
 // Node represents a tree-sitter node in PHP's syntax tree.
@@ -92,10 +92,10 @@ func convert(n *sitter.Node, src []byte, opts Options) *Node {
 		return nil
 	}
 
-	node := &Node{Kind: n.Type()}
+        node := &Node{Kind: n.Kind()}
 	if opts.Positions {
-		start := n.StartPoint()
-		end := n.EndPoint()
+                start := n.StartPosition()
+                end := n.EndPosition()
 		node.Start = int(start.Row) + 1
 		node.StartCol = int(start.Column)
 		node.End = int(end.Row) + 1
@@ -103,8 +103,8 @@ func convert(n *sitter.Node, src []byte, opts Options) *Node {
 	}
 
 	if n.NamedChildCount() == 0 {
-		if isValueNode(n.Type()) {
-			text := n.Content(src)
+                if isValueNode(n.Kind()) {
+                        text := n.Utf8Text(src)
 			if strings.TrimSpace(text) == "" {
 				return nil
 			}
@@ -114,8 +114,8 @@ func convert(n *sitter.Node, src []byte, opts Options) *Node {
 		}
 	}
 
-	for i := 0; i < int(n.NamedChildCount()); i++ {
-		child := n.NamedChild(i)
+        for i := 0; i < int(n.NamedChildCount()); i++ {
+                child := n.NamedChild(uint(i))
 		if child == nil {
 			continue
 		}
@@ -141,7 +141,7 @@ func isValueNode(kind string) bool {
 
 // newParser returns a tree-sitter parser for PHP.
 func newParser() *sitter.Parser {
-	p := sitter.NewParser()
-	p.SetLanguage(phpts.GetLanguage())
-	return p
+        p := sitter.NewParser()
+        p.SetLanguage(sitter.NewLanguage(phpts.LanguagePHP()))
+        return p
 }

--- a/aster/x/php/inspect.go
+++ b/aster/x/php/inspect.go
@@ -11,8 +11,8 @@ type Program struct {
 // Inspect parses PHP source code using tree-sitter and returns its AST.
 // If opts is nil, default options are used.
 func Inspect(src string, opts *Options) (*Program, error) {
-	parser := newParser()
-	tree := parser.Parse(nil, []byte(src))
+        parser := newParser()
+        tree := parser.Parse([]byte(src), nil)
 	var o Options
 	if opts != nil {
 		o = *opts

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/tree-sitter/tree-sitter-fsharp v0.1.0
 	github.com/tree-sitter/tree-sitter-go v0.23.4
 	github.com/tree-sitter/tree-sitter-haskell v0.23.1
+	github.com/tree-sitter/tree-sitter-php v0.23.11
 	github.com/tree-sitter/tree-sitter-python v0.23.6
 	github.com/tree-sitter/tree-sitter-racket v0.24.7
 	github.com/tree-sitter/tree-sitter-scheme v0.24.7


### PR DESCRIPTION
## Summary
- switch PHP lexer to `github.com/tree-sitter/go-tree-sitter`
- use `tree-sitter-php` grammar bindings
- update parser invocation
- tidy modules

## Testing
- `go test ./aster/x/php -run TestInspect_Golden -tags=slow -update`

------
https://chatgpt.com/codex/tasks/task_e_6889f9e9f83c8320b68b3f32125202cf