### PR TITLE
fs: open collections namespace for dict helpers

### DIFF
--- a/tests/algorithms/transpiler/FS/graphs/boruvka.bench
+++ b/tests/algorithms/transpiler/FS/graphs/boruvka.bench
@@ -1,5 +1,5 @@
 {
   "duration_us": 571223,
-  "memory_bytes": 81680,
+  "memory_bytes": 76464,
   "name": "main"
 }

--- a/tests/algorithms/transpiler/FS/graphs/boruvka.fs
+++ b/tests/algorithms/transpiler/FS/graphs/boruvka.fs
@@ -1,4 +1,4 @@
-// Generated 2025-08-13 16:41 +0700
+// Generated 2025-08-14 16:04 +0700
 
 exception Return
 let mutable _nowSeed:int64 = 0L
@@ -43,7 +43,6 @@ let _arrset (arr:'a array) (i:int) (v:'a) : 'a array =
     a
 let rec _str v =
     let s = sprintf "%A" v
-    let s = if s.EndsWith(".0") then s.Substring(0, s.Length - 2) else s
     s.Replace("[|", "[")
      .Replace("|]", "]")
      .Replace("; ", " ")

--- a/tests/algorithms/transpiler/FS/graphs/breadth_first_search.bench
+++ b/tests/algorithms/transpiler/FS/graphs/breadth_first_search.bench
@@ -1,5 +1,5 @@
 {
   "duration_us": 571223,
-  "memory_bytes": 68456,
+  "memory_bytes": 78528,
   "name": "main"
 }

--- a/tests/algorithms/transpiler/FS/graphs/breadth_first_search.fs
+++ b/tests/algorithms/transpiler/FS/graphs/breadth_first_search.fs
@@ -1,4 +1,4 @@
-// Generated 2025-08-07 16:27 +0700
+// Generated 2025-08-14 16:04 +0700
 
 exception Return
 let mutable _nowSeed:int64 = 0L
@@ -56,13 +56,13 @@ let rec add_edge (graph: System.Collections.Generic.IDictionary<int, int array>)
     let mutable ``to`` = ``to``
     try
         if graph.ContainsKey(from) then
-            graph.[from] <- Array.append (_dictGet graph (from)) [|``to``|]
+            graph <- _dictAdd (graph) (from) (Array.append (_dictGet graph (from)) [|``to``|])
         else
-            graph.[from] <- [|``to``|]
+            graph <- _dictAdd (graph) (from) (unbox<int array> [|``to``|])
         __ret
     with
         | Return -> __ret
-let rec print_graph (graph: System.Collections.Generic.IDictionary<int, int array>) =
+and print_graph (graph: System.Collections.Generic.IDictionary<int, int array>) =
     let mutable __ret : unit = Unchecked.defaultof<unit>
     let mutable graph = graph
     try
@@ -71,35 +71,35 @@ let rec print_graph (graph: System.Collections.Generic.IDictionary<int, int arra
             let mutable line: string = (_str (v)) + "  :  "
             let mutable i: int = 0
             while i < (Seq.length (adj)) do
-                line <- line + (_str (_idx adj (i)))
+                line <- line + (_str (_idx adj (int i)))
                 if i < ((Seq.length (adj)) - 1) then
                     line <- line + " -> "
                 i <- i + 1
-            printfn "%s" (line)
+            ignore (printfn "%s" (line))
         __ret
     with
         | Return -> __ret
-let rec bfs (graph: System.Collections.Generic.IDictionary<int, int array>) (start: int) =
+and bfs (graph: System.Collections.Generic.IDictionary<int, int array>) (start: int) =
     let mutable __ret : int array = Unchecked.defaultof<int array>
     let mutable graph = graph
     let mutable start = start
     try
         let mutable visited: System.Collections.Generic.IDictionary<int, bool> = _dictCreate []
-        let mutable queue: int array = [||]
-        let mutable order: int array = [||]
+        let mutable queue: int array = Array.empty<int>
+        let mutable order: int array = Array.empty<int>
         queue <- Array.append queue [|start|]
-        visited.[start] <- true
+        visited <- _dictAdd (visited) (start) (true)
         let mutable head: int = 0
         while head < (Seq.length (queue)) do
-            let vertex: int = _idx queue (head)
+            let vertex: int = _idx queue (int head)
             head <- head + 1
             order <- Array.append order [|vertex|]
             let neighbors: int array = _dictGet graph (vertex)
             let mutable i: int = 0
             while i < (Seq.length (neighbors)) do
-                let neighbor: int = _idx neighbors (i)
+                let neighbor: int = _idx neighbors (int i)
                 if not (visited.ContainsKey(neighbor)) then
-                    visited.[neighbor] <- true
+                    visited <- _dictAdd (visited) (neighbor) (true)
                     queue <- Array.append queue [|neighbor|]
                 i <- i + 1
         __ret <- order
@@ -115,7 +115,7 @@ add_edge (g) (2) (0)
 add_edge (g) (2) (3)
 add_edge (g) (3) (3)
 print_graph (g)
-printfn "%s" (_repr (bfs (g) (2)))
+ignore (printfn "%s" (_repr (bfs (g) (2))))
 let __bench_end = _now()
 let __mem_end = System.GC.GetTotalMemory(true)
 printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)

