### PR TITLE
feat: add proxy support to install script

### DIFF
--- a/install.js
+++ b/install.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const tar = require('tar');
+const { HttpsProxyAgent } = require('https-proxy-agent');
 
 const osMap = { darwin: 'Darwin', linux: 'Linux', win32: 'Windows' };
 const archMap = { x64: 'x86_64', arm64: 'arm64' };
@@ -20,16 +21,25 @@ const destDir = path.join(__dirname, 'bin');
 const destFile = path.join(destDir, filename);
 const binaryName = process.platform === 'win32' ? 'mochi.exe' : 'mochi';
 
+const proxy = process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy;
+const agent = proxy ? new HttpsProxyAgent(proxy) : undefined;
+
 fs.mkdirSync(destDir, { recursive: true });
 
 function download(url, outputPath) {
   return new Promise((resolve, reject) => {
-    const file = fs.createWriteStream(outputPath);
-    https.get(url, res => {
+    const options = {};
+    if (agent) options.agent = agent;
+    https.get(url, options, res => {
+      if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        download(res.headers.location, outputPath).then(resolve).catch(reject);
+        return;
+      }
       if (res.statusCode !== 200) {
         reject(new Error(`Failed to download ${url}: ${res.statusCode}`));
         return;
       }
+      const file = fs.createWriteStream(outputPath);
       res.pipe(file);
       file.on('finish', () => file.close(resolve));
     }).on('error', reject);
@@ -52,7 +62,12 @@ async function run() {
     }
     console.log('Mochi binary installed to', destDir);
   } catch (err) {
-    console.error('Failed to install Mochi binary:', err);
+    console.error('Failed to install Mochi binary:', err.message || err);
+    if (proxy) {
+      console.error(`Tried to use proxy: ${proxy}`);
+    } else {
+      console.error('If you are behind a proxy, set the HTTPS_PROXY environment variable.');
+    }
     process.exit(1);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,22 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "https-proxy-agent": "^7.0.2",
         "tar": "^6.2.0",
         "tree-sitter": "^0.22.4",
         "tree-sitter-ocaml": "^0.24.2"
       },
       "bin": {
         "mochi": "index.js"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/chownr": {
@@ -25,6 +35,23 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/fs-minipass": {
@@ -49,6 +76,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/minipass": {
@@ -96,6 +136,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/node-addon-api": {
       "version": "8.5.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "tar": "^6.2.0",
     "tree-sitter": "^0.22.4",
-    "tree-sitter-ocaml": "^0.24.2"
+    "tree-sitter-ocaml": "^0.24.2",
+    "https-proxy-agent": "^7.0.2"
   }
 }


### PR DESCRIPTION
## Summary
- support HTTPS_PROXY/HTTP_PROXY env variables when downloading Mochi binary
- follow HTTP redirects and improve install error messaging
- add https-proxy-agent dependency

## Testing
- `npm test` (fails: Missing script: "test")
- `node install.js` (fails: ENOENT: no such file or directory, chmod '/workspace/mochi/bin/mochi')

------
https://chatgpt.com/codex/tasks/task_e_68932c3a99d483208f2ab7acc94f20f1