### PR TITLE
Add Mochi version of binary tree diameter

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/diameter_of_binary_tree.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/diameter_of_binary_tree.mochi
@@ -1,0 +1,53 @@
+/*
+Diameter of Binary Tree
+
+The diameter (or width) of a binary tree is the number of nodes on the longest
+path between any two leaves. This implementation models the tree using arrays
+of child indices. The diameter at a node equals the sum of the depths of its
+left and right subtrees plus one for the node itself. Depth is the length of
+the longest path from a node down to a leaf. Both values are computed
+recursively.
+
+The sample tree:
+
+        1
+       / \
+      2   3
+     / \
+    4   5
+
+has diameter 4 through path 4-2-1-3. The code constructs this tree and prints
+the diameter for the root and its child subtrees.
+*/
+
+let left: list<int> = [0, 2, 4, 0, 0, 0]
+let right: list<int> = [0, 3, 5, 0, 0, 0]
+
+fun depth(i: int): int {
+  if i == 0 {
+    return 0
+  }
+  let left_depth = depth(left[i])
+  let right_depth = depth(right[i])
+  if left_depth > right_depth {
+    return left_depth + 1
+  }
+  return right_depth + 1
+}
+
+fun diameter(i: int): int {
+  if i == 0 {
+    return 0
+  }
+  let left_depth = depth(left[i])
+  let right_depth = depth(right[i])
+  return left_depth + right_depth + 1
+}
+
+fun main() {
+  print("root.diameter() = " + str(diameter(1)))
+  print("root.left.diameter() = " + str(diameter(left[1])))
+  print("root.right.diameter() = " + str(diameter(right[1])))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/diameter_of_binary_tree.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/diameter_of_binary_tree.out
@@ -1,0 +1,3 @@
+root.diameter() = 4
+root.left.diameter() = 3
+root.right.diameter() = 1

--- a/tests/github/TheAlgorithms/Python/data_structures/binary_tree/diameter_of_binary_tree.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/binary_tree/diameter_of_binary_tree.py
@@ -1,0 +1,73 @@
+"""
+The diameter/width of a tree is defined as the number of nodes on the longest path
+between two end nodes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Node:
+    data: int
+    left: Node | None = None
+    right: Node | None = None
+
+    def depth(self) -> int:
+        """
+        >>> root = Node(1)
+        >>> root.depth()
+        1
+        >>> root.left = Node(2)
+        >>> root.depth()
+        2
+        >>> root.left.depth()
+        1
+        >>> root.right = Node(3)
+        >>> root.depth()
+        2
+        """
+        left_depth = self.left.depth() if self.left else 0
+        right_depth = self.right.depth() if self.right else 0
+        return max(left_depth, right_depth) + 1
+
+    def diameter(self) -> int:
+        """
+        >>> root = Node(1)
+        >>> root.diameter()
+        1
+        >>> root.left = Node(2)
+        >>> root.diameter()
+        2
+        >>> root.left.diameter()
+        1
+        >>> root.right = Node(3)
+        >>> root.diameter()
+        3
+        """
+        left_depth = self.left.depth() if self.left else 0
+        right_depth = self.right.depth() if self.right else 0
+        return left_depth + right_depth + 1
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()
+    root = Node(1)
+    root.left = Node(2)
+    root.right = Node(3)
+    root.left.left = Node(4)
+    root.left.right = Node(5)
+    r"""
+    Constructed binary tree is
+        1
+       / \
+      2	  3
+     / \
+    4	 5
+    """
+    print(f"{root.diameter() = }")  # 4
+    print(f"{root.left.diameter() = }")  # 3
+    print(f"{root.right.diameter() = }")  # 1


### PR DESCRIPTION
## Summary
- port Python binary tree diameter algorithm to Mochi using child index arrays
- add generated output from running the Mochi implementation
- include original Python reference implementation

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/diameter_of_binary_tree.mochi > tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/diameter_of_binary_tree.out`
- `go test ./...` *(fails: interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689172e839d88320abab6e63634b45eb