### PR TITLE
fs transpiler: improve map and slice handling

### DIFF
--- a/tests/rosetta/transpiler/FS/exceptions-catch-an-exception-thrown-in-a-nested-call.bench
+++ b/tests/rosetta/transpiler/FS/exceptions-catch-an-exception-thrown-in-a-nested-call.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 238,
+  "memory_bytes": 43360,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/exceptions-catch-an-exception-thrown-in-a-nested-call.fs
+++ b/tests/rosetta/transpiler/FS/exceptions-catch-an-exception-thrown-in-a-nested-call.fs
@@ -1,0 +1,100 @@
+// Generated 2025-08-04 15:16 +0700
+
+exception Return
+let mutable __ret = ()
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+let mutable bazCall: int = 0
+let rec baz () =
+    let mutable __ret : string = Unchecked.defaultof<string>
+    try
+        bazCall <- bazCall + 1
+        printfn "%s" ("baz: start")
+        if bazCall = 1 then
+            printfn "%s" ("baz: raising U0")
+            __ret <- "U0"
+            raise Return
+        if bazCall = 2 then
+            printfn "%s" ("baz: raising U1")
+            __ret <- "U1"
+            raise Return
+        printfn "%s" ("baz: end")
+        __ret <- ""
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and bar () =
+    let mutable __ret : string = Unchecked.defaultof<string>
+    try
+        printfn "%s" ("bar: start")
+        let mutable err: string = baz()
+        if (String.length (err)) > 0 then
+            __ret <- err
+            raise Return
+        printfn "%s" ("bar: end")
+        __ret <- ""
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and foo () =
+    let mutable __ret : string = Unchecked.defaultof<string>
+    try
+        printfn "%s" ("foo: start")
+        let mutable err: string = bar()
+        if err = "U0" then
+            printfn "%s" ("foo: caught U0")
+        else
+            if (String.length (err)) > 0 then
+                __ret <- err
+                raise Return
+        err <- bar()
+        if err = "U0" then
+            printfn "%s" ("foo: caught U0")
+        else
+            if (String.length (err)) > 0 then
+                __ret <- err
+                raise Return
+        printfn "%s" ("foo: end")
+        __ret <- ""
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and main () =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    try
+        let __bench_start = _now()
+        let __mem_start = System.GC.GetTotalMemory(true)
+        printfn "%s" ("main: start")
+        let mutable err: string = foo()
+        if (String.length (err)) > 0 then
+            printfn "%s" ("main: unhandled " + err)
+        else
+            printfn "%s" ("main: success")
+        let __bench_end = _now()
+        let __mem_end = System.GC.GetTotalMemory(true)
+        printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)
+
+        __ret
+    with
+        | Return -> __ret
+main()

--- a/tests/rosetta/transpiler/FS/exceptions-catch-an-exception-thrown-in-a-nested-call.out
+++ b/tests/rosetta/transpiler/FS/exceptions-catch-an-exception-thrown-in-a-nested-call.out
@@ -1,0 +1,10 @@
+main: start
+foo: start
+bar: start
+baz: start
+baz: raising U0
+foo: caught U0
+bar: start
+baz: start
+baz: raising U1
+main: unhandled U1

--- a/tests/rosetta/transpiler/FS/exceptions.bench
+++ b/tests/rosetta/transpiler/FS/exceptions.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 244,
+  "memory_bytes": 47056,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/exceptions.fs
+++ b/tests/rosetta/transpiler/FS/exceptions.fs
@@ -1,0 +1,54 @@
+// Generated 2025-08-04 15:16 +0700
+
+exception Return
+let mutable __ret = ()
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+let rec foo () =
+    let mutable __ret : string = Unchecked.defaultof<string>
+    try
+        printfn "%s" ("let's foo...")
+        let mutable a: int array = [||]
+        if 12 >= (Seq.length (a)) then
+            __ret <- "runtime error: index out of range [12] with length " + (string (Seq.length (a)))
+            raise Return
+        a.[12] <- 0
+        __ret <- ""
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and main () =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    try
+        let __bench_start = _now()
+        let __mem_start = System.GC.GetTotalMemory(true)
+        let err: string = foo()
+        if (String.length (err)) > 0 then
+            printfn "%s" ("Recovered from " + err)
+        printfn "%s" ("glad that's over.")
+        let __bench_end = _now()
+        let __mem_end = System.GC.GetTotalMemory(true)
+        printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)
+
+        __ret
+    with
+        | Return -> __ret
+main()

--- a/tests/rosetta/transpiler/FS/exceptions.out
+++ b/tests/rosetta/transpiler/FS/exceptions.out
@@ -1,0 +1,3 @@
+let's foo...
+Recovered from runtime error: index out of range [12] with length 0
+glad that's over.

