### PR TITLE
feat: add rms speed of molecule implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/physics/rms_speed_of_molecule.mochi
+++ b/tests/github/TheAlgorithms/Mochi/physics/rms_speed_of_molecule.mochi
@@ -1,0 +1,41 @@
+/*
+Root-Mean-Square Speed of Gas Molecules
+---------------------------------------
+The root-mean-square (RMS) speed estimates the average speed of particles in a gas.
+For a given absolute temperature `T` in Kelvin and molar mass `M` in kg/mol,
+the RMS speed is given by:
+
+    Vrms = sqrt(3 * R * T / M)
+
+where `R` is the universal gas constant (8.3144598 J/(mol·K)).
+This implementation validates that the temperature is non-negative and the
+molar mass is positive before computing the square root using Newton's method.
+The algorithm runs in constant time.
+*/
+
+let UNIVERSAL_GAS_CONSTANT: float = 8.3144598
+
+fun sqrt(x: float): float {
+  if x <= 0.0 { return 0.0 }
+  var guess = x
+  var i = 0
+  while i < 10 {
+    guess = (guess + x / guess) / 2.0
+    i = i + 1
+  }
+  return guess
+}
+
+fun rms_speed_of_molecule(temperature: float, molar_mass: float): float {
+  if temperature < 0.0 { panic("Temperature cannot be less than 0 K") }
+  if molar_mass <= 0.0 { panic("Molar mass cannot be less than or equal to 0 kg/mol") }
+  let num = 3.0 * UNIVERSAL_GAS_CONSTANT * temperature
+  let val: float = num / molar_mass
+  let result: float = sqrt(val)
+  return result
+}
+
+print("rms_speed_of_molecule(100, 2) = " + str(rms_speed_of_molecule(100.0, 2.0)))
+print("rms_speed_of_molecule(273, 12) = " + str(rms_speed_of_molecule(273.0, 12.0)))
+let vrms = rms_speed_of_molecule(300.0, 28.0)
+print("Vrms of Nitrogen gas at 300 K is " + str(vrms) + " m/s")

--- a/tests/github/TheAlgorithms/Mochi/physics/rms_speed_of_molecule.out
+++ b/tests/github/TheAlgorithms/Mochi/physics/rms_speed_of_molecule.out
@@ -1,0 +1,3 @@
+rms_speed_of_molecule(100, 2) = 35.315279554323226
+rms_speed_of_molecule(273, 12) = 23.82145842197744
+Vrms of Nitrogen gas at 300 K is 16.347797820239535 m/s

--- a/tests/github/TheAlgorithms/Python/physics/rms_speed_of_molecule.py
+++ b/tests/github/TheAlgorithms/Python/physics/rms_speed_of_molecule.py
@@ -1,0 +1,51 @@
+"""
+The root-mean-square speed is essential in measuring the average speed of particles
+contained in a gas, defined as,
+ -----------------
+ | Vrms = √3RT/M |
+ -----------------
+
+In Kinetic Molecular Theory, gasified particles are in a condition of constant random
+motion; each particle moves at a completely different pace, perpetually clashing and
+changing directions consistently velocity is used to describe the movement of gas
+particles, thereby taking into account both speed and direction. Although the velocity
+of gaseous particles is constantly changing, the distribution of velocities does not
+change.
+We cannot gauge the velocity of every individual particle, thus we frequently reason
+in terms of the particles average behavior. Particles moving in opposite directions
+have velocities of opposite signs. Since gas particles are in random motion, it's
+plausible that there'll be about as several moving in one direction as within the other
+way, which means that the average velocity for a collection of gas particles equals
+zero; as this value is unhelpful, the average of velocities can be determined using an
+alternative method.
+"""
+
+UNIVERSAL_GAS_CONSTANT = 8.3144598
+
+
+def rms_speed_of_molecule(temperature: float, molar_mass: float) -> float:
+    """
+    >>> rms_speed_of_molecule(100, 2)
+    35.315279554323226
+    >>> rms_speed_of_molecule(273, 12)
+    23.821458421977443
+    """
+    if temperature < 0:
+        raise Exception("Temperature cannot be less than 0 K")
+    if molar_mass <= 0:
+        raise Exception("Molar mass cannot be less than or equal to 0 kg/mol")
+    else:
+        return (3 * UNIVERSAL_GAS_CONSTANT * temperature / molar_mass) ** 0.5
+
+
+if __name__ == "__main__":
+    import doctest
+
+    # run doctest
+    doctest.testmod()
+
+    # example
+    temperature = 300
+    molar_mass = 28
+    vrms = rms_speed_of_molecule(temperature, molar_mass)
+    print(f"Vrms of Nitrogen gas at 300 K is {vrms} m/s")


### PR DESCRIPTION
## Summary
- add TheAlgorithms Python example for RMS molecular speed
- implement RMS molecular speed in Mochi with input validation and Newton-based square root
- include example output

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68923c64f26c8320bc87a2d1a97a3776