### PR TITLE
transpiler/clj: add box-the-compass Rosetta example

### DIFF
--- a/tests/rosetta/transpiler/Clojure/box-the-compass.bench
+++ b/tests/rosetta/transpiler/Clojure/box-the-compass.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 54033,
+  "memory_bytes": 22597032,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/box-the-compass.clj
+++ b/tests/rosetta/transpiler/Clojure/box-the-compass.clj
@@ -1,0 +1,45 @@
+(ns main (:refer-clojure :exclude [padLeft padRight indexOf format2 cpx degrees2compasspoint]))
+
+(require 'clojure.set)
+
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
+(defn padStart [s w p]
+  (loop [out (str s)] (if (< (count out) w) (recur (str p out)) out)))
+
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
+(declare padLeft padRight indexOf format2 cpx degrees2compasspoint)
+
+(declare cpx_x format2_idx format2_need format2_s indexOf_i main_compassPoint main_cp main_h main_headings main_i main_idx padLeft_n padLeft_res padRight_i padRight_out)
+
+(defn padLeft [padLeft_s padLeft_w]
+  (try (do (def padLeft_res "") (def padLeft_n (- padLeft_w (count padLeft_s))) (while (> padLeft_n 0) (do (def padLeft_res (str padLeft_res " ")) (def padLeft_n (- padLeft_n 1)))) (throw (ex-info "return" {:v (str padLeft_res padLeft_s)}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn padRight [padRight_s padRight_w]
+  (try (do (def padRight_out padRight_s) (def padRight_i (count padRight_s)) (while (< padRight_i padRight_w) (do (def padRight_out (str padRight_out " ")) (def padRight_i (+ padRight_i 1)))) (throw (ex-info "return" {:v padRight_out}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn indexOf [indexOf_s indexOf_ch]
+  (try (do (def indexOf_i 0) (while (< indexOf_i (count indexOf_s)) (do (when (= (subs indexOf_s indexOf_i (+ indexOf_i 1)) indexOf_ch) (throw (ex-info "return" {:v indexOf_i}))) (def indexOf_i (+ indexOf_i 1)))) (throw (ex-info "return" {:v (- 1)}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn format2 [format2_f]
+  (try (do (def format2_s (str format2_f)) (def format2_idx (indexOf format2_s ".")) (if (< format2_idx 0) (def format2_s (str format2_s ".00")) (do (def format2_need (+ format2_idx 3)) (if (> (count format2_s) format2_need) (def format2_s (subs format2_s 0 format2_need)) (while (< (count format2_s) format2_need) (def format2_s (str format2_s "0")))))) (throw (ex-info "return" {:v format2_s}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn cpx [cpx_h]
+  (try (do (def cpx_x (int (+ (/ cpx_h 11.25) 0.5))) (def cpx_x (mod cpx_x 32)) (when (< cpx_x 0) (def cpx_x (+ cpx_x 32))) (throw (ex-info "return" {:v cpx_x}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(def main_compassPoint ["North" "North by east" "North-northeast" "Northeast by north" "Northeast" "Northeast by east" "East-northeast" "East by north" "East" "East by south" "East-southeast" "Southeast by east" "Southeast" "Southeast by south" "South-southeast" "South by east" "South" "South by west" "South-southwest" "Southwest by south" "Southwest" "Southwest by west" "West-southwest" "West by south" "West" "West by north" "West-northwest" "Northwest by west" "Northwest" "Northwest by north" "North-northwest" "North by west"])
+
+(defn degrees2compasspoint [degrees2compasspoint_h]
+  (try (throw (ex-info "return" {:v (nth main_compassPoint (cpx degrees2compasspoint_h))})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(def main_headings [0.0 16.87 16.88 33.75 50.62 50.63 67.5 84.37 84.38 101.25 118.12 118.13 135.0 151.87 151.88 168.75 185.62 185.63 202.5 219.37 219.38 236.25 253.12 253.13 270.0 286.87 286.88 303.75 320.62 320.63 337.5 354.37 354.38])
+
+(def main_i 0)
+
+(defn -main []
+  (println "Index  Compass point         Degree")
+  (while (< main_i (count main_headings)) (do (def main_h (nth main_headings main_i)) (def main_idx (+ (mod main_i 32) 1)) (def main_cp (degrees2compasspoint main_h)) (println (str (str (str (str (str (padLeft (str main_idx) 4) "   ") (padRight main_cp 19)) " ") (format2 main_h)) "°")) (def main_i (+ main_i 1)))))
+
+(-main)

--- a/tests/rosetta/transpiler/Clojure/box-the-compass.out
+++ b/tests/rosetta/transpiler/Clojure/box-the-compass.out
@@ -1,0 +1,34 @@
+Index  Compass point         Degree
+   1   North               0.00°
+   2   North by east       16.87°
+   3   North-northeast     16.88°
+   4   Northeast by north  33.75°
+   5   Northeast           50.62°
+   6   Northeast by east   50.63°
+   7   East-northeast      67.50°
+   8   East by north       84.37°
+   9   East                84.38°
+  10   East by south       101.25°
+  11   East-southeast      118.12°
+  12   Southeast by east   118.13°
+  13   Southeast           135.00°
+  14   Southeast by south  151.87°
+  15   South-southeast     151.88°
+  16   South by east       168.75°
+  17   South               185.62°
+  18   South by west       185.63°
+  19   South-southwest     202.50°
+  20   Southwest by south  219.37°
+  21   Southwest           219.38°
+  22   Southwest by west   236.25°
+  23   West-southwest      253.12°
+  24   West by south       253.13°
+  25   West                270.00°
+  26   West by north       286.87°
+  27   West-northwest      286.88°
+  28   Northwest by west   303.75°
+  29   Northwest           320.62°
+  30   Northwest by north  320.63°
+  31   North-northwest     337.50°
+  32   North by west       354.37°
+   1   North               354.38°

--- a/transpiler/x/clj/ROSETTA.md
+++ b/transpiler/x/clj/ROSETTA.md
@@ -1,7 +1,7 @@
 # Clojure Rosetta Transpiler
 
-Completed: 179/491
-Last updated: 2025-08-03 17:39 +0700
+Completed: 180/491
+Last updated: 2025-08-03 17:49 +0700
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
@@ -136,7 +136,7 @@ Last updated: 2025-08-03 17:39 +0700
 | 129 | bitwise-operations | ✓ | 45.75ms | 25.1 MB |
 | 130 | blum-integer | ✓ | 3.36ms | 3.5 MB |
 | 131 | boolean-values | ✓ | 35.813ms | 19.0 MB |
-| 132 | box-the-compass |   |  |  |
+| 132 | box-the-compass | ✓ | 54.033ms | 21.6 MB |
 | 133 | boyer-moore-string-search |   |  |  |
 | 134 | brazilian-numbers |   |  |  |
 | 135 | break-oo-privacy |   |  |  |


### PR DESCRIPTION
## Summary
- transpile Rosetta Code "box-the-compass" example (index 132) to Clojure
- record program output and benchmark data
- update Clojure Rosetta progress table

## Testing
- `go test -tags slow ./transpiler/x/clj -run Rosetta -index 132`
- `MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/clj -run Rosetta -index 132`


------
https://chatgpt.com/codex/tasks/task_e_688f3d3da0548320a8ee260f51bf79bd