### PR TITLE
Improve Kotlin AST printer

### DIFF
--- a/aster/x/kotlin/ast.go
+++ b/aster/x/kotlin/ast.go
@@ -13,13 +13,13 @@ import (
 // textual value populate the Text field. Position information can be omitted to
 // keep the output compact.
 type Node struct {
-	Kind     string `json:"kind"`
-	Text     string `json:"text,omitempty"`
-	Start    int    `json:"start,omitempty"`
-	StartCol int    `json:"startCol,omitempty"`
-	End      int    `json:"end,omitempty"`
-	EndCol   int    `json:"endCol,omitempty"`
-	Children []Node `json:"children,omitempty"`
+	Kind     string  `json:"kind"`
+	Text     string  `json:"text,omitempty"`
+	Start    int     `json:"start,omitempty"`
+	StartCol int     `json:"startCol,omitempty"`
+	End      int     `json:"end,omitempty"`
+	EndCol   int     `json:"endCol,omitempty"`
+	Children []*Node `json:"children,omitempty"`
 }
 
 // Typed node aliases mirroring the Kotlin grammar. Only the node kinds that
@@ -105,7 +105,7 @@ func convert(n *sitter.Node, src []byte, withPos bool) *Node {
 	for i := 0; i < int(n.NamedChildCount()); i++ {
 		child := convert(n.NamedChild(uint(i)), src, withPos)
 		if child != nil {
-			node.Children = append(node.Children, *child)
+			node.Children = append(node.Children, child)
 		}
 	}
 

--- a/aster/x/kotlin/print_test.go
+++ b/aster/x/kotlin/print_test.go
@@ -3,115 +3,107 @@
 package kotlin_test
 
 import (
-    "encoding/json"
-    "flag"
-    "os"
-    "os/exec"
-    "path/filepath"
-    "sort"
-    "strings"
-    "testing"
+	"encoding/json"
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
 
-    kotlin "mochi/aster/x/kotlin"
+	kotlin "mochi/aster/x/kotlin"
 )
 
 func shouldUpdate() bool {
-    f := flag.Lookup("update")
-    return f != nil && f.Value.String() == "true"
+	f := flag.Lookup("update")
+	return f != nil && f.Value.String() == "true"
 }
 
 func ensureKotlinc(t *testing.T) {
-    if _, err := exec.LookPath("kotlinc"); err != nil {
-        t.Skip("kotlinc not installed")
-    }
+	if _, err := exec.LookPath("kotlinc"); err != nil {
+		t.Skip("kotlinc not installed")
+	}
 }
 
 func TestPrint_Golden(t *testing.T) {
-    ensureKotlinc(t)
-    root := repoRoot(t)
-    srcDir := filepath.Join(root, "tests", "transpiler", "x", "kt")
-    outDir := filepath.Join(root, "tests", "aster", "x", "kotlin")
-    os.MkdirAll(outDir, 0o755)
+	ensureKotlinc(t)
+	root := repoRoot(t)
+	srcDir := filepath.Join(root, "tests", "transpiler", "x", "kt")
+	outDir := filepath.Join(root, "tests", "aster", "x", "kotlin")
+	os.MkdirAll(outDir, 0o755)
 
-    files, err := filepath.Glob(filepath.Join(srcDir, "*.kt"))
-    if err != nil {
-        t.Fatal(err)
-    }
-    sort.Strings(files)
-    var selected []string
-    for _, f := range files {
-        if filepath.Base(f) == "two-sum.kt" {
-            selected = append(selected, f)
-        }
-    }
-    files = selected
+	files, err := filepath.Glob(filepath.Join(srcDir, "*.kt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(files)
 
-    for _, src := range files {
-        name := strings.TrimSuffix(filepath.Base(src), ".kt")
-        t.Run(name, func(t *testing.T) {
-            data, err := os.ReadFile(src)
-            if err != nil {
-                t.Fatalf("read src: %v", err)
-            }
-            prog, err := kotlin.Inspect(string(data))
-            if err != nil {
-                t.Fatalf("inspect: %v", err)
-            }
-            astJSON, err := json.MarshalIndent(prog, "", "  ")
-            if err != nil {
-                t.Fatalf("marshal: %v", err)
-            }
-            astJSON = append(astJSON, '\n')
-            jsonPath := filepath.Join(outDir, name+".kt.json")
-            if shouldUpdate() {
-                if err := os.WriteFile(jsonPath, astJSON, 0644); err != nil {
-                    t.Fatalf("write json: %v", err)
-                }
-            }
-            wantJSON, err := os.ReadFile(jsonPath)
-            if err != nil {
-                t.Skip("missing golden")
-                return
-            }
-            if string(astJSON) != string(wantJSON) {
-                t.Fatalf("json mismatch\n--- got ---\n%s\n--- want ---\n%s", astJSON, wantJSON)
-            }
-            out, err := kotlin.Print(prog)
-            if err != nil {
-                t.Fatalf("print: %v", err)
-            }
-            outPath := filepath.Join(outDir, name+".kt")
-            if shouldUpdate() {
-                if err := os.WriteFile(outPath, []byte(out), 0644); err != nil {
-                    t.Fatalf("write out: %v", err)
-                }
-            }
-            jar := filepath.Join(outDir, name+".jar")
-            if outb, err := exec.Command("kotlinc", outPath, "-include-runtime", "-d", jar).CombinedOutput(); err != nil {
-                t.Fatalf("kotlinc error: %v\n%s", err, outb)
-            }
-            got, err := exec.Command("java", "-jar", jar).CombinedOutput()
-            if err != nil {
-                t.Fatalf("run printed: %v\n%s", err, got)
-            }
-            wantJar := filepath.Join(outDir, name+"_ref.jar")
-            if outb, err := exec.Command("kotlinc", src, "-include-runtime", "-d", wantJar).CombinedOutput(); err != nil {
-                t.Fatalf("kotlinc ref error: %v\n%s", err, outb)
-            }
-            want, err := exec.Command("java", "-jar", wantJar).CombinedOutput()
-            if err != nil {
-                t.Fatalf("run original: %v\n%s", err, want)
-            }
-            outFile := filepath.Join(outDir, name+".out")
-            if shouldUpdate() {
-                if err := os.WriteFile(outFile, got, 0644); err != nil {
-                    t.Fatalf("write out file: %v", err)
-                }
-            }
-            if string(got) != string(want) {
-                t.Fatalf("output mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
-            }
-        })
-    }
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".kt")
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(src)
+			if err != nil {
+				t.Fatalf("read src: %v", err)
+			}
+			prog, err := kotlin.Inspect(string(data))
+			if err != nil {
+				t.Fatalf("inspect: %v", err)
+			}
+			astJSON, err := json.MarshalIndent(prog, "", "  ")
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			astJSON = append(astJSON, '\n')
+			jsonPath := filepath.Join(outDir, name+".kt.json")
+			if shouldUpdate() {
+				if err := os.WriteFile(jsonPath, astJSON, 0644); err != nil {
+					t.Fatalf("write json: %v", err)
+				}
+			}
+			wantJSON, err := os.ReadFile(jsonPath)
+			if err != nil {
+				t.Skip("missing golden")
+				return
+			}
+			if string(astJSON) != string(wantJSON) {
+				t.Fatalf("json mismatch\n--- got ---\n%s\n--- want ---\n%s", astJSON, wantJSON)
+			}
+			out, err := kotlin.Print(prog)
+			if err != nil {
+				t.Fatalf("print: %v", err)
+			}
+			outPath := filepath.Join(outDir, name+".kt")
+			if shouldUpdate() {
+				if err := os.WriteFile(outPath, []byte(out), 0644); err != nil {
+					t.Fatalf("write out: %v", err)
+				}
+			}
+			jar := filepath.Join(outDir, name+".jar")
+			if outb, err := exec.Command("kotlinc", outPath, "-include-runtime", "-d", jar).CombinedOutput(); err != nil {
+				t.Fatalf("kotlinc error: %v\n%s", err, outb)
+			}
+			got, err := exec.Command("java", "-jar", jar).CombinedOutput()
+			if err != nil {
+				t.Fatalf("run printed: %v\n%s", err, got)
+			}
+			wantJar := filepath.Join(outDir, name+"_ref.jar")
+			if outb, err := exec.Command("kotlinc", src, "-include-runtime", "-d", wantJar).CombinedOutput(); err != nil {
+				t.Fatalf("kotlinc ref error: %v\n%s", err, outb)
+			}
+			want, err := exec.Command("java", "-jar", wantJar).CombinedOutput()
+			if err != nil {
+				t.Fatalf("run original: %v\n%s", err, want)
+			}
+			outFile := filepath.Join(outDir, name+".out")
+			if shouldUpdate() {
+				if err := os.WriteFile(outFile, got, 0644); err != nil {
+					t.Fatalf("write out file: %v", err)
+				}
+			}
+			if string(got) != string(want) {
+				t.Fatalf("output mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+			}
+		})
+	}
 }
-


### PR DESCRIPTION
## Summary
- switch `aster/x/kotlin` AST nodes to use pointers for children
- update Kotlin AST printer to handle pointer based AST
- broaden Kotlin printer test to work on all `.kt` sources

## Testing
- `go test ./aster/x/kotlin -tags slow -run TestInspect_Golden -count=1`
- `go test ./aster/x/kotlin -tags slow -run TestPrint_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_688aed929eb483209e7af305146733be