### PR TITLE
Update OCaml AST to use pointers

### DIFF
--- a/aster/x/ocaml/ast.go
+++ b/aster/x/ocaml/ast.go
@@ -18,13 +18,13 @@ type Options struct {
 // meaningful values keep their text to minimise the resulting JSON.
 // Source positions include both line and column information.
 type Node struct {
-	Kind     string `json:"kind"`
-	Text     string `json:"text,omitempty"`
-	Start    int    `json:"start,omitempty"`
-	StartCol int    `json:"startCol,omitempty"`
-	End      int    `json:"end,omitempty"`
-	EndCol   int    `json:"endCol,omitempty"`
-	Children []Node `json:"children,omitempty"`
+	Kind     string  `json:"kind"`
+	Text     string  `json:"text,omitempty"`
+	Start    int     `json:"start,omitempty"`
+	StartCol int     `json:"startCol,omitempty"`
+	End      int     `json:"end,omitempty"`
+	EndCol   int     `json:"endCol,omitempty"`
+	Children []*Node `json:"children,omitempty"`
 }
 
 // File is the root syntactic element of an OCaml source file.
@@ -114,7 +114,7 @@ func convert(n *sitter.Node, src []byte, pos bool) *Node {
 	for i := 0; i < int(n.NamedChildCount()); i++ {
 		child := convert(n.NamedChild(uint(i)), src, pos)
 		if child != nil {
-			node.Children = append(node.Children, *child)
+			node.Children = append(node.Children, child)
 		}
 	}
 

--- a/aster/x/ocaml/print.go
+++ b/aster/x/ocaml/print.go
@@ -24,7 +24,7 @@ func Print(p *Program) (string, error) {
 
 func writeCompilationUnit(b *bytes.Buffer, n *Node, indent int) {
 	for i := range n.Children {
-		writeStmt(b, &n.Children[i], indent)
+		writeStmt(b, n.Children[i], indent)
 	}
 }
 
@@ -37,7 +37,7 @@ func writeStmt(b *bytes.Buffer, n *Node, indent int) {
 		b.WriteByte('\n')
 	case "value_definition":
 		b.WriteString(ind)
-		writeValueDefinition(b, &n.Children[0], indent)
+		writeValueDefinition(b, n.Children[0], indent)
 		b.WriteByte('\n')
 	default:
 		b.WriteString(ind)
@@ -62,11 +62,11 @@ func writeLetBinding(b *bytes.Buffer, n *Node, indent int) {
 	}
 	for idx < len(n.Children) && n.Children[idx].Kind == "parameter" {
 		b.WriteByte(' ')
-		writeParameter(b, &n.Children[idx])
+		writeParameter(b, n.Children[idx])
 		idx++
 	}
 	if idx < len(n.Children) {
-		expr := &n.Children[idx]
+		expr := n.Children[idx]
 		switch expr.Kind {
 		case "let_expression", "sequence_expression", "for_expression", "if_expression":
 			b.WriteString(" =\n")
@@ -80,7 +80,7 @@ func writeLetBinding(b *bytes.Buffer, n *Node, indent int) {
 
 func writeParameter(b *bytes.Buffer, n *Node) {
 	if len(n.Children) > 0 {
-		writeExpr(b, &n.Children[0], 0)
+		writeExpr(b, n.Children[0], 0)
 	}
 }
 
@@ -93,14 +93,14 @@ func writeExpr(b *bytes.Buffer, n *Node, indent int) {
 			if i > 0 {
 				b.WriteByte('.')
 			}
-			writeExpr(b, &c, indent)
+			writeExpr(b, c, indent)
 		}
 	case "module_path":
 		for i, c := range n.Children {
 			if i > 0 {
 				b.WriteByte('.')
 			}
-			writeExpr(b, &c, indent)
+			writeExpr(b, c, indent)
 		}
 	case "module_name":
 		b.WriteString(n.Text)
@@ -121,14 +121,16 @@ func writeExpr(b *bytes.Buffer, n *Node, indent int) {
 			if i > 0 {
 				b.WriteByte(' ')
 			}
-			writeExpr(b, &c, indent)
+			writeExpr(b, c, indent)
 		}
 	case "let_expression":
 		if len(n.Children) == 2 {
 			b.WriteString(strings.Repeat("  ", indent))
-			writeValueDefinition(b, &n.Children[0].Children[0], indent)
+			if len(n.Children[0].Children) > 0 {
+				writeValueDefinition(b, n.Children[0].Children[0], indent)
+			}
 			b.WriteString(" in\n")
-			writeExpr(b, &n.Children[1], indent)
+			writeExpr(b, n.Children[1], indent)
 		}
 	case "list_expression":
 		b.WriteByte('[')
@@ -136,7 +138,7 @@ func writeExpr(b *bytes.Buffer, n *Node, indent int) {
 			if i > 0 {
 				b.WriteString("; ")
 			}
-			writeExpr(b, &c, indent)
+			writeExpr(b, c, indent)
 		}
 		b.WriteByte(']')
 	case "parenthesized_expression":
@@ -145,39 +147,39 @@ func writeExpr(b *bytes.Buffer, n *Node, indent int) {
 			if i > 0 {
 				b.WriteString("; ")
 			}
-			writeExpr(b, &c, indent)
+			writeExpr(b, c, indent)
 		}
 		b.WriteByte(')')
 	case "sign_expression":
 		if len(n.Children) == 2 {
-			writeExpr(b, &n.Children[0], indent)
-			writeExpr(b, &n.Children[1], indent)
+			writeExpr(b, n.Children[0], indent)
+			writeExpr(b, n.Children[1], indent)
 		}
 	case "prefix_expression":
 		if len(n.Children) == 2 {
-			writeExpr(b, &n.Children[0], indent)
-			writeExpr(b, &n.Children[1], indent)
+			writeExpr(b, n.Children[0], indent)
+			writeExpr(b, n.Children[1], indent)
 		}
 	case "infix_expression":
 		if len(n.Children) == 3 {
-			writeExpr(b, &n.Children[0], indent)
+			writeExpr(b, n.Children[0], indent)
 			b.WriteByte(' ')
-			writeExpr(b, &n.Children[1], indent)
+			writeExpr(b, n.Children[1], indent)
 			b.WriteByte(' ')
-			writeExpr(b, &n.Children[2], indent)
+			writeExpr(b, n.Children[2], indent)
 		}
 	case "for_expression":
 		if len(n.Children) >= 4 {
 			b.WriteString(strings.Repeat("  ", indent))
 			b.WriteString("for ")
-			writeExpr(b, &n.Children[0], indent)
+			writeExpr(b, n.Children[0], indent)
 			b.WriteString(" = ")
-			writeExpr(b, &n.Children[1], indent)
+			writeExpr(b, n.Children[1], indent)
 			b.WriteString(" to ")
-			writeExpr(b, &n.Children[2], indent)
+			writeExpr(b, n.Children[2], indent)
 			b.WriteString(" do\n")
 			if len(n.Children) > 3 {
-				writeExpr(b, &n.Children[3], indent+1)
+				writeExpr(b, n.Children[3], indent+1)
 				b.WriteByte('\n')
 			}
 			b.WriteString(strings.Repeat("  ", indent))
@@ -189,7 +191,7 @@ func writeExpr(b *bytes.Buffer, n *Node, indent int) {
 				b.WriteByte('\n')
 				b.WriteString(strings.Repeat("  ", indent))
 			}
-			writeExpr(b, &c, indent)
+			writeExpr(b, c, indent)
 		}
 	case "sequence_expression":
 		for i, c := range n.Children {
@@ -197,29 +199,29 @@ func writeExpr(b *bytes.Buffer, n *Node, indent int) {
 				b.WriteString(";\n")
 				b.WriteString(strings.Repeat("  ", indent))
 			}
-			writeExpr(b, &c, indent)
+			writeExpr(b, c, indent)
 		}
 	case "if_expression":
 		if len(n.Children) >= 2 {
 			b.WriteString(strings.Repeat("  ", indent))
 			b.WriteString("if ")
-			writeExpr(b, &n.Children[0], indent)
+			writeExpr(b, n.Children[0], indent)
 			b.WriteString(" then ")
-			writeExpr(b, &n.Children[1], indent)
+			writeExpr(b, n.Children[1], indent)
 		}
 	case "then_clause":
 		for _, c := range n.Children {
 			if c.Kind == "sequence_expression" {
 				b.WriteByte('(')
-				writeExpr(b, &c, indent)
+				writeExpr(b, c, indent)
 				b.WriteByte(')')
 			} else {
-				writeExpr(b, &c, indent)
+				writeExpr(b, c, indent)
 			}
 		}
 	case "constructor_path":
 		for _, c := range n.Children {
-			writeExpr(b, &c, indent)
+			writeExpr(b, c, indent)
 		}
 	case "constructor_name":
 		b.WriteString(n.Text)


### PR DESCRIPTION
## Summary
- refactor OCaml AST nodes to hold child pointers
- adjust Inspect conversion to build pointer-based tree
- update printer to work with pointer nodes

## Testing
- `go test ./aster/x/ocaml -run TestPrint_Golden -tags=slow`


------
https://chatgpt.com/codex/tasks/task_e_688af8b5ad4883209c4fc998dd1f5e98