### PR TITLE
pascal: add rosetta outputs for avl-tree and b-zier intersections

### DIFF
--- a/tests/rosetta/transpiler/Pascal/avl-tree.error
+++ b/tests/rosetta/transpiler/Pascal/avl-tree.error
@@ -1,0 +1,52 @@
+Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
+Copyright (c) 1993-2021 by Florian Klaempfl and others
+Target OS: Linux for x86-64
+Compiling /workspace/mochi/tests/rosetta/transpiler/Pascal/avl-tree.pas
+avl-tree.pas(74,31) Error: Illegal type conversion: "TFPGMap$2$crcA201DD2D" to "Variant"
+avl-tree.pas(80,31) Error: Illegal type conversion: "TFPGMap$2$crcA201DD2D" to "Variant"
+avl-tree.pas(86,31) Error: Illegal type conversion: "TFPGMap$2$crcA201DD2D" to "Variant"
+avl-tree.pas(104,31) Error: Illegal type conversion: "TFPGMap$2$crcA201DD2D" to "Variant"
+avl-tree.pas(110,31) Error: Illegal type conversion: "TFPGMap$2$crcA201DD2D" to "Variant"
+avl-tree.pas(116,31) Error: Illegal type conversion: "TFPGMap$2$crcA201DD2D" to "Variant"
+avl-tree.pas(122,31) Error: Illegal type conversion: "TFPGMap$2$crcA201DD2D" to "Variant"
+avl-tree.pas(128,31) Error: Illegal type conversion: "TFPGMap$2$crcA201DD2D" to "Variant"
+avl-tree.pas(134,31) Error: Illegal type conversion: "TFPGMap$2$crcA201DD2D" to "Variant"
+avl-tree.pas(140,31) Error: Illegal type conversion: "TFPGMap$2$crcA201DD2D" to "Variant"
+avl-tree.pas(146,31) Error: Illegal type conversion: "TFPGMap$2$crcA201DD2D" to "Variant"
+avl-tree.pas(154,40) Error: Ordinal expression expected
+avl-tree.pas(181,45) Error: Incompatible type for arg no. 1: Got "Variant", expected "TFPGMap<System.ShortString,System.Variant>"
+avl-tree.pas(182,32) Error: Incompatible type for arg no. 3: Got "TFPGMap<System.ShortString,System.Variant>", expected "Variant"
+avl-tree.pas(183,8) Error: Incompatible types: got "Variant" expected "TFPGMap<System.ShortString,System.Variant>"
+avl-tree.pas(189,48) Error: Incompatible type for arg no. 1: Got "Variant", expected "TFPGMap<System.ShortString,System.Variant>"
+avl-tree.pas(190,59) Error: Incompatible type for arg no. 1: Got "Variant", expected "TFPGMap<System.ShortString,System.Variant>"
+avl-tree.pas(191,21) Error: Incompatible type for arg no. 1: Got "Variant", expected "TFPGMap<System.ShortString,System.Variant>"
+avl-tree.pas(194,45) Error: Incompatible type for arg no. 1: Got "Variant", expected "TFPGMap<System.ShortString,System.Variant>"
+avl-tree.pas(195,32) Error: Incompatible type for arg no. 3: Got "TFPGMap<System.ShortString,System.Variant>", expected "Variant"
+avl-tree.pas(196,8) Error: Incompatible types: got "Variant" expected "TFPGMap<System.ShortString,System.Variant>"
+avl-tree.pas(203,22) Error: Incompatible types: got "Variant" expected "TFPGMap<System.ShortString,System.Variant>"
+avl-tree.pas(204,23) Error: Incompatible types: got "Variant" expected "TFPGMap<System.ShortString,System.Variant>"
+avl-tree.pas(224,22) Error: Incompatible types: got "Variant" expected "TFPGMap<System.ShortString,System.Variant>"
+avl-tree.pas(243,19) Error: Incompatible types: got "Variant" expected "TFPGMap<System.ShortString,System.Variant>"
+avl-tree.pas(248,16) Error: Incompatible types: got "TFPGMap<System.ShortString,System.Variant>" expected "LongInt"
+avl-tree.pas(249,48) Error: Illegal qualifier
+avl-tree.pas(250,16) Error: Illegal qualifier
+avl-tree.pas(274,22) Error: Incompatible types: got "Variant" expected "TFPGMap<System.ShortString,System.Variant>"
+avl-tree.pas(297,8) Error: Wrong number of parameters specified for call to "Map2"
+avl-tree.pas(143,10) Error: Found declaration: Map2(LongInt):TFPGMap$2<SYSTEM.ShortString,SYSTEM.Variant>;
+avl-tree.pas(299,19) Error: Incompatible types: got "Variant" expected "TFPGMap<System.ShortString,System.Variant>"
+avl-tree.pas(308,29) Error: Incompatible type for arg no. 1: Got "Variant", expected "TFPGMap<System.ShortString,System.Variant>"
+avl-tree.pas(309,39) Error: Incompatible type for arg no. 1: Got "Variant", expected "TFPGMap<System.ShortString,System.Variant>"
+avl-tree.pas(311,58) Error: Incompatible types: got "Constant String" expected "LongInt"
+avl-tree.pas(312,30) Error: Incompatible types: got "Constant String" expected "LongInt"
+avl-tree.pas(318,16) Error: Incompatible types: got "TFPGMap<System.ShortString,System.Variant>" expected "LongInt"
+avl-tree.pas(319,48) Error: Illegal qualifier
+avl-tree.pas(320,16) Error: Illegal qualifier
+avl-tree.pas(367,65) Error: Incompatible types: got "Constant String" expected "LongInt"
+avl-tree.pas(368,68) Error: Incompatible types: got "Constant String" expected "LongInt"
+avl-tree.pas(370,24) Error: Incompatible type for arg no. 1: Got "Variant", expected "TFPGMap<System.ShortString,System.Variant>"
+avl-tree.pas(371,24) Error: Incompatible type for arg no. 1: Got "Variant", expected "TFPGMap<System.ShortString,System.Variant>"
+avl-tree.pas(404,13) Error: Incompatible types: got "Variant" expected "TFPGMap<System.ShortString,System.Variant>"
+avl-tree.pas(406,16) Error: Incompatible types: got "TFPGMap<System.ShortString,System.Variant>" expected "Variant"
+avl-tree.pas(423) Fatal: There were 45 errors compiling module, stopping
+Fatal: Compilation aborted
+Error: /usr/bin/ppcx64 returned an error exitcode

