### PR TITLE
Add Mochi topological sort example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/graphs/g_topological_sort.mochi
+++ b/tests/github/TheAlgorithms/Mochi/graphs/g_topological_sort.mochi
@@ -1,0 +1,100 @@
+/*
+  Topological sort for ordering clothing items based on dependency graph.
+  Each directed edge u -> v means item u must precede item v when getting dressed.
+  We perform depth-first search, pushing vertices onto a stack after visiting all
+  descendants.  Popping from the stack yields a valid ordering that respects all
+  prerequisites.  The algorithm runs in O(V + E) time with O(V) additional space
+  for the visited array and recursion stack.
+*/
+
+fun depth_first_search(
+  u: int,
+  visited: list<bool>,
+  graph: list<list<int>>,
+  stack: list<int>
+): list<int> {
+  visited[u] = true
+  var i = 0
+  while i < len(graph[u]) {
+    let v = graph[u][i]
+    if !visited[v] {
+      stack = depth_first_search(v, visited, graph, stack)
+    }
+    i = i + 1
+  }
+  stack = append(stack, u)
+  return stack
+}
+
+fun topological_sort(graph: list<list<int>>): list<int> {
+  var visited: list<bool> = []
+  var i = 0
+  while i < len(graph) {
+    visited = append(visited, false)
+    i = i + 1
+  }
+  var stack: list<int> = []
+  i = 0
+  while i < len(graph) {
+    if !visited[i] {
+      stack = depth_first_search(i, visited, graph, stack)
+    }
+    i = i + 1
+  }
+  return stack
+}
+
+fun print_stack(stack: list<int>, clothes: map<int, string>) {
+  var order = 1
+  var s = stack
+  while len(s) > 0 {
+    let idx = s[len(s) - 1]
+    s = s[0:len(s) - 1]
+    print(str(order) + " " + clothes[idx])
+    order = order + 1
+  }
+}
+
+fun format_list(xs: list<int>): string {
+  var res = "["
+  var i = 0
+  while i < len(xs) {
+    res = res + str(xs[i])
+    if i < len(xs) - 1 {
+      res = res + ", "
+    }
+    i = i + 1
+  }
+  res = res + "]"
+  return res
+}
+
+fun main() {
+  let clothes: map<int, string> = {
+    0: "underwear",
+    1: "pants",
+    2: "belt",
+    3: "suit",
+    4: "shoe",
+    5: "socks",
+    6: "shirt",
+    7: "tie",
+    8: "watch",
+  }
+  let graph: list<list<int>> = [
+    [1, 4],
+    [2, 4],
+    [3],
+    [],
+    [],
+    [4],
+    [2, 7],
+    [3],
+    [],
+  ]
+  let stack = topological_sort(graph)
+  print(format_list(stack))
+  print_stack(stack, clothes)
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/graphs/g_topological_sort.out
+++ b/tests/github/TheAlgorithms/Mochi/graphs/g_topological_sort.out
@@ -1,0 +1,10 @@
+[3, 2, 4, 1, 0, 5, 7, 6, 8]
+1 watch
+2 shirt
+3 tie
+4 socks
+5 underwear
+6 pants
+7 shoe
+8 belt
+9 suit

--- a/tests/github/TheAlgorithms/Python/graphs/g_topological_sort.py
+++ b/tests/github/TheAlgorithms/Python/graphs/g_topological_sort.py
@@ -1,0 +1,47 @@
+# Author: Phyllipe Bezerra (https://github.com/pmba)
+
+clothes = {
+    0: "underwear",
+    1: "pants",
+    2: "belt",
+    3: "suit",
+    4: "shoe",
+    5: "socks",
+    6: "shirt",
+    7: "tie",
+    8: "watch",
+}
+
+graph = [[1, 4], [2, 4], [3], [], [], [4], [2, 7], [3], []]
+
+visited = [0 for x in range(len(graph))]
+stack = []
+
+
+def print_stack(stack, clothes):
+    order = 1
+    while stack:
+        current_clothing = stack.pop()
+        print(order, clothes[current_clothing])
+        order += 1
+
+
+def depth_first_search(u, visited, graph):
+    visited[u] = 1
+    for v in graph[u]:
+        if not visited[v]:
+            depth_first_search(v, visited, graph)
+
+    stack.append(u)
+
+
+def topological_sort(graph, visited):
+    for v in range(len(graph)):
+        if not visited[v]:
+            depth_first_search(v, visited, graph)
+
+
+if __name__ == "__main__":
+    topological_sort(graph, visited)
+    print(stack)
+    print_stack(stack, clothes)


### PR DESCRIPTION
## Summary
- add Python reference implementation for graph-based clothing order
- implement equivalent Mochi DFS topological sort and formatted output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/graphs/g_topological_sort.mochi > tests/github/TheAlgorithms/Mochi/graphs/g_topological_sort.out`


------
https://chatgpt.com/codex/tasks/task_e_6891cb70fb188320b69c889868377ff1