### PR TITLE
Update scheme AST and add two-sum sample

### DIFF
--- a/aster/x/scheme/ast.go
+++ b/aster/x/scheme/ast.go
@@ -16,13 +16,13 @@ var IncludePos bool
 // Text field populated so the resulting JSON remains compact. Position fields
 // are optional and only populated when IncludePos is true.
 type Node struct {
-	Kind     string  `json:"kind"`
-	Text     string  `json:"text,omitempty"`
-	Start    int     `json:"start,omitempty"`
-	StartCol int     `json:"startCol,omitempty"`
-	End      int     `json:"end,omitempty"`
-	EndCol   int     `json:"endCol,omitempty"`
-	Children []*Node `json:"children,omitempty"`
+        Kind     string  `json:"kind"`
+        Text     string  `json:"text,omitempty"`
+        Start    int     `json:"start,omitempty"`
+        End      int     `json:"end,omitempty"`
+        StartCol int     `json:"startCol,omitempty"`
+        EndCol   int     `json:"endCol,omitempty"`
+        Children []*Node `json:"children,omitempty"`
 }
 
 // The following typed aliases mirror the subset of tree-sitter node kinds that
@@ -63,10 +63,10 @@ func convertNode(n *sitter.Node, src []byte) *Node {
 	if IncludePos {
 		sp := n.StartPosition()
 		ep := n.EndPosition()
-		node.Start = int(sp.Row) + 1
-		node.StartCol = int(sp.Column)
-		node.End = int(ep.Row) + 1
-		node.EndCol = int(ep.Column)
+        node.Start = int(sp.Row) + 1
+        node.End = int(ep.Row) + 1
+        node.StartCol = int(sp.Column)
+        node.EndCol = int(ep.Column)
 	}
 
 	if n.NamedChildCount() == 0 {

--- a/tests/aster/x/scheme/two-sum.scheme.json
+++ b/tests/aster/x/scheme/two-sum.scheme.json
@@ -1,0 +1,459 @@
+{
+  "forms": [
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "two-sum"
+            },
+            {
+              "kind": "symbol",
+              "text": "nums"
+            },
+            {
+              "kind": "symbol",
+              "text": "target"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "let"
+            },
+            {
+              "kind": "symbol",
+              "text": "loop"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "i"
+                    },
+                    {
+                      "kind": "number",
+                      "text": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "if"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "="
+                    },
+                    {
+                      "kind": "symbol",
+                      "text": "i"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "length"
+                        },
+                        {
+                          "kind": "symbol",
+                          "text": "nums"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "quote",
+                  "children": [
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "number",
+                          "text": "-1"
+                        },
+                        {
+                          "kind": "number",
+                          "text": "-1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "let"
+                    },
+                    {
+                      "kind": "symbol",
+                      "text": "inner"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "j"
+                            },
+                            {
+                              "kind": "list",
+                              "children": [
+                                {
+                                  "kind": "symbol",
+                                  "text": "+"
+                                },
+                                {
+                                  "kind": "symbol",
+                                  "text": "i"
+                                },
+                                {
+                                  "kind": "number",
+                                  "text": "1"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cond"
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "list",
+                              "children": [
+                                {
+                                  "kind": "symbol",
+                                  "text": "="
+                                },
+                                {
+                                  "kind": "symbol",
+                                  "text": "j"
+                                },
+                                {
+                                  "kind": "list",
+                                  "children": [
+                                    {
+                                      "kind": "symbol",
+                                      "text": "length"
+                                    },
+                                    {
+                                      "kind": "symbol",
+                                      "text": "nums"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "list",
+                              "children": [
+                                {
+                                  "kind": "symbol",
+                                  "text": "loop"
+                                },
+                                {
+                                  "kind": "list",
+                                  "children": [
+                                    {
+                                      "kind": "symbol",
+                                      "text": "+"
+                                    },
+                                    {
+                                      "kind": "symbol",
+                                      "text": "i"
+                                    },
+                                    {
+                                      "kind": "number",
+                                      "text": "1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "list",
+                              "children": [
+                                {
+                                  "kind": "symbol",
+                                  "text": "="
+                                },
+                                {
+                                  "kind": "list",
+                                  "children": [
+                                    {
+                                      "kind": "symbol",
+                                      "text": "+"
+                                    },
+                                    {
+                                      "kind": "list",
+                                      "children": [
+                                        {
+                                          "kind": "symbol",
+                                          "text": "list-ref"
+                                        },
+                                        {
+                                          "kind": "symbol",
+                                          "text": "nums"
+                                        },
+                                        {
+                                          "kind": "symbol",
+                                          "text": "i"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "list",
+                                      "children": [
+                                        {
+                                          "kind": "symbol",
+                                          "text": "list-ref"
+                                        },
+                                        {
+                                          "kind": "symbol",
+                                          "text": "nums"
+                                        },
+                                        {
+                                          "kind": "symbol",
+                                          "text": "j"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "symbol",
+                                  "text": "target"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "list",
+                              "children": [
+                                {
+                                  "kind": "symbol",
+                                  "text": "list"
+                                },
+                                {
+                                  "kind": "symbol",
+                                  "text": "i"
+                                },
+                                {
+                                  "kind": "symbol",
+                                  "text": "j"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "else"
+                            },
+                            {
+                              "kind": "list",
+                              "children": [
+                                {
+                                  "kind": "symbol",
+                                  "text": "inner"
+                                },
+                                {
+                                  "kind": "list",
+                                  "children": [
+                                    {
+                                      "kind": "symbol",
+                                      "text": "+"
+                                    },
+                                    {
+                                      "kind": "symbol",
+                                      "text": "j"
+                                    },
+                                    {
+                                      "kind": "number",
+                                      "text": "1"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "symbol",
+          "text": "result"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "two-sum"
+            },
+            {
+              "kind": "quote",
+              "children": [
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "number",
+                      "text": "2"
+                    },
+                    {
+                      "kind": "number",
+                      "text": "7"
+                    },
+                    {
+                      "kind": "number",
+                      "text": "11"
+                    },
+                    {
+                      "kind": "number",
+                      "text": "15"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "number",
+              "text": "9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "display"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "list-ref"
+            },
+            {
+              "kind": "symbol",
+              "text": "result"
+            },
+            {
+              "kind": "number",
+              "text": "0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "newline"
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "display"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "list-ref"
+            },
+            {
+              "kind": "symbol",
+              "text": "result"
+            },
+            {
+              "kind": "number",
+              "text": "1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "newline"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- refactor scheme AST structs to have Start/End/StartCol/EndCol order
- regenerate two-sum Scheme AST using the new struct layout

## Testing
- `go test -tags slow ./aster/x/scheme`
- `go test -tags slow ./aster/x/scheme -run TestInspect_Golden -update`

------
https://chatgpt.com/codex/tasks/task_e_688ac20847b8832080573d20c2b625d0