### PR TITLE
feat(go-transpiler): precompute pointer params

### DIFF
--- a/transpiler/x/go/ALGORITHMS.md
+++ b/transpiler/x/go/ALGORITHMS.md
@@ -1,7 +1,7 @@
 # Go Algorithms Transpiler Output
 
 Completed programs: 715/1077
-Last updated: 2025-08-14 16:24 +0700
+Last updated: 2025-08-14 16:39 +0700
 
 Checklist:
 
@@ -435,7 +435,7 @@ Checklist:
 | 426 | graphs/frequent_pattern_graph_miner | ✓ | 1.0ms | 35.04KB |
 | 427 | graphs/g_topological_sort | ✓ | 592.0µs | 2.21KB |
 | 428 | graphs/gale_shapley_bigraph | ✓ | 661.0µs | 1.92KB |
-| 429 | graphs/graph_adjacency_list | ✓ | 964.0µs | 5.10KB |
+| 429 | graphs/graph_adjacency_list | ✓ | 1.0ms | 5.41KB |
 | 430 | graphs/graph_adjacency_matrix |   |  |  |
 | 431 | graphs/graph_list | ✓ | 885.0µs | 3.27KB |
 | 432 | graphs/graphs_floyd_warshall | ✓ | 413.0µs | 1.77KB |


### PR DESCRIPTION
## Summary
- precompute pointer parameters and expected types for Go transpilation
- add dereference handling for pointer arguments

## Testing
- `MOCHI_ALGORITHMS_INDEX=430 go test ./transpiler/x/go -tags=slow -run TestGoTranspiler_Algorithms_Golden -count=1` *(fails: exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_689daee94e78832084b332486e1a1f44