### PR TITLE
php: add missing benchmark results for conditional structure tests

### DIFF
--- a/tests/rosetta/transpiler/php/conditional-structures-5.bench
+++ b/tests/rosetta/transpiler/php/conditional-structures-5.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 0,
+  "duration_us": 1,
   "memory_bytes": 64,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/php/conditional-structures-5.out
+++ b/tests/rosetta/transpiler/php/conditional-structures-5.out
@@ -1,5 +1,5 @@
 {
-  "duration_us": 0,
+  "duration_us": 1,
   "memory_bytes": 64,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/php/conditional-structures-8.bench
+++ b/tests/rosetta/transpiler/php/conditional-structures-8.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 0,
+  "duration_us": 1,
   "memory_bytes": 64,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/php/conditional-structures-8.out
+++ b/tests/rosetta/transpiler/php/conditional-structures-8.out
@@ -1,5 +1,5 @@
 {
-  "duration_us": 0,
+  "duration_us": 1,
   "memory_bytes": 64,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/php/constrained-genericity-1.bench
+++ b/tests/rosetta/transpiler/php/constrained-genericity-1.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 0,
+  "duration_us": 1,
   "memory_bytes": 64,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/php/constrained-genericity-1.out
+++ b/tests/rosetta/transpiler/php/constrained-genericity-1.out
@@ -1,5 +1,5 @@
 {
-  "duration_us": 0,
+  "duration_us": 1,
   "memory_bytes": 64,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/php/constrained-genericity-2.bench
+++ b/tests/rosetta/transpiler/php/constrained-genericity-2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 0,
+  "duration_us": 1,
   "memory_bytes": 64,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/php/constrained-genericity-2.out
+++ b/tests/rosetta/transpiler/php/constrained-genericity-2.out
@@ -1,5 +1,5 @@
 {
-  "duration_us": 0,
+  "duration_us": 1,
   "memory_bytes": 64,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/php/constrained-genericity-3.bench
+++ b/tests/rosetta/transpiler/php/constrained-genericity-3.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 0,
+  "duration_us": 1,
   "memory_bytes": 64,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/php/constrained-genericity-3.out
+++ b/tests/rosetta/transpiler/php/constrained-genericity-3.out
@@ -1,5 +1,5 @@
 {
-  "duration_us": 0,
+  "duration_us": 1,
   "memory_bytes": 64,
   "name": "main"
 }

--- a/transpiler/x/php/ROSETTA.md
+++ b/transpiler/x/php/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from Mochi Rosetta tasks lives in `tests/rosetta/transpiler/php`.
 
-Last updated: 2025-08-02 14:02 +0700
+Last updated: 2025-08-02 07:22 +0000
 
 ## Checklist (482/491)
 | Index | Name | Status | Duration | Memory |
@@ -225,15 +225,15 @@ Last updated: 2025-08-02 14:02 +0700
 | 216 | conditional-structures-2 | ✓ | 1µs | 64 B |
 | 217 | conditional-structures-3 | ✓ | 1µs | 64 B |
 | 218 | conditional-structures-4 | ✓ | 1µs | 64 B |
-| 219 | conditional-structures-5 | ✓ |  |  |
+| 219 | conditional-structures-5 | ✓ | 1µs | 64 B |
 | 220 | conditional-structures-6 | ✓ | 1µs | 64 B |
 | 221 | conditional-structures-7 | ✓ | 1µs | 64 B |
-| 222 | conditional-structures-8 | ✓ |  |  |
+| 222 | conditional-structures-8 | ✓ | 1µs | 64 B |
 | 223 | conditional-structures-9 | ✓ | 1µs | 64 B |
 | 224 | consecutive-primes-with-ascending-or-descending-differences |   |  |  |
-| 225 | constrained-genericity-1 | ✓ |  |  |
-| 226 | constrained-genericity-2 | ✓ |  |  |
-| 227 | constrained-genericity-3 | ✓ |  |  |
+| 225 | constrained-genericity-1 | ✓ | 1µs | 64 B |
+| 226 | constrained-genericity-2 | ✓ | 1µs | 64 B |
+| 227 | constrained-genericity-3 | ✓ | 1µs | 64 B |
 | 228 | constrained-genericity-4 | ✓ | 75µs | 96 B |
 | 229 | constrained-random-points-on-a-circle-1 | ✓ | 851µs | 52.1 KB |
 | 230 | constrained-random-points-on-a-circle-2 | ✓ | 1.532ms | 149.5 KB |


### PR DESCRIPTION
## Summary
- benchmark php conditional structure 5 and 8 samples
- benchmark php constrained genericity examples 1-3
- record results in `ROSETTA.md`

## Testing
- `php tests/rosetta/transpiler/php/conditional-structures-5.php > /tmp/out && tail -n 5 /tmp/out`
- `php tests/rosetta/transpiler/php/conditional-structures-8.php > /tmp/out && tail -n 5 /tmp/out`
- `php tests/rosetta/transpiler/php/constrained-genericity-1.php > /tmp/out && tail -n 5 /tmp/out`
- `php tests/rosetta/transpiler/php/constrained-genericity-2.php > /tmp/out && tail -n 5 /tmp/out`
- `php tests/rosetta/transpiler/php/constrained-genericity-3.php > /tmp/out && tail -n 5 /tmp/out`


------
https://chatgpt.com/codex/tasks/task_e_688dba1906ac8320a8b5fec776a0b1f2