### PR TITLE
chore(kt): add transpiled calendar program

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/calendar---for-real-programmers-2.bench
+++ b/tests/rosetta/transpiler/Kotlin/calendar---for-real-programmers-2.bench
@@ -1,0 +1,1 @@
+{"duration_us":55658, "memory_bytes":139256, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/calendar---for-real-programmers-2.kt
+++ b/tests/rosetta/transpiler/Kotlin/calendar---for-real-programmers-2.kt
@@ -1,0 +1,95 @@
+import java.math.BigInteger
+
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+var daysInMonth: MutableList<Int> = mutableListOf(31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+var start: MutableList<Int> = mutableListOf(3, 6, 6, 2, 4, 0, 2, 5, 1, 3, 6, 1)
+var months: MutableList<String> = mutableListOf(" January ", " February", "  March  ", "  April  ", "   May   ", "   June  ", "   July  ", "  August ", "September", " October ", " November", " December")
+var days: MutableList<String> = mutableListOf("Su", "Mo", "Tu", "We", "Th", "Fr", "Sa")
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        println("                                [SNOOPY]\n")
+        println("                                  1969\n")
+        var qtr: Int = 0
+        while (qtr < 4) {
+            var mi: Int = 0
+            while (mi < 3) {
+                println(listOf(("      " + months[(qtr * 3) + mi]!!) + "           ", false).joinToString(" "))
+                mi = mi + 1
+            }
+            println("")
+            mi = 0
+            while (mi < 3) {
+                var d: Int = 0
+                while (d < 7) {
+                    println(listOf(" " + days[d]!!, false).joinToString(" "))
+                    d = d + 1
+                }
+                println(listOf("     ", false).joinToString(" "))
+                mi = mi + 1
+            }
+            println("")
+            var week: Int = 0
+            while (week < 6) {
+                mi = 0
+                while (mi < 3) {
+                    var day: Int = 0
+                    while (day < 7) {
+                        var m: BigInteger = ((qtr * 3) + mi).toBigInteger()
+                        var _val: BigInteger = ((((week * 7) + day) - start[(m).toInt()]!!) + 1).toBigInteger()
+                        if ((_val.compareTo((1).toBigInteger()) >= 0) && (_val.compareTo((daysInMonth[(m).toInt()]!!).toBigInteger()) <= 0)) {
+                            var s: String = _val.toString()
+                            if (s.length == 1) {
+                                s = " " + s
+                            }
+                            println(listOf(" " + s, false).joinToString(" "))
+                        } else {
+                            println(listOf("   ", false).joinToString(" "))
+                        }
+                        day = day + 1
+                    }
+                    println(listOf("     ", false).joinToString(" "))
+                    mi = mi + 1
+                }
+                println("")
+                week = week + 1
+            }
+            println("")
+            qtr = qtr + 1
+        }
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/calendar---for-real-programmers-2.out
+++ b/tests/rosetta/transpiler/Kotlin/calendar---for-real-programmers-2.out
@@ -1,0 +1,722 @@
+[SNOOPY]
+
+                                  1969
+
+       January             false
+       February            false
+        March              false
+
+ Su false
+ Mo false
+ Tu false
+ We false
+ Th false
+ Fr false
+ Sa false
+      false
+ Su false
+ Mo false
+ Tu false
+ We false
+ Th false
+ Fr false
+ Sa false
+      false
+ Su false
+ Mo false
+ Tu false
+ We false
+ Th false
+ Fr false
+ Sa false
+      false
+
+    false
+    false
+    false
+  1 false
+  2 false
+  3 false
+  4 false
+      false
+    false
+    false
+    false
+    false
+    false
+    false
+  1 false
+      false
+    false
+    false
+    false
+    false
+    false
+    false
+  1 false
+      false
+
+  5 false
+  6 false
+  7 false
+  8 false
+  9 false
+ 10 false
+ 11 false
+      false
+  2 false
+  3 false
+  4 false
+  5 false
+  6 false
+  7 false
+  8 false
+      false
+  2 false
+  3 false
+  4 false
+  5 false
+  6 false
+  7 false
+  8 false
+      false
+
+ 12 false
+ 13 false
+ 14 false
+ 15 false
+ 16 false
+ 17 false
+ 18 false
+      false
+  9 false
+ 10 false
+ 11 false
+ 12 false
+ 13 false
+ 14 false
+ 15 false
+      false
+  9 false
+ 10 false
+ 11 false
+ 12 false
+ 13 false
+ 14 false
+ 15 false
+      false
+
+ 19 false
+ 20 false
+ 21 false
+ 22 false
+ 23 false
+ 24 false
+ 25 false
+      false
+ 16 false
+ 17 false
+ 18 false
+ 19 false
+ 20 false
+ 21 false
+ 22 false
+      false
+ 16 false
+ 17 false
+ 18 false
+ 19 false
+ 20 false
+ 21 false
+ 22 false
+      false
+
+ 26 false
+ 27 false
+ 28 false
+ 29 false
+ 30 false
+ 31 false
+    false
+      false
+ 23 false
+ 24 false
+ 25 false
+ 26 false
+ 27 false
+ 28 false
+    false
+      false
+ 23 false
+ 24 false
+ 25 false
+ 26 false
+ 27 false
+ 28 false
+ 29 false
+      false
+
+    false
+    false
+    false
+    false
+    false
+    false
+    false
+      false
+    false
+    false
+    false
+    false
+    false
+    false
+    false
+      false
+ 30 false
+ 31 false
+    false
+    false
+    false
+    false
+    false
+      false
+
+
+        April              false
+         May               false
+         June              false
+
+ Su false
+ Mo false
+ Tu false
+ We false
+ Th false
+ Fr false
+ Sa false
+      false
+ Su false
+ Mo false
+ Tu false
+ We false
+ Th false
+ Fr false
+ Sa false
+      false
+ Su false
+ Mo false
+ Tu false
+ We false
+ Th false
+ Fr false
+ Sa false
+      false
+
+    false
+    false
+  1 false
+  2 false
+  3 false
+  4 false
+  5 false
+      false
+    false
+    false
+    false
+    false
+  1 false
+  2 false
+  3 false
+      false
+  1 false
+  2 false
+  3 false
+  4 false
+  5 false
+  6 false
+  7 false
+      false
+
+  6 false
+  7 false
+  8 false
+  9 false
+ 10 false
+ 11 false
+ 12 false
+      false
+  4 false
+  5 false
+  6 false
+  7 false
+  8 false
+  9 false
+ 10 false
+      false
+  8 false
+  9 false
+ 10 false
+ 11 false
+ 12 false
+ 13 false
+ 14 false
+      false
+
+ 13 false
+ 14 false
+ 15 false
+ 16 false
+ 17 false
+ 18 false
+ 19 false
+      false
+ 11 false
+ 12 false
+ 13 false
+ 14 false
+ 15 false
+ 16 false
+ 17 false
+      false
+ 15 false
+ 16 false
+ 17 false
+ 18 false
+ 19 false
+ 20 false
+ 21 false
+      false
+
+ 20 false
+ 21 false
+ 22 false
+ 23 false
+ 24 false
+ 25 false
+ 26 false
+      false
+ 18 false
+ 19 false
+ 20 false
+ 21 false
+ 22 false
+ 23 false
+ 24 false
+      false
+ 22 false
+ 23 false
+ 24 false
+ 25 false
+ 26 false
+ 27 false
+ 28 false
+      false
+
+ 27 false
+ 28 false
+ 29 false
+ 30 false
+    false
+    false
+    false
+      false
+ 25 false
+ 26 false
+ 27 false
+ 28 false
+ 29 false
+ 30 false
+ 31 false
+      false
+ 29 false
+ 30 false
+    false
+    false
+    false
+    false
+    false
+      false
+
+    false
+    false
+    false
+    false
+    false
+    false
+    false
+      false
+    false
+    false
+    false
+    false
+    false
+    false
+    false
+      false
+    false
+    false
+    false
+    false
+    false
+    false
+    false
+      false
+
+
+         July              false
+        August             false
+      September            false
+
+ Su false
+ Mo false
+ Tu false
+ We false
+ Th false
+ Fr false
+ Sa false
+      false
+ Su false
+ Mo false
+ Tu false
+ We false
+ Th false
+ Fr false
+ Sa false
+      false
+ Su false
+ Mo false
+ Tu false
+ We false
+ Th false
+ Fr false
+ Sa false
+      false
+
+    false
+    false
+  1 false
+  2 false
+  3 false
+  4 false
+  5 false
+      false
+    false
+    false
+    false
+    false
+    false
+  1 false
+  2 false
+      false
+    false
+  1 false
+  2 false
+  3 false
+  4 false
+  5 false
+  6 false
+      false
+
+  6 false
+  7 false
+  8 false
+  9 false
+ 10 false
+ 11 false
+ 12 false
+      false
+  3 false
+  4 false
+  5 false
+  6 false
+  7 false
+  8 false
+  9 false
+      false
+  7 false
+  8 false
+  9 false
+ 10 false
+ 11 false
+ 12 false
+ 13 false
+      false
+
+ 13 false
+ 14 false
+ 15 false
+ 16 false
+ 17 false
+ 18 false
+ 19 false
+      false
+ 10 false
+ 11 false
+ 12 false
+ 13 false
+ 14 false
+ 15 false
+ 16 false
+      false
+ 14 false
+ 15 false
+ 16 false
+ 17 false
+ 18 false
+ 19 false
+ 20 false
+      false
+
+ 20 false
+ 21 false
+ 22 false
+ 23 false
+ 24 false
+ 25 false
+ 26 false
+      false
+ 17 false
+ 18 false
+ 19 false
+ 20 false
+ 21 false
+ 22 false
+ 23 false
+      false
+ 21 false
+ 22 false
+ 23 false
+ 24 false
+ 25 false
+ 26 false
+ 27 false
+      false
+
+ 27 false
+ 28 false
+ 29 false
+ 30 false
+ 31 false
+    false
+    false
+      false
+ 24 false
+ 25 false
+ 26 false
+ 27 false
+ 28 false
+ 29 false
+ 30 false
+      false
+ 28 false
+ 29 false
+ 30 false
+    false
+    false
+    false
+    false
+      false
+
+    false
+    false
+    false
+    false
+    false
+    false
+    false
+      false
+ 31 false
+    false
+    false
+    false
+    false
+    false
+    false
+      false
+    false
+    false
+    false
+    false
+    false
+    false
+    false
+      false
+
+
+       October             false
+       November            false
+       December            false
+
+ Su false
+ Mo false
+ Tu false
+ We false
+ Th false
+ Fr false
+ Sa false
+      false
+ Su false
+ Mo false
+ Tu false
+ We false
+ Th false
+ Fr false
+ Sa false
+      false
+ Su false
+ Mo false
+ Tu false
+ We false
+ Th false
+ Fr false
+ Sa false
+      false
+
+    false
+    false
+    false
+  1 false
+  2 false
+  3 false
+  4 false
+      false
+    false
+    false
+    false
+    false
+    false
+    false
+  1 false
+      false
+    false
+  1 false
+  2 false
+  3 false
+  4 false
+  5 false
+  6 false
+      false
+
+  5 false
+  6 false
+  7 false
+  8 false
+  9 false
+ 10 false
+ 11 false
+      false
+  2 false
+  3 false
+  4 false
+  5 false
+  6 false
+  7 false
+  8 false
+      false
+  7 false
+  8 false
+  9 false
+ 10 false
+ 11 false
+ 12 false
+ 13 false
+      false
+
+ 12 false
+ 13 false
+ 14 false
+ 15 false
+ 16 false
+ 17 false
+ 18 false
+      false
+  9 false
+ 10 false
+ 11 false
+ 12 false
+ 13 false
+ 14 false
+ 15 false
+      false
+ 14 false
+ 15 false
+ 16 false
+ 17 false
+ 18 false
+ 19 false
+ 20 false
+      false
+
+ 19 false
+ 20 false
+ 21 false
+ 22 false
+ 23 false
+ 24 false
+ 25 false
+      false
+ 16 false
+ 17 false
+ 18 false
+ 19 false
+ 20 false
+ 21 false
+ 22 false
+      false
+ 21 false
+ 22 false
+ 23 false
+ 24 false
+ 25 false
+ 26 false
+ 27 false
+      false
+
+ 26 false
+ 27 false
+ 28 false
+ 29 false
+ 30 false
+ 31 false
+    false
+      false
+ 23 false
+ 24 false
+ 25 false
+ 26 false
+ 27 false
+ 28 false
+ 29 false
+      false
+ 28 false
+ 29 false
+ 30 false
+ 31 false
+    false
+    false
+    false
+      false
+
+    false
+    false
+    false
+    false
+    false
+    false
+    false
+      false
+ 30 false
+    false
+    false
+    false
+    false
+    false
+    false
+      false
+    false
+    false
+    false
+    false
+    false
+    false
+    false
+      false

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-08-03 17:35 +0700
+Last updated: 2025-08-03 21:05 +0700
 
-Completed tasks: **268/491**
+Completed tasks: **269/491**
 
 ### Checklist
 | Index | Name | Status | Duration | Memory |
@@ -153,7 +153,7 @@ Completed tasks: **268/491**
 | 142 | caesar-cipher-2 | ✓ | 43.42ms | 116.0 KB |
 | 143 | calculating-the-value-of-e |  |  |  |
 | 144 | calendar---for-real-programmers-1 | ✓ | 65.61ms | 136.0 KB |
-| 145 | calendar---for-real-programmers-2 |  |  |  |
+| 145 | calendar---for-real-programmers-2 | ✓ | 55.66ms | 136.0 KB |
 | 146 | calendar |  |  |  |
 | 147 | calkin-wilf-sequence |  |  |  |
 | 148 | call-a-foreign-language-function |  |  |  |


### PR DESCRIPTION
## Summary
- add Kotlin transcription of `calendar---for-real-programmers-2`
- record benchmark and output files
- refresh Rosetta checklist metadata

## Testing
- `ROSETTA_INDEX=145 go test ./transpiler/x/kt -run TestRosettaKotlin -tags slow -count=1`
- `ROSETTA_INDEX=145 MOCHI_BENCHMARK=true go test ./transpiler/x/kt -run TestRosettaKotlin -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_688f6cc5d8888320803e11f84703bf05