### PR TITLE
Clojure transpiler propagates mutations via return value

### DIFF
--- a/tests/algorithms/x/Clojure/graphs/breadth_first_search.bench
+++ b/tests/algorithms/x/Clojure/graphs/breadth_first_search.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 48500,
+  "memory_bytes": 22292304,
+  "name": "main"
+}

--- a/tests/algorithms/x/Clojure/graphs/breadth_first_search.clj
+++ b/tests/algorithms/x/Clojure/graphs/breadth_first_search.clj
@@ -14,6 +14,12 @@
 (defn split [s sep]
   (clojure.string/split s (re-pattern sep)))
 
+(defn toi [s]
+  (Integer/parseInt (str s)))
+
+(defn _fetch [url]
+  {:data [{:from "" :intensity {:actual 0 :forecast 0 :index ""} :to ""}]})
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare add_edge print_graph bfs)
@@ -43,13 +49,13 @@
 (def ^:dynamic print_graph_line nil)
 
 (defn add_edge [add_edge_graph_p add_edge_from add_edge_to]
-  (binding [add_edge_graph nil] (do (set! add_edge_graph add_edge_graph_p) (if (in add_edge_from add_edge_graph) (set! add_edge_graph (assoc add_edge_graph add_edge_from (conj (nth add_edge_graph add_edge_from) add_edge_to))) (set! add_edge_graph (assoc add_edge_graph add_edge_from [add_edge_to]))))))
+  (binding [add_edge_graph add_edge_graph_p] (do (if (in add_edge_from add_edge_graph) (set! add_edge_graph (assoc add_edge_graph add_edge_from (conj (get add_edge_graph add_edge_from) add_edge_to))) (set! add_edge_graph (assoc add_edge_graph add_edge_from [add_edge_to]))) add_edge_graph)))
 
 (defn print_graph [print_graph_graph]
-  (binding [print_graph_adj nil print_graph_i nil print_graph_line nil] (doseq [v (keys print_graph_graph)] (do (set! print_graph_adj (nth print_graph_graph v)) (set! print_graph_line (str (str v) "  :  ")) (set! print_graph_i 0) (while (< print_graph_i (count print_graph_adj)) (do (set! print_graph_line (str print_graph_line (str (nth print_graph_adj print_graph_i)))) (when (< print_graph_i (- (count print_graph_adj) 1)) (set! print_graph_line (str print_graph_line " -> "))) (set! print_graph_i (+ print_graph_i 1)))) (println print_graph_line)))))
+  (binding [print_graph_adj nil print_graph_i nil print_graph_line nil] (do (doseq [v (keys print_graph_graph)] (do (set! print_graph_adj (get print_graph_graph v)) (set! print_graph_line (str (str v) "  :  ")) (set! print_graph_i 0) (while (< print_graph_i (count print_graph_adj)) (do (set! print_graph_line (str print_graph_line (str (get print_graph_adj print_graph_i)))) (when (< print_graph_i (- (count print_graph_adj) 1)) (set! print_graph_line (str print_graph_line " -> "))) (set! print_graph_i (+ print_graph_i 1)))) (println print_graph_line))) print_graph_graph)))
 
 (defn bfs [bfs_graph bfs_start]
-  (binding [bfs_head nil bfs_i nil bfs_neighbor nil bfs_neighbors nil bfs_order nil bfs_queue nil bfs_vertex nil bfs_visited nil] (try (do (set! bfs_visited {}) (set! bfs_queue []) (set! bfs_order []) (set! bfs_queue (conj bfs_queue bfs_start)) (set! bfs_visited (assoc bfs_visited bfs_start true)) (set! bfs_head 0) (while (< bfs_head (count bfs_queue)) (do (set! bfs_vertex (nth bfs_queue bfs_head)) (set! bfs_head (+ bfs_head 1)) (set! bfs_order (conj bfs_order bfs_vertex)) (set! bfs_neighbors (nth bfs_graph bfs_vertex)) (set! bfs_i 0) (while (< bfs_i (count bfs_neighbors)) (do (set! bfs_neighbor (nth bfs_neighbors bfs_i)) (when (not (in bfs_neighbor bfs_visited)) (do (set! bfs_visited (assoc bfs_visited bfs_neighbor true)) (set! bfs_queue (conj bfs_queue bfs_neighbor)))) (set! bfs_i (+ bfs_i 1)))))) (throw (ex-info "return" {:v bfs_order}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
+  (binding [bfs_head nil bfs_i nil bfs_neighbor nil bfs_neighbors nil bfs_order nil bfs_queue nil bfs_vertex nil bfs_visited nil] (try (do (set! bfs_visited {}) (set! bfs_queue []) (set! bfs_order []) (set! bfs_queue (conj bfs_queue bfs_start)) (set! bfs_visited (assoc bfs_visited bfs_start true)) (set! bfs_head 0) (while (< bfs_head (count bfs_queue)) (do (set! bfs_vertex (nth bfs_queue bfs_head)) (set! bfs_head (+ bfs_head 1)) (set! bfs_order (conj bfs_order bfs_vertex)) (set! bfs_neighbors (get bfs_graph bfs_vertex)) (set! bfs_i 0) (while (< bfs_i (count bfs_neighbors)) (do (set! bfs_neighbor (get bfs_neighbors bfs_i)) (when (not (in bfs_neighbor bfs_visited)) (do (set! bfs_visited (assoc bfs_visited bfs_neighbor true)) (set! bfs_queue (conj bfs_queue bfs_neighbor)))) (set! bfs_i (+ bfs_i 1)))))) (throw (ex-info "return" {:v bfs_order}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
 
 (def ^:dynamic main_g {})
 
@@ -57,12 +63,12 @@
   (let [rt (Runtime/getRuntime)
     start-mem (- (.totalMemory rt) (.freeMemory rt))
     start (System/nanoTime)]
-      (add_edge main_g 0 1)
-      (add_edge main_g 0 2)
-      (add_edge main_g 1 2)
-      (add_edge main_g 2 0)
-      (add_edge main_g 2 3)
-      (add_edge main_g 3 3)
+      (let [__res (add_edge main_g 0 1)] (do (alter-var-root (var main_g) (constantly __res)) __res))
+      (let [__res (add_edge main_g 0 2)] (do (alter-var-root (var main_g) (constantly __res)) __res))
+      (let [__res (add_edge main_g 1 2)] (do (alter-var-root (var main_g) (constantly __res)) __res))
+      (let [__res (add_edge main_g 2 0)] (do (alter-var-root (var main_g) (constantly __res)) __res))
+      (let [__res (add_edge main_g 2 3)] (do (alter-var-root (var main_g) (constantly __res)) __res))
+      (let [__res (add_edge main_g 3 3)] (do (alter-var-root (var main_g) (constantly __res)) __res))
       (print_graph main_g)
       (println (bfs main_g 2))
       (System/gc)

--- a/tests/algorithms/x/Clojure/graphs/breadth_first_search.error
+++ b/tests/algorithms/x/Clojure/graphs/breadth_first_search.error
@@ -1,6 +1,0 @@
-run: exit status 1
-Execution error (UnsupportedOperationException) at main/bfs (breadth_first_search.clj:52).
-nth not supported on this type: PersistentArrayMap
-
-Full report at:
-/tmp/clojure-1666252563168504007.edn

--- a/tests/algorithms/x/Clojure/graphs/breadth_first_search.out
+++ b/tests/algorithms/x/Clojure/graphs/breadth_first_search.out
@@ -1,5 +1,5 @@
-Execution error (UnsupportedOperationException) at main/bfs (breadth_first_search.clj:52).
-nth not supported on this type: PersistentArrayMap
-
-Full report at:
-/tmp/clojure-1666252563168504007.edn
+0  :  1 -> 2
+1  :  2
+2  :  0 -> 3
+3  :  3
+[2 0 3 1]

--- a/transpiler/x/clj/ALGORITHMS.md
+++ b/transpiler/x/clj/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated Clojure code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Clojure`.
-Last updated: 2025-08-14 16:04 GMT+7
+Last updated: 2025-08-14 16:27 GMT+7
 
-## Algorithms Golden Test Checklist (781/1077)
+## Algorithms Golden Test Checklist (782/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 50.25ms | 19.66MB |
@@ -410,7 +410,7 @@ Last updated: 2025-08-14 16:04 GMT+7
 | 401 | graphs/bidirectional_breadth_first_search | ✓ | 95.401ms | 6.86MB |
 | 402 | graphs/bidirectional_search | ✓ | 58.021ms | 24.31MB |
 | 403 | graphs/boruvka | ✓ | 41.697ms | 25.65MB |
-| 404 | graphs/breadth_first_search | error |  |  |
+| 404 | graphs/breadth_first_search | ✓ | 48.5ms | 21.26MB |
 | 405 | graphs/breadth_first_search_2 | ✓ | 91.758ms | 24.31MB |
 | 406 | graphs/breadth_first_search_shortest_path | ✓ | 85.8ms | 24.49MB |
 | 407 | graphs/breadth_first_search_shortest_path_2 | ✓ | 87.688ms | 28.59MB |

--- a/transpiler/x/clj/transpiler.go
+++ b/transpiler/x/clj/transpiler.go
@@ -2908,25 +2908,26 @@ func transpileCall(c *parser.CallExpr) (Node, error) {
 	callNode := &List{Elems: elems}
 	if sym, ok := elems[0].(Symbol); ok {
 		if mps, ok := funcMutatedParams[string(sym)]; ok && len(mps) > 0 {
-			bindings := &Vector{Elems: []Node{Symbol("__res"), callNode}}
-			bodyElems := []Node{}
-			for _, mp := range mps {
-				if mp.Index < len(c.Args) {
-					if argName, ok := identName(c.Args[mp.Index]); ok {
-						assign := &List{Elems: []Node{Symbol("set!"), Symbol(argName), Symbol(mp.Name)}}
-						if funDepth == 1 && currentFun == "main" {
-							assign = &List{Elems: []Node{
-								Symbol("alter-var-root"),
-								&List{Elems: []Node{Symbol("var"), Symbol(argName)}},
-								&List{Elems: []Node{Symbol("constantly"), Symbol(mp.Name)}},
-							}}
-						}
-						bodyElems = append(bodyElems, assign)
-					}
-				}
-			}
-			bodyElems = append(bodyElems, Symbol("__res"))
-			callNode = &List{Elems: []Node{Symbol("let"), bindings, &List{Elems: append([]Node{Symbol("do")}, bodyElems...)}}}
+                        bindings := &Vector{Elems: []Node{Symbol("__res"), callNode}}
+                        bodyElems := []Node{}
+                        for _, mp := range mps {
+                                if mp.Index < len(c.Args) {
+                                        if argName, ok := identName(c.Args[mp.Index]); ok {
+                                                assignVal := Symbol("__res")
+                                                assign := &List{Elems: []Node{Symbol("set!"), Symbol(argName), assignVal}}
+                                                if funDepth == 1 && currentFun == "main" {
+                                                        assign = &List{Elems: []Node{
+                                                                Symbol("alter-var-root"),
+                                                                &List{Elems: []Node{Symbol("var"), Symbol(argName)}},
+                                                                &List{Elems: []Node{Symbol("constantly"), assignVal}},
+                                                        }}
+                                                }
+                                                bodyElems = append(bodyElems, assign)
+                                        }
+                                }
+                        }
+                        bodyElems = append(bodyElems, Symbol("__res"))
+                        callNode = &List{Elems: []Node{Symbol("let"), bindings, &List{Elems: append([]Node{Symbol("do")}, bodyElems...)}}}
 		} else if transpileEnv != nil {
 			if typ, err := transpileEnv.GetVar(string(sym)); err == nil {
 				callArity := len(elems) - 1


### PR DESCRIPTION
## Summary
- Fix Clojure transpiler to assign mutated arguments using the function return value
- Generate Clojure code and expected output for `graphs/breadth_first_search`
- Record benchmark results and update algorithm listing

## Testing
- `MOCHI_ALG_INDEX=404 go test ./transpiler/x/clj -run TestClojureTranspiler_Algorithms_Golden -count=1 -tags=slow`


------
https://chatgpt.com/codex/tasks/task_e_689daa3a5c2c83209c585831b7c58bba