### PR TITLE
clj: support error builtin

### DIFF
--- a/tests/algorithms/x/Clojure/maths/check_polygon.bench
+++ b/tests/algorithms/x/Clojure/maths/check_polygon.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 64072,
+  "memory_bytes": 20745408,
+  "name": "main"
+}

--- a/tests/algorithms/x/Clojure/maths/check_polygon.clj
+++ b/tests/algorithms/x/Clojure/maths/check_polygon.clj
@@ -17,6 +17,9 @@
 (defn toi [s]
   (Integer/parseInt (str s)))
 
+(defn _fetch [url]
+  {:data [{:from "" :intensity {:actual 0 :forecast 0 :index ""} :to ""}]})
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare check_polygon)
@@ -30,7 +33,7 @@
 (def ^:dynamic check_polygon_v nil)
 
 (defn check_polygon [check_polygon_nums]
-  (binding [check_polygon_i nil check_polygon_max_side nil check_polygon_total nil check_polygon_v nil] (try (do (when (< (count check_polygon_nums) 2) (error "Monogons and Digons are not polygons in the Euclidean space")) (set! check_polygon_i 0) (while (< check_polygon_i (count check_polygon_nums)) (do (when (<= (nth check_polygon_nums check_polygon_i) 0.0) (error "All values must be greater than 0")) (set! check_polygon_i (+ check_polygon_i 1)))) (set! check_polygon_total 0.0) (set! check_polygon_max_side 0.0) (set! check_polygon_i 0) (while (< check_polygon_i (count check_polygon_nums)) (do (set! check_polygon_v (nth check_polygon_nums check_polygon_i)) (set! check_polygon_total (+ check_polygon_total check_polygon_v)) (when (> check_polygon_v check_polygon_max_side) (set! check_polygon_max_side check_polygon_v)) (set! check_polygon_i (+ check_polygon_i 1)))) (throw (ex-info "return" {:v (< check_polygon_max_side (- check_polygon_total check_polygon_max_side))}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
+  (binding [check_polygon_i nil check_polygon_max_side nil check_polygon_total nil check_polygon_v nil] (try (do (when (< (count check_polygon_nums) 2) (throw (Exception. "Monogons and Digons are not polygons in the Euclidean space"))) (set! check_polygon_i 0) (while (< check_polygon_i (count check_polygon_nums)) (do (when (<= (nth check_polygon_nums check_polygon_i) 0.0) (throw (Exception. "All values must be greater than 0"))) (set! check_polygon_i (+ check_polygon_i 1)))) (set! check_polygon_total 0.0) (set! check_polygon_max_side 0.0) (set! check_polygon_i 0) (while (< check_polygon_i (count check_polygon_nums)) (do (set! check_polygon_v (nth check_polygon_nums check_polygon_i)) (set! check_polygon_total (+ check_polygon_total check_polygon_v)) (when (> check_polygon_v check_polygon_max_side) (set! check_polygon_max_side check_polygon_v)) (set! check_polygon_i (+ check_polygon_i 1)))) (throw (ex-info "return" {:v (< check_polygon_max_side (- check_polygon_total check_polygon_max_side))}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
 
 (def ^:dynamic main_nums [3.0 7.0 13.0 2.0])
 

--- a/tests/algorithms/x/Clojure/maths/check_polygon.error
+++ b/tests/algorithms/x/Clojure/maths/check_polygon.error
@@ -1,6 +1,0 @@
-run: exit status 1
-Syntax error compiling at (/workspace/mochi/tests/algorithms/x/Clojure/maths/check_polygon.clj:33:153).
-Unable to resolve symbol: error in this context
-
-Full report at:
-/tmp/clojure-5137888585078897165.edn

--- a/tests/algorithms/x/Clojure/maths/check_polygon.out
+++ b/tests/algorithms/x/Clojure/maths/check_polygon.out
@@ -1,5 +1,4 @@
-Syntax error compiling at (/workspace/mochi/tests/algorithms/x/Clojure/maths/check_polygon.clj:33:153).
-Unable to resolve symbol: error in this context
-
-Full report at:
-/tmp/clojure-5137888585078897165.edn
+true
+false
+false
+[3.0 7.0 13.0 2.0]

--- a/transpiler/x/clj/ALGORITHMS.md
+++ b/transpiler/x/clj/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated Clojure code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Clojure`.
-Last updated: 2025-08-11 17:09 GMT+7
+Last updated: 2025-08-11 18:54 GMT+7
 
-## Algorithms Golden Test Checklist (656/1077)
+## Algorithms Golden Test Checklist (657/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 50.25ms | 19.66MB |
@@ -515,22 +515,22 @@ Last updated: 2025-08-11 17:09 GMT+7
 | 506 | machine_learning/gradient_descent | ✓ | 216.382ms | 22.99MB |
 | 507 | machine_learning/k_means_clust | ✓ | 72.645ms | 25.24MB |
 | 508 | machine_learning/k_nearest_neighbours | ✓ | 58.161ms | 22.39MB |
-| 509 | machine_learning/linear_discriminant_analysis | error |  |  |
+| 509 | machine_learning/linear_discriminant_analysis | error | 137.579ms | 28.68MB |
 | 510 | machine_learning/linear_regression | ✓ | 52.012ms | 24.19MB |
 | 511 | machine_learning/local_weighted_learning/local_weighted_learning | ✓ | 49.433ms | 28.11MB |
 | 512 | machine_learning/logistic_regression | ✓ | 38.39ms | 16.33MB |
-| 513 | machine_learning/loss_functions | error |  |  |
+| 513 | machine_learning/loss_functions | error | 106.461ms | 38.02MB |
 | 514 | machine_learning/lstm/lstm_prediction | ✓ | 46.85ms | 47.87MB |
 | 515 | machine_learning/mfcc | error |  |  |
-| 516 | machine_learning/multilayer_perceptron_classifier | error |  |  |
+| 516 | machine_learning/multilayer_perceptron_classifier | error | 2.333668s | 25.93MB |
 | 517 | machine_learning/polynomial_regression | error |  |  |
-| 518 | machine_learning/principle_component_analysis | error |  |  |
+| 518 | machine_learning/principle_component_analysis | error | 80.71ms | 28.12MB |
 | 519 | machine_learning/scoring_functions | ✓ | 53.962ms | 25.29MB |
 | 520 | machine_learning/self_organizing_map | ✓ | 52.261ms | 22.37MB |
 | 521 | machine_learning/sequential_minimum_optimization | error |  |  |
 | 522 | machine_learning/similarity_search | ✓ | 66.53ms | 22.39MB |
 | 523 | machine_learning/support_vector_machines | ✓ | 75.962ms | 49.46MB |
-| 524 | machine_learning/word_frequency_functions | error |  |  |
+| 524 | machine_learning/word_frequency_functions | error | 113.311ms | 26.43MB |
 | 525 | machine_learning/xgboost_classifier | error |  |  |
 | 526 | machine_learning/xgboost_regressor | ✓ | 74.938ms | 23.85MB |
 | 527 | maths/abs | ✓ | 58.294ms | 22.51MB |
@@ -553,7 +553,7 @@ Last updated: 2025-08-11 17:09 GMT+7
 | 544 | maths/binomial_distribution | ✓ | 55.011ms | 20.74MB |
 | 545 | maths/ceil | ✓ | 82.046ms | 21.47MB |
 | 546 | maths/chebyshev_distance | ✓ | 56.379ms | 19.92MB |
-| 547 | maths/check_polygon | error |  |  |
+| 547 | maths/check_polygon | ✓ | 64.072ms | 19.78MB |
 | 548 | maths/chinese_remainder_theorem | ✓ | 59.396ms | 21.23MB |
 | 549 | maths/chudnovsky_algorithm | ✓ | 55.016ms | 22.80MB |
 | 550 | maths/collatz_sequence | ✓ | 89.9ms | 19.33MB |

--- a/transpiler/x/clj/transpiler.go
+++ b/transpiler/x/clj/transpiler.go
@@ -2473,6 +2473,9 @@ func transpileCall(c *parser.CallExpr) (Node, error) {
 			userFun = true
 		}
 	}
+	if c.Func == "error" {
+		userFun = false
+	}
 	if !userFun {
 		switch c.Func {
 		case "print":
@@ -2529,9 +2532,9 @@ func transpileCall(c *parser.CallExpr) (Node, error) {
 			}
 			endNode := &List{Elems: []Node{Symbol("min"), endArg, &List{Elems: []Node{Symbol("count"), strArg}}}}
 			return &List{Elems: []Node{Symbol("subs"), strArg, startArg, endNode}}, nil
-		case "panic":
+		case "panic", "error":
 			if len(c.Args) == 0 {
-				return nil, fmt.Errorf("panic expects at least 1 arg")
+				return nil, fmt.Errorf("%s expects at least 1 arg", c.Func)
 			}
 			var parts []Node
 			for _, a := range c.Args {


### PR DESCRIPTION
## Summary
- map `error` calls to `throw` in the Clojure transpiler
- regenerate Clojure outputs for `maths/check_polygon`
- update algorithms checklist

## Testing
- `MOCHI_ALG_INDEX=547 go test ./transpiler/x/clj -run TestClojureTranspiler_Algorithms_Golden -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6899d46819dc8320a24bcab1a8966692