### PR TITLE
docs(scala): update Rosetta checklist

### DIFF
--- a/transpiler/x/scala/ROSETTA.md
+++ b/transpiler/x/scala/ROSETTA.md
@@ -3,7 +3,7 @@
 Generated Scala code for Rosetta tasks in `tests/rosetta/x/Mochi`. Each program has a `.scala` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
 ## Golden Test Checklist (421/491)
-_Last updated: 2025-08-02 17:07 +0700_
+_Last updated: 2025-08-02 17:39 +0700_
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|


### PR DESCRIPTION
## Summary
- document progress for Scala transpiler Rosetta tasks, now including index 208 compiler VM interpreter

## Testing
- `MOCHI_ROSETTA_INDEX=208 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/scala -run TestScalaTranspiler_Rosetta_Golden -count=1`
- `MOCHI_ROSETTA_INDEX=208 go test -tags slow ./transpiler/x/scala -run TestScalaTranspiler_Rosetta_Golden -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688dea2e82a4832098570ad8d3aa82c0