### PR TITLE
Add Mochi implementation of apparent power algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/electronics/apparent_power.mochi
+++ b/tests/github/TheAlgorithms/Mochi/electronics/apparent_power.mochi
@@ -1,0 +1,98 @@
+/*
+Apparent Power in AC Circuits
+-----------------------------
+Computes the complex apparent power S in a single-phase AC circuit.
+Given voltage magnitude V and current magnitude I with phase angles
+in degrees (\u03b8_v and \u03b8_i), convert each phasor to rectangular form
+and multiply to obtain:
+  S = V * I = (V cos \u03b8_v + j V sin \u03b8_v) * (I cos \u03b8_i + j I sin \u03b8_i)
+The result is a complex number representing real and reactive power.
+The algorithm uses Taylor series for sine and cosine to avoid FFI and
+runs in constant time O(1).
+*/
+
+let PI: float = 3.141592653589793
+
+fun abs(x: float): float {
+  if x < 0.0 { return -x }
+  return x
+}
+
+fun to_radians(deg: float): float {
+  return deg * PI / 180.0
+}
+
+fun sin_taylor(x: float): float {
+  var term = x
+  var sum = x
+  var i = 1
+  while i < 10 {
+    let k1 = 2.0 * (i as float)
+    let k2 = k1 + 1.0
+    term = -term * x * x / (k1 * k2)
+    sum = sum + term
+    i = i + 1
+  }
+  return sum
+}
+
+fun cos_taylor(x: float): float {
+  var term = 1.0
+  var sum = 1.0
+  var i = 1
+  while i < 10 {
+    let k1 = 2.0 * (i as float) - 1.0
+    let k2 = 2.0 * (i as float)
+    term = -term * x * x / (k1 * k2)
+    sum = sum + term
+    i = i + 1
+  }
+  return sum
+}
+
+fun rect(mag: float, angle: float): list<float> {
+  let c = cos_taylor(angle)
+  let s = sin_taylor(angle)
+  return [mag * c, mag * s]
+}
+
+fun multiply(a: list<float>, b: list<float>): list<float> {
+  return [a[0] * b[0] - a[1] * b[1], a[0] * b[1] + a[1] * b[0]]
+}
+
+fun apparent_power(voltage: float, current: float, voltage_angle: float, current_angle: float): list<float> {
+  let vrad = to_radians(voltage_angle)
+  let irad = to_radians(current_angle)
+  let vrect: list<float> = rect(voltage, vrad)
+  let irect: list<float> = rect(current, irad)
+  let result: list<float> = multiply(vrect, irect)
+  return result
+}
+
+fun approx_equal(a: list<float>, b: list<float>, eps: float): bool {
+  return abs(a[0] - b[0]) < eps && abs(a[1] - b[1]) < eps
+}
+
+test "zero phase" {
+  let s = apparent_power(100.0, 5.0, 0.0, 0.0)
+  let expected = [500.0, 0.0]
+  expect approx_equal(s, expected, 0.001)
+}
+
+test "orthogonal voltage" {
+  let s = apparent_power(100.0, 5.0, 90.0, 0.0)
+  let expected = [0.0, 500.0]
+  expect approx_equal(s, expected, 0.5)
+}
+
+test "negative angles" {
+  let s = apparent_power(100.0, 5.0, -45.0, -60.0)
+  let expected = [-129.40952255126027, -482.9629131445341]
+  expect approx_equal(s, expected, 0.001)
+}
+
+test "another case" {
+  let s = apparent_power(200.0, 10.0, -30.0, -90.0)
+  let expected = [-1000.0, -1732.0508075688776]
+  expect approx_equal(s, expected, 0.001)
+}

--- a/tests/github/TheAlgorithms/Mochi/electronics/apparent_power.out
+++ b/tests/github/TheAlgorithms/Mochi/electronics/apparent_power.out
@@ -1,0 +1,5 @@
+[94;1mtests/github/TheAlgorithms/Mochi/electronics/apparent_power.mochi[0;22m
+   [33mtest[0m zero phase                     ... [32mok[0m (3.0ms)
+   [33mtest[0m orthogonal voltage             ... [32mok[0m (1.0ms)
+   [33mtest[0m negative angles                ... [32mok[0m (2.0ms)
+   [33mtest[0m another case                   ... [32mok[0m (1.0ms)

--- a/tests/github/TheAlgorithms/Python/electronics/apparent_power.py
+++ b/tests/github/TheAlgorithms/Python/electronics/apparent_power.py
@@ -1,0 +1,37 @@
+import cmath
+import math
+
+
+def apparent_power(
+    voltage: float, current: float, voltage_angle: float, current_angle: float
+) -> complex:
+    """
+    Calculate the apparent power in a single-phase AC circuit.
+
+    Reference: https://en.wikipedia.org/wiki/AC_power#Apparent_power
+
+    >>> apparent_power(100, 5, 0, 0)
+    (500+0j)
+    >>> apparent_power(100, 5, 90, 0)
+    (3.061616997868383e-14+500j)
+    >>> apparent_power(100, 5, -45, -60)
+    (-129.40952255126027-482.9629131445341j)
+    >>> apparent_power(200, 10, -30, -90)
+    (-999.9999999999998-1732.0508075688776j)
+    """
+    # Convert angles from degrees to radians
+    voltage_angle_rad = math.radians(voltage_angle)
+    current_angle_rad = math.radians(current_angle)
+
+    # Convert voltage and current to rectangular form
+    voltage_rect = cmath.rect(voltage, voltage_angle_rad)
+    current_rect = cmath.rect(current, current_angle_rad)
+
+    # Calculate apparent power
+    return voltage_rect * current_rect
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- download missing Python reference for apparent power calculation
- implement equivalent Mochi version using Taylor series trig functions and complex arithmetic
- add tests and runtime output for sample cases

## Testing
- `go run ./cmd/mochi test tests/github/TheAlgorithms/Mochi/electronics/apparent_power.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891b7ca3dc483209b4112aabb1b3bf6