### PR TITLE
Add Mochi solution for longest increasing subsequence

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/longest_increasing_subsequence.mochi
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/longest_increasing_subsequence.mochi
@@ -1,0 +1,62 @@
+/*
+Find the longest increasing subsequence (LIS) of a list of integers.
+
+The LIS of a sequence is the longest subsequence where each element is
+strictly greater than the previous one.  This implementation mirrors the
+recursive pivot-based strategy from the reference Python version:
+- Choose the first element as a pivot.
+- Search for the first smaller element and recursively compute the LIS
+  starting from that position.
+- Build another candidate by filtering the remaining elements that are
+  greater than or equal to the pivot, prepend the pivot and recurse.
+- Return the longer of the two candidates.
+The algorithm runs in O(n^2) time in the worst case.
+*/
+
+fun longest_subsequence(xs: list<int>): list<int> {
+  let n = len(xs)
+  if n <= 1 {
+    return xs
+  }
+  let pivot = xs[0]
+  var is_found = false
+  var i = 1
+  var longest_subseq: list<int> = []
+  while !is_found && i < n {
+    if xs[i] < pivot {
+      is_found = true
+      var temp_array = slice(xs, i, n)
+      temp_array = longest_subsequence(temp_array)
+      if len(temp_array) > len(longest_subseq) {
+        longest_subseq = temp_array
+      }
+    } else {
+      i = i + 1
+    }
+  }
+  var filtered: list<int> = []
+  var j = 1
+  while j < n {
+    if xs[j] >= pivot {
+      filtered = append(filtered, xs[j])
+    }
+    j = j + 1
+  }
+  var candidate: list<int> = []
+  candidate = append(candidate, pivot)
+  candidate = concat(candidate, longest_subsequence(filtered))
+  if len(candidate) > len(longest_subseq) {
+    return candidate
+  } else {
+    return longest_subseq
+  }
+}
+
+test "examples" {
+  expect longest_subsequence([10, 22, 9, 33, 21, 50, 41, 60, 80]) == [10, 22, 33, 41, 60, 80]
+  expect longest_subsequence([4, 8, 7, 5, 1, 12, 2, 3, 9]) == [1, 2, 3, 9]
+  expect longest_subsequence([28, 26, 12, 23, 35, 39]) == [12, 23, 35, 39]
+  expect longest_subsequence([9, 8, 7, 6, 5, 7]) == [5, 7]
+  expect longest_subsequence([1, 1, 1]) == [1, 1, 1]
+  expect longest_subsequence([]) == []
+}

--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/longest_increasing_subsequence.out
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/longest_increasing_subsequence.out
@@ -1,0 +1,2 @@
+[94;1mtests/github/TheAlgorithms/Mochi/dynamic_programming/longest_increasing_subsequence.mochi[0;22m
+   [33mtest[0m examples                       ... [32mok[0m (11.0ms)

--- a/tests/github/TheAlgorithms/Python/dynamic_programming/longest_increasing_subsequence.py
+++ b/tests/github/TheAlgorithms/Python/dynamic_programming/longest_increasing_subsequence.py
@@ -1,0 +1,67 @@
+"""
+Author  : Mehdi ALAOUI
+
+This is a pure Python implementation of Dynamic Programming solution to the longest
+increasing subsequence of a given sequence.
+
+The problem is:
+    Given an array, to find the longest and increasing sub-array in that given array and
+    return it.
+
+Example:
+    ``[10, 22, 9, 33, 21, 50, 41, 60, 80]`` as input will return
+    ``[10, 22, 33, 41, 60, 80]`` as output
+"""
+
+from __future__ import annotations
+
+
+def longest_subsequence(array: list[int]) -> list[int]:  # This function is recursive
+    """
+    Some examples
+
+    >>> longest_subsequence([10, 22, 9, 33, 21, 50, 41, 60, 80])
+    [10, 22, 33, 41, 60, 80]
+    >>> longest_subsequence([4, 8, 7, 5, 1, 12, 2, 3, 9])
+    [1, 2, 3, 9]
+    >>> longest_subsequence([28, 26, 12, 23, 35, 39])
+    [12, 23, 35, 39]
+    >>> longest_subsequence([9, 8, 7, 6, 5, 7])
+    [5, 7]
+    >>> longest_subsequence([1, 1, 1])
+    [1, 1, 1]
+    >>> longest_subsequence([])
+    []
+    """
+    array_length = len(array)
+    # If the array contains only one element, we return it (it's the stop condition of
+    # recursion)
+    if array_length <= 1:
+        return array
+        # Else
+    pivot = array[0]
+    is_found = False
+    i = 1
+    longest_subseq: list[int] = []
+    while not is_found and i < array_length:
+        if array[i] < pivot:
+            is_found = True
+            temp_array = array[i:]
+            temp_array = longest_subsequence(temp_array)
+            if len(temp_array) > len(longest_subseq):
+                longest_subseq = temp_array
+        else:
+            i += 1
+
+    temp_array = [element for element in array[1:] if element >= pivot]
+    temp_array = [pivot, *longest_subsequence(temp_array)]
+    if len(temp_array) > len(longest_subseq):
+        return temp_array
+    else:
+        return longest_subseq
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python reference implementation for longest increasing subsequence
- implement Mochi pivot-based recursion for longest increasing subsequence with tests

## Testing
- `go run ./cmd/mochi test tests/github/TheAlgorithms/Mochi/dynamic_programming/longest_increasing_subsequence.mochi`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6891ad764d18832085edfcd519c7057f