### PR TITLE
Add simple binary search algorithm in Mochi

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/searches/simple_binary_search.mochi
+++ b/tests/github/TheAlgorithms/Mochi/searches/simple_binary_search.mochi
@@ -1,0 +1,40 @@
+/*
+Simple Binary Search
+--------------------
+This program implements a recursive binary search on a sorted list of
+integers. The function divides the list in half each step, comparing the
+middle element to the target value and recursing into the appropriate
+sub‑range. It returns true when the target exists in the list and false
+otherwise. The algorithm runs in O(log n) time and uses only Mochi
+primitives so it can execute on the runtime/vm without foreign
+interfaces or use of the `any` type.
+*/
+
+fun binary_search_range(a_list: list<int>, item: int, start: int, end: int): bool {
+  if start >= end {
+    return false
+  }
+  let midpoint: int = (start + end) / 2
+  let midval: int = a_list[midpoint]
+  if midval == item {
+    return true
+  }
+  if item < midval {
+    return binary_search_range(a_list, item, start, midpoint)
+  }
+  return binary_search_range(a_list, item, midpoint + 1, end)
+}
+
+fun binary_search(a_list: list<int>, item: int): bool {
+  return binary_search_range(a_list, item, 0, len(a_list))
+}
+
+print(str(binary_search([0, 1, 2, 8, 13, 17, 19, 32, 42], 3)))
+print(str(binary_search([0, 1, 2, 8, 13, 17, 19, 32, 42], 13)))
+print(str(binary_search([4, 4, 5, 6, 7], 4)))
+print(str(binary_search([4, 4, 5, 6, 7], -10)))
+print(str(binary_search([-18, 2], -18)))
+print(str(binary_search([5], 5)))
+print(str(binary_search([], 1)))
+print(str(binary_search([0, 10, 20, 30, 40], 20)))
+print(str(binary_search([0, 10, 20, 30, 40], 25)))

--- a/tests/github/TheAlgorithms/Mochi/searches/simple_binary_search.out
+++ b/tests/github/TheAlgorithms/Mochi/searches/simple_binary_search.out
@@ -1,0 +1,9 @@
+false
+true
+true
+false
+true
+true
+false
+true
+false

--- a/tests/github/TheAlgorithms/Python/searches/simple_binary_search.py
+++ b/tests/github/TheAlgorithms/Python/searches/simple_binary_search.py
@@ -1,0 +1,60 @@
+"""
+Pure Python implementation of a binary search algorithm.
+
+For doctests run following command:
+python3 -m doctest -v simple_binary_search.py
+
+For manual testing run:
+python3 simple_binary_search.py
+"""
+
+from __future__ import annotations
+
+
+def binary_search(a_list: list[int], item: int) -> bool:
+    """
+    >>> test_list = [0, 1, 2, 8, 13, 17, 19, 32, 42]
+    >>> binary_search(test_list, 3)
+    False
+    >>> binary_search(test_list, 13)
+    True
+    >>> binary_search([4, 4, 5, 6, 7], 4)
+    True
+    >>> binary_search([4, 4, 5, 6, 7], -10)
+    False
+    >>> binary_search([-18, 2], -18)
+    True
+    >>> binary_search([5], 5)
+    True
+    >>> binary_search(['a', 'c', 'd'], 'c')
+    True
+    >>> binary_search(['a', 'c', 'd'], 'f')
+    False
+    >>> binary_search([], 1)
+    False
+    >>> binary_search([-.1, .1 , .8], .1)
+    True
+    >>> binary_search(range(-5000, 5000, 10), 80)
+    True
+    >>> binary_search(range(-5000, 5000, 10), 1255)
+    False
+    >>> binary_search(range(0, 10000, 5), 2)
+    False
+    """
+    if len(a_list) == 0:
+        return False
+    midpoint = len(a_list) // 2
+    if a_list[midpoint] == item:
+        return True
+    if item < a_list[midpoint]:
+        return binary_search(a_list[:midpoint], item)
+    else:
+        return binary_search(a_list[midpoint + 1 :], item)
+
+
+if __name__ == "__main__":
+    user_input = input("Enter numbers separated by comma:\n").strip()
+    sequence = [int(item.strip()) for item in user_input.split(",")]
+    target = int(input("Enter the number to be found in the list:\n").strip())
+    not_str = "" if binary_search(sequence, target) else "not "
+    print(f"{target} was {not_str}found in {sequence}")


### PR DESCRIPTION
## Summary
- add missing Python reference for simple_binary_search
- implement recursive binary search in Mochi
- include runtime output demonstrating search results

## Testing
- `go run runvm.go tests/github/TheAlgorithms/Mochi/searches/simple_binary_search.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892e4a4a57083209815ee924152e14c