### PR TITLE
Implement string literal support in Prolog printer

### DIFF
--- a/aster/x/prolog/ast.go
+++ b/aster/x/prolog/ast.go
@@ -23,6 +23,7 @@ type Term struct {
 	Args    []Term   `json:"args,omitempty"`
 	List    []Term   `json:"-"`
 	Atom    string   `json:"-"`
+	String  string   `json:"-"`
 	Number  *float64 `json:"-"`
 	Bool    *bool    `json:"-"`
 	Text    string   `json:"-"`
@@ -112,6 +113,8 @@ func termToNode(t Term) *Node {
 		return &Node{Kind: "number", Text: t.Text}
 	case t.Bool != nil:
 		return &Node{Kind: "bool", Text: t.Text}
+	case t.String != "":
+		return &Node{Kind: "string", Text: t.String}
 	case t.Atom != "":
 		return &Node{Kind: "atom", Text: t.Atom}
 	case t.List != nil:
@@ -222,6 +225,7 @@ func (t *Term) UnmarshalJSON(b []byte) error {
 	t.Args = nil
 	t.List = nil
 	t.Atom = ""
+	t.String = ""
 	t.Number = nil
 	t.Bool = nil
 	t.Text = ""
@@ -248,6 +252,13 @@ func (t *Term) UnmarshalJSON(b []byte) error {
 				}
 			}
 			t.Text = t.Functor
+			return nil
+		}
+		if s, ok := obj["string"]; ok {
+			if err := json.Unmarshal(s, &t.String); err != nil {
+				return err
+			}
+			t.Text = t.String
 			return nil
 		}
 		for k, v := range obj {
@@ -313,6 +324,10 @@ func (t Term) MarshalJSON() ([]byte, error) {
 		return json.Marshal(*t.Number)
 	case t.Bool != nil:
 		return json.Marshal(*t.Bool)
+	case t.String != "":
+		return json.Marshal(struct {
+			String string `json:"string"`
+		}{t.String})
 	default:
 		return json.Marshal(t.Atom)
 	}

--- a/aster/x/prolog/pl_ast.pl
+++ b/aster/x/prolog/pl_ast.pl
@@ -51,7 +51,9 @@ term_json(Vs, Term, JSON) :-
     var_name(Vs, Term, Name),
     JSON = _{var:Name}.
 term_json(_, Term, Term) :-
-    ( number(Term) ; string(Term) ), !.
+    number(Term), !.
+term_json(_, Term, _{string:Term}) :-
+    string(Term), !.
 term_json(_, Term, Atom) :-
     atom(Term), !,
     Atom = Term.

--- a/tests/aster/x/prolog/cross_join.prolog
+++ b/tests/aster/x/prolog/cross_join.prolog
@@ -1,3 +1,25 @@
 :- style_check(-singleton).
 :- initialization(main).
-main :- =(Customers, [{id: 1, name: 'Alice'}, {id: 2, name: 'Bob'}, {id: 3, name: 'Charlie'}]), =(Orders, [{id: 100, customerId: 1, total: 250}, {id: 101, customerId: 2, total: 125}, {id: 102, customerId: 1, total: 300}]), =(Result, [{orderId: 100, orderCustomerId: 1, pairedCustomerName: 'Alice', orderTotal: 250}, {orderId: 100, orderCustomerId: 1, pairedCustomerName: 'Bob', orderTotal: 250}, {orderId: 100, orderCustomerId: 1, pairedCustomerName: 'Charlie', orderTotal: 250}, {orderId: 101, orderCustomerId: 2, pairedCustomerName: 'Alice', orderTotal: 125}, {orderId: 101, orderCustomerId: 2, pairedCustomerName: 'Bob', orderTotal: 125}, {orderId: 101, orderCustomerId: 2, pairedCustomerName: 'Charlie', orderTotal: 125}, {orderId: 102, orderCustomerId: 1, pairedCustomerName: 'Alice', orderTotal: 300}, {orderId: 102, orderCustomerId: 1, pairedCustomerName: 'Bob', orderTotal: 300}, {orderId: 102, orderCustomerId: 1, pairedCustomerName: 'Charlie', orderTotal: 300}]), writeln('--- Cross Join: All order-customer pairs ---'), =(Entry, {orderId: 100, orderCustomerId: 1, pairedCustomerName: 'Alice', orderTotal: 250}), writeln('Order 100 (customerId: 1 , total: $ 250 ) paired with Alice'), =(Entry1, {orderId: 100, orderCustomerId: 1, pairedCustomerName: 'Bob', orderTotal: 250}), writeln('Order 100 (customerId: 1 , total: $ 250 ) paired with Bob'), =(Entry2, {orderId: 100, orderCustomerId: 1, pairedCustomerName: 'Charlie', orderTotal: 250}), writeln('Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie'), =(Entry3, {orderId: 101, orderCustomerId: 2, pairedCustomerName: 'Alice', orderTotal: 125}), writeln('Order 101 (customerId: 2 , total: $ 125 ) paired with Alice'), =(Entry4, {orderId: 101, orderCustomerId: 2, pairedCustomerName: 'Bob', orderTotal: 125}), writeln('Order 101 (customerId: 2 , total: $ 125 ) paired with Bob'), =(Entry5, {orderId: 101, orderCustomerId: 2, pairedCustomerName: 'Charlie', orderTotal: 125}), writeln('Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie'), =(Entry6, {orderId: 102, orderCustomerId: 1, pairedCustomerName: 'Alice', orderTotal: 300}), writeln('Order 102 (customerId: 1 , total: $ 300 ) paired with Alice'), =(Entry7, {orderId: 102, orderCustomerId: 1, pairedCustomerName: 'Bob', orderTotal: 300}), writeln('Order 102 (customerId: 1 , total: $ 300 ) paired with Bob'), =(Entry8, {orderId: 102, orderCustomerId: 1, pairedCustomerName: 'Charlie', orderTotal: 300}), writeln('Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie').
+main :-
+        =(Customers, [{id: 1, name: "Alice"}, {id: 2, name: "Bob"}, {id: 3, name: "Charlie"}]),
+            =(Orders, [{id: 100, customerId: 1, total: 250}, {id: 101, customerId: 2, total: 125}, {id: 102, customerId: 1, total: 300}]),
+            =(Result, [{orderId: 100, orderCustomerId: 1, pairedCustomerName: "Alice", orderTotal: 250}, {orderId: 100, orderCustomerId: 1, pairedCustomerName: "Bob", orderTotal: 250}, {orderId: 100, orderCustomerId: 1, pairedCustomerName: "Charlie", orderTotal: 250}, {orderId: 101, orderCustomerId: 2, pairedCustomerName: "Alice", orderTotal: 125}, {orderId: 101, orderCustomerId: 2, pairedCustomerName: "Bob", orderTotal: 125}, {orderId: 101, orderCustomerId: 2, pairedCustomerName: "Charlie", orderTotal: 125}, {orderId: 102, orderCustomerId: 1, pairedCustomerName: "Alice", orderTotal: 300}, {orderId: 102, orderCustomerId: 1, pairedCustomerName: "Bob", orderTotal: 300}, {orderId: 102, orderCustomerId: 1, pairedCustomerName: "Charlie", orderTotal: 300}]),
+            writeln("--- Cross Join: All order-customer pairs ---"),
+            =(Entry, {orderId: 100, orderCustomerId: 1, pairedCustomerName: "Alice", orderTotal: 250}),
+            writeln("Order 100 (customerId: 1 , total: $ 250 ) paired with Alice"),
+            =(Entry1, {orderId: 100, orderCustomerId: 1, pairedCustomerName: "Bob", orderTotal: 250}),
+            writeln("Order 100 (customerId: 1 , total: $ 250 ) paired with Bob"),
+            =(Entry2, {orderId: 100, orderCustomerId: 1, pairedCustomerName: "Charlie", orderTotal: 250}),
+            writeln("Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie"),
+            =(Entry3, {orderId: 101, orderCustomerId: 2, pairedCustomerName: "Alice", orderTotal: 125}),
+            writeln("Order 101 (customerId: 2 , total: $ 125 ) paired with Alice"),
+            =(Entry4, {orderId: 101, orderCustomerId: 2, pairedCustomerName: "Bob", orderTotal: 125}),
+            writeln("Order 101 (customerId: 2 , total: $ 125 ) paired with Bob"),
+            =(Entry5, {orderId: 101, orderCustomerId: 2, pairedCustomerName: "Charlie", orderTotal: 125}),
+            writeln("Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie"),
+            =(Entry6, {orderId: 102, orderCustomerId: 1, pairedCustomerName: "Alice", orderTotal: 300}),
+            writeln("Order 102 (customerId: 1 , total: $ 300 ) paired with Alice"),
+            =(Entry7, {orderId: 102, orderCustomerId: 1, pairedCustomerName: "Bob", orderTotal: 300}),
+            writeln("Order 102 (customerId: 1 , total: $ 300 ) paired with Bob"),
+            =(Entry8, {orderId: 102, orderCustomerId: 1, pairedCustomerName: "Charlie", orderTotal: 300}),
+        writeln("Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie").

--- a/tests/aster/x/prolog/cross_join.prolog.json
+++ b/tests/aster/x/prolog/cross_join.prolog.json
@@ -83,7 +83,7 @@
                                   "text": "name"
                                 },
                                 {
-                                  "kind": "atom",
+                                  "kind": "string",
                                   "text": "Alice"
                                 }
                               ]
