### PR TITLE
Add electric conductivity algorithm and Mochi translation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/electronics/electric_conductivity.mochi
+++ b/tests/github/TheAlgorithms/Mochi/electronics/electric_conductivity.mochi
@@ -1,0 +1,62 @@
+/*
+Electric Conductivity Calculations
+
+Given any two of the three parameters—electric conductivity, electron
+concentration, or electron mobility—compute the missing third value
+using σ = n * μ * q where:
+  σ is conductivity,
+  n is electron concentration,
+  μ is electron mobility,
+  q is the electron charge (1.6021e-19 C).
+
+The function accepts zeros to indicate which value to compute.
+It validates that exactly one parameter is zero and none are negative,
+then returns a record identifying the computed quantity and its value.
+*/
+
+let ELECTRON_CHARGE: float = 0.00000000000000000016021
+
+type Result {
+  kind: string,
+  value: float,
+}
+
+fun electric_conductivity(conductivity: float, electron_conc: float, mobility: float): Result {
+  var zero_count = 0
+  if conductivity == 0.0 {
+    zero_count = zero_count + 1
+  }
+  if electron_conc == 0.0 {
+    zero_count = zero_count + 1
+  }
+  if mobility == 0.0 {
+    zero_count = zero_count + 1
+  }
+  if zero_count != 1 {
+    panic("You cannot supply more or less than 2 values")
+  }
+  if conductivity < 0.0 {
+    panic("Conductivity cannot be negative")
+  }
+  if electron_conc < 0.0 {
+    panic("Electron concentration cannot be negative")
+  }
+  if mobility < 0.0 {
+    panic("mobility cannot be negative")
+  }
+  if conductivity == 0.0 {
+    return Result { kind: "conductivity", value: mobility * electron_conc * ELECTRON_CHARGE }
+  }
+  if electron_conc == 0.0 {
+    return Result { kind: "electron_conc", value: conductivity / (mobility * ELECTRON_CHARGE) }
+  }
+  return Result { kind: "mobility", value: conductivity / (electron_conc * ELECTRON_CHARGE) }
+}
+
+let r1 = electric_conductivity(25.0, 100.0, 0.0)
+let r2 = electric_conductivity(0.0, 1600.0, 200.0)
+let r3 = electric_conductivity(1000.0, 0.0, 1200.0)
+
+print(r1.kind + " " + str(r1.value))
+print(r2.kind + " " + str(r2.value))
+print(r3.kind + " " + str(r3.value))

--- a/tests/github/TheAlgorithms/Mochi/electronics/electric_conductivity.out
+++ b/tests/github/TheAlgorithms/Mochi/electronics/electric_conductivity.out
@@ -1,0 +1,3 @@
+mobility 1.5604519068722301e+18
+conductivity 5.12672e-14
+electron_conc 5.201506356240767e+18

--- a/tests/github/TheAlgorithms/Python/electronics/electric_conductivity.py
+++ b/tests/github/TheAlgorithms/Python/electronics/electric_conductivity.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+ELECTRON_CHARGE = 1.6021e-19  # units = C
+
+
+def electric_conductivity(
+    conductivity: float,
+    electron_conc: float,
+    mobility: float,
+) -> tuple[str, float]:
+    """
+    This function can calculate any one of the three -
+    1. Conductivity
+    2. Electron Concentration
+    3. Electron Mobility
+    This is calculated from the other two provided values
+    Examples -
+    >>> electric_conductivity(conductivity=25, electron_conc=100, mobility=0)
+    ('mobility', 1.5604519068722301e+18)
+    >>> electric_conductivity(conductivity=0, electron_conc=1600, mobility=200)
+    ('conductivity', 5.12672e-14)
+    >>> electric_conductivity(conductivity=1000, electron_conc=0, mobility=1200)
+    ('electron_conc', 5.201506356240767e+18)
+    >>> electric_conductivity(conductivity=-10, electron_conc=100, mobility=0)
+    Traceback (most recent call last):
+        ...
+    ValueError: Conductivity cannot be negative
+    >>> electric_conductivity(conductivity=50, electron_conc=-10, mobility=0)
+    Traceback (most recent call last):
+        ...
+    ValueError: Electron concentration cannot be negative
+    >>> electric_conductivity(conductivity=50, electron_conc=0, mobility=-10)
+    Traceback (most recent call last):
+        ...
+    ValueError: mobility cannot be negative
+    >>> electric_conductivity(conductivity=50, electron_conc=0, mobility=0)
+    Traceback (most recent call last):
+        ...
+    ValueError: You cannot supply more or less than 2 values
+    >>> electric_conductivity(conductivity=50, electron_conc=200, mobility=300)
+    Traceback (most recent call last):
+        ...
+    ValueError: You cannot supply more or less than 2 values
+    """
+    if (conductivity, electron_conc, mobility).count(0) != 1:
+        raise ValueError("You cannot supply more or less than 2 values")
+    elif conductivity < 0:
+        raise ValueError("Conductivity cannot be negative")
+    elif electron_conc < 0:
+        raise ValueError("Electron concentration cannot be negative")
+    elif mobility < 0:
+        raise ValueError("mobility cannot be negative")
+    elif conductivity == 0:
+        return (
+            "conductivity",
+            mobility * electron_conc * ELECTRON_CHARGE,
+        )
+    elif electron_conc == 0:
+        return (
+            "electron_conc",
+            conductivity / (mobility * ELECTRON_CHARGE),
+        )
+    else:
+        return (
+            "mobility",
+            conductivity / (electron_conc * ELECTRON_CHARGE),
+        )
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add electric conductivity Python reference implementation
- implement electric conductivity calculator in pure Mochi
- include sample outputs from Mochi runtime

## Testing
- `python tests/github/TheAlgorithms/Python/electronics/electric_conductivity.py`
- `go run -v ./cmd/mochi run tests/github/TheAlgorithms/Mochi/electronics/electric_conductivity.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6891b7f63be08320a2f1a9a463a80edd