### PR TITLE
Add PSNR implementation in Mochi tests

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_compression/peak_signal_to_noise_ratio.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_compression/peak_signal_to_noise_ratio.mochi
@@ -1,0 +1,80 @@
+/*
+Peak signal-to-noise ratio (PSNR) measures the quality of a compressed image.
+Given two images represented as 2‑D lists of pixel intensities in the range
+0–255, compute the mean squared error (MSE) between corresponding pixels and
+derive the PSNR value in decibels:
+
+  PSNR = 20 * log10(MAX_I / sqrt(MSE))
+
+where MAX_I is the maximum possible pixel value (255). If MSE is zero, the
+images are identical and PSNR is defined as 100. This implementation provides
+simple Newton iteration for square roots and a series expansion for natural
+logarithms so that no external libraries or FFI are required.
+*/
+
+fun abs(x: float): float {
+  if x < 0.0 { return -x }
+  return x
+}
+
+fun sqrtApprox(x: float): float {
+  if x <= 0.0 { return 0.0 }
+  var guess = x
+  var i = 0
+  while i < 10 {
+    guess = (guess + x / guess) / 2.0
+    i = i + 1
+  }
+  return guess
+}
+
+fun ln(x: float): float {
+  let t = (x - 1.0) / (x + 1.0)
+  var term = t
+  var sum = 0.0
+  var n = 1
+  while n <= 19 {
+    sum = sum + term / (n as float)
+    term = term * t * t
+    n = n + 2
+  }
+  return 2.0 * sum
+}
+
+fun log10(x: float): float {
+  return ln(x) / ln(10.0)
+}
+
+fun peak_signal_to_noise_ratio(original: list<list<int>>, contrast: list<list<int>>): float {
+  var mse = 0.0
+  var i = 0
+  while i < len(original) {
+    var j = 0
+    while j < len(original[i]) {
+      let diff = (original[i][j] - contrast[i][j]) as float
+      mse = mse + diff * diff
+      j = j + 1
+    }
+    i = i + 1
+  }
+  let size = (len(original) * len(original[0])) as float
+  mse = mse / size
+  if mse == 0.0 {
+    return 100.0
+  }
+  let PIXEL_MAX = 255.0
+  return 20.0 * log10(PIXEL_MAX / sqrtApprox(mse))
+}
+
+test "identical images" {
+  let img: list<list<int>> = [[52, 55], [61, 59]]
+  expect peak_signal_to_noise_ratio(img, img) == 100.0
+}
+
+test "single pixel difference" {
+  let original: list<list<int>> = [[0, 0], [0, 0]]
+  let contrast: list<list<int>> = [[0, 0], [0, 1]]
+  let psnr = peak_signal_to_noise_ratio(original, contrast)
+  let expected = 20.0 * log10(255.0 / sqrtApprox(0.25))
+  expect abs(psnr - expected) < 0.0001
+}

--- a/tests/github/TheAlgorithms/Mochi/data_compression/peak_signal_to_noise_ratio.out
+++ b/tests/github/TheAlgorithms/Mochi/data_compression/peak_signal_to_noise_ratio.out
@@ -1,0 +1,3 @@
+[94;1mtests/github/TheAlgorithms/Mochi/data_compression/peak_signal_to_noise_ratio.mochi[0;22m
+   [33mtest[0m identical images               ... [32mok[0m (1.0ms)
+   [33mtest[0m single pixel difference        ... [32mok[0m (6.0ms)

--- a/tests/github/TheAlgorithms/Python/data_compression/peak_signal_to_noise_ratio.py
+++ b/tests/github/TheAlgorithms/Python/data_compression/peak_signal_to_noise_ratio.py
@@ -1,0 +1,46 @@
+"""
+Peak signal-to-noise ratio - PSNR
+    https://en.wikipedia.org/wiki/Peak_signal-to-noise_ratio
+Source:
+https://tutorials.techonical.com/how-to-calculate-psnr-value-of-two-images-using-python
+"""
+
+import math
+import os
+
+import cv2
+import numpy as np
+
+PIXEL_MAX = 255.0
+
+
+def peak_signal_to_noise_ratio(original: float, contrast: float) -> float:
+    mse = np.mean((original - contrast) ** 2)
+    if mse == 0:
+        return 100
+
+    return 20 * math.log10(PIXEL_MAX / math.sqrt(mse))
+
+
+def main() -> None:
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    # Loading images (original image and compressed image)
+    original = cv2.imread(os.path.join(dir_path, "image_data/original_image.png"))
+    contrast = cv2.imread(os.path.join(dir_path, "image_data/compressed_image.png"), 1)
+
+    original2 = cv2.imread(os.path.join(dir_path, "image_data/PSNR-example-base.png"))
+    contrast2 = cv2.imread(
+        os.path.join(dir_path, "image_data/PSNR-example-comp-10.jpg"), 1
+    )
+
+    # Value expected: 29.73dB
+    print("-- First Test --")
+    print(f"PSNR value is {peak_signal_to_noise_ratio(original, contrast)} dB")
+
+    # # Value expected: 31.53dB (Wikipedia Example)
+    print("\n-- Second Test --")
+    print(f"PSNR value is {peak_signal_to_noise_ratio(original2, contrast2)} dB")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add TheAlgorithms Python PSNR source file
- implement peak signal-to-noise ratio algorithm in Mochi with custom sqrt and log functions
- include test output

## Testing
- `go run ./cmd/mochi test tests/github/TheAlgorithms/Mochi/data_compression/peak_signal_to_noise_ratio.mochi`

------
https://chatgpt.com/codex/tasks/task_e_68916bb2cf9c8320ba2f573635369a42