### PR TITLE
Improve numeric type inference and add Rosetta outputs 101-150

### DIFF
--- a/tests/aster/x/mochi/rosetta/base64-decode-data.error
+++ b/tests/aster/x/mochi/rosetta/base64-decode-data.error
@@ -1,0 +1,8 @@
+error[A026]: argument 1 to binToInt type mismatch: string vs any
+  --> /workspace/mochi/tests/rosetta/x/Mochi/base64-decode-data.mochi:103:24
+
+103 |     let val = binToInt(chunk)
+    |                        ^
+
+help:
+  Ensure arguments match parameter types

--- a/tests/aster/x/mochi/rosetta/bell-numbers.out.mochi
+++ b/tests/aster/x/mochi/rosetta/bell-numbers.out.mochi
@@ -1,0 +1,40 @@
+fun bellTriangle(n: int): list<list<bigint>> {
+  var tri: list<list<bigint>>
+  var i: int = 0
+  while (i < n) {
+    var row: list<bigint>
+    var j: int = 0
+    while (j < i) {
+      row = append(row, 0 as bigint)
+      j = (j + 1)
+    }
+    tri = append(tri, row)
+    i = (i + 1)
+  }
+  tri[1][0] = 1
+  i = 2
+  while (i < n) {
+    tri[i][0] = tri[(i - 1)][(i - 2)]
+    var j: int = 1
+    while (j < i) {
+      tri[i][j] = (tri[i][(j - 1)] + tri[(i - 1)][(j - 1)])
+      j = (j + 1)
+    }
+    i = (i + 1)
+  }
+  return tri
+}
+fun main() {
+  let bt: list<list<bigint>> = bellTriangle(51)
+  print("First fifteen and fiftieth Bell numbers:")
+  for i in 1..16 {
+    print(((("" + padStart(str(i), 2, " ")) + ": ") + str(bt[i][0])))
+  }
+  print(("50: " + str(bt[50][0])))
+  print("")
+  print("The first ten rows of Bell's triangle:")
+  for i in 1..11 {
+    print(bt[i])
+  }
+}
+main()

--- a/tests/aster/x/mochi/rosetta/benfords-law.error
+++ b/tests/aster/x/mochi/rosetta/benfords-law.error
@@ -1,0 +1,8 @@
+error[A003]: undefined variable n
+  --> /workspace/mochi/tests/rosetta/x/Mochi/benfords-law.mochi:73:26
+
+ 73 |     let d = leadingDigit(n)
+    |                          ^
+
+help:
+  Declare n before use

--- a/tests/aster/x/mochi/rosetta/bernoulli-numbers.error
+++ b/tests/aster/x/mochi/rosetta/bernoulli-numbers.error
@@ -1,0 +1,8 @@
+error[A003]: undefined variable i
+  --> /workspace/mochi/tests/rosetta/x/Mochi/bernoulli-numbers.mochi:25:21
+
+ 25 |   let b = bernoulli(i)
+    |                     ^
+
+help:
+  Declare i before use

--- a/tests/aster/x/mochi/rosetta/best-shuffle.error
+++ b/tests/aster/x/mochi/rosetta/best-shuffle.error
@@ -1,0 +1,8 @@
+error[A005]: list element type mismatch
+  --> /workspace/mochi/tests/rosetta/x/Mochi/best-shuffle.mochi:28:10
+
+ 28 |   return [res, sd]
+    |          ^
+
+help:
+  Ensure all list elements share a type

--- a/tests/aster/x/mochi/rosetta/bifid-cipher.error
+++ b/tests/aster/x/mochi/rosetta/bifid-cipher.error
@@ -1,0 +1,8 @@
+error[A007]: map entry type mismatch
+  --> /workspace/mochi/tests/rosetta/x/Mochi/bifid-cipher.mochi:18:22
+
+ 18 |   return {"e": emap, "d": dmap}
+    |                      ^
+
+help:
+  Ensure map keys and values share types

--- a/tests/aster/x/mochi/rosetta/bin-given-limits.out.mochi
+++ b/tests/aster/x/mochi/rosetta/bin-given-limits.out.mochi
@@ -1,0 +1,61 @@
+fun getBins(limits: list<int>, data: list<int>): list<int> {
+  var n: int = len(limits)
+  var bins: list<int>
+  var i: int = 0
+  while (i < (n + 1)) {
+    bins = append(bins, 0)
+    i = (i + 1)
+  }
+  var j: int = 0
+  while (j < len(data)) {
+    let d: int = data[j]
+    var index: int = 0
+    while (index < len(limits)) {
+      if (d < limits[index]) {
+        break
+      }
+      if (d == limits[index]) {
+        index = (index + 1)
+        break
+      }
+      index = (index + 1)
+    }
+    bins[index] = (bins[index] + 1)
+    j = (j + 1)
+  }
+  return bins
+}
+fun padLeft(n: int, width: int): string {
+  var s: string = str(n)
+  var pad: int = (width - len(s))
+  var out: string = ""
+  var i: int = 0
+  while (i < pad) {
+    out = (out + " ")
+    i = (i + 1)
+  }
+  return (out + s)
+}
+fun printBins(limits: list<int>, bins: list<int>) {
+  var n: int = len(limits)
+  print(((("           < " + padLeft(limits[0], 3)) + " = ") + padLeft(bins[0], 2)))
+  var i: int = 1
+  while (i < n) {
+    print((((((">= " + padLeft(limits[(i - 1)], 3)) + " and < ") + padLeft(limits[i], 3)) + " = ") + padLeft(bins[i], 2)))
+    i = (i + 1)
+  }
+  print((((">= " + padLeft(limits[(n - 1)], 3)) + "           = ") + padLeft(bins[n], 2)))
+  print("")
+}
+fun main() {
+  let limitsList: list<list<int>> = [[23, 37, 43, 53, 67, 83], [14, 18, 249, 312, 389, 392, 513, 591, 634, 720]]
+  let dataList: list<list<int>> = [[95, 21, 94, 12, 99, 4, 70, 75, 83, 93, 52, 80, 57, 5, 53, 86, 65, 17, 92, 83, 71, 61, 54, 58, 47, 16, 8, 9, 32, 84, 7, 87, 46, 19, 30, 37, 96, 6, 98, 40, 79, 97, 45, 64, 60, 29, 49, 36, 43, 55], [445, 814, 519, 697, 700, 130, 255, 889, 481, 122, 932, 77, 323, 525, 570, 219, 367, 523, 442, 933, 416, 589, 930, 373, 202, 253, 775, 47, 731, 685, 293, 126, 133, 450, 545, 100, 741, 583, 763, 306, 655, 267, 248, 477, 549, 238, 62, 678, 98, 534, 622, 907, 406, 714, 184, 391, 913, 42, 560, 247, 346, 860, 56, 138, 546, 38, 985, 948, 58, 213, 799, 319, 390, 634, 458, 945, 733, 507, 916, 123, 345, 110, 720, 917, 313, 845, 426, 9, 457, 628, 410, 723, 354, 895, 881, 953, 677, 137, 397, 97, 854, 740, 83, 216, 421, 94, 517, 479, 292, 963, 376, 981, 480, 39, 257, 272, 157, 5, 316, 395, 787, 942, 456, 242, 759, 898, 576, 67, 298, 425, 894, 435, 831, 241, 989, 614, 987, 770, 384, 692, 698, 765, 331, 487, 251, 600, 879, 342, 982, 527, 736, 795, 585, 40, 54, 901, 408, 359, 577, 237, 605, 847, 353, 968, 832, 205, 838, 427, 876, 959, 686, 646, 835, 127, 621, 892, 443, 198, 988, 791, 466, 23, 707, 467, 33, 670, 921, 180, 991, 396, 160, 436, 717, 918, 8, 374, 101, 684, 727, 749]]
+  var i: int = 0
+  while (i < len(limitsList)) {
+    print((("Example " + str((i + 1))) + "\n"))
+    let bins: list<int> = getBins(limitsList[i], dataList[i])
+    printBins(limitsList[i], bins)
+    i = (i + 1)
+  }
+}
+main()

