### PR TITLE
Add Archimedes principle buoyant force example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/physics/archimedes_principle_of_buoyant_force.mochi
+++ b/tests/github/TheAlgorithms/Mochi/physics/archimedes_principle_of_buoyant_force.mochi
@@ -1,0 +1,47 @@
+/*
+Archimedes' Principle - Buoyant Force
+------------------------------------
+This program calculates the buoyant force exerted on an object that is
+completely or partially submerged in a fluid. According to
+Archimedes' principle, the upward buoyant force on an object is equal
+to the weight of the fluid displaced by the object. The formula is:
+
+    F_b = rho * V * g
+
+where
+  rho  : density of the fluid (kg/m^3)
+  V    : volume of the displaced fluid (m^3)
+  g    : acceleration due to gravity (m/s^2)
+
+The function validates input parameters, rejecting non-positive density
+or volume and negative gravity, and returns the computed buoyant force.
+*/
+
+let G = 9.80665
+
+fun archimedes_principle(fluid_density: float, volume: float, gravity: float): float {
+  if fluid_density <= 0.0 {
+    panic("Impossible fluid density")
+  }
+  if volume <= 0.0 {
+    panic("Impossible object volume")
+  }
+  if gravity < 0.0 {
+    panic("Impossible gravity")
+  }
+  return fluid_density * volume * gravity
+}
+
+fun archimedes_principle_default(fluid_density: float, volume: float): float {
+  let res = archimedes_principle(fluid_density, volume, G)
+  return res
+}
+
+test "archimedes principle" {
+  expect archimedes_principle(500.0, 4.0, 9.8) == 19600.0
+  expect archimedes_principle(997.0, 0.5, 9.8) == 4885.3
+  let r = archimedes_principle_default(997.0, 0.7)
+  let expected = archimedes_principle(997.0, 0.7, G)
+  expect r == expected
+  expect archimedes_principle(997.0, 0.7, 0.0) == 0.0
+}

--- a/tests/github/TheAlgorithms/Mochi/physics/archimedes_principle_of_buoyant_force.out
+++ b/tests/github/TheAlgorithms/Mochi/physics/archimedes_principle_of_buoyant_force.out
@@ -1,0 +1,2 @@
+[94;1mtests/github/TheAlgorithms/Mochi/physics/archimedes_principle_of_buoyant_force.mochi[0;22m
+   [33mtest[0m archimedes principle           ... [32mok[0m (1.0ms)

--- a/tests/github/TheAlgorithms/Python/physics/archimedes_principle_of_buoyant_force.py
+++ b/tests/github/TheAlgorithms/Python/physics/archimedes_principle_of_buoyant_force.py
@@ -1,0 +1,62 @@
+"""
+Calculate the buoyant force of any body completely or partially submerged in a static
+fluid.  This principle was discovered by the Greek mathematician Archimedes.
+
+Equation for calculating buoyant force:
+Fb = p * V * g
+
+https://en.wikipedia.org/wiki/Archimedes%27_principle
+"""
+
+# Acceleration Constant on Earth (unit m/s^2)
+g = 9.80665  # Also available in scipy.constants.g
+
+
+def archimedes_principle(
+    fluid_density: float, volume: float, gravity: float = g
+) -> float:
+    """
+    Args:
+        fluid_density: density of fluid (kg/m^3)
+        volume: volume of object/liquid being displaced by the object (m^3)
+        gravity: Acceleration from gravity. Gravitational force on the system,
+            The default is Earth Gravity
+    returns:
+        the buoyant force on an object in Newtons
+
+    >>> archimedes_principle(fluid_density=500, volume=4, gravity=9.8)
+    19600.0
+    >>> archimedes_principle(fluid_density=997, volume=0.5, gravity=9.8)
+    4885.3
+    >>> archimedes_principle(fluid_density=997, volume=0.7)
+    6844.061035
+    >>> archimedes_principle(fluid_density=997, volume=-0.7)
+    Traceback (most recent call last):
+        ...
+    ValueError: Impossible object volume
+    >>> archimedes_principle(fluid_density=0, volume=0.7)
+    Traceback (most recent call last):
+        ...
+    ValueError: Impossible fluid density
+    >>> archimedes_principle(fluid_density=997, volume=0.7, gravity=0)
+    0.0
+    >>> archimedes_principle(fluid_density=997, volume=0.7, gravity=-9.8)
+    Traceback (most recent call last):
+        ...
+    ValueError: Impossible gravity
+    """
+
+    if fluid_density <= 0:
+        raise ValueError("Impossible fluid density")
+    if volume <= 0:
+        raise ValueError("Impossible object volume")
+    if gravity < 0:
+        raise ValueError("Impossible gravity")
+
+    return fluid_density * gravity * volume
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python source for Archimedes' principle buoyant force example
- implement Archimedes' principle in Mochi with input validation
- include VM test confirming expected buoyant force outputs

## Testing
- `python tests/github/TheAlgorithms/Python/physics/archimedes_principle_of_buoyant_force.py`
- `./mochi test tests/github/TheAlgorithms/Mochi/physics/archimedes_principle_of_buoyant_force.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6892257587308320af67ae1dc1c61033