### PR TITLE
php: avoid builtin collisions and refresh algorithm outputs

### DIFF
--- a/tests/algorithms/x/PHP/dynamic_programming/subset_generation.bench
+++ b/tests/algorithms/x/PHP/dynamic_programming/subset_generation.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 133,
+  "duration_us": 101,
   "memory_bytes": 40712,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/dynamic_programming/sum_of_subset.bench
+++ b/tests/algorithms/x/PHP/dynamic_programming/sum_of_subset.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 148,
+  "duration_us": 90,
   "memory_bytes": 39232,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/dynamic_programming/sum_of_subset.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/sum_of_subset.php
@@ -1,10 +1,27 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function create_bool_matrix($rows, $cols) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function create_bool_matrix($rows, $cols) {
   $matrix = [];
   $i = 0;
   while ($i <= $rows) {
@@ -18,8 +35,8 @@ function create_bool_matrix($rows, $cols) {
   $i = $i + 1;
 };
   return $matrix;
-}
-function is_sum_subset($arr, $required_sum) {
+};
+  function is_sum_subset($arr, $required_sum) {
   $arr_len = count($arr);
   $subset = create_bool_matrix($arr_len, $required_sum);
   $i = 0;
@@ -47,6 +64,14 @@ function is_sum_subset($arr, $required_sum) {
   $i = $i + 1;
 };
   return $subset[$arr_len][$required_sum];
-}
-echo rtrim(json_encode(is_sum_subset([2, 4, 6, 8], 5), 1344)), PHP_EOL;
-echo rtrim(json_encode(is_sum_subset([2, 4, 6, 8], 14), 1344)), PHP_EOL;
+};
+  echo rtrim(json_encode(is_sum_subset([2, 4, 6, 8], 5), 1344)), PHP_EOL;
+  echo rtrim(json_encode(is_sum_subset([2, 4, 6, 8], 14), 1344)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/dynamic_programming/trapped_water.bench
+++ b/tests/algorithms/x/PHP/dynamic_programming/trapped_water.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 98,
-  "memory_bytes": 40808,
+  "duration_us": 81,
+  "memory_bytes": 40936,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/dynamic_programming/trapped_water.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/trapped_water.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,7 +35,13 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function make_list($len, $value) {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function make_list($len, $value) {
   $arr = [];
   $i = 0;
   while ($i < $len) {
@@ -28,15 +49,15 @@ function make_list($len, $value) {
   $i = $i + 1;
 };
   return $arr;
-}
-function trapped_rainwater($heights) {
+};
+  function trapped_rainwater($heights) {
   if (count($heights) == 0) {
   return 0;
 }
   $i = 0;
   while ($i < count($heights)) {
   if ($heights[$i] < 0) {
-  $panic('No height can be negative');
+  _panic('No height can be negative');
 }
   $i = $i + 1;
 };
@@ -74,6 +95,14 @@ function trapped_rainwater($heights) {
   $i = $i + 1;
 };
   return $total;
-}
-echo rtrim(_str(trapped_rainwater([0, 1, 0, 2, 1, 0, 1, 3, 2, 1, 2, 1]))), PHP_EOL;
-echo rtrim(_str(trapped_rainwater([7, 1, 5, 3, 6, 4]))), PHP_EOL;
+};
+  echo rtrim(_str(trapped_rainwater([0, 1, 0, 2, 1, 0, 1, 3, 2, 1, 2, 1]))), PHP_EOL;
+  echo rtrim(_str(trapped_rainwater([7, 1, 5, 3, 6, 4]))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/dynamic_programming/tribonacci.bench
+++ b/tests/algorithms/x/PHP/dynamic_programming/tribonacci.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 69,
-  "memory_bytes": 39312,
+  "duration_us": 88,
+  "memory_bytes": 40320,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/dynamic_programming/tribonacci.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/tribonacci.php
@@ -1,10 +1,27 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function tribonacci($num) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function tribonacci($num) {
   $dp = [];
   $i = 0;
   while ($i < $num) {
@@ -21,5 +38,13 @@ function tribonacci($num) {
   $i = $i + 1;
 };
   return $dp;
-}
-echo rtrim(str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(tribonacci(8), 1344))))))), PHP_EOL;
+};
+  echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(tribonacci(8), 1344)))))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/dynamic_programming/viterbi.bench
+++ b/tests/algorithms/x/PHP/dynamic_programming/viterbi.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 111,
-  "memory_bytes": 40720,
+  "duration_us": 133,
+  "memory_bytes": 40848,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/dynamic_programming/wildcard_matching.bench
+++ b/tests/algorithms/x/PHP/dynamic_programming/wildcard_matching.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 129,
+  "duration_us": 170,
   "memory_bytes": 40896,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/dynamic_programming/wildcard_matching.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/wildcard_matching.php