--- a/tests/aster/x/mochi/rosetta/binary-digits.out.mochi
+++ b/tests/aster/x/mochi/rosetta/binary-digits.out.mochi
@@ -1,0 +1,15 @@
+fun toBin(n: int): string {
+  if (n == 0) {
+    return "0"
+  }
+  var bits: string = ""
+  var x: int = n
+  while (x > 0) {
+    bits = (str((x % 2)) + bits)
+    x = ((x / 2)) as int
+  }
+  return bits
+}
+for i in 0..16 {
+  print(toBin(i))
+}

--- a/tests/aster/x/mochi/rosetta/binary-search.out.mochi
+++ b/tests/aster/x/mochi/rosetta/binary-search.out.mochi
@@ -1,0 +1,45 @@
+fun bsearch(arr: list<int>, x: int): int {
+  var low: int = 0
+  var high: int = (len(arr) - 1)
+  while (low <= high) {
+    let mid: int = (((low + high)) / 2)
+    if (arr[mid] > x) {
+      high = (mid - 1)
+    } else     if (arr[mid] < x) {
+      low = (mid + 1)
+    } else {
+      return mid
+    }
+  }
+  return -1
+}
+fun bsearchRec(arr: list<int>, x: int, low: int, high: int): int {
+  if (high < low) {
+    return -1
+  }
+  let mid: int = (((low + high)) / 2)
+  if (arr[mid] > x) {
+    return bsearchRec(arr, x, low, (mid - 1))
+  } else   if (arr[mid] < x) {
+    return bsearchRec(arr, x, (mid + 1), high)
+  }
+  return mid
+}
+fun main() {
+  let nums: list<int> = [-31, 0, 1, 2, 2, 4, 65, 83, 99, 782]
+  var x: int = 2
+  var idx: int = bsearch(nums, x)
+  if (idx >= 0) {
+    print((((str(x) + " is at index ") + str(idx)) + "."))
+  } else {
+    print((str(x) + " is not found."))
+  }
+  x = 5
+  idx = bsearchRec(nums, x, 0, (len(nums) - 1))
+  if (idx >= 0) {
+    print((((str(x) + " is at index ") + str(idx)) + "."))
+  } else {
+    print((str(x) + " is not found."))
+  }
+}
+main()

--- a/tests/aster/x/mochi/rosetta/binary-strings.error
+++ b/tests/aster/x/mochi/rosetta/binary-strings.error
@@ -1,0 +1,8 @@
+error[A024]: unknown function substring
+  --> /workspace/mochi/tests/rosetta/x/Mochi/binary-strings.mochi:7:10
+
+  7 |   return substring(letters, idx, idx + 1)
+    |          ^
+
+help:
+  Declare substring before use

--- a/tests/aster/x/mochi/rosetta/bioinformatics-base-count.error
+++ b/tests/aster/x/mochi/rosetta/bioinformatics-base-count.error
@@ -1,0 +1,8 @@
+error[A024]: unknown function substring
+  --> /workspace/mochi/tests/rosetta/x/Mochi/bioinformatics-base-count.mochi:42:12
+
+ 42 |   let ch = substring(dna, idx, idx + 1)
+    |            ^
+
+help:
+  Declare substring before use

--- a/tests/aster/x/mochi/rosetta/bioinformatics-global-alignment.error
+++ b/tests/aster/x/mochi/rosetta/bioinformatics-global-alignment.error
@@ -1,0 +1,8 @@
+error[A026]: argument 2 to indexOfFrom type mismatch: string vs any
+  --> /workspace/mochi/tests/rosetta/x/Mochi/bioinformatics-global-alignment.mochi:80:32
+
+ 80 |     let ix = indexOfFrom(s1, s2[0:1], start)
+    |                                ^
+
+help:
+  Ensure arguments match parameter types

--- a/tests/aster/x/mochi/rosetta/bioinformatics-sequence-mutation.error
+++ b/tests/aster/x/mochi/rosetta/bioinformatics-sequence-mutation.error
@@ -1,0 +1,8 @@
+error[A005]: list element type mismatch
+  --> /workspace/mochi/tests/rosetta/x/Mochi/bioinformatics-sequence-mutation.mochi:31:10
+
+ 31 |   return [s, out]
+    |          ^
+
+help:
+  Ensure all list elements share a type

--- a/tests/aster/x/mochi/rosetta/biorhythms.error
+++ b/tests/aster/x/mochi/rosetta/biorhythms.error
@@ -1,0 +1,8 @@
+error[A026]: argument 1 to parseIntStr type mismatch: string vs any
+  --> /workspace/mochi/tests/rosetta/x/Mochi/biorhythms.mochi:58:24
+
+ 58 |   let y = parseIntStr(s[0:4])
+    |                        ^
+
+help:
+  Ensure arguments match parameter types

--- a/tests/aster/x/mochi/rosetta/bitcoin-address-validation.error
+++ b/tests/aster/x/mochi/rosetta/bitcoin-address-validation.error
@@ -1,0 +1,8 @@
+error[A026]: argument 2 to indexOf type mismatch: string vs any
+  --> /workspace/mochi/tests/rosetta/x/Mochi/bitcoin-address-validation.mochi:23:27
+
+ 23 |     var c = indexOf(tmpl, ch)
+    |                           ^
+
+help:
+  Ensure arguments match parameter types

--- a/tests/aster/x/mochi/rosetta/bitmap-b-zier-curves-cubic.error
+++ b/tests/aster/x/mochi/rosetta/bitmap-b-zier-curves-cubic.error
@@ -1,0 +1,8 @@
+error[A007]: map entry type mismatch
+  --> /workspace/mochi/tests/rosetta/x/Mochi/bitmap-b-zier-curves-cubic.mochi:29:39
+
+ 29 |   return {"cols": cols, "rows": rows, "data": d}
+    |                                       ^
+
+help:
+  Ensure map keys and values share types

--- a/tests/aster/x/mochi/rosetta/bitmap-b-zier-curves-quadratic.error
+++ b/tests/aster/x/mochi/rosetta/bitmap-b-zier-curves-quadratic.error
@@ -1,0 +1,8 @@
+error[A007]: map entry type mismatch
+  --> /workspace/mochi/tests/rosetta/x/Mochi/bitmap-b-zier-curves-quadratic.mochi:29:39
+
+ 29 |   return {"cols": cols, "rows": rows, "data": d}
+    |                                       ^
+
+help:
+  Ensure map keys and values share types

--- a/tests/aster/x/mochi/rosetta/bitmap-bresenhams-line-algorithm.out.mochi
+++ b/tests/aster/x/mochi/rosetta/bitmap-bresenhams-line-algorithm.out.mochi
@@ -1,0 +1,50 @@
+fun absi(x: int): int {
+  if (x < 0) {
+    return -x
+  }
+  return x
+}
+type Point {
+  x: int
+  y: int
+}
+fun bresenham(x0: int, y0: int, x1: int, y1: int): list<Point> {
+  var dx: int = absi((x1 - x0))
+  var dy: int = absi((y1 - y0))
+  var sx: int = -1
+  if (x0 < x1) {
+    sx = 1
+  }
+  var sy: int = -1
+  if (y0 < y1) {
+    sy = 1
+  }
+  var err: int = (dx - dy)
+  var pts: list<Point>
+  while true {
+    pts = append(pts, Point {x: x0, y: y0})
+    if ((x0 == x1) && (y0 == y1)) {
+      break
+    }
+    var e2: int = (2 * err)
+    if (e2 > (-dy)) {
+      err = (err - dy)
+      x0 = (x0 + sx)
+    }
+    if (e2 < dx) {
+      err = (err + dx)
+      y0 = (y0 + sy)
+    }
+  }
+  return pts
+}
+fun main() {
+  let pts: list<Point> = bresenham(0, 0, 6, 4)
+  var i: int = 0
+  while (i < len(pts)) {
+    let p: Point = pts[i]
+    print((((("(" + str(p.x)) + ",") + str(p.y)) + ")"))
+    i = (i + 1)
+  }
+}
+main()

