### PR TITLE
Add graph cycle detection example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/graphs/check_cycle.mochi
+++ b/tests/github/TheAlgorithms/Mochi/graphs/check_cycle.mochi
@@ -1,0 +1,54 @@
+/*
+Detect cycles in a directed graph using depth-first search.
+The graph is given as adjacency lists for vertices 0..n-1.
+The algorithm tracks visited nodes and a recursion stack. When exploring
+neighbors, hitting a node already on the stack reveals a cycle. The
+search runs in O(V+E) time and O(V) space for a graph with V vertices
+and E edges.
+*/
+fun depth_first_search(graph: list<list<int>>, vertex: int, visited: list<bool>, rec_stk: list<bool>): bool {
+  visited[vertex] = true
+  rec_stk[vertex] = true
+  for node in graph[vertex] {
+    if !visited[node] {
+      if depth_first_search(graph, node, visited, rec_stk) {
+        return true
+      }
+    } else if rec_stk[node] {
+      return true
+    }
+  }
+  rec_stk[vertex] = false
+  return false
+}
+
+fun check_cycle(graph: list<list<int>>): bool {
+  let n = len(graph)
+  var visited: list<bool> = []
+  var rec_stk: list<bool> = []
+  var i = 0
+  while i < n {
+    visited = append(visited, false)
+    rec_stk = append(rec_stk, false)
+    i = i + 1
+  }
+  i = 0
+  while i < n {
+    if !visited[i] {
+      if depth_first_search(graph, i, visited, rec_stk) {
+        return true
+      }
+    }
+    i = i + 1
+  }
+  return false
+}
+
+fun print_bool(b: bool) {
+  if b { print("true") } else { print("false") }
+}
+
+let g1 = [[], [0,3], [0,4], [5], [5], []]
+print_bool(check_cycle(g1))
+let g2 = [[1,2], [2], [0,3], [3]]
+print_bool(check_cycle(g2))

--- a/tests/github/TheAlgorithms/Mochi/graphs/check_cycle.out
+++ b/tests/github/TheAlgorithms/Mochi/graphs/check_cycle.out
@@ -1,0 +1,2 @@
+false
+true

--- a/tests/github/TheAlgorithms/Python/graphs/check_cycle.py
+++ b/tests/github/TheAlgorithms/Python/graphs/check_cycle.py
@@ -1,0 +1,52 @@
+"""
+Program to check if a cycle is present in a given graph
+"""
+
+
+def check_cycle(graph: dict) -> bool:
+    """
+    Returns True if graph is cyclic else False
+    >>> check_cycle(graph={0:[], 1:[0, 3], 2:[0, 4], 3:[5], 4:[5], 5:[]})
+    False
+    >>> check_cycle(graph={0:[1, 2], 1:[2], 2:[0, 3], 3:[3]})
+    True
+    """
+    # Keep track of visited nodes
+    visited: set[int] = set()
+    # To detect a back edge, keep track of vertices currently in the recursion stack
+    rec_stk: set[int] = set()
+    return any(
+        node not in visited and depth_first_search(graph, node, visited, rec_stk)
+        for node in graph
+    )
+
+
+def depth_first_search(graph: dict, vertex: int, visited: set, rec_stk: set) -> bool:
+    """
+    Recur for all neighbours.
+    If any neighbour is visited and in rec_stk then graph is cyclic.
+    >>> graph = {0:[], 1:[0, 3], 2:[0, 4], 3:[5], 4:[5], 5:[]}
+    >>> vertex, visited, rec_stk = 0, set(), set()
+    >>> depth_first_search(graph, vertex, visited, rec_stk)
+    False
+    """
+    # Mark current node as visited and add to recursion stack
+    visited.add(vertex)
+    rec_stk.add(vertex)
+
+    for node in graph[vertex]:
+        if node not in visited:
+            if depth_first_search(graph, node, visited, rec_stk):
+                return True
+        elif node in rec_stk:
+            return True
+
+    # The node needs to be removed from recursion stack before function ends
+    rec_stk.remove(vertex)
+    return False
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()


### PR DESCRIPTION
## Summary
- add Python `check_cycle` DFS implementation
- port cycle detection to Mochi using adjacency lists
- include generated outputs

## Testing
- `./mochi run tests/github/TheAlgorithms/Mochi/graphs/check_cycle.mochi > tests/github/TheAlgorithms/Mochi/graphs/check_cycle.out`

------
https://chatgpt.com/codex/tasks/task_e_6891c935e3a083208656d2fd10814759