### PR TITLE
Switch Scala aster to tree-sitter/go-tree-sitter

### DIFF
--- a/aster/x/scala/ast.go
+++ b/aster/x/scala/ast.go
@@ -1,7 +1,7 @@
 package scala
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 // Node represents a simplified Scala AST node converted from tree-sitter.
@@ -34,9 +34,9 @@ func convert(n *sitter.Node, src []byte, pos bool) *Node {
 	if n == nil {
 		return nil
 	}
-	start := n.StartPoint()
-	end := n.EndPoint()
-	node := &Node{Kind: n.Type()}
+	start := n.StartPosition()
+	end := n.EndPosition()
+	node := &Node{Kind: n.Kind()}
 	if pos {
 		node.Start = int(start.Row) + 1
 		node.StartCol = int(start.Column)
@@ -45,14 +45,14 @@ func convert(n *sitter.Node, src []byte, pos bool) *Node {
 	}
 
 	if n.NamedChildCount() == 0 {
-		if isValueNode(n.Type()) {
-			node.Text = n.Content(src)
+		if isValueNode(n.Kind()) {
+			node.Text = n.Utf8Text(src)
 		} else {
 			return nil
 		}
 	}
 
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i := uint(0); i < n.NamedChildCount(); i++ {
 		child := convert(n.NamedChild(i), src, pos)
 		if child != nil {
 			node.Children = append(node.Children, child)

--- a/aster/x/scala/inspect.go
+++ b/aster/x/scala/inspect.go
@@ -2,10 +2,9 @@ package scala
 
 import (
 	"context"
-	"fmt"
 
-	sitter "github.com/smacker/go-tree-sitter"
-	tscala "github.com/smacker/go-tree-sitter/scala"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	tscala "github.com/tree-sitter/tree-sitter-scala/bindings/go"
 )
 
 // Inspect parses Scala source code using tree-sitter and returns its AST.
@@ -15,11 +14,8 @@ func Inspect(src string, opts ...bool) (*Program, error) {
 		includePos = opts[0]
 	}
 	parser := sitter.NewParser()
-	parser.SetLanguage(tscala.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
-	if err != nil {
-		return nil, fmt.Errorf("parse: %w", err)
-	}
+	parser.SetLanguage(sitter.NewLanguage(tscala.Language()))
+	tree := parser.ParseCtx(context.Background(), []byte(src), nil)
 	n := convert(tree.RootNode(), []byte(src), includePos)
 	if n == nil {
 		return &Program{}, nil

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
+require github.com/tree-sitter/tree-sitter-scala v0.24.0
+
 require (
 	github.com/alexflint/go-scalar v1.2.0 // indirect
 	github.com/apache/arrow-go/v18 v18.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,8 @@ github.com/tree-sitter/tree-sitter-ruby v0.23.1 h1:T/NKHUA+iVbHM440hFx+lzVOzS4dV
 github.com/tree-sitter/tree-sitter-ruby v0.23.1/go.mod h1:kUS4kCCQloFcdX6sdpr8p6r2rogbM6ZjTox5ZOQy8cA=
 github.com/tree-sitter/tree-sitter-rust v0.23.2 h1:6AtoooCW5GqNrRpfnvl0iUhxTAZEovEmLKDbyHlfw90=
 github.com/tree-sitter/tree-sitter-rust v0.23.2/go.mod h1:hfeGWic9BAfgTrc7Xf6FaOAguCFJRo3RBbs7QJ6D7MI=
+github.com/tree-sitter/tree-sitter-scala v0.24.0 h1:F8UcZQdNQSkOGtkW8tUsFrqifOVXzmzJ19/JSbB+X3E=
+github.com/tree-sitter/tree-sitter-scala v0.24.0/go.mod h1:BmDV0f9rgsnGuG9QtKXQZnqJvECyR9fM8wVg984ulBo=
 github.com/tree-sitter/tree-sitter-typescript v0.23.2 h1:/Odvphn18PniVixb9e97X0DbNVsU6Qocv9mfkyzdXwU=
 github.com/tree-sitter/tree-sitter-typescript v0.23.2/go.mod h1:zjzMXT/Ulffel2xfOcAkQQkiAkmgnbtPGlFQw/5X4xA=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=


### PR DESCRIPTION
## Summary
- use tree-sitter/go-tree-sitter for Scala inspector
- pull tree-sitter-scala module

## Testing
- `go test ./aster/x/scala -tags=slow -run TestInspect_Golden/cross_join`

------
https://chatgpt.com/codex/tasks/task_e_6889fdc2b8e4832098469e584ed08dd2