### PR TITLE
kt: fix main wrapper for benchmarks

### DIFF
--- a/tests/algorithms/x/Kotlin/neural_network/activation_functions/binary_step.bench
+++ b/tests/algorithms/x/Kotlin/neural_network/activation_functions/binary_step.bench
@@ -1,2 +1,2 @@
 [0, 1, 1, 1, 0, 1]
-{"duration_us":17141, "memory_bytes":41248, "name":"main"}
+{"duration_us":22436, "memory_bytes":125464, "name":"main"}

--- a/tests/algorithms/x/Kotlin/neural_network/activation_functions/binary_step.kt
+++ b/tests/algorithms/x/Kotlin/neural_network/activation_functions/binary_step.kt
@@ -1,29 +1,3 @@
-var _nowSeed = 0L
-var _nowSeeded = false
-fun _now(): Long {
-    if (!_nowSeeded) {
-        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
-            _nowSeed = it
-            _nowSeeded = true
-        }
-    }
-    return if (_nowSeeded) {
-        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
-        kotlin.math.abs(_nowSeed)
-    } else {
-        kotlin.math.abs(System.nanoTime())
-    }
-}
-
-fun toJson(v: Any?): String = when (v) {
-    null -> "null"
-    is String -> "\"" + v.replace("\"", "\\\"") + "\""
-    is Boolean, is Number -> v.toString()
-    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
-    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
-    else -> toJson(v.toString())
-}
-
 fun binary_step(vector: MutableList<Double>): MutableList<Int> {
     var out: MutableList<Int> = mutableListOf<Int>()
     var i: Int = (0).toInt()
@@ -45,17 +19,5 @@ fun user_main(): Unit {
 }
 
 fun main() {
-    run {
-        System.gc()
-        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
-        val _start = _now()
-        user_main()
-        System.gc()
-        val _end = _now()
-        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
-        val _durationUs = (_end - _start) / 1000
-        val _memDiff = kotlin.math.abs(_endMem - _startMem)
-        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
-        println(toJson(_res))
-    }
+    user_main()
 }

--- a/transpiler/x/kt/ALGORITHMS.md
+++ b/transpiler/x/kt/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Kotlin code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Kotlin`.
-Last updated: 2025-08-12 14:21 GMT+7
+Last updated: 2025-08-12 16:15 GMT+7
 
 ## Algorithms Golden Test Checklist (463/1077)
 | Index | Name | Status | Duration | Memory |
@@ -727,7 +727,7 @@ Last updated: 2025-08-12 14:21 GMT+7
 | 718 | matrix/validate_sudoku_board | ✓ | 26.45ms | 132.62KiB |
 | 719 | networking_flow/ford_fulkerson | ✓ | 24.32ms | 132.37KiB |
 | 720 | networking_flow/minimum_cut | ✓ | 4.11ms | 28.62KiB |
-| 721 | neural_network/activation_functions/binary_step | ✓ | 17.14ms | 40.28KiB |
+| 721 | neural_network/activation_functions/binary_step | ✓ | 22.44ms | 122.52KiB |
 | 722 | neural_network/activation_functions/exponential_linear_unit | ✓ | 16.74ms | 41.36KiB |
 | 723 | neural_network/activation_functions/gaussian_error_linear_unit | ✓ | 6.86ms | 30.84KiB |
 | 724 | neural_network/activation_functions/leaky_rectified_linear_unit | ✓ | 5.68ms | 29.97KiB |

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
-Last updated: 2025-08-09 23:14 +0700
+Last updated: 2025-08-12 15:27 +0700
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-08-09 23:14 +0700
+Last updated: 2025-08-12 15:27 +0700
 
 Completed tasks: **367/491**
 

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,6 @@
+## VM Golden Progress (2025-08-12 15:27 +0700)
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-08-09 23:14 +0700)
 - Regenerated Kotlin golden files and README
 

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -3915,6 +3915,13 @@ func Transpile(env *types.Env, prog *parser.Program) (*Program, error) {
 			return nil, fmt.Errorf("unsupported statement")
 		}
 	}
+	for _, st := range p.Stmts {
+		if es, ok := st.(*ExprStmt); ok {
+			if ce, ok := es.Expr.(*CallExpr); ok && ce.Func == "main" {
+				ce.Func = "user_main"
+			}
+		}
+	}
 	if benchMain {
 		useHelper("_now")
 		useHelper("toJson")


### PR DESCRIPTION
## Summary
- ensure transpiled Kotlin main wrapper invokes user code instead of recursing when benchmarking
- regenerate golden benchmark for binary_step algorithm and refresh algorithms progress

## Testing
- `MOCHI_ALG_INDEX=721 go test ./transpiler/x/kt -run TestKTTranspiler_Algorithms_Golden -count=1 -timeout 120s -tags=slow -v`
- `MOCHI_ALG_INDEX=721 MOCHI_BENCHMARK=1 go test ./transpiler/x/kt -run TestKTTranspiler_Algorithms_Golden -update-algorithms-kt -count=1 -timeout 120s -tags=slow -v`


------
https://chatgpt.com/codex/tasks/task_e_689b032c42b08320847ab305872f80ee