### PR TITLE
Add Mochi implementation for longest common substring

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/longest_common_substring.mochi
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/longest_common_substring.mochi
@@ -1,0 +1,54 @@
+/*
+Given two strings, find the longest substring present in both.
+The algorithm uses dynamic programming where dp[i][j] stores
+length of the longest common suffix of the prefixes text1[0:i]
+and text2[0:j]. When characters match, the value extends the
+previous diagonal cell; otherwise it resets to 0. Tracking the
+maximum length and its ending position allows extraction of the
+longest common substring in O(m*n) time.
+*/
+
+fun longest_common_substring(text1: string, text2: string): string {
+  if len(text1) == 0 || len(text2) == 0 {
+    return ""
+  }
+  let m = len(text1)
+  let n = len(text2)
+
+  var dp: list<list<int>> = []
+  var i = 0
+  while i < m + 1 {
+    var row: list<int> = []
+    var j = 0
+    while j < n + 1 {
+      row = append(row, 0)
+      j = j + 1
+    }
+    dp = append(dp, row)
+    i = i + 1
+  }
+
+  var end_pos = 0
+  var max_len = 0
+  var ii = 1
+  while ii <= m {
+    var jj = 1
+    while jj <= n {
+      if substring(text1, ii - 1, ii) == substring(text2, jj - 1, jj) {
+        dp[ii][jj] = 1 + dp[ii - 1][jj - 1]
+        if dp[ii][jj] > max_len {
+          max_len = dp[ii][jj]
+          end_pos = ii
+        }
+      }
+      jj = jj + 1
+    }
+    ii = ii + 1
+  }
+
+  return substring(text1, end_pos - max_len, end_pos)
+}
+
+print(longest_common_substring("abcdef", "xabded"))
+print("\n")
+print(longest_common_substring("zxabcdezy", "yzabcdezx"))

--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/longest_common_substring.out
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/longest_common_substring.out
@@ -1,0 +1,4 @@
+ab
+
+
+abcdez

--- a/tests/github/TheAlgorithms/Python/dynamic_programming/longest_common_substring.py
+++ b/tests/github/TheAlgorithms/Python/dynamic_programming/longest_common_substring.py
@@ -1,0 +1,70 @@
+"""
+Longest Common Substring Problem Statement:
+    Given two sequences, find the
+    longest common substring present in both of them. A substring is
+    necessarily continuous.
+
+Example:
+    ``abcdef`` and ``xabded`` have two longest common substrings, ``ab`` or ``de``.
+    Therefore, algorithm should return any one of them.
+"""
+
+
+def longest_common_substring(text1: str, text2: str) -> str:
+    """
+    Finds the longest common substring between two strings.
+
+    >>> longest_common_substring("", "")
+    ''
+    >>> longest_common_substring("a","")
+    ''
+    >>> longest_common_substring("", "a")
+    ''
+    >>> longest_common_substring("a", "a")
+    'a'
+    >>> longest_common_substring("abcdef", "bcd")
+    'bcd'
+    >>> longest_common_substring("abcdef", "xabded")
+    'ab'
+    >>> longest_common_substring("GeeksforGeeks", "GeeksQuiz")
+    'Geeks'
+    >>> longest_common_substring("abcdxyz", "xyzabcd")
+    'abcd'
+    >>> longest_common_substring("zxabcdezy", "yzabcdezx")
+    'abcdez'
+    >>> longest_common_substring("OldSite:GeeksforGeeks.org", "NewSite:GeeksQuiz.com")
+    'Site:Geeks'
+    >>> longest_common_substring(1, 1)
+    Traceback (most recent call last):
+        ...
+    ValueError: longest_common_substring() takes two strings for inputs
+    """
+
+    if not (isinstance(text1, str) and isinstance(text2, str)):
+        raise ValueError("longest_common_substring() takes two strings for inputs")
+
+    if not text1 or not text2:
+        return ""
+
+    text1_length = len(text1)
+    text2_length = len(text2)
+
+    dp = [[0] * (text2_length + 1) for _ in range(text1_length + 1)]
+    end_pos = 0
+    max_length = 0
+
+    for i in range(1, text1_length + 1):
+        for j in range(1, text2_length + 1):
+            if text1[i - 1] == text2[j - 1]:
+                dp[i][j] = 1 + dp[i - 1][j - 1]
+                if dp[i][j] > max_length:
+                    end_pos = i
+                    max_length = dp[i][j]
+
+    return text1[end_pos - max_length : end_pos]
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add missing Python reference for longest_common_substring dynamic programming example
- implement longest common substring in Mochi with DP table and example outputs

## Testing
- `bin/mochi run tests/github/TheAlgorithms/Mochi/dynamic_programming/longest_common_substring.mochi > tests/github/TheAlgorithms/Mochi/dynamic_programming/longest_common_substring.out`

------
https://chatgpt.com/codex/tasks/task_e_6891ad6cb52483208556f8e95b901721