### PR TITLE
feat: add crossword puzzle solver

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/backtracking/crossword_puzzle_solver.mochi
+++ b/tests/github/TheAlgorithms/Mochi/backtracking/crossword_puzzle_solver.mochi
@@ -1,0 +1,70 @@
+/*
+Crossword Puzzle Solver using backtracking.
+Given an empty crossword grid and a list of words,
+place each word either vertically or horizontally without overlaps or out-of-bound placement.
+The algorithm tries all positions recursively, backtracking when a word cannot be placed,
+until all words fit or no solution exists.
+Functions:
+- is_valid: check if a word fits at a given position.
+- place_word/remove_word: modify the grid.
+- solve_crossword: recursively attempt to fill the grid using unused words.
+*/
+fun is_valid(puzzle: list<list<string>>, word: string, row: int, col: int, vertical: bool): bool {
+  for i in 0..len(word) {
+    if vertical {
+      if row + i >= len(puzzle) || puzzle[row + i][col] != "" { return false }
+    } else {
+      if col + i >= len(puzzle[0]) || puzzle[row][col + i] != "" { return false }
+    }
+  }
+  return true
+}
+
+fun place_word(puzzle: list<list<string>>, word: string, row: int, col: int, vertical: bool): void {
+  for i in 0..len(word) {
+    let ch: string = word[i]
+    if vertical { puzzle[row + i][col] = ch } else { puzzle[row][col + i] = ch }
+  }
+}
+
+fun remove_word(puzzle: list<list<string>>, word: string, row: int, col: int, vertical: bool): void {
+  for i in 0..len(word) {
+    if vertical { puzzle[row + i][col] = "" } else { puzzle[row][col + i] = "" }
+  }
+}
+
+fun solve_crossword(puzzle: list<list<string>>, words: list<string>, used: list<bool>): bool {
+  for row in 0..len(puzzle) {
+    for col in 0..len(puzzle[0]) {
+      if puzzle[row][col] == "" {
+        for i in 0..len(words) {
+          if !used[i] {
+            let word: string = words[i]
+            for vertical in [true, false] {
+              if is_valid(puzzle, word, row, col, vertical) {
+                place_word(puzzle, word, row, col, vertical)
+                used[i] = true
+                if solve_crossword(puzzle, words, used) { return true }
+                used[i] = false
+                remove_word(puzzle, word, row, col, vertical)
+              }
+            }
+          }
+        }
+        return false
+      }
+    }
+  }
+  return true
+}
+
+var puzzle: list<list<string>> = [["", "", ""], ["", "", ""], ["", "", ""]]
+var words: list<string> = ["cat", "dog", "car"]
+var used: list<bool> = [false, false, false]
+
+if solve_crossword(puzzle, words, used) {
+  print("Solution found:")
+  for row in puzzle { print(row) }
+} else {
+  print("No solution found:")
+}

--- a/tests/github/TheAlgorithms/Mochi/backtracking/crossword_puzzle_solver.out
+++ b/tests/github/TheAlgorithms/Mochi/backtracking/crossword_puzzle_solver.out
@@ -1,0 +1,4 @@
+Solution found:
+["c", "d", "c"]
+["a", "o", "a"]
+["t", "g", "r"]