@@ -119,7 +119,7 @@
                                   "text": "name"
                                 },
                                 {
-                                  "kind": "atom",
+                                  "kind": "string",
                                   "text": "Bob"
                                 }
                               ]
@@ -155,7 +155,7 @@
                                   "text": "name"
                                 },
                                 {
-                                  "kind": "atom",
+                                  "kind": "string",
                                   "text": "Charlie"
                                 }
                               ]
@@ -406,7 +406,7 @@
                                                   "text": "pairedCustomerName"
                                                 },
                                                 {
-                                                  "kind": "atom",
+                                                  "kind": "string",
                                                   "text": "Alice"
                                                 }
                                               ]
@@ -478,7 +478,7 @@
                                                   "text": "pairedCustomerName"
                                                 },
                                                 {
-                                                  "kind": "atom",
+                                                  "kind": "string",
                                                   "text": "Bob"
                                                 }
                                               ]
@@ -550,7 +550,7 @@
                                                   "text": "pairedCustomerName"
                                                 },
                                                 {
-                                                  "kind": "atom",
+                                                  "kind": "string",
                                                   "text": "Charlie"
                                                 }
                                               ]
@@ -622,7 +622,7 @@
                                                   "text": "pairedCustomerName"
                                                 },
                                                 {
-                                                  "kind": "atom",
+                                                  "kind": "string",
                                                   "text": "Alice"
                                                 }
                                               ]