--- a/transpiler/x/fs/ALGORITHMS.md
+++ b/transpiler/x/fs/ALGORITHMS.md
@@ -1,7 +1,7 @@
 # F# Algorithms Transpiler Output
 
 Completed programs: 919/1077
-Last updated: 2025-08-14 15:44 +0700
+Last updated: 2025-08-14 16:04 +0700
 
 Checklist:
 
@@ -409,8 +409,8 @@ Checklist:
 | 400 | graphs/bidirectional_a_star | ✓ | 571.223ms | 56.1 KB |
 | 401 | graphs/bidirectional_breadth_first_search | ✓ | 571.223ms | 57.2 KB |
 | 402 | graphs/bidirectional_search | ✓ | 571.223ms | 59.7 KB |
-| 403 | graphs/boruvka | ✓ | 571.223ms | 79.8 KB |
-| 404 | graphs/breadth_first_search | ✓ | 571.223ms | 66.9 KB |
+| 403 | graphs/boruvka | ✓ | 571.223ms | 74.7 KB |
+| 404 | graphs/breadth_first_search | ✓ | 571.223ms | 76.7 KB |
 | 405 | graphs/breadth_first_search_2 | ✓ | 571.223ms | 32.3 KB |
 | 406 | graphs/breadth_first_search_shortest_path | ✓ | 571.223ms | 33.5 KB |
 | 407 | graphs/breadth_first_search_shortest_path_2 | ✓ | 571.223ms | 16.5 KB |

--- a/transpiler/x/fs/README.md
+++ b/transpiler/x/fs/README.md
@@ -112,4 +112,4 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-Last updated: 2025-08-14 15:44 +0700
+Last updated: 2025-08-14 16:04 +0700

--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-08-14 16:04 +0700)
+- fs: ensure dictionary helpers open collections namespace
+- Generated F# for 103/105 programs (103 passing)
+
 ## Progress (2025-08-14 15:44 +0700)
 - lua: update algorithm outputs for indices 350-400
 - Generated F# for 103/105 programs (103 passing)

--- a/transpiler/x/fs/transpiler.go
+++ b/transpiler/x/fs/transpiler.go
@@ -3373,14 +3373,17 @@ func Emit(prog *Program) []byte {
 		buf.WriteString("\n")
 	}
 	if prog.UseDictAdd {
+		neededOpens["System.Collections.Generic"] = true
 		buf.WriteString(helperDictAdd)
 		buf.WriteString("\n")
 	}
 	if prog.UseDictCreate {
+		neededOpens["System.Collections.Generic"] = true
 		buf.WriteString(helperDictCreate)
 		buf.WriteString("\n")
 	}
 	if prog.UseDictGet {
+		neededOpens["System.Collections.Generic"] = true
 		buf.WriteString(helperDictGet)
 		buf.WriteString("\n")
 	}


### PR DESCRIPTION
## Summary
- ensure F# transpiler adds `open System.Collections.Generic` when emitting dictionary helpers
- regenerate F# outputs and benches for boruvka and breadth_first_search algorithms
- refresh algorithms checklist and progress notes

## Testing
- `MOCHI_ALGORITHMS_INDEX=403 go test ./transpiler/x/fs -run TestFSTranspiler_Algorithms_Golden -count=1 -tags slow`
- `MOCHI_ALGORITHMS_INDEX=404 go test ./transpiler/x/fs -run TestFSTranspiler_Algorithms_Golden -count=1 -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_689da69460208320a2bc89fd82ebad17