### PR TITLE
Add Mochi translation for string join algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/join.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/join.mochi
@@ -1,0 +1,35 @@
+/*
+String Join
+-----------
+Join a list of strings using a separator. The algorithm appends each string
+from the input list to a result, inserting the separator between consecutive
+strings. The last element is appended without a trailing separator.
+
+Time complexity: O(n) for n strings.
+Space complexity: O(1) extra space besides the output.
+*/
+
+fun join(separator: string, separated: list<string>): string {
+  var joined = ""
+  let last_index: int = len(separated) - 1
+  var i = 0
+  while i < len(separated) {
+    joined = joined + separated[i]
+    if i < last_index {
+      joined = joined + separator
+    }
+    i = i + 1
+  }
+  return joined
+}
+
+fun main() {
+  print(join("", ["a", "b", "c", "d"]))
+  print(join("#", ["a", "b", "c", "d"]))
+  print(join("#", ["a"]))
+  print(join(" ", ["You", "are", "amazing!"]))
+  print(join(",", ["", "", ""]))
+  print(join("-", ["apple", "banana", "cherry"]))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/strings/join.mochi.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/join.mochi.out
@@ -1,0 +1,6 @@
+abcd
+a#b#c#d
+a
+You are amazing!
+,,
+apple-banana-cherry

--- a/tests/github/TheAlgorithms/Python/strings/join.py
+++ b/tests/github/TheAlgorithms/Python/strings/join.py
@@ -1,0 +1,74 @@
+"""
+Program to join a list of strings with a separator
+"""
+
+
+def join(separator: str, separated: list[str]) -> str:
+    """
+    Joins a list of strings using a separator
+    and returns the result.
+
+    :param separator: Separator to be used
+                for joining the strings.
+    :param separated: List of strings to be joined.
+
+    :return: Joined string with the specified separator.
+
+    Examples:
+
+    >>> join("", ["a", "b", "c", "d"])
+    'abcd'
+    >>> join("#", ["a", "b", "c", "d"])
+    'a#b#c#d'
+    >>> join("#", "a")
+    'a'
+    >>> join(" ", ["You", "are", "amazing!"])
+    'You are amazing!'
+    >>> join(",", ["", "", ""])
+    ',,'
+
+    This example should raise an
+    exception for non-string elements:
+    >>> join("#", ["a", "b", "c", 1])
+    Traceback (most recent call last):
+        ...
+    Exception: join() accepts only strings
+
+    Additional test case with a different separator:
+    >>> join("-", ["apple", "banana", "cherry"])
+    'apple-banana-cherry'
+    """
+
+    # Check that all elements are strings
+    for word_or_phrase in separated:
+        # If the element is not a string, raise an exception
+        if not isinstance(word_or_phrase, str):
+            raise Exception("join() accepts only strings")
+
+    joined: str = ""
+    """
+    The last element of the list is not followed by the separator.
+    So, we need to iterate through the list and join each element
+    with the separator except the last element.
+    """
+    last_index: int = len(separated) - 1
+    """
+    Iterate through the list and join each element with the separator.
+    Except the last element, all other elements are followed by the separator.
+    """
+    for word_or_phrase in separated[:last_index]:
+        # join the element with the separator.
+        joined += word_or_phrase + separator
+
+    # If the list is not empty, join the last element.
+    if separated != []:
+        joined += separated[last_index]
+
+    # Return the joined string.
+    return joined
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()


### PR DESCRIPTION
## Summary
- add Python reference implementation of joining strings with separators
- provide equivalent pure Mochi version and sample outputs

## Testing
- `python tests/github/TheAlgorithms/Python/strings/join.py`
- `go run ./cmd/mochi/main.go run tests/github/TheAlgorithms/Mochi/strings/join.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6892e191c4588320a0032761abeb0b3d