### PR TITLE
Add linked queue implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/queues/linked_queue.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/queues/linked_queue.mochi
@@ -1,0 +1,104 @@
+/*
+Implement a first-in first-out queue using a singly linked list.
+
+Nodes store string data and the index of the next node. The queue keeps a list of
+nodes along with indexes of the front and rear entries. Enqueue appends a node to
+the list and updates the previous rear's next index; dequeue returns the data at
+the front index and advances it to the next node. When the queue becomes empty,
+both indexes reset to 0 - 1. Additional helpers compute length, check emptiness,
+convert the queue to a readable string, and clear all elements. Enqueue and
+dequeue operate in O(1) time, while length and string conversion traverse O(n).
+*/
+
+type Node {
+  data: string
+  next: int
+}
+
+type LinkedQueue {
+  nodes: list<Node>
+  front: int
+  rear: int
+}
+
+fun new_queue(): LinkedQueue {
+  return LinkedQueue { nodes: [], front: 0 - 1, rear: 0 - 1 }
+}
+
+fun is_empty(q: LinkedQueue): bool {
+  return q.front == 0 - 1
+}
+
+fun put(q: LinkedQueue, item: string): void {
+  let node = Node { data: item, next: 0 - 1 }
+  q.nodes = append(q.nodes, node)
+  let idx = len(q.nodes) - 1
+  if q.front == 0 - 1 {
+    q.front = idx
+    q.rear = idx
+  } else {
+    var nodes = q.nodes
+    nodes[q.rear].next = idx
+    q.nodes = nodes
+    q.rear = idx
+  }
+}
+
+fun get(q: LinkedQueue): string {
+  if is_empty(q) {
+    panic("dequeue from empty queue")
+  }
+  let idx = q.front
+  let node = q.nodes[idx]
+  q.front = node.next
+  if q.front == 0 - 1 {
+    q.rear = 0 - 1
+  }
+  return node.data
+}
+
+fun length(q: LinkedQueue): int {
+  var count = 0
+  var idx = q.front
+  while idx != 0 - 1 {
+    count = count + 1
+    idx = q.nodes[idx].next
+  }
+  return count
+}
+
+fun to_string(q: LinkedQueue): string {
+  var res = ""
+  var idx = q.front
+  var first = true
+  while idx != 0 - 1 {
+    let node = q.nodes[idx]
+    if first {
+      res = node.data
+      first = false
+    } else {
+      res = res + " <- " + node.data
+    }
+    idx = node.next
+  }
+  return res
+}
+
+fun clear(q: LinkedQueue): void {
+  q.nodes = []
+  q.front = 0 - 1
+  q.rear = 0 - 1
+}
+
+let queue = new_queue()
+print(str(is_empty(queue)))
+put(queue, "5")
+put(queue, "9")
+put(queue, "python")
+print(str(is_empty(queue)))
+print(get(queue))
+put(queue, "algorithms")
+print(get(queue))
+print(get(queue))
+print(get(queue))
+print(str(is_empty(queue)))

--- a/tests/github/TheAlgorithms/Mochi/data_structures/queues/linked_queue.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/queues/linked_queue.out
@@ -1,0 +1,7 @@
+true
+false
+5
+9
+python
+algorithms
+true

--- a/tests/github/TheAlgorithms/Python/data_structures/queues/linked_queue.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/queues/linked_queue.py
@@ -1,0 +1,156 @@
+"""A Queue using a linked list like structure"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+
+class Node:
+    def __init__(self, data: Any) -> None:
+        self.data: Any = data
+        self.next: Node | None = None
+
+    def __str__(self) -> str:
+        return f"{self.data}"
+
+
+class LinkedQueue:
+    """
+    >>> queue = LinkedQueue()
+    >>> queue.is_empty()
+    True
+    >>> queue.put(5)
+    >>> queue.put(9)
+    >>> queue.put('python')
+    >>> queue.is_empty()
+    False
+    >>> queue.get()
+    5
+    >>> queue.put('algorithms')
+    >>> queue.get()
+    9
+    >>> queue.get()
+    'python'
+    >>> queue.get()
+    'algorithms'
+    >>> queue.is_empty()
+    True
+    >>> queue.get()
+    Traceback (most recent call last):
+        ...
+    IndexError: dequeue from empty queue
+    """
+
+    def __init__(self) -> None:
+        self.front: Node | None = None
+        self.rear: Node | None = None
+
+    def __iter__(self) -> Iterator[Any]:
+        node = self.front
+        while node:
+            yield node.data
+            node = node.next
+
+    def __len__(self) -> int:
+        """
+        >>> queue = LinkedQueue()
+        >>> for i in range(1, 6):
+        ...     queue.put(i)
+        >>> len(queue)
+        5
+        >>> for i in range(1, 6):
+        ...     assert len(queue) == 6 - i
+        ...     _ = queue.get()
+        >>> len(queue)
+        0
+        """
+        return len(tuple(iter(self)))
+
+    def __str__(self) -> str:
+        """
+        >>> queue = LinkedQueue()
+        >>> for i in range(1, 4):
+        ...     queue.put(i)
+        >>> queue.put("Python")
+        >>> queue.put(3.14)
+        >>> queue.put(True)
+        >>> str(queue)
+        '1 <- 2 <- 3 <- Python <- 3.14 <- True'
+        """
+        return " <- ".join(str(item) for item in self)
+
+    def is_empty(self) -> bool:
+        """
+        >>> queue = LinkedQueue()
+        >>> queue.is_empty()
+        True
+        >>> for i in range(1, 6):
+        ...     queue.put(i)
+        >>> queue.is_empty()
+        False
+        """
+        return len(self) == 0
+
+    def put(self, item: Any) -> None:
+        """
+        >>> queue = LinkedQueue()
+        >>> queue.get()
+        Traceback (most recent call last):
+            ...
+        IndexError: dequeue from empty queue
+        >>> for i in range(1, 6):
+        ...     queue.put(i)
+        >>> str(queue)
+        '1 <- 2 <- 3 <- 4 <- 5'
+        """
+        node = Node(item)
+        if self.is_empty():
+            self.front = self.rear = node
+        else:
+            assert isinstance(self.rear, Node)
+            self.rear.next = node
+            self.rear = node
+
+    def get(self) -> Any:
+        """
+        >>> queue = LinkedQueue()
+        >>> queue.get()
+        Traceback (most recent call last):
+            ...
+        IndexError: dequeue from empty queue
+        >>> queue = LinkedQueue()
+        >>> for i in range(1, 6):
+        ...     queue.put(i)
+        >>> for i in range(1, 6):
+        ...     assert queue.get() == i
+        >>> len(queue)
+        0
+        """
+        if self.is_empty():
+            raise IndexError("dequeue from empty queue")
+        assert isinstance(self.front, Node)
+        node = self.front
+        self.front = self.front.next
+        if self.front is None:
+            self.rear = None
+        return node.data
+
+    def clear(self) -> None:
+        """
+        >>> queue = LinkedQueue()
+        >>> for i in range(1, 6):
+        ...     queue.put(i)
+        >>> queue.clear()
+        >>> len(queue)
+        0
+        >>> str(queue)
+        ''
+        """
+        self.front = self.rear = None
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()


### PR DESCRIPTION
## Summary
- add missing Python linked list queue source
- implement linked queue in Mochi using array-backed nodes
- include runtime output

## Testing
- `npm test` *(fails: Missing script "test")*
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/data_structures/queues/linked_queue.mochi`


------
https://chatgpt.com/codex/tasks/task_e_689184cb66148320ad28ca5832a11db7