### PR TITLE
Add JSON marshal helper for Zig AST

### DIFF
--- a/aster/x/zig/inspect.go
+++ b/aster/x/zig/inspect.go
@@ -3,15 +3,22 @@
 package zig
 
 import (
-	"context"
+        "context"
+        "encoding/json"
 
-	tsz "github.com/tree-sitter-grammars/tree-sitter-zig/bindings/go"
-	sitter "github.com/tree-sitter/go-tree-sitter"
+        tsz "github.com/tree-sitter-grammars/tree-sitter-zig/bindings/go"
+        sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 // Program describes a parsed Zig source file.
 type Program struct {
-	Root *SourceFile `json:"root"`
+        Root *SourceFile `json:"root"`
+}
+
+// MarshalJSON implements json.Marshaler for Program to provide stable output.
+func (p *Program) MarshalJSON() ([]byte, error) {
+        type Alias Program
+        return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(p)})
 }
 
 // Inspect parses Zig source code using tree-sitter.


### PR DESCRIPTION
## Summary
- expose encoding/json in zig inspect package
- implement Program.MarshalJSON helper

## Testing
- `go test -tags=slow ./aster/x/zig -run TestPrint -count=1` *(fails: exec: "zig": executable file not found in $PATH)*
- `go test -tags=slow ./aster/x/zig -run TestInspect -count=1` *(fails: missing golden files)*

------
https://chatgpt.com/codex/tasks/task_e_688aff95054483208a48ba3c43830680