### PR TITLE
Add linked list from sequence example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/from_sequence.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/from_sequence.mochi
@@ -1,0 +1,57 @@
+/*
+Construct a singly linked list from a sequence of integers. Each node
+stores an integer and the index of its successor; -1 represents the
+end of the list. The make_linked_list function takes a list of integers
+and returns the index of the head node. node_to_string creates a string
+representation in the form "<1> ---> <2> ---> <END>".
+
+The demonstration builds a list from a sample array and prints both the
+original array and the linked list string.
+*/
+
+type Node {
+  data: int,
+  next: int,
+}
+
+let NIL = 0 - 1
+var nodes: list<Node> = []
+
+fun make_linked_list(elements: list<int>): int {
+  if len(elements) == 0 { panic("The Elements List is empty") }
+  nodes = []
+  nodes = append(nodes, Node { data: elements[0], next: NIL })
+  var head = 0
+  var current = head
+  var i = 1
+  while i < len(elements) {
+    nodes = append(nodes, Node { data: elements[i], next: NIL })
+    nodes[current].next = len(nodes) - 1
+    current = len(nodes) - 1
+    i = i + 1
+  }
+  return head
+}
+
+fun node_to_string(head: int): string {
+  var s = ""
+  var index = head
+  while index != NIL {
+    let node = nodes[index]
+    s = s + "<" + str(node.data) + "> ---> "
+    index = node.next
+  }
+  s = s + "<END>"
+  return s
+}
+
+fun main() {
+  let list_data: list<int> = [1, 3, 5, 32, 44, 12, 43]
+  print("List: " + str(list_data))
+  print("Creating Linked List from List.")
+  let head = make_linked_list(list_data)
+  print("Linked List:")
+  print(node_to_string(head))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/from_sequence.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/from_sequence.out
@@ -1,0 +1,4 @@
+List: [1 3 5 32 44 12 43]
+Creating Linked List from List.
+Linked List:
+<1> ---> <3> ---> <5> ---> <32> ---> <44> ---> <12> ---> <43> ---> <END>

--- a/tests/github/TheAlgorithms/Python/data_structures/linked_list/from_sequence.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/linked_list/from_sequence.py
@@ -1,0 +1,44 @@
+# Recursive Program to create a Linked List from a sequence and
+# print a string representation of it.
+
+
+class Node:
+    def __init__(self, data=None):
+        self.data = data
+        self.next = None
+
+    def __repr__(self):
+        """Returns a visual representation of the node and all its following nodes."""
+        string_rep = ""
+        temp = self
+        while temp:
+            string_rep += f"<{temp.data}> ---> "
+            temp = temp.next
+        string_rep += "<END>"
+        return string_rep
+
+
+def make_linked_list(elements_list):
+    """Creates a Linked List from the elements of the given sequence
+    (list/tuple) and returns the head of the Linked List."""
+
+    # if elements_list is empty
+    if not elements_list:
+        raise Exception("The Elements List is empty")
+
+    # Set first element as Head
+    head = Node(elements_list[0])
+    current = head
+    # Loop through elements from position 1
+    for data in elements_list[1:]:
+        current.next = Node(data)
+        current = current.next
+    return head
+
+
+list_data = [1, 3, 5, 32, 44, 12, 43]
+print(f"List: {list_data}")
+print("Creating Linked List from List.")
+linked_list = make_linked_list(list_data)
+print("Linked List:")
+print(linked_list)


### PR DESCRIPTION
## Summary
- add missing Python reference implementation for creating a linked list from a sequence
- add Mochi version building a linked list using index-based nodes and generating formatted output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/data_structures/linked_list/from_sequence.mochi`
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_689184abced48320a24776676630114e