### PR TITLE
Add matrix chain multiplication algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/matrix_chain_multiplication.mochi
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/matrix_chain_multiplication.mochi
@@ -1,0 +1,67 @@
+/*
+Matrix Chain Multiplication
+---------------------------
+Given a sequence of matrix dimensions, the i-th matrix has size arr[i-1] x arr[i].
+The goal is to determine the minimum number of scalar multiplications needed to
+multiply the chain of matrices.
+
+The function `matrix_chain_multiply` uses bottom-up dynamic programming.
+`dp[i][j]` stores the minimal cost to multiply matrices i..j.  The table is
+filled for increasing chain lengths, yielding O(n^3) time and O(n^2) space.
+
+The implementation returns 0 when fewer than two matrices are provided.
+*/
+
+let INF = 1000000000
+
+fun matrix_chain_multiply(arr: list<int>): int {
+  if len(arr) < 2 { return 0 }
+  let n = len(arr)
+  var dp: list<list<int>> = []
+  var i = 0
+  while i < n {
+    var row: list<int> = []
+    var j = 0
+    while j < n {
+      row = append(row, INF)
+      j = j + 1
+    }
+    dp = append(dp, row)
+    i = i + 1
+  }
+  i = n - 1
+  while i > 0 {
+    var j = i
+    while j < n {
+      if i == j {
+        dp[i][j] = 0
+      } else {
+        var k = i
+        while k < j {
+          let cost = dp[i][k] + dp[k + 1][j] + arr[i - 1] * arr[k] * arr[j]
+          if cost < dp[i][j] { dp[i][j] = cost }
+          k = k + 1
+        }
+      }
+      j = j + 1
+    }
+    i = i - 1
+  }
+  return dp[1][n - 1]
+}
+
+test "example" {
+  expect matrix_chain_multiply([1,2,3,4,3]) == 30
+}
+
+test "single matrix" {
+  expect matrix_chain_multiply([10]) == 0
+}
+
+test "two matrices" {
+  expect matrix_chain_multiply([10,20]) == 0
+}
+
+test "cost calculation" {
+  expect matrix_chain_multiply([19,2,19]) == 722
+}

