### PR TITLE
Add wildcard matching dynamic programming example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/wildcard_matching.mochi
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/wildcard_matching.mochi
@@ -1,0 +1,81 @@
+/*
+Wildcard pattern matching using dynamic programming.
+
+Given an input string `s` and pattern `p` containing `?` and `*`, determine
+if the entire string matches the pattern. `?` matches any single character,
+while `*` matches any sequence of characters (including empty).
+We construct an (n+1) x (m+1) boolean table `dp` where `dp[i][j]` represents
+whether the first `i` characters of `s` match the first `j` characters of `p`.
+Transitions:
+  - If `p[j-1]` equals `s[i-1]` or is `?`, then `dp[i][j] = dp[i-1][j-1]`.
+  - If `p[j-1]` is `*`, then `dp[i][j] = dp[i-1][j] || dp[i][j-1]`
+    (consume a character from `s` or treat `*` as empty).
+The first row is initialized to handle leading `*` characters in the pattern.
+The algorithm runs in `O(n*m)` time and uses `O(n*m)` space.
+*/
+
+fun make_bool_list(n: int): list<bool> {
+  var row: list<bool> = []
+  var i = 0
+  while i < n {
+    row = append(row, false)
+    i = i + 1
+  }
+  return row
+}
+
+fun make_bool_matrix(rows: int, cols: int): list<list<bool>> {
+  var matrix: list<list<bool>> = []
+  var i = 0
+  while i < rows {
+    matrix = append(matrix, make_bool_list(cols))
+    i = i + 1
+  }
+  return matrix
+}
+
+fun is_match(s: string, p: string): bool {
+  let n = len(s)
+  let m = len(p)
+  var dp = make_bool_matrix(n + 1, m + 1)
+  dp[0][0] = true
+
+  var j = 1
+  while j <= m {
+    if p[j-1:j] == "*" {
+      dp[0][j] = dp[0][j-1]
+    }
+    j = j + 1
+  }
+
+  var i = 1
+  while i <= n {
+    var j2 = 1
+    while j2 <= m {
+      let pc = p[j2-1:j2]
+      let sc = s[i-1:i]
+      if pc == sc || pc == "?" {
+        dp[i][j2] = dp[i-1][j2-1]
+      } else if pc == "*" {
+        if dp[i-1][j2] || dp[i][j2-1] {
+          dp[i][j2] = true
+        }
+      }
+      j2 = j2 + 1
+    }
+    i = i + 1
+  }
+  return dp[n][m]
+}
+
+fun print_bool(b: bool) {
+  if b {
+    print("true")
+  } else {
+    print("false")
+  }
+}
+
+print_bool(is_match("abc", "a*c"))
+print_bool(is_match("abc", "a*d"))
+print_bool(is_match("baaabab", "*****ba*****ab"))

--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/wildcard_matching.out
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/wildcard_matching.out
@@ -1,0 +1,3 @@
+true
+false
+true

--- a/tests/github/TheAlgorithms/Python/dynamic_programming/wildcard_matching.py
+++ b/tests/github/TheAlgorithms/Python/dynamic_programming/wildcard_matching.py
@@ -1,0 +1,68 @@
+"""
+Author  : ilyas dahhou
+Date    : Oct 7, 2023
+
+Task:
+Given an input string and a pattern, implement wildcard pattern matching with support
+for '?' and '*' where:
+'?' matches any single character.
+'*' matches any sequence of characters (including the empty sequence).
+The matching should cover the entire input string (not partial).
+
+Runtime complexity: O(m * n)
+
+The implementation was tested on the
+leetcode: https://leetcode.com/problems/wildcard-matching/
+"""
+
+
+def is_match(string: str, pattern: str) -> bool:
+    """
+    >>> is_match("", "")
+    True
+    >>> is_match("aa", "a")
+    False
+    >>> is_match("abc", "abc")
+    True
+    >>> is_match("abc", "*c")
+    True
+    >>> is_match("abc", "a*")
+    True
+    >>> is_match("abc", "*a*")
+    True
+    >>> is_match("abc", "?b?")
+    True
+    >>> is_match("abc", "*?")
+    True
+    >>> is_match("abc", "a*d")
+    False
+    >>> is_match("abc", "a*c?")
+    False
+    >>> is_match('baaabab','*****ba*****ba')
+    False
+    >>> is_match('baaabab','*****ba*****ab')
+    True
+    >>> is_match('aa','*')
+    True
+    """
+    dp = [[False] * (len(pattern) + 1) for _ in string + "1"]
+    dp[0][0] = True
+    # Fill in the first row
+    for j, char in enumerate(pattern, 1):
+        if char == "*":
+            dp[0][j] = dp[0][j - 1]
+    # Fill in the rest of the DP table
+    for i, s_char in enumerate(string, 1):
+        for j, p_char in enumerate(pattern, 1):
+            if p_char in (s_char, "?"):
+                dp[i][j] = dp[i - 1][j - 1]
+            elif pattern[j - 1] == "*":
+                dp[i][j] = dp[i - 1][j] or dp[i][j - 1]
+    return dp[len(string)][len(pattern)]
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    print(f"{is_match('baaabab','*****ba*****ab') = }")


### PR DESCRIPTION
## Summary
- add Python reference implementation for wildcard pattern matching
- implement Mochi version using dynamic programming
- include runtime output for example cases

## Testing
- `./mochi run tests/github/TheAlgorithms/Mochi/dynamic_programming/wildcard_matching.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891b7c0a20c8320b7f55abef1233e50