### PR TITLE
Fix go build/test without slow tag

### DIFF
--- a/aster/x/hs/print.go
+++ b/aster/x/hs/print.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package hs
 
 import (

--- a/aster/x/hs/stub.go
+++ b/aster/x/hs/stub.go
@@ -1,0 +1,9 @@
+//go:build !slow
+
+package hs
+
+type Program struct{}
+
+func Inspect(src string) (*Program, error) { return &Program{}, nil }
+
+func Print(p *Program) (string, error) { return "", nil }

--- a/tools/a2mochi/x/hs/stub.go
+++ b/tools/a2mochi/x/hs/stub.go
@@ -1,0 +1,34 @@
+//go:build !slow
+
+package hs
+
+import "mochi/ast"
+
+type Field struct {
+	Name string
+	Type string
+}
+
+type Item struct {
+	Kind       string
+	Name       string
+	Params     []string
+	Body       string
+	Type       string
+	Fields     []Field
+	Collection string
+	Start      string
+	End        string
+	Line       int
+}
+
+type Program struct {
+	Items  []Item
+	Source string
+}
+
+func Parse(src string) (*Program, error) { return &Program{Source: src}, nil }
+
+func Print(node *ast.Node) (string, error) { return "", nil }
+
+func Transform(p *Program) (*ast.Node, error) { return nil, nil }


### PR DESCRIPTION
## Summary
- add stub implementations for Haskell AST helpers so the repository builds without `slow` tag
- restrict real implementation of `aster/x/hs/print.go` to the `slow` build tag

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_688c36508d1c832086b964432373c20e