### PR TITLE
Add Mochi solution for Project Euler 79

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/project_euler/problem_079/sol1.mochi
+++ b/tests/github/TheAlgorithms/Mochi/project_euler/problem_079/sol1.mochi
@@ -1,0 +1,122 @@
+/*
+Project Euler Problem 79 - Passcode derivation
+
+Given multiple successful login attempts each containing three ordered
+digits, determine the shortest possible secret passcode that satisfies all
+orderings.  For every permutation of the unique digits present in the
+attempts we check whether each triple appears in the same relative order.
+The first permutation that satisfies all constraints is the passcode.
+
+This implementation performs the search purely in Mochi using lists and
+recursion without any FFI or usage of the `any` type.
+*/
+
+fun parse_int(s: string): int {
+  var value = 0
+  var i = 0
+  while i < len(s) {
+    let c = s[i]
+    value = value * 10 + (c as int)
+    i = i + 1
+  }
+  return value
+}
+
+fun join(xs: list<string>): string {
+  var s = ""
+  var i = 0
+  while i < len(xs) {
+    s = s + xs[i]
+    i = i + 1
+  }
+  return s
+}
+
+fun contains(xs: list<string>, c: string): bool {
+  var i = 0
+  while i < len(xs) {
+    if xs[i] == c { return true }
+    i = i + 1
+  }
+  return false
+}
+
+fun index_of(xs: list<string>, c: string): int {
+  var i = 0
+  while i < len(xs) {
+    if xs[i] == c { return i }
+    i = i + 1
+  }
+  return -1
+}
+
+fun remove_at(xs: list<string>, idx: int): list<string> {
+  var res: list<string> = []
+  var i = 0
+  while i < len(xs) {
+    if i != idx { res = append(res, xs[i]) }
+    i = i + 1
+  }
+  return res
+}
+
+fun unique_chars(logins: list<string>): list<string> {
+  var chars: list<string> = []
+  var i = 0
+  while i < len(logins) {
+    let login = logins[i]
+    var j = 0
+    while j < len(login) {
+      let c = login[j]
+      if !contains(chars, c) {
+        chars = append(chars, c)
+      }
+      j = j + 1
+    }
+    i = i + 1
+  }
+  return chars
+}
+
+fun satisfies(permutation: list<string>, logins: list<string>): bool {
+  var i = 0
+  while i < len(logins) {
+    let login = logins[i]
+    let i0 = index_of(permutation, login[0])
+    let i1 = index_of(permutation, login[1])
+    let i2 = index_of(permutation, login[2])
+    if !(i0 < i1 && i1 < i2) { return false }
+    i = i + 1
+  }
+  return true
+}
+
+fun search(chars: list<string>, current: list<string>, logins: list<string>): string {
+  if len(chars) == 0 {
+    if satisfies(current, logins) { return join(current) }
+    return ""
+  }
+  var i = 0
+  while i < len(chars) {
+    let c = chars[i]
+    let rest = remove_at(chars, i)
+    let next = append(current, c)
+    let res = search(rest, next, logins)
+    if res != "" { return res }
+    i = i + 1
+  }
+  return ""
+}
+
+fun find_secret_passcode(logins: list<string>): int {
+  let chars = unique_chars(logins)
+  let s = search(chars, [], logins)
+  if s == "" { return -1 }
+  return parse_int(s)
+}
+
+let logins1: list<string> = ["135", "259", "235", "189", "690", "168", "120", "136", "289", "589", "160", "165", "580", "369", "250", "280"]
+print(str(find_secret_passcode(logins1)))
+
+let logins2: list<string> = ["426", "281", "061", "819", "268", "406", "420", "428", "209", "689", "019", "421", "469", "261", "681", "201"]
+print(str(find_secret_passcode(logins2)))

