### PR TITLE
Improve Dart transpiler map and string handling

### DIFF
--- a/tests/rosetta/transpiler/Dart/add-a-variable-to-a-class-instance-at-runtime.bench
+++ b/tests/rosetta/transpiler/Dart/add-a-variable-to-a-class-instance-at-runtime.bench
@@ -1,1 +1,1 @@
-{"duration_us":21949,"memory_bytes":12529664,"name":"main"}
+{"duration_us":41775,"memory_bytes":7454720,"name":"_start"}

--- a/tests/rosetta/transpiler/Dart/add-a-variable-to-a-class-instance-at-runtime.dart
+++ b/tests/rosetta/transpiler/Dart/add-a-variable-to-a-class-instance-at-runtime.dart
@@ -22,28 +22,33 @@ int _now() {
   return DateTime.now().microsecondsSinceEpoch;
 }
 
+String _substr(String s, int start, int end) {
+  var n = s.length;
+  if (start < 0) start += n;
+  if (end < 0) end += n;
+  if (start < 0) start = 0;
+  if (start > n) start = n;
+  if (end < 0) end = 0;
+  if (end > n) end = n;
+  if (start > end) start = end;
+  return s.substring(start, end);
+}
+
 class SomeStruct {
   Map<String, String> runtimeFields;
   SomeStruct({required this.runtimeFields});
 }
 
