### PR TITLE
Switch C# AST to upstream tree-sitter

### DIFF
--- a/aster/x/cs/ast.go
+++ b/aster/x/cs/ast.go
@@ -1,6 +1,6 @@
 package cs
 
-import sitter "github.com/smacker/go-tree-sitter"
+import sitter "github.com/tree-sitter/go-tree-sitter"
 
 // Node models a portion of the C# syntax tree as returned by tree-sitter.
 // Only leaves carrying a textual value populate the Text field. Position
@@ -56,10 +56,10 @@ func toNode(n *sitter.Node, src []byte, withPos bool) *Node {
 	if n == nil {
 		return nil
 	}
-	node := &Node{Kind: n.Type()}
+	node := &Node{Kind: n.Kind()}
 	if withPos {
-		sp := n.StartPoint()
-		ep := n.EndPoint()
+		sp := n.StartPosition()
+		ep := n.EndPosition()
 		node.Start = int(sp.Row) + 1
 		node.StartCol = int(sp.Column)
 		node.End = int(ep.Row) + 1
@@ -68,13 +68,13 @@ func toNode(n *sitter.Node, src []byte, withPos bool) *Node {
 
 	if n.NamedChildCount() == 0 {
 		if isValueNode(node.Kind) {
-			node.Text = n.Content(src)
+			node.Text = n.Utf8Text(src)
 		} else {
 			return nil
 		}
 	}
 
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i := uint(0); i < n.NamedChildCount(); i++ {
 		c := n.NamedChild(i)
 		if child := toNode(c, src, withPos); child != nil {
 			node.Children = append(node.Children, child)

--- a/aster/x/cs/inspect.go
+++ b/aster/x/cs/inspect.go
@@ -3,8 +3,8 @@ package cs
 import (
 	"encoding/json"
 
-	sitter "github.com/smacker/go-tree-sitter"
-	csharp "github.com/smacker/go-tree-sitter/csharp"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	csharp "github.com/tree-sitter/tree-sitter-c-sharp/bindings/go"
 )
 
 // Program is defined in ast.go and composes Node values.
@@ -15,9 +15,9 @@ import (
 // true the returned AST includes position information.
 func Inspect(src string, withPos bool) (*Program, error) {
 	p := sitter.NewParser()
-	p.SetLanguage(csharp.GetLanguage())
+	p.SetLanguage(sitter.NewLanguage(csharp.Language()))
 	data := []byte(src)
-	tree := p.Parse(nil, data)
+	tree := p.Parse(data, nil)
 	return &Program{File: (*CompilationUnit)(toNode(tree.RootNode(), data, withPos))}, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/tliron/glsp v0.2.2
 	github.com/tree-sitter/go-tree-sitter v0.25.0
 	github.com/tree-sitter/tree-sitter-c v0.23.4
+	github.com/tree-sitter/tree-sitter-c-sharp v0.23.1
 	github.com/tree-sitter/tree-sitter-elixir v0.3.4
 	github.com/tree-sitter/tree-sitter-fsharp v0.1.0
 	github.com/tree-sitter/tree-sitter-go v0.23.4

--- a/go.sum
+++ b/go.sum
@@ -179,6 +179,8 @@ github.com/tree-sitter/go-tree-sitter v0.25.0 h1:sx6kcg8raRFCvc9BnXglke6axya12kr
 github.com/tree-sitter/go-tree-sitter v0.25.0/go.mod h1:r77ig7BikoZhHrrsjAnv8RqGti5rtSyvDHPzgTPsUuU=
 github.com/tree-sitter/tree-sitter-c v0.23.4 h1:nBPH3FV07DzAD7p0GfNvXM+Y7pNIoPenQWBpvM++t4c=
 github.com/tree-sitter/tree-sitter-c v0.23.4/go.mod h1:MkI5dOiIpeN94LNjeCp8ljXN/953JCwAby4bClMr6bw=
+github.com/tree-sitter/tree-sitter-c-sharp v0.23.1 h1:ddG6osP34sMieVNN6lu5ZG/3N8Wn+67+43BmipqidyM=
+github.com/tree-sitter/tree-sitter-c-sharp v0.23.1/go.mod h1:H7/aFm5vR1A8Yn5VIOfLWPdlKuJsMgZ5eDmaJdv8bY0=
 github.com/tree-sitter/tree-sitter-cpp v0.23.4 h1:LaWZsiqQKvR65yHgKmnaqA+uz6tlDJTJFCyFIeZU/8w=
 github.com/tree-sitter/tree-sitter-cpp v0.23.4/go.mod h1:doqNW64BriC7WBCQ1klf0KmJpdEvfxyXtoEybnBo6v8=
 github.com/tree-sitter/tree-sitter-embedded-template v0.23.2 h1:nFkkH6Sbe56EXLmZBqHHcamTpmz3TId97I16EnGy4rg=


### PR DESCRIPTION
## Summary
- migrate `aster/x/cs` from `smacker/go-tree-sitter` to `tree-sitter/go-tree-sitter`
- use the new `tree-sitter-c-sharp` grammar
- update `go.mod`/`go.sum`
- regenerate the `cross_join.cs.json` golden to ensure compatibility

## Testing
- `go test ./aster/x/cs -tags slow -run TestInspect_Golden/cross_join`

------
https://chatgpt.com/codex/tasks/task_e_6889fd41aa9883209d44f277c7b84205