### PR TITLE
Add Burrows-Wheeler transform implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_compression/burrows_wheeler.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_compression/burrows_wheeler.mochi
@@ -1,0 +1,120 @@
+/*
+Burrows–Wheeler Transform (BWT)
+
+The BWT rearranges characters of a string into runs of similar characters to
+aid compression. For a given string, all rotations of the string are generated
+and sorted lexicographically. The transform is the string formed by taking the
+last character of each sorted rotation, along with the index of the original
+string within the sorted rotations.
+
+The transform is reversible. To invert, start with an array of empty strings.
+Repeatedly prepend the characters of the BWT string to each array element and
+sort the array each time. After as many iterations as the string length, the
+original string is the rotation at the saved index.
+
+This implementation provides both the forward transform and its inverse using
+only Mochi's standard library.
+*/
+
+type BWTResult { bwt_string: string, idx_original_string: int }
+
+fun all_rotations(s: string): list<string> {
+  let n = len(s)
+  var rotations: list<string> = []
+  var i = 0
+  while i < n {
+    let rotation = substring(s, i, n) + substring(s, 0, i)
+    rotations = append(rotations, rotation)
+    i = i + 1
+  }
+  return rotations
+}
+
+fun sort_strings(arr: list<string>): list<string> {
+  let n = len(arr)
+  var i = 1
+  while i < n {
+    var key = arr[i]
+    var j = i - 1
+    while j >= 0 && arr[j] > key {
+      arr[j + 1] = arr[j]
+      j = j - 1
+    }
+    arr[j + 1] = key
+    i = i + 1
+  }
+  return arr
+}
+
+fun join_strings(arr: list<string>): string {
+  var res = ""
+  var i = 0
+  while i < len(arr) {
+    res = res + arr[i]
+    i = i + 1
+  }
+  return res
+}
+
+fun bwt_transform(s: string): BWTResult {
+  if s == "" {
+    panic("input string must not be empty")
+  }
+  var rotations = all_rotations(s)
+  rotations = sort_strings(rotations)
+  var last_col: list<string> = []
+  var i = 0
+  while i < len(rotations) {
+    let word = rotations[i]
+    last_col = append(last_col, substring(word, len(word) - 1, len(word)))
+    i = i + 1
+  }
+  let bwt_string = join_strings(last_col)
+  let idx = index_of(rotations, s)
+  return BWTResult { bwt_string: bwt_string, idx_original_string: idx }
+}
+
+fun index_of(arr: list<string>, target: string): int {
+  var i = 0
+  while i < len(arr) {
+    if arr[i] == target {
+      return i
+    }
+    i = i + 1
+  }
+  return -1
+}
+
+fun reverse_bwt(bwt_string: string, idx_original_string: int): string {
+  if bwt_string == "" {
+    panic("bwt string must not be empty")
+  }
+  let n = len(bwt_string)
+  if idx_original_string < 0 || idx_original_string >= n {
+    panic("index out of range")
+  }
+  var ordered_rotations: list<string> = []
+  var i = 0
+  while i < n {
+    ordered_rotations = append(ordered_rotations, "")
+    i = i + 1
+  }
+  var iter = 0
+  while iter < n {
+    var j = 0
+    while j < n {
+      let ch = substring(bwt_string, j, j + 1)
+      ordered_rotations[j] = ch + ordered_rotations[j]
+      j = j + 1
+    }
+    ordered_rotations = sort_strings(ordered_rotations)
+    iter = iter + 1
+  }
+  return ordered_rotations[idx_original_string]
+}
+
+let s = "^BANANA"
+let result = bwt_transform(s)
+print(result.bwt_string)
+print(result.idx_original_string)
+print(reverse_bwt(result.bwt_string, result.idx_original_string))

--- a/tests/github/TheAlgorithms/Mochi/data_compression/burrows_wheeler.out
+++ b/tests/github/TheAlgorithms/Mochi/data_compression/burrows_wheeler.out
@@ -1,0 +1,3 @@
+BNN^AAA
+6
+^BANANA

