### PR TITLE
fs transpiler: drop unused return var

### DIFF
--- a/transpiler/x/fs/transpiler.go
+++ b/transpiler/x/fs/transpiler.go
@@ -2804,7 +2804,6 @@ func Emit(prog *Program) []byte {
 	}
 	if prog.UseReturn {
 		buf.WriteString("exception Return\n")
-		buf.WriteString("let mutable __ret = ()\n\n")
 	}
 	if prog.UseNow {
 		buf.WriteString(helperNow)


### PR DESCRIPTION
## Summary
- remove unused `__ret` variable from F# transpiler output
- add missing `.out` file for Fibonacci Rosetta example

## Testing
- `MOCHI_ROSETTA_INDEX=405 MOCHI_BENCHMARK=1 go test ./transpiler/x/fs -tags=slow -run TestFSTranspiler_Rosetta_Golden -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6890c04dad008320ae6deb66c3668751