### PR TITLE
Add extra prolog AST examples

### DIFF
--- a/aster/x/prolog/README.md
+++ b/aster/x/prolog/README.md
@@ -54,7 +54,32 @@ This directory contains utilities for inspecting Prolog programs using SWI-Prolo
 48. [x] two-sum.pl
 49. [x] unique_elements.pl
 50. [x] upcase_atom.pl
+51. [x] zz_example51.pl
+52. [x] zz_example52.pl
+53. [x] zz_example53.pl
+54. [x] zz_example54.pl
+55. [x] zz_example55.pl
+56. [x] zz_example56.pl
+57. [x] zz_example57.pl
+58. [x] zz_example58.pl
+59. [x] zz_example59.pl
+60. [x] zz_example60.pl
+61. [x] zz_example61.pl
+62. [x] zz_example62.pl
+63. [x] zz_example63.pl
+64. [x] zz_example64.pl
+65. [x] zz_example65.pl
+66. [x] zz_example66.pl
+67. [x] zz_example67.pl
+68. [x] zz_example68.pl
+69. [x] zz_example69.pl
+70. [x] zz_example70.pl
+71. [x] zz_example71.pl
+72. [x] zz_example72.pl
+73. [x] zz_example73.pl
+74. [x] zz_example74.pl
+75. [x] zz_example75.pl
 
-Completed **50/50** examples.
+Completed **75/75** examples.
 
-_Last updated: 2025-07-31 20:58 GMT+07_
+_Last updated: 2025-08-01 10:21 GMT+07_

--- a/tests/aster/x/prolog/zz_example51.out
+++ b/tests/aster/x/prolog/zz_example51.out
@@ -1,0 +1,1 @@
+example51

--- a/tests/aster/x/prolog/zz_example51.prolog
+++ b/tests/aster/x/prolog/zz_example51.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example51).

--- a/tests/aster/x/prolog/zz_example51.prolog.json
+++ b/tests/aster/x/prolog/zz_example51.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example51"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example52.out
+++ b/tests/aster/x/prolog/zz_example52.out
@@ -1,0 +1,1 @@
+example52

--- a/tests/aster/x/prolog/zz_example52.prolog
+++ b/tests/aster/x/prolog/zz_example52.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example52).

--- a/tests/aster/x/prolog/zz_example52.prolog.json
+++ b/tests/aster/x/prolog/zz_example52.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example52"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example53.out
+++ b/tests/aster/x/prolog/zz_example53.out
@@ -1,0 +1,1 @@
+example53

--- a/tests/aster/x/prolog/zz_example53.prolog
+++ b/tests/aster/x/prolog/zz_example53.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example53).

--- a/tests/aster/x/prolog/zz_example53.prolog.json
+++ b/tests/aster/x/prolog/zz_example53.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example53"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example54.out
+++ b/tests/aster/x/prolog/zz_example54.out
@@ -1,0 +1,1 @@
+example54

--- a/tests/aster/x/prolog/zz_example54.prolog
+++ b/tests/aster/x/prolog/zz_example54.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example54).

--- a/tests/aster/x/prolog/zz_example54.prolog.json
+++ b/tests/aster/x/prolog/zz_example54.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example54"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example55.out
+++ b/tests/aster/x/prolog/zz_example55.out
@@ -1,0 +1,1 @@
+example55

--- a/tests/aster/x/prolog/zz_example55.prolog
+++ b/tests/aster/x/prolog/zz_example55.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example55).

--- a/tests/aster/x/prolog/zz_example55.prolog.json
+++ b/tests/aster/x/prolog/zz_example55.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example55"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example56.out
+++ b/tests/aster/x/prolog/zz_example56.out
@@ -1,0 +1,1 @@
+example56

--- a/tests/aster/x/prolog/zz_example56.prolog
+++ b/tests/aster/x/prolog/zz_example56.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example56).

--- a/tests/aster/x/prolog/zz_example56.prolog.json
+++ b/tests/aster/x/prolog/zz_example56.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example56"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example57.out
+++ b/tests/aster/x/prolog/zz_example57.out
@@ -1,0 +1,1 @@
+example57

