### PR TITLE
feat: add word break dynamic programming example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/word_break.mochi
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/word_break.mochi
@@ -1,0 +1,54 @@
+/*
+Determine whether a string can be segmented into a space-separated sequence
+of dictionary words using dynamic programming.
+
+We store the dictionary in a map for constant-time lookups and use
+bottom-up dynamic programming. A boolean array `dp` of length `n+1`
+tracks whether the prefix ending at position `i` can be segmented. For
+each position we try all earlier split points and mark `dp[i]` true when a
+valid word is found. The algorithm runs in O(n^2) time and O(n) space.
+*/
+
+fun build_set(words: list<string>): map<string, bool> {
+  var m: map<string, bool> = {}
+  for w in words {
+    m[w] = true
+  }
+  return m
+}
+
+fun word_break(s: string, words: list<string>): bool {
+  let n = len(s)
+  let dict = build_set(words)
+  var dp: list<bool> = []
+  var i = 0
+  while i <= n {
+    dp = append(dp, false)
+    i = i + 1
+  }
+  dp[0] = true
+  i = 1
+  while i <= n {
+    var j = 0
+    while j < i {
+      if dp[j] {
+        let sub = s[j:i]
+        if sub in dict {
+          dp[i] = true
+          j = i
+        }
+      }
+      j = j + 1
+    }
+    i = i + 1
+  }
+  return dp[n]
+}
+
+fun print_bool(b: bool) {
+  if b { print("true") } else { print("false") }
+}
+
+print_bool(word_break("applepenapple", ["apple", "pen"]))
+print_bool(word_break("catsandog", ["cats", "dog", "sand", "and", "cat"]))
+print_bool(word_break("cars", ["car", "ca", "rs"]))

--- a/tests/github/TheAlgorithms/Mochi/dynamic_programming/word_break.out
+++ b/tests/github/TheAlgorithms/Mochi/dynamic_programming/word_break.out
@@ -1,0 +1,3 @@
+true
+false
+true

--- a/tests/github/TheAlgorithms/Python/dynamic_programming/word_break.py
+++ b/tests/github/TheAlgorithms/Python/dynamic_programming/word_break.py
@@ -1,0 +1,111 @@
+"""
+Author  : Alexander Pantyukhin
+Date    : December 12, 2022
+
+Task:
+Given a string and a list of words, return true if the string can be
+segmented into a space-separated sequence of one or more words.
+
+Note that the same word may be reused
+multiple times in the segmentation.
+
+Implementation notes: Trie + Dynamic programming up -> down.
+The Trie will be used to store the words. It will be useful for scanning
+available words for the current position in the string.
+
+Leetcode:
+https://leetcode.com/problems/word-break/description/
+
+Runtime: O(n * n)
+Space: O(n)
+"""
+
+import functools
+from typing import Any
+
+
+def word_break(string: str, words: list[str]) -> bool:
+    """
+    Return True if numbers have opposite signs False otherwise.
+
+    >>> word_break("applepenapple", ["apple","pen"])
+    True
+    >>> word_break("catsandog", ["cats","dog","sand","and","cat"])
+    False
+    >>> word_break("cars", ["car","ca","rs"])
+    True
+    >>> word_break('abc', [])
+    False
+    >>> word_break(123, ['a'])
+    Traceback (most recent call last):
+        ...
+    ValueError: the string should be not empty string
+    >>> word_break('', ['a'])
+    Traceback (most recent call last):
+        ...
+    ValueError: the string should be not empty string
+    >>> word_break('abc', [123])
+    Traceback (most recent call last):
+        ...
+    ValueError: the words should be a list of non-empty strings
+    >>> word_break('abc', [''])
+    Traceback (most recent call last):
+        ...
+    ValueError: the words should be a list of non-empty strings
+    """
+
+    # Validation
+    if not isinstance(string, str) or len(string) == 0:
+        raise ValueError("the string should be not empty string")
+
+    if not isinstance(words, list) or not all(
+        isinstance(item, str) and len(item) > 0 for item in words
+    ):
+        raise ValueError("the words should be a list of non-empty strings")
+
+    # Build trie
+    trie: dict[str, Any] = {}
+    word_keeper_key = "WORD_KEEPER"
+
+    for word in words:
+        trie_node = trie
+        for c in word:
+            if c not in trie_node:
+                trie_node[c] = {}
+
+            trie_node = trie_node[c]
+
+        trie_node[word_keeper_key] = True
+
+    len_string = len(string)
+
+    # Dynamic programming method
+    @functools.cache
+    def is_breakable(index: int) -> bool:
+        """
+        >>> string = 'a'
+        >>> is_breakable(1)
+        True
+        """
+        if index == len_string:
+            return True
+
+        trie_node = trie
+        for i in range(index, len_string):
+            trie_node = trie_node.get(string[i], None)
+
+            if trie_node is None:
+                return False
+
+            if trie_node.get(word_keeper_key, False) and is_breakable(i + 1):
+                return True
+
+        return False
+
+    return is_breakable(0)
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add TheAlgorithms Python word break implementation
- port word break dynamic programming solution to Mochi with tests

## Testing
- `npm test` *(fails: Missing script: "test")*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6891b7c5d87c8320b85e51f81626153d