### PR TITLE
Add pretty printer for scheme

### DIFF
--- a/aster/x/scheme/inspect.go
+++ b/aster/x/scheme/inspect.go
@@ -3,15 +3,42 @@
 package scheme
 
 import (
+	"encoding/json"
+
 	sitter "github.com/tree-sitter/go-tree-sitter"
 	tsscheme "github.com/tree-sitter/tree-sitter-scheme/bindings/go"
 )
 
+// Option controls how the AST is generated. When Positions is true the
+// positional fields of the produced nodes are populated, otherwise they remain
+// zero and are omitted from the JSON output.
+type Option struct {
+	Positions bool
+}
+
+// MarshalJSON implements json.Marshaler for Program to ensure stable output
+// ordering when serialising test data.
+func (p *Program) MarshalJSON() ([]byte, error) {
+	type Alias Program
+	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(p)})
+}
+
 // Inspect parses Scheme source code using tree-sitter and returns a Program
-// describing its syntax tree.
+// describing its syntax tree. Position information is omitted by default; use
+// InspectWithOption to enable it.
 func Inspect(src string) (*Program, error) {
+	return InspectWithOption(src, Option{})
+}
+
+// InspectWithOption behaves like Inspect but allows callers to control whether
+// positional information is included in the resulting AST.
+func InspectWithOption(src string, opt Option) (*Program, error) {
 	p := sitter.NewParser()
 	p.SetLanguage(sitter.NewLanguage(tsscheme.Language()))
-	tree := p.Parse([]byte(src), nil)
-	return convertProgram(tree.RootNode(), []byte(src)), nil
+	data := []byte(src)
+	prev := IncludePos
+	IncludePos = opt.Positions
+	defer func() { IncludePos = prev }()
+	tree := p.Parse(data, nil)
+	return convertProgram(tree.RootNode(), data), nil
 }

