### PR TITLE
cs transpiler: handle lists of generic functions

### DIFF
--- a/transpiler/x/cs/ROSETTA.md
+++ b/transpiler/x/cs/ROSETTA.md
@@ -1,7 +1,7 @@
 # Rosetta C# Transpiler Output
 
 Completed programs: 477/491
-Last updated: 2025-08-04 15:16 +0700
+Last updated: 2025-08-04 15:58 +0700
 
 ## Checklist
 | Index | Name | Status | Duration | Memory |


### PR DESCRIPTION
## Summary
- extend C# transpiler type inference to convert `list<fun()>` into `Func<object>[]`
- cast mixed-return function lists to `Func<object>` and propagate updated return types
- refresh Rosetta benchmark index metadata

## Testing
- `MOCHI_ROSETTA_INDEX=162 MOCHI_BENCHMARK=1 go test ./transpiler/x/cs -run TestCSTranspiler_Rosetta_Golden -count=1 -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_6890760e8308832097ab3636736c9d76