### PR TITLE
Add palindrome rearrangement check to TheAlgorithms tests

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/can_string_be_rearranged_as_palindrome.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/can_string_be_rearranged_as_palindrome.mochi
@@ -1,0 +1,97 @@
+/*
+Check Palindrome Rearrangement
+------------------------------
+Given a string, determine whether its characters can be rearranged to form a
+palindrome. A string can form a palindrome if each character appears an even
+number of times, with at most one character allowed to appear an odd number of
+times. Both provided functions ignore spaces and treat letters in a
+case-insensitive manner:
+
+1. can_string_be_rearranged_as_palindrome_counter:
+   Counts character frequencies using a map and verifies that fewer than two
+   characters have odd counts.
+2. can_string_be_rearranged_as_palindrome:
+   Builds the frequency map manually and checks the same condition without
+   using external helpers.
+
+Example evaluations are printed at the bottom for demonstration.
+*/
+
+let LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+let LOWERCASE = "abcdefghijklmnopqrstuvwxyz"
+
+fun char_to_lower(c: string): string {
+  var i = 0
+  while i < len(LETTERS) {
+    if c == substring(LETTERS, i, i + 1) {
+      return substring(LOWERCASE, i, i + 1)
+    }
+    i = i + 1
+  }
+  return c
+}
+
+fun normalize(input_str: string): string {
+  var res = ""
+  var i = 0
+  while i < len(input_str) {
+    let ch = substring(input_str, i, i + 1)
+    let lc = char_to_lower(ch)
+    if lc >= "a" && lc <= "z" {
+      res = res + lc
+    }
+    i = i + 1
+  }
+  return res
+}
+
+fun can_string_be_rearranged_as_palindrome_counter(input_str: string): bool {
+  let s = normalize(input_str)
+  var freq: map<string, int> = {}
+  var i = 0
+  while i < len(s) {
+    let ch = substring(s, i, i + 1)
+    if ch in freq {
+      freq[ch] = freq[ch] + 1
+    } else {
+      freq[ch] = 1
+    }
+    i = i + 1
+  }
+  var odd = 0
+  for key in freq {
+    if freq[key] % 2 != 0 {
+      odd = odd + 1
+    }
+  }
+  return odd < 2
+}
+
+fun can_string_be_rearranged_as_palindrome(input_str: string): bool {
+  let s = normalize(input_str)
+  if len(s) == 0 { return true }
+  var character_freq_dict: map<string, int> = {}
+  var i = 0
+  while i < len(s) {
+    let character = substring(s, i, i + 1)
+    if character in character_freq_dict {
+      character_freq_dict[character] = character_freq_dict[character] + 1
+    } else {
+      character_freq_dict[character] = 1
+    }
+    i = i + 1
+  }
+  var odd_char = 0
+  for character_key in character_freq_dict {
+    let character_count = character_freq_dict[character_key]
+    if character_count % 2 != 0 {
+      odd_char = odd_char + 1
+    }
+  }
+  return !(odd_char > 1)
+}
+
+print(can_string_be_rearranged_as_palindrome_counter("Momo"))
+print(can_string_be_rearranged_as_palindrome_counter("Mother"))
+print(can_string_be_rearranged_as_palindrome("Momo"))
+print(can_string_be_rearranged_as_palindrome("Mother"))

--- a/tests/github/TheAlgorithms/Mochi/strings/can_string_be_rearranged_as_palindrome.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/can_string_be_rearranged_as_palindrome.out
@@ -1,0 +1,4 @@
+true
+false
+true
+false

