### PR TITLE
Add CNN classification example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/computer_vision/cnn_classification.mochi
+++ b/tests/github/TheAlgorithms/Mochi/computer_vision/cnn_classification.mochi
@@ -1,0 +1,149 @@
+/*
+Convolutional Neural Network Classification (Simplified)
+
+This program demonstrates the forward pass of a minimal
+convolutional neural network.  The goal is to classify a
+small 5x5 grayscale image as "Normal" or "Abnormality detected".
+
+The algorithm follows the typical CNN pipeline:
+1. Convolution with a 3x3 kernel followed by ReLU activation.
+2. 2x2 max pooling to reduce spatial size.
+3. Flattening of the feature map.
+4. Dense layer with sigmoid activation that outputs a probability.
+   The weights are fixed to illustrate the mechanics rather than
+   train a real medical model.
+*/
+
+fun conv2d(image: list<list<float>>, kernel: list<list<float>>): list<list<float>> {
+  let rows = len(image)
+  let cols = len(image[0])
+  let k = len(kernel)
+  var output: list<list<float>> = []
+  var i = 0
+  while i <= rows - k {
+    var row: list<float> = []
+    var j = 0
+    while j <= cols - k {
+      var sum: float = 0.0
+      var ki = 0
+      while ki < k {
+        var kj = 0
+        while kj < k {
+          sum = sum + image[i + ki][j + kj] * kernel[ki][kj]
+          kj = kj + 1
+        }
+        ki = ki + 1
+      }
+      row = append(row, sum)
+      j = j + 1
+    }
+    output = append(output, row)
+    i = i + 1
+  }
+  return output
+}
+
+fun relu_matrix(m: list<list<float>>): list<list<float>> {
+  var out: list<list<float>> = []
+  for row in m {
+    var new_row: list<float> = []
+    for v in row {
+      if v > 0.0 {
+        new_row = append(new_row, v)
+      } else {
+        new_row = append(new_row, 0.0)
+      }
+    }
+    out = append(out, new_row)
+  }
+  return out
+}
+
+fun max_pool2x2(m: list<list<float>>): list<list<float>> {
+  let rows = len(m)
+  let cols = len(m[0])
+  var out: list<list<float>> = []
+  var i = 0
+  while i < rows {
+    var new_row: list<float> = []
+    var j = 0
+    while j < cols {
+      var max_val = m[i][j]
+      if m[i][j + 1] > max_val { max_val = m[i][j + 1] }
+      if m[i + 1][j] > max_val { max_val = m[i + 1][j] }
+      if m[i + 1][j + 1] > max_val { max_val = m[i + 1][j + 1] }
+      new_row = append(new_row, max_val)
+      j = j + 2
+    }
+    out = append(out, new_row)
+    i = i + 2
+  }
+  return out
+}
+
+fun flatten(m: list<list<float>>): list<float> {
+  var res: list<float> = []
+  for row in m {
+    for v in row {
+      res = append(res, v)
+    }
+  }
+  return res
+}
+
+fun dense(inputs: list<float>, weights: list<float>, bias: float): float {
+  var s: float = bias
+  var i = 0
+  while i < len(inputs) {
+    s = s + inputs[i] * weights[i]
+    i = i + 1
+  }
+  return s
+}
+
+fun exp_approx(x: float): float {
+  var sum: float = 1.0
+  var term: float = 1.0
+  var i = 1
+  while i <= 10 {
+    term = term * x / i
+    sum = sum + term
+    i = i + 1
+  }
+  return sum
+}
+
+fun sigmoid(x: float): float {
+  return 1.0 / (1.0 + exp_approx(-x))
+}
+
+let image: list<list<float>> = [
+  [0.0,1.0,1.0,0.0,0.0,0.0],
+  [0.0,1.0,1.0,0.0,0.0,0.0],
+  [0.0,0.0,1.0,1.0,0.0,0.0],
+  [0.0,0.0,1.0,1.0,0.0,0.0],
+  [0.0,0.0,0.0,0.0,0.0,0.0],
+  [0.0,0.0,0.0,0.0,0.0,0.0]
+]
+
+let kernel: list<list<float>> = [
+  [1.0,0.0,-1.0],
+  [1.0,0.0,-1.0],
+  [1.0,0.0,-1.0]
+]
+
+let conv = conv2d(image, kernel)
+let activated = relu_matrix(conv)
+let pooled = max_pool2x2(activated)
+let flat = flatten(pooled)
+let weights: list<float> = [0.5, -0.4, 0.3, 0.1]
+let bias: float = 0.0
+let output = dense(flat, weights, bias)
+let probability = sigmoid(output)
+if probability >= 0.5 {
+  print("Abnormality detected")
+} else {
+  print("Normal")
+}
+print("Probability:")
+print(probability)

