### PR TITLE
Improve Rust aster Print for negative numbers

### DIFF
--- a/tests/aster/x/rs/two-sum.rs
+++ b/tests/aster/x/rs/two-sum.rs
@@ -8,7 +8,7 @@ fn twoSum(nums: Vec<i64>, target: i64) -> Vec<i64> {
             }
         }
     }
-    return vec![1, 1]
+    return vec![-1, -1]
 }
 fn main() {
     let result = twoSum(vec![2, 7, 11, 15], 9);

--- a/tests/aster/x/rs/two-sum.rs.json
+++ b/tests/aster/x/rs/two-sum.rs.json
@@ -247,6 +247,7 @@
                                                           },
                                                           {
                                                             "kind": "token_tree",
+                                                            "text": "[i as i64, j as i64]",
                                                             "children": [
                                                               {
                                                                 "kind": "identifier",
@@ -300,14 +301,15 @@
                       },
                       {
                         "kind": "token_tree",
+                        "text": "[-1, -1]",
                         "children": [
                           {
                             "kind": "integer_literal",
-                            "text": "1"
+                            "text": "-1"
                           },
                           {
                             "kind": "integer_literal",
-                            "text": "1"
+                            "text": "-1"
                           }
                         ]
                       }
@@ -359,6 +361,7 @@
                               },
                               {
                                 "kind": "token_tree",
+                                "text": "[2, 7, 11, 15]",
                                 "children": [
                                   {
                                     "kind": "integer_literal",
@@ -402,6 +405,7 @@
                       },
                       {
                         "kind": "token_tree",
+                        "text": "(\"{}\", result[0])",
                         "children": [
                           {
                             "kind": "string_literal",
@@ -418,6 +422,7 @@
                           },
                           {
                             "kind": "token_tree",
+                            "text": "[0]",
                             "children": [
                               {
                                 "kind": "integer_literal",
@@ -443,6 +448,7 @@
                       },
                       {
                         "kind": "token_tree",
+                        "text": "(\"{}\", result[1])",
                         "children": [
                           {
                             "kind": "string_literal",
@@ -459,6 +465,7 @@
                           },
                           {
                             "kind": "token_tree",
+                            "text": "[1]",
                             "children": [
                               {
                                 "kind": "integer_literal",


### PR DESCRIPTION
## Summary
- preserve raw text for token trees and negative integers in Rust AST
- update golden files for two-sum

## Testing
- `go test ./aster/x/rs -tags slow -run TestPrint_Golden -v`

------
https://chatgpt.com/codex/tasks/task_e_688aedce15f8832083e1a17ebd14ee21