### PR TITLE
Add Mochi implementation for IMDb Top 250 CSV script

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/get_imdb_top_250_movies_csv.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/get_imdb_top_250_movies_csv.mochi
@@ -1,0 +1,35 @@
+/*
+Problem: Generate a CSV of IMDb's Top 250 movies.
+
+The original Python implementation downloads the IMDb Top 250 web page,
+parses the HTML with BeautifulSoup to extract each movie title and its
+rating, and writes the data to "IMDb_Top_250_Movies.csv".
+
+This pure Mochi version avoids external dependencies and network
+requests.  Instead it uses a small, static subset of the data to
+illustrate the same data processing steps:
+
+1. `get_imdb_top_250_movies` returns a map from movie titles to ratings.
+2. `write_movies` prints the CSV header followed by "title,rating" lines.
+   Output can be redirected to a file to recreate the CSV.
+*/
+
+fun get_imdb_top_250_movies(url: string): map<string, float> {
+  let movies: map<string, float> = {
+    "The Shawshank Redemption": 9.2,
+    "The Godfather": 9.2,
+    "The Dark Knight": 9.0
+  }
+  return movies
+}
+
+fun write_movies(filename: string): void {
+  let movies = get_imdb_top_250_movies("")
+  print("Movie title,IMDb rating")
+  for title in movies {
+    let rating = movies[title]
+    print(title + "," + str(rating))
+  }
+}
+
+write_movies("IMDb_Top_250_Movies.csv")

--- a/tests/github/TheAlgorithms/Mochi/web_programming/get_imdb_top_250_movies_csv.mochi.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/get_imdb_top_250_movies_csv.mochi.out
@@ -1,0 +1,4 @@
+Movie title,IMDb rating
+The Dark Knight,9
+The Godfather,9.2
+The Shawshank Redemption,9.2

--- a/tests/github/TheAlgorithms/Python/web_programming/get_imdb_top_250_movies_csv.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/get_imdb_top_250_movies_csv.py
@@ -1,0 +1,38 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "beautifulsoup4",
+#     "httpx",
+# ]
+# ///
+
+from __future__ import annotations
+
+import csv
+
+import httpx
+from bs4 import BeautifulSoup
+
+
+def get_imdb_top_250_movies(url: str = "") -> dict[str, float]:
+    url = url or "https://www.imdb.com/chart/top/?ref_=nv_mv_250"
+    soup = BeautifulSoup(httpx.get(url, timeout=10).text, "html.parser")
+    titles = soup.find_all("h3", class_="ipc-title__text")
+    ratings = soup.find_all("span", class_="ipc-rating-star--rating")
+    return {
+        title.a.text: float(rating.strong.text)
+        for title, rating in zip(titles, ratings)
+    }
+
+
+def write_movies(filename: str = "IMDb_Top_250_Movies.csv") -> None:
+    movies = get_imdb_top_250_movies()
+    with open(filename, "w", newline="") as out_file:
+        writer = csv.writer(out_file)
+        writer.writerow(["Movie title", "IMDb rating"])
+        for title, rating in movies.items():
+            writer.writerow([title, rating])
+
+
+if __name__ == "__main__":
+    write_movies()


### PR DESCRIPTION
## Summary
- add original Python script `get_imdb_top_250_movies_csv.py`
- implement equivalent Mochi program printing a CSV of sample IMDb ratings
- include VM run output for the Mochi version

## Testing
- `go run ./cmd/mochi/main.go run tests/github/TheAlgorithms/Mochi/web_programming/get_imdb_top_250_movies_csv.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892f071d84c8320b3ce04b5cc30832a