### PR TITLE
Add Chudnovsky algorithm and Mochi implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/maths/chudnovsky_algorithm.mochi
+++ b/tests/github/TheAlgorithms/Mochi/maths/chudnovsky_algorithm.mochi
@@ -1,0 +1,71 @@
+/*
+Chudnovsky algorithm to compute digits of Pi.
+
+This method expresses Pi via a rapidly converging series based on
+Ramanujan's formulas:
+
+  Pi = 426880 * sqrt(10005) / S
+  S  = sum_{k=0}^{n-1} ( (6k)! * (13591409 + 545140134k) ) /
+       ( (3k)! * (k!)^3 * (-262537412640768000)^k )
+
+Each iteration adds roughly 14 correct digits of Pi.  Factorials and
+large powers grow quickly so this implementation uses floating point
+arithmetic which suffices for moderate precision.
+
+Steps per iteration k:
+1. multinomial = (6k)! / ((3k)! * (k!)^3)
+2. linear     += 545140134
+3. exponential *= -262537412640768000
+4. partial_sum += multinomial * linear / exponential
+
+The function pi(n) computes Pi using ceil(n / 14) iterations.  It
+panics for non-positive n.  A simple Newton method provides square root
+without relying on external libraries.
+*/
+
+fun sqrtApprox(x: float): float {
+  if x <= 0.0 { return 0.0 }
+  var guess = x
+  var i = 0
+  while i < 20 {
+    guess = (guess + x / guess) / 2.0
+    i = i + 1
+  }
+  return guess
+}
+
+fun factorial_float(n: int): float {
+  var result = 1.0
+  var i = 2
+  while i <= n {
+    result = result * (i as float)
+    i = i + 1
+  }
+  return result
+}
+
+fun pi(n: int): float {
+  if n < 1 { panic("Undefined for non-natural numbers") }
+  let iterations = (n + 13) / 14
+  let constant_term = 426880.0 * sqrtApprox(10005.0)
+  var exponential_term = 1.0
+  var linear_term = 13591409.0
+  var partial_sum = linear_term
+  var k = 1
+  while k < iterations {
+    let k6 = 6 * k
+    let k3 = 3 * k
+    let fact6k = factorial_float(k6)
+    let fact3k = factorial_float(k3)
+    let factk = factorial_float(k)
+    let multinomial = fact6k / (fact3k * factk * factk * factk)
+    linear_term = linear_term + 545140134.0
+    exponential_term = exponential_term * (-262537412640768000.0)
+    partial_sum = partial_sum + multinomial * linear_term / exponential_term
+    k = k + 1
+  }
+  return constant_term / partial_sum
+}
+
+let n = 50
+print("The first " + str(n) + " digits of pi is: " + str(pi(n)))

--- a/tests/github/TheAlgorithms/Mochi/maths/chudnovsky_algorithm.out
+++ b/tests/github/TheAlgorithms/Mochi/maths/chudnovsky_algorithm.out
@@ -1,0 +1,1 @@
+The first 50 digits of pi is: 3.141592653589793

--- a/tests/github/TheAlgorithms/Python/maths/chudnovsky_algorithm.py
+++ b/tests/github/TheAlgorithms/Python/maths/chudnovsky_algorithm.py
@@ -1,0 +1,60 @@
+from decimal import Decimal, getcontext
+from math import ceil, factorial
+
+
+def pi(precision: int) -> str:
+    """
+    The Chudnovsky algorithm is a fast method for calculating the digits of PI,
+    based on Ramanujan's PI formulae.
+
+    https://en.wikipedia.org/wiki/Chudnovsky_algorithm
+
+    PI = constant_term / ((multinomial_term * linear_term) / exponential_term)
+        where constant_term = 426880 * sqrt(10005)
+
+    The linear_term and the exponential_term can be defined iteratively as follows:
+        L_k+1 = L_k + 545140134            where L_0 = 13591409
+        X_k+1 = X_k * -262537412640768000  where X_0 = 1
+
+    The multinomial_term is defined as follows:
+        6k! / ((3k)! * (k!) ^ 3)
+            where k is the k_th iteration.
+
+    This algorithm correctly calculates around 14 digits of PI per iteration
+
+    >>> pi(10)
+    '3.14159265'
+    >>> pi(100)
+    '3.14159265358979323846264338327950288419716939937510582097494459230781640628620899862803482534211706'
+    >>> pi('hello')
+    Traceback (most recent call last):
+        ...
+    TypeError: Undefined for non-integers
+    >>> pi(-1)
+    Traceback (most recent call last):
+        ...
+    ValueError: Undefined for non-natural numbers
+    """
+
+    if not isinstance(precision, int):
+        raise TypeError("Undefined for non-integers")
+    elif precision < 1:
+        raise ValueError("Undefined for non-natural numbers")
+
+    getcontext().prec = precision
+    num_iterations = ceil(precision / 14)
+    constant_term = 426880 * Decimal(10005).sqrt()
+    exponential_term = 1
+    linear_term = 13591409
+    partial_sum = Decimal(linear_term)
+    for k in range(1, num_iterations):
+        multinomial_term = factorial(6 * k) // (factorial(3 * k) * factorial(k) ** 3)
+        linear_term += 545140134
+        exponential_term *= -262537412640768000
+        partial_sum += Decimal(multinomial_term * linear_term) / exponential_term
+    return str(constant_term / partial_sum)[:-1]
+
+
+if __name__ == "__main__":
+    n = 50
+    print(f"The first {n} digits of pi is: {pi(n)}")


### PR DESCRIPTION
## Summary
- add missing Python source for Chudnovsky algorithm
- implement Chudnovsky series for pi in pure Mochi
- include generated output from running the Mochi program

## Testing
- `./bin/mochi run tests/github/TheAlgorithms/Mochi/maths/chudnovsky_algorithm.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891ea32274c832080feac0afdb80041