### PR TITLE
Add Open Library ISBN search example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/search_books_by_isbn.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/search_books_by_isbn.mochi
@@ -1,0 +1,147 @@
+/*
+Search books on Open Library by ISBN and display their details.
+
+This is a Mochi translation of TheAlgorithms/Python script
+"search_books_by_isbn".  The program normalizes an Open Library
+identifier (ISBN or author key), fetches JSON data from the
+Open Library API, and summarizes selected fields.
+
+Algorithm:
+1. Remove surrounding whitespace and slashes from the identifier.
+2. Ensure the identifier has exactly one '/'.
+3. Fetch the JSON document from https://openlibrary.org/{olid}.json
+   using Mochi's built in `fetch` expression.
+4. For book data, request each author record to obtain the author
+   names.
+5. Produce a summary containing title, publish date, authors,
+   number of pages, and ISBN numbers.
+
+The implementation uses only Mochi built-ins so it can run on the
+runtime/vm without any foreign interfaces.
+*/
+
+type AuthorRef {
+  key: string
+}
+
+type BookData {
+  title: string
+  publish_date: string
+  authors: list<AuthorRef>
+  number_of_pages: int
+  isbn_10: list<string>
+  isbn_13: list<string>
+}
+
+type AuthorData {
+  name: string
+}
+
+type BookSummary {
+  title: string
+  publish_date: string
+  authors: string
+  number_of_pages: int
+  isbn_10: string
+  isbn_13: string
+}
+
+fun join(xs: list<string>, sep: string): string {
+  var res = ""
+  var i = 0
+  while i < len(xs) {
+    if i > 0 { res = res + sep }
+    res = res + xs[i]
+    i = i + 1
+  }
+  return res
+}
+
+fun count_char(s: string, ch: string): int {
+  var cnt = 0
+  var i = 0
+  while i < len(s) {
+    if substring(s, i, i + 1) == ch { cnt = cnt + 1 }
+    i = i + 1
+  }
+  return cnt
+}
+
+fun strip(s: string): string {
+  var start = 0
+  var end = len(s)
+  while start < end && substring(s, start, start + 1) == " " {
+    start = start + 1
+  }
+  while end > start && substring(s, end - 1, end) == " " {
+    end = end - 1
+  }
+  return s[start:end]
+}
+
+fun trim_slashes(s: string): string {
+  var start = 0
+  var end = len(s)
+  while start < end && substring(s, start, start + 1) == "/" {
+    start = start + 1
+  }
+  while end > start && substring(s, end - 1, end) == "/" {
+    end = end - 1
+  }
+  return s[start:end]
+}
+
+fun normalize_olid(olid: string): string {
+  let stripped = strip(olid)
+  let cleaned = trim_slashes(stripped)
+  if count_char(cleaned, "/") != 1 {
+    panic(olid + " is not a valid Open Library olid")
+  }
+  return cleaned
+}
+
+fun get_book_data(olid: string): BookData {
+  let norm = normalize_olid(olid)
+  let url = "https://openlibrary.org/" + norm + ".json"
+  let data: BookData = fetch url
+  return data
+}
+
+fun get_author_data(olid: string): AuthorData {
+  let norm = normalize_olid(olid)
+  let url = "https://openlibrary.org/" + norm + ".json"
+  let data: AuthorData = fetch url
+  return data
+}
+
+fun summarize_book(book: BookData): BookSummary {
+  var names: list<string> = []
+  var i = 0
+  while i < len(book.authors) {
+    let ref = book.authors[i]
+    let auth = get_author_data(ref.key)
+    names = append(names, auth.name)
+    i = i + 1
+  }
+  return BookSummary{
+    title: book.title,
+    publish_date: book.publish_date,
+    authors: join(names, ", "),
+    number_of_pages: book.number_of_pages,
+    isbn_10: join(book.isbn_10, ", "),
+    isbn_13: join(book.isbn_13, ", "),
+  }
+}
+
+fun main() {
+  let book = get_book_data("isbn/0140328726")
+  let summary = summarize_book(book)
+  print("Title: " + summary.title)
+  print("Publish date: " + summary.publish_date)
+  print("Authors: " + summary.authors)
+  print("Number of pages: " + str(summary.number_of_pages))
+  print("ISBN (10): " + summary.isbn_10)
+  print("ISBN (13): " + summary.isbn_13)
+}
+
+main()

