### PR TITLE
Add upper string algorithm implementation

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/upper.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/upper.mochi
@@ -1,0 +1,43 @@
+/*
+Convert a string to all uppercase letters.
+
+The algorithm scans the input text character by character and transforms
+any lowercase ASCII letter ('a'-'z') into its uppercase counterpart.
+Two strings containing the lowercase and uppercase alphabets are used.
+For each character, we search for it in the lowercase string; if found,
+the corresponding uppercase character is appended to the result. Other
+characters remain unchanged. The procedure runs in O(n) time for n
+characters in the input.
+*/
+
+fun index_of(s: string, ch: string): int {
+  var i = 0
+  while i < len(s) {
+    if s[i] == ch { return i }
+    i = i + 1
+  }
+  return -1
+}
+
+fun upper(word: string): string {
+  let lower_chars = "abcdefghijklmnopqrstuvwxyz"
+  let upper_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  var result = ""
+  var i = 0
+  while i < len(word) {
+    let c = word[i]
+    let idx = index_of(lower_chars, c)
+    if idx >= 0 {
+      result = result + upper_chars[idx:idx+1]
+    } else {
+      result = result + c
+    }
+    i = i + 1
+  }
+  return result
+}
+
+print(upper("wow"))
+print(upper("Hello"))
+print(upper("WHAT"))
+print(upper("wh[]32"))

--- a/tests/github/TheAlgorithms/Mochi/strings/upper.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/upper.out
@@ -1,0 +1,4 @@
+WOW
+HELLO
+WHAT
+WH[]32

--- a/tests/github/TheAlgorithms/Python/strings/upper.py
+++ b/tests/github/TheAlgorithms/Python/strings/upper.py
@@ -1,0 +1,22 @@
+def upper(word: str) -> str:
+    """
+    Convert an entire string to ASCII uppercase letters by looking for lowercase ASCII
+    letters and subtracting 32 from their integer representation to get the uppercase
+    letter.
+
+    >>> upper("wow")
+    'WOW'
+    >>> upper("Hello")
+    'HELLO'
+    >>> upper("WHAT")
+    'WHAT'
+    >>> upper("wh[]32")
+    'WH[]32'
+    """
+    return "".join(chr(ord(char) - 32) if "a" <= char <= "z" else char for char in word)
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()


### PR DESCRIPTION
## Summary
- add the missing Python implementation for `upper` to convert strings to ASCII uppercase
- provide a Mochi version of `upper` using character-index mapping
- include generated output for example runs

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/strings/upper.mochi > tests/github/TheAlgorithms/Mochi/strings/upper.out`

------
https://chatgpt.com/codex/tasks/task_e_6892efeef4cc8320abd22c4f5a5d30bf