### PR TITLE
Implement Bifid cipher in Mochi

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/ciphers/bifid.mochi
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/bifid.mochi
@@ -1,0 +1,146 @@
+/*
+Encode and decode messages using the Bifid cipher.
+
+The Bifid cipher combines the Polybius square with transposition.  Each
+letter is located in a 5x5 grid (I/J share a cell) producing a row and
+column number.  For encoding, the message is first converted to lowercase,
+spaces are removed, and the letter 'j' is replaced with 'i'.  The row and
+column numbers of all letters are collected separately.  The two sequences
+are concatenated and then read in pairs to look up the final encrypted
+letters.  Decoding reverses this process by splitting the combined number
+sequence back into row and column halves before looking up letters in the
+grid again.
+
+This implementation uses only pure Mochi code with explicit integer and
+string types.
+*/
+
+let SQUARE: list<list<string>> = [
+  ["a", "b", "c", "d", "e"],
+  ["f", "g", "h", "i", "k"],
+  ["l", "m", "n", "o", "p"],
+  ["q", "r", "s", "t", "u"],
+  ["v", "w", "x", "y", "z"]
+]
+
+fun index_of(s: string, ch: string): int {
+  var i = 0
+  while i < len(s) {
+    if s[i] == ch {
+      return i
+    }
+    i = i + 1
+  }
+  return -1
+}
+
+fun to_lower_without_spaces(message: string, replace_j: bool): string {
+  let upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  let lower = "abcdefghijklmnopqrstuvwxyz"
+  var res = ""
+  var i = 0
+  while i < len(message) {
+    var ch = message[i]
+    let pos = index_of(upper, ch)
+    if pos >= 0 {
+      ch = lower[pos]
+    }
+    if ch != " " {
+      if replace_j && ch == "j" {
+        ch = "i"
+      }
+      res = res + ch
+    }
+    i = i + 1
+  }
+  return res
+}
+
+fun letter_to_numbers(letter: string): list<int> {
+  var r = 0
+  while r < len(SQUARE) {
+    var c = 0
+    while c < len(SQUARE[r]) {
+      if SQUARE[r][c] == letter {
+        return [r + 1, c + 1] as list<int>
+      }
+      c = c + 1
+    }
+    r = r + 1
+  }
+  return [0, 0] as list<int>
+}
+
+fun numbers_to_letter(row: int, col: int): string {
+  return SQUARE[row - 1][col - 1]
+}
+
+fun encode(message: string): string {
+  let clean = to_lower_without_spaces(message, true)
+  let l = len(clean)
+  var rows: list<int> = [] as list<int>
+  var cols: list<int> = [] as list<int>
+  var i = 0
+  while i < l {
+    let nums = letter_to_numbers(clean[i])
+    rows = append(rows, nums[0])
+    cols = append(cols, nums[1])
+    i = i + 1
+  }
+  var seq: list<int> = [] as list<int>
+  i = 0
+  while i < l {
+    seq = append(seq, rows[i])
+    i = i + 1
+  }
+  i = 0
+  while i < l {
+    seq = append(seq, cols[i])
+    i = i + 1
+  }
+  var encoded = ""
+  i = 0
+  while i < l {
+    let r = seq[2 * i]
+    let c = seq[2 * i + 1]
+    encoded = encoded + numbers_to_letter(r, c)
+    i = i + 1
+  }
+  return encoded
+}
+
+fun decode(message: string): string {
+  let clean = to_lower_without_spaces(message, false)
+  let l = len(clean)
+  var first: list<int> = [] as list<int>
+  var i = 0
+  while i < l {
+    let nums = letter_to_numbers(clean[i])
+    first = append(first, nums[0])
+    first = append(first, nums[1])
+    i = i + 1
+  }
+  var top: list<int> = [] as list<int>
+  var bottom: list<int> = [] as list<int>
+  i = 0
+  while i < l {
+    top = append(top, first[i])
+    bottom = append(bottom, first[i + l])
+    i = i + 1
+  }
+  var decoded = ""
+  i = 0
+  while i < l {
+    let r = top[i]
+    let c = bottom[i]
+    decoded = decoded + numbers_to_letter(r, c)
+    i = i + 1
+  }
+  return decoded
+}
+
+print(encode("testmessage"))
+print(encode("Test Message"))
+print(encode("test j"))
+print(encode("test i"))
+print(decode("qtltbdxrxlk"))

