### PR TITLE
Add Mochi implementation for current stock price algorithm

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/current_stock_price.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/current_stock_price.mochi
@@ -1,0 +1,57 @@
+/*
+Retrieve the latest stock price for a given ticker symbol using
+pre-recorded HTML fragments similar to Yahoo Finance pages.
+
+Each fragment contains a span element with the attribute
+`data-testid="qsp-price"` whose content represents the current price.  The
+`stock_price` function searches the HTML fragment for this span and returns
+its text content. If the span is missing, a message is returned indicating
+the price could not be found.
+
+Although real implementations would fetch live pages over HTTP and parse
+them, this example focuses on the core string searching algorithm for
+extracting the price from HTML.
+
+Time complexity: O(n * m) where n is the length of the HTML string and m is
+the length of the search patterns.
+*/
+
+fun find(text: string, pattern: string, start: int): int {
+  var i = start
+  let limit = len(text) - len(pattern)
+  while i <= limit {
+    if substring(text, i, i + len(pattern)) == pattern {
+      return i
+    }
+    i = i + 1
+  }
+  return -1
+}
+
+fun stock_price(symbol: string): string {
+  let pages: map<string, string> = {
+    "AAPL": "<span data-testid=\"qsp-price\">228.43</span>",
+    "AMZN": "<span data-testid=\"qsp-price\">201.85</span>",
+    "IBM":  "<span data-testid=\"qsp-price\">210.30</span>",
+    "GOOG": "<span data-testid=\"qsp-price\">177.86</span>",
+    "MSFT": "<span data-testid=\"qsp-price\">414.82</span>",
+    "ORCL": "<span data-testid=\"qsp-price\">188.87</span>"
+  }
+  if symbol in pages {
+    let html = pages[symbol]
+    let marker = "<span data-testid=\"qsp-price\">"
+    let start_idx = find(html, marker, 0)
+    if start_idx != (-1) {
+      let price_start = start_idx + len(marker)
+      let end_idx = find(html, "</span>", price_start)
+        if end_idx != (-1) {
+        return substring(html, price_start, end_idx)
+      }
+    }
+  }
+  return "No <fin-streamer> tag with the specified data-testid attribute found."
+}
+
+for symbol in ["AAPL", "AMZN", "IBM", "GOOG", "MSFT", "ORCL"] {
+  print("Current " + symbol + " stock price is " + stock_price(symbol))
+}

--- a/tests/github/TheAlgorithms/Mochi/web_programming/current_stock_price.mochi.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/current_stock_price.mochi.out
@@ -1,0 +1,6 @@
+Current AAPL stock price is 228.43
+Current AMZN stock price is 201.85
+Current IBM stock price is 210.30
+Current GOOG stock price is 177.86
+Current MSFT stock price is 414.82
+Current ORCL stock price is 188.87

--- a/tests/github/TheAlgorithms/Python/web_programming/current_stock_price.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/current_stock_price.py
@@ -1,0 +1,48 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "beautifulsoup4",
+#     "httpx",
+# ]
+# ///
+
+import httpx
+from bs4 import BeautifulSoup
+
+"""
+Get the HTML code of finance yahoo and select the current qsp-price
+Current AAPL stock price is   228.43
+Current AMZN stock price is   201.85
+Current IBM  stock price is   210.30
+Current GOOG stock price is   177.86
+Current MSFT stock price is   414.82
+Current ORCL stock price is   188.87
+"""
+
+
+def stock_price(symbol: str = "AAPL") -> str:
+    """
+    >>> stock_price("EEEE")
+    'No <fin-streamer> tag with the specified data-testid attribute found.'
+    >>> isinstance(float(stock_price("GOOG")),float)
+    True
+    """
+    url = f"https://finance.yahoo.com/quote/{symbol}?p={symbol}"
+    yahoo_finance_source = httpx.get(
+        url, headers={"USER-AGENT": "Mozilla/5.0"}, timeout=10, follow_redirects=True
+    ).text
+    soup = BeautifulSoup(yahoo_finance_source, "html.parser")
+
+    if specific_fin_streamer_tag := soup.find("span", {"data-testid": "qsp-price"}):
+        return specific_fin_streamer_tag.get_text()
+    return "No <fin-streamer> tag with the specified data-testid attribute found."
+
+
+# Search for the symbol at https://finance.yahoo.com/lookup
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()
+
+    for symbol in "AAPL AMZN IBM GOOG MSFT ORCL".split():
+        print(f"Current {symbol:<4} stock price is {stock_price(symbol):>8}")


### PR DESCRIPTION
## Summary
- add upstream Python script `current_stock_price.py`
- implement `current_stock_price.mochi` to parse sample HTML for price
- include `.out` with example output

## Testing
- `./mochi run tests/github/TheAlgorithms/Mochi/web_programming/current_stock_price.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892effdc73c83209b0dc91c2a02c941