--- a/tests/aster/x/mochi/rosetta/bitmap-flood-fill.out.mochi
+++ b/tests/aster/x/mochi/rosetta/bitmap-flood-fill.out.mochi
@@ -1,0 +1,20 @@
+var grid: list<list<string>> = [[".", ".", ".", ".", "."], [".", "#", "#", "#", "."], [".", "#", ".", "#", "."], [".", "#", "#", "#", "."], [".", ".", ".", ".", "."]]
+fun flood(x: int, y: int, repl: string) {
+  let target: string = grid[y][x]
+  fun ff(px: int, py: int) {
+    grid[py][px] = repl
+    ff((px - 1), py)
+    ff((px + 1), py)
+    ff(px, (py - 1))
+    ff(px, (py + 1))
+  }
+  ff(x, y)
+}
+flood(2, 2, "o")
+for row in grid {
+  var line: string = ""
+  for ch in row {
+    line = (line + ch)
+  }
+  print(line)
+}

--- a/tests/aster/x/mochi/rosetta/bitmap-histogram.out.mochi
+++ b/tests/aster/x/mochi/rosetta/bitmap-histogram.out.mochi
@@ -1,0 +1,91 @@
+fun image(): list<list<int>> {
+  return [[0, 0, 10000], [65535, 65535, 65535], [65535, 65535, 65535]]
+}
+fun histogram(g: list<list<int>>, bins: int): list<int> {
+  if (bins <= 0) {
+    bins = len(g[0])
+  }
+  var h: list<int>
+  var i: int = 0
+  while (i < bins) {
+    h = append(h, 0)
+    i = (i + 1)
+  }
+  var y: int = 0
+  while (y < len(g)) {
+    var row: list<int> = g[y]
+    var x: int = 0
+    while (x < len(row)) {
+      var p: int = row[x]
+      var idx: int = ((((p * ((bins - 1)))) / 65535)) as int
+      h[idx] = (h[idx] + 1)
+      x = (x + 1)
+    }
+    y = (y + 1)
+  }
+  return h
+}
+fun medianThreshold(h: list<int>): int {
+  var lb: int = 0
+  var ub: int = (len(h) - 1)
+  var lSum: int = 0
+  var uSum: int = 0
+  while (lb <= ub) {
+    if ((lSum + h[lb]) < (uSum + h[ub])) {
+      lSum = (lSum + h[lb])
+      lb = (lb + 1)
+    } else {
+      uSum = (uSum + h[ub])
+      ub = (ub - 1)
+    }
+  }
+  return ((((ub * 65535)) / len(h))) as int
+}
+fun threshold(g: list<list<int>>, t: int): list<list<int>> {
+  var out: list<list<int>>
+  var y: int = 0
+  while (y < len(g)) {
+    var row: list<int> = g[y]
+    var newRow: list<int>
+    var x: int = 0
+    while (x < len(row)) {
+      if (row[x] < t) {
+        newRow = append(newRow, 0)
+      } else {
+        newRow = append(newRow, 65535)
+      }
+      x = (x + 1)
+    }
+    out = append(out, newRow)
+    y = (y + 1)
+  }
+  return out
+}
+fun printImage(g: list<list<int>>) {
+  var y: int = 0
+  while (y < len(g)) {
+    var row: list<int> = g[y]
+    var line: string = ""
+    var x: int = 0
+    while (x < len(row)) {
+      if (row[x] == 0) {
+        line = (line + "0")
+      } else {
+        line = (line + "1")
+      }
+      x = (x + 1)
+    }
+    print(line)
+    y = (y + 1)
+  }
+}
+fun main() {
+  let img: list<list<int>> = image()
+  let h: list<int> = histogram(img, 0)
+  print(("Histogram: " + str(h)))
+  let t: int = medianThreshold(h)
+  print(("Threshold: " + str(t)))
+  let bw: list<list<int>> = threshold(img, t)
+  printImage(bw)
+}
+main()

--- a/tests/aster/x/mochi/rosetta/bitmap-midpoint-circle-algorithm.out.mochi
+++ b/tests/aster/x/mochi/rosetta/bitmap-midpoint-circle-algorithm.out.mochi
@@ -1,0 +1,62 @@
+fun initGrid(size: int): list<list<string>> {
+  var g: list<list<string>>
+  var y: int = 0
+  while (y < size) {
+    var row: list<string>
+    var x: int = 0
+    while (x < size) {
+      row = append(row, " ")
+      x = (x + 1)
+    }
+    g = append(g, row)
+    y = (y + 1)
+  }
+  return g
+}
+fun set(g: list<list<string>>, x: int, y: int) {
+  if ((((x >= 0) && (x < len(g[0]))) && (y >= 0)) && (y < len(g))) {
+    g[y][x] = "#"
+  }
+}
+fun circle(r: int): list<list<string>> {
+  let size: int = ((r * 2) + 1)
+  var g: list<list<string>> = initGrid(size)
+  var x: int = r
+  var y: int = 0
+  var err: int = (1 - r)
+  while (y <= x) {
+    set(g, (r + x), (r + y))
+    set(g, (r + y), (r + x))
+    set(g, (r - x), (r + y))
+    set(g, (r - y), (r + x))
+    set(g, (r - x), (r - y))
+    set(g, (r - y), (r - x))
+    set(g, (r + x), (r - y))
+    set(g, (r + y), (r - x))
+    y = (y + 1)
+    if (err < 0) {
+      err = ((err + (2 * y)) + 1)
+    } else {
+      x = (x - 1)
+      err = ((err + (2 * ((y - x)))) + 1)
+    }
+  }
+  return g
+}
+fun trimRight(row: list<string>): string {
+  var end: int = len(row)
+  while ((end > 0) && (row[(end - 1)] == " ")) {
+    end = (end - 1)
+  }
+  var s: string = ""
+  var i: int = 0
+  while (i < end) {
+    s = (s + row[i])
+    i = (i + 1)
+  }
+  return s
+}
+var g: list<list<string>> = circle(10)
+for row in g {
+  print(trimRight(row))
+}

