### PR TITLE
Add Mochi Borůvka MST implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/graphs/boruvka.mochi
+++ b/tests/github/TheAlgorithms/Mochi/graphs/boruvka.mochi
@@ -1,0 +1,142 @@
+/*
+Borůvka's algorithm for constructing a minimum spanning tree (MST).
+
+For each connected component of an undirected weighted graph, the algorithm
+selects the lightest outgoing edge. All selected edges are added to the MST
+simultaneously and their incident components are merged via union-find. The
+process repeats until a single component remains. Because each phase at least
+halves the number of components, the overall running time is O(E log V) where E
+is the number of edges and V the number of vertices. The extra memory required
+is O(V + E) for storing edges, component identifiers, and union-find metadata.
+*/
+
+type Edge { u: int, v: int, w: int }
+
+type Graph { num_nodes: int, edges: list<Edge>, component: map<int, int> }
+
+type UnionResult { graph: Graph, component_size: list<int> }
+
+fun new_graph(num_nodes: int): Graph {
+  return Graph{ num_nodes: num_nodes, edges: [], component: {} }
+}
+
+fun add_edge(g: Graph, u: int, v: int, w: int): Graph {
+  var es = g.edges
+  es = append(es, Edge{ u: u, v: v, w: w })
+  return Graph{ num_nodes: g.num_nodes, edges: es, component: g.component }
+}
+
+fun find_component(g: Graph, node: int): int {
+  if g.component[node] == node {
+    return node
+  }
+  return find_component(g, g.component[node])
+}
+
+fun set_component(g: Graph, node: int): Graph {
+  if g.component[node] != node {
+    var comp = g.component
+    for k in keys(comp) {
+      comp[k] = find_component(g, k)
+    }
+    g = Graph{ num_nodes: g.num_nodes, edges: g.edges, component: comp }
+  }
+  return g
+}
+
+fun union(g: Graph, component_size: list<int>, u: int, v: int): UnionResult {
+  var comp_size = component_size
+  var comp = g.component
+  if comp_size[u] <= comp_size[v] {
+    comp[u] = v
+    comp_size[v] = comp_size[v] + comp_size[u]
+    g = Graph{ num_nodes: g.num_nodes, edges: g.edges, component: comp }
+    g = set_component(g, u)
+  } else {
+    comp[v] = u
+    comp_size[u] = comp_size[u] + comp_size[v]
+    g = Graph{ num_nodes: g.num_nodes, edges: g.edges, component: comp }
+    g = set_component(g, v)
+  }
+  return UnionResult{ graph: g, component_size: comp_size }
+}
+
+fun create_empty_edges(n: int): list<Edge> {
+  var res: list<Edge> = []
+  var i = 0
+  while i < n {
+    res = append(res, Edge{ u: -1, v: -1, w: -1 })
+    i = i + 1
+  }
+  return res
+}
+
+fun boruvka(g: Graph): int {
+  var component_size: list<int> = []
+  var i = 0
+  while i < g.num_nodes {
+    component_size = append(component_size, 1)
+    g.component[i] = i
+    i = i + 1
+  }
+  var mst_weight = 0
+  var num_components = g.num_nodes
+  var minimum_weight_edge = create_empty_edges(g.num_nodes)
+
+  while num_components > 1 {
+    for e in g.edges {
+      let u = e.u
+      let v = e.v
+      let w = e.w
+      let u_comp = g.component[u]
+      let v_comp = g.component[v]
+      if u_comp != v_comp {
+        let current_u = minimum_weight_edge[u_comp]
+        if current_u.u == -1 || current_u.w > w {
+          minimum_weight_edge[u_comp] = Edge{ u: u, v: v, w: w }
+        }
+        let current_v = minimum_weight_edge[v_comp]
+        if current_v.u == -1 || current_v.w > w {
+          minimum_weight_edge[v_comp] = Edge{ u: u, v: v, w: w }
+        }
+      }
+    }
+
+    for e in minimum_weight_edge {
+      if e.u != -1 {
+        let u = e.u
+        let v = e.v
+        let w = e.w
+        let u_comp = g.component[u]
+        let v_comp = g.component[v]
+        if u_comp != v_comp {
+          mst_weight = mst_weight + w
+          let res = union(g, component_size, u_comp, v_comp)
+          g = res.graph
+          component_size = res.component_size
+          print("Added edge [" + str(u) + " - " + str(v) + "]")
+          print("Added weight: " + str(w))
+          print("")
+          num_components = num_components - 1
+        }
+      }
+    }
+    minimum_weight_edge = create_empty_edges(g.num_nodes)
+  }
+  print("The total weight of the minimal spanning tree is: " + str(mst_weight))
+  return mst_weight
+}
+
+fun main() {
+  var g = new_graph(8)
+  let edges: list<list<int>> = [
+    [0, 1, 10], [0, 2, 6], [0, 3, 5], [1, 3, 15], [2, 3, 4],
+    [3, 4, 8], [4, 5, 10], [4, 6, 6], [4, 7, 5], [5, 7, 15], [6, 7, 4]
+  ]
+  for e in edges {
+    g = add_edge(g, e[0], e[1], e[2])
+  }
+  boruvka(g)
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/graphs/boruvka.out
+++ b/tests/github/TheAlgorithms/Mochi/graphs/boruvka.out
@@ -1,0 +1,22 @@
+Added edge [0 - 3]
+Added weight: 5
+
+Added edge [0 - 1]
+Added weight: 10
+
+Added edge [2 - 3]
+Added weight: 4
+
+Added edge [4 - 7]
+Added weight: 5
+
+Added edge [4 - 5]
+Added weight: 10
+
+Added edge [6 - 7]
+Added weight: 4
+
+Added edge [3 - 4]
+Added weight: 8
+
+The total weight of the minimal spanning tree is: 46

--- a/tests/github/TheAlgorithms/Python/graphs/boruvka.py
+++ b/tests/github/TheAlgorithms/Python/graphs/boruvka.py
@@ -1,0 +1,176 @@
+"""Borůvka's algorithm.
+
+Determines the minimum spanning tree (MST) of a graph using the Borůvka's algorithm.
+Borůvka's algorithm is a greedy algorithm for finding a minimum spanning tree in a
+connected graph, or a minimum spanning forest if a graph that is not connected.
+
+The time complexity of this algorithm is O(ELogV), where E represents the number
+of edges, while V represents the number of nodes.
+O(number_of_edges Log number_of_nodes)
+
+The space complexity of this algorithm is O(V + E), since we have to keep a couple
+of lists whose sizes are equal to the number of nodes, as well as keep all the
+edges of a graph inside of the data structure itself.
+
+Borůvka's algorithm gives us pretty much the same result as other MST Algorithms -
+they all find the minimum spanning tree, and the time complexity is approximately
+the same.
+
+One advantage that Borůvka's algorithm has compared to the alternatives is that it
+doesn't need to presort the edges or maintain a priority queue in order to find the
+minimum spanning tree.
+Even though that doesn't help its complexity, since it still passes the edges logE
+times, it is a bit simpler to code.
+
+Details: https://en.wikipedia.org/wiki/Bor%C5%AFvka%27s_algorithm
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class Graph:
+    def __init__(self, num_of_nodes: int) -> None:
+        """
+        Arguments:
+            num_of_nodes - the number of nodes in the graph
+        Attributes:
+            m_num_of_nodes - the number of nodes in the graph.
+            m_edges - the list of edges.
+            m_component - the dictionary which stores the index of the component which
+            a node belongs to.
+        """
+
+        self.m_num_of_nodes = num_of_nodes
+        self.m_edges: list[list[int]] = []
+        self.m_component: dict[int, int] = {}
+
+    def add_edge(self, u_node: int, v_node: int, weight: int) -> None:
+        """Adds an edge in the format [first, second, edge weight] to graph."""
+
+        self.m_edges.append([u_node, v_node, weight])
+
+    def find_component(self, u_node: int) -> int:
+        """Propagates a new component throughout a given component."""
+
+        if self.m_component[u_node] == u_node:
+            return u_node
+        return self.find_component(self.m_component[u_node])
+
+    def set_component(self, u_node: int) -> None:
+        """Finds the component index of a given node"""
+
+        if self.m_component[u_node] != u_node:
+            for k in self.m_component:
+                self.m_component[k] = self.find_component(k)
+
+    def union(self, component_size: list[int], u_node: int, v_node: int) -> None:
+        """Union finds the roots of components for two nodes, compares the components
+        in terms of size, and attaches the smaller one to the larger one to form
+        single component"""
+
+        if component_size[u_node] <= component_size[v_node]:
+            self.m_component[u_node] = v_node
+            component_size[v_node] += component_size[u_node]
+            self.set_component(u_node)
+
+        elif component_size[u_node] >= component_size[v_node]:
+            self.m_component[v_node] = self.find_component(u_node)
+            component_size[u_node] += component_size[v_node]
+            self.set_component(v_node)
+
+    def boruvka(self) -> None:
+        """Performs Borůvka's algorithm to find MST."""
+
+        # Initialize additional lists required to algorithm.
+        component_size = []
+        mst_weight = 0
+
+        minimum_weight_edge: list[Any] = [-1] * self.m_num_of_nodes
+
+        # A list of components (initialized to all of the nodes)
+        for node in range(self.m_num_of_nodes):
+            self.m_component.update({node: node})
+            component_size.append(1)
+
+        num_of_components = self.m_num_of_nodes
+
+        while num_of_components > 1:
+            for edge in self.m_edges:
+                u, v, w = edge
+
+                u_component = self.m_component[u]
+                v_component = self.m_component[v]
+
+                if u_component != v_component:
+                    """If the current minimum weight edge of component u doesn't
+                    exist (is -1), or if it's greater than the edge we're
+                    observing right now, we will assign the value of the edge
+                    we're observing to it.
+
+                    If the current minimum weight edge of component v doesn't
+                    exist (is -1), or if it's greater than the edge we're
+                    observing right now, we will assign the value of the edge
+                    we're observing to it"""
+
+                    for component in (u_component, v_component):
+                        if (
+                            minimum_weight_edge[component] == -1
+                            or minimum_weight_edge[component][2] > w
+                        ):
+                            minimum_weight_edge[component] = [u, v, w]
+
+            for edge in minimum_weight_edge:
+                if isinstance(edge, list):
+                    u, v, w = edge
+
+                    u_component = self.m_component[u]
+                    v_component = self.m_component[v]
+
+                    if u_component != v_component:
+                        mst_weight += w
+                        self.union(component_size, u_component, v_component)
+                        print(f"Added edge [{u} - {v}]\nAdded weight: {w}\n")
+                        num_of_components -= 1
+
+            minimum_weight_edge = [-1] * self.m_num_of_nodes
+        print(f"The total weight of the minimal spanning tree is: {mst_weight}")
+
+
+def test_vector() -> None:
+    """
+    >>> g = Graph(8)
+    >>> for u_v_w in ((0, 1, 10), (0, 2, 6), (0, 3, 5), (1, 3, 15), (2, 3, 4),
+    ...    (3, 4, 8), (4, 5, 10), (4, 6, 6), (4, 7, 5), (5, 7, 15), (6, 7, 4)):
+    ...        g.add_edge(*u_v_w)
+    >>> g.boruvka()
+    Added edge [0 - 3]
+    Added weight: 5
+    <BLANKLINE>
+    Added edge [0 - 1]
+    Added weight: 10
+    <BLANKLINE>
+    Added edge [2 - 3]
+    Added weight: 4
+    <BLANKLINE>
+    Added edge [4 - 7]
+    Added weight: 5
+    <BLANKLINE>
+    Added edge [4 - 5]
+    Added weight: 10
+    <BLANKLINE>
+    Added edge [6 - 7]
+    Added weight: 4
+    <BLANKLINE>
+    Added edge [3 - 4]
+    Added weight: 8
+    <BLANKLINE>
+    The total weight of the minimal spanning tree is: 46
+    """
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add upstream Python source for Borůvka's algorithm
- implement Borůvka's minimum spanning tree algorithm in pure Mochi
- record expected sample execution output

## Testing
- `node runtime/vm tests/github/TheAlgorithms/Mochi/graphs/boruvka.mochi` *(fails: Cannot find module '/workspace/mochi/runtime/vm')*
- `npm install` *(fails: connect ENETUNREACH 140.82.113.3:443)*

------
https://chatgpt.com/codex/tasks/task_e_6891c5d660688320847165889ce93b2e