### PR TITLE
mochi: improve decorator void handling

### DIFF
--- a/aster/x/mochi/errors.go
+++ b/aster/x/mochi/errors.go
@@ -40,6 +40,7 @@ var Errors = map[string]diagnostic.Template{
 	"A026": {Code: "A026", Message: "argument %d to %s type mismatch: %s vs %s", Help: "Ensure arguments match parameter types"},
 	"A027": {Code: "A027", Message: "missing return type", Help: "Specify a return type"},
 	"A028": {Code: "A028", Message: "return type mismatch: expected %s, got %s", Help: "Ensure return value matches"},
+	"A029": {Code: "A029", Message: "void function should not return a value", Help: "Remove the return value or change the return type"},
 }
 
 func pos(n *Node) lexer.Position {
@@ -193,4 +194,8 @@ func errReturnTypeMismatch(want, got *Node, n *Node) error {
 	tmpl := Errors["A028"]
 	msg := fmt.Sprintf(tmpl.Message, typeString(want), typeString(got))
 	return diagnostic.New(tmpl.Code, pos(n), msg, tmpl.Help)
+}
+
+func errVoidReturnValue(n *Node) error {
+	return Errors["A029"].New(pos(n))
 }

--- a/tests/aster/x/mochi/100-prisoners.out.mochi
+++ b/tests/aster/x/mochi/100-prisoners.out.mochi
@@ -10,7 +10,7 @@ fun shuffle(xs: list<int>): list<int> {
   }
   return arr
 }
