### PR TITLE
Add Mochi LFU cache implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/other/lfu_cache.mochi
+++ b/tests/github/TheAlgorithms/Mochi/other/lfu_cache.mochi
@@ -1,0 +1,158 @@
+/*
+LFU (Least Frequently Used) cache implemented using a list of entries.
+Each entry stores a key, value, access frequency, and an order counter
+used to break ties.  On every access the frequency increases and the
+order counter is updated.  When capacity is exceeded the entry with the
+lowest frequency (and oldest order on ties) is evicted.
+
+This is a simplified equivalent of the Python implementation from
+TheAlgorithms/Python.  It avoids external libraries and is written in
+pure Mochi without any use of dynamic types.
+*/
+
+type Entry {
+  key: int,
+  val: int,
+  freq: int,
+  order: int,
+}
+
+type LFUCache {
+  entries: list<Entry>,
+  capacity: int,
+  hits: int,
+  miss: int,
+  tick: int,
+}
+
+type GetResult {
+  cache: LFUCache,
+  value: int,
+  ok: bool,
+}
+
+fun lfu_new(cap: int): LFUCache {
+  return LFUCache { entries: [], capacity: cap, hits: 0, miss: 0, tick: 0 }
+}
+
+fun find_entry(entries: list<Entry>, key: int): int {
+  var i = 0
+  while i < len(entries) {
+    let e = entries[i]
+    if e.key == key { return i }
+    i = i + 1
+  }
+  return 0 - 1
+}
+
+fun lfu_get(cache: LFUCache, key: int): GetResult {
+  let idx = find_entry(cache.entries, key)
+  if idx == 0 - 1 {
+    let new_cache = LFUCache {
+      entries: cache.entries,
+      capacity: cache.capacity,
+      hits: cache.hits,
+      miss: cache.miss + 1,
+      tick: cache.tick,
+    }
+    return GetResult { cache: new_cache, value: 0, ok: false }
+  }
+  var entries = cache.entries
+  var e = entries[idx]
+  e.freq = e.freq + 1
+  let new_tick = cache.tick + 1
+  e.order = new_tick
+  entries[idx] = e
+  let new_cache = LFUCache {
+    entries: entries,
+    capacity: cache.capacity,
+    hits: cache.hits + 1,
+    miss: cache.miss,
+    tick: new_tick,
+  }
+  return GetResult { cache: new_cache, value: e.val, ok: true }
+}
+
+fun remove_lfu(entries: list<Entry>): list<Entry> {
+  if len(entries) == 0 { return entries }
+  var min_idx = 0
+  var i = 1
+  while i < len(entries) {
+    let e = entries[i]
+    let m = entries[min_idx]
+    if e.freq < m.freq || (e.freq == m.freq && e.order < m.order) {
+      min_idx = i
+    }
+    i = i + 1
+  }
+  var res: list<Entry> = []
+  var j = 0
+  while j < len(entries) {
+    if j != min_idx { res = append(res, entries[j]) }
+    j = j + 1
+  }
+  return res
+}
+
+fun lfu_put(cache: LFUCache, key: int, value: int): LFUCache {
+  var entries = cache.entries
+  let idx = find_entry(entries, key)
+  if idx != 0 - 1 {
+    var e = entries[idx]
+    e.val = value
+    e.freq = e.freq + 1
+    let new_tick = cache.tick + 1
+    e.order = new_tick
+    entries[idx] = e
+    return LFUCache {
+      entries: entries,
+      capacity: cache.capacity,
+      hits: cache.hits,
+      miss: cache.miss,
+      tick: new_tick,
+    }
+  }
+  if len(entries) >= cache.capacity {
+    entries = remove_lfu(entries)
+  }
+  let new_tick = cache.tick + 1
+  let new_entry = Entry { key: key, val: value, freq: 1, order: new_tick }
+  entries = append(entries, new_entry)
+  return LFUCache {
+    entries: entries,
+    capacity: cache.capacity,
+    hits: cache.hits,
+    miss: cache.miss,
+    tick: new_tick,
+  }
+}
+
+fun cache_info(cache: LFUCache): string {
+  return "CacheInfo(hits=" + str(cache.hits) + ", misses=" + str(cache.miss) + ", capacity=" + str(cache.capacity) + ", current_size=" + str(len(cache.entries)) + ")"
+}
+
+fun main() {
+  var cache = lfu_new(2)
+  cache = lfu_put(cache, 1, 1)
+  cache = lfu_put(cache, 2, 2)
+  var r = lfu_get(cache, 1)
+  cache = r.cache
+  if r.ok { print(str(r.value)) } else { print("None") }
+  cache = lfu_put(cache, 3, 3)
+  r = lfu_get(cache, 2)
+  cache = r.cache
+  if r.ok { print(str(r.value)) } else { print("None") }
+  cache = lfu_put(cache, 4, 4)
+  r = lfu_get(cache, 1)
+  cache = r.cache
+  if r.ok { print(str(r.value)) } else { print("None") }
+  r = lfu_get(cache, 3)
+  cache = r.cache
+  if r.ok { print(str(r.value)) } else { print("None") }
+  r = lfu_get(cache, 4)
+  cache = r.cache
+  if r.ok { print(str(r.value)) } else { print("None") }
+  print(cache_info(cache))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/other/lfu_cache.out
+++ b/tests/github/TheAlgorithms/Mochi/other/lfu_cache.out
@@ -1,0 +1,6 @@
+1
+None
+1
+None
+4
+CacheInfo(hits=3, misses=2, capacity=2, current_size=2)

--- a/tests/github/TheAlgorithms/Python/other/lfu_cache.py
+++ b/tests/github/TheAlgorithms/Python/other/lfu_cache.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+class DoubleLinkedListNode[T, U]:
+    """
+    Double Linked List Node built specifically for LFU Cache
+
+    >>> node = DoubleLinkedListNode(1,1)
+    >>> node
+    Node: key: 1, val: 1, freq: 0, has next: False, has prev: False
+    """
+
+    def __init__(self, key: T | None, val: U | None):
+        self.key = key
+        self.val = val
+        self.freq: int = 0
+        self.next: DoubleLinkedListNode[T, U] | None = None
+        self.prev: DoubleLinkedListNode[T, U] | None = None
+
+    def __repr__(self) -> str:
+        return (
+            f"Node: key: {self.key}, val: {self.val}, freq: {self.freq}, "
+            f"has next: {self.next is not None}, has prev: {self.prev is not None}"
+        )
+
+
+class DoubleLinkedList[T, U]:
+    """
+    Double Linked List built specifically for LFU Cache
+
+    >>> dll: DoubleLinkedList = DoubleLinkedList()
+    >>> dll
+    DoubleLinkedList,
+        Node: key: None, val: None, freq: 0, has next: True, has prev: False,
+        Node: key: None, val: None, freq: 0, has next: False, has prev: True
+
+    >>> first_node = DoubleLinkedListNode(1,10)
+    >>> first_node
+    Node: key: 1, val: 10, freq: 0, has next: False, has prev: False
+
+
+    >>> dll.add(first_node)
+    >>> dll
+    DoubleLinkedList,
+        Node: key: None, val: None, freq: 0, has next: True, has prev: False,
+        Node: key: 1, val: 10, freq: 1, has next: True, has prev: True,
+        Node: key: None, val: None, freq: 0, has next: False, has prev: True
+
+    >>> # node is mutated
+    >>> first_node
+    Node: key: 1, val: 10, freq: 1, has next: True, has prev: True
+
+    >>> second_node = DoubleLinkedListNode(2,20)
+    >>> second_node
+    Node: key: 2, val: 20, freq: 0, has next: False, has prev: False
+
+    >>> dll.add(second_node)
+    >>> dll
+    DoubleLinkedList,
+        Node: key: None, val: None, freq: 0, has next: True, has prev: False,
+        Node: key: 1, val: 10, freq: 1, has next: True, has prev: True,
+        Node: key: 2, val: 20, freq: 1, has next: True, has prev: True,
+        Node: key: None, val: None, freq: 0, has next: False, has prev: True
+
+    >>> removed_node = dll.remove(first_node)
+    >>> assert removed_node == first_node
+    >>> dll
+    DoubleLinkedList,
+        Node: key: None, val: None, freq: 0, has next: True, has prev: False,
+        Node: key: 2, val: 20, freq: 1, has next: True, has prev: True,
+        Node: key: None, val: None, freq: 0, has next: False, has prev: True
+
+
+    >>> # Attempt to remove node not on list
+    >>> removed_node = dll.remove(first_node)
+    >>> removed_node is None
+    True
+
+    >>> # Attempt to remove head or rear
+    >>> dll.head
+    Node: key: None, val: None, freq: 0, has next: True, has prev: False
+    >>> dll.remove(dll.head) is None
+    True
+
+    >>> # Attempt to remove head or rear
+    >>> dll.rear
+    Node: key: None, val: None, freq: 0, has next: False, has prev: True
+    >>> dll.remove(dll.rear) is None
+    True
+
+
+    """
+
+    def __init__(self) -> None:
+        self.head: DoubleLinkedListNode[T, U] = DoubleLinkedListNode(None, None)
+        self.rear: DoubleLinkedListNode[T, U] = DoubleLinkedListNode(None, None)
+        self.head.next, self.rear.prev = self.rear, self.head
+
+    def __repr__(self) -> str:
+        rep = ["DoubleLinkedList"]
+        node = self.head
+        while node.next is not None:
+            rep.append(str(node))
+            node = node.next
+        rep.append(str(self.rear))
+        return ",\n    ".join(rep)
+
+    def add(self, node: DoubleLinkedListNode[T, U]) -> None:
+        """
+        Adds the given node at the tail of the list and shifting it to proper position
+        """
+
+        previous = self.rear.prev
+
+        # All nodes other than self.head are guaranteed to have non-None previous
+        assert previous is not None
+
+        previous.next = node
+        node.prev = previous
+        self.rear.prev = node
+        node.next = self.rear
+        node.freq += 1
+        self._position_node(node)
+
+    def _position_node(self, node: DoubleLinkedListNode[T, U]) -> None:
+        """
+        Moves node forward to maintain invariant of sort by freq value
+        """
+
+        while node.prev is not None and node.prev.freq > node.freq:
+            # swap node with previous node
+            previous_node = node.prev
+
+            node.prev = previous_node.prev
+            previous_node.next = node.prev
+            node.next = previous_node
+            previous_node.prev = node
+
+    def remove(
+        self, node: DoubleLinkedListNode[T, U]
+    ) -> DoubleLinkedListNode[T, U] | None:
+        """
+        Removes and returns the given node from the list
+
+        Returns None if node.prev or node.next is None
+        """
+
+        if node.prev is None or node.next is None:
+            return None
+
+        node.prev.next = node.next
+        node.next.prev = node.prev
+        node.prev = None
+        node.next = None
+        return node
+
+
+class LFUCache[T, U]:
+    """
+    LFU Cache to store a given capacity of data. Can be used as a stand-alone object
+    or as a function decorator.
+
+    >>> cache = LFUCache(2)
+    >>> cache.put(1, 1)
+    >>> cache.put(2, 2)
+    >>> cache.get(1)
+    1
+    >>> cache.put(3, 3)
+    >>> cache.get(2) is None
+    True
+    >>> cache.put(4, 4)
+    >>> cache.get(1) is None
+    True
+    >>> cache.get(3)
+    3
+    >>> cache.get(4)
+    4
+    >>> cache
+    CacheInfo(hits=3, misses=2, capacity=2, current_size=2)
+    >>> @LFUCache.decorator(100)
+    ... def fib(num):
+    ...     if num in (1, 2):
+    ...         return 1
+    ...     return fib(num - 1) + fib(num - 2)
+
+    >>> for i in range(1, 101):
+    ...     res = fib(i)
+
+    >>> fib.cache_info()
+    CacheInfo(hits=196, misses=100, capacity=100, current_size=100)
+    """
+
+    def __init__(self, capacity: int):
+        self.list: DoubleLinkedList[T, U] = DoubleLinkedList()
+        self.capacity = capacity
+        self.num_keys = 0
+        self.hits = 0
+        self.miss = 0
+        self.cache: dict[T, DoubleLinkedListNode[T, U]] = {}
+
+    def __repr__(self) -> str:
+        """
+        Return the details for the cache instance
+        [hits, misses, capacity, current_size]
+        """
+
+        return (
+            f"CacheInfo(hits={self.hits}, misses={self.miss}, "
+            f"capacity={self.capacity}, current_size={self.num_keys})"
+        )
+
+    def __contains__(self, key: T) -> bool:
+        """
+        >>> cache = LFUCache(1)
+
+        >>> 1 in cache
+        False
+
+        >>> cache.put(1, 1)
+        >>> 1 in cache
+        True
+        """
+
+        return key in self.cache
+
+    def get(self, key: T) -> U | None:
+        """
+        Returns the value for the input key and updates the Double Linked List. Returns
+        Returns None if key is not present in cache
+        """
+
+        if key in self.cache:
+            self.hits += 1
+            value_node: DoubleLinkedListNode[T, U] = self.cache[key]
+            node = self.list.remove(self.cache[key])
+            assert node == value_node
+
+            # node is guaranteed not None because it is in self.cache
+            assert node is not None
+            self.list.add(node)
+            return node.val
+        self.miss += 1
+        return None
+
+    def put(self, key: T, value: U) -> None:
+        """
+        Sets the value for the input key and updates the Double Linked List
+        """
+
+        if key not in self.cache:
+            if self.num_keys >= self.capacity:
+                # delete first node when over capacity
+                first_node = self.list.head.next
+
+                # guaranteed to have a non-None first node when num_keys > 0
+                # explain to type checker via assertions
+                assert first_node is not None
+                assert first_node.key is not None
+                assert self.list.remove(first_node) is not None
+                # first_node guaranteed to be in list
+
+                del self.cache[first_node.key]
+                self.num_keys -= 1
+            self.cache[key] = DoubleLinkedListNode(key, value)
+            self.list.add(self.cache[key])
+            self.num_keys += 1
+
+        else:
+            node = self.list.remove(self.cache[key])
+            assert node is not None  # node guaranteed to be in list
+            node.val = value
+            self.list.add(node)
+
+    @classmethod
+    def decorator(
+        cls: type[LFUCache[T, U]], size: int = 128
+    ) -> Callable[[Callable[[T], U]], Callable[..., U]]:
+        """
+        Decorator version of LFU Cache
+
+        Decorated function must be function of T -> U
+        """
+
+        def cache_decorator_inner(func: Callable[[T], U]) -> Callable[..., U]:
+            # variable to map the decorator functions to their respective instance
+            decorator_function_to_instance_map: dict[
+                Callable[[T], U], LFUCache[T, U]
+            ] = {}
+
+            def cache_decorator_wrapper(*args: T) -> U:
+                if func not in decorator_function_to_instance_map:
+                    decorator_function_to_instance_map[func] = LFUCache(size)
+
+                result = decorator_function_to_instance_map[func].get(args[0])
+                if result is None:
+                    result = func(*args)
+                    decorator_function_to_instance_map[func].put(args[0], result)
+                return result
+
+            def cache_info() -> LFUCache[T, U]:
+                return decorator_function_to_instance_map[func]
+
+            setattr(cache_decorator_wrapper, "cache_info", cache_info)  # noqa: B010
+
+            return cache_decorator_wrapper
+
+        return cache_decorator_inner
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python LFU cache reference from TheAlgorithms
- implement simplified LFU cache in Mochi with frequency-based eviction
- demonstrate cache operations and output stats

## Testing
- `./mochi run tests/github/TheAlgorithms/Mochi/other/lfu_cache.mochi > tests/github/TheAlgorithms/Mochi/other/lfu_cache.out`
- `cat tests/github/TheAlgorithms/Mochi/other/lfu_cache.out`


------
https://chatgpt.com/codex/tasks/task_e_689224691ff083209160f2a1042f004e