### PR TITLE
Update Mochi aster and add AST example

### DIFF
--- a/aster/x/mochi/inspect.go
+++ b/aster/x/mochi/inspect.go
@@ -7,11 +7,22 @@ import (
 
 // Inspect parses Mochi source code using the official parser and returns a
 // simplified AST representation.
-func Inspect(src string) (*Program, error) {
+// Inspect parses Mochi source code using the official parser and returns a
+// simplified Program. Positional information is omitted unless opts specifies
+// otherwise.
+func Inspect(src string, opts ...Option) (*Program, error) {
+	var withPos bool
+	if len(opts) > 0 {
+		withPos = opts[0].WithPositions
+	}
 	prog, err := parser.ParseString(src)
 	if err != nil {
 		return nil, err
 	}
 	root := ast.FromProgram(prog)
-	return &Program{File: toNode(root)}, nil
+	n := convert(root, withPos)
+	if n == nil {
+		n = &Node{}
+	}
+	return &Program{File: &ProgramNode{Node: *n}}, nil
 }

--- a/tests/aster/x/mochi/two_sum.mochi.json
+++ b/tests/aster/x/mochi/two_sum.mochi.json
@@ -1,0 +1,298 @@
+{
+  "file": {
+    "kind": "program",
+    "children": [
+      {
+        "kind": "fun",
+        "text": "twoSum",
+        "children": [
+          {
+            "kind": "param",
+            "text": "nums",
+            "children": [
+              {
+                "kind": "type",
+                "text": "list",
+                "children": [
+                  {
+                    "kind": "type",
+                    "text": "int"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "param",
+            "text": "target",
+            "children": [
+              {
+                "kind": "type",
+                "text": "int"
+              }
+            ]
+          },
+          {
+            "kind": "type",
+            "text": "list",
+            "children": [
+              {
+                "kind": "type",
+                "text": "int"
+              }
+            ]
+          },
+          {
+            "kind": "let",
+            "text": "n",
+            "children": [
+              {
+                "kind": "call",
+                "text": "len",
+                "children": [
+                  {
+                    "kind": "selector",
+                    "text": "nums"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "for",
+            "text": "i",
+            "children": [
+              {
+                "kind": "range",
+                "children": [
+                  {
+                    "kind": "int",
+                    "text": "0"
+                  },
+                  {
+                    "kind": "selector",
+                    "text": "n"
+                  }
+                ]
+              },
+              {
+                "kind": "block",
+                "children": [
+                  {
+                    "kind": "for",
+                    "text": "j",
+                    "children": [
+                      {
+                        "kind": "range",
+                        "children": [
+                          {
+                            "kind": "binary",
+                            "text": "+",
+                            "children": [
+                              {
+                                "kind": "selector",
+                                "text": "i"
+                              },
+                              {
+                                "kind": "int",
+                                "text": "1"
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "selector",
+                            "text": "n"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "block",
+                        "children": [
+                          {
+                            "kind": "if",
+                            "children": [
+                              {
+                                "kind": "binary",
+                                "text": "==",
+                                "children": [
+                                  {
+                                    "kind": "binary",
+                                    "text": "+",
+                                    "children": [
+                                      {
+                                        "kind": "index",
+                                        "children": [
+                                          {
+                                            "kind": "selector",
+                                            "text": "nums"
+                                          },
+                                          {
+                                            "kind": "selector",
+                                            "text": "i"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "index",
+                                        "children": [
+                                          {
+                                            "kind": "selector",
+                                            "text": "nums"
+                                          },
+                                          {
+                                            "kind": "selector",
+                                            "text": "j"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "selector",
+                                    "text": "target"
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "block",
+                                "children": [
+                                  {
+                                    "kind": "return",
+                                    "children": [
+                                      {
+                                        "kind": "list",
+                                        "children": [
+                                          {
+                                            "kind": "selector",
+                                            "text": "i"
+                                          },
+                                          {
+                                            "kind": "selector",
+                                            "text": "j"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "return",
+            "children": [
+              {
+                "kind": "list",
+                "children": [
+                  {
+                    "kind": "unary",
+                    "text": "-",
+                    "children": [
+                      {
+                        "kind": "int",
+                        "text": "1"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "unary",
+                    "text": "-",
+                    "children": [
+                      {
+                        "kind": "int",
+                        "text": "1"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "let",
+        "text": "result",
+        "children": [
+          {
+            "kind": "call",
+            "text": "twoSum",
+            "children": [
+              {
+                "kind": "list",
+                "children": [
+                  {
+                    "kind": "int",
+                    "text": "2"
+                  },
+                  {
+                    "kind": "int",
+                    "text": "7"
+                  },
+                  {
+                    "kind": "int",
+                    "text": "11"
+                  },
+                  {
+                    "kind": "int",
+                    "text": "15"
+                  }
+                ]
+              },
+              {
+                "kind": "int",
+                "text": "9"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "call",
+        "text": "print",
+        "children": [
+          {
+            "kind": "index",
+            "children": [
+              {
+                "kind": "selector",
+                "text": "result"
+              },
+              {
+                "kind": "int",
+                "text": "0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "call",
+        "text": "print",
+        "children": [
+          {
+            "kind": "index",
+            "children": [
+              {
+                "kind": "selector",
+                "text": "result"
+              },
+              {
+                "kind": "int",
+                "text": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- update `aster/x/mochi` to expose typed AST nodes
- add option for positions and new `convert` helper
- generate `two_sum.mochi.json` using new structures

## Testing
- `go test ./aster/x/mochi -run TestInspect_Golden -count=1 -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_688ac0f429808320a0eb63153839d759