### PR TITLE
feat: add numerical integration example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/maths/numerical_analysis/numerical_integration.mochi
+++ b/tests/github/TheAlgorithms/Mochi/maths/numerical_analysis/numerical_integration.mochi
@@ -1,0 +1,43 @@
+/*
+Approximates the area under a curve using the trapezoidal rule.
+Given a function f(x), a start point x_start, an end point x_end,
+and the number of segments (steps), it partitions the interval into
+segments of equal width. For each adjacent pair of points, the algorithm
+forms a trapezoid with area (f(x1) + f(x2)) * h / 2 where h is the segment width.
+Summing these trapezoids approximates the definite integral of f(x).
+This implementation mirrors the Python version from TheAlgorithms.
+*/
+
+fun abs_float(x: float): float {
+  if x < 0.0 { return -x } else { return x }
+}
+
+fun trapezoidal_area(f: fun(float): float, x_start: float, x_end: float, steps: int): float {
+  let step: float = (x_end - x_start) / (steps as float)
+  var x1: float = x_start
+  var fx1: float = f(x_start)
+  var area: float = 0.0
+  var i: int = 0
+  while i < steps {
+    let x2: float = x1 + step
+    let fx2: float = f(x2)
+    area = area + abs_float(fx2 + fx1) * step / 2.0
+    x1 = x2
+    fx1 = fx2
+    i = i + 1
+  }
+  return area
+}
+
+fun f(x: float): float {
+  return x * x * x
+}
+
+print("f(x) = x^3")
+print("The area between the curve, x = -10, x = 10 and the x axis is:")
+var i: int = 10
+while i <= 100000 {
+  let area: float = trapezoidal_area(f, -5.0, 5.0, i)
+  print("with " + str(i) + " steps: " + str(area))
+  i = i * 10
+}

--- a/tests/github/TheAlgorithms/Mochi/maths/numerical_analysis/numerical_integration.out
+++ b/tests/github/TheAlgorithms/Mochi/maths/numerical_analysis/numerical_integration.out
@@ -1,0 +1,7 @@
+f(x) = x^3
+The area between the curve, x = -10, x = 10 and the x axis is:
+with 10 steps: 325
+with 100 steps: 312.6250000000002
+with 1000 steps: 312.50124999999076
+with 10000 steps: 312.500012499954
+with 100000 steps: 312.50000012559866

--- a/tests/github/TheAlgorithms/Python/maths/numerical_analysis/numerical_integration.py
+++ b/tests/github/TheAlgorithms/Python/maths/numerical_analysis/numerical_integration.py
@@ -1,0 +1,66 @@
+"""
+Approximates the area under the curve using the trapezoidal rule
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+
+def trapezoidal_area(
+    fnc: Callable[[float], float],
+    x_start: float,
+    x_end: float,
+    steps: int = 100,
+) -> float:
+    """
+    Treats curve as a collection of linear lines and sums the area of the
+    trapezium shape they form
+    :param fnc: a function which defines a curve
+    :param x_start: left end point to indicate the start of line segment
+    :param x_end: right end point to indicate end of line segment
+    :param steps: an accuracy gauge; more steps increases the accuracy
+    :return: a float representing the length of the curve
+
+    >>> def f(x):
+    ...    return 5
+    >>> '%.3f' % trapezoidal_area(f, 12.0, 14.0, 1000)
+    '10.000'
+
+    >>> def f(x):
+    ...    return 9*x**2
+    >>> '%.4f' % trapezoidal_area(f, -4.0, 0, 10000)
+    '192.0000'
+
+    >>> '%.4f' % trapezoidal_area(f, -4.0, 4.0, 10000)
+    '384.0000'
+    """
+    x1 = x_start
+    fx1 = fnc(x_start)
+    area = 0.0
+
+    for _ in range(steps):
+        # Approximates small segments of curve as linear and solve
+        # for trapezoidal area
+        x2 = (x_end - x_start) / steps + x1
+        fx2 = fnc(x2)
+        area += abs(fx2 + fx1) * (x2 - x1) / 2
+
+        # Increment step
+        x1 = x2
+        fx1 = fx2
+    return area
+
+
+if __name__ == "__main__":
+
+    def f(x):
+        return x**3
+
+    print("f(x) = x^3")
+    print("The area between the curve, x = -10, x = 10 and the x axis is:")
+    i = 10
+    while i <= 100000:
+        area = trapezoidal_area(f, -5, 5, i)
+        print(f"with {i} steps: {area}")
+        i *= 10


### PR DESCRIPTION
## Summary
- add Python trapezoidal-rule integration example
- implement numerical integration in Mochi and generate sample output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/maths/numerical_analysis/numerical_integration.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892038beb808320826520d8a4da9862