--- a/tests/aster/x/mochi/rosetta/bitmap-ppm-conversion-through-a-pipe.out.mochi
+++ b/tests/aster/x/mochi/rosetta/bitmap-ppm-conversion-through-a-pipe.out.mochi
@@ -1,0 +1,107 @@
+type Pixel {
+  R: int
+  G: int
+  B: int
+}
+fun pixelFromRgb(c: int): Pixel {
+  let r: int = ((((c / 65536)) as int) % 256)
+  let g: int = ((((c / 256)) as int) % 256)
+  let b: int = (c % 256)
+  return Pixel {R: r, G: g, B: b}
+}
+fun rgbFromPixel(p: Pixel): int {
+  return (((p.R * 65536) + (p.G * 256)) + p.B)
+}
+type Bitmap {
+  cols: int
+  rows: int
+  px: list<list<Pixel>>
+}
+fun NewBitmap(x: int, y: int): Bitmap {
+  var data: list<list<Pixel>>
+  var row: int = 0
+  while (row < y) {
+    var r: list<Pixel>
+    var col: int = 0
+    while (col < x) {
+      r = append(r, Pixel {R: 0, G: 0, B: 0})
+      col = (col + 1)
+    }
+    data = append(data, r)
+    row = (row + 1)
+  }
+  return Bitmap {cols: x, rows: y, px: data}
+}
+fun FillRgb(b: Bitmap, c: int) {
+  var y: int = 0
+  let p: Pixel = pixelFromRgb(c)
+  while (y < b.rows) {
+    var x: int = 0
+    while (x < b.cols) {
+      var px: list<list<Pixel>> = b.px
+      var row: list<Pixel> = px[y]
+      row[x] = p
+      px[y] = row
+      b.px = px
+      x = (x + 1)
+    }
+    y = (y + 1)
+  }
+}
+fun SetPxRgb(b: Bitmap, x: int, y: int, c: int): bool {
+  if ((((x < 0) || (x >= b.cols)) || (y < 0)) || (y >= b.rows)) {
+    return false
+  }
+  var px: list<list<Pixel>> = b.px
+  var row: list<Pixel> = px[y]
+  row[x] = pixelFromRgb(c)
+  px[y] = row
+  b.px = px
+  return true
+}
+fun nextRand(seed: int): int {
+  return ((((seed * 1664525) + 1013904223)) % 2147483648)
+}
+fun main() {
+  var bm: Bitmap = NewBitmap(400, 300)
+  FillRgb(bm, 12615744)
+  var seed: int = now()
+  var i: int = 0
+  while (i < 2000) {
+    seed = nextRand(seed)
+    let x: int = (seed % 400)
+    seed = nextRand(seed)
+    let y: int = (seed % 300)
+    SetPxRgb(bm, x, y, 8405024)
+    i = (i + 1)
+  }
+  var x: int = 0
+  while (x < 400) {
+    var y: int = 240
+    while (y < 245) {
+      SetPxRgb(bm, x, y, 8405024)
+      y = (y + 1)
+    }
+    y = 260
+    while (y < 265) {
+      SetPxRgb(bm, x, y, 8405024)
+      y = (y + 1)
+    }
+    x = (x + 1)
+  }
+  var y: int = 0
+  while (y < 300) {
+    var x: int = 80
+    while (x < 85) {
+      SetPxRgb(bm, x, y, 8405024)
+      x = (x + 1)
+    }
+    x = 95
+    while (x < 100) {
+      SetPxRgb(bm, x, y, 8405024)
+      x = (x + 1)
+    }
+    y = (y + 1)
+  }
+}
+main()

--- a/tests/aster/x/mochi/rosetta/bitmap-read-a-ppm-file.error
+++ b/tests/aster/x/mochi/rosetta/bitmap-read-a-ppm-file.error
@@ -1,0 +1,8 @@
+error[A024]: unknown function substr
+  --> /workspace/mochi/tests/rosetta/x/Mochi/bitmap-read-a-ppm-file.mochi:51:14
+
+ 51 |     let ch = substr(s, i, i+1)
+    |              ^
+
+help:
+  Declare substr before use

--- a/tests/aster/x/mochi/rosetta/bitmap-read-an-image-through-a-pipe.error
+++ b/tests/aster/x/mochi/rosetta/bitmap-read-an-image-through-a-pipe.error
@@ -1,0 +1,8 @@
+error[A024]: unknown function substring
+  --> /workspace/mochi/tests/rosetta/x/Mochi/bitmap-read-an-image-through-a-pipe.mochi:36:14
+
+ 36 |     let ch = substring(s, i, i+1)
+    |              ^
+
+help:
+  Declare substring before use

--- a/tests/aster/x/mochi/rosetta/bitmap-write-a-ppm-file.out.mochi
+++ b/tests/aster/x/mochi/rosetta/bitmap-write-a-ppm-file.out.mochi
@@ -1,0 +1,101 @@
+type Colour {
+  R: int
+  G: int
+  B: int
+}
+type Bitmap {
+  width: int
+  height: int
+  pixels: list<list<Colour>>
+}
+fun newBitmap(w: int, h: int, c: Colour): Bitmap {
+  var rows: list<list<Colour>>
+  var y: int = 0
+  while (y < h) {
+    var row: list<Colour>
+    var x: int = 0
+    while (x < w) {
+      row = append(row, c)
+      x = (x + 1)
+    }
+    rows = append(rows, row)
+    y = (y + 1)
+  }
+  return Bitmap {width: w, height: h, pixels: rows}
+}
+fun setPixel(b: Bitmap, x: int, y: int, c: Colour) {
+  var rows: list<list<Colour>> = b.pixels
+  var row: list<Colour> = rows[y]
+  row[x] = c
+  rows[y] = row
+  b.pixels = rows
+}
+fun fillRect(b: Bitmap, x: int, y: int, w: int, h: int, c: Colour) {
+  var yy: int = y
+  while (yy < (y + h)) {
+    var xx: int = x
+    while (xx < (x + w)) {
+      setPixel(b, xx, yy, c)
+      xx = (xx + 1)
+    }
+    yy = (yy + 1)
+  }
+}
+fun pad(n: int, width: int): string {
+  var s: string = str(n)
+  while (len(s) < width) {
+    s = (" " + s)
+  }
+  return s
+}
+fun writePPMP3(b: Bitmap): string {
+  var maxv: int = 0
+  var y: int = 0
+  while (y < b.height) {
+    var x: int = 0
+    while (x < b.width) {
+      let p: Colour = b.pixels[y][x]
+      if (p.R > maxv) {
+        maxv = p.R
+      }
+      if (p.G > maxv) {
+        maxv = p.G
+      }
+      if (p.B > maxv) {
+        maxv = p.B
+      }
+      x = (x + 1)
+    }
+    y = (y + 1)
+  }
+  var out: string = (((((("P3\n# generated from Bitmap.writeppmp3\n" + str(b.width)) + " ") + str(b.height)) + "\n") + str(maxv)) + "\n")
+  var numsize: int = len(str(maxv))
+  y = (b.height - 1)
+  while (y >= 0) {
+    var line: string = ""
+    var x: int = 0
+    while (x < b.width) {
+      let p: Colour = b.pixels[y][x]
+      line = ((((((line + "   ") + pad(p.R, numsize)) + " ") + pad(p.G, numsize)) + " ") + pad(p.B, numsize))
+      x = (x + 1)
+    }
+    out = (out + line)
+    if (y > 0) {
+      out = (out + "\n")
+    } else {
+      out = (out + "\n")
+    }
+    y = (y - 1)
+  }
+  return out
+}
+fun main() {
+  let black: Colour = Colour {R: 0, G: 0, B: 0}
+  let white: Colour = Colour {R: 255, G: 255, B: 255}
+  var bm: Bitmap = newBitmap(4, 4, black)
+  fillRect(bm, 1, 0, 1, 2, white)
+  setPixel(bm, 3, 3, Colour {R: 127, G: 0, B: 63})
+  let ppm: string = writePPMP3(bm)
+  print(ppm)
+}
+main()

--- a/tests/aster/x/mochi/rosetta/bitmap.error
+++ b/tests/aster/x/mochi/rosetta/bitmap.error
@@ -1,0 +1,8 @@
+error[A007]: map entry type mismatch
+  --> /workspace/mochi/tests/rosetta/x/Mochi/bitmap.mochi:88:23
+
+ 88 |   return {"ok": true, "pixel": row[x]}
+    |                       ^
+
+help:
+  Ensure map keys and values share types

--- a/tests/aster/x/mochi/rosetta/bitwise-io-1.error
+++ b/tests/aster/x/mochi/rosetta/bitwise-io-1.error
@@ -1,0 +1,1 @@
+panic: runtime error: index out of range [0] with length 0

--- a/tests/aster/x/mochi/rosetta/bitwise-io-2.error
+++ b/tests/aster/x/mochi/rosetta/bitwise-io-2.error
@@ -1,0 +1,8 @@
+error[A007]: map entry type mismatch
+  --> /workspace/mochi/tests/rosetta/x/Mochi/bitwise-io-2.mochi:77:23
+
+ 77 |   return {"val": out, "eof": false}
+    |                       ^
+
+help:
+  Ensure map keys and values share types

