### PR TITLE
Add monoalphabetic cipher example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/ciphers/mono_alphabetic_ciphers.mochi
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/mono_alphabetic_ciphers.mochi
@@ -1,0 +1,91 @@
+/*
+Monoalphabetic Substitution Cipher
+
+This cipher substitutes each letter in the plaintext with a corresponding letter
+from a fixed key. The key is a permutation of the alphabet that defines the
+mapping. To encrypt, each plaintext letter is replaced by the letter at the same
+position in the key. To decrypt, the process is reversed, mapping characters
+from the key back to the standard alphabet.
+
+Non-alphabetic characters are left unchanged. The algorithm iterates through the
+input message, finds the index of each letter (case-insensitive) in the source
+alphabet (either the standard alphabet for encryption or the key for
+decryption), and appends the matching character from the target alphabet,
+preserving the original case. Time complexity is O(n) for a message of length n.
+*/
+
+let LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+fun find_char(s: string, ch: string): int {
+  var i = 0
+  while i < len(s) {
+    if s[i] == ch { return i }
+    i = i + 1
+  }
+  return -1
+}
+
+fun encrypt_message(key: string, message: string): string {
+  let chars_a = key
+  let chars_b = LETTERS
+  var translated = ""
+  var i = 0
+  while i < len(message) {
+    let symbol = message[i]
+    let upper_sym = upper(symbol)
+    let sym_index = find_char(chars_a, upper_sym)
+    if sym_index >= 0 {
+      let sub_char = chars_b[sym_index]
+      if symbol == upper_sym {
+        translated = translated + upper(sub_char)
+      } else {
+        translated = translated + lower(sub_char)
+      }
+    } else {
+      translated = translated + symbol
+    }
+    i = i + 1
+  }
+  return translated
+}
+
+fun decrypt_message(key: string, message: string): string {
+  let chars_a = LETTERS
+  let chars_b = key
+  var translated = ""
+  var i = 0
+  while i < len(message) {
+    let symbol = message[i]
+    let upper_sym = upper(symbol)
+    let sym_index = find_char(chars_a, upper_sym)
+    if sym_index >= 0 {
+      let sub_char = chars_b[sym_index]
+      if symbol == upper_sym {
+        translated = translated + upper(sub_char)
+      } else {
+        translated = translated + lower(sub_char)
+      }
+    } else {
+      translated = translated + symbol
+    }
+    i = i + 1
+  }
+  return translated
+}
+
+fun main(): void {
+  let message = "Hello World"
+  let key = "QWERTYUIOPASDFGHJKLZXCVBNM"
+  let mode = "decrypt"
+  var translated = ""
+  if mode == "encrypt" {
+    translated = encrypt_message(key, message)
+  } else {
+    if mode == "decrypt" {
+      translated = decrypt_message(key, message)
+    }
+  }
+  print("Using the key " + key + ", the " + mode + "ed message is: " + translated)
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/ciphers/mono_alphabetic_ciphers.out
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/mono_alphabetic_ciphers.out
@@ -1,0 +1,1 @@
+Using the key QWERTYUIOPASDFGHJKLZXCVBNM, the decrypted message is: Itssg Vgksr

--- a/tests/github/TheAlgorithms/Python/ciphers/mono_alphabetic_ciphers.py
+++ b/tests/github/TheAlgorithms/Python/ciphers/mono_alphabetic_ciphers.py
@@ -1,0 +1,63 @@
+from typing import Literal
+
+LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+def translate_message(
+    key: str, message: str, mode: Literal["encrypt", "decrypt"]
+) -> str:
+    """
+    >>> translate_message("QWERTYUIOPASDFGHJKLZXCVBNM","Hello World","encrypt")
+    'Pcssi Bidsm'
+    """
+    chars_a = LETTERS if mode == "decrypt" else key
+    chars_b = key if mode == "decrypt" else LETTERS
+    translated = ""
+    # loop through each symbol in the message
+    for symbol in message:
+        if symbol.upper() in chars_a:
+            # encrypt/decrypt the symbol
+            sym_index = chars_a.find(symbol.upper())
+            if symbol.isupper():
+                translated += chars_b[sym_index].upper()
+            else:
+                translated += chars_b[sym_index].lower()
+        else:
+            # symbol is not in LETTERS, just add it
+            translated += symbol
+    return translated
+
+
+def encrypt_message(key: str, message: str) -> str:
+    """
+    >>> encrypt_message("QWERTYUIOPASDFGHJKLZXCVBNM", "Hello World")
+    'Pcssi Bidsm'
+    """
+    return translate_message(key, message, "encrypt")
+
+
+def decrypt_message(key: str, message: str) -> str:
+    """
+    >>> decrypt_message("QWERTYUIOPASDFGHJKLZXCVBNM", "Hello World")
+    'Itssg Vgksr'
+    """
+    return translate_message(key, message, "decrypt")
+
+
+def main() -> None:
+    message = "Hello World"
+    key = "QWERTYUIOPASDFGHJKLZXCVBNM"
+    mode = "decrypt"  # set to 'encrypt' or 'decrypt'
+
+    if mode == "encrypt":
+        translated = encrypt_message(key, message)
+    elif mode == "decrypt":
+        translated = decrypt_message(key, message)
+    print(f"Using the key {key}, the {mode}ed message is: {translated}")
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    main()


### PR DESCRIPTION
## Summary
- add Python source for monoalphabetic substitution cipher
- implement equivalent Mochi version with encryption and decryption helpers
- capture example output using runtime VM

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/ciphers/mono_alphabetic_ciphers.mochi`

------
https://chatgpt.com/codex/tasks/task_e_689155200b288320bab9055ce11d0835