### PR TITLE
Fix binary expression handling for PostfixExpr

### DIFF
--- a/interpreter/consteval.go
+++ b/interpreter/consteval.go
@@ -71,9 +71,9 @@ func isConstExpr(e *parser.Expr, env *types.Env) bool {
 		return false
 	}
 	for _, op := range e.Binary.Right {
-		// BinaryOp.Right is a *parser.Unary after parser refactor.
-		// Use isConstUnary to inspect the entire unary expression.
-		if !isConstUnary(op.Right, env) {
+		// BinaryOp.Right is a *parser.PostfixExpr, so check the postfix
+		// expression directly for constant-ness.
+		if !isConstPostfix(op.Right, env) {
 			return false
 		}
 	}

--- a/interpreter/fold.go
+++ b/interpreter/fold.go
@@ -73,9 +73,9 @@ func foldExpr(e *parser.Expr, env *types.Env) {
 	}
 	foldUnary(e.Binary.Left, env)
 	for _, op := range e.Binary.Right {
-		// BinaryOp.Right now holds a *parser.Unary. Fold the unary
-		// expression rather than assuming a postfix expression.
-		foldUnary(op.Right, env)
+		// BinaryOp.Right is a *parser.PostfixExpr; fold the postfix
+		// expression directly.
+		foldPostfixExpr(op.Right, env)
 	}
 	if call, ok := callPattern(e); ok {
 		if lit, ok := foldCall(call, env); ok {

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -947,8 +947,9 @@ func (i *Interpreter) evalBinaryExpr(b *parser.BinaryExpr) (any, error) {
 	for _, part := range b.Right {
 		p := part
 		operators = append(operators, token{p.Pos, p.Op})
-		// Each binary operation's right side is now a unary expression.
-		operands = append(operands, operand{eval: func() (any, error) { return i.evalUnary(p.Right) }})
+		// Each binary operation's right side is stored as a postfix
+		// expression in the AST, so evaluate it accordingly.
+		operands = append(operands, operand{eval: func() (any, error) { return i.evalPostfixExpr(p.Right) }})
 	}
 
 	// Step 2: Apply precedence rules (high to low)

--- a/runtime/data/duckdb.go
+++ b/runtime/data/duckdb.go
@@ -297,13 +297,12 @@ func exprToSQL(e *parser.Expr, resolve func(string) (string, bool)) (string, err
 		return "", err
 	}
 	for _, op := range e.Binary.Right {
-		// op.Right is a *parser.Unary, which may contain prefix operators
-		// and a postfix expression.  The previous implementation attempted
-		// to pass it directly to postfixToSQL which expects a *parser.PostfixExpr
-		// and resulted in a compile-time type mismatch after parser refactors.
-		// Use unaryToSQL so both prefix operators and the inner postfix
-		// expression are handled correctly.
-		right, err := unaryToSQL(op.Right, resolve)
+		// In the AST a binary operator's right-hand side is stored as a
+		// *parser.PostfixExpr.  Earlier refactoring attempted to treat it
+		// as a *parser.Unary and call unaryToSQL which caused a compile-time
+		// type mismatch.  The right-hand side does not include prefix
+		// operators, so we can convert it directly using postfixToSQL.
+		right, err := postfixToSQL(op.Right, resolve)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
## Summary
- handle binary op right-hand sides as PostfixExpr across runtime and interpreter
- adjust constant folding and evaluation logic for PostfixExpr
- fix SQL translation for binary expressions

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899d292f38083209a3e447f816bc9a2