### PR TITLE
Refactor Java aster AST

### DIFF
--- a/aster/x/java/inspect.go
+++ b/aster/x/java/inspect.go
@@ -10,16 +10,19 @@ import (
 )
 
 // Program represents a parsed Java source file.
+// Program represents a parsed Java source file. The root node is a SourceFile.
 type Program struct {
-	Root *Node `json:"root"`
+	File *SourceFile `json:"file"`
 }
 
 // Inspect parses the given Java source code using tree-sitter and returns
 // its Program structure.
-func Inspect(src string) (*Program, error) {
+// Inspect parses the given Java source code using tree-sitter. When withPos is
+// true the returned AST includes positional information.
+func Inspect(src string, withPos bool) (*Program, error) {
 	parser := sitter.NewParser()
 	parser.SetLanguage(sitter.NewLanguage(javats.Language()))
 	tree := parser.ParseCtx(context.Background(), []byte(src), nil)
-	root := convert(tree.RootNode(), []byte(src))
-	return &Program{Root: root}, nil
+	root := toNode(tree.RootNode(), []byte(src), withPos)
+	return &Program{File: (*SourceFile)(root)}, nil
 }

--- a/aster/x/java/inspect_test.go
+++ b/aster/x/java/inspect_test.go
@@ -46,7 +46,7 @@ func TestInspect_Golden(t *testing.T) {
 	ensureJava(t)
 	root := repoRoot(t)
 	srcDir := filepath.Join(root, "tests", "transpiler", "x", "java")
-	outDir := filepath.Join(root, "tests", "json-ast", "x", "java")
+	outDir := filepath.Join(root, "tests", "aster", "x", "java")
 	os.MkdirAll(outDir, 0o755)
 
 	files, err := filepath.Glob(filepath.Join(srcDir, "*.java"))
@@ -62,7 +62,7 @@ func TestInspect_Golden(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read src: %v", err)
 			}
-			prog, err := javaast.Inspect(string(data))
+			prog, err := javaast.Inspect(string(data), false)
 			if err != nil {
 				t.Skipf("inspect error: %v", err)
 				return

--- a/tests/aster/x/java/print_hello.java.json
+++ b/tests/aster/x/java/print_hello.java.json
@@ -1,0 +1,99 @@
+{
+  "file": {
+    "kind": "program",
+    "children": [
+      {
+        "kind": "class_declaration",
+        "children": [
+          {
+            "kind": "identifier",
+            "text": "Main"
+          },
+          {
+            "kind": "class_body",
+            "children": [
+              {
+                "kind": "method_declaration",
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "text": "main"
+                  },
+                  {
+                    "kind": "formal_parameters",
+                    "children": [
+                      {
+                        "kind": "formal_parameter",
+                        "children": [
+                          {
+                            "kind": "array_type",
+                            "children": [
+                              {
+                                "kind": "type_identifier",
+                                "text": "String"
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "identifier",
+                            "text": "args"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "block",
+                    "children": [
+                      {
+                        "kind": "expression_statement",
+                        "children": [
+                          {
+                            "kind": "method_invocation",
+                            "children": [
+                              {
+                                "kind": "field_access",
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "text": "System"
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "text": "out"
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "text": "println"
+                              },
+                              {
+                                "kind": "argument_list",
+                                "children": [
+                                  {
+                                    "kind": "string_literal",
+                                    "children": [
+                                      {
+                                        "kind": "string_fragment",
+                                        "text": "hello"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add typed AST node aliases in `java` package
- include toggleable position fields with `toNode`
- update Program structure and regeneration logic
- regenerate Java AST golden for `print_hello`

## Testing
- `go build -tags slow ./aster/x/java`


------
https://chatgpt.com/codex/tasks/task_e_688a1751daa08320ab47481419888d6d