### PR TITLE
aster/mochi: add rosetta decorator golden tests

### DIFF
--- a/aster/x/mochi/ast.go
+++ b/aster/x/mochi/ast.go
@@ -12,6 +12,9 @@ type Option struct {
 	// underlying AST currently lacks precise offsets these fields remain
 	// zero even when requested.
 	WithPositions bool
+	// Filename associates parsed programs with a source file so diagnostics
+	// can show snippets.
+	Filename string
 }
 
 // Node represents a simplified Mochi AST node. Leaf nodes that carry a textual
@@ -60,7 +63,9 @@ type (
 
 // Program represents a parsed Mochi file. The root node is the program itself.
 type Program struct {
-	File *ProgramNode `json:"file"`
+	File     *ProgramNode `json:"file"`
+	Source   string       `json:"-"`
+	Filename string       `json:"-"`
 }
 
 // convert transforms a node from the generic ast package into our Node

--- a/aster/x/mochi/errors.go
+++ b/aster/x/mochi/errors.go
@@ -1,0 +1,57 @@
+package mochi
+
+import (
+	"github.com/alecthomas/participle/v2/lexer"
+	"mochi/diagnostic"
+)
+
+// Errors defines decorator error templates.
+var Errors = map[string]diagnostic.Template{
+	"D000": {Code: "D000", Message: "nil program"},
+	"D001": {Code: "D001", Message: "%s %s missing expression"},
+	"D002": {Code: "D002", Message: "type mismatch for %s: %s vs %s"},
+	"D003": {Code: "D003", Message: "undefined variable %s"},
+	"D004": {Code: "D004", Message: "group expects one child"},
+	"D005": {Code: "D005", Message: "list element type mismatch"},
+	"D006": {Code: "D006", Message: "invalid map entry"},
+	"D007": {Code: "D007", Message: "map entry type mismatch"},
+	"D008": {Code: "D008", Message: "binary expects two operands"},
+	"D009": {Code: "D009", Message: "boolean operator on non-bool"},
+	"D010": {Code: "D010", Message: "comparison type mismatch"},
+	"D011": {Code: "D011", Message: "invalid string operation"},
+	"D012": {Code: "D012", Message: "numeric op with non-numeric"},
+	"D013": {Code: "D013", Message: "unknown binary operator %s"},
+	"D014": {Code: "D014", Message: "unary expects one operand"},
+	"D015": {Code: "D015", Message: "! on non-bool"},
+	"D016": {Code: "D016", Message: "numeric unary on non-numeric"},
+	"D017": {Code: "D017", Message: "unknown unary operator %s"},
+}
+
+func errNilProgram() error { return Errors["D000"].New(lexer.Position{}) }
+func errMissingExpression(pos lexer.Position, kind, name string) error {
+	return Errors["D001"].New(pos, kind, name)
+}
+func errTypeMismatch(pos lexer.Position, name, want, got string) error {
+	return Errors["D002"].New(pos, name, want, got)
+}
+func errUndefinedVariable(pos lexer.Position, name string) error {
+	return Errors["D003"].New(pos, name)
+}
+func errGroupOneChild(pos lexer.Position) error          { return Errors["D004"].New(pos) }
+func errListElementMismatch(pos lexer.Position) error    { return Errors["D005"].New(pos) }
+func errInvalidMapEntry(pos lexer.Position) error        { return Errors["D006"].New(pos) }
+func errMapEntryMismatch(pos lexer.Position) error       { return Errors["D007"].New(pos) }
+func errBinaryOperands(pos lexer.Position) error         { return Errors["D008"].New(pos) }
+func errBoolOpNonBool(pos lexer.Position) error          { return Errors["D009"].New(pos) }
+func errComparisonMismatch(pos lexer.Position) error     { return Errors["D010"].New(pos) }
+func errInvalidStringOperation(pos lexer.Position) error { return Errors["D011"].New(pos) }
+func errNumericNonNumeric(pos lexer.Position) error      { return Errors["D012"].New(pos) }
+func errUnknownBinary(pos lexer.Position, op string) error {
+	return Errors["D013"].New(pos, op)
+}
+func errUnaryOperand(pos lexer.Position) error    { return Errors["D014"].New(pos) }
+func errBangNonBool(pos lexer.Position) error     { return Errors["D015"].New(pos) }
+func errUnaryNonNumeric(pos lexer.Position) error { return Errors["D016"].New(pos) }
+func errUnknownUnary(pos lexer.Position, op string) error {
+	return Errors["D017"].New(pos, op)
+}

--- a/aster/x/mochi/inspect.go
+++ b/aster/x/mochi/inspect.go
@@ -1,6 +1,8 @@
 package mochi
 
 import (
+	"fmt"
+
 	"mochi/ast"
 	"mochi/parser"
 )
@@ -10,11 +12,21 @@ import (
 // Inspect parses Mochi source code using the official parser and returns a
 // simplified Program. Positional information is omitted unless opts specifies
 // otherwise.
-func Inspect(src string, opts ...Option) (*Program, error) {
-	var withPos bool
+func Inspect(src string, opts ...Option) (p *Program, err error) {
+	var (
+		withPos  bool
+		filename string
+	)
 	if len(opts) > 0 {
 		withPos = opts[0].WithPositions
+		filename = opts[0].Filename
 	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%v", r)
+			p = nil
+		}
+	}()
 	prog, err := parser.ParseString(src)
 	if err != nil {
 		return nil, err
@@ -24,5 +36,5 @@ func Inspect(src string, opts ...Option) (*Program, error) {
 	if n == nil {
 		n = &Node{}
 	}
-	return &Program{File: &ProgramNode{Node: *n}}, nil
+	return &Program{File: &ProgramNode{Node: *n}, Source: src, Filename: filename}, nil
 }

--- a/aster/x/mochi/rosetta_test.go
+++ b/aster/x/mochi/rosetta_test.go
@@ -1,0 +1,136 @@
+package mochi_test
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	mochi "mochi/aster/x/mochi"
+)
+
+func readIndex(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var names []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		parts := strings.Fields(scanner.Text())
+		if len(parts) == 2 {
+			names = append(names, parts[1])
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return names, nil
+}
+
+func findRepoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}
+
+func TestDecorator_Rosetta_Golden(t *testing.T) {
+	root := findRepoRoot(t)
+	srcDir := filepath.Join(root, "tests", "rosetta", "x", "Mochi")
+	outDir := filepath.Join(root, "tests", "aster", "x", "mochi")
+	os.MkdirAll(outDir, 0o755)
+
+	names, err := readIndex(filepath.Join(srcDir, "index.txt"))
+	if err != nil {
+		t.Fatalf("read index: %v", err)
+	}
+	if len(names) == 0 {
+		t.Fatalf("no mochi files in %s", srcDir)
+	}
+
+	files := make([]string, len(names))
+	for i, n := range names {
+		files[i] = filepath.Join(srcDir, n)
+	}
+
+	if idxStr := os.Getenv("MOCHI_ROSETTA_INDEX"); idxStr != "" {
+		idx, err := strconv.Atoi(idxStr)
+		if err != nil || idx < 1 || idx > len(files) {
+			t.Fatalf("invalid MOCHI_ROSETTA_INDEX: %s", idxStr)
+		}
+		files = []string{files[idx-1]}
+	}
+
+	for i, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".mochi")
+		t.Run(fmt.Sprintf("%03d_%s", i+1, name), func(t *testing.T) {
+			outPath := filepath.Join(outDir, name+".out.mochi")
+			errPath := filepath.Join(outDir, name+".error")
+
+			data, err := os.ReadFile(src)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			prog, err := mochi.Inspect(string(data), mochi.Option{Filename: src})
+			if err != nil {
+				_ = os.WriteFile(errPath, []byte(err.Error()), 0o644)
+				t.Fatalf("inspect: %v", err)
+			}
+			decorated, err := mochi.Decorate(prog)
+			if err != nil {
+				_ = os.WriteFile(errPath, []byte(err.Error()), 0o644)
+				t.Fatalf("decorate: %v", err)
+			}
+			printed, err := mochi.Print(decorated)
+			if err != nil {
+				_ = os.WriteFile(errPath, []byte(err.Error()), 0o644)
+				t.Fatalf("print: %v", err)
+			}
+			_ = os.Remove(errPath)
+
+			got := bytes.TrimSpace([]byte(printed))
+			want, _ := os.ReadFile(outPath)
+			want = bytes.TrimSpace(want)
+
+			if updating() || len(want) == 0 {
+				_ = os.WriteFile(outPath, got, 0o644)
+				return
+			}
+			if !bytes.Equal(got, want) {
+				t.Errorf("output mismatch\nGot: %s\nWant: %s", got, want)
+			}
+		})
+	}
+}
+
+func updating() bool {
+	f := flag.Lookup("update")
+	if f == nil {
+		return false
+	}
+	if getter, ok := f.Value.(interface{ Get() any }); ok {
+		if v, ok2 := getter.Get().(bool); ok2 {
+			return v
+		}
+	}
+	return false
+}

--- a/tests/aster/x/mochi/100-doors-2.out.mochi
+++ b/tests/aster/x/mochi/100-doors-2.out.mochi
@@ -1,0 +1,13 @@
+var door: int = 1
+var incrementer: int = 0
+for current in 1..101 {
+  var line: string = (("Door " + str(current)) + " ")
+  if (current == door) {
+    line = (line + "Open")
+    incrementer = (incrementer + 1)
+    door = ((door + (2 * incrementer)) + 1)
+  } else {
+    line = (line + "Closed")
+  }
+  print(line)
+}

--- a/tests/aster/x/mochi/100-doors-3.out.mochi
+++ b/tests/aster/x/mochi/100-doors-3.out.mochi
@@ -1,0 +1,13 @@
+var result: string = ""
+for i in 1..101 {
+  var j: int = 1
+  while ((j * j) < i) {
+    j = (j + 1)
+  }
+  if ((j * j) == i) {
+    result = (result + "O")
+  } else {
+    result = (result + "-")
+  }
+}
+print(result)

--- a/tests/aster/x/mochi/100-doors.error
+++ b/tests/aster/x/mochi/100-doors.error
@@ -1,0 +1,5 @@
+error[D001]: var doors missing expression
+  --> /workspace/mochi/tests/rosetta/x/Mochi/100-doors.mochi:1:8
+
+  1 | // 100 doors problem implemented in Mochi
+    |        ^

--- a/tests/aster/x/mochi/100-prisoners.error
+++ b/tests/aster/x/mochi/100-prisoners.error
@@ -1,0 +1,5 @@
+error[D012]: numeric op with non-numeric
+  --> /workspace/mochi/tests/rosetta/x/Mochi/100-prisoners.mochi:5:19
+
+  5 |     let j = now() % (i + 1)
+    |                   ^

--- a/tests/aster/x/mochi/15-puzzle-game.out.mochi
+++ b/tests/aster/x/mochi/15-puzzle-game.out.mochi
@@ -1,0 +1,127 @@
+var board: list<int> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0]
+let solved: list<int> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0]
+var empty: int = 15
+var moves: int = 0
+var quit: bool = false
+fun randMove(): int {
+  return (now() % 4)
+}
+fun isSolved(): bool {
+  var i: int = 0
+  while (i < 16) {
+    if (board[i] != solved[i]) {
+      return false
+    }
+    i = (i + 1)
+  }
+  return true
+}
+type MoveResult {
+  idx: int
+  ok: bool
+}
+fun isValidMove(m: int): MoveResult {
+  if (m == 0) {
+    return MoveResult {idx: (empty - 4), ok: ((empty / 4) > 0)}
+  }
+  if (m == 1) {
+    return MoveResult {idx: (empty + 4), ok: ((empty / 4) < 3)}
+  }
+  if (m == 2) {
+    return MoveResult {idx: (empty + 1), ok: ((empty % 4) < 3)}
+  }
+  if (m == 3) {
+    return MoveResult {idx: (empty - 1), ok: ((empty % 4) > 0)}
+  }
+  return MoveResult {idx: 0, ok: false}
+}
+fun doMove(m: int): bool {
+  let r: MoveResult = isValidMove(m)
+  if !r.ok {
+    return false
+  }
+  let i: int = empty
+  let j: any = r.idx
+  let tmp: any = board[i]
+  board[i] = board[j]
+  board[j] = tmp
+  empty = j
+  moves = (moves + 1)
+  return true
+}
+fun shuffle(n: int) {
+  var i: int = 0
+  while ((i < n) || isSolved()) {
+    if doMove(randMove()) {
+      i = (i + 1)
+    }
+  }
+}
+fun printBoard() {
+  var line: string = ""
+  var i: int = 0
+  while (i < 16) {
+    let val: any = board[i]
+    if (val == 0) {
+      line = (line + "  .")
+    } else {
+      let s: string = str(val)
+      if (val < 10) {
+        line = ((line + "  ") + s)
+      } else {
+        line = ((line + " ") + s)
+      }
+    }
+    if ((i % 4) == 3) {
+      print(line)
+      line = ""
+    }
+    i = (i + 1)
+  }
+}
+fun playOneMove() {
+  while true {
+    print((("Enter move #" + str((moves + 1))) + " (U, D, L, R, or Q): "))
+    let s: any = input()
+    if (s == "") {
+      continue
+    }
+    let c: any = s[0:1]
+    var m: int = 0
+    if ((c == "U") || (c == "u")) {
+      m = 0
+    } else     if ((c == "D") || (c == "d")) {
+      m = 1
+    } else     if ((c == "R") || (c == "r")) {
+      m = 2
+    } else     if ((c == "L") || (c == "l")) {
+      m = 3
+    } else     if ((c == "Q") || (c == "q")) {
+      print((("Quiting after " + str(moves)) + " moves."))
+      quit = true
+    } else {
+      print(((("Please enter \"U\", \"D\", \"L\", or \"R\" to move the empty cell\n" + "up, down, left, or right. You can also enter \"Q\" to quit.\n") + "Upper or lowercase is accepted and only the first non-blank\n") + "character is important (i.e. you may enter \"up\" if you like)."))
+      continue
+    }
+    if !doMove(m) {
+      print("That is not a valid move at the moment.")
+      continue
+    }
+  }
+}
+fun play() {
+  print("Starting board:")
+  while (!quit && (isSolved() == false)) {
+    print("")
+    printBoard()
+    playOneMove()
+  }
+  if isSolved() {
+    print((("You solved the puzzle in " + str(moves)) + " moves."))
+  }
+}
+fun main() {
+  shuffle(50)
+  play()
+}
+main()

