### PR TITLE
Add regex matching dynamic programming example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/regex_match.mochi
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/regex_match.mochi
@@ -1,0 +1,114 @@
+/*
+Regular Expression Matching with '.' and '*'
+-------------------------------------------
+Determines if a text string fully matches a pattern where:
+  1. '.' matches any single character.
+  2. '*' matches zero or more of the preceding element.
+
+Two algorithms are provided:
+
+1. Recursive backtracking
+   Checks matches from the end of the strings. If characters are equal
+   or pattern has '.', it recurses on the preceding substrings. When '*'
+   appears, it explores two cases: consume one character or skip the
+   preceding element. Worst-case complexity is exponential in the length
+   of text and pattern due to the branching.
+
+2. Dynamic programming
+   Builds a (m+1) x (n+1) boolean table where m and n are the lengths of
+   text and pattern. dp[i][j] is true if the first i characters of text
+   match the first j characters of pattern. Transitions handle direct
+   character matches, '.' and '*'. Time and space complexity are O(m*n).
+*/
+
+fun recursive_match(text: string, pattern: string): bool {
+  if len(pattern) == 0 {
+    return len(text) == 0
+  }
+  if len(text) == 0 {
+    if len(pattern) >= 2 && substring(pattern, len(pattern) - 1, len(pattern)) == "*" {
+      return recursive_match(text, substring(pattern, 0, len(pattern) - 2))
+    }
+    return false
+  }
+  let last_text = substring(text, len(text) - 1, len(text))
+  let last_pattern = substring(pattern, len(pattern) - 1, len(pattern))
+  if last_text == last_pattern || last_pattern == "." {
+    return recursive_match(substring(text, 0, len(text) - 1), substring(pattern, 0, len(pattern) - 1))
+  }
+  if last_pattern == "*" {
+    if recursive_match(substring(text, 0, len(text) - 1), pattern) {
+      return true
+    }
+    return recursive_match(text, substring(pattern, 0, len(pattern) - 2))
+  }
+  return false
+}
+
+fun dp_match(text: string, pattern: string): bool {
+  let m = len(text)
+  let n = len(pattern)
+  var dp: list<list<bool>> = []
+  var i = 0
+  while i <= m {
+    var row: list<bool> = []
+    var j = 0
+    while j <= n {
+      row = append(row, false)
+      j = j + 1
+    }
+    dp = append(dp, row)
+    i = i + 1
+  }
+  dp[0][0] = true
+  var j = 1
+  while j <= n {
+    if substring(pattern, j - 1, j) == "*" && j >= 2 {
+      if dp[0][j - 2] { dp[0][j] = true }
+    }
+    j = j + 1
+  }
+  i = 1
+  while i <= m {
+    j = 1
+    while j <= n {
+      let p_char = substring(pattern, j - 1, j)
+      let t_char = substring(text, i - 1, i)
+      if p_char == "." || p_char == t_char {
+        if dp[i - 1][j - 1] { dp[i][j] = true }
+      } else if p_char == "*" {
+        if j >= 2 {
+          if dp[i][j - 2] { dp[i][j] = true }
+          let prev_p = substring(pattern, j - 2, j - 1)
+          if prev_p == "." || prev_p == t_char {
+            if dp[i - 1][j] { dp[i][j] = true }
+          }
+        }
+      } else {
+        dp[i][j] = false
+      }
+      j = j + 1
+    }
+    i = i + 1
+  }
+  return dp[m][n]
+}
+
+fun print_bool(b: bool) {
+  if b {
+    print("true")
+  } else {
+    print("false")
+  }
+}
+
+print_bool(recursive_match("abc", "a.c"))
+print_bool(recursive_match("abc", "af*.c"))
+print_bool(recursive_match("abc", "a.c*"))
+print_bool(recursive_match("abc", "a.c*d"))
+print_bool(recursive_match("aa", ".*"))
+print_bool(dp_match("abc", "a.c"))
+print_bool(dp_match("abc", "af*.c"))
+print_bool(dp_match("abc", "a.c*"))
+print_bool(dp_match("abc", "a.c*d"))
+print_bool(dp_match("aa", ".*"))

