### PR TITLE
Add Mochi implementation for anagram check

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/check_anagrams.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/check_anagrams.mochi
@@ -1,0 +1,77 @@
+/*
+Check Anagrams
+
+Two strings are anagrams if they contain the same letters with the same
+frequency, ignoring case and spaces. This implementation normalizes the input
+strings by converting to lowercase and stripping all spaces. It then uses a
+map<string, int> to count character occurrences: increment for the first string
+and decrement for the second. If the two strings are anagrams, the count for
+every character will end at zero.
+
+The algorithm runs in O(n) time and O(k) space where n is the length of the
+strings and k is the number of distinct characters.
+*/
+
+fun strip_and_remove_spaces(s: string): string {
+  var start = 0
+  var end = len(s) - 1
+  while start < len(s) && s[start] == " " {
+    start = start + 1
+  }
+  while end >= start && s[end] == " " {
+    end = end - 1
+  }
+  var res = ""
+  var i = start
+  while i <= end {
+    let ch = s[i]
+    if ch != " " {
+      res = res + ch
+    }
+    i = i + 1
+  }
+  return res
+}
+
+fun check_anagrams(a: string, b: string): bool {
+  var s1 = lower(a)
+  var s2 = lower(b)
+  s1 = strip_and_remove_spaces(s1)
+  s2 = strip_and_remove_spaces(s2)
+  if len(s1) != len(s2) {
+    return false
+  }
+  var count: map<string, int> = {}
+  var i = 0
+  while i < len(s1) {
+    let c1 = s1[i]
+    let c2 = s2[i]
+    if c1 in count {
+      count[c1] = count[c1] + 1
+    } else {
+      count[c1] = 1
+    }
+    if c2 in count {
+      count[c2] = count[c2] - 1
+    } else {
+      count[c2] = -1
+    }
+    i = i + 1
+  }
+  for ch in count {
+    if count[ch] != 0 {
+      return false
+    }
+  }
+  return true
+}
+
+fun print_bool(b: bool) {
+  if b { print("true") } else { print("false") }
+}
+
+print_bool(check_anagrams("Silent", "Listen"))
+print_bool(check_anagrams("This is a string", "Is this a string"))
+print_bool(check_anagrams("This is    a      string", "Is     this a string"))
+print_bool(check_anagrams("There", "Their"))
+

--- a/tests/github/TheAlgorithms/Mochi/strings/check_anagrams.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/check_anagrams.out
@@ -1,0 +1,4 @@
+true
+true
+true
+false

--- a/tests/github/TheAlgorithms/Python/strings/check_anagrams.py
+++ b/tests/github/TheAlgorithms/Python/strings/check_anagrams.py
@@ -1,0 +1,52 @@
+"""
+wiki: https://en.wikipedia.org/wiki/Anagram
+"""
+
+from collections import defaultdict
+
+
+def check_anagrams(first_str: str, second_str: str) -> bool:
+    """
+    Two strings are anagrams if they are made up of the same letters but are
+    arranged differently (ignoring the case).
+    >>> check_anagrams('Silent', 'Listen')
+    True
+    >>> check_anagrams('This is a string', 'Is this a string')
+    True
+    >>> check_anagrams('This is    a      string', 'Is     this a string')
+    True
+    >>> check_anagrams('There', 'Their')
+    False
+    """
+    first_str = first_str.lower().strip()
+    second_str = second_str.lower().strip()
+
+    # Remove whitespace
+    first_str = first_str.replace(" ", "")
+    second_str = second_str.replace(" ", "")
+
+    # Strings of different lengths are not anagrams
+    if len(first_str) != len(second_str):
+        return False
+
+    # Default values for count should be 0
+    count: defaultdict[str, int] = defaultdict(int)
+
+    # For each character in input strings,
+    # increment count in the corresponding
+    for i in range(len(first_str)):
+        count[first_str[i]] += 1
+        count[second_str[i]] -= 1
+
+    return all(_count == 0 for _count in count.values())
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()
+    input_a = input("Enter the first string ").strip()
+    input_b = input("Enter the second string ").strip()
+
+    status = check_anagrams(input_a, input_b)
+    print(f"{input_a} and {input_b} are {'' if status else 'not '}anagrams.")


### PR DESCRIPTION
## Summary
- add missing Python reference `check_anagrams.py`
- implement `check_anagrams.mochi` using character counts to detect anagrams
- add runtime output for sample cases

## Testing
- `go test ./...`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/strings/check_anagrams.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892e17400908320b3ba18d93566ebd8