--- a/aster/x/scheme/print_test.go
+++ b/aster/x/scheme/print_test.go
@@ -29,7 +29,7 @@ func ensureScheme(t *testing.T) {
 func TestPrint_Golden(t *testing.T) {
 	ensureScheme(t)
 	root := repoRoot(t)
-	srcDir := filepath.Join(root, "tests", "human", "x", "scheme")
+	srcDir := filepath.Join(root, "tests", "transpiler", "x", "scheme")
 	outDir := filepath.Join(root, "tests", "aster", "x", "scheme")
 	os.MkdirAll(outDir, 0o755)
 
@@ -41,7 +41,8 @@ func TestPrint_Golden(t *testing.T) {
 
 	var selected []string
 	for _, f := range files {
-		if filepath.Base(f) == "two-sum.scm" {
+		base := filepath.Base(f)
+		if base == "cross_join.scm" {
 			selected = append(selected, f)
 		}
 	}

--- a/tests/aster/x/scheme/cross_join.scm
+++ b/tests/aster/x/scheme/cross_join.scm
@@ -1,0 +1,142 @@
+;; Generated on 2025-07-25 08:58 +0700
+(import
+  (only
+    (scheme base) call/cc when list-ref list-set! list))
+(import
+  (scheme time))
+(import
+  (chibi string))
+(import
+  (only
+    (scheme char) string-upcase string-downcase))
+(import
+  (srfi 69))
+(define
+  (to-str x)
+  (cond
+    ((pair? x)
+      (string-append "["
+        (string-join
+          (map to-str x) ", ") "]"))
+    ((string? x) x)
+    ((boolean? x)
+      (if x "1" "0"))
+    (else
+      (number->string x))))
+(define
+  (upper s)
+  (string-upcase s))
+(define
+  (lower s)
+  (string-downcase s))
+(define
+  (fmod a b)
+  (- a
+    (*
+      (floor
+        (/ a b)) b)))
+(define customers
+  (list
+    (alist->hash-table
+      (list
+        (cons "id" 1)
+        (cons "name" "Alice")))
+    (alist->hash-table
+      (list
+        (cons "id" 2)
+        (cons "name" "Bob")))
+    (alist->hash-table
+      (list
+        (cons "id" 3)
+        (cons "name" "Charlie")))))
+(define orders
+  (list
+    (alist->hash-table
+      (list
+        (cons "id" 100)
+        (cons "customerId" 1)
+        (cons "total" 250)))
+    (alist->hash-table
+      (list
+        (cons "id" 101)
+        (cons "customerId" 2)
+        (cons "total" 125)))
+    (alist->hash-table
+      (list
+        (cons "id" 102)
+        (cons "customerId" 1)
+        (cons "total" 300)))))
+(define result
+  (let
+    ((res14
+        (list)))
+    (begin
+      (for-each
+        (lambda
+          (o)
+          (for-each
+            (lambda
+              (c)
+              (set! res14
+                (append res14
+                  (list
+                    (alist->hash-table
+                      (list
+                        (cons "orderId"
+                          (hash-table-ref o "id"))
+                        (cons "orderCustomerId"
+                          (hash-table-ref o "customerId"))
+                        (cons "pairedCustomerName"
+                          (hash-table-ref c "name"))
+                        (cons "orderTotal"
+                          (hash-table-ref o "total")))))))) customers)) orders) res14)))
+(display
+  (to-str "--- Cross Join: All order-customer pairs ---"))
+(newline)
+(call/cc
+  (lambda
+    (break16)
+    (letrec
+      ((loop15
+          (lambda
+            (xs)
+            (if
+              (null? xs)
+              (quote nil)
+              (begin
+                (let
+                  ((entry
+                      (car xs)))
+                  (begin
+                    (display
+                      (to-str "Order"))
+                    (display " ")
+                    (display
+                      (to-str
+                        (hash-table-ref entry "orderId")))
+                    (display " ")
+                    (display
+                      (to-str "(customerId:"))
+                    (display " ")
+                    (display
+                      (to-str
+                        (hash-table-ref entry "orderCustomerId")))
+                    (display " ")
+                    (display
+                      (to-str ", total: $"))
+                    (display " ")
+                    (display
+                      (to-str
+                        (hash-table-ref entry "orderTotal")))
+                    (display " ")
+                    (display
+                      (to-str ")
+ paired with"))
+                    (display " ")
+                    (display
+                      (to-str
+                        (hash-table-ref entry "pairedCustomerName")))
+                    (newline)))
+                (loop15
+                  (cdr xs)))))))
+      (loop15 result))))

--- a/tests/aster/x/scheme/two-sum.scm
+++ b/tests/aster/x/scheme/two-sum.scm
@@ -1,6 +1,31 @@
-(define (two-sum nums target) (let loop ((i 0)) (if (= i (length nums)) '(-1 -1) (let inner ((j (+ i 1))) (cond ((= j (length nums)) (loop (+ i 1))) ((= (+ (list-ref nums i) (list-ref nums j)) target) (list i j)) (else (inner (+ j 1))))))))
-(define result (two-sum '(2 7 11 15) 9))
-(display (list-ref result 0))
+(define
+  (two-sum nums target)
+  (let loop
+    ((i 0))
+    (if
+      (= i
+        (length nums)) '(-1 -1)
+      (let inner
+        ((j
+            (+ i 1)))
+        (cond
+          ((= j
+              (length nums))
+            (loop
+              (+ i 1)))
+          ((=
+              (+
+                (list-ref nums i)
+                (list-ref nums j)) target)
+            (list i j))
+          (else
+            (inner
+              (+ j 1))))))))
+(define result
+  (two-sum '(2 7 11 15) 9))
+(display
+  (list-ref result 0))
 (newline)
-(display (list-ref result 1))
+(display
+  (list-ref result 1))
 (newline)


### PR DESCRIPTION
## Summary
- support printing Scheme AST with indentation
- update Scheme inspect to handle options and marshal JSON
- generate Scheme cross_join output file and regenerate two-sum example
- update Scheme print golden test to read transpiler sources

## Testing
- `go test -tags slow ./aster/x/scheme -run TestPrint_Golden -update -v` *(fails: scheme not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688aede26a7883208e748579287c1b6a