### PR TITLE
cs transpiler: handle invalid identifiers

### DIFF
--- a/transpiler/x/cs/ALGORITHMS.md
+++ b/transpiler/x/cs/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated C# code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/CS`.
-Last updated: 2025-08-13 16:15 GMT+7
+Last updated: 2025-08-13 16:35 GMT+7
 
 ## Algorithms Golden Test Checklist (1014/1077)
 | Index | Name | Status | Duration | Memory |

--- a/transpiler/x/cs/transpiler.go
+++ b/transpiler/x/cs/transpiler.go
@@ -143,7 +143,7 @@ var reserved = map[string]bool{
 }
 
 func safeName(n string) string {
-	if reserved[n] {
+	if reserved[n] || !validIdent(n) {
 		return "_" + n
 	}
 	return n


### PR DESCRIPTION
## Summary
- make `safeName` guard against invalid C# identifiers in the transpiler
- refresh algorithms progress checklist

## Testing
- `MOCHI_ALGORITHMS_INDEX=347 go test -run TestCSTranspiler_Algorithms_Golden -tags=slow -count=1`
- `for i in $(seq 348 396); do MOCHI_ALGORITHMS_INDEX=$i go test -run TestCSTranspiler_Algorithms_Golden -tags=slow -count=1; done`

------
https://chatgpt.com/codex/tasks/task_e_689c5b00bfa8832099f03d66e1ffc040