### PR TITLE
Improve F# transpiler array/string handling

### DIFF
--- a/tests/rosetta/transpiler/FS/fusc-sequence.bench
+++ b/tests/rosetta/transpiler/FS/fusc-sequence.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 369,
+  "memory_bytes": 52088,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/fusc-sequence.fs
+++ b/tests/rosetta/transpiler/FS/fusc-sequence.fs
@@ -1,0 +1,127 @@
+// Generated 2025-08-02 01:18 +0700
+
+exception Return
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+let _substring (s:string) (start:int) (finish:int) =
+    let len = String.length s
+    let mutable st = if start < 0 then len + start else start
+    let mutable en = if finish < 0 then len + finish else finish
+    if st < 0 then st <- 0
+    if st > len then st <- len
+    if en > len then en <- len
+    if st > en then st <- en
+    s.Substring(st, en - st)
+
+let rec fuscVal (n: int) =
+    let mutable __ret : int = Unchecked.defaultof<int>
+    let mutable n = n
+    try
+        let mutable a: int = 1
+        let mutable b: int = 0
+        let mutable x: int = n
+        while x > 0 do
+            if (((x % 2 + 2) % 2)) = 0 then
+                x <- x / 2
+                a <- a + b
+            else
+                x <- (x - 1) / 2
+                b <- a + b
+        if n = 0 then
+            __ret <- 0
+            raise Return
+        __ret <- b
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and firstFusc (n: int) =
+    let mutable __ret : int array = Unchecked.defaultof<int array>
+    let mutable n = n
+    try
+        let mutable arr: int array = [||]
+        let mutable i: int = 0
+        while i < n do
+            arr <- Array.append arr [|unbox<int> (fuscVal i)|]
+            i <- i + 1
+        __ret <- arr
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and commatize (n: int) =
+    let mutable __ret : string = Unchecked.defaultof<string>
+    let mutable n = n
+    try
+        let mutable s: string = string n
+        let mutable neg: bool = false
+        if n < 0 then
+            neg <- true
+            s <- _substring s 1 (String.length s)
+        let mutable i: int = (String.length s) - 3
+        while i >= 1 do
+            s <- ((_substring s 0 i) + ",") + (_substring s i (String.length s))
+            i <- i - 3
+        if neg then
+            __ret <- "-" + s
+            raise Return
+        __ret <- s
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and padLeft (s: string) (w: int) =
+    let mutable __ret : string = Unchecked.defaultof<string>
+    let mutable s = s
+    let mutable w = w
+    try
+        let mutable out: string = s
+        while (String.length out) < w do
+            out <- " " + out
+        __ret <- out
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and main () =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    try
+        let __bench_start = _now()
+        let __mem_start = System.GC.GetTotalMemory(true)
+        printfn "%s" "The first 61 fusc numbers are:"
+        printfn "%s" (("[" + (unbox<string> (String.concat " " (Array.toList (Array.map string (firstFusc 61)))))) + "]")
+        printfn "%s" "\nThe fusc numbers whose length > any previous fusc number length are:"
+        let idxs: int array = [|0; 37; 1173; 35499; 699051; 19573419|]
+        let mutable i: int = 0
+        while i < (Seq.length idxs) do
+            let idx: int = idxs.[i]
+            let ``val``: int = fuscVal idx
+            let numStr: string = padLeft (commatize ``val``) 7
+            let idxStr: string = padLeft (commatize idx) 10
+            printfn "%s" (((numStr + " (index ") + idxStr) + ")")
+            i <- i + 1
+        let __bench_end = _now()
+        let __mem_end = System.GC.GetTotalMemory(true)
+        printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)
+
+        __ret
+    with
+        | Return -> __ret
+main()

--- a/tests/rosetta/transpiler/FS/fusc-sequence.out
+++ b/tests/rosetta/transpiler/FS/fusc-sequence.out
@@ -1,0 +1,10 @@
+The first 61 fusc numbers are:
+[0 1 1 2 1 3 2 3 1 4 3 5 2 5 3 4 1 5 4 7 3 8 5 7 2 7 5 8 3 7 4 5 1 6 5 9 4 11 7 10 3 11 8 13 5 12 7 9 2 9 7 12 5 13 8 11 3 10 7 11 4]
+
+The fusc numbers whose length > any previous fusc number length are:
+      0 (index          0)
+     11 (index         37)
+    108 (index      1,173)
+  1,076 (index     35,499)
+ 10,946 (index    699,051)
+103,682 (index 19,573,419)

--- a/transpiler/x/fs/ROSETTA.md
+++ b/transpiler/x/fs/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This file is auto-generated from rosetta tests.
 
-## Rosetta Golden Test Checklist (343/491)
+## Rosetta Golden Test Checklist (346/491)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 151µs | 41.3 KB |
@@ -473,9 +473,9 @@ This file is auto-generated from rosetta tests.
 | 466 | function-frequency | ✓ | 404µs | 70.8 KB |
 | 467 | function-prototype | ✓ | 21µs | 15.5 KB |
 | 468 | functional-coverage-tree | ✓ | 335µs | 34.5 KB |
-| 469 | fusc-sequence |   |  |  |
-| 470 | gamma-function |   |  |  |
-| 471 | general-fizzbuzz |   |  |  |
+| 469 | fusc-sequence | ✓ | 369µs | 50.9 KB |
+| 470 | gamma-function | ✓ | 395µs | 47.5 KB |
+| 471 | general-fizzbuzz | ✓ | 349µs | 52.4 KB |
 | 472 | generic-swap |   |  |  |
 | 473 | get-system-command-output |   |  |  |
 | 474 | giuga-numbers |   |  |  |
@@ -497,4 +497,4 @@ This file is auto-generated from rosetta tests.
 | 490 | window-management |   |  |  |
 | 491 | zumkeller-numbers |   |  |  |
 
-Last updated: 2025-08-02 00:55 +0700
+Last updated: 2025-08-02 01:18 +0700


### PR DESCRIPTION
## Summary
- fix str() on arrays for F# backend
- support typed dictionary literals with generic _dictCreate
- convert map keys and access indexes using `string`
- mark mutated vars as obj when types change
- add generated F# code and bench for `fusc-sequence`

## Testing
- `MOCHI_ROSETTA_INDEX=469 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/fs -run Rosetta -count=1`
- `MOCHI_ROSETTA_INDEX=471 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/fs -run Rosetta -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688d04f146fc8320b09e7383cc25901a