### PR TITLE
Add v0.10.53 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # 📦 CHANGELOG.md
 
+## [0.10.53] – 2025-08-01T14:33:11+07:00
+
+### Added
+
+* `mochix` print command for AST output
+* AST printers implemented across more languages including F#, Haskell, Swift and Prolog
+* Kome compiler example with dedicated tests
+* Extensive golden tests across languages
+
+### Changed
+
+* Build runs without the `slow` tag
+* Swift printer supports `do` statements and interpolation
+* Enhanced record, operator and pointer handling across printers
+
+### Fixed
+
+* Minor build issues and printer bugs
+
 ## [0.10.51] – 2025-07-31T09:04:29+07:00
 
 ### Added

--- a/releases/v0.10.53.md
+++ b/releases/v0.10.53.md
@@ -1,0 +1,21 @@
+# Aug 2025 (v0.10.53)
+
+Released on Fri Aug 1 14:33:11 2025 +0700.
+
+Mochi v0.10.53 expands AST printer coverage across many languages and introduces a print command in mochix with extensive new golden tests.
+
+## Tooling
+
+- `mochix` adds a `print` command for formatted AST output
+- Build without the `slow` tag is fixed
+
+## Printers
+
+- Swift printer gains `do` statements and string interpolation
+- Haskell, FS and other printers extended with record and operator handling
+- New printers and golden tests added across C, C++, C#, Dart, Java, Kotlin, Lua, OCaml, PHP, Prolog, Scala, Scheme and more
+
+## Examples
+
+- Kome compiler example added with tests
+- Golden test suites expanded beyond 100 programs for many languages


### PR DESCRIPTION
## Summary
- add release notes for `v0.10.53`
- document `v0.10.53` entry in `CHANGELOG.md`

## Testing
- `make test` *(fails: Interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_688c6dfc59088320af3adb02e6cbf448