### PR TITLE
Refresh Dart algorithms benchmarks

### DIFF
--- a/transpiler/x/dart/ALGORITHMS.md
+++ b/transpiler/x/dart/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Dart code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Dart`.
-Last updated: 2025-08-08 17:39 GMT+7
+Last updated: 2025-08-08 18:17 GMT+7
 
 ## Algorithms Golden Test Checklist (853/1077)
 | Index | Name | Status | Duration | Memory |

--- a/transpiler/x/dart/README.md
+++ b/transpiler/x/dart/README.md
@@ -109,4 +109,4 @@ Generated Dart code for programs in `tests/vm/valid`. Each program has a `.dart`
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-_Last updated: 2025-08-07 17:31 +0700_
+_Last updated: 2025-08-08 18:15 +0700_

--- a/transpiler/x/dart/ROSETTA.md
+++ b/transpiler/x/dart/ROSETTA.md
@@ -499,4 +499,4 @@ Compiled and ran: 477/491
 | 490 | window-management | ✓ | 11.069ms | 2.1 MB |
 | 491 | zumkeller-numbers | ✓ | 1.389357s | 3.9 MB |
 
-_Last updated: 2025-08-07 17:31 +0700_
+_Last updated: 2025-08-08 18:15 +0700_

--- a/transpiler/x/dart/TASKS.md
+++ b/transpiler/x/dart/TASKS.md
@@ -1,10 +1,10 @@
-## Recent Enhancements (2025-08-07 17:31 +0700)
+## Recent Enhancements (2025-08-08 18:15 +0700)
 - Added query cross join support using collection `for` loops.
 - Removed `where`/`map` helpers for cleaner output.
 - Simplified join result collection for readability.
 - Enhanced type inference for query results.
 
-## Progress (2025-08-07 17:31 +0700)
+## Progress (2025-08-08 18:15 +0700)
 - VM valid 102/105
 
 # Dart Transpiler Tasks


### PR DESCRIPTION
## Summary
- refresh Dart algorithms benchmark data and documentation

## Testing
- `for i in $(seq 1030 1077); do echo "Running index $i"; MOCHI_ALG_INDEX=$i MOCHI_BENCHMARK=1 go test ./transpiler/x/dart -run TestDartTranspiler_Algorithms_Golden -tags slow -count=1 -update-algorithms-dart >/tmp/test_$i.log && tail -n 5 /tmp/test_$i.log; done`


------
https://chatgpt.com/codex/tasks/task_e_6895d99de1c083208e1c9ee461f0f78a