### PR TITLE
Add word search backtracking example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/backtracking/word_search.mochi
+++ b/tests/github/TheAlgorithms/Mochi/backtracking/word_search.mochi
@@ -1,0 +1,92 @@
+/*
+Word Search - Backtracking
+
+Given a 2D grid of characters and a target word, determine if the word
+can be formed by sequentially adjacent cells (horizontally or vertically).
+Each cell may be used at most once. The algorithm performs a depth-first
+search from every cell, exploring neighbors recursively while tracking
+visited cells to avoid reuse. If any path matches the entire word, the
+search succeeds.
+
+Time complexity is O(m*n*4^k) in the worst case where m*n is the size of
+the grid and k is the length of the word. Space complexity is O(k) for
+the recursion stack and visited tracking.
+*/
+
+fun contains(xs: list<int>, x: int): bool {
+  var i = 0
+  while i < len(xs) {
+    if xs[i] == x {
+      return true
+    }
+    i = i + 1
+  }
+  return false
+}
+
+fun get_point_key(len_board: int, len_board_column: int, row: int, column: int): int {
+  return len_board * len_board_column * row + column
+}
+
+fun search_from(board: list<list<string>>, word: string, row: int, column: int, word_index: int, visited: list<int>): bool {
+  if board[row][column] != substring(word, word_index, word_index + 1) {
+    return false
+  }
+  if word_index == len(word) - 1 {
+    return true
+  }
+  let len_board = len(board)
+  let len_board_column = len(board[0])
+  let dir_i = [0,0,-1,1]
+  let dir_j = [1,-1,0,0]
+  var k = 0
+  while k < 4 {
+    let next_i = row + dir_i[k]
+    let next_j = column + dir_j[k]
+    if !(0 <= next_i && next_i < len_board && 0 <= next_j && next_j < len_board_column) {
+      k = k + 1
+      continue
+    }
+    let key = get_point_key(len_board, len_board_column, next_i, next_j)
+    if contains(visited, key) {
+      k = k + 1
+      continue
+    }
+    let new_visited = append(visited, key)
+    if search_from(board, word, next_i, next_j, word_index + 1, new_visited) {
+      return true
+    }
+    k = k + 1
+  }
+  return false
+}
+
+fun word_exists(board: list<list<string>>, word: string): bool {
+  let len_board = len(board)
+  let len_board_column = len(board[0])
+  var i = 0
+  while i < len_board {
+    var j = 0
+    while j < len_board_column {
+      let key = get_point_key(len_board, len_board_column, i, j)
+      let visited = append([] as list<int>, key)
+      if search_from(board, word, i, j, 0, visited) {
+        return true
+      }
+      j = j + 1
+    }
+    i = i + 1
+  }
+  return false
+}
+
+fun main() {
+  let board = [["A","B","C","E"],
+               ["S","F","C","S"],
+               ["A","D","E","E"]]
+  print(word_exists(board, "ABCCED"))
+  print(word_exists(board, "SEE"))
+  print(word_exists(board, "ABCB"))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/backtracking/word_search.out
+++ b/tests/github/TheAlgorithms/Mochi/backtracking/word_search.out
@@ -1,0 +1,3 @@
+true
+true
+false

--- a/tests/github/TheAlgorithms/Python/backtracking/word_search.py
+++ b/tests/github/TheAlgorithms/Python/backtracking/word_search.py
@@ -1,0 +1,162 @@
+"""
+Author  : Alexander Pantyukhin
+Date    : November 24, 2022
+
+Task:
+Given an m x n grid of characters board and a string word,
+return true if word exists in the grid.
+
+The word can be constructed from letters of sequentially adjacent cells,
+where adjacent cells are horizontally or vertically neighboring.
+The same letter cell may not be used more than once.
+
+Example:
+
+Matrix:
+---------
+|A|B|C|E|
+|S|F|C|S|
+|A|D|E|E|
+---------
+
+Word:
+"ABCCED"
+
+Result:
+True
+
+Implementation notes: Use backtracking approach.
+At each point, check all neighbors to try to find the next letter of the word.
+
+leetcode: https://leetcode.com/problems/word-search/
+
+"""
+
+
+def get_point_key(len_board: int, len_board_column: int, row: int, column: int) -> int:
+    """
+    Returns the hash key of matrix indexes.
+
+    >>> get_point_key(10, 20, 1, 0)
+    200
+    """
+
+    return len_board * len_board_column * row + column
+
+
+def exits_word(
+    board: list[list[str]],
+    word: str,
+    row: int,
+    column: int,
+    word_index: int,
+    visited_points_set: set[int],
+) -> bool:
+    """
+    Return True if it's possible to search the word suffix
+    starting from the word_index.
+
+    >>> exits_word([["A"]], "B", 0, 0, 0, set())
+    False
+    """
+
+    if board[row][column] != word[word_index]:
+        return False
+
+    if word_index == len(word) - 1:
+        return True
+
+    traverts_directions = [(0, 1), (0, -1), (-1, 0), (1, 0)]
+    len_board = len(board)
+    len_board_column = len(board[0])
+    for direction in traverts_directions:
+        next_i = row + direction[0]
+        next_j = column + direction[1]
+        if not (0 <= next_i < len_board and 0 <= next_j < len_board_column):
+            continue
+
+        key = get_point_key(len_board, len_board_column, next_i, next_j)
+        if key in visited_points_set:
+            continue
+
+        visited_points_set.add(key)
+        if exits_word(board, word, next_i, next_j, word_index + 1, visited_points_set):
+            return True
+
+        visited_points_set.remove(key)
+
+    return False
+
+
+def word_exists(board: list[list[str]], word: str) -> bool:
+    """
+    >>> word_exists([["A","B","C","E"],["S","F","C","S"],["A","D","E","E"]], "ABCCED")
+    True
+    >>> word_exists([["A","B","C","E"],["S","F","C","S"],["A","D","E","E"]], "SEE")
+    True
+    >>> word_exists([["A","B","C","E"],["S","F","C","S"],["A","D","E","E"]], "ABCB")
+    False
+    >>> word_exists([["A"]], "A")
+    True
+    >>> word_exists([["B", "A", "A"], ["A", "A", "A"], ["A", "B", "A"]], "ABB")
+    False
+    >>> word_exists([["A"]], 123)
+    Traceback (most recent call last):
+        ...
+    ValueError: The word parameter should be a string of length greater than 0.
+    >>> word_exists([["A"]], "")
+    Traceback (most recent call last):
+        ...
+    ValueError: The word parameter should be a string of length greater than 0.
+    >>> word_exists([[]], "AB")
+    Traceback (most recent call last):
+        ...
+    ValueError: The board should be a non empty matrix of single chars strings.
+    >>> word_exists([], "AB")
+    Traceback (most recent call last):
+        ...
+    ValueError: The board should be a non empty matrix of single chars strings.
+    >>> word_exists([["A"], [21]], "AB")
+    Traceback (most recent call last):
+        ...
+    ValueError: The board should be a non empty matrix of single chars strings.
+    """
+
+    # Validate board
+    board_error_message = (
+        "The board should be a non empty matrix of single chars strings."
+    )
+
+    len_board = len(board)
+    if not isinstance(board, list) or len(board) == 0:
+        raise ValueError(board_error_message)
+
+    for row in board:
+        if not isinstance(row, list) or len(row) == 0:
+            raise ValueError(board_error_message)
+
+        for item in row:
+            if not isinstance(item, str) or len(item) != 1:
+                raise ValueError(board_error_message)
+
+    # Validate word
+    if not isinstance(word, str) or len(word) == 0:
+        raise ValueError(
+            "The word parameter should be a string of length greater than 0."
+        )
+
+    len_board_column = len(board[0])
+    for i in range(len_board):
+        for j in range(len_board_column):
+            if exits_word(
+                board, word, i, j, 0, {get_point_key(len_board, len_board_column, i, j)}
+            ):
+                return True
+
+    return False
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python `word_search` backtracking example from TheAlgorithms
- port algorithm to Mochi with detailed documentation
- include example runtime output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/backtracking/word_search.mochi`

------
https://chatgpt.com/codex/tasks/task_e_68910ba3bfb48320a403fd95a6fed5e0