### PR TITLE
fs: fix float string emission

### DIFF
--- a/tests/algorithms/transpiler/FS/maths/average_mode.bench
+++ b/tests/algorithms/transpiler/FS/maths/average_mode.bench
@@ -1,5 +1,5 @@
 {
   "duration_us": 571223,
-  "memory_bytes": 59376,
+  "memory_bytes": 59488,
   "name": "main"
 }

--- a/tests/algorithms/transpiler/FS/maths/average_mode.fs
+++ b/tests/algorithms/transpiler/FS/maths/average_mode.fs
@@ -1,4 +1,4 @@
-// Generated 2025-08-08 17:07 +0700
+// Generated 2025-08-14 18:14 +0700
 
 exception Return
 let mutable _nowSeed:int64 = 0L
@@ -19,18 +19,6 @@ let _now () =
         int (System.DateTime.UtcNow.Ticks % 2147483647L)
 
 _initNow()
-let _dictAdd<'K,'V when 'K : equality> (d:System.Collections.Generic.IDictionary<'K,'V>) (k:'K) (v:'V) =
-    d.[k] <- v
-    d
-let _dictCreate<'K,'V when 'K : equality> (pairs:('K * 'V) list) : System.Collections.Generic.IDictionary<'K,'V> =
-    let d = System.Collections.Generic.Dictionary<'K, 'V>()
-    for (k, v) in pairs do
-        d.[k] <- v
-    upcast d
-let _dictGet<'K,'V when 'K : equality> (d:System.Collections.Generic.IDictionary<'K,'V>) (k:'K) : 'V =
-    match d.TryGetValue(k) with
-    | true, v -> v
-    | _ -> Unchecked.defaultof<'V>
 let _idx (arr:'a array) (i:int) : 'a =
     if not (obj.ReferenceEquals(arr, null)) && i >= 0 && i < arr.Length then arr.[i] else Unchecked.defaultof<'a>
 let _arrset (arr:'a array) (i:int) (v:'a) : 'a array =
@@ -55,7 +43,7 @@ let rec contains_int (xs: int array) (x: int) =
     try
         let mutable i: int = 0
         while i < (Seq.length (xs)) do
-            if (_idx xs (i)) = x then
+            if (_idx xs (int i)) = x then
                 __ret <- true
                 raise Return
             i <- i + 1
@@ -64,14 +52,14 @@ let rec contains_int (xs: int array) (x: int) =
         __ret
     with
         | Return -> __ret
-let rec contains_string (xs: string array) (x: string) =
+and contains_string (xs: string array) (x: string) =
     let mutable __ret : bool = Unchecked.defaultof<bool>
     let mutable xs = xs
     let mutable x = x
     try
         let mutable i: int = 0
         while i < (Seq.length (xs)) do
-            if (_idx xs (i)) = x then
+            if (_idx xs (int i)) = x then
                 __ret <- true
                 raise Return
             i <- i + 1
@@ -80,7 +68,7 @@ let rec contains_string (xs: string array) (x: string) =
         __ret
     with
         | Return -> __ret
-let rec count_int (xs: int array) (x: int) =
+and count_int (xs: int array) (x: int) =
     let mutable __ret : int = Unchecked.defaultof<int>
     let mutable xs = xs
     let mutable x = x
@@ -88,7 +76,7 @@ let rec count_int (xs: int array) (x: int) =
         let mutable cnt: int = 0
         let mutable i: int = 0
         while i < (Seq.length (xs)) do
-            if (_idx xs (i)) = x then
+            if (_idx xs (int i)) = x then
                 cnt <- cnt + 1
             i <- i + 1
         __ret <- cnt
@@ -96,7 +84,7 @@ let rec count_int (xs: int array) (x: int) =
         __ret
     with
         | Return -> __ret
-let rec count_string (xs: string array) (x: string) =
+and count_string (xs: string array) (x: string) =
     let mutable __ret : int = Unchecked.defaultof<int>
     let mutable xs = xs
     let mutable x = x
@@ -104,7 +92,7 @@ let rec count_string (xs: string array) (x: string) =
         let mutable cnt: int = 0
         let mutable i: int = 0
         while i < (Seq.length (xs)) do
-            if (_idx xs (i)) = x then
+            if (_idx xs (int i)) = x then
                 cnt <- cnt + 1
             i <- i + 1
         __ret <- cnt
@@ -112,7 +100,7 @@ let rec count_string (xs: string array) (x: string) =
         __ret
     with
         | Return -> __ret
-let rec sort_int (xs: int array) =
+and sort_int (xs: int array) =
     let mutable __ret : int array = Unchecked.defaultof<int array>
     let mutable xs = xs
     try
@@ -121,9 +109,9 @@ let rec sort_int (xs: int array) =
         while i < (Seq.length (arr)) do
             let mutable j: int = i + 1
             while j < (Seq.length (arr)) do
-                if (_idx arr (j)) < (_idx arr (i)) then
-                    let tmp: int = _idx arr (i)
-                    arr.[i] <- _idx arr (j)
+                if (_idx arr (int j)) < (_idx arr (int i)) then
+                    let tmp: int = _idx arr (int i)
+                    arr.[i] <- _idx arr (int j)
                     arr.[j] <- tmp
                 j <- j + 1
             i <- i + 1
@@ -132,7 +120,7 @@ let rec sort_int (xs: int array) =
         __ret
     with
         | Return -> __ret
-let rec sort_string (xs: string array) =
+and sort_string (xs: string array) =
     let mutable __ret : string array = Unchecked.defaultof<string array>
     let mutable xs = xs
     try
@@ -141,9 +129,9 @@ let rec sort_string (xs: string array) =
         while i < (Seq.length (arr)) do
             let mutable j: int = i + 1
             while j < (Seq.length (arr)) do
-                if (_idx arr (j)) < (_idx arr (i)) then
-                    let tmp: string = _idx arr (i)
-                    arr.[i] <- _idx arr (j)
+                if (_idx arr (int j)) < (_idx arr (int i)) then
+                    let tmp: string = _idx arr (int i)
+                    arr.[i] <- _idx arr (int j)
                     arr.[j] <- tmp
                 j <- j + 1
             i <- i + 1
@@ -152,7 +140,7 @@ let rec sort_string (xs: string array) =
         __ret
     with
         | Return -> __ret
-let rec mode_int (lst: int array) =
+and mode_int (lst: int array) =
     let mutable __ret : int array = Unchecked.defaultof<int array>
     let mutable lst = lst
     try
@@ -162,19 +150,19 @@ let rec mode_int (lst: int array) =
         let mutable counts: int array = Array.empty<int>
         let mutable i: int = 0
         while i < (Seq.length (lst)) do
-            counts <- Array.append counts [|(count_int (lst) (_idx lst (i)))|]
+            counts <- Array.append counts [|(count_int (lst) (_idx lst (int i)))|]
             i <- i + 1
         let mutable max_count: int = 0
         i <- 0
         while i < (Seq.length (counts)) do
-            if (_idx counts (i)) > max_count then
-                max_count <- _idx counts (i)
+            if (_idx counts (int i)) > max_count then
+                max_count <- _idx counts (int i)
             i <- i + 1
         let mutable modes: int array = Array.empty<int>
         i <- 0
         while i < (Seq.length (lst)) do
-            if (_idx counts (i)) = max_count then
-                let v: int = _idx lst (i)
+            if (_idx counts (int i)) = max_count then
+                let v: int = _idx lst (int i)
                 if not (contains_int (modes) (v)) then
                     modes <- Array.append modes [|v|]
             i <- i + 1
@@ -183,7 +171,7 @@ let rec mode_int (lst: int array) =
         __ret
     with
         | Return -> __ret
-let rec mode_string (lst: string array) =
+and mode_string (lst: string array) =
     let mutable __ret : string array = Unchecked.defaultof<string array>
     let mutable lst = lst
     try
@@ -193,19 +181,19 @@ let rec mode_string (lst: string array) =
         let mutable counts: int array = Array.empty<int>
         let mutable i: int = 0
         while i < (Seq.length (lst)) do
-            counts <- Array.append counts [|(count_string (lst) (_idx lst (i)))|]
+            counts <- Array.append counts [|(count_string (lst) (_idx lst (int i)))|]
             i <- i + 1
         let mutable max_count: int = 0
         i <- 0
         while i < (Seq.length (counts)) do
-            if (_idx counts (i)) > max_count then
-                max_count <- _idx counts (i)
+            if (_idx counts (int i)) > max_count then
+                max_count <- _idx counts (int i)
             i <- i + 1
         let mutable modes: string array = Array.empty<string>
         i <- 0
         while i < (Seq.length (lst)) do
-            if (_idx counts (i)) = max_count then
-                let v: string = _idx lst (i)
+            if (_idx counts (int i)) = max_count then
+                let v: string = _idx lst (int i)
                 if not (contains_string (modes) (v)) then
                     modes <- Array.append modes [|v|]
             i <- i + 1
@@ -214,11 +202,11 @@ let rec mode_string (lst: string array) =
         __ret
     with
         | Return -> __ret
-printfn "%s" (_repr (mode_int (unbox<int array> [|2; 3; 4; 5; 3; 4; 2; 5; 2; 2; 4; 2; 2; 2|])))
-printfn "%s" (_repr (mode_int (unbox<int array> [|3; 4; 5; 3; 4; 2; 5; 2; 2; 4; 4; 2; 2; 2|])))
-printfn "%s" (_repr (mode_int (unbox<int array> [|3; 4; 5; 3; 4; 2; 5; 2; 2; 4; 4; 4; 2; 2; 4; 2|])))
-printfn "%s" (_repr (mode_string (unbox<string array> [|"x"; "y"; "y"; "z"|])))
-printfn "%s" (_repr (mode_string (unbox<string array> [|"x"; "x"; "y"; "y"; "z"|])))
+ignore (printfn "%s" (_repr (mode_int (unbox<int array> [|2; 3; 4; 5; 3; 4; 2; 5; 2; 2; 4; 2; 2; 2|]))))
+ignore (printfn "%s" (_repr (mode_int (unbox<int array> [|3; 4; 5; 3; 4; 2; 5; 2; 2; 4; 4; 2; 2; 2|]))))
+ignore (printfn "%s" (_repr (mode_int (unbox<int array> [|3; 4; 5; 3; 4; 2; 5; 2; 2; 4; 4; 4; 2; 2; 4; 2|]))))
+ignore (printfn "%s" (_repr (mode_string (unbox<string array> [|"x"; "y"; "y"; "z"|]))))
+ignore (printfn "%s" (_repr (mode_string (unbox<string array> [|"x"; "x"; "y"; "y"; "z"|]))))
 let __bench_end = _now()
 let __mem_end = System.GC.GetTotalMemory(true)
 printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)

