### PR TITLE
Add Mochi translation for anagrams algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/anagrams.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/anagrams.mochi
@@ -1,0 +1,126 @@
+/*
+Find groups of anagrams in a word list.
+
+This program reads words from "words.txt", computes a signature for each
+word by sorting its letters, and groups words sharing the same signature.
+An anagram of a word is any other word composed of the same letters in a
+different order. The algorithm proceeds as follows:
+1. Read and normalize the list of words.
+2. Sort the letters of each word to form a key (the signature).
+3. Build a map from each signature to the list of words having that
+   signature.
+4. For every word that has more than one entry in its anagram list,
+   print the word followed by its anagrams.
+
+The character sorting and list sorting are implemented with insertion
+sort, keeping the implementation in pure Mochi without external
+libraries and avoiding the use of the "any" type.
+*/
+
+fun split(s: string, sep: string): list<string> {
+  var res: list<string> = []
+  var current = ""
+  var i = 0
+  while i < len(s) {
+    let ch = s[i:i+1]
+    if ch == sep {
+      res = append(res, current)
+      current = ""
+    } else {
+      current = current + ch
+    }
+    i = i + 1
+  }
+  res = append(res, current)
+  return res
+}
+
+fun insertion_sort(arr: list<string>): list<string> {
+  var a = arr
+  var i = 1
+  while i < len(a) {
+    let key = a[i]
+    var j = i - 1
+    while j >= 0 && a[j] > key {
+      a[j + 1] = a[j]
+      j = j - 1
+    }
+    a[j + 1] = key
+    i = i + 1
+  }
+  return a
+}
+
+fun sort_chars(word: string): string {
+  var chars: list<string> = []
+  var i = 0
+  while i < len(word) {
+    chars = append(chars, word[i:i+1])
+    i = i + 1
+  }
+  chars = insertion_sort(chars)
+  var res = ""
+  i = 0
+  while i < len(chars) {
+    res = res + chars[i]
+    i = i + 1
+  }
+  return res
+}
+
+fun unique_sorted(words: list<string>): list<string> {
+  var seen: map<string, bool> = {}
+  var res: list<string> = []
+  for w in words {
+    if w != "" && !(w in seen) {
+      res = append(res, w)
+      seen[w] = true
+    }
+  }
+  res = insertion_sort(res)
+  return res
+}
+
+var word_by_signature: map<string, list<string>> = {}
+
+fun build_map(words: list<string>) {
+  for w in words {
+    let sig = sort_chars(w)
+    var arr: list<string> = []
+    if sig in word_by_signature {
+      arr = word_by_signature[sig]
+    }
+    arr = append(arr, w)
+    word_by_signature[sig] = arr
+  }
+}
+
+fun anagram(my_word: string): list<string> {
+  let sig = sort_chars(my_word)
+  if sig in word_by_signature {
+    return word_by_signature[sig]
+  }
+  return []
+}
+
+fun main() {
+  let text = read_file("words.txt")
+  let lines = split(text, "\n")
+  let words = unique_sorted(lines)
+  build_map(words)
+  for w in words {
+    let anas = anagram(w)
+    if len(anas) > 1 {
+      var line = w + ":"
+      var i = 0
+      while i < len(anas) {
+        if i > 0 { line = line + "," }
+        line = line + anas[i]
+        i = i + 1
+      }
+      print(line)
+    }
+  }
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/strings/anagrams.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/anagrams.out
@@ -1,0 +1,10 @@
+act:act,cat,tac
+bird:bird,drib
+cat:act,cat,tac
+dog:dog,god
+drib:bird,drib
+god:dog,god
+sett:sett,stet,test
+stet:sett,stet,test
+tac:act,cat,tac
+test:sett,stet,test

--- a/tests/github/TheAlgorithms/Mochi/strings/words.txt
+++ b/tests/github/TheAlgorithms/Mochi/strings/words.txt
@@ -1,0 +1,10 @@
+cat
+act
+tac
+dog
+god
+bird
+drib
+sett
+test
+stet

--- a/tests/github/TheAlgorithms/Python/strings/anagrams.py
+++ b/tests/github/TheAlgorithms/Python/strings/anagrams.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import collections
+import pprint
+from pathlib import Path
+
+
+def signature(word: str) -> str:
+    """Return a word sorted
+    >>> signature("test")
+    'estt'
+    >>> signature("this is a test")
+    '   aehiisssttt'
+    >>> signature("finaltest")
+    'aefilnstt'
+    """
+    return "".join(sorted(word))
+
+
+def anagram(my_word: str) -> list[str]:
+    """Return every anagram of the given word
+    >>> anagram('test')
+    ['sett', 'stet', 'test']
+    >>> anagram('this is a test')
+    []
+    >>> anagram('final')
+    ['final']
+    """
+    return word_by_signature[signature(my_word)]
+
+
+data: str = Path(__file__).parent.joinpath("words.txt").read_text(encoding="utf-8")
+word_list = sorted({word.strip().lower() for word in data.splitlines()})
+
+word_by_signature = collections.defaultdict(list)
+for word in word_list:
+    word_by_signature[signature(word)].append(word)
+
+if __name__ == "__main__":
+    all_anagrams = {word: anagram(word) for word in word_list if len(anagram(word)) > 1}
+
+    with open("anagrams.txt", "w") as file:
+        file.write("all_anagrams = \n ")
+        file.write(pprint.pformat(all_anagrams))

--- a/tests/github/TheAlgorithms/Python/strings/words.txt
+++ b/tests/github/TheAlgorithms/Python/strings/words.txt
@@ -1,0 +1,10 @@
+cat
+act
+tac
+dog
+god
+bird
+drib
+sett
+test
+stet


### PR DESCRIPTION
## Summary
- add original Python `anagrams.py` and sample `words.txt`
- implement pure Mochi version with insertion-sort based signature mapping
- include example output demonstrating detected anagram groups

## Testing
- `python tests/github/TheAlgorithms/Python/strings/anagrams.py`
- `node runtime/vm tests/github/TheAlgorithms/Mochi/strings/anagrams.mochi` *(fails: Cannot find module '/workspace/mochi/runtime/vm')*
- `npm install` *(fails: connect ENETUNREACH 140.82.114.3:443)*

------
https://chatgpt.com/codex/tasks/task_e_6892e16690288320a93f39ce33703cc0