### PR TITLE
php: add bulls-and-cows-player rosetta output

### DIFF
--- a/tests/rosetta/transpiler/php/bulls-and-cows-player.bench
+++ b/tests/rosetta/transpiler/php/bulls-and-cows-player.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 18443,
+  "duration_us": 19678,
   "memory_bytes": 236456,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/php/bulls-and-cows-player.out
+++ b/tests/rosetta/transpiler/php/bulls-and-cows-player.out
@@ -6,3 +6,8 @@ I guess.  You score my guess:
 You give my score as two numbers separated with a space.
 My guess: 1234.  Score? (c b)
 I did it. :)
+{
+  "duration_us": 19678,
+  "memory_bytes": 236456,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/php/bulls-and-cows-player.php
+++ b/tests/rosetta/transpiler/php/bulls-and-cows-player.php
@@ -1,10 +1,27 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _indexof($s, $sub) {
     $pos = strpos($s, $sub);
     return $pos === false ? -1 : $pos;
 }
-function indexOf($s, $ch) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function indexOf($s, $ch) {
   $i = 0;
   while ($i < strlen($s)) {
   if (substr($s, $i, $i + 1 - $i) == $ch) {
@@ -13,8 +30,8 @@ function indexOf($s, $ch) {
   $i = $i + 1;
 };
   return -1;
-}
-function fields($s) {
+};
+  function fields($s) {
   $words = [];
   $cur = '';
   $i = 0;
@@ -35,8 +52,8 @@ function fields($s) {
   $words = array_merge($words, [$cur]);
 }
   return $words;
-}
-function makePatterns() {
+};
+  function makePatterns() {
   $digits = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
   $pats = [];
   $i = 0;
@@ -63,8 +80,8 @@ function makePatterns() {
   $i = $i + 1;
 };
   return $pats;
-}
-function main() {
+};
+  function main() {
   echo rtrim('Cows and bulls/player
 ' . 'You think of four digit number of unique digits in the range 1 to 9.
 ' . 'I guess.  You score my guess:
@@ -126,5 +143,13 @@ function main() {
 };
   $patterns = $next;
 };
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-Last updated: 2025-08-02 17:26 +0700
+Last updated: 2025-08-03 17:01 +0700
 
 ## VM Golden Test Checklist (103/105)
 - [x] append_builtin

--- a/transpiler/x/php/ROSETTA.md
+++ b/transpiler/x/php/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from Mochi Rosetta tasks lives in `tests/rosetta/transpiler/php`.
 
-Last updated: 2025-08-03 15:40 +0700
+Last updated: 2025-08-03 17:01 +0700
 
 ## Checklist (485/491)
 | Index | Name | Status | Duration | Memory |
@@ -144,7 +144,7 @@ Last updated: 2025-08-03 15:40 +0700
 | 135 | break-oo-privacy | ✓ | 62µs | 504 B |
 | 136 | brilliant-numbers |   |  |  |
 | 137 | brownian-tree | ✓ |  |  |
-| 138 | bulls-and-cows-player | ✓ | 18.443ms | 230.9 KB |
+| 138 | bulls-and-cows-player | ✓ | 19.678ms | 230.9 KB |
 | 139 | bulls-and-cows | ✓ |  |  |
 | 140 | burrows-wheeler-transform | ✓ | 9.414ms | 160 B |
 | 141 | caesar-cipher-1 | ✓ | 157µs | 96 B |

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,4 +1,4 @@
-## Progress (2025-08-02 17:26 +0700)
+## Progress (2025-08-03 17:01 +0700)
 - Generated PHP for 103/105 programs
 - Updated README checklist and outputs
 - Enhanced printing to match golden format


### PR DESCRIPTION
## Summary
- add generated PHP code, output, and benchmark data for Rosetta task 138 (bulls-and-cows-player)
- refresh PHP Rosetta checklist and timestamps

## Testing
- `UPDATE=1 MOCHI_ROSETTA_INDEX=138 MOCHI_BENCHMARK=1 go test -run TestPHPTranspiler_Rosetta_Golden -tags=slow -v ./transpiler/x/php -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688f3375ace4832095dd671a968543c2