### PR TITLE
Add Mochi implementation for snake_case string conversion

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/snake_case_to_camel_pascal_case.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/snake_case_to_camel_pascal_case.mochi
@@ -1,0 +1,67 @@
+/*
+Convert a snake_case string to camelCase or PascalCase.
+
+Given a string where words are separated by underscores, the function
+`snake_to_camel_case` returns a new string in camelCase format. When the
+`use_pascal` flag is true, the first word is also capitalized to produce
+PascalCase.
+
+Algorithm:
+1. Split the input string on underscores to obtain individual words.
+2. Leave the first word as-is for camelCase or skip it for PascalCase.
+3. Capitalize the first character of the remaining words and append them
+   to the result in order.
+4. Join everything into the final string.
+
+The running time is O(n) where n is the number of characters in the
+input string because each character is processed a constant number of
+times.
+*/
+
+fun split(s: string, sep: string): list<string> {
+  var res: list<string> = []
+  var current = ""
+  var i = 0
+  while i < len(s) {
+    let ch = substring(s, i, i + 1)
+    if ch == sep {
+      res = append(res, current)
+      current = ""
+    } else {
+      current = current + ch
+    }
+    i = i + 1
+  }
+  res = append(res, current)
+  return res
+}
+
+fun capitalize(word: string): string {
+  if len(word) == 0 { return "" }
+  let first = upper(substring(word, 0, 1))
+  let rest = substring(word, 1, len(word))
+  return first + rest
+}
+
+fun snake_to_camel_case(input_str: string, use_pascal: bool): string {
+  let words = split(input_str, "_")
+  var result = ""
+  var index = 0
+  if !use_pascal {
+    if len(words) > 0 {
+      result = words[0]
+      index = 1
+    }
+  }
+  while index < len(words) {
+    let word = words[index]
+    result = result + capitalize(word)
+    index = index + 1
+  }
+  return result
+}
+
+print(snake_to_camel_case("some_random_string", false))
+print(snake_to_camel_case("some_random_string", true))
+print(snake_to_camel_case("some_random_string_with_numbers_123", false))
+print(snake_to_camel_case("some_random_string_with_numbers_123", true))

--- a/tests/github/TheAlgorithms/Mochi/strings/snake_case_to_camel_pascal_case.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/snake_case_to_camel_pascal_case.out
@@ -1,0 +1,4 @@
+someRandomString
+SomeRandomString
+someRandomStringWithNumbers123
+SomeRandomStringWithNumbers123

--- a/tests/github/TheAlgorithms/Python/strings/snake_case_to_camel_pascal_case.py
+++ b/tests/github/TheAlgorithms/Python/strings/snake_case_to_camel_pascal_case.py
@@ -1,0 +1,52 @@
+def snake_to_camel_case(input_str: str, use_pascal: bool = False) -> str:
+    """
+    Transforms a snake_case given string to camelCase (or PascalCase if indicated)
+    (defaults to not use Pascal)
+
+    >>> snake_to_camel_case("some_random_string")
+    'someRandomString'
+
+    >>> snake_to_camel_case("some_random_string", use_pascal=True)
+    'SomeRandomString'
+
+    >>> snake_to_camel_case("some_random_string_with_numbers_123")
+    'someRandomStringWithNumbers123'
+
+    >>> snake_to_camel_case("some_random_string_with_numbers_123", use_pascal=True)
+    'SomeRandomStringWithNumbers123'
+
+    >>> snake_to_camel_case(123)
+    Traceback (most recent call last):
+        ...
+    ValueError: Expected string as input, found <class 'int'>
+
+    >>> snake_to_camel_case("some_string", use_pascal="True")
+    Traceback (most recent call last):
+        ...
+    ValueError: Expected boolean as use_pascal parameter, found <class 'str'>
+    """
+
+    if not isinstance(input_str, str):
+        msg = f"Expected string as input, found {type(input_str)}"
+        raise ValueError(msg)
+    if not isinstance(use_pascal, bool):
+        msg = f"Expected boolean as use_pascal parameter, found {type(use_pascal)}"
+        raise ValueError(msg)
+
+    words = input_str.split("_")
+
+    start_index = 0 if use_pascal else 1
+
+    words_to_capitalize = words[start_index:]
+
+    capitalized_words = [word[0].upper() + word[1:] for word in words_to_capitalize]
+
+    initial_word = "" if use_pascal else words[0]
+
+    return "".join([initial_word, *capitalized_words])
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()


### PR DESCRIPTION
## Summary
- add Python reference for converting snake_case to camelCase or PascalCase
- implement equivalent Mochi version using custom split and capitalization helpers
- include sample output

## Testing
- `./bin/mochi run tests/github/TheAlgorithms/Mochi/strings/snake_case_to_camel_pascal_case.mochi`
- `go test ./runtime/vm -run .`

------
https://chatgpt.com/codex/tasks/task_e_6892e1f7d85c832096f3e529485d5ce2