### PR TITLE
Update Clojure transpiler to support simple methods

### DIFF
--- a/tests/rosetta/transpiler/Clojure/call-an-object-method-1.bench
+++ b/tests/rosetta/transpiler/Clojure/call-an-object-method-1.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 40402,
+  "memory_bytes": 21064184,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/call-an-object-method-1.clj
+++ b/tests/rosetta/transpiler/Clojure/call-an-object-method-1.clj
@@ -8,6 +8,12 @@
 (defn padStart [s w p]
   (loop [out (str s)] (if (< (count out) w) (recur (str p out)) out)))
 
+(defn Foo_ValueMethod [Foo_ValueMethod_self Foo_ValueMethod_x]
+  (do))
+
+(defn Foo_PointerMethod [Foo_PointerMethod_self Foo_PointerMethod_x]
+  (do))
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare main_myPointer main_myValue)
@@ -17,11 +23,22 @@
 (def main_myPointer {})
 
 (defn -main []
-  ((:ValueMethod main_myValue) 0)
-  ((:PointerMethod main_myPointer) 0)
-  ((:ValueMethod main_myPointer) 0)
-  ((:PointerMethod main_myValue) 0)
-  ((:ValueMethod main_myValue) 0)
-  ((:PointerMethod main_myPointer) 0))
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (Foo_ValueMethod main_myValue 0)
+      (Foo_PointerMethod main_myPointer 0)
+      (Foo_ValueMethod main_myPointer 0)
+      (Foo_PointerMethod main_myValue 0)
+      (Foo_ValueMethod main_myValue 0)
+      (Foo_PointerMethod main_myPointer 0)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
 
 (-main)

--- a/tests/rosetta/transpiler/Clojure/call-an-object-method-1.error
+++ b/tests/rosetta/transpiler/Clojure/call-an-object-method-1.error
@@ -1,6 +1,0 @@
-run error: exit status 1
-Execution error (NullPointerException) at main/-main (call-an-object-method-1.clj:20).
-Cannot invoke "clojure.lang.IFn.invoke(Object)"
-
-Full report at:
-/tmp/clojure-15210315670236580572.edn

--- a/transpiler/x/clj/ROSETTA.md
+++ b/transpiler/x/clj/ROSETTA.md
@@ -1,7 +1,7 @@
 # Clojure Rosetta Transpiler
 
-Completed: 170/491
-Last updated: 2025-08-01 22:51 +0700
+Completed: 171/491
+Last updated: 2025-08-01 23:23 +0700
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
@@ -165,7 +165,7 @@ Last updated: 2025-08-01 22:51 +0700
 | 158 | call-a-function-7 | ✓ | 28.845ms | 18.8 MB |
 | 159 | call-a-function-8 |   |  |  |
 | 160 | call-a-function-9 | ✓ | 38.208ms | 19.3 MB |
-| 161 | call-an-object-method-1 |   |  |  |
+| 161 | call-an-object-method-1 | ✓ | 40.402ms | 20.1 MB |
 | 162 | call-an-object-method-2 |   |  |  |
 | 163 | call-an-object-method-3 |   |  |  |
 | 164 | call-an-object-method |   |  |  |


### PR DESCRIPTION
## Summary
- support method declarations and calls in the Clojure transpiler
- regenerate Clojure Rosetta output for `call-an-object-method-1`
- add benchmark output for the updated example

## Testing
- `go vet -tags slow ./transpiler/x/clj`
- `go test -tags slow ./transpiler/x/clj -run TestRosettaClojure -index 161 -count=1`
- `MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/clj -run TestRosettaClojure -index 161 -count=1`

------
https://chatgpt.com/codex/tasks/task_e_688ce6ba38648320911cec6761041865