--- a/tests/github/TheAlgorithms/Mochi/ciphers/bifid.out
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/bifid.out
@@ -1,0 +1,5 @@
+qtltbdxrxlk
+qtltbdxrxlk
+qtixt
+qtixt
+testmessage

--- a/tests/github/TheAlgorithms/Python/ciphers/bifid.py
+++ b/tests/github/TheAlgorithms/Python/ciphers/bifid.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+
+"""
+The Bifid Cipher uses a Polybius Square to encipher a message in a way that
+makes it fairly difficult to decipher without knowing the secret.
+
+https://www.braingle.com/brainteasers/codes/bifid.php
+"""
+
+import numpy as np
+
+SQUARE = [
+    ["a", "b", "c", "d", "e"],
+    ["f", "g", "h", "i", "k"],
+    ["l", "m", "n", "o", "p"],
+    ["q", "r", "s", "t", "u"],
+    ["v", "w", "x", "y", "z"],
+]
+
+
+class BifidCipher:
+    def __init__(self) -> None:
+        self.SQUARE = np.array(SQUARE)
+
+    def letter_to_numbers(self, letter: str) -> np.ndarray:
+        """
+        Return the pair of numbers that represents the given letter in the
+        polybius square
+
+        >>> np.array_equal(BifidCipher().letter_to_numbers('a'), [1,1])
+        True
+
+        >>> np.array_equal(BifidCipher().letter_to_numbers('u'), [4,5])
+        True
+        """
+        index1, index2 = np.where(letter == self.SQUARE)
+        indexes = np.concatenate([index1 + 1, index2 + 1])
+        return indexes
+
+    def numbers_to_letter(self, index1: int, index2: int) -> str:
+        """
+        Return the letter corresponding to the position [index1, index2] in
+        the polybius square
+
+        >>> BifidCipher().numbers_to_letter(4, 5) == "u"
+        True
+
+        >>> BifidCipher().numbers_to_letter(1, 1) == "a"
+        True
+        """
+        letter = self.SQUARE[index1 - 1, index2 - 1]
+        return letter
+
+    def encode(self, message: str) -> str:
+        """
+        Return the encoded version of message according to the polybius cipher
+
+        >>> BifidCipher().encode('testmessage') == 'qtltbdxrxlk'
+        True
+
+        >>> BifidCipher().encode('Test Message') == 'qtltbdxrxlk'
+        True
+
+        >>> BifidCipher().encode('test j') == BifidCipher().encode('test i')
+        True
+        """
+        message = message.lower()
+        message = message.replace(" ", "")
+        message = message.replace("j", "i")
+
+        first_step = np.empty((2, len(message)))
+        for letter_index in range(len(message)):
+            numbers = self.letter_to_numbers(message[letter_index])
+
+            first_step[0, letter_index] = numbers[0]
+            first_step[1, letter_index] = numbers[1]
+
+        second_step = first_step.reshape(2 * len(message))
+        encoded_message = ""
+        for numbers_index in range(len(message)):
+            index1 = int(second_step[numbers_index * 2])
+            index2 = int(second_step[(numbers_index * 2) + 1])
+            letter = self.numbers_to_letter(index1, index2)
+            encoded_message = encoded_message + letter
+
+        return encoded_message
+
+    def decode(self, message: str) -> str:
+        """
+        Return the decoded version of message according to the polybius cipher
+
+        >>> BifidCipher().decode('qtltbdxrxlk') == 'testmessage'
+        True
+        """
+        message = message.lower()
+        message.replace(" ", "")
+        first_step = np.empty(2 * len(message))
+        for letter_index in range(len(message)):
+            numbers = self.letter_to_numbers(message[letter_index])
+            first_step[letter_index * 2] = numbers[0]
+            first_step[letter_index * 2 + 1] = numbers[1]
+
+        second_step = first_step.reshape((2, len(message)))
+        decoded_message = ""
+        for numbers_index in range(len(message)):
+            index1 = int(second_step[0, numbers_index])
+            index2 = int(second_step[1, numbers_index])
+            letter = self.numbers_to_letter(index1, index2)
+            decoded_message = decoded_message + letter
+
+        return decoded_message


### PR DESCRIPTION
## Summary
- add upstream Python reference for Bifid cipher
- implement Bifid cipher encode/decode in pure Mochi
- include VM output verifying correctness

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/ciphers/bifid.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891547fd61c83209b966bdf0697e1a0