### PR TITLE
fs: add mirror formula algorithm

### DIFF
--- a/tests/algorithms/transpiler/FS/physics/mirror_formulae.bench
+++ b/tests/algorithms/transpiler/FS/physics/mirror_formulae.bench
@@ -1,5 +1,5 @@
 {
   "duration_us": 571223,
-  "memory_bytes": 80520,
+  "memory_bytes": 80632,
   "name": "main"
 }

--- a/tests/algorithms/transpiler/FS/physics/mirror_formulae.fs
+++ b/tests/algorithms/transpiler/FS/physics/mirror_formulae.fs
@@ -1,4 +1,4 @@
-// Generated 2025-08-09 23:14 +0700
+// Generated 2025-08-12 12:29 +0700
 
 exception Return
 let mutable _nowSeed:int64 = 0L
@@ -53,7 +53,7 @@ and focal_length (distance_of_object: float) (distance_of_image: float) =
     let mutable distance_of_image = distance_of_image
     try
         if (distance_of_object = 0.0) || (distance_of_image = 0.0) then
-            failwith ("Invalid inputs. Enter non zero values with respect to the sign convention.")
+            ignore (failwith ("Invalid inputs. Enter non zero values with respect to the sign convention."))
         __ret <- 1.0 / ((1.0 / distance_of_object) + (1.0 / distance_of_image))
         raise Return
         __ret
@@ -65,7 +65,7 @@ and object_distance (focal_length: float) (distance_of_image: float) =
     let mutable distance_of_image = distance_of_image
     try
         if (distance_of_image = 0.0) || (focal_length = 0.0) then
-            failwith ("Invalid inputs. Enter non zero values with respect to the sign convention.")
+            ignore (failwith ("Invalid inputs. Enter non zero values with respect to the sign convention."))
         __ret <- 1.0 / ((1.0 / focal_length) - (1.0 / distance_of_image))
         raise Return
         __ret
@@ -77,7 +77,7 @@ and image_distance (focal_length: float) (distance_of_object: float) =
     let mutable distance_of_object = distance_of_object
     try
         if (distance_of_object = 0.0) || (focal_length = 0.0) then
-            failwith ("Invalid inputs. Enter non zero values with respect to the sign convention.")
+            ignore (failwith ("Invalid inputs. Enter non zero values with respect to the sign convention."))
         __ret <- 1.0 / ((1.0 / focal_length) - (1.0 / distance_of_object))
         raise Return
         __ret
@@ -88,10 +88,10 @@ and test_focal_length () =
     try
         let f1: float = focal_length (10.0) (20.0)
         if not (isclose (f1) (6.66666666666666) (0.00000001)) then
-            failwith ("focal_length test1 failed")
+            ignore (failwith ("focal_length test1 failed"))
         let f2: float = focal_length (9.5) (6.7)
         if not (isclose (f2) (3.929012346) (0.00000001)) then
-            failwith ("focal_length test2 failed")
+            ignore (failwith ("focal_length test2 failed"))
         __ret
     with
         | Return -> __ret
@@ -100,10 +100,10 @@ and test_object_distance () =
     try
         let u1: float = object_distance (30.0) (20.0)
         if not (isclose (u1) (-60.0) (0.00000001)) then
-            failwith ("object_distance test1 failed")
+            ignore (failwith ("object_distance test1 failed"))
         let u2: float = object_distance (10.5) (11.7)
         if not (isclose (u2) (102.375) (0.00000001)) then
-            failwith ("object_distance test2 failed")
+            ignore (failwith ("object_distance test2 failed"))
         __ret
     with
         | Return -> __ret
@@ -112,10 +112,10 @@ and test_image_distance () =
     try
         let v1: float = image_distance (10.0) (40.0)
         if not (isclose (v1) (13.33333333) (0.00000001)) then
-            failwith ("image_distance test1 failed")
+            ignore (failwith ("image_distance test1 failed"))
         let v2: float = image_distance (1.5) (6.7)
         if not (isclose (v2) (1.932692308) (0.00000001)) then
