### PR TITLE
Add Mochi implementation for emails from URL

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/emails_from_url.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/emails_from_url.mochi
@@ -1,0 +1,211 @@
+/*
+Extract email addresses from linked web pages.
+
+Given a starting URL on a particular domain, parse the HTML of that page to
+collect all links.  The linked pages are then searched for strings of the
+form username@domain where "username" contains only letters or digits and
+the domain matches the starting URL.  Results are deduplicated and returned
+in alphabetical order.
+
+This Mochi implementation mirrors the logic of the Python reference but
+operates purely on in-memory HTML strings instead of performing network
+requests.  It demonstrates manual string parsing, set-like behaviour using
+lists, and a simple bubble sort.
+*/
+
+type Page {
+  url: string,
+  html: string,
+}
+
+fun index_of(s: string, ch: string): int {
+  var i = 0
+  while i < len(s) {
+    if s[i] == ch { return i }
+    i = i + 1
+  }
+  return -1
+}
+
+fun index_of_substring(s: string, sub: string): int {
+  let n = len(s)
+  let m = len(sub)
+  if m == 0 { return 0 }
+  var i = 0
+  while i <= n - m {
+    var j = 0
+    var is_match = true
+    while j < m {
+      if s[i + j] != sub[j] {
+        is_match = false
+        break
+      }
+      j = j + 1
+    }
+    if is_match { return i }
+    i = i + 1
+  }
+  return -1
+}
+
+fun split(s: string, sep: string): list<string> {
+  var parts: list<string> = []
+  var last = 0
+  var i = 0
+  while i < len(s) {
+    let ch = s[i]
+    if ch == sep {
+      parts = append(parts, substring(s, last, i))
+      last = i + 1
+    }
+    if i + 1 == len(s) {
+      parts = append(parts, substring(s, last, i + 1))
+    }
+    i = i + 1
+  }
+  return parts
+}
+
+fun get_sub_domain_name(url: string): string {
+  let proto_pos = index_of_substring(url, "://")
+  var start = 0
+  if proto_pos >= 0 { start = proto_pos + 3 }
+  var i = start
+  while i < len(url) {
+    if url[i] == "/" { break }
+    i = i + 1
+  }
+  return substring(url, start, i)
+}
+
+fun get_domain_name(url: string): string {
+  let sub = get_sub_domain_name(url)
+  let parts = split(sub, ".")
+  if len(parts) >= 2 {
+    return parts[len(parts)-2] + "." + parts[len(parts)-1]
+  }
+  return sub
+}
+
+fun is_alnum(ch: string): bool {
+  let chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+  return index_of(chars, ch) >= 0
+}
+
+fun contains(xs: list<string>, x: string): bool {
+  var i = 0
+  while i < len(xs) {
+    if xs[i] == x { return true }
+    i = i + 1
+  }
+  return false
+}
+
+fun bubble_sort(xs: list<string>): list<string> {
+  var arr = xs
+  var n = len(arr)
+  var i = 0
+  while i < n {
+    var j = 0
+    while j + 1 < n - i {
+      if arr[j] > arr[j + 1] {
+        let tmp = arr[j]
+        arr[j] = arr[j + 1]
+        arr[j + 1] = tmp
+      }
+      j = j + 1
+    }
+    i = i + 1
+  }
+  return arr
+}
+
+fun extract_links(domain: string, html: string): list<string> {
+  var links: list<string> = []
+  var pos = index_of_substring(html, "href=")
+  while pos >= 0 {
+    let start_quote = index_of(substring(html, pos + 5, len(html)), "\"")
+    if start_quote < 0 { break }
+    let rest = pos + 5 + start_quote + 1
+    let end_quote = index_of(substring(html, rest, len(html)), "\"")
+    if end_quote < 0 { break }
+    let link = substring(html, rest, rest + end_quote)
+    if !contains(links, link) {
+      var absolute = link
+      if !(index_of_substring(link, "http://") == 0 || index_of_substring(link, "https://") == 0) {
+        if index_of_substring(link, "/") == 0 {
+          absolute = "https://" + domain + link
+        } else {
+          absolute = "https://" + domain + "/" + link
+        }
+      }
+      links = append(links, absolute)
+    }
+    pos = index_of_substring(substring(html, rest + end_quote, len(html)), "href=")
+    if pos >= 0 { pos = pos + rest + end_quote }
+  }
+  return links
+}
+
+fun extract_emails(domain: string, text: string): list<string> {
+  var emails: list<string> = []
+  var i = 0
+  while i < len(text) {
+    if text[i] == "@" {
+      if substring(text, i + 1, i + 1 + len(domain)) == domain {
+        var j = i - 1
+        while j >= 0 && is_alnum(text[j]) { j = j - 1 }
+        let local = substring(text, j + 1, i)
+        if len(local) > 0 {
+          let email = local + "@" + domain
+          if !contains(emails, email) { emails = append(emails, email) }
+        }
+      }
+    }
+    i = i + 1
+  }
+  return emails
+}
+
+fun find_page(pages: list<Page>, url: string): string {
+  var i = 0
+  while i < len(pages) {
+    let p = pages[i]
+    if p.url == url { return p.html }
+    i = i + 1
+  }
+  return ""
+}
+
+fun emails_from_url(url: string, pages: list<Page>): list<string> {
+  let domain = get_domain_name(url)
+  let base_html = find_page(pages, url)
+  let links = extract_links(domain, base_html)
+  var found: list<string> = []
+  var i = 0
+  while i < len(links) {
+    let html = find_page(pages, links[i])
+    let emails = extract_emails(domain, html)
+    var j = 0
+    while j < len(emails) {
+      if !contains(found, emails[j]) { found = append(found, emails[j]) }
+      j = j + 1
+    }
+    i = i + 1
+  }
+  let sorted = bubble_sort(found)
+  return sorted
+}
+
+let pages = [
+  Page{url: "https://example.com", html: "<html><body><a href=\"/contact\">Contact</a></body></html>"},
+  Page{url: "https://example.com/contact", html: "<html>Contact us at info@example.com or support@example.com</html>"},
+]
+
+let emails = emails_from_url("https://example.com", pages)
+print(str(len(emails)) + " emails found:")
+var k = 0
+while k < len(emails) {
+  print(emails[k])
+  k = k + 1
+}

