### PR TITLE
feat(kt): add Kotlin transpiled comma quibbling

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/comma-quibbling.bench
+++ b/tests/rosetta/transpiler/Kotlin/comma-quibbling.bench
@@ -1,0 +1,1 @@
+{"duration_us":23134, "memory_bytes":126616, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/comma-quibbling.kt
+++ b/tests/rosetta/transpiler/Kotlin/comma-quibbling.kt
@@ -1,0 +1,75 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+fun quibble(items: MutableList<String>): String {
+    var n: Int = items.size
+    if (n == 0) {
+        return "{}"
+    } else {
+        if (n == 1) {
+            return ("{" + items[0]!!) + "}"
+        } else {
+            if (n == 2) {
+                return ((("{" + items[0]!!) + " and ") + items[1]!!) + "}"
+            } else {
+                var prefix: String = ""
+                for (i in 0 until n - 1) {
+                    if (i == (n - 1)) {
+                        break
+                    }
+                    if (i > 0) {
+                        prefix = prefix + ", "
+                    }
+                    prefix = prefix + items[i]!!
+                }
+                return ((("{" + prefix) + " and ") + items[n - 1]!!) + "}"
+            }
+        }
+    }
+}
+
+fun user_main(): Unit {
+    println(quibble(mutableListOf<String>()))
+    println(quibble(mutableListOf("ABC")))
+    println(quibble(mutableListOf("ABC", "DEF")))
+    println(quibble(mutableListOf("ABC", "DEF", "G", "H")))
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/comma-quibbling.out
+++ b/tests/rosetta/transpiler/Kotlin/comma-quibbling.out
@@ -1,0 +1,4 @@
+{}
+{ABC}
+{ABC and DEF}
+{ABC, DEF, G and H}

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-08-02 16:04 +0700
+Last updated: 2025-08-02 16:16 +0700
 
-Completed tasks: **245/491**
+Completed tasks: **246/491**
 
 ### Checklist
 | Index | Name | Status | Duration | Memory |
@@ -215,7 +215,7 @@ Completed tasks: **245/491**
 | 204 | circles-of-given-radius-through-two-points |  |  |  |
 | 205 | circular-primes | ✓ | 68.53ms | 119.0 KB |
 | 206 | cistercian-numerals |  |  |  |
-| 207 | comma-quibbling |  |  |  |
+| 207 | comma-quibbling | ✓ | 23.13ms | 123.6 KB |
 | 208 | compiler-virtual-machine-interpreter |  |  |  |
 | 209 | composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k |  |  |  |
 | 210 | compound-data-type |  |  |  |


### PR DESCRIPTION
## Summary
- add Kotlin transpiled Rosetta Code solution for `comma-quibbling`
- record benchmark and progress entry in `ROSETTA.md`

## Testing
- `ROSETTA_INDEX=207 go test -tags=slow ./transpiler/x/kt -run TestRosettaKotlin -count=1 -v`
- `ROSETTA_INDEX=207 MOCHI_BENCHMARK=true go test -tags=slow ./transpiler/x/kt -run TestRosettaKotlin -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_688dd713a9688320b549e9d510c2fe30