### PR TITLE
Add Mochi stack with singly linked list

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/stacks/stack_with_singly_linked_list.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/stacks/stack_with_singly_linked_list.mochi
@@ -1,0 +1,96 @@
+/*
+Stack Using Singly Linked List
+-------------------------------
+
+This program implements a stack where each element is stored in a node
+of a singly linked list.  For simplicity and to avoid using pointers,
+the nodes are kept in an array and each node stores the index of the
+next node, forming a linked structure.  The stack supports:
+
+  • push   - insert an item at the top of the stack
+  • pop    - remove and return the item at the top
+  • peek   - return the top item without removing it
+  • is_empty - check whether the stack has any items
+  • clear  - remove all items
+
+Each push appends a node to the array and records the previous top as
+its next index.  Pop retrieves the node at the current top index and
+moves the top pointer to the next index.  All operations are O(1).
+
+The demonstration below pushes and pops a few strings and prints the
+intermediate results.
+*/
+
+type Node {
+  value: string,
+  next: int,
+}
+
+type Stack {
+  nodes: list<Node>,
+  top: int,
+}
+
+fun empty_stack(): Stack {
+  return Stack { nodes: [], top: (-1) }
+}
+
+fun is_empty(stack: Stack): bool {
+  return stack.top == (-1)
+}
+
+fun push(stack: Stack, item: string): Stack {
+  let new_node = Node { value: item, next: stack.top }
+  var new_nodes = stack.nodes
+  new_nodes = append(new_nodes, new_node)
+  let new_top = len(new_nodes) - 1
+  return Stack { nodes: new_nodes, top: new_top }
+}
+
+type PopResult {
+  stack: Stack,
+  value: string,
+}
+
+fun pop(stack: Stack): PopResult {
+  if stack.top == (-1) { panic("pop from empty stack") }
+  let node = (stack.nodes[stack.top])
+  let new_top = node.next
+  let new_stack = Stack { nodes: stack.nodes, top: new_top }
+  return PopResult { stack: new_stack, value: node.value }
+}
+
+fun peek(stack: Stack): string {
+  if stack.top == (-1) { panic("peek from empty stack") }
+  let node = (stack.nodes[stack.top])
+  return node.value
+}
+
+fun clear(stack: Stack): Stack {
+  return Stack { nodes: [], top: (-1) }
+}
+
+fun main() {
+  var stack = empty_stack()
+  print(is_empty(stack))
+  stack = push(stack, "5")
+  stack = push(stack, "9")
+  stack = push(stack, "python")
+  print(is_empty(stack))
+  var res = pop(stack)
+  stack = res.stack
+  print(res.value)
+  stack = push(stack, "algorithms")
+  res = pop(stack)
+  stack = res.stack
+  print(res.value)
+  res = pop(stack)
+  stack = res.stack
+  print(res.value)
+  res = pop(stack)
+  stack = res.stack
+  print(res.value)
+  print(is_empty(stack))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/data_structures/stacks/stack_with_singly_linked_list.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/stacks/stack_with_singly_linked_list.out
@@ -1,0 +1,7 @@
+true
+false
+python
+algorithms
+9
+5
+true

--- a/tests/github/TheAlgorithms/Python/data_structures/stacks/stack_with_singly_linked_list.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/stacks/stack_with_singly_linked_list.py
@@ -1,0 +1,165 @@
+"""A Stack using a linked list like structure"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+class Node[T]:
+    def __init__(self, data: T):
+        self.data = data
+        self.next: Node[T] | None = None
+
+    def __str__(self) -> str:
+        return f"{self.data}"
+
+
+class LinkedStack[T]:
+    """
+    Linked List Stack implementing push (to top),
+    pop (from top) and is_empty
+
+    >>> stack = LinkedStack()
+    >>> stack.is_empty()
+    True
+    >>> stack.push(5)
+    >>> stack.push(9)
+    >>> stack.push('python')
+    >>> stack.is_empty()
+    False
+    >>> stack.pop()
+    'python'
+    >>> stack.push('algorithms')
+    >>> stack.pop()
+    'algorithms'
+    >>> stack.pop()
+    9
+    >>> stack.pop()
+    5
+    >>> stack.is_empty()
+    True
+    >>> stack.pop()
+    Traceback (most recent call last):
+        ...
+    IndexError: pop from empty stack
+    """
+
+    def __init__(self) -> None:
+        self.top: Node[T] | None = None
+
+    def __iter__(self) -> Iterator[T]:
+        node = self.top
+        while node:
+            yield node.data
+            node = node.next
+
+    def __str__(self) -> str:
+        """
+        >>> stack = LinkedStack()
+        >>> stack.push("c")
+        >>> stack.push("b")
+        >>> stack.push("a")
+        >>> str(stack)
+        'a->b->c'
+        """
+        return "->".join([str(item) for item in self])
+
+    def __len__(self) -> int:
+        """
+        >>> stack = LinkedStack()
+        >>> len(stack) == 0
+        True
+        >>> stack.push("c")
+        >>> stack.push("b")
+        >>> stack.push("a")
+        >>> len(stack) == 3
+        True
+        """
+        return len(tuple(iter(self)))
+
+    def is_empty(self) -> bool:
+        """
+        >>> stack = LinkedStack()
+        >>> stack.is_empty()
+        True
+        >>> stack.push(1)
+        >>> stack.is_empty()
+        False
+        """
+        return self.top is None
+
+    def push(self, item: T) -> None:
+        """
+        >>> stack = LinkedStack()
+        >>> stack.push("Python")
+        >>> stack.push("Java")
+        >>> stack.push("C")
+        >>> str(stack)
+        'C->Java->Python'
+        """
+        node = Node(item)
+        if not self.is_empty():
+            node.next = self.top
+        self.top = node
+
+    def pop(self) -> T:
+        """
+        >>> stack = LinkedStack()
+        >>> stack.pop()
+        Traceback (most recent call last):
+            ...
+        IndexError: pop from empty stack
+        >>> stack.push("c")
+        >>> stack.push("b")
+        >>> stack.push("a")
+        >>> stack.pop() == 'a'
+        True
+        >>> stack.pop() == 'b'
+        True
+        >>> stack.pop() == 'c'
+        True
+        """
+        if self.is_empty():
+            raise IndexError("pop from empty stack")
+        assert isinstance(self.top, Node)
+        pop_node = self.top
+        self.top = self.top.next
+        return pop_node.data
+
+    def peek(self) -> T:
+        """
+        >>> stack = LinkedStack()
+        >>> stack.push("Java")
+        >>> stack.push("C")
+        >>> stack.push("Python")
+        >>> stack.peek()
+        'Python'
+        """
+        if self.is_empty():
+            raise IndexError("peek from empty stack")
+
+        assert self.top is not None
+        return self.top.data
+
+    def clear(self) -> None:
+        """
+        >>> stack = LinkedStack()
+        >>> stack.push("Java")
+        >>> stack.push("C")
+        >>> stack.push("Python")
+        >>> str(stack)
+        'Python->C->Java'
+        >>> stack.clear()
+        >>> len(stack) == 0
+        True
+        """
+        self.top = None
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()


### PR DESCRIPTION
## Summary
- port TheAlgorithms/Python `stack_with_singly_linked_list` example and add to repo
- implement stack operations in Mochi using array-backed linked nodes
- include test output demonstrating push/pop sequence

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/data_structures/stacks/stack_with_singly_linked_list.mochi`


------
https://chatgpt.com/codex/tasks/task_e_689184f458148320ac235641d575dde8