### PR TITLE
Add Mochi implementation for permutation cipher

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/ciphers/permutation_cipher.mochi
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/permutation_cipher.mochi
@@ -1,0 +1,110 @@
+/*
+Permutation Cipher - Block-based transposition cipher.
+
+The permutation (or transposition) cipher rearranges characters within fixed-size blocks
+according to a secret permutation key. A message whose length is divisible by the block
+size is split into consecutive blocks. Each block is reordered by the key and concatenated
+to form the ciphertext. Decryption applies the inverse permutation to each block.
+
+To demonstrate the algorithm we:
+1. Choose a block size that divides the message length.
+2. Generate a pseudo-random permutation key using a simple linear congruential generator.
+3. Encrypt by permuting characters in each block using the key.
+4. Decrypt using the same key to restore the original message.
+
+Both operations run in O(n) time where n is the message length.
+*/
+
+var seed = 1
+fun rand(max: int): int {
+  seed = (seed * 1103515245 + 12345) % 2147483647
+  return seed % max
+}
+
+fun generate_valid_block_size(message_length: int): int {
+  var factors: list<int> = []
+  var i = 2
+  while i <= message_length {
+    if message_length % i == 0 {
+      factors = append(factors, i)
+    }
+    i = i + 1
+  }
+  let idx = rand(len(factors))
+  return factors[idx]
+}
+
+fun generate_permutation_key(block_size: int): list<int> {
+  var digits: list<int> = []
+  var i = 0
+  while i < block_size {
+    digits = append(digits, i)
+    i = i + 1
+  }
+  var j = block_size - 1
+  while j > 0 {
+    let k = rand(j + 1)
+    let temp = digits[j]
+    digits[j] = digits[k]
+    digits[k] = temp
+    j = j - 1
+  }
+  return digits
+}
+
+fun encrypt(message: string, key: list<int>, block_size: int): string {
+  var encrypted = ""
+  var i = 0
+  while i < len(message) {
+    let block = substring(message, i, i + block_size)
+    var j = 0
+    while j < block_size {
+      encrypted = encrypted + substring(block, key[j], key[j] + 1)
+      j = j + 1
+    }
+    i = i + block_size
+  }
+  return encrypted
+}
+
+fun repeat_string(times: int): list<string> {
+  var res: list<string> = []
+  var i = 0
+  while i < times {
+    res = append(res, "")
+    i = i + 1
+  }
+  return res
+}
+
+fun decrypt(encrypted: string, key: list<int>): string {
+  let klen = len(key)
+  var decrypted = ""
+  var i = 0
+  while i < len(encrypted) {
+    let block = substring(encrypted, i, i + klen)
+    var original = repeat_string(klen)
+    var j = 0
+    while j < klen {
+      original[key[j]] = substring(block, j, j + 1)
+      j = j + 1
+    }
+    j = 0
+    while j < klen {
+      decrypted = decrypted + original[j]
+      j = j + 1
+    }
+    i = i + klen
+  }
+  return decrypted
+}
+
+let message = "HELLO WORLD"
+let block_size = generate_valid_block_size(len(message))
+let key = generate_permutation_key(block_size)
+let encrypted = encrypt(message, key, block_size)
+let decrypted = decrypt(encrypted, key)
+print("Block size: " + str(block_size))
+print("Key: " + str(key))
+print("Encrypted: " + encrypted)
+print("Decrypted: " + decrypted)

--- a/tests/github/TheAlgorithms/Mochi/ciphers/permutation_cipher.out
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/permutation_cipher.out
@@ -1,0 +1,4 @@
+Block size: 11
+Key: [0 5 4 8 1 10 9 3 6 7 2]
+Encrypted: H OREDLLWOL
+Decrypted: HELLO WORLD

