### PR TITLE
Add continued fraction algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/maths/continued_fraction.mochi
+++ b/tests/github/TheAlgorithms/Mochi/maths/continued_fraction.mochi
@@ -1,0 +1,50 @@
+/*
+Compute the continued fraction expansion of a rational number.
+
+Given an initial numerator and denominator, the algorithm repeatedly takes the
+floor of their ratio to obtain successive integer terms. After each step the
+numerator is reduced by the integer part times the denominator and the roles of
+numerator and denominator are swapped. This is effectively the Euclidean
+algorithm and terminates when the remainder becomes zero.
+
+The resulting list of integers represents the continued fraction coefficients.
+Time complexity is O(k) where k is the length of this list.
+*/
+
+fun floor_div(a: int, b: int): int {
+  var q = a / b
+  let r = a % b
+  if r != 0 && ((a < 0 && b > 0) || (a > 0 && b < 0)) {
+    q = q - 1
+  }
+  return q
+}
+
+fun continued_fraction(numerator: int, denominator: int): list<int> {
+  var num = numerator
+  var den = denominator
+  var result: list<int> = []
+  while true {
+    let integer_part = floor_div(num, den)
+    result = append(result, integer_part)
+    num = num - integer_part * den
+    if num == 0 { break }
+    let tmp = num
+    num = den
+    den = tmp
+  }
+  return result
+}
+
+fun list_to_string(lst: list<int>): string {
+  var s = "["
+  var i = 0
+  while i < len(lst) {
+    s = s + str(lst[i])
+    if i < len(lst) - 1 { s = s + ", " }
+    i = i + 1
+  }
+  return s + "]"
+}
+
+print("Continued Fraction of 0.84375 is: " + list_to_string(continued_fraction(27, 32)))

--- a/tests/github/TheAlgorithms/Mochi/maths/continued_fraction.out
+++ b/tests/github/TheAlgorithms/Mochi/maths/continued_fraction.out
@@ -1,0 +1,1 @@
+Continued Fraction of 0.84375 is: [0, 1, 5, 2, 2]

--- a/tests/github/TheAlgorithms/Python/maths/continued_fraction.py
+++ b/tests/github/TheAlgorithms/Python/maths/continued_fraction.py
@@ -1,0 +1,57 @@
+"""
+Finding the continuous fraction for a rational number using python
+
+https://en.wikipedia.org/wiki/Continued_fraction
+"""
+
+from fractions import Fraction
+from math import floor
+
+
+def continued_fraction(num: Fraction) -> list[int]:
+    """
+    :param num:
+    Fraction of the number whose continued fractions to be found.
+    Use Fraction(str(number)) for more accurate results due to
+    float inaccuracies.
+
+    :return:
+    The continued fraction of rational number.
+    It is the all commas in the (n + 1)-tuple notation.
+
+    >>> continued_fraction(Fraction(2))
+    [2]
+    >>> continued_fraction(Fraction("3.245"))
+    [3, 4, 12, 4]
+    >>> continued_fraction(Fraction("2.25"))
+    [2, 4]
+    >>> continued_fraction(1/Fraction("2.25"))
+    [0, 2, 4]
+    >>> continued_fraction(Fraction("415/93"))
+    [4, 2, 6, 7]
+    >>> continued_fraction(Fraction(0))
+    [0]
+    >>> continued_fraction(Fraction(0.75))
+    [0, 1, 3]
+    >>> continued_fraction(Fraction("-2.25"))    # -2.25 = -3 + 0.75
+    [-3, 1, 3]
+    """
+    numerator, denominator = num.as_integer_ratio()
+    continued_fraction_list: list[int] = []
+    while True:
+        integer_part = floor(numerator / denominator)
+        continued_fraction_list.append(integer_part)
+        numerator -= integer_part * denominator
+        if numerator == 0:
+            break
+        numerator, denominator = denominator, numerator
+
+    return continued_fraction_list
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+
+    print("Continued Fraction of 0.84375 is: ", continued_fraction(Fraction("0.84375")))


### PR DESCRIPTION
## Summary
- add missing Python continued_fraction implementation
- implement continued fraction expansion in Mochi with custom floor division
- verify continued fraction output for 27/32

## Testing
- `go run cmd/mochi/main.go run tests/github/TheAlgorithms/Mochi/maths/continued_fraction.mochi > tests/github/TheAlgorithms/Mochi/maths/continued_fraction.out`
- `cat tests/github/TheAlgorithms/Mochi/maths/continued_fraction.out`


------
https://chatgpt.com/codex/tasks/task_e_6891ea374f308320a199717fbe717013