### PR TITLE
feat: add IP geolocation example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/get_ip_geolocation.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/get_ip_geolocation.mochi
@@ -1,0 +1,24 @@
+/*
+Retrieve geographic location information for a given IPv4 or IPv6 address.
+
+Algorithm:
+1. Build the ipinfo.io request URL using the provided IP address.
+2. Fetch the JSON response using `fetch` with a timeout.
+3. The response is decoded into a map keyed by field names.
+4. If the map contains `city`, `region`, and `country`, join them into a
+   location string.
+5. Otherwise report that location data was not found.
+*/
+
+fun get_ip_geolocation(ip_address: string): string {
+  let url = "https://ipinfo.io/" + ip_address + "/json"
+  let data: map<string, string> = fetch url with { timeout: 10.0 }
+  if "city" in data && "region" in data && "country" in data {
+    return "Location: " + data["city"] + ", " + data["region"] + ", " + data["country"]
+  }
+  return "Location data not found."
+}
+
+let ip_address: string = input()
+let location = get_ip_geolocation(ip_address)
+print(location)

--- a/tests/github/TheAlgorithms/Mochi/web_programming/get_ip_geolocation.mochi.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/get_ip_geolocation.mochi.out
@@ -1,0 +1,1 @@
+Location: Mountain View, California, US

--- a/tests/github/TheAlgorithms/Python/web_programming/get_ip_geolocation.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/get_ip_geolocation.py
@@ -1,0 +1,47 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "httpx",
+# ]
+# ///
+
+import httpx
+
+
+# Function to get geolocation data for an IP address
+def get_ip_geolocation(ip_address: str) -> str:
+    try:
+        # Construct the URL for the IP geolocation API
+        url = f"https://ipinfo.io/{ip_address}/json"
+
+        # Send a GET request to the API
+        response = httpx.get(url, timeout=10)
+
+        # Check if the HTTP request was successful
+        response.raise_for_status()
+
+        # Parse the response as JSON
+        data = response.json()
+
+        # Check if city, region, and country information is available
+        if "city" in data and "region" in data and "country" in data:
+            location = f"Location: {data['city']}, {data['region']}, {data['country']}"
+        else:
+            location = "Location data not found."
+
+        return location
+    except httpx.RequestError as e:
+        # Handle network-related exceptions
+        return f"Request error: {e}"
+    except ValueError as e:
+        # Handle JSON parsing errors
+        return f"JSON parsing error: {e}"
+
+
+if __name__ == "__main__":
+    # Prompt the user to enter an IP address
+    ip_address = input("Enter an IP address: ")
+
+    # Get the geolocation data and print it
+    location = get_ip_geolocation(ip_address)
+    print(location)


### PR DESCRIPTION
## Summary
- add missing Python source for IP geolocation lookup
- implement Mochi version using fetch and string map parsing
- include sample output of location lookup

## Testing
- `echo "8.8.8.8" | go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/web_programming/get_ip_geolocation.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6892f07276688320ad841c2b0f25e945