### PR TITLE
Add morphological erosion algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/digital_image_processing/morphological_operations/erosion_operation.mochi
+++ b/tests/github/TheAlgorithms/Mochi/digital_image_processing/morphological_operations/erosion_operation.mochi
@@ -1,0 +1,127 @@
+/*
+Convert an RGB image to grayscale, threshold it to a binary image, and
+apply morphological erosion. Erosion shrinks foreground regions by
+sliding a structuring element (kernel) over the binary image and keeping
+only the pixels where the kernel fits entirely within the foreground.
+
+The process is:
+1. `rgb_to_gray` computes 0.2989*R + 0.5870*G + 0.1140*B for each pixel.
+2. `gray_to_binary` keeps values in (127,255] as true.
+3. `erosion` pads the image and counts overlapping 1s under the kernel;
+   using a cross-shaped kernel with five ones, the output pixel is true
+   only when the sum equals five.
+This demonstration uses small arrays similar to the original Python
+examples.
+*/
+
+fun rgb_to_gray(rgb: list<list<list<int>>>): list<list<float>> {
+  var gray: list<list<float>> = []
+  var i = 0
+  while i < len(rgb) {
+    var row: list<float> = []
+    var j = 0
+    while j < len(rgb[i]) {
+      let r = rgb[i][j][0] as float
+      let g = rgb[i][j][1] as float
+      let b = rgb[i][j][2] as float
+      let value = 0.2989 * r + 0.5870 * g + 0.1140 * b
+      row = append(row, value)
+      j = j + 1
+    }
+    gray = append(gray, row)
+    i = i + 1
+  }
+  return gray
+}
+
+fun gray_to_binary(gray: list<list<float>>): list<list<bool>> {
+  var binary: list<list<bool>> = []
+  var i = 0
+  while i < len(gray) {
+    var row: list<bool> = []
+    var j = 0
+    while j < len(gray[i]) {
+      row = append(row, gray[i][j] > 127.0 && gray[i][j] <= 255.0)
+      j = j + 1
+    }
+    binary = append(binary, row)
+    i = i + 1
+  }
+  return binary
+}
+
+fun erosion(image: list<list<bool>>, kernel: list<list<int>>): list<list<bool>> {
+  let h = len(image)
+  let w = len(image[0])
+  let k_h = len(kernel)
+  let k_w = len(kernel[0])
+
+  let pad_y = k_h / 2
+  let pad_x = k_w / 2
+
+  // create padded image with zeros
+  var padded: list<list<bool>> = []
+  var y = 0
+  while y < h + 2 * pad_y {
+    var row: list<bool> = []
+    var x = 0
+    while x < w + 2 * pad_x {
+      row = append(row, false)
+      x = x + 1
+    }
+    padded = append(padded, row)
+    y = y + 1
+  }
+
+  // copy original image into padded
+  y = 0
+  while y < h {
+    var x = 0
+    while x < w {
+      padded[pad_y + y][pad_x + x] = image[y][x]
+      x = x + 1
+    }
+    y = y + 1
+  }
+
+  // apply erosion assuming kernel contains five ones
+  var output: list<list<bool>> = []
+  y = 0
+  while y < h {
+    var row_out: list<bool> = []
+    var x = 0
+    while x < w {
+      var sum = 0
+      var ky = 0
+      while ky < k_h {
+        var kx = 0
+        while kx < k_w {
+          if kernel[ky][kx] == 1 && padded[y + ky][x + kx] {
+            sum = sum + 1
+          }
+          kx = kx + 1
+        }
+        ky = ky + 1
+      }
+      row_out = append(row_out, sum == 5)
+      x = x + 1
+    }
+    output = append(output, row_out)
+    y = y + 1
+  }
+  return output
+}
+
+let rgb_img = [[[127, 255, 0]]]
+print(str(rgb_to_gray(rgb_img)))
+
+let gray_img = [[127.0, 255.0, 0.0]]
+print(str(gray_to_binary(gray_img)))
+
+let img1 = [[true, true, false]]
+let kernel1 = [[0, 1, 0]]
+print(str(erosion(img1, kernel1)))
+
+let img2 = [[true, false, false]]
+let kernel2 = [[1, 1, 0]]
+print(str(erosion(img2, kernel2)))

