### PR TITLE
chore(fs): update rosetta output for index 356

### DIFF
--- a/tests/rosetta/transpiler/FS/equal-prime-and-composite-sums.bench
+++ b/tests/rosetta/transpiler/FS/equal-prime-and-composite-sums.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 182638,
-  "memory_bytes": 277344,
+  "duration_us": 110860,
+  "memory_bytes": 269304,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/FS/equal-prime-and-composite-sums.fs
+++ b/tests/rosetta/transpiler/FS/equal-prime-and-composite-sums.fs
@@ -1,4 +1,4 @@
-// Generated 2025-08-02 17:52 +0700
+// Generated 2025-08-02 20:24 +0700
 
 exception Return
 let mutable __ret = ()

--- a/transpiler/x/fs/ROSETTA.md
+++ b/transpiler/x/fs/ROSETTA.md
@@ -360,7 +360,7 @@ This file is auto-generated from rosetta tests.
 | 353 | enumerations-4 | ✓ | 16µs | 15.5 KB |
 | 354 | environment-variables-1 | ✓ | 249µs | 50.4 KB |
 | 355 | environment-variables-2 | ✓ | 297µs | 63.2 KB |
-| 356 | equal-prime-and-composite-sums | ✓ | 182.638ms | 270.8 KB |
+| 356 | equal-prime-and-composite-sums | ✓ | 110.86ms | 263.0 KB |
 | 357 | equilibrium-index | ✓ | 10.144ms | 116.6 KB |
 | 358 | erd-s-nicolas-numbers |   |  |  |
 | 359 | erd-s-selfridge-categorization-of-primes |   |  |  |
@@ -497,4 +497,4 @@ This file is auto-generated from rosetta tests.
 | 490 | window-management | ✓ | 371µs | 45.5 KB |
 | 491 | zumkeller-numbers | ✓ | 44.206ms | 86.9 KB |
 
-Last updated: 2025-08-02 17:52 +0700
+Last updated: 2025-08-02 20:24 +0700


### PR DESCRIPTION
## Summary
- refresh F# transpiler output for `equal-prime-and-composite-sums`
- record new benchmark numbers in the Rosetta checklist

## Testing
- `MOCHI_ROSETTA_INDEX=356 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/fs -run TestFSTranspiler_Rosetta_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_688e11e24c18832083050245655551af