### PR TITLE
Switch to WhatsApp tree-sitter-erlang

### DIFF
--- a/aster/x/erlang/ast.go
+++ b/aster/x/erlang/ast.go
@@ -72,9 +72,9 @@ func convert(n *sitter.Node, src []byte, opt Option) *Node {
 	if n == nil {
 		return nil
 	}
-	start := n.StartPoint()
-	end := n.EndPoint()
-	node := &Node{Kind: n.Type()}
+	start := n.StartPosition()
+	end := n.EndPosition()
+	node := &Node{Kind: n.Kind()}
 	if opt.Positions {
 		node.Start = int(start.Row) + 1
 		node.StartCol = int(start.Column)
@@ -83,14 +83,14 @@ func convert(n *sitter.Node, src []byte, opt Option) *Node {
 	}
 
 	if n.NamedChildCount() == 0 {
-		if isValueNode(n.Type()) {
-			node.Text = n.Content(src)
+		if isValueNode(n.Kind()) {
+			node.Text = n.Utf8Text(src)
 		} else {
 			return nil
 		}
 	}
 
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i := uint(0); i < n.NamedChildCount(); i++ {
 		child := n.NamedChild(i)
 		if child == nil {
 			continue

--- a/aster/x/erlang/inspect.go
+++ b/aster/x/erlang/inspect.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	sitter "github.com/tree-sitter/go-tree-sitter"
-	tserlang "mochi/third_party/tree-sitter-erlang/bindings/go"
+	tserlang "github.com/tree-sitter/tree-sitter-erlang/bindings/go"
 )
 
 // Program represents a parsed Erlang file composed of Node structs.
@@ -19,11 +19,10 @@ type Program struct {
 // InspectWithOption parses Erlang source code using tree-sitter and returns a Program.
 func InspectWithOption(src string, opt Option) (*Program, error) {
 	parser := sitter.NewParser()
-	parser.SetLanguage(tserlang.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
-	if err != nil {
-		return nil, fmt.Errorf("parse: %w", err)
+	if err := parser.SetLanguage(sitter.NewLanguage(tserlang.Language())); err != nil {
+		return nil, fmt.Errorf("language: %w", err)
 	}
+	tree := parser.ParseCtx(context.Background(), []byte(src), nil)
 	root := convert(tree.RootNode(), []byte(src), opt)
 	if root == nil {
 		return &Program{}, nil

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,10 @@ require (
 	github.com/tree-sitter/tree-sitter-scheme v0.24.7
 )
 
-require github.com/tree-sitter/tree-sitter-elixir v0.3.4
+require (
+	github.com/tree-sitter/tree-sitter-elixir v0.3.4
+	github.com/tree-sitter/tree-sitter-erlang v0.0.0-20250613112728-07dad1469ecb
+)
 
 require (
 	github.com/alexflint/go-scalar v1.2.0 // indirect
@@ -124,3 +127,5 @@ require (
 )
 
 replace github.com/tree-sitter/tree-sitter-elixir => github.com/elixir-lang/tree-sitter-elixir v0.3.4
+
+replace github.com/tree-sitter/tree-sitter-erlang => github.com/WhatsApp/tree-sitter-erlang v0.0.0-20250613112728-07dad1469ecb

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/6cdh/tree-sitter-scheme v0.24.7 h1:yhRP+u4lRA4bCxq4dEETb+osMcwvqtG9hS
 github.com/6cdh/tree-sitter-scheme v0.24.7/go.mod h1:xgkD400pSRfWngDRCv8PwtmHbNWwkJGAKEXxef3q0Mg=
 github.com/UserNobody14/tree-sitter-dart v0.0.0-20250228221807-80e23c07b644 h1:k4tn8w6Ff/lqZ3ePeBEAviVFpyiuOKJ39ATc3eD2ibE=
 github.com/UserNobody14/tree-sitter-dart v0.0.0-20250228221807-80e23c07b644/go.mod h1:6zSIbyfHyxL/+XWRHElGLw+EUPYbDOyhDqIiAX6svrE=
+github.com/WhatsApp/tree-sitter-erlang v0.0.0-20250613112728-07dad1469ecb h1:ZoCyhLC5RNA5cwrX+FPD0rPNdZ0sLJs+EAc33QCQgow=
+github.com/WhatsApp/tree-sitter-erlang v0.0.0-20250613112728-07dad1469ecb/go.mod h1:BeJG7Ezjd3yHpmBcc4Gjw8xkXQz3BDrQdPr7c46z3MA=
 github.com/akrennmair/pascal v0.0.0-20230115195835-14bcf05a6156 h1:9TcsfXYLZ4uwgMoU1lHv4mOkvVSvT3jb79bUTnRk4m0=
 github.com/akrennmair/pascal v0.0.0-20230115195835-14bcf05a6156/go.mod h1:JZ7MoyNmDLD1Pwi0jPuSxY/kkBdfD9bEMwQzBFhdRoY=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=


### PR DESCRIPTION
## Summary
- replace custom Erlang parser with upstream `WhatsApp/tree-sitter-erlang`
- adjust AST generation to new tree-sitter API
- update module requirements

## Testing
- `go mod tidy`
- `go test -tags slow ./aster/x/erlang -run TestInspectGolden -count=0 -failfast` *(fails: running gcc failed)*

------
https://chatgpt.com/codex/tasks/task_e_688ac14072ac8320a5fdf1f0b7bc2d34