### PR TITLE
Update C++ parser to new go-tree-sitter

### DIFF
--- a/aster/x/cpp/ast.go
+++ b/aster/x/cpp/ast.go
@@ -1,7 +1,7 @@
 package cpp
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 // Node represents a tree-sitter node in a generic form with position
@@ -40,10 +40,10 @@ func convert(n *sitter.Node, src []byte, opts Options) *Node {
 	if n == nil {
 		return nil
 	}
-	node := &Node{Kind: n.Type()}
+	node := &Node{Kind: n.Kind()}
 	if opts.WithPositions {
-		start := n.StartPoint()
-		end := n.EndPoint()
+		start := n.StartPosition()
+		end := n.EndPosition()
 		node.Start = int(start.Row) + 1
 		node.End = int(end.Row) + 1
 		node.StartCol = int(start.Column)
@@ -51,14 +51,14 @@ func convert(n *sitter.Node, src []byte, opts Options) *Node {
 	}
 
 	if n.NamedChildCount() == 0 {
-		if isValueNode(n.Type()) || n.Type() == "comment" {
-			node.Text = n.Content(src)
+		if isValueNode(n.Kind()) || n.Kind() == "comment" {
+			node.Text = n.Utf8Text(src)
 		} else {
 			return nil
 		}
 	}
 
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i := uint(0); i < n.NamedChildCount(); i++ {
 		child := n.NamedChild(i)
 		if child == nil {
 			continue

--- a/aster/x/cpp/inspect.go
+++ b/aster/x/cpp/inspect.go
@@ -2,10 +2,9 @@ package cpp
 
 import (
 	"context"
-	"fmt"
 
-	sitter "github.com/smacker/go-tree-sitter"
-	ts "github.com/smacker/go-tree-sitter/cpp"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	ts "github.com/tree-sitter/tree-sitter-cpp/bindings/go"
 )
 
 // Program is the root of a parsed C++ translation unit.
@@ -22,11 +21,8 @@ type Program struct {
 // opts.WithPositions is set to true.
 func Inspect(src string, opts ...Options) (*Program, error) {
 	parser := sitter.NewParser()
-	parser.SetLanguage(ts.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
-	if err != nil {
-		return nil, fmt.Errorf("parse: %w", err)
-	}
+	parser.SetLanguage(sitter.NewLanguage(ts.Language()))
+	tree := parser.ParseCtx(context.Background(), []byte(src), nil)
 	var o Options
 	if len(opts) > 0 {
 		o = opts[0]

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/tree-sitter/go-tree-sitter v0.25.0
 	github.com/tree-sitter/tree-sitter-c v0.23.4
 	github.com/tree-sitter/tree-sitter-c-sharp v0.23.1
+	github.com/tree-sitter/tree-sitter-cpp v0.23.4
 	github.com/tree-sitter/tree-sitter-elixir v0.3.4
 	github.com/tree-sitter/tree-sitter-fsharp v0.1.0
 	github.com/tree-sitter/tree-sitter-go v0.23.4


### PR DESCRIPTION
## Summary
- swap smacker/go-tree-sitter for tree-sitter/go-tree-sitter in `aster/x/cpp`
- adjust AST conversion to the new API
- use official `tree-sitter-cpp` bindings
- add new module to `go.mod`

## Testing
- `go test -tags slow ./aster/x/cpp -run TestInspect_Golden/cross_join -update`


------
https://chatgpt.com/codex/tasks/task_e_6889ff6e26c08320b1f516293c6a9987