### PR TITLE
Add fractional knapsack algorithm in Mochi

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/greedy_methods/fractional_knapsack_2.mochi
+++ b/tests/github/TheAlgorithms/Mochi/greedy_methods/fractional_knapsack_2.mochi
@@ -1,0 +1,84 @@
+/*
+Fractional Knapsack (Greedy)
+----------------------------
+
+Given arrays `value` and `weight` for `n` items and a knapsack with capacity
+`capacity`, compute the maximal total value that can be placed into the
+knapsack when we are allowed to take fractional portions of an item.
+
+For each item we compute the value-to-weight ratio and greedily pick items
+in decreasing ratio order. For each item:
+  - If it fits, take it entirely.
+  - Otherwise take the remaining capacity fraction of that item.
+
+We return the maximal value obtained and an array `fractions` indicating
+the fraction of each item included.
+
+Time Complexity: O(n^2) due to insertion sort
+Space Complexity: O(n)
+*/
+
+type KnapsackResult { max_value: float, fractions: list<float> }
+
+fun sort_by_ratio(index: list<int>, ratio: list<float>): list<int> {
+  var i = 1
+  while i < len(index) {
+    let key = index[i]
+    let key_ratio = ratio[key]
+    var j = i - 1
+    while j >= 0 && ratio[index[j]] < key_ratio {
+      index[j + 1] = index[j]
+      j = j - 1
+    }
+    index[j + 1] = key
+    i = i + 1
+  }
+  return index
+}
+
+fun fractional_knapsack(value: list<float>, weight: list<float>, capacity: float): KnapsackResult {
+  let n = len(value)
+  var index: list<int> = []
+  var i = 0
+  while i < n {
+    index = append(index, i)
+    i = i + 1
+  }
+  var ratio: list<float> = []
+  i = 0
+  while i < n {
+    ratio = append(ratio, value[i] / weight[i])
+    i = i + 1
+  }
+  index = sort_by_ratio(index, ratio)
+
+  var fractions: list<float> = []
+  i = 0
+  while i < n {
+    fractions = append(fractions, 0.0)
+    i = i + 1
+  }
+  var max_value: float = 0.0
+  var idx = 0
+  while idx < len(index) {
+    let item = index[idx]
+    if weight[item] <= capacity {
+      fractions[item] = 1.0
+      max_value = max_value + value[item]
+      capacity = capacity - weight[item]
+    } else {
+      fractions[item] = capacity / weight[item]
+      max_value = max_value + value[item] * capacity / weight[item]
+      break
+    }
+    idx = idx + 1
+  }
+  return KnapsackResult { max_value: max_value, fractions: fractions }
+}
+
+let v: list<float> = [1.0, 3.0, 5.0, 7.0, 9.0]
+let w: list<float> = [0.9, 0.7, 0.5, 0.3, 0.1]
+
+print(fractional_knapsack(v, w, 5.0))
+print(fractional_knapsack([1.0, 3.0, 5.0, 7.0], [0.9, 0.7, 0.5, 0.3], 30.0))
+print(fractional_knapsack([] as list<float>, [] as list<float>, 30.0))

--- a/tests/github/TheAlgorithms/Mochi/greedy_methods/fractional_knapsack_2.out
+++ b/tests/github/TheAlgorithms/Mochi/greedy_methods/fractional_knapsack_2.out
@@ -1,0 +1,3 @@
+{"__name": "KnapsackResult", "fractions": [1.0, 1.0, 1.0, 1.0, 1.0], "max_value": 25.0}
+{"__name": "KnapsackResult", "fractions": [1.0, 1.0, 1.0, 1.0], "max_value": 16.0}
+{"__name": "KnapsackResult", "fractions": [], "max_value": 0.0}

--- a/tests/github/TheAlgorithms/Python/greedy_methods/fractional_knapsack_2.py
+++ b/tests/github/TheAlgorithms/Python/greedy_methods/fractional_knapsack_2.py
@@ -1,0 +1,53 @@
+# https://en.wikipedia.org/wiki/Continuous_knapsack_problem
+# https://www.guru99.com/fractional-knapsack-problem-greedy.html
+# https://medium.com/walkinthecode/greedy-algorithm-fractional-knapsack-problem-9aba1daecc93
+
+from __future__ import annotations
+
+
+def fractional_knapsack(
+    value: list[int], weight: list[int], capacity: int
+) -> tuple[float, list[float]]:
+    """
+    >>> value = [1, 3, 5, 7, 9]
+    >>> weight = [0.9, 0.7, 0.5, 0.3, 0.1]
+    >>> fractional_knapsack(value, weight, 5)
+    (25, [1, 1, 1, 1, 1])
+    >>> fractional_knapsack(value, weight, 15)
+    (25, [1, 1, 1, 1, 1])
+    >>> fractional_knapsack(value, weight, 25)
+    (25, [1, 1, 1, 1, 1])
+    >>> fractional_knapsack(value, weight, 26)
+    (25, [1, 1, 1, 1, 1])
+    >>> fractional_knapsack(value, weight, -1)
+    (-90.0, [0, 0, 0, 0, -10.0])
+    >>> fractional_knapsack([1, 3, 5, 7], weight, 30)
+    (16, [1, 1, 1, 1])
+    >>> fractional_knapsack(value, [0.9, 0.7, 0.5, 0.3, 0.1], 30)
+    (25, [1, 1, 1, 1, 1])
+    >>> fractional_knapsack([], [], 30)
+    (0, [])
+    """
+    index = list(range(len(value)))
+    ratio = [v / w for v, w in zip(value, weight)]
+    index.sort(key=lambda i: ratio[i], reverse=True)
+
+    max_value: float = 0
+    fractions: list[float] = [0] * len(value)
+    for i in index:
+        if weight[i] <= capacity:
+            fractions[i] = 1
+            max_value += value[i]
+            capacity -= weight[i]
+        else:
+            fractions[i] = capacity / weight[i]
+            max_value += value[i] * capacity / weight[i]
+            break
+
+    return max_value, fractions
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add upstream Python implementation for fractional knapsack
- implement fractional knapsack greedy algorithm in Mochi
- include sample executions and expected outputs

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/greedy_methods/fractional_knapsack_2.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891d4912da88320843f53d2c622b4f5