### PR TITLE
pascal: fix parameter name mapping

### DIFF
--- a/tests/algorithms/x/Pascal/dynamic_programming/tribonacci.pas
+++ b/tests/algorithms/x/Pascal/dynamic_programming/tribonacci.pas
@@ -1,4 +1,4 @@
-{$mode objfpc}
+{$mode objfpc}{$modeswitch nestedprocvars}
 program Main;
 uses SysUtils;
 type IntArray = array of integer;
@@ -37,6 +37,28 @@ procedure panic(msg: string);
 begin
   writeln(msg);
   halt(1);
+end;
+procedure error(msg: string);
+begin
+  panic(msg);
+end;
+function _to_float(x: integer): real;
+begin
+  _to_float := x;
+end;
+function to_float(x: integer): real;
+begin
+  to_float := _to_float(x);
+end;
+procedure json(xs: array of real);
+var i: integer;
+begin
+  write('[');
+  for i := 0 to High(xs) do begin
+    write(xs[i]);
+    if i < High(xs) then write(', ');
+  end;
+  writeln(']');
 end;
 procedure show_list(xs: array of integer);
 var i: integer;

--- a/transpiler/x/pas/ALGORITHMS.md
+++ b/transpiler/x/pas/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Pascal code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Pascal`.
-Last updated: 2025-08-12 16:26 GMT+7
+Last updated: 2025-08-13 16:16 GMT+7
 
 ## Algorithms Golden Test Checklist (403/1077)
 | Index | Name | Status | Duration | Memory |

--- a/transpiler/x/pas/transpiler.go
+++ b/transpiler/x/pas/transpiler.go
@@ -2298,7 +2298,7 @@ func Transpile(env *types.Env, prog *parser.Program) (*Program, error) {
 						typ = currProg.addArrayAlias(elem)
 					}
 					name := paramNames[p.Name]
-					params = append(params, formatParam(name, typ))
+					params = append(params, fmt.Sprintf("%s: %s", name, pasType(typ)))
 				}
 				if rt == "" {
 					for _, st := range fnBody {


### PR DESCRIPTION
## Summary
- ensure Pascal transpiler preserves original parameter names when generating function declarations
- regenerate tribonacci algorithm output and update checklist

## Testing
- `MOCHI_ALG_INDEX=346 MOCHI_BENCHMARK=1 go test ./transpiler/x/pas -run PascalTranspiler_Algorithms_Golden -tags slow -count=1 -update-algorithms-pas -v`

------
https://chatgpt.com/codex/tasks/task_e_689c55d5d5588320b45be3319c2563db