### PR TITLE
Add Mochi implementation for binary tree LCA algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/lowest_common_ancestor.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/lowest_common_ancestor.mochi
@@ -1,0 +1,131 @@
+/*
+Find the lowest common ancestor (LCA) of two nodes in a rooted tree using
+binary lifting.  The algorithm first performs a breadth‑first search (BFS) from
+the root to compute the depth of each node and record its immediate parent.
+Using these parents a sparse table parent[j][i] is built where parent[j][i]
+stores the 2^j‑th ancestor of node i.  To find the LCA of nodes u and v we:
+  1. Swap nodes so that u is the deeper node.
+  2. Lift u upwards until both nodes are at the same depth.
+  3. Lift both nodes simultaneously from the highest power of two downwards
+     until their ancestors diverge.
+  4. Return the parent of the divergence point.
+This method answers each LCA query in O(log N) time after O(N log N) preprocessing.
+*/
+
+fun pow2(exp: int): int {
+  var res = 1
+  var i = 0
+  while i < exp {
+    res = res * 2
+    i = i + 1
+  }
+  return res
+}
+
+fun create_sparse(max_node: int, parent: list<list<int>>): list<list<int>> {
+  var j = 1
+  while pow2(j) < max_node {
+    var i = 1
+    while i <= max_node {
+      parent[j][i] = parent[j - 1][parent[j - 1][i]]
+      i = i + 1
+    }
+    j = j + 1
+  }
+  return parent
+}
+
+fun lowest_common_ancestor(u: int, v: int, level: list<int>, parent: list<list<int>>): int {
+  if level[u] < level[v] {
+    let temp = u
+    u = v
+    v = temp
+  }
+  var i = 18
+  while i >= 0 {
+    if level[u] - pow2(i) >= level[v] {
+      u = parent[i][u]
+    }
+    i = i - 1
+  }
+  if u == v { return u }
+  i = 18
+  while i >= 0 {
+    let pu = parent[i][u]
+    let pv = parent[i][v]
+    if pu != 0 && pu != pv {
+      u = pu
+      v = pv
+    }
+    i = i - 1
+  }
+  return parent[0][u]
+}
+
+fun breadth_first_search(level: list<int>, parent: list<list<int>>, max_node: int, graph: map<int, list<int>>, root: int) {
+  level[root] = 0
+  var q: list<int> = []
+  q = append(q, root)
+  var head = 0
+  while head < len(q) {
+    let u = q[head]
+    head = head + 1
+    let adj = graph[u]
+    var j = 0
+    while j < len(adj) {
+      let v = adj[j]
+      if level[v] == 0 - 1 {
+        level[v] = level[u] + 1
+        parent[0][v] = u
+        q = append(q, v)
+      }
+      j = j + 1
+    }
+  }
+}
+
+fun main() {
+  let max_node = 13
+  var parent: list<list<int>> = []
+  var i = 0
+  while i < 20 {
+    var row: list<int> = []
+    var j = 0
+    while j < max_node + 10 {
+      row = append(row, 0)
+      j = j + 1
+    }
+    parent = append(parent, row)
+    i = i + 1
+  }
+  var level: list<int> = []
+  i = 0
+  while i < max_node + 10 {
+    level = append(level, 0 - 1)
+    i = i + 1
+  }
+  var graph: map<int, list<int>> = {}
+  graph[1] = [2, 3, 4]
+  graph[2] = [5]
+  graph[3] = [6, 7]
+  graph[4] = [8]
+  graph[5] = [9, 10]
+  graph[6] = [11]
+  graph[7] = []
+  graph[8] = [12, 13]
+  graph[9] = []
+  graph[10] = []
+  graph[11] = []
+  graph[12] = []
+  graph[13] = []
+  breadth_first_search(level, parent, max_node, graph, 1)
+  parent = create_sparse(max_node, parent)
+  print("LCA of node 1 and 3 is: " + str(lowest_common_ancestor(1, 3, level, parent)))
+  print("LCA of node 5 and 6 is: " + str(lowest_common_ancestor(5, 6, level, parent)))
+  print("LCA of node 7 and 11 is: " + str(lowest_common_ancestor(7, 11, level, parent)))
+  print("LCA of node 6 and 7 is: " + str(lowest_common_ancestor(6, 7, level, parent)))
+  print("LCA of node 4 and 12 is: " + str(lowest_common_ancestor(4, 12, level, parent)))
+  print("LCA of node 8 and 8 is: " + str(lowest_common_ancestor(8, 8, level, parent)))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/lowest_common_ancestor.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/lowest_common_ancestor.out
@@ -1,0 +1,6 @@
+LCA of node 1 and 3 is: 1
+LCA of node 5 and 6 is: 1
+LCA of node 7 and 11 is: 3
+LCA of node 6 and 7 is: 3
+LCA of node 4 and 12 is: 4
+LCA of node 8 and 8 is: 8

--- a/tests/github/TheAlgorithms/Python/data_structures/binary_tree/lowest_common_ancestor.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/binary_tree/lowest_common_ancestor.py
@@ -1,0 +1,171 @@
+# https://en.wikipedia.org/wiki/Lowest_common_ancestor
+# https://en.wikipedia.org/wiki/Breadth-first_search
+
+from __future__ import annotations
+
+from queue import Queue
+
+
+def swap(a: int, b: int) -> tuple[int, int]:
+    """
+    Return a tuple (b, a) when given two integers a and b
+    >>> swap(2,3)
+    (3, 2)
+    >>> swap(3,4)
+    (4, 3)
+    >>> swap(67, 12)
+    (12, 67)
+    >>> swap(3,-4)
+    (-4, 3)
+    """
+    a ^= b
+    b ^= a
+    a ^= b
+    return a, b
+
+
+def create_sparse(max_node: int, parent: list[list[int]]) -> list[list[int]]:
+    """
+    creating sparse table which saves each nodes 2^i-th parent
+    >>> max_node = 6
+    >>> parent = [[0, 0, 1, 1, 2, 2, 3]] + [[0] * 7 for _ in range(19)]
+    >>> parent = create_sparse(max_node=max_node, parent=parent)
+    >>> parent[0]
+    [0, 0, 1, 1, 2, 2, 3]
+    >>> parent[1]
+    [0, 0, 0, 0, 1, 1, 1]
+    >>> parent[2]
+    [0, 0, 0, 0, 0, 0, 0]
+
+    >>> max_node = 1
+    >>> parent = [[0, 0]] + [[0] * 2 for _ in range(19)]
+    >>> parent = create_sparse(max_node=max_node, parent=parent)
+    >>> parent[0]
+    [0, 0]
+    >>> parent[1]
+    [0, 0]
+    """
+    j = 1
+    while (1 << j) < max_node:
+        for i in range(1, max_node + 1):
+            parent[j][i] = parent[j - 1][parent[j - 1][i]]
+        j += 1
+    return parent
+
+
+# returns lca of node u,v
+def lowest_common_ancestor(
+    u: int, v: int, level: list[int], parent: list[list[int]]
+) -> int:
+    """
+    Return the lowest common ancestor between u and v
+
+    >>> level = [-1, 0, 1, 1, 2, 2, 2]
+    >>> parent = [[0, 0, 1, 1, 2, 2, 3],[0, 0, 0, 0, 1, 1, 1]] + \
+                    [[0] * 7 for _ in range(17)]
+    >>> lowest_common_ancestor(u=4, v=5, level=level, parent=parent)
+    2
+    >>> lowest_common_ancestor(u=4, v=6, level=level, parent=parent)
+    1
+    >>> lowest_common_ancestor(u=2, v=3, level=level, parent=parent)
+    1
+    >>> lowest_common_ancestor(u=6, v=6, level=level, parent=parent)
+    6
+    """
+    # u must be deeper in the tree than v
+    if level[u] < level[v]:
+        u, v = swap(u, v)
+    # making depth of u same as depth of v
+    for i in range(18, -1, -1):
+        if level[u] - (1 << i) >= level[v]:
+            u = parent[i][u]
+    # at the same depth if u==v that mean lca is found
+    if u == v:
+        return u
+    # moving both nodes upwards till lca in found
+    for i in range(18, -1, -1):
+        if parent[i][u] not in [0, parent[i][v]]:
+            u, v = parent[i][u], parent[i][v]
+    # returning longest common ancestor of u,v
+    return parent[0][u]
+
+
+# runs a breadth first search from root node of the tree
+def breadth_first_search(
+    level: list[int],
+    parent: list[list[int]],
+    max_node: int,
+    graph: dict[int, list[int]],
+    root: int = 1,
+) -> tuple[list[int], list[list[int]]]:
+    """
+    sets every nodes direct parent
+    parent of root node is set to 0
+    calculates depth of each node from root node
+    >>> level = [-1] * 7
+    >>> parent = [[0] * 7 for _ in range(20)]
+    >>> graph = {1: [2, 3], 2: [4, 5], 3: [6], 4: [], 5: [], 6: []}
+    >>> level, parent = breadth_first_search(
+    ...     level=level, parent=parent, max_node=6, graph=graph, root=1)
+    >>> level
+    [-1, 0, 1, 1, 2, 2, 2]
+    >>> parent[0]
+    [0, 0, 1, 1, 2, 2, 3]
+
+
+    >>> level = [-1] * 2
+    >>> parent = [[0] * 2 for _ in range(20)]
+    >>> graph = {1: []}
+    >>> level, parent = breadth_first_search(
+    ...     level=level, parent=parent, max_node=1, graph=graph, root=1)
+    >>> level
+    [-1, 0]
+    >>> parent[0]
+    [0, 0]
+    """
+    level[root] = 0
+    q: Queue[int] = Queue(maxsize=max_node)
+    q.put(root)
+    while q.qsize() != 0:
+        u = q.get()
+        for v in graph[u]:
+            if level[v] == -1:
+                level[v] = level[u] + 1
+                q.put(v)
+                parent[0][v] = u
+    return level, parent
+
+
+def main() -> None:
+    max_node = 13
+    # initializing with 0
+    parent = [[0 for _ in range(max_node + 10)] for _ in range(20)]
+    # initializing with -1 which means every node is unvisited
+    level = [-1 for _ in range(max_node + 10)]
+    graph: dict[int, list[int]] = {
+        1: [2, 3, 4],
+        2: [5],
+        3: [6, 7],
+        4: [8],
+        5: [9, 10],
+        6: [11],
+        7: [],
+        8: [12, 13],
+        9: [],
+        10: [],
+        11: [],
+        12: [],
+        13: [],
+    }
+    level, parent = breadth_first_search(level, parent, max_node, graph, 1)
+    parent = create_sparse(max_node, parent)
+    print("LCA of node 1 and 3 is: ", lowest_common_ancestor(1, 3, level, parent))
+    print("LCA of node 5 and 6 is: ", lowest_common_ancestor(5, 6, level, parent))
+    print("LCA of node 7 and 11 is: ", lowest_common_ancestor(7, 11, level, parent))
+    print("LCA of node 6 and 7 is: ", lowest_common_ancestor(6, 7, level, parent))
+    print("LCA of node 4 and 12 is: ", lowest_common_ancestor(4, 12, level, parent))
+    print("LCA of node 8 and 8 is: ", lowest_common_ancestor(8, 8, level, parent))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add missing Python reference `lowest_common_ancestor.py`
- implement lowest common ancestor using BFS preprocessing and binary lifting in Mochi
- include generated `.out` from running the Mochi program

## Testing
- `./mochi run tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/lowest_common_ancestor.mochi`

------
https://chatgpt.com/codex/tasks/task_e_689172f77020832098c5340bcb229581