-void main() {
-  var _benchMem0 = ProcessInfo.currentRss;
-  var _benchSw = Stopwatch()..start();
-  _initNow();
-  {
-  var _benchMem0 = ProcessInfo.currentRss;
-  var _benchSw = Stopwatch()..start();
-  void main() {
+void _main() {
   SomeStruct ss = SomeStruct(runtimeFields: {});
   print("Create two fields at runtime: \n");
   int i = 1;
   while (i <= 2) {
     print("  Field #" + (i).toString() + ":\n");
     print("       Enter name  : ");
-    final String name = stdin.readLineSync() ?? '';
+    String name = stdin.readLineSync() ?? '';
     print("       Enter value : ");
-    final String value = stdin.readLineSync() ?? '';
+    String value = stdin.readLineSync() ?? '';
     Map<String, String> fields = ss.runtimeFields;
     fields[name] = value;
     ss.runtimeFields = fields;
@@ -52,9 +57,9 @@ void main() {
   }
   while (true) {
     print("Which field do you want to inspect ? ");
-    final String name = stdin.readLineSync() ?? '';
+    String name = stdin.readLineSync() ?? '';
     if (ss.runtimeFields.containsKey(name)) {
-    final String value = ss.runtimeFields[name]!;
+    String value = ss.runtimeFields[name]!!;
     print("Its value is '" + value + "'");
     return;
   } else {
@@ -62,12 +67,22 @@ void main() {
   }
   }
 }
-  main();
+
+void _start() {
+  var _benchMem0 = ProcessInfo.currentRss;
+  var _benchSw = Stopwatch()..start();
+  _initNow();
+  {
+  var _benchMem0 = ProcessInfo.currentRss;
+  var _benchSw = Stopwatch()..start();
+  _main();
   _benchSw.stop();
   var _benchMem1 = ProcessInfo.currentRss;
   print(jsonEncode({"duration_us": _benchSw.elapsedMicroseconds, "memory_bytes": (_benchMem1 - _benchMem0).abs(), "name": "main"}));
 }
   _benchSw.stop();
   var _benchMem1 = ProcessInfo.currentRss;
-  print(jsonEncode({"duration_us": _benchSw.elapsedMicroseconds, "memory_bytes": (_benchMem1 - _benchMem0).abs(), "name": "main"}));
+  print(jsonEncode({"duration_us": _benchSw.elapsedMicroseconds, "memory_bytes": (_benchMem1 - _benchMem0).abs(), "name": "_start"}));
 }
+
+void main() => _start();

--- a/tests/rosetta/transpiler/Dart/adfgvx-cipher.error
+++ b/tests/rosetta/transpiler/Dart/adfgvx-cipher.error
@@ -1,0 +1,27 @@
+run: exit status 255
+6 x 6 Polybius square:
+
+  | A D F G V X
+---------------
+A | S L Z 7 2 T 
+D | O 1 0 3 U N 
+F | H I P V K J 
+G | 4 D 5 W E 6 
+V | C R Q F X 9 
+X | M A 8 G Y B 
+
+The key is EHOYKTA2G
+
+Plaintext : ATTACKAT1200AM
+Unhandled exception:
+NoSuchMethodError: Class 'String' has no instance method '>'.
+Receiver: "E"
+Tried calling: >("H")
+#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:38:5)
+#1      orderKey (file:///workspace/mochi/tests/rosetta/transpiler/Dart/adfgvx-cipher.dart:120:21)
+#2      encrypt (file:///workspace/mochi/tests/rosetta/transpiler/Dart/adfgvx-cipher.dart:184:21)
+#3      _main (file:///workspace/mochi/tests/rosetta/transpiler/Dart/adfgvx-cipher.dart:314:23)
+#4      _start (file:///workspace/mochi/tests/rosetta/transpiler/Dart/adfgvx-cipher.dart:327:3)
+#5      main (file:///workspace/mochi/tests/rosetta/transpiler/Dart/adfgvx-cipher.dart:337:16)
+#6      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:314:19)
+#7      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:193:12)

--- a/transpiler/x/dart/README.md
+++ b/transpiler/x/dart/README.md
@@ -109,4 +109,4 @@ Generated Dart code for programs in `tests/vm/valid`. Each program has a `.dart`
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-_Last updated: 2025-08-01 18:46 +0700_
+_Last updated: 2025-08-01 22:47 +0700_

--- a/transpiler/x/dart/ROSETTA.md
+++ b/transpiler/x/dart/ROSETTA.md
@@ -21,27 +21,27 @@ Compiled and ran: 420/491
 | 12 | 9-billion-names-of-god-the-integer | ✓ | 2.671112s | 319.5 MB |
 | 13 | 99-bottles-of-beer-2 | ✓ | 48.009ms | 15.8 MB |
 | 14 | 99-bottles-of-beer | ✓ | 8.928ms | 3.2 MB |
-| 15 | a+b | ✓ | 14.005ms | 11.3 MB |
-| 16 | abbreviations-automatic | ✓ | 19.029ms | 1.9 MB |
-| 17 | abbreviations-easy | ✓ | 9.104ms | 2.0 MB |
-| 18 | abbreviations-simple | ✓ | 11.198ms | 84.0 KB |
-| 19 | abc-problem | ✓ | 8.068ms | 568.0 KB |
-| 20 | abelian-sandpile-model-identity | ✓ | 6.995ms | 12.0 MB |
-| 21 | abelian-sandpile-model | ✓ | 6.336ms | 2.7 MB |
-| 22 | abstract-type | ✓ | 6.366ms | 13.1 MB |
-| 23 | abundant-deficient-and-perfect-number-classifications | ✓ | 186.855ms | 13.1 MB |
-| 24 | abundant-odd-numbers | ✓ | 385.384ms | 3.8 MB |
-| 25 | accumulator-factory | ✓ | 6.201ms | 11.8 MB |
-| 26 | achilles-numbers | ✓ | 23.77ms | 3.9 MB |
-| 27 | ackermann-function-2 | ✓ | 5.871ms | 2.8 MB |
+| 15 | a+b | ✓ | 23.382ms | 6.4 MB |
+| 16 | abbreviations-automatic | ✓ | 39.1ms | 8.3 MB |
+| 17 | abbreviations-easy | ✓ | 15.511ms | 4.8 MB |
+| 18 | abbreviations-simple | ✓ | 23.523ms | 6.0 MB |
+| 19 | abc-problem | ✓ | 15.901ms | 4.0 MB |
+| 20 | abelian-sandpile-model-identity | ✓ | 19.27ms | 5.0 MB |
+| 21 | abelian-sandpile-model | ✓ | 28.349ms | 9.7 MB |
+| 22 | abstract-type | ✓ | 9.782ms | 2.9 MB |
+| 23 | abundant-deficient-and-perfect-number-classifications | ✓ | 335.06ms | 2.5 MB |
+| 24 | abundant-odd-numbers | ✓ | 574.917ms | 3.4 MB |
+| 25 | accumulator-factory | ✓ | 31.285ms | 11.0 MB |
+| 26 | achilles-numbers | ✓ | 124.164ms | 3.1 MB |
+| 27 | ackermann-function-2 | ✓ | 19.882ms | 9.2 MB |
 | 28 | ackermann-function-3 | ✓ | 2m6.732393s | 8.3 MB |
 | 29 | ackermann-function | ✓ | 6.601ms | 1.2 MB |
 | 30 | active-directory-connect | ✓ | 13.872ms | 1.5 MB |
 | 31 | active-directory-search-for-a-user | ✓ | 6.278ms | 88.0 KB |
 | 32 | active-object | ✓ | 6.874ms | 11.9 MB |
-| 33 | add-a-variable-to-a-class-instance-at-runtime | ✓ | 21.949ms | 11.9 MB |
-| 34 | additive-primes | ✓ | 6.327ms | 12.6 MB |
-| 35 | address-of-a-variable | ✓ | 5.84ms | 10.7 MB |
+| 33 | add-a-variable-to-a-class-instance-at-runtime | ✓ | 41.775ms | 7.1 MB |
+| 34 | additive-primes | ✓ | 23.011ms | 10.5 MB |
+| 35 | address-of-a-variable | ✓ | 17.624ms | 9.9 MB |
 | 36 | adfgvx-cipher | ✓ | 9.665ms | 1.6 MB |
 | 37 | aks-test-for-primes | ✓ | 5.546ms | 496.0 KB |
 | 38 | algebraic-data-types | ✓ |  |  |
@@ -499,4 +499,4 @@ Compiled and ran: 420/491
 | 490 | window-management | ✓ | 11.069ms | 2.1 MB |
 | 491 | zumkeller-numbers | ✓ | 1.389357s | 3.9 MB |
 
-_Last updated: 2025-08-01 19:03 +0700_
+_Last updated: 2025-08-01 22:47 +0700_

--- a/transpiler/x/dart/TASKS.md
+++ b/transpiler/x/dart/TASKS.md
@@ -1,10 +1,10 @@
-## Recent Enhancements (2025-08-01 18:46 +0700)
+## Recent Enhancements (2025-08-01 22:47 +0700)
 - Added query cross join support using collection `for` loops.
 - Removed `where`/`map` helpers for cleaner output.
 - Simplified join result collection for readability.
 - Enhanced type inference for query results.
 
-## Progress (2025-08-01 18:46 +0700)
+## Progress (2025-08-01 22:47 +0700)
 - VM valid 102/105
 
 # Dart Transpiler Tasks


### PR DESCRIPTION
## Summary
- handle `in` with map fields using `containsKey`
- infer variable types from assigned value
- emit map index assignments without null checks
- detect more string-like expressions when comparing
- regenerate `add-a-variable-to-a-class-instance-at-runtime` Dart output
- record failure for `adfgvx-cipher`

## Testing
- `MOCHI_ROSETTA_INDEX=33 MOCHI_BENCHMARK=true go test ./transpiler/x/dart -tags slow -run Rosetta -count=1 -timeout=60m`
- `MOCHI_ROSETTA_INDEX=36 MOCHI_BENCHMARK=true go test ./transpiler/x/dart -tags slow -run Rosetta -count=1 -timeout=60m` *(fails: first failing program: adfgvx-cipher)*

------
https://chatgpt.com/codex/tasks/task_e_688ce1a1549c83208e477f3948006918