### PR TITLE
Update Java AST generation

### DIFF
--- a/aster/x/java/inspect.go
+++ b/aster/x/java/inspect.go
@@ -11,18 +11,22 @@ import (
 
 // Program represents a parsed Java source file.
 // Program represents a parsed Java source file. The root node is a SourceFile.
+// Program represents a parsed Java source file. The File field holds the root
+// program node of the AST.
 type Program struct {
-	File *SourceFile `json:"file"`
+	File *ProgramNode `json:"file"`
 }
 
 // Inspect parses the given Java source code using tree-sitter and returns
 // its Program structure.
 // Inspect parses the given Java source code using tree-sitter. When withPos is
 // true the returned AST includes positional information.
-func Inspect(src string, withPos bool) (*Program, error) {
+// Inspect parses the given Java source code using tree-sitter. When opt.Positions
+// is true positional information is recorded in the resulting AST.
+func Inspect(src string, opt Options) (*Program, error) {
 	parser := sitter.NewParser()
 	parser.SetLanguage(sitter.NewLanguage(javats.Language()))
 	tree := parser.ParseCtx(context.Background(), []byte(src), nil)
-	root := toNode(tree.RootNode(), []byte(src), withPos)
-	return &Program{File: (*SourceFile)(root)}, nil
+	root := convert(tree.RootNode(), []byte(src), opt.Positions)
+	return &Program{File: (*ProgramNode)(root)}, nil
 }

--- a/aster/x/java/inspect_test.go
+++ b/aster/x/java/inspect_test.go
@@ -62,7 +62,7 @@ func TestInspect_Golden(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read src: %v", err)
 			}
-			prog, err := javaast.Inspect(string(data), false)
+			prog, err := javaast.Inspect(string(data), javaast.Options{})
 			if err != nil {
 				t.Skipf("inspect error: %v", err)
 				return

--- a/cmd/mochix/main.go
+++ b/cmd/mochix/main.go
@@ -539,7 +539,7 @@ func runInspect(cmd *InspectCmd) error {
 	case "hs":
 		prog, err = hsast.Inspect(src)
 	case "java":
-		prog, err = javaast.Inspect(src, false)
+		prog, err = javaast.Inspect(src, javaast.Options{})
 	case "kotlin", "kt":
 		prog, err = kotlinast.Inspect(src)
 	case "lua":

--- a/tests/aster/x/java/two-sum.java.json
+++ b/tests/aster/x/java/two-sum.java.json
@@ -1,0 +1,490 @@
+{
+  "file": {
+    "kind": "program",
+    "children": [
+      {
+        "kind": "class_declaration",
+        "children": [
+          {
+            "kind": "identifier",
+            "text": "Main"
+          },
+          {
+            "kind": "class_body",
+            "children": [
+              {
+                "kind": "field_declaration",
+                "children": [
+                  {
+                    "kind": "variable_declarator",
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "text": "result"
+                      },
+                      {
+                        "kind": "method_invocation",
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "text": "twoSum"
+                          },
+                          {
+                            "kind": "argument_list",
+                            "children": [
+                              {
+                                "kind": "array_creation_expression",
+                                "children": [
+                                  {
+                                    "kind": "array_initializer",
+                                    "children": [
+                                      {
+                                        "kind": "decimal_integer_literal",
+                                        "text": "2"
+                                      },
+                                      {
+                                        "kind": "decimal_integer_literal",
+                                        "text": "7"
+                                      },
+                                      {
+                                        "kind": "decimal_integer_literal",
+                                        "text": "11"
+                                      },
+                                      {
+                                        "kind": "decimal_integer_literal",
+                                        "text": "15"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "decimal_integer_literal",
+                                "text": "9"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "method_declaration",
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "text": "twoSum"
+                  },
+                  {
+                    "kind": "formal_parameters",
+                    "children": [
+                      {
+                        "kind": "formal_parameter",
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "text": "nums"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "formal_parameter",
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "text": "target"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "block",
+                    "children": [
+                      {
+                        "kind": "local_variable_declaration",
+                        "children": [
+                          {
+                            "kind": "variable_declarator",
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "text": "n"
+                              },
+                              {
+                                "kind": "field_access",
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "text": "nums"
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "text": "length"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "for_statement",
+                        "children": [
+                          {
+                            "kind": "local_variable_declaration",
+                            "children": [
+                              {
+                                "kind": "variable_declarator",
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "text": "i"
+                                  },
+                                  {
+                                    "kind": "decimal_integer_literal",
+                                    "text": "0"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "binary_expression",
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "text": "i"
+                              },
+                              {
+                                "kind": "identifier",
+                                "text": "n"
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "update_expression",
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "text": "i"
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "block",
+                            "children": [
+                              {
+                                "kind": "for_statement",
+                                "children": [
+                                  {
+                                    "kind": "local_variable_declaration",
+                                    "children": [
+                                      {
+                                        "kind": "variable_declarator",
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "text": "j"
+                                          },
+                                          {
+                                            "kind": "binary_expression",
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "text": "i"
+                                              },
+                                              {
+                                                "kind": "decimal_integer_literal",
+                                                "text": "1"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "binary_expression",
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "text": "j"
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "text": "n"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "update_expression",
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "text": "j"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "block",
+                                    "children": [
+                                      {
+                                        "kind": "if_statement",
+                                        "children": [
+                                          {
+                                            "kind": "parenthesized_expression",
+                                            "children": [
+                                              {
+                                                "kind": "binary_expression",
+                                                "children": [
+                                                  {
+                                                    "kind": "binary_expression",
+                                                    "children": [
+                                                      {
+                                                        "kind": "array_access",
+                                                        "children": [
+                                                          {
+                                                            "kind": "identifier",
+                                                            "text": "nums"
+                                                          },
+                                                          {
+                                                            "kind": "identifier",
+                                                            "text": "i"
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "array_access",
+                                                        "children": [
+                                                          {
+                                                            "kind": "identifier",
+                                                            "text": "nums"
+                                                          },
+                                                          {
+                                                            "kind": "identifier",
+                                                            "text": "j"
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "identifier",
+                                                    "text": "target"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "block",
+                                            "children": [
+                                              {
+                                                "kind": "return_statement",
+                                                "children": [
+                                                  {
+                                                    "kind": "array_creation_expression",
+                                                    "children": [
+                                                      {
+                                                        "kind": "array_initializer",
+                                                        "children": [
+                                                          {
+                                                            "kind": "identifier",
+                                                            "text": "i"
+                                                          },
+                                                          {
+                                                            "kind": "identifier",
+                                                            "text": "j"
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "return_statement",
+                        "children": [
+                          {
+                            "kind": "array_creation_expression",
+                            "children": [
+                              {
+                                "kind": "array_initializer",
+                                "children": [
+                                  {
+                                    "kind": "unary_expression",
+                                    "children": [
+                                      {
+                                        "kind": "decimal_integer_literal",
+                                        "text": "1"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "unary_expression",
+                                    "children": [
+                                      {
+                                        "kind": "decimal_integer_literal",
+                                        "text": "1"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "method_declaration",
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "text": "main"
+                  },
+                  {
+                    "kind": "formal_parameters",
+                    "children": [
+                      {
+                        "kind": "formal_parameter",
+                        "children": [
+                          {
+                            "kind": "array_type",
+                            "children": [
+                              {
+                                "kind": "type_identifier",
+                                "text": "String"
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "identifier",
+                            "text": "args"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "block",
+                    "children": [
+                      {
+                        "kind": "expression_statement",
+                        "children": [
+                          {
+                            "kind": "method_invocation",
+                            "children": [
+                              {
+                                "kind": "field_access",
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "text": "System"
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "text": "out"
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "text": "println"
+                              },
+                              {
+                                "kind": "argument_list",
+                                "children": [
+                                  {
+                                    "kind": "array_access",
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "text": "result"
+                                      },
+                                      {
+                                        "kind": "decimal_integer_literal",
+                                        "text": "0"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "expression_statement",
+                        "children": [
+                          {
+                            "kind": "method_invocation",
+                            "children": [
+                              {
+                                "kind": "field_access",
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "text": "System"
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "text": "out"
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "text": "println"
+                              },
+                              {
+                                "kind": "argument_list",
+                                "children": [
+                                  {
+                                    "kind": "array_access",
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "text": "result"
+                                      },
+                                      {
+                                        "kind": "decimal_integer_literal",
+                                        "text": "1"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/mochix/aster_test.go
+++ b/tests/mochix/aster_test.go
@@ -97,7 +97,7 @@ func TestInspectGolden(t *testing.T) {
 			return json.MarshalIndent(p, "", "  ")
 		},
 		"java": func(src string) ([]byte, error) {
-			p, err := javaast.Inspect(src, false)
+			p, err := javaast.Inspect(src, javaast.Options{})
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Summary
- modernize aster/x/java AST generation
- expose Options struct controlling position fields
- implement `convert` for tree‑sitter nodes
- update mochix tooling for new API
- regenerate only `two-sum.java.json`

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_688ac191db6083208c4fede403c97893