### PR TITLE
Add Mochi implementation of word ladder

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/backtracking/word_ladder.mochi
+++ b/tests/github/TheAlgorithms/Mochi/backtracking/word_ladder.mochi
@@ -1,0 +1,78 @@
+/*
+Word Ladder - Backtracking
+
+Given a begin word and an end word along with a list of valid words,
+transform the begin word into the end word by changing one letter at a time.
+Each intermediate word must exist in the given list.  This implementation
+performs a depth-first search.  From the current word all possible single
+character substitutions are generated.  Valid transformations are removed
+from the available word list and recursion continues from the new word.
+If the end word is reached the accumulated path is returned, otherwise the
+search backtracks and tries alternative substitutions.
+*/
+
+let alphabet = "abcdefghijklmnopqrstuvwxyz"
+
+fun contains(xs: list<string>, x: string): bool {
+  var i = 0
+  while i < len(xs) {
+    if xs[i] == x {
+      return true
+    }
+    i = i + 1
+  }
+  return false
+}
+
+fun remove_item(xs: list<string>, x: string): list<string> {
+  var res: list<string> = []
+  var removed = false
+  var i = 0
+  while i < len(xs) {
+    if !removed && xs[i] == x {
+      removed = true
+    } else {
+      res = append(res, xs[i])
+    }
+    i = i + 1
+  }
+  return res
+}
+
+fun word_ladder(current: string, path: list<string>, target: string, words: list<string>): list<string> {
+  if current == target {
+    return path
+  }
+  var i = 0
+  while i < len(current) {
+    var j = 0
+    while j < len(alphabet) {
+      let c = substring(alphabet, j, j + 1)
+      let transformed = substring(current, 0, i) + c + substring(current, i + 1, len(current))
+      if contains(words, transformed) {
+        let new_words = remove_item(words, transformed)
+        let new_path = append(path, transformed)
+        let result = word_ladder(transformed, new_path, target, new_words)
+        if len(result) > 0 {
+          return result
+        }
+      }
+      j = j + 1
+    }
+    i = i + 1
+  }
+  return [] as list<string>
+}
+
+fun main() {
+  let w1 = ["hot", "dot", "dog", "lot", "log", "cog"]
+  print(str(word_ladder("hit", ["hit"], "cog", w1)))
+  let w2 = ["hot", "dot", "dog", "lot", "log"]
+  print(str(word_ladder("hit", ["hit"], "cog", w2)))
+  let w3 = ["load", "goad", "gold", "lead", "lord"]
+  print(str(word_ladder("lead", ["lead"], "gold", w3)))
+  let w4 = ["came", "cage", "code", "cade", "gave"]
+  print(str(word_ladder("game", ["game"], "code", w4)))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/backtracking/word_ladder.out
+++ b/tests/github/TheAlgorithms/Mochi/backtracking/word_ladder.out
@@ -1,0 +1,4 @@
+[hit hot dot lot log cog]
+[]
+[lead lead load goad gold]
+[game came cade code]

--- a/tests/github/TheAlgorithms/Python/backtracking/word_ladder.py
+++ b/tests/github/TheAlgorithms/Python/backtracking/word_ladder.py
@@ -1,0 +1,100 @@
+"""
+Word Ladder is a classic problem in computer science.
+The problem is to transform a start word into an end word
+by changing one letter at a time.
+Each intermediate word must be a valid word from a given list of words.
+The goal is to find a transformation sequence
+from the start word to the end word.
+
+Wikipedia: https://en.wikipedia.org/wiki/Word_ladder
+"""
+
+import string
+
+
+def backtrack(
+    current_word: str, path: list[str], end_word: str, word_set: set[str]
+) -> list[str]:
+    """
+    Helper function to perform backtracking to find the transformation
+    from the current_word to the end_word.
+
+    Parameters:
+    current_word (str): The current word in the transformation sequence.
+    path (list[str]): The list of transformations from begin_word to current_word.
+    end_word (str): The target word for transformation.
+    word_set (set[str]): The set of valid words for transformation.
+
+    Returns:
+    list[str]: The list of transformations from begin_word to end_word.
+               Returns an empty list if there is no valid
+                transformation from current_word to end_word.
+
+    Example:
+    >>> backtrack("hit", ["hit"], "cog", {"hot", "dot", "dog", "lot", "log", "cog"})
+    ['hit', 'hot', 'dot', 'lot', 'log', 'cog']
+
+    >>> backtrack("hit", ["hit"], "cog", {"hot", "dot", "dog", "lot", "log"})
+    []
+
+    >>> backtrack("lead", ["lead"], "gold", {"load", "goad", "gold", "lead", "lord"})
+    ['lead', 'lead', 'load', 'goad', 'gold']
+
+    >>> backtrack("game", ["game"], "code", {"came", "cage", "code", "cade", "gave"})
+    ['game', 'came', 'cade', 'code']
+    """
+
+    # Base case: If the current word is the end word, return the path
+    if current_word == end_word:
+        return path
+
+    # Try all possible single-letter transformations
+    for i in range(len(current_word)):
+        for c in string.ascii_lowercase:  # Try changing each letter
+            transformed_word = current_word[:i] + c + current_word[i + 1 :]
+            if transformed_word in word_set:
+                word_set.remove(transformed_word)
+                # Recur with the new word added to the path
+                result = backtrack(
+                    transformed_word, [*path, transformed_word], end_word, word_set
+                )
+                if result:  # valid transformation found
+                    return result
+                word_set.add(transformed_word)  # backtrack
+
+    return []  # No valid transformation found
+
+
+def word_ladder(begin_word: str, end_word: str, word_set: set[str]) -> list[str]:
+    """
+    Solve the Word Ladder problem using Backtracking and return
+    the list of transformations from begin_word to end_word.
+
+    Parameters:
+    begin_word (str): The word from which the transformation starts.
+    end_word (str): The target word for transformation.
+    word_list (list[str]): The list of valid words for transformation.
+
+    Returns:
+    list[str]: The list of transformations from begin_word to end_word.
+               Returns an empty list if there is no valid transformation.
+
+    Example:
+    >>> word_ladder("hit", "cog", ["hot", "dot", "dog", "lot", "log", "cog"])
+    ['hit', 'hot', 'dot', 'lot', 'log', 'cog']
+
+    >>> word_ladder("hit", "cog", ["hot", "dot", "dog", "lot", "log"])
+    []
+
+    >>> word_ladder("lead", "gold", ["load", "goad", "gold", "lead", "lord"])
+    ['lead', 'lead', 'load', 'goad', 'gold']
+
+    >>> word_ladder("game", "code", ["came", "cage", "code", "cade", "gave"])
+    ['game', 'came', 'cade', 'code']
+    """
+
+    if end_word not in word_set:  # no valid transformation possible
+        return []
+
+    # Perform backtracking starting from the begin_word
+    return backtrack(begin_word, [begin_word], end_word, word_set)


### PR DESCRIPTION
## Summary
- add reference Python implementation for word ladder backtracking algorithm
- implement word ladder in pure Mochi using depth-first search and backtracking
- include sample execution output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/backtracking/word_ladder.mochi > tests/github/TheAlgorithms/Mochi/backtracking/word_ladder.out`


------
https://chatgpt.com/codex/tasks/task_e_68910b9a683c83209ab215c58094571b