### PR TITLE
chore: update clojure fibonacci golden

### DIFF
--- a/tests/algorithms/x/Clojure/dynamic_programming/fibonacci.bench
+++ b/tests/algorithms/x/Clojure/dynamic_programming/fibonacci.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 49564,
-  "memory_bytes": 20847216,
+  "duration_us": 46342,
+  "memory_bytes": 21152408,
   "name": "main"
 }

--- a/tests/algorithms/x/Clojure/dynamic_programming/fibonacci.clj
+++ b/tests/algorithms/x/Clojure/dynamic_programming/fibonacci.clj
@@ -17,6 +17,9 @@
 (defn toi [s]
   (Integer/parseInt (str s)))
 
+(defn _fetch [url]
+  {:data [{:from "" :intensity {:actual 0 :forecast 0 :index ""} :to ""}]})
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare create_fibonacci fib_get main)
@@ -39,10 +42,10 @@
   (try (throw (ex-info "return" {:v {:sequence [0 1]}})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
 
 (defn fib_get [fib_get_f_p fib_get_index]
-  (binding [fib_get_f nil fib_get_i nil fib_get_result nil fib_get_seq nil next_v nil] (try (do (set! fib_get_f fib_get_f_p) (set! fib_get_seq (:sequence fib_get_f)) (while (< (count fib_get_seq) fib_get_index) (do (set! next_v (+ (get fib_get_seq (- (count fib_get_seq) 1)) (get fib_get_seq (- (count fib_get_seq) 2)))) (set! fib_get_seq (conj fib_get_seq next_v)))) (set! fib_get_f (assoc fib_get_f :sequence fib_get_seq)) (set! fib_get_result []) (set! fib_get_i 0) (while (< fib_get_i fib_get_index) (do (set! fib_get_result (conj fib_get_result (get fib_get_seq fib_get_i))) (set! fib_get_i (+ fib_get_i 1)))) (throw (ex-info "return" {:v {:fib fib_get_f :values fib_get_result}}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
+  (binding [fib_get_f fib_get_f_p fib_get_i nil fib_get_result nil fib_get_seq nil next_v nil] (try (do (set! fib_get_seq (:sequence fib_get_f)) (while (< (count fib_get_seq) fib_get_index) (do (set! next_v (+ (get fib_get_seq (- (count fib_get_seq) 1)) (get fib_get_seq (- (count fib_get_seq) 2)))) (set! fib_get_seq (conj fib_get_seq next_v)))) (set! fib_get_f (assoc fib_get_f :sequence fib_get_seq)) (set! fib_get_result []) (set! fib_get_i 0) (while (< fib_get_i fib_get_index) (do (set! fib_get_result (conj fib_get_result (get fib_get_seq fib_get_i))) (set! fib_get_i (+ fib_get_i 1)))) (throw (ex-info "return" {:v {:fib fib_get_f :values fib_get_result}}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))) (finally (alter-var-root (var fib_get_f) (constantly fib_get_f))))))
 
 (defn main []
-  (binding [main_fib nil main_res nil] (do (set! main_fib (create_fibonacci)) (set! main_res (fib_get main_fib 10)) (set! main_fib (:fib main_res)) (println (str (:values main_res))) (set! main_res (fib_get main_fib 5)) (set! main_fib (:fib main_res)) (println (str (:values main_res))))))
+  (binding [main_fib nil main_res nil] (do (set! main_fib (create_fibonacci)) (set! main_res (let [__res (fib_get main_fib 10)] (do (set! main_fib fib_get_f) __res))) (set! main_fib (:fib main_res)) (println (str (:values main_res))) (set! main_res (let [__res (fib_get main_fib 5)] (do (set! main_fib fib_get_f) __res))) (set! main_fib (:fib main_res)) (println (str (:values main_res))))))
 
 (defn -main []
   (let [rt (Runtime/getRuntime)

--- a/transpiler/x/clj/ALGORITHMS.md
+++ b/transpiler/x/clj/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Clojure code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Clojure`.
-Last updated: 2025-08-12 16:14 GMT+7
+Last updated: 2025-08-13 07:22 GMT+7
 
 ## Algorithms Golden Test Checklist (777/1077)
 | Index | Name | Status | Duration | Memory |
@@ -316,7 +316,7 @@ Last updated: 2025-08-12 16:14 GMT+7
 | 307 | dynamic_programming/edit_distance | ✓ | 218.464ms | 23.53MB |
 | 308 | dynamic_programming/factorial | ✓ | 70.38ms | 19.61MB |
 | 309 | dynamic_programming/fast_fibonacci | ✓ | 50.072ms | 19.93MB |
-| 310 | dynamic_programming/fibonacci | ✓ | 49.564ms | 19.88MB |
+| 310 | dynamic_programming/fibonacci | ✓ | 46.342ms | 20.17MB |
 | 311 | dynamic_programming/fizz_buzz | ✓ | 38.468ms | 19.25MB |
 | 312 | dynamic_programming/floyd_warshall | ✓ | 38.745ms | 21.01MB |
 | 313 | dynamic_programming/integer_partition | ✓ | 150.758ms | 20.11MB |
@@ -727,13 +727,13 @@ Last updated: 2025-08-12 16:14 GMT+7
 | 718 | matrix/validate_sudoku_board | ✓ |  |  |
 | 719 | networking_flow/ford_fulkerson | ✓ |  |  |
 | 720 | networking_flow/minimum_cut | ✓ | 77.986ms | 23.97MB |
-| 721 | neural_network/activation_functions/binary_step | ✓ | 56.266ms | 19.60MB |
-| 722 | neural_network/activation_functions/exponential_linear_unit | ✓ | 59.878ms | 20.31MB |
-| 723 | neural_network/activation_functions/gaussian_error_linear_unit | ✓ | 57.246ms | 20.68MB |
-| 724 | neural_network/activation_functions/leaky_rectified_linear_unit | ✓ | 56.105ms | 19.66MB |
-| 725 | neural_network/activation_functions/mish | ✓ | 59.528ms | 22.64MB |
-| 726 | neural_network/activation_functions/rectified_linear_unit | ✓ | 53.13ms | 19.16MB |
-| 727 | neural_network/activation_functions/scaled_exponential_linear_unit | ✓ | 50.86ms | 20.04MB |
+| 721 | neural_network/activation_functions/binary_step | ✓ | 56.957ms | 19.85MB |
+| 722 | neural_network/activation_functions/exponential_linear_unit | ✓ | 63.032ms | 20.59MB |
+| 723 | neural_network/activation_functions/gaussian_error_linear_unit | ✓ | 65.63ms | 21.07MB |
+| 724 | neural_network/activation_functions/leaky_rectified_linear_unit | ✓ | 60.744ms | 20.13MB |
+| 725 | neural_network/activation_functions/mish | ✓ | 69.572ms | 22.70MB |
+| 726 | neural_network/activation_functions/rectified_linear_unit | ✓ | 59.032ms | 19.75MB |
+| 727 | neural_network/activation_functions/scaled_exponential_linear_unit | ✓ | 59.685ms | 20.34MB |
 | 728 | neural_network/activation_functions/soboleva_modified_hyperbolic_tangent | ✓ | 46.468ms | 20.92MB |
 | 729 | neural_network/activation_functions/softplus | error |  |  |
 | 730 | neural_network/activation_functions/squareplus | ✓ | 60.457ms | 20.71MB |


### PR DESCRIPTION
## Summary
- regenerate Clojure code/bench for Fibonacci algorithm
- refresh Clojure transpiler algorithms progress

## Testing
- `MOCHI_ALG_INDEX=310 go test ./transpiler/x/clj -tags slow -run TestClojureTranspiler_Algorithms_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_689bda24a69c8320abd3dfaf616712da