@@ -1,10 +1,27 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function make_bool_list($n) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function make_bool_list($n) {
   $row = [];
   $i = 0;
   while ($i < $n) {
@@ -12,8 +29,8 @@ function make_bool_list($n) {
   $i = $i + 1;
 };
   return $row;
-}
-function make_bool_matrix($rows, $cols) {
+};
+  function make_bool_matrix($rows, $cols) {
   $matrix = [];
   $i = 0;
   while ($i < $rows) {
@@ -21,8 +38,8 @@ function make_bool_matrix($rows, $cols) {
   $i = $i + 1;
 };
   return $matrix;
-}
-function is_match($s, $p) {
+};
+  function is_match($s, $p) {
   $n = strlen($s);
   $m = strlen($p);
   $dp = make_bool_matrix($n + 1, $m + 1);
@@ -54,14 +71,22 @@ function is_match($s, $p) {
   $i = $i + 1;
 };
   return $dp[$n][$m];
-}
-function print_bool($b) {
+};
+  function print_bool($b) {
   if ($b) {
   echo rtrim((true ? 'true' : 'false')), PHP_EOL;
 } else {
   echo rtrim((false ? 'true' : 'false')), PHP_EOL;
 }
-}
-print_bool(is_match('abc', 'a*c'));
-print_bool(is_match('abc', 'a*d'));
-print_bool(is_match('baaabab', '*****ba*****ab'));
+};
+  print_bool(is_match('abc', 'a*c'));
+  print_bool(is_match('abc', 'a*d'));
+  print_bool(is_match('baaabab', '*****ba*****ab'));
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/dynamic_programming/word_break.bench
+++ b/tests/algorithms/x/PHP/dynamic_programming/word_break.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 147,
+  "duration_us": 106,
   "memory_bytes": 40712,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/electronics/apparent_power.php
+++ b/tests/algorithms/x/PHP/electronics/apparent_power.php
@@ -1,18 +1,35 @@
 <?php
 ini_set('memory_limit', '-1');
-$PI = 3.141592653589793;
-function mochi_abs($x) {
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $PI = 3.141592653589793;
+  function mochi_abs($x) {
   global $PI;
   if ($x < 0.0) {
   return -$x;
 }
   return $x;
-}
-function to_radians($deg) {
+};
+  function to_radians($deg) {
   global $PI;
   return $deg * $PI / 180.0;
-}
-function sin_taylor($x) {
+};
+  function sin_taylor($x) {
   global $PI;
   $term = $x;
   $sum = $x;
@@ -25,8 +42,8 @@ function sin_taylor($x) {
   $i = $i + 1;
 };
   return $sum;
-}
-function cos_taylor($x) {
+};
+  function cos_taylor($x) {
   global $PI;
   $term = 1.0;
   $sum = 1.0;
@@ -39,18 +56,18 @@ function cos_taylor($x) {
   $i = $i + 1;
 };
   return $sum;
-}
-function rect($mag, $angle) {
+};
+  function rect($mag, $angle) {
   global $PI;
   $c = cos_taylor($angle);
   $s = sin_taylor($angle);
   return [$mag * $c, $mag * $s];
-}
-function multiply($a, $b) {
+};
+  function multiply($a, $b) {
   global $PI;
   return [$a[0] * $b[0] - $a[1] * $b[1], $a[0] * $b[1] + $a[1] * $b[0]];
-}
-function apparent_power($voltage, $current, $voltage_angle, $current_angle) {
+};
+  function apparent_power($voltage, $current, $voltage_angle, $current_angle) {
   global $PI;
   $vrad = to_radians($voltage_angle);
   $irad = to_radians($current_angle);
@@ -58,8 +75,16 @@ function apparent_power($voltage, $current, $voltage_angle, $current_angle) {
   $irect = rect($current, $irad);
   $result = multiply($vrect, $irect);
   return $result;
-}
-function approx_equal($a, $b, $eps) {
+};
+  function approx_equal($a, $b, $eps) {
   global $PI;
   return mochi_abs($a[0] - $b[0]) < $eps && mochi_abs($a[1] - $b[1]) < $eps;
-}
+};
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/builtin_voltage.bench
+++ b/tests/algorithms/x/PHP/electronics/builtin_voltage.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 61,
-  "memory_bytes": 40104,
+  "duration_us": 68,
+  "memory_bytes": 40360,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/electronics/builtin_voltage.php
+++ b/tests/algorithms/x/PHP/electronics/builtin_voltage.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,7 +31,13 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-function pow10($n) {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function pow10($n) {
   global $BOLTZMANN, $ELECTRON_VOLT, $TEMPERATURE;
   $result = 1.0;
   $i = 0;
@@ -25,11 +46,11 @@ function pow10($n) {
   $i = $i + 1;
 };
   return $result;
-}
-$BOLTZMANN = 1.380649 / pow10(23);
-$ELECTRON_VOLT = 1.602176634 / pow10(19);
-$TEMPERATURE = 300.0;
-function ln_series($x) {
+};
+  $BOLTZMANN = 1.380649 / pow10(23);
+  $ELECTRON_VOLT = 1.602176634 / pow10(19);
+  $TEMPERATURE = 300.0;
+  function ln_series($x) {
   global $BOLTZMANN, $ELECTRON_VOLT, $TEMPERATURE;
   $t = ($x - 1.0) / ($x + 1.0);
   $term = $t;
@@ -41,8 +62,8 @@ function ln_series($x) {
   $n = $n + 2;
 };
   return 2.0 * $sum;
-}
-function ln($x) {
+};
+  function ln($x) {
   global $BOLTZMANN, $ELECTRON_VOLT, $TEMPERATURE;
   $y = $x;
   $k = 0;
@@ -55,24 +76,32 @@ function ln($x) {
   $k = $k - 1;
 };
   return ln_series($y) + (floatval($k)) * ln_series(10.0);
-}
-function builtin_voltage($donor_conc, $acceptor_conc, $intrinsic_conc) {
+};
+  function builtin_voltage($donor_conc, $acceptor_conc, $intrinsic_conc) {
   global $BOLTZMANN, $ELECTRON_VOLT, $TEMPERATURE;
   if ($donor_conc <= 0.0) {
-  $panic('Donor concentration should be positive');
+  _panic('Donor concentration should be positive');
 }
   if ($acceptor_conc <= 0.0) {
-  $panic('Acceptor concentration should be positive');
+  _panic('Acceptor concentration should be positive');
 }
   if ($intrinsic_conc <= 0.0) {
-  $panic('Intrinsic concentration should be positive');
+  _panic('Intrinsic concentration should be positive');
 }
   if ($donor_conc <= $intrinsic_conc) {
-  $panic('Donor concentration should be greater than intrinsic concentration');
+  _panic('Donor concentration should be greater than intrinsic concentration');
 }
   if ($acceptor_conc <= $intrinsic_conc) {
-  $panic('Acceptor concentration should be greater than intrinsic concentration');
+  _panic('Acceptor concentration should be greater than intrinsic concentration');
 }
   return $BOLTZMANN * $TEMPERATURE * ln(($donor_conc * $acceptor_conc) / ($intrinsic_conc * $intrinsic_conc)) / $ELECTRON_VOLT;
-}
-echo rtrim(_str(builtin_voltage(pow10(17), pow10(17), pow10(10)))), PHP_EOL;
+};
+  echo rtrim(_str(builtin_voltage(pow10(17), pow10(17), pow10(10)))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/capacitor_equivalence.bench
+++ b/tests/algorithms/x/PHP/electronics/capacitor_equivalence.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 82,
-  "memory_bytes": 37176,
+  "duration_us": 48,
+  "memory_bytes": 37336,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/electronics/capacitor_equivalence.php
+++ b/tests/algorithms/x/PHP/electronics/capacitor_equivalence.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,38 +31,52 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-function capacitor_parallel($capacitors) {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function capacitor_parallel($capacitors) {
   $sum_c = 0.0;
   $i = 0;
   while ($i < count($capacitors)) {
   $c = $capacitors[$i];
   if ($c < 0.0) {
-  $panic('Capacitor at index ' . _str($i) . ' has a negative value!');
+  _panic('Capacitor at index ' . _str($i) . ' has a negative value!');
   return 0.0;
 }
   $sum_c = $sum_c + $c;
   $i = $i + 1;
 };
   return $sum_c;
-}
-function capacitor_series($capacitors) {
+};
+  function capacitor_series($capacitors) {
   $first_sum = 0.0;
   $i = 0;
   while ($i < count($capacitors)) {
   $c = $capacitors[$i];
   if ($c <= 0.0) {
-  $panic('Capacitor at index ' . _str($i) . ' has a negative or zero value!');
+  _panic('Capacitor at index ' . _str($i) . ' has a negative or zero value!');
   return 0.0;
 }
   $first_sum = $first_sum + 1.0 / $c;
   $i = $i + 1;
 };
   return 1.0 / $first_sum;
-}
-function main() {
+};
+  function main() {
   $parallel = capacitor_parallel([5.71389, 12.0, 3.0]);
   $series = capacitor_series([5.71389, 12.0, 3.0]);
   echo rtrim(_str($parallel)), PHP_EOL;
   echo rtrim(_str($series)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/carrier_concentration.bench
+++ b/tests/algorithms/x/PHP/electronics/carrier_concentration.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 111,
-  "memory_bytes": 36680,
+  "duration_us": 74,
+  "memory_bytes": 36904,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/electronics/carrier_concentration.php
+++ b/tests/algorithms/x/PHP/electronics/carrier_concentration.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,7 +31,13 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-function sqrtApprox($x) {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function sqrtApprox($x) {
   global $r1, $r2, $r3;
   $guess = $x / 2.0;
   $i = 0;
@@ -25,8 +46,8 @@ function sqrtApprox($x) {
   $i = $i + 1;
 };
   return $guess;
-}
-function carrier_concentration($electron_conc, $hole_conc, $intrinsic_conc) {
+};
+  function carrier_concentration($electron_conc, $hole_conc, $intrinsic_conc) {
   global $r1, $r2, $r3;
   $zero_count = 0;
   if ($electron_conc == 0.0) {
@@ -39,16 +60,16 @@ function carrier_concentration($electron_conc, $hole_conc, $intrinsic_conc) {
   $zero_count = $zero_count + 1;
 }
   if ($zero_count != 1) {
-  $panic('You cannot supply more or less than 2 values');
+  _panic('You cannot supply more or less than 2 values');
 }
   if ($electron_conc < 0.0) {
-  $panic('Electron concentration cannot be negative in a semiconductor');
+  _panic('Electron concentration cannot be negative in a semiconductor');
 }
   if ($hole_conc < 0.0) {
-  $panic('Hole concentration cannot be negative in a semiconductor');
+  _panic('Hole concentration cannot be negative in a semiconductor');
 }
   if ($intrinsic_conc < 0.0) {
-  $panic('Intrinsic concentration cannot be negative in a semiconductor');
+  _panic('Intrinsic concentration cannot be negative in a semiconductor');
 }
   if ($electron_conc == 0.0) {
   return ['name' => 'electron_conc', 'value' => ($intrinsic_conc * $intrinsic_conc) / $hole_conc];
@@ -60,10 +81,18 @@ function carrier_concentration($electron_conc, $hole_conc, $intrinsic_conc) {
   return ['name' => 'intrinsic_conc', 'value' => sqrtApprox($electron_conc * $hole_conc)];
 }
   return ['name' => '', 'value' => -1.0];
-}
-$r1 = carrier_concentration(25.0, 100.0, 0.0);
-echo rtrim($r1['name'] . ', ' . _str($r1['value'])), PHP_EOL;
-$r2 = carrier_concentration(0.0, 1600.0, 200.0);
-echo rtrim($r2['name'] . ', ' . _str($r2['value'])), PHP_EOL;
-$r3 = carrier_concentration(1000.0, 0.0, 1200.0);
-echo rtrim($r3['name'] . ', ' . _str($r3['value'])), PHP_EOL;
+};
+  $r1 = carrier_concentration(25.0, 100.0, 0.0);
+  echo rtrim($r1['name'] . ', ' . _str($r1['value'])), PHP_EOL;
+  $r2 = carrier_concentration(0.0, 1600.0, 200.0);
+  echo rtrim($r2['name'] . ', ' . _str($r2['value'])), PHP_EOL;
+  $r3 = carrier_concentration(1000.0, 0.0, 1200.0);
+  echo rtrim($r3['name'] . ', ' . _str($r3['value'])), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/charging_capacitor.bench
+++ b/tests/algorithms/x/PHP/electronics/charging_capacitor.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 76,
-  "memory_bytes": 35928,
+  "duration_us": 56,
+  "memory_bytes": 36120,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/electronics/charging_capacitor.php
+++ b/tests/algorithms/x/PHP/electronics/charging_capacitor.php
@@ -1,6 +1,27 @@
 <?php
 ini_set('memory_limit', '-1');
-function expApprox($x) {
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function expApprox($x) {
   $y = $x;
   $is_neg = false;
   if ($x < 0.0) {
@@ -19,8 +40,8 @@ function expApprox($x) {
   return 1.0 / $sum;
 }
   return $sum;
-}
-function round3($x) {
+};
+  function round3($x) {
   $scaled = $x * 1000.0;
   if ($scaled >= 0.0) {
   $scaled = $scaled + 0.5;
@@ -29,22 +50,30 @@ function round3($x) {
 }
   $scaled_int = intval($scaled);
   return (floatval($scaled_int)) / 1000.0;
-}
-function charging_capacitor($source_voltage, $resistance, $capacitance, $time_sec) {
+};
+  function charging_capacitor($source_voltage, $resistance, $capacitance, $time_sec) {
   if ($source_voltage <= 0.0) {
-  $panic('Source voltage must be positive.');
+  _panic('Source voltage must be positive.');
 }
   if ($resistance <= 0.0) {
-  $panic('Resistance must be positive.');
+  _panic('Resistance must be positive.');
 }
   if ($capacitance <= 0.0) {
-  $panic('Capacitance must be positive.');
+  _panic('Capacitance must be positive.');
 }
   $exponent = -$time_sec / ($resistance * $capacitance);
   $voltage = $source_voltage * (1.0 - expApprox($exponent));
   return round3($voltage);
-}
-echo rtrim(json_encode(charging_capacitor(0.2, 0.9, 8.4, 0.5), 1344)), PHP_EOL;
-echo rtrim(json_encode(charging_capacitor(2.2, 3.5, 2.4, 9.0), 1344)), PHP_EOL;
-echo rtrim(json_encode(charging_capacitor(15.0, 200.0, 20.0, 2.0), 1344)), PHP_EOL;
-echo rtrim(json_encode(charging_capacitor(20.0, 2000.0, 0.0003, 4.0), 1344)), PHP_EOL;
+};
+  echo rtrim(json_encode(charging_capacitor(0.2, 0.9, 8.4, 0.5), 1344)), PHP_EOL;
+  echo rtrim(json_encode(charging_capacitor(2.2, 3.5, 2.4, 9.0), 1344)), PHP_EOL;
+  echo rtrim(json_encode(charging_capacitor(15.0, 200.0, 20.0, 2.0), 1344)), PHP_EOL;
+  echo rtrim(json_encode(charging_capacitor(20.0, 2000.0, 0.0003, 4.0), 1344)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/charging_inductor.bench
+++ b/tests/algorithms/x/PHP/electronics/charging_inductor.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 111,
-  "memory_bytes": 35864,
+  "duration_us": 71,
+  "memory_bytes": 40120,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/electronics/charging_inductor.php
+++ b/tests/algorithms/x/PHP/electronics/charging_inductor.php
@@ -1,6 +1,27 @@
 <?php
 ini_set('memory_limit', '-1');
-function expApprox($x) {
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function expApprox($x) {
   if ($x < 0.0) {
   return 1.0 / expApprox(-$x);
 }
@@ -17,15 +38,15 @@ function expApprox($x) {
   $n = $n + 1;
 };
   return $sum;
-}
-function mochi_floor($x) {
+};
+  function mochi_floor($x) {
   $i = intval($x);
   if ((floatval($i)) > $x) {
   $i = $i - 1;
 }
   return floatval($i);
-}
-function pow10($n) {
+};
+  function pow10($n) {
   $result = 1.0;
   $i = 0;
   while ($i < $n) {
@@ -33,25 +54,33 @@ function pow10($n) {
   $i = $i + 1;
 };
   return $result;
-}
-function mochi_round($x, $n) {
+};
+  function mochi_round($x, $n) {
   $m = pow10($n);
   return mochi_floor($x * $m + 0.5) / $m;
-}
-function charging_inductor($source_voltage, $resistance, $inductance, $time) {
+};
+  function charging_inductor($source_voltage, $resistance, $inductance, $time) {
   if ($source_voltage <= 0.0) {
-  $panic('Source voltage must be positive.');
+  _panic('Source voltage must be positive.');
 }
   if ($resistance <= 0.0) {
-  $panic('Resistance must be positive.');
+  _panic('Resistance must be positive.');
 }
   if ($inductance <= 0.0) {
-  $panic('Inductance must be positive.');
+  _panic('Inductance must be positive.');
 }
   $exponent = (-$time * $resistance) / $inductance;
   $current = $source_voltage / $resistance * (1.0 - expApprox($exponent));
   return mochi_round($current, 3);
-}
-echo rtrim(json_encode(charging_inductor(5.8, 1.5, 2.3, 2.0), 1344)), PHP_EOL;
-echo rtrim(json_encode(charging_inductor(8.0, 5.0, 3.0, 2.0), 1344)), PHP_EOL;
-echo rtrim(json_encode(charging_inductor(8.0, 5.0 * pow10(2), 3.0, 2.0), 1344)), PHP_EOL;
+};
+  echo rtrim(json_encode(charging_inductor(5.8, 1.5, 2.3, 2.0), 1344)), PHP_EOL;
+  echo rtrim(json_encode(charging_inductor(8.0, 5.0, 3.0, 2.0), 1344)), PHP_EOL;
+  echo rtrim(json_encode(charging_inductor(8.0, 500.0, 3.0, 2.0), 1344)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/circular_convolution.bench
+++ b/tests/algorithms/x/PHP/electronics/circular_convolution.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 266,
+  "duration_us": 117,
   "memory_bytes": 36264,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/electronics/circular_convolution.php
+++ b/tests/algorithms/x/PHP/electronics/circular_convolution.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,15 +35,17 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function mochi_floor($x) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function mochi_floor($x) {
   global $example1, $example2, $example3, $example4;
   $i = intval($x);
   if ((floatval($i)) > $x) {
   $i = $i - 1;
 }
   return floatval($i);
-}
-function pow10($n) {
+};
+  function pow10($n) {
   global $example1, $example2, $example3, $example4;
   $p = 1.0;
   $i = 0;
@@ -37,21 +54,21 @@ function pow10($n) {
   $i = $i + 1;
 };
   return $p;
-}
-function roundn($x, $n) {
+};
+  function roundn($x, $n) {
   global $example1, $example2, $example3, $example4;
   $m = pow10($n);
   return mochi_floor($x * $m + 0.5) / $m;
-}
-function pad($signal, $target) {
+};
+  function pad($signal, $target) {
   global $example1, $example2, $example3, $example4;
   $s = $signal;
   while (count($s) < $target) {
   $s = _append($s, 0.0);
 };
   return $s;
-}
-function circular_convolution($a, $b) {
+};
+  function circular_convolution($a, $b) {
   global $example1, $example2, $example3, $example4;
   $n1 = count($a);
   $n2 = count($b);
@@ -73,12 +90,20 @@ function circular_convolution($a, $b) {
   $i = $i + 1;
 };
   return $res;
-}
-$example1 = circular_convolution([2.0, 1.0, 2.0, -1.0], [1.0, 2.0, 3.0, 4.0]);
-echo rtrim(_str($example1)), PHP_EOL;
-$example2 = circular_convolution([0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6], [0.1, 0.3, 0.5, 0.7, 0.9, 1.1, 1.3, 1.5]);
-echo rtrim(_str($example2)), PHP_EOL;
-$example3 = circular_convolution([-1.0, 1.0, 2.0, -2.0], [0.5, 1.0, -1.0, 2.0, 0.75]);
-echo rtrim(_str($example3)), PHP_EOL;
-$example4 = circular_convolution([1.0, -1.0, 2.0, 3.0, -1.0], [1.0, 2.0, 3.0]);
-echo rtrim(_str($example4)), PHP_EOL;
+};
+  $example1 = circular_convolution([2.0, 1.0, 2.0, -1.0], [1.0, 2.0, 3.0, 4.0]);
+  echo rtrim(_str($example1)), PHP_EOL;
+  $example2 = circular_convolution([0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6], [0.1, 0.3, 0.5, 0.7, 0.9, 1.1, 1.3, 1.5]);
+  echo rtrim(_str($example2)), PHP_EOL;
+  $example3 = circular_convolution([-1.0, 1.0, 2.0, -2.0], [0.5, 1.0, -1.0, 2.0, 0.75]);
+  echo rtrim(_str($example3)), PHP_EOL;
+  $example4 = circular_convolution([1.0, -1.0, 2.0, 3.0, -1.0], [1.0, 2.0, 3.0]);
+  echo rtrim(_str($example4)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/coulombs_law.bench
+++ b/tests/algorithms/x/PHP/electronics/coulombs_law.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 168,
-  "memory_bytes": 40144,
+  "duration_us": 94,
+  "memory_bytes": 40304,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/electronics/coulombs_law.php
+++ b/tests/algorithms/x/PHP/electronics/coulombs_law.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,15 +31,21 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-$COULOMBS_CONSTANT = 8988000000.0;
-function mochi_abs($x) {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $COULOMBS_CONSTANT = 8988000000.0;
+  function mochi_abs($x) {
   global $COULOMBS_CONSTANT;
   if ($x < 0.0) {
   return -$x;
 }
   return $x;
-}
-function sqrtApprox($x) {
+};
+  function sqrtApprox($x) {
   global $COULOMBS_CONSTANT;
   if ($x <= 0.0) {
   return 0.0;
@@ -36,8 +57,8 @@ function sqrtApprox($x) {
   $i = $i + 1;
 };
   return $guess;
-}
-function coulombs_law($force, $charge1, $charge2, $distance) {
+};
+  function coulombs_law($force, $charge1, $charge2, $distance) {
   global $COULOMBS_CONSTANT;
   $charge_product = mochi_abs($charge1 * $charge2);
   $zero_count = 0;
@@ -54,10 +75,10 @@ function coulombs_law($force, $charge1, $charge2, $distance) {
   $zero_count = $zero_count + 1;
 }
   if ($zero_count != 1) {
-  $panic('One and only one argument must be 0');
+  _panic('One and only one argument must be 0');
 }
   if ($distance < 0.0) {
-  $panic('Distance cannot be negative');
+  _panic('Distance cannot be negative');
 }
   if ($force == 0.0) {
   $f = $COULOMBS_CONSTANT * $charge_product / ($distance * $distance);
@@ -73,13 +94,21 @@ function coulombs_law($force, $charge1, $charge2, $distance) {
 }
   $d = sqrtApprox($COULOMBS_CONSTANT * $charge_product / mochi_abs($force));
   return ['distance' => $d];
-}
-function print_map($m) {
+};
+  function print_map($m) {
   global $COULOMBS_CONSTANT;
   foreach (array_keys($m) as $k) {
   echo rtrim('{"' . $k . '": ' . _str($m[$k]) . '}'), PHP_EOL;
 };
-}
-print_map(coulombs_law(0.0, 3.0, 5.0, 2000.0));
-print_map(coulombs_law(10.0, 3.0, 5.0, 0.0));
-print_map(coulombs_law(10.0, 0.0, 5.0, 2000.0));
+};
+  print_map(coulombs_law(0.0, 3.0, 5.0, 2000.0));
+  print_map(coulombs_law(10.0, 3.0, 5.0, 0.0));
+  print_map(coulombs_law(10.0, 0.0, 5.0, 2000.0));
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/electric_conductivity.bench
+++ b/tests/algorithms/x/PHP/electronics/electric_conductivity.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 189,
-  "memory_bytes": 36448,
+  "duration_us": 63,
+  "memory_bytes": 36672,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/electronics/electric_conductivity.php
+++ b/tests/algorithms/x/PHP/electronics/electric_conductivity.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,8 +31,14 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-$ELECTRON_CHARGE = 0.00000000000000000016021;
-function electric_conductivity($conductivity, $electron_conc, $mobility) {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $ELECTRON_CHARGE = 0.00000000000000000016021;
+  function electric_conductivity($conductivity, $electron_conc, $mobility) {
   global $ELECTRON_CHARGE, $r1, $r2, $r3;
   $zero_count = 0;
   if ($conductivity == 0.0) {
@@ -30,16 +51,16 @@ function electric_conductivity($conductivity, $electron_conc, $mobility) {
   $zero_count = $zero_count + 1;
 }
   if ($zero_count != 1) {
-  $panic('You cannot supply more or less than 2 values');
+  _panic('You cannot supply more or less than 2 values');
 }
   if ($conductivity < 0.0) {
-  $panic('Conductivity cannot be negative');
+  _panic('Conductivity cannot be negative');
 }
   if ($electron_conc < 0.0) {
-  $panic('Electron concentration cannot be negative');
+  _panic('Electron concentration cannot be negative');
 }
   if ($mobility < 0.0) {
-  $panic('mobility cannot be negative');
+  _panic('mobility cannot be negative');
 }
   if ($conductivity == 0.0) {
   return ['kind' => 'conductivity', 'value' => $mobility * $electron_conc * $ELECTRON_CHARGE];
@@ -48,10 +69,18 @@ function electric_conductivity($conductivity, $electron_conc, $mobility) {
   return ['kind' => 'electron_conc', 'value' => $conductivity / ($mobility * $ELECTRON_CHARGE)];
 }
   return ['kind' => 'mobility', 'value' => $conductivity / ($electron_conc * $ELECTRON_CHARGE)];
-}
-$r1 = electric_conductivity(25.0, 100.0, 0.0);
-$r2 = electric_conductivity(0.0, 1600.0, 200.0);
-$r3 = electric_conductivity(1000.0, 0.0, 1200.0);
-echo rtrim($r1['kind'] . ' ' . _str($r1['value'])), PHP_EOL;
-echo rtrim($r2['kind'] . ' ' . _str($r2['value'])), PHP_EOL;
-echo rtrim($r3['kind'] . ' ' . _str($r3['value'])), PHP_EOL;
+};
+  $r1 = electric_conductivity(25.0, 100.0, 0.0);
+  $r2 = electric_conductivity(0.0, 1600.0, 200.0);
+  $r3 = electric_conductivity(1000.0, 0.0, 1200.0);
+  echo rtrim($r1['kind'] . ' ' . _str($r1['value'])), PHP_EOL;
+  echo rtrim($r2['kind'] . ' ' . _str($r2['value'])), PHP_EOL;
+  echo rtrim($r3['kind'] . ' ' . _str($r3['value'])), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/electric_power.bench
+++ b/tests/algorithms/x/PHP/electronics/electric_power.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 77,
+  "duration_us": 106,
   "memory_bytes": 37064,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/electronics/electric_power.php
+++ b/tests/algorithms/x/PHP/electronics/electric_power.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,14 +35,16 @@ function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-function absf($x) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function absf($x) {
   global $r1, $r2, $r3, $r4, $r5;
   if ($x < 0.0) {
   return -$x;
 }
   return $x;
-}
-function pow10($n) {
+};
+  function pow10($n) {
   global $r1, $r2, $r3, $r4, $r5;
   $p = 1.0;
   $i = 0;
@@ -36,13 +53,13 @@ function pow10($n) {
   $i = $i + 1;
 };
   return $p;
-}
-function round_to($x, $n) {
+};
+  function round_to($x, $n) {
   global $r1, $r2, $r3, $r4, $r5;
   $m = pow10($n);
   return floor($x * $m + 0.5) / $m;
-}
-function electric_power($voltage, $current, $power) {
+};
+  function electric_power($voltage, $current, $power) {
   global $r1, $r2, $r3, $r4, $r5;
   $zeros = 0;
   if ($voltage == 0.0) {
@@ -76,18 +93,26 @@ function electric_power($voltage, $current, $power) {
 };
 };
 }
-}
-function str_result($r) {
+};
+  function str_result($r) {
   global $r1, $r2, $r3, $r4, $r5;
   return 'Result(name=\'' . $r['name'] . '\', value=' . _str($r['value']) . ')';
-}
-$r1 = electric_power(0.0, 2.0, 5.0);
-echo rtrim(str_result($r1)), PHP_EOL;
-$r2 = electric_power(2.0, 2.0, 0.0);
-echo rtrim(str_result($r2)), PHP_EOL;
-$r3 = electric_power(-2.0, 3.0, 0.0);
-echo rtrim(str_result($r3)), PHP_EOL;
-$r4 = electric_power(2.2, 2.2, 0.0);
-echo rtrim(str_result($r4)), PHP_EOL;
-$r5 = electric_power(2.0, 0.0, 6.0);
-echo rtrim(str_result($r5)), PHP_EOL;
+};
+  $r1 = electric_power(0.0, 2.0, 5.0);
+  echo rtrim(str_result($r1)), PHP_EOL;
+  $r2 = electric_power(2.0, 2.0, 0.0);
+  echo rtrim(str_result($r2)), PHP_EOL;
+  $r3 = electric_power(-2.0, 3.0, 0.0);
+  echo rtrim(str_result($r3)), PHP_EOL;
+  $r4 = electric_power(2.2, 2.2, 0.0);
+  echo rtrim(str_result($r4)), PHP_EOL;
+  $r5 = electric_power(2.0, 0.0, 6.0);
+  echo rtrim(str_result($r5)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/electrical_impedance.bench
+++ b/tests/algorithms/x/PHP/electronics/electrical_impedance.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 144,
-  "memory_bytes": 37216,
+  "duration_us": 67,
+  "memory_bytes": 37152,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/electronics/electrical_impedance.php
+++ b/tests/algorithms/x/PHP/electronics/electrical_impedance.php
@@ -1,6 +1,27 @@
 <?php
 ini_set('memory_limit', '-1');
-function sqrtApprox($x) {
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function sqrtApprox($x) {
   if ($x <= 0.0) {
   return 0.0;
 }
@@ -11,8 +32,8 @@ function sqrtApprox($x) {
   $i = $i + 1;
 };
   return $guess;
-}
-function electrical_impedance($resistance, $reactance, $impedance) {
+};
+  function electrical_impedance($resistance, $reactance, $impedance) {
   $zero_count = 0;
   if ($resistance == 0.0) {
   $zero_count = $zero_count + 1;
@@ -24,7 +45,7 @@ function electrical_impedance($resistance, $reactance, $impedance) {
   $zero_count = $zero_count + 1;
 }
   if ($zero_count != 1) {
-  $panic('One and only one argument must be 0');
+  _panic('One and only one argument must be 0');
 }
   if ($resistance == 0.0) {
   $value = sqrtApprox($impedance * $impedance - $reactance * $reactance);
@@ -38,11 +59,19 @@ function electrical_impedance($resistance, $reactance, $impedance) {
   $value = sqrtApprox($resistance * $resistance + $reactance * $reactance);
   return ['impedance' => $value];
 } else {
-  $panic('Exactly one argument must be 0');
+  _panic('Exactly one argument must be 0');
 };
 };
 }
-}
-echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(electrical_impedance(3.0, 4.0, 0.0), 1344)))))), PHP_EOL;
-echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(electrical_impedance(0.0, 4.0, 5.0), 1344)))))), PHP_EOL;
-echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(electrical_impedance(3.0, 0.0, 5.0), 1344)))))), PHP_EOL;
+};
+  echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(electrical_impedance(3.0, 4.0, 0.0), 1344)))))), PHP_EOL;
+  echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(electrical_impedance(0.0, 4.0, 5.0), 1344)))))), PHP_EOL;
+  echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(electrical_impedance(3.0, 0.0, 5.0), 1344)))))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/ic_555_timer.bench
+++ b/tests/algorithms/x/PHP/electronics/ic_555_timer.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 63,
-  "memory_bytes": 39120,
+  "duration_us": 50,
+  "memory_bytes": 39280,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/electronics/ic_555_timer.php
+++ b/tests/algorithms/x/PHP/electronics/ic_555_timer.php
@@ -1,16 +1,45 @@
 <?php
 ini_set('memory_limit', '-1');
