### PR TITLE
feat: add proxy support to installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ mochi cheatsheet
 
 It’s a single binary — no dependencies, no setup.
 
+### npx
+
+You can also run Mochi via `npx`, which downloads the prebuilt binary on demand:
+
+```bash
+npx @mochilang/mochi run examples/hello.mochi
+```
+
+If you’re behind a proxy or need a custom mirror, set `HTTPS_PROXY` or
+`MOCHI_BINARY_BASE_URL` before installing so the script can fetch the binary.
+
 ### Docker
 
 Use Docker to run Mochi without installing anything:

--- a/install.js
+++ b/install.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const tar = require('tar');
+const { HttpsProxyAgent } = require('https-proxy-agent');
 
 const osMap = { darwin: 'Darwin', linux: 'Linux', win32: 'Windows' };
 const archMap = { x64: 'x86_64', arm64: 'arm64' };
@@ -15,7 +16,9 @@ if (!platform || !arch) {
 }
 
 const filename = `mochi_${platform}_${arch}.tar.gz`;
-const url = `https://github.com/mochilang/mochi/releases/latest/download/${filename}`;
+let baseUrl = process.env.MOCHI_BINARY_BASE_URL || 'https://github.com/mochilang/mochi/releases/latest/download';
+if (baseUrl.endsWith('/')) baseUrl = baseUrl.slice(0, -1);
+const url = `${baseUrl}/${filename}`;
 const destDir = path.join(__dirname, 'bin');
 const destFile = path.join(destDir, filename);
 const binaryName = process.platform === 'win32' ? 'mochi.exe' : 'mochi';
@@ -24,15 +27,23 @@ fs.mkdirSync(destDir, { recursive: true });
 
 function download(url, outputPath) {
   return new Promise((resolve, reject) => {
-    const file = fs.createWriteStream(outputPath);
-    https.get(url, res => {
-      if (res.statusCode !== 200) {
-        reject(new Error(`Failed to download ${url}: ${res.statusCode}`));
-        return;
-      }
-      res.pipe(file);
-      file.on('finish', () => file.close(resolve));
-    }).on('error', reject);
+    const proxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+    const options = proxy ? { agent: new HttpsProxyAgent(proxy) } : {};
+    https
+      .get(url, options, res => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          download(res.headers.location, outputPath).then(resolve).catch(reject);
+          return;
+        }
+        if (res.statusCode !== 200) {
+          reject(new Error(`Failed to download ${url}: ${res.statusCode}`));
+          return;
+        }
+        const file = fs.createWriteStream(outputPath);
+        res.pipe(file);
+        file.on('finish', () => file.close(resolve));
+      })
+      .on('error', reject);
   });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,22 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "https-proxy-agent": "^7.0.2",
         "tar": "^6.2.0",
         "tree-sitter": "^0.22.4",
         "tree-sitter-ocaml": "^0.24.2"
       },
       "bin": {
         "mochi": "index.js"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/chownr": {
@@ -25,6 +35,23 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/fs-minipass": {
@@ -49,6 +76,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/minipass": {
@@ -96,6 +136,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/node-addon-api": {
       "version": "8.5.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "tar": "^6.2.0",
     "tree-sitter": "^0.22.4",
-    "tree-sitter-ocaml": "^0.24.2"
+    "tree-sitter-ocaml": "^0.24.2",
+    "https-proxy-agent": "^7.0.2"
   }
 }


### PR DESCRIPTION
## Summary
- allow configuring Mochi binary download via `MOCHI_BINARY_BASE_URL`
- support `HTTPS_PROXY` and follow HTTP redirects during installer download
- document `npx` usage and proxy/mirror env vars

## Testing
- `npm test` (fails: Missing script: "test")
- `node install.js` (fails: ENOENT: no such file or directory, chmod '/workspace/mochi/bin/mochi')

------
https://chatgpt.com/codex/tasks/task_e_68932bf7469883209d6fb3cdb6dde6fe