### PR TITLE
pascal: expand keyword sanitization

### DIFF
--- a/tests/algorithms/x/Pascal/electronics/apparent_power.pas
+++ b/tests/algorithms/x/Pascal/electronics/apparent_power.pas
@@ -1,4 +1,4 @@
-{$mode objfpc}
+{$mode objfpc}{$modeswitch nestedprocvars}
 program Main;
 uses SysUtils;
 type RealArray = array of real;
@@ -38,23 +38,45 @@ begin
   writeln(msg);
   halt(1);
 end;
+procedure error(msg: string);
+begin
+  panic(msg);
+end;
+function _to_float(x: integer): real;
+begin
+  _to_float := x;
+end;
+function to_float(x: integer): real;
+begin
+  to_float := _to_float(x);
+end;
+procedure json(xs: array of real);
+var i: integer;
+begin
+  write('[');
+  for i := 0 to High(xs) do begin
+    write(xs[i]);
+    if i < High(xs) then write(', ');
+  end;
+  writeln(']');
+end;
 var
   bench_start_0: integer;
   bench_dur_0: integer;
   bench_mem_0: int64;
   bench_memdiff_0: int64;
   PI: real;
-  a: RealArray;
-  b: RealArray;
-  voltage: real;
-  eps: real;
   deg: real;
-  current: real;
-  x: real;
-  current_angle: real;
   angle: real;
-  mag: real;
+  current_angle: real;
+  voltage: real;
   voltage_angle: real;
+  x: real;
+  current: real;
+  a: RealArray;
+  mag: real;
+  eps: real;
+  b: RealArray;
 function abs(x: real): real; forward;
 function to_radians(deg: real): real; forward;
 function sin_taylor(x: real): real; forward;

--- a/transpiler/x/pas/ALGORITHMS.md
+++ b/transpiler/x/pas/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Pascal code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Pascal`.
-Last updated: 2025-08-13 16:16 GMT+7
+Last updated: 2025-08-14 10:04 GMT+7
 
 ## Algorithms Golden Test Checklist (403/1077)
 | Index | Name | Status | Duration | Memory |

--- a/transpiler/x/pas/transpiler.go
+++ b/transpiler/x/pas/transpiler.go
@@ -82,6 +82,8 @@ func declareName(name string) string {
 		"array", "real", "integer", "string", "boolean", "char",
 		// Additional common Pascal keywords
 		"begin", "var", "procedure", "function", "unit", "uses", "const", "file", "out",
+		// Control flow keywords
+		"case", "do", "downto", "else", "for", "if", "of", "then", "to", "until", "while", "with", "goto",
 		// Math functions that should map to Pascal's built-ins
 		"ln", "exp":
 		// Avoid Pascal reserved keywords and built-in types (case-insensitive)
@@ -115,7 +117,9 @@ func declareName(name string) string {
 func sanitizeField(name string) string {
 	switch strings.ToLower(name) {
 	case "label", "xor", "and", "or", "div", "mod", "type", "set", "result", "repeat", "end", "nil", "length", "ord",
-		"begin", "var", "procedure", "function", "unit", "uses", "const", "file", "out", "ln", "exp":
+		"begin", "var", "procedure", "function", "unit", "uses", "const", "file", "out",
+		"case", "do", "downto", "else", "for", "if", "of", "then", "to", "until", "while", "with", "goto",
+		"ln", "exp":
 		return name + "_"
 	}
 	return name


### PR DESCRIPTION
## Summary
- avoid collisions with Pascal reserved words by sanitizing control-flow keywords
- regenerate Pascal code and docs for `electronics/apparent_power`

## Testing
- `MOCHI_ALG_INDEX=350 MOCHI_BENCHMARK=1 go test ./transpiler/x/pas -tags=slow -run TestPascalTranspiler_Algorithms_Golden -update-algorithms-pas`


------
https://chatgpt.com/codex/tasks/task_e_689d512597488320be5c59165d1a2f5d