### PR TITLE
Add Mochi implementation of BBC News fetcher

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/fetch_bbc_news.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/fetch_bbc_news.mochi
@@ -1,0 +1,36 @@
+/*
+Fetch and display top BBC News headlines using the NewsAPI.
+
+The program constructs a request URL using the provided API key and sends an HTTP
+GET request. The JSON response is decoded into a structured type containing a
+list of articles. Each article's title is printed with its index. If the API key
+is invalid or no articles are returned, nothing will be printed.
+
+Time complexity: O(n) where n is the number of articles.
+Space complexity: O(n) for storing the list of articles.
+*/
+
+type Article {
+  title: string
+}
+
+type NewsResponse {
+  articles: list<Article>
+}
+
+fun fetch_bbc_news(api_key: string): unit {
+  let url = "https://newsapi.org/v1/articles?source=bbc-news&sortBy=top&apiKey=" + api_key
+  let resp: NewsResponse = fetch url with { timeout: 10.0 }
+  if len(resp.articles) == 0 {
+    print("No articles found.")
+    return
+  }
+  var i: int = 0
+  while i < len(resp.articles) {
+    let article = resp.articles[i]
+    print(str(i + 1) + ".) " + article.title)
+    i = i + 1
+  }
+}
+
+fetch_bbc_news("test")

--- a/tests/github/TheAlgorithms/Mochi/web_programming/fetch_bbc_news.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/fetch_bbc_news.out
@@ -1,0 +1,1 @@
+No articles found.

--- a/tests/github/TheAlgorithms/Python/web_programming/fetch_bbc_news.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/fetch_bbc_news.py
@@ -1,0 +1,24 @@
+# Created by sarathkaul on 12/11/19
+
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "httpx",
+# ]
+# ///
+
+import httpx
+
+_NEWS_API = "https://newsapi.org/v1/articles?source=bbc-news&sortBy=top&apiKey="
+
+
+def fetch_bbc_news(bbc_news_api_key: str) -> None:
+    # fetching a list of articles in json format
+    bbc_news_page = httpx.get(_NEWS_API + bbc_news_api_key, timeout=10).json()
+    # each article in the list is a dict
+    for i, article in enumerate(bbc_news_page["articles"], 1):
+        print(f"{i}.) {article['title']}")
+
+
+if __name__ == "__main__":
+    fetch_bbc_news(bbc_news_api_key="<Your BBC News API key goes here>")


### PR DESCRIPTION
## Summary
- add missing Python script `fetch_bbc_news.py`
- implement Mochi version of BBC News headline fetcher and record sample run

## Testing
- `./mochi_bin run tests/github/TheAlgorithms/Mochi/web_programming/fetch_bbc_news.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6892f06a6dc88320ab19679d22e0db2e