### PR TITLE
php: refine global emission

### DIFF
--- a/tests/algorithms/x/PHP/networking_flow/minimum_cut.bench
+++ b/tests/algorithms/x/PHP/networking_flow/minimum_cut.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 121,
+  "duration_us": 169,
   "memory_bytes": 41008,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/networking_flow/minimum_cut.php
+++ b/tests/algorithms/x/PHP/networking_flow/minimum_cut.php
@@ -38,7 +38,6 @@ function _append($arr, $x) {
 $__start_mem = memory_get_usage();
 $__start = _now();
   function bfs($graph, $s, $t, &$parent) {
-  global $test_graph, $result;
   $visited = [];
   $i = 0;
   while ($i < count($graph)) {
@@ -64,7 +63,6 @@ $__start = _now();
   return $visited[$t];
 };
   function mincut($graph, $source, $sink) {
-  global $test_graph, $result;
   $g = $graph;
   $parent = [];
   $i = 0;

--- a/transpiler/x/php/ALGORITHMS.md
+++ b/transpiler/x/php/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated PHP code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/PHP`.
-Last updated: 2025-08-12 10:20 GMT+7
+Last updated: 2025-08-12 11:46 GMT+7
 
 ## Algorithms Golden Test Checklist (956/1077)
 | Index | Name | Status | Duration | Memory |
@@ -726,7 +726,7 @@ Last updated: 2025-08-12 10:20 GMT+7
 | 717 | matrix/tests/test_matrix_operation | ✓ | 124µs | 74.1 KB |
 | 718 | matrix/validate_sudoku_board | ✓ | 145µs | 39.2 KB |
 | 719 | networking_flow/ford_fulkerson | ✓ | 107µs | 39.9 KB |
-| 720 | networking_flow/minimum_cut | ✓ | 121µs | 40.0 KB |
+| 720 | networking_flow/minimum_cut | ✓ | 169µs | 40.0 KB |
 | 721 | neural_network/activation_functions/binary_step | ✓ | 74µs | 35.7 KB |
 | 722 | neural_network/activation_functions/exponential_linear_unit | ✓ | 105µs | 38.8 KB |
 | 723 | neural_network/activation_functions/gaussian_error_linear_unit | ✓ | 104µs | 35.9 KB |

--- a/transpiler/x/php/transpiler.go
+++ b/transpiler/x/php/transpiler.go
@@ -1180,30 +1180,19 @@ func (f *FuncDecl) emit(w io.Writer) {
 	}
 	fmt.Fprint(w, ") {\n")
 	if len(globalNames) > 0 {
-		locals := map[string]struct{}{}
-		gatherLocals(f.Body, locals)
+		fv := freeVars(f.Body, f.Params)
 		var vars []string
-		for _, g := range globalNames {
-			if g == f.Name {
+		for _, name := range fv {
+			if name == f.Name {
 				continue
 			}
-			skip := false
-			for _, p := range f.Params {
-				if g == p {
-					skip = true
-					break
-				}
-			}
-			if _, ok := locals[g]; ok {
-				skip = true
-			}
-			if _, ok := globalFuncs[g]; ok {
-				skip = true
-			}
-			if skip {
+			if _, ok := globalSet[name]; !ok {
 				continue
 			}
-			vars = append(vars, "$"+sanitizeVarName(g))
+			if _, ok := globalFuncs[name]; ok {
+				continue
+			}
+			vars = append(vars, "$"+sanitizeVarName(name))
 		}
 		if len(vars) > 0 {
 			fmt.Fprintf(w, "  global %s;\n", strings.Join(vars, ", "))


### PR DESCRIPTION
## Summary
- limit PHP transpiler's global variable declarations to only variables actually referenced
- add generated PHP and benchmark outputs for networking_flow/minimum_cut
- update PHP algorithms progress report

## Testing
- `MOCHI_ALG_INDEX=720 MOCHI_BENCHMARK=1 go test ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags=slow -count=1 -update-algorithms-php`


------
https://chatgpt.com/codex/tasks/task_e_689ac6279f20832086aed37780205269