### PR TITLE
Add skeleton F# printer

### DIFF
--- a/aster/x/fs/print.go
+++ b/aster/x/fs/print.go
@@ -1,0 +1,110 @@
+package fs
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// Print returns F# source code for the given Program. The output is
+// reconstructed from the AST and only supports a limited subset of
+// constructs used in the golden tests.
+func Print(p *Program) (string, error) {
+	if p == nil || p.Root == nil {
+		return "", fmt.Errorf("nil program")
+	}
+	var b bytes.Buffer
+	writeNode(&b, (*Node)(p.Root), 0)
+	out := b.String()
+	if len(out) > 0 && out[len(out)-1] != '\n' {
+		out += "\n"
+	}
+	return out, nil
+}
+
+func writeNode(b *bytes.Buffer, n *Node, indent int) {
+	switch n.Kind {
+	case "file", "ERROR":
+		for i, c := range n.Children {
+			if i > 0 {
+				b.WriteByte('\n')
+			}
+			writeNode(b, c, indent)
+		}
+	case "line_comment":
+		b.WriteString(n.Text)
+	case "function_or_value_defn":
+		b.WriteString(strings.Repeat("    ", indent))
+		b.WriteString("let ")
+		if len(n.Children) >= 1 {
+			writeExpr(b, n.Children[0])
+		}
+		if len(n.Children) == 3 {
+			b.WriteString(": ")
+			writeExpr(b, n.Children[1])
+			b.WriteString(" = ")
+			writeExpr(b, n.Children[2])
+		} else if len(n.Children) == 2 {
+			b.WriteString(" = ")
+			writeExpr(b, n.Children[1])
+		}
+	default:
+		writeExpr(b, n)
+	}
+}
+
+func writeExpr(b *bytes.Buffer, n *Node) {
+	switch n.Kind {
+	case "identifier":
+		b.WriteString(n.Name)
+	case "int", "string":
+		b.WriteString(n.Text)
+	case "long_identifier_or_op", "long_identifier":
+		for i, c := range n.Children {
+			if i > 0 {
+				b.WriteByte('.')
+			}
+			writeExpr(b, c)
+		}
+	case "application_expression":
+		for i, c := range n.Children {
+			if i > 0 {
+				b.WriteByte(' ')
+			}
+			writeExpr(b, c)
+		}
+	case "list_expression":
+		b.WriteByte('[')
+		for i, c := range n.Children {
+			if i > 0 {
+				b.WriteString("; ")
+			}
+			writeExpr(b, c)
+		}
+		b.WriteByte(']')
+	case "index_expression":
+		if len(n.Children) == 2 {
+			writeExpr(b, n.Children[0])
+			b.WriteString(".[")
+			writeExpr(b, n.Children[1])
+			b.WriteByte(']')
+		}
+	case "paren_expression":
+		b.WriteByte('(')
+		for i, c := range n.Children {
+			if i > 0 {
+				b.WriteByte(' ')
+			}
+			writeExpr(b, c)
+		}
+		b.WriteByte(')')
+	case "infix_expression":
+		if len(n.Children) == 2 {
+			writeExpr(b, n.Children[0])
+			b.WriteString(" + ")
+			writeExpr(b, n.Children[1])
+		}
+	default:
+		// unsupported nodes are ignored
+	}
+}

