### PR TITLE
Add automorphic number example in Mochi tests

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/maths/special_numbers/automorphic_number.mochi
+++ b/tests/github/TheAlgorithms/Mochi/maths/special_numbers/automorphic_number.mochi
@@ -1,0 +1,31 @@
+/*
+Determine whether a non‑negative integer is an automorphic number.
+
+An automorphic number is one whose square ends with the same digits as the number itself.
+For example: 5^2 = 25 ends with 5, and 376^2 = 141376 ends with 376.
+
+The algorithm squares the number then iteratively compares the least significant digits
+of the original number and the square, stripping one digit on each step. If all compared
+digits match, the number is automorphic. Negative inputs are rejected as non-automorphic.
+This runs in O(log10(n)) time and uses O(1) space.
+*/
+
+fun is_automorphic_number(number: int): bool {
+  if number < 0 { return false }
+  var n = number
+  var sq = number * number
+  while n > 0 {
+    if n % 10 != sq % 10 { return false }
+    n = n / 10
+    sq = sq / 10
+  }
+  return true
+}
+
+print(str(is_automorphic_number(0)))
+print(str(is_automorphic_number(1)))
+print(str(is_automorphic_number(5)))
+print(str(is_automorphic_number(6)))
+print(str(is_automorphic_number(7)))
+print(str(is_automorphic_number(25)))
+print(str(is_automorphic_number(376)))

--- a/tests/github/TheAlgorithms/Mochi/maths/special_numbers/automorphic_number.out
+++ b/tests/github/TheAlgorithms/Mochi/maths/special_numbers/automorphic_number.out
@@ -1,0 +1,7 @@
+true
+true
+true
+true
+false
+true
+true

--- a/tests/github/TheAlgorithms/Python/maths/special_numbers/automorphic_number.py
+++ b/tests/github/TheAlgorithms/Python/maths/special_numbers/automorphic_number.py
@@ -1,0 +1,59 @@
+"""
+== Automorphic Numbers ==
+A number n is said to be a Automorphic number if
+the square of n "ends" in the same digits as n itself.
+
+Examples of Automorphic Numbers: 0, 1, 5, 6, 25, 76, 376, 625, 9376, 90625, ...
+https://en.wikipedia.org/wiki/Automorphic_number
+"""
+
+# Author : Akshay Dubey (https://github.com/itsAkshayDubey)
+# Time Complexity : O(log10n)
+
+
+def is_automorphic_number(number: int) -> bool:
+    """
+    # doctest: +NORMALIZE_WHITESPACE
+    This functions takes an integer number as input.
+    returns True if the number is automorphic.
+    >>> is_automorphic_number(-1)
+    False
+    >>> is_automorphic_number(0)
+    True
+    >>> is_automorphic_number(5)
+    True
+    >>> is_automorphic_number(6)
+    True
+    >>> is_automorphic_number(7)
+    False
+    >>> is_automorphic_number(25)
+    True
+    >>> is_automorphic_number(259918212890625)
+    True
+    >>> is_automorphic_number(259918212890636)
+    False
+    >>> is_automorphic_number(740081787109376)
+    True
+    >>> is_automorphic_number(5.0)
+    Traceback (most recent call last):
+        ...
+    TypeError: Input value of [number=5.0] must be an integer
+    """
+    if not isinstance(number, int):
+        msg = f"Input value of [number={number}] must be an integer"
+        raise TypeError(msg)
+    if number < 0:
+        return False
+    number_square = number * number
+    while number > 0:
+        if number % 10 != number_square % 10:
+            return False
+        number //= 10
+        number_square //= 10
+    return True
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python automorphic number example from TheAlgorithms
- implement automorphic number check in Mochi
- include runtime output for sample inputs

## Testing
- `npm test` *(fails: Missing script "test")*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68921238ed3883208735cc8fb07f3f5c