### PR TITLE
docs: add v0.10.64 changelog and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # 📦 CHANGELOG.md
 
+## [0.10.64] – 2025-08-11T11:27:00+00:00
+
+### Added
+
+* Min/max operations across Pascal real arrays, Java primitive arrays, and Go floats.
+* Unit return handling in Zig and Rust, with Swift treating unit as `Void`.
+* Python transpiler adds `not-in`; F# handles forward references and I/O.
+* Algorithm outputs expanded for Scheme, Scala, and Elixir.
+
+### Changed
+
+* Go transpiler now handles numeric `any` concatenation; Kotlin improves list type inference.
+* Pascal refines array printing and void functions; Racket isolates `if` branches.
+
+### Fixed
+
+* Parser unary usage alignment.
+* OCaml dynamic map handling.
+
 ## [0.10.63] – 2025-08-09T18:16:04+07:00
 
 ### Added

--- a/releases/v0.10.64.md
+++ b/releases/v0.10.64.md
@@ -1,0 +1,18 @@
+# Aug 2025 (v0.10.64)
+
+Released on Mon Aug 11 11:27:00 2025 +0000.
+
+Mochi v0.10.64 adds min/max helpers across multiple transpilers, refines unit return handling, and expands algorithm coverage.
+
+## Transpilers
+
+- Min/max support for Pascal real arrays, Java primitive arrays, and Go floats.
+- Zig and Rust support unit returns; Swift treats unit as `Void`.
+- Python adds `not-in`; F# handles forward refs and basic I/O.
+- Go handles numeric `any` concatenation; Kotlin improves list type inference.
+- Pascal refines array printing; Racket isolates `if` branches.
+- Fixed OCaml dynamic maps and aligned parser unary usage.
+
+## Algorithms
+
+- Added or refreshed algorithm outputs for Scheme, Scala, Python, and Elixir.


### PR DESCRIPTION
## Summary
- document min/max helpers, unit returns, and transpiler improvements
- expand algorithm outputs across Scheme, Scala, Python, and Elixir

## Testing
- `npm test` *(fails: Missing script "test")*
- `go test ./... --vet=off -v` *(fails: runtime/data/duckdb.go:306:28: cannot use op.Right (variable of type *parser.PostfixExpr) as *parser.Unary value in argument to unaryToSQL)*

------
https://chatgpt.com/codex/tasks/task_e_6899d2ca82c48320a944210e834be9c0