### PR TITLE
Add Clojure transpiler output for break-oo-privacy example

### DIFF
--- a/tests/rosetta/transpiler/Clojure/break-oo-privacy.bench
+++ b/tests/rosetta/transpiler/Clojure/break-oo-privacy.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 3549,
+  "memory_bytes": 2621440,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/break-oo-privacy.clj
+++ b/tests/rosetta/transpiler/Clojure/break-oo-privacy.clj
@@ -1,0 +1,42 @@
+(ns main (:refer-clojure :exclude [examineAndModify anotherExample]))
+
+(require 'clojure.set)
+
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
+(defn padStart [s w p]
+  (loop [out (str s)] (if (< (count out) w) (recur (str p out)) out)))
+
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
+(declare examineAndModify anotherExample)
+
+(declare main_obj)
+
+(defn examineAndModify [examineAndModify_f_p]
+  (try (do (def examineAndModify_f examineAndModify_f_p) (println (str (str (str (str (str (str (str (str " v: {" (str (:Exported examineAndModify_f))) " ") (str (:unexported examineAndModify_f))) "} = {") (str (:Exported examineAndModify_f))) " ") (str (:unexported examineAndModify_f))) "}")) (println "    Idx Name       Type CanSet") (println "     0: Exported   int  true") (println "     1: unexported int  false") (def examineAndModify_f (assoc examineAndModify_f :Exported 16)) (def examineAndModify_f (assoc examineAndModify_f :unexported 44)) (println "  modified unexported field via unsafe") (throw (ex-info "return" {:v examineAndModify_f}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn anotherExample []
+  (println "bufio.ReadByte returned error: unsafely injected error value into bufio inner workings"))
+
+(def main_obj {:Exported 12 :unexported 42})
+
+(defn -main []
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (println (str (str (str (str "obj: {" (str (:Exported main_obj))) " ") (str (:unexported main_obj))) "}"))
+      (def main_obj (examineAndModify main_obj))
+      (println (str (str (str (str "obj: {" (str (:Exported main_obj))) " ") (str (:unexported main_obj))) "}"))
+      (anotherExample)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
+
+(-main)

--- a/tests/rosetta/transpiler/Clojure/break-oo-privacy.out
+++ b/tests/rosetta/transpiler/Clojure/break-oo-privacy.out
@@ -1,0 +1,8 @@
+obj: {12 42}
+ v: {12 42} = {12 42}
+    Idx Name       Type CanSet
+     0: Exported   int  true
+     1: unexported int  false
+  modified unexported field via unsafe
+obj: {16 44}
+bufio.ReadByte returned error: unsafely injected error value into bufio inner workings

--- a/transpiler/x/clj/ROSETTA.md
+++ b/transpiler/x/clj/ROSETTA.md
@@ -1,7 +1,7 @@
 # Clojure Rosetta Transpiler
 
-Completed: 181/491
-Last updated: 2025-08-03 21:29 +0700
+Completed: 182/491
+Last updated: 2025-08-03 23:13 +0700
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
@@ -139,7 +139,7 @@ Last updated: 2025-08-03 21:29 +0700
 | 132 | box-the-compass | ✓ | 54.033ms | 21.6 MB |
 | 133 | boyer-moore-string-search | ✓ | 33.226ms | 21.0 MB |
 | 134 | brazilian-numbers |   |  |  |
-| 135 | break-oo-privacy |   |  |  |
+| 135 | break-oo-privacy | ✓ | 3.549ms | 2.5 MB |
 | 136 | brilliant-numbers |   |  |  |
 | 137 | brownian-tree |   |  |  |
 | 138 | bulls-and-cows-player |   |  |  |


### PR DESCRIPTION
## Summary
- add Rosetta Clojure transpiler output, benchmark, and expected output for `break-oo-privacy`
- update `ROSETTA.md` progress table to include example 135

## Testing
- `MOCHI_ROSETTA_INDEX=135 MOCHI_BENCHMARK=1 go test -tags=slow -run TestRosettaClojure -v ./transpiler/x/clj`


------
https://chatgpt.com/codex/tasks/task_e_688f8913191c8320a4c94ae3b307d4c6