### PR TITLE
Handle postfix expressions in Swift printer

### DIFF
--- a/aster/x/swift/print.go
+++ b/aster/x/swift/print.go
@@ -325,6 +325,15 @@ func writeExpr(b *bytes.Buffer, n *Node, indent int) {
 		}
 		b.WriteString(indentStr(indent))
 		b.WriteByte('}')
+	case "postfix_expression":
+		if len(n.Children) == 2 && n.Children[1].Kind == "bang" {
+			writeExpr(b, n.Children[0], indent)
+			b.WriteString(n.Children[1].Text)
+		} else {
+			for _, c := range n.Children {
+				writeExpr(b, c, indent)
+			}
+		}
 	case "navigation_expression":
 		if len(n.Children) == 2 {
 			writeExpr(b, n.Children[0], indent)


### PR DESCRIPTION
## Summary
- support `postfix_expression` in `aster/x/swift` printer

## Testing
- `go test -tags slow ./aster/x/swift -run TestPrint_Golden/two-sum`
- `go test -tags slow ./aster/x/swift -run TestInspect_Golden/two-sum`


------
https://chatgpt.com/codex/tasks/task_e_688b2b6b77c48320ad46475438a3f89e