--- a/tests/rosetta/transpiler/Pascal/avl-tree.pas
+++ b/tests/rosetta/transpiler/Pascal/avl-tree.pas
@@ -1,0 +1,422 @@
+{$mode objfpc}
+program Main;
+uses SysUtils, Variants, fgl;
+var _nowSeed: int64 = 0;
+var _nowSeeded: boolean = false;
+procedure init_now();
+var s: string; v: int64;
+begin
+  s := GetEnvironmentVariable('MOCHI_NOW_SEED');
+  if s <> '' then begin
+    Val(s, v);
+    _nowSeed := v;
+    _nowSeeded := true;
+  end;
+end;
+function _now(): integer;
+begin
+  if _nowSeeded then begin
+    _nowSeed := (_nowSeed * 1664525 + 1013904223) mod 2147483647;
+    _now := _nowSeed;
+  end else begin
+    _now := Integer(GetTickCount64()*1000);
+  end;
+end;
+function _bench_now(): int64;
+begin
+  _bench_now := GetTickCount64()*1000;
+end;
+function _mem(): int64;
+var h: TFPCHeapStatus;
+begin
+  h := GetFPCHeapStatus;
+  _mem := h.CurrHeapUsed;
+end;
+var
+  bench_start_0: integer;
+  bench_dur_0: integer;
+  bench_mem_0: int64;
+  bench_memdiff_0: int64;
+function Map14(removeR_node: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>; forward;
+function Map13(removeR_node: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>; forward;
+function Map12(removeR_node: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>; forward;
+function Map11(removeR_node: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>; forward;
+function Map10(removeR_node: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>; forward;
+function Map9(dir: integer; root: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>; forward;
+function Map8(dir: integer; root: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>; forward;
+function Map7(dir: integer; root: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>; forward;
+function Map6(insertR_dir: integer; insertR_node: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>; forward;
+function Map5(insertR_node: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>; forward;
+function Map4(insertR_node: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>; forward;
+function Map3(insertR_node: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>; forward;
+function Map2(data: integer): specialize TFPGMap<string, Variant>; forward;
+function Map1(data: integer): specialize TFPGMap<string, Variant>; forward;
+function Node(data: integer): specialize TFPGMap<string, Variant>; forward;
+function getLink(n: specialize TFPGMap<string, Variant>; dir: integer): Variant; forward;
+procedure setLink(n: specialize TFPGMap<string, Variant>; dir: integer; v: Variant); forward;
+function opp(dir: integer): integer; forward;
+function single(root: specialize TFPGMap<string, Variant>; dir: integer): specialize TFPGMap<string, Variant>; forward;
+function double(root: specialize TFPGMap<string, Variant>; dir: integer): specialize TFPGMap<string, Variant>; forward;
+procedure adjustBalance(root: specialize TFPGMap<string, Variant>; dir: integer; bal: integer); forward;
+function insertBalance(root: specialize TFPGMap<string, Variant>; dir: integer): specialize TFPGMap<string, Variant>; forward;
+function insertR(root: Variant; data: integer): specialize TFPGMap<string, Variant>; forward;
+function Insert(tree: Variant; data: integer): Variant; forward;
+function removeBalance(root: specialize TFPGMap<string, Variant>; dir: integer): specialize TFPGMap<string, Variant>; forward;
+function removeR(root: Variant; data: integer): specialize TFPGMap<string, Variant>; forward;
+function Remove(tree: Variant; data: integer): Variant; forward;
+function indentStr(n: integer): string; forward;
+procedure dumpNode(node: Variant; indent: integer; comma: boolean); forward;
+procedure dump(node: Variant; indent: integer); forward;
+procedure main(); forward;
+function Map14(removeR_node: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('node', Variant(removeR_node));
+  Result.AddOrSetData('done', Variant(false));
+end;
+function Map13(removeR_node: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('node', Variant(removeR_node));
+  Result.AddOrSetData('done', Variant(true));
+end;
+function Map12(removeR_node: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('node', Variant(removeR_node));
+  Result.AddOrSetData('done', Variant(true));
+end;
+function Map11(removeR_node: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('node', getLink(removeR_node, 0));
+  Result.AddOrSetData('done', Variant(false));
+end;
+function Map10(removeR_node: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('node', getLink(removeR_node, 1));
+  Result.AddOrSetData('done', Variant(false));
+end;
+function Map9(dir: integer; root: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('node', Variant(single(root, dir)));
+  Result.AddOrSetData('done', Variant(true));
+end;
+function Map8(dir: integer; root: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('node', Variant(double(root, dir)));
+  Result.AddOrSetData('done', Variant(false));
+end;
+function Map7(dir: integer; root: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('node', Variant(single(root, dir)));
+  Result.AddOrSetData('done', Variant(false));
+end;
+function Map6(insertR_dir: integer; insertR_node: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('node', Variant(insertBalance(insertR_node, insertR_dir)));
+  Result.AddOrSetData('done', Variant(true));
+end;
+function Map5(insertR_node: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('node', Variant(insertR_node));
+  Result.AddOrSetData('done', Variant(false));
+end;
+function Map4(insertR_node: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('node', Variant(insertR_node));
+  Result.AddOrSetData('done', Variant(true));
+end;
+function Map3(insertR_node: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('node', Variant(insertR_node));
+  Result.AddOrSetData('done', Variant(true));
+end;
+function Map2(data: integer): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('node', Variant(Node(data)));
+  Result.AddOrSetData('done', Variant(false));
+end;
+function Map1(data: integer): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('Data', Variant(data));
+  Result.AddOrSetData('Balance', Variant(0));
+  Result.AddOrSetData('Link', Variant([nil, nil]));
+end;
+function Node(data: integer): specialize TFPGMap<string, Variant>;
+begin
+  exit(Map1(data));
+end;
+function getLink(n: specialize TFPGMap<string, Variant>; dir: integer): Variant;
+begin
+  exit(n['Link'][dir]);
+end;
+procedure setLink(n: specialize TFPGMap<string, Variant>; dir: integer; v: Variant);
+var
+  setLink_links: array of Variant;
+begin
+  setLink_links := n['Link'];
+  setLink_links[dir] := v;
+  n.AddOrSetData('Link', Variant(setLink_links));
+end;
+function opp(dir: integer): integer;
+begin
+  exit(1 - dir);
+end;
+function single(root: specialize TFPGMap<string, Variant>; dir: integer): specialize TFPGMap<string, Variant>;
+var
+  single_tmp: Variant;
+begin
+  single_tmp := getLink(root, opp(dir));
+  setLink(root, opp(dir), getLink(single_tmp, dir));
+  setLink(single_tmp, dir, root);
+  exit(single_tmp);
+end;
+function double(root: specialize TFPGMap<string, Variant>; dir: integer): specialize TFPGMap<string, Variant>;
+var
+  double_tmp: Variant;
+begin
+  double_tmp := getLink(getLink(root, opp(dir)), dir);
+  setLink(getLink(root, opp(dir)), dir, getLink(double_tmp, opp(dir)));
+  setLink(double_tmp, opp(dir), getLink(root, opp(dir)));
+  setLink(root, opp(dir), double_tmp);
+  double_tmp := getLink(root, opp(dir));
+  setLink(root, opp(dir), getLink(double_tmp, dir));
+  setLink(double_tmp, dir, root);
+  exit(double_tmp);
+end;
+procedure adjustBalance(root: specialize TFPGMap<string, Variant>; dir: integer; bal: integer);
+var
+  adjustBalance_n: specialize TFPGMap<string, Variant>;
+  adjustBalance_nn: specialize TFPGMap<string, Variant>;
+begin
+  adjustBalance_n := getLink(root, dir);
+  adjustBalance_nn := getLink(adjustBalance_n, opp(dir));
+  if adjustBalance_nn['Balance'] = 0 then begin
+  root.AddOrSetData('Balance', Variant(0));
+  adjustBalance_n.AddOrSetData('Balance', Variant(0));
+end else begin
+  if adjustBalance_nn['Balance'] = bal then begin
+  root.AddOrSetData('Balance', Variant(-bal));
+  adjustBalance_n.AddOrSetData('Balance', Variant(0));
+end else begin
+  root.AddOrSetData('Balance', Variant(0));
+  adjustBalance_n.AddOrSetData('Balance', Variant(bal));
+end;
+end;
+  adjustBalance_nn.AddOrSetData('Balance', Variant(0));
+end;
+function insertBalance(root: specialize TFPGMap<string, Variant>; dir: integer): specialize TFPGMap<string, Variant>;
+var
+  insertBalance_n: specialize TFPGMap<string, Variant>;
+  insertBalance_bal: integer;
+begin
+  insertBalance_n := getLink(root, dir);
+  insertBalance_bal := (2 * dir) - 1;
+  if insertBalance_n['Balance'] = insertBalance_bal then begin
+  root.AddOrSetData('Balance', Variant(0));
+  insertBalance_n.AddOrSetData('Balance', Variant(0));
+  exit(single(root, opp(dir)));
+end;
+  adjustBalance(root, dir, insertBalance_bal);
+  exit(double(root, opp(dir)));
+end;
+function insertR(root: Variant; data: integer): specialize TFPGMap<string, Variant>;
+var
+  insertR_node: specialize TFPGMap<string, Variant>;
+  insertR_dir: integer;
+  insertR_r: integer;
+begin
+  if root = nil then begin
+  exit(Map2(data));
+end;
+  insertR_node := root;
+  insertR_dir := 0;
+  if Trunc(insertR_node['Data']) < data then begin
+  insertR_dir := 1;
+end;
+  insertR_r := insertR(getLink(insertR_node, insertR_dir), data);
+  setLink(insertR_node, insertR_dir, insertR_r['node']);
+  if insertR_r['done'] then begin
+  exit(Map3(insertR_node));
+end;
+  insertR_node.AddOrSetData('Balance', Variant(Trunc(insertR_node['Balance']) + ((2 * insertR_dir) - 1)));
+  if insertR_node['Balance'] = 0 then begin
+  exit(Map4(insertR_node));
+end;
+  if (insertR_node['Balance'] = 1) or (insertR_node['Balance'] = -1) then begin
+  exit(Map5(insertR_node));
+end;
+  exit(Map6(insertR_dir, insertR_node));
+end;
+function Insert(tree: Variant; data: integer): Variant;
+var
+  Insert_r: specialize TFPGMap<string, Variant>;
+begin
+  Insert_r := insertR(tree, data);
+  exit(Insert_r['node']);
+end;
+function removeBalance(root: specialize TFPGMap<string, Variant>; dir: integer): specialize TFPGMap<string, Variant>;
+var
+  removeBalance_n: specialize TFPGMap<string, Variant>;
+  removeBalance_bal: integer;
+begin
+  removeBalance_n := getLink(root, opp(dir));
+  removeBalance_bal := (2 * dir) - 1;
+  if removeBalance_n['Balance'] = -removeBalance_bal then begin
+  root.AddOrSetData('Balance', Variant(0));
+  removeBalance_n.AddOrSetData('Balance', Variant(0));
+  exit(Map7(dir, root));
+end;
+  if removeBalance_n['Balance'] = removeBalance_bal then begin
+  adjustBalance(root, opp(dir), -removeBalance_bal);
+  exit(Map8(dir, root));
+end;
+  root.AddOrSetData('Balance', Variant(-removeBalance_bal));
+  removeBalance_n.AddOrSetData('Balance', Variant(removeBalance_bal));
+  exit(Map9(dir, root));
+end;
+function removeR(root: Variant; data: integer): specialize TFPGMap<string, Variant>;
+var
+  removeR_node: specialize TFPGMap<string, Variant>;
+  removeR_heir: Variant;
+  removeR_dir: integer;
+  removeR_r: integer;
+begin
+  if root = nil then begin
+  exit(Map2());
+end;
+  removeR_node := root;
+  if Trunc(removeR_node['Data']) = data then begin
+  if getLink(removeR_node, 0) = nil then begin
+  exit(Map10(removeR_node));
+end;
+  if getLink(removeR_node, 1) = nil then begin
+  exit(Map11(removeR_node));
+end;
+  removeR_heir := getLink(removeR_node, 0);
+  while getLink(removeR_heir, 1) <> nil do begin
+  removeR_heir := getLink(removeR_heir, 1);
+end;
+  removeR_node.AddOrSetData('Data', Variant(removeR_heir['Data']));
+  data := Trunc(removeR_heir['Data']);
+end;
+  removeR_dir := 0;
+  if Trunc(removeR_node['Data']) < data then begin
+  removeR_dir := 1;
+end;
+  removeR_r := removeR(getLink(removeR_node, removeR_dir), data);
+  setLink(removeR_node, removeR_dir, removeR_r['node']);
+  if removeR_r['done'] then begin
+  exit(Map12(removeR_node));
+end;
+  removeR_node.AddOrSetData('Balance', Variant((Trunc(removeR_node['Balance']) + 1) - (2 * removeR_dir)));
+  if (removeR_node['Balance'] = 1) or (removeR_node['Balance'] = -1) then begin
+  exit(Map13(removeR_node));
+end;
+  if removeR_node['Balance'] = 0 then begin
+  exit(Map14(removeR_node));
+end;
+  exit(removeBalance(removeR_node, removeR_dir));
+end;
+function Remove(tree: Variant; data: integer): Variant;
+var
+  Remove_r: specialize TFPGMap<string, Variant>;
+begin
+  Remove_r := removeR(tree, data);
+  exit(Remove_r['node']);
+end;
+function indentStr(n: integer): string;
+var
+  indentStr_s: string;
+  indentStr_i: integer;
+begin
+  indentStr_s := '';
+  indentStr_i := 0;
+  while indentStr_i < n do begin
+  indentStr_s := indentStr_s + ' ';
+  indentStr_i := indentStr_i + 1;
+end;
+  exit(indentStr_s);
+end;
+procedure dumpNode(node: Variant; indent: integer; comma: boolean);
+var
+  dumpNode_sp: string;
+  dumpNode_line: string;
+  dumpNode_end: string;
+begin
+  dumpNode_sp := indentStr(indent);
+  if node = nil then begin
+  dumpNode_line := dumpNode_sp + 'null';
+  if comma then begin
+  dumpNode_line := dumpNode_line + ',';
+end;
+  writeln(dumpNode_line);
+end else begin
+  writeln(dumpNode_sp + '{');
+  writeln(((indentStr(indent + 3) + '"Data": ') + IntToStr(node['Data'])) + ',');
+  writeln(((indentStr(indent + 3) + '"Balance": ') + IntToStr(node['Balance'])) + ',');
+  writeln(indentStr(indent + 3) + '"Link": [');
+  dumpNode(getLink(node, 0), indent + 6, true);
+  dumpNode(getLink(node, 1), indent + 6, false);
+  writeln(indentStr(indent + 3) + ']');
+  dumpNode_end := dumpNode_sp + '}';
+  if comma then begin
+  dumpNode_end := dumpNode_end + ',';
+end;
+  writeln(dumpNode_end);
+end;
+end;
+procedure dump(node: Variant; indent: integer);
+begin
+  dumpNode(node, indent, false);
+end;
+procedure main();
+var
+  main_tree: Variant;
+  main_t: specialize TFPGMap<string, Variant>;
+begin
+  main_tree := nil;
+  writeln('Empty tree:');
+  dump(main_tree, 0);
+  writeln('');
+  writeln('Insert test:');
+  main_tree := Insert(main_tree, 3);
+  main_tree := Insert(main_tree, 1);
+  main_tree := Insert(main_tree, 4);
+  main_tree := Insert(main_tree, 1);
+  main_tree := Insert(main_tree, 5);
+  dump(main_tree, 0);
+  writeln('');
+  writeln('Remove test:');
+  main_tree := Remove(main_tree, 3);
+  main_tree := Remove(main_tree, 1);
+  main_t := main_tree;
+  main_t.AddOrSetData('Balance', Variant(0));
+  main_tree := main_t;
+  dump(main_tree, 0);
+end;
+begin
+  init_now();
+  bench_mem_0 := _mem();
+  bench_start_0 := _bench_now();
+  main();
+  Sleep(1);
+  bench_memdiff_0 := _mem() - bench_mem_0;
+  bench_dur_0 := (_bench_now() - bench_start_0) div 1000;
+  writeln('{');
+  writeln(('  "duration_us": ' + IntToStr(bench_dur_0)) + ',');
+  writeln(('  "memory_bytes": ' + IntToStr(bench_memdiff_0)) + ',');
+  writeln(('  "name": "' + 'main') + '"');
+  writeln('}');
+end.

--- a/tests/rosetta/transpiler/Pascal/b-zier-curves-intersections.error
+++ b/tests/rosetta/transpiler/Pascal/b-zier-curves-intersections.error
@@ -1,0 +1,44 @@
+Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
+Copyright (c) 1993-2021 by Florian Klaempfl and others
+Target OS: Linux for x86-64
+Compiling /workspace/mochi/tests/rosetta/transpiler/Pascal/b-zier-curves-intersections.pas
+b-zier-curves-intersections.pas(4,28) Error: Identifier not found "Point"
+b-zier-curves-intersections.pas(4,33) Error: Error in type definition
+b-zier-curves-intersections.pas(5,32) Error: Identifier not found "QuadCurve"
+b-zier-curves-intersections.pas(5,41) Error: Error in type definition
+b-zier-curves-intersections.pas(6,33) Error: Identifier not found "QuadSpline"
+b-zier-curves-intersections.pas(6,43) Error: Error in type definition
+b-zier-curves-intersections.pas(80,28) Error: Illegal type conversion: "QuadCurve" to "Variant"
+b-zier-curves-intersections.pas(81,28) Error: Illegal type conversion: "QuadCurve" to "Variant"
+b-zier-curves-intersections.pas(86,28) Error: Illegal type conversion: "QuadCurve" to "Variant"
+b-zier-curves-intersections.pas(87,28) Error: Illegal type conversion: "QuadCurve" to "Variant"
+b-zier-curves-intersections.pas(92,28) Error: Illegal type conversion: "QuadCurve" to "Variant"
+b-zier-curves-intersections.pas(93,28) Error: Illegal type conversion: "QuadCurve" to "Variant"
+b-zier-curves-intersections.pas(98,28) Error: Illegal type conversion: "QuadCurve" to "Variant"
+b-zier-curves-intersections.pas(99,28) Error: Illegal type conversion: "QuadCurve" to "Variant"
+b-zier-curves-intersections.pas(104,28) Error: Illegal type conversion: "QuadCurve" to "Variant"
+b-zier-curves-intersections.pas(105,28) Error: Illegal type conversion: "QuadCurve" to "Variant"
+b-zier-curves-intersections.pas(112,36) Error: Illegal type conversion: "Point" to "Variant"
+b-zier-curves-intersections.pas(190,8) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of QuadSpline" expected "QuadSplineArray"
+b-zier-curves-intersections.pas(201,91) Error: Incompatible type for arg no. 2: Got "<erroneous type>", expected "QuadSpline"
+b-zier-curves-intersections.pas(202,91) Error: Incompatible type for arg no. 2: Got "<erroneous type>", expected "QuadSpline"
+b-zier-curves-intersections.pas(203,8) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of QuadCurve" expected "QuadCurveArray"
+b-zier-curves-intersections.pas(290,30) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA201DD2D" expected "{Dynamic} Array Of TFPGMap$2$crcF6A9413E"
+b-zier-curves-intersections.pas(290,31) Error: Incompatible types: got "TFPGMap<System.ShortString,System.Variant>" expected "TFPGMap<System.ShortString,Main.QuadCurve>"
+b-zier-curves-intersections.pas(315,72) Error: Incompatible type for arg no. 2: Got "LongInt", expected "Point"
+b-zier-curves-intersections.pas(316,80) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of LongInt" expected "{Dynamic} Array Of Point"
+b-zier-curves-intersections.pas(316,59) Error: Incompatible types: got "LongInt" expected "Point"
+b-zier-curves-intersections.pas(326,106) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA201DD2D" expected "{Dynamic} Array Of TFPGMap$2$crcF6A9413E"
+b-zier-curves-intersections.pas(326,63) Error: Incompatible types: got "TFPGMap<System.ShortString,System.Variant>" expected "TFPGMap<System.ShortString,Main.QuadCurve>"
+b-zier-curves-intersections.pas(327,106) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA201DD2D" expected "{Dynamic} Array Of TFPGMap$2$crcF6A9413E"
+b-zier-curves-intersections.pas(327,63) Error: Incompatible types: got "TFPGMap<System.ShortString,System.Variant>" expected "TFPGMap<System.ShortString,Main.QuadCurve>"
+b-zier-curves-intersections.pas(328,106) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA201DD2D" expected "{Dynamic} Array Of TFPGMap$2$crcF6A9413E"
+b-zier-curves-intersections.pas(328,63) Error: Incompatible types: got "TFPGMap<System.ShortString,System.Variant>" expected "TFPGMap<System.ShortString,Main.QuadCurve>"
+b-zier-curves-intersections.pas(329,106) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA201DD2D" expected "{Dynamic} Array Of TFPGMap$2$crcF6A9413E"
+b-zier-curves-intersections.pas(329,63) Error: Incompatible types: got "TFPGMap<System.ShortString,System.Variant>" expected "TFPGMap<System.ShortString,Main.QuadCurve>"
+b-zier-curves-intersections.pas(319,6) Error: Incompatible types: got "LongInt" expected "Boolean"
+b-zier-curves-intersections.pas(333,8) Error: Incompatible types: got "{Dynamic} Array Of Point" expected "PointArray"
+b-zier-curves-intersections.pas(345,28) Error: Identifier not found "c0"
+b-zier-curves-intersections.pas(345,30) Fatal: Syntax error, ")" expected but ":" found
+Fatal: Compilation aborted
+Error: /usr/bin/ppcx64 returned an error exitcode

--- a/tests/rosetta/transpiler/Pascal/b-zier-curves-intersections.pas
+++ b/tests/rosetta/transpiler/Pascal/b-zier-curves-intersections.pas
@@ -1,0 +1,370 @@
+{$mode objfpc}
+program Main;
+uses SysUtils, fgl;
+type PointArray = array of Point;
+type QuadCurveArray = array of QuadCurve;
+type QuadSplineArray = array of QuadSpline;
+var _nowSeed: int64 = 0;
+var _nowSeeded: boolean = false;
+procedure init_now();
+var s: string; v: int64;
+begin
+  s := GetEnvironmentVariable('MOCHI_NOW_SEED');
+  if s <> '' then begin
+    Val(s, v);
+    _nowSeed := v;
+    _nowSeeded := true;
+  end;
+end;
+function _now(): integer;
+begin
+  if _nowSeeded then begin
+    _nowSeed := (_nowSeed * 1664525 + 1013904223) mod 2147483647;
+    _now := _nowSeed;
+  end else begin
+    _now := Integer(GetTickCount64()*1000);
+  end;
+end;
+function _bench_now(): int64;
+begin
+  _bench_now := GetTickCount64()*1000;
+end;
+function _mem(): int64;
+var h: TFPCHeapStatus;
+begin
+  h := GetFPCHeapStatus;
+  _mem := h.CurrHeapUsed;
+end;
+type Point = record
+  x: real;
+  y: real;
+end;
+type QuadSpline = record
+  c0: real;
+  c1: real;
+  c2: real;
+end;
+type QuadCurve = record
+  x: QuadSpline;
+  y: QuadSpline;
+end;
+var
+  bench_start_0: integer;
+  bench_dur_0: integer;
+  bench_mem_0: int64;
+  bench_memdiff_0: int64;
+function Map6(findIntersects_p1: QuadCurve; findIntersects_q1: QuadCurve): specialize TFPGMap<string, Variant>; forward;
+function Map5(findIntersects_p1: QuadCurve; findIntersects_q0: QuadCurve): specialize TFPGMap<string, Variant>; forward;
+function Map4(findIntersects_p0: QuadCurve; findIntersects_q1: QuadCurve): specialize TFPGMap<string, Variant>; forward;
+function Map3(findIntersects_p0: QuadCurve; findIntersects_q0: QuadCurve): specialize TFPGMap<string, Variant>; forward;
+function Map2(p: QuadCurve; q: QuadCurve): specialize TFPGMap<string, Variant>; forward;
+function Map1(testIntersect_accept: boolean; testIntersect_exclude: boolean; testIntersect_inter: Point): specialize TFPGMap<string, Variant>; forward;
+function makeQuadCurve(x: QuadSpline; y: QuadSpline): QuadCurve; forward;
+function makeQuadSpline(c0: real; c1: real; c2: real): QuadSpline; forward;
+function makePoint(x: real; y: real): Point; forward;
+function absf(x: real): real; forward;
+function maxf(a: real; b: real): real; forward;
+function minf(a: real; b: real): real; forward;
+function max3(a: real; b: real; c: real): real; forward;
+function min3(a: real; b: real; c: real): real; forward;
+function subdivideQuadSpline(q: QuadSpline; t: real): QuadSplineArray; forward;
+function subdivideQuadCurve(q: QuadCurve; t: real): QuadCurveArray; forward;
+function rectsOverlap(xa0: real; ya0: real; xa1: real; ya1: real; xb0: real; yb0: real; xb1: real; yb1: real): boolean; forward;
+function testIntersect(p: QuadCurve; q: QuadCurve; tol: real): specialize TFPGMap<string, Variant>; forward;
+function seemsToBeDuplicate(pts: PointArray; xy: Point; spacing: real): boolean; forward;
+function findIntersects(p: QuadCurve; q: QuadCurve; tol: real; spacing: real): PointArray; forward;
+procedure main(); forward;
+function Map6(findIntersects_p1: QuadCurve; findIntersects_q1: QuadCurve): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('p', Variant(findIntersects_p1));
+  Result.AddOrSetData('q', Variant(findIntersects_q1));
+end;
+function Map5(findIntersects_p1: QuadCurve; findIntersects_q0: QuadCurve): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('p', Variant(findIntersects_p1));
+  Result.AddOrSetData('q', Variant(findIntersects_q0));
+end;
+function Map4(findIntersects_p0: QuadCurve; findIntersects_q1: QuadCurve): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('p', Variant(findIntersects_p0));
+  Result.AddOrSetData('q', Variant(findIntersects_q1));
+end;
+function Map3(findIntersects_p0: QuadCurve; findIntersects_q0: QuadCurve): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('p', Variant(findIntersects_p0));
+  Result.AddOrSetData('q', Variant(findIntersects_q0));
+end;
+function Map2(p: QuadCurve; q: QuadCurve): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('p', Variant(p));
+  Result.AddOrSetData('q', Variant(q));
+end;
+function Map1(testIntersect_accept: boolean; testIntersect_exclude: boolean; testIntersect_inter: Point): specialize TFPGMap<string, Variant>;
+begin
+  Result := specialize TFPGMap<string, Variant>.Create();
+  Result.AddOrSetData('exclude', Variant(testIntersect_exclude));
+  Result.AddOrSetData('accept', Variant(testIntersect_accept));
+  Result.AddOrSetData('intersect', Variant(testIntersect_inter));
+end;
+function makeQuadCurve(x: QuadSpline; y: QuadSpline): QuadCurve;
+begin
+  Result.x := x;
+  Result.y := y;
+end;
+function makeQuadSpline(c0: real; c1: real; c2: real): QuadSpline;
+begin
+  Result.c0 := c0;
+  Result.c1 := c1;
+  Result.c2 := c2;
+end;
+function makePoint(x: real; y: real): Point;
+begin
+  Result.x := x;
+  Result.y := y;
+end;
+function absf(x: real): real;
+begin
+  if x < 0 then begin
+  exit(-x);
+end;
+  exit(x);
+end;
+function maxf(a: real; b: real): real;
+begin
+  if a > b then begin
+  exit(a);
+end;
+  exit(b);
+end;
+function minf(a: real; b: real): real;
+begin
+  if a < b then begin
+  exit(a);
+end;
+  exit(b);
+end;
+function max3(a: real; b: real; c: real): real;
+var
+  max3_m: real;
+begin
+  max3_m := a;
+  if b > max3_m then begin
+  max3_m := b;
+end;
+  if c > max3_m then begin
+  max3_m := c;
+end;
+  exit(max3_m);
+end;
+function min3(a: real; b: real; c: real): real;
+var
+  min3_m: real;
+begin
+  min3_m := a;
+  if b < min3_m then begin
+  min3_m := b;
+end;
+  if c < min3_m then begin
+  min3_m := c;
+end;
+  exit(min3_m);
+end;
+function subdivideQuadSpline(q: QuadSpline; t: real): QuadSplineArray;
+var
+  subdivideQuadSpline_s: real;
+  subdivideQuadSpline_u: QuadSpline;
+  subdivideQuadSpline_v: QuadSpline;
+begin
+  subdivideQuadSpline_s := 1 - t;
+  subdivideQuadSpline_u := makeQuadSpline(q.c0, 0, 0);
+  subdivideQuadSpline_v := makeQuadSpline(0, 0, q.c2);
+  subdivideQuadSpline_u.c1 := (subdivideQuadSpline_s * q.c0) + (t * q.c1);
+  subdivideQuadSpline_v.c1 := (subdivideQuadSpline_s * q.c1) + (t * q.c2);
+  subdivideQuadSpline_u.c2 := (subdivideQuadSpline_s * subdivideQuadSpline_u.c1) + (t * subdivideQuadSpline_v.c1);
+  subdivideQuadSpline_v.c0 := subdivideQuadSpline_u.c2;
+  exit([subdivideQuadSpline_u, subdivideQuadSpline_v]);
+end;
+function subdivideQuadCurve(q: QuadCurve; t: real): QuadCurveArray;
+var
+  subdivideQuadCurve_xs: QuadSplineArray;
+  subdivideQuadCurve_ys: QuadSplineArray;
+  subdivideQuadCurve_u: QuadCurve;
+  subdivideQuadCurve_v: QuadCurve;
+begin
+  subdivideQuadCurve_xs := subdivideQuadSpline(q.x, t);
+  subdivideQuadCurve_ys := subdivideQuadSpline(q.y, t);
+  subdivideQuadCurve_u := makeQuadCurve(subdivideQuadCurve_xs[0], subdivideQuadCurve_ys[0]);
+  subdivideQuadCurve_v := makeQuadCurve(subdivideQuadCurve_xs[1], subdivideQuadCurve_ys[1]);
+  exit([subdivideQuadCurve_u, subdivideQuadCurve_v]);
+end;
+function rectsOverlap(xa0: real; ya0: real; xa1: real; ya1: real; xb0: real; yb0: real; xb1: real; yb1: real): boolean;
+begin
+  exit((((xb0 <= xa1) and (xa0 <= xb1)) and (yb0 <= ya1)) and (ya0 <= yb1));
+end;
+function testIntersect(p: QuadCurve; q: QuadCurve; tol: real): specialize TFPGMap<string, Variant>;
+var
+  testIntersect_pxmin: real;
+  testIntersect_pymin: real;
+  testIntersect_pxmax: real;
+  testIntersect_pymax: real;
+  testIntersect_qxmin: real;
+  testIntersect_qymin: real;
+  testIntersect_qxmax: real;
+  testIntersect_qymax: real;
+  testIntersect_exclude: boolean;
+  testIntersect_accept: boolean;
+  testIntersect_inter: Point;
+  testIntersect_xmin: real;
+  testIntersect_xmax: real;
+  testIntersect_ymin: real;
+  testIntersect_ymax: real;
+begin
+  testIntersect_pxmin := min3(p.x.c0, p.x.c1, p.x.c2);
+  testIntersect_pymin := min3(p.y.c0, p.y.c1, p.y.c2);
+  testIntersect_pxmax := max3(p.x.c0, p.x.c1, p.x.c2);
+  testIntersect_pymax := max3(p.y.c0, p.y.c1, p.y.c2);
+  testIntersect_qxmin := min3(q.x.c0, q.x.c1, q.x.c2);
+  testIntersect_qymin := min3(q.y.c0, q.y.c1, q.y.c2);
+  testIntersect_qxmax := max3(q.x.c0, q.x.c1, q.x.c2);
+  testIntersect_qymax := max3(q.y.c0, q.y.c1, q.y.c2);
+  testIntersect_exclude := true;
+  testIntersect_accept := false;
+  testIntersect_inter := makePoint(0, 0);
+  if rectsOverlap(testIntersect_pxmin, testIntersect_pymin, testIntersect_pxmax, testIntersect_pymax, testIntersect_qxmin, testIntersect_qymin, testIntersect_qxmax, testIntersect_qymax) then begin
+  testIntersect_exclude := false;
+  testIntersect_xmin := maxf(testIntersect_pxmin, testIntersect_qxmin);
+  testIntersect_xmax := minf(testIntersect_pxmax, testIntersect_qxmax);
+  if (testIntersect_xmax - testIntersect_xmin) <= tol then begin
+  testIntersect_ymin := maxf(testIntersect_pymin, testIntersect_qymin);
+  testIntersect_ymax := minf(testIntersect_pymax, testIntersect_qymax);
+  if (testIntersect_ymax - testIntersect_ymin) <= tol then begin
+  testIntersect_accept := true;
+  testIntersect_inter.x := 0.5 * (testIntersect_xmin + testIntersect_xmax);
+  testIntersect_inter.y := 0.5 * (testIntersect_ymin + testIntersect_ymax);
+end;
+end;
+end;
+  exit(Map1(testIntersect_accept, testIntersect_exclude, testIntersect_inter));
+end;
+function seemsToBeDuplicate(pts: PointArray; xy: Point; spacing: real): boolean;
+var
+  seemsToBeDuplicate_i: integer;
+  seemsToBeDuplicate_pt: Point;
+begin
+  seemsToBeDuplicate_i := 0;
+  while seemsToBeDuplicate_i < Length(pts) do begin
+  seemsToBeDuplicate_pt := pts[seemsToBeDuplicate_i];
+  if (absf(seemsToBeDuplicate_pt.x - xy.x) < spacing) and (absf(seemsToBeDuplicate_pt.y - xy.y) < spacing) then begin
+  exit(true);
+end;
+  seemsToBeDuplicate_i := seemsToBeDuplicate_i + 1;
+end;
+  exit(false);
+end;
+function findIntersects(p: QuadCurve; q: QuadCurve; tol: real; spacing: real): PointArray;
+var
+  findIntersects_inters: array of Point;
+  findIntersects_workload: array of specialize TFPGMap<string, QuadCurve>;
+  findIntersects_idx: integer;
+  findIntersects_work: specialize TFPGMap<string, QuadCurve>;
+  findIntersects_res: specialize TFPGMap<string, Variant>;
+  findIntersects_excl: integer;
+  findIntersects_excl_idx: integer;
+  findIntersects_acc: integer;
+  findIntersects_acc_idx: integer;
+  findIntersects_inter: integer;
+  findIntersects_inter_idx: integer;
+  findIntersects_ps: QuadCurveArray;
+  findIntersects_qs: QuadCurveArray;
+  findIntersects_p0: QuadCurve;
+  findIntersects_p1: QuadCurve;
+  findIntersects_q0: QuadCurve;
+  findIntersects_q1: QuadCurve;
+begin
+  findIntersects_inters := [];
+  findIntersects_workload := [Map2(p, q)];
+  while Length(findIntersects_workload) > 0 do begin
+  findIntersects_idx := Length(findIntersects_workload) - 1;
+  findIntersects_work := findIntersects_workload[findIntersects_idx];
+  findIntersects_workload := copy(findIntersects_workload, 0, findIntersects_idx);
+  findIntersects_res := testIntersect(findIntersects_work['p'], findIntersects_work['q'], tol);
+  findIntersects_excl_idx := findIntersects_res.IndexOf('exclude');
+  if findIntersects_excl_idx <> -1 then begin
+  findIntersects_excl := findIntersects_res.Data[findIntersects_excl_idx];
+end else begin
+  findIntersects_excl := 0;
+end;
+  findIntersects_acc_idx := findIntersects_res.IndexOf('accept');
+  if findIntersects_acc_idx <> -1 then begin
+  findIntersects_acc := findIntersects_res.Data[findIntersects_acc_idx];
+end else begin
+  findIntersects_acc := 0;
+end;
+  findIntersects_inter_idx := findIntersects_res.IndexOf('intersect');
+  if findIntersects_inter_idx <> -1 then begin
+  findIntersects_inter := findIntersects_res.Data[findIntersects_inter_idx];
+end else begin
+  findIntersects_inter := 0;
+end;
+  if findIntersects_acc then begin
+  if not seemsToBeDuplicate(findIntersects_inters, findIntersects_inter, spacing) then begin
+  findIntersects_inters := concat(findIntersects_inters, [findIntersects_inter]);
+end;
+end else begin
+  if not findIntersects_excl then begin
+  findIntersects_ps := subdivideQuadCurve(findIntersects_work['p'], 0.5);
+  findIntersects_qs := subdivideQuadCurve(findIntersects_work['q'], 0.5);
+  findIntersects_p0 := findIntersects_ps[0];
+  findIntersects_p1 := findIntersects_ps[1];
+  findIntersects_q0 := findIntersects_qs[0];
+  findIntersects_q1 := findIntersects_qs[1];
+  findIntersects_workload := concat(findIntersects_workload, [Map3(findIntersects_p0, findIntersects_q0)]);
+  findIntersects_workload := concat(findIntersects_workload, [Map4(findIntersects_p0, findIntersects_q1)]);
+  findIntersects_workload := concat(findIntersects_workload, [Map5(findIntersects_p1, findIntersects_q0)]);
+  findIntersects_workload := concat(findIntersects_workload, [Map6(findIntersects_p1, findIntersects_q1)]);
+end;
+end;
+end;
+  exit(findIntersects_inters);
+end;
+procedure main();
+var
+  main_p: QuadCurve;
+  main_q: QuadCurve;
+  main_tol: real;
+  main_spacing: real;
+  main_inters: PointArray;
+  main_i: integer;
+  main_pt: Point;
+begin
+  main_p := makeQuadCurve((c0: -1; c1: 0; c2: 1), (c0: 0; c1: 10; c2: 0));
+  main_q := makeQuadCurve((c0: 2; c1: -8; c2: 2), (c0: 1; c1: 2; c2: 3));
+  main_tol := 1e-07;
+  main_spacing := main_tol * 10;
+  main_inters := findIntersects(main_p, main_q, main_tol, main_spacing);
+  main_i := 0;
+  while main_i < Length(main_inters) do begin
+  main_pt := main_inters[main_i];
+  writeln(((('(' + FloatToStr(main_pt.x)) + ', ') + FloatToStr(main_pt.y)) + ')');
+  main_i := main_i + 1;
+end;
+end;
+begin
+  init_now();
+  bench_mem_0 := _mem();
+  bench_start_0 := _bench_now();
+  main();
+  Sleep(1);
+  bench_memdiff_0 := _mem() - bench_mem_0;
+  bench_dur_0 := (_bench_now() - bench_start_0) div 1000;
+  writeln('{');
+  writeln(('  "duration_us": ' + IntToStr(bench_dur_0)) + ',');
+  writeln(('  "memory_bytes": ' + IntToStr(bench_memdiff_0)) + ',');
+  writeln(('  "name": "' + 'main') + '"');
+  writeln('}');
+end.

--- a/transpiler/x/pas/ROSETTA.md
+++ b/transpiler/x/pas/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated Pascal code for Rosetta tasks lives under `tests/rosetta/transpiler/Pascal`.
 
-## Rosetta Checklist (78/491) - updated 2025-08-02 09:46 UTC
+## Rosetta Checklist (78/491) - updated 2025-08-02 10:39 UTC
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 571.223ms | 128 B |


### PR DESCRIPTION
## Summary
- add Pascal transpilation outputs for `avl-tree` and `b-zier-curves-intersections`
- refresh Rosetta progress table

## Testing
- `ROSETTA_INDEX=87 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/pas -run Rosetta -v -update-rosetta-pas`
- `ROSETTA_INDEX=94 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/pas -run Rosetta -v -update-rosetta-pas` *(fails: illegal type conversion)*
- `ROSETTA_INDEX=95 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/pas -run Rosetta -v -update-rosetta-pas` *(fails: missing types & conversions)*

------
https://chatgpt.com/codex/tasks/task_e_688de9a0fe308320a035c3ce55cd8054