--- a/tests/github/TheAlgorithms/Mochi/web_programming/search_books_by_isbn.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/search_books_by_isbn.out
@@ -1,0 +1,6 @@
+Title: Fantastic Mr. Fox
+Publish date: October 1, 1988
+Authors: Roald Dahl
+Number of pages: 96
+ISBN (10): 0140328726
+ISBN (13): 9780140328721

--- a/tests/github/TheAlgorithms/Python/web_programming/search_books_by_isbn.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/search_books_by_isbn.py
@@ -1,0 +1,82 @@
+"""
+Get book and author data from https://openlibrary.org
+
+ISBN: https://en.wikipedia.org/wiki/International_Standard_Book_Number
+"""
+
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "httpx",
+# ]
+# ///
+
+from json import JSONDecodeError
+
+import httpx
+
+
+def get_openlibrary_data(olid: str = "isbn/0140328726") -> dict:
+    """
+    Given an 'isbn/0140328726', return book data from Open Library as a Python dict.
+    Given an '/authors/OL34184A', return authors data as a Python dict.
+    This code must work for olids with or without a leading slash ('/').
+
+    # Comment out doctests if they take too long or have results that may change
+    # >>> get_openlibrary_data(olid='isbn/0140328726')  # doctest: +ELLIPSIS
+    {'publishers': ['Puffin'], 'number_of_pages': 96, 'isbn_10': ['0140328726'], ...
+    # >>> get_openlibrary_data(olid='/authors/OL7353617A')  # doctest: +ELLIPSIS
+    {'name': 'Adrian Brisku', 'created': {'type': '/type/datetime', ...
+    """
+    new_olid = olid.strip().strip("/")  # Remove leading/trailing whitespace & slashes
+    if new_olid.count("/") != 1:
+        msg = f"{olid} is not a valid Open Library olid"
+        raise ValueError(msg)
+    return httpx.get(
+        f"https://openlibrary.org/{new_olid}.json", timeout=10, follow_redirects=True
+    ).json()
+
+
+def summarize_book(ol_book_data: dict) -> dict:
+    """
+    Given Open Library book data, return a summary as a Python dict.
+    """
+    desired_keys = {
+        "title": "Title",
+        "publish_date": "Publish date",
+        "authors": "Authors",
+        "number_of_pages": "Number of pages",
+        "isbn_10": "ISBN (10)",
+        "isbn_13": "ISBN (13)",
+    }
+    data = {better_key: ol_book_data[key] for key, better_key in desired_keys.items()}
+    data["Authors"] = [
+        get_openlibrary_data(author["key"])["name"] for author in data["Authors"]
+    ]
+    for key, value in data.items():
+        if isinstance(value, list):
+            data[key] = ", ".join(value)
+    return data
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+
+    while True:
+        isbn = input("\nEnter the ISBN code to search (or 'quit' to stop): ").strip()
+        if isbn.lower() in ("", "q", "quit", "exit", "stop"):
+            break
+
+        if len(isbn) not in (10, 13) or not isbn.isdigit():
+            print(f"Sorry, {isbn} is not a valid ISBN.  Please, input a valid ISBN.")
+            continue
+
+        print(f"\nSearching Open Library for ISBN: {isbn}...\n")
+
+        try:
+            book_summary = summarize_book(get_openlibrary_data(f"isbn/{isbn}"))
+            print("\n".join(f"{key}: {value}" for key, value in book_summary.items()))
+        except JSONDecodeError:
+            print(f"Sorry, there are no results for ISBN: {isbn}.")


### PR DESCRIPTION
## Summary
- import Python search example for retrieving book info by ISBN from Open Library
- add Mochi version that fetches book and author details and prints a summary

## Testing
- `./bin/mochi run tests/github/TheAlgorithms/Mochi/web_programming/search_books_by_isbn.mochi`
- `go test ./...`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6892f184f1d48320a5dbfff9e89d0507