### PR TITLE
chore(cs): add rosetta output for conditional-structures-9

### DIFF
--- a/transpiler/x/cs/ROSETTA.md
+++ b/transpiler/x/cs/ROSETTA.md
@@ -1,7 +1,7 @@
 # Rosetta C# Transpiler Output
 
 Completed programs: 468/491
-Last updated: 2025-08-03 00:11 +0700
+Last updated: 2025-08-03 08:50 +0700
 
 ## Checklist
 | Index | Name | Status | Duration | Memory |


### PR DESCRIPTION
## Summary
- record C# transpiler output for Rosetta index 223 (`conditional-structures-9`)
- regenerate Rosetta C# checklist

## Testing
- `MOCHI_ROSETTA_INDEX=223 MOCHI_BENCHMARK=1 go test ./transpiler/x/cs -tags slow -run TestCSTranspiler_Rosetta_Golden -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688ec0ab9e548320908c6edf64731c3b