### PR TITLE
Update Erlang aster/x parser to official tree-sitter

### DIFF
--- a/aster/x/erlang/ast.go
+++ b/aster/x/erlang/ast.go
@@ -1,7 +1,7 @@
 package erlang
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+        sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 // Node represents an Erlang AST node produced from tree-sitter.  Leaf nodes

--- a/aster/x/erlang/inspect.go
+++ b/aster/x/erlang/inspect.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	sitter "github.com/smacker/go-tree-sitter"
-	tserlang "mochi/third_party/tree-sitter-erlang/bindings/go"
+        sitter "github.com/tree-sitter/go-tree-sitter"
+        tserlang "github.com/tree-sitter/tree-sitter-erlang/bindings/go"
 )
 
 // Program represents a parsed Erlang file composed of Node structs.


### PR DESCRIPTION
## Summary
- switch Erlang inspector to `github.com/tree-sitter/go-tree-sitter`
- use `github.com/tree-sitter/tree-sitter-erlang` grammar

## Testing
- `go test ./aster/x/erlang -tags slow -run TestInspectGolden -update` *(fails: missing go.sum entry for github.com/tree-sitter/tree-sitter-elixir)*

------
https://chatgpt.com/codex/tasks/task_e_688a07a6fd9483209e83d18d59234aba