### PR TITLE
docs: add v0.10.56 changelog and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # 📦 CHANGELOG.md
 
+## [0.10.56] – 2025-08-03T10:08:34+07:00
+
+### Added
+
+* Scheme transpiler supports struct methods and typed div/mod
+* Racket and Pascal expand Rosetta benchmark coverage including 50 new Racket programs and Benford's law
+* Rust and C++ benchmarks capture memory usage directly
+
+### Changed
+
+* Benchmarks report memory more accurately across C++, Zig, C#, TypeScript and others
+* Rosetta outputs refreshed for Scala, Kotlin, Erlang, Pascal and more
+
+### Fixed
+
+* Corrected memory detection and capture in C++, Rust, Zig, C and PHP transpilers
+* Improved map and list handling in Pascal, Kotlin and Rust
+* Fixed benchmark timing and string comparison bugs across languages
+
 ## [0.10.55] – 2025-08-02T16:16:26+07:00
 
 ### Added

--- a/releases/v0.10.56.md
+++ b/releases/v0.10.56.md
@@ -1,0 +1,25 @@
+# Aug 2025 (v0.10.56)
+
+Released on Sun Aug 03 10:08:34 2025 +0700.
+
+Mochi v0.10.56 expands Rosetta benchmark coverage, improves benchmark memory reporting, and upgrades multiple transpilers.
+
+## Transpilers
+
+- Scheme adds struct method support and typed division/mod operations
+- Pascal introduces padStart, Int64 lists, and additional Rosetta outputs including Benford's law
+- Racket, Scala and Kotlin gain numerous new Rosetta benchmark outputs
+- C++ and Rust benchmarks report memory usage directly with improved detection
+- Zig and C# refine memory capture and variable mutability
+
+## Benchmarks
+
+- Racket benchmark suite adds 50 new Rosetta programs plus character code examples
+- New benchmark data for Pascal, Scala, Kotlin, Erlang and more expands Rosetta coverage
+- Benchmarks report more accurate memory statistics across languages
+
+## Fixes
+
+- Resolved memory detection issues in C++, Rust, Zig, C and TypeScript transpilers
+- Improved map and list handling across Pascal, Kotlin and Rust
+- Addressed benchmark timing and string comparison inconsistencies


### PR DESCRIPTION
## Summary
- add release notes for v0.10.56
- document changes in CHANGELOG

## Testing
- `npm test` (fails: Missing script)
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ed2259e148320b55405fef0c0e153