### PR TITLE
Add Mochi current weather example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/current_weather.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/current_weather.mochi
@@ -1,0 +1,52 @@
+/*
+Retrieve current weather information for a location using two public web
+APIs: OpenWeatherMap and Weatherstack.
+
+Algorithm:
+1. Prepare request parameters containing the location and API key for each
+   service.
+2. For every service with an API key, perform an HTTP GET request and append
+   the decoded JSON response to a list.
+3. If no services are available or return data, raise an error.
+
+This implementation simulates the HTTP responses with placeholder data so it
+can run without network access while preserving the control flow of the
+original Python version.
+*/
+
+let OPENWEATHERMAP_API_KEY = "demo"
+let WEATHERSTACK_API_KEY = ""
+let OPENWEATHERMAP_URL_BASE = "https://api.openweathermap.org/data/2.5/weather"
+let WEATHERSTACK_URL_BASE = "http://api.weatherstack.com/current"
+
+fun http_get(url: string, params: map<string, string>): map<string, string> {
+  if "q" in params {
+    return {"location": params["q"], "temperature": "20"}
+  }
+  return {"location": params["query"], "temperature": "20"}
+}
+
+fun current_weather(location: string): list<map<string, map<string, string>>> {
+  var weather_data: list<map<string, map<string, string>>> = []
+  if OPENWEATHERMAP_API_KEY != "" {
+    let params_openweathermap: map<string, string> = {"q": location, "appid": OPENWEATHERMAP_API_KEY}
+    let response_openweathermap = http_get(OPENWEATHERMAP_URL_BASE, params_openweathermap)
+    weather_data = append(weather_data, {"OpenWeatherMap": response_openweathermap})
+  }
+  if WEATHERSTACK_API_KEY != "" {
+    let params_weatherstack: map<string, string> = {"query": location, "access_key": WEATHERSTACK_API_KEY}
+    let response_weatherstack = http_get(WEATHERSTACK_URL_BASE, params_weatherstack)
+    weather_data = append(weather_data, {"Weatherstack": response_weatherstack})
+  }
+  if len(weather_data) == 0 {
+    panic("No API keys provided or no valid data returned.")
+  }
+  return weather_data
+}
+
+fun main() {
+  let data = current_weather("New York")
+  print(str(data))
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/web_programming/current_weather.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/current_weather.out
@@ -1,0 +1,1 @@
+[map[OpenWeatherMap:map[location:New York temperature:20]]]

--- a/tests/github/TheAlgorithms/Python/web_programming/current_weather.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/current_weather.py
@@ -1,0 +1,57 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "httpx",
+# ]
+# ///
+
+import httpx
+
+# Put your API key(s) here
+OPENWEATHERMAP_API_KEY = ""
+WEATHERSTACK_API_KEY = ""
+
+# Define the URL for the APIs with placeholders
+OPENWEATHERMAP_URL_BASE = "https://api.openweathermap.org/data/2.5/weather"
+WEATHERSTACK_URL_BASE = "http://api.weatherstack.com/current"
+
+
+def current_weather(location: str) -> list[dict]:
+    """
+    >>> current_weather("location")
+    Traceback (most recent call last):
+        ...
+    ValueError: No API keys provided or no valid data returned.
+    """
+    weather_data = []
+    if OPENWEATHERMAP_API_KEY:
+        params_openweathermap = {"q": location, "appid": OPENWEATHERMAP_API_KEY}
+        response_openweathermap = httpx.get(
+            OPENWEATHERMAP_URL_BASE, params=params_openweathermap, timeout=10
+        )
+        weather_data.append({"OpenWeatherMap": response_openweathermap.json()})
+    if WEATHERSTACK_API_KEY:
+        params_weatherstack = {"query": location, "access_key": WEATHERSTACK_API_KEY}
+        response_weatherstack = httpx.get(
+            WEATHERSTACK_URL_BASE, params=params_weatherstack, timeout=10
+        )
+        weather_data.append({"Weatherstack": response_weatherstack.json()})
+    if not weather_data:
+        raise ValueError("No API keys provided or no valid data returned.")
+    return weather_data
+
+
+if __name__ == "__main__":
+    from pprint import pprint
+
+    location = "to be determined..."
+    while location:
+        location = input("Enter a location (city name or latitude,longitude): ").strip()
+        if location:
+            try:
+                weather_data = current_weather(location)
+                for forecast in weather_data:
+                    pprint(forecast)
+            except ValueError as e:
+                print(repr(e))
+                location = ""


### PR DESCRIPTION
## Summary
- add Python reference current_weather API example
- provide Mochi translation that simulates API requests with placeholder data

## Testing
- `/tmp/mochi run tests/github/TheAlgorithms/Mochi/web_programming/current_weather.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892effeb4f483209ef8f80a26f24a9b