### PR TITLE
Fix scheme parser module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,9 +39,14 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
+replace github.com/tree-sitter/tree-sitter-scheme => github.com/6cdh/tree-sitter-scheme v0.24.7
+
 require github.com/tree-sitter/tree-sitter-scala v0.24.0
 
-require github.com/tree-sitter-grammars/tree-sitter-lua v0.3.0
+require (
+        github.com/tree-sitter-grammars/tree-sitter-lua v0.3.0
+        github.com/tree-sitter/tree-sitter-scheme v0.24.7
+)
 
 require (
 	github.com/alexflint/go-scalar v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/6cdh/tree-sitter-scheme v0.24.7 h1:yhRP+u4lRA4bCxq4dEETb+osMcwvqtG9hSYU9iGFgRk=
+github.com/6cdh/tree-sitter-scheme v0.24.7/go.mod h1:xgkD400pSRfWngDRCv8PwtmHbNWwkJGAKEXxef3q0Mg=
 github.com/UserNobody14/tree-sitter-dart v0.0.0-20250228221807-80e23c07b644 h1:k4tn8w6Ff/lqZ3ePeBEAviVFpyiuOKJ39ATc3eD2ibE=
 github.com/UserNobody14/tree-sitter-dart v0.0.0-20250228221807-80e23c07b644/go.mod h1:6zSIbyfHyxL/+XWRHElGLw+EUPYbDOyhDqIiAX6svrE=
 github.com/akrennmair/pascal v0.0.0-20230115195835-14bcf05a6156 h1:9TcsfXYLZ4uwgMoU1lHv4mOkvVSvT3jb79bUTnRk4m0=


### PR DESCRIPTION
## Summary
- add replace rule for scheme tree-sitter module
- require scheme parser at `v0.24.7`
- regenerate scheme AST test files

## Testing
- `go test ./aster/x/scheme -tags slow -run TestInspect_Golden -update -count=1`

------
https://chatgpt.com/codex/tasks/task_e_688a07943f3c83209309e6533f0f714f