### PR TITLE
Add electrical impedance algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/electronics/electrical_impedance.mochi
+++ b/tests/github/TheAlgorithms/Mochi/electronics/electrical_impedance.mochi
@@ -1,0 +1,49 @@
+/*
+Compute the missing component of electrical impedance.
+
+In an AC circuit, impedance (Z) combines resistance (R) and reactance (X)
+through the relation Z = sqrt(R^2 + X^2).
+
+Given any two of these values and setting the unknown one to 0, this function
+returns a map with the name and value of the missing quantity. If not exactly
+one argument is 0, the function panics.
+
+All operations use basic arithmetic and run in constant time.
+*/
+
+fun sqrtApprox(x: float): float {
+  if x <= 0.0 { return 0.0 }
+  var guess = x / 2.0
+  var i = 0
+  while i < 20 {
+    guess = (guess + x / guess) / 2.0
+    i = i + 1
+  }
+  return guess
+}
+
+fun electrical_impedance(resistance: float, reactance: float, impedance: float): map<string, float> {
+  var zero_count = 0
+  if resistance == 0.0 { zero_count = zero_count + 1 }
+  if reactance == 0.0 { zero_count = zero_count + 1 }
+  if impedance == 0.0 { zero_count = zero_count + 1 }
+  if zero_count != 1 {
+    panic("One and only one argument must be 0")
+  }
+  if resistance == 0.0 {
+    let value = sqrtApprox(impedance*impedance - reactance*reactance)
+    return {"resistance": value}
+  } else if reactance == 0.0 {
+    let value = sqrtApprox(impedance*impedance - resistance*resistance)
+    return {"reactance": value}
+  } else if impedance == 0.0 {
+    let value = sqrtApprox(resistance*resistance + reactance*reactance)
+    return {"impedance": value}
+  } else {
+    panic("Exactly one argument must be 0")
+  }
+}
+
+print(electrical_impedance(3.0, 4.0, 0.0))
+print(electrical_impedance(0.0, 4.0, 5.0))
+print(electrical_impedance(3.0, 0.0, 5.0))

--- a/tests/github/TheAlgorithms/Mochi/electronics/electrical_impedance.out
+++ b/tests/github/TheAlgorithms/Mochi/electronics/electrical_impedance.out
@@ -1,0 +1,3 @@
+{"impedance": 5.0}
+{"resistance": 3.0}
+{"reactance": 4.0}

--- a/tests/github/TheAlgorithms/Python/electronics/electrical_impedance.py
+++ b/tests/github/TheAlgorithms/Python/electronics/electrical_impedance.py
@@ -1,0 +1,46 @@
+"""Electrical impedance is the measure of the opposition that a
+circuit presents to a current when a voltage is applied.
+Impedance extends the concept of resistance to alternating current (AC) circuits.
+Source: https://en.wikipedia.org/wiki/Electrical_impedance
+"""
+
+from __future__ import annotations
+
+from math import pow, sqrt  # noqa: A004
+
+
+def electrical_impedance(
+    resistance: float, reactance: float, impedance: float
+) -> dict[str, float]:
+    """
+    Apply Electrical Impedance formula, on any two given electrical values,
+    which can be resistance, reactance, and impedance, and then in a Python dict
+    return name/value pair of the zero value.
+
+    >>> electrical_impedance(3,4,0)
+    {'impedance': 5.0}
+    >>> electrical_impedance(0,4,5)
+    {'resistance': 3.0}
+    >>> electrical_impedance(3,0,5)
+    {'reactance': 4.0}
+    >>> electrical_impedance(3,4,5)
+    Traceback (most recent call last):
+      ...
+    ValueError: One and only one argument must be 0
+    """
+    if (resistance, reactance, impedance).count(0) != 1:
+        raise ValueError("One and only one argument must be 0")
+    if resistance == 0:
+        return {"resistance": sqrt(pow(impedance, 2) - pow(reactance, 2))}
+    elif reactance == 0:
+        return {"reactance": sqrt(pow(impedance, 2) - pow(resistance, 2))}
+    elif impedance == 0:
+        return {"impedance": sqrt(pow(resistance, 2) + pow(reactance, 2))}
+    else:
+        raise ValueError("Exactly one argument must be 0")
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python implementation of electrical impedance formula
- port electrical impedance calculation to Mochi with sqrt approximation and validation
- include sample executions and output for Mochi version

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/electronics/electrical_impedance.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891b7fc7d9c8320a8e35ead8068f201