### PR TITLE
feat: add DDA line algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/graphics/digital_differential_analyzer_line.mochi
+++ b/tests/github/TheAlgorithms/Mochi/graphics/digital_differential_analyzer_line.mochi
@@ -1,0 +1,56 @@
+/*
+Digital Differential Analyzer (DDA) Line Drawing Algorithm
+---------------------------------------------------------
+Given two endpoints of a line segment on a 2D grid, the DDA algorithm
+increments the coordinate values in equal steps from the start point to the
+end point.  The number of steps equals the larger of |dx| or |dy| so that
+at each iteration we advance at most one pixel in either axis.  By adding
+a fractional increment to x and y and rounding to the nearest integer, we
+obtain all intermediate integer coordinates along the line.
+This routine runs in O(max(|dx|, |dy|)) time using O(1) extra space.
+*/
+
+type Point {
+  x: int,
+  y: int,
+}
+
+fun abs_int(n: int): int {
+  if n < 0 {
+    return -n
+  }
+  return n
+}
+
+fun round_int(x: float): int {
+  return (x + 0.5) as int
+}
+
+fun digital_differential_analyzer_line(p1: Point, p2: Point): list<Point> {
+  let dx = p2.x - p1.x
+  let dy = p2.y - p1.y
+  let abs_dx = abs_int(dx)
+  let abs_dy = abs_int(dy)
+  let steps = if abs_dx > abs_dy { abs_dx } else { abs_dy }
+  let x_increment = (dx as float) / (steps as float)
+  let y_increment = (dy as float) / (steps as float)
+  var coordinates: list<Point> = []
+  var x = p1.x as float
+  var y = p1.y as float
+  var i = 0
+  while i < steps {
+    x = x + x_increment
+    y = y + y_increment
+    let point = Point{x: round_int(x), y: round_int(y)}
+    coordinates = append(coordinates, point)
+    i = i + 1
+  }
+  return coordinates
+}
+
+fun main() {
+  let result = digital_differential_analyzer_line(Point{x:1, y:1}, Point{x:4, y:4})
+  print(result)
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/graphics/digital_differential_analyzer_line.out
+++ b/tests/github/TheAlgorithms/Mochi/graphics/digital_differential_analyzer_line.out
@@ -1,0 +1,1 @@
+[{"__name": "Point", "x": 2, "y": 2}, {"__name": "Point", "x": 3, "y": 3}, {"__name": "Point", "x": 4, "y": 4}]

--- a/tests/github/TheAlgorithms/Python/graphics/digital_differential_analyzer_line.py
+++ b/tests/github/TheAlgorithms/Python/graphics/digital_differential_analyzer_line.py
@@ -1,0 +1,52 @@
+import matplotlib.pyplot as plt
+
+
+def digital_differential_analyzer_line(
+    p1: tuple[int, int], p2: tuple[int, int]
+) -> list[tuple[int, int]]:
+    """
+    Draws a line between two points using the DDA algorithm.
+
+    Args:
+    - p1: Coordinates of the starting point.
+    - p2: Coordinates of the ending point.
+    Returns:
+    - List of coordinate points that form the line.
+
+    >>> digital_differential_analyzer_line((1, 1), (4, 4))
+    [(2, 2), (3, 3), (4, 4)]
+    """
+    x1, y1 = p1
+    x2, y2 = p2
+    dx = x2 - x1
+    dy = y2 - y1
+    steps = max(abs(dx), abs(dy))
+    x_increment = dx / float(steps)
+    y_increment = dy / float(steps)
+    coordinates = []
+    x: float = x1
+    y: float = y1
+    for _ in range(steps):
+        x += x_increment
+        y += y_increment
+        coordinates.append((round(x), round(y)))
+    return coordinates
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+
+    x1 = int(input("Enter the x-coordinate of the starting point: "))
+    y1 = int(input("Enter the y-coordinate of the starting point: "))
+    x2 = int(input("Enter the x-coordinate of the ending point: "))
+    y2 = int(input("Enter the y-coordinate of the ending point: "))
+    coordinates = digital_differential_analyzer_line((x1, y1), (x2, y2))
+    x_points, y_points = zip(*coordinates)
+    plt.plot(x_points, y_points, marker="o")
+    plt.title("Digital Differential Analyzer Line Drawing Algorithm")
+    plt.xlabel("X-axis")
+    plt.ylabel("Y-axis")
+    plt.grid()
+    plt.show()


### PR DESCRIPTION
## Summary
- port Digital Differential Analyzer line drawing algorithm from Python to Mochi
- include sample execution producing list of points along the line

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/graphics/digital_differential_analyzer_line.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6891c5c34dd48320a449f4944ddcd2f6