### PR TITLE
Fix F# transpiler ordering and unboxing

### DIFF
--- a/tests/rosetta/transpiler/FS/function-prototype.bench
+++ b/tests/rosetta/transpiler/FS/function-prototype.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 21,
+  "memory_bytes": 15920,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/function-prototype.fs
+++ b/tests/rosetta/transpiler/FS/function-prototype.fs
@@ -1,0 +1,49 @@
+// Generated 2025-08-01 23:54 +0700
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+let __bench_start = _now()
+let __mem_start = System.GC.GetTotalMemory(true)
+let rec a () =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    try
+
+        __ret
+    with
+        | Return -> __ret
+and b (x: int) (y: int) =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    let mutable x = x
+    let mutable y = y
+    try
+
+        __ret
+    with
+        | Return -> __ret
+and c (nums: int array) =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    let mutable nums = nums
+    try
+
+        __ret
+    with
+        | Return -> __ret
+let __bench_end = _now()
+let __mem_end = System.GC.GetTotalMemory(true)
+printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)

--- a/transpiler/x/fs/README.md
+++ b/transpiler/x/fs/README.md
@@ -112,4 +112,4 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-Last updated: 2025-08-01 22:40 +0700
+Last updated: 2025-08-01 23:54 +0700

--- a/transpiler/x/fs/ROSETTA.md
+++ b/transpiler/x/fs/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This file is auto-generated from rosetta tests.
 
-## Rosetta Golden Test Checklist (341/491)
+## Rosetta Golden Test Checklist (342/491)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 151µs | 41.3 KB |
@@ -471,7 +471,7 @@ This file is auto-generated from rosetta tests.
 | 464 | french-republican-calendar | ✓ | 245µs | 41.5 KB |
 | 465 | ftp |   |  |  |
 | 466 | function-frequency | ✓ | 404µs | 70.8 KB |
-| 467 | function-prototype |   |  |  |
+| 467 | function-prototype | ✓ | 21µs | 15.5 KB |
 | 468 | functional-coverage-tree |   |  |  |
 | 469 | fusc-sequence |   |  |  |
 | 470 | gamma-function |   |  |  |
@@ -497,4 +497,4 @@ This file is auto-generated from rosetta tests.
 | 490 | window-management |   |  |  |
 | 491 | zumkeller-numbers |   |  |  |
 
-Last updated: 2025-08-01 22:40 +0700
+Last updated: 2025-08-01 23:54 +0700

--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-08-01 23:54 +0700)
+- fs transpiler: fix array-of-map assignment
+- Generated F# for 103/105 programs (103 passing)
+
 ## Progress (2025-08-01 22:40 +0700)
 - WIP: attempt to fix ftp transpilation
 - Generated F# for 103/105 programs (103 passing)


### PR DESCRIPTION
## Summary
- add F# codegen for `function-prototype` rosetta example
- tweak F# transpiler ordering so global declarations precede functions
- detect array-of-map types when checking for maps
- unbox values from map index expressions when casting

## Testing
- `go test -run Rosetta_Golden -count=1 -tags=slow -timeout=0` for index 467
- `go test -run Rosetta_Golden -count=1 -tags=slow -timeout=0` for index 468 (fails)

------
https://chatgpt.com/codex/tasks/task_e_688cf156ce8c8320a4b8c89b1c3d7254