### PR TITLE
transpiler scheme: regenerate animation rosetta output

### DIFF
--- a/tests/rosetta/transpiler/scheme/animation.bench
+++ b/tests/rosetta/transpiler/scheme/animation.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 649,
-  "memory_bytes": 12877824,
+  "duration_us": 5000,
+  "memory_bytes": 13221888,
   "name": "main"
 }

--- a/transpiler/x/scheme/ROSETTA.md
+++ b/transpiler/x/scheme/ROSETTA.md
@@ -3,7 +3,7 @@
 Generated Scheme code for Rosetta Code tasks under `tests/rosetta/x/Mochi`.
 
 ## Checklist (457/491)
-Last updated: 2025-08-04 17:54 UTC
+Last updated: 2025-08-04 18:19 UTC
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
@@ -57,7 +57,7 @@ Last updated: 2025-08-04 17:54 UTC
 | 48 | angle-difference-between-two-bearings-2 | ✓ | 196µs | 12.8 MB |
 | 49 | angles-geometric-normalization-and-conversion | ✓ | 3.789ms | 13.0 MB |
 | 50 | animate-a-pendulum | ✓ | 191µs | 12.7 MB |
-| 51 | animation | ✓ | 649µs | 12.3 MB |
+| 51 | animation | ✓ | 5ms | 12.6 MB |
 | 52 | anonymous-recursion-1 | ✓ | 337µs | 12.7 MB |
 | 53 | anonymous-recursion-2 | ✓ | 305µs | 12.6 MB |
 | 54 | anonymous-recursion | ✓ | 4.272ms | 12.5 MB |


### PR DESCRIPTION
## Summary
- regenerate Scheme output for Rosetta task 51 (animation) and record benchmark statistics
- update Scheme Rosetta checklist with latest timing and memory usage for animation

## Testing
- `MOCHI_ROSETTA_INDEX=51 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/scheme -run TestSchemeTranspiler_Rosetta_Golden -update-rosetta-scheme -v`


------
https://chatgpt.com/codex/tasks/task_e_6890f8d25dec8320b7155b0ef75b2977