### PR TITLE
feat: add Mochi directory markdown builder

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/scripts/build_directory_md.mochi
+++ b/tests/github/TheAlgorithms/Mochi/scripts/build_directory_md.mochi
@@ -1,0 +1,227 @@
+/*
+Generate Directory Markdown
+
+Replicates TheAlgorithms/Python script build_directory_md.py.
+Given a collection of file paths it prints a hierarchical Markdown
+outline. Directories named "scripts", starting with '.' or '_', or
+containing "venv" are skipped. Files named "__init__.py" are ignored and
+only *.py or *.ipynb files are included. Directory names and file titles
+replace underscores with spaces and are converted to title case. Output
+uses Markdown headers for new directories and bullets for files.
+
+Algorithm:
+1. Filter paths to remove excluded directories and files.
+2. Sort remaining paths lexicographically.
+3. Iterate through paths, printing new directories when the prefix
+   differs from the previous path.
+4. Print each file as a Markdown bullet linking to the file with spaces
+   encoded as %20.
+*/
+
+fun split(s: string, sep: string): list<string> {
+  var parts: list<string> = []
+  var cur = ""
+  var i = 0
+  while i < len(s) {
+    if len(sep) > 0 && i + len(sep) <= len(s) && substring(s, i, i + len(sep)) == sep {
+      parts = append(parts, cur)
+      cur = ""
+      i = i + len(sep)
+    } else {
+      cur = cur + substring(s, i, i + 1)
+      i = i + 1
+    }
+  }
+  parts = append(parts, cur)
+  return parts
+}
+
+fun join(xs: list<string>, sep: string): string {
+  var res = ""
+  var i = 0
+  while i < len(xs) {
+    if i > 0 { res = res + sep }
+    res = res + xs[i]
+    i = i + 1
+  }
+  return res
+}
+
+fun repeat(s: string, n: int): string {
+  var out = ""
+  var i = 0
+  while i < n {
+    out = out + s
+    i = i + 1
+  }
+  return out
+}
+
+fun replace_char(s: string, old: string, new: string): string {
+  var out = ""
+  var i = 0
+  while i < len(s) {
+    let c = substring(s, i, i + 1)
+    if c == old {
+      out = out + new
+    } else {
+      out = out + c
+    }
+    i = i + 1
+  }
+  return out
+}
+
+fun contains(s: string, sub: string): bool {
+  if len(sub) == 0 { return true }
+  var i = 0
+  while i + len(sub) <= len(s) {
+    if substring(s, i, i + len(sub)) == sub { return true }
+    i = i + 1
+  }
+  return false
+}
+
+fun file_extension(name: string): string {
+  var i = len(name) - 1
+  while i >= 0 {
+    if substring(name, i, i + 1) == "." {
+      return name[i:]
+    }
+    i = i - 1
+  }
+  return ""
+}
+
+fun remove_extension(name: string): string {
+  var i = len(name) - 1
+  while i >= 0 {
+    if substring(name, i, i + 1) == "." {
+      return name[:i]
+    }
+    i = i - 1
+  }
+  return name
+}
+
+fun title_case(s: string): string {
+  var out = ""
+  var cap = true
+  var i = 0
+  while i < len(s) {
+    let c = substring(s, i, i + 1)
+    if c == " " {
+      out = out + c
+      cap = true
+    } else {
+      if cap {
+        out = out + upper(c)
+        cap = false
+      } else {
+        out = out + lower(c)
+      }
+    }
+    i = i + 1
+  }
+  return out
+}
+
+fun count_char(s: string, ch: string): int {
+  var cnt = 0
+  var i = 0
+  while i < len(s) {
+    if substring(s, i, i + 1) == ch { cnt = cnt + 1 }
+    i = i + 1
+  }
+  return cnt
+}
+
+fun md_prefix(level: int): string {
+  if level == 0 { return "\n##" }
+  return repeat("  ", level) + "*"
+}
+
+fun print_path(old_path: string, new_path: string): string {
+  let old_parts = split(old_path, "/")
+  let new_parts = split(new_path, "/")
+  var i = 0
+  while i < len(new_parts) {
+    if (i >= len(old_parts) || old_parts[i] != new_parts[i]) && new_parts[i] != "" {
+      let title = title_case(replace_char(new_parts[i], "_", " "))
+      print(md_prefix(i) + " " + title)
+    }
+    i = i + 1
+  }
+  return new_path
+}
+
+fun sort_strings(xs: list<string>): list<string> {
+  var arr = xs
+  var i = 0
+  while i < len(arr) {
+    var min_idx = i
+    var j = i + 1
+    while j < len(arr) {
+      if arr[j] < arr[min_idx] { min_idx = j }
+      j = j + 1
+    }
+    let tmp = arr[i]
+    arr[i] = arr[min_idx]
+    arr[min_idx] = tmp
+    i = i + 1
+  }
+  return arr
+}
+
+fun good_file_paths(paths: list<string>): list<string> {
+  var res: list<string> = []
+  for p in paths {
+    let parts = split(p, "/")
+    var skip = false
+    var k = 0
+    while k < len(parts) - 1 {
+      let part = parts[k]
+      if part == "scripts" || part[0:1] == "." || part[0:1] == "_" || contains(part, "venv") {
+        skip = true
+      }
+      k = k + 1
+    }
+    if skip { continue }
+    let filename = parts[len(parts) - 1]
+    if filename == "__init__.py" { continue }
+    let ext = file_extension(filename)
+    if ext == ".py" || ext == ".ipynb" {
+      res = append(res, p)
+    }
+  }
+  return res
+}
+
+fun print_directory_md(paths: list<string>) {
+  var files = sort_strings(good_file_paths(paths))
+  var old_path = ""
+  var i = 0
+  while i < len(files) {
+    let fp = files[i]
+    let parts = split(fp, "/")
+    let filename = parts[len(parts) - 1]
+    var filepath = ""
+    if len(parts) > 1 { filepath = join(parts[:len(parts)-1], "/") }
+    if filepath != old_path { old_path = print_path(old_path, filepath) }
+    var indent = 0
+    if len(filepath) > 0 { indent = count_char(filepath, "/") + 1 }
+    let url = replace_char(fp, " ", "%20")
+    let name = title_case(replace_char(remove_extension(filename), "_", " "))
+    print(md_prefix(indent) + " [" + name + "](" + url + ")")
+    i = i + 1
+  }
+}
+
+let sample = [
+  "data_structures/linked_list.py",
+  "data_structures/binary_tree.py",
+  "math/number_theory/prime_check.py",
+  "math/number_theory/greatest_common_divisor.ipynb"
+]
+
+print_directory_md(sample)

