### PR TITLE
feat: add Mochi Dijkstra algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/graphs/dijkstra_2.mochi
+++ b/tests/github/TheAlgorithms/Mochi/graphs/dijkstra_2.mochi
@@ -1,0 +1,87 @@
+/*
+Dijkstra's Shortest Path (Adjacency Matrix)
+
+This program computes shortest distances from a source vertex to all
+others in a weighted directed graph with non-negative edge weights.
+The graph is stored as an adjacency matrix using a large constant to
+represent absent edges. It mirrors the Python implementation from
+TheAlgorithms/Python.
+
+Algorithm:
+- Repeatedly select the unvisited vertex with smallest tentative distance.
+- Relax all edges from that vertex.
+The process repeats until all vertices are processed.
+*/
+
+let INF = 1000000000.0
+
+fun print_dist(dist: list<float>) {
+  print("Vertex Distance")
+  var i = 0
+  while i < len(dist) {
+    if dist[i] >= INF {
+      print(i, "\tINF")
+    } else {
+      print(i, "\t", dist[i] as int)
+    }
+    i = i + 1
+  }
+}
+
+fun min_dist(mdist: list<float>, vset: list<bool>): int {
+  var min_val = INF
+  var min_ind = -1
+  var i = 0
+  while i < len(mdist) {
+    if !(vset[i]) && mdist[i] < min_val {
+      min_val = mdist[i]
+      min_ind = i
+    }
+    i = i + 1
+  }
+  return min_ind
+}
+
+fun dijkstra(graph: list<list<float>>, src: int): list<float> {
+  let v = len(graph)
+  var mdist: list<float> = []
+  var vset: list<bool> = []
+  var i = 0
+  while i < v {
+    mdist = append(mdist, INF)
+    vset = append(vset, false)
+    i = i + 1
+  }
+  mdist[src] = 0.0
+
+  var count = 0
+  while count < v - 1 {
+    let u = min_dist(mdist, vset)
+    vset[u] = true
+
+    var i = 0
+    while i < v {
+      let alt = mdist[u] + graph[u][i]
+      if !(vset[i]) && graph[u][i] < INF && alt < mdist[i] {
+        mdist[i] = alt
+      }
+      i = i + 1
+    }
+    count = count + 1
+  }
+  return mdist
+}
+
+fun main() {
+  let graph: list<list<float>> = [
+    [0.0, 10.0, INF, INF, 5.0],
+    [INF, 0.0, 1.0, INF, 2.0],
+    [INF, INF, 0.0, 4.0, INF],
+    [INF, INF, 6.0, 0.0, INF],
+    [INF, 3.0, 9.0, 2.0, 0.0]
+  ]
+  let dist = dijkstra(graph, 0)
+  print_dist(dist)
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/graphs/dijkstra_2.out
+++ b/tests/github/TheAlgorithms/Mochi/graphs/dijkstra_2.out
@@ -1,0 +1,6 @@
+Vertex Distance
+0 	 0
+1 	 8
+2 	 9
+3 	 7
+4 	 5

--- a/tests/github/TheAlgorithms/Python/graphs/dijkstra_2.py
+++ b/tests/github/TheAlgorithms/Python/graphs/dijkstra_2.py
@@ -1,0 +1,58 @@
+def print_dist(dist, v):
+    print("\nVertex Distance")
+    for i in range(v):
+        if dist[i] != float("inf"):
+            print(i, "\t", int(dist[i]), end="\t")
+        else:
+            print(i, "\t", "INF", end="\t")
+        print()
+
+
+def min_dist(mdist, vset, v):
+    min_val = float("inf")
+    min_ind = -1
+    for i in range(v):
+        if (not vset[i]) and mdist[i] < min_val:
+            min_ind = i
+            min_val = mdist[i]
+    return min_ind
+
+
+def dijkstra(graph, v, src):
+    mdist = [float("inf") for _ in range(v)]
+    vset = [False for _ in range(v)]
+    mdist[src] = 0.0
+
+    for _ in range(v - 1):
+        u = min_dist(mdist, vset, v)
+        vset[u] = True
+
+        for i in range(v):
+            if (
+                (not vset[i])
+                and graph[u][i] != float("inf")
+                and mdist[u] + graph[u][i] < mdist[i]
+            ):
+                mdist[i] = mdist[u] + graph[u][i]
+
+    print_dist(mdist, i)
+
+
+if __name__ == "__main__":
+    V = int(input("Enter number of vertices: ").strip())
+    E = int(input("Enter number of edges: ").strip())
+
+    graph = [[float("inf") for i in range(V)] for j in range(V)]
+
+    for i in range(V):
+        graph[i][i] = 0.0
+
+    for i in range(E):
+        print("\nEdge ", i + 1)
+        src = int(input("Enter source:").strip())
+        dst = int(input("Enter destination:").strip())
+        weight = float(input("Enter weight:").strip())
+        graph[src][dst] = weight
+
+    gsrc = int(input("\nEnter shortest path source:").strip())
+    dijkstra(graph, V, gsrc)


### PR DESCRIPTION
## Summary
- add Python reference implementation for Dijkstra's algorithm
- add pure Mochi translation using adjacency-matrix representation
- include VM output sample of shortest path computation

## Testing
- `go run /tmp/runmochi.go tests/github/TheAlgorithms/Mochi/graphs/dijkstra_2.mochi`
- `go test ./runtime/vm -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6891c942182483208c1d54e8c9e9980c