### PR TITLE
scheme: record equilibrium-index benchmark

### DIFF
--- a/transpiler/x/scheme/ROSETTA.md
+++ b/transpiler/x/scheme/ROSETTA.md
@@ -3,7 +3,7 @@
 Generated Scheme code for Rosetta Code tasks under `tests/rosetta/x/Mochi`.
 
 ## Checklist (406/491)
-Last updated: 2025-08-03 09:04 UTC
+Last updated: 2025-08-03 10:04 UTC
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
@@ -363,7 +363,7 @@ Last updated: 2025-08-03 09:04 UTC
 | 354 | environment-variables-1 | ✓ | 571.223ms | 12.0 MB |
 | 355 | environment-variables-2 | ✓ | 571.223ms | 12.1 MB |
 | 356 | equal-prime-and-composite-sums |   |  |  |
-| 357 | equilibrium-index | ✓ |  |  |
+| 357 | equilibrium-index | ✓ | 693.671ms | 12.1 MB |
 | 358 | erd-s-nicolas-numbers |   |  |  |
 | 359 | erd-s-selfridge-categorization-of-primes |   |  |  |
 | 360 | esthetic-numbers |   |  |  |


### PR DESCRIPTION
## Summary
- record benchmark metrics for the `equilibrium-index` Rosetta example in the Scheme transpiler checklist

## Testing
- `MOCHI_ROSETTA_INDEX=357 MOCHI_BENCHMARK=1 go test -run TestSchemeTranspiler_Rosetta_Golden -tags=slow ./transpiler/x/scheme`

------
https://chatgpt.com/codex/tasks/task_e_688f299ecbf88320b31469d34f085ea0