### PR TITLE
Improve clj printer

### DIFF
--- a/aster/x/clj/print.go
+++ b/aster/x/clj/print.go
@@ -53,6 +53,27 @@ func writeNode(b *bytes.Buffer, n *Node) {
 			b.WriteByte(')')
 			return
 		}
+		// Print common reader macros when their canonical form is present
+		if len(n.Children) == 2 && n.Children[0].Kind == "symbol" {
+			switch n.Children[0].Text {
+			case "quote":
+				b.WriteByte('\'')
+				writeNode(b, n.Children[1])
+				return
+			case "quasiquote":
+				b.WriteByte('`')
+				writeNode(b, n.Children[1])
+				return
+			case "unquote":
+				b.WriteByte('~')
+				writeNode(b, n.Children[1])
+				return
+			case "unquote-splicing":
+				b.WriteString("~@")
+				writeNode(b, n.Children[1])
+				return
+			}
+		}
 		b.WriteByte('(')
 		for i, c := range n.Children {
 			if i > 0 {

--- a/tests/aster/x/clj/two-sum.clj
+++ b/tests/aster/x/clj/two-sum.clj
@@ -1,5 +1,5 @@
 (ns main (:refer-clojure :exclude [twoSum]))
-(require (quote clojure.set))
+(require 'clojure.set)
 (defn twoSum [nums target] (def n (count nums)) (dotimes [i n] (doseq [j (range (+ i 1) n)] (when (= (+ (nth nums i) (nth nums j)) target) [i j]))) [(- 1) (- 1)])
 (def result (twoSum [2 7 11 15] 9))
 (defn -main [] (println (nth result 0)) (println (nth result 1)))


### PR DESCRIPTION
## Summary
- support common reader macros in the Clojure printer
- regenerate the printed `two-sum.clj` golden file

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688af634ecac83208d38031bc70eb840