### PR TITLE
Add 3D collinearity check algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/maths/points_are_collinear_3d.mochi
+++ b/tests/github/TheAlgorithms/Mochi/maths/points_are_collinear_3d.mochi
@@ -1,0 +1,103 @@
+/*
+Check if three points are collinear in 3D space.
+
+The algorithm mirrors the Python version from TheAlgorithms project.
+Given three 3D points A, B and C, it determines whether they lie on a
+single straight line.  The steps are:
+
+1. Build vectors AB and AC from the input points.
+2. Compute the cross product of these vectors.  If AB and AC are
+   parallel then their cross product is the zero vector.
+3. Instead of computing the magnitude of the cross product, check
+   directly whether each component is zero after rounding to a given
+   accuracy.  This avoids square roots and division while still
+   providing a reliable test for collinearity.
+
+All data types are explicit and no foreign function interfaces are
+used so the program can execute on the runtime/vm.
+*/
+
+type Point3d {
+  x: float
+  y: float
+  z: float
+}
+
+type Vector3d {
+  x: float
+  y: float
+  z: float
+}
+
+fun create_vector(p1: Point3d, p2: Point3d): Vector3d {
+  let vx = p2.x - p1.x
+  let vy = p2.y - p1.y
+  let vz = p2.z - p1.z
+  return Vector3d { x: vx, y: vy, z: vz }
+}
+
+fun get_3d_vectors_cross(ab: Vector3d, ac: Vector3d): Vector3d {
+  let cx = ab.y * ac.z - ab.z * ac.y
+  let cy = ab.z * ac.x - ab.x * ac.z
+  let cz = ab.x * ac.y - ab.y * ac.x
+  return Vector3d { x: cx, y: cy, z: cz }
+}
+
+fun pow10(exp: int): float {
+  var result = 1.0
+  var i = 0
+  while i < exp {
+    result = result * 10.0
+    i = i + 1
+  }
+  return result
+}
+
+fun round_float(x: float, digits: int): float {
+  let factor = pow10(digits)
+  var v = x * factor
+  if v >= 0.0 {
+    v = v + 0.5
+  } else {
+    v = v - 0.5
+  }
+  let t = v as int
+  return (t as float) / factor
+}
+
+fun is_zero_vector(v: Vector3d, accuracy: int): bool {
+  return round_float(v.x, accuracy) == 0.0 &&
+         round_float(v.y, accuracy) == 0.0 &&
+         round_float(v.z, accuracy) == 0.0
+}
+
+fun are_collinear(a: Point3d, b: Point3d, c: Point3d, accuracy: int): bool {
+  let ab = create_vector(a, b)
+  let ac = create_vector(a, c)
+  let cross = get_3d_vectors_cross(ab, ac)
+  return is_zero_vector(cross, accuracy)
+}
+
+fun test_are_collinear() {
+  let p1 = Point3d { x: 0.0, y: 0.0, z: 0.0 }
+  let p2 = Point3d { x: 1.0, y: 1.0, z: 1.0 }
+  let p3 = Point3d { x: 2.0, y: 2.0, z: 2.0 }
+  if !are_collinear(p1, p2, p3, 10) { panic("collinear test failed") }
+
+  let q3 = Point3d { x: 1.0, y: 2.0, z: 3.0 }
+  if are_collinear(p1, p2, q3, 10) { panic("non-collinear test failed") }
+}
+
+fun main() {
+  test_are_collinear()
+  let a = Point3d { x: 4.802293498137402, y: 3.536233125455244, z: 0.0 }
+  let b = Point3d { x: -2.186788107953106, y: -9.24561398001649, z: 7.141509524846482 }
+  let c = Point3d { x: 1.530169574640268, y: -2.447927606600034, z: 3.343487096469054 }
+  print(str(are_collinear(a, b, c, 10)))
+  let d = Point3d { x: 2.399001826862445, y: -2.452009976680793, z: 4.464656666157666 }
+  let e = Point3d { x: -3.682816335934376, y: 5.753788986533145, z: 9.490993909044244 }
+  let f = Point3d { x: 1.962903518985307, y: 3.741415730125627, z: 7.0 }
+  print(str(are_collinear(d, e, f, 10)))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/maths/points_are_collinear_3d.out
+++ b/tests/github/TheAlgorithms/Mochi/maths/points_are_collinear_3d.out
@@ -1,0 +1,2 @@
+true
+false

--- a/tests/github/TheAlgorithms/Python/maths/points_are_collinear_3d.py
+++ b/tests/github/TheAlgorithms/Python/maths/points_are_collinear_3d.py
@@ -1,0 +1,126 @@
+"""
+Check if three points are collinear in 3D.
+
+In short, the idea is that we are able to create a triangle using three points,
+and the area of that triangle can determine if the three points are collinear or not.
+
+
+First, we create two vectors with the same initial point from the three points,
+then we will calculate the cross-product of them.
+
+The length of the cross vector is numerically equal to the area of a parallelogram.
+
+Finally, the area of the triangle is equal to half of the area of the parallelogram.
+
+Since we are only differentiating between zero and anything else,
+we can get rid of the square root when calculating the length of the vector,
+and also the division by two at the end.
+
+From a second perspective, if the two vectors are parallel and overlapping,
+we can't get a nonzero perpendicular vector,
+since there will be an infinite number of orthogonal vectors.
+
+To simplify the solution we will not calculate the length,
+but we will decide directly from the vector whether it is equal to (0, 0, 0) or not.
+
+
+Read More:
+    https://math.stackexchange.com/a/1951650
+"""
+
+Vector3d = tuple[float, float, float]
+Point3d = tuple[float, float, float]
+
+
+def create_vector(end_point1: Point3d, end_point2: Point3d) -> Vector3d:
+    """
+    Pass two points to get the vector from them in the form (x, y, z).
+
+    >>> create_vector((0, 0, 0), (1, 1, 1))
+    (1, 1, 1)
+    >>> create_vector((45, 70, 24), (47, 32, 1))
+    (2, -38, -23)
+    >>> create_vector((-14, -1, -8), (-7, 6, 4))
+    (7, 7, 12)
+    """
+    x = end_point2[0] - end_point1[0]
+    y = end_point2[1] - end_point1[1]
+    z = end_point2[2] - end_point1[2]
+    return (x, y, z)
+
+
+def get_3d_vectors_cross(ab: Vector3d, ac: Vector3d) -> Vector3d:
+    """
+    Get the cross of the two vectors AB and AC.
+
+    I used determinant of 2x2 to get the determinant of the 3x3 matrix in the process.
+
+    Read More:
+        https://en.wikipedia.org/wiki/Cross_product
+        https://en.wikipedia.org/wiki/Determinant
+
+    >>> get_3d_vectors_cross((3, 4, 7), (4, 9, 2))
+    (-55, 22, 11)
+    >>> get_3d_vectors_cross((1, 1, 1), (1, 1, 1))
+    (0, 0, 0)
+    >>> get_3d_vectors_cross((-4, 3, 0), (3, -9, -12))
+    (-36, -48, 27)
+    >>> get_3d_vectors_cross((17.67, 4.7, 6.78), (-9.5, 4.78, -19.33))
+    (-123.2594, 277.15110000000004, 129.11260000000001)
+    """
+    x = ab[1] * ac[2] - ab[2] * ac[1]  # *i
+    y = (ab[0] * ac[2] - ab[2] * ac[0]) * -1  # *j
+    z = ab[0] * ac[1] - ab[1] * ac[0]  # *k
+    return (x, y, z)
+
+
+def is_zero_vector(vector: Vector3d, accuracy: int) -> bool:
+    """
+    Check if vector is equal to (0, 0, 0) or not.
+
+    Since the algorithm is very accurate, we will never get a zero vector,
+    so we need to round the vector axis,
+    because we want a result that is either True or False.
+    In other applications, we can return a float that represents the collinearity ratio.
+
+    >>> is_zero_vector((0, 0, 0), accuracy=10)
+    True
+    >>> is_zero_vector((15, 74, 32), accuracy=10)
+    False
+    >>> is_zero_vector((-15, -74, -32), accuracy=10)
+    False
+    """
+    return tuple(round(x, accuracy) for x in vector) == (0, 0, 0)
+
+
+def are_collinear(a: Point3d, b: Point3d, c: Point3d, accuracy: int = 10) -> bool:
+    """
+    Check if three points are collinear or not.
+
+    1- Create two vectors AB and AC.
+    2- Get the cross vector of the two vectors.
+    3- Calculate the length of the cross vector.
+    4- If the length is zero then the points are collinear, else they are not.
+
+    The use of the accuracy parameter is explained in is_zero_vector docstring.
+
+    >>> are_collinear((4.802293498137402, 3.536233125455244, 0),
+    ...               (-2.186788107953106, -9.24561398001649, 7.141509524846482),
+    ...               (1.530169574640268, -2.447927606600034, 3.343487096469054))
+    True
+    >>> are_collinear((-6, -2, 6),
+    ...               (6.200213806439997, -4.930157614926678, -4.482371908289856),
+    ...               (-4.085171149525941, -2.459889509029438, 4.354787180795383))
+    True
+    >>> are_collinear((2.399001826862445, -2.452009976680793, 4.464656666157666),
+    ...               (-3.682816335934376, 5.753788986533145, 9.490993909044244),
+    ...               (1.962903518985307, 3.741415730125627, 7))
+    False
+    >>> are_collinear((1.875375340689544, -7.268426006071538, 7.358196269835993),
+    ...               (-3.546599383667157, -4.630005261513976, 3.208784032924246),
+    ...               (-2.564606140206386, 3.937845170672183, 7))
+    False
+    """
+    ab = create_vector(a, b)
+    ac = create_vector(a, c)
+    return is_zero_vector(get_3d_vectors_cross(ab, ac), accuracy)


### PR DESCRIPTION
## Summary
- add missing Python implementation for 3D collinearity detection
- implement equivalent Mochi version using cross product and rounding
- add runtime/vm output verifying collinear and non-collinear cases

## Testing
- `npm test` *(fails: Missing script "test")*
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/maths/points_are_collinear_3d.mochi`


------
https://chatgpt.com/codex/tasks/task_e_68920fb9a54083208540da5fb560ac99