### PR TITLE
pascal: handle unary expressions in binary ops

### DIFF
--- a/tests/algorithms/x/Pascal/machine_learning/data_transformations.pas
+++ b/tests/algorithms/x/Pascal/machine_learning/data_transformations.pas
@@ -2,37 +2,6 @@
 program Main;
 uses SysUtils, Math;
 type RealArray = array of real;
-var _nowSeed: int64 = 0;
-var _nowSeeded: boolean = false;
-procedure init_now();
-var s: string; v: int64;
-begin
-  s := GetEnvironmentVariable('MOCHI_NOW_SEED');
-  if s <> '' then begin
-    Val(s, v);
-    _nowSeed := v;
-    _nowSeeded := true;
-  end;
-end;
-function _now(): integer;
-begin
-  if _nowSeeded then begin
-    _nowSeed := (_nowSeed * 1664525 + 1013904223) mod 2147483647;
-    _now := _nowSeed;
-  end else begin
-    _now := Integer(GetTickCount64()*1000);
-  end;
-end;
-function _bench_now(): int64;
-begin
-  _bench_now := GetTickCount64()*1000;
-end;
-function _mem(): int64;
-var h: TFPCHeapStatus;
-begin
-  h := GetFPCHeapStatus;
-  _mem := h.CurrHeapUsed;
-end;
 procedure panic(msg: string);
 begin
   writeln(msg);
@@ -64,69 +33,60 @@ begin
   end;
   Result := Result + ']';
 end;
-var
-  bench_start_0: integer;
-  bench_dur_0: integer;
-  bench_mem_0: int64;
-  bench_memdiff_0: int64;
-  data: RealArray;
-  x: real;
-  n: integer;
-  ndigits: integer;
-function floor(x: real): real; forward;
-function pow10(n: integer): real; forward;
-function round(x: real; n: integer): real; forward;
-function sqrtApprox(x: real): real; forward;
-function mean(data: RealArray): real; forward;
-function stdev(data: RealArray): real; forward;
-function normalization(data: RealArray; ndigits: integer): RealArray; forward;
-function standardization(data: RealArray; ndigits: integer): RealArray; forward;
-function floor(x: real): real;
+function floor(floor_x: real): real; forward;
+function pow10(pow10_n: integer): real; forward;
+function round(round_x: real; round_n: integer): real; forward;
+function sqrtApprox(sqrtApprox_x: real): real; forward;
+function mean(mean_data: RealArray): real; forward;
+function stdev(stdev_data: RealArray): real; forward;
+function normalization(normalization_data: RealArray; normalization_ndigits: integer): RealArray; forward;
+function standardization(standardization_data: RealArray; standardization_ndigits: integer): RealArray; forward;
+function floor(floor_x: real): real;
 var
   floor_i: integer;
 begin
-  floor_i := Trunc(x);
-  if Double(floor_i) > x then begin
+  floor_i := Trunc(floor_x);
+  if Double(floor_i) > floor_x then begin
   floor_i := floor_i - 1;
 end;
   exit(Double(floor_i));
 end;
-function pow10(n: integer): real;
+function pow10(pow10_n: integer): real;
 var
   pow10_result_: real;
   pow10_i: integer;
 begin
   pow10_result_ := 1;
   pow10_i := 0;
-  while pow10_i < n do begin
+  while pow10_i < pow10_n do begin
   pow10_result_ := pow10_result_ * 10;
   pow10_i := pow10_i + 1;
 end;
   exit(pow10_result_);
 end;
-function round(x: real; n: integer): real;
+function round(round_x: real; round_n: integer): real;
 var
   round_m: real;
   round_y: real;
 begin
-  round_m := pow10(n);
-  round_y := Double(Floor((x * round_m) + 0.5));
+  round_m := pow10(round_n);
+  round_y := Double(Floor((round_x * round_m) + 0.5));
   exit(round_y / round_m);
 end;
-function sqrtApprox(x: real): real;
+function sqrtApprox(sqrtApprox_x: real): real;
 var
   sqrtApprox_guess: real;
   sqrtApprox_i: integer;
 begin
