### PR TITLE
Avoid duplicate benchmarking for Dart transpiler

### DIFF
--- a/tests/rosetta/transpiler/Dart/almost-prime.bench
+++ b/tests/rosetta/transpiler/Dart/almost-prime.bench
@@ -1,1 +1,1 @@
-{"duration_us":7954,"memory_bytes":110592,"name":"main"}
+{"duration_us":12876,"memory_bytes":11747328,"name":"main"}

--- a/tests/rosetta/transpiler/Dart/almost-prime.dart
+++ b/tests/rosetta/transpiler/Dart/almost-prime.dart
@@ -22,14 +22,21 @@ int _now() {
   return DateTime.now().microsecondsSinceEpoch;
 }
 
-void main() {
-  var _benchMem0 = ProcessInfo.currentRss;
-  var _benchSw = Stopwatch()..start();
-  _initNow();
-  {
-  var _benchMem0 = ProcessInfo.currentRss;
-  var _benchSw = Stopwatch()..start();
-  bool kPrime(int n, int k) {
+String _substr(String s, num start, num end) {
+  var n = s.length;
+  int s0 = start.toInt();
+  int e0 = end.toInt();
+  if (s0 < 0) s0 += n;
+  if (e0 < 0) e0 += n;
+  if (s0 < 0) s0 = 0;
+  if (s0 > n) s0 = n;
+  if (e0 < 0) e0 = 0;
+  if (e0 > n) e0 = n;
+  if (s0 > e0) s0 = e0;
+  return s.substring(s0, e0);
+}
+
+bool kPrime(int n, int k) {
   int nf = 0;
   int i = 2;
   while (i <= n) {
@@ -44,8 +51,9 @@ void main() {
   }
   return nf == k;
 }
-  List<int> gen(int k, int count) {
-  List<int> r = [];
+
+List<int> gen(int k, int count) {
+  List<int> r = <int>[];
   int n = 2;
   while (r.length < count) {
     if (kPrime(n, k)) {
@@ -55,19 +63,25 @@ void main() {
   }
   return r;
 }
-  void main() {
+
+void _main() {
   int k = 1;
   while (k <= 5) {
     print((k).toString() + " " + (gen(k, 10)).toString());
     k = k + 1;
   }
 }
-  main();
+
+void _start() {
+  _initNow();
+  {
+  var _benchMem0 = ProcessInfo.currentRss;
+  var _benchSw = Stopwatch()..start();
+  _main();
   _benchSw.stop();
   var _benchMem1 = ProcessInfo.currentRss;
   print(jsonEncode({"duration_us": _benchSw.elapsedMicroseconds, "memory_bytes": (_benchMem1 - _benchMem0).abs(), "name": "main"}));
 }
-  _benchSw.stop();
-  var _benchMem1 = ProcessInfo.currentRss;
-  print(jsonEncode({"duration_us": _benchSw.elapsedMicroseconds, "memory_bytes": (_benchMem1 - _benchMem0).abs(), "name": "main"}));
 }
+
+void main() => _start();

--- a/transpiler/x/dart/ROSETTA.md
+++ b/transpiler/x/dart/ROSETTA.md
@@ -48,7 +48,7 @@ Compiled and ran: 477/491
 | 39 | align-columns | ✓ | 7.95ms | 232.0 KB |
 | 40 | aliquot-sequence-classifications | ✓ | 40.353ms | 1012.0 KB |
 | 41 | almkvist-giullera-formula-for-pi | ✓ |  |  |
-| 42 | almost-prime | ✓ | 7.954ms | 108.0 KB |
+| 42 | almost-prime | ✓ | 12.876ms | 11.2 MB |
 | 43 | amb | ✓ | 5.844ms | 2.6 MB |
 | 44 | amicable-pairs | ✓ | 1.287573s | 11.4 MB |
 | 45 | anagrams-deranged-anagrams | ✓ | 7.343ms | 164.0 KB |
@@ -499,4 +499,4 @@ Compiled and ran: 477/491
 | 490 | window-management | ✓ | 11.069ms | 2.1 MB |
 | 491 | zumkeller-numbers | ✓ | 1.389357s | 3.9 MB |
 
-_Last updated: 2025-08-02 13:31 +0000_
+_Last updated: 2025-08-03 16:15 +0700_


### PR DESCRIPTION
## Summary
- avoid double benchmarking when wrapping `main`
- regenerate Rosetta index 42 (almost-prime) Dart output with single benchmark wrapper

## Testing
- `MOCHI_ROSETTA_INDEX=42 MOCHI_BENCHMARK=true go test -tags=slow ./transpiler/x/dart -run Rosetta -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688f26c7cf108320b21b66cc62a60d3e