### PR TITLE
scheme: improve float literal emission

### DIFF
--- a/transpiler/x/scheme/transpiler.go
+++ b/transpiler/x/scheme/transpiler.go
@@ -8,11 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -235,11 +235,12 @@ type FloatLit float64
 
 func (f FloatLit) Emit(w io.Writer) {
 	v := float64(f)
-	if math.Trunc(v) == v {
-		fmt.Fprintf(w, "%.1f", v)
-	} else {
-		fmt.Fprintf(w, "%g", v)
+	s := strconv.FormatFloat(v, 'g', -1, 64)
+	if !strings.ContainsAny(s, ".e") {
+		// ensure a decimal point so the literal is treated as inexact
+		s += ".0"
 	}
+	io.WriteString(w, s)
 }
 
 type BoolLit bool


### PR DESCRIPTION
## Summary
- ensure Scheme transpiler emits floats with full precision and explicit decimal point

## Testing
- `MOCHI_ALGORITHMS_INDEX=690 go test -tags slow ./transpiler/x/scheme -run TestSchemeTranspiler_Algorithms_Golden -count=1 -v`
- `MOCHI_ALGORITHMS_INDEX=763 go test -tags slow ./transpiler/x/scheme -run TestSchemeTranspiler_Algorithms_Golden -count=1 -update-algorithms-scheme -v` *(fails: exit status 70)*


------
https://chatgpt.com/codex/tasks/task_e_689ae32fb6d083208cb7826df609de23