### PR TITLE
aster: add rosetta decorator test and error templates

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -4,12 +4,16 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/alecthomas/participle/v2/lexer"
 )
 
 // Node is a simplified, uniform AST representation (inspired by Lisp)
 type Node struct {
-	Kind     string
-	Value    any
+	Kind  string
+	Value any
+	Pos   lexer.Position
+
 	Children []*Node
 }
 

--- a/aster/x/mochi/ast.go
+++ b/aster/x/mochi/ast.go
@@ -8,9 +8,7 @@ import (
 
 // Option controls how AST nodes are generated.
 type Option struct {
-	// WithPositions populates the positional fields when true. Since the
-	// underlying AST currently lacks precise offsets these fields remain
-	// zero even when requested.
+	// WithPositions populates the positional fields when true.
 	WithPositions bool
 }
 
@@ -75,8 +73,10 @@ func convert(n *mochiast.Node, withPos bool) *Node {
 		node.Text = fmt.Sprint(n.Value)
 	}
 	if withPos {
-		// The mochi/ast package does not currently retain precise
-		// position information so the fields remain zero.
+		node.Start = n.Pos.Line
+		if n.Pos.Column > 0 {
+			node.StartCol = n.Pos.Column - 1
+		}
 	}
 	for _, c := range n.Children {
 		if child := convert(c, withPos); child != nil {

--- a/aster/x/mochi/errors.go
+++ b/aster/x/mochi/errors.go
@@ -1,0 +1,148 @@
+package mochi
+
+import (
+	"fmt"
+
+	"github.com/alecthomas/participle/v2/lexer"
+	"mochi/diagnostic"
+)
+
+// Errors defines diagnostic templates for the Decorate type inference.
+// The list is intentionally small and covers the error messages produced by
+// the Decorate function. It mirrors the structure used in types/errors.go.
+var Errors = map[string]diagnostic.Template{
+	"A000": {Code: "A000", Message: "nil program", Help: "Provide a valid program"},
+	"A001": {Code: "A001", Message: "%s %s missing expression", Help: "Declare %s with a value"},
+	"A002": {Code: "A002", Message: "type mismatch for %s: %s vs %s", Help: "Ensure %s matches"},
+	"A003": {Code: "A003", Message: "undefined variable %s", Help: "Declare %s before use"},
+	"A004": {Code: "A004", Message: "group expects one child", Help: "Provide a single expression"},
+	"A005": {Code: "A005", Message: "list element type mismatch", Help: "Ensure all list elements share a type"},
+	"A006": {Code: "A006", Message: "invalid map entry", Help: "Map entries require key and value"},
+	"A007": {Code: "A007", Message: "map entry type mismatch", Help: "Ensure map keys and values share types"},
+	"A008": {Code: "A008", Message: "binary expects two operands", Help: "Binary expressions require two operands"},
+	"A009": {Code: "A009", Message: "boolean operator on non-bool", Help: "Use booleans with logical operators"},
+	"A010": {Code: "A010", Message: "comparison type mismatch", Help: "Operands must have the same type"},
+	"A011": {Code: "A011", Message: "numeric op with non-numeric", Help: "Use numeric operands"},
+	"A012": {Code: "A012", Message: "invalid string operation", Help: "Only concatenation is supported"},
+	"A013": {Code: "A013", Message: "unknown binary operator %s", Help: "Use a supported operator"},
+	"A014": {Code: "A014", Message: "unary expects one operand", Help: "Provide one operand"},
+	"A015": {Code: "A015", Message: "! on non-bool", Help: "Use ! with boolean expressions"},
+	"A016": {Code: "A016", Message: "unknown unary operator %s", Help: "Use a supported operator"},
+	"A017": {Code: "A017", Message: "index on non-indexable type %s", Help: "Only lists and maps support indexing"},
+	"A018": {Code: "A018", Message: "list index must be int", Help: "Use an int index"},
+	"A019": {Code: "A019", Message: "map key type mismatch: %s vs %s", Help: "Ensure the key matches the map's key type"},
+	"A020": {Code: "A020", Message: "unknown field %s on %s", Help: "Check the struct definition"},
+	"A021": {Code: "A021", Message: "%s is not a struct", Help: "Field access is only valid on structs"},
+}
+
+func pos(n *Node) lexer.Position {
+	if n == nil {
+		return lexer.Position{}
+	}
+	return lexer.Position{Line: n.Start, Column: n.StartCol + 1}
+}
+
+func errNilProgram(n *Node) error {
+	return Errors["A000"].New(pos(n))
+}
+
+func errMissingExpr(kind, name string, n *Node) error {
+	tmpl := Errors["A001"]
+	msg := fmt.Sprintf(tmpl.Message, kind, name)
+	help := fmt.Sprintf(tmpl.Help, name)
+	return diagnostic.New(tmpl.Code, pos(n), msg, help)
+}
+
+func errVarTypeMismatch(name string, want, got *Node, n *Node) error {
+	tmpl := Errors["A002"]
+	msg := fmt.Sprintf(tmpl.Message, name, typeString(want), typeString(got))
+	help := fmt.Sprintf(tmpl.Help, name)
+	return diagnostic.New(tmpl.Code, pos(n), msg, help)
+}
+
+func errUndefinedVar(name string, n *Node) error {
+	tmpl := Errors["A003"]
+	msg := fmt.Sprintf(tmpl.Message, name)
+	help := fmt.Sprintf(tmpl.Help, name)
+	return diagnostic.New(tmpl.Code, pos(n), msg, help)
+}
+
+func errGroupOneChild(n *Node) error {
+	return Errors["A004"].New(pos(n))
+}
+
+func errListElemMismatch(n *Node) error {
+	return Errors["A005"].New(pos(n))
+}
+
+func errInvalidMapEntry(n *Node) error {
+	return Errors["A006"].New(pos(n))
+}
+
+func errMapEntryTypeMismatch(n *Node) error {
+	return Errors["A007"].New(pos(n))
+}
+
+func errBinaryTwoOperands(n *Node) error {
+	return Errors["A008"].New(pos(n))
+}
+
+func errBoolOpNonBool(n *Node) error {
+	return Errors["A009"].New(pos(n))
+}
+
+func errComparisonMismatch(n *Node) error {
+	return Errors["A010"].New(pos(n))
+}
+
+func errNumericOpNonNumeric(n *Node) error {
+	return Errors["A011"].New(pos(n))
+}
+
+func errInvalidStringOp(n *Node) error {
+	return Errors["A012"].New(pos(n))
+}
+
+func errUnknownBinaryOp(op string, n *Node) error {
+	return Errors["A013"].New(pos(n), op)
+}
+
+func errUnaryOneOperand(n *Node) error {
+	return Errors["A014"].New(pos(n))
+}
+
+func errBangNonBool(n *Node) error {
+	return Errors["A015"].New(pos(n))
+}
+
+func errUnknownUnaryOp(op string, n *Node) error {
+	return Errors["A016"].New(pos(n), op)
+}
+
+func errIndexNonIndexable(t *Node, n *Node) error {
+	tmpl := Errors["A017"]
+	msg := fmt.Sprintf(tmpl.Message, typeString(t))
+	return diagnostic.New(tmpl.Code, pos(n), msg, tmpl.Help)
+}
+
+func errListIndexNotInt(n *Node) error {
+	return Errors["A018"].New(pos(n))
+}
+
+func errMapIndexTypeMismatch(expected, actual *Node, n *Node) error {
+	tmpl := Errors["A019"]
+	msg := fmt.Sprintf(tmpl.Message, typeString(expected), typeString(actual))
+	return diagnostic.New(tmpl.Code, pos(n), msg, tmpl.Help)
+}
+
+func errUnknownField(field string, typ *Node, n *Node) error {
+	tmpl := Errors["A020"]
+	msg := fmt.Sprintf(tmpl.Message, field, typeString(typ))
+	return diagnostic.New(tmpl.Code, pos(n), msg, tmpl.Help)
+}
+
+func errNotStruct(typ *Node, n *Node) error {
+	tmpl := Errors["A021"]
+	msg := fmt.Sprintf(tmpl.Message, typeString(typ))
+	return diagnostic.New(tmpl.Code, pos(n), msg, tmpl.Help)
+}

--- a/aster/x/mochi/rosetta_test.go
+++ b/aster/x/mochi/rosetta_test.go
@@ -1,0 +1,150 @@
+//go:build slow
+
+package mochi_test
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	mochi "mochi/aster/x/mochi"
+	"mochi/diagnostic"
+)
+
+func findRepoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}
+
+func TestRosettaDecorate(t *testing.T) {
+	root := findRepoRoot(t)
+	srcDir := filepath.Join(root, "tests", "rosetta", "x", "Mochi")
+	outDir := filepath.Join(root, "tests", "aster", "x", "mochi")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	files, err := filepath.Glob(filepath.Join(srcDir, "*.mochi"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	sort.Strings(files)
+	if len(files) == 0 {
+		t.Fatalf("no mochi files in %s", srcDir)
+		return
+	}
+	if idxStr := os.Getenv("MOCHI_ROSETTA_INDEX"); idxStr != "" {
+		idx, err := strconv.Atoi(idxStr)
+		if err != nil || idx < 1 || idx > len(files) {
+			t.Fatalf("invalid MOCHI_ROSETTA_INDEX: %s", idxStr)
+		}
+		files = []string{files[idx-1]}
+	}
+
+	var passed, failed int
+	var firstFail string
+	for i, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".mochi")
+		testName := fmt.Sprintf("%03d_%s", i+1, name)
+		ok := t.Run(testName, func(t *testing.T) {
+			outPath := filepath.Join(outDir, name+".out.mochi")
+			errPath := filepath.Join(outDir, name+".error")
+
+			defer func() {
+				if r := recover(); r != nil {
+					msg := fmt.Sprintf("panic: %v", r)
+					_ = os.WriteFile(errPath, []byte(msg+"\n"), 0o644)
+					_ = os.Remove(outPath)
+					t.Errorf("%s", msg)
+				}
+			}()
+
+			data, err := os.ReadFile(src)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			prog, err := mochi.Inspect(string(data), mochi.Option{WithPositions: true})
+			if err != nil {
+				writeError(errPath, src, err)
+				_ = os.Remove(outPath)
+				t.Errorf("inspect: %v", err)
+				return
+			}
+			dec, err := mochi.Decorate(prog)
+			if err != nil {
+				writeError(errPath, src, err)
+				_ = os.Remove(outPath)
+				t.Errorf("decorate: %v", err)
+				return
+			}
+			printed, err := mochi.Print(dec)
+			if err != nil {
+				t.Fatalf("print: %v", err)
+			}
+			_ = os.Remove(errPath)
+			got := bytes.TrimSpace([]byte(printed))
+			want, _ := os.ReadFile(outPath)
+			want = bytes.TrimSpace(want)
+			if err := os.WriteFile(outPath, append(got, '\n'), 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if !updating() && len(want) > 0 && !bytes.Equal(got, want) {
+				t.Errorf("output mismatch\nGot: %s\nWant: %s", got, want)
+			}
+		})
+		if ok {
+			passed++
+		} else {
+			failed++
+			if firstFail == "" {
+				firstFail = name
+			}
+		}
+	}
+	t.Logf("Summary: %d passed, %d failed", passed, failed)
+	if firstFail != "" {
+		t.Fatalf("first failing program: %s", firstFail)
+	}
+}
+
+func writeError(errPath, src string, err error) {
+	msg := err.Error()
+	if d, ok := err.(diagnostic.Diagnostic); ok {
+		d.Pos.Filename = src
+		msg = d.Format()
+	}
+	_ = os.WriteFile(errPath, []byte(msg+"\n"), 0o644)
+}
+
+func updating() bool {
+	f := flag.Lookup("update")
+	if f == nil {
+		return false
+	}
+	if getter, ok := f.Value.(interface{ Get() any }); ok {
+		if v, ok2 := getter.Get().(bool); ok2 {
+			return v
+		}
+	}
+	return false
+}

--- a/tests/aster/x/mochi/100-doors-2.out.mochi
+++ b/tests/aster/x/mochi/100-doors-2.out.mochi
@@ -1,0 +1,13 @@
+var door: int = 1
+var incrementer: int = 0
+for current in 1..101 {
+  var line: string = (("Door " + str(current)) + " ")
+  if (current == door) {
+    line = (line + "Open")
+    incrementer = (incrementer + 1)
+    door = ((door + (2 * incrementer)) + 1)
+  } else {
+    line = (line + "Closed")
+  }
+  print(line)
+}

--- a/tests/aster/x/mochi/100-doors-3.out.mochi
+++ b/tests/aster/x/mochi/100-doors-3.out.mochi
@@ -1,0 +1,13 @@
+var result: string = ""
+for i in 1..101 {
+  var j: int = 1
+  while ((j * j) < i) {
+    j = (j + 1)
+  }
+  if ((j * j) == i) {
+    result = (result + "O")
+  } else {
+    result = (result + "-")
+  }
+}
+print(result)

--- a/tests/aster/x/mochi/100-doors.error
+++ b/tests/aster/x/mochi/100-doors.error
@@ -1,0 +1,8 @@
+error[A001]: var doors missing expression
+  --> /workspace/mochi/tests/rosetta/x/Mochi/100-doors.mochi:5:1
+
+  5 | var doors = []
+    | ^
+
+help:
+  Declare doors with a value

--- a/tests/aster/x/mochi/100-prisoners.error
+++ b/tests/aster/x/mochi/100-prisoners.error
@@ -1,0 +1,8 @@
+error[A011]: numeric op with non-numeric
+  --> /workspace/mochi/tests/rosetta/x/Mochi/100-prisoners.mochi:73:32
+
+ 73 |   let rf = (pardoned as float) / (trials as float) * 100.0
+    |                                ^
+
+help:
+  Use numeric operands

--- a/tests/aster/x/mochi/15-puzzle-game.out.mochi
+++ b/tests/aster/x/mochi/15-puzzle-game.out.mochi
@@ -1,0 +1,127 @@
+var board: list<int> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0]
+let solved: list<int> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0]
+var empty: int = 15
+var moves: int = 0
+var quit: bool = false
+fun randMove(): int {
+  return (now() % 4)
+}
+fun isSolved(): bool {
+  var i: int = 0
+  while (i < 16) {
+    if (board[i] != solved[i]) {
+      return false
+    }
+    i = (i + 1)
+  }
+  return true
+}
+type MoveResult {
+  idx: int
+  ok: bool
+}
+fun isValidMove(m: int): MoveResult {
+  if (m == 0) {
+    return MoveResult {idx: (empty - 4), ok: ((empty / 4) > 0)}
+  }
+  if (m == 1) {
+    return MoveResult {idx: (empty + 4), ok: ((empty / 4) < 3)}
+  }
+  if (m == 2) {
+    return MoveResult {idx: (empty + 1), ok: ((empty % 4) < 3)}
+  }
+  if (m == 3) {
+    return MoveResult {idx: (empty - 1), ok: ((empty % 4) > 0)}
+  }
+  return MoveResult {idx: 0, ok: false}
+}
+fun doMove(m: int): bool {
+  let r: MoveResult = isValidMove(m)
+  if !r.ok {
+    return false
+  }
+  let i: int = empty
+  let j: int = r.idx
+  let tmp: int = board[i]
+  board[i] = board[j]
+  board[j] = tmp
+  empty = j
+  moves = (moves + 1)
+  return true
+}
+fun shuffle(n: int): any {
+  var i: int = 0
+  while ((i < n) || isSolved()) {
+    if doMove(randMove()) {
+      i = (i + 1)
+    }
+  }
+}
+fun printBoard(): any {
+  var line: string = ""
+  var i: int = 0
+  while (i < 16) {
+    let val: int = board[i]
+    if (val == 0) {
+      line = (line + "  .")
+    } else {
+      let s: string = str(val)
+      if (val < 10) {
+        line = ((line + "  ") + s)
+      } else {
+        line = ((line + " ") + s)
+      }
+    }
+    if ((i % 4) == 3) {
+      print(line)
+      line = ""
+    }
+    i = (i + 1)
+  }
+}
+fun playOneMove(): any {
+  while true {
+    print((("Enter move #" + str((moves + 1))) + " (U, D, L, R, or Q): "))
+    let s: any = input()
+    if (s == "") {
+      continue
+    }
+    let c: any = s[0:1]
+    var m: int = 0
+    if ((c == "U") || (c == "u")) {
+      m = 0
+    } else     if ((c == "D") || (c == "d")) {
+      m = 1
+    } else     if ((c == "R") || (c == "r")) {
+      m = 2
+    } else     if ((c == "L") || (c == "l")) {
+      m = 3
+    } else     if ((c == "Q") || (c == "q")) {
+      print((("Quiting after " + str(moves)) + " moves."))
+      quit = true
+    } else {
+      print(((("Please enter \"U\", \"D\", \"L\", or \"R\" to move the empty cell\n" + "up, down, left, or right. You can also enter \"Q\" to quit.\n") + "Upper or lowercase is accepted and only the first non-blank\n") + "character is important (i.e. you may enter \"up\" if you like)."))
+      continue
+    }
+    if !doMove(m) {
+      print("That is not a valid move at the moment.")
+      continue
+    }
+  }
+}
+fun play(): any {
+  print("Starting board:")
+  while (!quit && (isSolved() == false)) {
+    print("")
+    printBoard()
+    playOneMove()
+  }
+  if isSolved() {
+    print((("You solved the puzzle in " + str(moves)) + " moves."))
+  }
+}
+fun main(): any {
+  shuffle(50)
+  play()
+}
+main()

