### PR TITLE
cpp transpiler: add index casting and benchmarks for mid-range programs

### DIFF
--- a/tests/rosetta/transpiler/CPP/compound-data-type.bench
+++ b/tests/rosetta/transpiler/CPP/compound-data-type.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 4,
+  "memory_bytes": 12435456,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/concurrent-computing-1.bench
+++ b/tests/rosetta/transpiler/CPP/concurrent-computing-1.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 196,
+  "memory_bytes": 13217792,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/concurrent-computing-2.bench
+++ b/tests/rosetta/transpiler/CPP/concurrent-computing-2.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 195,
+  "memory_bytes": 13324288,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/concurrent-computing-3.bench
+++ b/tests/rosetta/transpiler/CPP/concurrent-computing-3.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 207,
+  "memory_bytes": 13492224,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/conditional-structures-1.bench
+++ b/tests/rosetta/transpiler/CPP/conditional-structures-1.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 22,
+  "memory_bytes": 13262848,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/conditional-structures-10.bench
+++ b/tests/rosetta/transpiler/CPP/conditional-structures-10.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 296,
+  "memory_bytes": 13504512,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/conditional-structures-2.bench
+++ b/tests/rosetta/transpiler/CPP/conditional-structures-2.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 23,
+  "memory_bytes": 13328384,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/conditional-structures-3.bench
+++ b/tests/rosetta/transpiler/CPP/conditional-structures-3.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 16,
+  "memory_bytes": 13455360,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/conditional-structures-4.bench
+++ b/tests/rosetta/transpiler/CPP/conditional-structures-4.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 5,
+  "memory_bytes": 13787136,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/conditional-structures-5.bench
+++ b/tests/rosetta/transpiler/CPP/conditional-structures-5.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 4,
+  "memory_bytes": 13361152,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/conditional-structures-6.bench
+++ b/tests/rosetta/transpiler/CPP/conditional-structures-6.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 17,
+  "memory_bytes": 13692928,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/conditional-structures-7.bench
+++ b/tests/rosetta/transpiler/CPP/conditional-structures-7.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 4,
+  "memory_bytes": 13217792,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/conditional-structures-8.bench
+++ b/tests/rosetta/transpiler/CPP/conditional-structures-8.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 4,
+  "memory_bytes": 13312000,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/conditional-structures-9.bench
+++ b/tests/rosetta/transpiler/CPP/conditional-structures-9.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 4,
+  "memory_bytes": 13406208,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/consecutive-primes-with-ascending-or-descending-differences.bench
+++ b/tests/rosetta/transpiler/CPP/consecutive-primes-with-ascending-or-descending-differences.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 87312,
+  "memory_bytes": 14438400,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/constrained-genericity-1.bench
+++ b/tests/rosetta/transpiler/CPP/constrained-genericity-1.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 4,
+  "memory_bytes": 13361152,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/constrained-genericity-2.bench
+++ b/tests/rosetta/transpiler/CPP/constrained-genericity-2.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 4,
+  "memory_bytes": 13017088,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/constrained-genericity-3.bench
+++ b/tests/rosetta/transpiler/CPP/constrained-genericity-3.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 5,
+  "memory_bytes": 13352960,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/constrained-genericity-4.bench
+++ b/tests/rosetta/transpiler/CPP/constrained-genericity-4.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 150,
+  "memory_bytes": 13590528,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/constrained-random-points-on-a-circle-1.error
+++ b/tests/rosetta/transpiler/CPP/constrained-random-points-on-a-circle-1.error
@@ -1,29 +1,29 @@
 compile: exit status 1
-/workspace/mochi/tests/rosetta/transpiler/CPP/constrained-random-points-on-a-circle-1.cpp:36:181: warning: multi-character character constant [-Wmultichar]
-   36 |     else if(val.type() == typeid(std::vector<int64_t>)) { const auto& v = std::any_cast<const std::vector<int64_t>&>(val); os << '['; for(size_t i=0;i<v.size();++i){ if(i>0) os << ', '; os << v[i]; } os << ']'; }
+/workspace/mochi/tests/rosetta/transpiler/CPP/constrained-random-points-on-a-circle-1.cpp:49:181: warning: multi-character character constant [-Wmultichar]
+   49 |     else if(val.type() == typeid(std::vector<int64_t>)) { const auto& v = std::any_cast<const std::vector<int64_t>&>(val); os << '['; for(size_t i=0;i<v.size();++i){ if(i>0) os << ', '; os << v[i]; } os << ']'; }
       |                                                                                                                                                                                     ^~~~
