### PR TITLE
Add Mochi credit card validator using Luhn algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/credit_card_validator.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/credit_card_validator.mochi
@@ -1,0 +1,85 @@
+/*
+Validate credit card numbers using the Luhn checksum.
+
+This implementation mirrors typical credit card validation rules:
+1. All characters must be digits.
+2. The length must be between 13 and 16 characters.
+3. The number must start with one of the common issuer prefixes
+   (34, 35, 37, 4, 5 or 6).
+4. The Luhn algorithm is applied: starting from the rightmost digit,
+   every second digit is doubled; if the doubled value exceeds 9 it is
+   reduced by subtracting 9.  Summing all digits yields a checksum that
+   must be divisible by 10 for the number to be valid.
+
+The procedure runs in O(n) time and O(1) space where n is the number of
+characters in the input string.
+*/
+
+fun validate_initial_digits(cc: string): bool {
+  return cc[0:2] == "34" ||
+         cc[0:2] == "35" ||
+         cc[0:2] == "37" ||
+         cc[0:1] == "4" ||
+         cc[0:1] == "5" ||
+         cc[0:1] == "6"
+}
+
+fun luhn_validation(cc: string): bool {
+  var sum = 0
+  var double_digit = false
+  var i = len(cc) - 1
+  while i >= 0 {
+    var n = cc[i:i+1] as int
+    if double_digit {
+      n = n * 2
+      if n > 9 {
+        n = n - 9
+      }
+    }
+    sum = sum + n
+    double_digit = !double_digit
+    i = i - 1
+  }
+  return sum % 10 == 0
+}
+
+fun is_digit_string(s: string): bool {
+  var i = 0
+  while i < len(s) {
+    let c = s[i:i+1]
+    if c < "0" || c > "9" {
+      return false
+    }
+    i = i + 1
+  }
+  return true
+}
+
+fun validate_credit_card_number(cc: string): bool {
+  let error_message = cc + " is an invalid credit card number because"
+  if !is_digit_string(cc) {
+    print(error_message + " it has nonnumerical characters.")
+    return false
+  }
+  if !(len(cc) >= 13 && len(cc) <= 16) {
+    print(error_message + " of its length.")
+    return false
+  }
+  if !validate_initial_digits(cc) {
+    print(error_message + " of its first two digits.")
+    return false
+  }
+  if !luhn_validation(cc) {
+    print(error_message + " it fails the Luhn check.")
+    return false
+  }
+  print(cc + " is a valid credit card number.")
+  return true
+}
+
+fun main() {
+  validate_credit_card_number("4111111111111111")
+  validate_credit_card_number("32323")
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/strings/credit_card_validator.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/credit_card_validator.out
@@ -1,0 +1,2 @@
+4111111111111111 is a valid credit card number.
+32323 is an invalid credit card number because of its length.

--- a/tests/github/TheAlgorithms/Python/strings/credit_card_validator.py
+++ b/tests/github/TheAlgorithms/Python/strings/credit_card_validator.py
@@ -1,0 +1,103 @@
+"""
+Functions for testing the validity of credit card numbers.
+
+https://en.wikipedia.org/wiki/Luhn_algorithm
+"""
+
+
+def validate_initial_digits(credit_card_number: str) -> bool:
+    """
+    Function to validate initial digits of a given credit card number.
+    >>> valid = "4111111111111111 41111111111111 34 35 37 412345 523456 634567"
+    >>> all(validate_initial_digits(cc) for cc in valid.split())
+    True
+    >>> invalid = "14 25 76 32323 36111111111111"
+    >>> all(validate_initial_digits(cc) is False for cc in invalid.split())
+    True
+    """
+    return credit_card_number.startswith(("34", "35", "37", "4", "5", "6"))
+
+
+def luhn_validation(credit_card_number: str) -> bool:
+    """
+    Function to luhn algorithm validation for a given credit card number.
+    >>> luhn_validation('4111111111111111')
+    True
+    >>> luhn_validation('36111111111111')
+    True
+    >>> luhn_validation('41111111111111')
+    False
+    """
+    cc_number = credit_card_number
+    total = 0
+    half_len = len(cc_number) - 2
+    for i in range(half_len, -1, -2):
+        #  double the value of every second digit
+        digit = int(cc_number[i])
+        digit *= 2
+        # If doubling of a number results in a two digit number
+        # i.e greater than 9(e.g., 6 x 2 = 12),
+        # then add the digits of the product (e.g., 12: 1 + 2 = 3, 15: 1 + 5 = 6),
+        # to get a single digit number.
+        if digit > 9:
+            digit %= 10
+            digit += 1
+        cc_number = cc_number[:i] + str(digit) + cc_number[i + 1 :]
+        total += digit
+
+    # Sum up the remaining digits
+    for i in range(len(cc_number) - 1, -1, -2):
+        total += int(cc_number[i])
+
+    return total % 10 == 0
+
+
+def validate_credit_card_number(credit_card_number: str) -> bool:
+    """
+    Function to validate the given credit card number.
+    >>> validate_credit_card_number('4111111111111111')
+    4111111111111111 is a valid credit card number.
+    True
+    >>> validate_credit_card_number('helloworld$')
+    helloworld$ is an invalid credit card number because it has nonnumerical characters.
+    False
+    >>> validate_credit_card_number('32323')
+    32323 is an invalid credit card number because of its length.
+    False
+    >>> validate_credit_card_number('32323323233232332323')
+    32323323233232332323 is an invalid credit card number because of its length.
+    False
+    >>> validate_credit_card_number('36111111111111')
+    36111111111111 is an invalid credit card number because of its first two digits.
+    False
+    >>> validate_credit_card_number('41111111111111')
+    41111111111111 is an invalid credit card number because it fails the Luhn check.
+    False
+    """
+    error_message = f"{credit_card_number} is an invalid credit card number because"
+    if not credit_card_number.isdigit():
+        print(f"{error_message} it has nonnumerical characters.")
+        return False
+
+    if not 13 <= len(credit_card_number) <= 16:
+        print(f"{error_message} of its length.")
+        return False
+
+    if not validate_initial_digits(credit_card_number):
+        print(f"{error_message} of its first two digits.")
+        return False
+
+    if not luhn_validation(credit_card_number):
+        print(f"{error_message} it fails the Luhn check.")
+        return False
+
+    print(f"{credit_card_number} is a valid credit card number.")
+    return True
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    validate_credit_card_number("4111111111111111")
+    validate_credit_card_number("32323")


### PR DESCRIPTION
## Summary
- add missing Python credit card validator reference implementation
- port credit card validator to Mochi with explicit digit, length, prefix, and Luhn checksum checks
- include execution output from running the Mochi program

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/strings/credit_card_validator.mochi > tests/github/TheAlgorithms/Mochi/strings/credit_card_validator.out`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6892e176950083209d31ad5fe9fccdea