### PR TITLE
Add Mochi translation for Google image downloader

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/download_images_from_google_query.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/download_images_from_google_query.mochi
@@ -1,0 +1,86 @@
+/*
+Downloading images from a Google query
+
+This program emulates the behavior of the Python algorithm from
+TheAlgorithms repository which fetches image results for a query from
+Google and saves them to disk. Due to the lack of networking and HTML
+parsing libraries in the pure Mochi runtime, this implementation works
+with a small sample of HTML returned by a search request. The program:
+
+1. Defines a static HTML snippet that contains several image URLs.
+2. Extracts all direct links to JPG images by scanning for occurrences
+   of "https://" followed by characters up to the ".jpg" suffix.
+3. Limits the number of images to at most 50 and to the requested maximum.
+4. Prints messages for the images that would be downloaded.
+
+No external libraries or FFI are used and all types are explicit.
+*/
+
+fun replace_spaces(s: string): string {
+  var res = ""
+  var i = 0
+  while i < len(s) {
+    let ch = s[i:i+1]
+    if ch == " " {
+      res = res + "_"
+    } else {
+      res = res + ch
+    }
+    i = i + 1
+  }
+  return res
+}
+
+fun extract_image_urls(html: string): list<string> {
+  var urls: list<string> = []
+  var i = 0
+  while i < len(html) {
+    if i + 8 <= len(html) && html[i:i+8] == "https://" {
+      var j = i
+      while j < len(html) && !(j + 4 <= len(html) && html[j:j+4] == ".jpg") {
+        j = j + 1
+      }
+      if j + 4 <= len(html) {
+        let url = html[i:j+4]
+        urls = append(urls, url)
+        i = j + 4
+      } else {
+        i = j
+      }
+    } else {
+      i = i + 1
+    }
+  }
+  return urls
+}
+
+fun download_images_from_google_query(query: string, max_images: int): int {
+  var limit = max_images
+  if limit > 50 {
+    limit = 50
+  }
+  let sample_html =
+    "<img src='https://example.com/a.jpg'>" +
+    "<img src='https://example.com/b.jpg'>" +
+    "<img src='https://example.com/c.jpg'>" +
+    "<img src='https://example.com/d.jpg'>" +
+    "<img src='https://example.com/e.jpg'>"
+  let urls = extract_image_urls(sample_html)
+  var count = 0
+  let path_name = "query_" + replace_spaces(query)
+  var i = 0
+  while i < len(urls) && i < limit {
+    let url = urls[i]
+    print("Downloading", url, "to", path_name, "image", i)
+    count = count + 1
+    i = i + 1
+  }
+  return count
+}
+
+fun main() {
+  let c = download_images_from_google_query("dhaka", 5)
+  print(c, "images were downloaded.")
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/web_programming/download_images_from_google_query.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/download_images_from_google_query.out
@@ -1,0 +1,6 @@
+Downloading https://example.com/a.jpg to query_dhaka image 0
+Downloading https://example.com/b.jpg to query_dhaka image 1
+Downloading https://example.com/c.jpg to query_dhaka image 2
+Downloading https://example.com/d.jpg to query_dhaka image 3
+Downloading https://example.com/e.jpg to query_dhaka image 4
+5 images were downloaded.

--- a/tests/github/TheAlgorithms/Python/web_programming/download_images_from_google_query.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/download_images_from_google_query.py
@@ -1,0 +1,111 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "beautifulsoup4",
+#     "httpx",
+# ]
+# ///
+
+import json
+import os
+import re
+import sys
+import urllib.request
+
+import httpx
+from bs4 import BeautifulSoup
+
+headers = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+    " (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.19582"
+}
+
+
+def download_images_from_google_query(query: str = "dhaka", max_images: int = 5) -> int:
+    """
+    Searches google using the provided query term and downloads the images in a folder.
+
+    Args:
+         query : The image search term to be provided by the user. Defaults to
+        "dhaka".
+        image_numbers : [description]. Defaults to 5.
+
+    Returns:
+        The number of images successfully downloaded.
+
+    # Comment out slow (4.20s call) doctests
+    # >>> download_images_from_google_query()
+    5
+    # >>> download_images_from_google_query("potato")
+    5
+    """
+    max_images = min(max_images, 50)  # Prevent abuse!
+    params = {
+        "q": query,
+        "tbm": "isch",
+        "hl": "en",
+        "ijn": "0",
+    }
+
+    html = httpx.get(
+        "https://www.google.com/search", params=params, headers=headers, timeout=10
+    )
+    soup = BeautifulSoup(html.text, "html.parser")
+    matched_images_data = "".join(
+        re.findall(r"AF_initDataCallback\(([^<]+)\);", str(soup.select("script")))
+    )
+
+    matched_images_data_fix = json.dumps(matched_images_data)
+    matched_images_data_json = json.loads(matched_images_data_fix)
+
+    matched_google_image_data = re.findall(
+        r"\[\"GRID_STATE0\",null,\[\[1,\[0,\".*?\",(.*),\"All\",",
+        matched_images_data_json,
+    )
+    if not matched_google_image_data:
+        return 0
+
+    removed_matched_google_images_thumbnails = re.sub(
+        r"\[\"(https\:\/\/encrypted-tbn0\.gstatic\.com\/images\?.*?)\",\d+,\d+\]",
+        "",
+        str(matched_google_image_data),
+    )
+
+    matched_google_full_resolution_images = re.findall(
+        r"(?:'|,),\[\"(https:|http.*?)\",\d+,\d+\]",
+        removed_matched_google_images_thumbnails,
+    )
+    for index, fixed_full_res_image in enumerate(matched_google_full_resolution_images):
+        if index >= max_images:
+            return index
+        original_size_img_not_fixed = bytes(fixed_full_res_image, "ascii").decode(
+            "unicode-escape"
+        )
+        original_size_img = bytes(original_size_img_not_fixed, "ascii").decode(
+            "unicode-escape"
+        )
+        opener = urllib.request.build_opener()
+        opener.addheaders = [
+            (
+                "User-Agent",
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+                " (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.19582",
+            )
+        ]
+        urllib.request.install_opener(opener)
+        path_name = f"query_{query.replace(' ', '_')}"
+        if not os.path.exists(path_name):
+            os.makedirs(path_name)
+        urllib.request.urlretrieve(  # noqa: S310
+            original_size_img, f"{path_name}/original_size_img_{index}.jpg"
+        )
+    return index
+
+
+if __name__ == "__main__":
+    try:
+        image_count = download_images_from_google_query(sys.argv[1])
+        print(f"{image_count} images were downloaded to disk.")
+    except IndexError:
+        print("Please provide a search term.")
+        raise


### PR DESCRIPTION
## Summary
- add missing Python reference `download_images_from_google_query.py`
- implement a pure Mochi version that parses a sample HTML snippet for image URLs and simulates downloading
- include expected runtime output

## Testing
- `GOPROXY=direct GOSUMDB=off go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/web_programming/download_images_from_google_query.mochi` *(failed: only toolchain verification message, no output)*

------
https://chatgpt.com/codex/tasks/task_e_6892f000fd6083209d67cd54118c4cd5