### PR TITLE
Add price plus tax algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/financial/price_plus_tax.mochi
+++ b/tests/github/TheAlgorithms/Mochi/financial/price_plus_tax.mochi
@@ -1,0 +1,15 @@
+/*
+Price Plus Tax
+--------------
+Given the base price of a good or service and a tax rate expressed as a
+fraction, this algorithm computes the total cost including tax.  The
+final price is obtained by multiplying the price by (1 + tax_rate).
+For example, a price of 100 with a 25% tax rate yields 125.
+*/
+
+fun price_plus_tax(price: float, tax_rate: float): float {
+  return price * (1.0 + tax_rate)
+}
+
+print("price_plus_tax(100, 0.25) = " + str(price_plus_tax(100.0, 0.25)))
+print("price_plus_tax(125.50, 0.05) = " + str(price_plus_tax(125.50, 0.05)))

--- a/tests/github/TheAlgorithms/Mochi/financial/price_plus_tax.out
+++ b/tests/github/TheAlgorithms/Mochi/financial/price_plus_tax.out
@@ -1,0 +1,2 @@
+price_plus_tax(100, 0.25) = 125
+price_plus_tax(125.50, 0.05) = 131.775

--- a/tests/github/TheAlgorithms/Python/financial/price_plus_tax.py
+++ b/tests/github/TheAlgorithms/Python/financial/price_plus_tax.py
@@ -1,0 +1,18 @@
+"""
+Calculate price plus tax of a good or service given its price and a tax rate.
+"""
+
+
+def price_plus_tax(price: float, tax_rate: float) -> float:
+    """
+    >>> price_plus_tax(100, 0.25)
+    125.0
+    >>> price_plus_tax(125.50, 0.05)
+    131.775
+    """
+    return price * (1 + tax_rate)
+
+
+if __name__ == "__main__":
+    print(f"{price_plus_tax(100, 0.25) = }")
+    print(f"{price_plus_tax(125.50, 0.05) = }")


### PR DESCRIPTION
## Summary
- Add Python implementation for calculating price plus tax
- Add equivalent Mochi implementation with sample output

## Testing
- `bin/mochi run tests/github/TheAlgorithms/Mochi/financial/price_plus_tax.mochi`
- `npm test` *(fails: Missing script "test")*
- `go test ./runtime/vm` *(hangs, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6891ba9b4850832090de17bb68f91505