### PR TITLE
Add Mochi implementation for string split algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/split.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/split.mochi
@@ -1,0 +1,40 @@
+/*
+String Split
+
+Given a string and a separator character, produce a list of substrings
+split on the separator.  This mirrors Python's str.split but implemented
+manually.  The algorithm scans the string character by character while
+tracking the start index of the current token.  When the separator is
+encountered, the substring from the last start index to the separator is
+appended to the result, and the start index is advanced.  After the scan
+completes, the final substring is appended.  Empty substrings are preserved
+for consecutive separators or separators at the ends of the input.
+*/
+
+fun split_with_sep(s: string, sep: string): list<string> {
+  var parts: list<string> = []
+  var last = 0
+  var i = 0
+  while i < len(s) {
+    let ch = substring(s, i, i + 1)
+    if ch == sep {
+      parts = append(parts, substring(s, last, i))
+      last = i + 1
+    }
+    if i + 1 == len(s) {
+      parts = append(parts, substring(s, last, i + 1))
+    }
+    i = i + 1
+  }
+  return parts
+}
+
+fun split(s: string): list<string> {
+  return split_with_sep(s, " ")
+}
+
+print(str(split_with_sep("apple#banana#cherry#orange", "#")))
+print(str(split("Hello there")))
+print(str(split_with_sep("11/22/63", "/")))
+print(str(split_with_sep("12:43:39", ":")))
+print(str(split_with_sep(";abbb;;c;", ";")))

--- a/tests/github/TheAlgorithms/Mochi/strings/split.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/split.out
@@ -1,0 +1,5 @@
+[apple banana cherry orange]
+[Hello there]
+[11 22 63]
+[12 43 39]
+[ abbb  c ]

--- a/tests/github/TheAlgorithms/Python/strings/split.py
+++ b/tests/github/TheAlgorithms/Python/strings/split.py
@@ -1,0 +1,37 @@
+def split(string: str, separator: str = " ") -> list:
+    """
+    Will split the string up into all the values separated by the separator
+    (defaults to spaces)
+
+    >>> split("apple#banana#cherry#orange",separator='#')
+    ['apple', 'banana', 'cherry', 'orange']
+
+    >>> split("Hello there")
+    ['Hello', 'there']
+
+    >>> split("11/22/63",separator = '/')
+    ['11', '22', '63']
+
+    >>> split("12:43:39",separator = ":")
+    ['12', '43', '39']
+
+    >>> split(";abbb;;c;", separator=';')
+    ['', 'abbb', '', 'c', '']
+    """
+
+    split_words = []
+
+    last_index = 0
+    for index, char in enumerate(string):
+        if char == separator:
+            split_words.append(string[last_index:index])
+            last_index = index + 1
+        if index + 1 == len(string):
+            split_words.append(string[last_index : index + 1])
+    return split_words
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()


### PR DESCRIPTION
## Summary
- add reference Python `split` implementation from TheAlgorithms
- implement equivalent Mochi `split_with_sep` and default `split`
- add runtime output for sample cases

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/strings/split.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892e1f9700883208f7caca57ff855b2