### PR TITLE
Add Mochi implementation for word occurrence

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/strings/word_occurrence.mochi
+++ b/tests/github/TheAlgorithms/Mochi/strings/word_occurrence.mochi
@@ -1,0 +1,51 @@
+/*
+Word Occurrence Counter
+
+Counts how many times each distinct word appears in a sentence. Words are
+separated by spaces and sequences of spaces are treated as a single
+separator. The algorithm scans the sentence character by character, builds
+the current word, and on each separator updates a map<string, int> with the
+word's count. This runs in O(n) time for n characters and uses only core
+Mochi features so it can execute on the runtime/vm without any FFI or the
+"any" type.
+*/
+
+fun word_occurrence(sentence: string): map<string, int> {
+  var occurrence: map<string, int> = {}
+  var word = ""
+  var i = 0
+  while i < len(sentence) {
+    let ch = substring(sentence, i, i + 1)
+    if ch == " " {
+      if word != "" {
+        if word in occurrence {
+          occurrence[word] = occurrence[word] + 1
+        } else {
+          occurrence[word] = 1
+        }
+        word = ""
+      }
+    } else {
+      word = word + ch
+    }
+    i = i + 1
+  }
+  if word != "" {
+    if word in occurrence {
+      occurrence[word] = occurrence[word] + 1
+    } else {
+      occurrence[word] = 1
+    }
+  }
+  return occurrence
+}
+
+fun main() {
+  let result = word_occurrence("INPUT STRING")
+  for w in result {
+    print(w + ": " + str(result[w]))
+  }
+}
+
+main()
+

--- a/tests/github/TheAlgorithms/Mochi/strings/word_occurrence.out
+++ b/tests/github/TheAlgorithms/Mochi/strings/word_occurrence.out
@@ -1,0 +1,2 @@
+INPUT: 1
+STRING: 1

--- a/tests/github/TheAlgorithms/Python/strings/word_occurrence.py
+++ b/tests/github/TheAlgorithms/Python/strings/word_occurrence.py
@@ -1,0 +1,26 @@
+# Created by sarathkaul on 17/11/19
+# Modified by Arkadip Bhattacharya(@darkmatter18) on 20/04/2020
+from collections import defaultdict
+
+
+def word_occurrence(sentence: str) -> dict:
+    """
+    >>> from collections import Counter
+    >>> SENTENCE = "a b A b c b d b d e f e g e h e i e j e 0"
+    >>> occurence_dict = word_occurrence(SENTENCE)
+    >>> all(occurence_dict[word] == count for word, count
+    ...     in Counter(SENTENCE.split()).items())
+    True
+    >>> dict(word_occurrence("Two  spaces"))
+    {'Two': 1, 'spaces': 1}
+    """
+    occurrence: defaultdict[str, int] = defaultdict(int)
+    # Creating a dictionary containing count of each word
+    for word in sentence.split():
+        occurrence[word] += 1
+    return occurrence
+
+
+if __name__ == "__main__":
+    for word, count in word_occurrence("INPUT STRING").items():
+        print(f"{word}: {count}")


### PR DESCRIPTION
## Summary
- add missing Python word occurrence algorithm
- implement word occurrence counter in Mochi using map-based counts

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/strings/word_occurrence.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892eff2516083208df124c32ccbcd9f