### PR TITLE
Add Mochi implementation for fetching quotes

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/fetch_quotes.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/fetch_quotes.mochi
@@ -1,0 +1,37 @@
+/*
+Fetch quotes from the ZenQuotes API using HTTP GET requests.
+
+The API provides two endpoints:
+  - /today returns the quote of the day
+  - /random returns a random quote
+
+Both endpoints respond with a JSON array of objects
+containing the fields:
+  q: the quote text
+  a: the author's name
+  h: the quote in HTML format
+
+The program defines a Quote type and two helper functions
+that use Mochi's built-in `fetch` to retrieve the data. The
+functions return a list of Quote values.  At the end a random
+quote is fetched and printed.  The implementation uses only
+Mochi primitives so it runs on runtime/vm without any FFI
+and avoids the `any` type.
+*/
+
+type Quote {
+  q: string
+  a: string
+  h: string
+}
+
+fun quote_of_the_day(): list<Quote> {
+  return fetch "https://zenquotes.io/api/today"
+}
+
+fun random_quotes(): list<Quote> {
+  return fetch "https://zenquotes.io/api/random"
+}
+
+let response = random_quotes()
+print(response)

--- a/tests/github/TheAlgorithms/Mochi/web_programming/fetch_quotes.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/fetch_quotes.out
@@ -1,0 +1,1 @@
+[{"a": "Mark Manson", "h": "<blockquote>&ldquo;Life is about not knowing and then doing something anyway.&rdquo; &mdash; <footer>Mark Manson</footer></blockquote>", "q": "Life is about not knowing and then doing something anyway."}]

--- a/tests/github/TheAlgorithms/Python/web_programming/fetch_quotes.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/fetch_quotes.py
@@ -1,0 +1,41 @@
+"""
+This file fetches quotes from the " ZenQuotes API ".
+It does not require any API key as it uses free tier.
+
+For more details and premium features visit:
+    https://zenquotes.io/
+"""
+
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "httpx",
+# ]
+# ///
+
+import pprint
+
+import httpx
+
+API_ENDPOINT_URL = "https://zenquotes.io/api"
+
+
+def quote_of_the_day() -> list:
+    return httpx.get(API_ENDPOINT_URL + "/today", timeout=10).json()
+
+
+def random_quotes() -> list:
+    return httpx.get(API_ENDPOINT_URL + "/random", timeout=10).json()
+
+
+if __name__ == "__main__":
+    """
+    response object has all the info with the quote
+    To retrieve the actual quote access the response.json() object as below
+    response.json() is a list of json object
+        response.json()[0]['q'] = actual quote.
+        response.json()[0]['a'] = author name.
+        response.json()[0]['h'] = in html format.
+    """
+    response = random_quotes()
+    pprint.pprint(response)


### PR DESCRIPTION
## Summary
- add missing Python script that fetches quotes from ZenQuotes API
- implement equivalent Mochi version using typed `fetch`
- include runtime output of Mochi program

## Testing
- `python tests/github/TheAlgorithms/Python/web_programming/fetch_quotes.py`
- `./bin/mochi run tests/github/TheAlgorithms/Mochi/web_programming/fetch_quotes.mochi > tests/github/TheAlgorithms/Mochi/web_programming/fetch_quotes.out`


------
https://chatgpt.com/codex/tasks/task_e_6892f06de0388320855595b551110bee