### PR TITLE
Add Mochi implementation for Fizz Buzz

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/fizz_buzz.mochi
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/fizz_buzz.mochi
@@ -1,0 +1,37 @@
+/*
+Fizz Buzz is a simple programming exercise used to teach control flow.
+Starting from a given number, each subsequent number is examined up to a
+specified limit. For multiples of three the algorithm outputs "Fizz",
+for multiples of five it outputs "Buzz", and for numbers divisible by
+both three and five it outputs "FizzBuzz". All other numbers are
+represented as themselves. The concatenated results form the final
+string. The algorithm runs in O(n) time where n is the range length.
+*/
+
+fun fizz_buzz(number: int, iterations: int): string {
+  if number < 1 {
+    panic("starting number must be an integer and be more than 0")
+  }
+  if iterations < 1 {
+    panic("Iterations must be done more than 0 times to play FizzBuzz")
+  }
+  var out = ""
+  var n = number
+  while n <= iterations {
+    if n % 3 == 0 {
+      out = out + "Fizz"
+    }
+    if n % 5 == 0 {
+      out = out + "Buzz"
+    }
+    if n % 3 != 0 && n % 5 != 0 {
+      out = out + str(n)
+    }
+    out = out + " "
+    n = n + 1
+  }
+  return out
+}
+
+print(fizz_buzz(1, 7))
+print(fizz_buzz(1, 15))

--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/fizz_buzz.out
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/fizz_buzz.out
@@ -1,0 +1,2 @@
+1 2 Fizz 4 Buzz Fizz 7 
+1 2 Fizz 4 Buzz Fizz 7 8 Fizz Buzz 11 Fizz 13 14 FizzBuzz 

--- a/tests/github/TheAlgorithms/Python/dynamic_programming/fizz_buzz.py
+++ b/tests/github/TheAlgorithms/Python/dynamic_programming/fizz_buzz.py
@@ -1,0 +1,65 @@
+# https://en.wikipedia.org/wiki/Fizz_buzz#Programming
+
+
+def fizz_buzz(number: int, iterations: int) -> str:
+    """
+    | Plays FizzBuzz.
+    | Prints Fizz if number is a multiple of ``3``.
+    | Prints Buzz if its a multiple of ``5``.
+    | Prints FizzBuzz if its a multiple of both ``3`` and ``5`` or ``15``.
+    | Else Prints The Number Itself.
+
+    >>> fizz_buzz(1,7)
+    '1 2 Fizz 4 Buzz Fizz 7 '
+    >>> fizz_buzz(1,0)
+    Traceback (most recent call last):
+      ...
+    ValueError: Iterations must be done more than 0 times to play FizzBuzz
+    >>> fizz_buzz(-5,5)
+    Traceback (most recent call last):
+        ...
+    ValueError: starting number must be
+                             and integer and be more than 0
+    >>> fizz_buzz(10,-5)
+    Traceback (most recent call last):
+        ...
+    ValueError: Iterations must be done more than 0 times to play FizzBuzz
+    >>> fizz_buzz(1.5,5)
+    Traceback (most recent call last):
+        ...
+    ValueError: starting number must be
+                             and integer and be more than 0
+    >>> fizz_buzz(1,5.5)
+    Traceback (most recent call last):
+        ...
+    ValueError: iterations must be defined as integers
+    """
+    if not isinstance(iterations, int):
+        raise ValueError("iterations must be defined as integers")
+    if not isinstance(number, int) or not number >= 1:
+        raise ValueError(
+            """starting number must be
+                         and integer and be more than 0"""
+        )
+    if not iterations >= 1:
+        raise ValueError("Iterations must be done more than 0 times to play FizzBuzz")
+
+    out = ""
+    while number <= iterations:
+        if number % 3 == 0:
+            out += "Fizz"
+        if number % 5 == 0:
+            out += "Buzz"
+        if 0 not in (number % 3, number % 5):
+            out += str(number)
+
+        # print(out)
+        number += 1
+        out += " "
+    return out
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python Fizz Buzz algorithm and corresponding Mochi implementation
- implement Fizz Buzz logic in pure Mochi with validation and output tests

## Testing
- `python tests/github/TheAlgorithms/Python/dynamic_programming/fizz_buzz.py`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/dynamic_programming/fizz_buzz.mochi > tests/github/TheAlgorithms/Mochi/dynamic_programming/fizz_buzz.out`


------
https://chatgpt.com/codex/tasks/task_e_6891acd535788320b4158f11b4086d9c