--- a/tests/github/TheAlgorithms/Python/data_compression/burrows_wheeler.py
+++ b/tests/github/TheAlgorithms/Python/data_compression/burrows_wheeler.py
@@ -1,0 +1,177 @@
+"""
+https://en.wikipedia.org/wiki/Burrows%E2%80%93Wheeler_transform
+
+The Burrows-Wheeler transform (BWT, also called block-sorting compression)
+rearranges a character string into runs of similar characters. This is useful
+for compression, since it tends to be easy to compress a string that has runs
+of repeated characters by techniques such as move-to-front transform and
+run-length encoding. More importantly, the transformation is reversible,
+without needing to store any additional data except the position of the first
+original character. The BWT is thus a "free" method of improving the efficiency
+of text compression algorithms, costing only some extra computation.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class BWTTransformDict(TypedDict):
+    bwt_string: str
+    idx_original_string: int
+
+
+def all_rotations(s: str) -> list[str]:
+    """
+    :param s: The string that will be rotated len(s) times.
+    :return: A list with the rotations.
+    :raises TypeError: If s is not an instance of str.
+    Examples:
+
+    >>> all_rotations("^BANANA|") # doctest: +NORMALIZE_WHITESPACE
+    ['^BANANA|', 'BANANA|^', 'ANANA|^B', 'NANA|^BA', 'ANA|^BAN', 'NA|^BANA',
+    'A|^BANAN', '|^BANANA']
+    >>> all_rotations("a_asa_da_casa") # doctest: +NORMALIZE_WHITESPACE
+    ['a_asa_da_casa', '_asa_da_casaa', 'asa_da_casaa_', 'sa_da_casaa_a',
+    'a_da_casaa_as', '_da_casaa_asa', 'da_casaa_asa_', 'a_casaa_asa_d',
+    '_casaa_asa_da', 'casaa_asa_da_', 'asaa_asa_da_c', 'saa_asa_da_ca',
+    'aa_asa_da_cas']
+    >>> all_rotations("panamabanana") # doctest: +NORMALIZE_WHITESPACE
+    ['panamabanana', 'anamabananap', 'namabananapa', 'amabananapan',
+    'mabananapana', 'abananapanam', 'bananapanama', 'ananapanamab',
+    'nanapanamaba', 'anapanamaban', 'napanamabana', 'apanamabanan']
+    >>> all_rotations(5)
+    Traceback (most recent call last):
+        ...
+    TypeError: The parameter s type must be str.
+    """
+    if not isinstance(s, str):
+        raise TypeError("The parameter s type must be str.")
+
+    return [s[i:] + s[:i] for i in range(len(s))]
+
+
+def bwt_transform(s: str) -> BWTTransformDict:
+    """
+    :param s: The string that will be used at bwt algorithm
+    :return: the string composed of the last char of each row of the ordered
+    rotations and the index of the original string at ordered rotations list
+    :raises TypeError: If the s parameter type is not str
+    :raises ValueError: If the s parameter is empty
+    Examples:
+
+    >>> bwt_transform("^BANANA")
+    {'bwt_string': 'BNN^AAA', 'idx_original_string': 6}
+    >>> bwt_transform("a_asa_da_casa")
+    {'bwt_string': 'aaaadss_c__aa', 'idx_original_string': 3}
+    >>> bwt_transform("panamabanana")
+    {'bwt_string': 'mnpbnnaaaaaa', 'idx_original_string': 11}
+    >>> bwt_transform(4)
+    Traceback (most recent call last):
+        ...
+    TypeError: The parameter s type must be str.
+    >>> bwt_transform('')
+    Traceback (most recent call last):
+        ...
+    ValueError: The parameter s must not be empty.
+    """
+    if not isinstance(s, str):
+        raise TypeError("The parameter s type must be str.")
+    if not s:
+        raise ValueError("The parameter s must not be empty.")
+
+    rotations = all_rotations(s)
+    rotations.sort()  # sort the list of rotations in alphabetically order
+    # make a string composed of the last char of each rotation
+    response: BWTTransformDict = {
+        "bwt_string": "".join([word[-1] for word in rotations]),
+        "idx_original_string": rotations.index(s),
+    }
+    return response
+
+
+def reverse_bwt(bwt_string: str, idx_original_string: int) -> str:
+    """
+    :param bwt_string: The string returned from bwt algorithm execution
+    :param idx_original_string: A 0-based index of the string that was used to
+    generate bwt_string at ordered rotations list
+    :return: The string used to generate bwt_string when bwt was executed
+    :raises TypeError: If the bwt_string parameter type is not str
+    :raises ValueError: If the bwt_string parameter is empty
+    :raises TypeError: If the idx_original_string type is not int or if not
+    possible to cast it to int
+    :raises ValueError: If the idx_original_string value is lower than 0 or
+    greater than len(bwt_string) - 1
+
+    >>> reverse_bwt("BNN^AAA", 6)
+    '^BANANA'
+    >>> reverse_bwt("aaaadss_c__aa", 3)
+    'a_asa_da_casa'
+    >>> reverse_bwt("mnpbnnaaaaaa", 11)
+    'panamabanana'
+    >>> reverse_bwt(4, 11)
+    Traceback (most recent call last):
+        ...
+    TypeError: The parameter bwt_string type must be str.
+    >>> reverse_bwt("", 11)
+    Traceback (most recent call last):
+        ...
+    ValueError: The parameter bwt_string must not be empty.
+    >>> reverse_bwt("mnpbnnaaaaaa", "asd") # doctest: +NORMALIZE_WHITESPACE
+    Traceback (most recent call last):
+        ...
+    TypeError: The parameter idx_original_string type must be int or passive
+    of cast to int.
+    >>> reverse_bwt("mnpbnnaaaaaa", -1)
+    Traceback (most recent call last):
+        ...
+    ValueError: The parameter idx_original_string must not be lower than 0.
+    >>> reverse_bwt("mnpbnnaaaaaa", 12) # doctest: +NORMALIZE_WHITESPACE
+    Traceback (most recent call last):
+        ...
+    ValueError: The parameter idx_original_string must be lower than
+    len(bwt_string).
+    >>> reverse_bwt("mnpbnnaaaaaa", 11.0)
+    'panamabanana'
+    >>> reverse_bwt("mnpbnnaaaaaa", 11.4)
+    'panamabanana'
+    """
+    if not isinstance(bwt_string, str):
+        raise TypeError("The parameter bwt_string type must be str.")
+    if not bwt_string:
+        raise ValueError("The parameter bwt_string must not be empty.")
+    try:
+        idx_original_string = int(idx_original_string)
+    except ValueError:
+        raise TypeError(
+            "The parameter idx_original_string type must be int or passive"
+            " of cast to int."
+        )
+    if idx_original_string < 0:
+        raise ValueError("The parameter idx_original_string must not be lower than 0.")
+    if idx_original_string >= len(bwt_string):
+        raise ValueError(
+            "The parameter idx_original_string must be lower than len(bwt_string)."
+        )
+
+    ordered_rotations = [""] * len(bwt_string)
+    for _ in range(len(bwt_string)):
+        for i in range(len(bwt_string)):
+            ordered_rotations[i] = bwt_string[i] + ordered_rotations[i]
+        ordered_rotations.sort()
+    return ordered_rotations[idx_original_string]
+
+
+if __name__ == "__main__":
+    entry_msg = "Provide a string that I will generate its BWT transform: "
+    s = input(entry_msg).strip()
+    result = bwt_transform(s)
+    print(
+        f"Burrows Wheeler transform for string '{s}' results "
+        f"in '{result['bwt_string']}'"
+    )
+    original_string = reverse_bwt(result["bwt_string"], result["idx_original_string"])
+    print(
+        f"Reversing Burrows Wheeler transform for entry '{result['bwt_string']}' "
+        f"we get original string '{original_string}'"
+    )


### PR DESCRIPTION
## Summary
- add Python source for Burrows–Wheeler transform
- implement Burrows–Wheeler transform and inverse in Mochi

## Testing
- `./mochi run tests/github/TheAlgorithms/Mochi/data_compression/burrows_wheeler.mochi`

------
https://chatgpt.com/codex/tasks/task_e_689165ff8eb883208ab3efc44cd370e4