### PR TITLE
php: add knapsack test

### DIFF
--- a/tests/algorithms/x/PHP/knapsack/tests/test_knapsack.bench
+++ b/tests/algorithms/x/PHP/knapsack/tests/test_knapsack.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 131,
+  "memory_bytes": 39768,
+  "name": "main"
+}

--- a/tests/algorithms/x/PHP/knapsack/tests/test_knapsack.out
+++ b/tests/algorithms/x/PHP/knapsack/tests/test_knapsack.out
@@ -1,0 +1,4 @@
+true
+true
+true
+true

--- a/tests/algorithms/x/PHP/knapsack/tests/test_knapsack.php
+++ b/tests/algorithms/x/PHP/knapsack/tests/test_knapsack.php
@@ -1,0 +1,73 @@
+<?php
+ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function knapsack($capacity, $weights, $values, $counter) {
+  if ($counter == 0 || $capacity == 0) {
+  return 0;
+}
+  if ($weights[$counter - 1] > $capacity) {
+  return knapsack($capacity, $weights, $values, $counter - 1);
+}
+  $left_capacity = $capacity - $weights[$counter - 1];
+  $include_val = $values[$counter - 1] + knapsack($left_capacity, $weights, $values, $counter - 1);
+  $exclude_val = knapsack($capacity, $weights, $values, $counter - 1);
+  if ($include_val > $exclude_val) {
+  return $include_val;
+}
+  return $exclude_val;
+};
+  function test_base_case() {
+  $cap = 0;
+  $val = [0];
+  $w = [0];
+  $c = count($val);
+  if (knapsack($cap, $w, $val, $c) != 0) {
+  return false;
+}
+  $val2 = [60];
+  $w2 = [10];
+  $c2 = count($val2);
+  return knapsack($cap, $w2, $val2, $c2) == 0;
+};
+  function test_easy_case() {
+  $cap = 3;
+  $val = [1, 2, 3];
+  $w = [3, 2, 1];
+  $c = count($val);
+  return knapsack($cap, $w, $val, $c) == 5;
+};
+  function test_knapsack() {
+  $cap = 50;
+  $val = [60, 100, 120];
+  $w = [10, 20, 30];
+  $c = count($val);
+  return knapsack($cap, $w, $val, $c) == 220;
+};
+  echo rtrim(json_encode(test_base_case(), 1344)), PHP_EOL;
+  echo rtrim(json_encode(test_easy_case(), 1344)), PHP_EOL;
+  echo rtrim(json_encode(test_knapsack(), 1344)), PHP_EOL;
+  echo rtrim((true ? 'true' : 'false')), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/transpiler/x/php/ALGORITHMS.md
+++ b/transpiler/x/php/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated PHP code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/PHP`.
-Last updated: 2025-08-06 23:56 GMT+7
+Last updated: 2025-08-07 00:11 GMT+7
 
-## Algorithms Golden Test Checklist (444/1077)
+## Algorithms Golden Test Checklist (445/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 117µs | 38.8 KB |
@@ -487,7 +487,7 @@ Last updated: 2025-08-06 23:56 GMT+7
 | 478 | knapsack/knapsack | ✓ |  |  |
 | 479 | knapsack/recursive_approach_knapsack | ✓ |  |  |
 | 480 | knapsack/tests/test_greedy_knapsack | ✓ |  |  |
-| 481 | knapsack/tests/test_knapsack |   |  |  |
+| 481 | knapsack/tests/test_knapsack | ✓ | 131µs | 38.8 KB |
 | 482 | linear_algebra/gaussian_elimination |   |  |  |
 | 483 | linear_algebra/jacobi_iteration_method |   |  |  |
 | 484 | linear_algebra/lu_decomposition |   |  |  |

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-Last updated: 2025-08-06 23:40 +0700
+Last updated: 2025-08-07 00:05 +0700
 
 ## VM Golden Test Checklist (103/105)
 - [x] append_builtin

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,4 +1,4 @@
-## Progress (2025-08-06 23:40 +0700)
+## Progress (2025-08-07 00:05 +0700)
 - Generated PHP for 103/105 programs
 - Updated README checklist and outputs
 - Enhanced printing to match golden format


### PR DESCRIPTION
## Summary
- transpile TheAlgorithms knapsack test to PHP and record benchmark
- refresh PHP transpiler progress files

## Testing
- `MOCHI_ALG_INDEX=481 MOCHI_BENCHMARK=1 go test -tags slow -run TestPHPTranspiler_Algorithms_Golden -update-algorithms-php`

------
https://chatgpt.com/codex/tasks/task_e_68938b6e17608320a5493112c646c85d