### PR TITLE
php rosetta: add bench for bulls-and-cows-player

### DIFF
--- a/tests/rosetta/transpiler/php/bulls-and-cows-player.bench
+++ b/tests/rosetta/transpiler/php/bulls-and-cows-player.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 18443,
+  "memory_bytes": 236456,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/php/bulls-and-cows-player.php
+++ b/tests/rosetta/transpiler/php/bulls-and-cows-player.php
@@ -5,7 +5,6 @@ function _indexof($s, $sub) {
     return $pos === false ? -1 : $pos;
 }
 function indexOf($s, $ch) {
-  global $fields, $makePatterns, $main;
   $i = 0;
   while ($i < strlen($s)) {
   if (substr($s, $i, $i + 1 - $i) == $ch) {
@@ -16,7 +15,6 @@ function indexOf($s, $ch) {
   return -1;
 }
 function fields($s) {
-  global $indexOf, $makePatterns, $main;
   $words = [];
   $cur = '';
   $i = 0;
@@ -39,7 +37,6 @@ function fields($s) {
   return $words;
 }
 function makePatterns() {
-  global $indexOf, $fields, $main;
   $digits = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
   $pats = [];
   $i = 0;
@@ -68,7 +65,6 @@ function makePatterns() {
   return $pats;
 }
 function main() {
-  global $indexOf, $fields, $makePatterns;
   echo rtrim('Cows and bulls/player
 ' . 'You think of four digit number of unique digits in the range 1 to 9.
 ' . 'I guess.  You score my guess:

--- a/transpiler/x/php/ROSETTA.md
+++ b/transpiler/x/php/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from Mochi Rosetta tasks lives in `tests/rosetta/transpiler/php`.
 
-Last updated: 2025-08-02 23:21 +0700
+Last updated: 2025-08-03 15:40 +0700
 
 ## Checklist (485/491)
 | Index | Name | Status | Duration | Memory |
@@ -144,7 +144,7 @@ Last updated: 2025-08-02 23:21 +0700
 | 135 | break-oo-privacy | ✓ | 62µs | 504 B |
 | 136 | brilliant-numbers |   |  |  |
 | 137 | brownian-tree | ✓ |  |  |
-| 138 | bulls-and-cows-player | ✓ |  |  |
+| 138 | bulls-and-cows-player | ✓ | 18.443ms | 230.9 KB |
 | 139 | bulls-and-cows | ✓ |  |  |
 | 140 | burrows-wheeler-transform | ✓ | 9.414ms | 160 B |
 | 141 | caesar-cipher-1 | ✓ | 157µs | 96 B |


### PR DESCRIPTION
## Summary
- add benchmark data for bulls-and-cows-player PHP rosetta program
- record new timing/memory in Rosetta checklist

## Testing
- `MOCHI_ROSETTA_INDEX=138 go test ./transpiler/x/php -run TestPHPTranspiler_Rosetta_Golden -tags=slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688f2279b7e08320aa41cd614291fad8