--- a/tests/github/TheAlgorithms/Python/ciphers/permutation_cipher.py
+++ b/tests/github/TheAlgorithms/Python/ciphers/permutation_cipher.py
@@ -1,0 +1,143 @@
+"""
+The permutation cipher, also called the transposition cipher, is a simple encryption
+technique that rearranges the characters in a message based on a secret key. It
+divides the message into blocks and applies a permutation to the characters within
+each block according to the key. The key is a sequence of unique integers that
+determine the order of character rearrangement.
+
+For more info: https://www.nku.edu/~christensen/1402%20permutation%20ciphers.pdf
+"""
+
+import random
+
+
+def generate_valid_block_size(message_length: int) -> int:
+    """
+    Generate a valid block size that is a factor of the message length.
+
+    Args:
+        message_length (int): The length of the message.
+
+    Returns:
+        int: A valid block size.
+
+    Example:
+        >>> random.seed(1)
+        >>> generate_valid_block_size(12)
+        3
+    """
+    block_sizes = [
+        block_size
+        for block_size in range(2, message_length + 1)
+        if message_length % block_size == 0
+    ]
+    return random.choice(block_sizes)
+
+
+def generate_permutation_key(block_size: int) -> list[int]:
+    """
+    Generate a random permutation key of a specified block size.
+
+    Args:
+        block_size (int): The size of each permutation block.
+
+    Returns:
+        list[int]: A list containing a random permutation of digits.
+
+    Example:
+        >>> random.seed(0)
+        >>> generate_permutation_key(4)
+        [2, 0, 1, 3]
+    """
+    digits = list(range(block_size))
+    random.shuffle(digits)
+    return digits
+
+
+def encrypt(
+    message: str, key: list[int] | None = None, block_size: int | None = None
+) -> tuple[str, list[int]]:
+    """
+    Encrypt a message using a permutation cipher with block rearrangement using a key.
+
+    Args:
+        message (str): The plaintext message to be encrypted.
+        key (list[int]): The permutation key for decryption.
+        block_size (int): The size of each permutation block.
+
+    Returns:
+        tuple: A tuple containing the encrypted message and the encryption key.
+
+    Example:
+        >>> encrypted_message, key = encrypt("HELLO WORLD")
+        >>> decrypted_message = decrypt(encrypted_message, key)
+        >>> decrypted_message
+        'HELLO WORLD'
+    """
+    message = message.upper()
+    message_length = len(message)
+
+    if key is None or block_size is None:
+        block_size = generate_valid_block_size(message_length)
+        key = generate_permutation_key(block_size)
+
+    encrypted_message = ""
+
+    for i in range(0, message_length, block_size):
+        block = message[i : i + block_size]
+        rearranged_block = [block[digit] for digit in key]
+        encrypted_message += "".join(rearranged_block)
+
+    return encrypted_message, key
+
+
+def decrypt(encrypted_message: str, key: list[int]) -> str:
+    """
+    Decrypt an encrypted message using a permutation cipher with block rearrangement.
+
+    Args:
+        encrypted_message (str): The encrypted message.
+        key (list[int]): The permutation key for decryption.
+
+    Returns:
+        str: The decrypted plaintext message.
+
+    Example:
+        >>> encrypted_message, key = encrypt("HELLO WORLD")
+        >>> decrypted_message = decrypt(encrypted_message, key)
+        >>> decrypted_message
+        'HELLO WORLD'
+    """
+    key_length = len(key)
+    decrypted_message = ""
+
+    for i in range(0, len(encrypted_message), key_length):
+        block = encrypted_message[i : i + key_length]
+        original_block = [""] * key_length
+        for j, digit in enumerate(key):
+            original_block[digit] = block[j]
+        decrypted_message += "".join(original_block)
+
+    return decrypted_message
+
+
+def main() -> None:
+    """
+    Driver function to pass message to get encrypted, then decrypted.
+
+    Example:
+    >>> main()
+    Decrypted message: HELLO WORLD
+    """
+    message = "HELLO WORLD"
+    encrypted_message, key = encrypt(message)
+
+    decrypted_message = decrypt(encrypted_message, key)
+    print(f"Decrypted message: {decrypted_message}")
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    main()


### PR DESCRIPTION
## Summary
- add Python reference for the permutation cipher
- implement permutation cipher in Mochi with pseudo-random key generation, block encryption, and decryption

## Testing
- `python tests/github/TheAlgorithms/Python/ciphers/permutation_cipher.py`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/ciphers/permutation_cipher.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891553e6e008320af63bfb521ee73ca