### PR TITLE
docs: add v0.10.66 release notes and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # 📦 CHANGELOG.md
 
+## [0.10.66] – 2025-08-14T10:19:34+00:00
+
+### Added
+
+* C transpiler gains breadth-first search support.
+* Zig handles shadowed parameters and list types.
+* C# transpiler supports deterministic timestamps.
+* Go precomputes pointer parameters.
+* Erlang accepts untyped function parameters.
+
+### Changed
+
+* Lua defaults to list indexing.
+* OCaml improves map handling and string-to-int conversion.
+* Algorithm outputs refreshed for Ruby, F# and Clojure.
+
+### Fixed
+
+* Racket supports list field mutation.
+* TypeScript fixes negative integer division.
+* Dart casts integers to doubles when necessary.
+* Ruby clones arrays before appending.
+
 ## [0.10.65] – 2025-08-13T09:00:06+00:00
 
 ### Added

--- a/releases/v0.10.66.md
+++ b/releases/v0.10.66.md
@@ -1,0 +1,22 @@
+# Aug 2025 (v0.10.66)
+
+Released on Thu Aug 14 10:19:34 2025 +0000.
+
+Mochi v0.10.66 expands graph algorithm coverage and enhances multiple transpilers.
+
+## Transpilers
+
+- C transpiler adds breadth-first search support.
+- Zig handles shadowed parameters and list types.
+- C# transpiler produces deterministic timestamps.
+- Go precomputes pointer parameters.
+- Erlang allows untyped parameters.
+- Dart casts integers to doubles when needed.
+- TypeScript fixes negative integer division.
+- Racket supports list field mutation.
+
+## Algorithms
+
+- Ruby transpiles algorithms 503–553 and clones arrays when appending.
+- Algorithm metrics refreshed for Clojure and F#.
+- Racket and others regenerate algorithm outputs.


### PR DESCRIPTION
## Summary
- document v0.10.66 release notes
- record changelog for v0.10.66

## Testing
- `make test` *(fails: signal interrupt)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689db7a9b94883209c177bcff74bbc64