### PR TITLE
Add RSA key generator example in Mochi tests

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/ciphers/rsa_key_generator.mochi
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/rsa_key_generator.mochi
@@ -1,0 +1,116 @@
+/*
+  RSA Key Generator using simple deterministic randomness.
+
+  The algorithm demonstrates how public and private keys are created.
+  Steps:
+  1. Generate two pseudo-random primes p and q with the requested bit size.
+  2. Compute n = p * q and Euler's totient phi = (p - 1) * (q - 1).
+  3. Choose e such that gcd(e, phi) = 1.
+  4. Compute d, the modular multiplicative inverse of e mod phi.
+
+  The returned keys are (n, e) for the public key and (n, d) for the private
+  key.  This example uses an 8-bit key size so the primes are small and the
+  program runs quickly.
+*/
+
+fun pow2(exp: int): int {
+  var res = 1
+  var i = 0
+  while i < exp {
+    res = res * 2
+    i = i + 1
+  }
+  return res
+}
+
+var seed: int = 1
+fun next_seed(x: int): int {
+  return (x * 1103515245 + 12345) % 2147483648
+}
+
+fun rand_range(min: int, max: int): int {
+  seed = next_seed(seed)
+  return min + seed % (max - min)
+}
+
+fun gcd(a: int, b: int): int {
+  var x = a
+  var y = b
+  while y != 0 {
+    let temp = x % y
+    x = y
+    y = temp
+  }
+  return x
+}
+
+fun mod_inverse(e: int, phi: int): int {
+  var t = 0
+  var newt = 1
+  var r = phi
+  var newr = e
+  while newr != 0 {
+    let quotient = r / newr
+    let tmp = newt
+    newt = t - quotient * newt
+    t = tmp
+    let tmp_r = newr
+    newr = r - quotient * newr
+    r = tmp_r
+  }
+  if r > 1 { return 0 }
+  if t < 0 { t = t + phi }
+  return t
+}
+
+fun is_prime(n: int): bool {
+  if n < 2 { return false }
+  var i = 2
+  while i * i <= n {
+    if n % i == 0 { return false }
+    i = i + 1
+  }
+  return true
+}
+
+fun generate_prime(bits: int): int {
+  let min = pow2(bits - 1)
+  let max = pow2(bits)
+  var p = rand_range(min, max)
+  if p % 2 == 0 { p = p + 1 }
+  while !is_prime(p) {
+    p = p + 2
+    if p >= max {
+      p = min + 1
+    }
+  }
+  return p
+}
+
+type Keys {
+  public_key: list<int>,
+  private_key: list<int>
+}
+
+fun generate_key(bits: int): Keys {
+  let p = generate_prime(bits)
+  let q = generate_prime(bits)
+  let n = p * q
+  let phi = (p - 1) * (q - 1)
+  var e = rand_range(2, phi)
+  while gcd(e, phi) != 1 {
+    e = e + 1
+    if e >= phi { e = 2 }
+  }
+  let d = mod_inverse(e, phi)
+  return Keys {
+    public_key: [n, e],
+    private_key: [n, d]
+  }
+}
+
+let keys = generate_key(8)
+let pub = keys.public_key
+let priv = keys.private_key
+print("Public key: (" + str(pub[0]) + ", " + str(pub[1]) + ")")
+print("Private key: (" + str(priv[0]) + ", " + str(priv[1]) + ")")

--- a/tests/github/TheAlgorithms/Mochi/ciphers/rsa_key_generator.out
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/rsa_key_generator.out
@@ -1,0 +1,2 @@
+Public key: (38911, 28477)
+Private key: (38911, 22213)

--- a/tests/github/TheAlgorithms/Python/ciphers/rsa_key_generator.py
+++ b/tests/github/TheAlgorithms/Python/ciphers/rsa_key_generator.py
@@ -1,0 +1,63 @@
+import os
+import random
+import sys
+
+from maths.greatest_common_divisor import gcd_by_iterative
+
+from . import cryptomath_module, rabin_miller
+
+
+def main() -> None:
+    print("Making key files...")
+    make_key_files("rsa", 1024)
+    print("Key files generation successful.")
+
+
+def generate_key(key_size: int) -> tuple[tuple[int, int], tuple[int, int]]:
+    """
+    >>> random.seed(0) # for repeatability
+    >>> public_key, private_key = generate_key(8)
+    >>> public_key
+    (26569, 239)
+    >>> private_key
+    (26569, 2855)
+    """
+    p = rabin_miller.generate_large_prime(key_size)
+    q = rabin_miller.generate_large_prime(key_size)
+    n = p * q
+
+    # Generate e that is relatively prime to (p - 1) * (q - 1)
+    while True:
+        e = random.randrange(2 ** (key_size - 1), 2 ** (key_size))
+        if gcd_by_iterative(e, (p - 1) * (q - 1)) == 1:
+            break
+
+    # Calculate d that is mod inverse of e
+    d = cryptomath_module.find_mod_inverse(e, (p - 1) * (q - 1))
+
+    public_key = (n, e)
+    private_key = (n, d)
+    return (public_key, private_key)
+
+
+def make_key_files(name: str, key_size: int) -> None:
+    if os.path.exists(f"{name}_pubkey.txt") or os.path.exists(f"{name}_privkey.txt"):
+        print("\nWARNING:")
+        print(
+            f'"{name}_pubkey.txt" or "{name}_privkey.txt" already exists. \n'
+            "Use a different name or delete these files and re-run this program."
+        )
+        sys.exit()
+
+    public_key, private_key = generate_key(key_size)
+    print(f"\nWriting public key to file {name}_pubkey.txt...")
+    with open(f"{name}_pubkey.txt", "w") as out_file:
+        out_file.write(f"{key_size},{public_key[0]},{public_key[1]}")
+
+    print(f"Writing private key to file {name}_privkey.txt...")
+    with open(f"{name}_privkey.txt", "w") as out_file:
+        out_file.write(f"{key_size},{private_key[0]},{private_key[1]}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python `rsa_key_generator` source from TheAlgorithms
- implement equivalent Mochi RSA key generator using deterministic prime selection and modular inverse
- include sample output file

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/ciphers/rsa_key_generator.mochi`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6891582ec4c08320b7fabcd8b555ef63