### PR TITLE
Add BFS shortest path Mochi implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/graphs/breadth_first_search_shortest_path_2.mochi
+++ b/tests/github/TheAlgorithms/Mochi/graphs/breadth_first_search_shortest_path_2.mochi
@@ -1,0 +1,129 @@
+/*
+Breadth-First Search Shortest Path
+----------------------------------
+This module implements two related graph algorithms using breadth-first
+search (BFS):
+
+1. `bfs_shortest_path` returns the actual shortest path between a start
+   node and a goal node in an unweighted graph.  The algorithm explores
+   the graph level by level using a queue of paths.  When the goal is
+   discovered the corresponding path is returned.  If no path exists an
+   empty list is produced.  Time complexity is O(V + E) where V is the
+   number of vertices and E the number of edges.
+
+2. `bfs_shortest_path_distance` computes only the distance (number of
+   edges) between two nodes.  It performs a standard BFS keeping track of
+   visited nodes and their distance from the start node.  If the target
+   node is unreachable the function returns -1.
+
+Both algorithms operate on graphs represented as maps from a node label
+(string) to a list of neighbouring node labels.  They avoid use of any
+foreign functions and provide explicit types for all values.
+*/
+
+fun contains(xs: list<string>, x: string): bool {
+  var i = 0
+  while i < len(xs) {
+    if xs[i] == x { return true }
+    i = i + 1
+  }
+  return false
+}
+
+fun contains_key(m: map<string, list<string>>, key: string): bool {
+  for k in m {
+    if k == key { return true }
+  }
+  return false
+}
+
+fun bfs_shortest_path(graph: map<string, list<string>>, start: string, goal: string): list<string> {
+  var explored: list<string> = []
+  var queue: list<list<string>> = [[start]]
+  if start == goal { return [start] }
+  while len(queue) > 0 {
+    let path = queue[0]
+    queue = slice(queue, 1, len(queue))
+    let node = path[len(path) - 1]
+    if !contains(explored, node) {
+      let neighbours = graph[node]
+      var i = 0
+      while i < len(neighbours) {
+        let neighbour = neighbours[i]
+        var new_path = path
+        new_path = append(new_path, neighbour)
+        queue = append(queue, new_path)
+        if neighbour == goal { return new_path }
+        i = i + 1
+      }
+      explored = append(explored, node)
+    }
+  }
+  return []
+}
+
+fun bfs_shortest_path_distance(graph: map<string, list<string>>, start: string, target: string): int {
+  if (contains_key(graph, start) == false) || (contains_key(graph, target) == false) { return -1 }
+  if start == target { return 0 }
+  var queue: list<string> = [start]
+  var visited: list<string> = [start]
+  var dist: map<string, int> = {}
+  dist[start] = 0
+  dist[target] = (-1)
+  while len(queue) > 0 {
+    let node = queue[0]
+    queue = slice(queue, 1, len(queue))
+    if node == target {
+      if dist[target] == (-1) || dist[node] < dist[target] {
+        dist[target] = dist[node]
+      }
+    }
+    let adj = graph[node]
+    var i = 0
+    while i < len(adj) {
+      let next = adj[i]
+      if !contains(visited, next) {
+        visited = append(visited, next)
+        queue = append(queue, next)
+        dist[next] = dist[node] + 1
+      }
+      i = i + 1
+    }
+  }
+  return dist[target]
+}
+
+let demo_graph: map<string, list<string>> = {
+  "A": ["B", "C", "E"],
+  "B": ["A", "D", "E"],
+  "C": ["A", "F", "G"],
+  "D": ["B"],
+  "E": ["A", "B", "D"],
+  "F": ["C"],
+  "G": ["C"]
+}
+
+
+test "path found" {
+  expect bfs_shortest_path(demo_graph, "G", "D") == ["G", "C", "A", "B", "D"]
+}
+
+test "path to self" {
+  expect bfs_shortest_path(demo_graph, "G", "G") == ["G"]
+}
+
+test "path not found" {
+  expect len(bfs_shortest_path(demo_graph, "G", "Unknown")) == 0
+}
+
+test "distance found" {
+  expect bfs_shortest_path_distance(demo_graph, "G", "D") == 4
+}
+
+test "distance to self" {
+  expect bfs_shortest_path_distance(demo_graph, "A", "A") == 0
+}
+
+test "distance not found" {
+  expect bfs_shortest_path_distance(demo_graph, "A", "Unknown") == (-1)
+}

