### PR TITLE
php: add convert seconds to compound duration

### DIFF
--- a/tests/rosetta/transpiler/php/convert-seconds-to-compound-duration.bench
+++ b/tests/rosetta/transpiler/php/convert-seconds-to-compound-duration.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 151,
+  "duration_us": 45,
   "memory_bytes": 96,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/php/convert-seconds-to-compound-duration.out
+++ b/tests/rosetta/transpiler/php/convert-seconds-to-compound-duration.out
@@ -2,7 +2,7 @@
 1 d
 9 wk, 6 d, 10 hr, 40 min
 {
-  "duration_us": 151,
+  "duration_us": 45,
   "memory_bytes": 96,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/php/convert-seconds-to-compound-duration.php
+++ b/tests/rosetta/transpiler/php/convert-seconds-to-compound-duration.php
@@ -33,8 +33,8 @@ function _str($x) {
 }
 function _intdiv($a, $b) {
     if (function_exists('bcdiv')) {
-        $sa = is_int($a) ? strval($a) : sprintf('%.0f', $a);
-        $sb = is_int($b) ? strval($b) : sprintf('%.0f', $b);
+        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
+        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
         return intval(bcdiv($sa, $sb, 0));
     }
     return intdiv($a, $b);
@@ -90,9 +90,9 @@ $__start = _now();
   echo rtrim(timeStr(6000000)), PHP_EOL;
 $__end = _now();
 $__end_mem = memory_get_usage();
-$__duration = intdiv($__end - $__start, 1000);
+$__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
 $__j = json_encode($__bench, 128);
 $__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;;
+echo $__j, PHP_EOL;

--- a/transpiler/x/php/ROSETTA.md
+++ b/transpiler/x/php/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from Mochi Rosetta tasks lives in `tests/rosetta/transpiler/php`.
 
-Last updated: 2025-08-02 07:22 +0000
+Last updated: 2025-08-02 14:25 +0700
 
 ## Checklist (482/491)
 | Index | Name | Status | Duration | Memory |
@@ -239,7 +239,7 @@ Last updated: 2025-08-02 07:22 +0000
 | 230 | constrained-random-points-on-a-circle-2 | ✓ | 1.532ms | 149.5 KB |
 | 231 | continued-fraction | ✓ | 138µs | 96 B |
 | 232 | convert-decimal-number-to-rational | ✓ | 119µs | 96 B |
-| 233 | convert-seconds-to-compound-duration | ✓ | 151µs | 96 B |
+| 233 | convert-seconds-to-compound-duration | ✓ | 45µs | 96 B |
 | 234 | convex-hull | ✓ | 149µs | 376 B |
 | 235 | conways-game-of-life | ✓ | 765.75ms | 128 B |
 | 236 | copy-a-string-1 | ✓ | 1µs | 64 B |


### PR DESCRIPTION
## Summary
- add generated PHP code and output for Rosetta task convert-seconds-to-compound-duration
- refresh PHP Rosetta checklist to include task 233

## Testing
- `MOCHI_ROSETTA_INDEX=233 UPDATE=1 MOCHI_BENCHMARK=1 go test -tags=slow ./transpiler/x/php -run Rosetta -count=1`

------
https://chatgpt.com/codex/tasks/task_e_688dbd748db88320bc8f9be4d964e9f5