### PR TITLE
Add Fractionated Morse Cipher example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/ciphers/fractionated_morse_cipher.mochi
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/fractionated_morse_cipher.mochi
@@ -1,0 +1,215 @@
+/*
+Fractionated Morse Cipher implementation in Mochi.
+
+This classical cipher first converts plaintext to Morse code where each letter
+is translated to dots and dashes and separated by 'x'.  The resulting Morse
+string is padded with 'x' so its length is a multiple of three.  Every group of
+three symbols (trigram) is then mapped to a letter using a key-derived alphabet,
+which mixes plaintext letters across the ciphertext making simple frequency
+analysis difficult.
+
+Decryption reverses the process: the key reconstructs the trigram mapping,
+ciphertext letters are expanded back into Morse trigrams, and the Morse code is
+split on 'x' boundaries to recover the original characters.
+*/
+
+let MORSE_CODE_DICT: map<string, string> = {
+  "A": ".-",
+  "B": "-...",
+  "C": "-.-.",
+  "D": "-..",
+  "E": ".",
+  "F": "..-.",
+  "G": "--.",
+  "H": "....",
+  "I": "..",
+  "J": ".---",
+  "K": "-.-",
+  "L": ".-..",
+  "M": "--",
+  "N": "-.",
+  "O": "---",
+  "P": ".--.",
+  "Q": "--.-",
+  "R": ".-.",
+  "S": "...",
+  "T": "-",
+  "U": "..-",
+  "V": "...-",
+  "W": ".--",
+  "X": "-..-",
+  "Y": "-.--",
+  "Z": "--..",
+  " ": ""
+}
+
+let MORSE_COMBINATIONS: list<string> = [
+  "...", "..-", "..x", ".-.", ".--", ".-x", ".x.", ".x-", ".xx",
+  "-..", "-.-", "-.x", "--.", "---", "--x", "-x.", "-x-", "-xx",
+  "x..", "x.-", "x.x", "x-.", "x--", "x-x", "xx.", "xx-", "xxx"
+]
+
+let REVERSE_DICT: map<string, string> = {
+  ".-": "A",
+  "-...": "B",
+  "-.-.": "C",
+  "-..": "D",
+  ".": "E",
+  "..-.": "F",
+  "--.": "G",
+  "....": "H",
+  "..": "I",
+  ".---": "J",
+  "-.-": "K",
+  ".-..": "L",
+  "--": "M",
+  "-.": "N",
+  "---": "O",
+  ".--.": "P",
+  "--.-": "Q",
+  ".-.": "R",
+  "...": "S",
+  "-": "T",
+  "..-": "U",
+  "...-": "V",
+  ".--": "W",
+  "-..-": "X",
+  "-.--": "Y",
+  "--..": "Z",
+  "": " "
+}
+
+fun encodeToMorse(plaintext: string): string {
+  var morse = ""
+  var i = 0
+  while i < len(plaintext) {
+    let ch = upper(plaintext[i:i+1])
+    var code = ""
+    if ch in MORSE_CODE_DICT {
+      code = MORSE_CODE_DICT[ch]
+    }
+    if i > 0 {
+      morse = morse + "x"
+    }
+    morse = morse + code
+    i = i + 1
+  }
+  return morse
+}
+
+fun encryptFractionatedMorse(plaintext: string, key: string): string {
+  var morseCode = encodeToMorse(plaintext)
+  var combinedKey = upper(key) + "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  var dedupKey = ""
+  var i = 0
+  while i < len(combinedKey) {
+    let ch = combinedKey[i:i+1]
+    if !(ch in dedupKey) {
+      dedupKey = dedupKey + ch
+    }
+    i = i + 1
+  }
+  var paddingLength = 3 - (len(morseCode) % 3)
+  var p = 0
+  while p < paddingLength {
+    morseCode = morseCode + "x"
+    p = p + 1
+  }
+  var dict: map<string, string> = {}
+  var j = 0
+  while j < 26 {
+    let combo = MORSE_COMBINATIONS[j]
+    let letter = dedupKey[j:j+1]
+    dict[combo] = letter
+    j = j + 1
+  }
+  dict["xxx"] = ""
+  var encrypted = ""
+  var k = 0
+  while k < len(morseCode) {
+    let group = morseCode[k:k+3]
+    encrypted = encrypted + dict[group]
+    k = k + 3
+  }
+  return encrypted
+}
+
+fun decryptFractionatedMorse(ciphertext: string, key: string): string {
+  var combinedKey = upper(key) + "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  var dedupKey = ""
+  var i = 0
+  while i < len(combinedKey) {
+    let ch = combinedKey[i:i+1]
+    if !(ch in dedupKey) {
+      dedupKey = dedupKey + ch
+    }
+    i = i + 1
+  }
+  var inv: map<string, string> = {}
+  var j = 0
+  while j < 26 {
+    let letter = dedupKey[j:j+1]
+    inv[letter] = MORSE_COMBINATIONS[j]
+    j = j + 1
+  }
+  var morse = ""
+  var k = 0
+  while k < len(ciphertext) {
+    let ch = ciphertext[k:k+1]
+    if ch in inv {
+      morse = morse + inv[ch]
+    }
+    k = k + 1
+  }
+  var codes: list<string> = []
+  var current = ""
+  var m = 0
+  while m < len(morse) {
+    let ch = morse[m:m+1]
+    if ch == "x" {
+      codes = append(codes, current)
+      current = ""
+    } else {
+      current = current + ch
+    }
+    m = m + 1
+  }
+  codes = append(codes, current)
+  var decrypted = ""
+  var idx = 0
+  while idx < len(codes) {
+    let code = codes[idx]
+    decrypted = decrypted + REVERSE_DICT[code]
+    idx = idx + 1
+  }
+  var start = 0
+  while true {
+    if start < len(decrypted) {
+      if decrypted[start:start+1] == " " {
+        start = start + 1
+        continue
+      }
+    }
+    break
+  }
+  var end = len(decrypted)
+  while true {
+    if end > start {
+      if decrypted[end-1:end] == " " {
+        end = end - 1
+        continue
+      }
+    }
+    break
+  }
+  return decrypted[start:end]
+}
+
+let plaintext = "defend the east"
+print("Plain Text:", plaintext)
+let key = "ROUNDTABLE"
+let ciphertext = encryptFractionatedMorse(plaintext, key)
+print("Encrypted:", ciphertext)
+let decrypted = decryptFractionatedMorse(ciphertext, key)
+print("Decrypted:", decrypted)
+

