### PR TITLE
fix memory capture in rust transpiler

### DIFF
--- a/tests/rosetta/transpiler/Rust/100-doors-2.bench
+++ b/tests/rosetta/transpiler/Rust/100-doors-2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 109,
-  "memory_bytes": 3313664,
+  "duration_us": 78,
+  "memory_bytes": 2088960,
   "name": "main"
 }

--- a/transpiler/x/rs/ROSETTA.md
+++ b/transpiler/x/rs/ROSETTA.md
@@ -2,12 +2,12 @@
 
 This checklist is auto-generated.
 Generated Rust code from programs in `tests/rosetta/x/Mochi` lives in `tests/rosetta/transpiler/Rust`.
-Last updated: 2025-08-03 04:20 UTC
+Last updated: 2025-08-03 04:43 UTC
 
 ## Rosetta Golden Test Checklist (218/491)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
-| 1 | 100-doors-2 | ✓ | 109µs | 3.2 MB |
+| 1 | 100-doors-2 | ✓ | 78µs | 2.0 MB |
 | 2 | 100-doors-3 | ✓ | 81µs | 3.2 MB |
 | 3 | 100-doors | ✓ | 118µs | 3.2 MB |
 | 4 | 100-prisoners | ✓ | 138.514ms | 3.3 MB |


### PR DESCRIPTION
## Summary
- ensure benchmarked Rust programs report current memory usage instead of deltas
- treat map literals passed to functions expecting `HashMap` values as true hash maps
- refresh Rosetta progress with updated memory metrics

## Testing
- `MOCHI_ROSETTA_INDEX=1 MOCHI_BENCHMARK=1 go test -tags=slow ./transpiler/x/rs -run Rosetta -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688ee731ae70832098d2c861ddf8a5fd