### PR TITLE
java: fix string length handling

### DIFF
--- a/tests/rosetta/transpiler/Java/animation.bench
+++ b/tests/rosetta/transpiler/Java/animation.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 11174,
-  "memory_bytes": 0,
+  "duration_us": 40817,
+  "memory_bytes": 33664,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/animation.java
+++ b/tests/rosetta/transpiler/Java/animation.java
@@ -1,59 +1,35 @@
 public class Main {
-    static String msg = "Hello World! ";
-    static int shift = 0;
-    static int inc = 1;
-    static int clicks = 0;
-    static int frames = 0;
+    static String msg;
+    static int shift;
+    static int inc;
+    static int clicks;
+    static int frames;
 
     public static void main(String[] args) {
-        {
-            long _benchStart = _now();
-            long _benchMem = _mem();
-            while (clicks < 5) {
-                String line = "";
-                int i = 0;
-                while (i < msg.length()) {
-                    int idx = (shift + i) % msg.length();
-                    line = String.valueOf(line + msg.substring(idx, idx + 1));
-                    i = i + 1;
-                }
-                System.out.println(line);
-                shift = (shift + inc) % msg.length();
-                frames = frames + 1;
-                if (frames % msg.length() == 0) {
-                    inc = msg.length() - inc;
-                    clicks = clicks + 1;
-                }
+        msg = "Hello World! ";
+        shift = 0;
+        inc = 1;
+        clicks = 0;
+        frames = 0;
+        while (clicks < 5) {
+            String line = "";
+            int i = 0;
+            while (i < _runeLen(msg)) {
+                int idx = Math.floorMod((shift + i), _runeLen(msg));
+                line = line + msg.substring(idx, idx + 1);
+                i = i + 1;
             }
-            long _benchDuration = _now() - _benchStart;
-            long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
-            return;
+            System.out.println(line);
+            shift = Math.floorMod((shift + inc), _runeLen(msg));
+            frames = frames + 1;
+            if (Math.floorMod(frames, _runeLen(msg)) == 0) {
+                inc = _runeLen(msg) - inc;
+                clicks = clicks + 1;
+            }
         }
     }
 
-    static boolean _nowSeeded = false;
-    static int _nowSeed;
-    static int _now() {
-        if (!_nowSeeded) {
-            String s = System.getenv("MOCHI_NOW_SEED");
-            if (s != null && !s.isEmpty()) {
-                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
-            }
-        }
-        if (_nowSeeded) {
-            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
-            return _nowSeed;
-        }
-        return (int)(System.nanoTime() / 1000);
-    }
-
-    static long _mem() {
-        Runtime rt = Runtime.getRuntime();
-        return rt.totalMemory() - rt.freeMemory();
+    static int _runeLen(String s) {
+        return s.codePointCount(0, s.length());
     }
 }

--- a/transpiler/x/java/README.md
+++ b/transpiler/x/java/README.md
@@ -2,7 +2,7 @@
 
 Generated Java code for programs in `tests/vm/valid`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
-## VM Golden Test Checklist (103/105) - updated 2025-08-02 11:17 UTC
+## VM Golden Test Checklist (103/105) - updated 2025-08-04 14:33 UTC
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi

--- a/transpiler/x/java/ROSETTA.md
+++ b/transpiler/x/java/ROSETTA.md
@@ -1,7 +1,7 @@
 # Java Rosetta Transpiler Output
 
 Generated Java code for programs in `tests/rosetta/x/Mochi`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
-Last updated: 2025-08-04 21:23 GMT+7
+Last updated: 2025-08-04 21:33 GMT+7
 
 ## Rosetta Checklist (453/491)
 | Index | Name | Status | Duration | Memory |
@@ -56,7 +56,7 @@ Last updated: 2025-08-04 21:23 GMT+7
 | 48 | angle-difference-between-two-bearings-2 | ✓ | 802.0µs | 0B |
 | 49 | angles-geometric-normalization-and-conversion | ✓ | 9.0ms | 245.78KB |
 | 50 | animate-a-pendulum | ✓ | 634.0µs | 0B |
-| 51 | animation | ✓ | 11.0ms | 0B |
+| 51 | animation | ✓ | 40.0ms | 32.88KB |
 | 52 | anonymous-recursion-1 | ✓ | 7.0ms | 0B |
 | 53 | anonymous-recursion-2 | ✓ | 8.0ms | 0B |
 | 54 | anonymous-recursion | ✓ | 10.0ms | 0B |

--- a/transpiler/x/java/TASKS.md
+++ b/transpiler/x/java/TASKS.md
@@ -1,4 +1,8 @@
-## Progress (2025-08-02 17:58 +0700)
+## Progress (2025-08-04 21:28 +0700)
+- fix java transpiler string comparisons (1601cd716f)
+
+- fix java transpiler string comparisons (1601cd716f)
+
 - fix java transpiler ref var init and add rosetta outputs (5e9500e288)
 
 - fix java transpiler ref var init and add rosetta outputs (5e9500e288)


### PR DESCRIPTION
## Summary
- ensure Java transpiler uses `_runeLen` and `Math.floorMod` when shifting strings in animation program
- refresh Java Rosetta checklist and benchmarks for animation task

## Testing
- `MOCHI_ROSETTA_INDEX=51 UPDATE=1 MOCHI_BENCHMARK=1 go test ./transpiler/x/java -tags slow -run Rosetta`
- `MOCHI_ROSETTA_INDEX=51 go test ./transpiler/x/java -tags slow -run Rosetta`


------
https://chatgpt.com/codex/tasks/task_e_6890c387cb248320ae6f9fa446d23b8e