### PR TITLE
Port TheAlgorithms knapsack tests to Mochi

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/knapsack/tests/test_greedy_knapsack.mochi
+++ b/tests/github/TheAlgorithms/Mochi/knapsack/tests/test_greedy_knapsack.mochi
@@ -1,0 +1,122 @@
+/*
+Greedy Knapsack Test Suite
+
+This program mirrors the Python test "knapsack/tests/test_greedy_knapsack.py" from TheAlgorithms.
+The tested algorithm chooses items based on profit-to-weight ratio to maximize profit within a
+weight limit. Negative weights or profits, zero or negative max_weight, and mismatched list lengths
+are handled as errors. The Mochi implementation provides a `calc_profit` function returning either a
+valid profit or an error message, and a series of tests verify normal and error paths.
+*/
+
+type CalcResult {
+  ok: bool,
+  value: float,
+  error: string
+}
+
+fun calc_profit(profit: list<int>, weight: list<int>, max_weight: int): CalcResult {
+  if len(profit) != len(weight) {
+    return CalcResult { ok: false, value: 0.0, error: "The length of profit and weight must be same." }
+  }
+  if max_weight <= 0 {
+    return CalcResult { ok: false, value: 0.0, error: "max_weight must greater than zero." }
+  }
+  var i = 0
+  while i < len(profit) {
+    if profit[i] < 0 {
+      return CalcResult { ok: false, value: 0.0, error: "Profit can not be negative." }
+    }
+    if weight[i] < 0 {
+      return CalcResult { ok: false, value: 0.0, error: "Weight can not be negative." }
+    }
+    i = i + 1
+  }
+
+  var used: list<bool> = [] as list<bool>
+  var j = 0
+  while j < len(profit) {
+    used = append(used, false)
+    j = j + 1
+  }
+
+  var limit = 0
+  var gain: float = 0.0
+
+  while limit < max_weight {
+    var max_ratio: float = -1.0
+    var idx = 0 - 1
+    var k = 0
+    while k < len(profit) {
+      if !used[k] {
+        let ratio = (profit[k] as float) / (weight[k] as float)
+        if ratio > max_ratio {
+          max_ratio = ratio
+          idx = k
+        }
+      }
+      k = k + 1
+    }
+    if idx == 0 - 1 {
+      break
+    }
+    used[idx] = true
+    if max_weight - limit >= weight[idx] {
+      limit = limit + weight[idx]
+      gain = gain + (profit[idx] as float)
+    } else {
+      gain = gain + (((max_weight - limit) as float) / (weight[idx] as float)) * (profit[idx] as float)
+      break
+    }
+  }
+  return CalcResult { ok: true, value: gain, error: "" }
+}
+
+fun test_sorted(): bool {
+  let profit = [10, 20, 30, 40, 50, 60]
+  let weight = [2, 4, 6, 8, 10, 12]
+  let res = calc_profit(profit, weight, 100)
+  return res.ok && res.value == 210.0
+}
+
+fun test_negative_max_weight(): bool {
+  let profit = [10, 20, 30, 40, 50, 60]
+  let weight = [2, 4, 6, 8, 10, 12]
+  let res = calc_profit(profit, weight, -15)
+  return !res.ok && res.error == "max_weight must greater than zero."
+}
+
+fun test_negative_profit_value(): bool {
+  let profit = [10, -20, 30, 40, 50, 60]
+  let weight = [2, 4, 6, 8, 10, 12]
+  let res = calc_profit(profit, weight, 15)
+  return !res.ok && res.error == "Profit can not be negative."
+}
+
+fun test_negative_weight_value(): bool {
+  let profit = [10, 20, 30, 40, 50, 60]
+  let weight = [2, -4, 6, -8, 10, 12]
+  let res = calc_profit(profit, weight, 15)
+  return !res.ok && res.error == "Weight can not be negative."
+}
+
+fun test_null_max_weight(): bool {
+  let profit = [10, 20, 30, 40, 50, 60]
+  let weight = [2, 4, 6, 8, 10, 12]
+  let res = calc_profit(profit, weight, 0)
+  return !res.ok && res.error == "max_weight must greater than zero."
+}
+
+fun test_unequal_list_length(): bool {
+  let profit = [10, 20, 30, 40, 50]
+  let weight = [2, 4, 6, 8, 10, 12]
+  let res = calc_profit(profit, weight, 100)
+  return !res.ok && res.error == "The length of profit and weight must be same."
+}
+
+print(test_sorted())
+print(test_negative_max_weight())
+print(test_negative_profit_value())
+print(test_negative_weight_value())
+print(test_null_max_weight())
+print(test_unequal_list_length())
+print(true)

