### PR TITLE
feat: add md5 hash implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/hashes/md5.mochi
+++ b/tests/github/TheAlgorithms/Mochi/hashes/md5.mochi
@@ -1,0 +1,284 @@
+/*
+MD5 Hash Function Implementation
+--------------------------------
+This program implements the MD5 hashing algorithm purely in Mochi without
+relying on built in bitwise operations or foreign function interfaces.  MD5
+processes an input message in 512‑bit blocks and produces a 128‑bit digest.
+The main steps are:
+1. Preprocess the input by converting it to a binary string, appending a
+   single "1" bit, padding with zeros so that the length is 448 modulo 512,
+   and finally appending the original length as a 64‑bit little‑endian
+   integer.
+2. Break the stream into 512‑bit blocks and each block into sixteen 32‑bit
+   little‑endian words.
+3. Iterate over each block updating the four 32‑bit state variables using the
+   nonlinear functions described in RFC 1321.  All arithmetic is performed
+   modulo 2^32.  Since the VM lacks native bitwise operators, helper
+   functions emulate AND, OR, XOR, NOT and bit rotation using integer
+   arithmetic.
+4. After processing all blocks, the final state values are converted to
+   little‑endian hexadecimal and concatenated to produce the 32 character
+   digest.
+The implementation includes test cases verifying standard MD5 test vectors.
+*/
+
+let MOD = 4294967296
+let ASCII = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+
+fun ord(ch: string): int {
+  var i = 0
+  while i < len(ASCII) {
+    if ASCII[i:i+1] == ch { return 32 + i }
+    i = i + 1
+  }
+  return 0
+}
+
+fun to_little_endian(s: string): string {
+  if len(s) != 32 { panic("Input must be of length 32") }
+  return s[24:32] + s[16:24] + s[8:16] + s[0:8]
+}
+
+fun int_to_bits(n: int, width: int): string {
+  var bits = ""
+  var num = n
+  while num > 0 {
+    bits = str(num % 2) + bits
+    num = num / 2
+  }
+  while len(bits) < width { bits = "0" + bits }
+  if len(bits) > width { bits = bits[len(bits)-width:len(bits)] }
+  return bits
+}
+
+fun bits_to_int(bits: string): int {
+  var num = 0
+  var i = 0
+  while i < len(bits) {
+    if bits[i:i+1] == "1" {
+      num = num * 2 + 1
+    } else {
+      num = num * 2
+    }
+    i = i + 1
+  }
+  return num
+}
+
+fun to_hex(n: int): string {
+  let digits = "0123456789abcdef"
+  if n == 0 { return "0" }
+  var num = n
+  var s = ""
+  while num > 0 {
+    let d = num % 16
+    s = digits[d:d+1] + s
+    num = num / 16
+  }
+  return s
+}
+
+fun reformat_hex(i: int): string {
+  if i < 0 { panic("Input must be non-negative") }
+  var hex = to_hex(i)
+  while len(hex) < 8 { hex = "0" + hex }
+  if len(hex) > 8 { hex = hex[len(hex)-8:len(hex)] }
+  var le = ""
+  var j = len(hex) - 2
+  while j >= 0 {
+    le = le + hex[j:j+2]
+    j = j - 2
+  }
+  return le
+}
+
+fun preprocess(message: string): string {
+  var bit_string = ""
+  var i = 0
+  while i < len(message) {
+    let ch = message[i:i+1]
+    bit_string = bit_string + int_to_bits(ord(ch), 8)
+    i = i + 1
+  }
+  let start_len = int_to_bits(len(bit_string), 64)
+  bit_string = bit_string + "1"
+  while len(bit_string) % 512 != 448 { bit_string = bit_string + "0" }
+  bit_string = bit_string + to_little_endian(start_len[32:64]) + to_little_endian(start_len[0:32])
+  return bit_string
+}
+
+fun get_block_words(bit_string: string): list<list<int>> {
+  if len(bit_string) % 512 != 0 { panic("Input must have length that's a multiple of 512") }
+  var blocks: list<list<int>> = []
+  var pos = 0
+  while pos < len(bit_string) {
+    var block: list<int> = []
+    var i = 0
+    while i < 512 {
+      let part = bit_string[pos + i: pos + i + 32]
+      let word = bits_to_int(to_little_endian(part))
+      block = append(block, word)
+      i = i + 32
+    }
+    blocks = append(blocks, block)
+    pos = pos + 512
+  }
+  return blocks
+}
+
+fun bit_and(a: int, b: int): int {
+  var x = a
+  var y = b
+  var res = 0
+  var bit = 1
+  var i = 0
+  while i < 32 {
+    if (x % 2 == 1) && (y % 2 == 1) { res = res + bit }
+    x = x / 2
+    y = y / 2
+    bit = bit * 2
+    i = i + 1
+  }
+  return res
+}
+
+fun bit_or(a: int, b: int): int {
+  var x = a
+  var y = b
+  var res = 0
+  var bit = 1
+  var i = 0
+  while i < 32 {
+    let abit = x % 2
+    let bbit = y % 2
+    if abit == 1 || bbit == 1 { res = res + bit }
+    x = x / 2
+    y = y / 2
+    bit = bit * 2
+    i = i + 1
+  }
+  return res
+}
+
+fun bit_xor(a: int, b: int): int {
+  var x = a
+  var y = b
+  var res = 0
+  var bit = 1
+  var i = 0
+  while i < 32 {
+    let abit = x % 2
+    let bbit = y % 2
+    if (abit + bbit) % 2 == 1 { res = res + bit }
+    x = x / 2
+    y = y / 2
+    bit = bit * 2
+    i = i + 1
+  }
+  return res
+}
+
+fun not_32(i: int): int {
+  if i < 0 { panic("Input must be non-negative") }
+  return 4294967295 - i
+}
+
+fun sum_32(a: int, b: int): int {
+  return (a + b) % MOD
+}
+
+fun lshift(num: int, k: int): int {
+  var result = num % MOD
+  var i = 0
+  while i < k {
+    result = (result * 2) % MOD
+    i = i + 1
+  }
+  return result
+}
+
+fun rshift(num: int, k: int): int {
+  var result = num
+  var i = 0
+  while i < k {
+    result = result / 2
+    i = i + 1
+  }
+  return result
+}
+
+fun left_rotate_32(i: int, shift: int): int {
+  if i < 0 { panic("Input must be non-negative") }
+  if shift < 0 { panic("Shift must be non-negative") }
+  let left = lshift(i, shift)
+  let right = rshift(i, 32 - shift)
+  return (left + right) % MOD
+}
+
+fun md5_me(message: string): string {
+  let bit_string = preprocess(message)
+  let added_consts: list<int> = [3614090360,3905402710,606105819,3250441966,4118548399,1200080426,2821735955,4249261313,1770035416,2336552879,4294925233,2304563134,1804603682,4254626195,2792965006,1236535329,4129170786,3225465664,643717713,3921069994,3593408605,38016083,3634488961,3889429448,568446438,3275163606,4107603335,1163531501,2850285829,4243563512,1735328473,2368359562,4294588738,2272392833,1839030562,4259657740,2763975236,1272893353,4139469664,3200236656,681279174,3936430074,3572445317,76029189,3654602809,3873151461,530742520,3299628645,4096336452,1126891415,2878612391,4237533241,1700485571,2399980690,4293915773,2240044497,1873313359,4264355552,2734768916,1309151649,4149444226,3174756917,718787259,3951481745]
+  let shift_amounts: list<int> = [7,12,17,22,7,12,17,22,7,12,17,22,7,12,17,22,5,9,14,20,5,9,14,20,5,9,14,20,5,9,14,20,4,11,16,23,4,11,16,23,4,11,16,23,4,11,16,23,6,10,15,21,6,10,15,21,6,10,15,21,6,10,15,21]
+
+  var a0 = 0x67452301
+  var b0 = 0xEFCDAB89
+  var c0 = 0x98BADCFE
+  var d0 = 0x10325476
+
+  let blocks = get_block_words(bit_string)
+  var bi = 0
+  while bi < len(blocks) {
+    let block = blocks[bi]
+    var a = a0
+    var b = b0
+    var c = c0
+    var d = d0
+    var i = 0
+    while i < 64 {
+      var f = 0
+      var g = 0
+      if i <= 15 {
+        f = bit_xor(d, bit_and(b, bit_xor(c, d)))
+        g = i
+      } else if i <= 31 {
+        f = bit_xor(c, bit_and(d, bit_xor(b, c)))
+        g = (5 * i + 1) % 16
+      } else if i <= 47 {
+        f = bit_xor(bit_xor(b, c), d)
+        g = (3 * i + 5) % 16
+      } else {
+        f = bit_xor(c, bit_or(b, not_32(d)))
+        g = (7 * i) % 16
+      }
+      f = sum_32(f, a)
+      f = sum_32(f, added_consts[i])
+      f = sum_32(f, block[g])
+      let rotated = left_rotate_32(f, shift_amounts[i])
+      let new_b = sum_32(b, rotated)
+      a = d
+      d = c
+      c = b
+      b = new_b
+      i = i + 1
+    }
+    a0 = sum_32(a0, a)
+    b0 = sum_32(b0, b)
+    c0 = sum_32(c0, c)
+    d0 = sum_32(d0, d)
+    bi = bi + 1
+  }
+  let digest = reformat_hex(a0) + reformat_hex(b0) + reformat_hex(c0) + reformat_hex(d0)
+  return digest
+}
+
+test "md5 empty" {
+  expect md5_me("") == "d41d8cd98f00b204e9800998ecf8427e"
+}
+
+test "md5 fox" {
+  expect md5_me("The quick brown fox jumps over the lazy dog") == "9e107d9d372bb6826bd81d3542a419d6"
+}
+
+test "md5 fox dot" {
+  expect md5_me("The quick brown fox jumps over the lazy dog.") == "e4d909c290d0fb1ca068ffaddf22cbd0"
+}

