### PR TITLE
Add Mochi implementation for shear stress

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/physics/shear_stress.mochi
+++ b/tests/github/TheAlgorithms/Mochi/physics/shear_stress.mochi
@@ -1,0 +1,46 @@
+/*
+Compute one missing quantity among shear stress, tangential force,
+and cross-sectional area using the relation:
+
+  stress = tangential_force / area
+
+Exactly two of the parameters must be provided (non-zero) and the
+remaining one set to 0. The algorithm validates the inputs and
+returns a Result struct indicating which quantity was computed and
+its value. Runtime is O(1) with basic arithmetic.
+*/
+
+type Result { name: string, value: float }
+
+fun shear_stress(stress: float, tangential_force: float, area: float): Result {
+  var zeros = 0
+  if stress == 0.0 { zeros = zeros + 1 }
+  if tangential_force == 0.0 { zeros = zeros + 1 }
+  if area == 0.0 { zeros = zeros + 1 }
+  if zeros != 1 {
+    panic("You cannot supply more or less than 2 values")
+  } else if stress < 0.0 {
+    panic("Stress cannot be negative")
+  } else if tangential_force < 0.0 {
+    panic("Tangential Force cannot be negative")
+  } else if area < 0.0 {
+    panic("Area cannot be negative")
+  } else if stress == 0.0 {
+    return Result{ name: "stress", value: tangential_force / area }
+  } else if tangential_force == 0.0 {
+    return Result{ name: "tangential_force", value: stress * area }
+  } else {
+    return Result{ name: "area", value: tangential_force / stress }
+  }
+}
+
+fun str_result(r: Result): string {
+  return "Result(name='" + r.name + "', value=" + str(r.value) + ")"
+}
+
+let r1 = shear_stress(25.0, 100.0, 0.0)
+print(str_result(r1))
+let r2 = shear_stress(0.0, 1600.0, 200.0)
+print(str_result(r2))
+let r3 = shear_stress(1000.0, 0.0, 1200.0)
+print(str_result(r3))

--- a/tests/github/TheAlgorithms/Mochi/physics/shear_stress.out
+++ b/tests/github/TheAlgorithms/Mochi/physics/shear_stress.out
@@ -1,0 +1,3 @@
+Result(name='area', value=4)
+Result(name='stress', value=8)
+Result(name='tangential_force', value=1.2e+06)

--- a/tests/github/TheAlgorithms/Python/physics/shear_stress.py
+++ b/tests/github/TheAlgorithms/Python/physics/shear_stress.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""
+Shear stress is a component of stress that is coplanar to the material cross-section.
+It arises due to a shear force, the component of the force vector parallel to the
+material cross-section.
+
+https://en.wikipedia.org/wiki/Shear_stress
+"""
+
+
+def shear_stress(
+    stress: float,
+    tangential_force: float,
+    area: float,
+) -> tuple[str, float]:
+    """
+    This function can calculate any one of the three -
+    1. Shear Stress
+    2. Tangential Force
+    3. Cross-sectional Area
+    This is calculated from the other two provided values
+    Examples -
+    >>> shear_stress(stress=25, tangential_force=100, area=0)
+    ('area', 4.0)
+    >>> shear_stress(stress=0, tangential_force=1600, area=200)
+    ('stress', 8.0)
+    >>> shear_stress(stress=1000, tangential_force=0, area=1200)
+    ('tangential_force', 1200000)
+    """
+    if (stress, tangential_force, area).count(0) != 1:
+        raise ValueError("You cannot supply more or less than 2 values")
+    elif stress < 0:
+        raise ValueError("Stress cannot be negative")
+    elif tangential_force < 0:
+        raise ValueError("Tangential Force cannot be negative")
+    elif area < 0:
+        raise ValueError("Area cannot be negative")
+    elif stress == 0:
+        return (
+            "stress",
+            tangential_force / area,
+        )
+    elif tangential_force == 0:
+        return (
+            "tangential_force",
+            stress * area,
+        )
+    else:
+        return (
+            "area",
+            tangential_force / stress,
+        )
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add upstream Python shear stress implementation for reference
- implement and document Mochi version using a Result struct
- include example runtime output verifying calculations

## Testing
- `python tests/github/TheAlgorithms/Python/physics/shear_stress.py`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/physics/shear_stress.mochi`


------
https://chatgpt.com/codex/tasks/task_e_68923c66c1d88320b9886f09df40a7e5