### PR TITLE
Add Mochi version of Gauss Easter algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/other/gauss_easter.mochi
+++ b/tests/github/TheAlgorithms/Mochi/other/gauss_easter.mochi
@@ -1,0 +1,60 @@
+/*
+Gauss's Easter algorithm computes the date of Easter Sunday for a given year
+in the Gregorian calendar. The method uses modular arithmetic to approximate
+the Paschal full moon and then finds the following Sunday. Steps:
+
+1. Compute remainders of the year for the 19-year Metonic cycle, the 4-year
+   leap-year cycle and the 7-day week.
+2. Adjust these values with century-based corrections for Gregorian leap year
+   rules.
+3. Determine the offset to the Paschal full moon and the days from that moon to
+   Sunday.
+4. Special cases move Easter from April 19 or April 18 when the calculated full
+   moon falls too late in the calendar.
+5. Otherwise add the offsets to March 22 to obtain the month and day.
+
+The algorithm runs in constant time using only integer and floating-point
+arithmetic.
+*/
+
+type EasterDate = { month: int, day: int }
+
+fun gauss_easter(year: int): EasterDate {
+  let metonic_cycle = year % 19
+  let julian_leap_year = year % 4
+  let non_leap_year = year % 7
+  let leap_day_inhibits = year / 100
+  let lunar_orbit_correction = (13 + 8 * leap_day_inhibits) / 25
+  let leap_day_reinstall_number = (leap_day_inhibits as float) / 4.0
+  let secular_moon_shift = (15.0 - (lunar_orbit_correction as float) + (leap_day_inhibits as float) - leap_day_reinstall_number) % 30.0
+  let century_starting_point = (4.0 + (leap_day_inhibits as float) - leap_day_reinstall_number) % 7.0
+  let days_to_add = (19.0 * (metonic_cycle as float) + secular_moon_shift) % 30.0
+  let days_from_phm_to_sunday = (2.0 * (julian_leap_year as float) + 4.0 * (non_leap_year as float) + 6.0 * days_to_add + century_starting_point) % 7.0
+  if days_to_add == 29.0 && days_from_phm_to_sunday == 6.0 {
+    return EasterDate{ month: 4, day: 19 }
+  }
+  if days_to_add == 28.0 && days_from_phm_to_sunday == 6.0 {
+    return EasterDate{ month: 4, day: 18 }
+  }
+  let offset = (days_to_add + days_from_phm_to_sunday) as int
+  let total = 22 + offset
+  if total > 31 {
+    return EasterDate{ month: 4, day: total - 31 }
+  }
+  return EasterDate{ month: 3, day: total }
+}
+
+fun format_date(year: int, d: EasterDate): string {
+  let month = if d.month < 10 { "0" + str(d.month) } else { str(d.month) }
+  let day = if d.day < 10 { "0" + str(d.day) } else { str(d.day) }
+  return str(year) + "-" + month + "-" + day
+}
+
+let years = [1994, 2000, 2010, 2021, 2023, 2032, 2100]
+var i = 0
+while i < len(years) {
+  let y = years[i]
+  let e = gauss_easter(y)
+  print("Easter in " + str(y) + " is " + format_date(y, e))
+  i = i + 1
+}

--- a/tests/github/TheAlgorithms/Mochi/other/gauss_easter.out
+++ b/tests/github/TheAlgorithms/Mochi/other/gauss_easter.out
@@ -1,0 +1,7 @@
+Easter in 1994 is 1994-03-28
+Easter in 2000 is 2000-04-23
+Easter in 2010 is 2010-04-04
+Easter in 2021 is 2021-04-04
+Easter in 2023 is 2023-04-09
+Easter in 2032 is 2032-03-28
+Easter in 2100 is 2100-03-26

--- a/tests/github/TheAlgorithms/Python/other/gauss_easter.py
+++ b/tests/github/TheAlgorithms/Python/other/gauss_easter.py
@@ -1,0 +1,60 @@
+"""
+https://en.wikipedia.org/wiki/Computus#Gauss'_Easter_algorithm
+"""
+
+import math
+from datetime import UTC, datetime, timedelta
+
+
+def gauss_easter(year: int) -> datetime:
+    """
+    Calculation Gregorian easter date for given year
+
+    >>> gauss_easter(2007)
+    datetime.datetime(2007, 4, 8, 0, 0, tzinfo=datetime.timezone.utc)
+
+    >>> gauss_easter(2008)
+    datetime.datetime(2008, 3, 23, 0, 0, tzinfo=datetime.timezone.utc)
+
+    >>> gauss_easter(2020)
+    datetime.datetime(2020, 4, 12, 0, 0, tzinfo=datetime.timezone.utc)
+
+    >>> gauss_easter(2021)
+    datetime.datetime(2021, 4, 4, 0, 0, tzinfo=datetime.timezone.utc)
+    """
+    metonic_cycle = year % 19
+    julian_leap_year = year % 4
+    non_leap_year = year % 7
+    leap_day_inhibits = math.floor(year / 100)
+    lunar_orbit_correction = math.floor((13 + 8 * leap_day_inhibits) / 25)
+    leap_day_reinstall_number = leap_day_inhibits / 4
+    secular_moon_shift = (
+        15 - lunar_orbit_correction + leap_day_inhibits - leap_day_reinstall_number
+    ) % 30
+    century_starting_point = (4 + leap_day_inhibits - leap_day_reinstall_number) % 7
+
+    # days to be added to March 21
+    days_to_add = (19 * metonic_cycle + secular_moon_shift) % 30
+
+    # PHM -> Paschal Full Moon
+    days_from_phm_to_sunday = (
+        2 * julian_leap_year
+        + 4 * non_leap_year
+        + 6 * days_to_add
+        + century_starting_point
+    ) % 7
+
+    if days_to_add == 29 and days_from_phm_to_sunday == 6:
+        return datetime(year, 4, 19, tzinfo=UTC)
+    elif days_to_add == 28 and days_from_phm_to_sunday == 6:
+        return datetime(year, 4, 18, tzinfo=UTC)
+    else:
+        return datetime(year, 3, 22, tzinfo=UTC) + timedelta(
+            days=int(days_to_add + days_from_phm_to_sunday)
+        )
+
+
+if __name__ == "__main__":
+    for year in (1994, 2000, 2010, 2021, 2023, 2032, 2100):
+        tense = "will be" if year > datetime.now(tz=UTC).year else "was"
+        print(f"Easter in {year} {tense} {gauss_easter(year)}")


### PR DESCRIPTION
## Summary
- add missing Python implementation for Gauss Easter algorithm
- implement Gauss Easter calculation in Mochi
- run Mochi program with runtime/vm and record sample outputs

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/other/gauss_easter.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6892246194048320970fc97e3f821697