### PR TITLE
Add Mochi implementation of gradient descent

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/machine_learning/gradient_descent.mochi
+++ b/tests/github/TheAlgorithms/Mochi/machine_learning/gradient_descent.mochi
@@ -1,0 +1,128 @@
+/*
+Gradient Descent for Linear Hypothesis Function
+-----------------------------------------------
+This program implements batch gradient descent to minimize the cost of a
+linear hypothesis function for a small training set. Each training example
+has three features and an associated output value. The hypothesis function
+includes a bias term and three feature weights.
+
+Algorithm:
+1. Start with an initial parameter vector [bias, w1, w2, w3].
+2. Repeatedly update each parameter by subtracting the learning rate times
+   the partial derivative of the cost function with respect to that parameter.
+   The derivative for the bias uses just the prediction error; derivatives
+   for the weights also multiply by the corresponding feature value.
+3. Continue until successive parameter vectors are within specified absolute
+   and relative error tolerances.
+4. After convergence, test the learned parameters on unseen data and print
+   both the true and predicted outputs.
+
+This implementation uses only Mochi standard features and no FFI.
+*/
+
+type DataPoint = { x: list<float>, y: float }
+
+fun absf(x: float): float {
+  if x < 0.0 { return -x }
+  return x
+}
+
+fun hypothesis_value(input: list<float>, params: list<float>): float {
+  var value = params[0]
+  var i = 0
+  while i < len(input) {
+    value = value + input[i] * params[i + 1]
+    i = i + 1
+  }
+  return value
+}
+
+fun calc_error(dp: DataPoint, params: list<float>): float {
+  return hypothesis_value(dp.x, params) - dp.y
+}
+
+fun summation_of_cost_derivative(index: int, params: list<float>, data: list<DataPoint>): float {
+  var sum = 0.0
+  var i = 0
+  while i < len(data) {
+    let dp = data[i]
+    let e = calc_error(dp, params)
+    if index == (-1) {
+      sum = sum + e
+    } else {
+      sum = sum + e * dp.x[index]
+    }
+    i = i + 1
+  }
+  return sum
+}
+
+fun get_cost_derivative(index: int, params: list<float>, data: list<DataPoint>): float {
+  return summation_of_cost_derivative(index, params, data) / (len(data) as float)
+}
+
+fun allclose(a: list<float>, b: list<float>, atol: float, rtol: float): bool {
+  var i = 0
+  while i < len(a) {
+    let diff = absf(a[i] - b[i])
+    let limit = atol + rtol * absf(b[i])
+    if diff > limit {
+      return false
+    }
+    i = i + 1
+  }
+  return true
+}
+
+fun run_gradient_descent(train_data: list<DataPoint>, initial_params: list<float>): list<float> {
+  let learning_rate = 0.009
+  let absolute_error_limit = 0.000002
+  let relative_error_limit = 0.0
+  var j = 0
+  var params = initial_params
+  while true {
+    j = j + 1
+    var temp: list<float> = []
+    var i = 0
+    while i < len(params) {
+      let deriv = get_cost_derivative(i - 1, params, train_data)
+      temp = append(temp, params[i] - learning_rate * deriv)
+      i = i + 1
+    }
+    if allclose(params, temp, absolute_error_limit, relative_error_limit) {
+      print("Number of iterations:" + str(j))
+      break
+    }
+    params = temp
+  }
+  return params
+}
+
+fun test_gradient_descent(test_data: list<DataPoint>, params: list<float>) {
+  var i = 0
+  while i < len(test_data) {
+    let dp = test_data[i]
+    print("Actual output value:" + str(dp.y))
+    print("Hypothesis output:" + str(hypothesis_value(dp.x, params)))
+    i = i + 1
+  }
+}
+
+let train_data: list<DataPoint> = [
+  DataPoint{ x: [5.0, 2.0, 3.0], y: 15.0 },
+  DataPoint{ x: [6.0, 5.0, 9.0], y: 25.0 },
+  DataPoint{ x: [11.0, 12.0, 13.0], y: 41.0 },
+  DataPoint{ x: [1.0, 1.0, 1.0], y: 8.0 },
+  DataPoint{ x: [11.0, 12.0, 13.0], y: 41.0 },
+]
+
+let test_data: list<DataPoint> = [
+  DataPoint{ x: [515.0, 22.0, 13.0], y: 555.0 },
+  DataPoint{ x: [61.0, 35.0, 49.0], y: 150.0 },
+]
+
+var parameter_vector: list<float> = [2.0, 4.0, 1.0, 5.0]
+
+parameter_vector = run_gradient_descent(train_data, parameter_vector)
+print("\nTesting gradient descent for a linear hypothesis function.\n")
+test_gradient_descent(test_data, parameter_vector)

--- a/tests/github/TheAlgorithms/Mochi/machine_learning/gradient_descent.mochi.out
+++ b/tests/github/TheAlgorithms/Mochi/machine_learning/gradient_descent.mochi.out
@@ -1,0 +1,8 @@
+Number of iterations:5993
+
+Testing gradient descent for a linear hypothesis function.
+
+Actual output value:555
+Hypothesis output:555.2244946726339
+Actual output value:150
+Hypothesis output:150.01694829900703

