### PR TITLE
java: handle higher-order call expressions

### DIFF
--- a/tests/rosetta/transpiler/Java/chowla-numbers.bench
+++ b/tests/rosetta/transpiler/Java/chowla-numbers.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 6168,
+  "duration_us": 22031,
   "memory_bytes": 3920,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/chowla-numbers.java
+++ b/tests/rosetta/transpiler/Java/chowla-numbers.java
@@ -1,6 +1,40 @@
 public class Main {
 
     public static void main(String[] args) {
-        System.out.println("chowla( 1) = 0\nchowla( 2) = 0\nchowla( 3) = 0\nchowla( 4) = 2\nchowla( 5) = 0\nchowla( 6) = 5\nchowla( 7) = 0\nchowla( 8) = 6\nchowla( 9) = 3\nchowla(10) = 7\nchowla(11) = 0\nchowla(12) = 15\nchowla(13) = 0\nchowla(14) = 9\nchowla(15) = 8\nchowla(16) = 14\nchowla(17) = 0\nchowla(18) = 20\nchowla(19) = 0\nchowla(20) = 21\nchowla(21) = 10\nchowla(22) = 13\nchowla(23) = 0\nchowla(24) = 35\nchowla(25) = 5\nchowla(26) = 15\nchowla(27) = 12\nchowla(28) = 27\nchowla(29) = 0\nchowla(30) = 41\nchowla(31) = 0\nchowla(32) = 30\nchowla(33) = 14\nchowla(34) = 19\nchowla(35) = 12\nchowla(36) = 54\nchowla(37) = 0\n\nCount of primes up to 100        = 25\nCount of primes up to 1,000      = 168\nCount of primes up to 10,000     = 1,229\nCount of primes up to 100,000    = 9,592\nCount of primes up to 1,000,000  = 78,498\nCount of primes up to 10,000,000 = 664,579\n\n6 is a perfect number\n28 is a perfect number\n496 is a perfect number\n8,128 is a perfect number\n33,550,336 is a perfect number\nThere are 5 perfect numbers <= 35,000,000");
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            System.out.println("chowla( 1) = 0\nchowla( 2) = 0\nchowla( 3) = 0\nchowla( 4) = 2\nchowla( 5) = 0\nchowla( 6) = 5\nchowla( 7) = 0\nchowla( 8) = 6\nchowla( 9) = 3\nchowla(10) = 7\nchowla(11) = 0\nchowla(12) = 15\nchowla(13) = 0\nchowla(14) = 9\nchowla(15) = 8\nchowla(16) = 14\nchowla(17) = 0\nchowla(18) = 20\nchowla(19) = 0\nchowla(20) = 21\nchowla(21) = 10\nchowla(22) = 13\nchowla(23) = 0\nchowla(24) = 35\nchowla(25) = 5\nchowla(26) = 15\nchowla(27) = 12\nchowla(28) = 27\nchowla(29) = 0\nchowla(30) = 41\nchowla(31) = 0\nchowla(32) = 30\nchowla(33) = 14\nchowla(34) = 19\nchowla(35) = 12\nchowla(36) = 54\nchowla(37) = 0\n\nCount of primes up to 100        = 25\nCount of primes up to 1,000      = 168\nCount of primes up to 10,000     = 1,229\nCount of primes up to 100,000    = 9,592\nCount of primes up to 1,000,000  = 78,498\nCount of primes up to 10,000,000 = 664,579\n\n6 is a perfect number\n28 is a perfect number\n496 is a perfect number\n8,128 is a perfect number\n33,550,336 is a perfect number\nThere are 5 perfect numbers <= 35,000,000");
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
     }
 }

