### PR TITLE
Add Beaufort cipher example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/ciphers/beaufort_cipher.mochi
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/beaufort_cipher.mochi
@@ -1,0 +1,72 @@
+/*
+Beaufort Cipher Implementation
+
+The Beaufort cipher is a substitution cipher similar to the Vigenère cipher
+but uses a slightly different encryption algorithm. A key is repeated to the
+length of the message. For each alphabetic character, the cipher subtracts
+its key character position from the plaintext character position (mod 26)
+producing the ciphertext. Decryption adds the key character position to the
+ciphertext character position (mod 26) to recover the original message.
+
+This implementation handles only uppercase English letters and preserves
+spaces in the input message.
+*/
+
+let ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+fun index_of(ch: string): int {
+  for i in 0..len(ALPHABET) {
+    if ALPHABET[i] == ch { return i }
+  }
+  return -1
+}
+
+fun generate_key(message: string, key: string): string {
+  var key_new = key
+  var i = 0
+  while len(key_new) < len(message) {
+    key_new = key_new + key[i]
+    i = i + 1
+    if i == len(key) { i = 0 }
+  }
+  return key_new
+}
+
+fun cipher_text(message: string, key_new: string): string {
+  var res = ""
+  var i = 0
+  for idx in 0..len(message) {
+    let ch = message[idx]
+    if ch == " " {
+      res = res + " "
+    } else {
+      let x = (index_of(ch) - index_of(key_new[i]) + 26) % 26
+      i = i + 1
+      res = res + ALPHABET[x]
+    }
+  }
+  return res
+}
+
+fun original_text(cipher: string, key_new: string): string {
+  var res = ""
+  var i = 0
+  for idx in 0..len(cipher) {
+    let ch = cipher[idx]
+    if ch == " " {
+      res = res + " "
+    } else {
+      let x = (index_of(ch) + index_of(key_new[i]) + 26) % 26
+      i = i + 1
+      res = res + ALPHABET[x]
+    }
+  }
+  return res
+}
+
+let message = "THE GERMAN ATTACK"
+let key = "SECRET"
+let key_new = generate_key(message, key)
+let encrypted = cipher_text(message, key_new)
+print("Encrypted Text = " + encrypted)
+print("Original Text = " + original_text(encrypted, key_new))

--- a/tests/github/TheAlgorithms/Mochi/ciphers/beaufort_cipher.out
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/beaufort_cipher.out
@@ -1,0 +1,2 @@
+Encrypted Text = BDC PAYUWL JPAIYI
+Original Text = THE GERMAN ATTACK

--- a/tests/github/TheAlgorithms/Python/ciphers/beaufort_cipher.py
+++ b/tests/github/TheAlgorithms/Python/ciphers/beaufort_cipher.py
@@ -1,0 +1,82 @@
+"""
+Author: Mohit Radadiya
+"""
+
+from string import ascii_uppercase
+
+dict1 = {char: i for i, char in enumerate(ascii_uppercase)}
+dict2 = dict(enumerate(ascii_uppercase))
+
+
+# This function generates the key in
+# a cyclic manner until it's length isn't
+# equal to the length of original text
+def generate_key(message: str, key: str) -> str:
+    """
+    >>> generate_key("THE GERMAN ATTACK","SECRET")
+    'SECRETSECRETSECRE'
+    """
+    x = len(message)
+    i = 0
+    while True:
+        if x == i:
+            i = 0
+        if len(key) == len(message):
+            break
+        key += key[i]
+        i += 1
+    return key
+
+
+# This function returns the encrypted text
+# generated with the help of the key
+def cipher_text(message: str, key_new: str) -> str:
+    """
+    >>> cipher_text("THE GERMAN ATTACK","SECRETSECRETSECRE")
+    'BDC PAYUWL JPAIYI'
+    """
+    cipher_text = ""
+    i = 0
+    for letter in message:
+        if letter == " ":
+            cipher_text += " "
+        else:
+            x = (dict1[letter] - dict1[key_new[i]]) % 26
+            i += 1
+            cipher_text += dict2[x]
+    return cipher_text
+
+
+# This function decrypts the encrypted text
+# and returns the original text
+def original_text(cipher_text: str, key_new: str) -> str:
+    """
+    >>> original_text("BDC PAYUWL JPAIYI","SECRETSECRETSECRE")
+    'THE GERMAN ATTACK'
+    """
+    or_txt = ""
+    i = 0
+    for letter in cipher_text:
+        if letter == " ":
+            or_txt += " "
+        else:
+            x = (dict1[letter] + dict1[key_new[i]] + 26) % 26
+            i += 1
+            or_txt += dict2[x]
+    return or_txt
+
+
+def main() -> None:
+    message = "THE GERMAN ATTACK"
+    key = "SECRET"
+    key_new = generate_key(message, key)
+    s = cipher_text(message, key_new)
+    print(f"Encrypted Text = {s}")
+    print(f"Original Text = {original_text(s, key_new)}")
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    main()


### PR DESCRIPTION
## Summary
- add Python reference implementation for Beaufort cipher
- implement Beaufort cipher in Mochi with key generation, encryption, and decryption
- include runtime output for verification

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/ciphers/beaufort_cipher.mochi`

------
https://chatgpt.com/codex/tasks/task_e_68915476acc88320b2f2bdb353f1637a