### PR TITLE
Add list-based priority queues

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/queues/priority_queue_using_list.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/queues/priority_queue_using_list.mochi
@@ -1,0 +1,210 @@
+/*
+Implement two priority queue variants using only built-in Mochi data structures.
+
+1. FixedPriorityQueue maintains three internal FIFO queues for priorities 0
+   (highest) through 2 (lowest).  Enqueue validates priority and capacity and
+   appends the value to the appropriate internal queue.  Dequeue searches the
+   queues in priority order, removes the first element of the first nonempty
+   queue, and returns it.  Attempting to dequeue when all queues are empty
+   raises an error.
+2. ElementPriorityQueue treats the value of each element as its priority.  The
+   queue is stored as a single list.  Enqueue appends the new value while
+   enforcing a capacity limit.  Dequeue scans for the minimum value, removes it
+   from the list, and returns it.  Underflow occurs if the queue is empty.
+
+The demonstration mirrors the Python implementation from TheAlgorithms project:
+values are enqueued, the queue contents are printed, several dequeues are
+performed, and an additional dequeue shows the underflow error.
+*/
+
+fun panic(msg: string) {
+  print(msg)
+}
+
+type FixedPriorityQueue {
+  queues: list<list<int>>
+}
+
+fun fpq_new(): FixedPriorityQueue {
+  return FixedPriorityQueue { queues: [[], [], []] }
+}
+
+fun fpq_enqueue(fpq: FixedPriorityQueue, priority: int, data: int): FixedPriorityQueue {
+  if priority < 0 || priority >= len(fpq.queues) {
+    panic("Valid priorities are 0, 1, and 2")
+    return fpq
+  }
+  if len(fpq.queues[priority]) >= 100 {
+    panic("Maximum queue size is 100")
+    return fpq
+  }
+  var qs = fpq.queues
+  qs[priority] = append(qs[priority], data)
+  fpq.queues = qs
+  return fpq
+}
+
+type FPQDequeueResult {
+  queue: FixedPriorityQueue
+  value: int
+}
+
+fun fpq_dequeue(fpq: FixedPriorityQueue): FPQDequeueResult {
+  var qs = fpq.queues
+  var i = 0
+  while i < len(qs) {
+    let q = qs[i]
+    if len(q) > 0 {
+      let val = q[0]
+      var new_q: list<int> = []
+      var j = 1
+      while j < len(q) {
+        new_q = append(new_q, q[j])
+        j = j + 1
+      }
+      qs[i] = new_q
+      fpq.queues = qs
+      return FPQDequeueResult { queue: fpq, value: val }
+    }
+    i = i + 1
+  }
+  panic("All queues are empty")
+  return FPQDequeueResult { queue: fpq, value: 0 }
+}
+
+fun fpq_to_string(fpq: FixedPriorityQueue): string {
+  var lines: list<string> = []
+  var i = 0
+  while i < len(fpq.queues) {
+    var q_str: string = "["
+    var q = fpq.queues[i]
+    var j = 0
+    while j < len(q) {
+      if j > 0 { q_str = q_str + ", " }
+      q_str = q_str + str(q[j])
+      j = j + 1
+    }
+    q_str = q_str + "]"
+    lines = append(lines, "Priority " + str(i) + ": " + q_str)
+    i = i + 1
+  }
+  var res: string = ""
+  i = 0
+  while i < len(lines) {
+    if i > 0 { res = res + "\n" }
+    res = res + lines[i]
+    i = i + 1
+  }
+  return res
+}
+
+type ElementPriorityQueue {
+  queue: list<int>
+}
+
+fun epq_new(): ElementPriorityQueue {
+  return ElementPriorityQueue { queue: [] }
+}
+
+fun epq_enqueue(epq: ElementPriorityQueue, data: int): ElementPriorityQueue {
+  if len(epq.queue) >= 100 {
+    panic("Maximum queue size is 100")
+    return epq
+  }
+  epq.queue = append(epq.queue, data)
+  return epq
+}
+
+type EPQDequeueResult {
+  queue: ElementPriorityQueue
+  value: int
+}
+
+fun epq_dequeue(epq: ElementPriorityQueue): EPQDequeueResult {
+  if len(epq.queue) == 0 {
+    panic("The queue is empty")
+    return EPQDequeueResult { queue: epq, value: 0 }
+  }
+  var min_val = epq.queue[0]
+  var idx = 0
+  var i = 1
+  while i < len(epq.queue) {
+    let v = epq.queue[i]
+    if v < min_val {
+      min_val = v
+      idx = i
+    }
+    i = i + 1
+  }
+  var new_q: list<int> = []
+  i = 0
+  while i < len(epq.queue) {
+    if i != idx {
+      new_q = append(new_q, epq.queue[i])
+    }
+    i = i + 1
+  }
+  epq.queue = new_q
+  return EPQDequeueResult { queue: epq, value: min_val }
+}
+
+fun epq_to_string(epq: ElementPriorityQueue): string {
+  return str(epq.queue)
+}
+
+fun fixed_priority_queue() {
+  var fpq = fpq_new()
+  fpq = fpq_enqueue(fpq, 0, 10)
+  fpq = fpq_enqueue(fpq, 1, 70)
+  fpq = fpq_enqueue(fpq, 0, 100)
+  fpq = fpq_enqueue(fpq, 2, 1)
+  fpq = fpq_enqueue(fpq, 2, 5)
+  fpq = fpq_enqueue(fpq, 1, 7)
+  fpq = fpq_enqueue(fpq, 2, 4)
+  fpq = fpq_enqueue(fpq, 1, 64)
+  fpq = fpq_enqueue(fpq, 0, 128)
+  print(fpq_to_string(fpq))
+  var res = fpq_dequeue(fpq); fpq = res.queue; print(res.value)
+  res = fpq_dequeue(fpq); fpq = res.queue; print(res.value)
+  res = fpq_dequeue(fpq); fpq = res.queue; print(res.value)
+  res = fpq_dequeue(fpq); fpq = res.queue; print(res.value)
+  res = fpq_dequeue(fpq); fpq = res.queue; print(res.value)
+  print(fpq_to_string(fpq))
+  res = fpq_dequeue(fpq); fpq = res.queue; print(res.value)
+  res = fpq_dequeue(fpq); fpq = res.queue; print(res.value)
+  res = fpq_dequeue(fpq); fpq = res.queue; print(res.value)
+  res = fpq_dequeue(fpq); fpq = res.queue; print(res.value)
+  res = fpq_dequeue(fpq); fpq = res.queue; print(res.value)
+}
+
+fun element_priority_queue() {
+  var epq = epq_new()
+  epq = epq_enqueue(epq, 10)
+  epq = epq_enqueue(epq, 70)
+  epq = epq_enqueue(epq, 100)
+  epq = epq_enqueue(epq, 1)
+  epq = epq_enqueue(epq, 5)
+  epq = epq_enqueue(epq, 7)
+  epq = epq_enqueue(epq, 4)
+  epq = epq_enqueue(epq, 64)
+  epq = epq_enqueue(epq, 128)
+  print(epq_to_string(epq))
+  var res = epq_dequeue(epq); epq = res.queue; print(res.value)
+  res = epq_dequeue(epq); epq = res.queue; print(res.value)
+  res = epq_dequeue(epq); epq = res.queue; print(res.value)
+  res = epq_dequeue(epq); epq = res.queue; print(res.value)
+  res = epq_dequeue(epq); epq = res.queue; print(res.value)
+  print(epq_to_string(epq))
+  res = epq_dequeue(epq); epq = res.queue; print(res.value)
+  res = epq_dequeue(epq); epq = res.queue; print(res.value)
+  res = epq_dequeue(epq); epq = res.queue; print(res.value)
+  res = epq_dequeue(epq); epq = res.queue; print(res.value)
+  res = epq_dequeue(epq); epq = res.queue; print(res.value)
+}
+
+fun main() {
+  fixed_priority_queue()
+  element_priority_queue()
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/data_structures/queues/priority_queue_using_list.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/queues/priority_queue_using_list.out
@@ -1,0 +1,30 @@
+Priority 0: [10, 100, 128]
+Priority 1: [70, 7, 64]
+Priority 2: [1, 5, 4]
+10
+100
+128
+70
+7
+Priority 0: []
+Priority 1: [64]
+Priority 2: [1, 5, 4]
+64
+1
+5
+4
+All queues are empty
+0
+[10 70 100 1 5 7 4 64 128]
+1
+4
+5
+7
+10
+[70 100 64 128]
+64
+70
+100
+128
+The queue is empty
+0

--- a/tests/github/TheAlgorithms/Python/data_structures/queues/priority_queue_using_list.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/queues/priority_queue_using_list.py
@@ -1,0 +1,232 @@
+"""
+Pure Python implementations of a Fixed Priority Queue and an Element Priority Queue
+using Python lists.
+"""
+
+
+class OverFlowError(Exception):
+    pass
+
+
+class UnderFlowError(Exception):
+    pass
+
+
+class FixedPriorityQueue:
+    """
+    Tasks can be added to a Priority Queue at any time and in any order but when Tasks
+    are removed then the Task with the highest priority is removed in FIFO order.  In
+    code we will use three levels of priority with priority zero Tasks being the most
+    urgent (high priority) and priority 2 tasks being the least urgent.
+
+    Examples
+    >>> fpq = FixedPriorityQueue()
+    >>> fpq.enqueue(0, 10)
+    >>> fpq.enqueue(1, 70)
+    >>> fpq.enqueue(0, 100)
+    >>> fpq.enqueue(2, 1)
+    >>> fpq.enqueue(2, 5)
+    >>> fpq.enqueue(1, 7)
+    >>> fpq.enqueue(2, 4)
+    >>> fpq.enqueue(1, 64)
+    >>> fpq.enqueue(0, 128)
+    >>> print(fpq)
+    Priority 0: [10, 100, 128]
+    Priority 1: [70, 7, 64]
+    Priority 2: [1, 5, 4]
+    >>> fpq.dequeue()
+    10
+    >>> fpq.dequeue()
+    100
+    >>> fpq.dequeue()
+    128
+    >>> fpq.dequeue()
+    70
+    >>> fpq.dequeue()
+    7
+    >>> print(fpq)
+    Priority 0: []
+    Priority 1: [64]
+    Priority 2: [1, 5, 4]
+    >>> fpq.dequeue()
+    64
+    >>> fpq.dequeue()
+    1
+    >>> fpq.dequeue()
+    5
+    >>> fpq.dequeue()
+    4
+    >>> fpq.dequeue()
+    Traceback (most recent call last):
+        ...
+    data_structures.queues.priority_queue_using_list.UnderFlowError: All queues are empty
+    >>> print(fpq)
+    Priority 0: []
+    Priority 1: []
+    Priority 2: []
+    """  # noqa: E501
+
+    def __init__(self):
+        self.queues = [
+            [],
+            [],
+            [],
+        ]
+
+    def enqueue(self, priority: int, data: int) -> None:
+        """
+        Add an element to a queue based on its priority.
+        If the priority is invalid ValueError is raised.
+        If the queue is full an OverFlowError is raised.
+        """
+        try:
+            if len(self.queues[priority]) >= 100:
+                raise OverflowError("Maximum queue size is 100")
+            self.queues[priority].append(data)
+        except IndexError:
+            raise ValueError("Valid priorities are 0, 1, and 2")
+
+    def dequeue(self) -> int:
+        """
+        Return the highest priority element in FIFO order.
+        If the queue is empty then an under flow exception is raised.
+        """
+        for queue in self.queues:
+            if queue:
+                return queue.pop(0)
+        raise UnderFlowError("All queues are empty")
+
+    def __str__(self) -> str:
+        return "\n".join(f"Priority {i}: {q}" for i, q in enumerate(self.queues))
+
+
+class ElementPriorityQueue:
+    """
+    Element Priority Queue is the same as Fixed Priority Queue except that the value of
+    the element itself is the priority. The rules for priorities are the same the as
+    Fixed Priority Queue.
+
+    >>> epq = ElementPriorityQueue()
+    >>> epq.enqueue(10)
+    >>> epq.enqueue(70)
+    >>> epq.enqueue(4)
+    >>> epq.enqueue(1)
+    >>> epq.enqueue(5)
+    >>> epq.enqueue(7)
+    >>> epq.enqueue(4)
+    >>> epq.enqueue(64)
+    >>> epq.enqueue(128)
+    >>> print(epq)
+    [10, 70, 4, 1, 5, 7, 4, 64, 128]
+    >>> epq.dequeue()
+    1
+    >>> epq.dequeue()
+    4
+    >>> epq.dequeue()
+    4
+    >>> epq.dequeue()
+    5
+    >>> epq.dequeue()
+    7
+    >>> epq.dequeue()
+    10
+    >>> print(epq)
+    [70, 64, 128]
+    >>> epq.dequeue()
+    64
+    >>> epq.dequeue()
+    70
+    >>> epq.dequeue()
+    128
+    >>> epq.dequeue()
+    Traceback (most recent call last):
+        ...
+    data_structures.queues.priority_queue_using_list.UnderFlowError: The queue is empty
+    >>> print(epq)
+    []
+    """
+
+    def __init__(self):
+        self.queue = []
+
+    def enqueue(self, data: int) -> None:
+        """
+        This function enters the element into the queue
+        If the queue is full an Exception is raised saying Over Flow!
+        """
+        if len(self.queue) == 100:
+            raise OverFlowError("Maximum queue size is 100")
+        self.queue.append(data)
+
+    def dequeue(self) -> int:
+        """
+        Return the highest priority element in FIFO order.
+        If the queue is empty then an under flow exception is raised.
+        """
+        if not self.queue:
+            raise UnderFlowError("The queue is empty")
+        else:
+            data = min(self.queue)
+            self.queue.remove(data)
+            return data
+
+    def __str__(self) -> str:
+        """
+        Prints all the elements within the Element Priority Queue
+        """
+        return str(self.queue)
+
+
+def fixed_priority_queue():
+    fpq = FixedPriorityQueue()
+    fpq.enqueue(0, 10)
+    fpq.enqueue(1, 70)
+    fpq.enqueue(0, 100)
+    fpq.enqueue(2, 1)
+    fpq.enqueue(2, 5)
+    fpq.enqueue(1, 7)
+    fpq.enqueue(2, 4)
+    fpq.enqueue(1, 64)
+    fpq.enqueue(0, 128)
+    print(fpq)
+    print(fpq.dequeue())
+    print(fpq.dequeue())
+    print(fpq.dequeue())
+    print(fpq.dequeue())
+    print(fpq.dequeue())
+    print(fpq)
+    print(fpq.dequeue())
+    print(fpq.dequeue())
+    print(fpq.dequeue())
+    print(fpq.dequeue())
+    print(fpq.dequeue())
+
+
+def element_priority_queue():
+    epq = ElementPriorityQueue()
+    epq.enqueue(10)
+    epq.enqueue(70)
+    epq.enqueue(100)
+    epq.enqueue(1)
+    epq.enqueue(5)
+    epq.enqueue(7)
+    epq.enqueue(4)
+    epq.enqueue(64)
+    epq.enqueue(128)
+    print(epq)
+    print(epq.dequeue())
+    print(epq.dequeue())
+    print(epq.dequeue())
+    print(epq.dequeue())
+    print(epq.dequeue())
+    print(epq)
+    print(epq.dequeue())
+    print(epq.dequeue())
+    print(epq.dequeue())
+    print(epq.dequeue())
+    print(epq.dequeue())
+
+
+if __name__ == "__main__":
+    fixed_priority_queue()
+    element_priority_queue()


### PR DESCRIPTION
## Summary
- add TheAlgorithms Python example for fixed and element priority queues
- implement equivalent Mochi versions using lists
- include runtime output of queue operations

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/data_structures/queues/priority_queue_using_list.mochi`


------
https://chatgpt.com/codex/tasks/task_e_689184d064b48320831d132d090be954