### PR TITLE
Add Mochi example for Karnaugh map simplification

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/boolean_algebra/karnaugh_map_simplification.mochi
+++ b/tests/github/TheAlgorithms/Mochi/boolean_algebra/karnaugh_map_simplification.mochi
@@ -1,0 +1,70 @@
+/*
+Simplify a 2x2 Karnaugh map by generating a sum-of-products expression.
+
+Each cell corresponds to a conjunction of literals A or A' for the row
+and B or B' for the column.  For every cell containing a truthy value
+(non-zero), we append its term.  Finally, terms are joined using " + ".
+
+This routine merely enumerates minterms without performing any further
+algebraic simplification.  The runtime is O(n*m) for an n by m map.
+*/
+
+fun row_string(row: list<int>): string {
+  var s = "["
+  var i = 0
+  while i < len(row) {
+    s = s + str(row[i])
+    if i < len(row) - 1 {
+      s = s + ", "
+    }
+    i = i + 1
+  }
+  s = s + "]"
+  return s
+}
+
+fun print_kmap(kmap: list<list<int>>) {
+  var i = 0
+  while i < len(kmap) {
+    print(row_string(kmap[i]))
+    i = i + 1
+  }
+}
+
+fun join_terms(terms: list<string>): string {
+  if len(terms) == 0 {
+    return ""
+  }
+  var res = terms[0]
+  var i = 1
+  while i < len(terms) {
+    res = res + " + " + terms[i]
+    i = i + 1
+  }
+  return res
+}
+
+fun simplify_kmap(board: list<list<int>>): string {
+  var terms: list<string> = []
+  var a = 0
+  while a < len(board) {
+    let row = board[a]
+    var b = 0
+    while b < len(row) {
+      let item = row[b]
+      if item != 0 {
+        let term = (if a != 0 { "A" } else { "A'" }) + (if b != 0 { "B" } else { "B'" })
+        terms = append(terms, term)
+      }
+      b = b + 1
+    }
+    a = a + 1
+  }
+  let expr = join_terms(terms)
+  return expr
+}
+
+var kmap = [[0, 1], [1, 1]]
+print_kmap(kmap)
+print("Simplified Expression:")
+print(simplify_kmap(kmap))

--- a/tests/github/TheAlgorithms/Mochi/boolean_algebra/karnaugh_map_simplification.out
+++ b/tests/github/TheAlgorithms/Mochi/boolean_algebra/karnaugh_map_simplification.out
@@ -1,0 +1,4 @@
+[0, 1]
+[1, 1]
+Simplified Expression:
+A'B + AB' + AB

--- a/tests/github/TheAlgorithms/Python/boolean_algebra/karnaugh_map_simplification.py
+++ b/tests/github/TheAlgorithms/Python/boolean_algebra/karnaugh_map_simplification.py
@@ -1,0 +1,55 @@
+"""
+https://en.wikipedia.org/wiki/Karnaugh_map
+https://www.allaboutcircuits.com/technical-articles/karnaugh-map-boolean-algebraic-simplification-technique
+"""
+
+
+def simplify_kmap(kmap: list[list[int]]) -> str:
+    """
+    Simplify the Karnaugh map.
+    >>> simplify_kmap(kmap=[[0, 1], [1, 1]])
+    "A'B + AB' + AB"
+    >>> simplify_kmap(kmap=[[0, 0], [0, 0]])
+    ''
+    >>> simplify_kmap(kmap=[[0, 1], [1, -1]])
+    "A'B + AB' + AB"
+    >>> simplify_kmap(kmap=[[0, 1], [1, 2]])
+    "A'B + AB' + AB"
+    >>> simplify_kmap(kmap=[[0, 1], [1, 1.1]])
+    "A'B + AB' + AB"
+    >>> simplify_kmap(kmap=[[0, 1], [1, 'a']])
+    "A'B + AB' + AB"
+    """
+    simplified_f = []
+    for a, row in enumerate(kmap):
+        for b, item in enumerate(row):
+            if item:
+                term = ("A" if a else "A'") + ("B" if b else "B'")
+                simplified_f.append(term)
+    return " + ".join(simplified_f)
+
+
+def main() -> None:
+    """
+    Main function to create and simplify a K-Map.
+
+    >>> main()
+    [0, 1]
+    [1, 1]
+    Simplified Expression:
+    A'B + AB' + AB
+    """
+    kmap = [[0, 1], [1, 1]]
+
+    # Manually generate the product of [0, 1] and [0, 1]
+
+    for row in kmap:
+        print(row)
+
+    print("Simplified Expression:")
+    print(simplify_kmap(kmap))
+
+
+if __name__ == "__main__":
+    main()
+    print(f"{simplify_kmap(kmap=[[0, 1], [1, 1]]) = }")


### PR DESCRIPTION
## Summary
- add missing Python example for Karnaugh map simplification
- implement equivalent Mochi version that builds a sum-of-products expression
- capture VM output for the new Mochi example

## Testing
- `python tests/github/TheAlgorithms/Python/boolean_algebra/karnaugh_map_simplification.py`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/boolean_algebra/karnaugh_map_simplification.mochi`


------
https://chatgpt.com/codex/tasks/task_e_68910fa7c22c832092fd9d74c12d8d3e