### PR TITLE
Add Mochi implementation of LRU cache

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/other/lru_cache.mochi
+++ b/tests/github/TheAlgorithms/Mochi/other/lru_cache.mochi
@@ -1,0 +1,206 @@
+/*
+Implementation of an LRU (Least Recently Used) cache.
+
+The cache stores integer keys and values with a fixed capacity. When the
+capacity is exceeded, the least recently used item is evicted. To achieve
+constant time operations, the cache combines a doubly linked list and a map:
+
+- The doubly linked list keeps track of usage order. New or recently accessed
+  nodes are moved to the end (near the tail sentinel). The head sentinel's next
+  node is the least recently used item.
+- The map provides O(1) access from keys to node indices in the list.
+
+Each list node stores its key, value and links to previous and next nodes by
+index. Two sentinel nodes (head and tail) simplify edge operations. `put`
+adds or updates a value and moves the node to the end. `get` retrieves a value
+if present and moves the accessed node to the end. On cache overflow, the node
+after the head sentinel is removed and its key deleted from the map.
+
+The program demonstrates the cache with a sequence of operations similar to the
+example from TheAlgorithms/Python repository.
+*/
+
+type Node {
+  key: int,
+  value: int,
+  prev: int,
+  next: int,
+}
+
+type DoubleLinkedList {
+  nodes: list<Node>,
+  head: int,
+  tail: int,
+}
+
+fun new_list(): DoubleLinkedList {
+  var nodes: list<Node> = []
+  let head = Node { key: 0, value: 0, prev: 0 - 1, next: 1 }
+  let tail = Node { key: 0, value: 0, prev: 0, next: 0 - 1 }
+  nodes = append(nodes, head)
+  nodes = append(nodes, tail)
+  return DoubleLinkedList { nodes: nodes, head: 0, tail: 1 }
+}
+
+fun dll_add(lst: DoubleLinkedList, idx: int): DoubleLinkedList {
+  var nodes = lst.nodes
+  let tail_idx = lst.tail
+  var tail_node = nodes[tail_idx]
+  let prev_idx = tail_node.prev
+  var node = nodes[idx]
+  node.prev = prev_idx
+  node.next = tail_idx
+  nodes[idx] = node
+  var prev_node = nodes[prev_idx]
+  prev_node.next = idx
+  nodes[prev_idx] = prev_node
+  tail_node.prev = idx
+  nodes[tail_idx] = tail_node
+  lst.nodes = nodes
+  return lst
+}
+
+fun dll_remove(lst: DoubleLinkedList, idx: int): DoubleLinkedList {
+  var nodes = lst.nodes
+  var node = nodes[idx]
+  let prev_idx = node.prev
+  let next_idx = node.next
+  if prev_idx == 0 - 1 || next_idx == 0 - 1 {
+    return lst
+  }
+  var prev_node = nodes[prev_idx]
+  prev_node.next = next_idx
+  nodes[prev_idx] = prev_node
+  var next_node = nodes[next_idx]
+  next_node.prev = prev_idx
+  nodes[next_idx] = next_node
+  node.prev = 0 - 1
+  node.next = 0 - 1
+  nodes[idx] = node
+  lst.nodes = nodes
+  return lst
+}
+
+
+type LRUCache {
+  list: DoubleLinkedList,
+  capacity: int,
+  num_keys: int,
+  hits: int,
+  misses: int,
+  cache: map<string, int>,
+}
+
+type GetResult {
+  cache: LRUCache,
+  value: int,
+  ok: bool,
+}
+
+fun new_cache(cap: int): LRUCache {
+  var empty_map: map<string, int> = {}
+  return LRUCache {
+    list: new_list(),
+    capacity: cap,
+    num_keys: 0,
+    hits: 0,
+    misses: 0,
+    cache: empty_map,
+  }
+}
+
+fun lru_get(c: LRUCache, key: int): GetResult {
+  var cache = c
+  let key_str = str(key)
+  if key_str in cache.cache {
+    let idx = cache.cache[key_str]
+    if idx != 0 - 1 {
+      cache.hits = cache.hits + 1
+      let node = cache.list.nodes[idx]
+      let value = node.value
+      cache.list = dll_remove(cache.list, idx)
+      cache.list = dll_add(cache.list, idx)
+      return GetResult { cache: cache, value: value, ok: true }
+    }
+  }
+  cache.misses = cache.misses + 1
+  return GetResult { cache: cache, value: 0, ok: false }
+}
+
+fun lru_put(c: LRUCache, key: int, value: int): LRUCache {
+  var cache = c
+  let key_str = str(key)
+    if !(key_str in cache.cache) {
+      if cache.num_keys >= cache.capacity {
+      let head_node = cache.list.nodes[cache.list.head]
+      let first_idx = head_node.next
+      let first_node = cache.list.nodes[first_idx]
+      let old_key = first_node.key
+      cache.list = dll_remove(cache.list, first_idx)
+      var mdel = cache.cache
+      mdel[str(old_key)] = 0 - 1
+      cache.cache = mdel
+      cache.num_keys = cache.num_keys - 1
+      }
+    var nodes = cache.list.nodes
+    let new_node = Node { key: key, value: value, prev: 0 - 1, next: 0 - 1 }
+    nodes = append(nodes, new_node)
+    let idx = len(nodes) - 1
+    cache.list.nodes = nodes
+    cache.list = dll_add(cache.list, idx)
+    var m = cache.cache
+    m[key_str] = idx
+    cache.cache = m
+    cache.num_keys = cache.num_keys + 1
+  } else {
+    var m = cache.cache
+    let idx = m[key_str]
+    var nodes = cache.list.nodes
+    var node = nodes[idx]
+    node.value = value
+    nodes[idx] = node
+    cache.list.nodes = nodes
+    cache.list = dll_remove(cache.list, idx)
+    cache.list = dll_add(cache.list, idx)
+    cache.cache = m
+  }
+  return cache
+}
+
+fun cache_info(cache: LRUCache): string {
+  return "CacheInfo(hits=" + str(cache.hits) + ", misses=" + str(cache.misses) + ", capacity=" + str(cache.capacity) + ", current size=" + str(cache.num_keys) + ")"
+}
+
+fun print_result(res: GetResult) {
+  if res.ok {
+    print(str(res.value))
+  } else {
+    print("None")
+  }
+}
+
+fun main() {
+  var cache = new_cache(2)
+  cache = lru_put(cache, 1, 1)
+  cache = lru_put(cache, 2, 2)
+  var r1 = lru_get(cache, 1)
+  cache = r1.cache
+  print_result(r1)
+  cache = lru_put(cache, 3, 3)
+  var r2 = lru_get(cache, 2)
+  cache = r2.cache
+  print_result(r2)
+  cache = lru_put(cache, 4, 4)
+  var r3 = lru_get(cache, 1)
+  cache = r3.cache
+  print_result(r3)
+  var r4 = lru_get(cache, 3)
+  cache = r4.cache
+  print_result(r4)
+  var r5 = lru_get(cache, 4)
+  cache = r5.cache
+  print_result(r5)
+  print(cache_info(cache))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/other/lru_cache.out
+++ b/tests/github/TheAlgorithms/Mochi/other/lru_cache.out
@@ -1,0 +1,6 @@
+1
+None
+None
+3
+4
+CacheInfo(hits=3, misses=2, capacity=2, current size=2)

--- a/tests/github/TheAlgorithms/Python/other/lru_cache.py
+++ b/tests/github/TheAlgorithms/Python/other/lru_cache.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+class DoubleLinkedListNode[T, U]:
+    """
+    Double Linked List Node built specifically for LRU Cache
+
+    >>> DoubleLinkedListNode(1,1)
+    Node: key: 1, val: 1, has next: False, has prev: False
+    """
+
+    def __init__(self, key: T | None, val: U | None):
+        self.key = key
+        self.val = val
+        self.next: DoubleLinkedListNode[T, U] | None = None
+        self.prev: DoubleLinkedListNode[T, U] | None = None
+
+    def __repr__(self) -> str:
+        return (
+            f"Node: key: {self.key}, val: {self.val}, "
+            f"has next: {bool(self.next)}, has prev: {bool(self.prev)}"
+        )
+
+
+class DoubleLinkedList[T, U]:
+    """
+    Double Linked List built specifically for LRU Cache
+
+    >>> dll: DoubleLinkedList = DoubleLinkedList()
+    >>> dll
+    DoubleLinkedList,
+        Node: key: None, val: None, has next: True, has prev: False,
+        Node: key: None, val: None, has next: False, has prev: True
+
+    >>> first_node = DoubleLinkedListNode(1,10)
+    >>> first_node
+    Node: key: 1, val: 10, has next: False, has prev: False
+
+
+    >>> dll.add(first_node)
+    >>> dll
+    DoubleLinkedList,
+        Node: key: None, val: None, has next: True, has prev: False,
+        Node: key: 1, val: 10, has next: True, has prev: True,
+        Node: key: None, val: None, has next: False, has prev: True
+
+    >>> # node is mutated
+    >>> first_node
+    Node: key: 1, val: 10, has next: True, has prev: True
+
+    >>> second_node = DoubleLinkedListNode(2,20)
+    >>> second_node
+    Node: key: 2, val: 20, has next: False, has prev: False
+
+    >>> dll.add(second_node)
+    >>> dll
+    DoubleLinkedList,
+        Node: key: None, val: None, has next: True, has prev: False,
+        Node: key: 1, val: 10, has next: True, has prev: True,
+        Node: key: 2, val: 20, has next: True, has prev: True,
+        Node: key: None, val: None, has next: False, has prev: True
+
+    >>> removed_node = dll.remove(first_node)
+    >>> assert removed_node == first_node
+    >>> dll
+    DoubleLinkedList,
+        Node: key: None, val: None, has next: True, has prev: False,
+        Node: key: 2, val: 20, has next: True, has prev: True,
+        Node: key: None, val: None, has next: False, has prev: True
+
+
+    >>> # Attempt to remove node not on list
+    >>> removed_node = dll.remove(first_node)
+    >>> removed_node is None
+    True
+
+    >>> # Attempt to remove head or rear
+    >>> dll.head
+    Node: key: None, val: None, has next: True, has prev: False
+    >>> dll.remove(dll.head) is None
+    True
+
+    >>> # Attempt to remove head or rear
+    >>> dll.rear
+    Node: key: None, val: None, has next: False, has prev: True
+    >>> dll.remove(dll.rear) is None
+    True
+
+
+    """
+
+    def __init__(self) -> None:
+        self.head: DoubleLinkedListNode[T, U] = DoubleLinkedListNode(None, None)
+        self.rear: DoubleLinkedListNode[T, U] = DoubleLinkedListNode(None, None)
+        self.head.next, self.rear.prev = self.rear, self.head
+
+    def __repr__(self) -> str:
+        rep = ["DoubleLinkedList"]
+        node = self.head
+        while node.next is not None:
+            rep.append(str(node))
+            node = node.next
+        rep.append(str(self.rear))
+        return ",\n    ".join(rep)
+
+    def add(self, node: DoubleLinkedListNode[T, U]) -> None:
+        """
+        Adds the given node to the end of the list (before rear)
+        """
+
+        previous = self.rear.prev
+
+        # All nodes other than self.head are guaranteed to have non-None previous
+        assert previous is not None
+
+        previous.next = node
+        node.prev = previous
+        self.rear.prev = node
+        node.next = self.rear
+
+    def remove(
+        self, node: DoubleLinkedListNode[T, U]
+    ) -> DoubleLinkedListNode[T, U] | None:
+        """
+        Removes and returns the given node from the list
+
+        Returns None if node.prev or node.next is None
+        """
+
+        if node.prev is None or node.next is None:
+            return None
+
+        node.prev.next = node.next
+        node.next.prev = node.prev
+        node.prev = None
+        node.next = None
+        return node
+
+
+class LRUCache[T, U]:
+    """
+    LRU Cache to store a given capacity of data. Can be used as a stand-alone object
+    or as a function decorator.
+
+    >>> cache = LRUCache(2)
+
+    >>> cache.put(1, 1)
+    >>> cache.put(2, 2)
+    >>> cache.get(1)
+    1
+
+    >>> cache.list
+    DoubleLinkedList,
+        Node: key: None, val: None, has next: True, has prev: False,
+        Node: key: 2, val: 2, has next: True, has prev: True,
+        Node: key: 1, val: 1, has next: True, has prev: True,
+        Node: key: None, val: None, has next: False, has prev: True
+
+    >>> cache.cache  # doctest: +NORMALIZE_WHITESPACE
+    {1: Node: key: 1, val: 1, has next: True, has prev: True, \
+     2: Node: key: 2, val: 2, has next: True, has prev: True}
+
+    >>> cache.put(3, 3)
+
+    >>> cache.list
+    DoubleLinkedList,
+        Node: key: None, val: None, has next: True, has prev: False,
+        Node: key: 1, val: 1, has next: True, has prev: True,
+        Node: key: 3, val: 3, has next: True, has prev: True,
+        Node: key: None, val: None, has next: False, has prev: True
+
+    >>> cache.cache  # doctest: +NORMALIZE_WHITESPACE
+    {1: Node: key: 1, val: 1, has next: True, has prev: True, \
+     3: Node: key: 3, val: 3, has next: True, has prev: True}
+
+    >>> cache.get(2) is None
+    True
+
+    >>> cache.put(4, 4)
+
+    >>> cache.get(1) is None
+    True
+
+    >>> cache.get(3)
+    3
+
+    >>> cache.get(4)
+    4
+
+    >>> cache
+    CacheInfo(hits=3, misses=2, capacity=2, current size=2)
+
+    >>> @LRUCache.decorator(100)
+    ... def fib(num):
+    ...     if num in (1, 2):
+    ...         return 1
+    ...     return fib(num - 1) + fib(num - 2)
+
+    >>> for i in range(1, 100):
+    ...     res = fib(i)
+
+    >>> fib.cache_info()
+    CacheInfo(hits=194, misses=99, capacity=100, current size=99)
+    """
+
+    def __init__(self, capacity: int):
+        self.list: DoubleLinkedList[T, U] = DoubleLinkedList()
+        self.capacity = capacity
+        self.num_keys = 0
+        self.hits = 0
+        self.miss = 0
+        self.cache: dict[T, DoubleLinkedListNode[T, U]] = {}
+
+    def __repr__(self) -> str:
+        """
+        Return the details for the cache instance
+        [hits, misses, capacity, current_size]
+        """
+
+        return (
+            f"CacheInfo(hits={self.hits}, misses={self.miss}, "
+            f"capacity={self.capacity}, current size={self.num_keys})"
+        )
+
+    def __contains__(self, key: T) -> bool:
+        """
+        >>> cache = LRUCache(1)
+
+        >>> 1 in cache
+        False
+
+        >>> cache.put(1, 1)
+
+        >>> 1 in cache
+        True
+        """
+
+        return key in self.cache
+
+    def get(self, key: T) -> U | None:
+        """
+        Returns the value for the input key and updates the Double Linked List.
+        Returns None if key is not present in cache
+        """
+        # Note: pythonic interface would throw KeyError rather than return None
+
+        if key in self.cache:
+            self.hits += 1
+            value_node: DoubleLinkedListNode[T, U] = self.cache[key]
+            node = self.list.remove(self.cache[key])
+            assert node == value_node
+
+            # node is guaranteed not None because it is in self.cache
+            assert node is not None
+            self.list.add(node)
+            return node.val
+        self.miss += 1
+        return None
+
+    def put(self, key: T, value: U) -> None:
+        """
+        Sets the value for the input key and updates the Double Linked List
+        """
+
+        if key not in self.cache:
+            if self.num_keys >= self.capacity:
+                # delete first node (oldest) when over capacity
+                first_node = self.list.head.next
+
+                # guaranteed to have a non-None first node when num_keys > 0
+                # explain to type checker via assertions
+                assert first_node is not None
+                assert first_node.key is not None
+                assert (
+                    self.list.remove(first_node) is not None
+                )  # node guaranteed to be in list assert node.key is not None
+
+                del self.cache[first_node.key]
+                self.num_keys -= 1
+            self.cache[key] = DoubleLinkedListNode(key, value)
+            self.list.add(self.cache[key])
+            self.num_keys += 1
+
+        else:
+            # bump node to the end of the list, update value
+            node = self.list.remove(self.cache[key])
+            assert node is not None  # node guaranteed to be in list
+            node.val = value
+            self.list.add(node)
+
+    @classmethod
+    def decorator(
+        cls, size: int = 128
+    ) -> Callable[[Callable[[T], U]], Callable[..., U]]:
+        """
+        Decorator version of LRU Cache
+
+        Decorated function must be function of T -> U
+        """
+
+        def cache_decorator_inner(func: Callable[[T], U]) -> Callable[..., U]:
+            # variable to map the decorator functions to their respective instance
+            decorator_function_to_instance_map: dict[
+                Callable[[T], U], LRUCache[T, U]
+            ] = {}
+
+            def cache_decorator_wrapper(*args: T) -> U:
+                if func not in decorator_function_to_instance_map:
+                    decorator_function_to_instance_map[func] = LRUCache(size)
+
+                result = decorator_function_to_instance_map[func].get(args[0])
+                if result is None:
+                    result = func(*args)
+                    decorator_function_to_instance_map[func].put(args[0], result)
+                return result
+
+            def cache_info() -> LRUCache[T, U]:
+                return decorator_function_to_instance_map[func]
+
+            setattr(cache_decorator_wrapper, "cache_info", cache_info)  # noqa: B010
+
+            return cache_decorator_wrapper
+
+        return cache_decorator_inner
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add original Python LRU cache source
- implement an equivalent LRU cache in pure Mochi and demo usage

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/other/lru_cache.mochi > tests/github/TheAlgorithms/Mochi/other/lru_cache.out`

------
https://chatgpt.com/codex/tasks/task_e_6892246dc54c832094fe65a5641eb01d