### PR TITLE
Add Mochi implementation for binary tree traversals

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/binary_tree_traversals.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/binary_tree_traversals.mochi
@@ -1,0 +1,143 @@
+/*
+Binary tree traversal algorithms using an array-based tree representation.
+
+The example tree:
+    1
+   / \
+  2   3
+ / \
+4   5
+is stored as a list of nodes where each node holds the index of its left
+and right child (-1 denotes no child).
+
+The program implements:
+- Pre-order traversal (root, left, right)
+- Post-order traversal (left, right, root)
+- In-order traversal (left, root, right)
+- Reverse in-order traversal (right, root, left)
+- Level-order traversal (breadth-first)
+- ZigZag traversal (alternating directions per level)
+
+All traversals run in O(n) time for n nodes. Recursion depth determines
+additional space usage.
+*/
+
+type Node {
+  value: int
+  left: int
+  right: int
+}
+
+fun max2(a: int, b: int): int {
+  if a > b {
+    return a
+  } else {
+    return b
+  }
+}
+
+fun make_tree(): list<Node> {
+  return [
+    Node { value: 1, left: 1, right: 2 },
+    Node { value: 2, left: 3, right: 4 },
+    Node { value: 3, left: (-1), right: (-1) },
+    Node { value: 4, left: (-1), right: (-1) },
+    Node { value: 5, left: (-1), right: (-1) }
+  ]
+}
+
+fun preorder(tree: list<Node>, idx: int): list<int> {
+  if idx == (-1) { return [] as list<int> }
+  let node = tree[idx]
+  return concat([node.value], concat(preorder(tree, node.left), preorder(tree, node.right)))
+}
+
+fun postorder(tree: list<Node>, idx: int): list<int> {
+  if idx == (-1) { return [] as list<int> }
+  let node = tree[idx]
+  return concat(postorder(tree, node.left), concat(postorder(tree, node.right), [node.value]))
+}
+
+fun inorder(tree: list<Node>, idx: int): list<int> {
+  if idx == (-1) { return [] as list<int> }
+  let node = tree[idx]
+  return concat(inorder(tree, node.left), concat([node.value], inorder(tree, node.right)))
+}
+
+fun reverse_inorder(tree: list<Node>, idx: int): list<int> {
+  if idx == (-1) { return [] as list<int> }
+  let node = tree[idx]
+  return concat(reverse_inorder(tree, node.right), concat([node.value], reverse_inorder(tree, node.left)))
+}
+
+fun height(tree: list<Node>, idx: int): int {
+  if idx == (-1) { return 0 }
+  let node = tree[idx]
+  return max2(height(tree, node.left), height(tree, node.right)) + 1
+}
+
+fun get_nodes_from_left_to_right(tree: list<Node>, idx: int, level: int): list<int> {
+  if idx == (-1) { return [] as list<int> }
+  let node = tree[idx]
+  if level == 1 {
+    return [node.value]
+  }
+  return concat(get_nodes_from_left_to_right(tree, node.left, level - 1), get_nodes_from_left_to_right(tree, node.right, level - 1))
+}
+
+fun get_nodes_from_right_to_left(tree: list<Node>, idx: int, level: int): list<int> {
+  if idx == (-1) { return [] as list<int> }
+  let node = tree[idx]
+  if level == 1 {
+    return [node.value]
+  }
+  return concat(get_nodes_from_right_to_left(tree, node.right, level - 1), get_nodes_from_right_to_left(tree, node.left, level - 1))
+}
+
+fun level_order(tree: list<Node>, idx: int): list<int> {
+  let h = height(tree, idx)
+  var res: list<int> = []
+  var lvl = 1
+  while lvl <= h {
+    res = concat(res, get_nodes_from_left_to_right(tree, idx, lvl))
+    lvl = lvl + 1
+  }
+  return res
+}
+
+fun zigzag(tree: list<Node>, idx: int): list<int> {
+  let h = height(tree, idx)
+  var res: list<int> = []
+  var lvl = 1
+  var flag = 0
+  while lvl <= h {
+    if flag == 0 {
+      res = concat(res, get_nodes_from_left_to_right(tree, idx, lvl))
+      flag = 1
+    } else {
+      res = concat(res, get_nodes_from_right_to_left(tree, idx, lvl))
+      flag = 0
+    }
+    lvl = lvl + 1
+  }
+  return res
+}
+
+let tree = make_tree()
+let root = 0
+print("In-order Traversal: " + str(inorder(tree, root)))
+print("Reverse In-order Traversal: " + str(reverse_inorder(tree, root)))
+print("Pre-order Traversal: " + str(preorder(tree, root)))
+print("Post-order Traversal: " + str(postorder(tree, root)) + "\n")
+print("Height of Tree: " + str(height(tree, root)) + "\n")
+print("Complete Level Order Traversal:")
+print(str(level_order(tree, root)) + " \n")
+print("Level-wise order Traversal:")
+var level = 1
+let h = height(tree, root)
+while level <= h {
+  print("Level " + str(level) + ": " + str(get_nodes_from_left_to_right(tree, root, level)))
+  level = level + 1
+}
+print("\nZigZag order Traversal:")
+print(str(zigzag(tree, root)))

