### PR TITLE
feat: add Ohm's law algorithm in Mochi

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/electronics/ohms_law.mochi
+++ b/tests/github/TheAlgorithms/Mochi/electronics/ohms_law.mochi
@@ -1,0 +1,36 @@
+/*
+Ohm's Law relates three fundamental electrical quantities:
+voltage (V), current (I), and resistance (R).
+For any electrical component, knowing any two of these values
+allows computation of the third using V = I * R.
+This function accepts three floats where exactly one value
+must be 0. It validates the inputs (ensuring only one zero and
+non‑negative resistance) and returns a map containing the
+missing quantity.
+*/
+
+fun ohms_law(voltage: float, current: float, resistance: float): map<string, float> {
+  var zeros = 0
+  if voltage == 0.0 { zeros = zeros + 1 }
+  if current == 0.0 { zeros = zeros + 1 }
+  if resistance == 0.0 { zeros = zeros + 1 }
+  if zeros != 1 {
+    print("One and only one argument must be 0")
+    return {}
+  }
+  if resistance < 0.0 {
+    print("Resistance cannot be negative")
+    return {}
+  }
+  if voltage == 0.0 {
+    return {"voltage": current * resistance}
+  }
+  if current == 0.0 {
+    return {"current": voltage / resistance}
+  }
+  return {"resistance": voltage / current}
+}
+
+json(ohms_law(10.0, 0.0, 5.0))
+json(ohms_law(-10.0, 1.0, 0.0))
+json(ohms_law(0.0, -1.5, 2.0))

--- a/tests/github/TheAlgorithms/Mochi/electronics/ohms_law.out
+++ b/tests/github/TheAlgorithms/Mochi/electronics/ohms_law.out
@@ -1,0 +1,9 @@
+{
+  "current": 2
+}
+{
+  "resistance": -10
+}
+{
+  "voltage": -3
+}

--- a/tests/github/TheAlgorithms/Python/electronics/ohms_law.py
+++ b/tests/github/TheAlgorithms/Python/electronics/ohms_law.py
@@ -1,0 +1,42 @@
+# https://en.wikipedia.org/wiki/Ohm%27s_law
+from __future__ import annotations
+
+
+def ohms_law(voltage: float, current: float, resistance: float) -> dict[str, float]:
+    """
+    Apply Ohm's Law, on any two given electrical values, which can be voltage, current,
+    and resistance, and then in a Python dict return name/value pair of the zero value.
+
+    >>> ohms_law(voltage=10, resistance=5, current=0)
+    {'current': 2.0}
+    >>> ohms_law(voltage=0, current=0, resistance=10)
+    Traceback (most recent call last):
+      ...
+    ValueError: One and only one argument must be 0
+    >>> ohms_law(voltage=0, current=1, resistance=-2)
+    Traceback (most recent call last):
+      ...
+    ValueError: Resistance cannot be negative
+    >>> ohms_law(resistance=0, voltage=-10, current=1)
+    {'resistance': -10.0}
+    >>> ohms_law(voltage=0, current=-1.5, resistance=2)
+    {'voltage': -3.0}
+    """
+    if (voltage, current, resistance).count(0) != 1:
+        raise ValueError("One and only one argument must be 0")
+    if resistance < 0:
+        raise ValueError("Resistance cannot be negative")
+    if voltage == 0:
+        return {"voltage": float(current * resistance)}
+    elif current == 0:
+        return {"current": voltage / resistance}
+    elif resistance == 0:
+        return {"resistance": voltage / current}
+    else:
+        raise ValueError("Exactly one argument must be 0")
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python reference implementation of Ohm's law
- port Ohm's law to pure Mochi with sample executions

## Testing
- `go test ./...` *(partial; many packages report no test files)*
- `node index.js run tests/github/TheAlgorithms/Mochi/electronics/ohms_law.mochi` *(fails: Mochi binary not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891b80c0dfc8320af89a50d8f0d524c