--- a/aster/x/fs/print_test.go
+++ b/aster/x/fs/print_test.go
@@ -1,0 +1,119 @@
+//go:build slow
+
+package fs_test
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	fs "mochi/aster/x/fs"
+)
+
+func shouldUpdate() bool {
+	f := flag.Lookup("update")
+	return f != nil && f.Value.String() == "true"
+}
+
+func ensureFSharp(t *testing.T) {
+	if _, err := exec.LookPath("fsharpc"); err != nil {
+		t.Skip("fsharpc not installed")
+	}
+}
+
+func TestPrint_Golden(t *testing.T) {
+	ensureFSharp(t)
+	root := repoRoot(t)
+	srcDir := filepath.Join(root, "tests", "transpiler", "x", "fs")
+	outDir := filepath.Join(root, "tests", "aster", "x", "fs")
+	os.MkdirAll(outDir, 0o755)
+
+	files, err := filepath.Glob(filepath.Join(srcDir, "*.fs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(files)
+	var selected []string
+	for _, f := range files {
+		if filepath.Base(f) == "two-sum.fs" {
+			selected = append(selected, f)
+		}
+	}
+	files = selected
+
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".fs")
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(src)
+			if err != nil {
+				t.Fatalf("read src: %v", err)
+			}
+			prog, err := fs.Inspect(string(data))
+			if err != nil {
+				t.Fatalf("inspect: %v", err)
+			}
+			astJSON, err := json.MarshalIndent(prog, "", "  ")
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			astJSON = append(astJSON, '\n')
+			jsonPath := filepath.Join(outDir, name+".fs.json")
+			if shouldUpdate() {
+				if err := os.WriteFile(jsonPath, astJSON, 0644); err != nil {
+					t.Fatalf("write json: %v", err)
+				}
+			}
+			wantJSON, err := os.ReadFile(jsonPath)
+			if err != nil {
+				t.Skip("missing golden")
+				return
+			}
+			if string(astJSON) != string(wantJSON) {
+				t.Fatalf("json mismatch\n--- got ---\n%s\n--- want ---\n%s", astJSON, wantJSON)
+			}
+			out, err := fs.Print(prog)
+			if err != nil {
+				t.Fatalf("print: %v", err)
+			}
+			outPath := filepath.Join(outDir, name+".fs")
+			if shouldUpdate() {
+				if err := os.WriteFile(outPath, []byte(out), 0644); err != nil {
+					t.Fatalf("write out: %v", err)
+				}
+			}
+			exe := filepath.Join(outDir, name+".exe")
+			cmd := exec.Command("fsharpc", "--target:exe", "--out:"+exe, outPath)
+			if b, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("compile printed: %v\n%s", err, b)
+			}
+			run := exec.Command("mono", exe)
+			got, err := run.CombinedOutput()
+			if err != nil {
+				t.Fatalf("run printed: %v\n%s", err, got)
+			}
+			cmdOrig := exec.Command("fsharpc", "--target:exe", "--out:"+exe, src)
+			if b, err := cmdOrig.CombinedOutput(); err != nil {
+				t.Fatalf("compile original: %v\n%s", err, b)
+			}
+			runOrig := exec.Command("mono", exe)
+			want, err := runOrig.CombinedOutput()
+			if err != nil {
+				t.Fatalf("run original: %v\n%s", err, want)
+			}
+			outFile := filepath.Join(outDir, name+".out")
+			if shouldUpdate() {
+				if err := os.WriteFile(outFile, got, 0644); err != nil {
+					t.Fatalf("write out file: %v", err)
+				}
+			}
+			if string(got) != string(want) {
+				t.Fatalf("output mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+			}
+		})
+	}
+}

--- a/tests/aster/x/fs/two-sum.fs
+++ b/tests/aster/x/fs/two-sum.fs
@@ -1,0 +1,11 @@
+// Generated 2025-07-21 18:37 +0700
+
+let :  = Seq.length nums
+
+
+
+
+((nums.[i]) + (nums.[j])) + target
+[i; j] [; ]
+let  = twoSum [; ; ; ] 
+printfn  (string (result.[])) printfn  (string (result.[]))


### PR DESCRIPTION
## Summary
- add minimal F# printer implementation
- add golden test for F# printer
- store generated `two-sum.fs`

## Testing
- `go test -tags slow ./aster/x/fs -run TestPrint_Golden -count=1` *(fails: compile printed)*

------
https://chatgpt.com/codex/tasks/task_e_688add76ed888320bf8cfd4c02356cd4