### PR TITLE
Add camel case to snake case algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/camel_case_to_snake_case.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/camel_case_to_snake_case.mochi
@@ -1,0 +1,106 @@
+/*
+CamelCase or PascalCase to snake_case Conversion
+
+This algorithm converts an identifier written in camelCase or PascalCase
+into snake_case. It scans the input string character by character and
+inserts underscores at case transitions, between letters and digits, and
+in place of non-alphanumeric characters.
+
+Steps:
+1. Iterate through each character while tracking whether the previous
+   character was a digit or a letter.
+2. If the current character is uppercase, append an underscore followed by
+   its lowercase form.
+3. If transitioning from a digit to a lowercase letter or from a letter to
+   a digit, insert an underscore before the current character.
+4. Replace any non-alphanumeric character with an underscore.
+5. Remove a leading underscore if one was added at the beginning.
+*/
+
+let LOWER = "abcdefghijklmnopqrstuvwxyz"
+let UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+let DIGITS = "0123456789"
+
+fun is_lower(ch: string): bool {
+  var i = 0
+  while i < len(LOWER) {
+    if LOWER[i] == ch { return true }
+    i = i + 1
+  }
+  return false
+}
+
+fun is_upper(ch: string): bool {
+  var i = 0
+  while i < len(UPPER) {
+    if UPPER[i] == ch { return true }
+    i = i + 1
+  }
+  return false
+}
+
+fun is_digit(ch: string): bool {
+  var i = 0
+  while i < len(DIGITS) {
+    if DIGITS[i] == ch { return true }
+    i = i + 1
+  }
+  return false
+}
+
+fun is_alpha(ch: string): bool {
+  if is_lower(ch) { return true }
+  if is_upper(ch) { return true }
+  return false
+}
+
+fun is_alnum(ch: string): bool {
+  if is_alpha(ch) { return true }
+  if is_digit(ch) { return true }
+  return false
+}
+
+fun to_lower(ch: string): string {
+  var i = 0
+  while i < len(UPPER) {
+    if UPPER[i] == ch { return LOWER[i] }
+    i = i + 1
+  }
+  return ch
+}
+
+fun camel_to_snake_case(input_str: string): string {
+  var snake_str = ""
+  var i = 0
+  var prev_is_digit = false
+  var prev_is_alpha = false
+  while i < len(input_str) {
+    let ch = input_str[i]
+    if is_upper(ch) {
+      snake_str = snake_str + "_" + to_lower(ch)
+    } else if prev_is_digit && is_lower(ch) {
+      snake_str = snake_str + "_" + ch
+    } else if prev_is_alpha && is_digit(ch) {
+      snake_str = snake_str + "_" + ch
+    } else if !is_alnum(ch) {
+      snake_str = snake_str + "_"
+    } else {
+      snake_str = snake_str + ch
+    }
+    prev_is_digit = is_digit(ch)
+    prev_is_alpha = is_alpha(ch)
+    i = i + 1
+  }
+  if len(snake_str) > 0 && snake_str[0] == "_" {
+    snake_str = snake_str[1:len(snake_str)]
+  }
+  return snake_str
+}
+
+fun main() {
+  print(camel_to_snake_case("someRandomString"))
+  print(camel_to_snake_case("SomeRandomStr#ng"))
+  print(camel_to_snake_case("123SomeRandom123String123"))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/strings/camel_case_to_snake_case.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/camel_case_to_snake_case.out
@@ -1,0 +1,3 @@
+some_random_string
+some_random_str_ng
+123_some_random_123_string_123

--- a/tests/github/TheAlgorithms/Python/strings/camel_case_to_snake_case.py
+++ b/tests/github/TheAlgorithms/Python/strings/camel_case_to_snake_case.py
@@ -1,0 +1,60 @@
+def camel_to_snake_case(input_str: str) -> str:
+    """
+    Transforms a camelCase (or PascalCase) string to snake_case
+
+    >>> camel_to_snake_case("someRandomString")
+    'some_random_string'
+
+    >>> camel_to_snake_case("SomeRandomStr#ng")
+    'some_random_str_ng'
+
+    >>> camel_to_snake_case("123someRandom123String123")
+    '123_some_random_123_string_123'
+
+    >>> camel_to_snake_case("123SomeRandom123String123")
+    '123_some_random_123_string_123'
+
+    >>> camel_to_snake_case(123)
+    Traceback (most recent call last):
+        ...
+    ValueError: Expected string as input, found <class 'int'>
+
+    """
+
+    # check for invalid input type
+    if not isinstance(input_str, str):
+        msg = f"Expected string as input, found {type(input_str)}"
+        raise ValueError(msg)
+
+    snake_str = ""
+
+    for index, char in enumerate(input_str):
+        if char.isupper():
+            snake_str += "_" + char.lower()
+
+        # if char is lowercase but proceeded by a digit:
+        elif input_str[index - 1].isdigit() and char.islower():
+            snake_str += "_" + char
+
+        # if char is a digit proceeded by a letter:
+        elif input_str[index - 1].isalpha() and char.isnumeric():
+            snake_str += "_" + char.lower()
+
+        # if char is not alphanumeric:
+        elif not char.isalnum():
+            snake_str += "_"
+
+        else:
+            snake_str += char
+
+    # remove leading underscore
+    if snake_str[0] == "_":
+        snake_str = snake_str[1:]
+
+    return snake_str
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()


### PR DESCRIPTION
## Summary
- add missing Python reference for camelCase to snake_case
- implement camel to snake case converter in Mochi with character classification helpers
- include runtime output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/strings/camel_case_to_snake_case.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6892e170a5088320bb8bca11b66e0f83