### PR TITLE
feat: add knapsack DP example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/knapsack.mochi
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/knapsack.mochi
@@ -1,0 +1,143 @@
+/*
+0/1 Knapsack Dynamic Programming
+
+Given n items with weights wt[i] and values val[i] and a knapsack of
+capacity W, determine the maximum achievable value without exceeding
+the weight limit.  This implementation mirrors the classic dynamic
+programming approach:
+
+1. Iterative DP builds a matrix dp where dp[i][j] is the best value
+   using the first i items and capacity j.
+2. mf_knapsack demonstrates the same recurrence with memoization.
+3. construct_solution rebuilds an example optimal subset by tracing
+   decisions in the filled DP table.
+*/
+
+var f: list<list<int>>
+
+fun max_int(a: int, b: int): int {
+  if a > b { return a } else { return b }
+}
+
+fun init_f(n: int, w: int): list<list<int>> {
+  var table: list<list<int>>
+  var i = 0
+  while i <= n {
+    var row: list<int>
+    var j = 0
+    while j <= w {
+      if i == 0 || j == 0 {
+        row = append(row, 0)
+      } else {
+        row = append(row, -1)
+      }
+      j = j + 1
+    }
+    table = append(table, row)
+    i = i + 1
+  }
+  return table
+}
+
+fun mf_knapsack(i: int, wt: list<int>, val: list<int>, j: int): int {
+  if f[i][j] < 0 {
+    if j < wt[i - 1] {
+      f[i][j] = mf_knapsack(i - 1, wt, val, j)
+    } else {
+      let without_item = mf_knapsack(i - 1, wt, val, j)
+      let with_item = mf_knapsack(i - 1, wt, val, j - wt[i - 1]) + val[i - 1]
+      f[i][j] = max_int(without_item, with_item)
+    }
+  }
+  return f[i][j]
+}
+
+fun create_matrix(rows: int, cols: int): list<list<int>> {
+  var matrix: list<list<int>>
+  var i = 0
+  while i <= rows {
+    var row: list<int>
+    var j = 0
+    while j <= cols {
+      row = append(row, 0)
+      j = j + 1
+    }
+    matrix = append(matrix, row)
+    i = i + 1
+  }
+  return matrix
+}
+
+fun knapsack(w: int, wt: list<int>, val: list<int>, n: int): list<list<int>> {
+  var dp: list<list<int>> = create_matrix(n, w)
+  var i = 1
+  while i <= n {
+    var w_ = 1
+    while w_ <= w {
+      if wt[i - 1] <= w_ {
+        let include = val[i - 1] + dp[i - 1][w_ - wt[i - 1]]
+        let exclude = dp[i - 1][w_]
+        dp[i][w_] = max_int(include, exclude)
+      } else {
+        dp[i][w_] = dp[i - 1][w_]
+      }
+      w_ = w_ + 1
+    }
+    i = i + 1
+  }
+  return dp
+}
+
+fun construct_solution(dp: list<list<int>>, wt: list<int>, i: int, j: int, optimal_set: list<int>): list<int> {
+  if i > 0 && j > 0 {
+    if dp[i - 1][j] == dp[i][j] {
+      return construct_solution(dp, wt, i - 1, j, optimal_set)
+    } else {
+      let with_prev = construct_solution(dp, wt, i - 1, j - wt[i - 1], optimal_set)
+      return append(with_prev, i)
+    }
+  }
+  return optimal_set
+}
+
+type KnapsackResult {
+  value: int,
+  subset: list<int>
+}
+
+fun knapsack_with_example_solution(w: int, wt: list<int>, val: list<int>): KnapsackResult {
+  let num_items = len(wt)
+  let dp_table = knapsack(w, wt, val, num_items)
+  let optimal_val = dp_table[num_items][w]
+  let subset = construct_solution(dp_table, wt, num_items, w, [])
+  return { value: optimal_val, subset: subset }
+}
+
+fun format_set(xs: list<int>): string {
+  var res = "{"
+  var i = 0
+  while i < len(xs) {
+    res = res + str(xs[i])
+    if i + 1 < len(xs) {
+      res = res + ", "
+    }
+    i = i + 1
+  }
+  res = res + "}"
+  return res
+}
+
+let val_list: list<int> = [3, 2, 4, 4]
+let wt_list: list<int> = [4, 3, 2, 3]
+let n: int = 4
+let w_cap: int = 6
+
+f = init_f(n, w_cap)
+let dp_table = knapsack(w_cap, wt_list, val_list, n)
+let optimal_solution = dp_table[n][w_cap]
+print(optimal_solution)
+print(mf_knapsack(n, wt_list, val_list, w_cap))
+
+let example = knapsack_with_example_solution(w_cap, wt_list, val_list)
+print("optimal_value = " + str(example.value))
+print("An optimal subset corresponding to the optimal value " + format_set(example.subset))

--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/knapsack.out
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/knapsack.out
@@ -1,0 +1,4 @@
+8
+8
+optimal_value = 8
+An optimal subset corresponding to the optimal value {3, 4}

