### PR TITLE
Add Mochi prime number utilities

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/hashing/number_theory/prime_numbers.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/hashing/number_theory/prime_numbers.mochi
@@ -1,0 +1,69 @@
+/*
+Prime number utilities.
+
+This program provides two functions:
+
+1. isPrime(n): determines whether an integer n is prime.
+   - Returns false for values < 2 and for even numbers greater than 2.
+   - Checks odd divisors up to the square root of n using i*i <= n.
+
+2. nextPrime(value, factor, desc): returns the next prime relative to
+   `value * factor` searching upward by default. If `desc` is true it
+   searches downward. If the starting value is already prime, the next
+   prime in the given direction is returned.
+
+The implementation avoids external libraries and uses only integer
+arithmetic for primality testing.
+*/
+
+fun isPrime(number: int): bool {
+  if number < 2 {
+    return false
+  }
+  if number < 4 {
+    return true
+  }
+  if number % 2 == 0 {
+    return false
+  }
+  var i = 3
+  while i * i <= number {
+    if number % i == 0 {
+      return false
+    }
+    i = i + 2
+  }
+  return true
+}
+
+fun nextPrime(value: int, factor: int, desc: bool): int {
+  var v = value * factor
+  let firstValue = v
+  while !isPrime(v) {
+    if desc {
+      v = v - 1
+    } else {
+      v = v + 1
+    }
+  }
+  if v == firstValue {
+    if desc {
+      return nextPrime(v - 1, 1, desc)
+    } else {
+      return nextPrime(v + 1, 1, desc)
+    }
+  }
+  return v
+}
+
+print(isPrime(0))
+print(isPrime(1))
+print(isPrime(2))
+print(isPrime(3))
+print(isPrime(27))
+print(isPrime(87))
+print(isPrime(563))
+print(isPrime(2999))
+print(isPrime(67483))
+print(nextPrime(14, 1, false))
+print(nextPrime(14, 1, true))

--- a/tests/github/TheAlgorithms/Mochi/data_structures/hashing/number_theory/prime_numbers.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/hashing/number_theory/prime_numbers.out
@@ -1,0 +1,11 @@
+false
+false
+true
+true
+false
+false
+true
+true
+false
+17
+13

--- a/tests/github/TheAlgorithms/Python/data_structures/hashing/number_theory/prime_numbers.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/hashing/number_theory/prime_numbers.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+module to operations with prime numbers
+"""
+
+import math
+
+
+def is_prime(number: int) -> bool:
+    """Checks to see if a number is a prime in O(sqrt(n)).
+
+    A number is prime if it has exactly two factors: 1 and itself.
+
+    >>> is_prime(0)
+    False
+    >>> is_prime(1)
+    False
+    >>> is_prime(2)
+    True
+    >>> is_prime(3)
+    True
+    >>> is_prime(27)
+    False
+    >>> is_prime(87)
+    False
+    >>> is_prime(563)
+    True
+    >>> is_prime(2999)
+    True
+    >>> is_prime(67483)
+    False
+    """
+
+    # precondition
+    assert isinstance(number, int) and (number >= 0), (
+        "'number' must been an int and positive"
+    )
+
+    if 1 < number < 4:
+        # 2 and 3 are primes
+        return True
+    elif number < 2 or not number % 2:
+        # Negatives, 0, 1 and all even numbers are not primes
+        return False
+
+    odd_numbers = range(3, int(math.sqrt(number) + 1), 2)
+    return not any(not number % i for i in odd_numbers)
+
+
+def next_prime(value, factor=1, **kwargs):
+    value = factor * value
+    first_value_val = value
+
+    while not is_prime(value):
+        value += 1 if not ("desc" in kwargs and kwargs["desc"] is True) else -1
+
+    if value == first_value_val:
+        return next_prime(value + 1, **kwargs)
+    return value


### PR DESCRIPTION
## Summary
- add TheAlgorithms Python prime number script at tests/github/TheAlgorithms/Python/data_structures/hashing/number_theory/prime_numbers.py
- implement equivalent Mochi version with isPrime and nextPrime
- include execution output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/data_structures/hashing/number_theory/prime_numbers.mochi`

------
https://chatgpt.com/codex/tasks/task_e_68917634631c8320b7f1ce90bb9e6a91