-/workspace/mochi/tests/rosetta/transpiler/CPP/constrained-random-points-on-a-circle-1.cpp:37:209: warning: multi-character character constant [-Wmultichar]
-   37 |     else if(val.type() == typeid(std::vector<std::vector<int64_t>>)) { const auto& vv = std::any_cast<const std::vector<std::vector<int64_t>>&>(val); os << '['; for(size_t i=0;i<vv.size();++i){ if(i>0) os << ', '; const auto& v = vv[i]; os << '['; for(size_t j=0;j<v.size();++j){ if(j>0) os << ', '; os << v[j]; } os << ']'; } os << ']'; }
+/workspace/mochi/tests/rosetta/transpiler/CPP/constrained-random-points-on-a-circle-1.cpp:50:209: warning: multi-character character constant [-Wmultichar]
+   50 |     else if(val.type() == typeid(std::vector<std::vector<int64_t>>)) { const auto& vv = std::any_cast<const std::vector<std::vector<int64_t>>&>(val); os << '['; for(size_t i=0;i<vv.size();++i){ if(i>0) os << ', '; const auto& v = vv[i]; os << '['; for(size_t j=0;j<v.size();++j){ if(j>0) os << ', '; os << v[j]; } os << ']'; } os << ']'; }
       |                                                                                                                                                                                                                 ^~~~
-/workspace/mochi/tests/rosetta/transpiler/CPP/constrained-random-points-on-a-circle-1.cpp:37:295: warning: multi-character character constant [-Wmultichar]
-   37 |     else if(val.type() == typeid(std::vector<std::vector<int64_t>>)) { const auto& vv = std::any_cast<const std::vector<std::vector<int64_t>>&>(val); os << '['; for(size_t i=0;i<vv.size();++i){ if(i>0) os << ', '; const auto& v = vv[i]; os << '['; for(size_t j=0;j<v.size();++j){ if(j>0) os << ', '; os << v[j]; } os << ']'; } os << ']'; }
+/workspace/mochi/tests/rosetta/transpiler/CPP/constrained-random-points-on-a-circle-1.cpp:50:295: warning: multi-character character constant [-Wmultichar]
+   50 |     else if(val.type() == typeid(std::vector<std::vector<int64_t>>)) { const auto& vv = std::any_cast<const std::vector<std::vector<int64_t>>&>(val); os << '['; for(size_t i=0;i<vv.size();++i){ if(i>0) os << ', '; const auto& v = vv[i]; os << '['; for(size_t j=0;j<v.size();++j){ if(j>0) os << ', '; os << v[j]; } os << ']'; } os << ']'; }
       |                                                                                                                                                                                                                                                                                                       ^~~~
-/workspace/mochi/tests/rosetta/transpiler/CPP/constrained-random-points-on-a-circle-1.cpp:38:189: warning: multi-character character constant [-Wmultichar]
-   38 |     else if(val.type() == typeid(std::vector<std::string>)) { const auto& v = std::any_cast<const std::vector<std::string>&>(val); os << '['; for(size_t i=0;i<v.size();++i){ if(i>0) os << ', '; os << v[i]; } os << ']'; }
+/workspace/mochi/tests/rosetta/transpiler/CPP/constrained-random-points-on-a-circle-1.cpp:51:189: warning: multi-character character constant [-Wmultichar]
+   51 |     else if(val.type() == typeid(std::vector<std::string>)) { const auto& v = std::any_cast<const std::vector<std::string>&>(val); os << '['; for(size_t i=0;i<v.size();++i){ if(i>0) os << ', '; os << v[i]; } os << ']'; }
       |                                                                                                                                                                                             ^~~~
-/workspace/mochi/tests/rosetta/transpiler/CPP/constrained-random-points-on-a-circle-1.cpp:39:183: warning: multi-character character constant [-Wmultichar]
-   39 |     else if(val.type() == typeid(std::vector<std::any>)) { const auto& v = std::any_cast<const std::vector<std::any>&>(val); os << '['; for(size_t i=0;i<v.size();++i){ if(i>0) os << ', '; any_to_stream(os, v[i]); } os << ']'; }
+/workspace/mochi/tests/rosetta/transpiler/CPP/constrained-random-points-on-a-circle-1.cpp:52:183: warning: multi-character character constant [-Wmultichar]
+   52 |     else if(val.type() == typeid(std::vector<std::any>)) { const auto& v = std::any_cast<const std::vector<std::any>&>(val); os << '['; for(size_t i=0;i<v.size();++i){ if(i>0) os << ', '; any_to_stream(os, v[i]); } os << ']'; }
       |                                                                                                                                                                                       ^~~~
