### PR TITLE
Add flatten binary tree to linked list example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/flatten_binarytree_to_linkedlist.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/flatten_binarytree_to_linkedlist.mochi
@@ -1,0 +1,74 @@
+/*
+Flatten a binary tree into a right-skewed linked list.
+
+Each node's left child pointer is set to null and its right child
+pointer points to the next node in preorder. The algorithm works
+by visiting nodes in preorder, collecting their values, and
+reconstructing the traversal as a linear list. A small example tree
+is built and the flattened order is displayed.
+*/
+
+var node_data: list<int> = [0] as list<int>
+var left_child: list<int> = [0] as list<int>
+var right_child: list<int> = [0] as list<int>
+
+fun new_node(value: int): int {
+  node_data = append(node_data, value)
+  left_child = append(left_child, 0)
+  right_child = append(right_child, 0)
+  return len(node_data) - 1
+}
+
+fun build_tree(): int {
+  let root = new_node(1)
+  let n2 = new_node(2)
+  let n5 = new_node(5)
+  let n3 = new_node(3)
+  let n4 = new_node(4)
+  let n6 = new_node(6)
+  left_child[root] = n2
+  right_child[root] = n5
+  left_child[n2] = n3
+  right_child[n2] = n4
+  right_child[n5] = n6
+  return root
+}
+
+fun flatten(root: int): list<int> {
+  if root == 0 {
+    return [] as list<int>
+  }
+  var res: list<int> = [node_data[root]] as list<int>
+  let left_vals = flatten(left_child[root])
+  let right_vals = flatten(right_child[root])
+  var i = 0
+  while i < len(left_vals) {
+    res = append(res, left_vals[i])
+    i = i + 1
+  }
+  i = 0
+  while i < len(right_vals) {
+    res = append(res, right_vals[i])
+    i = i + 1
+  }
+  return res
+}
+
+fun display(values: list<int>): void {
+  var s = ""
+  var i = 0
+  while i < len(values) {
+    if i == 0 {
+      s = str(values[i])
+    } else {
+      s = s + " " + str(values[i])
+    }
+    i = i + 1
+  }
+  print(s)
+}
+
+print("Flattened Linked List:")
+let root = build_tree()
+let vals = flatten(root)
+display(vals)

--- a/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/flatten_binarytree_to_linkedlist.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/flatten_binarytree_to_linkedlist.out
@@ -1,0 +1,2 @@
+Flattened Linked List:
+1 2 3 0 0 4 0 0 5 0 6 0 0

--- a/tests/github/TheAlgorithms/Python/data_structures/binary_tree/flatten_binarytree_to_linkedlist.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/binary_tree/flatten_binarytree_to_linkedlist.py
@@ -1,0 +1,139 @@
+"""
+Binary Tree Flattening Algorithm
+
+This code defines an algorithm to flatten a binary tree into a linked list
+represented using the right pointers of the tree nodes. It uses in-place
+flattening and demonstrates the flattening process along with a display
+function to visualize the flattened linked list.
+https://www.geeksforgeeks.org/flatten-a-binary-tree-into-linked-list
+
+Author: Arunkumar A
+Date: 04/09/2023
+"""
+
+from __future__ import annotations
+
+
+class TreeNode:
+    """
+    A TreeNode has data variable and pointers to TreeNode objects
+    for its left and right children.
+    """
+
+    def __init__(self, data: int) -> None:
+        self.data = data
+        self.left: TreeNode | None = None
+        self.right: TreeNode | None = None
+
+
+def build_tree() -> TreeNode:
+    """
+    Build and return a sample binary tree.
+
+    Returns:
+        TreeNode: The root of the binary tree.
+
+    Examples:
+        >>> root = build_tree()
+        >>> root.data
+        1
+        >>> root.left.data
+        2
+        >>> root.right.data
+        5
+        >>> root.left.left.data
+        3
+        >>> root.left.right.data
+        4
+        >>> root.right.right.data
+        6
+    """
+    root = TreeNode(1)
+    root.left = TreeNode(2)
+    root.right = TreeNode(5)
+    root.left.left = TreeNode(3)
+    root.left.right = TreeNode(4)
+    root.right.right = TreeNode(6)
+    return root
+
+
+def flatten(root: TreeNode | None) -> None:
+    """
+    Flatten a binary tree into a linked list in-place, where the linked list is
+    represented using the right pointers of the tree nodes.
+
+    Args:
+        root (TreeNode): The root of the binary tree to be flattened.
+
+    Examples:
+        >>> root = TreeNode(1)
+        >>> root.left = TreeNode(2)
+        >>> root.right = TreeNode(5)
+        >>> root.left.left = TreeNode(3)
+        >>> root.left.right = TreeNode(4)
+        >>> root.right.right = TreeNode(6)
+        >>> flatten(root)
+        >>> root.data
+        1
+        >>> root.right.right is None
+        False
+        >>> root.right.right = TreeNode(3)
+        >>> root.right.right.right is None
+        True
+    """
+    if not root:
+        return
+
+    # Flatten the left subtree
+    flatten(root.left)
+
+    # Save the right subtree
+    right_subtree = root.right
+
+    # Make the left subtree the new right subtree
+    root.right = root.left
+    root.left = None
+
+    # Find the end of the new right subtree
+    current = root
+    while current.right:
+        current = current.right
+
+    # Append the original right subtree to the end
+    current.right = right_subtree
+
+    # Flatten the updated right subtree
+    flatten(right_subtree)
+
+
+def display_linked_list(root: TreeNode | None) -> None:
+    """
+    Display the flattened linked list.
+
+    Args:
+        root (TreeNode | None): The root of the flattened linked list.
+
+    Examples:
+        >>> root = TreeNode(1)
+        >>> root.right = TreeNode(2)
+        >>> root.right.right = TreeNode(3)
+        >>> display_linked_list(root)
+        1 2 3
+        >>> root = None
+        >>> display_linked_list(root)
+
+    """
+    current = root
+    while current:
+        if current.right is None:
+            print(current.data, end="")
+            break
+        print(current.data, end=" ")
+        current = current.right
+
+
+if __name__ == "__main__":
+    print("Flattened Linked List:")
+    root = build_tree()
+    flatten(root)
+    display_linked_list(root)


### PR DESCRIPTION
## Summary
- add Python reference implementation for flattening a binary tree to a linked list
- implement corresponding Mochi version and sample run output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/flatten_binarytree_to_linkedlist.mochi > tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/flatten_binarytree_to_linkedlist.out`


------
https://chatgpt.com/codex/tasks/task_e_689172ecd2bc8320b13618e03b75ebd8