### PR TITLE
Fix Java transpiler variable scoping

### DIFF
--- a/tests/rosetta/transpiler/Java/floyd-warshall-algorithm.bench
+++ b/tests/rosetta/transpiler/Java/floyd-warshall-algorithm.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 56357,
+  "memory_bytes": 111296,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/floyd-warshall-algorithm.java
+++ b/tests/rosetta/transpiler/Java/floyd-warshall-algorithm.java
@@ -1,0 +1,141 @@
+public class Main {
+
+    static void main() {
+        int INF = 1000000000;
+        int n = 4;
+        int[][] dist = new int[][]{};
+        int[][][] next = new int[1][][];
+        next[0] = new int[][]{};
+        int i = 0;
+        while (i < n) {
+            int[] row = new int[]{};
+            int[] nrow = new int[]{};
+            int j = 0;
+            while (j < n) {
+                if (i == j) {
+                    row = java.util.stream.IntStream.concat(java.util.Arrays.stream(row), java.util.stream.IntStream.of(0)).toArray();
+                } else {
+                    row = java.util.stream.IntStream.concat(java.util.Arrays.stream(row), java.util.stream.IntStream.of(INF)).toArray();
+                }
+                nrow = java.util.stream.IntStream.concat(java.util.Arrays.stream(nrow), java.util.stream.IntStream.of(0 - 1)).toArray();
+                j = j + 1;
+            }
+            dist = appendObj(dist, row);
+            next[0] = appendObj(next[0], nrow);
+            i = i + 1;
+        }
+dist[0][2] = -2;
+next[0][0][2] = 2;
+dist[2][3] = 2;
+next[0][2][3] = 3;
+dist[3][1] = -1;
+next[0][3][1] = 1;
+dist[1][0] = 4;
+next[0][1][0] = 0;
+dist[1][2] = 3;
+next[0][1][2] = 2;
+        int k = 0;
+        while (k < n) {
+            int i_1 = 0;
+            while (i_1 < n) {
+                int j_1 = 0;
+                while (j_1 < n) {
+                    if (dist[i_1][k] < INF && dist[k][j_1] < INF) {
+                        int alt = dist[i_1][k] + dist[k][j_1];
+                        if (alt < dist[i_1][j_1]) {
+dist[i_1][j_1] = alt;
+next[0][i_1][j_1] = next[0][i_1][k];
+                        }
+                    }
+                    j_1 = j_1 + 1;
+                }
+                i_1 = i_1 + 1;
+            }
+            k = k + 1;
+        }
+        java.util.function.BiFunction<Integer,Integer,int[]> path = (u, v) -> {
+        int ui = u - 1;
+        int vi = v - 1;
+        if (next[0][ui][vi] == 0 - 1) {
+            return new int[]{};
+        }
+        int[] p = new int[]{u};
+        int cur = ui;
+        while (cur != vi) {
+            cur = next[0][cur][vi];
+            p = java.util.stream.IntStream.concat(java.util.Arrays.stream(p), java.util.stream.IntStream.of(cur + 1)).toArray();
+        }
+        return p;
+};
+        java.util.function.Function<int[],String> pathStr = (p_1) -> {
+        String s = "";
+        boolean first = true;
+        int idx = 0;
+        while (idx < p_1.length) {
+            int x = p_1[idx];
+            if (!first) {
+                s = s + " -> ";
+            }
+            s = s + String.valueOf(x);
+            first = false;
+            idx = idx + 1;
+        }
+        return s;
+};
+        System.out.println("pair\tdist\tpath");
+        int a = 0;
+        while (a < n) {
+            int b = 0;
+            while (b < n) {
+                if (a != b) {
+                    System.out.println(String.valueOf(a + 1) + " -> " + String.valueOf(b + 1) + "\t" + String.valueOf(dist[a][b]) + "\t" + String.valueOf(pathStr.apply(path.apply(a + 1, b + 1))));
+                }
+                b = b + 1;
+            }
+            a = a + 1;
+        }
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static <T> T[] appendObj(T[] arr, T v) {
+        T[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
+    }
+}

--- a/transpiler/x/java/README.md
+++ b/transpiler/x/java/README.md
@@ -2,7 +2,7 @@
 
 Generated Java code for programs in `tests/vm/valid`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
-## VM Golden Test Checklist (103/105) - updated 2025-07-30 17:42 UTC
+## VM Golden Test Checklist (103/105) - updated 2025-08-01 10:51 UTC
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi

--- a/transpiler/x/java/ROSETTA.md
+++ b/transpiler/x/java/ROSETTA.md
@@ -1,9 +1,9 @@
 # Java Rosetta Transpiler Output
 
 Generated Java code for programs in `tests/rosetta/x/Mochi`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
-Last updated: 2025-07-31 00:42 GMT+7
+Last updated: 2025-08-01 17:51 GMT+7
 
-## Rosetta Checklist (298/491)
+## Rosetta Checklist (299/491)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 23.0ms | 245.84KB |
@@ -455,7 +455,7 @@ Last updated: 2025-07-31 00:42 GMT+7
 | 447 | flow-control-structures-2 |   |  |  |
 | 448 | flow-control-structures-3 |   |  |  |
 | 449 | flow-control-structures-4 |   |  |  |
-| 450 | floyd-warshall-algorithm |   |  |  |
+| 450 | floyd-warshall-algorithm | ✓ | 56.0ms | 108.69KB |
 | 451 | floyd-warshall-algorithm2 |   |  |  |
 | 452 | floyds-triangle |   |  |  |
 | 453 | forest-fire |   |  |  |

--- a/transpiler/x/java/TASKS.md
+++ b/transpiler/x/java/TASKS.md
@@ -1,4 +1,24 @@
-## Progress (2025-07-30 17:36 UTC)
+## Progress (2025-08-01 15:22 +0700)
+- docs: add v0.10.53 release notes (1deb4f017c)
+
+- docs: add v0.10.53 release notes (1deb4f017c)
+
+- docs: add v0.10.53 release notes (1deb4f017c)
+
+- docs: add v0.10.53 release notes (1deb4f017c)
+
+- docs: add v0.10.53 release notes (1deb4f017c)
+
+- docs: add v0.10.53 release notes (1deb4f017c)
+
+- docs: add v0.10.53 release notes (1deb4f017c)
+
+- docs: add v0.10.53 release notes (1deb4f017c)
+
+- docs: add v0.10.53 release notes (1deb4f017c)
+
+- docs: add v0.10.53 release notes (1deb4f017c)
+
 - java rosetta: support top level initializations (8da863ec62)
 
 - java rosetta: support top level initializations (8da863ec62)


### PR DESCRIPTION
## Summary
- handle re-used variable names by introducing alias tracking
- preserve current function return type when compiling functions
- mark captured variables from outer scopes for reference semantics
- fix array wrapper emission for captured vars
- regenerate Java output for Floyd–Warshall algorithm

## Testing
- `go test ./transpiler/x/java -run Rosetta -index 450 -tags slow -count=1`
- `UPDATE=1 MOCHI_BENCHMARK=1 go test ./transpiler/x/java -run Rosetta -index 450 -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688c9752ebfc8320b582b14df154db4f