### PR TITLE
Add string case conversion algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/string_switch_case.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/string_switch_case.mochi
@@ -1,0 +1,114 @@
+/*
+String case conversion utilities.
+
+This program provides functions to convert an input text into several naming
+conventions: PascalCase, camelCase, snake_case, and kebab-case. The algorithm
+first removes characters that are neither alphanumeric nor spaces and splits
+the remaining text into words. Depending on the target case, the words are then
+concatenated with specific capitalization rules or joined with separators.
+*/
+
+fun split_words(s: string): list<string> {
+  var words: list<string> = []
+  var current: string = ""
+  for ch in s {
+    if ch == " " {
+      if current != "" {
+        words = append(words, current)
+        current = ""
+      }
+    } else {
+      current = current + ch
+    }
+  }
+  if current != "" {
+    words = append(words, current)
+  }
+  return words
+}
+
+fun is_alnum(c: string): bool {
+  return c in "0123456789" ||
+         c in "abcdefghijklmnopqrstuvwxyz" ||
+         c in "ABCDEFGHIJKLMNOPQRSTUVWXYZ" ||
+         c == " "
+}
+
+fun split_input(text: string): list<list<string>> {
+  var result: list<list<string>> = []
+  var current: string = ""
+  for ch in text {
+    if is_alnum(ch) {
+      current = current + ch
+    } else {
+      if current != "" {
+        result = append(result, split_words(current))
+        current = ""
+      }
+    }
+  }
+  if current != "" {
+    result = append(result, split_words(current))
+  }
+  return result
+}
+
+fun capitalize(word: string): string {
+  if len(word) == 0 { return "" }
+  if len(word) == 1 { return upper(word) }
+  return upper(word[0:1]) + lower(word[1:])
+}
+
+fun to_simple_case(text: string): string {
+  let parts = split_input(text)
+  var res: string = ""
+  for sub in parts {
+    for w in sub {
+      res = res + capitalize(w)
+    }
+  }
+  return res
+}
+
+fun to_complex_case(text: string, upper_flag: bool, sep: string): string {
+  let parts = split_input(text)
+  var res: string = ""
+  for sub in parts {
+    var first: bool = true
+    for w in sub {
+      var word = if upper_flag { upper(w) } else { lower(w) }
+      if first {
+        res = res + word
+        first = false
+      } else {
+        res = res + sep + word
+      }
+    }
+  }
+  return res
+}
+
+fun to_pascal_case(text: string): string {
+  return to_simple_case(text)
+}
+
+fun to_camel_case(text: string): string {
+  let s = to_simple_case(text)
+  if len(s) == 0 { return "" }
+  return lower(s[0:1]) + s[1:]
+}
+
+fun to_snake_case(text: string, upper_flag: bool): string {
+  return to_complex_case(text, upper_flag, "_")
+}
+
+fun to_kebab_case(text: string, upper_flag: bool): string {
+  return to_complex_case(text, upper_flag, "-")
+}
+
+print(to_pascal_case("one two 31235three4four"))
+print(to_camel_case("one two 31235three4four"))
+print(to_snake_case("one two 31235three4four", true))
+print(to_snake_case("one two 31235three4four", false))
+print(to_kebab_case("one two 31235three4four", true))
+print(to_kebab_case("one two 31235three4four", false))

--- a/tests/github/TheAlgorithms/Mochi/strings/string_switch_case.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/string_switch_case.out
@@ -1,0 +1,6 @@
+OneTwo31235three4four
+oneTwo31235three4four
+ONE_TWO_31235THREE4FOUR
+one_two_31235three4four
+ONE-TWO-31235THREE4FOUR
+one-two-31235three4four