--- a/tests/algorithms/transpiler/FS/maths/decimal_to_fraction.bench
+++ b/tests/algorithms/transpiler/FS/maths/decimal_to_fraction.bench
@@ -1,5 +1,5 @@
 {
   "duration_us": 571223,
-  "memory_bytes": 84216,
+  "memory_bytes": 70488,
   "name": "main"
 }

--- a/tests/algorithms/transpiler/FS/maths/decimal_to_fraction.fs
+++ b/tests/algorithms/transpiler/FS/maths/decimal_to_fraction.fs
@@ -1,4 +1,4 @@
-// Generated 2025-08-12 08:17 +0700
+// Generated 2025-08-14 18:14 +0700
 
 exception Break
 exception Continue
@@ -33,13 +33,15 @@ let _substring (s:string) (start:int) (finish:int) =
     s.Substring(st, en - st)
 
 let rec _str v =
-    let s = sprintf "%A" v
-    let s = if s.EndsWith(".0") then s.Substring(0, s.Length - 2) else s
-    s.Replace("[|", "[")
-     .Replace("|]", "]")
-     .Replace("; ", " ")
-     .Replace(";", "")
-     .Replace("\"", "")
+    match box v with
+    | :? float as f -> sprintf "%.15g" f
+    | _ ->
+        let s = sprintf "%A" v
+        s.Replace("[|", "[")
+         .Replace("|]", "]")
+         .Replace("; ", " ")
+         .Replace(";", "")
+         .Replace("\"", "")
 let _floordiv (a:int) (b:int) : int =
     let q = a / b
     let r = a % b
