### PR TITLE
Add Recaptcha verification example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/recaptcha_verification.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/recaptcha_verification.mochi
@@ -1,0 +1,86 @@
+/*
+Recaptcha Verification and Login Simulation
+
+This Mochi module is a lightweight adaptation of the Python example from
+TheAlgorithms repository.  It demonstrates the control flow of verifying a
+user's Recaptcha token before allowing a login.
+
+Algorithm overview:
+1. The client submits a username, password, and Recaptcha token via POST.
+2. The server sends these credentials along with a secret key to the
+   Recaptcha verification service.
+3. If the service validates the token and the username/password pair is
+   correct, the user is logged in and redirected; otherwise the login page is
+   rendered again.
+
+For demonstration this implementation mocks the network verification and user
+authentication steps.  It uses strictly typed records and maps without any
+foreign function interfaces.
+*/
+
+type Request {
+  method: string,
+  post: map<string, string>
+}
+
+fun http_post(secret: string, client: string): map<string, bool> {
+  let success = secret == "secretKey" && client == "clientKey"
+  return {"success": success}
+}
+
+fun authenticate(username: string, password: string): bool {
+  return username == "user" && password == "pass"
+}
+
+fun login(_user: string) {
+  // In a real application this would set session data
+}
+
+fun render(page: string): string {
+  return "render:" + page
+}
+
+fun redirect(url: string): string {
+  return "redirect:" + url
+}
+
+fun login_using_recaptcha(request: Request): string {
+  let secret_key = "secretKey"
+  if request.method != "POST" {
+    return render("login.html")
+  }
+  let username = request.post["username"]
+  let password = request.post["password"]
+  let client_key = request.post["g-recaptcha-response"]
+  let response = http_post(secret_key, client_key)
+  if response["success"] {
+    if authenticate(username, password) {
+      login(username)
+      return redirect("/your-webpage")
+    }
+  }
+  return render("login.html")
+}
+
+let get_request = Request { method: "GET", post: {} }
+print(login_using_recaptcha(get_request))
+
+let ok_request = Request {
+  method: "POST",
+  post: {
+    "username": "user",
+    "password": "pass",
+    "g-recaptcha-response": "clientKey"
+  }
+}
+print(login_using_recaptcha(ok_request))
+
+let bad_request = Request {
+  method: "POST",
+  post: {
+    "username": "user",
+    "password": "wrong",
+    "g-recaptcha-response": "clientKey"
+  }
+}
+print(login_using_recaptcha(bad_request))

--- a/tests/github/TheAlgorithms/Mochi/web_programming/recaptcha_verification.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/recaptcha_verification.out
@@ -1,0 +1,3 @@
+render:login.html
+redirect:/your-webpage
+render:login.html

--- a/tests/github/TheAlgorithms/Python/web_programming/recaptcha_verification.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/recaptcha_verification.py
@@ -1,0 +1,76 @@
+"""
+Recaptcha is a free captcha service offered by Google in order to secure websites and
+forms.  At https://www.google.com/recaptcha/admin/create you can create new recaptcha
+keys and see the keys that your have already created.
+* Keep in mind that recaptcha doesn't work with localhost
+When you create a recaptcha key, your will get two separate keys: ClientKey & SecretKey.
+ClientKey should be kept in your site's front end
+SecretKey should be kept in your site's  back end
+
+# An example HTML login form with recaptcha tag is shown below
+
+    <form action="" method="post">
+        <h2 class="text-center">Log in</h2>
+        {% csrf_token %}
+        <div class="form-group">
+            <input type="text" name="username" required="required">
+        </div>
+        <div class="form-group">
+            <input type="password" name="password" required="required">
+        </div>
+        <div class="form-group">
+            <button type="submit">Log in</button>
+        </div>
+        <!-- Below is the recaptcha tag of html -->
+        <div class="g-recaptcha" data-sitekey="ClientKey"></div>
+    </form>
+
+    <!-- Below is the recaptcha script to be kept inside html tag -->
+    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+
+Below a Django function for the views.py file contains a login form for demonstrating
+recaptcha verification.
+"""
+
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "httpx",
+# ]
+# ///
+
+import httpx
+
+try:
+    from django.contrib.auth import authenticate, login
+    from django.shortcuts import redirect, render
+except ImportError:
+    authenticate = login = render = redirect = print
+
+
+def login_using_recaptcha(request):
+    # Enter your recaptcha secret key here
+    secret_key = "secretKey"  # noqa: S105
+    url = "https://www.google.com/recaptcha/api/siteverify"
+
+    # when method is not POST, direct user to login page
+    if request.method != "POST":
+        return render(request, "login.html")
+
+    # from the frontend, get username, password, and client_key
+    username = request.POST.get("username")
+    password = request.POST.get("password")
+    client_key = request.POST.get("g-recaptcha-response")
+
+    # post recaptcha response to Google's recaptcha api
+    response = httpx.post(
+        url, data={"secret": secret_key, "response": client_key}, timeout=10
+    )
+    # if the recaptcha api verified our keys
+    if response.json().get("success", False):
+        # authenticate the user
+        user_in_database = authenticate(request, username=username, password=password)
+        if user_in_database:
+            login(request, user_in_database)
+            return redirect("/your-webpage")
+    return render(request, "login.html")


### PR DESCRIPTION
## Summary
- add missing Python source for Recaptcha verification
- implement equivalent Mochi demo without FFI and include runtime output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/web_programming/recaptcha_verification.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6892f180cdf88320aecde86bc314bc57