### PR TITLE
Add Mochi implementation for Instagram video downloader

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/instagram_video.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/instagram_video.mochi
@@ -1,0 +1,24 @@
+/*
+Problem: Download an Instagram video via the Downloadgram service.
+
+The reference Python implementation performs two HTTP requests:
+1. Combine the service endpoint with the Instagram post URL to create a request URL.
+2. Fetch that URL to obtain the direct video link, then download the video bytes
+   and save them to disk with a timestamped file name.
+
+This Mochi version focuses on the core URL construction step and prints the
+resulting download link. Network access and file operations are omitted so the
+program can run inside the VM without external dependencies.
+*/
+
+let base_url: string = "https://downloadgram.net/wp-json/wppress/video-downloader/video?url="
+
+
+fun download_video(url: string): string {
+  let request_url: string = base_url + url
+  return request_url
+}
+
+let sample_url: string = "https://www.instagram.com/p/Example/"
+let link: string = download_video(sample_url)
+print("Download link:", link)

--- a/tests/github/TheAlgorithms/Mochi/web_programming/instagram_video.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/instagram_video.out
@@ -1,0 +1,1 @@
+Download link: https://downloadgram.net/wp-json/wppress/video-downloader/video?url=https://www.instagram.com/p/Example/

--- a/tests/github/TheAlgorithms/Python/web_programming/instagram_video.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/instagram_video.py
@@ -1,0 +1,24 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "httpx",
+# ]
+# ///
+
+from datetime import UTC, datetime
+
+import httpx
+
+
+def download_video(url: str) -> bytes:
+    base_url = "https://downloadgram.net/wp-json/wppress/video-downloader/video?url="
+    video_url = httpx.get(base_url + url, timeout=10)
+    return httpx.get(video_url, timeout=10).content
+
+
+if __name__ == "__main__":
+    url = input("Enter Video/IGTV url: ").strip()
+    file_name = f"{datetime.now(tz=UTC).astimezone():%Y-%m-%d_%H-%M-%S}.mp4"
+    with open(file_name, "wb") as fp:
+        fp.write(download_video(url))
+    print(f"Done. Video saved to disk as {file_name}.")


### PR DESCRIPTION
## Summary
- add missing Python script for downloading Instagram videos
- implement Mochi version that constructs the Downloadgram request URL and outputs the link

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/web_programming/instagram_video.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6892f17b98c083208919be185bb5b9b9