### PR TITLE
Add infix to postfix conversion algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/stacks/infix_to_postfix_conversion.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/stacks/infix_to_postfix_conversion.mochi
@@ -1,0 +1,137 @@
+/*
+Convert an infix expression to postfix (Reverse Polish) notation using
+Dijkstra's shunting-yard algorithm.
+
+The algorithm processes each token of the input expression once, using a
+stack to temporarily hold operators. When an operator with lower
+precedence or different associativity is encountered, operators are
+popped from the stack to the output list until the stack condition
+allows the incoming operator to be pushed. Parentheses cause operators
+inside them to be evaluated before those outside.
+
+Time complexity: O(n) where n is the length of the expression.
+Space complexity: O(n) for the operator stack and output list.
+*/
+let PRECEDENCES: map<string, int> = {
+  "+": 1,
+  "-": 1,
+  "*": 2,
+  "/": 2,
+  "^": 3
+}
+let ASSOCIATIVITIES: map<string, string> = {
+  "+": "LR",
+  "-": "LR",
+  "*": "LR",
+  "/": "LR",
+  "^": "RL"
+}
+
+fun precedence(ch: string): int {
+  if ch in PRECEDENCES { return PRECEDENCES[ch] }
+  return -1
+}
+
+fun associativity(ch: string): string {
+  if ch in ASSOCIATIVITIES { return ASSOCIATIVITIES[ch] }
+  return ""
+}
+
+fun balanced_parentheses(expr: string): bool {
+  var count = 0
+  var i = 0
+  while i < len(expr) {
+    let ch = substring(expr, i, i + 1)
+    if ch == "(" { count = count + 1 }
+    if ch == ")" {
+      count = count - 1
+      if count < 0 { return false }
+    }
+    i = i + 1
+  }
+  return count == 0
+}
+
+fun is_letter(ch: string): bool {
+  return ("a" <= ch && ch <= "z") || ("A" <= ch && ch <= "Z")
+}
+
+fun is_digit(ch: string): bool {
+  return "0" <= ch && ch <= "9"
+}
+
+fun is_alnum(ch: string): bool {
+  return is_letter(ch) || is_digit(ch)
+}
+
+fun infix_to_postfix(expression: string): string {
+  if balanced_parentheses(expression) == false {
+    panic("Mismatched parentheses")
+  }
+  var stack: list<string> = []
+  var postfix: list<string> = []
+  var i = 0
+  while i < len(expression) {
+    let ch = substring(expression, i, i + 1)
+    if is_alnum(ch) {
+      postfix = append(postfix, ch)
+    } else if ch == "(" {
+      stack = append(stack, ch)
+    } else if ch == ")" {
+      while len(stack) > 0 && stack[len(stack) - 1] != "(" {
+        postfix = append(postfix, stack[len(stack) - 1])
+        stack = slice(stack, 0, len(stack) - 1)
+      }
+      if len(stack) > 0 {
+        stack = slice(stack, 0, len(stack) - 1)
+      }
+    } else if ch == " " {
+      // ignore spaces
+    } else {
+      while true {
+        if len(stack) == 0 {
+          stack = append(stack, ch)
+          break
+        }
+        let cp = precedence(ch)
+        let tp = precedence(stack[len(stack) - 1])
+        if cp > tp {
+          stack = append(stack, ch)
+          break
+        }
+        if cp < tp {
+          postfix = append(postfix, stack[len(stack) - 1])
+          stack = slice(stack, 0, len(stack) - 1)
+          continue
+        }
+        if associativity(ch) == "RL" {
+          stack = append(stack, ch)
+          break
+        }
+        postfix = append(postfix, stack[len(stack) - 1])
+        stack = slice(stack, 0, len(stack) - 1)
+      }
+    }
+    i = i + 1
+  }
+  while len(stack) > 0 {
+    postfix = append(postfix, stack[len(stack) - 1])
+    stack = slice(stack, 0, len(stack) - 1)
+  }
+  var res = ""
+  var j = 0
+  while j < len(postfix) {
+    if j > 0 { res = res + " " }
+    res = res + postfix[j]
+    j = j + 1
+  }
+  return res
+}
+
+fun main() {
+  let expression = "a+b*(c^d-e)^(f+g*h)-i"
+  print(expression)
+  print(infix_to_postfix(expression))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/data_structures/stacks/infix_to_postfix_conversion.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/stacks/infix_to_postfix_conversion.out
@@ -1,0 +1,2 @@
+a+b*(c^d-e)^(f+g*h)-i
+a b c d ^ e - f g h * + ^ * + i -

--- a/tests/github/TheAlgorithms/Python/data_structures/stacks/infix_to_postfix_conversion.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/stacks/infix_to_postfix_conversion.py
@@ -1,0 +1,113 @@
+"""
+https://en.wikipedia.org/wiki/Infix_notation
+https://en.wikipedia.org/wiki/Reverse_Polish_notation
+https://en.wikipedia.org/wiki/Shunting-yard_algorithm
+"""
+
+from typing import Literal
+
+from .balanced_parentheses import balanced_parentheses
+from .stack import Stack
+
+PRECEDENCES: dict[str, int] = {
+    "+": 1,
+    "-": 1,
+    "*": 2,
+    "/": 2,
+    "^": 3,
+}
+ASSOCIATIVITIES: dict[str, Literal["LR", "RL"]] = {
+    "+": "LR",
+    "-": "LR",
+    "*": "LR",
+    "/": "LR",
+    "^": "RL",
+}
+
+
+def precedence(char: str) -> int:
+    """
+    Return integer value representing an operator's precedence, or
+    order of operation.
+    https://en.wikipedia.org/wiki/Order_of_operations
+    """
+    return PRECEDENCES.get(char, -1)
+
+
+def associativity(char: str) -> Literal["LR", "RL"]:
+    """
+    Return the associativity of the operator `char`.
+    https://en.wikipedia.org/wiki/Operator_associativity
+    """
+    return ASSOCIATIVITIES[char]
+
+
+def infix_to_postfix(expression_str: str) -> str:
+    """
+    >>> infix_to_postfix("(1*(2+3)+4))")
+    Traceback (most recent call last):
+        ...
+    ValueError: Mismatched parentheses
+    >>> infix_to_postfix("")
+    ''
+    >>> infix_to_postfix("3+2")
+    '3 2 +'
+    >>> infix_to_postfix("(3+4)*5-6")
+    '3 4 + 5 * 6 -'
+    >>> infix_to_postfix("(1+2)*3/4-5")
+    '1 2 + 3 * 4 / 5 -'
+    >>> infix_to_postfix("a+b*c+(d*e+f)*g")
+    'a b c * + d e * f + g * +'
+    >>> infix_to_postfix("x^y/(5*z)+2")
+    'x y ^ 5 z * / 2 +'
+    >>> infix_to_postfix("2^3^2")
+    '2 3 2 ^ ^'
+    """
+    if not balanced_parentheses(expression_str):
+        raise ValueError("Mismatched parentheses")
+    stack: Stack[str] = Stack()
+    postfix = []
+    for char in expression_str:
+        if char.isalpha() or char.isdigit():
+            postfix.append(char)
+        elif char == "(":
+            stack.push(char)
+        elif char == ")":
+            while not stack.is_empty() and stack.peek() != "(":
+                postfix.append(stack.pop())
+            stack.pop()
+        else:
+            while True:
+                if stack.is_empty():
+                    stack.push(char)
+                    break
+
+                char_precedence = precedence(char)
+                tos_precedence = precedence(stack.peek())
+
+                if char_precedence > tos_precedence:
+                    stack.push(char)
+                    break
+                if char_precedence < tos_precedence:
+                    postfix.append(stack.pop())
+                    continue
+                # Precedences are equal
+                if associativity(char) == "RL":
+                    stack.push(char)
+                    break
+                postfix.append(stack.pop())
+
+    while not stack.is_empty():
+        postfix.append(stack.pop())
+    return " ".join(postfix)
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()
+    expression = "a+b*(c^d-e)^(f+g*h)-i"
+
+    print("Infix to Postfix Notation demonstration:\n")
+    print("Infix notation: " + expression)
+    print("Postfix notation: " + infix_to_postfix(expression))


### PR DESCRIPTION
## Summary
- add TheAlgorithms Python implementation for infix to postfix conversion
- port algorithm to Mochi with operator precedence and associativity tables
- show demo converting an infix expression to postfix form

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/data_structures/stacks/infix_to_postfix_conversion.mochi`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689184d94b68832091fea97516a02619