### PR TITLE
chore(fs): update algorithm outputs

### DIFF
--- a/tests/algorithms/transpiler/FS/dynamic_programming/trapped_water.bench
+++ b/tests/algorithms/transpiler/FS/dynamic_programming/trapped_water.bench
@@ -1,5 +1,5 @@
 {
   "duration_us": 571223,
-  "memory_bytes": 83816,
+  "memory_bytes": 79800,
   "name": "main"
 }

--- a/tests/algorithms/transpiler/FS/dynamic_programming/trapped_water.fs
+++ b/tests/algorithms/transpiler/FS/dynamic_programming/trapped_water.fs
@@ -1,4 +1,4 @@
-// Generated 2025-08-13 07:12 +0700
+// Generated 2025-08-13 16:00 +0700
 
 exception Return
 let mutable _nowSeed:int64 = 0L

--- a/tests/algorithms/transpiler/FS/dynamic_programming/tribonacci.bench
+++ b/tests/algorithms/transpiler/FS/dynamic_programming/tribonacci.bench
@@ -1,5 +1,5 @@
 {
   "duration_us": 571223,
-  "memory_bytes": 61920,
+  "memory_bytes": 56520,
   "name": "main"
 }

--- a/tests/algorithms/transpiler/FS/dynamic_programming/tribonacci.fs
+++ b/tests/algorithms/transpiler/FS/dynamic_programming/tribonacci.fs
@@ -1,4 +1,4 @@
-// Generated 2025-08-13 07:12 +0700
+// Generated 2025-08-13 16:00 +0700
 
 exception Return
 let mutable _nowSeed:int64 = 0L

--- a/tests/algorithms/transpiler/FS/dynamic_programming/viterbi.bench
+++ b/tests/algorithms/transpiler/FS/dynamic_programming/viterbi.bench
@@ -1,5 +1,5 @@
 {
   "duration_us": 571223,
-  "memory_bytes": 50160,
+  "memory_bytes": 38448,
   "name": "main"
 }

--- a/tests/algorithms/transpiler/FS/dynamic_programming/viterbi.fs
+++ b/tests/algorithms/transpiler/FS/dynamic_programming/viterbi.fs
@@ -1,4 +1,4 @@
-// Generated 2025-08-13 07:12 +0700
+// Generated 2025-08-13 16:00 +0700
 
 exception Return
 let mutable _nowSeed:int64 = 0L

--- a/tests/algorithms/transpiler/FS/dynamic_programming/wildcard_matching.bench
+++ b/tests/algorithms/transpiler/FS/dynamic_programming/wildcard_matching.bench
@@ -1,5 +1,5 @@
 {
   "duration_us": 571223,
-  "memory_bytes": 36360,
+  "memory_bytes": 43536,
   "name": "main"
 }

--- a/tests/algorithms/transpiler/FS/dynamic_programming/wildcard_matching.fs
+++ b/tests/algorithms/transpiler/FS/dynamic_programming/wildcard_matching.fs
@@ -1,4 +1,4 @@
-// Generated 2025-08-13 07:12 +0700
+// Generated 2025-08-13 16:00 +0700
 
 exception Return
 let mutable _nowSeed:int64 = 0L

--- a/tests/algorithms/transpiler/FS/dynamic_programming/word_break.bench
+++ b/tests/algorithms/transpiler/FS/dynamic_programming/word_break.bench
@@ -1,5 +1,5 @@
 {
   "duration_us": 571223,
-  "memory_bytes": 33456,
+  "memory_bytes": 37592,
   "name": "main"
 }

--- a/tests/algorithms/transpiler/FS/dynamic_programming/word_break.fs
+++ b/tests/algorithms/transpiler/FS/dynamic_programming/word_break.fs
@@ -1,4 +1,4 @@
-// Generated 2025-08-13 07:12 +0700
+// Generated 2025-08-13 16:00 +0700
 
 exception Return
 let mutable _nowSeed:int64 = 0L

--- a/tests/algorithms/transpiler/FS/physics/basic_orbital_capture.error
+++ b/tests/algorithms/transpiler/FS/physics/basic_orbital_capture.error
@@ -1,10 +1,10 @@
 exit status 1
 Unhandled Exception:
 System.Exception: capture_area failed
