### PR TITLE
Improve C++ AST printing

### DIFF
--- a/aster/x/cpp/ast.go
+++ b/aster/x/cpp/ast.go
@@ -96,6 +96,17 @@ func convert(n *sitter.Node, src []byte, opts Options) *Node {
 			opBytes := src[left.EndByte():right.StartByte()]
 			node.Text = strings.TrimSpace(string(opBytes))
 		}
+	} else if n.Kind() == "update_expression" && n.NamedChildCount() == 1 {
+		child := n.NamedChild(0)
+		if child != nil {
+			before := strings.TrimSpace(string(src[n.StartByte():child.StartByte()]))
+			after := strings.TrimSpace(string(src[child.EndByte():n.EndByte()]))
+			if before != "" {
+				node.Text = "pre" + before
+			} else {
+				node.Text = "post" + after
+			}
+		}
 	}
 
 	for i := uint(0); i < n.NamedChildCount(); i++ {

--- a/aster/x/cpp/print.go
+++ b/aster/x/cpp/print.go
@@ -274,10 +274,26 @@ func writeExpr(b *bytes.Buffer, n *Node, indent int) {
 		}
 		writeBinaryOp(b, n, indent, op)
 	case "update_expression":
-		if len(n.Children) > 0 {
-			writeExpr(b, n.Children[0], indent)
+		op := strings.TrimSpace(n.Text)
+		prefix := false
+		if strings.HasPrefix(op, "pre") {
+			prefix = true
+			op = strings.TrimPrefix(op, "pre")
+		} else if strings.HasPrefix(op, "post") {
+			op = strings.TrimPrefix(op, "post")
 		}
-		b.WriteString("++")
+		if op == "" {
+			op = "++"
+		}
+		if len(n.Children) > 0 {
+			if prefix {
+				b.WriteString(op)
+				writeExpr(b, n.Children[0], indent)
+			} else {
+				writeExpr(b, n.Children[0], indent)
+				b.WriteString(op)
+			}
+		}
 	default:
 		b.WriteString(n.Kind)
 	}

--- a/aster/x/cpp/print_test.go
+++ b/aster/x/cpp/print_test.go
@@ -100,8 +100,10 @@ func TestPrint_Golden(t *testing.T) {
 				t.Fatalf("print: %v", err)
 			}
 			outPath := filepath.Join(outDir, name+".cpp")
-			if err := os.WriteFile(outPath, []byte(out), 0o644); err != nil {
-				t.Fatalf("write out: %v", err)
+			if shouldUpdate() {
+				if err := os.WriteFile(outPath, []byte(out), 0o644); err != nil {
+					t.Fatalf("write out: %v", err)
+				}
 			}
 			bin := filepath.Join(outDir, name)
 			if outb, err := exec.Command("g++", outPath, "-std=c++20", "-o", bin).CombinedOutput(); err != nil {
@@ -122,8 +124,10 @@ func TestPrint_Golden(t *testing.T) {
 				t.Fatalf("run original: %v\n%s", err, want)
 			}
 			outFile := filepath.Join(outDir, name+".out")
-			if err := os.WriteFile(outFile, got, 0o644); err != nil {
-				t.Fatalf("write out file: %v", err)
+			if shouldUpdate() {
+				if err := os.WriteFile(outFile, got, 0o644); err != nil {
+					t.Fatalf("write out file: %v", err)
+				}
 			}
 			if string(got) != string(want) {
 				t.Fatalf("output mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)

--- a/tests/aster/x/cpp/two-sum.cpp.json
+++ b/tests/aster/x/cpp/two-sum.cpp.json
@@ -188,6 +188,7 @@
                   },
                   {
                     "kind": "update_expression",
+                    "text": "post++",
                     "children": [
                       {
                         "kind": "identifier",
@@ -254,6 +255,7 @@
                           },
                           {
                             "kind": "update_expression",
+                            "text": "post++",
                             "children": [
                               {
                                 "kind": "identifier",


### PR DESCRIPTION
## Summary
- enrich AST conversion with prefix/postfix update information
- use new information in the C++ printer
- only write golden outputs when requested
- update golden JSON for two-sum

## Testing
- `go test ./aster/x/cpp -run TestPrint_Golden -update -count=1 -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_688af60d631c83208e45f0a27f717a68