### PR TITLE
Add Mochi validation script for Project Euler solutions

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/scripts/validate_solutions.mochi
+++ b/tests/github/TheAlgorithms/Mochi/scripts/validate_solutions.mochi
@@ -1,0 +1,64 @@
+/*
+Project Euler Solution Validator
+--------------------------------
+This Mochi program mirrors the logic of TheAlgorithms/Python
+`scripts/validate_solutions.py`. It demonstrates how a Project Euler
+solution can be verified by comparing the SHA-256 hash of the solution's
+output with the known correct hash.
+
+Algorithm:
+1. Compute the solution to Project Euler problem 1: sum all integers
+   below 1000 that are multiples of 3 or 5.
+2. Convert the numeric answer to a string and hash it using the built-in
+   `sha256` function.
+3. Encode the hash as hexadecimal for comparison.
+4. Check the computed hash against the expected value and report success
+   or failure.
+
+This implementation is pure Mochi (no FFI) and is runnable with
+`runtime/vm`.
+*/
+
+let HEX = "0123456789abcdef"
+
+fun byte_to_hex(b: int): string {
+  let hi = b / 16
+  let lo = b % 16
+  return HEX[hi] + HEX[lo]
+}
+
+fun bytes_to_hex(bs: list<int>): string {
+  var res = ""
+  var i = 0
+  while i < len(bs) {
+    res = res + byte_to_hex(bs[i])
+    i = i + 1
+  }
+  return res
+}
+
+fun sha256_hex(s: string): string {
+  return bytes_to_hex(sha256(s))
+}
+
+fun solution_001(): string {
+  var total = 0
+  var n = 0
+  while n < 1000 {
+    if n % 3 == 0 || n % 5 == 0 {
+      total = total + n
+    }
+    n = n + 1
+  }
+  return str(total)
+}
+
+let expected = sha256_hex("233168")
+let answer = solution_001()
+let computed = sha256_hex(answer)
+
+if computed == expected {
+  print("Problem 001 passed")
+} else {
+  print("Problem 001 failed: " + computed + " != " + expected)
+}

--- a/tests/github/TheAlgorithms/Mochi/scripts/validate_solutions.out
+++ b/tests/github/TheAlgorithms/Mochi/scripts/validate_solutions.out
@@ -1,0 +1,1 @@
+Problem 001 passed

--- a/tests/github/TheAlgorithms/Python/scripts/validate_solutions.py
+++ b/tests/github/TheAlgorithms/Python/scripts/validate_solutions.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "httpx",
+#     "pytest",
+# ]
+# ///
+
+import hashlib
+import importlib.util
+import json
+import os
+import pathlib
+from types import ModuleType
+
+import httpx
+import pytest
+
+PROJECT_EULER_DIR_PATH = pathlib.Path.cwd().joinpath("project_euler")
+PROJECT_EULER_ANSWERS_PATH = pathlib.Path.cwd().joinpath(
+    "scripts", "project_euler_answers.json"
+)
+
+with open(PROJECT_EULER_ANSWERS_PATH) as file_handle:
+    PROBLEM_ANSWERS: dict[str, str] = json.load(file_handle)
+
+
+def convert_path_to_module(file_path: pathlib.Path) -> ModuleType:
+    """Converts a file path to a Python module"""
+    spec = importlib.util.spec_from_file_location(file_path.name, str(file_path))
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+def all_solution_file_paths() -> list[pathlib.Path]:
+    """Collects all the solution file path in the Project Euler directory"""
+    solution_file_paths = []
+    for problem_dir_path in PROJECT_EULER_DIR_PATH.iterdir():
+        if problem_dir_path.is_file() or problem_dir_path.name.startswith("_"):
+            continue
+        for file_path in problem_dir_path.iterdir():
+            if file_path.suffix != ".py" or file_path.name.startswith(("_", "test")):
+                continue
+            solution_file_paths.append(file_path)
+    return solution_file_paths
+
+
+def get_files_url() -> str:
+    """Return the pull request number which triggered this action."""
+    with open(os.environ["GITHUB_EVENT_PATH"]) as file:
+        event = json.load(file)
+    return event["pull_request"]["url"] + "/files"
+
+
+def added_solution_file_path() -> list[pathlib.Path]:
+    """Collects only the solution file path which got added in the current
+    pull request.
+
+    This will only be triggered if the script is ran from GitHub Actions.
+    """
+    solution_file_paths = []
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "Authorization": "token " + os.environ["GITHUB_TOKEN"],
+    }
+    files = httpx.get(get_files_url(), headers=headers, timeout=10).json()
+    for file in files:
+        filepath = pathlib.Path.cwd().joinpath(file["filename"])
+        if (
+            filepath.suffix != ".py"
+            or filepath.name.startswith(("_", "test"))
+            or not filepath.name.startswith("sol")
+        ):
+            continue
+        solution_file_paths.append(filepath)
+    return solution_file_paths
+
+
+def collect_solution_file_paths() -> list[pathlib.Path]:
+    # Return only if there are any, otherwise default to all solutions
+    if (
+        os.environ.get("CI")
+        and os.environ.get("GITHUB_EVENT_NAME") == "pull_request"
+        and (filepaths := added_solution_file_path())
+    ):
+        return filepaths
+    return all_solution_file_paths()
+
+
+@pytest.mark.parametrize(
+    "solution_path",
+    collect_solution_file_paths(),
+    ids=lambda path: f"{path.parent.name}/{path.name}",
+)
+def test_project_euler(solution_path: pathlib.Path) -> None:
+    """Testing for all Project Euler solutions"""
+    # problem_[extract this part] and pad it with zeroes for width 3
+    problem_number: str = solution_path.parent.name[8:].zfill(3)
+    expected: str = PROBLEM_ANSWERS[problem_number]
+    solution_module = convert_path_to_module(solution_path)
+    answer = str(solution_module.solution())
+    answer = hashlib.sha256(answer.encode()).hexdigest()
+    assert answer == expected, (
+        f"Expected solution to {problem_number} to have hash {expected}, got {answer}"
+    )


### PR DESCRIPTION
## Summary
- add missing `scripts/validate_solutions.py` from TheAlgorithms/Python
- implement pure Mochi validator that checks Project Euler problem 1 output via SHA-256 hash
- include execution output for the Mochi script

## Testing
- `python -m py_compile tests/github/TheAlgorithms/Python/scripts/validate_solutions.py`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/scripts/validate_solutions.mochi > tests/github/TheAlgorithms/Mochi/scripts/validate_solutions.out`


------
https://chatgpt.com/codex/tasks/task_e_6892c8a32f548320b6fd28fd91a25dd1