-  at Basic_orbital_capture.run_tests () [0x000d3] in <689b0adb9e5f4611a7450383db0a9b68>:0 
-  at Basic_orbital_capture.main () [0x000f4] in <689b0adb9e5f4611a7450383db0a9b68>:0 
-  at <StartupCode$basic_orbital_capture>.$Basic_orbital_capture.main@ () [0x00019] in <689b0adb9e5f4611a7450383db0a9b68>:0 
+  at Basic_orbital_capture.run_tests () [0x000d3] in <689c555d9e5f4611a74503835d559c68>:0 
+  at Basic_orbital_capture.main () [0x000f4] in <689c555d9e5f4611a74503835d559c68>:0 
+  at <StartupCode$basic_orbital_capture>.$Basic_orbital_capture.main@ () [0x00019] in <689c555d9e5f4611a74503835d559c68>:0 
 [ERROR] FATAL UNHANDLED EXCEPTION: System.Exception: capture_area failed
-  at Basic_orbital_capture.run_tests () [0x000d3] in <689b0adb9e5f4611a7450383db0a9b68>:0 
-  at Basic_orbital_capture.main () [0x000f4] in <689b0adb9e5f4611a7450383db0a9b68>:0 
-  at <StartupCode$basic_orbital_capture>.$Basic_orbital_capture.main@ () [0x00019] in <689b0adb9e5f4611a7450383db0a9b68>:0
+  at Basic_orbital_capture.run_tests () [0x000d3] in <689c555d9e5f4611a74503835d559c68>:0 
+  at Basic_orbital_capture.main () [0x000f4] in <689c555d9e5f4611a74503835d559c68>:0 
+  at <StartupCode$basic_orbital_capture>.$Basic_orbital_capture.main@ () [0x00019] in <689c555d9e5f4611a74503835d559c68>:0

--- a/tests/algorithms/transpiler/FS/physics/basic_orbital_capture.fs
+++ b/tests/algorithms/transpiler/FS/physics/basic_orbital_capture.fs
@@ -1,4 +1,4 @@
-// Generated 2025-08-12 16:24 +0700
+// Generated 2025-08-13 16:00 +0700
 
 exception Return
 let mutable _nowSeed:int64 = 0L

--- a/transpiler/x/fs/ALGORITHMS.md
+++ b/transpiler/x/fs/ALGORITHMS.md
@@ -1,7 +1,7 @@
 # F# Algorithms Transpiler Output
 
 Completed programs: 915/1077
-Last updated: 2025-08-13 12:32 +0700
+Last updated: 2025-08-13 16:00 +0700
 
 Checklist:
 
@@ -351,11 +351,11 @@ Checklist:
 | 342 | dynamic_programming/smith_waterman | ✓ | 571.223ms | 40.1 KB |
 | 343 | dynamic_programming/subset_generation | ✓ | 571.223ms | 78.3 KB |
 | 344 | dynamic_programming/sum_of_subset | ✓ | 571.223ms | 31.5 KB |
-| 345 | dynamic_programming/trapped_water | ✓ | 571.223ms | 81.9 KB |
-| 346 | dynamic_programming/tribonacci | ✓ | 571.223ms | 60.5 KB |
-| 347 | dynamic_programming/viterbi | ✓ | 571.223ms | 49.0 KB |
-| 348 | dynamic_programming/wildcard_matching | ✓ | 571.223ms | 35.5 KB |
-| 349 | dynamic_programming/word_break | ✓ | 571.223ms | 32.7 KB |
+| 345 | dynamic_programming/trapped_water | ✓ | 571.223ms | 77.9 KB |
+| 346 | dynamic_programming/tribonacci | ✓ | 571.223ms | 55.2 KB |
+| 347 | dynamic_programming/viterbi | ✓ | 571.223ms | 37.5 KB |
+| 348 | dynamic_programming/wildcard_matching | ✓ | 571.223ms | 42.5 KB |
+| 349 | dynamic_programming/word_break | ✓ | 571.223ms | 36.7 KB |
 | 350 | electronics/apparent_power | ✓ | 571.223ms | 2.0 KB |
 | 351 | electronics/builtin_voltage | ✓ | 571.223ms | 78.8 KB |
 | 352 | electronics/capacitor_equivalence | ✓ | 571.223ms | 86.9 KB |


### PR DESCRIPTION
## Summary
- refresh F# transpiled code and benchmarks for a batch of dynamic programming algorithms
- capture failing run for `physics/basic_orbital_capture`

## Testing
- `MOCHI_ALGORITHMS_INDEX=345 go test -tags=slow -run TestFSTranspiler_Algorithms_Golden -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_689c53fdcdfc8320b21dad735e811dee