--- a/tests/github/TheAlgorithms/Python/dynamic_programming/knapsack.py
+++ b/tests/github/TheAlgorithms/Python/dynamic_programming/knapsack.py
@@ -1,0 +1,153 @@
+"""
+Given weights and values of n items, put these items in a knapsack of
+capacity W to get the maximum total value in the knapsack.
+
+Note that only the integer weights 0-1 knapsack problem is solvable
+using dynamic programming.
+"""
+
+
+def mf_knapsack(i, wt, val, j):
+    """
+    This code involves the concept of memory functions. Here we solve the subproblems
+    which are needed unlike the below example
+    F is a 2D array with ``-1`` s filled up
+    """
+    global f  # a global dp table for knapsack
+    if f[i][j] < 0:
+        if j < wt[i - 1]:
+            val = mf_knapsack(i - 1, wt, val, j)
+        else:
+            val = max(
+                mf_knapsack(i - 1, wt, val, j),
+                mf_knapsack(i - 1, wt, val, j - wt[i - 1]) + val[i - 1],
+            )
+        f[i][j] = val
+    return f[i][j]
+
+
+def knapsack(w, wt, val, n):
+    dp = [[0] * (w + 1) for _ in range(n + 1)]
+
+    for i in range(1, n + 1):
+        for w_ in range(1, w + 1):
+            if wt[i - 1] <= w_:
+                dp[i][w_] = max(val[i - 1] + dp[i - 1][w_ - wt[i - 1]], dp[i - 1][w_])
+            else:
+                dp[i][w_] = dp[i - 1][w_]
+
+    return dp[n][w_], dp
+
+
+def knapsack_with_example_solution(w: int, wt: list, val: list):
+    """
+    Solves the integer weights knapsack problem returns one of
+    the several possible optimal subsets.
+
+    Parameters
+    ----------
+
+    * `w`: int, the total maximum weight for the given knapsack problem.
+    * `wt`: list, the vector of weights for all items where ``wt[i]`` is the weight
+       of the ``i``-th item.
+    * `val`: list, the vector of values for all items where ``val[i]`` is the value
+      of the ``i``-th item
+
+    Returns
+    -------
+
+    * `optimal_val`: float, the optimal value for the given knapsack problem
+    * `example_optional_set`: set, the indices of one of the optimal subsets
+      which gave rise to the optimal value.
+
+    Examples
+    --------
+
+    >>> knapsack_with_example_solution(10, [1, 3, 5, 2], [10, 20, 100, 22])
+    (142, {2, 3, 4})
+    >>> knapsack_with_example_solution(6, [4, 3, 2, 3], [3, 2, 4, 4])
+    (8, {3, 4})
+    >>> knapsack_with_example_solution(6, [4, 3, 2, 3], [3, 2, 4])
+    Traceback (most recent call last):
+        ...
+    ValueError: The number of weights must be the same as the number of values.
+    But got 4 weights and 3 values
+    """
+    if not (isinstance(wt, (list, tuple)) and isinstance(val, (list, tuple))):
+        raise ValueError(
+            "Both the weights and values vectors must be either lists or tuples"
+        )
+
+    num_items = len(wt)
+    if num_items != len(val):
+        msg = (
+            "The number of weights must be the same as the number of values.\n"
+            f"But got {num_items} weights and {len(val)} values"
+        )
+        raise ValueError(msg)
+    for i in range(num_items):
+        if not isinstance(wt[i], int):
+            msg = (
+                "All weights must be integers but got weight of "
+                f"type {type(wt[i])} at index {i}"
+            )
+            raise TypeError(msg)
+
+    optimal_val, dp_table = knapsack(w, wt, val, num_items)
+    example_optional_set: set = set()
+    _construct_solution(dp_table, wt, num_items, w, example_optional_set)
+
+    return optimal_val, example_optional_set
+
+
+def _construct_solution(dp: list, wt: list, i: int, j: int, optimal_set: set):
+    """
+    Recursively reconstructs one of the optimal subsets given
+    a filled DP table and the vector of weights
+
+    Parameters
+    ----------
+
+    * `dp`: list of list, the table of a solved integer weight dynamic programming
+      problem
+    * `wt`: list or tuple, the vector of weights of the items
+    * `i`: int, the index of the item under consideration
+    * `j`: int, the current possible maximum weight
+    * `optimal_set`: set, the optimal subset so far. This gets modified by the function.
+
+    Returns
+    -------
+
+    ``None``
+    """
+    # for the current item i at a maximum weight j to be part of an optimal subset,
+    # the optimal value at (i, j) must be greater than the optimal value at (i-1, j).
+    # where i - 1 means considering only the previous items at the given maximum weight
+    if i > 0 and j > 0:
+        if dp[i - 1][j] == dp[i][j]:
+            _construct_solution(dp, wt, i - 1, j, optimal_set)
+        else:
+            optimal_set.add(i)
+            _construct_solution(dp, wt, i - 1, j - wt[i - 1], optimal_set)
+
+
+if __name__ == "__main__":
+    """
+    Adding test case for knapsack
+    """
+    val = [3, 2, 4, 4]
+    wt = [4, 3, 2, 3]
+    n = 4
+    w = 6
+    f = [[0] * (w + 1)] + [[0] + [-1] * (w + 1) for _ in range(n + 1)]
+    optimal_solution, _ = knapsack(w, wt, val, n)
+    print(optimal_solution)
+    print(mf_knapsack(n, wt, val, w))  # switched the n and w
+
+    # testing the dynamic programming problem with example
+    # the optimal subset for the above example are items 3 and 4
+    optimal_solution, optimal_subset = knapsack_with_example_solution(w, wt, val)
+    assert optimal_solution == 8
+    assert optimal_subset == {3, 4}
+    print("optimal_value = ", optimal_solution)
+    print("An optimal subset corresponding to the optimal value", optimal_subset)


### PR DESCRIPTION
## Summary
- add missing Python knapsack dynamic programming example
- port knapsack algorithm to Mochi with memoized and iterative DP plus solution reconstruction

## Testing
- `node index.js run tests/github/TheAlgorithms/Mochi/dynamic_programming/knapsack.mochi` *(fails: Mochi binary not found)*
- `npm install` *(fails: connect ENETUNREACH 140.82.113.3:443)*


------
https://chatgpt.com/codex/tasks/task_e_6891ad3841c48320aa9f29c8863904cd