@@ -694,7 +694,7 @@
                                                   "text": "pairedCustomerName"
                                                 },
                                                 {
-                                                  "kind": "atom",
+                                                  "kind": "string",
                                                   "text": "Bob"
                                                 }
                                               ]
@@ -766,7 +766,7 @@
                                                   "text": "pairedCustomerName"
                                                 },
                                                 {
-                                                  "kind": "atom",
+                                                  "kind": "string",
                                                   "text": "Charlie"
                                                 }
                                               ]
@@ -838,7 +838,7 @@
                                                   "text": "pairedCustomerName"
                                                 },
                                                 {
-                                                  "kind": "atom",
+                                                  "kind": "string",
                                                   "text": "Alice"
                                                 }
                                               ]
@@ -910,7 +910,7 @@
                                                   "text": "pairedCustomerName"
                                                 },
                                                 {
-                                                  "kind": "atom",
+                                                  "kind": "string",
                                                   "text": "Bob"
                                                 }
                                               ]
@@ -982,7 +982,7 @@
                                                   "text": "pairedCustomerName"
                                                 },
                                                 {
-                                                  "kind": "atom",
+                                                  "kind": "string",
                                                   "text": "Charlie"
                                                 }
                                               ]
@@ -1019,7 +1019,7 @@
                           "kind": "writeln",
                           "children": [
                             {
-                              "kind": "atom",
+                              "kind": "string",
                               "text": "--- Cross Join: All order-customer pairs ---"
                             }
                           ]
