### PR TITLE
Improve C AST printer

### DIFF
--- a/aster/x/c/README.md
+++ b/aster/x/c/README.md
@@ -2,32 +2,34 @@
 
 Generated files for C programs live under `tests/aster/x/c`.
 
-Last updated: 2025-07-31 15:31 GMT+7
 
-## Golden Test Checklist (25/25)
-- [x] append_builtin.c
-- [x] avg_builtin.c
-- [x] basic_compare.c
-- [x] bench_block.c
-- [x] binary_precedence.c
-- [x] bool_chain.c
-- [x] break_continue.c
-- [x] cast_string_to_int.c
-- [x] cast_struct.c
-- [x] closure.c
-- [x] count_builtin.c
-- [x] cross_join.c
-- [x] cross_join_filter.c
-- [x] cross_join_triple.c
-- [x] dataset_sort_take_limit.c
-- [x] dataset_where_filter.c
-- [x] exists_builtin.c
-- [x] for_list_collection.c
-- [x] for_loop.c
-- [x] for_map_collection.c
-- [x] fun_call.c
-- [x] fun_expr_in_let.c
-- [x] fun_three_args.c
-- [x] go_auto.c
-- [x] group_by.c
+Checked: 25/25
+_Last updated: 2025-07-31 20:32 GMT+7_
+
+## Golden Test Checklist
+1. [x] append_builtin.c
+2. [x] avg_builtin.c
+3. [x] basic_compare.c
+4. [x] bench_block.c
+5. [x] binary_precedence.c
+6. [x] bool_chain.c
+7. [x] break_continue.c
+8. [x] cast_string_to_int.c
+9. [x] cast_struct.c
+10. [x] closure.c
+11. [x] count_builtin.c
+12. [x] cross_join.c
+13. [x] cross_join_filter.c
+14. [x] cross_join_triple.c
+15. [x] dataset_sort_take_limit.c
+16. [x] dataset_where_filter.c
+17. [x] exists_builtin.c
+18. [x] for_list_collection.c
+19. [x] for_loop.c
+20. [x] for_map_collection.c
+21. [x] fun_call.c
+22. [x] fun_expr_in_let.c
+23. [x] fun_three_args.c
+24. [x] go_auto.c
+25. [x] group_by.c
 


### PR DESCRIPTION
## Summary
- tweak C AST printer to construct declarations from parsed nodes
- handle pointer and cast expressions
- update C printer progress readme

## Testing
- `go test ./aster/x/c -c -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_688b6e6333ac83208c9c3966eff67224