### PR TITLE
Add shortest job first scheduling algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/scheduling/shortest_job_first.mochi
+++ b/tests/github/TheAlgorithms/Mochi/scheduling/shortest_job_first.mochi
@@ -1,0 +1,113 @@
+/*
+Shortest Job First (Shortest Remaining Time First) Scheduling
+
+Given lists of arrival times and burst times for a set of processes,
+this algorithm schedules the CPU so that at any moment the process with
+least remaining burst time among arrived processes runs. It computes for
+each process its waiting time and turnaround time and also reports the
+average waiting and turnaround times.
+
+Algorithm:
+1. Maintain arrays for remaining time and waiting time for all processes.
+2. At each time increment, select the available process with minimum
+   remaining time.
+3. Run the selected process for one unit, updating remaining time.
+4. When a process completes, record its waiting time.
+5. After all processes finish, compute turnaround times and averages.
+
+Time Complexity: O(n^2) in the worst case due to the inner loop checking
+all processes at each time step.
+*/
+
+fun calculate_waitingtime(arrival_time: list<int>, burst_time: list<int>, no_of_processes: int): list<int> {
+  var remaining_time: list<int> = []
+  var i = 0
+  while i < no_of_processes {
+    remaining_time = append(remaining_time, burst_time[i])
+    i = i + 1
+  }
+  var waiting_time: list<int> = []
+  i = 0
+  while i < no_of_processes {
+    waiting_time = append(waiting_time, 0)
+    i = i + 1
+  }
+  var complete = 0
+  var increment_time = 0
+  var minm = 1000000000
+  var short = 0
+  var check = false
+  while complete != no_of_processes {
+    var j = 0
+    while j < no_of_processes {
+      if arrival_time[j] <= increment_time && remaining_time[j] > 0 && remaining_time[j] < minm {
+        minm = remaining_time[j]
+        short = j
+        check = true
+      }
+      j = j + 1
+    }
+    if !check {
+      increment_time = increment_time + 1
+      continue
+    }
+    remaining_time[short] = remaining_time[short] - 1
+    minm = remaining_time[short]
+    if minm == 0 {
+      minm = 1000000000
+    }
+    if remaining_time[short] == 0 {
+      complete = complete + 1
+      check = false
+      let finish_time = increment_time + 1
+      let finar = finish_time - arrival_time[short]
+      waiting_time[short] = finar - burst_time[short]
+      if waiting_time[short] < 0 {
+        waiting_time[short] = 0
+      }
+    }
+    increment_time = increment_time + 1
+  }
+  return waiting_time
+}
+
+fun calculate_turnaroundtime(burst_time: list<int>, no_of_processes: int, waiting_time: list<int>): list<int> {
+  var turn_around_time: list<int> = []
+  var i = 0
+  while i < no_of_processes {
+    turn_around_time = append(turn_around_time, burst_time[i] + waiting_time[i])
+    i = i + 1
+  }
+  return turn_around_time
+}
+
+fun to_float(x: int): float {
+  return x * 1.0
+}
+
+fun calculate_average_times(waiting_time: list<int>, turn_around_time: list<int>, no_of_processes: int): void {
+  var total_waiting_time = 0
+  var total_turn_around_time = 0
+  var i = 0
+  while i < no_of_processes {
+    total_waiting_time = total_waiting_time + waiting_time[i]
+    total_turn_around_time = total_turn_around_time + turn_around_time[i]
+    i = i + 1
+  }
+  let avg_wait = to_float(total_waiting_time) / to_float(no_of_processes)
+  let avg_turn = to_float(total_turn_around_time) / to_float(no_of_processes)
+  print("Average waiting time = " + str(avg_wait))
+  print("Average turn around time = " + str(avg_turn))
+}
+
+print(calculate_waitingtime([1, 2, 3, 4], [3, 3, 5, 1], 4))
+print(calculate_waitingtime([1, 2, 3], [2, 5, 1], 3))
+print(calculate_waitingtime([2, 3], [5, 1], 2))
+
+print(calculate_turnaroundtime([3, 3, 5, 1], 4, [0, 3, 5, 0]))
+print(calculate_turnaroundtime([3, 3], 2, [0, 3]))
+print(calculate_turnaroundtime([8, 10, 1], 3, [1, 0, 3]))
+
+calculate_average_times([0, 3, 5, 0], [3, 6, 10, 1], 4)
+calculate_average_times([2, 3], [3, 6], 2)
+calculate_average_times([10, 4, 3], [2, 7, 6], 3)

--- a/tests/github/TheAlgorithms/Mochi/scheduling/shortest_job_first.out
+++ b/tests/github/TheAlgorithms/Mochi/scheduling/shortest_job_first.out
@@ -1,0 +1,12 @@
+[0, 3, 5, 0]
+[0, 2, 0]
+[1, 0]
+[3, 6, 10, 1]
+[3, 6]
+[9, 10, 4]
+Average waiting time = 2
+Average turn around time = 5
+Average waiting time = 2.5
+Average turn around time = 4.5
+Average waiting time = 5.666666666666667
+Average turn around time = 5

