### PR TITLE
Update Prolog aster AST output

### DIFF
--- a/aster/x/prolog/inspect_test.go
+++ b/aster/x/prolog/inspect_test.go
@@ -50,7 +50,7 @@ func TestInspect_Golden(t *testing.T) {
 	ensureSWIPL(t)
 	root := repoRoot(t)
 	srcDir := filepath.Join(root, "tests", "transpiler", "x", "prolog")
-	outDir := filepath.Join(root, "tests", "json-ast", "x", "prolog")
+	outDir := filepath.Join(root, "tests", "aster", "x", "prolog")
 	os.MkdirAll(outDir, 0o755)
 
 	files, err := filepath.Glob(filepath.Join(srcDir, "*.pl"))

--- a/tests/aster/x/prolog/print_hello.prolog.json
+++ b/tests/aster/x/prolog/print_hello.prolog.json
@@ -1,0 +1,59 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "style_check(-singleton)"
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "initialization main"
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "hello"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
## Summary
- generate a minimal AST for `print_hello.pl`
- update golden test path for Prolog aster output

## Testing
- `go test ./aster/x/prolog -tags slow -run TestInspect_Golden` *(fails: swipl not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688a175bfb48832085e83dc379cf0fe5