### PR TITLE
Add static equilibrium physics algorithm and Mochi port

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/physics/in_static_equilibrium.mochi
+++ b/tests/github/TheAlgorithms/Mochi/physics/in_static_equilibrium.mochi
@@ -1,0 +1,85 @@
+/*
+Check whether a system of planar forces is in static equilibrium.
+
+The algorithm models each force as a vector acting at a location.
+To determine equilibrium, we compute the net moment about the origin.
+For each force-location pair (r, F), the moment contribution is the
+2‑D cross product r_x * F_y - r_y * F_x.  If the sum of all moments
+is approximately zero, the system is in equilibrium.
+
+The helper `polar_force` converts a force given in polar form
+(magnitude and angle) into its rectangular components using small
+Taylor series approximations for sine and cosine, keeping the
+implementation in pure Mochi with no foreign function calls.
+*/
+
+let PI: float = 3.141592653589793
+let TWO_PI: float = 6.283185307179586
+
+fun _mod(x: float, m: float): float {
+  return x - (int(x / m) as float) * m
+}
+
+fun sin_approx(x: float): float {
+  let y = _mod(x + PI, TWO_PI) - PI
+  let y2 = y * y
+  let y3 = y2 * y
+  let y5 = y3 * y2
+  let y7 = y5 * y2
+  return y - y3 / 6.0 + y5 / 120.0 - y7 / 5040.0
+}
+
+fun cos_approx(x: float): float {
+  let y = _mod(x + PI, TWO_PI) - PI
+  let y2 = y * y
+  let y4 = y2 * y2
+  let y6 = y4 * y2
+  return 1.0 - y2 / 2.0 + y4 / 24.0 - y6 / 720.0
+}
+
+fun polar_force(magnitude: float, angle: float, radian_mode: bool): list<float> {
+  let theta = if radian_mode { angle } else { angle * PI / 180.0 }
+  return [magnitude * cos_approx(theta), magnitude * sin_approx(theta)]
+}
+
+fun abs_float(x: float): float {
+  if x < 0.0 { return -x } else { return x }
+}
+
+fun in_static_equilibrium(forces: list<list<float>>, location: list<list<float>>, eps: float): bool {
+  var sum_moments: float = 0.0
+  var i = 0
+  let n = len(forces)
+  while i < n {
+    let r = location[i]
+    let f = forces[i]
+    let moment = r[0] * f[1] - r[1] * f[0]
+    sum_moments = sum_moments + moment
+    i = i + 1
+  }
+  return abs_float(sum_moments) < eps
+}
+
+let forces1: list<list<float>> = [[1.0, 1.0], [-1.0, 2.0]]
+let location1: list<list<float>> = [[1.0, 0.0], [10.0, 0.0]]
+print(str(in_static_equilibrium(forces1, location1, 0.1)))
+
+let forces2: list<list<float>> = [
+  polar_force(718.4, 150.0, false),
+  polar_force(879.54, 45.0, false),
+  polar_force(100.0, -90.0, false)
+]
+let location2: list<list<float>> = [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]]
+print(str(in_static_equilibrium(forces2, location2, 0.1)))
+
+let forces3: list<list<float>> = [
+  polar_force(30.0 * 9.81, 15.0, false),
+  polar_force(215.0, 135.0, false),
+  polar_force(264.0, 60.0, false)
+]
+let location3: list<list<float>> = [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]]
+print(str(in_static_equilibrium(forces3, location3, 0.1)))
+
+let forces4: list<list<float>> = [[0.0, -2000.0], [0.0, -1200.0], [0.0, 15600.0], [0.0, -12400.0]]
+let location4: list<list<float>> = [[0.0, 0.0], [6.0, 0.0], [10.0, 0.0], [12.0, 0.0]]
+print(str(in_static_equilibrium(forces4, location4, 0.1)))

--- a/tests/github/TheAlgorithms/Mochi/physics/in_static_equilibrium.out
+++ b/tests/github/TheAlgorithms/Mochi/physics/in_static_equilibrium.out
@@ -1,0 +1,4 @@
+false
+true
+true
+true

--- a/tests/github/TheAlgorithms/Python/physics/in_static_equilibrium.py
+++ b/tests/github/TheAlgorithms/Python/physics/in_static_equilibrium.py
@@ -1,0 +1,95 @@
+"""
+Checks if a system of forces is in static equilibrium.
+"""
+
+from __future__ import annotations
+
+from numpy import array, cos, cross, float64, radians, sin
+from numpy.typing import NDArray
+
+
+def polar_force(
+    magnitude: float, angle: float, radian_mode: bool = False
+) -> list[float]:
+    """
+    Resolves force along rectangular components.
+    (force, angle) => (force_x, force_y)
+    >>> import math
+    >>> force = polar_force(10, 45)
+    >>> math.isclose(force[0], 7.071067811865477)
+    True
+    >>> math.isclose(force[1], 7.0710678118654755)
+    True
+    >>> force = polar_force(10, 3.14, radian_mode=True)
+    >>> math.isclose(force[0], -9.999987317275396)
+    True
+    >>> math.isclose(force[1], 0.01592652916486828)
+    True
+    """
+    if radian_mode:
+        return [magnitude * cos(angle), magnitude * sin(angle)]
+    return [magnitude * cos(radians(angle)), magnitude * sin(radians(angle))]
+
+
+def in_static_equilibrium(
+    forces: NDArray[float64], location: NDArray[float64], eps: float = 10**-1
+) -> bool:
+    """
+    Check if a system is in equilibrium.
+    It takes two numpy.array objects.
+    forces ==>  [
+                        [force1_x, force1_y],
+                        [force2_x, force2_y],
+                        ....]
+    location ==>  [
+                        [x1, y1],
+                        [x2, y2],
+                        ....]
+    >>> force = array([[1, 1], [-1, 2]])
+    >>> location = array([[1, 0], [10, 0]])
+    >>> in_static_equilibrium(force, location)
+    False
+    """
+    # summation of moments is zero
+    moments: NDArray[float64] = cross(location, forces)
+    sum_moments: float = sum(moments)
+    return bool(abs(sum_moments) < eps)
+
+
+if __name__ == "__main__":
+    # Test to check if it works
+    forces = array(
+        [
+            polar_force(718.4, 180 - 30),
+            polar_force(879.54, 45),
+            polar_force(100, -90),
+        ]
+    )
+
+    location: NDArray[float64] = array([[0, 0], [0, 0], [0, 0]])
+
+    assert in_static_equilibrium(forces, location)
+
+    # Problem 1 in image_data/2D_problems.jpg
+    forces = array(
+        [
+            polar_force(30 * 9.81, 15),
+            polar_force(215, 180 - 45),
+            polar_force(264, 90 - 30),
+        ]
+    )
+
+    location = array([[0, 0], [0, 0], [0, 0]])
+
+    assert in_static_equilibrium(forces, location)
+
+    # Problem in image_data/2D_problems_1.jpg
+    forces = array([[0, -2000], [0, -1200], [0, 15600], [0, -12400]])
+
+    location = array([[0, 0], [6, 0], [10, 0], [12, 0]])
+
+    assert in_static_equilibrium(forces, location)
+
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python reference implementation for static equilibrium of forces
- implement static equilibrium check in Mochi with custom sine/cosine approximations
- include runtime output for example systems

## Testing
- `./bin/mochi run tests/github/TheAlgorithms/Mochi/physics/in_static_equilibrium.mochi`

------
https://chatgpt.com/codex/tasks/task_e_68923c3d614083209713d048f768ce33