### PR TITLE
Add Pythagoras theorem implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/maths/pythagoras.mochi
+++ b/tests/github/TheAlgorithms/Mochi/maths/pythagoras.mochi
@@ -1,0 +1,62 @@
+/*
+Distance Between Two Points in 3D Space
+--------------------------------------
+This program computes the Euclidean distance between two points using the
+Pythagorean theorem. Each point is represented by x, y, and z coordinates.
+The distance is the square root of the sum of squared differences of the
+coordinates.
+
+Algorithm:
+1. Subtract corresponding coordinates of the two points to get dx, dy, dz.
+2. Square each difference and sum them.
+3. Take the square root of the absolute value of the sum to avoid negative
+   inputs due to floating point error.
+
+Square roots are approximated with Newton's method so the code runs on the
+VM without external libraries.
+*/
+
+type Point = { x: float, y: float, z: float }
+
+fun absf(x: float): float {
+  if x < 0.0 { return -x }
+  return x
+}
+
+fun sqrt_approx(x: float): float {
+  if x <= 0.0 { return 0.0 }
+  var guess = x / 2.0
+  var i = 0
+  while i < 20 {
+    guess = (guess + x / guess) / 2.0
+    i = i + 1
+  }
+  return guess
+}
+
+fun distance(a: Point, b: Point): float {
+  let dx = b.x - a.x
+  let dy = b.y - a.y
+  let dz = b.z - a.z
+  return sqrt_approx(absf(dx * dx + dy * dy + dz * dz))
+}
+
+fun point_to_string(p: Point): string {
+  return "Point(" + str(p.x) + ", " + str(p.y) + ", " + str(p.z) + ")"
+}
+
+fun test_distance() {
+  let p1: Point = Point{ x: 2.0, y: -1.0, z: 7.0 }
+  let p2: Point = Point{ x: 1.0, y: -3.0, z: 5.0 }
+  let d = distance(p1, p2)
+  if absf(d - 3.0) > 0.0001 {
+    panic("distance test failed")
+  }
+  print("Distance from " + point_to_string(p1) + " to " + point_to_string(p2) + " is " + str(d))
+}
+
+fun main() {
+  test_distance()
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/maths/pythagoras.out
+++ b/tests/github/TheAlgorithms/Mochi/maths/pythagoras.out
@@ -1,0 +1,1 @@
+Distance from Point(2, -1, 7) to Point(1, -3, 5) is 3

--- a/tests/github/TheAlgorithms/Python/maths/pythagoras.py
+++ b/tests/github/TheAlgorithms/Python/maths/pythagoras.py
@@ -1,0 +1,29 @@
+"""Uses Pythagoras theorem to calculate the distance between two points in space."""
+
+import math
+
+
+class Point:
+    def __init__(self, x, y, z):
+        self.x = x
+        self.y = y
+        self.z = z
+
+    def __repr__(self) -> str:
+        return f"Point({self.x}, {self.y}, {self.z})"
+
+
+def distance(a: Point, b: Point) -> float:
+    """
+    >>> point1 = Point(2, -1, 7)
+    >>> point2 = Point(1, -3, 5)
+    >>> print(f"Distance from {point1} to {point2} is {distance(point1, point2)}")
+    Distance from Point(2, -1, 7) to Point(1, -3, 5) is 3.0
+    """
+    return math.sqrt(abs((b.x - a.x) ** 2 + (b.y - a.y) ** 2 + (b.z - a.z) ** 2))
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add missing Python source for Pythagoras theorem distance calculation
- implement equivalent Mochi version using Newton's method for sqrt

## Testing
- `python tests/github/TheAlgorithms/Python/maths/pythagoras.py`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/maths/pythagoras.mochi`


------
https://chatgpt.com/codex/tasks/task_e_68920fca8ab48320b7fa6ea309823bd8