### PR TITLE
Add Mochi implementation for circular primes

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/project_euler/problem_035/sol1.mochi
+++ b/tests/github/TheAlgorithms/Mochi/project_euler/problem_035/sol1.mochi
@@ -1,0 +1,96 @@
+/*
+Project Euler Problem 35 - Circular Primes
+
+A circular prime is a prime number that remains prime under all rotations of its digits.
+For example, 197 generates the rotations 197, 971, and 719 which are all prime.
+
+Algorithm:
+1. Build a sieve of Eratosthenes marking primes up to the given limit.
+2. For each odd number without an even digit, generate all rotations of its digits.
+3. Use the sieve to verify that every rotation is also prime.
+4. Count the numbers that satisfy the circular prime property.
+
+The constant `LIMIT` controls the search range.  It is set to 10,000 here to
+keep the runtime short, but increasing it to 1,000,000 reproduces the original
+Project Euler problem.
+*/
+
+let LIMIT = 10000
+var sieve: list<bool> = []
+var i = 0
+while i <= LIMIT {
+  sieve = append(sieve, true)
+  i = i + 1
+}
+
+var p = 2
+while p * p <= LIMIT {
+  if sieve[p] {
+    var j = p * p
+    while j <= LIMIT {
+      sieve[j] = false
+      j = j + p
+    }
+  }
+  p = p + 1
+}
+
+fun is_prime(n: int): bool {
+  return sieve[n]
+}
+
+fun contains_an_even_digit(n: int): bool {
+  let s = str(n)
+  var idx = 0
+  while idx < len(s) {
+    let c = s[idx]
+    if c == "0" || c == "2" || c == "4" || c == "6" || c == "8" {
+      return true
+    }
+    idx = idx + 1
+  }
+  return false
+}
+
+fun parse_int(s: string): int {
+  var value = 0
+  var k = 0
+  while k < len(s) {
+    let ch = s[k]
+    value = value * 10 + (ch as int)
+    k = k + 1
+  }
+  return value
+}
+
+fun find_circular_primes(limit: int): list<int> {
+  var result: list<int> = [2]
+  var num = 3
+  while num <= limit {
+    if is_prime(num) && (contains_an_even_digit(num) == false) {
+      let s = str(num)
+      var all_prime = true
+      var j = 0
+      while j < len(s) {
+        let rotated_str = substring(s, j, len(s)) + substring(s, 0, j)
+        let rotated = parse_int(rotated_str)
+        if !is_prime(rotated) {
+          all_prime = false
+          break
+        }
+        j = j + 1
+      }
+      if all_prime {
+        result = append(result, num)
+      }
+    }
+    num = num + 2
+  }
+  return result
+}
+
+fun solution(): int {
+  return len(find_circular_primes(LIMIT))
+}
+
+print("len(find_circular_primes()) = " + str(solution()))

--- a/tests/github/TheAlgorithms/Mochi/project_euler/problem_035/sol1.out
+++ b/tests/github/TheAlgorithms/Mochi/project_euler/problem_035/sol1.out
@@ -1,0 +1,1 @@
+len(find_circular_primes()) = 33

--- a/tests/github/TheAlgorithms/Python/project_euler/problem_035/sol1.py
+++ b/tests/github/TheAlgorithms/Python/project_euler/problem_035/sol1.py
@@ -1,0 +1,83 @@
+"""
+Project Euler Problem 35
+https://projecteuler.net/problem=35
+
+Problem Statement:
+
+The number 197 is called a circular prime because all rotations of the digits:
+197, 971, and 719, are themselves prime.
+There are thirteen such primes below 100: 2, 3, 5, 7, 11, 13, 17, 31, 37, 71, 73,
+79, and 97.
+How many circular primes are there below one million?
+
+To solve this problem in an efficient manner, we will first mark all the primes
+below 1 million using the Sieve of Eratosthenes. Then, out of all these primes,
+we will rule out the numbers which contain an even digit. After this we will
+generate each circular combination of the number and check if all are prime.
+"""
+
+from __future__ import annotations
+
+sieve = [True] * 1000001
+i = 2
+while i * i <= 1000000:
+    if sieve[i]:
+        for j in range(i * i, 1000001, i):
+            sieve[j] = False
+    i += 1
+
+
+def is_prime(n: int) -> bool:
+    """
+    For 2 <= n <= 1000000, return True if n is prime.
+    >>> is_prime(87)
+    False
+    >>> is_prime(23)
+    True
+    >>> is_prime(25363)
+    False
+    """
+    return sieve[n]
+
+
+def contains_an_even_digit(n: int) -> bool:
+    """
+    Return True if n contains an even digit.
+    >>> contains_an_even_digit(0)
+    True
+    >>> contains_an_even_digit(975317933)
+    False
+    >>> contains_an_even_digit(-245679)
+    True
+    """
+    return any(digit in "02468" for digit in str(n))
+
+
+def find_circular_primes(limit: int = 1000000) -> list[int]:
+    """
+    Return circular primes below limit.
+    >>> len(find_circular_primes(100))
+    13
+    >>> len(find_circular_primes(1000000))
+    55
+    """
+    result = [2]  # result already includes the number 2.
+    for num in range(3, limit + 1, 2):
+        if is_prime(num) and not contains_an_even_digit(num):
+            str_num = str(num)
+            list_nums = [int(str_num[j:] + str_num[:j]) for j in range(len(str_num))]
+            if all(is_prime(i) for i in list_nums):
+                result.append(num)
+    return result
+
+
+def solution() -> int:
+    """
+    >>> solution()
+    55
+    """
+    return len(find_circular_primes())
+
+
+if __name__ == "__main__":
+    print(f"{len(find_circular_primes()) = }")


### PR DESCRIPTION
## Summary
- add Python solution for Project Euler problem 35 (circular primes)
- implement equivalent Mochi version with adjustable search limit and prime sieve
- record runtime output for the Mochi solution

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/project_euler/problem_035/sol1.mochi > tests/github/TheAlgorithms/Mochi/project_euler/problem_035/sol1.out`


------
https://chatgpt.com/codex/tasks/task_e_6892a5c3631c83208d9040629fa90a46