--- a/tests/github/TheAlgorithms/Mochi/digital_image_processing/morphological_operations/erosion_operation.out
+++ b/tests/github/TheAlgorithms/Mochi/digital_image_processing/morphological_operations/erosion_operation.out
@@ -1,0 +1,4 @@
+[[187.6453]]
+[[false true false]]
+[[false false false]]
+[[false false false]]

--- a/tests/github/TheAlgorithms/Python/digital_image_processing/morphological_operations/erosion_operation.py
+++ b/tests/github/TheAlgorithms/Python/digital_image_processing/morphological_operations/erosion_operation.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+
+def rgb_to_gray(rgb: np.ndarray) -> np.ndarray:
+    """
+    Return gray image from rgb image
+
+    >>> rgb_to_gray(np.array([[[127, 255, 0]]]))
+    array([[187.6453]])
+    >>> rgb_to_gray(np.array([[[0, 0, 0]]]))
+    array([[0.]])
+    >>> rgb_to_gray(np.array([[[2, 4, 1]]]))
+    array([[3.0598]])
+    >>> rgb_to_gray(np.array([[[26, 255, 14], [5, 147, 20], [1, 200, 0]]]))
+    array([[159.0524,  90.0635, 117.6989]])
+    """
+    r, g, b = rgb[:, :, 0], rgb[:, :, 1], rgb[:, :, 2]
+    return 0.2989 * r + 0.5870 * g + 0.1140 * b
+
+
+def gray_to_binary(gray: np.ndarray) -> np.ndarray:
+    """
+    Return binary image from gray image
+
+    >>> gray_to_binary(np.array([[127, 255, 0]]))
+    array([[False,  True, False]])
+    >>> gray_to_binary(np.array([[0]]))
+    array([[False]])
+    >>> gray_to_binary(np.array([[26.2409, 4.9315, 1.4729]]))
+    array([[False, False, False]])
+    >>> gray_to_binary(np.array([[26, 255, 14], [5, 147, 20], [1, 200, 0]]))
+    array([[False,  True, False],
+           [False,  True, False],
+           [False,  True, False]])
+    """
+    return (gray > 127) & (gray <= 255)
+
+
+def erosion(image: np.ndarray, kernel: np.ndarray) -> np.ndarray:
+    """
+    Return eroded image
+
+    >>> erosion(np.array([[True, True, False]]), np.array([[0, 1, 0]]))
+    array([[False, False, False]])
+    >>> erosion(np.array([[True, False, False]]), np.array([[1, 1, 0]]))
+    array([[False, False, False]])
+    """
+    output = np.zeros_like(image)
+    image_padded = np.zeros(
+        (image.shape[0] + kernel.shape[0] - 1, image.shape[1] + kernel.shape[1] - 1)
+    )
+
+    # Copy image to padded image
+    image_padded[kernel.shape[0] - 2 : -1 :, kernel.shape[1] - 2 : -1 :] = image
+
+    # Iterate over image & apply kernel
+    for x in range(image.shape[1]):
+        for y in range(image.shape[0]):
+            summation = (
+                kernel * image_padded[y : y + kernel.shape[0], x : x + kernel.shape[1]]
+            ).sum()
+            output[y, x] = int(summation == 5)
+    return output
+
+
+if __name__ == "__main__":
+    # read original image
+    lena_path = Path(__file__).resolve().parent / "image_data" / "lena.jpg"
+    lena = np.array(Image.open(lena_path))
+
+    # kernel to be applied
+    structuring_element = np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]])
+
+    # Apply erosion operation to a binary image
+    output = erosion(gray_to_binary(rgb_to_gray(lena)), structuring_element)
+
+    # Save the output image
+    pil_img = Image.fromarray(output).convert("RGB")
+    pil_img.save("result_erosion.png")


### PR DESCRIPTION
## Summary
- add Python example for morphological erosion
- implement equivalent Mochi version with grayscale and binary helpers
- include runtime output from Mochi VM

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/digital_image_processing/morphological_operations/erosion_operation.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891a746892c8320a30cfa933726d167