### PR TITLE
Improve Haskell AST printer

### DIFF
--- a/aster/x/haskell/ast.go
+++ b/aster/x/haskell/ast.go
@@ -99,8 +99,17 @@ func convert(n *sitter.Node, src []byte, opt Option) *Node {
 		return node
 	}
 
-	for i := uint(0); i < n.NamedChildCount(); i++ {
-		child := convert(n.NamedChild(i), src, opt)
+	for i := uint(0); i < n.ChildCount(); i++ {
+		c := n.Child(i)
+		if !c.IsNamed() {
+			kind := c.Kind()
+			if kind == "hiding" {
+				node.Children = append(node.Children, Node{Kind: kind, Text: c.Utf8Text(src)})
+				continue
+			}
+			continue
+		}
+		child := convert(c, src, opt)
 		if child != nil {
 			node.Children = append(node.Children, *child)
 		}

--- a/aster/x/haskell/print.go
+++ b/aster/x/haskell/print.go
@@ -47,6 +47,10 @@ func writeNode(b *bytes.Buffer, n *Node, indent int) {
 			if i > 0 {
 				b.WriteByte(' ')
 			}
+			if c.Kind == "hiding" {
+				b.WriteString("hiding ")
+				continue
+			}
 			writeNode(b, &c, indent)
 		}
 	case "module":
@@ -202,7 +206,12 @@ func writeNode(b *bytes.Buffer, n *Node, indent int) {
 		}
 		if len(n.Children) >= 2 {
 			b.WriteString(" {")
-			writeNode(b, &n.Children[1], indent)
+			for i, c := range n.Children[1:] {
+				if i > 0 {
+					b.WriteString(", ")
+				}
+				writeNode(b, &c, indent)
+			}
 			b.WriteString("}")
 		}
 	case "fields":

--- a/tests/aster/x/haskell/cross_join.hs.json
+++ b/tests/aster/x/haskell/cross_join.hs.json
@@ -30,6 +30,10 @@
                 ]
               },
               {
+                "kind": "hiding",
+                "text": "hiding"
+              },
+              {
                 "kind": "import_list",
                 "children": [
                   {


### PR DESCRIPTION
## Summary
- enhance Haskell AST conversion to capture `hiding` keyword
- improve printer logic for import statements and record expressions
- regenerate Haskell AST for `cross_join.hs`

## Testing
- `go test ./aster/x/haskell -c -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_688affc14e3483208b11ab27511ad137