### PR TITLE
Add rotate linked list algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/rotate_to_the_right.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/rotate_to_the_right.mochi
@@ -1,0 +1,65 @@
+/*
+Rotate a singly linked list to the right by a given number of positions.
+
+The list is represented as an array of node values.  Rotating to the right
+by `k` places moves the last `k` nodes to the front while preserving order.
+
+Algorithm:
+1. Compute the list length `n` and reduce `k` modulo `n` so that `0 <= k < n`.
+2. Split the list at index `n - k`.  The suffix starting at this index becomes
+   the new prefix, followed by the original prefix.
+3. Build a new list by concatenating the two segments.
+
+The helper functions allow appending new values and converting the list to a
+"a->b->c" string for display.
+*/
+
+fun list_to_string(xs: list<int>): string {
+  if len(xs) == 0 { return "" }
+  var s = str(xs[0])
+  var i = 1
+  while i < len(xs) {
+    s = s + "->" + str(xs[i])
+    i = i + 1
+  }
+  return s
+}
+
+fun insert_node(xs: list<int>, data: int): list<int> {
+  return append(xs, data)
+}
+
+fun rotate_to_the_right(xs: list<int>, places: int): list<int> {
+  if len(xs) == 0 { panic("The linked list is empty.") }
+  let n = len(xs)
+  var k = places % n
+  if k == 0 { return xs }
+  let split = n - k
+  var res: list<int> = []
+  var i = split
+  while i < n {
+    res = append(res, xs[i])
+    i = i + 1
+  }
+  var j = 0
+  while j < split {
+    res = append(res, xs[j])
+    j = j + 1
+  }
+  return res
+}
+
+fun main() {
+  var head: list<int> = []
+  head = insert_node(head, 5)
+  head = insert_node(head, 1)
+  head = insert_node(head, 2)
+  head = insert_node(head, 4)
+  head = insert_node(head, 3)
+  print("Original list: " + list_to_string(head))
+  let places = 3
+  let new_head = rotate_to_the_right(head, places)
+  print("After " + str(places) + " iterations: " + list_to_string(new_head))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/rotate_to_the_right.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/rotate_to_the_right.out
@@ -1,0 +1,2 @@
+Original list: 5->1->2->4->3
+After 3 iterations: 2->4->3->5->1

--- a/tests/github/TheAlgorithms/Python/data_structures/linked_list/rotate_to_the_right.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/linked_list/rotate_to_the_right.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Node:
+    data: int
+    next_node: Node | None = None
+
+
+def print_linked_list(head: Node | None) -> None:
+    """
+        Print the entire linked list iteratively.
+
+        This function prints the elements of a linked list separated by '->'.
+
+        Parameters:
+            head (Node | None): The head of the linked list to be printed,
+    or None if the linked list is empty.
+
+        >>> head = insert_node(None, 0)
+        >>> head = insert_node(head, 2)
+        >>> head = insert_node(head, 1)
+        >>> print_linked_list(head)
+        0->2->1
+        >>> head = insert_node(head, 4)
+        >>> head = insert_node(head, 5)
+        >>> print_linked_list(head)
+        0->2->1->4->5
+    """
+    if head is None:
+        return
+    while head.next_node is not None:
+        print(head.data, end="->")
+        head = head.next_node
+    print(head.data)
+
+
+def insert_node(head: Node | None, data: int) -> Node:
+    """
+    Insert a new node at the end of a linked list and return the new head.
+
+    Parameters:
+        head (Node | None): The head of the linked list.
+        data (int): The data to be inserted into the new node.
+
+    Returns:
+        Node: The new head of the linked list.
+
+    >>> head = insert_node(None, 10)
+    >>> head = insert_node(head, 9)
+    >>> head = insert_node(head, 8)
+    >>> print_linked_list(head)
+    10->9->8
+    """
+    new_node = Node(data)
+    # If the linked list is empty, the new_node becomes the head
+    if head is None:
+        return new_node
+
+    temp_node = head
+    while temp_node.next_node:
+        temp_node = temp_node.next_node
+
+    temp_node.next_node = new_node
+    return head
+
+
+def rotate_to_the_right(head: Node, places: int) -> Node:
+    """
+    Rotate a linked list to the right by places times.
+
+    Parameters:
+        head: The head of the linked list.
+        places: The number of places to rotate.
+
+    Returns:
+        Node: The head of the rotated linked list.
+
+    >>> rotate_to_the_right(None, places=1)
+    Traceback (most recent call last):
+        ...
+    ValueError: The linked list is empty.
+    >>> head = insert_node(None, 1)
+    >>> rotate_to_the_right(head, places=1) == head
+    True
+    >>> head = insert_node(None, 1)
+    >>> head = insert_node(head, 2)
+    >>> head = insert_node(head, 3)
+    >>> head = insert_node(head, 4)
+    >>> head = insert_node(head, 5)
+    >>> new_head = rotate_to_the_right(head, places=2)
+    >>> print_linked_list(new_head)
+    4->5->1->2->3
+    """
+    # Check if the list is empty or has only one element
+    if not head:
+        raise ValueError("The linked list is empty.")
+
+    if head.next_node is None:
+        return head
+
+    # Calculate the length of the linked list
+    length = 1
+    temp_node = head
+    while temp_node.next_node is not None:
+        length += 1
+        temp_node = temp_node.next_node
+
+    # Adjust the value of places to avoid places longer than the list.
+    places %= length
+
+    if places == 0:
+        return head  # As no rotation is needed.
+
+    # Find the new head position after rotation.
+    new_head_index = length - places
+
+    # Traverse to the new head position
+    temp_node = head
+    for _ in range(new_head_index - 1):
+        assert temp_node.next_node
+        temp_node = temp_node.next_node
+
+    # Update pointers to perform rotation
+    assert temp_node.next_node
+    new_head = temp_node.next_node
+    temp_node.next_node = None
+    temp_node = new_head
+    while temp_node.next_node:
+        temp_node = temp_node.next_node
+    temp_node.next_node = head
+
+    assert new_head
+    return new_head
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    head = insert_node(None, 5)
+    head = insert_node(head, 1)
+    head = insert_node(head, 2)
+    head = insert_node(head, 4)
+    head = insert_node(head, 3)
+
+    print("Original list: ", end="")
+    print_linked_list(head)
+
+    places = 3
+    new_head = rotate_to_the_right(head, places)
+
+    print(f"After {places} iterations: ", end="")
+    print_linked_list(new_head)


### PR DESCRIPTION
## Summary
- add missing Python implementation of rotating a linked list to the right
- port the algorithm to Mochi and provide demonstration output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/data_structures/linked_list/rotate_to_the_right.mochi`

------
https://chatgpt.com/codex/tasks/task_e_689184b90e4483209e27b4918d9b255c