### PR TITLE
Add Mochi wildcard pattern matching example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/wildcard_pattern_matching.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/wildcard_pattern_matching.mochi
@@ -1,0 +1,101 @@
+/*
+Wildcard Pattern Matching
+-------------------------
+Matches an input string against a pattern containing two special
+characters:
+  '.' - matches any single character
+  '*' - matches zero or more of the preceding character
+
+This implementation builds a dynamic programming table where dp[i][j]
+indicates whether the first i characters of the input match the first
+j characters of the pattern.  The table is filled using a bottom-up
+approach considering the rules for '.' and '*'.  The algorithm runs in
+O(n*m) time where n is the length of the string and m is the length of
+the pattern.
+*/
+
+fun make_matrix_bool(rows: int, cols: int, init: bool): list<list<bool>> {
+  var matrix: list<list<bool>> = []
+  for _ in 0..rows {
+    var row: list<bool> = []
+    for _2 in 0..cols {
+      row = append(row, init)
+    }
+    matrix = append(matrix, row)
+  }
+  return matrix
+}
+
+fun match_pattern(input_string: string, pattern: string): bool {
+  let len_string = len(input_string) + 1
+  let len_pattern = len(pattern) + 1
+  var dp = make_matrix_bool(len_string, len_pattern, false)
+
+  var row0 = dp[0]
+  row0[0] = true
+  dp[0] = row0
+
+  var j = 1
+  while j < len_pattern {
+    row0 = dp[0]
+    if substring(pattern, j - 1, j) == "*" {
+      row0[j] = row0[j - 2]
+    } else {
+      row0[j] = false
+    }
+    dp[0] = row0
+    j = j + 1
+  }
+
+  var i = 1
+  while i < len_string {
+    var row = dp[i]
+    var j2 = 1
+    while j2 < len_pattern {
+      let s_char = substring(input_string, i - 1, i)
+      let p_char = substring(pattern, j2 - 1, j2)
+      if s_char == p_char || p_char == "." {
+        row[j2] = dp[i - 1][j2 - 1]
+      } else if p_char == "*" {
+        var val = dp[i][j2 - 2]
+        let prev_p = substring(pattern, j2 - 2, j2 - 1)
+        if !val && (prev_p == s_char || prev_p == ".") {
+          val = dp[i - 1][j2]
+        }
+        row[j2] = val
+      } else {
+        row[j2] = false
+      }
+      j2 = j2 + 1
+    }
+    dp[i] = row
+    i = i + 1
+  }
+  return dp[len_string - 1][len_pattern - 1]
+}
+
+fun main() {
+  if !match_pattern("aab", "c*a*b") { panic("case1 failed") }
+  if match_pattern("dabc", "*abc") { panic("case2 failed") }
+  if match_pattern("aaa", "aa") { panic("case3 failed") }
+  if !match_pattern("aaa", "a.a") { panic("case4 failed") }
+  if match_pattern("aaab", "aa*") { panic("case5 failed") }
+  if !match_pattern("aaab", ".*") { panic("case6 failed") }
+  if match_pattern("a", "bbbb") { panic("case7 failed") }
+  if match_pattern("", "bbbb") { panic("case8 failed") }
+  if match_pattern("a", "") { panic("case9 failed") }
+  if !match_pattern("", "") { panic("case10 failed") }
+
+  print(str(match_pattern("aab", "c*a*b")))
+  print(str(match_pattern("dabc", "*abc")))
+  print(str(match_pattern("aaa", "aa")))
+  print(str(match_pattern("aaa", "a.a")))
+  print(str(match_pattern("aaab", "aa*")))
+  print(str(match_pattern("aaab", ".*")))
+  print(str(match_pattern("a", "bbbb")))
+  print(str(match_pattern("", "bbbb")))
+  print(str(match_pattern("a", "")))
+  print(str(match_pattern("", "")))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/strings/wildcard_pattern_matching.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/wildcard_pattern_matching.out
@@ -1,0 +1,10 @@
+true
+false
+false
+true
+false
+true
+false
+false
+false
+true

--- a/tests/github/TheAlgorithms/Python/strings/wildcard_pattern_matching.py
+++ b/tests/github/TheAlgorithms/Python/strings/wildcard_pattern_matching.py
@@ -1,0 +1,112 @@
+"""
+Implementation of regular expression matching with support for '.' and '*'.
+'.' Matches any single character.
+'*' Matches zero or more of the preceding element.
+The matching should cover the entire input string (not partial).
+
+"""
+
+
+def match_pattern(input_string: str, pattern: str) -> bool:
+    """
+    uses bottom-up dynamic programming solution for matching the input
+    string with a given pattern.
+
+    Runtime: O(len(input_string)*len(pattern))
+
+    Arguments
+    --------
+    input_string: str, any string which should be compared with the pattern
+    pattern: str, the string that represents a pattern and may contain
+    '.' for single character matches and '*' for zero or more of preceding character
+    matches
+
+    Note
+    ----
+    the pattern cannot start with a '*',
+    because there should be at least one character before *
+
+    Returns
+    -------
+    A Boolean denoting whether the given string follows the pattern
+
+    Examples
+    -------
+    >>> match_pattern("aab", "c*a*b")
+    True
+    >>> match_pattern("dabc", "*abc")
+    False
+    >>> match_pattern("aaa", "aa")
+    False
+    >>> match_pattern("aaa", "a.a")
+    True
+    >>> match_pattern("aaab", "aa*")
+    False
+    >>> match_pattern("aaab", ".*")
+    True
+    >>> match_pattern("a", "bbbb")
+    False
+    >>> match_pattern("", "bbbb")
+    False
+    >>> match_pattern("a", "")
+    False
+    >>> match_pattern("", "")
+    True
+    """
+
+    len_string = len(input_string) + 1
+    len_pattern = len(pattern) + 1
+
+    # dp is a 2d matrix where dp[i][j] denotes whether prefix string of
+    # length i of input_string matches with prefix string of length j of
+    # given pattern.
+    # "dp" stands for dynamic programming.
+    dp = [[0 for i in range(len_pattern)] for j in range(len_string)]
+
+    # since string of zero length match pattern of zero length
+    dp[0][0] = 1
+
+    # since pattern of zero length will never match with string of non-zero length
+    for i in range(1, len_string):
+        dp[i][0] = 0
+
+    # since string of zero length will match with pattern where there
+    # is at least one * alternatively
+    for j in range(1, len_pattern):
+        dp[0][j] = dp[0][j - 2] if pattern[j - 1] == "*" else 0
+
+    # now using bottom-up approach to find for all remaining lengths
+    for i in range(1, len_string):
+        for j in range(1, len_pattern):
+            if input_string[i - 1] == pattern[j - 1] or pattern[j - 1] == ".":
+                dp[i][j] = dp[i - 1][j - 1]
+
+            elif pattern[j - 1] == "*":
+                if dp[i][j - 2] == 1:
+                    dp[i][j] = 1
+                elif pattern[j - 2] in (input_string[i - 1], "."):
+                    dp[i][j] = dp[i - 1][j]
+                else:
+                    dp[i][j] = 0
+            else:
+                dp[i][j] = 0
+
+    return bool(dp[-1][-1])
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    # inputing the strings
+    # input_string = input("input a string :")
+    # pattern = input("input a pattern :")
+
+    input_string = "aab"
+    pattern = "c*a*b"
+
+    # using function to check whether given string matches the given pattern
+    if match_pattern(input_string, pattern):
+        print(f"{input_string} matches the given pattern {pattern}")
+    else:
+        print(f"{input_string} does not match with the given pattern {pattern}")


### PR DESCRIPTION
## Summary
- add missing Python source for wildcard pattern matching
- implement Mochi version using DP
- include generated output from runtime

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/strings/wildcard_pattern_matching.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6892eff1b0708320a667b959b5d0dc3d