### PR TITLE
Fix Kotlin map index assignment

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/associative-array-iteration.bench
+++ b/tests/rosetta/transpiler/Kotlin/associative-array-iteration.bench
@@ -1,0 +1,1 @@
+{"duration_us":20029, "memory_bytes":123352, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/associative-array-iteration.kt
+++ b/tests/rosetta/transpiler/Kotlin/associative-array-iteration.kt
@@ -1,0 +1,54 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+fun user_main(): Unit {
+    var m: MutableMap<String, Int> = mutableMapOf<String, Int>("hello" to (13), "world" to (31), "!" to (71)) as MutableMap<String, Int>
+    for (k in m.keys.toMutableList()) {
+        println((("key = " + k) + ", value = ") + ((m)[k] as Int).toString())
+    }
+    for (k in m.keys.toMutableList()) {
+        println("key = " + k)
+    }
+    for (k in m.keys.toMutableList()) {
+        println("value = " + ((m)[k] as Int).toString())
+    }
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/associative-array-iteration.out
+++ b/tests/rosetta/transpiler/Kotlin/associative-array-iteration.out
@@ -1,0 +1,9 @@
+key = hello, value = 13
+key = world, value = 31
+key = !, value = 71
+key = hello
+key = world
+key = !
+value = 13
+value = 31
+value = 71

--- a/tests/rosetta/transpiler/Kotlin/associative-array-merging.bench
+++ b/tests/rosetta/transpiler/Kotlin/associative-array-merging.bench
@@ -1,0 +1,1 @@
+{"duration_us":13110, "memory_bytes":119152, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/associative-array-merging.kt
+++ b/tests/rosetta/transpiler/Kotlin/associative-array-merging.kt
@@ -1,0 +1,59 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+fun merge(base: MutableMap<String, Any?>, update: MutableMap<String, Any?>): MutableMap<String, Any?> {
+    var result: MutableMap<String, Any?> = mutableMapOf<Any?, Any?>() as MutableMap<String, Any?>
+    for (k in base.keys) {
+        (result)[k] = (base)[k] as Any?
+    }
+    for (k in update.keys) {
+        (result)[k] = (update)[k] as Any?
+    }
+    return result
+}
+
+fun user_main(): Unit {
+    var base: MutableMap<String, Any?> = mutableMapOf<String, Any?>("name" to ("Rocket Skates"), "price" to (12.75), "color" to ("yellow")) as MutableMap<String, Any?>
+    var update: MutableMap<String, Any?> = mutableMapOf<String, Any?>("price" to (15.25), "color" to ("red"), "year" to (1974)) as MutableMap<String, Any?>
+    var result: MutableMap<String, Any?> = merge(base, update)
+    println(result)
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-08-01 21:10 +0700
+Last updated: 2025-08-01 22:43 +0700
 
-Completed tasks: **223/491**
+Completed tasks: **225/491**
 
 ### Checklist
 | Index | Name | Status | Duration | Memory |
@@ -88,8 +88,8 @@ Completed tasks: **223/491**
 | 77 | ascii-art-diagram-converter | ✓ | 5.01ms | 130.9 KB |
 | 78 | assertions | ✓ | 2.99ms | 134.0 KB |
 | 79 | associative-array-creation |  |  |  |
-| 80 | associative-array-iteration |  |  |  |
-| 81 | associative-array-merging |  |  |  |
+| 80 | associative-array-iteration | ✓ | 20.03ms | 120.5 KB |
+| 81 | associative-array-merging | ✓ | 13.11ms | 116.4 KB |
 | 82 | atomic-updates | ✓ | 11.17ms | 114.8 KB |
 | 83 | attractive-numbers | ✓ | 5.01ms | 134.0 KB |
 | 84 | average-loop-length | ✓ | 244.04ms | 847.4 KB |

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -274,9 +274,7 @@ type IndexAssignStmt struct {
 func (s *IndexAssignStmt) emit(w io.Writer, indentLevel int) {
 	indent(w, indentLevel)
 	if ix, ok := s.Target.(*IndexExpr); ok {
-		io.WriteString(w, "(")
-		ix.emit(w)
-		io.WriteString(w, ")")
+		ix.emitTarget(w)
 	} else {
 		s.Target.emit(w)
 	}


### PR DESCRIPTION
## Summary
- support assignments to map entries in Kotlin transpiler
- update Rosetta Kotlin checklist for programs 80 and 81
- add generated Kotlin source and benchmark output for associative-array-merging

## Testing
- `ROSETTA_INDEX=81 MOCHI_BENCHMARK=true go test ./transpiler/x/kt -run RosettaKotlin -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_688cdef1e154832082d41ce168dc3852