### PR TITLE
Add Word Break backtracking implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/backtracking/word_break.mochi
+++ b/tests/github/TheAlgorithms/Mochi/backtracking/word_break.mochi
@@ -1,0 +1,40 @@
+/*
+Word Break Problem - Backtracking
+
+Given a string and a set of dictionary words, determine if the string can
+be segmented into a sequence of one or more dictionary words. The
+algorithm explores every possible prefix starting from a given index; if
+that prefix is in the dictionary, the function recursively attempts to
+segment the remaining substring. The recursion succeeds when the start
+index reaches the end of the string. This approach has exponential
+worst-case time complexity but demonstrates a straightforward
+backtracking solution.
+*/
+
+fun contains(words: list<string>, target: string): bool {
+  for w in words {
+    if w == target { return true }
+  }
+  return false
+}
+
+fun backtrack(s: string, word_dict: list<string>, start: int): bool {
+  if start == len(s) { return true }
+  var end = start + 1
+  while end <= len(s) {
+    let substr = substring(s, start, end)
+    if contains(word_dict, substr) && backtrack(s, word_dict, end) {
+      return true
+    }
+    end = end + 1
+  }
+  return false
+}
+
+fun word_break(s: string, word_dict: list<string>): bool {
+  return backtrack(s, word_dict, 0)
+}
+
+print(str(word_break("leetcode", ["leet", "code"])))
+print(str(word_break("applepenapple", ["apple", "pen"])))
+print(str(word_break("catsandog", ["cats", "dog", "sand", "and", "cat"])))

--- a/tests/github/TheAlgorithms/Mochi/backtracking/word_break.out
+++ b/tests/github/TheAlgorithms/Mochi/backtracking/word_break.out
@@ -1,0 +1,3 @@
+true
+true
+false

--- a/tests/github/TheAlgorithms/Python/backtracking/word_break.py
+++ b/tests/github/TheAlgorithms/Python/backtracking/word_break.py
@@ -1,0 +1,71 @@
+"""
+Word Break Problem is a well-known problem in computer science.
+Given a string and a dictionary of words, the task is to determine if
+the string can be segmented into a sequence of one or more dictionary words.
+
+Wikipedia: https://en.wikipedia.org/wiki/Word_break_problem
+"""
+
+
+def backtrack(input_string: str, word_dict: set[str], start: int) -> bool:
+    """
+    Helper function that uses backtracking to determine if a valid
+    word segmentation is possible starting from index 'start'.
+
+    Parameters:
+    input_string (str): The input string to be segmented.
+    word_dict (set[str]): A set of valid dictionary words.
+    start (int): The starting index of the substring to be checked.
+
+    Returns:
+    bool: True if a valid segmentation is possible, otherwise False.
+
+    Example:
+    >>> backtrack("leetcode", {"leet", "code"}, 0)
+    True
+
+    >>> backtrack("applepenapple", {"apple", "pen"}, 0)
+    True
+
+    >>> backtrack("catsandog", {"cats", "dog", "sand", "and", "cat"}, 0)
+    False
+    """
+
+    # Base case: if the starting index has reached the end of the string
+    if start == len(input_string):
+        return True
+
+    # Try every possible substring from 'start' to 'end'
+    for end in range(start + 1, len(input_string) + 1):
+        if input_string[start:end] in word_dict and backtrack(
+            input_string, word_dict, end
+        ):
+            return True
+
+    return False
+
+
+def word_break(input_string: str, word_dict: set[str]) -> bool:
+    """
+    Determines if the input string can be segmented into a sequence of
+    valid dictionary words using backtracking.
+
+    Parameters:
+    input_string (str): The input string to segment.
+    word_dict (set[str]): The set of valid words.
+
+    Returns:
+    bool: True if the string can be segmented into valid words, otherwise False.
+
+    Example:
+    >>> word_break("leetcode", {"leet", "code"})
+    True
+
+    >>> word_break("applepenapple", {"apple", "pen"})
+    True
+
+    >>> word_break("catsandog", {"cats", "dog", "sand", "and", "cat"})
+    False
+    """
+
+    return backtrack(input_string, word_dict, 0)


### PR DESCRIPTION
## Summary
- add original Python implementation for Word Break backtracking problem
- port algorithm to Mochi with explanatory block comments
- include sample outputs verifying segmentation results

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/backtracking/word_break.mochi`

------
https://chatgpt.com/codex/tasks/task_e_68910b9172408320b5162d198774ac6f