### PR TITLE
java: use floorDiv for integer division

### DIFF
--- a/tests/algorithms/x/Java/maths/special_numbers/automorphic_number.bench
+++ b/tests/algorithms/x/Java/maths/special_numbers/automorphic_number.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 34087,
+  "memory_bytes": 768,
+  "name": "main"
+}

--- a/tests/algorithms/x/Java/maths/special_numbers/automorphic_number.java
+++ b/tests/algorithms/x/Java/maths/special_numbers/automorphic_number.java
@@ -1,0 +1,43 @@
+public class Main {
+
+    static boolean is_automorphic_number(int number) {
+        if (number < 0) {
+            return false;
+        }
+        int n = number;
+        int sq = number * number;
+        while (n > 0) {
+            if (Math.floorMod(n, 10) != Math.floorMod(sq, 10)) {
+                return false;
+            }
+            n = Math.floorDiv(n, 10);
+            sq = Math.floorDiv(sq, 10);
+        }
+        return true;
+    }
+    public static void main(String[] args) {
+        System.out.println(_p(is_automorphic_number(0)));
+        System.out.println(_p(is_automorphic_number(1)));
+        System.out.println(_p(is_automorphic_number(5)));
+        System.out.println(_p(is_automorphic_number(6)));
+        System.out.println(_p(is_automorphic_number(7)));
+        System.out.println(_p(is_automorphic_number(25)));
+        System.out.println(_p(is_automorphic_number(376)));
+    }
+
+    static String _p(Object v) {
+        if (v == null) return "<nil>";
+        if (v.getClass().isArray()) {
+            if (v instanceof int[]) return java.util.Arrays.toString((int[]) v);
+            if (v instanceof long[]) return java.util.Arrays.toString((long[]) v);
+            if (v instanceof double[]) return java.util.Arrays.toString((double[]) v);
+            if (v instanceof boolean[]) return java.util.Arrays.toString((boolean[]) v);
+            if (v instanceof byte[]) return java.util.Arrays.toString((byte[]) v);
+            if (v instanceof char[]) return java.util.Arrays.toString((char[]) v);
+            if (v instanceof short[]) return java.util.Arrays.toString((short[]) v);
+            if (v instanceof float[]) return java.util.Arrays.toString((float[]) v);
+            return java.util.Arrays.deepToString((Object[]) v);
+        }
+        return String.valueOf(v);
+    }
+}

--- a/tests/algorithms/x/Java/maths/special_numbers/automorphic_number.out
+++ b/tests/algorithms/x/Java/maths/special_numbers/automorphic_number.out
@@ -1,0 +1,7 @@
+true
+true
+true
+true
+false
+true
+true

--- a/transpiler/x/java/ALGORITHMS.md
+++ b/transpiler/x/java/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated Java code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Java`.
-Last updated: 2025-08-07 00:16 GMT+7
+Last updated: 2025-08-07 08:18 GMT+7
 
-## Algorithms Golden Test Checklist (551/1077)
+## Algorithms Golden Test Checklist (552/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 40.0ms | 46.14KB |
@@ -670,7 +670,7 @@ Last updated: 2025-08-07 00:16 GMT+7
 | 661 | maths/solovay_strassen_primality_test | ✓ | 18.0ms | 768B |
 | 662 | maths/spearman_rank_correlation_coefficient | ✓ | 45.0ms | 56.05KB |
 | 663 | maths/special_numbers/armstrong_numbers | ✓ | 37.0ms | 46.14KB |
-| 664 | maths/special_numbers/automorphic_number |   |  |  |
+| 664 | maths/special_numbers/automorphic_number | ✓ | 34.0ms | 768B |
 | 665 | maths/special_numbers/bell_numbers |   |  |  |
 | 666 | maths/special_numbers/carmichael_number |   |  |  |
 | 667 | maths/special_numbers/catalan_number |   |  |  |

--- a/transpiler/x/java/transpiler.go
+++ b/transpiler/x/java/transpiler.go
@@ -3620,26 +3620,26 @@ func Transpile(p *parser.Program, env *types.Env) (*Program, error) {
 	varTypes = map[string]string{}
 	funcRet = map[string]string{}
 	extraDecls = nil
-        structCount = 0
-        topEnv = env
-        groupItems = map[string]string{}
-        needLoadYaml = false
-        needSaveJsonl = false
-        needAppendObj = false
-        needConcat = false
-        needNetLookupHost = false
-        needEnviron = false
-        needRepeat = false
-        needMin = false
-        needMax = false
-        needExists = false
-        needToObjectArray = false
-        needJSON = false
-        needCastInt2D = false
-        needFn3 = false
-        needInput = false
-        needNow = false
-        needMem = false
+	structCount = 0
+	topEnv = env
+	groupItems = map[string]string{}
+	needLoadYaml = false
+	needSaveJsonl = false
+	needAppendObj = false
+	needConcat = false
+	needNetLookupHost = false
+	needEnviron = false
+	needRepeat = false
+	needMin = false
+	needMax = false
+	needExists = false
+	needToObjectArray = false
+	needJSON = false
+	needCastInt2D = false
+	needFn3 = false
+	needInput = false
+	needNow = false
+	needMem = false
 	needAppendBool = false
 	needPadStart = false
 	needSHA256 = false
@@ -4765,6 +4765,13 @@ func applyBinaryOp(left Expr, op *parser.BinaryOp, right Expr) (Expr, error) {
 					return &CastExpr{Type: "int", Value: call}, nil
 				}
 				return &CallExpr{Func: "Math.floorMod", Args: []Expr{left, right}}, nil
+			}
+		}
+		if op.Op == "/" {
+			lt := inferType(left)
+			rt := inferType(right)
+			if lt != "double" && lt != "float" && rt != "double" && rt != "float" && lt != "bigint" && rt != "bigint" && lt != "java.math.BigInteger" && rt != "java.math.BigInteger" {
+				return &CallExpr{Func: "Math.floorDiv", Args: []Expr{left, right}}, nil
 			}
 		}
 		return &BinaryExpr{Left: left, Op: op.Op, Right: right}, nil


### PR DESCRIPTION
## Summary
- ensure Java transpiler uses Math.floorDiv for integer division to match Mochi semantics
- add transpiled output, benchmark and expected results for automorphic number algorithm (index 664)
- refresh algorithms progress checklist for Java transpiler

## Testing
- `MOCHI_ALG_INDEX=664 MOCHI_BENCHMARK=1 go test ./transpiler/x/java -run TestJavaTranspiler_Algorithms_Golden -tags=slow -update-algorithms-java -v`
- `MOCHI_ALG_INDEX=664 go test ./transpiler/x/java -run TestJavaTranspiler_Algorithms_Golden -tags=slow -update-algorithms-java -v`
- `MOCHI_ALG_INDEX=664 go test ./transpiler/x/java -run TestJavaTranspiler_Algorithms_Golden -tags=slow -v`


------
https://chatgpt.com/codex/tasks/task_e_6893fd23ef148320be72ef820b283ebc