### PR TITLE
Add Mochi implementation for LCS

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/longest_common_subsequence.mochi
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/longest_common_subsequence.mochi
@@ -1,0 +1,75 @@
+/*
+Longest Common Subsequence
+-------------------------
+Given two strings, find the longest subsequence present in both.
+This dynamic programming approach builds a (m+1) x (n+1) table where
+`dp[i][j]` stores the length of the LCS of prefixes `x[:i]` and `y[:j]`.
+After filling the table, we reconstruct the subsequence by tracing
+back from `dp[m][n]`, moving diagonally when characters match and
+otherwise moving toward the larger neighboring cell.
+This runs in O(m * n) time and O(m * n) space.
+*/
+
+type LcsResult { length: int, sequence: string }
+
+fun zeros_matrix(rows: int, cols: int): list<list<int>> {
+  var matrix: list<list<int>> = []
+  var i = 0
+  while i <= rows {
+    var row: list<int> = []
+    var j = 0
+    while j <= cols {
+      row = append(row, 0)
+      j = j + 1
+    }
+    matrix = append(matrix, row)
+    i = i + 1
+  }
+  return matrix
+}
+
+fun longest_common_subsequence(x: string, y: string): LcsResult {
+  let m = len(x)
+  let n = len(y)
+  var dp = zeros_matrix(m, n)
+
+  var i = 1
+  while i <= m {
+    var j = 1
+    while j <= n {
+      if x[i - 1] == y[j - 1] {
+        dp[i][j] = dp[i - 1][j - 1] + 1
+      } else {
+        if dp[i - 1][j] > dp[i][j - 1] {
+          dp[i][j] = dp[i - 1][j]
+        } else {
+          dp[i][j] = dp[i][j - 1]
+        }
+      }
+      j = j + 1
+    }
+    i = i + 1
+  }
+
+  var seq = ""
+  var i2 = m
+  var j2 = n
+  while i2 > 0 && j2 > 0 {
+    if x[i2 - 1] == y[j2 - 1] {
+      seq = x[i2 - 1] + seq
+      i2 = i2 - 1
+      j2 = j2 - 1
+    } else if dp[i2 - 1][j2] >= dp[i2][j2 - 1] {
+      i2 = i2 - 1
+    } else {
+      j2 = j2 - 1
+    }
+  }
+
+  return LcsResult { length: dp[m][n], sequence: seq }
+}
+
+let a = "AGGTAB"
+let b = "GXTXAYB"
+let res = longest_common_subsequence(a, b)
+print("len = " + str(res.length) + ", sub-sequence = " + res.sequence)

--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/longest_common_subsequence.out
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/longest_common_subsequence.out
@@ -1,0 +1,1 @@
+len = 4, sub-sequence = GTAB

--- a/tests/github/TheAlgorithms/Python/dynamic_programming/longest_common_subsequence.py
+++ b/tests/github/TheAlgorithms/Python/dynamic_programming/longest_common_subsequence.py
@@ -1,0 +1,95 @@
+"""
+LCS Problem Statement: Given two sequences, find the length of longest subsequence
+present in both of them.  A subsequence is a sequence that appears in the same relative
+order, but not necessarily continuous.
+Example:"abc", "abg" are subsequences of "abcdefgh".
+"""
+
+
+def longest_common_subsequence(x: str, y: str):
+    """
+    Finds the longest common subsequence between two strings. Also returns the
+    The subsequence found
+
+    Parameters
+    ----------
+
+    x: str, one of the strings
+    y: str, the other string
+
+    Returns
+    -------
+    L[m][n]: int, the length of the longest subsequence. Also equal to len(seq)
+    Seq: str, the subsequence found
+
+    >>> longest_common_subsequence("programming", "gaming")
+    (6, 'gaming')
+    >>> longest_common_subsequence("physics", "smartphone")
+    (2, 'ph')
+    >>> longest_common_subsequence("computer", "food")
+    (1, 'o')
+    >>> longest_common_subsequence("", "abc")  # One string is empty
+    (0, '')
+    >>> longest_common_subsequence("abc", "")  # Other string is empty
+    (0, '')
+    >>> longest_common_subsequence("", "")  # Both strings are empty
+    (0, '')
+    >>> longest_common_subsequence("abc", "def")  # No common subsequence
+    (0, '')
+    >>> longest_common_subsequence("abc", "abc")  # Identical strings
+    (3, 'abc')
+    >>> longest_common_subsequence("a", "a")  # Single character match
+    (1, 'a')
+    >>> longest_common_subsequence("a", "b")  # Single character no match
+    (0, '')
+    >>> longest_common_subsequence("abcdef", "ace")  # Interleaved subsequence
+    (3, 'ace')
+    >>> longest_common_subsequence("ABCD", "ACBD")  # No repeated characters
+    (3, 'ABD')
+    """
+    # find the length of strings
+
+    assert x is not None
+    assert y is not None
+
+    m = len(x)
+    n = len(y)
+
+    # declaring the array for storing the dp values
+    dp = [[0] * (n + 1) for _ in range(m + 1)]
+
+    for i in range(1, m + 1):
+        for j in range(1, n + 1):
+            match = 1 if x[i - 1] == y[j - 1] else 0
+
+            dp[i][j] = max(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1] + match)
+
+    seq = ""
+    i, j = m, n
+    while i > 0 and j > 0:
+        match = 1 if x[i - 1] == y[j - 1] else 0
+
+        if dp[i][j] == dp[i - 1][j - 1] + match:
+            if match == 1:
+                seq = x[i - 1] + seq
+            i -= 1
+            j -= 1
+        elif dp[i][j] == dp[i - 1][j]:
+            i -= 1
+        else:
+            j -= 1
+
+    return dp[m][n], seq
+
+
+if __name__ == "__main__":
+    a = "AGGTAB"
+    b = "GXTXAYB"
+    expected_ln = 4
+    expected_subseq = "GTAB"
+
+    ln, subseq = longest_common_subsequence(a, b)
+    print("len =", ln, ", sub-sequence =", subseq)
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python reference for dynamic_programming/longest_common_subsequence
- implement longest common subsequence in Mochi using dynamic programming
- include execution output for sample input

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/dynamic_programming/longest_common_subsequence.mochi`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6891ad5e001883208d59581363e89198