### PR TITLE
Add Mochi port for BST validation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/is_sorted.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/is_sorted.mochi
@@ -1,0 +1,67 @@
+/*
+  Validate whether a binary tree satisfies the binary search tree (BST) property.
+
+  The tree is represented using parallel arrays:
+    - data: value stored at each node
+    - left: index of the left child or NONE (-1) if absent
+    - right: index of the right child or NONE (-1) if absent
+
+  A tree is a valid BST when for every node:
+    * the left child contains a smaller value and its subtree is also a BST
+    * the right child contains a larger value and its subtree is also a BST
+
+  The algorithm performs an inorder traversal to display node ordering and
+  recursively verifies the BST property on each subtree.
+  Runtime: O(n) for n nodes; space: O(h) for recursion depth h.
+*/
+
+let NONE = 0 - 1
+
+type Tree { data: list<float>, left: list<int>, right: list<int> }
+
+fun inorder(tree: Tree, index: int): list<float> {
+  var res: list<float> = []
+  if index == NONE { return res }
+  let left_idx = tree.left[index]
+  if left_idx != NONE { res = concat(res, inorder(tree, left_idx)) }
+  res = append(res, tree.data[index])
+  let right_idx = tree.right[index]
+  if right_idx != NONE { res = concat(res, inorder(tree, right_idx)) }
+  return res
+}
+
+fun is_sorted(tree: Tree, index: int): bool {
+  if index == NONE { return true }
+  let left_idx = tree.left[index]
+  if left_idx != NONE {
+    if tree.data[index] < tree.data[left_idx] { return false }
+    if !is_sorted(tree, left_idx) { return false }
+  }
+  let right_idx = tree.right[index]
+  if right_idx != NONE {
+    if tree.data[index] > tree.data[right_idx] { return false }
+    if !is_sorted(tree, right_idx) { return false }
+  }
+  return true
+}
+
+let tree1 = Tree {
+  data: [2.1, 2.0, 2.2],
+  left: [1, NONE, NONE],
+  right: [2, NONE, NONE]
+}
+print("Tree " + str(inorder(tree1, 0)) + " is sorted: " + str(is_sorted(tree1, 0)))
+
+let tree2 = Tree {
+  data: [2.1, 2.0, 2.0],
+  left: [1, NONE, NONE],
+  right: [2, NONE, NONE]
+}
+print("Tree " + str(inorder(tree2, 0)) + " is sorted: " + str(is_sorted(tree2, 0)))
+
+let tree3 = Tree {
+  data: [2.1, 2.0, 2.1],
+  left: [1, NONE, NONE],
+  right: [2, NONE, NONE]
+}
+print("Tree " + str(inorder(tree3, 0)) + " is sorted: " + str(is_sorted(tree3, 0)))

--- a/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/is_sorted.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/is_sorted.out
@@ -1,0 +1,3 @@
+Tree [2 2.1 2.2] is sorted: true
+Tree [2 2.1 2] is sorted: false
+Tree [2 2.1 2.1] is sorted: true

--- a/tests/github/TheAlgorithms/Python/data_structures/binary_tree/is_sorted.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/binary_tree/is_sorted.py
@@ -1,0 +1,98 @@
+"""
+Given the root of a binary tree, determine if it is a valid binary search tree (BST).
+
+A valid binary search tree is defined as follows:
+- The left subtree of a node contains only nodes with keys less than the node's key.
+- The right subtree of a node contains only nodes with keys greater than the node's key.
+- Both the left and right subtrees must also be binary search trees.
+
+In effect, a binary tree is a valid BST if its nodes are sorted in ascending order.
+leetcode: https://leetcode.com/problems/validate-binary-search-tree/
+
+If n is the number of nodes in the tree then:
+Runtime: O(n)
+Space: O(1)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+
+@dataclass
+class Node:
+    data: float
+    left: Node | None = None
+    right: Node | None = None
+
+    def __iter__(self) -> Iterator[float]:
+        """
+        >>> root = Node(data=2.1)
+        >>> list(root)
+        [2.1]
+        >>> root.left=Node(data=2.0)
+        >>> list(root)
+        [2.0, 2.1]
+        >>> root.right=Node(data=2.2)
+        >>> list(root)
+        [2.0, 2.1, 2.2]
+        """
+        if self.left:
+            yield from self.left
+        yield self.data
+        if self.right:
+            yield from self.right
+
+    @property
+    def is_sorted(self) -> bool:
+        """
+        >>> Node(data='abc').is_sorted
+        True
+        >>> Node(data=2,
+        ...      left=Node(data=1.999),
+        ...      right=Node(data=3)).is_sorted
+        True
+        >>> Node(data=0,
+        ...      left=Node(data=0),
+        ...      right=Node(data=0)).is_sorted
+        True
+        >>> Node(data=0,
+        ...      left=Node(data=-11),
+        ...      right=Node(data=3)).is_sorted
+        True
+        >>> Node(data=5,
+        ...      left=Node(data=1),
+        ...      right=Node(data=4, left=Node(data=3))).is_sorted
+        False
+        >>> Node(data='a',
+        ...      left=Node(data=1),
+        ...      right=Node(data=4, left=Node(data=3))).is_sorted
+        Traceback (most recent call last):
+            ...
+        TypeError: '<' not supported between instances of 'str' and 'int'
+        >>> Node(data=2,
+        ...      left=Node([]),
+        ...      right=Node(data=4, left=Node(data=3))).is_sorted
+        Traceback (most recent call last):
+            ...
+        TypeError: '<' not supported between instances of 'int' and 'list'
+        """
+        if self.left and (self.data < self.left.data or not self.left.is_sorted):
+            return False
+        return not (
+            self.right and (self.data > self.right.data or not self.right.is_sorted)
+        )
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    tree = Node(data=2.1, left=Node(data=2.0), right=Node(data=2.2))
+    print(f"Tree {list(tree)} is sorted: {tree.is_sorted = }.")
+    assert tree.right
+    tree.right.data = 2.0
+    print(f"Tree {list(tree)} is sorted: {tree.is_sorted = }.")
+    tree.right.data = 2.1
+    print(f"Tree {list(tree)} is sorted: {tree.is_sorted = }.")


### PR DESCRIPTION
## Summary
- add missing Python source for binary tree is_sorted
- implement array-based Mochi version with inorder traversal and BST check

## Testing
- `python tests/github/TheAlgorithms/Python/data_structures/binary_tree/is_sorted.py`
- `/tmp/mochi run tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/is_sorted.mochi`

------
https://chatgpt.com/codex/tasks/task_e_689172f38e6083209b0cb1592e3dd6cd