--- a/tests/aster/x/mochi/rosetta/bitwise-operations.out.mochi
+++ b/tests/aster/x/mochi/rosetta/bitwise-operations.out.mochi
@@ -1,0 +1,137 @@
+fun toUnsigned16(n: int): int {
+  var u: int = n
+  if (u < 0) {
+    u = (u + 65536)
+  }
+  return (u % 65536)
+}
+fun bin16(n: int): string {
+  var u: int = toUnsigned16(n)
+  var bits: string = ""
+  var mask: int = 32768
+  for i in 0..16 {
+    if (u >= mask) {
+      bits = (bits + "1")
+      u = (u - mask)
+    } else {
+      bits = (bits + "0")
+    }
+    mask = ((mask / 2)) as int
+  }
+  return bits
+}
+fun bit_and(a: int, b: int): int {
+  var ua: int = toUnsigned16(a)
+  var ub: int = toUnsigned16(b)
+  var res: int = 0
+  var bit: int = 1
+  for i in 0..16 {
+    if (((ua % 2) == 1) && ((ub % 2) == 1)) {
+      res = (res + bit)
+    }
+    ua = ((ua / 2)) as int
+    ub = ((ub / 2)) as int
+    bit = (bit * 2)
+  }
+  return res
+}
+fun bit_or(a: int, b: int): int {
+  var ua: int = toUnsigned16(a)
+  var ub: int = toUnsigned16(b)
+  var res: int = 0
+  var bit: int = 1
+  for i in 0..16 {
+    if (((ua % 2) == 1) || ((ub % 2) == 1)) {
+      res = (res + bit)
+    }
+    ua = ((ua / 2)) as int
+    ub = ((ub / 2)) as int
+    bit = (bit * 2)
+  }
+  return res
+}
+fun bit_xor(a: int, b: int): int {
+  var ua: int = toUnsigned16(a)
+  var ub: int = toUnsigned16(b)
+  var res: int = 0
+  var bit: int = 1
+  for i in 0..16 {
+    let abit: int = (ua % 2)
+    let bbit: int = (ub % 2)
+    if ((((abit == 1) && (bbit == 0))) || (((abit == 0) && (bbit == 1)))) {
+      res = (res + bit)
+    }
+    ua = ((ua / 2)) as int
+    ub = ((ub / 2)) as int
+    bit = (bit * 2)
+  }
+  return res
+}
+fun bit_not(a: int): int {
+  var ua: int = toUnsigned16(a)
+  return (65535 - ua)
+}
+fun shl(a: int, b: int): int {
+  var ua: int = toUnsigned16(a)
+  var i: int = 0
+  while (i < b) {
+    ua = (((ua * 2)) % 65536)
+    i = (i + 1)
+  }
+  return ua
+}
+fun shr(a: int, b: int): int {
+  var ua: int = toUnsigned16(a)
+  var i: int = 0
+  while (i < b) {
+    ua = ((ua / 2)) as int
+    i = (i + 1)
+  }
+  return ua
+}
+fun las(a: int, b: int): int {
+  return shl(a, b)
+}
+fun ras(a: int, b: int): int {
+  var val: int = a
+  var i: int = 0
+  while (i < b) {
+    if (val >= 0) {
+      val = ((val / 2)) as int
+    } else {
+      val = ((((val - 1)) / 2)) as int
+    }
+    i = (i + 1)
+  }
+  return toUnsigned16(val)
+}
+fun rol(a: int, b: int): int {
+  var ua: int = toUnsigned16(a)
+  let left: int = shl(ua, b)
+  let right: int = shr(ua, (16 - b))
+  return toUnsigned16((left + right))
+}
+fun ror(a: int, b: int): int {
+  var ua: int = toUnsigned16(a)
+  let right: int = shr(ua, b)
+  let left: int = shl(ua, (16 - b))
+  return toUnsigned16((left + right))
+}
+fun bitwise(a: int, b: int) {
+  print(("a:   " + bin16(a)))
+  print(("b:   " + bin16(b)))
+  print(("and: " + bin16(bit_and(a, b))))
+  print(("or:  " + bin16(bit_or(a, b))))
+  print(("xor: " + bin16(bit_xor(a, b))))
+  print(("not: " + bin16(bit_not(a))))
+  if (b < 0) {
+    print("Right operand is negative, but all shifts require an unsigned right operand (shift distance).")
+  }
+  print(("shl: " + bin16(shl(a, b))))
+  print(("shr: " + bin16(shr(a, b))))
+  print(("las: " + bin16(las(a, b))))
+  print(("ras: " + bin16(ras(a, b))))
+  print(("rol: " + bin16(rol(a, b))))
+  print(("ror: " + bin16(ror(a, b))))
+}
+bitwise(-460, 6)

--- a/tests/aster/x/mochi/rosetta/blum-integer.out.mochi
+++ b/tests/aster/x/mochi/rosetta/blum-integer.out.mochi
@@ -1,0 +1,124 @@
+fun isPrime(n: int): bool {
+  if (n < 2) {
+    return false
+  }
+  if ((n % 2) == 0) {
+    return (n == 2)
+  }
+  if ((n % 3) == 0) {
+    return (n == 3)
+  }
+  var d: int = 5
+  while ((d * d) <= n) {
+    if ((n % d) == 0) {
+      return false
+    }
+    d = (d + 2)
+    if ((n % d) == 0) {
+      return false
+    }
+    d = (d + 4)
+  }
+  return true
+}
+fun firstPrimeFactor(n: int): int {
+  if (n == 1) {
+    return 1
+  }
+  if ((n % 3) == 0) {
+    return 3
+  }
+  if ((n % 5) == 0) {
+    return 5
+  }
+  var inc: list<int> = [4, 2, 4, 2, 4, 6, 2, 6]
+  var k: int = 7
+  var i: int = 0
+  while ((k * k) <= n) {
+    if ((n % k) == 0) {
+      return k
+    }
+    k = (k + inc[i])
+    i = (((i + 1)) % len(inc))
+  }
+  return n
+}
+fun indexOf(s: string, ch: string): int {
+  var i: int = 0
+  while (i < len(s)) {
+    if (substring(s, i, (i + 1)) == ch) {
+      return i
+    }
+    i = (i + 1)
+  }
+  return -1
+}
+fun padLeft(n: int, width: int): string {
+  var s: string = str(n)
+  while (len(s) < width) {
+    s = (" " + s)
+  }
+  return s
+}
+fun formatFloat(f: float, prec: int): string {
+  let s: string = str(f)
+  let idx: int = indexOf(s, ".")
+  if (idx < 0) {
+    return s
+  }
+  let need: int = ((idx + 1) + prec)
+  if (len(s) > need) {
+    return substring(s, 0, need)
+  }
+  return s
+}
+fun main() {
+  var blum: list<int>
+  var counts: list<int> = [0, 0, 0, 0]
+  var digits: list<int> = [1, 3, 7, 9]
+  var i: int = 1
+  var bc: int = 0
+  while true {
+    let p: int = firstPrimeFactor(i)
+    if ((p % 4) == 3) {
+      let q: int = ((i / p)) as int
+      if (((q != p) && ((q % 4) == 3)) && isPrime(q)) {
+        if (bc < 50) {
+          blum = append(blum, i)
+        }
+        let d: int = (i % 10)
+        if (d == 1) {
+          counts[0] = (counts[0] + 1)
+        } else         if (d == 3) {
+          counts[1] = (counts[1] + 1)
+        } else         if (d == 7) {
+          counts[2] = (counts[2] + 1)
+        } else         if (d == 9) {
+          counts[3] = (counts[3] + 1)
+        }
+        bc = (bc + 1)
+        if (bc == 50) {
+          print("First 50 Blum integers:")
+          var idx: int = 0
+          while (idx < 50) {
+            var line: string = ""
+            var j: int = 0
+            while (j < 10) {
+              line = ((line + padLeft(blum[idx], 3)) + " ")
+              idx = (idx + 1)
+              j = (j + 1)
+            }
+            print(substring(line, 0, (len(line) - 1)))
+          }
+          break
+        }
+      }
+    }
+    if ((i % 5) == 3) {
+      i = (i + 4)
+    } else {
+      i = (i + 2)
+    }
+  }
+}
+main()

