### PR TITLE
Partial rosetta transpiler fix attempt

### DIFF
--- a/transpiler/x/rs/transpiler.go
+++ b/transpiler/x/rs/transpiler.go
@@ -3090,9 +3090,9 @@ func compileFunStmt(fn *parser.FunStmt) (Stmt, error) {
 	varTypes = copyStringMap(varTypes)
 	if curEnv != nil {
 		for name, t := range curEnv.Types() {
-			if _, ok := varTypes[name]; !ok {
-				varTypes[name] = rustTypeFromType(t)
-			}
+			// Always prefer the type information from the checker to avoid
+			// stale inferences from previous functions.
+			varTypes[name] = rustTypeFromType(t)
 		}
 	}
 	mapVars = copyBoolMap(mapVars)


### PR DESCRIPTION
## Summary
- refresh env var types for each function in Rust transpiler

## Testing
- `MOCHI_ROSETTA_INDEX=461 go test ./transpiler/x/rs -tags slow -run Rosetta -count=1 -v` *(fails: rustc exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_688cba8429cc8320b50191842bfe6b12