### PR TITLE
Add pangram algorithms in Mochi tests

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/is_pangram.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/is_pangram.mochi
@@ -1,0 +1,80 @@
+/*
+Check if a string is a pangram, meaning it contains every letter of the
+English alphabet at least once. Three approaches are implemented:
+
+1. is_pangram collects unique letters in a list and checks its size.
+2. is_pangram_faster tracks presence of each alphabet letter with a boolean list.
+3. is_pangram_fastest verifies that each letter from 'a' to 'z' occurs in the string.
+
+All functions are written in pure Mochi without using the `any` type or FFI
+so they can run on the runtime/vm.
+*/
+
+fun is_pangram(input_str: string): bool {
+  var letters: list<string> = []
+  var i = 0
+  while i < len(input_str) {
+    let c = lower(input_str[i])
+    let is_new = !(c in letters)
+    if c != " " && "a" <= c && c <= "z" && is_new {
+      letters = append(letters, c)
+    }
+    i = i + 1
+  }
+  return len(letters) == 26
+}
+
+fun is_pangram_faster(input_str: string): bool {
+  let alphabet = "abcdefghijklmnopqrstuvwxyz"
+  var flag: list<bool> = []
+  var i = 0
+  while i < 26 {
+    flag = append(flag, false)
+    i = i + 1
+  }
+  var j = 0
+  while j < len(input_str) {
+    let c = lower(input_str[j])
+    var k = 0
+    while k < 26 {
+      if alphabet[k] == c {
+        flag[k] = true
+        break
+      }
+      k = k + 1
+    }
+    j = j + 1
+  }
+  var t = 0
+  while t < 26 {
+    if !flag[t] {
+      return false
+    }
+    t = t + 1
+  }
+  return true
+}
+
+fun is_pangram_fastest(input_str: string): bool {
+  let s = lower(input_str)
+  let alphabet = "abcdefghijklmnopqrstuvwxyz"
+  var i = 0
+  while i < len(alphabet) {
+    let letter = alphabet[i]
+    if !(letter in s) {
+      return false
+    }
+    i = i + 1
+  }
+  return true
+}
+
+let s1 = "The quick brown fox jumps over the lazy dog"
+let s2 = "My name is Unknown"
+
+print(str(is_pangram(s1)))
+print(str(is_pangram(s2)))
+print(str(is_pangram_faster(s1)))
+print(str(is_pangram_faster(s2)))
+print(str(is_pangram_fastest(s1)))
+print(str(is_pangram_fastest(s2)))

--- a/tests/github/TheAlgorithms/Mochi/strings/is_pangram.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/is_pangram.out
@@ -1,0 +1,6 @@
+true
+false
+true
+false
+true
+false

--- a/tests/github/TheAlgorithms/Python/strings/is_pangram.py
+++ b/tests/github/TheAlgorithms/Python/strings/is_pangram.py
@@ -1,0 +1,95 @@
+"""
+wiki: https://en.wikipedia.org/wiki/Pangram
+"""
+
+
+def is_pangram(
+    input_str: str = "The quick brown fox jumps over the lazy dog",
+) -> bool:
+    """
+    A Pangram String contains all the alphabets at least once.
+    >>> is_pangram("The quick brown fox jumps over the lazy dog")
+    True
+    >>> is_pangram("Waltz, bad nymph, for quick jigs vex.")
+    True
+    >>> is_pangram("Jived fox nymph grabs quick waltz.")
+    True
+    >>> is_pangram("My name is Unknown")
+    False
+    >>> is_pangram("The quick brown fox jumps over the la_y dog")
+    False
+    >>> is_pangram()
+    True
+    """
+    # Declare frequency as a set to have unique occurrences of letters
+    frequency = set()
+
+    # Replace all the whitespace in our sentence
+    input_str = input_str.replace(" ", "")
+    for alpha in input_str:
+        if "a" <= alpha.lower() <= "z":
+            frequency.add(alpha.lower())
+    return len(frequency) == 26
+
+
+def is_pangram_faster(
+    input_str: str = "The quick brown fox jumps over the lazy dog",
+) -> bool:
+    """
+    >>> is_pangram_faster("The quick brown fox jumps over the lazy dog")
+    True
+    >>> is_pangram_faster("Waltz, bad nymph, for quick jigs vex.")
+    True
+    >>> is_pangram_faster("Jived fox nymph grabs quick waltz.")
+    True
+    >>> is_pangram_faster("The quick brown fox jumps over the la_y dog")
+    False
+    >>> is_pangram_faster()
+    True
+    """
+    flag = [False] * 26
+    for char in input_str:
+        if char.islower():
+            flag[ord(char) - 97] = True
+        elif char.isupper():
+            flag[ord(char) - 65] = True
+    return all(flag)
+
+
+def is_pangram_fastest(
+    input_str: str = "The quick brown fox jumps over the lazy dog",
+) -> bool:
+    """
+    >>> is_pangram_fastest("The quick brown fox jumps over the lazy dog")
+    True
+    >>> is_pangram_fastest("Waltz, bad nymph, for quick jigs vex.")
+    True
+    >>> is_pangram_fastest("Jived fox nymph grabs quick waltz.")
+    True
+    >>> is_pangram_fastest("The quick brown fox jumps over the la_y dog")
+    False
+    >>> is_pangram_fastest()
+    True
+    """
+    return len({char for char in input_str.lower() if char.isalpha()}) == 26
+
+
+def benchmark() -> None:
+    """
+    Benchmark code comparing different version.
+    """
+    from timeit import timeit
+
+    setup = "from __main__ import is_pangram, is_pangram_faster, is_pangram_fastest"
+    print(timeit("is_pangram()", setup=setup))
+    print(timeit("is_pangram_faster()", setup=setup))
+    print(timeit("is_pangram_fastest()", setup=setup))
+    # 5.348480500048026, 2.6477354579837993, 1.8470395830227062
+    # 5.036091582966037, 2.644472333951853,  1.8869528750656173
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    benchmark()


### PR DESCRIPTION
## Summary
- add original Python `is_pangram` implementations
- implement `is_pangram`, `is_pangram_faster`, and `is_pangram_fastest` in Mochi
- record sample outputs for pangram detection

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/strings/is_pangram.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892e186ba7c832083b1b6d07d95900f