-  sqrtApprox_guess := x;
+  sqrtApprox_guess := sqrtApprox_x;
   sqrtApprox_i := 0;
   while sqrtApprox_i < 20 do begin
-  sqrtApprox_guess := (sqrtApprox_guess + (x / sqrtApprox_guess)) / 2;
+  sqrtApprox_guess := (sqrtApprox_guess + (sqrtApprox_x / sqrtApprox_guess)) / 2;
   sqrtApprox_i := sqrtApprox_i + 1;
 end;
   exit(sqrtApprox_guess);
 end;
-function mean(data: RealArray): real;
+function mean(mean_data: RealArray): real;
 var
   mean_total: real;
   mean_i: integer;
@@ -134,14 +94,14 @@ var
 begin
   mean_total := 0;
   mean_i := 0;
-  mean_n := Length(data);
+  mean_n := Length(mean_data);
   while mean_i < mean_n do begin
-  mean_total := mean_total + data[mean_i];
+  mean_total := mean_total + mean_data[mean_i];
   mean_i := mean_i + 1;
 end;
   exit(mean_total / Double(mean_n));
 end;
-function stdev(data: RealArray): real;
+function stdev(stdev_data: RealArray): real;
 var
   stdev_n: integer;
   stdev_m: real;
@@ -149,21 +109,21 @@ var
   stdev_i: integer;
   stdev_diff: real;
 begin
-  stdev_n := Length(data);
+  stdev_n := Length(stdev_data);
   if stdev_n <= 1 then begin
   panic('data length must be > 1');
 end;
-  stdev_m := mean(data);
+  stdev_m := mean(stdev_data);
   stdev_sum_sq := 0;
   stdev_i := 0;
   while stdev_i < stdev_n do begin
-  stdev_diff := data[stdev_i] - stdev_m;
+  stdev_diff := stdev_data[stdev_i] - stdev_m;
   stdev_sum_sq := stdev_sum_sq + (stdev_diff * stdev_diff);
   stdev_i := stdev_i + 1;
 end;
   exit(sqrtApprox(stdev_sum_sq / Double(stdev_n - 1)));
 end;
-function normalization(data: RealArray; ndigits: integer): RealArray;
+function normalization(normalization_data: RealArray; normalization_ndigits: integer): RealArray;
 var
   normalization_x_min: real;
   normalization_x_max: real;
@@ -173,20 +133,20 @@ var
   normalization_n: integer;
   normalization_norm: real;
 begin
-  normalization_x_min := Double(min_real(data));
-  normalization_x_max := Double(max_real(data));
+  normalization_x_min := Double(min_real(normalization_data));
+  normalization_x_max := Double(max_real(normalization_data));
   normalization_denom := normalization_x_max - normalization_x_min;
   normalization_result_ := [];
   normalization_i := 0;
-  normalization_n := Length(data);
+  normalization_n := Length(normalization_data);
   while normalization_i < normalization_n do begin
-  normalization_norm := (data[normalization_i] - normalization_x_min) / normalization_denom;
-  normalization_result_ := concat(normalization_result_, [round(normalization_norm, ndigits)]);
+  normalization_norm := (normalization_data[normalization_i] - normalization_x_min) / normalization_denom;
+  normalization_result_ := concat(normalization_result_, [round(normalization_norm, normalization_ndigits)]);
   normalization_i := normalization_i + 1;
 end;
   exit(normalization_result_);
 end;
-function standardization(data: RealArray; ndigits: integer): RealArray;
+function standardization(standardization_data: RealArray; standardization_ndigits: integer): RealArray;
 var
   standardization_mu: real;
   standardization_sigma: real;
@@ -195,31 +155,21 @@ var
   standardization_n: integer;
   standardization_z: real;
 begin
-  standardization_mu := mean(data);
-  standardization_sigma := stdev(data);
+  standardization_mu := mean(standardization_data);
+  standardization_sigma := stdev(standardization_data);
   standardization_result_ := [];
   standardization_i := 0;
