### PR TITLE
Enhance scheme printer

### DIFF
--- a/aster/x/scheme/inspect.go
+++ b/aster/x/scheme/inspect.go
@@ -14,6 +14,7 @@ import (
 // zero and are omitted from the JSON output.
 type Option struct {
 	Positions bool
+	Comments  bool
 }
 
 // MarshalJSON implements json.Marshaler for Program to ensure stable output
@@ -27,7 +28,7 @@ func (p *Program) MarshalJSON() ([]byte, error) {
 // describing its syntax tree. Position information is omitted by default; use
 // InspectWithOption to enable it.
 func Inspect(src string) (*Program, error) {
-	return InspectWithOption(src, Option{})
+	return InspectWithOption(src, Option{Comments: true})
 }
 
 // InspectWithOption behaves like Inspect but allows callers to control whether
@@ -40,5 +41,5 @@ func InspectWithOption(src string, opt Option) (*Program, error) {
 	IncludePos = opt.Positions
 	defer func() { IncludePos = prev }()
 	tree := p.Parse(data, nil)
-	return convertProgram(tree.RootNode(), data), nil
+	return convertProgram(tree.RootNode(), data, opt.Comments), nil
 }

--- a/aster/x/scheme/print.go
+++ b/aster/x/scheme/print.go
@@ -66,7 +66,7 @@ func writeExpr(b *bytes.Buffer, n *Node, indent int) {
 		if len(n.Children) > 0 {
 			writeExpr(b, n.Children[0], indent)
 		}
-	case "symbol", "string", "number":
+	case "symbol", "string", "number", "boolean":
 		b.WriteString(n.Text)
 	default:
 		if n.Text != "" {

--- a/aster/x/scheme/print_test.go
+++ b/aster/x/scheme/print_test.go
@@ -39,15 +39,6 @@ func TestPrint_Golden(t *testing.T) {
 	}
 	sort.Strings(files)
 
-	var selected []string
-	for _, f := range files {
-		base := filepath.Base(f)
-		if base == "cross_join.scm" {
-			selected = append(selected, f)
-		}
-	}
-	files = selected
-
 	for _, src := range files {
 		name := strings.TrimSuffix(filepath.Base(src), ".scm")
 		t.Run(name, func(t *testing.T) {
@@ -55,7 +46,7 @@ func TestPrint_Golden(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read src: %v", err)
 			}
-			prog, err := scheme.Inspect(string(data))
+			prog, err := scheme.InspectWithOption(string(data), scheme.Option{Comments: true})
 			if err != nil {
 				t.Fatalf("inspect: %v", err)
 			}


### PR DESCRIPTION
## Summary
- extend scheme AST with Quote and Boolean node aliases
- allow optional comment emission via Inspect options
- print boolean nodes
- run print golden tests over all Scheme fixtures

## Testing
- `go test -tags slow ./aster/x/scheme -run TestPrint_Golden -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688affd5dd3483209c49e097362e42d7