--- a/tests/aster/x/mochi/rosetta/boolean-values.error
+++ b/tests/aster/x/mochi/rosetta/boolean-values.error
@@ -1,0 +1,8 @@
+error[A024]: unknown function lower
+  --> /workspace/mochi/tests/rosetta/x/Mochi/boolean-values.mochi:3:11
+
+  3 |   let l = lower(s)
+    |           ^
+
+help:
+  Declare lower before use

--- a/tests/aster/x/mochi/rosetta/box-the-compass.out.mochi
+++ b/tests/aster/x/mochi/rosetta/box-the-compass.out.mochi
@@ -1,0 +1,67 @@
+fun padLeft(s: string, w: int): string {
+  var res: string = ""
+  var n: int = (w - len(s))
+  while (n > 0) {
+    res = (res + " ")
+    n = (n - 1)
+  }
+  return (res + s)
+}
+fun padRight(s: string, w: int): string {
+  var out: string = s
+  var i: int = len(s)
+  while (i < w) {
+    out = (out + " ")
+    i = (i + 1)
+  }
+  return out
+}
+fun indexOf(s: string, ch: string): int {
+  var i: int = 0
+  while (i < len(s)) {
+    if (substring(s, i, (i + 1)) == ch) {
+      return i
+    }
+    i = (i + 1)
+  }
+  return -1
+}
+fun format2(f: float): string {
+  var s: string = str(f)
+  let idx: int = indexOf(s, ".")
+  if (idx < 0) {
+    s = (s + ".00")
+  } else {
+    var need: int = (idx + 3)
+    if (len(s) > need) {
+      s = substring(s, 0, need)
+    } else {
+      while (len(s) < need) {
+        s = (s + "0")
+      }
+    }
+  }
+  return s
+}
+fun cpx(h: float): int {
+  var x: int = ((((h / 11.25)) + 0.5)) as int
+  x = (x % 32)
+  if (x < 0) {
+    x = (x + 32)
+  }
+  return x
+}
+let compassPoint: list<string> = ["North", "North by east", "North-northeast", "Northeast by north", "Northeast", "Northeast by east", "East-northeast", "East by north", "East", "East by south", "East-southeast", "Southeast by east", "Southeast", "Southeast by south", "South-southeast", "South by east", "South", "South by west", "South-southwest", "Southwest by south", "Southwest", "Southwest by west", "West-southwest", "West by south", "West", "West by north", "West-northwest", "Northwest by west", "Northwest", "Northwest by north", "North-northwest", "North by west"]
+fun degrees2compasspoint(h: float): string {
+  return compassPoint[cpx(h)]
+}
+let headings: list<float> = [0, 16.87, 16.88, 33.75, 50.62, 50.63, 67.5, 84.37, 84.38, 101.25, 118.12, 118.13, 135, 151.87, 151.88, 168.75, 185.62, 185.63, 202.5, 219.37, 219.38, 236.25, 253.12, 253.13, 270, 286.87, 286.88, 303.75, 320.62, 320.63, 337.5, 354.37, 354.38]
+print("Index  Compass point         Degree")
+var i: int = 0
+while (i < len(headings)) {
+  let h: float = headings[i]
+  let idx: int = ((i % 32) + 1)
+  let cp: string = degrees2compasspoint(h)
+  print((((((padLeft(str(idx), 4) + "   ") + padRight(cp, 19)) + " ") + format2(h)) + "°"))
+  i = (i + 1)
+}

--- a/tests/aster/x/mochi/rosetta/boyer-moore-string-search.error
+++ b/tests/aster/x/mochi/rosetta/boyer-moore-string-search.error
@@ -1,0 +1,8 @@
+error[A024]: unknown function substring
+  --> /workspace/mochi/tests/rosetta/x/Mochi/boyer-moore-string-search.mochi:23:26
+
+ 23 |     let idx = indexOfStr(substring(h, start, hlen), n)
+    |                          ^
+
+help:
+  Declare substring before use

--- a/tests/aster/x/mochi/rosetta/brazilian-numbers.out.mochi
+++ b/tests/aster/x/mochi/rosetta/brazilian-numbers.out.mochi
@@ -1,0 +1,90 @@
+fun sameDigits(n: int, b: int): bool {
+  var f: int = (n % b)
+  n = ((n / b)) as int
+  while (n > 0) {
+    if ((n % b) != f) {
+      return false
+    }
+    n = ((n / b)) as int
+  }
+  return true
+}
+fun isBrazilian(n: int): bool {
+  if (n < 7) {
+    return false
+  }
+  if (((n % 2) == 0) && (n >= 8)) {
+    return true
+  }
+  var b: int = 2
+  while (b < (n - 1)) {
+    if sameDigits(n, b) {
+      return true
+    }
+    b = (b + 1)
+  }
+  return false
+}
+fun isPrime(n: int): bool {
+  if (n < 2) {
+    return false
+  }
+  if ((n % 2) == 0) {
+    return (n == 2)
+  }
+  if ((n % 3) == 0) {
+    return (n == 3)
+  }
+  var d: int = 5
+  while ((d * d) <= n) {
+    if ((n % d) == 0) {
+      return false
+    }
+    d = (d + 2)
+    if ((n % d) == 0) {
+      return false
+    }
+    d = (d + 4)
+  }
+  return true
+}
+fun main() {
+  var kinds: list<string> = [" ", " odd ", " prime "]
+  for kind in kinds {
+    print((("First 20" + kind) + "Brazilian numbers:"))
+    var c: int = 0
+    var n: int = 7
+    while true {
+      if isBrazilian(n) {
+        print((str(n) + " "))
+        c = (c + 1)
+        if (c == 20) {
+          print("\n")
+          break
+        }
+      }
+      if (kind == " ") {
+        n = (n + 1)
+      } else       if (kind == " odd ") {
+        n = (n + 2)
+      } else {
+        while true {
+          n = (n + 2)
+          if isPrime(n) {
+            break
+          }
+        }
+      }
+    }
+  }
+  var n: int = 7
+  var c: int = 0
+  while (c < 100000) {
+    if isBrazilian(n) {
+      c = (c + 1)
+    }
+    n = (n + 1)
+  }
+  print(("The 100,000th Brazilian number: " + str((n - 1))))
+}
+main()

--- a/tests/aster/x/mochi/rosetta/break-oo-privacy.out.mochi
+++ b/tests/aster/x/mochi/rosetta/break-oo-privacy.out.mochi
@@ -1,0 +1,22 @@
+type Foobar {
+  Exported: int
+  unexported: int
+}
+fun examineAndModify(f: Foobar): Foobar {
+  print(((((((((" v: {" + str(f.Exported)) + " ") + str(f.unexported)) + "} = {") + str(f.Exported)) + " ") + str(f.unexported)) + "}"))
+  print("    Idx Name       Type CanSet")
+  print("     0: Exported   int  true")
+  print("     1: unexported int  false")
+  f.Exported = 16
+  f.unexported = 44
+  print("  modified unexported field via unsafe")
+  return f
+}
+fun anotherExample() {
+  print("bufio.ReadByte returned error: unsafely injected error value into bufio inner workings")
+}
+var obj: Foobar = Foobar {Exported: 12, unexported: 42}
+print((((("obj: {" + str(obj.Exported)) + " ") + str(obj.unexported)) + "}"))
+obj = examineAndModify(obj)
+print((((("obj: {" + str(obj.Exported)) + " ") + str(obj.unexported)) + "}"))
+anotherExample()

