### PR TITLE
clj: support string indexing

### DIFF
--- a/tests/algorithms/x/Clojure/docs/conf.bench
+++ b/tests/algorithms/x/Clojure/docs/conf.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 27855,
-  "memory_bytes": 20691656,
+  "duration_us": 45974,
+  "memory_bytes": 21263064,
   "name": "main"
 }

--- a/tests/algorithms/x/Clojure/docs/conf.clj
+++ b/tests/algorithms/x/Clojure/docs/conf.clj
@@ -14,6 +14,9 @@
 (defn split [s sep]
   (clojure.string/split s (re-pattern sep)))
 
+(defn toi [s]
+  (Integer/parseInt (str s)))
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare parse_project_name)
@@ -25,7 +28,7 @@
 (def ^:dynamic parse_project_name_name nil)
 
 (defn parse_project_name [parse_project_name_toml]
-  (binding [parse_project_name_i nil parse_project_name_n nil parse_project_name_name nil] (try (do (set! parse_project_name_i 0) (set! parse_project_name_name "") (set! parse_project_name_n (count parse_project_name_toml)) (while (< (+ parse_project_name_i 4) parse_project_name_n) (do (when (and (and (and (= (nth parse_project_name_toml parse_project_name_i) "n") (= (nth parse_project_name_toml (+ parse_project_name_i 1)) "a")) (= (nth parse_project_name_toml (+ parse_project_name_i 2)) "m")) (= (nth parse_project_name_toml (+ parse_project_name_i 3)) "e")) (do (set! parse_project_name_i (+ parse_project_name_i 4)) (while (and (< parse_project_name_i parse_project_name_n) (not= (nth parse_project_name_toml parse_project_name_i) "\"")) (set! parse_project_name_i (+ parse_project_name_i 1))) (set! parse_project_name_i (+ parse_project_name_i 1)) (while (and (< parse_project_name_i parse_project_name_n) (not= (nth parse_project_name_toml parse_project_name_i) "\"")) (do (set! parse_project_name_name (str parse_project_name_name (nth parse_project_name_toml parse_project_name_i))) (set! parse_project_name_i (+ parse_project_name_i 1)))) (throw (ex-info "return" {:v parse_project_name_name})))) (set! parse_project_name_i (+ parse_project_name_i 1)))) (throw (ex-info "return" {:v parse_project_name_name}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
+  (binding [parse_project_name_i nil parse_project_name_n nil parse_project_name_name nil] (try (do (set! parse_project_name_i 0) (set! parse_project_name_name "") (set! parse_project_name_n (count parse_project_name_toml)) (while (< (+ parse_project_name_i 4) parse_project_name_n) (do (when (and (and (and (= (subs parse_project_name_toml parse_project_name_i (+ parse_project_name_i 1)) "n") (= (subs parse_project_name_toml (+ parse_project_name_i 1) (+ (+ parse_project_name_i 1) 1)) "a")) (= (subs parse_project_name_toml (+ parse_project_name_i 2) (+ (+ parse_project_name_i 2) 1)) "m")) (= (subs parse_project_name_toml (+ parse_project_name_i 3) (+ (+ parse_project_name_i 3) 1)) "e")) (do (set! parse_project_name_i (+ parse_project_name_i 4)) (while (and (< parse_project_name_i parse_project_name_n) (not= (subs parse_project_name_toml parse_project_name_i (+ parse_project_name_i 1)) "\"")) (set! parse_project_name_i (+ parse_project_name_i 1))) (set! parse_project_name_i (+ parse_project_name_i 1)) (while (and (< parse_project_name_i parse_project_name_n) (not= (subs parse_project_name_toml parse_project_name_i (+ parse_project_name_i 1)) "\"")) (do (set! parse_project_name_name (str parse_project_name_name (subs parse_project_name_toml parse_project_name_i (+ parse_project_name_i 1)))) (set! parse_project_name_i (+ parse_project_name_i 1)))) (throw (ex-info "return" {:v parse_project_name_name})))) (set! parse_project_name_i (+ parse_project_name_i 1)))) (throw (ex-info "return" {:v parse_project_name_name}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
 
 (def ^:dynamic main_pyproject "[project]\nname = \"thealgorithms-python\"")
 

--- a/tests/algorithms/x/Clojure/docs/conf.out
+++ b/tests/algorithms/x/Clojure/docs/conf.out
@@ -1,0 +1,1 @@
+thealgorithms-python

--- a/tests/algorithms/x/Clojure/dynamic_programming/abbreviation.bench
+++ b/tests/algorithms/x/Clojure/dynamic_programming/abbreviation.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 32373,
-  "memory_bytes": 23535032,
+  "duration_us": 51310,
+  "memory_bytes": 23765464,
   "name": "main"
 }

--- a/tests/algorithms/x/Clojure/dynamic_programming/abbreviation.clj
+++ b/tests/algorithms/x/Clojure/dynamic_programming/abbreviation.clj
@@ -14,6 +14,9 @@
 (defn split [s sep]
   (clojure.string/split s (re-pattern sep)))
 
+(defn toi [s]
+  (Integer/parseInt (str s)))
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare index_of ord chr to_upper_char is_lower abbr print_bool)
@@ -47,7 +50,7 @@
 (def ^:dynamic to_upper_char_code nil)
 
 (defn index_of [index_of_s index_of_ch]
-  (binding [index_of_i nil] (try (do (set! index_of_i 0) (while (< index_of_i (count index_of_s)) (do (when (= (nth index_of_s index_of_i) index_of_ch) (throw (ex-info "return" {:v index_of_i}))) (set! index_of_i (+ index_of_i 1)))) (throw (ex-info "return" {:v (- 1)}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
+  (binding [index_of_i nil] (try (do (set! index_of_i 0) (while (< index_of_i (count index_of_s)) (do (when (= (subs index_of_s index_of_i (+ index_of_i 1)) index_of_ch) (throw (ex-info "return" {:v index_of_i}))) (set! index_of_i (+ index_of_i 1)))) (throw (ex-info "return" {:v (- 1)}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
 
 (defn ord [ord_ch]
   (binding [ord_idx nil ord_lower nil ord_upper nil] (try (do (set! ord_upper "ABCDEFGHIJKLMNOPQRSTUVWXYZ") (set! ord_lower "abcdefghijklmnopqrstuvwxyz") (set! ord_idx (index_of ord_upper ord_ch)) (when (>= ord_idx 0) (throw (ex-info "return" {:v (+ 65 ord_idx)}))) (set! ord_idx (index_of ord_lower ord_ch)) (if (>= ord_idx 0) (+ 97 ord_idx) 0)) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
@@ -62,10 +65,10 @@
   (binding [is_lower_code nil] (try (do (set! is_lower_code (ord is_lower_c)) (throw (ex-info "return" {:v (and (>= is_lower_code 97) (<= is_lower_code 122))}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
 
 (defn abbr [abbr_a abbr_b]
-  (binding [abbr_dp nil abbr_i nil abbr_j nil abbr_m nil abbr_n nil abbr_row nil] (try (do (set! abbr_n (count abbr_a)) (set! abbr_m (count abbr_b)) (set! abbr_dp []) (set! abbr_i 0) (while (<= abbr_i abbr_n) (do (set! abbr_row []) (set! abbr_j 0) (while (<= abbr_j abbr_m) (do (set! abbr_row (conj abbr_row false)) (set! abbr_j (+ abbr_j 1)))) (set! abbr_dp (conj abbr_dp abbr_row)) (set! abbr_i (+ abbr_i 1)))) (set! abbr_dp (assoc-in abbr_dp [0 0] true)) (set! abbr_i 0) (while (< abbr_i abbr_n) (do (set! abbr_j 0) (while (<= abbr_j abbr_m) (do (when (nth (nth abbr_dp abbr_i) abbr_j) (do (when (and (< abbr_j abbr_m) (= (to_upper_char (nth abbr_a abbr_i)) (nth abbr_b abbr_j))) (set! abbr_dp (assoc-in abbr_dp [(+ abbr_i 1) (+ abbr_j 1)] true))) (when (is_lower (nth abbr_a abbr_i)) (set! abbr_dp (assoc-in abbr_dp [(+ abbr_i 1) abbr_j] true))))) (set! abbr_j (+ abbr_j 1)))) (set! abbr_i (+ abbr_i 1)))) (throw (ex-info "return" {:v (nth (nth abbr_dp abbr_n) abbr_m)}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
+  (binding [abbr_dp nil abbr_i nil abbr_j nil abbr_m nil abbr_n nil abbr_row nil] (try (do (set! abbr_n (count abbr_a)) (set! abbr_m (count abbr_b)) (set! abbr_dp []) (set! abbr_i 0) (while (<= abbr_i abbr_n) (do (set! abbr_row []) (set! abbr_j 0) (while (<= abbr_j abbr_m) (do (set! abbr_row (conj abbr_row false)) (set! abbr_j (+ abbr_j 1)))) (set! abbr_dp (conj abbr_dp abbr_row)) (set! abbr_i (+ abbr_i 1)))) (set! abbr_dp (assoc-in abbr_dp [0 0] true)) (set! abbr_i 0) (while (< abbr_i abbr_n) (do (set! abbr_j 0) (while (<= abbr_j abbr_m) (do (when (nth (nth abbr_dp abbr_i) abbr_j) (do (when (and (< abbr_j abbr_m) (= (to_upper_char (subs abbr_a abbr_i (+ abbr_i 1))) (subs abbr_b abbr_j (+ abbr_j 1)))) (set! abbr_dp (assoc-in abbr_dp [(+ abbr_i 1) (+ abbr_j 1)] true))) (when (is_lower (subs abbr_a abbr_i (+ abbr_i 1))) (set! abbr_dp (assoc-in abbr_dp [(+ abbr_i 1) abbr_j] true))))) (set! abbr_j (+ abbr_j 1)))) (set! abbr_i (+ abbr_i 1)))) (throw (ex-info "return" {:v (nth (nth abbr_dp abbr_n) abbr_m)}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
 
 (defn print_bool [print_bool_b]
-  (if print_bool_b (println true) (println false)))
+  (do (if print_bool_b (println true) (println false)) print_bool_b))
 
 (defn -main []
   (let [rt (Runtime/getRuntime)

--- a/tests/algorithms/x/Clojure/dynamic_programming/abbreviation.out
+++ b/tests/algorithms/x/Clojure/dynamic_programming/abbreviation.out
@@ -1,2 +1,2 @@
-false
+true
 false

--- a/tests/algorithms/x/Clojure/dynamic_programming/all_construct.bench
+++ b/tests/algorithms/x/Clojure/dynamic_programming/all_construct.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 45822,
-  "memory_bytes": 21417648,
+  "duration_us": 63890,
+  "memory_bytes": 21387008,
   "name": "main"
 }

--- a/tests/algorithms/x/Clojure/dynamic_programming/all_construct.clj
+++ b/tests/algorithms/x/Clojure/dynamic_programming/all_construct.clj
@@ -14,6 +14,9 @@
 (defn split [s sep]
   (clojure.string/split s (re-pattern sep)))
 
+(defn toi [s]
+  (Integer/parseInt (str s)))
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare allConstruct)

--- a/tests/algorithms/x/Clojure/dynamic_programming/bitmask.bench
+++ b/tests/algorithms/x/Clojure/dynamic_programming/bitmask.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 28883,
-  "memory_bytes": 20845280,
+  "duration_us": 56138,
+  "memory_bytes": 20737432,
   "name": "main"
 }

--- a/tests/algorithms/x/Clojure/dynamic_programming/bitmask.clj
+++ b/tests/algorithms/x/Clojure/dynamic_programming/bitmask.clj
@@ -14,6 +14,9 @@
 (defn split [s sep]
   (clojure.string/split s (re-pattern sep)))
 
+(defn toi [s]
+  (Integer/parseInt (str s)))
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare count_assignments count_no_of_ways main)

--- a/tests/algorithms/x/Clojure/dynamic_programming/catalan_numbers.bench
+++ b/tests/algorithms/x/Clojure/dynamic_programming/catalan_numbers.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 46773,
-  "memory_bytes": 20296360,
+  "duration_us": 58577,
+  "memory_bytes": 20588848,
   "name": "main"
 }

--- a/tests/algorithms/x/Clojure/dynamic_programming/catalan_numbers.clj
+++ b/tests/algorithms/x/Clojure/dynamic_programming/catalan_numbers.clj
@@ -14,6 +14,9 @@
 (defn split [s sep]
   (clojure.string/split s (re-pattern sep)))
 
+(defn toi [s]
+  (Integer/parseInt (str s)))
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare panic catalan_numbers)
@@ -27,7 +30,7 @@
 (def ^:dynamic catalan_numbers_next_val nil)
 
 (defn panic [panic_msg]
-  (println panic_msg))
+  (do (println panic_msg) panic_msg))
 
 (defn catalan_numbers [catalan_numbers_upper_limit]
   (binding [catalan_numbers_catalans nil catalan_numbers_j nil catalan_numbers_n nil catalan_numbers_next_val nil] (try (do (when (< catalan_numbers_upper_limit 0) (do (panic "Limit for the Catalan sequence must be >= 0") (throw (ex-info "return" {:v []})))) (set! catalan_numbers_catalans [1]) (set! catalan_numbers_n 1) (while (<= catalan_numbers_n catalan_numbers_upper_limit) (do (set! catalan_numbers_next_val 0) (set! catalan_numbers_j 0) (while (< catalan_numbers_j catalan_numbers_n) (do (set! catalan_numbers_next_val (+ catalan_numbers_next_val (* (nth catalan_numbers_catalans catalan_numbers_j) (nth catalan_numbers_catalans (- (- catalan_numbers_n catalan_numbers_j) 1))))) (set! catalan_numbers_j (+ catalan_numbers_j 1)))) (set! catalan_numbers_catalans (conj catalan_numbers_catalans catalan_numbers_next_val)) (set! catalan_numbers_n (+ catalan_numbers_n 1)))) (throw (ex-info "return" {:v catalan_numbers_catalans}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))

--- a/tests/algorithms/x/Clojure/dynamic_programming/climbing_stairs.bench
+++ b/tests/algorithms/x/Clojure/dynamic_programming/climbing_stairs.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 38246,
-  "memory_bytes": 20213168,
+  "duration_us": 53545,
+  "memory_bytes": 19940848,
   "name": "main"
 }

--- a/tests/algorithms/x/Clojure/dynamic_programming/climbing_stairs.clj
+++ b/tests/algorithms/x/Clojure/dynamic_programming/climbing_stairs.clj
@@ -14,6 +14,9 @@
 (defn split [s sep]
   (clojure.string/split s (re-pattern sep)))
 
+(defn toi [s]
+  (Integer/parseInt (str s)))
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare climb_stairs)

--- a/tests/algorithms/x/Clojure/dynamic_programming/combination_sum_iv.bench
+++ b/tests/algorithms/x/Clojure/dynamic_programming/combination_sum_iv.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 37286,
-  "memory_bytes": 23206664,
+  "duration_us": 51910,
+  "memory_bytes": 22821896,
   "name": "main"
 }

--- a/tests/algorithms/x/Clojure/dynamic_programming/combination_sum_iv.clj
+++ b/tests/algorithms/x/Clojure/dynamic_programming/combination_sum_iv.clj
@@ -14,6 +14,9 @@
 (defn split [s sep]
   (clojure.string/split s (re-pattern sep)))
 
+(defn toi [s]
+  (Integer/parseInt (str s)))
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare make_list count_recursive combination_sum_iv count_dp combination_sum_iv_dp_array combination_sum_iv_bottom_up)

--- a/tests/algorithms/x/Clojure/dynamic_programming/edit_distance.bench
+++ b/tests/algorithms/x/Clojure/dynamic_programming/edit_distance.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 147950,
-  "memory_bytes": 24548728,
+  "duration_us": 218464,
+  "memory_bytes": 24674328,
   "name": "main"
 }

--- a/tests/algorithms/x/Clojure/dynamic_programming/edit_distance.clj
+++ b/tests/algorithms/x/Clojure/dynamic_programming/edit_distance.clj
@@ -14,6 +14,9 @@
 (defn split [s sep]
   (clojure.string/split s (re-pattern sep)))
 
+(defn toi [s]
+  (Integer/parseInt (str s)))
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare min3 helper_top_down min_dist_top_down min_dist_bottom_up)

--- a/tests/algorithms/x/Clojure/dynamic_programming/factorial.bench
+++ b/tests/algorithms/x/Clojure/dynamic_programming/factorial.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 51875,
-  "memory_bytes": 20657024,
+  "duration_us": 70380,
+  "memory_bytes": 20567424,
   "name": "main"
 }

--- a/tests/algorithms/x/Clojure/dynamic_programming/factorial.clj
+++ b/tests/algorithms/x/Clojure/dynamic_programming/factorial.clj
@@ -14,6 +14,9 @@
 (defn split [s sep]
   (clojure.string/split s (re-pattern sep)))
 
+(defn toi [s]
+  (Integer/parseInt (str s)))
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare factorial)

--- a/tests/algorithms/x/Clojure/dynamic_programming/fast_fibonacci.bench
+++ b/tests/algorithms/x/Clojure/dynamic_programming/fast_fibonacci.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 37346,
-  "memory_bytes": 20567792,
+  "duration_us": 50072,
+  "memory_bytes": 20899952,
   "name": "main"
 }

--- a/tests/algorithms/x/Clojure/dynamic_programming/fast_fibonacci.clj
+++ b/tests/algorithms/x/Clojure/dynamic_programming/fast_fibonacci.clj
@@ -14,6 +14,9 @@
 (defn split [s sep]
   (clojure.string/split s (re-pattern sep)))
 
+(defn toi [s]
+  (Integer/parseInt (str s)))
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare _fib fibonacci)

--- a/transpiler/x/clj/ALGORITHMS.md
+++ b/transpiler/x/clj/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Clojure code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Clojure`.
-Last updated: 2025-08-09 10:41 GMT+7
+Last updated: 2025-08-09 16:06 GMT+7
 
 ## Algorithms Golden Test Checklist (419/1077)
 | Index | Name | Status | Duration | Memory |
@@ -306,16 +306,16 @@ Last updated: 2025-08-09 10:41 GMT+7
 | 297 | divide_and_conquer/peak | ✓ | 29.857ms | 19.65MB |
 | 298 | divide_and_conquer/power | ✓ | 31.917ms | 19.49MB |
 | 299 | divide_and_conquer/strassen_matrix_multiplication | ✓ | 195.425ms | 27.71MB |
-| 300 | docs/conf | ✓ | 27.855ms | 19.73MB |
-| 301 | dynamic_programming/abbreviation | ✓ | 32.373ms | 22.44MB |
-| 302 | dynamic_programming/all_construct | ✓ | 45.822ms | 20.43MB |
-| 303 | dynamic_programming/bitmask | ✓ | 28.883ms | 19.88MB |
-| 304 | dynamic_programming/catalan_numbers | ✓ | 46.773ms | 19.36MB |
-| 305 | dynamic_programming/climbing_stairs | ✓ | 38.246ms | 19.28MB |
-| 306 | dynamic_programming/combination_sum_iv | ✓ | 37.286ms | 22.13MB |
-| 307 | dynamic_programming/edit_distance | ✓ | 147.95ms | 23.41MB |
-| 308 | dynamic_programming/factorial | ✓ | 51.875ms | 19.70MB |
-| 309 | dynamic_programming/fast_fibonacci | ✓ | 37.346ms | 19.61MB |
+| 300 | docs/conf | ✓ | 45.974ms | 20.28MB |
+| 301 | dynamic_programming/abbreviation | ✓ | 51.31ms | 22.66MB |
+| 302 | dynamic_programming/all_construct | ✓ | 63.89ms | 20.40MB |
+| 303 | dynamic_programming/bitmask | ✓ | 56.138ms | 19.78MB |
+| 304 | dynamic_programming/catalan_numbers | ✓ | 58.577ms | 19.64MB |
+| 305 | dynamic_programming/climbing_stairs | ✓ | 53.545ms | 19.02MB |
+| 306 | dynamic_programming/combination_sum_iv | ✓ | 51.91ms | 21.76MB |
+| 307 | dynamic_programming/edit_distance | ✓ | 218.464ms | 23.53MB |
+| 308 | dynamic_programming/factorial | ✓ | 70.38ms | 19.61MB |
+| 309 | dynamic_programming/fast_fibonacci | ✓ | 50.072ms | 19.93MB |
 | 310 | dynamic_programming/fibonacci | ✓ | 71.727ms | 20.10MB |
 | 311 | dynamic_programming/fizz_buzz | ✓ | 39.596ms | 19.50MB |
 | 312 | dynamic_programming/floyd_warshall | ✓ | 47.381ms | 21.39MB |

--- a/transpiler/x/clj/transpiler.go
+++ b/transpiler/x/clj/transpiler.go
@@ -3,21 +3,21 @@
 package cljt
 
 import (
-        "bytes"
-        "encoding/json"
-        "fmt"
-        "io"
-        "os"
-        "path/filepath"
-        "sort"
-        "strconv"
-        "strings"
-        "unicode"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
 
-        yaml "gopkg.in/yaml.v3"
+	yaml "gopkg.in/yaml.v3"
 
-        "mochi/parser"
-        "mochi/types"
+	"mochi/parser"
+	"mochi/types"
 )
 
 // mutatingCallFuncs lists functions that mutate their first argument when
@@ -26,7 +26,7 @@ import (
 // first argument. This avoids incorrectly rewriting normal function calls
 // like `strictly_diagonally_dominant(coefficient)`.
 var mutatingCallFuncs = map[string]bool{
-        "append": true,
+	"append": true,
 }
 
 // --- Simple Clojure AST ---
@@ -1014,30 +1014,30 @@ func transpileStmt(s *parser.Statement) (Node, error) {
 	case s.ExternVar != nil, s.ExternFun != nil, s.ExternType != nil, s.ExternObject != nil:
 		// extern declarations only affect type checking
 		return nil, nil
-       case s.Expr != nil:
-               if c := callExpr(s.Expr.Expr); c != nil {
-                       if len(c.Args) > 0 {
-                               if name, ok := identName(c.Args[0]); ok {
-                                       if transpileEnv != nil {
-                                               if _, ok := transpileEnv.GetFunc(c.Func); ok && mutatingCallFuncs[c.Func] {
-                                                       n, err := transpileExpr(s.Expr.Expr)
-                                                       if err != nil {
-                                                               return nil, err
-                                                       }
-                                                       if declVars != nil && declVars[name] {
-                                                               return &List{Elems: []Node{Symbol("set!"), Symbol(name), n}}, nil
-                                                       }
-                                                       return &List{Elems: []Node{
-                                                               Symbol("alter-var-root"),
-                                                               &List{Elems: []Node{Symbol("var"), Symbol(name)}},
-                                                               &List{Elems: []Node{Symbol("constantly"), n}},
-                                                       }}, nil
-                                               }
-                                       }
-                               }
-                       }
-               }
-               return transpileExpr(s.Expr.Expr)
+	case s.Expr != nil:
+		if c := callExpr(s.Expr.Expr); c != nil {
+			if len(c.Args) > 0 {
+				if name, ok := identName(c.Args[0]); ok {
+					if transpileEnv != nil {
+						if _, ok := transpileEnv.GetFunc(c.Func); ok && mutatingCallFuncs[c.Func] {
+							n, err := transpileExpr(s.Expr.Expr)
+							if err != nil {
+								return nil, err
+							}
+							if declVars != nil && declVars[name] {
+								return &List{Elems: []Node{Symbol("set!"), Symbol(name), n}}, nil
+							}
+							return &List{Elems: []Node{
+								Symbol("alter-var-root"),
+								&List{Elems: []Node{Symbol("var"), Symbol(name)}},
+								&List{Elems: []Node{Symbol("constantly"), n}},
+							}}, nil
+						}
+					}
+				}
+			}
+		}
+		return transpileExpr(s.Expr.Expr)
 	case s.If != nil:
 		return transpileIfStmt(s.If)
 	case s.Let != nil:
@@ -2053,7 +2053,11 @@ func transpilePostfix(p *parser.PostfixExpr) (Node, error) {
 			if err != nil {
 				return nil, err
 			}
-			if isMapNode(n) || isStringNode(i) {
+			if isStringNode(n) {
+				// Indexing a string returns a one-character substring
+				one := &List{Elems: []Node{Symbol("+"), i, IntLit(1)}}
+				n = &List{Elems: []Node{Symbol("subs"), n, i, one}}
+			} else if isMapNode(n) || isStringNode(i) {
 				n = &List{Elems: []Node{Symbol("get"), n, i}}
 			} else if l, ok := n.(*List); ok && len(l.Elems) == 2 {
 				if kw, ok1 := l.Elems[0].(Keyword); ok1 {


### PR DESCRIPTION
## Summary
- fix Clojure transpiler so indexing a string yields a one-character substring
- regenerate Clojure algorithm fixtures for indices 300-309

## Testing
- `MOCHI_ALG_INDEX=300 go test ./transpiler/x/clj -run TestClojureTranspiler_Algorithms_Golden -tags slow -count=1`
- `MOCHI_ALG_INDEX=301 go test ./transpiler/x/clj -run TestClojureTranspiler_Algorithms_Golden -tags slow -count=1`
- `for i in $(seq 302 309); do MOCHI_ALG_INDEX=$i go test ./transpiler/x/clj -run TestClojureTranspiler_Algorithms_Golden -tags slow -count=1; done`


------
https://chatgpt.com/codex/tasks/task_e_68970e059cf0832097a776af618b7108