### PR TITLE
Add conversion of numbers to English words in Mochi

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/conversions/convert_number_to_words.mochi
+++ b/tests/github/TheAlgorithms/Mochi/conversions/convert_number_to_words.mochi
@@ -1,0 +1,115 @@
+/*
+Convert a non-negative integer into its English words representation for
+three numbering systems: short scale, long scale, and the Indian system.
+Each system defines groups of digits (thousand, lakh, etc.). The algorithm
+recursively extracts digit groups using powers of ten, converts each group
+into words (handling irregular numbers below one hundred), and appends the
+associated unit. Negative values are prefixed with "negative" and inputs are
+validated against each system's maximum supported value. The complexity is
+O(d) where d is the number of digit groups in the input, proportional to the
+logarithm base 10 of the number.
+*/
+
+let ones: list<string> = ["zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"]
+let teens: list<string> = ["ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen", "nineteen"]
+let tens: list<string> = ["", "", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety"]
+
+let short_powers: list<int> = [15, 12, 9, 6, 3, 2]
+let short_units: list<string> = ["quadrillion", "trillion", "billion", "million", "thousand", "hundred"]
+let long_powers: list<int> = [15, 9, 6, 3, 2]
+let long_units: list<string> = ["billiard", "milliard", "million", "thousand", "hundred"]
+let indian_powers: list<int> = [14, 12, 7, 5, 3, 2]
+let indian_units: list<string> = ["crore crore", "lakh crore", "crore", "lakh", "thousand", "hundred"]
+
+fun pow10(exp: int): int {
+  var res = 1
+  var i = 0
+  while i < exp {
+    res = res * 10
+    i = i + 1
+  }
+  return res
+}
+
+fun max_value(system: string): int {
+  if system == "short" { return pow10(18) - 1 }
+  if system == "long" { return pow10(21) - 1 }
+  if system == "indian" { return pow10(19) - 1 }
+  return 0
+}
+
+fun join_words(words: list<string>): string {
+  var res = ""
+  var i = 0
+  while i < len(words) {
+    if i > 0 { res = res + " " }
+    res = res + words[i]
+    i = i + 1
+  }
+  return res
+}
+
+fun convert_small_number(num: int): string {
+  if num < 0 { return "" }
+  if num >= 100 { return "" }
+  let tens_digit = num / 10
+  let ones_digit = num % 10
+  if tens_digit == 0 { return ones[ones_digit] }
+  if tens_digit == 1 { return teens[ones_digit] }
+  let hyphen = if ones_digit > 0 { "-" } else "" 
+  let tail = if ones_digit > 0 { ones[ones_digit] } else ""
+  return tens[tens_digit] + hyphen + tail
+}
+
+fun convert_number(num: int, system: string): string {
+  var word_groups: list<string> = []
+  var n = num
+  if n < 0 {
+    word_groups = append(word_groups, "negative")
+    n = -n
+  }
+  if n > max_value(system) { return "" }
+
+  var powers: list<int> = []
+  var units: list<string> = []
+  if system == "short" {
+    powers = short_powers
+    units = short_units
+  } else {
+    if system == "long" {
+      powers = long_powers
+      units = long_units
+    } else {
+      if system == "indian" {
+        powers = indian_powers
+        units = indian_units
+      } else {
+        return ""
+      }
+    }
+  }
+
+  var i = 0
+  while i < len(powers) {
+    let power = powers[i]
+    let unit = units[i]
+    let divisor = pow10(power)
+    let digit_group = n / divisor
+    n = n % divisor
+    if digit_group > 0 {
+      let word_group = if digit_group >= 100 { convert_number(digit_group, system) } else { convert_small_number(digit_group) }
+      word_groups = append(word_groups, word_group + " " + unit)
+    }
+    i = i + 1
+  }
+
+  if n > 0 || len(word_groups) == 0 {
+    word_groups = append(word_groups, convert_small_number(n))
+  }
+  let joined = join_words(word_groups)
+  return joined
+}
+
+print(convert_number(123456789012345, "short"))
+print(convert_number(123456789012345, "long"))
+print(convert_number(123456789012345, "indian"))

--- a/tests/github/TheAlgorithms/Mochi/conversions/convert_number_to_words.out
+++ b/tests/github/TheAlgorithms/Mochi/conversions/convert_number_to_words.out
@@ -1,0 +1,3 @@
+one hundred twenty-three trillion four hundred fifty-six billion seven hundred eighty-nine million twelve thousand three hundred forty-five
+one hundred twenty-three thousand four hundred fifty-six milliard seven hundred eighty-nine million twelve thousand three hundred forty-five
+one crore crore twenty-three lakh crore forty-five thousand six hundred seventy-eight crore ninety lakh twelve thousand three hundred forty-five

--- a/tests/github/TheAlgorithms/Python/conversions/convert_number_to_words.py
+++ b/tests/github/TheAlgorithms/Python/conversions/convert_number_to_words.py
@@ -1,0 +1,205 @@
+from enum import Enum
+from typing import Literal
+
+
+class NumberingSystem(Enum):
+    SHORT = (
+        (15, "quadrillion"),
+        (12, "trillion"),
+        (9, "billion"),
+        (6, "million"),
+        (3, "thousand"),
+        (2, "hundred"),
+    )
+
+    LONG = (
+        (15, "billiard"),
+        (9, "milliard"),
+        (6, "million"),
+        (3, "thousand"),
+        (2, "hundred"),
+    )
+
+    INDIAN = (
+        (14, "crore crore"),
+        (12, "lakh crore"),
+        (7, "crore"),
+        (5, "lakh"),
+        (3, "thousand"),
+        (2, "hundred"),
+    )
+
+    @classmethod
+    def max_value(cls, system: str) -> int:
+        """
+        Gets the max value supported by the given number system.
+
+        >>> NumberingSystem.max_value("short") == 10**18 - 1
+        True
+        >>> NumberingSystem.max_value("long") == 10**21 - 1
+        True
+        >>> NumberingSystem.max_value("indian") == 10**19 - 1
+        True
+        """
+        match system_enum := cls[system.upper()]:
+            case cls.SHORT:
+                max_exp = system_enum.value[0][0] + 3
+            case cls.LONG:
+                max_exp = system_enum.value[0][0] + 6
+            case cls.INDIAN:
+                max_exp = 19
+            case _:
+                raise ValueError("Invalid numbering system")
+        return 10**max_exp - 1
+
+
+class NumberWords(Enum):
+    ONES = {  # noqa: RUF012
+        0: "",
+        1: "one",
+        2: "two",
+        3: "three",
+        4: "four",
+        5: "five",
+        6: "six",
+        7: "seven",
+        8: "eight",
+        9: "nine",
+    }
+
+    TEENS = {  # noqa: RUF012
+        0: "ten",
+        1: "eleven",
+        2: "twelve",
+        3: "thirteen",
+        4: "fourteen",
+        5: "fifteen",
+        6: "sixteen",
+        7: "seventeen",
+        8: "eighteen",
+        9: "nineteen",
+    }
+
+    TENS = {  # noqa: RUF012
+        2: "twenty",
+        3: "thirty",
+        4: "forty",
+        5: "fifty",
+        6: "sixty",
+        7: "seventy",
+        8: "eighty",
+        9: "ninety",
+    }
+
+
+def convert_small_number(num: int) -> str:
+    """
+    Converts small, non-negative integers with irregular constructions in English (i.e.,
+    numbers under 100) into words.
+
+    >>> convert_small_number(0)
+    'zero'
+    >>> convert_small_number(5)
+    'five'
+    >>> convert_small_number(10)
+    'ten'
+    >>> convert_small_number(15)
+    'fifteen'
+    >>> convert_small_number(20)
+    'twenty'
+    >>> convert_small_number(25)
+    'twenty-five'
+    >>> convert_small_number(-1)
+    Traceback (most recent call last):
+    ...
+    ValueError: This function only accepts non-negative integers
+    >>> convert_small_number(123)
+    Traceback (most recent call last):
+    ...
+    ValueError: This function only converts numbers less than 100
+    """
+    if num < 0:
+        raise ValueError("This function only accepts non-negative integers")
+    if num >= 100:
+        raise ValueError("This function only converts numbers less than 100")
+    tens, ones = divmod(num, 10)
+    if tens == 0:
+        return NumberWords.ONES.value[ones] or "zero"
+    if tens == 1:
+        return NumberWords.TEENS.value[ones]
+    return (
+        NumberWords.TENS.value[tens]
+        + ("-" if NumberWords.ONES.value[ones] else "")
+        + NumberWords.ONES.value[ones]
+    )
+
+
+def convert_number(
+    num: int, system: Literal["short", "long", "indian"] = "short"
+) -> str:
+    """
+    Converts an integer to English words.
+
+    :param num: The integer to be converted
+    :param system: The numbering system (short, long, or Indian)
+
+    >>> convert_number(0)
+    'zero'
+    >>> convert_number(1)
+    'one'
+    >>> convert_number(100)
+    'one hundred'
+    >>> convert_number(-100)
+    'negative one hundred'
+    >>> convert_number(123_456_789_012_345) # doctest: +NORMALIZE_WHITESPACE
+    'one hundred twenty-three trillion four hundred fifty-six billion
+    seven hundred eighty-nine million twelve thousand three hundred forty-five'
+    >>> convert_number(123_456_789_012_345, "long") # doctest: +NORMALIZE_WHITESPACE
+    'one hundred twenty-three thousand four hundred fifty-six milliard
+    seven hundred eighty-nine million twelve thousand three hundred forty-five'
+    >>> convert_number(12_34_56_78_90_12_345, "indian") # doctest: +NORMALIZE_WHITESPACE
+    'one crore crore twenty-three lakh crore
+    forty-five thousand six hundred seventy-eight crore
+    ninety lakh twelve thousand three hundred forty-five'
+    >>> convert_number(10**18)
+    Traceback (most recent call last):
+    ...
+    ValueError: Input number is too large
+    >>> convert_number(10**21, "long")
+    Traceback (most recent call last):
+    ...
+    ValueError: Input number is too large
+    >>> convert_number(10**19, "indian")
+    Traceback (most recent call last):
+    ...
+    ValueError: Input number is too large
+    """
+    word_groups = []
+
+    if num < 0:
+        word_groups.append("negative")
+        num *= -1
+
+    if num > NumberingSystem.max_value(system):
+        raise ValueError("Input number is too large")
+
+    for power, unit in NumberingSystem[system.upper()].value:
+        digit_group, num = divmod(num, 10**power)
+        if digit_group > 0:
+            word_group = (
+                convert_number(digit_group, system)
+                if digit_group >= 100
+                else convert_small_number(digit_group)
+            )
+            word_groups.append(f"{word_group} {unit}")
+    if num > 0 or not word_groups:  # word_groups is only empty if input num was 0
+        word_groups.append(convert_small_number(num))
+    return " ".join(word_groups)
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+
+    print(f"{convert_number(123456789) = }")


### PR DESCRIPTION
## Summary
- add Python reference for number to words conversion supporting short, long and Indian systems
- implement pure Mochi version of number-to-words converter with recursive digit grouping
- include runtime output demonstrating all three numbering systems

## Testing
- `python3 -m py_compile tests/github/TheAlgorithms/Python/conversions/convert_number_to_words.py`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/conversions/convert_number_to_words.mochi > /tmp/raw.out`


------
https://chatgpt.com/codex/tasks/task_e_6891645ef07c8320a9bf50599df0d540