### PR TITLE
Add Mochi solution for Fibonacci digit digit count problem

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/project_euler/problem_025/sol3.mochi
+++ b/tests/github/TheAlgorithms/Mochi/project_euler/problem_025/sol3.mochi
@@ -1,0 +1,41 @@
+/*
+Project Euler Problem 25: 1000-digit Fibonacci number
+----------------------------------------------------
+The Fibonacci sequence is defined by F_n = F_{n-1} + F_{n-2} with
+F_1 = F_2 = 1. The task is to find the index of the first term in the
+sequence that contains n digits. This implementation iteratively
+builds Fibonacci numbers and counts their digits via repeated division
+by 10, avoiding conversions to strings. The loop stops once a term's
+digit count equals n, and the corresponding index is returned.
+*/
+
+fun num_digits(x: int): int {
+  var count: int = 0
+  var n: int = x
+  while n > 0 {
+    count = count + 1
+    n = n / 10
+  }
+  return count
+}
+
+fun solution(n: int): int {
+  var f1: int = 1
+  var f2: int = 1
+  var index: int = 2
+  while true {
+    let f: int = f1 + f2
+    f1 = f2
+    f2 = f
+    index = index + 1
+    if num_digits(f) == n {
+      break
+    }
+  }
+  return index
+}
+
+print("solution(1000) = " + str(solution(1000)))
+print("solution(100) = " + str(solution(100)))
+print("solution(50) = " + str(solution(50)))
+print("solution(3) = " + str(solution(3)))

--- a/tests/github/TheAlgorithms/Mochi/project_euler/problem_025/sol3.out
+++ b/tests/github/TheAlgorithms/Mochi/project_euler/problem_025/sol3.out
@@ -1,0 +1,4 @@
+solution(1000) = 4782
+solution(100) = 476
+solution(50) = 237
+solution(3) = 12

--- a/tests/github/TheAlgorithms/Python/project_euler/problem_025/sol3.py
+++ b/tests/github/TheAlgorithms/Python/project_euler/problem_025/sol3.py
@@ -1,0 +1,56 @@
+"""
+The Fibonacci sequence is defined by the recurrence relation:
+
+    Fn = Fn-1 + Fn-2, where F1 = 1 and F2 = 1.
+
+Hence the first 12 terms will be:
+
+    F1 = 1
+    F2 = 1
+    F3 = 2
+    F4 = 3
+    F5 = 5
+    F6 = 8
+    F7 = 13
+    F8 = 21
+    F9 = 34
+    F10 = 55
+    F11 = 89
+    F12 = 144
+
+The 12th term, F12, is the first term to contain three digits.
+
+What is the index of the first term in the Fibonacci sequence to contain 1000
+digits?
+"""
+
+
+def solution(n: int = 1000) -> int:
+    """Returns the index of the first term in the Fibonacci sequence to contain
+    n digits.
+
+    >>> solution(1000)
+    4782
+    >>> solution(100)
+    476
+    >>> solution(50)
+    237
+    >>> solution(3)
+    12
+    """
+    f1, f2 = 1, 1
+    index = 2
+    while True:
+        i = 0
+        f = f1 + f2
+        f1, f2 = f2, f
+        index += 1
+        for _ in str(f):
+            i += 1
+        if i == n:
+            break
+    return index
+
+
+if __name__ == "__main__":
+    print(solution(int(str(input()).strip())))


### PR DESCRIPTION
## Summary
- add missing Python implementation for Project Euler 25
- provide pure Mochi port that iteratively builds Fibonacci numbers and counts digits without string conversion
- include sample outputs from running the Mochi program

## Testing
- `python3 tests/github/TheAlgorithms/Python/project_euler/problem_025/sol3.py <<'EOF'
1000
EOF`
- `bin/mochi run tests/github/TheAlgorithms/Mochi/project_euler/problem_025/sol3.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6892a488aca88320b4335db6135fedd2