### PR TITLE
Add factorial dynamic programming example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/factorial.mochi
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/factorial.mochi
@@ -1,0 +1,31 @@
+/*
+Compute factorial of a non-negative integer using memoization.
+The recursive relation is n! = n * (n-1)! with base cases 0! = 1 and 1! = 1.
+A global list caches previously computed results so each value is computed at most once.
+This dynamic programming approach runs in O(n) time for new values and uses O(n) space.
+*/
+
+var memo: list<int> = [1, 1]
+
+fun factorial(num: int): int {
+  if num < 0 {
+    print("Number should not be negative.")
+    return 0
+  }
+  var m = memo
+  var i = len(m)
+  while i <= num {
+    m = append(m, i * m[i - 1])
+    i = i + 1
+  }
+  memo = m
+  return m[num]
+}
+
+print(str(factorial(7)))
+factorial(-1)
+var results: list<int> = []
+for i in 0..10 {
+  results = append(results, factorial(i))
+}
+print(str(results))

--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/factorial.out
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/factorial.out
@@ -1,0 +1,3 @@
+5040
+Number should not be negative.
+[1 1 2 6 24 120 720 5040 40320 362880]

--- a/tests/github/TheAlgorithms/Python/dynamic_programming/factorial.py
+++ b/tests/github/TheAlgorithms/Python/dynamic_programming/factorial.py
@@ -1,0 +1,27 @@
+# Factorial of a number using memoization
+
+from functools import lru_cache
+
+
+@lru_cache
+def factorial(num: int) -> int:
+    """
+    >>> factorial(7)
+    5040
+    >>> factorial(-1)
+    Traceback (most recent call last):
+      ...
+    ValueError: Number should not be negative.
+    >>> [factorial(i) for i in range(10)]
+    [1, 1, 2, 6, 24, 120, 720, 5040, 40320, 362880]
+    """
+    if num < 0:
+        raise ValueError("Number should not be negative.")
+
+    return 1 if num in (0, 1) else num * factorial(num - 1)
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python reference implementation for factorial with memoization
- implement Mochi version using a memoized dynamic programming list
- generate runtime output for the new example

## Testing
- `go run cmd/mochi/main.go run tests/github/TheAlgorithms/Mochi/dynamic_programming/factorial.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6891acbaeb6883208116c11a21c7ed92