### PR TITLE
Add Dijkstra alternate Mochi implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/graphs/dijkstra_alternate.mochi
+++ b/tests/github/TheAlgorithms/Mochi/graphs/dijkstra_alternate.mochi
@@ -1,0 +1,87 @@
+/*
+Dijkstra's Algorithm with Adjacency Matrix
+------------------------------------------
+This implementation solves the single-source shortest path problem for a graph
+represented as an adjacency matrix. Each cell `graph[u][v]` holds the weight of
+the edge from vertex `u` to `v` (0 denotes no edge). The algorithm maintains two
+arrays:
+
+1. `distances` – distance estimates from the source to every vertex. They are
+   initialized to a large sentinel value (1e7) except for the source which is 0.
+2. `visited` – marks vertices whose final shortest distance has been determined.
+
+Repeatedly, the unvisited vertex with the smallest tentative distance is
+selected. For each neighbor `v` of this vertex `u`, if the path through `u`
+produces a shorter distance than the current estimate for `v`, it is updated.
+The algorithm runs in `O(V^2)` time for `V` vertices when using an adjacency
+matrix.
+*/
+
+fun minimum_distance(distances: list<int>, visited: list<bool>): int {
+  var minimum = 10000000
+  var min_index = 0
+  var vertex = 0
+  while vertex < len(distances) {
+    if distances[vertex] < minimum && visited[vertex] == false {
+      minimum = distances[vertex]
+      min_index = vertex
+    }
+    vertex = vertex + 1
+  }
+  return min_index
+}
+
+fun dijkstra(graph: list<list<int>>, source: int): list<int> {
+  let vertices = len(graph)
+  var distances: list<int>
+  var i = 0
+  while i < vertices {
+    distances = append(distances, 10000000)
+    i = i + 1
+  }
+  distances[source] = 0
+  var visited: list<bool>
+  i = 0
+  while i < vertices {
+    visited = append(visited, false)
+    i = i + 1
+  }
+  var count = 0
+  while count < vertices {
+    let u = minimum_distance(distances, visited)
+    visited[u] = true
+    var v = 0
+    while v < vertices {
+      if graph[u][v] > 0 && visited[v] == false && distances[v] > distances[u] + graph[u][v] {
+        distances[v] = distances[u] + graph[u][v]
+      }
+      v = v + 1
+    }
+    count = count + 1
+  }
+  return distances
+}
+
+fun print_solution(distances: list<int>) {
+  print("Vertex \t Distance from Source")
+  var v = 0
+  while v < len(distances) {
+    print(str(v) + "\t\t" + str(distances[v]))
+    v = v + 1
+  }
+}
+
+let graph = [
+  [0, 4, 0, 0, 0, 0, 0, 8, 0],
+  [4, 0, 8, 0, 0, 0, 0, 11, 0],
+  [0, 8, 0, 7, 0, 4, 0, 0, 2],
+  [0, 0, 7, 0, 9, 14, 0, 0, 0],
+  [0, 0, 0, 9, 0, 10, 0, 0, 0],
+  [0, 0, 4, 14, 10, 0, 2, 0, 0],
+  [0, 0, 0, 0, 0, 2, 0, 1, 6],
+  [8, 11, 0, 0, 0, 0, 1, 0, 7],
+  [0, 0, 2, 0, 0, 0, 6, 7, 0],
+]
+
+let distances = dijkstra(graph, 0)
+print_solution(distances)

--- a/tests/github/TheAlgorithms/Mochi/graphs/dijkstra_alternate.out
+++ b/tests/github/TheAlgorithms/Mochi/graphs/dijkstra_alternate.out
@@ -1,0 +1,10 @@
+Vertex 	 Distance from Source
+0		0
+1		4
+2		12
+3		19
+4		21
+5		11
+6		9
+7		8
+8		14

