### PR TITLE
zig transpiler: count print uses and unique param names

### DIFF
--- a/transpiler/x/zig/transpiler.go
+++ b/transpiler/x/zig/transpiler.go
@@ -3755,6 +3755,8 @@ func compileFunStmt(fn *parser.FunStmt, prog *parser.Program) (*Func, error) {
 			paramName = uniqueName(name + "_param")
 		} else if globalNames[name] {
 			paramName = name + "_param"
+		} else {
+			paramName = uniqueName(name)
 		}
 		aliasName := paramName
 		if mutables[p.Name] {
@@ -4539,6 +4541,10 @@ func collectVarInfo(p *Program) (map[string]int, map[string]bool) {
 			walkExpr(t.Value)
 		case *ExprStmt:
 			walkExpr(t.Expr)
+		case *PrintStmt:
+			for _, v := range t.Values {
+				walkExpr(v)
+			}
 		case *ReturnStmt:
 			if t.Value != nil {
 				walkExpr(t.Value)


### PR DESCRIPTION
## Summary
- ensure PrintStmt expressions are tracked for usage analysis in the Zig transpiler
- generate unique parameter names for all functions to avoid cross-scope collisions

## Testing
- `MOCHI_ROSETTA_INDEX=152 MOCHI_BENCHMARK=true go test -tags slow ./transpiler/x/zig -run TestZigTranspiler_Rosetta -update-rosetta-zig` *(fails: call-a-function-12.mochi: exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_6890c3ba87888320b5621452e4e43f9a