### PR TITLE
chore: update Kotlin Rosetta benchmark

### DIFF
--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-08-03 23:38 +0700
+Last updated: 2025-08-03 23:46 +0700
 
 Completed tasks: **273/491**
 


### PR DESCRIPTION
## Summary
- refresh Kotlin Rosetta checklist timestamp

## Testing
- `ROSETTA_INDEX=200 MOCHI_BENCHMARK=true go test -tags slow ./transpiler/x/kt -run TestRosettaKotlin -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688f922f1d688320bf8cfa1fc4f5e466