### PR TITLE
Improve Scala AST printing

### DIFF
--- a/aster/x/scala/inspect.go
+++ b/aster/x/scala/inspect.go
@@ -9,15 +9,20 @@ import (
 // default positional information is omitted. Pass an Options value with
 // Positions=true to include it.
 func Inspect(src string, opts ...Options) (*Program, error) {
-	var withPos bool
+	var opt Options
 	if len(opts) > 0 {
-		withPos = opts[0].Positions
+		opt = opts[0]
 	}
+	return InspectWithOptions(src, opt)
+}
+
+// InspectWithOptions behaves like Inspect but accepts an explicit Options value.
+func InspectWithOptions(src string, opt Options) (*Program, error) {
 	parser := sitter.NewParser()
 	parser.SetLanguage(sitter.NewLanguage(tscala.Language()))
 	data := []byte(src)
 	tree := parser.Parse(data, nil)
-	n := convert(tree.RootNode(), data, withPos)
+	n := convert(tree.RootNode(), data, opt.Positions)
 	if n == nil {
 		return &Program{}, nil
 	}

--- a/aster/x/scala/print.go
+++ b/aster/x/scala/print.go
@@ -69,6 +69,8 @@ func writeStmt(b *bytes.Buffer, n *Node, indent int) {
 			b.WriteString(ind)
 			b.WriteString("}\n")
 		}
+	case "class_definition":
+		writeClassDefinition(b, n, indent)
 	case "function_definition":
 		writeFunctionDefinition(b, n, indent)
 	case "val_definition":
@@ -159,6 +161,35 @@ func writeValDefinition(b *bytes.Buffer, n *Node, indent int) {
 		writeExpr(b, n.Children[idx], indent)
 	}
 	b.WriteByte('\n')
+}
+
+func writeClassDefinition(b *bytes.Buffer, n *Node, indent int) {
+	if len(n.Children) == 0 {
+		return
+	}
+	ind := strings.Repeat("  ", indent)
+	b.WriteString(ind)
+	b.WriteString("case class ")
+	b.WriteString(n.Children[0].Text)
+	if len(n.Children) > 1 {
+		writeClassParameters(b, n.Children[1], indent)
+	}
+	b.WriteByte('\n')
+}
+
+func writeClassParameters(b *bytes.Buffer, n *Node, indent int) {
+	b.WriteByte('(')
+	for i, p := range n.Children {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		if len(p.Children) >= 2 {
+			b.WriteString(p.Children[0].Text)
+			b.WriteString(": ")
+			writeExpr(b, p.Children[1], indent)
+		}
+	}
+	b.WriteByte(')')
 }
 
 func writeForExpression(b *bytes.Buffer, n *Node, indent int) {

--- a/aster/x/scala/print_test.go
+++ b/aster/x/scala/print_test.go
@@ -60,13 +60,6 @@ func TestPrint_Golden(t *testing.T) {
 		t.Fatal(err)
 	}
 	sort.Strings(files)
-	var selected []string
-	for _, f := range files {
-		if filepath.Base(f) == "two-sum.scala" {
-			selected = append(selected, f)
-		}
-	}
-	files = selected
 
 	for _, src := range files {
 		name := strings.TrimSuffix(filepath.Base(src), ".scala")


### PR DESCRIPTION
## Summary
- extend scala Print to handle class definitions
- expose InspectWithOptions in scala inspect API
- broaden Scala print_test to run on all examples

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688aedd8d37c8320876fcebefddaf3f7