### PR TITLE
kt transpiler: handle map int retrieval

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/display-an-outline-as-a-nested-table.bench
+++ b/tests/rosetta/transpiler/Kotlin/display-an-outline-as-a-nested-table.bench
@@ -1,0 +1,1 @@
+{"duration_us":25135, "memory_bytes":108632, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/display-an-outline-as-a-nested-table.kt
+++ b/tests/rosetta/transpiler/Kotlin/display-an-outline-as-a-nested-table.kt
@@ -1,46 +1,20 @@
 import java.math.BigInteger
 
-var _nowSeed = 0L
-var _nowSeeded = false
-fun _now(): Long {
-    if (!_nowSeeded) {
-        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
-            _nowSeed = it
-            _nowSeeded = true
-        }
-    }
-    return if (_nowSeeded) {
-        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
-        kotlin.math.abs(_nowSeed)
-    } else {
-        kotlin.math.abs(System.nanoTime())
-    }
-}
-
-fun toJson(v: Any?): String = when (v) {
-    null -> "null"
-    is String -> "\"" + v.replace("\"", "\\\"") + "\""
-    is Boolean, is Number -> v.toString()
-    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
-    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
-    else -> toJson(v.toString())
-}
-
 fun split(s: String, sep: String): MutableList<String> {
     var out: MutableList<String> = mutableListOf<String>()
     var cur: String = ""
     var i: Int = 0
     while (i < s.length) {
         if (((i + sep.length) <= s.length) && (s.substring(i, i + sep.length) == sep)) {
-            out = run { val _tmp = out.toMutableList(); _tmp.add(cur); _tmp } as MutableList<String>
+            out = run { val _tmp = out.toMutableList(); _tmp.add(cur); _tmp }
             cur = ""
             i = i + sep.length
         } else {
-            cur = cur + (s.substring(i, i + 1)).toString()
+            cur = cur + s.substring(i, i + 1)
             i = i + 1
         }
     }
-    out = run { val _tmp = out.toMutableList(); _tmp.add(cur); _tmp } as MutableList<String>
+    out = run { val _tmp = out.toMutableList(); _tmp.add(cur); _tmp }
     return out
 }
 
@@ -51,7 +25,7 @@ fun join(xs: MutableList<String>, sep: String): String {
         if (i > 0) {
             res = res + sep
         }
-        res = res + xs[i]
+        res = res + xs[i]!!
         i = i + 1
     }
     return res
