### PR TITLE
docs: add v0.10.55 changelog and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # 📦 CHANGELOG.md
 
+## [0.10.55] – 2025-08-02T16:16:26+07:00
+
+### Added
+
+* Kotlin circular primes and call-a-function examples with struct method support
+* Pascal, Racket and Zig transpilers extend map handling, dynamic indexing and multi-argument features
+* New Rosetta benchmarks such as Floyd–Warshall, Cholesky decomposition and bubble sort
+
+### Changed
+
+* Rosetta outputs regenerated across PHP, Go, Scala, Ruby and more
+* Improved map, list and index handling in Pascal, Kotlin, Scala, Swift and C transpilers
+
+### Fixed
+
+* Java list literal typing, Kotlin map assignment and Scala lambda returns
+* Swift BigInt modulo overflow, Ruby fetch helper JSON dependency and PHP benchmark timing
+
 ## [0.10.54] – 2025-08-02T10:23:53+07:00
 
 ### Added

--- a/releases/v0.10.55.md
+++ b/releases/v0.10.55.md
@@ -1,0 +1,22 @@
+# Aug 2025 (v0.10.55)
+
+Released on Sat Aug 02 16:16:26 2025 +0700.
+
+Mochi v0.10.55 broadens Rosetta benchmark coverage and strengthens map and list handling across transpilers while refining cross-language outputs and addressing several typing bugs.
+
+## Transpilers
+
+- Kotlin adds circular primes and call-a-function examples with struct method support
+- Pascal, Racket and Zig transpilers expand dynamic map features, printing and multi-argument capabilities
+- Go, PHP, Ruby and others regenerate Rosetta outputs for broader benchmark support
+
+## Benchmarks
+
+- New metrics and examples including Floyd–Warshall, Cholesky decomposition and bubble sort
+- Expanded Rosetta outputs across Java, F#, Erlang, Prolog and more
+
+## Fixes
+
+- Corrected Java list literal typing, Kotlin map assignment and Scala lambda returns
+- Resolved Swift BigInt modulo overflow and Ruby fetch helper dependency
+- Fixed PHP benchmark timing and other minor bugs


### PR DESCRIPTION
## Summary
- document v0.10.55 release date and notes
- log added features, changes, and fixes in CHANGELOG

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688dda35fbc88320a175a367484a3e62