### PR TITLE
fs: add rosetta output for first-class functions

### DIFF
--- a/tests/rosetta/transpiler/FS/first-class-functions-use-numbers-analogously.bench
+++ b/tests/rosetta/transpiler/FS/first-class-functions-use-numbers-analogously.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 313,
-  "memory_bytes": 43728,
+  "duration_us": 463,
+  "memory_bytes": 51904,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/FS/first-class-functions-use-numbers-analogously.fs
+++ b/tests/rosetta/transpiler/FS/first-class-functions-use-numbers-analogously.fs
@@ -1,4 +1,4 @@
-// Generated 2025-08-05 00:29 +0700
+// Generated 2025-08-05 01:50 +0700
 
 exception Return
 let mutable _nowSeed:int64 = 0L

--- a/transpiler/x/fs/README.md
+++ b/transpiler/x/fs/README.md
@@ -112,4 +112,4 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-Last updated: 2025-08-05 01:14 +0700
+Last updated: 2025-08-05 01:50 +0700

--- a/transpiler/x/fs/ROSETTA.md
+++ b/transpiler/x/fs/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This file is auto-generated from rosetta tests.
 
-## Rosetta Golden Test Checklist (402/491)
+## Rosetta Golden Test Checklist (403/491)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 151µs | 41.3 KB |
@@ -436,7 +436,7 @@ This file is auto-generated from rosetta tests.
 | 429 | find-the-last-sunday-of-each-month | ✓ | 337µs | 60.0 KB |
 | 430 | find-the-missing-permutation | ✓ | 338µs | 41.7 KB |
 | 431 | first-class-environments | ✓ | 336µs | 45.9 KB |
-| 432 | first-class-functions-use-numbers-analogously | ✓ | 313µs | 42.7 KB |
+| 432 | first-class-functions-use-numbers-analogously | ✓ | 463µs | 50.7 KB |
 | 433 | first-power-of-2-that-has-leading-decimal-digits-of-12 |   |  |  |
 | 434 | five-weekends | ✓ | 375µs | 41.1 KB |
 | 435 | fivenum-1 | ✓ | 346µs | 42.5 KB |
@@ -497,4 +497,4 @@ This file is auto-generated from rosetta tests.
 | 490 | window-management | ✓ | 371µs | 45.5 KB |
 | 491 | zumkeller-numbers | ✓ | 44.206ms | 86.9 KB |
 
-Last updated: 2025-08-05 01:14 +0700
+Last updated: 2025-08-05 01:50 +0700

--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-08-05 01:50 +0700)
+- fs transpiler: avoid treating nested funcs as global
+- Generated F# for 103/105 programs (103 passing)
+
 ## Progress (2025-08-05 01:14 +0700)
 - fs transpiler: support int64 literals
 - Generated F# for 103/105 programs (103 passing)


### PR DESCRIPTION
## Summary
- regenerate F# output and benchmarks for `first-class-functions-use-numbers-analogously`
- refresh Rosetta progress table and timestamps

## Testing
- `MOCHI_ROSETTA_INDEX=432 MOCHI_BENCHMARK=1 go test -run Rosetta -count=1 -tags slow -v`


------
https://chatgpt.com/codex/tasks/task_e_689100f6ab5c8320921d0ed6aea201b9