### PR TITLE
Add Fermat's Little Theorem example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/maths/fermat_little_theorem.mochi
+++ b/tests/github/TheAlgorithms/Mochi/maths/fermat_little_theorem.mochi
@@ -1,0 +1,46 @@
+/*
+Demonstration of Fermat's Little Theorem for modular division.
+
+Given integers a and b and a prime modulus p where b divides a and p does not
+divide b, Fermat's little theorem states that:
+  (a / b) mod p == (a * b^(p-2)) mod p
+Thus b^(p-2) mod p acts as the multiplicative inverse of b modulo p.
+
+The program implements binary exponentiation to compute b^(p-2) mod p in O(log p)
+time and verifies the identity above. It also demonstrates a naive modular
+exponentiation using a linear-time loop.
+*/
+
+fun binary_exponentiation(a: int, n: int, mod: int): int {
+  if n == 0 { return 1 }
+  if n % 2 == 1 {
+    return (binary_exponentiation(a, n - 1, mod) * a) % mod
+  }
+  let b = binary_exponentiation(a, n / 2, mod)
+  return (b * b) % mod
+}
+
+fun naive_exponent_mod(a: int, n: int, mod: int): int {
+  var result = 1
+  var i = 0
+  while i < n {
+    result = (result * a) % mod
+    i = i + 1
+  }
+  return result
+}
+
+fun print_bool(b: bool) {
+  if b { print("true") } else { print("false") }
+}
+
+let p = 701
+let a = 1000000000
+let b = 10
+
+let left = (a / b) % p
+let right_fast = (a * binary_exponentiation(b, p - 2, p)) % p
+print_bool(left == right_fast)
+
+let right_naive = (a * naive_exponent_mod(b, p - 2, p)) % p
+print_bool(left == right_naive)

--- a/tests/github/TheAlgorithms/Mochi/maths/fermat_little_theorem.out
+++ b/tests/github/TheAlgorithms/Mochi/maths/fermat_little_theorem.out
@@ -1,0 +1,2 @@
+true
+true

--- a/tests/github/TheAlgorithms/Python/maths/fermat_little_theorem.py
+++ b/tests/github/TheAlgorithms/Python/maths/fermat_little_theorem.py
@@ -1,0 +1,30 @@
+# Python program to show the usage of Fermat's little theorem in a division
+# According to Fermat's little theorem, (a / b) mod p always equals
+# a * (b ^ (p - 2)) mod p
+# Here we assume that p is a prime number, b divides a, and p doesn't divide b
+# Wikipedia reference: https://en.wikipedia.org/wiki/Fermat%27s_little_theorem
+
+
+def binary_exponentiation(a: int, n: float, mod: int) -> int:
+    if n == 0:
+        return 1
+
+    elif n % 2 == 1:
+        return (binary_exponentiation(a, n - 1, mod) * a) % mod
+
+    else:
+        b = binary_exponentiation(a, n / 2, mod)
+        return (b * b) % mod
+
+
+# a prime number
+p = 701
+
+a = 1000000000
+b = 10
+
+# using binary exponentiation function, O(log(p)):
+print((a / b) % p == (a * binary_exponentiation(b, p - 2, p)) % p)
+
+# using Python operators:
+print((a / b) % p == (a * b ** (p - 2)) % p)


### PR DESCRIPTION
## Summary
- add Fermat's Little Theorem Python source and corresponding Mochi implementation
- demonstrate modular inverse using binary exponentiation

## Testing
- `./mochi run tests/github/TheAlgorithms/Mochi/maths/fermat_little_theorem.mochi`
- `npm test` *(fails: Missing script: "test")*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891f96d902c8320bf45914ac17becf4