--- a/tests/github/TheAlgorithms/Mochi/scripts/build_directory_md.out
+++ b/tests/github/TheAlgorithms/Mochi/scripts/build_directory_md.out
@@ -1,0 +1,9 @@
+
+## Data Structures
+  * [Binary Tree](data_structures/binary_tree.py)
+  * [Linked List](data_structures/linked_list.py)
+
+## Math
+  * Number Theory
+    * [Greatest Common Divisor](math/number_theory/greatest_common_divisor.ipynb)
+    * [Prime Check](math/number_theory/prime_check.py)

--- a/tests/github/TheAlgorithms/Python/scripts/build_directory_md.py
+++ b/tests/github/TheAlgorithms/Python/scripts/build_directory_md.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import os
+from collections.abc import Iterator
+
+
+def good_file_paths(top_dir: str = ".") -> Iterator[str]:
+    for dir_path, dir_names, filenames in os.walk(top_dir):
+        dir_names[:] = [
+            d
+            for d in dir_names
+            if d != "scripts" and d[0] not in "._" and "venv" not in d
+        ]
+        for filename in filenames:
+            if filename == "__init__.py":
+                continue
+            if os.path.splitext(filename)[1] in (".py", ".ipynb"):
+                yield os.path.join(dir_path, filename).lstrip("./")
+
+
+def md_prefix(i):
+    return f"{i * '  '}*" if i else "\n##"
+
+
+def print_path(old_path: str, new_path: str) -> str:
+    old_parts = old_path.split(os.sep)
+    for i, new_part in enumerate(new_path.split(os.sep)):
+        if (i + 1 > len(old_parts) or old_parts[i] != new_part) and new_part:
+            print(f"{md_prefix(i)} {new_part.replace('_', ' ').title()}")
+    return new_path
+
+
+def print_directory_md(top_dir: str = ".") -> None:
+    old_path = ""
+    for filepath in sorted(good_file_paths(top_dir)):
+        filepath, filename = os.path.split(filepath)
+        if filepath != old_path:
+            old_path = print_path(old_path, filepath)
+        indent = (filepath.count(os.sep) + 1) if filepath else 0
+        url = f"{filepath}/{filename}".replace(" ", "%20")
+        filename = os.path.splitext(filename.replace("_", " ").title())[0]
+        print(f"{md_prefix(indent)} [{filename}]({url})")
+
+
+if __name__ == "__main__":
+    print_directory_md(".")


### PR DESCRIPTION
## Summary
- add `build_directory_md.py` from TheAlgorithms/Python
- port directory markdown builder to Mochi with sample output

## Testing
- `npm test` (fails: Missing script)
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6892c8a037c483209e1f028d6dcd2e3a