### PR TITLE
Add prefix sum data structure example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/arrays/prefix_sum.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/arrays/prefix_sum.mochi
@@ -1,0 +1,68 @@
+/*
+Compute prefix sums of an integer array to enable fast range sum queries.
+The constructor produces a list where each entry is the sum of all elements
+up to that index. A range sum from start..end is then obtained in O(1)
+by subtracting adjacent prefix values. The data structure also supports
+checking if any contiguous subarray totals to a target value by tracking
+seen prefix sums. For an array of length n this construction runs in O(n)
+time and uses O(n) space, while queries run in O(1).
+*/
+
+type PrefixSum = { prefix_sum: list<int> }
+
+fun make_prefix_sum(arr: list<int>): PrefixSum {
+  var prefix: list<int> = []
+  var running = 0
+  var i = 0
+  while i < len(arr) {
+    running = running + arr[i]
+    prefix = append(prefix, running)
+    i = i + 1
+  }
+  return PrefixSum{ prefix_sum: prefix }
+}
+
+fun get_sum(ps: PrefixSum, start: int, end: int): int {
+  let prefix = ps.prefix_sum
+  if len(prefix) == 0 {
+    panic("The array is empty.")
+  }
+  if start < 0 || end >= len(prefix) || start > end {
+    panic("Invalid range specified.")
+  }
+  if start == 0 {
+    return prefix[end]
+  }
+  return prefix[end] - prefix[start - 1]
+}
+
+fun contains_sum(ps: PrefixSum, target_sum: int): bool {
+  let prefix = ps.prefix_sum
+  var sums: list<int> = [0]
+  var i = 0
+  while i < len(prefix) {
+    let sum_item = prefix[i]
+    var j = 0
+    while j < len(sums) {
+      if sums[j] == sum_item - target_sum {
+        return true
+      }
+      j = j + 1
+    }
+    sums = append(sums, sum_item)
+    i = i + 1
+  }
+  return false
+}
+
+let ps = make_prefix_sum([1, 2, 3])
+print(str(get_sum(ps, 0, 2)))
+print(str(get_sum(ps, 1, 2)))
+print(str(get_sum(ps, 2, 2)))
+print(str(contains_sum(ps, 6)))
+print(str(contains_sum(ps, 5)))
+print(str(contains_sum(ps, 3)))
+print(str(contains_sum(ps, 4)))
+print(str(contains_sum(ps, 7)))
+let ps2 = make_prefix_sum([1, -2, 3])
+print(str(contains_sum(ps2, 2)))

--- a/tests/github/TheAlgorithms/Mochi/data_structures/arrays/prefix_sum.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/arrays/prefix_sum.out
@@ -1,0 +1,9 @@
+6
+5
+3
+true
+true
+true
+false
+false
+true

--- a/tests/github/TheAlgorithms/Python/data_structures/arrays/prefix_sum.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/arrays/prefix_sum.py
@@ -1,0 +1,96 @@
+"""
+Author  : Alexander Pantyukhin
+Date    : November 3, 2022
+
+Implement the class of prefix sum with useful functions based on it.
+
+"""
+
+
+class PrefixSum:
+    def __init__(self, array: list[int]) -> None:
+        len_array = len(array)
+        self.prefix_sum = [0] * len_array
+
+        if len_array > 0:
+            self.prefix_sum[0] = array[0]
+
+        for i in range(1, len_array):
+            self.prefix_sum[i] = self.prefix_sum[i - 1] + array[i]
+
+    def get_sum(self, start: int, end: int) -> int:
+        """
+        The function returns the sum of array from the start to the end indexes.
+        Runtime : O(1)
+        Space: O(1)
+
+        >>> PrefixSum([1,2,3]).get_sum(0, 2)
+        6
+        >>> PrefixSum([1,2,3]).get_sum(1, 2)
+        5
+        >>> PrefixSum([1,2,3]).get_sum(2, 2)
+        3
+        >>> PrefixSum([]).get_sum(0, 0)
+        Traceback (most recent call last):
+        ...
+        ValueError: The array is empty.
+        >>> PrefixSum([1,2,3]).get_sum(-1, 2)
+        Traceback (most recent call last):
+        ...
+        ValueError: Invalid range specified.
+        >>> PrefixSum([1,2,3]).get_sum(2, 3)
+        Traceback (most recent call last):
+        ...
+        ValueError: Invalid range specified.
+        >>> PrefixSum([1,2,3]).get_sum(2, 1)
+        Traceback (most recent call last):
+        ...
+        ValueError: Invalid range specified.
+        """
+        if not self.prefix_sum:
+            raise ValueError("The array is empty.")
+
+        if start < 0 or end >= len(self.prefix_sum) or start > end:
+            raise ValueError("Invalid range specified.")
+
+        if start == 0:
+            return self.prefix_sum[end]
+
+        return self.prefix_sum[end] - self.prefix_sum[start - 1]
+
+    def contains_sum(self, target_sum: int) -> bool:
+        """
+        The function returns True if array contains the target_sum,
+        False otherwise.
+
+        Runtime : O(n)
+        Space: O(n)
+
+        >>> PrefixSum([1,2,3]).contains_sum(6)
+        True
+        >>> PrefixSum([1,2,3]).contains_sum(5)
+        True
+        >>> PrefixSum([1,2,3]).contains_sum(3)
+        True
+        >>> PrefixSum([1,2,3]).contains_sum(4)
+        False
+        >>> PrefixSum([1,2,3]).contains_sum(7)
+        False
+        >>> PrefixSum([1,-2,3]).contains_sum(2)
+        True
+        """
+
+        sums = {0}
+        for sum_item in self.prefix_sum:
+            if sum_item - target_sum in sums:
+                return True
+
+            sums.add(sum_item)
+
+        return False
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python `prefix_sum` class example for prefix sums and subarray sum checks
- implement equivalent Mochi version with range sum and target checks
- include execution output for the Mochi implementation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68916bc50be083209d79f84959101593