### PR TITLE
Fix Kotlin transpiler map assignment

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/call-a-function-4.bench
+++ b/tests/rosetta/transpiler/Kotlin/call-a-function-4.bench
@@ -1,0 +1,1 @@
+{"duration_us":6367, "memory_bytes":133928, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/call-a-function-4.kt
+++ b/tests/rosetta/transpiler/Kotlin/call-a-function-4.kt
@@ -28,8 +28,8 @@ fun gifEncode(out: Any?, img: Any?, opts: MutableMap<String, Int>): Unit {
 }
 
 fun user_main(): Unit {
-    var opts: MutableMap<String, Int> = mutableMapOf<Any?, Any?>() as MutableMap<String, Int>
-    ((opts)["NumColors"] as Int) = 16
+    var opts: MutableMap<String, Int> = mutableMapOf<String, Int>()
+    (opts)["NumColors"] = 16
     gifEncode(null as Any?, null as Any?, opts)
 }
 

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-08-02 11:46 +0700
+Last updated: 2025-08-02 12:08 +0700
 
-Completed tasks: **226/491**
+Completed tasks: **227/491**
 
 ### Checklist
 | Index | Name | Status | Duration | Memory |
@@ -163,7 +163,7 @@ Completed tasks: **226/491**
 | 152 | call-a-function-12 | ✓ | 11.05ms | 131.5 KB |
 | 153 | call-a-function-2 | ✓ | 29.05ms | 132.0 KB |
 | 154 | call-a-function-3 | ✓ | 22.90ms | 124.1 KB |
-| 155 | call-a-function-4 |  |  |  |
+| 155 | call-a-function-4 | ✓ | 6.37ms | 130.8 KB |
 | 156 | call-a-function-5 |  |  |  |
 | 157 | call-a-function-6 |  |  |  |
 | 158 | call-a-function-7 | ✓ | 7.18ms | 134.6 KB |


### PR DESCRIPTION
## Summary
- handle map index assignments without emitting invalid cast expressions
- initialize typed maps without runtime casts in Kotlin code generation
- add Kotlin output and benchmarks for `call-a-function-4`

## Testing
- `ROSETTA_INDEX=155 go test -tags slow ./transpiler/x/kt -run TestRosettaKotlin -count=1`
- `MOCHI_BENCHMARK=true ROSETTA_INDEX=155 go test -tags slow ./transpiler/x/kt -run TestRosettaKotlin -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688d9b823c0c8320a9f03fc9002c8fb9