### PR TITLE
fs: add Rosetta output for even-or-odd

### DIFF
--- a/tests/rosetta/transpiler/FS/even-or-odd.bench
+++ b/tests/rosetta/transpiler/FS/even-or-odd.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 538,
+  "memory_bytes": 54784,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/even-or-odd.fs
+++ b/tests/rosetta/transpiler/FS/even-or-odd.fs
@@ -1,0 +1,122 @@
+// Generated 2025-08-04 00:30 +0700
+
+exception Return
+let mutable __ret = ()
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+let _substring (s:string) (start:int) (finish:int) =
+    let len = String.length s
+    let mutable st = if start < 0 then len + start else start
+    let mutable en = if finish < 0 then len + finish else finish
+    if st < 0 then st <- 0
+    if st > len then st <- len
+    if en > len then en <- len
+    if st > en then st <- en
+    s.Substring(st, en - st)
+
+let rec parseBigInt (str: string) =
+    let mutable __ret : bigint = Unchecked.defaultof<bigint>
+    let mutable str = str
+    try
+        let mutable i: int = 0
+        let mutable neg: bool = false
+        if ((String.length (str)) > 0) && ((_substring str 0 1) = "-") then
+            neg <- true
+            i <- 1
+        let mutable n: bigint = bigint 0
+        while i < (String.length (str)) do
+            let ch: string = _substring str i (i + 1)
+            let d: int = int ch
+            n <- (n * (bigint 10)) + (bigint d)
+            i <- i + 1
+        if neg then
+            n <- -n
+        __ret <- n
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and pad (n: int) (width: int) =
+    let mutable __ret : string = Unchecked.defaultof<string>
+    let mutable n = n
+    let mutable width = width
+    try
+        let mutable s: string = string (n)
+        while (String.length (s)) < width do
+            s <- " " + s
+        __ret <- s
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and showInt (n: int) =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    let mutable n = n
+    try
+        let mutable line: string = ("Testing integer " + (pad (n) (3))) + ":  "
+        if (((n % 2 + 2) % 2)) = 0 then
+            line <- line + "even "
+        else
+            line <- line + " odd "
+        if (((n % 2 + 2) % 2)) = 0 then
+            line <- line + "even"
+        else
+            line <- line + " odd"
+        printfn "%s" (line)
+        __ret
+    with
+        | Return -> __ret
+and showBig (s: string) =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    let mutable s = s
+    try
+        let b: bigint = parseBigInt (s)
+        let mutable line: string = ("Testing big integer " + (string (b))) + ":  "
+        if (((b % (bigint 2) + (bigint 2)) % (bigint 2))) = (bigint 0) then
+            line <- line + "even"
+        else
+            line <- line + "odd"
+        printfn "%s" (line)
+        __ret
+    with
+        | Return -> __ret
+and main () =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    try
+        let __bench_start = _now()
+        let __mem_start = System.GC.GetTotalMemory(true)
+        showInt (-2)
+        showInt (-1)
+        showInt (0)
+        showInt (1)
+        showInt (2)
+        showBig ("-222222222222222222222222222222222222")
+        showBig ("-1")
+        showBig ("0")
+        showBig ("1")
+        showBig ("222222222222222222222222222222222222")
+        let __bench_end = _now()
+        let __mem_end = System.GC.GetTotalMemory(true)
+        printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)
+
+        __ret
+    with
+        | Return -> __ret
+main()

--- a/tests/rosetta/transpiler/FS/even-or-odd.out
+++ b/tests/rosetta/transpiler/FS/even-or-odd.out
@@ -1,0 +1,10 @@
+Testing integer  -2:  even even
+Testing integer  -1:   odd  odd
+Testing integer   0:  even even
+Testing integer   1:   odd  odd
+Testing integer   2:  even even
+Testing big integer -222222222222222222222222222222222222:  even
+Testing big integer -1:  odd
+Testing big integer 0:  even
+Testing big integer 1:  odd
+Testing big integer 222222222222222222222222222222222222:  even

--- a/transpiler/x/fs/ROSETTA.md
+++ b/transpiler/x/fs/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This file is auto-generated from rosetta tests.
 
-## Rosetta Golden Test Checklist (368/491)
+## Rosetta Golden Test Checklist (369/491)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 151µs | 41.3 KB |
@@ -372,7 +372,7 @@ This file is auto-generated from rosetta tests.
 | 365 | eulers-identity | ✓ | 393µs | 61.2 KB |
 | 366 | eulers-sum-of-powers-conjecture | ✓ | 1.243ms | 45.3 KB |
 | 367 | evaluate-binomial-coefficients | ✓ | 388µs | 46.0 KB |
-| 368 | even-or-odd |   |  |  |
+| 368 | even-or-odd | ✓ | 538µs | 53.5 KB |
 | 369 | events |   |  |  |
 | 370 | evolutionary-algorithm |   |  |  |
 | 371 | exceptions-catch-an-exception-thrown-in-a-nested-call |   |  |  |
@@ -497,4 +497,4 @@ This file is auto-generated from rosetta tests.
 | 490 | window-management | ✓ | 371µs | 45.5 KB |
 | 491 | zumkeller-numbers | ✓ | 44.206ms | 86.9 KB |
 
-Last updated: 2025-08-03 23:50 +0700
+Last updated: 2025-08-04 00:30 +0700


### PR DESCRIPTION
## Summary
- add generated F# code and output for Rosetta task even-or-odd (index 368)
- update F# Rosetta checklist with benchmark data for even-or-odd

## Testing
- `MOCHI_ROSETTA_INDEX=368 MOCHI_BENCHMARK=1 go test ./transpiler/x/fs -run Rosetta -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688f9ca963dc8320a6e29279195e8abf