### PR TITLE
Add Autokey cipher translation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/ciphers/autokey.mochi
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/autokey.mochi
@@ -1,0 +1,116 @@
+/*
+Autokey cipher implementation.
+
+The Autokey cipher is a polyalphabetic substitution cipher where the key is
+formed by concatenating a short secret key with the plaintext itself. During
+encryption we append the plaintext to the key and for each letter produce a new
+letter by adding the key letter and plaintext letter positions within the
+alphabet modulo 26. Non alphabetic characters are copied unchanged and they do
+not advance the key. Decryption repeats the process: for each ciphertext letter
+we subtract the key letter position to recover the plaintext. As each plaintext
+letter is recovered it is appended to the key so later letters can be decoded.
+This implementation only works on ASCII letters and keeps other characters as
+they are. Time complexity for both operations is O(n) where n is the length of
+input text.
+*/
+
+let LOWER = "abcdefghijklmnopqrstuvwxyz"
+let UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+fun to_lowercase(s: string): string {
+  var res = ""
+  var i = 0
+  while i < len(s) {
+    let c = s[i]
+    var j = 0
+    var found = false
+    while j < 26 {
+      if c == UPPER[j] {
+        res = res + LOWER[j]
+        found = true
+        break
+      }
+      j = j + 1
+    }
+    if !found {
+      res = res + c
+    }
+    i = i + 1
+  }
+  return res
+}
+
+fun char_index(c: string): int {
+  var i = 0
+  while i < 26 {
+    if c == LOWER[i] { return i }
+    i = i + 1
+  }
+  return -1
+}
+
+fun index_char(i: int): string {
+  return LOWER[i]
+}
+
+fun encrypt(plaintext: string, key: string): string {
+  if len(plaintext) == 0 { panic("plaintext is empty") }
+  if len(key) == 0 { panic("key is empty") }
+  var full_key = key + plaintext
+  plaintext = to_lowercase(plaintext)
+  full_key = to_lowercase(full_key)
+  var p_i = 0
+  var k_i = 0
+  var ciphertext = ""
+  while p_i < len(plaintext) {
+    let p_char = plaintext[p_i]
+    let p_idx = char_index(p_char)
+    if p_idx < 0 {
+      ciphertext = ciphertext + p_char
+      p_i = p_i + 1
+    } else {
+      let k_char = full_key[k_i]
+      let k_idx = char_index(k_char)
+      if k_idx < 0 {
+        k_i = k_i + 1
+      } else {
+        let c_idx = (p_idx + k_idx) % 26
+        ciphertext = ciphertext + index_char(c_idx)
+        k_i = k_i + 1
+        p_i = p_i + 1
+      }
+    }
+  }
+  return ciphertext
+}
+
+fun decrypt(ciphertext: string, key: string): string {
+  if len(ciphertext) == 0 { panic("ciphertext is empty") }
+  if len(key) == 0 { panic("key is empty") }
+  var current_key = to_lowercase(key)
+  var c_i = 0
+  var k_i = 0
+  var plaintext = ""
+  while c_i < len(ciphertext) {
+    let c_char = ciphertext[c_i]
+    let c_idx = char_index(c_char)
+    if c_idx < 0 {
+      plaintext = plaintext + c_char
+    } else {
+      let k_char = current_key[k_i]
+      let k_idx = char_index(k_char)
+      let p_idx = (c_idx - k_idx + 26) % 26
+      let p_char = index_char(p_idx)
+      plaintext = plaintext + p_char
+      current_key = current_key + p_char
+      k_i = k_i + 1
+    }
+    c_i = c_i + 1
+  }
+  return plaintext
+}
+
+print(encrypt("hello world", "coffee"))
+print(decrypt("jsqqs avvwo", "coffee"))
+print(encrypt("coffee is good as python", "TheAlgorithms"))
+print(decrypt("vvjfpk wj ohvp su ddylsv", "TheAlgorithms"))

--- a/tests/github/TheAlgorithms/Mochi/ciphers/autokey.mochi.out
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/autokey.mochi.out
@@ -1,0 +1,4 @@
+jsqqs avvwo
+hello world
+vvjfpk wj ohvp su ddylsv
+coffee is good as python