--- a/tests/github/TheAlgorithms/Mochi/project_euler/problem_079/sol1.out
+++ b/tests/github/TheAlgorithms/Mochi/project_euler/problem_079/sol1.out
@@ -1,0 +1,19 @@
+Mochi binary not found. Please run `npm install` again.
+node:internal/modules/cjs/loader:1368
+  throw err;
+  ^
+
+Error: Cannot find module '/workspace/mochi/runtime/vm'
+    at Function._resolveFilename (node:internal/modules/cjs/loader:1365:15)
+    at defaultResolveImpl (node:internal/modules/cjs/loader:1021:19)
+    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1026:22)
+    at Function._load (node:internal/modules/cjs/loader:1175:37)
+    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
+    at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
+    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:171:5)
+    at node:internal/main/run_main_module:36:49 {
+  code: 'MODULE_NOT_FOUND',
+  requireStack: []
+}
+
+Node.js v22.18.0

--- a/tests/github/TheAlgorithms/Python/project_euler/problem_079/sol1.py
+++ b/tests/github/TheAlgorithms/Python/project_euler/problem_079/sol1.py
@@ -1,0 +1,70 @@
+"""
+Project Euler Problem 79: https://projecteuler.net/problem=79
+
+Passcode derivation
+
+A common security method used for online banking is to ask the user for three
+random characters from a passcode. For example, if the passcode was 531278,
+they may ask for the 2nd, 3rd, and 5th characters; the expected reply would
+be: 317.
+
+The text file, keylog.txt, contains fifty successful login attempts.
+
+Given that the three characters are always asked for in order, analyse the file
+so as to determine the shortest possible secret passcode of unknown length.
+"""
+
+import itertools
+from pathlib import Path
+
+
+def find_secret_passcode(logins: list[str]) -> int:
+    """
+    Returns the shortest possible secret passcode of unknown length.
+
+    >>> find_secret_passcode(["135", "259", "235", "189", "690", "168", "120",
+    ...     "136", "289", "589", "160", "165", "580", "369", "250", "280"])
+    12365890
+
+    >>> find_secret_passcode(["426", "281", "061", "819" "268", "406", "420",
+    ...     "428", "209", "689", "019", "421", "469", "261", "681", "201"])
+    4206819
+    """
+
+    # Split each login by character e.g. '319' -> ('3', '1', '9')
+    split_logins = [tuple(login) for login in logins]
+
+    unique_chars = {char for login in split_logins for char in login}
+
+    for permutation in itertools.permutations(unique_chars):
+        satisfied = True
+        for login in logins:
+            if not (
+                permutation.index(login[0])
+                < permutation.index(login[1])
+                < permutation.index(login[2])
+            ):
+                satisfied = False
+                break
+
+        if satisfied:
+            return int("".join(permutation))
+
+    raise Exception("Unable to find the secret passcode")
+
+
+def solution(input_file: str = "keylog.txt") -> int:
+    """
+    Returns the shortest possible secret passcode of unknown length
+    for successful login attempts given by `input_file` text file.
+
+    >>> solution("keylog_test.txt")
+    6312980
+    """
+    logins = Path(__file__).parent.joinpath(input_file).read_text().splitlines()
+
+    return find_secret_passcode(logins)
+
+
+if __name__ == "__main__":
+    print(f"{solution() = }")


### PR DESCRIPTION
## Summary
- add Project Euler 79 passcode derivation reference Python implementation
- implement Project Euler 79 search for valid passcode purely in Mochi
- capture failed runtime attempts due to missing Mochi binary

## Testing
- `node index.js run tests/github/TheAlgorithms/Mochi/project_euler/problem_079/sol1.mochi` *(fails: Mochi binary not found)*
- `node runtime/vm tests/github/TheAlgorithms/Mochi/project_euler/problem_079/sol1.mochi.ir` *(fails: Cannot find module 'runtime/vm')*


------
https://chatgpt.com/codex/tasks/task_e_6892b509929c8320b002dd9ca88f08a0