### PR TITLE
Add divide-and-conquer inversion counting example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/divide_and_conquer/inversions.mochi
+++ b/tests/github/TheAlgorithms/Mochi/divide_and_conquer/inversions.mochi
@@ -1,0 +1,98 @@
+/*
+Counting Inversions in an Array
+-------------------------------
+An inversion is a pair of indices (i, j) such that i < j and arr[i] > arr[j].
+This program implements two approaches to count inversions:
+
+1. Brute Force:  O(n^2) time using nested loops to check all pairs.
+2. Divide and Conquer:  O(n log n) time using a merge step similar to
+   merge sort. The array is recursively split, sorted halves are merged
+   while counting cross inversions between them.
+
+Both functions operate on lists of integers and return the inversion count.
+The divide-and-conquer variant also produces the sorted array as it merges.
+*/
+
+type InvResult {
+  arr: list<int>
+  inv: int
+}
+
+fun slice_list(arr: list<int>, start: int, end: int): list<int> {
+  var res: list<int> = []
+  var k = start
+  while k < end {
+    res = append(res, arr[k])
+    k = k + 1
+  }
+  return res
+}
+
+fun count_inversions_bf(arr: list<int>): int {
+  let n = len(arr)
+  var inv = 0
+  var i = 0
+  while i < n - 1 {
+    var j = i + 1
+    while j < n {
+      if arr[i] > arr[j] {
+        inv = inv + 1
+      }
+      j = j + 1
+    }
+    i = i + 1
+  }
+  return inv
+}
+
+fun count_cross_inversions(p: list<int>, q: list<int>): InvResult {
+  var r: list<int> = []
+  var i = 0
+  var j = 0
+  var inv = 0
+  while i < len(p) && j < len(q) {
+    if p[i] > q[j] {
+      inv = inv + (len(p) - i)
+      r = append(r, q[j])
+      j = j + 1
+    } else {
+      r = append(r, p[i])
+      i = i + 1
+    }
+  }
+  if i < len(p) {
+    r = concat(r, slice_list(p, i, len(p)))
+  } else {
+    r = concat(r, slice_list(q, j, len(q)))
+  }
+  return InvResult { arr: r, inv: inv }
+}
+
+fun count_inversions_recursive(arr: list<int>): InvResult {
+  if len(arr) <= 1 {
+    return InvResult { arr: arr, inv: 0 }
+  }
+  let mid = len(arr) / 2
+  let p = slice_list(arr, 0, mid)
+  let q = slice_list(arr, mid, len(arr))
+  let res_p = count_inversions_recursive(p)
+  let res_q = count_inversions_recursive(q)
+  let res_cross = count_cross_inversions(res_p.arr, res_q.arr)
+  let total = res_p.inv + res_q.inv + res_cross.inv
+  return InvResult { arr: res_cross.arr, inv: total }
+}
+
+var arr_1: list<int> = [10, 2, 1, 5, 5, 2, 11]
+let nbf = count_inversions_bf(arr_1)
+let nrec = count_inversions_recursive(arr_1).inv
+print("number of inversions = ", nbf)
+
+arr_1 = [1, 2, 2, 5, 5, 10, 11]
+let nbf2 = count_inversions_bf(arr_1)
+let nrec2 = count_inversions_recursive(arr_1).inv
+print("number of inversions = ", nbf2)
+
+arr_1 = []
+let nbf3 = count_inversions_bf(arr_1)
+let nrec3 = count_inversions_recursive(arr_1).inv
+print("number of inversions = ", nbf3)

--- a/tests/github/TheAlgorithms/Mochi/divide_and_conquer/inversions.out
+++ b/tests/github/TheAlgorithms/Mochi/divide_and_conquer/inversions.out
@@ -1,0 +1,3 @@
+number of inversions =  8
+number of inversions =  0
+number of inversions =  0