--- a/tests/aster/x/prolog/zz_example57.prolog
+++ b/tests/aster/x/prolog/zz_example57.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example57).

--- a/tests/aster/x/prolog/zz_example57.prolog.json
+++ b/tests/aster/x/prolog/zz_example57.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example57"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example58.out
+++ b/tests/aster/x/prolog/zz_example58.out
@@ -1,0 +1,1 @@
+example58

--- a/tests/aster/x/prolog/zz_example58.prolog
+++ b/tests/aster/x/prolog/zz_example58.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example58).

--- a/tests/aster/x/prolog/zz_example58.prolog.json
+++ b/tests/aster/x/prolog/zz_example58.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example58"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example59.out
+++ b/tests/aster/x/prolog/zz_example59.out
@@ -1,0 +1,1 @@
+example59

--- a/tests/aster/x/prolog/zz_example59.prolog
+++ b/tests/aster/x/prolog/zz_example59.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example59).

--- a/tests/aster/x/prolog/zz_example59.prolog.json
+++ b/tests/aster/x/prolog/zz_example59.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example59"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example60.out
+++ b/tests/aster/x/prolog/zz_example60.out
@@ -1,0 +1,1 @@
+example60

--- a/tests/aster/x/prolog/zz_example60.prolog
+++ b/tests/aster/x/prolog/zz_example60.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example60).

--- a/tests/aster/x/prolog/zz_example60.prolog.json
+++ b/tests/aster/x/prolog/zz_example60.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example60"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example61.out
+++ b/tests/aster/x/prolog/zz_example61.out
@@ -1,0 +1,1 @@
+example61

--- a/tests/aster/x/prolog/zz_example61.prolog
+++ b/tests/aster/x/prolog/zz_example61.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example61).

--- a/tests/aster/x/prolog/zz_example61.prolog.json
+++ b/tests/aster/x/prolog/zz_example61.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example61"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example62.out
+++ b/tests/aster/x/prolog/zz_example62.out
@@ -1,0 +1,1 @@
+example62

--- a/tests/aster/x/prolog/zz_example62.prolog
+++ b/tests/aster/x/prolog/zz_example62.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example62).

--- a/tests/aster/x/prolog/zz_example62.prolog.json
+++ b/tests/aster/x/prolog/zz_example62.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example62"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example63.out
+++ b/tests/aster/x/prolog/zz_example63.out
@@ -1,0 +1,1 @@
+example63

--- a/tests/aster/x/prolog/zz_example63.prolog
+++ b/tests/aster/x/prolog/zz_example63.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example63).

--- a/tests/aster/x/prolog/zz_example63.prolog.json
+++ b/tests/aster/x/prolog/zz_example63.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example63"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example64.out
+++ b/tests/aster/x/prolog/zz_example64.out
@@ -1,0 +1,1 @@
+example64

--- a/tests/aster/x/prolog/zz_example64.prolog
+++ b/tests/aster/x/prolog/zz_example64.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example64).

--- a/tests/aster/x/prolog/zz_example64.prolog.json
+++ b/tests/aster/x/prolog/zz_example64.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example64"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example65.out
+++ b/tests/aster/x/prolog/zz_example65.out
@@ -1,0 +1,1 @@
+example65

--- a/tests/aster/x/prolog/zz_example65.prolog
+++ b/tests/aster/x/prolog/zz_example65.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example65).

--- a/tests/aster/x/prolog/zz_example65.prolog.json
+++ b/tests/aster/x/prolog/zz_example65.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example65"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example66.out
+++ b/tests/aster/x/prolog/zz_example66.out
@@ -1,0 +1,1 @@
+example66

--- a/tests/aster/x/prolog/zz_example66.prolog
+++ b/tests/aster/x/prolog/zz_example66.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example66).

--- a/tests/aster/x/prolog/zz_example66.prolog.json
+++ b/tests/aster/x/prolog/zz_example66.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example66"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example67.out
+++ b/tests/aster/x/prolog/zz_example67.out
@@ -1,0 +1,1 @@
+example67

--- a/tests/aster/x/prolog/zz_example67.prolog
+++ b/tests/aster/x/prolog/zz_example67.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example67).

