### PR TITLE
Add Armstrong numbers algorithm in Mochi tests

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/maths/special_numbers/armstrong_numbers.mochi
+++ b/tests/github/TheAlgorithms/Mochi/maths/special_numbers/armstrong_numbers.mochi
@@ -1,0 +1,95 @@
+/*
+Determine whether a positive integer is an Armstrong number.
+
+An Armstrong number (also known as a narcissistic or pluperfect number)
+equals the sum of its digits each raised to the power of the total number
+of digits. Three equivalent checks are implemented:
+
+- `armstrong_number` iterates over the digits and accumulates each digit
+  raised to the digit count.
+- `pluperfect_number` counts how often each digit appears and multiplies
+  that count by the digit raised to the digit count.
+- `narcissistic_number` computes the same property using a direct sum.
+
+All functions run in O(d) time where d is the number of digits in `n`.
+*/
+
+fun pow_int(base: int, exp: int): int {
+  var result = 1
+  var i = 0
+  while i < exp {
+    result = result * base
+    i = i + 1
+  }
+  return result
+}
+
+fun armstrong_number(n: int): bool {
+  if n < 1 { return false }
+  var digits = 0
+  var temp = n
+  while temp > 0 {
+    temp = temp / 10
+    digits = digits + 1
+  }
+  var total = 0
+  temp = n
+  while temp > 0 {
+    let rem = temp % 10
+    total = total + pow_int(rem, digits)
+    temp = temp / 10
+  }
+  return total == n
+}
+
+fun pluperfect_number(n: int): bool {
+  if n < 1 { return false }
+  var digit_histogram: list<int> = []
+  var i = 0
+  while i < 10 {
+    digit_histogram = append(digit_histogram, 0)
+    i = i + 1
+  }
+  var digit_total = 0
+  var temp = n
+  while temp > 0 {
+    let rem = temp % 10
+    digit_histogram[rem] = digit_histogram[rem] + 1
+    digit_total = digit_total + 1
+    temp = temp / 10
+  }
+  var total = 0
+  i = 0
+  while i < 10 {
+    if digit_histogram[i] > 0 {
+      total = total + digit_histogram[i] * pow_int(i, digit_total)
+    }
+    i = i + 1
+  }
+  return total == n
+}
+
+fun narcissistic_number(n: int): bool {
+  if n < 1 { return false }
+  var digits = 0
+  var temp = n
+  while temp > 0 {
+    temp = temp / 10
+    digits = digits + 1
+  }
+  temp = n
+  var total = 0
+  while temp > 0 {
+    let rem = temp % 10
+    total = total + pow_int(rem, digits)
+    temp = temp / 10
+  }
+  return total == n
+}
+
+print(armstrong_number(371))
+print(armstrong_number(200))
+print(pluperfect_number(371))
+print(pluperfect_number(200))
+print(narcissistic_number(371))
+print(narcissistic_number(200))

--- a/tests/github/TheAlgorithms/Mochi/maths/special_numbers/armstrong_numbers.out
+++ b/tests/github/TheAlgorithms/Mochi/maths/special_numbers/armstrong_numbers.out
@@ -1,0 +1,6 @@
+true
+false
+true
+false
+true
+false

--- a/tests/github/TheAlgorithms/Python/maths/special_numbers/armstrong_numbers.py
+++ b/tests/github/TheAlgorithms/Python/maths/special_numbers/armstrong_numbers.py
@@ -1,0 +1,99 @@
+"""
+An Armstrong number is equal to the sum of its own digits each raised to the
+power of the number of digits.
+
+For example, 370 is an Armstrong number because 3*3*3 + 7*7*7 + 0*0*0 = 370.
+
+Armstrong numbers are also called Narcissistic numbers and Pluperfect numbers.
+
+On-Line Encyclopedia of Integer Sequences entry: https://oeis.org/A005188
+"""
+
+PASSING = (1, 153, 370, 371, 1634, 24678051, 115132219018763992565095597973971522401)
+FAILING: tuple = (-153, -1, 0, 1.2, 200, "A", [], {}, None)
+
+
+def armstrong_number(n: int) -> bool:
+    """
+    Return True if n is an Armstrong number or False if it is not.
+
+    >>> all(armstrong_number(n) for n in PASSING)
+    True
+    >>> any(armstrong_number(n) for n in FAILING)
+    False
+    """
+    if not isinstance(n, int) or n < 1:
+        return False
+
+    # Initialization of sum and number of digits.
+    total = 0
+    number_of_digits = 0
+    temp = n
+    # Calculation of digits of the number
+    number_of_digits = len(str(n))
+    # Dividing number into separate digits and find Armstrong number
+    temp = n
+    while temp > 0:
+        rem = temp % 10
+        total += rem**number_of_digits
+        temp //= 10
+    return n == total
+
+
+def pluperfect_number(n: int) -> bool:
+    """Return True if n is a pluperfect number or False if it is not
+
+    >>> all(pluperfect_number(n) for n in PASSING)
+    True
+    >>> any(pluperfect_number(n) for n in FAILING)
+    False
+    """
+    if not isinstance(n, int) or n < 1:
+        return False
+
+    # Init a "histogram" of the digits
+    digit_histogram = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    digit_total = 0
+    total = 0
+    temp = n
+    while temp > 0:
+        temp, rem = divmod(temp, 10)
+        digit_histogram[rem] += 1
+        digit_total += 1
+
+    for cnt, i in zip(digit_histogram, range(len(digit_histogram))):
+        total += cnt * i**digit_total
+
+    return n == total
+
+
+def narcissistic_number(n: int) -> bool:
+    """Return True if n is a narcissistic number or False if it is not.
+
+    >>> all(narcissistic_number(n) for n in PASSING)
+    True
+    >>> any(narcissistic_number(n) for n in FAILING)
+    False
+    """
+    if not isinstance(n, int) or n < 1:
+        return False
+    expo = len(str(n))  # the power that all digits will be raised to
+    # check if sum of each digit multiplied expo times is equal to number
+    return n == sum(int(i) ** expo for i in str(n))
+
+
+def main():
+    """
+    Request that user input an integer and tell them if it is Armstrong number.
+    """
+    num = int(input("Enter an integer to see if it is an Armstrong number: ").strip())
+    print(f"{num} is {'' if armstrong_number(num) else 'not '}an Armstrong number.")
+    print(f"{num} is {'' if narcissistic_number(num) else 'not '}an Armstrong number.")
+    print(f"{num} is {'' if pluperfect_number(num) else 'not '}an Armstrong number.")
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    main()


### PR DESCRIPTION
## Summary
- add Python reference for Armstrong numbers
- implement Armstrong, pluperfect, and narcissistic number checks in Mochi
- include output from running the Mochi program with sample inputs

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/maths/special_numbers/armstrong_numbers.mochi`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68921237bea083208f9507c19bac26e1