--- a/tests/github/TheAlgorithms/Python/ciphers/autokey.py
+++ b/tests/github/TheAlgorithms/Python/ciphers/autokey.py
@@ -1,0 +1,150 @@
+"""
+https://en.wikipedia.org/wiki/Autokey_cipher
+
+An autokey cipher (also known as the autoclave cipher) is a cipher that
+incorporates the message (the plaintext) into the key.
+The key is generated from the message in some automated fashion,
+sometimes by selecting certain letters from the text or, more commonly,
+by adding a short primer key to the front of the message.
+"""
+
+
+def encrypt(plaintext: str, key: str) -> str:
+    """
+    Encrypt a given `plaintext` (string) and `key` (string), returning the
+    encrypted ciphertext.
+
+    >>> encrypt("hello world", "coffee")
+    'jsqqs avvwo'
+    >>> encrypt("coffee is good as python", "TheAlgorithms")
+    'vvjfpk wj ohvp su ddylsv'
+    >>> encrypt("coffee is good as python", 2)
+    Traceback (most recent call last):
+        ...
+    TypeError: key must be a string
+    >>> encrypt("", "TheAlgorithms")
+    Traceback (most recent call last):
+        ...
+    ValueError: plaintext is empty
+    >>> encrypt("coffee is good as python", "")
+    Traceback (most recent call last):
+        ...
+    ValueError: key is empty
+    >>> encrypt(527.26, "TheAlgorithms")
+    Traceback (most recent call last):
+        ...
+    TypeError: plaintext must be a string
+    """
+    if not isinstance(plaintext, str):
+        raise TypeError("plaintext must be a string")
+    if not isinstance(key, str):
+        raise TypeError("key must be a string")
+
+    if not plaintext:
+        raise ValueError("plaintext is empty")
+    if not key:
+        raise ValueError("key is empty")
+
+    key += plaintext
+    plaintext = plaintext.lower()
+    key = key.lower()
+    plaintext_iterator = 0
+    key_iterator = 0
+    ciphertext = ""
+    while plaintext_iterator < len(plaintext):
+        if (
+            ord(plaintext[plaintext_iterator]) < 97
+            or ord(plaintext[plaintext_iterator]) > 122
+        ):
+            ciphertext += plaintext[plaintext_iterator]
+            plaintext_iterator += 1
+        elif ord(key[key_iterator]) < 97 or ord(key[key_iterator]) > 122:
+            key_iterator += 1
+        else:
+            ciphertext += chr(
+                (
+                    (ord(plaintext[plaintext_iterator]) - 97 + ord(key[key_iterator]))
+                    - 97
+                )
+                % 26
+                + 97
+            )
+            key_iterator += 1
+            plaintext_iterator += 1
+    return ciphertext
+
+
+def decrypt(ciphertext: str, key: str) -> str:
+    """
+    Decrypt a given `ciphertext` (string) and `key` (string), returning the decrypted
+    ciphertext.
+
+    >>> decrypt("jsqqs avvwo", "coffee")
+    'hello world'
+    >>> decrypt("vvjfpk wj ohvp su ddylsv", "TheAlgorithms")
+    'coffee is good as python'
+    >>> decrypt("vvjfpk wj ohvp su ddylsv", "")
+    Traceback (most recent call last):
+        ...
+    ValueError: key is empty
+    >>> decrypt(527.26, "TheAlgorithms")
+    Traceback (most recent call last):
+        ...
+    TypeError: ciphertext must be a string
+    >>> decrypt("", "TheAlgorithms")
+    Traceback (most recent call last):
+        ...
+    ValueError: ciphertext is empty
+    >>> decrypt("vvjfpk wj ohvp su ddylsv", 2)
+    Traceback (most recent call last):
+        ...
+    TypeError: key must be a string
+    """
+    if not isinstance(ciphertext, str):
+        raise TypeError("ciphertext must be a string")
+    if not isinstance(key, str):
+        raise TypeError("key must be a string")
+
+    if not ciphertext:
+        raise ValueError("ciphertext is empty")
+    if not key:
+        raise ValueError("key is empty")
+
+    key = key.lower()
+    ciphertext_iterator = 0
+    key_iterator = 0
+    plaintext = ""
+    while ciphertext_iterator < len(ciphertext):
+        if (
+            ord(ciphertext[ciphertext_iterator]) < 97
+            or ord(ciphertext[ciphertext_iterator]) > 122
+        ):
+            plaintext += ciphertext[ciphertext_iterator]
+        else:
+            plaintext += chr(
+                (ord(ciphertext[ciphertext_iterator]) - ord(key[key_iterator])) % 26
+                + 97
+            )
+            key += chr(
+                (ord(ciphertext[ciphertext_iterator]) - ord(key[key_iterator])) % 26
+                + 97
+            )
+            key_iterator += 1
+        ciphertext_iterator += 1
+    return plaintext
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    operation = int(input("Type 1 to encrypt or 2 to decrypt:"))
+    if operation == 1:
+        plaintext = input("Typeplaintext to be encrypted:\n")
+        key = input("Type the key:\n")
+        print(encrypt(plaintext, key))
+    elif operation == 2:
+        ciphertext = input("Type the ciphertext to be decrypted:\n")
+        key = input("Type the key:\n")
+        print(decrypt(ciphertext, key))
+    decrypt("jsqqs avvwo", "coffee")


### PR DESCRIPTION
## Summary
- add Python reference implementation for Autokey cipher
- implement Autokey cipher encryption and decryption in pure Mochi
- include runtime output from running the Mochi translation

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/ciphers/autokey.mochi`
- `go test ./runtime/vm`


------
https://chatgpt.com/codex/tasks/task_e_6891543fcbd48320ad63dbcda0c6b678