--- a/tests/aster/x/mochi/rosetta/brilliant-numbers.error
+++ b/tests/aster/x/mochi/rosetta/brilliant-numbers.error
@@ -1,0 +1,8 @@
+error[A007]: map entry type mismatch
+  --> /workspace/mochi/tests/rosetta/x/Mochi/brilliant-numbers.mochi:104:28
+
+104 |   return {"bc": brilliant, "next": next}
+    |                            ^
+
+help:
+  Ensure map keys and values share types

--- a/tests/aster/x/mochi/rosetta/brownian-tree.out.mochi
+++ b/tests/aster/x/mochi/rosetta/brownian-tree.out.mochi
@@ -1,0 +1,75 @@
+let w: int = 400
+let h: int = 300
+let n: int = 15000
+let frost: int = 255
+var grid: list<list<int>>
+var y: int = 0
+while (y < h) {
+  var row: list<int>
+  var x: int = 0
+  while (x < w) {
+    row = append(row, 0)
+    x = (x + 1)
+  }
+  grid = append(grid, row)
+  y = (y + 1)
+}
+grid[(h / 3)][(w / 3)] = frost
+fun inBounds(x: int, y: int): bool {
+  return ((((x >= 0) && (x < w)) && (y >= 0)) && (y < h))
+}
+fun hasNeighbor(x: int, y: int): bool {
+  var dy: int = -1
+  while (dy <= 1) {
+    var dx: int = -1
+    while (dx <= 1) {
+      if !(((dx == 0) && (dy == 0))) {
+        let nx: int = (x + dx)
+        let ny: int = (y + dy)
+        if (inBounds(nx, ny) && (grid[ny][nx] == frost)) {
+          return true
+        }
+      }
+      dx = (dx + 1)
+    }
+    dy = (dy + 1)
+  }
+  return false
+}
+var a: int = 0
+while (a < n) {
+  var px: int = (now() % w)
+  var py: int = (now() % h)
+  if (grid[py][px] == frost) {
+    var lost: bool = false
+    while true {
+      px = ((px + ((now() % 3))) - 1)
+      py = ((py + ((now() % 3))) - 1)
+      if !inBounds(px, py) {
+        lost = true
+        break
+      }
+      if (grid[py][px] != frost) {
+        break
+      }
+    }
+    if lost {
+      continue
+    }
+  } else {
+    var lost: bool = false
+    while !hasNeighbor(px, py) {
+      px = ((px + ((now() % 3))) - 1)
+      py = ((py + ((now() % 3))) - 1)
+      if !inBounds(px, py) {
+        lost = true
+        break
+      }
+    }
+    if lost {
+      continue
+    }
+  }
+  grid[py][px] = frost
+  a = (a + 1)
+}

--- a/tests/aster/x/mochi/rosetta/bulls-and-cows-player.error
+++ b/tests/aster/x/mochi/rosetta/bulls-and-cows-player.error
@@ -1,0 +1,8 @@
+error[A024]: unknown function substring
+  --> /workspace/mochi/tests/rosetta/x/Mochi/bulls-and-cows-player.mochi:20:14
+
+ 20 |     let ch = substring(s, i, i + 1)
+    |              ^
+
+help:
+  Declare substring before use

--- a/tests/aster/x/mochi/rosetta/bulls-and-cows.error
+++ b/tests/aster/x/mochi/rosetta/bulls-and-cows.error
@@ -1,0 +1,8 @@
+error[A024]: unknown function input
+  --> /workspace/mochi/tests/rosetta/x/Mochi/bulls-and-cows.mochi:36:17
+
+ 36 |     let guess = input()
+    |                 ^
+
+help:
+  Declare input before use

--- a/tests/aster/x/mochi/rosetta/burrows-wheeler-transform.error
+++ b/tests/aster/x/mochi/rosetta/burrows-wheeler-transform.error
@@ -1,0 +1,8 @@
+error[A024]: unknown function substring
+  --> /workspace/mochi/tests/rosetta/x/Mochi/burrows-wheeler-transform.mochi:43:15
+
+ 43 |     let rot = substring(s, i, le) + substring(s, 0, i)
+    |               ^
+
+help:
+  Declare substring before use

--- a/tests/aster/x/mochi/rosetta/caesar-cipher-1.error
+++ b/tests/aster/x/mochi/rosetta/caesar-cipher-1.error
@@ -1,0 +1,8 @@
+error[A003]: undefined variable key
+  --> /workspace/mochi/tests/rosetta/x/Mochi/caesar-cipher-1.mochi:62:27
+
+ 62 |     let ct = encipher(pt, key)
+    |                           ^
+
+help:
+  Declare key before use

--- a/tests/aster/x/mochi/rosetta/caesar-cipher-2.error
+++ b/tests/aster/x/mochi/rosetta/caesar-cipher-2.error
@@ -1,0 +1,8 @@
+error[A003]: undefined variable key
+  --> /workspace/mochi/tests/rosetta/x/Mochi/caesar-cipher-2.mochi:62:27
+
+ 62 |     let ct = encipher(pt, key)
+    |                           ^
+
+help:
+  Declare key before use

--- a/tests/aster/x/mochi/rosetta/calculating-the-value-of-e.error
+++ b/tests/aster/x/mochi/rosetta/calculating-the-value-of-e.error
@@ -1,0 +1,8 @@
+error[A024]: unknown function substring
+  --> /workspace/mochi/tests/rosetta/x/Mochi/calculating-the-value-of-e.mochi:26:17
+
+ 26 |   let intPart = substring(digits, 0, len(digits)-prec)
+    |                 ^
+
+help:
+  Declare substring before use

--- a/tests/aster/x/mochi/rosetta/calendar---for-real-programmers-1.out.mochi
+++ b/tests/aster/x/mochi/rosetta/calendar---for-real-programmers-1.out.mochi
@@ -1,0 +1,53 @@
+let daysInMonth: list<int> = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+let start: list<int> = [3, 6, 6, 2, 4, 0, 2, 5, 1, 3, 6, 1]
+let months: list<string> = [" January ", " February", "  March  ", "  April  ", "   May   ", "   June  ", "   July  ", "  August ", "September", " October ", " November", " December"]
+let days: list<string> = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]
+print("                                [SNOOPY]\n")
+print("                                  1969\n")
+var qtr: int = 0
+while (qtr < 4) {
+  var mi: int = 0
+  while (mi < 3) {
+    print((("      " + months[((qtr * 3) + mi)]) + "           "), false)
+    mi = (mi + 1)
+  }
+  print("")
+  mi = 0
+  while (mi < 3) {
+    var d: int = 0
+    while (d < 7) {
+      print((" " + days[d]), false)
+      d = (d + 1)
+    }
+    print("     ", false)
+    mi = (mi + 1)
+  }
+  print("")
+  var week: int = 0
+  while (week < 6) {
+    mi = 0
+    while (mi < 3) {
+      var day: int = 0
+      while (day < 7) {
+        let m: int = ((qtr * 3) + mi)
+        let val: int = ((((week * 7) + day) - start[m]) + 1)
+        if ((val >= 1) && (val <= daysInMonth[m])) {
+          var s: string = str(val)
+          if (len(s) == 1) {
+            s = (" " + s)
+          }
+          print((" " + s), false)
+        } else {
+          print("   ", false)
+        }
+        day = (day + 1)
+      }
+      print("     ", false)
+      mi = (mi + 1)
+    }
+    print("")
+    week = (week + 1)
+  }
+  print("")
+  qtr = (qtr + 1)
+}

