### PR TITLE
kt: handle recursive function return types

### DIFF
--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -15,21 +15,21 @@ import (
 )
 
 var (
-	extraDecls     []*DataClass
-	extraUnions    []*SumType
-	extraAliases   []*TypeAlias
-	helperSnippets map[string]string
-	extraHelpers   []string
-	helpersUsed    map[string]bool
-	localFuncs     map[string]bool
-	varDecls       map[string]*VarStmt
-	funcRets       map[string]string
-	builtinAliases map[string]string
-	reserved       map[string]bool
-        currentRetType string
-        overrideRetType string
-	benchMain      bool
-	unusedCounter  int
+	extraDecls      []*DataClass
+	extraUnions     []*SumType
+	extraAliases    []*TypeAlias
+	helperSnippets  map[string]string
+	extraHelpers    []string
+	helpersUsed     map[string]bool
+	localFuncs      map[string]bool
+	varDecls        map[string]*VarStmt
+	funcRets        map[string]string
+	builtinAliases  map[string]string
+	reserved        map[string]bool
+	currentRetType  string
+	overrideRetType string
+	benchMain       bool
+	unusedCounter   int
 )
 
 func init() {
@@ -529,7 +529,7 @@ func (s *StructLit) emit(w io.Writer) {
 		if i > 0 {
 			io.WriteString(w, ", ")
 		}
-               io.WriteString(w, safeName(s.Names[i])+" = ")
+		io.WriteString(w, safeName(s.Names[i])+" = ")
 		f.emit(w)
 	}
 	io.WriteString(w, ")")
@@ -566,7 +566,7 @@ func (d *DataClass) emit(w io.Writer, indentLevel int) {
 					typ += "?"
 				}
 			}
-                       io.WriteString(w, "var "+safeName(f.Name)+": "+typ)
+			io.WriteString(w, "var "+safeName(f.Name)+": "+typ)
 			if f.Default != "" {
 				io.WriteString(w, " = "+f.Default)
 			}
@@ -3627,31 +3627,31 @@ func Transpile(env *types.Env, prog *parser.Program) (*Program, error) {
 			}
 			p.Stmts = append(p.Stmts, stmt)
 			seenStmt = true
-               case st.Return != nil:
-                       var val Expr
-                       if st.Return.Value != nil {
-                               var err error
-                               val, err = convertExpr(env, st.Return.Value)
-                               if err != nil {
-                                       return nil, err
-                               }
-                       }
-                       if _, ok := val.(*NullLit); ok && (currentRetType == "" || currentRetType == "Unit") {
-                               val = nil
-                       }
-                       if currentRetType != "" && currentRetType != "Any" && val != nil {
-                               valType := guessType(val)
-                               if valType != currentRetType {
-                                       if strings.HasPrefix(currentRetType, "MutableList<") && valType == "MutableList<Any?>" {
-                                               currentRetType = "MutableList<Any?>"
-                                               overrideRetType = currentRetType
-                                       } else {
-                                               val = &CastExpr{Value: val, Type: currentRetType}
-                                       }
-                               }
-                       }
-                       p.Stmts = append(p.Stmts, &ReturnStmt{Value: val})
-                       seenStmt = true
+		case st.Return != nil:
+			var val Expr
+			if st.Return.Value != nil {
+				var err error
+				val, err = convertExpr(env, st.Return.Value)
+				if err != nil {
+					return nil, err
+				}
+			}
+			if _, ok := val.(*NullLit); ok && (currentRetType == "" || currentRetType == "Unit") {
+				val = nil
+			}
+			if currentRetType != "" && currentRetType != "Any" && val != nil {
+				valType := guessType(val)
+				if valType != currentRetType {
+					if strings.HasPrefix(currentRetType, "MutableList<") && valType == "MutableList<Any?>" {
+						currentRetType = "MutableList<Any?>"
+						overrideRetType = currentRetType
+					} else {
+						val = &CastExpr{Value: val, Type: currentRetType}
+					}
+				}
+			}
+			p.Stmts = append(p.Stmts, &ReturnStmt{Value: val})
+			seenStmt = true
 		case st.Fun != nil:
 			bodyEnv := types.NewEnv(env)
 			ftParams := make([]types.Type, 0, len(st.Fun.Params))
@@ -3691,26 +3691,43 @@ func Transpile(env *types.Env, prog *parser.Program) (*Program, error) {
 			if fname == "main" {
 				fname = "user_main"
 			}
-                       body, err := convertStmts(bodyEnv, st.Fun.Body)
-                       if overrideRetType != "" {
-                               ret = overrideRetType
-                               funcRets[fname] = ret
-                               overrideRetType = ""
-                       } else {
-                               funcRets[fname] = ret
-                       }
-                       currentRetType = prevRet
-                       if err != nil {
-                               return nil, err
-                       }
-                       var params []string
-                       for _, p0 := range st.Fun.Params {
-                               typ := kotlinType(p0.Type)
-                               if typ == "" {
-                                       typ = "Any"
-                               }
-                               params = append(params, fmt.Sprintf("%s: %s", safeName(p0.Name), typ))
-                       }
+			// record return type before converting body so recursive
+			// calls know their return type
+			funcRets[fname] = ret
+			// isolate variable declarations within function scope
+			savedVarDecls := varDecls
+			varDecls = map[string]*VarStmt{}
+			for k, v := range savedVarDecls {
+				varDecls[k] = v
+			}
+			for _, p0 := range st.Fun.Params {
+				ptyp := kotlinType(p0.Type)
+				if ptyp == "" {
+					ptyp = "Any"
+				}
+				varDecls[p0.Name] = &VarStmt{Name: p0.Name, Type: ptyp}
+			}
+			body, err := convertStmts(bodyEnv, st.Fun.Body)
+			varDecls = savedVarDecls
+			if overrideRetType != "" {
+				ret = overrideRetType
+				funcRets[fname] = ret
+				overrideRetType = ""
+			} else {
+				funcRets[fname] = ret
+			}
+			currentRetType = prevRet
+			if err != nil {
+				return nil, err
+			}
+			var params []string
+			for _, p0 := range st.Fun.Params {
+				typ := kotlinType(p0.Type)
+				if typ == "" {
+					typ = "Any"
+				}
+				params = append(params, fmt.Sprintf("%s: %s", safeName(p0.Name), typ))
+			}
 			// insert mutable parameter locals if assigned
 			for i, p0 := range st.Fun.Params {
 				if paramAssigned(p0.Name, body) {


### PR DESCRIPTION
## Summary
- ensure recursive Kotlin functions know their return type
- keep variable declarations scoped within Kotlin functions

## Testing
- `MOCHI_ALG_INDEX=191 go test ./transpiler/x/kt -tags=slow -run TestKTTranspiler_Algorithms_Golden -update-algorithms-kt -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6896bd9e5cb88320a2386aa070093313