-/workspace/mochi/tests/rosetta/transpiler/CPP/constrained-random-points-on-a-circle-1.cpp:40:215: warning: multi-character character constant [-Wmultichar]
-   40 |     else if(val.type() == typeid(std::map<std::string, std::any>)) { const auto& m = std::any_cast<const std::map<std::string, std::any>&>(val); os << '{'; bool first=true; for(const auto& p : m){ if(!first) os << ', '; first=false; os << p.first << ': '; any_to_stream(os, p.second); } os << '}'; }
+/workspace/mochi/tests/rosetta/transpiler/CPP/constrained-random-points-on-a-circle-1.cpp:53:215: warning: multi-character character constant [-Wmultichar]
+   53 |     else if(val.type() == typeid(std::map<std::string, std::any>)) { const auto& m = std::any_cast<const std::map<std::string, std::any>&>(val); os << '{'; bool first=true; for(const auto& p : m){ if(!first) os << ', '; first=false; os << p.first << ': '; any_to_stream(os, p.second); } os << '}'; }
       |                                                                                                                                                                                                                       ^~~~
-/workspace/mochi/tests/rosetta/transpiler/CPP/constrained-random-points-on-a-circle-1.cpp:40:251: warning: multi-character character constant [-Wmultichar]
-   40 |     else if(val.type() == typeid(std::map<std::string, std::any>)) { const auto& m = std::any_cast<const std::map<std::string, std::any>&>(val); os << '{'; bool first=true; for(const auto& p : m){ if(!first) os << ', '; first=false; os << p.first << ': '; any_to_stream(os, p.second); } os << '}'; }
+/workspace/mochi/tests/rosetta/transpiler/CPP/constrained-random-points-on-a-circle-1.cpp:53:251: warning: multi-character character constant [-Wmultichar]
+   53 |     else if(val.type() == typeid(std::map<std::string, std::any>)) { const auto& m = std::any_cast<const std::map<std::string, std::any>&>(val); os << '{'; bool first=true; for(const auto& p : m){ if(!first) os << ', '; first=false; os << p.first << ': '; any_to_stream(os, p.second); } os << '}'; }
       |                                                                                                                                                                                                                                                           ^~~~
 /workspace/mochi/tests/rosetta/transpiler/CPP/constrained-random-points-on-a-circle-1.cpp: In function ‘int main()’:
-/workspace/mochi/tests/rosetta/transpiler/CPP/constrained-random-points-on-a-circle-1.cpp:107:13: error: no match for ‘operator[]’ (operand types are ‘std::vector<std::vector<std::__cxx11::basic_string<char> > >’ and ‘boost::multiprecision::cpp_int’ {aka ‘boost::multiprecision::number<boost::multiprecision::backends::cpp_int_backend<> >’})
-  107 |         rows[row][col] = std::string("*");
-      |             ^
+/workspace/mochi/tests/rosetta/transpiler/CPP/constrained-random-points-on-a-circle-1.cpp:133:17: error: no match for ‘operator[]’ (operand types are ‘std::vector<std::vector<std::__cxx11::basic_string<char> > >’ and ‘boost::multiprecision::cpp_int’ {aka ‘boost::multiprecision::number<boost::multiprecision::backends::cpp_int_backend<> >’})
+  133 |             rows[row][col] = std::string("*");
+      |                 ^
 In file included from /usr/include/c++/13/vector:66,
                  from /workspace/mochi/tests/rosetta/transpiler/CPP/constrained-random-points-on-a-circle-1.cpp:4:
 /usr/include/c++/13/bits/stl_vector.h:1126:7: note: candidate: ‘constexpr std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](size_type) [with _Tp = std::vector<std::__cxx11::basic_string<char> >; _Alloc = std::allocator<std::vector<std::__cxx11::basic_string<char> > >; reference = std::vector<std::__cxx11::basic_string<char> >&; size_type = long unsigned int]’

--- a/transpiler/x/cpp/ROSETTA.md
+++ b/transpiler/x/cpp/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This directory stores C++ code generated from Mochi programs in `tests/rosetta/x/Mochi`. Each file is compiled and executed during tests. Successful runs keep the generated `.cpp` source along with a matching `.out` file. Failures are recorded in `.error` files when tests run with `-update`.
 
-Checklist of programs that currently transpile and run (264/491) - Last updated 2025-08-02 14:01 +0700:
+Checklist of programs that currently transpile and run (264/491) - Last updated 2025-08-02 17:26 +0700:
 | Index | Name | Status | Duration | Memory |
 | ---: | --- | :---: | ---: | ---: |
 | 1 | 100-doors-2 | ✓ | 222.0µs | 13.12MB |
