### PR TITLE
scheme: handle postfix in binary expr

### DIFF
--- a/transpiler/x/scheme/ALGORITHMS.md
+++ b/transpiler/x/scheme/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Scheme code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Scheme`.
-Last updated: 2025-08-11 18:24 GMT+7
+Last updated: 2025-08-11 18:35 GMT+7
 
 ## Algorithms Golden Test Checklist (823/1077)
 | Index | Name | Status | Duration | Memory |

--- a/transpiler/x/scheme/transpiler.go
+++ b/transpiler/x/scheme/transpiler.go
@@ -1367,12 +1367,17 @@ func convertParserExpr(e *parser.Expr) (Node, error) {
 	ops := []string{}
 
 	for _, part := range e.Binary.Right {
-		// part.Right is a *parser.Unary, convert accordingly.
-		right, err := convertParserUnary(part.Right)
+		// part.Right is a *parser.PostfixExpr, convert accordingly.
+		right, err := convertParserPostfix(part.Right)
 		if err != nil {
 			return nil, err
 		}
-		rightType := types.ExprType(&parser.Expr{Binary: &parser.BinaryExpr{Left: part.Right}}, currentEnv)
+		// Determine type of the right-hand side by wrapping the postfix
+		// expression in a unary placeholder.
+		rightType := types.ExprType(
+			&parser.Expr{Binary: &parser.BinaryExpr{Left: &parser.Unary{Value: part.Right}}},
+			currentEnv,
+		)
 
 		for len(ops) > 0 && precedence(ops[len(ops)-1]) >= precedence(part.Op) {
 			r := exprs[len(exprs)-1]


### PR DESCRIPTION
## Summary
- fix Scheme transpiler to convert binary expression parts whose RHS is a postfix expression
- regenerate algorithms checklist after running indices 500-549

## Testing
- `MOCHI_ALGORITHMS_INDEX=500 go test -run TestSchemeTranspiler_Algorithms_Golden -update-algorithms-scheme -tags slow`
- `for i in $(seq 501 549); do MOCHI_ALGORITHMS_INDEX=$i go test -run TestSchemeTranspiler_Algorithms_Golden -update-algorithms-scheme -tags slow || break; done`


------
https://chatgpt.com/codex/tasks/task_e_6899d48cd7888320ab096800fde730ec