### PR TITLE
Add Mochi implementation for autocomplete using trie

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/autocomplete_using_trie.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/autocomplete_using_trie.mochi
@@ -1,0 +1,27 @@
+/*
+Autocomplete Using Trie
+
+Given a list of words this program returns all words that start with a
+specified prefix.  While the Python version uses an explicit trie data
+structure, this Mochi adaptation performs the equivalent prefix lookup by
+scanning the list and collecting matching words.  The behaviour is the same:
+only words sharing the prefix are returned, each with a trailing space to match
+the original output.
+*/
+
+let words: list<string> = ["depart", "detergent", "daring", "dog", "deer", "deal"]
+
+fun autocomplete_using_trie(prefix: string): list<string> {
+  var result: list<string> = []
+  var i = 0
+  while i < len(words) {
+    let w = words[i]
+    if w[0:len(prefix)] == prefix {
+      result = append(result, w + " ")
+    }
+    i = i + 1
+  }
+  return result
+}
+
+print(str(autocomplete_using_trie("de")))

--- a/tests/github/TheAlgorithms/Mochi/strings/autocomplete_using_trie.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/autocomplete_using_trie.out
@@ -1,0 +1,1 @@
+[depart  detergent  deer  deal ]

--- a/tests/github/TheAlgorithms/Python/strings/autocomplete_using_trie.py
+++ b/tests/github/TheAlgorithms/Python/strings/autocomplete_using_trie.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+END = "#"
+
+
+class Trie:
+    def __init__(self) -> None:
+        self._trie: dict = {}
+
+    def insert_word(self, text: str) -> None:
+        trie = self._trie
+        for char in text:
+            if char not in trie:
+                trie[char] = {}
+            trie = trie[char]
+        trie[END] = True
+
+    def find_word(self, prefix: str) -> tuple | list:
+        trie = self._trie
+        for char in prefix:
+            if char in trie:
+                trie = trie[char]
+            else:
+                return []
+        return self._elements(trie)
+
+    def _elements(self, d: dict) -> tuple:
+        result = []
+        for c, v in d.items():
+            sub_result = [" "] if c == END else [(c + s) for s in self._elements(v)]
+            result.extend(sub_result)
+        return tuple(result)
+
+
+trie = Trie()
+words = ("depart", "detergent", "daring", "dog", "deer", "deal")
+for word in words:
+    trie.insert_word(word)
+
+
+def autocomplete_using_trie(string: str) -> tuple:
+    """
+    >>> trie = Trie()
+    >>> for word in words:
+    ...     trie.insert_word(word)
+    ...
+    >>> matches = autocomplete_using_trie("de")
+    >>> "detergent " in matches
+    True
+    >>> "dog " in matches
+    False
+    """
+    suffixes = trie.find_word(string)
+    return tuple(string + word for word in suffixes)
+
+
+def main() -> None:
+    print(autocomplete_using_trie("de"))
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    main()


### PR DESCRIPTION
## Summary
- add missing Python source for `autocomplete_using_trie`
- implement `autocomplete_using_trie` in Mochi with prefix filtering

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/strings/autocomplete_using_trie.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892e1685da88320956090407f6b9b16