### PR TITLE
Update Mochi AST printer tests

### DIFF
--- a/aster/x/mochi/README.md
+++ b/aster/x/mochi/README.md
@@ -2,11 +2,20 @@
 
 This directory stores golden files for the Mochi language AST printer.
 
-- `break_continue.mochi`
-- `cast_struct.mochi`
-- `closure.mochi`
-- `cross_join.mochi`
-- `two_sum.mochi`
+## Test Files
 
-All **5** examples are covered. Generated on 2025-07-31 14:26 GMT+7.
+1. break_continue.mochi
+2. cast_struct.mochi
+3. closure.mochi
+4. cross_join.mochi
+5. two_sum.mochi
+6. dataset-sort-take-limit.mochi
+7. except.mochi
+8. group-by.mochi
+9. union.mochi
+10. union_all.mochi
+
+Completed **10/10** examples.
+
+_Last updated: 2025-07-31 18:36 GMT+7_
 

--- a/aster/x/mochi/print.go
+++ b/aster/x/mochi/print.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"regexp"
+	"strings"
 
 	mast "mochi/ast"
 )
@@ -19,6 +21,13 @@ func Print(p *Program) (string, error) {
 		return "", err
 	}
 	src := buf.String()
+	// Normalize query keywords that mast.Fprint doesn't handle exactly
+	src = strings.ReplaceAll(src, "union_all", "union all")
+	src = strings.ReplaceAll(src, "left_join", "left join")
+	src = strings.ReplaceAll(src, "right_join", "right join")
+	src = strings.ReplaceAll(src, "outer_join", "outer join")
+	reSort := regexp.MustCompile(`(?m)^(\s*)sort (.+)$`)
+	src = reSort.ReplaceAllString(src, "${1}sort by ${2}")
 	if len(src) > 0 && src[len(src)-1] != '\n' {
 		src += "\n"
 	}

--- a/tests/aster/x/mochi/dataset-sort-take-limit.mochi
+++ b/tests/aster/x/mochi/dataset-sort-take-limit.mochi
@@ -1,0 +1,10 @@
+let products = [{name: "Laptop", price: 1500}, {name: "Smartphone", price: 900}, {name: "Tablet", price: 600}, {name: "Monitor", price: 300}, {name: "Keyboard", price: 100}, {name: "Mouse", price: 50}, {name: "Headphones", price: 200}]
+let expensive = from p in products
+                  sort by -p.price
+                  skip 1
+                  take 3
+                  select p
+print("--- Top products (excluding most expensive) ---")
+for item in expensive {
+  print(item.name, "costs $", item.price)
+}