--- a/tests/github/TheAlgorithms/Python/divide_and_conquer/inversions.py
+++ b/tests/github/TheAlgorithms/Python/divide_and_conquer/inversions.py
@@ -1,0 +1,153 @@
+"""
+Given an array-like data structure A[1..n], how many pairs
+(i, j) for all 1 <= i < j <= n such that A[i] > A[j]? These pairs are
+called inversions. Counting the number of such inversions in an array-like
+object is the important. Among other things, counting inversions can help
+us determine how close a given array is to being sorted.
+In this implementation, I provide two algorithms, a divide-and-conquer
+algorithm which runs in nlogn and the brute-force n^2 algorithm.
+"""
+
+
+def count_inversions_bf(arr):
+    """
+    Counts the number of inversions using a naive brute-force algorithm
+    Parameters
+    ----------
+    arr: arr: array-like, the list containing the items for which the number
+    of inversions is desired. The elements of `arr` must be comparable.
+    Returns
+    -------
+    num_inversions: The total number of inversions in `arr`
+    Examples
+    ---------
+     >>> count_inversions_bf([1, 4, 2, 4, 1])
+     4
+     >>> count_inversions_bf([1, 1, 2, 4, 4])
+     0
+     >>> count_inversions_bf([])
+     0
+    """
+
+    num_inversions = 0
+    n = len(arr)
+
+    for i in range(n - 1):
+        for j in range(i + 1, n):
+            if arr[i] > arr[j]:
+                num_inversions += 1
+
+    return num_inversions
+
+
+def count_inversions_recursive(arr):
+    """
+    Counts the number of inversions using a divide-and-conquer algorithm
+    Parameters
+    -----------
+    arr: array-like, the list containing the items for which the number
+    of inversions is desired. The elements of `arr` must be comparable.
+    Returns
+    -------
+    C: a sorted copy of `arr`.
+    num_inversions: int, the total number of inversions in 'arr'
+    Examples
+    --------
+    >>> count_inversions_recursive([1, 4, 2, 4, 1])
+    ([1, 1, 2, 4, 4], 4)
+    >>> count_inversions_recursive([1, 1, 2, 4, 4])
+    ([1, 1, 2, 4, 4], 0)
+    >>> count_inversions_recursive([])
+    ([], 0)
+    """
+    if len(arr) <= 1:
+        return arr, 0
+    mid = len(arr) // 2
+    p = arr[0:mid]
+    q = arr[mid:]
+
+    a, inversion_p = count_inversions_recursive(p)
+    b, inversions_q = count_inversions_recursive(q)
+    c, cross_inversions = _count_cross_inversions(a, b)
+
+    num_inversions = inversion_p + inversions_q + cross_inversions
+    return c, num_inversions
+
+
+def _count_cross_inversions(p, q):
+    """
+    Counts the inversions across two sorted arrays.
+    And combine the two arrays into one sorted array
+    For all 1<= i<=len(P) and for all 1 <= j <= len(Q),
+    if P[i] > Q[j], then (i, j) is a cross inversion
+    Parameters
+    ----------
+    P: array-like, sorted in non-decreasing order
+    Q: array-like, sorted in non-decreasing order
+    Returns
+    ------
+    R: array-like, a sorted array of the elements of `P` and `Q`
+    num_inversion: int, the number of inversions across `P` and `Q`
+    Examples
+    --------
+    >>> _count_cross_inversions([1, 2, 3], [0, 2, 5])
+    ([0, 1, 2, 2, 3, 5], 4)
+    >>> _count_cross_inversions([1, 2, 3], [3, 4, 5])
+    ([1, 2, 3, 3, 4, 5], 0)
+    """
+
+    r = []
+    i = j = num_inversion = 0
+    while i < len(p) and j < len(q):
+        if p[i] > q[j]:
+            # if P[1] > Q[j], then P[k] > Q[k] for all  i < k <= len(P)
+            # These are all inversions. The claim emerges from the
+            # property that P is sorted.
+            num_inversion += len(p) - i
+            r.append(q[j])
+            j += 1
+        else:
+            r.append(p[i])
+            i += 1
+
+    if i < len(p):
+        r.extend(p[i:])
+    else:
+        r.extend(q[j:])
+
+    return r, num_inversion
+
+
+def main():
+    arr_1 = [10, 2, 1, 5, 5, 2, 11]
+
+    # this arr has 8 inversions:
+    # (10, 2), (10, 1), (10, 5), (10, 5), (10, 2), (2, 1), (5, 2), (5, 2)
+
+    num_inversions_bf = count_inversions_bf(arr_1)
+    _, num_inversions_recursive = count_inversions_recursive(arr_1)
+
+    assert num_inversions_bf == num_inversions_recursive == 8
+
+    print("number of inversions = ", num_inversions_bf)
+
+    # testing an array with zero inversion (a sorted arr_1)
+
+    arr_1.sort()
+    num_inversions_bf = count_inversions_bf(arr_1)
+    _, num_inversions_recursive = count_inversions_recursive(arr_1)
+
+    assert num_inversions_bf == num_inversions_recursive == 0
+    print("number of inversions = ", num_inversions_bf)
+
+    # an empty list should also have zero inversions
+    arr_1 = []
+    num_inversions_bf = count_inversions_bf(arr_1)
+    _, num_inversions_recursive = count_inversions_recursive(arr_1)
+
+    assert num_inversions_bf == num_inversions_recursive == 0
+    print("number of inversions = ", num_inversions_bf)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python reference for inversion counting
- implement brute-force and divide-and-conquer inversion counters in Mochi
- record sample output from the Mochi VM

## Testing
- `python tests/github/TheAlgorithms/Python/divide_and_conquer/inversions.py`
- `/tmp/mochi_bin run tests/github/TheAlgorithms/Mochi/divide_and_conquer/inversions.mochi`
- `go test ./runtime/vm -run TestVMValidPrograms -tags slow` *(fails: golden mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6891a7a59df48320bb0bc926c6f39273