### PR TITLE
Add Mochi implementation for min cost string conversion

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/min_cost_string_conversion.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/min_cost_string_conversion.mochi
@@ -1,0 +1,196 @@
+/*
+Calculate the minimum cost sequence of operations to transform one string into
+another using dynamic programming. Allowed operations are:
+- copy a matching character (cost `copy_cost`)
+- replace one character with another (cost `replace_cost`)
+- delete a character (cost `delete_cost`)
+- insert a character (cost `insert_cost`)
+The algorithm builds two tables: `costs` storing the minimal cost and `ops`
+recording the chosen operation at each step.  Backtracking through `ops`
+produces the optimal sequence of edits.  Complexity is O(m*n) for strings of
+length m and n.  Implemented in pure Mochi so it can run on runtime/vm.
+*/
+
+type TransformTables {
+  costs: list<list<int>>,
+  ops: list<list<string>>,
+}
+
+fun string_to_chars(s: string): list<string> {
+  var chars: list<string> = []
+  var i = 0
+  while i < len(s) {
+    chars = append(chars, substring(s, i, i + 1))
+    i = i + 1
+  }
+  return chars
+}
+
+fun join_chars(chars: list<string>): string {
+  var res = ""
+  var i = 0
+  while i < len(chars) {
+    res = res + chars[i]
+    i = i + 1
+  }
+  return res
+}
+
+fun insert_at(chars: list<string>, index: int, ch: string): list<string> {
+  var res: list<string> = []
+  var i = 0
+  while i < index {
+    res = append(res, chars[i])
+    i = i + 1
+  }
+  res = append(res, ch)
+  while i < len(chars) {
+    res = append(res, chars[i])
+    i = i + 1
+  }
+  return res
+}
+
+fun remove_at(chars: list<string>, index: int): list<string> {
+  var res: list<string> = []
+  var i = 0
+  while i < len(chars) {
+    if i != index {
+      res = append(res, chars[i])
+    }
+    i = i + 1
+  }
+  return res
+}
+
+fun make_matrix_int(rows: int, cols: int, init: int): list<list<int>> {
+  var matrix: list<list<int>> = []
+  for _ in 0..rows {
+    var row: list<int> = []
+    for _2 in 0..cols {
+      row = append(row, init)
+    }
+    matrix = append(matrix, row)
+  }
+  return matrix
+}
+
+fun make_matrix_string(rows: int, cols: int, init: string): list<list<string>> {
+  var matrix: list<list<string>> = []
+  for _ in 0..rows {
+    var row: list<string> = []
+    for _2 in 0..cols {
+      row = append(row, init)
+    }
+    matrix = append(matrix, row)
+  }
+  return matrix
+}
+
+fun compute_transform_tables(source_string: string, destination_string: string, copy_cost: int, replace_cost: int, delete_cost: int, insert_cost: int): TransformTables {
+  let source_seq = string_to_chars(source_string)
+  let dest_seq = string_to_chars(destination_string)
+  let m = len(source_seq)
+  let n = len(dest_seq)
+  var costs = make_matrix_int(m + 1, n + 1, 0)
+  var ops = make_matrix_string(m + 1, n + 1, "0")
+
+  var i = 1
+  while i <= m {
+    costs[i][0] = i * delete_cost
+    ops[i][0] = "D" + source_seq[i - 1]
+    i = i + 1
+  }
+
+  var j = 1
+  while j <= n {
+    costs[0][j] = j * insert_cost
+    ops[0][j] = "I" + dest_seq[j - 1]
+    j = j + 1
+  }
+
+  i = 1
+  while i <= m {
+    j = 1
+    while j <= n {
+      if source_seq[i - 1] == dest_seq[j - 1] {
+        costs[i][j] = costs[i - 1][j - 1] + copy_cost
+        ops[i][j] = "C" + source_seq[i - 1]
+      } else {
+        costs[i][j] = costs[i - 1][j - 1] + replace_cost
+        ops[i][j] = "R" + source_seq[i - 1] + dest_seq[j - 1]
+      }
+      if costs[i - 1][j] + delete_cost < costs[i][j] {
+        costs[i][j] = costs[i - 1][j] + delete_cost
+        ops[i][j] = "D" + source_seq[i - 1]
+      }
+      if costs[i][j - 1] + insert_cost < costs[i][j] {
+        costs[i][j] = costs[i][j - 1] + insert_cost
+        ops[i][j] = "I" + dest_seq[j - 1]
+      }
+      j = j + 1
+    }
+    i = i + 1
+  }
+  return TransformTables { costs: costs, ops: ops }
+}
+
+fun assemble_transformation(ops: list<list<string>>, i: int, j: int): list<string> {
+  if i == 0 && j == 0 { return [] }
+  let op = ops[i][j]
+  let kind = substring(op, 0, 1)
+  if kind == "C" || kind == "R" {
+    var seq = assemble_transformation(ops, i - 1, j - 1)
+    seq = append(seq, op)
+    return seq
+  } else if kind == "D" {
+    var seq = assemble_transformation(ops, i - 1, j)
+    seq = append(seq, op)
+    return seq
+  } else {
+    var seq = assemble_transformation(ops, i, j - 1)
+    seq = append(seq, op)
+    return seq
+  }
+}
+
+fun main() {
+  let copy_cost = -1
+  let replace_cost = 1
+  let delete_cost = 2
+  let insert_cost = 2
+  let src = "Python"
+  let dst = "Algorithms"
+  let tables = compute_transform_tables(src, dst, copy_cost, replace_cost, delete_cost, insert_cost)
+  let operations = tables.ops
+  let m = len(operations)
+  let n = len(operations[0])
+  var sequence = assemble_transformation(operations, m - 1, n - 1)
+  var string_list = string_to_chars(src)
+  var idx = 0
+  var cost = 0
+  var k = 0
+  while k < len(sequence) {
+    print(join_chars(string_list))
+    let op = sequence[k]
+    let kind = substring(op, 0, 1)
+    if kind == "C" {
+      cost = cost + copy_cost
+    } else if kind == "R" {
+      string_list[idx] = substring(op, 2, 3)
+      cost = cost + replace_cost
+    } else if kind == "D" {
+      string_list = remove_at(string_list, idx)
+      cost = cost + delete_cost
+    } else {
+      string_list = insert_at(string_list, idx, substring(op, 1, 2))
+      cost = cost + insert_cost
+    }
+    idx = idx + 1
+    k = k + 1
+  }
+  print(join_chars(string_list))
+  print("Cost: " + str(cost))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/strings/min_cost_string_conversion.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/min_cost_string_conversion.out
@@ -1,0 +1,12 @@
+Python
+APython
+AlPython
+AlgPython
+AlgoPython
+Algorython
+Algorithon
+Algorithon
+Algorithon
+Algorithmn
+Algorithms
+Cost: 10

--- a/tests/github/TheAlgorithms/Python/strings/min_cost_string_conversion.py
+++ b/tests/github/TheAlgorithms/Python/strings/min_cost_string_conversion.py
@@ -1,0 +1,170 @@
+"""
+Algorithm for calculating the most cost-efficient sequence for converting one string
+into another.
+The only allowed operations are
+--- Cost to copy a character is copy_cost
+--- Cost to replace a character is replace_cost
+--- Cost to delete a character is delete_cost
+--- Cost to insert a character is insert_cost
+"""
+
+
+def compute_transform_tables(
+    source_string: str,
+    destination_string: str,
+    copy_cost: int,
+    replace_cost: int,
+    delete_cost: int,
+    insert_cost: int,
+) -> tuple[list[list[int]], list[list[str]]]:
+    """
+    Finds the most cost efficient sequence
+    for converting one string into another.
+
+    >>> costs, operations = compute_transform_tables("cat", "cut", 1, 2, 3, 3)
+    >>> costs[0][:4]
+    [0, 3, 6, 9]
+    >>> costs[2][:4]
+    [6, 4, 3, 6]
+    >>> operations[0][:4]
+    ['0', 'Ic', 'Iu', 'It']
+    >>> operations[3][:4]
+    ['Dt', 'Dt', 'Rtu', 'Ct']
+
+    >>> compute_transform_tables("", "", 1, 2, 3, 3)
+    ([[0]], [['0']])
+    """
+    source_seq = list(source_string)
+    destination_seq = list(destination_string)
+    len_source_seq = len(source_seq)
+    len_destination_seq = len(destination_seq)
+    costs = [
+        [0 for _ in range(len_destination_seq + 1)] for _ in range(len_source_seq + 1)
+    ]
+    ops = [
+        ["0" for _ in range(len_destination_seq + 1)] for _ in range(len_source_seq + 1)
+    ]
+
+    for i in range(1, len_source_seq + 1):
+        costs[i][0] = i * delete_cost
+        ops[i][0] = f"D{source_seq[i - 1]}"
+
+    for i in range(1, len_destination_seq + 1):
+        costs[0][i] = i * insert_cost
+        ops[0][i] = f"I{destination_seq[i - 1]}"
+
+    for i in range(1, len_source_seq + 1):
+        for j in range(1, len_destination_seq + 1):
+            if source_seq[i - 1] == destination_seq[j - 1]:
+                costs[i][j] = costs[i - 1][j - 1] + copy_cost
+                ops[i][j] = f"C{source_seq[i - 1]}"
+            else:
+                costs[i][j] = costs[i - 1][j - 1] + replace_cost
+                ops[i][j] = f"R{source_seq[i - 1]}" + str(destination_seq[j - 1])
+
+            if costs[i - 1][j] + delete_cost < costs[i][j]:
+                costs[i][j] = costs[i - 1][j] + delete_cost
+                ops[i][j] = f"D{source_seq[i - 1]}"
+
+            if costs[i][j - 1] + insert_cost < costs[i][j]:
+                costs[i][j] = costs[i][j - 1] + insert_cost
+                ops[i][j] = f"I{destination_seq[j - 1]}"
+
+    return costs, ops
+
+
+def assemble_transformation(ops: list[list[str]], i: int, j: int) -> list[str]:
+    """
+    Assembles the transformations based on the ops table.
+
+    >>> ops = [['0', 'Ic', 'Iu', 'It'],
+    ...        ['Dc', 'Cc', 'Iu', 'It'],
+    ...        ['Da', 'Da', 'Rau', 'Rat'],
+    ...        ['Dt', 'Dt', 'Rtu', 'Ct']]
+    >>> x = len(ops) - 1
+    >>> y = len(ops[0]) - 1
+    >>> assemble_transformation(ops, x, y)
+    ['Cc', 'Rau', 'Ct']
+
+    >>> ops1 = [['0']]
+    >>> x1 = len(ops1) - 1
+    >>> y1 = len(ops1[0]) - 1
+    >>> assemble_transformation(ops1, x1, y1)
+    []
+
+    >>> ops2 = [['0', 'I1', 'I2', 'I3'],
+    ...         ['D1', 'C1', 'I2', 'I3'],
+    ...         ['D2', 'D2', 'R23', 'R23']]
+    >>> x2 = len(ops2) - 1
+    >>> y2 = len(ops2[0]) - 1
+    >>> assemble_transformation(ops2, x2, y2)
+    ['C1', 'I2', 'R23']
+    """
+    if i == 0 and j == 0:
+        return []
+    elif ops[i][j][0] in {"C", "R"}:
+        seq = assemble_transformation(ops, i - 1, j - 1)
+        seq.append(ops[i][j])
+        return seq
+    elif ops[i][j][0] == "D":
+        seq = assemble_transformation(ops, i - 1, j)
+        seq.append(ops[i][j])
+        return seq
+    else:
+        seq = assemble_transformation(ops, i, j - 1)
+        seq.append(ops[i][j])
+        return seq
+
+
+if __name__ == "__main__":
+    _, operations = compute_transform_tables("Python", "Algorithms", -1, 1, 2, 2)
+
+    m = len(operations)
+    n = len(operations[0])
+    sequence = assemble_transformation(operations, m - 1, n - 1)
+
+    string = list("Python")
+    i = 0
+    cost = 0
+
+    with open("min_cost.txt", "w") as file:
+        for op in sequence:
+            print("".join(string))
+
+            if op[0] == "C":
+                file.write("%-16s" % "Copy %c" % op[1])  # noqa: UP031
+                file.write("\t\t\t" + "".join(string))
+                file.write("\r\n")
+
+                cost -= 1
+            elif op[0] == "R":
+                string[i] = op[2]
+
+                file.write("%-16s" % ("Replace %c" % op[1] + " with " + str(op[2])))  # noqa: UP031
+                file.write("\t\t" + "".join(string))
+                file.write("\r\n")
+
+                cost += 1
+            elif op[0] == "D":
+                string.pop(i)
+
+                file.write("%-16s" % "Delete %c" % op[1])  # noqa: UP031
+                file.write("\t\t\t" + "".join(string))
+                file.write("\r\n")
+
+                cost += 2
+            else:
+                string.insert(i, op[1])
+
+                file.write("%-16s" % "Insert %c" % op[1])  # noqa: UP031
+                file.write("\t\t\t" + "".join(string))
+                file.write("\r\n")
+
+                cost += 2
+
+            i += 1
+
+        print("".join(string))
+        print("Cost: ", cost)
+
+        file.write("\r\nMinimum cost: " + str(cost))


### PR DESCRIPTION
## Summary
- add Python and Mochi versions of min cost string conversion
- compute transform cost table and reconstruction sequence
- run algorithm example converting "Python" to "Algorithms"

## Testing
- `./mochi run tests/github/TheAlgorithms/Mochi/strings/min_cost_string_conversion.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892e198d1708320b6abc4ee7bd4ad8c