### PR TITLE
fs transpiler: handle subprocess getoutput

### DIFF
--- a/tests/rosetta/transpiler/FS/execute-a-system-command.bench
+++ b/tests/rosetta/transpiler/FS/execute-a-system-command.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 398,
+  "memory_bytes": 52376,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/execute-a-system-command.fs
+++ b/tests/rosetta/transpiler/FS/execute-a-system-command.fs
@@ -1,0 +1,49 @@
+// Generated 2025-08-04 17:04 +0700
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+let __bench_start = _now()
+let __mem_start = System.GC.GetTotalMemory(true)
+open System.Diagnostics
+
+open System
+
+module subprocess =
+    let rec getoutput (cmd: string) =
+        let mutable __ret : string = Unchecked.defaultof<string>
+        let mutable cmd = cmd
+        try
+            let psi = System.Diagnostics.ProcessStartInfo()
+            psi.FileName <- "/bin/sh"
+            psi.Arguments <- "-c " + (unbox<string> cmd)
+            psi.RedirectStandardOutput <- true
+            psi.UseShellExecute <- false
+            let p = System.Diagnostics.Process.Start (psi)
+            let output = p.StandardOutput.ReadToEnd()
+            p.WaitForExit()
+            __ret <- output.TrimEnd()
+            __ret
+        with
+            | Return -> __ret
+
+let out: string = subprocess.getoutput("ls -l")
+printfn "%s" (out)
+let __bench_end = _now()
+let __mem_end = System.GC.GetTotalMemory(true)
+printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)

--- a/tests/rosetta/transpiler/FS/execute-a-system-command.out
+++ b/tests/rosetta/transpiler/FS/execute-a-system-command.out
@@ -1,0 +1,8 @@
+README.md
+ROSETTA.md
+TASKS.md
+rosetta_test.go
+stub.go
+transpiler.go
+transpiler_test.go
+vm_valid_golden_test.go

--- a/transpiler/x/fs/ROSETTA.md
+++ b/transpiler/x/fs/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This file is auto-generated from rosetta tests.
 
-## Rosetta Golden Test Checklist (373/491)
+## Rosetta Golden Test Checklist (374/491)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 151µs | 41.3 KB |
@@ -379,7 +379,7 @@ This file is auto-generated from rosetta tests.
 | 372 | exceptions | ✓ | 244µs | 46.0 KB |
 | 373 | executable-library | ✓ | 14.229ms | 76.3 KB |
 | 374 | execute-a-markov-algorithm | ✓ | 361µs | 36.1 KB |
-| 375 | execute-a-system-command |   |  |  |
+| 375 | execute-a-system-command | ✓ | 398µs | 51.1 KB |
 | 376 | execute-brain- |   |  |  |
 | 377 | execute-computer-zero-1 |   |  |  |
 | 378 | execute-computer-zero |   |  |  |
@@ -497,4 +497,4 @@ This file is auto-generated from rosetta tests.
 | 490 | window-management | ✓ | 371µs | 45.5 KB |
 | 491 | zumkeller-numbers | ✓ | 44.206ms | 86.9 KB |
 
-Last updated: 2025-08-04 16:14 +0700
+Last updated: 2025-08-04 17:04 +0700

--- a/transpiler/x/fs/transpiler.go
+++ b/transpiler/x/fs/transpiler.go
@@ -4613,7 +4613,9 @@ func convertImport(im *parser.ImportStmt) (Stmt, error) {
 			neededOpens["System.Diagnostics"] = true
 			stub := &ModuleDef{Name: alias, Stmts: []Stmt{
 				&FunDef{Name: "getoutput", Params: []string{"cmd"}, Types: []string{"string"}, Return: "string", Body: []Stmt{
-					&LetStmt{Name: "psi", Expr: &CallExpr{Func: "System.Diagnostics.ProcessStartInfo", Args: []Expr{&StringLit{Value: "/bin/sh"}, &BinaryExpr{Left: &StringLit{Value: "-c "}, Op: "+", Right: &IdentExpr{Name: "cmd"}}}}},
+					&LetStmt{Name: "psi", Expr: &CallExpr{Func: "System.Diagnostics.ProcessStartInfo", Args: nil}},
+					&AssignStmt{Name: "psi.FileName", Expr: &StringLit{Value: "/bin/sh"}},
+					&AssignStmt{Name: "psi.Arguments", Expr: &BinaryExpr{Left: &StringLit{Value: "-c "}, Op: "+", Right: &IdentExpr{Name: "cmd"}}},
 					&AssignStmt{Name: "psi.RedirectStandardOutput", Expr: &BoolLit{Value: true}},
 					&AssignStmt{Name: "psi.UseShellExecute", Expr: &BoolLit{Value: false}},
 					&LetStmt{Name: "p", Expr: &CallExpr{Func: "System.Diagnostics.Process.Start", Args: []Expr{&IdentExpr{Name: "psi"}}}},


### PR DESCRIPTION
## Summary
- add F# transpiler support for `python subprocess` import by constructing `ProcessStartInfo` and capturing output
- update Rosetta checklist and add generated F# code for `execute-a-system-command`

## Testing
- `MOCHI_ROSETTA_INDEX=375 MOCHI_BENCHMARK=1 go test -run Rosetta -tags slow ./transpiler/x/fs -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68908592382883208f6ad8e5dc3190ec