### PR TITLE
Add serialize/deserialize binary tree implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/serialize_deserialize_binary_tree.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/serialize_deserialize_binary_tree.mochi
@@ -1,0 +1,122 @@
+/*
+Serialize and Deserialize Binary Tree
+-------------------------------------
+
+This program demonstrates how to serialize a binary tree into a comma
+separated string using preorder traversal and how to reconstruct the
+tree from that string. Null children are recorded as the literal
+"null" so the structure can be perfectly rebuilt.
+
+Serialization visits each node in the order: current node, left
+subtree, then right subtree. Each visit appends the node's value to the
+output, or "null" if the node is absent.
+
+Deserialization consumes the comma separated values one by one,
+recursively creating nodes and assigning their left and right children.
+Since the traversal includes explicit null markers, the process runs in
+O(n) time for n nodes and results in an exact copy of the original
+binary tree.
+
+The example builds a small tree, serializes it, deserializes the string
+and prints both serializations along with a check that they match.
+*/
+
+
+type TreeNode =
+  Empty
+  | Node(left: TreeNode, value: int, right: TreeNode)
+
+type BuildResult {
+  node: TreeNode,
+  next: int,
+}
+
+fun digit(ch: string): int {
+  let digits = "0123456789"
+  var i = 0
+  while i < len(digits) {
+    if substring(digits, i, i + 1) == ch {
+      return i
+    }
+    i = i + 1
+  }
+  return 0
+}
+
+fun to_int(s: string): int {
+  var i = 0
+  var sign = 1
+  if len(s) > 0 && substring(s, 0, 1) == "-" {
+    sign = -1
+    i = 1
+  }
+  var num = 0
+  while i < len(s) {
+    let ch = substring(s, i, i + 1)
+    num = num * 10 + digit(ch)
+    i = i + 1
+  }
+  return sign * num
+}
+
+fun split(s: string, sep: string): list<string> {
+  var res: list<string> = []
+  var current = ""
+  var i = 0
+  while i < len(s) {
+    let ch = substring(s, i, i + 1)
+    if ch == sep {
+      res = append(res, current)
+      current = ""
+    } else {
+      current = current + ch
+    }
+    i = i + 1
+  }
+  res = append(res, current)
+  return res
+}
+
+fun serialize(node: TreeNode): string {
+  return match node {
+    Empty => "null"
+    Node(l, v, r) => str(v) + "," + serialize(l) + "," + serialize(r)
+  }
+}
+
+fun build(nodes: list<string>, idx: int): BuildResult {
+  let value = nodes[idx]
+  if value == "null" {
+    return BuildResult { node: Empty {}, next: idx + 1 }
+  }
+  let left_res = build(nodes, idx + 1)
+  let right_res = build(nodes, left_res.next)
+  let node = Node { left: left_res.node, value: to_int(value), right: right_res.node }
+  return BuildResult { node: node, next: right_res.next }
+}
+
+fun deserialize(data: string): TreeNode {
+  let nodes = split(data, ",")
+  let res = build(nodes, 0)
+  return res.node
+}
+
+fun five_tree(): TreeNode {
+  let left_child = Node { value: 2, left: Empty {}, right: Empty {} }
+  let right_left = Node { value: 4, left: Empty {}, right: Empty {} }
+  let right_right = Node { value: 5, left: Empty {}, right: Empty {} }
+  let right_child = Node { value: 3, left: right_left, right: right_right }
+  return Node { value: 1, left: left_child, right: right_child }
+}
+
+fun main() {
+  let root = five_tree()
+  let serial = serialize(root)
+  print(serial)
+  let rebuilt = deserialize(serial)
+  let serial2 = serialize(rebuilt)
+  print(serial2)
+  print(serial == serial2)
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/serialize_deserialize_binary_tree.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/serialize_deserialize_binary_tree.out
@@ -1,0 +1,3 @@
+1,2,null,null,3,4,null,null,5,null,null
+1,2,null,null,3,4,null,null,5,null,null
+true

--- a/tests/github/TheAlgorithms/Python/data_structures/binary_tree/serialize_deserialize_binary_tree.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/binary_tree/serialize_deserialize_binary_tree.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+
+@dataclass
+class TreeNode:
+    """
+    A binary tree node has a value, left child, and right child.
+
+    Props:
+        value: The value of the node.
+        left: The left child of the node.
+        right: The right child of the node.
+    """
+
+    value: int = 0
+    left: TreeNode | None = None
+    right: TreeNode | None = None
+
+    def __post_init__(self):
+        if not isinstance(self.value, int):
+            raise TypeError("Value must be an integer.")
+
+    def __iter__(self) -> Iterator[TreeNode]:
+        """
+        Iterate through the tree in preorder.
+
+        Returns:
+            An iterator of the tree nodes.
+
+        >>> list(TreeNode(1))
+        [1,null,null]
+        >>> tuple(TreeNode(1, TreeNode(2), TreeNode(3)))
+        (1,2,null,null,3,null,null, 2,null,null, 3,null,null)
+        """
+        yield self
+        yield from self.left or ()
+        yield from self.right or ()
+
+    def __len__(self) -> int:
+        """
+        Count the number of nodes in the tree.
+
+        Returns:
+            The number of nodes in the tree.
+
+        >>> len(TreeNode(1))
+        1
+        >>> len(TreeNode(1, TreeNode(2), TreeNode(3)))
+        3
+        """
+        return sum(1 for _ in self)
+
+    def __repr__(self) -> str:
+        """
+        Represent the tree as a string.
+
+        Returns:
+            A string representation of the tree.
+
+        >>> repr(TreeNode(1))
+        '1,null,null'
+        >>> repr(TreeNode(1, TreeNode(2), TreeNode(3)))
+        '1,2,null,null,3,null,null'
+        >>> repr(TreeNode(1, TreeNode(2), TreeNode(3, TreeNode(4), TreeNode(5))))
+        '1,2,null,null,3,4,null,null,5,null,null'
+        """
+        return f"{self.value},{self.left!r},{self.right!r}".replace("None", "null")
+
+    @classmethod
+    def five_tree(cls) -> TreeNode:
+        """
+        >>> repr(TreeNode.five_tree())
+        '1,2,null,null,3,4,null,null,5,null,null'
+        """
+        root = TreeNode(1)
+        root.left = TreeNode(2)
+        root.right = TreeNode(3)
+        root.right.left = TreeNode(4)
+        root.right.right = TreeNode(5)
+        return root
+
+
+def deserialize(data: str) -> TreeNode | None:
+    """
+    Deserialize a string to a binary tree.
+
+    Args:
+        data(str): The serialized string.
+
+    Returns:
+        The root of the binary tree.
+
+    >>> root = TreeNode.five_tree()
+    >>> serialzed_data = repr(root)
+    >>> deserialized = deserialize(serialzed_data)
+    >>> root == deserialized
+    True
+    >>> root is deserialized  # two separate trees
+    False
+    >>> root.right.right.value = 6
+    >>> root == deserialized
+    False
+    >>> serialzed_data = repr(root)
+    >>> deserialized = deserialize(serialzed_data)
+    >>> root == deserialized
+    True
+    >>> deserialize("")
+    Traceback (most recent call last):
+        ...
+    ValueError: Data cannot be empty.
+    """
+
+    if not data:
+        raise ValueError("Data cannot be empty.")
+
+    # Split the serialized string by a comma to get node values
+    nodes = data.split(",")
+
+    def build_tree() -> TreeNode | None:
+        # Get the next value from the list
+        value = nodes.pop(0)
+
+        if value == "null":
+            return None
+
+        node = TreeNode(int(value))
+        node.left = build_tree()  # Recursively build left subtree
+        node.right = build_tree()  # Recursively build right subtree
+        return node
+
+    return build_tree()
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- download Python reference for binary tree serialization and deserialization
- implement equivalent Mochi version using preorder traversal with explicit null markers
- include runnable example and capture output

## Testing
- `./bin/mochi run tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/serialize_deserialize_binary_tree.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891761e1dc48320b1c4a9916c9ee3a9