### PR TITLE
feat: add doubly linked deque in Mochi

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/deque_doubly.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/deque_doubly.mochi
@@ -1,0 +1,134 @@
+/*
+Implement a double-ended queue (deque) using a doubly linked list with
+explicit head and tail sentinels.  Each node stores a string value along with
+indexes of its previous and next nodes in an array.  The structure allows
+constant-time insertion and removal at both ends:
+
+* `add_first` inserts a value directly after the head sentinel.
+* `add_last` inserts a value directly before the tail sentinel.
+* `remove_first` and `remove_last` delete and return values at the ends.
+* `front` and `back` access the element at either end without removal.
+
+Nodes are referenced by integer indexes to avoid using a dynamic "any" type.
+A simple demonstration exercises the operations and prints intermediate
+results.
+*/
+
+type Node {
+  data: string,
+  prev: int,
+  next: int,
+}
+
+type LinkedDeque {
+  nodes: list<Node>,
+  header: int,
+  trailer: int,
+  size: int,
+}
+
+fun new_deque(): LinkedDeque {
+  var nodes: list<Node> = []
+  // index 0 -> header, index 1 -> trailer
+  nodes = append(nodes, Node{ data: "", prev: -1, next: 1 })
+  nodes = append(nodes, Node{ data: "", prev: 0, next: -1 })
+  return LinkedDeque{ nodes: nodes, header: 0, trailer: 1, size: 0 }
+}
+
+fun is_empty(d: LinkedDeque): bool { return d.size == 0 }
+
+fun front(d: LinkedDeque): string {
+  if is_empty(d) { panic("List is empty") }
+  let head = d.nodes[d.header]
+  let idx = head.next
+  let node = d.nodes[idx]
+  return node.data
+}
+
+fun back(d: LinkedDeque): string {
+  if is_empty(d) { panic("List is empty") }
+  let tail = d.nodes[d.trailer]
+  let idx = tail.prev
+  let node = d.nodes[idx]
+  return node.data
+}
+
+fun insert(d: LinkedDeque, pred: int, value: string, succ: int): LinkedDeque {
+  var nodes = d.nodes
+  let new_idx = len(nodes)
+  nodes = append(nodes, Node{ data: value, prev: pred, next: succ })
+  var pred_node = nodes[pred]
+  pred_node.next = new_idx
+  nodes[pred] = pred_node
+  var succ_node = nodes[succ]
+  succ_node.prev = new_idx
+  nodes[succ] = succ_node
+  d.nodes = nodes
+  d.size = d.size + 1
+  return d
+}
+
+type DeleteResult {
+  deque: LinkedDeque,
+  value: string,
+}
+
+fun delete(d: LinkedDeque, idx: int): DeleteResult {
+  var nodes = d.nodes
+  let node = nodes[idx]
+  let pred = node.prev
+  let succ = node.next
+  var pred_node = nodes[pred]
+  pred_node.next = succ
+  nodes[pred] = pred_node
+  var succ_node = nodes[succ]
+  succ_node.prev = pred
+  nodes[succ] = succ_node
+  let val = node.data
+  d.nodes = nodes
+  d.size = d.size - 1
+  return DeleteResult{ deque: d, value: val }
+}
+
+fun add_first(d: LinkedDeque, value: string): LinkedDeque {
+  let head = d.nodes[d.header]
+  let succ = head.next
+  return insert(d, d.header, value, succ)
+}
+
+fun add_last(d: LinkedDeque, value: string): LinkedDeque {
+  let tail = d.nodes[d.trailer]
+  let pred = tail.prev
+  return insert(d, pred, value, d.trailer)
+}
+
+fun remove_first(d: LinkedDeque): DeleteResult {
+  if is_empty(d) { panic("remove_first from empty list") }
+  let head = d.nodes[d.header]
+  let idx = head.next
+  return delete(d, idx)
+}
+
+fun remove_last(d: LinkedDeque): DeleteResult {
+  if is_empty(d) { panic("remove_first from empty list") }
+  let tail = d.nodes[d.trailer]
+  let idx = tail.prev
+  return delete(d, idx)
+}
+
+fun main() {
+  var d = new_deque()
+  d = add_first(d, "A")
+  print(front(d))
+  d = add_last(d, "B")
+  print(back(d))
+  var r = remove_first(d)
+  d = r.deque
+  print(r.value)
+  r = remove_last(d)
+  d = r.deque
+  print(r.value)
+  print(str(is_empty(d)))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/deque_doubly.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/deque_doubly.out
@@ -1,0 +1,5 @@
+A
+B
+A
+B
+true

--- a/tests/github/TheAlgorithms/Python/data_structures/linked_list/deque_doubly.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/linked_list/deque_doubly.py
@@ -1,0 +1,143 @@
+"""
+Implementing Deque using DoublyLinkedList ...
+Operations:
+    1. insertion in the front -> O(1)
+    2. insertion in the end -> O(1)
+    3. remove from the front -> O(1)
+    4. remove from the end -> O(1)
+"""
+
+
+class _DoublyLinkedBase:
+    """A Private class (to be inherited)"""
+
+    class _Node:
+        __slots__ = "_data", "_next", "_prev"
+
+        def __init__(self, link_p, element, link_n):
+            self._prev = link_p
+            self._data = element
+            self._next = link_n
+
+        def has_next_and_prev(self):
+            return (
+                f" Prev -> {self._prev is not None}, Next -> {self._next is not None}"
+            )
+
+    def __init__(self):
+        self._header = self._Node(None, None, None)
+        self._trailer = self._Node(None, None, None)
+        self._header._next = self._trailer
+        self._trailer._prev = self._header
+        self._size = 0
+
+    def __len__(self):
+        return self._size
+
+    def is_empty(self):
+        return self.__len__() == 0
+
+    def _insert(self, predecessor, e, successor):
+        # Create new_node by setting it's prev.link -> header
+        # setting it's next.link -> trailer
+        new_node = self._Node(predecessor, e, successor)
+        predecessor._next = new_node
+        successor._prev = new_node
+        self._size += 1
+        return self
+
+    def _delete(self, node):
+        predecessor = node._prev
+        successor = node._next
+
+        predecessor._next = successor
+        successor._prev = predecessor
+        self._size -= 1
+        temp = node._data
+        node._prev = node._next = node._data = None
+        del node
+        return temp
+
+
+class LinkedDeque(_DoublyLinkedBase):
+    def first(self):
+        """return first element
+        >>> d = LinkedDeque()
+        >>> d.add_first('A').first()
+        'A'
+        >>> d.add_first('B').first()
+        'B'
+        """
+        if self.is_empty():
+            raise Exception("List is empty")
+        return self._header._next._data
+
+    def last(self):
+        """return last element
+        >>> d = LinkedDeque()
+        >>> d.add_last('A').last()
+        'A'
+        >>> d.add_last('B').last()
+        'B'
+        """
+        if self.is_empty():
+            raise Exception("List is empty")
+        return self._trailer._prev._data
+
+    # DEque Insert Operations (At the front, At the end)
+
+    def add_first(self, element):
+        """insertion in the front
+        >>> LinkedDeque().add_first('AV').first()
+        'AV'
+        """
+        return self._insert(self._header, element, self._header._next)
+
+    def add_last(self, element):
+        """insertion in the end
+        >>> LinkedDeque().add_last('B').last()
+        'B'
+        """
+        return self._insert(self._trailer._prev, element, self._trailer)
+
+    # DEqueu Remove Operations (At the front, At the end)
+
+    def remove_first(self):
+        """removal from the front
+        >>> d = LinkedDeque()
+        >>> d.is_empty()
+        True
+        >>> d.remove_first()
+        Traceback (most recent call last):
+           ...
+        IndexError: remove_first from empty list
+        >>> d.add_first('A') # doctest: +ELLIPSIS
+        <data_structures.linked_list.deque_doubly.LinkedDeque object at ...
+        >>> d.remove_first()
+        'A'
+        >>> d.is_empty()
+        True
+        """
+        if self.is_empty():
+            raise IndexError("remove_first from empty list")
+        return self._delete(self._header._next)
+
+    def remove_last(self):
+        """removal in the end
+        >>> d = LinkedDeque()
+        >>> d.is_empty()
+        True
+        >>> d.remove_last()
+        Traceback (most recent call last):
+           ...
+        IndexError: remove_first from empty list
+        >>> d.add_first('A') # doctest: +ELLIPSIS
+        <data_structures.linked_list.deque_doubly.LinkedDeque object at ...
+        >>> d.remove_last()
+        'A'
+        >>> d.is_empty()
+        True
+        """
+        if self.is_empty():
+            raise IndexError("remove_first from empty list")
+        return self._delete(self._trailer._prev)


### PR DESCRIPTION
## Summary
- add missing Python implementation for doubly linked deque
- implement matching Mochi version using array-backed doubly linked list with head/tail sentinels
- include runtime output for the Mochi example

## Testing
- `./mochi run tests/github/TheAlgorithms/Mochi/data_structures/linked_list/deque_doubly.mochi`


------
https://chatgpt.com/codex/tasks/task_e_689184a6296c83209bf314995e010193