### PR TITLE
Add Mochi version of largest divisible subset

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/largest_divisible_subset.mochi
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/largest_divisible_subset.mochi
@@ -1,0 +1,77 @@
+/*
+Find the largest subset of integers such that for every pair (x, y) in the subset,
+one divides the other. The algorithm sorts the numbers in ascending order and uses
+dynamic programming to build the longest chain where each number is divisible by its
+predecessor. A `memo` list stores the length of the longest valid chain ending at each
+index, while a `prev` list tracks predecessors for reconstruction. Zero is treated as
+a universal divisor so that multiple zeros are chained together as in the original
+Python implementation. The subset is reconstructed by following the `prev` indices
+from the element with maximal chain length back to the start.
+*/
+
+fun sort_list(nums: list<int>): list<int> {
+  var arr = nums
+  var i = 1
+  while i < len(arr) {
+    let key = arr[i]
+    var j = i - 1
+    while j >= 0 && arr[j] > key {
+      arr[j + 1] = arr[j]
+      j = j - 1
+    }
+    arr[j + 1] = key
+    i = i + 1
+  }
+  return arr
+}
+
+fun largest_divisible_subset(items: list<int>): list<int> {
+  if len(items) == 0 { return [] }
+  var nums = sort_list(items)
+  let n = len(nums)
+  var memo: list<int> = []
+  var prev: list<int> = []
+  var i = 0
+  while i < n {
+    memo = append(memo, 1)
+    prev = append(prev, i)
+    i = i + 1
+  }
+  i = 0
+  while i < n {
+    var j = 0
+    while j < i {
+      if (nums[j] == 0 || nums[i] % nums[j] == 0) && memo[j] + 1 > memo[i] {
+        memo[i] = memo[j] + 1
+        prev[i] = j
+      }
+      j = j + 1
+    }
+    i = i + 1
+  }
+  var ans = 0 - 1
+  var last_index = 0 - 1
+  i = 0
+  while i < n {
+    if memo[i] > ans {
+      ans = memo[i]
+      last_index = i
+    }
+    i = i + 1
+  }
+  if last_index == 0 - 1 { return [] }
+  var result: list<int> = [nums[last_index]]
+  while prev[last_index] != last_index {
+    last_index = prev[last_index]
+    result = append(result, nums[last_index])
+  }
+  return result
+}
+
+fun main() {
+  let items = [1, 16, 7, 8, 4]
+  let subset = largest_divisible_subset(items)
+  print("The longest divisible subset of " + str(items) + " is " + str(subset) + ".")
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/largest_divisible_subset.out
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/largest_divisible_subset.out
@@ -1,0 +1,1 @@
+The longest divisible subset of [1 16 7 8 4] is [16 8 4 1].

--- a/tests/github/TheAlgorithms/Python/dynamic_programming/largest_divisible_subset.py
+++ b/tests/github/TheAlgorithms/Python/dynamic_programming/largest_divisible_subset.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+
+def largest_divisible_subset(items: list[int]) -> list[int]:
+    """
+    Algorithm to find the biggest subset in the given array such that for any 2 elements
+    x and y in the subset, either x divides y or y divides x.
+    >>> largest_divisible_subset([1, 16, 7, 8, 4])
+    [16, 8, 4, 1]
+    >>> largest_divisible_subset([1, 2, 3])
+    [2, 1]
+    >>> largest_divisible_subset([-1, -2, -3])
+    [-3]
+    >>> largest_divisible_subset([1, 2, 4, 8])
+    [8, 4, 2, 1]
+    >>> largest_divisible_subset((1, 2, 4, 8))
+    [8, 4, 2, 1]
+    >>> largest_divisible_subset([1, 1, 1])
+    [1, 1, 1]
+    >>> largest_divisible_subset([0, 0, 0])
+    [0, 0, 0]
+    >>> largest_divisible_subset([-1, -1, -1])
+    [-1, -1, -1]
+    >>> largest_divisible_subset([])
+    []
+    """
+    # Sort the array in ascending order as the sequence does not matter we only have to
+    # pick up a subset.
+    items = sorted(items)
+
+    number_of_items = len(items)
+
+    # Initialize memo with 1s and hash with increasing numbers
+    memo = [1] * number_of_items
+    hash_array = list(range(number_of_items))
+
+    # Iterate through the array
+    for i, item in enumerate(items):
+        for prev_index in range(i):
+            if ((items[prev_index] != 0 and item % items[prev_index]) == 0) and (
+                (1 + memo[prev_index]) > memo[i]
+            ):
+                memo[i] = 1 + memo[prev_index]
+                hash_array[i] = prev_index
+
+    ans = -1
+    last_index = -1
+
+    # Find the maximum length and its corresponding index
+    for i, memo_item in enumerate(memo):
+        if memo_item > ans:
+            ans = memo_item
+            last_index = i
+
+    # Reconstruct the divisible subset
+    if last_index == -1:
+        return []
+    result = [items[last_index]]
+    while hash_array[last_index] != last_index:
+        last_index = hash_array[last_index]
+        result.append(items[last_index])
+
+    return result
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()
+
+    items = [1, 16, 7, 8, 4]
+    print(
+        f"The longest divisible subset of {items} is {largest_divisible_subset(items)}."
+    )


### PR DESCRIPTION
## Summary
- add original Python largest_divisible_subset algorithm
- port largest_divisible_subset to pure Mochi with dynamic programming and zero handling
- include generated `.out` after running with the VM

## Testing
- `bin/mochi run tests/github/TheAlgorithms/Mochi/dynamic_programming/largest_divisible_subset.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891ad4267608320a2c6558d9f310be0