### PR TITLE
Add rail fence cipher algorithm in Mochi tests

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/ciphers/rail_fence_cipher.mochi
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/rail_fence_cipher.mochi
@@ -1,0 +1,119 @@
+/*
+Rail Fence Cipher - Transposition Cipher
+
+The algorithm writes the message in a zigzag pattern on a set of rails
+whose count is determined by the key. Characters are placed row by row
+while moving down and up the rails. Reading the rows sequentially
+produces the encrypted text.
+
+To decrypt, the pattern of traversal is reconstructed to determine how
+many characters belong to each rail. The cipher text is then sliced and
+filled into the rails before reading them again in a zigzag to recover
+the original message. A helper function demonstrates brute forcing all
+possible keys.
+
+Time complexity is O(n) for both encryption and decryption where n is
+the length of the input string.
+*/
+
+fun encrypt(input_string: string, key: int): string {
+  if key <= 0 { panic("Height of grid can't be 0 or negative") }
+  if key == 1 || len(input_string) <= key { return input_string }
+  let lowest = key - 1
+  var temp_grid: list<list<string>> = []
+  var i = 0
+  while i < key {
+    temp_grid = append(temp_grid, [] as list<string>)
+    i = i + 1
+  }
+  var position = 0
+  while position < len(input_string) {
+    var num = position % (lowest * 2)
+    let alt = lowest * 2 - num
+    if num > alt { num = alt }
+    var row = temp_grid[num]
+    row = append(row, substring(input_string, position, position + 1))
+    temp_grid[num] = row
+    position = position + 1
+  }
+  var output = ""
+  i = 0
+  while i < key {
+    var row = temp_grid[i]
+    var j = 0
+    while j < len(row) {
+      output = output + row[j]
+      j = j + 1
+    }
+    i = i + 1
+  }
+  return output
+}
+
+fun decrypt(input_string: string, key: int): string {
+  if key <= 0 { panic("Height of grid can't be 0 or negative") }
+  if key == 1 { return input_string }
+  let lowest = key - 1
+  var counts: list<int> = []
+  var i = 0
+  while i < key {
+    counts = append(counts, 0)
+    i = i + 1
+  }
+  var pos = 0
+  while pos < len(input_string) {
+    var num = pos % (lowest * 2)
+    let alt = lowest * 2 - num
+    if num > alt { num = alt }
+    counts[num] = counts[num] + 1
+    pos = pos + 1
+  }
+  var grid: list<list<string>> = []
+  var counter = 0
+  i = 0
+  while i < key {
+    let length = counts[i]
+    let slice = substring(input_string, counter, counter + length)
+    var row: list<string> = []
+    var j = 0
+    while j < len(slice) {
+      row = append(row, slice[j])
+      j = j + 1
+    }
+    grid = append(grid, row)
+    counter = counter + length
+    i = i + 1
+  }
+  var indices: list<int> = []
+  i = 0
+  while i < key {
+    indices = append(indices, 0)
+    i = i + 1
+  }
+  var output = ""
+  pos = 0
+  while pos < len(input_string) {
+    var num = pos % (lowest * 2)
+    let alt = lowest * 2 - num
+    if num > alt { num = alt }
+    output = output + grid[num][indices[num]]
+    indices[num] = indices[num] + 1
+    pos = pos + 1
+  }
+  return output
+}
+
+fun bruteforce(input_string: string): map<int, string> {
+  var results: map<int, string> = {}
+  var key_guess = 1
+  while key_guess < len(input_string) {
+    results[key_guess] = decrypt(input_string, key_guess)
+    key_guess = key_guess + 1
+  }
+  return results
+}
+
+print(encrypt("Hello World", 4))
+print(decrypt("HWe olordll", 4))
+let bf = bruteforce("HWe olordll")
+print(bf[4])

--- a/tests/github/TheAlgorithms/Mochi/ciphers/rail_fence_cipher.out
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/rail_fence_cipher.out
@@ -1,0 +1,3 @@
+HWe olordll
+Hello World
+Hello World

