### PR TITLE
clj: add Rosetta boolean-values

### DIFF
--- a/tests/rosetta/transpiler/Clojure/boolean-values.bench
+++ b/tests/rosetta/transpiler/Clojure/boolean-values.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 35813,
+  "memory_bytes": 19956024,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/boolean-values.clj
+++ b/tests/rosetta/transpiler/Clojure/boolean-values.clj
@@ -1,0 +1,37 @@
+(ns main (:refer-clojure :exclude [parseBool main]))
+
+(require 'clojure.set)
+
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
+(defn padStart [s w p]
+  (loop [out (str s)] (if (< (count out) w) (recur (str p out)) out)))
+
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
+(declare parseBool main)
+
+(declare main_bolStr main_n main_str1 main_x main_y parseBool_l)
+
+(defn parseBool [parseBool_s]
+  (try (do (def parseBool_l (clojure.string/lower-case parseBool_s)) (if (or (or (or (or (= parseBool_l "1") (= parseBool_l "t")) (= parseBool_l true)) (= parseBool_l "yes")) (= parseBool_l "y")) true false)) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn main []
+  (do (def main_n true) (println main_n) (println "bool") (def main_n (not main_n)) (println main_n) (def main_x 5) (def main_y 8) (println "x == y:" (= main_x main_y)) (println "x < y:" (< main_x main_y)) (println "\nConvert String into Boolean Data type\n") (def main_str1 "japan") (println "Before :" "string") (def main_bolStr (parseBool main_str1)) (println "After :" "bool")))
+
+(defn -main []
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (main)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
+
+(-main)

--- a/tests/rosetta/transpiler/Clojure/boolean-values.out
+++ b/tests/rosetta/transpiler/Clojure/boolean-values.out
@@ -1,0 +1,10 @@
+true
+bool
+false
+x == y: false
+x < y: true
+
+Convert String into Boolean Data type
+
+Before : string
+After : bool

--- a/transpiler/x/clj/ROSETTA.md
+++ b/transpiler/x/clj/ROSETTA.md
@@ -1,7 +1,7 @@
 # Clojure Rosetta Transpiler
 
-Completed: 178/491
-Last updated: 2025-08-03 17:10 +0700
+Completed: 179/491
+Last updated: 2025-08-03 17:39 +0700
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
@@ -135,7 +135,7 @@ Last updated: 2025-08-03 17:10 +0700
 | 128 | bitwise-io-2 |   |  |  |
 | 129 | bitwise-operations | ✓ | 45.75ms | 25.1 MB |
 | 130 | blum-integer | ✓ | 3.36ms | 3.5 MB |
-| 131 | boolean-values |   |  |  |
+| 131 | boolean-values | ✓ | 35.813ms | 19.0 MB |
 | 132 | box-the-compass |   |  |  |
 | 133 | boyer-moore-string-search |   |  |  |
 | 134 | brazilian-numbers |   |  |  |


### PR DESCRIPTION
## Summary
- transpile Rosetta "boolean-values" example to Clojure
- record benchmark results in `ROSETTA.md`

## Testing
- `MOCHI_ROSETTA_INDEX=131 go test -tags=slow ./transpiler/x/clj -run TestRosettaClojure`
- `MOCHI_ROSETTA_INDEX=131 MOCHI_BENCHMARK=1 go test -tags=slow ./transpiler/x/clj -run TestRosettaClojure`


------
https://chatgpt.com/codex/tasks/task_e_688f3b4d51d083209c49871a37c955c6