### PR TITLE
Port round robin scheduling algorithm to Mochi

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/scheduling/round_robin.mochi
+++ b/tests/github/TheAlgorithms/Mochi/scheduling/round_robin.mochi
@@ -1,0 +1,114 @@
+/*
+Simulate the Round Robin CPU scheduling algorithm.
+
+Each process has a burst time representing its required CPU time. Round
+Robin assigns a fixed time quantum to each process in a cyclic order.
+Processes that do not finish within their quantum are placed back in the
+queue with their remaining burst time. This continues until all processes
+finish.
+
+The algorithm computes two metrics:
+1. Waiting Time – total time a process spends waiting before its last
+   execution finishes.
+2. Turnaround Time – total time from arrival to completion, equal to burst
+   time plus waiting time.
+
+Implementation details:
+- `calculate_waiting_times` iteratively simulates execution with a
+  constant quantum (2 units) and records waiting times.
+- `calculate_turn_around_times` adds burst and waiting times for each
+  process.
+- `mean` computes the average of a list of integers.
+- `format_float_5` formats a float to 5 decimal places without using any
+  external libraries.
+
+Time complexity for computing waiting and turnaround times is
+O(n * m) where `n` is the number of processes and `m` is the number of
+quantum cycles required for the longest burst time.
+*/
+
+fun calculate_waiting_times(burst_times: list<int>): list<int> {
+  let quantum = 2
+  var rem: list<int> = []
+  var i = 0
+  while i < len(burst_times) {
+    rem = append(rem, burst_times[i])
+    i = i + 1
+  }
+  var waiting: list<int> = []
+  i = 0
+  while i < len(burst_times) {
+    waiting = append(waiting, 0)
+    i = i + 1
+  }
+  var t = 0
+  while true {
+    var done = true
+    var j = 0
+    while j < len(burst_times) {
+      if rem[j] > 0 {
+        done = false
+        if rem[j] > quantum {
+          t = t + quantum
+          rem[j] = rem[j] - quantum
+        } else {
+          t = t + rem[j]
+          waiting[j] = t - burst_times[j]
+          rem[j] = 0
+        }
+      }
+      j = j + 1
+    }
+    if done { return waiting }
+  }
+  return waiting
+}
+
+fun calculate_turn_around_times(burst_times: list<int>, waiting_times: list<int>): list<int> {
+  var result: list<int> = []
+  var i = 0
+  while i < len(burst_times) {
+    result = append(result, burst_times[i] + waiting_times[i])
+    i = i + 1
+  }
+  return result
+}
+
+fun mean(values: list<int>): float {
+  var total = 0
+  var i = 0
+  while i < len(values) {
+    total = total + values[i]
+    i = i + 1
+  }
+  return (total as float) / (len(values) as float)
+}
+
+fun format_float_5(x: float): string {
+  let scaled = int(x * 100000.0 + 0.5)
+  let int_part = scaled / 100000
+  let frac_part = scaled % 100000
+  var frac_str = str(frac_part)
+  while len(frac_str) < 5 {
+    frac_str = "0" + frac_str
+  }
+  return str(int_part) + "." + frac_str
+}
+
+fun main() {
+  let burst_times = [3, 5, 7]
+  let waiting_times = calculate_waiting_times(burst_times)
+  let turn_around_times = calculate_turn_around_times(burst_times, waiting_times)
+  print("Process ID \tBurst Time \tWaiting Time \tTurnaround Time")
+  var i = 0
+  while i < len(burst_times) {
+    let line = "  " + str(i + 1) + "\t\t  " + str(burst_times[i]) + "\t\t  " + str(waiting_times[i]) + "\t\t  " + str(turn_around_times[i])
+    print(line)
+    i = i + 1
+  }
+  print("")
+  print("Average waiting time = " + format_float_5(mean(waiting_times)))
+  print("Average turn around time = " + format_float_5(mean(turn_around_times)))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/scheduling/round_robin.out
+++ b/tests/github/TheAlgorithms/Mochi/scheduling/round_robin.out
@@ -1,0 +1,7 @@
+Process ID 	Burst Time 	Waiting Time 	Turnaround Time
+  1		  3		  4		  7
+  2		  5		  7		  12
+  3		  7		  8		  15
+
+Average waiting time = 6.33333
+Average turn around time = 11.33333

--- a/tests/github/TheAlgorithms/Python/scheduling/round_robin.py
+++ b/tests/github/TheAlgorithms/Python/scheduling/round_robin.py
@@ -1,0 +1,67 @@
+"""
+Round Robin is a scheduling algorithm.
+In Round Robin each process is assigned a fixed time slot in a cyclic way.
+https://en.wikipedia.org/wiki/Round-robin_scheduling
+"""
+
+from __future__ import annotations
+
+from statistics import mean
+
+
+def calculate_waiting_times(burst_times: list[int]) -> list[int]:
+    """
+    Calculate the waiting times of a list of processes that have a specified duration.
+
+    Return: The waiting time for each process.
+    >>> calculate_waiting_times([10, 5, 8])
+    [13, 10, 13]
+    >>> calculate_waiting_times([4, 6, 3, 1])
+    [5, 8, 9, 6]
+    >>> calculate_waiting_times([12, 2, 10])
+    [12, 2, 12]
+    """
+    quantum = 2
+    rem_burst_times = list(burst_times)
+    waiting_times = [0] * len(burst_times)
+    t = 0
+    while True:
+        done = True
+        for i, burst_time in enumerate(burst_times):
+            if rem_burst_times[i] > 0:
+                done = False
+                if rem_burst_times[i] > quantum:
+                    t += quantum
+                    rem_burst_times[i] -= quantum
+                else:
+                    t += rem_burst_times[i]
+                    waiting_times[i] = t - burst_time
+                    rem_burst_times[i] = 0
+        if done is True:
+            return waiting_times
+
+
+def calculate_turn_around_times(
+    burst_times: list[int], waiting_times: list[int]
+) -> list[int]:
+    """
+    >>> calculate_turn_around_times([1, 2, 3, 4], [0, 1, 3])
+    [1, 3, 6]
+    >>> calculate_turn_around_times([10, 3, 7], [10, 6, 11])
+    [20, 9, 18]
+    """
+    return [burst + waiting for burst, waiting in zip(burst_times, waiting_times)]
+
+
+if __name__ == "__main__":
+    burst_times = [3, 5, 7]
+    waiting_times = calculate_waiting_times(burst_times)
+    turn_around_times = calculate_turn_around_times(burst_times, waiting_times)
+    print("Process ID \tBurst Time \tWaiting Time \tTurnaround Time")
+    for i, burst_time in enumerate(burst_times):
+        print(
+            f"  {i + 1}\t\t  {burst_time}\t\t  {waiting_times[i]}\t\t  "
+            f"{turn_around_times[i]}"
+        )
+    print(f"\nAverage waiting time = {mean(waiting_times):.5f}")
+    print(f"Average turn around time = {mean(turn_around_times):.5f}")


### PR DESCRIPTION
## Summary
- add Python reference implementation for Round Robin CPU scheduling
- implement Round Robin scheduling in Mochi with waiting/turnaround time calculations
- include example output generated via runtime/vm

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/scheduling/round_robin.mochi`
- `npm test` *(fails: Missing script: "test")*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6892c89d0ebc83208d13cfddde1472f3