### PR TITLE
Fix clojure call expr renaming

### DIFF
--- a/transpiler/x/clj/transpiler.go
+++ b/transpiler/x/clj/transpiler.go
@@ -2184,8 +2184,12 @@ func transpileCall(c *parser.CallExpr) (Node, error) {
 		}
 	}
 	if len(elems) == 0 {
-		elems = append(elems, Symbol(c.Func))
-		if extra, ok := nestedFunArgs[c.Func]; ok {
+		name := c.Func
+		if v, ok := lookupVar(name); ok {
+			name = v
+		}
+		elems = append(elems, Symbol(name))
+		if extra, ok := nestedFunArgs[name]; ok {
 			for _, v := range extra {
 				elems = append(elems, Symbol(v))
 			}


### PR DESCRIPTION
## Summary
- fix variable renaming for call expressions in clojure transpiler

## Testing
- `go test -tags=slow ./transpiler/x/clj -run TestRosettaClojure -args -index=179` *(fails: clojure not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688cff62df48832086b8ffaf1a8b75cb