### PR TITLE
fix(java-tr): handle string equality

### DIFF
--- a/transpiler/x/java/ROSETTA.md
+++ b/transpiler/x/java/ROSETTA.md
@@ -1,12 +1,12 @@
 # Java Rosetta Transpiler Output
 
 Generated Java code for programs in `tests/rosetta/x/Mochi`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
-Last updated: 2025-08-02 16:19 GMT+7
+Last updated: 2025-08-02 16:42 GMT+7
 
 ## Rosetta Checklist (387/491)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
-| 1 | 100-doors-2 | ✓ | 23.0ms | 245.84KB |
+| 1 | 100-doors-2 | ✓ | 46.0ms | 71.64KB |
 | 2 | 100-doors-3 | ✓ | 10.0ms | 0B |
 | 3 | 100-doors | ✓ | 11.0ms | 0B |
 | 4 | 100-prisoners | ✓ | 684.0ms | 43.51MB |


### PR DESCRIPTION
## Summary
- use `.equals` when comparing string expressions
- refresh Rosetta progress table

## Testing
- `UPDATE=1 MOCHI_BENCHMARK=1 go test ./transpiler/x/java -tags slow -run Rosetta -args -index 1`

------
https://chatgpt.com/codex/tasks/task_e_688dda95d0d88320aacabe243a828620