### PR TITLE
Add Eulerian path and circuit algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/graphs/eulerian_path_and_circuit_for_undirected_graph.mochi
+++ b/tests/github/TheAlgorithms/Mochi/graphs/eulerian_path_and_circuit_for_undirected_graph.mochi
@@ -1,0 +1,114 @@
+/*
+Eulerian Path and Circuit for Undirected Graph
+
+This module determines whether an undirected graph contains an Eulerian
+path or an Eulerian circuit and produces the corresponding traversal.
+An Eulerian path visits every edge exactly once, while an Eulerian
+circuit is an Eulerian path that starts and ends on the same vertex.
+
+For an undirected graph:
+- A circuit exists iff every vertex has even degree.
+- A path (but not a circuit) exists iff exactly two vertices have odd degree.
+
+The algorithm proceeds as follows:
+1. Count vertices with odd degree to classify the graph.
+2. Use a matrix to mark edges as visited.
+3. Perform depth-first search to build the Eulerian traversal.
+
+Time Complexity: O(V + E)
+Space Complexity: O(V^2)
+*/
+
+type CheckResult {
+  status: int,
+  odd_node: int,
+}
+
+fun make_matrix(n: int): list<list<bool>> {
+  var matrix: list<list<bool>> = []
+  var i = 0
+  while i <= n {
+    var row: list<bool> = []
+    var j = 0
+    while j <= n {
+      row = append(row, false)
+      j = j + 1
+    }
+    matrix = append(matrix, row)
+    i = i + 1
+  }
+  return matrix
+}
+
+fun dfs(u: int, graph: map<int, list<int>>, visited_edge: list<list<bool>>, path: list<int>): list<int> {
+  path = append(path, u)
+  if u in graph {
+    let neighbors = graph[u]
+    var i = 0
+    while i < len(neighbors) {
+      let v = neighbors[i]
+      if visited_edge[u][v] == false {
+        visited_edge[u][v] = true
+        visited_edge[v][u] = true
+        path = dfs(v, graph, visited_edge, path)
+      }
+      i = i + 1
+    }
+  }
+  return path
+}
+
+fun check_circuit_or_path(graph: map<int, list<int>>, max_node: int): CheckResult {
+  var odd_degree_nodes = 0
+  var odd_node = -1
+  var i = 0
+  while i < max_node {
+    if i in graph {
+      if len(graph[i]) % 2 == 1 {
+        odd_degree_nodes = odd_degree_nodes + 1
+        odd_node = i
+      }
+    }
+    i = i + 1
+  }
+  if odd_degree_nodes == 0 {
+    return CheckResult { status: 1, odd_node: odd_node }
+  }
+  if odd_degree_nodes == 2 {
+    return CheckResult { status: 2, odd_node: odd_node }
+  }
+  return CheckResult { status: 3, odd_node: odd_node }
+}
+
+fun check_euler(graph: map<int, list<int>>, max_node: int) {
+  var visited_edge = make_matrix(max_node)
+  let res = check_circuit_or_path(graph, max_node)
+  if res.status == 3 {
+    print("graph is not Eulerian")
+    print("no path")
+    return
+  }
+  var start_node = 1
+  if res.status == 2 {
+    start_node = res.odd_node
+    print("graph has a Euler path")
+  }
+  if res.status == 1 {
+    print("graph has a Euler cycle")
+  }
+  let path = dfs(start_node, graph, visited_edge, [])
+  print(str(path))
+}
+
+let g1: map<int, list<int>> = {1: [2, 3, 4], 2: [1, 3], 3: [1, 2], 4: [1, 5], 5: [4]}
+let g2: map<int, list<int>> = {1: [2, 3, 4, 5], 2: [1, 3], 3: [1, 2], 4: [1, 5], 5: [1, 4]}
+let g3: map<int, list<int>> = {1: [2, 3, 4], 2: [1, 3, 4], 3: [1, 2], 4: [1, 2, 5], 5: [4]}
+let g4: map<int, list<int>> = {1: [2, 3], 2: [1, 3], 3: [1, 2]}
+let g5: map<int, list<int>> = {1: [], 2: []}
+
+let max_node = 10
+check_euler(g1, max_node)
+check_euler(g2, max_node)
+check_euler(g3, max_node)
+check_euler(g4, max_node)
+check_euler(g5, max_node)

