### PR TITLE
Attempt Pascal map loop support

### DIFF
--- a/tests/rosetta/transpiler/Pascal/associative-array-creation.error
+++ b/tests/rosetta/transpiler/Pascal/associative-array-creation.error
@@ -1,0 +1,17 @@
+Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
+Copyright (c) 1993-2021 by Florian Klaempfl and others
+Target OS: Linux for x86-64
+Compiling /workspace/mochi/tests/rosetta/transpiler/Pascal/associative-array-creation.pas
+fgl.pp(1668,8) Note: Call to subroutine "function TFPGMap<System.ShortString,System.LongInt>.IndexOf(const AKey:ShortString):LongInt;" marked as inline is not inlined
+fgl.pp(1668,8) Note: Call to subroutine "function TFPGMap<System.ShortString,System.Variant>.IndexOf(const AKey:ShortString):LongInt;" marked as inline is not inlined
+associative-array-creation.pas(47,3) Note: Call to subroutine "procedure TFPGMap<System.ShortString,System.LongInt>.AddOrSetData(const AKey:ShortString;const AData:LongInt);" marked as inline is not inlined
+associative-array-creation.pas(48,3) Note: Call to subroutine "procedure TFPGMap<System.ShortString,System.LongInt>.AddOrSetData(const AKey:ShortString;const AData:LongInt);" marked as inline is not inlined
+associative-array-creation.pas(49,3) Note: Call to subroutine "procedure TFPGMap<System.ShortString,System.LongInt>.AddOrSetData(const AKey:ShortString;const AData:LongInt);" marked as inline is not inlined
+associative-array-creation.pas(61,6) Error: Incompatible types: got "LongInt" expected "ShortString"
+associative-array-creation.pas(62,60) Error: Incompatible type for arg no. 1: Got "LongInt", expected "ShortString"
+associative-array-creation.pas(60,24) Error: Cannot find an enumerator for the type "TFPGMap$2$crcD929FFD2"
+associative-array-creation.pas(65,8) Warning: Local variable "removeKey_out" does not seem to be initialized
+associative-array-creation.pas(74,13) Error: Incompatible types: got "TFPGMap<System.ShortString,System.Variant>" expected "TFPGMap<System.ShortString,System.LongInt>"
+associative-array-creation.pas(98) Fatal: There were 4 errors compiling module, stopping
+Fatal: Compilation aborted
+Error: /usr/bin/ppcx64 returned an error exitcode

--- a/tests/rosetta/transpiler/Pascal/associative-array-creation.pas
+++ b/tests/rosetta/transpiler/Pascal/associative-array-creation.pas
@@ -1,0 +1,97 @@
+{$mode objfpc}
+program Main;
+uses SysUtils, fgl;
+var _nowSeed: int64 = 0;
+var _nowSeeded: boolean = false;
+procedure init_now();
+var s: string; v: int64;
+begin
+  s := GetEnvironmentVariable('MOCHI_NOW_SEED');
+  if s <> '' then begin
+    Val(s, v);
+    _nowSeed := v;
+    _nowSeeded := true;
+  end;
+end;
+function _now(): integer;
+begin
+  if _nowSeeded then begin
+    _nowSeed := (_nowSeed * 1664525 + 1013904223) mod 2147483647;
+    _now := _nowSeed;
+  end else begin
+    _now := Integer(GetTickCount64()*1000);
+  end;
+end;
+function _bench_now(): int64;
+begin
+  _bench_now := GetTickCount64()*1000;
+end;
+function _mem(): int64;
+var h: TFPCHeapStatus;
+begin
+  h := GetFPCHeapStatus;
+  _mem := h.CurrHeapUsed;
+end;
+var
+  bench_start_0: integer;
+  bench_dur_0: integer;
+  bench_mem_0: int64;
+  bench_memdiff_0: int64;
+function Map2(): specialize TFPGMap<string, integer>; forward;
+function Map1(): specialize TFPGMap<string, Variant>; forward;
+function removeKey(m: specialize TFPGMap<string, integer>; k: string): specialize TFPGMap<string, integer>; forward;
+procedure main(); forward;
+function Map2(): specialize TFPGMap<string, integer>;
+begin
+  Result := specialize TFPGMap<string, integer>.Create();
+  Result.AddOrSetData('foo', 2);
+  Result.AddOrSetData('bar', 42);
+  Result.AddOrSetData('baz', -1);
+end;
+function Map1(): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+end;
+function removeKey(m: specialize TFPGMap<string, integer>; k: string): specialize TFPGMap<string, integer>;
+var
+  removeKey_out: specialize TFPGMap<string, integer>;
+  removeKey_key: integer;
+begin
+  for removeKey_key in m do begin
+  if removeKey_key <> k then begin
+  removeKey_out.AddOrSetData(removeKey_key, m[removeKey_key]);
+end;
+end;
+  exit(removeKey_out);
+end;
+procedure main();
+var
+  main_x: specialize TFPGMap<string, integer>;
+  main_y1: integer;
+  main_ok: boolean;
+begin
+  main_x := nil;
+  main_x := Map1();
+  main_x.AddOrSetData('foo', 3);
+  main_y1 := main_x['bar'];
+  main_ok := main_x.IndexOf('bar') <> -1;
+  writeln(main_y1);
+  writeln(Ord(main_ok));
+  main_x := removeKey(main_x, 'foo');
+  main_x := Map2();
+  writeln(main_x['foo'], ' ', main_x['bar'], ' ', main_x['baz']);
+end;
+begin
+  init_now();
+  bench_mem_0 := _mem();
+  bench_start_0 := _bench_now();
+  main();
+  Sleep(1);
+  bench_memdiff_0 := _mem() - bench_mem_0;
+  bench_dur_0 := (_bench_now() - bench_start_0) div 1000;
+  writeln('{');
+  writeln(('  "duration_us": ' + IntToStr(bench_dur_0)) + ',');
+  writeln(('  "memory_bytes": ' + IntToStr(bench_memdiff_0)) + ',');
+  writeln(('  "name": "' + 'main') + '"');
+  writeln('}');
+end.


### PR DESCRIPTION
## Summary
- start implementing map iteration support in Pascal transpiler
- regenerate associative-array-creation Pascal output

## Testing
- `ROSETTA_INDEX=79 MOCHI_BENCHMARK=1 go test ./transpiler/x/pas -run Rosetta -tags slow -count=1 -v` *(fails: compile error)*

------
https://chatgpt.com/codex/tasks/task_e_688abd89ee9083208a42011870da2dce