### PR TITLE
Regenerate F# Rosetta output for find-common-directory-path

### DIFF
--- a/tests/rosetta/transpiler/FS/find-common-directory-path.bench
+++ b/tests/rosetta/transpiler/FS/find-common-directory-path.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 359,
-  "memory_bytes": 49152,
+  "duration_us": 515,
+  "memory_bytes": 43520,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/FS/find-common-directory-path.fs
+++ b/tests/rosetta/transpiler/FS/find-common-directory-path.fs
@@ -1,10 +1,9 @@
-// Generated 2025-07-30 21:05 +0700
+// Generated 2025-08-05 01:14 +0700
 
 exception Break
 exception Continue
 
 exception Return
-
 let mutable _nowSeed:int64 = 0L
 let mutable _nowSeeded = false
 let _initNow () =
@@ -33,6 +32,8 @@ let _substring (s:string) (start:int) (finish:int) =
     if st > en then st <- en
     s.Substring(st, en - st)
 
+let _idx (arr:'a array) (i:int) : 'a =
+    if i >= 0 && i < arr.Length then arr.[i] else Unchecked.defaultof<'a>
 let rec splitPath (p: string) =
     let mutable __ret : string array = Unchecked.defaultof<string array>
     let mutable p = p
@@ -40,7 +41,7 @@ let rec splitPath (p: string) =
         let mutable parts: string array = [||]
         let mutable cur: string = ""
         let mutable i: int = 0
-        while i < (String.length p) do
+        while i < (String.length(p)) do
             if (_substring p i (i + 1)) = "/" then
                 if cur <> "" then
                     parts <- Array.append parts [|cur|]
@@ -61,8 +62,8 @@ and joinPath (parts: string array) =
     try
         let mutable s: string = ""
         let mutable i: int = 0
-        while i < (Seq.length parts) do
-            s <- (s + "/") + (parts.[i])
+        while i < (Seq.length(parts)) do
+            s <- (s + "/") + (_idx parts (i))
             i <- i + 1
         __ret <- s
         raise Return
@@ -73,22 +74,22 @@ and commonPrefix (paths: string array) =
     let mutable __ret : string = Unchecked.defaultof<string>
     let mutable paths = paths
     try
-        if (Seq.length paths) = 0 then
+        if (Seq.length(paths)) = 0 then
             __ret <- ""
             raise Return
-        let mutable ``base``: string array = splitPath (paths.[0])
+        let mutable ``base``: string array = splitPath (_idx paths (0))
         let mutable i: int = 0
         let mutable prefix: string array = [||]
         try
-            while i < (Seq.length ``base``) do
+            while i < (Seq.length(``base``)) do
                 try
-                    let comp: string = ``base``.[i]
+                    let comp: string = _idx ``base`` (i)
                     let mutable ok: bool = true
                     try
-                        for p in paths do
+                        for p in Seq.map string (paths) do
                             try
-                                let parts: string array = splitPath p
-                                if (i >= (Seq.length parts)) || ((parts.[i]) <> comp) then
+                                let mutable parts: string array = splitPath (p)
+                                if (i >= (Seq.length(parts))) || ((_idx parts (i)) <> comp) then
                                     ok <- false
                                     raise Break
                             with
@@ -108,7 +109,7 @@ and commonPrefix (paths: string array) =
         with
         | Break -> ()
         | Continue -> ()
-        __ret <- joinPath prefix
+        __ret <- joinPath (prefix)
         raise Return
         __ret
     with
@@ -119,9 +120,9 @@ and main () =
         let __bench_start = _now()
         let __mem_start = System.GC.GetTotalMemory(true)
         let paths: string array = [|"/home/user1/tmp/coverage/test"; "/home/user1/tmp/covert/operator"; "/home/user1/tmp/coven/members"; "/home//user1/tmp/coventry"; "/home/user1/././tmp/covertly/foo"; "/home/bob/../user1/tmp/coved/bar"|]
-        let c: string = commonPrefix paths
+        let c: string = commonPrefix (paths)
         if c = "" then
-            printfn "%s" "No common path"
+            printfn "%s" ("No common path")
         else
             printfn "%s" ("Common path: " + c)
         let __bench_end = _now()

--- a/transpiler/x/fs/README.md
+++ b/transpiler/x/fs/README.md
@@ -112,4 +112,4 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-Last updated: 2025-08-05 00:29 +0700
+Last updated: 2025-08-05 01:14 +0700

--- a/transpiler/x/fs/ROSETTA.md
+++ b/transpiler/x/fs/ROSETTA.md
@@ -426,7 +426,7 @@ This file is auto-generated from rosetta tests.
 | 419 | filter | ✓ | 336µs | 45.4 KB |
 | 420 | find-chess960-starting-position-identifier-2 | ✓ | 310µs | 55.4 KB |
 | 421 | find-chess960-starting-position-identifier | ✓ | 304µs | 54.3 KB |
-| 422 | find-common-directory-path | ✓ | 359µs | 48.0 KB |
+| 422 | find-common-directory-path | ✓ | 515µs | 42.5 KB |
 | 423 | find-duplicate-files | ✓ | 470µs | 57.2 KB |
 | 424 | find-largest-left-truncatable-prime-in-a-given-base | ✓ | 893µs | 45.9 KB |
 | 425 | find-limit-of-recursion | ✓ | 350µs | 49.8 KB |
@@ -497,4 +497,4 @@ This file is auto-generated from rosetta tests.
 | 490 | window-management | ✓ | 371µs | 45.5 KB |
 | 491 | zumkeller-numbers | ✓ | 44.206ms | 86.9 KB |
 
-Last updated: 2025-08-05 00:41 +0700
+Last updated: 2025-08-05 01:14 +0700

--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-08-05 01:14 +0700)
+- fs transpiler: support int64 literals
+- Generated F# for 103/105 programs (103 passing)
+
 ## Progress (2025-08-05 00:29 +0700)
 - fs transpiler: handle static fields and string iteration
 - Generated F# for 103/105 programs (103 passing)


### PR DESCRIPTION
## Summary
- regenerate F# Rosetta output for `find-common-directory-path`
- refresh benchmarks and Rosetta checklist

## Testing
- `MOCHI_BENCHMARK=1 MOCHI_ROSETTA_INDEX=422 go test -tags=slow ./transpiler/x/fs -run TestFSTranspiler_Rosetta_Golden -v`

------
https://chatgpt.com/codex/tasks/task_e_6890f88375a48320b7971d209377ca4b