### PR TITLE
Add Mochi suffix tree search example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/suffix_tree/example/example_usage.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/suffix_tree/example/example_usage.mochi
@@ -1,0 +1,52 @@
+/*
+Demonstrate substring search using a simple suffix tree abstraction.
+The program constructs a tree from the text "monkey banana" and
+searches several patterns.  Instead of building a full suffix tree,
+which stores every suffix explicitly, we keep the original text and
+check each pattern by scanning the text.  For a pattern of length m
+and text length n, the search runs in O(n*m) time by comparing
+substrings at every starting index.  The results indicate whether
+each pattern occurs within the text.
+*/
+
+type SuffixTree {
+  text: string
+}
+
+fun new_suffix_tree(text: string): SuffixTree {
+  return SuffixTree { text: text }
+}
+
+fun search(tree: SuffixTree, pattern: string): bool {
+  let n = len(tree.text)
+  let m = len(pattern)
+  if m == 0 {
+    return true
+  }
+  if m > n {
+    return false
+  }
+  var i = 0
+  while i <= n - m {
+    if tree.text[i:i + m] == pattern {
+      return true
+    }
+    i = i + 1
+  }
+  return false
+}
+
+fun main() {
+  let text = "monkey banana"
+  let suffix_tree = new_suffix_tree(text)
+  let patterns: list<string> = ["ana", "ban", "na", "xyz", "mon"]
+  var i = 0
+  while i < len(patterns) {
+    let pattern = patterns[i]
+    let found = search(suffix_tree, pattern)
+    print("Pattern '" + pattern + "' found: " + str(found))
+    i = i + 1
+  }
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/data_structures/suffix_tree/example/example_usage.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/suffix_tree/example/example_usage.out
@@ -1,0 +1,5 @@
+Pattern 'ana' found: true
+Pattern 'ban' found: true
+Pattern 'na' found: true
+Pattern 'xyz' found: false
+Pattern 'mon' found: true

--- a/tests/github/TheAlgorithms/Python/data_structures/suffix_tree/example/example_usage.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/suffix_tree/example/example_usage.py
@@ -1,0 +1,37 @@
+#  Created by: Ramy-Badr-Ahmed (https://github.com/Ramy-Badr-Ahmed)
+#  in Pull Request: #11554
+#  https://github.com/TheAlgorithms/Python/pull/11554
+#
+#  Please mention me (@Ramy-Badr-Ahmed) in any issue or pull request
+#  addressing bugs/corrections to this file.
+#  Thank you!
+
+from data_structures.suffix_tree.suffix_tree import SuffixTree
+
+
+def main() -> None:
+    """
+    Demonstrate the usage of the SuffixTree class.
+
+    - Initializes a SuffixTree with a predefined text.
+    - Defines a list of patterns to search for within the suffix tree.
+    - Searches for each pattern in the suffix tree.
+
+    Patterns tested:
+        - "ana" (found) --> True
+        - "ban" (found) --> True
+        - "na" (found) --> True
+        - "xyz" (not found) --> False
+        - "mon" (found) --> True
+    """
+    text = "monkey banana"
+    suffix_tree = SuffixTree(text)
+
+    patterns = ["ana", "ban", "na", "xyz", "mon"]
+    for pattern in patterns:
+        found = suffix_tree.search(pattern)
+        print(f"Pattern '{pattern}' found: {found}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python example for suffix tree pattern searching
- implement equivalent Mochi version using naive substring scan
- include runtime output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/data_structures/suffix_tree/example/example_usage.mochi > tests/github/TheAlgorithms/Mochi/data_structures/suffix_tree/example/example_usage.out`


------
https://chatgpt.com/codex/tasks/task_e_689184f78b788320ba0242c87c17ec6e