### PR TITLE
chore(fs): add window management rosetta

### DIFF
--- a/tests/rosetta/transpiler/FS/window-management.bench
+++ b/tests/rosetta/transpiler/FS/window-management.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 371,
+  "memory_bytes": 46584,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/window-management.fs
+++ b/tests/rosetta/transpiler/FS/window-management.fs
@@ -1,0 +1,152 @@
+// Generated 2025-08-02 11:33 +0700
+
+exception Return
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+type Window = {
+    x: int
+    y: int
+    w: int
+    h: int
+    maximized: bool
+    iconified: bool
+    visible: bool
+    shifted: bool
+}
+let rec showState (w: Window) (label: string) =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    let mutable w = w
+    let mutable label = label
+    try
+        printfn "%s" ((((((((((((((label + ": pos=(") + (string (w.x))) + ",") + (string (w.y))) + ") size=(") + (string (w.w))) + "x") + (string (w.h))) + ") max=") + (string (w.maximized))) + " icon=") + (string (w.iconified))) + " visible=") + (string (w.visible)))
+        __ret
+    with
+        | Return -> __ret
+and maximize (w: Window) =
+    let mutable __ret : Window = Unchecked.defaultof<Window>
+    let mutable w = w
+    try
+        w <- { w with maximized = true }
+        w <- { w with w = 800 }
+        w <- { w with h = 600 }
+        __ret <- w
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and unmaximize (w: Window) =
+    let mutable __ret : Window = Unchecked.defaultof<Window>
+    let mutable w = w
+    try
+        w <- { w with maximized = false }
+        w <- { w with w = 640 }
+        w <- { w with h = 480 }
+        __ret <- w
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and iconify (w: Window) =
+    let mutable __ret : Window = Unchecked.defaultof<Window>
+    let mutable w = w
+    try
+        w <- { w with iconified = true }
+        w <- { w with visible = false }
+        __ret <- w
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and deiconify (w: Window) =
+    let mutable __ret : Window = Unchecked.defaultof<Window>
+    let mutable w = w
+    try
+        w <- { w with iconified = false }
+        w <- { w with visible = true }
+        __ret <- w
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and hide (w: Window) =
+    let mutable __ret : Window = Unchecked.defaultof<Window>
+    let mutable w = w
+    try
+        w <- { w with visible = false }
+        __ret <- w
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and showWindow (w: Window) =
+    let mutable __ret : Window = Unchecked.defaultof<Window>
+    let mutable w = w
+    try
+        w <- { w with visible = true }
+        __ret <- w
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and move (w: Window) =
+    let mutable __ret : Window = Unchecked.defaultof<Window>
+    let mutable w = w
+    try
+        if w.shifted then
+            w <- { w with x = (w.x) - 10 }
+            w <- { w with y = (w.y) - 10 }
+        else
+            w <- { w with x = (w.x) + 10 }
+            w <- { w with y = (w.y) + 10 }
+        w <- { w with shifted = not (w.shifted) }
+        __ret <- w
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and main () =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    try
+        let __bench_start = _now()
+        let __mem_start = System.GC.GetTotalMemory(true)
+        let mutable win: Window = { x = 100; y = 100; w = 640; h = 480; maximized = false; iconified = false; visible = true; shifted = false }
+        showState (win) ("Start")
+        win <- maximize (win)
+        showState (win) ("Maximize")
+        win <- unmaximize (win)
+        showState (win) ("Unmaximize")
+        win <- iconify (win)
+        showState (win) ("Iconify")
+        win <- deiconify (win)
+        showState (win) ("Deiconify")
+        win <- hide (win)
+        showState (win) ("Hide")
+        win <- showWindow (win)
+        showState (win) ("Show")
+        win <- move (win)
+        showState (win) ("Move")
+        let __bench_end = _now()
+        let __mem_end = System.GC.GetTotalMemory(true)
+        printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)
+
+        __ret
+    with
+        | Return -> __ret
+main()

--- a/tests/rosetta/transpiler/FS/window-management.out
+++ b/tests/rosetta/transpiler/FS/window-management.out
@@ -1,0 +1,8 @@
+Start: pos=(100,100) size=(640x480) max=False icon=False visible=True
+Maximize: pos=(100,100) size=(800x600) max=True icon=False visible=True
+Unmaximize: pos=(100,100) size=(640x480) max=False icon=False visible=True
+Iconify: pos=(100,100) size=(640x480) max=False icon=True visible=False
+Deiconify: pos=(100,100) size=(640x480) max=False icon=False visible=True
+Hide: pos=(100,100) size=(640x480) max=False icon=False visible=False
+Show: pos=(100,100) size=(640x480) max=False icon=False visible=True
+Move: pos=(110,110) size=(640x480) max=False icon=False visible=True

--- a/transpiler/x/fs/ROSETTA.md
+++ b/transpiler/x/fs/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This file is auto-generated from rosetta tests.
 
-## Rosetta Golden Test Checklist (349/491)
+## Rosetta Golden Test Checklist (350/491)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 151µs | 41.3 KB |
@@ -494,7 +494,7 @@ This file is auto-generated from rosetta tests.
 | 487 | nim-game | ✓ | 387µs | 50.2 KB |
 | 488 | plasma-effect | ✓ | 1.288ms | 55.4 KB |
 | 489 | sorting-algorithms-bubble-sort | ✓ | 304µs | 43.3 KB |
-| 490 | window-management |   |  |  |
+| 490 | window-management | ✓ | 371µs | 45.5 KB |
 | 491 | zumkeller-numbers |   |  |  |
 
-Last updated: 2025-08-02 11:21 +0700
+Last updated: 2025-08-02 11:33 +0700


### PR DESCRIPTION
## Summary
- transpile Rosetta example 490 (window-management) to F#
- record benchmark and mark test as passing in Rosetta checklist

## Testing
- `MOCHI_ROSETTA_INDEX=490 MOCHI_BENCHMARK=1 go test ./transpiler/x/fs -run TestFSTranspiler_Rosetta_Golden -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688d9505e4f88320baecfa2ee98da21f