### PR TITLE
Add reverse k-group linked list algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/reverse_k_group.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/reverse_k_group.mochi
@@ -1,0 +1,63 @@
+/*
+Reverses nodes of a singly linked list in groups of size k.
+The linked list is represented as a record holding a list of integers.
+For each consecutive block of k nodes, their order is reversed while
+leaving any remaining nodes (fewer than k) at the end untouched.
+This approach walks through the list once, building a new list by
+collecting values in temporary groups and appending them in reverse
+order when the group size reaches k. The overall complexity is O(n).
+*/
+
+type LinkedList {
+  data: list<int>
+}
+
+fun to_string(list: LinkedList): string {
+  if len(list.data) == 0 { return "" }
+  var s = str(list.data[0])
+  var i = 1
+  while i < len(list.data) {
+    s = s + " -> " + str(list.data[i])
+    i = i + 1
+  }
+  return s
+}
+
+fun reverse_k_nodes(list: LinkedList, k: int): LinkedList {
+  if k <= 1 { return list }
+  var res: list<int> = []
+  var i = 0
+  while i < len(list.data) {
+    var j = 0
+    var group: list<int> = []
+    while j < k && i + j < len(list.data) {
+      group = append(group, list.data[i + j])
+      j = j + 1
+    }
+    if len(group) == k {
+      var g = k - 1
+      while g >= 0 {
+        res = append(res, group[g])
+        g = g - 1
+      }
+    } else {
+      var g = 0
+      while g < len(group) {
+        res = append(res, group[g])
+        g = g + 1
+      }
+    }
+    i = i + k
+  }
+  return LinkedList { data: res }
+}
+
+fun main() {
+  var ll = LinkedList { data: [1, 2, 3, 4, 5] }
+  print("Original Linked List: " + to_string(ll))
+  var k = 2
+  ll = reverse_k_nodes(ll, k)
+  print("After reversing groups of size " + str(k) + ": " + to_string(ll))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/reverse_k_group.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/reverse_k_group.out
@@ -1,0 +1,2 @@
+Original Linked List: 1 -> 2 -> 3 -> 4 -> 5
+After reversing groups of size 2: 2 -> 1 -> 4 -> 3 -> 5

--- a/tests/github/TheAlgorithms/Python/data_structures/linked_list/reverse_k_group.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/linked_list/reverse_k_group.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+
+
+@dataclass
+class Node:
+    data: int
+    next_node: Node | None = None
+
+
+class LinkedList:
+    def __init__(self, ints: Iterable[int]) -> None:
+        self.head: Node | None = None
+        for i in ints:
+            self.append(i)
+
+    def __iter__(self) -> Iterator[int]:
+        """
+        >>> ints = []
+        >>> list(LinkedList(ints)) == ints
+        True
+        >>> ints = tuple(range(5))
+        >>> tuple(LinkedList(ints)) == ints
+        True
+        """
+        node = self.head
+        while node:
+            yield node.data
+            node = node.next_node
+
+    def __len__(self) -> int:
+        """
+        >>> for i in range(3):
+        ...     len(LinkedList(range(i))) == i
+        True
+        True
+        True
+        >>> len(LinkedList("abcdefgh"))
+        8
+        """
+        return sum(1 for _ in self)
+
+    def __str__(self) -> str:
+        """
+        >>> str(LinkedList([]))
+        ''
+        >>> str(LinkedList(range(5)))
+        '0 -> 1 -> 2 -> 3 -> 4'
+        """
+        return " -> ".join([str(node) for node in self])
+
+    def append(self, data: int) -> None:
+        """
+        >>> ll = LinkedList([1, 2])
+        >>> tuple(ll)
+        (1, 2)
+        >>> ll.append(3)
+        >>> tuple(ll)
+        (1, 2, 3)
+        >>> ll.append(4)
+        >>> tuple(ll)
+        (1, 2, 3, 4)
+        >>> len(ll)
+        4
+        """
+        if not self.head:
+            self.head = Node(data)
+            return
+        node = self.head
+        while node.next_node:
+            node = node.next_node
+        node.next_node = Node(data)
+
+    def reverse_k_nodes(self, group_size: int) -> None:
+        """
+        reverse nodes within groups of size k
+        >>> ll = LinkedList([1, 2, 3, 4, 5])
+        >>> ll.reverse_k_nodes(2)
+        >>> tuple(ll)
+        (2, 1, 4, 3, 5)
+        >>> str(ll)
+        '2 -> 1 -> 4 -> 3 -> 5'
+        """
+        if self.head is None or self.head.next_node is None:
+            return
+
+        length = len(self)
+        dummy_head = Node(0)
+        dummy_head.next_node = self.head
+        previous_node = dummy_head
+
+        while length >= group_size:
+            current_node = previous_node.next_node
+            assert current_node
+            next_node = current_node.next_node
+            for _ in range(1, group_size):
+                assert next_node, current_node
+                current_node.next_node = next_node.next_node
+                assert previous_node
+                next_node.next_node = previous_node.next_node
+                previous_node.next_node = next_node
+                next_node = current_node.next_node
+            previous_node = current_node
+            length -= group_size
+        self.head = dummy_head.next_node
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    ll = LinkedList([1, 2, 3, 4, 5])
+    print(f"Original Linked List: {ll}")
+    k = 2
+    ll.reverse_k_nodes(k)
+    print(f"After reversing groups of size {k}: {ll}")


### PR DESCRIPTION
## Summary
- add missing Python source for reverse_k_group linked list problem
- implement equivalent Mochi version with block comment and example run output

## Testing
- `python tests/github/TheAlgorithms/Python/data_structures/linked_list/reverse_k_group.py`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/data_structures/linked_list/reverse_k_group.mochi`


------
https://chatgpt.com/codex/tasks/task_e_689184b74cb48320b9317b6bb13eb836