### PR TITLE
Expand Dart aster printer coverage

### DIFF
--- a/aster/x/dart/README.md
+++ b/aster/x/dart/README.md
@@ -3,7 +3,6 @@
 This folder contains golden test data for printing Dart ASTs back into source code.
 
 ## Supported examples
-
 - [x] 1. append_builtin.dart
 - [x] 2. avg_builtin.dart
 - [x] 3. basic_compare.dart
@@ -14,6 +13,15 @@ This folder contains golden test data for printing Dart ASTs back into source co
 - [x] 8. cast_string_to_int.dart
 - [x] 9. cast_struct.dart
 - [x] 10. closure.dart
+- [x] 11. count_builtin.dart
+- [x] 12. cross_join.dart
+- [x] 13. cross_join_filter.dart
+- [x] 14. cross_join_triple.dart
+- [x] 15. dataset_sort_take_limit.dart
+- [x] 16. dataset_where_filter.dart
+- [x] 17. exists_builtin.dart
+- [x] 18. for_list_collection.dart
+- [x] 19. for_loop.dart
+- [x] 20. for_map_collection.dart
 
-Completed 10/10 at 2025-07-31 15:32 GMT+7
-
+Completed 20/103 at 2025-07-31 15:48 GMT+7

--- a/aster/x/dart/inspect_test.go
+++ b/aster/x/dart/inspect_test.go
@@ -46,8 +46,8 @@ func TestInspect_Golden(t *testing.T) {
 		t.Fatal(err)
 	}
 	sort.Strings(files)
-	if len(files) > 10 {
-		files = files[:10]
+	if len(files) > 20 {
+		files = files[:20]
 	}
 
 	for _, src := range files {

--- a/aster/x/dart/print_test.go
+++ b/aster/x/dart/print_test.go
@@ -38,8 +38,8 @@ func TestPrint_Golden(t *testing.T) {
 		t.Fatal(err)
 	}
 	sort.Strings(files)
-	if len(files) > 10 {
-		files = files[:10]
+	if len(files) > 20 {
+		files = files[:20]
 	}
 
 	for _, src := range files {


### PR DESCRIPTION
## Summary
- extend golden tests in Dart aster to cover first 20 examples
- update README with new checklist

## Testing
- `go test ./aster/x/dart -run TestInspect_Golden -tags slow -count=1`
- `go test ./aster/x/dart -run TestPrint_Golden -tags slow -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_688b2ce533cc8320b260f06c21c5cf7b