### PR TITLE
Add Atbash cipher implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/ciphers/atbash.mochi
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/atbash.mochi
@@ -1,0 +1,51 @@
+/*
+Atbash cipher is a monoalphabetic substitution cipher that maps each letter
+to its reverse position in the alphabet. For the English alphabet this means
+'A' ↔ 'Z', 'B' ↔ 'Y', and so on. This implementation processes an input string,
+replacing each alphabetic character with its counterpart in the reversed
+alphabet while leaving non-alphabetic characters unchanged.
+
+The algorithm scans the string once, so its time complexity is O(n) where n
+is the length of the input. It uses a fixed amount of additional space.
+*/
+
+fun index_of(s: string, c: string): int {
+  var i = 0
+  while i < len(s) {
+    if s[i] == c {
+      return i
+    }
+    i = i + 1
+  }
+  return (-1)
+}
+
+fun atbash(sequence: string): string {
+  let lower = "abcdefghijklmnopqrstuvwxyz"
+  let upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  let lower_rev = "zyxwvutsrqponmlkjihgfedcba"
+  let upper_rev = "ZYXWVUTSRQPONMLKJIHGFEDCBA"
+  var result = ""
+  var i = 0
+  while i < len(sequence) {
+    let ch = sequence[i]
+    let idx = index_of(lower, ch)
+    if idx != (-1) {
+      result = result + lower_rev[idx]
+    } else {
+      let idx2 = index_of(upper, ch)
+        if idx2 != (-1) {
+        result = result + upper_rev[idx2]
+      } else {
+        result = result + ch
+      }
+    }
+    i = i + 1
+  }
+  return result
+}
+
+print(atbash("ABCDEFGH"))
+print(atbash("123GGjj"))
+print(atbash("testStringtest"))
+print(atbash("with space"))

--- a/tests/github/TheAlgorithms/Mochi/ciphers/atbash.out
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/atbash.out
@@ -1,0 +1,4 @@
+ZYXWVUTS
+123TTqq
+gvhgHgirmtgvhg
+drgs hkzxv

--- a/tests/github/TheAlgorithms/Python/ciphers/atbash.py
+++ b/tests/github/TheAlgorithms/Python/ciphers/atbash.py
@@ -1,0 +1,54 @@
+"""https://en.wikipedia.org/wiki/Atbash"""
+
+import string
+
+
+def atbash_slow(sequence: str) -> str:
+    """
+    >>> atbash_slow("ABCDEFG")
+    'ZYXWVUT'
+
+    >>> atbash_slow("aW;;123BX")
+    'zD;;123YC'
+    """
+    output = ""
+    for i in sequence:
+        extract = ord(i)
+        if 65 <= extract <= 90:
+            output += chr(155 - extract)
+        elif 97 <= extract <= 122:
+            output += chr(219 - extract)
+        else:
+            output += i
+    return output
+
+
+def atbash(sequence: str) -> str:
+    """
+    >>> atbash("ABCDEFG")
+    'ZYXWVUT'
+
+    >>> atbash("aW;;123BX")
+    'zD;;123YC'
+    """
+    letters = string.ascii_letters
+    letters_reversed = string.ascii_lowercase[::-1] + string.ascii_uppercase[::-1]
+    return "".join(
+        letters_reversed[letters.index(c)] if c in letters else c for c in sequence
+    )
+
+
+def benchmark() -> None:
+    """Let's benchmark our functions side-by-side..."""
+    from timeit import timeit
+
+    print("Running performance benchmarks...")
+    setup = "from string import printable ; from __main__ import atbash, atbash_slow"
+    print(f"> atbash_slow(): {timeit('atbash_slow(printable)', setup=setup)} seconds")
+    print(f">      atbash(): {timeit('atbash(printable)', setup=setup)} seconds")
+
+
+if __name__ == "__main__":
+    for example in ("ABCDEFGH", "123GGjj", "testStringtest", "with space"):
+        print(f"{example} encrypted in atbash: {atbash(example)}")
+    benchmark()


### PR DESCRIPTION
## Summary
- add Python reference implementation for Atbash cipher
- port Atbash cipher to Mochi with helper for character lookup and sample runs

## Testing
- `./bin/mochi run tests/github/TheAlgorithms/Mochi/ciphers/atbash.mochi`
- `npm test` *(fails: Missing script: "test")*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68915436caa4832081ce46bc467f08bd