### PR TITLE
Add Mochi implementation of activity selection problem

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/other/activity_selection.mochi
+++ b/tests/github/TheAlgorithms/Mochi/other/activity_selection.mochi
@@ -1,0 +1,33 @@
+/*
+Activity Selection Problem
+--------------------------
+Given a list of activities with start and finish times already sorted by
+finish time, choose the maximum number of activities that can be performed by
+one person assuming a person can only work on a single activity at a time.
+
+The greedy algorithm chooses the first activity and then iteratively selects
+the next activity with a start time greater than or equal to the finish time
+of the last selected activity. This implementation prints the indices of the
+selected activities for a given start and finish time list.
+*/
+
+fun print_max_activities(start: list<int>, finish: list<int>): unit {
+    let n: int = len(finish)
+    print("The following activities are selected:")
+
+    var i: int = 0
+    var result: string = "0,"
+    var j: int = 1
+    while j < n {
+        if start[j] >= finish[i] {
+            result = result + str(j) + ","
+            i = j
+        }
+        j = j + 1
+    }
+    print(result)
+}
+
+let start: list<int> = [1, 3, 0, 5, 8, 5]
+let finish: list<int> = [2, 4, 6, 7, 9, 9]
+print_max_activities(start, finish)

--- a/tests/github/TheAlgorithms/Mochi/other/activity_selection.mochi.out
+++ b/tests/github/TheAlgorithms/Mochi/other/activity_selection.mochi.out
@@ -1,0 +1,2 @@
+The following activities are selected:
+0,1,3,4,

--- a/tests/github/TheAlgorithms/Python/other/activity_selection.py
+++ b/tests/github/TheAlgorithms/Python/other/activity_selection.py
@@ -1,0 +1,43 @@
+"""The following implementation assumes that the activities
+are already sorted according to their finish time"""
+
+"""Prints a maximum set of activities that can be done by a
+single person, one at a time"""
+# n --> Total number of activities
+# start[]--> An array that contains start time of all activities
+# finish[] --> An array that contains finish time of all activities
+
+
+def print_max_activities(start: list[int], finish: list[int]) -> None:
+    """
+    >>> start = [1, 3, 0, 5, 8, 5]
+    >>> finish = [2, 4, 6, 7, 9, 9]
+    >>> print_max_activities(start, finish)
+    The following activities are selected:
+    0,1,3,4,
+    """
+    n = len(finish)
+    print("The following activities are selected:")
+
+    # The first activity is always selected
+    i = 0
+    print(i, end=",")
+
+    # Consider rest of the activities
+    for j in range(n):
+        # If this activity has start time greater than
+        # or equal to the finish time of previously
+        # selected activity, then select it
+        if start[j] >= finish[i]:
+            print(j, end=",")
+            i = j
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+
+    start = [1, 3, 0, 5, 8, 5]
+    finish = [2, 4, 6, 7, 9, 9]
+    print_max_activities(start, finish)


### PR DESCRIPTION
## Summary
- add missing Python reference implementation of activity selection
- implement greedy activity selection algorithm in Mochi and run with runtime/vm
- include generated program output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/other/activity_selection.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892210138ec8320b3eecd90438fe8a4