--- a/tests/github/TheAlgorithms/Python/strings/string_switch_case.py
+++ b/tests/github/TheAlgorithms/Python/strings/string_switch_case.py
@@ -1,0 +1,122 @@
+import re
+
+"""
+general info:
+https://en.wikipedia.org/wiki/Naming_convention_(programming)#Python_and_Ruby
+
+pascal case [ an upper Camel Case ]: https://en.wikipedia.org/wiki/Camel_case
+
+camel case: https://en.wikipedia.org/wiki/Camel_case
+
+kebab case [ can be found in general info ]:
+https://en.wikipedia.org/wiki/Naming_convention_(programming)#Python_and_Ruby
+
+snake case: https://en.wikipedia.org/wiki/Snake_case
+"""
+
+
+# assistant functions
+def split_input(str_: str) -> list:
+    """
+    >>> split_input("one two 31235three4four")
+    [['one', 'two', '31235three4four']]
+    """
+    return [char.split() for char in re.split(r"[^ a-z A-Z 0-9 \s]", str_)]
+
+
+def to_simple_case(str_: str) -> str:
+    """
+    >>> to_simple_case("one two 31235three4four")
+    'OneTwo31235three4four'
+    >>> to_simple_case("This should be combined")
+    'ThisShouldBeCombined'
+    >>> to_simple_case("The first letters are capitalized, then string is merged")
+    'TheFirstLettersAreCapitalizedThenStringIsMerged'
+    >>> to_simple_case("special characters :, ', %, ^, $, are ignored")
+    'SpecialCharactersAreIgnored'
+    """
+    string_split = split_input(str_)
+    return "".join(
+        ["".join([char.capitalize() for char in sub_str]) for sub_str in string_split]
+    )
+
+
+def to_complex_case(text: str, upper: bool, separator: str) -> str:
+    """
+    Returns the string concatenated with the delimiter we provide.
+
+    Parameters:
+    @text: The string on which we want to perform operation
+    @upper: Boolean value to determine whether we want capitalized result or not
+    @separator: The delimiter with which we want to concatenate words
+
+    Examples:
+    >>> to_complex_case("one two 31235three4four", True, "_")
+    'ONE_TWO_31235THREE4FOUR'
+    >>> to_complex_case("one two 31235three4four", False, "-")
+    'one-two-31235three4four'
+    """
+    try:
+        string_split = split_input(text)
+        if upper:
+            res_str = "".join(
+                [
+                    separator.join([char.upper() for char in sub_str])
+                    for sub_str in string_split
+                ]
+            )
+        else:
+            res_str = "".join(
+                [
+                    separator.join([char.lower() for char in sub_str])
+                    for sub_str in string_split
+                ]
+            )
+        return res_str
+    except IndexError:
+        return "not valid string"
+
+
+# main content
+def to_pascal_case(text: str) -> str:
+    """
+    >>> to_pascal_case("one two 31235three4four")
+    'OneTwo31235three4four'
+    """
+    return to_simple_case(text)
+
+
+def to_camel_case(text: str) -> str:
+    """
+    >>> to_camel_case("one two 31235three4four")
+    'oneTwo31235three4four'
+    """
+    try:
+        res_str = to_simple_case(text)
+        return res_str[0].lower() + res_str[1:]
+    except IndexError:
+        return "not valid string"
+
+
+def to_snake_case(text: str, upper: bool) -> str:
+    """
+    >>> to_snake_case("one two 31235three4four", True)
+    'ONE_TWO_31235THREE4FOUR'
+    >>> to_snake_case("one two 31235three4four", False)
+    'one_two_31235three4four'
+    """
+    return to_complex_case(text, upper, "_")
+
+
+def to_kebab_case(text: str, upper: bool) -> str:
+    """
+    >>> to_kebab_case("one two 31235three4four", True)
+    'ONE-TWO-31235THREE4FOUR'
+    >>> to_kebab_case("one two 31235three4four", False)
+    'one-two-31235three4four'
+    """
+    return to_complex_case(text, upper, "-")
+
+
+if __name__ == "__main__":
+    __import__("doctest").testmod()


### PR DESCRIPTION
## Summary
- add missing Python source for string case conversion utilities
- implement Mochi version providing Pascal, camel, snake, and kebab case conversions
- include sample outputs from the Mochi VM

## Testing
- `python tests/github/TheAlgorithms/Python/strings/string_switch_case.py`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/strings/string_switch_case.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892e1fd13d08320a8baf58e778eb065