--- a/tests/github/TheAlgorithms/Mochi/graphs/breadth_first_search_shortest_path_2.out
+++ b/tests/github/TheAlgorithms/Mochi/graphs/breadth_first_search_shortest_path_2.out
@@ -1,0 +1,7 @@
+[94;1mtests/github/TheAlgorithms/Mochi/graphs/breadth_first_search_shortest_path_2.mochi[0;22m
+   [33mtest[0m path found                     ... [32mok[0m (3.0ms)
+   [33mtest[0m path to self                   ... [32mok[0m (3.0ms)
+   [33mtest[0m path not found                 ... [32mok[0m (1.0ms)
+   [33mtest[0m distance found                 ... [32mok[0m (3.0ms)
+   [33mtest[0m distance to self               ... [32mok[0m (1.0ms)
+   [33mtest[0m distance not found             ... [32mok[0m (2.0ms)

--- a/tests/github/TheAlgorithms/Python/graphs/breadth_first_search_shortest_path_2.py
+++ b/tests/github/TheAlgorithms/Python/graphs/breadth_first_search_shortest_path_2.py
@@ -1,0 +1,111 @@
+"""Breadth-first search shortest path implementations.
+doctest:
+python -m doctest -v bfs_shortest_path.py
+Manual test:
+python bfs_shortest_path.py
+"""
+
+demo_graph = {
+    "A": ["B", "C", "E"],
+    "B": ["A", "D", "E"],
+    "C": ["A", "F", "G"],
+    "D": ["B"],
+    "E": ["A", "B", "D"],
+    "F": ["C"],
+    "G": ["C"],
+}
+
+
+def bfs_shortest_path(graph: dict, start, goal) -> list[str]:
+    """Find shortest path between `start` and `goal` nodes.
+    Args:
+        graph (dict): node/list of neighboring nodes key/value pairs.
+        start: start node.
+        goal: target node.
+    Returns:
+        Shortest path between `start` and `goal` nodes as a string of nodes.
+        'Not found' string if no path found.
+    Example:
+        >>> bfs_shortest_path(demo_graph, "G", "D")
+        ['G', 'C', 'A', 'B', 'D']
+        >>> bfs_shortest_path(demo_graph, "G", "G")
+        ['G']
+        >>> bfs_shortest_path(demo_graph, "G", "Unknown")
+        []
+    """
+    # keep track of explored nodes
+    explored = set()
+    # keep track of all the paths to be checked
+    queue = [[start]]
+
+    # return path if start is goal
+    if start == goal:
+        return [start]
+
+    # keeps looping until all possible paths have been checked
+    while queue:
+        # pop the first path from the queue
+        path = queue.pop(0)
+        # get the last node from the path
+        node = path[-1]
+        if node not in explored:
+            neighbours = graph[node]
+            # go through all neighbour nodes, construct a new path and
+            # push it into the queue
+            for neighbour in neighbours:
+                new_path = list(path)
+                new_path.append(neighbour)
+                queue.append(new_path)
+                # return path if neighbour is goal
+                if neighbour == goal:
+                    return new_path
+
+            # mark node as explored
+            explored.add(node)
+
+    # in case there's no path between the 2 nodes
+    return []
+
+
+def bfs_shortest_path_distance(graph: dict, start, target) -> int:
+    """Find shortest path distance between `start` and `target` nodes.
+    Args:
+        graph: node/list of neighboring nodes key/value pairs.
+        start: node to start search from.
+        target: node to search for.
+    Returns:
+        Number of edges in shortest path between `start` and `target` nodes.
+        -1 if no path exists.
+    Example:
+        >>> bfs_shortest_path_distance(demo_graph, "G", "D")
+        4
+        >>> bfs_shortest_path_distance(demo_graph, "A", "A")
+        0
+        >>> bfs_shortest_path_distance(demo_graph, "A", "Unknown")
+        -1
+    """
+    if not graph or start not in graph or target not in graph:
+        return -1
+    if start == target:
+        return 0
+    queue = [start]
+    visited = set(start)
+    # Keep tab on distances from `start` node.
+    dist = {start: 0, target: -1}
+    while queue:
+        node = queue.pop(0)
+        if node == target:
+            dist[target] = (
+                dist[node] if dist[target] == -1 else min(dist[target], dist[node])
+            )
+        for adjacent in graph[node]:
+            if adjacent not in visited:
+                visited.add(adjacent)
+                queue.append(adjacent)
+                dist[adjacent] = dist[node] + 1
+    return dist[target]
+
+
+if __name__ == "__main__":
+    print(bfs_shortest_path(demo_graph, "G", "D"))  # returns ['G', 'C', 'A', 'B', 'D']
+    print(bfs_shortest_path_distance(demo_graph, "G", "D"))  # returns 4


### PR DESCRIPTION
## Summary
- add Python reference implementation for breadth-first search shortest path and distance
- implement equivalent Mochi version with detailed description and tests
- include test run outputs for the Mochi implementation

## Testing
- `go run ./cmd/mochi test tests/github/TheAlgorithms/Mochi/graphs/breadth_first_search_shortest_path_2.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891c9314bb08320ad33f677cc15096e