### PR TITLE
Add Mochi suffix tree test implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/data_structures/suffix_tree/tests/test_suffix_tree.mochi
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/suffix_tree/tests/test_suffix_tree.mochi
@@ -1,0 +1,75 @@
+/*
+Suffix Tree Pattern Search Tests
+--------------------------------
+This program mirrors the Python unit tests for the SuffixTree data structure.
+Instead of building a full suffix tree, we store the original text and
+perform naive substring search to check if a pattern exists. The search runs
+in O(n*m) time where n is the text length and m is the pattern length. The
+program verifies:
+ - patterns that should be found in the text
+ - patterns that should not be found
+ - searching for the empty string
+ - searching for the full text
+ - searching for several substrings
+Each result is printed as "true" or "false".
+*/
+
+type SuffixTree {
+  text: string
+}
+
+fun suffix_tree_new(text: string): SuffixTree {
+  return SuffixTree{ text: text }
+}
+
+fun suffix_tree_search(st: SuffixTree, pattern: string): bool {
+  if len(pattern) == 0 {
+    return true
+  }
+  var i: int = 0
+  let n = len(st.text)
+  let m = len(pattern)
+  while i <= n - m {
+    var j: int = 0
+    var found: bool = true
+    while j < m {
+      if st.text[i + j] != pattern[j] {
+        found = false
+        break
+      }
+      j = j + 1
+    }
+    if found {
+      return true
+    }
+    i = i + 1
+  }
+  return false
+}
+
+let text = "banana"
+let st = suffix_tree_new(text)
+
+let patterns_exist = ["ana", "ban", "na"]
+var i: int = 0
+while i < len(patterns_exist) {
+  print(str(suffix_tree_search(st, patterns_exist[i])))
+  i = i + 1
+}
+
+let patterns_none = ["xyz", "apple", "cat"]
+i = 0
+while i < len(patterns_none) {
+  print(str(suffix_tree_search(st, patterns_none[i])))
+  i = i + 1
+}
+
+print(str(suffix_tree_search(st, "")))
+print(str(suffix_tree_search(st, text)))
+
+let substrings = ["ban", "ana", "a", "na"]
+i = 0
+while i < len(substrings) {
+  print(str(suffix_tree_search(st, substrings[i])))
+  i = i + 1
+}

--- a/tests/github/TheAlgorithms/Mochi/data_structures/suffix_tree/tests/test_suffix_tree.out
+++ b/tests/github/TheAlgorithms/Mochi/data_structures/suffix_tree/tests/test_suffix_tree.out
@@ -1,0 +1,12 @@
+true
+true
+true
+false
+false
+false
+true
+true
+true
+true
+true
+true

--- a/tests/github/TheAlgorithms/Python/data_structures/suffix_tree/tests/test_suffix_tree.py
+++ b/tests/github/TheAlgorithms/Python/data_structures/suffix_tree/tests/test_suffix_tree.py
@@ -1,0 +1,59 @@
+#  Created by: Ramy-Badr-Ahmed (https://github.com/Ramy-Badr-Ahmed)
+#  in Pull Request: #11554
+#  https://github.com/TheAlgorithms/Python/pull/11554
+#
+#  Please mention me (@Ramy-Badr-Ahmed) in any issue or pull request
+#  addressing bugs/corrections to this file.
+#  Thank you!
+
+import unittest
+
+from data_structures.suffix_tree.suffix_tree import SuffixTree
+
+
+class TestSuffixTree(unittest.TestCase):
+    def setUp(self) -> None:
+        """Set up the initial conditions for each test."""
+        self.text = "banana"
+        self.suffix_tree = SuffixTree(self.text)
+
+    def test_search_existing_patterns(self) -> None:
+        """Test searching for patterns that exist in the suffix tree."""
+        patterns = ["ana", "ban", "na"]
+        for pattern in patterns:
+            with self.subTest(pattern=pattern):
+                assert self.suffix_tree.search(pattern), (
+                    f"Pattern '{pattern}' should be found."
+                )
+
+    def test_search_non_existing_patterns(self) -> None:
+        """Test searching for patterns that do not exist in the suffix tree."""
+        patterns = ["xyz", "apple", "cat"]
+        for pattern in patterns:
+            with self.subTest(pattern=pattern):
+                assert not self.suffix_tree.search(pattern), (
+                    f"Pattern '{pattern}' should not be found."
+                )
+
+    def test_search_empty_pattern(self) -> None:
+        """Test searching for an empty pattern."""
+        assert self.suffix_tree.search(""), "An empty pattern should be found."
+
+    def test_search_full_text(self) -> None:
+        """Test searching for the full text."""
+        assert self.suffix_tree.search(self.text), (
+            "The full text should be found in the suffix tree."
+        )
+
+    def test_search_substrings(self) -> None:
+        """Test searching for substrings of the full text."""
+        substrings = ["ban", "ana", "a", "na"]
+        for substring in substrings:
+            with self.subTest(substring=substring):
+                assert self.suffix_tree.search(substring), (
+                    f"Substring '{substring}' should be found."
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- port Python suffix tree tests and create equivalent Mochi version
- implement simple SuffixTree search and pattern checks

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/data_structures/suffix_tree/tests/test_suffix_tree.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891850806d48320b9bfb191de5cdd8b