### PR TITLE
Add Mochi implementation for Hacker News top posts

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/get_top_hn_posts.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/get_top_hn_posts.mochi
@@ -1,0 +1,60 @@
+/*
+Retrieve the top stories from Hacker News.
+
+This port of the Python implementation queries the public
+Hacker News Firebase API. It first fetches the list of top
+story IDs, then retrieves each story's metadata. For every
+story we keep only the title and URL, falling back to the
+Hacker News item page when an external link is missing.
+
+The helper `hackernews_top_stories_as_markdown` assembles the
+stories into a Markdown bullet list. All network requests are
+performed with the VM's `fetch` builtin and the algorithm runs
+in O(n) time for n requested stories.
+*/
+
+type Story {
+  title: string,
+  url: string,
+}
+
+fun get_hackernews_story(story_id: int): Story {
+  let url: string = "https://hacker-news.firebaseio.com/v0/item/" + str(story_id) + ".json?print=pretty"
+  var story: Story = (fetch url) as Story
+  if story.url == "" {
+    story.url = "https://news.ycombinator.com/item?id=" + str(story_id)
+  }
+  return story
+}
+
+fun hackernews_top_stories(max_stories: int): list<Story> {
+  let url: string = "https://hacker-news.firebaseio.com/v0/topstories.json?print=pretty"
+  var ids: list<int> = (fetch url) as list<int>
+  ids = ids[0:max_stories]
+  var stories: list<Story> = []
+  var i = 0
+  while i < len(ids) {
+    stories = append(stories, get_hackernews_story(ids[i]))
+    i = i + 1
+  }
+  return stories
+}
+
+fun hackernews_top_stories_as_markdown(max_stories: int): string {
+  let stories = hackernews_top_stories(max_stories)
+  var output = ""
+  var i = 0
+  while i < len(stories) {
+    let s = stories[i]
+    let line = "* [" + s.title + "](" + s.url + ")"
+    if i == 0 {
+      output = line
+    } else {
+      output = output + "\n" + line
+    }
+    i = i + 1
+  }
+  return output
+}
+
+print(hackernews_top_stories_as_markdown(5))

--- a/tests/github/TheAlgorithms/Mochi/web_programming/get_top_hn_posts.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/get_top_hn_posts.out
@@ -1,0 +1,5 @@
+* [Show HN: Kitten TTS – 25MB CPU-Only, Open-Source TTS Model](https://github.com/KittenML/KittenTTS)
+* [Open models by OpenAI](https://openai.com/open-models/)
+* [Marines now have an official drone-fighting handbook](https://www.marinecorpstimes.com/news/your-marine-corps/2025/08/04/the-marines-now-have-an-official-drone-fighting-handbook/)
+* [Software Rot](https://permacomputing.net/software_rot/)
+* [The Amaranth hardware description language](https://amaranth-lang.org/docs/amaranth/latest/intro.html#the-amaranth-language)

--- a/tests/github/TheAlgorithms/Python/web_programming/get_top_hn_posts.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/get_top_hn_posts.py
@@ -1,0 +1,33 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "httpx",
+# ]
+# ///
+
+from __future__ import annotations
+
+import httpx
+
+
+def get_hackernews_story(story_id: str) -> dict:
+    url = f"https://hacker-news.firebaseio.com/v0/item/{story_id}.json?print=pretty"
+    return httpx.get(url, timeout=10).json()
+
+
+def hackernews_top_stories(max_stories: int = 10) -> list[dict]:
+    """
+    Get the top max_stories posts from HackerNews - https://news.ycombinator.com/
+    """
+    url = "https://hacker-news.firebaseio.com/v0/topstories.json?print=pretty"
+    story_ids = httpx.get(url, timeout=10).json()[:max_stories]
+    return [get_hackernews_story(story_id) for story_id in story_ids]
+
+
+def hackernews_top_stories_as_markdown(max_stories: int = 10) -> str:
+    stories = hackernews_top_stories(max_stories)
+    return "\n".join("* [{title}]({url})".format(**story) for story in stories)
+
+
+if __name__ == "__main__":
+    print(hackernews_top_stories_as_markdown())


### PR DESCRIPTION
## Summary
- add Python reference implementation for fetching top Hacker News posts
- port the algorithm to Mochi and emit Markdown bullet list of titles and URLs

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/web_programming/get_top_hn_posts.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892f17669bc8320b0b52db2972dc9bb