@@ -1080,7 +1080,7 @@
                                                       "text": "pairedCustomerName"
                                                     },
                                                     {
-                                                      "kind": "atom",
+                                                      "kind": "string",
                                                       "text": "Alice"
                                                     }
                                                   ]
@@ -1115,7 +1115,7 @@
                                   "kind": "writeln",
                                   "children": [
                                     {
-                                      "kind": "atom",
+                                      "kind": "string",
                                       "text": "Order 100 (customerId: 1 , total: $ 250 ) paired with Alice"
                                     }
                                   ]
@@ -1176,7 +1176,7 @@
                                                               "text": "pairedCustomerName"
                                                             },
                                                             {
-                                                              "kind": "atom",
+                                                              "kind": "string",
                                                               "text": "Bob"
                                                             }
                                                           ]
@@ -1211,7 +1211,7 @@
                                           "kind": "writeln",
                                           "children": [
                                             {
-                                              "kind": "atom",
+                                              "kind": "string",
                                               "text": "Order 100 (customerId: 1 , total: $ 250 ) paired with Bob"
                                             }
                                           ]
@@ -1272,7 +1272,7 @@
                                                                       "text": "pairedCustomerName"
                                                                     },
                                                                     {
-                                                                      "kind": "atom",
+                                                                      "kind": "string",
                                                                       "text": "Charlie"
                                                                     }
                                                                   ]
@@ -1307,7 +1307,7 @@
                                                   "kind": "writeln",
                                                   "children": [
                                                     {
-                                                      "kind": "atom",
+                                                      "kind": "string",
                                                       "text": "Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie"
                                                     }
                                                   ]
@@ -1368,7 +1368,7 @@
                                                                               "text": "pairedCustomerName"
                                                                             },
                                                                             {
-                                                                              "kind": "atom",
+                                                                              "kind": "string",
                                                                               "text": "Alice"
                                                                             }
                                                                           ]
@@ -1403,7 +1403,7 @@
                                                           "kind": "writeln",
                                                           "children": [
                                                             {
-                                                              "kind": "atom",
+                                                              "kind": "string",
                                                               "text": "Order 101 (customerId: 2 , total: $ 125 ) paired with Alice"
                                                             }
                                                           ]
@@ -1464,7 +1464,7 @@
                                                                                       "text": "pairedCustomerName"
                                                                                     },
                                                                                     {
-                                                                                      "kind": "atom",
+                                                                                      "kind": "string",
                                                                                       "text": "Bob"
                                                                                     }
                                                                                   ]
@@ -1499,7 +1499,7 @@
                                                                   "kind": "writeln",
                                                                   "children": [
                                                                     {
-                                                                      "kind": "atom",
+                                                                      "kind": "string",
                                                                       "text": "Order 101 (customerId: 2 , total: $ 125 ) paired with Bob"
                                                                     }
                                                                   ]
@@ -1560,7 +1560,7 @@
                                                                                               "text": "pairedCustomerName"
                                                                                             },
                                                                                             {
-                                                                                              "kind": "atom",
+                                                                                              "kind": "string",
                                                                                               "text": "Charlie"
                                                                                             }
                                                                                           ]
@@ -1595,7 +1595,7 @@
                                                                           "kind": "writeln",
                                                                           "children": [
                                                                             {
-                                                                              "kind": "atom",
+                                                                              "kind": "string",
                                                                               "text": "Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie"
                                                                             }
                                                                           ]
@@ -1656,7 +1656,7 @@
                                                                                                       "text": "pairedCustomerName"
                                                                                                     },
                                                                                                     {
-                                                                                                      "kind": "atom",
+                                                                                                      "kind": "string",
                                                                                                       "text": "Alice"
                                                                                                     }
                                                                                                   ]
@@ -1691,7 +1691,7 @@
                                                                                   "kind": "writeln",
                                                                                   "children": [
                                                                                     {
-                                                                                      "kind": "atom",
+                                                                                      "kind": "string",
                                                                                       "text": "Order 102 (customerId: 1 , total: $ 300 ) paired with Alice"
                                                                                     }
                                                                                   ]
