### PR TITLE
Fix mochix inspection options

### DIFF
--- a/cmd/mochix/main.go
+++ b/cmd/mochix/main.go
@@ -561,9 +561,9 @@ func runInspect(cmd *InspectCmd) error {
 	case "rb", "ruby":
 		prog, err = rbast.Inspect(src)
 	case "rkt", "racket":
-		prog, err = rktast.Inspect(src, false)
+		prog, err = rktast.Inspect(src, rktast.Options{})
 	case "rs", "rust":
-		prog, err = rsast.Inspect(src, false)
+		prog, err = rsast.Inspect(src, rsast.Option{})
 	case "scala":
 		prog, err = scalaast.Inspect(src)
 	case "scheme":


### PR DESCRIPTION
## Summary
- build mochix with correct option types for Racket and Rust

## Testing
- `go vet ./cmd/...` *(fails: environment limits)*
- `go build -tags slow ./cmd/mochix` *(fails: environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_688a22c2550c8320b4a9bf93a310d9ab