### PR TITLE
Improve Kotlin transpiler and generate Rosetta outputs

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/csv-to-html-translation-2.bench
+++ b/tests/rosetta/transpiler/Kotlin/csv-to-html-translation-2.bench
@@ -1,0 +1,1 @@
+{"duration_us":22268, "memory_bytes":120744, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/csv-to-html-translation-2.kt
+++ b/tests/rosetta/transpiler/Kotlin/csv-to-html-translation-2.kt
@@ -1,0 +1,82 @@
+fun split(s: String, sep: String): MutableList<String> {
+    return s.split(sep).toMutableList()
+}
+
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+var c: String = (((("Character,Speech\n" + "The multitude,The messiah! Show us the messiah!\n") + "Brians mother,<angry>Now you listen here! He's not the messiah; he's a very naughty boy! Now go away!</angry>\n") + "The multitude,Who are you?\n") + "Brians mother,I'm his mother; that's who!\n") + "The multitude,Behold his mother! Behold his mother!"
+var rows: MutableList<MutableList<String>> = mutableListOf<MutableList<String>>()
+var headings: Boolean = true
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        for (line in split(c, "\n")) {
+            rows = run { val _tmp = rows.toMutableList(); _tmp.add(split(line, ",")); _tmp }
+        }
+        println("<table>")
+        if ((headings as Boolean)) {
+            if (rows.size > 0) {
+                var th: String = ""
+                for (h in rows[0]!!) {
+                    th = (((((th + "<th>") + (h).toString()).toString()) + "</th>") as String)
+                }
+                println("   <thead>")
+                println(("      <tr>" + th) + "</tr>")
+                println("   </thead>")
+                println("   <tbody>")
+                var i: Int = 1
+                while (i < rows.size) {
+                    var cells: String = ""
+                    for (cell in rows[i]!!) {
+                        cells = (((((cells + "<td>") + (cell).toString()).toString()) + "</td>") as String)
+                    }
+                    println(("      <tr>" + cells) + "</tr>")
+                    i = i + 1
+                }
+                println("   </tbody>")
+            }
+        } else {
+            for (row in rows) {
+                var cells: String = ""
+                for (cell in row) {
+                    cells = ((cells + "<td>") + cell) + "</td>"
+                }
+                println(("    <tr>" + cells) + "</tr>")
+            }
+        }
+        println("</table>")
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/csv-to-html-translation-3.bench
+++ b/tests/rosetta/transpiler/Kotlin/csv-to-html-translation-3.bench
@@ -1,0 +1,1 @@
+{"duration_us":9847, "memory_bytes":136264, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/csv-to-html-translation-3.kt
+++ b/tests/rosetta/transpiler/Kotlin/csv-to-html-translation-3.kt
@@ -1,0 +1,52 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        println("<table>")
+        println("   <thead>")
+        println("      <tr><th>Character</th><th>Speech</th></tr>")
+        println("   </thead>")
+        println("   <tbody>")
+        println("      <tr><td>The multitude</td><td>The messiah! Show us the messiah!</td></tr>")
+        println("      <tr><td>Brians mother</td><td>&lt;angry&gt;Now you listen here! He&#39;s not the messiah; he&#39;s a very naughty boy! Now go away!&lt;/angry&gt;</td></tr>")
+        println("      <tr><td>The multitude</td><td>Who are you?</td></tr>")
+        println("      <tr><td>Brians mother</td><td>I&#39;m his mother; that&#39;s who!</td></tr>")
+        println("      <tr><td>The multitude</td><td>Behold his mother! Behold his mother!</td></tr>")
+        println("   </tbody>")
+        println("</table>")
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/csv-to-html-translation-4.bench
+++ b/tests/rosetta/transpiler/Kotlin/csv-to-html-translation-4.bench
@@ -1,0 +1,1 @@
+{"duration_us":6161, "memory_bytes":136512, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/csv-to-html-translation-4.kt
+++ b/tests/rosetta/transpiler/Kotlin/csv-to-html-translation-4.kt
@@ -1,0 +1,48 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        println("<table>")
+        println("    <tr><td>Character</td><td>Speech</td></tr>")
+        println("    <tr><td>The multitude</td><td>The messiah! Show us the messiah!</td></tr>")
+        println("    <tr><td>Brians mother</td><td>&lt;angry&gt;Now you listen here! He&#39;s not the messiah; he&#39;s a very naughty boy! Now go away!&lt;/angry&gt;</td></tr>")
+        println("    <tr><td>The multitude</td><td>Who are you?</td></tr>")
+        println("    <tr><td>Brians mother</td><td>I&#39;m his mother; that&#39;s who!</td></tr>")
+        println("    <tr><td>The multitude</td><td>Behold his mother! Behold his mother!</td></tr>")
+        println("</table>")
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/csv-to-html-translation-5.bench
+++ b/tests/rosetta/transpiler/Kotlin/csv-to-html-translation-5.bench
@@ -1,0 +1,1 @@
+{"duration_us":22905, "memory_bytes":125272, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/csv-to-html-translation-5.kt
+++ b/tests/rosetta/transpiler/Kotlin/csv-to-html-translation-5.kt
@@ -1,0 +1,95 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+var c: String = (((("Character,Speech\n" + "The multitude,The messiah! Show us the messiah!\n") + "Brians mother,<angry>Now you listen here! He's not the messiah; he's a very naughty boy! Now go away!</angry>\n") + "The multitude,Who are you?\n") + "Brians mother,I'm his mother; that's who!\n") + "The multitude,Behold his mother! Behold his mother!"
+var rows: MutableList<MutableList<String>> = mutableListOf<MutableList<String>>()
+fun split(s: String, sep: String): MutableList<String> {
+    var out: MutableList<String> = mutableListOf<String>()
+    var start: Int = 0
+    var i: Int = 0
+    var n: Int = sep.length
+    while (i <= (s.length - n)) {
+        if (s.substring(i, i + n) == sep) {
+            out = run { val _tmp = out.toMutableList(); _tmp.add(s.substring(start, i)); _tmp }
+            i = i + n
+            start = i
+        } else {
+            i = i + 1
+        }
+    }
+    out = run { val _tmp = out.toMutableList(); _tmp.add(s.substring(start, s.length)); _tmp }
+    return out
+}
+
+fun htmlEscape(s: String): String {
+    var out: String = ""
+    var i: Int = 0
+    while (i < s.length) {
+        var ch: String = s.substring(i, i + 1)
+        if (ch == "&") {
+            out = out + "&amp;"
+        } else {
+            if (ch == "<") {
+                out = out + "&lt;"
+            } else {
+                if (ch == ">") {
+                    out = out + "&gt;"
+                } else {
+                    out = out + ch
+                }
+            }
+        }
+        i = i + 1
+    }
+    return out
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        for (line in split(c, "\n")) {
+            rows = run { val _tmp = rows.toMutableList(); _tmp.add(split(line, ",")); _tmp }
+        }
+        println("<table>")
+        for (row in rows) {
+            var cells: String = ""
+            for (cell in row) {
+                cells = ((cells + "<td>") + htmlEscape(cell)) + "</td>"
+            }
+            println(("    <tr>" + cells) + "</tr>")
+        }
+        println("</table>")
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/cuban-primes.bench
+++ b/tests/rosetta/transpiler/Kotlin/cuban-primes.bench
@@ -1,0 +1,1 @@
+{"duration_us":4928960, "memory_bytes":851360, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/cuban-primes.kt
+++ b/tests/rosetta/transpiler/Kotlin/cuban-primes.kt
@@ -1,0 +1,176 @@
+import java.math.BigInteger
+
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+fun modPow(base: Int, exp: Int, m: Int): Int {
+    var result: BigInteger = (Math.floorMod(1, m)).toBigInteger()
+    var b: BigInteger = (Math.floorMod(base, m)).toBigInteger()
+    var e: Int = exp
+    while (e > 0) {
+        if ((Math.floorMod(e, 2)) == 1) {
+            result = (result.multiply((b))).remainder((m).toBigInteger())
+        }
+        b = (b.multiply((b))).remainder((m).toBigInteger())
+        e = ((e / 2).toInt())
+    }
+    return (result.toInt())
+}
+
+fun isPrime(n: Int): Boolean {
+    if (n < 2) {
+        return false
+    }
+    for (p in mutableListOf(2, 3, 5, 7, 11, 13, 17, 19, 23, 29)) {
+        if ((Math.floorMod(n, p)) == 0) {
+            return n == p
+        }
+    }
+    var d: BigInteger = (n - 1).toBigInteger()
+    var s: Int = 0
+    while ((d.remainder((2).toBigInteger())).compareTo((0).toBigInteger()) == 0) {
+        d = d.divide((2).toBigInteger())
+        s = s + 1
+    }
+    for (a in mutableListOf(2, 325, 9375, 28178, 450775, 9780504, 1795265022)) {
+        if ((Math.floorMod(a, n)) == 0) {
+            return true
+        }
+        var x: Int = modPow(a, (d.toInt()), n)
+        if ((x == 1) || (x == (n - 1))) {
+            continue
+        }
+        var r: Int = 1
+        var passed: Boolean = false
+        while (r < s) {
+            x = Math.floorMod((x * x), n)
+            if (x == (n - 1)) {
+                passed = true
+                break
+            }
+            r = r + 1
+        }
+        if (!passed) {
+            return false
+        }
+    }
+    return true
+}
+
+fun commatize(n: Int): String {
+    var s: String = n.toString()
+    var i: BigInteger = (s.length - 3).toBigInteger()
+    while (i.compareTo((0).toBigInteger()) > 0) {
+        s = (s.substring(0, (i).toInt()) + ",") + s.substring((i).toInt(), s.length)
+        i = i.subtract((3).toBigInteger())
+    }
+    return s
+}
+
+fun pad(s: String, width: Int): String {
+    var out: String = s
+    while (out.length < width) {
+        out = " " + out
+    }
+    return out
+}
+
+fun join(xs: MutableList<String>, sep: String): String {
+    var res: String = ""
+    var i: Int = 0
+    while (i < xs.size) {
+        if (i > 0) {
+            res = res + sep
+        }
+        res = res + xs[i]!!
+        i = i + 1
+    }
+    return res
+}
+
+fun formatRow(row: MutableList<String>): String {
+    var padded: MutableList<String> = mutableListOf<String>()
+    var i: Int = 0
+    while (i < row.size) {
+        padded = run { val _tmp = padded.toMutableList(); _tmp.add(pad(row[i]!!, 9)); _tmp }
+        i = i + 1
+    }
+    return ("[" + join(padded, " ")) + "]"
+}
+
+fun user_main(): Unit {
+    var cubans: MutableList<String> = mutableListOf<String>()
+    var cube1: Int = 1
+    var count: Int = 0
+    var cube100k: Int = 0
+    var i: Int = 1
+    while (true) {
+        var j: BigInteger = (i + 1).toBigInteger()
+        var cube2: BigInteger = (j.multiply((j))).multiply((j))
+        var diff: BigInteger = cube2.subtract((cube1).toBigInteger())
+        if (((isPrime((diff.toInt()))) as Boolean)) {
+            if (count < 200) {
+                cubans = run { val _tmp = cubans.toMutableList(); _tmp.add(commatize((diff.toInt()))); _tmp }
+            }
+            count = count + 1
+            if (count == 100000) {
+                cube100k = (diff.toInt())
+                break
+            }
+        }
+        cube1 = (cube2.toInt())
+        i = i + 1
+    }
+    println("The first 200 cuban primes are:-")
+    var row: Int = 0
+    while (row < 20) {
+        var slice: MutableList<String> = mutableListOf<String>()
+        var k: Int = 0
+        while (k < 10) {
+            slice = run { val _tmp = slice.toMutableList(); _tmp.add(cubans[(row * 10) + k]!!); _tmp }
+            k = k + 1
+        }
+        println(formatRow(slice))
+        row = row + 1
+    }
+    println("\nThe 100,000th cuban prime is " + commatize(cube100k))
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/cullen-and-woodall-numbers.bench
+++ b/tests/rosetta/transpiler/Kotlin/cullen-and-woodall-numbers.bench
@@ -1,0 +1,1 @@
+{"duration_us":23827, "memory_bytes":116144, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/cullen-and-woodall-numbers.kt
+++ b/tests/rosetta/transpiler/Kotlin/cullen-and-woodall-numbers.kt
@@ -1,0 +1,104 @@
+import java.math.BigInteger
+
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+fun pow_big(base: BigInteger, exp: Int): BigInteger {
+    var result: BigInteger = java.math.BigInteger.valueOf(1)
+    var b: BigInteger = base
+    var e: Int = exp
+    while (e > 0) {
+        if ((Math.floorMod(e, 2)) == 1) {
+            result = result.multiply((b))
+        }
+        b = b.multiply((b))
+        e = ((e / 2).toInt())
+    }
+    return result
+}
+
+fun cullen(n: Int): BigInteger {
+    var two_n: BigInteger = pow_big((2.toBigInteger()), n)
+    return (two_n.multiply(((n.toBigInteger())))).add(((1.toBigInteger())))
+}
+
+fun woodall(n: Int): BigInteger {
+    return cullen(n).subtract(((2.toBigInteger())))
+}
+
+fun show_list(xs: MutableList<BigInteger>): String {
+    var line: String = ""
+    var i: Int = 0
+    while (i < xs.size) {
+        line = line + (xs[i]!!).toString()
+        if (i < (xs.size - 1)) {
+            line = line + " "
+        }
+        i = i + 1
+    }
+    return line
+}
+
+fun user_main(): Unit {
+    var cnums: MutableList<BigInteger> = mutableListOf<BigInteger>()
+    var i: Int = 1
+    while (i <= 20) {
+        cnums = run { val _tmp = cnums.toMutableList(); _tmp.add(cullen(i)); _tmp }
+        i = i + 1
+    }
+    println("First 20 Cullen numbers (n * 2^n + 1):")
+    println(show_list(cnums))
+    var wnums: MutableList<BigInteger> = mutableListOf<BigInteger>()
+    i = 1
+    while (i <= 20) {
+        wnums = run { val _tmp = wnums.toMutableList(); _tmp.add(woodall(i)); _tmp }
+        i = i + 1
+    }
+    println("\nFirst 20 Woodall numbers (n * 2^n - 1):")
+    println(show_list(wnums))
+    var cprimes: MutableList<BigInteger> = mutableListOf((1.toBigInteger()), (141.toBigInteger()), (4713.toBigInteger()), (5795.toBigInteger()), (6611.toBigInteger()))
+    println("\nFirst 5 Cullen primes (in terms of n):")
+    println(show_list(cprimes))
+    var wprimes: MutableList<BigInteger> = mutableListOf((2.toBigInteger()), (3.toBigInteger()), (6.toBigInteger()), (30.toBigInteger()), (75.toBigInteger()), (81.toBigInteger()), (115.toBigInteger()), (123.toBigInteger()), (249.toBigInteger()), (362.toBigInteger()), (384.toBigInteger()), (462.toBigInteger()))
+    println("\nFirst 12 Woodall primes (in terms of n):")
+    println(show_list(wprimes))
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/cumulative-standard-deviation.bench
+++ b/tests/rosetta/transpiler/Kotlin/cumulative-standard-deviation.bench
@@ -1,0 +1,1 @@
+{"duration_us":17459, "memory_bytes":116432, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/cumulative-standard-deviation.kt
+++ b/tests/rosetta/transpiler/Kotlin/cumulative-standard-deviation.kt
@@ -1,0 +1,78 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+data class Rsdv(var n: Double = 0.0, var a: Double = 0.0, var q: Double = 0.0)
+fun sqrtApprox(x: Double): Double {
+    if (x <= 0.0) {
+        return 0.0
+    }
+    var g: Double = x
+    var i: Int = 0
+    while (i < 20) {
+        g = (g + (x / g)) / 2.0
+        i = i + 1
+    }
+    return g
+}
+
+fun newRsdv(): Rsdv {
+    return Rsdv(n = 0.0, a = 0.0, q = 0.0)
+}
+
+fun add(r: Rsdv, x: Double): Rsdv {
+    var n1: Double = r.n + 1.0
+    var a1: Double = r.a + ((x - r.a) / n1)
+    var q1: Double = r.q + ((x - r.a) * (x - a1))
+    return Rsdv(n = n1, a = a1, q = q1)
+}
+
+fun sd(r: Rsdv): Double {
+    return sqrtApprox(r.q / r.n)
+}
+
+fun user_main(): Unit {
+    var r: Rsdv = newRsdv()
+    for (x in mutableListOf(2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0)) {
+        r = add(r, x)
+        println(sd(r).toString())
+    }
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/currency.bench
+++ b/tests/rosetta/transpiler/Kotlin/currency.bench
@@ -1,0 +1,1 @@
+{"duration_us":15312, "memory_bytes":119512, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/currency.kt
+++ b/tests/rosetta/transpiler/Kotlin/currency.kt
@@ -1,0 +1,181 @@
+import java.math.BigInteger
+
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+fun parseIntDigits(s: String): Int {
+    var n: Int = 0
+    var i: Int = 0
+    var digits: MutableMap<String, Int> = mutableMapOf<String, Int>("0" to (0), "1" to (1), "2" to (2), "3" to (3), "4" to (4), "5" to (5), "6" to (6), "7" to (7), "8" to (8), "9" to (9))
+    while (i < s.length) {
+        var ch: String = s.substring(i, i + 1)
+        if (!(ch in digits)) {
+            return 0
+        }
+        n = (n * 10) + (digits)[ch]!!
+        i = i + 1
+    }
+    return n
+}
+
+fun parseDC(s: String): Int {
+    var s: String = s
+    var neg: Boolean = false
+    if ((s.length > 0) && (s.substring(0, 1) == "-")) {
+        neg = true
+        s = s.substring(1, s.length)
+    }
+    var dollars: Int = 0
+    var cents: Int = 0
+    var i: Int = 0
+    var seenDot: Boolean = false
+    var centDigits: Int = 0
+    while (i < s.length) {
+        var ch: String = s.substring(i, i + 1)
+        if (ch == ".") {
+            seenDot = true
+            i = i + 1
+            continue
+        }
+        var d: Int = parseIntDigits(ch)
+        if ((seenDot as Boolean)) {
+            if (centDigits < 2) {
+                cents = (cents * 10) + d
+                centDigits = centDigits + 1
+            }
+        } else {
+            dollars = (dollars * 10) + d
+        }
+        i = i + 1
+    }
+    if (centDigits == 1) {
+        cents = cents * 10
+    }
+    var _val: BigInteger = ((dollars * 100) + cents).toBigInteger()
+    if ((neg as Boolean)) {
+        _val = (0).toBigInteger().subtract((_val))
+    }
+    return (_val.toInt())
+}
+
+fun parseRate(s: String): Int {
+    var s: String = s
+    var neg: Boolean = false
+    if ((s.length > 0) && (s.substring(0, 1) == "-")) {
+        neg = true
+        s = s.substring(1, s.length)
+    }
+    var whole: Int = 0
+    var frac: Int = 0
+    var digits: Int = 0
+    var seenDot: Boolean = false
+    var i: Int = 0
+    while (i < s.length) {
+        var ch: String = s.substring(i, i + 1)
+        if (ch == ".") {
+            seenDot = true
+            i = i + 1
+            continue
+        }
+        var d: Int = parseIntDigits(ch)
+        if ((seenDot as Boolean)) {
+            if (digits < 4) {
+                frac = (frac * 10) + d
+                digits = digits + 1
+            }
+        } else {
+            whole = (whole * 10) + d
+        }
+        i = i + 1
+    }
+    while (digits < 4) {
+        frac = frac * 10
+        digits = digits + 1
+    }
+    var _val: BigInteger = ((whole * 10000) + frac).toBigInteger()
+    if ((neg as Boolean)) {
+        _val = (0).toBigInteger().subtract((_val))
+    }
+    return (_val.toInt())
+}
+
+fun dcString(dc: Int): String {
+    var d: Int = dc / 100
+    var n: Int = dc
+    if (n < 0) {
+        n = 0 - n
+    }
+    var c: BigInteger = (Math.floorMod(n, 100)).toBigInteger()
+    var cstr: String = c.toString()
+    if (cstr.length == 1) {
+        cstr = "0" + cstr
+    }
+    return (d.toString() + ".") + cstr
+}
+
+fun extend(dc: Int, n: Int): Int {
+    return dc * n
+}
+
+fun tax(total: Int, rate: Int): Int {
+    return ((((total * rate) + 5000) / 10000).toInt())
+}
+
+fun padLeft(s: String, n: Int): String {
+    var out: String = s
+    while (out.length < n) {
+        out = " " + out
+    }
+    return out
+}
+
+fun user_main(): Unit {
+    var hp: Int = parseDC("5.50")
+    var mp: Int = parseDC("2.86")
+    var rate: Int = parseRate("0.0765")
+    var totalBeforeTax: BigInteger = (extend(hp, (4000000000000000L.toInt())) + extend(mp, 2)).toBigInteger()
+    var t: Int = tax((totalBeforeTax.toInt()), rate)
+    var total: BigInteger = totalBeforeTax.add((t).toBigInteger())
+    println("Total before tax: " + padLeft(dcString((totalBeforeTax.toInt())), 22))
+    println("             Tax: " + padLeft(dcString(t), 22))
+    println("           Total: " + padLeft(dcString((total.toInt())), 22))
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/currying.bench
+++ b/tests/rosetta/transpiler/Kotlin/currying.bench
@@ -1,0 +1,1 @@
+{"duration_us":13742, "memory_bytes":119808, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/currying.kt
+++ b/tests/rosetta/transpiler/Kotlin/currying.kt
@@ -1,0 +1,88 @@
+fun pow2(n: Int): Long {
+var v = 1L
+var i = 0
+while (i < n) {
+v *= 2
+i++
+}
+return v
+}
+
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+data class Foo(var value: Int = 0) {
+    fun Method(b: Int): Int {
+        return (value as Int) + b
+    }
+}
+fun pow(base: Double, exp: Double): Double {
+    var result: Double = 1.0
+    var i: Int = 0
+    while (i < ((exp.toInt()))) {
+        result = result * base
+        i = i + 1
+    }
+    return result
+}
+
+fun PowN(b: Double): (Double) -> Double {
+    return ({ e: Double -> pow(b, e) } as (Double) -> Double)
+}
+
+fun PowE(e: Double): (Double) -> Double {
+    return ({ b: Double -> pow(b, e) } as (Double) -> Double)
+}
+
+fun user_main(): Unit {
+    var pow2: (Double) -> Double = PowN(2.0)
+    var cube: (Double) -> Double = PowE(3.0)
+    println("2^8 = " + pow2(8.0).toString())
+    println("4³ = " + cube(4.0).toString())
+    var a: Foo = Foo(value = 2)
+    var fn1 = { b: Int -> a.Method(b) }
+    var fn2 = { f: Foo, b: Int -> f.Method(b) }
+    println("2 + 2 = " + a.Method(2).toString())
+    println("2 + 3 = " + fn1(3).toString())
+    println("2 + 4 = " + fn2(a, 4).toString())
+    println("3 + 5 = " + fn2(Foo(value = 3), 5).toString())
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/curzon-numbers.bench
+++ b/tests/rosetta/transpiler/Kotlin/curzon-numbers.bench
@@ -1,0 +1,1 @@
+{"duration_us":576563, "memory_bytes":848960, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/curzon-numbers.kt
+++ b/tests/rosetta/transpiler/Kotlin/curzon-numbers.kt
@@ -1,0 +1,104 @@
+import java.math.BigInteger
+
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+fun padLeft(n: Int, width: Int): String {
+    var s: String = n.toString()
+    while (s.length < width) {
+        s = " " + s
+    }
+    return s
+}
+
+fun modPow(base: Int, exp: Int, mod: Int): Int {
+    var result: BigInteger = (Math.floorMod(1, mod)).toBigInteger()
+    var b: BigInteger = (Math.floorMod(base, mod)).toBigInteger()
+    var e: Int = exp
+    while (e > 0) {
+        if ((Math.floorMod(e, 2)) == 1) {
+            result = (result.multiply((b))).remainder((mod).toBigInteger())
+        }
+        b = (b.multiply((b))).remainder((mod).toBigInteger())
+        e = e / 2
+    }
+    return (result.toInt())
+}
+
+fun user_main(): Unit {
+    var k: Int = 2
+    while (k <= 10) {
+        println(("The first 50 Curzon numbers using a base of " + k.toString()) + " :")
+        var count: Int = 0
+        var n: Int = 1
+        var curzon50: MutableList<Int> = mutableListOf<Int>()
+        while (true) {
+            var d: BigInteger = ((k * n) + 1).toBigInteger()
+            if ((((modPow(k, n, (d.toInt())) + 1)).toBigInteger().remainder((d))).compareTo((0).toBigInteger()) == 0) {
+                if (count < 50) {
+                    curzon50 = run { val _tmp = curzon50.toMutableList(); _tmp.add(n); _tmp }
+                }
+                count = count + 1
+                if (count == 50) {
+                    var idx: Int = 0
+                    while (idx < curzon50.size) {
+                        var line: String = ""
+                        var j: Int = 0
+                        while (j < 10) {
+                            line = (line + padLeft(curzon50[idx]!!, 4)) + " "
+                            idx = idx + 1
+                            j = j + 1
+                        }
+                        println(line.substring(0, line.length - 1))
+                    }
+                }
+                if (count == 1000) {
+                    println("\nOne thousandth: " + n.toString())
+                    break
+                }
+            }
+            n = n + 1
+        }
+        println("")
+        k = k + 2
+    }
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-08-04 10:22 +0700
+Last updated: 2025-08-04 10:46 +0700
 
-Completed tasks: **321/491**
+Completed tasks: **331/491**
 
 ### Checklist
 | Index | Name | Status | Duration | Memory |
@@ -266,16 +266,16 @@ Completed tasks: **321/491**
 | 255 | create-an-object-at-a-given-address | ✓ | 18.33ms | 133.7 KB |
 | 256 | csv-data-manipulation | ✓ | 7.11ms | 142.9 KB |
 | 257 | csv-to-html-translation-1 | ✓ | 23.20ms | 127.3 KB |
-| 258 | csv-to-html-translation-2 |  |  |  |
-| 259 | csv-to-html-translation-3 |  |  |  |
-| 260 | csv-to-html-translation-4 |  |  |  |
-| 261 | csv-to-html-translation-5 |  |  |  |
-| 262 | cuban-primes |  |  |  |
-| 263 | cullen-and-woodall-numbers |  |  |  |
-| 264 | cumulative-standard-deviation |  |  |  |
-| 265 | currency |  |  |  |
-| 266 | currying |  |  |  |
-| 267 | curzon-numbers |  |  |  |
+| 258 | csv-to-html-translation-2 | ✓ | 22.27ms | 117.9 KB |
+| 259 | csv-to-html-translation-3 | ✓ | 9.85ms | 133.1 KB |
+| 260 | csv-to-html-translation-4 | ✓ | 6.16ms | 133.3 KB |
+| 261 | csv-to-html-translation-5 | ✓ | 22.91ms | 122.3 KB |
+| 262 | cuban-primes | ✓ | 4.93s | 831.4 KB |
+| 263 | cullen-and-woodall-numbers | ✓ | 23.83ms | 113.4 KB |
+| 264 | cumulative-standard-deviation | ✓ | 17.46ms | 113.7 KB |
+| 265 | currency | ✓ | 15.31ms | 116.7 KB |
+| 266 | currying | ✓ | 13.74ms | 117.0 KB |
+| 267 | curzon-numbers | ✓ | 576.56ms | 829.1 KB |
 | 268 | cusip |  |  |  |
 | 269 | cyclops-numbers |  |  |  |
 | 270 | damm-algorithm |  |  |  |


### PR DESCRIPTION
## Summary
- fix Kotlin transpiler string concatenation by narrowing list operations
- avoid helper collisions by skipping helper emission when user functions exist
- respect user-defined `pow` implementations during transpilation
- generate Kotlin code/benchmarks for Rosetta tasks 258–267

## Testing
- `ROSETTA_INDEX=258 MOCHI_BENCHMARK=true go test -tags slow -v ./transpiler/x/kt -run TestRosettaKotlin -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68902d1046ac8320bedf0a18cf826469