### PR TITLE
Add Proth number algorithm in Mochi tests

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/maths/special_numbers/proth_number.mochi
+++ b/tests/github/TheAlgorithms/Mochi/maths/special_numbers/proth_number.mochi
@@ -1,0 +1,75 @@
+/*
+Compute the nth Proth number.
+
+A Proth number has the form k * 2^n + 1 where k is odd and k < 2^n.
+The sequence begins 3, 5, 9, 13, 17, 25, ... .
+
+This implementation generates Proth numbers in ascending order using a
+block method similar to the reference Python algorithm:
+1. Prepopulate the list with the first two Proth numbers 3 and 5.
+2. For each block, append numbers offset from the previous ones by a
+   power of two.  The number of elements added doubles each block.
+3. Continue until the requested index is produced.
+
+Time complexity grows roughly O(n) for generating the first n numbers,
+while space complexity is also O(n) to store them.
+*/
+
+fun pow2(exp: int): int {
+  var result = 1
+  var i = 0
+  while i < exp {
+    result = result * 2
+    i = i + 1
+  }
+  return result
+}
+
+fun proth(number: int): int {
+  if number < 1 {
+    panic("Input value must be > 0")
+  }
+  if number == 1 {
+    return 3
+  }
+  if number == 2 {
+    return 5
+  }
+
+  let temp = (number / 3) as int
+  var pow = 1
+  var block_index = 1
+  while pow <= temp {
+    pow = pow * 2
+    block_index = block_index + 1
+  }
+
+  var proth_list: list<int> = [3, 5]
+  var proth_index = 2
+  var increment = 3
+  var block = 1
+  while block < block_index {
+    var i = 0
+    while i < increment {
+      let next_val = pow2(block + 1) + proth_list[proth_index - 1]
+      proth_list = append(proth_list, next_val)
+      proth_index = proth_index + 1
+      i = i + 1
+    }
+    increment = increment * 2
+    block = block + 1
+  }
+
+  return proth_list[number - 1]
+}
+
+fun main() {
+  var n = 1
+  while n <= 10 {
+    let value = proth(n)
+    print("The " + str(n) + "th Proth number: " + str(value))
+    n = n + 1
+  }
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/maths/special_numbers/proth_number.out
+++ b/tests/github/TheAlgorithms/Mochi/maths/special_numbers/proth_number.out
@@ -1,0 +1,10 @@
+The 1th Proth number: 3
+The 2th Proth number: 5
+The 3th Proth number: 9
+The 4th Proth number: 13
+The 5th Proth number: 17
+The 6th Proth number: 25
+The 7th Proth number: 33
+The 8th Proth number: 41
+The 9th Proth number: 49
+The 10th Proth number: 57

--- a/tests/github/TheAlgorithms/Python/maths/special_numbers/proth_number.py
+++ b/tests/github/TheAlgorithms/Python/maths/special_numbers/proth_number.py
@@ -1,0 +1,75 @@
+"""
+Calculate the nth Proth number
+Source:
+    https://handwiki.org/wiki/Proth_number
+"""
+
+import math
+
+
+def proth(number: int) -> int:
+    """
+    :param number: nth number to calculate in the sequence
+    :return: the nth number in Proth number
+    Note: indexing starts at 1 i.e. proth(1) gives the first Proth number of 3
+    >>> proth(6)
+    25
+    >>> proth(0)
+    Traceback (most recent call last):
+        ...
+    ValueError: Input value of [number=0] must be > 0
+    >>> proth(-1)
+    Traceback (most recent call last):
+        ...
+    ValueError: Input value of [number=-1] must be > 0
+    >>> proth(6.0)
+    Traceback (most recent call last):
+        ...
+    TypeError: Input value of [number=6.0] must be an integer
+    """
+
+    if not isinstance(number, int):
+        msg = f"Input value of [number={number}] must be an integer"
+        raise TypeError(msg)
+
+    if number < 1:
+        msg = f"Input value of [number={number}] must be > 0"
+        raise ValueError(msg)
+    elif number == 1:
+        return 3
+    elif number == 2:
+        return 5
+    else:
+        """
+        +1 for binary starting at 0 i.e. 2^0, 2^1, etc.
+        +1 to start the sequence at the 3rd Proth number
+        Hence, we have a +2 in the below statement
+        """
+        block_index = int(math.log(number // 3, 2)) + 2
+
+        proth_list = [3, 5]
+        proth_index = 2
+        increment = 3
+        for block in range(1, block_index):
+            for _ in range(increment):
+                proth_list.append(2 ** (block + 1) + proth_list[proth_index - 1])
+                proth_index += 1
+            increment *= 2
+
+    return proth_list[number - 1]
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+
+    for number in range(11):
+        value = 0
+        try:
+            value = proth(number)
+        except ValueError:
+            print(f"ValueError: there is no {number}th Proth number")
+            continue
+
+        print(f"The {number}th Proth number: {value}")


### PR DESCRIPTION
## Summary
- add missing Python reference for Proth numbers
- implement Proth number generator in Mochi with sample output

## Testing
- `go run ./cmd/mochi/main.go run tests/github/TheAlgorithms/Mochi/maths/special_numbers/proth_number.mochi`

------
https://chatgpt.com/codex/tasks/task_e_689215c3806883209331ce9ad4e4797c