### PR TITLE
Add Mochi implementation for area under curve

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/maths/area_under_curve.mochi
+++ b/tests/github/TheAlgorithms/Mochi/maths/area_under_curve.mochi
@@ -1,0 +1,44 @@
+/*
+Approximates the area under a curve using the trapezoidal rule.
+Given a function f(x), starting point x_start, ending point x_end,
+and the number of segments (steps), it partitions the interval
+[x_start, x_end] into equal widths. For each adjacent pair of points,
+the algorithm treats the curve segment as a trapezoid with area
+(f(x_i) + f(x_{i+1})) * h / 2 where h is the segment width.
+Summing these trapezoids approximates the definite integral of f(x).
+This implementation mirrors the Python version from TheAlgorithms.
+*/
+
+fun abs_float(x: float): float {
+  if x < 0.0 { return -x } else { return x }
+}
+
+fun trapezoidal_area(f: fun(float): float, x_start: float, x_end: float, steps: int): float {
+  let step: float = (x_end - x_start) / (steps as float)
+  var x1: float = x_start
+  var fx1: float = f(x_start)
+  var area: float = 0.0
+  var i: int = 0
+  while i < steps {
+    let x2: float = x1 + step
+    let fx2: float = f(x2)
+    area = area + abs_float(fx2 + fx1) * step / 2.0
+    x1 = x2
+    fx1 = fx2
+    i = i + 1
+  }
+  return area
+}
+
+fun f(x: float): float {
+  return x * x * x + x * x
+}
+
+print("f(x) = x^3 + x^2")
+print("The area between the curve, x = -5, x = 5 and the x axis is:")
+var i: int = 10
+while i <= 100000 {
+  let result: float = trapezoidal_area(f, -5.0, 5.0, i)
+  print("with " + str(i) + " steps: " + str(result))
+  i = i * 10
+}

--- a/tests/github/TheAlgorithms/Mochi/maths/area_under_curve.out
+++ b/tests/github/TheAlgorithms/Mochi/maths/area_under_curve.out
@@ -1,0 +1,7 @@
+f(x) = x^3 + x^2
+The area between the curve, x = -5, x = 5 and the x axis is:
+with 10 steps: 325
+with 100 steps: 312.7900000000002
+with 1000 steps: 312.6678999999877
+with 10000 steps: 312.666678999954
+with 100000 steps: 312.666666790683

--- a/tests/github/TheAlgorithms/Python/maths/area_under_curve.py
+++ b/tests/github/TheAlgorithms/Python/maths/area_under_curve.py
@@ -1,0 +1,61 @@
+"""
+Approximates the area under the curve using the trapezoidal rule
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+
+def trapezoidal_area(
+    fnc: Callable[[float], float],
+    x_start: float,
+    x_end: float,
+    steps: int = 100,
+) -> float:
+    """
+    Treats curve as a collection of linear lines and sums the area of the
+    trapezium shape they form
+    :param fnc: a function which defines a curve
+    :param x_start: left end point to indicate the start of line segment
+    :param x_end: right end point to indicate end of line segment
+    :param steps: an accuracy gauge; more steps increases the accuracy
+    :return: a float representing the length of the curve
+
+    >>> def f(x):
+    ...    return 5
+    >>> f"{trapezoidal_area(f, 12.0, 14.0, 1000):.3f}"
+    '10.000'
+    >>> def f(x):
+    ...    return 9*x**2
+    >>> f"{trapezoidal_area(f, -4.0, 0, 10000):.4f}"
+    '192.0000'
+    >>> f"{trapezoidal_area(f, -4.0, 4.0, 10000):.4f}"
+    '384.0000'
+    """
+    x1 = x_start
+    fx1 = fnc(x_start)
+    area = 0.0
+    for _ in range(steps):
+        # Approximates small segments of curve as linear and solve
+        # for trapezoidal area
+        x2 = (x_end - x_start) / steps + x1
+        fx2 = fnc(x2)
+        area += abs(fx2 + fx1) * (x2 - x1) / 2
+        # Increment step
+        x1 = x2
+        fx1 = fx2
+    return area
+
+
+if __name__ == "__main__":
+
+    def f(x):
+        return x**3 + x**2
+
+    print("f(x) = x^3 + x^2")
+    print("The area between the curve, x = -5, x = 5 and the x axis is:")
+    i = 10
+    while i <= 100000:
+        print(f"with {i} steps: {trapezoidal_area(f, -5, 5, i)}")
+        i *= 10


### PR DESCRIPTION
## Summary
- add missing Python reference implementation of trapezoidal area under curve
- implement equivalent Mochi version with detailed comments
- include runtime output showing area approximation for a sample polynomial

## Testing
- `./bin/mochi run tests/github/TheAlgorithms/Mochi/maths/area_under_curve.mochi`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6891e61de1ec8320a9bcb76be8c5a184