### PR TITLE
Add PESEL validation algorithm in Mochi

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/is_polish_national_id.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/is_polish_national_id.mochi
@@ -1,0 +1,64 @@
+/*
+Validate Polish national identification numbers (PESEL).
+
+A PESEL contains 11 digits encoding the birth date and a checksum.
+This implementation verifies:
+1. The input string is numeric and within the allowed range.
+2. Month digits encode a valid month for the proper century.
+3. Day digits form a value between 1 and 31.
+4. The final digit matches the checksum computed with weights
+   [1,3,7,9,1,3,7,9,1,3].
+
+The code is written in pure Mochi without FFI and avoids the "any" type,
+so it can execute on the runtime/vm.
+*/
+
+fun parse_int(s: string): int {
+  var value = 0
+  var i = 0
+  while i < len(s) {
+    let c = s[i]
+    value = value * 10 + (c as int)
+    i = i + 1
+  }
+  return value
+}
+
+fun is_polish_national_id(id: string): bool {
+  if len(id) == 0 { return false }
+  if substring(id, 0, 1) == "-" { return false }
+
+  let input_int = parse_int(id)
+  if input_int < 10100000 || input_int > 99923199999 { return false }
+
+  let month = parse_int(substring(id, 2, 4))
+  if !((month >= 1 && month <= 12) ||
+       (month >= 21 && month <= 32) ||
+       (month >= 41 && month <= 52) ||
+       (month >= 61 && month <= 72) ||
+       (month >= 81 && month <= 92)) {
+    return false
+  }
+
+  let day = parse_int(substring(id, 4, 6))
+  if day < 1 || day > 31 { return false }
+
+  let multipliers: list<int> = [1, 3, 7, 9, 1, 3, 7, 9, 1, 3]
+  var subtotal = 0
+  var i = 0
+  while i < len(multipliers) {
+    let digit = parse_int(substring(id, i, i + 1))
+    subtotal = subtotal + (digit * multipliers[i]) % 10
+    i = i + 1
+  }
+
+  let checksum = 10 - (subtotal % 10)
+  return checksum == input_int % 10
+}
+
+print(str(is_polish_national_id("02070803628")))
+print(str(is_polish_national_id("02150803629")))
+print(str(is_polish_national_id("02075503622")))
+print(str(is_polish_national_id("-99012212349")))
+print(str(is_polish_national_id("990122123499999")))
+print(str(is_polish_national_id("02070803621")))

--- a/tests/github/TheAlgorithms/Mochi/strings/is_polish_national_id.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/is_polish_national_id.out
@@ -1,0 +1,6 @@
+true
+false
+false
+false
+false
+false

--- a/tests/github/TheAlgorithms/Python/strings/is_polish_national_id.py
+++ b/tests/github/TheAlgorithms/Python/strings/is_polish_national_id.py
@@ -1,0 +1,92 @@
+def is_polish_national_id(input_str: str) -> bool:
+    """
+    Verification of the correctness of the PESEL number.
+    www-gov-pl.translate.goog/web/gov/czym-jest-numer-pesel?_x_tr_sl=auto&_x_tr_tl=en
+
+    PESEL can start with 0, that's why we take str as input,
+    but convert it to int for some calculations.
+
+
+    >>> is_polish_national_id(123)
+    Traceback (most recent call last):
+        ...
+    ValueError: Expected str as input, found <class 'int'>
+
+    >>> is_polish_national_id("abc")
+    Traceback (most recent call last):
+        ...
+    ValueError: Expected number as input
+
+    >>> is_polish_national_id("02070803628") # correct PESEL
+    True
+
+    >>> is_polish_national_id("02150803629") # wrong month
+    False
+
+    >>> is_polish_national_id("02075503622") # wrong day
+    False
+
+    >>> is_polish_national_id("-99012212349") # wrong range
+    False
+
+    >>> is_polish_national_id("990122123499999") # wrong range
+    False
+
+    >>> is_polish_national_id("02070803621") # wrong checksum
+    False
+    """
+
+    # check for invalid input type
+    if not isinstance(input_str, str):
+        msg = f"Expected str as input, found {type(input_str)}"
+        raise ValueError(msg)
+
+    # check if input can be converted to int
+    try:
+        input_int = int(input_str)
+    except ValueError:
+        msg = "Expected number as input"
+        raise ValueError(msg)
+
+    # check number range
+    if not 10100000 <= input_int <= 99923199999:
+        return False
+
+    # check month correctness
+    month = int(input_str[2:4])
+
+    if (
+        month not in range(1, 13)  # year 1900-1999
+        and month not in range(21, 33)  # 2000-2099
+        and month not in range(41, 53)  # 2100-2199
+        and month not in range(61, 73)  # 2200-2299
+        and month not in range(81, 93)  # 1800-1899
+    ):
+        return False
+
+    # check day correctness
+    day = int(input_str[4:6])
+
+    if day not in range(1, 32):
+        return False
+
+    # check the checksum
+    multipliers = [1, 3, 7, 9, 1, 3, 7, 9, 1, 3]
+    subtotal = 0
+
+    digits_to_check = str(input_str)[:-1]  # cut off the checksum
+
+    for index, digit in enumerate(digits_to_check):
+        # Multiply corresponding digits and multipliers.
+        # In case of a double-digit result, add only the last digit.
+        subtotal += (int(digit) * multipliers[index]) % 10
+
+    checksum = 10 - subtotal % 10
+
+    return checksum == input_int % 10
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()


### PR DESCRIPTION
## Summary
- add missing Python implementation for validating Polish national ID (PESEL)
- port PESEL validator to Mochi with range, date and checksum checks
- include sample runs and output

## Testing
- `python3 tests/github/TheAlgorithms/Python/strings/is_polish_national_id.py`
- `bash -lc 'go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/strings/is_polish_national_id.mochi > tests/github/TheAlgorithms/Mochi/strings/is_polish_national_id.out'`
- `cat tests/github/TheAlgorithms/Mochi/strings/is_polish_national_id.out`


------
https://chatgpt.com/codex/tasks/task_e_6892e1883ea0832092d516c614e1bc99