### PR TITLE
Add Mochi implementation for WellRx price fetch

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/fetch_well_rx_price.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/fetch_well_rx_price.mochi
@@ -1,0 +1,83 @@
+/*
+Fetch WellRx Price List
+
+This program mirrors the Python script `web_programming/fetch_well_rx_price.py`.
+Given a prescription drug name and a ZIP code, it retrieves a list of
+pharmacies and their prices from a WellRx results page.  Network access is
+not used; instead a small sample of HTML is embedded and parsed.  The parser
+searches for `<div class="grid-x pharmCard">` sections, extracting the
+pharmacy name from `<p class="list-title">` and the price from
+`<span class="price price-large">`.  It returns a list of maps where each map
+contains `pharmacy_name` and `price` keys.  The code avoids FFI and the `any`
+type so it can run on the `runtime/vm`.
+*/
+
+let SAMPLE_HTML = "<div class=\"grid-x pharmCard\"><p class=\"list-title\">Pharmacy A</p><span class=\"price price-large\">$10.00</span></div><div class=\"grid-x pharmCard\"><p class=\"list-title\">Pharmacy B</p><span class=\"price price-large\">$12.50</span></div>"
+
+fun find_substring(s: string, sub: string, from: int): int {
+  var i = from
+  while i <= len(s) - len(sub) {
+    var j = 0
+    while j < len(sub) && substring(s, i + j, i + j + 1) == substring(sub, j, j + 1) {
+      j = j + 1
+    }
+    if j == len(sub) {
+      return i
+    }
+    i = i + 1
+  }
+  return -1
+}
+
+fun fetch_pharmacy_and_price_list(drug_name: string, zip_code: string): list<map<string,string>> {
+  if drug_name == "" || zip_code == "" {
+    return null
+  }
+  var results: list<map<string,string>> = []
+  var pos = 0
+  let block_tag = "<div class=\"grid-x pharmCard\">"
+  let name_tag = "<p class=\"list-title\">"
+  let price_tag = "<span class=\"price price-large\">"
+  while true {
+    let div_idx = find_substring(SAMPLE_HTML, block_tag, pos)
+    if div_idx < 0 {
+      break
+    }
+    let name_start = find_substring(SAMPLE_HTML, name_tag, div_idx)
+    if name_start < 0 {
+      break
+    }
+    name_start = name_start + len(name_tag)
+    let name_end = find_substring(SAMPLE_HTML, "</p>", name_start)
+    if name_end < 0 {
+      break
+    }
+    let name = substring(SAMPLE_HTML, name_start, name_end)
+    let price_start = find_substring(SAMPLE_HTML, price_tag, name_end)
+    if price_start < 0 {
+      break
+    }
+    price_start = price_start + len(price_tag)
+    let price_end = find_substring(SAMPLE_HTML, "</span>", price_start)
+    if price_end < 0 {
+      break
+    }
+    let price = substring(SAMPLE_HTML, price_start, price_end)
+    results = append(results, {"pharmacy_name": name, "price": price})
+    pos = price_end
+  }
+  return results
+}
+
+let pharmacy_price_list = fetch_pharmacy_and_price_list("aspirin", "30303")
+if pharmacy_price_list != null {
+  var i = 0
+  while i < len(pharmacy_price_list) {
+    let entry = pharmacy_price_list[i]
+    print("Pharmacy: " + entry["pharmacy_name"] + " Price: " + entry["price"])
+    i = i + 1
+  }
+} else {
+  print("No results found")
+}
+

--- a/tests/github/TheAlgorithms/Mochi/web_programming/fetch_well_rx_price.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/fetch_well_rx_price.out
@@ -1,0 +1,2 @@
+Pharmacy: Pharmacy A Price: $10.00
+Pharmacy: Pharmacy B Price: $12.50

--- a/tests/github/TheAlgorithms/Python/web_programming/fetch_well_rx_price.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/fetch_well_rx_price.py
@@ -1,0 +1,91 @@
+"""
+
+Scrape the price and pharmacy name for a prescription drug from rx site
+after providing the drug name and zipcode.
+
+"""
+
+import httpx
+from bs4 import BeautifulSoup
+
+BASE_URL = "https://www.wellrx.com/prescriptions/{}/{}/?freshSearch=true"
+
+
+def fetch_pharmacy_and_price_list(drug_name: str, zip_code: str) -> list | None:
+    """[summary]
+
+    This function will take input of drug name and zipcode,
+    then request to the BASE_URL site.
+    Get the page data and scrape it to generate the
+    list of the lowest prices for the prescription drug.
+
+    Args:
+        drug_name (str): [Drug name]
+        zip_code(str): [Zip code]
+
+    Returns:
+        list: [List of pharmacy name and price]
+
+    >>> print(fetch_pharmacy_and_price_list(None, None))
+    None
+    >>> print(fetch_pharmacy_and_price_list(None, 30303))
+    None
+    >>> print(fetch_pharmacy_and_price_list("eliquis", None))
+    None
+    """
+
+    try:
+        # Has user provided both inputs?
+        if not drug_name or not zip_code:
+            return None
+
+        request_url = BASE_URL.format(drug_name, zip_code)
+        response = httpx.get(request_url, timeout=10).raise_for_status()
+
+        # Scrape the data using bs4
+        soup = BeautifulSoup(response.text, "html.parser")
+
+        # This list will store the name and price.
+        pharmacy_price_list = []
+
+        # Fetch all the grids that contain the items.
+        grid_list = soup.find_all("div", {"class": "grid-x pharmCard"})
+        if grid_list and len(grid_list) > 0:
+            for grid in grid_list:
+                # Get the pharmacy price.
+                pharmacy_name = grid.find("p", {"class": "list-title"}).text
+
+                # Get the price of the drug.
+                price = grid.find("span", {"p", "price price-large"}).text
+
+                pharmacy_price_list.append(
+                    {
+                        "pharmacy_name": pharmacy_name,
+                        "price": price,
+                    }
+                )
+
+        return pharmacy_price_list
+
+    except (httpx.HTTPError, ValueError):
+        return None
+
+
+if __name__ == "__main__":
+    # Enter a drug name and a zip code
+    drug_name = input("Enter drug name: ").strip()
+    zip_code = input("Enter zip code: ").strip()
+
+    pharmacy_price_list: list | None = fetch_pharmacy_and_price_list(
+        drug_name, zip_code
+    )
+
+    if pharmacy_price_list:
+        print(f"\nSearch results for {drug_name} at location {zip_code}:")
+        for pharmacy_price in pharmacy_price_list:
+            name = pharmacy_price["pharmacy_name"]
+            price = pharmacy_price["price"]
+
+            print(f"Pharmacy: {name} Price: {price}")
+    else:
+        print(f"No results found for {drug_name}")


### PR DESCRIPTION
## Summary
- add missing Python source `web_programming/fetch_well_rx_price.py`
- port WellRx price scraping logic to Mochi with manual HTML parsing
- include runtime output file for the Mochi example

## Testing
- `go run /tmp/runmochi.go tests/github/TheAlgorithms/Mochi/web_programming/fetch_well_rx_price.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6892f06eeb088320ae42c906f32df2fd