### PR TITLE
Add linear regression implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/machine_learning/linear_regression.mochi
+++ b/tests/github/TheAlgorithms/Mochi/machine_learning/linear_regression.mochi
@@ -1,0 +1,132 @@
+/*
+Linear Regression Using Gradient Descent
+---------------------------------------
+
+Given a set of training examples with one or more features and a target value,
+linear regression fits a weight vector `theta` that minimises the mean squared
+error between predicted and actual outputs.
+
+Starting from an initial weight vector of zeros, gradient descent repeatedly:
+
+1. Computes the prediction for each example using the current weights.
+2. Evaluates the gradient of the mean squared error with respect to each weight.
+3. Updates the weights in the opposite direction of the gradient scaled by the
+   learning rate `alpha`.
+
+This implementation demonstrates the algorithm on a tiny dataset with an
+intercept term.  At each iteration the current error is printed.  After
+training, the resulting weights and a sample mean absolute error calculation
+are displayed.
+
+Time complexity per iteration: O(m * n) for m samples and n features.
+*/
+
+fun dot(x: list<float>, y: list<float>): float {
+  var sum: float = 0.0
+  var i: int = 0
+  while i < len(x) {
+    sum = sum + x[i] * y[i]
+    i = i + 1
+  }
+  return sum
+}
+
+fun run_steep_gradient_descent(
+  data_x: list<list<float>>,
+  data_y: list<float>,
+  len_data: int,
+  alpha: float,
+  theta: list<float>
+): list<float> {
+  var gradients: list<float> = []
+  var j: int = 0
+  while j < len(theta) {
+    gradients = append(gradients, 0.0)
+    j = j + 1
+  }
+  var i: int = 0
+  while i < len_data {
+    let prediction = dot(theta, data_x[i])
+    let error = prediction - data_y[i]
+    var k: int = 0
+    while k < len(theta) {
+      gradients[k] = gradients[k] + error * data_x[i][k]
+      k = k + 1
+    }
+    i = i + 1
+  }
+  var t: list<float> = []
+  var g: int = 0
+  while g < len(theta) {
+    t = append(t, theta[g] - (alpha / len_data) * gradients[g])
+    g = g + 1
+  }
+  return t
+}
+
+fun sum_of_square_error(
+  data_x: list<list<float>>,
+  data_y: list<float>,
+  len_data: int,
+  theta: list<float>
+): float {
+  var total: float = 0.0
+  var i: int = 0
+  while i < len_data {
+    let prediction = dot(theta, data_x[i])
+    let diff = prediction - data_y[i]
+    total = total + diff * diff
+    i = i + 1
+  }
+  return total / (2.0 * len_data)
+}
+
+fun run_linear_regression(data_x: list<list<float>>, data_y: list<float>): list<float> {
+  let iterations: int = 10
+  let alpha: float = 0.01
+  let no_features: int = len(data_x[0])
+  let len_data: int = len(data_x)
+  var theta: list<float> = []
+  var i: int = 0
+  while i < no_features {
+    theta = append(theta, 0.0)
+    i = i + 1
+  }
+  var iter: int = 0
+  while iter < iterations {
+    theta = run_steep_gradient_descent(data_x, data_y, len_data, alpha, theta)
+    let error = sum_of_square_error(data_x, data_y, len_data, theta)
+    print("At Iteration " + str(iter + 1) + " - Error is " + str(error))
+    iter = iter + 1
+  }
+  return theta
+}
+
+fun absf(x: float): float {
+  if x < 0.0 { return -x } else { return x }
+}
+
+fun mean_absolute_error(predicted_y: list<float>, original_y: list<float>): float {
+  var total: float = 0.0
+  var i: int = 0
+  while i < len(predicted_y) {
+    let diff = absf(predicted_y[i] - original_y[i])
+    total = total + diff
+    i = i + 1
+  }
+  return total / len(predicted_y)
+}
+
+let data_x: list<list<float>> = [[1.0, 1.0], [1.0, 2.0], [1.0, 3.0]]
+let data_y: list<float> = [1.0, 2.0, 3.0]
+let theta = run_linear_regression(data_x, data_y)
+print("Resultant Feature vector :")
+var i: int = 0
+while i < len(theta) {
+  print(str(theta[i]))
+  i = i + 1
+}
+let predicted_y: list<float> = [3.0, -0.5, 2.0, 7.0]
+let original_y: list<float> = [2.5, 0.0, 2.0, 8.0]
+let mae = mean_absolute_error(predicted_y, original_y)
+print("Mean Absolute Error : " + str(mae))

--- a/tests/github/TheAlgorithms/Mochi/machine_learning/linear_regression.out
+++ b/tests/github/TheAlgorithms/Mochi/machine_learning/linear_regression.out
@@ -1,0 +1,14 @@
+At Iteration 1 - Error is 2.0827037037037037
+At Iteration 2 - Error is 1.8591027801646092
+At Iteration 3 - Error is 1.6596154397458098
+At Iteration 4 - Error is 1.4816409644214683
+At Iteration 5 - Error is 1.3228591315720422
+At Iteration 6 - Error is 1.181199961693929
+At Iteration 7 - Error is 1.054816728911467
+At Iteration 8 - Error is 0.9420618823880457
+At Iteration 9 - Error is 0.8414655646869247
+At Iteration 10 - Error is 0.7517164469927611
+Resultant Feature vector :
+0.15586072628289852
+0.3662629180621683
+Mean Absolute Error : 0.5