--- a/tests/github/TheAlgorithms/Python/strings/can_string_be_rearranged_as_palindrome.py
+++ b/tests/github/TheAlgorithms/Python/strings/can_string_be_rearranged_as_palindrome.py
@@ -1,0 +1,113 @@
+# Created by susmith98
+
+from collections import Counter
+from timeit import timeit
+
+# Problem Description:
+# Check if characters of the given string can be rearranged to form a palindrome.
+# Counter is faster for long strings and non-Counter is faster for short strings.
+
+
+def can_string_be_rearranged_as_palindrome_counter(
+    input_str: str = "",
+) -> bool:
+    """
+    A Palindrome is a String that reads the same forward as it does backwards.
+    Examples of Palindromes mom, dad, malayalam
+    >>> can_string_be_rearranged_as_palindrome_counter("Momo")
+    True
+    >>> can_string_be_rearranged_as_palindrome_counter("Mother")
+    False
+    >>> can_string_be_rearranged_as_palindrome_counter("Father")
+    False
+    >>> can_string_be_rearranged_as_palindrome_counter("A man a plan a canal Panama")
+    True
+    """
+    return sum(c % 2 for c in Counter(input_str.replace(" ", "").lower()).values()) < 2
+
+
+def can_string_be_rearranged_as_palindrome(input_str: str = "") -> bool:
+    """
+    A Palindrome is a String that reads the same forward as it does backwards.
+    Examples of Palindromes mom, dad, malayalam
+    >>> can_string_be_rearranged_as_palindrome("Momo")
+    True
+    >>> can_string_be_rearranged_as_palindrome("Mother")
+    False
+    >>> can_string_be_rearranged_as_palindrome("Father")
+    False
+    >>> can_string_be_rearranged_as_palindrome_counter("A man a plan a canal Panama")
+    True
+    """
+    if len(input_str) == 0:
+        return True
+    lower_case_input_str = input_str.replace(" ", "").lower()
+    # character_freq_dict: Stores the frequency of every character in the input string
+    character_freq_dict: dict[str, int] = {}
+
+    for character in lower_case_input_str:
+        character_freq_dict[character] = character_freq_dict.get(character, 0) + 1
+    """
+    Above line of code is equivalent to:
+    1) Getting the frequency of current character till previous index
+    >>> character_freq =  character_freq_dict.get(character, 0)
+    2) Incrementing the frequency of current character by 1
+    >>> character_freq = character_freq + 1
+    3) Updating the frequency of current character
+    >>> character_freq_dict[character] = character_freq
+    """
+    """
+    OBSERVATIONS:
+    Even length palindrome
+    -> Every character appears even no.of times.
+    Odd length palindrome
+    -> Every character appears even no.of times except for one character.
+    LOGIC:
+    Step 1: We'll count number of characters that appear odd number of times i.e oddChar
+    Step 2:If we find more than 1 character that appears odd number of times,
+    It is not possible to rearrange as a palindrome
+    """
+    odd_char = 0
+
+    for character_count in character_freq_dict.values():
+        if character_count % 2:
+            odd_char += 1
+    return not odd_char > 1
+
+
+def benchmark(input_str: str = "") -> None:
+    """
+    Benchmark code for comparing above 2 functions
+    """
+    print("\nFor string = ", input_str, ":")
+    print(
+        "> can_string_be_rearranged_as_palindrome_counter()",
+        "\tans =",
+        can_string_be_rearranged_as_palindrome_counter(input_str),
+        "\ttime =",
+        timeit(
+            "z.can_string_be_rearranged_as_palindrome_counter(z.check_str)",
+            setup="import __main__ as z",
+        ),
+        "seconds",
+    )
+    print(
+        "> can_string_be_rearranged_as_palindrome()",
+        "\tans =",
+        can_string_be_rearranged_as_palindrome(input_str),
+        "\ttime =",
+        timeit(
+            "z.can_string_be_rearranged_as_palindrome(z.check_str)",
+            setup="import __main__ as z",
+        ),
+        "seconds",
+    )
+
+
+if __name__ == "__main__":
+    check_str = input(
+        "Enter string to determine if it can be rearranged as a palindrome or not: "
+    ).strip()
+    benchmark(check_str)
+    status = can_string_be_rearranged_as_palindrome_counter(check_str)
+    print(f"{check_str} can {'' if status else 'not '}be rearranged as a palindrome")


### PR DESCRIPTION
## Summary
- add original Python solution `can_string_be_rearranged_as_palindrome.py`
- implement Mochi translation that counts character frequencies to detect possible palindromic permutations
- include sample executions for positive and negative cases

## Testing
- `./bin/mochi run tests/github/TheAlgorithms/Mochi/strings/can_string_be_rearranged_as_palindrome.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892e17272688320aa55fdb89bad8242