### PR TITLE
Add isogram string algorithm in Mochi

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/is_isogram.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/is_isogram.mochi
@@ -1,0 +1,67 @@
+/*
+Checks whether a string is an isogram (no repeated letters).
+
+An isogram is a word or phrase without a repeating letter. The algorithm
+verifies that the input consists solely of alphabetic characters, converting
+letters to lowercase to ensure case-insensitive comparison. It tracks the
+characters seen so far in a string and for each new character checks whether it
+has already been encountered. If a duplicate is found the function returns
+false; otherwise it returns true after processing all letters. The complexity
+is O(n^2) in the worst case due to repeated membership checks, and O(n) space
+for the collected characters.
+*/
+
+fun index_of(s: string, ch: string): int {
+  var i: int = 0
+  while i < len(s) {
+    if s[i] == ch { return i }
+    i = i + 1
+  }
+  return -1
+}
+
+fun ord(ch: string): int {
+  let upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  let lower = "abcdefghijklmnopqrstuvwxyz"
+  var idx: int = index_of(upper, ch)
+  if idx >= 0 { return 65 + idx }
+  idx = index_of(lower, ch)
+  if idx >= 0 { return 97 + idx }
+  return -1
+}
+
+fun chr(n: int): string {
+  let upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  let lower = "abcdefghijklmnopqrstuvwxyz"
+  if n >= 65 && n < 91 { return upper[n-65:n-64] }
+  if n >= 97 && n < 123 { return lower[n-97:n-96] }
+  return "?"
+}
+
+fun to_lower_char(c: string): string {
+  let code: int = ord(c)
+  if code >= 65 && code <= 90 { return chr(code + 32) }
+  return c
+}
+
+fun is_alpha(c: string): bool {
+  let code: int = ord(c)
+  return (code >= 65 && code <= 90) || (code >= 97 && code <= 122)
+}
+
+fun is_isogram(s: string): bool {
+  var seen: string = ""
+  var i: int = 0
+  while i < len(s) {
+    let ch: string = s[i]
+    if !is_alpha(ch) { panic("String must only contain alphabetic characters.") }
+    let lower: string = to_lower_char(ch)
+    if index_of(seen, lower) >= 0 { return false }
+    seen = seen + lower
+    i = i + 1
+  }
+  return true
+}
+
+print(str(is_isogram("Uncopyrightable")))
+print(str(is_isogram("allowance")))

--- a/tests/github/TheAlgorithms/Mochi/strings/is_isogram.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/is_isogram.out
@@ -1,0 +1,2 @@
+true
+false

--- a/tests/github/TheAlgorithms/Python/strings/is_isogram.py
+++ b/tests/github/TheAlgorithms/Python/strings/is_isogram.py
@@ -1,0 +1,30 @@
+"""
+wiki: https://en.wikipedia.org/wiki/Heterogram_(literature)#Isograms
+"""
+
+
+def is_isogram(string: str) -> bool:
+    """
+    An isogram is a word in which no letter is repeated.
+    Examples of isograms are uncopyrightable and ambidextrously.
+    >>> is_isogram('Uncopyrightable')
+    True
+    >>> is_isogram('allowance')
+    False
+    >>> is_isogram('copy1')
+    Traceback (most recent call last):
+     ...
+    ValueError: String must only contain alphabetic characters.
+    """
+    if not all(x.isalpha() for x in string):
+        raise ValueError("String must only contain alphabetic characters.")
+
+    letters = sorted(string.lower())
+    return len(letters) == len(set(letters))
+
+
+if __name__ == "__main__":
+    input_str = input("Enter a string ").strip()
+
+    isogram = is_isogram(input_str)
+    print(f"{input_str} is {'an' if isogram else 'not an'} isogram.")


### PR DESCRIPTION
## Summary
- add Python implementation of isogram check
- provide Mochi version with ASCII-based validation and duplicate detection
- include run output example

## Testing
- `npm install` *(failed: connect ENETUNREACH 140.82.112.4:443)*

------
https://chatgpt.com/codex/tasks/task_e_6892e18585148320ab6b77a9e505b4c5