### PR TITLE
Add linked list loop detection algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/has_loop.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/has_loop.mochi
@@ -1,0 +1,61 @@
+/*
+Detect whether a singly linked list contains a loop.
+Each node stores an integer and the index of its successor; -1 marks the end.
+Floyd's cycle detection algorithm moves a slow pointer one step at a time and
+a fast pointer two steps at a time. If the list contains a loop, the pointers
+will eventually meet; otherwise the fast pointer reaches the end.
+
+The demonstration builds lists analogous to the Python version:
+1) 1->2->3->4 without a loop.
+2) The last node is linked back to the second node creating a loop.
+3) 5->6->5->6 where values repeat but nodes are distinct (no loop).
+4) A single-node list.
+The expected outputs are false, true, false, and false.
+*/
+
+type Node {
+  data: int,
+  next: int
+}
+
+fun has_loop(nodes: list<Node>, head: int): bool {
+  var slow = head
+  var fast = head
+  while fast != 0 - 1 {
+    let fast_node1 = nodes[fast]
+    if fast_node1.next == 0 - 1 { return false }
+    let fast_node2 = nodes[fast_node1.next]
+    if fast_node2.next == 0 - 1 { return false }
+    let slow_node = nodes[slow]
+    slow = slow_node.next
+    fast = fast_node2.next
+    if slow == fast { return true }
+  }
+  return false
+}
+
+fun make_nodes(values: list<int>): list<Node> {
+  var nodes: list<Node> = []
+  var i = 0
+  while i < len(values) {
+    let next_idx = if i == len(values) - 1 { 0 - 1 } else { i + 1 }
+    nodes = append(nodes, Node { data: values[i], next: next_idx })
+    i = i + 1
+  }
+  return nodes
+}
+
+fun main() {
+  var list1 = make_nodes([1, 2, 3, 4])
+  print(str(has_loop(list1, 0)))
+  list1[3].next = 1
+  print(str(has_loop(list1, 0)))
+
+  let list2 = make_nodes([5, 6, 5, 6])
+  print(str(has_loop(list2, 0)))
+
+  let list3 = make_nodes([1])
+  print(str(has_loop(list3, 0)))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/has_loop.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/has_loop.out
@@ -1,0 +1,4 @@
+false
+true
+false
+false

--- a/tests/github/TheAlgorithms/Python/data_structures/linked_list/has_loop.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/linked_list/has_loop.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class ContainsLoopError(Exception):
+    pass
+
+
+class Node:
+    def __init__(self, data: Any) -> None:
+        self.data: Any = data
+        self.next_node: Node | None = None
+
+    def __iter__(self):
+        node = self
+        visited = set()
+        while node:
+            if node in visited:
+                raise ContainsLoopError
+            visited.add(node)
+            yield node.data
+            node = node.next_node
+
+    @property
+    def has_loop(self) -> bool:
+        """
+        A loop is when the exact same Node appears more than once in a linked list.
+        >>> root_node = Node(1)
+        >>> root_node.next_node = Node(2)
+        >>> root_node.next_node.next_node = Node(3)
+        >>> root_node.next_node.next_node.next_node = Node(4)
+        >>> root_node.has_loop
+        False
+        >>> root_node.next_node.next_node.next_node = root_node.next_node
+        >>> root_node.has_loop
+        True
+        """
+        try:
+            list(self)
+            return False
+        except ContainsLoopError:
+            return True
+
+
+if __name__ == "__main__":
+    root_node = Node(1)
+    root_node.next_node = Node(2)
+    root_node.next_node.next_node = Node(3)
+    root_node.next_node.next_node.next_node = Node(4)
+    print(root_node.has_loop)  # False
+    root_node.next_node.next_node.next_node = root_node.next_node
+    print(root_node.has_loop)  # True
+
+    root_node = Node(5)
+    root_node.next_node = Node(6)
+    root_node.next_node.next_node = Node(5)
+    root_node.next_node.next_node.next_node = Node(6)
+    print(root_node.has_loop)  # False
+
+    root_node = Node(1)
+    print(root_node.has_loop)  # False


### PR DESCRIPTION
## Summary
- add missing Python implementation for detecting loops in linked lists
- implement loop detection in Mochi using Floyd's cycle detection
- include runtime output for verification

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/data_structures/linked_list/has_loop.mochi`


------
https://chatgpt.com/codex/tasks/task_e_689184ad1b4c8320a99808ba771f10d3