@@ -87,7 +89,7 @@ and parse_decimal (s: string) =
     let mutable s = s
     try
         if (String.length (s)) = 0 then
-            failwith ("invalid number")
+            ignore (failwith ("invalid number"))
         let mutable idx: int = 0
         let mutable sign: int = 1
         let first: string = _substring s 0 1
@@ -148,12 +150,12 @@ and parse_decimal (s: string) =
                     exp_str <- exp_str + c
                     idx <- idx + 1
                 else
-                    failwith ("invalid number")
+                    ignore (failwith ("invalid number"))
             if (String.length (exp_str)) = 0 then
-                failwith ("invalid number")
+                ignore (failwith ("invalid number"))
             exp <- exp_sign * (int (int (exp_str)))
         if idx <> (String.length (s)) then
-            failwith ("invalid number")
+            ignore (failwith ("invalid number"))
         if (String.length (int_part)) = 0 then
             int_part <- "0"
         let mutable num_str: string = int_part + frac_part
@@ -176,7 +178,7 @@ and reduce (fr: Fraction) =
     let mutable fr = fr
     try
         let g: int = gcd (fr._numerator) (fr._denominator)
-        __ret <- { _numerator = _floordiv (fr._numerator) g; _denominator = _floordiv (fr._denominator) g }
+        __ret <- { _numerator = _floordiv (int (fr._numerator)) (int g); _denominator = _floordiv (int (fr._denominator)) (int g) }
         raise Return
         __ret
     with