--- a/tests/github/TheAlgorithms/Python/machine_learning/linear_regression.py
+++ b/tests/github/TheAlgorithms/Python/machine_learning/linear_regression.py
@@ -1,0 +1,147 @@
+"""
+Linear regression is the most basic type of regression commonly used for
+predictive analysis. The idea is pretty simple: we have a dataset and we have
+features associated with it. Features should be chosen very cautiously
+as they determine how much our model will be able to make future predictions.
+We try to set the weight of these features, over many iterations, so that they best
+fit our dataset. In this particular code, I had used a CSGO dataset (ADR vs
+Rating). We try to best fit a line through dataset and estimate the parameters.
+"""
+
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "httpx",
+#     "numpy",
+# ]
+# ///
+
+import httpx
+import numpy as np
+
+
+def collect_dataset():
+    """Collect dataset of CSGO
+    The dataset contains ADR vs Rating of a Player
+    :return : dataset obtained from the link, as matrix
+    """
+    response = httpx.get(
+        "https://raw.githubusercontent.com/yashLadha/The_Math_of_Intelligence/"
+        "master/Week1/ADRvsRating.csv",
+        timeout=10,
+    )
+    lines = response.text.splitlines()
+    data = []
+    for item in lines:
+        item = item.split(",")
+        data.append(item)
+    data.pop(0)  # This is for removing the labels from the list
+    dataset = np.matrix(data)
+    return dataset
+
+
+def run_steep_gradient_descent(data_x, data_y, len_data, alpha, theta):
+    """Run steep gradient descent and updates the Feature vector accordingly_
+    :param data_x   : contains the dataset
+    :param data_y   : contains the output associated with each data-entry
+    :param len_data : length of the data_
+    :param alpha    : Learning rate of the model
+    :param theta    : Feature vector (weight's for our model)
+    ;param return    : Updated Feature's, using
+                       curr_features - alpha_ * gradient(w.r.t. feature)
+    >>> import numpy as np
+    >>> data_x = np.array([[1, 2], [3, 4]])
+    >>> data_y = np.array([5, 6])
+    >>> len_data = len(data_x)
+    >>> alpha = 0.01
+    >>> theta = np.array([0.1, 0.2])
+    >>> run_steep_gradient_descent(data_x, data_y, len_data, alpha, theta)
+    array([0.196, 0.343])
+    """
+    n = len_data
+
+    prod = np.dot(theta, data_x.transpose())
+    prod -= data_y.transpose()
+    sum_grad = np.dot(prod, data_x)
+    theta = theta - (alpha / n) * sum_grad
+    return theta
+
+
+def sum_of_square_error(data_x, data_y, len_data, theta):
+    """Return sum of square error for error calculation
+    :param data_x    : contains our dataset
+    :param data_y    : contains the output (result vector)
+    :param len_data  : len of the dataset
+    :param theta     : contains the feature vector
+    :return          : sum of square error computed from given feature's
+
+    Example:
+    >>> vc_x = np.array([[1.1], [2.1], [3.1]])
+    >>> vc_y = np.array([1.2, 2.2, 3.2])
+    >>> round(sum_of_square_error(vc_x, vc_y, 3, np.array([1])),3)
+    np.float64(0.005)
+    """
+    prod = np.dot(theta, data_x.transpose())
+    prod -= data_y.transpose()
+    sum_elem = np.sum(np.square(prod))
+    error = sum_elem / (2 * len_data)
+    return error
+
+
+def run_linear_regression(data_x, data_y):
+    """Implement Linear regression over the dataset
+    :param data_x  : contains our dataset
+    :param data_y  : contains the output (result vector)
+    :return        : feature for line of best fit (Feature vector)
+    """
+    iterations = 100000
+    alpha = 0.0001550
+
+    no_features = data_x.shape[1]
+    len_data = data_x.shape[0] - 1
+
+    theta = np.zeros((1, no_features))
+
+    for i in range(iterations):
+        theta = run_steep_gradient_descent(data_x, data_y, len_data, alpha, theta)
+        error = sum_of_square_error(data_x, data_y, len_data, theta)
+        print(f"At Iteration {i + 1} - Error is {error:.5f}")
+
+    return theta
+
+
+def mean_absolute_error(predicted_y, original_y):
+    """Return sum of square error for error calculation
+    :param predicted_y   : contains the output of prediction (result vector)
+    :param original_y    : contains values of expected outcome
+    :return          : mean absolute error computed from given feature's
+
+    >>> predicted_y = [3, -0.5, 2, 7]
+    >>> original_y = [2.5, 0.0, 2, 8]
+    >>> mean_absolute_error(predicted_y, original_y)
+    0.5
+    """
+    total = sum(abs(y - predicted_y[i]) for i, y in enumerate(original_y))
+    return total / len(original_y)
+
+
+def main():
+    """Driver function"""
+    data = collect_dataset()
+
+    len_data = data.shape[0]
+    data_x = np.c_[np.ones(len_data), data[:, :-1]].astype(float)
+    data_y = data[:, -1].astype(float)
+
+    theta = run_linear_regression(data_x, data_y)
+    len_result = theta.shape[1]
+    print("Resultant Feature vector : ")
+    for i in range(len_result):
+        print(f"{theta[0, i]:.5f}")
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    main()


### PR DESCRIPTION
## Summary
- add missing Python linear_regression example from TheAlgorithms
- implement linear_regression in Mochi using gradient descent and mean absolute error
- include generated output file from Mochi runtime

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/machine_learning/linear_regression.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6891e3a8347483209efe1dd803504079