### PR TITLE
docs: add v0.10.63 changelog and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # 📦 CHANGELOG.md
 
+## [0.10.63] – 2025-08-09T18:16:04+07:00
+
+### Added
+
+* Broadened algorithm outputs and coverage across languages including C++, C#, Elixir, and OCaml.
+* Enhanced slice, string, and list handling in many transpilers such as Clojure, Java, Kotlin, Rust, PHP, and Zig.
+* Improved memory detection in TypeScript and guarded resource imports in Python.
+
+### Changed
+
+* Refreshed algorithm outputs and benchmarks across Scheme, Go, Ruby, Swift, and more.
+* Updated Project Euler datasets and new algorithms like OCaml resistor equivalence.
+
+### Fixed
+
+* Resolved C++ const list appends, PHP struct literal keys, and Zig slice returns.
+* Corrected benchmark timing and algorithm handling in Ruby and Java.
+
+
 ## [0.10.62] – 2025-08-09T03:04:56+00:00
 
 ### Added

--- a/releases/v0.10.63.md
+++ b/releases/v0.10.63.md
@@ -1,0 +1,16 @@
+# Aug 2025 (v0.10.63)
+
+Released on Sat Aug 09 18:16:04 2025 +0700.
+
+Mochi v0.10.63 broadens algorithm coverage and improves slice and string handling across many transpilers.
+
+## Transpilers
+
+- Expanded slice, string, and list handling across Clojure, Java, Kotlin, Rust, PHP, Zig, and others.
+- Added helpers and fixes including Python resource import guards, default returns in Zig, and C docs/conf algorithm support.
+- Improved memory detection in TypeScript and refined Dart list casting.
+
+## Algorithms
+
+- Added or refreshed algorithm outputs for C++, C#, Elixir, Scheme, Go, Ruby, and more.
+- Introduced new OCaml resistor equivalence algorithm and expanded Project Euler datasets.


### PR DESCRIPTION
## Summary
- document v0.10.63 release with date-driven changelog
- add release notes highlighting algorithm coverage and slicing improvements

## Testing
- `npm test` *(fails: Missing script: "test")*
- `go test ./... -run TestNonExistent`


------
https://chatgpt.com/codex/tasks/task_e_68972de28a188320b5bd95b74b61feee