### PR TITLE
Add Mochi Luhn algorithm example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/hashes/luhn.mochi
+++ b/tests/github/TheAlgorithms/Mochi/hashes/luhn.mochi
@@ -1,0 +1,38 @@
+/*
+Luhn Algorithm Validator
+-----------------------
+The Luhn algorithm validates identification numbers such as credit card
+numbers. Given a string of decimal digits:
+1. Remove the last digit which serves as the check digit.
+2. Starting from the rightmost remaining digit, double every second digit.
+3. If a doubled digit exceeds 9, subtract 9 from it.
+4. Sum all digits including the check digit.
+5. The number is valid if the total modulo 10 equals 0.
+This implementation follows the same steps using only pure Mochi code.
+*/
+
+fun is_luhn(s: string): bool {
+  let n = len(s)
+  if n <= 1 { return false }
+  var check_digit = int(substring(s, n - 1, n))
+  var i = n - 2
+  var even = true
+  while i >= 0 {
+    let digit = int(substring(s, i, i + 1))
+    if even {
+      var doubled = digit * 2
+      if doubled > 9 {
+        doubled = doubled - 9
+      }
+      check_digit = check_digit + doubled
+    } else {
+      check_digit = check_digit + digit
+    }
+    even = !even
+    i = i - 1
+  }
+  return check_digit % 10 == 0
+}
+
+json(is_luhn("79927398713"))
+json(is_luhn("79927398714"))

--- a/tests/github/TheAlgorithms/Mochi/hashes/luhn.out
+++ b/tests/github/TheAlgorithms/Mochi/hashes/luhn.out
@@ -1,0 +1,2 @@
+true
+false

--- a/tests/github/TheAlgorithms/Python/hashes/luhn.py
+++ b/tests/github/TheAlgorithms/Python/hashes/luhn.py
@@ -1,0 +1,43 @@
+"""Luhn Algorithm"""
+
+from __future__ import annotations
+
+
+def is_luhn(string: str) -> bool:
+    """
+    Perform Luhn validation on an input string
+    Algorithm:
+    * Double every other digit starting from 2nd last digit.
+    * Subtract 9 if number is greater than 9.
+    * Sum the numbers
+    *
+    >>> test_cases = (79927398710, 79927398711, 79927398712, 79927398713,
+    ...     79927398714, 79927398715, 79927398716, 79927398717, 79927398718,
+    ...     79927398719)
+    >>> [is_luhn(str(test_case)) for test_case in test_cases]
+    [False, False, False, True, False, False, False, False, False, False]
+    """
+    check_digit: int
+    _vector: list[str] = list(string)
+    __vector, check_digit = _vector[:-1], int(_vector[-1])
+    vector: list[int] = [int(digit) for digit in __vector]
+
+    vector.reverse()
+    for i, digit in enumerate(vector):
+        if i & 1 == 0:
+            doubled: int = digit * 2
+            if doubled > 9:
+                doubled -= 9
+            check_digit += doubled
+        else:
+            check_digit += digit
+
+    return check_digit % 10 == 0
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    assert is_luhn("79927398713")
+    assert not is_luhn("79927398714")


### PR DESCRIPTION
## Summary
- add TheAlgorithms Python reference for Luhn credit-card checksum
- implement Luhn validator in pure Mochi and sample calls

## Testing
- `npm test` *(fails: Missing script "test")*
- `go test ./...`
- `./mochi run tests/github/TheAlgorithms/Mochi/hashes/luhn.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891db90dc608320ae2545714c9ffbaf