### PR TITLE
feat: add stack with doubly linked list implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/stacks/stack_with_doubly_linked_list.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/stacks/stack_with_doubly_linked_list.mochi
@@ -1,0 +1,126 @@
+/*
+Implement a stack of integers using a doubly linked list represented by
+an array of nodes.  Each node stores its value and the indexes of the
+next and previous nodes.  The stack tracks the index of the head node,
+which corresponds to the top of the stack.  Pushing creates a new node
+at the head and updates links.  Popping removes the head node, returns
+its value, and relinks the remaining list.  Additional operations
+include peeking at the top element, computing the size, checking for
+emptiness, and printing the stack from top to bottom.  The demonstration
+pushes four values, prints the stack, pops twice, prints again, and
+reports whether the stack is empty.
+*/
+
+type Node {
+  data: int,
+  next: int,
+  prev: int,
+}
+
+type Stack {
+  nodes: list<Node>,
+  head: int,
+}
+
+fun empty_stack(): Stack {
+  return Stack { nodes: [], head: 0 - 1 }
+}
+
+fun push(stack: Stack, value: int): Stack {
+  var nodes = stack.nodes
+  let idx = len(nodes)
+  var new_node = Node { data: value, next: stack.head, prev: 0 - 1 }
+  nodes = append(nodes, new_node)
+  if stack.head != 0 - 1 {
+    var head_node = nodes[stack.head]
+    head_node.prev = idx
+    nodes[stack.head] = head_node
+  }
+  return Stack { nodes: nodes, head: idx }
+}
+
+type PopResult {
+  stack: Stack,
+  value: int,
+  ok: bool,
+}
+
+fun pop(stack: Stack): PopResult {
+  if stack.head == 0 - 1 {
+    return PopResult { stack: stack, value: 0, ok: false }
+  }
+  var nodes = stack.nodes
+  var head_node = nodes[stack.head]
+  let value = head_node.data
+  let next_idx = head_node.next
+  if next_idx != 0 - 1 {
+    var next_node = nodes[next_idx]
+    next_node.prev = 0 - 1
+    nodes[next_idx] = next_node
+  }
+  let new_stack = Stack { nodes: nodes, head: next_idx }
+  return PopResult { stack: new_stack, value: value, ok: true }
+}
+
+type TopResult {
+  value: int,
+  ok: bool,
+}
+
+fun top(stack: Stack): TopResult {
+  if stack.head == 0 - 1 {
+    return TopResult { value: 0, ok: false }
+  }
+  let node = stack.nodes[stack.head]
+  return TopResult { value: node.data, ok: true }
+}
+
+fun size(stack: Stack): int {
+  var count = 0
+  var idx = stack.head
+  while idx != 0 - 1 {
+    count = count + 1
+    let node = stack.nodes[idx]
+    idx = node.next
+  }
+  return count
+}
+
+fun is_empty(stack: Stack): bool {
+  return stack.head == 0 - 1
+}
+
+fun print_stack(stack: Stack) {
+  print("stack elements are:")
+  var idx = stack.head
+  var s = ""
+  while idx != 0 - 1 {
+    let node = stack.nodes[idx]
+    s = s + str(node.data) + "->"
+    idx = node.next
+  }
+  if len(s) > 0 {
+    print(s)
+  }
+}
+
+fun main() {
+  var stack = empty_stack()
+  print("Stack operations using Doubly LinkedList")
+  stack = push(stack, 4)
+  stack = push(stack, 5)
+  stack = push(stack, 6)
+  stack = push(stack, 7)
+  print_stack(stack)
+  let t = top(stack)
+  if t.ok { print("Top element is " + str(t.value)) } else { print("Top element is None") }
+  print("Size of the stack is " + str(size(stack)))
+  var p = pop(stack)
+  stack = p.stack
+  p = pop(stack)
+  stack = p.stack
+  print_stack(stack)
+  print("stack is empty: " + str(is_empty(stack)))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/data_structures/stacks/stack_with_doubly_linked_list.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/stacks/stack_with_doubly_linked_list.out
@@ -1,0 +1,8 @@
+Stack operations using Doubly LinkedList
+stack elements are:
+7->6->5->4->
+Top element is 7
+Size of the stack is 4
+stack elements are:
+5->4->
+stack is empty: false

--- a/tests/github/TheAlgorithms/Python/data_structures/stacks/stack_with_doubly_linked_list.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/stacks/stack_with_doubly_linked_list.py
@@ -1,0 +1,130 @@
+# A complete working Python program to demonstrate all
+# stack operations using a doubly linked list
+
+from __future__ import annotations
+
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+class Node[T]:
+    def __init__(self, data: T):
+        self.data = data  # Assign data
+        self.next: Node[T] | None = None  # Initialize next as null
+        self.prev: Node[T] | None = None  # Initialize prev as null
+
+
+class Stack[T]:
+    """
+    >>> stack = Stack()
+    >>> stack.is_empty()
+    True
+    >>> stack.print_stack()
+    stack elements are:
+    >>> for i in range(4):
+    ...     stack.push(i)
+    ...
+    >>> stack.is_empty()
+    False
+    >>> stack.print_stack()
+    stack elements are:
+    3->2->1->0->
+    >>> stack.top()
+    3
+    >>> len(stack)
+    4
+    >>> stack.pop()
+    3
+    >>> stack.print_stack()
+    stack elements are:
+    2->1->0->
+    """
+
+    def __init__(self) -> None:
+        self.head: Node[T] | None = None
+
+    def push(self, data: T) -> None:
+        """add a Node to the stack"""
+        if self.head is None:
+            self.head = Node(data)
+        else:
+            new_node = Node(data)
+            self.head.prev = new_node
+            new_node.next = self.head
+            new_node.prev = None
+            self.head = new_node
+
+    def pop(self) -> T | None:
+        """pop the top element off the stack"""
+        if self.head is None:
+            return None
+        else:
+            assert self.head is not None
+            temp = self.head.data
+            self.head = self.head.next
+            if self.head is not None:
+                self.head.prev = None
+            return temp
+
+    def top(self) -> T | None:
+        """return the top element of the stack"""
+        return self.head.data if self.head is not None else None
+
+    def __len__(self) -> int:
+        temp = self.head
+        count = 0
+        while temp is not None:
+            count += 1
+            temp = temp.next
+        return count
+
+    def is_empty(self) -> bool:
+        return self.head is None
+
+    def print_stack(self) -> None:
+        print("stack elements are:")
+        temp = self.head
+        while temp is not None:
+            print(temp.data, end="->")
+            temp = temp.next
+
+
+# Code execution starts here
+if __name__ == "__main__":
+    # Start with the empty stack
+    stack: Stack[int] = Stack()
+
+    # Insert 4 at the beginning. So stack becomes 4->None
+    print("Stack operations using Doubly LinkedList")
+    stack.push(4)
+
+    # Insert 5 at the beginning. So stack becomes 4->5->None
+    stack.push(5)
+
+    # Insert 6 at the beginning. So stack becomes 4->5->6->None
+    stack.push(6)
+
+    # Insert 7 at the beginning. So stack becomes 4->5->6->7->None
+    stack.push(7)
+
+    # Print the stack
+    stack.print_stack()
+
+    # Print the top element
+    print("\nTop element is ", stack.top())
+
+    # Print the stack size
+    print("Size of the stack is ", len(stack))
+
+    # pop the top element
+    stack.pop()
+
+    # pop the top element
+    stack.pop()
+
+    # two elements have now been popped off
+    stack.print_stack()
+
+    # Print True if the stack is empty else False
+    print("\nstack is empty:", stack.is_empty())


### PR DESCRIPTION
## Summary
- add Python reference for stack implemented with a doubly linked list
- implement stack with a doubly linked list in Mochi and demo operations

## Testing
- `npm test` *(fails: Missing script "test")*
- `go test ./...` *(interrupted: some packages have no tests)*
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/data_structures/stacks/stack_with_doubly_linked_list.mochi`

------
https://chatgpt.com/codex/tasks/task_e_689184f2550c83208595afdb65dd694c