### PR TITLE
lua: add newline to panic output

### DIFF
--- a/transpiler/x/lua/ALGORITHMS.md
+++ b/transpiler/x/lua/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Lua code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Lua`.
-Last updated: 2025-08-12 09:22 GMT+7
+Last updated: 2025-08-12 10:11 GMT+7
 
 ## Algorithms Golden Test Checklist (1019/1077)
 | Index | Name | Status | Duration | Memory |

--- a/transpiler/x/lua/transpiler.go
+++ b/transpiler/x/lua/transpiler.go
@@ -186,7 +186,8 @@ end
 
 const helperPanic = `
 local function _panic(msg)
-  io.stderr:write(tostring(msg))
+  -- ensure panic messages are newline-terminated for readability
+  io.stderr:write(tostring(msg) .. '\n')
   os.exit(1)
 end
 `


### PR DESCRIPTION
## Summary
- ensure Lua panic helper writes a trailing newline so messages aren't concatenated
- refresh ALGORITHMS.md after running algorithms 750-799

## Testing
- `for i in $(seq 750 799); do MOCHI_ALG_INDEX=$i go test -tags slow ./transpiler/x/lua -run TestLuaTranspiler_Algorithms_Golden -count=1 >/tmp/alg_test.log && tail -n 2 /tmp/alg_test.log; done`


------
https://chatgpt.com/codex/tasks/task_e_689aaf93d49c8320910dc72ea98c9652