### PR TITLE
docs: add v0.10.57 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # 📦 CHANGELOG.md
 
+## [0.10.57] – 2025-08-04T11:04:01+07:00
+
+### Added
+
+* Validate function types and allow explicit casts via decorator
+* Aster infers builtins and struct types automatically
+* Kotlin transpiler adds split helper, pow2/nullable variable handling and 20 new Rosetta tasks
+* Clojure and C++ gain new Rosetta outputs including Catalan numbers, cartesian product and display-a-linear-combination
+* Swift benchmark suite gains 15-puzzle solver with improved timing
+
+### Changed
+
+* Elixir transpiler handles split builtin, global vars in loops and refined loop tracking
+* Swift transpiler seeds _now RNG and fixes timing
+* C++ map iteration and ECDSA example handling improved
+* Scala and Kotlin transpilers refine integer handling and default value typing
+
+### Fixed
+
+* OCaml float modulo and dynamic return handling
+* C transpiler supports 2D float lists
+* Swift int casting and Scala variable type widening
+* Kotlin newline printing
+
 ## [0.10.56] – 2025-08-03T10:08:34+07:00
 
 ### Added

--- a/releases/v0.10.57.md
+++ b/releases/v0.10.57.md
@@ -1,0 +1,27 @@
+# Aug 2025 (v0.10.57)
+
+Released on Mon Aug 04 11:04:01 2025 +0700.
+
+Mochi v0.10.57 introduces function type validation and decorator casting, expands Rosetta coverage across Kotlin, Clojure and C++, and refines the Swift benchmark suite.
+
+## Transpilers
+
+- Kotlin adds split helper, pow2/nullable variable handling and 20 new Rosetta tasks
+- Clojure adds Catalan numbers, cartesian product and new parseIntStr/ratio helpers with 64-bit casts
+- Elixir transpiler handles split builtin, global vars in loops and improved loop tracking
+- Swift seeds _now RNG, fixes timing and adds 15-puzzle solver benchmark
+- C++ adds display-a-linear-combination and disarium numbers outputs with better map iteration
+- Scheme supports subprocess getoutput and hoists function definitions
+- Aster infers builtins and struct types automatically
+
+## Benchmarks
+
+- Records convex hull benchmark and expands Rosetta outputs across Clojure, Kotlin, C++ and Swift
+- Adds 15-puzzle solver to Swift benchmarks
+
+## Fixes
+
+- OCaml float modulo and dynamic return handling corrected
+- C transpiler supports 2D float lists
+- Kotlin newline and Scala var type widening issues resolved
+- Swift int casting fixed


### PR DESCRIPTION
## Summary
- document v0.10.57 release
- record notable changes and fixes in CHANGELOG

## Testing
- `npm test` *(fails: Missing script: "test")*
- `make test` *(interrupted after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_6890301664448320a90b7bbe4e5a43ac