### PR TITLE
pas: improve map literal inference

### DIFF
--- a/tests/rosetta/transpiler/Pascal/babylonian-spiral.error
+++ b/tests/rosetta/transpiler/Pascal/babylonian-spiral.error
@@ -8,22 +8,39 @@ babylonian-spiral.pas(58,3) Note: Call to subroutine "procedure TFPGMap<System.S
 babylonian-spiral.pas(59,3) Note: Call to subroutine "procedure TFPGMap<System.ShortString,System.Variant>.AddOrSetData(const AKey:ShortString;const AData:Variant);" marked as inline is not inlined
 babylonian-spiral.pas(60,3) Note: Call to subroutine "procedure TFPGMap<System.ShortString,System.Variant>.AddOrSetData(const AKey:ShortString;const AData:Variant);" marked as inline is not inlined
 babylonian-spiral.pas(60,39) Note: Call to subroutine "operator :=(const source:LongInt):Variant;" marked as inline is not inlined
-babylonian-spiral.pas(65,40) Error: Illegal qualifier
-babylonian-spiral.pas(65,50) Error: Illegal qualifier
-babylonian-spiral.pas(65,63) Error: Illegal qualifier
-babylonian-spiral.pas(65,79) Error: Illegal qualifier
-babylonian-spiral.pas(66,39) Error: Illegal qualifier
-babylonian-spiral.pas(67,39) Error: Illegal qualifier
+babylonian-spiral.pas(65,3) Note: Call to subroutine "procedure TFPGMap<System.ShortString,System.LongInt>.AddOrSetData(const AKey:ShortString;const AData:LongInt);" marked as inline is not inlined
+babylonian-spiral.pas(65,90) Note: Call to subroutine "operator :=(const source:Variant):LongInt;" marked as inline is not inlined
+babylonian-spiral.pas(65,90) Note: Call to subroutine "operator :=(const source:Int64):Variant;" marked as inline is not inlined
+babylonian-spiral.pas(65,39) Note: Call to subroutine "function TFPGMap<System.ShortString,System.LongInt>.GetKeyData(const AKey:ShortString):LongInt;" marked as inline is not inlined
+babylonian-spiral.pas(65,49) Note: Call to subroutine "function TFPGMap<System.ShortString,System.LongInt>.GetKeyData(const AKey:ShortString):LongInt;" marked as inline is not inlined
+babylonian-spiral.pas(65,62) Note: Call to subroutine "function TFPGMap<System.ShortString,System.LongInt>.GetKeyData(const AKey:ShortString):LongInt;" marked as inline is not inlined
+babylonian-spiral.pas(65,78) Note: Call to subroutine "function TFPGMap<System.ShortString,System.LongInt>.GetKeyData(const AKey:ShortString):LongInt;" marked as inline is not inlined
+babylonian-spiral.pas(66,3) Note: Call to subroutine "procedure TFPGMap<System.ShortString,System.LongInt>.AddOrSetData(const AKey:ShortString;const AData:LongInt);" marked as inline is not inlined
+babylonian-spiral.pas(66,44) Note: Call to subroutine "operator :=(const source:Variant):LongInt;" marked as inline is not inlined
+babylonian-spiral.pas(66,44) Note: Call to subroutine "operator :=(const source:LongInt):Variant;" marked as inline is not inlined
+babylonian-spiral.pas(66,28) Note: Call to subroutine "function TFPGMap<System.ShortString,System.LongInt>.GetKeyData(const AKey:ShortString):LongInt;" marked as inline is not inlined
+babylonian-spiral.pas(67,3) Note: Call to subroutine "procedure TFPGMap<System.ShortString,System.LongInt>.AddOrSetData(const AKey:ShortString;const AData:LongInt);" marked as inline is not inlined
+babylonian-spiral.pas(67,48) Note: Call to subroutine "operator :=(const source:Variant):LongInt;" marked as inline is not inlined
+babylonian-spiral.pas(67,48) Note: Call to subroutine "operator :=(const source:Int64):Variant;" marked as inline is not inlined
+babylonian-spiral.pas(67,38) Note: Call to subroutine "function TFPGMap<System.ShortString,System.LongInt>.GetKeyData(const AKey:ShortString):LongInt;" marked as inline is not inlined
+babylonian-spiral.pas(72,3) Note: Call to subroutine "procedure TFPGMap<System.ShortString,System.LongInt>.AddOrSetData(const AKey:ShortString;const AData:LongInt);" marked as inline is not inlined
+babylonian-spiral.pas(72,44) Note: Call to subroutine "operator :=(const source:Variant):LongInt;" marked as inline is not inlined
+babylonian-spiral.pas(72,44) Note: Call to subroutine "operator :=(const source:Int64):Variant;" marked as inline is not inlined
+babylonian-spiral.pas(73,3) Note: Call to subroutine "procedure TFPGMap<System.ShortString,System.LongInt>.AddOrSetData(const AKey:ShortString;const AData:LongInt);" marked as inline is not inlined
+babylonian-spiral.pas(73,39) Note: Call to subroutine "operator :=(const source:Variant):LongInt;" marked as inline is not inlined
+babylonian-spiral.pas(73,39) Note: Call to subroutine "operator :=(const source:LongInt):Variant;" marked as inline is not inlined
+babylonian-spiral.pas(74,3) Note: Call to subroutine "procedure TFPGMap<System.ShortString,System.LongInt>.AddOrSetData(const AKey:ShortString;const AData:LongInt);" marked as inline is not inlined
+babylonian-spiral.pas(74,38) Note: Call to subroutine "operator :=(const source:Variant):LongInt;" marked as inline is not inlined
+babylonian-spiral.pas(74,38) Note: Call to subroutine "operator :=(const source:ShortInt):Variant;" marked as inline is not inlined
 babylonian-spiral.pas(84,16) Error: Incompatible types: got "TFPGMap<System.ShortString,System.LongInt>" expected "LongInt"
 babylonian-spiral.pas(86,16) Error: Incompatible types: got "LongInt" expected "TFPGMap<System.ShortString,System.LongInt>"
