### PR TITLE
fix: recognize builtin functions

### DIFF
--- a/transpiler/x/erl/transpiler.go
+++ b/transpiler/x/erl/transpiler.go
@@ -4857,6 +4857,10 @@ func convertPrimary(p *parser.Primary, env *types.Env, ctx *context) (Expr, erro
 			}
 			return call, nil
 		}
+		if builtinFunc(p.Selector.Root) {
+			name := sanitizeFuncName(p.Selector.Root)
+			return &NameRef{Name: name}, nil
+		}
 		if t, err := env.GetVar(p.Selector.Root); err == nil {
 			if ft, ok := t.(types.FuncType); ok && !ctx.isGlobal(p.Selector.Root) && ctx.alias[p.Selector.Root] == "" {
 				if fn, ok := env.GetFunc(p.Selector.Root); ok {


### PR DESCRIPTION
## Summary
- recognize builtin functions when converting primary expressions in Erlang transpiler

## Testing
- `MOCHI_ROSETTA_INDEX=104 go test -run TestRosettaTranspile -tags="rosetta slow" ./transpiler/x/erl -count=1 -v` *(fails: signal killed)*

------
https://chatgpt.com/codex/tasks/task_e_68908367383483208f2d425be5df76c4