--- a/tests/github/TheAlgorithms/Python/backtracking/crossword_puzzle_solver.py
+++ b/tests/github/TheAlgorithms/Python/backtracking/crossword_puzzle_solver.py
@@ -1,0 +1,131 @@
+# https://www.geeksforgeeks.org/solve-crossword-puzzle/
+
+
+def is_valid(
+    puzzle: list[list[str]], word: str, row: int, col: int, vertical: bool
+) -> bool:
+    """
+    Check if a word can be placed at the given position.
+
+    >>> puzzle = [
+    ...     ['', '', '', ''],
+    ...     ['', '', '', ''],
+    ...     ['', '', '', ''],
+    ...     ['', '', '', '']
+    ... ]
+    >>> is_valid(puzzle, 'word', 0, 0, True)
+    True
+    >>> puzzle = [
+    ...     ['', '', '', ''],
+    ...     ['', '', '', ''],
+    ...     ['', '', '', ''],
+    ...     ['', '', '', '']
+    ... ]
+    >>> is_valid(puzzle, 'word', 0, 0, False)
+    True
+    """
+    for i in range(len(word)):
+        if vertical:
+            if row + i >= len(puzzle) or puzzle[row + i][col] != "":
+                return False
+        elif col + i >= len(puzzle[0]) or puzzle[row][col + i] != "":
+            return False
+    return True
+
+
+def place_word(
+    puzzle: list[list[str]], word: str, row: int, col: int, vertical: bool
+) -> None:
+    """
+    Place a word at the given position.
+
+    >>> puzzle = [
+    ...     ['', '', '', ''],
+    ...     ['', '', '', ''],
+    ...     ['', '', '', ''],
+    ...     ['', '', '', '']
+    ... ]
+    >>> place_word(puzzle, 'word', 0, 0, True)
+    >>> puzzle
+    [['w', '', '', ''], ['o', '', '', ''], ['r', '', '', ''], ['d', '', '', '']]
+    """
+    for i, char in enumerate(word):
+        if vertical:
+            puzzle[row + i][col] = char
+        else:
+            puzzle[row][col + i] = char
+
+
+def remove_word(
+    puzzle: list[list[str]], word: str, row: int, col: int, vertical: bool
+) -> None:
+    """
+    Remove a word from the given position.
+
+    >>> puzzle = [
+    ...     ['w', '', '', ''],
+    ...     ['o', '', '', ''],
+    ...     ['r', '', '', ''],
+    ...     ['d', '', '', '']
+    ... ]
+    >>> remove_word(puzzle, 'word', 0, 0, True)
+    >>> puzzle
+    [['', '', '', ''], ['', '', '', ''], ['', '', '', ''], ['', '', '', '']]
+    """
+    for i in range(len(word)):
+        if vertical:
+            puzzle[row + i][col] = ""
+        else:
+            puzzle[row][col + i] = ""
+
+
+def solve_crossword(puzzle: list[list[str]], words: list[str]) -> bool:
+    """
+    Solve the crossword puzzle using backtracking.
+
+    >>> puzzle = [
+    ...     ['', '', '', ''],
+    ...     ['', '', '', ''],
+    ...     ['', '', '', ''],
+    ...     ['', '', '', '']
+    ... ]
+
+    >>> words = ['word', 'four', 'more', 'last']
+    >>> solve_crossword(puzzle, words)
+    True
+    >>> puzzle = [
+    ...     ['', '', '', ''],
+    ...     ['', '', '', ''],
+    ...     ['', '', '', ''],
+    ...     ['', '', '', '']
+    ... ]
+    >>> words = ['word', 'four', 'more', 'paragraphs']
+    >>> solve_crossword(puzzle, words)
+    False
+    """
+    for row in range(len(puzzle)):
+        for col in range(len(puzzle[0])):
+            if puzzle[row][col] == "":
+                for word in words:
+                    for vertical in [True, False]:
+                        if is_valid(puzzle, word, row, col, vertical):
+                            place_word(puzzle, word, row, col, vertical)
+                            words.remove(word)
+                            if solve_crossword(puzzle, words):
+                                return True
+                            words.append(word)
+                            remove_word(puzzle, word, row, col, vertical)
+                return False
+    return True
+
+
+if __name__ == "__main__":
+    PUZZLE = [[""] * 3 for _ in range(3)]
+    WORDS = ["cat", "dog", "car"]
+
+    if solve_crossword(PUZZLE, WORDS):
+        print("Solution found:")
+        for row in PUZZLE:
+            print(" ".join(row))
+    else:
+        print("No solution found:")


### PR DESCRIPTION
## Summary
- add Python reference for crossword puzzle solver at index 9
- document Mochi backtracking solver with detailed block comment and sample output

## Testing
- `npm install` *(fails: connect ENETUNREACH)*
- `node index.js run tests/github/TheAlgorithms/Mochi/backtracking/crossword_puzzle_solver.mochi` *(fails: Mochi binary not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890ffc489648320bbcba771e02ca540