### PR TITLE
Add shuffled shift cipher implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/ciphers/shuffled_shift_cipher.mochi
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/shuffled_shift_cipher.mochi
@@ -1,0 +1,230 @@
+/*
+Shuffled Shift Cipher
+
+This algorithm enhances the classic Caesar cipher by shuffling the
+alphabet used for lookup, removing simple brute force attacks.
+
+1. A passcode consisting of random letters and digits is generated. The
+   passcode determines two things:
+   - Breakpoints that partition the allowed character list.
+   - A shift key derived from alternating sums of ASCII codes.
+2. The allowed characters include uppercase and lowercase letters,
+   digits, punctuation and whitespace.  The list is split at each
+   breakpoint character and each section is reversed to create a new
+   shuffled key list.  This yields many possible permutations.
+3. The shift key is the sum of ASCII codes of the passcode characters
+   where every second code is negated.  If the result is non–positive,
+   the length of the passcode is used instead.
+4. Encryption and decryption shift characters through the shuffled key
+   list much like a Caesar cipher but using the calculated shift key.
+
+The complexity of both encryption and decryption is O(n) for a message
+of length n since each character requires a lookup in the key list.
+*/
+
+// convert a single character to its ASCII code
+fun ord(ch: string): int {
+  let digits = "0123456789"
+  var i = 0
+  while i < len(digits) {
+    if substring(digits, i, i + 1) == ch {
+      return 48 + i
+    }
+    i = i + 1
+  }
+  let upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  i = 0
+  while i < len(upper) {
+    if substring(upper, i, i + 1) == ch {
+      return 65 + i
+    }
+    i = i + 1
+  }
+  let lower = "abcdefghijklmnopqrstuvwxyz"
+  i = 0
+  while i < len(lower) {
+    if substring(lower, i, i + 1) == ch {
+      return 97 + i
+    }
+    i = i + 1
+  }
+  return 0
+}
+
+// multiply every second element by -1
+fun neg_pos(iterlist: list<int>): list<int> {
+  var i = 1
+  while i < len(iterlist) {
+    iterlist[i] = -iterlist[i]
+    i = i + 2
+  }
+  return iterlist
+}
+
+// simple time based pseudo random passcode generator
+fun passcode_creator(): list<string> {
+  let choices = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+  var seed = now()
+  let length = 10 + (seed % 11)
+  var password: list<string> = []
+  var i = 0
+  while i < length {
+    seed = (seed * 1103515245 + 12345) % 2147483647
+    let idx = seed % len(choices)
+    password = append(password, substring(choices, idx, idx + 1))
+    i = i + 1
+  }
+  return password
+}
+
+// sort unique characters from passcode
+fun unique_sorted(chars: list<string>): list<string> {
+  var uniq: list<string> = []
+  var i = 0
+  while i < len(chars) {
+    let ch = chars[i]
+    if !(ch in uniq) {
+      uniq = append(uniq, ch)
+    }
+    i = i + 1
+  }
+  // selection sort
+  var j = 0
+  while j < len(uniq) {
+    var k = j + 1
+    var min_idx = j
+    while k < len(uniq) {
+      if uniq[k] < uniq[min_idx] {
+        min_idx = k
+      }
+      k = k + 1
+    }
+    if min_idx != j {
+      let tmp = uniq[j]
+      uniq[j] = uniq[min_idx]
+      uniq[min_idx] = tmp
+    }
+    j = j + 1
+  }
+  return uniq
+}
+
+// create shuffled key list using breakpoint characters
+fun make_key_list(passcode: list<string>): list<string> {
+  let key_list_options = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ \t\n"
+  let breakpoints = unique_sorted(passcode)
+  var keys_l: list<string> = []
+  var temp_list: list<string> = []
+  var i = 0
+  while i < len(key_list_options) {
+    let ch = substring(key_list_options, i, i + 1)
+    temp_list = append(temp_list, ch)
+    if ch in breakpoints || i == len(key_list_options) - 1 {
+      var k = len(temp_list) - 1
+      while k >= 0 {
+        keys_l = append(keys_l, temp_list[k])
+        k = k - 1
+      }
+      temp_list = []
+    }
+    i = i + 1
+  }
+  return keys_l
+}
+
+// compute shift key from passcode characters
+fun make_shift_key(passcode: list<string>): int {
+  var codes: list<int> = []
+  var i = 0
+  while i < len(passcode) {
+    codes = append(codes, ord(passcode[i]))
+    i = i + 1
+  }
+  codes = neg_pos(codes)
+  var total = 0
+  i = 0
+  while i < len(codes) {
+    total = total + codes[i]
+    i = i + 1
+  }
+  if total > 0 {
+    return total
+  }
+  return len(passcode)
+}
+
+type Cipher {
+  passcode: list<string>,
+  key_list: list<string>,
+  shift_key: int,
+}
+
+fun new_cipher(passcode_str: string): Cipher {
+  var passcode: list<string> = []
+  if len(passcode_str) == 0 {
+    passcode = passcode_creator()
+  } else {
+    var i = 0
+    while i < len(passcode_str) {
+      passcode = append(passcode, substring(passcode_str, i, i + 1))
+      i = i + 1
+    }
+  }
+  let key_list = make_key_list(passcode)
+  let shift_key = make_shift_key(passcode)
+  return Cipher { passcode: passcode, key_list: key_list, shift_key: shift_key }
+}
+
+fun index_of(lst: list<string>, ch: string): int {
+  var i = 0
+  while i < len(lst) {
+    if lst[i] == ch {
+      return i
+    }
+    i = i + 1
+  }
+  return -1
+}
+
+fun encrypt(c: Cipher, plaintext: string): string {
+  var encoded = ""
+  var i = 0
+  let n = len(c.key_list)
+  while i < len(plaintext) {
+    let ch = substring(plaintext, i, i + 1)
+    let position = index_of(c.key_list, ch)
+    let new_pos = (position + c.shift_key) % n
+    encoded = encoded + c.key_list[new_pos]
+    i = i + 1
+  }
+  return encoded
+}
+
+fun decrypt(c: Cipher, encoded_message: string): string {
+  var decoded = ""
+  var i = 0
+  let n = len(c.key_list)
+  while i < len(encoded_message) {
+    let ch = substring(encoded_message, i, i + 1)
+    let position = index_of(c.key_list, ch)
+    var new_pos = (position - c.shift_key) % n
+    if new_pos < 0 {
+      new_pos = new_pos + n
+    }
+    decoded = decoded + c.key_list[new_pos]
+    i = i + 1
+  }
+  return decoded
+}
+
+fun test_end_to_end(): string {
+  let msg = "Hello, this is a modified Caesar cipher"
+  let cip = new_cipher("")
+  return decrypt(cip, encrypt(cip, msg))
+}
+
+// Example usage matching the Python docstring
+let ssc = new_cipher("4PYIXyqeQZr44")
+let encoded = encrypt(ssc, "Hello, this is a modified Caesar cipher")
+print(encoded)
+print(decrypt(ssc, encoded))

