### PR TITLE
Add carrier concentration algorithm in Mochi

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/electronics/carrier_concentration.mochi
+++ b/tests/github/TheAlgorithms/Mochi/electronics/carrier_concentration.mochi
@@ -1,0 +1,72 @@
+/*
+Carrier Concentration Relationships in Semiconductors
+
+In intrinsic and doped semiconductors the electron concentration (n),
+hole concentration (p) and intrinsic carrier concentration (ni) obey the
+mass-action law: n * p = ni^2.  Knowing any two values allows the third
+one to be computed directly:
+  • n = ni^2 / p when n is unknown
+  • p = ni^2 / n when p is unknown
+  • ni = sqrt(n * p) when ni is unknown
+
+The function below accepts three floating point arguments where exactly
+one must be zero to indicate the missing value.  It validates that the
+provided concentrations are non-negative and determines the missing one
+using the relationships above.  The result is returned as a structure
+containing the name of the computed quantity and its value.
+*/
+
+type CarrierResult {
+  name: string
+  value: float
+}
+
+fun sqrtApprox(x: float): float {
+  var guess = x / 2.0
+  var i = 0
+  while i < 20 {
+    guess = (guess + x / guess) / 2.0
+    i = i + 1
+  }
+  return guess
+}
+
+fun carrier_concentration(
+  electron_conc: float,
+  hole_conc: float,
+  intrinsic_conc: float
+): CarrierResult {
+  var zero_count = 0
+  if electron_conc == 0.0 { zero_count = zero_count + 1 }
+  if hole_conc == 0.0 { zero_count = zero_count + 1 }
+  if intrinsic_conc == 0.0 { zero_count = zero_count + 1 }
+  if zero_count != 1 {
+    panic("You cannot supply more or less than 2 values")
+  }
+  if electron_conc < 0.0 {
+    panic("Electron concentration cannot be negative in a semiconductor")
+  }
+  if hole_conc < 0.0 {
+    panic("Hole concentration cannot be negative in a semiconductor")
+  }
+  if intrinsic_conc < 0.0 {
+    panic("Intrinsic concentration cannot be negative in a semiconductor")
+  }
+  if electron_conc == 0.0 {
+    return CarrierResult { name: "electron_conc", value: (intrinsic_conc * intrinsic_conc) / hole_conc }
+  }
+  if hole_conc == 0.0 {
+    return CarrierResult { name: "hole_conc", value: (intrinsic_conc * intrinsic_conc) / electron_conc }
+  }
+  if intrinsic_conc == 0.0 {
+    return CarrierResult { name: "intrinsic_conc", value: sqrtApprox(electron_conc * hole_conc) }
+  }
+  return CarrierResult { name: "", value: -1.0 }
+}
+
+let r1 = carrier_concentration(25.0, 100.0, 0.0)
+print(r1.name + ", " + str(r1.value))
+let r2 = carrier_concentration(0.0, 1600.0, 200.0)
+print(r2.name + ", " + str(r2.value))
+let r3 = carrier_concentration(1000.0, 0.0, 1200.0)
+print(r3.name + ", " + str(r3.value))

--- a/tests/github/TheAlgorithms/Mochi/electronics/carrier_concentration.out
+++ b/tests/github/TheAlgorithms/Mochi/electronics/carrier_concentration.out
@@ -1,0 +1,3 @@
+intrinsic_conc, 50
+electron_conc, 25
+hole_conc, 1440

--- a/tests/github/TheAlgorithms/Python/electronics/carrier_concentration.py
+++ b/tests/github/TheAlgorithms/Python/electronics/carrier_concentration.py
@@ -1,0 +1,75 @@
+# https://en.wikipedia.org/wiki/Charge_carrier_density
+# https://www.pveducation.org/pvcdrom/pn-junctions/equilibrium-carrier-concentration
+# http://www.ece.utep.edu/courses/ee3329/ee3329/Studyguide/ToC/Fundamentals/Carriers/concentrations.html
+
+from __future__ import annotations
+
+
+def carrier_concentration(
+    electron_conc: float,
+    hole_conc: float,
+    intrinsic_conc: float,
+) -> tuple:
+    """
+    This function can calculate any one of the three -
+    1. Electron Concentration
+    2, Hole Concentration
+    3. Intrinsic Concentration
+    given the other two.
+    Examples -
+    >>> carrier_concentration(electron_conc=25, hole_conc=100, intrinsic_conc=0)
+    ('intrinsic_conc', 50.0)
+    >>> carrier_concentration(electron_conc=0, hole_conc=1600, intrinsic_conc=200)
+    ('electron_conc', 25.0)
+    >>> carrier_concentration(electron_conc=1000, hole_conc=0, intrinsic_conc=1200)
+    ('hole_conc', 1440.0)
+    >>> carrier_concentration(electron_conc=1000, hole_conc=400, intrinsic_conc=1200)
+    Traceback (most recent call last):
+        ...
+    ValueError: You cannot supply more or less than 2 values
+    >>> carrier_concentration(electron_conc=-1000, hole_conc=0, intrinsic_conc=1200)
+    Traceback (most recent call last):
+        ...
+    ValueError: Electron concentration cannot be negative in a semiconductor
+    >>> carrier_concentration(electron_conc=0, hole_conc=-400, intrinsic_conc=1200)
+    Traceback (most recent call last):
+        ...
+    ValueError: Hole concentration cannot be negative in a semiconductor
+    >>> carrier_concentration(electron_conc=0, hole_conc=400, intrinsic_conc=-1200)
+    Traceback (most recent call last):
+        ...
+    ValueError: Intrinsic concentration cannot be negative in a semiconductor
+    """
+    if (electron_conc, hole_conc, intrinsic_conc).count(0) != 1:
+        raise ValueError("You cannot supply more or less than 2 values")
+    elif electron_conc < 0:
+        raise ValueError("Electron concentration cannot be negative in a semiconductor")
+    elif hole_conc < 0:
+        raise ValueError("Hole concentration cannot be negative in a semiconductor")
+    elif intrinsic_conc < 0:
+        raise ValueError(
+            "Intrinsic concentration cannot be negative in a semiconductor",
+        )
+    elif electron_conc == 0:
+        return (
+            "electron_conc",
+            intrinsic_conc**2 / hole_conc,
+        )
+    elif hole_conc == 0:
+        return (
+            "hole_conc",
+            intrinsic_conc**2 / electron_conc,
+        )
+    elif intrinsic_conc == 0:
+        return (
+            "intrinsic_conc",
+            (electron_conc * hole_conc) ** 0.5,
+        )
+    else:
+        return (-1, -1)
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add TheAlgorithms Python implementation of `carrier_concentration`
- implement equivalent Mochi version with detailed docs and runtime output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/electronics/carrier_concentration.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891b7d92e708320b46c526f8b3e0d91