-function astable_frequency($resistance_1, $resistance_2, $capacitance) {
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function astable_frequency($resistance_1, $resistance_2, $capacitance) {
   if ($resistance_1 <= 0.0 || $resistance_2 <= 0.0 || $capacitance <= 0.0) {
-  $panic('All values must be positive');
+  _panic('All values must be positive');
 }
   return (1.44 / (($resistance_1 + 2.0 * $resistance_2) * $capacitance)) * 1000000.0;
-}
-function astable_duty_cycle($resistance_1, $resistance_2) {
+};
+  function astable_duty_cycle($resistance_1, $resistance_2) {
   if ($resistance_1 <= 0.0 || $resistance_2 <= 0.0) {
-  $panic('All values must be positive');
+  _panic('All values must be positive');
 }
   return ($resistance_1 + $resistance_2) / ($resistance_1 + 2.0 * $resistance_2) * 100.0;
-}
-echo rtrim(json_encode(astable_frequency(45.0, 45.0, 7.0), 1344)), PHP_EOL;
-echo rtrim(json_encode(astable_duty_cycle(45.0, 45.0), 1344)), PHP_EOL;
+};
+  echo rtrim(json_encode(astable_frequency(45.0, 45.0, 7.0), 1344)), PHP_EOL;
+  echo rtrim(json_encode(astable_duty_cycle(45.0, 45.0), 1344)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/ind_reactance.bench
+++ b/tests/algorithms/x/PHP/electronics/ind_reactance.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 91,
+  "duration_us": 61,
   "memory_bytes": 37192,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/electronics/ind_reactance.php
+++ b/tests/algorithms/x/PHP/electronics/ind_reactance.php
@@ -1,7 +1,28 @@
 <?php
 ini_set('memory_limit', '-1');
-$PI = 3.141592653589793;
-function ind_reactance($inductance, $frequency, $reactance) {
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $PI = 3.141592653589793;
+  function ind_reactance($inductance, $frequency, $reactance) {
   global $PI;
   $zero_count = 0;
   if ($inductance == 0.0) {
@@ -14,16 +35,16 @@ function ind_reactance($inductance, $frequency, $reactance) {
   $zero_count = $zero_count + 1;
 }
   if ($zero_count != 1) {
-  $panic('One and only one argument must be 0');
+  _panic('One and only one argument must be 0');
 }
   if ($inductance < 0.0) {
-  $panic('Inductance cannot be negative');
+  _panic('Inductance cannot be negative');
 }
   if ($frequency < 0.0) {
-  $panic('Frequency cannot be negative');
+  _panic('Frequency cannot be negative');
 }
   if ($reactance < 0.0) {
-  $panic('Inductive reactance cannot be negative');
+  _panic('Inductive reactance cannot be negative');
 }
   if ($inductance == 0.0) {
   return ['inductance' => $reactance / (2.0 * $PI * $frequency)];
@@ -32,7 +53,15 @@ function ind_reactance($inductance, $frequency, $reactance) {
   return ['frequency' => $reactance / (2.0 * $PI * $inductance)];
 }
   return ['reactance' => 2.0 * $PI * $frequency * $inductance];
-}
-echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(ind_reactance(0.0, 10000.0, 50.0), 1344)))))), PHP_EOL;
-echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(ind_reactance(0.035, 0.0, 50.0), 1344)))))), PHP_EOL;
-echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(ind_reactance(0.000035, 1000.0, 0.0), 1344)))))), PHP_EOL;
+};
+  echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(ind_reactance(0.0, 10000.0, 50.0), 1344)))))), PHP_EOL;
+  echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(ind_reactance(0.035, 0.0, 50.0), 1344)))))), PHP_EOL;
+  echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(ind_reactance(0.000035, 1000.0, 0.0), 1344)))))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/ohms_law.bench
+++ b/tests/algorithms/x/PHP/electronics/ohms_law.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 87,
+  "duration_us": 63,
   "memory_bytes": 39952,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/electronics/ohms_law.php
+++ b/tests/algorithms/x/PHP/electronics/ohms_law.php
@@ -1,6 +1,23 @@
 <?php
 ini_set('memory_limit', '-1');
