### PR TITLE
feat: add Instagram picture meta tag parser

### DIFF
--- a/tests/github/TheAlgorithms/Mochi/web_programming/instagram_pic.mochi
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/instagram_pic.mochi
@@ -1,0 +1,53 @@
+/*
+Instagram Picture URL Extraction
+
+The original Python algorithm downloads an Instagram page, searches
+for the `<meta property="og:image">` tag that stores the preview image,
+retrieves the image URL, and saves the image to a timestamped file.
+
+This Mochi version focuses on the HTML parsing logic without performing
+network requests or file I/O.  Given the HTML source of a page, it scans
+for the first meta tag with `property="og:image"` and extracts the value of
+the `content` attribute.  If the tag or attribute is missing, an
+informative message is returned.  The search is implemented with a
+simple O(n * m) substring scan.
+*/
+
+fun find_from(s: string, pattern: string, start: int): int {
+  let n: int = len(s)
+  let m: int = len(pattern)
+  var i: int = start
+  while i <= n - m {
+    if substring(s, i, i + m) == pattern {
+      return i
+    }
+    i = i + 1
+  }
+  return -1
+}
+
+fun download_image(html: string): string {
+  let tag: string = "<meta property=\"og:image\""
+  let idx_tag: int = find_from(html, tag, 0)
+  if idx_tag == -1 {
+    return "No meta tag with property 'og:image' was found."
+  }
+  let key: string = "content=\""
+  let idx_content: int = find_from(html, key, idx_tag)
+  if idx_content == -1 {
+    return "Image URL not found in meta tag."
+  }
+  let start: int = idx_content + len(key)
+  var end: int = start
+  while end < len(html) and substring(html, end, end + 1) != "\"" {
+    end = end + 1
+  }
+  if end >= len(html) {
+    return "Image URL not found in meta tag."
+  }
+  let image_url: string = substring(html, start, end)
+  return "Image URL: " + image_url
+}
+
+let sample_html: string = "<html><head><meta property=\"og:image\" content=\"https://example.com/pic.jpg\"/></head></html>"
+print(download_image(sample_html))

--- a/tests/github/TheAlgorithms/Mochi/web_programming/instagram_pic.out
+++ b/tests/github/TheAlgorithms/Mochi/web_programming/instagram_pic.out
@@ -1,0 +1,1 @@
+Image URL: https://example.com/pic.jpg

--- a/tests/github/TheAlgorithms/Python/web_programming/instagram_pic.py
+++ b/tests/github/TheAlgorithms/Python/web_programming/instagram_pic.py
@@ -1,0 +1,55 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "beautifulsoup4",
+#     "httpx",
+# ]
+# ///
+
+from datetime import UTC, datetime
+
+import httpx
+from bs4 import BeautifulSoup
+
+
+def download_image(url: str) -> str:
+    """
+    Download an image from a given URL by scraping the 'og:image' meta tag.
+
+    Parameters:
+        url: The URL to scrape.
+
+    Returns:
+        A message indicating the result of the operation.
+    """
+    try:
+        response = httpx.get(url, timeout=10)
+        response.raise_for_status()
+    except httpx.RequestError as e:
+        return f"An error occurred during the HTTP request to {url}: {e!r}"
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    image_meta_tag = soup.find("meta", {"property": "og:image"})
+    if not image_meta_tag:
+        return "No meta tag with property 'og:image' was found."
+
+    image_url = image_meta_tag.get("content")
+    if not image_url:
+        return f"Image URL not found in meta tag {image_meta_tag}."
+
+    try:
+        image_data = httpx.get(image_url, timeout=10).content
+    except httpx.RequestError as e:
+        return f"An error occurred during the HTTP request to {image_url}: {e!r}"
+    if not image_data:
+        return f"Failed to download the image from {image_url}."
+
+    file_name = f"{datetime.now(tz=UTC).astimezone():%Y-%m-%d_%H-%M-%S}.jpg"
+    with open(file_name, "wb") as out_file:
+        out_file.write(image_data)
+    return f"Image downloaded and saved in the file {file_name}"
+
+
+if __name__ == "__main__":
+    url = input("Enter image URL: ").strip() or "https://www.instagram.com"
+    print(f"download_image({url}): {download_image(url)}")


### PR DESCRIPTION
## Summary
- add Python source for `web_programming/instagram_pic`
- implement HTML `og:image` extractor in Mochi and add sample output

## Testing
- `node runtime/vm tests/github/TheAlgorithms/Mochi/web_programming/instagram_pic.mochi` *(fails: Cannot find module '/workspace/mochi/runtime/vm')*
- `npm install` *(fails: connect ENETUNREACH 140.82.114.3:443)*

------
https://chatgpt.com/codex/tasks/task_e_6892f17aa9048320a3ae11d3ed5fd0be