### PR TITLE
Add balanced parentheses algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/stacks/balanced_parentheses.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/stacks/balanced_parentheses.mochi
@@ -1,0 +1,52 @@
+/*
+Check if all types of brackets in a string are properly balanced.
+
+The algorithm scans the input string and uses a stack to track opening
+brackets. Each time an opening bracket "(", "[", or "{" is seen it is
+pushed onto the stack. When a closing bracket is encountered the top of the
+stack must contain the matching opening bracket; otherwise the string is
+unbalanced. At the end the stack must be empty for the string to be balanced.
+
+Time complexity is O(n) where n is the length of the string, and space
+complexity is O(n) in the worst case when all characters are opening brackets.
+*/
+
+fun pop_last(xs: list<string>): list<string> {
+  var res: list<string> = []
+  var i = 0
+  while i < len(xs) - 1 {
+    res = append(res, xs[i])
+    i = i + 1
+  }
+  return res
+}
+
+fun balanced_parentheses(s: string): bool {
+  var stack: list<string> = []
+  let pairs: map<string, string> = {"(": ")", "[": "]", "{": "}"}
+  var i = 0
+  while i < len(s) {
+    let ch = s[i]
+    if ch in pairs {
+      stack = append(stack, ch)
+    } else if ch == ")" || ch == "]" || ch == "}" {
+      if len(stack) == 0 {
+        return false
+      }
+      let top = stack[len(stack) - 1]
+      if pairs[top] != ch {
+        return false
+      }
+      stack = pop_last(stack)
+    }
+    i = i + 1
+  }
+  return len(stack) == 0
+}
+
+var tests: list<string> = ["([]{})", "[()]{}{[()()]()}", "[(])", "1+2*3-4", ""]
+var idx = 0
+while idx < len(tests) {
+  print(balanced_parentheses(tests[idx]))
+  idx = idx + 1
+}

--- a/tests/github/TheAlgorithms/Mochi/data_structures/stacks/balanced_parentheses.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/stacks/balanced_parentheses.out
@@ -1,0 +1,5 @@
+true
+true
+false
+true
+true

--- a/tests/github/TheAlgorithms/Python/data_structures/stacks/balanced_parentheses.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/stacks/balanced_parentheses.py
@@ -1,0 +1,38 @@
+from .stack import Stack
+
+
+def balanced_parentheses(parentheses: str) -> bool:
+    """Use a stack to check if a string of parentheses is balanced.
+    >>> balanced_parentheses("([]{})")
+    True
+    >>> balanced_parentheses("[()]{}{[()()]()}")
+    True
+    >>> balanced_parentheses("[(])")
+    False
+    >>> balanced_parentheses("1+2*3-4")
+    True
+    >>> balanced_parentheses("")
+    True
+    """
+    stack: Stack[str] = Stack()
+    bracket_pairs = {"(": ")", "[": "]", "{": "}"}
+    for bracket in parentheses:
+        if bracket in bracket_pairs:
+            stack.push(bracket)
+        elif bracket in (")", "]", "}") and (
+            stack.is_empty() or bracket_pairs[stack.pop()] != bracket
+        ):
+            return False
+    return stack.is_empty()
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()
+
+    examples = ["((()))", "((())", "(()))"]
+    print("Balanced parentheses demonstration:\n")
+    for example in examples:
+        not_str = "" if balanced_parentheses(example) else "not "
+        print(f"{example} is {not_str}balanced")

