### PR TITLE
Add Mochi version of match_word_pattern algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/backtracking/match_word_pattern.mochi
+++ b/tests/github/TheAlgorithms/Mochi/backtracking/match_word_pattern.mochi
@@ -1,0 +1,72 @@
+/*
+Given a pattern string and an input string, determine if the pattern can be mapped to the string such that each unique character in the pattern corresponds to a distinct substring and the pattern expands to the entire string.
+This is solved via backtracking by attempting all possible substring assignments for unassigned pattern characters while ensuring no substring is reused.
+*/
+
+fun get_value(keys: list<string>, values: list<string>, key: string): string {
+  var i = 0
+  while i < len(keys) {
+    if keys[i] == key {
+      return values[i]
+    }
+    i = i + 1
+  }
+  return null
+}
+
+fun contains_value(values: list<string>, value: string): bool {
+  var i = 0
+  while i < len(values) {
+    if values[i] == value {
+      return true
+    }
+    i = i + 1
+  }
+  return false
+}
+
+fun backtrack(pattern: string, input_string: string, pi: int, si: int, keys: list<string>, values: list<string>): bool {
+  if pi == len(pattern) && si == len(input_string) {
+    return true
+  }
+  if pi == len(pattern) || si == len(input_string) {
+    return false
+  }
+  let ch = substring(pattern, pi, pi + 1)
+  let mapped = get_value(keys, values, ch)
+  if mapped != null {
+    if substring(input_string, si, si + len(mapped)) == mapped {
+      return backtrack(pattern, input_string, pi + 1, si + len(mapped), keys, values)
+    }
+    return false
+  }
+  var end = si + 1
+  while end <= len(input_string) {
+    let substr = substring(input_string, si, end)
+    if contains_value(values, substr) {
+      end = end + 1
+      continue
+    }
+    let new_keys = append(keys, ch)
+    let new_values = append(values, substr)
+    if backtrack(pattern, input_string, pi + 1, end, new_keys, new_values) {
+      return true
+    }
+    end = end + 1
+  }
+  return false
+}
+
+fun match_word_pattern(pattern: string, input_string: string): bool {
+  let keys: list<string> = []
+  let values: list<string> = []
+  return backtrack(pattern, input_string, 0, 0, keys, values)
+}
+
+fun main() {
+  print(match_word_pattern("aba", "GraphTreesGraph"))
+  print(match_word_pattern("xyx", "PythonRubyPython"))
+  print(match_word_pattern("GG", "PythonJavaPython"))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/backtracking/match_word_pattern.out
+++ b/tests/github/TheAlgorithms/Mochi/backtracking/match_word_pattern.out
@@ -1,0 +1,3 @@
+true
+true
+false

--- a/tests/github/TheAlgorithms/Python/backtracking/match_word_pattern.py
+++ b/tests/github/TheAlgorithms/Python/backtracking/match_word_pattern.py
@@ -1,0 +1,61 @@
+def match_word_pattern(pattern: str, input_string: str) -> bool:
+    """
+    Determine if a given pattern matches a string using backtracking.
+
+    pattern: The pattern to match.
+    input_string: The string to match against the pattern.
+    return: True if the pattern matches the string, False otherwise.
+
+    >>> match_word_pattern("aba", "GraphTreesGraph")
+    True
+
+    >>> match_word_pattern("xyx", "PythonRubyPython")
+    True
+
+    >>> match_word_pattern("GG", "PythonJavaPython")
+    False
+    """
+
+    def backtrack(pattern_index: int, str_index: int) -> bool:
+        """
+        >>> backtrack(0, 0)
+        True
+
+        >>> backtrack(0, 1)
+        True
+
+        >>> backtrack(0, 4)
+        False
+        """
+        if pattern_index == len(pattern) and str_index == len(input_string):
+            return True
+        if pattern_index == len(pattern) or str_index == len(input_string):
+            return False
+        char = pattern[pattern_index]
+        if char in pattern_map:
+            mapped_str = pattern_map[char]
+            if input_string.startswith(mapped_str, str_index):
+                return backtrack(pattern_index + 1, str_index + len(mapped_str))
+            else:
+                return False
+        for end in range(str_index + 1, len(input_string) + 1):
+            substr = input_string[str_index:end]
+            if substr in str_map:
+                continue
+            pattern_map[char] = substr
+            str_map[substr] = char
+            if backtrack(pattern_index + 1, end):
+                return True
+            del pattern_map[char]
+            del str_map[substr]
+        return False
+
+    pattern_map: dict[str, str] = {}
+    str_map: dict[str, str] = {}
+    return backtrack(0, 0)
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- include Python reference implementation of match_word_pattern
- translate match_word_pattern to Mochi with list-based backtracking and detailed block comment
- record VM execution output alongside the Mochi source

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/backtracking/match_word_pattern.mochi`

------
https://chatgpt.com/codex/tasks/task_e_68910061ebdc83209d69c668818d3baa