### PR TITLE
php: handle reserved time date functions

### DIFF
--- a/tests/algorithms/x/PHP/graphs/random_graph_generator.bench
+++ b/tests/algorithms/x/PHP/graphs/random_graph_generator.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 156,
-  "memory_bytes": 35776,
+  "duration_us": 85,
+  "memory_bytes": 35712,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/random_graph_generator.php
+++ b/tests/algorithms/x/PHP/graphs/random_graph_generator.php
@@ -1,20 +1,37 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-$seed = 1;
-function mochi_rand() {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $seed = 1;
+  function mochi_rand() {
   global $seed;
   $seed = ($seed * 1103515245 + 12345) % 2147483648;
   return $seed;
-}
-function random() {
+};
+  function random() {
   global $seed;
   return (1.0 * mochi_rand()) / 2147483648.0;
-}
-function complete_graph($vertices_number) {
+};
+  function complete_graph($vertices_number) {
   global $seed;
   $graph = [];
   $i = 0;
@@ -31,8 +48,8 @@ function complete_graph($vertices_number) {
   $i = $i + 1;
 };
   return $graph;
-}
-function random_graph($vertices_number, $probability, $directed) {
+};
+  function random_graph($vertices_number, $probability, $directed) {
   global $seed;
   $graph = [];
   $i = 0;
@@ -61,8 +78,8 @@ function random_graph($vertices_number, $probability, $directed) {
   $i = $i + 1;
 };
   return $graph;
-}
-function main() {
+};
+  function main() {
   global $seed;
   $seed = 1;
   $g1 = random_graph(4, 0.5, false);
@@ -70,5 +87,13 @@ function main() {
   $seed = 1;
   $g2 = random_graph(4, 0.5, true);
   echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode($g2, 1344)))))), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/transpiler/x/php/ALGORITHMS.md
+++ b/transpiler/x/php/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated PHP code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/PHP`.
-Last updated: 2025-08-12 07:59 GMT+7
+Last updated: 2025-08-12 08:44 GMT+7
 
 ## Algorithms Golden Test Checklist (951/1077)
 | Index | Name | Status | Duration | Memory |
@@ -456,7 +456,7 @@ Last updated: 2025-08-12 07:59 GMT+7
 | 447 | graphs/multi_heuristic_astar | ✓ | 257µs | 107.7 KB |
 | 448 | graphs/page_rank | error |  |  |
 | 449 | graphs/prim | ✓ | 202µs | 73.1 KB |
-| 450 | graphs/random_graph_generator | ✓ | 156µs | 34.9 KB |
+| 450 | graphs/random_graph_generator | ✓ | 85µs | 34.9 KB |
 | 451 | graphs/scc_kosaraju | ✓ | 122µs | 36.6 KB |
 | 452 | graphs/strongly_connected_components | ✓ | 239µs | 36.6 KB |
 | 453 | graphs/tarjans_scc | error |  |  |

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-Last updated: 2025-08-11 16:20 +0700
+Last updated: 2025-08-12 08:38 +0700
 
 ## VM Golden Test Checklist (103/105)
 - [x] append_builtin

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,4 +1,4 @@
-## Progress (2025-08-11 16:20 +0700)
+## Progress (2025-08-12 08:38 +0700)
 - Generated PHP for 103/105 programs
 - Updated README checklist and outputs
 - Enhanced printing to match golden format

--- a/transpiler/x/php/transpiler.go
+++ b/transpiler/x/php/transpiler.go
@@ -340,9 +340,11 @@ var phpReserved = map[string]struct{}{
 	"sin":           {},
 	"cos":           {},
 	"tan":           {},
-	"log":           {},
-	"log10":         {},
-	"pi":            {},
+        "log":           {},
+        "log10":         {},
+        "pi":            {},
+        "time":          {},
+        "date":          {},
 }
 
 // phpReservedVar lists variable names that cannot be used directly in PHP


### PR DESCRIPTION
## Summary
- handle PHP `time` and `date` reserved function names when transpiling
- regenerate random graph generator algorithm with benchmarking data

## Testing
- `MOCHI_ALG_INDEX=450 ALGORITHMS_MAX=50 MOCHI_BENCHMARK=1 go test ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags slow -count=1 -update-algorithms-php`


------
https://chatgpt.com/codex/tasks/task_e_689a9b83832083209b5adea9c1da0c56