### PR TITLE
Add InspectWithOption for C++ aster

### DIFF
--- a/aster/x/cpp/inspect.go
+++ b/aster/x/cpp/inspect.go
@@ -15,20 +15,22 @@ type Program struct {
 	Root *TranslationUnit `json:"root"`
 }
 
-// Inspect parses the given C++ source code using tree-sitter and
-// returns its Program structure.
-// Inspect parses the given C++ source code using tree-sitter and
-// returns its Program structure. Position information is omitted unless
-// opts.WithPositions is set to true.
+// Inspect parses the given C++ source code and returns a Program.
+// Position information is included when opt.WithPositions is true.
 func Inspect(src string, opts ...Options) (*Program, error) {
+	var opt Options
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+	return InspectWithOption(src, opt)
+}
+
+// InspectWithOption behaves like Inspect but takes an explicit Options value.
+func InspectWithOption(src string, opt Options) (*Program, error) {
 	parser := sitter.NewParser()
 	parser.SetLanguage(sitter.NewLanguage(ts.Language()))
 	tree := parser.ParseCtx(context.Background(), []byte(src), nil)
-	var o Options
-	if len(opts) > 0 {
-		o = opts[0]
-	}
-	root := convert(tree.RootNode(), []byte(src), o)
+	root := convert(tree.RootNode(), []byte(src), opt)
 	if root == nil {
 		return &Program{}, nil
 	}


### PR DESCRIPTION
## Summary
- provide InspectWithOption to match Python aster API

## Testing
- `go test ./aster/x/cpp -tags slow -run TestPrint_Golden`

------
https://chatgpt.com/codex/tasks/task_e_688b0017d7348320b06026747420297b