### PR TITLE
docs: add v0.10.60 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # 📦 CHANGELOG.md
 
+## [0.10.60] – 2025-08-07T07:42:09+00:00
+
+### Added
+
+* Centralized example input handling and expanded fetch support
+* New algorithms including LZW decompression, Burrows–Wheeler transform, number_of_digits and numerous refreshed outputs across languages
+
+### Changed
+
+* Improved transpilers with better map and list operations, BigInt and float conversions, panic helpers and function field support
+
+### Fixed
+
+* Resolved issues with string slicing, map iteration, typed lists, integer casts and reserved names across multiple targets
+
 ## [0.10.59] – 2025-08-06T15:21:31+07:00
 
 ### Added

--- a/releases/v0.10.60.md
+++ b/releases/v0.10.60.md
@@ -1,0 +1,16 @@
+# Aug 2025 (v0.10.60)
+
+Released on Thu Aug 07 07:42:09 2025 +0000.
+
+Mochi v0.10.60 broadens language transpiler capabilities and refreshes algorithm coverage across the project.
+
+## Transpilers
+
+- Centralized example input handling and expanded fetch support.
+- Added panic helpers, deep equality and map defaults while improving map/list operations, float and BigInt conversions, and function field support across many targets.
+- Numerous fixes including string slicing, map iteration, typed lists, integer casts and reserved names.
+
+## Algorithms
+
+- New implementations such as LZW decompression, Burrows–Wheeler transform and number_of_digits.
+- Refreshed and expanded algorithm outputs for Java, Scheme, Lua, Python, Dart, F# and more.


### PR DESCRIPTION
## Summary
- add release notes for v0.10.60
- document changes for v0.10.60 in CHANGELOG

## Testing
- `npm test` (missing script)
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689458004e7883208cf8cb723630211c