### PR TITLE
propagate mutations from nested functions

### DIFF
--- a/tests/rosetta/transpiler/Haskell/accumulator-factory.error
+++ b/tests/rosetta/transpiler/Haskell/accumulator-factory.error
@@ -1,1 +1,7 @@
-transpile: unsupported statement in block
+run: exit status 1
+
+/workspace/mochi/tests/rosetta/transpiler/Haskell/accumulator-factory.hs:57:9: error:
+    parse error (possibly incorrect indentation or mismatched brackets)
+   |
+57 |         return (((deref store) !! 0))
+   |         ^

--- a/transpiler/x/hs/transpiler.go
+++ b/transpiler/x/hs/transpiler.go
@@ -4098,6 +4098,9 @@ func convertLocalFunStmt(f *parser.FunStmt) (Expr, error) {
 		if globals[name] {
 			mutatedGlobal[name] = true
 		}
+		if prevLocals[name] {
+			markMutated(name)
+		}
 	}
 	locals = prevLocals
 


### PR DESCRIPTION
## Summary
- ensure nested functions propagate outer variable mutations in Haskell transpiler

## Testing
- `ROSETTA_INDEX=25 UPDATE=1 MOCHI_BENCHMARK=1 go test -tags slow -run TestHSTranspiler_Rosetta_Golden -count=1 -v` *(fails: run error exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_688f32ecd45c8320b32ffb81e1fc70e5