### PR TITLE
Add NOR gate algorithm and truth table

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/boolean_algebra/nor_gate.mochi
+++ b/tests/github/TheAlgorithms/Mochi/boolean_algebra/nor_gate.mochi
@@ -1,0 +1,57 @@
+/*
+Simulate a NOR logic gate and generate its truth table.
+
+A NOR gate outputs 1 only when both binary inputs are 0; otherwise it outputs 0.
+This is equivalent to performing a logical OR followed by negation. The program
+implements the NOR operation and constructs a formatted truth table showing all
+possible input combinations. The complexity is O(1) since there are only four
+input pairs to evaluate.
+*/
+
+fun nor_gate(input_1: int, input_2: int): int {
+  if input_1 == 0 && input_2 == 0 {
+    return 1
+  }
+  return 0
+}
+
+fun center(s: string, width: int): string {
+  var total = width - len(s)
+  if total <= 0 {
+    return s
+  }
+  var left = total / 2
+  var right = total - left
+  var res = s
+  var i = 0
+  while i < left {
+    res = " " + res
+    i = i + 1
+  }
+  var j = 0
+  while j < right {
+    res = res + " "
+    j = j + 1
+  }
+  return res
+}
+
+fun make_table_row(i: int, j: int): string {
+  let output = nor_gate(i, j)
+  return "| " + center(str(i), 8) + " | " + center(str(j), 8) + " | " + center(str(output), 8) + " |"
+}
+
+fun truth_table(): string {
+  return "Truth Table of NOR Gate:\n" +
+         "| Input 1 | Input 2 | Output  |\n" +
+         make_table_row(0, 0) + "\n" +
+         make_table_row(0, 1) + "\n" +
+         make_table_row(1, 0) + "\n" +
+         make_table_row(1, 1)
+}
+
+print(nor_gate(0, 0))
+print(nor_gate(0, 1))
+print(nor_gate(1, 0))
+print(nor_gate(1, 1))
+print(truth_table())

--- a/tests/github/TheAlgorithms/Mochi/boolean_algebra/nor_gate.out
+++ b/tests/github/TheAlgorithms/Mochi/boolean_algebra/nor_gate.out
@@ -1,0 +1,10 @@
+1
+0
+0
+0
+Truth Table of NOR Gate:
+| Input 1 | Input 2 | Output  |
+|    0     |    0     |    1     |
+|    0     |    1     |    0     |
+|    1     |    0     |    0     |
+|    1     |    1     |    0     |

--- a/tests/github/TheAlgorithms/Python/boolean_algebra/nor_gate.py
+++ b/tests/github/TheAlgorithms/Python/boolean_algebra/nor_gate.py
@@ -1,0 +1,68 @@
+"""
+A NOR Gate is a logic gate in boolean algebra which results in false(0) if any of the
+inputs is 1, and True(1) if all inputs are 0.
+Following is the truth table of a NOR Gate:
+    Truth Table of NOR Gate:
+    | Input 1  | Input 2  |  Output  |
+    |    0     |    0     |    1     |
+    |    0     |    1     |    0     |
+    |    1     |    0     |    0     |
+    |    1     |    1     |    0     |
+
+    Code provided by Akshaj Vishwanathan
+https://www.geeksforgeeks.org/logic-gates-in-python
+"""
+
+from collections.abc import Callable
+
+
+def nor_gate(input_1: int, input_2: int) -> int:
+    """
+    >>> nor_gate(0, 0)
+    1
+    >>> nor_gate(0, 1)
+    0
+    >>> nor_gate(1, 0)
+    0
+    >>> nor_gate(1, 1)
+    0
+    >>> nor_gate(0.0, 0.0)
+    1
+    >>> nor_gate(0, -7)
+    0
+    """
+    return int(input_1 == input_2 == 0)
+
+
+def truth_table(func: Callable) -> str:
+    """
+    >>> print(truth_table(nor_gate))
+    Truth Table of NOR Gate:
+    | Input 1  | Input 2  |  Output  |
+    |    0     |    0     |    1     |
+    |    0     |    1     |    0     |
+    |    1     |    0     |    0     |
+    |    1     |    1     |    0     |
+    """
+
+    def make_table_row(items: list | tuple) -> str:
+        """
+        >>> make_table_row(("One", "Two", "Three"))
+        '|   One    |   Two    |  Three   |'
+        """
+        return f"| {' | '.join(f'{item:^8}' for item in items)} |"
+
+    return "\n".join(
+        (
+            "Truth Table of NOR Gate:",
+            make_table_row(("Input 1", "Input 2", "Output")),
+            *[make_table_row((i, j, func(i, j))) for i in (0, 1) for j in (0, 1)],
+        )
+    )
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    print(truth_table(nor_gate))


### PR DESCRIPTION
## Summary
- add NOR gate Python source for reference
- implement NOR gate in Mochi with formatted truth table
- include runtime output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/boolean_algebra/nor_gate.mochi`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68910fcdde188320a226aa30933f5f5d