### PR TITLE
Add Mochi version of Sudoku board validation algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/matrix/validate_sudoku_board.mochi
+++ b/tests/github/TheAlgorithms/Mochi/matrix/validate_sudoku_board.mochi
@@ -1,0 +1,82 @@
+/*
+Validate Sudoku Board
+
+Given a partially filled 9x9 Sudoku grid represented by digits "1"-"9" and ".",
+this program checks whether the board is valid. A board is valid if each row,
+column and each of the nine 3x3 sub-boxes contains no repeated digits. Empty
+cells denoted by '.' are ignored. The algorithm scans all cells while tracking
+seen digits for every row, column and box using lists to emulate sets. If a digit
+reappears in its row, column or box, the board is invalid.
+
+Time complexity: O(81) because the board has fixed size.
+Space complexity: O(81) for the tracking structures.
+*/
+
+let NUM_SQUARES = 9
+let EMPTY_CELL = "."
+
+fun is_valid_sudoku_board(board: list<list<string>>): bool {
+  if len(board) != NUM_SQUARES {
+    return false
+  }
+  var i = 0
+  while i < NUM_SQUARES {
+    if len(board[i]) != NUM_SQUARES {
+      return false
+    }
+    i = i + 1
+  }
+  var rows: list<list<string>> = []
+  var cols: list<list<string>> = []
+  var boxes: list<list<string>> = []
+  i = 0
+  while i < NUM_SQUARES {
+    rows = append(rows, [])
+    cols = append(cols, [])
+    boxes = append(boxes, [])
+    i = i + 1
+  }
+  for r in 0..NUM_SQUARES {
+    for c in 0..NUM_SQUARES {
+      let value = board[r][c]
+      if value == EMPTY_CELL {
+        continue
+      }
+      let box: int = int(r / 3) * 3 + int(c / 3)
+      if value in rows[r] || value in cols[c] || value in boxes[box] {
+        return false
+      }
+      rows[r] = append(rows[r], value)
+      cols[c] = append(cols[c], value)
+      boxes[box] = append(boxes[box], value)
+    }
+  }
+  return true
+}
+
+let valid_board: list<list<string>> = [
+  ["5","3",".",".","7",".",".",".","."],
+  ["6",".",".","1","9","5",".",".","."],
+  [".","9","8",".",".",".",".","6","."],
+  ["8",".",".",".","6",".",".",".","3"],
+  ["4",".",".","8",".","3",".",".","1"],
+  ["7",".",".",".","2",".",".",".","6"],
+  [".","6",".",".",".",".","2","8","."],
+  [".",".",".","4","1","9",".",".","5"],
+  [".",".",".",".","8",".",".","7","9"]
+]
+
+let invalid_board: list<list<string>> = [
+  ["8","3",".",".","7",".",".",".","."],
+  ["6",".",".","1","9","5",".",".","."],
+  [".","9","8",".",".",".",".","6","."],
+  ["8",".",".",".","6",".",".",".","3"],
+  ["4",".",".","8",".","3",".",".","1"],
+  ["7",".",".",".","2",".",".",".","6"],
+  [".","6",".",".",".",".","2","8","."],
+  [".",".",".","4","1","9",".",".","5"],
+  [".",".",".",".","8",".",".","7","9"]
+]
+
+print(is_valid_sudoku_board(valid_board))
+print(is_valid_sudoku_board(invalid_board))

--- a/tests/github/TheAlgorithms/Mochi/matrix/validate_sudoku_board.out
+++ b/tests/github/TheAlgorithms/Mochi/matrix/validate_sudoku_board.out
@@ -1,0 +1,2 @@
+true
+false

