### PR TITLE
lua: parse benchmark flag with strconv

### DIFF
--- a/transpiler/x/lua/ALGORITHMS.md
+++ b/transpiler/x/lua/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Lua code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Lua`.
-Last updated: 2025-08-08 19:25 GMT+7
+Last updated: 2025-08-09 08:34 GMT+7
 
 ## Algorithms Golden Test Checklist (990/1077)
 | Index | Name | Status | Duration | Memory |

--- a/transpiler/x/lua/transpiler.go
+++ b/transpiler/x/lua/transpiler.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -31,9 +32,10 @@ var benchMainFlag bool
 var currentStruct string
 
 func init() {
-	v := os.Getenv("MOCHI_BENCHMARK")
-	if strings.EqualFold(v, "true") || v == "1" {
-		benchMainFlag = true
+	if v := os.Getenv("MOCHI_BENCHMARK"); v != "" {
+		if ok, err := strconv.ParseBool(v); err == nil && ok {
+			benchMainFlag = true
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- handle more values for `MOCHI_BENCHMARK` by parsing it with `strconv.ParseBool`
- regenerate Lua algorithms outputs and checklist for indices 51-100

## Testing
- `MOCHI_ALG_INDEX=51 go test ./transpiler/x/lua -run TestLuaTranspiler_Algorithms_Golden -tags=slow -update-algorithms-lua`
- `for i in $(seq 52 100); do MOCHI_ALG_INDEX=$i go test ./transpiler/x/lua -run TestLuaTranspiler_Algorithms_Golden -tags=slow -update-algorithms-lua; done`


------
https://chatgpt.com/codex/tasks/task_e_6896a46cc7c88320b6a7429699272e78