### PR TITLE
Add non-preemptive SJF scheduling algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/scheduling/non_preemptive_shortest_job_first.mochi
+++ b/tests/github/TheAlgorithms/Mochi/scheduling/non_preemptive_shortest_job_first.mochi
@@ -1,0 +1,116 @@
+/*
+Non-Preemptive Shortest Job First Scheduling
+
+Given a set of processes with individual arrival times and CPU burst
+lengths, the scheduler always selects the process with the shortest
+remaining execution time among the processes that have already
+arrived. Once a process starts running it executes to completion
+(non-preemptive).  The waiting time of a process is the elapsed time
+between its arrival and the start of its execution.  The turnaround
+time is the total elapsed time from arrival to completion.
+
+This program implements two helper functions:
+1. calculate_waitingtime: simulate the dispatcher and compute waiting
+   times for every process.
+2. calculate_turnaroundtime: add each process's burst time to its
+   waiting time.
+
+The example in main reproduces the sample from TheAlgorithms/Python
+repository and prints a table together with average waiting and
+turnaround times.
+*/
+
+fun calculate_waitingtime(
+  arrival_time: list<int>,
+  burst_time: list<int>,
+  no_of_processes: int
+): list<int> {
+  var waiting_time: list<int>
+  var remaining_time: list<int>
+  var i = 0
+  while i < no_of_processes {
+    waiting_time = append(waiting_time, 0)
+    remaining_time = append(remaining_time, burst_time[i])
+    i = i + 1
+  }
+
+  var completed = 0
+  var total_time = 0
+
+  while completed != no_of_processes {
+    var ready_process: list<int> = []
+    var target_process = -1
+
+    var j = 0
+    while j < no_of_processes {
+      if arrival_time[j] <= total_time && remaining_time[j] > 0 {
+        ready_process = append(ready_process, j)
+      }
+      j = j + 1
+    }
+
+    if len(ready_process) > 0 {
+      target_process = ready_process[0]
+      var k = 0
+      while k < len(ready_process) {
+        let idx = ready_process[k]
+        if remaining_time[idx] < remaining_time[target_process] {
+          target_process = idx
+        }
+        k = k + 1
+      }
+      total_time = total_time + burst_time[target_process]
+      completed = completed + 1
+      remaining_time[target_process] = 0
+      waiting_time[target_process] = total_time - arrival_time[target_process] - burst_time[target_process]
+    } else {
+      total_time = total_time + 1
+    }
+  }
+  return waiting_time
+}
+
+fun calculate_turnaroundtime(
+  burst_time: list<int>,
+  no_of_processes: int,
+  waiting_time: list<int>
+): list<int> {
+  var turn_around_time: list<int>
+  var i = 0
+  while i < no_of_processes {
+    turn_around_time = append(turn_around_time, burst_time[i] + waiting_time[i])
+    i = i + 1
+  }
+  return turn_around_time
+}
+
+fun average(values: list<int>): float {
+  var total = 0
+  var i = 0
+  while i < len(values) {
+    total = total + values[i]
+    i = i + 1
+  }
+  return (total as float) / (len(values) as float)
+}
+
+print("[TEST CASE 01]")
+
+let no_of_processes = 4
+let burst_time: list<int> = [2, 5, 3, 7]
+let arrival_time: list<int> = [0, 0, 0, 0]
+let waiting_time = calculate_waitingtime(arrival_time, burst_time, no_of_processes)
+let turn_around_time = calculate_turnaroundtime(burst_time, no_of_processes, waiting_time)
+
+print("PID\tBurst Time\tArrival Time\tWaiting Time\tTurnaround Time")
+var i = 0
+while i < no_of_processes {
+  let pid = i + 1
+  print(str(pid) + "\t" + str(burst_time[i]) + "\t\t\t" + str(arrival_time[i]) + "\t\t\t\t" + str(waiting_time[i]) + "\t\t\t\t" + str(turn_around_time[i]))
+  i = i + 1
+}
+
+let avg_wait = average(waiting_time)
+let avg_turn = average(turn_around_time)
+print("\nAverage waiting time = " + str(avg_wait))
+print("Average turnaround time = " + str(avg_turn))

--- a/tests/github/TheAlgorithms/Mochi/scheduling/non_preemptive_shortest_job_first.out
+++ b/tests/github/TheAlgorithms/Mochi/scheduling/non_preemptive_shortest_job_first.out
@@ -1,0 +1,9 @@
+[TEST CASE 01]
+PID	Burst Time	Arrival Time	Waiting Time	Turnaround Time
+1	2			0				0				2
+2	5			0				5				10
+3	3			0				2				5
+4	7			0				10				17
+
+Average waiting time = 4.25
+Average turnaround time = 8.5