-function ohms_law($voltage, $current, $resistance) {
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function ohms_law($voltage, $current, $resistance) {
   $zeros = 0;
   if ($voltage == 0.0) {
   $zeros = $zeros + 1;
@@ -26,7 +43,15 @@ function ohms_law($voltage, $current, $resistance) {
   return ['current' => $voltage / $resistance];
 }
   return ['resistance' => $voltage / $current];
-}
-echo str_replace('    ', '  ', json_encode(ohms_law(10.0, 0.0, 5.0), 128)), PHP_EOL;
-echo str_replace('    ', '  ', json_encode(ohms_law(-10.0, 1.0, 0.0), 128)), PHP_EOL;
-echo str_replace('    ', '  ', json_encode(ohms_law(0.0, -1.5, 2.0), 128)), PHP_EOL;
+};
+  echo str_replace('    ', '  ', json_encode(ohms_law(10.0, 0.0, 5.0), 128)), PHP_EOL;
+  echo str_replace('    ', '  ', json_encode(ohms_law(-10.0, 1.0, 0.0), 128)), PHP_EOL;
+  echo str_replace('    ', '  ', json_encode(ohms_law(0.0, -1.5, 2.0), 128)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/real_and_reactive_power.bench
+++ b/tests/algorithms/x/PHP/electronics/real_and_reactive_power.bench
@@ -1,1 +1,5 @@
-Fatal error: Cannot redeclare function sqrt() in /workspace/mochi/tests/algorithms/x/PHP/electronics/real_and_reactive_power.php on line 36
+{
+  "duration_us": 48,
+  "memory_bytes": 36568,
+  "name": "main"
+}

--- a/tests/algorithms/x/PHP/electronics/real_and_reactive_power.error
+++ b/tests/algorithms/x/PHP/electronics/real_and_reactive_power.error
@@ -1,3 +1,0 @@
-run: exit status 255
-
-Fatal error: Cannot redeclare function sqrt() in /workspace/mochi/tests/algorithms/x/PHP/electronics/real_and_reactive_power.php on line 19

--- a/tests/algorithms/x/PHP/electronics/real_and_reactive_power.out
+++ b/tests/algorithms/x/PHP/electronics/real_and_reactive_power.out
@@ -1,1 +1,6 @@
-Fatal error: Cannot redeclare function sqrt() in /workspace/mochi/tests/algorithms/x/PHP/electronics/real_and_reactive_power.php on line 19
+90
+0
+-90
+43.588989435407
+0
+43.588989435407

--- a/tests/algorithms/x/PHP/electronics/real_and_reactive_power.php
+++ b/tests/algorithms/x/PHP/electronics/real_and_reactive_power.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,7 +31,13 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-function sqrt($x) {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function mochi_sqrt($x) {
   if ($x <= 0.0) {
   return 0.0;
 }
@@ -27,22 +48,30 @@ function sqrt($x) {
   $i = $i + 1;
 };
   return $guess;
-}
-function real_power($apparent_power, $power_factor) {
+};
+  function real_power($apparent_power, $power_factor) {
   if ($power_factor < 0.0 - 1.0 || $power_factor > 1.0) {
-  $panic('power_factor must be a valid float value between -1 and 1.');
+  _panic('power_factor must be a valid float value between -1 and 1.');
 }
   return $apparent_power * $power_factor;
-}
-function reactive_power($apparent_power, $power_factor) {
+};
+  function reactive_power($apparent_power, $power_factor) {
   if ($power_factor < 0.0 - 1.0 || $power_factor > 1.0) {
-  $panic('power_factor must be a valid float value between -1 and 1.');
+  _panic('power_factor must be a valid float value between -1 and 1.');
 }
-  return $apparent_power * sqrt(1.0 - $power_factor * $power_factor);
-}
-echo rtrim(_str(real_power(100.0, 0.9))), PHP_EOL;
-echo rtrim(_str(real_power(0.0, 0.8))), PHP_EOL;
-echo rtrim(_str(real_power(100.0, -0.9))), PHP_EOL;
-echo rtrim(_str(reactive_power(100.0, 0.9))), PHP_EOL;
-echo rtrim(_str(reactive_power(0.0, 0.8))), PHP_EOL;
-echo rtrim(_str(reactive_power(100.0, -0.9))), PHP_EOL;
+  return $apparent_power * mochi_sqrt(1.0 - $power_factor * $power_factor);
+};
+  echo rtrim(_str(real_power(100.0, 0.9))), PHP_EOL;
+  echo rtrim(_str(real_power(0.0, 0.8))), PHP_EOL;
+  echo rtrim(_str(real_power(100.0, -0.9))), PHP_EOL;
+  echo rtrim(_str(reactive_power(100.0, 0.9))), PHP_EOL;
+  echo rtrim(_str(reactive_power(0.0, 0.8))), PHP_EOL;
+  echo rtrim(_str(reactive_power(100.0, -0.9))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/resistor_color_code.bench
+++ b/tests/algorithms/x/PHP/electronics/resistor_color_code.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 2,
-  "memory_bytes": 74448,
+  "duration_us": 1,
+  "memory_bytes": 74928,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/electronics/resistor_color_code.php
+++ b/tests/algorithms/x/PHP/electronics/resistor_color_code.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,54 +31,60 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-$valid_colors = ['Black', 'Brown', 'Red', 'Orange', 'Yellow', 'Green', 'Blue', 'Violet', 'Grey', 'White', 'Gold', 'Silver'];
-$significant_figures_color_values = ['Black' => 0, 'Brown' => 1, 'Red' => 2, 'Orange' => 3, 'Yellow' => 4, 'Green' => 5, 'Blue' => 6, 'Violet' => 7, 'Grey' => 8, 'White' => 9];
-$multiplier_color_values = ['Black' => 1.0, 'Brown' => 10.0, 'Red' => 100.0, 'Orange' => 1000.0, 'Yellow' => 10000.0, 'Green' => 100000.0, 'Blue' => 1000000.0, 'Violet' => 10000000.0, 'Grey' => 100000000.0, 'White' => 1000000000.0, 'Gold' => 0.1, 'Silver' => 0.01];
-$tolerance_color_values = ['Brown' => 1.0, 'Red' => 2.0, 'Orange' => 0.05, 'Yellow' => 0.02, 'Green' => 0.5, 'Blue' => 0.25, 'Violet' => 0.1, 'Grey' => 0.01, 'Gold' => 5.0, 'Silver' => 10.0];
-$temperature_coeffecient_color_values = ['Black' => 250, 'Brown' => 100, 'Red' => 50, 'Orange' => 15, 'Yellow' => 25, 'Green' => 20, 'Blue' => 10, 'Violet' => 5, 'Grey' => 1];
-function contains($list, $value) {
-  global $valid_colors, $significant_figures_color_values, $multiplier_color_values, $tolerance_color_values, $temperature_coeffecient_color_values;
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $valid_colors = ['Black', 'Brown', 'Red', 'Orange', 'Yellow', 'Green', 'Blue', 'Violet', 'Grey', 'White', 'Gold', 'Silver'];
+  $significant_figures_color_values = ['Black' => 0, 'Brown' => 1, 'Red' => 2, 'Orange' => 3, 'Yellow' => 4, 'Green' => 5, 'Blue' => 6, 'Violet' => 7, 'Grey' => 8, 'White' => 9];
+  $multiplier_color_values = ['Black' => 1.0, 'Brown' => 10.0, 'Red' => 100.0, 'Orange' => 1000.0, 'Yellow' => 10000.0, 'Green' => 100000.0, 'Blue' => 1000000.0, 'Violet' => 10000000.0, 'Grey' => 100000000.0, 'White' => 1000000000.0, 'Gold' => 0.1, 'Silver' => 0.01];
+  $tolerance_color_values = ['Brown' => 1.0, 'Red' => 2.0, 'Orange' => 0.05, 'Yellow' => 0.02, 'Green' => 0.5, 'Blue' => 0.25, 'Violet' => 0.1, 'Grey' => 0.01, 'Gold' => 5.0, 'Silver' => 10.0];
+  $temperature_coeffecient_color_values = ['Black' => 250, 'Brown' => 100, 'Red' => 50, 'Orange' => 15, 'Yellow' => 25, 'Green' => 20, 'Blue' => 10, 'Violet' => 5, 'Grey' => 1];
+  function contains($list, $value) {
+  global $multiplier_color_values, $significant_figures_color_values, $temperature_coeffecient_color_values, $tolerance_color_values, $valid_colors;
   foreach ($list as $c) {
   if ($c == $value) {
   return true;
 }
 };
   return false;
-}
-function get_significant_digits($colors) {
-  global $valid_colors, $significant_figures_color_values, $multiplier_color_values, $tolerance_color_values, $temperature_coeffecient_color_values;
+};
+  function get_significant_digits($colors) {
+  global $multiplier_color_values, $significant_figures_color_values, $temperature_coeffecient_color_values, $tolerance_color_values, $valid_colors;
   $digit = 0;
   foreach ($colors as $color) {
   if (!(isset($significant_figures_color_values[$color]))) {
-  $panic($color . ' is not a valid color for significant figure bands');
+  _panic($color . ' is not a valid color for significant figure bands');
 }
   $digit = $digit * 10 + $significant_figures_color_values[$color];
 };
   return $digit;
-}
-function get_multiplier($color) {
-  global $valid_colors, $significant_figures_color_values, $multiplier_color_values, $tolerance_color_values, $temperature_coeffecient_color_values;
+};
+  function get_multiplier($color) {
+  global $multiplier_color_values, $significant_figures_color_values, $temperature_coeffecient_color_values, $tolerance_color_values, $valid_colors;
   if (!(isset($multiplier_color_values[$color]))) {
-  $panic($color . ' is not a valid color for multiplier band');
+  _panic($color . ' is not a valid color for multiplier band');
 }
   return $multiplier_color_values[$color];
-}
-function get_tolerance($color) {
-  global $valid_colors, $significant_figures_color_values, $multiplier_color_values, $tolerance_color_values, $temperature_coeffecient_color_values;
+};
+  function get_tolerance($color) {
+  global $multiplier_color_values, $significant_figures_color_values, $temperature_coeffecient_color_values, $tolerance_color_values, $valid_colors;
   if (!(isset($tolerance_color_values[$color]))) {
-  $panic($color . ' is not a valid color for tolerance band');
+  _panic($color . ' is not a valid color for tolerance band');
 }
   return $tolerance_color_values[$color];
-}
-function get_temperature_coeffecient($color) {
-  global $valid_colors, $significant_figures_color_values, $multiplier_color_values, $tolerance_color_values, $temperature_coeffecient_color_values;
+};
+  function get_temperature_coeffecient($color) {
+  global $multiplier_color_values, $significant_figures_color_values, $temperature_coeffecient_color_values, $tolerance_color_values, $valid_colors;
   if (!(isset($temperature_coeffecient_color_values[$color]))) {
-  $panic($color . ' is not a valid color for temperature coeffecient band');
+  _panic($color . ' is not a valid color for temperature coeffecient band');
 }
   return $temperature_coeffecient_color_values[$color];
-}
-function get_band_type_count($total, $typ) {
-  global $valid_colors, $significant_figures_color_values, $multiplier_color_values, $tolerance_color_values, $temperature_coeffecient_color_values;
+};
+  function get_band_type_count($total, $typ) {
+  global $multiplier_color_values, $significant_figures_color_values, $temperature_coeffecient_color_values, $tolerance_color_values, $valid_colors;
   if ($total == 3) {
   if ($typ == 'significant') {
   return 2;
@@ -71,7 +92,7 @@ function get_band_type_count($total, $typ) {
   if ($typ == 'multiplier') {
   return 1;
 };
-  $panic($typ . ' is not valid for a 3 band resistor');
+  _panic($typ . ' is not valid for a 3 band resistor');
 } else {
   if ($total == 4) {
   if ($typ == 'significant') {
@@ -83,7 +104,7 @@ function get_band_type_count($total, $typ) {
   if ($typ == 'tolerance') {
   return 1;
 };
-  $panic($typ . ' is not valid for a 4 band resistor');
+  _panic($typ . ' is not valid for a 4 band resistor');
 } else {
   if ($total == 5) {
   if ($typ == 'significant') {
@@ -95,7 +116,7 @@ function get_band_type_count($total, $typ) {
   if ($typ == 'tolerance') {
   return 1;
 };
-  $panic($typ . ' is not valid for a 5 band resistor');
+  _panic($typ . ' is not valid for a 5 band resistor');
 } else {
   if ($total == 6) {
   if ($typ == 'significant') {
@@ -110,34 +131,34 @@ function get_band_type_count($total, $typ) {
   if ($typ == 'temp_coeffecient') {
   return 1;
 };
-  $panic($typ . ' is not valid for a 6 band resistor');
+  _panic($typ . ' is not valid for a 6 band resistor');
 } else {
-  $panic(_str($total) . ' is not a valid number of bands');
+  _panic(_str($total) . ' is not a valid number of bands');
 };
 };
 };
 }
-}
-function check_validity($number_of_bands, $colors) {
-  global $valid_colors, $significant_figures_color_values, $multiplier_color_values, $tolerance_color_values, $temperature_coeffecient_color_values;
+};
+  function check_validity($number_of_bands, $colors) {
+  global $multiplier_color_values, $significant_figures_color_values, $temperature_coeffecient_color_values, $tolerance_color_values, $valid_colors;
   if ($number_of_bands < 3 || $number_of_bands > 6) {
-  $panic('Invalid number of bands. Resistor bands must be 3 to 6');
+  _panic('Invalid number of bands. Resistor bands must be 3 to 6');
 }
   if ($number_of_bands != count($colors)) {
-  $panic('Expecting ' . _str($number_of_bands) . ' colors, provided ' . _str(count($colors)) . ' colors');
+  _panic('Expecting ' . _str($number_of_bands) . ' colors, provided ' . _str(count($colors)) . ' colors');
 }
   foreach ($colors as $color) {
   if (!contains($valid_colors, $color)) {
-  $panic($color . ' is not a valid color');
+  _panic($color . ' is not a valid color');
 }
 };
   return true;
-}
-function calculate_resistance($number_of_bands, $color_code_list) {
-  global $valid_colors, $significant_figures_color_values, $multiplier_color_values, $tolerance_color_values, $temperature_coeffecient_color_values;
+};
+  function calculate_resistance($number_of_bands, $color_code_list) {
+  global $multiplier_color_values, $significant_figures_color_values, $temperature_coeffecient_color_values, $tolerance_color_values, $valid_colors;
   check_validity($number_of_bands, $color_code_list);
   $sig_count = get_band_type_count($number_of_bands, 'significant');
-  $significant_colors = array_slice($color_code_list, 0, $sig_count - 0);
+  $significant_colors = array_slice($color_code_list, 0, $sig_count);
   $significant_digits = get_significant_digits($significant_colors);
   $multiplier_color = $color_code_list[$sig_count];
   $multiplier = get_multiplier($multiplier_color);
@@ -161,4 +182,12 @@ function calculate_resistance($number_of_bands, $color_code_list) {
   $answer = $answer . _str($temp_coeff) . ' ppm/K';
 }
   return $answer;
-}
+};
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/resistor_equivalence.bench
+++ b/tests/algorithms/x/PHP/electronics/resistor_equivalence.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 75,
-  "memory_bytes": 37248,
+  "duration_us": 68,
+  "memory_bytes": 37408,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/electronics/resistor_equivalence.php
+++ b/tests/algorithms/x/PHP/electronics/resistor_equivalence.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,35 +31,49 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-function resistor_parallel($resistors) {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function resistor_parallel($resistors) {
   $sum = 0.0;
   $i = 0;
   while ($i < count($resistors)) {
   $r = $resistors[$i];
   if ($r <= 0.0) {
-  $panic('Resistor at index ' . _str($i) . ' has a negative or zero value!');
+  _panic('Resistor at index ' . _str($i) . ' has a negative or zero value!');
 }
   $sum = $sum + 1.0 / $r;
   $i = $i + 1;
 };
   return 1.0 / $sum;
-}
-function resistor_series($resistors) {
+};
+  function resistor_series($resistors) {
   $sum = 0.0;
   $i = 0;
   while ($i < count($resistors)) {
   $r = $resistors[$i];
   if ($r < 0.0) {
-  $panic('Resistor at index ' . _str($i) . ' has a negative value!');
+  _panic('Resistor at index ' . _str($i) . ' has a negative value!');
 }
   $sum = $sum + $r;
   $i = $i + 1;
 };
   return $sum;
-}
-function main() {
+};
+  function main() {
   $resistors = [3.21389, 2.0, 3.0];
   echo rtrim('Parallel: ' . _str(resistor_parallel($resistors))), PHP_EOL;
   echo rtrim('Series: ' . _str(resistor_series($resistors))), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/resonant_frequency.bench
+++ b/tests/algorithms/x/PHP/electronics/resonant_frequency.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 62,
-  "memory_bytes": 40064,
+  "duration_us": 104,
+  "memory_bytes": 40224,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/electronics/resonant_frequency.php
+++ b/tests/algorithms/x/PHP/electronics/resonant_frequency.php
@@ -1,7 +1,28 @@
 <?php
 ini_set('memory_limit', '-1');
-$PI = 3.141592653589793;
-function sqrtApprox($x) {
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $PI = 3.141592653589793;
+  function sqrtApprox($x) {
   global $PI;
   $guess = $x / 2.0;
   $i = 0;
@@ -10,16 +31,24 @@ function sqrtApprox($x) {
   $i = $i + 1;
 };
   return $guess;
-}
-function resonant_frequency($inductance, $capacitance) {
+};
+  function resonant_frequency($inductance, $capacitance) {
   global $PI;
   if ($inductance <= 0.0) {
-  $panic('Inductance cannot be 0 or negative');
+  _panic('Inductance cannot be 0 or negative');
 }
   if ($capacitance <= 0.0) {
-  $panic('Capacitance cannot be 0 or negative');
+  _panic('Capacitance cannot be 0 or negative');
 }
   $denom = 2.0 * $PI * sqrtApprox($inductance * $capacitance);
   return 1.0 / $denom;
-}
-echo rtrim(json_encode(resonant_frequency(10.0, 5.0), 1344)), PHP_EOL;
+};
+  echo rtrim(json_encode(resonant_frequency(10.0, 5.0), 1344)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/wheatstone_bridge.bench
+++ b/tests/algorithms/x/PHP/electronics/wheatstone_bridge.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 82,
-  "memory_bytes": 39072,
+  "duration_us": 51,
+  "memory_bytes": 39200,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/electronics/wheatstone_bridge.php
+++ b/tests/algorithms/x/PHP/electronics/wheatstone_bridge.php
@@ -1,10 +1,39 @@
 <?php
 ini_set('memory_limit', '-1');
-function wheatstone_solver($resistance_1, $resistance_2, $resistance_3) {
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function wheatstone_solver($resistance_1, $resistance_2, $resistance_3) {
   if ($resistance_1 <= 0.0 || $resistance_2 <= 0.0 || $resistance_3 <= 0.0) {
-  $panic('All resistance values must be positive');
+  _panic('All resistance values must be positive');
 }
   return ($resistance_2 / $resistance_1) * $resistance_3;
-}
-echo rtrim(json_encode(wheatstone_solver(2.0, 4.0, 5.0), 1344)), PHP_EOL;
-echo rtrim(json_encode(wheatstone_solver(356.0, 234.0, 976.0), 1344)), PHP_EOL;
+};
+  echo rtrim(json_encode(wheatstone_solver(2.0, 4.0, 5.0), 1344)), PHP_EOL;
+  echo rtrim(json_encode(wheatstone_solver(356.0, 234.0, 976.0), 1344)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/file_transfer/receive_file.bench
+++ b/tests/algorithms/x/PHP/file_transfer/receive_file.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 122,
+  "duration_us": 43,
   "memory_bytes": 36616,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/file_transfer/receive_file.php
+++ b/tests/algorithms/x/PHP/file_transfer/receive_file.php
@@ -1,6 +1,23 @@
 <?php
 ini_set('memory_limit', '-1');
-function receive_file($chunks) {
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function receive_file($chunks) {
   $out = '';
   $i = 0;
   echo rtrim('File opened'), PHP_EOL;
@@ -16,10 +33,18 @@ function receive_file($chunks) {
   echo rtrim('Successfully received the file'), PHP_EOL;
   echo rtrim('Connection closed'), PHP_EOL;
   return $out;
-}
-function main() {
+};
+  function main() {
   $incoming = ['Hello ', 'from ', 'server'];
   $received = receive_file($incoming);
   echo rtrim($received), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/file_transfer/send_file.bench
+++ b/tests/algorithms/x/PHP/file_transfer/send_file.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 68,
+  "duration_us": 42,
   "memory_bytes": 36136,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/file_transfer/send_file.php
+++ b/tests/algorithms/x/PHP/file_transfer/send_file.php
@@ -1,6 +1,23 @@
 <?php
 ini_set('memory_limit', '-1');
-function send_file($content, $chunk_size) {
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function send_file($content, $chunk_size) {
   $start = 0;
   $n = strlen($content);
   while ($start < $n) {
@@ -12,5 +29,13 @@ function send_file($content, $chunk_size) {
   echo rtrim($chunk), PHP_EOL;
   $start = $end;
 };
-}
-send_file('The quick brown fox jumps over the lazy dog.', 10);
+};
+  send_file('The quick brown fox jumps over the lazy dog.', 10);
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/file_transfer/tests/test_send_file.bench
+++ b/tests/algorithms/x/PHP/file_transfer/tests/test_send_file.bench
@@ -1,1 +1,1 @@
-Fatal error: Cannot redeclare function socket_bind() in /workspace/mochi/tests/algorithms/x/PHP/file_transfer/tests/test_send_file.php on line 41
+Fatal error: Cannot redeclare function socket_bind() in /workspace/mochi/tests/algorithms/x/PHP/file_transfer/tests/test_send_file.php on line 42

--- a/tests/algorithms/x/PHP/file_transfer/tests/test_send_file.error
+++ b/tests/algorithms/x/PHP/file_transfer/tests/test_send_file.error
@@ -1,3 +1,3 @@
 run: exit status 255
 
-Fatal error: Cannot redeclare function socket_bind() in /workspace/mochi/tests/algorithms/x/PHP/file_transfer/tests/test_send_file.php on line 24
+Fatal error: Cannot redeclare function socket_bind() in /workspace/mochi/tests/algorithms/x/PHP/file_transfer/tests/test_send_file.php on line 42

--- a/tests/algorithms/x/PHP/file_transfer/tests/test_send_file.php
+++ b/tests/algorithms/x/PHP/file_transfer/tests/test_send_file.php
@@ -1,46 +1,64 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _len($x) {
+    if ($x === null) { return 0; }
     if (is_array($x)) { return count($x); }
     if (is_string($x)) { return strlen($x); }
     return strlen(strval($x));
 }
-function make_conn_mock() {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function make_conn_mock() {
   return ['recv_called' => 0, 'send_called' => 0, 'close_called' => 0];
-}
-function conn_recv(&$conn, $size) {
+};
+  function conn_recv(&$conn, $size) {
   $conn['recv_called'] = $conn['recv_called'] + 1;
   return 0;
-}
-function conn_send(&$conn, $data) {
+};
+  function conn_send(&$conn, $data) {
   $conn['send_called'] = $conn['send_called'] + 1;
-}
-function conn_close(&$conn) {
+};
+  function conn_close(&$conn) {
   $conn['close_called'] = $conn['close_called'] + 1;
-}
-function make_socket_mock($conn) {
+};
+  function make_socket_mock($conn) {
   return ['bind_called' => 0, 'listen_called' => 0, 'accept_called' => 0, 'shutdown_called' => 0, 'close_called' => 0, 'conn' => $conn];
-}
-function socket_bind(&$sock) {
+};
+  function socket_bind(&$sock) {
   $sock['bind_called'] = $sock['bind_called'] + 1;
-}
-function socket_listen(&$sock) {
+};
+  function socket_listen(&$sock) {
   $sock['listen_called'] = $sock['listen_called'] + 1;
-}
-function socket_accept(&$sock) {
+};
+  function socket_accept(&$sock) {
   $sock['accept_called'] = $sock['accept_called'] + 1;
   return $sock['conn'];
-}
-function socket_shutdown(&$sock) {
+};
+  function socket_shutdown(&$sock) {
   $sock['shutdown_called'] = $sock['shutdown_called'] + 1;
-}
-function socket_close(&$sock) {
+};
+  function socket_close(&$sock) {
   $sock['close_called'] = $sock['close_called'] + 1;
-}
-function make_file_mock($values) {
+};
+  function make_file_mock($values) {
   return ['read_called' => 0, 'data' => $values];
-}
-function file_read(&$f, $size) {
+};
+  function file_read(&$f, $size) {
   if ($f['read_called'] < _len($f['data'])) {
   $value = $f['data'][$f['read_called']];
   $f['read_called'] = $f['read_called'] + 1;
@@ -48,11 +66,11 @@ function file_read(&$f, $size) {
 }
   $f['read_called'] = $f['read_called'] + 1;
   return 0;
-}
-function file_open() {
+};
+  function file_open() {
   return make_file_mock([1, 0]);
-}
-function send_file(&$sock, &$f) {
+};
+  function send_file(&$sock, &$f) {
   socket_bind($sock);
   socket_listen($sock);
   $conn = socket_accept($sock);
@@ -65,8 +83,8 @@ function send_file(&$sock, &$f) {
   conn_close($conn);
   socket_shutdown($sock);
   socket_close($sock);
-}
-function test_send_file_running_as_expected() {
+};
+  function test_send_file_running_as_expected() {
   $conn = make_conn_mock();
   $sock = make_socket_mock($conn);
   $f = file_open();
@@ -75,5 +93,13 @@ function test_send_file_running_as_expected() {
   return 'pass';
 }
   return 'fail';
-}
-echo rtrim(test_send_file_running_as_expected()), PHP_EOL;
+};
+  echo rtrim(test_send_file_running_as_expected()), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/financial/equated_monthly_installments.bench
+++ b/tests/algorithms/x/PHP/financial/equated_monthly_installments.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 59,
-  "memory_bytes": 39752,
+  "duration_us": 81,
+  "memory_bytes": 39944,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/financial/equated_monthly_installments.php
+++ b/tests/algorithms/x/PHP/financial/equated_monthly_installments.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,7 +31,13 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-function pow_float($base, $exp) {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function pow_float($base, $exp) {
   $result = 1.0;
   $i = 0;
   while ($i < $exp) {
@@ -24,21 +45,29 @@ function pow_float($base, $exp) {
   $i = $i + 1;
 };
   return $result;
-}
-function equated_monthly_installments($principal, $rate_per_annum, $years_to_repay) {
+};
+  function equated_monthly_installments($principal, $rate_per_annum, $years_to_repay) {
   if ($principal <= 0.0) {
-  $panic('Principal borrowed must be > 0');
+  _panic('Principal borrowed must be > 0');
 }
   if ($rate_per_annum < 0.0) {
-  $panic('Rate of interest must be >= 0');
+  _panic('Rate of interest must be >= 0');
 }
   if ($years_to_repay <= 0) {
-  $panic('Years to repay must be an integer > 0');
+  _panic('Years to repay must be an integer > 0');
 }
   $rate_per_month = $rate_per_annum / 12.0;
   $number_of_payments = $years_to_repay * 12;
   $factor = pow_float(1.0 + $rate_per_month, $number_of_payments);
   return $principal * $rate_per_month * $factor / ($factor - 1.0);
-}
-echo rtrim(_str(equated_monthly_installments(25000.0, 0.12, 3))), PHP_EOL;
-echo rtrim(_str(equated_monthly_installments(25000.0, 0.12, 10))), PHP_EOL;
+};
+  echo rtrim(_str(equated_monthly_installments(25000.0, 0.12, 3))), PHP_EOL;
+  echo rtrim(_str(equated_monthly_installments(25000.0, 0.12, 10))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/financial/exponential_moving_average.bench
+++ b/tests/algorithms/x/PHP/financial/exponential_moving_average.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 154,
-  "memory_bytes": 40448,
+  "duration_us": 109,
+  "memory_bytes": 40576,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/financial/exponential_moving_average.php
+++ b/tests/algorithms/x/PHP/financial/exponential_moving_average.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,9 +35,16 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function exponential_moving_average($stock_prices, $window_size) {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function exponential_moving_average($stock_prices, $window_size) {
+  global $result;
   if ($window_size <= 0) {
-  $panic('window_size must be > 0');
+  _panic('window_size must be > 0');
 }
   $alpha = 2.0 / (1.0 + (floatval($window_size)));
   $moving_average = 0.0;
@@ -43,8 +65,16 @@ function exponential_moving_average($stock_prices, $window_size) {
   $i = $i + 1;
 };
   return $result;
-}
-$stock_prices = [2.0, 5.0, 3.0, 8.2, 6.0, 9.0, 10.0];
-$window_size = 3;
-$result = exponential_moving_average($stock_prices, $window_size);
-echo rtrim(_str($result)), PHP_EOL;
+};
+  $stock_prices = [2.0, 5.0, 3.0, 8.2, 6.0, 9.0, 10.0];
+  $window_size = 3;
+  $result = exponential_moving_average($stock_prices, $window_size);
+  echo rtrim(_str($result)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/financial/interest.bench
+++ b/tests/algorithms/x/PHP/financial/interest.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 96,
+  "duration_us": 138,
   "memory_bytes": 41376,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/financial/interest.php
+++ b/tests/algorithms/x/PHP/financial/interest.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,10 +31,12 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-function panic($msg) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function panic($msg) {
   echo rtrim($msg), PHP_EOL;
-}
-function powf($base, $exp) {
+};
+  function powf($base, $exp) {
   $result = 1.0;
   $i = 0;
   while ($i < intval($exp)) {
@@ -27,8 +44,8 @@ function powf($base, $exp) {
   $i = $i + 1;
 };
   return $result;
-}
-function simple_interest($principal, $daily_rate, $days) {
+};
+  function simple_interest($principal, $daily_rate, $days) {
   if ($days <= 0.0) {
   panic('days_between_payments must be > 0');
   return 0.0;
@@ -42,8 +59,8 @@ function simple_interest($principal, $daily_rate, $days) {
   return 0.0;
 }
   return $principal * $daily_rate * $days;
-}
-function compound_interest($principal, $nominal_rate, $periods) {
+};
+  function compound_interest($principal, $nominal_rate, $periods) {
   if ($periods <= 0.0) {
   panic('number_of_compounding_periods must be > 0');
   return 0.0;
@@ -57,8 +74,8 @@ function compound_interest($principal, $nominal_rate, $periods) {
   return 0.0;
 }
   return $principal * (powf(1.0 + $nominal_rate, $periods) - 1.0);
-}
-function apr_interest($principal, $apr, $years) {
+};
+  function apr_interest($principal, $apr, $years) {
   if ($years <= 0.0) {
   panic('number_of_years must be > 0');
   return 0.0;
@@ -72,8 +89,8 @@ function apr_interest($principal, $apr, $years) {
   return 0.0;
 }
   return compound_interest($principal, $apr / 365.0, $years * 365.0);
-}
-function main() {
+};
+  function main() {
   echo rtrim(_str(simple_interest(18000.0, 0.06, 3.0))), PHP_EOL;
   echo rtrim(_str(simple_interest(0.5, 0.06, 3.0))), PHP_EOL;
   echo rtrim(_str(simple_interest(18000.0, 0.01, 10.0))), PHP_EOL;
@@ -81,5 +98,13 @@ function main() {
   echo rtrim(_str(compound_interest(10000.0, 0.05, 1.0))), PHP_EOL;
   echo rtrim(_str(apr_interest(10000.0, 0.05, 3.0))), PHP_EOL;
   echo rtrim(_str(apr_interest(10000.0, 0.05, 1.0))), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/financial/present_value.bench
+++ b/tests/algorithms/x/PHP/financial/present_value.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 76,
-  "memory_bytes": 40000,
+  "duration_us": 89,
+  "memory_bytes": 40160,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/financial/present_value.php
+++ b/tests/algorithms/x/PHP/financial/present_value.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,7 +31,13 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-function powf($base, $exponent) {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function powf($base, $exponent) {
   $result = 1.0;
   $i = 0;
   while ($i < $exponent) {
@@ -24,21 +45,21 @@ function powf($base, $exponent) {
   $i = $i + 1;
 };
   return $result;
-}
-function round2($value) {
+};
+  function round2($value) {
   if ($value >= 0.0) {
   $scaled = intval(($value * 100.0 + 0.5));
   return (floatval($scaled)) / 100.0;
 }
   $scaled = intval(($value * 100.0 - 0.5));
   return (floatval($scaled)) / 100.0;
-}
-function present_value($discount_rate, $cash_flows) {
+};
+  function present_value($discount_rate, $cash_flows) {
   if ($discount_rate < 0.0) {
-  $panic('Discount rate cannot be negative');
+  _panic('Discount rate cannot be negative');
 }
   if (count($cash_flows) == 0) {
-  $panic('Cash flows list cannot be empty');
+  _panic('Cash flows list cannot be empty');
 }
   $pv = 0.0;
   $i = 0;
@@ -49,7 +70,15 @@ function present_value($discount_rate, $cash_flows) {
   $i = $i + 1;
 };
   return round2($pv);
-}
-echo rtrim(_str(present_value(0.13, [10.0, 20.7, -293.0, 297.0]))), PHP_EOL;
-echo rtrim(_str(present_value(0.07, [-109129.39, 30923.23, 15098.93, 29734.0, 39.0]))), PHP_EOL;
-echo rtrim(_str(present_value(0.07, [109129.39, 30923.23, 15098.93, 29734.0, 39.0]))), PHP_EOL;
+};
+  echo rtrim(_str(present_value(0.13, [10.0, 20.7, -293.0, 297.0]))), PHP_EOL;
+  echo rtrim(_str(present_value(0.07, [-109129.39, 30923.23, 15098.93, 29734.0, 39.0]))), PHP_EOL;
+  echo rtrim(_str(present_value(0.07, [109129.39, 30923.23, 15098.93, 29734.0, 39.0]))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/financial/price_plus_tax.bench
+++ b/tests/algorithms/x/PHP/financial/price_plus_tax.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 54,
+  "duration_us": 37,
   "memory_bytes": 39616,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/financial/price_plus_tax.php
+++ b/tests/algorithms/x/PHP/financial/price_plus_tax.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,8 +31,18 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-function price_plus_tax($price, $tax_rate) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function price_plus_tax($price, $tax_rate) {
   return $price * (1.0 + $tax_rate);
-}
-echo rtrim('price_plus_tax(100, 0.25) = ' . _str(price_plus_tax(100.0, 0.25))), PHP_EOL;
-echo rtrim('price_plus_tax(125.50, 0.05) = ' . _str(price_plus_tax(125.5, 0.05))), PHP_EOL;
+};
+  echo rtrim('price_plus_tax(100, 0.25) = ' . _str(price_plus_tax(100.0, 0.25))), PHP_EOL;
+  echo rtrim('price_plus_tax(125.50, 0.05) = ' . _str(price_plus_tax(125.5, 0.05))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/financial/simple_moving_average.bench
+++ b/tests/algorithms/x/PHP/financial/simple_moving_average.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 131,
-  "memory_bytes": 40032,
+  "duration_us": 95,
+  "memory_bytes": 40160,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/financial/simple_moving_average.php
+++ b/tests/algorithms/x/PHP/financial/simple_moving_average.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,10 +35,16 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function simple_moving_average($data, $window_size) {
-  global $sma_values, $idx, $item;
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function simple_moving_average($data, $window_size) {
+  global $idx, $item, $sma_values;
   if ($window_size < 1) {
-  $panic('Window size must be a positive integer');
+  _panic('Window size must be a positive integer');
 }
   $result = [];
   $window_sum = 0.0;
@@ -42,12 +63,12 @@ function simple_moving_average($data, $window_size) {
   $i = $i + 1;
 };
   return $result;
-}
-$data = [10.0, 12.0, 15.0, 13.0, 14.0, 16.0, 18.0, 17.0, 19.0, 21.0];
-$window_size = 3;
-$sma_values = simple_moving_average($data, $window_size);
-$idx = 0;
-while ($idx < count($sma_values)) {
+};
+  $data = [10.0, 12.0, 15.0, 13.0, 14.0, 16.0, 18.0, 17.0, 19.0, 21.0];
+  $window_size = 3;
+  $sma_values = simple_moving_average($data, $window_size);
+  $idx = 0;
+  while ($idx < count($sma_values)) {
   $item = $sma_values[$idx];
   if ($item['ok']) {
   echo rtrim('Day ' . _str($idx + 1) . ': ' . _str($item['value'])), PHP_EOL;
@@ -56,3 +77,11 @@ while ($idx < count($sma_values)) {
 }
   $idx = $idx + 1;
 }
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/financial/straight_line_depreciation.bench
+++ b/tests/algorithms/x/PHP/financial/straight_line_depreciation.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 156,
-  "memory_bytes": 36424,
+  "duration_us": 134,
+  "memory_bytes": 36616,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/financial/straight_line_depreciation.php
+++ b/tests/algorithms/x/PHP/financial/straight_line_depreciation.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,15 +35,21 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function straight_line_depreciation($useful_years, $purchase_value, $residual_value) {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function straight_line_depreciation($useful_years, $purchase_value, $residual_value) {
   if ($useful_years < 1) {
-  $panic('Useful years cannot be less than 1');
+  _panic('Useful years cannot be less than 1');
 }
   if ($purchase_value < 0.0) {
-  $panic('Purchase value cannot be less than zero');
+  _panic('Purchase value cannot be less than zero');
 }
   if ($purchase_value < $residual_value) {
-  $panic('Purchase value cannot be less than residual value');
+  _panic('Purchase value cannot be less than residual value');
 }
   $depreciable_cost = $purchase_value - $residual_value;
   $annual_expense = $depreciable_cost / (1.0 * $useful_years);
@@ -46,9 +67,17 @@ function straight_line_depreciation($useful_years, $purchase_value, $residual_va
   $period = $period + 1;
 };
   return $expenses;
-}
-echo rtrim(_str(straight_line_depreciation(10, 1100.0, 100.0))), PHP_EOL;
-echo rtrim(_str(straight_line_depreciation(6, 1250.0, 50.0))), PHP_EOL;
-echo rtrim(_str(straight_line_depreciation(4, 1001.0, 0.0))), PHP_EOL;
-echo rtrim(_str(straight_line_depreciation(11, 380.0, 50.0))), PHP_EOL;
-echo rtrim(_str(straight_line_depreciation(1, 4985.0, 100.0))), PHP_EOL;
+};
+  echo rtrim(_str(straight_line_depreciation(10, 1100.0, 100.0))), PHP_EOL;
+  echo rtrim(_str(straight_line_depreciation(6, 1250.0, 50.0))), PHP_EOL;
+  echo rtrim(_str(straight_line_depreciation(4, 1001.0, 0.0))), PHP_EOL;
+  echo rtrim(_str(straight_line_depreciation(11, 380.0, 50.0))), PHP_EOL;
+  echo rtrim(_str(straight_line_depreciation(1, 4985.0, 100.0))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/financial/time_and_half_pay.bench
+++ b/tests/algorithms/x/PHP/financial/time_and_half_pay.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 59,
+  "duration_us": 58,
   "memory_bytes": 37200,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/financial/time_and_half_pay.php
+++ b/tests/algorithms/x/PHP/financial/time_and_half_pay.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,7 +31,9 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-function pay($hours_worked, $pay_rate, $hours) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function pay($hours_worked, $pay_rate, $hours) {
   $normal_pay = $hours_worked * $pay_rate;
   $over_time = $hours_worked - $hours;
   if ($over_time < 0.0) {
@@ -24,10 +41,18 @@ function pay($hours_worked, $pay_rate, $hours) {
 }
   $over_time_pay = $over_time * $pay_rate / 2.0;
   return $normal_pay + $over_time_pay;
-}
-function main() {
+};
+  function main() {
   echo rtrim(_str(pay(41.0, 1.0, 40.0))), PHP_EOL;
   echo rtrim(_str(pay(65.0, 19.0, 40.0))), PHP_EOL;
   echo rtrim(_str(pay(10.0, 1.0, 40.0))), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/fractals/julia_sets.bench
+++ b/tests/algorithms/x/PHP/fractals/julia_sets.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 1139,
-  "memory_bytes": 38240,
+  "duration_us": 757,
+  "memory_bytes": 38176,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/fractals/julia_sets.php
+++ b/tests/algorithms/x/PHP/fractals/julia_sets.php
@@ -1,18 +1,35 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function complex_add($a, $b) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function complex_add($a, $b) {
   return ['re' => $a['re'] + $b['re'], 'im' => $a['im'] + $b['im']];
-}
-function complex_mul($a, $b) {
+};
+  function complex_mul($a, $b) {
   $real = $a['re'] * $b['re'] - $a['im'] * $b['im'];
   $imag = $a['re'] * $b['im'] + $a['im'] * $b['re'];
   return ['re' => $real, 'im' => $imag];
-}
-function sqrtApprox($x) {
+};
+  function sqrtApprox($x) {
   $guess = $x / 2.0;
   $i = 0;
   while ($i < 20) {
@@ -20,11 +37,11 @@ function sqrtApprox($x) {
   $i = $i + 1;
 };
   return $guess;
-}
-function complex_abs($a) {
+};
+  function complex_abs($a) {
   return sqrtApprox($a['re'] * $a['re'] + $a['im'] * $a['im']);
-}
-function sin_taylor($x) {
+};
+  function sin_taylor($x) {
   $term = $x;
   $sum = $x;
   $i = 1;
@@ -36,8 +53,8 @@ function sin_taylor($x) {
   $i = $i + 1;
 };
   return $sum;
-}
-function cos_taylor($x) {
+};
+  function cos_taylor($x) {
   $term = 1.0;
   $sum = 1.0;
   $i = 1;
@@ -49,8 +66,8 @@ function cos_taylor($x) {
   $i = $i + 1;
 };
   return $sum;
-}
-function exp_taylor($x) {
+};
+  function exp_taylor($x) {
   $term = 1.0;
   $sum = 1.0;
   $i = 1.0;
@@ -60,18 +77,18 @@ function exp_taylor($x) {
   $i = $i + 1.0;
 };
   return $sum;
-}
-function complex_exp($z) {
+};
+  function complex_exp($z) {
   $e = exp_taylor($z['re']);
   return ['re' => $e * cos_taylor($z['im']), 'im' => $e * sin_taylor($z['im'])];
-}
-function eval_quadratic($c, $z) {
+};
+  function eval_quadratic($c, $z) {
   return complex_add(complex_mul($z, $z), $c);
-}
-function eval_exponential($c, $z) {
+};
+  function eval_exponential($c, $z) {
   return complex_add(complex_exp($z), $c);
-}
-function iterate_function($eval_function, $c, $nb_iterations, $z0, $infinity) {
+};
+  function iterate_function($eval_function, $c, $nb_iterations, $z0, $infinity) {
   $z_n = $z0;
   $i = 0;
   while ($i < $nb_iterations) {
@@ -82,8 +99,8 @@ function iterate_function($eval_function, $c, $nb_iterations, $z0, $infinity) {
   $i = $i + 1;
 };
   return $z_n;
-}
-function prepare_grid($window_size, $nb_pixels) {
+};
+  function prepare_grid($window_size, $nb_pixels) {
   $grid = [];
   $i = 0;
   while ($i < $nb_pixels) {
@@ -99,8 +116,8 @@ function prepare_grid($window_size, $nb_pixels) {
   $i = $i + 1;
 };
   return $grid;
-}
-function julia_demo() {
+};
+  function julia_demo() {
   $grid = prepare_grid(1.0, 5);
   $c_poly = ['re' => -0.4, 'im' => 0.6];
   $c_exp = ['re' => -2.0, 'im' => 0.0];
@@ -125,5 +142,13 @@ function julia_demo() {
 };
   echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode($poly_result, 1344)))))), PHP_EOL;
   echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode($exp_result, 1344)))))), PHP_EOL;
-}
-julia_demo();
+};
+  julia_demo();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/fractals/koch_snowflake.bench
+++ b/tests/algorithms/x/PHP/fractals/koch_snowflake.bench
@@ -1,1 +1,5 @@
-Fatal error: Cannot redeclare function sin() in /workspace/mochi/tests/algorithms/x/PHP/fractals/koch_snowflake.php on line 46
+{
+  "duration_us": 94,
+  "memory_bytes": 40560,
+  "name": "main"
+}

--- a/tests/algorithms/x/PHP/fractals/koch_snowflake.error
+++ b/tests/algorithms/x/PHP/fractals/koch_snowflake.error
@@ -1,3 +1,0 @@
-run: exit status 255
-
-Fatal error: Cannot redeclare function sin() in /workspace/mochi/tests/algorithms/x/PHP/fractals/koch_snowflake.php on line 29

--- a/tests/algorithms/x/PHP/fractals/koch_snowflake.php
+++ b/tests/algorithms/x/PHP/fractals/koch_snowflake.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,38 +35,40 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-$PI = 3.141592653589793;
-$TWO_PI = 6.283185307179586;
-function _mod($x, $m) {
-  global $PI, $TWO_PI, $VECTOR_1, $VECTOR_2, $VECTOR_3, $INITIAL_VECTORS, $example;
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $PI = 3.141592653589793;
+  $TWO_PI = 6.283185307179586;
+  function _mod($x, $m) {
+  global $INITIAL_VECTORS, $PI, $TWO_PI, $VECTOR_1, $VECTOR_2, $VECTOR_3, $example;
   return $x - (floatval(intval($x / $m))) * $m;
-}
-function sin($x) {
-  global $PI, $TWO_PI, $VECTOR_1, $VECTOR_2, $VECTOR_3, $INITIAL_VECTORS, $example;
+};
+  function mochi_sin($x) {
+  global $INITIAL_VECTORS, $PI, $TWO_PI, $VECTOR_1, $VECTOR_2, $VECTOR_3, $example;
   $y = _mod($x + $PI, $TWO_PI) - $PI;
   $y2 = $y * $y;
   $y3 = $y2 * $y;
   $y5 = $y3 * $y2;
   $y7 = $y5 * $y2;
   return $y - $y3 / 6.0 + $y5 / 120.0 - $y7 / 5040.0;
-}
-function cos($x) {
-  global $PI, $TWO_PI, $VECTOR_1, $VECTOR_2, $VECTOR_3, $INITIAL_VECTORS, $example;
+};
+  function mochi_cos($x) {
+  global $INITIAL_VECTORS, $PI, $TWO_PI, $VECTOR_1, $VECTOR_2, $VECTOR_3, $example;
   $y = _mod($x + $PI, $TWO_PI) - $PI;
   $y2 = $y * $y;
   $y4 = $y2 * $y2;
   $y6 = $y4 * $y2;
   return 1.0 - $y2 / 2.0 + $y4 / 24.0 - $y6 / 720.0;
-}
-function rotate($v, $angle_deg) {
-  global $PI, $TWO_PI, $VECTOR_1, $VECTOR_2, $VECTOR_3, $INITIAL_VECTORS, $example;
+};
+  function rotate($v, $angle_deg) {
+  global $INITIAL_VECTORS, $PI, $TWO_PI, $VECTOR_1, $VECTOR_2, $VECTOR_3, $example;
   $theta = $angle_deg * $PI / 180.0;
-  $c = cos($theta);
-  $s = sin($theta);
+  $c = mochi_cos($theta);
+  $s = mochi_sin($theta);
   return ['x' => $v['x'] * $c - $v['y'] * $s, 'y' => $v['x'] * $s + $v['y'] * $c];
-}
-function iteration_step($vectors) {
-  global $PI, $TWO_PI, $VECTOR_1, $VECTOR_2, $VECTOR_3, $INITIAL_VECTORS, $example;
+};
+  function iteration_step($vectors) {
+  global $INITIAL_VECTORS, $PI, $TWO_PI, $VECTOR_1, $VECTOR_2, $VECTOR_3, $example;
   $new_vectors = [];
   $i = 0;
   while ($i < count($vectors) - 1) {
@@ -71,9 +88,9 @@ function iteration_step($vectors) {
 };
   $new_vectors = _append($new_vectors, $vectors[count($vectors) - 1]);
   return $new_vectors;
-}
-function iterate($initial, $steps) {
-  global $PI, $TWO_PI, $VECTOR_1, $VECTOR_2, $VECTOR_3, $INITIAL_VECTORS, $example;
+};
+  function iterate($initial, $steps) {
+  global $INITIAL_VECTORS, $PI, $TWO_PI, $VECTOR_1, $VECTOR_2, $VECTOR_3, $example;
   $vectors = $initial;
   $i = 0;
   while ($i < $steps) {
@@ -81,13 +98,13 @@ function iterate($initial, $steps) {
   $i = $i + 1;
 };
   return $vectors;
-}
-function vec_to_string($v) {
-  global $PI, $TWO_PI, $VECTOR_1, $VECTOR_2, $VECTOR_3, $INITIAL_VECTORS, $example;
+};
+  function vec_to_string($v) {
+  global $INITIAL_VECTORS, $PI, $TWO_PI, $VECTOR_1, $VECTOR_2, $VECTOR_3, $example;
   return '(' . _str($v['x']) . ', ' . _str($v['y']) . ')';
-}
-function vec_list_to_string($lst) {
-  global $PI, $TWO_PI, $VECTOR_1, $VECTOR_2, $VECTOR_3, $INITIAL_VECTORS, $example;
+};
+  function vec_list_to_string($lst) {
+  global $INITIAL_VECTORS, $PI, $TWO_PI, $VECTOR_1, $VECTOR_2, $VECTOR_3, $example;
   $res = '[';
   $i = 0;
   while ($i < count($lst)) {
@@ -99,10 +116,18 @@ function vec_list_to_string($lst) {
 };
   $res = $res . ']';
   return $res;
-}
-$VECTOR_1 = ['x' => 0.0, 'y' => 0.0];
-$VECTOR_2 = ['x' => 0.5, 'y' => 0.8660254];
-$VECTOR_3 = ['x' => 1.0, 'y' => 0.0];
-$INITIAL_VECTORS = [$VECTOR_1, $VECTOR_2, $VECTOR_3, $VECTOR_1];
-$example = iterate([$VECTOR_1, $VECTOR_3], 1);
-echo rtrim(vec_list_to_string($example)), PHP_EOL;
+};
+  $VECTOR_1 = ['x' => 0.0, 'y' => 0.0];
+  $VECTOR_2 = ['x' => 0.5, 'y' => 0.8660254];
+  $VECTOR_3 = ['x' => 1.0, 'y' => 0.0];
+  $INITIAL_VECTORS = [$VECTOR_1, $VECTOR_2, $VECTOR_3, $VECTOR_1];
+  $example = iterate([$VECTOR_1, $VECTOR_3], 1);
+  echo rtrim(vec_list_to_string($example)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/fractals/mandelbrot.bench
+++ b/tests/algorithms/x/PHP/fractals/mandelbrot.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 372,
+  "duration_us": 222,
   "memory_bytes": 41136,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/fractals/mandelbrot.php
+++ b/tests/algorithms/x/PHP/fractals/mandelbrot.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,11 +35,13 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function round_int($x) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function round_int($x) {
   global $img1, $img2;
   return intval(($x + 0.5));
-}
-function hsv_to_rgb($h, $s, $v) {
+};
+  function hsv_to_rgb($h, $s, $v) {
   global $img1, $img2;
   $i = intval(($h * 6.0));
   $f = $h * 6.0 - (floatval($i));
@@ -69,8 +86,8 @@ function hsv_to_rgb($h, $s, $v) {
 };
 }
   return ['r' => round_int($r * 255.0), 'g' => round_int($g * 255.0), 'b' => round_int($b * 255.0)];
-}
-function get_distance($x, $y, $max_step) {
+};
+  function get_distance($x, $y, $max_step) {
   global $img1, $img2;
   $a = $x;
   $b = $y;
@@ -85,24 +102,24 @@ function get_distance($x, $y, $max_step) {
 }
 };
   return (floatval($step)) / (floatval(($max_step - 1)));
-}
-function get_black_and_white_rgb($distance) {
+};
+  function get_black_and_white_rgb($distance) {
   global $img1, $img2;
   if ($distance == 1.0) {
   return ['r' => 0, 'g' => 0, 'b' => 0];
 } else {
   return ['r' => 255, 'g' => 255, 'b' => 255];
 }
-}
-function get_color_coded_rgb($distance) {
+};
+  function get_color_coded_rgb($distance) {
   global $img1, $img2;
   if ($distance == 1.0) {
   return ['r' => 0, 'g' => 0, 'b' => 0];
 } else {
   return hsv_to_rgb($distance, 1.0, 1.0);
 }
-}
-function get_image($image_width, $image_height, $figure_center_x, $figure_center_y, $figure_width, $max_step, $use_distance_color_coding) {
+};
+  function get_image($image_width, $image_height, $figure_center_x, $figure_center_y, $figure_width, $max_step, $use_distance_color_coding) {
   global $img1, $img2;
   $img = [];
   $figure_height = $figure_width / (floatval($image_width)) * (floatval($image_height));
@@ -127,12 +144,20 @@ function get_image($image_width, $image_height, $figure_center_x, $figure_center
   $image_y = $image_y + 1;
 };
   return $img;
-}
-function rgb_to_string($c) {
+};
+  function rgb_to_string($c) {
   global $img1, $img2;
   return '(' . _str($c['r']) . ', ' . _str($c['g']) . ', ' . _str($c['b']) . ')';
-}
-$img1 = get_image(10, 10, -0.6, 0.0, 3.2, 50, true);
-echo rtrim(rgb_to_string($img1[0][0])), PHP_EOL;
-$img2 = get_image(10, 10, -0.6, 0.0, 3.2, 50, false);
-echo rtrim(rgb_to_string($img2[0][0])), PHP_EOL;
+};
+  $img1 = get_image(10, 10, -0.6, 0.0, 3.2, 50, true);
+  echo rtrim(rgb_to_string($img1[0][0])), PHP_EOL;
+  $img2 = get_image(10, 10, -0.6, 0.0, 3.2, 50, false);
+  echo rtrim(rgb_to_string($img2[0][0])), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/fractals/sierpinski_triangle.bench
+++ b/tests/algorithms/x/PHP/fractals/sierpinski_triangle.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 112,
+  "duration_us": 70,
   "memory_bytes": 39432,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/fractals/sierpinski_triangle.php
+++ b/tests/algorithms/x/PHP/fractals/sierpinski_triangle.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,13 +31,15 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-function get_mid($p1, $p2) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function get_mid($p1, $p2) {
   return ['x' => ($p1['x'] + $p2['x']) / 2, 'y' => ($p1['y'] + $p2['y']) / 2];
-}
-function point_to_string($p) {
+};
+  function point_to_string($p) {
   return '(' . _str($p['x']) . ',' . _str($p['y']) . ')';
-}
-function triangle($v1, $v2, $v3, $depth) {
+};
+  function triangle($v1, $v2, $v3, $depth) {
   echo rtrim(point_to_string($v1) . ' ' . point_to_string($v2) . ' ' . point_to_string($v3)), PHP_EOL;
   if ($depth == 0) {
   return;
@@ -30,5 +47,13 @@ function triangle($v1, $v2, $v3, $depth) {
   triangle($v1, get_mid($v1, $v2), get_mid($v1, $v3), $depth - 1);
   triangle($v2, get_mid($v1, $v2), get_mid($v2, $v3), $depth - 1);
   triangle($v3, get_mid($v3, $v2), get_mid($v1, $v3), $depth - 1);
-}
-triangle(['x' => -175, 'y' => -125], ['x' => 0, 'y' => 175], ['x' => 175, 'y' => -125], 2);
+};
+  triangle(['x' => -175, 'y' => -125], ['x' => 0, 'y' => 175], ['x' => 175, 'y' => -125], 2);
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/fractals/vicsek.bench
+++ b/tests/algorithms/x/PHP/fractals/vicsek.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 117,
+  "duration_us": 132,
   "memory_bytes": 36400,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/fractals/vicsek.php
+++ b/tests/algorithms/x/PHP/fractals/vicsek.php
@@ -1,10 +1,27 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function repeat_char($c, $count) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function repeat_char($c, $count) {
   $s = '';
   $i = 0;
   while ($i < $count) {
@@ -12,8 +29,8 @@ function repeat_char($c, $count) {
   $i = $i + 1;
 };
   return $s;
-}
-function vicsek($order) {
+};
+  function vicsek($order) {
   if ($order == 0) {
   return ['#'];
 }
@@ -37,17 +54,25 @@ function vicsek($order) {
   $i = $i + 1;
 };
   return $result;
-}
-function print_pattern($pattern) {
+};
+  function print_pattern($pattern) {
   $i = 0;
   while ($i < count($pattern)) {
   echo rtrim($pattern[$i]), PHP_EOL;
   $i = $i + 1;
 };
-}
-function main() {
+};
+  function main() {
   $depth = 3;
   $pattern = vicsek($depth);
   print_pattern($pattern);
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/fuzzy_logic/fuzzy_operations.bench
+++ b/tests/algorithms/x/PHP/fuzzy_logic/fuzzy_operations.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 132,
+  "duration_us": 75,
   "memory_bytes": 38696,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/fuzzy_logic/fuzzy_operations.php
+++ b/tests/algorithms/x/PHP/fuzzy_logic/fuzzy_operations.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,38 +31,40 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-function stringify($fs) {
-  global $sheru, $siya, $sheru_comp, $inter, $uni;
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function stringify($fs) {
+  global $inter, $sheru, $sheru_comp, $siya, $uni;
   return $fs['name'] . ': [' . _str($fs['left_boundary']) . ', ' . _str($fs['peak']) . ', ' . _str($fs['right_boundary']) . ']';
-}
-function max2($a, $b) {
-  global $sheru, $siya, $sheru_comp, $inter, $uni;
+};
+  function max2($a, $b) {
+  global $inter, $sheru, $sheru_comp, $siya, $uni;
   if ($a > $b) {
   return $a;
 }
   return $b;
-}
-function min2($a, $b) {
-  global $sheru, $siya, $sheru_comp, $inter, $uni;
+};
+  function min2($a, $b) {
+  global $inter, $sheru, $sheru_comp, $siya, $uni;
   if ($a < $b) {
   return $a;
 }
   return $b;
-}
-function complement($fs) {
-  global $sheru, $siya, $sheru_comp, $inter, $uni;
+};
+  function complement($fs) {
+  global $inter, $sheru, $sheru_comp, $siya, $uni;
   return ['name' => '¬' . $fs['name'], 'left_boundary' => 1.0 - $fs['right_boundary'], 'peak' => 1.0 - $fs['left_boundary'], 'right_boundary' => 1.0 - $fs['peak']];
-}
-function intersection($a, $b) {
-  global $sheru, $siya, $sheru_comp, $inter, $uni;
+};
+  function intersection($a, $b) {
+  global $inter, $sheru, $sheru_comp, $siya, $uni;
   return ['name' => $a['name'] . ' ∩ ' . $b['name'], 'left_boundary' => max2($a['left_boundary'], $b['left_boundary']), 'peak' => min2($a['right_boundary'], $b['right_boundary']), 'right_boundary' => ($a['peak'] + $b['peak']) / 2.0];
-}
-function union($a, $b) {
-  global $sheru, $siya, $sheru_comp, $inter, $uni;
+};
+  function union($a, $b) {
+  global $inter, $sheru, $sheru_comp, $siya, $uni;
   return ['name' => $a['name'] . ' U ' . $b['name'], 'left_boundary' => min2($a['left_boundary'], $b['left_boundary']), 'peak' => max2($a['right_boundary'], $b['right_boundary']), 'right_boundary' => ($a['peak'] + $b['peak']) / 2.0];
-}
-function membership($fs, $x) {
-  global $sheru, $siya, $sheru_comp, $inter, $uni;
+};
+  function membership($fs, $x) {
+  global $inter, $sheru, $sheru_comp, $siya, $uni;
   if ($x <= $fs['left_boundary'] || $x >= $fs['right_boundary']) {
   return 0.0;
 }
@@ -58,16 +75,24 @@ function membership($fs, $x) {
   return ($fs['right_boundary'] - $x) / ($fs['right_boundary'] - $fs['peak']);
 }
   return 0.0;
-}
-$sheru = ['name' => 'Sheru', 'left_boundary' => 0.4, 'peak' => 1.0, 'right_boundary' => 0.6];
-$siya = ['name' => 'Siya', 'left_boundary' => 0.5, 'peak' => 1.0, 'right_boundary' => 0.7];
-echo rtrim(stringify($sheru)), PHP_EOL;
-echo rtrim(stringify($siya)), PHP_EOL;
-$sheru_comp = complement($sheru);
-echo rtrim(stringify($sheru_comp)), PHP_EOL;
-$inter = intersection($siya, $sheru);
-echo rtrim(stringify($inter)), PHP_EOL;
-echo rtrim('Sheru membership 0.5: ' . _str(membership($sheru, 0.5))), PHP_EOL;
-echo rtrim('Sheru membership 0.6: ' . _str(membership($sheru, 0.6))), PHP_EOL;
-$uni = union($siya, $sheru);
-echo rtrim(stringify($uni)), PHP_EOL;
+};
+  $sheru = ['name' => 'Sheru', 'left_boundary' => 0.4, 'peak' => 1.0, 'right_boundary' => 0.6];
+  $siya = ['name' => 'Siya', 'left_boundary' => 0.5, 'peak' => 1.0, 'right_boundary' => 0.7];
+  echo rtrim(stringify($sheru)), PHP_EOL;
+  echo rtrim(stringify($siya)), PHP_EOL;
+  $sheru_comp = complement($sheru);
+  echo rtrim(stringify($sheru_comp)), PHP_EOL;
+  $inter = intersection($siya, $sheru);
+  echo rtrim(stringify($inter)), PHP_EOL;
+  echo rtrim('Sheru membership 0.5: ' . _str(membership($sheru, 0.5))), PHP_EOL;
+  echo rtrim('Sheru membership 0.6: ' . _str(membership($sheru, 0.6))), PHP_EOL;
+  $uni = union($siya, $sheru);
+  echo rtrim(stringify($uni)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/genetic_algorithm/basic_string.bench
+++ b/tests/algorithms/x/PHP/genetic_algorithm/basic_string.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 146,
+  "duration_us": 83,
   "memory_bytes": 36144,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/genetic_algorithm/basic_string.php
+++ b/tests/algorithms/x/PHP/genetic_algorithm/basic_string.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,7 +31,9 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-function evaluate($item, $target) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function evaluate($item, $target) {
   $score = 0;
   $i = 0;
   while ($i < strlen($item) && $i < strlen($target)) {
@@ -26,26 +43,34 @@ function evaluate($item, $target) {
   $i = $i + 1;
 };
   return $score;
-}
-function crossover($parent1, $parent2) {
+};
+  function crossover($parent1, $parent2) {
   $cut = strlen($parent1) / 2;
-  $child1 = substr($parent1, 0, $cut - 0) . substr($parent2, $cut, strlen($parent2) - $cut);
-  $child2 = substr($parent2, 0, $cut - 0) . substr($parent1, $cut, strlen($parent1) - $cut);
+  $child1 = substr($parent1, 0, $cut) . substr($parent2, $cut, strlen($parent2) - $cut);
+  $child2 = substr($parent2, 0, $cut) . substr($parent1, $cut, strlen($parent1) - $cut);
   return ['first' => $child1, 'second' => $child2];
-}
-function mutate($child, $genes) {
+};
+  function mutate($child, $genes) {
   if (strlen($child) == 0) {
   return $child;
 }
   $gene = $genes[0];
-  return substr($child, 0, strlen($child) - 1 - 0) . $gene;
-}
-function main() {
+  return substr($child, 0, strlen($child) - 1) . $gene;
+};
+  function main() {
   echo rtrim(_str(evaluate('Helxo Worlx', 'Hello World'))), PHP_EOL;
   $pair = crossover('123456', 'abcdef');
   echo rtrim(json_encode($pair['first'], 1344)), PHP_EOL;
   echo rtrim(json_encode($pair['second'], 1344)), PHP_EOL;
   $mut = mutate('123456', ['A', 'B', 'C', 'D', 'E', 'F']);
   echo rtrim($mut), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/geodesy/haversine_distance.bench
+++ b/tests/algorithms/x/PHP/geodesy/haversine_distance.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 107,
+  "duration_us": 75,
   "memory_bytes": 40800,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/geodesy/haversine_distance.php
+++ b/tests/algorithms/x/PHP/geodesy/haversine_distance.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,16 +31,18 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-$PI = 3.141592653589793;
-$AXIS_A = 6378137.0;
-$AXIS_B = 6356752.314245;
-$RADIUS = 6378137.0;
-function to_radians($deg) {
-  global $PI, $AXIS_A, $AXIS_B, $RADIUS, $SAN_FRANCISCO, $YOSEMITE;
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $PI = 3.141592653589793;
+  $AXIS_A = 6378137.0;
+  $AXIS_B = 6356752.314245;
+  $RADIUS = 6378137.0;
+  function to_radians($deg) {
+  global $AXIS_A, $AXIS_B, $PI, $RADIUS, $SAN_FRANCISCO, $YOSEMITE;
   return $deg * $PI / 180.0;
-}
-function sin_taylor($x) {
-  global $PI, $AXIS_A, $AXIS_B, $RADIUS, $SAN_FRANCISCO, $YOSEMITE;
+};
+  function sin_taylor($x) {
+  global $AXIS_A, $AXIS_B, $PI, $RADIUS, $SAN_FRANCISCO, $YOSEMITE;
   $term = $x;
   $sum = $x;
   $i = 1;
@@ -37,9 +54,9 @@ function sin_taylor($x) {
   $i = $i + 1;
 };
   return $sum;
-}
-function cos_taylor($x) {
-  global $PI, $AXIS_A, $AXIS_B, $RADIUS, $SAN_FRANCISCO, $YOSEMITE;
+};
+  function cos_taylor($x) {
+  global $AXIS_A, $AXIS_B, $PI, $RADIUS, $SAN_FRANCISCO, $YOSEMITE;
   $term = 1.0;
   $sum = 1.0;
   $i = 1;
@@ -51,13 +68,13 @@ function cos_taylor($x) {
   $i = $i + 1;
 };
   return $sum;
-}
-function tan_approx($x) {
-  global $PI, $AXIS_A, $AXIS_B, $RADIUS, $SAN_FRANCISCO, $YOSEMITE;
+};
+  function tan_approx($x) {
+  global $AXIS_A, $AXIS_B, $PI, $RADIUS, $SAN_FRANCISCO, $YOSEMITE;
   return sin_taylor($x) / cos_taylor($x);
-}
-function sqrtApprox($x) {
-  global $PI, $AXIS_A, $AXIS_B, $RADIUS, $SAN_FRANCISCO, $YOSEMITE;
+};
+  function sqrtApprox($x) {
+  global $AXIS_A, $AXIS_B, $PI, $RADIUS, $SAN_FRANCISCO, $YOSEMITE;
   $guess = $x / 2.0;
   $i = 0;
   while ($i < 20) {
@@ -65,9 +82,9 @@ function sqrtApprox($x) {
   $i = $i + 1;
 };
   return $guess;
-}
-function atanApprox($x) {
-  global $PI, $AXIS_A, $AXIS_B, $RADIUS, $SAN_FRANCISCO, $YOSEMITE;
+};
+  function atanApprox($x) {
+  global $AXIS_A, $AXIS_B, $PI, $RADIUS, $SAN_FRANCISCO, $YOSEMITE;
   if ($x > 1.0) {
   return $PI / 2.0 - $x / ($x * $x + 0.28);
 }
@@ -75,9 +92,9 @@ function atanApprox($x) {
   return -$PI / 2.0 - $x / ($x * $x + 0.28);
 }
   return $x / (1.0 + 0.28 * $x * $x);
-}
-function atan2Approx($y, $x) {
-  global $PI, $AXIS_A, $AXIS_B, $RADIUS, $SAN_FRANCISCO, $YOSEMITE;
+};
+  function atan2Approx($y, $x) {
+  global $AXIS_A, $AXIS_B, $PI, $RADIUS, $SAN_FRANCISCO, $YOSEMITE;
   if ($x > 0.0) {
   $val = atanApprox($y / $x);
   return $val;
@@ -95,15 +112,15 @@ function atan2Approx($y, $x) {
   return -$PI / 2.0;
 }
   return 0.0;
-}
-function asinApprox($x) {
-  global $PI, $AXIS_A, $AXIS_B, $RADIUS, $SAN_FRANCISCO, $YOSEMITE;
+};
+  function asinApprox($x) {
+  global $AXIS_A, $AXIS_B, $PI, $RADIUS, $SAN_FRANCISCO, $YOSEMITE;
   $denom = sqrtApprox(1.0 - $x * $x);
   $res = atan2Approx($x, $denom);
   return $res;
-}
-function haversine_distance($lat1, $lon1, $lat2, $lon2) {
-  global $PI, $AXIS_A, $AXIS_B, $RADIUS, $SAN_FRANCISCO, $YOSEMITE;
+};
+  function haversine_distance($lat1, $lon1, $lat2, $lon2) {
+  global $AXIS_A, $AXIS_B, $PI, $RADIUS, $SAN_FRANCISCO, $YOSEMITE;
   $flattening = ($AXIS_A - $AXIS_B) / $AXIS_A;
   $phi_1 = atanApprox((1.0 - $flattening) * tan_approx(to_radians($lat1)));
   $phi_2 = atanApprox((1.0 - $flattening) * tan_approx(to_radians($lat2)));
@@ -115,7 +132,15 @@ function haversine_distance($lat1, $lon1, $lat2, $lon2) {
   $sin_sq_lambda = $sin_sq_lambda * $sin_sq_lambda;
   $h_value = sqrtApprox($sin_sq_phi + cos_taylor($phi_1) * cos_taylor($phi_2) * $sin_sq_lambda);
   return 2.0 * $RADIUS * asinApprox($h_value);
-}
-$SAN_FRANCISCO = [37.774856, -122.424227];
-$YOSEMITE = [37.864742, -119.537521];
-echo rtrim(_str(haversine_distance($SAN_FRANCISCO[0], $SAN_FRANCISCO[1], $YOSEMITE[0], $YOSEMITE[1]))), PHP_EOL;
+};
+  $SAN_FRANCISCO = [37.774856, -122.424227];
+  $YOSEMITE = [37.864742, -119.537521];
+  echo rtrim(_str(haversine_distance($SAN_FRANCISCO[0], $SAN_FRANCISCO[1], $YOSEMITE[0], $YOSEMITE[1]))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/geodesy/lamberts_ellipsoidal_distance.bench
+++ b/tests/algorithms/x/PHP/geodesy/lamberts_ellipsoidal_distance.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 106,
+  "duration_us": 57,
   "memory_bytes": 35656,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/geodesy/lamberts_ellipsoidal_distance.php
+++ b/tests/algorithms/x/PHP/geodesy/lamberts_ellipsoidal_distance.php
@@ -1,13 +1,30 @@
 <?php
 ini_set('memory_limit', '-1');
-$PI = 3.141592653589793;
-$EQUATORIAL_RADIUS = 6378137.0;
-function to_radians($deg) {
-  global $PI, $EQUATORIAL_RADIUS;
-  return $deg * $PI / 180.0;
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
 }
-function sin_approx($x) {
-  global $PI, $EQUATORIAL_RADIUS;
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $PI = 3.141592653589793;
+  $EQUATORIAL_RADIUS = 6378137.0;
+  function to_radians($deg) {
+  global $EQUATORIAL_RADIUS, $PI;
+  return $deg * $PI / 180.0;
+};
+  function sin_approx($x) {
+  global $EQUATORIAL_RADIUS, $PI;
   $term = $x;
   $sum = $x;
   $i = 1;
@@ -19,9 +36,9 @@ function sin_approx($x) {
   $i = $i + 1;
 };
   return $sum;
-}
-function cos_approx($x) {
-  global $PI, $EQUATORIAL_RADIUS;
+};
+  function cos_approx($x) {
+  global $EQUATORIAL_RADIUS, $PI;
   $term = 1.0;
   $sum = 1.0;
   $i = 1;
@@ -33,9 +50,9 @@ function cos_approx($x) {
   $i = $i + 1;
 };
   return $sum;
-}
-function sqrt_approx($x) {
-  global $PI, $EQUATORIAL_RADIUS;
+};
+  function sqrt_approx($x) {
+  global $EQUATORIAL_RADIUS, $PI;
   if ($x <= 0.0) {
   return 0.0;
 }
@@ -46,9 +63,9 @@ function sqrt_approx($x) {
   $i = $i + 1;
 };
   return $guess;
-}
-function lamberts_ellipsoidal_distance($lat1, $lon1, $lat2, $lon2) {
-  global $PI, $EQUATORIAL_RADIUS;
+};
+  function lamberts_ellipsoidal_distance($lat1, $lon1, $lat2, $lon2) {
+  global $EQUATORIAL_RADIUS, $PI;
   $phi1 = to_radians($lat1);
   $phi2 = to_radians($lat2);
   $lambda1 = to_radians($lon1);
@@ -56,7 +73,15 @@ function lamberts_ellipsoidal_distance($lat1, $lon1, $lat2, $lon2) {
   $x = ($lambda2 - $lambda1) * cos_approx(($phi1 + $phi2) / 2.0);
   $y = $phi2 - $phi1;
   return $EQUATORIAL_RADIUS * sqrt_approx($x * $x + $y * $y);
-}
-echo rtrim(json_encode(lamberts_ellipsoidal_distance(37.774856, -122.424227, 37.864742, -119.537521), 1344)), PHP_EOL;
-echo rtrim(json_encode(lamberts_ellipsoidal_distance(37.774856, -122.424227, 40.713019, -74.012647), 1344)), PHP_EOL;
-echo rtrim(json_encode(lamberts_ellipsoidal_distance(37.774856, -122.424227, 45.443012, 12.313071), 1344)), PHP_EOL;
+};
+  echo rtrim(json_encode(lamberts_ellipsoidal_distance(37.774856, -122.424227, 37.864742, -119.537521), 1344)), PHP_EOL;
+  echo rtrim(json_encode(lamberts_ellipsoidal_distance(37.774856, -122.424227, 40.713019, -74.012647), 1344)), PHP_EOL;
+  echo rtrim(json_encode(lamberts_ellipsoidal_distance(37.774856, -122.424227, 45.443012, 12.313071), 1344)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/geometry/geometry.bench
+++ b/tests/algorithms/x/PHP/geometry/geometry.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 139,
-  "memory_bytes": 40072,
+  "duration_us": 95,
+  "memory_bytes": 40296,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/geometry/geometry.php
+++ b/tests/algorithms/x/PHP/geometry/geometry.php
@@ -1,78 +1,99 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-$PI = 3.141592653589793;
-function make_angle($deg) {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $PI = 3.141592653589793;
+  function make_angle($deg) {
   global $PI;
   if ($deg < 0.0 || $deg > 360.0) {
-  $panic('degrees must be between 0 and 360');
+  _panic('degrees must be between 0 and 360');
 }
   return ['degrees' => $deg];
-}
-function make_side($length, $angle) {
+};
+  function make_side($length, $angle) {
   global $PI;
   if ($length <= 0.0) {
-  $panic('length must be positive');
+  _panic('length must be positive');
 }
   return ['length' => $length, 'angle' => $angle, 'next' => -1];
-}
-function ellipse_area($e) {
+};
+  function ellipse_area($e) {
   global $PI;
   return $PI * $e['major'] * $e['minor'];
-}
-function ellipse_perimeter($e) {
+};
+  function ellipse_perimeter($e) {
   global $PI;
   return $PI * ($e['major'] + $e['minor']);
-}
-function circle_area($c) {
+};
+  function circle_area($c) {
   global $PI;
   $e = ['major' => $c['radius'], 'minor' => $c['radius']];
   $area = ellipse_area($e);
   return $area;
-}
-function circle_perimeter($c) {
+};
+  function circle_perimeter($c) {
   global $PI;
   $e = ['major' => $c['radius'], 'minor' => $c['radius']];
   $per = ellipse_perimeter($e);
   return $per;
-}
-function circle_diameter($c) {
+};
+  function circle_diameter($c) {
   global $PI;
   return $c['radius'] * 2.0;
-}
-function circle_max_parts($num_cuts) {
+};
+  function circle_max_parts($num_cuts) {
   global $PI;
   if ($num_cuts < 0.0) {
-  $panic('num_cuts must be positive');
+  _panic('num_cuts must be positive');
 }
   return ($num_cuts + 2.0 + $num_cuts * $num_cuts) * 0.5;
-}
-function make_polygon() {
+};
+  function make_polygon() {
   global $PI;
   $s = [];
   return ['sides' => $s];
-}
-function polygon_add_side(&$p, $s) {
+};
+  function polygon_add_side(&$p, $s) {
   global $PI;
   $p['sides'] = _append($p['sides'], $s);
-}
-function polygon_get_side($p, $index) {
+};
+  function polygon_get_side($p, $index) {
   global $PI;
   return $p['sides'][$index];
-}
-function polygon_set_side(&$p, $index, $s) {
+};
+  function polygon_set_side(&$p, $index, $s) {
   global $PI;
   $tmp = $p['sides'];
   $tmp[$index] = $s;
   $p['sides'] = $tmp;
-}
-function make_rectangle($short_len, $long_len) {
+};
+  function make_rectangle($short_len, $long_len) {
   global $PI;
   if ($short_len <= 0.0 || $long_len <= 0.0) {
-  $panic('length must be positive');
+  _panic('length must be positive');
 }
   $short = make_side($short_len, make_angle(90.0));
   $long = make_side($long_len, make_angle(90.0));
@@ -80,31 +101,31 @@ function make_rectangle($short_len, $long_len) {
   polygon_add_side($p, $short);
   polygon_add_side($p, $long);
   return ['short_side' => $short, 'long_side' => $long, 'poly' => $p];
-}
-function rectangle_perimeter($r) {
+};
+  function rectangle_perimeter($r) {
   global $PI;
   return ($r['short_side']['length'] + $r['long_side']['length']) * 2.0;
-}
-function rectangle_area($r) {
+};
+  function rectangle_area($r) {
   global $PI;
   return $r['short_side']['length'] * $r['long_side']['length'];
-}
-function make_square($side_len) {
+};
+  function make_square($side_len) {
   global $PI;
   $rect = make_rectangle($side_len, $side_len);
   return ['side' => $rect['short_side'], 'rect' => $rect];
-}
-function square_perimeter($s) {
+};
+  function square_perimeter($s) {
   global $PI;
   $p = rectangle_perimeter($s['rect']);
   return $p;
-}
-function square_area($s) {
+};
+  function square_area($s) {
   global $PI;
   $a = rectangle_area($s['rect']);
   return $a;
-}
-function main() {
+};
+  function main() {
   global $PI;
   $a = make_angle(90.0);
   echo rtrim(json_encode($a['degrees'], 1344)), PHP_EOL;
@@ -124,5 +145,13 @@ function main() {
   $q = make_square(5.0);
   echo rtrim(json_encode(square_perimeter($q), 1344)), PHP_EOL;
   echo rtrim(json_encode(square_area($q), 1344)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphics/bezier_curve.bench
+++ b/tests/algorithms/x/PHP/graphics/bezier_curve.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 176,
+  "duration_us": 113,
   "memory_bytes": 40064,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphics/bezier_curve.php
+++ b/tests/algorithms/x/PHP/graphics/bezier_curve.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,7 +35,9 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function n_choose_k($n, $k) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function n_choose_k($n, $k) {
   global $control;
   if ($k < 0 || $k > $n) {
   return 0.0;
@@ -35,8 +52,8 @@ function n_choose_k($n, $k) {
   $i = $i + 1;
 };
   return $result;
-}
-function pow_float($base, $exp) {
+};
+  function pow_float($base, $exp) {
   global $control;
   $result = 1.0;
   $i = 0;
@@ -45,8 +62,8 @@ function pow_float($base, $exp) {
   $i = $i + 1;
 };
   return $result;
-}
-function basis_function($points, $t) {
+};
+  function basis_function($points, $t) {
   global $control;
   $degree = count($points) - 1;
   $res = [];
@@ -58,8 +75,8 @@ function basis_function($points, $t) {
   $i = $i + 1;
 };
   return $res;
-}
-function bezier_point($points, $t) {
+};
+  function bezier_point($points, $t) {
   global $control;
   $basis = basis_function($points, $t);
   $x = 0.0;
@@ -71,9 +88,17 @@ function bezier_point($points, $t) {
   $i = $i + 1;
 };
   return [$x, $y];
-}
-$control = [[1.0, 1.0], [1.0, 2.0]];
-echo rtrim(_str(basis_function($control, 0.0))), PHP_EOL;
-echo rtrim(_str(basis_function($control, 1.0))), PHP_EOL;
-echo rtrim(_str(bezier_point($control, 0.0))), PHP_EOL;
-echo rtrim(_str(bezier_point($control, 1.0))), PHP_EOL;
+};
+  $control = [[1.0, 1.0], [1.0, 2.0]];
+  echo rtrim(_str(basis_function($control, 0.0))), PHP_EOL;
+  echo rtrim(_str(basis_function($control, 1.0))), PHP_EOL;
+  echo rtrim(_str(bezier_point($control, 0.0))), PHP_EOL;
+  echo rtrim(_str(bezier_point($control, 1.0))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphics/butterfly_pattern.bench
+++ b/tests/algorithms/x/PHP/graphics/butterfly_pattern.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 124,
+  "duration_us": 86,
   "memory_bytes": 40376,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphics/butterfly_pattern.php
+++ b/tests/algorithms/x/PHP/graphics/butterfly_pattern.php
@@ -1,10 +1,27 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function repeat_char($ch, $count) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function repeat_char($ch, $count) {
   $result = '';
   $i = 0;
   while ($i < $count) {
@@ -12,8 +29,8 @@ function repeat_char($ch, $count) {
   $i = $i + 1;
 };
   return $result;
-}
-function butterfly_pattern($n) {
+};
+  function butterfly_pattern($n) {
   $lines = [];
   $i = 1;
   while ($i < $n) {
@@ -43,6 +60,14 @@ function butterfly_pattern($n) {
   $k = $k + 1;
 };
   return $out;
-}
-echo rtrim(butterfly_pattern(3)), PHP_EOL;
-echo rtrim(butterfly_pattern(5)), PHP_EOL;
+};
+  echo rtrim(butterfly_pattern(3)), PHP_EOL;
+  echo rtrim(butterfly_pattern(5)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphics/digital_differential_analyzer_line.bench
+++ b/tests/algorithms/x/PHP/graphics/digital_differential_analyzer_line.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 135,
-  "memory_bytes": 38584,
+  "duration_us": 74,
+  "memory_bytes": 38808,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphics/digital_differential_analyzer_line.php
+++ b/tests/algorithms/x/PHP/graphics/digital_differential_analyzer_line.php
@@ -1,19 +1,36 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function abs_int($n) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function abs_int($n) {
   if ($n < 0) {
   return -$n;
 }
   return $n;
-}
-function round_int($x) {
+};
+  function round_int($x) {
   return intval(($x + 0.5));
-}
-function digital_differential_analyzer_line($p1, $p2) {
+};
+  function digital_differential_analyzer_line($p1, $p2) {
   $dx = $p2['x'] - $p1['x'];
   $dy = $p2['y'] - $p1['y'];
   $abs_dx = abs_int($dx);
@@ -33,9 +50,17 @@ function digital_differential_analyzer_line($p1, $p2) {
   $i = $i + 1;
 };
   return $coordinates;
-}
-function main() {
+};
+  function main() {
   $result = digital_differential_analyzer_line(['x' => 1, 'y' => 1], ['x' => 4, 'y' => 4]);
   echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode($result, 1344)))))), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/transpiler/x/php/ALGORITHMS.md
+++ b/transpiler/x/php/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated PHP code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/PHP`.
-Last updated: 2025-08-13 07:26 GMT+7
+Last updated: 2025-08-13 12:56 GMT+7
 
-## Algorithms Golden Test Checklist (976/1077)
+## Algorithms Golden Test Checklist (978/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 117µs | 38.8 KB |
@@ -349,56 +349,56 @@ Last updated: 2025-08-13 07:26 GMT+7
 | 340 | dynamic_programming/regex_match | ✓ | 186µs | 37.4 KB |
 | 341 | dynamic_programming/rod_cutting | ✓ | 79µs | 38.4 KB |
 | 342 | dynamic_programming/smith_waterman | ✓ | 98µs | 38.5 KB |
-| 343 | dynamic_programming/subset_generation | ✓ | 133µs | 39.8 KB |
-| 344 | dynamic_programming/sum_of_subset | ✓ | 148µs | 38.3 KB |
-| 345 | dynamic_programming/trapped_water | ✓ | 98µs | 39.9 KB |
-| 346 | dynamic_programming/tribonacci | ✓ | 69µs | 38.4 KB |
-| 347 | dynamic_programming/viterbi | ✓ | 111µs | 39.8 KB |
-| 348 | dynamic_programming/wildcard_matching | ✓ | 129µs | 39.9 KB |
-| 349 | dynamic_programming/word_break | ✓ | 147µs | 39.8 KB |
+| 343 | dynamic_programming/subset_generation | ✓ | 101µs | 39.8 KB |
+| 344 | dynamic_programming/sum_of_subset | ✓ | 90µs | 38.3 KB |
+| 345 | dynamic_programming/trapped_water | ✓ | 81µs | 40.0 KB |
+| 346 | dynamic_programming/tribonacci | ✓ | 88µs | 39.4 KB |
+| 347 | dynamic_programming/viterbi | ✓ | 133µs | 39.9 KB |
+| 348 | dynamic_programming/wildcard_matching | ✓ | 170µs | 39.9 KB |
+| 349 | dynamic_programming/word_break | ✓ | 106µs | 39.8 KB |
 | 350 | electronics/apparent_power | ✓ | 1µs | 35.9 KB |
-| 351 | electronics/builtin_voltage | ✓ | 61µs | 39.2 KB |
-| 352 | electronics/capacitor_equivalence | ✓ | 82µs | 36.3 KB |
-| 353 | electronics/carrier_concentration | ✓ | 111µs | 35.8 KB |
-| 354 | electronics/charging_capacitor | ✓ | 76µs | 35.1 KB |
-| 355 | electronics/charging_inductor | ✓ | 111µs | 35.0 KB |
-| 356 | electronics/circular_convolution | ✓ | 266µs | 35.4 KB |
-| 357 | electronics/coulombs_law | ✓ | 168µs | 39.2 KB |
-| 358 | electronics/electric_conductivity | ✓ | 189µs | 35.6 KB |
-| 359 | electronics/electric_power | ✓ | 77µs | 36.2 KB |
-| 360 | electronics/electrical_impedance | ✓ | 144µs | 36.3 KB |
-| 361 | electronics/ic_555_timer | ✓ | 63µs | 38.2 KB |
-| 362 | electronics/ind_reactance | ✓ | 91µs | 36.3 KB |
-| 363 | electronics/ohms_law | ✓ | 87µs | 39.0 KB |
-| 364 | electronics/real_and_reactive_power | error |  |  |
-| 365 | electronics/resistor_color_code | ✓ | 2µs | 72.7 KB |
-| 366 | electronics/resistor_equivalence | ✓ | 75µs | 36.4 KB |
-| 367 | electronics/resonant_frequency | ✓ | 62µs | 39.1 KB |
-| 368 | electronics/wheatstone_bridge | ✓ | 82µs | 38.2 KB |
-| 369 | file_transfer/receive_file | ✓ | 122µs | 35.8 KB |
-| 370 | file_transfer/send_file | ✓ | 68µs | 35.3 KB |
+| 351 | electronics/builtin_voltage | ✓ | 68µs | 39.4 KB |
+| 352 | electronics/capacitor_equivalence | ✓ | 48µs | 36.5 KB |
+| 353 | electronics/carrier_concentration | ✓ | 74µs | 36.0 KB |
+| 354 | electronics/charging_capacitor | ✓ | 56µs | 35.3 KB |
+| 355 | electronics/charging_inductor | ✓ | 71µs | 39.2 KB |
+| 356 | electronics/circular_convolution | ✓ | 117µs | 35.4 KB |
+| 357 | electronics/coulombs_law | ✓ | 94µs | 39.4 KB |
+| 358 | electronics/electric_conductivity | ✓ | 63µs | 35.8 KB |
+| 359 | electronics/electric_power | ✓ | 106µs | 36.2 KB |
+| 360 | electronics/electrical_impedance | ✓ | 67µs | 36.3 KB |
+| 361 | electronics/ic_555_timer | ✓ | 50µs | 38.4 KB |
+| 362 | electronics/ind_reactance | ✓ | 61µs | 36.3 KB |
+| 363 | electronics/ohms_law | ✓ | 63µs | 39.0 KB |
+| 364 | electronics/real_and_reactive_power | ✓ | 48µs | 35.7 KB |
+| 365 | electronics/resistor_color_code | ✓ | 1µs | 73.2 KB |
+| 366 | electronics/resistor_equivalence | ✓ | 68µs | 36.5 KB |
+| 367 | electronics/resonant_frequency | ✓ | 104µs | 39.3 KB |
+| 368 | electronics/wheatstone_bridge | ✓ | 51µs | 38.3 KB |
+| 369 | file_transfer/receive_file | ✓ | 43µs | 35.8 KB |
+| 370 | file_transfer/send_file | ✓ | 42µs | 35.3 KB |
 | 371 | file_transfer/tests/test_send_file | error |  |  |
-| 372 | financial/equated_monthly_installments | ✓ | 59µs | 38.8 KB |
-| 373 | financial/exponential_moving_average | ✓ | 154µs | 39.5 KB |
-| 374 | financial/interest | ✓ | 96µs | 40.4 KB |
-| 375 | financial/present_value | ✓ | 76µs | 39.1 KB |
-| 376 | financial/price_plus_tax | ✓ | 54µs | 38.7 KB |
-| 377 | financial/simple_moving_average | ✓ | 131µs | 39.1 KB |
-| 378 | financial/straight_line_depreciation | ✓ | 156µs | 35.6 KB |
-| 379 | financial/time_and_half_pay | ✓ | 59µs | 36.3 KB |
-| 380 | fractals/julia_sets | ✓ | 1.139ms | 37.3 KB |
-| 381 | fractals/koch_snowflake | error |  |  |
-| 382 | fractals/mandelbrot | ✓ | 372µs | 40.2 KB |
-| 383 | fractals/sierpinski_triangle | ✓ | 112µs | 38.5 KB |
-| 384 | fractals/vicsek | ✓ | 117µs | 35.5 KB |
-| 385 | fuzzy_logic/fuzzy_operations | ✓ | 132µs | 37.8 KB |
-| 386 | genetic_algorithm/basic_string | ✓ | 146µs | 35.3 KB |
-| 387 | geodesy/haversine_distance | ✓ | 107µs | 39.8 KB |
-| 388 | geodesy/lamberts_ellipsoidal_distance | ✓ | 106µs | 34.8 KB |
-| 389 | geometry/geometry | ✓ | 139µs | 39.1 KB |
-| 390 | graphics/bezier_curve | ✓ | 176µs | 39.1 KB |
-| 391 | graphics/butterfly_pattern | ✓ | 124µs | 39.4 KB |
-| 392 | graphics/digital_differential_analyzer_line | ✓ | 135µs | 37.7 KB |
+| 372 | financial/equated_monthly_installments | ✓ | 81µs | 39.0 KB |
+| 373 | financial/exponential_moving_average | ✓ | 109µs | 39.6 KB |
+| 374 | financial/interest | ✓ | 138µs | 40.4 KB |
+| 375 | financial/present_value | ✓ | 89µs | 39.2 KB |
+| 376 | financial/price_plus_tax | ✓ | 37µs | 38.7 KB |
+| 377 | financial/simple_moving_average | ✓ | 95µs | 39.2 KB |
+| 378 | financial/straight_line_depreciation | ✓ | 134µs | 35.8 KB |
+| 379 | financial/time_and_half_pay | ✓ | 58µs | 36.3 KB |
+| 380 | fractals/julia_sets | ✓ | 757µs | 37.3 KB |
+| 381 | fractals/koch_snowflake | ✓ | 94µs | 39.6 KB |
+| 382 | fractals/mandelbrot | ✓ | 222µs | 40.2 KB |
+| 383 | fractals/sierpinski_triangle | ✓ | 70µs | 38.5 KB |
+| 384 | fractals/vicsek | ✓ | 132µs | 35.5 KB |
+| 385 | fuzzy_logic/fuzzy_operations | ✓ | 75µs | 37.8 KB |
+| 386 | genetic_algorithm/basic_string | ✓ | 83µs | 35.3 KB |
+| 387 | geodesy/haversine_distance | ✓ | 75µs | 39.8 KB |
+| 388 | geodesy/lamberts_ellipsoidal_distance | ✓ | 57µs | 34.8 KB |
+| 389 | geometry/geometry | ✓ | 95µs | 39.4 KB |
+| 390 | graphics/bezier_curve | ✓ | 113µs | 39.1 KB |
+| 391 | graphics/butterfly_pattern | ✓ | 86µs | 39.4 KB |
+| 392 | graphics/digital_differential_analyzer_line | ✓ | 74µs | 37.9 KB |
 | 393 | graphics/vector3_for_2d_rendering | ✓ | 144µs | 39.5 KB |
 | 394 | graphs/a_star | ✓ | 213µs | 79.9 KB |
 | 395 | graphs/ant_colony_optimization_algorithms | ✓ | 9.918ms | 73.3 KB |

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-Last updated: 2025-08-12 14:22 +0700
+Last updated: 2025-08-13 12:32 +0700
 
 ## VM Golden Test Checklist (103/105)
 - [x] append_builtin

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,4 +1,4 @@
-## Progress (2025-08-12 14:22 +0700)
+## Progress (2025-08-13 12:32 +0700)
 - Generated PHP for 103/105 programs
 - Updated README checklist and outputs
 - Enhanced printing to match golden format

--- a/transpiler/x/php/transpiler.go
+++ b/transpiler/x/php/transpiler.go
@@ -373,6 +373,12 @@ var phpReserved = map[string]struct{}{
 	"date":          {},
 }
 
+func init() {
+	for name := range builtinNames {
+		phpReserved[name] = struct{}{}
+	}
+}
+
 // phpReservedVar lists variable names that cannot be used directly in PHP
 // programs. The transpiler renames these variables to avoid runtime errors.
 var phpReservedVar = map[string]struct{}{


### PR DESCRIPTION
## Summary
- ensure PHP built-ins are treated as reserved and auto-prefixed
- regenerate PHP algorithm outputs for TheAlgorithms tests
- update progress docs and benchmarks

## Testing
- `MOCHI_ALG_INDEX=364 MOCHI_BENCHMARK=1 go test ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags=slow -update-algorithms-php`


------
https://chatgpt.com/codex/tasks/task_e_689c27994b048320813e422d3c43c1d2