### PR TITLE
feat: support proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ CGO_ENABLED=0 go build -o vmreport ./tools/vmreport
 
 This installs `mochi` into `~/bin` and runs the full test suite.
 
+### Installing behind a proxy
+
+If you're running `npm install` behind a corporate proxy, avoid using the deprecated `http-proxy` environment variable. Instead, set `HTTPS_PROXY`, `HTTP_PROXY`, or `npm_config_proxy`. The installer respects these variables when downloading the Mochi binary.
+
 ## Usage with Visual Studio Code
 
 There is a VS Code extension under `tools/vscode` that bundles the Mochi language syntax. Run `npm install` and `npm run package` in that folder to build `mochi.vsix` for local installation.

--- a/install.js
+++ b/install.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const tar = require('tar');
+const { HttpsProxyAgent } = require('https-proxy-agent');
 
 const osMap = { darwin: 'Darwin', linux: 'Linux', win32: 'Windows' };
 const archMap = { x64: 'x86_64', arm64: 'arm64' };
@@ -25,7 +26,15 @@ fs.mkdirSync(destDir, { recursive: true });
 function download(url, outputPath) {
   return new Promise((resolve, reject) => {
     const file = fs.createWriteStream(outputPath);
-    https.get(url, res => {
+    const proxy =
+      process.env.HTTPS_PROXY ||
+      process.env.https_proxy ||
+      process.env.HTTP_PROXY ||
+      process.env.http_proxy ||
+      process.env.npm_config_https_proxy ||
+      process.env.npm_config_proxy;
+    const options = proxy ? { agent: new HttpsProxyAgent(proxy) } : {};
+    https.get(url, options, res => {
       if (res.statusCode !== 200) {
         reject(new Error(`Failed to download ${url}: ${res.statusCode}`));
         return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,22 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "https-proxy-agent": "^7.0.2",
         "tar": "^6.2.0",
         "tree-sitter": "^0.22.4",
         "tree-sitter-ocaml": "^0.24.2"
       },
       "bin": {
         "mochi": "index.js"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/chownr": {
@@ -25,6 +35,23 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/fs-minipass": {
@@ -49,6 +76,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/minipass": {
@@ -96,6 +136,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/node-addon-api": {
       "version": "8.5.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "postinstall": "node install.js"
   },
   "dependencies": {
+    "https-proxy-agent": "^7.0.2",
     "tar": "^6.2.0",
     "tree-sitter": "^0.22.4",
     "tree-sitter-ocaml": "^0.24.2"


### PR DESCRIPTION
## Summary
- document proxy env vars so `http-proxy` warning no longer appears
- add proxy support in installer via `https-proxy-agent`

## Testing
- `npm install --ignore-scripts`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68932bd497088320aeb75dd5962b457c