### PR TITLE
scheme: fix benchmark timing for transpiler

### DIFF
--- a/tests/rosetta/transpiler/scheme/equilibrium-index.bench
+++ b/tests/rosetta/transpiler/scheme/equilibrium-index.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": -693671,
-  "memory_bytes": 12689408,
+  "duration_us": 12732711,
+  "memory_bytes": 13148160,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/scheme/equilibrium-index.scm
+++ b/tests/rosetta/transpiler/scheme/equilibrium-index.scm
@@ -1,11 +1,11 @@
-;; Generated on 2025-08-03 15:40 +0700
-(import (rename (scheme base) (list _list)))
+;; Generated on 2025-08-03 22:49 +0700
+(import (scheme base))
 (import (scheme time))
 (import (chibi string))
 (import (only (scheme char) string-upcase string-downcase))
-(import (scheme write))
 (import (srfi 69))
 (import (srfi 1))
+(define _list list)
 (import (chibi time) (srfi 98))
 (define _now_seeded #f)
 (define _now_seed 0)
@@ -21,6 +21,7 @@
         _now_seed)
       (exact (floor (* (current-second) 1000000000))))
 )
+(define (_bench_now) (exact (floor (* (current-second) 1000000))))
 (define (_mem) (* 1024 (resource-usage-max-rss (get-resource-usage resource-usage/self))))
 (import (chibi json))
 (define (to-str x)
@@ -100,4 +101,4 @@
                   (loop (_substring r (+ idx (string-length del)) (string-length r))
                         (cons (_substring r 0 idx) acc)))
                 (reverse (cons r acc)))))))))
-(let ((start10 (now))) (begin (define seed (modulo (now) 2147483647)) (define (randN n) (call/cc (lambda (ret1) (begin (set! seed (modulo (_add (* seed 1664525) 1013904223) 2147483647)) (ret1 (modulo seed n)))))) (define (eqIndices xs) (call/cc (lambda (ret2) (let ((r 0)) (begin (let ((i 0)) (begin (call/cc (lambda (break4) (letrec ((loop3 (lambda () (if (< i (cond ((string? xs) (string-length xs)) ((hash-table? xs) (hash-table-size xs)) (else (length xs)))) (begin (set! r (+ r (list-ref xs i))) (set! i (+ i 1)) (loop3)) (quote ()))))) (loop3)))) (let ((l 0)) (begin (let ((eq (_list))) (begin (set! i 0) (call/cc (lambda (break6) (letrec ((loop5 (lambda () (if (< i (cond ((string? xs) (string-length xs)) ((hash-table? xs) (hash-table-size xs)) (else (length xs)))) (begin (set! r (- r (list-ref xs i))) (if (equal? l r) (begin (set! eq (append eq (_list i)))) (quote ())) (set! l (+ l (list-ref xs i))) (set! i (+ i 1)) (loop5)) (quote ()))))) (loop5)))) (ret2 eq)))))))))))) (define (main) (call/cc (lambda (ret7) (begin (_display (to-str (eqIndices (_list (- 7) 1 5 2 (- 4) 3 0)))) (newline) (let ((verylong (_list))) (begin (let ((i 0)) (begin (call/cc (lambda (break9) (letrec ((loop8 (lambda () (if (< i 10000) (begin (set! seed (modulo (_add (* seed 1664525) 1013904223) 2147483647)) (set! verylong (append verylong (_list (- (modulo seed 1001) 500)))) (set! i (+ i 1)) (loop8)) (quote ()))))) (loop8)))) (_display (to-str (eqIndices verylong))) (newline))))))))) (main) (let ((end11 (now))) (let ((dur12 (quotient (- end11 start10) 1000))) (begin (_display (string-append "{\n  \"duration_us\": " (number->string dur12) ",\n  \"memory_bytes\": " (number->string (_mem)) ",\n  \"name\": \"main\"\n}")) (newline))))))
+(let ((start10 (_bench_now))) (begin (define seed (modulo (now) 2147483647)) (define (randN n) (call/cc (lambda (ret1) (begin (set! seed (modulo (_add (* seed 1664525) 1013904223) 2147483647)) (ret1 (modulo seed n)))))) (define (eqIndices xs) (call/cc (lambda (ret2) (let ((r 0)) (begin (let ((i 0)) (begin (call/cc (lambda (break4) (letrec ((loop3 (lambda () (if (< i (cond ((string? xs) (string-length xs)) ((hash-table? xs) (hash-table-size xs)) (else (length xs)))) (begin (set! r (+ r (list-ref xs i))) (set! i (+ i 1)) (loop3)) (quote ()))))) (loop3)))) (let ((l 0)) (begin (let ((eq (_list))) (begin (set! i 0) (call/cc (lambda (break6) (letrec ((loop5 (lambda () (if (< i (cond ((string? xs) (string-length xs)) ((hash-table? xs) (hash-table-size xs)) (else (length xs)))) (begin (set! r (- r (list-ref xs i))) (if (equal? l r) (begin (set! eq (append eq (_list i)))) (quote ())) (set! l (+ l (list-ref xs i))) (set! i (+ i 1)) (loop5)) (quote ()))))) (loop5)))) (ret2 eq)))))))))))) (define (main) (call/cc (lambda (ret7) (begin (_display (to-str (eqIndices (_list (- 7) 1 5 2 (- 4) 3 0)))) (newline) (let ((verylong (_list))) (begin (let ((i 0)) (begin (call/cc (lambda (break9) (letrec ((loop8 (lambda () (if (< i 10000) (begin (set! seed (modulo (_add (* seed 1664525) 1013904223) 2147483647)) (set! verylong (append verylong (_list (- (modulo seed 1001) 500)))) (set! i (+ i 1)) (loop8)) (quote ()))))) (loop8)))) (_display (to-str (eqIndices verylong))) (newline))))))))) (main) (let ((end11 (_bench_now))) (let ((dur12 (- end11 start10))) (begin (_display (string-append "{\n  \"duration_us\": " (number->string dur12) ",\n  \"memory_bytes\": " (number->string (_mem)) ",\n  \"name\": \"main\"\n}")) (newline))))))

