### PR TITLE
Fix C# benchmark memory reporting

### DIFF
--- a/transpiler/x/cs/transpiler.go
+++ b/transpiler/x/cs/transpiler.go
@@ -319,7 +319,7 @@ type BenchStmt struct {
 
 func (b *BenchStmt) emit(w io.Writer) {
 	fmt.Fprint(w, "{\n")
-	fmt.Fprint(w, "    var __memStart = _mem(true);\n")
+	fmt.Fprint(w, "    var __memStart = _mem();\n")
 	fmt.Fprint(w, "    var __start = _now();\n")
 	for _, st := range b.Body {
 		fmt.Fprint(w, "    ")
@@ -331,9 +331,7 @@ func (b *BenchStmt) emit(w io.Writer) {
 		}
 	}
 	fmt.Fprint(w, "    var __end = _now();\n")
-	// Force a full collection at the end to ensure memory usage isn't reported
-	// as zero for trivial programs where GC hasn't run yet.
-	fmt.Fprint(w, "    var __memEnd = _mem(true);\n")
+	fmt.Fprint(w, "    var __memEnd = _mem();\n")
 	fmt.Fprint(w, "    var __dur = (__end - __start);\n")
 	fmt.Fprint(w, "    if (__dur <= 0) __dur = 1;\n")
 	fmt.Fprint(w, "    var __memDiff = __memEnd - __memStart;\n")
@@ -4566,8 +4564,8 @@ func Emit(prog *Program) []byte {
 		buf.WriteString("\t}\n")
 	}
 	if usesMem {
-		buf.WriteString("\tstatic long _mem(bool force) {\n")
-		buf.WriteString("\t\treturn GC.GetTotalMemory(force);\n")
+		buf.WriteString("\tstatic long _mem() {\n")
+		buf.WriteString("\t\treturn GC.GetTotalAllocatedBytes(true);\n")
 		buf.WriteString("\t}\n")
 	}
 	if usesSHA256 {


### PR DESCRIPTION
## Summary
- improve C# transpiler benchmark blocks to use a unified `_mem()` helper
- track memory with `GC.GetTotalAllocatedBytes` so results no longer show zero

## Testing
- `MOCHI_BENCHMARK=1 MOCHI_ROSETTA_INDEX=220 go test -tags=slow ./transpiler/x/cs -run TestCSTranspiler_Rosetta_Golden -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688e3995d83c8320ac25150e86dd1836