### PR TITLE
Switch tree-sitter deps

### DIFF
--- a/aster/x/erlang/ast.go
+++ b/aster/x/erlang/ast.go
@@ -1,7 +1,7 @@
 package erlang
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 // Node represents an Erlang AST node produced from tree-sitter.  Leaf nodes

--- a/aster/x/erlang/inspect.go
+++ b/aster/x/erlang/inspect.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 	tserlang "mochi/third_party/tree-sitter-erlang/bindings/go"
 )
 

--- a/aster/x/kotlin/ast.go
+++ b/aster/x/kotlin/ast.go
@@ -1,7 +1,7 @@
 package kotlin
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 	"strings"
 )
 

--- a/aster/x/kotlin/inspect.go
+++ b/aster/x/kotlin/inspect.go
@@ -3,8 +3,8 @@ package kotlin
 import (
 	"encoding/json"
 
-	sitter "github.com/smacker/go-tree-sitter"
-	ts "github.com/smacker/go-tree-sitter/kotlin"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	ts "github.com/tree-sitter/tree-sitter-kotlin/bindings/go"
 )
 
 // Program represents a parsed Kotlin source file.

--- a/aster/x/py/ast.go
+++ b/aster/x/py/ast.go
@@ -1,6 +1,6 @@
 package py
 
-import sitter "github.com/smacker/go-tree-sitter"
+import sitter "github.com/tree-sitter/go-tree-sitter"
 
 // Node represents a simplified Python AST node converted from tree-sitter.
 // Positional fields are omitted from JSON when zero so callers can decide

--- a/aster/x/py/inspect.go
+++ b/aster/x/py/inspect.go
@@ -3,8 +3,8 @@ package py
 import (
 	"encoding/json"
 
-	sitter "github.com/smacker/go-tree-sitter"
-	tspython "github.com/smacker/go-tree-sitter/python"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	tspython "github.com/tree-sitter/tree-sitter-python/bindings/go"
 )
 
 // Program represents a parsed Python source file.

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/marcboeker/go-duckdb v1.8.5
 	github.com/mark3labs/mcp-go v0.36.0
 	github.com/mattn/go-sqlite3 v1.14.28
-	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/tliron/commonlog v0.2.20
@@ -24,7 +23,7 @@ require (
 	github.com/tree-sitter/tree-sitter-c v0.23.4
 	github.com/tree-sitter/tree-sitter-c-sharp v0.23.1
 	github.com/tree-sitter/tree-sitter-cpp v0.23.4
-	github.com/tree-sitter/tree-sitter-elixir v0.3.4
+       github.com/tree-sitter/tree-sitter-elixir v0.3.4
 	github.com/tree-sitter/tree-sitter-fsharp v0.1.0
 	github.com/tree-sitter/tree-sitter-go v0.23.4
 	github.com/tree-sitter/tree-sitter-haskell v0.23.1
@@ -38,12 +37,14 @@ require (
 	github.com/tree-sitter/tree-sitter-swift v0.0.0-20250623040733-277b583bbb02
 	github.com/tree-sitter/tree-sitter-typescript v0.23.2
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
-	github.com/yuin/gopher-lua v1.1.1
-	github.com/z7zmey/php-parser v0.7.2
-	golang.org/x/mod v0.26.0
-	golang.org/x/tools v0.35.0
-	gopkg.in/yaml.v3 v3.0.1
+       github.com/yuin/gopher-lua v1.1.1
+       github.com/z7zmey/php-parser v0.7.2
+       golang.org/x/mod v0.26.0
+       golang.org/x/tools v0.35.0
+       gopkg.in/yaml.v3 v3.0.1
 )
+
+replace github.com/tree-sitter/tree-sitter-elixir => github.com/elixir-lang/tree-sitter-elixir v0.3.4
 
 require github.com/tree-sitter/tree-sitter-scala v0.24.0
 

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,6 @@ github.com/sasha-s/go-deadlock v0.3.5 h1:tNCOEEDG6tBqrNDOX35j/7hL5FcFViG6awUGROb
 github.com/sasha-s/go-deadlock v0.3.5/go.mod h1:bugP6EGbdGYObIlx7pUZtWqlvo8k9H6vCBBsiChJQ5U=
 github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
 github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
-github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82 h1:6C8qej6f1bStuePVkLSFxoU22XBS165D3klxlzRg8F4=
-github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82/go.mod h1:xe4pgH49k4SsmkQq5OT8abwhWmnzkhpgnXeekbx2efw=
 github.com/sourcegraph/jsonrpc2 v0.2.1 h1:2GtljixMQYUYCmIg7W9aF2dFmniq/mOr2T9tFRh6zSQ=
 github.com/sourcegraph/jsonrpc2 v0.2.1/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
 github.com/spf13/cast v1.9.2 h1:SsGfm7M8QOFtEzumm7UZrZdLLquNdzFYfIbEXntcFbE=


### PR DESCRIPTION
## Summary
- refactor aster/x packages to use `github.com/tree-sitter/go-tree-sitter`
- point Elixir grammar to the elixir-lang repo via `replace`
- remove smacker dependency
- regenerate Elixir golden AST

## Testing
- `go test -tags slow ./aster/x/elixir -run TestInspect_Golden -update`


------
https://chatgpt.com/codex/tasks/task_e_688a079b4ba483209994e1eb39bfd185