### PR TITLE
dart transpiler: remove unused list equality helper

### DIFF
--- a/tests/algorithms/x/Dart/dynamic_programming/viterbi.bench
+++ b/tests/algorithms/x/Dart/dynamic_programming/viterbi.bench
@@ -1,1 +1,1 @@
-{"duration_us":14141,"memory_bytes":4063232,"name":"main"}
+{"duration_us":9376,"memory_bytes":3932160,"name":"main"}

--- a/tests/algorithms/x/Dart/dynamic_programming/viterbi.dart
+++ b/tests/algorithms/x/Dart/dynamic_programming/viterbi.dart
@@ -40,21 +40,6 @@ dynamic _substr(dynamic s, num start, num end) {
 }
 
 
-bool _listEq(List a, List b) {
-  if (a.length != b.length) return false;
-  for (var i = 0; i < a.length; i++) {
-    final x = a[i];
-    final y = b[i];
-    if (x is List && y is List) {
-      if (!_listEq(x, y)) return false;
-    } else if (x != y) {
-      return false;
-    }
-  }
-  return true;
-}
-
-
 Never _error(String msg) {
   throw Exception(msg);
 }

--- a/transpiler/x/dart/ALGORITHMS.md
+++ b/transpiler/x/dart/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Dart code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Dart`.
-Last updated: 2025-08-13 16:16 GMT+7
+Last updated: 2025-08-13 16:30 GMT+7
 
 ## Algorithms Golden Test Checklist (912/1077)
 | Index | Name | Status | Duration | Memory |
@@ -353,7 +353,7 @@ Last updated: 2025-08-13 16:16 GMT+7
 | 344 | dynamic_programming/sum_of_subset | ✓ | 15.578ms | 4.0 MB |
 | 345 | dynamic_programming/trapped_water | ✓ | 12.917ms | 3.4 MB |
 | 346 | dynamic_programming/tribonacci | ✓ | 20.593ms | 9.7 MB |
-| 347 | dynamic_programming/viterbi | ✓ | 14.141ms | 3.9 MB |
+| 347 | dynamic_programming/viterbi | ✓ | 9.376ms | 3.8 MB |
 | 348 | dynamic_programming/wildcard_matching | ✓ | 20.482ms | 3.3 MB |
 | 349 | dynamic_programming/word_break | ✓ | 13.047ms | 3.6 MB |
 | 350 | electronics/apparent_power | ✓ | 17.534ms | 10.2 MB |

--- a/transpiler/x/dart/transpiler.go
+++ b/transpiler/x/dart/transpiler.go
@@ -2850,38 +2850,38 @@ func (c *CastExpr) emit(w io.Writer) error {
 		}
 	}
 
-       if c.Type == "int" && valType == "BigInt" {
-               if _, err := io.WriteString(w, "("); err != nil {
-                       return err
-               }
-               if err := c.Value.emit(w); err != nil {
-                       return err
-               }
-               _, err := io.WriteString(w, ").toInt()")
-               return err
-       }
+	if c.Type == "int" && valType == "BigInt" {
+		if _, err := io.WriteString(w, "("); err != nil {
+			return err
+		}
+		if err := c.Value.emit(w); err != nil {
+			return err
+		}
+		_, err := io.WriteString(w, ").toInt()")
+		return err
+	}
 
-       if c.Type == "int" && valType == "String" {
-               if _, err := io.WriteString(w, "int.parse("); err != nil {
-                       return err
-               }
-               if err := c.Value.emit(w); err != nil {
-                       return err
-               }
-               _, err := io.WriteString(w, ")")
-               return err
-       }
+	if c.Type == "int" && valType == "String" {
+		if _, err := io.WriteString(w, "int.parse("); err != nil {
+			return err
+		}
+		if err := c.Value.emit(w); err != nil {
+			return err
+		}
+		_, err := io.WriteString(w, ")")
+		return err
+	}
 
-       if c.Type == "int" {
-               if _, err := io.WriteString(w, "("); err != nil {
-                       return err
-               }
-               if err := c.Value.emit(w); err != nil {
-                       return err
-               }
-               _, err := io.WriteString(w, ").toInt()")
-               return err
-       }
+	if c.Type == "int" {
+		if _, err := io.WriteString(w, "("); err != nil {
+			return err
+		}
+		if err := c.Value.emit(w); err != nil {
+			return err
+		}
+		_, err := io.WriteString(w, ").toInt()")
+		return err
+	}
 
 	if c.Type == "num" || c.Type == "double" {
 		if valType == "num" || valType == "double" {
@@ -4522,11 +4522,11 @@ func Emit(w io.Writer, p *Program) error {
 			return err
 		}
 	}
-       if useStr {
-               if _, err := io.WriteString(w, "String _str(dynamic v) => v.toString();\n\n"); err != nil {
-                       return err
-               }
-       }
+	if useStr {
+		if _, err := io.WriteString(w, "String _str(dynamic v) => v.toString();\n\n"); err != nil {
+			return err
+		}
+	}
 	if useBigRat {
 		if _, err := io.WriteString(w, "class BigRat {\n  BigInt num;\n  BigInt den;\n  BigRat(this.num, [BigInt? d]) : den = d ?? BigInt.one {\n    if (den.isNegative) { num = -num; den = -den; }\n    var g = num.gcd(den);\n    num = num ~/ g;\n    den = den ~/ g;\n  }\n  BigRat add(BigRat o) => BigRat(num * o.den + o.num * den, den * o.den);\n  BigRat sub(BigRat o) => BigRat(num * o.den - o.num * den, den * o.den);\n  BigRat mul(BigRat o) => BigRat(num * o.num, den * o.den);\n  BigRat div(BigRat o) => BigRat(num * o.den, den * o.num);\n}\n\nBigRat _bigrat(dynamic n, [dynamic d]) {\n  if (n is BigRat && d == null) return BigRat(n.num, n.den);\n  BigInt numer;\n  BigInt denom = d == null ? BigInt.one : (d is BigInt ? d : BigInt.from((d as num).toInt()));\n  if (n is BigRat) { numer = n.num; denom = n.den; }\n  else if (n is BigInt) { numer = n; }\n  else if (n is int) { numer = BigInt.from(n); }\n  else if (n is num) { numer = BigInt.from(n.toInt()); }\n  else { numer = BigInt.zero; }\n  return BigRat(numer, denom);\n}\nBigInt _num(BigRat r) => r.num;\nBigInt _denom(BigRat r) => r.den;\nBigRat _add(BigRat a, BigRat b) => a.add(b);\nBigRat _sub(BigRat a, BigRat b) => a.sub(b);\nBigRat _mul(BigRat a, BigRat b) => a.mul(b);\nBigRat _div(BigRat a, BigRat b) => a.div(b);\nBigRat _neg(BigRat a) => BigRat(-a.num, a.den);\n\n"); err != nil {
 			return err
@@ -4761,7 +4761,7 @@ func Transpile(prog *parser.Program, env *types.Env, bench, wrapMain bool) (*Pro
 	useStr = false
 	useParseIntStr = false
 	useFloor = false
-	useListEq = true
+	useListEq = false
 	imports = nil
 	testpkgAliases = map[string]struct{}{}
 	netAliases = map[string]struct{}{}


### PR DESCRIPTION
## Summary
- avoid eagerly enabling list equality helper in Dart transpiler
- regenerate Viterbi algorithm output and benchmarks
- refresh Dart algorithms progress report

## Testing
- `MOCHI_ALG_INDEX=347 MOCHI_BENCHMARK=1 go test -v -tags slow -run TestDartTranspiler_Algorithms_Golden ./transpiler/x/dart -update-algorithms-dart`

------
https://chatgpt.com/codex/tasks/task_e_689c5a386bd08320acb155ee8fa2918d