### PR TITLE
feat: add hamiltonian cycle algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/backtracking/hamiltonian_cycle.mochi
+++ b/tests/github/TheAlgorithms/Mochi/backtracking/hamiltonian_cycle.mochi
@@ -1,0 +1,73 @@
+/*
+Hamiltonian Cycle
+-----------------
+Given an undirected graph, a Hamiltonian cycle is a cycle that visits
+each vertex exactly once and returns to the starting vertex. The
+algorithm below uses backtracking to construct such a cycle. At every
+step a candidate vertex is checked to ensure it is adjacent to the last
+vertex in the current path and has not already been used. If all
+vertices are included and the last one connects back to the start, a
+Hamiltonian cycle has been found; otherwise the search backtracks and
+tries alternative vertices.
+*/
+
+fun valid_connection(graph: list<list<int>>, next_ver: int, curr_ind: int, path: list<int>): bool {
+  if graph[path[curr_ind - 1]][next_ver] == 0 {
+    return false
+  }
+  for v in path {
+    if v == next_ver {
+      return false
+    }
+  }
+  return true
+}
+
+fun util_hamilton_cycle(graph: list<list<int>>, path: list<int>, curr_ind: int): bool {
+  if curr_ind == len(graph) {
+    return graph[path[curr_ind - 1]][path[0]] == 1
+  }
+  var next_ver = 0
+  while next_ver < len(graph) {
+    if valid_connection(graph, next_ver, curr_ind, path) {
+      path[curr_ind] = next_ver
+      if util_hamilton_cycle(graph, path, curr_ind + 1) {
+        return true
+      }
+      path[curr_ind] = -1
+    }
+    next_ver = next_ver + 1
+  }
+  return false
+}
+
+fun hamilton_cycle(graph: list<list<int>>, start_index: int): list<int> {
+  var path: list<int>
+  var i = 0
+  while i < len(graph) + 1 {
+    path[i] = -1
+    i = i + 1
+  }
+  path[0] = start_index
+  var last: int = len(path) - 1
+  path[last] = start_index
+  if util_hamilton_cycle(graph, path, 1) {
+    return path
+  }
+  return []
+}
+
+test "case 1" {
+  let graph = [[0,1,0,1,0], [1,0,1,1,1], [0,1,0,0,1], [1,1,0,0,1], [0,1,1,1,0]]
+  expect hamilton_cycle(graph, 0) == [0,1,2,4,3,0]
+}
+
+test "case 2" {
+  let graph = [[0,1,0,1,0], [1,0,1,1,1], [0,1,0,0,1], [1,1,0,0,1], [0,1,1,1,0]]
+  expect hamilton_cycle(graph, 3) == [3,0,1,2,4,3]
+}
+
+test "case 3" {
+  let graph = [[0,1,0,1,0], [1,0,1,1,1], [0,1,0,0,1], [1,1,0,0,0], [0,1,1,0,0]]
+  expect hamilton_cycle(graph, 4) == []
+}

