### PR TITLE
Add Mochi solution for Project Euler problem 39

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/project_euler/problem_039/sol1.mochi
+++ b/tests/github/TheAlgorithms/Mochi/project_euler/problem_039/sol1.mochi
@@ -1,0 +1,87 @@
+/*
+Problem 39 - Integer Right Triangles
+
+Given a bound on the perimeter p of a right angled triangle with integer side
+lengths (a, b, c) where a^2 + b^2 = c^2, count how many distinct Pythagorean
+triplets produce each perimeter.  Enumerating all integer pairs (a, b) up to the
+maximum perimeter and checking whether the hypotenuse is integral yields all
+triplets.  The perimeter with the highest number of solutions for p ≤ 1000 is
+then returned.
+
+The algorithm runs in O(p^2 log p) time where p is the maximum perimeter since it
+inspects each pair (a, b) once and uses binary search for integer square roots.
+Space complexity is O(p) to store counts for each perimeter.
+*/
+
+fun int_sqrt(n: int): int {
+  var low: int = 0
+  var high: int = n
+  while low <= high {
+    let mid = (low + high) / 2
+    let sq = mid * mid
+    if sq == n {
+      return mid
+    }
+    if sq < n {
+      low = mid + 1
+    } else {
+      high = mid - 1
+    }
+  }
+  return high
+}
+
+fun pythagorean_triple(max_perimeter: int): map<int, int> {
+  var triplets: map<int, int> = {}
+  var base: int = 1
+  while base <= max_perimeter {
+    var perpendicular: int = base
+    while perpendicular <= max_perimeter {
+      let hyp_sq = base * base + perpendicular * perpendicular
+      let hyp = int_sqrt(hyp_sq)
+      if hyp * hyp == hyp_sq {
+        let perimeter = base + perpendicular + hyp
+        if perimeter <= max_perimeter {
+          if perimeter in triplets {
+            triplets[perimeter] = triplets[perimeter] + 1
+          } else {
+            triplets[perimeter] = 1
+          }
+        }
+      }
+      perpendicular = perpendicular + 1
+    }
+    base = base + 1
+  }
+  return triplets
+}
+
+fun max_perimeter(counts: map<int, int>): int {
+  var best_p = 0
+  var max_count = 0
+  for p in counts {
+    let count = counts[p]
+    if (count > max_count) || ((count == max_count) && (p > best_p)) {
+      max_count = count
+      best_p = p
+    }
+  }
+  return best_p
+}
+
+fun solution(n: int): int {
+  let triplets = pythagorean_triple(n)
+  return max_perimeter(triplets)
+}
+
+fun main() {
+  let s200 = max_perimeter(pythagorean_triple(200))
+  let s100 = max_perimeter(pythagorean_triple(100))
+  print(str(s100))
+  print(str(s200))
+  let best = max_perimeter(pythagorean_triple(1000))
+  print(str(best))
+  print("Perimeter " + str(best) + " has maximum solutions")
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/project_euler/problem_039/sol1.out
+++ b/tests/github/TheAlgorithms/Mochi/project_euler/problem_039/sol1.out
@@ -1,0 +1,4 @@
+90
+180
+840
+Perimeter 840 has maximum solutions

--- a/tests/github/TheAlgorithms/Python/project_euler/problem_039/sol1.py
+++ b/tests/github/TheAlgorithms/Python/project_euler/problem_039/sol1.py
@@ -1,0 +1,55 @@
+"""
+Problem 39: https://projecteuler.net/problem=39
+
+If p is the perimeter of a right angle triangle with integral length sides,
+{a,b,c}, there are exactly three solutions for p = 120.
+{20,48,52}, {24,45,51}, {30,40,50}
+
+For which value of p ≤ 1000, is the number of solutions maximised?
+"""
+
+from __future__ import annotations
+
+import typing
+from collections import Counter
+
+
+def pythagorean_triple(max_perimeter: int) -> typing.Counter[int]:
+    """
+    Returns a dictionary with keys as the perimeter of a right angled triangle
+    and value as the number of corresponding triplets.
+    >>> pythagorean_triple(15)
+    Counter({12: 1})
+    >>> pythagorean_triple(40)
+    Counter({12: 1, 30: 1, 24: 1, 40: 1, 36: 1})
+    >>> pythagorean_triple(50)
+    Counter({12: 1, 30: 1, 24: 1, 40: 1, 36: 1, 48: 1})
+    """
+    triplets: typing.Counter[int] = Counter()
+    for base in range(1, max_perimeter + 1):
+        for perpendicular in range(base, max_perimeter + 1):
+            hypotenuse = (base * base + perpendicular * perpendicular) ** 0.5
+            if hypotenuse == int(hypotenuse):
+                perimeter = int(base + perpendicular + hypotenuse)
+                if perimeter > max_perimeter:
+                    continue
+                triplets[perimeter] += 1
+    return triplets
+
+
+def solution(n: int = 1000) -> int:
+    """
+    Returns perimeter with maximum solutions.
+    >>> solution(100)
+    90
+    >>> solution(200)
+    180
+    >>> solution(1000)
+    840
+    """
+    triplets = pythagorean_triple(n)
+    return triplets.most_common(1)[0][0]
+
+
+if __name__ == "__main__":
+    print(f"Perimeter {solution()} has maximum solutions")


### PR DESCRIPTION
## Summary
- sync Project Euler problem 39 Python source
- add pure Mochi implementation that enumerates right triangles and selects the perimeter with most solutions
- record VM output

## Testing
- `npm test` *(fails: Missing script "test")*
- `./mochi run tests/github/TheAlgorithms/Mochi/project_euler/problem_039/sol1.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892a5ed41ec8320ae1cc40e3bf0926f