### PR TITLE
Add Mochi port of fuzzy set operations

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/fuzzy_logic/fuzzy_operations.mochi
+++ b/tests/github/TheAlgorithms/Mochi/fuzzy_logic/fuzzy_operations.mochi
@@ -1,0 +1,96 @@
+/*
+Triangular Fuzzy Set Operations
+
+This program models basic operations on triangular fuzzy sets used in
+fuzzy logic.  A fuzzy set is represented by three points
+(left_boundary, peak, right_boundary) forming a triangle-shaped
+membership function over the range [0,1].  The operations implemented
+are:
+
+- membership(x): piecewise linear degree of membership for value x.
+- complement: mirror the set around 1 to obtain its negation.
+- intersection: combine two sets by taking the maximum of left
+  boundaries, the minimum of right boundaries and the average of peaks.
+- union: combine two sets using the minimum of left boundaries, the
+  maximum of right boundaries and the average of peaks.
+
+The example at the bottom constructs two fuzzy sets and demonstrates
+these operations.
+*/
+
+type FuzzySet {
+  name: string,
+  left_boundary: float,
+  peak: float,
+  right_boundary: float
+}
+
+fun stringify(fs: FuzzySet): string {
+  return fs.name + ": [" + str(fs.left_boundary) + ", " + str(fs.peak) + ", " + str(fs.right_boundary) + "]"
+}
+
+fun max2(a: float, b: float): float {
+  if a > b { return a }
+  return b
+}
+
+fun min2(a: float, b: float): float {
+  if a < b { return a }
+  return b
+}
+
+fun complement(fs: FuzzySet): FuzzySet {
+  return FuzzySet {
+    name: "¬" + fs.name,
+    left_boundary: 1.0 - fs.right_boundary,
+    peak: 1.0 - fs.left_boundary,
+    right_boundary: 1.0 - fs.peak
+  }
+}
+
+fun intersection(a: FuzzySet, b: FuzzySet): FuzzySet {
+  return FuzzySet {
+    name: a.name + " ∩ " + b.name,
+    left_boundary: max2(a.left_boundary, b.left_boundary),
+    peak: min2(a.right_boundary, b.right_boundary),
+    right_boundary: (a.peak + b.peak) / 2.0
+  }
+}
+
+fun union(a: FuzzySet, b: FuzzySet): FuzzySet {
+  return FuzzySet {
+    name: a.name + " U " + b.name,
+    left_boundary: min2(a.left_boundary, b.left_boundary),
+    peak: max2(a.right_boundary, b.right_boundary),
+    right_boundary: (a.peak + b.peak) / 2.0
+  }
+}
+
+fun membership(fs: FuzzySet, x: float): float {
+  if x <= fs.left_boundary || x >= fs.right_boundary { return 0.0 }
+  if fs.left_boundary < x && x <= fs.peak {
+    return (x - fs.left_boundary) / (fs.peak - fs.left_boundary)
+  }
+  if fs.peak < x && x < fs.right_boundary {
+    return (fs.right_boundary - x) / (fs.right_boundary - fs.peak)
+  }
+  return 0.0
+}
+
+let sheru = FuzzySet { name: "Sheru", left_boundary: 0.4, peak: 1.0, right_boundary: 0.6 }
+let siya = FuzzySet { name: "Siya", left_boundary: 0.5, peak: 1.0, right_boundary: 0.7 }
+
+print(stringify(sheru))
+print(stringify(siya))
+
+let sheru_comp = complement(sheru)
+print(stringify(sheru_comp))
+
+let inter = intersection(siya, sheru)
+print(stringify(inter))
+
+print("Sheru membership 0.5: " + str(membership(sheru, 0.5)))
+print("Sheru membership 0.6: " + str(membership(sheru, 0.6)))
+
+let uni = union(siya, sheru)
+print(stringify(uni))

