### PR TITLE
Add quadratic equation solver with complex roots

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/maths/quadratic_equations_complex_numbers.mochi
+++ b/tests/github/TheAlgorithms/Mochi/maths/quadratic_equations_complex_numbers.mochi
@@ -1,0 +1,82 @@
+/*
+Solve roots of a quadratic equation a*x^2 + b*x + c = 0.
+
+The classical quadratic formula uses the discriminant d = b^2 - 4ac.
+If d >= 0, the equation has two real roots; otherwise the roots are a
+complex conjugate pair.  This Mochi implementation mirrors
+TheAlgorithms/Python version and avoids foreign functions by providing a
+Newton-method square root for non-negative inputs and representing
+complex numbers as a struct of real and imaginary parts.
+
+Time complexity is O(1) as the algorithm performs a fixed number of
+arithmetic operations. Space complexity is O(1).
+*/
+
+type Complex {
+  re: float
+  im: float
+}
+
+fun add(a: Complex, b: Complex): Complex {
+  return Complex { re: a.re + b.re, im: a.im + b.im }
+}
+
+fun sub(a: Complex, b: Complex): Complex {
+  return Complex { re: a.re - b.re, im: a.im - b.im }
+}
+
+fun div_real(a: Complex, r: float): Complex {
+  return Complex { re: a.re / r, im: a.im / r }
+}
+
+fun sqrt_newton(x: float): float {
+  if x <= 0.0 { return 0.0 }
+  var guess = x / 2.0
+  var i = 0
+  while i < 20 {
+    guess = (guess + x / guess) / 2.0
+    i = i + 1
+  }
+  return guess
+}
+
+fun sqrt_to_complex(d: float): Complex {
+  if d >= 0.0 {
+    return Complex { re: sqrt_newton(d), im: 0.0 }
+  }
+  return Complex { re: 0.0, im: sqrt_newton(-d) }
+}
+
+fun quadratic_roots(a: float, b: float, c: float): list<Complex> {
+  if a == 0.0 {
+    print("ValueError: coefficient 'a' must not be zero")
+    return []
+  }
+  let delta = b * b - 4.0 * a * c
+  let sqrt_d = sqrt_to_complex(delta)
+  let minus_b = Complex { re: -b, im: 0.0 }
+  let two_a = 2.0 * a
+  let root1 = div_real(add(minus_b, sqrt_d), two_a)
+  let root2 = div_real(sub(minus_b, sqrt_d), two_a)
+  return [root1, root2]
+}
+
+fun root_str(r: Complex): string {
+  if r.im == 0.0 { return str(r.re) }
+  var s = str(r.re)
+  if r.im >= 0.0 {
+    s = s + "+" + str(r.im) + "i"
+  } else {
+    s = s + str(r.im) + "i"
+  }
+  return s
+}
+
+fun main() {
+  let roots = quadratic_roots(5.0, 6.0, 1.0)
+  if len(roots) == 2 {
+    print("The solutions are: " + root_str(roots[0]) + " and " + root_str(roots[1]))
+  }
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/maths/quadratic_equations_complex_numbers.out
+++ b/tests/github/TheAlgorithms/Mochi/maths/quadratic_equations_complex_numbers.out
@@ -1,0 +1,1 @@
+The solutions are: -0.2 and -1

--- a/tests/github/TheAlgorithms/Python/maths/quadratic_equations_complex_numbers.py
+++ b/tests/github/TheAlgorithms/Python/maths/quadratic_equations_complex_numbers.py
@@ -1,0 +1,36 @@
+from cmath import sqrt
+
+
+def quadratic_roots(a: int, b: int, c: int) -> tuple[complex, complex]:
+    """
+    Given the numerical coefficients a, b and c,
+    calculates the roots for any quadratic equation of the form ax^2 + bx + c
+
+    >>> quadratic_roots(a=1, b=3, c=-4)
+    (1.0, -4.0)
+    >>> quadratic_roots(5, 6, 1)
+    (-0.2, -1.0)
+    >>> quadratic_roots(1, -6, 25)
+    ((3+4j), (3-4j))
+    """
+
+    if a == 0:
+        raise ValueError("Coefficient 'a' must not be zero.")
+    delta = b * b - 4 * a * c
+
+    root_1 = (-b + sqrt(delta)) / (2 * a)
+    root_2 = (-b - sqrt(delta)) / (2 * a)
+
+    return (
+        root_1.real if not root_1.imag else root_1,
+        root_2.real if not root_2.imag else root_2,
+    )
+
+
+def main():
+    solution1, solution2 = quadratic_roots(a=5, b=6, c=1)
+    print(f"The solutions are: {solution1} and {solution2}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add missing Python implementation for solving quadratic equations that may have complex roots
- implement corresponding Mochi version using a custom Complex struct and Newton-method square root
- include program output verifying the solver

## Testing
- `python tests/github/TheAlgorithms/Python/maths/quadratic_equations_complex_numbers.py`
- `./mochi run tests/github/TheAlgorithms/Mochi/maths/quadratic_equations_complex_numbers.mochi`


------
https://chatgpt.com/codex/tasks/task_e_68920fcde1d48320b58cc54464f00060