### PR TITLE
feat: add swap nodes linked list

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/swap_nodes.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/swap_nodes.mochi
@@ -1,0 +1,59 @@
+/*
+Swap two nodes in a singly linked list by their integer values. The list is
+modeled as a simple wrapper around a list of integers. Pushing prepends a value
+and swapping traverses the list to find the first occurrences of the targets
+and exchanges them if both are present. This mirrors the Python
+implementation from TheAlgorithms while remaining pure Mochi so it runs on
+the `runtime/vm`.
+*/
+
+type LinkedList {
+  data: list<int>
+}
+
+fun empty_list(): LinkedList {
+  return LinkedList { data: [] }
+}
+
+fun push(list: LinkedList, value: int): LinkedList {
+  var res: list<int> = [value]
+  res = concat(res, list.data)
+  return LinkedList { data: res }
+}
+
+fun swap_nodes(list: LinkedList, v1: int, v2: int): LinkedList {
+  if v1 == v2 { return list }
+  var idx1: int = 0 - 1
+  var idx2: int = 0 - 1
+  var i: int = 0
+  while i < len(list.data) {
+    if list.data[i] == v1 && idx1 == 0 - 1 { idx1 = i }
+    if list.data[i] == v2 && idx2 == 0 - 1 { idx2 = i }
+    i = i + 1
+  }
+  if idx1 == 0 - 1 || idx2 == 0 - 1 { return list }
+  var res = list.data
+  let temp = res[idx1]
+  res[idx1] = res[idx2]
+  res[idx2] = temp
+  return LinkedList { data: res }
+}
+
+fun to_string(list: LinkedList): string {
+  return str(list.data)
+}
+
+fun main() {
+  var ll = empty_list()
+  var i = 5
+  while i > 0 {
+    ll = push(ll, i)
+    i = i - 1
+  }
+  print("Original Linked List: " + to_string(ll))
+  ll = swap_nodes(ll, 1, 4)
+  print("Modified Linked List: " + to_string(ll))
+  print("After swapping the nodes whose data is 1 and 4.")
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/swap_nodes.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/linked_list/swap_nodes.out
@@ -1,0 +1,3 @@
+Original Linked List: [1 2 3 4 5]
+Modified Linked List: [4 2 3 1 5]
+After swapping the nodes whose data is 1 and 4.

--- a/tests/github/TheAlgorithms/Python/data_structures/linked_list/swap_nodes.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/linked_list/swap_nodes.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class Node:
+    data: Any
+    next_node: Node | None = None
+
+
+@dataclass
+class LinkedList:
+    head: Node | None = None
+
+    def __iter__(self) -> Iterator:
+        """
+        >>> linked_list = LinkedList()
+        >>> list(linked_list)
+        []
+        >>> linked_list.push(0)
+        >>> tuple(linked_list)
+        (0,)
+        """
+        node = self.head
+        while node:
+            yield node.data
+            node = node.next_node
+
+    def __len__(self) -> int:
+        """
+        >>> linked_list = LinkedList()
+        >>> len(linked_list)
+        0
+        >>> linked_list.push(0)
+        >>> len(linked_list)
+        1
+        """
+        return sum(1 for _ in self)
+
+    def push(self, new_data: Any) -> None:
+        """
+        Add a new node with the given data to the beginning of the Linked List.
+
+        Args:
+            new_data (Any): The data to be added to the new node.
+
+        Returns:
+            None
+
+        Examples:
+            >>> linked_list = LinkedList()
+            >>> linked_list.push(5)
+            >>> linked_list.push(4)
+            >>> linked_list.push(3)
+            >>> linked_list.push(2)
+            >>> linked_list.push(1)
+            >>> list(linked_list)
+            [1, 2, 3, 4, 5]
+        """
+        new_node = Node(new_data)
+        new_node.next_node = self.head
+        self.head = new_node
+
+    def swap_nodes(self, node_data_1: Any, node_data_2: Any) -> None:
+        """
+        Swap the positions of two nodes in the Linked List based on their data values.
+
+        Args:
+            node_data_1: Data value of the first node to be swapped.
+            node_data_2: Data value of the second node to be swapped.
+
+
+        Note:
+            If either of the specified data values isn't found then, no swapping occurs.
+
+        Examples:
+        When both values are present in a linked list.
+            >>> linked_list = LinkedList()
+            >>> linked_list.push(5)
+            >>> linked_list.push(4)
+            >>> linked_list.push(3)
+            >>> linked_list.push(2)
+            >>> linked_list.push(1)
+            >>> list(linked_list)
+            [1, 2, 3, 4, 5]
+            >>> linked_list.swap_nodes(1, 5)
+            >>> tuple(linked_list)
+            (5, 2, 3, 4, 1)
+
+        When one value is present and the other isn't in the linked list.
+            >>> second_list = LinkedList()
+            >>> second_list.push(6)
+            >>> second_list.push(7)
+            >>> second_list.push(8)
+            >>> second_list.push(9)
+            >>> second_list.swap_nodes(1, 6) is None
+            True
+
+        When both values are absent in the linked list.
+            >>> second_list = LinkedList()
+            >>> second_list.push(10)
+            >>> second_list.push(9)
+            >>> second_list.push(8)
+            >>> second_list.push(7)
+            >>> second_list.swap_nodes(1, 3) is None
+            True
+
+        When linkedlist is empty.
+            >>> second_list = LinkedList()
+            >>> second_list.swap_nodes(1, 3) is None
+            True
+
+        Returns:
+            None
+        """
+        if node_data_1 == node_data_2:
+            return
+
+        node_1 = self.head
+        while node_1 and node_1.data != node_data_1:
+            node_1 = node_1.next_node
+        node_2 = self.head
+        while node_2 and node_2.data != node_data_2:
+            node_2 = node_2.next_node
+        if node_1 is None or node_2 is None:
+            return
+        # Swap the data values of the two nodes
+        node_1.data, node_2.data = node_2.data, node_1.data
+
+
+if __name__ == "__main__":
+    """
+    Python script that outputs the swap of nodes in a linked list.
+    """
+    from doctest import testmod
+
+    testmod()
+    linked_list = LinkedList()
+    for i in range(5, 0, -1):
+        linked_list.push(i)
+
+    print(f"Original Linked List: {list(linked_list)}")
+    linked_list.swap_nodes(1, 4)
+    print(f"Modified Linked List: {list(linked_list)}")
+    print("After swapping the nodes whose data is 1 and 4.")


### PR DESCRIPTION
## Summary
- add Python linked list node swap example
- implement swap nodes in Mochi and sample output

## Testing
- `go run /tmp/runvm.go tests/github/TheAlgorithms/Mochi/data_structures/linked_list/swap_nodes.mochi`
- `go test ./...` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689184c410a883208b65c1ec42bb23e2