### PR TITLE
feat: add infix to prefix conversion

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/stacks/infix_to_prefix_conversion.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/stacks/infix_to_prefix_conversion.mochi
@@ -1,0 +1,125 @@
+/*
+Convert an infix expression to prefix notation using a stack.
+
+The algorithm first converts the given infix expression to postfix form.  
+Operands are output immediately, while operators are pushed onto a stack. 
+When an operator of lower or equal precedence is encountered, operators are popped
+from the stack until this condition is false. Parentheses cause operators to be
+pushed or popped until the matching pair is reached.  After processing the
+entire expression, remaining operators on the stack are appended to the output.
+This produces the postfix representation.
+
+To obtain prefix notation, the infix string is reversed with parenthesis
+orientation swapped, converted to postfix using the above procedure, and the
+result is reversed again.  The algorithms run in O(n) time for expressions of
+length n and use O(n) additional space for the stacks and intermediate strings.
+*/
+
+let PRIORITY: map<string, int> = {
+  "^": 3,
+  "*": 2,
+  "/": 2,
+  "%": 2,
+  "+": 1,
+  "-": 1,
+}
+
+let LETTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+let DIGITS = "0123456789"
+
+fun is_alpha(ch: string): bool {
+  var i = 0
+  while i < len(LETTERS) {
+    if LETTERS[i] == ch { return true }
+    i = i + 1
+  }
+  return false
+}
+
+fun is_digit(ch: string): bool {
+  var i = 0
+  while i < len(DIGITS) {
+    if DIGITS[i] == ch { return true }
+    i = i + 1
+  }
+  return false
+}
+
+fun reverse_string(s: string): string {
+  var out = ""
+  var i = len(s) - 1
+  while i >= 0 {
+    out = out + s[i]
+    i = i - 1
+  }
+  return out
+}
+
+fun infix_to_postfix(infix: string): string {
+  var stack: list<string> = []
+  var post: list<string> = []
+  var i = 0
+  while i < len(infix) {
+    let x = infix[i]
+    if is_alpha(x) || is_digit(x) {
+      post = append(post, x)
+    } else if x == "(" {
+      stack = append(stack, x)
+    } else if x == ")" {
+      if len(stack) == 0 { panic("list index out of range") }
+      while stack[len(stack) - 1] != "(" {
+        post = append(post, stack[len(stack) - 1])
+        stack = stack[0:len(stack) - 1]
+      }
+      stack = stack[0:len(stack) - 1]
+    } else if len(stack) == 0 {
+      stack = append(stack, x)
+    } else {
+      while len(stack) > 0 && stack[len(stack) - 1] != "(" && PRIORITY[x] <= PRIORITY[stack[len(stack) - 1]] {
+        post = append(post, stack[len(stack) - 1])
+        stack = stack[0:len(stack) - 1]
+      }
+      stack = append(stack, x)
+    }
+    i = i + 1
+  }
+  while len(stack) > 0 {
+    if stack[len(stack) - 1] == "(" { panic("invalid expression") }
+    post = append(post, stack[len(stack) - 1])
+    stack = stack[0:len(stack) - 1]
+  }
+  var res = ""
+  var j = 0
+  while j < len(post) {
+    res = res + post[j]
+    j = j + 1
+  }
+  return res
+}
+
+fun infix_to_prefix(infix: string): string {
+  var reversed = ""
+  var i = len(infix) - 1
+  while i >= 0 {
+    let ch = infix[i]
+    if ch == "(" {
+      reversed = reversed + ")"
+    } else if ch == ")" {
+      reversed = reversed + "("
+    } else {
+      reversed = reversed + ch
+    }
+    i = i - 1
+  }
+  let postfix = infix_to_postfix(reversed)
+  let prefix = reverse_string(postfix)
+  return prefix
+}
+
+test "simple expression" {
+  expect infix_to_prefix("a+b^c") == "+a^bc"
+}
+
+test "complex expression" {
+  expect infix_to_prefix("1*((-a)*2+b)") == "*1+*-a2b"
+}

