### PR TITLE
Fix go build/test by adding stubs for non-default packages

### DIFF
--- a/compiler/x/java/stub.go
+++ b/compiler/x/java/stub.go
@@ -1,0 +1,5 @@
+//go:build !slow
+
+package javacode
+
+// This stub ensures the package builds without the slow build tag.

--- a/runtime/infer/stub.go
+++ b/runtime/infer/stub.go
@@ -1,0 +1,3 @@
+package infer
+
+// This package contains only tests; stub added for build.

--- a/scripts/dummy.go
+++ b/scripts/dummy.go
@@ -1,0 +1,5 @@
+//go:build !archive
+
+package scripts
+
+// Package scripts provides build-time utilities disabled in normal builds.

--- a/scripts/noslow.go
+++ b/scripts/noslow.go
@@ -1,4 +1,4 @@
-//go:build !slow
+//go:build archive && !slow
 
 package main
 

--- a/tests/vm_extended/stub.go
+++ b/tests/vm_extended/stub.go
@@ -1,0 +1,3 @@
+package vm_test
+
+// This package contains extended VM tests only.

--- a/tools/dummy.go
+++ b/tools/dummy.go
@@ -1,0 +1,5 @@
+//go:build !tools
+
+package tools
+
+// Placeholder to make the tools module build without the tools tag.

--- a/tools/stub.go
+++ b/tools/stub.go
@@ -1,4 +1,4 @@
-//go:build !slow
+//go:build tools && !slow
 
 package main
 


### PR DESCRIPTION
## Summary
- adjust build tags for scripts and tools to avoid binaries in normal builds
- add stub packages for java compiler, runtime infer, vm extended tests, and build-time tools

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6890d2efb764832091729a06ba87c4d9