### PR TITLE
Add BFS shortest path example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/graphs/breadth_first_search_shortest_path.mochi
+++ b/tests/github/TheAlgorithms/Mochi/graphs/breadth_first_search_shortest_path.mochi
@@ -1,0 +1,62 @@
+/*
+Breadth-First Search (BFS) to find shortest paths in an unweighted graph.
+The graph is represented as a map from a vertex to a list of adjacent
+vertices. Starting from a given source, BFS explores vertices in layers,
+recording each vertex's parent when first discovered. The shortest_path
+function reconstructs a path to any target by walking this parent map.
+If a vertex is unreachable, a descriptive message is returned instead.
+*/
+
+type Graph {
+  graph: map<string, list<string>>,
+  parent: map<string, string>,
+  source: string
+}
+
+fun newGraph(g: map<string, list<string>>, s: string): Graph {
+  return Graph{graph: g, parent: {}, source: s}
+}
+
+fun breath_first_search(g: Graph): Graph {
+  var parent = g.parent
+  parent[g.source] = g.source
+  var queue: list<string> = [g.source]
+  var idx = 0
+  while idx < len(queue) {
+    let vertex = queue[idx]
+    for adj in g.graph[vertex] {
+      if !(adj in parent) {
+        parent[adj] = vertex
+        queue = append(queue, adj)
+      }
+    }
+    idx = idx + 1
+  }
+  g.parent = parent
+  return g
+}
+
+fun shortest_path(g: Graph, target: string): string {
+  if target == g.source { return g.source }
+  if !(target in g.parent) {
+    return "No path from vertex: " + g.source + " to vertex: " + target
+  }
+  let p = g.parent[target]
+  return shortest_path(g, p) + "->" + target
+}
+
+let graph: map<string, list<string>> = {
+  "A": ["B", "C", "E"],
+  "B": ["A", "D", "E"],
+  "C": ["A", "F", "G"],
+  "D": ["B"],
+  "E": ["A", "B", "D"],
+  "F": ["C"],
+  "G": ["C"]
+}
+
+var g = newGraph(graph, "G")
+g = breath_first_search(g)
+print(shortest_path(g, "D"))
+print(shortest_path(g, "G"))
+print(shortest_path(g, "Foo"))

--- a/tests/github/TheAlgorithms/Mochi/graphs/breadth_first_search_shortest_path.out
+++ b/tests/github/TheAlgorithms/Mochi/graphs/breadth_first_search_shortest_path.out
@@ -1,0 +1,3 @@
+G->C->A->B->D
+G
+No path from vertex: G to vertex: Foo

--- a/tests/github/TheAlgorithms/Python/graphs/breadth_first_search_shortest_path.py
+++ b/tests/github/TheAlgorithms/Python/graphs/breadth_first_search_shortest_path.py
@@ -1,0 +1,90 @@
+"""Breath First Search (BFS) can be used when finding the shortest path
+from a given source node to a target node in an unweighted graph.
+"""
+
+from __future__ import annotations
+
+graph = {
+    "A": ["B", "C", "E"],
+    "B": ["A", "D", "E"],
+    "C": ["A", "F", "G"],
+    "D": ["B"],
+    "E": ["A", "B", "D"],
+    "F": ["C"],
+    "G": ["C"],
+}
+
+
+class Graph:
+    def __init__(self, graph: dict[str, list[str]], source_vertex: str) -> None:
+        """
+        Graph is implemented as dictionary of adjacency lists. Also,
+        Source vertex have to be defined upon initialization.
+        """
+        self.graph = graph
+        # mapping node to its parent in resulting breadth first tree
+        self.parent: dict[str, str | None] = {}
+        self.source_vertex = source_vertex
+
+    def breath_first_search(self) -> None:
+        """
+        This function is a helper for running breath first search on this graph.
+        >>> g = Graph(graph, "G")
+        >>> g.breath_first_search()
+        >>> g.parent
+        {'G': None, 'C': 'G', 'A': 'C', 'F': 'C', 'B': 'A', 'E': 'A', 'D': 'B'}
+        """
+        visited = {self.source_vertex}
+        self.parent[self.source_vertex] = None
+        queue = [self.source_vertex]  # first in first out queue
+
+        while queue:
+            vertex = queue.pop(0)
+            for adjacent_vertex in self.graph[vertex]:
+                if adjacent_vertex not in visited:
+                    visited.add(adjacent_vertex)
+                    self.parent[adjacent_vertex] = vertex
+                    queue.append(adjacent_vertex)
+
+    def shortest_path(self, target_vertex: str) -> str:
+        """
+        This shortest path function returns a string, describing the result:
+        1.) No path is found. The string is a human readable message to indicate this.
+        2.) The shortest path is found. The string is in the form
+            `v1(->v2->v3->...->vn)`, where v1 is the source vertex and vn is the target
+            vertex, if it exists separately.
+
+        >>> g = Graph(graph, "G")
+        >>> g.breath_first_search()
+
+        Case 1 - No path is found.
+        >>> g.shortest_path("Foo")
+        Traceback (most recent call last):
+            ...
+        ValueError: No path from vertex: G to vertex: Foo
+
+        Case 2 - The path is found.
+        >>> g.shortest_path("D")
+        'G->C->A->B->D'
+        >>> g.shortest_path("G")
+        'G'
+        """
+        if target_vertex == self.source_vertex:
+            return self.source_vertex
+
+        target_vertex_parent = self.parent.get(target_vertex)
+        if target_vertex_parent is None:
+            msg = (
+                f"No path from vertex: {self.source_vertex} to vertex: {target_vertex}"
+            )
+            raise ValueError(msg)
+
+        return self.shortest_path(target_vertex_parent) + f"->{target_vertex}"
+
+
+if __name__ == "__main__":
+    g = Graph(graph, "G")
+    g.breath_first_search()
+    print(g.shortest_path("D"))
+    print(g.shortest_path("G"))
+    print(g.shortest_path("Foo"))


### PR DESCRIPTION
## Summary
- add original Python implementation for breadth-first search shortest path
- translate the BFS shortest path algorithm into Mochi with parent tracking
- capture VM output showing path results and unreachable vertex message

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/graphs/breadth_first_search_shortest_path.mochi > tests/github/TheAlgorithms/Mochi/graphs/breadth_first_search_shortest_path.out`
- `npm test` *(fails: Missing script: "test")*
- `go test ./...` *(fails: signal: interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6891c9304f848320ba4b079dbf6da52d