### PR TITLE
php: fix binary parsing and bigint detection

### DIFF
--- a/tests/algorithms/x/PHP/maths/collatz_sequence.bench
+++ b/tests/algorithms/x/PHP/maths/collatz_sequence.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 192,
-  "memory_bytes": 40024,
+  "duration_us": 151,
+  "memory_bytes": 37784,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/collatz_sequence.php
+++ b/tests/algorithms/x/PHP/maths/collatz_sequence.php
@@ -46,41 +46,6 @@ function _intdiv($a, $b) {
     }
     return intdiv($a, $b);
 }
-function _iadd($a, $b) {
-    if (function_exists('bcadd')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcadd($sa, $sb, 0);
-    }
-    return $a + $b;
-}
-function _isub($a, $b) {
-    if (function_exists('bcsub')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcsub($sa, $sb, 0);
-    }
-    return $a - $b;
-}
-function _imul($a, $b) {
-    if (function_exists('bcmul')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcmul($sa, $sb, 0);
-    }
-    return $a * $b;
-}
-function _idiv($a, $b) {
-    return _intdiv($a, $b);
-}
-function _imod($a, $b) {
-    if (function_exists('bcmod')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return intval(bcmod($sa, $sb));
-    }
-    return $a % $b;
-}
 function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
@@ -94,10 +59,10 @@ $__start = _now();
   $seq = [$n];
   $current = $n;
   while ($current != 1) {
-  if (_imod($current, 2) == 0) {
+  if ($current % 2 == 0) {
   $current = _intdiv($current, 2);
 } else {
-  $current = _iadd(_imul(3, $current), 1);
+  $current = 3 * $current + 1;
 }
   $seq = _append($seq, $current);
 };

--- a/tests/algorithms/x/PHP/maths/fibonacci.bench
+++ b/tests/algorithms/x/PHP/maths/fibonacci.bench
@@ -1,1 +1,5 @@
-Fatal error: Cannot redeclare function sqrt() in /workspace/mochi/tests/algorithms/x/PHP/maths/fibonacci.php on line 48
+{
+  "duration_us": 418,
+  "memory_bytes": 80160,
+  "name": "main"
+}

--- a/tests/algorithms/x/PHP/maths/fibonacci.error
+++ b/tests/algorithms/x/PHP/maths/fibonacci.error
@@ -1,3 +1,0 @@
-run: exit status 255
-
-Fatal error: Cannot redeclare function sqrt() in /workspace/mochi/tests/algorithms/x/PHP/maths/fibonacci.php on line 48

--- a/tests/algorithms/x/PHP/maths/fibonacci.out
+++ b/tests/algorithms/x/PHP/maths/fibonacci.out
@@ -1,1 +1,1 @@
-Fatal error: Cannot redeclare function sqrt() in /workspace/mochi/tests/algorithms/x/PHP/maths/fibonacci.php on line 31
+55

--- a/tests/algorithms/x/PHP/maths/fibonacci.php
+++ b/tests/algorithms/x/PHP/maths/fibonacci.php
@@ -36,6 +36,9 @@ function _append($arr, $x) {
     return $arr;
 }
 function _intdiv($a, $b) {
+    if ($b === 0 || $b === '0') {
+        throw new DivisionByZeroError();
+    }
     if (function_exists('bcdiv')) {
         $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
@@ -43,9 +46,48 @@ function _intdiv($a, $b) {
     }
     return intdiv($a, $b);
 }
+function _iadd($a, $b) {
+    if (function_exists('bcadd')) {
+        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
+        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
+        return bcadd($sa, $sb, 0);
+    }
+    return $a + $b;
+}
+function _isub($a, $b) {
+    if (function_exists('bcsub')) {
+        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
+        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
+        return bcsub($sa, $sb, 0);
+    }
+    return $a - $b;
+}
+function _imul($a, $b) {
+    if (function_exists('bcmul')) {
+        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
+        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
+        return bcmul($sa, $sb, 0);
+    }
+    return $a * $b;
+}
+function _idiv($a, $b) {
+    return _intdiv($a, $b);
+}
+function _imod($a, $b) {
+    if (function_exists('bcmod')) {
+        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
+        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
+        return intval(bcmod($sa, $sb));
+    }
+    return $a % $b;
+}
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
 $__start_mem = memory_get_usage();
 $__start = _now();
-  function sqrt($x) {
+  function mochi_sqrt($x) {
   global $fib_cache_global, $fib_memo_cache;
   if ($x <= 0.0) {
   return 0.0;
@@ -54,7 +96,7 @@ $__start = _now();
   $i = 0;
   while ($i < 10) {
   $guess = ($guess + $x / $guess) / 2.0;
-  $i = $i + 1;
+  $i = _iadd($i, 1);
 };
   return $guess;
 };
@@ -64,7 +106,7 @@ $__start = _now();
   $i = 0;
   while ($i < $n) {
   $res = $res * $x;
-  $i = $i + 1;
+  $i = _iadd($i, 1);
 };
   return $res;
 };
@@ -78,7 +120,7 @@ $__start = _now();
   function fib_iterative($n) {
   global $fib_cache_global, $fib_memo_cache;
   if ($n < 0) {
-  $panic('n is negative');
+  _panic('n is negative');
 }
   if ($n == 0) {
   return [0];
@@ -86,31 +128,31 @@ $__start = _now();
   $fib = [0, 1];
   $i = 2;
   while ($i <= $n) {
-  $fib = _append($fib, $fib[$i - 1] + $fib[$i - 2]);
-  $i = $i + 1;
+  $fib = _append($fib, _iadd($fib[_isub($i, 1)], $fib[_isub($i, 2)]));
+  $i = _iadd($i, 1);
 };
   return $fib;
 };
   function fib_recursive_term($i) {
   global $fib_cache_global, $fib_memo_cache;
   if ($i < 0) {
-  $panic('n is negative');
+  _panic('n is negative');
 }
   if ($i < 2) {
   return $i;
 }
-  return fib_recursive_term($i - 1) + fib_recursive_term($i - 2);
+  return _iadd(fib_recursive_term(_isub($i, 1)), fib_recursive_term(_isub($i, 2)));
 };
   function fib_recursive($n) {
   global $fib_cache_global, $fib_memo_cache;
   if ($n < 0) {
-  $panic('n is negative');
+  _panic('n is negative');
 }
   $res = [];
   $i = 0;
   while ($i <= $n) {
   $res = _append($res, fib_recursive_term($i));
-  $i = $i + 1;
+  $i = _iadd($i, 1);
 };
   return $res;
 };
@@ -118,7 +160,7 @@ $__start = _now();
   function fib_recursive_cached_term($i) {
   global $fib_cache_global, $fib_memo_cache;
   if ($i < 0) {
-  $panic('n is negative');
+  _panic('n is negative');
 }
   if ($i < 2) {
   return $i;
@@ -126,20 +168,20 @@ $__start = _now();
   if (array_key_exists($i, $fib_cache_global)) {
   return $fib_cache_global[$i];
 }
-  $val = fib_recursive_cached_term($i - 1) + fib_recursive_cached_term($i - 2);
+  $val = _iadd(fib_recursive_cached_term(_isub($i, 1)), fib_recursive_cached_term(_isub($i, 2)));
   $fib_cache_global[$i] = $val;
   return $val;
 };
   function fib_recursive_cached($n) {
   global $fib_cache_global, $fib_memo_cache;
   if ($n < 0) {
-  $panic('n is negative');
+  _panic('n is negative');
 }
   $res = [];
   $j = 0;
   while ($j <= $n) {
   $res = _append($res, fib_recursive_cached_term($j));
-  $j = $j + 1;
+  $j = _iadd($j, 1);
 };
   return $res;
 };
@@ -149,60 +191,60 @@ $__start = _now();
   if (array_key_exists($num, $fib_memo_cache)) {
   return $fib_memo_cache[$num];
 }
-  $value = fib_memoization_term($num - 1) + fib_memoization_term($num - 2);
+  $value = _iadd(fib_memoization_term(_isub($num, 1)), fib_memoization_term(_isub($num, 2)));
   $fib_memo_cache[$num] = $value;
   return $value;
 };
   function fib_memoization($n) {
   global $fib_cache_global, $fib_memo_cache;
   if ($n < 0) {
-  $panic('n is negative');
+  _panic('n is negative');
 }
   $out = [];
   $i = 0;
   while ($i <= $n) {
   $out = _append($out, fib_memoization_term($i));
-  $i = $i + 1;
+  $i = _iadd($i, 1);
 };
   return $out;
 };
   function fib_binet($n) {
   global $fib_cache_global, $fib_memo_cache;
   if ($n < 0) {
-  $panic('n is negative');
+  _panic('n is negative');
 }
   if ($n >= 1475) {
-  $panic('n is too large');
+  _panic('n is too large');
 }
-  $sqrt5 = sqrt(5.0);
+  $sqrt5 = mochi_sqrt(5.0);
   $phi = (1.0 + $sqrt5) / 2.0;
   $res = [];
   $i = 0;
   while ($i <= $n) {
   $val = roundf(powf($phi, $i) / $sqrt5);
   $res = _append($res, $val);
-  $i = $i + 1;
+  $i = _iadd($i, 1);
 };
   return $res;
 };
   function matrix_mul($a, $b) {
   global $fib_cache_global, $fib_memo_cache;
-  $a00 = $a[0][0] * $b[0][0] + $a[0][1] * $b[1][0];
-  $a01 = $a[0][0] * $b[0][1] + $a[0][1] * $b[1][1];
-  $a10 = $a[1][0] * $b[0][0] + $a[1][1] * $b[1][0];
-  $a11 = $a[1][0] * $b[0][1] + $a[1][1] * $b[1][1];
+  $a00 = _iadd(_imul($a[0][0], $b[0][0]), _imul($a[0][1], $b[1][0]));
+  $a01 = _iadd(_imul($a[0][0], $b[0][1]), _imul($a[0][1], $b[1][1]));
+  $a10 = _iadd(_imul($a[1][0], $b[0][0]), _imul($a[1][1], $b[1][0]));
+  $a11 = _iadd(_imul($a[1][0], $b[0][1]), _imul($a[1][1], $b[1][1]));
   return [[$a00, $a01], [$a10, $a11]];
 };
   function matrix_pow($m, $power) {
   global $fib_cache_global, $fib_memo_cache;
   if ($power < 0) {
-  $panic('power is negative');
+  _panic('power is negative');
 }
   $result = [[1, 0], [0, 1]];
   $base = $m;
   $p = $power;
   while ($p > 0) {
-  if ($p % 2 == 1) {
+  if (_imod($p, 2) == 1) {
   $result = matrix_mul($result, $base);
 }
   $base = matrix_mul($base, $base);
@@ -213,13 +255,13 @@ $__start = _now();
   function fib_matrix($n) {
   global $fib_cache_global, $fib_memo_cache;
   if ($n < 0) {
-  $panic('n is negative');
+  _panic('n is negative');
 }
   if ($n == 0) {
   return 0;
 }
   $m = [[1, 1], [1, 0]];
-  $res = matrix_pow($m, $n - 1);
+  $res = matrix_pow($m, _isub($n, 1));
   return $res[0][0];
 };
   function run_tests() {
@@ -232,22 +274,22 @@ $__start = _now();
   $bin = fib_binet(10);
   $m = fib_matrix(10);
   if ($it != $expected) {
-  $panic('iterative failed');
+  _panic('iterative failed');
 }
   if ($rec != $expected) {
-  $panic('recursive failed');
+  _panic('recursive failed');
 }
   if ($cache != $expected) {
-  $panic('cached failed');
+  _panic('cached failed');
 }
   if ($memo != $expected) {
-  $panic('memoization failed');
+  _panic('memoization failed');
 }
   if ($bin != $expected) {
-  $panic('binet failed');
+  _panic('binet failed');
 }
   if ($m != 55) {
-  $panic('matrix failed');
+  _panic('matrix failed');
 }
   return $m;
 };

--- a/tests/algorithms/x/PHP/maths/gamma.bench
+++ b/tests/algorithms/x/PHP/maths/gamma.bench
@@ -1,1 +1,5 @@
-Fatal error: Cannot redeclare function sqrt() in /workspace/mochi/tests/algorithms/x/PHP/maths/gamma.php on line 28
+{
+  "duration_us": 1515259,
+  "memory_bytes": 72936,
+  "name": "main"
+}

--- a/tests/algorithms/x/PHP/maths/gamma.error
+++ b/tests/algorithms/x/PHP/maths/gamma.error
@@ -1,3 +1,0 @@
-run: exit status 255
-
-Fatal error: Cannot redeclare function sqrt() in /workspace/mochi/tests/algorithms/x/PHP/maths/gamma.php on line 28

--- a/tests/algorithms/x/PHP/maths/gamma.out
+++ b/tests/algorithms/x/PHP/maths/gamma.out
@@ -1,1 +1,3 @@
-Fatal error: Cannot redeclare function sqrt() in /workspace/mochi/tests/algorithms/x/PHP/maths/gamma.php on line 11
+-1.6276357111598094e+28
+24.0
+1.7724538509055159

--- a/tests/algorithms/x/PHP/maths/gamma.php
+++ b/tests/algorithms/x/PHP/maths/gamma.php
@@ -15,6 +15,45 @@ function _now() {
     }
     return hrtime(true);
 }
+function _iadd($a, $b) {
+    if (function_exists('bcadd')) {
+        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
+        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
+        return bcadd($sa, $sb, 0);
+    }
+    return $a + $b;
+}
+function _isub($a, $b) {
+    if (function_exists('bcsub')) {
+        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
+        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
+        return bcsub($sa, $sb, 0);
+    }
+    return $a - $b;
+}
+function _imul($a, $b) {
+    if (function_exists('bcmul')) {
+        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
+        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
+        return bcmul($sa, $sb, 0);
+    }
+    return $a * $b;
+}
+function _idiv($a, $b) {
+    return _intdiv($a, $b);
+}
+function _imod($a, $b) {
+    if (function_exists('bcmod')) {
+        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
+        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
+        return intval(bcmod($sa, $sb));
+    }
+    return $a % $b;
+}
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
 $__start_mem = memory_get_usage();
 $__start = _now();
   $PI = 3.141592653589793;
@@ -25,23 +64,23 @@ $__start = _now();
 }
   return $x;
 };
-  function sqrt($x) {
+  function mochi_sqrt($x) {
   global $PI;
   if ($x < 0.0) {
-  $panic('sqrt domain error');
+  _panic('sqrt domain error');
 }
   $guess = $x / 2.0;
   $i = 0;
   while ($i < 20) {
   $guess = ($guess + $x / $guess) / 2.0;
-  $i = $i + 1;
+  $i = _iadd($i, 1);
 };
   return $guess;
 };
   function ln($x) {
   global $PI;
   if ($x <= 0.0) {
-  $panic('ln domain error');
+  _panic('ln domain error');
 }
   $y = ($x - 1.0) / ($x + 1.0);
   $y2 = $y * $y;
@@ -49,10 +88,10 @@ $__start = _now();
   $sum = 0.0;
   $k = 0;
   while ($k < 10) {
-  $denom = floatval((2 * $k + 1));
+  $denom = floatval((_iadd(_imul(2, $k), 1)));
   $sum = $sum + $term / $denom;
   $term = $term * $y2;
-  $k = $k + 1;
+  $k = _iadd($k, 1);
 };
   return 2.0 * $sum;
 };
@@ -64,7 +103,7 @@ $__start = _now();
   while ($n < 20) {
   $term = $term * $x / (floatval($n));
   $sum = $sum + $term;
-  $n = $n + 1;
+  $n = _iadd($n, 1);
 };
   return $sum;
 };
@@ -82,7 +121,7 @@ $__start = _now();
   function gamma_iterative($num) {
   global $PI;
   if ($num <= 0.0) {
-  $panic('math domain error');
+  _panic('math domain error');
 }
   $step = 0.001;
   $limit = 100.0;
@@ -97,18 +136,18 @@ $__start = _now();
   function gamma_recursive($num) {
   global $PI;
   if ($num <= 0.0) {
-  $panic('math domain error');
+  _panic('math domain error');
 }
   if ($num > 171.5) {
-  $panic('math range error');
+  _panic('math range error');
 }
   $int_part = intval($num);
   $frac = $num - (floatval($int_part));
   if (!(absf($frac) < 0.000001 || absf($frac - 0.5) < 0.000001)) {
-  $panic('num must be an integer or a half-integer');
+  _panic('num must be an integer or a half-integer');
 }
   if (absf($num - 0.5) < 0.000001) {
-  return sqrt($PI);
+  return mochi_sqrt($PI);
 }
   if (absf($num - 1.0) < 0.000001) {
   return 1.0;

--- a/tests/algorithms/x/PHP/maths/geometric_mean.error
+++ b/tests/algorithms/x/PHP/maths/geometric_mean.error
@@ -1,10 +1,2 @@
-run: exit status 255
-
-Warning: Undefined variable $panic in /workspace/mochi/tests/algorithms/x/PHP/maths/geometric_mean.php on line 95
-
-Fatal error: Uncaught Error: Value of type null is not callable in /workspace/mochi/tests/algorithms/x/PHP/maths/geometric_mean.php:95
-Stack trace:
-#0 /workspace/mochi/tests/algorithms/x/PHP/maths/geometric_mean.php(103): test_compute_geometric_mean()
-#1 /workspace/mochi/tests/algorithms/x/PHP/maths/geometric_mean.php(106): main()
-#2 {main}
-  thrown in /workspace/mochi/tests/algorithms/x/PHP/maths/geometric_mean.php on line 95
+run: exit status 1
+test4 failed

--- a/tests/algorithms/x/PHP/maths/geometric_mean.php
+++ b/tests/algorithms/x/PHP/maths/geometric_mean.php
@@ -1,29 +1,16 @@
 <?php
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
 }
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
-$__start_mem = memory_get_usage();
-$__start = _now();
-  function mochi_abs($x) {
+function mochi_abs($x) {
   if ($x < 0.0) {
   return -$x;
 }
   return $x;
-};
-  function pow_int($base, $exp) {
+}
+function pow_int($base, $exp) {
   $result = 1.0;
   $i = 0;
   while ($i < $exp) {
@@ -31,8 +18,8 @@ $__start = _now();
   $i = $i + 1;
 };
   return $result;
-};
-  function nth_root($x, $n) {
+}
+function nth_root($x, $n) {
   if ($x == 0.0) {
   return 0.0;
 }
@@ -44,18 +31,18 @@ $__start = _now();
   $i = $i + 1;
 };
   return $guess;
-};
-  function round_nearest($x) {
+}
+function round_nearest($x) {
   if ($x >= 0.0) {
   $n = intval(($x + 0.5));
   return floatval($n);
 }
   $n = intval(($x - 0.5));
   return floatval($n);
-};
-  function compute_geometric_mean($nums) {
+}
+function compute_geometric_mean($nums) {
   if (count($nums) == 0) {
-  $panic('no numbers');
+  _panic('no numbers');
 }
   $product = 1.0;
   $i = 0;
@@ -64,7 +51,7 @@ $__start = _now();
   $i = $i + 1;
 };
   if ($product < 0.0 && fmod(count($nums), 2) == 0) {
-  $panic('Cannot Compute Geometric Mean for these numbers.');
+  _panic('Cannot Compute Geometric Mean for these numbers.');
 }
   $mean = nth_root(mochi_abs($product), count($nums));
   if ($product < 0.0) {
@@ -75,40 +62,32 @@ $__start = _now();
   $mean = $possible;
 }
   return $mean;
-};
-  function test_compute_geometric_mean() {
+}
+function test_compute_geometric_mean() {
   $eps = 0.0001;
   $m1 = compute_geometric_mean([2.0, 8.0]);
   if (mochi_abs($m1 - 4.0) > $eps) {
-  $panic('test1 failed');
+  _panic('test1 failed');
 }
   $m2 = compute_geometric_mean([5.0, 125.0]);
   if (mochi_abs($m2 - 25.0) > $eps) {
-  $panic('test2 failed');
+  _panic('test2 failed');
 }
   $m3 = compute_geometric_mean([1.0, 0.0]);
   if (mochi_abs($m3 - 0.0) > $eps) {
-  $panic('test3 failed');
+  _panic('test3 failed');
 }
   $m4 = compute_geometric_mean([1.0, 5.0, 25.0, 5.0]);
   if (mochi_abs($m4 - 5.0) > $eps) {
-  $panic('test4 failed');
+  _panic('test4 failed');
 }
   $m5 = compute_geometric_mean([-5.0, 25.0, 1.0]);
   if (mochi_abs($m5 + 5.0) > $eps) {
-  $panic('test5 failed');
+  _panic('test5 failed');
 }
-};
-  function main() {
+}
+function main() {
   test_compute_geometric_mean();
   echo rtrim(json_encode(compute_geometric_mean([-3.0, -27.0]), 1344)), PHP_EOL;
-};
-  main();
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+main();

--- a/tests/algorithms/x/PHP/maths/juggler_sequence.bench
+++ b/tests/algorithms/x/PHP/maths/juggler_sequence.bench
@@ -1,1 +1,5 @@
-Fatal error: Cannot redeclare function sqrt() in /workspace/mochi/tests/algorithms/x/PHP/maths/juggler_sequence.php on line 43
+{
+  "duration_us": 193,
+  "memory_bytes": 41008,
+  "name": "main"
+}

--- a/tests/algorithms/x/PHP/maths/juggler_sequence.error
+++ b/tests/algorithms/x/PHP/maths/juggler_sequence.error
@@ -1,3 +1,0 @@
-run: exit status 255
-
-Fatal error: Cannot redeclare function sqrt() in /workspace/mochi/tests/algorithms/x/PHP/maths/juggler_sequence.php on line 43

--- a/tests/algorithms/x/PHP/maths/juggler_sequence.out
+++ b/tests/algorithms/x/PHP/maths/juggler_sequence.out
@@ -1,1 +1,2 @@
-Fatal error: Cannot redeclare function sqrt() in /workspace/mochi/tests/algorithms/x/PHP/maths/juggler_sequence.php on line 26
+[3 5 11 36 6 2 1]
+[10 3 5 11 36 6 2 1]

--- a/tests/algorithms/x/PHP/maths/juggler_sequence.php
+++ b/tests/algorithms/x/PHP/maths/juggler_sequence.php
@@ -35,12 +35,16 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
 $__start_mem = memory_get_usage();
 $__start = _now();
   function to_float($x) {
   return $x * 1.0;
 };
-  function sqrt($x) {
+  function mochi_sqrt($x) {
   if ($x <= 0.0) {
   return 0.0;
 }
@@ -63,15 +67,15 @@ $__start = _now();
 };
   function juggler_sequence($n) {
   if ($n < 1) {
-  $panic('number must be a positive integer');
+  _panic('number must be a positive integer');
 }
   $seq = [$n];
   $current = $n;
   while ($current != 1) {
   if ($current % 2 == 0) {
-  $current = mochi_floor(sqrt(to_float($current)));
+  $current = mochi_floor(mochi_sqrt(floatval($current)));
 } else {
-  $r = sqrt(to_float($current));
+  $r = mochi_sqrt(floatval($current));
   $current = mochi_floor($r * $r * $r);
 }
   $seq = _append($seq, $current);

--- a/tests/algorithms/x/PHP/maths/largest_of_very_large_numbers.bench
+++ b/tests/algorithms/x/PHP/maths/largest_of_very_large_numbers.bench
@@ -1,1 +1,5 @@
-Fatal error: Cannot redeclare function log10() in /workspace/mochi/tests/algorithms/x/PHP/maths/largest_of_very_large_numbers.php on line 48
+{
+  "duration_us": 61,
+  "memory_bytes": 41864,
+  "name": "main"
+}

--- a/tests/algorithms/x/PHP/maths/largest_of_very_large_numbers.error
+++ b/tests/algorithms/x/PHP/maths/largest_of_very_large_numbers.error
@@ -1,3 +1,0 @@
-run: exit status 255
-
-Fatal error: Cannot redeclare function log10() in /workspace/mochi/tests/algorithms/x/PHP/maths/largest_of_very_large_numbers.php on line 48

--- a/tests/algorithms/x/PHP/maths/largest_of_very_large_numbers.out
+++ b/tests/algorithms/x/PHP/maths/largest_of_very_large_numbers.out
@@ -1,1 +1,1 @@
-Fatal error: Cannot redeclare function log10() in /workspace/mochi/tests/algorithms/x/PHP/maths/largest_of_very_large_numbers.php on line 31
+Largest number is 5 ^ 7

--- a/tests/algorithms/x/PHP/maths/largest_of_very_large_numbers.php
+++ b/tests/algorithms/x/PHP/maths/largest_of_very_large_numbers.php
@@ -31,6 +31,10 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
 $__start_mem = memory_get_usage();
 $__start = _now();
   function ln($x) {
@@ -45,7 +49,7 @@ $__start = _now();
 };
   return 2.0 * $sum;
 };
-  function log10($x) {
+  function mochi_log10($x) {
   return ln($x) / ln(10.0);
 };
   function absf($x) {
@@ -62,19 +66,19 @@ $__start = _now();
   return 1.0;
 }
   if ($x < 0) {
-  $panic('math domain error');
+  _panic('math domain error');
 }
-  return (floatval($y)) * log10(floatval($x));
+  return (floatval($y)) * mochi_log10(floatval($x));
 };
   function test_res() {
   if (absf(res(5, 7) - 4.892790030352132) > 0.0000001) {
-  $panic('res(5,7) failed');
+  _panic('res(5,7) failed');
 }
   if (res(0, 5) != 0.0) {
-  $panic('res(0,5) failed');
+  _panic('res(0,5) failed');
 }
   if (res(3, 0) != 1.0) {
-  $panic('res(3,0) failed');
+  _panic('res(3,0) failed');
 }
 };
   function compare($x1, $y1, $x2, $y2) {

--- a/transpiler/x/php/ALGORITHMS.md
+++ b/transpiler/x/php/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated PHP code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/PHP`.
-Last updated: 2025-08-11 18:17 GMT+7
+Last updated: 2025-08-12 07:59 GMT+7
 
-## Algorithms Golden Test Checklist (947/1077)
+## Algorithms Golden Test Checklist (951/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 117µs | 38.8 KB |
@@ -556,7 +556,7 @@ Last updated: 2025-08-11 18:17 GMT+7
 | 547 | maths/check_polygon | ✓ | 150µs | 41.4 KB |
 | 548 | maths/chinese_remainder_theorem | ✓ | 187µs | 71.6 KB |
 | 549 | maths/chudnovsky_algorithm | ✓ | 93µs | 42.8 KB |
-| 550 | maths/collatz_sequence | ✓ | 192µs | 39.1 KB |
+| 550 | maths/collatz_sequence | ✓ | 151µs | 36.9 KB |
 | 551 | maths/combinations | ✓ | 83µs | 38.5 KB |
 | 552 | maths/continued_fraction | ✓ | 137µs | 40.3 KB |
 | 553 | maths/decimal_isolate | ✓ | 88µs | 35.9 KB |
@@ -574,11 +574,11 @@ Last updated: 2025-08-11 18:17 GMT+7
 | 565 | maths/factors | ✓ | 195µs | 36.9 KB |
 | 566 | maths/fast_inverse_sqrt | ✓ | 951µs | 70.3 KB |
 | 567 | maths/fermat_little_theorem | ✓ | 133µs | 39.1 KB |
-| 568 | maths/fibonacci | error |  |  |
+| 568 | maths/fibonacci | ✓ | 418µs | 78.3 KB |
 | 569 | maths/find_max | ✓ | 128µs | 36.9 KB |
 | 570 | maths/find_min | ✓ | 134µs | 40.2 KB |
 | 571 | maths/floor | ✓ | 76µs | 36.1 KB |
-| 572 | maths/gamma | error |  |  |
+| 572 | maths/gamma | ✓ | 1.515259s | 71.2 KB |
 | 573 | maths/gaussian | ✓ | 62µs | 35.5 KB |
 | 574 | maths/gcd_of_n_numbers | ✓ | 79µs | 39.2 KB |
 | 575 | maths/geometric_mean | error |  |  |
@@ -593,10 +593,10 @@ Last updated: 2025-08-11 18:17 GMT+7
 | 584 | maths/jaccard_similarity | ✓ | 156µs | 38.1 KB |
 | 585 | maths/joint_probability_distribution | ✓ | 151µs | 36.8 KB |
 | 586 | maths/josephus_problem | ✓ | 138µs | 39.2 KB |
-| 587 | maths/juggler_sequence | error |  |  |
+| 587 | maths/juggler_sequence | ✓ | 193µs | 40.0 KB |
 | 588 | maths/karatsuba | ✓ | 172µs | 39.6 KB |
 | 589 | maths/kth_lexicographic_permutation | ✓ | 204µs | 37.8 KB |
-| 590 | maths/largest_of_very_large_numbers | error |  |  |
+| 590 | maths/largest_of_very_large_numbers | ✓ | 61µs | 40.9 KB |
 | 591 | maths/least_common_multiple | ✓ | 57µs | 35.1 KB |
 | 592 | maths/line_length | ✓ | 969µs | 38.6 KB |
 | 593 | maths/liouville_lambda | ✓ | 96µs | 38.8 KB |

--- a/transpiler/x/php/transpiler.go
+++ b/transpiler/x/php/transpiler.go
@@ -2603,7 +2603,7 @@ func convertBinary(b *parser.BinaryExpr) (Expr, error) {
 		strFlags = append(strFlags, false)
 	}
 	for _, p := range b.Right {
-		r, err := convertUnary(p.Right)
+		r, err := convertPostfix(p.Right)
 		if err != nil {
 			return nil, err
 		}
@@ -2614,7 +2614,7 @@ func convertBinary(b *parser.BinaryExpr) (Expr, error) {
 		ops = append(ops, op)
 		operands = append(operands, r)
 		if transpileEnv != nil {
-			t := types.TypeOfUnary(p.Right, transpileEnv)
+			t := types.TypeOfPostfix(p.Right, transpileEnv)
 			_, ok := t.(types.StringType)
 			strFlags = append(strFlags, ok)
 		} else {
@@ -4953,16 +4953,6 @@ func isIntExpr(e Expr) bool {
 
 func isBigIntExpr(e Expr) bool {
 	switch v := e.(type) {
-	case *IntLit:
-		return true
-	case *Var:
-		if transpileEnv != nil {
-			if t, err := transpileEnv.GetVar(v.Name); err == nil {
-				if types.IsIntType(t) || types.IsBigIntType(t) {
-					return true
-				}
-			}
-		}
 	case *BinaryExpr:
 		switch v.Op {
 		case "+", "-", "*", "/", "%":
@@ -4980,7 +4970,7 @@ func isBigIntExpr(e Expr) bool {
 			return true
 		}
 	}
-	if t := exprType(e); types.IsIntType(t) || types.IsBigIntType(t) {
+	if t := exprType(e); types.IsBigIntType(t) {
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary
- handle postfix operands in binary expression conversion
- narrow bigint detection to actual bigint types
- regenerate PHP outputs for updated algorithm suite

## Testing
- `MOCHI_ALG_INDEX=568 MOCHI_BENCHMARK=1 go test ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags slow -count=1 -update-algorithms-php`
- `MOCHI_ALG_INDEX=572 MOCHI_BENCHMARK=1 go test ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags slow -count=1 -update-algorithms-php`
- `MOCHI_ALG_INDEX=587 MOCHI_BENCHMARK=1 go test ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags slow -count=1 -update-algorithms-php`
- `MOCHI_ALG_INDEX=590 MOCHI_BENCHMARK=1 go test ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags slow -count=1 -update-algorithms-php`


------
https://chatgpt.com/codex/tasks/task_e_689a8fbbd05c83209ae2de14e68544b3