### PR TITLE
Add Mochi implementation of Manacher's longest palindrome algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/manacher.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/manacher.mochi
@@ -1,0 +1,79 @@
+/*
+Manacher's algorithm finds the longest palindromic substring of a given string
+in linear time. The input string is transformed by inserting a separator
+character between every pair of characters so that both even and odd length
+palindromes can be handled uniformly. For each position in the transformed
+string the algorithm expands around the centre using previously computed
+palindrome lengths to skip redundant comparisons. It tracks the current right
+most palindrome and uses symmetry to initialise expansions. The maximal length
+and start position are updated when longer palindromes are found and finally
+the separators are removed from the resulting substring.
+*/
+
+fun palindromic_string(input_string: string): string {
+  var max_length = 0
+  var new_input_string: string = ""
+  var output_string: string = ""
+
+  let n = len(input_string)
+  var i = 0
+  while i < n - 1 {
+    new_input_string = new_input_string + substring(input_string, i, i + 1) + "|"
+    i = i + 1
+  }
+  new_input_string = new_input_string + substring(input_string, n - 1, n)
+
+  var left = 0
+  var right = 0
+  var length: list<int> = []
+  i = 0
+  let m = len(new_input_string)
+  while i < m {
+    length = append(length, 1)
+    i = i + 1
+  }
+
+  var start = 0
+  var j = 0
+  while j < m {
+    var k = 1
+    if j <= right {
+      let mirror = left + right - j
+      k = length[mirror] / 2
+      let diff = right - j + 1
+      if diff < k { k = diff }
+      if k < 1 { k = 1 }
+    }
+    while j - k >= 0 && j + k < m && substring(new_input_string, j + k, j + k + 1) == substring(new_input_string, j - k, j - k + 1) {
+      k = k + 1
+    }
+    length[j] = 2 * k - 1
+    if j + k - 1 > right {
+      left = j - k + 1
+      right = j + k - 1
+    }
+    if length[j] > max_length {
+      max_length = length[j]
+      start = j
+    }
+    j = j + 1
+  }
+
+  let s = substring(new_input_string, start - max_length / 2, start + max_length / 2 + 1)
+  var idx = 0
+  while idx < len(s) {
+    let ch = substring(s, idx, idx + 1)
+    if ch != "|" {
+      output_string = output_string + ch
+    }
+    idx = idx + 1
+  }
+  return output_string
+}
+
+fun main() {
+  print(palindromic_string("abbbaba"))
+  print(palindromic_string("ababa"))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/strings/manacher.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/manacher.out
@@ -1,0 +1,2 @@
+abbba
+ababa

--- a/tests/github/TheAlgorithms/Python/strings/manacher.py
+++ b/tests/github/TheAlgorithms/Python/strings/manacher.py
@@ -1,0 +1,109 @@
+def palindromic_string(input_string: str) -> str:
+    """
+    >>> palindromic_string('abbbaba')
+    'abbba'
+    >>> palindromic_string('ababa')
+    'ababa'
+
+    Manacher's algorithm which finds Longest palindromic Substring in linear time.
+
+    1. first this convert input_string("xyx") into new_string("x|y|x") where odd
+        positions are actual input characters.
+    2. for each character in new_string it find corresponding length and
+        store the length and left,right to store previously calculated info.
+        (please look the explanation for details)
+
+    3. return corresponding output_string by removing all "|"
+    """
+    max_length = 0
+
+    # if input_string is "aba" than new_input_string become "a|b|a"
+    new_input_string = ""
+    output_string = ""
+
+    # append each character + "|" in new_string for range(0, length-1)
+    for i in input_string[: len(input_string) - 1]:
+        new_input_string += i + "|"
+    # append last character
+    new_input_string += input_string[-1]
+
+    # we will store the starting and ending of previous furthest ending palindromic
+    # substring
+    left, right = 0, 0
+
+    # length[i] shows the length of palindromic substring with center i
+    length = [1 for i in range(len(new_input_string))]
+
+    # for each character in new_string find corresponding palindromic string
+    start = 0
+    for j in range(len(new_input_string)):
+        k = 1 if j > right else min(length[left + right - j] // 2, right - j + 1)
+        while (
+            j - k >= 0
+            and j + k < len(new_input_string)
+            and new_input_string[k + j] == new_input_string[j - k]
+        ):
+            k += 1
+
+        length[j] = 2 * k - 1
+
+        # does this string is ending after the previously explored end (that is right) ?
+        # if yes the update the new right to the last index of this
+        if j + k - 1 > right:
+            left = j - k + 1
+            right = j + k - 1
+
+        # update max_length and start position
+        if max_length < length[j]:
+            max_length = length[j]
+            start = j
+
+    # create that string
+    s = new_input_string[start - max_length // 2 : start + max_length // 2 + 1]
+    for i in s:
+        if i != "|":
+            output_string += i
+
+    return output_string
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+
+"""
+...a0...a1...a2.....a3......a4...a5...a6....
+
+consider the string for which we are calculating the longest palindromic substring is
+shown above where ... are some characters in between and right now we are calculating
+the length of palindromic substring with center at a5 with following conditions :
+i) we have stored the length of palindromic substring which has center at a3
+    (starts at left ends at right) and it is the furthest ending till now,
+    and it has ending after a6
+ii) a2 and a4 are equally distant from a3 so char(a2) == char(a4)
+iii) a0 and a6 are equally distant from a3 so char(a0) == char(a6)
+iv) a1 is corresponding equal character of a5 in palindrome with center a3 (remember
+    that in below derivation of a4==a6)
+
+now for a5 we will calculate the length of palindromic substring with center as a5 but
+can we use previously calculated information in some way?
+Yes, look the above string we know that a5 is inside the palindrome with center a3 and
+previously we have calculated that
+a0==a2 (palindrome of center a1)
+a2==a4 (palindrome of center a3)
+a0==a6 (palindrome of center a3)
+so a4==a6
+
+so we can say that palindrome at center a5 is at least as long as palindrome at center
+a1 but this only holds if a0 and a6 are inside the limits of palindrome centered at a3
+so finally ..
+
+len_of_palindrome__at(a5) = min(len_of_palindrome_at(a1), right-a5)
+where a3 lies from left to right and we have to keep updating that
+
+and if the a5 lies outside of left,right boundary we calculate length of palindrome with
+bruteforce and update left,right.
+
+it gives the linear time complexity just like z-function
+"""


### PR DESCRIPTION
## Summary
- add missing Python source for Manacher's algorithm
- implement Manacher's algorithm in Mochi with sample usage
- include runtime output

## Testing
- `go test ./...`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/strings/manacher.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892e197046c832099317b39a17a22d5