@@ -1752,7 +1752,7 @@
                                                                                                               "text": "pairedCustomerName"
                                                                                                             },
                                                                                                             {
-                                                                                                              "kind": "atom",
+                                                                                                              "kind": "string",
                                                                                                               "text": "Bob"
                                                                                                             }
                                                                                                           ]
@@ -1787,7 +1787,7 @@
                                                                                           "kind": "writeln",
                                                                                           "children": [
                                                                                             {
-                                                                                              "kind": "atom",
+                                                                                              "kind": "string",
                                                                                               "text": "Order 102 (customerId: 1 , total: $ 300 ) paired with Bob"
                                                                                             }
                                                                                           ]
@@ -1848,7 +1848,7 @@
                                                                                                                       "text": "pairedCustomerName"
                                                                                                                     },
                                                                                                                     {
-                                                                                                                      "kind": "atom",
+                                                                                                                      "kind": "string",
                                                                                                                       "text": "Charlie"
                                                                                                                     }
                                                                                                                   ]
@@ -1880,7 +1880,7 @@
                                                                                               "kind": "writeln",
                                                                                               "children": [
                                                                                                 {
-                                                                                                  "kind": "atom",
+                                                                                                  "kind": "string",
                                                                                                   "text": "Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie"
                                                                                                 }
                                                                                               ]

--- a/tests/aster/x/prolog/two-sum.prolog
+++ b/tests/aster/x/prolog/two-sum.prolog
@@ -2,21 +2,21 @@
 get_item(Container, Key, Val) :-
         is_dict(Container),
             !,
-            string(Key) -> atom_string(A, Key); =(A, Key),
-        get_dict(A, Container, Val)
+            ((string(Key) -> atom_string(A, Key)); =(A, Key)),
+        get_dict(A, Container, Val).
 get_item(Container, Index, Val) :-
         string(Container),
             !,
             string_chars(Container, Chars),
-        nth0(Index, Chars, Val)
+        nth0(Index, Chars, Val).
 get_item(List, Index, Val) :-
-    nth0(Index, List, Val)
+    nth0(Index, List, Val).
 twosum(Nums, Target, Res) :-
-    catch(length(Nums, _V0), =(N, _V0), is(_V1, -(N, 1)), catch(between(0, _V1, I), catch(is(_V2, +(I, 1)), is(_V3, -(N, 1)), catch(between(_V2, _V3, J), catch(get_item(Nums, I, _V4), get_item(Nums, J, _V5), is(_V6, +(_V4, _V5)), =(_V6, Target) -> throw(return([I, J])); true, true, continue, true), fail; true, break, true), true, true, continue, true), fail; true, break, true), true, true, return(_V7), =(Res, _V7))
+    catch(length(Nums, _V0), =(N, _V0), is(_V1, -(N, 1)), catch((between(0, _V1, I), catch(is(_V2, +(I, 1)), is(_V3, -(N, 1)), catch((between(_V2, _V3, J), catch(get_item(Nums, I, _V4), get_item(Nums, J, _V5), is(_V6, +(_V4, _V5)), ((=(_V6, Target) -> throw(return([I, J]))); true), true, continue, true), fail; true), break, true), true, true, continue, true), fail; true), break, true), true, true, return(_V7), =(Res, _V7)).
 twosum(Nums, Target, Res) :-
         is(_V8, -(1)),
             is(_V9, -(1)),
-        =(Res, [_V8, _V9])
+        =(Res, [_V8, _V9]).
 main :-
         twosum([2, 7, 11, 15], 9, _V10),
             =(Result, _V10),
@@ -25,5 +25,5 @@ main :-
             nl,
             get_item(Result, 1, _V12),
             write(_V12),
-        nl
+        nl.
 :- initialization(main, main).


### PR DESCRIPTION
## Summary
- enhance Prolog AST inspector to distinguish strings
- update printer to handle string literals and add clause terminators
- regenerate Prolog golden files

## Testing
- `go test ./aster/x/prolog -run TestInspect_Golden -update -tags slow`
- `go test ./aster/x/prolog -run TestPrint_Golden -update -tags slow`
- `swipl -q -s tests/aster/x/prolog/cross_join.prolog -t halt | head`

------
https://chatgpt.com/codex/tasks/task_e_688af9b728d08320a6611345110e41df