### PR TITLE
Add Monte Carlo estimators

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/maths/monte_carlo.mochi
+++ b/tests/github/TheAlgorithms/Mochi/maths/monte_carlo.mochi
@@ -1,0 +1,120 @@
+/*
+Monte Carlo Estimation
+----------------------
+This module implements basic Monte Carlo techniques using only
+pure Mochi features. A simple linear congruential generator
+produces deterministic pseudo-random numbers so the program can
+run on the runtime/vm without external libraries.
+
+1. `pi_estimator(iterations)` drops random points inside a
+   square and approximates π from the proportion that fall in
+the inscribed unit circle.
+2. `area_under_curve_estimator(iterations, f, min_value, max_value)`
+   estimates the definite integral of a non-negative function by
+   averaging random samples. It is exercised by
+   `area_under_line_estimator_check` for f(x)=x and
+   `pi_estimator_using_area_under_curve` for the upper half of a
+   circle of radius 2, whose area equals π.
+*/
+
+let PI = 3.141592653589793
+var rand_seed: int = 123456789
+
+fun rand_float(): float {
+  rand_seed = (1103515245 * rand_seed + 12345) % 2147483648
+  return (rand_seed as float) / 2147483648.0
+}
+
+fun rand_range(min_val: float, max_val: float): float {
+  return rand_float() * (max_val - min_val) + min_val
+}
+
+fun abs_float(x: float): float {
+  if x < 0.0 { return -x }
+  return x
+}
+
+fun sqrtApprox(x: float): float {
+  if x == 0.0 { return 0.0 }
+  var guess = x / 2.0
+  var i = 0
+  while i < 20 {
+    guess = (guess + x / guess) / 2.0
+    i = i + 1
+  }
+  return guess
+}
+
+fun pi_estimator(iterations: int) {
+  var inside = 0.0
+  var i = 0
+  while i < iterations {
+    let x = rand_range(-1.0, 1.0)
+    let y = rand_range(-1.0, 1.0)
+    if x * x + y * y <= 1.0 {
+      inside = inside + 1.0
+    }
+    i = i + 1
+  }
+  let proportion = inside / (iterations as float)
+  let pi_estimate = proportion * 4.0
+  print("The estimated value of pi is", pi_estimate)
+  print("The numpy value of pi is", PI)
+  print("The total error is", abs_float(PI - pi_estimate))
+}
+
+fun area_under_curve_estimator(
+  iterations: int,
+  f: fun(float): float,
+  min_value: float,
+  max_value: float
+): float {
+  var sum = 0.0
+  var i = 0
+  while i < iterations {
+    let x = rand_range(min_value, max_value)
+    sum = sum + f(x)
+    i = i + 1
+  }
+  let expected = sum / (iterations as float)
+  return expected * (max_value - min_value)
+}
+
+fun area_under_line_estimator_check(
+  iterations: int,
+  min_value: float,
+  max_value: float
+) {
+  fun identity_function(x: float): float { return x }
+  let estimated_value = area_under_curve_estimator(iterations, identity_function, min_value, max_value)
+  let expected_value = (max_value * max_value - min_value * min_value) / 2.0
+  print("******************")
+  print("Estimating area under y=x where x varies from", min_value)
+  print("Estimated value is", estimated_value)
+  print("Expected value is", expected_value)
+  print("Total error is", abs_float(estimated_value - expected_value))
+  print("******************")
+}
+
+fun pi_estimator_using_area_under_curve(iterations: int) {
+  fun semi_circle(x: float): float {
+    let y = 4.0 - x * x
+    let s = sqrtApprox(y)
+    return s
+  }
+  let estimated_value = area_under_curve_estimator(iterations, semi_circle, 0.0, 2.0)
+  print("******************")
+  print("Estimating pi using area_under_curve_estimator")
+  print("Estimated value is", estimated_value)
+  print("Expected value is", PI)
+  print("Total error is", abs_float(estimated_value - PI))
+  print("******************")
+}
+
+fun main() {
+  pi_estimator(1000)
+  area_under_line_estimator_check(1000, 0.0, 1.0)
+  pi_estimator_using_area_under_curve(1000)
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/maths/monte_carlo.out
+++ b/tests/github/TheAlgorithms/Mochi/maths/monte_carlo.out
@@ -1,0 +1,15 @@
+The estimated value of pi is 3.196
+The numpy value of pi is 3.141592653589793
+The total error is 0.05440734641020706
+******************
+Estimating area under y=x where x varies from 0
+Estimated value is 0.48612035608105364
+Expected value is 0.5
+Total error is 0.01387964391894636
+******************
+******************
+Estimating pi using area_under_curve_estimator
+Estimated value is 3.1325437689330586
+Expected value is 3.141592653589793
+Total error is 0.00904888465673448
+******************

--- a/tests/github/TheAlgorithms/Python/maths/monte_carlo.py
+++ b/tests/github/TheAlgorithms/Python/maths/monte_carlo.py
@@ -1,0 +1,131 @@
+"""
+@author: MatteoRaso
+"""
+
+from collections.abc import Callable
+from math import pi, sqrt
+from random import uniform
+from statistics import mean
+
+
+def pi_estimator(iterations: int):
+    """
+    An implementation of the Monte Carlo method used to find pi.
+    1. Draw a 2x2 square centred at (0,0).
+    2. Inscribe a circle within the square.
+    3. For each iteration, place a dot anywhere in the square.
+       a. Record the number of dots within the circle.
+    4. After all the dots are placed, divide the dots in the circle by the total.
+    5. Multiply this value by 4 to get your estimate of pi.
+    6. Print the estimated and numpy value of pi
+    """
+
+    # A local function to see if a dot lands in the circle.
+    def is_in_circle(x: float, y: float) -> bool:
+        distance_from_centre = sqrt((x**2) + (y**2))
+        # Our circle has a radius of 1, so a distance
+        # greater than 1 would land outside the circle.
+        return distance_from_centre <= 1
+
+    # The proportion of guesses that landed in the circle
+    proportion = mean(
+        int(is_in_circle(uniform(-1.0, 1.0), uniform(-1.0, 1.0)))
+        for _ in range(iterations)
+    )
+    # The ratio of the area for circle to square is pi/4.
+    pi_estimate = proportion * 4
+    print(f"The estimated value of pi is {pi_estimate}")
+    print(f"The numpy value of pi is {pi}")
+    print(f"The total error is {abs(pi - pi_estimate)}")
+
+
+def area_under_curve_estimator(
+    iterations: int,
+    function_to_integrate: Callable[[float], float],
+    min_value: float = 0.0,
+    max_value: float = 1.0,
+) -> float:
+    """
+    An implementation of the Monte Carlo method to find area under
+       a single variable non-negative real-valued continuous function,
+       say f(x), where x lies within a continuous bounded interval,
+       say [min_value, max_value], where min_value and max_value are
+       finite numbers
+    1. Let x be a uniformly distributed random variable between min_value to
+       max_value
+    2. Expected value of f(x) =
+       (integrate f(x) from min_value to max_value)/(max_value - min_value)
+    3. Finding expected value of f(x):
+        a. Repeatedly draw x from uniform distribution
+        b. Evaluate f(x) at each of the drawn x values
+        c. Expected value = average of the function evaluations
+    4. Estimated value of integral = Expected value * (max_value - min_value)
+    5. Returns estimated value
+    """
+
+    return mean(
+        function_to_integrate(uniform(min_value, max_value)) for _ in range(iterations)
+    ) * (max_value - min_value)
+
+
+def area_under_line_estimator_check(
+    iterations: int, min_value: float = 0.0, max_value: float = 1.0
+) -> None:
+    """
+    Checks estimation error for area_under_curve_estimator function
+    for f(x) = x where x lies within min_value to max_value
+    1. Calls "area_under_curve_estimator" function
+    2. Compares with the expected value
+    3. Prints estimated, expected and error value
+    """
+
+    def identity_function(x: float) -> float:
+        """
+        Represents identity function
+        >>> [function_to_integrate(x) for x in [-2.0, -1.0, 0.0, 1.0, 2.0]]
+        [-2.0, -1.0, 0.0, 1.0, 2.0]
+        """
+        return x
+
+    estimated_value = area_under_curve_estimator(
+        iterations, identity_function, min_value, max_value
+    )
+    expected_value = (max_value * max_value - min_value * min_value) / 2
+
+    print("******************")
+    print(f"Estimating area under y=x where x varies from {min_value} to {max_value}")
+    print(f"Estimated value is {estimated_value}")
+    print(f"Expected value is {expected_value}")
+    print(f"Total error is {abs(estimated_value - expected_value)}")
+    print("******************")
+
+
+def pi_estimator_using_area_under_curve(iterations: int) -> None:
+    """
+    Area under curve y = sqrt(4 - x^2) where x lies in 0 to 2 is equal to pi
+    """
+
+    def function_to_integrate(x: float) -> float:
+        """
+        Represents semi-circle with radius 2
+        >>> [function_to_integrate(x) for x in [-2.0, 0.0, 2.0]]
+        [0.0, 2.0, 0.0]
+        """
+        return sqrt(4.0 - x * x)
+
+    estimated_value = area_under_curve_estimator(
+        iterations, function_to_integrate, 0.0, 2.0
+    )
+
+    print("******************")
+    print("Estimating pi using area_under_curve_estimator")
+    print(f"Estimated value is {estimated_value}")
+    print(f"Expected value is {pi}")
+    print(f"Total error is {abs(estimated_value - pi)}")
+    print("******************")
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python reference for Monte Carlo estimators from TheAlgorithms
- implement Monte Carlo pi and integral estimators in pure Mochi

## Testing
- `go run /tmp/runvm.go tests/github/TheAlgorithms/Mochi/maths/monte_carlo.mochi`
- `go test ./runtime/vm -run Test -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6891fdf1e9908320aec762a303da878c