### PR TITLE
Add send file algorithm example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/file_transfer/send_file.mochi
+++ b/tests/github/TheAlgorithms/Mochi/file_transfer/send_file.mochi
@@ -1,0 +1,27 @@
+/*
+File Transfer: Send File over Network
+
+The original Python implementation starts a simple TCP server that sends the
+contents of a file to a client in 1024 byte chunks.  It waits for a connection,
+reads the file in fixed-size blocks, sends each block, and closes the
+connection when finished.
+
+This Mochi version simulates the same chunked transmission without using
+network sockets.  Given a string containing file data, it emits each
+chunk to standard output to illustrate the incremental sending algorithm.
+*/
+fun send_file(content: string, chunk_size: int) {
+  var start: int = 0
+  let n: int = len(content)
+  while start < n {
+    var end: int = start + chunk_size
+    if end > n {
+      end = n
+    }
+    let chunk: string = substring(content, start, end)
+    print(chunk)
+    start = end
+  }
+}
+
+send_file("The quick brown fox jumps over the lazy dog.", 10)

--- a/tests/github/TheAlgorithms/Mochi/file_transfer/send_file.out
+++ b/tests/github/TheAlgorithms/Mochi/file_transfer/send_file.out
@@ -1,0 +1,5 @@
+The quick 
+brown fox 
+jumps over
+ the lazy 
+dog.

--- a/tests/github/TheAlgorithms/Python/file_transfer/send_file.py
+++ b/tests/github/TheAlgorithms/Python/file_transfer/send_file.py
@@ -1,0 +1,35 @@
+def send_file(filename: str = "mytext.txt", testing: bool = False) -> None:
+    import socket
+
+    port = 12312  # Reserve a port for your service.
+    sock = socket.socket()  # Create a socket object
+    host = socket.gethostname()  # Get local machine name
+    sock.bind((host, port))  # Bind to the port
+    sock.listen(5)  # Now wait for client connection.
+
+    print("Server listening....")
+
+    while True:
+        conn, addr = sock.accept()  # Establish connection with client.
+        print(f"Got connection from {addr}")
+        data = conn.recv(1024)
+        print(f"Server received: {data = }")
+
+        with open(filename, "rb") as in_file:
+            data = in_file.read(1024)
+            while data:
+                conn.send(data)
+                print(f"Sent {data!r}")
+                data = in_file.read(1024)
+
+        print("Done sending")
+        conn.close()
+        if testing:  # Allow the test to complete
+            break
+
+    sock.shutdown(1)
+    sock.close()
+
+
+if __name__ == "__main__":
+    send_file()


### PR DESCRIPTION
## Summary
- add missing Python send_file implementation for file transfer
- simulate file transfer in Mochi by chunking string data and printing chunks

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/file_transfer/send_file.mochi > tests/github/TheAlgorithms/Mochi/file_transfer/send_file.out`


------
https://chatgpt.com/codex/tasks/task_e_6891ba8b68bc83209f5ff0c60ac4e1b9