### PR TITLE
Enhance C++ AST printer

### DIFF
--- a/aster/x/cpp/README.md
+++ b/aster/x/cpp/README.md
@@ -2,8 +2,8 @@
 
 Golden files for the C++ inspector and printer live in this directory.
 
-Completed programs: 37/103
-Date: 2025-07-31 20:03 GMT+7
+Completed programs: 44/103
+Date: 2025-07-31 20:30 GMT+7
 
 ## Checklist
 - [ ] append_builtin
@@ -58,18 +58,18 @@ Date: 2025-07-31 20:03 GMT+7
 - [x] list_index
 - [x] list_nested_assign
 - [ ] list_set_ops
-- [ ] load_jsonl
+- [x] load_jsonl
 - [x] load_yaml
 - [x] map_assign
 - [ ] map_in_operator
-- [ ] map_index
-- [ ] map_int_key
-- [ ] map_literal_dynamic
+- [x] map_index
+- [x] map_int_key
+- [x] map_literal_dynamic
 - [ ] map_membership
-- [ ] map_nested_assign
-- [ ] match_expr
+- [x] map_nested_assign
+- [x] match_expr
 - [ ] match_full
-- [ ] math_ops
+- [x] math_ops
 - [ ] membership
 - [ ] min_max_builtin
 - [ ] mix_go_python

--- a/aster/x/cpp/ast.go
+++ b/aster/x/cpp/ast.go
@@ -113,6 +113,12 @@ func convert(n *sitter.Node, src []byte, opts Options) *Node {
 			op := strings.TrimSpace(string(src[n.StartByte():child.StartByte()]))
 			node.Text = op
 		}
+	} else if n.Kind() == "pointer_expression" && n.NamedChildCount() == 1 {
+		child := n.NamedChild(0)
+		if child != nil {
+			op := strings.TrimSpace(string(src[n.StartByte():child.StartByte()]))
+			node.Text = op
+		}
 	} else if n.Kind() == "function_declarator" && n.NamedChildCount() >= 1 {
 		child := n.NamedChild(0)
 		if child != nil {

--- a/aster/x/cpp/inspect_test.go
+++ b/aster/x/cpp/inspect_test.go
@@ -55,14 +55,11 @@ func TestInspect_Golden(t *testing.T) {
 		if base == "bench_block.cpp" || base == "closure.cpp" {
 			continue
 		}
-               count++
-               if count <= 30 {
-                       continue
-               }
-		selected = append(selected, f)
-		if len(selected) >= 10 {
-			break
+		count++
+		if count < 26 || count > 50 {
+			continue
 		}
+		selected = append(selected, f)
 	}
 	files = selected
 

--- a/aster/x/cpp/print.go
+++ b/aster/x/cpp/print.go
@@ -70,7 +70,8 @@ func writeStmt(b *bytes.Buffer, n *Node, indent int) {
 			b.WriteString(ind)
 			c := n.Children[0]
 			if c.Kind == "binary_expression" {
-				writeBinaryOp(b, c, indent, detectOperator(c))
+				op := strings.TrimSpace(c.Text)
+				writeBinaryOp(b, c, indent, op)
 			} else {
 				writeExpr(b, c, indent)
 			}
@@ -353,6 +354,11 @@ func writeExpr(b *bytes.Buffer, n *Node, indent int) {
 		for _, c := range n.Children {
 			writeExpr(b, c, indent)
 		}
+	case "pointer_expression":
+		b.WriteByte('*')
+		if len(n.Children) > 0 {
+			writeExpr(b, n.Children[0], indent)
+		}
 	case "function_declarator":
 		writeFunctionDeclarator(b, n, indent)
 	case "type_qualifier":
@@ -556,6 +562,9 @@ func writeBinaryOp(b *bytes.Buffer, n *Node, indent int, op string) {
 	if len(n.Children) != 2 {
 		b.WriteString(n.Kind)
 		return
+	}
+	if strings.TrimSpace(op) == "" {
+		op = detectOperator(n)
 	}
 	writeExpr(b, n.Children[0], indent)
 	b.WriteString(" " + op + " ")

--- a/aster/x/cpp/print_test.go
+++ b/aster/x/cpp/print_test.go
@@ -68,14 +68,11 @@ func TestPrint_Golden(t *testing.T) {
 		if base == "bench_block.cpp" || base == "closure.cpp" {
 			continue
 		}
-               count++
-               if count <= 30 {
-                       continue
-               }
-		selected = append(selected, f)
-		if len(selected) >= 10 {
-			break
+		count++
+		if count < 26 || count > 50 {
+			continue
 		}
+		selected = append(selected, f)
 	}
 	files = selected
 

--- a/scripts/update_cpp_readme.go
+++ b/scripts/update_cpp_readme.go
@@ -1,0 +1,9 @@
+//go:build archive
+
+package main
+
+import cpp "mochi/aster/x/cpp"
+
+func main() {
+	cpp.UpdateReadme()
+}


### PR DESCRIPTION
## Summary
- handle `pointer_expression` in the C++ printer
- improve operator printing logic
- limit golden tests to files 26‑50
- update README checklist for C++
- helper script to regenerate README

## Testing
- `go test -tags slow ./aster/x/cpp -run TestPrint_Golden/in_operator$ -update` *(fails: compile printed: exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_688b6cc0c780832085150740f55cde30