--- a/tests/github/TheAlgorithms/Python/machine_learning/gradient_descent.py
+++ b/tests/github/TheAlgorithms/Python/machine_learning/gradient_descent.py
@@ -1,0 +1,139 @@
+"""
+Implementation of gradient descent algorithm for minimizing cost of a linear hypothesis
+function.
+"""
+
+import numpy as np
+
+# List of input, output pairs
+train_data = (
+    ((5, 2, 3), 15),
+    ((6, 5, 9), 25),
+    ((11, 12, 13), 41),
+    ((1, 1, 1), 8),
+    ((11, 12, 13), 41),
+)
+test_data = (((515, 22, 13), 555), ((61, 35, 49), 150))
+parameter_vector = [2, 4, 1, 5]
+m = len(train_data)
+LEARNING_RATE = 0.009
+
+
+def _error(example_no, data_set="train"):
+    """
+    :param data_set: train data or test data
+    :param example_no: example number whose error has to be checked
+    :return: error in example pointed by example number.
+    """
+    return calculate_hypothesis_value(example_no, data_set) - output(
+        example_no, data_set
+    )
+
+
+def _hypothesis_value(data_input_tuple):
+    """
+    Calculates hypothesis function value for a given input
+    :param data_input_tuple: Input tuple of a particular example
+    :return: Value of hypothesis function at that point.
+    Note that there is an 'biased input' whose value is fixed as 1.
+    It is not explicitly mentioned in input data.. But, ML hypothesis functions use it.
+    So, we have to take care of it separately. Line 36 takes care of it.
+    """
+    hyp_val = 0
+    for i in range(len(parameter_vector) - 1):
+        hyp_val += data_input_tuple[i] * parameter_vector[i + 1]
+    hyp_val += parameter_vector[0]
+    return hyp_val
+
+
+def output(example_no, data_set):
+    """
+    :param data_set: test data or train data
+    :param example_no: example whose output is to be fetched
+    :return: output for that example
+    """
+    if data_set == "train":
+        return train_data[example_no][1]
+    elif data_set == "test":
+        return test_data[example_no][1]
+    return None
+
+
+def calculate_hypothesis_value(example_no, data_set):
+    """
+    Calculates hypothesis value for a given example
+    :param data_set: test data or train_data
+    :param example_no: example whose hypothesis value is to be calculated
+    :return: hypothesis value for that example
+    """
+    if data_set == "train":
+        return _hypothesis_value(train_data[example_no][0])
+    elif data_set == "test":
+        return _hypothesis_value(test_data[example_no][0])
+    return None
+
+
+def summation_of_cost_derivative(index, end=m):
+    """
+    Calculates the sum of cost function derivative
+    :param index: index wrt derivative is being calculated
+    :param end: value where summation ends, default is m, number of examples
+    :return: Returns the summation of cost derivative
+    Note: If index is -1, this means we are calculating summation wrt to biased
+        parameter.
+    """
+    summation_value = 0
+    for i in range(end):
+        if index == -1:
+            summation_value += _error(i)
+        else:
+            summation_value += _error(i) * train_data[i][0][index]
+    return summation_value
+
+
+def get_cost_derivative(index):
+    """
+    :param index: index of the parameter vector wrt to derivative is to be calculated
+    :return: derivative wrt to that index
+    Note: If index is -1, this means we are calculating summation wrt to biased
+        parameter.
+    """
+    cost_derivative_value = summation_of_cost_derivative(index, m) / m
+    return cost_derivative_value
+
+
+def run_gradient_descent():
+    global parameter_vector
+    # Tune these values to set a tolerance value for predicted output
+    absolute_error_limit = 0.000002
+    relative_error_limit = 0
+    j = 0
+    while True:
+        j += 1
+        temp_parameter_vector = [0, 0, 0, 0]
+        for i in range(len(parameter_vector)):
+            cost_derivative = get_cost_derivative(i - 1)
+            temp_parameter_vector[i] = (
+                parameter_vector[i] - LEARNING_RATE * cost_derivative
+            )
+        if np.allclose(
+            parameter_vector,
+            temp_parameter_vector,
+            atol=absolute_error_limit,
+            rtol=relative_error_limit,
+        ):
+            break
+        parameter_vector = temp_parameter_vector
+    print(("Number of iterations:", j))
+
+
+def test_gradient_descent():
+    for i in range(len(test_data)):
+        print(("Actual output value:", output(i, "test")))
+        print(("Hypothesis output:", calculate_hypothesis_value(i, "test")))
+
+
+if __name__ == "__main__":
+    run_gradient_descent()
+    print("\nTesting gradient descent for a linear hypothesis function.\n")
+    test_gradient_descent()


### PR DESCRIPTION
## Summary
- add Python reference implementation for gradient descent
- implement equivalent Mochi version with convergence check and test routine
- include VM execution output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/machine_learning/gradient_descent.mochi`
- `python tests/github/TheAlgorithms/Python/machine_learning/gradient_descent.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6891e3a154288320a8cafaad6ebdac39