### PR TITLE
dart: guard _str int conversion

### DIFF
--- a/transpiler/x/dart/ALGORITHMS.md
+++ b/transpiler/x/dart/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Dart code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Dart`.
-Last updated: 2025-08-12 13:52 GMT+7
+Last updated: 2025-08-12 16:12 GMT+7
 
 ## Algorithms Golden Test Checklist (899/1077)
 | Index | Name | Status | Duration | Memory |

--- a/transpiler/x/dart/transpiler.go
+++ b/transpiler/x/dart/transpiler.go
@@ -4527,7 +4527,7 @@ func Emit(w io.Writer, p *Program) error {
 	}
 	if useStr {
 		if _, err := io.WriteString(w, "String _str(dynamic v) {"+
-			" if (v is double && v == v.roundToDouble()) {"+
+			" if (v is double && v.abs() <= 9007199254740991 && v == v.roundToDouble()) {"+
 			" var i = v.toInt();"+
 			" if (i == 0) return '0';"+
 			" return i.toString();"+


### PR DESCRIPTION
## Summary
- avoid lossy integer conversion when formatting large doubles in Dart transpiler
- regenerate algorithms checklist for indices 721-770

## Testing
- `MOCHI_ALG_INDEX=721 go test -tags=slow ./transpiler/x/dart -run TestDartTranspiler_Algorithms_Golden`


------
https://chatgpt.com/codex/tasks/task_e_689b0323a74c8320a31617754f8fa55f