### PR TITLE
Add Miller-Rabin primality test

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/ciphers/rabin_miller.mochi
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/rabin_miller.mochi
@@ -1,0 +1,115 @@
+/*
+Miller-Rabin Primality Test
+
+This program implements a probabilistic primality test.  For an odd
+number n > 2, write n − 1 as 2^t * s with s odd.  For several random
+bases a, compute v = a^s mod n.  If v is neither 1 nor n − 1, square v
+up to t−1 times.  If none of the squares equal n − 1 the number is
+composite.  Repeating with multiple bases reduces the probability of
+a composite being identified as prime.
+
+The implementation first removes small composite numbers using trial
+division with primes under 1000, then performs five rounds of the
+Miller–Rabin test using a time based pseudo random generator.  The code
+avoids any FFI and uses only pure Mochi features.
+*/
+
+fun int_pow(base: int, exp: int): int {
+  var result = 1
+  var i = 0
+  while i < exp {
+    result = result * base
+    i = i + 1
+  }
+  return result
+}
+
+fun pow_mod(base: int, exp: int, mod: int): int {
+  var result = 1
+  var b = base % mod
+  var e = exp
+  while e > 0 {
+    if e % 2 == 1 {
+      result = (result * b) % mod
+    }
+    e = e / 2
+    b = (b * b) % mod
+  }
+  return result
+}
+
+fun rand_range(low: int, high: int): int {
+  return (now() % (high - low)) + low
+}
+
+fun rabin_miller(num: int): bool {
+  var s = num - 1
+  var t = 0
+  while s % 2 == 0 {
+    s = s / 2
+    t = t + 1
+  }
+  var k = 0
+  while k < 5 {
+    let a = rand_range(2, num - 1)
+    var v = pow_mod(a, s, num)
+    if v != 1 {
+      var i = 0
+      while v != (num - 1) {
+        if i == t - 1 {
+          return false
+        }
+        i = i + 1
+        v = (v * v) % num
+      }
+    }
+    k = k + 1
+  }
+  return true
+}
+
+fun is_prime_low_num(num: int): bool {
+  if num < 2 {
+    return false
+  }
+  let low_primes = [
+    2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47,
+    53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113,
+    127, 131, 137, 139, 149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199,
+    211, 223, 227, 229, 233, 239, 241, 251, 257, 263, 269, 271, 277, 281, 283, 293,
+    307, 311, 313, 317, 331, 337, 347, 349, 353, 359, 367, 373, 379, 383, 389, 397,
+    401, 409, 419, 421, 431, 433, 439, 443, 449, 457, 461, 463, 467, 479, 487, 491,
+    499, 503, 509, 521, 523, 541, 547, 557, 563, 569, 571, 577, 587, 593, 599, 601,
+    607, 613, 617, 619, 631, 641, 643, 647, 653, 659, 661, 673, 677, 683, 691, 701,
+    709, 719, 727, 733, 739, 743, 751, 757, 761, 769, 773, 787, 797, 809, 811, 821,
+    823, 827, 829, 839, 853, 857, 859, 863, 877, 881, 883, 887, 907, 911, 919, 929,
+    937, 941, 947, 953, 967, 971, 977, 983, 991, 997
+  ]
+  if num in low_primes {
+    return true
+  }
+  var i = 0
+  while i < len(low_primes) {
+    let p = low_primes[i]
+    if num % p == 0 {
+      return false
+    }
+    i = i + 1
+  }
+  return rabin_miller(num)
+}
+
+fun generate_large_prime(keysize: int): int {
+  var start = int_pow(2, keysize - 1)
+  var end = int_pow(2, keysize)
+  while true {
+    let num = rand_range(start, end)
+    if is_prime_low_num(num) {
+      return num
+    }
+  }
+}
+
+let p = generate_large_prime(16)
+print("Prime number: " + str(p))
+print("is_prime_low_num: " + str(is_prime_low_num(p)))

