### PR TITLE
Add weird number algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/maths/special_numbers/weird_number.mochi
+++ b/tests/github/TheAlgorithms/Mochi/maths/special_numbers/weird_number.mochi
@@ -1,0 +1,139 @@
+/*
+Weird Number Detection
+----------------------
+A "weird number" is defined as an abundant number that is not semi-perfect.
+An abundant number has the sum of its proper divisors greater than the number
+itself.  A number is semi-perfect if some subset of its proper divisors sums to
+the number.  Numbers satisfying both properties are rare and are known as
+"weird" numbers.  This module mirrors the Python implementation from
+TheAlgorithms and avoids any foreign function interfaces so it can run on the
+runtime/vm.
+
+Algorithm details:
+- `factors(n)` enumerates all positive divisors of `n` excluding `n` itself.
+  It iterates up to the square root of `n`, collecting factor pairs and finally
+  sorting the list using bubble sort.  For `n <= 1` it returns `[1]`.
+- `abundant(n)` computes the sum of the factors and checks if it exceeds `n`.
+- `semi_perfect(n)` solves the subset sum problem on the list of factors using
+  dynamic programming.  A boolean array `possible` tracks achievable sums.  The
+  number is semi-perfect if `possible[n]` becomes true.
+- `weird(n)` returns `true` if `n` is abundant but not semi-perfect.
+
+Time Complexity:
+- Factor enumeration runs in O(sqrt(n)).
+- Semi-perfect detection runs in O(k * n) where k is the number of factors.
+*/
+
+fun bubble_sort(xs: list<int>): list<int> {
+  var arr = xs
+  var n = len(arr)
+  var i = 0
+  while i < n {
+    var j = 0
+    while j < n - i - 1 {
+      if arr[j] > arr[j + 1] {
+        let tmp = arr[j]
+        arr[j] = arr[j + 1]
+        arr[j + 1] = tmp
+      }
+      j = j + 1
+    }
+    i = i + 1
+  }
+  return arr
+}
+
+fun factors(num: int): list<int> {
+  var values: list<int> = [1]
+  var i = 2
+  while i * i <= num {
+    if num % i == 0 {
+      values = append(values, i)
+      let d = num / i
+      if d != i {
+        values = append(values, d)
+      }
+    }
+    i = i + 1
+  }
+  return bubble_sort(values)
+}
+
+fun sum_list(xs: list<int>): int {
+  var total = 0
+  var i = 0
+  while i < len(xs) {
+    total = total + xs[i]
+    i = i + 1
+  }
+  return total
+}
+
+fun abundant(n: int): bool {
+  return sum_list(factors(n)) > n
+}
+
+fun semi_perfect(number: int): bool {
+  if number <= 0 {
+    return true
+  }
+  let values = factors(number)
+  var possible: list<bool> = []
+  var j = 0
+  while j <= number {
+    possible = append(possible, j == 0)
+    j = j + 1
+  }
+  var idx = 0
+  while idx < len(values) {
+    let v = values[idx]
+    var s = number
+    while s >= v {
+      if possible[s - v] {
+        possible[s] = true
+      }
+      s = s - 1
+    }
+    idx = idx + 1
+  }
+  return possible[number]
+}
+
+fun weird(number: int): bool {
+  return abundant(number) && semi_perfect(number) == false
+}
+
+fun run_tests() {
+  if factors(12) != [1, 2, 3, 4, 6] { panic("factors 12 failed") }
+  if factors(1) != [1] { panic("factors 1 failed") }
+  if factors(100) != [1, 2, 4, 5, 10, 20, 25, 50] { panic("factors 100 failed") }
+  if abundant(0) != true { panic("abundant 0 failed") }
+  if abundant(1) != false { panic("abundant 1 failed") }
+  if abundant(12) != true { panic("abundant 12 failed") }
+  if abundant(13) != false { panic("abundant 13 failed") }
+  if abundant(20) != true { panic("abundant 20 failed") }
+  if semi_perfect(0) != true { panic("semi_perfect 0 failed") }
+  if semi_perfect(1) != true { panic("semi_perfect 1 failed") }
+  if semi_perfect(12) != true { panic("semi_perfect 12 failed") }
+  if semi_perfect(13) != false { panic("semi_perfect 13 failed") }
+  if weird(0) != false { panic("weird 0 failed") }
+  if weird(70) != true { panic("weird 70 failed") }
+  if weird(77) != false { panic("weird 77 failed") }
+}
+
+fun main() {
+  run_tests()
+  let nums: list<int> = [69, 70, 71]
+  var i = 0
+  while i < len(nums) {
+    let n = nums[i]
+    if weird(n) {
+      print(str(n) + " is weird.")
+    } else {
+      print(str(n) + " is not weird.")
+    }
+    i = i + 1
+  }
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/maths/special_numbers/weird_number.out
+++ b/tests/github/TheAlgorithms/Mochi/maths/special_numbers/weird_number.out
@@ -1,0 +1,3 @@
+69 is not weird.
+70 is weird.
+71 is not weird.

--- a/tests/github/TheAlgorithms/Python/maths/special_numbers/weird_number.py
+++ b/tests/github/TheAlgorithms/Python/maths/special_numbers/weird_number.py
@@ -1,0 +1,101 @@
+"""
+https://en.wikipedia.org/wiki/Weird_number
+
+Fun fact: The set of weird numbers has positive asymptotic density.
+"""
+
+from math import sqrt
+
+
+def factors(number: int) -> list[int]:
+    """
+    >>> factors(12)
+    [1, 2, 3, 4, 6]
+    >>> factors(1)
+    [1]
+    >>> factors(100)
+    [1, 2, 4, 5, 10, 20, 25, 50]
+
+    # >>> factors(-12)
+    # [1, 2, 3, 4, 6]
+    """
+
+    values = [1]
+    for i in range(2, int(sqrt(number)) + 1, 1):
+        if number % i == 0:
+            values.append(i)
+            if int(number // i) != i:
+                values.append(int(number // i))
+    return sorted(values)
+
+
+def abundant(n: int) -> bool:
+    """
+    >>> abundant(0)
+    True
+    >>> abundant(1)
+    False
+    >>> abundant(12)
+    True
+    >>> abundant(13)
+    False
+    >>> abundant(20)
+    True
+
+    # >>> abundant(-12)
+    # True
+    """
+    return sum(factors(n)) > n
+
+
+def semi_perfect(number: int) -> bool:
+    """
+    >>> semi_perfect(0)
+    True
+    >>> semi_perfect(1)
+    True
+    >>> semi_perfect(12)
+    True
+    >>> semi_perfect(13)
+    False
+
+    # >>> semi_perfect(-12)
+    # True
+    """
+    values = factors(number)
+    r = len(values)
+    subset = [[0 for i in range(number + 1)] for j in range(r + 1)]
+    for i in range(r + 1):
+        subset[i][0] = True
+
+    for i in range(1, number + 1):
+        subset[0][i] = False
+
+    for i in range(1, r + 1):
+        for j in range(1, number + 1):
+            if j < values[i - 1]:
+                subset[i][j] = subset[i - 1][j]
+            else:
+                subset[i][j] = subset[i - 1][j] or subset[i - 1][j - values[i - 1]]
+
+    return subset[r][number] != 0
+
+
+def weird(number: int) -> bool:
+    """
+    >>> weird(0)
+    False
+    >>> weird(70)
+    True
+    >>> weird(77)
+    False
+    """
+    return abundant(number) and not semi_perfect(number)
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod(verbose=True)
+    for number in (69, 70, 71):
+        print(f"{number} is {'' if weird(number) else 'not '}weird.")


### PR DESCRIPTION
## Summary
- add missing Python implementation for Weird Number detection
- port Weird Number detection to Mochi with bubble sort factor enumeration and subset-sum DP
- include runtime/vm output for sample numbers

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/maths/special_numbers/weird_number.mochi`

------
https://chatgpt.com/codex/tasks/task_e_689215c8421c8320b26834bc56dac93f