### PR TITLE
feat: add indian phone validator

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/indian_phone_validator.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/indian_phone_validator.mochi
@@ -1,0 +1,57 @@
+/*
+Indian Phone Number Validator
+-----------------------------
+This program verifies whether a string represents a valid Indian phone
+number.  Valid numbers may optionally include the country code "+91" with
+an optional space or hyphen, may begin with an optional leading zero, and
+may optionally repeat the prefix "91".  After removing these prefixes, the
+remaining part must be exactly ten digits long, starting with 7, 8, or 9.
+The algorithm mirrors a regular expression implementation using only
+primitive string operations available in Mochi.  No FFI is used.
+*/
+
+fun all_digits(s: string): bool {
+  if len(s) == 0 { return false }
+  var i = 0
+  while i < len(s) {
+    let c = s[i]
+    if c < "0" || c > "9" { return false }
+    i = i + 1
+  }
+  return true
+}
+
+fun indian_phone_validator(phone: string): bool {
+  var s = phone
+
+  if len(s) >= 3 && substring(s, 0, 3) == "+91" {
+    s = substring(s, 3, len(s))
+    if len(s) > 0 {
+      let c = s[0]
+      if c == "-" || c == " " {
+        s = substring(s, 1, len(s))
+      }
+    }
+  }
+
+  if len(s) > 0 && s[0] == "0" {
+    s = substring(s, 1, len(s))
+  }
+
+  if len(s) >= 2 && substring(s, 0, 2) == "91" {
+    s = substring(s, 2, len(s))
+  }
+
+  if len(s) != 10 { return false }
+  let first = s[0]
+  if !(first == "7" || first == "8" || first == "9") { return false }
+  if !all_digits(s) { return false }
+  return true
+}
+
+print(str(indian_phone_validator("+91123456789")))
+print(str(indian_phone_validator("+919876543210")))
+print(str(indian_phone_validator("01234567896")))
+print(str(indian_phone_validator("919876543218")))
+print(str(indian_phone_validator("+91-1234567899")))
+print(str(indian_phone_validator("+91-9876543218")))

--- a/tests/github/TheAlgorithms/Mochi/strings/indian_phone_validator.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/indian_phone_validator.out
@@ -1,0 +1,6 @@
+false
+true
+false
+true
+false
+true

--- a/tests/github/TheAlgorithms/Python/strings/indian_phone_validator.py
+++ b/tests/github/TheAlgorithms/Python/strings/indian_phone_validator.py
@@ -1,0 +1,29 @@
+import re
+
+
+def indian_phone_validator(phone: str) -> bool:
+    """
+    Determine whether the string is a valid phone number or not
+    :param phone:
+    :return: Boolean
+    >>> indian_phone_validator("+91123456789")
+    False
+    >>> indian_phone_validator("+919876543210")
+    True
+    >>> indian_phone_validator("01234567896")
+    False
+    >>> indian_phone_validator("919876543218")
+    True
+    >>> indian_phone_validator("+91-1234567899")
+    False
+    >>> indian_phone_validator("+91-9876543218")
+    True
+    """
+    pat = re.compile(r"^(\+91[\-\s]?)?[0]?(91)?[789]\d{9}$")
+    if match := re.search(pat, phone):
+        return match.string == phone
+    return False
+
+
+if __name__ == "__main__":
+    print(indian_phone_validator("+918827897895"))


### PR DESCRIPTION
## Summary
- add missing TheAlgorithms Python implementation for Indian phone number validation
- implement Indian phone validator in Mochi using manual prefix stripping and digit checks
- include runtime output for validator examples

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/strings/indian_phone_validator.mochi > tests/github/TheAlgorithms/Mochi/strings/indian_phone_validator.out`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6892e182c880832088df22eb0740bc28