--- a/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/binary_tree_traversals.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/binary_tree_traversals.out
@@ -1,0 +1,17 @@
+In-order Traversal: [4 2 5 1 3]
+Reverse In-order Traversal: [3 1 5 2 4]
+Pre-order Traversal: [1 2 4 5 3]
+Post-order Traversal: [4 5 2 3 1]
+
+Height of Tree: 3
+
+Complete Level Order Traversal:
+[1 2 3 4 5] 
+
+Level-wise order Traversal:
+Level 1: [1]
+Level 2: [2 3]
+Level 3: [4 5]
+
+ZigZag order Traversal:
+[1 3 2 4 5]

--- a/tests/github/TheAlgorithms/Python/data_structures/binary_tree/binary_tree_traversals.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/binary_tree/binary_tree_traversals.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Generator
+from dataclasses import dataclass
+
+
+# https://en.wikipedia.org/wiki/Tree_traversal
+@dataclass
+class Node:
+    data: int
+    left: Node | None = None
+    right: Node | None = None
+
+
+def make_tree() -> Node | None:
+    r"""
+    The below tree
+        1
+       / \
+      2   3
+     / \
+    4   5
+    """
+    tree = Node(1)
+    tree.left = Node(2)
+    tree.right = Node(3)
+    tree.left.left = Node(4)
+    tree.left.right = Node(5)
+    return tree
+
+
+def preorder(root: Node | None) -> Generator[int]:
+    """
+    Pre-order traversal visits root node, left subtree, right subtree.
+    >>> list(preorder(make_tree()))
+    [1, 2, 4, 5, 3]
+    """
+    if not root:
+        return
+    yield root.data
+    yield from preorder(root.left)
+    yield from preorder(root.right)
+
+
+def postorder(root: Node | None) -> Generator[int]:
+    """
+    Post-order traversal visits left subtree, right subtree, root node.
+    >>> list(postorder(make_tree()))
+    [4, 5, 2, 3, 1]
+    """
+    if not root:
+        return
+    yield from postorder(root.left)
+    yield from postorder(root.right)
+    yield root.data
+
+
+def inorder(root: Node | None) -> Generator[int]:
+    """
+    In-order traversal visits left subtree, root node, right subtree.
+    >>> list(inorder(make_tree()))
+    [4, 2, 5, 1, 3]
+    """
+    if not root:
+        return
+    yield from inorder(root.left)
+    yield root.data
+    yield from inorder(root.right)
+
+
+def reverse_inorder(root: Node | None) -> Generator[int]:
+    """
+    Reverse in-order traversal visits right subtree, root node, left subtree.
+    >>> list(reverse_inorder(make_tree()))
+    [3, 1, 5, 2, 4]
+    """
+    if not root:
+        return
+    yield from reverse_inorder(root.right)
+    yield root.data
+    yield from reverse_inorder(root.left)
+
+
+def height(root: Node | None) -> int:
+    """
+    Recursive function for calculating the height of the binary tree.
+    >>> height(None)
+    0
+    >>> height(make_tree())
+    3
+    """
+    return (max(height(root.left), height(root.right)) + 1) if root else 0
+
+
+def level_order(root: Node | None) -> Generator[int]:
+    """
+    Returns a list of nodes value from a whole binary tree in Level Order Traverse.
+    Level Order traverse: Visit nodes of the tree level-by-level.
+    >>> list(level_order(make_tree()))
+    [1, 2, 3, 4, 5]
+    """
+
+    if root is None:
+        return
+
+    process_queue = deque([root])
+
+    while process_queue:
+        node = process_queue.popleft()
+        yield node.data
+
+        if node.left:
+            process_queue.append(node.left)
+        if node.right:
+            process_queue.append(node.right)
+
+
+def get_nodes_from_left_to_right(root: Node | None, level: int) -> Generator[int]:
+    """
+    Returns a list of nodes value from a particular level:
+    Left to right direction of the binary tree.
+    >>> list(get_nodes_from_left_to_right(make_tree(), 1))
+    [1]
+    >>> list(get_nodes_from_left_to_right(make_tree(), 2))
+    [2, 3]
+    """
+
+    def populate_output(root: Node | None, level: int) -> Generator[int]:
+        if not root:
+            return
+        if level == 1:
+            yield root.data
+        elif level > 1:
+            yield from populate_output(root.left, level - 1)
+            yield from populate_output(root.right, level - 1)
+
+    yield from populate_output(root, level)
+
+
+def get_nodes_from_right_to_left(root: Node | None, level: int) -> Generator[int]:
+    """
+    Returns a list of nodes value from a particular level:
+    Right to left direction of the binary tree.
+    >>> list(get_nodes_from_right_to_left(make_tree(), 1))
+    [1]
+    >>> list(get_nodes_from_right_to_left(make_tree(), 2))
+    [3, 2]
+    """
+
+    def populate_output(root: Node | None, level: int) -> Generator[int]:
+        if not root:
+            return
+        if level == 1:
+            yield root.data
+        elif level > 1:
+            yield from populate_output(root.right, level - 1)
+            yield from populate_output(root.left, level - 1)
+
+    yield from populate_output(root, level)
+
+
+def zigzag(root: Node | None) -> Generator[int]:
+    """
+    ZigZag traverse:
+    Returns a list of nodes value from left to right and right to left, alternatively.
+    >>> list(zigzag(make_tree()))
+    [1, 3, 2, 4, 5]
+    """
+    if root is None:
+        return
+
+    flag = 0
+    height_tree = height(root)
+
+    for h in range(1, height_tree + 1):
+        if not flag:
+            yield from get_nodes_from_left_to_right(root, h)
+            flag = 1
+        else:
+            yield from get_nodes_from_right_to_left(root, h)
+            flag = 0
+
+
+def main() -> None:  # Main function for testing.
+    # Create binary tree.
+    root = make_tree()
+
+    # All Traversals of the binary are as follows:
+    print(f"In-order Traversal: {list(inorder(root))}")
+    print(f"Reverse In-order Traversal: {list(reverse_inorder(root))}")
+    print(f"Pre-order Traversal: {list(preorder(root))}")
+    print(f"Post-order Traversal: {list(postorder(root))}", "\n")
+
+    print(f"Height of Tree: {height(root)}", "\n")
+
+    print("Complete Level Order Traversal: ")
+    print(f"{list(level_order(root))} \n")
+
+    print("Level-wise order Traversal: ")
+
+    for level in range(1, height(root) + 1):
+        print(f"Level {level}:", list(get_nodes_from_left_to_right(root, level=level)))
+
+    print("\nZigZag order Traversal: ")
+    print(f"{list(zigzag(root))}")
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    main()


### PR DESCRIPTION
## Summary
- add Python reference for binary tree traversals from TheAlgorithms
- implement binary tree traversals in Mochi using array-based tree
- include runtime output demonstrating traversal orders

## Testing
- `go run runmochi.go tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/binary_tree_traversals.mochi > tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/binary_tree_traversals.out`


------
https://chatgpt.com/codex/tasks/task_e_689172e7114c832093fa048558435e60