### PR TITLE
php: simplify slice bounds

### DIFF
--- a/tests/algorithms/x/PHP/data_structures/stacks/stock_span_problem.bench
+++ b/tests/algorithms/x/PHP/data_structures/stacks/stock_span_problem.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 123,
+  "duration_us": 124,
   "memory_bytes": 39696,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/stacks/stock_span_problem.php
+++ b/tests/algorithms/x/PHP/data_structures/stacks/stock_span_problem.php
@@ -1,10 +1,27 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function calculation_span($price) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function calculation_span($price) {
   global $spans;
   $n = count($price);
   $st = [];
@@ -13,20 +30,28 @@ function calculation_span($price) {
   $span = _append($span, 1);
   for ($i = 1; $i < $n; $i++) {
   while (count($st) > 0 && $price[$st[count($st) - 1]] <= $price[$i]) {
-  $st = array_slice($st, 0, count($st) - 1 - 0);
+  $st = array_slice($st, 0, count($st) - 1);
 };
   $s = (count($st) <= 0 ? $i + 1 : $i - $st[count($st) - 1]);
   $span = _append($span, $s);
   $st = _append($st, $i);
 };
   return $span;
-}
-function print_array($arr) {
+};
+  function print_array($arr) {
   global $price, $spans;
   for ($i = 0; $i < count($arr); $i++) {
   echo rtrim(json_encode($arr[$i], 1344)), PHP_EOL;
 };
-}
-$price = [10, 4, 5, 90, 120, 80];
-$spans = calculation_span($price);
-print_array($spans);
+};
+  $price = [10, 4, 5, 90, 120, 80];
+  $spans = calculation_span($price);
+  print_array($spans);
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/transpiler/x/php/ALGORITHMS.md
+++ b/transpiler/x/php/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated PHP code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/PHP`.
-Last updated: 2025-08-07 16:42 GMT+7
+Last updated: 2025-08-08 10:20 GMT+7
 
 ## Algorithms Golden Test Checklist (734/1077)
 | Index | Name | Status | Duration | Memory |
@@ -266,7 +266,7 @@ Last updated: 2025-08-07 16:42 GMT+7
 | 257 | data_structures/stacks/stack_using_two_queues | ✓ | 97µs | 37.1 KB |
 | 258 | data_structures/stacks/stack_with_doubly_linked_list | ✓ | 166µs | 41.4 KB |
 | 259 | data_structures/stacks/stack_with_singly_linked_list | ✓ | 80µs | 36.7 KB |
-| 260 | data_structures/stacks/stock_span_problem | ✓ | 123µs | 38.8 KB |
+| 260 | data_structures/stacks/stock_span_problem | ✓ | 124µs | 38.8 KB |
 | 261 | data_structures/suffix_tree/example/example_usage | error |  |  |
 | 262 | data_structures/suffix_tree/suffix_tree | ✓ | 112µs | 40.2 KB |
 | 263 | data_structures/suffix_tree/suffix_tree_node | ✓ | 86µs | 35.7 KB |

--- a/transpiler/x/php/transpiler.go
+++ b/transpiler/x/php/transpiler.go
@@ -2249,7 +2249,11 @@ func (s *SubstringExpr) emit(w io.Writer) {
 	s.Start.emit(w)
 	if s.End != nil {
 		fmt.Fprint(w, ", ")
-		(&BinaryExpr{Left: s.End, Op: "-", Right: s.Start}).emit(w)
+		if lit, ok := s.Start.(*IntLit); ok && lit.Value == 0 {
+			s.End.emit(w)
+		} else {
+			(&BinaryExpr{Left: s.End, Op: "-", Right: s.Start}).emit(w)
+		}
 	}
 	fmt.Fprint(w, ")")
 }
@@ -2294,7 +2298,11 @@ func (s *SliceExpr) emit(w io.Writer) {
 	s.Start.emit(w)
 	if s.End != nil {
 		fmt.Fprint(w, ", ")
-		(&BinaryExpr{Left: s.End, Op: "-", Right: s.Start}).emit(w)
+		if lit, ok := s.Start.(*IntLit); ok && lit.Value == 0 {
+			s.End.emit(w)
+		} else {
+			(&BinaryExpr{Left: s.End, Op: "-", Right: s.Start}).emit(w)
+		}
 	}
 	fmt.Fprint(w, ")")
 }


### PR DESCRIPTION
## Summary
- avoid redundant start subtraction in PHP slice emission
- update stock span PHP example and benchmarks
- refresh PHP algorithms progress table

## Testing
- `MOCHI_ALG_INDEX=260 go test ./transpiler/x/php -tags=slow -run TestPHPTranspiler_Algorithms_Golden -update-algorithms-php -count=1`
- `MOCHI_ALG_INDEX=260 MOCHI_BENCHMARK=1 go test ./transpiler/x/php -tags=slow -run TestPHPTranspiler_Algorithms_Golden -update-algorithms-php -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68956a4d2e808320860923492dbd6bb6