### PR TITLE
Fix Dart map contains

### DIFF
--- a/tests/rosetta/transpiler/Dart/add-a-variable-to-a-class-instance-at-runtime.error
+++ b/tests/rosetta/transpiler/Dart/add-a-variable-to-a-class-instance-at-runtime.error
@@ -1,0 +1,26 @@
+run: exit status 255
+Create two fields at runtime: 
+
+  Field #1:
+
+       Enter name  : 
+       Enter value : 
+
+
+  Field #2:
+
+       Enter name  : 
+       Enter value : 
+
+
+Which field do you want to inspect ? 
+Unhandled exception:
+NoSuchMethodError: Class '_Map<String, String>' has no instance method 'contains'.
+Receiver: _Map len:1
+Tried calling: contains("")
+#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:38:5)
+#1      _main (file:///workspace/mochi/tests/rosetta/transpiler/Dart/add-a-variable-to-a-class-instance-at-runtime.dart:61:26)
+#2      _start (file:///workspace/mochi/tests/rosetta/transpiler/Dart/add-a-variable-to-a-class-instance-at-runtime.dart:78:3)
+#3      main (file:///workspace/mochi/tests/rosetta/transpiler/Dart/add-a-variable-to-a-class-instance-at-runtime.dart:88:16)
+#4      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:314:19)
+#5      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:193:12)

--- a/transpiler/x/dart/transpiler.go
+++ b/transpiler/x/dart/transpiler.go
@@ -2034,8 +2034,18 @@ func (c *ContainsExpr) emit(w io.Writer) error {
 		return err
 	}
 	method := ".contains("
-	if strings.HasPrefix(inferType(c.Target), "Map<") {
+	t := inferType(c.Target)
+	if strings.HasPrefix(t, "Map<") {
 		method = ".containsKey("
+	} else if sel, ok := c.Target.(*SelectorExpr); ok {
+		if fields, ok := structFields[inferType(sel.Receiver)]; ok {
+			for _, f := range fields {
+				if f.Name == sel.Field && strings.HasPrefix(f.Type, "Map<") {
+					method = ".containsKey("
+					break
+				}
+			}
+		}
 	}
 	if _, err := io.WriteString(w, method); err != nil {
 		return err


### PR DESCRIPTION
## Summary
- add map field check for contains
- capture failing runtime error for add-a-variable-to-a-class-instance-at-runtime

## Testing
- `go test ./...` *(fails: context deadline exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_688cc44fcefc8320b9df1abc792b6f80