--- a/tests/github/TheAlgorithms/Mochi/ciphers/fractionated_morse_cipher.out
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/fractionated_morse_cipher.out
@@ -1,0 +1,3 @@
+Plain Text: defend the east
+Encrypted: ESOAVVLJRSSTRX
+Decrypted: DEFEND THE EAST

--- a/tests/github/TheAlgorithms/Python/ciphers/fractionated_morse_cipher.py
+++ b/tests/github/TheAlgorithms/Python/ciphers/fractionated_morse_cipher.py
@@ -1,0 +1,168 @@
+"""
+Python program for the Fractionated Morse Cipher.
+
+The Fractionated Morse cipher first converts the plaintext to Morse code,
+then enciphers fixed-size blocks of Morse code back to letters.
+This procedure means plaintext letters are mixed into the ciphertext letters,
+making it more secure than substitution ciphers.
+
+http://practicalcryptography.com/ciphers/fractionated-morse-cipher/
+"""
+
+import string
+
+MORSE_CODE_DICT = {
+    "A": ".-",
+    "B": "-...",
+    "C": "-.-.",
+    "D": "-..",
+    "E": ".",
+    "F": "..-.",
+    "G": "--.",
+    "H": "....",
+    "I": "..",
+    "J": ".---",
+    "K": "-.-",
+    "L": ".-..",
+    "M": "--",
+    "N": "-.",
+    "O": "---",
+    "P": ".--.",
+    "Q": "--.-",
+    "R": ".-.",
+    "S": "...",
+    "T": "-",
+    "U": "..-",
+    "V": "...-",
+    "W": ".--",
+    "X": "-..-",
+    "Y": "-.--",
+    "Z": "--..",
+    " ": "",
+}
+
+# Define possible trigrams of Morse code
+MORSE_COMBINATIONS = [
+    "...",
+    "..-",
+    "..x",
+    ".-.",
+    ".--",
+    ".-x",
+    ".x.",
+    ".x-",
+    ".xx",
+    "-..",
+    "-.-",
+    "-.x",
+    "--.",
+    "---",
+    "--x",
+    "-x.",
+    "-x-",
+    "-xx",
+    "x..",
+    "x.-",
+    "x.x",
+    "x-.",
+    "x--",
+    "x-x",
+    "xx.",
+    "xx-",
+    "xxx",
+]
+
+# Create a reverse dictionary for Morse code
+REVERSE_DICT = {value: key for key, value in MORSE_CODE_DICT.items()}
+
+
+def encode_to_morse(plaintext: str) -> str:
+    """Encode a plaintext message into Morse code.
+
+    Args:
+        plaintext: The plaintext message to encode.
+
+    Returns:
+        The Morse code representation of the plaintext message.
+
+    Example:
+        >>> encode_to_morse("defend the east")
+        '-..x.x..-.x.x-.x-..xx-x....x.xx.x.-x...x-'
+    """
+    return "x".join([MORSE_CODE_DICT.get(letter.upper(), "") for letter in plaintext])
+
+
+def encrypt_fractionated_morse(plaintext: str, key: str) -> str:
+    """Encrypt a plaintext message using Fractionated Morse Cipher.
+
+    Args:
+        plaintext: The plaintext message to encrypt.
+        key: The encryption key.
+
+    Returns:
+        The encrypted ciphertext.
+
+    Example:
+        >>> encrypt_fractionated_morse("defend the east","Roundtable")
+        'ESOAVVLJRSSTRX'
+
+    """
+    morse_code = encode_to_morse(plaintext)
+    key = key.upper() + string.ascii_uppercase
+    key = "".join(sorted(set(key), key=key.find))
+
+    # Ensure morse_code length is a multiple of 3
+    padding_length = 3 - (len(morse_code) % 3)
+    morse_code += "x" * padding_length
+
+    fractionated_morse_dict = {v: k for k, v in zip(key, MORSE_COMBINATIONS)}
+    fractionated_morse_dict["xxx"] = ""
+    encrypted_text = "".join(
+        [
+            fractionated_morse_dict[morse_code[i : i + 3]]
+            for i in range(0, len(morse_code), 3)
+        ]
+    )
+    return encrypted_text
+
+
+def decrypt_fractionated_morse(ciphertext: str, key: str) -> str:
+    """Decrypt a ciphertext message encrypted with Fractionated Morse Cipher.
+
+    Args:
+        ciphertext: The ciphertext message to decrypt.
+        key: The decryption key.
+
+    Returns:
+        The decrypted plaintext message.
+
+    Example:
+        >>> decrypt_fractionated_morse("ESOAVVLJRSSTRX","Roundtable")
+        'DEFEND THE EAST'
+    """
+    key = key.upper() + string.ascii_uppercase
+    key = "".join(sorted(set(key), key=key.find))
+
+    inverse_fractionated_morse_dict = dict(zip(key, MORSE_COMBINATIONS))
+    morse_code = "".join(
+        [inverse_fractionated_morse_dict.get(letter, "") for letter in ciphertext]
+    )
+    decrypted_text = "".join(
+        [REVERSE_DICT[code] for code in morse_code.split("x")]
+    ).strip()
+    return decrypted_text
+
+
+if __name__ == "__main__":
+    """
+    Example usage of Fractionated Morse Cipher.
+    """
+    plaintext = "defend the east"
+    print("Plain Text:", plaintext)
+    key = "ROUNDTABLE"
+
+    ciphertext = encrypt_fractionated_morse(plaintext, key)
+    print("Encrypted:", ciphertext)
+
+    decrypted_text = decrypt_fractionated_morse(ciphertext, key)
+    print("Decrypted:", decrypted_text)


### PR DESCRIPTION
## Summary
- add Python source for Fractionated Morse cipher
- implement Fractionated Morse cipher in pure Mochi with encode, encrypt, and decrypt routines
- include sample execution output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/ciphers/fractionated_morse_cipher.mochi`


------
https://chatgpt.com/codex/tasks/task_e_689154ebf7e483209acaec2fda7f797f