### PR TITLE
Add reverse words algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/reverse_words.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/reverse_words.mochi
@@ -1,0 +1,52 @@
+/*
+Reverse Words in a String
+-------------------------
+Given an input string, produce a new string with the words in reverse
+order. Words are contiguous sequences of non-space characters. Multiple
+spaces are treated as a single separator. The algorithm splits the input
+into words, reverses the list, and joins them with single spaces.
+This mirrors the Python implementation using `" ".join(input_str.split()[::-1])`.
+*/
+
+fun split_words(s: string): list<string> {
+  var words: list<string> = []
+  var current: string = ""
+  var i = 0
+  while i < len(s) {
+    let ch = s[i]
+    if ch == " " {
+      if len(current) > 0 {
+        words = append(words, current)
+        current = ""
+      }
+    } else {
+      current = current + ch
+    }
+    i = i + 1
+  }
+  if len(current) > 0 {
+    words = append(words, current)
+  }
+  return words
+}
+
+fun reverse_words(input_str: string): string {
+  let words = split_words(input_str)
+  var res: string = ""
+  var i = len(words) - 1
+  while i >= 0 {
+    res = res + words[i]
+    if i > 0 {
+      res = res + " "
+    }
+    i = i - 1
+  }
+  return res
+}
+
+fun main() {
+  print(reverse_words("I love Python"))
+  print(reverse_words("I     Love          Python"))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/strings/reverse_words.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/reverse_words.out
@@ -1,0 +1,2 @@
+Python love I
+Python Love I

--- a/tests/github/TheAlgorithms/Python/strings/reverse_words.py
+++ b/tests/github/TheAlgorithms/Python/strings/reverse_words.py
@@ -1,0 +1,15 @@
+def reverse_words(input_str: str) -> str:
+    """
+    Reverses words in a given string
+    >>> reverse_words("I love Python")
+    'Python love I'
+    >>> reverse_words("I     Love          Python")
+    'Python Love I'
+    """
+    return " ".join(input_str.split()[::-1])
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Summary
- add missing Python implementation for string word reversal
- implement pure Mochi version of reverse_words and sample execution

## Testing
- `python tests/github/TheAlgorithms/Python/strings/reverse_words.py`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/strings/reverse_words.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892e1f691c883209ef94cfebc1311f4