### PR TITLE
Add transposition cipher file encryption example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/ciphers/transposition_cipher_encrypt_decrypt_file.mochi
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/transposition_cipher_encrypt_decrypt_file.mochi
@@ -1,0 +1,68 @@
+/*
+Transposition cipher file encryption and decryption.
+
+This program demonstrates the columnar transposition cipher used to encrypt
+and decrypt text. Given a numeric key representing the number of columns, the
+plain text is written row-wise into a grid and read column by column to produce
+cipher text. Decryption rebuilds the grid using the key, accounting for empty
+cells in the final row.
+
+The original Python script reads from an input file and writes the translated
+result. This Mochi version focuses on the algorithm itself and runs on a
+sample string.
+*/
+
+fun encrypt_message(key: int, message: string): string {
+  var result = ""
+  var col = 0
+  while col < key {
+    var pointer = col
+    while pointer < len(message) {
+      result = result + message[pointer]
+      pointer = pointer + key
+    }
+    col = col + 1
+  }
+  return result
+}
+
+fun decrypt_message(key: int, message: string): string {
+  let msg_len = len(message)
+  var num_cols = msg_len / key
+  if msg_len % key != 0 { num_cols = num_cols + 1 }
+  let num_rows = key
+  let num_shaded_boxes = num_cols * num_rows - msg_len
+  var plain: list<string> = []
+  var i = 0
+  while i < num_cols {
+    plain = append(plain, "")
+    i = i + 1
+  }
+  var col = 0
+  var row = 0
+  var idx = 0
+  while idx < msg_len {
+    let ch = message[idx]
+    plain[col] = plain[col] + ch
+    col = col + 1
+    if col == num_cols || (col == num_cols - 1 && row >= num_rows - num_shaded_boxes) {
+      col = 0
+      row = row + 1
+    }
+    idx = idx + 1
+  }
+  var result = ""
+  i = 0
+  while i < num_cols {
+    result = result + plain[i]
+    i = i + 1
+  }
+  return result
+}
+
+let key = 6
+let message = "Harshil Darji"
+let encrypted = encrypt_message(key, message)
+print(encrypted)
+let decrypted = decrypt_message(key, encrypted)
+print(decrypted)

--- a/tests/github/TheAlgorithms/Mochi/ciphers/transposition_cipher_encrypt_decrypt_file.out
+++ b/tests/github/TheAlgorithms/Mochi/ciphers/transposition_cipher_encrypt_decrypt_file.out
@@ -1,0 +1,2 @@
+Hlia rDsahrij
+Harshil Darji

--- a/tests/github/TheAlgorithms/Python/ciphers/transposition_cipher_encrypt_decrypt_file.py
+++ b/tests/github/TheAlgorithms/Python/ciphers/transposition_cipher_encrypt_decrypt_file.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import time
+
+from . import transposition_cipher as trans_cipher
+
+
+def main() -> None:
+    input_file = "./prehistoric_men.txt"
+    output_file = "./Output.txt"
+    key = int(input("Enter key: "))
+    mode = input("Encrypt/Decrypt [e/d]: ")
+
+    if not os.path.exists(input_file):
+        print(f"File {input_file} does not exist. Quitting...")
+        sys.exit()
+    if os.path.exists(output_file):
+        print(f"Overwrite {output_file}? [y/n]")
+        response = input("> ")
+        if not response.lower().startswith("y"):
+            sys.exit()
+
+    start_time = time.time()
+    if mode.lower().startswith("e"):
+        with open(input_file) as f:
+            content = f.read()
+        translated = trans_cipher.encrypt_message(key, content)
+    elif mode.lower().startswith("d"):
+        with open(output_file) as f:
+            content = f.read()
+        translated = trans_cipher.decrypt_message(key, content)
+
+    with open(output_file, "w") as output_obj:
+        output_obj.write(translated)
+
+    total_time = round(time.time() - start_time, 2)
+    print(("Done (", total_time, "seconds )"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python script for transposition cipher file encryption/decryption
- implement Mochi version with columnar transposition encryption and decryption
- include example output generated by runtime/vm

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/ciphers/transposition_cipher_encrypt_decrypt_file.mochi`

------
https://chatgpt.com/codex/tasks/task_e_689159c02374832087fe622a5422a1fe