### PR TITLE
Add Mochi implementation for bit manipulation is_even

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/bit_manipulation/is_even.mochi
+++ b/tests/github/TheAlgorithms/Mochi/bit_manipulation/is_even.mochi
@@ -1,0 +1,20 @@
+/*
+  Check if an integer is even using bit manipulation. In binary, even numbers
+  have 0 as their least significant bit while odd numbers have 1. By applying a
+  bitwise AND with 1 we isolate this bit; a result of 0 indicates the number is
+  even and 1 means it is odd. This constant-time approach avoids division or
+  modulo operations. In Mochi we emulate this by taking the number modulo 2,
+  which yields the same least-significant bit.
+*/
+
+fun is_even(number: int): bool {
+  return number % 2 == 0
+}
+
+print(str(is_even(1)))
+print(str(is_even(4)))
+print(str(is_even(9)))
+print(str(is_even(15)))
+print(str(is_even(40)))
+print(str(is_even(100)))
+print(str(is_even(101)))

--- a/tests/github/TheAlgorithms/Mochi/bit_manipulation/is_even.out
+++ b/tests/github/TheAlgorithms/Mochi/bit_manipulation/is_even.out
@@ -1,0 +1,7 @@
+false
+true
+false
+false
+true
+true
+false

--- a/tests/github/TheAlgorithms/Python/bit_manipulation/is_even.py
+++ b/tests/github/TheAlgorithms/Python/bit_manipulation/is_even.py
@@ -1,0 +1,37 @@
+def is_even(number: int) -> bool:
+    """
+    return true if the input integer is even
+    Explanation: Lets take a look at the following decimal to binary conversions
+    2 => 10
+    14 => 1110
+    100 => 1100100
+    3 => 11
+    13 => 1101
+    101 => 1100101
+    from the above examples we can observe that
+    for all the odd integers there is always 1 set bit at the end
+    also, 1 in binary can be represented as 001, 00001, or 0000001
+    so for any odd integer n => n&1 is always equals 1 else the integer is even
+
+    >>> is_even(1)
+    False
+    >>> is_even(4)
+    True
+    >>> is_even(9)
+    False
+    >>> is_even(15)
+    False
+    >>> is_even(40)
+    True
+    >>> is_even(100)
+    True
+    >>> is_even(101)
+    False
+    """
+    return number & 1 == 0
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add original Python `is_even` using bitwise parity check
- implement Mochi version checking parity via modulo
- record runtime output from Mochi VM

## Testing
- `go test ./...`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/bit_manipulation/is_even.mochi`

------
https://chatgpt.com/codex/tasks/task_e_68910d7f2f0c8320a654a0fb78c88d58