### PR TITLE
feat: add cast support to decorator

### DIFF
--- a/aster/x/mochi/decorator.go
+++ b/aster/x/mochi/decorator.go
@@ -181,6 +181,14 @@ func inferType(n *Node, env map[string]*Node) (*Node, error) {
 			}
 		}
 		return &Node{Kind: "type", Text: "any"}, nil
+	case "cast":
+		if len(n.Children) < 2 || n.Children[1].Kind != "type" {
+			return nil, errCastMissingType(n)
+		}
+		if _, err := inferType(n.Children[0], env); err != nil {
+			return nil, err
+		}
+		return cloneNode(n.Children[1]), nil
 	case "group":
 		if len(n.Children) != 1 {
 			return nil, errGroupOneChild(n)

--- a/aster/x/mochi/errors.go
+++ b/aster/x/mochi/errors.go
@@ -33,6 +33,7 @@ var Errors = map[string]diagnostic.Template{
 	"A019": {Code: "A019", Message: "map key type mismatch: %s vs %s", Help: "Ensure the key matches the map's key type"},
 	"A020": {Code: "A020", Message: "unknown field %s on %s", Help: "Check the struct definition"},
 	"A021": {Code: "A021", Message: "%s is not a struct", Help: "Field access is only valid on structs"},
+	"A022": {Code: "A022", Message: "cast expects a type", Help: "Provide a type after 'as'"},
 }
 
 func pos(n *Node) lexer.Position {
@@ -145,4 +146,8 @@ func errNotStruct(typ *Node, n *Node) error {
 	tmpl := Errors["A021"]
 	msg := fmt.Sprintf(tmpl.Message, typeString(typ))
 	return diagnostic.New(tmpl.Code, pos(n), msg, tmpl.Help)
+}
+
+func errCastMissingType(n *Node) error {
+	return Errors["A022"].New(pos(n))
 }

--- a/tests/aster/x/mochi/100-prisoners.error
+++ b/tests/aster/x/mochi/100-prisoners.error
@@ -1,8 +1,0 @@
-error[A011]: numeric op with non-numeric
-  --> /workspace/mochi/tests/rosetta/x/Mochi/100-prisoners.mochi:73:32
-
- 73 |   let rf = (pardoned as float) / (trials as float) * 100.0
-    |                                ^
-
-help:
-  Use numeric operands

--- a/tests/aster/x/mochi/100-prisoners.out.mochi
+++ b/tests/aster/x/mochi/100-prisoners.out.mochi
@@ -1,0 +1,84 @@
+fun shuffle(xs: list<int>): list<int> {
+  var arr: list<int> = xs
+  var i: int = 99
+  while (i > 0) {
+    let j: int = (now() % ((i + 1)))
+    let tmp: int = arr[i]
+    arr[i] = arr[j]
+    arr[j] = tmp
+    i = (i - 1)
+  }
+  return arr
+}
+fun doTrials(trials: int, np: int, strategy: string): any {
+  var pardoned: int = 0
+  var t: int = 0
+  while (t < trials) {
+    var drawers: list<int>
+    var i: int = 0
+    while (i < 100) {
+      drawers = append(drawers, i)
+      i = (i + 1)
+    }
+    drawers = shuffle(drawers)
+    var p: int = 0
+    var success: bool = true
+    while (p < np) {
+      var found: bool = false
+      if (strategy == "optimal") {
+        var prev: int = p
+        var d: int = 0
+        while (d < 50) {
+          let this: int = drawers[prev]
+          if (this == p) {
+            found = true
+            break
+          }
+          prev = this
+          d = (d + 1)
+        }
+      } else {
+        var opened: list<bool>
+        var k: int = 0
+        while (k < 100) {
+          opened = append(opened, false)
+          k = (k + 1)
+        }
+        var d: int = 0
+        while (d < 50) {
+          var n: int = (now() % 100)
+          while opened[n] {
+            n = (now() % 100)
+          }
+          opened[n] = true
+          if (drawers[n] == p) {
+            found = true
+            break
+          }
+          d = (d + 1)
+        }
+      }
+      if !found {
+        success = false
+        break
+      }
+      p = (p + 1)
+    }
+    if success {
+      pardoned = (pardoned + 1)
+    }
+    t = (t + 1)
+  }
+  let rf: float = (((pardoned as float) / (trials as float)) * 100)
+  print((((((("  strategy = " + strategy) + "  pardoned = ") + str(pardoned)) + " relative frequency = ") + str(rf)) + "%"))
+}
+fun main(): any {
+  let trials: int = 1000
+  for np in [10, 100] {
+    print((((("Results from " + str(trials)) + " trials with ") + str(np)) + " prisoners:\n"))
+    for strat in ["random", "optimal"] {
+      doTrials(trials, np, strat)
+    }
+  }
+}
+main()

--- a/tests/aster/x/mochi/99-bottles-of-beer-2.error
+++ b/tests/aster/x/mochi/99-bottles-of-beer-2.error
@@ -1,8 +1,0 @@
-error[A018]: list index must be int
-  --> /workspace/mochi/tests/rosetta/x/Mochi/99-bottles-of-beer-2.mochi:49:17
-
- 49 |     var t = tens[(n / 10) as int]
-    |                 ^
-
-help:
-  Use an int index

--- a/tests/aster/x/mochi/99-bottles-of-beer-2.out.mochi
+++ b/tests/aster/x/mochi/99-bottles-of-beer-2.out.mochi
@@ -1,0 +1,109 @@
+fun fields(s: string): list<string> {
+  var words: list<string>
+  var cur: string = ""
+  var i: int = 0
+  while (i < len(s)) {
+    let ch: any = substring(s, i, (i + 1))
+    if (((ch == " ") || (ch == "\n")) || (ch == "\t")) {
+      if (len(cur) > 0) {
+        words = append(words, cur)
+        cur = ""
+      }
+    } else {
+      cur = (cur + ch)
+    }
+    i = (i + 1)
+  }
+  if (len(cur) > 0) {
+    words = append(words, cur)
+  }
+  return words
+}
+fun join(xs: list<string>, sep: string): string {
+  var res: string = ""
+  var i: int = 0
+  while (i < len(xs)) {
+    if (i > 0) {
+      res = (res + sep)
+    }
+    res = (res + xs[i])
+    i = (i + 1)
+  }
+  return res
+}
+fun numberName(n: int): string {
+  let small: list<string> = ["no", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen", "nineteen"]
+  let tens: list<string> = ["ones", "ten", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety"]
+  if (n < 0) {
+    return ""
+  }
+  if (n < 20) {
+    return small[n]
+  }
+  if (n < 100) {
+    var t: string = tens[((n / 10)) as int]
+    var s: int = (n % 10)
+    if (s > 0) {
+      t = ((t + " ") + small[s])
+    }
+    return t
+  }
+  return ""
+}
+fun pluralizeFirst(s: string, n: int): string {
+  if (n == 1) {
+    return s
+  }
+  let w: list<string> = fields(s)
+  if (len(w) > 0) {
+    w[0] = (w[0] + "s")
+  }
+  return join(w, " ")
+}
+fun randInt(seed: int, n: int): int {
+  let next: int = ((((seed * 1664525) + 1013904223)) % 2147483647)
+  return (next % n)
+}
+fun slur(p: string, d: int): string {
+  if (len(p) <= 2) {
+    return p
+  }
+  var a: list<string>
+  var i: int = 1
+  while (i < (len(p) - 1)) {
+    a = append(a, substring(p, i, (i + 1)))
+    i = (i + 1)
+  }
+  var idx: int = (len(a) - 1)
+  var seed: int = d
+  while (idx >= 1) {
+    seed = ((((seed * 1664525) + 1013904223)) % 2147483647)
+    if ((seed % 100) >= d) {
+      let j: int = (seed % ((idx + 1)))
+      let tmp: string = a[idx]
+      a[idx] = a[j]
+      a[j] = tmp
+    }
+    idx = (idx - 1)
+  }
+  var s: any = substring(p, 0, 1)
+  var k: int = 0
+  while (k < len(a)) {
+    s = (s + a[k])
+    k = (k + 1)
+  }
+  s = (s + substring(p, (len(p) - 1), len(p)))
+  let w: list<string> = fields(s)
+  return join(w, " ")
+}
+fun main(): any {
+  var i: int = 99
+  while (i > 0) {
+    print(((((slur(numberName(i), i) + " ") + pluralizeFirst(slur("bottle of", i), i)) + " ") + slur("beer on the wall", i)))
+    print(((((slur(numberName(i), i) + " ") + pluralizeFirst(slur("bottle of", i), i)) + " ") + slur("beer", i)))
+    print(((((slur("take one", i) + " ") + slur("down", i)) + " ") + slur("pass it around", i)))
+    print(((((slur(numberName((i - 1)), i) + " ") + pluralizeFirst(slur("bottle of", i), (i - 1))) + " ") + slur("beer on the wall", i)))
+    i = (i - 1)
+  }
+}
+main()

--- a/tests/aster/x/mochi/abbreviations-simple.out.mochi
+++ b/tests/aster/x/mochi/abbreviations-simple.out.mochi
@@ -125,8 +125,8 @@ fun main(): any {
   let table: string = (((((((("" + "add 1  alter 3  backup 2  bottom 1  Cappend 2  change 1  Schange  Cinsert 2  Clast 3 ") + "compress 4 copy 2 count 3 Coverlay 3 cursor 3  delete 3 Cdelete 2  down 1  duplicate ") + "3 xEdit 1 expand 3 extract 3  find 1 Nfind 2 Nfindup 6 NfUP 3 Cfind 2 findUP 3 fUP 2 ") + "forward 2  get  help 1 hexType 4  input 1 powerInput 3  join 1 split 2 spltJOIN load ") + "locate 1 Clocate 2 lowerCase 3 upperCase 3 Lprefix 2  macro  merge 2 modify 3 move 2 ") + "msg  next 1 overlay 1 parse preserve 4 purge 3 put putD query 1 quit  read recover 3 ") + "refresh renum 3 repeat 3 replace 1 Creplace 2 reset 3 restore 4 rgtLEFT right 2 left ") + "2  save  set  shift 2  si  sort  sos  stack 3 status 4 top  transfer 3  type 1  up 1 ")
   let sentence: string = "riG   rePEAT copies  put mo   rest    types   fup.    6\npoweRin"
   let tbl: map<string, any> = readTable(table)
-  let commands: any = tbl["commands"] as list<string>
-  let mins: any = tbl["mins"] as list<int>
+  let commands: list<string> = tbl["commands"] as list<string>
+  let mins: list<int> = tbl["mins"] as list<int>
   let words: list<string> = fields(sentence)
   let results: list<string> = validate(commands, mins, words)
   var out1: string = "user words:"

--- a/tests/aster/x/mochi/abundant-odd-numbers.out.mochi
+++ b/tests/aster/x/mochi/abundant-odd-numbers.out.mochi
@@ -4,7 +4,7 @@ fun divisors(n: int): list<int> {
   var i: int = 2
   while ((i * i) <= n) {
     if ((n % i) == 0) {
-      let j: any = ((n / i)) as int
+      let j: int = ((n / i)) as int
       divs = append(divs, i)
       if (i != j) {
         divs2 = append(divs2, j)


### PR DESCRIPTION
## Summary
- add cast expression handling to mochi decorator with validation
- track missing cast type errors via A022 diagnostic
- regenerate Rosetta outputs for first 30 programs, including new files

## Testing
- `go test ./aster/x/mochi -run TestDecorate -count=1`
- `for i in $(seq 1 30); do MOCHI_ROSETTA_INDEX=$i go test -tags slow ./aster/x/mochi -run TestRosettaDecorate -count=1; done`

------
https://chatgpt.com/codex/tasks/task_e_689021ef14d483208c4cbfc203a50f8a