### PR TITLE
kt transpiler: handle parseIntStr return type

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/cusip.bench
+++ b/tests/rosetta/transpiler/Kotlin/cusip.bench
@@ -1,0 +1,1 @@
+{"duration_us":25597, "memory_bytes":129736, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/cusip.kt
+++ b/tests/rosetta/transpiler/Kotlin/cusip.kt
@@ -1,0 +1,99 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+var candidates: MutableList<String> = mutableListOf("037833100", "17275R102", "38259P508", "594918104", "68389X106", "68389X105")
+fun ord(ch: String): Int {
+    var upper: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    if ((ch >= "0") && (ch <= "9")) {
+        return Integer.parseInt(ch, 10) + 48
+    }
+    var idx: Int = upper.indexOf(ch)
+    if (idx >= 0) {
+        return 65 + idx
+    }
+    return 0
+}
+
+fun isCusip(s: String): Boolean {
+    if (s.length != 9) {
+        return false
+    }
+    var sum: Int = 0
+    var i: Int = 0
+    while (i < 8) {
+        var c: String = s.substring(i, i + 1)
+        var v: Int = 0
+        if ((c >= "0") && (c <= "9")) {
+            v = Integer.parseInt(c, 10)
+        } else {
+            if ((c >= "A") && (c <= "Z")) {
+                v = ord(c) - 55
+            } else {
+                if (c == "*") {
+                    v = 36
+                } else {
+                    if (c == "@") {
+                        v = 37
+                    } else {
+                        if (c == "#") {
+                            v = 38
+                        } else {
+                            return false
+                        }
+                    }
+                }
+            }
+        }
+        if ((Math.floorMod(i, 2)) == 1) {
+            v = v * 2
+        }
+        sum = (sum + (v / 10)) + (Math.floorMod(v, 10))
+        i = i + 1
+    }
+    return Integer.parseInt(s.substring(8, 9), 10) == (Math.floorMod((10 - (Math.floorMod(sum, 10))), 10))
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        for (cand in candidates) {
+            var b: String = "incorrect"
+            if (((isCusip(cand)) as Boolean)) {
+                b = "correct"
+            }
+            println((cand + " -> ") + b)
+        }
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/cusip.out
+++ b/tests/rosetta/transpiler/Kotlin/cusip.out
@@ -1,0 +1,6 @@
+037833100 -> correct
+17275R102 -> correct
+38259P508 -> correct
+594918104 -> correct
+68389X106 -> incorrect
+68389X105 -> correct

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-08-04 10:46 +0700
+Last updated: 2025-08-04 11:07 +0700
 
-Completed tasks: **331/491**
+Completed tasks: **332/491**
 
 ### Checklist
 | Index | Name | Status | Duration | Memory |
@@ -276,7 +276,7 @@ Completed tasks: **331/491**
 | 265 | currency | ✓ | 15.31ms | 116.7 KB |
 | 266 | currying | ✓ | 13.74ms | 117.0 KB |
 | 267 | curzon-numbers | ✓ | 576.56ms | 829.1 KB |
-| 268 | cusip |  |  |  |
+| 268 | cusip | ✓ | 25.60ms | 126.7 KB |
 | 269 | cyclops-numbers |  |  |  |
 | 270 | damm-algorithm |  |  |  |
 | 271 | date-format |  |  |  |

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -3141,6 +3141,10 @@ func Transpile(env *types.Env, prog *parser.Program) (*Program, error) {
 				}
 				if typ == "" {
 					typ = guessType(val)
+				} else if strings.Contains(typ, "->") {
+					if gt := guessType(val); gt != "" && gt != "Any" && !strings.Contains(gt, "->") {
+						typ = gt
+					}
 				}
 				if typ == "Int" {
 					if lit, ok := val.(*IntLit); ok {
@@ -5477,6 +5481,7 @@ func convertPrimary(env *types.Env, p *parser.Primary) (Expr, error) {
 				} else if len(args) != 2 {
 					return nil, fmt.Errorf("parseIntStr expects 1 or 2 args")
 				}
+				funcRets["Integer.parseInt"] = "Int"
 				return &CallExpr{Func: "Integer.parseInt", Args: args}, nil
 			}
 			if name == "now" {


### PR DESCRIPTION
## Summary
- fix Kotlin transpiler type inference for `parseIntStr`
- add generated code and benchmark for Rosetta task 268 (cusip)

## Testing
- `ROSETTA_INDEX=268 go test ./transpiler/x/kt -run TestRosettaKotlin -tags slow`
- `ROSETTA_INDEX=268 MOCHI_BENCHMARK=true go test ./transpiler/x/kt -run TestRosettaKotlin -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_689031ea4d3883208db477c7aee8f371