--- a/tests/github/TheAlgorithms/Mochi/data_structures/stacks/infix_to_prefix_conversion.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/stacks/infix_to_prefix_conversion.out
@@ -1,0 +1,3 @@
+[94;1mtests/github/TheAlgorithms/Mochi/data_structures/stacks/infix_to_prefix_conversion.mochi[0;22m
+   [33mtest[0m simple expression              ... [32mok[0m (7.0ms)
+   [33mtest[0m complex expression             ... [32mok[0m (7.0ms)

--- a/tests/github/TheAlgorithms/Python/data_structures/stacks/infix_to_prefix_conversion.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/stacks/infix_to_prefix_conversion.py
@@ -1,0 +1,192 @@
+"""
+Output:
+
+Enter an Infix Equation = a + b ^c
+ Symbol  |  Stack  | Postfix
+----------------------------
+   c     |         | c
+   ^     | ^       | c
+   b     | ^       | cb
+   +     | +       | cb^
+   a     | +       | cb^a
+         |         | cb^a+
+
+         a+b^c (Infix) ->  +a^bc (Prefix)
+"""
+
+
+def infix_2_postfix(infix: str) -> str:
+    """
+    >>> infix_2_postfix("a+b^c")  # doctest: +NORMALIZE_WHITESPACE
+     Symbol  |  Stack  | Postfix
+    ----------------------------
+       a     |         | a
+       +     | +       | a
+       b     | +       | ab
+       ^     | +^      | ab
+       c     | +^      | abc
+             | +       | abc^
+             |         | abc^+
+    'abc^+'
+
+    >>> infix_2_postfix("1*((-a)*2+b)")   # doctest: +NORMALIZE_WHITESPACE
+      Symbol  |    Stack     |   Postfix
+    -------------------------------------------
+       1     |              | 1
+       *     | *            | 1
+       (     | *(           | 1
+       (     | *((          | 1
+       -     | *((-         | 1
+       a     | *((-         | 1a
+       )     | *(           | 1a-
+       *     | *(*          | 1a-
+       2     | *(*          | 1a-2
+       +     | *(+          | 1a-2*
+       b     | *(+          | 1a-2*b
+       )     | *            | 1a-2*b+
+             |              | 1a-2*b+*
+    '1a-2*b+*'
+
+    >>> infix_2_postfix("")
+     Symbol  |  Stack  | Postfix
+    ----------------------------
+    ''
+
+    >>> infix_2_postfix("(()")
+    Traceback (most recent call last):
+        ...
+    ValueError: invalid expression
+
+    >>> infix_2_postfix("())")
+    Traceback (most recent call last):
+        ...
+    IndexError: list index out of range
+    """
+    stack = []
+    post_fix = []
+    priority = {
+        "^": 3,
+        "*": 2,
+        "/": 2,
+        "%": 2,
+        "+": 1,
+        "-": 1,
+    }  # Priority of each operator
+    print_width = max(len(infix), 7)
+
+    # Print table header for output
+    print(
+        "Symbol".center(8),
+        "Stack".center(print_width),
+        "Postfix".center(print_width),
+        sep=" | ",
+    )
+    print("-" * (print_width * 3 + 7))
+
+    for x in infix:
+        if x.isalpha() or x.isdigit():
+            post_fix.append(x)  # if x is Alphabet / Digit, add it to Postfix
+        elif x == "(":
+            stack.append(x)  # if x is "(" push to Stack
+        elif x == ")":  # if x is ")" pop stack until "(" is encountered
+            if len(stack) == 0:  # close bracket without open bracket
+                raise IndexError("list index out of range")
+
+            while stack[-1] != "(":
+                post_fix.append(stack.pop())  # Pop stack & add the content to Postfix
+            stack.pop()
+        elif len(stack) == 0:
+            stack.append(x)  # If stack is empty, push x to stack
+        else:  # while priority of x is not > priority of element in the stack
+            while stack and stack[-1] != "(" and priority[x] <= priority[stack[-1]]:
+                post_fix.append(stack.pop())  # pop stack & add to Postfix
+            stack.append(x)  # push x to stack
+
+        print(
+            x.center(8),
+            ("".join(stack)).ljust(print_width),
+            ("".join(post_fix)).ljust(print_width),
+            sep=" | ",
+        )  # Output in tabular format
+
+    while len(stack) > 0:  # while stack is not empty
+        if stack[-1] == "(":  # open bracket with no close bracket
+            raise ValueError("invalid expression")
+
+        post_fix.append(stack.pop())  # pop stack & add to Postfix
+        print(
+            " ".center(8),
+            ("".join(stack)).ljust(print_width),
+            ("".join(post_fix)).ljust(print_width),
+            sep=" | ",
+        )  # Output in tabular format
+
+    return "".join(post_fix)  # return Postfix as str
+
+
+def infix_2_prefix(infix: str) -> str:
+    """
+    >>> infix_2_prefix("a+b^c")  # doctest: +NORMALIZE_WHITESPACE
+     Symbol  |  Stack  | Postfix
+    ----------------------------
+       c     |         | c
+       ^     | ^       | c
+       b     | ^       | cb
+       +     | +       | cb^
+       a     | +       | cb^a
+             |         | cb^a+
+    '+a^bc'
+
+    >>> infix_2_prefix("1*((-a)*2+b)") # doctest: +NORMALIZE_WHITESPACE
+     Symbol  |    Stack     |   Postfix
+    -------------------------------------------
+       (     | (            |
+       b     | (            | b
+       +     | (+           | b
+       2     | (+           | b2
+       *     | (+*          | b2
+       (     | (+*(         | b2
+       a     | (+*(         | b2a
+       -     | (+*(-        | b2a
+       )     | (+*          | b2a-
+       )     |              | b2a-*+
+       *     | *            | b2a-*+
+       1     | *            | b2a-*+1
+             |              | b2a-*+1*
+    '*1+*-a2b'
+
+    >>> infix_2_prefix('')
+     Symbol  |  Stack  | Postfix
+    ----------------------------
+    ''
+
+    >>> infix_2_prefix('(()')
+    Traceback (most recent call last):
+        ...
+    IndexError: list index out of range
+
+    >>> infix_2_prefix('())')
+    Traceback (most recent call last):
+        ...
+    ValueError: invalid expression
+    """
+    reversed_infix = list(infix[::-1])  # reverse the infix equation
+
+    for i in range(len(reversed_infix)):
+        if reversed_infix[i] == "(":
+            reversed_infix[i] = ")"  # change "(" to ")"
+        elif reversed_infix[i] == ")":
+            reversed_infix[i] = "("  # change ")" to "("
+
+    # call infix_2_postfix on Infix, return reverse of Postfix
+    return (infix_2_postfix("".join(reversed_infix)))[::-1]
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()
+
+    Infix = input("\nEnter an Infix Equation = ")  # Input an Infix equation
+    Infix = "".join(Infix.split())  # Remove spaces from the input
+    print("\n\t", Infix, "(Infix) -> ", infix_2_prefix(Infix), "(Prefix)")


### PR DESCRIPTION
## Summary
- add missing Python reference for infix to prefix conversion
- implement infix to prefix conversion in Mochi
- add tests for infix to prefix conversion

## Testing
- `go run ./cmd/mochi test tests/github/TheAlgorithms/Mochi/data_structures/stacks/infix_to_prefix_conversion.mochi`


------
https://chatgpt.com/codex/tasks/task_e_689184da73c48320bc4e5844e8d6de0a