### PR TITLE
dart transpiler: fix numeric cast handling

### DIFF
--- a/tests/algorithms/x/Dart/maths/sigmoid.bench
+++ b/tests/algorithms/x/Dart/maths/sigmoid.bench
@@ -1,7 +1,1 @@
-Unhandled exception:
-type 'int' is not a subtype of type 'double' in type cast
-#0      exp_approx (file:///workspace/mochi/tests/algorithms/x/Dart/maths/sigmoid.dart:44:26)
-#1      sigmoid (file:///workspace/mochi/tests/algorithms/x/Dart/maths/sigmoid.dart:56:29)
-#2      main (file:///workspace/mochi/tests/algorithms/x/Dart/maths/sigmoid.dart:70:10)
-#3      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:314:19)
-#4      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:193:12)
+{"duration_us":28625,"memory_bytes":9891840,"name":"main"}

--- a/tests/algorithms/x/Dart/maths/sigmoid.dart
+++ b/tests/algorithms/x/Dart/maths/sigmoid.dart
@@ -13,12 +13,14 @@ String _substr(String s, num start, num end) {
   return s.substring(s0, e0);
 }
 
+String _str(dynamic v) { if (v is double && v == v.roundToDouble()) { return v.toInt().toString(); } return v.toString(); }
+
 double exp_approx(double x) {
   double sum = 1.0;
   double term = 1.0;
   int i = 1;
   while (i <= 10) {
-    term = term * x / (i as double);
+    term = term * x / ((i).toDouble());
     sum = sum + term;
     i = i + 1;
   }
@@ -38,6 +40,6 @@ List<double> sigmoid(List<double> vector) {
 }
 
 void main() {
-  print((sigmoid(List<double>.from([-1.0, 1.0, 2.0]))).toString());
-  print((sigmoid([0.0])).toString());
+  print(_str(sigmoid(List<double>.from([-1.0, 1.0, 2.0]))));
+  print(_str(sigmoid([0.0])));
 }

--- a/tests/algorithms/x/Dart/maths/sigmoid.error
+++ b/tests/algorithms/x/Dart/maths/sigmoid.error
@@ -1,8 +1,0 @@
-run: exit status 255
-Unhandled exception:
-type 'int' is not a subtype of type 'double' in type cast
-#0      exp_approx (file:///workspace/mochi/tests/algorithms/x/Dart/maths/sigmoid.dart:21:26)
-#1      sigmoid (file:///workspace/mochi/tests/algorithms/x/Dart/maths/sigmoid.dart:33:29)
-#2      main (file:///workspace/mochi/tests/algorithms/x/Dart/maths/sigmoid.dart:41:10)
-#3      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:314:19)
-#4      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:193:12)

--- a/tests/algorithms/x/Dart/maths/sigmoid.out
+++ b/tests/algorithms/x/Dart/maths/sigmoid.out
@@ -1,7 +1,2 @@
-Unhandled exception:
-type 'int' is not a subtype of type 'double' in type cast
-#0      exp_approx (file:///workspace/mochi/tests/algorithms/x/Dart/maths/sigmoid.dart:21:26)
-#1      sigmoid (file:///workspace/mochi/tests/algorithms/x/Dart/maths/sigmoid.dart:33:29)
-#2      main (file:///workspace/mochi/tests/algorithms/x/Dart/maths/sigmoid.dart:41:10)
-#3      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:314:19)
-#4      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:193:12)
+[0.2689414233455059, 0.7310585662766599, 0.880763017273518]
+[0.5]

--- a/transpiler/x/dart/ALGORITHMS.md
+++ b/transpiler/x/dart/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated Dart code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Dart`.
-Last updated: 2025-08-07 16:33 GMT+7
+Last updated: 2025-08-07 17:11 GMT+7
 
-## Algorithms Golden Test Checklist (652/1077)
+## Algorithms Golden Test Checklist (653/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 11.075ms | 3.5 MB |
@@ -661,7 +661,7 @@ Last updated: 2025-08-07 16:33 GMT+7
 | 652 | maths/series/hexagonal_numbers | ✓ | 11.858ms | 4.2 MB |
 | 653 | maths/series/p_series | ✓ | 12.796ms | 2.6 MB |
 | 654 | maths/sieve_of_eratosthenes | ✓ | 13.931ms | 4.6 MB |
-| 655 | maths/sigmoid | error |  |  |
+| 655 | maths/sigmoid | ✓ | 28.625ms | 9.4 MB |
 | 656 | maths/signum | ✓ | 19.34ms | 10.3 MB |
 | 657 | maths/simultaneous_linear_equation_solver | error |  |  |
 | 658 | maths/sin | error |  |  |

--- a/transpiler/x/dart/README.md
+++ b/transpiler/x/dart/README.md
@@ -109,4 +109,4 @@ Generated Dart code for programs in `tests/vm/valid`. Each program has a `.dart`
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-_Last updated: 2025-08-06 21:55 +0700_
+_Last updated: 2025-08-07 16:58 +0700_

--- a/transpiler/x/dart/ROSETTA.md
+++ b/transpiler/x/dart/ROSETTA.md
@@ -499,4 +499,4 @@ Compiled and ran: 477/491
 | 490 | window-management | ✓ | 11.069ms | 2.1 MB |
 | 491 | zumkeller-numbers | ✓ | 1.389357s | 3.9 MB |
 
-_Last updated: 2025-08-06 21:55 +0700_
+_Last updated: 2025-08-07 16:58 +0700_

--- a/transpiler/x/dart/TASKS.md
+++ b/transpiler/x/dart/TASKS.md
@@ -1,10 +1,10 @@
-## Recent Enhancements (2025-08-06 21:55 +0700)
+## Recent Enhancements (2025-08-07 16:58 +0700)
 - Added query cross join support using collection `for` loops.
 - Removed `where`/`map` helpers for cleaner output.
 - Simplified join result collection for readability.
 - Enhanced type inference for query results.
 
-## Progress (2025-08-06 21:55 +0700)
+## Progress (2025-08-07 16:58 +0700)
 - VM valid 102/105
 
 # Dart Transpiler Tasks

--- a/transpiler/x/dart/transpiler.go
+++ b/transpiler/x/dart/transpiler.go
@@ -2741,7 +2741,10 @@ func (c *CastExpr) emit(w io.Writer) error {
 		return err
 	}
 
-	if (c.Type == "num" || c.Type == "double") && valType == "int" {
+	if c.Type == "num" || c.Type == "double" {
+		if valType == "num" || valType == "double" {
+			return c.Value.emit(w)
+		}
 		if _, err := io.WriteString(w, "("); err != nil {
 			return err
 		}
@@ -2754,10 +2757,6 @@ func (c *CastExpr) emit(w io.Writer) error {
 		}
 		_, err = io.WriteString(w, ".toDouble()")
 		return err
-	}
-
-	if c.Type == "num" && valType == "double" {
-		return c.Value.emit(w)
 	}
 	if strings.HasPrefix(c.Type, "List<") && valType != c.Type {
 		return emitListConversion(w, c.Value, c.Type)


### PR DESCRIPTION
## Summary
- handle numeric casts to `float` by emitting `.toDouble()` instead of `as double`
- generate Dart + golden outputs for TheAlgorithms `maths/sigmoid`
- refresh dart transpiler progress docs

## Testing
- `MOCHI_ALG_INDEX=655 go test ./transpiler/x/dart -run TestDartTranspiler_Algorithms_Golden -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_689478c4c360832097f0e5b7a366343d