### PR TITLE
Add MarshalJSON for Erlang Program

### DIFF
--- a/aster/x/erlang/inspect.go
+++ b/aster/x/erlang/inspect.go
@@ -4,6 +4,7 @@ package erlang
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	sitter "github.com/tree-sitter/go-tree-sitter"
@@ -14,6 +15,12 @@ import (
 // Program represents a parsed Erlang source file.
 type Program struct {
 	Root *SourceFile `json:"root"`
+}
+
+// MarshalJSON implements json.Marshaler for Program to ensure stable output.
+func (p *Program) MarshalJSON() ([]byte, error) {
+	type Alias Program
+	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(p)})
 }
 
 // InspectWithOption parses Erlang source code using tree-sitter and returns a Program.


### PR DESCRIPTION
## Summary
- implement MarshalJSON for erlang Program so AST output is stable

## Testing
- `go test ./aster/x/erlang -tags slow -run TestPrint_Golden`


------
https://chatgpt.com/codex/tasks/task_e_688af6c47a448320b5bfde1e9d15ff1a