@@ -200,44 +202,44 @@ and decimal_to_fraction (x: float) =
     with
         | Return -> __ret
 and assert_fraction (name: string) (fr: Fraction) (num: int) (den: int) =
-    let mutable __ret : unit = Unchecked.defaultof<unit>
+    let mutable __ret : obj = Unchecked.defaultof<obj>
     let mutable name = name
     let mutable fr = fr
     let mutable num = num
     let mutable den = den
     try
         if ((fr._numerator) <> num) || ((fr._denominator) <> den) then
-            failwith (name)
+            ignore (failwith (name))
         __ret
     with
         | Return -> __ret
 and test_decimal_to_fraction () =
-    let mutable __ret : unit = Unchecked.defaultof<unit>
+    let mutable __ret : obj = Unchecked.defaultof<obj>
     try
-        assert_fraction ("case1") (decimal_to_fraction (2.0)) (2) (1)
-        assert_fraction ("case2") (decimal_to_fraction (89.0)) (89) (1)
-        assert_fraction ("case3") (decimal_to_fraction_str ("67")) (67) (1)
-        assert_fraction ("case4") (decimal_to_fraction_str ("45.0")) (45) (1)
-        assert_fraction ("case5") (decimal_to_fraction (1.5)) (3) (2)
-        assert_fraction ("case6") (decimal_to_fraction_str ("6.25")) (25) (4)
-        assert_fraction ("case7") (decimal_to_fraction (0.0)) (0) (1)
-        assert_fraction ("case8") (decimal_to_fraction (-2.5)) (-5) (2)
-        assert_fraction ("case9") (decimal_to_fraction (0.125)) (1) (8)
-        assert_fraction ("case10") (decimal_to_fraction (1000000.25)) (4000001) (4)
-        assert_fraction ("case11") (decimal_to_fraction (1.3333)) (13333) (10000)
-        assert_fraction ("case12") (decimal_to_fraction_str ("1.23e2")) (123) (1)
-        assert_fraction ("case13") (decimal_to_fraction_str ("0.500")) (1) (2)
+        ignore (assert_fraction ("case1") (decimal_to_fraction (2.0)) (2) (1))
+        ignore (assert_fraction ("case2") (decimal_to_fraction (89.0)) (89) (1))
+        ignore (assert_fraction ("case3") (decimal_to_fraction_str ("67")) (67) (1))
+        ignore (assert_fraction ("case4") (decimal_to_fraction_str ("45.0")) (45) (1))
+        ignore (assert_fraction ("case5") (decimal_to_fraction (1.5)) (3) (2))
+        ignore (assert_fraction ("case6") (decimal_to_fraction_str ("6.25")) (25) (4))
+        ignore (assert_fraction ("case7") (decimal_to_fraction (0.0)) (0) (1))
+        ignore (assert_fraction ("case8") (decimal_to_fraction (-2.5)) (-5) (2))
+        ignore (assert_fraction ("case9") (decimal_to_fraction (0.125)) (1) (8))
+        ignore (assert_fraction ("case10") (decimal_to_fraction (1000000.25)) (4000001) (4))
+        ignore (assert_fraction ("case11") (decimal_to_fraction (1.3333)) (13333) (10000))
+        ignore (assert_fraction ("case12") (decimal_to_fraction_str ("1.23e2")) (123) (1))
+        ignore (assert_fraction ("case13") (decimal_to_fraction_str ("0.500")) (1) (2))
         __ret
     with
         | Return -> __ret
 and main () =
