### PR TITLE
Add Mochi translation for validate_filenames script

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/scripts/validate_filenames.mochi
+++ b/tests/github/TheAlgorithms/Mochi/scripts/validate_filenames.mochi
@@ -1,0 +1,82 @@
+/*
+Validate Filenames
+------------------
+This program checks a list of file paths for common formatting issues.
+For each path it flags four potential problems:
+  1. Uppercase characters
+  2. Space characters
+  3. Hyphen characters (excluding paths containing "/site-packages/")
+  4. Files not located inside a directory (no '/' present)
+
+The `validate` function returns the total number of problematic files and
+prints each offending file grouped by issue. The code avoids the `any`
+type and uses only Mochi built-ins so it can run on the `runtime/vm`.
+*/
+
+fun indexOf(s: string, sub: string): int {
+  let n = len(s)
+  let m = len(sub)
+  var i = 0
+  while i <= n - m {
+    if substring(s, i, i + m) == sub { return i }
+    i = i + 1
+  }
+  return -1
+}
+
+fun contains(s: string, sub: string): bool {
+  return indexOf(s, sub) >= 0
+}
+
+fun validate(files: list<string>): int {
+  var upper: list<string> = []
+  var space: list<string> = []
+  var hyphen: list<string> = []
+  var nodir: list<string> = []
+
+  for f in files {
+    if f != lower(f) { upper = append(upper, f) }
+    if contains(f, " ") { space = append(space, f) }
+    if contains(f, "-") && contains(f, "/site-packages/") == false {
+      hyphen = append(hyphen, f)
+    }
+    if !contains(f, "/") { nodir = append(nodir, f) }
+  }
+
+  if len(upper) > 0 {
+    print(str(len(upper)) + " files contain uppercase characters:")
+    for f in upper { print(f) }
+    print("")
+  }
+  if len(space) > 0 {
+    print(str(len(space)) + " files contain space characters:")
+    for f in space { print(f) }
+    print("")
+  }
+  if len(hyphen) > 0 {
+    print(str(len(hyphen)) + " files contain hyphen characters:")
+    for f in hyphen { print(f) }
+    print("")
+  }
+  if len(nodir) > 0 {
+    print(str(len(nodir)) + " files are not in a directory:")
+    for f in nodir { print(f) }
+    print("")
+  }
+  return len(upper) + len(space) + len(hyphen) + len(nodir)
+}
+
+fun main() {
+  let files: list<string> = [
+    "scripts/Validate_filenames.py",
+    "good/file.txt",
+    "bad file.txt",
+    "/site-packages/pkg-name.py",
+    "nopath",
+    "src/hyphen-name.py"
+  ]
+  let bad = validate(files)
+  print(str(bad))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/scripts/validate_filenames.mochi.out
+++ b/tests/github/TheAlgorithms/Mochi/scripts/validate_filenames.mochi.out
@@ -1,0 +1,14 @@
+1 files contain uppercase characters:
+scripts/Validate_filenames.py
+
+1 files contain space characters:
+bad file.txt
+
+1 files contain hyphen characters:
+src/hyphen-name.py
+
+2 files are not in a directory:
+bad file.txt
+nopath
+
+5

--- a/tests/github/TheAlgorithms/Python/scripts/validate_filenames.py
+++ b/tests/github/TheAlgorithms/Python/scripts/validate_filenames.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import os
+
+try:
+    from .build_directory_md import good_file_paths
+except ImportError:
+    from build_directory_md import good_file_paths  # type: ignore[no-redef]
+
+filepaths = list(good_file_paths())
+assert filepaths, "good_file_paths() failed!"
+
+if upper_files := [file for file in filepaths if file != file.lower()]:
+    print(f"{len(upper_files)} files contain uppercase characters:")
+    print("\n".join(upper_files) + "\n")
+
+if space_files := [file for file in filepaths if " " in file]:
+    print(f"{len(space_files)} files contain space characters:")
+    print("\n".join(space_files) + "\n")
+
+if hyphen_files := [
+    file for file in filepaths if "-" in file and "/site-packages/" not in file
+]:
+    print(f"{len(hyphen_files)} files contain hyphen characters:")
+    print("\n".join(hyphen_files) + "\n")
+
+if nodir_files := [file for file in filepaths if os.sep not in file]:
+    print(f"{len(nodir_files)} files are not in a directory:")
+    print("\n".join(nodir_files) + "\n")
+
+if bad_files := len(upper_files + space_files + hyphen_files + nodir_files):
+    import sys
+
+    sys.exit(bad_files)


### PR DESCRIPTION
## Summary
- add missing Python script `validate_filenames.py`
- implement Mochi version that checks filenames for uppercase, spaces, hyphens (excluding `/site-packages/`), and missing directories
- include sample run output

## Testing
- `go test ./...` *(fails: C source files not allowed when not using cgo or SWIG: q1.c)*
- `go test ./runtime/vm`
- `go run runner.go tests/github/TheAlgorithms/Mochi/scripts/validate_filenames.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892c8a282948320af8776bb64804362