### PR TITLE
Add Mochi implementation for text justification algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/text_justification.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/text_justification.mochi
@@ -1,0 +1,118 @@
+/*
+Text Justification
+
+Given a string and a maximum line width, format the text so each line
+contains exactly max_width characters and is fully justified. Words are
+pushed to the left and right by distributing spaces evenly between them.
+Extra spaces are placed on the left gaps.
+
+Algorithm:
+1. Split the input text into words.
+2. Repeatedly add words to a line until adding another would exceed max_width.
+3. For each completed line, distribute spaces between words so that the line
+   reaches max_width characters. If the line contains only one word, pad
+   with spaces on the right.
+4. The final line is left-justified: words separated by a single space, and
+   the remainder of the width filled with trailing spaces.
+5. Return the list of justified lines.
+
+The implementation avoids FFI, uses only Mochi primitives, and avoids the
+`any` type.
+*/
+
+fun repeat_str(s: string, count: int): string {
+  var res: string = ""
+  var i: int = 0
+  while i < count {
+    res = res + s
+    i = i + 1
+  }
+  return res
+}
+
+fun split_words(s: string): list<string> {
+  var res: list<string> = []
+  var current: string = ""
+  var i: int = 0
+  while i < len(s) {
+    let ch = s[i:i+1]
+    if ch == " " {
+      if current != "" {
+        res = append(res, current)
+        current = ""
+      }
+    } else {
+      current = current + ch
+    }
+    i = i + 1
+  }
+  if current != "" {
+    res = append(res, current)
+  }
+  return res
+}
+
+fun justify_line(line: list<string>, width: int, max_width: int): string {
+  let overall_spaces_count: int = max_width - width
+  let words_count: int = len(line)
+  if words_count == 1 {
+    return line[0] + repeat_str(" ", overall_spaces_count)
+  }
+  let spaces_to_insert_between_words: int = words_count - 1
+  var num_spaces_between_words_list: list<int> = []
+  let base: int = overall_spaces_count / spaces_to_insert_between_words
+  let extra: int = overall_spaces_count % spaces_to_insert_between_words
+  var i: int = 0
+  while i < spaces_to_insert_between_words {
+    var spaces: int = base
+    if i < extra {
+      spaces = spaces + 1
+    }
+    num_spaces_between_words_list = append(num_spaces_between_words_list, spaces)
+    i = i + 1
+  }
+  var aligned: string = ""
+  i = 0
+  while i < spaces_to_insert_between_words {
+    aligned = aligned + line[i] + repeat_str(" ", num_spaces_between_words_list[i])
+    i = i + 1
+  }
+  aligned = aligned + line[spaces_to_insert_between_words]
+  return aligned
+}
+
+fun text_justification(word: string, max_width: int): list<string> {
+  let words = split_words(word)
+  var answer: list<string> = []
+  var line: list<string> = []
+  var width: int = 0
+  var idx: int = 0
+  while idx < len(words) {
+    let w = words[idx]
+    if width + len(w) + len(line) <= max_width {
+      line = append(line, w)
+      width = width + len(w)
+    } else {
+      answer = append(answer, justify_line(line, width, max_width))
+      line = [w]
+      width = len(w)
+    }
+    idx = idx + 1
+  }
+  let remaining_spaces: int = max_width - width - len(line)
+  var last_line: string = ""
+  var j: int = 0
+  while j < len(line) {
+    if j > 0 {
+      last_line = last_line + " "
+    }
+    last_line = last_line + line[j]
+    j = j + 1
+  }
+  last_line = last_line + repeat_str(" ", remaining_spaces + 1)
+  answer = append(answer, last_line)
+  return answer
+}
+
+print(str(text_justification("This is an example of text justification.", 16)))
+print(str(text_justification("Two roads diverged in a yellow wood", 16)))

--- a/tests/github/TheAlgorithms/Mochi/strings/text_justification.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/text_justification.out
@@ -1,0 +1,2 @@
+[This    is    an example  of text justification.  ]
+[Two        roads diverged   in  a yellow wood     ]

--- a/tests/github/TheAlgorithms/Python/strings/text_justification.py
+++ b/tests/github/TheAlgorithms/Python/strings/text_justification.py
@@ -1,0 +1,91 @@
+def text_justification(word: str, max_width: int) -> list:
+    """
+    Will format the string such that each line has exactly
+    (max_width) characters and is fully (left and right) justified,
+    and return the list of justified text.
+
+    example 1:
+    string = "This is an example of text justification."
+    max_width = 16
+
+    output = ['This    is    an',
+              'example  of text',
+              'justification.  ']
+
+    >>> text_justification("This is an example of text justification.", 16)
+    ['This    is    an', 'example  of text', 'justification.  ']
+
+    example 2:
+    string = "Two roads diverged in a yellow wood"
+    max_width = 16
+    output = ['Two        roads',
+              'diverged   in  a',
+              'yellow wood     ']
+
+    >>> text_justification("Two roads diverged in a yellow wood", 16)
+    ['Two        roads', 'diverged   in  a', 'yellow wood     ']
+
+    Time complexity: O(m*n)
+    Space complexity: O(m*n)
+    """
+
+    # Converting string into list of strings split by a space
+    words = word.split()
+
+    def justify(line: list, width: int, max_width: int) -> str:
+        overall_spaces_count = max_width - width
+        words_count = len(line)
+        if len(line) == 1:
+            # if there is only word in line
+            # just insert overall_spaces_count for the remainder of line
+            return line[0] + " " * overall_spaces_count
+        else:
+            spaces_to_insert_between_words = words_count - 1
+            # num_spaces_between_words_list[i] : tells you to insert
+            # num_spaces_between_words_list[i] spaces
+            # after word on line[i]
+            num_spaces_between_words_list = spaces_to_insert_between_words * [
+                overall_spaces_count // spaces_to_insert_between_words
+            ]
+            spaces_count_in_locations = (
+                overall_spaces_count % spaces_to_insert_between_words
+            )
+            # distribute spaces via round robin to the left words
+            for i in range(spaces_count_in_locations):
+                num_spaces_between_words_list[i] += 1
+            aligned_words_list = []
+            for i in range(spaces_to_insert_between_words):
+                # add the word
+                aligned_words_list.append(line[i])
+                # add the spaces to insert
+                aligned_words_list.append(num_spaces_between_words_list[i] * " ")
+            # just add the last word to the sentence
+            aligned_words_list.append(line[-1])
+            # join the aligned words list to form a justified line
+            return "".join(aligned_words_list)
+
+    answer = []
+    line: list[str] = []
+    width = 0
+    for inner_word in words:
+        if width + len(inner_word) + len(line) <= max_width:
+            # keep adding words until we can fill out max_width
+            # width = sum of length of all words (without overall_spaces_count)
+            # len(inner_word) = length of current inner_word
+            # len(line) = number of overall_spaces_count to insert between words
+            line.append(inner_word)
+            width += len(inner_word)
+        else:
+            # justify the line and add it to result
+            answer.append(justify(line, width, max_width))
+            # reset new line and new width
+            line, width = [inner_word], len(inner_word)
+    remaining_spaces = max_width - width - len(line)
+    answer.append(" ".join(line) + (remaining_spaces + 1) * " ")
+    return answer
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()


### PR DESCRIPTION
## Summary
- add missing Python reference implementation for text justification
- implement Mochi version of text justification with space distribution
- provide runtime output example

## Testing
- `go test ./...`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/strings/text_justification.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6892efeb9a488320bc99169761407a0c