### PR TITLE
Add Mochi implementation for N-Queens algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/backtracking/n_queens.mochi
+++ b/tests/github/TheAlgorithms/Mochi/backtracking/n_queens.mochi
@@ -1,0 +1,110 @@
+/*
+Solve the classic N-Queens puzzle using backtracking on a 2D board.
+Each queen must be placed so that no two queens share a row, column,
+or diagonal.  A recursive search explores row by row.  For each row the
+algorithm tries every column and calls `is_safe` to verify that no
+existing queen conflicts.  When a full board is constructed it is
+printed and counted as a solution.  The brute-force nature means the
+search tree can grow exponentially; in the worst case the time
+complexity is O(N!), the number of possible placements, though pruning
+invalid positions early reduces actual work.
+*/
+
+fun create_board(n: int): list<list<int>> {
+  var board: list<list<int>> = []
+  var i = 0
+  while i < n {
+    var row: list<int> = []
+    var j = 0
+    while j < n {
+      row = append(row, 0)
+      j = j + 1
+    }
+    board = append(board, row)
+    i = i + 1
+  }
+  return board
+}
+
+fun is_safe(board: list<list<int>>, row: int, column: int): bool {
+  let n = len(board)
+  var i = 0
+  // check same column
+  while i < row {
+    if board[i][column] == 1 {
+      return false
+    }
+    i = i + 1
+  }
+  // check upper left diagonal
+  i = row - 1
+  var j = column - 1
+  while i >= 0 && j >= 0 {
+    if board[i][j] == 1 {
+      return false
+    }
+    i = i - 1
+    j = j - 1
+  }
+  // check upper right diagonal
+  i = row - 1
+  j = column + 1
+  while i >= 0 && j < n {
+    if board[i][j] == 1 {
+      return false
+    }
+    i = i - 1
+    j = j + 1
+  }
+  return true
+}
+
+fun row_string(row: list<int>): string {
+  var s = ""
+  var j = 0
+  while j < len(row) {
+    if row[j] == 1 {
+      s = s + "Q "
+    } else {
+      s = s + ". "
+    }
+    j = j + 1
+  }
+  return s
+}
+
+fun printboard(board: list<list<int>>) {
+  var i = 0
+  while i < len(board) {
+    print(row_string(board[i]))
+    i = i + 1
+  }
+}
+
+fun solve(board: list<list<int>>, row: int): int {
+  if row >= len(board) {
+    printboard(board)
+    print("")
+    return 1
+  }
+  var count = 0
+  var i = 0
+  while i < len(board) {
+    if is_safe(board, row, i) {
+      board[row][i] = 1
+      count = count + solve(board, row + 1)
+      board[row][i] = 0
+    }
+    i = i + 1
+  }
+  return count
+}
+
+fun n_queens(n: int): int {
+  let board = create_board(n)
+  let total = solve(board, 0)
+  print("The total number of solutions are: " + str(total))
+  return total
+}
+
+n_queens(4)

--- a/tests/github/TheAlgorithms/Mochi/backtracking/n_queens.out
+++ b/tests/github/TheAlgorithms/Mochi/backtracking/n_queens.out
@@ -1,0 +1,11 @@
+. Q . . 
+. . . Q 
+Q . . . 
+. . Q . 
+
+. . Q . 
+Q . . . 
+. . . Q 
+. Q . . 
+
+The total number of solutions are: 2

--- a/tests/github/TheAlgorithms/Python/backtracking/n_queens.py
+++ b/tests/github/TheAlgorithms/Python/backtracking/n_queens.py
@@ -1,0 +1,101 @@
+"""
+
+The nqueens problem is of placing N queens on a N * N
+chess board such that no queen can attack any other queens placed
+on that chess board.
+This means that one queen cannot have any other queen on its horizontal, vertical and
+diagonal lines.
+
+"""
+
+from __future__ import annotations
+
+solution = []
+
+
+def is_safe(board: list[list[int]], row: int, column: int) -> bool:
+    """
+    This function returns a boolean value True if it is safe to place a queen there
+    considering the current state of the board.
+
+    Parameters:
+    board (2D matrix): The chessboard
+    row, column: Coordinates of the cell on the board
+
+    Returns:
+    Boolean Value
+
+    >>> is_safe([[0, 0, 0], [0, 0, 0], [0, 0, 0]], 1, 1)
+    True
+    >>> is_safe([[0, 1, 0], [0, 0, 0], [0, 0, 0]], 1, 1)
+    False
+    >>> is_safe([[1, 0, 0], [0, 0, 0], [0, 0, 0]], 1, 1)
+    False
+    >>> is_safe([[0, 0, 1], [0, 0, 0], [0, 0, 0]], 1, 1)
+    False
+    """
+
+    n = len(board)  # Size of the board
+
+    # Check if there is any queen in the same upper column,
+    # left upper diagonal and right upper diagonal
+    return (
+        all(board[i][j] != 1 for i, j in zip(range(row), [column] * row))
+        and all(
+            board[i][j] != 1
+            for i, j in zip(range(row - 1, -1, -1), range(column - 1, -1, -1))
+        )
+        and all(
+            board[i][j] != 1
+            for i, j in zip(range(row - 1, -1, -1), range(column + 1, n))
+        )
+    )
+
+
+def solve(board: list[list[int]], row: int) -> bool:
+    """
+    This function creates a state space tree and calls the safe function until it
+    receives a False Boolean and terminates that branch and backtracks to the next
+    possible solution branch.
+    """
+    if row >= len(board):
+        """
+        If the row number exceeds N, we have a board with a successful combination
+        and that combination is appended to the solution list and the board is printed.
+        """
+        solution.append(board)
+        printboard(board)
+        print()
+        return True
+    for i in range(len(board)):
+        """
+        For every row, it iterates through each column to check if it is feasible to
+        place a queen there.
+        If all the combinations for that particular branch are successful, the board is
+        reinitialized for the next possible combination.
+        """
+        if is_safe(board, row, i):
+            board[row][i] = 1
+            solve(board, row + 1)
+            board[row][i] = 0
+    return False
+
+
+def printboard(board: list[list[int]]) -> None:
+    """
+    Prints the boards that have a successful combination.
+    """
+    for i in range(len(board)):
+        for j in range(len(board)):
+            if board[i][j] == 1:
+                print("Q", end=" ")  # Queen is present
+            else:
+                print(".", end=" ")  # Empty cell
+        print()
+
+
+# Number of queens (e.g., n=8 for an 8x8 board)
+n = 8
+board = [[0 for i in range(n)] for j in range(n)]
+solve(board, 0)
+print("The total number of solutions are:", len(solution))


### PR DESCRIPTION
## Summary
- add missing Python reference implementation of `n_queens`
- add Mochi translation using backtracking and board safety checks
- record runtime output for sample 4-queen problem

## Testing
- `./bin/mochi run tests/github/TheAlgorithms/Mochi/backtracking/n_queens.mochi > tests/github/TheAlgorithms/Mochi/backtracking/n_queens.out`


------
https://chatgpt.com/codex/tasks/task_e_68910ae4244c8320bb8338ae8bb4f1cd