--- a/tests/github/TheAlgorithms/Python/ciphers/rail_fence_cipher.py
+++ b/tests/github/TheAlgorithms/Python/ciphers/rail_fence_cipher.py
@@ -1,0 +1,102 @@
+"""https://en.wikipedia.org/wiki/Rail_fence_cipher"""
+
+
+def encrypt(input_string: str, key: int) -> str:
+    """
+    Shuffles the character of a string by placing each of them
+    in a grid (the height is dependent on the key) in a zigzag
+    formation and reading it left to right.
+
+    >>> encrypt("Hello World", 4)
+    'HWe olordll'
+
+    >>> encrypt("This is a message", 0)
+    Traceback (most recent call last):
+        ...
+    ValueError: Height of grid can't be 0 or negative
+
+    >>> encrypt(b"This is a byte string", 5)
+    Traceback (most recent call last):
+        ...
+    TypeError: sequence item 0: expected str instance, int found
+    """
+    temp_grid: list[list[str]] = [[] for _ in range(key)]
+    lowest = key - 1
+
+    if key <= 0:
+        raise ValueError("Height of grid can't be 0 or negative")
+    if key == 1 or len(input_string) <= key:
+        return input_string
+
+    for position, character in enumerate(input_string):
+        num = position % (lowest * 2)  # puts it in bounds
+        num = min(num, lowest * 2 - num)  # creates zigzag pattern
+        temp_grid[num].append(character)
+    grid = ["".join(row) for row in temp_grid]
+    output_string = "".join(grid)
+
+    return output_string
+
+
+def decrypt(input_string: str, key: int) -> str:
+    """
+    Generates a template based on the key and fills it in with
+    the characters of the input string and then reading it in
+    a zigzag formation.
+
+    >>> decrypt("HWe olordll", 4)
+    'Hello World'
+
+    >>> decrypt("This is a message", -10)
+    Traceback (most recent call last):
+        ...
+    ValueError: Height of grid can't be 0 or negative
+
+    >>> decrypt("My key is very big", 100)
+    'My key is very big'
+    """
+    grid = []
+    lowest = key - 1
+
+    if key <= 0:
+        raise ValueError("Height of grid can't be 0 or negative")
+    if key == 1:
+        return input_string
+
+    temp_grid: list[list[str]] = [[] for _ in range(key)]  # generates template
+    for position in range(len(input_string)):
+        num = position % (lowest * 2)  # puts it in bounds
+        num = min(num, lowest * 2 - num)  # creates zigzag pattern
+        temp_grid[num].append("*")
+
+    counter = 0
+    for row in temp_grid:  # fills in the characters
+        splice = input_string[counter : counter + len(row)]
+        grid.append(list(splice))
+        counter += len(row)
+
+    output_string = ""  # reads as zigzag
+    for position in range(len(input_string)):
+        num = position % (lowest * 2)  # puts it in bounds
+        num = min(num, lowest * 2 - num)  # creates zigzag pattern
+        output_string += grid[num][0]
+        grid[num].pop(0)
+    return output_string
+
+
+def bruteforce(input_string: str) -> dict[int, str]:
+    """Uses decrypt function by guessing every key
+
+    >>> bruteforce("HWe olordll")[4]
+    'Hello World'
+    """
+    results = {}
+    for key_guess in range(1, len(input_string)):  # tries every key
+        results[key_guess] = decrypt(input_string, key_guess)
+    return results
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python reference implementation of the rail fence cipher for index 101
- implement rail fence cipher in Mochi with encrypt, decrypt, and brute-force helpers

## Testing
- `go test ./interpreter`
- `./runtime/vm/vm tests/github/TheAlgorithms/Mochi/ciphers/rail_fence_cipher.mochi` *(fails: No such file or directory)*
- `npm install` *(fails: connect ENETUNREACH 140.82.114.3:443)*

------
https://chatgpt.com/codex/tasks/task_e_689158010e6483209ee0b1c9694e3162