### PR TITLE
Add palindrome algorithms in Mochi

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/palindrome.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/palindrome.mochi
@@ -1,0 +1,102 @@
+/*
+Palindrome Detection in Strings
+
+This module implements four strategies to test whether a given string reads
+identically forward and backward:
+1. is_palindrome: Uses two indices that move toward the center comparing
+   mirrored characters. The loop exits early on mismatch. O(n) time, O(1) space.
+2. is_palindrome_traversal: Traverses only the first half of the string and
+   compares each character with its counterpart from the other end. O(n) time,
+   O(1) space.
+3. is_palindrome_recursive: Recursively compares the first and last characters
+   and reduces the problem size by stripping them off each call. O(n) time,
+   O(n) recursion depth.
+4. is_palindrome_slice: Creates a reversed copy of the string and checks for
+   equality. O(n) time and space for the temporary copy.
+
+Each function accepts a string and returns true if it is a palindrome.
+The program validates the algorithms against several examples and prints the
+expected result for each test case.
+*/
+
+type Case { text: string, expected: bool }
+
+fun reverse(s: string): string {
+  var res: string = ""
+  var i: int = len(s) - 1
+  while i >= 0 {
+    res = res + s[i]
+    i = i - 1
+  }
+  return res
+}
+
+fun is_palindrome(s: string): bool {
+  var start_i: int = 0
+  var end_i: int = len(s) - 1
+  while start_i < end_i {
+    if s[start_i] == s[end_i] {
+      start_i = start_i + 1
+      end_i = end_i - 1
+    } else {
+      return false
+    }
+  }
+  return true
+}
+
+fun is_palindrome_traversal(s: string): bool {
+  let end: int = len(s) / 2
+  let n: int = len(s)
+  var i: int = 0
+  while i < end {
+    if s[i] != s[n - i - 1] {
+      return false
+    }
+    i = i + 1
+  }
+  return true
+}
+
+fun is_palindrome_recursive(s: string): bool {
+  if len(s) <= 1 {
+    return true
+  }
+  if s[0] == s[len(s) - 1] {
+    return is_palindrome_recursive(s[1:len(s)-1])
+  }
+  return false
+}
+
+fun is_palindrome_slice(s: string): bool {
+  return s == reverse(s)
+}
+
+let test_data: list<Case> = [
+  Case{ text: "MALAYALAM", expected: true },
+  Case{ text: "String", expected: false },
+  Case{ text: "rotor", expected: true },
+  Case{ text: "level", expected: true },
+  Case{ text: "A", expected: true },
+  Case{ text: "BB", expected: true },
+  Case{ text: "ABC", expected: false },
+  Case{ text: "amanaplanacanalpanama", expected: true }
+]
+
+fun main() {
+  for t in test_data {
+    let s: string = t.text
+    let expected: bool = t.expected
+    let r1: bool = is_palindrome(s)
+    let r2: bool = is_palindrome_traversal(s)
+    let r3: bool = is_palindrome_recursive(s)
+    let r4: bool = is_palindrome_slice(s)
+    if r1 != expected || r2 != expected || r3 != expected || r4 != expected {
+      panic("algorithm mismatch")
+    }
+    print(s + " " + str(expected))
+  }
+  print("a man a plan a canal panama")
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/strings/palindrome.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/palindrome.out
@@ -1,0 +1,9 @@
+MALAYALAM true
+String false
+rotor true
+level true
+A true
+BB true
+ABC false
+amanaplanacanalpanama true
+a man a plan a canal panama

--- a/tests/github/TheAlgorithms/Python/strings/palindrome.py
+++ b/tests/github/TheAlgorithms/Python/strings/palindrome.py
@@ -1,0 +1,104 @@
+# Algorithms to determine if a string is palindrome
+
+from timeit import timeit
+
+test_data = {
+    "MALAYALAM": True,
+    "String": False,
+    "rotor": True,
+    "level": True,
+    "A": True,
+    "BB": True,
+    "ABC": False,
+    "amanaplanacanalpanama": True,  # "a man a plan a canal panama"
+}
+# Ensure our test data is valid
+assert all((key == key[::-1]) is value for key, value in test_data.items())
+
+
+def is_palindrome(s: str) -> bool:
+    """
+    Return True if s is a palindrome otherwise return False.
+
+    >>> all(is_palindrome(key) is value for key, value in test_data.items())
+    True
+    """
+
+    start_i = 0
+    end_i = len(s) - 1
+    while start_i < end_i:
+        if s[start_i] == s[end_i]:
+            start_i += 1
+            end_i -= 1
+        else:
+            return False
+    return True
+
+
+def is_palindrome_traversal(s: str) -> bool:
+    """
+    Return True if s is a palindrome otherwise return False.
+
+    >>> all(is_palindrome_traversal(key) is value for key, value in test_data.items())
+    True
+    """
+    end = len(s) // 2
+    n = len(s)
+
+    # We need to traverse till half of the length of string
+    # as we can get access of the i'th last element from
+    # i'th index.
+    # eg: [0,1,2,3,4,5] => 4th index can be accessed
+    # with the help of 1st index (i==n-i-1)
+    # where n is length of string
+    return all(s[i] == s[n - i - 1] for i in range(end))
+
+
+def is_palindrome_recursive(s: str) -> bool:
+    """
+    Return True if s is a palindrome otherwise return False.
+
+    >>> all(is_palindrome_recursive(key) is value for key, value in test_data.items())
+    True
+    """
+    if len(s) <= 2:
+        return True
+    if s[0] == s[len(s) - 1]:
+        return is_palindrome_recursive(s[1:-1])
+    else:
+        return False
+
+
+def is_palindrome_slice(s: str) -> bool:
+    """
+    Return True if s is a palindrome otherwise return False.
+
+    >>> all(is_palindrome_slice(key) is value for key, value in test_data.items())
+    True
+    """
+    return s == s[::-1]
+
+
+def benchmark_function(name: str) -> None:
+    stmt = f"all({name}(key) is value for key, value in test_data.items())"
+    setup = f"from __main__ import test_data, {name}"
+    number = 500000
+    result = timeit(stmt=stmt, setup=setup, number=number)
+    print(f"{name:<35} finished {number:,} runs in {result:.5f} seconds")
+
+
+if __name__ == "__main__":
+    for key, value in test_data.items():
+        assert is_palindrome(key) is is_palindrome_recursive(key)
+        assert is_palindrome(key) is is_palindrome_slice(key)
+        print(f"{key:21} {value}")
+    print("a man a plan a canal panama")
+
+    # finished 500,000 runs in 0.46793 seconds
+    benchmark_function("is_palindrome_slice")
+    # finished 500,000 runs in 0.85234 seconds
+    benchmark_function("is_palindrome")
+    # finished 500,000 runs in 1.32028 seconds
+    benchmark_function("is_palindrome_recursive")
+    # finished 500,000 runs in 2.08679 seconds
+    benchmark_function("is_palindrome_traversal")


### PR DESCRIPTION
## Summary
- port Python palindrome examples and test data
- implement four palindrome detection strategies in pure Mochi
- add runtime output for sample inputs

## Testing
- `go run ./cmd/mochi/main.go run tests/github/TheAlgorithms/Mochi/strings/palindrome.mochi`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6892e1eed72483209430d959de801b76