### PR TITLE
Add Mochi implementation for binary tree mirror algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/binary_tree_mirror.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/binary_tree_mirror.mochi
@@ -1,0 +1,49 @@
+/*
+Binary Tree Mirror - Map representation
+
+Given a binary tree represented as a map from node id to [left, right] child ids,
+produce its mirror image by recursively swapping the left and right children for
+every node reachable from a given root. If the tree is empty or the root does
+not exist, an error is raised.
+
+The algorithm performs a depth-first traversal starting at the root. For each
+node, it swaps the two entries and then recurses on both children. This yields
+the mirrored tree in O(n) time where n is the number of nodes. Space complexity
+is O(h) for recursion depth, with h being the tree height.
+*/
+
+fun binary_tree_mirror_dict(tree: map<int, list<int>>, root: int) {
+  if (root == 0) || (!(root in tree)) {
+    return
+  }
+  let children = tree[root]
+  let left = children[0]
+  let right = children[1]
+  tree[root] = [right, left]
+  binary_tree_mirror_dict(tree, left)
+  binary_tree_mirror_dict(tree, right)
+}
+
+fun binary_tree_mirror(binary_tree: map<int, list<int>>, root: int): map<int, list<int>> {
+  if len(binary_tree) == 0 {
+    panic("binary tree cannot be empty")
+  }
+  if !(root in binary_tree) {
+    panic("root " + str(root) + " is not present in the binary_tree")
+  }
+  var tree_copy: map<int, list<int>> = {}
+  for k in binary_tree {
+    tree_copy[k] = binary_tree[k]
+  }
+  binary_tree_mirror_dict(tree_copy, root)
+  return tree_copy
+}
+
+fun main() {
+  let binary_tree: map<int, list<int>> = {1: [2,3], 2: [4,5], 3: [6,7], 7: [8,9]}
+  print("Binary tree: " + str(binary_tree))
+  let mirrored = binary_tree_mirror(binary_tree, 1)
+  print("Binary tree mirror: " + str(mirrored))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/binary_tree_mirror.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/binary_tree_mirror.out
@@ -1,0 +1,2 @@
+Binary tree: map[1:[2 3] 2:[4 5] 3:[6 7] 7:[8 9]]
+Binary tree mirror: map[1:[3 2] 2:[5 4] 3:[7 6] 7:[9 8]]

--- a/tests/github/TheAlgorithms/Python/data_structures/binary_tree/binary_tree_mirror.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/binary_tree/binary_tree_mirror.py
@@ -1,0 +1,45 @@
+"""
+Problem Description:
+Given a binary tree, return its mirror.
+"""
+
+
+def binary_tree_mirror_dict(binary_tree_mirror_dictionary: dict, root: int):
+    if not root or root not in binary_tree_mirror_dictionary:
+        return
+    left_child, right_child = binary_tree_mirror_dictionary[root][:2]
+    binary_tree_mirror_dictionary[root] = [right_child, left_child]
+    binary_tree_mirror_dict(binary_tree_mirror_dictionary, left_child)
+    binary_tree_mirror_dict(binary_tree_mirror_dictionary, right_child)
+
+
+def binary_tree_mirror(binary_tree: dict, root: int = 1) -> dict:
+    """
+    >>> binary_tree_mirror({ 1: [2,3], 2: [4,5], 3: [6,7], 7: [8,9]}, 1)
+    {1: [3, 2], 2: [5, 4], 3: [7, 6], 7: [9, 8]}
+    >>> binary_tree_mirror({ 1: [2,3], 2: [4,5], 3: [6,7], 4: [10,11]}, 1)
+    {1: [3, 2], 2: [5, 4], 3: [7, 6], 4: [11, 10]}
+    >>> binary_tree_mirror({ 1: [2,3], 2: [4,5], 3: [6,7], 4: [10,11]}, 5)
+    Traceback (most recent call last):
+        ...
+    ValueError: root 5 is not present in the binary_tree
+    >>> binary_tree_mirror({}, 5)
+    Traceback (most recent call last):
+        ...
+    ValueError: binary tree cannot be empty
+    """
+    if not binary_tree:
+        raise ValueError("binary tree cannot be empty")
+    if root not in binary_tree:
+        msg = f"root {root} is not present in the binary_tree"
+        raise ValueError(msg)
+    binary_tree_mirror_dictionary = dict(binary_tree)
+    binary_tree_mirror_dict(binary_tree_mirror_dictionary, root)
+    return binary_tree_mirror_dictionary
+
+
+if __name__ == "__main__":
+    binary_tree = {1: [2, 3], 2: [4, 5], 3: [6, 7], 7: [8, 9]}
+    print(f"Binary tree: {binary_tree}")
+    binary_tree_mirror_dictionary = binary_tree_mirror(binary_tree, 5)
+    print(f"Binary tree mirror: {binary_tree_mirror_dictionary}")


### PR DESCRIPTION
## Summary
- add missing Python reference for binary tree mirror algorithm
- implement binary_tree_mirror in Mochi using recursive child swapping on a map
- include sample run output demonstrating mirrored structure

## Testing
- `npm test` *(fails: Missing script "test")*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68916bda51988320a97073d702c1a166