### PR TITLE
Add Mochi output for N queens math

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/backtracking/n_queens_math.out
+++ b/tests/github/TheAlgorithms/Mochi/backtracking/n_queens_math.out
@@ -1,0 +1,11 @@
+. Q . . 
+. . . Q 
+Q . . . 
+. . Q . 
+
+. . Q . 
+Q . . . 
+. . . Q 
+. Q . . 
+
+2 solutions were found.


### PR DESCRIPTION
## Summary
- capture VM output for Mochi implementation of the N queens problem

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/backtracking/n_queens_math.mochi > tests/github/TheAlgorithms/Mochi/backtracking/n_queens_math.out`


------
https://chatgpt.com/codex/tasks/task_e_689103fd7e848320aaa26b54e15f4e9f