--- a/tests/github/TheAlgorithms/Mochi/fuzzy_logic/fuzzy_operations.out
+++ b/tests/github/TheAlgorithms/Mochi/fuzzy_logic/fuzzy_operations.out
@@ -1,0 +1,7 @@
+Sheru: [0.4, 1, 0.6]
+Siya: [0.5, 1, 0.7]
+¬Sheru: [0.4, 0.6, 0]
+Siya ∩ Sheru: [0.5, 0.6, 1]
+Sheru membership 0.5: 0.16666666666666663
+Sheru membership 0.6: 0
+Siya U Sheru: [0.4, 0.7, 1]

--- a/tests/github/TheAlgorithms/Python/fuzzy_logic/fuzzy_operations.py
+++ b/tests/github/TheAlgorithms/Python/fuzzy_logic/fuzzy_operations.py
@@ -1,0 +1,195 @@
+"""
+By @Shreya123714
+
+https://en.wikipedia.org/wiki/Fuzzy_set
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+@dataclass
+class FuzzySet:
+    """
+    A class for representing and manipulating triangular fuzzy sets.
+    Attributes:
+        name: The name or label of the fuzzy set.
+        left_boundary: The left boundary of the fuzzy set.
+        peak: The peak (central) value of the fuzzy set.
+        right_boundary: The right boundary of the fuzzy set.
+    Methods:
+        membership(x): Calculate the membership value of an input 'x' in the fuzzy set.
+        union(other): Calculate the union of this fuzzy set with another fuzzy set.
+        intersection(other): Calculate the intersection of this fuzzy set with another.
+        complement(): Calculate the complement (negation) of this fuzzy set.
+        plot(): Plot the membership function of the fuzzy set.
+
+    >>> sheru = FuzzySet("Sheru", 0.4, 1, 0.6)
+    >>> sheru
+    FuzzySet(name='Sheru', left_boundary=0.4, peak=1, right_boundary=0.6)
+    >>> str(sheru)
+    'Sheru: [0.4, 1, 0.6]'
+
+    >>> siya = FuzzySet("Siya", 0.5, 1, 0.7)
+    >>> siya
+    FuzzySet(name='Siya', left_boundary=0.5, peak=1, right_boundary=0.7)
+
+    # Complement Operation
+    >>> sheru.complement()
+    FuzzySet(name='¬Sheru', left_boundary=0.4, peak=0.6, right_boundary=0)
+    >>> siya.complement()  # doctest: +NORMALIZE_WHITESPACE
+    FuzzySet(name='¬Siya', left_boundary=0.30000000000000004, peak=0.5,
+     right_boundary=0)
+
+    # Intersection Operation
+    >>> siya.intersection(sheru)
+    FuzzySet(name='Siya ∩ Sheru', left_boundary=0.5, peak=0.6, right_boundary=1.0)
+
+    # Membership Operation
+    >>> sheru.membership(0.5)
+    0.16666666666666663
+    >>> sheru.membership(0.6)
+    0.0
+
+    # Union Operations
+    >>> siya.union(sheru)
+    FuzzySet(name='Siya U Sheru', left_boundary=0.4, peak=0.7, right_boundary=1.0)
+    """
+
+    name: str
+    left_boundary: float
+    peak: float
+    right_boundary: float
+
+    def __str__(self) -> str:
+        """
+        >>> FuzzySet("fuzzy_set", 0.1, 0.2, 0.3)
+        FuzzySet(name='fuzzy_set', left_boundary=0.1, peak=0.2, right_boundary=0.3)
+        """
+        return (
+            f"{self.name}: [{self.left_boundary}, {self.peak}, {self.right_boundary}]"
+        )
+
+    def complement(self) -> FuzzySet:
+        """
+        Calculate the complement (negation) of this fuzzy set.
+        Returns:
+            FuzzySet: A new fuzzy set representing the complement.
+
+        >>> FuzzySet("fuzzy_set", 0.1, 0.2, 0.3).complement()
+        FuzzySet(name='¬fuzzy_set', left_boundary=0.7, peak=0.9, right_boundary=0.8)
+        """
+        return FuzzySet(
+            f"¬{self.name}",
+            1 - self.right_boundary,
+            1 - self.left_boundary,
+            1 - self.peak,
+        )
+
+    def intersection(self, other) -> FuzzySet:
+        """
+        Calculate the intersection of this fuzzy set
+        with another fuzzy set.
+        Args:
+            other: Another fuzzy set to intersect with.
+        Returns:
+            A new fuzzy set representing the intersection.
+
+        >>> FuzzySet("a", 0.1, 0.2, 0.3).intersection(FuzzySet("b", 0.4, 0.5, 0.6))
+        FuzzySet(name='a ∩ b', left_boundary=0.4, peak=0.3, right_boundary=0.35)
+        """
+        return FuzzySet(
+            f"{self.name} ∩ {other.name}",
+            max(self.left_boundary, other.left_boundary),
+            min(self.right_boundary, other.right_boundary),
+            (self.peak + other.peak) / 2,
+        )
+
+    def membership(self, x: float) -> float:
+        """
+        Calculate the membership value of an input 'x' in the fuzzy set.
+        Returns:
+            The membership value of 'x' in the fuzzy set.
+
+        >>> a = FuzzySet("a", 0.1, 0.2, 0.3)
+        >>> a.membership(0.09)
+        0.0
+        >>> a.membership(0.1)
+        0.0
+        >>> a.membership(0.11)
+        0.09999999999999995
+        >>> a.membership(0.4)
+        0.0
+        >>> FuzzySet("A", 0, 0.5, 1).membership(0.1)
+        0.2
+        >>> FuzzySet("B", 0.2, 0.7, 1).membership(0.6)
+        0.8
+        """
+        if x <= self.left_boundary or x >= self.right_boundary:
+            return 0.0
+        elif self.left_boundary < x <= self.peak:
+            return (x - self.left_boundary) / (self.peak - self.left_boundary)
+        elif self.peak < x < self.right_boundary:
+            return (self.right_boundary - x) / (self.right_boundary - self.peak)
+        msg = f"Invalid value {x} for fuzzy set {self}"
+        raise ValueError(msg)
+
+    def union(self, other) -> FuzzySet:
+        """
+        Calculate the union of this fuzzy set with another fuzzy set.
+        Args:
+            other (FuzzySet): Another fuzzy set to union with.
+        Returns:
+            FuzzySet: A new fuzzy set representing the union.
+
+        >>> FuzzySet("a", 0.1, 0.2, 0.3).union(FuzzySet("b", 0.4, 0.5, 0.6))
+        FuzzySet(name='a U b', left_boundary=0.1, peak=0.6, right_boundary=0.35)
+        """
+        return FuzzySet(
+            f"{self.name} U {other.name}",
+            min(self.left_boundary, other.left_boundary),
+            max(self.right_boundary, other.right_boundary),
+            (self.peak + other.peak) / 2,
+        )
+
+    def plot(self):
+        """
+        Plot the membership function of the fuzzy set.
+        """
+        x = np.linspace(0, 1, 1000)
+        y = [self.membership(xi) for xi in x]
+
+        plt.plot(x, y, label=self.name)
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()
+    a = FuzzySet("A", 0, 0.5, 1)
+    b = FuzzySet("B", 0.2, 0.7, 1)
+
+    a.plot()
+    b.plot()
+
+    plt.xlabel("x")
+    plt.ylabel("Membership")
+    plt.legend()
+    plt.show()
+
+    union_ab = a.union(b)
+    intersection_ab = a.intersection(b)
+    complement_a = a.complement()
+
+    union_ab.plot()
+    intersection_ab.plot()
+    complement_a.plot()
+
+    plt.xlabel("x")
+    plt.ylabel("Membership")
+    plt.legend()
+    plt.show()


### PR DESCRIPTION
## Summary
- add TheAlgorithms Python reference for triangular fuzzy set operations
- implement equivalent fuzzy set operations in Mochi and demo usage

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/fuzzy_logic/fuzzy_operations.mochi > tests/github/TheAlgorithms/Mochi/fuzzy_logic/fuzzy_operations.out`


------
https://chatgpt.com/codex/tasks/task_e_6891c5bacdb8832097efe42c9095a0bc