-fun doTrials(trials: int, np: int, strategy: string): void {
+fun doTrials(trials: int, np: int, strategy: string) {
   var pardoned: int = 0
   var t: int = 0
   while (t < trials) {
@@ -72,7 +72,7 @@ fun doTrials(trials: int, np: int, strategy: string): void {
   let rf: float = (((pardoned as float) / (trials as float)) * 100)
   print((((((("  strategy = " + strategy) + "  pardoned = ") + str(pardoned)) + " relative frequency = ") + str(rf)) + "%"))
 }
-fun main(): void {
+fun main() {
   let trials: int = 1000
   for np in [10, 100] {
     print((((("Results from " + str(trials)) + " trials with ") + str(np)) + " prisoners:\n"))

--- a/tests/aster/x/mochi/24-game-solve.out.mochi
+++ b/tests/aster/x/mochi/24-game-solve.out.mochi
@@ -89,7 +89,7 @@ fun solve(xs: list<Node>): bool {
   }
   return false
 }
-fun main(): void {
+fun main() {
   var iter: int = 0
   while (iter < 10) {
     var cards: list<Node>

--- a/tests/aster/x/mochi/99-bottles-of-beer.out.mochi
+++ b/tests/aster/x/mochi/99-bottles-of-beer.out.mochi
@@ -7,7 +7,7 @@ fun bottles(n: int): string {
   }
   return (str(n) + " bottles")
 }
-fun main(): void {
+fun main() {
   var i: int = 99
   while (i > 0) {
     print((bottles(i) + " of beer on the wall"))

--- a/tests/aster/x/mochi/a+b.out.mochi
+++ b/tests/aster/x/mochi/a+b.out.mochi
@@ -1,4 +1,4 @@
-fun main(): void {
+fun main() {
   let a: int = int(input())
   let b: int = int(input())
   print((a + b))

--- a/tests/aster/x/mochi/abelian-sandpile-model.out.mochi
+++ b/tests/aster/x/mochi/abelian-sandpile-model.out.mochi
@@ -45,7 +45,7 @@ fun handlePile(pile: list<list<int>>, x: int, y: int): list<list<int>> {
   }
   return pile
 }
-fun drawPile(pile: list<list<int>>, d: int): void {
+fun drawPile(pile: list<list<int>>, d: int) {
   let chars: list<string> = [" ", "░", "▓", "█"]
   var row: int = 0
   while (row < d) {
@@ -63,7 +63,7 @@ fun drawPile(pile: list<list<int>>, d: int): void {
     row = (row + 1)
   }
 }
-fun main(): void {
+fun main() {
   var pile: list<list<int>> = newPile(16)
   let hdim: int = 7
   pile[hdim][hdim] = 16

--- a/tests/aster/x/mochi/abundant-deficient-and-perfect-number-classifications.out.mochi
+++ b/tests/aster/x/mochi/abundant-deficient-and-perfect-number-classifications.out.mochi
@@ -9,7 +9,7 @@ fun pfacSum(i: int): int {
   }
   return sum
 }
-fun main(): void {
+fun main() {
   var d: int = 0
   var a: int = 0
   var pnum: int = 0

--- a/tests/aster/x/mochi/achilles-numbers.out.mochi
+++ b/tests/aster/x/mochi/achilles-numbers.out.mochi
@@ -29,7 +29,7 @@ fun totient(n: int): int {
   return tot
 }
 var pps: map<int, bool>
-fun getPerfectPowers(maxExp: int): void {
+fun getPerfectPowers(maxExp: int) {
   let upper: int = pow10(maxExp)
   var i: int = 2
   while ((i * i) < upper) {
@@ -102,7 +102,7 @@ fun pad(n: int, width: int): string {
   }
   return s
 }
-fun main(): void {
+fun main() {
   let maxDigits: int = 15
   getPerfectPowers(5)
   let achSet: map<int, bool> = getAchilles(1, 5)

--- a/tests/aster/x/mochi/ackermann-function-2.out.mochi
+++ b/tests/aster/x/mochi/ackermann-function-2.out.mochi
@@ -25,7 +25,7 @@ fun ackermann2(m: int, n: int): int {
   }
   return ackermann2((m - 1), ackermann2(m, (n - 1)))
 }
-fun main(): void {
+fun main() {
   print(("A(0, 0) = " + str(ackermann2(0, 0))))
   print(("A(1, 2) = " + str(ackermann2(1, 2))))
   print(("A(2, 4) = " + str(ackermann2(2, 4))))

--- a/tests/aster/x/mochi/ackermann-function.out.mochi
+++ b/tests/aster/x/mochi/ackermann-function.out.mochi
@@ -7,7 +7,7 @@ fun ackermann(m: int, n: int): int {
   }
   return ackermann((m - 1), ackermann(m, (n - 1)))
 }
-fun main(): void {
+fun main() {
   print(("A(0, 0) = " + str(ackermann(0, 0))))
   print(("A(1, 2) = " + str(ackermann(1, 2))))
   print(("A(2, 4) = " + str(ackermann(2, 4))))

--- a/tests/aster/x/mochi/active-directory-connect.out.mochi
+++ b/tests/aster/x/mochi/active-directory-connect.out.mochi
@@ -12,7 +12,7 @@ type LDAPClient {
 fun connect(client: LDAPClient): bool {
   return ((client.Host != "") && (client.Port > 0))
 }
-fun main(): void {
+fun main() {
   let client: LDAPClient = LDAPClient {Base: "dc=example,dc=com", Host: "ldap.example.com", Port: 389, UseSSL: false, BindDN: "uid=readonlyuser,ou=People,dc=example,dc=com", BindPassword: "readonlypassword", UserFilter: "(uid=%s)", GroupFilter: "(memberUid=%s)", Attributes: ["givenName", "sn", "mail", "uid"]}
   if connect(client) {
     print(("Connected to " + client.Host))


### PR DESCRIPTION
## Summary
- enforce error when void functions return values
- support closure type inference and initializer decoration
- update Rosetta outputs to omit `: void`

## Testing
- `go test ./aster/x/mochi`
- `for i in $(seq 1 30); do MOCHI_ROSETTA_INDEX=$i go test -run TestRosettaDecorate -tags=slow ./aster/x/mochi; done`


------
https://chatgpt.com/codex/tasks/task_e_68902e39b1b08320a99d0f47eeb3f36e