### PR TITLE
Improve Swift AST printing

### DIFF
--- a/aster/x/swift/inspect.go
+++ b/aster/x/swift/inspect.go
@@ -18,20 +18,23 @@ type Program struct {
 // returned AST includes positional information.
 type Option struct {
 	Positions bool
+	Comments  bool
 }
 
 // Inspect parses the given Swift source code using tree-sitter and returns
 // a Program describing its syntax tree.
 func Inspect(src string, opts ...Option) (*Program, error) {
 	var withPos bool
+	var withComments bool
 	if len(opts) > 0 {
 		withPos = opts[0].Positions
+		withComments = opts[0].Comments
 	}
 	p := sitter.NewParser()
 	p.SetLanguage(sitter.NewLanguage(tsswift.Language()))
 	b := []byte(src)
 	tree := p.Parse(b, nil)
-	return &Program{File: ConvertFile(tree.RootNode(), b, withPos)}, nil
+	return &Program{File: ConvertFile(tree.RootNode(), b, withPos, withComments)}, nil
 }
 
 // MarshalJSON implements json.Marshaler for Program to ensure stable output.

--- a/aster/x/swift/inspect_test.go
+++ b/aster/x/swift/inspect_test.go
@@ -59,7 +59,7 @@ func TestInspect_Golden(t *testing.T) {
 				t.Logf("skip %s due to compile error", name)
 				return
 			}
-			prog, err := swift.Inspect(string(data))
+			prog, err := swift.Inspect(string(data), swift.Option{Comments: true})
 			if err != nil {
 				t.Logf("skip %s: %v", name, err)
 				return

--- a/aster/x/swift/print.go
+++ b/aster/x/swift/print.go
@@ -197,6 +197,22 @@ func writeExpr(b *bytes.Buffer, n *Node, indent int) {
 			writeExpr(b, c, indent)
 		}
 		b.WriteByte(']')
+	case "dictionary_literal":
+		b.WriteByte('[')
+		for i := 0; i < len(n.Children); i += 2 {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			if i+1 >= len(n.Children) {
+				break
+			}
+			key := n.Children[i]
+			val := n.Children[i+1]
+			writeExpr(b, key, indent)
+			b.WriteString(": ")
+			writeExpr(b, val, indent)
+		}
+		b.WriteByte(']')
 	case "tuple_expression":
 		if len(n.Children) == 1 {
 			writeExpr(b, n.Children[0], indent)
@@ -241,6 +257,13 @@ func writeExpr(b *bytes.Buffer, n *Node, indent int) {
 			writeType(b, n.Children[1])
 			b.WriteByte(')')
 		}
+	case "lambda_literal":
+		b.WriteString("{\n")
+		for _, c := range n.Children {
+			writeStmt(b, c, indent+1)
+		}
+		b.WriteString(indentStr(indent))
+		b.WriteByte('}')
 	case "navigation_expression":
 		if len(n.Children) == 2 {
 			writeExpr(b, n.Children[0], indent)

--- a/aster/x/swift/print_test.go
+++ b/aster/x/swift/print_test.go
@@ -102,7 +102,7 @@ func TestPrint_Golden(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read src: %v", err)
 			}
-			prog, err := swift.Inspect(string(data))
+			prog, err := swift.Inspect(string(data), swift.Option{Comments: true})
 			if err != nil {
 				t.Fatalf("inspect: %v", err)
 			}


### PR DESCRIPTION
## Summary
- update Swift AST inspection options
- support dictionary and lambda literals when printing Swift AST
- handle comment option in Inspect
- update Swift print tests to use the new option

## Testing
- `go test -tags slow ./aster/x/swift -run TestPrint_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_688aedee6638832098006ce24b9b3204