### PR TITLE
Improve C AST printer

### DIFF
--- a/aster/x/c/README.md
+++ b/aster/x/c/README.md
@@ -2,7 +2,7 @@
 
 Generated files for C programs live under `tests/aster/x/c`.
 
-Last updated: 2025-07-31 15:31 GMT+7
+Last updated: 2025-07-31 20:46 GMT+7
 
 ## Golden Test Checklist (25/25)
 - [x] append_builtin.c

--- a/aster/x/c/ast.go
+++ b/aster/x/c/ast.go
@@ -118,13 +118,11 @@ func convert(n *sitter.Node, src []byte, pos bool) *Node {
 
 	switch node.Kind {
 	case "declaration":
-		if len(node.Children) == 1 && node.Children[0].Kind == "init_declarator" {
-			node.Text = n.Utf8Text(src)
-		}
+		// All pieces of a declaration are kept as children so the source
+		// can be reconstructed without relying on the original text.
 	case "function_definition":
-		if len(node.Children) < 3 {
-			node.Text = n.Utf8Text(src)
-		}
+		// Function definitions are printed from their children, so we no
+		// longer fall back to storing the original text.
 	}
 
 	if len(node.Children) == 0 && node.Text == "" {
@@ -137,6 +135,7 @@ func isValueNode(kind string) bool {
 	switch kind {
 	case "identifier", "field_identifier", "number_literal", "char_literal", "string_literal",
 		"system_lib_string", "primitive_type", "type_identifier",
+		"storage_class_specifier", "type_qualifier", "sized_type_specifier",
 		"string_content", "escape_sequence", "comment":
 		return true
 	default:

--- a/tests/aster/x/c/bench_block.c
+++ b/tests/aster/x/c/bench_block.c
@@ -5,17 +5,17 @@
 #include <malloc.h>
 #include <time.h>
 #include <stdlib.h>
-int seeded_now = 0;
-static long long now_seed = 0;;
+static int seeded_now = 0;
+static long long now_seed = 0;
 static long long _now(void) {
-    if (!seeded_now) {
+    if ((!seeded_now)) {
         const char *s = getenv("MOCHI_NOW_SEED");
-        if (s && *s) {
+        if ((s && *s)) {
             now_seed = atoll(s);
             seeded_now = 1;
         }
     }
-    if (seeded_now) {
+    if ((seeded_now)) {
         now_seed = (now_seed * 1664525 + 1013904223) % 2147483647;
         return now_seed;
     }
@@ -29,17 +29,17 @@ static long long _mem(void) {
 }
 int main(void) {
     {
-        long long __start = _now();;
-        long long __mem_start = _mem();;
+        long long __start = _now();
+        long long __mem_start = _mem();
         int n = 1000;
         int s = 0;
         for (int i = 1; i < n; i++) {
             s = s + i;
         }
-        long long __end = _now();;
-        long long __mem_end = _mem();;
-        long long __dur_us = (__end - __start) / 1000;;
-        long long __mem_bytes = __mem_end - __mem_start;;
+        long long __end = _now();
+        long long __mem_end = _mem();
+        long long __dur_us = (__end - __start) / 1000;
+        long long __mem_bytes = __mem_end - __mem_start;
         printf("{\n  \"duration_us\": %-lld,\n  \"memory_bytes\": %-lld,\n  \"name\": \"simple\"\n}\n", __dur_us, __mem_bytes);
     }
     return 0;

--- a/tests/aster/x/c/bench_block.c.json
+++ b/tests/aster/x/c/bench_block.c.json
@@ -64,6 +64,10 @@
         "kind": "declaration",
         "children": [
           {
+            "kind": "storage_class_specifier",
+            "text": "static"
+          },
+          {
             "kind": "primitive_type",
             "text": "int"
           },
@@ -84,8 +88,15 @@
       },
       {
         "kind": "declaration",
-        "text": "static long long now_seed = 0;",
         "children": [
+          {
+            "kind": "storage_class_specifier",
+            "text": "static"
+          },
+          {
+            "kind": "sized_type_specifier",
+            "text": "long long"
+          },
           {
             "kind": "init_declarator",
             "children": [
@@ -103,8 +114,15 @@
       },
       {
         "kind": "function_definition",
-        "text": "static long long _now(void) {\n    if (!seeded_now) {\n        const char *s = getenv(\"MOCHI_NOW_SEED\");\n        if (s \u0026\u0026 *s) {\n            now_seed = atoll(s);\n            seeded_now = 1;\n        }\n    }\n    if (seeded_now) {\n        now_seed = (now_seed * 1664525 + 1013904223) % 2147483647;\n        return now_seed;\n    }\n    struct timespec ts;\n    clock_gettime(CLOCK_REALTIME, \u0026ts);\n    return (long long)(ts.tv_sec * 1000000000LL + ts.tv_nsec);\n}",
         "children": [
+          {
+            "kind": "storage_class_specifier",
+            "text": "static"
+          },
+          {
+            "kind": "sized_type_specifier",
+            "text": "long long"
+          },
           {
             "kind": "function_declarator",
             "children": [
@@ -155,6 +173,10 @@
                       {
                         "kind": "declaration",
                         "children": [
+                          {
+                            "kind": "type_qualifier",
+                            "text": "const"
+                          },
                           {
                             "kind": "primitive_type",
                             "text": "char"
@@ -429,6 +451,15 @@
                     "kind": "cast_expression",
                     "children": [
                       {
+                        "kind": "type_descriptor",
+                        "children": [
+                          {
+                            "kind": "sized_type_specifier",
+                            "text": "long long"
+                          }
+                        ]
+                      },
+                      {
                         "kind": "parenthesized_expression",
                         "children": [
                           {
@@ -485,8 +516,15 @@
       },
       {
         "kind": "function_definition",
-        "text": "static long long _mem(void) {\n    struct mallinfo mi = mallinfo();\n    return (long long)mi.uordblks;\n}",
         "children": [
+          {
+            "kind": "storage_class_specifier",
+            "text": "static"
+          },
+          {
+            "kind": "sized_type_specifier",
+            "text": "long long"
+          },
           {
             "kind": "function_declarator",
             "children": [
@@ -552,6 +590,15 @@
                     "kind": "cast_expression",
                     "children": [
                       {
+                        "kind": "type_descriptor",
+                        "children": [
+                          {
+                            "kind": "sized_type_specifier",
+                            "text": "long long"
+                          }
+                        ]
+                      },
+                      {
                         "kind": "field_expression",
                         "children": [
                           {
@@ -610,8 +657,11 @@
                 "children": [
                   {
                     "kind": "declaration",
-                    "text": "long long __start = _now();",
                     "children": [
+                      {
+                        "kind": "sized_type_specifier",
+                        "text": "long long"
+                      },
                       {
                         "kind": "init_declarator",
                         "children": [
@@ -634,8 +684,11 @@
                   },
                   {
                     "kind": "declaration",
-                    "text": "long long __mem_start = _mem();",
                     "children": [
+                      {
+                        "kind": "sized_type_specifier",
+                        "text": "long long"
+                      },
                       {
                         "kind": "init_declarator",
                         "children": [
@@ -787,8 +840,11 @@
                   },
                   {
                     "kind": "declaration",
-                    "text": "long long __end = _now();",
                     "children": [
+                      {
+                        "kind": "sized_type_specifier",
+                        "text": "long long"
+                      },
                       {
                         "kind": "init_declarator",
                         "children": [
@@ -811,8 +867,11 @@
                   },
                   {
                     "kind": "declaration",
-                    "text": "long long __mem_end = _mem();",
                     "children": [
+                      {
+                        "kind": "sized_type_specifier",
+                        "text": "long long"
+                      },
                       {
                         "kind": "init_declarator",
                         "children": [
@@ -835,8 +894,11 @@
                   },
                   {
                     "kind": "declaration",
-                    "text": "long long __dur_us = (__end - __start) / 1000;",
                     "children": [
+                      {
+                        "kind": "sized_type_specifier",
+                        "text": "long long"
+                      },
                       {
                         "kind": "init_declarator",
                         "children": [
@@ -879,8 +941,11 @@
                   },
                   {
                     "kind": "declaration",
-                    "text": "long long __mem_bytes = __mem_end - __mem_start;",
                     "children": [
+                      {
+                        "kind": "sized_type_specifier",
+                        "text": "long long"
+                      },
                       {
                         "kind": "init_declarator",
                         "children": [

--- a/tests/aster/x/c/cast_struct.c
+++ b/tests/aster/x/c/cast_struct.c
@@ -3,7 +3,7 @@
 #include <string.h>
 typedef struct Todo Todo;
 struct Todo {
-    char *title;
+    const char *title;
 };
 Todo todo = (Todo){.title = "hi"};
 int main(void) {

--- a/tests/aster/x/c/cast_struct.c.json
+++ b/tests/aster/x/c/cast_struct.c.json
@@ -56,6 +56,10 @@
                 "kind": "field_declaration",
                 "children": [
                   {
+                    "kind": "type_qualifier",
+                    "text": "const"
+                  },
+                  {
                     "kind": "primitive_type",
                     "text": "char"
                   },

--- a/tests/aster/x/c/cross_join.c
+++ b/tests/aster/x/c/cross_join.c
@@ -10,15 +10,15 @@ struct Anon5 {
     int orderCustomerId;
     int orderId;
     int orderTotal;
-    char *pairedCustomerName;
+    const char *pairedCustomerName;
 };
 struct Customers {
     int id;
-    char *name;
+    const char *name;
 };
 struct Data2 {
     int id;
-    char *name;
+    const char *name;
 };
 struct Data4 {
     int id;

--- a/tests/aster/x/c/cross_join.c.json
+++ b/tests/aster/x/c/cross_join.c.json
@@ -167,6 +167,10 @@
                 "kind": "field_declaration",
                 "children": [
                   {
+                    "kind": "type_qualifier",
+                    "text": "const"
+                  },
+                  {
                     "kind": "primitive_type",
                     "text": "char"
                   },
@@ -212,6 +216,10 @@
                 "kind": "field_declaration",
                 "children": [
                   {
+                    "kind": "type_qualifier",
+                    "text": "const"
+                  },
+                  {
                     "kind": "primitive_type",
                     "text": "char"
                   },
@@ -256,6 +264,10 @@
               {
                 "kind": "field_declaration",
                 "children": [
+                  {
+                    "kind": "type_qualifier",
+                    "text": "const"
+                  },
                   {
                     "kind": "primitive_type",
                     "text": "char"

--- a/tests/aster/x/c/cross_join_filter.c
+++ b/tests/aster/x/c/cross_join_filter.c
@@ -4,10 +4,10 @@
 typedef struct Pair Pair;
 struct Pair {
     int n;
-    char *l;
+    const char *l;
 };
 int nums[] = {1,2,3};
-char *letters[] = {"A","B"};
+const char *letters[] = {"A","B"};
 int main(void) {
     Pair pairs[] = {(Pair){.n = 2,.l = "A"},(Pair){.n = 2,.l = "B"}};
     puts("--- Even pairs ---");

--- a/tests/aster/x/c/cross_join_filter.c.json
+++ b/tests/aster/x/c/cross_join_filter.c.json
@@ -69,6 +69,10 @@
                 "kind": "field_declaration",
                 "children": [
                   {
+                    "kind": "type_qualifier",
+                    "text": "const"
+                  },
+                  {
                     "kind": "primitive_type",
                     "text": "char"
                   },
@@ -130,6 +134,10 @@
       {
         "kind": "declaration",
         "children": [
+          {
+            "kind": "type_qualifier",
+            "text": "const"
+          },
           {
             "kind": "primitive_type",
             "text": "char"

--- a/tests/aster/x/c/cross_join_triple.c
+++ b/tests/aster/x/c/cross_join_triple.c
@@ -4,11 +4,11 @@
 typedef struct Anon1 Anon1;
 struct Anon1 {
     int b;
-    char *l;
+    const char *l;
     int n;
 };
 int nums[] = {1,2};
-char *letters[] = {"A","B"};
+const char *letters[] = {"A","B"};
 int bools[] = {1,0};
 Anon1 combos[] = {(Anon1){.b = 1,.l = "A",.n = 1},(Anon1){.b = 0,.l = "A",.n = 1},(Anon1){.b = 1,.l = "B",.n = 1},(Anon1){.b = 0,.l = "B",.n = 1},(Anon1){.b = 1,.l = "A",.n = 2},(Anon1){.b = 0,.l = "A",.n = 2},(Anon1){.b = 1,.l = "B",.n = 2},(Anon1){.b = 0,.l = "B",.n = 2}};
 int main(void) {

--- a/tests/aster/x/c/cross_join_triple.c.json
+++ b/tests/aster/x/c/cross_join_triple.c.json
@@ -69,6 +69,10 @@
                 "kind": "field_declaration",
                 "children": [
                   {
+                    "kind": "type_qualifier",
+                    "text": "const"
+                  },
+                  {
                     "kind": "primitive_type",
                     "text": "char"
                   },
@@ -139,6 +143,10 @@
       {
         "kind": "declaration",
         "children": [
+          {
+            "kind": "type_qualifier",
+            "text": "const"
+          },
           {
             "kind": "primitive_type",
             "text": "char"

--- a/tests/aster/x/c/dataset_sort_take_limit.c
+++ b/tests/aster/x/c/dataset_sort_take_limit.c
@@ -5,15 +5,15 @@ typedef struct Anon3 Anon3;
 typedef struct Data2 Data2;
 typedef struct Products Products;
 struct Anon3 {
-    char *name;
+    const char *name;
     int price;
 };
 struct Data2 {
-    char *name;
+    const char *name;
     int price;
 };
 struct Products {
-    char *name;
+    const char *name;
     int price;
 };
 Products products[] = {(Products){.name = "Laptop",.price = 1500},(Products){.name = "Smartphone",.price = 900},(Products){.name = "Tablet",.price = 600},(Products){.name = "Monitor",.price = 300},(Products){.name = "Keyboard",.price = 100},(Products){.name = "Mouse",.price = 50},(Products){.name = "Headphones",.price = 200}};

--- a/tests/aster/x/c/dataset_sort_take_limit.c.json
+++ b/tests/aster/x/c/dataset_sort_take_limit.c.json
@@ -92,6 +92,10 @@
                 "kind": "field_declaration",
                 "children": [
                   {
+                    "kind": "type_qualifier",
+                    "text": "const"
+                  },
+                  {
                     "kind": "primitive_type",
                     "text": "char"
                   },
@@ -137,6 +141,10 @@
                 "kind": "field_declaration",
                 "children": [
                   {
+                    "kind": "type_qualifier",
+                    "text": "const"
+                  },
+                  {
                     "kind": "primitive_type",
                     "text": "char"
                   },
@@ -181,6 +189,10 @@
               {
                 "kind": "field_declaration",
                 "children": [
+                  {
+                    "kind": "type_qualifier",
+                    "text": "const"
+                  },
                   {
                     "kind": "primitive_type",
                     "text": "char"

--- a/tests/aster/x/c/dataset_where_filter.c
+++ b/tests/aster/x/c/dataset_where_filter.c
@@ -6,26 +6,26 @@ typedef struct Anon3 Anon3;
 typedef struct Data2 Data2;
 typedef struct People People;
 struct Adult {
-    char *name;
+    const char *name;
     int age;
     int is_senior;
 };
 struct Anon3 {
     int age;
-    char *name;
+    const char *name;
 };
 struct Data2 {
-    char *name;
+    const char *name;
     int age;
 };
 struct People {
-    char *name;
+    const char *name;
     int age;
 };
 People people[] = {(People){.name = "Alice",.age = 30},(People){.name = "Bob",.age = 15},(People){.name = "Charlie",.age = 65},(People){.name = "Diana",.age = 45}};
 int main(void) {
     struct Adult {
-        char *name;
+        const char *name;
         int age;
         int is_senior;
     };

--- a/tests/aster/x/c/dataset_where_filter.c.json
+++ b/tests/aster/x/c/dataset_where_filter.c.json
@@ -110,6 +110,10 @@
                 "kind": "field_declaration",
                 "children": [
                   {
+                    "kind": "type_qualifier",
+                    "text": "const"
+                  },
+                  {
                     "kind": "primitive_type",
                     "text": "char"
                   },
@@ -181,6 +185,10 @@
                 "kind": "field_declaration",
                 "children": [
                   {
+                    "kind": "type_qualifier",
+                    "text": "const"
+                  },
+                  {
                     "kind": "primitive_type",
                     "text": "char"
                   },
@@ -212,6 +220,10 @@
               {
                 "kind": "field_declaration",
                 "children": [
+                  {
+                    "kind": "type_qualifier",
+                    "text": "const"
+                  },
                   {
                     "kind": "primitive_type",
                     "text": "char"
@@ -257,6 +269,10 @@
               {
                 "kind": "field_declaration",
                 "children": [
+                  {
+                    "kind": "type_qualifier",
+                    "text": "const"
+                  },
                   {
                     "kind": "primitive_type",
                     "text": "char"
@@ -603,6 +619,10 @@
                       {
                         "kind": "field_declaration",
                         "children": [
+                          {
+                            "kind": "type_qualifier",
+                            "text": "const"
+                          },
                           {
                             "kind": "primitive_type",
                             "text": "char"

--- a/tests/aster/x/c/for_map_collection.c
+++ b/tests/aster/x/c/for_map_collection.c
@@ -3,10 +3,10 @@
 #include <string.h>
 int main(void) {
     {
-        char *k_arr[] = {"a","b"};
+        const char *k_arr[] = {"a","b"};
         size_t k_len = sizeof((k_arr)) / sizeof((k_arr[0]));
         for (size_t i = 0; i < k_len; i++) {
-            char *k = k_arr[i];
+            const char *k = k_arr[i];
             puts(k);
         }
     }

--- a/tests/aster/x/c/for_map_collection.c.json
+++ b/tests/aster/x/c/for_map_collection.c.json
@@ -64,6 +64,10 @@
                     "kind": "declaration",
                     "children": [
                       {
+                        "kind": "type_qualifier",
+                        "text": "const"
+                      },
+                      {
                         "kind": "primitive_type",
                         "text": "char"
                       },
@@ -227,6 +231,10 @@
                           {
                             "kind": "declaration",
                             "children": [
+                              {
+                                "kind": "type_qualifier",
+                                "text": "const"
+                              },
                               {
                                 "kind": "primitive_type",
                                 "text": "char"

--- a/tests/aster/x/c/group_by.c
+++ b/tests/aster/x/c/group_by.c
@@ -7,18 +7,18 @@ typedef struct Data2 Data2;
 typedef struct People People;
 struct Anon3 {
     double avg_age;
-    char *city;
+    const char *city;
     int count;
 };
 struct Data2 {
-    char *name;
+    const char *name;
     int age;
-    char *city;
+    const char *city;
 };
 struct People {
-    char *name;
+    const char *name;
     int age;
-    char *city;
+    const char *city;
 };
 People people[] = {(People){.name = "Alice",.age = 30,.city = "Paris"},(People){.name = "Bob",.age = 15,.city = "Hanoi"},(People){.name = "Charlie",.age = 65,.city = "Paris"},(People){.name = "Diana",.age = 45,.city = "Hanoi"},(People){.name = "Eve",.age = 70,.city = "Paris"},(People){.name = "Frank",.age = 22,.city = "Hanoi"}};
 Anon3 stats[] = {(Anon3){.avg_age = 55,.city = "Paris",.count = 3},(Anon3){.avg_age = 27.333333333333332,.city = "Hanoi",.count = 3}};

--- a/tests/aster/x/c/group_by.c.json
+++ b/tests/aster/x/c/group_by.c.json
@@ -114,6 +114,10 @@
                 "kind": "field_declaration",
                 "children": [
                   {
+                    "kind": "type_qualifier",
+                    "text": "const"
+                  },
+                  {
                     "kind": "primitive_type",
                     "text": "char"
                   },
@@ -159,6 +163,10 @@
                 "kind": "field_declaration",
                 "children": [
                   {
+                    "kind": "type_qualifier",
+                    "text": "const"
+                  },
+                  {
                     "kind": "primitive_type",
                     "text": "char"
                   },
@@ -189,6 +197,10 @@
               {
                 "kind": "field_declaration",
                 "children": [
+                  {
+                    "kind": "type_qualifier",
+                    "text": "const"
+                  },
                   {
                     "kind": "primitive_type",
                     "text": "char"
@@ -222,6 +234,10 @@
                 "kind": "field_declaration",
                 "children": [
                   {
+                    "kind": "type_qualifier",
+                    "text": "const"
+                  },
+                  {
                     "kind": "primitive_type",
                     "text": "char"
                   },
@@ -252,6 +268,10 @@
               {
                 "kind": "field_declaration",
                 "children": [
+                  {
+                    "kind": "type_qualifier",
+                    "text": "const"
+                  },
                   {
                     "kind": "primitive_type",
                     "text": "char"


### PR DESCRIPTION
## Summary
- expand conversion to keep more node kinds for C
- rebuild C source strictly from AST, avoiding original source strings
- handle new expression forms like casts and unary operators
- update golden outputs for C examples

## Testing
- `go test -tags=slow ./aster/x/c -run TestPrint_Golden -update`
- `go test -tags=slow ./aster/x/c -run TestPrint_Golden`

------
https://chatgpt.com/codex/tasks/task_e_688b706f17548320b8a365ae3d0f0c44