### PR TITLE
feat(fs): support type aliases

### DIFF
--- a/tests/rosetta/transpiler/FS/enumerations-3.bench
+++ b/tests/rosetta/transpiler/FS/enumerations-3.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 16,
+  "memory_bytes": 26256,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/enumerations-3.fs
+++ b/tests/rosetta/transpiler/FS/enumerations-3.fs
@@ -1,0 +1,29 @@
+// Generated 2025-08-02 11:55 +0700
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+type fruit = int
+let __bench_start = _now()
+let __mem_start = System.GC.GetTotalMemory(true)
+let apple: fruit = 0
+let banana: fruit = (int apple) + 1
+let cherry: fruit = (int banana) + 1
+let __bench_end = _now()
+let __mem_end = System.GC.GetTotalMemory(true)
+printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)

--- a/tests/rosetta/transpiler/FS/enumerations-4.bench
+++ b/tests/rosetta/transpiler/FS/enumerations-4.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 16,
+  "memory_bytes": 15840,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/enumerations-4.fs
+++ b/tests/rosetta/transpiler/FS/enumerations-4.fs
@@ -1,0 +1,29 @@
+// Generated 2025-08-02 11:55 +0700
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+type fruit = int
+let __bench_start = _now()
+let __mem_start = System.GC.GetTotalMemory(true)
+let apple: fruit = 0
+let banana: fruit = 1
+let cherry: fruit = 2
+let __bench_end = _now()
+let __mem_end = System.GC.GetTotalMemory(true)
+printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)

--- a/transpiler/x/fs/README.md
+++ b/transpiler/x/fs/README.md
@@ -112,4 +112,4 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-Last updated: 2025-08-02 01:57 +0700
+Last updated: 2025-08-02 11:55 +0700

--- a/transpiler/x/fs/ROSETTA.md
+++ b/transpiler/x/fs/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This file is auto-generated from rosetta tests.
 
-## Rosetta Golden Test Checklist (351/491)
+## Rosetta Golden Test Checklist (353/491)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 151µs | 41.3 KB |
@@ -356,8 +356,8 @@ This file is auto-generated from rosetta tests.
 | 349 | entropy-narcissist |   |  |  |
 | 350 | enumerations-1 |   |  |  |
 | 351 | enumerations-2 |   |  |  |
-| 352 | enumerations-3 |   |  |  |
-| 353 | enumerations-4 |   |  |  |
+| 352 | enumerations-3 | ✓ | 16µs | 25.6 KB |
+| 353 | enumerations-4 | ✓ | 16µs | 15.5 KB |
 | 354 | environment-variables-1 |   |  |  |
 | 355 | environment-variables-2 |   |  |  |
 | 356 | equal-prime-and-composite-sums |   |  |  |
@@ -497,4 +497,4 @@ This file is auto-generated from rosetta tests.
 | 490 | window-management | ✓ | 371µs | 45.5 KB |
 | 491 | zumkeller-numbers | ✓ | 44.206ms | 86.9 KB |
 
-Last updated: 2025-08-02 11:41 +0700
+Last updated: 2025-08-02 11:55 +0700

--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-08-02 11:55 +0700)
+- chore(fs): add zumkeller numbers rosetta
+- Generated F# for 103/105 programs (103 passing)
+
 ## Progress (2025-08-02 01:57 +0700)
 - fs transpiler: support array str and typed maps
 - Generated F# for 103/105 programs (103 passing)


### PR DESCRIPTION
## Summary
- support type aliases in F# transpiler and handle casts
- add Rosetta results for enumerations tasks

## Testing
- `MOCHI_BENCHMARK=1 MOCHI_ROSETTA_INDEX=352 go test ./transpiler/x/fs -run TestFSTranspiler_Rosetta_Golden -tags=slow -count=1`
- `MOCHI_BENCHMARK=1 MOCHI_ROSETTA_INDEX=353 go test ./transpiler/x/fs -run TestFSTranspiler_Rosetta_Golden -tags=slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688d9a6610dc83208fedb18313f47de7