### PR TITLE
Switch Kotlin parser to new tree-sitter

### DIFF
--- a/aster/x/kotlin/ast.go
+++ b/aster/x/kotlin/ast.go
@@ -1,7 +1,7 @@
 package kotlin
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 	"strings"
 )
 

--- a/aster/x/kotlin/inspect.go
+++ b/aster/x/kotlin/inspect.go
@@ -3,8 +3,8 @@ package kotlin
 import (
 	"encoding/json"
 
-	sitter "github.com/smacker/go-tree-sitter"
-	ts "github.com/smacker/go-tree-sitter/kotlin"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	ts "github.com/tree-sitter/kotlin-tree-sitter"
 )
 
 // Program represents a parsed Kotlin source file.

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,8 @@ require github.com/tree-sitter/tree-sitter-scala v0.24.0
 
 require github.com/tree-sitter-grammars/tree-sitter-lua v0.3.0
 
+require github.com/tree-sitter/kotlin-tree-sitter v0.22.4 // indirect
+
 require (
 	github.com/alexflint/go-scalar v1.2.0 // indirect
 	github.com/apache/arrow-go/v18 v18.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,10 @@ github.com/tree-sitter-grammars/tree-sitter-lua v0.3.0 h1:EsPKckt1PBbdjSKQgnqSLn
 github.com/tree-sitter-grammars/tree-sitter-lua v0.3.0/go.mod h1:hIOfn+lxpU4SRrtejLVrU2+8SAoRwNC01m3XaR/Cw0A=
 github.com/tree-sitter/go-tree-sitter v0.25.0 h1:sx6kcg8raRFCvc9BnXglke6axya12krCJF5xJ2sftRU=
 github.com/tree-sitter/go-tree-sitter v0.25.0/go.mod h1:r77ig7BikoZhHrrsjAnv8RqGti5rtSyvDHPzgTPsUuU=
+github.com/tree-sitter/kotlin-tree-sitter v0.22.4 h1:QKoAe9eu53oxpZHjkTItAnfjYLLP8Tea3W8W0JUyJ7o=
+github.com/tree-sitter/kotlin-tree-sitter v0.22.4/go.mod h1:aFh27JsPSa4V3RPvxiAwYbKhhwj5M3Dg+Wi2ddyyEHU=
+github.com/tree-sitter/kotlin-tree-sitter v0.24.1 h1:SIPe5d53asRPrsRTbBbKAZGGCm4HGhN9SsZuHoIoPr4=
+github.com/tree-sitter/kotlin-tree-sitter v0.24.1/go.mod h1:aFh27JsPSa4V3RPvxiAwYbKhhwj5M3Dg+Wi2ddyyEHU=
 github.com/tree-sitter/tree-sitter-c v0.23.4 h1:nBPH3FV07DzAD7p0GfNvXM+Y7pNIoPenQWBpvM++t4c=
 github.com/tree-sitter/tree-sitter-c v0.23.4/go.mod h1:MkI5dOiIpeN94LNjeCp8ljXN/953JCwAby4bClMr6bw=
 github.com/tree-sitter/tree-sitter-c-sharp v0.23.1 h1:ddG6osP34sMieVNN6lu5ZG/3N8Wn+67+43BmipqidyM=


### PR DESCRIPTION
## Summary
- replace smacker go-tree-sitter with the official package for Kotlin parser
- include `kotlin-tree-sitter` dependency

## Testing
- `go test ./aster/x/kotlin -run TestInspect_Golden -count=1` *(fails: no required module provides package github.com/tree-sitter/kotlin-tree-sitter)*

------
https://chatgpt.com/codex/tasks/task_e_688a0b1e57588320a03ea1c43fdba1ff