--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/matrix_chain_multiplication.out
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/matrix_chain_multiplication.out
@@ -1,0 +1,5 @@
+[94;1mtests/github/TheAlgorithms/Mochi/dynamic_programming/matrix_chain_multiplication.mochi[0;22m
+   [33mtest[0m example                        ... [32mok[0m (2.0ms)
+   [33mtest[0m single matrix                  ... [32mok[0m (2.0ms)
+   [33mtest[0m two matrices                   ... [32mok[0m (13.0ms)
+   [33mtest[0m cost calculation               ... [32mok[0m (3.0ms)

--- a/tests/github/TheAlgorithms/Python/dynamic_programming/matrix_chain_multiplication.py
+++ b/tests/github/TheAlgorithms/Python/dynamic_programming/matrix_chain_multiplication.py
@@ -1,0 +1,151 @@
+"""
+| Find the minimum number of multiplications needed to multiply chain of matrices.
+| Reference: https://www.geeksforgeeks.org/matrix-chain-multiplication-dp-8/
+
+The algorithm has interesting real-world applications.
+
+Example:
+  1. Image transformations in Computer Graphics as images are composed of matrix.
+  2. Solve complex polynomial equations in the field of algebra using least processing
+     power.
+  3. Calculate overall impact of macroeconomic decisions as economic equations involve a
+     number of variables.
+  4. Self-driving car navigation can be made more accurate as matrix multiplication can
+     accurately determine position and orientation of obstacles in short time.
+
+Python doctests can be run with the following command::
+
+  python -m doctest -v matrix_chain_multiply.py
+
+Given a sequence ``arr[]`` that represents chain of 2D matrices such that the dimension
+of the ``i`` th matrix is ``arr[i-1]*arr[i]``.
+So suppose ``arr = [40, 20, 30, 10, 30]`` means we have ``4`` matrices of dimensions
+``40*20``, ``20*30``, ``30*10`` and ``10*30``.
+
+``matrix_chain_multiply()`` returns an integer denoting minimum number of
+multiplications to multiply the chain.
+
+We do not need to perform actual multiplication here.
+We only need to decide the order in which to perform the multiplication.
+
+Hints:
+  1. Number of multiplications (ie cost) to multiply ``2`` matrices
+     of size ``m*p`` and ``p*n`` is ``m*p*n``.
+  2. Cost of matrix multiplication is not associative ie ``(M1*M2)*M3 != M1*(M2*M3)``
+  3. Matrix multiplication is not commutative. So, ``M1*M2`` does not mean ``M2*M1``
+     can be done.
+  4. To determine the required order, we can try different combinations.
+
+So, this problem has overlapping sub-problems and can be solved using recursion.
+We use Dynamic Programming for optimal time complexity.
+
+Example input:
+    ``arr = [40, 20, 30, 10, 30]``
+output:
+    ``26000``
+"""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from functools import cache
+from sys import maxsize
+
+
+def matrix_chain_multiply(arr: list[int]) -> int:
+    """
+    Find the minimum number of multiplcations required to multiply the chain of matrices
+
+    Args:
+        `arr`: The input array of integers.
+
+    Returns:
+        Minimum number of multiplications needed to multiply the chain
+
+    Examples:
+
+    >>> matrix_chain_multiply([1, 2, 3, 4, 3])
+    30
+    >>> matrix_chain_multiply([10])
+    0
+    >>> matrix_chain_multiply([10, 20])
+    0
+    >>> matrix_chain_multiply([19, 2, 19])
+    722
+    >>> matrix_chain_multiply(list(range(1, 100)))
+    323398
+    >>> # matrix_chain_multiply(list(range(1, 251)))
+    # 2626798
+    """
+    if len(arr) < 2:
+        return 0
+    # initialising 2D dp matrix
+    n = len(arr)
+    dp = [[maxsize for j in range(n)] for i in range(n)]
+    # we want minimum cost of multiplication of matrices
+    # of dimension (i*k) and (k*j). This cost is arr[i-1]*arr[k]*arr[j].
+    for i in range(n - 1, 0, -1):
+        for j in range(i, n):
+            if i == j:
+                dp[i][j] = 0
+                continue
+            for k in range(i, j):
+                dp[i][j] = min(
+                    dp[i][j], dp[i][k] + dp[k + 1][j] + arr[i - 1] * arr[k] * arr[j]
+                )
+
+    return dp[1][n - 1]
+
+
+def matrix_chain_order(dims: list[int]) -> int:
+    """
+    Source: https://en.wikipedia.org/wiki/Matrix_chain_multiplication
+
+    The dynamic programming solution is faster than cached the recursive solution and
+    can handle larger inputs.
+
+    >>> matrix_chain_order([1, 2, 3, 4, 3])
+    30
+    >>> matrix_chain_order([10])
+    0
+    >>> matrix_chain_order([10, 20])
+    0
+    >>> matrix_chain_order([19, 2, 19])
+    722
+    >>> matrix_chain_order(list(range(1, 100)))
+    323398
+    >>> # matrix_chain_order(list(range(1, 251)))  # Max before RecursionError is raised
+    # 2626798
+    """
+
+    @cache
+    def a(i: int, j: int) -> int:
+        return min(
+            (a(i, k) + dims[i] * dims[k] * dims[j] + a(k, j) for k in range(i + 1, j)),
+            default=0,
+        )
+
+    return a(0, len(dims) - 1)
+
+
+@contextmanager
+def elapsed_time(msg: str) -> Iterator:
+    # print(f"Starting: {msg}")
+    from time import perf_counter_ns
+
+    start = perf_counter_ns()
+    yield
+    print(f"Finished: {msg} in {(perf_counter_ns() - start) / 10**9} seconds.")
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    with elapsed_time("matrix_chain_order"):
+        print(f"{matrix_chain_order(list(range(1, 251))) = }")
+    with elapsed_time("matrix_chain_multiply"):
+        print(f"{matrix_chain_multiply(list(range(1, 251))) = }")
+    with elapsed_time("matrix_chain_order"):
+        print(f"{matrix_chain_order(list(range(1, 251))) = }")
+    with elapsed_time("matrix_chain_multiply"):
+        print(f"{matrix_chain_multiply(list(range(1, 251))) = }")


### PR DESCRIPTION
## Summary
- port matrix chain multiplication to Mochi using bottom-up dynamic programming
- include example tests

## Testing
- `go run ./cmd/mochi test tests/github/TheAlgorithms/Mochi/dynamic_programming/matrix_chain_multiplication.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891adbc224083209a8b76e7c764e5b2