### PR TITLE
Add IPv4 address validator algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/maths/is_ip_v4_address_valid.mochi
+++ b/tests/github/TheAlgorithms/Mochi/maths/is_ip_v4_address_valid.mochi
@@ -1,0 +1,83 @@
+/*
+IPv4 Address Validation
+-----------------------
+This module checks whether a string represents a valid IPv4 address.
+A valid IPv4 address consists of exactly four decimal octets separated by
+periods. Each octet must:
+1. Contain only digit characters.
+2. Represent a number in the range [0, 255].
+3. Have no leading zeros unless the octet is exactly "0".
+
+The algorithm avoids FFI and operates within the Mochi runtime by
+splitting the input string manually, verifying each octet, and converting
+its characters into integers. The procedure mirrors the Python version in
+TheAlgorithms repository.
+*/
+
+fun split_by_dot(s: string): list<string> {
+  var res: list<string> = []
+  var current = ""
+  var i = 0
+  while i < len(s) {
+    let c = s[i]
+    if c == "." {
+      res = append(res, current)
+      current = ""
+    } else {
+      current = current + c
+    }
+    i = i + 1
+  }
+  res = append(res, current)
+  return res
+}
+
+fun is_digit_str(s: string): bool {
+  if len(s) == 0 { return false }
+  var i = 0
+  while i < len(s) {
+    let c = s[i]
+    if c < "0" || c > "9" { return false }
+    i = i + 1
+  }
+  return true
+}
+
+fun parse_decimal(s: string): int {
+  var value = 0
+  var i = 0
+  while i < len(s) {
+    let c = s[i]
+    value = value * 10 + (c as int)
+    i = i + 1
+  }
+  return value
+}
+
+fun is_ip_v4_address_valid(ip: string): bool {
+  let octets = split_by_dot(ip)
+  if len(octets) != 4 { return false }
+  var i = 0
+  while i < 4 {
+    let oct = octets[i]
+    if !is_digit_str(oct) { return false }
+    let number = parse_decimal(oct)
+    if len(str(number)) != len(oct) { return false }
+    if number < 0 || number > 255 { return false }
+    i = i + 1
+  }
+  return true
+}
+
+print(str(is_ip_v4_address_valid("192.168.0.23")))
+print(str(is_ip_v4_address_valid("192.256.15.8")))
+print(str(is_ip_v4_address_valid("172.100.0.8")))
+print(str(is_ip_v4_address_valid("255.256.0.256")))
+print(str(is_ip_v4_address_valid("1.2.33333333.4")))
+print(str(is_ip_v4_address_valid("1.2.-3.4")))
+print(str(is_ip_v4_address_valid("1.2.3")))
+print(str(is_ip_v4_address_valid("1.2.3.4.5")))
+print(str(is_ip_v4_address_valid("1.2.A.4")))
+print(str(is_ip_v4_address_valid("0.0.0.0")))
+print(str(is_ip_v4_address_valid("1.2.3.")))
+print(str(is_ip_v4_address_valid("1.2.3.05")))

--- a/tests/github/TheAlgorithms/Mochi/maths/is_ip_v4_address_valid.out
+++ b/tests/github/TheAlgorithms/Mochi/maths/is_ip_v4_address_valid.out
@@ -1,0 +1,12 @@
+true
+false
+true
+false
+false
+false
+false
+false
+false
+true
+false
+false

--- a/tests/github/TheAlgorithms/Python/maths/is_ip_v4_address_valid.py
+++ b/tests/github/TheAlgorithms/Python/maths/is_ip_v4_address_valid.py
@@ -1,0 +1,75 @@
+"""
+wiki: https://en.wikipedia.org/wiki/IPv4
+
+Is IP v4 address valid?
+A valid IP address must be four octets in the form of A.B.C.D,
+where A, B, C and D are numbers from 0-255
+for example: 192.168.23.1, 172.255.255.255 are valid IP address
+             192.168.256.0, 256.192.3.121 are invalid IP address
+"""
+
+
+def is_ip_v4_address_valid(ip: str) -> bool:
+    """
+    print "Valid IP address" If IP is valid.
+    or
+    print "Invalid IP address" If IP is invalid.
+
+    >>> is_ip_v4_address_valid("192.168.0.23")
+    True
+
+    >>> is_ip_v4_address_valid("192.256.15.8")
+    False
+
+    >>> is_ip_v4_address_valid("172.100.0.8")
+    True
+
+    >>> is_ip_v4_address_valid("255.256.0.256")
+    False
+
+    >>> is_ip_v4_address_valid("1.2.33333333.4")
+    False
+
+    >>> is_ip_v4_address_valid("1.2.-3.4")
+    False
+
+    >>> is_ip_v4_address_valid("1.2.3")
+    False
+
+    >>> is_ip_v4_address_valid("1.2.3.4.5")
+    False
+
+    >>> is_ip_v4_address_valid("1.2.A.4")
+    False
+
+    >>> is_ip_v4_address_valid("0.0.0.0")
+    True
+
+    >>> is_ip_v4_address_valid("1.2.3.")
+    False
+
+    >>> is_ip_v4_address_valid("1.2.3.05")
+    False
+    """
+    octets = ip.split(".")
+    if len(octets) != 4:
+        return False
+
+    for octet in octets:
+        if not octet.isdigit():
+            return False
+
+        number = int(octet)
+        if len(str(number)) != len(octet):
+            return False
+
+        if not 0 <= number <= 255:
+            return False
+
+    return True
+
+
+if __name__ == "__main__":
+    ip = input().strip()
+    valid_or_invalid = "valid" if is_ip_v4_address_valid(ip) else "invalid"
+    print(f"{ip} is a {valid_or_invalid} IPv4 address.")


### PR DESCRIPTION
## Summary
- add Python reference implementation for validating IPv4 addresses
- translate IPv4 validation algorithm into Mochi and record sample outputs

## Testing
- `./bin/mochi run tests/github/TheAlgorithms/Mochi/maths/is_ip_v4_address_valid.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891fab7f5848320ba44bf3c4747b1dc