### PR TITLE
kt: add bitmap histogram rosetta result

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/bitmap-histogram.bench
+++ b/tests/rosetta/transpiler/Kotlin/bitmap-histogram.bench
@@ -1,1 +1,1 @@
-{"duration_us":30047, "memory_bytes":115072, "name":"main"}
+{"duration_us":21349, "memory_bytes":115696, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/bitmap-histogram.kt
+++ b/tests/rosetta/transpiler/Kotlin/bitmap-histogram.kt
@@ -38,7 +38,7 @@ fun histogram(g: MutableList<MutableList<Int>>, bins: Int): MutableList<Int> {
     var h: MutableList<Int> = mutableListOf<Int>()
     var i: Int = 0
     while (i < bins) {
-        h = run { val _tmp = h.toMutableList(); _tmp.add(0); _tmp } as MutableList<Int>
+        h = run { val _tmp = h.toMutableList(); _tmp.add(0); _tmp }
         i = i + 1
     }
     var y: Int = 0
@@ -47,8 +47,8 @@ fun histogram(g: MutableList<MutableList<Int>>, bins: Int): MutableList<Int> {
         var x: Int = 0
         while (x < row.size) {
             var p: Int = row[x]!!
-            var idx: Int = ((p * (bins - 1)) / 65535).toInt()
-            (h[idx]) = h[idx]!! + 1
+            var idx: Int = (((p * (bins - 1)) / 65535).toInt())
+            h[idx] = h[idx]!! + 1
             x = x + 1
         }
         y = y + 1
@@ -61,16 +61,16 @@ fun medianThreshold(h: MutableList<Int>): Int {
     var ub: BigInteger = (h.size - 1).toBigInteger()
     var lSum: Int = 0
     var uSum: Int = 0
-    while ((lb).toBigInteger().compareTo(ub) <= 0) {
+    while ((lb).toBigInteger().compareTo((ub)) <= 0) {
         if ((lSum + h[lb]!!) < (uSum + h[(ub).toInt()]!!)) {
             lSum = lSum + h[lb]!!
             lb = lb + 1
         } else {
             uSum = uSum + h[(ub).toInt()]!!
-            ub = ub.subtract(1.toBigInteger())
+            ub = ub.subtract((1).toBigInteger())
         }
     }
-    return ((ub.multiply(65535.toBigInteger())).divide(h.size.toBigInteger())).toInt()
+    return (((ub.multiply((65535).toBigInteger())).divide((h.size).toBigInteger())).toInt())
 }
 
 fun threshold(g: MutableList<MutableList<Int>>, t: Int): MutableList<MutableList<Int>> {
@@ -82,13 +82,13 @@ fun threshold(g: MutableList<MutableList<Int>>, t: Int): MutableList<MutableList
         var x: Int = 0
         while (x < row.size) {
             if (row[x]!! < t) {
-                newRow = run { val _tmp = newRow.toMutableList(); _tmp.add(0); _tmp } as MutableList<Int>
+                newRow = run { val _tmp = newRow.toMutableList(); _tmp.add(0); _tmp }
             } else {
-                newRow = run { val _tmp = newRow.toMutableList(); _tmp.add(65535); _tmp } as MutableList<Int>
+                newRow = run { val _tmp = newRow.toMutableList(); _tmp.add(65535); _tmp }
             }
             x = x + 1
         }
-        out = run { val _tmp = out.toMutableList(); _tmp.add(newRow); _tmp } as MutableList<MutableList<Int>>
+        out = run { val _tmp = out.toMutableList(); _tmp.add(newRow); _tmp }
         y = y + 1
     }
     return out

--- a/tests/rosetta/transpiler/Kotlin/bitmap-histogram.out
+++ b/tests/rosetta/transpiler/Kotlin/bitmap-histogram.out
@@ -1,0 +1,5 @@
+Histogram: [3, 0, 6]
+Threshold: 21845
+000
+111
+111

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-08-02 17:54 +0700
+Last updated: 2025-08-02 20:26 +0700
 
 Completed tasks: **249/491**
 
@@ -128,7 +128,7 @@ Completed tasks: **249/491**
 | 117 | bitmap-b-zier-curves-quadratic | ✓ | 56.42ms | 3.4 MB |
 | 118 | bitmap-bresenhams-line-algorithm |  |  |  |
 | 119 | bitmap-flood-fill | ✓ | 11.94ms | 130.9 KB |
-| 120 | bitmap-histogram | ✓ | 30.05ms | 112.4 KB |
+| 120 | bitmap-histogram | ✓ | 21.35ms | 113.0 KB |
 | 121 | bitmap-midpoint-circle-algorithm |  |  |  |
 | 122 | bitmap-ppm-conversion-through-a-pipe |  |  |  |
 | 123 | bitmap-read-a-ppm-file |  |  |  |


### PR DESCRIPTION
## Summary
- update Kotlin Rosetta checklist with benchmarked bitmap-histogram (index 120)
- add generated Kotlin source, output and benchmark files for bitmap-histogram

## Testing
- `ROSETTA_INDEX=120 go test -run TestRosettaKotlin -tags slow -count=1`
- `MOCHI_BENCHMARK=true ROSETTA_INDEX=120 go test -run TestRosettaKotlin -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688e121e58848320b0476c59a1ab024c