### PR TITLE
pascal transpiler: handle map keys iteration

### DIFF
--- a/tests/rosetta/transpiler/Pascal/associative-array-iteration.bench
+++ b/tests/rosetta/transpiler/Pascal/associative-array-iteration.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 1,
+  "memory_bytes": 1472,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Pascal/associative-array-iteration.out
+++ b/tests/rosetta/transpiler/Pascal/associative-array-iteration.out
@@ -1,0 +1,9 @@
+key = hello, value = 13
+key = world, value = 31
+key = !, value = 71
+key = hello
+key = world
+key = !
+value = 13
+value = 31
+value = 71

--- a/tests/rosetta/transpiler/Pascal/associative-array-iteration.pas
+++ b/tests/rosetta/transpiler/Pascal/associative-array-iteration.pas
@@ -1,0 +1,82 @@
+{$mode objfpc}
+program Main;
+uses SysUtils, fgl;
+var _nowSeed: int64 = 0;
+var _nowSeeded: boolean = false;
+procedure init_now();
+var s: string; v: int64;
+begin
+  s := GetEnvironmentVariable('MOCHI_NOW_SEED');
+  if s <> '' then begin
+    Val(s, v);
+    _nowSeed := v;
+    _nowSeeded := true;
+  end;
+end;
+function _now(): integer;
+begin
+  if _nowSeeded then begin
+    _nowSeed := (_nowSeed * 1664525 + 1013904223) mod 2147483647;
+    _now := _nowSeed;
+  end else begin
+    _now := Integer(GetTickCount64()*1000);
+  end;
+end;
+function _bench_now(): int64;
+begin
+  _bench_now := GetTickCount64()*1000;
+end;
+function _mem(): int64;
+var h: TFPCHeapStatus;
+begin
+  h := GetFPCHeapStatus;
+  _mem := h.CurrHeapUsed;
+end;
+var
+  bench_start_0: integer;
+  bench_dur_0: integer;
+  bench_mem_0: int64;
+  bench_memdiff_0: int64;
+function Map1(): specialize TFPGMap<string, integer>; forward;
+procedure main(); forward;
+function Map1(): specialize TFPGMap<string, integer>;
+begin
+  Result := specialize TFPGMap<string, integer>.Create();
+  Result.AddOrSetData('hello', 13);
+  Result.AddOrSetData('world', 31);
+  Result.AddOrSetData('!', 71);
+end;
+procedure main();
+var
+  main_m: specialize TFPGMap<string, integer>;
+  main_k: string;
+  main_k_idx: integer;
+begin
+  main_m := Map1();
+  for main_k_idx := 0 to (main_m.Count - 1) do begin
+  main_k := main_m.Keys[main_k_idx];
+  writeln((('key = ' + main_k) + ', value = ') + IntToStr(main_m[main_k]));
+end;
+  for main_k_idx := 0 to (main_m.Count - 1) do begin
+  main_k := main_m.Keys[main_k_idx];
+  writeln('key = ' + main_k);
+end;
+  for main_k_idx := 0 to (main_m.Count - 1) do begin
+  main_k := main_m.Keys[main_k_idx];
+  writeln('value = ' + IntToStr(main_m[main_k]));
+end;
+end;
+begin
+  init_now();
+  bench_mem_0 := _mem();
+  bench_start_0 := _bench_now();
+  main();
+  Sleep(1);
+  bench_memdiff_0 := _mem() - bench_mem_0;
+  bench_dur_0 := (_bench_now() - bench_start_0) div 1000;
+  writeln('{');
+  writeln(('  "duration_us": ' + IntToStr(bench_dur_0)) + ',');
+  writeln(('  "memory_bytes": ' + IntToStr(bench_memdiff_0)) + ',');
+  writeln(('  "name": "' + 'main') + '"');
+  writeln('}');
+end.

--- a/transpiler/x/pas/ROSETTA.md
+++ b/transpiler/x/pas/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated Pascal code for Rosetta tasks lives under `tests/rosetta/transpiler/Pascal`.
 
-## Rosetta Checklist (64/491) - updated 2025-08-02 07:27 UTC
+## Rosetta Checklist (65/491) - updated 2025-08-02 07:35 UTC
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 571.223ms | 128 B |
@@ -84,7 +84,7 @@ Generated Pascal code for Rosetta tasks lives under `tests/rosetta/transpiler/Pa
 | 77 | ascii-art-diagram-converter | ✓ | 1µs |  |
 | 78 | assertions | ✓ | 2µs |  |
 | 79 | associative-array-creation | ✓ | 1µs | 3.0 KB |
-| 80 | associative-array-iteration |   |  |  |
+| 80 | associative-array-iteration | ✓ | 1µs | 1.4 KB |
 | 81 | associative-array-merging |   |  |  |
 | 82 | atomic-updates |   |  |  |
 | 83 | attractive-numbers |   |  |  |

--- a/transpiler/x/pas/transpiler.go
+++ b/transpiler/x/pas/transpiler.go
@@ -3990,20 +3990,23 @@ func convertPrimary(env *types.Env, p *parser.Primary) (Expr, error) {
 		} else if name == "avg" && len(args) == 1 {
 			currProg.NeedAvg = true
 			return &CallExpr{Name: "avg", Args: args}, nil
-		} else if name == "min" && len(args) == 1 {
-			currProg.NeedMin = true
-			return &CallExpr{Name: "min", Args: args}, nil
-		} else if name == "max" && len(args) == 1 {
-			currProg.NeedMax = true
-			return &CallExpr{Name: "max", Args: args}, nil
-		} else if name == "values" && len(args) == 1 {
-			if vr, ok := args[0].(*VarRef); ok {
-				if t, ok := currentVarTypes[vr.Name]; ok {
-					for _, r := range currProg.Records {
-						if r.Name == t {
-							var elems []Expr
-							for _, f := range r.Fields {
-								elems = append(elems, &SelectorExpr{Root: vr.Name, Tail: []string{f.Name}})
+               } else if name == "min" && len(args) == 1 {
+                       currProg.NeedMin = true
+                       return &CallExpr{Name: "min", Args: args}, nil
+               } else if name == "max" && len(args) == 1 {
+                       currProg.NeedMax = true
+                       return &CallExpr{Name: "max", Args: args}, nil
+               } else if name == "keys" && len(args) == 1 {
+                       // treat keys(map) as the map itself for iteration purposes
+                       return args[0], nil
+               } else if name == "values" && len(args) == 1 {
+                       if vr, ok := args[0].(*VarRef); ok {
+                               if t, ok := currentVarTypes[vr.Name]; ok {
+                                       for _, r := range currProg.Records {
+                                               if r.Name == t {
+                                                       var elems []Expr
+                                                       for _, f := range r.Fields {
+                                                               elems = append(elems, &SelectorExpr{Root: vr.Name, Tail: []string{f.Name}})
 							}
 							return &ValuesExpr{Elems: elems}, nil
 						}


### PR DESCRIPTION
## Summary
- support `keys(map)` in Pascal transpiler so map key iteration works
- add Rosetta entry for `associative-array-iteration`
- generate Pascal source, output, and benchmark files for the task

## Testing
- `ROSETTA_INDEX=80 MOCHI_BENCHMARK=1 go test -run TestPascalTranspiler_Rosetta -tags slow ./transpiler/x/pas -update-rosetta-pas`


------
https://chatgpt.com/codex/tasks/task_e_688dbe9e48d48320a65af27d11f6ae56