### PR TITLE
docs: add v0.10.62 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # 📦 CHANGELOG.md
 
+## [0.10.62] – 2025-08-09T03:04:56+00:00
+
+### Added
+
+* Support char literals in the Clojure transpiler.
+* Inverse matrix algorithm in F#.
+* Transpiled additional Swift algorithms.
+
+### Changed
+
+* Lua transpiler now parses `MOCHI_BENCHMARK` using `strconv`.
+* Simplified PHP string index casts.
+
+### Fixed
+
+* Corrected for-in index iteration in the TypeScript transpiler.
+* Fixed nil return handling in Pascal.
+
+
 ## [0.10.61] – 2025-08-08T10:28:49+07:00
 
 ### Added

--- a/releases/v0.10.62.md
+++ b/releases/v0.10.62.md
@@ -1,0 +1,16 @@
+# Aug 2025 (v0.10.62)
+
+Released on Sat Aug 09 03:04:56 2025 +0000.
+
+Mochi v0.10.62 introduces Clojure char literal support, expands algorithm coverage, and refines several transpilers.
+
+## Transpilers
+
+- Adds char literal support to the Clojure transpiler.
+- Simplifies PHP string index casts and fixes TypeScript for-in index iteration.
+- Parses `MOCHI_BENCHMARK` using `strconv` in Lua.
+
+## Algorithms
+
+- Adds inverse matrix algorithm for F#.
+- Transpiles additional Swift algorithms.


### PR DESCRIPTION
## Summary
- document v0.10.62 release details
- record new features and fixes in CHANGELOG

## Testing
- `npm test` (fails: Missing script "test")
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6896ba2464888320974a1de8372de97f