### PR TITLE
Add Scala printer improvements

### DIFF
--- a/aster/x/scala/README.md
+++ b/aster/x/scala/README.md
@@ -110,5 +110,5 @@ The printer is validated against selected programs under `tests/transpiler/x/sca
 - [x] 100. while_loop.scala
 Completed 100 / 100 examples.
 
-_Last updated: 2025-07-31 19:32 GMT+7
+_Last updated: 2025-08-01 09:21 GMT+7_
 

--- a/aster/x/scala/print.go
+++ b/aster/x/scala/print.go
@@ -230,8 +230,11 @@ func writeObjectDefinition(b *bytes.Buffer, n *Node, indent int) {
 	idx := 1
 	if idx < len(n.Children) && n.Children[idx].Kind == "extends_clause" {
 		b.WriteString(" extends ")
-		if len(n.Children[idx].Children) > 0 {
-			writeExpr(b, n.Children[idx].Children[0], indent)
+		for i, ex := range n.Children[idx].Children {
+			if i > 0 {
+				b.WriteString(" with ")
+			}
+			writeExpr(b, ex, indent)
 		}
 		idx++
 	}
@@ -253,6 +256,17 @@ func writeTraitDefinition(b *bytes.Buffer, n *Node, indent int) {
 	b.WriteString(ind)
 	b.WriteString("trait ")
 	b.WriteString(n.Children[0].Text)
+	idx := 1
+	if idx < len(n.Children) && n.Children[idx].Kind == "extends_clause" {
+		b.WriteString(" extends ")
+		for i, ex := range n.Children[idx].Children {
+			if i > 0 {
+				b.WriteString(" with ")
+			}
+			writeExpr(b, ex, indent)
+		}
+		idx++
+	}
 	b.WriteByte('\n')
 }
 


### PR DESCRIPTION
## Summary
- support `extends` clause in object and trait definitions for Scala printer
- update Scala README timestamp

## Testing
- `go test -tags slow ./aster/x/scala -run TestPrint_Golden -count=1 -v` *(fails: scalac not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688c238d253c8320ab42febe040f39db