### PR TITLE
Add Affine cipher example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/ciphers/affine_cipher.mochi
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/affine_cipher.mochi
@@ -1,0 +1,138 @@
+/*
+Implement the Affine cipher for encryption and decryption using the 95 printable
+ASCII characters as the symbol set.
+
+Each character is mapped to its index within the symbol set. Encryption applies
+(x * keyA + keyB) mod m, where m is the size of the symbol set. Decryption uses
+the modular inverse of keyA so that the original index is recovered as
+((y - keyB) * invA) mod m.
+
+Keys are validated to ensure that keyA and m are coprime and keyB is within the
+valid range. The example at the bottom encrypts a sample message and then
+decrypts it back to the original text.
+*/
+
+let SYMBOLS = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+
+fun gcd(a: int, b: int): int {
+  var x = a
+  var y = b
+  while y != 0 {
+    let temp = x % y
+    x = y
+    y = temp
+  }
+  return x
+}
+
+fun mod_inverse(a: int, m: int): int {
+  if gcd(a, m) != 1 {
+    panic("mod inverse of " + str(a) + " and " + str(m) + " does not exist")
+  }
+  var u1 = 1
+  var u2 = 0
+  var u3 = a
+  var v1 = 0
+  var v2 = 1
+  var v3 = m
+  while v3 != 0 {
+    let q = u3 / v3
+    let t1 = u1 - q * v1
+    let t2 = u2 - q * v2
+    let t3 = u3 - q * v3
+    u1 = v1
+    u2 = v2
+    u3 = v3
+    v1 = t1
+    v2 = t2
+    v3 = t3
+  }
+  let res = u1 % m
+  if res < 0 {
+    return res + m
+  }
+  return res
+}
+
+fun find_symbol(ch: string): int {
+  var i = 0
+  while i < len(SYMBOLS) {
+    if SYMBOLS[i] == ch {
+      return i
+    }
+    i = i + 1
+  }
+  return -1
+}
+
+fun check_keys(key_a: int, key_b: int, mode: string): void {
+  let m = len(SYMBOLS)
+  if mode == "encrypt" {
+    if key_a == 1 {
+      panic("The affine cipher becomes weak when key A is set to 1. Choose different key")
+    }
+    if key_b == 0 {
+      panic("The affine cipher becomes weak when key B is set to 0. Choose different key")
+    }
+  }
+  if key_a < 0 || key_b < 0 || key_b > m - 1 {
+    panic("Key A must be greater than 0 and key B must be between 0 and " + str(m - 1))
+  }
+  if gcd(key_a, m) != 1 {
+    panic("Key A " + str(key_a) + " and the symbol set size " + str(m) + " are not relatively prime. Choose a different key.")
+  }
+}
+
+fun encrypt_message(key: int, message: string): string {
+  let m = len(SYMBOLS)
+  let key_a = key / m
+  let key_b = key % m
+  check_keys(key_a, key_b, "encrypt")
+  var cipher_text = ""
+  var i = 0
+  while i < len(message) {
+    let ch = message[i]
+    let index = find_symbol(ch)
+    if index >= 0 {
+      cipher_text = cipher_text + SYMBOLS[(index * key_a + key_b) % m]
+    } else {
+      cipher_text = cipher_text + ch
+    }
+    i = i + 1
+  }
+  return cipher_text
+}
+
+fun decrypt_message(key: int, message: string): string {
+  let m = len(SYMBOLS)
+  let key_a = key / m
+  let key_b = key % m
+  check_keys(key_a, key_b, "decrypt")
+  let inv = mod_inverse(key_a, m)
+  var plain_text = ""
+  var i = 0
+  while i < len(message) {
+    let ch = message[i]
+    let index = find_symbol(ch)
+    if index >= 0 {
+      var n = (index - key_b) * inv
+      let pos = n % m
+      let final = if pos < 0 { pos + m } else { pos }
+      plain_text = plain_text + SYMBOLS[final]
+    } else {
+      plain_text = plain_text + ch
+    }
+    i = i + 1
+  }
+  return plain_text
+}
+
+fun main(): void {
+  let key = 4545
+  let msg = "The affine cipher is a type of monoalphabetic substitution cipher."
+  let enc = encrypt_message(key, msg)
+  print(enc)
+  print(decrypt_message(key, enc))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/ciphers/affine_cipher.out
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/affine_cipher.out
@@ -1,0 +1,2 @@
+VL}p MM{I}p~{HL}Gp{vp pFsH}pxMpyxIx JHL O}F{~pvuOvF{FuF{xIp~{HL}Gi
+The affine cipher is a type of monoalphabetic substitution cipher.

--- a/tests/github/TheAlgorithms/Python/ciphers/affine_cipher.py
+++ b/tests/github/TheAlgorithms/Python/ciphers/affine_cipher.py
@@ -1,0 +1,109 @@
+import random
+import sys
+
+from maths.greatest_common_divisor import gcd_by_iterative
+
+from . import cryptomath_module as cryptomath
+
+SYMBOLS = (
+    r""" !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`"""
+    r"""abcdefghijklmnopqrstuvwxyz{|}~"""
+)
+
+
+def check_keys(key_a: int, key_b: int, mode: str) -> None:
+    if mode == "encrypt":
+        if key_a == 1:
+            sys.exit(
+                "The affine cipher becomes weak when key "
+                "A is set to 1. Choose different key"
+            )
+        if key_b == 0:
+            sys.exit(
+                "The affine cipher becomes weak when key "
+                "B is set to 0. Choose different key"
+            )
+    if key_a < 0 or key_b < 0 or key_b > len(SYMBOLS) - 1:
+        sys.exit(
+            "Key A must be greater than 0 and key B must "
+            f"be between 0 and {len(SYMBOLS) - 1}."
+        )
+    if gcd_by_iterative(key_a, len(SYMBOLS)) != 1:
+        sys.exit(
+            f"Key A {key_a} and the symbol set size {len(SYMBOLS)} "
+            "are not relatively prime. Choose a different key."
+        )
+
+
+def encrypt_message(key: int, message: str) -> str:
+    """
+    >>> encrypt_message(4545, 'The affine cipher is a type of monoalphabetic '
+    ...                       'substitution cipher.')
+    'VL}p MM{I}p~{HL}Gp{vp pFsH}pxMpyxIx JHL O}F{~pvuOvF{FuF{xIp~{HL}Gi'
+    """
+    key_a, key_b = divmod(key, len(SYMBOLS))
+    check_keys(key_a, key_b, "encrypt")
+    cipher_text = ""
+    for symbol in message:
+        if symbol in SYMBOLS:
+            sym_index = SYMBOLS.find(symbol)
+            cipher_text += SYMBOLS[(sym_index * key_a + key_b) % len(SYMBOLS)]
+        else:
+            cipher_text += symbol
+    return cipher_text
+
+
+def decrypt_message(key: int, message: str) -> str:
+    """
+    >>> decrypt_message(4545, 'VL}p MM{I}p~{HL}Gp{vp pFsH}pxMpyxIx JHL O}F{~pvuOvF{FuF'
+    ...                       '{xIp~{HL}Gi')
+    'The affine cipher is a type of monoalphabetic substitution cipher.'
+    """
+    key_a, key_b = divmod(key, len(SYMBOLS))
+    check_keys(key_a, key_b, "decrypt")
+    plain_text = ""
+    mod_inverse_of_key_a = cryptomath.find_mod_inverse(key_a, len(SYMBOLS))
+    for symbol in message:
+        if symbol in SYMBOLS:
+            sym_index = SYMBOLS.find(symbol)
+            plain_text += SYMBOLS[
+                (sym_index - key_b) * mod_inverse_of_key_a % len(SYMBOLS)
+            ]
+        else:
+            plain_text += symbol
+    return plain_text
+
+
+def get_random_key() -> int:
+    while True:
+        key_b = random.randint(2, len(SYMBOLS))
+        key_b = random.randint(2, len(SYMBOLS))
+        if gcd_by_iterative(key_b, len(SYMBOLS)) == 1 and key_b % len(SYMBOLS) != 0:
+            return key_b * len(SYMBOLS) + key_b
+
+
+def main() -> None:
+    """
+    >>> key = get_random_key()
+    >>> msg = "This is a test!"
+    >>> decrypt_message(key, encrypt_message(key, msg)) == msg
+    True
+    """
+    message = input("Enter message: ").strip()
+    key = int(input("Enter key [2000 - 9000]: ").strip())
+    mode = input("Encrypt/Decrypt [E/D]: ").strip().lower()
+
+    if mode.startswith("e"):
+        mode = "encrypt"
+        translated = encrypt_message(key, message)
+    elif mode.startswith("d"):
+        mode = "decrypt"
+        translated = decrypt_message(key, message)
+    print(f"\n{mode.title()}ed text: \n{translated}")
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    # main()

--- a/tests/github/TheAlgorithms/Python/ciphers/cryptomath_module.py
+++ b/tests/github/TheAlgorithms/Python/ciphers/cryptomath_module.py
@@ -1,0 +1,13 @@
+from maths.greatest_common_divisor import gcd_by_iterative
+
+
+def find_mod_inverse(a: int, m: int) -> int:
+    if gcd_by_iterative(a, m) != 1:
+        msg = f"mod inverse of {a!r} and {m!r} does not exist"
+        raise ValueError(msg)
+    u1, u2, u3 = 1, 0, a
+    v1, v2, v3 = 0, 1, m
+    while v3 != 0:
+        q = u3 // v3
+        v1, v2, v3, u1, u2, u3 = (u1 - q * v1), (u2 - q * v2), (u3 - q * v3), v1, v2, v3
+    return u1 % m

--- a/tests/github/TheAlgorithms/Python/maths/greatest_common_divisor.py
+++ b/tests/github/TheAlgorithms/Python/maths/greatest_common_divisor.py
@@ -1,0 +1,77 @@
+"""
+Greatest Common Divisor.
+
+Wikipedia reference: https://en.wikipedia.org/wiki/Greatest_common_divisor
+
+gcd(a, b) = gcd(a, -b) = gcd(-a, b) = gcd(-a, -b) by definition of divisibility
+"""
+
+
+def greatest_common_divisor(a: int, b: int) -> int:
+    """
+    Calculate Greatest Common Divisor (GCD).
+    >>> greatest_common_divisor(24, 40)
+    8
+    >>> greatest_common_divisor(1, 1)
+    1
+    >>> greatest_common_divisor(1, 800)
+    1
+    >>> greatest_common_divisor(11, 37)
+    1
+    >>> greatest_common_divisor(3, 5)
+    1
+    >>> greatest_common_divisor(16, 4)
+    4
+    >>> greatest_common_divisor(-3, 9)
+    3
+    >>> greatest_common_divisor(9, -3)
+    3
+    >>> greatest_common_divisor(3, -9)
+    3
+    >>> greatest_common_divisor(-3, -9)
+    3
+    """
+    return abs(b) if a == 0 else greatest_common_divisor(b % a, a)
+
+
+def gcd_by_iterative(x: int, y: int) -> int:
+    """
+    Below method is more memory efficient because it does not create additional
+    stack frames for recursive functions calls (as done in the above method).
+    >>> gcd_by_iterative(24, 40)
+    8
+    >>> greatest_common_divisor(24, 40) == gcd_by_iterative(24, 40)
+    True
+    >>> gcd_by_iterative(-3, -9)
+    3
+    >>> gcd_by_iterative(3, -9)
+    3
+    >>> gcd_by_iterative(1, -800)
+    1
+    >>> gcd_by_iterative(11, 37)
+    1
+    """
+    while y:  # --> when y=0 then loop will terminate and return x as final GCD.
+        x, y = y, x % y
+    return abs(x)
+
+
+def main():
+    """
+    Call Greatest Common Divisor function.
+    """
+    try:
+        nums = input("Enter two integers separated by comma (,): ").split(",")
+        num_1 = int(nums[0])
+        num_2 = int(nums[1])
+        print(
+            f"greatest_common_divisor({num_1}, {num_2}) = "
+            f"{greatest_common_divisor(num_1, num_2)}"
+        )
+        print(f"By iterative gcd({num_1}, {num_2}) = {gcd_by_iterative(num_1, num_2)}")
+    except (IndexError, UnboundLocalError, ValueError):
+        print("Wrong input")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python affine cipher and supporting math utilities
- implement affine cipher in Mochi using printable ASCII set
- include sample execution output

## Testing
- `./bin/mochi lint tests/github/TheAlgorithms/Mochi/ciphers/affine_cipher.mochi`
- `./bin/mochi run tests/github/TheAlgorithms/Mochi/ciphers/affine_cipher.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891114e19608320999fc43296c486d9