### PR TITLE
Add Mochi example for Amazon product data scraping

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/get_amazon_product_data.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/get_amazon_product_data.mochi
@@ -1,0 +1,154 @@
+/*
+Get Amazon Product Data
+-----------------------
+This program demonstrates scraping of product information from an Amazon
+search results page. Given a product name, the code parses the HTML for each
+result entry to extract:
+  - Product title
+  - Link
+  - Current price
+  - Rating
+  - Listed MRP
+  - Discount percentage
+
+The implementation uses Mochi's string processing to locate relevant HTML
+fragments for each search result. It iterates over every
+`<div class="s-result-item" data-component-type="s-search-result">`
+block and extracts the required fields using helper functions.
+The discount is computed from the price and MRP if both are available.
+
+This is a pure Mochi implementation without FFI so it can run inside
+`runtime/vm`.
+*/
+
+type Product {
+  title: string
+  link: string
+  price: string
+  rating: string
+  mrp: string
+  discount: float
+}
+
+fun find_index(s: string, pat: string, start: int): int {
+  var i = start
+  while i <= len(s) - len(pat) {
+    var j = 0
+    var ok = true
+    while j < len(pat) {
+      if s[i + j] != pat[j] {
+        ok = false
+        break
+      }
+      j = j + 1
+    }
+    if ok {
+      return i
+    }
+    i = i + 1
+  }
+  return -1
+}
+
+fun slice_between(s: string, start_pat: string, end_pat: string, from: int): string {
+  let a = find_index(s, start_pat, from)
+  if a < 0 {
+    return ""
+  }
+  let b = a + len(start_pat)
+  let c = find_index(s, end_pat, b)
+  if c < 0 {
+    return ""
+  }
+  return substring(s, b, c)
+}
+
+fun char_to_digit(c: string): int {
+  if c == "0" { return 0 }
+  if c == "1" { return 1 }
+  if c == "2" { return 2 }
+  if c == "3" { return 3 }
+  if c == "4" { return 4 }
+  if c == "5" { return 5 }
+  if c == "6" { return 6 }
+  if c == "7" { return 7 }
+  if c == "8" { return 8 }
+  return 9
+}
+
+fun parse_int(txt: string): int {
+  var n = 0
+  var i = 0
+  while i < len(txt) {
+    let c = txt[i]
+    if c >= "0" && c <= "9" {
+      n = n * 10 + char_to_digit(c)
+    }
+    i = i + 1
+  }
+  return n
+}
+
+fun parse_product(block: string): Product {
+  let href = slice_between(block, "href=\"", "\"", 0)
+  let link = "https://www.amazon.in" + href
+  let title = slice_between(block, ">", "</a>", find_index(block, "<a", 0))
+  let price = slice_between(block, "<span class=\"a-offscreen\">", "</span>", 0)
+  var rating = slice_between(block, "<span class=\"a-icon-alt\">", "</span>", 0)
+  if len(rating) == 0 {
+    rating = "Not available"
+  }
+  var mrp = slice_between(block, "<span class=\"a-price a-text-price\">", "</span>", 0)
+  var disc: float = 0.0
+  if len(mrp) > 0 && len(price) > 0 {
+    let p = parse_int(price)
+    let m = parse_int(mrp)
+    if m > 0 {
+      disc = ((m - p) * 100) as float / (m as float)
+    }
+  } else {
+    mrp = ""
+    disc = 0.0
+  }
+  return Product{
+    title: title,
+    link: link,
+    price: price,
+    rating: rating,
+    mrp: mrp,
+    discount: disc
+  }
+}
+
+fun get_amazon_product_data(product: string): list<Product> {
+  // Sample HTML containing two products for demonstration
+  let html = "<div class=\"s-result-item\" data-component-type=\"s-search-result\"><h2><a href=\"/sample_product\">Sample Product</a></h2><span class=\"a-offscreen\">₹900</span><span class=\"a-icon-alt\">4.3 out of 5 stars</span><span class=\"a-price a-text-price\">₹1000</span></div><div class=\"s-result-item\" data-component-type=\"s-search-result\"><h2><a href=\"/item2\">Another Product</a></h2><span class=\"a-offscreen\">₹500</span><span class=\"a-icon-alt\">3.8 out of 5 stars</span><span class=\"a-price a-text-price\">₹800</span></div>"
+  var out: list<Product> = []
+  var start = 0
+  while true {
+    let div_start = find_index(html, "<div class=\"s-result-item\"", start)
+    if div_start < 0 {
+      break
+    }
+    let div_end = find_index(html, "</div>", div_start)
+    if div_end < 0 {
+      break
+    }
+    let block = substring(html, div_start, div_end)
+    out = append(out, parse_product(block))
+    start = div_end + len("</div>")
+  }
+  return out
+}
+
+fun main() {
+  let products = get_amazon_product_data("laptop")
+  var i = 0
+  while i < len(products) {
+    let p = products[i]
+    print(p.title + " | " + p.link + " | " + p.price + " | " + p.rating + " | " + p.mrp + " | " + str(p.discount))
+    i = i + 1
+  }
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/web_programming/get_amazon_product_data.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/get_amazon_product_data.out
@@ -1,0 +1,2 @@
+Sample Product | https://www.amazon.in/sample_product | ₹900 | 4.3 out of 5 stars | ₹1000 | 10
+Another Product | https://www.amazon.in/item2 | ₹500 | 3.8 out of 5 stars | ₹800 | 37.5

--- a/tests/github/TheAlgorithms/Python/web_programming/get_amazon_product_data.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/get_amazon_product_data.py
@@ -1,0 +1,112 @@
+"""
+This file provides a function which will take a product name as input from the user,
+and fetch from Amazon information about products of this name or category.  The product
+information will include title, URL, price, ratings, and the discount available.
+"""
+
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "beautifulsoup4",
+#     "httpx",
+#     "pandas",
+# ]
+# ///
+
+from itertools import zip_longest
+
+import httpx
+from bs4 import BeautifulSoup
+from pandas import DataFrame
+
+
+def get_amazon_product_data(product: str = "laptop") -> DataFrame:
+    """
+    Take a product name or category as input and return product information from Amazon
+    including title, URL, price, ratings, and the discount available.
+    """
+    url = f"https://www.amazon.in/laptop/s?k={product}"
+    header = {
+        "User-Agent": (
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"
+            "(KHTML, like Gecko)Chrome/44.0.2403.157 Safari/537.36"
+        ),
+        "Accept-Language": "en-US, en;q=0.5",
+    }
+    soup = BeautifulSoup(
+        httpx.get(url, headers=header, timeout=10).text, features="lxml"
+    )
+    # Initialize a Pandas dataframe with the column titles
+    data_frame = DataFrame(
+        columns=[
+            "Product Title",
+            "Product Link",
+            "Current Price of the product",
+            "Product Rating",
+            "MRP of the product",
+            "Discount",
+        ]
+    )
+    # Loop through each entry and store them in the dataframe
+    for item, _ in zip_longest(
+        soup.find_all(
+            "div",
+            attrs={"class": "s-result-item", "data-component-type": "s-search-result"},
+        ),
+        soup.find_all("div", attrs={"class": "a-row a-size-base a-color-base"}),
+    ):
+        try:
+            product_title = item.h2.text
+            product_link = "https://www.amazon.in/" + item.h2.a["href"]
+            product_price = item.find("span", attrs={"class": "a-offscreen"}).text
+            try:
+                product_rating = item.find("span", attrs={"class": "a-icon-alt"}).text
+            except AttributeError:
+                product_rating = "Not available"
+            try:
+                product_mrp = (
+                    "₹"
+                    + item.find(
+                        "span", attrs={"class": "a-price a-text-price"}
+                    ).text.split("₹")[1]
+                )
+            except AttributeError:
+                product_mrp = ""
+            try:
+                discount = float(
+                    (
+                        (
+                            float(product_mrp.strip("₹").replace(",", ""))
+                            - float(product_price.strip("₹").replace(",", ""))
+                        )
+                        / float(product_mrp.strip("₹").replace(",", ""))
+                    )
+                    * 100
+                )
+            except ValueError:
+                discount = float("nan")
+        except AttributeError:
+            continue
+        data_frame.loc[str(len(data_frame.index))] = [
+            product_title,
+            product_link,
+            product_price,
+            product_rating,
+            product_mrp,
+            discount,
+        ]
+    data_frame.loc[
+        data_frame["Current Price of the product"] > data_frame["MRP of the product"],
+        "MRP of the product",
+    ] = " "
+    data_frame.loc[
+        data_frame["Current Price of the product"] > data_frame["MRP of the product"],
+        "Discount",
+    ] = " "
+    data_frame.index += 1
+    return data_frame
+
+
+if __name__ == "__main__":
+    product = "headphones"
+    get_amazon_product_data(product).to_csv(f"Amazon Product Data for {product}.csv")


### PR DESCRIPTION
## Summary
- add missing Python script for fetching Amazon product data
- implement a pure Mochi version that parses HTML and computes discount values
- include example output for two sample products

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/web_programming/get_amazon_product_data.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892f070055c8320a58f56efd13ac8b2