### PR TITLE
Add Mochi pigeonhole sort implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/sorts/pigeonhole_sort.mochi
+++ b/tests/github/TheAlgorithms/Mochi/sorts/pigeonhole_sort.mochi
@@ -1,0 +1,55 @@
+/*
+Pigeonhole Sort
+---------------
+Pigeonhole sort orders a list of integers by counting occurrences of each
+value. The algorithm creates an array of "holes" covering the range from the
+minimum to the maximum element. Each input number increments its hole.
+Finally the holes are scanned from smallest to largest index and the original
+array is rebuilt in sorted order. The complexity is O(n + N) where n is the
+number of elements and N is the value range, using O(N) extra space.
+*/
+
+fun pigeonhole_sort(arr: list<int>): list<int> {
+  if len(arr) == 0 { return arr }
+  let min_val = min(arr) as int
+  let max_val = max(arr) as int
+  let size: int = max_val - min_val + 1
+
+  var holes: list<int> = []
+  var i = 0
+  while i < size {
+    holes = append(holes, 0)
+    i = i + 1
+  }
+
+  i = 0
+  while i < len(arr) {
+    let x = arr[i]
+    let index = x - min_val
+    holes[index] = holes[index] + 1
+    i = i + 1
+  }
+
+  var sorted_index = 0
+  var count = 0
+  while count < size {
+    while holes[count] > 0 {
+      arr[sorted_index] = count + min_val
+      holes[count] = holes[count] - 1
+      sorted_index = sorted_index + 1
+    }
+    count = count + 1
+  }
+  return arr
+}
+
+let example: list<int> = [8, 3, 2, 7, 4, 6, 8]
+let result = pigeonhole_sort(example)
+
+var output = "Sorted order is:"
+var j = 0
+while j < len(result) {
+  output = output + " " + str(result[j])
+  j = j + 1
+}
+print(output)

--- a/tests/github/TheAlgorithms/Mochi/sorts/pigeonhole_sort.out
+++ b/tests/github/TheAlgorithms/Mochi/sorts/pigeonhole_sort.out
@@ -1,0 +1,1 @@
+Sorted order is: 2 3 4 6 7 8 8

--- a/tests/github/TheAlgorithms/Python/sorts/pigeonhole_sort.py
+++ b/tests/github/TheAlgorithms/Python/sorts/pigeonhole_sort.py
@@ -1,0 +1,45 @@
+# Python program to implement Pigeonhole Sorting in python
+
+# Algorithm for the pigeonhole sorting
+
+
+def pigeonhole_sort(a):
+    """
+    >>> a = [8, 3, 2, 7, 4, 6, 8]
+    >>> b = sorted(a)  # a nondestructive sort
+    >>> pigeonhole_sort(a)  # a destructive sort
+    >>> a == b
+    True
+    """
+    # size of range of values in the list (ie, number of pigeonholes we need)
+
+    min_val = min(a)  # min() finds the minimum value
+    max_val = max(a)  # max() finds the maximum value
+
+    size = max_val - min_val + 1  # size is difference of max and min values plus one
+
+    # list of pigeonholes of size equal to the variable size
+    holes = [0] * size
+
+    # Populate the pigeonholes.
+    for x in a:
+        assert isinstance(x, int), "integers only please"
+        holes[x - min_val] += 1
+
+    # Putting the elements back into the array in an order.
+    i = 0
+    for count in range(size):
+        while holes[count] > 0:
+            holes[count] -= 1
+            a[i] = count + min_val
+            i += 1
+
+
+def main():
+    a = [8, 3, 2, 7, 4, 6, 8]
+    pigeonhole_sort(a)
+    print("Sorted order is:", " ".join(a))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python reference for pigeonhole sort
- implement pigeonhole sort in Mochi with detailed comments
- include VM output for the Mochi example

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/sorts/pigeonhole_sort.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892d92eaab883208df0a9c3b3a09b6f