### PR TITLE
Add Kotlin typealias support

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/enumerations-1.bench
+++ b/tests/rosetta/transpiler/Kotlin/enumerations-1.bench
@@ -1,0 +1,1 @@
+{"duration_us":4675, "memory_bytes":144864, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/enumerations-1.kt
+++ b/tests/rosetta/transpiler/Kotlin/enumerations-1.kt
@@ -1,0 +1,45 @@
+import java.math.BigInteger
+
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+val apple: Int = 0
+val banana: BigInteger = (apple + 1).toBigInteger()
+val cherry: BigInteger = banana.add(1.toBigInteger())
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/enumerations-2.bench
+++ b/tests/rosetta/transpiler/Kotlin/enumerations-2.bench
@@ -1,0 +1,1 @@
+{"duration_us":5021, "memory_bytes":144864, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/enumerations-2.kt
+++ b/tests/rosetta/transpiler/Kotlin/enumerations-2.kt
@@ -1,0 +1,43 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+val apple: Int = 0
+val banana: Int = 1
+val cherry: Int = 2
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/enumerations-3.bench
+++ b/tests/rosetta/transpiler/Kotlin/enumerations-3.bench
@@ -1,0 +1,1 @@
+{"duration_us":5220, "memory_bytes":144864, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/enumerations-3.kt
+++ b/tests/rosetta/transpiler/Kotlin/enumerations-3.kt
@@ -1,0 +1,44 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+typealias fruit = Int
+val apple: fruit = 0 as fruit
+val banana: fruit = (apple.toInt() + 1) as fruit
+val cherry: fruit = (banana.toInt() + 1) as fruit
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/enumerations-4.bench
+++ b/tests/rosetta/transpiler/Kotlin/enumerations-4.bench
@@ -1,0 +1,1 @@
+{"duration_us":5250, "memory_bytes":144864, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/enumerations-4.kt
+++ b/tests/rosetta/transpiler/Kotlin/enumerations-4.kt
@@ -1,0 +1,44 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+typealias fruit = Int
+val apple: fruit = 0 as fruit
+val banana: fruit = 1 as fruit
+val cherry: fruit = 2 as fruit
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/environment-variables-1.error
+++ b/tests/rosetta/transpiler/Kotlin/environment-variables-1.error
@@ -1,0 +1,1 @@
+transpile error: unsupported import

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -2,11 +2,11 @@
 
 Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
-Last updated: 2025-07-28 11:42 +0700
+Last updated: 2025-07-31 00:20 +0700
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 
-Completed golden tests: **102/104** (auto-generated)
+Completed golden tests: **102/105** (auto-generated)
 
 ### Golden test checklist
 - [x] append_builtin.mochi
@@ -79,6 +79,7 @@ Completed golden tests: **102/104** (auto-generated)
 - [x] nested_function.mochi
 - [x] order_by_map.mochi
 - [x] outer_join.mochi
+- [ ] pairs_loop.mochi
 - [x] partial_application.mochi
 - [x] print_hello.mochi
 - [x] pure_fold.mochi

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-07-28 11:42 +0700
+Last updated: 2025-07-31 00:20 +0700
 
-Completed tasks: **128/493**
+Completed tasks: **131/491**
 
 ### Checklist
 | Index | Name | Status | Duration | Memory |
@@ -23,482 +23,480 @@ Completed tasks: **128/493**
 | 12 | 9-billion-names-of-god-the-integer | ✓ | 245.36ms | 825.1 KB |
 | 13 | 99-bottles-of-beer-2 | ✓ |  | 97.2 KB |
 | 14 | 99-bottles-of-beer | ✓ | 11.87ms | 133.8 KB |
-| 15 | DNS-query | ✓ |  | 134.1 KB |
-| 16 | Duffinian-numbers |  |  |  |
-| 17 | Find-if-a-point-is-within-a-triangle |  |  |  |
-| 18 | a+b | ✓ |  | 102.6 KB |
-| 19 | abbreviations-automatic | ✓ | 24.27ms | 131.6 KB |
-| 20 | abbreviations-easy | ✓ |  | 123.0 KB |
-| 21 | abbreviations-simple | ✓ |  | 119.5 KB |
-| 22 | abc-problem | ✓ | 13.57ms | 121.4 KB |
-| 23 | abelian-sandpile-model-identity | ✓ |  | 133.0 KB |
-| 24 | abelian-sandpile-model | ✓ |  | 123.5 KB |
-| 25 | abstract-type | ✓ | 5.54ms | 130.4 KB |
-| 26 | abundant-deficient-and-perfect-number-classifications | ✓ |  | 133.6 KB |
-| 27 | abundant-odd-numbers | ✓ |  | 826.2 KB |
-| 28 | accumulator-factory | ✓ | 12.46ms | 109.0 KB |
-| 29 | achilles-numbers |  |  |  |
-| 30 | ackermann-function-2 | ✓ | 3.06ms | 133.9 KB |
-| 31 | ackermann-function-3 | ✓ |  |  |
-| 32 | ackermann-function | ✓ |  | 133.9 KB |
-| 33 | active-directory-connect | ✓ | 9.17ms | 122.7 KB |
-| 34 | active-directory-search-for-a-user | ✓ |  | 120.8 KB |
-| 35 | active-object | ✓ |  | 124.4 KB |
-| 36 | add-a-variable-to-a-class-instance-at-runtime | ✓ | 14.70ms | 101.4 KB |
-| 37 | additive-primes | ✓ |  | 131.2 KB |
-| 38 | address-of-a-variable | ✓ | 19.16ms | 105.8 KB |
-| 39 | adfgvx-cipher |  |  |  |
-| 40 | aks-test-for-primes | ✓ | 5.39ms | 130.5 KB |
-| 41 | algebraic-data-types | ✓ |  | 121.9 KB |
-| 42 | align-columns |  |  |  |
-| 43 | aliquot-sequence-classifications |  |  |  |
-| 44 | almkvist-giullera-formula-for-pi |  |  |  |
-| 45 | almost-prime | ✓ | 13.54ms | 122.7 KB |
-| 46 | amb | ✓ | 31.89ms | 121.2 KB |
-| 47 | amicable-pairs | ✓ | 1.96s | 821.3 KB |
-| 48 | anagrams-deranged-anagrams | ✓ | 22.78ms | 129.9 KB |
-| 49 | anagrams | ✓ | 25.65ms | 128.6 KB |
-| 50 | angle-difference-between-two-bearings-1 | ✓ | 11.23ms | 131.0 KB |
-| 51 | angle-difference-between-two-bearings-2 | ✓ | 10.72ms | 131.0 KB |
-| 52 | angles-geometric-normalization-and-conversion | ✓ | 26.45ms | 120.1 KB |
-| 53 | animate-a-pendulum | ✓ | 7.51ms | 141.0 KB |
-| 54 | animation | ✓ | 17.19ms | 138.1 KB |
-| 55 | anonymous-recursion-1 | ✓ | 19.00ms | 130.2 KB |
-| 56 | anonymous-recursion-2 | ✓ | 19.31ms | 130.1 KB |
-| 57 | anonymous-recursion | ✓ | 7.40ms | 140.7 KB |
-| 58 | anti-primes | ✓ | 49.29ms | 137.7 KB |
-| 59 | append-a-record-to-the-end-of-a-text-file | ✓ | 22.00ms | 130.3 KB |
-| 60 | apply-a-callback-to-an-array-1 | ✓ | 19.75ms | 130.3 KB |
-| 61 | apply-a-callback-to-an-array-2 | ✓ | 21.43ms | 128.2 KB |
-| 62 | apply-a-digital-filter-direct-form-ii-transposed- | ✓ | 9.07ms | 131.2 KB |
-| 63 | approximate-equality | ✓ | 19.54ms | 119.9 KB |
-| 64 | arbitrary-precision-integers-included- | ✓ | 61.69ms | 823.6 KB |
-| 65 | archimedean-spiral | ✓ | 20.34ms | 130.2 KB |
-| 66 | arena-storage-pool | ✓ | 33.26ms | 127.2 KB |
-| 67 | arithmetic-complex | ✓ | 16.13ms | 126.4 KB |
-| 68 | arithmetic-derivative | ✓ | 35.42ms | 130.4 KB |
-| 69 | arithmetic-evaluation | ✓ | 14.23ms | 137.1 KB |
-| 70 | arithmetic-geometric-mean-calculate-pi | ✓ | 10.88ms | 130.6 KB |
-| 71 | arithmetic-geometric-mean | ✓ | 12.15ms | 130.6 KB |
-| 72 | arithmetic-integer-1 | ✓ | 12.68ms | 140.1 KB |
-| 73 | arithmetic-integer-2 | ✓ | 10.42ms | 140.1 KB |
-| 74 | arithmetic-numbers |  |  |  |
-| 75 | arithmetic-rational |  |  |  |
-| 76 | array-concatenation | ✓ | 5.91ms | 132.0 KB |
-| 77 | array-length | ✓ | 10.63ms | 123.6 KB |
-| 78 | arrays | ✓ | 6.53ms | 131.7 KB |
-| 79 | ascending-primes | ✓ | 13.98ms | 120.7 KB |
-| 80 | ascii-art-diagram-converter | ✓ | 5.01ms | 130.9 KB |
-| 81 | assertions | ✓ | 2.99ms | 134.0 KB |
-| 82 | associative-array-creation |  |  |  |
-| 83 | associative-array-iteration |  |  |  |
-| 84 | associative-array-merging |  |  |  |
-| 85 | atomic-updates | ✓ | 11.17ms | 114.8 KB |
-| 86 | attractive-numbers | ✓ | 5.01ms | 134.0 KB |
-| 87 | average-loop-length | ✓ | 244.04ms | 847.4 KB |
-| 88 | averages-arithmetic-mean | ✓ | 12.80ms | 110.5 KB |
-| 89 | averages-mean-time-of-day | ✓ | 23.52ms | 124.8 KB |
-| 90 | averages-median-1 | ✓ | 10.06ms | 113.8 KB |
-| 91 | averages-median-2 | ✓ |  |  |
-| 92 | averages-median-3 | ✓ |  |  |
-| 93 | averages-mode | ✓ |  |  |
-| 94 | averages-pythagorean-means | ✓ |  |  |
-| 95 | averages-root-mean-square | ✓ |  |  |
-| 96 | averages-simple-moving-average | ✓ |  |  |
-| 97 | avl-tree |  |  |  |
-| 98 | b-zier-curves-intersections | ✓ |  |  |
-| 99 | babbage-problem | ✓ |  |  |
-| 100 | babylonian-spiral | ✓ |  |  |
-| 101 | balanced-brackets | ✓ | 11.75ms | 115.2 KB |
-| 102 | balanced-ternary | ✓ | 13.76ms | 111.5 KB |
-| 103 | barnsley-fern | ✓ | 28.58ms | 44.6 KB |
-| 104 | base64-decode-data | ✓ | 7.03ms | 93.1 KB |
-| 105 | bell-numbers | ✓ | 20.23ms | 109.4 KB |
-| 106 | benfords-law | ✓ | 15.94ms | 65.9 KB |
-| 107 | bernoulli-numbers | ✓ | 88.28ms | 835.6 KB |
-| 108 | best-shuffle |  |  |  |
-| 109 | bifid-cipher |  |  |  |
-| 110 | bin-given-limits |  |  |  |
-| 111 | binary-digits |  |  |  |
-| 112 | binary-search |  |  |  |
-| 113 | binary-strings |  |  |  |
-| 114 | bioinformatics-base-count |  |  |  |
-| 115 | bioinformatics-global-alignment |  |  |  |
-| 116 | bioinformatics-sequence-mutation |  |  |  |
-| 117 | biorhythms |  |  |  |
-| 118 | bitcoin-address-validation |  |  |  |
-| 119 | bitmap-b-zier-curves-cubic |  |  |  |
-| 120 | bitmap-b-zier-curves-quadratic |  |  |  |
-| 121 | bitmap-bresenhams-line-algorithm |  |  |  |
-| 122 | bitmap-flood-fill |  |  |  |
-| 123 | bitmap-histogram |  |  |  |
-| 124 | bitmap-midpoint-circle-algorithm |  |  |  |
-| 125 | bitmap-ppm-conversion-through-a-pipe |  |  |  |
-| 126 | bitmap-read-a-ppm-file |  |  |  |
-| 127 | bitmap-read-an-image-through-a-pipe |  |  |  |
-| 128 | bitmap-write-a-ppm-file |  |  |  |
-| 129 | bitmap |  |  |  |
-| 130 | bitwise-io-1 |  |  |  |
-| 131 | bitwise-io-2 |  |  |  |
-| 132 | bitwise-operations |  |  |  |
-| 133 | blum-integer |  |  |  |
-| 134 | boolean-values |  |  |  |
-| 135 | box-the-compass |  |  |  |
-| 136 | boyer-moore-string-search |  |  |  |
-| 137 | brazilian-numbers |  |  |  |
-| 138 | break-oo-privacy |  |  |  |
-| 139 | brilliant-numbers |  |  |  |
-| 140 | brownian-tree |  |  |  |
-| 141 | bulls-and-cows-player |  |  |  |
-| 142 | bulls-and-cows |  |  |  |
-| 143 | burrows-wheeler-transform |  |  |  |
-| 144 | caesar-cipher-1 |  |  |  |
-| 145 | caesar-cipher-2 |  |  |  |
-| 146 | calculating-the-value-of-e |  |  |  |
-| 147 | calendar---for-real-programmers-1 |  |  |  |
-| 148 | calendar---for-real-programmers-2 |  |  |  |
-| 149 | calendar |  |  |  |
-| 150 | calkin-wilf-sequence |  |  |  |
-| 151 | call-a-foreign-language-function |  |  |  |
-| 152 | call-a-function-1 |  |  |  |
-| 153 | call-a-function-10 |  |  |  |
-| 154 | call-a-function-11 |  |  |  |
-| 155 | call-a-function-12 |  |  |  |
-| 156 | call-a-function-2 |  |  |  |
-| 157 | call-a-function-3 |  |  |  |
-| 158 | call-a-function-4 |  |  |  |
-| 159 | call-a-function-5 |  |  |  |
-| 160 | call-a-function-6 |  |  |  |
-| 161 | call-a-function-7 |  |  |  |
-| 162 | call-a-function-8 |  |  |  |
-| 163 | call-a-function-9 |  |  |  |
-| 164 | call-an-object-method-1 |  |  |  |
-| 165 | call-an-object-method-2 |  |  |  |
-| 166 | call-an-object-method-3 |  |  |  |
-| 167 | call-an-object-method |  |  |  |
-| 168 | camel-case-and-snake-case |  |  |  |
-| 169 | canny-edge-detector |  |  |  |
-| 170 | canonicalize-cidr |  |  |  |
-| 171 | cantor-set |  |  |  |
-| 172 | carmichael-3-strong-pseudoprimes |  |  |  |
-| 173 | cartesian-product-of-two-or-more-lists-1 |  |  |  |
-| 174 | cartesian-product-of-two-or-more-lists-2 |  |  |  |
-| 175 | cartesian-product-of-two-or-more-lists-3 |  |  |  |
-| 176 | cartesian-product-of-two-or-more-lists-4 |  |  |  |
-| 177 | case-sensitivity-of-identifiers |  |  |  |
-| 178 | casting-out-nines |  |  |  |
-| 179 | catalan-numbers-1 |  |  |  |
-| 180 | catalan-numbers-2 |  |  |  |
-| 181 | catalan-numbers-pascals-triangle |  |  |  |
-| 182 | catamorphism |  |  |  |
-| 183 | catmull-clark-subdivision-surface |  |  |  |
-| 184 | chaocipher |  |  |  |
-| 185 | chaos-game |  |  |  |
-| 186 | character-codes-1 |  |  |  |
-| 187 | character-codes-2 |  |  |  |
-| 188 | character-codes-3 |  |  |  |
-| 189 | character-codes-4 |  |  |  |
-| 190 | character-codes-5 |  |  |  |
-| 191 | chat-server |  |  |  |
-| 192 | check-machin-like-formulas |  |  |  |
-| 193 | check-that-file-exists |  |  |  |
-| 194 | checkpoint-synchronization-1 |  |  |  |
-| 195 | checkpoint-synchronization-2 |  |  |  |
-| 196 | checkpoint-synchronization-3 |  |  |  |
-| 197 | checkpoint-synchronization-4 |  |  |  |
-| 198 | chernicks-carmichael-numbers |  |  |  |
-| 199 | cheryls-birthday |  |  |  |
-| 200 | chinese-remainder-theorem | ✓ | 8.12ms | 134.1 KB |
-| 201 | chinese-zodiac | ✓ | 10.60ms | 124.1 KB |
-| 202 | cholesky-decomposition-1 |  |  |  |
-| 203 | cholesky-decomposition |  |  |  |
-| 204 | chowla-numbers |  |  |  |
-| 205 | church-numerals-1 |  |  |  |
-| 206 | church-numerals-2 |  |  |  |
-| 207 | circles-of-given-radius-through-two-points |  |  |  |
-| 208 | circular-primes |  |  |  |
-| 209 | cistercian-numerals |  |  |  |
-| 210 | comma-quibbling |  |  |  |
-| 211 | compiler-virtual-machine-interpreter |  |  |  |
-| 212 | composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k |  |  |  |
-| 213 | compound-data-type |  |  |  |
-| 214 | concurrent-computing-1 |  |  |  |
-| 215 | concurrent-computing-2 |  |  |  |
-| 216 | concurrent-computing-3 |  |  |  |
-| 217 | conditional-structures-1 |  |  |  |
-| 218 | conditional-structures-10 |  |  |  |
-| 219 | conditional-structures-2 |  |  |  |
-| 220 | conditional-structures-3 |  |  |  |
-| 221 | conditional-structures-4 |  |  |  |
-| 222 | conditional-structures-5 |  |  |  |
-| 223 | conditional-structures-6 |  |  |  |
-| 224 | conditional-structures-7 |  |  |  |
-| 225 | conditional-structures-8 |  |  |  |
-| 226 | conditional-structures-9 |  |  |  |
-| 227 | consecutive-primes-with-ascending-or-descending-differences |  |  |  |
-| 228 | constrained-genericity-1 |  |  |  |
-| 229 | constrained-genericity-2 |  |  |  |
-| 230 | constrained-genericity-3 |  |  |  |
-| 231 | constrained-genericity-4 |  |  |  |
-| 232 | constrained-random-points-on-a-circle-1 |  |  |  |
-| 233 | constrained-random-points-on-a-circle-2 |  |  |  |
-| 234 | continued-fraction |  |  |  |
-| 235 | convert-decimal-number-to-rational |  |  |  |
-| 236 | convert-seconds-to-compound-duration |  |  |  |
-| 237 | convex-hull |  |  |  |
-| 238 | conways-game-of-life |  |  |  |
-| 239 | copy-a-string-1 |  |  |  |
-| 240 | copy-a-string-2 |  |  |  |
-| 241 | copy-stdin-to-stdout-1 |  |  |  |
-| 242 | copy-stdin-to-stdout-2 |  |  |  |
-| 243 | count-in-factors |  |  |  |
-| 244 | count-in-octal-1 |  |  |  |
-| 245 | count-in-octal-2 |  |  |  |
-| 246 | count-in-octal-3 |  |  |  |
-| 247 | count-in-octal-4 |  |  |  |
-| 248 | count-occurrences-of-a-substring |  |  |  |
-| 249 | count-the-coins-1 |  |  |  |
-| 250 | count-the-coins-2 | ✓ | 38.64ms | 92.5 KB |
-| 251 | cramers-rule | ✓ | 10.09ms | 130.8 KB |
-| 252 | crc-32-1 |  |  |  |
-| 253 | crc-32-2 |  |  |  |
-| 254 | create-a-file-on-magnetic-tape |  |  |  |
-| 255 | create-a-file |  |  |  |
-| 256 | create-a-two-dimensional-array-at-runtime-1 |  |  |  |
-| 257 | create-an-html-table |  |  |  |
-| 258 | create-an-object-at-a-given-address |  |  |  |
-| 259 | csv-data-manipulation |  |  |  |
-| 260 | csv-to-html-translation-1 |  |  |  |
-| 261 | csv-to-html-translation-2 |  |  |  |
-| 262 | csv-to-html-translation-3 |  |  |  |
-| 263 | csv-to-html-translation-4 |  |  |  |
-| 264 | csv-to-html-translation-5 |  |  |  |
-| 265 | cuban-primes |  |  |  |
-| 266 | cullen-and-woodall-numbers |  |  |  |
-| 267 | cumulative-standard-deviation |  |  |  |
-| 268 | currency |  |  |  |
-| 269 | currying |  |  |  |
-| 270 | curzon-numbers |  |  |  |
-| 271 | cusip |  |  |  |
-| 272 | cyclops-numbers |  |  |  |
-| 273 | damm-algorithm |  |  |  |
-| 274 | date-format |  |  |  |
-| 275 | date-manipulation |  |  |  |
-| 276 | day-of-the-week |  |  |  |
-| 277 | de-bruijn-sequences |  |  |  |
-| 278 | deal-cards-for-freecell |  |  |  |
-| 279 | death-star |  |  |  |
-| 280 | deceptive-numbers |  |  |  |
-| 281 | deconvolution-1d-2 |  |  |  |
-| 282 | deconvolution-1d-3 |  |  |  |
-| 283 | deconvolution-1d |  |  |  |
-| 284 | deepcopy-1 |  |  |  |
-| 285 | define-a-primitive-data-type |  |  |  |
-| 286 | delegates |  |  |  |
-| 287 | demings-funnel |  |  |  |
-| 288 | department-numbers |  |  |  |
-| 289 | descending-primes |  |  |  |
-| 290 | detect-division-by-zero |  |  |  |
-| 291 | determine-if-a-string-has-all-the-same-characters |  |  |  |
-| 292 | determine-if-a-string-has-all-unique-characters |  |  |  |
-| 293 | determine-if-a-string-is-collapsible |  |  |  |
-| 294 | determine-if-a-string-is-numeric-1 |  |  |  |
-| 295 | determine-if-a-string-is-numeric-2 |  |  |  |
-| 296 | determine-if-a-string-is-squeezable |  |  |  |
-| 297 | determine-if-only-one-instance-is-running |  |  |  |
-| 298 | determine-if-two-triangles-overlap |  |  |  |
-| 299 | determine-sentence-type |  |  |  |
-| 300 | dice-game-probabilities-1 | ✓ | 25.89ms | 33.1 KB |
-| 301 | dice-game-probabilities-2 | ✓ | 12.89ms | 124.1 KB |
-| 302 | digital-root-multiplicative-digital-root | ✓ | 51.76ms | 829.9 KB |
-| 303 | dijkstras-algorithm |  |  |  |
-| 304 | dinesmans-multiple-dwelling-problem | ✓ | 8.30ms | 133.8 KB |
-| 305 | dining-philosophers-1 | ✓ | 13.78ms | 123.1 KB |
-| 306 | dining-philosophers-2 | ✓ | 12.41ms | 123.1 KB |
-| 307 | disarium-numbers | ✓ | 976.28ms | 828.0 KB |
-| 308 | discordian-date | ✓ | 5.90ms | 124.4 KB |
-| 309 | display-a-linear-combination | ✓ | 10.62ms | 123.2 KB |
-| 310 | display-an-outline-as-a-nested-table |  |  |  |
-| 311 | distance-and-bearing |  |  |  |
-| 312 | distributed-programming |  |  |  |
-| 313 | diversity-prediction-theorem | ✓ | 17.96ms | 115.4 KB |
-| 314 | documentation | ✓ | 3.23ms | 134.6 KB |
-| 315 | doomsday-rule | ✓ | 9.22ms | 121.0 KB |
-| 316 | dot-product | ✓ | 15.22ms | 123.8 KB |
-| 317 | doubly-linked-list-definition-1 | ✓ | 3.30ms | 134.6 KB |
-| 318 | doubly-linked-list-definition-2 |  |  |  |
-| 319 | doubly-linked-list-element-definition |  |  |  |
-| 320 | doubly-linked-list-traversal |  |  |  |
-| 321 | dragon-curve | ✓ | 15.97ms | 121.9 KB |
-| 322 | draw-a-clock | ✓ | 4.00ms | 162.8 KB |
-| 323 | draw-a-cuboid | ✓ | 11.28ms | 121.1 KB |
-| 324 | draw-a-pixel-1 | ✓ | 89.65ms | 1.3 MB |
-| 325 | draw-a-rotating-cube |  |  |  |
-| 326 | draw-a-sphere | ✓ | 21.77ms | 142.6 KB |
-| 327 | dutch-national-flag-problem | ✓ | 20.25ms | 115.5 KB |
-| 328 | dynamic-variable-names |  |  |  |
-| 329 | earliest-difference-between-prime-gaps |  |  |  |
-| 330 | eban-numbers |  |  |  |
-| 331 | ecdsa-example |  |  |  |
-| 332 | echo-server | ✓ | 9.78ms | 123.6 KB |
-| 333 | eertree |  |  |  |
-| 334 | egyptian-division |  |  |  |
-| 335 | ekg-sequence-convergence | ✓ | 23.01ms | 113.1 KB |
-| 336 | element-wise-operations |  |  |  |
-| 337 | elementary-cellular-automaton-infinite-length | ✓ | 16.52ms | 114.3 KB |
-| 338 | elementary-cellular-automaton-random-number-generator |  |  |  |
-| 339 | elementary-cellular-automaton | ✓ | 7.52ms | 130.2 KB |
-| 340 | elliptic-curve-arithmetic | ✓ | 5.91ms | 120.2 KB |
-| 341 | elliptic-curve-digital-signature-algorithm | ✓ | 4.42ms | 133.4 KB |
-| 342 | emirp-primes | ✓ | 209.14ms | 818.5 KB |
-| 343 | empty-directory |  |  |  |
-| 344 | empty-program | ✓ | 3.33ms | 134.6 KB |
-| 345 | empty-string-1 |  |  |  |
-| 346 | empty-string-2 | ✓ | 4.96ms | 130.6 KB |
-| 347 | enforced-immutability | ✓ | 3.58ms | 134.2 KB |
-| 348 | entropy-1 |  |  |  |
-| 349 | entropy-2 |  |  |  |
-| 350 | entropy-narcissist |  |  |  |
-| 351 | enumerations-1 |  |  |  |
-| 352 | enumerations-2 |  |  |  |
-| 353 | enumerations-3 |  |  |  |
-| 354 | enumerations-4 |  |  |  |
-| 355 | environment-variables-1 |  |  |  |
-| 356 | environment-variables-2 |  |  |  |
-| 357 | equal-prime-and-composite-sums |  |  |  |
-| 358 | equilibrium-index |  |  |  |
-| 359 | erd-s-nicolas-numbers |  |  |  |
-| 360 | erd-s-selfridge-categorization-of-primes |  |  |  |
-| 361 | esthetic-numbers |  |  |  |
-| 362 | ethiopian-multiplication |  |  |  |
-| 363 | euclid-mullin-sequence |  |  |  |
-| 364 | euler-method |  |  |  |
-| 365 | eulers-constant-0.5772... |  |  |  |
-| 366 | eulers-identity |  |  |  |
-| 367 | eulers-sum-of-powers-conjecture |  |  |  |
-| 368 | evaluate-binomial-coefficients |  |  |  |
-| 369 | even-or-odd |  |  |  |
-| 370 | events |  |  |  |
-| 371 | evolutionary-algorithm |  |  |  |
-| 372 | exceptions-catch-an-exception-thrown-in-a-nested-call |  |  |  |
-| 373 | exceptions |  |  |  |
-| 374 | executable-library |  |  |  |
-| 375 | execute-a-markov-algorithm |  |  |  |
-| 376 | execute-a-system-command |  |  |  |
-| 377 | execute-brain- |  |  |  |
-| 378 | execute-computer-zero-1 |  |  |  |
-| 379 | execute-computer-zero |  |  |  |
-| 380 | execute-hq9+ |  |  |  |
-| 381 | execute-snusp |  |  |  |
-| 382 | exponentiation-operator-2 |  |  |  |
-| 383 | exponentiation-operator |  |  |  |
-| 384 | exponentiation-order |  |  |  |
-| 385 | exponentiation-with-infix-operators-in-or-operating-on-the-base |  |  |  |
-| 386 | extend-your-language |  |  |  |
-| 387 | extensible-prime-generator |  |  |  |
-| 388 | extreme-floating-point-values |  |  |  |
-| 389 | faces-from-a-mesh-2 |  |  |  |
-| 390 | faces-from-a-mesh |  |  |  |
-| 391 | factorial-base-numbers-indexing-permutations-of-a-collection |  |  |  |
-| 392 | factorial-primes |  |  |  |
-| 393 | factorial |  |  |  |
-| 394 | factorions |  |  |  |
-| 395 | factors-of-a-mersenne-number |  |  |  |
-| 396 | factors-of-an-integer |  |  |  |
-| 397 | fairshare-between-two-and-more |  |  |  |
-| 398 | farey-sequence |  |  |  |
-| 399 | fast-fourier-transform |  |  |  |
-| 400 | fasta-format |  |  |  |
-| 401 | faulhabers-formula |  |  |  |
-| 402 | faulhabers-triangle |  |  |  |
-| 403 | feigenbaum-constant-calculation |  |  |  |
-| 404 | fermat-numbers |  |  |  |
-| 405 | fibonacci-n-step-number-sequences |  |  |  |
-| 406 | fibonacci-sequence-1 |  |  |  |
-| 407 | fibonacci-sequence-2 |  |  |  |
-| 408 | fibonacci-sequence-3 |  |  |  |
-| 409 | fibonacci-sequence-4 |  |  |  |
-| 410 | fibonacci-sequence-5 |  |  |  |
-| 411 | fibonacci-word-fractal |  |  |  |
-| 412 | fibonacci-word |  |  |  |
-| 413 | file-extension-is-in-extensions-list |  |  |  |
-| 414 | file-input-output-1 |  |  |  |
-| 415 | file-input-output-2 |  |  |  |
-| 416 | file-input-output-3 |  |  |  |
-| 417 | file-modification-time |  |  |  |
-| 418 | file-size-distribution |  |  |  |
-| 419 | file-size |  |  |  |
-| 420 | filter |  |  |  |
-| 421 | find-chess960-starting-position-identifier-2 |  |  |  |
-| 422 | find-chess960-starting-position-identifier |  |  |  |
-| 423 | find-common-directory-path |  |  |  |
-| 424 | find-duplicate-files |  |  |  |
-| 425 | find-if-a-point-is-within-a-triangle |  |  |  |
-| 426 | find-largest-left-truncatable-prime-in-a-given-base |  |  |  |
-| 427 | find-limit-of-recursion |  |  |  |
-| 428 | find-palindromic-numbers-in-both-binary-and-ternary-bases |  |  |  |
-| 429 | find-the-intersection-of-a-line-with-a-plane |  |  |  |
-| 430 | find-the-intersection-of-two-lines |  |  |  |
-| 431 | find-the-last-sunday-of-each-month |  |  |  |
-| 432 | find-the-missing-permutation |  |  |  |
-| 433 | first-class-environments |  |  |  |
-| 434 | first-class-functions-use-numbers-analogously |  |  |  |
-| 435 | first-power-of-2-that-has-leading-decimal-digits-of-12 |  |  |  |
-| 436 | five-weekends |  |  |  |
-| 437 | fivenum-1 |  |  |  |
-| 438 | fivenum-2 |  |  |  |
-| 439 | fivenum-3 |  |  |  |
-| 440 | fixed-length-records-1 |  |  |  |
-| 441 | fixed-length-records-2 |  |  |  |
-| 442 | fizzbuzz-1 |  |  |  |
-| 443 | fizzbuzz-2 |  |  |  |
-| 444 | fizzbuzz |  |  |  |
-| 445 | flatten-a-list-1 |  |  |  |
-| 446 | flatten-a-list-2 |  |  |  |
-| 447 | flipping-bits-game |  |  |  |
-| 448 | flow-control-structures-1 |  |  |  |
-| 449 | flow-control-structures-2 |  |  |  |
-| 450 | flow-control-structures-3 |  |  |  |
-| 451 | flow-control-structures-4 |  |  |  |
-| 452 | floyd-warshall-algorithm |  |  |  |
-| 453 | floyd-warshall-algorithm2 |  |  |  |
-| 454 | floyds-triangle |  |  |  |
-| 455 | forest-fire |  |  |  |
-| 456 | fork-2 |  |  |  |
-| 457 | fork |  |  |  |
-| 458 | formal-power-series |  |  |  |
-| 459 | formatted-numeric-output |  |  |  |
-| 460 | forward-difference |  |  |  |
-| 461 | four-bit-adder-1 |  |  |  |
-| 462 | four-is-magic |  |  |  |
-| 463 | four-is-the-number-of-letters-in-the-... |  |  |  |
-| 464 | fractal-tree |  |  |  |
-| 465 | fractran |  |  |  |
-| 466 | french-republican-calendar |  |  |  |
-| 467 | ftp |  |  |  |
-| 468 | function-frequency |  |  |  |
-| 469 | function-prototype |  |  |  |
-| 470 | functional-coverage-tree |  |  |  |
-| 471 | fusc-sequence |  |  |  |
-| 472 | gamma-function |  |  |  |
-| 473 | general-fizzbuzz |  |  |  |
-| 474 | generic-swap |  |  |  |
-| 475 | get-system-command-output |  |  |  |
-| 476 | giuga-numbers |  |  |  |
-| 477 | globally-replace-text-in-several-files |  |  |  |
-| 478 | goldbachs-comet |  |  |  |
-| 479 | golden-ratio-convergence |  |  |  |
-| 480 | graph-colouring |  |  |  |
-| 481 | gray-code |  |  |  |
-| 482 | gui-component-interaction |  |  |  |
-| 483 | gui-enabling-disabling-of-controls |  |  |  |
-| 484 | gui-maximum-window-dimensions |  |  |  |
-| 485 | http |  |  |  |
-| 486 | image-noise |  |  |  |
-| 487 | loops-increment-loop-index-within-loop-body |  |  |  |
-| 488 | md5 |  |  |  |
-| 489 | nim-game |  |  |  |
-| 490 | plasma-effect |  |  |  |
-| 491 | sorting-algorithms-bubble-sort |  |  |  |
-| 492 | window-management |  |  |  |
-| 493 | zumkeller-numbers |  |  |  |
+| 15 | a+b | ✓ |  | 102.6 KB |
+| 16 | abbreviations-automatic | ✓ | 24.27ms | 131.6 KB |
+| 17 | abbreviations-easy | ✓ |  | 123.0 KB |
+| 18 | abbreviations-simple | ✓ |  | 119.5 KB |
+| 19 | abc-problem | ✓ | 13.57ms | 121.4 KB |
+| 20 | abelian-sandpile-model-identity | ✓ |  | 133.0 KB |
+| 21 | abelian-sandpile-model | ✓ |  | 123.5 KB |
+| 22 | abstract-type | ✓ | 5.54ms | 130.4 KB |
+| 23 | abundant-deficient-and-perfect-number-classifications | ✓ |  | 133.6 KB |
+| 24 | abundant-odd-numbers | ✓ |  | 826.2 KB |
+| 25 | accumulator-factory | ✓ | 12.46ms | 109.0 KB |
+| 26 | achilles-numbers |  |  |  |
+| 27 | ackermann-function-2 | ✓ | 3.06ms | 133.9 KB |
+| 28 | ackermann-function-3 | ✓ |  |  |
+| 29 | ackermann-function | ✓ |  | 133.9 KB |
+| 30 | active-directory-connect | ✓ | 9.17ms | 122.7 KB |
+| 31 | active-directory-search-for-a-user | ✓ |  | 120.8 KB |
+| 32 | active-object | ✓ |  | 124.4 KB |
+| 33 | add-a-variable-to-a-class-instance-at-runtime | ✓ | 14.70ms | 101.4 KB |
+| 34 | additive-primes | ✓ |  | 131.2 KB |
+| 35 | address-of-a-variable | ✓ | 19.16ms | 105.8 KB |
+| 36 | adfgvx-cipher |  |  |  |
+| 37 | aks-test-for-primes | ✓ | 5.39ms | 130.5 KB |
+| 38 | algebraic-data-types | ✓ |  | 121.9 KB |
+| 39 | align-columns |  |  |  |
+| 40 | aliquot-sequence-classifications |  |  |  |
+| 41 | almkvist-giullera-formula-for-pi |  |  |  |
+| 42 | almost-prime | ✓ | 13.54ms | 122.7 KB |
+| 43 | amb | ✓ | 31.89ms | 121.2 KB |
+| 44 | amicable-pairs | ✓ | 1.96s | 821.3 KB |
+| 45 | anagrams-deranged-anagrams | ✓ | 22.78ms | 129.9 KB |
+| 46 | anagrams | ✓ | 25.65ms | 128.6 KB |
+| 47 | angle-difference-between-two-bearings-1 | ✓ | 11.23ms | 131.0 KB |
+| 48 | angle-difference-between-two-bearings-2 | ✓ | 10.72ms | 131.0 KB |
+| 49 | angles-geometric-normalization-and-conversion | ✓ | 26.45ms | 120.1 KB |
+| 50 | animate-a-pendulum | ✓ | 7.51ms | 141.0 KB |
+| 51 | animation | ✓ | 17.19ms | 138.1 KB |
+| 52 | anonymous-recursion-1 | ✓ | 19.00ms | 130.2 KB |
+| 53 | anonymous-recursion-2 | ✓ | 19.31ms | 130.1 KB |
+| 54 | anonymous-recursion | ✓ | 7.40ms | 140.7 KB |
+| 55 | anti-primes | ✓ | 49.29ms | 137.7 KB |
+| 56 | append-a-record-to-the-end-of-a-text-file | ✓ | 22.00ms | 130.3 KB |
+| 57 | apply-a-callback-to-an-array-1 | ✓ | 19.75ms | 130.3 KB |
+| 58 | apply-a-callback-to-an-array-2 | ✓ | 21.43ms | 128.2 KB |
+| 59 | apply-a-digital-filter-direct-form-ii-transposed- | ✓ | 9.07ms | 131.2 KB |
+| 60 | approximate-equality | ✓ | 19.54ms | 119.9 KB |
+| 61 | arbitrary-precision-integers-included- | ✓ | 61.69ms | 823.6 KB |
+| 62 | archimedean-spiral | ✓ | 20.34ms | 130.2 KB |
+| 63 | arena-storage-pool | ✓ | 33.26ms | 127.2 KB |
+| 64 | arithmetic-complex | ✓ | 16.13ms | 126.4 KB |
+| 65 | arithmetic-derivative | ✓ | 35.42ms | 130.4 KB |
+| 66 | arithmetic-evaluation | ✓ | 14.23ms | 137.1 KB |
+| 67 | arithmetic-geometric-mean-calculate-pi | ✓ | 10.88ms | 130.6 KB |
+| 68 | arithmetic-geometric-mean | ✓ | 12.15ms | 130.6 KB |
+| 69 | arithmetic-integer-1 | ✓ | 12.68ms | 140.1 KB |
+| 70 | arithmetic-integer-2 | ✓ | 10.42ms | 140.1 KB |
+| 71 | arithmetic-numbers |  |  |  |
+| 72 | arithmetic-rational |  |  |  |
+| 73 | array-concatenation | ✓ | 5.91ms | 132.0 KB |
+| 74 | array-length | ✓ | 10.63ms | 123.6 KB |
+| 75 | arrays | ✓ | 6.53ms | 131.7 KB |
+| 76 | ascending-primes | ✓ | 13.98ms | 120.7 KB |
+| 77 | ascii-art-diagram-converter | ✓ | 5.01ms | 130.9 KB |
+| 78 | assertions | ✓ | 2.99ms | 134.0 KB |
+| 79 | associative-array-creation |  |  |  |
+| 80 | associative-array-iteration |  |  |  |
+| 81 | associative-array-merging |  |  |  |
+| 82 | atomic-updates | ✓ | 11.17ms | 114.8 KB |
+| 83 | attractive-numbers | ✓ | 5.01ms | 134.0 KB |
+| 84 | average-loop-length | ✓ | 244.04ms | 847.4 KB |
+| 85 | averages-arithmetic-mean | ✓ | 12.80ms | 110.5 KB |
+| 86 | averages-mean-time-of-day | ✓ | 23.52ms | 124.8 KB |
+| 87 | averages-median-1 | ✓ | 10.06ms | 113.8 KB |
+| 88 | averages-median-2 | ✓ |  |  |
+| 89 | averages-median-3 | ✓ |  |  |
+| 90 | averages-mode | ✓ |  |  |
+| 91 | averages-pythagorean-means | ✓ |  |  |
+| 92 | averages-root-mean-square | ✓ |  |  |
+| 93 | averages-simple-moving-average | ✓ |  |  |
+| 94 | avl-tree |  |  |  |
+| 95 | b-zier-curves-intersections | ✓ |  |  |
+| 96 | babbage-problem | ✓ |  |  |
+| 97 | babylonian-spiral | ✓ |  |  |
+| 98 | balanced-brackets | ✓ | 11.75ms | 115.2 KB |
+| 99 | balanced-ternary | ✓ | 13.76ms | 111.5 KB |
+| 100 | barnsley-fern | ✓ | 28.58ms | 44.6 KB |
+| 101 | base64-decode-data | ✓ | 7.03ms | 93.1 KB |
+| 102 | bell-numbers | ✓ | 20.23ms | 109.4 KB |
+| 103 | benfords-law | ✓ | 15.94ms | 65.9 KB |
+| 104 | bernoulli-numbers | ✓ | 88.28ms | 835.6 KB |
+| 105 | best-shuffle |  |  |  |
+| 106 | bifid-cipher |  |  |  |
+| 107 | bin-given-limits |  |  |  |
+| 108 | binary-digits |  |  |  |
+| 109 | binary-search |  |  |  |
+| 110 | binary-strings |  |  |  |
+| 111 | bioinformatics-base-count |  |  |  |
+| 112 | bioinformatics-global-alignment |  |  |  |
+| 113 | bioinformatics-sequence-mutation |  |  |  |
+| 114 | biorhythms |  |  |  |
+| 115 | bitcoin-address-validation |  |  |  |
+| 116 | bitmap-b-zier-curves-cubic |  |  |  |
+| 117 | bitmap-b-zier-curves-quadratic |  |  |  |
+| 118 | bitmap-bresenhams-line-algorithm |  |  |  |
+| 119 | bitmap-flood-fill |  |  |  |
+| 120 | bitmap-histogram |  |  |  |
+| 121 | bitmap-midpoint-circle-algorithm |  |  |  |
+| 122 | bitmap-ppm-conversion-through-a-pipe |  |  |  |
+| 123 | bitmap-read-a-ppm-file |  |  |  |
+| 124 | bitmap-read-an-image-through-a-pipe |  |  |  |
+| 125 | bitmap-write-a-ppm-file |  |  |  |
+| 126 | bitmap |  |  |  |
+| 127 | bitwise-io-1 |  |  |  |
+| 128 | bitwise-io-2 |  |  |  |
+| 129 | bitwise-operations |  |  |  |
+| 130 | blum-integer |  |  |  |
+| 131 | boolean-values |  |  |  |
+| 132 | box-the-compass |  |  |  |
+| 133 | boyer-moore-string-search |  |  |  |
+| 134 | brazilian-numbers |  |  |  |
+| 135 | break-oo-privacy |  |  |  |
+| 136 | brilliant-numbers |  |  |  |
+| 137 | brownian-tree |  |  |  |
+| 138 | bulls-and-cows-player |  |  |  |
+| 139 | bulls-and-cows |  |  |  |
+| 140 | burrows-wheeler-transform |  |  |  |
+| 141 | caesar-cipher-1 |  |  |  |
+| 142 | caesar-cipher-2 |  |  |  |
+| 143 | calculating-the-value-of-e |  |  |  |
+| 144 | calendar---for-real-programmers-1 |  |  |  |
+| 145 | calendar---for-real-programmers-2 |  |  |  |
+| 146 | calendar |  |  |  |
+| 147 | calkin-wilf-sequence |  |  |  |
+| 148 | call-a-foreign-language-function |  |  |  |
+| 149 | call-a-function-1 |  |  |  |
+| 150 | call-a-function-10 |  |  |  |
+| 151 | call-a-function-11 |  |  |  |
+| 152 | call-a-function-12 |  |  |  |
+| 153 | call-a-function-2 |  |  |  |
+| 154 | call-a-function-3 |  |  |  |
+| 155 | call-a-function-4 |  |  |  |
+| 156 | call-a-function-5 |  |  |  |
+| 157 | call-a-function-6 |  |  |  |
+| 158 | call-a-function-7 |  |  |  |
+| 159 | call-a-function-8 |  |  |  |
+| 160 | call-a-function-9 |  |  |  |
+| 161 | call-an-object-method-1 |  |  |  |
+| 162 | call-an-object-method-2 |  |  |  |
+| 163 | call-an-object-method-3 |  |  |  |
+| 164 | call-an-object-method |  |  |  |
+| 165 | camel-case-and-snake-case |  |  |  |
+| 166 | canny-edge-detector |  |  |  |
+| 167 | canonicalize-cidr |  |  |  |
+| 168 | cantor-set |  |  |  |
+| 169 | carmichael-3-strong-pseudoprimes |  |  |  |
+| 170 | cartesian-product-of-two-or-more-lists-1 |  |  |  |
+| 171 | cartesian-product-of-two-or-more-lists-2 |  |  |  |
+| 172 | cartesian-product-of-two-or-more-lists-3 |  |  |  |
+| 173 | cartesian-product-of-two-or-more-lists-4 |  |  |  |
+| 174 | case-sensitivity-of-identifiers |  |  |  |
+| 175 | casting-out-nines |  |  |  |
+| 176 | catalan-numbers-1 |  |  |  |
+| 177 | catalan-numbers-2 |  |  |  |
+| 178 | catalan-numbers-pascals-triangle |  |  |  |
+| 179 | catamorphism |  |  |  |
+| 180 | catmull-clark-subdivision-surface |  |  |  |
+| 181 | chaocipher |  |  |  |
+| 182 | chaos-game |  |  |  |
+| 183 | character-codes-1 |  |  |  |
+| 184 | character-codes-2 |  |  |  |
+| 185 | character-codes-3 |  |  |  |
+| 186 | character-codes-4 |  |  |  |
+| 187 | character-codes-5 |  |  |  |
+| 188 | chat-server |  |  |  |
+| 189 | check-machin-like-formulas |  |  |  |
+| 190 | check-that-file-exists |  |  |  |
+| 191 | checkpoint-synchronization-1 |  |  |  |
+| 192 | checkpoint-synchronization-2 |  |  |  |
+| 193 | checkpoint-synchronization-3 |  |  |  |
+| 194 | checkpoint-synchronization-4 |  |  |  |
+| 195 | chernicks-carmichael-numbers |  |  |  |
+| 196 | cheryls-birthday |  |  |  |
+| 197 | chinese-remainder-theorem | ✓ | 8.12ms | 134.1 KB |
+| 198 | chinese-zodiac | ✓ | 10.60ms | 124.1 KB |
+| 199 | cholesky-decomposition-1 |  |  |  |
+| 200 | cholesky-decomposition |  |  |  |
+| 201 | chowla-numbers |  |  |  |
+| 202 | church-numerals-1 |  |  |  |
+| 203 | church-numerals-2 |  |  |  |
+| 204 | circles-of-given-radius-through-two-points |  |  |  |
+| 205 | circular-primes |  |  |  |
+| 206 | cistercian-numerals |  |  |  |
+| 207 | comma-quibbling |  |  |  |
+| 208 | compiler-virtual-machine-interpreter |  |  |  |
+| 209 | composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k |  |  |  |
+| 210 | compound-data-type |  |  |  |
+| 211 | concurrent-computing-1 |  |  |  |
+| 212 | concurrent-computing-2 |  |  |  |
+| 213 | concurrent-computing-3 |  |  |  |
+| 214 | conditional-structures-1 |  |  |  |
+| 215 | conditional-structures-10 |  |  |  |
+| 216 | conditional-structures-2 |  |  |  |
+| 217 | conditional-structures-3 |  |  |  |
+| 218 | conditional-structures-4 |  |  |  |
+| 219 | conditional-structures-5 |  |  |  |
+| 220 | conditional-structures-6 |  |  |  |
+| 221 | conditional-structures-7 |  |  |  |
+| 222 | conditional-structures-8 |  |  |  |
+| 223 | conditional-structures-9 |  |  |  |
+| 224 | consecutive-primes-with-ascending-or-descending-differences |  |  |  |
+| 225 | constrained-genericity-1 |  |  |  |
+| 226 | constrained-genericity-2 |  |  |  |
+| 227 | constrained-genericity-3 |  |  |  |
+| 228 | constrained-genericity-4 |  |  |  |
+| 229 | constrained-random-points-on-a-circle-1 |  |  |  |
+| 230 | constrained-random-points-on-a-circle-2 |  |  |  |
+| 231 | continued-fraction |  |  |  |
+| 232 | convert-decimal-number-to-rational |  |  |  |
+| 233 | convert-seconds-to-compound-duration |  |  |  |
+| 234 | convex-hull |  |  |  |
+| 235 | conways-game-of-life |  |  |  |
+| 236 | copy-a-string-1 |  |  |  |
+| 237 | copy-a-string-2 |  |  |  |
+| 238 | copy-stdin-to-stdout-1 |  |  |  |
+| 239 | copy-stdin-to-stdout-2 |  |  |  |
+| 240 | count-in-factors |  |  |  |
+| 241 | count-in-octal-1 |  |  |  |
+| 242 | count-in-octal-2 |  |  |  |
+| 243 | count-in-octal-3 |  |  |  |
+| 244 | count-in-octal-4 |  |  |  |
+| 245 | count-occurrences-of-a-substring |  |  |  |
+| 246 | count-the-coins-1 |  |  |  |
+| 247 | count-the-coins-2 | ✓ | 38.64ms | 92.5 KB |
+| 248 | cramers-rule | ✓ | 10.09ms | 130.8 KB |
+| 249 | crc-32-1 |  |  |  |
+| 250 | crc-32-2 |  |  |  |
+| 251 | create-a-file-on-magnetic-tape |  |  |  |
+| 252 | create-a-file |  |  |  |
+| 253 | create-a-two-dimensional-array-at-runtime-1 |  |  |  |
+| 254 | create-an-html-table |  |  |  |
+| 255 | create-an-object-at-a-given-address |  |  |  |
+| 256 | csv-data-manipulation |  |  |  |
+| 257 | csv-to-html-translation-1 |  |  |  |
+| 258 | csv-to-html-translation-2 |  |  |  |
+| 259 | csv-to-html-translation-3 |  |  |  |
+| 260 | csv-to-html-translation-4 |  |  |  |
+| 261 | csv-to-html-translation-5 |  |  |  |
+| 262 | cuban-primes |  |  |  |
+| 263 | cullen-and-woodall-numbers |  |  |  |
+| 264 | cumulative-standard-deviation |  |  |  |
+| 265 | currency |  |  |  |
+| 266 | currying |  |  |  |
+| 267 | curzon-numbers |  |  |  |
+| 268 | cusip |  |  |  |
+| 269 | cyclops-numbers |  |  |  |
+| 270 | damm-algorithm |  |  |  |
+| 271 | date-format |  |  |  |
+| 272 | date-manipulation |  |  |  |
+| 273 | day-of-the-week |  |  |  |
+| 274 | de-bruijn-sequences |  |  |  |
+| 275 | deal-cards-for-freecell |  |  |  |
+| 276 | death-star |  |  |  |
+| 277 | deceptive-numbers |  |  |  |
+| 278 | deconvolution-1d-2 |  |  |  |
+| 279 | deconvolution-1d-3 |  |  |  |
+| 280 | deconvolution-1d |  |  |  |
+| 281 | deepcopy-1 |  |  |  |
+| 282 | define-a-primitive-data-type |  |  |  |
+| 283 | delegates |  |  |  |
+| 284 | demings-funnel |  |  |  |
+| 285 | department-numbers |  |  |  |
+| 286 | descending-primes |  |  |  |
+| 287 | detect-division-by-zero |  |  |  |
+| 288 | determine-if-a-string-has-all-the-same-characters |  |  |  |
+| 289 | determine-if-a-string-has-all-unique-characters |  |  |  |
+| 290 | determine-if-a-string-is-collapsible |  |  |  |
+| 291 | determine-if-a-string-is-numeric-1 |  |  |  |
+| 292 | determine-if-a-string-is-numeric-2 |  |  |  |
+| 293 | determine-if-a-string-is-squeezable |  |  |  |
+| 294 | determine-if-only-one-instance-is-running |  |  |  |
+| 295 | determine-if-two-triangles-overlap |  |  |  |
+| 296 | determine-sentence-type |  |  |  |
+| 297 | dice-game-probabilities-1 | ✓ | 25.89ms | 33.1 KB |
+| 298 | dice-game-probabilities-2 | ✓ | 12.89ms | 124.1 KB |
+| 299 | digital-root-multiplicative-digital-root | ✓ | 51.76ms | 829.9 KB |
+| 300 | dijkstras-algorithm |  |  |  |
+| 301 | dinesmans-multiple-dwelling-problem | ✓ | 8.30ms | 133.8 KB |
+| 302 | dining-philosophers-1 | ✓ | 13.78ms | 123.1 KB |
+| 303 | dining-philosophers-2 | ✓ | 12.41ms | 123.1 KB |
+| 304 | disarium-numbers | ✓ | 976.28ms | 828.0 KB |
+| 305 | discordian-date | ✓ | 5.90ms | 124.4 KB |
+| 306 | display-a-linear-combination | ✓ | 10.62ms | 123.2 KB |
+| 307 | display-an-outline-as-a-nested-table |  |  |  |
+| 308 | distance-and-bearing |  |  |  |
+| 309 | distributed-programming |  |  |  |
+| 310 | diversity-prediction-theorem | ✓ | 17.96ms | 115.4 KB |
+| 311 | dns-query |  |  |  |
+| 312 | documentation | ✓ | 3.23ms | 134.6 KB |
+| 313 | doomsday-rule | ✓ | 9.22ms | 121.0 KB |
+| 314 | dot-product | ✓ | 15.22ms | 123.8 KB |
+| 315 | doubly-linked-list-definition-1 | ✓ | 3.30ms | 134.6 KB |
+| 316 | doubly-linked-list-definition-2 |  |  |  |
+| 317 | doubly-linked-list-element-definition |  |  |  |
+| 318 | doubly-linked-list-traversal |  |  |  |
+| 319 | dragon-curve | ✓ | 15.97ms | 121.9 KB |
+| 320 | draw-a-clock | ✓ | 4.00ms | 162.8 KB |
+| 321 | draw-a-cuboid | ✓ | 11.28ms | 121.1 KB |
+| 322 | draw-a-pixel-1 | ✓ | 89.65ms | 1.3 MB |
+| 323 | draw-a-rotating-cube |  |  |  |
+| 324 | draw-a-sphere | ✓ | 21.77ms | 142.6 KB |
+| 325 | duffinian-numbers |  |  |  |
+| 326 | dutch-national-flag-problem | ✓ | 20.25ms | 115.5 KB |
+| 327 | dynamic-variable-names |  |  |  |
+| 328 | earliest-difference-between-prime-gaps |  |  |  |
+| 329 | eban-numbers |  |  |  |
+| 330 | ecdsa-example |  |  |  |
+| 331 | echo-server | ✓ | 9.78ms | 123.6 KB |
+| 332 | eertree |  |  |  |
+| 333 | egyptian-division |  |  |  |
+| 334 | ekg-sequence-convergence | ✓ | 23.01ms | 113.1 KB |
+| 335 | element-wise-operations |  |  |  |
+| 336 | elementary-cellular-automaton-infinite-length | ✓ | 16.52ms | 114.3 KB |
+| 337 | elementary-cellular-automaton-random-number-generator |  |  |  |
+| 338 | elementary-cellular-automaton | ✓ | 7.52ms | 130.2 KB |
+| 339 | elliptic-curve-arithmetic | ✓ | 5.91ms | 120.2 KB |
+| 340 | elliptic-curve-digital-signature-algorithm | ✓ | 4.42ms | 133.4 KB |
+| 341 | emirp-primes | ✓ | 209.14ms | 818.5 KB |
+| 342 | empty-directory |  |  |  |
+| 343 | empty-program | ✓ | 3.33ms | 134.6 KB |
+| 344 | empty-string-1 |  |  |  |
+| 345 | empty-string-2 | ✓ | 4.96ms | 130.6 KB |
+| 346 | enforced-immutability | ✓ | 3.58ms | 134.2 KB |
+| 347 | entropy-1 |  |  |  |
+| 348 | entropy-2 |  |  |  |
+| 349 | entropy-narcissist |  |  |  |
+| 350 | enumerations-1 | ✓ | 4.67ms | 141.5 KB |
+| 351 | enumerations-2 | ✓ | 5.02ms | 141.5 KB |
+| 352 | enumerations-3 | ✓ | 5.22ms | 141.5 KB |
+| 353 | enumerations-4 | ✓ | 5.25ms | 141.5 KB |
+| 354 | environment-variables-1 |  |  |  |
+| 355 | environment-variables-2 |  |  |  |
+| 356 | equal-prime-and-composite-sums |  |  |  |
+| 357 | equilibrium-index |  |  |  |
+| 358 | erd-s-nicolas-numbers |  |  |  |
+| 359 | erd-s-selfridge-categorization-of-primes |  |  |  |
+| 360 | esthetic-numbers |  |  |  |
+| 361 | ethiopian-multiplication |  |  |  |
+| 362 | euclid-mullin-sequence |  |  |  |
+| 363 | euler-method |  |  |  |
+| 364 | eulers-constant-0.5772... |  |  |  |
+| 365 | eulers-identity |  |  |  |
+| 366 | eulers-sum-of-powers-conjecture |  |  |  |
+| 367 | evaluate-binomial-coefficients |  |  |  |
+| 368 | even-or-odd |  |  |  |
+| 369 | events |  |  |  |
+| 370 | evolutionary-algorithm |  |  |  |
+| 371 | exceptions-catch-an-exception-thrown-in-a-nested-call |  |  |  |
+| 372 | exceptions |  |  |  |
+| 373 | executable-library |  |  |  |
+| 374 | execute-a-markov-algorithm |  |  |  |
+| 375 | execute-a-system-command |  |  |  |
+| 376 | execute-brain- |  |  |  |
+| 377 | execute-computer-zero-1 |  |  |  |
+| 378 | execute-computer-zero |  |  |  |
+| 379 | execute-hq9+ |  |  |  |
+| 380 | execute-snusp |  |  |  |
+| 381 | exponentiation-operator-2 |  |  |  |
+| 382 | exponentiation-operator |  |  |  |
+| 383 | exponentiation-order |  |  |  |
+| 384 | exponentiation-with-infix-operators-in-or-operating-on-the-base |  |  |  |
+| 385 | extend-your-language |  |  |  |
+| 386 | extensible-prime-generator |  |  |  |
+| 387 | extreme-floating-point-values |  |  |  |
+| 388 | faces-from-a-mesh-2 |  |  |  |
+| 389 | faces-from-a-mesh |  |  |  |
+| 390 | factorial-base-numbers-indexing-permutations-of-a-collection |  |  |  |
+| 391 | factorial-primes |  |  |  |
+| 392 | factorial |  |  |  |
+| 393 | factorions |  |  |  |
+| 394 | factors-of-a-mersenne-number |  |  |  |
+| 395 | factors-of-an-integer |  |  |  |
+| 396 | fairshare-between-two-and-more |  |  |  |
+| 397 | farey-sequence |  |  |  |
+| 398 | fast-fourier-transform |  |  |  |
+| 399 | fasta-format |  |  |  |
+| 400 | faulhabers-formula |  |  |  |
+| 401 | faulhabers-triangle |  |  |  |
+| 402 | feigenbaum-constant-calculation |  |  |  |
+| 403 | fermat-numbers |  |  |  |
+| 404 | fibonacci-n-step-number-sequences |  |  |  |
+| 405 | fibonacci-sequence-1 |  |  |  |
+| 406 | fibonacci-sequence-2 |  |  |  |
+| 407 | fibonacci-sequence-3 |  |  |  |
+| 408 | fibonacci-sequence-4 |  |  |  |
+| 409 | fibonacci-sequence-5 |  |  |  |
+| 410 | fibonacci-word-fractal |  |  |  |
+| 411 | fibonacci-word |  |  |  |
+| 412 | file-extension-is-in-extensions-list |  |  |  |
+| 413 | file-input-output-1 |  |  |  |
+| 414 | file-input-output-2 |  |  |  |
+| 415 | file-input-output-3 |  |  |  |
+| 416 | file-modification-time |  |  |  |
+| 417 | file-size-distribution |  |  |  |
+| 418 | file-size |  |  |  |
+| 419 | filter |  |  |  |
+| 420 | find-chess960-starting-position-identifier-2 |  |  |  |
+| 421 | find-chess960-starting-position-identifier |  |  |  |
+| 422 | find-common-directory-path |  |  |  |
+| 423 | find-duplicate-files |  |  |  |
+| 424 | find-largest-left-truncatable-prime-in-a-given-base |  |  |  |
+| 425 | find-limit-of-recursion |  |  |  |
+| 426 | find-palindromic-numbers-in-both-binary-and-ternary-bases |  |  |  |
+| 427 | find-the-intersection-of-a-line-with-a-plane |  |  |  |
+| 428 | find-the-intersection-of-two-lines |  |  |  |
+| 429 | find-the-last-sunday-of-each-month |  |  |  |
+| 430 | find-the-missing-permutation |  |  |  |
+| 431 | first-class-environments |  |  |  |
+| 432 | first-class-functions-use-numbers-analogously |  |  |  |
+| 433 | first-power-of-2-that-has-leading-decimal-digits-of-12 |  |  |  |
+| 434 | five-weekends |  |  |  |
+| 435 | fivenum-1 |  |  |  |
+| 436 | fivenum-2 |  |  |  |
+| 437 | fivenum-3 |  |  |  |
+| 438 | fixed-length-records-1 |  |  |  |
+| 439 | fixed-length-records-2 |  |  |  |
+| 440 | fizzbuzz-1 |  |  |  |
+| 441 | fizzbuzz-2 |  |  |  |
+| 442 | fizzbuzz |  |  |  |
+| 443 | flatten-a-list-1 |  |  |  |
+| 444 | flatten-a-list-2 |  |  |  |
+| 445 | flipping-bits-game |  |  |  |
+| 446 | flow-control-structures-1 |  |  |  |
+| 447 | flow-control-structures-2 |  |  |  |
+| 448 | flow-control-structures-3 |  |  |  |
+| 449 | flow-control-structures-4 |  |  |  |
+| 450 | floyd-warshall-algorithm |  |  |  |
+| 451 | floyd-warshall-algorithm2 |  |  |  |
+| 452 | floyds-triangle |  |  |  |
+| 453 | forest-fire |  |  |  |
+| 454 | fork-2 |  |  |  |
+| 455 | fork |  |  |  |
+| 456 | formal-power-series |  |  |  |
+| 457 | formatted-numeric-output |  |  |  |
+| 458 | forward-difference |  |  |  |
+| 459 | four-bit-adder-1 |  |  |  |
+| 460 | four-is-magic |  |  |  |
+| 461 | four-is-the-number-of-letters-in-the-... |  |  |  |
+| 462 | fractal-tree |  |  |  |
+| 463 | fractran |  |  |  |
+| 464 | french-republican-calendar |  |  |  |
+| 465 | ftp |  |  |  |
+| 466 | function-frequency |  |  |  |
+| 467 | function-prototype |  |  |  |
+| 468 | functional-coverage-tree |  |  |  |
+| 469 | fusc-sequence |  |  |  |
+| 470 | gamma-function |  |  |  |
+| 471 | general-fizzbuzz |  |  |  |
+| 472 | generic-swap |  |  |  |
+| 473 | get-system-command-output |  |  |  |
+| 474 | giuga-numbers |  |  |  |
+| 475 | globally-replace-text-in-several-files |  |  |  |
+| 476 | goldbachs-comet |  |  |  |
+| 477 | golden-ratio-convergence |  |  |  |
+| 478 | graph-colouring |  |  |  |
+| 479 | gray-code |  |  |  |
+| 480 | gui-component-interaction |  |  |  |
+| 481 | gui-enabling-disabling-of-controls |  |  |  |
+| 482 | gui-maximum-window-dimensions |  |  |  |
+| 483 | http |  |  |  |
+| 484 | image-noise |  |  |  |
+| 485 | loops-increment-loop-index-within-loop-body |  |  |  |
+| 486 | md5 |  |  |  |
+| 487 | nim-game |  |  |  |
+| 488 | plasma-effect |  |  |  |
+| 489 | sorting-algorithms-bubble-sort |  |  |  |
+| 490 | window-management |  |  |  |
+| 491 | zumkeller-numbers |  |  |  |

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,33 @@
+## VM Golden Progress (2025-07-31 00:20 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-31 00:20 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-31 00:20 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-31 00:20 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-31 00:20 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-31 00:20 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-31 00:20 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-31 00:20 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-31 00:20 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-31 00:20 +0700)
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-28 11:42 +0700)
 - Regenerated Kotlin golden files and README
 


### PR DESCRIPTION
## Summary
- transpiler/kt: handle simple type alias declarations
- regenerate Kotlin code for Rosetta programs 350-353 with benchmark data
- update Kotlin transpiler docs and progress

## Testing
- `ROSETTA_INDEX=352 MOCHI_BENCHMARK=true go test -tags slow ./transpiler/x/kt -run RosettaKotlin -count=1`
- `for i in $(seq 353 360); do ...` (fails at 354)


------
https://chatgpt.com/codex/tasks/task_e_688a54abc0888320ba738d5921e98bbc