### PR TITLE
Add Mochi translation for COVID stats example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/covid_stats_via_xpath.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/covid_stats_via_xpath.mochi
@@ -1,0 +1,86 @@
+/*
+Fetch global COVID-19 statistics using XPath-like parsing.
+
+The original Python version downloads the worldometers page and applies the
+XPath expression `//div[@class="maincounter-number"]/span/text()` to extract
+the total number of cases, deaths and recoveries.  To keep this example
+self‑contained and runnable on the Mochi VM without external libraries,
+this reimplementation operates on a provided HTML string.  It searches for
+`<span>` elements inside divs with class `maincounter-number` and converts
+their text content into integers to produce a `CovidData` record.
+*/
+
+type CovidData {
+  cases: int
+  deaths: int
+  recovered: int
+}
+
+fun parse_int(s: string): int {
+  var value = 0
+  var i = 0
+  while i < len(s) {
+    let ch = substring(s, i, i + 1)
+    if ch == "," {
+      i = i + 1
+      continue
+    }
+    value = value * 10 + (ch as int)
+    i = i + 1
+  }
+  return value
+}
+
+fun find(haystack: string, needle: string, start: int): int {
+  let nlen = len(needle)
+  var i = start
+  while i <= len(haystack) - nlen {
+    var j = 0
+    var matched = true
+    while j < nlen {
+      if substring(haystack, i + j, i + j + 1) != substring(needle, j, j + 1) {
+        matched = false
+        break
+      }
+      j = j + 1
+    }
+    if matched { return i }
+    i = i + 1
+  }
+  return 0 - 1
+}
+
+fun extract_numbers(html: string): list<int> {
+  var nums: list<int> = []
+  var pos = 0
+  let start_tag = "<span>"
+  let end_tag = "</span>"
+  while true {
+    let s = find(html, start_tag, pos)
+    if s == 0 - 1 { break }
+    let content_start = s + len(start_tag)
+    let e = find(html, end_tag, content_start)
+    if e == 0 - 1 { break }
+    let num_str = substring(html, content_start, e)
+    nums = append(nums, parse_int(num_str))
+    pos = e + len(end_tag)
+  }
+  return nums
+}
+
+fun covid_stats(html: string): CovidData {
+  let nums = extract_numbers(html)
+  return CovidData { cases: nums[0], deaths: nums[1], recovered: nums[2] }
+}
+
+fun main() {
+  let sample_html = "<div class=\"maincounter-number\"><span>123456</span></div>" +
+                    "<div class=\"maincounter-number\"><span>7890</span></div>" +
+                    "<div class=\"maincounter-number\"><span>101112</span></div>"
+  let stats = covid_stats(sample_html)
+  print("Total COVID-19 cases in the world: " + str(stats.cases))
+  print("Total deaths due to COVID-19 in the world: " + str(stats.deaths))
+  print("Total COVID-19 patients recovered in the world: " + str(stats.recovered))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/web_programming/covid_stats_via_xpath.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/covid_stats_via_xpath.out
@@ -1,0 +1,3 @@
+Total COVID-19 cases in the world: 123456
+Total deaths due to COVID-19 in the world: 7890
+Total COVID-19 patients recovered in the world: 101112

--- a/tests/github/TheAlgorithms/Python/web_programming/covid_stats_via_xpath.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/covid_stats_via_xpath.py
@@ -1,0 +1,37 @@
+"""
+This is to show simple COVID19 info fetching from worldometers site using lxml
+* The main motivation to use lxml in place of bs4 is that it is faster and therefore
+more convenient to use in Python web projects (e.g. Django or Flask-based)
+"""
+
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "httpx",
+#     "lxml",
+# ]
+# ///
+
+from typing import NamedTuple
+
+import httpx
+from lxml import html
+
+
+class CovidData(NamedTuple):
+    cases: int
+    deaths: int
+    recovered: int
+
+
+def covid_stats(url: str = "https://www.worldometers.info/coronavirus/") -> CovidData:
+    xpath_str = '//div[@class = "maincounter-number"]/span/text()'
+    return CovidData(
+        *html.fromstring(httpx.get(url, timeout=10).content).xpath(xpath_str)
+    )
+
+
+fmt = """Total COVID-19 cases in the world: {}
+Total deaths due to COVID-19 in the world: {}
+Total COVID-19 patients recovered in the world: {}"""
+print(fmt.format(*covid_stats()))


### PR DESCRIPTION
## Summary
- add missing Python script for obtaining COVID stats via XPath
- implement equivalent Mochi version using manual HTML `<span>` parsing
- record runtime output for the Mochi script

## Testing
- `npm test` *(fails: Missing script "test" )*
- `go test ./...` *(interrupted after partial run)*
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/web_programming/covid_stats_via_xpath.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6892eff8aea083208d0e142f0f7eaf04