### PR TITLE
Add union-find disjoint set example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/disjoint_set/alternate_disjoint_set.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/disjoint_set/alternate_disjoint_set.mochi
@@ -1,0 +1,98 @@
+/*
+Implements a disjoint-set (union–find) structure with union by rank and
+path compression.  Each set is represented by an index.  Arrays track
+parents, ranks and the number of items in each set.  The `merge` function
+joins two sets by attaching the root with lower rank under the root with
+higher rank, increasing the destination rank when both are equal.  The
+`get_parent` function performs path compression to keep trees shallow by
+recursively finding a node's root and updating parent pointers on the way
+up.  After every union the size of the largest set is stored in
+`max_set`.
+*/
+
+type DisjointSet {
+  set_counts: list<int>,
+  max_set: int,
+  ranks: list<int>,
+  parents: list<int>,
+}
+
+fun max_list(xs: list<int>): int {
+  var m = xs[0]
+  var i = 1
+  while i < len(xs) {
+    if xs[i] > m { m = xs[i] }
+    i = i + 1
+  }
+  return m
+}
+
+fun disjoint_set_new(set_counts: list<int>): DisjointSet {
+  let max_set = max_list(set_counts)
+  let num_sets = len(set_counts)
+  var ranks: list<int> = []
+  var parents: list<int> = []
+  var i = 0
+  while i < num_sets {
+    ranks = append(ranks, 1)
+    parents = append(parents, i)
+    i = i + 1
+  }
+  return DisjointSet{
+    set_counts: set_counts,
+    max_set: max_set,
+    ranks: ranks,
+    parents: parents,
+  }
+}
+
+fun get_parent(ds: DisjointSet, idx: int): int {
+  if ds.parents[idx] == idx { return idx }
+  var parents = ds.parents
+  parents[idx] = get_parent(ds, parents[idx])
+  ds.parents = parents
+  return ds.parents[idx]
+}
+
+fun merge(ds: DisjointSet, src: int, dst: int): bool {
+  let src_parent = get_parent(ds, src)
+  let dst_parent = get_parent(ds, dst)
+  if src_parent == dst_parent { return false }
+
+  if ds.ranks[dst_parent] >= ds.ranks[src_parent] {
+    var counts = ds.set_counts
+    counts[dst_parent] = counts[dst_parent] + counts[src_parent]
+    counts[src_parent] = 0
+    ds.set_counts = counts
+    var parents = ds.parents
+    parents[src_parent] = dst_parent
+    ds.parents = parents
+    if ds.ranks[dst_parent] == ds.ranks[src_parent] {
+      var ranks = ds.ranks
+      ranks[dst_parent] = ranks[dst_parent] + 1
+      ds.ranks = ranks
+    }
+    let joined = ds.set_counts[dst_parent]
+    if joined > ds.max_set { ds.max_set = joined }
+  } else {
+    var counts = ds.set_counts
+    counts[src_parent] = counts[src_parent] + counts[dst_parent]
+    counts[dst_parent] = 0
+    ds.set_counts = counts
+    var parents = ds.parents
+    parents[dst_parent] = src_parent
+    ds.parents = parents
+    let joined = ds.set_counts[src_parent]
+    if joined > ds.max_set { ds.max_set = joined }
+  }
+  return true
+}
+
+// Example usage
+var ds = disjoint_set_new([1, 1, 1])
+print(merge(ds, 1, 2))
+print(merge(ds, 0, 2))
+print(merge(ds, 0, 1))
+print(get_parent(ds, 0))
+print(get_parent(ds, 1))
+print(ds.max_set)

--- a/tests/github/TheAlgorithms/Mochi/data_structures/disjoint_set/alternate_disjoint_set.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/disjoint_set/alternate_disjoint_set.out
@@ -1,0 +1,6 @@
+true
+true
+false
+2
+2
+3

--- a/tests/github/TheAlgorithms/Python/data_structures/disjoint_set/alternate_disjoint_set.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/disjoint_set/alternate_disjoint_set.py
@@ -1,0 +1,68 @@
+"""
+Implements a disjoint set using Lists and some added heuristics for efficiency
+Union by Rank Heuristic and Path Compression
+"""
+
+
+class DisjointSet:
+    def __init__(self, set_counts: list) -> None:
+        """
+        Initialize with a list of the number of items in each set
+        and with rank = 1 for each set
+        """
+        self.set_counts = set_counts
+        self.max_set = max(set_counts)
+        num_sets = len(set_counts)
+        self.ranks = [1] * num_sets
+        self.parents = list(range(num_sets))
+
+    def merge(self, src: int, dst: int) -> bool:
+        """
+        Merge two sets together using Union by rank heuristic
+        Return True if successful
+        Merge two disjoint sets
+        >>> A = DisjointSet([1, 1, 1])
+        >>> A.merge(1, 2)
+        True
+        >>> A.merge(0, 2)
+        True
+        >>> A.merge(0, 1)
+        False
+        """
+        src_parent = self.get_parent(src)
+        dst_parent = self.get_parent(dst)
+
+        if src_parent == dst_parent:
+            return False
+
+        if self.ranks[dst_parent] >= self.ranks[src_parent]:
+            self.set_counts[dst_parent] += self.set_counts[src_parent]
+            self.set_counts[src_parent] = 0
+            self.parents[src_parent] = dst_parent
+            if self.ranks[dst_parent] == self.ranks[src_parent]:
+                self.ranks[dst_parent] += 1
+            joined_set_size = self.set_counts[dst_parent]
+        else:
+            self.set_counts[src_parent] += self.set_counts[dst_parent]
+            self.set_counts[dst_parent] = 0
+            self.parents[dst_parent] = src_parent
+            joined_set_size = self.set_counts[src_parent]
+
+        self.max_set = max(self.max_set, joined_set_size)
+        return True
+
+    def get_parent(self, disj_set: int) -> int:
+        """
+        Find the Parent of a given set
+        >>> A = DisjointSet([1, 1, 1])
+        >>> A.merge(1, 2)
+        True
+        >>> A.get_parent(0)
+        0
+        >>> A.get_parent(1)
+        2
+        """
+        if self.parents[disj_set] == disj_set:
+            return disj_set
+        self.parents[disj_set] = self.get_parent(self.parents[disj_set])
+        return self.parents[disj_set]


### PR DESCRIPTION
## Summary
- add reference Python implementation of union-find with union by rank and path compression
- implement equivalent Mochi disjoint-set structure and sample usage

## Testing
- `npm test` (fails: Missing script "test")
- `./mochi_bin run tests/github/TheAlgorithms/Mochi/data_structures/disjoint_set/alternate_disjoint_set.mochi`


------
https://chatgpt.com/codex/tasks/task_e_68917626dbb0832097b1433f8129d7bf