### PR TITLE
Fix Zig transpiler alias var types

### DIFF
--- a/transpiler/x/zig/transpiler.go
+++ b/transpiler/x/zig/transpiler.go
@@ -3437,6 +3437,8 @@ func compileStmt(s *parser.Statement, prog *parser.Program) (Stmt, error) {
 		} else if vd.Type == "" {
 			varTypes[s.Let.Name] = zigTypeFromExpr(expr)
 		}
+		// also record the alias name for later lookups
+		varTypes[alias] = varTypes[s.Let.Name]
 		if funDepth == 0 && !isConstExpr(expr) {
 			vd.Value = nil
 			globalInits = append(globalInits, &AssignStmt{Name: s.Let.Name, Value: expr})
@@ -3486,6 +3488,8 @@ func compileStmt(s *parser.Statement, prog *parser.Program) (Stmt, error) {
 		} else if vd.Type == "" {
 			varTypes[s.Var.Name] = zigTypeFromExpr(expr)
 		}
+		// record alias name as well so later lookups succeed
+		varTypes[alias] = varTypes[s.Var.Name]
 		if funDepth == 0 && !isConstExpr(expr) {
 			vd.Value = nil
 			globalInits = append(globalInits, &AssignStmt{Name: s.Var.Name, Value: expr})


### PR DESCRIPTION
## Summary
- ensure variable type lookup works with aliased names in Zig transpiler

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688ca30775048320b0641d579024829d