@@ -214,25 +214,25 @@ Checklist of programs that currently transpile and run (264/491) - Last updated 
 | 207 | comma-quibbling | ✓ | 172.0µs | 12.96MB |
 | 208 | compiler-virtual-machine-interpreter |   |  |  |
 | 209 | composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k | ✓ | 27.29s | 14.12MB |
-| 210 | compound-data-type | ✓ |  |  |
-| 211 | concurrent-computing-1 | ✓ |  |  |
-| 212 | concurrent-computing-2 | ✓ |  |  |
-| 213 | concurrent-computing-3 | ✓ |  |  |
-| 214 | conditional-structures-1 | ✓ |  |  |
-| 215 | conditional-structures-10 | ✓ |  |  |
-| 216 | conditional-structures-2 | ✓ |  |  |
-| 217 | conditional-structures-3 | ✓ |  |  |
-| 218 | conditional-structures-4 | ✓ |  |  |
-| 219 | conditional-structures-5 | ✓ |  |  |
-| 220 | conditional-structures-6 | ✓ |  |  |
-| 221 | conditional-structures-7 | ✓ |  |  |
-| 222 | conditional-structures-8 | ✓ |  |  |
-| 223 | conditional-structures-9 | ✓ |  |  |
-| 224 | consecutive-primes-with-ascending-or-descending-differences | ✓ |  |  |
-| 225 | constrained-genericity-1 | ✓ |  |  |
-| 226 | constrained-genericity-2 | ✓ |  |  |
-| 227 | constrained-genericity-3 | ✓ |  |  |
-| 228 | constrained-genericity-4 | ✓ |  |  |
+| 210 | compound-data-type | ✓ | 4.0µs | 11.86MB |
+| 211 | concurrent-computing-1 | ✓ | 196.0µs | 12.61MB |
+| 212 | concurrent-computing-2 | ✓ | 195.0µs | 12.71MB |
+| 213 | concurrent-computing-3 | ✓ | 207.0µs | 12.87MB |
+| 214 | conditional-structures-1 | ✓ | 22.0µs | 12.65MB |
+| 215 | conditional-structures-10 | ✓ | 296.0µs | 12.88MB |
+| 216 | conditional-structures-2 | ✓ | 23.0µs | 12.71MB |
+| 217 | conditional-structures-3 | ✓ | 16.0µs | 12.83MB |
+| 218 | conditional-structures-4 | ✓ | 5.0µs | 13.15MB |
+| 219 | conditional-structures-5 | ✓ | 4.0µs | 12.74MB |
+| 220 | conditional-structures-6 | ✓ | 17.0µs | 13.06MB |
+| 221 | conditional-structures-7 | ✓ | 4.0µs | 12.61MB |
+| 222 | conditional-structures-8 | ✓ | 4.0µs | 12.70MB |
+| 223 | conditional-structures-9 | ✓ | 4.0µs | 12.79MB |
+| 224 | consecutive-primes-with-ascending-or-descending-differences | ✓ | 87.0ms | 13.77MB |
+| 225 | constrained-genericity-1 | ✓ | 4.0µs | 12.74MB |
+| 226 | constrained-genericity-2 | ✓ | 4.0µs | 12.41MB |
+| 227 | constrained-genericity-3 | ✓ | 5.0µs | 12.73MB |
+| 228 | constrained-genericity-4 | ✓ | 150.0µs | 12.96MB |
 | 229 | constrained-random-points-on-a-circle-1 |   |  |  |
 | 230 | constrained-random-points-on-a-circle-2 |   |  |  |
 | 231 | continued-fraction |   |  |  |


### PR DESCRIPTION
## Summary
- cast non-standard indices to `size_t` in the C++ transpiler
- benchmark and record Rosetta programs 210-228
- store benchmark artifacts for these programs

## Testing
- `MOCHI_ROSETTA_INDEX=220 MOCHI_BENCHMARK=1 go test ./transpiler/x/cpp -tags slow -run Rosetta -update-rosetta-cpp`
- `MOCHI_ROSETTA_INDEX=229 MOCHI_BENCHMARK=1 go test ./transpiler/x/cpp -tags slow -run Rosetta -update-rosetta-cpp` *(fails: no match for operator[] with boost::multiprecision::cpp_int)*


------
https://chatgpt.com/codex/tasks/task_e_688de8301c308320a073eb4c0210006c