### PR TITLE
Improve Kotlin transpiler type inference

### DIFF
--- a/tests/algorithms/x/Kotlin/neural_network/back_propagation_neural_network.error
+++ b/tests/algorithms/x/Kotlin/neural_network/back_propagation_neural_network.error
@@ -1,6 +1,4 @@
-run: exit status 1
-Exception in thread "main" java.lang.ClassCastException: class java.util.ArrayList cannot be cast to class Layer (java.util.ArrayList is in module java.base of loader 'bootstrap'; Layer is in unnamed module of loader 'app')
-	at Back_propagation_neural_networkKt.train(back_propagation_neural_network.kt:262)
-	at Back_propagation_neural_networkKt.user_main(back_propagation_neural_network.kt:292)
-	at Back_propagation_neural_networkKt.main(back_propagation_neural_network.kt:297)
-	at Back_propagation_neural_networkKt.main(back_propagation_neural_network.kt)
+kotlinc: exit status 1
+/workspace/mochi/tests/algorithms/x/Kotlin/neural_network/back_propagation_neural_network.kt:289:71: error: type mismatch: inferred type is Layer but MutableList<Double> was expected
+            var grad: MutableList<Double> = calc_gradient(ydata[i]!!, out)
+                                                                      ^

--- a/transpiler/x/kt/ALGORITHMS.md
+++ b/transpiler/x/kt/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Kotlin code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Kotlin`.
-Last updated: 2025-08-12 16:24 GMT+7
+Last updated: 2025-08-12 16:36 GMT+7
 
 ## Algorithms Golden Test Checklist (464/1077)
 | Index | Name | Status | Duration | Memory |

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -4144,6 +4144,11 @@ func convertStmts(env *types.Env, list []*parser.Statement) ([]Stmt, error) {
 						}
 					}
 				}
+				if typ != "" {
+					if gt := guessType(v); gt != "" && gt != typ {
+						typ = gt
+					}
+				}
 				if typ == "" || typ == "Any" || typ == "Any?" {
 					typ = guessType(v)
 					if typ == "" {


### PR DESCRIPTION
## Summary
- Refine Kotlin transpiler variable type inference to favor runtime type guesses when they conflict with static checks.
- Regenerate Kotlin algorithm artifacts for back_propagation_neural_network test case (still fails to compile).

## Testing
- `MOCHI_ALG_INDEX=732 MOCHI_BENCHMARK=1 go test ./transpiler/x/kt -run TestKTTranspiler_Algorithms_Golden -tags slow -count=1 -update-algorithms-kt` *(fails: kotlinc exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_689b090f7f088320ad20ef118fc35b32