### PR TITLE
Add Kotlin transpilation for Rosetta caesar cipher

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/caesar-cipher-1.bench
+++ b/tests/rosetta/transpiler/Kotlin/caesar-cipher-1.bench
@@ -1,0 +1,1 @@
+{"duration_us":31530, "memory_bytes":125424, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/caesar-cipher-1.kt
+++ b/tests/rosetta/transpiler/Kotlin/caesar-cipher-1.kt
@@ -1,0 +1,117 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+fun indexOf(s: String, ch: String): Int {
+    var i: Int = 0
+    while (i < s.length) {
+        if (s.substring(i, i + 1) == ch) {
+            return i
+        }
+        i = i + 1
+    }
+    return 0 - 1
+}
+
+fun ord(ch: String): Int {
+    var upper: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    var lower: String = "abcdefghijklmnopqrstuvwxyz"
+    var idx: Int = upper.indexOf(ch)
+    if (idx >= 0) {
+        return 65 + idx
+    }
+    idx = lower.indexOf(ch)
+    if (idx >= 0) {
+        return 97 + idx
+    }
+    return 0
+}
+
+fun chr(n: Int): String {
+    var upper: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    var lower: String = "abcdefghijklmnopqrstuvwxyz"
+    if ((n >= 65) && (n < 91)) {
+        return upper.substring(n - 65, n - 64)
+    }
+    if ((n >= 97) && (n < 123)) {
+        return lower.substring(n - 97, n - 96)
+    }
+    return "?"
+}
+
+fun shiftRune(r: String, k: Int): String {
+    if ((r >= "a") && (r <= "z")) {
+        return chr((Math.floorMod(((ord(r) - 97) + k), 26)) + 97)
+    }
+    if ((r >= "A") && (r <= "Z")) {
+        return chr((Math.floorMod(((ord(r) - 65) + k), 26)) + 65)
+    }
+    return r
+}
+
+fun encipher(s: String, k: Int): String {
+    var out: String = ""
+    var i: Int = 0
+    while (i < s.length) {
+        out = out + shiftRune(s.substring(i, i + 1), k)
+        i = i + 1
+    }
+    return out
+}
+
+fun decipher(s: String, k: Int): String {
+    return encipher(s, Math.floorMod((26 - (Math.floorMod(k, 26))), 26))
+}
+
+fun user_main(): Unit {
+    var pt: String = "The five boxing wizards jump quickly"
+    println("Plaintext: " + pt)
+    for (key in mutableListOf(0, 1, 7, 25, 26)) {
+        if ((key < 1) || (key > 25)) {
+            println(("Key " + key.toString()) + " invalid")
+            continue
+        }
+        var ct: String = encipher(pt, key)
+        println("Key " + key.toString())
+        println("  Enciphered: " + ct)
+        println("  Deciphered: " + decipher(ct, key))
+    }
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/caesar-cipher-1.out
+++ b/tests/rosetta/transpiler/Kotlin/caesar-cipher-1.out
@@ -1,0 +1,12 @@
+Plaintext: The five boxing wizards jump quickly
+Key 0 invalid
+Key 1
+  Enciphered: Uif gjwf cpyjoh xjabset kvnq rvjdlmz
+  Deciphered: The five boxing wizards jump quickly
+Key 7
+  Enciphered: Aol mpcl ivepun dpghykz qbtw xbpjrsf
+  Deciphered: The five boxing wizards jump quickly
+Key 25
+  Enciphered: Sgd ehud anwhmf vhyzqcr itlo pthbjkx
+  Deciphered: The five boxing wizards jump quickly
+Key 26 invalid

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-08-03 15:40 +0700
+Last updated: 2025-08-03 16:13 +0700
 
-Completed tasks: **265/491**
+Completed tasks: **266/491**
 
 ### Checklist
 | Index | Name | Status | Duration | Memory |
@@ -149,7 +149,7 @@ Completed tasks: **265/491**
 | 138 | bulls-and-cows-player |  |  |  |
 | 139 | bulls-and-cows |  |  |  |
 | 140 | burrows-wheeler-transform | ✓ | 74.95ms | 127.5 KB |
-| 141 | caesar-cipher-1 |  |  |  |
+| 141 | caesar-cipher-1 | ✓ | 31.53ms | 122.5 KB |
 | 142 | caesar-cipher-2 |  |  |  |
 | 143 | calculating-the-value-of-e |  |  |  |
 | 144 | calendar---for-real-programmers-1 |  |  |  |


### PR DESCRIPTION
## Summary
- transpile Rosetta Code problem 141 (caesar-cipher-1) to Kotlin
- record benchmark/output and update Kotlin Rosetta checklist

## Testing
- `ROSETTA_INDEX=141 go test -run TestRosettaKotlin -tags slow`
- `ROSETTA_INDEX=141 MOCHI_BENCHMARK=true go test -run TestRosettaKotlin -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_688f284052d4832086df1deb6a1c7509