### PR TITLE
Add Euler's totient algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/maths/eulers_totient.mochi
+++ b/tests/github/TheAlgorithms/Mochi/maths/eulers_totient.mochi
@@ -1,0 +1,77 @@
+/*
+Euler's Totient Function
+-----------------------
+Euler's totient \u03c6(n) counts how many integers 1 \u2264 k < n are coprime with n.
+This implementation computes totients for all numbers below a bound n using a
+prime sieve:
+
+1. Maintain a list of discovered primes.
+2. For each integer i, multiply by each prime p.
+   * If i * p \u2265 n we stop processing.
+   * Mark i * p as composite.
+   * If p divides i then \u03c6(i * p) = \u03c6(i) * p and no other primes are checked.
+   * Otherwise \u03c6(i * p) = \u03c6(i) * (p - 1).
+3. The array of totients is returned where index i holds \u03c6(i).
+
+The complexity is O(n log log n) and uses no foreign function interface so it
+runs on the runtime/vm.
+*/
+
+fun totient(n: int): list<int> {
+  var is_prime: list<bool> = []
+  var totients: list<int> = []
+  var primes: list<int> = []
+  var i = 0
+  while i <= n {
+    is_prime = append(is_prime, true)
+    totients = append(totients, i - 1)
+    i = i + 1
+  }
+  i = 2
+  while i <= n {
+    if is_prime[i] {
+      primes = append(primes, i)
+    }
+    var j = 0
+    while j < len(primes) {
+      let p = primes[j]
+      if i * p >= n {
+        break
+      }
+      is_prime[i * p] = false
+      if i % p == 0 {
+        totients[i * p] = totients[i] * p
+        break
+      }
+      totients[i * p] = totients[i] * (p - 1)
+      j = j + 1
+    }
+    i = i + 1
+  }
+  return totients
+}
+
+fun test_totient() {
+  let expected: list<int> = [-1, 0, 1, 2, 2, 4, 2, 6, 4, 6, 9]
+  let res = totient(10)
+  var idx = 0
+  while idx < len(expected) {
+    if res[idx] != expected[idx] {
+      panic("totient mismatch at " + str(idx))
+    }
+    idx = idx + 1
+  }
+}
+
+fun main() {
+  test_totient()
+  let n = 10
+  let res = totient(n)
+  var i = 1
+  while i < n {
+    print(str(i) + " has " + str(res[i]) + " relative primes.")
+    i = i + 1
+  }
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/maths/eulers_totient.out
+++ b/tests/github/TheAlgorithms/Mochi/maths/eulers_totient.out
@@ -1,0 +1,9 @@
+1 has 0 relative primes.
+2 has 1 relative primes.
+3 has 2 relative primes.
+4 has 2 relative primes.
+5 has 4 relative primes.
+6 has 2 relative primes.
+7 has 6 relative primes.
+8 has 4 relative primes.
+9 has 6 relative primes.

--- a/tests/github/TheAlgorithms/Python/maths/eulers_totient.py
+++ b/tests/github/TheAlgorithms/Python/maths/eulers_totient.py
@@ -1,0 +1,41 @@
+# Eulers Totient function finds the number of relative primes of a number n from 1 to n
+def totient(n: int) -> list:
+    """
+    >>> n = 10
+    >>> totient_calculation = totient(n)
+    >>> for i in range(1, n):
+    ...     print(f"{i} has {totient_calculation[i]} relative primes.")
+    1 has 0 relative primes.
+    2 has 1 relative primes.
+    3 has 2 relative primes.
+    4 has 2 relative primes.
+    5 has 4 relative primes.
+    6 has 2 relative primes.
+    7 has 6 relative primes.
+    8 has 4 relative primes.
+    9 has 6 relative primes.
+    """
+    is_prime = [True for i in range(n + 1)]
+    totients = [i - 1 for i in range(n + 1)]
+    primes = []
+    for i in range(2, n + 1):
+        if is_prime[i]:
+            primes.append(i)
+        for j in range(len(primes)):
+            if i * primes[j] >= n:
+                break
+            is_prime[i * primes[j]] = False
+
+            if i % primes[j] == 0:
+                totients[i * primes[j]] = totients[i] * primes[j]
+                break
+
+            totients[i * primes[j]] = totients[i] * (primes[j] - 1)
+
+    return totients
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python reference for Euler's totient function
- port Euler's totient to pure Mochi with tests and demo output

## Testing
- `python3 tests/github/TheAlgorithms/Python/maths/eulers_totient.py`
- `./bin/mochi run tests/github/TheAlgorithms/Mochi/maths/eulers_totient.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891f50d5a34832099477ce6faf200d6