### PR TITLE
Improve Prolog printer with infix operators

### DIFF
--- a/aster/x/prolog/print.go
+++ b/aster/x/prolog/print.go
@@ -125,6 +125,44 @@ func writeTerm(b *strings.Builder, n *Node, indent int) {
 		} else {
 			writeFunctor(b, n, indent)
 		}
+	case "=":
+		if len(n.Children) == 2 {
+			writeTerm(b, n.Children[0], indent)
+			b.WriteString(" = ")
+			writeTerm(b, n.Children[1], indent)
+		} else {
+			writeFunctor(b, n, indent)
+		}
+	case "is":
+		if len(n.Children) == 2 {
+			writeTerm(b, n.Children[0], indent)
+			b.WriteString(" is ")
+			writeTerm(b, n.Children[1], indent)
+		} else {
+			writeFunctor(b, n, indent)
+		}
+	case "+":
+		if len(n.Children) == 2 {
+			writeTerm(b, n.Children[0], indent)
+			b.WriteString(" + ")
+			writeTerm(b, n.Children[1], indent)
+		} else if len(n.Children) == 1 {
+			b.WriteByte('+')
+			writeTerm(b, n.Children[0], indent)
+		} else {
+			writeFunctor(b, n, indent)
+		}
+	case "-":
+		if len(n.Children) == 2 {
+			writeTerm(b, n.Children[0], indent)
+			b.WriteString(" - ")
+			writeTerm(b, n.Children[1], indent)
+		} else if len(n.Children) == 1 {
+			b.WriteByte('-')
+			writeTerm(b, n.Children[0], indent)
+		} else {
+			writeFunctor(b, n, indent)
+		}
 	case ",":
 		for i, c := range n.Children {
 			if i > 0 {

--- a/tests/aster/x/prolog/two-sum.prolog
+++ b/tests/aster/x/prolog/two-sum.prolog
@@ -2,7 +2,7 @@
 get_item(Container, Key, Val) :-
         is_dict(Container),
             !,
-            string(Key) -> atom_string(A, Key); =(A, Key),
+            string(Key) -> atom_string(A, Key); A = Key,
         get_dict(A, Container, Val)
 get_item(Container, Index, Val) :-
         string(Container),
@@ -12,14 +12,14 @@ get_item(Container, Index, Val) :-
 get_item(List, Index, Val) :-
     nth0(Index, List, Val)
 twosum(Nums, Target, Res) :-
-    catch(length(Nums, _V0), =(N, _V0), is(_V1, -(N, 1)), catch(between(0, _V1, I), catch(is(_V2, +(I, 1)), is(_V3, -(N, 1)), catch(between(_V2, _V3, J), catch(get_item(Nums, I, _V4), get_item(Nums, J, _V5), is(_V6, +(_V4, _V5)), =(_V6, Target) -> throw(return([I, J])); true, true, continue, true), fail; true, break, true), true, true, continue, true), fail; true, break, true), true, true, return(_V7), =(Res, _V7))
+    catch(length(Nums, _V0), N = _V0, _V1 is N - 1, catch(between(0, _V1, I), catch(_V2 is I + 1, _V3 is N - 1, catch(between(_V2, _V3, J), catch(get_item(Nums, I, _V4), get_item(Nums, J, _V5), _V6 is _V4 + _V5, _V6 = Target -> throw(return([I, J])); true, true, continue, true), fail; true, break, true), true, true, continue, true), fail; true, break, true), true, true, return(_V7), Res = _V7)
 twosum(Nums, Target, Res) :-
-        is(_V8, -(1)),
-            is(_V9, -(1)),
-        =(Res, [_V8, _V9])
+        _V8 is -1,
+            _V9 is -1,
+        Res = [_V8, _V9]
 main :-
         twosum([2, 7, 11, 15], 9, _V10),
-            =(Result, _V10),
+            Result = _V10,
             get_item(Result, 0, _V11),
             write(_V11),
             nl,


### PR DESCRIPTION
## Summary
- support infix notation when printing Prolog AST
- update two-sum.prolog golden output to new format

## Testing
- `go test ./aster/x/prolog -run TestPrint_Golden -tags slow -count=1 -v` *(fails: swipl not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688af938325883209a64c28361519084