--- a/tests/github/TheAlgorithms/Python/scheduling/non_preemptive_shortest_job_first.py
+++ b/tests/github/TheAlgorithms/Python/scheduling/non_preemptive_shortest_job_first.py
@@ -1,0 +1,110 @@
+"""
+Non-preemptive Shortest Job First
+Shortest execution time process is chosen for the next execution.
+https://www.guru99.com/shortest-job-first-sjf-scheduling.html
+https://en.wikipedia.org/wiki/Shortest_job_next
+"""
+
+from __future__ import annotations
+
+from statistics import mean
+
+
+def calculate_waitingtime(
+    arrival_time: list[int], burst_time: list[int], no_of_processes: int
+) -> list[int]:
+    """
+    Calculate the waiting time of each processes
+
+    Return: The waiting time for each process.
+    >>> calculate_waitingtime([0,1,2], [10, 5, 8], 3)
+    [0, 9, 13]
+    >>> calculate_waitingtime([1,2,2,4], [4, 6, 3, 1], 4)
+    [0, 7, 4, 1]
+    >>> calculate_waitingtime([0,0,0], [12, 2, 10],3)
+    [12, 0, 2]
+    """
+
+    waiting_time = [0] * no_of_processes
+    remaining_time = [0] * no_of_processes
+
+    # Initialize remaining_time to waiting_time.
+
+    for i in range(no_of_processes):
+        remaining_time[i] = burst_time[i]
+    ready_process: list[int] = []
+
+    completed = 0
+    total_time = 0
+
+    # When processes are not completed,
+    # A process whose arrival time has passed \
+    # and has remaining execution time is put into the ready_process.
+    # The shortest process in the ready_process, target_process is executed.
+
+    while completed != no_of_processes:
+        ready_process = []
+        target_process = -1
+
+        for i in range(no_of_processes):
+            if (arrival_time[i] <= total_time) and (remaining_time[i] > 0):
+                ready_process.append(i)
+
+        if len(ready_process) > 0:
+            target_process = ready_process[0]
+            for i in ready_process:
+                if remaining_time[i] < remaining_time[target_process]:
+                    target_process = i
+            total_time += burst_time[target_process]
+            completed += 1
+            remaining_time[target_process] = 0
+            waiting_time[target_process] = (
+                total_time - arrival_time[target_process] - burst_time[target_process]
+            )
+        else:
+            total_time += 1
+
+    return waiting_time
+
+
+def calculate_turnaroundtime(
+    burst_time: list[int], no_of_processes: int, waiting_time: list[int]
+) -> list[int]:
+    """
+    Calculate the turnaround time of each process.
+
+    Return: The turnaround time for each process.
+    >>> calculate_turnaroundtime([0,1,2], 3, [0, 10, 15])
+    [0, 11, 17]
+    >>> calculate_turnaroundtime([1,2,2,4], 4, [1, 8, 5, 4])
+    [2, 10, 7, 8]
+    >>> calculate_turnaroundtime([0,0,0], 3, [12, 0, 2])
+    [12, 0, 2]
+    """
+
+    turn_around_time = [0] * no_of_processes
+    for i in range(no_of_processes):
+        turn_around_time[i] = burst_time[i] + waiting_time[i]
+    return turn_around_time
+
+
+if __name__ == "__main__":
+    print("[TEST CASE 01]")
+
+    no_of_processes = 4
+    burst_time = [2, 5, 3, 7]
+    arrival_time = [0, 0, 0, 0]
+    waiting_time = calculate_waitingtime(arrival_time, burst_time, no_of_processes)
+    turn_around_time = calculate_turnaroundtime(
+        burst_time, no_of_processes, waiting_time
+    )
+
+    # Printing the Result
+    print("PID\tBurst Time\tArrival Time\tWaiting Time\tTurnaround Time")
+    for i, process_id in enumerate(list(range(1, 5))):
+        print(
+            f"{process_id}\t{burst_time[i]}\t\t\t{arrival_time[i]}\t\t\t\t"
+            f"{waiting_time[i]}\t\t\t\t{turn_around_time[i]}"
+        )
+    print(f"\nAverage waiting time = {mean(waiting_time):.5f}")
+    print(f"Average turnaround time = {mean(turn_around_time):.5f}")


### PR DESCRIPTION
## Summary
- add Python source for non_preemptive_shortest_job_first
- implement equivalent Mochi version with waiting and turnaround time calculations
- include example run output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/scheduling/non_preemptive_shortest_job_first.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892c89bb3f08320a56f36bb427e8533