### PR TITLE
Add Mochi example for Giphy GIF search

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/giphy.json
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/giphy.json
@@ -1,0 +1,1 @@
+[{"url": "https://example.com/1"}, {"url": "https://example.com/2"}, {"url": "https://example.com/3"}]

--- a/tests/github/TheAlgorithms/Mochi/web_programming/giphy.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/giphy.mochi
@@ -1,0 +1,43 @@
+/*
+Retrieve GIF URLs for a search query. The Python version sends an HTTP
+request to the Giphy API with the query terms joined by '+', then parses
+the JSON response to collect each GIF's canonical URL. This Mochi
+translation mirrors the data processing and URL formatting steps while
+using a locally stored JSON sample instead of making a network request.
+*/
+
+type Gif { url: string }
+
+fun format_query(q: string): string {
+  var result = ""
+  var i = 0
+  while i < len(q) {
+    let ch = q[i:i+1]
+    if ch == " " { result = result + "+" } else { result = result + ch }
+    i = i + 1
+  }
+  return result
+}
+
+fun join(xs: list<string>, sep: string): string {
+  if len(xs) == 0 { return "" }
+  var out = xs[0]
+  var i = 1
+  while i < len(xs) {
+    out = out + sep + xs[i]
+    i = i + 1
+  }
+  return out
+}
+
+fun get_gifs(query: string): list<string> {
+  let formatted = format_query(query)
+  let gifs = load "tests/github/TheAlgorithms/Mochi/web_programming/giphy.json" as Gif with { format: "json" }
+  var urls: list<string> = []
+  for g in gifs {
+    urls = append(urls, g.url)
+  }
+  return urls
+}
+
+print(join(get_gifs("space ship"), "\n"))

--- a/tests/github/TheAlgorithms/Mochi/web_programming/giphy.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/giphy.out
@@ -1,0 +1,3 @@
+https://example.com/1
+https://example.com/2
+https://example.com/3

--- a/tests/github/TheAlgorithms/Python/web_programming/giphy.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/giphy.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "httpx",
+# ]
+# ///
+
+import httpx
+
+giphy_api_key = "YOUR API KEY"
+# Can be fetched from https://developers.giphy.com/dashboard/
+
+
+def get_gifs(query: str, api_key: str = giphy_api_key) -> list:
+    """
+    Get a list of URLs of GIFs based on a given query..
+    """
+    formatted_query = "+".join(query.split())
+    url = f"https://api.giphy.com/v1/gifs/search?q={formatted_query}&api_key={api_key}"
+    gifs = httpx.get(url, timeout=10).json()["data"]
+    return [gif["url"] for gif in gifs]
+
+
+if __name__ == "__main__":
+    print("\n".join(get_gifs("space ship")))


### PR DESCRIPTION
## Summary
- add Python source for Giphy GIF search utility
- translate Giphy GIF search to pure Mochi using a local JSON sample

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/web_programming/giphy.mochi > tests/github/TheAlgorithms/Mochi/web_programming/giphy.out`


------
https://chatgpt.com/codex/tasks/task_e_6892f1781474832096f470be0a39e75a