### PR TITLE
scala: handle scala3 keywords

### DIFF
--- a/transpiler/x/scala/ALGORITHMS.md
+++ b/transpiler/x/scala/ALGORITHMS.md
@@ -1,7 +1,7 @@
 # Scala Algorithms Transpiler Output
 
 Completed programs: 914/1077
-Last updated: 2025-08-12 09:13 +0700
+Last updated: 2025-08-12 11:46 +0700
 
 Checklist:
 

--- a/transpiler/x/scala/README.md
+++ b/transpiler/x/scala/README.md
@@ -3,7 +3,7 @@
 Generated Scala code for programs in `tests/vm/valid`. Each program has a `.scala` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
 ## Golden Test Checklist (93/105)
-_Last updated: 2025-08-12 09:01 +0700_
+_Last updated: 2025-08-12 11:51 +0700_
 
 - [x] append_builtin
 - [x] avg_builtin

--- a/transpiler/x/scala/ROSETTA.md
+++ b/transpiler/x/scala/ROSETTA.md
@@ -3,7 +3,7 @@
 Generated Scala code for Rosetta tasks in `tests/rosetta/x/Mochi`. Each program has a `.scala` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
 ## Golden Test Checklist (451/491)
-_Last updated: 2025-08-12 09:01 +0700_
+_Last updated: 2025-08-12 11:51 +0700_
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|

--- a/transpiler/x/scala/TASKS.md
+++ b/transpiler/x/scala/TASKS.md
@@ -1,3 +1,215 @@
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
+## Progress (2025-08-12 11:18 +0700)
+- ts transpiler: respect custom ln and exp
+- Regenerated golden files - 93/105 vm valid programs passing
+
 ## Progress (2025-08-12 08:38 +0700)
 - chore(lua): update algorithms progress
 - Regenerated golden files - 93/105 vm valid programs passing

--- a/transpiler/x/scala/transpiler.go
+++ b/transpiler/x/scala/transpiler.go
@@ -108,6 +108,11 @@ var scalaKeywords = map[string]bool{
 	"implicit": true,
 	"lazy":     true,
 	"override": true,
+	// Scala 3 keywords
+	"inline":    true,
+	"opaque":    true,
+	"open":      true,
+	"extension": true,
 	// Future Scala keywords
 	"enum":  true,
 	"given": true,
@@ -2026,13 +2031,13 @@ func Emit(p *Program) []byte {
 		buf.WriteString("  private var _nowSeeded: Boolean = false\n")
 		buf.WriteString("  private def _now(): Int = {\n")
 		buf.WriteString("    if (!_nowSeeded) {\n")
-                buf.WriteString("      sys.env.get(\"MOCHI_NOW_SEED\").foreach { s =>\n")
-                buf.WriteString("        try { _nowSeed = s.toInt; _nowSeeded = true } catch { case _ : NumberFormatException => () }\n")
-                buf.WriteString("      }\n")
-                if benchMain {
-                        buf.WriteString("      if (!_nowSeeded) { _nowSeed = 0L; _nowSeeded = true }\n")
-                }
-                buf.WriteString("    }\n")
+		buf.WriteString("      sys.env.get(\"MOCHI_NOW_SEED\").foreach { s =>\n")
+		buf.WriteString("        try { _nowSeed = s.toInt; _nowSeeded = true } catch { case _ : NumberFormatException => () }\n")
+		buf.WriteString("      }\n")
+		if benchMain {
+			buf.WriteString("      if (!_nowSeeded) { _nowSeed = 0L; _nowSeeded = true }\n")
+		}
+		buf.WriteString("    }\n")
 		buf.WriteString("    if (_nowSeeded) {\n")
 		buf.WriteString("      _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647\n")
 		buf.WriteString("      _nowSeed.toInt\n")


### PR DESCRIPTION
## Summary
- support additional Scala 3 reserved words in transpiler keyword list
- refresh generated documentation for Scala transpiler

## Testing
- `for i in $(seq 720 769); do MOCHI_ALGORITHMS_INDEX=$i go test -tags=slow ./transpiler/x/scala -run TestScalaTranspiler_Algorithms_Golden -count=1 >/tmp/test_$i.log && tail -n 1 /tmp/test_$i.log; done`
- `MOCHI_ALGORITHMS_INDEX=769 go test -tags=slow ./transpiler/x/scala -run TestScalaTranspiler_Algorithms_Golden -count=1`


------
https://chatgpt.com/codex/tasks/task_e_689ac63b40448320be87f2cdbd0c6875