### PR TITLE
Add Mochi port of crawl_google_results

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/crawl_google_results.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/crawl_google_results.mochi
@@ -1,0 +1,84 @@
+/*
+Parse mock Google search HTML to extract top result links.
+
+This program demonstrates simple HTML parsing without external
+libraries. It scans a string containing simplified Google search
+results and extracts the first five anchor tags with the CSS class
+"eZt8xd", which is used by Google to mark result links. For each
+matched anchor tag, the program captures its href attribute and the
+visible text. If the link text equals "Maps", the original href is
+printed; otherwise the href is prefixed with "https://google.com".
+
+Algorithm steps:
+1. Search the HTML string for occurrences of '<a class="eZt8xd"'.
+2. For each occurrence, locate the surrounding href and inner text.
+3. Store extracted href/text pairs in a list.
+4. Print the number of collected links and each resolved URL,
+   handling the special "Maps" case.
+
+The implementation uses only basic string operations and avoids the
+"any" type, keeping the solution fully in pure Mochi.
+*/
+
+fun index_of_from(s: string, sub: string, start: int): int {
+  var i = start
+  let max = len(s) - len(sub)
+  while i <= max {
+    if s[i:i+len(sub)] == sub { return i }
+    i = i + 1
+  }
+  return -1
+}
+
+fun extract_links(html: string): list<map<string, string>> {
+  var res: list<map<string, string>> = []
+  var i = 0
+  while true {
+    let tag_start = index_of_from(html, "<a class=\"eZt8xd\"", i)
+    if tag_start == (-1) {
+      break
+    }
+    let href_start = index_of_from(html, "href=\"", tag_start)
+    if href_start == (-1) {
+      break
+    }
+    href_start = href_start + len("href=\"")
+    let href_end = index_of_from(html, "\"", href_start)
+    if href_end == (-1) {
+      break
+    }
+    let href = html[href_start:href_end]
+    let text_start = index_of_from(html, ">", href_end) + 1
+    let text_end = index_of_from(html, "</a>", text_start)
+    if text_end == (-1) {
+      break
+    }
+    let text = html[text_start:text_end]
+    let link: map<string, string> = {"href": href, "text": text}
+    res = append(res, link)
+    i = text_end + len("</a>")
+  }
+  return res
+}
+
+fun main() {
+  let html = "<div><a class=\"eZt8xd\" href=\"/url?q=http://example1.com\">Example1</a>" +
+             "<a class=\"eZt8xd\" href=\"/maps\">Maps</a>" +
+             "<a class=\"eZt8xd\" href=\"/url?q=http://example2.com\">Example2</a></div>"
+  let links = extract_links(html)
+  print(str(len(links)))
+  var i = 0
+  while i < len(links) && i < 5 {
+    let link = links[i]
+    let href = link["href"]
+    let text = link["text"]
+    if text == "Maps" {
+      print(href)
+    } else {
+      print("https://google.com" + href)
+    }
+    i = i + 1
+  }
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/web_programming/crawl_google_results.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/crawl_google_results.out
@@ -1,0 +1,4 @@
+3
+https://google.com/url?q=http://example1.com
+/maps
+https://google.com/url?q=http://example2.com

--- a/tests/github/TheAlgorithms/Python/web_programming/crawl_google_results.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/crawl_google_results.py
@@ -1,0 +1,38 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "beautifulsoup4",
+#     "fake-useragent",
+#     "httpx",
+# ]
+# ///
+
+import sys
+import webbrowser
+
+import httpx
+from bs4 import BeautifulSoup
+from fake_useragent import UserAgent
+
+if __name__ == "__main__":
+    print("Googling.....")
+    url = "https://www.google.com/search?q=" + " ".join(sys.argv[1:])
+    res = httpx.get(
+        url,
+        headers={"UserAgent": UserAgent().random},
+        timeout=10,
+        follow_redirects=True,
+    )
+    # res.raise_for_status()
+    with open("project1a.html", "wb") as out_file:  # only for knowing the class
+        for data in res.iter_content(10000):
+            out_file.write(data)
+    soup = BeautifulSoup(res.text, "html.parser")
+    links = list(soup.select(".eZt8xd"))[:5]
+
+    print(len(links))
+    for link in links:
+        if link.text == "Maps":
+            webbrowser.open(link.get("href"))
+        else:
+            webbrowser.open(f"https://google.com{link.get('href')}")


### PR DESCRIPTION
## Summary
- add missing Python script crawl_google_results using httpx and BeautifulSoup
- implement pure Mochi version that parses mock Google result HTML and prints top links
- include runtime output for the Mochi example

## Testing
- `python -m py_compile tests/github/TheAlgorithms/Python/web_programming/crawl_google_results.py`
- `./mochi run tests/github/TheAlgorithms/Mochi/web_programming/crawl_google_results.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6892eff9c3f88320992dacc96aef212c