### PR TITLE
Fix Kotlin transpiler indexing and global init

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/floyd-warshall-algorithm.bench
+++ b/tests/rosetta/transpiler/Kotlin/floyd-warshall-algorithm.bench
@@ -1,0 +1,1 @@
+{"duration_us":26859, "memory_bytes":114064, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/floyd-warshall-algorithm.kt
+++ b/tests/rosetta/transpiler/Kotlin/floyd-warshall-algorithm.kt
@@ -1,0 +1,140 @@
+import java.math.BigInteger
+
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+fun user_main(): Unit {
+    var INF: Int = 1000000000
+    var n: Int = 4
+    var dist: MutableList<MutableList<Int>> = mutableListOf<MutableList<Int>>()
+    var next: MutableList<MutableList<Int>> = mutableListOf<MutableList<Int>>()
+    var i: Int = 0
+    while (i < n) {
+        var row: MutableList<Int> = mutableListOf<Int>()
+        var nrow: MutableList<Int> = mutableListOf<Int>()
+        var j: Int = 0
+        while (j < n) {
+            if (i == j) {
+                row = run { val _tmp = row.toMutableList(); _tmp.add(0); _tmp } as MutableList<Int>
+            } else {
+                row = run { val _tmp = row.toMutableList(); _tmp.add(INF); _tmp } as MutableList<Int>
+            }
+            nrow = run { val _tmp = nrow.toMutableList(); _tmp.add(0 - 1); _tmp } as MutableList<Int>
+            j = j + 1
+        }
+        dist = run { val _tmp = dist.toMutableList(); _tmp.add(row); _tmp } as MutableList<MutableList<Int>>
+        next = run { val _tmp = next.toMutableList(); _tmp.add(nrow); _tmp } as MutableList<MutableList<Int>>
+        i = i + 1
+    }
+    ((dist[0]!!)[2]) = 0 - 2
+    ((next[0]!!)[2]) = 2
+    ((dist[2]!!)[3]) = 2
+    ((next[2]!!)[3]) = 3
+    ((dist[3]!!)[1]) = 0 - 1
+    ((next[3]!!)[1]) = 1
+    ((dist[1]!!)[0]) = 4
+    ((next[1]!!)[0]) = 0
+    ((dist[1]!!)[2]) = 3
+    ((next[1]!!)[2]) = 2
+    var k: Int = 0
+    while (k < n) {
+        var i: Int = 0
+        while (i < n) {
+            var j: Int = 0
+            while (j < n) {
+                if ((((dist[i]!!) as MutableList<Int>)[k]!! < INF) && (((dist[k]!!) as MutableList<Int>)[j]!! < INF)) {
+                    var alt: BigInteger = (((dist[i]!!) as MutableList<Int>)[k]!! + ((dist[k]!!) as MutableList<Int>)[j]!!).toBigInteger()
+                    if (alt.compareTo(((dist[i]!!) as MutableList<Int>)[j]!!.toBigInteger()) < 0) {
+                        ((dist[i]!!)[j]) = alt.toInt()
+                        ((next[i]!!)[j]) = ((next[i]!!) as MutableList<Int>)[k]!!
+                    }
+                }
+                j = j + 1
+            }
+            i = i + 1
+        }
+        k = k + 1
+    }
+    fun path(u: Int, v: Int): MutableList<Int> {
+        var ui: Int = u - 1
+        var vi: Int = v - 1
+        if (((next[ui]!!) as MutableList<Int>)[vi]!! == (0 - 1)) {
+            return mutableListOf<Int>()
+        }
+        var p: MutableList<Int> = mutableListOf(u)
+        var cur: Int = ui
+        while (cur != vi) {
+            cur = ((next[cur]!!) as MutableList<Int>)[vi]!!
+            p = run { val _tmp = p.toMutableList(); _tmp.add(cur + 1); _tmp } as MutableList<Int>
+        }
+        return p
+    }
+
+    fun pathStr(p: MutableList<Int>): String {
+        var s: String = ""
+        var first: Boolean = true
+        var idx: Int = 0
+        while (idx < p.size) {
+            var x: Int = p[idx]!!
+            if (!first) {
+                s = s + " -> "
+            }
+            s = s + x.toString()
+            first = false
+            idx = idx + 1
+        }
+        return s
+    }
+
+    println("pair\tdist\tpath")
+    var a: Int = 0
+    while (a < n) {
+        var b: Int = 0
+        while (b < n) {
+            if (a != b) {
+                println(((((((a + 1).toString() + " -> ") + (b + 1).toString()) + "\t") + (((dist[a]!!) as MutableList<Int>)[b]!!).toString()) + "\t") + (pathStr((path(a + 1, b + 1)) as MutableList<Int>)).toString())
+            }
+            b = b + 1
+        }
+        a = a + 1
+    }
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/floyd-warshall-algorithm2.bench
+++ b/tests/rosetta/transpiler/Kotlin/floyd-warshall-algorithm2.bench
@@ -1,0 +1,1 @@
+{"duration_us":28593, "memory_bytes":116584, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/floyd-warshall-algorithm2.kt
+++ b/tests/rosetta/transpiler/Kotlin/floyd-warshall-algorithm2.kt
@@ -1,0 +1,146 @@
+import java.math.BigInteger
+
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+data class FWResult(var dist: MutableList<MutableList<Int>>, var next: MutableList<MutableList<Int>>)
+var INF: Int = 1000000
+var n: Int = 4
+var g: MutableList<MutableList<Int>> = mutableListOf<MutableList<Int>>()
+fun floydWarshall(graph: MutableList<MutableList<Int>>): FWResult {
+    var n: Int = graph.size
+    var dist: MutableList<MutableList<Int>> = mutableListOf<MutableList<Int>>()
+    var next: MutableList<MutableList<Int>> = mutableListOf<MutableList<Int>>()
+    var i: Int = 0
+    while (i < n) {
+        var drow: MutableList<Int> = mutableListOf<Int>()
+        var nrow: MutableList<Int> = mutableListOf<Int>()
+        var j: Int = 0
+        while (j < n) {
+            drow = run { val _tmp = drow.toMutableList(); _tmp.add(((graph[i]!!) as MutableList<Int>)[j]!!); _tmp } as MutableList<Int>
+            if ((((graph[i]!!) as MutableList<Int>)[j]!! < INF) && (i != j)) {
+                nrow = run { val _tmp = nrow.toMutableList(); _tmp.add(j); _tmp } as MutableList<Int>
+            } else {
+                nrow = run { val _tmp = nrow.toMutableList(); _tmp.add(0 - 1); _tmp } as MutableList<Int>
+            }
+            j = j + 1
+        }
+        dist = run { val _tmp = dist.toMutableList(); _tmp.add(drow); _tmp } as MutableList<MutableList<Int>>
+        next = run { val _tmp = next.toMutableList(); _tmp.add(nrow); _tmp } as MutableList<MutableList<Int>>
+        i = i + 1
+    }
+    var k: Int = 0
+    while (k < n) {
+        var i: Int = 0
+        while (i < n) {
+            var j: Int = 0
+            while (j < n) {
+                if ((((dist[i]!!) as MutableList<Int>)[k]!! < INF) && (((dist[k]!!) as MutableList<Int>)[j]!! < INF)) {
+                    var alt: BigInteger = (((dist[i]!!) as MutableList<Int>)[k]!! + ((dist[k]!!) as MutableList<Int>)[j]!!).toBigInteger()
+                    if (alt.compareTo(((dist[i]!!) as MutableList<Int>)[j]!!.toBigInteger()) < 0) {
+                        ((dist[i]!!)[j]) = alt.toInt()
+                        ((next[i]!!)[j]) = ((next[i]!!) as MutableList<Int>)[k]!!
+                    }
+                }
+                j = j + 1
+            }
+            i = i + 1
+        }
+        k = k + 1
+    }
+    return FWResult(dist = dist, next = next)
+}
+
+fun path(u: Int, v: Int, next: MutableList<MutableList<Int>>): MutableList<Int> {
+    if (((next[u]!!) as MutableList<Int>)[v]!! < 0) {
+        return mutableListOf<Int>()
+    }
+    var p: MutableList<Int> = mutableListOf(u)
+    var x: Int = u
+    while (x != v) {
+        x = ((next[x]!!) as MutableList<Int>)[v]!!
+        p = run { val _tmp = p.toMutableList(); _tmp.add(x); _tmp } as MutableList<Int>
+    }
+    return p
+}
+
+fun pathStr(p: MutableList<Int>): String {
+    var s: String = ""
+    var i: Int = 0
+    while (i < p.size) {
+        s = s + (p[i]!! + 1).toString()
+        if (i < (p.size - 1)) {
+            s = s + " -> "
+        }
+        i = i + 1
+    }
+    return s
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        for (i in 0 until n) {
+            var row: MutableList<Int> = mutableListOf<Int>()
+            for (j in 0 until n) {
+                if (i == j) {
+                    row = run { val _tmp = row.toMutableList(); _tmp.add(0); _tmp } as MutableList<Int>
+                } else {
+                    row = run { val _tmp = row.toMutableList(); _tmp.add(INF); _tmp } as MutableList<Int>
+                }
+            }
+            g = run { val _tmp = g.toMutableList(); _tmp.add(row); _tmp } as MutableList<MutableList<Int>>
+        }
+        ((g[0]!!)[2]) = 0 - 2
+        ((g[2]!!)[3]) = 2
+        ((g[3]!!)[1]) = 0 - 1
+        ((g[1]!!)[0]) = 4
+        ((g[1]!!)[2]) = 3
+        var res: FWResult = floydWarshall(g)
+        println("pair\tdist\tpath")
+        var i: Int = 0
+        while (i < n) {
+            var j: Int = 0
+            while (j < n) {
+                if (i != j) {
+                    var p: MutableList<Int> = path(i, j, res.next)
+                    println(((((((i + 1).toString() + " -> ") + (j + 1).toString()) + "\t") + ((((res.dist)[i]!!) as MutableList<Int>)[j]!!).toString()) + "\t") + pathStr(p))
+                }
+                j = j + 1
+            }
+            i = i + 1
+        }
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
-Last updated: 2025-07-31 08:02 +0700
+Last updated: 2025-08-01 15:22 +0700
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-07-31 08:02 +0700
+Last updated: 2025-08-01 15:22 +0700
 
-Completed tasks: **141/491**
+Completed tasks: **143/491**
 
 ### Checklist
 | Index | Name | Status | Duration | Memory |
@@ -458,8 +458,8 @@ Completed tasks: **141/491**
 | 447 | flow-control-structures-2 |  |  |  |
 | 448 | flow-control-structures-3 |  |  |  |
 | 449 | flow-control-structures-4 |  |  |  |
-| 450 | floyd-warshall-algorithm |  |  |  |
-| 451 | floyd-warshall-algorithm2 |  |  |  |
+| 450 | floyd-warshall-algorithm | ✓ | 26.86ms | 111.4 KB |
+| 451 | floyd-warshall-algorithm2 | ✓ | 28.59ms | 113.9 KB |
 | 452 | floyds-triangle |  |  |  |
 | 453 | forest-fire |  |  |  |
 | 454 | fork-2 |  |  |  |

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,24 @@
+## VM Golden Progress (2025-08-01 15:22 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-08-01 15:22 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-08-01 15:22 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-08-01 15:22 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-08-01 15:22 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-08-01 15:22 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-08-01 15:22 +0700)
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-31 08:02 +0700)
 - Regenerated Kotlin golden files and README
 


### PR DESCRIPTION
## Summary
- handle nested index expressions that include casts by wrapping targets in parentheses
- preserve order of top-level variable declarations by moving them into the main function when they appear after executable statements
- regenerate Kotlin Rosetta checklist and benchmarks for indices 450–451

## Testing
- `ROSETTA_INDEX=450 MOCHI_BENCHMARK=true go test ./transpiler/x/kt -run TestRosettaKotlin -count=1 -tags slow`
- `ROSETTA_INDEX=451 MOCHI_BENCHMARK=true go test ./transpiler/x/kt -run TestRosettaKotlin -count=1 -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_688c9754d1b48320a5d0e1a918b9853b