--- a/tests/rosetta/transpiler/Java/church-numerals-1.error
+++ b/tests/rosetta/transpiler/Java/church-numerals-1.error
@@ -1,1 +1,37 @@
-transpile: unsupported call
+compile: exit status 1
+/tmp/TestJavaTranspiler_Rosetta_Goldenchurch-numerals-13412736213/001/Main.java:23: error: incompatible types: Function<Object,Integer> cannot be converted to int
+        int di = toInt(d);
+                      ^
+/tmp/TestJavaTranspiler_Rosetta_Goldenchurch-numerals-13412736213/001/Main.java:38: error: cannot find symbol
+        return ((Number)(c.apply(incr).apply(0))).intValue();
+                                 ^
+  symbol:   variable incr
+  location: class Main
+/tmp/TestJavaTranspiler_Rosetta_Goldenchurch-numerals-13412736213/001/Main.java:38: error: incompatible types: int cannot be converted to Function<Object,Integer>
+        return ((Number)(c.apply(incr).apply(0))).intValue();
+                                                          ^
+/tmp/TestJavaTranspiler_Rosetta_Goldenchurch-numerals-13412736213/001/Main.java:42: error: bad operand types for binary operator '=='
+        if (i == 0) {
+              ^
+  first type:  Function<Object,Integer>
+  second type: int
+/tmp/TestJavaTranspiler_Rosetta_Goldenchurch-numerals-13412736213/001/Main.java:43: error: cannot find symbol
+            return zero;
+                   ^
+  symbol:   variable zero
+  location: class Main
+/tmp/TestJavaTranspiler_Rosetta_Goldenchurch-numerals-13412736213/001/Main.java:45: error: bad operand types for binary operator '-'
+        return succ(intToChurch(i - 1));
+                                  ^
+  first type:  Function<Object,Integer>
+  second type: int
+/tmp/TestJavaTranspiler_Rosetta_Goldenchurch-numerals-13412736213/001/Main.java:51: error: cannot find symbol
+            z = zero;
+                ^
+  symbol:   variable zero
+  location: class Main
+/tmp/TestJavaTranspiler_Rosetta_Goldenchurch-numerals-13412736213/001/Main.java:60: error: incompatible types: int cannot be converted to Function<Object,Integer>
+            System.out.println("5 -> five    -> " + _p(toInt(intToChurch(5))));
+                                                                         ^
+Note: Some messages have been simplified; recompile with -Xdiags:verbose to get full output
+8 errors

--- a/tests/rosetta/transpiler/Java/church-numerals-1.java
+++ b/tests/rosetta/transpiler/Java/church-numerals-1.java
@@ -1,0 +1,97 @@
+public class Main {
+    static java.util.function.Function<java.util.function.Function<Object,Object>,java.util.function.Function<Object,Object>> z;
+    static java.util.function.Function<java.util.function.Function<Object,Object>,java.util.function.Function<Object,Object>> three;
+    static java.util.function.Function<java.util.function.Function<Object,Object>,java.util.function.Function<Object,Object>> four;
+
+    static java.util.function.Function<Object,Object> zero(java.util.function.Function<Object,Object> f) {
+        return (x) -> x;
+    }
+
+    static java.util.function.Function<java.util.function.Function<Object,Object>,java.util.function.Function<Object,Object>> succ(java.util.function.Function<java.util.function.Function<Object,Object>,java.util.function.Function<Object,Object>> c) {
+        return (f) -> (x_1) -> f.apply(c.apply(f).apply(x_1));
+    }
+
+    static java.util.function.Function<java.util.function.Function<Object,Object>,java.util.function.Function<Object,Object>> add(java.util.function.Function<java.util.function.Function<Object,Object>,java.util.function.Function<Object,Object>> c, java.util.function.Function<java.util.function.Function<Object,Object>,java.util.function.Function<Object,Object>> d) {
+        return (f_1) -> (x_2) -> c.apply(f_1).apply(d.apply(f_1).apply(x_2));
+    }
+
+    static java.util.function.Function<java.util.function.Function<Object,Object>,java.util.function.Function<Object,Object>> mul(java.util.function.Function<java.util.function.Function<Object,Object>,java.util.function.Function<Object,Object>> c, java.util.function.Function<java.util.function.Function<Object,Object>,java.util.function.Function<Object,Object>> d) {
+        return (f_2) -> (x_3) -> c.apply(d.apply(f_2)).apply(x_3);
+    }
+
+    static java.util.function.Function<java.util.function.Function<Object,Object>,java.util.function.Function<Object,Object>> pow(java.util.function.Function<java.util.function.Function<Object,Object>,java.util.function.Function<Object,Object>> c, java.util.function.Function<java.util.function.Function<Object,Object>,java.util.function.Function<Object,Object>> d) {
+        int di = toInt(d);
+        java.util.function.Function<java.util.function.Function<Object,Object>,java.util.function.Function<Object,Object>> prod = c;
+        int i = 1;
+        while (i < di) {
+            prod = mul(prod, c);
+            i = i + 1;
+        }
+        return prod;
+    }
+
+    static Object incr(Object i) {
+        return (((Number)(i)).intValue()) + 1;
+    }
+
+    static java.util.function.Function<Object,Integer> toInt(java.util.function.Function<java.util.function.Function<Object,Object>,java.util.function.Function<Object,Object>> c) {
+        return ((Number)(c.apply(incr).apply(0))).intValue();
+    }
+
+    static java.util.function.Function<java.util.function.Function<Object,Object>,java.util.function.Function<Object,Object>> intToChurch(java.util.function.Function<Object,Integer> i) {
+        if (i == 0) {
+            return zero;
+        }
+        return succ(intToChurch(i - 1));
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            z = zero;
+            three = succ(succ(succ(z)));
+            four = succ(three);
+            System.out.println("three        -> " + _p(toInt(three)));
+            System.out.println("four         -> " + _p(toInt(four)));
+            System.out.println("three + four -> " + _p(toInt(add(three, four))));
+            System.out.println("three * four -> " + _p(toInt(mul(three, four))));
+            System.out.println("three ^ four -> " + _p(toInt(pow(three, four))));
+            System.out.println("four ^ three -> " + _p(toInt(pow(four, three))));
+            System.out.println("5 -> five    -> " + _p(toInt(intToChurch(5))));
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static String _p(Object v) {
+        return v != null ? String.valueOf(v) : "<nil>";
+    }
+}

--- a/transpiler/x/java/ROSETTA.md
+++ b/transpiler/x/java/ROSETTA.md
@@ -1,7 +1,7 @@
 # Java Rosetta Transpiler Output
 
 Generated Java code for programs in `tests/rosetta/x/Mochi`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
-Last updated: 2025-08-02 20:49 GMT+7
+Last updated: 2025-08-02 23:25 GMT+7
 
 ## Rosetta Checklist (414/491)
 | Index | Name | Status | Duration | Memory |
@@ -206,7 +206,7 @@ Last updated: 2025-08-02 20:49 GMT+7
 | 198 | chinese-zodiac | ✓ | 45.0ms | 99.30KB |
 | 199 | cholesky-decomposition-1 |   |  |  |
 | 200 | cholesky-decomposition | ✓ | 17.0ms | 65.20KB |
-| 201 | chowla-numbers | ✓ | 6.0ms | 3.83KB |
+| 201 | chowla-numbers | ✓ | 22.0ms | 3.83KB |
 | 202 | church-numerals-1 |   |  |  |
 | 203 | church-numerals-2 |   |  |  |
 | 204 | circles-of-given-radius-through-two-points |   |  |  |


### PR DESCRIPTION
## Summary
- support nested call and method call expressions by invoking `apply`
- resolve function type aliases and improve cast handling
- ensure declaration order for generated statements

## Testing
- `MOCHI_ROSETTA_INDEX=201 MOCHI_BENCHMARK=1 UPDATE=1 go test ./transpiler/x/java -run TestJavaTranspiler_Rosetta_Golden -tags=slow -count=1`
- `MOCHI_ROSETTA_INDEX=202 MOCHI_BENCHMARK=1 UPDATE=1 go test ./transpiler/x/java -run TestJavaTranspiler_Rosetta_Golden -tags=slow -count=1` *(fails: javac church-numerals-1: exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_688e392df75c83208071f896b02d3f05