### PR TITLE
Add Mochi implementation for A1Z26 cipher

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/ciphers/a1z26.mochi
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/a1z26.mochi
@@ -1,0 +1,74 @@
+/*
+A1Z26 Cipher
+------------
+This program implements the A1Z26 substitution cipher where each letter of the
+English alphabet is replaced by its 1-indexed position (a=1, b=2, ..., z=26).
+Two functions are provided:
+  - encode: converts a lowercase string into a list of integers representing
+    each letter's position in the alphabet.
+  - decode: converts a list of integers back into the original lowercase
+    string.
+The main function demonstrates both operations by reading a line of input,
+encoding it, printing the numeric sequence, and then decoding it back to the
+original string. The implementation avoids foreign function interfaces and
+uses only the Mochi standard features, ensuring compatibility with the
+runtime VM.
+*/
+
+fun indexOf(s: string, ch: string): int {
+  var i = 0
+  while i < len(s) {
+    if substring(s, i, i+1) == ch {
+      return i
+    }
+    i = i + 1
+  }
+  return -1
+}
+
+fun charToNum(ch: string): int {
+  let letters = "abcdefghijklmnopqrstuvwxyz"
+  let idx = indexOf(letters, ch)
+  if idx >= 0 { return idx + 1 }
+  return 0
+}
+
+fun numToChar(n: int): string {
+  let letters = "abcdefghijklmnopqrstuvwxyz"
+  if n >= 1 && n <= 26 {
+    return substring(letters, n-1, n)
+  }
+  return "?"
+}
+
+fun encode(plain: string): list<int> {
+  var res: list<int> = []
+  var i = 0
+  while i < len(plain) {
+    let ch = lower(substring(plain, i, i+1))
+    let val = charToNum(ch)
+    if val > 0 {
+      res = append(res, val)
+    }
+    i = i + 1
+  }
+  return res
+}
+
+fun decode(encoded: list<int>): string {
+  var out = ""
+  for n in encoded {
+    out = out + numToChar(n)
+  }
+  return out
+}
+
+fun main() {
+  print("-> ")
+  let text = lower(input())
+  let enc = encode(text)
+  print("Encoded: " + str(enc))
+  print("Decoded: " + decode(enc))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/ciphers/a1z26.out
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/a1z26.out
@@ -1,0 +1,3 @@
+-> 
+Encoded: [13 25 14 1 13 5]
+Decoded: myname

--- a/tests/github/TheAlgorithms/Python/ciphers/a1z26.py
+++ b/tests/github/TheAlgorithms/Python/ciphers/a1z26.py
@@ -1,0 +1,35 @@
+"""
+Convert a string of characters to a sequence of numbers
+corresponding to the character's position in the alphabet.
+
+https://www.dcode.fr/letter-number-cipher
+http://bestcodes.weebly.com/a1z26.html
+"""
+
+from __future__ import annotations
+
+
+def encode(plain: str) -> list[int]:
+    """
+    >>> encode("myname")
+    [13, 25, 14, 1, 13, 5]
+    """
+    return [ord(elem) - 96 for elem in plain]
+
+
+def decode(encoded: list[int]) -> str:
+    """
+    >>> decode([13, 25, 14, 1, 13, 5])
+    'myname'
+    """
+    return "".join(chr(elem + 96) for elem in encoded)
+
+
+def main() -> None:
+    encoded = encode(input("-> ").strip().lower())
+    print("Encoded: ", encoded)
+    print("Decoded:", decode(encoded))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add missing Python source for A1Z26 cipher
- implement A1Z26 encode/decode in pure Mochi with detailed comment
- include runtime/vm output for sample input

## Testing
- `npm test` (fails: Missing script)
- `go test ./runtime/vm -run .` (no test files)
- `printf "myname" | go run /tmp/runvm.go tests/github/TheAlgorithms/Mochi/ciphers/a1z26.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891113f931c8320bff8d40adb2c4483