### PR TITLE
Improve PHP AST printer

### DIFF
--- a/aster/x/php/print.go
+++ b/aster/x/php/print.go
@@ -179,12 +179,18 @@ func writeExpr(b *bytes.Buffer, n *Node, indent int) {
 		}
 	case "encapsed_string", "string":
 		if len(n.Children) > 0 {
-			fmt.Fprintf(b, "%q", n.Children[0].Text)
+			b.WriteByte('"')
+			b.WriteString(n.Children[0].Text)
+			b.WriteByte('"')
 		} else {
-			fmt.Fprintf(b, "%q", n.Text)
+			b.WriteByte('"')
+			b.WriteString(n.Text)
+			b.WriteByte('"')
 		}
 	case "string_content":
-		fmt.Fprintf(b, "%q", n.Text)
+		b.WriteByte('"')
+		b.WriteString(n.Text)
+		b.WriteByte('"')
 	case "simple_parameter":
 		if len(n.Children) > 0 {
 			writeExpr(b, n.Children[0], indent)
@@ -238,16 +244,21 @@ func writeExpr(b *bytes.Buffer, n *Node, indent int) {
 			writeExpr(b, n.Children[0], indent)
 		}
 	case "binary_expression":
-		if len(n.Children) == 2 {
-			writeExpr(b, n.Children[0], indent)
-			b.WriteByte(' ')
+		if len(n.Children) >= 2 {
 			op := n.Text
 			if op == "" {
 				op = "+"
 			}
-			b.WriteString(op)
-			b.WriteByte(' ')
-			writeExpr(b, n.Children[1], indent)
+			for i, c := range n.Children {
+				if i > 0 {
+					b.WriteByte(' ')
+					b.WriteString(op)
+					b.WriteByte(' ')
+				}
+				writeExpr(b, c, indent)
+			}
+		} else if len(n.Children) == 1 {
+			writeExpr(b, n.Children[0], indent)
 		}
 	case "assignment_expression", "augmented_assignment_expression":
 		if len(n.Children) == 2 {

--- a/aster/x/php/print_test.go
+++ b/aster/x/php/print_test.go
@@ -32,8 +32,8 @@ func TestPrint_Golden(t *testing.T) {
 		t.Fatal(err)
 	}
 	sort.Strings(files)
-	if len(files) > 25 {
-		files = files[:25]
+	if len(files) > 50 {
+		files = files[:50]
 	}
 
 	for _, src := range files {


### PR DESCRIPTION
## Summary
- tweak quoting logic in the PHP AST printer
- handle binary expressions with arbitrary arity
- extend PHP printer golden tests to first 50 programs

## Testing
- `go test ./aster/x/php -tags slow -run TestPrint_Golden -count=1` *(fails: Parse error in left_join_multi.php)*

------
https://chatgpt.com/codex/tasks/task_e_688b76ba211483208978b9b7955a9b15