@@ -66,47 +40,47 @@ fun trimLeftSpaces(s: String): String {
 }
 
 fun makeIndent(outline: String, tab: Int): MutableList<MutableMap<String, Any?>> {
-    val lines: MutableList<String> = split(outline, "\n")
+    var lines: MutableList<String> = split(outline, "\n")
     var nodes: MutableList<MutableMap<String, Any?>> = mutableListOf<MutableMap<String, Any?>>()
     for (line in lines) {
-        val line2: String = trimLeftSpaces(line)
-        val level: BigInteger = ((line.length - line2.length) / tab).toBigInteger()
-        nodes = run { val _tmp = nodes.toMutableList(); _tmp.add(mutableMapOf<String, Any?>("level" to (level), "name" to (line2))); _tmp } as MutableList<MutableMap<String, Any?>>
+        var line2: String = trimLeftSpaces(line)
+        var level: BigInteger = ((line.length - line2.length) / tab).toBigInteger()
+        nodes = run { val _tmp = nodes.toMutableList(); _tmp.add(mutableMapOf<String, Any?>("level" to (level), "name" to (line2))); _tmp }
     }
     return nodes
 }
 
 fun toNest(nodes: MutableList<MutableMap<String, Any?>>, start: Int, level: Int, n: MutableMap<String, Any?>): Unit {
     if (level == 0) {
-        (n)["name"] as Any? = (nodes[0])["name"] as Any?
+        (n)["name"] = (((nodes[0] as MutableMap<String, Any?>) as MutableMap<String, Any?>))["name"]!!
     }
-    var i: BigInteger = (start + 1).toBigInteger()
-    while (i.compareTo(nodes.size.toBigInteger()) < 0) {
-        val node: MutableMap<String, Any?> = nodes[(i).toInt()]
-        val lev: Int = (node)["level"] as Int
+    var i: BigInteger = ((start + 1).toBigInteger())
+    while (i.compareTo((nodes.size).toBigInteger()) < 0) {
+        var node: MutableMap<String, Any?> = nodes[(i).toInt()] as MutableMap<String, Any?>
+        var lev: Int = ((node)["level"] as java.math.BigInteger).toInt()
         if (lev == (level + 1)) {
-            var child: MutableMap<String, Any?> = mutableMapOf<String, Any?>("name" to ((node)["name"] as Any?), "children" to (mutableListOf<Any?>()))
-            toNest(nodes, i.toInt(), level + 1, child)
-            var cs: MutableList<Any?> = ((n)["children"] as Any?) as MutableList<Any?>
-            cs = run { val _tmp = cs.toMutableList(); _tmp.add(child as Any?); _tmp } as MutableList<Any?>
-            (n)["children"] as Any? = cs as Any?
+            var child: MutableMap<String, Any?> = mutableMapOf<String, Any?>("name" to ((node)["name"]!!), "children" to (mutableListOf<Any?>()))
+            toNest(nodes, (i.toInt()), level + 1, child)
+            var cs: MutableList<Any?> = (((n)["children"]!!) as MutableList<Any?>)
+            cs = run { val _tmp = cs.toMutableList(); _tmp.add((child as Any?)); _tmp }
+            (n)["children"] = (cs as Any?)
         } else {
             if (lev <= level) {
                 return
             }
         }
-        i = i.add(1.toBigInteger())
+        i = i.add((1).toBigInteger())
     }
 }
 
 fun countLeaves(n: MutableMap<String, Any?>): Int {
-    val kids: MutableList<Any?> = ((n)["children"] as Any?) as MutableList<Any?>
+    var kids: MutableList<Any?> = (((n)["children"]!!) as MutableList<Any?>)
     if (kids.size == 0) {
         return 1
     }
     var total: Int = 0
     for (k in kids) {
-        total = total + countLeaves(k as MutableMap<String, Any?>)
+        total = total + countLeaves((k as MutableMap<String, Any?>))
     }
     return total
 }
@@ -116,12 +90,12 @@ fun nodesByDepth(root: MutableMap<String, Any?>, depth: Int): MutableList<Mutabl
     var current: MutableList<MutableMap<String, Any?>> = mutableListOf(root)
     var d: Int = 0
     while (d < depth) {
-        levels = run { val _tmp = levels.toMutableList(); _tmp.add(current); _tmp } as MutableList<MutableList<MutableMap<String, Any?>>>
+        levels = run { val _tmp = levels.toMutableList(); _tmp.add(current); _tmp }
         var next: MutableList<MutableMap<String, Any?>> = mutableListOf<MutableMap<String, Any?>>()
         for (n in current) {
-            val kids: MutableList<Any?> = ((n)["children"] as Any?) as MutableList<Any?>
+            var kids: MutableList<Any?> = (((n)["children"]!!) as MutableList<Any?>)
             for (k in kids) {
-                next = run { val _tmp = next.toMutableList(); _tmp.add(k as MutableMap<String, Any?>); _tmp } as MutableList<MutableMap<String, Any?>>
+                next = run { val _tmp = next.toMutableList(); _tmp.add((k as MutableMap<String, Any?>)); _tmp }
             }
         }
         current = next
@@ -132,22 +106,22 @@ fun nodesByDepth(root: MutableMap<String, Any?>, depth: Int): MutableList<Mutabl
 
 fun toMarkup(n: MutableMap<String, Any?>, cols: MutableList<String>, depth: Int): String {
     var lines: MutableList<String> = mutableListOf<String>()
-    lines = run { val _tmp = lines.toMutableList(); _tmp.add("{| class=\"wikitable\" style=\"text-align: center;\""); _tmp } as MutableList<String>
-    val l1: String = "|-"
-    lines = run { val _tmp = lines.toMutableList(); _tmp.add(l1); _tmp } as MutableList<String>
-    val span: Int = countLeaves(n)
-    lines = run { val _tmp = lines.toMutableList(); _tmp.add((((("| style=\"background: " + cols[0]) + " \" colSpan=") + span.toString()) + " | ") + (n)["name"] as String); _tmp } as MutableList<String>
-    lines = run { val _tmp = lines.toMutableList(); _tmp.add(l1); _tmp } as MutableList<String>
-    val lvls: MutableList<MutableList<MutableMap<String, Any?>>> = nodesByDepth(n, depth)
+    lines = run { val _tmp = lines.toMutableList(); _tmp.add("{| class=\"wikitable\" style=\"text-align: center;\""); _tmp }
+    var l1: String = "|-"
+    lines = run { val _tmp = lines.toMutableList(); _tmp.add(l1); _tmp }
+    var span: Int = countLeaves(n)
+    lines = run { val _tmp = lines.toMutableList(); _tmp.add((((("| style=\"background: " + cols[0]!!) + " \" colSpan=") + span.toString()) + " | ") + (n)["name"] as String); _tmp }
+    lines = run { val _tmp = lines.toMutableList(); _tmp.add(l1); _tmp }
+    var lvls: MutableList<MutableList<MutableMap<String, Any?>>> = nodesByDepth(n, depth)
     var lvl: Int = 1
     while (lvl < depth) {
-        val nodes: MutableList<MutableMap<String, Any?>> = lvls[lvl]
+        var nodes: MutableList<MutableMap<String, Any?>> = lvls[lvl] as MutableList<MutableMap<String, Any?>>
         if (nodes.size == 0) {
-            lines = run { val _tmp = lines.toMutableList(); _tmp.add("|  |"); _tmp } as MutableList<String>
+            lines = run { val _tmp = lines.toMutableList(); _tmp.add("|  |"); _tmp }
         } else {
             var idx: Int = 0
             while (idx < nodes.size) {
-                val node: MutableMap<String, Any?> = nodes[idx]
+                var node: MutableMap<String, Any?> = nodes[idx] as MutableMap<String, Any?>
                 span = countLeaves(node)
                 var col: Int = lvl
                 if (lvl == 1) {
@@ -156,53 +130,41 @@ fun toMarkup(n: MutableMap<String, Any?>, cols: MutableList<String>, depth: Int)
                 if (col >= cols.size) {
                     col = cols.size - 1
                 }
-                val cell: String = (((("| style=\"background: " + cols[col]) + " \" colspan=") + span.toString()) + " | ") + (node)["name"] as String
-                lines = run { val _tmp = lines.toMutableList(); _tmp.add(cell); _tmp } as MutableList<String>
+                var cell: String = (((("| style=\"background: " + cols[col]!!) + " \" colspan=") + span.toString()) + " | ") + (node)["name"] as String
+                lines = run { val _tmp = lines.toMutableList(); _tmp.add(cell); _tmp }
                 idx = idx + 1
             }
         }
         if (lvl < (depth - 1)) {
-            lines = run { val _tmp = lines.toMutableList(); _tmp.add(l1); _tmp } as MutableList<String>
+            lines = run { val _tmp = lines.toMutableList(); _tmp.add(l1); _tmp }
         }
         lvl = lvl + 1
     }
-    lines = run { val _tmp = lines.toMutableList(); _tmp.add("|}"); _tmp } as MutableList<String>
+    lines = run { val _tmp = lines.toMutableList(); _tmp.add("|}"); _tmp }
     return join(lines, "\n")
 }
 
 fun user_main(): Unit {
-    val outline: String = (((((((((("Display an outline as a nested table.\n" + "    Parse the outline to a tree,\n") + "        measuring the indent of each line,\n") + "        translating the indentation to a nested structure,\n") + "        and padding the tree to even depth.\n") + "    count the leaves descending from each node,\n") + "        defining the width of a leaf as 1,\n") + "        and the width of a parent node as a sum.\n") + "            (The sum of the widths of its children)\n") + "    and write out a table with 'colspan' values\n") + "        either as a wiki table,\n") + "        or as HTML."
-    val yellow: String = "#ffffe6;"
-    val orange: String = "#ffebd2;"
-    val green: String = "#f0fff0;"
-    val blue: String = "#e6ffff;"
-    val pink: String = "#ffeeff;"
-    val cols: MutableList<String> = mutableListOf(yellow, orange, green, blue, pink)
-    val nodes: MutableList<MutableMap<String, Any?>> = makeIndent(outline, 4)
+    var outline: String = (((((((((("Display an outline as a nested table.\n" + "    Parse the outline to a tree,\n") + "        measuring the indent of each line,\n") + "        translating the indentation to a nested structure,\n") + "        and padding the tree to even depth.\n") + "    count the leaves descending from each node,\n") + "        defining the width of a leaf as 1,\n") + "        and the width of a parent node as a sum.\n") + "            (The sum of the widths of its children)\n") + "    and write out a table with 'colspan' values\n") + "        either as a wiki table,\n") + "        or as HTML."
+    var yellow: String = "#ffffe6;"
+    var orange: String = "#ffebd2;"
+    var green: String = "#f0fff0;"
+    var blue: String = "#e6ffff;"
+    var pink: String = "#ffeeff;"
+    var cols: MutableList<String> = mutableListOf(yellow, orange, green, blue, pink)
+    var nodes: MutableList<MutableMap<String, Any?>> = makeIndent(outline, 4)
     var n: MutableMap<String, Any?> = mutableMapOf<String, Any?>("name" to (""), "children" to (mutableListOf<Any?>()))
     toNest(nodes, 0, 0, n)
     println(toMarkup(n, cols, 4))
     println("\n")
-    val outline2: String = (((((((((((("Display an outline as a nested table.\n" + "    Parse the outline to a tree,\n") + "        measuring the indent of each line,\n") + "        translating the indentation to a nested structure,\n") + "        and padding the tree to even depth.\n") + "    count the leaves descending from each node,\n") + "        defining the width of a leaf as 1,\n") + "        and the width of a parent node as a sum.\n") + "            (The sum of the widths of its children)\n") + "            Propagating the sums upward as necessary.\n") + "    and write out a table with 'colspan' values\n") + "        either as a wiki table,\n") + "        or as HTML.\n") + "    Optionally add color to the nodes."
-    val cols2: MutableList<String> = mutableListOf(blue, yellow, orange, green, pink)
-    val nodes2: MutableList<MutableMap<String, Any?>> = makeIndent(outline2, 4)
+    var outline2: String = (((((((((((("Display an outline as a nested table.\n" + "    Parse the outline to a tree,\n") + "        measuring the indent of each line,\n") + "        translating the indentation to a nested structure,\n") + "        and padding the tree to even depth.\n") + "    count the leaves descending from each node,\n") + "        defining the width of a leaf as 1,\n") + "        and the width of a parent node as a sum.\n") + "            (The sum of the widths of its children)\n") + "            Propagating the sums upward as necessary.\n") + "    and write out a table with 'colspan' values\n") + "        either as a wiki table,\n") + "        or as HTML.\n") + "    Optionally add color to the nodes."
+    var cols2: MutableList<String> = mutableListOf(blue, yellow, orange, green, pink)
+    var nodes2: MutableList<MutableMap<String, Any?>> = makeIndent(outline2, 4)
     var n2: MutableMap<String, Any?> = mutableMapOf<String, Any?>("name" to (""), "children" to (mutableListOf<Any?>()))
     toNest(nodes2, 0, 0, n2)
     println(toMarkup(n2, cols2, 4))
 }
 
 fun main() {
-    run {
-        System.gc()
-        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
-        val _start = _now()
-        user_main()
-        System.gc()
-        val _end = _now()
-        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
-        val _durationUs = (_end - _start) / 1000
-        val _memDiff = kotlin.math.abs(_endMem - _startMem)
-        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
-        println(toJson(_res))
-    }
+    user_main()
 }

--- a/tests/rosetta/transpiler/Kotlin/display-an-outline-as-a-nested-table.out
+++ b/tests/rosetta/transpiler/Kotlin/display-an-outline-as-a-nested-table.out
@@ -1,0 +1,40 @@
+{| class="wikitable" style="text-align: center;"
+|-
+| style="background: #ffffe6; " colSpan=7 | Display an outline as a nested table.
+|-
+| style="background: #ffebd2; " colspan=3 | Parse the outline to a tree,
+| style="background: #f0fff0; " colspan=2 | count the leaves descending from each node,
+| style="background: #e6ffff; " colspan=2 | and write out a table with 'colspan' values
+|-
+| style="background: #f0fff0; " colspan=1 | measuring the indent of each line,
+| style="background: #f0fff0; " colspan=1 | translating the indentation to a nested structure,
+| style="background: #f0fff0; " colspan=1 | and padding the tree to even depth.
+| style="background: #f0fff0; " colspan=1 | defining the width of a leaf as 1,
+| style="background: #f0fff0; " colspan=1 | and the width of a parent node as a sum.
+| style="background: #f0fff0; " colspan=1 | either as a wiki table,
+| style="background: #f0fff0; " colspan=1 | or as HTML.
+|-
+| style="background: #e6ffff; " colspan=1 | (The sum of the widths of its children)
+|}
+
+
+{| class="wikitable" style="text-align: center;"
+|-
+| style="background: #e6ffff; " colSpan=9 | Display an outline as a nested table.
+|-
+| style="background: #ffffe6; " colspan=3 | Parse the outline to a tree,
+| style="background: #ffebd2; " colspan=3 | count the leaves descending from each node,
+| style="background: #f0fff0; " colspan=2 | and write out a table with 'colspan' values
+| style="background: #ffeeff; " colspan=1 | Optionally add color to the nodes.
+|-
+| style="background: #ffebd2; " colspan=1 | measuring the indent of each line,
+| style="background: #ffebd2; " colspan=1 | translating the indentation to a nested structure,
+| style="background: #ffebd2; " colspan=1 | and padding the tree to even depth.
+| style="background: #ffebd2; " colspan=1 | defining the width of a leaf as 1,
+| style="background: #ffebd2; " colspan=2 | and the width of a parent node as a sum.
+| style="background: #ffebd2; " colspan=1 | either as a wiki table,
+| style="background: #ffebd2; " colspan=1 | or as HTML.
+|-
+| style="background: #f0fff0; " colspan=1 | (The sum of the widths of its children)
+| style="background: #f0fff0; " colspan=1 | Propagating the sums upward as necessary.
+|}

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-08-04 15:54 +0700
+Last updated: 2025-08-04 16:54 +0700
 
-Completed tasks: **358/491**
+Completed tasks: **359/491**
 
 ### Checklist
 | Index | Name | Status | Duration | Memory |
@@ -315,7 +315,7 @@ Completed tasks: **358/491**
 | 304 | disarium-numbers | ✓ | 1.44s | 828.2 KB |
 | 305 | discordian-date | ✓ | 8.09ms | 123.9 KB |
 | 306 | display-a-linear-combination | ✓ | 15.58ms | 123.1 KB |
-| 307 | display-an-outline-as-a-nested-table |  |  |  |
+| 307 | display-an-outline-as-a-nested-table | ✓ | 25.14ms | 106.1 KB |
 | 308 | distance-and-bearing |  |  |  |
 | 309 | distributed-programming |  |  |  |
 | 310 | diversity-prediction-theorem | ✓ | 17.96ms | 115.4 KB |


### PR DESCRIPTION
## Summary
- fix Kotlin transpiler index expression to cast BigInteger values to Int
- transpile Rosetta `display-an-outline-as-a-nested-table` program and update checklist

## Testing
- `ROSETTA_INDEX=307 MOCHI_BENCHMARK=true go test ./transpiler/x/kt -run TestRosettaKotlin -tags=slow -count=1`
- `ROSETTA_INDEX=307 go test ./transpiler/x/kt -run TestRosettaKotlin -tags=slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6890833fa5a88320865c0e6212fe89a6