### PR TITLE
Add Kotlin transpiled output for call-a-function-2

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/call-a-function-2.bench
+++ b/tests/rosetta/transpiler/Kotlin/call-a-function-2.bench
@@ -1,0 +1,1 @@
+{"duration_us":29054, "memory_bytes":135200, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/call-a-function-2.kt
+++ b/tests/rosetta/transpiler/Kotlin/call-a-function-2.kt
@@ -39,7 +39,7 @@ fun user_main(): Unit {
     f()
     g(1, 2.0)
     var res: MutableList<Any?> = f()
-    g((res[0] as Any?) as Int, (res[1] as Any?).toDouble())
+    g((res[0] as Any?) as Int, (res[1] as Any?) as Double)
     g(g(1, 2.0), 3.0)
 }
 

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-08-01 22:43 +0700
+Last updated: 2025-08-02 11:46 +0700
 
-Completed tasks: **225/491**
+Completed tasks: **226/491**
 
 ### Checklist
 | Index | Name | Status | Duration | Memory |
@@ -161,7 +161,7 @@ Completed tasks: **225/491**
 | 150 | call-a-function-10 | ✓ | 22.80ms | 124.9 KB |
 | 151 | call-a-function-11 | ✓ | 21.31ms | 123.5 KB |
 | 152 | call-a-function-12 | ✓ | 11.05ms | 131.5 KB |
-| 153 | call-a-function-2 |  |  |  |
+| 153 | call-a-function-2 | ✓ | 29.05ms | 132.0 KB |
 | 154 | call-a-function-3 | ✓ | 22.90ms | 124.1 KB |
 | 155 | call-a-function-4 |  |  |  |
 | 156 | call-a-function-5 |  |  |  |


### PR DESCRIPTION
## Summary
- transpile Rosetta program `call-a-function-2` to Kotlin and record benchmark output
- update Kotlin Rosetta checklist

## Testing
- `ROSETTA_INDEX=153 MOCHI_BENCHMARK=true go test -run Rosetta -tags slow ./transpiler/x/kt -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_688d97272e208320af5ce7e8bf6614c1