### PR TITLE
kt transpiler: support panic

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/distributed-programming.bench
+++ b/tests/rosetta/transpiler/Kotlin/distributed-programming.bench
@@ -1,0 +1,1 @@
+{"duration_us":16003, "memory_bytes":137096, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/distributed-programming.kt
+++ b/tests/rosetta/transpiler/Kotlin/distributed-programming.kt
@@ -1,3 +1,5 @@
+fun panic(msg: String): Nothing { throw RuntimeException(msg) }
+
 var _nowSeed = 0L
 var _nowSeeded = false
 fun _now(): Long {
@@ -24,8 +26,8 @@ fun toJson(v: Any?): String = when (v) {
     else -> toJson(v.toString())
 }
 
-val amount: Int = 300
-val result: Int = tax(amount)
+var amount: Int = 300
+var result: Int = tax(amount)
 fun tax(cents: Int): Int {
     if (cents < 0) {
         panic("Negative amounts not allowed")

--- a/tests/rosetta/transpiler/Kotlin/distributed-programming.out
+++ b/tests/rosetta/transpiler/Kotlin/distributed-programming.out
@@ -1,0 +1,1 @@
+tax on 300 cents is 15 cents

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-08-04 18:31 +0700
+Last updated: 2025-08-04 21:01 +0700
 
-Completed tasks: **360/491**
+Completed tasks: **361/491**
 
 ### Checklist
 | Index | Name | Status | Duration | Memory |
@@ -317,7 +317,7 @@ Completed tasks: **360/491**
 | 306 | display-a-linear-combination | ✓ | 15.58ms | 123.1 KB |
 | 307 | display-an-outline-as-a-nested-table | ✓ | 25.14ms | 106.1 KB |
 | 308 | distance-and-bearing | ✓ | 10.32ms | 122.3 KB |
-| 309 | distributed-programming |  |  |  |
+| 309 | distributed-programming | ✓ | 16.00ms | 133.9 KB |
 | 310 | diversity-prediction-theorem | ✓ | 17.96ms | 115.4 KB |
 | 311 | dns-query |  |  |  |
 | 312 | documentation | ✓ | 3.23ms | 134.6 KB |

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -145,6 +145,7 @@ func init() {
     else -> v.toString().length
 }`,
 		"expect":       `fun expect(cond: Boolean) { if (!cond) throw RuntimeException("expect failed") }`,
+		"panic":        `fun panic(msg: String): Nothing { throw RuntimeException(msg) }`,
 		"input":        `fun input(): String = readLine() ?: ""`,
 		"importBigInt": `import java.math.BigInteger`,
 		"_now": `var _nowSeed = 0L


### PR DESCRIPTION
## Summary
- handle `panic` in Kotlin transpiler
- generate Rosetta Kotlin sources and outputs for `distributed-programming`

## Testing
- `ROSETTA_INDEX=309 go test ./transpiler/x/kt -run TestRosettaKotlin -tags slow -count=1`
- `ROSETTA_INDEX=309 MOCHI_BENCHMARK=true go test ./transpiler/x/kt -run TestRosettaKotlin -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6890bd37586483208a51df8541ec9a55