### PR TITLE
Add Mochi minimax algorithm example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/backtracking/minimax.mochi
+++ b/tests/github/TheAlgorithms/Mochi/backtracking/minimax.mochi
@@ -1,0 +1,42 @@
+/*
+  Evaluate a complete binary game tree using the minimax algorithm.
+
+  Each element in `scores` represents a terminal node. The tree is traversed
+  depth‑first where players alternate between maximizing and minimizing the
+  reachable score. The height of the tree is derived from the length of the
+  score list and is used to stop the recursion when a leaf is reached.
+
+  The algorithm explores both child branches at every step and returns the
+  optimal value assuming perfect play from both players.
+*/
+fun minimax(depth: int, node_index: int, is_max: bool, scores: list<int>, height: int): int {
+  if depth < 0 { panic("Depth cannot be less than 0") }
+  if len(scores) == 0 { panic("Scores cannot be empty") }
+  if depth == height { return scores[node_index] }
+  if is_max {
+    let left = minimax(depth + 1, node_index * 2, false, scores, height)
+    let right = minimax(depth + 1, node_index * 2 + 1, false, scores, height)
+    if left > right { return left } else { return right }
+  }
+  let left = minimax(depth + 1, node_index * 2, true, scores, height)
+  let right = minimax(depth + 1, node_index * 2 + 1, true, scores, height)
+  if left < right { return left } else { return right }
+}
+
+fun tree_height(n: int): int {
+  var h = 0
+  var v = n
+  while v > 1 {
+    v = v / 2
+    h = h + 1
+  }
+  return h
+}
+
+fun main() {
+  let scores = [90, 23, 6, 33, 21, 65, 123, 34423]
+  let height = tree_height(len(scores))
+  print("Optimal value : " + str(minimax(0, 0, true, scores, height)))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/backtracking/minimax.out
+++ b/tests/github/TheAlgorithms/Mochi/backtracking/minimax.out
@@ -1,0 +1,1 @@
+Optimal value : 65

--- a/tests/github/TheAlgorithms/Python/backtracking/minimax.py
+++ b/tests/github/TheAlgorithms/Python/backtracking/minimax.py
@@ -1,0 +1,95 @@
+"""
+Minimax helps to achieve maximum score in a game by checking all possible moves
+depth is current depth in game tree.
+
+nodeIndex is index of current node in scores[].
+if move is of maximizer return true else false
+leaves of game tree is stored in scores[]
+height is maximum height of Game tree
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def minimax(
+    depth: int, node_index: int, is_max: bool, scores: list[int], height: float
+) -> int:
+    """
+    This function implements the minimax algorithm, which helps achieve the optimal
+    score for a player in a two-player game by checking all possible moves.
+    If the player is the maximizer, then the score is maximized.
+    If the player is the minimizer, then the score is minimized.
+
+    Parameters:
+    - depth: Current depth in the game tree.
+    - node_index: Index of the current node in the scores list.
+    - is_max: A boolean indicating whether the current move
+              is for the maximizer (True) or minimizer (False).
+    - scores: A list containing the scores of the leaves of the game tree.
+    - height: The maximum height of the game tree.
+
+    Returns:
+    - An integer representing the optimal score for the current player.
+
+    >>> import math
+    >>> scores = [90, 23, 6, 33, 21, 65, 123, 34423]
+    >>> height = math.log(len(scores), 2)
+    >>> minimax(0, 0, True, scores, height)
+    65
+    >>> minimax(-1, 0, True, scores, height)
+    Traceback (most recent call last):
+        ...
+    ValueError: Depth cannot be less than 0
+    >>> minimax(0, 0, True, [], 2)
+    Traceback (most recent call last):
+        ...
+    ValueError: Scores cannot be empty
+    >>> scores = [3, 5, 2, 9, 12, 5, 23, 23]
+    >>> height = math.log(len(scores), 2)
+    >>> minimax(0, 0, True, scores, height)
+    12
+    """
+
+    if depth < 0:
+        raise ValueError("Depth cannot be less than 0")
+    if len(scores) == 0:
+        raise ValueError("Scores cannot be empty")
+
+    # Base case: If the current depth equals the height of the tree,
+    # return the score of the current node.
+    if depth == height:
+        return scores[node_index]
+
+    # If it's the maximizer's turn, choose the maximum score
+    # between the two possible moves.
+    if is_max:
+        return max(
+            minimax(depth + 1, node_index * 2, False, scores, height),
+            minimax(depth + 1, node_index * 2 + 1, False, scores, height),
+        )
+
+    # If it's the minimizer's turn, choose the minimum score
+    # between the two possible moves.
+    return min(
+        minimax(depth + 1, node_index * 2, True, scores, height),
+        minimax(depth + 1, node_index * 2 + 1, True, scores, height),
+    )
+
+
+def main() -> None:
+    # Sample scores and height calculation
+    scores = [90, 23, 6, 33, 21, 65, 123, 34423]
+    height = math.log(len(scores), 2)
+
+    # Calculate and print the optimal value using the minimax algorithm
+    print("Optimal value : ", end="")
+    print(minimax(0, 0, True, scores, height))
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    main()


### PR DESCRIPTION
## Summary
- add minimax algorithm Python source from TheAlgorithms
- implement equivalent minimax in Mochi with tree height helper
- document the minimax problem and algorithm with a top-level block comment
- record runtime output from the Mochi example

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/backtracking/minimax.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6891007a0f30832099f05cad6867eb79