### PR TITLE
Add scheme group_by golden data

### DIFF
--- a/aster/x/scheme/README.md
+++ b/aster/x/scheme/README.md
@@ -2,9 +2,9 @@
 
 Generated files for Scheme programs live under `tests/aster/x/scheme`.
 
-Last updated: 2025-07-31 19:27 GMT+7
+Last updated: 2025-07-31 20:46 GMT+7
 
-## Golden Test Checklist (49/87)
+## Golden Test Checklist (51/87)
 - [x] append_builtin.scm
 - [x] avg_builtin.scm
 - [x] basic_compare.scm
@@ -28,6 +28,8 @@ Last updated: 2025-07-31 19:27 GMT+7
 - [x] fun_call.scm
 - [x] fun_expr_in_let.scm
 - [x] fun_three_args.scm
+- [x] group_by.scm
+- [x] group_by_conditional_sum.scm
 - [x] two-sum.scm
 - [x] group_by_join.scm
 - [x] group_by_left_join.scm

--- a/tests/aster/x/scheme/group_by.scheme.json
+++ b/tests/aster/x/scheme/group_by.scheme.json
@@ -1,0 +1,1514 @@
+{
+  "forms": [
+    {
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "import"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "srfi"
+            },
+            {
+              "kind": "number",
+              "text": "1"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "srfi"
+            },
+            {
+              "kind": "number",
+              "text": "69"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "chibi"
+            },
+            {
+              "kind": "symbol",
+              "text": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "symbol",
+          "text": "people"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "list"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "list"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"name\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"Alice\""
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"age\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "30"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"city\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"Paris\""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "list"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"name\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"Bob\""
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"age\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "15"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"city\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"Hanoi\""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "list"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"name\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"Charlie\""
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"age\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "65"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"city\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"Paris\""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "list"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"name\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"Diana\""
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"age\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "45"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"city\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"Hanoi\""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "list"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"name\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"Eve\""
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"age\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "70"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"city\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"Paris\""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "list"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"name\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"Frank\""
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"age\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "22"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"city\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"Hanoi\""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "symbol",
+          "text": "stats"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "let"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "groups8"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "make-hash-table"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "res11"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "list"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "begin"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "for-each"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "lambda"
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "person"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "let*"
+                            },
+                            {
+                              "kind": "list",
+                              "children": [
+                                {
+                                  "kind": "list",
+                                  "children": [
+                                    {
+                                      "kind": "symbol",
+                                      "text": "k10"
+                                    },
+                                    {
+                                      "kind": "list",
+                                      "children": [
+                                        {
+                                          "kind": "symbol",
+                                          "text": "hash-table-ref"
+                                        },
+                                        {
+                                          "kind": "symbol",
+                                          "text": "person"
+                                        },
+                                        {
+                                          "kind": "string",
+                                          "text": "\"city\""
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "list",
+                                  "children": [
+                                    {
+                                      "kind": "symbol",
+                                      "text": "g9"
+                                    },
+                                    {
+                                      "kind": "list",
+                                      "children": [
+                                        {
+                                          "kind": "symbol",
+                                          "text": "hash-table-ref/default"
+                                        },
+                                        {
+                                          "kind": "symbol",
+                                          "text": "groups8"
+                                        },
+                                        {
+                                          "kind": "symbol",
+                                          "text": "k10"
+                                        },
+                                        {
+                                          "kind": "boolean",
+                                          "text": "#f"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "list",
+                              "children": [
+                                {
+                                  "kind": "symbol",
+                                  "text": "begin"
+                                },
+                                {
+                                  "kind": "list",
+                                  "children": [
+                                    {
+                                      "kind": "symbol",
+                                      "text": "if"
+                                    },
+                                    {
+                                      "kind": "list",
+                                      "children": [
+                                        {
+                                          "kind": "symbol",
+                                          "text": "not"
+                                        },
+                                        {
+                                          "kind": "symbol",
+                                          "text": "g9"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "list",
+                                      "children": [
+                                        {
+                                          "kind": "symbol",
+                                          "text": "begin"
+                                        },
+                                        {
+                                          "kind": "list",
+                                          "children": [
+                                            {
+                                              "kind": "symbol",
+                                              "text": "set!"
+                                            },
+                                            {
+                                              "kind": "symbol",
+                                              "text": "g9"
+                                            },
+                                            {
+                                              "kind": "list",
+                                              "children": [
+                                                {
+                                                  "kind": "symbol",
+                                                  "text": "alist-\u003ehash-table"
+                                                },
+                                                {
+                                                  "kind": "list",
+                                                  "children": [
+                                                    {
+                                                      "kind": "symbol",
+                                                      "text": "list"
+                                                    },
+                                                    {
+                                                      "kind": "list",
+                                                      "children": [
+                                                        {
+                                                          "kind": "symbol",
+                                                          "text": "cons"
+                                                        },
+                                                        {
+                                                          "kind": "string",
+                                                          "text": "\"key\""
+                                                        },
+                                                        {
+                                                          "kind": "symbol",
+                                                          "text": "k10"
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "list",
+                                                      "children": [
+                                                        {
+                                                          "kind": "symbol",
+                                                          "text": "cons"
+                                                        },
+                                                        {
+                                                          "kind": "string",
+                                                          "text": "\"items\""
+                                                        },
+                                                        {
+                                                          "kind": "list",
+                                                          "children": [
+                                                            {
+                                                              "kind": "symbol",
+                                                              "text": "list"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "list",
+                                          "children": [
+                                            {
+                                              "kind": "symbol",
+                                              "text": "hash-table-set!"
+                                            },
+                                            {
+                                              "kind": "symbol",
+                                              "text": "groups8"
+                                            },
+                                            {
+                                              "kind": "symbol",
+                                              "text": "k10"
+                                            },
+                                            {
+                                              "kind": "symbol",
+                                              "text": "g9"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "list",
+                                      "children": [
+                                        {
+                                          "kind": "symbol",
+                                          "text": "quote"
+                                        },
+                                        {
+                                          "kind": "symbol",
+                                          "text": "nil"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "list",
+                                  "children": [
+                                    {
+                                      "kind": "symbol",
+                                      "text": "hash-table-set!"
+                                    },
+                                    {
+                                      "kind": "symbol",
+                                      "text": "g9"
+                                    },
+                                    {
+                                      "kind": "string",
+                                      "text": "\"items\""
+                                    },
+                                    {
+                                      "kind": "list",
+                                      "children": [
+                                        {
+                                          "kind": "symbol",
+                                          "text": "append"
+                                        },
+                                        {
+                                          "kind": "list",
+                                          "children": [
+                                            {
+                                              "kind": "symbol",
+                                              "text": "hash-table-ref"
+                                            },
+                                            {
+                                              "kind": "symbol",
+                                              "text": "g9"
+                                            },
+                                            {
+                                              "kind": "string",
+                                              "text": "\"items\""
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "list",
+                                          "children": [
+                                            {
+                                              "kind": "symbol",
+                                              "text": "list"
+                                            },
+                                            {
+                                              "kind": "list",
+                                              "children": [
+                                                {
+                                                  "kind": "symbol",
+                                                  "text": "alist-\u003ehash-table"
+                                                },
+                                                {
+                                                  "kind": "list",
+                                                  "children": [
+                                                    {
+                                                      "kind": "symbol",
+                                                      "text": "list"
+                                                    },
+                                                    {
+                                                      "kind": "list",
+                                                      "children": [
+                                                        {
+                                                          "kind": "symbol",
+                                                          "text": "cons"
+                                                        },
+                                                        {
+                                                          "kind": "string",
+                                                          "text": "\"person\""
+                                                        },
+                                                        {
+                                                          "kind": "symbol",
+                                                          "text": "person"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "symbol",
+                      "text": "people"
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "for-each"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "lambda"
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "g"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "set!"
+                            },
+                            {
+                              "kind": "symbol",
+                              "text": "res11"
+                            },
+                            {
+                              "kind": "list",
+                              "children": [
+                                {
+                                  "kind": "symbol",
+                                  "text": "append"
+                                },
+                                {
+                                  "kind": "symbol",
+                                  "text": "res11"
+                                },
+                                {
+                                  "kind": "list",
+                                  "children": [
+                                    {
+                                      "kind": "symbol",
+                                      "text": "list"
+                                    },
+                                    {
+                                      "kind": "list",
+                                      "children": [
+                                        {
+                                          "kind": "symbol",
+                                          "text": "alist-\u003ehash-table"
+                                        },
+                                        {
+                                          "kind": "list",
+                                          "children": [
+                                            {
+                                              "kind": "symbol",
+                                              "text": "list"
+                                            },
+                                            {
+                                              "kind": "list",
+                                              "children": [
+                                                {
+                                                  "kind": "symbol",
+                                                  "text": "cons"
+                                                },
+                                                {
+                                                  "kind": "string",
+                                                  "text": "\"city\""
+                                                },
+                                                {
+                                                  "kind": "list",
+                                                  "children": [
+                                                    {
+                                                      "kind": "symbol",
+                                                      "text": "hash-table-ref"
+                                                    },
+                                                    {
+                                                      "kind": "symbol",
+                                                      "text": "g"
+                                                    },
+                                                    {
+                                                      "kind": "string",
+                                                      "text": "\"key\""
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "list",
+                                              "children": [
+                                                {
+                                                  "kind": "symbol",
+                                                  "text": "cons"
+                                                },
+                                                {
+                                                  "kind": "string",
+                                                  "text": "\"count\""
+                                                },
+                                                {
+                                                  "kind": "list",
+                                                  "children": [
+                                                    {
+                                                      "kind": "symbol",
+                                                      "text": "length"
+                                                    },
+                                                    {
+                                                      "kind": "list",
+                                                      "children": [
+                                                        {
+                                                          "kind": "symbol",
+                                                          "text": "hash-table-ref"
+                                                        },
+                                                        {
+                                                          "kind": "symbol",
+                                                          "text": "g"
+                                                        },
+                                                        {
+                                                          "kind": "string",
+                                                          "text": "\"items\""
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "list",
+                                              "children": [
+                                                {
+                                                  "kind": "symbol",
+                                                  "text": "cons"
+                                                },
+                                                {
+                                                  "kind": "string",
+                                                  "text": "\"avg_age\""
+                                                },
+                                                {
+                                                  "kind": "list",
+                                                  "children": [
+                                                    {
+                                                      "kind": "symbol",
+                                                      "text": "let"
+                                                    },
+                                                    {
+                                                      "kind": "list",
+                                                      "children": [
+                                                        {
+                                                          "kind": "list",
+                                                          "children": [
+                                                            {
+                                                              "kind": "symbol",
+                                                              "text": "xs"
+                                                            },
+                                                            {
+                                                              "kind": "list",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "symbol",
+                                                                  "text": "let"
+                                                                },
+                                                                {
+                                                                  "kind": "list",
+                                                                  "children": [
+                                                                    {
+                                                                      "kind": "list",
+                                                                      "children": [
+                                                                        {
+                                                                          "kind": "symbol",
+                                                                          "text": "res7"
+                                                                        },
+                                                                        {
+                                                                          "kind": "list",
+                                                                          "children": [
+                                                                            {
+                                                                              "kind": "symbol",
+                                                                              "text": "list"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                {
+                                                                  "kind": "list",
+                                                                  "children": [
+                                                                    {
+                                                                      "kind": "symbol",
+                                                                      "text": "begin"
+                                                                    },
+                                                                    {
+                                                                      "kind": "list",
+                                                                      "children": [
+                                                                        {
+                                                                          "kind": "symbol",
+                                                                          "text": "for-each"
+                                                                        },
+                                                                        {
+                                                                          "kind": "list",
+                                                                          "children": [
+                                                                            {
+                                                                              "kind": "symbol",
+                                                                              "text": "lambda"
+                                                                            },
+                                                                            {
+                                                                              "kind": "list",
+                                                                              "children": [
+                                                                                {
+                                                                                  "kind": "symbol",
+                                                                                  "text": "p"
+                                                                                }
+                                                                              ]
+                                                                            },
+                                                                            {
+                                                                              "kind": "list",
+                                                                              "children": [
+                                                                                {
+                                                                                  "kind": "symbol",
+                                                                                  "text": "set!"
+                                                                                },
+                                                                                {
+                                                                                  "kind": "symbol",
+                                                                                  "text": "res7"
+                                                                                },
+                                                                                {
+                                                                                  "kind": "list",
+                                                                                  "children": [
+                                                                                    {
+                                                                                      "kind": "symbol",
+                                                                                      "text": "append"
+                                                                                    },
+                                                                                    {
+                                                                                      "kind": "symbol",
+                                                                                      "text": "res7"
+                                                                                    },
+                                                                                    {
+                                                                                      "kind": "list",
+                                                                                      "children": [
+                                                                                        {
+                                                                                          "kind": "symbol",
+                                                                                          "text": "list"
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "list",
+                                                                                          "children": [
+                                                                                            {
+                                                                                              "kind": "symbol",
+                                                                                              "text": "hash-table-ref"
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "symbol",
+                                                                                              "text": "p"
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "string",
+                                                                                              "text": "\"age\""
+                                                                                            }
+                                                                                          ]
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  ]
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          ]
+                                                                        },
+                                                                        {
+                                                                          "kind": "list",
+                                                                          "children": [
+                                                                            {
+                                                                              "kind": "symbol",
+                                                                              "text": "hash-table-ref"
+                                                                            },
+                                                                            {
+                                                                              "kind": "symbol",
+                                                                              "text": "g"
+                                                                            },
+                                                                            {
+                                                                              "kind": "string",
+                                                                              "text": "\"items\""
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "kind": "symbol",
+                                                                      "text": "res7"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "list",
+                                                      "children": [
+                                                        {
+                                                          "kind": "symbol",
+                                                          "text": "exact-\u003einexact"
+                                                        },
+                                                        {
+                                                          "kind": "list",
+                                                          "children": [
+                                                            {
+                                                              "kind": "symbol",
+                                                              "text": "/"
+                                                            },
+                                                            {
+                                                              "kind": "list",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "symbol",
+                                                                  "text": "apply"
+                                                                },
+                                                                {
+                                                                  "kind": "symbol",
+                                                                  "text": "+"
+                                                                },
+                                                                {
+                                                                  "kind": "symbol",
+                                                                  "text": "xs"
+                                                                }
+                                                              ]
+                                                            },
+                                                            {
+                                                              "kind": "list",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "symbol",
+                                                                  "text": "length"
+                                                                },
+                                                                {
+                                                                  "kind": "symbol",
+                                                                  "text": "xs"
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "hash-table-values"
+                        },
+                        {
+                          "kind": "symbol",
+                          "text": "groups8"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "symbol",
+                  "text": "res11"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "display"
+        },
+        {
+          "kind": "string",
+          "text": "\"--- People grouped by city ---\""
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "newline"
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "for-each"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "lambda"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "s"
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "begin"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "display"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
+                        },
+                        {
+                          "kind": "symbol",
+                          "text": "s"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"city\""
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "display"
+                    },
+                    {
+                      "kind": "string",
+                      "text": "\" \""
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "display"
+                    },
+                    {
+                      "kind": "string",
+                      "text": "\": count =\""
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "display"
+                    },
+                    {
+                      "kind": "string",
+                      "text": "\" \""
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "display"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
+                        },
+                        {
+                          "kind": "symbol",
+                          "text": "s"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"count\""
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "display"
+                    },
+                    {
+                      "kind": "string",
+                      "text": "\" \""
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "display"
+                    },
+                    {
+                      "kind": "string",
+                      "text": "\", avg_age =\""
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "display"
+                    },
+                    {
+                      "kind": "string",
+                      "text": "\" \""
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "display"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
+                        },
+                        {
+                          "kind": "symbol",
+                          "text": "s"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"avg_age\""
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "newline"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "symbol",
+          "text": "stats"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/scheme/group_by.scm
+++ b/tests/aster/x/scheme/group_by.scm
@@ -1,0 +1,123 @@
+;; Generated on 2025-07-21 17:26 +0700
+(import
+  (srfi 1)
+  (srfi 69)
+  (chibi string))
+(define people
+  (list
+    (alist->hash-table
+      (list
+        (cons "name" "Alice")
+        (cons "age" 30)
+        (cons "city" "Paris")))
+    (alist->hash-table
+      (list
+        (cons "name" "Bob")
+        (cons "age" 15)
+        (cons "city" "Hanoi")))
+    (alist->hash-table
+      (list
+        (cons "name" "Charlie")
+        (cons "age" 65)
+        (cons "city" "Paris")))
+    (alist->hash-table
+      (list
+        (cons "name" "Diana")
+        (cons "age" 45)
+        (cons "city" "Hanoi")))
+    (alist->hash-table
+      (list
+        (cons "name" "Eve")
+        (cons "age" 70)
+        (cons "city" "Paris")))
+    (alist->hash-table
+      (list
+        (cons "name" "Frank")
+        (cons "age" 22)
+        (cons "city" "Hanoi")))))
+(define stats
+  (let
+    ((groups8
+        (make-hash-table))
+      (res11
+        (list)))
+    (begin
+      (for-each
+        (lambda
+          (person)
+          (let*
+            ((k10
+                (hash-table-ref person "city"))
+              (g9
+                (hash-table-ref/default groups8 k10 #f)))
+            (begin
+              (if
+                (not g9)
+                (begin
+                  (set! g9
+                    (alist->hash-table
+                      (list
+                        (cons "key" k10)
+                        (cons "items"
+                          (list)))))
+                  (hash-table-set! groups8 k10 g9))
+                (quote nil))
+              (hash-table-set! g9 "items"
+                (append
+                  (hash-table-ref g9 "items")
+                  (list
+                    (alist->hash-table
+                      (list
+                        (cons "person" person))))))))) people)
+      (for-each
+        (lambda
+          (g)
+          (set! res11
+            (append res11
+              (list
+                (alist->hash-table
+                  (list
+                    (cons "city"
+                      (hash-table-ref g "key"))
+                    (cons "count"
+                      (length
+                        (hash-table-ref g "items")))
+                    (cons "avg_age"
+                      (let
+                        ((xs
+                            (let
+                              ((res7
+                                  (list)))
+                              (begin
+                                (for-each
+                                  (lambda
+                                    (p)
+                                    (set! res7
+                                      (append res7
+                                        (list
+                                          (hash-table-ref p "age")))))
+                                  (hash-table-ref g "items")) res7))))
+                        (exact->inexact
+                          (/
+                            (apply + xs)
+                            (length xs)))))))))))
+        (hash-table-values groups8)) res11)))
+(display "--- People grouped by city ---")
+(newline)
+(for-each
+  (lambda
+    (s)
+    (begin
+      (display
+        (hash-table-ref s "city"))
+      (display " ")
+      (display ": count =")
+      (display " ")
+      (display
+        (hash-table-ref s "count"))
+      (display " ")
+      (display ", avg_age =")
+      (display " ")
+      (display
+        (hash-table-ref s "avg_age"))
+      (newline))) stats)

--- a/tests/aster/x/scheme/group_by_conditional_sum.scheme.json
+++ b/tests/aster/x/scheme/group_by_conditional_sum.scheme.json
@@ -1,0 +1,813 @@
+{
+  "forms": [
+    {
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "import"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "srfi"
+            },
+            {
+              "kind": "number",
+              "text": "1"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "srfi"
+            },
+            {
+              "kind": "number",
+              "text": "69"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "chibi"
+            },
+            {
+              "kind": "symbol",
+              "text": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "symbol",
+          "text": "items"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "list"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "list"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"cat\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"a\""
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"val\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "10"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"flag\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"true\""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "list"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"cat\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"a\""
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"val\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "5"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"flag\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"false\""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "list"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"cat\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"b\""
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"val\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "20"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"flag\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"true\""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "symbol",
+          "text": "result"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "let"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "res14"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "list"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "begin"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "for-each"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "lambda"
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "i"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "set!"
+                            },
+                            {
+                              "kind": "symbol",
+                              "text": "res14"
+                            },
+                            {
+                              "kind": "list",
+                              "children": [
+                                {
+                                  "kind": "symbol",
+                                  "text": "append"
+                                },
+                                {
+                                  "kind": "symbol",
+                                  "text": "res14"
+                                },
+                                {
+                                  "kind": "list",
+                                  "children": [
+                                    {
+                                      "kind": "symbol",
+                                      "text": "list"
+                                    },
+                                    {
+                                      "kind": "list",
+                                      "children": [
+                                        {
+                                          "kind": "symbol",
+                                          "text": "alist-\u003ehash-table"
+                                        },
+                                        {
+                                          "kind": "list",
+                                          "children": [
+                                            {
+                                              "kind": "symbol",
+                                              "text": "list"
+                                            },
+                                            {
+                                              "kind": "list",
+                                              "children": [
+                                                {
+                                                  "kind": "symbol",
+                                                  "text": "cons"
+                                                },
+                                                {
+                                                  "kind": "string",
+                                                  "text": "\"cat\""
+                                                },
+                                                {
+                                                  "kind": "list",
+                                                  "children": [
+                                                    {
+                                                      "kind": "symbol",
+                                                      "text": "hash-table-ref"
+                                                    },
+                                                    {
+                                                      "kind": "symbol",
+                                                      "text": "g"
+                                                    },
+                                                    {
+                                                      "kind": "string",
+                                                      "text": "\"key\""
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "list",
+                                              "children": [
+                                                {
+                                                  "kind": "symbol",
+                                                  "text": "cons"
+                                                },
+                                                {
+                                                  "kind": "string",
+                                                  "text": "\"share\""
+                                                },
+                                                {
+                                                  "kind": "list",
+                                                  "children": [
+                                                    {
+                                                      "kind": "symbol",
+                                                      "text": "quotient"
+                                                    },
+                                                    {
+                                                      "kind": "list",
+                                                      "children": [
+                                                        {
+                                                          "kind": "symbol",
+                                                          "text": "apply"
+                                                        },
+                                                        {
+                                                          "kind": "symbol",
+                                                          "text": "+"
+                                                        },
+                                                        {
+                                                          "kind": "list",
+                                                          "children": [
+                                                            {
+                                                              "kind": "symbol",
+                                                              "text": "let"
+                                                            },
+                                                            {
+                                                              "kind": "list",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "list",
+                                                                  "children": [
+                                                                    {
+                                                                      "kind": "symbol",
+                                                                      "text": "res12"
+                                                                    },
+                                                                    {
+                                                                      "kind": "list",
+                                                                      "children": [
+                                                                        {
+                                                                          "kind": "symbol",
+                                                                          "text": "list"
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              ]
+                                                            },
+                                                            {
+                                                              "kind": "list",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "symbol",
+                                                                  "text": "begin"
+                                                                },
+                                                                {
+                                                                  "kind": "list",
+                                                                  "children": [
+                                                                    {
+                                                                      "kind": "symbol",
+                                                                      "text": "for-each"
+                                                                    },
+                                                                    {
+                                                                      "kind": "list",
+                                                                      "children": [
+                                                                        {
+                                                                          "kind": "symbol",
+                                                                          "text": "lambda"
+                                                                        },
+                                                                        {
+                                                                          "kind": "list",
+                                                                          "children": [
+                                                                            {
+                                                                              "kind": "symbol",
+                                                                              "text": "x"
+                                                                            }
+                                                                          ]
+                                                                        },
+                                                                        {
+                                                                          "kind": "list",
+                                                                          "children": [
+                                                                            {
+                                                                              "kind": "symbol",
+                                                                              "text": "set!"
+                                                                            },
+                                                                            {
+                                                                              "kind": "symbol",
+                                                                              "text": "res12"
+                                                                            },
+                                                                            {
+                                                                              "kind": "list",
+                                                                              "children": [
+                                                                                {
+                                                                                  "kind": "symbol",
+                                                                                  "text": "append"
+                                                                                },
+                                                                                {
+                                                                                  "kind": "symbol",
+                                                                                  "text": "res12"
+                                                                                },
+                                                                                {
+                                                                                  "kind": "list",
+                                                                                  "children": [
+                                                                                    {
+                                                                                      "kind": "symbol",
+                                                                                      "text": "list"
+                                                                                    },
+                                                                                    {
+                                                                                      "kind": "list",
+                                                                                      "children": [
+                                                                                        {
+                                                                                          "kind": "symbol",
+                                                                                          "text": "if"
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "list",
+                                                                                          "children": [
+                                                                                            {
+                                                                                              "kind": "symbol",
+                                                                                              "text": "hash-table-ref"
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "symbol",
+                                                                                              "text": "x"
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "string",
+                                                                                              "text": "\"flag\""
+                                                                                            }
+                                                                                          ]
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "list",
+                                                                                          "children": [
+                                                                                            {
+                                                                                              "kind": "symbol",
+                                                                                              "text": "hash-table-ref"
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "symbol",
+                                                                                              "text": "x"
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "string",
+                                                                                              "text": "\"val\""
+                                                                                            }
+                                                                                          ]
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "number",
+                                                                                          "text": "0"
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  ]
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "kind": "string",
+                                                                      "text": "\"g\""
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                {
+                                                                  "kind": "symbol",
+                                                                  "text": "res12"
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "list",
+                                                      "children": [
+                                                        {
+                                                          "kind": "symbol",
+                                                          "text": "apply"
+                                                        },
+                                                        {
+                                                          "kind": "symbol",
+                                                          "text": "+"
+                                                        },
+                                                        {
+                                                          "kind": "list",
+                                                          "children": [
+                                                            {
+                                                              "kind": "symbol",
+                                                              "text": "let"
+                                                            },
+                                                            {
+                                                              "kind": "list",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "list",
+                                                                  "children": [
+                                                                    {
+                                                                      "kind": "symbol",
+                                                                      "text": "res13"
+                                                                    },
+                                                                    {
+                                                                      "kind": "list",
+                                                                      "children": [
+                                                                        {
+                                                                          "kind": "symbol",
+                                                                          "text": "list"
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              ]
+                                                            },
+                                                            {
+                                                              "kind": "list",
+                                                              "children": [
+                                                                {
+                                                                  "kind": "symbol",
+                                                                  "text": "begin"
+                                                                },
+                                                                {
+                                                                  "kind": "list",
+                                                                  "children": [
+                                                                    {
+                                                                      "kind": "symbol",
+                                                                      "text": "for-each"
+                                                                    },
+                                                                    {
+                                                                      "kind": "list",
+                                                                      "children": [
+                                                                        {
+                                                                          "kind": "symbol",
+                                                                          "text": "lambda"
+                                                                        },
+                                                                        {
+                                                                          "kind": "list",
+                                                                          "children": [
+                                                                            {
+                                                                              "kind": "symbol",
+                                                                              "text": "x"
+                                                                            }
+                                                                          ]
+                                                                        },
+                                                                        {
+                                                                          "kind": "list",
+                                                                          "children": [
+                                                                            {
+                                                                              "kind": "symbol",
+                                                                              "text": "set!"
+                                                                            },
+                                                                            {
+                                                                              "kind": "symbol",
+                                                                              "text": "res13"
+                                                                            },
+                                                                            {
+                                                                              "kind": "list",
+                                                                              "children": [
+                                                                                {
+                                                                                  "kind": "symbol",
+                                                                                  "text": "append"
+                                                                                },
+                                                                                {
+                                                                                  "kind": "symbol",
+                                                                                  "text": "res13"
+                                                                                },
+                                                                                {
+                                                                                  "kind": "list",
+                                                                                  "children": [
+                                                                                    {
+                                                                                      "kind": "symbol",
+                                                                                      "text": "list"
+                                                                                    },
+                                                                                    {
+                                                                                      "kind": "list",
+                                                                                      "children": [
+                                                                                        {
+                                                                                          "kind": "symbol",
+                                                                                          "text": "hash-table-ref"
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "symbol",
+                                                                                          "text": "x"
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "string",
+                                                                                          "text": "\"val\""
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  ]
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "kind": "string",
+                                                                      "text": "\"g\""
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                {
+                                                                  "kind": "symbol",
+                                                                  "text": "res13"
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "symbol",
+                      "text": "items"
+                    }
+                  ]
+                },
+                {
+                  "kind": "symbol",
+                  "text": "res14"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "display"
+        },
+        {
+          "kind": "symbol",
+          "text": "result"
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "newline"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/scheme/group_by_conditional_sum.scm
+++ b/tests/aster/x/scheme/group_by_conditional_sum.scm
@@ -1,0 +1,67 @@
+;; Generated on 2025-07-21 17:26 +0700
+(import
+  (srfi 1)
+  (srfi 69)
+  (chibi string))
+(define items
+  (list
+    (alist->hash-table
+      (list
+        (cons "cat" "a")
+        (cons "val" 10)
+        (cons "flag" "true")))
+    (alist->hash-table
+      (list
+        (cons "cat" "a")
+        (cons "val" 5)
+        (cons "flag" "false")))
+    (alist->hash-table
+      (list
+        (cons "cat" "b")
+        (cons "val" 20)
+        (cons "flag" "true")))))
+(define result
+  (let
+    ((res14
+        (list)))
+    (begin
+      (for-each
+        (lambda
+          (i)
+          (set! res14
+            (append res14
+              (list
+                (alist->hash-table
+                  (list
+                    (cons "cat"
+                      (hash-table-ref g "key"))
+                    (cons "share"
+                      (quotient
+                        (apply +
+                          (let
+                            ((res12
+                                (list)))
+                            (begin
+                              (for-each
+                                (lambda
+                                  (x)
+                                  (set! res12
+                                    (append res12
+                                      (list
+                                        (if
+                                          (hash-table-ref x "flag")
+                                          (hash-table-ref x "val") 0))))) "g") res12)))
+                        (apply +
+                          (let
+                            ((res13
+                                (list)))
+                            (begin
+                              (for-each
+                                (lambda
+                                  (x)
+                                  (set! res13
+                                    (append res13
+                                      (list
+                                        (hash-table-ref x "val"))))) "g") res13))))))))))) items) res14)))
+(display result)
+(newline)


### PR DESCRIPTION
## Summary
- update scheme README progress with new entries
- add AST JSON and printed Scheme sources for `group_by` tests

## Testing
- `go test -tags slow . -run TestInspect_Golden -update` *(fails: cannot run due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_688b729aff788320937e54b4043759bc