### PR TITLE
Fix C# AST printer

### DIFF
--- a/aster/x/cs/print.go
+++ b/aster/x/cs/print.go
@@ -304,20 +304,29 @@ func writeExpr(b *bytes.Buffer, n *Node, indentLevel int) {
 	switch n.Kind {
 	case "identifier", "integer_literal", "real_literal", "boolean_literal", "implicit_type", "predefined_type", "modifier":
 		b.WriteString(n.Text)
-       case "member_access_expression":
-               if len(n.Children) == 2 {
-                       writeExpr(b, n.Children[0], indentLevel)
-                       b.WriteByte('.')
-                       writeExpr(b, n.Children[1], indentLevel)
-               }
-       case "qualified_name":
-               for i, c := range n.Children {
-                       if i > 0 {
-                               b.WriteByte('.')
-                       }
-                       writeExpr(b, c, indentLevel)
-               }
-       case "invocation_expression":
+	case "string_literal":
+		b.WriteByte('"')
+		for _, c := range n.Children {
+			b.WriteString(c.Text)
+		}
+		if n.Text != "" && len(n.Children) == 0 {
+			b.WriteString(n.Text)
+		}
+		b.WriteByte('"')
+	case "member_access_expression":
+		if len(n.Children) == 2 {
+			writeExpr(b, n.Children[0], indentLevel)
+			b.WriteByte('.')
+			writeExpr(b, n.Children[1], indentLevel)
+		}
+	case "qualified_name":
+		for i, c := range n.Children {
+			if i > 0 {
+				b.WriteByte('.')
+			}
+			writeExpr(b, c, indentLevel)
+		}
+	case "invocation_expression":
 		if len(n.Children) >= 1 {
 			writeExpr(b, n.Children[0], indentLevel)
 			if len(n.Children) > 1 {
@@ -376,6 +385,18 @@ func writeExpr(b *bytes.Buffer, n *Node, indentLevel int) {
 			op := n.Text
 			if op == "" {
 				op = "+"
+			}
+			b.WriteByte(' ')
+			b.WriteString(op)
+			b.WriteByte(' ')
+			writeExpr(b, n.Children[1], indentLevel)
+		}
+	case "assignment_expression":
+		if len(n.Children) == 2 {
+			writeExpr(b, n.Children[0], indentLevel)
+			op := n.Text
+			if op == "" {
+				op = "="
 			}
 			b.WriteByte(' ')
 			b.WriteString(op)

--- a/tests/aster/x/cs/cross_join.cs
+++ b/tests/aster/x/cs/cross_join.cs
@@ -21,13 +21,13 @@ struct OResult {
     public override string ToString() => $"{{orderId: {orderId}, orderCustomerId: {orderCustomerId}, pairedCustomerName: {pairedCustomerName}, orderTotal: {orderTotal}}}";
 }
 class Program {
-    static Customer[] customers = new Customer[]{new Customer{id1, name}, new Customer{id2, name}, new Customer{id3, name}};
-    static Order[] orders = new Order[]{new Order{id100, customerId1, total250}, new Order{id101, customerId2, total125}, new Order{id102, customerId1, total300}};
-    static OResult[] result = (from o in orders from c in customers select new OResult{orderIdo.id, orderCustomerIdo.customerId, pairedCustomerNamec.name, orderTotalo.total}).ToArray();
+    static Customer[] customers = new Customer[]{new Customer{id = 1, name = "Alice"}, new Customer{id = 2, name = "Bob"}, new Customer{id = 3, name = "Charlie"}};
+    static Order[] orders = new Order[]{new Order{id = 100, customerId = 1, total = 250}, new Order{id = 101, customerId = 2, total = 125}, new Order{id = 102, customerId = 1, total = 300}};
+    static OResult[] result = (from o in orders from c in customers select new OResult{orderId = o.id, orderCustomerId = o.customerId, pairedCustomerName = c.name, orderTotal = o.total}).ToArray();
     static void Main() {
-        Console.WriteLine();
+        Console.WriteLine("--- Cross Join: All order-customer pairs ---");
         foreach (var entry in result) {
-            Console.WriteLine(string.Join(, new object[]{, entry.orderId, , entry.orderCustomerId, , entry.orderTotal, , entry.pairedCustomerName}).TrimEnd());
+            Console.WriteLine(string.Join(" ", new object[]{"Order", entry.orderId, "(customerId:", entry.orderCustomerId, ", total: $", entry.orderTotal, ") paired with", entry.pairedCustomerName}).TrimEnd());
         }
     }
 }

--- a/tests/aster/x/cs/cross_join.out
+++ b/tests/aster/x/cs/cross_join.out
@@ -1,0 +1,10 @@
+--- Cross Join: All order-customer pairs ---
+Order 100 (customerId: 1 , total: $ 250 ) paired with Alice
+Order 100 (customerId: 1 , total: $ 250 ) paired with Bob
+Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie
+Order 101 (customerId: 2 , total: $ 125 ) paired with Alice
+Order 101 (customerId: 2 , total: $ 125 ) paired with Bob
+Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie
+Order 102 (customerId: 1 , total: $ 300 ) paired with Alice
+Order 102 (customerId: 1 , total: $ 300 ) paired with Bob
+Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie


### PR DESCRIPTION
## Summary
- improve `cs` AST printing so literal values and assignments are emitted
- regenerate the `cross_join` golden output

## Testing
- `UPDATE_GOLDEN=1 go test -tags=slow ./aster/x/cs -run TestPrint_Golden -count=1`
- `go test -tags=slow ./aster/x/cs -run TestPrint_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_688b00bb8cd88320a16f7aec5cc9586a