### PR TITLE
feat: add wave string algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/wave_string.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/wave_string.mochi
@@ -1,0 +1,65 @@
+/*
+Wave String
+
+Generates a "Mexican wave" representation of a string.
+For each alphabetic character in the input, a new string is
+created with that character capitalized while the rest remain
+unchanged. Non-letter characters are skipped.
+
+Algorithm:
+1. Iterate over the characters of the input string.
+2. If the current character is alphabetic, uppercase it and
+   concatenate the prefix and suffix around it.
+3. Append each modified string to a result list.
+
+Uppercasing and alphabet checks are implemented manually using
+ASCII lookup tables, avoiding any external dependencies.
+
+Time complexity is O(n * 26) due to the alphabet scans, effectively
+O(n) for typical ASCII strings.
+*/
+
+let lowercase = "abcdefghijklmnopqrstuvwxyz"
+let uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+fun index_of(s: string, c: string): int {
+  var i = 0
+  while i < len(s) {
+    if substring(s, i, i + 1) == c {
+      return i
+    }
+    i = i + 1
+  }
+  return -1
+}
+
+fun is_alpha(c: string): bool {
+  return index_of(lowercase, c) >= 0 || index_of(uppercase, c) >= 0
+}
+
+fun to_upper(c: string): string {
+  let idx = index_of(lowercase, c)
+  if idx >= 0 {
+    return substring(uppercase, idx, idx + 1)
+  }
+  return c
+}
+
+fun wave(txt: string): list<string> {
+  var result: list<string> = []
+  var i = 0
+  while i < len(txt) {
+    let ch = substring(txt, i, i + 1)
+    if is_alpha(ch) {
+      let prefix = substring(txt, 0, i)
+      let suffix = substring(txt, i + 1, len(txt))
+      result = append(result, prefix + to_upper(ch) + suffix)
+    }
+    i = i + 1
+  }
+  return result
+}
+
+print(str(wave("cat")))
+print(str(wave("one")))
+print(str(wave("book")))

--- a/tests/github/TheAlgorithms/Mochi/strings/wave_string.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/wave_string.out
@@ -1,0 +1,3 @@
+[Cat cAt caT]
+[One oNe onE]
+[Book bOok boOk booK]

--- a/tests/github/TheAlgorithms/Python/strings/wave_string.py
+++ b/tests/github/TheAlgorithms/Python/strings/wave_string.py
@@ -1,0 +1,20 @@
+def wave(txt: str) -> list:
+    """
+    Returns a so called 'wave' of a given string
+    >>> wave('cat')
+    ['Cat', 'cAt', 'caT']
+    >>> wave('one')
+    ['One', 'oNe', 'onE']
+    >>> wave('book')
+    ['Book', 'bOok', 'boOk', 'booK']
+    """
+
+    return [
+        txt[:a] + txt[a].upper() + txt[a + 1 :]
+        for a in range(len(txt))
+        if txt[a].isalpha()
+    ]
+
+
+if __name__ == "__main__":
+    __import__("doctest").testmod()


### PR DESCRIPTION
## Summary
- add missing Python wave_string implementation from TheAlgorithms
- implement wave_string algorithm in Mochi to generate capitalized wave strings
- capture sample output from Mochi runtime

## Testing
- `npm test` *(fails: Missing script: "test")*
- `go test ./...`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/strings/wave_string.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6892eff084748320baaa0b9852d4d529