### PR TITLE
chore(fs): regenerate algorithm outputs and log failure

### DIFF
--- a/tests/algorithms/transpiler/FS/other/lru_cache.fs
+++ b/tests/algorithms/transpiler/FS/other/lru_cache.fs
@@ -1,4 +1,4 @@
-// Generated 2025-08-12 09:13 +0700
+// Generated 2025-08-12 10:04 +0700
 
 exception Return
 let mutable _nowSeed:int64 = 0L

--- a/tests/algorithms/transpiler/FS/other/magicdiamondpattern.bench
+++ b/tests/algorithms/transpiler/FS/other/magicdiamondpattern.bench
@@ -1,5 +1,5 @@
 {
   "duration_us": 571223,
-  "memory_bytes": 50768,
+  "memory_bytes": 59408,
   "name": "main"
 }

--- a/tests/algorithms/transpiler/FS/other/magicdiamondpattern.fs
+++ b/tests/algorithms/transpiler/FS/other/magicdiamondpattern.fs
@@ -1,4 +1,4 @@
-// Generated 2025-08-09 10:14 +0700
+// Generated 2025-08-12 10:04 +0700
 
 exception Return
 let mutable _nowSeed:int64 = 0L
@@ -19,18 +19,6 @@ let _now () =
         int (System.DateTime.UtcNow.Ticks % 2147483647L)
 
 _initNow()
-let _dictAdd<'K,'V when 'K : equality> (d:System.Collections.Generic.IDictionary<'K,'V>) (k:'K) (v:'V) =
-    d.[k] <- v
-    d
-let _dictCreate<'K,'V when 'K : equality> (pairs:('K * 'V) list) : System.Collections.Generic.IDictionary<'K,'V> =
-    let d = System.Collections.Generic.Dictionary<'K, 'V>()
-    for (k, v) in pairs do
-        d.[k] <- v
-    upcast d
-let _dictGet<'K,'V when 'K : equality> (d:System.Collections.Generic.IDictionary<'K,'V>) (k:'K) : 'V =
-    match d.TryGetValue(k) with
-    | true, v -> v
-    | _ -> Unchecked.defaultof<'V>
 let rec floyd (n: int) =
     let mutable __ret : string = Unchecked.defaultof<string>
     let mutable n = n
@@ -94,8 +82,8 @@ and main () =
     try
         let __bench_start = _now()
         let __mem_start = System.GC.GetTotalMemory(true)
-        printfn "%s" (pretty_print (3))
-        printfn "%s" (pretty_print (0))
+        ignore (printfn "%s" (pretty_print (3)))
+        ignore (printfn "%s" (pretty_print (0)))
         let __bench_end = _now()
         let __mem_end = System.GC.GetTotalMemory(true)
         printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)

--- a/tests/algorithms/transpiler/FS/project_euler/problem_055/sol1.error
+++ b/tests/algorithms/transpiler/FS/project_euler/problem_055/sol1.error
@@ -1,0 +1,8 @@
+error[P999]: /workspace/mochi/tests/github/TheAlgorithms/Mochi/project_euler/problem_055/sol1.mochi:46:28: unexpected token "!" (expected PostfixExpr)
+  --> /workspace/mochi/tests/github/TheAlgorithms/Mochi/project_euler/problem_055/sol1.mochi:46:28
+
+ 46 |     if iterations == 50 && !is_palindrome(current) {
+    |                            ^
+
+help:
+  Parse error occurred. Check syntax near this location.

--- a/transpiler/x/fs/ALGORITHMS.md
+++ b/transpiler/x/fs/ALGORITHMS.md
@@ -1,7 +1,7 @@
 # F# Algorithms Transpiler Output
 
 Completed programs: 885/1077
-Last updated: 2025-08-12 09:13 +0700
+Last updated: 2025-08-12 10:04 +0700
 
 Checklist:
 
@@ -757,7 +757,7 @@ Checklist:
 | 748 | other/lfu_cache | ✓ | 571.223ms | 78.2 KB |
 | 749 | other/linear_congruential_generator |   |  |  |
 | 750 | other/lru_cache | ✓ | 571.223ms | 79.3 KB |
-| 751 | other/magicdiamondpattern | ✓ | 571.223ms | 49.6 KB |
+| 751 | other/magicdiamondpattern | ✓ | 571.223ms | 58.0 KB |
 | 752 | other/majority_vote_algorithm | ✓ | 571.223ms | 78.2 KB |
 | 753 | other/maximum_subsequence | ✓ | 571.223ms | 44.8 KB |
 | 754 | other/nested_brackets | ✓ | 571.223ms | 40.4 KB |


### PR DESCRIPTION
## Summary
- regenerate F# transpiler outputs for lru_cache and magicdiamondpattern algorithms
- record parser error for Project Euler problem 055
- refresh algorithms listing with latest benchmark stats

## Testing
- `MOCHI_ALGORITHMS_INDEX=750 go test ./transpiler/x/fs -run TestFSTranspiler_Algorithms_Golden -tags slow -count=1`
- `MOCHI_ALGORITHMS_INDEX=751 go test ./transpiler/x/fs -run TestFSTranspiler_Algorithms_Golden -tags slow -count=1`
- `MOCHI_ALGORITHMS_INDEX=886 go test ./transpiler/x/fs -run TestFSTranspiler_Algorithms_Golden -tags slow -count=1` (fails with parse error)


------
https://chatgpt.com/codex/tasks/task_e_689aaf8deb988320a90835bd88db0165