### PR TITLE
Add release notes for v0.10.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # 📦 CHANGELOG.md
 
+## [0.10.51] – 2025-07-31T09:04:29+07:00
+
+### Added
+
+* `mochix` inspect command for AST output
+* Typed AST examples for `print_hello`, `cross_join` and `two-sum`
+* New builtins `padStart`, `slice` and `repeat`
+
+### Changed
+
+* Parsers migrated to official tree-sitter grammars
+* Rosetta outputs regenerated with new benchmarks
+* Transpiler improvements across languages
+
+### Fixed
+
+* Variable scope, string key and MD5Hex bugs
+
 ## [0.10.50] – 2025-07-30T16:21:04+07:00
 
 ### Added

--- a/releases/v0.10.51.md
+++ b/releases/v0.10.51.md
@@ -1,0 +1,23 @@
+# Jul 2025 (v0.10.51)
+
+Released on Thu Jul 31 09:04:29 2025 +0700.
+
+Mochi v0.10.51 extends typed AST coverage with new examples and introduces an inspect command along with extensive transpiler updates.
+
+## Tooling
+
+- `mochix` adds an `inspect` command for emitting AST output
+- Typed `print_hello`, `cross_join` and `two-sum` examples across all languages
+- Official tree-sitter grammars integrated for multiple parsers
+- Golden AST tests regenerated with new nodes and positions
+
+## Compilers
+
+- New builtins such as `padStart`, `slice` and `repeat`
+- Improved method handling, map assignment and struct references
+- Rosetta outputs refreshed with additional benchmarks
+- Bigrat casts supported for Pascal, OCaml and Java
+
+## Documentation
+
+- Kotlin and PHP progress documentation regenerated


### PR DESCRIPTION
## Summary
- document release v0.10.51
- update CHANGELOG

## Testing
- `make test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688acf52bfc08320b9a4e2bac7bd99c9