--- a/tests/github/TheAlgorithms/Mochi/hashes/md5.out
+++ b/tests/github/TheAlgorithms/Mochi/hashes/md5.out
@@ -1,0 +1,4 @@
+[94;1mtests/github/TheAlgorithms/Mochi/hashes/md5.mochi[0;22m
+   [33mtest[0m md5 empty                      ... [32mok[0m (39.0ms)
+   [33mtest[0m md5 fox                        ... [32mok[0m (35.0ms)
+   [33mtest[0m md5 fox dot                    ... [32mok[0m (30.0ms)

--- a/tests/github/TheAlgorithms/Python/hashes/md5.py
+++ b/tests/github/TheAlgorithms/Python/hashes/md5.py
@@ -1,0 +1,444 @@
+"""
+The MD5 algorithm is a hash function that's commonly used as a checksum to
+detect data corruption. The algorithm works by processing a given message in
+blocks of 512 bits, padding the message as needed. It uses the blocks to operate
+a 128-bit state and performs a total of 64 such operations. Note that all values
+are little-endian, so inputs are converted as needed.
+
+Although MD5 was used as a cryptographic hash function in the past, it's since
+been cracked, so it shouldn't be used for security purposes.
+
+For more info, see https://en.wikipedia.org/wiki/MD5
+"""
+
+from collections.abc import Generator
+from math import sin
+
+
+def to_little_endian(string_32: bytes) -> bytes:
+    """
+    Converts the given string to little-endian in groups of 8 chars.
+
+    Arguments:
+        string_32 {[string]} -- [32-char string]
+
+    Raises:
+        ValueError -- [input is not 32 char]
+
+    Returns:
+        32-char little-endian string
+    >>> to_little_endian(b'1234567890abcdfghijklmnopqrstuvw')
+    b'pqrstuvwhijklmno90abcdfg12345678'
+    >>> to_little_endian(b'1234567890')
+    Traceback (most recent call last):
+    ...
+    ValueError: Input must be of length 32
+    """
+    if len(string_32) != 32:
+        raise ValueError("Input must be of length 32")
+
+    little_endian = b""
+    for i in [3, 2, 1, 0]:
+        little_endian += string_32[8 * i : 8 * i + 8]
+    return little_endian
+
+
+def reformat_hex(i: int) -> bytes:
+    """
+    Converts the given non-negative integer to hex string.
+
+    Example: Suppose the input is the following:
+        i = 1234
+
+        The input is 0x000004d2 in hex, so the little-endian hex string is
+        "d2040000".
+
+    Arguments:
+        i {[int]} -- [integer]
+
+    Raises:
+        ValueError -- [input is negative]
+
+    Returns:
+        8-char little-endian hex string
+
+    >>> reformat_hex(1234)
+    b'd2040000'
+    >>> reformat_hex(666)
+    b'9a020000'
+    >>> reformat_hex(0)
+    b'00000000'
+    >>> reformat_hex(1234567890)
+    b'd2029649'
+    >>> reformat_hex(1234567890987654321)
+    b'b11c6cb1'
+    >>> reformat_hex(-1)
+    Traceback (most recent call last):
+    ...
+    ValueError: Input must be non-negative
+    """
+    if i < 0:
+        raise ValueError("Input must be non-negative")
+
+    hex_rep = format(i, "08x")[-8:]
+    little_endian_hex = b""
+    for j in [3, 2, 1, 0]:
+        little_endian_hex += hex_rep[2 * j : 2 * j + 2].encode("utf-8")
+    return little_endian_hex
+
+
+def preprocess(message: bytes) -> bytes:
+    """
+    Preprocesses the message string:
+    - Convert message to bit string
+    - Pad bit string to a multiple of 512 chars:
+        - Append a 1
+        - Append 0's until length = 448 (mod 512)
+        - Append length of original message (64 chars)
+
+    Example: Suppose the input is the following:
+        message = "a"
+
+        The message bit string is "01100001", which is 8 bits long. Thus, the
+        bit string needs 439 bits of padding so that
+        (bit_string + "1" + padding) = 448 (mod 512).
+        The message length is "000010000...0" in 64-bit little-endian binary.
+        The combined bit string is then 512 bits long.
+
+    Arguments:
+        message {[string]} -- [message string]
+
+    Returns:
+        processed bit string padded to a multiple of 512 chars
+
+    >>> preprocess(b"a") == (b"01100001" + b"1" +
+    ...                     (b"0" * 439) + b"00001000" + (b"0" * 56))
+    True
+    >>> preprocess(b"") == b"1" + (b"0" * 447) + (b"0" * 64)
+    True
+    """
+    bit_string = b""
+    for char in message:
+        bit_string += format(char, "08b").encode("utf-8")
+    start_len = format(len(bit_string), "064b").encode("utf-8")
+
+    # Pad bit_string to a multiple of 512 chars
+    bit_string += b"1"
+    while len(bit_string) % 512 != 448:
+        bit_string += b"0"
+    bit_string += to_little_endian(start_len[32:]) + to_little_endian(start_len[:32])
+
+    return bit_string
+
+
+def get_block_words(bit_string: bytes) -> Generator[list[int]]:
+    """
+    Splits bit string into blocks of 512 chars and yields each block as a list
+    of 32-bit words
+
+    Example: Suppose the input is the following:
+        bit_string =
+            "000000000...0" +  # 0x00 (32 bits, padded to the right)
+            "000000010...0" +  # 0x01 (32 bits, padded to the right)
+            "000000100...0" +  # 0x02 (32 bits, padded to the right)
+            "000000110...0" +  # 0x03 (32 bits, padded to the right)
+            ...
+            "000011110...0"    # 0x0a (32 bits, padded to the right)
+
+        Then len(bit_string) == 512, so there'll be 1 block. The block is split
+        into 32-bit words, and each word is converted to little endian. The
+        first word is interpreted as 0 in decimal, the second word is
+        interpreted as 1 in decimal, etc.
+
+        Thus, block_words == [[0, 1, 2, 3, ..., 15]].
+
+    Arguments:
+        bit_string {[string]} -- [bit string with multiple of 512 as length]
+
+    Raises:
+        ValueError -- [length of bit string isn't multiple of 512]
+
+    Yields:
+        a list of 16 32-bit words
+
+    >>> test_string = ("".join(format(n << 24, "032b") for n in range(16))
+    ...                  .encode("utf-8"))
+    >>> list(get_block_words(test_string))
+    [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]]
+    >>> list(get_block_words(test_string * 4)) == [list(range(16))] * 4
+    True
+    >>> list(get_block_words(b"1" * 512)) == [[4294967295] * 16]
+    True
+    >>> list(get_block_words(b""))
+    []
+    >>> list(get_block_words(b"1111"))
+    Traceback (most recent call last):
+    ...
+    ValueError: Input must have length that's a multiple of 512
+    """
+    if len(bit_string) % 512 != 0:
+        raise ValueError("Input must have length that's a multiple of 512")
+
+    for pos in range(0, len(bit_string), 512):
+        block = bit_string[pos : pos + 512]
+        block_words = []
+        for i in range(0, 512, 32):
+            block_words.append(int(to_little_endian(block[i : i + 32]), 2))
+        yield block_words
+
+
+def not_32(i: int) -> int:
+    """
+    Perform bitwise NOT on given int.
+
+    Arguments:
+        i {[int]} -- [given int]
+
+    Raises:
+        ValueError -- [input is negative]
+
+    Returns:
+        Result of bitwise NOT on i
+
+    >>> not_32(34)
+    4294967261
+    >>> not_32(1234)
+    4294966061
+    >>> not_32(4294966061)
+    1234
+    >>> not_32(0)
+    4294967295
+    >>> not_32(1)
+    4294967294
+    >>> not_32(-1)
+    Traceback (most recent call last):
+    ...
+    ValueError: Input must be non-negative
+    """
+    if i < 0:
+        raise ValueError("Input must be non-negative")
+
+    i_str = format(i, "032b")
+    new_str = ""
+    for c in i_str:
+        new_str += "1" if c == "0" else "0"
+    return int(new_str, 2)
+
+
+def sum_32(a: int, b: int) -> int:
+    """
+    Add two numbers as 32-bit ints.
+
+    Arguments:
+        a {[int]} -- [first given int]
+        b {[int]} -- [second given int]
+
+    Returns:
+        (a + b) as an unsigned 32-bit int
+
+    >>> sum_32(1, 1)
+    2
+    >>> sum_32(2, 3)
+    5
+    >>> sum_32(0, 0)
+    0
+    >>> sum_32(-1, -1)
+    4294967294
+    >>> sum_32(4294967295, 1)
+    0
+    """
+    return (a + b) % 2**32
+
+
+def left_rotate_32(i: int, shift: int) -> int:
+    """
+    Rotate the bits of a given int left by a given amount.
+
+    Arguments:
+        i {[int]} -- [given int]
+        shift {[int]} -- [shift amount]
+
+    Raises:
+        ValueError -- [either given int or shift is negative]
+
+    Returns:
+        `i` rotated to the left by `shift` bits
+
+    >>> left_rotate_32(1234, 1)
+    2468
+    >>> left_rotate_32(1111, 4)
+    17776
+    >>> left_rotate_32(2147483648, 1)
+    1
+    >>> left_rotate_32(2147483648, 3)
+    4
+    >>> left_rotate_32(4294967295, 4)
+    4294967295
+    >>> left_rotate_32(1234, 0)
+    1234
+    >>> left_rotate_32(0, 0)
+    0
+    >>> left_rotate_32(-1, 0)
+    Traceback (most recent call last):
+    ...
+    ValueError: Input must be non-negative
+    >>> left_rotate_32(0, -1)
+    Traceback (most recent call last):
+    ...
+    ValueError: Shift must be non-negative
+    """
+    if i < 0:
+        raise ValueError("Input must be non-negative")
+    if shift < 0:
+        raise ValueError("Shift must be non-negative")
+    return ((i << shift) ^ (i >> (32 - shift))) % 2**32
+
+
+def md5_me(message: bytes) -> bytes:
+    """
+    Returns the 32-char MD5 hash of a given message.
+
+    Reference: https://en.wikipedia.org/wiki/MD5#Algorithm
+
+    Arguments:
+        message {[string]} -- [message]
+
+    Returns:
+        32-char MD5 hash string
+
+    >>> md5_me(b"")
+    b'd41d8cd98f00b204e9800998ecf8427e'
+    >>> md5_me(b"The quick brown fox jumps over the lazy dog")
+    b'9e107d9d372bb6826bd81d3542a419d6'
+    >>> md5_me(b"The quick brown fox jumps over the lazy dog.")
+    b'e4d909c290d0fb1ca068ffaddf22cbd0'
+
+    >>> import hashlib
+    >>> from string import ascii_letters
+    >>> msgs = [b"", ascii_letters.encode("utf-8"), "Üñîçø∂é".encode("utf-8"),
+    ...         b"The quick brown fox jumps over the lazy dog."]
+    >>> all(md5_me(msg) == hashlib.md5(msg).hexdigest().encode("utf-8") for msg in msgs)
+    True
+    """
+
+    # Convert to bit string, add padding and append message length
+    bit_string = preprocess(message)
+
+    added_consts = [int(2**32 * abs(sin(i + 1))) for i in range(64)]
+
+    # Starting states
+    a0 = 0x67452301
+    b0 = 0xEFCDAB89
+    c0 = 0x98BADCFE
+    d0 = 0x10325476
+
+    shift_amounts = [
+        7,
+        12,
+        17,
+        22,
+        7,
+        12,
+        17,
+        22,
+        7,
+        12,
+        17,
+        22,
+        7,
+        12,
+        17,
+        22,
+        5,
+        9,
+        14,
+        20,
+        5,
+        9,
+        14,
+        20,
+        5,
+        9,
+        14,
+        20,
+        5,
+        9,
+        14,
+        20,
+        4,
+        11,
+        16,
+        23,
+        4,
+        11,
+        16,
+        23,
+        4,
+        11,
+        16,
+        23,
+        4,
+        11,
+        16,
+        23,
+        6,
+        10,
+        15,
+        21,
+        6,
+        10,
+        15,
+        21,
+        6,
+        10,
+        15,
+        21,
+        6,
+        10,
+        15,
+        21,
+    ]
+
+    # Process bit string in chunks, each with 16 32-char words
+    for block_words in get_block_words(bit_string):
+        a = a0
+        b = b0
+        c = c0
+        d = d0
+
+        # Hash current chunk
+        for i in range(64):
+            if i <= 15:
+                # f = (b & c) | (not_32(b) & d)     # Alternate definition for f
+                f = d ^ (b & (c ^ d))
+                g = i
+            elif i <= 31:
+                # f = (d & b) | (not_32(d) & c)     # Alternate definition for f
+                f = c ^ (d & (b ^ c))
+                g = (5 * i + 1) % 16
+            elif i <= 47:
+                f = b ^ c ^ d
+                g = (3 * i + 5) % 16
+            else:
+                f = c ^ (b | not_32(d))
+                g = (7 * i) % 16
+            f = (f + a + added_consts[i] + block_words[g]) % 2**32
+            a = d
+            d = c
+            c = b
+            b = sum_32(b, left_rotate_32(f, shift_amounts[i]))
+
+        # Add hashed chunk to running total
+        a0 = sum_32(a0, a)
+        b0 = sum_32(b0, b)
+        c0 = sum_32(c0, c)
+        d0 = sum_32(d0, d)
+
+    digest = reformat_hex(a0) + reformat_hex(b0) + reformat_hex(c0) + reformat_hex(d0)
+    return digest
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python MD5 algorithm source
- implement MD5 hash algorithm in Mochi with bitwise helpers and tests

## Testing
- `go run ./cmd/mochi test tests/github/TheAlgorithms/Mochi/hashes/md5.mochi`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891db94010083209ce65032291b1e4a