### PR TITLE
Add Floyd-Warshall algorithm in Mochi

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/graphs/graphs_floyd_warshall.mochi
+++ b/tests/github/TheAlgorithms/Mochi/graphs/graphs_floyd_warshall.mochi
@@ -1,0 +1,76 @@
+/*
+Floyd-Warshall All-Pairs Shortest Paths
+---------------------------------------
+Given a directed graph represented by a weight matrix, possibly with negative
+edge weights, the task is to compute the minimum distance between every pair
+of vertices. The Floyd–Warshall algorithm performs dynamic programming on
+the adjacency matrix, iteratively improving path lengths by allowing each
+vertex as an intermediate. For every pair (i, j) and intermediate k it
+sets dist[i][j] = min(dist[i][j], dist[i][k] + dist[k][j]). Complexity is
+O(n^3) for n vertices and the algorithm handles negative edges as long as
+there are no negative cycles.
+*/
+
+let INF: float = 1000000000.0
+
+fun floyd_warshall(graph: list<list<float>>): list<list<float>> {
+  let v = len(graph)
+  var dist: list<list<float>> = []
+  var i = 0
+  while i < v {
+    var row: list<float> = []
+    var j = 0
+    while j < v {
+      row = append(row, graph[i][j])
+      j = j + 1
+    }
+    dist = append(dist, row)
+    i = i + 1
+  }
+
+  var k = 0
+  while k < v {
+    var i = 0
+    while i < v {
+      var j = 0
+      while j < v {
+        if dist[i][k] < INF && dist[k][j] < INF && dist[i][k] + dist[k][j] < dist[i][j] {
+          dist[i][j] = dist[i][k] + dist[k][j]
+        }
+        j = j + 1
+      }
+      i = i + 1
+    }
+    k = k + 1
+  }
+  return dist
+}
+
+fun print_dist(dist: list<list<float>>): void {
+  print("\nThe shortest path matrix using Floyd Warshall algorithm\n")
+  var i = 0
+  while i < len(dist) {
+    var j = 0
+    var line = ""
+    while j < len(dist[i]) {
+      if dist[i][j] >= INF / 2.0 {
+        line = line + "INF\t"
+      } else {
+        line = line + str(int(dist[i][j])) + "\t"
+      }
+      j = j + 1
+    }
+    print(line)
+    i = i + 1
+  }
+}
+
+let graph = [
+  [0.0, 5.0, INF, 10.0],
+  [INF, 0.0, 3.0, INF],
+  [INF, INF, 0.0, 1.0],
+  [INF, INF, INF, 0.0]
+]
+
+let result = floyd_warshall(graph)
+print_dist(result)

--- a/tests/github/TheAlgorithms/Mochi/graphs/graphs_floyd_warshall.out
+++ b/tests/github/TheAlgorithms/Mochi/graphs/graphs_floyd_warshall.out
@@ -1,0 +1,7 @@
+
+The shortest path matrix using Floyd Warshall algorithm
+
+0	5	8	9	
+INF	0	3	4	
+INF	INF	0	1	
+INF	INF	INF	0	

--- a/tests/github/TheAlgorithms/Python/graphs/graphs_floyd_warshall.py
+++ b/tests/github/TheAlgorithms/Python/graphs/graphs_floyd_warshall.py
@@ -1,0 +1,102 @@
+# floyd_warshall.py
+"""
+The problem is to find the shortest distance between all pairs of vertices in a
+weighted directed graph that can have negative edge weights.
+"""
+
+
+def _print_dist(dist, v):
+    print("\nThe shortest path matrix using Floyd Warshall algorithm\n")
+    for i in range(v):
+        for j in range(v):
+            if dist[i][j] != float("inf"):
+                print(int(dist[i][j]), end="\t")
+            else:
+                print("INF", end="\t")
+        print()
+
+
+def floyd_warshall(graph, v):
+    """
+    :param graph: 2D array calculated from weight[edge[i, j]]
+    :type graph: List[List[float]]
+    :param v: number of vertices
+    :type v: int
+    :return: shortest distance between all vertex pairs
+    distance[u][v] will contain the shortest distance from vertex u to v.
+
+    1. For all edges from v to n, distance[i][j] = weight(edge(i, j)).
+    3. The algorithm then performs distance[i][j] = min(distance[i][j], distance[i][k] +
+        distance[k][j]) for each possible pair i, j of vertices.
+    4. The above is repeated for each vertex k in the graph.
+    5. Whenever distance[i][j] is given a new minimum value, next vertex[i][j] is
+        updated to the next vertex[i][k].
+    """
+
+    dist = [[float("inf") for _ in range(v)] for _ in range(v)]
+
+    for i in range(v):
+        for j in range(v):
+            dist[i][j] = graph[i][j]
+
+            # check vertex k against all other vertices (i, j)
+    for k in range(v):
+        # looping through rows of graph array
+        for i in range(v):
+            # looping through columns of graph array
+            for j in range(v):
+                if (
+                    dist[i][k] != float("inf")
+                    and dist[k][j] != float("inf")
+                    and dist[i][k] + dist[k][j] < dist[i][j]
+                ):
+                    dist[i][j] = dist[i][k] + dist[k][j]
+
+    _print_dist(dist, v)
+    return dist, v
+
+
+if __name__ == "__main__":
+    v = int(input("Enter number of vertices: "))
+    e = int(input("Enter number of edges: "))
+
+    graph = [[float("inf") for i in range(v)] for j in range(v)]
+
+    for i in range(v):
+        graph[i][i] = 0.0
+
+        # src and dst are indices that must be within the array size graph[e][v]
+        # failure to follow this will result in an error
+    for i in range(e):
+        print("\nEdge ", i + 1)
+        src = int(input("Enter source:"))
+        dst = int(input("Enter destination:"))
+        weight = float(input("Enter weight:"))
+        graph[src][dst] = weight
+
+    floyd_warshall(graph, v)
+
+    # Example Input
+    # Enter number of vertices: 3
+    # Enter number of edges: 2
+
+    # # generated graph from vertex and edge inputs
+    # [[inf, inf, inf], [inf, inf, inf], [inf, inf, inf]]
+    # [[0.0, inf, inf], [inf, 0.0, inf], [inf, inf, 0.0]]
+
+    # specify source, destination and weight for edge #1
+    # Edge  1
+    # Enter source:1
+    # Enter destination:2
+    # Enter weight:2
+
+    # specify source, destination and weight for edge #2
+    # Edge  2
+    # Enter source:2
+    # Enter destination:1
+    # Enter weight:1
+
+    # # Expected Output from the vertice, edge and src, dst, weight inputs!!
+    # 0		INF	INF
+    # INF	0	2
+    # INF	1	0


### PR DESCRIPTION
## Summary
- add missing Python reference implementation for Floyd-Warshall all-pairs shortest paths
- port Floyd-Warshall to pure Mochi with dynamic programming and matrix printer

## Testing
- `./mochi_bin run tests/github/TheAlgorithms/Mochi/graphs/graphs_floyd_warshall.mochi`
- `go test ./runtime/vm`

------
https://chatgpt.com/codex/tasks/task_e_6891cb7d058c83209438f771956c5199