### PR TITLE
Fix inspect command and add golden test

### DIFF
--- a/cmd/mochix/main.go
+++ b/cmd/mochix/main.go
@@ -525,13 +525,13 @@ func runInspect(cmd *InspectCmd) error {
 	case "cpp", "c++":
 		prog, err = cppast.Inspect(src)
 	case "cs", "csharp":
-		prog, err = csast.Inspect(src, false)
+		prog, err = csast.Inspect(src)
 	case "dart":
 		prog, err = dartast.Inspect(src)
 	case "elixir", "ex":
-		prog, err = elixirast.Inspect(src, false)
+		prog, err = elixirast.Inspect(src)
 	case "fs", "fsharp":
-		prog, err = fsast.Inspect(src, false)
+		prog, err = fsast.Inspect(src)
 	case "go":
 		prog, err = goast.Inspect(src)
 	case "haskell":
@@ -539,7 +539,7 @@ func runInspect(cmd *InspectCmd) error {
 	case "hs":
 		prog, err = hsast.Inspect(src)
 	case "java":
-		prog, err = javaast.Inspect(src)
+		prog, err = javaast.Inspect(src, false)
 	case "kotlin", "kt":
 		prog, err = kotlinast.Inspect(src)
 	case "lua":
@@ -557,7 +557,7 @@ func runInspect(cmd *InspectCmd) error {
 	case "prolog":
 		prog, err = prologast.Inspect(src)
 	case "py", "python":
-		prog, err = pyast.Inspect(src, false)
+		prog, err = pyast.Inspect(src)
 	case "rb", "ruby":
 		prog, err = rbast.Inspect(src)
 	case "rkt", "racket":

--- a/tests/mochix/aster_test.go
+++ b/tests/mochix/aster_test.go
@@ -1,0 +1,28 @@
+//go:build slow
+
+package mochix_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInspectGoPrintHello(t *testing.T) {
+	root := repoRoot(t)
+	src := filepath.Join(root, "tests/transpiler/x/go/print_hello.go")
+	got, err := runMochix(t, "inspect", "go", src)
+	if err != nil {
+		t.Fatalf("inspect error: %v", err)
+	}
+	wantPath := filepath.Join(root, "tests/aster/x/go/print_hello.go.json")
+	want, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	want = bytes.TrimSpace(want)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("golden mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- fix `mochix` inspect command for updated aster signatures
- test inspecting a Go file via `mochix inspect`

## Testing
- `go build -tags slow ./cmd/mochix` *(fails: running gcc failed)*
- `go test ./tests/mochix -run TestInspectGoPrintHello -tags slow -count=1` *(fails: exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_688a1f126b8c832090d4e4eab6cde5d3