### PR TITLE
Add Mochi implementation for Slack webhook

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/slack_message.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/slack_message.mochi
@@ -1,0 +1,27 @@
+/*
+Slack Message via Webhook
+
+This program demonstrates how to send a message to a Slack channel using
+an incoming webhook.  The message text is wrapped in a JSON object and
+sent via an HTTP POST request.  If the server does not respond with the
+string "ok" then an error is raised, mirroring Slack's webhook behaviour.
+*/
+
+fun send_slack_message(message_body: string, slack_url: string): string {
+  let headers = {
+    "Content-Type": "application/json"
+  }
+  let response: string = fetch slack_url as string with {
+    method: "POST",
+    headers: headers,
+    body: { text: message_body }
+  }
+  if response != "ok" {
+    error("Request to slack returned an error: " + response)
+  }
+  return response
+}
+
+let url = "https://httpbin.org/post"
+send_slack_message("Hello from Mochi", url)
+print("Message sent")

--- a/tests/github/TheAlgorithms/Mochi/web_programming/slack_message.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/slack_message.out
@@ -1,0 +1,1 @@
+Message sent

--- a/tests/github/TheAlgorithms/Python/web_programming/slack_message.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/slack_message.py
@@ -1,0 +1,29 @@
+# Created by sarathkaul on 12/11/19
+
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "httpx",
+# ]
+# ///
+
+import httpx
+
+
+def send_slack_message(message_body: str, slack_url: str) -> None:
+    headers = {"Content-Type": "application/json"}
+    response = httpx.post(
+        slack_url, json={"text": message_body}, headers=headers, timeout=10
+    )
+    if response.status_code != 200:
+        msg = (
+            "Request to slack returned an error "
+            f"{response.status_code}, the response is:\n{response.text}"
+        )
+        raise ValueError(msg)
+
+
+if __name__ == "__main__":
+    # Set the slack url to the one provided by Slack when you create the webhook at
+    # https://my.slack.com/services/new/incoming-webhook/
+    send_slack_message("<YOUR MESSAGE BODY>", "<SLACK CHANNEL URL>")


### PR DESCRIPTION
## Summary
- add upstream Python `slack_message` example
- implement Slack webhook posting in pure Mochi
- record runtime output

## Testing
- `go run ./cmd/mochi run tests/github/TheAlgorithms/Mochi/web_programming/slack_message.mochi > tests/github/TheAlgorithms/Mochi/web_programming/slack_message.out 2>&1`


------
https://chatgpt.com/codex/tasks/task_e_6892f185bf5c83209d0ec88690794888