### PR TITLE
Add square-free check algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/maths/is_square_free.mochi
+++ b/tests/github/TheAlgorithms/Mochi/maths/is_square_free.mochi
@@ -1,0 +1,38 @@
+/*
+Square-Free Checker
+-------------------
+Determine if a number is square-free based on its prime factors.
+A square-free number has no repeated prime factors. Given a list of
+prime factors, the algorithm verifies that every factor appears at
+most once.
+
+Algorithm:
+1. Iterate through the list using two indices.
+2. Compare each factor with all factors that follow it.
+3. If any duplicate is found, return false.
+4. If no duplicates are found, return true.
+
+Examples:
+- [1, 2, 3, 4] -> true
+- [1, 1, 2, 3, 4] -> false
+- [1, 2, 2, 5] -> false
+*/
+
+fun is_square_free(factors: list<int>): bool {
+  var i = 0
+  while i < len(factors) {
+    var j = i + 1
+    while j < len(factors) {
+      if factors[i] == factors[j] {
+        return false
+      }
+      j = j + 1
+    }
+    i = i + 1
+  }
+  return true
+}
+
+print(str(is_square_free([1, 2, 3, 4])))
+print(str(is_square_free([1, 1, 2, 3, 4])))
+print(str(is_square_free([1, 2, 2, 5])))

--- a/tests/github/TheAlgorithms/Mochi/maths/is_square_free.out
+++ b/tests/github/TheAlgorithms/Mochi/maths/is_square_free.out
@@ -1,0 +1,3 @@
+true
+false
+false

--- a/tests/github/TheAlgorithms/Python/maths/is_square_free.py
+++ b/tests/github/TheAlgorithms/Python/maths/is_square_free.py
@@ -1,0 +1,40 @@
+"""
+References: wikipedia:square free number
+psf/black : True
+ruff : True
+"""
+
+from __future__ import annotations
+
+
+def is_square_free(factors: list[int]) -> bool:
+    """
+    # doctest: +NORMALIZE_WHITESPACE
+    This functions takes a list of prime factors as input.
+    returns True if the factors are square free.
+    >>> is_square_free([1, 1, 2, 3, 4])
+    False
+
+    These are wrong but should return some value
+    it simply checks for repetition in the numbers.
+    >>> is_square_free([1, 3, 4, 'sd', 0.0])
+    True
+
+    >>> is_square_free([1, 0.5, 2, 0.0])
+    True
+    >>> is_square_free([1, 2, 2, 5])
+    False
+    >>> is_square_free('asd')
+    True
+    >>> is_square_free(24)
+    Traceback (most recent call last):
+        ...
+    TypeError: 'int' object is not iterable
+    """
+    return len(set(factors)) == len(factors)
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add missing Python implementation for checking if factors are square-free
- implement equivalent Mochi version and generated VM output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/maths/is_square_free.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6891fad55c9c83208670a8653ec3c733