### PR TITLE
feat: add all construct dynamic programming

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/all_construct.mochi
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/all_construct.mochi
@@ -1,0 +1,65 @@
+/*
+Given a target string and a list of substrings (word bank),
+list every possible combination of words that can concatenate
+exactly to the target. The algorithm uses dynamic programming
+(tabulation) where each table entry at index i stores all word
+sequences that build the prefix target[0:i]. Starting from the
+empty string at position 0, we iterate through the table. When a
+word from the bank matches the slice of the target beginning at
+i, that word is appended to each combination at table[i] and the
+new combination is stored at table[i + len(word)].
+The entry at table[len(target)] therefore contains all complete
+constructions of the target.
+
+Time complexity is roughly O(n * m * k), where n is the target
+length, m is the size of the word bank, and k is the average
+number of combinations copied. Space complexity grows with the
+total size of stored combinations.
+*/
+
+fun allConstruct(target: string, wordBank: list<string>): list<list<string>> {
+  let tableSize = len(target) + 1
+  var table: list<list<list<string>>> = []
+  var idx = 0
+  while idx < tableSize {
+    var empty: list<list<string>> = []
+    table = append(table, empty)
+    idx = idx + 1
+  }
+  var base: list<string> = []
+  table[0] = [base]
+
+  var i = 0
+  while i < tableSize {
+    if len(table[i]) != 0 {
+      var w = 0
+      while w < len(wordBank) {
+        let word = wordBank[w]
+        let wordLen = len(word)
+        if target[i:i + wordLen] == word {
+          var k = 0
+          while k < len(table[i]) {
+            let way = table[i][k]
+            var combination: list<string> = []
+            var m = 0
+            while m < len(way) {
+              combination = append(combination, way[m])
+              m = m + 1
+            }
+            combination = append(combination, word)
+            let nextIndex = i + wordLen
+            table[nextIndex] = append(table[nextIndex], combination)
+            k = k + 1
+          }
+        }
+        w = w + 1
+      }
+    }
+    i = i + 1
+  }
+  return table[len(target)]
+}
+
+print(str(allConstruct("jwajalapa", ["jwa", "j", "w", "a", "la", "lapa"])))
+print(str(allConstruct("rajamati", ["s", "raj", "amat", "raja", "ma", "i", "t"])))
+print(str(allConstruct("hexagonosaurus", ["h", "ex", "hex", "ag", "ago", "ru", "auru", "rus", "go", "no", "o", "s"])))

--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/all_construct.out
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/all_construct.out
@@ -1,0 +1,3 @@
+[[jwa j a lapa] [j w a j a lapa]]
+[[raj amat i] [raja ma t i]]
+[[hex ago no s auru s] [h ex ago no s auru s] [hex ag o no s auru s] [h ex ag o no s auru s]]

--- a/tests/github/TheAlgorithms/Python/dynamic_programming/all_construct.py
+++ b/tests/github/TheAlgorithms/Python/dynamic_programming/all_construct.py
@@ -1,0 +1,60 @@
+"""
+Program to list all the ways a target string can be
+constructed from the given list of substrings
+"""
+
+from __future__ import annotations
+
+
+def all_construct(target: str, word_bank: list[str] | None = None) -> list[list[str]]:
+    """
+    returns the list containing all the possible
+    combinations a string(`target`) can be constructed from
+    the given list of substrings(`word_bank`)
+
+    >>> all_construct("hello", ["he", "l", "o"])
+    [['he', 'l', 'l', 'o']]
+    >>> all_construct("purple",["purp","p","ur","le","purpl"])
+    [['purp', 'le'], ['p', 'ur', 'p', 'le']]
+    """
+
+    word_bank = word_bank or []
+    # create a table
+    table_size: int = len(target) + 1
+
+    table: list[list[list[str]]] = []
+    for _ in range(table_size):
+        table.append([])
+    # seed value
+    table[0] = [[]]  # because empty string has empty combination
+
+    # iterate through the indices
+    for i in range(table_size):
+        # condition
+        if table[i] != []:
+            for word in word_bank:
+                # slice condition
+                if target[i : i + len(word)] == word:
+                    new_combinations: list[list[str]] = [
+                        [word, *way] for way in table[i]
+                    ]
+                    # adds the word to every combination the current position holds
+                    # now,push that combination to the table[i+len(word)]
+                    table[i + len(word)] += new_combinations
+
+    # combinations are in reverse order so reverse for better output
+    for combination in table[len(target)]:
+        combination.reverse()
+
+    return table[len(target)]
+
+
+if __name__ == "__main__":
+    print(all_construct("jwajalapa", ["jwa", "j", "w", "a", "la", "lapa"]))
+    print(all_construct("rajamati", ["s", "raj", "amat", "raja", "ma", "i", "t"]))
+    print(
+        all_construct(
+            "hexagonosaurus",
+            ["h", "ex", "hex", "ag", "ago", "ru", "auru", "rus", "go", "no", "o", "s"],
+        )
+    )


### PR DESCRIPTION
## Summary
- add missing Python implementation for dynamic-programming `all_construct`
- port `all_construct` to Mochi using tabulation and examples

## Testing
- `go test ./...`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/dynamic_programming/all_construct.mochi > tests/github/TheAlgorithms/Mochi/dynamic_programming/all_construct.out`


------
https://chatgpt.com/codex/tasks/task_e_6891aa0035908320b58bcff0bf1665b8