### PR TITLE
Add prolog two-sum AST

### DIFF
--- a/tests/aster/x/prolog/two-sum.prolog.json
+++ b/tests/aster/x/prolog/two-sum.prolog.json
@@ -1,0 +1,977 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "style_check(-singleton)"
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "get_item",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "Container"
+            },
+            {
+              "kind": "atom",
+              "text": "Key"
+            },
+            {
+              "kind": "atom",
+              "text": "Val"
+            }
+          ]
+        },
+        {
+          "kind": ",",
+          "children": [
+            {
+              "kind": "is_dict",
+              "children": [
+                {
+                  "kind": "var",
+                  "text": "Container"
+                }
+              ]
+            },
+            {
+              "kind": ",",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "!"
+                },
+                {
+                  "kind": ",",
+                  "children": [
+                    {
+                      "kind": ";",
+                      "children": [
+                        {
+                          "kind": "-\u003e",
+                          "children": [
+                            {
+                              "kind": "string",
+                              "children": [
+                                {
+                                  "kind": "var",
+                                  "text": "Key"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "atom_string",
+                              "children": [
+                                {
+                                  "kind": "var",
+                                  "text": "A"
+                                },
+                                {
+                                  "kind": "var",
+                                  "text": "Key"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "=",
+                          "children": [
+                            {
+                              "kind": "var",
+                              "text": "A"
+                            },
+                            {
+                              "kind": "var",
+                              "text": "Key"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "get_dict",
+                      "children": [
+                        {
+                          "kind": "var",
+                          "text": "A"
+                        },
+                        {
+                          "kind": "var",
+                          "text": "Container"
+                        },
+                        {
+                          "kind": "var",
+                          "text": "Val"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "get_item",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "Container"
+            },
+            {
+              "kind": "atom",
+              "text": "Index"
+            },
+            {
+              "kind": "atom",
+              "text": "Val"
+            }
+          ]
+        },
+        {
+          "kind": ",",
+          "children": [
+            {
+              "kind": "string",
+              "children": [
+                {
+                  "kind": "var",
+                  "text": "Container"
+                }
+              ]
+            },
+            {
+              "kind": ",",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "!"
+                },
+                {
+                  "kind": ",",
+                  "children": [
+                    {
+                      "kind": "string_chars",
+                      "children": [
+                        {
+                          "kind": "var",
+                          "text": "Container"
+                        },
+                        {
+                          "kind": "var",
+                          "text": "Chars"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nth0",
+                      "children": [
+                        {
+                          "kind": "var",
+                          "text": "Index"
+                        },
+                        {
+                          "kind": "var",
+                          "text": "Chars"
+                        },
+                        {
+                          "kind": "var",
+                          "text": "Val"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "get_item",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "List"
+            },
+            {
+              "kind": "atom",
+              "text": "Index"
+            },
+            {
+              "kind": "atom",
+              "text": "Val"
+            }
+          ]
+        },
+        {
+          "kind": "nth0",
+          "children": [
+            {
+              "kind": "var",
+              "text": "Index"
+            },
+            {
+              "kind": "var",
+              "text": "List"
+            },
+            {
+              "kind": "var",
+              "text": "Val"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "twosum",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "Nums"
+            },
+            {
+              "kind": "atom",
+              "text": "Target"
+            },
+            {
+              "kind": "atom",
+              "text": "Res"
+            }
+          ]
+        },
+        {
+          "kind": "catch",
+          "children": [
+            {
+              "kind": ",",
+              "children": [
+                {
+                  "kind": "length",
+                  "children": [
+                    {
+                      "kind": "var",
+                      "text": "Nums"
+                    },
+                    {
+                      "kind": "var",
+                      "text": "_V0"
+                    }
+                  ]
+                },
+                {
+                  "kind": ",",
+                  "children": [
+                    {
+                      "kind": "=",
+                      "children": [
+                        {
+                          "kind": "var",
+                          "text": "N"
+                        },
+                        {
+                          "kind": "var",
+                          "text": "_V0"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": ",",
+                      "children": [
+                        {
+                          "kind": "is",
+                          "children": [
+                            {
+                              "kind": "var",
+                              "text": "_V1"
+                            },
+                            {
+                              "kind": "-",
+                              "children": [
+                                {
+                                  "kind": "var",
+                                  "text": "N"
+                                },
+                                {
+                                  "kind": "number",
+                                  "text": "1"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": ",",
+                          "children": [
+                            {
+                              "kind": "catch",
+                              "children": [
+                                {
+                                  "kind": ";",
+                                  "children": [
+                                    {
+                                      "kind": ",",
+                                      "children": [
+                                        {
+                                          "kind": "between",
+                                          "children": [
+                                            {
+                                              "kind": "number",
+                                              "text": "0"
+                                            },
+                                            {
+                                              "kind": "var",
+                                              "text": "_V1"
+                                            },
+                                            {
+                                              "kind": "var",
+                                              "text": "I"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": ",",
+                                          "children": [
+                                            {
+                                              "kind": "catch",
+                                              "children": [
+                                                {
+                                                  "kind": ",",
+                                                  "children": [
+                                                    {
+                                                      "kind": "is",
+                                                      "children": [
+                                                        {
+                                                          "kind": "var",
+                                                          "text": "_V2"
+                                                        },
+                                                        {
+                                                          "kind": "+",
+                                                          "children": [
+                                                            {
+                                                              "kind": "var",
+                                                              "text": "I"
+                                                            },
+                                                            {
+                                                              "kind": "number",
+                                                              "text": "1"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": ",",
+                                                      "children": [
+                                                        {
+                                                          "kind": "is",
+                                                          "children": [
+                                                            {
+                                                              "kind": "var",
+                                                              "text": "_V3"
+                                                            },
+                                                            {
+                                                              "kind": "-",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "var",
+                                                                  "text": "N"
+                                                                },
+                                                                {
+                                                                  "kind": "number",
+                                                                  "text": "1"
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        },
+                                                        {
+                                                          "kind": ",",
+                                                          "children": [
+                                                            {
+                                                              "kind": "catch",
+                                                              "children": [
+                                                                {
+                                                                  "kind": ";",
+                                                                  "children": [
+                                                                    {
+                                                                      "kind": ",",
+                                                                      "children": [
+                                                                        {
+                                                                          "kind": "between",
+                                                                          "children": [
+                                                                            {
+                                                                              "kind": "var",
+                                                                              "text": "_V2"
+                                                                            },
+                                                                            {
+                                                                              "kind": "var",
+                                                                              "text": "_V3"
+                                                                            },
+                                                                            {
+                                                                              "kind": "var",
+                                                                              "text": "J"
+                                                                            }
+                                                                          ]
+                                                                        },
+                                                                        {
+                                                                          "kind": ",",
+                                                                          "children": [
+                                                                            {
+                                                                              "kind": "catch",
+                                                                              "children": [
+                                                                                {
+                                                                                  "kind": ",",
+                                                                                  "children": [
+                                                                                    {
+                                                                                      "kind": "get_item",
+                                                                                      "children": [
+                                                                                        {
+                                                                                          "kind": "var",
+                                                                                          "text": "Nums"
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "var",
+                                                                                          "text": "I"
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "var",
+                                                                                          "text": "_V4"
+                                                                                        }
+                                                                                      ]
+                                                                                    },
+                                                                                    {
+                                                                                      "kind": ",",
+                                                                                      "children": [
+                                                                                        {
+                                                                                          "kind": "get_item",
+                                                                                          "children": [
+                                                                                            {
+                                                                                              "kind": "var",
+                                                                                              "text": "Nums"
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "var",
+                                                                                              "text": "J"
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "var",
+                                                                                              "text": "_V5"
+                                                                                            }
+                                                                                          ]
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": ",",
+                                                                                          "children": [
+                                                                                            {
+                                                                                              "kind": "is",
+                                                                                              "children": [
+                                                                                                {
+                                                                                                  "kind": "var",
+                                                                                                  "text": "_V6"
+                                                                                                },
+                                                                                                {
+                                                                                                  "kind": "+",
+                                                                                                  "children": [
+                                                                                                    {
+                                                                                                      "kind": "var",
+                                                                                                      "text": "_V4"
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "kind": "var",
+                                                                                                      "text": "_V5"
+                                                                                                    }
+                                                                                                  ]
+                                                                                                }
+                                                                                              ]
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": ",",
+                                                                                              "children": [
+                                                                                                {
+                                                                                                  "kind": ";",
+                                                                                                  "children": [
+                                                                                                    {
+                                                                                                      "kind": "-\u003e",
+                                                                                                      "children": [
+                                                                                                        {
+                                                                                                          "kind": "=",
+                                                                                                          "children": [
+                                                                                                            {
+                                                                                                              "kind": "var",
+                                                                                                              "text": "_V6"
+                                                                                                            },
+                                                                                                            {
+                                                                                                              "kind": "var",
+                                                                                                              "text": "Target"
+                                                                                                            }
+                                                                                                          ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                          "kind": "throw",
+                                                                                                          "children": [
+                                                                                                            {
+                                                                                                              "kind": "return",
+                                                                                                              "children": [
+                                                                                                                {
+                                                                                                                  "kind": "list",
+                                                                                                                  "children": [
+                                                                                                                    {
+                                                                                                                      "kind": "var",
+                                                                                                                      "text": "I"
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                      "kind": "var",
+                                                                                                                      "text": "J"
+                                                                                                                    }
+                                                                                                                  ]
+                                                                                                                }
+                                                                                                              ]
+                                                                                                            }
+                                                                                                          ]
+                                                                                                        }
+                                                                                                      ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "kind": "bool",
+                                                                                                      "text": "true"
+                                                                                                    }
+                                                                                                  ]
+                                                                                                },
+                                                                                                {
+                                                                                                  "kind": "bool",
+                                                                                                  "text": "true"
+                                                                                                }
+                                                                                              ]
+                                                                                            }
+                                                                                          ]
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  ]
+                                                                                },
+                                                                                {
+                                                                                  "kind": "atom",
+                                                                                  "text": "continue"
+                                                                                },
+                                                                                {
+                                                                                  "kind": "bool",
+                                                                                  "text": "true"
+                                                                                }
+                                                                              ]
+                                                                            },
+                                                                            {
+                                                                              "kind": "atom",
+                                                                              "text": "fail"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "kind": "bool",
+                                                                      "text": "true"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                {
+                                                                  "kind": "atom",
+                                                                  "text": "break"
+                                                                },
+                                                                {
+                                                                  "kind": "bool",
+                                                                  "text": "true"
+                                                                }
+                                                              ]
+                                                            },
+                                                            {
+                                                              "kind": ",",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "bool",
+                                                                  "text": "true"
+                                                                },
+                                                                {
+                                                                  "kind": "bool",
+                                                                  "text": "true"
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "atom",
+                                                  "text": "continue"
+                                                },
+                                                {
+                                                  "kind": "bool",
+                                                  "text": "true"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "atom",
+                                              "text": "fail"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "bool",
+                                      "text": "true"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "atom",
+                                  "text": "break"
+                                },
+                                {
+                                  "kind": "bool",
+                                  "text": "true"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": ",",
+                              "children": [
+                                {
+                                  "kind": "bool",
+                                  "text": "true"
+                                },
+                                {
+                                  "kind": "bool",
+                                  "text": "true"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "return",
+              "children": [
+                {
+                  "kind": "var",
+                  "text": "_V7"
+                }
+              ]
+            },
+            {
+              "kind": "=",
+              "children": [
+                {
+                  "kind": "var",
+                  "text": "Res"
+                },
+                {
+                  "kind": "var",
+                  "text": "_V7"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "twosum",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "Nums"
+            },
+            {
+              "kind": "atom",
+              "text": "Target"
+            },
+            {
+              "kind": "atom",
+              "text": "Res"
+            }
+          ]
+        },
+        {
+          "kind": ",",
+          "children": [
+            {
+              "kind": "is",
+              "children": [
+                {
+                  "kind": "var",
+                  "text": "_V8"
+                },
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "number",
+                      "text": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": ",",
+              "children": [
+                {
+                  "kind": "is",
+                  "children": [
+                    {
+                      "kind": "var",
+                      "text": "_V9"
+                    },
+                    {
+                      "kind": "-",
+                      "children": [
+                        {
+                          "kind": "number",
+                          "text": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "=",
+                  "children": [
+                    {
+                      "kind": "var",
+                      "text": "Res"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "var",
+                          "text": "_V8"
+                        },
+                        {
+                          "kind": "var",
+                          "text": "_V9"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": ",",
+          "children": [
+            {
+              "kind": "twosum",
+              "children": [
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "number",
+                      "text": "2"
+                    },
+                    {
+                      "kind": "number",
+                      "text": "7"
+                    },
+                    {
+                      "kind": "number",
+                      "text": "11"
+                    },
+                    {
+                      "kind": "number",
+                      "text": "15"
+                    }
+                  ]
+                },
+                {
+                  "kind": "number",
+                  "text": "9"
+                },
+                {
+                  "kind": "var",
+                  "text": "_V10"
+                }
+              ]
+            },
+            {
+              "kind": ",",
+              "children": [
+                {
+                  "kind": "=",
+                  "children": [
+                    {
+                      "kind": "var",
+                      "text": "Result"
+                    },
+                    {
+                      "kind": "var",
+                      "text": "_V10"
+                    }
+                  ]
+                },
+                {
+                  "kind": ",",
+                  "children": [
+                    {
+                      "kind": "get_item",
+                      "children": [
+                        {
+                          "kind": "var",
+                          "text": "Result"
+                        },
+                        {
+                          "kind": "number",
+                          "text": "0"
+                        },
+                        {
+                          "kind": "var",
+                          "text": "_V11"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": ",",
+                      "children": [
+                        {
+                          "kind": "write",
+                          "children": [
+                            {
+                              "kind": "var",
+                              "text": "_V11"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": ",",
+                          "children": [
+                            {
+                              "kind": "atom",
+                              "text": "nl"
+                            },
+                            {
+                              "kind": ",",
+                              "children": [
+                                {
+                                  "kind": "get_item",
+                                  "children": [
+                                    {
+                                      "kind": "var",
+                                      "text": "Result"
+                                    },
+                                    {
+                                      "kind": "number",
+                                      "text": "1"
+                                    },
+                                    {
+                                      "kind": "var",
+                                      "text": "_V12"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": ",",
+                                  "children": [
+                                    {
+                                      "kind": "write",
+                                      "children": [
+                                        {
+                                          "kind": "var",
+                                          "text": "_V12"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "atom",
+                                      "text": "nl"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "initialization(main, main)"
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
## Summary
- run `mochix inspect` to generate an AST for the Prolog two-sum example
- store the output under `tests/aster/x/prolog`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688ac1c4ff1883209d72d68f43392925