### PR TITLE
Add BFS algorithm implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/graphs/breadth_first_search_2.mochi
+++ b/tests/github/TheAlgorithms/Mochi/graphs/breadth_first_search_2.mochi
@@ -1,0 +1,85 @@
+/*
+Perform breadth-first search on an unweighted graph.
+
+The algorithm explores the graph level by level starting from a given
+source vertex.  A queue stores the frontier.  Each iteration removes the
+front vertex, visits all unseen neighbors, marks them visited and enqueues
+them.  The visit order is the BFS traversal order and covers each vertex
+at the minimal distance from the start.  Runtime is O(V + E) for V
+vertices and E edges.
+
+Two versions are provided:
+1. `breadth_first_search` uses list slicing to dequeue, mimicking a simple
+   queue structure.
+2. `breadth_first_search_with_deque` keeps a head index to dequeue in O(1)
+   time similar to a double-ended queue.
+*/
+
+fun join(xs: list<string>): string {
+  var s = ""
+  var i = 0
+  while i < len(xs) {
+    s = s + xs[i]
+    i = i + 1
+  }
+  return s
+}
+
+fun breadth_first_search(graph: map<string, list<string>>, start: string): list<string> {
+  var explored: map<string, bool> = {}
+  explored[start] = true
+  var result: list<string> = [start]
+  var queue: list<string> = [start]
+  while len(queue) > 0 {
+    let v = queue[0]
+    queue = queue[1:len(queue)]
+    let children = graph[v]
+    var i = 0
+    while i < len(children) {
+      let w = children[i]
+      if !(w in explored) {
+        explored[w] = true
+        result = append(result, w)
+        queue = append(queue, w)
+      }
+      i = i + 1
+    }
+  }
+  return result
+}
+
+fun breadth_first_search_with_deque(graph: map<string, list<string>>, start: string): list<string> {
+  var visited: map<string, bool> = {}
+  visited[start] = true
+  var result: list<string> = [start]
+  var queue: list<string> = [start]
+  var head = 0
+  while head < len(queue) {
+    let v = queue[head]
+    head = head + 1
+    let children = graph[v]
+    var i = 0
+    while i < len(children) {
+      let child = children[i]
+      if !(child in visited) {
+        visited[child] = true
+        result = append(result, child)
+        queue = append(queue, child)
+      }
+      i = i + 1
+    }
+  }
+  return result
+}
+
+let G: map<string, list<string>> = {
+  "A": ["B", "C"],
+  "B": ["A", "D", "E"],
+  "C": ["A", "F"],
+  "D": ["B"],
+  "E": ["B", "F"],
+  "F": ["C", "E"]
+}
+
+print(join(breadth_first_search(G, "A")))
+print(join(breadth_first_search_with_deque(G, "A")))

--- a/tests/github/TheAlgorithms/Mochi/graphs/breadth_first_search_2.out
+++ b/tests/github/TheAlgorithms/Mochi/graphs/breadth_first_search_2.out
@@ -1,0 +1,2 @@
+ABCDEF
+ABCDEF

--- a/tests/github/TheAlgorithms/Python/graphs/breadth_first_search_2.py
+++ b/tests/github/TheAlgorithms/Python/graphs/breadth_first_search_2.py
@@ -1,0 +1,88 @@
+"""
+https://en.wikipedia.org/wiki/Breadth-first_search
+pseudo-code:
+breadth_first_search(graph G, start vertex s):
+// all nodes initially unexplored
+mark s as explored
+let Q = queue data structure, initialized with s
+while Q is non-empty:
+    remove the first node of Q, call it v
+    for each edge(v, w):  // for w in graph[v]
+        if w unexplored:
+            mark w as explored
+            add w to Q (at the end)
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from queue import Queue
+from timeit import timeit
+
+G = {
+    "A": ["B", "C"],
+    "B": ["A", "D", "E"],
+    "C": ["A", "F"],
+    "D": ["B"],
+    "E": ["B", "F"],
+    "F": ["C", "E"],
+}
+
+
+def breadth_first_search(graph: dict, start: str) -> list[str]:
+    """
+    Implementation of breadth first search using queue.Queue.
+
+    >>> ''.join(breadth_first_search(G, 'A'))
+    'ABCDEF'
+    """
+    explored = {start}
+    result = [start]
+    queue: Queue = Queue()
+    queue.put(start)
+    while not queue.empty():
+        v = queue.get()
+        for w in graph[v]:
+            if w not in explored:
+                explored.add(w)
+                result.append(w)
+                queue.put(w)
+    return result
+
+
+def breadth_first_search_with_deque(graph: dict, start: str) -> list[str]:
+    """
+    Implementation of breadth first search using collection.queue.
+
+    >>> ''.join(breadth_first_search_with_deque(G, 'A'))
+    'ABCDEF'
+    """
+    visited = {start}
+    result = [start]
+    queue = deque([start])
+    while queue:
+        v = queue.popleft()
+        for child in graph[v]:
+            if child not in visited:
+                visited.add(child)
+                result.append(child)
+                queue.append(child)
+    return result
+
+
+def benchmark_function(name: str) -> None:
+    setup = f"from __main__ import G, {name}"
+    number = 10000
+    res = timeit(f"{name}(G, 'A')", setup=setup, number=number)
+    print(f"{name:<35} finished {number} runs in {res:.5f} seconds")
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+
+    benchmark_function("breadth_first_search")
+    benchmark_function("breadth_first_search_with_deque")
+    # breadth_first_search                finished 10000 runs in 0.20999 seconds
+    # breadth_first_search_with_deque     finished 10000 runs in 0.01421 seconds


### PR DESCRIPTION
## Summary
- add Python Breadth First Search reference implementation
- port BFS to Mochi with queue and deque variants
- include runtime output for traversal

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/graphs/breadth_first_search_2.mochi`
- `python tests/github/TheAlgorithms/Python/graphs/breadth_first_search_2.py`

------
https://chatgpt.com/codex/tasks/task_e_6891c92e5a488320a8fa6056270021a5