--- a/tests/github/TheAlgorithms/Mochi/computer_vision/cnn_classification.out
+++ b/tests/github/TheAlgorithms/Mochi/computer_vision/cnn_classification.out
@@ -1,0 +1,3 @@
+Normal
+Probability:
+0.3775406687999645

--- a/tests/github/TheAlgorithms/Python/computer_vision/cnn_classification.py
+++ b/tests/github/TheAlgorithms/Python/computer_vision/cnn_classification.py
@@ -1,0 +1,100 @@
+"""
+Convolutional Neural Network
+
+Objective : To train a CNN model detect if TB is present in Lung X-ray or not.
+
+Resources CNN Theory :
+    https://en.wikipedia.org/wiki/Convolutional_neural_network
+Resources Tensorflow : https://www.tensorflow.org/tutorials/images/cnn
+
+Download dataset from :
+https://lhncbc.nlm.nih.gov/LHC-publications/pubs/TuberculosisChestXrayImageDataSets.html
+
+1. Download the dataset folder and create two folder training set and test set
+in the parent dataset folder
+2. Move 30-40 image from both TB positive and TB Negative folder
+in the test set folder
+3. The labels of the images will be extracted from the folder name
+the image is present in.
+
+"""
+
+# Part 1 - Building the CNN
+
+import numpy as np
+
+# Importing the Keras libraries and packages
+import tensorflow as tf
+from keras import layers, models
+
+if __name__ == "__main__":
+    # Initialising the CNN
+    # (Sequential- Building the model layer by layer)
+    classifier = models.Sequential()
+
+    # Step 1 - Convolution
+    # Here 64,64 is the length & breadth of dataset images and 3 is for the RGB channel
+    # (3,3) is the kernel size (filter matrix)
+    classifier.add(
+        layers.Conv2D(32, (3, 3), input_shape=(64, 64, 3), activation="relu")
+    )
+
+    # Step 2 - Pooling
+    classifier.add(layers.MaxPooling2D(pool_size=(2, 2)))
+
+    # Adding a second convolutional layer
+    classifier.add(layers.Conv2D(32, (3, 3), activation="relu"))
+    classifier.add(layers.MaxPooling2D(pool_size=(2, 2)))
+
+    # Step 3 - Flattening
+    classifier.add(layers.Flatten())
+
+    # Step 4 - Full connection
+    classifier.add(layers.Dense(units=128, activation="relu"))
+    classifier.add(layers.Dense(units=1, activation="sigmoid"))
+
+    # Compiling the CNN
+    classifier.compile(
+        optimizer="adam", loss="binary_crossentropy", metrics=["accuracy"]
+    )
+
+    # Part 2 - Fitting the CNN to the images
+
+    # Load Trained model weights
+
+    # from keras.models import load_model
+    # regressor=load_model('cnn.h5')
+
+    train_datagen = tf.keras.preprocessing.image.ImageDataGenerator(
+        rescale=1.0 / 255, shear_range=0.2, zoom_range=0.2, horizontal_flip=True
+    )
+
+    test_datagen = tf.keras.preprocessing.image.ImageDataGenerator(rescale=1.0 / 255)
+
+    training_set = train_datagen.flow_from_directory(
+        "dataset/training_set", target_size=(64, 64), batch_size=32, class_mode="binary"
+    )
+
+    test_set = test_datagen.flow_from_directory(
+        "dataset/test_set", target_size=(64, 64), batch_size=32, class_mode="binary"
+    )
+
+    classifier.fit_generator(
+        training_set, steps_per_epoch=5, epochs=30, validation_data=test_set
+    )
+
+    classifier.save("cnn.h5")
+
+    # Part 3 - Making new predictions
+
+    test_image = tf.keras.preprocessing.image.load_img(
+        "dataset/single_prediction/image.png", target_size=(64, 64)
+    )
+    test_image = tf.keras.preprocessing.image.img_to_array(test_image)
+    test_image = np.expand_dims(test_image, axis=0)
+    result = classifier.predict(test_image)
+    # training_set.class_indices
+    if result[0][0] == 0:
+        prediction = "Normal"
+    if result[0][0] == 1:
+        prediction = "Abnormality detected"


### PR DESCRIPTION
## Summary
- add missing Python CNN classification example from TheAlgorithms
- implement simplified forward-pass CNN example in Mochi
- include output demonstrating classification probability

## Testing
- `/root/bin/mochi run tests/github/TheAlgorithms/Mochi/computer_vision/cnn_classification.mochi`

------
https://chatgpt.com/codex/tasks/task_e_68915a1424188320ba94883790e6a2b6