### PR TITLE
Add binomial distribution algorithm in Mochi tests

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/maths/binomial_distribution.mochi
+++ b/tests/github/TheAlgorithms/Mochi/maths/binomial_distribution.mochi
@@ -1,0 +1,68 @@
+/*
+Binomial Distribution Probability
+---------------------------------
+This module computes the probability of observing a given number of
+successes in a fixed number of independent Bernoulli trials.  For `trials`
+(n) trials each with success probability `prob` (p), the probability of
+exactly `successes` (k) successes is:
+
+    P(X = k) = C(n, k) * p^k * (1 - p)^(n - k)
+
+where C(n, k) = n! / (k!(n-k)!) is the binomial coefficient.  This
+implementation validates its inputs, computes factorials iteratively and
+performs exponentiation by repeated multiplication.  The overall time
+complexity is O(n) for the factorial and exponent computations.
+*/
+
+fun abs(x: float): float {
+  if x < 0.0 { return -x }
+  return x
+}
+
+fun factorial(n: int): int {
+  if n < 0 { panic("factorial is undefined for negative numbers") }
+  var result = 1
+  var i = 2
+  while i <= n {
+    result = result * i
+    i = i + 1
+  }
+  return result
+}
+
+fun pow_float(base: float, exp: int): float {
+  var result = 1.0
+  var i = 0
+  while i < exp {
+    result = result * base
+    i = i + 1
+  }
+  return result
+}
+
+fun binomial_distribution(successes: int, trials: int, prob: float): float {
+  if successes > trials {
+    panic("successes must be lower or equal to trials")
+  }
+  if trials < 0 || successes < 0 {
+    panic("the function is defined for non-negative integers")
+  }
+  if !(0.0 < prob && prob < 1.0) {
+    panic("prob has to be in range of 1 - 0")
+  }
+  let probability = pow_float(prob, successes) * pow_float(1.0 - prob, trials - successes)
+  let numerator = factorial(trials) as float
+  let denominator = (factorial(successes) * factorial(trials - successes)) as float
+  let coefficient = numerator / denominator
+  return probability * coefficient
+}
+
+test "example1" {
+  let result = binomial_distribution(3, 5, 0.7)
+  expect abs(result - 0.3087) < 0.0000001
+}
+
+test "example2" {
+  let result = binomial_distribution(2, 4, 0.5)
+  expect abs(result - 0.375) < 0.0000001
+}

--- a/tests/github/TheAlgorithms/Mochi/maths/binomial_distribution.mochi.out
+++ b/tests/github/TheAlgorithms/Mochi/maths/binomial_distribution.mochi.out
@@ -1,0 +1,3 @@
+[94;1mtests/github/TheAlgorithms/Mochi/maths/binomial_distribution.mochi[0;22m
+   [33mtest[0m example1                       ... [32mok[0m (1.0ms)
+   [33mtest[0m example2                       ... [32mok[0m (1.0ms)

--- a/tests/github/TheAlgorithms/Python/maths/binomial_distribution.py
+++ b/tests/github/TheAlgorithms/Python/maths/binomial_distribution.py
@@ -1,0 +1,41 @@
+"""For more information about the Binomial Distribution -
+https://en.wikipedia.org/wiki/Binomial_distribution"""
+
+from math import factorial
+
+
+def binomial_distribution(successes: int, trials: int, prob: float) -> float:
+    """
+    Return probability of k successes out of n tries, with p probability for one
+    success
+
+    The function uses the factorial function in order to calculate the binomial
+    coefficient
+
+    >>> binomial_distribution(3, 5, 0.7)
+    0.30870000000000003
+    >>> binomial_distribution (2, 4, 0.5)
+    0.375
+    """
+    if successes > trials:
+        raise ValueError("""successes must be lower or equal to trials""")
+    if trials < 0 or successes < 0:
+        raise ValueError("the function is defined for non-negative integers")
+    if not isinstance(successes, int) or not isinstance(trials, int):
+        raise ValueError("the function is defined for non-negative integers")
+    if not 0 < prob < 1:
+        raise ValueError("prob has to be in range of 1 - 0")
+    probability = (prob**successes) * ((1 - prob) ** (trials - successes))
+    # Calculate the binomial coefficient: n! / k!(n-k)!
+    coefficient = float(factorial(trials))
+    coefficient /= factorial(successes) * factorial(trials - successes)
+    return probability * coefficient
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()
+    print("Probability of 2 successes out of 4 trails")
+    print("with probability of 0.75 is:", end=" ")
+    print(binomial_distribution(2, 4, 0.75))


### PR DESCRIPTION
## Summary
- add Python reference for binomial distribution
- implement binomial distribution probability in pure Mochi with factorial and exponent helpers
- add tests verifying sample outcomes

## Testing
- `CGO_ENABLED=0 go run ./cmd/mochi test tests/github/TheAlgorithms/Mochi/maths/binomial_distribution.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891ea2bffd883208e4735233d57035a