### PR TITLE
Add Spanish national ID validator example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/is_spain_national_id.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/is_spain_national_id.mochi
@@ -1,0 +1,83 @@
+/*
+Validate a Spanish National Identity Number (DNI).
+A DNI consists of eight digits followed by a letter. The letter is a checksum
+computed from the number modulo 23 and looked up in a fixed table
+"TRWAGMYFPDXBNJZSQVHLCKE". Input may include dashes and is case-insensitive.
+The algorithm removes any dash, converts the string to upper case, verifies
+that the cleaned ID has exactly nine characters and that the first eight are
+numeric while the final one is a letter. The checksum letter is calculated and
+compared to the provided letter. Runs in O(n) time for n characters.
+*/
+
+let DIGITS = "0123456789"
+let UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+let LOWER = "abcdefghijklmnopqrstuvwxyz"
+let LOOKUP_LETTERS = "TRWAGMYFPDXBNJZSQVHLCKE"
+let ERROR_MSG = "Input must be a string of 8 numbers plus letter"
+
+fun to_upper(s: string): string {
+  var res = ""
+  var i = 0
+  while i < len(s) {
+    let ch = s[i]
+    var j = 0
+    var converted = ch
+    while j < len(LOWER) {
+      if LOWER[j] == ch {
+        converted = UPPER[j]
+        break
+      }
+      j = j + 1
+    }
+    res = res + converted
+    i = i + 1
+  }
+  return res
+}
+
+fun is_digit(ch: string): bool {
+  var i = 0
+  while i < len(DIGITS) {
+    if DIGITS[i] == ch { return true }
+    i = i + 1
+  }
+  return false
+}
+
+fun clean_id(spanish_id: string): string {
+  let upper_id = to_upper(spanish_id)
+  var cleaned = ""
+  var i = 0
+  while i < len(upper_id) {
+    let ch = upper_id[i]
+    if ch != "-" {
+      cleaned = cleaned + ch
+    }
+    i = i + 1
+  }
+  return cleaned
+}
+
+fun is_spain_national_id(spanish_id: string): bool {
+  let sid = clean_id(spanish_id)
+  if len(sid) != 9 { panic(ERROR_MSG) }
+  var i = 0
+  while i < 8 {
+    if !is_digit(sid[i]) { panic(ERROR_MSG) }
+    i = i + 1
+  }
+  let number = int(substring(sid, 0, 8))
+  let letter = sid[8]
+  if is_digit(letter) { panic(ERROR_MSG) }
+  let expected = LOOKUP_LETTERS[number % 23]
+  return letter == expected
+}
+
+fun main() {
+  print(is_spain_national_id("12345678Z"))
+  print(is_spain_national_id("12345678z"))
+  print(is_spain_national_id("12345678x"))
+  print(is_spain_national_id("12345678I"))
+  print(is_spain_national_id("12345678-Z"))
+}
+main()

--- a/tests/github/TheAlgorithms/Mochi/strings/is_spain_national_id.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/is_spain_national_id.out
@@ -1,0 +1,5 @@
+true
+true
+false
+false
+true

--- a/tests/github/TheAlgorithms/Python/strings/is_spain_national_id.py
+++ b/tests/github/TheAlgorithms/Python/strings/is_spain_national_id.py
@@ -1,0 +1,73 @@
+NUMBERS_PLUS_LETTER = "Input must be a string of 8 numbers plus letter"
+LOOKUP_LETTERS = "TRWAGMYFPDXBNJZSQVHLCKE"
+
+
+def is_spain_national_id(spanish_id: str) -> bool:
+    """
+    Spain National Id is a string composed by 8 numbers plus a letter
+    The letter in fact is not part of the ID, it acts as a validator,
+    checking you didn't do a mistake when entering it on a system or
+    are giving a fake one.
+
+    https://en.wikipedia.org/wiki/Documento_Nacional_de_Identidad_(Spain)#Number
+
+    >>> is_spain_national_id("12345678Z")
+    True
+    >>> is_spain_national_id("12345678z")  # It is case-insensitive
+    True
+    >>> is_spain_national_id("12345678x")
+    False
+    >>> is_spain_national_id("12345678I")
+    False
+    >>> is_spain_national_id("12345678-Z")  # Some systems add a dash
+    True
+    >>> is_spain_national_id("12345678")
+    Traceback (most recent call last):
+        ...
+    ValueError: Input must be a string of 8 numbers plus letter
+    >>> is_spain_national_id("123456709")
+    Traceback (most recent call last):
+        ...
+    ValueError: Input must be a string of 8 numbers plus letter
+    >>> is_spain_national_id("1234567--Z")
+    Traceback (most recent call last):
+        ...
+    ValueError: Input must be a string of 8 numbers plus letter
+    >>> is_spain_national_id("1234Z")
+    Traceback (most recent call last):
+        ...
+    ValueError: Input must be a string of 8 numbers plus letter
+    >>> is_spain_national_id("1234ZzZZ")
+    Traceback (most recent call last):
+        ...
+    ValueError: Input must be a string of 8 numbers plus letter
+    >>> is_spain_national_id(12345678)
+    Traceback (most recent call last):
+        ...
+    TypeError: Expected string as input, found int
+    """
+
+    if not isinstance(spanish_id, str):
+        msg = f"Expected string as input, found {type(spanish_id).__name__}"
+        raise TypeError(msg)
+
+    spanish_id_clean = spanish_id.replace("-", "").upper()
+    if len(spanish_id_clean) != 9:
+        raise ValueError(NUMBERS_PLUS_LETTER)
+
+    try:
+        number = int(spanish_id_clean[0:8])
+        letter = spanish_id_clean[8]
+    except ValueError as ex:
+        raise ValueError(NUMBERS_PLUS_LETTER) from ex
+
+    if letter.isdigit():
+        raise ValueError(NUMBERS_PLUS_LETTER)
+
+    return letter == LOOKUP_LETTERS[number % 23]
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add Python implementation for validating Spanish national ID numbers
- provide equivalent Mochi version with inline tests

## Testing
- `python tests/github/TheAlgorithms/Python/strings/is_spain_national_id.py`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/strings/is_spain_national_id.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6892e1890abc832095d342f44f22b731