-            failwith ("image_distance test2 failed")
+            ignore (failwith ("image_distance test2 failed"))
         __ret
     with
         | Return -> __ret
@@ -127,9 +127,9 @@ and main () =
         test_focal_length()
         test_object_distance()
         test_image_distance()
-        printfn "%s" (_str (focal_length (10.0) (20.0)))
-        printfn "%s" (_str (object_distance (30.0) (20.0)))
-        printfn "%s" (_str (image_distance (10.0) (40.0)))
+        ignore (printfn "%s" (_str (focal_length (10.0) (20.0))))
+        ignore (printfn "%s" (_str (object_distance (30.0) (20.0))))
+        ignore (printfn "%s" (_str (image_distance (10.0) (40.0))))
         let __bench_end = _now()
         let __mem_end = System.GC.GetTotalMemory(true)
         printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)

--- a/transpiler/x/fs/ALGORITHMS.md
+++ b/transpiler/x/fs/ALGORITHMS.md
@@ -1,7 +1,7 @@
 # F# Algorithms Transpiler Output
 
 Completed programs: 886/1077
-Last updated: 2025-08-12 11:18 +0700
+Last updated: 2025-08-12 12:29 +0700
 
 Checklist:
 
@@ -728,31 +728,31 @@ Checklist:
 | 719 | networking_flow/ford_fulkerson | ✓ | 571.223ms | 77.9 KB |
 | 720 | networking_flow/minimum_cut | ✓ | 571.223ms | 78.4 KB |
 | 721 | neural_network/activation_functions/binary_step | ✓ | 571.223ms | 55.2 KB |
-| 722 | neural_network/activation_functions/exponential_linear_unit | ✓ | 571.223ms | 119.5 KB |
-| 723 | neural_network/activation_functions/gaussian_error_linear_unit | ✓ | 571.223ms | 56.5 KB |
-| 724 | neural_network/activation_functions/leaky_rectified_linear_unit | ✓ | 571.223ms | 79.5 KB |
-| 725 | neural_network/activation_functions/mish | ✓ | 571.223ms | 79.2 KB |
+| 722 | neural_network/activation_functions/exponential_linear_unit | ✓ | 571.223ms | 85.8 KB |
+| 723 | neural_network/activation_functions/gaussian_error_linear_unit | ✓ | 571.223ms | 60.6 KB |
+| 724 | neural_network/activation_functions/leaky_rectified_linear_unit | ✓ | 571.223ms | 79.4 KB |
+| 725 | neural_network/activation_functions/mish | ✓ | 571.223ms | 88.6 KB |
 | 726 | neural_network/activation_functions/rectified_linear_unit | ✓ | 571.223ms | 79.2 KB |
-| 727 | neural_network/activation_functions/scaled_exponential_linear_unit | ✓ | 571.223ms | 85.6 KB |
-| 728 | neural_network/activation_functions/soboleva_modified_hyperbolic_tangent | ✓ | 571.223ms | 32.4 KB |
+| 727 | neural_network/activation_functions/scaled_exponential_linear_unit | ✓ | 571.223ms | 56.3 KB |
+| 728 | neural_network/activation_functions/soboleva_modified_hyperbolic_tangent | ✓ | 571.223ms | 6.9 KB |
 | 729 | neural_network/activation_functions/softplus | ✓ | 571.223ms | 56.5 KB |
-| 730 | neural_network/activation_functions/squareplus | ✓ | 571.223ms | 79.2 KB |
-| 731 | neural_network/activation_functions/swish | ✓ | 571.223ms | 83.7 KB |
+| 730 | neural_network/activation_functions/squareplus | ✓ | 571.223ms | 83.0 KB |
+| 731 | neural_network/activation_functions/swish | ✓ | 571.223ms | 83.4 KB |
 | 732 | neural_network/back_propagation_neural_network | ✓ | 571.223ms | 46.9 KB |