--- a/tests/github/TheAlgorithms/Mochi/web_programming/emails_from_url.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/emails_from_url.out
@@ -1,0 +1,3 @@
+2 emails found:
+info@example.com
+support@example.com

--- a/tests/github/TheAlgorithms/Python/web_programming/emails_from_url.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/emails_from_url.py
@@ -1,0 +1,117 @@
+"""Get the site emails from URL."""
+
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "httpx",
+# ]
+# ///
+
+from __future__ import annotations
+
+__author__ = "Muhammad Umer Farooq"
+__license__ = "MIT"
+__version__ = "1.0.0"
+__maintainer__ = "Muhammad Umer Farooq"
+__email__ = "contact@muhammadumerfarooq.me"
+__status__ = "Alpha"
+
+import re
+from html.parser import HTMLParser
+from urllib import parse
+
+import httpx
+
+
+class Parser(HTMLParser):
+    def __init__(self, domain: str) -> None:
+        super().__init__()
+        self.urls: list[str] = []
+        self.domain = domain
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        """
+        This function parse html to take takes url from tags
+        """
+        # Only parse the 'anchor' tag.
+        if tag == "a":
+            # Check the list of defined attributes.
+            for name, value in attrs:
+                # If href is defined, not empty nor # print it and not already in urls.
+                if name == "href" and value not in (*self.urls, "", "#"):
+                    url = parse.urljoin(self.domain, value)
+                    self.urls.append(url)
+
+
+# Get main domain name (example.com)
+def get_domain_name(url: str) -> str:
+    """
+    This function get the main domain name
+
+    >>> get_domain_name("https://a.b.c.d/e/f?g=h,i=j#k")
+    'c.d'
+    >>> get_domain_name("Not a URL!")
+    ''
+    """
+    return ".".join(get_sub_domain_name(url).split(".")[-2:])
+
+
+# Get sub domain name (sub.example.com)
+def get_sub_domain_name(url: str) -> str:
+    """
+    >>> get_sub_domain_name("https://a.b.c.d/e/f?g=h,i=j#k")
+    'a.b.c.d'
+    >>> get_sub_domain_name("Not a URL!")
+    ''
+    """
+    return parse.urlparse(url).netloc
+
+
+def emails_from_url(url: str = "https://github.com") -> list[str]:
+    """
+    This function takes url and return all valid urls
+    """
+    # Get the base domain from the url
+    domain = get_domain_name(url)
+
+    # Initialize the parser
+    parser = Parser(domain)
+
+    try:
+        # Open URL
+        r = httpx.get(url, timeout=10, follow_redirects=True)
+
+        # pass the raw HTML to the parser to get links
+        parser.feed(r.text)
+
+        # Get links and loop through
+        valid_emails = set()
+        for link in parser.urls:
+            # open URL.
+            # Check if the link is already absolute
+            if not link.startswith("http://") and not link.startswith("https://"):
+                # Prepend protocol only if link starts with domain, normalize otherwise
+                if link.startswith(domain):
+                    link = f"https://{link}"
+                else:
+                    link = parse.urljoin(f"https://{domain}", link)
+            try:
+                read = httpx.get(link, timeout=10, follow_redirects=True)
+                # Get the valid email.
+                emails = re.findall("[a-zA-Z0-9]+@" + domain, read.text)
+                # If not in list then append it.
+                for email in emails:
+                    valid_emails.add(email)
+            except ValueError:
+                pass
+    except ValueError:
+        raise SystemExit(1)
+
+    # Finally return a sorted list of email addresses with no duplicates.
+    return sorted(valid_emails)
+
+
+if __name__ == "__main__":
+    emails = emails_from_url("https://github.com")
+    print(f"{len(emails)} emails found:")
+    print("\n".join(sorted(emails)))


### PR DESCRIPTION
## Summary
- add Python reference implementation `emails_from_url.py`
- implement pure Mochi version to collect emails from links on a domain
- add runtime output for verification

## Testing
- `python -m py_compile tests/github/TheAlgorithms/Python/web_programming/emails_from_url.py`
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/web_programming/emails_from_url.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892f001d4fc8320b8751dc9ccc77591