### PR TITLE
feat: add daily horoscope example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/daily_horoscope.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/daily_horoscope.mochi
@@ -1,0 +1,60 @@
+/*
+Daily horoscope retrieval.
+
+The original Python algorithm fetches the daily horoscope from
+Horoscope.com for a given zodiac sign (1–12) and day ("yesterday",
+"today", or "tomorrow").  It builds a URL like
+"https://www.horoscope.com/us/horoscopes/general/horoscope-general-daily-{day}.aspx?sign={sign}".
+The page is downloaded with an HTTP client and parsed with
+BeautifulSoup to extract the text inside the <div class="main-horoscope">.
+
+In this pure Mochi version, networking and HTML parsing are omitted to
+stay compatible with runtime/vm.  Instead, the function performs a
+constant‑time lookup of canned messages for each sign and day.
+
+Algorithm:
+1. Validate the zodiac sign and requested day.
+2. Map the sign number to its name (Aries .. Pisces).
+3. Map the day to a pre-defined message (yesterday, today, tomorrow).
+4. Return the combined "Name: message" string.
+
+Both time and space complexity are O(1).
+*/
+
+let days: list<string> = ["yesterday", "today", "tomorrow"]
+let zodiac_names: list<string> = [
+  "Aries", "Taurus", "Gemini", "Cancer", "Leo", "Virgo",
+  "Libra", "Scorpio", "Sagittarius", "Capricorn", "Aquarius", "Pisces"
+]
+let day_messages: list<string> = [
+  "Reflect on what has passed and learn from it.",
+  "Focus on the present and take decisive action.",
+  "Prepare for future opportunities with optimism."
+]
+
+fun horoscope(zodiac_sign: int, day: string): string {
+  var day_index = 0 - 1
+  var i = 0
+  while i < len(days) {
+    if day == days[i] {
+      day_index = i
+      break
+    }
+    i = i + 1
+  }
+  var sign_index = zodiac_sign - 1
+  if day_index == 0 - 1 {
+    return "Invalid zodiac sign or day"
+  }
+  if sign_index < 0 || sign_index >= len(zodiac_names) {
+    return "Invalid zodiac sign or day"
+  }
+  return zodiac_names[sign_index] + ": " + day_messages[day_index]
+}
+
+fun main() {
+  let result = horoscope(1, "today")
+  print(result)
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/web_programming/daily_horoscope.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/daily_horoscope.out
@@ -1,0 +1,1 @@
+Aries: Focus on the present and take decisive action.

--- a/tests/github/TheAlgorithms/Python/web_programming/daily_horoscope.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/daily_horoscope.py
@@ -1,0 +1,43 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "beautifulsoup4",
+#     "httpx",
+# ]
+# ///
+
+import httpx
+from bs4 import BeautifulSoup
+
+
+def horoscope(zodiac_sign: int, day: str) -> str:
+    url = (
+        "https://www.horoscope.com/us/horoscopes/general/"
+        f"horoscope-general-daily-{day}.aspx?sign={zodiac_sign}"
+    )
+    soup = BeautifulSoup(httpx.get(url, timeout=10).content, "html.parser")
+    return soup.find("div", class_="main-horoscope").p.text
+
+
+if __name__ == "__main__":
+    print("Daily Horoscope. \n")
+    print(
+        "enter your Zodiac sign number:\n",
+        "1. Aries\n",
+        "2. Taurus\n",
+        "3. Gemini\n",
+        "4. Cancer\n",
+        "5. Leo\n",
+        "6. Virgo\n",
+        "7. Libra\n",
+        "8. Scorpio\n",
+        "9. Sagittarius\n",
+        "10. Capricorn\n",
+        "11. Aquarius\n",
+        "12. Pisces\n",
+    )
+    zodiac_sign = int(input("number> ").strip())
+    print("choose some day:\n", "yesterday\n", "today\n", "tomorrow\n")
+    day = input("enter the day> ")
+    horoscope_text = horoscope(zodiac_sign, day)
+    print(horoscope_text)


### PR DESCRIPTION
## Summary
- add Python `daily_horoscope` scraper from TheAlgorithms
- provide Mochi translation using offline lookup so it runs on the VM
- record sample output

## Testing
- `go test ./...`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6892efffa7f88320906dac0fcf74fb98