### PR TITLE
scheme: use monotonic time for benchmark

### DIFF
--- a/tests/rosetta/transpiler/scheme/equilibrium-index.bench
+++ b/tests/rosetta/transpiler/scheme/equilibrium-index.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": -693671,
-  "memory_bytes": 12689408,
+  "duration_us": 17372000,
+  "memory_bytes": 13017088,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/scheme/equilibrium-index.scm
+++ b/tests/rosetta/transpiler/scheme/equilibrium-index.scm
@@ -1,11 +1,11 @@
-;; Generated on 2025-08-03 15:40 +0700
-(import (rename (scheme base) (list _list)))
+;; Generated on 2025-08-03 22:12 +0700
+(import (scheme base))
 (import (scheme time))
 (import (chibi string))
 (import (only (scheme char) string-upcase string-downcase))
-(import (scheme write))
 (import (srfi 69))
 (import (srfi 1))
+(define _list list)
 (import (chibi time) (srfi 98))
 (define _now_seeded #f)
 (define _now_seed 0)
@@ -100,4 +100,4 @@
                   (loop (_substring r (+ idx (string-length del)) (string-length r))
                         (cons (_substring r 0 idx) acc)))
                 (reverse (cons r acc)))))))))
-(let ((start10 (now))) (begin (define seed (modulo (now) 2147483647)) (define (randN n) (call/cc (lambda (ret1) (begin (set! seed (modulo (_add (* seed 1664525) 1013904223) 2147483647)) (ret1 (modulo seed n)))))) (define (eqIndices xs) (call/cc (lambda (ret2) (let ((r 0)) (begin (let ((i 0)) (begin (call/cc (lambda (break4) (letrec ((loop3 (lambda () (if (< i (cond ((string? xs) (string-length xs)) ((hash-table? xs) (hash-table-size xs)) (else (length xs)))) (begin (set! r (+ r (list-ref xs i))) (set! i (+ i 1)) (loop3)) (quote ()))))) (loop3)))) (let ((l 0)) (begin (let ((eq (_list))) (begin (set! i 0) (call/cc (lambda (break6) (letrec ((loop5 (lambda () (if (< i (cond ((string? xs) (string-length xs)) ((hash-table? xs) (hash-table-size xs)) (else (length xs)))) (begin (set! r (- r (list-ref xs i))) (if (equal? l r) (begin (set! eq (append eq (_list i)))) (quote ())) (set! l (+ l (list-ref xs i))) (set! i (+ i 1)) (loop5)) (quote ()))))) (loop5)))) (ret2 eq)))))))))))) (define (main) (call/cc (lambda (ret7) (begin (_display (to-str (eqIndices (_list (- 7) 1 5 2 (- 4) 3 0)))) (newline) (let ((verylong (_list))) (begin (let ((i 0)) (begin (call/cc (lambda (break9) (letrec ((loop8 (lambda () (if (< i 10000) (begin (set! seed (modulo (_add (* seed 1664525) 1013904223) 2147483647)) (set! verylong (append verylong (_list (- (modulo seed 1001) 500)))) (set! i (+ i 1)) (loop8)) (quote ()))))) (loop8)))) (_display (to-str (eqIndices verylong))) (newline))))))))) (main) (let ((end11 (now))) (let ((dur12 (quotient (- end11 start10) 1000))) (begin (_display (string-append "{\n  \"duration_us\": " (number->string dur12) ",\n  \"memory_bytes\": " (number->string (_mem)) ",\n  \"name\": \"main\"\n}")) (newline))))))
+(let ((start10 (current-jiffy)) (jps13 (jiffies-per-second))) (begin (define seed (modulo (now) 2147483647)) (define (randN n) (call/cc (lambda (ret1) (begin (set! seed (modulo (_add (* seed 1664525) 1013904223) 2147483647)) (ret1 (modulo seed n)))))) (define (eqIndices xs) (call/cc (lambda (ret2) (let ((r 0)) (begin (let ((i 0)) (begin (call/cc (lambda (break4) (letrec ((loop3 (lambda () (if (< i (cond ((string? xs) (string-length xs)) ((hash-table? xs) (hash-table-size xs)) (else (length xs)))) (begin (set! r (+ r (list-ref xs i))) (set! i (+ i 1)) (loop3)) (quote ()))))) (loop3)))) (let ((l 0)) (begin (let ((eq (_list))) (begin (set! i 0) (call/cc (lambda (break6) (letrec ((loop5 (lambda () (if (< i (cond ((string? xs) (string-length xs)) ((hash-table? xs) (hash-table-size xs)) (else (length xs)))) (begin (set! r (- r (list-ref xs i))) (if (equal? l r) (begin (set! eq (append eq (_list i)))) (quote ())) (set! l (+ l (list-ref xs i))) (set! i (+ i 1)) (loop5)) (quote ()))))) (loop5)))) (ret2 eq)))))))))))) (define (main) (call/cc (lambda (ret7) (begin (_display (to-str (eqIndices (_list (- 7) 1 5 2 (- 4) 3 0)))) (newline) (let ((verylong (_list))) (begin (let ((i 0)) (begin (call/cc (lambda (break9) (letrec ((loop8 (lambda () (if (< i 10000) (begin (set! seed (modulo (_add (* seed 1664525) 1013904223) 2147483647)) (set! verylong (append verylong (_list (- (modulo seed 1001) 500)))) (set! i (+ i 1)) (loop8)) (quote ()))))) (loop8)))) (_display (to-str (eqIndices verylong))) (newline))))))))) (main) (let ((end11 (current-jiffy))) (let ((dur12 (quotient (* (- end11 start10) 1000000) jps13))) (begin (_display (string-append "{\n  \"duration_us\": " (number->string dur12) ",\n  \"memory_bytes\": " (number->string (_mem)) ",\n  \"name\": \"main\"\n}")) (newline))))))

--- a/transpiler/x/scheme/ROSETTA.md
+++ b/transpiler/x/scheme/ROSETTA.md
@@ -3,7 +3,7 @@
 Generated Scheme code for Rosetta Code tasks under `tests/rosetta/x/Mochi`.
 
 ## Checklist (409/491)
-Last updated: 2025-08-03 10:57 UTC
+Last updated: 2025-08-03 15:21 UTC
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
@@ -363,7 +363,7 @@ Last updated: 2025-08-03 10:57 UTC
 | 354 | environment-variables-1 | ✓ | 571.223ms | 12.0 MB |
 | 355 | environment-variables-2 | ✓ | 571.223ms | 12.1 MB |
 | 356 | equal-prime-and-composite-sums |   |  |  |
-| 357 | equilibrium-index | ✓ |  |  |
+| 357 | equilibrium-index | ✓ | 17.372s | 12.4 MB |
 | 358 | erd-s-nicolas-numbers |   |  |  |
 | 359 | erd-s-selfridge-categorization-of-primes | ✓ | 571.223ms | 32.8 MB |
 | 360 | esthetic-numbers |   |  |  |


### PR DESCRIPTION
## Summary
- use Scheme's jiffies to compute benchmark durations so they stay positive
- add generated Scheme code and benchmark output for Rosetta task 357 (equilibrium-index)

## Testing
- `MOCHI_ROSETTA_INDEX=357 MOCHI_BENCHMARK=1 go test ./transpiler/x/scheme -tags=slow -run TestSchemeTranspiler_Rosetta_Golden -update-rosetta-scheme -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688f7c8be8648320a35a983578b45d49