-    let mutable __ret : unit = Unchecked.defaultof<unit>
+    let mutable __ret : obj = Unchecked.defaultof<obj>
     try
         let __bench_start = _now()
         let __mem_start = System.GC.GetTotalMemory(true)
-        test_decimal_to_fraction()
+        ignore (test_decimal_to_fraction())
         let fr: Fraction = decimal_to_fraction (1.5)
-        printfn "%s" (((_str (fr._numerator)) + "/") + (_str (fr._denominator)))
+        ignore (printfn "%s" (((_str (fr._numerator)) + "/") + (_str (fr._denominator))))
         let __bench_end = _now()
         let __mem_end = System.GC.GetTotalMemory(true)
         printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)
@@ -245,4 +247,4 @@ and main () =
         __ret
     with
         | Return -> __ret
-main()
+ignore (main())

--- a/transpiler/x/fs/ALGORITHMS.md
+++ b/transpiler/x/fs/ALGORITHMS.md
@@ -1,7 +1,7 @@
 # F# Algorithms Transpiler Output
 
 Completed programs: 921/1077
-Last updated: 2025-08-14 17:48 +0700
+Last updated: 2025-08-14 18:14 +0700
 
 Checklist:
 
@@ -543,7 +543,7 @@ Checklist:
 | 534 | maths/average_absolute_deviation | ✓ | 571.223ms | 56.8 KB |
 | 535 | maths/average_mean | ✓ | 571.223ms | 56.1 KB |
 | 536 | maths/average_median | ✓ | 571.223ms | 60.0 KB |
-| 537 | maths/average_mode | ✓ | 571.223ms | 58.0 KB |
+| 537 | maths/average_mode | ✓ | 571.223ms | 58.1 KB |
 | 538 | maths/bailey_borwein_plouffe | ✓ | 571.223ms | 58.7 KB |
 | 539 | maths/base_neg2_conversion |   |  |  |
 | 540 | maths/basic_maths | ✓ | 571.223ms | 62.2 KB |
@@ -560,7 +560,7 @@ Checklist:
 | 551 | maths/combinations | ✓ | 571.223ms | 78.1 KB |
 | 552 | maths/continued_fraction | ✓ | 571.223ms | 78.0 KB |
 | 553 | maths/decimal_isolate | ✓ | 571.223ms | 79.1 KB |
-| 554 | maths/decimal_to_fraction | ✓ | 571.223ms | 82.2 KB |
+| 554 | maths/decimal_to_fraction | ✓ | 571.223ms | 68.8 KB |
 | 555 | maths/dodecahedron | ✓ | 571.223ms | 33.5 KB |
 | 556 | maths/double_factorial | ✓ | 571.223ms | 43.4 KB |
 | 557 | maths/dual_number_automatic_differentiation | ✓ | 571.223ms | 34.0 KB |

--- a/transpiler/x/fs/README.md
+++ b/transpiler/x/fs/README.md
@@ -112,4 +112,4 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-Last updated: 2025-08-14 17:48 +0700
+Last updated: 2025-08-14 18:14 +0700

--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-08-14 18:14 +0700)
+- fs: print floats without trailing zeros
+- Generated F# for 103/105 programs (103 passing)
+
 ## Progress (2025-08-14 17:48 +0700)
 - fs: add toi helper
 - Generated F# for 103/105 programs (103 passing)

--- a/transpiler/x/fs/transpiler.go
+++ b/transpiler/x/fs/transpiler.go
@@ -228,7 +228,7 @@ const helperJSON = `let json (arr:obj) =
 
 const helperStr = `let rec _str v =
     match box v with
-    | :? float as f -> sprintf "%g" f
+    | :? float as f -> sprintf "%.15g" f
     | _ ->
         let s = sprintf "%A" v
         s.Replace("[|", "[")


### PR DESCRIPTION
## Summary
- handle float to string without scientific notation in F# transpiler
- regenerate average_mode and decimal_to_fraction outputs with new benchmarks
- refresh algorithm docs

## Testing
- `MOCHI_ALGORITHMS_INDEX=537 go test -run TestFSTranspiler_Algorithms_Golden -tags slow ./transpiler/x/fs -count=1`
- `MOCHI_ALGORITHMS_INDEX=554 go test -run TestFSTranspiler_Algorithms_Golden -tags slow ./transpiler/x/fs -count=1`


------
https://chatgpt.com/codex/tasks/task_e_689dc5280c448320bf2a901540b59934