### PR TITLE
Add simulated file transfer example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/file_transfer/receive_file.mochi
+++ b/tests/github/TheAlgorithms/Mochi/file_transfer/receive_file.mochi
@@ -1,0 +1,48 @@
+/*
+Receive File via Simulated Socket
+
+The original Python program connects to a server using TCP, sends a greeting,
+then receives file data in 1024-byte chunks until no more data is available.
+Each chunk is written to a local file before the connection is closed.
+
+This Mochi version avoids real network and file I/O to remain runnable in the
+VM. Instead, it simulates incoming network packets using a list of string
+chunks. Each non-empty chunk is appended to an output buffer until an empty
+string indicates the end of transmission. The concatenated result represents
+the received file.
+
+Algorithm:
+1. Initialize output buffer.
+2. For each chunk in the input list:
+   - Stop if the chunk is an empty string.
+   - Append the chunk to the buffer.
+3. Return the assembled data.
+
+Time complexity is O(n) where n is the total length of all chunks.
+*/
+
+fun receive_file(chunks: list<string>): string {
+  var out = ""
+  var i = 0
+  print("File opened")
+  print("Receiving data...")
+  while i < len(chunks) {
+    let data = chunks[i]
+    if data == "" {
+      break
+    }
+    out = out + data
+    i = i + 1
+  }
+  print("Successfully received the file")
+  print("Connection closed")
+  return out
+}
+
+fun main() {
+  let incoming = ["Hello ", "from ", "server"]
+  let received = receive_file(incoming)
+  print(received)
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/file_transfer/receive_file.out
+++ b/tests/github/TheAlgorithms/Mochi/file_transfer/receive_file.out
@@ -1,0 +1,5 @@
+File opened
+Receiving data...
+Successfully received the file
+Connection closed
+Hello from server

--- a/tests/github/TheAlgorithms/Python/file_transfer/receive_file.py
+++ b/tests/github/TheAlgorithms/Python/file_transfer/receive_file.py
@@ -1,0 +1,27 @@
+import socket
+
+
+def main():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    host = socket.gethostname()
+    port = 12312
+
+    sock.connect((host, port))
+    sock.send(b"Hello server!")
+
+    with open("Received_file", "wb") as out_file:
+        print("File opened")
+        print("Receiving data...")
+        while True:
+            data = sock.recv(1024)
+            if not data:
+                break
+            out_file.write(data)
+
+    print("Successfully received the file")
+    sock.close()
+    print("Connection closed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python file_transfer receive_file example
- implement equivalent Mochi version simulating socket file reception

## Testing
- `bin/mochi run tests/github/TheAlgorithms/Mochi/file_transfer/receive_file.mochi > tests/github/TheAlgorithms/Mochi/file_transfer/receive_file.out`


------
https://chatgpt.com/codex/tasks/task_e_6891ba89a39883209b3a3ff3f0d0d45d