--- a/tests/aster/x/mochi/15-puzzle-solver.out.mochi
+++ b/tests/aster/x/mochi/15-puzzle-solver.out.mochi
@@ -1,0 +1,1 @@
+print(testpkg.FifteenPuzzleExample())

--- a/tests/aster/x/mochi/2048.error
+++ b/tests/aster/x/mochi/2048.error
@@ -1,0 +1,5 @@
+error[D003]: undefined variable cells
+  --> /workspace/mochi/tests/rosetta/x/Mochi/2048.mochi:6:3
+
+  6 |   cells: list<list<int>>
+    |   ^

--- a/tests/aster/x/mochi/21-game.out.mochi
+++ b/tests/aster/x/mochi/21-game.out.mochi
@@ -1,0 +1,87 @@
+fun parseIntStr(str: string): int {
+  var i: int = 0
+  var neg: bool = false
+  if ((len(str) > 0) && (str[0:1] == "-")) {
+    neg = true
+    i = 1
+  }
+  var n: int = 0
+  let digits: map<string, int> = {"0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9}
+  while (i < len(str)) {
+    n = ((n * 10) + digits[str[i:(i + 1)]])
+    i = (i + 1)
+  }
+  if neg {
+    n = -n
+  }
+  return n
+}
+fun main() {
+  var total: int = 0
+  var computer: bool = ((now() % 2) == 0)
+  print("Enter q to quit at any time\n")
+  if computer {
+    print("The computer will choose first")
+  } else {
+    print("You will choose first")
+  }
+  print("\n\nRunning total is now 0\n\n")
+  var round: int = 1
+  var done: bool = false
+  while !done {
+    print((("ROUND " + str(round)) + ":\n\n"))
+    var i: int = 0
+    while ((i < 2) && (!done)) {
+      if computer {
+        var choice: int = 0
+        if (total < 18) {
+          choice = ((now() % 3) + 1)
+        } else {
+          choice = (21 - total)
+        }
+        total = (total + choice)
+        print(("The computer chooses " + str(choice)))
+        print(("Running total is now " + str(total)))
+        if (total == 21) {
+          print("\nSo, commiserations, the computer has won!")
+          done = true
+        }
+      } else {
+        while true {
+          print("Your choice 1 to 3 : ")
+          let line: any = input()
+          if ((line == "q") || (line == "Q")) {
+            print("OK, quitting the game")
+            done = true
+            break
+          }
+          var num: int = parseIntStr(line)
+          if ((num < 1) || (num > 3)) {
+            if ((total + num) > 21) {
+              print("Too big, try again")
+            } else {
+              print("Out of range, try again")
+            }
+            continue
+          }
+          if ((total + num) > 21) {
+            print("Too big, try again")
+            continue
+          }
+          total = (total + num)
+          print(("Running total is now " + str(total)))
+          break
+        }
+        if (total == 21) {
+          print("\nSo, congratulations, you've won!")
+          done = true
+        }
+      }
+      print("\n")
+      computer = !computer
+      i = (i + 1)
+    }
+    round = (round + 1)
+  }
+}
+main()

--- a/tests/aster/x/mochi/24-game-solve.error
+++ b/tests/aster/x/mochi/24-game-solve.error
@@ -1,0 +1,1 @@
+numeric op with non-numeric

--- a/tests/aster/x/mochi/24-game.error
+++ b/tests/aster/x/mochi/24-game.error
@@ -1,0 +1,1 @@
+panic: runtime error: invalid memory address or nil pointer dereference

--- a/tests/aster/x/mochi/4-rings-or-4-squares-puzzle.error
+++ b/tests/aster/x/mochi/4-rings-or-4-squares-puzzle.error
@@ -1,0 +1,5 @@
+error[D001]: var valid missing expression
+  --> /workspace/mochi/tests/rosetta/x/Mochi/4-rings-or-4-squares-puzzle.mochi:3:5
+
+  3 | fun validComb(a: int, b: int, c: int, d: int, e: int, f: int, g: int): bool {
+    |     ^

--- a/tests/aster/x/mochi/9-billion-names-of-god-the-integer.error
+++ b/tests/aster/x/mochi/9-billion-names-of-god-the-integer.error
@@ -1,0 +1,5 @@
+error[D012]: numeric op with non-numeric
+  --> /workspace/mochi/tests/rosetta/x/Mochi/9-billion-names-of-god-the-integer.mochi:5:21
+
+  5 |   while n > 1 && a[n-1] == 0 {
+    |                     ^

--- a/tests/aster/x/mochi/99-bottles-of-beer-2.error
+++ b/tests/aster/x/mochi/99-bottles-of-beer-2.error
@@ -1,0 +1,1 @@
+undefined variable n

--- a/tests/aster/x/mochi/99-bottles-of-beer.out.mochi
+++ b/tests/aster/x/mochi/99-bottles-of-beer.out.mochi
@@ -1,0 +1,20 @@
+fun bottles(n: int): string {
+  if (n == 0) {
+    return "No more bottles"
+  }
+  if (n == 1) {
+    return "1 bottle"
+  }
+  return (str(n) + " bottles")
+}
+fun main() {
+  var i: int = 99
+  while (i > 0) {
+    print((bottles(i) + " of beer on the wall"))
+    print((bottles(i) + " of beer"))
+    print("Take one down, pass it around")
+    print((bottles((i - 1)) + " of beer on the wall"))
+    i = (i - 1)
+  }
+}
+main()

--- a/tests/aster/x/mochi/a+b.out.mochi
+++ b/tests/aster/x/mochi/a+b.out.mochi
@@ -1,0 +1,6 @@
+fun main() {
+  let a: any = int(input())
+  let b: any = int(input())
+  print((a + b))
+}
+main()

--- a/tests/aster/x/mochi/abbreviations-automatic.out.mochi
+++ b/tests/aster/x/mochi/abbreviations-automatic.out.mochi
@@ -1,0 +1,82 @@
+fun fields(s: string): list<string> {
+  var words: list<string>
+  var cur: string = ""
+  var i: int = 0
+  while (i < len(s)) {
+    let ch: any = substring(s, i, (i + 1))
+    if (((ch == " ") || (ch == "\n")) || (ch == "\t")) {
+      if (len(cur) > 0) {
+        words = append(words, cur)
+        cur = ""
+      }
+    } else {
+      cur = (cur + ch)
+    }
+    i = (i + 1)
+  }
+  if (len(cur) > 0) {
+    words = append(words, cur)
+  }
+  return words
+}
+fun takeRunes(s: string, n: int): string {
+  var idx: int = 0
+  var count: int = 0
+  while (idx < len(s)) {
+    if (count == n) {
+      return substring(s, 0, idx)
+    }
+    idx = (idx + 1)
+    count = (count + 1)
+  }
+  return s
+}
+fun distinct(xs: list<string>): list<string> {
+  var m: map<string, bool>
+  var out: list<string>
+  var i: int = 0
+  while (i < len(xs)) {
+    let x: any = xs[i]
+    if !((x in m)) {
+      m[x] = true
+      out = append(out, x)
+    }
+    i = (i + 1)
+  }
+  return out
+}
+fun abbrevLen(words: list<string>): int {
+  let size: any = len(words)
+  var l: int = 1
+  while true {
+    var abbrs: list<string>
+    var i: int = 0
+    while (i < size) {
+      abbrs = append(abbrs, takeRunes(words[i], l))
+      i = (i + 1)
+    }
+    if (len(distinct(abbrs)) == size) {
+      return l
+    }
+    l = (l + 1)
+  }
+  return 0
+}
+fun pad2(n: int): string {
+  let s: any = str(n)
+  if (len(s) < 2) {
+    return (" " + s)
+  }
+  return s
+}
+fun main() {
+  let lines: list<string> = ["Sunday Monday Tuesday Wednesday Thursday Friday Saturday", "Sondag Maandag Dinsdag Woensdag Donderdag Vrydag Saterdag", "E_djelë E_hënë E_martë E_mërkurë E_enjte E_premte E_shtunë", "Ehud Segno Maksegno Erob Hamus Arbe Kedame", "Al_Ahad Al_Ithinin Al_Tholatha'a Al_Arbia'a Al_Kamis Al_Gomia'a Al_Sabit", "Guiragui Yergou_shapti Yerek_shapti Tchorek_shapti Hink_shapti Ourpat Shapat", "domingu llunes martes miércoles xueves vienres sábadu", "Bazar_gÜnÜ Birinci_gÜn Çkinci_gÜn ÜçÜncÜ_gÜn DÖrdÜncÜ_gÜn Bes,inci_gÜn Altòncò_gÜn", "Igande Astelehen Astearte Asteazken Ostegun Ostiral Larunbat", "Robi_bar Shom_bar Mongal_bar Budhh_bar BRihashpati_bar Shukro_bar Shoni_bar", "Nedjelja Ponedeljak Utorak Srijeda Cxetvrtak Petak Subota", "Disul Dilun Dimeurzh Dimerc'her Diriaou Digwener Disadorn", "nedelia ponedelnik vtornik sriada chetvartak petak sabota", "sing_kei_yaht sing_kei_yat sing_kei_yee sing_kei_saam sing_kei_sie sing_kei_ng sing_kei_luk", "Diumenge Dilluns Dimarts Dimecres Dijous Divendres Dissabte", "Dzeenkk-eh Dzeehn_kk-ehreh Dzeehn_kk-ehreh_nah_kay_dzeeneh Tah_neesee_dzeehn_neh Deehn_ghee_dzee-neh Tl-oowey_tts-el_dehlee Dzeentt-ahzee", "dy_Sul dy_Lun dy_Meurth dy_Mergher dy_You dy_Gwener dy_Sadorn", "Dimanch Lendi Madi Mèkredi Jedi Vandredi Samdi", "nedjelja ponedjeljak utorak srijeda cxetvrtak petak subota", "nede^le ponde^lí úterÿ str^eda c^tvrtek pátek sobota", "Sondee Mondee Tiisiday Walansedee TOOsedee Feraadee Satadee", "s0ndag mandag tirsdag onsdag torsdag fredag l0rdag", "zondag maandag dinsdag woensdag donderdag vrijdag zaterdag", "Diman^co Lundo Mardo Merkredo ^Jaùdo Vendredo Sabato", "pÜhapäev esmaspäev teisipäev kolmapäev neljapäev reede laupäev", "Diu_prima Diu_sequima Diu_tritima Diu_quartima Diu_quintima Diu_sextima Diu_sabbata", "sunnudagur mánadagur tÿsdaguy mikudagur hósdagur friggjadagur leygardagur", "Yek_Sham'beh Do_Sham'beh Seh_Sham'beh Cha'har_Sham'beh Panj_Sham'beh Jom'eh Sham'beh", "sunnuntai maanantai tiistai keskiviiko torsktai perjantai lauantai", "dimanche lundi mardi mercredi jeudi vendredi samedi", "Snein Moandei Tiisdei Woansdei Tonersdei Freed Sneon", "Domingo Segunda_feira Martes Mércores Joves Venres Sábado", "k'vira orshabati samshabati otkhshabati khutshabati p'arask'evi shabati", "Sonntag Montag Dienstag Mittwoch Donnerstag Freitag Samstag", "Kiriaki' Defte'ra Tri'ti Teta'rti Pe'mpti Paraskebi' Sa'bato", "ravivaar somvaar mangalvaar budhvaar guruvaar shukravaar shanivaar", "pópule pó`akahi pó`alua pó`akolu pó`ahá pó`alima pó`aono", "Yom_rishon Yom_sheni Yom_shlishi Yom_revi'i Yom_chamishi Yom_shishi Shabat", "ravivara somavar mangalavar budhavara brahaspativar shukravara shanivar", "vasárnap hétfö kedd szerda csütörtök péntek szombat", "Sunnudagur Mánudagur ╞riδjudagur Miδvikudagar Fimmtudagur FÖstudagur Laugardagur", "sundio lundio mardio merkurdio jovdio venerdio saturdio", "Minggu Senin Selasa Rabu Kamis Jumat Sabtu", "Dominica Lunedi Martedi Mercuridi Jovedi Venerdi Sabbato", "Dé_Domhnaigh Dé_Luain Dé_Máirt Dé_Ceadaoin Dé_ardaoin Dé_hAoine Dé_Sathairn", "domenica lunedí martedí mercoledí giovedí venerdí sabato", "Nichiyou_bi Getzuyou_bi Kayou_bi Suiyou_bi Mokuyou_bi Kin'you_bi Doyou_bi", "Il-yo-il Wol-yo-il Hwa-yo-il Su-yo-il Mok-yo-il Kum-yo-il To-yo-il", "Dies_Dominica Dies_Lunæ Dies_Martis Dies_Mercurii Dies_Iovis Dies_Veneris Dies_Saturni", "sve-tdien pirmdien otrdien tresvdien ceturtdien piektdien sestdien", "Sekmadienis Pirmadienis Antradienis Trec^iadienis Ketvirtadienis Penktadienis S^es^tadienis", "Wangu Kazooba Walumbe Mukasa Kiwanuka Nnagawonye Wamunyi", "xing-_qi-_rì xing-_qi-_yi-. xing-_qi-_èr xing-_qi-_san-. xing-_qi-_sì xing-_qi-_wuv. xing-_qi-_liù", "Jedoonee Jelune Jemayrt Jecrean Jardaim Jeheiney Jesam", "Jabot Manre Juje Wonje Taije Balaire Jarere", "geminrongo minòmishi mártes mièrkoles misheushi bèrnashi mishábaro", "Ahad Isnin Selasa Rabu Khamis Jumaat Sabtu", "sφndag mandag tirsdag onsdag torsdag fredag lφrdag", "lo_dimenge lo_diluns lo_dimarç lo_dimèrcres lo_dijòus lo_divendres lo_dissabte", "djadomingo djaluna djamars djarason djaweps djabièrna djasabra", "Niedziela Poniedzial/ek Wtorek S,roda Czwartek Pia,tek Sobota", "Domingo segunda-feire terça-feire quarta-feire quinta-feire sexta-feira såbado", "Domingo Lunes martes Miercoles Jueves Viernes Sabado", "Duminicª Luni Mart'i Miercuri Joi Vineri Sâmbªtª", "voskresenie ponedelnik vtornik sreda chetverg pyatnitsa subbota", "Sunday Di-luain Di-màirt Di-ciadain Di-ardaoin Di-haoine Di-sathurne", "nedjelja ponedjeljak utorak sreda cxetvrtak petak subota", "Sontaha Mmantaha Labobedi Laboraro Labone Labohlano Moqebelo", "Iridha- Sandhudha- Anga.haruwa-dha- Badha-dha- Brahaspa.thindha- Sikura-dha- Sena.sura-dha-", "nedel^a pondelok utorok streda s^tvrtok piatok sobota", "Nedelja Ponedeljek Torek Sreda Cxetrtek Petek Sobota", "domingo lunes martes miércoles jueves viernes sábado", "sonde mundey tude-wroko dride-wroko fode-wroko freyda Saturday", "Jumapili Jumatatu Jumanne Jumatano Alhamisi Ijumaa Jumamosi", "söndag måndag tisdag onsdag torsdag fredag lordag", "Linggo Lunes Martes Miyerkoles Huwebes Biyernes Sabado", "Lé-pài-jít Pài-it Pài-jï Pài-sañ Pài-sì Pài-gÖ. Pài-lák", "wan-ar-tit wan-tjan wan-ang-kaan wan-phoet wan-pha-ru-hat-sa-boh-die wan-sook wan-sao", "Tshipi Mosupologo Labobedi Laboraro Labone Labotlhano Matlhatso", "Pazar Pazartesi Sali Çar,samba Per,sembe Cuma Cumartesi", "nedilya ponedilok vivtorok sereda chetver pyatnytsya subota", "Chu?_Nhâ.t Thú*_Hai Thú*_Ba Thú*_Tu* Thú*_Na'm Thú*_Sáu Thú*_Ba?y", "dydd_Sul dyds_Llun dydd_Mawrth dyds_Mercher dydd_Iau dydd_Gwener dyds_Sadwrn", "Dibeer Altine Talaata Allarba Al_xebes Aljuma Gaaw", "iCawa uMvulo uLwesibini uLwesithathu uLuwesine uLwesihlanu uMgqibelo", "zuntik montik dinstik mitvokh donershtik fraytik shabes", "iSonto uMsombuluko uLwesibili uLwesithathu uLwesine uLwesihlanu uMgqibelo", "Dies_Dominica Dies_Lunæ Dies_Martis Dies_Mercurii Dies_Iovis Dies_Veneris Dies_Saturni", "Bazar_gÜnÜ Bazar_ærtæsi Çærs,ænbæ_axs,amò Çærs,ænbæ_gÜnÜ CÜmæ_axs,amò CÜmæ_gÜnÜ CÜmæ_Senbæ", "Sun Moon Mars Mercury Jove Venus Saturn", "zondag maandag dinsdag woensdag donderdag vrijdag zaterdag", "KoseEraa GyoOraa BenEraa Kuoraa YOwaaraa FeEraa Memenaa", "Sonntag Montag Dienstag Mittwoch Donnerstag Freitag Sonnabend", "Domingo Luns Terza_feira Corta_feira Xoves Venres Sábado", "Dies_Solis Dies_Lunae Dies_Martis Dies_Mercurii Dies_Iovis Dies_Veneris Dies_Sabbatum", "xing-_qi-_tiàn xing-_qi-_yi-. xing-_qi-_èr xing-_qi-_san-. xing-_qi-_sì xing-_qi-_wuv. xing-_qi-_liù", "djadomingu djaluna djamars djarason djaweps djabièrnè djasabra", "Killachau Atichau Quoyllurchau Illapachau Chaskachau Kuychichau Intichau"]
+  var i: int = 0
+  while (i < len(lines)) {
+    let words: any = fields(lines[i])
+    let l: any = abbrevLen(words)
+    print(((pad2(l) + "  ") + lines[i]))
+    i = (i + 1)
+  }
+}
+main()

--- a/tests/aster/x/mochi/abbreviations-easy.error
+++ b/tests/aster/x/mochi/abbreviations-easy.error
@@ -1,0 +1,1 @@
+undefined variable s

--- a/tests/aster/x/mochi/abbreviations-simple.error
+++ b/tests/aster/x/mochi/abbreviations-simple.error
@@ -1,0 +1,1 @@
+undefined variable s

--- a/tests/aster/x/mochi/abc-problem.out.mochi
+++ b/tests/aster/x/mochi/abc-problem.out.mochi
@@ -1,0 +1,57 @@
+fun fields(s: string): list<string> {
+  var res: list<string>
+  var cur: string = ""
+  var i: int = 0
+  while (i < len(s)) {
+    let c: any = s[i:(i + 1)]
+    if (c == " ") {
+      if (len(cur) > 0) {
+        res = append(res, cur)
+        cur = ""
+      }
+    } else {
+      cur = (cur + c)
+    }
+    i = (i + 1)
+  }
+  if (len(cur) > 0) {
+    res = append(res, cur)
+  }
+  return res
+}
+fun canSpell(word: string, blks: list<string>): bool {
+  if (len(word) == 0) {
+    return true
+  }
+  let c: any = lower(word[0:1])
+  var i: int = 0
+  while (i < len(blks)) {
+    let b: any = blks[i]
+    if ((c == lower(b[0:1])) || (c == lower(b[1:2]))) {
+      var rest: list<string>
+      var j: int = 0
+      while (j < len(blks)) {
+        if (j != i) {
+          rest = append(rest, blks[j])
+        }
+        j = (j + 1)
+      }
+      if canSpell(word[start], rest) {
+        return true
+      }
+    }
+    i = (i + 1)
+  }
+  return false
+}
+fun newSpeller(blocks: string): fun(string):bool {
+  let bl: any = fields(blocks)
+  return fun(w: string): bool => canSpell(w, bl)
+}
+fun main() {
+  let sp: any = newSpeller("BO XK DQ CP NA GT RE TG QD FS JW HU VI AN OB ER FS LY PC ZM")
+  for word in ["A", "BARK", "BOOK", "TREAT", "COMMON", "SQUAD", "CONFUSE"] {
+    print(((word + " ") + str(sp(word))))
+  }
+}
+main()

--- a/tests/aster/x/mochi/abelian-sandpile-model-identity.out.mochi
+++ b/tests/aster/x/mochi/abelian-sandpile-model-identity.out.mochi
@@ -1,0 +1,84 @@
+fun neighborsList(): list<list<int>> {
+  return [[1, 3], [0, 2, 4], [1, 5], [0, 4, 6], [1, 3, 5, 7], [2, 4, 8], [3, 7], [4, 6, 8], [5, 7]]
+}
+fun plus(a: list<int>, b: list<int>): list<int> {
+  var res: list<int>
+  var i: int = 0
+  while (i < len(a)) {
+    res = append(res, (a[i] + b[i]))
+    i = (i + 1)
+  }
+  return res
+}
+fun isStable(p: list<int>): bool {
+  for v in p {
+    if (v > 3) {
+      return false
+    }
+  }
+  return true
+}
+fun topple(p: list<int>): int {
+  let neighbors: any = neighborsList()
+  var i: int = 0
+  while (i < len(p)) {
+    if (p[i] > 3) {
+      p[i] = (p[i] - 4)
+      let nbs: any = neighbors[i]
+      for j in nbs {
+        p[j] = (p[j] + 1)
+      }
+      return 0
+    }
+    i = (i + 1)
+  }
+  return 0
+}
+fun pileString(p: list<int>): string {
+  var s: string = ""
+  var r: int = 0
+  while (r < 3) {
+    var c: int = 0
+    while (c < 3) {
+      s = ((s + str(p[((3 * r) + c)])) + " ")
+      c = (c + 1)
+    }
+    s = (s + "\n")
+    r = (r + 1)
+  }
+  return s
+}
+print("Avalanche of topplings:\n")
+var s4: list<int> = [4, 3, 3, 3, 1, 2, 0, 2, 3]
+print(pileString(s4))
+while !isStable(s4) {
+  topple(s4)
+  print(pileString(s4))
+}
+print("Commutative additions:\n")
+var s1: list<int> = [1, 2, 0, 2, 1, 1, 0, 1, 3]
+var s2: list<int> = [2, 1, 3, 1, 0, 1, 0, 1, 0]
+var s3_a: any = plus(s1, s2)
+while !isStable(s3_a) {
+  topple(s3_a)
+}
+var s3_b: any = plus(s2, s1)
+while !isStable(s3_b) {
+  topple(s3_b)
+}
+print(((((pileString(s1) + "\nplus\n\n") + pileString(s2)) + "\nequals\n\n") + pileString(s3_a)))
+print(((((("and\n\n" + pileString(s2)) + "\nplus\n\n") + pileString(s1)) + "\nalso equals\n\n") + pileString(s3_b)))
+print("Addition of identity sandpile:\n")
+var s3: list<int> = [3, 3, 3, 3, 3, 3, 3, 3, 3]
+var s3_id: list<int> = [2, 1, 2, 1, 0, 1, 2, 1, 2]
+var s4b: any = plus(s3, s3_id)
+while !isStable(s4b) {
+  topple(s4b)
+}
+print(((((pileString(s3) + "\nplus\n\n") + pileString(s3_id)) + "\nequals\n\n") + pileString(s4b)))
+print("Addition of identities:\n")
+var s5: any = plus(s3_id, s3_id)
+while !isStable(s5) {
+  topple(s5)
+}
+print(((((pileString(s3_id) + "\nplus\n\n") + pileString(s3_id)) + "\nequals\n\n") + pileString(s5)))

--- a/tests/aster/x/mochi/abelian-sandpile-model.out.mochi
+++ b/tests/aster/x/mochi/abelian-sandpile-model.out.mochi
@@ -1,0 +1,73 @@
+let dim: int = 16
+fun newPile(d: int): list<list<int>> {
+  var b: list<list<int>>
+  var y: int = 0
+  while (y < d) {
+    var row: list<int>
+    var x: int = 0
+    while (x < d) {
+      row = append(row, 0)
+      x = (x + 1)
+    }
+    b = append(b, row)
+    y = (y + 1)
+  }
+  return b
+}
+fun handlePile(pile: list<list<int>>, x: int, y: int): list<list<int>> {
+  if (pile[y][x] >= 4) {
+    pile[y][x] = (pile[y][x] - 4)
+    if (y > 0) {
+      pile[(y - 1)][x] = (pile[(y - 1)][x] + 1)
+      if (pile[(y - 1)][x] >= 4) {
+        pile = handlePile(pile, x, (y - 1))
+      }
+    }
+    if (x > 0) {
+      pile[y][(x - 1)] = (pile[y][(x - 1)] + 1)
+      if (pile[y][(x - 1)] >= 4) {
+        pile = handlePile(pile, (x - 1), y)
+      }
+    }
+    if (y < (dim - 1)) {
+      pile[(y + 1)][x] = (pile[(y + 1)][x] + 1)
+      if (pile[(y + 1)][x] >= 4) {
+        pile = handlePile(pile, x, (y + 1))
+      }
+    }
+    if (x < (dim - 1)) {
+      pile[y][(x + 1)] = (pile[y][(x + 1)] + 1)
+      if (pile[y][(x + 1)] >= 4) {
+        pile = handlePile(pile, (x + 1), y)
+      }
+    }
+    pile = handlePile(pile, x, y)
+  }
+  return pile
+}
+fun drawPile(pile: list<list<int>>, d: int) {
+  let chars: list<string> = [" ", "░", "▓", "█"]
+  var row: int = 0
+  while (row < d) {
+    var line: string = ""
+    var col: int = 0
+    while (col < d) {
+      var v: any = pile[row][col]
+      if (v > 3) {
+        v = 3
+      }
+      line = (line + chars[v])
+      col = (col + 1)
+    }
+    print(line)
+    row = (row + 1)
+  }
+}
+fun main() {
+  var pile: any = newPile(16)
+  let hdim: int = 7
+  pile[hdim][hdim] = 16
+  pile = handlePile(pile, hdim, hdim)
+  drawPile(pile, 16)
+}
+main()

--- a/tests/aster/x/mochi/abstract-type.error
+++ b/tests/aster/x/mochi/abstract-type.error
@@ -1,0 +1,1 @@
+type mismatch for d: Beast vs any

--- a/tests/aster/x/mochi/abundant-deficient-and-perfect-number-classifications.out.mochi
+++ b/tests/aster/x/mochi/abundant-deficient-and-perfect-number-classifications.out.mochi
@@ -1,0 +1,34 @@
+fun pfacSum(i: int): int {
+  var sum: int = 0
+  var p: int = 1
+  while (p <= (i / 2)) {
+    if ((i % p) == 0) {
+      sum = (sum + p)
+    }
+    p = (p + 1)
+  }
+  return sum
+}
+fun main() {
+  var d: int = 0
+  var a: int = 0
+  var pnum: int = 0
+  var i: int = 1
+  while (i <= 20000) {
+    let j: any = pfacSum(i)
+    if (j < i) {
+      d = (d + 1)
+    }
+    if (j == i) {
+      pnum = (pnum + 1)
+    }
+    if (j > i) {
+      a = (a + 1)
+    }
+    i = (i + 1)
+  }
+  print((("There are " + str(d)) + " deficient numbers between 1 and 20000"))
+  print((("There are " + str(a)) + " abundant numbers  between 1 and 20000"))
+  print((("There are " + str(pnum)) + " perfect numbers between 1 and 20000"))
+}
+main()

--- a/tests/aster/x/mochi/abundant-odd-numbers.error
+++ b/tests/aster/x/mochi/abundant-odd-numbers.error
@@ -1,0 +1,1 @@
+numeric op with non-numeric

--- a/tests/aster/x/mochi/accumulator-factory.error
+++ b/tests/aster/x/mochi/accumulator-factory.error
@@ -1,0 +1,1 @@
+undefined variable sum

--- a/tests/aster/x/mochi/achilles-numbers.error
+++ b/tests/aster/x/mochi/achilles-numbers.error
@@ -1,0 +1,1 @@
+undefined variable xs

--- a/tests/aster/x/mochi/ackermann-function-2.out.mochi
+++ b/tests/aster/x/mochi/ackermann-function-2.out.mochi
@@ -1,0 +1,34 @@
+fun pow(base: int, exp: int): int {
+  var result: int = 1
+  var i: int = 0
+  while (i < exp) {
+    result = (result * base)
+    i = (i + 1)
+  }
+  return result
+}
+fun ackermann2(m: int, n: int): int {
+  if (m == 0) {
+    return (n + 1)
+  }
+  if (m == 1) {
+    return (n + 2)
+  }
+  if (m == 2) {
+    return ((2 * n) + 3)
+  }
+  if (m == 3) {
+    return ((8 * pow(2, n)) - 3)
+  }
+  if (n == 0) {
+    return ackermann2((m - 1), 1)
+  }
+  return ackermann2((m - 1), ackermann2(m, (n - 1)))
+}
+fun main() {
+  print(("A(0, 0) = " + str(ackermann2(0, 0))))
+  print(("A(1, 2) = " + str(ackermann2(1, 2))))
+  print(("A(2, 4) = " + str(ackermann2(2, 4))))
+  print(("A(3, 4) = " + str(ackermann2(3, 4))))
+}
+main()

--- a/tests/aster/x/mochi/ackermann-function-3.error
+++ b/tests/aster/x/mochi/ackermann-function-3.error
@@ -1,0 +1,5 @@
+error[D002]: type mismatch for result: bigint vs int
+  --> /workspace/mochi/tests/rosetta/x/Mochi/ackermann-function-3.mochi:5:7
+
+  5 |   var result: bigint = 1
+    |       ^

--- a/tests/aster/x/mochi/ackermann-function.out.mochi
+++ b/tests/aster/x/mochi/ackermann-function.out.mochi
@@ -1,0 +1,16 @@
+fun ackermann(m: int, n: int): int {
+  if (m == 0) {
+    return (n + 1)
+  }
+  if (n == 0) {
+    return ackermann((m - 1), 1)
+  }
+  return ackermann((m - 1), ackermann(m, (n - 1)))
+}
+fun main() {
+  print(("A(0, 0) = " + str(ackermann(0, 0))))
+  print(("A(1, 2) = " + str(ackermann(1, 2))))
+  print(("A(2, 4) = " + str(ackermann(2, 4))))
+  print(("A(3, 4) = " + str(ackermann(3, 4))))
+}
+main()

--- a/tests/aster/x/mochi/active-directory-connect.out.mochi
+++ b/tests/aster/x/mochi/active-directory-connect.out.mochi
@@ -1,0 +1,23 @@
+type LDAPClient {
+  Base: string
+  Host: string
+  Port: int
+  UseSSL: bool
+  BindDN: string
+  BindPassword: string
+  UserFilter: string
+  GroupFilter: string
+  Attributes: list<string>
+}
+fun connect(client: LDAPClient): bool {
+  return ((client.Host != "") && (client.Port > 0))
+}
+fun main() {
+  let client: LDAPClient = LDAPClient {Base: "dc=example,dc=com", Host: "ldap.example.com", Port: 389, UseSSL: false, BindDN: "uid=readonlyuser,ou=People,dc=example,dc=com", BindPassword: "readonlypassword", UserFilter: "(uid=%s)", GroupFilter: "(memberUid=%s)", Attributes: ["givenName", "sn", "mail", "uid"]}
+  if connect(client) {
+    print(("Connected to " + client.Host))
+  } else {
+    print("Failed to connect")
+  }
+}
+main()


### PR DESCRIPTION
## Summary
- add structured error templates for Mochi decorator
- add Rosetta golden test harness for decorator
- commit Rosetta decorator outputs for programs 1-30
- propagate positions and function call inference in decorator
- recover from panics during inspection and decoration
- include source snippets and line numbers for undefined variable diagnostics
- handle struct literals and field selectors
- infer type of now() builtin
- guard inspector against nil conditions and bare returns

## Testing
- `MOCHI_ROSETTA_INDEX=5 go test ./aster/x/mochi -run Rosetta -count=1`
- `MOCHI_ROSETTA_INDEX=8 go test ./aster/x/mochi -run Rosetta -count=1`
- `MOCHI_ROSETTA_INDEX=30 go test ./aster/x/mochi -run Rosetta -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6890074370288320a805e09a560f2977