### PR TITLE
Add Mochi port of Instagram crawler

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/instagram_crawler.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/instagram_crawler.mochi
@@ -1,0 +1,116 @@
+/*
+Instagram user information extraction.
+
+This program mirrors the behaviour of TheAlgorithms/Python
+`web_programming/instagram_crawler.py` in a simplified form.  Given a
+string containing JSON data embedded in an Instagram page, it extracts
+profile details such as the username, biography, follower counts and
+verification status.  The extraction is implemented purely in Mochi
+using basic string parsing helpers and avoids the use of FFI or the
+`any` type.  The sample JSON is embedded so the program can run without
+network access and demonstrates the parsing logic.
+*/
+
+type EdgeCount { count: int }
+
+type UserData {
+  username: string,
+  full_name: string,
+  biography: string,
+  business_email: string,
+  external_url: string,
+  edge_followed_by: EdgeCount,
+  edge_follow: EdgeCount,
+  edge_owner_to_timeline_media: EdgeCount,
+  profile_pic_url_hd: string,
+  is_verified: bool,
+  is_private: bool
+}
+
+fun index_of(s: string, sub: string): int {
+  var i = 0
+  while i <= len(s) - len(sub) {
+    if substring(s, i, i + len(sub)) == sub {
+      return i
+    }
+    i = i + 1
+  }
+  return -1
+}
+
+fun parse_int(s: string): int {
+  var value = 0
+  var i = 0
+  while i < len(s) {
+    value = value * 10 + (s[i] as int)
+    i = i + 1
+  }
+  return value
+}
+
+fun extract_string(text: string, key: string): string {
+  let pattern = "\"" + key + "\":\""
+  let start = index_of(text, pattern) + len(pattern)
+  var end = start
+  while end < len(text) && substring(text, end, end + 1) != "\"" {
+    end = end + 1
+  }
+  return substring(text, start, end)
+}
+
+fun extract_int(text: string, key: string): int {
+  let pattern = "\"" + key + "\":{\"count\":"
+  let start = index_of(text, pattern) + len(pattern)
+  var end = start
+  while end < len(text) {
+    let ch = text[end]
+    if ch < "0" || ch > "9" {
+      break
+    }
+    end = end + 1
+  }
+  let digits = substring(text, start, end)
+  let num = parse_int(digits)
+  return num
+}
+
+fun extract_bool(text: string, key: string): bool {
+  let pattern = "\"" + key + "\":"
+  let start = index_of(text, pattern) + len(pattern)
+  let val = substring(text, start, start + 5)
+  let first = val[0]
+  if first == "t" {
+    return true
+  }
+  return false
+}
+
+fun extract_user_profile(script: string): UserData {
+  return UserData {
+    username: extract_string(script, "username"),
+    full_name: extract_string(script, "full_name"),
+    biography: extract_string(script, "biography"),
+    business_email: extract_string(script, "business_email"),
+    external_url: extract_string(script, "external_url"),
+    edge_followed_by: EdgeCount { count: extract_int(script, "edge_followed_by") },
+    edge_follow: EdgeCount { count: extract_int(script, "edge_follow") },
+    edge_owner_to_timeline_media: EdgeCount { count: extract_int(script, "edge_owner_to_timeline_media") },
+    profile_pic_url_hd: extract_string(script, "profile_pic_url_hd"),
+    is_verified: extract_bool(script, "is_verified"),
+    is_private: extract_bool(script, "is_private")
+  }
+}
+
+let sample_script = "{\"entry_data\":{\"ProfilePage\":[{\"graphql\":{\"user\":{\"username\":\"github\",\"full_name\":\"GitHub\",\"biography\":\"Built for developers.\",\"business_email\":\"support@github.com\",\"external_url\":\"https://github.com/readme\",\"edge_followed_by\":{\"count\":120000},\"edge_follow\":{\"count\":16},\"edge_owner_to_timeline_media\":{\"count\":150},\"profile_pic_url_hd\":\"https://instagram.com/pic.jpg\",\"is_verified\":true,\"is_private\":false}}}]}}"
+
+let user = extract_user_profile(sample_script)
+
+print(user.full_name + " (" + user.username + ") is " + user.biography)
+print("number_of_posts = " + str(user.edge_owner_to_timeline_media.count))
+print("number_of_followers = " + str(user.edge_followed_by.count))
+print("number_of_followings = " + str(user.edge_follow.count))
+print("email = " + user.business_email)
+print("website = " + user.external_url)
+print("profile_picture_url = " + user.profile_pic_url_hd)
+print("is_verified = " + str(user.is_verified))
+print("is_private = " + str(user.is_private))

