### PR TITLE
Add Langton's Ant algorithm and Mochi implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/cellular_automata/langtons_ant.mochi
+++ b/tests/github/TheAlgorithms/Mochi/cellular_automata/langtons_ant.mochi
@@ -1,0 +1,80 @@
+/*
+Langton's Ant Simulation
+------------------------
+Langton's Ant is a two-dimensional universal Turing machine.  The ant
+moves on a grid of white and black cells following two simple rules:
+
+1. If the ant is on a white cell it turns 90 degrees to the right,
+   flips the cell to black, then moves forward one step.
+2. If the ant is on a black cell it turns 90 degrees to the left,
+   flips the cell to white, then moves forward one step.
+
+The board starts entirely white.  Despite the simplicity of the rules
+this system exhibits complex emergent behaviour.  The algorithm below
+simulates the ant for a given number of steps and returns the final
+state of the board.  The simulation runs in O(steps) time with
+O(width*height) space for the board.
+*/
+
+fun create_board(width: int, height: int): list<list<bool>> {
+  var board: list<list<bool>> = []
+  var i = 0
+  while i < height {
+    var row: list<bool> = []
+    var j = 0
+    while j < width {
+      row = append(row, true)
+      j = j + 1
+    }
+    board = append(board, row)
+    i = i + 1
+  }
+  return board
+}
+
+fun move_ant(board: list<list<bool>>, x: int, y: int, direction: int): list<int> {
+  if board[x][y] {
+    direction = (direction + 1) % 4
+  } else {
+    direction = (direction + 3) % 4
+  }
+  let old_x = x
+  let old_y = y
+  if direction == 0 {
+    x = x - 1
+  } else if direction == 1 {
+    y = y + 1
+  } else if direction == 2 {
+    x = x + 1
+  } else {
+    y = y - 1
+  }
+  board[old_x][old_y] = !board[old_x][old_y]
+  return [x, y, direction]
+}
+
+fun langtons_ant(width: int, height: int, steps: int): list<list<bool>> {
+  var board = create_board(width, height)
+  var x = width / 2
+  var y = height / 2
+  var dir = 3
+  var s = 0
+  while s < steps {
+    let state = move_ant(board, x, y, dir)
+    x = state[0]
+    y = state[1]
+    dir = state[2]
+    s = s + 1
+  }
+  return board
+}
+
+test "first move" {
+  let board = langtons_ant(2, 2, 1)
+  expect board == [[true,true], [true,false]]
+}
+
+test "second move" {
+  let board = langtons_ant(2, 2, 2)
+  expect board == [[true,false], [true,false]]
+}

--- a/tests/github/TheAlgorithms/Mochi/cellular_automata/langtons_ant.out
+++ b/tests/github/TheAlgorithms/Mochi/cellular_automata/langtons_ant.out
@@ -1,0 +1,3 @@
+[94;1mtests/github/TheAlgorithms/Mochi/cellular_automata/langtons_ant.mochi[0;22m
+   [33mtest[0m first move                     ... [32mok[0m (4.0ms)
+   [33mtest[0m second move                    ... [32mok[0m (2.0ms)

--- a/tests/github/TheAlgorithms/Python/cellular_automata/langtons_ant.py
+++ b/tests/github/TheAlgorithms/Python/cellular_automata/langtons_ant.py
@@ -1,0 +1,106 @@
+"""
+Langton's ant
+
+@ https://en.wikipedia.org/wiki/Langton%27s_ant
+@ https://upload.wikimedia.org/wikipedia/commons/0/09/LangtonsAntAnimated.gif
+"""
+
+from functools import partial
+
+from matplotlib import pyplot as plt
+from matplotlib.animation import FuncAnimation
+
+WIDTH = 80
+HEIGHT = 80
+
+
+class LangtonsAnt:
+    """
+    Represents the main LangonsAnt algorithm.
+
+    >>> la = LangtonsAnt(2, 2)
+    >>> la.board
+    [[True, True], [True, True]]
+    >>> la.ant_position
+    (1, 1)
+    """
+
+    def __init__(self, width: int, height: int) -> None:
+        # Each square is either True or False where True is white and False is black
+        self.board = [[True] * width for _ in range(height)]
+        self.ant_position: tuple[int, int] = (width // 2, height // 2)
+
+        # Initially pointing left (similar to the wikipedia image)
+        # (0 = 0° | 1 = 90° | 2 = 180 ° | 3 = 270°)
+        self.ant_direction: int = 3
+
+    def move_ant(self, axes: plt.Axes | None, display: bool, _frame: int) -> None:
+        """
+        Performs three tasks:
+            1. The ant turns either clockwise or anti-clockwise according to the colour
+            of the square that it is currently on. If the square is white, the ant
+            turns clockwise, and if the square is black the ant turns anti-clockwise
+            2. The ant moves one square in the direction that it is currently facing
+            3. The square the ant was previously on is inverted (White -> Black and
+            Black -> White)
+
+        If display is True, the board will also be displayed on the axes
+
+        >>> la = LangtonsAnt(2, 2)
+        >>> la.move_ant(None, True, 0)
+        >>> la.board
+        [[True, True], [True, False]]
+        >>> la.move_ant(None, True, 0)
+        >>> la.board
+        [[True, False], [True, False]]
+        """
+        directions = {
+            0: (-1, 0),  # 0°
+            1: (0, 1),  # 90°
+            2: (1, 0),  # 180°
+            3: (0, -1),  # 270°
+        }
+        x, y = self.ant_position
+
+        # Turn clockwise or anti-clockwise according to colour of square
+        if self.board[x][y] is True:
+            # The square is white so turn 90° clockwise
+            self.ant_direction = (self.ant_direction + 1) % 4
+        else:
+            # The square is black so turn 90° anti-clockwise
+            self.ant_direction = (self.ant_direction - 1) % 4
+
+        # Move ant
+        move_x, move_y = directions[self.ant_direction]
+        self.ant_position = (x + move_x, y + move_y)
+
+        # Flip colour of square
+        self.board[x][y] = not self.board[x][y]
+
+        if display and axes:
+            # Display the board on the axes
+            axes.get_xaxis().set_ticks([])
+            axes.get_yaxis().set_ticks([])
+            axes.imshow(self.board, cmap="gray", interpolation="nearest")
+
+    def display(self, frames: int = 100_000) -> None:
+        """
+        Displays the board without delay in a matplotlib plot
+        to visually understand and track the ant.
+
+        >>> _ = LangtonsAnt(WIDTH, HEIGHT)
+        """
+        fig, ax = plt.subplots()
+        # Assign animation to a variable to prevent it from getting garbage collected
+        self.animation = FuncAnimation(
+            fig, partial(self.move_ant, ax, True), frames=frames, interval=1
+        )
+        plt.show()
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+
+    LangtonsAnt(WIDTH, HEIGHT).display()


### PR DESCRIPTION
## Summary
- add Python reference implementation for Langton's Ant
- port Langton's Ant to pure Mochi with board simulation
- include tests demonstrating board state after the first two moves

## Testing
- `python3 -m py_compile tests/github/TheAlgorithms/Python/cellular_automata/langtons_ant.py`
- `go run ./cmd/mochi test tests/github/TheAlgorithms/Mochi/cellular_automata/langtons_ant.mochi`


------
https://chatgpt.com/codex/tasks/task_e_68911118de5c8320a7dc15cb53fffe5d