### PR TITLE
pascal: support averages arithmetic mean

### DIFF
--- a/tests/rosetta/transpiler/Pascal/averages-arithmetic-mean.bench
+++ b/tests/rosetta/transpiler/Pascal/averages-arithmetic-mean.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 2,
+  "memory_bytes": 7840,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Pascal/averages-arithmetic-mean.out
+++ b/tests/rosetta/transpiler/Pascal/averages-arithmetic-mean.out
@@ -1,0 +1,14 @@
+Vector: []
+Mean undefined
+
+Vector: [3 1 4 1 5 9]
+Mean of 6 numbers is 3.83333333333333
+
+Vector: [1E20 3 1 4 1 5 9 -1E20]
+Mean of 8 numbers is 0
+
+Vector: [10 9 8 7 6 5 4 3 2 1 0 0 0 0 0.11]
+Mean of 15 numbers is 3.674
+
+Vector: [10 20 30 40 50 -100 4.7 -1100]
+Mean of 8 numbers is -130.6625

--- a/tests/rosetta/transpiler/Pascal/averages-arithmetic-mean.pas
+++ b/tests/rosetta/transpiler/Pascal/averages-arithmetic-mean.pas
@@ -1,0 +1,113 @@
+{$mode objfpc}
+program Main;
+uses SysUtils, Variants, fgl;
+type RealArray = array of real;
+var _nowSeed: int64 = 0;
+var _nowSeeded: boolean = false;
+procedure init_now();
+var s: string; v: int64;
+begin
+  s := GetEnvironmentVariable('MOCHI_NOW_SEED');
+  if s <> '' then begin
+    Val(s, v);
+    _nowSeed := v;
+    _nowSeeded := true;
+  end;
+end;
+function _now(): integer;
+begin
+  if _nowSeeded then begin
+    _nowSeed := (_nowSeed * 1664525 + 1013904223) mod 2147483647;
+    _now := _nowSeed;
+  end else begin
+    _now := Integer(GetTickCount64()*1000);
+  end;
+end;
+function _bench_now(): int64;
+begin
+  _bench_now := GetTickCount64()*1000;
+end;
+function _mem(): int64;
+var h: TFPCHeapStatus;
+begin
+  h := GetFPCHeapStatus;
+  _mem := h.CurrHeapUsed;
+end;
+function list_real_to_str(xs: array of real): string;
+var i: integer;
+begin
+  Result := '[';
+  for i := 0 to High(xs) do begin
+    Result := Result + FloatToStr(xs[i]);
+    if i < High(xs) then Result := Result + ' ';
+  end;
+  Result := Result + ']';
+end;
+var
+  bench_start_0: integer;
+  bench_dur_0: integer;
+  bench_mem_0: int64;
+  bench_memdiff_0: int64;
+function Map2(mean_sum: real; v: RealArray): specialize TFPGMap<string, Variant>; forward;
+function Map1(): specialize TFPGMap<string, Variant>; forward;
+function mean(v: RealArray): specialize TFPGMap<string, Variant>; forward;
+procedure main(); forward;
+function Map2(mean_sum: real; v: RealArray): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('ok', true);
+  Result.AddOrSetData('mean', mean_sum / Double(Length(v)));
+end;
+function Map1(): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('ok', false);
+end;
+function mean(v: RealArray): specialize TFPGMap<string, Variant>;
+var
+  mean_sum: real;
+  mean_i: integer;
+begin
+  if Length(v) = 0 then begin
+  exit(Map1());
+end;
+  mean_sum := 0;
+  mean_i := 0;
+  while mean_i < Length(v) do begin
+  mean_sum := mean_sum + v[mean_i];
+  mean_i := mean_i + 1;
+end;
+  exit(Map2(mean_sum, v));
+end;
+procedure main();
+var
+  main_sets: array of array of real;
+  main_v: array of real;
+  main_r: specialize TFPGMap<string, Variant>;
+begin
+  main_sets := [[], [3, 1, 4, 1, 5, 9], [1e+20, 3, 1, 4, 1, 5, 9, -1e+20], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0.11], [10, 20, 30, 40, 50, -100, 4.7, -1100]];
+  for main_v in main_sets do begin
+  writeln('Vector: ' + list_real_to_str(main_v));
+  main_r := mean(main_v);
+  if main_r['ok'] then begin
+  writeln((('Mean of ' + IntToStr(Length(main_v))) + ' numbers is ') + VarToStr(main_r['mean']));
+end else begin
+  writeln('Mean undefined');
+end;
+  writeln('');
+end;
+end;
+begin
+  init_now();
+  bench_mem_0 := _mem();
+  bench_start_0 := _bench_now();
+  main();
+  Sleep(1);
+  bench_memdiff_0 := _mem() - bench_mem_0;
+  bench_dur_0 := (_bench_now() - bench_start_0) div 1000;
+  writeln('{');
+  writeln(('  "duration_us": ' + IntToStr(bench_dur_0)) + ',');
+  writeln(('  "memory_bytes": ' + IntToStr(bench_memdiff_0)) + ',');
+  writeln(('  "name": "' + 'main') + '"');
+  writeln('}');
+end.

