### PR TITLE
Add Solovay-Strassen primality test in Mochi

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/maths/solovay_strassen_primality_test.mochi
+++ b/tests/github/TheAlgorithms/Mochi/maths/solovay_strassen_primality_test.mochi
@@ -1,0 +1,97 @@
+/*
+Solovay-Strassen Primality Test
+------------------------------
+
+This probabilistic test uses properties of quadratic residues to determine
+if a number is likely prime. For each iteration a random base `a` is chosen
+from [2, n-2]. The Jacobi symbol (a/n) is compared with
+`a^((n-1)/2) mod n`. If they differ or the Jacobi symbol is zero the number
+is composite. Repeating the test with multiple random bases decreases
+the chance of falsely identifying a composite as prime.
+
+The implementation uses a simple linear congruential generator (LCG)
+for pseudo-random numbers to keep the example self contained.
+
+The main function demonstrates the test on several integers.
+*/
+
+var seed: int = 1
+
+fun set_seed(s: int) {
+  seed = s
+}
+
+fun randint(a: int, b: int): int {
+  seed = (seed * 1103515245 + 12345) % 2147483648
+  return (seed % (b - a + 1)) + a
+}
+
+fun jacobi_symbol(random_a: int, number: int): int {
+  if random_a == 0 || random_a == 1 {
+    return random_a
+  }
+  random_a = random_a % number
+  var t: int = 1
+  while random_a != 0 {
+    while random_a % 2 == 0 {
+      random_a = random_a / 2
+      let r = number % 8
+      if r == 3 || r == 5 {
+        t = -t
+      }
+    }
+    let temp = random_a
+    random_a = number
+    number = temp
+    if random_a % 4 == 3 && number % 4 == 3 {
+      t = -t
+    }
+    random_a = random_a % number
+  }
+  if number == 1 {
+    return t
+  }
+  return 0
+}
+
+fun pow_mod(base: int, exp: int, mod: int): int {
+  var result: int = 1
+  var b = base % mod
+  var e = exp
+  while e > 0 {
+    if e % 2 == 1 {
+      result = (result * b) % mod
+    }
+    b = (b * b) % mod
+    e = e / 2
+  }
+  return result
+}
+
+fun solovay_strassen(number: int, iterations: int): bool {
+  if number <= 1 { return false }
+  if number <= 3 { return true }
+
+  var i: int = 0
+  while i < iterations {
+    let a = randint(2, number - 2)
+    let x = jacobi_symbol(a, number)
+    let y = pow_mod(a, (number - 1) / 2, number)
+    var mod_x = x % number
+    if mod_x < 0 { mod_x = mod_x + number }
+    if x == 0 || y != mod_x {
+      return false
+    }
+    i = i + 1
+  }
+  return true
+}
+
+fun main() {
+  set_seed(10)
+  print(str(solovay_strassen(13, 5)))
+  print(str(solovay_strassen(9, 10)))
+  print(str(solovay_strassen(17, 15)))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/maths/solovay_strassen_primality_test.out
+++ b/tests/github/TheAlgorithms/Mochi/maths/solovay_strassen_primality_test.out
@@ -1,0 +1,3 @@
+true
+false
+true

--- a/tests/github/TheAlgorithms/Python/maths/solovay_strassen_primality_test.py
+++ b/tests/github/TheAlgorithms/Python/maths/solovay_strassen_primality_test.py
@@ -1,0 +1,106 @@
+"""
+This script implements the Solovay-Strassen Primality test.
+
+This probabilistic primality test is based on Euler's criterion. It is similar
+to the Fermat test but uses quadratic residues. It can quickly identify
+composite numbers but may occasionally classify composite numbers as prime.
+
+More details and concepts about this can be found on:
+https://en.wikipedia.org/wiki/Solovay%E2%80%93Strassen_primality_test
+"""
+
+import random
+
+
+def jacobi_symbol(random_a: int, number: int) -> int:
+    """
+    Calculate the Jacobi symbol. The Jacobi symbol is a generalization
+    of the Legendre symbol, which can be used to simplify computations involving
+    quadratic residues. The Jacobi symbol is used in primality tests, like the
+    Solovay-Strassen test, because it helps determine if an integer is a
+    quadratic residue modulo a given modulus, providing valuable information
+    about the number's potential primality or compositeness.
+
+    Parameters:
+        random_a: A randomly chosen integer from 2 to n-2 (inclusive)
+        number: The number that is tested for primality
+
+    Returns:
+        jacobi_symbol: The Jacobi symbol is a mathematical function
+        used to determine whether an integer is a quadratic residue modulo
+        another integer (usually prime) or not.
+
+    >>> jacobi_symbol(2, 13)
+    -1
+    >>> jacobi_symbol(5, 19)
+    1
+    >>> jacobi_symbol(7, 14)
+    0
+    """
+
+    if random_a in (0, 1):
+        return random_a
+
+    random_a %= number
+    t = 1
+
+    while random_a != 0:
+        while random_a % 2 == 0:
+            random_a //= 2
+            r = number % 8
+            if r in (3, 5):
+                t = -t
+
+        random_a, number = number, random_a
+
+        if random_a % 4 == number % 4 == 3:
+            t = -t
+
+        random_a %= number
+
+    return t if number == 1 else 0
+
+
+def solovay_strassen(number: int, iterations: int) -> bool:
+    """
+    Check whether the input number is prime or not using
+    the Solovay-Strassen Primality test
+
+    Parameters:
+        number: The number that is tested for primality
+        iterations: The number of times that the test is run
+        which effects the accuracy
+
+    Returns:
+        result: True if number is probably prime and false
+        if not
+
+    >>> random.seed(10)
+    >>> solovay_strassen(13, 5)
+    True
+    >>> solovay_strassen(9, 10)
+    False
+    >>> solovay_strassen(17, 15)
+    True
+    """
+
+    if number <= 1:
+        return False
+    if number <= 3:
+        return True
+
+    for _ in range(iterations):
+        a = random.randint(2, number - 2)
+        x = jacobi_symbol(a, number)
+        y = pow(a, (number - 1) // 2, number)
+
+        if x == 0 or y != x % number:
+            return False
+
+    return True
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python reference for Solovay-Strassen probabilistic primality test
- implement Solovay-Strassen primality test in Mochi with LCG-based RNG and Jacobi symbol
- include runtime output for deterministic sample runs

## Testing
- `python -m doctest -v tests/github/TheAlgorithms/Python/maths/solovay_strassen_primality_test.py`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/maths/solovay_strassen_primality_test.mochi`


------
https://chatgpt.com/codex/tasks/task_e_68921222da3883208ec09d23e1e6a8ae