--- a/tests/github/TheAlgorithms/Mochi/graphs/eulerian_path_and_circuit_for_undirected_graph.out
+++ b/tests/github/TheAlgorithms/Mochi/graphs/eulerian_path_and_circuit_for_undirected_graph.out
@@ -1,0 +1,10 @@
+graph has a Euler path
+[5 4 1 2 3 1]
+graph has a Euler cycle
+[1 2 3 1 4 5 1]
+graph is not Eulerian
+no path
+graph has a Euler cycle
+[1 2 3 1]
+graph has a Euler cycle
+[1]

--- a/tests/github/TheAlgorithms/Python/graphs/eulerian_path_and_circuit_for_undirected_graph.py
+++ b/tests/github/TheAlgorithms/Python/graphs/eulerian_path_and_circuit_for_undirected_graph.py
@@ -1,0 +1,71 @@
+# Eulerian Path is a path in graph that visits every edge exactly once.
+# Eulerian Circuit is an Eulerian Path which starts and ends on the same
+# vertex.
+# time complexity is O(V+E)
+# space complexity is O(VE)
+
+
+# using dfs for finding eulerian path traversal
+def dfs(u, graph, visited_edge, path=None):
+    path = (path or []) + [u]
+    for v in graph[u]:
+        if visited_edge[u][v] is False:
+            visited_edge[u][v], visited_edge[v][u] = True, True
+            path = dfs(v, graph, visited_edge, path)
+    return path
+
+
+# for checking in graph has euler path or circuit
+def check_circuit_or_path(graph, max_node):
+    odd_degree_nodes = 0
+    odd_node = -1
+    for i in range(max_node):
+        if i not in graph:
+            continue
+        if len(graph[i]) % 2 == 1:
+            odd_degree_nodes += 1
+            odd_node = i
+    if odd_degree_nodes == 0:
+        return 1, odd_node
+    if odd_degree_nodes == 2:
+        return 2, odd_node
+    return 3, odd_node
+
+
+def check_euler(graph, max_node):
+    visited_edge = [[False for _ in range(max_node + 1)] for _ in range(max_node + 1)]
+    check, odd_node = check_circuit_or_path(graph, max_node)
+    if check == 3:
+        print("graph is not Eulerian")
+        print("no path")
+        return
+    start_node = 1
+    if check == 2:
+        start_node = odd_node
+        print("graph has a Euler path")
+    if check == 1:
+        print("graph has a Euler cycle")
+    path = dfs(start_node, graph, visited_edge)
+    print(path)
+
+
+def main():
+    g1 = {1: [2, 3, 4], 2: [1, 3], 3: [1, 2], 4: [1, 5], 5: [4]}
+    g2 = {1: [2, 3, 4, 5], 2: [1, 3], 3: [1, 2], 4: [1, 5], 5: [1, 4]}
+    g3 = {1: [2, 3, 4], 2: [1, 3, 4], 3: [1, 2], 4: [1, 2, 5], 5: [4]}
+    g4 = {1: [2, 3], 2: [1, 3], 3: [1, 2]}
+    g5 = {
+        1: [],
+        2: [],
+        # all degree is zero
+    }
+    max_node = 10
+    check_euler(g1, max_node)
+    check_euler(g2, max_node)
+    check_euler(g3, max_node)
+    check_euler(g4, max_node)
+    check_euler(g5, max_node)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python source for Eulerian path and circuit detection
- implement Eulerian path and circuit algorithm in pure Mochi with DFS traversal
- capture runtime output demonstrating path and cycle identification

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/graphs/eulerian_path_and_circuit_for_undirected_graph.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891c94f8efc8320a1569e3b72e0470f