--- a/transpiler/x/pas/ROSETTA.md
+++ b/transpiler/x/pas/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated Pascal code for Rosetta tasks lives under `tests/rosetta/transpiler/Pascal`.
 
-## Rosetta Checklist (69/491) - updated 2025-08-02 07:48 UTC
+## Rosetta Checklist (70/491) - updated 2025-08-02 09:14 UTC
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 571.223ms | 128 B |
@@ -89,7 +89,7 @@ Generated Pascal code for Rosetta tasks lives under `tests/rosetta/transpiler/Pa
 | 82 | atomic-updates | ✓ | 2µs |  |
 | 83 | attractive-numbers | ✓ | 1µs |  |
 | 84 | average-loop-length | ✓ | 185µs |  |
-| 85 | averages-arithmetic-mean |   |  |  |
+| 85 | averages-arithmetic-mean | ✓ | 2µs | 7.7 KB |
 | 86 | averages-mean-time-of-day |   |  |  |
 | 87 | averages-median-1 |   |  |  |
 | 88 | averages-median-2 |   |  |  |

--- a/transpiler/x/pas/transpiler.go
+++ b/transpiler/x/pas/transpiler.go
@@ -135,8 +135,9 @@ type Program struct {
 	LateAliases     map[string]string
 	UseFGL          bool
 	Stmts           []Stmt
-	UseSysUtils     bool
-	UseMath         bool
+        UseSysUtils     bool
+       UseVariants     bool
+        UseMath         bool
 	NeedAvg         bool
 	NeedMin         bool
 	NeedMax         bool
@@ -159,23 +160,29 @@ type Program struct {
 }
 
 func collectVarNames(e Expr, set map[string]struct{}) {
-	switch v := e.(type) {
-	case *VarRef:
-		set[v.Name] = struct{}{}
-	case *BinaryExpr:
-		collectVarNames(v.Left, set)
-		if v.Right != nil {
-			collectVarNames(v.Right, set)
-		}
-	case *CallExpr:
-		for _, a := range v.Args {
-			collectVarNames(a, set)
-		}
-	case *IndexExpr:
-		collectVarNames(v.Target, set)
-		collectVarNames(v.Index, set)
-	case *SliceExpr:
-		collectVarNames(v.Target, set)
+        switch v := e.(type) {
+        case *VarRef:
+                set[v.Name] = struct{}{}
+        case *BinaryExpr:
+                collectVarNames(v.Left, set)
+                if v.Right != nil {
+                        collectVarNames(v.Right, set)
+                }
+        case *CallExpr:
+                for _, a := range v.Args {
+                        collectVarNames(a, set)
+                }
+       case *CastExpr:
+               if v.Expr != nil {
+                       collectVarNames(v.Expr, set)
+               }
+       case *SelectorExpr:
+               collectVarNames(&VarRef{Name: v.Root}, set)
+        case *IndexExpr:
+                collectVarNames(v.Target, set)
+                collectVarNames(v.Index, set)
+        case *SliceExpr:
+                collectVarNames(v.Target, set)
 		if v.Start != nil {
 			collectVarNames(v.Start, set)
 		}
@@ -958,9 +965,12 @@ func (p *Program) Emit() []byte {
 	var buf bytes.Buffer
 	buf.WriteString("{$mode objfpc}\nprogram Main;\n")
 	var uses []string
-	if p.UseSysUtils {
-		uses = append(uses, "SysUtils")
-	}
+        if p.UseSysUtils {
+                uses = append(uses, "SysUtils")
+        }
+       if p.UseVariants {
+               uses = append(uses, "Variants")
+       }
 	if p.UseMath {
 		uses = append(uses, "Math")
 	}
@@ -2083,36 +2093,34 @@ func convertBody(env *types.Env, body []*parser.Statement, varTypes map[string]s
 					startType = fmt.Sprintf("specialize TFPGMap<%s, %s>", keyT, valT)
 				}
 			}
-			typ := "integer"
-			if st.For.RangeEnd == nil {
-				if strings.HasPrefix(startType, "array of ") {
-					elem := strings.TrimPrefix(startType, "array of ")
-					switch elem {
-					case "string":
-						typ = "string"
-					case "boolean":
-						typ = "boolean"
-					}
-				} else if strings.HasPrefix(startType, "specialize TFPGMap") {
-					parts := strings.TrimPrefix(startType, "specialize TFPGMap<")
-					parts = strings.TrimSuffix(parts, ">")
-					kv := strings.Split(parts, ",")
-					if len(kv) == 2 {
-						typ = strings.TrimSpace(kv[0])
-					}
-				} else {
-					tt := types.ExprType(st.For.Source, env)
-					if lt, ok := tt.(types.ListType); ok {
-						if _, ok := lt.Elem.(types.StringType); ok {
-							typ = "string"
-						} else if _, ok := lt.Elem.(types.BoolType); ok {
-							typ = "boolean"
-						}
-					} else if mt, ok := tt.(types.MapType); ok {
-						typ = pasTypeFromType(mt.Key)
-					}
-				}
-			}
+                       typ := "integer"
+                       if st.For.RangeEnd == nil {
+                               if strings.HasPrefix(startType, "array of ") {
+                                       elem := strings.TrimPrefix(startType, "array of ")
+                                       switch elem {
+                                       case "string":
+                                               typ = "string"
+                                       case "boolean":
+                                               typ = "boolean"
+                                       default:
+                                               typ = elem
+                                       }
+                               } else if strings.HasPrefix(startType, "specialize TFPGMap") {
+                                       parts := strings.TrimPrefix(startType, "specialize TFPGMap<")
+                                       parts = strings.TrimSuffix(parts, ">")
+                                       kv := strings.Split(parts, ",")
+                                       if len(kv) == 2 {
+                                               typ = strings.TrimSpace(kv[0])
+                                       }
+                               } else {
+                                       tt := types.ExprType(st.For.Source, env)
+                                       if lt, ok := tt.(types.ListType); ok {
+                                               typ = pasTypeFromType(lt.Elem)
+                                       } else if mt, ok := tt.(types.MapType); ok {
+                                               typ = pasTypeFromType(mt.Key)
+                                       }
+                               }
+                       }
 			name := sanitize(st.For.Name)
 			varTypes[name] = typ
 			setVarType(name, varTypes[name])
@@ -4021,13 +4029,18 @@ func convertPrimary(env *types.Env, p *parser.Primary) (Expr, error) {
 				currProg.NeedListStr2 = true
 				return &CallExpr{Name: "list_int_to_str", Args: args}, nil
 			}
-			if t == "Variant" || t == "any" || t == "string" {
-				return args[0], nil
-			}
-			if t == "real" {
-				name = "FloatToStr"
-				currProg.UseSysUtils = true
-			} else if t == "BigRat" {
+                       if t == "Variant" || t == "any" {
+                               currProg.UseSysUtils = true
+                               currProg.UseVariants = true
+                               return &CallExpr{Name: "VarToStr", Args: args}, nil
+                       }
+                       if t == "string" {
+                               return args[0], nil
+                       }
+                       if t == "real" {
+                                name = "FloatToStr"
+                                currProg.UseSysUtils = true
+                        } else if t == "BigRat" {
 				currProg.UseSysUtils = true
 				numCall := &CallExpr{Name: "IntToStr", Args: []Expr{&CallExpr{Name: "num", Args: args}}}
 				denCall := &CallExpr{Name: "IntToStr", Args: []Expr{&CallExpr{Name: "denom", Args: args}}}


### PR DESCRIPTION
## Summary
- handle cast and selector variables when collecting map literal deps
- infer element types for `for-in` loops and support variant-to-string conversion
- transpile Rosetta `averages-arithmetic-mean` and record benchmark

## Testing
- `ROSETTA_INDEX=85 MOCHI_BENCHMARK=1 go test -tags=slow ./transpiler/x/pas -run Rosetta -count=1`

------
https://chatgpt.com/codex/tasks/task_e_688dd4dbc5d88320820e6a815d722f39