### PR TITLE
Add simple moving average example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/financial/simple_moving_average.mochi
+++ b/tests/github/TheAlgorithms/Mochi/financial/simple_moving_average.mochi
@@ -1,0 +1,51 @@
+/*
+Calculate the simple moving average (SMA) of a time series.
+For each position i in the data list we consider the last `window_size`
+values including the current one. If fewer than `window_size` values
+exist we record that no average is available. Otherwise we compute the
+mean of the window. This uses a sliding window sum so the algorithm runs
+in O(n) time where n is the number of data points and uses O(1) extra
+space beyond the output list.
+*/
+
+type SMAValue {
+  value: float,
+  ok: bool,
+}
+
+fun simple_moving_average(data: list<float>, window_size: int): list<SMAValue> {
+  if window_size < 1 {
+    panic("Window size must be a positive integer")
+  }
+  var result: list<SMAValue> = []
+  var window_sum: float = 0.0
+  var i: int = 0
+  while i < len(data) {
+    window_sum = window_sum + data[i]
+    if i >= window_size {
+      window_sum = window_sum - data[i - window_size]
+    }
+    if i >= window_size - 1 {
+      let avg = window_sum / window_size
+      result = append(result, SMAValue { value: avg, ok: true })
+    } else {
+      result = append(result, SMAValue { value: 0.0, ok: false })
+    }
+    i = i + 1
+  }
+  return result
+}
+
+let data = [10.0, 12.0, 15.0, 13.0, 14.0, 16.0, 18.0, 17.0, 19.0, 21.0]
+let window_size = 3
+let sma_values = simple_moving_average(data, window_size)
+var idx = 0
+while idx < len(sma_values) {
+  let item = sma_values[idx]
+  if item.ok {
+    print("Day " + str(idx + 1) + ": " + str(item.value))
+  } else {
+    print("Day " + str(idx + 1) + ": Not enough data for SMA")
+  }
+  idx = idx + 1
+}

--- a/tests/github/TheAlgorithms/Mochi/financial/simple_moving_average.out
+++ b/tests/github/TheAlgorithms/Mochi/financial/simple_moving_average.out
@@ -1,0 +1,10 @@
+Day 1: Not enough data for SMA
+Day 2: Not enough data for SMA
+Day 3: 12.333333333333334
+Day 4: 13.333333333333334
+Day 5: 14
+Day 6: 14.333333333333334
+Day 7: 16
+Day 8: 17
+Day 9: 18
+Day 10: 19

--- a/tests/github/TheAlgorithms/Python/financial/simple_moving_average.py
+++ b/tests/github/TheAlgorithms/Python/financial/simple_moving_average.py
@@ -1,0 +1,69 @@
+"""
+The Simple Moving Average (SMA) is a statistical calculation used to analyze data points
+by creating a constantly updated average price over a specific time period.
+In finance, SMA is often used in time series analysis to smooth out price data
+and identify trends.
+
+Reference: https://en.wikipedia.org/wiki/Moving_average
+"""
+
+from collections.abc import Sequence
+
+
+def simple_moving_average(
+    data: Sequence[float], window_size: int
+) -> list[float | None]:
+    """
+    Calculate the simple moving average (SMA) for some given time series data.
+
+    :param data: A list of numerical data points.
+    :param window_size: An integer representing the size of the SMA window.
+    :return: A list of SMA values with the same length as the input data.
+
+    Examples:
+    >>> sma = simple_moving_average([10, 12, 15, 13, 14, 16, 18, 17, 19, 21], 3)
+    >>> [round(value, 2) if value is not None else None for value in sma]
+    [None, None, 12.33, 13.33, 14.0, 14.33, 16.0, 17.0, 18.0, 19.0]
+    >>> simple_moving_average([10, 12, 15], 5)
+    [None, None, None]
+    >>> simple_moving_average([10, 12, 15, 13, 14, 16, 18, 17, 19, 21], 0)
+    Traceback (most recent call last):
+    ...
+    ValueError: Window size must be a positive integer
+    """
+    if window_size < 1:
+        raise ValueError("Window size must be a positive integer")
+
+    sma: list[float | None] = []
+
+    for i in range(len(data)):
+        if i < window_size - 1:
+            sma.append(None)  # SMA not available for early data points
+        else:
+            window = data[i - window_size + 1 : i + 1]
+            sma_value = sum(window) / window_size
+            sma.append(sma_value)
+    return sma
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+
+    # Example data (replace with your own time series data)
+    data = [10, 12, 15, 13, 14, 16, 18, 17, 19, 21]
+
+    # Specify the window size for the SMA
+    window_size = 3
+
+    # Calculate the Simple Moving Average
+    sma_values = simple_moving_average(data, window_size)
+
+    # Print the SMA values
+    print("Simple Moving Average (SMA) Values:")
+    for i, value in enumerate(sma_values):
+        if value is not None:
+            print(f"Day {i + 1}: {value:.2f}")
+        else:
+            print(f"Day {i + 1}: Not enough data for SMA")


### PR DESCRIPTION
## Summary
- add TheAlgorithms' simple moving average Python source
- implement simple moving average in Mochi using a sliding window
- capture VM runtime output for the Mochi example

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/financial/simple_moving_average.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891ba9d25948320bc2fc2fe5ad3a579