### PR TITLE
fs transpiler: improve float and string printing

### DIFF
--- a/tests/rosetta/transpiler/FS/address-of-a-variable.bench
+++ b/tests/rosetta/transpiler/FS/address-of-a-variable.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 808,
-  "memory_bytes": 78848,
+  "duration_us": 460,
+  "memory_bytes": 53768,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/FS/address-of-a-variable.fs
+++ b/tests/rosetta/transpiler/FS/address-of-a-variable.fs
@@ -1,4 +1,4 @@
-// Generated 2025-07-26 19:29 +0700
+// Generated 2025-08-02 14:26 +0700
 
 let mutable _nowSeed:int64 = 0L
 let mutable _nowSeeded = false
@@ -21,8 +21,8 @@ _initNow()
 let __bench_start = _now()
 let __mem_start = System.GC.GetTotalMemory(true)
 let mutable myVar: float = 3.14
-printfn "%s" (String.concat " " [|sprintf "%A" "value as float:"; sprintf "%.1f" myVar|])
-printfn "%s" "address: <not available>"
+printfn "%s" (String.concat (" ") ([|sprintf "%s" ("value as float:"); sprintf "%g" (myVar)|]))
+printfn "%s" ("address: <not available>")
 let __bench_end = _now()
 let __mem_end = System.GC.GetTotalMemory(true)
 printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)

--- a/tests/rosetta/transpiler/FS/address-of-a-variable.out
+++ b/tests/rosetta/transpiler/FS/address-of-a-variable.out
@@ -1,2 +1,2 @@
-"value as float:" 3.1
+value as float: 3.14
 address: <not available>

--- a/transpiler/x/fs/README.md
+++ b/transpiler/x/fs/README.md
@@ -112,4 +112,4 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-Last updated: 2025-08-02 11:55 +0700
+Last updated: 2025-08-02 14:26 +0700

--- a/transpiler/x/fs/ROSETTA.md
+++ b/transpiler/x/fs/ROSETTA.md
@@ -39,7 +39,7 @@ This file is auto-generated from rosetta tests.
 | 32 | active-object | ✓ | 405µs | 50.4 KB |
 | 33 | add-a-variable-to-a-class-instance-at-runtime | ✓ |  |  |
 | 34 | additive-primes | ✓ | 351µs | 53.5 KB |
-| 35 | address-of-a-variable | ✓ | 808µs | 77.0 KB |
+| 35 | address-of-a-variable | ✓ | 460µs | 52.5 KB |
 | 36 | adfgvx-cipher |   |  |  |
 | 37 | aks-test-for-primes | ✓ |  |  |
 | 38 | algebraic-data-types | ✓ | 393µs | 66.7 KB |
@@ -497,4 +497,4 @@ This file is auto-generated from rosetta tests.
 | 490 | window-management | ✓ | 371µs | 45.5 KB |
 | 491 | zumkeller-numbers | ✓ | 44.206ms | 86.9 KB |
 
-Last updated: 2025-08-02 14:06 +0700
+Last updated: 2025-08-02 14:26 +0700

--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-08-02 14:26 +0700)
+- fs transpiler: support any type arithmetic
+- Generated F# for 103/105 programs (103 passing)
+
 ## Progress (2025-08-02 11:55 +0700)
 - chore(fs): add zumkeller numbers rosetta
 - Generated F# for 103/105 programs (103 passing)

--- a/transpiler/x/fs/transpiler.go
+++ b/transpiler/x/fs/transpiler.go
@@ -3739,7 +3739,7 @@ func convertPrimary(p *parser.Primary) (Expr, error) {
 				case "int":
 					return &CallExpr{Func: "printfn \"%d\"", Args: []Expr{args[0]}}, nil
 				case "float":
-					return &CallExpr{Func: "printfn \"%.1f\"", Args: []Expr{args[0]}}, nil
+					return &CallExpr{Func: "printfn \"%g\"", Args: []Expr{args[0]}}, nil
 				case "array":
 					mapped := &CallExpr{Func: "Array.map string", Args: []Expr{args[0]}}
 					concat := &CallExpr{Func: "String.concat", Args: []Expr{&StringLit{Value: " "}, &CallExpr{Func: "Array.toList", Args: []Expr{mapped}}}}
@@ -3759,7 +3759,9 @@ func convertPrimary(p *parser.Primary) (Expr, error) {
 				case "int":
 					elems[i] = &CallExpr{Func: "sprintf \"%d\"", Args: []Expr{a}}
 				case "float":
-					elems[i] = &CallExpr{Func: "sprintf \"%.1f\"", Args: []Expr{a}}
+					elems[i] = &CallExpr{Func: "sprintf \"%g\"", Args: []Expr{a}}
+				case "string":
+					elems[i] = &CallExpr{Func: "sprintf \"%s\"", Args: []Expr{a}}
 				case "array":
 					mapped := &CallExpr{Func: "Array.map string", Args: []Expr{a}}
 					elems[i] = &BinaryExpr{Left: &BinaryExpr{Left: &StringLit{Value: "["}, Op: "+", Right: &CallExpr{Func: "String.concat", Args: []Expr{&StringLit{Value: " "}, &CallExpr{Func: "Array.toList", Args: []Expr{mapped}}}}}, Op: "+", Right: &StringLit{Value: "]"}}
@@ -3779,7 +3781,7 @@ func convertPrimary(p *parser.Primary) (Expr, error) {
 				case "int":
 					return &CallExpr{Func: "printf \"%d\"", Args: []Expr{args[0]}}, nil
 				case "float":
-					return &CallExpr{Func: "printf \"%.1f\"", Args: []Expr{args[0]}}, nil
+					return &CallExpr{Func: "printf \"%g\"", Args: []Expr{args[0]}}, nil
 				case "array":
 					mapped := &CallExpr{Func: "Array.map string", Args: []Expr{args[0]}}
 					concat := &CallExpr{Func: "String.concat", Args: []Expr{&StringLit{Value: " "}, &CallExpr{Func: "Array.toList", Args: []Expr{mapped}}}}
@@ -3799,7 +3801,9 @@ func convertPrimary(p *parser.Primary) (Expr, error) {
 				case "int":
 					elems[i] = &CallExpr{Func: "sprintf \"%d\"", Args: []Expr{a}}
 				case "float":
-					elems[i] = &CallExpr{Func: "sprintf \"%.1f\"", Args: []Expr{a}}
+					elems[i] = &CallExpr{Func: "sprintf \"%g\"", Args: []Expr{a}}
+				case "string":
+					elems[i] = &CallExpr{Func: "sprintf \"%s\"", Args: []Expr{a}}
 				case "array":
 					mapped := &CallExpr{Func: "Array.map string", Args: []Expr{a}}
 					elems[i] = &BinaryExpr{Left: &BinaryExpr{Left: &StringLit{Value: "["}, Op: "+", Right: &CallExpr{Func: "String.concat", Args: []Expr{&StringLit{Value: " "}, &CallExpr{Func: "Array.toList", Args: []Expr{mapped}}}}}, Op: "+", Right: &StringLit{Value: "]"}}


### PR DESCRIPTION
## Summary
- fix F# transpiler print helpers to use `%g` for floats and `%s` for strings
- regenerate Rosetta `address-of-a-variable` outputs with benchmark data
- refresh F# Rosetta progress docs

## Testing
- `MOCHI_ROSETTA_INDEX=35 MOCHI_BENCHMARK=1 go test ./transpiler/x/fs -run TestFSTranspiler_Rosetta_Golden -tags=slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_688dbda415148320a3e385016d98d40e