### PR TITLE
dart: improve str helper and refresh algorithm benchmarks

### DIFF
--- a/transpiler/x/dart/ALGORITHMS.md
+++ b/transpiler/x/dart/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Dart code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Dart`.
-Last updated: 2025-08-08 17:10 GMT+7
+Last updated: 2025-08-08 17:39 GMT+7
 
 ## Algorithms Golden Test Checklist (853/1077)
 | Index | Name | Status | Duration | Memory |

--- a/transpiler/x/dart/transpiler.go
+++ b/transpiler/x/dart/transpiler.go
@@ -4384,7 +4384,14 @@ func Emit(w io.Writer, p *Program) error {
 		}
 	}
 	if useStr {
-		if _, err := io.WriteString(w, "String _str(dynamic v) { if (v is double && v == v.roundToDouble()) { return v.toInt().toString(); } return v.toString(); }\n\n"); err != nil {
+		if _, err := io.WriteString(w, "String _str(dynamic v) {"+
+			" if (v is double && v == v.roundToDouble()) {"+
+			" var i = v.toInt();"+
+			" if (i == 0) return '0';"+
+			" return i.toString();"+
+			" }"+
+			" return v.toString();"+
+			" }\n\n"); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary
- refine Dart transpiler `_str` helper to normalise integer-like doubles, preventing `-0` output
- regenerate algorithms benchmark summary for indices 1015–1077

## Testing
- `MOCHI_ALG_INDEX=1015 go test -tags=slow ./transpiler/x/dart -run TestDartTranspiler_Algorithms_Golden -count=1`
- `MOCHI_ALG_INDEX=1015 MOCHI_BENCHMARK=1 go test -tags=slow ./transpiler/x/dart -run TestDartTranspiler_Algorithms_Golden -update-algorithms-dart -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6895d22822008320ad3dd8722749f344