--- a/tests/aster/x/mochi/15-puzzle-solver.out.mochi
+++ b/tests/aster/x/mochi/15-puzzle-solver.out.mochi
@@ -1,0 +1,1 @@
+print(testpkg.FifteenPuzzleExample())

--- a/tests/aster/x/mochi/2048.out.mochi
+++ b/tests/aster/x/mochi/2048.out.mochi
@@ -1,0 +1,327 @@
+let SIZE: int = 4
+type Board {
+  cells: list<list<int>>
+}
+type SpawnResult {
+  board: Board
+  full: bool
+}
+type SlideResult {
+  row: list<int>
+  gain: int
+}
+type MoveResult {
+  board: Board
+  score: int
+  moved: bool
+}
+fun newBoard(): Board {
+  var b: list<list<int>>
+  var y: int = 0
+  while (y < SIZE) {
+    var row: list<int>
+    var x: int = 0
+    while (x < SIZE) {
+      row = append(row, 0)
+      x = (x + 1)
+    }
+    b = append(b, row)
+    y = (y + 1)
+  }
+  return Board {cells: b}
+}
+fun spawnTile(b: Board): SpawnResult {
+  var grid: list<list<int>> = b.cells
+  var empty: list<list<int>>
+  var y: int = 0
+  while (y < SIZE) {
+    var x: int = 0
+    while (x < SIZE) {
+      if (grid[y][x] == 0) {
+        empty = append(empty, [x, y])
+      }
+      x = (x + 1)
+    }
+    y = (y + 1)
+  }
+  if (len(empty) == 0) {
+    return SpawnResult {board: b, full: true}
+  }
+  var idx: int = (now() % len(empty))
+  let cell: list<int> = empty[idx]
+  var val: int = 4
+  if ((now() % 10) < 9) {
+    val = 2
+  }
+  grid[cell[1]][cell[0]] = val
+  return SpawnResult {board: Board {cells: grid}, full: (len(empty) == 1)}
+}
+fun pad(n: int): string {
+  var s: string = str(n)
+  var pad: int = (4 - len(s))
+  var i: int = 0
+  var out: string = ""
+  while (i < pad) {
+    out = (out + " ")
+    i = (i + 1)
+  }
+  return (out + s)
+}
+fun draw(b: Board, score: int): any {
+  print(("Score: " + str(score)))
+  var y: int = 0
+  while (y < SIZE) {
+    print("+----+----+----+----+")
+    var line: string = "|"
+    var x: int = 0
+    while (x < SIZE) {
+      var v: int = b.cells[y][x]
+      if (v == 0) {
+        line = (line + "    |")
+      } else {
+        line = ((line + pad(v)) + "|")
+      }
+      x = (x + 1)
+    }
+    print(line)
+    y = (y + 1)
+  }
+  print("+----+----+----+----+")
+  print("W=Up S=Down A=Left D=Right Q=Quit")
+}
+fun reverseRow(r: list<int>): list<int> {
+  var out: list<int>
+  var i: int = (len(r) - 1)
+  while (i >= 0) {
+    out = append(out, r[i])
+    i = (i - 1)
+  }
+  return out
+}
+fun slideLeft(row: list<int>): SlideResult {
+  var xs: list<int>
+  var i: int = 0
+  while (i < len(row)) {
+    if (row[i] != 0) {
+      xs = append(xs, row[i])
+    }
+    i = (i + 1)
+  }
+  var res: list<int>
+  var gain: int = 0
+  i = 0
+  while (i < len(xs)) {
+    if (((i + 1) < len(xs)) && (xs[i] == xs[(i + 1)])) {
+      let v: int = (xs[i] * 2)
+      gain = (gain + v)
+      res = append(res, v)
+      i = (i + 2)
+    } else {
+      res = append(res, xs[i])
+      i = (i + 1)
+    }
+  }
+  while (len(res) < SIZE) {
+    res = append(res, 0)
+  }
+  return SlideResult {row: res, gain: gain}
+}
+fun moveLeft(b: Board, score: int): MoveResult {
+  var grid: list<list<int>> = b.cells
+  var moved: bool = false
+  var y: int = 0
+  while (y < SIZE) {
+    let r: SlideResult = slideLeft(grid[y])
+    let new: list<int> = r.row
+    score = (score + r.gain)
+    var x: int = 0
+    while (x < SIZE) {
+      if (grid[y][x] != new[x]) {
+        moved = true
+      }
+      grid[y][x] = new[x]
+      x = (x + 1)
+    }
+    y = (y + 1)
+  }
+  return MoveResult {board: Board {cells: grid}, score: score, moved: moved}
+}
+fun moveRight(b: Board, score: int): MoveResult {
+  var grid: list<list<int>> = b.cells
+  var moved: bool = false
+  var y: int = 0
+  while (y < SIZE) {
+    var rev: list<int> = reverseRow(grid[y])
+    let r: SlideResult = slideLeft(rev)
+    rev = r.row
+    score = (score + r.gain)
+    rev = reverseRow(rev)
+    var x: int = 0
+    while (x < SIZE) {
+      if (grid[y][x] != rev[x]) {
+        moved = true
+      }
+      grid[y][x] = rev[x]
+      x = (x + 1)
+    }
+    y = (y + 1)
+  }
+  return MoveResult {board: Board {cells: grid}, score: score, moved: moved}
+}
+fun getCol(b: Board, x: int): list<int> {
+  var col: list<int>
+  var y: int = 0
+  while (y < SIZE) {
+    col = append(col, b.cells[y][x])
+    y = (y + 1)
+  }
+  return col
+}
+fun setCol(b: Board, x: int, col: list<int>): any {
+  var rows: list<list<int>> = b.cells
+  var y: int = 0
+  while (y < SIZE) {
+    var row: list<int> = rows[y]
+    row[x] = col[y]
+    rows[y] = row
+    y = (y + 1)
+  }
+  b.cells = rows
+}
+fun moveUp(b: Board, score: int): MoveResult {
+  var grid: list<list<int>> = b.cells
+  var moved: bool = false
+  var x: int = 0
+  while (x < SIZE) {
+    var col: list<int> = getCol(b, x)
+    let r: SlideResult = slideLeft(col)
+    let new: list<int> = r.row
+    score = (score + r.gain)
+    var y: int = 0
+    while (y < SIZE) {
+      if (grid[y][x] != new[y]) {
+        moved = true
+      }
+      grid[y][x] = new[y]
+      y = (y + 1)
+    }
+    x = (x + 1)
+  }
+  return MoveResult {board: Board {cells: grid}, score: score, moved: moved}
+}
+fun moveDown(b: Board, score: int): MoveResult {
+  var grid: list<list<int>> = b.cells
+  var moved: bool = false
+  var x: int = 0
+  while (x < SIZE) {
+    var col: list<int> = reverseRow(getCol(b, x))
+    let r: SlideResult = slideLeft(col)
+    col = r.row
+    score = (score + r.gain)
+    col = reverseRow(col)
+    var y: int = 0
+    while (y < SIZE) {
+      if (grid[y][x] != col[y]) {
+        moved = true
+      }
+      grid[y][x] = col[y]
+      y = (y + 1)
+    }
+    x = (x + 1)
+  }
+  return MoveResult {board: Board {cells: grid}, score: score, moved: moved}
+}
+fun hasMoves(b: Board): bool {
+  var y: int = 0
+  while (y < SIZE) {
+    var x: int = 0
+    while (x < SIZE) {
+      if (b.cells[y][x] == 0) {
+        return true
+      }
+      if (((x + 1) < SIZE) && (b.cells[y][x] == b.cells[y][(x + 1)])) {
+        return true
+      }
+      if (((y + 1) < SIZE) && (b.cells[y][x] == b.cells[(y + 1)][x])) {
+        return true
+      }
+      x = (x + 1)
+    }
+    y = (y + 1)
+  }
+  return false
+}
+fun has2048(b: Board): bool {
+  var y: int = 0
+  while (y < SIZE) {
+    var x: int = 0
+    while (x < SIZE) {
+      if (b.cells[y][x] >= 2048) {
+        return true
+      }
+      x = (x + 1)
+    }
+    y = (y + 1)
+  }
+  return false
+}
+var board: Board = newBoard()
+var r: SpawnResult = spawnTile(board)
+board = r.board
+var full: bool = r.full
+r = spawnTile(board)
+board = r.board
+full = r.full
+var score: int = 0
+draw(board, score)
+while true {
+  print("Move: ")
+  let cmd: any = input()
+  var moved: bool = false
+  if ((cmd == "a") || (cmd == "A")) {
+    let m: MoveResult = moveLeft(board, score)
+    board = m.board
+    score = m.score
+    moved = m.moved
+  }
+  if ((cmd == "d") || (cmd == "D")) {
+    let m: MoveResult = moveRight(board, score)
+    board = m.board
+    score = m.score
+    moved = m.moved
+  }
+  if ((cmd == "w") || (cmd == "W")) {
+    let m: MoveResult = moveUp(board, score)
+    board = m.board
+    score = m.score
+    moved = m.moved
+  }
+  if ((cmd == "s") || (cmd == "S")) {
+    let m: MoveResult = moveDown(board, score)
+    board = m.board
+    score = m.score
+    moved = m.moved
+  }
+  if ((cmd == "q") || (cmd == "Q")) {
+    break
+  }
+  if moved {
+    let r2: SpawnResult = spawnTile(board)
+    board = r2.board
+    full = r2.full
+    if (full && (!hasMoves(board))) {
+      draw(board, score)
+      print("Game Over")
+      break
+    }
+  }
+  draw(board, score)
+  if has2048(board) {
+    print("You win!")
+    break
+  }
+  if !hasMoves(board) {
+    print("Game Over")
+    break
+  }
+}