-  standardization_n := Length(data);
+  standardization_n := Length(standardization_data);
   while standardization_i < standardization_n do begin
-  standardization_z := (data[standardization_i] - standardization_mu) / standardization_sigma;
-  standardization_result_ := concat(standardization_result_, [round(standardization_z, ndigits)]);
+  standardization_z := (standardization_data[standardization_i] - standardization_mu) / standardization_sigma;
+  standardization_result_ := concat(standardization_result_, [round(standardization_z, standardization_ndigits)]);
   standardization_i := standardization_i + 1;
 end;
   exit(standardization_result_);
 end;
 begin
-  init_now();
-  bench_mem_0 := _mem();
-  bench_start_0 := _bench_now();
   writeln(list_real_to_str(normalization([2, 7, 10, 20, 30, 50], 3)));
   writeln(list_real_to_str(normalization([5, 10, 15, 20, 25], 3)));
   writeln(list_real_to_str(standardization([2, 7, 10, 20, 30, 50], 3)));
   writeln(list_real_to_str(standardization([5, 10, 15, 20, 25], 3)));
-  bench_memdiff_0 := _mem() - bench_mem_0;
-  bench_dur_0 := (_bench_now() - bench_start_0) div 1000;
-  writeln('{');
-  writeln(('  "duration_us": ' + IntToStr(bench_dur_0)) + ',');
-  writeln(('  "memory_bytes": ' + IntToStr(bench_memdiff_0)) + ',');
-  writeln(('  "name": "' + 'main') + '"');
-  writeln('}');
 end.

--- a/transpiler/x/pas/ALGORITHMS.md
+++ b/transpiler/x/pas/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Pascal code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Pascal`.
-Last updated: 2025-08-11 18:13 GMT+7
+Last updated: 2025-08-11 18:36 GMT+7
 
 ## Algorithms Golden Test Checklist (267/1077)
 | Index | Name | Status | Duration | Memory |

--- a/transpiler/x/pas/transpiler.go
+++ b/transpiler/x/pas/transpiler.go
@@ -2990,7 +2990,7 @@ func convertExpr(env *types.Env, e *parser.Expr) (Expr, error) {
 		return left, nil
 	}
 	if len(e.Binary.Right) == 1 && e.Binary.Right[0].Op == "+" {
-		right, err := convertUnary(env, e.Binary.Right[0].Right)
+		right, err := convertUnary(env, &parser.Unary{Value: e.Binary.Right[0].Right})
 		if err != nil {
 			return nil, err
 		}
@@ -3001,11 +3001,11 @@ func convertExpr(env *types.Env, e *parser.Expr) (Expr, error) {
 		}
 	}
 	if len(e.Binary.Right) == 1 && e.Binary.Right[0].Op == "in" {
-		right, err := convertUnary(env, e.Binary.Right[0].Right)
+		right, err := convertUnary(env, &parser.Unary{Value: e.Binary.Right[0].Right})
 		if err != nil {
 			return nil, err
 		}
-		tmp := &parser.Expr{Binary: &parser.BinaryExpr{Left: e.Binary.Right[0].Right}}
+		tmp := &parser.Expr{Binary: &parser.BinaryExpr{Left: &parser.Unary{Value: e.Binary.Right[0].Right}}}
 		t := types.ExprType(tmp, env)
 		if _, ok := t.(types.ListType); ok {
 			currProg.NeedContains = true
@@ -3107,7 +3107,7 @@ func convertExpr(env *types.Env, e *parser.Expr) (Expr, error) {
 	}
 
 	for _, op := range e.Binary.Right {
-		right, err := convertUnary(env, op.Right)
+		right, err := convertUnary(env, &parser.Unary{Value: op.Right})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- fix Pascal transpiler to wrap binary operands as `parser.Unary`
- add generated Pascal code and output for `machine_learning/data_transformations`
- refresh algorithms index with new benchmark entry

## Testing
- `MOCHI_ALG_INDEX=500 go test ./transpiler/x/pas -run TestPascalTranspiler_Algorithms_Golden -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_6899d47bb6e88320b187c506d47511b0