-babylonian-spiral.pas(104,24) Error: Incompatible type for arg no. 2: Got "TFPGMap<System.ShortString,System.Variant>", expected "TFPGMap<System.ShortString,System.LongInt>"
 babylonian-spiral.pas(110,10) Error: Incompatible types: got "TFPGMap<System.ShortString,System.LongInt>" expected "LongInt"
 babylonian-spiral.pas(112,33) Error: Illegal qualifier
 babylonian-spiral.pas(112,42) Error: Illegal qualifier
 babylonian-spiral.pas(112,13) Error: Incompatible type for arg no. 3: Got "{Array Of Const/Constant Open} Array of {Dynamic} Array Of IntArray", expected "{Open} Array Of Pointer"
 babylonian-spiral.pas(113,9) Error: Illegal qualifier
 babylonian-spiral.pas(113,19) Error: Illegal qualifier
-babylonian-spiral.pas(114,24) Error: Incompatible type for arg no. 2: Got "TFPGMap<System.ShortString,System.Variant>", expected "TFPGMap<System.ShortString,System.LongInt>"
-babylonian-spiral.pas(227) Fatal: There were 16 errors compiling module, stopping
+babylonian-spiral.pas(114,23) Error: Incompatible type for arg no. 1: Got "LongInt", expected "TFPGMap<System.ShortString,System.LongInt>"
+babylonian-spiral.pas(227) Fatal: There were 9 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode

--- a/tests/rosetta/transpiler/Pascal/babylonian-spiral.pas
+++ b/tests/rosetta/transpiler/Pascal/babylonian-spiral.pas
@@ -45,8 +45,8 @@ var
   nv: integer;
   s: string;
 function Map3(h: SpecializeTFPGMapStringIntegerArray; nv: integer; step_best: IntArray): specialize TFPGMap<string, Variant>; forward;
-function Map2(it: integer): specialize TFPGMap<string, Variant>; forward;
-function Map1(nv: integer): specialize TFPGMap<string, Variant>; forward;
+function Map2(it: specialize TFPGMap<string, integer>): specialize TFPGMap<string, integer>; forward;
+function Map1(nv: integer): specialize TFPGMap<string, integer>; forward;
 function push(h: SpecializeTFPGMapStringIntegerArray; it: specialize TFPGMap<string, integer>): SpecializeTFPGMapStringIntegerArray; forward;
 function step(h: SpecializeTFPGMapStringIntegerArray; nv: integer; dir: IntArray): specialize TFPGMap<string, Variant>; forward;
 function positions(n: integer): IntArrayArray; forward;
@@ -59,16 +59,16 @@ begin
   Result.AddOrSetData('heap', Variant(h));
   Result.AddOrSetData('n', Variant(nv));
 end;
-function Map2(it: integer): specialize TFPGMap<string, Variant>;
+function Map2(it: specialize TFPGMap<string, integer>): specialize TFPGMap<string, integer>;
 begin
-  Result := specialize TFPGMap<string, Variant>.Create();
+  Result := specialize TFPGMap<string, integer>.Create();
   Result.AddOrSetData('s', Variant((it['a'] * it['a']) + ((it['b'] + 1) * (it['b'] + 1))));
   Result.AddOrSetData('a', Variant(it['a']));
   Result.AddOrSetData('b', Variant(it['b'] + 1));
 end;
-function Map1(nv: integer): specialize TFPGMap<string, Variant>;
+function Map1(nv: integer): specialize TFPGMap<string, integer>;
 begin
-  Result := specialize TFPGMap<string, Variant>.Create();
+  Result := specialize TFPGMap<string, integer>.Create();
   Result.AddOrSetData('s', Variant(nv * nv));
   Result.AddOrSetData('a', Variant(nv));
   Result.AddOrSetData('b', Variant(0));


### PR DESCRIPTION
## Summary
- improve local variable and selector type lookup
- detect map index usage to infer map parameter types and value types

## Testing
- `ROSETTA_INDEX=97 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/pas -run TestPascalTranspiler_Rosetta -update-rosetta-pas` *(fails: compile: exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_688e38d3b01c83208a04a9da37430171