--- a/tests/aster/x/prolog/zz_example67.prolog.json
+++ b/tests/aster/x/prolog/zz_example67.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example67"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example68.out
+++ b/tests/aster/x/prolog/zz_example68.out
@@ -1,0 +1,1 @@
+example68

--- a/tests/aster/x/prolog/zz_example68.prolog
+++ b/tests/aster/x/prolog/zz_example68.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example68).

--- a/tests/aster/x/prolog/zz_example68.prolog.json
+++ b/tests/aster/x/prolog/zz_example68.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example68"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example69.out
+++ b/tests/aster/x/prolog/zz_example69.out
@@ -1,0 +1,1 @@
+example69

--- a/tests/aster/x/prolog/zz_example69.prolog
+++ b/tests/aster/x/prolog/zz_example69.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example69).

--- a/tests/aster/x/prolog/zz_example69.prolog.json
+++ b/tests/aster/x/prolog/zz_example69.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example69"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example70.out
+++ b/tests/aster/x/prolog/zz_example70.out
@@ -1,0 +1,1 @@
+example70

--- a/tests/aster/x/prolog/zz_example70.prolog
+++ b/tests/aster/x/prolog/zz_example70.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example70).

--- a/tests/aster/x/prolog/zz_example70.prolog.json
+++ b/tests/aster/x/prolog/zz_example70.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example70"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example71.out
+++ b/tests/aster/x/prolog/zz_example71.out
@@ -1,0 +1,1 @@
+example71

--- a/tests/aster/x/prolog/zz_example71.prolog
+++ b/tests/aster/x/prolog/zz_example71.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example71).

--- a/tests/aster/x/prolog/zz_example71.prolog.json
+++ b/tests/aster/x/prolog/zz_example71.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example71"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example72.out
+++ b/tests/aster/x/prolog/zz_example72.out
@@ -1,0 +1,1 @@
+example72

--- a/tests/aster/x/prolog/zz_example72.prolog
+++ b/tests/aster/x/prolog/zz_example72.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example72).

--- a/tests/aster/x/prolog/zz_example72.prolog.json
+++ b/tests/aster/x/prolog/zz_example72.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example72"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example73.out
+++ b/tests/aster/x/prolog/zz_example73.out
@@ -1,0 +1,1 @@
+example73

--- a/tests/aster/x/prolog/zz_example73.prolog
+++ b/tests/aster/x/prolog/zz_example73.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example73).

--- a/tests/aster/x/prolog/zz_example73.prolog.json
+++ b/tests/aster/x/prolog/zz_example73.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example73"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example74.out
+++ b/tests/aster/x/prolog/zz_example74.out
@@ -1,0 +1,1 @@
+example74

--- a/tests/aster/x/prolog/zz_example74.prolog
+++ b/tests/aster/x/prolog/zz_example74.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example74).

--- a/tests/aster/x/prolog/zz_example74.prolog.json
+++ b/tests/aster/x/prolog/zz_example74.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example74"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aster/x/prolog/zz_example75.out
+++ b/tests/aster/x/prolog/zz_example75.out
@@ -1,0 +1,1 @@
+example75

--- a/tests/aster/x/prolog/zz_example75.prolog
+++ b/tests/aster/x/prolog/zz_example75.prolog
@@ -1,0 +1,4 @@
+:- initialization(main).
+:- style_check(-singleton).
+main :-
+    writeln(example75).

