### PR TITLE
Add Mochi implementation of Playfair cipher

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/ciphers/playfair_cipher.mochi
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/playfair_cipher.mochi
@@ -1,0 +1,161 @@
+/*
+Playfair Cipher - Classical Encryption
+
+The Playfair cipher encodes text by substituting pairs of letters using a 5x5
+matrix built from a keyword. The matrix merges I and J to fit the alphabet.
+Plaintext is cleaned by removing non letters, converting to uppercase and
+inserting 'X' between repeated letters. If the final length is odd an extra
+'X' is appended.
+
+For each letter pair:
+- Same row: replace each with the letter to its right (wrapping around).
+- Same column: replace each with the letter below it (wrapping around).
+- Rectangle: swap the columns of the letters.
+
+Decoding applies the inverse operations. This implementation demonstrates
+both encoding and decoding using the runtime/vm.
+*/
+
+fun contains(xs: list<string>, x: string): bool {
+  var i = 0
+  while i < len(xs) {
+    if xs[i] == x {
+      return true
+    }
+    i = i + 1
+  }
+  return false
+}
+
+fun index_of(xs: list<string>, x: string): int {
+  var i = 0
+  while i < len(xs) {
+    if xs[i] == x {
+      return i
+    }
+    i = i + 1
+  }
+  return -1
+}
+
+fun prepare_input(dirty: string): string {
+  let letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  let upper_dirty = upper(dirty)
+  var filtered = ""
+  var i = 0
+  while i < len(upper_dirty) {
+    let c = substring(upper_dirty, i, i + 1)
+    if c in letters {
+      filtered = filtered + c
+    }
+    i = i + 1
+  }
+  if len(filtered) < 2 {
+    return filtered
+  }
+  var clean = ""
+  i = 0
+  while i < len(filtered) - 1 {
+    let c1 = substring(filtered, i, i + 1)
+    let c2 = substring(filtered, i + 1, i + 2)
+    clean = clean + c1
+    if c1 == c2 {
+      clean = clean + "X"
+    }
+    i = i + 1
+  }
+  clean = clean + substring(filtered, len(filtered) - 1, len(filtered))
+  if len(clean) % 2 == 1 {
+    clean = clean + "X"
+  }
+  return clean
+}
+
+fun generate_table(key: string): list<string> {
+  let alphabet = "ABCDEFGHIKLMNOPQRSTUVWXYZ"
+  var table: list<string> = []
+  let upper_key = upper(key)
+  var i = 0
+  while i < len(upper_key) {
+    let c = substring(upper_key, i, i + 1)
+    if c in alphabet {
+      if !(contains(table, c)) {
+        table = append(table, c)
+      }
+    }
+    i = i + 1
+  }
+  i = 0
+  while i < len(alphabet) {
+    let c = substring(alphabet, i, i + 1)
+    if !(contains(table, c)) {
+      table = append(table, c)
+    }
+    i = i + 1
+  }
+  return table
+}
+
+fun encode(plaintext: string, key: string): string {
+  let table = generate_table(key)
+  let text = prepare_input(plaintext)
+  var cipher = ""
+  var i = 0
+  while i < len(text) {
+    let c1 = substring(text, i, i + 1)
+    let c2 = substring(text, i + 1, i + 2)
+    let idx1 = index_of(table, c1)
+    let idx2 = index_of(table, c2)
+    let row1 = idx1 / 5
+    let col1 = idx1 % 5
+    let row2 = idx2 / 5
+    let col2 = idx2 % 5
+    if row1 == row2 {
+      cipher = cipher + table[row1 * 5 + (col1 + 1) % 5]
+      cipher = cipher + table[row2 * 5 + (col2 + 1) % 5]
+    } else if col1 == col2 {
+      cipher = cipher + table[((row1 + 1) % 5) * 5 + col1]
+      cipher = cipher + table[((row2 + 1) % 5) * 5 + col2]
+    } else {
+      cipher = cipher + table[row1 * 5 + col2]
+      cipher = cipher + table[row2 * 5 + col1]
+    }
+    i = i + 2
+  }
+  return cipher
+}
+
+fun decode(cipher: string, key: string): string {
+  let table = generate_table(key)
+  var plain = ""
+  var i = 0
+  while i < len(cipher) {
+    let c1 = substring(cipher, i, i + 1)
+    let c2 = substring(cipher, i + 1, i + 2)
+    let idx1 = index_of(table, c1)
+    let idx2 = index_of(table, c2)
+    let row1 = idx1 / 5
+    let col1 = idx1 % 5
+    let row2 = idx2 / 5
+    let col2 = idx2 % 5
+    if row1 == row2 {
+      plain = plain + table[row1 * 5 + (col1 + 4) % 5]
+      plain = plain + table[row2 * 5 + (col2 + 4) % 5]
+    } else if col1 == col2 {
+      plain = plain + table[((row1 + 4) % 5) * 5 + col1]
+      plain = plain + table[((row2 + 4) % 5) * 5 + col2]
+    } else {
+      plain = plain + table[row1 * 5 + col2]
+      plain = plain + table[row2 * 5 + col1]
+    }
+    i = i + 2
+  }
+  return plain
+}
+
+fun main() {
+  print("Encoded:", encode("BYE AND THANKS", "GREETING"))
+  print("Decoded:", decode("CXRBANRLBALQ", "GREETING"))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/ciphers/playfair_cipher.out
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/playfair_cipher.out
@@ -1,0 +1,2 @@
+Encoded: CXRBANRLBALQ
+Decoded: BYEANDTHANKS

--- a/tests/github/TheAlgorithms/Python/ciphers/playfair_cipher.py
+++ b/tests/github/TheAlgorithms/Python/ciphers/playfair_cipher.py
@@ -1,0 +1,159 @@
+"""
+https://en.wikipedia.org/wiki/Playfair_cipher#Description
+
+The Playfair cipher was developed by Charles Wheatstone in 1854
+It's use was heavily promotedby Lord Playfair, hence its name
+
+Some features of the Playfair cipher are:
+
+1) It was the first literal diagram substitution cipher
+2) It is a manual symmetric encryption technique
+3) It is a multiple letter encryption cipher
+
+The implementation in the code below encodes alphabets only.
+It removes spaces, special characters and numbers from the
+code.
+
+Playfair is no longer used by military forces because of known
+insecurities and of the advent of automated encryption devices.
+This cipher is regarded as insecure since before World War I.
+"""
+
+import itertools
+import string
+from collections.abc import Generator, Iterable
+
+
+def chunker(seq: Iterable[str], size: int) -> Generator[tuple[str, ...]]:
+    it = iter(seq)
+    while True:
+        chunk = tuple(itertools.islice(it, size))
+        if not chunk:
+            return
+        yield chunk
+
+
+def prepare_input(dirty: str) -> str:
+    """
+    Prepare the plaintext by up-casing it
+    and separating repeated letters with X's
+    """
+
+    dirty = "".join([c.upper() for c in dirty if c in string.ascii_letters])
+    clean = ""
+
+    if len(dirty) < 2:
+        return dirty
+
+    for i in range(len(dirty) - 1):
+        clean += dirty[i]
+
+        if dirty[i] == dirty[i + 1]:
+            clean += "X"
+
+    clean += dirty[-1]
+
+    if len(clean) & 1:
+        clean += "X"
+
+    return clean
+
+
+def generate_table(key: str) -> list[str]:
+    # I and J are used interchangeably to allow
+    # us to use a 5x5 table (25 letters)
+    alphabet = "ABCDEFGHIKLMNOPQRSTUVWXYZ"
+    # we're using a list instead of a '2d' array because it makes the math
+    # for setting up the table and doing the actual encoding/decoding simpler
+    table = []
+
+    # copy key chars into the table if they are in `alphabet` ignoring duplicates
+    for char in key.upper():
+        if char not in table and char in alphabet:
+            table.append(char)
+
+    # fill the rest of the table in with the remaining alphabet chars
+    for char in alphabet:
+        if char not in table:
+            table.append(char)
+
+    return table
+
+
+def encode(plaintext: str, key: str) -> str:
+    """
+    Encode the given plaintext using the Playfair cipher.
+    Takes the plaintext and the key as input and returns the encoded string.
+
+    >>> encode("Hello", "MONARCHY")
+    'CFSUPM'
+    >>> encode("attack on the left flank", "EMERGENCY")
+    'DQZSBYFSDZFMFNLOHFDRSG'
+    >>> encode("Sorry!", "SPECIAL")
+    'AVXETX'
+    >>> encode("Number 1", "NUMBER")
+    'UMBENF'
+    >>> encode("Photosynthesis!", "THE SUN")
+    'OEMHQHVCHESUKE'
+    """
+
+    table = generate_table(key)
+    plaintext = prepare_input(plaintext)
+    ciphertext = ""
+
+    for char1, char2 in chunker(plaintext, 2):
+        row1, col1 = divmod(table.index(char1), 5)
+        row2, col2 = divmod(table.index(char2), 5)
+
+        if row1 == row2:
+            ciphertext += table[row1 * 5 + (col1 + 1) % 5]
+            ciphertext += table[row2 * 5 + (col2 + 1) % 5]
+        elif col1 == col2:
+            ciphertext += table[((row1 + 1) % 5) * 5 + col1]
+            ciphertext += table[((row2 + 1) % 5) * 5 + col2]
+        else:  # rectangle
+            ciphertext += table[row1 * 5 + col2]
+            ciphertext += table[row2 * 5 + col1]
+
+    return ciphertext
+
+
+def decode(ciphertext: str, key: str) -> str:
+    """
+    Decode the input string using the provided key.
+
+    >>> decode("BMZFAZRZDH", "HAZARD")
+    'FIREHAZARD'
+    >>> decode("HNBWBPQT", "AUTOMOBILE")
+    'DRIVINGX'
+    >>> decode("SLYSSAQS", "CASTLE")
+    'ATXTACKX'
+    """
+
+    table = generate_table(key)
+    plaintext = ""
+
+    for char1, char2 in chunker(ciphertext, 2):
+        row1, col1 = divmod(table.index(char1), 5)
+        row2, col2 = divmod(table.index(char2), 5)
+
+        if row1 == row2:
+            plaintext += table[row1 * 5 + (col1 - 1) % 5]
+            plaintext += table[row2 * 5 + (col2 - 1) % 5]
+        elif col1 == col2:
+            plaintext += table[((row1 - 1) % 5) * 5 + col1]
+            plaintext += table[((row2 - 1) % 5) * 5 + col2]
+        else:  # rectangle
+            plaintext += table[row1 * 5 + col2]
+            plaintext += table[row2 * 5 + col1]
+
+    return plaintext
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+
+    print("Encoded:", encode("BYE AND THANKS", "GREETING"))
+    print("Decoded:", decode("CXRBANRLBALQ", "GREETING"))


### PR DESCRIPTION
## Summary
- add Python reference for Playfair cipher
- implement Playfair cipher in Mochi with encode/decode
- include runtime output

## Testing
- `python tests/github/TheAlgorithms/Python/ciphers/playfair_cipher.py`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/ciphers/playfair_cipher.mochi`

------
https://chatgpt.com/codex/tasks/task_e_68915547ea4c832097e137202e77a98b