### PR TITLE
Add backtracking subsequences example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/backtracking/all_subsequences.mochi
+++ b/tests/github/TheAlgorithms/Mochi/backtracking/all_subsequences.mochi
@@ -1,30 +1,28 @@
-fun createStateSpaceTreeInt(sequence: list<int>, current: list<int>, index: int): void {
+/*
+Generate all possible subsequences of a given sequence using backtracking.
+At each position, the algorithm explores two choices: exclude the current
+item or include it in the growing subsequence. This forms a binary
+state-space tree with 2^n leaves for a sequence of length n.
+Depth-first traversal of this tree prints every subsequence.
+Time complexity: O(2^n) and space complexity: O(n) for recursion stack.
+*/
+
+fun create_state_space_tree(sequence: list<any>, current: list<any>, index: int): void {
   if index == len(sequence) {
     print(current)
     return
   }
-  createStateSpaceTreeInt(sequence, current, index + 1)
-  let withElem = append(current, sequence[index])
-  createStateSpaceTreeInt(sequence, withElem, index + 1)
+  create_state_space_tree(sequence, current, index + 1)
+  let with_elem = append(current, sequence[index])
+  create_state_space_tree(sequence, with_elem, index + 1)
 }
 
-fun generateAllSubsequencesInt(sequence: list<int>): void {
-  createStateSpaceTreeInt(sequence, [], 0)
+fun generate_all_subsequences(sequence: list<any>): void {
+  create_state_space_tree(sequence, [] as list<any>, 0)
 }
 
-fun createStateSpaceTreeString(sequence: list<string>, current: list<string>, index: int): void {
-  if index == len(sequence) {
-    print(current)
-    return
-  }
-  createStateSpaceTreeString(sequence, current, index + 1)
-  let withElem = append(current, sequence[index])
-  createStateSpaceTreeString(sequence, withElem, index + 1)
-}
+let seq: list<any> = [1, 2, 3]
+generate_all_subsequences(seq)
 
-fun generateAllSubsequencesString(sequence: list<string>): void {
-  createStateSpaceTreeString(sequence, [], 0)
-}
-
-generateAllSubsequencesInt([1, 2, 3])
-generateAllSubsequencesString(["A", "B", "C"])
+let seq2: list<any> = ["A", "B", "C"]
+generate_all_subsequences(seq2)

--- a/tests/github/TheAlgorithms/Python/backtracking/all_subsequences.py
+++ b/tests/github/TheAlgorithms/Python/backtracking/all_subsequences.py
@@ -1,0 +1,93 @@
+"""
+In this problem, we want to determine all possible subsequences
+of the given sequence. We use backtracking to solve this problem.
+
+Time complexity: O(2^n),
+where n denotes the length of the given sequence.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def generate_all_subsequences(sequence: list[Any]) -> None:
+    create_state_space_tree(sequence, [], 0)
+
+
+def create_state_space_tree(
+    sequence: list[Any], current_subsequence: list[Any], index: int
+) -> None:
+    """
+    Creates a state space tree to iterate through each branch using DFS.
+    We know that each state has exactly two children.
+    It terminates when it reaches the end of the given sequence.
+
+    :param sequence: The input sequence for which subsequences are generated.
+    :param current_subsequence: The current subsequence being built.
+    :param index: The current index in the sequence.
+
+    Example:
+    >>> sequence = [3, 2, 1]
+    >>> current_subsequence = []
+    >>> create_state_space_tree(sequence, current_subsequence, 0)
+    []
+    [1]
+    [2]
+    [2, 1]
+    [3]
+    [3, 1]
+    [3, 2]
+    [3, 2, 1]
+
+    >>> sequence = ["A", "B"]
+    >>> current_subsequence = []
+    >>> create_state_space_tree(sequence, current_subsequence, 0)
+    []
+    ['B']
+    ['A']
+    ['A', 'B']
+
+    >>> sequence = []
+    >>> current_subsequence = []
+    >>> create_state_space_tree(sequence, current_subsequence, 0)
+    []
+
+    >>> sequence = [1, 2, 3, 4]
+    >>> current_subsequence = []
+    >>> create_state_space_tree(sequence, current_subsequence, 0)
+    []
+    [4]
+    [3]
+    [3, 4]
+    [2]
+    [2, 4]
+    [2, 3]
+    [2, 3, 4]
+    [1]
+    [1, 4]
+    [1, 3]
+    [1, 3, 4]
+    [1, 2]
+    [1, 2, 4]
+    [1, 2, 3]
+    [1, 2, 3, 4]
+    """
+
+    if index == len(sequence):
+        print(current_subsequence)
+        return
+
+    create_state_space_tree(sequence, current_subsequence, index + 1)
+    current_subsequence.append(sequence[index])
+    create_state_space_tree(sequence, current_subsequence, index + 1)
+    current_subsequence.pop()
+
+
+if __name__ == "__main__":
+    seq: list[Any] = [1, 2, 3]
+    generate_all_subsequences(seq)
+
+    seq.clear()
+    seq.extend(["A", "B", "C"])
+    generate_all_subsequences(seq)


### PR DESCRIPTION
## Summary
- add reference Python implementation for generating all subsequences via backtracking
- add pure Mochi version with generic list support and detailed algorithm comment

## Testing
- `npm test` (fails: Missing script "test")
- `go test ./...` (partial, interrupted)
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/backtracking/all_subsequences.mochi`


------
https://chatgpt.com/codex/tasks/task_e_68910ad20524832096f2bfea2a57d061