### PR TITLE
Update inspect command and extend AST tests

### DIFF
--- a/cmd/mochix/main.go
+++ b/cmd/mochix/main.go
@@ -84,12 +84,12 @@ import (
 	prologast "mochi/aster/x/prolog"
 	pyast "mochi/aster/x/py"
 	rbast "mochi/aster/x/rb"
-	rktast "mochi/aster/x/rkt"
 	rsast "mochi/aster/x/rs"
 	scalaast "mochi/aster/x/scala"
 	schemeast "mochi/aster/x/scheme"
 	swiftast "mochi/aster/x/swift"
 	tsast "mochi/aster/x/ts"
+	zigast "mochi/aster/x/zig"
 
 	"mochi/ast"
 	"mochi/interpreter"
@@ -560,8 +560,8 @@ func runInspect(cmd *InspectCmd) error {
 		prog, err = pyast.Inspect(src)
 	case "rb", "ruby":
 		prog, err = rbast.Inspect(src)
-	case "rkt", "racket":
-		prog, err = rktast.Inspect(src, rktast.Options{})
+	case "zig":
+		prog, err = zigast.Inspect(src)
 	case "rs", "rust":
 		prog, err = rsast.Inspect(src, rsast.Option{})
 	case "scala":

--- a/tests/mochix/aster_test.go
+++ b/tests/mochix/aster_test.go
@@ -6,23 +6,69 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
 )
 
-func TestInspectGoPrintHello(t *testing.T) {
+func TestInspectGolden(t *testing.T) {
 	root := repoRoot(t)
-	src := filepath.Join(root, "tests/transpiler/x/go/print_hello.go")
-	got, err := runMochix(t, "inspect", "go", src)
-	if err != nil {
-		t.Fatalf("inspect error: %v", err)
+	asterDir := filepath.Join(root, "tests/aster/x")
+	langMap := map[string]struct{ dir, ext string }{
+		"elixir":  {"ex", "exs"},
+		"erlang":  {"erl", "erl"},
+		"haskell": {"hs", "hs"},
+		"kotlin":  {"kt", "kt"},
+		"ocaml":   {"ocaml", "ml"},
+		"prolog":  {"prolog", "pl"},
+		"ruby":    {"rb", "rb"},
+		"scheme":  {"scheme", "scm"},
 	}
-	wantPath := filepath.Join(root, "tests/aster/x/go/print_hello.go.json")
-	want, err := os.ReadFile(wantPath)
+
+	entries, err := os.ReadDir(asterDir)
 	if err != nil {
-		t.Fatalf("read golden: %v", err)
+		t.Fatal(err)
 	}
-	want = bytes.TrimSpace(want)
-	if !bytes.Equal(got, want) {
-		t.Fatalf("golden mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	for _, ent := range entries {
+		lang := ent.Name()
+		if !ent.IsDir() || lang == "rkt" {
+			continue
+		}
+		cfg, ok := langMap[lang]
+		if !ok {
+			cfg = struct{ dir, ext string }{lang, lang}
+		}
+
+		gfiles, err := filepath.Glob(filepath.Join(asterDir, lang, "*.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		sort.Strings(gfiles)
+		for _, gf := range gfiles {
+			base := filepath.Base(gf)
+			nameExt := strings.TrimSuffix(base, ".json")
+			i := strings.LastIndex(nameExt, ".")
+			if i < 0 {
+				t.Fatalf("invalid golden filename: %s", base)
+			}
+			name := nameExt[:i]
+			src := filepath.Join(root, "tests/transpiler/x", cfg.dir, name+"."+cfg.ext)
+			if _, err := os.Stat(src); os.IsNotExist(err) {
+				t.Skipf("source %s not found", src)
+				continue
+			}
+			got, err := runMochix(t, "inspect", lang, src)
+			if err != nil {
+				t.Fatalf("inspect error: %v", err)
+			}
+			want, err := os.ReadFile(gf)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			want = bytes.TrimSpace(want)
+			if !bytes.Equal(got, want) {
+				t.Fatalf("golden mismatch for %s\n--- got ---\n%s\n--- want ---\n%s", base, got, want)
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- add zig inspector case in mochix inspect command
- drop racket inspector
- expand mochix AST tests to cover multiple languages via golden files

## Testing
- `go test ./tests/mochix -run TestInspectGolden -tags slow` *(fails: context canceled or long)*

------
https://chatgpt.com/codex/tasks/task_e_688a54314c3883208dbac59f645dd0c3