-| 733 | neural_network/convolution_neural_network | ✓ | 571.223ms | 58.6 KB |
-| 734 | neural_network/input_data | ✓ | 571.223ms | 84.0 KB |
+| 733 | neural_network/convolution_neural_network | ✓ | 571.223ms | 58.5 KB |
+| 734 | neural_network/input_data | ✓ | 571.223ms | 89.0 KB |
 | 735 | neural_network/simple_neural_network | ✓ | 571.223ms | 33.5 KB |
 | 736 | neural_network/two_hidden_layers_neural_network | ✓ | 571.223ms | 78.0 KB |
-| 737 | other/activity_selection | ✓ | 571.223ms | 78.0 KB |
+| 737 | other/activity_selection | ✓ | 571.223ms | 88.9 KB |
 | 738 | other/alternative_list_arrange | ✓ | 571.223ms | 79.3 KB |
-| 739 | other/bankers_algorithm | ✓ | 571.223ms | 79.5 KB |
-| 740 | other/davis_putnam_logemann_loveland | ✓ | 571.223ms | 45.6 KB |
+| 739 | other/bankers_algorithm | ✓ | 571.223ms | 87.3 KB |
+| 740 | other/davis_putnam_logemann_loveland | ✓ | 571.223ms | 33.2 KB |
 | 741 | other/doomsday | ✓ | 571.223ms | 32.3 KB |
-| 742 | other/fischer_yates_shuffle | ✓ | 571.223ms | 88.5 KB |
+| 742 | other/fischer_yates_shuffle | ✓ | 571.223ms | 84.8 KB |
 | 743 | other/gauss_easter | ✓ | 571.223ms | 78.0 KB |
 | 744 | other/greedy | ✓ | 571.223ms | 79.8 KB |
-| 745 | other/guess_the_number_search | ✓ | 571.223ms | 88.4 KB |
-| 746 | other/h_index | ✓ | 571.223ms | 78.1 KB |
+| 745 | other/guess_the_number_search | ✓ | 571.223ms | 81.9 KB |
+| 746 | other/h_index | ✓ | 571.223ms | 94.4 KB |
 | 747 | other/least_recently_used | ✓ | 571.223ms | 78.2 KB |
 | 748 | other/lfu_cache | ✓ | 571.223ms | 78.2 KB |
 | 749 | other/linear_congruential_generator | ✓ |  | 112.9 KB |
@@ -786,7 +786,7 @@ Checklist:
 | 777 | physics/lorentz_transformation_four_vector | ✓ | 571.223ms | 85.1 KB |
 | 778 | physics/malus_law | ✓ | 571.223ms | 78.5 KB |
 | 779 | physics/mass_energy_equivalence | ✓ | 571.223ms | 79.3 KB |
-| 780 | physics/mirror_formulae | ✓ | 571.223ms | 78.6 KB |
+| 780 | physics/mirror_formulae | ✓ | 571.223ms | 78.7 KB |
 | 781 | physics/n_body_simulation | ✓ | 571.223ms | 28.9 KB |
 | 782 | physics/newtons_law_of_gravitation | ✓ | 571.223ms | 79.3 KB |
 | 783 | physics/newtons_second_law_of_motion | ✓ | 571.223ms | 78.8 KB |

--- a/transpiler/x/fs/README.md
+++ b/transpiler/x/fs/README.md
@@ -112,4 +112,4 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-Last updated: 2025-08-12 09:13 +0700
+Last updated: 2025-08-12 12:29 +0700

--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-08-12 12:29 +0700)
+- zig: support slice literals and to_float
+- Generated F# for 103/105 programs (103 passing)
+
 ## Progress (2025-08-12 09:13 +0700)
 - scala: handle struct indexing and list types
 - Generated F# for 103/105 programs (103 passing)


### PR DESCRIPTION
## Summary
- transpile `physics/mirror_formulae.mochi` to F# with benchmark-enabled main
- refresh algorithm checklist and progress notes

## Testing
- `MOCHI_ALGORITHMS_INDEX=780 go test ./transpiler/x/fs -run TestFSTranspiler_Algorithms_Golden -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_689ad1d4dfb8832084df2b33138323cc