### PR TITLE
Improve C# aster printing with operator tokens

### DIFF
--- a/aster/x/cs/ast.go
+++ b/aster/x/cs/ast.go
@@ -54,6 +54,17 @@ func convert(n *sitter.Node, src []byte) *Node {
 		return nil
 	}
 	node := &Node{Kind: n.Kind()}
+
+	// Capture operator tokens for expressions where tree-sitter stores the
+	// symbol in a separate field. This allows the printer to faithfully
+	// reconstruct the original source code.
+	switch n.Kind() {
+	case "binary_expression", "assignment_expression", "prefix_unary_expression",
+		"postfix_unary_expression":
+		if op := n.ChildByFieldName("operator"); op != nil {
+			node.Text = op.Utf8Text(src)
+		}
+	}
 	if IncludePositions {
 		sp := n.StartPosition()
 		ep := n.EndPosition()

--- a/aster/x/cs/print.go
+++ b/aster/x/cs/print.go
@@ -312,13 +312,21 @@ func writeExpr(b *bytes.Buffer, n *Node, indentLevel int) {
 	case "binary_expression":
 		if len(n.Children) == 2 {
 			writeExpr(b, n.Children[0], indentLevel)
+			op := n.Text
+			if op == "" {
+				op = "+"
+			}
 			b.WriteByte(' ')
-			b.WriteString(detectOperator(n))
+			b.WriteString(op)
 			b.WriteByte(' ')
 			writeExpr(b, n.Children[1], indentLevel)
 		}
 	case "prefix_unary_expression":
-		b.WriteByte('-')
+		op := n.Text
+		if op == "" {
+			op = "-"
+		}
+		b.WriteString(op)
 		if len(n.Children) > 0 {
 			writeExpr(b, n.Children[0], indentLevel)
 		}
@@ -326,7 +334,11 @@ func writeExpr(b *bytes.Buffer, n *Node, indentLevel int) {
 		if len(n.Children) > 0 {
 			writeExpr(b, n.Children[0], indentLevel)
 		}
-		b.WriteString("++")
+		op := n.Text
+		if op == "" {
+			op = "++"
+		}
+		b.WriteString(op)
 	case "element_access_expression":
 		if len(n.Children) >= 2 {
 			writeExpr(b, n.Children[0], indentLevel)
@@ -348,18 +360,4 @@ func writeExpr(b *bytes.Buffer, n *Node, indentLevel int) {
 			writeExpr(b, c, indentLevel)
 		}
 	}
-}
-
-func detectOperator(n *Node) string {
-	if len(n.Children) != 2 {
-		return "+"
-	}
-	r := n.Children[1]
-	if r.Kind == "identifier" && r.Text == "n" {
-		return "<"
-	}
-	if r.Kind == "identifier" && r.Text == "target" {
-		return "=="
-	}
-	return "+"
 }

--- a/tests/aster/x/cs/two-sum.cs.json
+++ b/tests/aster/x/cs/two-sum.cs.json
@@ -242,6 +242,7 @@
                           },
                           {
                             "kind": "binary_expression",
+                            "text": "\u003c",
                             "children": [
                               {
                                 "kind": "identifier",
@@ -287,6 +288,7 @@
                                             "children": [
                                               {
                                                 "kind": "binary_expression",
+                                                "text": "+",
                                                 "children": [
                                                   {
                                                     "kind": "identifier",
@@ -306,6 +308,7 @@
                                   },
                                   {
                                     "kind": "binary_expression",
+                                    "text": "\u003c",
                                     "children": [
                                       {
                                         "kind": "identifier",
@@ -337,12 +340,14 @@
                                             "children": [
                                               {
                                                 "kind": "binary_expression",
+                                                "text": "==",
                                                 "children": [
                                                   {
                                                     "kind": "parenthesized_expression",
                                                     "children": [
                                                       {
                                                         "kind": "binary_expression",
+                                                        "text": "+",
                                                         "children": [
                                                           {
                                                             "kind": "element_access_expression",


### PR DESCRIPTION
## Summary
- capture operator tokens in C# AST conversion
- use recorded operators when printing C# code
- regenerate golden `two-sum.cs.json`

## Testing
- `UPDATE_GOLDEN=1 go test -run TestPrint_Golden -count=1 -tags slow ./aster/x/cs`
- `go test ./aster/x/cs -run TestPrint_Golden -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_688af62a479083208b2f5f90321b33f4