### PR TITLE
kt: fix Any comparisons for distance and bearing rosetta example

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/distance-and-bearing.bench
+++ b/tests/rosetta/transpiler/Kotlin/distance-and-bearing.bench
@@ -1,0 +1,1 @@
+{"duration_us":10323, "memory_bytes":125192, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/distance-and-bearing.kt
+++ b/tests/rosetta/transpiler/Kotlin/distance-and-bearing.kt
@@ -24,15 +24,15 @@ fun toJson(v: Any?): String = when (v) {
     else -> toJson(v.toString())
 }
 
-data class Airport(var name: String, var country: String, var icao: String, var lat: Double, var lon: Double)
-val PI: Double = 3.141592653589793
-val airports: MutableList<Airport> = mutableListOf(Airport(name = "Koksijde Air Base", country = "Belgium", icao = "EBFN", lat = 51.090301513671875, lon = 2.652780055999756), Airport(name = "Ostend-Bruges International Airport", country = "Belgium", icao = "EBOS", lat = 51.198898315399994, lon = 2.8622200489), Airport(name = "Kent International Airport", country = "United Kingdom", icao = "EGMH", lat = 51.342201, lon = 1.34611), Airport(name = "Calais-Dunkerque Airport", country = "France", icao = "LFAC", lat = 50.962100982666016, lon = 1.954759955406189), Airport(name = "Westkapelle heliport", country = "Belgium", icao = "EBKW", lat = 51.32222366333, lon = 3.2930560112), Airport(name = "Lympne Airport", country = "United Kingdom", icao = "EGMK", lat = 51.08, lon = 1.013), Airport(name = "Ursel Air Base", country = "Belgium", icao = "EBUL", lat = 51.14419937133789, lon = 3.475559949874878), Airport(name = "Southend Airport", country = "United Kingdom", icao = "EGMC", lat = 51.5713996887207, lon = 0.6955559849739075), Airport(name = "Merville-Calonne Airport", country = "France", icao = "LFQT", lat = 50.61840057373047, lon = 2.642240047454834), Airport(name = "Wevelgem Airport", country = "Belgium", icao = "EBKT", lat = 50.817199707, lon = 3.20472002029), Airport(name = "Midden-Zeeland Airport", country = "Netherlands", icao = "EHMZ", lat = 51.5121994019, lon = 3.73111009598), Airport(name = "Lydd Airport", country = "United Kingdom", icao = "EGMD", lat = 50.95610046386719, lon = 0.9391670227050781), Airport(name = "RAF Wattisham", country = "United Kingdom", icao = "EGUW", lat = 52.1273002625, lon = 0.956264019012), Airport(name = "Beccles Airport", country = "United Kingdom", icao = "EGSM", lat = 52.435298919699996, lon = 1.6183300018300002), Airport(name = "Lille/Marcq-en-Baroeul Airport", country = "France", icao = "LFQO", lat = 50.687198638916016, lon = 3.0755600929260254), Airport(name = "Lashenden (Headcorn) Airfield", country = "United Kingdom", icao = "EGKH", lat = 51.156898, lon = 0.641667), Airport(name = "Le Touquet-Côte d'Opale Airport", country = "France", icao = "LFAT", lat = 50.517398834228516, lon = 1.6205899715423584), Airport(name = "Rochester Airport", country = "United Kingdom", icao = "EGTO", lat = 51.351898193359375, lon = 0.5033329725265503), Airport(name = "Lille-Lesquin Airport", country = "France", icao = "LFQQ", lat = 50.563332, lon = 3.086886), Airport(name = "Thurrock Airfield", country = "United Kingdom", icao = "EGMT", lat = 51.537505, lon = 0.367634))
+data class Airport(var name: String = "", var country: String = "", var icao: String = "", var lat: Double = 0.0, var lon: Double = 0.0)
+var PI: Double = 3.141592653589793
+var airports: MutableList<Airport> = mutableListOf(Airport(name = "Koksijde Air Base", country = "Belgium", icao = "EBFN", lat = 51.090301513671875, lon = 2.652780055999756), Airport(name = "Ostend-Bruges International Airport", country = "Belgium", icao = "EBOS", lat = 51.198898315399994, lon = 2.8622200489), Airport(name = "Kent International Airport", country = "United Kingdom", icao = "EGMH", lat = 51.342201, lon = 1.34611), Airport(name = "Calais-Dunkerque Airport", country = "France", icao = "LFAC", lat = 50.962100982666016, lon = 1.954759955406189), Airport(name = "Westkapelle heliport", country = "Belgium", icao = "EBKW", lat = 51.32222366333, lon = 3.2930560112), Airport(name = "Lympne Airport", country = "United Kingdom", icao = "EGMK", lat = 51.08, lon = 1.013), Airport(name = "Ursel Air Base", country = "Belgium", icao = "EBUL", lat = 51.14419937133789, lon = 3.475559949874878), Airport(name = "Southend Airport", country = "United Kingdom", icao = "EGMC", lat = 51.5713996887207, lon = 0.6955559849739075), Airport(name = "Merville-Calonne Airport", country = "France", icao = "LFQT", lat = 50.61840057373047, lon = 2.642240047454834), Airport(name = "Wevelgem Airport", country = "Belgium", icao = "EBKT", lat = 50.817199707, lon = 3.20472002029), Airport(name = "Midden-Zeeland Airport", country = "Netherlands", icao = "EHMZ", lat = 51.5121994019, lon = 3.73111009598), Airport(name = "Lydd Airport", country = "United Kingdom", icao = "EGMD", lat = 50.95610046386719, lon = 0.9391670227050781), Airport(name = "RAF Wattisham", country = "United Kingdom", icao = "EGUW", lat = 52.1273002625, lon = 0.956264019012), Airport(name = "Beccles Airport", country = "United Kingdom", icao = "EGSM", lat = 52.435298919699996, lon = 1.6183300018300002), Airport(name = "Lille/Marcq-en-Baroeul Airport", country = "France", icao = "LFQO", lat = 50.687198638916016, lon = 3.0755600929260254), Airport(name = "Lashenden (Headcorn) Airfield", country = "United Kingdom", icao = "EGKH", lat = 51.156898, lon = 0.641667), Airport(name = "Le Touquet-Côte d'Opale Airport", country = "France", icao = "LFAT", lat = 50.517398834228516, lon = 1.6205899715423584), Airport(name = "Rochester Airport", country = "United Kingdom", icao = "EGTO", lat = 51.351898193359375, lon = 0.5033329725265503), Airport(name = "Lille-Lesquin Airport", country = "France", icao = "LFQQ", lat = 50.563332, lon = 3.086886), Airport(name = "Thurrock Airfield", country = "United Kingdom", icao = "EGMT", lat = 51.537505, lon = 0.367634))
 fun sinApprox(x: Double): Double {
     var term: Double = x
     var sum: Double = x
     var n: Int = 1
     while (n <= 8) {
-        val denom: Double = ((2 * n) * ((2 * n) + 1)).toDouble()
+        var denom: Double = (((2 * n) * ((2 * n) + 1)).toDouble())
         term = (((0.0 - term) * x) * x) / denom
         sum = sum + term
         n = n + 1
@@ -45,7 +45,7 @@ fun cosApprox(x: Double): Double {
     var sum: Double = 1.0
     var n: Int = 1
     while (n <= 8) {
-        val denom: Double = (((2 * n) - 1) * (2 * n)).toDouble()
+        var denom: Double = ((((2 * n) - 1) * (2 * n)).toDouble())
         term = (((0.0 - term) * x) * x) / denom
         sum = sum + term
         n = n + 1
@@ -65,7 +65,7 @@ fun atanApprox(x: Double): Double {
 
 fun atan2Approx(y: Double, x: Double): Double {
     if (x > 0.0) {
-        val r: Double = atanApprox(y / x)
+        var r: Double = atanApprox(y / x)
         return r
     }
     if (x < 0.0) {
@@ -102,24 +102,24 @@ fun deg(x: Double): Double {
 }
 
 fun distance(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
-    val phi1: Double = rad(lat1)
-    val phi2: Double = rad(lat2)
-    val dphi: Double = rad(lat2 - lat1)
-    val dlambda: Double = rad(lon2 - lon1)
-    val sdphi: Double = sinApprox(dphi / 2)
-    val sdlambda: Double = sinApprox(dlambda / 2)
-    val a: Double = (sdphi * sdphi) + (((cosApprox(phi1) * cosApprox(phi2)) * sdlambda) * sdlambda)
-    val c: Double = 2 * atan2Approx(sqrtApprox(a), sqrtApprox(1 - a))
+    var phi1: Double = rad(lat1)
+    var phi2: Double = rad(lat2)
+    var dphi: Double = rad(lat2 - lat1)
+    var dlambda: Double = rad(lon2 - lon1)
+    var sdphi: Double = sinApprox(dphi / 2)
+    var sdlambda: Double = sinApprox(dlambda / 2)
+    var a: Double = (sdphi * sdphi) + (((cosApprox(phi1) * cosApprox(phi2)) * sdlambda) * sdlambda)
+    var c: Double = 2 * atan2Approx(sqrtApprox(a), sqrtApprox(1 - a))
     return (6371.0 / 1.852) * c
 }
 
 fun bearing(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
-    val phi1: Double = rad(lat1)
-    val phi2: Double = rad(lat2)
-    val dl: Double = rad(lon2 - lon1)
-    val y: Double = sinApprox(dl) * cosApprox(phi2)
-    val x: Double = (cosApprox(phi1) * sinApprox(phi2)) - ((sinApprox(phi1) * cosApprox(phi2)) * cosApprox(dl))
-    val br: Double = deg(atan2Approx(y, x))
+    var phi1: Double = rad(lat1)
+    var phi2: Double = rad(lat2)
+    var dl: Double = rad(lon2 - lon1)
+    var y: Double = sinApprox(dl) * cosApprox(phi2)
+    var x: Double = (cosApprox(phi1) * sinApprox(phi2)) - ((sinApprox(phi1) * cosApprox(phi2)) * cosApprox(dl))
+    var br: Double = deg(atan2Approx(y, x))
     if (br < 0) {
         br = br + 360
     }
@@ -127,11 +127,11 @@ fun bearing(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
 }
 
 fun floor(x: Double): Double {
-    var i: Int = x.toInt()
-    if (i.toDouble() > x) {
+    var i: Int = (x.toInt())
+    if (((i.toDouble())) > x) {
         i = i - 1
     }
-    return i.toDouble()
+    return (i.toDouble())
 }
 
 fun pow10(n: Int): Double {
@@ -145,7 +145,7 @@ fun pow10(n: Int): Double {
 }
 
 fun round(x: Double, n: Int): Double {
-    val m: Double = pow10(n)
+    var m: Double = pow10(n)
     return floor((x * m) + 0.5) / m
 }
 
@@ -154,9 +154,9 @@ fun sortByDistance(xs: MutableList<MutableList<Any?>>): MutableList<MutableList<
     var i: Int = 1
     while (i < arr.size) {
         var j: Int = i
-        while ((j > 0) && (arr[j - 1][0] > arr[j][0])) {
-            val tmp: MutableList<Any?> = arr[j - 1]
-            arr[j - 1] = arr[j]
+        while ((j > 0) && (((((arr[j - 1] as MutableList<Any?>) as MutableList<Any?>))[0] as Any? as Number).toDouble() > ((((arr[j] as MutableList<Any?>) as MutableList<Any?>))[0] as Any? as Number).toDouble())) {
+            var tmp: MutableList<Any?> = arr[j - 1] as MutableList<Any?>
+            arr[j - 1] = arr[j] as MutableList<Any?>
             arr[j] = tmp
             j = j - 1
         }
@@ -166,24 +166,24 @@ fun sortByDistance(xs: MutableList<MutableList<Any?>>): MutableList<MutableList<
 }
 
 fun user_main(): Unit {
-    val planeLat: Double = 51.514669
-    val planeLon: Double = 2.198581
+    var planeLat: Double = 51.514669
+    var planeLon: Double = 2.198581
     var results: MutableList<MutableList<Any?>> = mutableListOf<MutableList<Any?>>()
     for (ap in airports) {
-        val d: Double = distance(planeLat, planeLon, ap.lat, ap.lon)
-        val b: Double = bearing(planeLat, planeLon, ap.lat, ap.lon)
-        results = run { val _tmp = results.toMutableList(); _tmp.add(mutableListOf<Any?>(d, b, ap)); _tmp } as MutableList<MutableList<Any?>>
+        var d: Double = distance(planeLat, planeLon, ap.lat, ap.lon)
+        var b: Double = bearing(planeLat, planeLon, ap.lat, ap.lon)
+        results = run { val _tmp = results.toMutableList(); _tmp.add(mutableListOf<Any?>((d as Any?), (b as Any?), (ap as Any?))); _tmp }
     }
     results = sortByDistance(results)
     println("Distance Bearing ICAO Country               Airport")
     println("--------------------------------------------------------------")
     var i: Int = 0
     while (i < results.size) {
-        val r: MutableList<Any?> = results[i]
-        val ap: Any? = r[2]
-        val dist: Any? = r[0]
-        val bear: Any? = r[1]
-        val line: String = (((((((round(dist.toDouble(), 1).toString() + "\t") + round(bear.toDouble(), 0).toString()) + "\t") + (ap.icao).toString()) + "\t") + (ap.country).toString()) + " ") + (ap.name).toString()
+        var r: MutableList<Any?> = results[i] as MutableList<Any?>
+        var ap: Any? = r[2] as Any?
+        var dist: Any? = r[0] as Any?
+        var bear: Any? = r[1] as Any?
+        var line: String = (((((((round((dist as Double), 1).toString() + "\t") + round((bear as Double), 0).toString()) + "\t") + ((ap as Airport)).icao) + "\t") + ((ap as Airport)).country) + " ") + ((ap as Airport)).name
         println(line)
         i = i + 1
     }

--- a/tests/rosetta/transpiler/Kotlin/distance-and-bearing.out
+++ b/tests/rosetta/transpiler/Kotlin/distance-and-bearing.out
@@ -1,0 +1,22 @@
+Distance Bearing ICAO Country               Airport
+--------------------------------------------------------------
+30.7	146.0	EBFN	Belgium Koksijde Air Base
+31.3	127.0	EBOS	Belgium Ostend-Bruges International Airport
+33.6	252.0	EGMH	United Kingdom Kent International Airport
+34.4	196.0	LFAC	France Calais-Dunkerque Airport
+42.6	105.0	EBKW	Belgium Westkapelle heliport
+51.6	240.0	EGMK	United Kingdom Lympne Airport
+52.8	115.0	EBUL	Belgium Ursel Air Base
+56.2	274.0	EGMC	United Kingdom Southend Airport
+56.4	162.0	LFQT	France Merville-Calonne Airport
+56.5	137.0	EBKT	Belgium Wevelgem Airport
+57.3	90.0	EHMZ	Netherlands Midden-Zeeland Airport
+58.0	235.0	EGMD	United Kingdom Lydd Airport
+59.0	309.0	EGUW	United Kingdom RAF Wattisham
+59.3	339.0	EGSM	United Kingdom Beccles Airport
+59.7	146.0	LFQO	France Lille/Marcq-en-Baroeul Airport
+62.2	250.0	EGKH	United Kingdom Lashenden (Headcorn) Airfield
+63.7	200.0	LFAT	France Le Touquet-Côte d'Opale Airport
+64.2	262.0	EGTO	United Kingdom Rochester Airport
+66.2	149.0	LFQQ	France Lille-Lesquin Airport
+68.4	272.0	EGMT	United Kingdom Thurrock Airfield

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-08-04 16:54 +0700
+Last updated: 2025-08-04 18:31 +0700
 
-Completed tasks: **359/491**
+Completed tasks: **360/491**
 
 ### Checklist
 | Index | Name | Status | Duration | Memory |
@@ -316,7 +316,7 @@ Completed tasks: **359/491**
 | 305 | discordian-date | ✓ | 8.09ms | 123.9 KB |
 | 306 | display-a-linear-combination | ✓ | 15.58ms | 123.1 KB |
 | 307 | display-an-outline-as-a-nested-table | ✓ | 25.14ms | 106.1 KB |
-| 308 | distance-and-bearing |  |  |  |
+| 308 | distance-and-bearing | ✓ | 10.32ms | 122.3 KB |
 | 309 | distributed-programming |  |  |  |
 | 310 | diversity-prediction-theorem | ✓ | 17.96ms | 115.4 KB |
 | 311 | dns-query |  |  |  |

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -1241,6 +1241,10 @@ func (b *BinaryExpr) emit(w io.Writer) {
 				cast(e, "Double")
 				return
 			}
+			if (lt == "Any" || lt == "Any?") && (rt == "Any" || rt == "Any?") {
+				cast(e, "Double")
+				return
+			}
 			if (rt == "Any" || rt == "Any?") && (lt == "Double" || lt == "Int") {
 				cast(e, lt)
 				return


### PR DESCRIPTION
## Summary
- cast `Any` comparisons to `Double` in Kotlin transpiler so dynamic lists can be sorted numerically
- mark distance-and-bearing Rosetta example complete and add generated Kotlin/bench output

## Testing
- `ROSETTA_INDEX=308 MOCHI_BENCHMARK=true go test -tags slow -run TestRosettaKotlin -count=1 ./transpiler/x/kt`


------
https://chatgpt.com/codex/tasks/task_e_689099e7b2f48320a3db12223815543b