### PR TITLE
Add Mochi implementation for largest exponent comparison

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/maths/largest_of_very_large_numbers.mochi
+++ b/tests/github/TheAlgorithms/Mochi/maths/largest_of_very_large_numbers.mochi
@@ -1,0 +1,66 @@
+/*
+Large Exponent Comparison
+-------------------------
+This program compares numbers of the form x^y without computing the power
+directly. For very large x and y the value might overflow, so we use the
+identity log10(x^y) = y * log10(x) to compare magnitudes instead.
+
+The `res` function returns this scaled logarithm. Special cases handle
+bases of 0 and exponents of 0, and negative bases raise an error. The
+`compare` function uses `res` to determine which of two exponentials is
+larger.
+
+The implementation avoids any foreign interfaces so it can run on
+`runtime/vm`.
+*/
+fun ln(x: float): float {
+  let t = (x - 1.0) / (x + 1.0)
+  var term = t
+  var sum = 0.0
+  var k = 1
+  while k <= 99 {
+    sum = sum + term / (k as float)
+    term = term * t * t
+    k = k + 2
+  }
+  return 2.0 * sum
+}
+
+fun log10(x: float): float {
+  return ln(x) / ln(10.0)
+}
+
+fun absf(x: float): float {
+  if x < 0.0 { return -x }
+  return x
+}
+
+fun res(x: int, y: int): float {
+  if x == 0 { return 0.0 }
+  if y == 0 { return 1.0 }
+  if x < 0 { panic("math domain error") }
+  return (y as float) * log10(x as float)
+}
+
+fun test_res() {
+  if absf(res(5, 7) - 4.892790030352132) > 0.0000001 {
+    panic("res(5,7) failed")
+  }
+  if res(0, 5) != 0.0 { panic("res(0,5) failed") }
+  if res(3, 0) != 1.0 { panic("res(3,0) failed") }
+}
+
+fun compare(x1: int, y1: int, x2: int, y2: int): string {
+  let r1 = res(x1, y1)
+  let r2 = res(x2, y2)
+  if r1 > r2 {
+    return "Largest number is " + str(x1) + " ^ " + str(y1)
+  }
+  if r2 > r1 {
+    return "Largest number is " + str(x2) + " ^ " + str(y2)
+  }
+  return "Both are equal"
+}
+
+test_res()
+print(compare(5, 7, 4, 8))

--- a/tests/github/TheAlgorithms/Mochi/maths/largest_of_very_large_numbers.out
+++ b/tests/github/TheAlgorithms/Mochi/maths/largest_of_very_large_numbers.out
@@ -1,0 +1,1 @@
+Largest number is 5 ^ 7

--- a/tests/github/TheAlgorithms/Python/maths/largest_of_very_large_numbers.py
+++ b/tests/github/TheAlgorithms/Python/maths/largest_of_very_large_numbers.py
@@ -1,0 +1,47 @@
+# Author: Abhijeeth S
+
+import math
+
+def res(x, y):
+    """
+    Reduces large number to a more manageable number
+    >>> res(5, 7)
+    4.892790030352132
+    >>> res(0, 5)
+    0
+    >>> res(3, 0)
+    1
+    >>> res(-1, 5)
+    Traceback (most recent call last):
+    ...
+    ValueError: math domain error
+    """
+    if 0 not in (x, y):
+        # We use the relation x^y = y*log10(x), where 10 is the base.
+        return y * math.log10(x)
+    elif x == 0:  # 0 raised to any number is 0
+        return 0
+    elif y == 0:
+        return 1  # any number raised to 0 is 1
+    raise AssertionError("This should never happen")
+
+
+if __name__ == "__main__":  # Main function
+    # Read two numbers from input and typecast them to int using map function.
+    # Here x is the base and y is the power.
+    prompt = "Enter the base and the power separated by a comma: "
+    x1, y1 = map(int, input(prompt).split(","))
+    x2, y2 = map(int, input(prompt).split(","))
+
+    # We find the log of each number, using the function res(), which takes two
+    # arguments.
+    res1 = res(x1, y1)
+    res2 = res(x2, y2)
+
+    # We check for the largest number
+    if res1 > res2:
+        print("Largest number is", x1, "^", y1)
+    elif res2 > res1:
+        print("Largest number is", x2, "^", y2)
+    else:
+        print("Both are equal")


### PR DESCRIPTION
## Summary
- add missing Python implementation for comparing large exponent numbers
- implement Mochi version with logarithmic comparison and tests
- record sample output from VM run

## Testing
- `npm test` (fails: Missing script)
- `go test ./...` (partial run, some packages have no tests)
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/maths/largest_of_very_large_numbers.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6891fb1760108320a65bb76badd1c889