### PR TITLE
Fix build by tagging optional parsers as slow

### DIFF
--- a/aster/x/elixir/ast.go
+++ b/aster/x/elixir/ast.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package elixir
 
 import (

--- a/aster/x/elixir/inspect.go
+++ b/aster/x/elixir/inspect.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package elixir
 
 import (

--- a/aster/x/erlang/ast.go
+++ b/aster/x/erlang/ast.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package erlang
 
 import (

--- a/aster/x/erlang/inspect.go
+++ b/aster/x/erlang/inspect.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package erlang
 
 import (

--- a/aster/x/fs/ast.go
+++ b/aster/x/fs/ast.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package fs
 
 import (

--- a/aster/x/fs/inspect.go
+++ b/aster/x/fs/inspect.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package fs
 
 import (

--- a/aster/x/fs/types.go
+++ b/aster/x/fs/types.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package fs
 
 type Var struct {

--- a/aster/x/rkt/ast.go
+++ b/aster/x/rkt/ast.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rkt
 
 import sitter "github.com/tree-sitter/go-tree-sitter"

--- a/aster/x/rkt/inspect.go
+++ b/aster/x/rkt/inspect.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rkt
 
 import (

--- a/aster/x/scheme/ast.go
+++ b/aster/x/scheme/ast.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package scheme
 
 import (

--- a/aster/x/scheme/inspect.go
+++ b/aster/x/scheme/inspect.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package scheme
 
 import (

--- a/aster/x/swift/ast.go
+++ b/aster/x/swift/ast.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package swift
 
 import (

--- a/aster/x/swift/inspect.go
+++ b/aster/x/swift/inspect.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package swift
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,8 @@ require github.com/tree-sitter/tree-sitter-scala v0.24.0
 
 require github.com/tree-sitter-grammars/tree-sitter-lua v0.3.0
 
+require github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82 // indirect
+
 require (
 	github.com/alexflint/go-scalar v1.2.0 // indirect
 	github.com/apache/arrow-go/v18 v18.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/sasha-s/go-deadlock v0.3.5 h1:tNCOEEDG6tBqrNDOX35j/7hL5FcFViG6awUGROb
 github.com/sasha-s/go-deadlock v0.3.5/go.mod h1:bugP6EGbdGYObIlx7pUZtWqlvo8k9H6vCBBsiChJQ5U=
 github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
 github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
+github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82 h1:6C8qej6f1bStuePVkLSFxoU22XBS165D3klxlzRg8F4=
+github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82/go.mod h1:xe4pgH49k4SsmkQq5OT8abwhWmnzkhpgnXeekbx2efw=
 github.com/sourcegraph/jsonrpc2 v0.2.1 h1:2GtljixMQYUYCmIg7W9aF2dFmniq/mOr2T9tFRh6zSQ=
 github.com/sourcegraph/jsonrpc2 v0.2.1/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
 github.com/spf13/cast v1.9.2 h1:SsGfm7M8QOFtEzumm7UZrZdLLquNdzFYfIbEXntcFbE=


### PR DESCRIPTION
## Summary
- mark optional tree-sitter-based parsers with `//go:build slow`
- add the `go-tree-sitter` dependency needed for Kotlin and Python modules

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688a09479dd48320ae0a9a4b42082b0a