### PR TITLE
Add Mochi world COVID stats example

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/world_covid19_stats.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/world_covid19_stats.mochi
@@ -1,0 +1,75 @@
+/*
+Collect worldwide COVID-19 statistics by scraping an HTML page.
+
+This example mimics the behaviour of the Python implementation which
+fetches data from "https://www.worldometers.info/coronavirus/".
+Since Mochi's standard library does not include an HTML parser or HTTP
+client, a small sample of the page is embedded and parsed manually.
+The algorithm scans the HTML for heading tags (<h1>) and panel titles
+(<span class="panel-title">) to gather statistic labels. It similarly
+extracts the numerical values from elements with classes
+"maincounter-number" and "number-table-main". Labels and values are
+paired in the order found and printed.
+*/
+
+fun index_of(s: string, sub: string, start: int): int {
+  let n = len(s)
+  let m = len(sub)
+  var i = start
+  while i <= n - m {
+    var j = 0
+    while j < m && s[i + j:i + j + 1] == sub[j:j + 1] {
+      j = j + 1
+    }
+    if j == m {
+      return i
+    }
+    i = i + 1
+  }
+  return -1
+}
+
+fun find_all(html: string, open: string, close: string): list<string> {
+  var res: list<string> = []
+  var pos = 0
+  let ol = len(open)
+  let cl = len(close)
+  while true {
+    let start = index_of(html, open, pos)
+    if start == -1 { break }
+    let begin = start + ol
+    let end = index_of(html, close, begin)
+    if end == -1 { break }
+    res = append(res, html[begin:end])
+    pos = end + cl
+  }
+  return res
+}
+
+fun world_covid19_stats(html: string): list<list<string>> {
+  var keys = find_all(html, "<h1>", "</h1>")
+  var values = find_all(html, "<div class=\"maincounter-number\"><span>", "</span></div>")
+  let extra_keys = find_all(html, "<span class=\"panel-title\">", "</span>")
+  for k in extra_keys { keys = append(keys, k) }
+  let extra_vals = find_all(html, "<div class=\"number-table-main\">", "</div>")
+  for v in extra_vals { values = append(values, v) }
+  var res: list<list<string>> = []
+  var i = 0
+  while i < len(keys) && i < len(values) {
+    res = append(res, [keys[i], values[i]])
+    i = i + 1
+  }
+  return res
+}
+
+let sample_html: string = "<h1>Coronavirus Cases:</h1><div class=\"maincounter-number\"><span>100</span></div><h1>Deaths:</h1><div class=\"maincounter-number\"><span>10</span></div><h1>Recovered:</h1><div class=\"maincounter-number\"><span>50</span></div><span class=\"panel-title\">Active Cases</span><div class=\"number-table-main\">20</div><span class=\"panel-title\">Closed Cases</span><div class=\"number-table-main\">80</div>"
+
+let stats = world_covid19_stats(sample_html)
+
+print("COVID-19 Status of the World\n")
+var i = 0
+while i < len(stats) {
+  print(stats[i][0])
+  print(stats[i][1])
+  i = i + 1
+}

--- a/tests/github/TheAlgorithms/Mochi/web_programming/world_covid19_stats.mochi.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/world_covid19_stats.mochi.out
@@ -1,0 +1,12 @@
+COVID-19 Status of the World
+
+Coronavirus Cases:
+100
+Deaths:
+10
+Recovered:
+50
+Active Cases
+20
+Closed Cases
+80

--- a/tests/github/TheAlgorithms/Python/web_programming/world_covid19_stats.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/world_covid19_stats.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+"""
+Provide the current worldwide COVID-19 statistics.
+This data is being scrapped from 'https://www.worldometers.info/coronavirus/'.
+"""
+
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "beautifulsoup4",
+#     "httpx",
+# ]
+# ///
+
+import httpx
+from bs4 import BeautifulSoup
+
+
+def world_covid19_stats(
+    url: str = "https://www.worldometers.info/coronavirus/",
+) -> dict:
+    """
+    Return a dict of current worldwide COVID-19 statistics
+    """
+    soup = BeautifulSoup(
+        httpx.get(url, timeout=10, follow_redirects=True).text, "html.parser"
+    )
+    keys = soup.find_all("h1")
+    values = soup.find_all("div", {"class": "maincounter-number"})
+    keys += soup.find_all("span", {"class": "panel-title"})
+    values += soup.find_all("div", {"class": "number-table-main"})
+    return {key.text.strip(): value.text.strip() for key, value in zip(keys, values)}
+
+
+if __name__ == "__main__":
+    print("\033[1m COVID-19 Status of the World \033[0m\n")
+    print("\n".join(f"{key}\n{value}" for key, value in world_covid19_stats().items()))


### PR DESCRIPTION
## Summary
- add Python reference for world_covid19_stats
- implement matching Mochi script that parses sample HTML and prints stats

## Testing
- `go test ./...` *(partial output, then interrupted)*
- `node install.js` *(failed: connect ENETUNREACH 140.82.113.3:443)*

------
https://chatgpt.com/codex/tasks/task_e_6892f18821548320b601c3a796cfdd6b