--- a/transpiler/x/scheme/ROSETTA.md
+++ b/transpiler/x/scheme/ROSETTA.md
@@ -3,7 +3,7 @@
 Generated Scheme code for Rosetta Code tasks under `tests/rosetta/x/Mochi`.
 
 ## Checklist (409/491)
-Last updated: 2025-08-03 10:57 UTC
+Last updated: 2025-08-03 16:02 UTC
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
@@ -363,7 +363,7 @@ Last updated: 2025-08-03 10:57 UTC
 | 354 | environment-variables-1 | ✓ | 571.223ms | 12.0 MB |
 | 355 | environment-variables-2 | ✓ | 571.223ms | 12.1 MB |
 | 356 | equal-prime-and-composite-sums |   |  |  |
-| 357 | equilibrium-index | ✓ |  |  |
+| 357 | equilibrium-index | ✓ | 12.732711s | 12.5 MB |
 | 358 | erd-s-nicolas-numbers |   |  |  |
 | 359 | erd-s-selfridge-categorization-of-primes | ✓ | 571.223ms | 32.8 MB |
 | 360 | esthetic-numbers |   |  |  |

--- a/transpiler/x/scheme/transpiler.go
+++ b/transpiler/x/scheme/transpiler.go
@@ -231,6 +231,7 @@ func header() []byte {
 		if !usesNow {
 			prelude += "(import (chibi time))\n"
 		}
+		prelude += "(define (_bench_now) (exact (floor (* (current-second) 1000000))))\n"
 		prelude += "(define (_mem) (* 1024 (resource-usage-max-rss (get-resource-usage resource-usage/self))))\n"
 	}
 	if usesLookupHost {
@@ -1006,21 +1007,21 @@ func Transpile(prog *parser.Program, env *types.Env) (*Program, error) {
 		innerLet2 := &List{Elems: []Node{
 			Symbol("let"),
 			&List{Elems: []Node{
-				&List{Elems: []Node{Symbol(durSym), &List{Elems: []Node{Symbol("quotient"), &List{Elems: []Node{Symbol("-"), Symbol(endSym), Symbol(startSym)}}, IntLit(1000)}}}},
+				&List{Elems: []Node{Symbol(durSym), &List{Elems: []Node{Symbol("-"), Symbol(endSym), Symbol(startSym)}}}},
 			}},
 			jsonCall,
 		}}
 		innerLet1 := &List{Elems: []Node{
 			Symbol("let"),
 			&List{Elems: []Node{
-				&List{Elems: []Node{Symbol(endSym), &List{Elems: []Node{Symbol("now")}}}},
+				&List{Elems: []Node{Symbol(endSym), &List{Elems: []Node{Symbol("_bench_now")}}}},
 			}},
 			innerLet2,
 		}}
 		inner := append(p.Forms, innerLet1)
 		p.Forms = []Node{&List{Elems: []Node{
 			Symbol("let"),
-			&List{Elems: []Node{&List{Elems: []Node{Symbol(startSym), &List{Elems: []Node{Symbol("now")}}}}}},
+			&List{Elems: []Node{&List{Elems: []Node{Symbol(startSym), &List{Elems: []Node{Symbol("_bench_now")}}}}}},
 			&List{Elems: append([]Node{Symbol("begin")}, inner...)},
 		}}}
 	}


### PR DESCRIPTION
## Summary
- use dedicated monotonic `_bench_now` for benchmarks
- wrap generated Scheme programs with `_bench_now` to compute duration
- record benchmark stats for equilibrium-index task

## Testing
- `MOCHI_ROSETTA_INDEX=357 MOCHI_BENCHMARK=1 go test -run Rosetta -update-rosetta-scheme -count=1 -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_688f80dc4cb0832091cffdcbfd0adbcc