### PR TITLE
docs: add v0.10.54 release notes and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # 📦 CHANGELOG.md
 
+## [0.10.54] – 2025-08-02T10:23:53+07:00
+
+### Added
+
+* F# transpiler support for array strings, typed maps and dictionaries
+* Swift, Scala and OCaml transpilers gain large integer support, dynamic struct indexing and a `split` builtin
+* Rust function prototypes and Clojure catamorphism generation
+
+### Changed
+
+* Rosetta benchmark outputs refreshed across languages including Dart and Go
+* Improved float literal emission and parameter casts
+
+### Fixed
+
+* Base64 decode and return handling bugs
+* Dart transpiler map index null issue
+
 ## [0.10.53] – 2025-08-01T14:33:11+07:00
 
 ### Added

--- a/releases/v0.10.54.md
+++ b/releases/v0.10.54.md
@@ -1,0 +1,17 @@
+# Aug 2025 (v0.10.54)
+
+Released on Sat Aug 02 10:23:53 2025 +0700.
+
+Mochi v0.10.54 expands transpiler support with typed collections and dynamic casting across languages while updating Rosetta examples and addressing several decoding and return handling bugs.
+
+## Transpilers
+
+- F# transpiler now handles array strings, typed maps and dictionaries
+- Swift, Scala and OCaml transpilers gain large integer support, dynamic struct indexing and a `split` builtin
+- Rust and Clojure generation extended with function prototypes and catamorphism
+- Rosetta outputs refreshed for Dart, Go and more
+
+## Fixes
+
+- Base64 decode and return handling bugs resolved
+- Corrected Dart map index null handling and improved float literal casting


### PR DESCRIPTION
## Summary
- document v0.10.54 release with expanded transpiler support and fixes
- add 0.10.54 entry to CHANGELOG

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d8441ab088320a5e01f52a0587b9f