### PR TITLE
Fix F# variable mutation handling

### DIFF
--- a/tests/rosetta/transpiler/FS/generic-swap.bench
+++ b/tests/rosetta/transpiler/FS/generic-swap.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 237,
+  "memory_bytes": 42488,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/generic-swap.fs
+++ b/tests/rosetta/transpiler/FS/generic-swap.fs
@@ -1,0 +1,52 @@
+// Generated 2025-08-02 01:57 +0700
+
+exception Return
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+let rec swap (a: obj) (b: obj) =
+    let mutable __ret : obj array = Unchecked.defaultof<obj array>
+    let mutable a = a
+    let mutable b = b
+    try
+        __ret <- [|box (b); box (a)|]
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and main () =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    try
+        let __bench_start = _now()
+        let __mem_start = System.GC.GetTotalMemory(true)
+        let mutable a: obj = box 3
+        let mutable b: obj = box "four"
+        printfn "%s" (((string a) + " ") + (string b))
+        let mutable res: obj array = swap a b
+        a <- box (res.[0])
+        b <- box (res.[1])
+        printfn "%s" (((string a) + " ") + (string b))
+        let __bench_end = _now()
+        let __mem_end = System.GC.GetTotalMemory(true)
+        printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)
+
+        __ret
+    with
+        | Return -> __ret
+main()

--- a/tests/rosetta/transpiler/FS/generic-swap.out
+++ b/tests/rosetta/transpiler/FS/generic-swap.out
@@ -1,0 +1,2 @@
+3 four
+four 3

--- a/tests/rosetta/transpiler/FS/get-system-command-output.bench
+++ b/tests/rosetta/transpiler/FS/get-system-command-output.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 230,
+  "memory_bytes": 42624,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/get-system-command-output.fs
+++ b/tests/rosetta/transpiler/FS/get-system-command-output.fs
@@ -1,0 +1,26 @@
+// Generated 2025-08-02 01:57 +0700
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+let __bench_start = _now()
+let __mem_start = System.GC.GetTotalMemory(true)
+printfn "%s" "Would run: ls -l and capture output"
+let __bench_end = _now()
+let __mem_end = System.GC.GetTotalMemory(true)
+printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)

--- a/tests/rosetta/transpiler/FS/get-system-command-output.out
+++ b/tests/rosetta/transpiler/FS/get-system-command-output.out
@@ -1,0 +1,1 @@
+Would run: ls -l and capture output

--- a/transpiler/x/fs/README.md
+++ b/transpiler/x/fs/README.md
@@ -112,4 +112,4 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-Last updated: 2025-08-02 00:55 +0700
+Last updated: 2025-08-02 01:57 +0700

--- a/transpiler/x/fs/ROSETTA.md
+++ b/transpiler/x/fs/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This file is auto-generated from rosetta tests.
 
-## Rosetta Golden Test Checklist (346/491)
+## Rosetta Golden Test Checklist (359/491)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 151µs | 41.3 KB |
@@ -474,27 +474,27 @@ This file is auto-generated from rosetta tests.
 | 467 | function-prototype | ✓ | 21µs | 15.5 KB |
 | 468 | functional-coverage-tree | ✓ | 335µs | 34.5 KB |
 | 469 | fusc-sequence | ✓ | 369µs | 50.9 KB |
-| 470 | gamma-function | ✓ | 395µs | 47.5 KB |
-| 471 | general-fizzbuzz | ✓ | 349µs | 52.4 KB |
-| 472 | generic-swap |   |  |  |
-| 473 | get-system-command-output |   |  |  |
-| 474 | giuga-numbers |   |  |  |
-| 475 | globally-replace-text-in-several-files |   |  |  |
-| 476 | goldbachs-comet |   |  |  |
-| 477 | golden-ratio-convergence |   |  |  |
-| 478 | graph-colouring |   |  |  |
-| 479 | gray-code |   |  |  |
+| 470 | gamma-function |   |  |  |
+| 471 | general-fizzbuzz |   |  |  |
+| 472 | generic-swap | ✓ | 237µs | 41.5 KB |
+| 473 | get-system-command-output | ✓ | 230µs | 41.6 KB |
+| 474 | giuga-numbers | ✓ | 507µs | 84.3 KB |
+| 475 | globally-replace-text-in-several-files | ✓ | 240µs | 41.6 KB |
+| 476 | goldbachs-comet | ✓ | 258µs | 41.6 KB |
+| 477 | golden-ratio-convergence | ✓ | 248µs | 55.3 KB |
+| 478 | graph-colouring | ✓ | 230µs | 41.6 KB |
+| 479 | gray-code | ✓ | 252µs | 41.6 KB |
 | 480 | gui-component-interaction |   |  |  |
-| 481 | gui-enabling-disabling-of-controls |   |  |  |
-| 482 | gui-maximum-window-dimensions |   |  |  |
+| 481 | gui-enabling-disabling-of-controls | ✓ | 249µs | 54.1 KB |
+| 482 | gui-maximum-window-dimensions | ✓ | 226µs | 49.1 KB |
 | 483 | http |   |  |  |
-| 484 | image-noise |   |  |  |
-| 485 | loops-increment-loop-index-within-loop-body |   |  |  |
-| 486 | md5 |   |  |  |
+| 484 | image-noise | ✓ | 2.533ms | 69.6 KB |
+| 485 | loops-increment-loop-index-within-loop-body | ✓ |  |  |
+| 486 | md5 | ✓ |  |  |
 | 487 | nim-game |   |  |  |
-| 488 | plasma-effect |   |  |  |
-| 489 | sorting-algorithms-bubble-sort |   |  |  |
+| 488 | plasma-effect | ✓ |  |  |
+| 489 | sorting-algorithms-bubble-sort | ✓ | 245µs | 43.3 KB |
 | 490 | window-management |   |  |  |
 | 491 | zumkeller-numbers |   |  |  |
 
-Last updated: 2025-08-02 01:18 +0700
+Last updated: 2025-08-02 01:57 +0700

--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-08-02 01:57 +0700)
+- fs transpiler: support array str and typed maps
+- Generated F# for 103/105 programs (103 passing)
+
 ## Progress (2025-08-02 00:55 +0700)
 - go transpiler: fix float casting and map[string]any returns
 - Generated F# for 103/105 programs (103 passing)


### PR DESCRIPTION
## Summary
- adjust F# transpiler so variable declarations tracked in `letPtrs`
- update variable type and box initial value when assignments widen type
- regenerate Rosetta results for index 472
- add generated F# files and benchmark outputs for `generic-swap` and `get-system-command-output`

## Testing
- `MOCHI_ROSETTA_INDEX=472 go test ./transpiler/x/fs -run Rosetta -tags slow -count=1`
- `MOCHI_ROSETTA_INDEX=472 MOCHI_BENCHMARK=1 go test ./transpiler/x/fs -run Rosetta -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_688d0e2d620083209463527fbb111118