### PR TITLE
Fix zig tree-sitter binding

### DIFF
--- a/aster/x/zig/ast.go
+++ b/aster/x/zig/ast.go
@@ -38,9 +38,6 @@ type (
 	InitList        Node
 )
 
-// SourceFile is the root of a Zig program.
-type SourceFile struct{ Node }
-
 // Options control how the AST is produced.
 type Options struct {
 	// Positions includes line/column information when true.

--- a/aster/x/zig/inspect.go
+++ b/aster/x/zig/inspect.go
@@ -5,8 +5,8 @@ package zig
 import (
 	"context"
 
+	tsz "github.com/tree-sitter-grammars/tree-sitter-zig/bindings/go"
 	sitter "github.com/tree-sitter/go-tree-sitter"
-	tsz "github.com/tree-sitter/tree-sitter-zig/bindings/go"
 )
 
 // Program describes a parsed Zig source file.

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require github.com/tree-sitter/tree-sitter-scala v0.24.0
 require (
 	github.com/tree-sitter-grammars/tree-sitter-kotlin v1.1.0
 	github.com/tree-sitter-grammars/tree-sitter-lua v0.4.0
+	github.com/tree-sitter-grammars/tree-sitter-zig v1.1.2
 	github.com/tree-sitter/tree-sitter-scheme v0.24.7
 )
 

--- a/go.sum
+++ b/go.sum
@@ -183,6 +183,8 @@ github.com/tree-sitter-grammars/tree-sitter-kotlin v1.1.0 h1:SWIUDASa+WPhDDem1U5
 github.com/tree-sitter-grammars/tree-sitter-kotlin v1.1.0/go.mod h1:eH+flFf3QOa9c9BY9g3Bz02F7zTq30kGIG3cgB0lSlI=
 github.com/tree-sitter-grammars/tree-sitter-lua v0.4.0 h1:Wfi4r05k6XUupv67RAObbsIBTnBlUpTOZtoAdM86uq8=
 github.com/tree-sitter-grammars/tree-sitter-lua v0.4.0/go.mod h1:hIOfn+lxpU4SRrtejLVrU2+8SAoRwNC01m3XaR/Cw0A=
+github.com/tree-sitter-grammars/tree-sitter-zig v1.1.2 h1:j8JARutysdxMwBEfVLGx9us7cdSzD1TTui/pPLGCFDk=
+github.com/tree-sitter-grammars/tree-sitter-zig v1.1.2/go.mod h1:ekWQEqj2e/gQal396f5rKJ6L14/a4bMPMqSRzmf8OZE=
 github.com/tree-sitter/go-tree-sitter v0.25.0 h1:sx6kcg8raRFCvc9BnXglke6axya12krCJF5xJ2sftRU=
 github.com/tree-sitter/go-tree-sitter v0.25.0/go.mod h1:r77ig7BikoZhHrrsjAnv8RqGti5rtSyvDHPzgTPsUuU=
 github.com/tree-sitter/tree-sitter-c v0.24.1 h1:GV9DjvIV6uYe3W/JBKMFwE4hJcRxzRDq63llxNFHOkY=


### PR DESCRIPTION
## Summary
- fix path for Zig tree-sitter binding
- remove duplicate `SourceFile` type in Zig AST
- add zig grammar module to go.mod

## Testing
- `go build ./aster/x/zig`
- `go mod tidy`

------
https://chatgpt.com/codex/tasks/task_e_688a1dfa8d988320810d81ac39e3074c