### PR TITLE
Improve C AST printing

### DIFF
--- a/aster/x/c/ast.go
+++ b/aster/x/c/ast.go
@@ -63,6 +63,16 @@ func convert(n *sitter.Node, src []byte, pos bool) *Node {
 		return nil
 	}
 	node := &Node{Kind: n.Kind()}
+
+	// Capture operator text for expressions where tree-sitter stores it in an
+	// unnamed child field. This information is required when reconstructing the
+	// original source from the AST.
+	switch n.Kind() {
+	case "binary_expression", "assignment_expression", "update_expression", "unary_expression", "pointer_expression":
+		if op := n.ChildByFieldName("operator"); op != nil {
+			node.Text = op.Utf8Text(src)
+		}
+	}
 	if pos {
 		start := n.StartPosition()
 		end := n.EndPosition()

--- a/aster/x/c/print.go
+++ b/aster/x/c/print.go
@@ -231,13 +231,23 @@ func writeExpr(b *bytes.Buffer, n *Node, indent int) {
 	case "assignment_expression":
 		if len(n.Children) == 2 {
 			writeExpr(b, n.Children[0], indent)
-			b.WriteString(" = ")
+			op := n.Text
+			if op == "" {
+				op = "="
+			}
+			b.WriteByte(' ')
+			b.WriteString(op)
+			b.WriteByte(' ')
 			writeExpr(b, n.Children[1], indent)
 		}
 	case "update_expression":
 		if len(n.Children) == 1 {
 			writeExpr(b, n.Children[0], indent)
-			b.WriteString("++")
+			op := n.Text
+			if op == "" {
+				op = "++"
+			}
+			b.WriteString(op)
 		}
 	case "initializer_list":
 		b.WriteByte('{')
@@ -275,16 +285,8 @@ func writeBinaryExpr(b *bytes.Buffer, n *Node, indent int) {
 		return
 	}
 	left, right := n.Children[0], n.Children[1]
-	op := "+"
-	if right.Kind == "identifier" && left.Kind == "identifier" {
-		op = "<"
-	} else if right.Kind == "number_literal" && right.Text == "9" {
-		op = "=="
-	} else if right.Kind == "number_literal" && right.Text == "1" {
-		op = "+"
-	} else if left.Kind == "subscript_expression" && right.Kind == "subscript_expression" {
-		op = "+"
-	} else {
+	op := n.Text
+	if op == "" {
 		op = "+"
 	}
 	writeExpr(b, left, indent)

--- a/tests/aster/x/c/two-sum.c.json
+++ b/tests/aster/x/c/two-sum.c.json
@@ -194,6 +194,7 @@
                   },
                   {
                     "kind": "binary_expression",
+                    "text": "\u003c",
                     "children": [
                       {
                         "kind": "identifier",
@@ -207,6 +208,7 @@
                   },
                   {
                     "kind": "update_expression",
+                    "text": "++",
                     "children": [
                       {
                         "kind": "identifier",
@@ -236,6 +238,7 @@
                                   },
                                   {
                                     "kind": "binary_expression",
+                                    "text": "+",
                                     "children": [
                                       {
                                         "kind": "identifier",
@@ -253,6 +256,7 @@
                           },
                           {
                             "kind": "binary_expression",
+                            "text": "\u003c",
                             "children": [
                               {
                                 "kind": "identifier",
@@ -266,6 +270,7 @@
                           },
                           {
                             "kind": "update_expression",
+                            "text": "++",
                             "children": [
                               {
                                 "kind": "identifier",
@@ -284,9 +289,11 @@
                                     "children": [
                                       {
                                         "kind": "binary_expression",
+                                        "text": "==",
                                         "children": [
                                           {
                                             "kind": "binary_expression",
+                                            "text": "+",
                                             "children": [
                                               {
                                                 "kind": "subscript_expression",
@@ -332,6 +339,7 @@
                                         "children": [
                                           {
                                             "kind": "assignment_expression",
+                                            "text": "=",
                                             "children": [
                                               {
                                                 "kind": "identifier",
@@ -350,6 +358,7 @@
                                         "children": [
                                           {
                                             "kind": "assignment_expression",
+                                            "text": "=",
                                             "children": [
                                               {
                                                 "kind": "identifier",


### PR DESCRIPTION
## Summary
- capture operator tokens when inspecting C code
- use captured operator tokens when printing C AST
- regenerate golden file for `two-sum.c.json`

## Testing
- `go test ./aster/x/c -tags slow -run TestPrint_Golden -update -count=1`
- `go test ./aster/x/c -tags slow -run TestPrint_Golden -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688aed3843c4832091e8af335f87400d