### PR TITLE
php transpiler: fix main call and closure var capture

### DIFF
--- a/tests/rosetta/transpiler/php/church-numerals-2.bench
+++ b/tests/rosetta/transpiler/php/church-numerals-2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 0,
-  "memory_bytes": 64,
+  "duration_us": 134,
+  "memory_bytes": 11984,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/php/church-numerals-2.out
+++ b/tests/rosetta/transpiler/php/church-numerals-2.out
@@ -1,5 +1,12 @@
+zero = 0
+one = 1
+two = 2
+three = 3
+four = 4
+eight = 8
+toStr(four) = ||||
 {
-  "duration_us": 0,
-  "memory_bytes": 64,
+  "duration_us": 134,
+  "memory_bytes": 11984,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/php/church-numerals-2.php
+++ b/tests/rosetta/transpiler/php/church-numerals-2.php
@@ -67,7 +67,8 @@ $__start = _now();
 };
   function toInt($x) {
   $counter = 0;
-  $fCounter = function($f) use (&$fCounter, $x, $counter) {
+  $fCounter = null;
+$fCounter = function($f) use (&$fCounter, $x, &$counter) {
   $counter = $counter + 1;
   return $f;
 };
@@ -76,7 +77,8 @@ $__start = _now();
 };
   function toStr($x) {
   $s = '';
-  $fCounter = function($f) use (&$fCounter, $x, $s) {
+  $fCounter = null;
+$fCounter = function($f) use (&$fCounter, $x, &$s) {
   $s = $s . '|';
   return $f;
 };
@@ -97,6 +99,7 @@ $__start = _now();
   echo rtrim('eight = ' . _str(toInt($eight))), PHP_EOL;
   echo rtrim('toStr(four) = ' . toStr($four)), PHP_EOL;
 };
+  main();
 $__end = _now();
 $__end_mem = memory_get_usage();
 $__duration = intdiv($__end - $__start, 1000);
@@ -104,4 +107,4 @@ $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
 $__j = json_encode($__bench, 128);
 $__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;;
+echo $__j, PHP_EOL;

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-Last updated: 2025-08-02 11:41 +0700
+Last updated: 2025-08-02 11:59 +0700
 
 ## VM Golden Test Checklist (103/105)
 - [x] append_builtin

--- a/transpiler/x/php/ROSETTA.md
+++ b/transpiler/x/php/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from Mochi Rosetta tasks lives in `tests/rosetta/transpiler/php`.
 
-Last updated: 2025-08-02 11:41 +0700
+Last updated: 2025-08-02 11:59 +0700
 
 ## Checklist (482/491)
 | Index | Name | Status | Duration | Memory |
@@ -209,7 +209,7 @@ Last updated: 2025-08-02 11:41 +0700
 | 200 | cholesky-decomposition | ✓ | 147µs | 96 B |
 | 201 | chowla-numbers | ✓ | 97µs | 96 B |
 | 202 | church-numerals-1 | ✓ | 603µs | 3.2 KB |
-| 203 | church-numerals-2 | ✓ |  |  |
+| 203 | church-numerals-2 | ✓ | 134µs | 11.7 KB |
 | 204 | circles-of-given-radius-through-two-points | ✓ | 148µs | 760 B |
 | 205 | circular-primes | ✓ | 464µs | 17.1 KB |
 | 206 | cistercian-numerals | ✓ | 503µs | 68.9 KB |

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,4 +1,4 @@
-## Progress (2025-08-02 11:41 +0700)
+## Progress (2025-08-02 11:59 +0700)
 - Generated PHP for 103/105 programs
 - Updated README checklist and outputs
 - Enhanced printing to match golden format


### PR DESCRIPTION
## Summary
- ensure `main()` runs even when benchmark wrapper is used
- capture mutated outer variables by reference in PHP closures
- regenerate church-numerals-2 output and update Rosetta checklist

## Testing
- `MOCHI_ROSETTA_INDEX=203 MOCHI_BENCHMARK=1 UPDATE=1 go test ./transpiler/x/php -run TestPHPTranspiler_Rosetta_Golden -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_688d9b42dbc88320b05aa5b0d0394bed