--- a/tests/aster/x/mochi/rosetta/calendar---for-real-programmers-2.out.mochi
+++ b/tests/aster/x/mochi/rosetta/calendar---for-real-programmers-2.out.mochi
@@ -1,0 +1,53 @@
+let daysInMonth: list<int> = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+let start: list<int> = [3, 6, 6, 2, 4, 0, 2, 5, 1, 3, 6, 1]
+let months: list<string> = [" January ", " February", "  March  ", "  April  ", "   May   ", "   June  ", "   July  ", "  August ", "September", " October ", " November", " December"]
+let days: list<string> = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]
+print("                                [SNOOPY]\n")
+print("                                  1969\n")
+var qtr: int = 0
+while (qtr < 4) {
+  var mi: int = 0
+  while (mi < 3) {
+    print((("      " + months[((qtr * 3) + mi)]) + "           "), false)
+    mi = (mi + 1)
+  }
+  print("")
+  mi = 0
+  while (mi < 3) {
+    var d: int = 0
+    while (d < 7) {
+      print((" " + days[d]), false)
+      d = (d + 1)
+    }
+    print("     ", false)
+    mi = (mi + 1)
+  }
+  print("")
+  var week: int = 0
+  while (week < 6) {
+    mi = 0
+    while (mi < 3) {
+      var day: int = 0
+      while (day < 7) {
+        let m: int = ((qtr * 3) + mi)
+        let val: int = ((((week * 7) + day) - start[m]) + 1)
+        if ((val >= 1) && (val <= daysInMonth[m])) {
+          var s: string = str(val)
+          if (len(s) == 1) {
+            s = (" " + s)
+          }
+          print((" " + s), false)
+        } else {
+          print("   ", false)
+        }
+        day = (day + 1)
+      }
+      print("     ", false)
+      mi = (mi + 1)
+    }
+    print("")
+    week = (week + 1)
+  }
+  print("")
+  qtr = (qtr + 1)
+}

--- a/tests/aster/x/mochi/rosetta/calendar.out.mochi
+++ b/tests/aster/x/mochi/rosetta/calendar.out.mochi
@@ -1,0 +1,53 @@
+let daysInMonth: list<int> = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+let start: list<int> = [3, 6, 6, 2, 4, 0, 2, 5, 1, 3, 6, 1]
+let months: list<string> = [" January ", " February", "  March  ", "  April  ", "   May   ", "   June  ", "   July  ", "  August ", "September", " October ", " November", " December"]
+let days: list<string> = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]
+print("                                [SNOOPY]\n")
+print("                                  1969\n")
+var qtr: int = 0
+while (qtr < 4) {
+  var mi: int = 0
+  while (mi < 3) {
+    print((("      " + months[((qtr * 3) + mi)]) + "           "), false)
+    mi = (mi + 1)
+  }
+  print("")
+  mi = 0
+  while (mi < 3) {
+    var d: int = 0
+    while (d < 7) {
+      print((" " + days[d]), false)
+      d = (d + 1)
+    }
+    print("     ", false)
+    mi = (mi + 1)
+  }
+  print("")
+  var week: int = 0
+  while (week < 6) {
+    mi = 0
+    while (mi < 3) {
+      var day: int = 0
+      while (day < 7) {
+        let m: int = ((qtr * 3) + mi)
+        let val: int = ((((week * 7) + day) - start[m]) + 1)
+        if ((val >= 1) && (val <= daysInMonth[m])) {
+          var s: string = str(val)
+          if (len(s) == 1) {
+            s = (" " + s)
+          }
+          print((" " + s), false)
+        } else {
+          print("   ", false)
+        }
+        day = (day + 1)
+      }
+      print("     ", false)
+      mi = (mi + 1)
+    }
+    print("")
+    week = (week + 1)
+  }
+  print("")
+  qtr = (qtr + 1)
+}

--- a/tests/aster/x/mochi/rosetta/calkin-wilf-sequence.error
+++ b/tests/aster/x/mochi/rosetta/calkin-wilf-sequence.error
@@ -1,0 +1,8 @@
+error[A011]: numeric op with non-numeric
+  --> /workspace/mochi/tests/rosetta/x/Mochi/calkin-wilf-sequence.mochi:1:59
+
+  1 | fun bigrat(a: int, b: int): bigrat { return (a as bigrat) / (b as bigrat) }
+    |                                                           ^
+
+help:
+  Use numeric operands

--- a/tests/aster/x/mochi/rosetta/call-a-foreign-language-function.out.mochi
+++ b/tests/aster/x/mochi/rosetta/call-a-foreign-language-function.out.mochi
@@ -1,0 +1,9 @@
+fun strdup(s: string): string {
+  return (s + "")
+}
+fun main() {
+  let go1: string = "hello C"
+  let c2: string = strdup(go1)
+  print(c2)
+}
+main()

--- a/tests/aster/x/mochi/rosetta/call-a-function-1.error
+++ b/tests/aster/x/mochi/rosetta/call-a-function-1.error
@@ -1,0 +1,8 @@
+error[A005]: list element type mismatch
+  --> /workspace/mochi/tests/rosetta/x/Mochi/call-a-function-1.mochi:4:10
+
+  4 |   return [0, 0.0]
+    |          ^
+
+help:
+  Ensure all list elements share a type

--- a/tests/aster/x/mochi/rosetta/call-a-function-10.out.mochi
+++ b/tests/aster/x/mochi/rosetta/call-a-function-10.out.mochi
@@ -1,0 +1,13 @@
+fun main() {
+  var list: list<int>
+  var a: int = 1
+  var d: int = 2
+  var e: int = 3
+  var i: int = 4
+  list = append(list, a)
+  list = append(list, d)
+  list = append(list, e)
+  list = append(list, i)
+  i = len(list)
+}
+main()

--- a/types/infer.go
+++ b/types/infer.go
@@ -122,6 +122,10 @@ func inferBinaryType(env *Env, b *parser.BinaryExpr) Type {
 						res = Int64Type{}
 						break
 					}
+					if isBigRat(left) || isBigRat(right) {
+						res = BigRatType{}
+						break
+					}
 					if (isFloat(left) || isFloat(right)) &&
 						(isInt(left) || isFloat(left) || isInt64(left)) &&
 						(isInt(right) || isFloat(right) || isInt64(right)) {
@@ -753,8 +757,21 @@ func ResultType(op string, left, right Type) Type {
 	switch op {
 	case "+", "-", "*", "/", "%":
 		if isNumeric(left) && isNumeric(right) {
+			if isBigRat(left) || isBigRat(right) {
+				return BigRatType{}
+			}
+			if isBigInt(left) || isBigInt(right) {
+				return BigIntType{}
+			}
+			if (isInt64(left) && (isInt64(right) || isInt(right))) ||
+				(isInt64(right) && isInt(left)) {
+				return Int64Type{}
+			}
 			if isFloat(left) || isFloat(right) {
 				return FloatType{}
+			}
+			if isInt(left) && isInt(right) {
+				return IntType{}
 			}
 			return IntType{}
 		}
@@ -873,6 +890,7 @@ func equalTypes(a, b Type) bool {
 func isInt64(t Type) bool  { _, ok := t.(Int64Type); return ok }
 func isInt(t Type) bool    { _, ok := t.(IntType); return ok }
 func isBigInt(t Type) bool { _, ok := t.(BigIntType); return ok }
+func isBigRat(t Type) bool { _, ok := t.(BigRatType); return ok }
 func isFloat(t Type) bool {
 	_, ok := t.(FloatType)
 	if ok {


### PR DESCRIPTION
## Summary
- handle BigInt, BigRat and Int64 arithmetic results for more precise type inference
- add Rosetta decorator outputs and errors for programs 101-150

## Testing
- `go test ./types`
- ran decorator tests for programs 101-150 (`MOCHI_ROSETTA_INDEX=101..150`)

------
https://chatgpt.com/codex/tasks/task_e_6890d36ee820832085c4a882f4734ef6