### PR TITLE
fs: regenerate graph adjacency list outputs

### DIFF
--- a/tests/algorithms/transpiler/FS/graphs/graph_adjacency_list.bench
+++ b/tests/algorithms/transpiler/FS/graphs/graph_adjacency_list.bench
@@ -1,5 +1,5 @@
 {
   "duration_us": 571223,
-  "memory_bytes": 74400,
+  "memory_bytes": 66992,
   "name": "main"
 }

--- a/transpiler/x/fs/ALGORITHMS.md
+++ b/transpiler/x/fs/ALGORITHMS.md
@@ -1,7 +1,7 @@
 # F# Algorithms Transpiler Output
 
 Completed programs: 921/1077
-Last updated: 2025-08-14 18:14 +0700
+Last updated: 2025-08-15 10:20 +0700
 
 Checklist:
 
@@ -435,7 +435,7 @@ Checklist:
 | 426 | graphs/frequent_pattern_graph_miner |   |  |  |
 | 427 | graphs/g_topological_sort | ✓ | 571.223ms | 78.5 KB |
 | 428 | graphs/gale_shapley_bigraph | ✓ | 571.223ms | 55.6 KB |
-| 429 | graphs/graph_adjacency_list | ✓ | 571.223ms | 72.7 KB |
+| 429 | graphs/graph_adjacency_list | ✓ | 571.223ms | 65.4 KB |
 | 430 | graphs/graph_adjacency_matrix |   |  |  |
 | 431 | graphs/graph_list | ✓ | 571.223ms | 77.3 KB |
 | 432 | graphs/graphs_floyd_warshall | ✓ | 571.223ms | 69.4 KB |

--- a/transpiler/x/fs/README.md
+++ b/transpiler/x/fs/README.md
@@ -112,4 +112,4 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-Last updated: 2025-08-14 18:14 +0700
+Last updated: 2025-08-15 10:20 +0700

--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-08-15 10:20 +0700)
+- php: support toi builtin and reserve reset
+- Generated F# for 103/105 programs (103 passing)
+
 ## Progress (2025-08-14 18:14 +0700)
 - fs: print floats without trailing zeros
 - Generated F# for 103/105 programs (103 passing)


### PR DESCRIPTION
## Summary
- Regenerate F# code and benchmark output for `graph_adjacency_list` algorithm
- Refresh F# algorithms progress docs

## Testing
- `MOCHI_ALGORITHMS_INDEX=429 go test ./transpiler/x/fs -run TestFSTranspiler_Algorithms_Golden -tags slow -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_689ea668a8288320bac9134d585b240e