### PR TITLE
Add Mochi implementation for mirror binary tree

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/mirror_binary_tree.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/mirror_binary_tree.mochi
@@ -1,0 +1,90 @@
+/*
+Given the root of a binary tree, create its mirror image where the left and right
+children of every node are swapped.  This implementation models a tree using
+parallel arrays: `values` holds node values while `left` and `right` store child
+indices (or -1 for missing children).  Mirroring swaps the child indices at each
+node via depth first traversal.
+
+Algorithm:
+1. Starting from the root index, swap the left and right child indices.
+2. Recursively apply the same operation to the new left and right children.
+3. An inorder traversal is used to show the tree structure before and after
+   mirroring.
+
+Each node is visited once, so the time complexity is O(n) for a tree with `n`
+nodes.  The recursion depth corresponds to the height of the tree.
+*/
+
+type Tree {
+  values: list<int>,
+  left: list<int>,
+  right: list<int>,
+  root: int,
+}
+
+fun mirror_node(left: list<int>, right: list<int>, idx: int) {
+  if idx == (-1) {
+    return
+  }
+  let temp = left[idx]
+  left[idx] = right[idx]
+  right[idx] = temp
+  mirror_node(left, right, left[idx])
+  mirror_node(left, right, right[idx])
+}
+
+fun mirror(tree: Tree): Tree {
+  mirror_node(tree.left, tree.right, tree.root)
+  return tree
+}
+
+fun inorder(tree: Tree, idx: int): list<int> {
+  if idx == (-1) {
+    return []
+  }
+  let left_vals = inorder(tree, tree.left[idx])
+  let right_vals = inorder(tree, tree.right[idx])
+  return concat(concat(left_vals, [tree.values[idx]]), right_vals)
+}
+
+fun make_tree_zero(): Tree {
+  return Tree {
+    values: [0],
+    left: [-1],
+    right: [-1],
+    root: 0,
+  }
+}
+
+fun make_tree_seven(): Tree {
+  return Tree {
+    values: [1, 2, 3, 4, 5, 6, 7],
+    left: [1, 3, 5, -1, -1, -1, -1],
+    right: [2, 4, 6, -1, -1, -1, -1],
+    root: 0,
+  }
+}
+
+fun make_tree_nine(): Tree {
+  return Tree {
+    values: [1, 2, 3, 4, 5, 6, 7, 8, 9],
+    left: [1, 3, -1, 6, -1, -1, -1, -1, -1],
+    right: [2, 4, 5, 7, 8, -1, -1, -1, -1],
+    root: 0,
+  }
+}
+
+fun main() {
+  let names: list<string> = ["zero", "seven", "nine"]
+  let trees: list<Tree> = [make_tree_zero(), make_tree_seven(), make_tree_nine()]
+  var i = 0
+  while i < len(trees) {
+    let tree = trees[i]
+    print("      The " + names[i] + " tree: " + str(inorder(tree, tree.root)))
+    let mirrored = mirror(tree)
+    print("Mirror of " + names[i] + " tree: " + str(inorder(mirrored, mirrored.root)))
+    i = i + 1
+  }
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/mirror_binary_tree.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/mirror_binary_tree.out
@@ -1,0 +1,6 @@
+      The zero tree: [0]
+Mirror of zero tree: [0]
+      The seven tree: [4 2 5 1 6 3 7]
+Mirror of seven tree: [7 3 6 1 5 2 4]
+      The nine tree: [7 4 8 2 5 9 1 3 6]
+Mirror of nine tree: [6 3 1 9 5 2 8 4 7]

--- a/tests/github/TheAlgorithms/Python/data_structures/binary_tree/mirror_binary_tree.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/binary_tree/mirror_binary_tree.py
@@ -1,0 +1,160 @@
+"""
+Given the root of a binary tree, mirror the tree, and return its root.
+
+Leetcode problem reference: https://leetcode.com/problems/mirror-binary-tree/
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+
+@dataclass
+class Node:
+    """
+    A Node has value variable and pointers to Nodes to its left and right.
+    """
+
+    value: int
+    left: Node | None = None
+    right: Node | None = None
+
+    def __iter__(self) -> Iterator[int]:
+        if self.left:
+            yield from self.left
+        yield self.value
+        if self.right:
+            yield from self.right
+
+    def __len__(self) -> int:
+        return sum(1 for _ in self)
+
+    def mirror(self) -> Node:
+        """
+        Mirror the binary tree rooted at this node by swapping left and right children.
+
+        >>> tree = Node(0)
+        >>> list(tree)
+        [0]
+        >>> list(tree.mirror())
+        [0]
+        >>> tree = Node(1, Node(0), Node(3, Node(2), Node(4, None, Node(5))))
+        >>> tuple(tree)
+        (0, 1, 2, 3, 4, 5)
+        >>> tuple(tree.mirror())
+        (5, 4, 3, 2, 1, 0)
+        """
+        self.left, self.right = self.right, self.left
+        if self.left:
+            self.left.mirror()
+        if self.right:
+            self.right.mirror()
+        return self
+
+
+def make_tree_seven() -> Node:
+    r"""
+    Return a binary tree with 7 nodes that looks like this:
+    ::
+
+           1
+         /   \
+        2     3
+       / \   / \
+      4   5 6   7
+
+    >>> tree_seven = make_tree_seven()
+    >>> len(tree_seven)
+    7
+    >>> list(tree_seven)
+    [4, 2, 5, 1, 6, 3, 7]
+    """
+    tree = Node(1)
+    tree.left = Node(2)
+    tree.right = Node(3)
+    tree.left.left = Node(4)
+    tree.left.right = Node(5)
+    tree.right.left = Node(6)
+    tree.right.right = Node(7)
+    return tree
+
+
+def make_tree_nine() -> Node:
+    r"""
+    Return a binary tree with 9 nodes that looks like this:
+    ::
+
+            1
+           / \
+          2   3
+         / \   \
+        4   5   6
+       / \   \
+      7   8   9
+
+    >>> tree_nine = make_tree_nine()
+    >>> len(tree_nine)
+    9
+    >>> list(tree_nine)
+    [7, 4, 8, 2, 5, 9, 1, 3, 6]
+    """
+    tree = Node(1)
+    tree.left = Node(2)
+    tree.right = Node(3)
+    tree.left.left = Node(4)
+    tree.left.right = Node(5)
+    tree.right.right = Node(6)
+    tree.left.left.left = Node(7)
+    tree.left.left.right = Node(8)
+    tree.left.right.right = Node(9)
+    return tree
+
+
+def main() -> None:
+    r"""
+    Mirror binary trees with the given root and returns the root
+
+    >>> tree = make_tree_nine()
+    >>> tuple(tree)
+    (7, 4, 8, 2, 5, 9, 1, 3, 6)
+    >>> tuple(tree.mirror())
+    (6, 3, 1, 9, 5, 2, 8, 4, 7)
+
+    nine_tree::
+
+            1
+           / \
+          2   3
+         / \   \
+        4   5   6
+       / \   \
+      7   8   9
+
+    The mirrored tree looks like this::
+
+          1
+         / \
+        3   2
+       /   / \
+      6   5   4
+         /   / \
+        9   8   7
+    """
+    trees = {"zero": Node(0), "seven": make_tree_seven(), "nine": make_tree_nine()}
+    for name, tree in trees.items():
+        print(f"      The {name} tree: {tuple(tree)}")
+        # (0,)
+        # (4, 2, 5, 1, 6, 3, 7)
+        # (7, 4, 8, 2, 5, 9, 1, 3, 6)
+        print(f"Mirror of {name} tree: {tuple(tree.mirror())}")
+        # (0,)
+        # (7, 3, 6, 1, 5, 2, 4)
+        # (6, 3, 1, 9, 5, 2, 8, 4, 7)
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    main()


### PR DESCRIPTION
## Summary
- add missing Python source for mirror binary tree
- implement mirror binary tree in Mochi using array-based nodes
- include execution output of the Mochi example

## Testing
- `python tests/github/TheAlgorithms/Python/data_structures/binary_tree/mirror_binary_tree.py`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/data_structures/binary_tree/mirror_binary_tree.mochi`


------
https://chatgpt.com/codex/tasks/task_e_689172fca6f4832081e89f05c69ef05c