### PR TITLE
fs transpiler: fix dictionary index string cast

### DIFF
--- a/tests/rosetta/transpiler/FS/nim-game.bench
+++ b/tests/rosetta/transpiler/FS/nim-game.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 387,
+  "memory_bytes": 51432,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/nim-game.fs
+++ b/tests/rosetta/transpiler/FS/nim-game.fs
@@ -1,0 +1,99 @@
+// Generated 2025-08-02 10:37 +0700
+
+exception Return
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+let _dictAdd (d:System.Collections.Generic.IDictionary<string, obj>) (k:string) (v:obj) =
+    d.[k] <- v
+    d
+let _dictCreate<'T> (pairs:(string * 'T) list) : System.Collections.Generic.IDictionary<string,'T> =
+    let d = System.Collections.Generic.Dictionary<string, 'T>()
+    for (k, v) in pairs do
+        d.[k] <- v
+    upcast d
+open System.Collections.Generic
+
+open System
+
+let rec parseIntStr (str: string) =
+    let mutable __ret : int = Unchecked.defaultof<int>
+    let mutable str = str
+    try
+        let mutable i: int = 0
+        let mutable neg: bool = false
+        if ((String.length (str)) > 0) && ((str.Substring(0, 1 - 0)) = "-") then
+            neg <- true
+            i <- 1
+        let mutable n: int = 0
+        let digits: System.Collections.Generic.IDictionary<string, int> = _dictCreate<int> [(string "0", 0); (string "1", 1); (string "2", 2); (string "3", 3); (string "4", 4); (string "5", 5); (string "6", 6); (string "7", 7); (string "8", 8); (string "9", 9)]
+        while i < (String.length (str)) do
+            n <- int ((n * 10) + (unbox<int> (digits.[(string (str.Substring(i, (i + 1) - i)))])))
+            i <- i + 1
+        if neg then
+            n <- -n
+        __ret <- n
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and showTokens (tokens: int) =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    let mutable tokens = tokens
+    try
+        printfn "%s" ("Tokens remaining " + (string (tokens)))
+        __ret
+    with
+        | Return -> __ret
+and main () =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    try
+        let __bench_start = _now()
+        let __mem_start = System.GC.GetTotalMemory(true)
+        let mutable tokens: int = 12
+        let mutable ``done``: bool = false
+        while not ``done`` do
+            showTokens (tokens)
+            printfn "%s" ("")
+            printfn "%s" ("How many tokens 1, 2 or 3?")
+            let line: string = System.Console.ReadLine()
+            let mutable t: int = 0
+            if (String.length (line)) > 0 then
+                t <- parseIntStr (line)
+            if (t < 1) || (t > 3) then
+                printfn "%s" ("\nMust be a number between 1 and 3, try again.\n")
+            else
+                let mutable ct: int = 4 - t
+                let mutable s: string = "s"
+                if ct = 1 then
+                    s <- ""
+                printfn "%s" (((("  Computer takes " + (string (ct))) + " token") + s) + "\n\n")
+                tokens <- tokens - 4
+            if tokens = 0 then
+                showTokens (0)
+                printfn "%s" ("  Computer wins!")
+                ``done`` <- true
+        let __bench_end = _now()
+        let __mem_end = System.GC.GetTotalMemory(true)
+        printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)
+
+        __ret
+    with
+        | Return -> __ret
+main()

--- a/tests/rosetta/transpiler/FS/nim-game.out
+++ b/tests/rosetta/transpiler/FS/nim-game.out
@@ -1,0 +1,20 @@
+Tokens remaining 12
+
+How many tokens 1, 2 or 3?
+  Computer takes 3 tokens
+
+
+Tokens remaining 8
+
+How many tokens 1, 2 or 3?
+  Computer takes 3 tokens
+
+
+Tokens remaining 4
+
+How many tokens 1, 2 or 3?
+  Computer takes 3 tokens
+
+
+Tokens remaining 0
+  Computer wins!

--- a/transpiler/x/fs/ROSETTA.md
+++ b/transpiler/x/fs/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This file is auto-generated from rosetta tests.
 
-## Rosetta Golden Test Checklist (359/491)
+## Rosetta Golden Test Checklist (347/491)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 151µs | 41.3 KB |
@@ -478,23 +478,23 @@ This file is auto-generated from rosetta tests.
 | 471 | general-fizzbuzz |   |  |  |
 | 472 | generic-swap | ✓ | 237µs | 41.5 KB |
 | 473 | get-system-command-output | ✓ | 230µs | 41.6 KB |
