### PR TITLE
php: handle serialize builtin

### DIFF
--- a/tests/algorithms/x/PHP/data_structures/binary_tree/serialize_deserialize_binary_tree.bench
+++ b/tests/algorithms/x/PHP/data_structures/binary_tree/serialize_deserialize_binary_tree.bench
@@ -1,0 +1,1 @@
+Fatal error: Cannot redeclare function serialize() in /workspace/mochi/tests/algorithms/x/PHP/data_structures/binary_tree/serialize_deserialize_binary_tree.php on line 83

--- a/tests/algorithms/x/PHP/data_structures/binary_tree/serialize_deserialize_binary_tree.error
+++ b/tests/algorithms/x/PHP/data_structures/binary_tree/serialize_deserialize_binary_tree.error
@@ -1,0 +1,3 @@
+run: exit status 255
+
+Fatal error: Cannot redeclare function serialize() in /workspace/mochi/tests/algorithms/x/PHP/data_structures/binary_tree/serialize_deserialize_binary_tree.php on line 83

--- a/tests/algorithms/x/PHP/data_structures/binary_tree/serialize_deserialize_binary_tree.php
+++ b/tests/algorithms/x/PHP/data_structures/binary_tree/serialize_deserialize_binary_tree.php
@@ -1,0 +1,134 @@
+<?php
+ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+function _str($x) {
+    if (is_array($x)) {
+        $isList = array_keys($x) === range(0, count($x) - 1);
+        if ($isList) {
+            $parts = [];
+            foreach ($x as $v) { $parts[] = _str($v); }
+            return '[' . implode(' ', $parts) . ']';
+        }
+        $parts = [];
+        foreach ($x as $k => $v) { $parts[] = _str($k) . ':' . _str($v); }
+        return 'map[' . implode(' ', $parts) . ']';
+    }
+    if (is_bool($x)) return $x ? 'true' : 'false';
+    if ($x === null) return 'null';
+    return strval($x);
+}
+function _append($arr, $x) {
+    $arr[] = $x;
+    return $arr;
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function digit($ch) {
+  $digits = '0123456789';
+  $i = 0;
+  while ($i < strlen($digits)) {
+  if (substr($digits, $i, $i + 1 - $i) == $ch) {
+  return $i;
+}
+  $i = $i + 1;
+};
+  return 0;
+};
+  function to_int($s) {
+  $i = 0;
+  $sign = 1;
+  if (strlen($s) > 0 && substr($s, 0, 1 - 0) == '-') {
+  $sign = -1;
+  $i = 1;
+}
+  $num = 0;
+  while ($i < strlen($s)) {
+  $ch = substr($s, $i, $i + 1 - $i);
+  $num = $num * 10 + digit($ch);
+  $i = $i + 1;
+};
+  return $sign * $num;
+};
+  function split($s, $sep) {
+  $res = [];
+  $current = '';
+  $i = 0;
+  while ($i < strlen($s)) {
+  $ch = substr($s, $i, $i + 1 - $i);
+  if ($ch == $sep) {
+  $res = _append($res, $current);
+  $current = '';
+} else {
+  $current = $current . $ch;
+}
+  $i = $i + 1;
+};
+  $res = _append($res, $current);
+  return $res;
+};
+  function mochi_serialize($node) {
+  return (function($__v) {
+  if ($__v['__tag'] === "Empty") {
+    return 'null';
+  } elseif ($__v['__tag'] === "Node") {
+    $l = $__v["left"];
+    $v = $__v["value"];
+    $r = $__v["right"];
+    return _str($v) . ',' . mochi_serialize($l) . ',' . mochi_serialize($r);
+  }
+})($node);
+};
+  function build($nodes, $idx) {
+  $value = $nodes[$idx];
+  if ($value == 'null') {
+  return ['node' => ['__tag' => 'Empty'], 'next' => $idx + 1];
+}
+  $left_res = build($nodes, $idx + 1);
+  $right_res = build($nodes, $left_res['next']);
+  $node = ['__tag' => 'Node', 'left' => $left_res['node'], 'value' => to_int($value), 'right' => $right_res['node']];
+  return ['node' => $node, 'next' => $right_res['next']];
+};
+  function deserialize($data) {
+  $nodes = explode(',', $data);
+  $res = build($nodes, 0);
+  return $res['node'];
+};
+  function five_tree() {
+  $left_child = ['__tag' => 'Node', 'left' => 2, 'value' => ['__tag' => 'Empty'], 'right' => ['__tag' => 'Empty']];
+  $right_left = ['__tag' => 'Node', 'left' => 4, 'value' => ['__tag' => 'Empty'], 'right' => ['__tag' => 'Empty']];
+  $right_right = ['__tag' => 'Node', 'left' => 5, 'value' => ['__tag' => 'Empty'], 'right' => ['__tag' => 'Empty']];
+  $right_child = ['__tag' => 'Node', 'left' => 3, 'value' => $right_left, 'right' => $right_right];
+  return ['__tag' => 'Node', 'left' => 1, 'value' => $left_child, 'right' => $right_child];
+};
+  function main() {
+  $root = five_tree();
+  $serial = mochi_serialize($root);
+  echo rtrim($serial), PHP_EOL;
+  $rebuilt = deserialize($serial);
+  $serial2 = mochi_serialize($rebuilt);
+  echo rtrim($serial2), PHP_EOL;
+  echo rtrim(($serial == $serial2 ? 'true' : 'false')), PHP_EOL;
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/binary_tree/symmetric_tree.bench
+++ b/tests/algorithms/x/PHP/data_structures/binary_tree/symmetric_tree.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 131,
+  "memory_bytes": 39992,
+  "name": "main"
+}

--- a/tests/algorithms/x/PHP/data_structures/binary_tree/symmetric_tree.out
+++ b/tests/algorithms/x/PHP/data_structures/binary_tree/symmetric_tree.out
@@ -1,0 +1,2 @@
+true
+false

--- a/tests/algorithms/x/PHP/data_structures/binary_tree/symmetric_tree.php
+++ b/tests/algorithms/x/PHP/data_structures/binary_tree/symmetric_tree.php
@@ -1,0 +1,84 @@
+<?php
+ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+function _str($x) {
+    if (is_array($x)) {
+        $isList = array_keys($x) === range(0, count($x) - 1);
+        if ($isList) {
+            $parts = [];
+            foreach ($x as $v) { $parts[] = _str($v); }
+            return '[' . implode(' ', $parts) . ']';
+        }
+        $parts = [];
+        foreach ($x as $k => $v) { $parts[] = _str($k) . ':' . _str($v); }
+        return 'map[' . implode(' ', $parts) . ']';
+    }
+    if (is_bool($x)) return $x ? 'true' : 'false';
+    if ($x === null) return 'null';
+    return strval($x);
+}
+function _append($arr, $x) {
+    $arr[] = $x;
+    return $arr;
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function make_symmetric_tree() {
+  global $symmetric_tree, $asymmetric_tree;
+  return [[1, 1, 2], [2, 3, 4], [2, 5, 6], [3, -1, -1], [4, -1, -1], [4, -1, -1], [3, -1, -1]];
+};
+  function make_asymmetric_tree() {
+  global $symmetric_tree, $asymmetric_tree;
+  return [[1, 1, 2], [2, 3, 4], [2, 5, 6], [3, -1, -1], [4, -1, -1], [3, -1, -1], [4, -1, -1]];
+};
+  function is_symmetric_tree($tree) {
+  global $symmetric_tree, $asymmetric_tree;
+  $stack = [$tree[0][1], $tree[0][2]];
+  while (count($stack) >= 2) {
+  $left = $stack[count($stack) - 2];
+  $right = $stack[count($stack) - 1];
+  $stack = array_slice($stack, 0, count($stack) - 2 - 0);
+  if ($left == (-1) && $right == (-1)) {
+  continue;
+}
+  if ($left == (-1) || $right == (-1)) {
+  return false;
+}
+  $lnode = $tree[$left];
+  $rnode = $tree[$right];
+  if ($lnode[0] != $rnode[0]) {
+  return false;
+}
+  $stack = _append($stack, $lnode[1]);
+  $stack = _append($stack, $rnode[2]);
+  $stack = _append($stack, $lnode[2]);
+  $stack = _append($stack, $rnode[1]);
+};
+  return true;
+};
+  $symmetric_tree = make_symmetric_tree();
+  $asymmetric_tree = make_asymmetric_tree();
+  echo rtrim(_str(is_symmetric_tree($symmetric_tree))), PHP_EOL;
+  echo rtrim(_str(is_symmetric_tree($asymmetric_tree))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/transpiler/x/php/ALGORITHMS.md
+++ b/transpiler/x/php/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated PHP code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/PHP`.
-Last updated: 2025-08-06 21:35 GMT+7
+Last updated: 2025-08-06 22:06 GMT+7
 
-## Algorithms Golden Test Checklist (188/1077)
+## Algorithms Golden Test Checklist (189/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 117µs | 38.8 KB |
@@ -203,8 +203,8 @@ Last updated: 2025-08-06 21:35 GMT+7
 | 194 | data_structures/binary_tree/red_black_tree | ✓ | 216µs | 70.0 KB |
 | 195 | data_structures/binary_tree/segment_tree | ✓ | 197µs | 41.1 KB |
 | 196 | data_structures/binary_tree/segment_tree_other | error |  |  |
-| 197 | data_structures/binary_tree/serialize_deserialize_binary_tree |   |  |  |
-| 198 | data_structures/binary_tree/symmetric_tree |   |  |  |
+| 197 | data_structures/binary_tree/serialize_deserialize_binary_tree | error |  |  |
+| 198 | data_structures/binary_tree/symmetric_tree | ✓ | 131µs | 39.1 KB |
 | 199 | data_structures/binary_tree/treap |   |  |  |
 | 200 | data_structures/binary_tree/wavelet_tree |   |  |  |
 | 201 | data_structures/disjoint_set/alternate_disjoint_set |   |  |  |

--- a/transpiler/x/php/transpiler.go
+++ b/transpiler/x/php/transpiler.go
@@ -318,6 +318,8 @@ var phpReserved = map[string]struct{}{
 	"base64_decode": {},
 	"trim":          {},
 	"copy":          {},
+	"serialize":     {},
+	"unserialize":   {},
 	"extract":       {},
 	"new":           {},
 	"New":           {},


### PR DESCRIPTION
## Summary
- avoid conflicts with PHP's `serialize`/`unserialize` builtins
- add algorithm outputs for `symmetric_tree`
- record failing case for `serialize_deserialize_binary_tree`

## Testing
- `MOCHI_ALG_INDEX=198 go test ./transpiler/x/php -tags=slow -run TestPHPTranspiler_Algorithms_Golden -update-algorithms-php`
- `MOCHI_ALG_INDEX=198 MOCHI_BENCHMARK=1 go test ./transpiler/x/php -tags=slow -run TestPHPTranspiler_Algorithms_Golden -update-algorithms-php`


------
https://chatgpt.com/codex/tasks/task_e_68936ae278808320b7c2e227ee879a3a