--- a/tests/aster/x/mochi/dataset-sort-take-limit.mochi.json
+++ b/tests/aster/x/mochi/dataset-sort-take-limit.mochi.json
@@ -1,0 +1,364 @@
+{
+  "file": {
+    "kind": "program",
+    "children": [
+      {
+        "kind": "let",
+        "text": "products",
+        "children": [
+          {
+            "kind": "list",
+            "children": [
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Laptop"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "price"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "1500"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Smartphone"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "price"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "900"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Tablet"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "price"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "600"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Monitor"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "price"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "300"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Keyboard"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "price"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "100"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Mouse"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "price"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "50"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Headphones"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "price"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "200"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "let",
+        "text": "expensive",
+        "children": [
+          {
+            "kind": "query",
+            "text": "p",
+            "children": [
+              {
+                "kind": "source",
+                "children": [
+                  {
+                    "kind": "selector",
+                    "text": "products"
+                  }
+                ]
+              },
+              {
+                "kind": "sort",
+                "children": [
+                  {
+                    "kind": "unary",
+                    "text": "-",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "price",
+                        "children": [
+                          {
+                            "kind": "selector",
+                            "text": "p"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "skip",
+                "children": [
+                  {
+                    "kind": "int",
+                    "text": "1"
+                  }
+                ]
+              },
+              {
+                "kind": "take",
+                "children": [
+                  {
+                    "kind": "int",
+                    "text": "3"
+                  }
+                ]
+              },
+              {
+                "kind": "select",
+                "children": [
+                  {
+                    "kind": "selector",
+                    "text": "p"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "call",
+        "text": "print",
+        "children": [
+          {
+            "kind": "string",
+            "text": "--- Top products (excluding most expensive) ---"
+          }
+        ]
+      },
+      {
+        "kind": "for",
+        "text": "item",
+        "children": [
+          {
+            "kind": "in",
+            "children": [
+              {
+                "kind": "selector",
+                "text": "expensive"
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "children": [
+              {
+                "kind": "call",
+                "text": "print",
+                "children": [
+                  {
+                    "kind": "selector",
+                    "text": "name",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "item"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "string",
+                    "text": "costs $"
+                  },
+                  {
+                    "kind": "selector",
+                    "text": "price",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "item"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/aster/x/mochi/dataset-sort-take-limit.mochi.out
+++ b/tests/aster/x/mochi/dataset-sort-take-limit.mochi.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300

--- a/tests/aster/x/mochi/except.mochi
+++ b/tests/aster/x/mochi/except.mochi
@@ -1,0 +1,9 @@
+let listA = [{id: 1, name: "Alice"}, {id: 2, name: "Bob"}, {id: 3, name: "Charlie"}]
+let listB = [{id: 2, name: "Bob"}, {id: 4, name: "Diana"}]
+let result = ((from x in listA
+               select x) except (from x in listB
+               select x))
+print("--- EXCEPT ---")
+for x in result {
+  print(((("Customer " + str(x.id)) + " - ") + x.name))
+}

--- a/tests/aster/x/mochi/except.mochi.json
+++ b/tests/aster/x/mochi/except.mochi.json
@@ -1,0 +1,342 @@
+{
+  "file": {
+    "kind": "program",
+    "children": [
+      {
+        "kind": "let",
+        "text": "listA",
+        "children": [
+          {
+            "kind": "list",
+            "children": [
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "id"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "1"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Alice"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "id"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "2"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Bob"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "id"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "3"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Charlie"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "let",
+        "text": "listB",
+        "children": [
+          {
+            "kind": "list",
+            "children": [
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "id"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "2"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Bob"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "id"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "4"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Diana"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "let",
+        "text": "result",
+        "children": [
+          {
+            "kind": "binary",
+            "text": "except",
+            "children": [
+              {
+                "kind": "group",
+                "children": [
+                  {
+                    "kind": "query",
+                    "text": "x",
+                    "children": [
+                      {
+                        "kind": "source",
+                        "children": [
+                          {
+                            "kind": "selector",
+                            "text": "listA"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "select",
+                        "children": [
+                          {
+                            "kind": "selector",
+                            "text": "x"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "group",
+                "children": [
+                  {
+                    "kind": "query",
+                    "text": "x",
+                    "children": [
+                      {
+                        "kind": "source",
+                        "children": [
+                          {
+                            "kind": "selector",
+                            "text": "listB"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "select",
+                        "children": [
+                          {
+                            "kind": "selector",
+                            "text": "x"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "call",
+        "text": "print",
+        "children": [
+          {
+            "kind": "string",
+            "text": "--- EXCEPT ---"
+          }
+        ]
+      },
+      {
+        "kind": "for",
+        "text": "x",
+        "children": [
+          {
+            "kind": "in",
+            "children": [
+              {
+                "kind": "selector",
+                "text": "result"
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "children": [
+              {
+                "kind": "call",
+                "text": "print",
+                "children": [
+                  {
+                    "kind": "binary",
+                    "text": "+",
+                    "children": [
+                      {
+                        "kind": "binary",
+                        "text": "+",
+                        "children": [
+                          {
+                            "kind": "binary",
+                            "text": "+",
+                            "children": [
+                              {
+                                "kind": "string",
+                                "text": "Customer "
+                              },
+                              {
+                                "kind": "call",
+                                "text": "str",
+                                "children": [
+                                  {
+                                    "kind": "selector",
+                                    "text": "id",
+                                    "children": [
+                                      {
+                                        "kind": "selector",
+                                        "text": "x"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "text": " - "
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "selector",
+                        "text": "name",
+                        "children": [
+                          {
+                            "kind": "selector",
+                            "text": "x"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/aster/x/mochi/except.mochi.out
+++ b/tests/aster/x/mochi/except.mochi.out
@@ -1,0 +1,3 @@
+--- EXCEPT ---
+Customer 1 - Alice
+Customer 3 - Charlie

--- a/tests/aster/x/mochi/group-by.mochi
+++ b/tests/aster/x/mochi/group-by.mochi
@@ -1,0 +1,9 @@
+let people = [{name: "Alice", age: 30, city: "Paris"}, {name: "Bob", age: 15, city: "Hanoi"}, {name: "Charlie", age: 65, city: "Paris"}, {name: "Diana", age: 45, city: "Hanoi"}, {name: "Eve", age: 70, city: "Paris"}, {name: "Frank", age: 22, city: "Hanoi"}]
+let stats = from person in people
+              group by person.city into g
+              select {city: g.key, count: count(g), avg_age: avg(from p in g
+              select p.age)}
+print("--- People grouped by city ---")
+for s in stats {
+  print(s.city, ": count =", s.count, ", avg_age =", s.avg_age)
+}

--- a/tests/aster/x/mochi/group-by.mochi.json
+++ b/tests/aster/x/mochi/group-by.mochi.json
@@ -1,0 +1,489 @@
+{
+  "file": {
+    "kind": "program",
+    "children": [
+      {
+        "kind": "let",
+        "text": "people",
+        "children": [
+          {
+            "kind": "list",
+            "children": [
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Alice"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "age"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "30"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "city"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Paris"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Bob"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "age"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "15"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "city"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Hanoi"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Charlie"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "age"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "65"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "city"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Paris"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Diana"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "age"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "45"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "city"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Hanoi"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Eve"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "age"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "70"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "city"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Paris"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Frank"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "age"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "22"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "city"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Hanoi"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "let",
+        "text": "stats",
+        "children": [
+          {
+            "kind": "query",
+            "text": "person",
+            "children": [
+              {
+                "kind": "source",
+                "children": [
+                  {
+                    "kind": "selector",
+                    "text": "people"
+                  }
+                ]
+              },
+              {
+                "kind": "group_by",
+                "children": [
+                  {
+                    "kind": "selector",
+                    "text": "city",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "person"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "into",
+                    "text": "g"
+                  }
+                ]
+              },
+              {
+                "kind": "select",
+                "children": [
+                  {
+                    "kind": "map",
+                    "children": [
+                      {
+                        "kind": "entry",
+                        "children": [
+                          {
+                            "kind": "selector",
+                            "text": "city"
+                          },
+                          {
+                            "kind": "selector",
+                            "text": "key",
+                            "children": [
+                              {
+                                "kind": "selector",
+                                "text": "g"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "entry",
+                        "children": [
+                          {
+                            "kind": "selector",
+                            "text": "count"
+                          },
+                          {
+                            "kind": "call",
+                            "text": "count",
+                            "children": [
+                              {
+                                "kind": "selector",
+                                "text": "g"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "entry",
+                        "children": [
+                          {
+                            "kind": "selector",
+                            "text": "avg_age"
+                          },
+                          {
+                            "kind": "call",
+                            "text": "avg",
+                            "children": [
+                              {
+                                "kind": "query",
+                                "text": "p",
+                                "children": [
+                                  {
+                                    "kind": "source",
+                                    "children": [
+                                      {
+                                        "kind": "selector",
+                                        "text": "g"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "select",
+                                    "children": [
+                                      {
+                                        "kind": "selector",
+                                        "text": "age",
+                                        "children": [
+                                          {
+                                            "kind": "selector",
+                                            "text": "p"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "call",
+        "text": "print",
+        "children": [
+          {
+            "kind": "string",
+            "text": "--- People grouped by city ---"
+          }
+        ]
+      },
+      {
+        "kind": "for",
+        "text": "s",
+        "children": [
+          {
+            "kind": "in",
+            "children": [
+              {
+                "kind": "selector",
+                "text": "stats"
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "children": [
+              {
+                "kind": "call",
+                "text": "print",
+                "children": [
+                  {
+                    "kind": "selector",
+                    "text": "city",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "s"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "string",
+                    "text": ": count ="
+                  },
+                  {
+                    "kind": "selector",
+                    "text": "count",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "s"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "string",
+                    "text": ", avg_age ="
+                  },
+                  {
+                    "kind": "selector",
+                    "text": "avg_age",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "s"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/aster/x/mochi/group-by.mochi.out
+++ b/tests/aster/x/mochi/group-by.mochi.out
@@ -1,0 +1,3 @@
+--- People grouped by city ---
+Paris : count = 3 , avg_age = 55
+Hanoi : count = 3 , avg_age = 27.333333333333332

--- a/tests/aster/x/mochi/union.mochi
+++ b/tests/aster/x/mochi/union.mochi
@@ -1,0 +1,9 @@
+let listA = [{id: 1, name: "Alice"}, {id: 2, name: "Bob"}]
+let listB = [{id: 2, name: "Bob"}, {id: 3, name: "Charlie"}]
+let result = ((from x in listA
+               select x) union (from x in listB
+               select x))
+print("--- UNION (deduplicated) ---")
+for x in result {
+  print(((("Customer " + str(x.id)) + " - ") + x.name))
+}

--- a/tests/aster/x/mochi/union.mochi.json
+++ b/tests/aster/x/mochi/union.mochi.json
@@ -1,0 +1,311 @@
+{
+  "file": {
+    "kind": "program",
+    "children": [
+      {
+        "kind": "let",
+        "text": "listA",
+        "children": [
+          {
+            "kind": "list",
+            "children": [
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "id"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "1"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Alice"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "id"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "2"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Bob"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "let",
+        "text": "listB",
+        "children": [
+          {
+            "kind": "list",
+            "children": [
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "id"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "2"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Bob"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "id"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "3"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Charlie"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "let",
+        "text": "result",
+        "children": [
+          {
+            "kind": "binary",
+            "text": "union",
+            "children": [
+              {
+                "kind": "group",
+                "children": [
+                  {
+                    "kind": "query",
+                    "text": "x",
+                    "children": [
+                      {
+                        "kind": "source",
+                        "children": [
+                          {
+                            "kind": "selector",
+                            "text": "listA"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "select",
+                        "children": [
+                          {
+                            "kind": "selector",
+                            "text": "x"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "group",
+                "children": [
+                  {
+                    "kind": "query",
+                    "text": "x",
+                    "children": [
+                      {
+                        "kind": "source",
+                        "children": [
+                          {
+                            "kind": "selector",
+                            "text": "listB"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "select",
+                        "children": [
+                          {
+                            "kind": "selector",
+                            "text": "x"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "call",
+        "text": "print",
+        "children": [
+          {
+            "kind": "string",
+            "text": "--- UNION (deduplicated) ---"
+          }
+        ]
+      },
+      {
+        "kind": "for",
+        "text": "x",
+        "children": [
+          {
+            "kind": "in",
+            "children": [
+              {
+                "kind": "selector",
+                "text": "result"
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "children": [
+              {
+                "kind": "call",
+                "text": "print",
+                "children": [
+                  {
+                    "kind": "binary",
+                    "text": "+",
+                    "children": [
+                      {
+                        "kind": "binary",
+                        "text": "+",
+                        "children": [
+                          {
+                            "kind": "binary",
+                            "text": "+",
+                            "children": [
+                              {
+                                "kind": "string",
+                                "text": "Customer "
+                              },
+                              {
+                                "kind": "call",
+                                "text": "str",
+                                "children": [
+                                  {
+                                    "kind": "selector",
+                                    "text": "id",
+                                    "children": [
+                                      {
+                                        "kind": "selector",
+                                        "text": "x"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "text": " - "
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "selector",
+                        "text": "name",
+                        "children": [
+                          {
+                            "kind": "selector",
+                            "text": "x"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/aster/x/mochi/union.mochi.out
+++ b/tests/aster/x/mochi/union.mochi.out
@@ -1,0 +1,4 @@
+--- UNION (deduplicated) ---
+Customer 1 - Alice
+Customer 2 - Bob
+Customer 3 - Charlie

--- a/tests/aster/x/mochi/union_all.mochi
+++ b/tests/aster/x/mochi/union_all.mochi
@@ -1,0 +1,9 @@
+let listA = [{id: 1, name: "Alice"}, {id: 2, name: "Bob"}]
+let listB = [{id: 2, name: "Bob"}, {id: 3, name: "Charlie"}]
+let result = ((from x in listA
+               select x) union all (from x in listB
+               select x))
+print("--- UNION ALL (with duplicates) ---")
+for x in result {
+  print(((("Customer " + str(x.id)) + " - ") + x.name))
+}

--- a/tests/aster/x/mochi/union_all.mochi.json
+++ b/tests/aster/x/mochi/union_all.mochi.json
@@ -1,0 +1,311 @@
+{
+  "file": {
+    "kind": "program",
+    "children": [
+      {
+        "kind": "let",
+        "text": "listA",
+        "children": [
+          {
+            "kind": "list",
+            "children": [
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "id"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "1"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Alice"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "id"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "2"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Bob"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "let",
+        "text": "listB",
+        "children": [
+          {
+            "kind": "list",
+            "children": [
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "id"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "2"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Bob"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "map",
+                "children": [
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "id"
+                      },
+                      {
+                        "kind": "int",
+                        "text": "3"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "entry",
+                    "children": [
+                      {
+                        "kind": "selector",
+                        "text": "name"
+                      },
+                      {
+                        "kind": "string",
+                        "text": "Charlie"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "let",
+        "text": "result",
+        "children": [
+          {
+            "kind": "binary",
+            "text": "union_all",
+            "children": [
+              {
+                "kind": "group",
+                "children": [
+                  {
+                    "kind": "query",
+                    "text": "x",
+                    "children": [
+                      {
+                        "kind": "source",
+                        "children": [
+                          {
+                            "kind": "selector",
+                            "text": "listA"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "select",
+                        "children": [
+                          {
+                            "kind": "selector",
+                            "text": "x"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "group",
+                "children": [
+                  {
+                    "kind": "query",
+                    "text": "x",
+                    "children": [
+                      {
+                        "kind": "source",
+                        "children": [
+                          {
+                            "kind": "selector",
+                            "text": "listB"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "select",
+                        "children": [
+                          {
+                            "kind": "selector",
+                            "text": "x"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "call",
+        "text": "print",
+        "children": [
+          {
+            "kind": "string",
+            "text": "--- UNION ALL (with duplicates) ---"
+          }
+        ]
+      },
+      {
+        "kind": "for",
+        "text": "x",
+        "children": [
+          {
+            "kind": "in",
+            "children": [
+              {
+                "kind": "selector",
+                "text": "result"
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "children": [
+              {
+                "kind": "call",
+                "text": "print",
+                "children": [
+                  {
+                    "kind": "binary",
+                    "text": "+",
+                    "children": [
+                      {
+                        "kind": "binary",
+                        "text": "+",
+                        "children": [
+                          {
+                            "kind": "binary",
+                            "text": "+",
+                            "children": [
+                              {
+                                "kind": "string",
+                                "text": "Customer "
+                              },
+                              {
+                                "kind": "call",
+                                "text": "str",
+                                "children": [
+                                  {
+                                    "kind": "selector",
+                                    "text": "id",
+                                    "children": [
+                                      {
+                                        "kind": "selector",
+                                        "text": "x"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "text": " - "
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "selector",
+                        "text": "name",
+                        "children": [
+                          {
+                            "kind": "selector",
+                            "text": "x"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/aster/x/mochi/union_all.mochi.out
+++ b/tests/aster/x/mochi/union_all.mochi.out
@@ -1,0 +1,5 @@
+--- UNION ALL (with duplicates) ---
+Customer 1 - Alice
+Customer 2 - Bob
+Customer 2 - Bob
+Customer 3 - Charlie

--- a/tests/transpiler/x/mochi/dataset-sort-take-limit.mochi
+++ b/tests/transpiler/x/mochi/dataset-sort-take-limit.mochi
@@ -1,0 +1,24 @@
+// dataset-sort-take-limit.mochi
+// Sort a dataset, skip the first few, and take a limited number of records
+
+let products = [
+  { name: "Laptop", price: 1500 },
+  { name: "Smartphone", price: 900 },
+  { name: "Tablet", price: 600 },
+  { name: "Monitor", price: 300 },
+  { name: "Keyboard", price: 100 },
+  { name: "Mouse", price: 50 },
+  { name: "Headphones", price: 200 }
+]
+
+// Sort by price descending
+let expensive = from p in products
+                sort by -p.price
+                skip 1
+                take 3
+                select p
+
+print("--- Top products (excluding most expensive) ---")
+for item in expensive {
+  print(item.name, "costs $", item.price)
+}

--- a/tests/transpiler/x/mochi/except.mochi
+++ b/tests/transpiler/x/mochi/except.mochi
@@ -1,0 +1,22 @@
+// except.mochi
+// Set difference: A EXCEPT B → values in A that are NOT in B
+
+let listA = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" }
+]
+
+let listB = [
+  { id: 2, name: "Bob" },
+  { id: 4, name: "Diana" }
+]
+
+let result = (from x in listA select x)
+             except
+             (from x in listB select x)
+
+print("--- EXCEPT ---")
+for x in result {
+  print("Customer " + str(x.id) + " - " + x.name)
+}

--- a/tests/transpiler/x/mochi/group-by.mochi
+++ b/tests/transpiler/x/mochi/group-by.mochi
@@ -1,0 +1,25 @@
+// group-by.mochi
+// Group a list of people by their city and compute aggregates
+
+let people = [
+  { name: "Alice", age: 30, city: "Paris" },
+  { name: "Bob", age: 15, city: "Hanoi" },
+  { name: "Charlie", age: 65, city: "Paris" },
+  { name: "Diana", age: 45, city: "Hanoi" },
+  { name: "Eve", age: 70, city: "Paris" },
+  { name: "Frank", age: 22, city: "Hanoi" }
+]
+
+// Group people by city and calculate count and average age
+let stats = from person in people
+            group by person.city into g
+            select {
+              city: g.key,
+              count: count(g),
+              avg_age: avg(from p in g select p.age)
+            }
+
+print("--- People grouped by city ---")
+for s in stats {
+  print(s.city, ": count =", s.count, ", avg_age =", s.avg_age)
+}

--- a/tests/transpiler/x/mochi/union.mochi
+++ b/tests/transpiler/x/mochi/union.mochi
@@ -1,0 +1,22 @@
+// union.mochi
+// Deduplicating union of two customer lists
+
+let listA = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" }
+]
+
+let listB = [
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" }
+]
+
+// Standard union (deduplicated)
+let result = (from x in listA select x)
+             union
+             (from x in listB select x)
+
+print("--- UNION (deduplicated) ---")
+for x in result {
+  print("Customer " + str(x.id) + " - " + x.name)
+}

--- a/tests/transpiler/x/mochi/union_all.mochi
+++ b/tests/transpiler/x/mochi/union_all.mochi
@@ -1,0 +1,22 @@
+// union_all.mochi
+// Union ALL – include duplicates
+
+let listA = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" }
+]
+
+let listB = [
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" }
+]
+
+// Union all (no deduplication)
+let result = (from x in listA select x)
+             union all
+             (from x in listB select x)
+
+print("--- UNION ALL (with duplicates) ---")
+for x in result {
+  print("Customer " + str(x.id) + " - " + x.name)
+}


### PR DESCRIPTION
## Summary
- expand golden test suite for Mochi AST printer with five more examples
- fix `Print` to normalize query operators and `sort by`
- document all ten test files in README

## Testing
- `go test ./aster/x/mochi -run TestPrint_Golden -count=1`
- `go test -tags slow ./aster/x/mochi -run TestInspect_Golden -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688b4f1ac38c832096529d318bb0157f