### PR TITLE
ocaml: add fizz buzz algorithm output

### DIFF
--- a/tests/algorithms/x/OCaml/dynamic_programming/fibonacci.bench
+++ b/tests/algorithms/x/OCaml/dynamic_programming/fibonacci.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 130,
+  "duration_us": 210,
   "memory_bytes": 5008,
   "name": "main"
 }

--- a/tests/algorithms/x/OCaml/dynamic_programming/fizz_buzz.bench
+++ b/tests/algorithms/x/OCaml/dynamic_programming/fizz_buzz.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 160,
+  "memory_bytes": 2000,
+  "name": "main"
+}

--- a/tests/algorithms/x/OCaml/dynamic_programming/fizz_buzz.ml
+++ b/tests/algorithms/x/OCaml/dynamic_programming/fizz_buzz.ml
@@ -87,53 +87,43 @@ exception Continue
 
 exception Return
 
-let rec create_fibonacci () =
-  let __ret = ref ([] : (string * Obj.t) list) in
+let rec fizz_buzz number iterations =
+  let __ret = ref "" in
   (try
-  __ret := (Obj.magic ([(__str ("sequence"), Obj.repr ([0; 1]))]) : (string * Obj.t) list); raise Return
-  with Return -> !__ret)
-
-and fib_get f index =
-  let __ret = ref ([] : (string * Obj.t) list) in
-  (try
-  let index = (Obj.magic index : int) in
-  let seq = ref ((Obj.obj (List.assoc (__str ("sequence")) (!f) : Obj.t) : int list)) in
-  (try while (List.length (!seq) < index) do
+  let number = (Obj.magic number : int) in
+  let iterations = (Obj.magic iterations : int) in
+  if (number < 1) then (
+  (failwith ("starting number must be an integer and be more than 0"));
+  );
+  if (iterations < 1) then (
+  (failwith ("Iterations must be done more than 0 times to play FizzBuzz"));
+  );
+  let out = ref ("") in
+  let n = ref (number) in
+  (try while (!n <= iterations) do
     try
-  let next = (List.nth (!seq) ((List.length (!seq) - 1)) + List.nth (!seq) ((List.length (!seq) - 2))) in
-  seq := (List.append (!seq) [(Obj.magic (next) : int)]);
+  if (((!n mod 3 + 3) mod 3) = 0) then (
+  out := (!out ^ "Fizz");
+  );
+  if (((!n mod 5 + 5) mod 5) = 0) then (
+  out := (!out ^ "Buzz");
+  );
+  if ((((!n mod 3 + 3) mod 3) <> 0) && (((!n mod 5 + 5) mod 5) <> 0)) then (
+  out := (!out ^ (string_of_int (!n)));
+  );
+  out := (!out ^ " ");
+  n := (!n + 1);
     with Continue -> ()
   done with Break -> ());
-  f := ((__str ("sequence"), Obj.repr (!seq)) :: List.remove_assoc (__str ("sequence")) (Obj.magic (!f) : (string * Obj.t) list));
-  let result = ref (([] : (int) list)) in
-  let i = ref (0) in
-  (try while (!i < index) do
-    try
-  result := (List.append (!result) [(Obj.magic (List.nth (!seq) (!i)) : int)]);
-  i := (!i + 1);
-    with Continue -> ()
-  done with Break -> ());
-  __ret := (Obj.magic ([(__str ("fib"), Obj.repr (!f)); (__str ("values"), Obj.repr (!result))]) : (string * Obj.t) list); raise Return
-  with Return -> !__ret)
-
-and main () =
-  let __ret = ref (Obj.magic 0) in
-  (try
-  let fib = ref (create_fibonacci ()) in
-  let res = ref (fib_get (fib) (Obj.repr (10))) in
-  fib := (Obj.obj (List.assoc (__str ("fib")) (!res) : Obj.t) : ( string * Obj.t ) list);
-  print_endline ((__str ((Obj.obj (List.assoc (__str ("values")) (!res) : Obj.t) : int list))));
-  res := fib_get (fib) (Obj.repr (5));
-  fib := (Obj.obj (List.assoc (__str ("fib")) (!res) : Obj.t) : ( string * Obj.t ) list);
-  print_endline ((__str ((Obj.obj (List.assoc (__str ("values")) (!res) : Obj.t) : int list))));
-    !__ret
+  __ret := (Obj.magic (!out) : string); raise Return
   with Return -> !__ret)
 
 
 let () =
   let mem_start = _mem () in
   let start = _now () in
-  ignore (main ());
+  print_endline ((fizz_buzz (Obj.repr (1)) (Obj.repr (7))));
+  print_endline ((fizz_buzz (Obj.repr (1)) (Obj.repr (15))));
   let finish = _now () in
   let mem_end = _mem () in
   let dur = (finish - start) / 1000 in

--- a/tests/algorithms/x/OCaml/dynamic_programming/fizz_buzz.out
+++ b/tests/algorithms/x/OCaml/dynamic_programming/fizz_buzz.out
@@ -1,0 +1,2 @@
+1 2 Fizz 4 Buzz Fizz 7 
+1 2 Fizz 4 Buzz Fizz 7 8 Fizz Buzz 11 Fizz 13 14 FizzBuzz

--- a/transpiler/x/ocaml/ALGORITHMS.md
+++ b/transpiler/x/ocaml/ALGORITHMS.md
@@ -1,7 +1,7 @@
 # OCaml Algorithms Transpiler Output
 
-Completed programs: 287/1077
-Last updated: 2025-08-08 16:40 +0700
+Completed programs: 288/1077
+Last updated: 2025-08-08 17:12 +0700
 
 Checklist:
 
@@ -316,8 +316,8 @@ Checklist:
 | 307 | dynamic_programming/edit_distance | ✓ | 1.0ms | 127.11KB |
 | 308 | dynamic_programming/factorial | ✓ | 167.0µs | 3.73KB |
 | 309 | dynamic_programming/fast_fibonacci | ✓ | 174.0µs | 5.09KB |
-| 310 | dynamic_programming/fibonacci | ✓ | 130.0µs | 4.89KB |
-| 311 | dynamic_programming/fizz_buzz |   |  |  |
+| 310 | dynamic_programming/fibonacci | ✓ | 210.0µs | 4.89KB |
+| 311 | dynamic_programming/fizz_buzz | ✓ | 160.0µs | 1.95KB |
 | 312 | dynamic_programming/floyd_warshall |   |  |  |
 | 313 | dynamic_programming/integer_partition |   |  |  |
 | 314 | dynamic_programming/iterating_through_submasks |   |  |  |

--- a/transpiler/x/ocaml/README.md
+++ b/transpiler/x/ocaml/README.md
@@ -112,4 +112,4 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 104. [x] var_assignment.mochi
 105. [x] while_loop.mochi
 
-Last updated 2025-08-08 16:40 +0700
+Last updated 2025-08-08 17:12 +0700

--- a/transpiler/x/ocaml/TASKS.md
+++ b/transpiler/x/ocaml/TASKS.md
@@ -1,7 +1,22 @@
-## Progress (2025-08-08 16:40 +0700)
-- ocaml: handle nested map updates (23572929fc)
+## Progress (2025-08-08 17:12 +0700)
+- ocaml: add fibonacci algorithm output (eeb1f97b1c)
 
 - VM valid programs compiled: 102/105
+
+- ocaml: add fibonacci algorithm output (eeb1f97b1c)
+
+
+- ocaml: add fibonacci algorithm output (eeb1f97b1c)
+
+
+- ocaml: add fibonacci algorithm output (eeb1f97b1c)
+
+
+- ocaml: add fibonacci algorithm output (eeb1f97b1c)
+
+
+- ocaml: handle nested map updates (23572929fc)
+
 
 - transpiler/ocaml: update rosetta outputs for indices 184-233 (efa94d8a28)
 


### PR DESCRIPTION
## Summary
- transpile Fibonacci and Fizz Buzz Mochi programs to OCaml and record benchmarks
- refresh algorithm progress documentation

## Testing
- `MOCHI_ALGORITHMS_INDEX=310 go test ./transpiler/x/ocaml -run TestOCamlTranspiler_Algorithms_Golden -tags slow -count=1`
- `MOCHI_ALGORITHMS_INDEX=311 go test ./transpiler/x/ocaml -run TestOCamlTranspiler_Algorithms_Golden -tags slow -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_6895cd85830c8320b820fdcb117a6a20