### PR TITLE
fix rs transpiler string enum field

### DIFF
--- a/tests/algorithms/x/Rust/other/alternative_list_arrange.bench
+++ b/tests/algorithms/x/Rust/other/alternative_list_arrange.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 110,
-  "memory_bytes": 2240512,
+  "duration_us": 89,
+  "memory_bytes": 2215936,
   "name": "main"
 }

--- a/tests/algorithms/x/Rust/other/alternative_list_arrange.rs
+++ b/tests/algorithms/x/Rust/other/alternative_list_arrange.rs
@@ -48,8 +48,8 @@ fn main() {
     fn from_string(s: &str) -> Item {
     return Item::Str { value: s.to_string() }
 };
-    fn item_to_string(it: &Item) -> String {
-    return match it { Item::Int { value: v } => (*v).to_string(), Item::Str { value: s } => (*s).clone(), }.to_string().clone()
+    fn item_to_string(mut it: Item) -> String {
+    return match it { Item::Int { value: v } => v.to_string(), Item::Str { value: s } => s, }.to_string().clone()
 };
     fn alternative_list_arrange(mut first: Vec<Item>, mut second: Vec<Item>) -> Vec<Item> {
     let len1: i64 = (first.len() as i64);
@@ -72,7 +72,7 @@ fn main() {
     let mut s: String = String::from("[").clone();
     let mut i: i64 = 0;
     while (i < (xs.len() as i64)) {
-        s = format!("{}{}", s, item_to_string(&xs[i as usize].clone()));
+        s = format!("{}{}", s, item_to_string(xs[i as usize].clone()));
         if (i < ((xs.len() as i64) - 1)) {
             s = format!("{}{}", s, ", ");
         }

--- a/transpiler/x/rs/ALGORITHMS.md
+++ b/transpiler/x/rs/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Rust code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Rust`.
-Last updated: 2025-08-12 13:50 GMT+7
+Last updated: 2025-08-12 14:21 GMT+7
 
 ## Algorithms Golden Test Checklist (646/1077)
 | Index | Name | Status | Duration | Memory |
@@ -744,7 +744,7 @@ Last updated: 2025-08-12 13:50 GMT+7
 | 735 | neural_network/simple_neural_network | ✓ | 98.423ms | 2.2 MB |
 | 736 | neural_network/two_hidden_layers_neural_network | ✓ | 819µs | 2.3 MB |
 | 737 | other/activity_selection | ✓ | 42µs | 2.0 MB |
-| 738 | other/alternative_list_arrange | ✓ | 110µs | 2.1 MB |
+| 738 | other/alternative_list_arrange | ✓ | 89µs | 2.1 MB |
 | 739 | other/bankers_algorithm | ✓ | 144µs | 2.0 MB |
 | 740 | other/davis_putnam_logemann_loveland | ✓ | 141µs | 2.2 MB |
 | 741 | other/doomsday | ✓ | 40µs | 2.0 MB |


### PR DESCRIPTION
## Summary
- handle &str parameters assigned to enum String fields in Rust transpiler
- regenerate alternative_list_arrange algorithm output and benchmarks

## Testing
- `MOCHI_ALG_INDEX=738 go test -tags=slow ./transpiler/x/rs -run TestRsTranspiler_Algorithms_Golden -count=1`
- `MOCHI_ALG_INDEX=738 MOCHI_BENCHMARK=1 go test -tags=slow ./transpiler/x/rs -run TestRsTranspiler_Algorithms_Golden -count=1 -update-algorithms-rs`


------
https://chatgpt.com/codex/tasks/task_e_689ae919d9088320b212090358cb2c83