### PR TITLE
php: handle reserved socket names

### DIFF
--- a/transpiler/x/php/ALGORITHMS.md
+++ b/transpiler/x/php/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated PHP code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/PHP`.
-Last updated: 2025-08-13 12:56 GMT+7
+Last updated: 2025-08-14 10:08 GMT+7
 
 ## Algorithms Golden Test Checklist (978/1077)
 | Index | Name | Status | Duration | Memory |


### PR DESCRIPTION
## Summary
- prevent PHP built-in socket_* conflicts by reserving those identifiers
- support returning references from functions and binding results accordingly
- refresh PHP algorithms checklist

## Testing
- `MOCHI_ALG_INDEX=350 MOCHI_BENCHMARK=1 go test -tags=slow ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -update-algorithms-php`


------
https://chatgpt.com/codex/tasks/task_e_689d51280908832092ee0d62c0db7adc