--- a/tests/rosetta/transpiler/FS/executable-library.bench
+++ b/tests/rosetta/transpiler/FS/executable-library.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 14229,
+  "memory_bytes": 78144,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/executable-library.fs
+++ b/tests/rosetta/transpiler/FS/executable-library.fs
@@ -1,0 +1,89 @@
+// Generated 2025-08-04 15:16 +0700
+
+exception Return
+let mutable __ret = ()
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+let _idx (arr:'a array) (i:int) : 'a =
+    if i >= 0 && i < arr.Length then arr.[i] else Unchecked.defaultof<'a>
+let __bench_start = _now()
+let __mem_start = System.GC.GetTotalMemory(true)
+let rec hailstone (n: int) =
+    let mutable __ret : int array = Unchecked.defaultof<int array>
+    let mutable n = n
+    try
+        let mutable seq: int array = [||]
+        let mutable x: int = n
+        seq <- Array.append seq [|x|]
+        while x > 1 do
+            if (((x % 2 + 2) % 2)) = 0 then
+                x <- x / 2
+            else
+                x <- (3 * x) + 1
+            seq <- Array.append seq [|x|]
+        __ret <- seq
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and listString (xs: int array) =
+    let mutable __ret : string = Unchecked.defaultof<string>
+    let mutable xs = xs
+    try
+        let mutable s: string = "["
+        let mutable i: int = 0
+        while i < (Seq.length (xs)) do
+            s <- s + (string (_idx xs i))
+            if i < ((Seq.length (xs)) - 1) then
+                s <- s + " "
+            i <- i + 1
+        s <- s + "]"
+        __ret <- s
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and libMain () =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    try
+        let mutable seq: int array = hailstone (27)
+        printfn "%s" ("")
+        printfn "%s" ("Hailstone sequence for the number 27:")
+        printfn "%s" (("  has " + (string (Seq.length (seq)))) + " elements")
+        printfn "%s" ("  starts with " + (listString (Array.sub seq 0 (4 - 0))))
+        printfn "%s" ("  ends with " + (listString (Array.sub seq ((Seq.length (seq)) - 4) ((Seq.length (seq)) - ((Seq.length (seq)) - 4)))))
+        let mutable longest: int = 0
+        let mutable length: int = 0
+        let mutable i: int = 1
+        while i < 100000 do
+            let l: int = Seq.length (hailstone (i))
+            if l > length then
+                longest <- i
+                length <- l
+            i <- i + 1
+        printfn "%s" ("")
+        printfn "%s" ((((string (longest)) + " has the longest Hailstone sequence, its length being ") + (string (length))) + ".")
+        __ret
+    with
+        | Return -> __ret
+libMain()
+let __bench_end = _now()
+let __mem_end = System.GC.GetTotalMemory(true)
+printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)

--- a/tests/rosetta/transpiler/FS/executable-library.out
+++ b/tests/rosetta/transpiler/FS/executable-library.out
@@ -1,0 +1,6 @@
+Hailstone sequence for the number 27:
+  has 112 elements
+  starts with [27 82 41 124]
+  ends with [8 4 2 1]
+
+77031 has the longest Hailstone sequence, its length being 351.

--- a/transpiler/x/fs/ROSETTA.md
+++ b/transpiler/x/fs/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This file is auto-generated from rosetta tests.
 
-## Rosetta Golden Test Checklist (369/491)
+## Rosetta Golden Test Checklist (372/491)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 151µs | 41.3 KB |
@@ -375,9 +375,9 @@ This file is auto-generated from rosetta tests.
 | 368 | even-or-odd | ✓ | 538µs | 53.5 KB |
 | 369 | events |   |  |  |
 | 370 | evolutionary-algorithm |   |  |  |
-| 371 | exceptions-catch-an-exception-thrown-in-a-nested-call |   |  |  |
-| 372 | exceptions |   |  |  |
-| 373 | executable-library |   |  |  |
+| 371 | exceptions-catch-an-exception-thrown-in-a-nested-call | ✓ | 238µs | 42.3 KB |
+| 372 | exceptions | ✓ | 244µs | 46.0 KB |
+| 373 | executable-library | ✓ | 14.229ms | 76.3 KB |
 | 374 | execute-a-markov-algorithm |   |  |  |
 | 375 | execute-a-system-command |   |  |  |
 | 376 | execute-brain- |   |  |  |
@@ -497,4 +497,4 @@ This file is auto-generated from rosetta tests.
 | 490 | window-management | ✓ | 371µs | 45.5 KB |
 | 491 | zumkeller-numbers | ✓ | 44.206ms | 86.9 KB |
 
-Last updated: 2025-08-04 00:30 +0700
+Last updated: 2025-08-04 15:16 +0700


### PR DESCRIPTION
## Summary
- support string slices and fall back to Substring when target type is unknown
- emit map literals without generic parameters to let F# infer key/value types
- add Rosetta outputs for F# transpiler: exceptions-catching, exceptions, executable-library

## Testing
- `MOCHI_BENCHMARK=1 MOCHI_ROSETTA_INDEX=371 go test -run TestFSTranspiler_Rosetta_Golden -count=1 -tags=slow`
- `MOCHI_BENCHMARK=1 MOCHI_ROSETTA_INDEX=372 go test -run TestFSTranspiler_Rosetta_Golden -count=1 -tags=slow`
- `MOCHI_BENCHMARK=1 MOCHI_ROSETTA_INDEX=373 go test -run TestFSTranspiler_Rosetta_Golden -count=1 -tags=slow`


------
https://chatgpt.com/codex/tasks/task_e_68906de96a348320a31edb1388261728