### PR TITLE
Add matrix chain order dynamic programming example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/matrix_chain_order.mochi
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/matrix_chain_order.mochi
@@ -1,0 +1,79 @@
+/*
+Matrix Chain Order via Dynamic Programming.
+
+Given a sequence of matrices where the ith matrix has dimension p[i-1] x p[i],
+we seek the most efficient way to multiply these matrices together.  The
+matrix_chain_order function uses dynamic programming to compute the minimum
+number of scalar multiplications needed and records the optimal split points.
+The algorithm runs in O(n^3) time and O(n^2) space.
+*/
+
+type MatrixChainResult {
+  matrix: list<list<int>>,
+  solution: list<list<int>>
+}
+
+fun make_2d(n: int): list<list<int>> {
+  var res: list<list<int>> = []
+  var i = 0
+  while i < n {
+    var row: list<int> = []
+    var j = 0
+    while j < n {
+      row = append(row, 0)
+      j = j + 1
+    }
+    res = append(res, row)
+    i = i + 1
+  }
+  return res
+}
+
+fun matrix_chain_order(arr: list<int>): MatrixChainResult {
+  let n = len(arr)
+  var m: list<list<int>> = make_2d(n)
+  var s: list<list<int>> = make_2d(n)
+  var chain_length = 2
+  while chain_length < n {
+    var a = 1
+    while a < n - chain_length + 1 {
+      let b = a + chain_length - 1
+      m[a][b] = 1000000000
+      var c = a
+      while c < b {
+        let cost = m[a][c] + m[c + 1][b] + arr[a - 1] * arr[c] * arr[b]
+        if cost < m[a][b] {
+          m[a][b] = cost
+          s[a][b] = c
+        }
+        c = c + 1
+      }
+      a = a + 1
+    }
+    chain_length = chain_length + 1
+  }
+  return MatrixChainResult { matrix: m, solution: s }
+}
+
+fun optimal_parenthesization(s: list<list<int>>, i: int, j: int): string {
+  if i == j {
+    return "A" + str(i)
+  } else {
+    let left = optimal_parenthesization(s, i, s[i][j])
+    let right = optimal_parenthesization(s, s[i][j] + 1, j)
+    return "( " + left + " " + right + " )"
+  }
+}
+
+fun main() {
+  let arr = [30, 35, 15, 5, 10, 20, 25]
+  let n = len(arr)
+  let res = matrix_chain_order(arr)
+  let m = res.matrix
+  let s = res.solution
+  print("No. of Operation required: " + str(m[1][n - 1]))
+  let seq = optimal_parenthesization(s, 1, n - 1)
+  print(seq)
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/matrix_chain_order.out
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/matrix_chain_order.out
@@ -1,0 +1,2 @@
+No. of Operation required: 15125
+( ( A1 ( A2 A3 ) ) ( ( A4 A5 ) A6 ) )

--- a/tests/github/TheAlgorithms/Python/dynamic_programming/matrix_chain_order.py
+++ b/tests/github/TheAlgorithms/Python/dynamic_programming/matrix_chain_order.py
@@ -1,0 +1,67 @@
+import sys
+
+"""
+Dynamic Programming
+Implementation of Matrix Chain Multiplication
+Time Complexity: O(n^3)
+Space Complexity: O(n^2)
+
+Reference: https://en.wikipedia.org/wiki/Matrix_chain_multiplication
+"""
+
+
+def matrix_chain_order(array: list[int]) -> tuple[list[list[int]], list[list[int]]]:
+    """
+    >>> matrix_chain_order([10, 30, 5])
+    ([[0, 0, 0], [0, 0, 1500], [0, 0, 0]], [[0, 0, 0], [0, 0, 1], [0, 0, 0]])
+    """
+    n = len(array)
+    matrix = [[0 for _ in range(n)] for _ in range(n)]
+    sol = [[0 for _ in range(n)] for _ in range(n)]
+
+    for chain_length in range(2, n):
+        for a in range(1, n - chain_length + 1):
+            b = a + chain_length - 1
+
+            matrix[a][b] = sys.maxsize
+            for c in range(a, b):
+                cost = (
+                    matrix[a][c] + matrix[c + 1][b] + array[a - 1] * array[c] * array[b]
+                )
+                if cost < matrix[a][b]:
+                    matrix[a][b] = cost
+                    sol[a][b] = c
+    return matrix, sol
+
+
+def print_optimal_solution(optimal_solution: list[list[int]], i: int, j: int):
+    """
+    Print order of matrix with Ai as Matrix.
+    """
+
+    if i == j:
+        print("A" + str(i), end=" ")
+    else:
+        print("(", end=" ")
+        print_optimal_solution(optimal_solution, i, optimal_solution[i][j])
+        print_optimal_solution(optimal_solution, optimal_solution[i][j] + 1, j)
+        print(")", end=" ")
+
+
+def main():
+    """
+    Size of matrix created from array [30, 35, 15, 5, 10, 20, 25] will be:
+    30*35 35*15 15*5 5*10 10*20 20*25
+    """
+
+    array = [30, 35, 15, 5, 10, 20, 25]
+    n = len(array)
+
+    matrix, optimal_solution = matrix_chain_order(array)
+
+    print("No. of Operation required: " + str(matrix[1][n - 1]))
+    print_optimal_solution(optimal_solution, 1, n - 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python reference implementation for matrix chain order DP
- implement equivalent Mochi version with optimal parenthesization output
- include example runtime output

## Testing
- `npm test` (fails: Missing script: "test")
- `./bin/mochi run tests/github/TheAlgorithms/Mochi/dynamic_programming/matrix_chain_order.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6891adcb9a0883208e49f0df98d01229