--- a/tests/github/TheAlgorithms/Mochi/ciphers/rabin_miller.out
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/rabin_miller.out
@@ -1,0 +1,2 @@
+Prime number: 41539
+is_prime_low_num: true

--- a/tests/github/TheAlgorithms/Python/ciphers/rabin_miller.py
+++ b/tests/github/TheAlgorithms/Python/ciphers/rabin_miller.py
@@ -1,0 +1,223 @@
+# Primality Testing with the Rabin-Miller Algorithm
+
+import random
+
+
+def rabin_miller(num: int) -> bool:
+    s = num - 1
+    t = 0
+
+    while s % 2 == 0:
+        s = s // 2
+        t += 1
+
+    for _ in range(5):
+        a = random.randrange(2, num - 1)
+        v = pow(a, s, num)
+        if v != 1:
+            i = 0
+            while v != (num - 1):
+                if i == t - 1:
+                    return False
+                else:
+                    i = i + 1
+                    v = (v**2) % num
+    return True
+
+
+def is_prime_low_num(num: int) -> bool:
+    if num < 2:
+        return False
+
+    low_primes = [
+        2,
+        3,
+        5,
+        7,
+        11,
+        13,
+        17,
+        19,
+        23,
+        29,
+        31,
+        37,
+        41,
+        43,
+        47,
+        53,
+        59,
+        61,
+        67,
+        71,
+        73,
+        79,
+        83,
+        89,
+        97,
+        101,
+        103,
+        107,
+        109,
+        113,
+        127,
+        131,
+        137,
+        139,
+        149,
+        151,
+        157,
+        163,
+        167,
+        173,
+        179,
+        181,
+        191,
+        193,
+        197,
+        199,
+        211,
+        223,
+        227,
+        229,
+        233,
+        239,
+        241,
+        251,
+        257,
+        263,
+        269,
+        271,
+        277,
+        281,
+        283,
+        293,
+        307,
+        311,
+        313,
+        317,
+        331,
+        337,
+        347,
+        349,
+        353,
+        359,
+        367,
+        373,
+        379,
+        383,
+        389,
+        397,
+        401,
+        409,
+        419,
+        421,
+        431,
+        433,
+        439,
+        443,
+        449,
+        457,
+        461,
+        463,
+        467,
+        479,
+        487,
+        491,
+        499,
+        503,
+        509,
+        521,
+        523,
+        541,
+        547,
+        557,
+        563,
+        569,
+        571,
+        577,
+        587,
+        593,
+        599,
+        601,
+        607,
+        613,
+        617,
+        619,
+        631,
+        641,
+        643,
+        647,
+        653,
+        659,
+        661,
+        673,
+        677,
+        683,
+        691,
+        701,
+        709,
+        719,
+        727,
+        733,
+        739,
+        743,
+        751,
+        757,
+        761,
+        769,
+        773,
+        787,
+        797,
+        809,
+        811,
+        821,
+        823,
+        827,
+        829,
+        839,
+        853,
+        857,
+        859,
+        863,
+        877,
+        881,
+        883,
+        887,
+        907,
+        911,
+        919,
+        929,
+        937,
+        941,
+        947,
+        953,
+        967,
+        971,
+        977,
+        983,
+        991,
+        997,
+    ]
+
+    if num in low_primes:
+        return True
+
+    for prime in low_primes:
+        if (num % prime) == 0:
+            return False
+
+    return rabin_miller(num)
+
+
+def generate_large_prime(keysize: int = 1024) -> int:
+    while True:
+        num = random.randrange(2 ** (keysize - 1), 2 ** (keysize))
+        if is_prime_low_num(num):
+            return num
+
+
+if __name__ == "__main__":
+    num = generate_large_prime()
+    print(("Prime number:", num))
+    print(("is_prime_low_num:", is_prime_low_num(num)))


### PR DESCRIPTION
## Summary
- add Python rabin_miller implementation to ciphers directory
- port Miller–Rabin primality test to Mochi with helper utilities and small prime sieve
- include runtime output demonstrating generated prime

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/ciphers/rabin_miller.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891556494e4832091afc259c37e5f64