--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/regex_match.out
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/regex_match.out
@@ -1,0 +1,10 @@
+true
+true
+true
+false
+true
+true
+true
+true
+false
+true

--- a/tests/github/TheAlgorithms/Python/dynamic_programming/regex_match.py
+++ b/tests/github/TheAlgorithms/Python/dynamic_programming/regex_match.py
@@ -1,0 +1,99 @@
+"""
+Regex matching check if a text matches pattern or not.
+Pattern:
+
+    1. ``.`` Matches any single character.
+    2. ``*`` Matches zero or more of the preceding element.
+
+More info:
+    https://medium.com/trick-the-interviwer/regular-expression-matching-9972eb74c03
+"""
+
+
+def recursive_match(text: str, pattern: str) -> bool:
+    r"""
+    Recursive matching algorithm.
+
+    | Time complexity: O(2^(\|text\| + \|pattern\|))
+    | Space complexity: Recursion depth is O(\|text\| + \|pattern\|).
+
+    :param text: Text to match.
+    :param pattern: Pattern to match.
+    :return: ``True`` if `text` matches `pattern`, ``False`` otherwise.
+
+    >>> recursive_match('abc', 'a.c')
+    True
+    >>> recursive_match('abc', 'af*.c')
+    True
+    >>> recursive_match('abc', 'a.c*')
+    True
+    >>> recursive_match('abc', 'a.c*d')
+    False
+    >>> recursive_match('aa', '.*')
+    True
+    """
+    if not pattern:
+        return not text
+
+    if not text:
+        return pattern[-1] == "*" and recursive_match(text, pattern[:-2])
+
+    if text[-1] == pattern[-1] or pattern[-1] == ".":
+        return recursive_match(text[:-1], pattern[:-1])
+
+    if pattern[-1] == "*":
+        return recursive_match(text[:-1], pattern) or recursive_match(
+            text, pattern[:-2]
+        )
+
+    return False
+
+
+def dp_match(text: str, pattern: str) -> bool:
+    r"""
+    Dynamic programming matching algorithm.
+
+    | Time complexity: O(\|text\| * \|pattern\|)
+    | Space complexity: O(\|text\| * \|pattern\|)
+
+    :param text: Text to match.
+    :param pattern: Pattern to match.
+    :return: ``True`` if `text` matches `pattern`, ``False`` otherwise.
+
+    >>> dp_match('abc', 'a.c')
+    True
+    >>> dp_match('abc', 'af*.c')
+    True
+    >>> dp_match('abc', 'a.c*')
+    True
+    >>> dp_match('abc', 'a.c*d')
+    False
+    >>> dp_match('aa', '.*')
+    True
+    """
+    m = len(text)
+    n = len(pattern)
+    dp = [[False for _ in range(n + 1)] for _ in range(m + 1)]
+    dp[0][0] = True
+
+    for j in range(1, n + 1):
+        dp[0][j] = pattern[j - 1] == "*" and dp[0][j - 2]
+
+    for i in range(1, m + 1):
+        for j in range(1, n + 1):
+            if pattern[j - 1] in {".", text[i - 1]}:
+                dp[i][j] = dp[i - 1][j - 1]
+            elif pattern[j - 1] == "*":
+                dp[i][j] = dp[i][j - 2]
+                if pattern[j - 2] in {".", text[i - 1]}:
+                    dp[i][j] |= dp[i - 1][j]
+            else:
+                dp[i][j] = False
+
+    return dp[m][n]
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python regex matching algorithm for '.' and '*'
- implement Mochi recursive and DP regex matcher with tests
- include sample output verifying matches

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/dynamic_programming/regex_match.mochi > tests/github/TheAlgorithms/Mochi/dynamic_programming/regex_match.out`
- `cat tests/github/TheAlgorithms/Mochi/dynamic_programming/regex_match.out`


------
https://chatgpt.com/codex/tasks/task_e_6891b79c8bac8320b59c316a80a29885