### PR TITLE
kt transpiler: handle underscore vars and len on Any

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/cartesian-product-of-two-or-more-lists-2.bench
+++ b/tests/rosetta/transpiler/Kotlin/cartesian-product-of-two-or-more-lists-2.bench
@@ -1,0 +1,1 @@
+{"duration_us":29297, "memory_bytes":116848, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/cartesian-product-of-two-or-more-lists-2.kt
+++ b/tests/rosetta/transpiler/Kotlin/cartesian-product-of-two-or-more-lists-2.kt
@@ -71,7 +71,7 @@ fun cartN(lists: Any?): MutableList<MutableList<Int>> {
     }
     var res: MutableList<MutableList<Int>> = mutableListOf<MutableList<Int>>()
     var idx: MutableList<Int> = mutableListOf<Int>()
-    for (_ in a) {
+    for (_u1 in a) {
         idx = run { val _tmp = idx.toMutableList(); _tmp.add(0); _tmp } as MutableList<Int>
     }
     var n: Int = a.size
@@ -86,11 +86,11 @@ fun cartN(lists: Any?): MutableList<MutableList<Int>> {
         res = run { val _tmp = res.toMutableList(); _tmp.add(row); _tmp } as MutableList<MutableList<Int>>
         var k: BigInteger = (n - 1).toBigInteger()
         while (k.compareTo(0.toBigInteger()) >= 0) {
-            (idx[(k).toInt()]) = idx[(k).toInt()]!! + 1
+            idx[(k).toInt()] = idx[(k).toInt()]!! + 1
             if (idx[(k).toInt()]!! < (a[(k).toInt()]!!).size) {
                 break
             }
-            (idx[(k).toInt()]) = 0
+            idx[(k).toInt()] = 0
             k = k.subtract(1.toBigInteger())
         }
         count = count + 1

--- a/tests/rosetta/transpiler/Kotlin/cartesian-product-of-two-or-more-lists-3.bench
+++ b/tests/rosetta/transpiler/Kotlin/cartesian-product-of-two-or-more-lists-3.bench
@@ -1,1 +1,1 @@
-{"duration_us":30888, "memory_bytes":125928, "name":"main"}
+{"duration_us":27831, "memory_bytes":125912, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/cartesian-product-of-two-or-more-lists-4.bench
+++ b/tests/rosetta/transpiler/Kotlin/cartesian-product-of-two-or-more-lists-4.bench
@@ -1,1 +1,1 @@
-{"duration_us":27351, "memory_bytes":117008, "name":"main"}
+{"duration_us":27912, "memory_bytes":116920, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/case-sensitivity-of-identifiers.bench
+++ b/tests/rosetta/transpiler/Kotlin/case-sensitivity-of-identifiers.bench
@@ -1,0 +1,1 @@
+{"duration_us":23162, "memory_bytes":126792, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/case-sensitivity-of-identifiers.kt
+++ b/tests/rosetta/transpiler/Kotlin/case-sensitivity-of-identifiers.kt
@@ -38,24 +38,24 @@ fun user_main(): Unit {
     var dog: String = "Benjamin"
     d = (packageSees(pkg_dog, Dog, pkg_DOG)) as MutableMap<String, Boolean>
     println((((("Main sees:   " + dog) + " ") + Dog) + " ") + pkg_DOG)
-    ((d)["dog"] as Boolean) = true
-    ((d)["Dog"] as Boolean) = true
-    ((d)["pkg_DOG"] as Boolean) = true
+    (d)["dog"] = true
+    (d)["Dog"] = true
+    (d)["pkg_DOG"] = true
     println(("There are " + d.size.toString()) + " dogs.\n")
     Dog = "Samba"
     d = (packageSees(pkg_dog, Dog, pkg_DOG)) as MutableMap<String, Boolean>
     println((((("Main sees:   " + dog) + " ") + Dog) + " ") + pkg_DOG)
-    ((d)["dog"] as Boolean) = true
-    ((d)["Dog"] as Boolean) = true
-    ((d)["pkg_DOG"] as Boolean) = true
+    (d)["dog"] = true
+    (d)["Dog"] = true
+    (d)["pkg_DOG"] = true
     println(("There are " + d.size.toString()) + " dogs.\n")
     var DOG: String = "Bernie"
     d = (packageSees(pkg_dog, Dog, pkg_DOG)) as MutableMap<String, Boolean>
     println((((("Main sees:   " + dog) + " ") + Dog) + " ") + DOG)
-    ((d)["dog"] as Boolean) = true
-    ((d)["Dog"] as Boolean) = true
-    ((d)["pkg_DOG"] as Boolean) = true
-    ((d)["DOG"] as Boolean) = true
+    (d)["dog"] = true
+    (d)["Dog"] = true
+    (d)["pkg_DOG"] = true
+    (d)["DOG"] = true
     println(("There are " + d.size.toString()) + " dogs.")
 }
 

--- a/tests/rosetta/transpiler/Kotlin/casting-out-nines.bench
+++ b/tests/rosetta/transpiler/Kotlin/casting-out-nines.bench
@@ -1,0 +1,1 @@
+{"duration_us":33672, "memory_bytes":145680, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/casting-out-nines.kt
+++ b/tests/rosetta/transpiler/Kotlin/casting-out-nines.kt
@@ -1,5 +1,12 @@
 import java.math.BigInteger
 
+fun _len(v: Any?): Int = when (v) {
+    is String -> v.length
+    is Collection<*> -> v.size
+    is Map<*, *> -> v.size
+    else -> v.toString().length
+}
+
 var _nowSeed = 0L
 var _nowSeeded = false
 fun _now(): Long {
@@ -95,8 +102,8 @@ fun main() {
             var sx: Int = 0
             var valid: Boolean = true
             var i: Int = 0
-            while (i < ((tc)["kaprekar"] as Any?).toString().length) {
-                var k = (((tc)["kaprekar"] as Any?) as Any?)[i]
+            while (i < _len((tc)["kaprekar"] as Any?)) {
+                var k = (((tc)["kaprekar"] as Any?) as Any? as MutableList<Any?>)[i]
                 var found: Boolean = false
                 while (sx < s.size) {
                     if (s[sx]!! == k) {

--- a/tests/rosetta/transpiler/Kotlin/catalan-numbers-1.bench
+++ b/tests/rosetta/transpiler/Kotlin/catalan-numbers-1.bench
@@ -1,1 +1,1 @@
-{"duration_us":8572, "memory_bytes":137424, "name":"main"}
+{"duration_us":8076, "memory_bytes":137408, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/catalan-numbers-2.bench
+++ b/tests/rosetta/transpiler/Kotlin/catalan-numbers-2.bench
@@ -1,1 +1,1 @@
-{"duration_us":14844, "memory_bytes":124344, "name":"main"}
+{"duration_us":15506, "memory_bytes":124328, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/catalan-numbers-pascals-triangle.bench
+++ b/tests/rosetta/transpiler/Kotlin/catalan-numbers-pascals-triangle.bench
@@ -1,0 +1,1 @@
+{"duration_us":24677, "memory_bytes":117960, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/catalan-numbers-pascals-triangle.kt
+++ b/tests/rosetta/transpiler/Kotlin/catalan-numbers-pascals-triangle.kt
@@ -33,20 +33,20 @@ fun main() {
         System.gc()
         val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
         val _start = _now()
-        for (_ in 0 until n + 2) {
+        for (_u1 in 0 until n + 2) {
             t = run { val _tmp = t.toMutableList(); _tmp.add(0); _tmp } as MutableList<Int>
         }
-        (t[1]) = 1
+        t[1] = 1
         for (i in 1 until n + 1) {
             var j: Int = i
             while (j > 1) {
-                (t[j]) = t[j]!! + t[j - 1]!!
+                t[j] = t[j]!! + t[j - 1]!!
                 j = j - 1
             }
-            (t[(i + 1).toInt()]) = t[i]!!
+            t[(i + 1).toInt()] = t[i]!!
             j = i + 1
             while (j > 1) {
-                (t[j]) = t[j]!! + t[j - 1]!!
+                t[j] = t[j]!! + t[j - 1]!!
                 j = j - 1
             }
             var cat: BigInteger = (t[i + 1]!! - t[i]!!).toBigInteger()

--- a/tests/rosetta/transpiler/Kotlin/catamorphism.bench
+++ b/tests/rosetta/transpiler/Kotlin/catamorphism.bench
@@ -1,1 +1,1 @@
-{"duration_us":12456, "memory_bytes":134760, "name":"main"}
+{"duration_us":11116, "memory_bytes":134744, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/catmull-clark-subdivision-surface.bench
+++ b/tests/rosetta/transpiler/Kotlin/catmull-clark-subdivision-surface.bench
@@ -1,0 +1,1 @@
+{"duration_us":48053, "memory_bytes":99200, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/catmull-clark-subdivision-surface.kt
+++ b/tests/rosetta/transpiler/Kotlin/catmull-clark-subdivision-surface.kt
@@ -26,9 +26,9 @@ fun toJson(v: Any?): String = when (v) {
     else -> toJson(v.toString())
 }
 
-data class Point(var x: Double, var y: Double, var z: Double)
-data class Edge(var pn1: Int, var pn2: Int, var fn1: Int, var fn2: Int, var cp: Point)
-data class PointEx(var p: Point, var n: Int)
+data class Point(var x: Double = 0.0, var y: Double = 0.0, var z: Double = 0.0)
+data class Edge(var pn1: Int = 0, var pn2: Int = 0, var fn1: Int = 0, var fn2: Int = 0, var cp: Point = Point(x = 0.0, y = 0.0, z = 0.0))
+data class PointEx(var p: Point = Point(x = 0.0, y = 0.0, z = 0.0), var n: Int = 0)
 fun indexOf(s: String, ch: String): Int {
     var i: Int = 0
     while (i < s.length) {
@@ -47,7 +47,7 @@ fun fmt4(x: Double): String {
     } else {
         y = y - 0.5
     }
-    y = (y.toInt()).toDouble() / 10000.0
+    y = ((y.toInt()).toDouble()) / 10000.0
     var s: String = y.toString()
     var dot: Int = s.indexOf(".")
     if (dot == (0 - 1)) {
@@ -220,7 +220,7 @@ fun getAvgFacePoints(points: MutableList<Point>, faces: MutableList<MutableList<
         var fp: Point = facePoints[fnum]!!
         for (pn in faces[fnum]!!) {
             var tp: PointEx = temp[pn]!!
-            (temp[pn]) = PointEx(p = sumPoint((tp.p) as Point, fp), n = tp.n + 1)
+            temp[pn] = PointEx(p = sumPoint((tp.p) as Point, fp), n = tp.n + 1)
         }
         fnum = fnum + 1
     }
@@ -247,7 +247,7 @@ fun getAvgMidEdges(points: MutableList<Point>, edgesFaces: MutableList<Edge>): M
         var arr: MutableList<Int> = mutableListOf(edge.pn1, edge.pn2)
         for (pn in arr) {
             var tp: PointEx = temp[pn]!!
-            (temp[pn]) = PointEx(p = sumPoint(tp.p, cp), n = tp.n + 1)
+            temp[pn] = PointEx(p = sumPoint(tp.p, cp), n = tp.n + 1)
         }
     }
     var avg: MutableList<Point> = mutableListOf<Point>()
@@ -270,7 +270,7 @@ fun getPointsFaces(points: MutableList<Point>, faces: MutableList<MutableList<In
     var fnum: Int = 0
     while (fnum < faces.size) {
         for (pn in faces[fnum]!!) {
-            (pf[pn]) = pf[pn]!! + 1
+            pf[pn] = pf[pn]!! + 1
         }
         fnum = fnum + 1
     }
@@ -317,12 +317,12 @@ fun cmcSubdiv(points: MutableList<Point>, faces: MutableList<MutableList<Int>>):
         facePointNums = run { val _tmp = facePointNums.toMutableList(); _tmp.add(nextPoint); _tmp } as MutableList<Int>
         nextPoint = nextPoint + 1
     }
-    var edgePointNums: MutableMap<String, Int> = mutableMapOf<Any?, Any?>() as MutableMap<String, Int>
+    var edgePointNums: MutableMap<String, Int> = mutableMapOf<String, Int>()
     var idx: Int = 0
     while (idx < edgesFaces.size) {
         var e: Edge = edgesFaces[idx]!!
         newPoints = run { val _tmp = newPoints.toMutableList(); _tmp.add(edgePoints[idx]!!); _tmp } as MutableList<Point>
-        ((edgePointNums)[key(e.pn1, e.pn2)] as Int) = nextPoint
+        (edgePointNums)[key(e.pn1, e.pn2)] = nextPoint
         nextPoint = nextPoint + 1
         idx = idx + 1
     }

--- a/tests/rosetta/transpiler/Kotlin/chaocipher.bench
+++ b/tests/rosetta/transpiler/Kotlin/chaocipher.bench
@@ -1,1 +1,1 @@
-{"duration_us":23958, "memory_bytes":128448, "name":"main"}
+{"duration_us":27188, "memory_bytes":128432, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/chaos-game.bench
+++ b/tests/rosetta/transpiler/Kotlin/chaos-game.bench
@@ -1,1 +1,1 @@
-{"duration_us":49181, "memory_bytes":109384, "name":"main"}
+{"duration_us":45126, "memory_bytes":109368, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/chaos-game.kt
+++ b/tests/rosetta/transpiler/Kotlin/chaos-game.kt
@@ -27,7 +27,7 @@ fun toJson(v: Any?): String = when (v) {
 }
 
 var width: Int = 60
-var height: Int = (width.toDouble() * 0.86602540378).toInt()
+var height: Int = ((width.toDouble()) * 0.86602540378).toInt()
 var iterations: Int = 5000
 var grid: MutableList<MutableList<String>> = mutableListOf<MutableList<String>>()
 var y: Int = 0
@@ -64,7 +64,7 @@ fun main() {
             px = ((px + v[0]!!) / 2).toInt()
             py = ((py + v[1]!!) / 2).toInt()
             if ((((((px >= 0) && (px < width) as Boolean)) && (py >= 0) as Boolean)) && (py < height)) {
-                ((grid[py]!!)[px]) = "*"
+                (grid[py]!!)[px] = "*"
             }
             i = i + 1
         }

--- a/tests/rosetta/transpiler/Kotlin/character-codes-1.bench
+++ b/tests/rosetta/transpiler/Kotlin/character-codes-1.bench
@@ -1,1 +1,1 @@
-{"duration_us":12701, "memory_bytes":133680, "name":"main"}
+{"duration_us":12692, "memory_bytes":133664, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/character-codes-2.bench
+++ b/tests/rosetta/transpiler/Kotlin/character-codes-2.bench
@@ -1,1 +1,1 @@
-{"duration_us":13832, "memory_bytes":133680, "name":"main"}
+{"duration_us":11081, "memory_bytes":133664, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/character-codes-3.bench
+++ b/tests/rosetta/transpiler/Kotlin/character-codes-3.bench
@@ -1,1 +1,1 @@
-{"duration_us":9328, "memory_bytes":137104, "name":"main"}
+{"duration_us":7394, "memory_bytes":137088, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/character-codes-4.bench
+++ b/tests/rosetta/transpiler/Kotlin/character-codes-4.bench
@@ -1,1 +1,1 @@
-{"duration_us":9089, "memory_bytes":137216, "name":"main"}
+{"duration_us":9522, "memory_bytes":137200, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/character-codes-5.bench
+++ b/tests/rosetta/transpiler/Kotlin/character-codes-5.bench
@@ -1,1 +1,1 @@
-{"duration_us":8640, "memory_bytes":137216, "name":"main"}
+{"duration_us":8976, "memory_bytes":137200, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/chat-server.bench
+++ b/tests/rosetta/transpiler/Kotlin/chat-server.bench
@@ -1,1 +1,1 @@
-{"duration_us":27825, "memory_bytes":122712, "name":"main"}
+{"duration_us":26603, "memory_bytes":122696, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/check-machin-like-formulas.bench
+++ b/tests/rosetta/transpiler/Kotlin/check-machin-like-formulas.bench
@@ -1,1 +1,1 @@
-{"duration_us":44068, "memory_bytes":85232, "name":"main"}
+{"duration_us":50103, "memory_bytes":85216, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/check-that-file-exists.bench
+++ b/tests/rosetta/transpiler/Kotlin/check-that-file-exists.bench
@@ -1,0 +1,1 @@
+{"duration_us":20741, "memory_bytes":127416, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/check-that-file-exists.kt
+++ b/tests/rosetta/transpiler/Kotlin/check-that-file-exists.kt
@@ -37,8 +37,8 @@ fun printStat(fs: MutableMap<String, Boolean>, path: String): Unit {
 }
 
 fun user_main(): Unit {
-    var fs: MutableMap<String, Boolean> = mutableMapOf<Any?, Any?>() as MutableMap<String, Boolean>
-    ((fs)["docs"] as Boolean) = true
+    var fs: MutableMap<String, Boolean> = mutableMapOf<String, Boolean>()
+    (fs)["docs"] = true
     for (p in mutableListOf("input.txt", "/input.txt", "docs", "/docs")) {
         printStat(fs, p)
     }

--- a/tests/rosetta/transpiler/Kotlin/checkpoint-synchronization-1.bench
+++ b/tests/rosetta/transpiler/Kotlin/checkpoint-synchronization-1.bench
@@ -1,1 +1,1 @@
-{"duration_us":9650, "memory_bytes":136888, "name":"main"}
+{"duration_us":11568, "memory_bytes":136872, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/checkpoint-synchronization-2.bench
+++ b/tests/rosetta/transpiler/Kotlin/checkpoint-synchronization-2.bench
@@ -1,0 +1,1 @@
+{"duration_us":11781, "memory_bytes":136792, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/checkpoint-synchronization-2.kt
+++ b/tests/rosetta/transpiler/Kotlin/checkpoint-synchronization-2.kt
@@ -32,7 +32,7 @@ fun lower(ch: String): String {
     var i: Int = 0
     while (i < upper.length) {
         if (ch == upper.substring(i, i + 1)) {
-            return ::lower.substring(i, i + 1)
+            return lower.substring(i, i + 1)
         }
         i = i + 1
     }

--- a/tests/rosetta/transpiler/Kotlin/checkpoint-synchronization-3.bench
+++ b/tests/rosetta/transpiler/Kotlin/checkpoint-synchronization-3.bench
@@ -1,1 +1,1 @@
-{"duration_us":10323, "memory_bytes":136664, "name":"main"}
+{"duration_us":11413, "memory_bytes":136648, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/checkpoint-synchronization-4.bench
+++ b/tests/rosetta/transpiler/Kotlin/checkpoint-synchronization-4.bench
@@ -1,1 +1,1 @@
-{"duration_us":10934, "memory_bytes":136808, "name":"main"}
+{"duration_us":12096, "memory_bytes":136792, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/chernicks-carmichael-numbers.bench
+++ b/tests/rosetta/transpiler/Kotlin/chernicks-carmichael-numbers.bench
@@ -1,1 +1,1 @@
-{"duration_us":430303, "memory_bytes":858544, "name":"main"}
+{"duration_us":409396, "memory_bytes":848384, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/cheryls-birthday.bench
+++ b/tests/rosetta/transpiler/Kotlin/cheryls-birthday.bench
@@ -1,1 +1,1 @@
-{"duration_us":11400, "memory_bytes":134776, "name":"main"}
+{"duration_us":12645, "memory_bytes":134760, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/cheryls-birthday.kt
+++ b/tests/rosetta/transpiler/Kotlin/cheryls-birthday.kt
@@ -24,7 +24,7 @@ fun toJson(v: Any?): String = when (v) {
     else -> toJson(v.toString())
 }
 
-data class Birthday(var month: Int, var day: Int)
+data class Birthday(var month: Int = 0, var day: Int = 0)
 var choices: MutableList<Birthday> = mutableListOf(Birthday(month = 5, day = 15), Birthday(month = 5, day = 16), Birthday(month = 5, day = 19), Birthday(month = 6, day = 17), Birthday(month = 6, day = 18), Birthday(month = 7, day = 14), Birthday(month = 7, day = 16), Birthday(month = 8, day = 14), Birthday(month = 8, day = 15), Birthday(month = 8, day = 17))
 var filtered: MutableList<Birthday> = mutableListOf<Birthday>()
 var filtered2: MutableList<Birthday> = mutableListOf<Birthday>()

--- a/tests/rosetta/transpiler/Kotlin/chinese-remainder-theorem.bench
+++ b/tests/rosetta/transpiler/Kotlin/chinese-remainder-theorem.bench
@@ -1,1 +1,1 @@
-{"duration_us":8235, "memory_bytes":137320, "name":"main"}
+{"duration_us":10045, "memory_bytes":137304, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/chinese-zodiac.bench
+++ b/tests/rosetta/transpiler/Kotlin/chinese-zodiac.bench
@@ -1,1 +1,1 @@
-{"duration_us":12166, "memory_bytes":127112, "name":"main"}
+{"duration_us":12609, "memory_bytes":127096, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/chinese-zodiac.kt
+++ b/tests/rosetta/transpiler/Kotlin/chinese-zodiac.kt
@@ -26,7 +26,7 @@ fun toJson(v: Any?): String = when (v) {
     else -> toJson(v.toString())
 }
 
-data class Info(var animal: String, var yinYang: String, var element: String, var stemBranch: String, var cycle: Int)
+data class Info(var animal: String = "", var yinYang: String = "", var element: String = "", var stemBranch: String = "", var cycle: Int = 0)
 var animal: MutableList<String> = mutableListOf("Rat", "Ox", "Tiger", "Rabbit", "Dragon", "Snake", "Horse", "Goat", "Monkey", "Rooster", "Dog", "Pig")
 var yinYang: MutableList<String> = mutableListOf("Yang", "Yin")
 var element: MutableList<String> = mutableListOf("Wood", "Fire", "Earth", "Metal", "Water")

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-08-02 13:55 +0700
+Last updated: 2025-08-02 14:18 +0700
 
-Completed tasks: **234/491**
+Completed tasks: **241/491**
 
 ### Checklist
 | Index | Name | Status | Duration | Memory |
@@ -179,34 +179,34 @@ Completed tasks: **234/491**
 | 168 | cantor-set | ✓ | 16.47ms | 122.5 KB |
 | 169 | carmichael-3-strong-pseudoprimes | ✓ | 26.90ms | 120.8 KB |
 | 170 | cartesian-product-of-two-or-more-lists-1 | ✓ | 22.52ms | 123.5 KB |
-| 171 | cartesian-product-of-two-or-more-lists-2 |  |  |  |
-| 172 | cartesian-product-of-two-or-more-lists-3 | ✓ | 30.89ms | 123.0 KB |
-| 173 | cartesian-product-of-two-or-more-lists-4 | ✓ | 27.35ms | 114.3 KB |
-| 174 | case-sensitivity-of-identifiers |  |  |  |
-| 175 | casting-out-nines |  |  |  |
-| 176 | catalan-numbers-1 | ✓ | 8.57ms | 134.2 KB |
-| 177 | catalan-numbers-2 | ✓ | 14.84ms | 121.4 KB |
-| 178 | catalan-numbers-pascals-triangle |  |  |  |
-| 179 | catamorphism | ✓ | 12.46ms | 131.6 KB |
-| 180 | catmull-clark-subdivision-surface |  |  |  |
-| 181 | chaocipher | ✓ | 23.96ms | 125.4 KB |
-| 182 | chaos-game | ✓ | 49.18ms | 106.8 KB |
-| 183 | character-codes-1 | ✓ | 12.70ms | 130.5 KB |
-| 184 | character-codes-2 | ✓ | 13.83ms | 130.5 KB |
-| 185 | character-codes-3 | ✓ | 9.33ms | 133.9 KB |
-| 186 | character-codes-4 | ✓ | 9.09ms | 134.0 KB |
-| 187 | character-codes-5 | ✓ | 8.64ms | 134.0 KB |
-| 188 | chat-server | ✓ | 27.82ms | 119.8 KB |
-| 189 | check-machin-like-formulas | ✓ | 44.07ms | 83.2 KB |
-| 190 | check-that-file-exists |  |  |  |
-| 191 | checkpoint-synchronization-1 | ✓ | 9.65ms | 133.7 KB |
-| 192 | checkpoint-synchronization-2 |  |  |  |
-| 193 | checkpoint-synchronization-3 | ✓ | 10.32ms | 133.5 KB |
-| 194 | checkpoint-synchronization-4 | ✓ | 10.93ms | 133.6 KB |
-| 195 | chernicks-carmichael-numbers | ✓ | 430.30ms | 838.4 KB |
-| 196 | cheryls-birthday | ✓ | 11.40ms | 131.6 KB |
-| 197 | chinese-remainder-theorem | ✓ | 8.23ms | 134.1 KB |
-| 198 | chinese-zodiac | ✓ | 12.17ms | 124.1 KB |
+| 171 | cartesian-product-of-two-or-more-lists-2 | ✓ | 29.30ms | 114.1 KB |
+| 172 | cartesian-product-of-two-or-more-lists-3 | ✓ | 27.83ms | 123.0 KB |
+| 173 | cartesian-product-of-two-or-more-lists-4 | ✓ | 27.91ms | 114.2 KB |
+| 174 | case-sensitivity-of-identifiers | ✓ | 23.16ms | 123.8 KB |
+| 175 | casting-out-nines | ✓ | 33.67ms | 142.3 KB |
+| 176 | catalan-numbers-1 | ✓ | 8.08ms | 134.2 KB |
+| 177 | catalan-numbers-2 | ✓ | 15.51ms | 121.4 KB |
+| 178 | catalan-numbers-pascals-triangle | ✓ | 24.68ms | 115.2 KB |
+| 179 | catamorphism | ✓ | 11.12ms | 131.6 KB |
+| 180 | catmull-clark-subdivision-surface | ✓ | 48.05ms | 96.9 KB |
+| 181 | chaocipher | ✓ | 27.19ms | 125.4 KB |
+| 182 | chaos-game | ✓ | 45.13ms | 106.8 KB |
+| 183 | character-codes-1 | ✓ | 12.69ms | 130.5 KB |
+| 184 | character-codes-2 | ✓ | 11.08ms | 130.5 KB |
+| 185 | character-codes-3 | ✓ | 7.39ms | 133.9 KB |
+| 186 | character-codes-4 | ✓ | 9.52ms | 134.0 KB |
+| 187 | character-codes-5 | ✓ | 8.98ms | 134.0 KB |
+| 188 | chat-server | ✓ | 26.60ms | 119.8 KB |
+| 189 | check-machin-like-formulas | ✓ | 50.10ms | 83.2 KB |
+| 190 | check-that-file-exists | ✓ | 20.74ms | 124.4 KB |
+| 191 | checkpoint-synchronization-1 | ✓ | 11.57ms | 133.7 KB |
+| 192 | checkpoint-synchronization-2 | ✓ | 11.78ms | 133.6 KB |
+| 193 | checkpoint-synchronization-3 | ✓ | 11.41ms | 133.4 KB |
+| 194 | checkpoint-synchronization-4 | ✓ | 12.10ms | 133.6 KB |
+| 195 | chernicks-carmichael-numbers | ✓ | 409.40ms | 828.5 KB |
+| 196 | cheryls-birthday | ✓ | 12.64ms | 131.6 KB |
+| 197 | chinese-remainder-theorem | ✓ | 10.04ms | 134.1 KB |
+| 198 | chinese-zodiac | ✓ | 12.61ms | 124.1 KB |
 | 199 | cholesky-decomposition-1 |  |  |  |
 | 200 | cholesky-decomposition | ✓ | 26.00ms | 113.2 KB |
 | 201 | chowla-numbers |  |  |  |


### PR DESCRIPTION
## Summary
- avoid Kotlin-reserved underscore identifiers by auto-renaming them
- support length checks on `Any?` values via new `_len` helper
- regenerate Kotlin Rosetta outputs and benchmarks for tasks 171-198

## Testing
- `ROSETTA_INDEX=175 MOCHI_BENCHMARK=true go test ./transpiler/x/kt -run TestRosettaKotlin -tags=slow -count=1 -v`
- `for i in $(seq 176 198); do ROSETTA_INDEX=$i MOCHI_BENCHMARK=true go test ./transpiler/x/kt -run TestRosettaKotlin -tags=slow -count=1; done`

------
https://chatgpt.com/codex/tasks/task_e_688dbbde322c8320b4581b9acf1b5891