### PR TITLE
chore(scala): regen equilibrium-index benchmark

### DIFF
--- a/transpiler/x/scala/README.md
+++ b/transpiler/x/scala/README.md
@@ -3,7 +3,7 @@
 Generated Scala code for programs in `tests/vm/valid`. Each program has a `.scala` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
 ## Golden Test Checklist (93/105)
-_Last updated: 2025-08-02 21:10 +0700_
+_Last updated: 2025-08-03 16:22 +0700_
 
 - [x] append_builtin
 - [x] avg_builtin

--- a/transpiler/x/scala/ROSETTA.md
+++ b/transpiler/x/scala/ROSETTA.md
@@ -3,7 +3,7 @@
 Generated Scala code for Rosetta tasks in `tests/rosetta/x/Mochi`. Each program has a `.scala` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
 ## Golden Test Checklist (427/491)
-_Last updated: 2025-08-03 09:00 +0000_
+_Last updated: 2025-08-03 16:22 +0700_
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|

--- a/transpiler/x/scala/TASKS.md
+++ b/transpiler/x/scala/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-08-03 16:19 +0700)
+- Add Scheme transpiler output for equilibrium-index
+- Regenerated golden files - 93/105 vm valid programs passing
+
 ## Progress (2025-08-02 20:55 +0700)
 - transpiler/java: support nested list literals
 - Regenerated golden files - 93/105 vm valid programs passing


### PR DESCRIPTION
## Summary
- regenerate Scala Rosetta benchmark for equilibrium-index
- update Rosetta checklist timestamp and progress log

## Testing
- `MOCHI_ROSETTA_INDEX=357 MOCHI_BENCHMARK=1 go test ./transpiler/x/scala -run Rosetta -count=1 -tags=slow`


------
https://chatgpt.com/codex/tasks/task_e_688f298d5fa88320b19f2a31c9370209