--- a/tests/github/TheAlgorithms/Python/data_structures/stacks/stack.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/stacks/stack.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+class StackOverflowError(BaseException):
+    pass
+
+
+class StackUnderflowError(BaseException):
+    pass
+
+
+class Stack[T]:
+    """A stack is an abstract data type that serves as a collection of
+    elements with two principal operations: push() and pop(). push() adds an
+    element to the top of the stack, and pop() removes an element from the top
+    of a stack. The order in which elements come off of a stack are
+    Last In, First Out (LIFO).
+    https://en.wikipedia.org/wiki/Stack_(abstract_data_type)
+    """
+
+    def __init__(self, limit: int = 10):
+        self.stack: list[T] = []
+        self.limit = limit
+
+    def __bool__(self) -> bool:
+        return bool(self.stack)
+
+    def __str__(self) -> str:
+        return str(self.stack)
+
+    def push(self, data: T) -> None:
+        """
+        Push an element to the top of the stack.
+
+        >>> S = Stack(2) # stack size = 2
+        >>> S.push(10)
+        >>> S.push(20)
+        >>> print(S)
+        [10, 20]
+
+        >>> S = Stack(1) # stack size = 1
+        >>> S.push(10)
+        >>> S.push(20)
+        Traceback (most recent call last):
+        ...
+        data_structures.stacks.stack.StackOverflowError
+
+        """
+        if len(self.stack) >= self.limit:
+            raise StackOverflowError
+        self.stack.append(data)
+
+    def pop(self) -> T:
+        """
+        Pop an element off of the top of the stack.
+
+        >>> S = Stack()
+        >>> S.push(-5)
+        >>> S.push(10)
+        >>> S.pop()
+        10
+
+        >>> Stack().pop()
+        Traceback (most recent call last):
+            ...
+        data_structures.stacks.stack.StackUnderflowError
+        """
+        if not self.stack:
+            raise StackUnderflowError
+        return self.stack.pop()
+
+    def peek(self) -> T:
+        """
+        Peek at the top-most element of the stack.
+
+        >>> S = Stack()
+        >>> S.push(-5)
+        >>> S.push(10)
+        >>> S.peek()
+        10
+
+        >>> Stack().peek()
+        Traceback (most recent call last):
+            ...
+        data_structures.stacks.stack.StackUnderflowError
+        """
+        if not self.stack:
+            raise StackUnderflowError
+        return self.stack[-1]
+
+    def is_empty(self) -> bool:
+        """
+        Check if a stack is empty.
+
+        >>> S = Stack()
+        >>> S.is_empty()
+        True
+
+        >>> S = Stack()
+        >>> S.push(10)
+        >>> S.is_empty()
+        False
+        """
+        return not bool(self.stack)
+
+    def is_full(self) -> bool:
+        """
+        >>> S = Stack()
+        >>> S.is_full()
+        False
+
+        >>> S = Stack(1)
+        >>> S.push(10)
+        >>> S.is_full()
+        True
+        """
+        return self.size() == self.limit
+
+    def size(self) -> int:
+        """
+        Return the size of the stack.
+
+        >>> S = Stack(3)
+        >>> S.size()
+        0
+
+        >>> S = Stack(3)
+        >>> S.push(10)
+        >>> S.size()
+        1
+
+        >>> S = Stack(3)
+        >>> S.push(10)
+        >>> S.push(20)
+        >>> S.size()
+        2
+        """
+        return len(self.stack)
+
+    def __contains__(self, item: T) -> bool:
+        """
+        Check if item is in stack
+
+        >>> S = Stack(3)
+        >>> S.push(10)
+        >>> 10 in S
+        True
+
+        >>> S = Stack(3)
+        >>> S.push(10)
+        >>> 20 in S
+        False
+        """
+        return item in self.stack
+
+
+def test_stack() -> None:
+    """
+    >>> test_stack()
+    """
+    stack: Stack[int] = Stack(10)
+    assert bool(stack) is False
+    assert stack.is_empty() is True
+    assert stack.is_full() is False
+    assert str(stack) == "[]"
+
+    try:
+        _ = stack.pop()
+        raise AssertionError  # This should not happen
+    except StackUnderflowError:
+        assert True  # This should happen
+
+    try:
+        _ = stack.peek()
+        raise AssertionError  # This should not happen
+    except StackUnderflowError:
+        assert True  # This should happen
+
+    for i in range(10):
+        assert stack.size() == i
+        stack.push(i)
+
+    assert bool(stack)
+    assert not stack.is_empty()
+    assert stack.is_full()
+    assert str(stack) == str(list(range(10)))
+    assert stack.pop() == 9
+    assert stack.peek() == 8
+
+    stack.push(100)
+    assert str(stack) == str([0, 1, 2, 3, 4, 5, 6, 7, 8, 100])
+
+    try:
+        stack.push(200)
+        raise AssertionError  # This should not happen
+    except StackOverflowError:
+        assert True  # This should happen
+
+    assert not stack.is_empty()
+    assert stack.size() == 10
+
+    assert 5 in stack
+    assert 55 not in stack
+
+
+if __name__ == "__main__":
+    test_stack()
+
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python implementation of balanced parentheses and supporting stack
- add pure Mochi translation using list-based stack
- include sample output demonstrating balanced-parentheses results

## Testing
- `npm test` *(fails: Missing script: "test")*
- `go test ./...`
- `./bin/mochi run tests/github/TheAlgorithms/Mochi/data_structures/stacks/balanced_parentheses.mochi`


------
https://chatgpt.com/codex/tasks/task_e_689184d612a48320a85921dbaf3f6908