--- a/tests/github/TheAlgorithms/Python/matrix/validate_sudoku_board.py
+++ b/tests/github/TheAlgorithms/Python/matrix/validate_sudoku_board.py
@@ -1,0 +1,167 @@
+"""
+LeetCode 36. Valid Sudoku
+https://leetcode.com/problems/valid-sudoku/
+https://en.wikipedia.org/wiki/Sudoku
+
+Determine if a 9 x 9 Sudoku board is valid. Only the filled cells need to be
+validated according to the following rules:
+
+- Each row must contain the digits 1-9 without repetition.
+- Each column must contain the digits 1-9 without repetition.
+- Each of the nine 3 x 3 sub-boxes of the grid must contain the digits 1-9
+  without repetition.
+
+Note:
+
+A Sudoku board (partially filled) could be valid but is not necessarily
+solvable.
+
+Only the filled cells need to be validated according to the mentioned rules.
+"""
+
+from collections import defaultdict
+
+NUM_SQUARES = 9
+EMPTY_CELL = "."
+
+
+def is_valid_sudoku_board(sudoku_board: list[list[str]]) -> bool:
+    """
+    This function validates (but does not solve) a sudoku board.
+    The board may be valid but unsolvable.
+
+    >>> is_valid_sudoku_board([
+    ...  ["5","3",".",".","7",".",".",".","."]
+    ... ,["6",".",".","1","9","5",".",".","."]
+    ... ,[".","9","8",".",".",".",".","6","."]
+    ... ,["8",".",".",".","6",".",".",".","3"]
+    ... ,["4",".",".","8",".","3",".",".","1"]
+    ... ,["7",".",".",".","2",".",".",".","6"]
+    ... ,[".","6",".",".",".",".","2","8","."]
+    ... ,[".",".",".","4","1","9",".",".","5"]
+    ... ,[".",".",".",".","8",".",".","7","9"]
+    ... ])
+    True
+    >>> is_valid_sudoku_board([
+    ...  ["8","3",".",".","7",".",".",".","."]
+    ... ,["6",".",".","1","9","5",".",".","."]
+    ... ,[".","9","8",".",".",".",".","6","."]
+    ... ,["8",".",".",".","6",".",".",".","3"]
+    ... ,["4",".",".","8",".","3",".",".","1"]
+    ... ,["7",".",".",".","2",".",".",".","6"]
+    ... ,[".","6",".",".",".",".","2","8","."]
+    ... ,[".",".",".","4","1","9",".",".","5"]
+    ... ,[".",".",".",".","8",".",".","7","9"]
+    ... ])
+    False
+    >>> is_valid_sudoku_board([
+    ...  ["1","2","3","4","5","6","7","8","9"]
+    ... ,["4","5","6","7","8","9","1","2","3"]
+    ... ,["7","8","9","1","2","3","4","5","6"]
+    ... ,[".",".",".",".",".",".",".",".","."]
+    ... ,[".",".",".",".",".",".",".",".","."]
+    ... ,[".",".",".",".",".",".",".",".","."]
+    ... ,[".",".",".",".",".",".",".",".","."]
+    ... ,[".",".",".",".",".",".",".",".","."]
+    ... ,[".",".",".",".",".",".",".",".","."]
+    ... ])
+    True
+    >>> is_valid_sudoku_board([
+    ...  ["1","2","3",".",".",".",".",".","."]
+    ... ,["4","5","6",".",".",".",".",".","."]
+    ... ,["7","8","9",".",".",".",".",".","."]
+    ... ,[".",".",".","4","5","6",".",".","."]
+    ... ,[".",".",".","7","8","9",".",".","."]
+    ... ,[".",".",".","1","2","3",".",".","."]
+    ... ,[".",".",".",".",".",".","7","8","9"]
+    ... ,[".",".",".",".",".",".","1","2","3"]
+    ... ,[".",".",".",".",".",".","4","5","6"]
+    ... ])
+    True
+    >>> is_valid_sudoku_board([
+    ...  ["1","2","3",".",".",".","5","6","4"]
+    ... ,["4","5","6",".",".",".","8","9","7"]
+    ... ,["7","8","9",".",".",".","2","3","1"]
+    ... ,[".",".",".","4","5","6",".",".","."]
+    ... ,[".",".",".","7","8","9",".",".","."]
+    ... ,[".",".",".","1","2","3",".",".","."]
+    ... ,["3","1","2",".",".",".","7","8","9"]
+    ... ,["6","4","5",".",".",".","1","2","3"]
+    ... ,["9","7","8",".",".",".","4","5","6"]
+    ... ])
+    True
+    >>> is_valid_sudoku_board([
+    ...  ["1","2","3","4","5","6","7","8","9"]
+    ... ,["2",".",".",".",".",".",".",".","8"]
+    ... ,["3",".",".",".",".",".",".",".","7"]
+    ... ,["4",".",".",".",".",".",".",".","6"]
+    ... ,["5",".",".",".",".",".",".",".","5"]
+    ... ,["6",".",".",".",".",".",".",".","4"]
+    ... ,["7",".",".",".",".",".",".",".","3"]
+    ... ,["8",".",".",".",".",".",".",".","2"]
+    ... ,["9","8","7","6","5","4","3","2","1"]
+    ... ])
+    False
+    >>> is_valid_sudoku_board([
+    ...  ["1","2","3","8","9","7","5","6","4"]
+    ... ,["4","5","6","2","3","1","8","9","7"]
+    ... ,["7","8","9","5","6","4","2","3","1"]
+    ... ,["2","3","1","4","5","6","9","7","8"]
+    ... ,["5","6","4","7","8","9","3","1","2"]
+    ... ,["8","9","7","1","2","3","6","4","5"]
+    ... ,["3","1","2","6","4","5","7","8","9"]
+    ... ,["6","4","5","9","7","8","1","2","3"]
+    ... ,["9","7","8","3","1","2","4","5","6"]
+    ... ])
+    True
+    >>> is_valid_sudoku_board([["1", "2", "3", "4", "5", "6", "7", "8", "9"]])
+    Traceback (most recent call last):
+        ...
+    ValueError: Sudoku boards must be 9x9 squares.
+    >>> is_valid_sudoku_board(
+    ...        [["1"], ["2"], ["3"], ["4"], ["5"], ["6"], ["7"], ["8"], ["9"]]
+    ...  )
+    Traceback (most recent call last):
+        ...
+    ValueError: Sudoku boards must be 9x9 squares.
+    """
+    if len(sudoku_board) != NUM_SQUARES or (
+        any(len(row) != NUM_SQUARES for row in sudoku_board)
+    ):
+        error_message = f"Sudoku boards must be {NUM_SQUARES}x{NUM_SQUARES} squares."
+        raise ValueError(error_message)
+
+    row_values: defaultdict[int, set[str]] = defaultdict(set)
+    col_values: defaultdict[int, set[str]] = defaultdict(set)
+    box_values: defaultdict[tuple[int, int], set[str]] = defaultdict(set)
+
+    for row in range(NUM_SQUARES):
+        for col in range(NUM_SQUARES):
+            value = sudoku_board[row][col]
+
+            if value == EMPTY_CELL:
+                continue
+
+            box = (row // 3, col // 3)
+
+            if (
+                value in row_values[row]
+                or value in col_values[col]
+                or value in box_values[box]
+            ):
+                return False
+
+            row_values[row].add(value)
+            col_values[col].add(value)
+            box_values[box].add(value)
+
+    return True
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+    from timeit import timeit
+
+    testmod()
+    print(timeit("is_valid_sudoku_board(valid_board)", globals=globals()))
+    print(timeit("is_valid_sudoku_board(invalid_board)", globals=globals()))


### PR DESCRIPTION
## Summary
- add missing Python source for Sudoku board validation
- implement Sudoku board validator in Mochi using list-based sets
- include runtime output demonstrating valid vs invalid boards

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/matrix/validate_sudoku_board.mochi > tests/github/TheAlgorithms/Mochi/matrix/validate_sudoku_board.out`
- `cat tests/github/TheAlgorithms/Mochi/matrix/validate_sudoku_board.out`

------
https://chatgpt.com/codex/tasks/task_e_68922089a5308320b13cd130b87175d5