### PR TITLE
Refine Kotlin AST output

### DIFF
--- a/aster/x/kotlin/ast.go
+++ b/aster/x/kotlin/ast.go
@@ -64,7 +64,7 @@ func isValueLeaf(n *sitter.Node) bool {
 		return false
 	}
 	switch n.Kind() {
-	case "simple_identifier", "type_identifier", "integer_literal",
+	case "identifier", "simple_identifier", "type_identifier", "integer_literal",
 		"string_literal", "string_content":
 		return true
 	}

--- a/aster/x/kotlin/inspect_test.go
+++ b/aster/x/kotlin/inspect_test.go
@@ -39,7 +39,7 @@ func repoRoot(t *testing.T) string {
 func TestInspect_Golden(t *testing.T) {
 	root := repoRoot(t)
 	srcDir := filepath.Join(root, "tests", "transpiler", "x", "kt")
-	outDir := filepath.Join(root, "tests", "json-ast", "x", "kotlin")
+	outDir := filepath.Join(root, "tests", "aster", "x", "kotlin")
 	os.MkdirAll(outDir, 0o755)
 
 	files, err := filepath.Glob(filepath.Join(srcDir, "*.kt"))

--- a/tests/aster/x/kotlin/print_hello.kt.json
+++ b/tests/aster/x/kotlin/print_hello.kt.json
@@ -1,0 +1,54 @@
+{
+  "root": {
+    "kind": "source_file",
+    "children": [
+      {
+        "kind": "function_declaration",
+        "children": [
+          {
+            "kind": "identifier",
+            "text": "main"
+          },
+          {
+            "kind": "function_body",
+            "children": [
+              {
+                "kind": "block",
+                "children": [
+                  {
+                    "kind": "call_expression",
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "text": "println"
+                      },
+                      {
+                        "kind": "value_arguments",
+                        "children": [
+                          {
+                            "kind": "value_argument",
+                            "children": [
+                              {
+                                "kind": "string_literal",
+                                "children": [
+                                  {
+                                    "kind": "string_content",
+                                    "text": "hello"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- update Kotlin AST to keep identifier leaves
- adjust kotlin inspect tests to use the `tests/aster` folder
- add a new golden output for `print_hello.kt`

## Testing
- `go test ./aster/x/kotlin -tags slow -run TestInspect_Golden`

------
https://chatgpt.com/codex/tasks/task_e_688a175373608320be8f6522adb80fa9