### PR TITLE
Switch Erlang aster bindings to official tree-sitter

### DIFF
--- a/aster/x/erlang/ast.go
+++ b/aster/x/erlang/ast.go
@@ -1,7 +1,7 @@
 package erlang
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 // Node represents an Erlang AST node produced from tree-sitter.  Leaf nodes
@@ -70,9 +70,9 @@ func convert(n *sitter.Node, src []byte, opt Option) *Node {
 	if n == nil {
 		return nil
 	}
-	start := n.StartPoint()
-	end := n.EndPoint()
-	node := &Node{Kind: n.Type()}
+	start := n.StartPosition()
+	end := n.EndPosition()
+	node := &Node{Kind: n.Kind()}
 	if opt.Positions {
 		node.Start = int(start.Row) + 1
 		node.StartCol = int(start.Column)
@@ -81,14 +81,14 @@ func convert(n *sitter.Node, src []byte, opt Option) *Node {
 	}
 
 	if n.NamedChildCount() == 0 {
-		if isValueNode(n.Type()) {
-			node.Text = n.Content(src)
+		if isValueNode(n.Kind()) {
+			node.Text = n.Utf8Text(src)
 		} else {
 			return nil
 		}
 	}
 
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i := uint(0); i < n.NamedChildCount(); i++ {
 		child := n.NamedChild(i)
 		if child == nil {
 			continue

--- a/aster/x/erlang/inspect.go
+++ b/aster/x/erlang/inspect.go
@@ -2,9 +2,8 @@ package erlang
 
 import (
 	"context"
-	"fmt"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 	tserlang "mochi/third_party/tree-sitter-erlang/bindings/go"
 )
 
@@ -18,10 +17,7 @@ type Program struct {
 func InspectWithOption(src string, opt Option) (*Program, error) {
 	parser := sitter.NewParser()
 	parser.SetLanguage(tserlang.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
-	if err != nil {
-		return nil, fmt.Errorf("parse: %w", err)
-	}
+	tree := parser.ParseCtx(context.Background(), []byte(src), nil)
 	root := convert(tree.RootNode(), []byte(src), opt)
 	if root == nil {
 		return &Program{}, nil

--- a/third_party/tree-sitter-erlang/bindings/go/binding.go
+++ b/third_party/tree-sitter-erlang/bindings/go/binding.go
@@ -7,7 +7,7 @@ import "C"
 import (
 	"unsafe"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 // GetLanguage returns the tree-sitter Language for Erlang.


### PR DESCRIPTION
## Summary
- refactor Erlang aster package to use `github.com/tree-sitter/go-tree-sitter`
- update Erlang tree-sitter bindings
- refresh cross_join AST via tests

## Testing
- `go vet ./aster/x/erlang`
- `go build ./aster/x/erlang`
- `go test -v -tags slow ./aster/x/erlang -run 'TestInspectGolden/cross_join$'`

------
https://chatgpt.com/codex/tasks/task_e_6889ff2b38d88320aae98e420c5804f6