### PR TITLE
Add Mochi implementation for anime fetch demo

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/fetch_anime_and_play.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/fetch_anime_and_play.mochi
@@ -1,0 +1,99 @@
+/*
+Anime Search and Episode Retrieval
+
+The original Python script scrapes the gogoanime website to find anime titles,
+list their episodes, and build streaming links. This Mochi implementation
+reproduces the workflow using static data and string processing so it can run on
+runtime/vm without any foreign interfaces.
+
+Functions:
+- contains_str(s, sub): helper for substring matching.
+- search_scraper(name): case-insensitive search over sample titles (O(n)).
+- search_anime_episode_list(endpoint): returns a list of episode maps for an
+  anime endpoint (O(1) map lookup).
+- get_anime_episode(endpoint): constructs watch and download URLs from an embed
+  path (O(1) string manipulation).
+
+The main routine demonstrates the process with sample inputs.
+*/
+
+let BASE_URL = "https://ww7.gogoanime2.org"
+
+fun contains_str(s: string, sub: string): bool {
+  if len(sub) == 0 { return true }
+  var i = 0
+  while i + len(sub) <= len(s) {
+    if substring(s, i, i + len(sub)) == sub { return true }
+    i = i + 1
+  }
+  return false
+}
+
+let ANIME_DB: list<map<string, string>> = [
+  {"title": "Demon Slayer", "url": "/anime/kimetsu-no-yaiba"},
+  {"title": "Naruto", "url": "/anime/naruto"}
+]
+
+fun search_scraper(anime_name: string): list<map<string, string>> {
+  let term = lower(anime_name)
+  var res: list<map<string, string>> = []
+  var i = 0
+  while i < len(ANIME_DB) {
+    let item = ANIME_DB[i]
+    if contains_str(lower(item["title"]), term) {
+      res = append(res, item)
+    }
+    i = i + 1
+  }
+  return res
+}
+
+let EPISODE_DB: map<string, list<map<string, string>>> = {
+  "/anime/kimetsu-no-yaiba": [
+    {"title": "Episode 1", "url": "/watch/kimetsu-no-yaiba/1"},
+    {"title": "Episode 2", "url": "/watch/kimetsu-no-yaiba/2"}
+  ],
+  "/anime/naruto": [
+    {"title": "Episode 1", "url": "/watch/naruto/1"}
+  ]
+}
+
+fun search_anime_episode_list(endpoint: string): list<map<string, string>> {
+  if endpoint in EPISODE_DB {
+    return EPISODE_DB[endpoint]
+  }
+  var empty: list<map<string, string>> = []
+  return empty
+}
+
+let EPISODE_EMBED: map<string, string> = {
+  "/watch/kimetsu-no-yaiba/1": "/embed/kimetsu-no-yaiba/1",
+  "/watch/kimetsu-no-yaiba/2": "/embed/kimetsu-no-yaiba/2",
+  "/watch/naruto/1": "/embed/naruto/1"
+}
+
+fun to_playlist(embed: string): string {
+  return "/playlist/" + embed[7:] + ".m3u8"
+}
+
+fun get_anime_episode(endpoint: string): list<string> {
+  if endpoint in EPISODE_EMBED {
+    let embed = EPISODE_EMBED[endpoint]
+    let play = BASE_URL + embed
+    let download = BASE_URL + to_playlist(embed)
+    return [play, download]
+  }
+  var empty: list<string> = []
+  return empty
+}
+
+fun main() {
+  let animes = search_scraper("demon")
+  print(animes)
+  let episodes = search_anime_episode_list("/anime/kimetsu-no-yaiba")
+  print(episodes)
+  let links = get_anime_episode("/watch/kimetsu-no-yaiba/1")
+  print(links)
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/web_programming/fetch_anime_and_play.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/fetch_anime_and_play.out
@@ -1,0 +1,3 @@
+[{"title": "Demon Slayer", "url": "/anime/kimetsu-no-yaiba"}]
+[{"title": "Episode 1", "url": "/watch/kimetsu-no-yaiba/1"}, {"title": "Episode 2", "url": "/watch/kimetsu-no-yaiba/2"}]
+["https://ww7.gogoanime2.org/embed/kimetsu-no-yaiba/1", "https://ww7.gogoanime2.org/playlist/kimetsu-no-yaiba/1.m3u8"]

--- a/tests/github/TheAlgorithms/Python/web_programming/fetch_anime_and_play.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/fetch_anime_and_play.py
@@ -1,0 +1,197 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "beautifulsoup4",
+#     "fake-useragent",
+#     "httpx",
+# ]
+# ///
+
+import httpx
+from bs4 import BeautifulSoup, NavigableString, Tag
+from fake_useragent import UserAgent
+
+BASE_URL = "https://ww7.gogoanime2.org"
+
+
+def search_scraper(anime_name: str) -> list:
+    """[summary]
+
+    Take an url and
+    return list of anime after scraping the site.
+
+    >>> type(search_scraper("demon_slayer"))
+    <class 'list'>
+
+    Args:
+        anime_name (str): [Name of anime]
+
+    Raises:
+        e: [Raises exception on failure]
+
+    Returns:
+        [list]: [List of animes]
+    """
+
+    # concat the name to form the search url.
+    search_url = f"{BASE_URL}/search?keyword={anime_name}"
+
+    response = httpx.get(
+        search_url, headers={"UserAgent": UserAgent().chrome}, timeout=10
+    )  # request the url.
+
+    # Is the response ok?
+    response.raise_for_status()
+
+    # parse with soup.
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    # get list of anime
+    anime_ul = soup.find("ul", {"class": "items"})
+    if anime_ul is None or isinstance(anime_ul, NavigableString):
+        msg = f"Could not find and anime with name {anime_name}"
+        raise ValueError(msg)
+    anime_li = anime_ul.children
+
+    # for each anime, insert to list. the name and url.
+    anime_list = []
+    for anime in anime_li:
+        if isinstance(anime, Tag):
+            anime_url = anime.find("a")
+            if anime_url is None or isinstance(anime_url, NavigableString):
+                continue
+            anime_title = anime.find("a")
+            if anime_title is None or isinstance(anime_title, NavigableString):
+                continue
+
+            anime_list.append({"title": anime_title["title"], "url": anime_url["href"]})
+
+    return anime_list
+
+
+def search_anime_episode_list(episode_endpoint: str) -> list:
+    """[summary]
+
+    Take an url and
+    return list of episodes after scraping the site
+    for an url.
+
+    >>> type(search_anime_episode_list("/anime/kimetsu-no-yaiba"))
+    <class 'list'>
+
+    Args:
+        episode_endpoint (str): [Endpoint of episode]
+
+    Raises:
+        e: [description]
+
+    Returns:
+        [list]: [List of episodes]
+    """
+
+    request_url = f"{BASE_URL}{episode_endpoint}"
+
+    response = httpx.get(
+        url=request_url, headers={"UserAgent": UserAgent().chrome}, timeout=10
+    )
+    response.raise_for_status()
+
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    # With this id. get the episode list.
+    episode_page_ul = soup.find("ul", {"id": "episode_related"})
+    if episode_page_ul is None or isinstance(episode_page_ul, NavigableString):
+        msg = f"Could not find any anime eposiodes with name {anime_name}"
+        raise ValueError(msg)
+    episode_page_li = episode_page_ul.children
+
+    episode_list = []
+    for episode in episode_page_li:
+        if isinstance(episode, Tag):
+            url = episode.find("a")
+            if url is None or isinstance(url, NavigableString):
+                continue
+            title = episode.find("div", {"class": "name"})
+            if title is None or isinstance(title, NavigableString):
+                continue
+
+            episode_list.append(
+                {"title": title.text.replace(" ", ""), "url": url["href"]}
+            )
+
+    return episode_list
+
+
+def get_anime_episode(episode_endpoint: str) -> list:
+    """[summary]
+
+    Get click url and download url from episode url
+
+    >>> type(get_anime_episode("/watch/kimetsu-no-yaiba/1"))
+    <class 'list'>
+
+    Args:
+        episode_endpoint (str): [Endpoint of episode]
+
+    Raises:
+        e: [description]
+
+    Returns:
+        [list]: [List of download and watch url]
+    """
+
+    episode_page_url = f"{BASE_URL}{episode_endpoint}"
+
+    response = httpx.get(
+        url=episode_page_url, headers={"User-Agent": UserAgent().chrome}, timeout=10
+    )
+    response.raise_for_status()
+
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    url = soup.find("iframe", {"id": "playerframe"})
+    if url is None or isinstance(url, NavigableString):
+        msg = f"Could not find url and download url from {episode_endpoint}"
+        raise RuntimeError(msg)
+
+    episode_url = url["src"]
+    if not isinstance(episode_url, str):
+        msg = f"Could not find url and download url from {episode_endpoint}"
+        raise RuntimeError(msg)
+    download_url = episode_url.replace("/embed/", "/playlist/") + ".m3u8"
+
+    return [f"{BASE_URL}{episode_url}", f"{BASE_URL}{download_url}"]
+
+
+if __name__ == "__main__":
+    anime_name = input("Enter anime name: ").strip()
+    anime_list = search_scraper(anime_name)
+    print("\n")
+
+    if len(anime_list) == 0:
+        print("No anime found with this name")
+    else:
+        print(f"Found {len(anime_list)} results: ")
+        for i, anime in enumerate(anime_list):
+            anime_title = anime["title"]
+            print(f"{i + 1}. {anime_title}")
+
+        anime_choice = int(input("\nPlease choose from the following list: ").strip())
+        chosen_anime = anime_list[anime_choice - 1]
+        print(f"You chose {chosen_anime['title']}. Searching for episodes...")
+
+        episode_list = search_anime_episode_list(chosen_anime["url"])
+        if len(episode_list) == 0:
+            print("No episode found for this anime")
+        else:
+            print(f"Found {len(episode_list)} results: ")
+            for i, episode in enumerate(episode_list):
+                print(f"{i + 1}. {episode['title']}")
+
+            episode_choice = int(input("\nChoose an episode by serial no: ").strip())
+            chosen_episode = episode_list[episode_choice - 1]
+            print(f"You chose {chosen_episode['title']}. Searching...")
+
+            episode_url, download_url = get_anime_episode(chosen_episode["url"])
+            print(f"\nTo watch, ctrl+click on {episode_url}.")
+            print(f"To download, ctrl+click on {download_url}.")


### PR DESCRIPTION
## Summary
- add original Python script `fetch_anime_and_play.py`
- implement equivalent Mochi version using static data so it runs on runtime/vm
- include runtime output file

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/web_programming/fetch_anime_and_play.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892f068d37c8320a83b2a66888755a0