### PR TITLE
Add Mochi solution for integer palindrome algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/maths/is_int_palindrome.mochi
+++ b/tests/github/TheAlgorithms/Mochi/maths/is_int_palindrome.mochi
@@ -1,0 +1,41 @@
+/*
+Determine whether an integer is a palindrome.
+
+The algorithm reverses the digits of the given non-negative integer and
+compares the reversed number with the original. Negative numbers are
+immediately rejected because of the leading minus sign.
+
+Steps:
+1. Copy the original value.
+2. Repeatedly extract the last digit using modulo 10 and build a reversed
+   number by multiplying the accumulator by 10 and adding the digit.
+3. Truncate the original by dividing by 10 each iteration.
+4. After processing all digits, compare the reversed number with the copy.
+
+Time complexity: O(k) where k is the number of digits in the input.
+Space complexity: O(1).
+*/
+
+fun is_int_palindrome(num: int): bool {
+  if num < 0 {
+    return false
+  }
+  var n = num
+  var rev = 0
+  while n > 0 {
+    rev = rev * 10 + (n % 10)
+    n = n / 10
+  }
+  return rev == num
+}
+
+fun main() {
+  print(is_int_palindrome(-121))
+  print(is_int_palindrome(0))
+  print(is_int_palindrome(10))
+  print(is_int_palindrome(11))
+  print(is_int_palindrome(101))
+  print(is_int_palindrome(120))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/maths/is_int_palindrome.out
+++ b/tests/github/TheAlgorithms/Mochi/maths/is_int_palindrome.out
@@ -1,0 +1,6 @@
+false
+true
+false
+true
+true
+false

--- a/tests/github/TheAlgorithms/Python/maths/is_int_palindrome.py
+++ b/tests/github/TheAlgorithms/Python/maths/is_int_palindrome.py
@@ -1,0 +1,34 @@
+def is_int_palindrome(num: int) -> bool:
+    """
+    Returns whether `num` is a palindrome or not
+    (see for reference https://en.wikipedia.org/wiki/Palindromic_number).
+
+    >>> is_int_palindrome(-121)
+    False
+    >>> is_int_palindrome(0)
+    True
+    >>> is_int_palindrome(10)
+    False
+    >>> is_int_palindrome(11)
+    True
+    >>> is_int_palindrome(101)
+    True
+    >>> is_int_palindrome(120)
+    False
+    """
+    if num < 0:
+        return False
+
+    num_copy: int = num
+    rev_num: int = 0
+    while num > 0:
+        rev_num = rev_num * 10 + (num % 10)
+        num //= 10
+
+    return num_copy == rev_num
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add missing Python source for `is_int_palindrome`
- implement equivalent Mochi version and generate runtime output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/maths/is_int_palindrome.mochi`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891fa8ed0948320b652a83b0643f223