### PR TITLE
Switch PHP AST to official tree-sitter

### DIFF
--- a/aster/x/php/ast.go
+++ b/aster/x/php/ast.go
@@ -3,8 +3,8 @@ package php
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
-	phpts "github.com/smacker/go-tree-sitter/php"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	phpts "github.com/tree-sitter/tree-sitter-php/bindings/go"
 )
 
 // Node represents a tree-sitter node in PHP's syntax tree.
@@ -92,10 +92,10 @@ func convert(n *sitter.Node, src []byte, opts Options) *Node {
 		return nil
 	}
 
-	node := &Node{Kind: n.Type()}
+	node := &Node{Kind: n.Kind()}
 	if opts.Positions {
-		start := n.StartPoint()
-		end := n.EndPoint()
+		start := n.StartPosition()
+		end := n.EndPosition()
 		node.Start = int(start.Row) + 1
 		node.StartCol = int(start.Column)
 		node.End = int(end.Row) + 1
@@ -103,8 +103,8 @@ func convert(n *sitter.Node, src []byte, opts Options) *Node {
 	}
 
 	if n.NamedChildCount() == 0 {
-		if isValueNode(n.Type()) {
-			text := n.Content(src)
+		if isValueNode(n.Kind()) {
+			text := n.Utf8Text(src)
 			if strings.TrimSpace(text) == "" {
 				return nil
 			}
@@ -114,7 +114,7 @@ func convert(n *sitter.Node, src []byte, opts Options) *Node {
 		}
 	}
 
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i := uint(0); i < n.NamedChildCount(); i++ {
 		child := n.NamedChild(i)
 		if child == nil {
 			continue
@@ -142,6 +142,6 @@ func isValueNode(kind string) bool {
 // newParser returns a tree-sitter parser for PHP.
 func newParser() *sitter.Parser {
 	p := sitter.NewParser()
-	p.SetLanguage(phpts.GetLanguage())
+	p.SetLanguage(sitter.NewLanguage(phpts.LanguagePHP()))
 	return p
 }

--- a/aster/x/php/inspect.go
+++ b/aster/x/php/inspect.go
@@ -12,7 +12,7 @@ type Program struct {
 // If opts is nil, default options are used.
 func Inspect(src string, opts *Options) (*Program, error) {
 	parser := newParser()
-	tree := parser.Parse(nil, []byte(src))
+	tree := parser.Parse([]byte(src), nil)
 	var o Options
 	if opts != nil {
 		o = *opts

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/tree-sitter/tree-sitter-go v0.23.4
 	github.com/tree-sitter/tree-sitter-haskell v0.23.1
 	github.com/tree-sitter/tree-sitter-ocaml v0.24.2
+	github.com/tree-sitter/tree-sitter-php v0.23.11
 	github.com/tree-sitter/tree-sitter-python v0.23.6
 	github.com/tree-sitter/tree-sitter-racket v0.24.7
 	github.com/tree-sitter/tree-sitter-ruby v0.23.1


### PR DESCRIPTION
## Summary
- refactor PHP AST parser to use `github.com/tree-sitter/go-tree-sitter`
- use `tree-sitter-php` grammar
- adjust node API usage
- regenerate golden test for PHP

## Testing
- `go test -tags slow ./aster/x/php -run TestInspect_Golden -update -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6889fdb3def483208198a7e835f54fb9