--- a/tests/github/TheAlgorithms/Python/scheduling/shortest_job_first.py
+++ b/tests/github/TheAlgorithms/Python/scheduling/shortest_job_first.py
@@ -1,0 +1,153 @@
+"""
+Shortest job remaining first
+Please note arrival time and burst
+Please use spaces to separate times entered.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def calculate_waitingtime(
+    arrival_time: list[int], burst_time: list[int], no_of_processes: int
+) -> list[int]:
+    """
+    Calculate the waiting time of each processes
+    Return: List of waiting times.
+    >>> calculate_waitingtime([1,2,3,4],[3,3,5,1],4)
+    [0, 3, 5, 0]
+    >>> calculate_waitingtime([1,2,3],[2,5,1],3)
+    [0, 2, 0]
+    >>> calculate_waitingtime([2,3],[5,1],2)
+    [1, 0]
+    """
+    remaining_time = [0] * no_of_processes
+    waiting_time = [0] * no_of_processes
+    # Copy the burst time into remaining_time[]
+    for i in range(no_of_processes):
+        remaining_time[i] = burst_time[i]
+
+    complete = 0
+    increment_time = 0
+    minm = 999999999
+    short = 0
+    check = False
+
+    # Process until all processes are completed
+    while complete != no_of_processes:
+        for j in range(no_of_processes):
+            if (
+                arrival_time[j] <= increment_time
+                and remaining_time[j] > 0
+                and remaining_time[j] < minm
+            ):
+                minm = remaining_time[j]
+                short = j
+                check = True
+
+        if not check:
+            increment_time += 1
+            continue
+        remaining_time[short] -= 1
+
+        minm = remaining_time[short]
+        if minm == 0:
+            minm = 999999999
+
+        if remaining_time[short] == 0:
+            complete += 1
+            check = False
+
+            # Find finish time of current process
+            finish_time = increment_time + 1
+
+            # Calculate waiting time
+            finar = finish_time - arrival_time[short]
+            waiting_time[short] = finar - burst_time[short]
+
+            waiting_time[short] = max(waiting_time[short], 0)
+
+        # Increment time
+        increment_time += 1
+    return waiting_time
+
+
+def calculate_turnaroundtime(
+    burst_time: list[int], no_of_processes: int, waiting_time: list[int]
+) -> list[int]:
+    """
+    Calculate the turn around time of each Processes
+    Return: list of turn around times.
+    >>> calculate_turnaroundtime([3,3,5,1], 4, [0,3,5,0])
+    [3, 6, 10, 1]
+    >>> calculate_turnaroundtime([3,3], 2, [0,3])
+    [3, 6]
+    >>> calculate_turnaroundtime([8,10,1], 3, [1,0,3])
+    [9, 10, 4]
+    """
+    turn_around_time = [0] * no_of_processes
+    for i in range(no_of_processes):
+        turn_around_time[i] = burst_time[i] + waiting_time[i]
+    return turn_around_time
+
+
+def calculate_average_times(
+    waiting_time: list[int], turn_around_time: list[int], no_of_processes: int
+) -> None:
+    """
+    This function calculates the average of the waiting & turnaround times
+    Prints: Average Waiting time & Average Turn Around Time
+    >>> calculate_average_times([0,3,5,0],[3,6,10,1],4)
+    Average waiting time = 2.00000
+    Average turn around time = 5.0
+    >>> calculate_average_times([2,3],[3,6],2)
+    Average waiting time = 2.50000
+    Average turn around time = 4.5
+    >>> calculate_average_times([10,4,3],[2,7,6],3)
+    Average waiting time = 5.66667
+    Average turn around time = 5.0
+    """
+    total_waiting_time = 0
+    total_turn_around_time = 0
+    for i in range(no_of_processes):
+        total_waiting_time = total_waiting_time + waiting_time[i]
+        total_turn_around_time = total_turn_around_time + turn_around_time[i]
+    print(f"Average waiting time = {total_waiting_time / no_of_processes:.5f}")
+    print("Average turn around time =", total_turn_around_time / no_of_processes)
+
+
+if __name__ == "__main__":
+    print("Enter how many process you want to analyze")
+    no_of_processes = int(input())
+    burst_time = [0] * no_of_processes
+    arrival_time = [0] * no_of_processes
+    processes = list(range(1, no_of_processes + 1))
+
+    for i in range(no_of_processes):
+        print("Enter the arrival time and burst time for process:--" + str(i + 1))
+        arrival_time[i], burst_time[i] = map(int, input().split())
+
+    waiting_time = calculate_waitingtime(arrival_time, burst_time, no_of_processes)
+
+    bt = burst_time
+    n = no_of_processes
+    wt = waiting_time
+    turn_around_time = calculate_turnaroundtime(bt, n, wt)
+
+    calculate_average_times(waiting_time, turn_around_time, no_of_processes)
+
+    fcfs = pd.DataFrame(
+        list(zip(processes, burst_time, arrival_time, waiting_time, turn_around_time)),
+        columns=[
+            "Process",
+            "BurstTime",
+            "ArrivalTime",
+            "WaitingTime",
+            "TurnAroundTime",
+        ],
+    )
+
+    # Printing the dataFrame
+    pd.set_option("display.max_rows", fcfs.shape[0] + 1)
+    print(fcfs)


### PR DESCRIPTION
## Summary
- add missing Python reference for shortest job first scheduler
- implement shortest job first scheduling in Mochi with waiting, turnaround, and averages output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/scheduling/shortest_job_first.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892c89ea2148320aeeaf9be75a5e6db