### PR TITLE
feat: partial match block support in C transpiler

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -523,7 +523,8 @@ type IfExpr struct {
 type MatchCase struct {
 	Pos     lexer.Position `json:"pos,omitempty" parser:""`
 	Pattern *Expr          `json:"pattern,omitempty" parser:"@@ '=>'"`
-	Result  *Expr          `json:"result,omitempty" parser:"@@"`
+	Block   []*Statement   `json:"block,omitempty" parser:"[ '{' @@* '}' ]"`
+	Result  *Expr          `json:"result,omitempty" parser:"[ @@ ]"`
 }
 
 type Primary struct {


### PR DESCRIPTION
## Summary
- allow match cases to parse optional statement blocks
- add helper structs and functions in C transpiler for block matches

## Testing
- `MOCHI_ALG_INDEX=412 MOCHI_BENCHMARK=1 go test ./transpiler/x/c -run TestCTranspiler_Algorithms_Golden -update-algorithms-c -count=1 -tags slow` *(fails: parse error at graphs/deep_clone_graph.mochi)*

------
https://chatgpt.com/codex/tasks/task_e_689dcfe4922883208ac549db3d649830