### PR TITLE
Add self organizing map example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/machine_learning/self_organizing_map.mochi
+++ b/tests/github/TheAlgorithms/Mochi/machine_learning/self_organizing_map.mochi
@@ -1,0 +1,80 @@
+/*
+Self-Organizing Map (SOM) demonstration with two clusters.
+
+A self-organizing map is an unsupervised learning algorithm where each node has
+an associated weight vector. For each input sample the node whose weights are
+closest (by Euclidean distance) is chosen as the winner and its weights are
+moved toward the sample.
+
+This translation matches the behavior of the reference Python code. The winner
+is determined using only the first component and the update adjusts only as many
+components as there are weight vectors. Although simplified, it reproduces the
+same training dynamics as the original script.
+
+The program trains on four binary samples for three epochs and then classifies a
+test sample, printing the winning cluster and the trained weights.
+*/
+
+fun get_winner(weights: list<list<float>>, sample: list<int>): int {
+  var d0 = 0.0
+  var d1 = 0.0
+  for i in 0..len(sample) {
+    let diff0 = sample[i] - weights[0][i]
+    let diff1 = sample[i] - weights[1][i]
+    d0 = d0 + diff0 * diff0
+    d1 = d1 + diff1 * diff1
+    return if d0 > d1 { 0 } else { 1 }
+  }
+  return 0
+}
+
+fun update(weights: list<list<float>>, sample: list<int>, j: int, alpha: float): list<list<float>> {
+  for i in 0..len(weights) {
+    weights[j][i] = weights[j][i] + alpha * (sample[i] - weights[j][i])
+  }
+  return weights
+}
+
+fun list_to_string(xs: list<float>): string {
+  var s = "["
+  var i = 0
+  while i < len(xs) {
+    s = s + str(xs[i])
+    if i < len(xs) - 1 { s = s + ", " }
+    i = i + 1
+  }
+  s = s + "]"
+  return s
+}
+
+fun matrix_to_string(m: list<list<float>>): string {
+  var s = "["
+  var i = 0
+  while i < len(m) {
+    s = s + list_to_string(m[i])
+    if i < len(m) - 1 { s = s + ", " }
+    i = i + 1
+  }
+  s = s + "]"
+  return s
+}
+
+fun main() {
+  let training_samples: list<list<int>> = [[1, 1, 0, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 0, 1, 1]]
+  var weights: list<list<float>> = [[0.2, 0.6, 0.5, 0.9], [0.8, 0.4, 0.7, 0.3]]
+  let epochs = 3
+  let alpha = 0.5
+  for _ in 0..epochs {
+    for j in 0..len(training_samples) {
+      let sample = training_samples[j]
+      let winner = get_winner(weights, sample)
+      weights = update(weights, sample, winner, alpha)
+    }
+  }
+  let sample: list<int> = [0, 0, 0, 1]
+  let winner = get_winner(weights, sample)
+  print("Clusters that the test sample belongs to : " + str(winner))
+  print("Weights that have been trained : " + matrix_to_string(weights))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/machine_learning/self_organizing_map.out
+++ b/tests/github/TheAlgorithms/Mochi/machine_learning/self_organizing_map.out
@@ -1,0 +1,2 @@
+Clusters that the test sample belongs to : 0
+Weights that have been trained : [[0.6000000000000001, 0.8, 0.5, 0.9], [0.3333984375, 0.0666015625, 0.7, 0.3]]

--- a/tests/github/TheAlgorithms/Python/machine_learning/self_organizing_map.py
+++ b/tests/github/TheAlgorithms/Python/machine_learning/self_organizing_map.py
@@ -1,0 +1,73 @@
+"""
+https://en.wikipedia.org/wiki/Self-organizing_map
+"""
+
+import math
+
+
+class SelfOrganizingMap:
+    def get_winner(self, weights: list[list[float]], sample: list[int]) -> int:
+        """
+        Compute the winning vector by Euclidean distance
+
+        >>> SelfOrganizingMap().get_winner([[1, 2, 3], [4, 5, 6]], [1, 2, 3])
+        1
+        """
+        d0 = 0.0
+        d1 = 0.0
+        for i in range(len(sample)):
+            d0 += math.pow((sample[i] - weights[0][i]), 2)
+            d1 += math.pow((sample[i] - weights[1][i]), 2)
+            return 0 if d0 > d1 else 1
+        return 0
+
+    def update(
+        self, weights: list[list[int | float]], sample: list[int], j: int, alpha: float
+    ) -> list[list[int | float]]:
+        """
+        Update the winning vector.
+
+        >>> SelfOrganizingMap().update([[1, 2, 3], [4, 5, 6]], [1, 2, 3], 1, 0.1)
+        [[1, 2, 3], [3.7, 4.7, 6]]
+        """
+        for i in range(len(weights)):
+            weights[j][i] += alpha * (sample[i] - weights[j][i])
+        return weights
+
+
+# Driver code
+def main() -> None:
+    # Training Examples ( m, n )
+    training_samples = [[1, 1, 0, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 0, 1, 1]]
+
+    # weight initialization ( n, C )
+    weights = [[0.2, 0.6, 0.5, 0.9], [0.8, 0.4, 0.7, 0.3]]
+
+    # training
+    self_organizing_map = SelfOrganizingMap()
+    epochs = 3
+    alpha = 0.5
+
+    for _ in range(epochs):
+        for j in range(len(training_samples)):
+            # training sample
+            sample = training_samples[j]
+
+            # Compute the winning vector
+            winner = self_organizing_map.get_winner(weights, sample)
+
+            # Update the winning vector
+            weights = self_organizing_map.update(weights, sample, winner, alpha)
+
+    # classify test sample
+    sample = [0, 0, 0, 1]
+    winner = self_organizing_map.get_winner(weights, sample)
+
+    # results
+    print(f"Clusters that the test sample belongs to : {winner}")
+    print(f"Weights that have been trained : {weights}")
+
+
+# running the main() function
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python self-organizing map reference implementation
- port the algorithm to Mochi with helper printing utilities
- include sample run output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/machine_learning/self_organizing_map.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891e3c180e88320a2332b63008d47cd