### PR TITLE
Add option for positions in clj inspect

### DIFF
--- a/aster/x/clj/inspect.go
+++ b/aster/x/clj/inspect.go
@@ -126,6 +126,7 @@ func Inspect(src string) (*Program, error) {
 // additional information should be captured. The returned AST structure is the
 // same regardless of the options provided.
 func InspectWithOption(src string, opt Option) (*Program, error) {
+	IncludePositions = opt.Positions
 	if err := EnsureBabashka(); err != nil {
 		return nil, err
 	}

--- a/aster/x/clj/print.go
+++ b/aster/x/clj/print.go
@@ -10,6 +10,9 @@ func Print(p *Program) (string, error) {
 	if p == nil {
 		return "", fmt.Errorf("nil program")
 	}
+	if len(p.Forms) == 0 {
+		return "", fmt.Errorf("empty program")
+	}
 	var b bytes.Buffer
 	for i, f := range p.Forms {
 		if f == nil {


### PR DESCRIPTION
## Summary
- set `IncludePositions` via Inspect options
- validate program emptiness in `Print`

## Testing
- `go test -tags slow ./aster/x/clj -run TestPrint_Golden -count=1` *(fails: bb not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688b010a4b94832094676788dd684a21