### PR TITLE
Fix Dart transpiler list typing for nested empty lists

### DIFF
--- a/tests/algorithms/x/Dart/graphs/check_cycle.bench
+++ b/tests/algorithms/x/Dart/graphs/check_cycle.bench
@@ -1,4 +1,1 @@
-../../../tests/algorithms/x/Dart/graphs/check_cycle.dart:99:26: Error: The argument type 'List<List<dynamic>>' can't be assigned to the parameter type 'List<List<int>>'.
- - 'List' is from 'dart:core'.
-  print_bool(check_cycle(g1));
-                         ^
+{"duration_us":9573,"memory_bytes":3014656,"name":"main"}

--- a/tests/algorithms/x/Dart/graphs/check_cycle.dart
+++ b/tests/algorithms/x/Dart/graphs/check_cycle.dart
@@ -59,8 +59,8 @@ bool depth_first_search(List<List<int>> graph, int vertex, List<bool> visited, L
 
 bool check_cycle(List<List<int>> graph) {
   int n = graph.length;
-  List<bool> visited = <bool>[];
-  List<bool> rec_stk = <bool>[];
+  List<dynamic> visited = <dynamic>[];
+  List<dynamic> rec_stk = <dynamic>[];
   int i = 0;
   while (i < n) {
     visited = [...visited, false];
@@ -70,7 +70,7 @@ bool check_cycle(List<List<int>> graph) {
   i = 0;
   while (i < n) {
     if (!visited[i]) {
-    if (depth_first_search(graph, i, visited, rec_stk)) {
+    if (depth_first_search(graph, i, List<bool>.from(visited), List<bool>.from(rec_stk))) {
     return true;
   };
   }
@@ -87,7 +87,7 @@ void print_bool(bool b) {
   }
 }
 
-List<List<dynamic>> g1 = [[], [0, 3], [0, 4], [5], [5], []];
+List<List<int>> g1 = [<int>[], [0, 3], [0, 4], [5], [5], <int>[]];
 List<List<int>> g2 = [[1, 2], [2], [0, 3], [3]];
 void main() {
   var _benchMem0 = ProcessInfo.currentRss;

--- a/tests/algorithms/x/Dart/graphs/check_cycle.error
+++ b/tests/algorithms/x/Dart/graphs/check_cycle.error
@@ -1,5 +1,0 @@
-run: exit status 254
-../../../tests/algorithms/x/Dart/graphs/check_cycle.dart:99:26: Error: The argument type 'List<List<dynamic>>' can't be assigned to the parameter type 'List<List<int>>'.
- - 'List' is from 'dart:core'.
-  print_bool(check_cycle(g1));
-                         ^

--- a/tests/algorithms/x/Dart/graphs/check_cycle.out
+++ b/tests/algorithms/x/Dart/graphs/check_cycle.out
@@ -1,4 +1,2 @@
-../../../tests/algorithms/x/Dart/graphs/check_cycle.dart:67:26: Error: The argument type 'List<List<dynamic>>' can't be assigned to the parameter type 'List<List<int>>'.
- - 'List' is from 'dart:core'.
-  print_bool(check_cycle(g1));
-                         ^
+0
+1

--- a/transpiler/x/dart/ALGORITHMS.md
+++ b/transpiler/x/dart/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated Dart code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Dart`.
-Last updated: 2025-08-15 10:07 GMT+7
+Last updated: 2025-08-15 10:39 GMT+7
 
-## Algorithms Golden Test Checklist (944/1077)
+## Algorithms Golden Test Checklist (945/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 16.068ms | 2.7 MB |
@@ -416,7 +416,7 @@ Last updated: 2025-08-15 10:07 GMT+7
 | 407 | graphs/breadth_first_search_shortest_path_2 | ✓ | 13.758ms | 2.4 MB |
 | 408 | graphs/breadth_first_search_zero_one_shortest_path | ✓ | 18.581ms | 2.6 MB |
 | 409 | graphs/check_bipatrite | ✓ | 19.526ms | 3.4 MB |
-| 410 | graphs/check_cycle | error |  |  |
+| 410 | graphs/check_cycle | ✓ | 9.573ms | 2.9 MB |
 | 411 | graphs/connected_components | ✓ | 42.457ms | 8.9 MB |
 | 412 | graphs/deep_clone_graph | error |  |  |
 | 413 | graphs/depth_first_search | ✓ | 18.223ms | 2.6 MB |


### PR DESCRIPTION
## Summary
- ensure Dart transpiler infers element types for nested empty lists
- add precise list type inference for variable declarations
- regenerate Dart artifacts for `graphs/check_cycle`

## Testing
- `MOCHI_ALG_INDEX=410 go test -count=1 -tags=slow -run TestDartTranspiler_Algorithms_Golden ./transpiler/x/dart -args -update-algorithms-dart`
- `MOCHI_ALG_INDEX=410 MOCHI_BENCHMARK=1 go test -count=1 -tags=slow ./transpiler/x/dart -run TestDartTranspiler_Algorithms_Golden`


------
https://chatgpt.com/codex/tasks/task_e_689ea6124dac8320a2f8076f5d9cb77d