--- a/tests/github/TheAlgorithms/Mochi/ciphers/shuffled_shift_cipher.out
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/shuffled_shift_cipher.out
@@ -1,0 +1,2 @@
+d>**-1z6&'5z'5z:z+-='$'>=zp:>5:#z<'.&>#
+Hello, this is a modified Caesar cipher

--- a/tests/github/TheAlgorithms/Python/ciphers/shuffled_shift_cipher.py
+++ b/tests/github/TheAlgorithms/Python/ciphers/shuffled_shift_cipher.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import random
+import string
+
+
+class ShuffledShiftCipher:
+    """
+    This algorithm uses the Caesar Cipher algorithm but removes the option to
+    use brute force to decrypt the message.
+
+    The passcode is a random password from the selection buffer of
+    1. uppercase letters of the English alphabet
+    2. lowercase letters of the English alphabet
+    3. digits from 0 to 9
+
+    Using unique characters from the passcode, the normal list of characters,
+    that can be allowed in the plaintext, is pivoted and shuffled. Refer to docstring
+    of __make_key_list() to learn more about the shuffling.
+
+    Then, using the passcode, a number is calculated which is used to encrypt the
+    plaintext message with the normal shift cipher method, only in this case, the
+    reference, to look back at while decrypting, is shuffled.
+
+    Each cipher object can possess an optional argument as passcode, without which a
+    new passcode is generated for that object automatically.
+    cip1 = ShuffledShiftCipher('d4usr9TWxw9wMD')
+    cip2 = ShuffledShiftCipher()
+    """
+
+    def __init__(self, passcode: str | None = None) -> None:
+        """
+        Initializes a cipher object with a passcode as it's entity
+        Note: No new passcode is generated if user provides a passcode
+        while creating the object
+        """
+        self.__passcode = passcode or self.__passcode_creator()
+        self.__key_list = self.__make_key_list()
+        self.__shift_key = self.__make_shift_key()
+
+    def __str__(self) -> str:
+        """
+        :return: passcode of the cipher object
+        """
+        return "".join(self.__passcode)
+
+    def __neg_pos(self, iterlist: list[int]) -> list[int]:
+        """
+        Mutates the list by changing the sign of each alternate element
+
+        :param iterlist: takes a list iterable
+        :return: the mutated list
+
+        """
+        for i in range(1, len(iterlist), 2):
+            iterlist[i] *= -1
+        return iterlist
+
+    def __passcode_creator(self) -> list[str]:
+        """
+        Creates a random password from the selection buffer of
+        1. uppercase letters of the English alphabet
+        2. lowercase letters of the English alphabet
+        3. digits from 0 to 9
+
+        :rtype: list
+        :return: a password of a random length between 10 to 20
+        """
+        choices = string.ascii_letters + string.digits
+        password = [random.choice(choices) for _ in range(random.randint(10, 20))]
+        return password
+
+    def __make_key_list(self) -> list[str]:
+        """
+        Shuffles the ordered character choices by pivoting at breakpoints
+        Breakpoints are the set of characters in the passcode
+
+        eg:
+            if, ABCDEFGHIJKLMNOPQRSTUVWXYZ are the possible characters
+            and CAMERA is the passcode
+            then, breakpoints = [A,C,E,M,R] # sorted set of characters from passcode
+            shuffled parts: [A,CB,ED,MLKJIHGF,RQPON,ZYXWVUTS]
+            shuffled __key_list : ACBEDMLKJIHGFRQPONZYXWVUTS
+
+        Shuffling only 26 letters of the english alphabet can generate 26!
+        combinations for the shuffled list. In the program we consider, a set of
+        97 characters (including letters, digits, punctuation and whitespaces),
+        thereby creating a possibility of 97! combinations (which is a 152 digit number
+        in itself), thus diminishing the possibility of a brute force approach.
+        Moreover, shift keys even introduce a multiple of 26 for a brute force approach
+        for each of the already 97! combinations.
+        """
+        # key_list_options contain nearly all printable except few elements from
+        # string.whitespace
+        key_list_options = (
+            string.ascii_letters + string.digits + string.punctuation + " \t\n"
+        )
+
+        keys_l = []
+
+        # creates points known as breakpoints to break the key_list_options at those
+        # points and pivot each substring
+        breakpoints = sorted(set(self.__passcode))
+        temp_list: list[str] = []
+
+        # algorithm for creating a new shuffled list, keys_l, out of key_list_options
+        for i in key_list_options:
+            temp_list.extend(i)
+
+            # checking breakpoints at which to pivot temporary sublist and add it into
+            # keys_l
+            if i in breakpoints or i == key_list_options[-1]:
+                keys_l.extend(temp_list[::-1])
+                temp_list.clear()
+
+        # returning a shuffled keys_l to prevent brute force guessing of shift key
+        return keys_l
+
+    def __make_shift_key(self) -> int:
+        """
+        sum() of the mutated list of ascii values of all characters where the
+        mutated list is the one returned by __neg_pos()
+        """
+        num = sum(self.__neg_pos([ord(x) for x in self.__passcode]))
+        return num if num > 0 else len(self.__passcode)
+
+    def decrypt(self, encoded_message: str) -> str:
+        """
+        Performs shifting of the encoded_message w.r.t. the shuffled __key_list
+        to create the decoded_message
+
+        >>> ssc = ShuffledShiftCipher('4PYIXyqeQZr44')
+        >>> ssc.decrypt("d>**-1z6&'5z'5z:z+-='$'>=zp:>5:#z<'.&>#")
+        'Hello, this is a modified Caesar cipher'
+
+        """
+        decoded_message = ""
+
+        # decoding shift like Caesar cipher algorithm implementing negative shift or
+        # reverse shift or left shift
+        for i in encoded_message:
+            position = self.__key_list.index(i)
+            decoded_message += self.__key_list[
+                (position - self.__shift_key) % -len(self.__key_list)
+            ]
+
+        return decoded_message
+
+    def encrypt(self, plaintext: str) -> str:
+        """
+        Performs shifting of the plaintext w.r.t. the shuffled __key_list
+        to create the encoded_message
+
+        >>> ssc = ShuffledShiftCipher('4PYIXyqeQZr44')
+        >>> ssc.encrypt('Hello, this is a modified Caesar cipher')
+        "d>**-1z6&'5z'5z:z+-='$'>=zp:>5:#z<'.&>#"
+
+        """
+        encoded_message = ""
+
+        # encoding shift like Caesar cipher algorithm implementing positive shift or
+        # forward shift or right shift
+        for i in plaintext:
+            position = self.__key_list.index(i)
+            encoded_message += self.__key_list[
+                (position + self.__shift_key) % len(self.__key_list)
+            ]
+
+        return encoded_message
+
+
+def test_end_to_end(msg: str = "Hello, this is a modified Caesar cipher") -> str:
+    """
+    >>> test_end_to_end()
+    'Hello, this is a modified Caesar cipher'
+    """
+    cip1 = ShuffledShiftCipher()
+    return cip1.decrypt(cip1.encrypt(msg))
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python reference for shuffled shift cipher
- implement shuffled shift cipher in Mochi with passcode generation, key list shuffling, and encrypt/decrypt helpers
- include runtime output example

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/ciphers/shuffled_shift_cipher.mochi > tests/github/TheAlgorithms/Mochi/ciphers/shuffled_shift_cipher.out`

------
https://chatgpt.com/codex/tasks/task_e_68915841640483208208d0dac5d2ee39