### PR TITLE
Add Mochi circular queue linked list example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/queues/circular_queue_linked_list.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/queues/circular_queue_linked_list.mochi
@@ -1,0 +1,94 @@
+/*
+Implement a fixed-capacity circular queue using a linked list structure.  Each
+node stores a string value and links to its successor and predecessor, forming a
+ring.  The queue tracks indexes of the front and rear nodes inside parallel
+arrays for node data and links.  Enqueue advances the rear pointer and inserts
+at the tail, while dequeue retrieves the front value and advances the front
+pointer.  When the rear's next index equals the front the queue is full.  An
+empty queue occurs when front equals rear and its data is an empty string.
+All operations run in O(1) time.
+*/
+
+type CircularQueue {
+  data: list<string>
+  next: list<int>
+  prev: list<int>
+  front: int
+  rear: int
+}
+
+type DequeueResult {
+  queue: CircularQueue
+  value: string
+}
+
+fun create_queue(capacity: int): CircularQueue {
+  var data: list<string> = []
+  var next: list<int> = []
+  var prev: list<int> = []
+  var i = 0
+  while i < capacity {
+    data = append(data, "")
+    next = append(next, (i + 1) % capacity)
+    prev = append(prev, (i - 1 + capacity) % capacity)
+    i = i + 1
+  }
+  return CircularQueue { data: data, next: next, prev: prev, front: 0, rear: 0 }
+}
+
+fun is_empty(q: CircularQueue): bool {
+  return q.front == q.rear && q.data[q.front] == ""
+}
+
+fun check_can_perform(q: CircularQueue) {
+  if is_empty(q) { panic("Empty Queue") }
+}
+
+fun check_is_full(q: CircularQueue) {
+  if q.next[q.rear] == q.front { panic("Full Queue") }
+}
+
+fun peek(q: CircularQueue): string {
+  check_can_perform(q)
+  return q.data[q.front]
+}
+
+fun enqueue(q: CircularQueue, value: string): CircularQueue {
+  check_is_full(q)
+  if !is_empty(q) {
+    q.rear = q.next[q.rear]
+  }
+  var data = q.data
+  data[q.rear] = value
+  q.data = data
+  return q
+}
+
+fun dequeue(q: CircularQueue): DequeueResult {
+  check_can_perform(q)
+  var data = q.data
+  let val = data[q.front]
+  data[q.front] = ""
+  q.data = data
+  if q.front != q.rear {
+    q.front = q.next[q.front]
+  }
+  return DequeueResult { queue: q, value: val }
+}
+
+fun main() {
+  var q = create_queue(3)
+  print(str(is_empty(q)))
+  q = enqueue(q, "a")
+  q = enqueue(q, "b")
+  print(peek(q))
+  var res = dequeue(q)
+  q = res.queue
+  print(res.value)
+  res = dequeue(q)
+  q = res.queue
+  print(res.value)
+  print(str(is_empty(q)))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/data_structures/queues/circular_queue_linked_list.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/queues/circular_queue_linked_list.out
@@ -1,0 +1,5 @@
+true
+a
+a
+b
+true

--- a/tests/github/TheAlgorithms/Python/data_structures/queues/circular_queue_linked_list.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/queues/circular_queue_linked_list.py
@@ -1,0 +1,161 @@
+# Implementation of Circular Queue using linked lists
+# https://en.wikipedia.org/wiki/Circular_buffer
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class CircularQueueLinkedList:
+    """
+    Circular FIFO list with the given capacity (default queue length : 6)
+
+    >>> cq = CircularQueueLinkedList(2)
+    >>> cq.enqueue('a')
+    >>> cq.enqueue('b')
+    >>> cq.enqueue('c')
+    Traceback (most recent call last):
+       ...
+    Exception: Full Queue
+    """
+
+    def __init__(self, initial_capacity: int = 6) -> None:
+        self.front: Node | None = None
+        self.rear: Node | None = None
+        self.create_linked_list(initial_capacity)
+
+    def create_linked_list(self, initial_capacity: int) -> None:
+        current_node = Node()
+        self.front = current_node
+        self.rear = current_node
+        previous_node = current_node
+        for _ in range(1, initial_capacity):
+            current_node = Node()
+            previous_node.next = current_node
+            current_node.prev = previous_node
+            previous_node = current_node
+        previous_node.next = self.front
+        self.front.prev = previous_node
+
+    def is_empty(self) -> bool:
+        """
+        Checks whether the queue is empty or not
+        >>> cq = CircularQueueLinkedList()
+        >>> cq.is_empty()
+        True
+        >>> cq.enqueue('a')
+        >>> cq.is_empty()
+        False
+        >>> cq.dequeue()
+        'a'
+        >>> cq.is_empty()
+        True
+        """
+
+        return (
+            self.front == self.rear
+            and self.front is not None
+            and self.front.data is None
+        )
+
+    def first(self) -> Any | None:
+        """
+        Returns the first element of the queue
+        >>> cq = CircularQueueLinkedList()
+        >>> cq.first()
+        Traceback (most recent call last):
+           ...
+        Exception: Empty Queue
+        >>> cq.enqueue('a')
+        >>> cq.first()
+        'a'
+        >>> cq.dequeue()
+        'a'
+        >>> cq.first()
+        Traceback (most recent call last):
+           ...
+        Exception: Empty Queue
+        >>> cq.enqueue('b')
+        >>> cq.enqueue('c')
+        >>> cq.first()
+        'b'
+        """
+        self.check_can_perform_operation()
+        return self.front.data if self.front else None
+
+    def enqueue(self, data: Any) -> None:
+        """
+        Saves data at the end of the queue
+
+        >>> cq = CircularQueueLinkedList()
+        >>> cq.enqueue('a')
+        >>> cq.enqueue('b')
+        >>> cq.dequeue()
+        'a'
+        >>> cq.dequeue()
+        'b'
+        >>> cq.dequeue()
+        Traceback (most recent call last):
+           ...
+        Exception: Empty Queue
+        """
+        if self.rear is None:
+            return
+
+        self.check_is_full()
+        if not self.is_empty():
+            self.rear = self.rear.next
+        if self.rear:
+            self.rear.data = data
+
+    def dequeue(self) -> Any:
+        """
+        Removes and retrieves the first element of the queue
+
+        >>> cq = CircularQueueLinkedList()
+        >>> cq.dequeue()
+        Traceback (most recent call last):
+           ...
+        Exception: Empty Queue
+        >>> cq.enqueue('a')
+        >>> cq.dequeue()
+        'a'
+        >>> cq.dequeue()
+        Traceback (most recent call last):
+           ...
+        Exception: Empty Queue
+        """
+        self.check_can_perform_operation()
+        if self.rear is None or self.front is None:
+            return None
+        if self.front == self.rear:
+            data = self.front.data
+            self.front.data = None
+            return data
+
+        old_front = self.front
+        self.front = old_front.next
+        data = old_front.data
+        old_front.data = None
+        return data
+
+    def check_can_perform_operation(self) -> None:
+        if self.is_empty():
+            raise Exception("Empty Queue")
+
+    def check_is_full(self) -> None:
+        if self.rear and self.rear.next == self.front:
+            raise Exception("Full Queue")
+
+
+class Node:
+    def __init__(self) -> None:
+        self.data: Any | None = None
+        self.next: Node | None = None
+        self.prev: Node | None = None
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add missing Python source for circular queue based on linked list
- implement equivalent Mochi version with fixed-capacity ring buffer
- include runtime output demonstrating queue operations

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/data_structures/queues/circular_queue_linked_list.mochi`

------
https://chatgpt.com/codex/tasks/task_e_689184c7a9808320ab671ff8d8e15164