### PR TITLE
Update F# AST structs and regenerate print_hello

### DIFF
--- a/aster/x/fs/inspect.go
+++ b/aster/x/fs/inspect.go
@@ -3,6 +3,8 @@
 package fs
 
 import (
+	"encoding/json"
+
 	sitter "github.com/tree-sitter/go-tree-sitter"
 	fsharp "github.com/tree-sitter/tree-sitter-fsharp/bindings/go"
 )
@@ -11,18 +13,32 @@ import (
 // Program represents a parsed F# source file. The Root field mirrors the tree
 // sitter "file" node.
 type Program struct {
-	Root File `json:"root"`
+	Root *File `json:"root"`
 }
 
-// Inspect parses F# code using tree-sitter and returns its Program representation.
-// When withPos is false, positional information is omitted from the resulting AST.
-func Inspect(src string, withPos bool) (*Program, error) {
+// Inspect parses the given F# source code using tree-sitter. Positional fields
+// are omitted unless IncludePositions is set to true.
+func Inspect(src string) (*Program, error) {
 	parser := sitter.NewParser()
 	parser.SetLanguage(sitter.NewLanguage(fsharp.LanguageFSharp()))
 	tree := parser.Parse([]byte(src), nil)
-	root := convert(tree.RootNode(), []byte(src), withPos)
+	root := convert(tree.RootNode(), []byte(src))
 	if root == nil {
 		return &Program{}, nil
 	}
-	return &Program{Root: File(*root)}, nil
+	return &Program{Root: (*File)(root)}, nil
+}
+
+// InspectWithPositions parses the source and populates position fields in the
+// resulting AST.
+func InspectWithPositions(src string) (*Program, error) {
+	IncludePositions = true
+	defer func() { IncludePositions = false }()
+	return Inspect(src)
+}
+
+// MarshalJSON implements json.Marshaler for Program to ensure stable output.
+func (p *Program) MarshalJSON() ([]byte, error) {
+	type Alias Program
+	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(p)})
 }

--- a/aster/x/fs/inspect_test.go
+++ b/aster/x/fs/inspect_test.go
@@ -45,7 +45,7 @@ func TestInspect_Golden(t *testing.T) {
 		t.Fatalf("no files: %s", srcPattern)
 	}
 
-	outDir := filepath.Join(root, "tests/json-ast/x/fs")
+	outDir := filepath.Join(root, "tests/aster/x/fs")
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		t.Fatalf("mkout: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestInspect_Golden(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read src: %v", err)
 			}
-			prog, err := fs.Inspect(string(data), false)
+			prog, err := fs.Inspect(string(data))
 			if err != nil {
 				t.Fatalf("inspect: %v", err)
 			}

--- a/tests/aster/x/fs/print_hello.fs.json
+++ b/tests/aster/x/fs/print_hello.fs.json
@@ -1,0 +1,48 @@
+{
+  "root": {
+    "kind": "file",
+    "children": [
+      {
+        "kind": "line_comment",
+        "text": "// Generated 2025-07-22 04:52 +0700"
+      },
+      {
+        "kind": "application_expression",
+        "children": [
+          {
+            "kind": "application_expression",
+            "children": [
+              {
+                "kind": "long_identifier_or_op",
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "name": "printfn"
+                  }
+                ]
+              },
+              {
+                "kind": "const",
+                "children": [
+                  {
+                    "kind": "string",
+                    "text": "\"%s\""
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "const",
+            "children": [
+              {
+                "kind": "string",
+                "text": "\"hello\""
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add `IncludePositions` option for F# AST nodes
- update `convert` and inspection helpers to use the global option
- adjust tests to write output under `tests/aster/x/fs`
- regenerate `print_hello.fs.json` with the new AST structures

## Testing
- `go test -tags slow ./aster/x/fs -run TestInspect_Golden -update`

------
https://chatgpt.com/codex/tasks/task_e_688a174a4828832093a425649fcb91c5