### PR TITLE
Add Bloom filter implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/hashing/bloom_filter.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/hashing/bloom_filter.mochi
@@ -1,0 +1,185 @@
+/*
+Bloom Filter for Probabilistic Set Membership
+
+A Bloom filter is a space-efficient data structure that answers membership
+queries with possible false positives but no false negatives. It uses a bit
+array and multiple hash functions. To add a value, each hash function maps the
+value to a position in the bit array and sets that bit to 1. To test membership,
+all corresponding bits must be 1. The probability of false positives increases
+as more elements are inserted and decreases with a larger bit array.
+
+This implementation keeps the bit array as a list<int> of 0/1 values and employs
+two simple polynomial rolling hash functions instead of cryptographic hashes to
+remain self-contained. The estimated error rate is computed as
+(n_ones / size)^k where k is the number of hash functions.
+
+Functions provided:
+- new_bloom(size): create a filter with all bits zero.
+- bloom_add(filter, value): insert a string into the filter.
+- bloom_exists(filter, value): check if a string might be in the set.
+- format_hash(filter, value): show bits that would be set for a value.
+- bitstring(filter): current bit array as a binary string.
+- estimated_error_rate(filter): estimate probability of false positives.
+
+Time complexity for add and membership tests is O(len(value)).
+*/
+
+let ascii = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+
+fun ord(ch: string): int {
+  var i = 0
+  while i < len(ascii) {
+    if ascii[i:i+1] == ch { return 32 + i }
+    i = i + 1
+  }
+  return 0
+}
+
+type Bloom {
+  size: int,
+  bits: list<int>
+}
+
+fun new_bloom(size: int): Bloom {
+  var bits: list<int> = []
+  var i = 0
+  while i < size {
+    bits = append(bits, 0)
+    i = i + 1
+  }
+  return Bloom { size: size, bits: bits }
+}
+
+fun hash1(value: string, size: int): int {
+  var h = 0
+  var i = 0
+  while i < len(value) {
+    h = (h * 31 + ord(value[i:i+1])) % size
+    i = i + 1
+  }
+  return h
+}
+
+fun hash2(value: string, size: int): int {
+  var h = 0
+  var i = 0
+  while i < len(value) {
+    h = (h * 131 + ord(value[i:i+1])) % size
+    i = i + 1
+  }
+  return h
+}
+
+fun hash_positions(value: string, size: int): list<int> {
+  let h1 = hash1(value, size)
+  let h2 = hash2(value, size)
+  var res: list<int> = []
+  res = append(res, h1)
+  res = append(res, h2)
+  return res
+}
+
+fun bloom_add(b: Bloom, value: string): Bloom {
+  let pos = hash_positions(value, b.size)
+  var bits = b.bits
+  var i = 0
+  while i < len(pos) {
+    let idx = b.size - 1 - pos[i]
+    bits[idx] = 1
+    i = i + 1
+  }
+  return Bloom { size: b.size, bits: bits }
+}
+
+fun bloom_exists(b: Bloom, value: string): bool {
+  let pos = hash_positions(value, b.size)
+  var i = 0
+  while i < len(pos) {
+    let idx = b.size - 1 - pos[i]
+    if b.bits[idx] != 1 { return false }
+    i = i + 1
+  }
+  return true
+}
+
+fun bitstring(b: Bloom): string {
+  var res = ""
+  var i = 0
+  while i < b.size {
+    res = res + str(b.bits[i])
+    i = i + 1
+  }
+  return res
+}
+
+fun format_hash(b: Bloom, value: string): string {
+  let pos = hash_positions(value, b.size)
+  var bits: list<int> = []
+  var i = 0
+  while i < b.size {
+    bits = append(bits, 0)
+    i = i + 1
+  }
+  i = 0
+  while i < len(pos) {
+    let idx = b.size - 1 - pos[i]
+    bits[idx] = 1
+    i = i + 1
+  }
+  var res = ""
+  i = 0
+  while i < b.size {
+    res = res + str(bits[i])
+    i = i + 1
+  }
+  return res
+}
+
+fun estimated_error_rate(b: Bloom): float {
+  var ones = 0
+  var i = 0
+  while i < b.size {
+    if b.bits[i] == 1 { ones = ones + 1 }
+    i = i + 1
+  }
+  let frac = (ones as float) / (b.size as float)
+  return frac * frac
+}
+
+fun any_in(b: Bloom, items: list<string>): bool {
+  var i = 0
+  while i < len(items) {
+    if bloom_exists(b, items[i]) { return true }
+    i = i + 1
+  }
+  return false
+}
+
+fun main() {
+  var bloom = new_bloom(8)
+  print(bitstring(bloom))
+  print(bloom_exists(bloom, "Titanic"))
+  bloom = bloom_add(bloom, "Titanic")
+  print(bitstring(bloom))
+  print(bloom_exists(bloom, "Titanic"))
+  bloom = bloom_add(bloom, "Avatar")
+  print(bloom_exists(bloom, "Avatar"))
+  print(format_hash(bloom, "Avatar"))
+  print(bitstring(bloom))
+  let not_present = ["The Godfather", "Interstellar", "Parasite", "Pulp Fiction"]
+  var i = 0
+  while i < len(not_present) {
+    let film = not_present[i]
+    print(film + ":" + format_hash(bloom, film))
+    i = i + 1
+  }
+  print(any_in(bloom, not_present))
+  print(bloom_exists(bloom, "Ratatouille"))
+  print(format_hash(bloom, "Ratatouille"))
+  print(str(estimated_error_rate(bloom)))
+  bloom = bloom_add(bloom, "The Godfather")
+  print(str(estimated_error_rate(bloom)))
+  print(bitstring(bloom))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/data_structures/hashing/bloom_filter.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/hashing/bloom_filter.out
@@ -1,0 +1,17 @@
+00000000
+false
+01000100
+true
+true
+00100010
+01100110
+The Godfather:00000010
+Interstellar:00000010
+Parasite:10001000
+Pulp Fiction:00100000
+true
+true
+00000100
+0.25
+0.25
+01100110

--- a/tests/github/TheAlgorithms/Python/data_structures/hashing/bloom_filter.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/hashing/bloom_filter.py
@@ -1,0 +1,106 @@
+"""
+See https://en.wikipedia.org/wiki/Bloom_filter
+
+The use of this data structure is to test membership in a set.
+Compared to Python's built-in set() it is more space-efficient.
+In the following example, only 8 bits of memory will be used:
+>>> bloom = Bloom(size=8)
+
+Initially, the filter contains all zeros:
+>>> bloom.bitstring
+'00000000'
+
+When an element is added, two bits are set to 1
+since there are 2 hash functions in this implementation:
+>>> "Titanic" in bloom
+False
+>>> bloom.add("Titanic")
+>>> bloom.bitstring
+'01100000'
+>>> "Titanic" in bloom
+True
+
+However, sometimes only one bit is added
+because both hash functions return the same value
+>>> bloom.add("Avatar")
+>>> "Avatar" in bloom
+True
+>>> bloom.format_hash("Avatar")
+'00000100'
+>>> bloom.bitstring
+'01100100'
+
+Not added elements should return False ...
+>>> not_present_films = ("The Godfather", "Interstellar", "Parasite", "Pulp Fiction")
+>>> {
+...   film: bloom.format_hash(film) for film in not_present_films
+... } # doctest: +NORMALIZE_WHITESPACE
+{'The Godfather': '00000101',
+ 'Interstellar': '00000011',
+ 'Parasite': '00010010',
+ 'Pulp Fiction': '10000100'}
+>>> any(film in bloom for film in not_present_films)
+False
+
+but sometimes there are false positives:
+>>> "Ratatouille" in bloom
+True
+>>> bloom.format_hash("Ratatouille")
+'01100000'
+
+The probability increases with the number of elements added.
+The probability decreases with the number of bits in the bitarray.
+>>> bloom.estimated_error_rate
+0.140625
+>>> bloom.add("The Godfather")
+>>> bloom.estimated_error_rate
+0.25
+>>> bloom.bitstring
+'01100101'
+"""
+
+from hashlib import md5, sha256
+
+HASH_FUNCTIONS = (sha256, md5)
+
+
+class Bloom:
+    def __init__(self, size: int = 8) -> None:
+        self.bitarray = 0b0
+        self.size = size
+
+    def add(self, value: str) -> None:
+        h = self.hash_(value)
+        self.bitarray |= h
+
+    def exists(self, value: str) -> bool:
+        h = self.hash_(value)
+        return (h & self.bitarray) == h
+
+    def __contains__(self, other: str) -> bool:
+        return self.exists(other)
+
+    def format_bin(self, bitarray: int) -> str:
+        res = bin(bitarray)[2:]
+        return res.zfill(self.size)
+
+    @property
+    def bitstring(self) -> str:
+        return self.format_bin(self.bitarray)
+
+    def hash_(self, value: str) -> int:
+        res = 0b0
+        for func in HASH_FUNCTIONS:
+            position = (
+                int.from_bytes(func(value.encode()).digest(), "little") % self.size
+            )
+            res |= 2**position
+        return res
+
+    def format_hash(self, value: str) -> str:
+        return self.format_bin(self.hash_(value))
+
+    @property
+    def estimated_error_rate(self) -> float:
+        n_ones = bin(self.bitarray).count("1")
+        return (n_ones / self.size) ** len(HASH_FUNCTIONS)


### PR DESCRIPTION
## Summary
- add Python bloom_filter implementation from TheAlgorithms
- provide Mochi version with two simple hash functions
- include runtime output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/data_structures/hashing/bloom_filter.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891762abb8483208d4b643dcb8b10fd