### PR TITLE
use tree-sitter parser in Racket inspector

### DIFF
--- a/aster/x/rkt/inspect.go
+++ b/aster/x/rkt/inspect.go
@@ -16,7 +16,9 @@ type Program struct {
 // resulting AST nodes include line and column information.
 func Inspect(src string, withPos bool) (*Program, error) {
 	p := sitter.NewParser()
+	defer p.Close()
 	p.SetLanguage(sitter.NewLanguage(racket.Language()))
 	tree := p.Parse([]byte(src), nil)
+	defer tree.Close()
 	return convertProgram(tree.RootNode(), []byte(src), withPos), nil
 }


### PR DESCRIPTION
## Summary
- ensure resources from tree-sitter's Go bindings are released
- use `defer` to close the parser and resulting parse tree

## Testing
- `go test -tags=slow -run TestInspect_Golden -update` *(fails: missing go.sum entry)*

------
https://chatgpt.com/codex/tasks/task_e_688a0787ea388320becd37cbc3214f57