### PR TITLE
Add Mochi version of numbers_different_signs algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/bit_manipulation/numbers_different_signs.mochi
+++ b/tests/github/TheAlgorithms/Mochi/bit_manipulation/numbers_different_signs.mochi
@@ -1,0 +1,23 @@
+/*
+Numbers Different Signs - Bit Manipulation
+
+Given two integers, determine whether they have opposite signs.  In a two's
+complement representation, the sign bit is the highest bit.  XORing the two
+numbers sets this bit if and only if the inputs have different signs.  To avoid
+implementing full bitwise arithmetic, we compute the XOR of the sign bits by
+comparing the signs of each number.
+*/
+
+fun different_signs(num1: int, num2: int): bool {
+  let sign1 = num1 < 0
+  let sign2 = num2 < 0
+  return sign1 != sign2
+}
+
+print(str(different_signs(1, -1)))
+print(str(different_signs(1, 1)))
+print(str(different_signs(1000000000000000000, -1000000000000000000)))
+print(str(different_signs(-1000000000000000000, 1000000000000000000)))
+print(str(different_signs(50, 278)))
+print(str(different_signs(0, 2)))
+print(str(different_signs(2, 0)))

--- a/tests/github/TheAlgorithms/Mochi/bit_manipulation/numbers_different_signs.out
+++ b/tests/github/TheAlgorithms/Mochi/bit_manipulation/numbers_different_signs.out
@@ -1,0 +1,7 @@
+true
+false
+true
+true
+false
+false
+false

--- a/tests/github/TheAlgorithms/Python/bit_manipulation/numbers_different_signs.py
+++ b/tests/github/TheAlgorithms/Python/bit_manipulation/numbers_different_signs.py
@@ -1,0 +1,39 @@
+"""
+Author  : Alexander Pantyukhin
+Date    : November 30, 2022
+
+Task:
+Given two int numbers. Return True these numbers have opposite signs
+or False otherwise.
+
+Implementation notes: Use bit manipulation.
+Use XOR for two numbers.
+"""
+
+
+def different_signs(num1: int, num2: int) -> bool:
+    """
+    Return True if numbers have opposite signs False otherwise.
+
+    >>> different_signs(1, -1)
+    True
+    >>> different_signs(1, 1)
+    False
+    >>> different_signs(1000000000000000000000000000, -1000000000000000000000000000)
+    True
+    >>> different_signs(-1000000000000000000000000000, 1000000000000000000000000000)
+    True
+    >>> different_signs(50, 278)
+    False
+    >>> different_signs(0, 2)
+    False
+    >>> different_signs(2, 0)
+    False
+    """
+    return num1 ^ num2 < 0
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python source for detecting if two numbers have opposite signs using XOR
- implement equivalent Mochi routine and sample invocations
- include runtime output demonstrating correct behaviour

## Testing
- `python tests/github/TheAlgorithms/Python/bit_manipulation/numbers_different_signs.py`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/bit_manipulation/numbers_different_signs.mochi > tests/github/TheAlgorithms/Mochi/bit_manipulation/numbers_different_signs.out`

------
https://chatgpt.com/codex/tasks/task_e_68910dca25208320b3fcf38a01bd814b