--- a/tests/aster/x/mochi/21-game.out.mochi
+++ b/tests/aster/x/mochi/21-game.out.mochi
@@ -1,0 +1,87 @@
+fun parseIntStr(str: string): int {
+  var i: int = 0
+  var neg: bool = false
+  if ((len(str) > 0) && (str[0:1] == "-")) {
+    neg = true
+    i = 1
+  }
+  var n: int = 0
+  let digits: map<string, int> = {"0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9}
+  while (i < len(str)) {
+    n = ((n * 10) + digits[str[i:(i + 1)]])
+    i = (i + 1)
+  }
+  if neg {
+    n = -n
+  }
+  return n
+}
+fun main(): any {
+  var total: int = 0
+  var computer: bool = ((now() % 2) == 0)
+  print("Enter q to quit at any time\n")
+  if computer {
+    print("The computer will choose first")
+  } else {
+    print("You will choose first")
+  }
+  print("\n\nRunning total is now 0\n\n")
+  var round: int = 1
+  var done: bool = false
+  while !done {
+    print((("ROUND " + str(round)) + ":\n\n"))
+    var i: int = 0
+    while ((i < 2) && (!done)) {
+      if computer {
+        var choice: int = 0
+        if (total < 18) {
+          choice = ((now() % 3) + 1)
+        } else {
+          choice = (21 - total)
+        }
+        total = (total + choice)
+        print(("The computer chooses " + str(choice)))
+        print(("Running total is now " + str(total)))
+        if (total == 21) {
+          print("\nSo, commiserations, the computer has won!")
+          done = true
+        }
+      } else {
+        while true {
+          print("Your choice 1 to 3 : ")
+          let line: any = input()
+          if ((line == "q") || (line == "Q")) {
+            print("OK, quitting the game")
+            done = true
+            break
+          }
+          var num: int = parseIntStr(line)
+          if ((num < 1) || (num > 3)) {
+            if ((total + num) > 21) {
+              print("Too big, try again")
+            } else {
+              print("Out of range, try again")
+            }
+            continue
+          }
+          if ((total + num) > 21) {
+            print("Too big, try again")
+            continue
+          }
+          total = (total + num)
+          print(("Running total is now " + str(total)))
+          break
+        }
+        if (total == 21) {
+          print("\nSo, congratulations, you've won!")
+          done = true
+        }
+      }
+      print("\n")
+      computer = !computer
+      i = (i + 1)
+    }
+    round = (round + 1)
+  }
+}
+main()

--- a/tests/aster/x/mochi/24-game-solve.out.mochi
+++ b/tests/aster/x/mochi/24-game-solve.out.mochi
@@ -1,0 +1,110 @@
+type Rational {
+  num: int
+  denom: int
+}
+let OP_ADD: int = 1
+let OP_SUB: int = 2
+let OP_MUL: int = 3
+let OP_DIV: int = 4
+type Node {
+  val: Rational
+  txt: string
+}
+fun makeNode(n: int): Node {
+  return Node {val: Rational {num: n, denom: 1}, txt: str(n)}
+}
+fun combine(op: int, l: Node, r: Node): Node {
+  var res: Rational
+  if (op == OP_ADD) {
+    res = Rational {num: ((l.val.num * r.val.denom) + (l.val.denom * r.val.num)), denom: (l.val.denom * r.val.denom)}
+  } else   if (op == OP_SUB) {
+    res = Rational {num: ((l.val.num * r.val.denom) - (l.val.denom * r.val.num)), denom: (l.val.denom * r.val.denom)}
+  } else   if (op == OP_MUL) {
+    res = Rational {num: (l.val.num * r.val.num), denom: (l.val.denom * r.val.denom)}
+  } else {
+    res = Rational {num: (l.val.num * r.val.denom), denom: (l.val.denom * r.val.num)}
+  }
+  var opstr: string = ""
+  if (op == OP_ADD) {
+    opstr = " + "
+  } else   if (op == OP_SUB) {
+    opstr = " - "
+  } else   if (op == OP_MUL) {
+    opstr = " * "
+  } else {
+    opstr = " / "
+  }
+  return Node {val: res, txt: (((("(" + l.txt) + opstr) + r.txt) + ")")}
+}
+fun exprEval(x: Node): Rational {
+  return x.val
+}
+fun exprString(x: Node): string {
+  return x.txt
+}
+let n_cards: int = 4
+let goal: int = 24
+let digit_range: int = 9
+fun solve(xs: list<Node>): bool {
+  if (len(xs) == 1) {
+    let f: Rational = exprEval(xs[0])
+    if ((f.denom != 0) && (f.num == (f.denom * goal))) {
+      print(exprString(xs[0]))
+      return true
+    }
+    return false
+  }
+  var i: int = 0
+  while (i < len(xs)) {
+    var j: int = (i + 1)
+    while (j < len(xs)) {
+      var rest: list<Node>
+      var k: int = 0
+      while (k < len(xs)) {
+        if ((k != i) && (k != j)) {
+          rest = append(rest, xs[k])
+        }
+        k = (k + 1)
+      }
+      let a: Node = xs[i]
+      let b: Node = xs[j]
+      var node: Node
+      for op in [OP_ADD, OP_SUB, OP_MUL, OP_DIV] {
+        node = combine(op, a, b)
+        if solve(append(rest, node)) {
+          return true
+        }
+      }
+      node = combine(OP_SUB, b, a)
+      if solve(append(rest, node)) {
+        return true
+      }
+      node = combine(OP_DIV, b, a)
+      if solve(append(rest, node)) {
+        return true
+      }
+      j = (j + 1)
+    }
+    i = (i + 1)
+  }
+  return false
+}
+fun main(): any {
+  var iter: int = 0
+  while (iter < 10) {
+    var cards: list<Node>
+    var i: int = 0
+    while (i < n_cards) {
+      let n: int = (((now() % ((digit_range - 1)))) + 1)
+      cards = append(cards, makeNode(n))
+      print((" " + str(n)))
+      i = (i + 1)
+    }
+    print(":  ")
+    if !solve(cards) {
+      print("No solution")
+    }
+    iter = (iter + 1)
+  }
+}
+main()

--- a/tests/aster/x/mochi/24-game.error
+++ b/tests/aster/x/mochi/24-game.error
@@ -1,0 +1,8 @@
+error[A001]: var digits missing expression
+  --> /workspace/mochi/tests/rosetta/x/Mochi/24-game.mochi:8:3
+
+  8 |   var digits = []
+    |   ^
+
+help:
+  Declare digits with a value

--- a/tests/aster/x/mochi/4-rings-or-4-squares-puzzle.error
+++ b/tests/aster/x/mochi/4-rings-or-4-squares-puzzle.error
@@ -1,0 +1,8 @@
+error[A001]: var valid missing expression
+  --> /workspace/mochi/tests/rosetta/x/Mochi/4-rings-or-4-squares-puzzle.mochi:26:3
+
+ 26 |   var valid = []
+    |   ^
+
+help:
+  Declare valid with a value

--- a/tests/aster/x/mochi/9-billion-names-of-god-the-integer.error
+++ b/tests/aster/x/mochi/9-billion-names-of-god-the-integer.error
@@ -1,0 +1,8 @@
+error[A011]: numeric op with non-numeric
+  --> /workspace/mochi/tests/rosetta/x/Mochi/9-billion-names-of-god-the-integer.mochi:63:20
+
+ 63 |   var i = count(a) - 1
+    |                    ^
+
+help:
+  Use numeric operands

--- a/tests/aster/x/mochi/99-bottles-of-beer-2.error
+++ b/tests/aster/x/mochi/99-bottles-of-beer-2.error
@@ -1,0 +1,8 @@
+error[A018]: list index must be int
+  --> /workspace/mochi/tests/rosetta/x/Mochi/99-bottles-of-beer-2.mochi:49:17
+
+ 49 |     var t = tens[(n / 10) as int]
+    |                 ^
+
+help:
+  Use an int index

--- a/tests/aster/x/mochi/99-bottles-of-beer.out.mochi
+++ b/tests/aster/x/mochi/99-bottles-of-beer.out.mochi
@@ -1,0 +1,20 @@
+fun bottles(n: int): string {
+  if (n == 0) {
+    return "No more bottles"
+  }
+  if (n == 1) {
+    return "1 bottle"
+  }
+  return (str(n) + " bottles")
+}
+fun main(): any {
+  var i: int = 99
+  while (i > 0) {
+    print((bottles(i) + " of beer on the wall"))
+    print((bottles(i) + " of beer"))
+    print("Take one down, pass it around")
+    print((bottles((i - 1)) + " of beer on the wall"))
+    i = (i - 1)
+  }
+}
+main()

--- a/tests/aster/x/mochi/a+b.out.mochi
+++ b/tests/aster/x/mochi/a+b.out.mochi
@@ -1,0 +1,6 @@
+fun main(): any {
+  let a: int = int(input())
+  let b: int = int(input())
+  print((a + b))
+}
+main()

--- a/tests/aster/x/mochi/abbreviations-automatic.out.mochi
+++ b/tests/aster/x/mochi/abbreviations-automatic.out.mochi
@@ -1,0 +1,82 @@
+fun fields(s: string): list<string> {
+  var words: list<string>
+  var cur: string = ""
+  var i: int = 0
+  while (i < len(s)) {
+    let ch: any = substring(s, i, (i + 1))
+    if (((ch == " ") || (ch == "\n")) || (ch == "\t")) {
+      if (len(cur) > 0) {
+        words = append(words, cur)
+        cur = ""
+      }
+    } else {
+      cur = (cur + ch)
+    }
+    i = (i + 1)
+  }
+  if (len(cur) > 0) {
+    words = append(words, cur)
+  }
+  return words
+}
+fun takeRunes(s: string, n: int): string {
+  var idx: int = 0
+  var count: int = 0
+  while (idx < len(s)) {
+    if (count == n) {
+      return substring(s, 0, idx)
+    }
+    idx = (idx + 1)
+    count = (count + 1)
+  }
+  return s
+}
+fun distinct(xs: list<string>): list<string> {
+  var m: map<string, bool>
+  var out: list<string>
+  var i: int = 0
+  while (i < len(xs)) {
+    let x: string = xs[i]
+    if !((x in m)) {
+      m[x] = true
+      out = append(out, x)
+    }
+    i = (i + 1)
+  }
+  return out
+}
+fun abbrevLen(words: list<string>): int {
+  let size: int = len(words)
+  var l: int = 1
+  while true {
+    var abbrs: list<string>
+    var i: int = 0
+    while (i < size) {
+      abbrs = append(abbrs, takeRunes(words[i], l))
+      i = (i + 1)
+    }
+    if (len(distinct(abbrs)) == size) {
+      return l
+    }
+    l = (l + 1)
+  }
+  return 0
+}
+fun pad2(n: int): string {
+  let s: string = str(n)
+  if (len(s) < 2) {
+    return (" " + s)
+  }
+  return s
+}
+fun main(): any {
+  let lines: list<string> = ["Sunday Monday Tuesday Wednesday Thursday Friday Saturday", "Sondag Maandag Dinsdag Woensdag Donderdag Vrydag Saterdag", "E_djelë E_hënë E_martë E_mërkurë E_enjte E_premte E_shtunë", "Ehud Segno Maksegno Erob Hamus Arbe Kedame", "Al_Ahad Al_Ithinin Al_Tholatha'a Al_Arbia'a Al_Kamis Al_Gomia'a Al_Sabit", "Guiragui Yergou_shapti Yerek_shapti Tchorek_shapti Hink_shapti Ourpat Shapat", "domingu llunes martes miércoles xueves vienres sábadu", "Bazar_gÜnÜ Birinci_gÜn Çkinci_gÜn ÜçÜncÜ_gÜn DÖrdÜncÜ_gÜn Bes,inci_gÜn Altòncò_gÜn", "Igande Astelehen Astearte Asteazken Ostegun Ostiral Larunbat", "Robi_bar Shom_bar Mongal_bar Budhh_bar BRihashpati_bar Shukro_bar Shoni_bar", "Nedjelja Ponedeljak Utorak Srijeda Cxetvrtak Petak Subota", "Disul Dilun Dimeurzh Dimerc'her Diriaou Digwener Disadorn", "nedelia ponedelnik vtornik sriada chetvartak petak sabota", "sing_kei_yaht sing_kei_yat sing_kei_yee sing_kei_saam sing_kei_sie sing_kei_ng sing_kei_luk", "Diumenge Dilluns Dimarts Dimecres Dijous Divendres Dissabte", "Dzeenkk-eh Dzeehn_kk-ehreh Dzeehn_kk-ehreh_nah_kay_dzeeneh Tah_neesee_dzeehn_neh Deehn_ghee_dzee-neh Tl-oowey_tts-el_dehlee Dzeentt-ahzee", "dy_Sul dy_Lun dy_Meurth dy_Mergher dy_You dy_Gwener dy_Sadorn", "Dimanch Lendi Madi Mèkredi Jedi Vandredi Samdi", "nedjelja ponedjeljak utorak srijeda cxetvrtak petak subota", "nede^le ponde^lí úterÿ str^eda c^tvrtek pátek sobota", "Sondee Mondee Tiisiday Walansedee TOOsedee Feraadee Satadee", "s0ndag mandag tirsdag onsdag torsdag fredag l0rdag", "zondag maandag dinsdag woensdag donderdag vrijdag zaterdag", "Diman^co Lundo Mardo Merkredo ^Jaùdo Vendredo Sabato", "pÜhapäev esmaspäev teisipäev kolmapäev neljapäev reede laupäev", "Diu_prima Diu_sequima Diu_tritima Diu_quartima Diu_quintima Diu_sextima Diu_sabbata", "sunnudagur mánadagur tÿsdaguy mikudagur hósdagur friggjadagur leygardagur", "Yek_Sham'beh Do_Sham'beh Seh_Sham'beh Cha'har_Sham'beh Panj_Sham'beh Jom'eh Sham'beh", "sunnuntai maanantai tiistai keskiviiko torsktai perjantai lauantai", "dimanche lundi mardi mercredi jeudi vendredi samedi", "Snein Moandei Tiisdei Woansdei Tonersdei Freed Sneon", "Domingo Segunda_feira Martes Mércores Joves Venres Sábado", "k'vira orshabati samshabati otkhshabati khutshabati p'arask'evi shabati", "Sonntag Montag Dienstag Mittwoch Donnerstag Freitag Samstag", "Kiriaki' Defte'ra Tri'ti Teta'rti Pe'mpti Paraskebi' Sa'bato", "ravivaar somvaar mangalvaar budhvaar guruvaar shukravaar shanivaar", "pópule pó`akahi pó`alua pó`akolu pó`ahá pó`alima pó`aono", "Yom_rishon Yom_sheni Yom_shlishi Yom_revi'i Yom_chamishi Yom_shishi Shabat", "ravivara somavar mangalavar budhavara brahaspativar shukravara shanivar", "vasárnap hétfö kedd szerda csütörtök péntek szombat", "Sunnudagur Mánudagur ╞riδjudagur Miδvikudagar Fimmtudagur FÖstudagur Laugardagur", "sundio lundio mardio merkurdio jovdio venerdio saturdio", "Minggu Senin Selasa Rabu Kamis Jumat Sabtu", "Dominica Lunedi Martedi Mercuridi Jovedi Venerdi Sabbato", "Dé_Domhnaigh Dé_Luain Dé_Máirt Dé_Ceadaoin Dé_ardaoin Dé_hAoine Dé_Sathairn", "domenica lunedí martedí mercoledí giovedí venerdí sabato", "Nichiyou_bi Getzuyou_bi Kayou_bi Suiyou_bi Mokuyou_bi Kin'you_bi Doyou_bi", "Il-yo-il Wol-yo-il Hwa-yo-il Su-yo-il Mok-yo-il Kum-yo-il To-yo-il", "Dies_Dominica Dies_Lunæ Dies_Martis Dies_Mercurii Dies_Iovis Dies_Veneris Dies_Saturni", "sve-tdien pirmdien otrdien tresvdien ceturtdien piektdien sestdien", "Sekmadienis Pirmadienis Antradienis Trec^iadienis Ketvirtadienis Penktadienis S^es^tadienis", "Wangu Kazooba Walumbe Mukasa Kiwanuka Nnagawonye Wamunyi", "xing-_qi-_rì xing-_qi-_yi-. xing-_qi-_èr xing-_qi-_san-. xing-_qi-_sì xing-_qi-_wuv. xing-_qi-_liù", "Jedoonee Jelune Jemayrt Jecrean Jardaim Jeheiney Jesam", "Jabot Manre Juje Wonje Taije Balaire Jarere", "geminrongo minòmishi mártes mièrkoles misheushi bèrnashi mishábaro", "Ahad Isnin Selasa Rabu Khamis Jumaat Sabtu", "sφndag mandag tirsdag onsdag torsdag fredag lφrdag", "lo_dimenge lo_diluns lo_dimarç lo_dimèrcres lo_dijòus lo_divendres lo_dissabte", "djadomingo djaluna djamars djarason djaweps djabièrna djasabra", "Niedziela Poniedzial/ek Wtorek S,roda Czwartek Pia,tek Sobota", "Domingo segunda-feire terça-feire quarta-feire quinta-feire sexta-feira såbado", "Domingo Lunes martes Miercoles Jueves Viernes Sabado", "Duminicª Luni Mart'i Miercuri Joi Vineri Sâmbªtª", "voskresenie ponedelnik vtornik sreda chetverg pyatnitsa subbota", "Sunday Di-luain Di-màirt Di-ciadain Di-ardaoin Di-haoine Di-sathurne", "nedjelja ponedjeljak utorak sreda cxetvrtak petak subota", "Sontaha Mmantaha Labobedi Laboraro Labone Labohlano Moqebelo", "Iridha- Sandhudha- Anga.haruwa-dha- Badha-dha- Brahaspa.thindha- Sikura-dha- Sena.sura-dha-", "nedel^a pondelok utorok streda s^tvrtok piatok sobota", "Nedelja Ponedeljek Torek Sreda Cxetrtek Petek Sobota", "domingo lunes martes miércoles jueves viernes sábado", "sonde mundey tude-wroko dride-wroko fode-wroko freyda Saturday", "Jumapili Jumatatu Jumanne Jumatano Alhamisi Ijumaa Jumamosi", "söndag måndag tisdag onsdag torsdag fredag lordag", "Linggo Lunes Martes Miyerkoles Huwebes Biyernes Sabado", "Lé-pài-jít Pài-it Pài-jï Pài-sañ Pài-sì Pài-gÖ. Pài-lák", "wan-ar-tit wan-tjan wan-ang-kaan wan-phoet wan-pha-ru-hat-sa-boh-die wan-sook wan-sao", "Tshipi Mosupologo Labobedi Laboraro Labone Labotlhano Matlhatso", "Pazar Pazartesi Sali Çar,samba Per,sembe Cuma Cumartesi", "nedilya ponedilok vivtorok sereda chetver pyatnytsya subota", "Chu?_Nhâ.t Thú*_Hai Thú*_Ba Thú*_Tu* Thú*_Na'm Thú*_Sáu Thú*_Ba?y", "dydd_Sul dyds_Llun dydd_Mawrth dyds_Mercher dydd_Iau dydd_Gwener dyds_Sadwrn", "Dibeer Altine Talaata Allarba Al_xebes Aljuma Gaaw", "iCawa uMvulo uLwesibini uLwesithathu uLuwesine uLwesihlanu uMgqibelo", "zuntik montik dinstik mitvokh donershtik fraytik shabes", "iSonto uMsombuluko uLwesibili uLwesithathu uLwesine uLwesihlanu uMgqibelo", "Dies_Dominica Dies_Lunæ Dies_Martis Dies_Mercurii Dies_Iovis Dies_Veneris Dies_Saturni", "Bazar_gÜnÜ Bazar_ærtæsi Çærs,ænbæ_axs,amò Çærs,ænbæ_gÜnÜ CÜmæ_axs,amò CÜmæ_gÜnÜ CÜmæ_Senbæ", "Sun Moon Mars Mercury Jove Venus Saturn", "zondag maandag dinsdag woensdag donderdag vrijdag zaterdag", "KoseEraa GyoOraa BenEraa Kuoraa YOwaaraa FeEraa Memenaa", "Sonntag Montag Dienstag Mittwoch Donnerstag Freitag Sonnabend", "Domingo Luns Terza_feira Corta_feira Xoves Venres Sábado", "Dies_Solis Dies_Lunae Dies_Martis Dies_Mercurii Dies_Iovis Dies_Veneris Dies_Sabbatum", "xing-_qi-_tiàn xing-_qi-_yi-. xing-_qi-_èr xing-_qi-_san-. xing-_qi-_sì xing-_qi-_wuv. xing-_qi-_liù", "djadomingu djaluna djamars djarason djaweps djabièrnè djasabra", "Killachau Atichau Quoyllurchau Illapachau Chaskachau Kuychichau Intichau"]
+  var i: int = 0
+  while (i < len(lines)) {
+    let words: list<string> = fields(lines[i])
+    let l: int = abbrevLen(words)
+    print(((pad2(l) + "  ") + lines[i]))
+    i = (i + 1)
+  }
+}
+main()

--- a/tests/aster/x/mochi/abbreviations-easy.out.mochi
+++ b/tests/aster/x/mochi/abbreviations-easy.out.mochi
@@ -1,0 +1,105 @@
+fun fields(s: string): list<string> {
+  var words: list<string>
+  var cur: string = ""
+  var i: int = 0
+  while (i < len(s)) {
+    let ch: any = substring(s, i, (i + 1))
+    if (((ch == " ") || (ch == "\n")) || (ch == "\t")) {
+      if (len(cur) > 0) {
+        words = append(words, cur)
+        cur = ""
+      }
+    } else {
+      cur = (cur + ch)
+    }
+    i = (i + 1)
+  }
+  if (len(cur) > 0) {
+    words = append(words, cur)
+  }
+  return words
+}
+fun padRight(s: string, width: int): string {
+  var out: string = s
+  var i: int = len(s)
+  while (i < width) {
+    out = (out + " ")
+    i = (i + 1)
+  }
+  return out
+}
+fun join(xs: list<string>, sep: string): string {
+  var res: string = ""
+  var i: int = 0
+  while (i < len(xs)) {
+    if (i > 0) {
+      res = (res + sep)
+    }
+    res = (res + xs[i])
+    i = (i + 1)
+  }
+  return res
+}
+fun validate(commands: list<string>, words: list<string>, mins: list<int>): list<string> {
+  var results: list<string>
+  if (len(words) == 0) {
+    return results
+  }
+  var wi: int = 0
+  while (wi < len(words)) {
+    let w: string = words[wi]
+    var found: bool = false
+    let wlen: int = len(w)
+    var ci: int = 0
+    while (ci < len(commands)) {
+      let cmd: string = commands[ci]
+      if (((mins[ci] != 0) && (wlen >= mins[ci])) && (wlen <= len(cmd))) {
+        let c: any = upper(cmd)
+        let ww: any = upper(w)
+        if (substring(c, 0, wlen) == ww) {
+          results = append(results, c)
+          found = true
+          break
+        }
+      }
+      ci = (ci + 1)
+    }
+    if !found {
+      results = append(results, "*error*")
+    }
+    wi = (wi + 1)
+  }
+  return results
+}
+fun main(): any {
+  let table: string = (((((("Add ALTer  BAckup Bottom  CAppend Change SCHANGE  CInsert CLAst COMPress Copy " + "COUnt COVerlay CURsor DELete CDelete Down DUPlicate Xedit EXPand EXTract Find ") + "NFind NFINDUp NFUp CFind FINdup FUp FOrward GET Help HEXType Input POWerinput ") + " Join SPlit SPLTJOIN  LOAD  Locate CLocate  LOWercase UPPercase  LPrefix MACRO ") + "MErge MODify MOve MSG Next Overlay PARSE PREServe PURge PUT PUTD  Query  QUIT ") + "READ  RECover REFRESH RENum REPeat  Replace CReplace  RESet  RESTore  RGTLEFT ") + "RIght LEft  SAVE  SET SHift SI  SORT  SOS  STAck STATus  TOP TRAnsfer TypeUp ")
+  let commands: list<string> = fields(table)
+  var mins: list<int>
+  var i: int = 0
+  while (i < len(commands)) {
+    var count: int = 0
+    var j: int = 0
+    let cmd: string = commands[i]
+    while (j < len(cmd)) {
+      let ch: any = substring(cmd, j, (j + 1))
+      if ((ch >= "A") && (ch <= "Z")) {
+        count = (count + 1)
+      }
+      j = (j + 1)
+    }
+    mins = append(mins, count)
+    i = (i + 1)
+  }
+  let sentence: string = "riG   rePEAT copies  put mo   rest    types   fup.    6       poweRin"
+  let words: list<string> = fields(sentence)
+  let results: list<string> = validate(commands, words, mins)
+  var out1: string = "user words:  "
+  var k: int = 0
+  while (k < len(words)) {
+    out1 = ((out1 + padRight(words[k], len(results[k]))) + " ")
+    k = (k + 1)
+  }
+  print(out1)
+  print(("full words:  " + join(results, " ")))
+}
+main()

--- a/tests/aster/x/mochi/abbreviations-simple.out.mochi
+++ b/tests/aster/x/mochi/abbreviations-simple.out.mochi
@@ -1,0 +1,146 @@
+fun fields(s: string): list<string> {
+  var words: list<string>
+  var cur: string = ""
+  var i: int = 0
+  while (i < len(s)) {
+    let ch: any = substring(s, i, (i + 1))
+    if (((ch == " ") || (ch == "\n")) || (ch == "\t")) {
+      if (len(cur) > 0) {
+        words = append(words, cur)
+        cur = ""
+      }
+    } else {
+      cur = (cur + ch)
+    }
+    i = (i + 1)
+  }
+  if (len(cur) > 0) {
+    words = append(words, cur)
+  }
+  return words
+}
+fun padRight(s: string, width: int): string {
+  var out: string = s
+  var i: int = len(s)
+  while (i < width) {
+    out = (out + " ")
+    i = (i + 1)
+  }
+  return out
+}
+fun join(xs: list<string>, sep: string): string {
+  var res: string = ""
+  var i: int = 0
+  while (i < len(xs)) {
+    if (i > 0) {
+      res = (res + sep)
+    }
+    res = (res + xs[i])
+    i = (i + 1)
+  }
+  return res
+}
+fun parseIntStr(str: string): int {
+  var i: int = 0
+  var neg: bool = false
+  if ((len(str) > 0) && (str[0:1] == "-")) {
+    neg = true
+    i = 1
+  }
+  var n: int = 0
+  let digits: map<string, int> = {"0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9}
+  while (i < len(str)) {
+    n = ((n * 10) + digits[str[i:(i + 1)]])
+    i = (i + 1)
+  }
+  if neg {
+    n = -n
+  }
+  return n
+}
+fun isDigits(s: string): bool {
+  if (len(s) == 0) {
+    return false
+  }
+  var i: int = 0
+  while (i < len(s)) {
+    let ch: any = substring(s, i, (i + 1))
+    if ((ch < "0") || (ch > "9")) {
+      return false
+    }
+    i = (i + 1)
+  }
+  return true
+}
+fun readTable(table: string): map<string, any> {
+  let toks: list<string> = fields(table)
+  var cmds: list<string>
+  var mins: list<int>
+  var i: int = 0
+  while (i < len(toks)) {
+    let cmd: string = toks[i]
+    var minlen: int = len(cmd)
+    i = (i + 1)
+    if ((i < len(toks)) && isDigits(toks[i])) {
+      let num: int = parseIntStr(toks[i])
+      if ((num >= 1) && (num < len(cmd))) {
+        minlen = num
+        i = (i + 1)
+      }
+    }
+    cmds = append(cmds, cmd)
+    mins = append(mins, minlen)
+  }
+  return {"commands": cmds, "mins": mins}
+}
+fun validate(commands: list<string>, mins: list<int>, words: list<string>): list<string> {
+  var results: list<string>
+  var wi: int = 0
+  while (wi < len(words)) {
+    let w: string = words[wi]
+    var found: bool = false
+    let wlen: int = len(w)
+    var ci: int = 0
+    while (ci < len(commands)) {
+      let cmd: string = commands[ci]
+      if (((mins[ci] != 0) && (wlen >= mins[ci])) && (wlen <= len(cmd))) {
+        let c: any = upper(cmd)
+        let ww: any = upper(w)
+        if (substring(c, 0, wlen) == ww) {
+          results = append(results, c)
+          found = true
+          break
+        }
+      }
+      ci = (ci + 1)
+    }
+    if !found {
+      results = append(results, "*error*")
+    }
+    wi = (wi + 1)
+  }
+  return results
+}
+fun main(): any {
+  let table: string = (((((((("" + "add 1  alter 3  backup 2  bottom 1  Cappend 2  change 1  Schange  Cinsert 2  Clast 3 ") + "compress 4 copy 2 count 3 Coverlay 3 cursor 3  delete 3 Cdelete 2  down 1  duplicate ") + "3 xEdit 1 expand 3 extract 3  find 1 Nfind 2 Nfindup 6 NfUP 3 Cfind 2 findUP 3 fUP 2 ") + "forward 2  get  help 1 hexType 4  input 1 powerInput 3  join 1 split 2 spltJOIN load ") + "locate 1 Clocate 2 lowerCase 3 upperCase 3 Lprefix 2  macro  merge 2 modify 3 move 2 ") + "msg  next 1 overlay 1 parse preserve 4 purge 3 put putD query 1 quit  read recover 3 ") + "refresh renum 3 repeat 3 replace 1 Creplace 2 reset 3 restore 4 rgtLEFT right 2 left ") + "2  save  set  shift 2  si  sort  sos  stack 3 status 4 top  transfer 3  type 1  up 1 ")
+  let sentence: string = "riG   rePEAT copies  put mo   rest    types   fup.    6\npoweRin"
+  let tbl: map<string, any> = readTable(table)
+  let commands: any = tbl["commands"] as list<string>
+  let mins: any = tbl["mins"] as list<int>
+  let words: list<string> = fields(sentence)
+  let results: list<string> = validate(commands, mins, words)
+  var out1: string = "user words:"
+  var k: int = 0
+  while (k < len(words)) {
+    out1 = (out1 + " ")
+    if (k < (len(words) - 1)) {
+      out1 = (out1 + padRight(words[k], len(results[k])))
+    } else {
+      out1 = (out1 + words[k])
+    }
+    k = (k + 1)
+  }
+  print(out1)
+  print(("full words: " + join(results, " ")))
+}
+main()

--- a/tests/aster/x/mochi/abc-problem.out.mochi
+++ b/tests/aster/x/mochi/abc-problem.out.mochi
@@ -1,0 +1,58 @@
+fun fields(s: string): list<string> {
+  var res: list<string>
+  var cur: string = ""
+  var i: int = 0
+  while (i < len(s)) {
+    let c: any = s[i:(i + 1)]
+    if (c == " ") {
+      if (len(cur) > 0) {
+        res = append(res, cur)
+        cur = ""
+      }
+    } else {
+      cur = (cur + c)
+    }
+    i = (i + 1)
+  }
+  if (len(cur) > 0) {
+    res = append(res, cur)
+  }
+  return res
+}
+fun canSpell(word: string, blks: list<string>): bool {
+  if (len(word) == 0) {
+    return true
+  }
+  let c: any = lower(word[0:1])
+  var i: int = 0
+  while (i < len(blks)) {
+    let b: string = blks[i]
+    if ((c == lower(b[0:1])) || (c == lower(b[1:2]))) {
+      var rest: list<string>
+      var j: int = 0
+      while (j < len(blks)) {
+        if (j != i) {
+          rest = append(rest, blks[j])
+        }
+        j = (j + 1)
+      }
+      if canSpell(word[start], rest) {
+        return true
+      }
+    }
+    i = (i + 1)
+  }
+  return false
+}
+fun newSpeller(blocks: string): any {
+  typefun
+  let bl: list<string> = fields(blocks)
+  return fun(w: string): bool => canSpell(w, bl)
+}
+fun main(): any {
+  let sp: any = newSpeller("BO XK DQ CP NA GT RE TG QD FS JW HU VI AN OB ER FS LY PC ZM")
+  for word in ["A", "BARK", "BOOK", "TREAT", "COMMON", "SQUAD", "CONFUSE"] {
+    print(((word + " ") + str(sp(word))))
+  }
+}
+main()

--- a/tests/aster/x/mochi/abelian-sandpile-model-identity.out.mochi
+++ b/tests/aster/x/mochi/abelian-sandpile-model-identity.out.mochi
@@ -1,0 +1,84 @@
+fun neighborsList(): list<list<int>> {
+  return [[1, 3], [0, 2, 4], [1, 5], [0, 4, 6], [1, 3, 5, 7], [2, 4, 8], [3, 7], [4, 6, 8], [5, 7]]
+}
+fun plus(a: list<int>, b: list<int>): list<int> {
+  var res: list<int>
+  var i: int = 0
+  while (i < len(a)) {
+    res = append(res, (a[i] + b[i]))
+    i = (i + 1)
+  }
+  return res
+}
+fun isStable(p: list<int>): bool {
+  for v in p {
+    if (v > 3) {
+      return false
+    }
+  }
+  return true
+}
+fun topple(p: list<int>): int {
+  let neighbors: list<list<int>> = neighborsList()
+  var i: int = 0
+  while (i < len(p)) {
+    if (p[i] > 3) {
+      p[i] = (p[i] - 4)
+      let nbs: list<int> = neighbors[i]
+      for j in nbs {
+        p[j] = (p[j] + 1)
+      }
+      return 0
+    }
+    i = (i + 1)
+  }
+  return 0
+}
+fun pileString(p: list<int>): string {
+  var s: string = ""
+  var r: int = 0
+  while (r < 3) {
+    var c: int = 0
+    while (c < 3) {
+      s = ((s + str(p[((3 * r) + c)])) + " ")
+      c = (c + 1)
+    }
+    s = (s + "\n")
+    r = (r + 1)
+  }
+  return s
+}
+print("Avalanche of topplings:\n")
+var s4: list<int> = [4, 3, 3, 3, 1, 2, 0, 2, 3]
+print(pileString(s4))
+while !isStable(s4) {
+  topple(s4)
+  print(pileString(s4))
+}
+print("Commutative additions:\n")
+var s1: list<int> = [1, 2, 0, 2, 1, 1, 0, 1, 3]
+var s2: list<int> = [2, 1, 3, 1, 0, 1, 0, 1, 0]
+var s3_a: list<int> = plus(s1, s2)
+while !isStable(s3_a) {
+  topple(s3_a)
+}
+var s3_b: list<int> = plus(s2, s1)
+while !isStable(s3_b) {
+  topple(s3_b)
+}
+print(((((pileString(s1) + "\nplus\n\n") + pileString(s2)) + "\nequals\n\n") + pileString(s3_a)))
+print(((((("and\n\n" + pileString(s2)) + "\nplus\n\n") + pileString(s1)) + "\nalso equals\n\n") + pileString(s3_b)))
+print("Addition of identity sandpile:\n")
+var s3: list<int> = [3, 3, 3, 3, 3, 3, 3, 3, 3]
+var s3_id: list<int> = [2, 1, 2, 1, 0, 1, 2, 1, 2]
+var s4b: list<int> = plus(s3, s3_id)
+while !isStable(s4b) {
+  topple(s4b)
+}
+print(((((pileString(s3) + "\nplus\n\n") + pileString(s3_id)) + "\nequals\n\n") + pileString(s4b)))
+print("Addition of identities:\n")
+var s5: list<int> = plus(s3_id, s3_id)
+while !isStable(s5) {
+  topple(s5)
+}
+print(((((pileString(s3_id) + "\nplus\n\n") + pileString(s3_id)) + "\nequals\n\n") + pileString(s5)))

--- a/tests/aster/x/mochi/abelian-sandpile-model.out.mochi
+++ b/tests/aster/x/mochi/abelian-sandpile-model.out.mochi
@@ -1,0 +1,73 @@
+let dim: int = 16
+fun newPile(d: int): list<list<int>> {
+  var b: list<list<int>>
+  var y: int = 0
+  while (y < d) {
+    var row: list<int>
+    var x: int = 0
+    while (x < d) {
+      row = append(row, 0)
+      x = (x + 1)
+    }
+    b = append(b, row)
+    y = (y + 1)
+  }
+  return b
+}
+fun handlePile(pile: list<list<int>>, x: int, y: int): list<list<int>> {
+  if (pile[y][x] >= 4) {
+    pile[y][x] = (pile[y][x] - 4)
+    if (y > 0) {
+      pile[(y - 1)][x] = (pile[(y - 1)][x] + 1)
+      if (pile[(y - 1)][x] >= 4) {
+        pile = handlePile(pile, x, (y - 1))
+      }
+    }
+    if (x > 0) {
+      pile[y][(x - 1)] = (pile[y][(x - 1)] + 1)
+      if (pile[y][(x - 1)] >= 4) {
+        pile = handlePile(pile, (x - 1), y)
+      }
+    }
+    if (y < (dim - 1)) {
+      pile[(y + 1)][x] = (pile[(y + 1)][x] + 1)
+      if (pile[(y + 1)][x] >= 4) {
+        pile = handlePile(pile, x, (y + 1))
+      }
+    }
+    if (x < (dim - 1)) {
+      pile[y][(x + 1)] = (pile[y][(x + 1)] + 1)
+      if (pile[y][(x + 1)] >= 4) {
+        pile = handlePile(pile, (x + 1), y)
+      }
+    }
+    pile = handlePile(pile, x, y)
+  }
+  return pile
+}
+fun drawPile(pile: list<list<int>>, d: int): any {
+  let chars: list<string> = [" ", "░", "▓", "█"]
+  var row: int = 0
+  while (row < d) {
+    var line: string = ""
+    var col: int = 0
+    while (col < d) {
+      var v: int = pile[row][col]
+      if (v > 3) {
+        v = 3
+      }
+      line = (line + chars[v])
+      col = (col + 1)
+    }
+    print(line)
+    row = (row + 1)
+  }
+}
+fun main(): any {
+  var pile: list<list<int>> = newPile(16)
+  let hdim: int = 7
+  pile[hdim][hdim] = 16
+  pile = handlePile(pile, hdim, hdim)
+  drawPile(pile, 16)
+}
+main()

--- a/tests/aster/x/mochi/abstract-type.error
+++ b/tests/aster/x/mochi/abstract-type.error
@@ -1,0 +1,8 @@
+error[A002]: type mismatch for d: Beast vs Dog
+  --> /workspace/mochi/tests/rosetta/x/Mochi/abstract-type.mochi:34:3
+
+ 34 |   let d: Beast = Dog { kind: "labrador", name: "Max" }
+    |   ^
+
+help:
+  Ensure d matches

--- a/tests/aster/x/mochi/abundant-deficient-and-perfect-number-classifications.out.mochi
+++ b/tests/aster/x/mochi/abundant-deficient-and-perfect-number-classifications.out.mochi
@@ -1,0 +1,34 @@
+fun pfacSum(i: int): int {
+  var sum: int = 0
+  var p: int = 1
+  while (p <= (i / 2)) {
+    if ((i % p) == 0) {
+      sum = (sum + p)
+    }
+    p = (p + 1)
+  }
+  return sum
+}
+fun main(): any {
+  var d: int = 0
+  var a: int = 0
+  var pnum: int = 0
+  var i: int = 1
+  while (i <= 20000) {
+    let j: int = pfacSum(i)
+    if (j < i) {
+      d = (d + 1)
+    }
+    if (j == i) {
+      pnum = (pnum + 1)
+    }
+    if (j > i) {
+      a = (a + 1)
+    }
+    i = (i + 1)
+  }
+  print((("There are " + str(d)) + " deficient numbers between 1 and 20000"))
+  print((("There are " + str(a)) + " abundant numbers  between 1 and 20000"))
+  print((("There are " + str(pnum)) + " perfect numbers between 1 and 20000"))
+}
+main()

--- a/tests/aster/x/mochi/abundant-odd-numbers.out.mochi
+++ b/tests/aster/x/mochi/abundant-odd-numbers.out.mochi
@@ -1,0 +1,84 @@
+fun divisors(n: int): list<int> {
+  var divs: list<int> = [1]
+  var divs2: list<int>
+  var i: int = 2
+  while ((i * i) <= n) {
+    if ((n % i) == 0) {
+      let j: any = ((n / i)) as int
+      divs = append(divs, i)
+      if (i != j) {
+        divs2 = append(divs2, j)
+      }
+    }
+    i = (i + 1)
+  }
+  var j: int = (len(divs2) - 1)
+  while (j >= 0) {
+    divs = append(divs, divs2[j])
+    j = (j - 1)
+  }
+  return divs
+}
+fun sum(xs: list<int>): int {
+  var tot: int = 0
+  for v in xs {
+    tot = (tot + v)
+  }
+  return tot
+}
+fun sumStr(xs: list<int>): string {
+  var s: string = ""
+  var i: int = 0
+  while (i < len(xs)) {
+    s = ((s + str(xs[i])) + " + ")
+    i = (i + 1)
+  }
+  return substring(s, 0, (len(s) - 3))
+}
+fun pad2(n: int): string {
+  let s: string = str(n)
+  if (len(s) < 2) {
+    return (" " + s)
+  }
+  return s
+}
+fun pad5(n: int): string {
+  var s: string = str(n)
+  while (len(s) < 5) {
+    s = (" " + s)
+  }
+  return s
+}
+fun abundantOdd(searchFrom: int, countFrom: int, countTo: int, printOne: bool): int {
+  var count: int = countFrom
+  var n: int = searchFrom
+  while (count < countTo) {
+    let divs: list<int> = divisors(n)
+    let tot: int = sum(divs)
+    if (tot > n) {
+      count = (count + 1)
+      if (printOne && (count < countTo)) {
+        n = (n + 2)
+        continue
+      }
+      let s: string = sumStr(divs)
+      if !printOne {
+        print(((((((pad2(count) + ". ") + pad5(n)) + " < ") + s) + " = ") + str(tot)))
+      } else {
+        print(((((str(n) + " < ") + s) + " = ") + str(tot)))
+      }
+    }
+    n = (n + 2)
+  }
+  return n
+}
+fun main(): any {
+  let max: int = 25
+  print((("The first " + str(max)) + " abundant odd numbers are:"))
+  let n: int = abundantOdd(1, 0, max, false)
+  print("\nThe one thousandth abundant odd number is:")
+  abundantOdd(n, max, 1000, true)
+  print("\nThe first abundant odd number above one billion is:")
+  abundantOdd(1000000001, 0, 1, true)
+}
+main()

--- a/tests/aster/x/mochi/accumulator-factory.out.mochi
+++ b/tests/aster/x/mochi/accumulator-factory.out.mochi
@@ -1,0 +1,16 @@
+fun accumulator(sum: any): any {
+  typefun
+  var store: list<any> = [sum]
+  fun add(nv: any): any {
+    store[0] = (store[0] + nv)
+    return store[0]
+  }
+  return add
+}
+fun main(): any {
+  let x: any = accumulator(1)
+  x(5)
+  accumulator(3)
+  print(str(x(2.3)))
+}
+main()

--- a/tests/aster/x/mochi/achilles-numbers.out.mochi
+++ b/tests/aster/x/mochi/achilles-numbers.out.mochi
@@ -1,0 +1,164 @@
+fun pow10(exp: int): int {
+  var n: int = 1
+  var i: int = 0
+  while (i < exp) {
+    n = (n * 10)
+    i = (i + 1)
+  }
+  return n
+}
+fun totient(n: int): int {
+  var tot: int = n
+  var nn: int = n
+  var i: int = 2
+  while ((i * i) <= nn) {
+    if ((nn % i) == 0) {
+      while ((nn % i) == 0) {
+        nn = (nn / i)
+      }
+      tot = (tot - (tot / i))
+    }
+    if (i == 2) {
+      i = 1
+    }
+    i = (i + 2)
+  }
+  if (nn > 1) {
+    tot = (tot - (tot / nn))
+  }
+  return tot
+}
+var pps: map<int, bool>
+fun getPerfectPowers(maxExp: int): any {
+  let upper: int = pow10(maxExp)
+  var i: int = 2
+  while ((i * i) < upper) {
+    var p: int = i
+    while true {
+      p = (p * i)
+      if (p >= upper) {
+        break
+      }
+      pps[p] = true
+    }
+    i = (i + 1)
+  }
+}
+fun getAchilles(minExp: int, maxExp: int): map<int, bool> {
+  let lower: int = pow10(minExp)
+  let upper: int = pow10(maxExp)
+  var achilles: map<int, bool>
+  var b: int = 1
+  while (((b * b) * b) < upper) {
+    let b3: int = ((b * b) * b)
+    var a: int = 1
+    while true {
+      let p: int = ((b3 * a) * a)
+      if (p >= upper) {
+        break
+      }
+      if (p >= lower) {
+        if !((p in pps)) {
+          achilles[p] = true
+        }
+      }
+      a = (a + 1)
+    }
+    b = (b + 1)
+  }
+  return achilles
+}
+fun sortInts(xs: list<int>): list<int> {
+  var res: list<int>
+  var tmp: list<int> = xs
+  while (len(tmp) > 0) {
+    var min: int = tmp[0]
+    var idx: int = 0
+    var i: int = 1
+    while (i < len(tmp)) {
+      if (tmp[i] < min) {
+        min = tmp[i]
+        idx = i
+      }
+      i = (i + 1)
+    }
+    res = (res + [min])
+    var out: list<int>
+    var j: int = 0
+    while (j < len(tmp)) {
+      if (j != idx) {
+        out = (out + [tmp[j]])
+      }
+      j = (j + 1)
+    }
+    tmp = out
+  }
+  return res
+}
+fun pad(n: int, width: int): string {
+  var s: string = str(n)
+  while (len(s) < width) {
+    s = (" " + s)
+  }
+  return s
+}
+fun main(): any {
+  let maxDigits: int = 15
+  getPerfectPowers(5)
+  let achSet: map<int, bool> = getAchilles(1, 5)
+  var ach: list<int>
+  for k in achSet.keys() {
+    ach = (ach + [k])
+  }
+  ach = sortInts(ach)
+  print("First 50 Achilles numbers:")
+  var i: int = 0
+  while (i < 50) {
+    var line: string = ""
+    var j: int = 0
+    while (j < 10) {
+      line = (line + pad(ach[i], 4))
+      if (j < 9) {
+        line = (line + " ")
+      }
+      i = (i + 1)
+      j = (j + 1)
+    }
+    print(line)
+  }
+  print("\nFirst 30 strong Achilles numbers:")
+  var strong: list<int>
+  var count: int = 0
+  var idx: int = 0
+  while (count < 30) {
+    let tot: int = totient(ach[idx])
+    if (tot in achSet) {
+      strong = (strong + [ach[idx]])
+      count = (count + 1)
+    }
+    idx = (idx + 1)
+  }
+  i = 0
+  while (i < 30) {
+    var line: string = ""
+    var j: int = 0
+    while (j < 10) {
+      line = (line + pad(strong[i], 5))
+      if (j < 9) {
+        line = (line + " ")
+      }
+      i = (i + 1)
+      j = (j + 1)
+    }
+    print(line)
+  }
+  print("\nNumber of Achilles numbers with:")
+  let counts: list<int> = [1, 12, 47, 192, 664, 2242, 7395, 24008, 77330, 247449, 788855, 2508051, 7960336, 25235383]
+  var d: int = 2
+  while (d <= maxDigits) {
+    let c: int = counts[(d - 2)]
+    print(((pad(d, 2) + " digits: ") + str(c)))
+    d = (d + 1)
+  }
+}
+main()

--- a/tests/aster/x/mochi/ackermann-function-2.out.mochi
+++ b/tests/aster/x/mochi/ackermann-function-2.out.mochi
@@ -1,0 +1,34 @@
+fun pow(base: int, exp: int): int {
+  var result: int = 1
+  var i: int = 0
+  while (i < exp) {
+    result = (result * base)
+    i = (i + 1)
+  }
+  return result
+}
+fun ackermann2(m: int, n: int): int {
+  if (m == 0) {
+    return (n + 1)
+  }
+  if (m == 1) {
+    return (n + 2)
+  }
+  if (m == 2) {
+    return ((2 * n) + 3)
+  }
+  if (m == 3) {
+    return ((8 * pow(2, n)) - 3)
+  }
+  if (n == 0) {
+    return ackermann2((m - 1), 1)
+  }
+  return ackermann2((m - 1), ackermann2(m, (n - 1)))
+}
+fun main(): any {
+  print(("A(0, 0) = " + str(ackermann2(0, 0))))
+  print(("A(1, 2) = " + str(ackermann2(1, 2))))
+  print(("A(2, 4) = " + str(ackermann2(2, 4))))
+  print(("A(3, 4) = " + str(ackermann2(3, 4))))
+}
+main()

--- a/tests/aster/x/mochi/ackermann-function-3.error
+++ b/tests/aster/x/mochi/ackermann-function-3.error
@@ -1,0 +1,8 @@
+error[A002]: type mismatch for result: bigint vs int
+  --> /workspace/mochi/tests/rosetta/x/Mochi/ackermann-function-3.mochi:5:3
+
+  5 |   var result: bigint = 1
+    |   ^
+
+help:
+  Ensure result matches

--- a/tests/aster/x/mochi/ackermann-function.out.mochi
+++ b/tests/aster/x/mochi/ackermann-function.out.mochi
@@ -1,0 +1,16 @@
+fun ackermann(m: int, n: int): int {
+  if (m == 0) {
+    return (n + 1)
+  }
+  if (n == 0) {
+    return ackermann((m - 1), 1)
+  }
+  return ackermann((m - 1), ackermann(m, (n - 1)))
+}
+fun main(): any {
+  print(("A(0, 0) = " + str(ackermann(0, 0))))
+  print(("A(1, 2) = " + str(ackermann(1, 2))))
+  print(("A(2, 4) = " + str(ackermann(2, 4))))
+  print(("A(3, 4) = " + str(ackermann(3, 4))))
+}
+main()

--- a/tests/aster/x/mochi/active-directory-connect.out.mochi
+++ b/tests/aster/x/mochi/active-directory-connect.out.mochi
@@ -1,0 +1,23 @@
+type LDAPClient {
+  Base: string
+  Host: string
+  Port: int
+  UseSSL: bool
+  BindDN: string
+  BindPassword: string
+  UserFilter: string
+  GroupFilter: string
+  Attributes: list<string>
+}
+fun connect(client: LDAPClient): bool {
+  return ((client.Host != "") && (client.Port > 0))
+}
+fun main(): any {
+  let client: LDAPClient = LDAPClient {Base: "dc=example,dc=com", Host: "ldap.example.com", Port: 389, UseSSL: false, BindDN: "uid=readonlyuser,ou=People,dc=example,dc=com", BindPassword: "readonlypassword", UserFilter: "(uid=%s)", GroupFilter: "(memberUid=%s)", Attributes: ["givenName", "sn", "mail", "uid"]}
+  if connect(client) {
+    print(("Connected to " + client.Host))
+  } else {
+    print("Failed to connect")
+  }
+}
+main()


### PR DESCRIPTION
## Summary
- capture parser positions in `ast` nodes so decorator diagnostics report line numbers
- handle function declarations and calls in the decorator, including basic builtin types
- enable Rosetta decoration test to parse files with position info and standardize error formatting
- record decorator failures for Rosetta programs, writing `.error` files with source snippets and recovering from panics

## Testing
- `go test ./aster/x/mochi -run TestDecorate -count=1`
- `go test -c -tags slow ./aster/x/mochi`
- `for i in $(seq 1 30); do MOCHI_ROSETTA_INDEX=$i ./mochi.test -test.run TestRosettaDecorate -test.count=1; done`


------
https://chatgpt.com/codex/tasks/task_e_689007310e78832083d9bcd589f048db