### PR TITLE
lua: improve slice helper and refresh docs

### DIFF
--- a/transpiler/x/lua/ALGORITHMS.md
+++ b/transpiler/x/lua/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Lua code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Lua`.
-Last updated: 2025-08-09 08:34 GMT+7
+Last updated: 2025-08-09 10:08 GMT+7
 
 ## Algorithms Golden Test Checklist (990/1077)
 | Index | Name | Status | Duration | Memory |

--- a/transpiler/x/lua/README.md
+++ b/transpiler/x/lua/README.md
@@ -4,7 +4,7 @@ Generated Lua code for programs in `tests/vm/valid`. Each program has a `.lua` f
 
 Transpiled programs: 104/105
 
-Last updated: 2025-08-08 18:13 GMT+7
+Last updated: 2025-08-09 10:01 GMT+7
 
 Checklist:
 

--- a/transpiler/x/lua/TASKS.md
+++ b/transpiler/x/lua/TASKS.md
@@ -1,3 +1,211 @@
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-09 10:01 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
 ## Progress (2025-08-08 18:13 GMT+7)
 - 104/105 VM tests passing
 - Added float literal support

--- a/transpiler/x/lua/transpiler.go
+++ b/transpiler/x/lua/transpiler.go
@@ -277,12 +277,16 @@ end
 
 const helperSlice = `
 local function slice(lst, s, e)
-  if s < 0 then s = #lst + s end
+  local len = #lst
+  if s < 0 then s = len + s end
+  if s < 0 then s = 0 end
   if e == nil then
-    e = #lst
+    e = len
   elseif e < 0 then
-    e = #lst + e
+    e = len + e
   end
+  if e > len then e = len end
+  if s > e then return {} end
   local r = {}
   for i = s + 1, e do
     r[#r+1] = lst[i]


### PR DESCRIPTION
## Summary
- tighten Lua slice helper to clamp indices and avoid out-of-range slices
- refresh Lua algorithms progress docs

## Testing
- `for i in $(seq 251 300); do MOCHI_ALG_INDEX=$i go test ./transpiler/x/lua -run TestLuaTranspiler_Algorithms_Golden -tags slow; done`


------
https://chatgpt.com/codex/tasks/task_e_6896ba0c2bc0832093b9feea1358e28f