### PR TITLE
rkt: sanitize append name

### DIFF
--- a/transpiler/x/rkt/ALGORITHMS.md
+++ b/transpiler/x/rkt/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Racket code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Racket`.
-Last updated: 2025-08-11 11:44 UTC
+Last updated: 2025-08-12 01:45 UTC
 
 ## Algorithms Golden Test Checklist (795/1077)
 | Index | Name | Status | Duration | Memory |

--- a/transpiler/x/rkt/transpiler.go
+++ b/transpiler/x/rkt/transpiler.go
@@ -79,6 +79,8 @@ func sanitizeName(name string) string {
 		return "quotient_"
 	case "panic":
 		return "panic_"
+	case "append":
+		return "append_"
 	default:
 		return name
 	}


### PR DESCRIPTION
## Summary
- avoid name collisions with Racket's `append`
- refresh algorithms transpiler progress checklist

## Testing
- `MOCHI_ALGORITHMS_INDEX=450 go test -tags=slow ./transpiler/x/rkt -run TestRktTranspiler_Algorithms_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_689a9b93cc9c8320872abe7f36e37ff8