### PR TITLE
feat(clj): add power_of_4 algorithm output

### DIFF
--- a/tests/algorithms/x/Clojure/bit_manipulation/power_of_4.bench
+++ b/tests/algorithms/x/Clojure/bit_manipulation/power_of_4.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 33962,
+  "memory_bytes": 19927760,
+  "name": "main"
+}

--- a/tests/algorithms/x/Clojure/bit_manipulation/power_of_4.clj
+++ b/tests/algorithms/x/Clojure/bit_manipulation/power_of_4.clj
@@ -1,0 +1,44 @@
+(ns main (:refer-clojure :exclude [power_of_4]))
+
+(require 'clojure.set)
+
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
+(defn padStart [s w p]
+  (loop [out (str s)] (if (< (count out) w) (recur (str p out)) out)))
+
+(defn indexOf [s sub]
+  (let [idx (clojure.string/index-of s sub)] (if (nil? idx) -1 idx)))
+
+(defn split [s sep]
+  (clojure.string/split s (re-pattern sep)))
+
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
+(declare power_of_4)
+
+(def ^:dynamic power_of_4_n nil)
+
+(defn power_of_4 [power_of_4_number]
+  (binding [power_of_4_n nil] (try (do (when (<= power_of_4_number 0) (throw (ex-info "return" {:v false}))) (set! power_of_4_n power_of_4_number) (while (= (mod power_of_4_n 4) 0) (set! power_of_4_n (quot power_of_4_n 4))) (throw (ex-info "return" {:v (= power_of_4_n 1)}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
+
+(defn -main []
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (println (str (power_of_4 1)))
+      (println (str (power_of_4 2)))
+      (println (str (power_of_4 4)))
+      (println (str (power_of_4 6)))
+      (println (str (power_of_4 64)))
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
+
+(-main)

--- a/tests/algorithms/x/Clojure/bit_manipulation/power_of_4.out
+++ b/tests/algorithms/x/Clojure/bit_manipulation/power_of_4.out
@@ -1,0 +1,5 @@
+true
+false
+true
+false
+true

--- a/transpiler/x/clj/ALGORITHMS.md
+++ b/transpiler/x/clj/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated Clojure code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Clojure`.
-Last updated: 2025-08-07 15:17 GMT+7
+Last updated: 2025-08-07 16:40 GMT+7
 
-## Algorithms Golden Test Checklist (110/1077)
+## Algorithms Golden Test Checklist (111/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 50.25ms | 19.66MB |
@@ -48,7 +48,7 @@ Last updated: 2025-08-07 15:17 GMT+7
 | 39 | bit_manipulation/largest_pow_of_two_le_num | ✓ | 36.464ms | 18.96MB |
 | 40 | bit_manipulation/missing_number | ✓ | 34.818ms | 19.64MB |
 | 41 | bit_manipulation/numbers_different_signs |   |  |  |
-| 42 | bit_manipulation/power_of_4 |   |  |  |
+| 42 | bit_manipulation/power_of_4 | ✓ | 33.962ms | 19.00MB |
 | 43 | bit_manipulation/reverse_bits |   |  |  |
 | 44 | bit_manipulation/single_bit_manipulation_operations |   |  |  |
 | 45 | bit_manipulation/swap_all_odd_and_even_bits |   |  |  |


### PR DESCRIPTION
## Summary
- generate Clojure code and outputs for `bit_manipulation/power_of_4`
- update algorithm progress table

## Testing
- `MOCHI_ALG_INDEX=42 go test ./transpiler/x/clj -run TestClojureTranspiler_Algorithms_Golden -tags=slow`


------
https://chatgpt.com/codex/tasks/task_e_689464c3fe988320b6912d14caa086a8