### PR TITLE
lua: ensure trailing newline in emitted code

### DIFF
--- a/transpiler/x/lua/ALGORITHMS.md
+++ b/transpiler/x/lua/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Lua code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Lua`.
-Last updated: 2025-08-07 08:40 GMT+7
+Last updated: 2025-08-07 09:07 GMT+7
 
 ## Algorithms Golden Test Checklist (495/1077)
 | Index | Name | Status | Duration | Memory |

--- a/transpiler/x/lua/transpiler.go
+++ b/transpiler/x/lua/transpiler.go
@@ -2904,7 +2904,11 @@ func Emit(p *Program) []byte {
 		b.WriteString(";\n")
 	}
 	currentEnv = prevEnv
-	return formatLua(b.Bytes())
+	code := formatLua(b.Bytes())
+	if len(code) == 0 || code[len(code)-1] != '\n' {
+		code = append(code, '\n')
+	}
+	return code
 }
 
 func convertExpr(e *parser.Expr) (Expr, error) {


### PR DESCRIPTION
## Summary
- ensure Lua emitter terminates code with a newline to avoid truncated output
- refresh Lua algorithms progress metadata

## Testing
- `for i in $(seq 518 617); do MOCHI_ALG_INDEX=$i go test ./transpiler/x/lua -run TestLuaTranspiler_Algorithms_Golden -tags slow -count=1; done`
- `MOCHI_ALG_INDEX=518 go test ./transpiler/x/lua -run TestLuaTranspiler_Algorithms_Golden -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6894051878848320b48d0c40544bb916