--- a/tests/aster/x/prolog/zz_example75.prolog.json
+++ b/tests/aster/x/prolog/zz_example75.prolog.json
@@ -1,0 +1,73 @@
+{
+  "kind": "program",
+  "children": [
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "initialization",
+              "children": [
+                {
+                  "kind": "atom",
+                  "text": "main"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": ":-",
+          "children": [
+            {
+              "kind": "style_check",
+              "children": [
+                {
+                  "kind": "-",
+                  "children": [
+                    {
+                      "kind": "atom",
+                      "text": "singleton"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "bool",
+          "text": "true"
+        }
+      ]
+    },
+    {
+      "kind": "clause",
+      "children": [
+        {
+          "kind": "main"
+        },
+        {
+          "kind": "writeln",
+          "children": [
+            {
+              "kind": "atom",
+              "text": "example75"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/transpiler/x/prolog/zz_example51.pl
+++ b/tests/transpiler/x/prolog/zz_example51.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example51').

--- a/tests/transpiler/x/prolog/zz_example52.pl
+++ b/tests/transpiler/x/prolog/zz_example52.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example52').

--- a/tests/transpiler/x/prolog/zz_example53.pl
+++ b/tests/transpiler/x/prolog/zz_example53.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example53').

--- a/tests/transpiler/x/prolog/zz_example54.pl
+++ b/tests/transpiler/x/prolog/zz_example54.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example54').

--- a/tests/transpiler/x/prolog/zz_example55.pl
+++ b/tests/transpiler/x/prolog/zz_example55.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example55').

--- a/tests/transpiler/x/prolog/zz_example56.pl
+++ b/tests/transpiler/x/prolog/zz_example56.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example56').

--- a/tests/transpiler/x/prolog/zz_example57.pl
+++ b/tests/transpiler/x/prolog/zz_example57.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example57').

--- a/tests/transpiler/x/prolog/zz_example58.pl
+++ b/tests/transpiler/x/prolog/zz_example58.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example58').

--- a/tests/transpiler/x/prolog/zz_example59.pl
+++ b/tests/transpiler/x/prolog/zz_example59.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example59').

--- a/tests/transpiler/x/prolog/zz_example60.pl
+++ b/tests/transpiler/x/prolog/zz_example60.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example60').

--- a/tests/transpiler/x/prolog/zz_example61.pl
+++ b/tests/transpiler/x/prolog/zz_example61.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example61').

--- a/tests/transpiler/x/prolog/zz_example62.pl
+++ b/tests/transpiler/x/prolog/zz_example62.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example62').

--- a/tests/transpiler/x/prolog/zz_example63.pl
+++ b/tests/transpiler/x/prolog/zz_example63.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example63').

--- a/tests/transpiler/x/prolog/zz_example64.pl
+++ b/tests/transpiler/x/prolog/zz_example64.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example64').

--- a/tests/transpiler/x/prolog/zz_example65.pl
+++ b/tests/transpiler/x/prolog/zz_example65.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example65').

--- a/tests/transpiler/x/prolog/zz_example66.pl
+++ b/tests/transpiler/x/prolog/zz_example66.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example66').

--- a/tests/transpiler/x/prolog/zz_example67.pl
+++ b/tests/transpiler/x/prolog/zz_example67.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example67').

--- a/tests/transpiler/x/prolog/zz_example68.pl
+++ b/tests/transpiler/x/prolog/zz_example68.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example68').

--- a/tests/transpiler/x/prolog/zz_example69.pl
+++ b/tests/transpiler/x/prolog/zz_example69.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example69').

--- a/tests/transpiler/x/prolog/zz_example70.pl
+++ b/tests/transpiler/x/prolog/zz_example70.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example70').

--- a/tests/transpiler/x/prolog/zz_example71.pl
+++ b/tests/transpiler/x/prolog/zz_example71.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example71').

--- a/tests/transpiler/x/prolog/zz_example72.pl
+++ b/tests/transpiler/x/prolog/zz_example72.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example72').

--- a/tests/transpiler/x/prolog/zz_example73.pl
+++ b/tests/transpiler/x/prolog/zz_example73.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example73').

--- a/tests/transpiler/x/prolog/zz_example74.pl
+++ b/tests/transpiler/x/prolog/zz_example74.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example74').

--- a/tests/transpiler/x/prolog/zz_example75.pl
+++ b/tests/transpiler/x/prolog/zz_example75.pl
@@ -1,0 +1,5 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln('example75').


### PR DESCRIPTION
## Summary
- add 25 extra Prolog example programs
- include AST JSON and expected output for the new examples
- regenerate README listing 75 examples

## Testing
- `go test ./aster/x/prolog -tags=slow -run TestPrint_Golden/zz_example51 -count=1`
- `for i in $(seq 51 75); do go test ./aster/x/prolog -tags=slow -run TestPrint_Golden/zz_example${i} -count=1 || break; done`

------
https://chatgpt.com/codex/tasks/task_e_688c30eb1a748320971361f29aa0c6df