### PR TITLE
docs: add v0.10.65 changelog and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # 📦 CHANGELOG.md
 
+## [0.10.65] – 2025-08-13T09:00:06+00:00
+
+### Added
+
+* F# casts operands before floor division.
+* Erlang handles floor operations.
+* Elixir captures function references.
+
+### Changed
+
+* Refreshed algorithm outputs and subset sum statistics.
+
+### Fixed
+
+* Removed stale error logs from Dart transpiler.
+
+
 ## [0.10.64] – 2025-08-11T11:27:00+00:00
 
 ### Added

--- a/releases/v0.10.65.md
+++ b/releases/v0.10.65.md
@@ -1,0 +1,16 @@
+# Aug 2025 (v0.10.65)
+
+Released on Wed Aug 13 09:00:06 2025 +0000.
+
+Mochi v0.10.65 refines floor division across multiple transpilers and refreshes algorithm data.
+
+## Transpilers
+
+- F# casts operands before floor division for correct results.
+- Erlang handles `floor` operations and updates algorithm outputs.
+- Elixir captures function references and refreshes algorithm outputs.
+- Dart removes stale error logs.
+
+## Algorithms
+
+- Tweaked subset sum statistics and refreshed various outputs.


### PR DESCRIPTION
## Summary
- document v0.10.65 release with floor division and algorithm refinements
- note floor handling in Erlang and function reference capture in Elixir
- clean up stale Dart logs and update subset sum statistics

## Testing
- `npm test` *(fails: Missing script: "test")*
- `go test ./... --vet=off -v`


------
https://chatgpt.com/codex/tasks/task_e_689c541ad3e88320ac745ac05b3729f4