### PR TITLE
Add nested brackets algorithm translation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/other/nested_brackets.mochi
+++ b/tests/github/TheAlgorithms/Mochi/other/nested_brackets.mochi
@@ -1,0 +1,69 @@
+/*
+Determine whether a string of brackets is properly nested.
+
+A sequence is properly nested if it is empty, of the form (U), [U] or {U}
+where U is itself properly nested, or if it is the concatenation of two
+properly nested strings.  The algorithm uses a stack to store opening
+brackets.  When a closing bracket appears, it must match the latest opening
+bracket on the stack; otherwise the string is unbalanced.  Non-bracket
+characters are ignored.  After processing all characters, the stack must be
+empty for the string to be balanced.
+
+Time complexity: O(n) for n characters.
+Space complexity: O(n) in the worst case for the stack.
+*/
+
+let OPEN_TO_CLOSED: map<string, string> = {"(": ")", "[": "]", "{": "}"}
+
+fun slice_without_last(xs: list<string>): list<string> {
+  var res: list<string> = []
+  var i = 0
+  while i < len(xs) - 1 {
+    res = append(res, xs[i])
+    i = i + 1
+  }
+  return res
+}
+
+fun is_balanced(s: string): bool {
+  var stack: list<string> = []
+  var i = 0
+  while i < len(s) {
+    let symbol = substring(s, i, i + 1)
+    if symbol in OPEN_TO_CLOSED {
+      stack = append(stack, symbol)
+    } else if symbol == ")" || symbol == "]" || symbol == "}" {
+      if len(stack) == 0 {
+        return false
+      }
+      let top = stack[len(stack) - 1]
+      if OPEN_TO_CLOSED[top] != symbol {
+        return false
+      }
+      stack = slice_without_last(stack)
+    }
+    i = i + 1
+  }
+  return len(stack) == 0
+}
+
+fun main() {
+  print(is_balanced(""))
+  print(is_balanced("()"))
+  print(is_balanced("[]"))
+  print(is_balanced("{}"))
+  print(is_balanced("()[]{}"))
+  print(is_balanced("(())"))
+  print(is_balanced("[["))
+  print(is_balanced("([{}])"))
+  print(is_balanced("(()[)]"))
+  print(is_balanced("([)]"))
+  print(is_balanced("[[()]]"))
+  print(is_balanced("(()(()))"))
+  print(is_balanced("]"))
+  print(is_balanced("Life is a bowl of cherries."))
+  print(is_balanced("Life is a bowl of che{}ies."))
+  print(is_balanced("Life is a bowl of che}{ies."))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/other/nested_brackets.out
+++ b/tests/github/TheAlgorithms/Mochi/other/nested_brackets.out
@@ -1,0 +1,16 @@
+true
+true
+true
+true
+true
+true
+false
+true
+false
+false
+true
+true
+false
+true
+true
+false

--- a/tests/github/TheAlgorithms/Python/other/nested_brackets.py
+++ b/tests/github/TheAlgorithms/Python/other/nested_brackets.py
@@ -1,0 +1,73 @@
+"""
+The nested brackets problem is a problem that determines if a sequence of
+brackets are properly nested.  A sequence of brackets s is considered properly nested
+if any of the following conditions are true:
+
+    - s is empty
+    - s has the form (U) or [U] or {U} where U is a properly nested string
+    - s has the form VW where V and W are properly nested strings
+
+For example, the string "()()[()]" is properly nested but "[(()]" is not.
+
+The function called is_balanced takes as input a string S which is a sequence of
+brackets and returns true if S is nested and false otherwise.
+"""
+
+
+def is_balanced(s: str) -> bool:
+    """
+    >>> is_balanced("")
+    True
+    >>> is_balanced("()")
+    True
+    >>> is_balanced("[]")
+    True
+    >>> is_balanced("{}")
+    True
+    >>> is_balanced("()[]{}")
+    True
+    >>> is_balanced("(())")
+    True
+    >>> is_balanced("[[")
+    False
+    >>> is_balanced("([{}])")
+    True
+    >>> is_balanced("(()[)]")
+    False
+    >>> is_balanced("([)]")
+    False
+    >>> is_balanced("[[()]]")
+    True
+    >>> is_balanced("(()(()))")
+    True
+    >>> is_balanced("]")
+    False
+    >>> is_balanced("Life is a bowl of cherries.")
+    True
+    >>> is_balanced("Life is a bowl of che{}ies.")
+    True
+    >>> is_balanced("Life is a bowl of che}{ies.")
+    False
+    """
+    open_to_closed = {"{": "}", "[": "]", "(": ")"}
+    stack = []
+    for symbol in s:
+        if symbol in open_to_closed:
+            stack.append(symbol)
+        elif symbol in open_to_closed.values() and (
+            not stack or open_to_closed[stack.pop()] != symbol
+        ):
+            return False
+    return not stack  # stack should be empty
+
+
+def main():
+    s = input("Enter sequence of brackets: ")
+    print(f"'{s}' is {'' if is_balanced(s) else 'not '}balanced.")
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()
+    main()


### PR DESCRIPTION
## Summary
- add Python nested brackets reference implementation
- add Mochi version using stack and map to verify bracket nesting
- record execution output of nested bracket checks

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/other/nested_brackets.mochi`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6892247c6ee8832097198f58822d6d1b