### PR TITLE
cs: handle nil slice append in transpiler

### DIFF
--- a/transpiler/x/cs/ALGORITHMS.md
+++ b/transpiler/x/cs/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated C# code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/CS`.
-Last updated: 2025-08-14 17:14 GMT+7
+Last updated: 2025-08-14 17:51 GMT+7
 
 ## Algorithms Golden Test Checklist (1019/1077)
 | Index | Name | Status | Duration | Memory |

--- a/transpiler/x/cs/transpiler.go
+++ b/transpiler/x/cs/transpiler.go
@@ -2428,6 +2428,8 @@ type AppendExpr struct {
 }
 
 func (a *AppendExpr) emit(w io.Writer) {
+	// append creates a new array with the provided item appended.
+	// We rely on System.Linq for the convenient ToList/ToArray helpers.
 	usesLinq = true
 	t := typeOfExpr(a.List)
 	if t == "" || strings.HasSuffix(t, "object[]") {
@@ -2445,6 +2447,11 @@ func (a *AppendExpr) emit(w io.Writer) {
 	}
 	listStr := exprString(a.List)
 	itemStr := exprString(a.Item)
+	if listStr == "null" {
+		// handle appending to a nil slice by creating a new array
+		fmt.Fprintf(w, "new %s[]{%s}", elem, itemStr)
+		return
+	}
 	tItem := typeOfExpr(a.Item)
 	if (tItem == "object" || tItem == "object[]") && elem != "object" {
 		if lit, ok := a.Item.(*ListLit); ok && len(lit.Elems) == 0 {


### PR DESCRIPTION
## Summary
- handle appending to `null` slices in C# transpiler
- refresh algorithms checklist

## Testing
- `MOCHI_ALGORITHMS_INDEX=477 go test -run TestCSTranspiler_Algorithms_Golden -tags=slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_689dbe6d9ba48320a4cd5e84edfa6d61