-| 474 | giuga-numbers | ✓ | 507µs | 84.3 KB |
-| 475 | globally-replace-text-in-several-files | ✓ | 240µs | 41.6 KB |
-| 476 | goldbachs-comet | ✓ | 258µs | 41.6 KB |
-| 477 | golden-ratio-convergence | ✓ | 248µs | 55.3 KB |
-| 478 | graph-colouring | ✓ | 230µs | 41.6 KB |
-| 479 | gray-code | ✓ | 252µs | 41.6 KB |
+| 474 | giuga-numbers |   |  |  |
+| 475 | globally-replace-text-in-several-files |   |  |  |
+| 476 | goldbachs-comet |   |  |  |
+| 477 | golden-ratio-convergence |   |  |  |
+| 478 | graph-colouring |   |  |  |
+| 479 | gray-code |   |  |  |
 | 480 | gui-component-interaction |   |  |  |
-| 481 | gui-enabling-disabling-of-controls | ✓ | 249µs | 54.1 KB |
-| 482 | gui-maximum-window-dimensions | ✓ | 226µs | 49.1 KB |
+| 481 | gui-enabling-disabling-of-controls |   |  |  |
+| 482 | gui-maximum-window-dimensions |   |  |  |
 | 483 | http |   |  |  |
-| 484 | image-noise | ✓ | 2.533ms | 69.6 KB |
-| 485 | loops-increment-loop-index-within-loop-body | ✓ |  |  |
-| 486 | md5 | ✓ |  |  |
-| 487 | nim-game |   |  |  |
-| 488 | plasma-effect | ✓ |  |  |
-| 489 | sorting-algorithms-bubble-sort | ✓ | 245µs | 43.3 KB |
+| 484 | image-noise |   |  |  |
+| 485 | loops-increment-loop-index-within-loop-body |   |  |  |
+| 486 | md5 |   |  |  |
+| 487 | nim-game | ✓ | 387µs | 50.2 KB |
+| 488 | plasma-effect |   |  |  |
+| 489 | sorting-algorithms-bubble-sort |   |  |  |
 | 490 | window-management |   |  |  |
 | 491 | zumkeller-numbers |   |  |  |
 
-Last updated: 2025-08-02 01:57 +0700
+Last updated: 2025-08-02 10:37 +0700

--- a/transpiler/x/fs/transpiler.go
+++ b/transpiler/x/fs/transpiler.go
@@ -2103,14 +2103,9 @@ func (c *CallExpr) emit(w io.Writer) {
 		return
 	}
 	for _, a := range c.Args {
-		io.WriteString(w, " ")
-		if needsParen(a) {
-			io.WriteString(w, "(")
-			a.emit(w)
-			io.WriteString(w, ")")
-		} else {
-			a.emit(w)
-		}
+		io.WriteString(w, " (")
+		a.emit(w)
+		io.WriteString(w, ")")
 	}
 }
 
@@ -2149,28 +2144,18 @@ func (i *IndexExpr) emit(w io.Writer) {
 	if id, ok := i.Target.(*IdentExpr); ok && strings.HasPrefix(id.Type, "System.Collections.Generic.IDictionary<") {
 		i.Target.emit(w)
 		io.WriteString(w, ".[")
-		if needsParen(i.Index) {
-			io.WriteString(w, "(string ")
-			i.Index.emit(w)
-			io.WriteString(w, ")")
-		} else {
-			io.WriteString(w, "string ")
-			i.Index.emit(w)
-		}
+		io.WriteString(w, "(string (")
+		i.Index.emit(w)
+		io.WriteString(w, "))")
 		io.WriteString(w, "]")
 		return
 	}
 	if strings.HasPrefix(t, "System.Collections.Generic.IDictionary<") {
 		i.Target.emit(w)
 		io.WriteString(w, ".[")
-		if needsParen(i.Index) {
-			io.WriteString(w, "(string ")
-			i.Index.emit(w)
-			io.WriteString(w, ")")
-		} else {
-			io.WriteString(w, "string ")
-			i.Index.emit(w)
-		}
+		io.WriteString(w, "(string (")
+		i.Index.emit(w)
+		io.WriteString(w, "))")
 		io.WriteString(w, "]")
 		return
 	}


### PR DESCRIPTION
## Summary
- fix F# transpiler to parenthesize function calls and dictionary index casts
- add Rosetta nim-game F# output and benchmark

## Testing
- `MOCHI_ROSETTA_INDEX=487 MOCHI_BENCHMARK=1 go test -tags slow -run TestFSTranspiler_Rosetta_Golden -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_688d88395ff4832097bf16b70ab62980