### PR TITLE
Add polygon validity check

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/maths/check_polygon.mochi
+++ b/tests/github/TheAlgorithms/Mochi/maths/check_polygon.mochi
@@ -1,0 +1,48 @@
+/*
+Determine whether a polygon can be formed from given side lengths.
+
+For a set of side lengths in Euclidean space, a polygon exists only if
+no single side is longer than the sum of the remaining sides. This
+function preserves the input order while verifying the following:
+  1. At least two side lengths are provided; monogons and digons are
+     not valid polygons.
+  2. All side lengths are positive numbers.
+  3. Compute the total perimeter and the longest side. A polygon is
+     valid when the longest side is strictly less than the sum of the
+     others.
+
+The procedure runs in O(n) time with O(1) extra space and does not
+mutate the original list of side lengths.
+*/
+
+fun check_polygon(nums: list<float>): bool {
+  if len(nums) < 2 {
+    error("Monogons and Digons are not polygons in the Euclidean space")
+  }
+  var i = 0
+  while i < len(nums) {
+    if nums[i] <= 0.0 {
+      error("All values must be greater than 0")
+    }
+    i = i + 1
+  }
+  var total = 0.0
+  var max_side = 0.0
+  i = 0
+  while i < len(nums) {
+    let v = nums[i]
+    total = total + v
+    if v > max_side {
+      max_side = v
+    }
+    i = i + 1
+  }
+  return max_side < (total - max_side)
+}
+
+print(str(check_polygon([6.0, 10.0, 5.0])))
+print(str(check_polygon([3.0, 7.0, 13.0, 2.0])))
+print(str(check_polygon([1.0, 4.3, 5.2, 12.2])))
+var nums: list<float> = [3.0, 7.0, 13.0, 2.0]
+let _ = check_polygon(nums)
+print(str(nums))

--- a/tests/github/TheAlgorithms/Mochi/maths/check_polygon.out
+++ b/tests/github/TheAlgorithms/Mochi/maths/check_polygon.out
@@ -1,0 +1,4 @@
+true
+false
+false
+[3 7 13 2]

--- a/tests/github/TheAlgorithms/Python/maths/check_polygon.py
+++ b/tests/github/TheAlgorithms/Python/maths/check_polygon.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+
+def check_polygon(nums: list[float]) -> bool:
+    """
+    Takes list of possible side lengths and determines whether a
+    two-dimensional polygon with such side lengths can exist.
+
+    Returns a boolean value for the < comparison
+    of the largest side length with sum of the rest.
+    Wiki: https://en.wikipedia.org/wiki/Triangle_inequality
+
+    >>> check_polygon([6, 10, 5])
+    True
+    >>> check_polygon([3, 7, 13, 2])
+    False
+    >>> check_polygon([1, 4.3, 5.2, 12.2])
+    False
+    >>> nums = [3, 7, 13, 2]
+    >>> _ = check_polygon(nums) #   Run function, do not show answer in output
+    >>> nums #  Check numbers are not reordered
+    [3, 7, 13, 2]
+    >>> check_polygon([])
+    Traceback (most recent call last):
+        ...
+    ValueError: Monogons and Digons are not polygons in the Euclidean space
+    >>> check_polygon([-2, 5, 6])
+    Traceback (most recent call last):
+        ...
+    ValueError: All values must be greater than 0
+    """
+    if len(nums) < 2:
+        raise ValueError("Monogons and Digons are not polygons in the Euclidean space")
+    if any(i <= 0 for i in nums):
+        raise ValueError("All values must be greater than 0")
+    copy_nums = nums.copy()
+    copy_nums.sort()
+    return copy_nums[-1] < sum(copy_nums[:-1])
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python algorithm for polygon inequality check
- implement Mochi version that validates side lengths and ensures longest side is shorter than the sum of the others
- record runtime output for the Mochi implementation

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/maths/check_polygon.mochi`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891ea2f6eb08320bb27e43724265d14