### PR TITLE
Add merge two binary trees algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/merge_two_binary_trees.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/merge_two_binary_trees.mochi
@@ -1,0 +1,94 @@
+/*
+Merge Two Binary Trees
+
+Given two binary trees, create a new tree by summing values of overlapping
+nodes. When only one node exists at a position, that node is used directly
+in the merged tree.
+
+Algorithm:
+- If both nodes are leaves, return the other node where present.
+- Otherwise sum the values of overlapping nodes and recursively merge the
+  corresponding children.
+
+The merge visits each node that appears in either input tree exactly once,
+so the time complexity is O(n) where n is the total number of nodes across
+both trees. Only the recursion stack is used, giving O(h) auxiliary space
+where h is the height of the resulting tree.
+*/
+
+type Tree =
+  Leaf {}
+  | Node(left: Tree, value: int, right: Tree)
+
+fun merge_two_binary_trees(t1: Tree, t2: Tree): Tree {
+  return match t1 {
+    Leaf => t2
+    Node(l1, v1, r1) => match t2 {
+      Leaf => t1
+      Node(l2, v2, r2) => Node {
+        left: merge_two_binary_trees(l1, l2),
+        value: v1 + v2,
+        right: merge_two_binary_trees(r1, r2)
+      }
+    }
+  }
+}
+
+fun is_leaf(t: Tree): bool {
+  return match t {
+    Leaf => true
+    _ => false
+  }
+}
+
+fun get_left(t: Tree): Tree {
+  return match t {
+    Node(l, _, _) => l
+    _ => Leaf {}
+  }
+}
+
+fun get_right(t: Tree): Tree {
+  return match t {
+    Node(_, _, r) => r
+    _ => Leaf {}
+  }
+}
+
+fun get_value(t: Tree): int {
+  return match t {
+    Node(_, v, _) => v
+    _ => 0
+  }
+}
+
+fun print_preorder(t: Tree): unit {
+  if !is_leaf(t) {
+    let v = get_value(t)
+    let l = get_left(t)
+    let r = get_right(t)
+    print(v)
+    print_preorder(l)
+    print_preorder(r)
+  }
+}
+
+let tree1 = Node {
+  left: Node { left: Node { left: Leaf {}, value: 4, right: Leaf {} }, value: 2, right: Leaf {} },
+  value: 1,
+  right: Node { left: Leaf {}, value: 3, right: Leaf {} }
+}
+
+let tree2 = Node {
+  left: Node { left: Leaf {}, value: 4, right: Node { left: Leaf {}, value: 9, right: Leaf {} } },
+  value: 2,
+  right: Node { left: Leaf {}, value: 6, right: Node { left: Leaf {}, value: 5, right: Leaf {} } }
+}
+
+print("Tree1 is:")
+print_preorder(tree1)
+print("Tree2 is:")
+print_preorder(tree2)
+let merged_tree = merge_two_binary_trees(tree1, tree2)
+print("Merged Tree is:")
+print_preorder(merged_tree)

--- a/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/merge_two_binary_trees.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/merge_two_binary_trees.out
@@ -1,0 +1,18 @@
+Tree1 is:
+1
+2
+4
+3
+Tree2 is:
+2
+4
+9
+6
+5
+Merged Tree is:
+3
+6
+4
+9
+9
+5

--- a/tests/github/TheAlgorithms/Python/data_structures/binary_tree/merge_two_binary_trees.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/binary_tree/merge_two_binary_trees.py
@@ -1,0 +1,94 @@
+#!/usr/local/bin/python3
+"""
+Problem Description: Given two binary tree, return the merged tree.
+The rule for merging is that if two nodes overlap, then put the value sum of
+both nodes to the new value of the merged node. Otherwise, the NOT null node
+will be used as the node of new tree.
+"""
+
+from __future__ import annotations
+
+
+class Node:
+    """
+    A binary node has value variable and pointers to its left and right node.
+    """
+
+    def __init__(self, value: int = 0) -> None:
+        self.value = value
+        self.left: Node | None = None
+        self.right: Node | None = None
+
+
+def merge_two_binary_trees(tree1: Node | None, tree2: Node | None) -> Node | None:
+    """
+    Returns root node of the merged tree.
+
+    >>> tree1 = Node(5)
+    >>> tree1.left = Node(6)
+    >>> tree1.right = Node(7)
+    >>> tree1.left.left = Node(2)
+    >>> tree2 = Node(4)
+    >>> tree2.left = Node(5)
+    >>> tree2.right = Node(8)
+    >>> tree2.left.right = Node(1)
+    >>> tree2.right.right = Node(4)
+    >>> merged_tree = merge_two_binary_trees(tree1, tree2)
+    >>> print_preorder(merged_tree)
+    9
+    11
+    2
+    1
+    15
+    4
+    """
+    if tree1 is None:
+        return tree2
+    if tree2 is None:
+        return tree1
+
+    tree1.value = tree1.value + tree2.value
+    tree1.left = merge_two_binary_trees(tree1.left, tree2.left)
+    tree1.right = merge_two_binary_trees(tree1.right, tree2.right)
+    return tree1
+
+
+def print_preorder(root: Node | None) -> None:
+    """
+    Print pre-order traversal of the tree.
+
+    >>> root = Node(1)
+    >>> root.left = Node(2)
+    >>> root.right = Node(3)
+    >>> print_preorder(root)
+    1
+    2
+    3
+    >>> print_preorder(root.right)
+    3
+    """
+    if root:
+        print(root.value)
+        print_preorder(root.left)
+        print_preorder(root.right)
+
+
+if __name__ == "__main__":
+    tree1 = Node(1)
+    tree1.left = Node(2)
+    tree1.right = Node(3)
+    tree1.left.left = Node(4)
+
+    tree2 = Node(2)
+    tree2.left = Node(4)
+    tree2.right = Node(6)
+    tree2.left.right = Node(9)
+    tree2.right.right = Node(5)
+
+    print("Tree1 is: ")
+    print_preorder(tree1)
+    print("Tree2 is: ")
+    print_preorder(tree2)
+    merged_tree = merge_two_binary_trees(tree1, tree2)
+    print("Merged Tree is: ")
+    print_preorder(merged_tree)


### PR DESCRIPTION
## Summary
- add Python source for merging two binary trees
- implement merge_two_binary_trees in pure Mochi with preorder traversal
- include VM output for verification

## Testing
- `node index.js run tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/merge_two_binary_trees.mochi > tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/merge_two_binary_trees.out`

------
https://chatgpt.com/codex/tasks/task_e_689172fa82a88320a4cea83d67c23b38