--- a/tests/github/TheAlgorithms/Mochi/web_programming/instagram_crawler.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/instagram_crawler.out
@@ -1,0 +1,9 @@
+GitHub (github) is Built for developers.
+number_of_posts = 150
+number_of_followers = 120000
+number_of_followings = 16
+email = support@github.com
+website = https://github.com/readme
+profile_picture_url = https://instagram.com/pic.jpg
+is_verified = true
+is_private = false

--- a/tests/github/TheAlgorithms/Python/web_programming/instagram_crawler.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/instagram_crawler.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "beautifulsoup4",
+#     "fake-useragent",
+#     "httpx",
+# ]
+# ///
+
+from __future__ import annotations
+
+import json
+
+import httpx
+from bs4 import BeautifulSoup
+from fake_useragent import UserAgent
+
+headers = {"UserAgent": UserAgent().random}
+
+
+def extract_user_profile(script) -> dict:
+    """
+    May raise json.decoder.JSONDecodeError
+    """
+    data = script.contents[0]
+    info = json.loads(data[data.find('{"config"') : -1])
+    return info["entry_data"]["ProfilePage"][0]["graphql"]["user"]
+
+
+class InstagramUser:
+    """
+    Class Instagram crawl instagram user information
+
+    Usage: (doctest failing on GitHub Actions)
+    # >>> instagram_user = InstagramUser("github")
+    # >>> instagram_user.is_verified
+    True
+    # >>> instagram_user.biography
+    'Built for developers.'
+    """
+
+    def __init__(self, username):
+        self.url = f"https://www.instagram.com/{username}/"
+        self.user_data = self.get_json()
+
+    def get_json(self) -> dict:
+        """
+        Return a dict of user information
+        """
+        html = httpx.get(self.url, headers=headers, timeout=10).text
+        scripts = BeautifulSoup(html, "html.parser").find_all("script")
+        try:
+            return extract_user_profile(scripts[4])
+        except (json.decoder.JSONDecodeError, KeyError):
+            return extract_user_profile(scripts[3])
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}('{self.username}')"
+
+    def __str__(self) -> str:
+        return f"{self.fullname} ({self.username}) is {self.biography}"
+
+    @property
+    def username(self) -> str:
+        return self.user_data["username"]
+
+    @property
+    def fullname(self) -> str:
+        return self.user_data["full_name"]
+
+    @property
+    def biography(self) -> str:
+        return self.user_data["biography"]
+
+    @property
+    def email(self) -> str:
+        return self.user_data["business_email"]
+
+    @property
+    def website(self) -> str:
+        return self.user_data["external_url"]
+
+    @property
+    def number_of_followers(self) -> int:
+        return self.user_data["edge_followed_by"]["count"]
+
+    @property
+    def number_of_followings(self) -> int:
+        return self.user_data["edge_follow"]["count"]
+
+    @property
+    def number_of_posts(self) -> int:
+        return self.user_data["edge_owner_to_timeline_media"]["count"]
+
+    @property
+    def profile_picture_url(self) -> str:
+        return self.user_data["profile_pic_url_hd"]
+
+    @property
+    def is_verified(self) -> bool:
+        return self.user_data["is_verified"]
+
+    @property
+    def is_private(self) -> bool:
+        return self.user_data["is_private"]
+
+
+def test_instagram_user(username: str = "github") -> None:
+    """
+    A self running doctest
+    >>> test_instagram_user()
+    """
+    import os
+
+    if os.environ.get("CI"):
+        return  # test failing on GitHub Actions
+    instagram_user = InstagramUser(username)
+    assert instagram_user.user_data
+    assert isinstance(instagram_user.user_data, dict)
+    assert instagram_user.username == username
+    if username != "github":
+        return
+    assert instagram_user.fullname == "GitHub"
+    assert instagram_user.biography == "Built for developers."
+    assert instagram_user.number_of_posts > 150
+    assert instagram_user.number_of_followers > 120000
+    assert instagram_user.number_of_followings > 15
+    assert instagram_user.email == "support@github.com"
+    assert instagram_user.website == "https://github.com/readme"
+    assert instagram_user.profile_picture_url.startswith("https://instagram.")
+    assert instagram_user.is_verified is True
+    assert instagram_user.is_private is False
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    instagram_user = InstagramUser("github")
+    print(instagram_user)
+    print(f"{instagram_user.number_of_posts = }")
+    print(f"{instagram_user.number_of_followers = }")
+    print(f"{instagram_user.number_of_followings = }")
+    print(f"{instagram_user.email = }")
+    print(f"{instagram_user.website = }")
+    print(f"{instagram_user.profile_picture_url = }")
+    print(f"{instagram_user.is_verified = }")
+    print(f"{instagram_user.is_private = }")


### PR DESCRIPTION
## Summary
- add the missing Python `instagram_crawler.py`
- port Instagram user crawler to pure Mochi using manual string parsing

## Testing
- `./mochi_bin run tests/github/TheAlgorithms/Mochi/web_programming/instagram_crawler.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892f17960c8832099194dc7762657ab