--- a/tests/github/TheAlgorithms/Mochi/knapsack/tests/test_greedy_knapsack.out
+++ b/tests/github/TheAlgorithms/Mochi/knapsack/tests/test_greedy_knapsack.out
@@ -1,0 +1,7 @@
+true
+true
+true
+true
+true
+true
+true

--- a/tests/github/TheAlgorithms/Python/knapsack/tests/test_greedy_knapsack.py
+++ b/tests/github/TheAlgorithms/Python/knapsack/tests/test_greedy_knapsack.py
@@ -1,0 +1,75 @@
+import unittest
+
+import pytest
+
+from knapsack import greedy_knapsack as kp
+
+
+class TestClass(unittest.TestCase):
+    """
+    Test cases for knapsack
+    """
+
+    def test_sorted(self):
+        """
+        kp.calc_profit takes the required argument (profit, weight, max_weight)
+        and returns whether the answer matches to the expected ones
+        """
+        profit = [10, 20, 30, 40, 50, 60]
+        weight = [2, 4, 6, 8, 10, 12]
+        max_weight = 100
+        assert kp.calc_profit(profit, weight, max_weight) == 210
+
+    def test_negative_max_weight(self):
+        """
+        Returns ValueError for any negative max_weight value
+        :return: ValueError
+        """
+        # profit = [10, 20, 30, 40, 50, 60]
+        # weight = [2, 4, 6, 8, 10, 12]
+        # max_weight = -15
+        pytest.raises(ValueError, match="max_weight must greater than zero.")
+
+    def test_negative_profit_value(self):
+        """
+        Returns ValueError for any negative profit value in the list
+        :return: ValueError
+        """
+        # profit = [10, -20, 30, 40, 50, 60]
+        # weight = [2, 4, 6, 8, 10, 12]
+        # max_weight = 15
+        pytest.raises(ValueError, match="Weight can not be negative.")
+
+    def test_negative_weight_value(self):
+        """
+        Returns ValueError for any negative weight value in the list
+        :return: ValueError
+        """
+        # profit = [10, 20, 30, 40, 50, 60]
+        # weight = [2, -4, 6, -8, 10, 12]
+        # max_weight = 15
+        pytest.raises(ValueError, match="Profit can not be negative.")
+
+    def test_null_max_weight(self):
+        """
+        Returns ValueError for any zero max_weight value
+        :return: ValueError
+        """
+        # profit = [10, 20, 30, 40, 50, 60]
+        # weight = [2, 4, 6, 8, 10, 12]
+        # max_weight = null
+        pytest.raises(ValueError, match="max_weight must greater than zero.")
+
+    def test_unequal_list_length(self):
+        """
+        Returns IndexError if length of lists (profit and weight) are unequal.
+        :return: IndexError
+        """
+        # profit = [10, 20, 30, 40, 50]
+        # weight = [2, 4, 6, 8, 10, 12]
+        # max_weight = 100
+        pytest.raises(IndexError, match="The length of profit and weight must be same.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add missing Python knapsack test suite from upstream
- implement greedy knapsack algorithm with comprehensive tests in Mochi
- record interpreter output for the Mochi tests

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/knapsack/tests/test_greedy_knapsack.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891dba121108320ae5bb903dac5b387