### PR TITLE
dart: handle toi builtin

### DIFF
--- a/tests/algorithms/x/Dart/graphs/frequent_pattern_graph_miner.bench
+++ b/tests/algorithms/x/Dart/graphs/frequent_pattern_graph_miner.bench
@@ -1,6 +1,1 @@
-../../../tests/algorithms/x/Dart/graphs/frequent_pattern_graph_miner.dart:132:9: Error: Method not found: 'toi'.
-    if (toi((table[j]["count"] ?? "")).compareTo(toi((table[max_i]["count"] ?? ""))) > 0) {
-        ^^^
-../../../tests/algorithms/x/Dart/graphs/frequent_pattern_graph_miner.dart:132:50: Error: Method not found: 'toi'.
-    if (toi((table[j]["count"] ?? "")).compareTo(toi((table[max_i]["count"] ?? ""))) > 0) {
-                                                 ^^^
+{"duration_us":22398,"memory_bytes":5738496,"name":"_start"}

--- a/tests/algorithms/x/Dart/graphs/frequent_pattern_graph_miner.dart
+++ b/tests/algorithms/x/Dart/graphs/frequent_pattern_graph_miner.dart
@@ -129,7 +129,7 @@ List<Map<String, String>> get_frequency_table(List<List<List<String>>> edge_arra
     int max_i = i;
     int j = i + 1;
     while (j < table.length) {
-    if (toi((table[j]["count"] ?? "")).compareTo(toi((table[max_i]["count"] ?? ""))) > 0) {
+    if (int.parse((table[j]["count"] ?? "")) > int.parse((table[max_i]["count"] ?? ""))) {
     max_i = j;
   }
     j = j + 1;

--- a/tests/algorithms/x/Dart/graphs/frequent_pattern_graph_miner.error
+++ b/tests/algorithms/x/Dart/graphs/frequent_pattern_graph_miner.error
@@ -1,7 +1,0 @@
-run: exit status 254
-../../../tests/algorithms/x/Dart/graphs/frequent_pattern_graph_miner.dart:132:9: Error: Method not found: 'toi'.
-    if (toi((table[j]["count"] ?? "")).compareTo(toi((table[max_i]["count"] ?? ""))) > 0) {
-        ^^^
-../../../tests/algorithms/x/Dart/graphs/frequent_pattern_graph_miner.dart:132:50: Error: Method not found: 'toi'.
-    if (toi((table[j]["count"] ?? "")).compareTo(toi((table[max_i]["count"] ?? ""))) > 0) {
-                                                 ^^^

--- a/tests/algorithms/x/Dart/graphs/frequent_pattern_graph_miner.out
+++ b/tests/algorithms/x/Dart/graphs/frequent_pattern_graph_miner.out
@@ -1,6 +1,69 @@
-../../../tests/algorithms/x/Dart/graphs/frequent_pattern_graph_miner.dart:109:9: Error: Method not found: 'toi'.
-    if (toi((table[j]["count"] ?? "")).compareTo(toi((table[max_i]["count"] ?? ""))) > 0) {
-        ^^^
-../../../tests/algorithms/x/Dart/graphs/frequent_pattern_graph_miner.dart:109:50: Error: Method not found: 'toi'.
-    if (toi((table[j]["count"] ?? "")).compareTo(toi((table[max_i]["count"] ?? ""))) > 0) {
-                                                 ^^^
+Nodes
+
+11111
+[ab, ac, bc, bd, df]
+11011
+[cd]
+11101
+[de, ef, eg, fg]
+11001
+[ad]
+10101
+[dg]
+10010
+[dh, bh]
+11000
+[be]
+10001
+[ce]
+10100
+[gh]
+10000
+[hi]
+00100
+[eh, fh]
+
+Support
+
+[100, 80, 60, 40, 20]
+
+Cluster
+
+5:[11111]
+4:[11011, 11101]
+3:[11001, 10101]
+2:[10010, 11000, 10001, 10100]
+1:[10000, 00100]
+
+Graph
+
+Header
+[11111]
+11111
+[Header]
+10000
+[10010, 11000, 10001, 10100]
+10010
+[11011]
+11000
+[11001]
+10001
+[11001, 10101]
+10100
+[10101]
+00100
+[10100]
+11011
+[11111]
+11001
+[11011, 11101]
+10101
+[11101]
+11101
+[11111]
+
+Edge List of Frequent subgraphs
+
+[[a, d], [c, d], [a, b], [a, c], [b, c], [b, d], [d, f]]
+[[a, d], [d, e], [e, f], [e, g], [f, g], [a, b], [a, c], [b, c], [b, d], [d, f]]
+[[d, g], [d, e], [e, f], [e, g], [f, g], [a, b], [a, c], [b, c], [b, d], [d, f]]

--- a/transpiler/x/dart/ALGORITHMS.md
+++ b/transpiler/x/dart/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated Dart code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Dart`.
-Last updated: 2025-08-14 18:41 GMT+7
+Last updated: 2025-08-15 10:07 GMT+7
 
-## Algorithms Golden Test Checklist (943/1077)
+## Algorithms Golden Test Checklist (944/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 16.068ms | 2.7 MB |
@@ -432,7 +432,7 @@ Last updated: 2025-08-14 18:41 GMT+7
 | 423 | graphs/eulerian_path_and_circuit_for_undirected_graph | ✓ | 42.858ms | 9.1 MB |
 | 424 | graphs/even_tree | ✓ | 36.334ms | 8.9 MB |
 | 425 | graphs/finding_bridges | ✓ | 35.596ms | 8.9 MB |
-| 426 | graphs/frequent_pattern_graph_miner | error |  |  |
+| 426 | graphs/frequent_pattern_graph_miner | ✓ | 22.398ms | 5.5 MB |
 | 427 | graphs/g_topological_sort | ✓ | 23.326ms | 2.5 MB |
 | 428 | graphs/gale_shapley_bigraph | ✓ | 37.587ms | 10.0 MB |
 | 429 | graphs/graph_adjacency_list | ✓ | 33.034ms | 3.7 MB |

--- a/transpiler/x/dart/transpiler.go
+++ b/transpiler/x/dart/transpiler.go
@@ -5948,6 +5948,13 @@ func convertPrimary(p *parser.Primary) (Expr, error) {
 			}
 			return &CastExpr{Value: v, Type: "int"}, nil
 		}
+		if p.Call.Func == "toi" && len(p.Call.Args) == 1 {
+			v, err := convertExpr(p.Call.Args[0])
+			if err != nil {
+				return nil, err
+			}
+			return &CallExpr{Func: &SelectorExpr{Receiver: &Name{Name: "int"}, Field: "parse"}, Args: []Expr{v}}, nil
+		}
 		if p.Call.Func == "parseIntStr" && (len(p.Call.Args) == 1 || len(p.Call.Args) == 2) {
 			arg, err := convertExpr(p.Call.Args[0])
 			if err != nil {


### PR DESCRIPTION
## Summary
- handle `toi` builtin by converting to `int.parse` in Dart transpiler
- regenerate graphs/frequent_pattern_graph_miner golden files and benchmarks
- mark frequent_pattern_graph_miner as passing in algorithms checklist

## Testing
- `MOCHI_ALG_INDEX=426 go test ./transpiler/x/dart -run TestDartTranspiler_Algorithms_Golden -update-algorithms-dart -tags=slow`
- `MOCHI_ALG_INDEX=426 MOCHI_BENCHMARK=1 go test ./transpiler/x/dart -run TestDartTranspiler_Algorithms_Golden -update-algorithms-dart -tags=slow`


------
https://chatgpt.com/codex/tasks/task_e_689ea2ad50848320a3687048d4bc1571