### PR TITLE
rkt: sanitize reverse function name

### DIFF
--- a/transpiler/x/rkt/ALGORITHMS.md
+++ b/transpiler/x/rkt/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Racket code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Racket`.
-Last updated: 2025-08-12 01:45 UTC
+Last updated: 2025-08-12 02:16 UTC
 
 ## Algorithms Golden Test Checklist (795/1077)
 | Index | Name | Status | Duration | Memory |

--- a/transpiler/x/rkt/README.md
+++ b/transpiler/x/rkt/README.md
@@ -2,7 +2,7 @@
 This directory contains the experimental Racket transpiler. Golden tests under `tests/vm/valid` check the generated code and its runtime output.
 
 ## Golden Test Checklist (103/105)
-Last updated: 2025-08-09 10:22 +0700
+Last updated: 2025-08-12 09:13 +0700
 
 - [x] append_builtin
 - [x] avg_builtin

--- a/transpiler/x/rkt/TASKS.md
+++ b/transpiler/x/rkt/TASKS.md
@@ -1,3 +1,263 @@
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
+## Progress (2025-08-12 09:13 +0700)
+- Commit 0b57d92bab: scheme: generate 50 algorithm outputs
+- Generated Racket for 98/100 programs
+- Updated README checklist
+
 ## Progress (2025-08-09 10:22 +0700)
 - Commit 88180f7792: release: v0.10.62
 - Generated Racket for 98/100 programs

--- a/transpiler/x/rkt/transpiler.go
+++ b/transpiler/x/rkt/transpiler.go
@@ -81,6 +81,8 @@ func sanitizeName(name string) string {
 		return "panic_"
 	case "append":
 		return "append_"
+	case "reverse":
+		return "reverse_"
 	default:
 		return name
 	}


### PR DESCRIPTION
## Summary
- avoid collision with Racket `reverse` by sanitizing user-defined `reverse`
- refresh Racket algorithms checklist

## Testing
- `for i in $(seq 700 749); do echo "Running index $i"; MOCHI_ALGORITHMS_INDEX=$i go test -tags slow ./transpiler/x/rkt -run TestRktTranspiler_Algorithms_Golden -count=1 || break; done`
- `MOCHI_ALGORITHMS_INDEX=700 go test -tags slow ./transpiler/x/rkt -run TestRktTranspiler_Algorithms_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_689aa35a672883208db62b2b0bcd7024