### PR TITLE
feat: add xgboost regressor example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/machine_learning/xgboost_regressor.mochi
+++ b/tests/github/TheAlgorithms/Mochi/machine_learning/xgboost_regressor.mochi
@@ -1,0 +1,163 @@
+/*
+Gradient boosting builds an ensemble of weak regression trees by iteratively
+fitting each tree to the residuals of previous predictions.  This simplified
+version uses decision stumps (depth-1 trees) on a single feature.
+
+Algorithm steps for each boosting round:
+1. Compute residuals between targets and current predictions.
+2. Split data at the mean of the first feature.
+3. Compute average residual on each side of the split.
+4. Update predictions by adding the averaged residuals scaled by a
+   learning rate.
+5. Store threshold and leaf values for later predictions.
+
+Time complexity is O(n_estimators * n_samples).
+*/
+
+type Dataset {
+  data: list<list<float>>
+  target: list<float>
+}
+
+type Tree {
+  threshold: float
+  left_value: float
+  right_value: float
+}
+
+fun data_handling(dataset: Dataset): Dataset {
+  return dataset
+}
+
+fun xgboost(
+  features: list<list<float>>, target: list<float>, test_features: list<list<float>>
+): list<float> {
+  let learning_rate = 0.5
+  let n_estimators = 3
+  var trees: list<Tree> = []
+
+  var predictions: list<float> = []
+  var i = 0
+  while i < len(target) {
+    predictions = append(predictions, 0.0)
+    i = i + 1
+  }
+
+  var est = 0
+  while est < n_estimators {
+    // compute residuals
+    var residuals: list<float> = []
+    var j = 0
+    while j < len(target) {
+      residuals = append(residuals, target[j] - predictions[j])
+      j = j + 1
+    }
+    // threshold as mean of first feature
+    var sum_feat = 0.0
+    j = 0
+    while j < len(features) {
+      sum_feat = sum_feat + features[j][0]
+      j = j + 1
+    }
+    let threshold = sum_feat / (len(features) as float)
+    // compute leaf values
+    var left_sum = 0.0
+    var left_count = 0
+    var right_sum = 0.0
+    var right_count = 0
+    j = 0
+    while j < len(features) {
+      if features[j][0] <= threshold {
+        left_sum = left_sum + residuals[j]
+        left_count = left_count + 1
+      } else {
+        right_sum = right_sum + residuals[j]
+        right_count = right_count + 1
+      }
+      j = j + 1
+    }
+    var left_value = 0.0
+    if left_count > 0 {
+      left_value = left_sum / (left_count as float)
+    }
+    var right_value = 0.0
+    if right_count > 0 {
+      right_value = right_sum / (right_count as float)
+    }
+    // update predictions
+    j = 0
+    while j < len(features) {
+      if features[j][0] <= threshold {
+        predictions[j] = predictions[j] + learning_rate * left_value
+      } else {
+        predictions[j] = predictions[j] + learning_rate * right_value
+      }
+      j = j + 1
+    }
+    trees = append(trees, Tree { threshold: threshold, left_value: left_value, right_value: right_value })
+    est = est + 1
+  }
+
+  // predict for test features
+  var preds: list<float> = []
+  var t = 0
+  while t < len(test_features) {
+    var pred = 0.0
+    var k = 0
+    while k < len(trees) {
+      if test_features[t][0] <= trees[k].threshold {
+        pred = pred + learning_rate * trees[k].left_value
+      } else {
+        pred = pred + learning_rate * trees[k].right_value
+      }
+      k = k + 1
+    }
+    preds = append(preds, pred)
+    t = t + 1
+  }
+  return preds
+}
+
+fun mean_absolute_error(y_true: list<float>, y_pred: list<float>): float {
+  var sum = 0.0
+  var i = 0
+  while i < len(y_true) {
+    var diff = y_true[i] - y_pred[i]
+    if diff < 0.0 { diff = -diff }
+    sum = sum + diff
+    i = i + 1
+  }
+  return sum / (len(y_true) as float)
+}
+
+fun mean_squared_error(y_true: list<float>, y_pred: list<float>): float {
+  var sum = 0.0
+  var i = 0
+  while i < len(y_true) {
+    let diff = y_true[i] - y_pred[i]
+    sum = sum + diff * diff
+    i = i + 1
+  }
+  return sum / (len(y_true) as float)
+}
+
+fun main(): void {
+  let california = Dataset {
+    data: [[1.0], [2.0], [3.0], [4.0]],
+    target: [2.0, 3.0, 4.0, 5.0]
+  }
+  let ds = data_handling(california)
+  let x_train = ds.data
+  let y_train = ds.target
+  let x_test = [[1.5], [3.5]]
+  let y_test = [2.5, 4.5]
+  let predictions = xgboost(x_train, y_train, x_test)
+  print("Predictions:")
+  print(predictions)
+  print("Mean Absolute Error:")
+  print(mean_absolute_error(y_test, predictions))
+  print("Mean Square Error:")
+  print(mean_squared_error(y_test, predictions))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/machine_learning/xgboost_regressor.out
+++ b/tests/github/TheAlgorithms/Mochi/machine_learning/xgboost_regressor.out
@@ -1,0 +1,6 @@
+Predictions:
+[0.0, 0.0]
+Mean Absolute Error:
+3.5
+Mean Square Error:
+13.25

--- a/tests/github/TheAlgorithms/Python/machine_learning/xgboost_regressor.py
+++ b/tests/github/TheAlgorithms/Python/machine_learning/xgboost_regressor.py
@@ -1,0 +1,66 @@
+# XGBoost Regressor Example
+import numpy as np
+from sklearn.datasets import fetch_california_housing
+from sklearn.metrics import mean_absolute_error, mean_squared_error
+from sklearn.model_selection import train_test_split
+from xgboost import XGBRegressor
+
+
+def data_handling(data: dict) -> tuple:
+    # Split dataset into features and target.  Data is features.
+    """
+    >>> data_handling((
+    ...  {'data':'[ 8.3252 41. 6.9841269 1.02380952  322. 2.55555556   37.88 -122.23 ]',
+    ...  'target':([4.526])}))
+    ('[ 8.3252 41. 6.9841269 1.02380952  322. 2.55555556   37.88 -122.23 ]', [4.526])
+    """
+    return (data["data"], data["target"])
+
+
+def xgboost(
+    features: np.ndarray, target: np.ndarray, test_features: np.ndarray
+) -> np.ndarray:
+    """
+    >>> xgboost(np.array([[ 2.3571 ,   52. , 6.00813008, 1.06775068,
+    ...    907. , 2.45799458,   40.58 , -124.26]]),np.array([1.114]),
+    ... np.array([[1.97840000e+00,  3.70000000e+01,  4.98858447e+00,  1.03881279e+00,
+    ...    1.14300000e+03,  2.60958904e+00,  3.67800000e+01, -1.19780000e+02]]))
+    array([[1.1139996]], dtype=float32)
+    """
+    xgb = XGBRegressor(
+        verbosity=0, random_state=42, tree_method="exact", base_score=0.5
+    )
+    xgb.fit(features, target)
+    # Predict target for test data
+    predictions = xgb.predict(test_features)
+    predictions = predictions.reshape(len(predictions), 1)
+    return predictions
+
+
+def main() -> None:
+    """
+    The URL for this algorithm
+    https://xgboost.readthedocs.io/en/stable/
+    California house price dataset is used to demonstrate the algorithm.
+
+    Expected error values:
+    Mean Absolute Error: 0.30957163379906033
+    Mean Square Error: 0.22611560196662744
+    """
+    # Load California house price dataset
+    california = fetch_california_housing()
+    data, target = data_handling(california)
+    x_train, x_test, y_train, y_test = train_test_split(
+        data, target, test_size=0.25, random_state=1
+    )
+    predictions = xgboost(x_train, y_train, x_test)
+    # Error printing
+    print(f"Mean Absolute Error: {mean_absolute_error(y_test, predictions)}")
+    print(f"Mean Square Error: {mean_squared_error(y_test, predictions)}")
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod(verbose=True)
+    main()


### PR DESCRIPTION
## Summary
- add TheAlgorithms Python xgboost regressor example
- translate to Mochi with a basic gradient boosting regressor and runtime output

## Testing
- `go test ./...`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/machine_learning/xgboost_regressor.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6891e6103d7883209829ff86a8026556