--- a/tests/github/TheAlgorithms/Mochi/backtracking/hamiltonian_cycle.out
+++ b/tests/github/TheAlgorithms/Mochi/backtracking/hamiltonian_cycle.out
@@ -1,0 +1,4 @@
+[94;1mtests/github/TheAlgorithms/Mochi/backtracking/hamiltonian_cycle.mochi[0;22m
+   [33mtest[0m case 1                         ... [32mok[0m (2.0ms)
+   [33mtest[0m case 2                         ... [32mok[0m (977.0µs)
+   [33mtest[0m case 3                         ... [32mok[0m (829.0µs)

--- a/tests/github/TheAlgorithms/Python/backtracking/hamiltonian_cycle.py
+++ b/tests/github/TheAlgorithms/Python/backtracking/hamiltonian_cycle.py
@@ -1,0 +1,176 @@
+"""
+A Hamiltonian cycle (Hamiltonian circuit) is a graph cycle
+through a graph that visits each node exactly once.
+Determining whether such paths and cycles exist in graphs
+is the 'Hamiltonian path problem', which is NP-complete.
+
+Wikipedia: https://en.wikipedia.org/wiki/Hamiltonian_path
+"""
+
+
+def valid_connection(
+    graph: list[list[int]], next_ver: int, curr_ind: int, path: list[int]
+) -> bool:
+    """
+    Checks whether it is possible to add next into path by validating 2 statements
+    1. There should be path between current and next vertex
+    2. Next vertex should not be in path
+    If both validations succeed we return True, saying that it is possible to connect
+    this vertices, otherwise we return False
+
+    Case 1:Use exact graph as in main function, with initialized values
+    >>> graph = [[0, 1, 0, 1, 0],
+    ...          [1, 0, 1, 1, 1],
+    ...          [0, 1, 0, 0, 1],
+    ...          [1, 1, 0, 0, 1],
+    ...          [0, 1, 1, 1, 0]]
+    >>> path = [0, -1, -1, -1, -1, 0]
+    >>> curr_ind = 1
+    >>> next_ver = 1
+    >>> valid_connection(graph, next_ver, curr_ind, path)
+    True
+
+    Case 2: Same graph, but trying to connect to node that is already in path
+    >>> path = [0, 1, 2, 4, -1, 0]
+    >>> curr_ind = 4
+    >>> next_ver = 1
+    >>> valid_connection(graph, next_ver, curr_ind, path)
+    False
+    """
+
+    # 1. Validate that path exists between current and next vertices
+    if graph[path[curr_ind - 1]][next_ver] == 0:
+        return False
+
+    # 2. Validate that next vertex is not already in path
+    return not any(vertex == next_ver for vertex in path)
+
+
+def util_hamilton_cycle(graph: list[list[int]], path: list[int], curr_ind: int) -> bool:
+    """
+    Pseudo-Code
+    Base Case:
+    1. Check if we visited all of vertices
+        1.1 If last visited vertex has path to starting vertex return True either
+            return False
+    Recursive Step:
+    2. Iterate over each vertex
+        Check if next vertex is valid for transiting from current vertex
+            2.1 Remember next vertex as next transition
+            2.2 Do recursive call and check if going to this vertex solves problem
+            2.3 If next vertex leads to solution return True
+            2.4 Else backtrack, delete remembered vertex
+
+    Case 1: Use exact graph as in main function, with initialized values
+    >>> graph = [[0, 1, 0, 1, 0],
+    ...          [1, 0, 1, 1, 1],
+    ...          [0, 1, 0, 0, 1],
+    ...          [1, 1, 0, 0, 1],
+    ...          [0, 1, 1, 1, 0]]
+    >>> path = [0, -1, -1, -1, -1, 0]
+    >>> curr_ind = 1
+    >>> util_hamilton_cycle(graph, path, curr_ind)
+    True
+    >>> path
+    [0, 1, 2, 4, 3, 0]
+
+    Case 2: Use exact graph as in previous case, but in the properties taken from
+        middle of calculation
+    >>> graph = [[0, 1, 0, 1, 0],
+    ...          [1, 0, 1, 1, 1],
+    ...          [0, 1, 0, 0, 1],
+    ...          [1, 1, 0, 0, 1],
+    ...          [0, 1, 1, 1, 0]]
+    >>> path = [0, 1, 2, -1, -1, 0]
+    >>> curr_ind = 3
+    >>> util_hamilton_cycle(graph, path, curr_ind)
+    True
+    >>> path
+    [0, 1, 2, 4, 3, 0]
+    """
+
+    # Base Case
+    if curr_ind == len(graph):
+        # return whether path exists between current and starting vertices
+        return graph[path[curr_ind - 1]][path[0]] == 1
+
+    # Recursive Step
+    for next_ver in range(len(graph)):
+        if valid_connection(graph, next_ver, curr_ind, path):
+            # Insert current vertex  into path as next transition
+            path[curr_ind] = next_ver
+            # Validate created path
+            if util_hamilton_cycle(graph, path, curr_ind + 1):
+                return True
+            # Backtrack
+            path[curr_ind] = -1
+    return False
+
+
+def hamilton_cycle(graph: list[list[int]], start_index: int = 0) -> list[int]:
+    r"""
+    Wrapper function to call subroutine called util_hamilton_cycle,
+    which will either return array of vertices indicating hamiltonian cycle
+    or an empty list indicating that hamiltonian cycle was not found.
+    Case 1:
+    Following graph consists of 5 edges.
+    If we look closely, we can see that there are multiple Hamiltonian cycles.
+    For example one result is when we iterate like:
+    (0)->(1)->(2)->(4)->(3)->(0)
+
+    (0)---(1)---(2)
+     |   /   \   |
+     |  /     \  |
+     | /       \ |
+     |/         \|
+    (3)---------(4)
+    >>> graph = [[0, 1, 0, 1, 0],
+    ...          [1, 0, 1, 1, 1],
+    ...          [0, 1, 0, 0, 1],
+    ...          [1, 1, 0, 0, 1],
+    ...          [0, 1, 1, 1, 0]]
+    >>> hamilton_cycle(graph)
+    [0, 1, 2, 4, 3, 0]
+
+    Case 2:
+    Same Graph as it was in Case 1, changed starting index from default to 3
+
+    (0)---(1)---(2)
+     |   /   \   |
+     |  /     \  |
+     | /       \ |
+     |/         \|
+    (3)---------(4)
+    >>> graph = [[0, 1, 0, 1, 0],
+    ...          [1, 0, 1, 1, 1],
+    ...          [0, 1, 0, 0, 1],
+    ...          [1, 1, 0, 0, 1],
+    ...          [0, 1, 1, 1, 0]]
+    >>> hamilton_cycle(graph, 3)
+    [3, 0, 1, 2, 4, 3]
+
+    Case 3:
+    Following Graph is exactly what it was before, but edge 3-4 is removed.
+    Result is that there is no Hamiltonian Cycle anymore.
+
+    (0)---(1)---(2)
+     |   /   \   |
+     |  /     \  |
+     | /       \ |
+     |/         \|
+    (3)         (4)
+    >>> graph = [[0, 1, 0, 1, 0],
+    ...          [1, 0, 1, 1, 1],
+    ...          [0, 1, 0, 0, 1],
+    ...          [1, 1, 0, 0, 0],
+    ...          [0, 1, 1, 0, 0]]
+    >>> hamilton_cycle(graph,4)
+    []
+    """
+
+    # Initialize path with -1, indicating that we have not visited them yet
+    path = [-1] * (len(graph) + 1)
+    # initialize start and end of path with starting index
+    path[0] = path[-1] = start_index
+    # evaluate and if we find answer return path either return empty array
+    return path if util_hamilton_cycle(graph, path, 1) else []


### PR DESCRIPTION
## Summary
- add Python reference implementation for Hamiltonian cycle
- document and test Mochi backtracking solution with VM output

## Testing
- `go run ./cmd/mochi test tests/github/TheAlgorithms/Mochi/backtracking/hamiltonian_cycle.mochi`
- `go test ./... > /tmp/go_test.log && tail -n 20 /tmp/go_test.log`


------
https://chatgpt.com/codex/tasks/task_e_68910050405c83209c43a63a97e7852f