### PR TITLE
Add Mochi implementation for ROT13 cipher

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/ciphers/rot13.mochi
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/rot13.mochi
@@ -1,0 +1,63 @@
+/*
+ROT13 Cipher
+
+Applies the ROT13 substitution cipher to a string. Each alphabetical
+character is rotated by 13 positions within the alphabet. Characters
+outside A-Z and a-z remain unchanged. Applying the function twice returns
+the original message.
+
+Algorithm:
+1. For each character in the input string:
+   - If it is uppercase, shift within "A"-"Z" by n positions.
+   - If it is lowercase, shift within "a"-"z" by n positions.
+   - Otherwise leave it unchanged.
+2. Concatenate the transformed characters.
+
+Time complexity is O(len(s)).
+*/
+
+let uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+let lowercase = "abcdefghijklmnopqrstuvwxyz"
+
+fun index_of(s: string, c: string): int {
+  var i = 0
+  while i < len(s) {
+    if substring(s, i, i + 1) == c {
+      return i
+    }
+    i = i + 1
+  }
+  return -1
+}
+
+fun dencrypt(s: string, n: int): string {
+  var out = ""
+  var i = 0
+  while i < len(s) {
+    let ch = substring(s, i, i + 1)
+    let idx_u = index_of(uppercase, ch)
+    if idx_u >= 0 {
+      let new_idx = (idx_u + n) % 26
+      out = out + substring(uppercase, new_idx, new_idx + 1)
+    } else {
+      let idx_l = index_of(lowercase, ch)
+      if idx_l >= 0 {
+        let new_idx = (idx_l + n) % 26
+        out = out + substring(lowercase, new_idx, new_idx + 1)
+      } else {
+        out = out + ch
+      }
+    }
+    i = i + 1
+  }
+  return out
+}
+
+fun main() {
+  let msg = "My secret bank account number is 173-52946 so don't tell anyone!!"
+  let s = dencrypt(msg, 13)
+  print(s)
+  print(str(dencrypt(s, 13) == msg))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/ciphers/rot13.out
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/rot13.out
@@ -1,0 +1,2 @@
+Zl frperg onax nppbhag ahzore vf 173-52946 fb qba'g gryy nalbar!!
+true

--- a/tests/github/TheAlgorithms/Python/ciphers/rot13.py
+++ b/tests/github/TheAlgorithms/Python/ciphers/rot13.py
@@ -1,0 +1,37 @@
+def dencrypt(s: str, n: int = 13) -> str:
+    """
+    https://en.wikipedia.org/wiki/ROT13
+
+    >>> msg = "My secret bank account number is 173-52946 so don't tell anyone!!"
+    >>> s = dencrypt(msg)
+    >>> s
+    "Zl frperg onax nppbhag ahzore vf 173-52946 fb qba'g gryy nalbar!!"
+    >>> dencrypt(s) == msg
+    True
+    """
+    out = ""
+    for c in s:
+        if "A" <= c <= "Z":
+            out += chr(ord("A") + (ord(c) - ord("A") + n) % 26)
+        elif "a" <= c <= "z":
+            out += chr(ord("a") + (ord(c) - ord("a") + n) % 26)
+        else:
+            out += c
+    return out
+
+
+def main() -> None:
+    s0 = input("Enter message: ")
+
+    s1 = dencrypt(s0, 13)
+    print("Encryption:", s1)
+
+    s2 = dencrypt(s1, 13)
+    print("Decryption: ", s2)
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    main()


### PR DESCRIPTION
## Summary
- add missing Python reference for ROT13 cipher
- implement ROT13 cipher in Mochi with comments and examples
- record runtime output for the Mochi version

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/ciphers/rot13.mochi > tests/github/TheAlgorithms/Mochi/ciphers/rot13.out`


------
https://chatgpt.com/codex/tasks/task_e_6891580d08e08320a9655c9ca80e626b