### PR TITLE
docs: add v0.10.61 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # 📦 CHANGELOG.md
 
+## [0.10.61] – 2025-08-08T10:28:49+07:00
+
+### Added
+
+* Expanded slice and map support across multiple transpilers.
+* New algorithm examples including stock span and coloring problems.
+
+### Changed
+
+* Refreshed algorithm outputs and benchmarks for Java, Python, Go, F#, and more.
+
+### Fixed
+
+* Corrected list append evaluation and recursion issues in C++ and Dart transpilers.
+* Improved substring handling in Ruby and safer array indexing in Swift.
+
 ## [0.10.60] – 2025-08-07T07:42:09+00:00
 
 ### Added

--- a/releases/v0.10.61.md
+++ b/releases/v0.10.61.md
@@ -1,0 +1,16 @@
+# Aug 2025 (v0.10.61)
+
+Released on Fri Aug 08 10:28:49 2025 +0700.
+
+Mochi v0.10.61 expands slice handling across languages and refreshes algorithm benchmarks and outputs.
+
+## Transpilers
+
+- Adds slice and negative index support across Go, Pascal, PHP, Kotlin, C, Clojure and more.
+- Fixes recursion, value parameter passing and list append evaluation in the C++ and Dart transpilers.
+- Enhances helpers with array-scalar addition in Ruby, SHA256 string inputs in C# and safer array indexing in Swift.
+
+## Algorithms
+
+- Updates benchmarks and algorithm outputs for Java, Python, Go, F#, Elixir and others, including the stock span problem.
+- Introduces new examples such as coloring algorithms and nearest neighbour search.


### PR DESCRIPTION
## Summary
- document v0.10.61 changes in CHANGELOG
- add release notes for v0.10.61

## Testing
- `go test ./... --vet=off`


------
https://chatgpt.com/codex/tasks/task_e_68956ee193988320be693c054bd96a7d