--- a/tests/github/TheAlgorithms/Python/graphs/dijkstra_alternate.py
+++ b/tests/github/TheAlgorithms/Python/graphs/dijkstra_alternate.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+
+class Graph:
+    def __init__(self, vertices: int) -> None:
+        """
+        >>> graph = Graph(2)
+        >>> graph.vertices
+        2
+        >>> len(graph.graph)
+        2
+        >>> len(graph.graph[0])
+        2
+        """
+        self.vertices = vertices
+        self.graph = [[0] * vertices for _ in range(vertices)]
+
+    def print_solution(self, distances_from_source: list[int]) -> None:
+        """
+        >>> Graph(0).print_solution([])  # doctest: +NORMALIZE_WHITESPACE
+        Vertex 	 Distance from Source
+        """
+        print("Vertex \t Distance from Source")
+        for vertex in range(self.vertices):
+            print(vertex, "\t\t", distances_from_source[vertex])
+
+    def minimum_distance(
+        self, distances_from_source: list[int], visited: list[bool]
+    ) -> int:
+        """
+        A utility function to find the vertex with minimum distance value, from the set
+        of vertices not yet included in shortest path tree.
+
+        >>> Graph(3).minimum_distance([1, 2, 3], [False, False, True])
+        0
+        """
+
+        # Initialize minimum distance for next node
+        minimum = 1e7
+        min_index = 0
+
+        # Search not nearest vertex not in the shortest path tree
+        for vertex in range(self.vertices):
+            if distances_from_source[vertex] < minimum and visited[vertex] is False:
+                minimum = distances_from_source[vertex]
+                min_index = vertex
+        return min_index
+
+    def dijkstra(self, source: int) -> None:
+        """
+        Function that implements Dijkstra's single source shortest path algorithm for a
+        graph represented using adjacency matrix representation.
+
+        >>> Graph(4).dijkstra(1)  # doctest: +NORMALIZE_WHITESPACE
+        Vertex  Distance from Source
+        0 		 10000000
+        1 		 0
+        2 		 10000000
+        3 		 10000000
+        """
+
+        distances = [int(1e7)] * self.vertices  # distances from the source
+        distances[source] = 0
+        visited = [False] * self.vertices
+
+        for _ in range(self.vertices):
+            u = self.minimum_distance(distances, visited)
+            visited[u] = True
+
+            # Update dist value of the adjacent vertices
+            # of the picked vertex only if the current
+            # distance is greater than new distance and
+            # the vertex in not in the shortest path tree
+            for v in range(self.vertices):
+                if (
+                    self.graph[u][v] > 0
+                    and visited[v] is False
+                    and distances[v] > distances[u] + self.graph[u][v]
+                ):
+                    distances[v] = distances[u] + self.graph[u][v]
+
+        self.print_solution(distances)
+
+
+if __name__ == "__main__":
+    graph = Graph(9)
+    graph.graph = [
+        [0, 4, 0, 0, 0, 0, 0, 8, 0],
+        [4, 0, 8, 0, 0, 0, 0, 11, 0],
+        [0, 8, 0, 7, 0, 4, 0, 0, 2],
+        [0, 0, 7, 0, 9, 14, 0, 0, 0],
+        [0, 0, 0, 9, 0, 10, 0, 0, 0],
+        [0, 0, 4, 14, 10, 0, 2, 0, 0],
+        [0, 0, 0, 0, 0, 2, 0, 1, 6],
+        [8, 11, 0, 0, 0, 0, 1, 0, 7],
+        [0, 0, 2, 0, 0, 0, 6, 7, 0],
+    ]
+    graph.dijkstra(0)


### PR DESCRIPTION
## Summary
- add Python source for Dijkstra variant from TheAlgorithms
- implement Dijkstra's single-source shortest path algorithm in Mochi
- include runtime output of shortest path distances

## Testing
- `./mochi run tests/github/TheAlgorithms/Mochi/graphs/dijkstra_alternate.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891c944f6188320a231baf5c680ff7b