### PR TITLE
php transpiler: handle string fetch

### DIFF
--- a/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.bench
+++ b/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.bench
@@ -1,0 +1,19 @@
+Warning: file_get_contents(https://openlibrary.org/isbn/0140328726.json): Failed to open stream: Network is unreachable in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php on line 70
+
+Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php on line 167
+
+Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php on line 173
+
+Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php on line 173
+
+Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php on line 173
+
+Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php on line 173
+
+Fatal error: Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php:102
+Stack trace:
+#0 /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php(173): mochi_join(NULL, ', ')
+#1 /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php(177): summarize_book(NULL)
+#2 /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php(185): main()
+#3 {main}
+  thrown in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php on line 102

--- a/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.error
+++ b/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.error
@@ -1,0 +1,21 @@
+run: exit status 255
+
+Warning: file_get_contents(https://openlibrary.org/isbn/0140328726.json): Failed to open stream: Network is unreachable in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php on line 70
+
+Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php on line 167
+
+Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php on line 173
+
+Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php on line 173
+
+Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php on line 173
+
+Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php on line 173
+
+Fatal error: Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php:102
+Stack trace:
+#0 /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php(173): mochi_join(NULL, ', ')
+#1 /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php(177): summarize_book(NULL)
+#2 /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php(185): main()
+#3 {main}
+  thrown in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php on line 102

--- a/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.out
+++ b/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.out
@@ -1,0 +1,19 @@
+Warning: file_get_contents(https://openlibrary.org/isbn/0140328726.json): Failed to open stream: Network is unreachable in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php on line 55
+
+Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php on line 150
+
+Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php on line 156
+
+Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php on line 156
+
+Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php on line 156
+
+Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php on line 156
+
+Fatal error: Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php:85
+Stack trace:
+#0 /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php(156): mochi_join(NULL, ', ')
+#1 /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php(160): summarize_book(NULL)
+#2 /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php(168): main()
+#3 {main}
+  thrown in /workspace/mochi/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php on line 85

--- a/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php
+++ b/tests/algorithms/x/PHP/web_programming/search_books_by_isbn.php
@@ -1,0 +1,193 @@
+<?php
+ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+function _len($x) {
+    if ($x === null) { return 0; }
+    if (is_array($x)) { return count($x); }
+    if (is_string($x)) { return strlen($x); }
+    return strlen(strval($x));
+}
+function _str($x) {
+    if (is_array($x)) {
+        $isList = array_keys($x) === range(0, count($x) - 1);
+        if ($isList) {
+            $parts = [];
+            foreach ($x as $v) { $parts[] = _str($v); }
+            return '[' . implode(' ', $parts) . ']';
+        }
+        $parts = [];
+        foreach ($x as $k => $v) { $parts[] = _str($k) . ':' . _str($v); }
+        return 'map[' . implode(' ', $parts) . ']';
+    }
+    if (is_bool($x)) return $x ? 'true' : 'false';
+    if ($x === null) return 'null';
+    return strval($x);
+}
+function _append($arr, $x) {
+    $arr[] = $x;
+    return $arr;
+}
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+function _fetch($url, $opts = null) {
+    $method = 'GET';
+    $headers = [];
+    $body = null;
+    $query = null;
+    $timeout = 0;
+    if ($opts !== null) {
+        if (isset($opts['method'])) $method = strtoupper($opts['method']);
+        if (isset($opts['headers'])) {
+            foreach ($opts['headers'] as $k => $v) { $headers[] = "$k: $v"; }
+        }
+        if (isset($opts['body'])) $body = json_encode($opts['body']);
+        if (isset($opts['query'])) $query = http_build_query($opts['query']);
+        if (isset($opts['timeout'])) $timeout = intval($opts['timeout']);
+    }
+    if ($query !== null) {
+        $url .= (strpos($url, '?') !== false ? '&' : '?') . $query;
+    }
+    $context = ['http' => ['method' => $method, 'header' => implode("\r\n", $headers)]];
+    if ($body !== null) $context['http']['content'] = $body;
+    if ($timeout > 0) $context['http']['timeout'] = $timeout / 1000.0;
+    $ctx = stream_context_create($context);
+    $data = file_get_contents($url, false, $ctx);
+    return json_decode($data, true);
+}
+function _fetch_str($url, $opts = null) {
+    $method = 'GET';
+    $headers = [];
+    $body = null;
+    $query = null;
+    $timeout = 0;
+    if ($opts !== null) {
+        if (isset($opts['method'])) $method = strtoupper($opts['method']);
+        if (isset($opts['headers'])) {
+            foreach ($opts['headers'] as $k => $v) { $headers[] = "$k: $v"; }
+        }
+        if (isset($opts['body'])) $body = json_encode($opts['body']);
+        if (isset($opts['query'])) $query = http_build_query($opts['query']);
+        if (isset($opts['timeout'])) $timeout = intval($opts['timeout']);
+    }
+    if ($query !== null) {
+        $url .= (strpos($url, '?') !== false ? '&' : '?') . $query;
+    }
+    $context = ['http' => ['method' => $method, 'header' => implode("\r\n", $headers)]];
+    if ($body !== null) $context['http']['content'] = $body;
+    if ($timeout > 0) $context['http']['timeout'] = $timeout / 1000.0;
+    $ctx = stream_context_create($context);
+    return file_get_contents($url, false, $ctx);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function mochi_join($xs, $sep) {
+  $res = '';
+  $i = 0;
+  while ($i < count($xs)) {
+  if ($i > 0) {
+  $res = $res . $sep;
+}
+  $res = $res . $xs[$i];
+  $i = $i + 1;
+};
+  return $res;
+};
+  function count_char($s, $ch) {
+  $cnt = 0;
+  $i = 0;
+  while ($i < strlen($s)) {
+  if (substr($s, $i, $i + 1 - $i) == $ch) {
+  $cnt = $cnt + 1;
+}
+  $i = $i + 1;
+};
+  return $cnt;
+};
+  function strip($s) {
+  $start = 0;
+  $end = strlen($s);
+  while ($start < $end && substr($s, $start, $start + 1 - $start) == ' ') {
+  $start = $start + 1;
+};
+  while ($end > $start && substr($s, $end - 1, $end - ($end - 1)) == ' ') {
+  $end = $end - 1;
+};
+  return substr($s, $start, $end - $start);
+};
+  function trim_slashes($s) {
+  $start = 0;
+  $end = strlen($s);
+  while ($start < $end && substr($s, $start, $start + 1 - $start) == '/') {
+  $start = $start + 1;
+};
+  while ($end > $start && substr($s, $end - 1, $end - ($end - 1)) == '/') {
+  $end = $end - 1;
+};
+  return substr($s, $start, $end - $start);
+};
+  function normalize_olid($olid) {
+  $stripped = strip($olid);
+  $cleaned = trim_slashes($stripped);
+  if (count_char($cleaned, '/') != 1) {
+  _panic($olid . ' is not a valid Open Library olid');
+}
+  return $cleaned;
+};
+  function get_book_data($olid) {
+  $norm = normalize_olid($olid);
+  $url = 'https://openlibrary.org/' . $norm . '.json';
+  $data = _fetch($url);
+  return $data;
+};
+  function get_author_data($olid) {
+  $norm = normalize_olid($olid);
+  $url = 'https://openlibrary.org/' . $norm . '.json';
+  $data = _fetch($url);
+  return $data;
+};
+  function summarize_book($book) {
+  $names = [];
+  $i = 0;
+  while ($i < _len($book['authors'])) {
+  $ref = $book['authors'][$i];
+  $auth = get_author_data($ref['key']);
+  $names = _append($names, $auth['name']);
+  $i = $i + 1;
+};
+  return ['title' => $book['title'], 'publish_date' => $book['publish_date'], 'authors' => mochi_join($names, ', '), 'number_of_pages' => $book['number_of_pages'], 'isbn_10' => mochi_join($book['isbn_10'], ', '), 'isbn_13' => mochi_join($book['isbn_13'], ', ')];
+};
+  function main() {
+  $book = get_book_data('isbn/0140328726');
+  $summary = summarize_book($book);
+  echo rtrim('Title: ' . $summary['title']), PHP_EOL;
+  echo rtrim('Publish date: ' . $summary['publish_date']), PHP_EOL;
+  echo rtrim('Authors: ' . $summary['authors']), PHP_EOL;
+  echo rtrim('Number of pages: ' . _str($summary['number_of_pages'])), PHP_EOL;
+  echo rtrim('ISBN (10): ' . $summary['isbn_10']), PHP_EOL;
+  echo rtrim('ISBN (13): ' . $summary['isbn_13']), PHP_EOL;
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/web_programming/slack_message.bench
+++ b/tests/algorithms/x/PHP/web_programming/slack_message.bench
@@ -1,0 +1,2 @@
+Warning: file_get_contents(https://httpbin.org/post): Failed to open stream: Network is unreachable in /workspace/mochi/tests/algorithms/x/PHP/web_programming/slack_message.php on line 69
+Request to slack returned an error:

--- a/tests/algorithms/x/PHP/web_programming/slack_message.error
+++ b/tests/algorithms/x/PHP/web_programming/slack_message.error
@@ -1,0 +1,4 @@
+run: exit status 1
+
+Warning: file_get_contents(https://httpbin.org/post): Failed to open stream: Network is unreachable in /workspace/mochi/tests/algorithms/x/PHP/web_programming/slack_message.php on line 69
+Request to slack returned an error: 

--- a/tests/algorithms/x/PHP/web_programming/slack_message.out
+++ b/tests/algorithms/x/PHP/web_programming/slack_message.out
@@ -1,0 +1,2 @@
+Warning: file_get_contents(https://httpbin.org/post): Failed to open stream: Network is unreachable in /workspace/mochi/tests/algorithms/x/PHP/web_programming/slack_message.php on line 54
+Request to slack returned an error:

--- a/tests/algorithms/x/PHP/web_programming/slack_message.php
+++ b/tests/algorithms/x/PHP/web_programming/slack_message.php
@@ -1,0 +1,92 @@
+<?php
+ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+function _fetch($url, $opts = null) {
+    $method = 'GET';
+    $headers = [];
+    $body = null;
+    $query = null;
+    $timeout = 0;
+    if ($opts !== null) {
+        if (isset($opts['method'])) $method = strtoupper($opts['method']);
+        if (isset($opts['headers'])) {
+            foreach ($opts['headers'] as $k => $v) { $headers[] = "$k: $v"; }
+        }
+        if (isset($opts['body'])) $body = json_encode($opts['body']);
+        if (isset($opts['query'])) $query = http_build_query($opts['query']);
+        if (isset($opts['timeout'])) $timeout = intval($opts['timeout']);
+    }
+    if ($query !== null) {
+        $url .= (strpos($url, '?') !== false ? '&' : '?') . $query;
+    }
+    $context = ['http' => ['method' => $method, 'header' => implode("\r\n", $headers)]];
+    if ($body !== null) $context['http']['content'] = $body;
+    if ($timeout > 0) $context['http']['timeout'] = $timeout / 1000.0;
+    $ctx = stream_context_create($context);
+    $data = file_get_contents($url, false, $ctx);
+    return json_decode($data, true);
+}
+function _fetch_str($url, $opts = null) {
+    $method = 'GET';
+    $headers = [];
+    $body = null;
+    $query = null;
+    $timeout = 0;
+    if ($opts !== null) {
+        if (isset($opts['method'])) $method = strtoupper($opts['method']);
+        if (isset($opts['headers'])) {
+            foreach ($opts['headers'] as $k => $v) { $headers[] = "$k: $v"; }
+        }
+        if (isset($opts['body'])) $body = json_encode($opts['body']);
+        if (isset($opts['query'])) $query = http_build_query($opts['query']);
+        if (isset($opts['timeout'])) $timeout = intval($opts['timeout']);
+    }
+    if ($query !== null) {
+        $url .= (strpos($url, '?') !== false ? '&' : '?') . $query;
+    }
+    $context = ['http' => ['method' => $method, 'header' => implode("\r\n", $headers)]];
+    if ($body !== null) $context['http']['content'] = $body;
+    if ($timeout > 0) $context['http']['timeout'] = $timeout / 1000.0;
+    $ctx = stream_context_create($context);
+    return file_get_contents($url, false, $ctx);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function send_slack_message($message_body, $slack_url) {
+  global $url;
+  $headers = ['Content-Type' => 'application/json'];
+  $response = _fetch_str(strval($slack_url), ['method' => 'POST', 'headers' => $headers, 'body' => ['text' => $message_body]]);
+  if ($response != 'ok') {
+  _panic('Request to slack returned an error: ' . $response);
+}
+  return $response;
+};
+  $url = 'https://httpbin.org/post';
+  send_slack_message('Hello from Mochi', $url);
+  echo rtrim('Message sent'), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/transpiler/x/php/ALGORITHMS.md
+++ b/transpiler/x/php/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated PHP code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/PHP`.
-Last updated: 2025-08-12 14:02 GMT+7
+Last updated: 2025-08-12 14:18 GMT+7
 
 ## Algorithms Golden Test Checklist (972/1077)
 | Index | Name | Status | Duration | Memory |
@@ -1080,7 +1080,7 @@ Last updated: 2025-08-12 14:02 GMT+7
 | 1071 | web_programming/random_anime_character | ✓ | 150µs | 38.7 KB |
 | 1072 | web_programming/recaptcha_verification | ✓ | 99µs | 39.0 KB |
 | 1073 | web_programming/reddit | ✓ | 465µs | 40.9 KB |
-| 1074 | web_programming/search_books_by_isbn |   |  |  |
-| 1075 | web_programming/slack_message |   |  |  |
+| 1074 | web_programming/search_books_by_isbn | error |  |  |
+| 1075 | web_programming/slack_message | error |  |  |
 | 1076 | web_programming/test_fetch_github_info | ✓ | 132µs | 37.2 KB |
 | 1077 | web_programming/world_covid19_stats | ✓ | 699µs | 39.5 KB |


### PR DESCRIPTION
## Summary
- allow PHP transpiler to fetch raw strings via new `_fetch_str` helper
- handle string-typed fetch assignments
- add generated PHP and outputs for `search_books_by_isbn` and `slack_message`

## Testing
- `MOCHI_ALG_INDEX=1074 go test ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags slow -count=1 -update-algorithms-php`
- `MOCHI_ALG_INDEX=1074 MOCHI_BENCHMARK=1 go test ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags slow -count=1 -update-algorithms-php`
- `MOCHI_ALG_INDEX=1075 go test ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags slow -count=1 -update-algorithms-php`
- `MOCHI_ALG_INDEX=1075 MOCHI_BENCHMARK=1 go test ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags slow -count=1 -update-algorithms-php`

------
https://chatgpt.com/codex/tasks/task_e_689ae831504c8320869f87fa581ba67e