### PR TITLE
php: support sha256 builtin and refresh benchmarks

### DIFF
--- a/tests/algorithms/x/PHP/graphs/graph_adjacency_list.bench
+++ b/tests/algorithms/x/PHP/graphs/graph_adjacency_list.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 110,
+  "duration_us": 210,
   "memory_bytes": 71208,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/graph_adjacency_list.php
+++ b/tests/algorithms/x/PHP/graphs/graph_adjacency_list.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -24,7 +39,9 @@ function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-function create_graph($vertices, $edges, $directed) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function create_graph($vertices, $edges, $directed) {
   $adj = [];
   foreach ($vertices as $v) {
   $adj[$v] = [];
@@ -44,8 +61,8 @@ function create_graph($vertices, $edges, $directed) {
 }
 };
   return ['adj' => $adj, 'directed' => $directed];
-}
-function add_vertex($graph, $v) {
+};
+  function add_vertex($graph, $v) {
   if (isset($graph['adj'][$v])) {
   _panic('vertex exists');
 }
@@ -55,8 +72,8 @@ function add_vertex($graph, $v) {
 };
   $adj[$v] = [];
   return ['adj' => $adj, 'directed' => $graph['directed']];
-}
-function remove_from_list($lst, $value) {
+};
+  function remove_from_list($lst, $value) {
   $res = [];
   $i = 0;
   while ($i < count($lst)) {
@@ -66,8 +83,8 @@ function remove_from_list($lst, $value) {
   $i = $i + 1;
 };
   return $res;
-}
-function remove_key($m, $key) {
+};
+  function remove_key($m, $key) {
   $res = [];
   foreach (array_keys($m) as $k) {
   if ($k != $key) {
@@ -75,8 +92,8 @@ function remove_key($m, $key) {
 }
 };
   return $res;
-}
-function add_edge($graph, $s, $d) {
+};
+  function add_edge($graph, $s, $d) {
   if (((!(isset($graph['adj'][$s]))) || (!(isset($graph['adj'][$d]))))) {
   _panic('vertex missing');
 }
@@ -96,8 +113,8 @@ function add_edge($graph, $s, $d) {
   $adj[$d] = $list_d;
 }
   return ['adj' => $adj, 'directed' => $graph['directed']];
-}
-function remove_edge($graph, $s, $d) {
+};
+  function remove_edge($graph, $s, $d) {
   if (((!(isset($graph['adj'][$s]))) || (!(isset($graph['adj'][$d]))))) {
   _panic('vertex missing');
 }
@@ -113,8 +130,8 @@ function remove_edge($graph, $s, $d) {
   $adj[$d] = remove_from_list($adj[$d], $s);
 }
   return ['adj' => $adj, 'directed' => $graph['directed']];
-}
-function remove_vertex($graph, $v) {
+};
+  function remove_vertex($graph, $v) {
   if (!(isset($graph['adj'][$v]))) {
   _panic('vertex missing');
 }
@@ -125,11 +142,11 @@ function remove_vertex($graph, $v) {
 }
 };
   return ['adj' => $adj, 'directed' => $graph['directed']];
-}
-function contains_vertex($graph, $v) {
+};
+  function contains_vertex($graph, $v) {
   return isset($graph['adj'][$v]);
-}
-function contains_edge($graph, $s, $d) {
+};
+  function contains_edge($graph, $s, $d) {
   if (((!(isset($graph['adj'][$s]))) || (!(isset($graph['adj'][$d]))))) {
   _panic('vertex missing');
 }
@@ -139,14 +156,14 @@ function contains_edge($graph, $s, $d) {
 }
 };
   return false;
-}
-function clear_graph($graph) {
+};
+  function clear_graph($graph) {
   return ['adj' => [], 'directed' => $graph['directed']];
-}
-function to_string($graph) {
+};
+  function to_string($graph) {
   return _str($graph['adj']);
-}
-function main() {
+};
+  function main() {
   $vertices = ['1', '2', '3', '4'];
   $edges = [['1', '2'], ['2', '3'], ['3', '4']];
   $g = create_graph($vertices, $edges, false);
@@ -157,5 +174,13 @@ function main() {
   $g = remove_edge($g, '1', '2');
   $g = remove_vertex($g, '3');
   echo rtrim(to_string($g)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/graph_adjacency_matrix.bench
+++ b/tests/algorithms/x/PHP/graphs/graph_adjacency_matrix.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 103,
+  "duration_us": 161,
   "memory_bytes": 72136,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/graph_adjacency_matrix.php
+++ b/tests/algorithms/x/PHP/graphs/graph_adjacency_matrix.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _len($x) {
     if ($x === null) { return 0; }
     if (is_array($x)) { return count($x); }
@@ -30,7 +45,9 @@ function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-function make_graph($vertices, $edges, $directed) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function make_graph($vertices, $edges, $directed) {
   $g = ['directed' => $directed, 'vertex_to_index' => [], 'adj_matrix' => []];
   $i = 0;
   while ($i < count($vertices)) {
@@ -44,11 +61,11 @@ function make_graph($vertices, $edges, $directed) {
   $j = $j + 1;
 };
   return $g;
-}
-function contains_vertex($g, $v) {
+};
+  function contains_vertex($g, $v) {
   return isset($g['vertex_to_index'][$v]);
-}
-function add_vertex(&$g, $v) {
+};
+  function add_vertex(&$g, $v) {
   if (contains_vertex($g, $v)) {
   _panic('vertex already exists');
 }
@@ -69,8 +86,8 @@ function add_vertex(&$g, $v) {
   $idx_map = $g['vertex_to_index'];
   $idx_map[$v] = count($matrix) - 1;
   $g['vertex_to_index'] = $idx_map;
-}
-function remove_key($m, $k) {
+};
+  function remove_key($m, $k) {
   global $g;
   $out = [];
   foreach (array_keys($m) as $key) {
@@ -79,8 +96,8 @@ function remove_key($m, $k) {
 }
 };
   return $out;
-}
-function decrement_indices($m, $start) {
+};
+  function decrement_indices($m, $start) {
   global $g;
   $out = [];
   foreach (array_keys($m) as $key) {
@@ -92,8 +109,8 @@ function decrement_indices($m, $start) {
 }
 };
   return $out;
-}
-function remove_vertex(&$g, $v) {
+};
+  function remove_vertex(&$g, $v) {
   if (!contains_vertex($g, $v)) {
   _panic('vertex does not exist');
 }
@@ -118,8 +135,8 @@ function remove_vertex(&$g, $v) {
   $g['adj_matrix'] = $new_matrix;
   $m = remove_key($g['vertex_to_index'], $v);
   $g['vertex_to_index'] = decrement_indices($m, $idx);
-}
-function add_edge(&$g, $u, $v) {
+};
+  function add_edge(&$g, $u, $v) {
   if (!(contains_vertex($g, $u) && contains_vertex($g, $v))) {
   _panic('missing vertex');
 }
@@ -131,8 +148,8 @@ function add_edge(&$g, $u, $v) {
   $matrix[$j][$i] = 1;
 }
   $g['adj_matrix'] = $matrix;
-}
-function remove_edge(&$g, $u, $v) {
+};
+  function remove_edge(&$g, $u, $v) {
   if (!(contains_vertex($g, $u) && contains_vertex($g, $v))) {
   _panic('missing vertex');
 }
@@ -144,8 +161,8 @@ function remove_edge(&$g, $u, $v) {
   $matrix[$j][$i] = 0;
 }
   $g['adj_matrix'] = $matrix;
-}
-function contains_edge($g, $u, $v) {
+};
+  function contains_edge($g, $u, $v) {
   if (!(contains_vertex($g, $u) && contains_vertex($g, $v))) {
   _panic('missing vertex');
 }
@@ -153,16 +170,24 @@ function contains_edge($g, $u, $v) {
   $j = ($g['vertex_to_index'])[$v];
   $matrix = $g['adj_matrix'];
   return $matrix[$i][$j] == 1;
-}
-function clear_graph(&$g) {
+};
+  function clear_graph(&$g) {
   $g['vertex_to_index'] = [];
   $g['adj_matrix'] = [];
-}
-$g = make_graph([1, 2, 3], [[1, 2], [2, 3]], false);
-echo rtrim(_str($g['adj_matrix'])), PHP_EOL;
-echo rtrim(_str(contains_edge($g, 1, 2))), PHP_EOL;
-echo rtrim(_str(contains_edge($g, 2, 1))), PHP_EOL;
-remove_edge($g, 1, 2);
-echo rtrim(_str(contains_edge($g, 1, 2))), PHP_EOL;
-remove_vertex($g, 2);
-echo rtrim(_str($g['adj_matrix'])), PHP_EOL;
+};
+  $g = make_graph([1, 2, 3], [[1, 2], [2, 3]], false);
+  echo rtrim(_str($g['adj_matrix'])), PHP_EOL;
+  echo rtrim(_str(contains_edge($g, 1, 2))), PHP_EOL;
+  echo rtrim(_str(contains_edge($g, 2, 1))), PHP_EOL;
+  remove_edge($g, 1, 2);
+  echo rtrim(_str(contains_edge($g, 1, 2))), PHP_EOL;
+  remove_vertex($g, 2);
+  echo rtrim(_str($g['adj_matrix'])), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/graph_list.bench
+++ b/tests/algorithms/x/PHP/graphs/graph_list.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 99,
+  "duration_us": 126,
   "memory_bytes": 37384,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/graph_list.php
+++ b/tests/algorithms/x/PHP/graphs/graph_list.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,16 +35,18 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function make_graph($directed) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function make_graph($directed) {
   global $d_graph;
   $m = [];
   return ['adj_list' => $m, 'directed' => $directed];
-}
-function contains_vertex($m, $v) {
+};
+  function contains_vertex($m, $v) {
   global $d_graph;
   return array_key_exists($v, $m);
-}
-function add_edge($g, $s, $d) {
+};
+  function add_edge($g, $s, $d) {
   global $d_graph;
   $adj = $g['adj_list'];
   if (!$g['directed']) {
@@ -69,19 +86,27 @@ function add_edge($g, $s, $d) {
 }
   $g['adj_list'] = $adj;
   return $g;
-}
-function graph_to_string($g) {
+};
+  function graph_to_string($g) {
   global $d_graph;
   return _str($g['adj_list']);
-}
-$d_graph = make_graph(true);
-$d_graph = add_edge($d_graph, _str(0), _str(1));
-echo rtrim(graph_to_string($d_graph)), PHP_EOL;
-$d_graph = add_edge($d_graph, _str(1), _str(2));
-$d_graph = add_edge($d_graph, _str(1), _str(4));
-$d_graph = add_edge($d_graph, _str(1), _str(5));
-echo rtrim(graph_to_string($d_graph)), PHP_EOL;
-$d_graph = add_edge($d_graph, _str(2), _str(0));
-$d_graph = add_edge($d_graph, _str(2), _str(6));
-$d_graph = add_edge($d_graph, _str(2), _str(7));
-echo rtrim(graph_to_string($d_graph)), PHP_EOL;
+};
+  $d_graph = make_graph(true);
+  $d_graph = add_edge($d_graph, _str(0), _str(1));
+  echo rtrim(graph_to_string($d_graph)), PHP_EOL;
+  $d_graph = add_edge($d_graph, _str(1), _str(2));
+  $d_graph = add_edge($d_graph, _str(1), _str(4));
+  $d_graph = add_edge($d_graph, _str(1), _str(5));
+  echo rtrim(graph_to_string($d_graph)), PHP_EOL;
+  $d_graph = add_edge($d_graph, _str(2), _str(0));
+  $d_graph = add_edge($d_graph, _str(2), _str(6));
+  $d_graph = add_edge($d_graph, _str(2), _str(7));
+  echo rtrim(graph_to_string($d_graph)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/graphs_floyd_warshall.bench
+++ b/tests/algorithms/x/PHP/graphs/graphs_floyd_warshall.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 76,
+  "duration_us": 88,
   "memory_bytes": 39688,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/graphs_floyd_warshall.php
+++ b/tests/algorithms/x/PHP/graphs/graphs_floyd_warshall.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,8 +35,10 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-$INF = 1000000000.0;
-function floyd_warshall($graph) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $INF = 1000000000.0;
+  function floyd_warshall($graph) {
   global $INF, $result;
   $v = count($graph);
   $dist = [];
@@ -52,8 +69,8 @@ function floyd_warshall($graph) {
   $k = $k + 1;
 };
   return $dist;
-}
-function print_dist($dist) {
+};
+  function print_dist($dist) {
   global $INF, $graph, $result;
   echo rtrim('
 The shortest path matrix using Floyd Warshall algorithm
@@ -73,7 +90,15 @@ The shortest path matrix using Floyd Warshall algorithm
   echo rtrim($line), PHP_EOL;
   $i = $i + 1;
 };
-}
-$graph = [[0.0, 5.0, $INF, 10.0], [$INF, 0.0, 3.0, $INF], [$INF, $INF, 0.0, 1.0], [$INF, $INF, $INF, 0.0]];
-$result = floyd_warshall($graph);
-print_dist($result);
+};
+  $graph = [[0.0, 5.0, $INF, 10.0], [$INF, 0.0, 3.0, $INF], [$INF, $INF, 0.0, 1.0], [$INF, $INF, $INF, 0.0]];
+  $result = floyd_warshall($graph);
+  print_dist($result);
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/greedy_best_first.bench
+++ b/tests/algorithms/x/PHP/graphs/greedy_best_first.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 386,
+  "duration_us": 478,
   "memory_bytes": 70168,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/greedy_best_first.php
+++ b/tests/algorithms/x/PHP/graphs/greedy_best_first.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,18 +35,20 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function mochi_abs($x) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function mochi_abs($x) {
   global $TEST_GRIDS, $delta;
   if ($x < 0) {
   return 0 - $x;
 }
   return $x;
-}
-function manhattan($x1, $y1, $x2, $y2) {
+};
+  function manhattan($x1, $y1, $x2, $y2) {
   global $TEST_GRIDS, $delta;
   return mochi_abs($x1 - $x2) + mochi_abs($y1 - $y2);
-}
-function clone_path($p) {
+};
+  function clone_path($p) {
   global $TEST_GRIDS, $delta;
   $res = [];
   $i = 0;
@@ -40,18 +57,18 @@ function clone_path($p) {
   $i = $i + 1;
 };
   return $res;
-}
-function make_node($pos_x, $pos_y, $goal_x, $goal_y, $g_cost, $path) {
+};
+  function make_node($pos_x, $pos_y, $goal_x, $goal_y, $g_cost, $path) {
   global $TEST_GRIDS, $delta;
   $f = manhattan($pos_x, $pos_y, $goal_x, $goal_y);
   return ['pos_x' => $pos_x, 'pos_y' => $pos_y, 'goal_x' => $goal_x, 'goal_y' => $goal_y, 'g_cost' => $g_cost, 'f_cost' => $f, 'path' => $path];
-}
-$delta = [['y' => -1, 'x' => 0], ['y' => 0, 'x' => -1], ['y' => 1, 'x' => 0], ['y' => 0, 'x' => 1]];
-function node_equal($a, $b) {
+};
+  $delta = [['y' => -1, 'x' => 0], ['y' => 0, 'x' => -1], ['y' => 1, 'x' => 0], ['y' => 0, 'x' => 1]];
+  function node_equal($a, $b) {
   global $TEST_GRIDS, $delta;
   return $a['pos_x'] == $b['pos_x'] && $a['pos_y'] == $b['pos_y'];
-}
-function mochi_contains($nodes, $node) {
+};
+  function mochi_contains($nodes, $node) {
   global $TEST_GRIDS, $delta;
   $i = 0;
   while ($i < count($nodes)) {
@@ -61,8 +78,8 @@ function mochi_contains($nodes, $node) {
   $i = $i + 1;
 };
   return false;
-}
-function sort_nodes($nodes) {
+};
+  function sort_nodes($nodes) {
   global $TEST_GRIDS, $delta;
   $arr = $nodes;
   $i = 1;
@@ -82,8 +99,8 @@ function sort_nodes($nodes) {
   $i = $i + 1;
 };
   return $arr;
-}
-function get_successors($grid, $parent, $target) {
+};
+  function get_successors($grid, $parent, $target) {
   global $TEST_GRIDS, $delta;
   $res = [];
   $i = 0;
@@ -99,8 +116,8 @@ function get_successors($grid, $parent, $target) {
   $i = $i + 1;
 };
   return $res;
-}
-function greedy_best_first($grid, $init, $goal) {
+};
+  function greedy_best_first($grid, $init, $goal) {
   global $TEST_GRIDS, $delta;
   $start_path = [$init];
   $start = make_node($init['x'], $init['y'], $goal['x'], $goal['y'], 0, $start_path);
@@ -132,17 +149,17 @@ function greedy_best_first($grid, $init, $goal) {
 };
   $r = [$init];
   return $r;
-}
-$TEST_GRIDS = [[[0, 0, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0], [0, 0, 1, 0, 0, 0, 0], [1, 0, 1, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 1, 0, 0]], [[0, 0, 0, 1, 1, 0, 0], [0, 0, 0, 0, 1, 0, 1], [0, 0, 0, 1, 1, 0, 0], [0, 1, 0, 0, 1, 0, 0], [1, 0, 0, 1, 1, 0, 1], [0, 0, 0, 0, 0, 0, 0]], [[0, 0, 1, 0, 0], [0, 1, 0, 0, 0], [0, 0, 1, 0, 1], [1, 0, 0, 1, 1], [0, 0, 0, 0, 0]]];
-function print_grid($grid) {
+};
+  $TEST_GRIDS = [[[0, 0, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0], [0, 0, 1, 0, 0, 0, 0], [1, 0, 1, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 1, 0, 0]], [[0, 0, 0, 1, 1, 0, 0], [0, 0, 0, 0, 1, 0, 1], [0, 0, 0, 1, 1, 0, 0], [0, 1, 0, 0, 1, 0, 0], [1, 0, 0, 1, 1, 0, 1], [0, 0, 0, 0, 0, 0, 0]], [[0, 0, 1, 0, 0], [0, 1, 0, 0, 0], [0, 0, 1, 0, 1], [1, 0, 0, 1, 1], [0, 0, 0, 0, 0]]];
+  function print_grid($grid) {
   global $TEST_GRIDS, $delta;
   $i = 0;
   while ($i < count($grid)) {
   echo rtrim(_str($grid[$i])), PHP_EOL;
   $i = $i + 1;
 };
-}
-function main() {
+};
+  function main() {
   global $TEST_GRIDS, $delta;
   $idx = 0;
   while ($idx < count($TEST_GRIDS)) {
@@ -162,5 +179,13 @@ function main() {
   print_grid($grid);
   $idx = $idx + 1;
 };
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/greedy_min_vertex_cover.bench
+++ b/tests/algorithms/x/PHP/graphs/greedy_min_vertex_cover.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 97,
+  "duration_us": 142,
   "memory_bytes": 40536,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/greedy_min_vertex_cover.php
+++ b/tests/algorithms/x/PHP/graphs/greedy_min_vertex_cover.php
@@ -1,10 +1,27 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function remove_value($lst, $val) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function remove_value($lst, $val) {
   global $graph;
   $res = [];
   $i = 0;
@@ -15,8 +32,8 @@ function remove_value($lst, $val) {
   $i = $i + 1;
 };
   return $res;
-}
-function greedy_min_vertex_cover($graph) {
+};
+  function greedy_min_vertex_cover($graph) {
   $g = $graph;
   $cover = [];
   while (true) {
@@ -44,6 +61,14 @@ function greedy_min_vertex_cover($graph) {
   $g[$max_v] = [];
 };
   return $cover;
-}
-$graph = [0 => [1, 3], 1 => [0, 3], 2 => [0, 3, 4], 3 => [0, 1, 2], 4 => [2, 3]];
-echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(greedy_min_vertex_cover($graph), 1344)))))), PHP_EOL;
+};
+  $graph = [0 => [1, 3], 1 => [0, 3], 2 => [0, 3, 4], 3 => [0, 1, 2], 4 => [2, 3]];
+  echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(greedy_min_vertex_cover($graph), 1344)))))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/kahns_algorithm_long.bench
+++ b/tests/algorithms/x/PHP/graphs/kahns_algorithm_long.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 109,
+  "duration_us": 84,
   "memory_bytes": 40088,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/kahns_algorithm_long.php
+++ b/tests/algorithms/x/PHP/graphs/kahns_algorithm_long.php
@@ -1,10 +1,27 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function longest_distance($graph) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function longest_distance($graph) {
   $n = count($graph);
   $indegree = [];
   $i = 0;
@@ -57,6 +74,14 @@ function longest_distance($graph) {
   $m = $m + 1;
 };
   return $max_len;
-}
-$graph = [[2, 3, 4], [2, 7], [5], [5, 7], [7], [6], [7], []];
-echo rtrim(json_encode(longest_distance($graph), 1344)), PHP_EOL;
+};
+  $graph = [[2, 3, 4], [2, 7], [5], [5, 7], [7], [6], [7], []];
+  echo rtrim(json_encode(longest_distance($graph), 1344)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/kahns_algorithm_topo.bench
+++ b/tests/algorithms/x/PHP/graphs/kahns_algorithm_topo.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 77,
+  "duration_us": 109,
   "memory_bytes": 36288,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/kahns_algorithm_topo.php
+++ b/tests/algorithms/x/PHP/graphs/kahns_algorithm_topo.php
@@ -1,10 +1,27 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function topological_sort($graph) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function topological_sort($graph) {
   $indegree = [];
   $i = 0;
   while ($i < count($graph)) {
@@ -50,11 +67,19 @@ function topological_sort($graph) {
   return null;
 }
   return $order;
-}
-function main() {
+};
+  function main() {
   $graph = [0 => [1, 2], 1 => [3], 2 => [3], 3 => [4, 5], 4 => [], 5 => []];
   echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(topological_sort($graph), 1344)))))), PHP_EOL;
   $cyclic = [0 => [1], 1 => [2], 2 => [0]];
   echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(topological_sort($cyclic), 1344)))))), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/karger.bench
+++ b/tests/algorithms/x/PHP/graphs/karger.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 253,
+  "duration_us": 192,
   "memory_bytes": 85952,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/karger.php
+++ b/tests/algorithms/x/PHP/graphs/karger.php
@@ -1,16 +1,33 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-$seed = 1;
-function rand_int($n) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $seed = 1;
+  function rand_int($n) {
   global $TEST_GRAPH, $result, $seed;
   $seed = ($seed * 1103515245 + 12345) % 2147483648;
   return $seed % $n;
-}
-function mochi_contains($list, $value) {
+};
+  function mochi_contains($list, $value) {
   global $TEST_GRAPH, $result, $seed;
   $i = 0;
   while ($i < count($list)) {
@@ -20,8 +37,8 @@ function mochi_contains($list, $value) {
   $i = $i + 1;
 };
   return false;
-}
-function remove_all($list, $value) {
+};
+  function remove_all($list, $value) {
   global $TEST_GRAPH, $result, $seed;
   $res = [];
   $i = 0;
@@ -32,8 +49,8 @@ function remove_all($list, $value) {
   $i = $i + 1;
 };
   return $res;
-}
-function partition_graph($graph) {
+};
+  function partition_graph($graph) {
   global $TEST_GRAPH, $result, $seed;
   $contracted = [];
   foreach (array_keys($graph) as $node) {
@@ -126,8 +143,8 @@ function partition_graph($graph) {
   $j = $j + 1;
 };
   return $cut;
-}
-function cut_to_string($cut) {
+};
+  function cut_to_string($cut) {
   global $TEST_GRAPH, $result, $seed;
   $s = '{';
   $i = 0;
@@ -141,7 +158,15 @@ function cut_to_string($cut) {
 };
   $s = $s . '}';
   return $s;
-}
-$TEST_GRAPH = ['1' => ['2', '3', '4', '5'], '2' => ['1', '3', '4', '5'], '3' => ['1', '2', '4', '5', '10'], '4' => ['1', '2', '3', '5', '6'], '5' => ['1', '2', '3', '4', '7'], '6' => ['7', '8', '9', '10', '4'], '7' => ['6', '8', '9', '10', '5'], '8' => ['6', '7', '9', '10'], '9' => ['6', '7', '8', '10'], '10' => ['6', '7', '8', '9', '3']];
-$result = partition_graph($TEST_GRAPH);
-echo rtrim(cut_to_string($result)), PHP_EOL;
+};
+  $TEST_GRAPH = ['1' => ['2', '3', '4', '5'], '2' => ['1', '3', '4', '5'], '3' => ['1', '2', '4', '5', '10'], '4' => ['1', '2', '3', '5', '6'], '5' => ['1', '2', '3', '4', '7'], '6' => ['7', '8', '9', '10', '4'], '7' => ['6', '8', '9', '10', '5'], '8' => ['6', '7', '9', '10'], '9' => ['6', '7', '8', '10'], '10' => ['6', '7', '8', '9', '3']];
+  $result = partition_graph($TEST_GRAPH);
+  echo rtrim(cut_to_string($result)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/lanczos_eigenvectors.bench
+++ b/tests/algorithms/x/PHP/graphs/lanczos_eigenvectors.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 119,
+  "duration_us": 227,
   "memory_bytes": 108928,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/lanczos_eigenvectors.php
+++ b/tests/algorithms/x/PHP/graphs/lanczos_eigenvectors.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -24,17 +39,19 @@ function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-$seed = 123456789;
-function mochi_rand() {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $seed = 123456789;
+  function mochi_rand() {
   global $graph, $result, $seed;
   $seed = ($seed * 1103515245 + 12345) % 2147483648;
   return $seed;
-}
-function random() {
+};
+  function random() {
   global $graph, $result, $seed;
   return (1.0 * mochi_rand()) / 2147483648.0;
-}
-function sqrtApprox($x) {
+};
+  function sqrtApprox($x) {
   global $graph, $result, $seed;
   if ($x <= 0.0) {
   return 0.0;
@@ -46,12 +63,12 @@ function sqrtApprox($x) {
   $i = $i + 1;
 };
   return $guess;
-}
-function absf($x) {
+};
+  function absf($x) {
   global $graph, $result, $seed;
   return ($x < 0.0 ? -$x : $x);
-}
-function dot($a, $b) {
+};
+  function dot($a, $b) {
   global $graph, $result, $seed;
   $s = 0.0;
   $i = 0;
@@ -60,8 +77,8 @@ function dot($a, $b) {
   $i = $i + 1;
 };
   return $s;
-}
-function vector_scale($v, $s) {
+};
+  function vector_scale($v, $s) {
   global $graph, $result, $seed;
   $res = [];
   $i = 0;
@@ -70,8 +87,8 @@ function vector_scale($v, $s) {
   $i = $i + 1;
 };
   return $res;
-}
-function vector_sub($a, $b) {
+};
+  function vector_sub($a, $b) {
   global $graph, $result, $seed;
   $res = [];
   $i = 0;
@@ -80,8 +97,8 @@ function vector_sub($a, $b) {
   $i = $i + 1;
 };
   return $res;
-}
-function vector_add($a, $b) {
+};
+  function vector_add($a, $b) {
   global $graph, $result, $seed;
   $res = [];
   $i = 0;
@@ -90,8 +107,8 @@ function vector_add($a, $b) {
   $i = $i + 1;
 };
   return $res;
-}
-function zeros_matrix($r, $c) {
+};
+  function zeros_matrix($r, $c) {
   global $graph, $result, $seed;
   $m = [];
   $i = 0;
@@ -106,8 +123,8 @@ function zeros_matrix($r, $c) {
   $i = $i + 1;
 };
   return $m;
-}
-function column($m, $idx) {
+};
+  function column($m, $idx) {
   global $graph, $result, $seed;
   $col = [];
   $i = 0;
@@ -116,8 +133,8 @@ function column($m, $idx) {
   $i = $i + 1;
 };
   return $col;
-}
-function validate_adjacency_list($graph) {
+};
+  function validate_adjacency_list($graph) {
   global $result, $seed;
   $i = 0;
   while ($i < count($graph)) {
@@ -131,8 +148,8 @@ function validate_adjacency_list($graph) {
 };
   $i = $i + 1;
 };
-}
-function multiply_matrix_vector($graph, $vector) {
+};
+  function multiply_matrix_vector($graph, $vector) {
   global $seed;
   $n = count($graph);
   if (count($vector) != $n) {
@@ -152,8 +169,8 @@ function multiply_matrix_vector($graph, $vector) {
   $i = $i + 1;
 };
   return $result;
-}
-function lanczos_iteration($graph, $k) {
+};
+  function lanczos_iteration($graph, $k) {
   global $result, $seed;
   $n = count($graph);
   if ($k < 1 || $k > $n) {
@@ -211,8 +228,8 @@ function lanczos_iteration($graph, $k) {
   $j = $j + 1;
 };
   return ['t' => $t, 'q' => $q];
-}
-function jacobi_eigen($a_in, $max_iter) {
+};
+  function jacobi_eigen($a_in, $max_iter) {
   global $graph, $result, $seed;
   $n = count($a_in);
   $a = $a_in;
@@ -288,8 +305,8 @@ function jacobi_eigen($a_in, $max_iter) {
   $i = $i + 1;
 };
   return ['values' => $eigenvalues, 'vectors' => $v];
-}
-function matmul($a, $b) {
+};
+  function matmul($a, $b) {
   global $graph, $result, $seed;
   $rows = count($a);
   $cols = count($b[0]);
@@ -311,8 +328,8 @@ function matmul($a, $b) {
   $i = $i + 1;
 };
   return $m;
-}
-function sort_eigenpairs($vals, $vecs) {
+};
+  function sort_eigenpairs($vals, $vecs) {
   global $graph, $result, $seed;
   $n = count($vals);
   $values = $vals;
@@ -338,8 +355,8 @@ function sort_eigenpairs($vals, $vecs) {
   $i = $i + 1;
 };
   return ['values' => $values, 'vectors' => $vectors];
-}
-function find_lanczos_eigenvectors($graph, $k) {
+};
+  function find_lanczos_eigenvectors($graph, $k) {
   global $result, $seed;
   validate_adjacency_list($graph);
   $res = lanczos_iteration($graph, $k);
@@ -347,8 +364,8 @@ function find_lanczos_eigenvectors($graph, $k) {
   $sorted = sort_eigenpairs($eig['values'], $eig['vectors']);
   $final_vectors = matmul($res['q'], $sorted['vectors']);
   return ['values' => $sorted['values'], 'vectors' => $final_vectors];
-}
-function list_to_string($arr) {
+};
+  function list_to_string($arr) {
   global $graph, $result, $seed;
   $s = '[';
   $i = 0;
@@ -360,8 +377,8 @@ function list_to_string($arr) {
   $i = $i + 1;
 };
   return $s . ']';
-}
-function matrix_to_string($m) {
+};
+  function matrix_to_string($m) {
   global $graph, $result, $seed;
   $s = '[';
   $i = 0;
@@ -373,8 +390,16 @@ function matrix_to_string($m) {
   $i = $i + 1;
 };
   return $s . ']';
-}
-$graph = [[1, 2], [0, 2], [0, 1]];
-$result = find_lanczos_eigenvectors($graph, 2);
-echo rtrim(list_to_string($result['values'])), PHP_EOL;
-echo rtrim(matrix_to_string($result['vectors'])), PHP_EOL;
+};
+  $graph = [[1, 2], [0, 2], [0, 1]];
+  $result = find_lanczos_eigenvectors($graph, 2);
+  echo rtrim(list_to_string($result['values'])), PHP_EOL;
+  echo rtrim(matrix_to_string($result['vectors'])), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/markov_chain.bench
+++ b/tests/algorithms/x/PHP/graphs/markov_chain.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 911,
+  "duration_us": 978,
   "memory_bytes": 37504,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/markov_chain.php
+++ b/tests/algorithms/x/PHP/graphs/markov_chain.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,17 +35,19 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-$seed = 1;
-function mochi_rand() {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $seed = 1;
+  function mochi_rand() {
   global $seed;
   $seed = ($seed * 1103515245 + 12345) % 2147483648;
   return $seed;
-}
-function random() {
+};
+  function random() {
   global $seed;
   return (1.0 * mochi_rand()) / 2147483648.0;
-}
-function get_nodes($trans) {
+};
+  function get_nodes($trans) {
   global $seed;
   $seen = [];
   foreach ($trans as $t) {
@@ -42,8 +59,8 @@ function get_nodes($trans) {
   $nodes = _append($nodes, $k);
 };
   return $nodes;
-}
-function transition($current, $trans) {
+};
+  function transition($current, $trans) {
   global $seed;
   $current_probability = 0.0;
   $random_value = random();
@@ -56,8 +73,8 @@ function transition($current, $trans) {
 }
 };
   return '';
-}
-function get_transitions($start, $trans, $steps) {
+};
+  function get_transitions($start, $trans, $steps) {
   global $seed;
   $visited = [];
   foreach (get_nodes($trans) as $node) {
@@ -74,11 +91,19 @@ function get_transitions($start, $trans, $steps) {
   $i = $i + 1;
 };
   return $visited;
-}
-function main() {
+};
+  function main() {
   global $seed;
   $transitions = [['src' => 'a', 'dst' => 'a', 'prob' => 0.9], ['src' => 'a', 'dst' => 'b', 'prob' => 0.075], ['src' => 'a', 'dst' => 'c', 'prob' => 0.025], ['src' => 'b', 'dst' => 'a', 'prob' => 0.15], ['src' => 'b', 'dst' => 'b', 'prob' => 0.8], ['src' => 'b', 'dst' => 'c', 'prob' => 0.05], ['src' => 'c', 'dst' => 'a', 'prob' => 0.25], ['src' => 'c', 'dst' => 'b', 'prob' => 0.25], ['src' => 'c', 'dst' => 'c', 'prob' => 0.5]];
   $result = get_transitions('a', $transitions, 5000);
   echo rtrim(_str($result['a']) . ' ' . _str($result['b']) . ' ' . _str($result['c'])), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/matching_min_vertex_cover.bench
+++ b/tests/algorithms/x/PHP/graphs/matching_min_vertex_cover.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 127,
+  "duration_us": 115,
   "memory_bytes": 40616,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/matching_min_vertex_cover.php
+++ b/tests/algorithms/x/PHP/graphs/matching_min_vertex_cover.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,7 +35,9 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function mochi_contains($xs, $v) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function mochi_contains($xs, $v) {
   global $cover, $graph;
   foreach ($xs as $x) {
   if ($x == $v) {
@@ -28,8 +45,8 @@ function mochi_contains($xs, $v) {
 }
 };
   return false;
-}
-function get_edges($graph) {
+};
+  function get_edges($graph) {
   global $cover;
   $n = count($graph);
   $edges = [];
@@ -39,8 +56,8 @@ function get_edges($graph) {
 };
 };
   return $edges;
-}
-function matching_min_vertex_cover($graph) {
+};
+  function matching_min_vertex_cover($graph) {
   global $cover;
   $chosen = [];
   $edges = get_edges($graph);
@@ -67,7 +84,15 @@ function matching_min_vertex_cover($graph) {
   $edges = $filtered;
 };
   return $chosen;
-}
-$graph = [0 => [1, 3], 1 => [0, 3], 2 => [0, 3, 4], 3 => [0, 1, 2], 4 => [2, 3]];
-$cover = matching_min_vertex_cover($graph);
-echo rtrim(_str($cover)), PHP_EOL;
+};
+  $graph = [0 => [1, 3], 1 => [0, 3], 2 => [0, 3, 4], 3 => [0, 1, 2], 4 => [2, 3]];
+  $cover = matching_min_vertex_cover($graph);
+  echo rtrim(_str($cover)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/minimum_path_sum.bench
+++ b/tests/algorithms/x/PHP/graphs/minimum_path_sum.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 111,
+  "duration_us": 98,
   "memory_bytes": 39976,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/minimum_path_sum.php
+++ b/tests/algorithms/x/PHP/graphs/minimum_path_sum.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,7 +35,9 @@ function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-function fill_row($current_row, $row_above) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function fill_row($current_row, $row_above) {
   global $grid1, $grid2;
   $current_row[0] = $current_row[0] + $row_above[0];
   $cell_n = 1;
@@ -35,8 +52,8 @@ function fill_row($current_row, $row_above) {
   $cell_n = $cell_n + 1;
 };
   return $current_row;
-}
-function min_path_sum(&$grid) {
+};
+  function min_path_sum(&$grid) {
   global $grid1, $grid2;
   if (count($grid) == 0 || count($grid[0]) == 0) {
   _panic('The grid does not contain the appropriate information');
@@ -55,8 +72,16 @@ function min_path_sum(&$grid) {
   $row_n = $row_n + 1;
 };
   return $grid[count($grid) - 1][count($grid[0]) - 1];
-}
-$grid1 = [[1, 3, 1], [1, 5, 1], [4, 2, 1]];
-echo rtrim(_str(min_path_sum($grid1))), PHP_EOL;
-$grid2 = [[1, 0, 5, 6, 7], [8, 9, 0, 4, 2], [4, 4, 4, 5, 1], [9, 6, 3, 1, 0], [8, 4, 3, 2, 7]];
-echo rtrim(_str(min_path_sum($grid2))), PHP_EOL;
+};
+  $grid1 = [[1, 3, 1], [1, 5, 1], [4, 2, 1]];
+  echo rtrim(_str(min_path_sum($grid1))), PHP_EOL;
+  $grid2 = [[1, 0, 5, 6, 7], [8, 9, 0, 4, 2], [4, 4, 4, 5, 1], [9, 6, 3, 1, 0], [8, 4, 3, 2, 7]];
+  echo rtrim(_str(min_path_sum($grid2))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/minimum_spanning_tree_boruvka.bench
+++ b/tests/algorithms/x/PHP/graphs/minimum_spanning_tree_boruvka.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 69,
+  "duration_us": 94,
   "memory_bytes": 38344,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/minimum_spanning_tree_boruvka.php
+++ b/tests/algorithms/x/PHP/graphs/minimum_spanning_tree_boruvka.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,7 +35,9 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function uf_make($n) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function uf_make($n) {
   $p = [];
   $r = [];
   $i = 0;
@@ -30,8 +47,8 @@ function uf_make($n) {
   $i = $i + 1;
 };
   return ['parent' => $p, 'rank' => $r];
-}
-function uf_find($uf, $x) {
+};
+  function uf_find($uf, $x) {
   $p = $uf['parent'];
   if ($p[$x] != $x) {
   $res = uf_find(['parent' => $p, 'rank' => $uf['rank']], $p[$x]);
@@ -40,8 +57,8 @@ function uf_find($uf, $x) {
   return ['root' => $res['root'], 'uf' => ['parent' => $p, 'rank' => $res['uf']['rank']]];
 }
   return ['root' => $x, 'uf' => $uf];
-}
-function uf_union($uf, $x, $y) {
+};
+  function uf_union($uf, $x, $y) {
   $fr1 = uf_find($uf, $x);
   $uf1 = $fr1['uf'];
   $root1 = $fr1['root'];
@@ -64,8 +81,8 @@ function uf_union($uf, $x, $y) {
 };
 }
   return ['parent' => $p, 'rank' => $r];
-}
-function boruvka($n, $edges) {
+};
+  function boruvka($n, $edges) {
   $uf = uf_make($n);
   $num_components = $n;
   $mst = [];
@@ -116,12 +133,20 @@ function boruvka($n, $edges) {
 };
 };
   return $mst;
-}
-function main() {
+};
+  function main() {
   $edges = [['u' => 0, 'v' => 1, 'w' => 1], ['u' => 0, 'v' => 2, 'w' => 2], ['u' => 2, 'v' => 3, 'w' => 3]];
   $mst = boruvka(4, $edges);
   foreach ($mst as $e) {
   echo rtrim(_str($e['u']) . ' - ' . _str($e['v']) . ' : ' . _str($e['w'])), PHP_EOL;
 };
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/minimum_spanning_tree_kruskal.bench
+++ b/tests/algorithms/x/PHP/graphs/minimum_spanning_tree_kruskal.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 141,
+  "duration_us": 111,
   "memory_bytes": 40152,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/minimum_spanning_tree_kruskal.php
+++ b/tests/algorithms/x/PHP/graphs/minimum_spanning_tree_kruskal.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,7 +35,9 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function sort_edges($edges) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function sort_edges($edges) {
   global $edges1, $edges2, $edges3;
   $es = $edges;
   $i = 0;
@@ -37,15 +54,15 @@ function sort_edges($edges) {
   $i = $i + 1;
 };
   return $es;
-}
-function &find_parent(&$parent, $i) {
+};
+  function &find_parent(&$parent, $i) {
   global $edges1, $edges2, $edges3;
   if ($parent[$i] != $i) {
   $parent[$i] = find_parent($parent, $parent[$i]);
 }
   return $parent[$i];
-}
-function kruskal($num_nodes, $edges) {
+};
+  function kruskal($num_nodes, $edges) {
   global $edges1, $edges2, $edges3;
   $es = sort_edges($edges);
   $parent = [];
@@ -67,8 +84,8 @@ function kruskal($num_nodes, $edges) {
   $idx = $idx + 1;
 };
   return $mst;
-}
-function edges_to_string($es) {
+};
+  function edges_to_string($es) {
   global $edges1, $edges2, $edges3;
   $s = '[';
   $i = 0;
@@ -82,10 +99,18 @@ function edges_to_string($es) {
 };
   $s = $s . ']';
   return $s;
-}
-$edges1 = [[0, 1, 3], [1, 2, 5], [2, 3, 1]];
-echo rtrim(edges_to_string(kruskal(4, $edges1))), PHP_EOL;
-$edges2 = [[0, 1, 3], [1, 2, 5], [2, 3, 1], [0, 2, 1], [0, 3, 2]];
-echo rtrim(edges_to_string(kruskal(4, $edges2))), PHP_EOL;
-$edges3 = [[0, 1, 3], [1, 2, 5], [2, 3, 1], [0, 2, 1], [0, 3, 2], [2, 1, 1]];
-echo rtrim(edges_to_string(kruskal(4, $edges3))), PHP_EOL;
+};
+  $edges1 = [[0, 1, 3], [1, 2, 5], [2, 3, 1]];
+  echo rtrim(edges_to_string(kruskal(4, $edges1))), PHP_EOL;
+  $edges2 = [[0, 1, 3], [1, 2, 5], [2, 3, 1], [0, 2, 1], [0, 3, 2]];
+  echo rtrim(edges_to_string(kruskal(4, $edges2))), PHP_EOL;
+  $edges3 = [[0, 1, 3], [1, 2, 5], [2, 3, 1], [0, 2, 1], [0, 3, 2], [2, 1, 1]];
+  echo rtrim(edges_to_string(kruskal(4, $edges3))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/minimum_spanning_tree_kruskal2.bench
+++ b/tests/algorithms/x/PHP/graphs/minimum_spanning_tree_kruskal2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 103,
+  "duration_us": 112,
   "memory_bytes": 39640,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/minimum_spanning_tree_kruskal2.php
+++ b/tests/algorithms/x/PHP/graphs/minimum_spanning_tree_kruskal2.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,10 +35,12 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function new_graph() {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function new_graph() {
   return ['edges' => [], 'num_nodes' => 0];
-}
-function add_edge($g, $u, $v, $w) {
+};
+  function add_edge($g, $u, $v, $w) {
   $es = $g['edges'];
   $es = _append($es, ['u' => $u, 'v' => $v, 'w' => $w]);
   $n = $g['num_nodes'];
@@ -34,8 +51,8 @@ function add_edge($g, $u, $v, $w) {
   $n = $v;
 }
   return ['edges' => $es, 'num_nodes' => $n];
-}
-function make_ds($n) {
+};
+  function make_ds($n) {
   $parent = [];
   $rank = [];
   $i = 0;
@@ -45,8 +62,8 @@ function make_ds($n) {
   $i = $i + 1;
 };
   return ['parent' => $parent, 'rank' => $rank];
-}
-function find_set($ds, $x) {
+};
+  function find_set($ds, $x) {
   if ($ds['parent'][$x] == $x) {
   return ['ds' => $ds, 'root' => $x];
 }
@@ -54,8 +71,8 @@ function find_set($ds, $x) {
   $p = $res['ds']['parent'];
   $p[$x] = $res['root'];
   return ['ds' => ['parent' => $p, 'rank' => $res['ds']['rank']], 'root' => $res['root']];
-}
-function union_set($ds, $x, $y) {
+};
+  function union_set($ds, $x, $y) {
   $fx = find_set($ds, $x);
   $ds1 = $fx['ds'];
   $x_root = $fx['root'];
@@ -76,8 +93,8 @@ function union_set($ds, $x, $y) {
 };
 }
   return ['parent' => $p, 'rank' => $r];
-}
-function sort_edges($edges) {
+};
+  function sort_edges($edges) {
   $arr = $edges;
   $i = 1;
   while ($i < count($arr)) {
@@ -96,8 +113,8 @@ function sort_edges($edges) {
   $i = $i + 1;
 };
   return $arr;
-}
-function kruskal($g) {
+};
+  function kruskal($g) {
   $edges = sort_edges($g['edges']);
   $ds = make_ds($g['num_nodes']);
   $mst_edges = [];
@@ -119,14 +136,14 @@ function kruskal($g) {
 }
 };
   return ['edges' => $mst_edges, 'num_nodes' => $g['num_nodes']];
-}
-function print_mst($g) {
+};
+  function print_mst($g) {
   $es = sort_edges($g['edges']);
   foreach ($es as $e) {
   echo rtrim(_str($e['u']) . '-' . _str($e['v']) . ':' . _str($e['w'])), PHP_EOL;
 };
-}
-function main() {
+};
+  function main() {
   $g = new_graph();
   $g = add_edge($g, 1, 2, 1);
   $g = add_edge($g, 2, 3, 2);
@@ -135,5 +152,13 @@ function main() {
   $g = add_edge($g, 4, 5, 5);
   $mst = kruskal($g);
   print_mst($mst);
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/minimum_spanning_tree_prims.bench
+++ b/tests/algorithms/x/PHP/graphs/minimum_spanning_tree_prims.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 84,
+  "duration_us": 104,
   "memory_bytes": 40960,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/minimum_spanning_tree_prims.php
+++ b/tests/algorithms/x/PHP/graphs/minimum_spanning_tree_prims.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,8 +35,10 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-$INF = 1000000000;
-function pairs_to_string($edges) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $INF = 1000000000;
+  function pairs_to_string($edges) {
   global $INF, $adjacency_list, $mst_edges;
   $s = '[';
   $i = 0;
@@ -34,8 +51,8 @@ function pairs_to_string($edges) {
   $i = $i + 1;
 };
   return $s . ']';
-}
-function prim_mst($graph) {
+};
+  function prim_mst($graph) {
   global $INF, $adjacency_list, $mst_edges;
   $n = count($graph);
   $visited = [];
@@ -78,7 +95,15 @@ function prim_mst($graph) {
   $count = $count + 1;
 };
   return $result;
-}
-$adjacency_list = [[['to' => 1, 'weight' => 1], ['to' => 3, 'weight' => 3]], [['to' => 0, 'weight' => 1], ['to' => 2, 'weight' => 6], ['to' => 3, 'weight' => 5], ['to' => 4, 'weight' => 1]], [['to' => 1, 'weight' => 6], ['to' => 4, 'weight' => 5], ['to' => 5, 'weight' => 2]], [['to' => 0, 'weight' => 3], ['to' => 1, 'weight' => 5], ['to' => 4, 'weight' => 1]], [['to' => 1, 'weight' => 1], ['to' => 2, 'weight' => 5], ['to' => 3, 'weight' => 1], ['to' => 5, 'weight' => 4]], [['to' => 2, 'weight' => 2], ['to' => 4, 'weight' => 4]]];
-$mst_edges = prim_mst($adjacency_list);
-echo rtrim(pairs_to_string($mst_edges)), PHP_EOL;
+};
+  $adjacency_list = [[['to' => 1, 'weight' => 1], ['to' => 3, 'weight' => 3]], [['to' => 0, 'weight' => 1], ['to' => 2, 'weight' => 6], ['to' => 3, 'weight' => 5], ['to' => 4, 'weight' => 1]], [['to' => 1, 'weight' => 6], ['to' => 4, 'weight' => 5], ['to' => 5, 'weight' => 2]], [['to' => 0, 'weight' => 3], ['to' => 1, 'weight' => 5], ['to' => 4, 'weight' => 1]], [['to' => 1, 'weight' => 1], ['to' => 2, 'weight' => 5], ['to' => 3, 'weight' => 1], ['to' => 5, 'weight' => 4]], [['to' => 2, 'weight' => 2], ['to' => 4, 'weight' => 4]]];
+  $mst_edges = prim_mst($adjacency_list);
+  echo rtrim(pairs_to_string($mst_edges)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/minimum_spanning_tree_prims2.bench
+++ b/tests/algorithms/x/PHP/graphs/minimum_spanning_tree_prims2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 175,
+  "duration_us": 122,
   "memory_bytes": 36680,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/minimum_spanning_tree_prims2.php
+++ b/tests/algorithms/x/PHP/graphs/minimum_spanning_tree_prims2.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,7 +35,9 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function prims_algo($graph) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function prims_algo($graph) {
   global $res;
   $INF = 2147483647;
   $dist = [];
@@ -106,21 +123,29 @@ function prims_algo($graph) {
 };
 };
   return ['dist' => $dist, 'parent' => $parent];
-}
-function iabs($x) {
+};
+  function iabs($x) {
   global $dist, $graph, $res;
   if ($x < 0) {
   return -$x;
 }
   return $x;
-}
-$graph = [];
-$graph['a'] = ['b' => 3, 'c' => 15];
-$graph['b'] = ['a' => 3, 'c' => 10, 'd' => 100];
-$graph['c'] = ['a' => 15, 'b' => 10, 'd' => 5];
-$graph['d'] = ['b' => 100, 'c' => 5];
-$res = prims_algo($graph);
-$dist = $res['dist'];
-echo rtrim(_str(iabs($dist['a'] - $dist['b']))), PHP_EOL;
-echo rtrim(_str(iabs($dist['d'] - $dist['b']))), PHP_EOL;
-echo rtrim(_str(iabs($dist['a'] - $dist['c']))), PHP_EOL;
+};
+  $graph = [];
+  $graph['a'] = ['b' => 3, 'c' => 15];
+  $graph['b'] = ['a' => 3, 'c' => 10, 'd' => 100];
+  $graph['c'] = ['a' => 15, 'b' => 10, 'd' => 5];
+  $graph['d'] = ['b' => 100, 'c' => 5];
+  $res = prims_algo($graph);
+  $dist = $res['dist'];
+  echo rtrim(_str(iabs($dist['a'] - $dist['b']))), PHP_EOL;
+  echo rtrim(_str(iabs($dist['d'] - $dist['b']))), PHP_EOL;
+  echo rtrim(_str(iabs($dist['a'] - $dist['c']))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/multi_heuristic_astar.bench
+++ b/tests/algorithms/x/PHP/graphs/multi_heuristic_astar.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 130,
+  "duration_us": 139,
   "memory_bytes": 110360,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/multi_heuristic_astar.php
+++ b/tests/algorithms/x/PHP/graphs/multi_heuristic_astar.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,21 +35,23 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-$W1 = 1.0;
-$W2 = 1.0;
-$n = 20;
-$n_heuristic = 3;
-$INF = 1000000000.0;
-$t = 1;
-function pos_equal($a, $b) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $W1 = 1.0;
+  $W2 = 1.0;
+  $n = 20;
+  $n_heuristic = 3;
+  $INF = 1000000000.0;
+  $t = 1;
+  function pos_equal($a, $b) {
   global $INF, $W1, $W2, $blocks, $goal, $n, $n_heuristic, $start, $t;
   return $a['x'] == $b['x'] && $a['y'] == $b['y'];
-}
-function pos_key($p) {
+};
+  function pos_key($p) {
   global $INF, $W1, $W2, $blocks, $goal, $n, $n_heuristic, $start, $t;
   return _str($p['x']) . ',' . _str($p['y']);
-}
-function sqrtApprox($x) {
+};
+  function sqrtApprox($x) {
   global $INF, $W1, $W2, $blocks, $goal, $n, $n_heuristic, $start, $t;
   if ($x <= 0.0) {
   return 0.0;
@@ -46,30 +63,30 @@ function sqrtApprox($x) {
   $i = $i + 1;
 };
   return $guess;
-}
-function consistent_heuristic($p, $goal) {
+};
+  function consistent_heuristic($p, $goal) {
   global $INF, $W1, $W2, $blocks, $n, $n_heuristic, $start, $t;
   $dx = floatval(($p['x'] - $goal['x']));
   $dy = floatval(($p['y'] - $goal['y']));
   return sqrtApprox($dx * $dx + $dy * $dy);
-}
-function iabs($x) {
+};
+  function iabs($x) {
   global $INF, $W1, $W2, $blocks, $goal, $n, $n_heuristic, $start, $t;
   if ($x < 0) {
   return -$x;
 }
   return $x;
-}
-function heuristic_1($p, $goal) {
+};
+  function heuristic_1($p, $goal) {
   global $INF, $W1, $W2, $blocks, $n, $n_heuristic, $start, $t;
   return floatval((iabs($p['x'] - $goal['x']) + iabs($p['y'] - $goal['y'])));
-}
-function heuristic_2($p, $goal) {
+};
+  function heuristic_2($p, $goal) {
   global $INF, $W1, $W2, $blocks, $n, $n_heuristic, $start, $t;
   $h = consistent_heuristic($p, $goal);
   return $h / (floatval($t));
-}
-function heuristic($i, $p, $goal) {
+};
+  function heuristic($i, $p, $goal) {
   global $INF, $W1, $W2, $blocks, $n, $n_heuristic, $start, $t;
   if ($i == 0) {
   return consistent_heuristic($p, $goal);
@@ -78,13 +95,13 @@ function heuristic($i, $p, $goal) {
   return heuristic_1($p, $goal);
 }
   return heuristic_2($p, $goal);
-}
-function key_fn($start, $i, $goal, $g_func) {
+};
+  function key_fn($start, $i, $goal, $g_func) {
   global $INF, $W1, $W2, $blocks, $n, $n_heuristic, $t;
   $g = $g_func[pos_key($start)];
   return $g + $W1 * heuristic($i, $start, $goal);
-}
-function valid($p) {
+};
+  function valid($p) {
   global $INF, $W1, $W2, $blocks, $goal, $n, $n_heuristic, $start, $t;
   if ($p['x'] < 0 || $p['x'] > $n - 1) {
   return false;
@@ -93,9 +110,9 @@ function valid($p) {
   return false;
 }
   return true;
-}
-$blocks = [['x' => 0, 'y' => 1], ['x' => 1, 'y' => 1], ['x' => 2, 'y' => 1], ['x' => 3, 'y' => 1], ['x' => 4, 'y' => 1], ['x' => 5, 'y' => 1], ['x' => 6, 'y' => 1], ['x' => 7, 'y' => 1], ['x' => 8, 'y' => 1], ['x' => 9, 'y' => 1], ['x' => 10, 'y' => 1], ['x' => 11, 'y' => 1], ['x' => 12, 'y' => 1], ['x' => 13, 'y' => 1], ['x' => 14, 'y' => 1], ['x' => 15, 'y' => 1], ['x' => 16, 'y' => 1], ['x' => 17, 'y' => 1], ['x' => 18, 'y' => 1], ['x' => 19, 'y' => 1]];
-function in_blocks($p) {
+};
+  $blocks = [['x' => 0, 'y' => 1], ['x' => 1, 'y' => 1], ['x' => 2, 'y' => 1], ['x' => 3, 'y' => 1], ['x' => 4, 'y' => 1], ['x' => 5, 'y' => 1], ['x' => 6, 'y' => 1], ['x' => 7, 'y' => 1], ['x' => 8, 'y' => 1], ['x' => 9, 'y' => 1], ['x' => 10, 'y' => 1], ['x' => 11, 'y' => 1], ['x' => 12, 'y' => 1], ['x' => 13, 'y' => 1], ['x' => 14, 'y' => 1], ['x' => 15, 'y' => 1], ['x' => 16, 'y' => 1], ['x' => 17, 'y' => 1], ['x' => 18, 'y' => 1], ['x' => 19, 'y' => 1]];
+  function in_blocks($p) {
   global $INF, $W1, $W2, $blocks, $goal, $n, $n_heuristic, $start, $t;
   $i = 0;
   while ($i < count($blocks)) {
@@ -105,8 +122,8 @@ function in_blocks($p) {
   $i = $i + 1;
 };
   return false;
-}
-function pq_put($pq, $node, $pri) {
+};
+  function pq_put($pq, $node, $pri) {
   global $INF, $W1, $W2, $blocks, $goal, $n, $n_heuristic, $start, $t;
   $updated = false;
   $i = 0;
@@ -123,8 +140,8 @@ function pq_put($pq, $node, $pri) {
   $pq = _append($pq, ['pos' => $node, 'pri' => $pri]);
 }
   return $pq;
-}
-function pq_minkey($pq) {
+};
+  function pq_minkey($pq) {
   global $INF, $W1, $W2, $blocks, $goal, $n, $n_heuristic, $start, $t;
   if (count($pq) == 0) {
   return $INF;
@@ -140,8 +157,8 @@ function pq_minkey($pq) {
   $i = $i + 1;
 };
   return $m;
-}
-function pq_pop_min($pq) {
+};
+  function pq_pop_min($pq) {
   global $INF, $W1, $W2, $blocks, $goal, $n, $n_heuristic, $start, $t;
   $best = $pq[0];
   $idx = 0;
@@ -162,8 +179,8 @@ function pq_pop_min($pq) {
   $i = $i + 1;
 };
   return ['pq' => $new_pq, 'node' => $best];
-}
-function pq_remove($pq, $node) {
+};
+  function pq_remove($pq, $node) {
   global $INF, $W1, $W2, $blocks, $goal, $n, $n_heuristic, $start, $t;
   $new_pq = [];
   $i = 0;
@@ -174,8 +191,8 @@ function pq_remove($pq, $node) {
   $i = $i + 1;
 };
   return $new_pq;
-}
-function reconstruct($back_pointer, $goal, $start) {
+};
+  function reconstruct($back_pointer, $goal, $start) {
   global $INF, $W1, $W2, $blocks, $n, $n_heuristic, $t;
   $path = [];
   $current = $goal;
@@ -193,16 +210,16 @@ function reconstruct($back_pointer, $goal, $start) {
   $i = $i - 1;
 };
   return $rev;
-}
-function neighbours($p) {
+};
+  function neighbours($p) {
   global $INF, $W1, $W2, $blocks, $goal, $n, $n_heuristic, $start, $t;
   $left = ['x' => $p['x'] - 1, 'y' => $p['y']];
   $right = ['x' => $p['x'] + 1, 'y' => $p['y']];
   $up = ['x' => $p['x'], 'y' => $p['y'] + 1];
   $down = ['x' => $p['x'], 'y' => $p['y'] - 1];
   return [$left, $right, $up, $down];
-}
-function multi_a_star($start, $goal, $n_heuristic) {
+};
+  function multi_a_star($start, $goal, $n_heuristic) {
   global $INF, $W1, $W2, $blocks, $n, $t;
   $g_function = [];
   $back_pointer = [];
@@ -280,7 +297,15 @@ function multi_a_star($start, $goal, $n_heuristic) {
 };
 };
   echo rtrim('No path found to goal'), PHP_EOL;
-}
-$start = ['x' => 0, 'y' => 0];
-$goal = ['x' => $n - 1, 'y' => $n - 1];
-multi_a_star($start, $goal, $n_heuristic);
+};
+  $start = ['x' => 0, 'y' => 0];
+  $goal = ['x' => $n - 1, 'y' => $n - 1];
+  multi_a_star($start, $goal, $n_heuristic);
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/page_rank.bench
+++ b/tests/algorithms/x/PHP/graphs/page_rank.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 110,
+  "duration_us": 128,
   "memory_bytes": 37544,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/page_rank.php
+++ b/tests/algorithms/x/PHP/graphs/page_rank.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _len($x) {
     if ($x === null) { return 0; }
     if (is_array($x)) { return count($x); }
@@ -26,11 +41,13 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function node_to_string($n) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function node_to_string($n) {
   global $ci, $graph, $n_in, $n_out, $names, $nodes, $ri, $row;
   return '<node=' . $n['name'] . ' inbound=' . $n['inbound'] . ' outbound=' . $n['outbound'] . '>';
-}
-function page_rank($nodes, $limit, $d) {
+};
+  function page_rank($nodes, $limit, $d) {
   global $ci, $graph, $n_in, $n_out, $names, $ri, $row;
   $ranks = [];
   foreach ($nodes as $n) {
@@ -54,15 +71,15 @@ function page_rank($nodes, $limit, $d) {
   $i = $i + 1;
 };
   return $ranks;
-}
-$names = ['A', 'B', 'C'];
-$graph = [[0, 1, 1], [0, 0, 1], [1, 0, 0]];
-$nodes = [];
-foreach ($names as $name) {
+};
+  $names = ['A', 'B', 'C'];
+  $graph = [[0, 1, 1], [0, 0, 1], [1, 0, 0]];
+  $nodes = [];
+  foreach ($names as $name) {
   $nodes = _append($nodes, ['name' => $name, 'inbound' => [], 'outbound' => []]);
 }
-$ri = 0;
-while ($ri < count($graph)) {
+  $ri = 0;
+  while ($ri < count($graph)) {
   $row = $graph[$ri];
   $ci = 0;
   while ($ci < count($row)) {
@@ -78,8 +95,16 @@ while ($ri < count($graph)) {
 };
   $ri = $ri + 1;
 }
-echo rtrim('======= Nodes ======='), PHP_EOL;
-foreach ($nodes as $n) {
+  echo rtrim('======= Nodes ======='), PHP_EOL;
+  foreach ($nodes as $n) {
   echo rtrim(json_encode($n, 1344)), PHP_EOL;
 }
-page_rank($nodes, 3, 0.85);
+  page_rank($nodes, 3, 0.85);
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/prim.bench
+++ b/tests/algorithms/x/PHP/graphs/prim.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 100,
+  "duration_us": 137,
   "memory_bytes": 74904,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/prim.php
+++ b/tests/algorithms/x/PHP/graphs/prim.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,8 +35,10 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-$INF = 1000000000;
-function connect($graph, $a, $b, $w) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $INF = 1000000000;
+  function connect($graph, $a, $b, $w) {
   global $INF;
   $u = $a - 1;
   $v = $b - 1;
@@ -29,8 +46,8 @@ function connect($graph, $a, $b, $w) {
   $g[$u] = _append($g[$u], [$v, $w]);
   $g[$v] = _append($g[$v], [$u, $w]);
   return $g;
-}
-function in_list($arr, $x) {
+};
+  function in_list($arr, $x) {
   global $INF;
   $i = 0;
   while ($i < count($arr)) {
@@ -40,8 +57,8 @@ function in_list($arr, $x) {
   $i = $i + 1;
 };
   return false;
-}
-function prim($graph, $s, $n) {
+};
+  function prim($graph, $s, $n) {
   global $INF;
   $dist = [];
   $parent = [];
@@ -86,8 +103,8 @@ function prim($graph, $s, $n) {
   $j = $j + 1;
 };
   return $edges;
-}
-function sort_heap($h, $dist) {
+};
+  function sort_heap($h, $dist) {
   global $INF;
   $a = $h;
   $i = 0;
@@ -106,8 +123,8 @@ function sort_heap($h, $dist) {
   $i = $i + 1;
 };
   return $a;
-}
-function prim_heap($graph, $s, $n) {
+};
+  function prim_heap($graph, $s, $n) {
   global $INF;
   $dist = [];
   $parent = [];
@@ -145,8 +162,8 @@ function prim_heap($graph, $s, $n) {
   $j = $j + 1;
 };
   return $edges;
-}
-function print_edges($edges) {
+};
+  function print_edges($edges) {
   global $INF;
   $i = 0;
   while ($i < count($edges)) {
@@ -154,8 +171,8 @@ function print_edges($edges) {
   echo rtrim('(' . _str($e[0]) . ', ' . _str($e[1]) . ')'), PHP_EOL;
   $i = $i + 1;
 };
-}
-function test_vector() {
+};
+  function test_vector() {
   global $INF;
   $x = 5;
   $G = [];
@@ -174,5 +191,13 @@ function test_vector() {
   print_edges($mst);
   $mst_heap = prim_heap($G, 0, $x);
   print_edges($mst_heap);
-}
-test_vector();
+};
+  test_vector();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/random_graph_generator.bench
+++ b/tests/algorithms/x/PHP/graphs/random_graph_generator.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 71,
+  "duration_us": 142,
   "memory_bytes": 35712,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/random_graph_generator.php
+++ b/tests/algorithms/x/PHP/graphs/random_graph_generator.php
@@ -1,20 +1,37 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-$seed = 1;
-function mochi_rand() {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $seed = 1;
+  function mochi_rand() {
   global $seed;
   $seed = ($seed * 1103515245 + 12345) % 2147483648;
   return $seed;
-}
-function random() {
+};
+  function random() {
   global $seed;
   return (1.0 * mochi_rand()) / 2147483648.0;
-}
-function complete_graph($vertices_number) {
+};
+  function complete_graph($vertices_number) {
   global $seed;
   $graph = [];
   $i = 0;
@@ -31,8 +48,8 @@ function complete_graph($vertices_number) {
   $i = $i + 1;
 };
   return $graph;
-}
-function random_graph($vertices_number, $probability, $directed) {
+};
+  function random_graph($vertices_number, $probability, $directed) {
   global $seed;
   $graph = [];
   $i = 0;
@@ -61,8 +78,8 @@ function random_graph($vertices_number, $probability, $directed) {
   $i = $i + 1;
 };
   return $graph;
-}
-function main() {
+};
+  function main() {
   global $seed;
   $seed = 1;
   $g1 = random_graph(4, 0.5, false);
@@ -70,5 +87,13 @@ function main() {
   $seed = 1;
   $g2 = random_graph(4, 0.5, true);
   echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode($g2, 1344)))))), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/scc_kosaraju.php
+++ b/tests/algorithms/x/PHP/graphs/scc_kosaraju.php
@@ -1,10 +1,27 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function dfs($u, $graph, &$visit, $stack) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function dfs($u, $graph, &$visit, $stack) {
   if ($visit[$u]) {
   return $stack;
 }
@@ -14,8 +31,8 @@ function dfs($u, $graph, &$visit, $stack) {
 };
   $stack = _append($stack, $u);
   return $stack;
-}
-function dfs2($u, $reversed_graph, &$visit, $component) {
+};
+  function dfs2($u, $reversed_graph, &$visit, $component) {
   if ($visit[$u]) {
   return $component;
 }
@@ -25,8 +42,8 @@ function dfs2($u, $reversed_graph, &$visit, $component) {
   $component = dfs2($v, $reversed_graph, $visit, $component);
 };
   return $component;
-}
-function kosaraju($graph) {
+};
+  function kosaraju($graph) {
   $n = count($graph);
   $reversed_graph = [];
   $i = 0;
@@ -72,8 +89,8 @@ function kosaraju($graph) {
   $idx = $idx - 1;
 };
   return $scc;
-}
-function main() {
+};
+  function main() {
   $graph = [[1], [2], [0, 3], [4], []];
   $comps = kosaraju($graph);
   $i = 0;
@@ -81,5 +98,13 @@ function main() {
   echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode($comps[$i], 1344)))))), PHP_EOL;
   $i = $i + 1;
 };
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/strongly_connected_components.bench
+++ b/tests/algorithms/x/PHP/graphs/strongly_connected_components.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 120,
+  "duration_us": 149,
   "memory_bytes": 37496,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/strongly_connected_components.php
+++ b/tests/algorithms/x/PHP/graphs/strongly_connected_components.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,7 +35,9 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function topology_sort($graph, $vert, &$visited) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function topology_sort($graph, $vert, &$visited) {
   $visited[$vert] = true;
   $order = [];
   foreach ($graph[$vert] as $neighbour) {
@@ -30,8 +47,8 @@ function topology_sort($graph, $vert, &$visited) {
 };
   $order = _append($order, $vert);
   return $order;
-}
-function find_component($graph, $vert, &$visited) {
+};
+  function find_component($graph, $vert, &$visited) {
   $visited[$vert] = true;
   $comp = [$vert];
   foreach ($graph[$vert] as $neighbour) {
@@ -40,8 +57,8 @@ function find_component($graph, $vert, &$visited) {
 }
 };
   return $comp;
-}
-function strongly_connected_components($graph) {
+};
+  function strongly_connected_components($graph) {
   $n = count($graph);
   $visited = [];
   for ($_ = 0; $_ < $n; $_++) {
@@ -77,11 +94,19 @@ function strongly_connected_components($graph) {
   $i = $i + 1;
 };
   return $components;
-}
-function main() {
+};
+  function main() {
   $test_graph_1 = [[2, 3], [0], [1], [4], []];
   $test_graph_2 = [[1, 2, 3], [2], [0], [4], [5], [3]];
   echo rtrim(_str(strongly_connected_components($test_graph_1))), PHP_EOL;
   echo rtrim(_str(strongly_connected_components($test_graph_2))), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/tarjans_scc.bench
+++ b/tests/algorithms/x/PHP/graphs/tarjans_scc.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 129,
+  "duration_us": 157,
   "memory_bytes": 37488,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/tarjans_scc.php
+++ b/tests/algorithms/x/PHP/graphs/tarjans_scc.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,7 +35,9 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function tarjan($g) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function tarjan($g) {
   $n = count($g);
   $stack = [];
   $on_stack = [];
@@ -79,8 +96,8 @@ $strong_connect = function($v, $index) use (&$strong_connect, $g, $n, &$stack, &
   $v = $v + 1;
 };
   return $components;
-}
-function create_graph($n, $edges) {
+};
+  function create_graph($n, $edges) {
   $g = [];
   $i = 0;
   while ($i < $n) {
@@ -93,8 +110,8 @@ function create_graph($n, $edges) {
   $g[$u] = _append($g[$u], $v);
 };
   return $g;
-}
-function main() {
+};
+  function main() {
   $n_vertices = 7;
   $source = [0, 0, 1, 2, 3, 3, 4, 4, 6];
   $target = [1, 3, 2, 0, 1, 4, 5, 6, 5];
@@ -106,5 +123,13 @@ function main() {
 };
   $g = create_graph($n_vertices, $edges);
   echo rtrim(_str(tarjan($g))), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/tests/test_min_spanning_tree_kruskal.bench
+++ b/tests/algorithms/x/PHP/graphs/tests/test_min_spanning_tree_kruskal.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 101,
+  "duration_us": 152,
   "memory_bytes": 35952,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/tests/test_min_spanning_tree_kruskal.php
+++ b/tests/algorithms/x/PHP/graphs/tests/test_min_spanning_tree_kruskal.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,7 +35,9 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function sort_edges($edges) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function sort_edges($edges) {
   $es = $edges;
   $i = 0;
   while ($i < count($es)) {
@@ -36,15 +53,15 @@ function sort_edges($edges) {
   $i = $i + 1;
 };
   return $es;
-}
-function find($parent, $x) {
+};
+  function find($parent, $x) {
   $r = $x;
   while ($parent[$r] != $r) {
   $r = $parent[$r];
 };
   return $r;
-}
-function kruskal($n, $edges) {
+};
+  function kruskal($n, $edges) {
   $parent = [];
   $i = 0;
   while ($i < $n) {
@@ -71,8 +88,8 @@ function kruskal($n, $edges) {
 }
 };
   return $mst;
-}
-function edges_equal($a, $b) {
+};
+  function edges_equal($a, $b) {
   if (count($a) != count($b)) {
   return false;
 }
@@ -86,8 +103,8 @@ function edges_equal($a, $b) {
   $i = $i + 1;
 };
   return true;
-}
-function main() {
+};
+  function main() {
   $num_nodes = 9;
   $edges = [[0, 1, 4], [0, 7, 8], [1, 2, 8], [7, 8, 7], [7, 6, 1], [2, 8, 2], [8, 6, 6], [2, 3, 7], [2, 5, 4], [6, 5, 2], [3, 5, 14], [3, 4, 9], [5, 4, 10], [1, 7, 11]];
   $expected = [[7, 6, 1], [2, 8, 2], [6, 5, 2], [0, 1, 4], [2, 5, 4], [2, 3, 7], [0, 7, 8], [3, 4, 9]];
@@ -100,5 +117,13 @@ function main() {
 } else {
   echo rtrim((false ? 'true' : 'false')), PHP_EOL;
 }
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/graphs/tests/test_min_spanning_tree_prim.bench
+++ b/tests/algorithms/x/PHP/graphs/tests/test_min_spanning_tree_prim.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 198,
+  "duration_us": 231,
   "memory_bytes": 41576,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/graphs/tests/test_min_spanning_tree_prim.php
+++ b/tests/algorithms/x/PHP/graphs/tests/test_min_spanning_tree_prim.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,7 +35,9 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function prims_algorithm($adjacency) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function prims_algorithm($adjacency) {
   $visited = [];
   $visited[0] = true;
   $mst = [];
@@ -50,8 +67,8 @@ function prims_algorithm($adjacency) {
   $count = $count + 1;
 };
   return $mst;
-}
-function test_prim_successful_result() {
+};
+  function test_prim_successful_result() {
   $edges = [[0, 1, 4], [0, 7, 8], [1, 2, 8], [7, 8, 7], [7, 6, 1], [2, 8, 2], [8, 6, 6], [2, 3, 7], [2, 5, 4], [6, 5, 2], [3, 5, 14], [3, 4, 9], [5, 4, 10], [1, 7, 11]];
   $adjacency = [];
   foreach ($edges as $e) {
@@ -83,6 +100,14 @@ function test_prim_successful_result() {
 }
 };
   return true;
-}
-echo rtrim(json_encode(test_prim_successful_result(), 1344)), PHP_EOL;
-echo rtrim((true ? 'true' : 'false')), PHP_EOL;
+};
+  echo rtrim(json_encode(test_prim_successful_result(), 1344)), PHP_EOL;
+  echo rtrim((true ? 'true' : 'false')), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/greedy_methods/best_time_to_buy_and_sell_stock.bench
+++ b/tests/algorithms/x/PHP/greedy_methods/best_time_to_buy_and_sell_stock.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 46,
+  "duration_us": 58,
   "memory_bytes": 39056,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/greedy_methods/best_time_to_buy_and_sell_stock.php
+++ b/tests/algorithms/x/PHP/greedy_methods/best_time_to_buy_and_sell_stock.php
@@ -1,6 +1,23 @@
 <?php
 ini_set('memory_limit', '-1');
-function max_profit($prices) {
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function max_profit($prices) {
   if (count($prices) == 0) {
   return 0;
 }
@@ -19,6 +36,14 @@ function max_profit($prices) {
   $i = $i + 1;
 };
   return $max_profit;
-}
-echo rtrim(json_encode(max_profit([7, 1, 5, 3, 6, 4]), 1344)), PHP_EOL;
-echo rtrim(json_encode(max_profit([7, 6, 4, 3, 1]), 1344)), PHP_EOL;
+};
+  echo rtrim(json_encode(max_profit([7, 1, 5, 3, 6, 4]), 1344)), PHP_EOL;
+  echo rtrim(json_encode(max_profit([7, 6, 4, 3, 1]), 1344)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/greedy_methods/fractional_cover_problem.bench
+++ b/tests/algorithms/x/PHP/greedy_methods/fractional_cover_problem.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 72,
+  "duration_us": 114,
   "memory_bytes": 36864,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/greedy_methods/fractional_cover_problem.php
+++ b/tests/algorithms/x/PHP/greedy_methods/fractional_cover_problem.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _len($x) {
     if ($x === null) { return 0; }
     if (is_array($x)) { return count($x); }
@@ -26,11 +41,13 @@ function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-function ratio($item) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function ratio($item) {
   global $items1, $items2, $items3, $items4;
   return (floatval($item['value'])) / (floatval($item['weight']));
-}
-function fractional_cover($items, $capacity) {
+};
+  function fractional_cover($items, $capacity) {
   global $items1, $items2, $items3, $items4;
   if ($capacity < 0) {
   _panic('Capacity cannot be negative');
@@ -51,14 +68,22 @@ foreach ($items as $it) {
   $idx = $idx + 1;
 };
   return $total;
-}
-$items1 = [['weight' => 10, 'value' => 60], ['weight' => 20, 'value' => 100], ['weight' => 30, 'value' => 120]];
-echo rtrim(_str(fractional_cover($items1, 50))), PHP_EOL;
-$items2 = [['weight' => 20, 'value' => 100], ['weight' => 30, 'value' => 120], ['weight' => 10, 'value' => 60]];
-echo rtrim(_str(fractional_cover($items2, 25))), PHP_EOL;
-$items3 = [];
-echo rtrim(_str(fractional_cover($items3, 50))), PHP_EOL;
-$items4 = [['weight' => 10, 'value' => 60]];
-echo rtrim(_str(fractional_cover($items4, 5))), PHP_EOL;
-echo rtrim(_str(fractional_cover($items4, 1))), PHP_EOL;
-echo rtrim(_str(fractional_cover($items4, 0))), PHP_EOL;
+};
+  $items1 = [['weight' => 10, 'value' => 60], ['weight' => 20, 'value' => 100], ['weight' => 30, 'value' => 120]];
+  echo rtrim(_str(fractional_cover($items1, 50))), PHP_EOL;
+  $items2 = [['weight' => 20, 'value' => 100], ['weight' => 30, 'value' => 120], ['weight' => 10, 'value' => 60]];
+  echo rtrim(_str(fractional_cover($items2, 25))), PHP_EOL;
+  $items3 = [];
+  echo rtrim(_str(fractional_cover($items3, 50))), PHP_EOL;
+  $items4 = [['weight' => 10, 'value' => 60]];
+  echo rtrim(_str(fractional_cover($items4, 5))), PHP_EOL;
+  echo rtrim(_str(fractional_cover($items4, 1))), PHP_EOL;
+  echo rtrim(_str(fractional_cover($items4, 0))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/greedy_methods/fractional_knapsack.bench
+++ b/tests/algorithms/x/PHP/greedy_methods/fractional_knapsack.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 71,
+  "duration_us": 98,
   "memory_bytes": 41152,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/greedy_methods/fractional_knapsack.php
+++ b/tests/algorithms/x/PHP/greedy_methods/fractional_knapsack.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,7 +35,9 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function sort_by_ratio_desc($arr) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function sort_by_ratio_desc($arr) {
   global $result, $vl, $wt;
   $i = 1;
   while ($i < count($arr)) {
@@ -39,8 +56,8 @@ function sort_by_ratio_desc($arr) {
   $i = $i + 1;
 };
   return $arr;
-}
-function sum_first($arr, $k) {
+};
+  function sum_first($arr, $k) {
   global $result, $vl, $wt;
   $s = 0.0;
   $i = 0;
@@ -49,8 +66,8 @@ function sum_first($arr, $k) {
   $i = $i + 1;
 };
   return $s;
-}
-function frac_knapsack($vl, $wt, $w, $n) {
+};
+  function frac_knapsack($vl, $wt, $w, $n) {
   global $result;
   $items = [];
   $i = 0;
@@ -90,8 +107,16 @@ function frac_knapsack($vl, $wt, $w, $n) {
   return sum_first($values, $k) + ($w - $acc[$k - 1]) * $values[$k] / $weights[$k];
 }
   return sum_first($values, $k);
-}
-$vl = [60.0, 100.0, 120.0];
-$wt = [10.0, 20.0, 30.0];
-$result = frac_knapsack($vl, $wt, 50.0, 3);
-echo rtrim(_str($result)), PHP_EOL;
+};
+  $vl = [60.0, 100.0, 120.0];
+  $wt = [10.0, 20.0, 30.0];
+  $result = frac_knapsack($vl, $wt, 50.0, 3);
+  echo rtrim(_str($result)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/greedy_methods/fractional_knapsack_2.bench
+++ b/tests/algorithms/x/PHP/greedy_methods/fractional_knapsack_2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 76,
+  "duration_us": 93,
   "memory_bytes": 39680,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/greedy_methods/fractional_knapsack_2.php
+++ b/tests/algorithms/x/PHP/greedy_methods/fractional_knapsack_2.php
@@ -1,10 +1,27 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function sort_by_ratio($index, $ratio) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function sort_by_ratio($index, $ratio) {
   global $v, $w;
   $i = 1;
   while ($i < count($index)) {
@@ -19,8 +36,8 @@ function sort_by_ratio($index, $ratio) {
   $i = $i + 1;
 };
   return $index;
-}
-function fractional_knapsack($value, $weight, $capacity) {
+};
+  function fractional_knapsack($value, $weight, $capacity) {
   global $v, $w;
   $n = count($value);
   $index = [];
@@ -58,9 +75,17 @@ function fractional_knapsack($value, $weight, $capacity) {
   $idx = $idx + 1;
 };
   return ['max_value' => $max_value, 'fractions' => $fractions];
-}
-$v = [1.0, 3.0, 5.0, 7.0, 9.0];
-$w = [0.9, 0.7, 0.5, 0.3, 0.1];
-echo rtrim(json_encode(fractional_knapsack($v, $w, 5.0), 1344)), PHP_EOL;
-echo rtrim(json_encode(fractional_knapsack([1.0, 3.0, 5.0, 7.0], [0.9, 0.7, 0.5, 0.3], 30.0), 1344)), PHP_EOL;
-echo rtrim(json_encode(fractional_knapsack([], [], 30.0), 1344)), PHP_EOL;
+};
+  $v = [1.0, 3.0, 5.0, 7.0, 9.0];
+  $w = [0.9, 0.7, 0.5, 0.3, 0.1];
+  echo rtrim(json_encode(fractional_knapsack($v, $w, 5.0), 1344)), PHP_EOL;
+  echo rtrim(json_encode(fractional_knapsack([1.0, 3.0, 5.0, 7.0], [0.9, 0.7, 0.5, 0.3], 30.0), 1344)), PHP_EOL;
+  echo rtrim(json_encode(fractional_knapsack([], [], 30.0), 1344)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/greedy_methods/gas_station.bench
+++ b/tests/algorithms/x/PHP/greedy_methods/gas_station.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 71,
+  "duration_us": 81,
   "memory_bytes": 39944,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/greedy_methods/gas_station.php
+++ b/tests/algorithms/x/PHP/greedy_methods/gas_station.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,7 +35,9 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function get_gas_stations($gas_quantities, $costs) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function get_gas_stations($gas_quantities, $costs) {
   global $example1, $example2;
   $stations = [];
   $i = 0;
@@ -29,8 +46,8 @@ function get_gas_stations($gas_quantities, $costs) {
   $i = $i + 1;
 };
   return $stations;
-}
-function can_complete_journey($gas_stations) {
+};
+  function can_complete_journey($gas_stations) {
   global $example1, $example2;
   $total_gas = 0;
   $total_cost = 0;
@@ -56,8 +73,16 @@ function can_complete_journey($gas_stations) {
   $i = $i + 1;
 };
   return $start;
-}
-$example1 = get_gas_stations([1, 2, 3, 4, 5], [3, 4, 5, 1, 2]);
-echo rtrim(_str(can_complete_journey($example1))), PHP_EOL;
-$example2 = get_gas_stations([2, 3, 4], [3, 4, 3]);
-echo rtrim(_str(can_complete_journey($example2))), PHP_EOL;
+};
+  $example1 = get_gas_stations([1, 2, 3, 4, 5], [3, 4, 5, 1, 2]);
+  echo rtrim(_str(can_complete_journey($example1))), PHP_EOL;
+  $example2 = get_gas_stations([2, 3, 4], [3, 4, 3]);
+  echo rtrim(_str(can_complete_journey($example2))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/greedy_methods/minimum_coin_change.bench
+++ b/tests/algorithms/x/PHP/greedy_methods/minimum_coin_change.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 99,
+  "duration_us": 109,
   "memory_bytes": 39584,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/greedy_methods/minimum_coin_change.php
+++ b/tests/algorithms/x/PHP/greedy_methods/minimum_coin_change.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,7 +35,9 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function find_minimum_change($denominations, $value) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function find_minimum_change($denominations, $value) {
   if ($value <= 0) {
   return [];
 }
@@ -36,6 +53,14 @@ function find_minimum_change($denominations, $value) {
   $i = $i - 1;
 };
   return $answer;
-}
-echo rtrim(_str(find_minimum_change([1, 2, 5, 10, 20, 50, 100, 500, 2000], 987))), PHP_EOL;
-echo rtrim(_str(find_minimum_change([1, 5, 100, 500, 1000], 456))), PHP_EOL;
+};
+  echo rtrim(_str(find_minimum_change([1, 2, 5, 10, 20, 50, 100, 500, 2000], 987))), PHP_EOL;
+  echo rtrim(_str(find_minimum_change([1, 5, 100, 500, 1000], 456))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/greedy_methods/minimum_waiting_time.bench
+++ b/tests/algorithms/x/PHP/greedy_methods/minimum_waiting_time.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 52,
+  "duration_us": 56,
   "memory_bytes": 35648,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/greedy_methods/minimum_waiting_time.php
+++ b/tests/algorithms/x/PHP/greedy_methods/minimum_waiting_time.php
@@ -1,6 +1,23 @@
 <?php
 ini_set('memory_limit', '-1');
-function insertion_sort($a) {
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function insertion_sort($a) {
   $i = 1;
   while ($i < count($a)) {
   $key = $a[$i];
@@ -13,8 +30,8 @@ function insertion_sort($a) {
   $i = $i + 1;
 };
   return $a;
-}
-function minimum_waiting_time($queries) {
+};
+  function minimum_waiting_time($queries) {
   $n = count($queries);
   if ($n == 0 || $n == 1) {
   return 0;
@@ -27,9 +44,17 @@ function minimum_waiting_time($queries) {
   $i = $i + 1;
 };
   return $total;
-}
-echo rtrim(json_encode(minimum_waiting_time([3, 2, 1, 2, 6]), 1344)), PHP_EOL;
-echo rtrim(json_encode(minimum_waiting_time([3, 2, 1]), 1344)), PHP_EOL;
-echo rtrim(json_encode(minimum_waiting_time([1, 2, 3, 4]), 1344)), PHP_EOL;
-echo rtrim(json_encode(minimum_waiting_time([5, 5, 5, 5]), 1344)), PHP_EOL;
-echo rtrim(json_encode(minimum_waiting_time([]), 1344)), PHP_EOL;
+};
+  echo rtrim(json_encode(minimum_waiting_time([3, 2, 1, 2, 6]), 1344)), PHP_EOL;
+  echo rtrim(json_encode(minimum_waiting_time([3, 2, 1]), 1344)), PHP_EOL;
+  echo rtrim(json_encode(minimum_waiting_time([1, 2, 3, 4]), 1344)), PHP_EOL;
+  echo rtrim(json_encode(minimum_waiting_time([5, 5, 5, 5]), 1344)), PHP_EOL;
+  echo rtrim(json_encode(minimum_waiting_time([]), 1344)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/greedy_methods/optimal_merge_pattern.bench
+++ b/tests/algorithms/x/PHP/greedy_methods/optimal_merge_pattern.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 91,
+  "duration_us": 88,
   "memory_bytes": 39368,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/greedy_methods/optimal_merge_pattern.php
+++ b/tests/algorithms/x/PHP/greedy_methods/optimal_merge_pattern.php
@@ -1,10 +1,27 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function index_of_min($xs) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function index_of_min($xs) {
   $min_idx = 0;
   $i = 1;
   while ($i < count($xs)) {
@@ -14,8 +31,8 @@ function index_of_min($xs) {
   $i = $i + 1;
 };
   return $min_idx;
-}
-function remove_at($xs, $idx) {
+};
+  function remove_at($xs, $idx) {
   $res = [];
   $i = 0;
   while ($i < count($xs)) {
@@ -25,8 +42,8 @@ function remove_at($xs, $idx) {
   $i = $i + 1;
 };
   return $res;
-}
-function optimal_merge_pattern($files) {
+};
+  function optimal_merge_pattern($files) {
   $arr = $files;
   $optimal_merge_cost = 0;
   while (count($arr) > 1) {
@@ -42,7 +59,15 @@ function optimal_merge_pattern($files) {
   $optimal_merge_cost = $optimal_merge_cost + $temp;
 };
   return $optimal_merge_cost;
-}
-echo rtrim(json_encode(optimal_merge_pattern([2, 3, 4]), 1344)), PHP_EOL;
-echo rtrim(json_encode(optimal_merge_pattern([5, 10, 20, 30, 30]), 1344)), PHP_EOL;
-echo rtrim(json_encode(optimal_merge_pattern([8, 8, 8, 8, 8]), 1344)), PHP_EOL;
+};
+  echo rtrim(json_encode(optimal_merge_pattern([2, 3, 4]), 1344)), PHP_EOL;
+  echo rtrim(json_encode(optimal_merge_pattern([5, 10, 20, 30, 30]), 1344)), PHP_EOL;
+  echo rtrim(json_encode(optimal_merge_pattern([8, 8, 8, 8, 8]), 1344)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/greedy_methods/smallest_range.bench
+++ b/tests/algorithms/x/PHP/greedy_methods/smallest_range.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 130,
+  "duration_us": 99,
   "memory_bytes": 37792,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/greedy_methods/smallest_range.php
+++ b/tests/algorithms/x/PHP/greedy_methods/smallest_range.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,8 +35,10 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-$INF = 1000000000;
-function smallest_range($nums) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $INF = 1000000000;
+  function smallest_range($nums) {
   global $INF;
   $heap = [];
   $current_max = -$INF;
@@ -70,8 +87,8 @@ function smallest_range($nums) {
 }
 };
   return $best;
-}
-function list_to_string($arr) {
+};
+  function list_to_string($arr) {
   global $INF;
   $s = '[';
   $i = 0;
@@ -83,12 +100,20 @@ function list_to_string($arr) {
   $i = $i + 1;
 };
   return $s . ']';
-}
-function main() {
+};
+  function main() {
   global $INF;
   $result1 = smallest_range([[4, 10, 15, 24, 26], [0, 9, 12, 20], [5, 18, 22, 30]]);
   echo rtrim(list_to_string($result1)), PHP_EOL;
   $result2 = smallest_range([[1, 2, 3], [1, 2, 3], [1, 2, 3]]);
   echo rtrim(list_to_string($result2)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/hashes/adler32.bench
+++ b/tests/algorithms/x/PHP/hashes/adler32.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 50,
+  "duration_us": 73,
   "memory_bytes": 37344,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/hashes/adler32.php
+++ b/tests/algorithms/x/PHP/hashes/adler32.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,8 +31,10 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-$MOD_ADLER = 65521;
-function mochi_ord($ch) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $MOD_ADLER = 65521;
+  function mochi_ord($ch) {
   global $MOD_ADLER;
   $lower = 'abcdefghijklmnopqrstuvwxyz';
   $upper = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
@@ -47,8 +64,8 @@ function mochi_ord($ch) {
   return 32;
 }
   return 0;
-}
-function adler32($plain_text) {
+};
+  function adler32($plain_text) {
   global $MOD_ADLER;
   $a = 1;
   $b = 0;
@@ -60,10 +77,18 @@ function adler32($plain_text) {
   $i = $i + 1;
 };
   return $b * 65536 + $a;
-}
-function main() {
+};
+  function main() {
   global $MOD_ADLER;
   echo rtrim(_str(adler32('Algorithms'))), PHP_EOL;
   echo rtrim(_str(adler32('go adler em all'))), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/hashes/chaos_machine.bench
+++ b/tests/algorithms/x/PHP/hashes/chaos_machine.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 327,
+  "duration_us": 328,
   "memory_bytes": 37360,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/hashes/djb2.bench
+++ b/tests/algorithms/x/PHP/hashes/djb2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 65,
+  "duration_us": 83,
   "memory_bytes": 39496,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/hashes/djb2.php
+++ b/tests/algorithms/x/PHP/hashes/djb2.php
@@ -1,6 +1,23 @@
 <?php
 ini_set('memory_limit', '-1');
-function index_of($s, $ch) {
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function index_of($s, $ch) {
   $i = 0;
   while ($i < strlen($s)) {
   if (substr($s, $i, $i + 1 - $i) == $ch) {
@@ -9,8 +26,8 @@ function index_of($s, $ch) {
   $i = $i + 1;
 };
   return -1;
-}
-function mochi_ord($ch) {
+};
+  function mochi_ord($ch) {
   $upper = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
   $lower = 'abcdefghijklmnopqrstuvwxyz';
   $digits = '0123456789';
@@ -30,8 +47,8 @@ function mochi_ord($ch) {
   return 32;
 }
   return 0;
-}
-function djb2($s) {
+};
+  function djb2($s) {
   $hash_value = 5381;
   $i = 0;
   while ($i < strlen($s)) {
@@ -40,6 +57,14 @@ function djb2($s) {
   $i = $i + 1;
 };
   return $hash_value;
-}
-echo rtrim(json_encode(djb2('Algorithms'), 1344)), PHP_EOL;
-echo rtrim(json_encode(djb2('scramble bits'), 1344)), PHP_EOL;
+};
+  echo rtrim(json_encode(djb2('Algorithms'), 1344)), PHP_EOL;
+  echo rtrim(json_encode(djb2('scramble bits'), 1344)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/hashes/elf.bench
+++ b/tests/algorithms/x/PHP/hashes/elf.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 557,
+  "duration_us": 571,
   "memory_bytes": 41816,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/hashes/elf.php
+++ b/tests/algorithms/x/PHP/hashes/elf.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -27,8 +42,10 @@ function _intdiv($a, $b) {
     }
     return intdiv($a, $b);
 }
-$ascii = ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-function mochi_ord($ch) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $ascii = ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
+  function mochi_ord($ch) {
   global $ascii;
   $i = 0;
   while ($i < strlen($ascii)) {
@@ -38,8 +55,8 @@ function mochi_ord($ch) {
   $i = $i + 1;
 };
   return 0;
-}
-function bit_and($a, $b) {
+};
+  function bit_and($a, $b) {
   global $ascii;
   $ua = $a;
   $ub = $b;
@@ -54,8 +71,8 @@ function bit_and($a, $b) {
   $bit = $bit * 2;
 };
   return $res;
-}
-function bit_xor($a, $b) {
+};
+  function bit_xor($a, $b) {
   global $ascii;
   $ua = $a;
   $ub = $b;
@@ -72,8 +89,8 @@ function bit_xor($a, $b) {
   $bit = $bit * 2;
 };
   return $res;
-}
-function bit_not32($x) {
+};
+  function bit_not32($x) {
   global $ascii;
   $ux = $x;
   $res = 0;
@@ -88,8 +105,8 @@ function bit_not32($x) {
   $count = $count + 1;
 };
   return $res;
-}
-function elf_hash($data) {
+};
+  function elf_hash($data) {
   global $ascii;
   $hash_ = 0;
   $i = 0;
@@ -104,5 +121,13 @@ function elf_hash($data) {
   $i = $i + 1;
 };
   return $hash_;
-}
-echo rtrim(_str(elf_hash('lorem ipsum'))), PHP_EOL;
+};
+  echo rtrim(_str(elf_hash('lorem ipsum'))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/hashes/enigma_machine.bench
+++ b/tests/algorithms/x/PHP/hashes/enigma_machine.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 240,
+  "duration_us": 271,
   "memory_bytes": 41256,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/hashes/enigma_machine.php
+++ b/tests/algorithms/x/PHP/hashes/enigma_machine.php
@@ -1,11 +1,28 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-$ASCII = ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}';
-function build_alphabet() {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $ASCII = ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}';
+  function build_alphabet() {
   global $ASCII, $encoded, $message, $token;
   $result = [];
   $i = 0;
@@ -14,8 +31,8 @@ function build_alphabet() {
   $i = $i + 1;
 };
   return $result;
-}
-function range_list($n) {
+};
+  function range_list($n) {
   global $ASCII, $encoded, $message, $token;
   $lst = [];
   $i = 0;
@@ -24,8 +41,8 @@ function range_list($n) {
   $i = $i + 1;
 };
   return $lst;
-}
-function reversed_range_list($n) {
+};
+  function reversed_range_list($n) {
   global $ASCII, $encoded, $message, $token;
   $lst = [];
   $i = $n - 1;
@@ -34,8 +51,8 @@ function reversed_range_list($n) {
   $i = $i - 1;
 };
   return $lst;
-}
-function index_of_char($lst, $ch) {
+};
+  function index_of_char($lst, $ch) {
   global $ASCII, $encoded, $message, $token;
   $i = 0;
   while ($i < count($lst)) {
@@ -45,8 +62,8 @@ function index_of_char($lst, $ch) {
   $i = $i + 1;
 };
   return -1;
-}
-function index_of_int($lst, $value) {
+};
+  function index_of_int($lst, $value) {
   global $ASCII, $encoded, $message, $token;
   $i = 0;
   while ($i < count($lst)) {
@@ -56,8 +73,8 @@ function index_of_int($lst, $value) {
   $i = $i + 1;
 };
   return -1;
-}
-function enigma_encrypt($message, $token) {
+};
+  function enigma_encrypt($message, $token) {
   global $ASCII, $encoded;
   $alphabets = build_alphabet();
   $n = count($alphabets);
@@ -112,8 +129,16 @@ $engine = function($ch) use (&$engine, $message, $token, $alphabets, $n, $gear_o
   $idx = $idx + 1;
 };
   return $result;
-}
-$message = 'HELLO WORLD';
-$token = 123;
-$encoded = enigma_encrypt($message, $token);
-echo rtrim($encoded), PHP_EOL;
+};
+  $message = 'HELLO WORLD';
+  $token = 123;
+  $encoded = enigma_encrypt($message, $token);
+  echo rtrim($encoded), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/hashes/fletcher16.php
+++ b/tests/algorithms/x/PHP/hashes/fletcher16.php
@@ -1,7 +1,24 @@
 <?php
 ini_set('memory_limit', '-1');
-$ascii_chars = ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-function mochi_ord($ch) {
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $ascii_chars = ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
+  function mochi_ord($ch) {
   global $ascii_chars;
   $i = 0;
   while ($i < strlen($ascii_chars)) {
@@ -11,8 +28,8 @@ function mochi_ord($ch) {
   $i = $i + 1;
 };
   return 0;
-}
-function fletcher16($text) {
+};
+  function fletcher16($text) {
   global $ascii_chars;
   $sum1 = 0;
   $sum2 = 0;
@@ -24,4 +41,12 @@ function fletcher16($text) {
   $i = $i + 1;
 };
   return $sum2 * 256 + $sum1;
-}
+};
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/hashes/hamming_code.bench
+++ b/tests/algorithms/x/PHP/hashes/hamming_code.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 648,
+  "duration_us": 606,
   "memory_bytes": 76320,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/hashes/hamming_code.php
+++ b/tests/algorithms/x/PHP/hashes/hamming_code.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
@@ -15,7 +30,9 @@ function _intdiv($a, $b) {
     }
     return intdiv($a, $b);
 }
-function index_of($s, $ch) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function index_of($s, $ch) {
   $i = 0;
   while ($i < strlen($s)) {
   if (substr($s, $i, $i + 1 - $i) == $ch) {
@@ -24,8 +41,8 @@ function index_of($s, $ch) {
   $i = $i + 1;
 };
   return -1;
-}
-function mochi_ord($ch) {
+};
+  function mochi_ord($ch) {
   $upper = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
   $lower = 'abcdefghijklmnopqrstuvwxyz';
   $idx = index_of($upper, $ch);
@@ -37,8 +54,8 @@ function mochi_ord($ch) {
   return 97 + $idx;
 }
   return 0;
-}
-function mochi_chr($n) {
+};
+  function mochi_chr($n) {
   $upper = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
   $lower = 'abcdefghijklmnopqrstuvwxyz';
   if ($n >= 65 && $n < 91) {
@@ -48,8 +65,8 @@ function mochi_chr($n) {
   return substr($lower, $n - 97, $n - 96 - ($n - 97));
 }
   return '?';
-}
-function text_to_bits($text) {
+};
+  function text_to_bits($text) {
   $bits = '';
   $i = 0;
   while ($i < strlen($text)) {
@@ -67,8 +84,8 @@ function text_to_bits($text) {
   $i = $i + 1;
 };
   return $bits;
-}
-function text_from_bits($bits) {
+};
+  function text_from_bits($bits) {
   $text = '';
   $i = 0;
   while ($i < strlen($bits)) {
@@ -85,14 +102,14 @@ function text_from_bits($bits) {
   $i = $i + 8;
 };
   return $text;
-}
-function bool_to_string($b) {
+};
+  function bool_to_string($b) {
   if ($b) {
   return 'True';
 }
   return 'False';
-}
-function string_to_bitlist($s) {
+};
+  function string_to_bitlist($s) {
   $res = [];
   $i = 0;
   while ($i < strlen($s)) {
@@ -104,8 +121,8 @@ function string_to_bitlist($s) {
   $i = $i + 1;
 };
   return $res;
-}
-function bitlist_to_string($bits) {
+};
+  function bitlist_to_string($bits) {
   $s = '';
   $i = 0;
   while ($i < count($bits)) {
@@ -117,8 +134,8 @@ function bitlist_to_string($bits) {
   $i = $i + 1;
 };
   return $s;
-}
-function is_power_of_two($x) {
+};
+  function is_power_of_two($x) {
   if ($x < 1) {
   return false;
 }
@@ -127,8 +144,8 @@ function is_power_of_two($x) {
   $p = $p * 2;
 };
   return $p == $x;
-}
-function list_eq($a, $b) {
+};
+  function list_eq($a, $b) {
   if (count($a) != count($b)) {
   return false;
 }
@@ -140,8 +157,8 @@ function list_eq($a, $b) {
   $i = $i + 1;
 };
   return true;
-}
-function pow2($e) {
+};
+  function pow2($e) {
   $res = 1;
   $i = 0;
   while ($i < $e) {
@@ -149,15 +166,15 @@ function pow2($e) {
   $i = $i + 1;
 };
   return $res;
-}
-function has_bit($n, $b) {
+};
+  function has_bit($n, $b) {
   $p = pow2($b);
   if (((_intdiv($n, $p)) % 2) == 1) {
   return true;
 }
   return false;
-}
-function hamming_encode($r, $data_bits) {
+};
+  function hamming_encode($r, $data_bits) {
   $total = $r + count($data_bits);
   $data_ord = [];
   $cont_data = 0;
@@ -202,8 +219,8 @@ function hamming_encode($r, $data_bits) {
   $i = $i + 1;
 };
   return $result;
-}
-function hamming_decode($r, $code) {
+};
+  function hamming_decode($r, $code) {
   $data_output = [];
   $parity_received = [];
   $i = 1;
@@ -228,8 +245,8 @@ function hamming_decode($r, $code) {
 };
   $ack = list_eq($parity_received, $parity_calc);
   return ['data' => $data_output, 'ack' => $ack];
-}
-function main() {
+};
+  function main() {
   $sizePari = 4;
   $be = 2;
   $text = 'Message01';
@@ -254,5 +271,13 @@ function main() {
 }
   $decoded_err = hamming_decode($sizePari, $corrupted);
   echo rtrim('Data receive (error) ----> ' . bitlist_to_string($decoded_err['data']) . ' -- Data integrity: ' . bool_to_string($decoded_err['ack'])), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/hashes/luhn.bench
+++ b/tests/algorithms/x/PHP/hashes/luhn.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 66,
+  "duration_us": 58,
   "memory_bytes": 39448,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/hashes/luhn.php
+++ b/tests/algorithms/x/PHP/hashes/luhn.php
@@ -1,6 +1,23 @@
 <?php
 ini_set('memory_limit', '-1');
-function is_luhn($s) {
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function is_luhn($s) {
   $n = strlen($s);
   if ($n <= 1) {
   return false;
@@ -23,6 +40,14 @@ function is_luhn($s) {
   $i = $i - 1;
 };
   return $check_digit % 10 == 0;
-}
-echo str_replace('    ', '  ', json_encode(is_luhn('79927398713'), 128)), PHP_EOL;
-echo str_replace('    ', '  ', json_encode(is_luhn('79927398714'), 128)), PHP_EOL;
+};
+  echo str_replace('    ', '  ', json_encode(is_luhn('79927398713'), 128)), PHP_EOL;
+  echo str_replace('    ', '  ', json_encode(is_luhn('79927398714'), 128)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/hashes/md5.php
+++ b/tests/algorithms/x/PHP/hashes/md5.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -35,9 +50,11 @@ function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-$MOD = 4294967296;
-$ASCII = ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-function mochi_ord($ch) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $MOD = 4294967296;
+  $ASCII = ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
+  function mochi_ord($ch) {
   global $ASCII, $MOD;
   $i = 0;
   while ($i < strlen($ASCII)) {
@@ -47,15 +64,15 @@ function mochi_ord($ch) {
   $i = $i + 1;
 };
   return 0;
-}
-function to_little_endian($s) {
+};
+  function to_little_endian($s) {
   global $ASCII, $MOD;
   if (strlen($s) != 32) {
   _panic('Input must be of length 32');
 }
   return substr($s, 24, 32 - 24) . substr($s, 16, 24 - 16) . substr($s, 8, 16 - 8) . substr($s, 0, 8);
-}
-function int_to_bits($n, $width) {
+};
+  function int_to_bits($n, $width) {
   global $ASCII, $MOD;
   $bits = '';
   $num = $n;
@@ -70,8 +87,8 @@ function int_to_bits($n, $width) {
   $bits = substr($bits, strlen($bits) - $width, strlen($bits) - (strlen($bits) - $width));
 }
   return $bits;
-}
-function bits_to_int($bits) {
+};
+  function bits_to_int($bits) {
   global $ASCII, $MOD;
   $num = 0;
   $i = 0;
@@ -84,8 +101,8 @@ function bits_to_int($bits) {
   $i = $i + 1;
 };
   return $num;
-}
-function to_hex($n) {
+};
+  function to_hex($n) {
   global $ASCII, $MOD;
   $digits = '0123456789abcdef';
   if ($n == 0) {
@@ -99,8 +116,8 @@ function to_hex($n) {
   $num = _intdiv($num, 16);
 };
   return $s;
-}
-function reformat_hex($i) {
+};
+  function reformat_hex($i) {
   global $ASCII, $MOD;
   if ($i < 0) {
   _panic('Input must be non-negative');
@@ -119,8 +136,8 @@ function reformat_hex($i) {
   $j = $j - 2;
 };
   return $le;
-}
-function preprocess($message) {
+};
+  function preprocess($message) {
   global $ASCII, $MOD;
   $bit_string = '';
   $i = 0;
@@ -136,8 +153,8 @@ function preprocess($message) {
 };
   $bit_string = $bit_string . to_little_endian(substr($start_len, 32, 64 - 32)) . to_little_endian(substr($start_len, 0, 32));
   return $bit_string;
-}
-function get_block_words($bit_string) {
+};
+  function get_block_words($bit_string) {
   global $ASCII, $MOD;
   if (fmod(strlen($bit_string), 512) != 0) {
   _panic('Input must have length that\'s a multiple of 512');
@@ -157,8 +174,8 @@ function get_block_words($bit_string) {
   $pos = $pos + 512;
 };
   return $blocks;
-}
-function bit_and($a, $b) {
+};
+  function bit_and($a, $b) {
   global $ASCII, $MOD;
   $x = $a;
   $y = $b;
@@ -175,8 +192,8 @@ function bit_and($a, $b) {
   $i = $i + 1;
 };
   return $res;
-}
-function bit_or($a, $b) {
+};
+  function bit_or($a, $b) {
   global $ASCII, $MOD;
   $x = $a;
   $y = $b;
@@ -195,8 +212,8 @@ function bit_or($a, $b) {
   $i = $i + 1;
 };
   return $res;
-}
-function bit_xor($a, $b) {
+};
+  function bit_xor($a, $b) {
   global $ASCII, $MOD;
   $x = $a;
   $y = $b;
@@ -215,19 +232,19 @@ function bit_xor($a, $b) {
   $i = $i + 1;
 };
   return $res;
-}
-function not_32($i) {
+};
+  function not_32($i) {
   global $ASCII, $MOD;
   if ($i < 0) {
   _panic('Input must be non-negative');
 }
   return 4294967295 - $i;
-}
-function sum_32($a, $b) {
+};
+  function sum_32($a, $b) {
   global $ASCII, $MOD;
   return ($a + $b) % $MOD;
-}
-function lshift($num, $k) {
+};
+  function lshift($num, $k) {
   global $ASCII, $MOD;
   $result = $num % $MOD;
   $i = 0;
@@ -236,8 +253,8 @@ function lshift($num, $k) {
   $i = $i + 1;
 };
   return $result;
-}
-function rshift($num, $k) {
+};
+  function rshift($num, $k) {
   global $ASCII, $MOD;
   $result = $num;
   $i = 0;
@@ -246,8 +263,8 @@ function rshift($num, $k) {
   $i = $i + 1;
 };
   return $result;
-}
-function left_rotate_32($i, $shift) {
+};
+  function left_rotate_32($i, $shift) {
   global $ASCII, $MOD;
   if ($i < 0) {
   _panic('Input must be non-negative');
@@ -258,8 +275,8 @@ function left_rotate_32($i, $shift) {
   $left = lshift($i, $shift);
   $right = rshift($i, 32 - $shift);
   return ($left + $right) % $MOD;
-}
-function md5_me($message) {
+};
+  function md5_me($message) {
   global $ASCII, $MOD;
   $bit_string = preprocess($message);
   $added_consts = [3614090360, 3905402710, 606105819, 3250441966, 4118548399, 1200080426, 2821735955, 4249261313, 1770035416, 2336552879, 4294925233, 2304563134, 1804603682, 4254626195, 2792965006, 1236535329, 4129170786, 3225465664, 643717713, 3921069994, 3593408605, 38016083, 3634488961, 3889429448, 568446438, 3275163606, 4107603335, 1163531501, 2850285829, 4243563512, 1735328473, 2368359562, 4294588738, 2272392833, 1839030562, 4259657740, 2763975236, 1272893353, 4139469664, 3200236656, 681279174, 3936430074, 3572445317, 76029189, 3654602809, 3873151461, 530742520, 3299628645, 4096336452, 1126891415, 2878612391, 4237533241, 1700485571, 2399980690, 4293915773, 2240044497, 1873313359, 4264355552, 2734768916, 1309151649, 4149444226, 3174756917, 718787259, 3951481745];
@@ -316,4 +333,12 @@ function md5_me($message) {
 };
   $digest = reformat_hex($a0) . reformat_hex($b0) . reformat_hex($c0) . reformat_hex($d0);
   return $digest;
-}
+};
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/hashes/sdbm.bench
+++ b/tests/algorithms/x/PHP/hashes/sdbm.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 237,
+  "duration_us": 109,
   "memory_bytes": 39864,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/hashes/sdbm.php
+++ b/tests/algorithms/x/PHP/hashes/sdbm.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,8 +31,10 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-$ascii = ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-function mochi_ord($ch) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $ascii = ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
+  function mochi_ord($ch) {
   global $ascii;
   $i = 0;
   while ($i < strlen($ascii)) {
@@ -27,8 +44,8 @@ function mochi_ord($ch) {
   $i = $i + 1;
 };
   return 0;
-}
-function sdbm($plain_text) {
+};
+  function sdbm($plain_text) {
   global $ascii;
   $hash_value = 0;
   $i = 0;
@@ -38,6 +55,14 @@ function sdbm($plain_text) {
   $i = $i + 1;
 };
   return $hash_value;
-}
-echo rtrim(_str(sdbm('Algorithms'))), PHP_EOL;
-echo rtrim(_str(sdbm('scramble bits'))), PHP_EOL;
+};
+  echo rtrim(_str(sdbm('Algorithms'))), PHP_EOL;
+  echo rtrim(_str(sdbm('scramble bits'))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/hashes/sha1.bench
+++ b/tests/algorithms/x/PHP/hashes/sha1.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 11715,
+  "duration_us": 9046,
   "memory_bytes": 92112,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/hashes/sha1.php
+++ b/tests/algorithms/x/PHP/hashes/sha1.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
@@ -15,9 +30,11 @@ function _intdiv($a, $b) {
     }
     return intdiv($a, $b);
 }
-$MOD = 4294967296;
-$ASCII = ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-function mochi_ord($ch) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $MOD = 4294967296;
+  $ASCII = ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
+  function mochi_ord($ch) {
   global $ASCII, $MOD;
   $i = 0;
   while ($i < strlen($ASCII)) {
@@ -27,8 +44,8 @@ function mochi_ord($ch) {
   $i = $i + 1;
 };
   return 0;
-}
-function pow2($n) {
+};
+  function pow2($n) {
   global $ASCII, $MOD;
   $res = 1;
   $i = 0;
@@ -37,8 +54,8 @@ function pow2($n) {
   $i = $i + 1;
 };
   return $res;
-}
-function bit_and($a, $b) {
+};
+  function bit_and($a, $b) {
   global $ASCII, $MOD;
   $x = $a;
   $y = $b;
@@ -55,8 +72,8 @@ function bit_and($a, $b) {
   $i = $i + 1;
 };
   return $res;
-}
-function bit_or($a, $b) {
+};
+  function bit_or($a, $b) {
   global $ASCII, $MOD;
   $x = $a;
   $y = $b;
@@ -75,8 +92,8 @@ function bit_or($a, $b) {
   $i = $i + 1;
 };
   return $res;
-}
-function bit_xor($a, $b) {
+};
+  function bit_xor($a, $b) {
   global $ASCII, $MOD;
   $x = $a;
   $y = $b;
@@ -95,18 +112,18 @@ function bit_xor($a, $b) {
   $i = $i + 1;
 };
   return $res;
-}
-function bit_not($a) {
+};
+  function bit_not($a) {
   global $ASCII, $MOD;
   return ($MOD - 1) - $a;
-}
-function rotate_left($n, $b) {
+};
+  function rotate_left($n, $b) {
   global $ASCII, $MOD;
   $left = fmod(($n * pow2($b)), $MOD);
   $right = $n / pow2(32 - $b);
   return ($left + $right) % $MOD;
-}
-function to_hex32($n) {
+};
+  function to_hex32($n) {
   global $ASCII, $MOD;
   $digits = '0123456789abcdef';
   $num = $n;
@@ -126,8 +143,8 @@ function to_hex32($n) {
   $s = substr($s, strlen($s) - 8, strlen($s) - (strlen($s) - 8));
 }
   return $s;
-}
-function mochi_sha1($message) {
+};
+  function mochi_sha1($message) {
   global $ASCII, $MOD;
   $bytes = [];
   $i = 0;
@@ -228,9 +245,17 @@ function mochi_sha1($message) {
   $bindex = $bindex + 1;
 };
   return to_hex32($h0) . to_hex32($h1) . to_hex32($h2) . to_hex32($h3) . to_hex32($h4);
-}
-function main() {
+};
+  function main() {
   global $ASCII, $MOD;
   echo rtrim(json_encode(mochi_sha1('Test String'), 1344)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/hashes/sha256.bench
+++ b/tests/algorithms/x/PHP/hashes/sha256.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 230,
+  "memory_bytes": 40048,
+  "name": "main"
+}

--- a/tests/algorithms/x/PHP/hashes/sha256.php
+++ b/tests/algorithms/x/PHP/hashes/sha256.php
@@ -1,6 +1,24 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _intdiv($a, $b) {
+    if ($b === 0 || $b === '0') {
+        throw new DivisionByZeroError();
+    }
     if (function_exists('bcdiv')) {
         $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
@@ -14,14 +32,16 @@ function _sha256($bs) {
     $hash = hash('sha256', $bin, true);
     return array_values(unpack('C*', $hash));
 }
-$HEX = '0123456789abcdef';
-function byte_to_hex($b) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $HEX = '0123456789abcdef';
+  function byte_to_hex($b) {
   global $HEX;
   $hi = _intdiv($b, 16);
   $lo = $b % 16;
   return substr($HEX, $hi, $hi + 1 - $hi) . substr($HEX, $lo, $lo + 1 - $lo);
-}
-function bytes_to_hex($bs) {
+};
+  function bytes_to_hex($bs) {
   global $HEX;
   $res = '';
   $i = 0;
@@ -30,6 +50,14 @@ function bytes_to_hex($bs) {
   $i = $i + 1;
 };
   return $res;
-}
-echo rtrim(bytes_to_hex(_sha256('Python'))), PHP_EOL;
-echo rtrim(bytes_to_hex(_sha256('hello world'))), PHP_EOL;
+};
+  echo rtrim(bytes_to_hex(_sha256('Python'))), PHP_EOL;
+  echo rtrim(bytes_to_hex(_sha256('hello world'))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/knapsack/greedy_knapsack.bench
+++ b/tests/algorithms/x/PHP/knapsack/greedy_knapsack.bench
@@ -1,5 +1,5 @@
 {
   "duration_us": 90,
-  "memory_bytes": 37736,
+  "memory_bytes": 37776,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/knapsack/greedy_knapsack.php
+++ b/tests/algorithms/x/PHP/knapsack/greedy_knapsack.php
@@ -1,23 +1,44 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function calc_profit($profit, $weight, $max_weight) {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function calc_profit($profit, $weight, $max_weight) {
   if (count($profit) != count($weight)) {
-  $panic('The length of profit and weight must be same.');
+  _panic('The length of profit and weight must be same.');
 }
   if ($max_weight <= 0) {
-  $panic('max_weight must greater than zero.');
+  _panic('max_weight must greater than zero.');
 }
   $i = 0;
   while ($i < count($profit)) {
   if ($profit[$i] < 0) {
-  $panic('Profit can not be negative.');
+  _panic('Profit can not be negative.');
 }
   if ($weight[$i] < 0) {
-  $panic('Weight can not be negative.');
+  _panic('Weight can not be negative.');
 }
   $i = $i + 1;
 };
@@ -59,10 +80,18 @@ function calc_profit($profit, $weight, $max_weight) {
   $count = $count + 1;
 };
   return $gain;
-}
-function main() {
+};
+  function main() {
   echo rtrim(json_encode(calc_profit([1, 2, 3], [3, 4, 5], 15), 1344)), PHP_EOL;
   echo rtrim(json_encode(calc_profit([10, 9, 8], [3, 4, 5], 25), 1344)), PHP_EOL;
   echo rtrim(json_encode(calc_profit([10, 9, 8], [3, 4, 5], 5), 1344)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/knapsack/knapsack.bench
+++ b/tests/algorithms/x/PHP/knapsack/knapsack.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 57,
+  "memory_bytes": 36848,
+  "name": "main"
+}

--- a/tests/algorithms/x/PHP/knapsack/knapsack.php
+++ b/tests/algorithms/x/PHP/knapsack/knapsack.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,7 +31,9 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-function knapsack($capacity, $weights, $values, $counter) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function knapsack($capacity, $weights, $values, $counter) {
   if ($counter == 0 || $capacity == 0) {
   return 0;
 }
@@ -32,13 +49,21 @@ function knapsack($capacity, $weights, $values, $counter) {
   return $without_new_value;
 };
 }
-}
-function main() {
+};
+  function main() {
   $weights = [10, 20, 30];
   $values = [60, 100, 120];
   $cap = 50;
   $count = count($values);
   $result = knapsack($cap, $weights, $values, $count);
   echo rtrim(_str($result)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/knapsack/recursive_approach_knapsack.bench
+++ b/tests/algorithms/x/PHP/knapsack/recursive_approach_knapsack.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 62,
+  "memory_bytes": 37168,
+  "name": "main"
+}

--- a/tests/algorithms/x/PHP/knapsack/recursive_approach_knapsack.php
+++ b/tests/algorithms/x/PHP/knapsack/recursive_approach_knapsack.php
@@ -1,5 +1,20 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,7 +31,9 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-function knapsack($weights, $values, $number_of_items, $max_weight, $index) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function knapsack($weights, $values, $number_of_items, $max_weight, $index) {
   if ($index == $number_of_items) {
   return 0;
 }
@@ -29,8 +46,8 @@ function knapsack($weights, $values, $number_of_items, $max_weight, $index) {
   return $ans1;
 }
   return $ans2;
-}
-function main() {
+};
+  function main() {
   $w1 = [1, 2, 4, 5];
   $v1 = [5, 4, 8, 6];
   $r1 = knapsack($w1, $v1, 4, 5, 0);
@@ -39,5 +56,13 @@ function main() {
   $v2 = [10, 9, 8];
   $r2 = knapsack($w2, $v2, 3, 25, 0);
   echo rtrim(_str($r2)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/transpiler/x/php/ALGORITHMS.md
+++ b/transpiler/x/php/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated PHP code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/PHP`.
-Last updated: 2025-08-15 10:29 GMT+7
+Last updated: 2025-08-15 15:22 GMT+7
 
 ## Algorithms Golden Test Checklist (988/1077)
 | Index | Name | Status | Duration | Memory |
@@ -435,57 +435,57 @@ Last updated: 2025-08-15 10:29 GMT+7
 | 426 | graphs/frequent_pattern_graph_miner | ✓ | 253µs | 106.9 KB |
 | 427 | graphs/g_topological_sort | ✓ | 239µs | 36.6 KB |
 | 428 | graphs/gale_shapley_bigraph | ✓ | 90µs | 40.2 KB |
-| 429 | graphs/graph_adjacency_list | ✓ | 110µs | 69.5 KB |
-| 430 | graphs/graph_adjacency_matrix | ✓ | 103µs | 70.4 KB |
-| 431 | graphs/graph_list | ✓ | 99µs | 36.5 KB |
-| 432 | graphs/graphs_floyd_warshall | ✓ | 76µs | 38.8 KB |
-| 433 | graphs/greedy_best_first | ✓ | 386µs | 68.5 KB |
-| 434 | graphs/greedy_min_vertex_cover | ✓ | 97µs | 39.6 KB |
-| 435 | graphs/kahns_algorithm_long | ✓ | 109µs | 39.1 KB |
-| 436 | graphs/kahns_algorithm_topo | ✓ | 77µs | 35.4 KB |
-| 437 | graphs/karger | ✓ | 253µs | 83.9 KB |
-| 438 | graphs/lanczos_eigenvectors | ✓ | 119µs | 106.4 KB |
-| 439 | graphs/markov_chain | ✓ | 911µs | 36.6 KB |
-| 440 | graphs/matching_min_vertex_cover | ✓ | 127µs | 39.7 KB |
-| 441 | graphs/minimum_path_sum | ✓ | 111µs | 39.0 KB |
-| 442 | graphs/minimum_spanning_tree_boruvka | ✓ | 69µs | 37.4 KB |
-| 443 | graphs/minimum_spanning_tree_kruskal | ✓ | 141µs | 39.2 KB |
-| 444 | graphs/minimum_spanning_tree_kruskal2 | ✓ | 103µs | 38.7 KB |
-| 445 | graphs/minimum_spanning_tree_prims | ✓ | 84µs | 40.0 KB |
-| 446 | graphs/minimum_spanning_tree_prims2 | ✓ | 175µs | 35.8 KB |
-| 447 | graphs/multi_heuristic_astar | ✓ | 130µs | 107.8 KB |
-| 448 | graphs/page_rank | ✓ | 110µs | 36.7 KB |
-| 449 | graphs/prim | ✓ | 100µs | 73.1 KB |
-| 450 | graphs/random_graph_generator | ✓ | 71µs | 34.9 KB |
-| 451 | graphs/scc_kosaraju | ✓ | 92µs | 36.9 KB |
-| 452 | graphs/strongly_connected_components | ✓ | 120µs | 36.6 KB |
-| 453 | graphs/tarjans_scc | ✓ | 129µs | 36.6 KB |
-| 454 | graphs/tests/test_min_spanning_tree_kruskal | ✓ | 101µs | 35.1 KB |
-| 455 | graphs/tests/test_min_spanning_tree_prim | ✓ | 198µs | 40.6 KB |
-| 456 | greedy_methods/best_time_to_buy_and_sell_stock | ✓ | 46µs | 38.1 KB |
-| 457 | greedy_methods/fractional_cover_problem | ✓ | 72µs | 36.0 KB |
-| 458 | greedy_methods/fractional_knapsack | ✓ | 71µs | 40.2 KB |
-| 459 | greedy_methods/fractional_knapsack_2 | ✓ | 76µs | 38.8 KB |
-| 460 | greedy_methods/gas_station | ✓ | 71µs | 39.0 KB |
-| 461 | greedy_methods/minimum_coin_change | ✓ | 99µs | 38.7 KB |
-| 462 | greedy_methods/minimum_waiting_time | ✓ | 52µs | 34.8 KB |
-| 463 | greedy_methods/optimal_merge_pattern | ✓ | 91µs | 38.4 KB |
-| 464 | greedy_methods/smallest_range | ✓ | 130µs | 36.9 KB |
-| 465 | hashes/adler32 | ✓ | 50µs | 36.5 KB |
-| 466 | hashes/chaos_machine | ✓ | 327µs | 36.5 KB |
-| 467 | hashes/djb2 | ✓ | 65µs | 38.6 KB |
-| 468 | hashes/elf | ✓ | 557µs | 40.8 KB |
-| 469 | hashes/enigma_machine | ✓ | 240µs | 40.3 KB |
+| 429 | graphs/graph_adjacency_list | ✓ | 210µs | 69.5 KB |
+| 430 | graphs/graph_adjacency_matrix | ✓ | 161µs | 70.4 KB |
+| 431 | graphs/graph_list | ✓ | 126µs | 36.5 KB |
+| 432 | graphs/graphs_floyd_warshall | ✓ | 88µs | 38.8 KB |
+| 433 | graphs/greedy_best_first | ✓ | 478µs | 68.5 KB |
+| 434 | graphs/greedy_min_vertex_cover | ✓ | 142µs | 39.6 KB |
+| 435 | graphs/kahns_algorithm_long | ✓ | 84µs | 39.1 KB |
+| 436 | graphs/kahns_algorithm_topo | ✓ | 109µs | 35.4 KB |
+| 437 | graphs/karger | ✓ | 192µs | 83.9 KB |
+| 438 | graphs/lanczos_eigenvectors | ✓ | 227µs | 106.4 KB |
+| 439 | graphs/markov_chain | ✓ | 978µs | 36.6 KB |
+| 440 | graphs/matching_min_vertex_cover | ✓ | 115µs | 39.7 KB |
+| 441 | graphs/minimum_path_sum | ✓ | 98µs | 39.0 KB |
+| 442 | graphs/minimum_spanning_tree_boruvka | ✓ | 94µs | 37.4 KB |
+| 443 | graphs/minimum_spanning_tree_kruskal | ✓ | 111µs | 39.2 KB |
+| 444 | graphs/minimum_spanning_tree_kruskal2 | ✓ | 112µs | 38.7 KB |
+| 445 | graphs/minimum_spanning_tree_prims | ✓ | 104µs | 40.0 KB |
+| 446 | graphs/minimum_spanning_tree_prims2 | ✓ | 122µs | 35.8 KB |
+| 447 | graphs/multi_heuristic_astar | ✓ | 139µs | 107.8 KB |
+| 448 | graphs/page_rank | ✓ | 128µs | 36.7 KB |
+| 449 | graphs/prim | ✓ | 137µs | 73.1 KB |
+| 450 | graphs/random_graph_generator | ✓ | 142µs | 34.9 KB |
+| 451 | graphs/scc_kosaraju | ✓ | 90µs | 36.9 KB |
+| 452 | graphs/strongly_connected_components | ✓ | 149µs | 36.6 KB |
+| 453 | graphs/tarjans_scc | ✓ | 157µs | 36.6 KB |
+| 454 | graphs/tests/test_min_spanning_tree_kruskal | ✓ | 152µs | 35.1 KB |
+| 455 | graphs/tests/test_min_spanning_tree_prim | ✓ | 231µs | 40.6 KB |
+| 456 | greedy_methods/best_time_to_buy_and_sell_stock | ✓ | 58µs | 38.1 KB |
+| 457 | greedy_methods/fractional_cover_problem | ✓ | 114µs | 36.0 KB |
+| 458 | greedy_methods/fractional_knapsack | ✓ | 98µs | 40.2 KB |
+| 459 | greedy_methods/fractional_knapsack_2 | ✓ | 93µs | 38.8 KB |
+| 460 | greedy_methods/gas_station | ✓ | 81µs | 39.0 KB |
+| 461 | greedy_methods/minimum_coin_change | ✓ | 109µs | 38.7 KB |
+| 462 | greedy_methods/minimum_waiting_time | ✓ | 56µs | 34.8 KB |
+| 463 | greedy_methods/optimal_merge_pattern | ✓ | 88µs | 38.4 KB |
+| 464 | greedy_methods/smallest_range | ✓ | 99µs | 36.9 KB |
+| 465 | hashes/adler32 | ✓ | 73µs | 36.5 KB |
+| 466 | hashes/chaos_machine | ✓ | 328µs | 36.5 KB |
+| 467 | hashes/djb2 | ✓ | 83µs | 38.6 KB |
+| 468 | hashes/elf | ✓ | 571µs | 40.8 KB |
+| 469 | hashes/enigma_machine | ✓ | 271µs | 40.3 KB |
 | 470 | hashes/fletcher16 | ✓ | 1µs | 35.5 KB |
-| 471 | hashes/hamming_code | ✓ | 648µs | 74.5 KB |
-| 472 | hashes/luhn | ✓ | 66µs | 38.5 KB |
+| 471 | hashes/hamming_code | ✓ | 606µs | 74.5 KB |
+| 472 | hashes/luhn | ✓ | 58µs | 38.5 KB |
 | 473 | hashes/md5 | ✓ | 1µs | 103.9 KB |
-| 474 | hashes/sdbm | ✓ | 237µs | 38.9 KB |
-| 475 | hashes/sha1 | ✓ | 11.715ms | 90.0 KB |
-| 476 | hashes/sha256 | ✓ |  |  |
-| 477 | knapsack/greedy_knapsack | ✓ |  |  |
-| 478 | knapsack/knapsack | ✓ |  |  |
-| 479 | knapsack/recursive_approach_knapsack | ✓ |  |  |
+| 474 | hashes/sdbm | ✓ | 109µs | 38.9 KB |
+| 475 | hashes/sha1 | ✓ | 9.046ms | 90.0 KB |
+| 476 | hashes/sha256 | ✓ | 230µs | 39.1 KB |
+| 477 | knapsack/greedy_knapsack | ✓ | 90µs | 36.9 KB |
+| 478 | knapsack/knapsack | ✓ | 57µs | 36.0 KB |
+| 479 | knapsack/recursive_approach_knapsack | ✓ | 62µs | 36.3 KB |
 | 480 | knapsack/tests/test_greedy_knapsack | ✓ |  |  |
 | 481 | knapsack/tests/test_knapsack | ✓ | 131µs | 38.8 KB |
 | 482 | linear_algebra/gaussian_elimination | ✓ | 357µs | 39.4 KB |

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-Last updated: 2025-08-15 09:59 +0700
+Last updated: 2025-08-15 15:17 +0700
 
 ## VM Golden Test Checklist (103/105)
 - [x] append_builtin

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,4 +1,4 @@
-## Progress (2025-08-15 09:59 +0700)
+## Progress (2025-08-15 15:17 +0700)
 - Generated PHP for 103/105 programs
 - Updated README checklist and outputs
 - Enhanced printing to match golden format

--- a/transpiler/x/php/transpiler.go
+++ b/transpiler/x/php/transpiler.go
@@ -27,7 +27,7 @@ var builtinNames = map[string]struct{}{
 	"values": {}, "keys": {}, "load": {}, "save": {}, "now": {}, "input": {},
 	"upper": {}, "lower": {}, "num": {}, "denom": {}, "indexOf": {}, "repeat": {}, "parseIntStr": {}, "slice": {}, "split": {}, "contains": {}, "first": {}, "substr": {}, "pow": {}, "getoutput": {}, "intval": {}, "floatval": {}, "int": {}, "float": {}, "to_float": {}, "ord": {}, "ctype_digit": {}, "toi": {}, "reset": {},
 	"concat": {}, "panic": {}, "error": {}, "ceil": {}, "floor": {},
-	"sha1": {},
+	"sha1": {}, "sha256": {},
 }
 
 const helperLookupHost = `function _lookup_host($host) {


### PR DESCRIPTION
## Summary
- recognize `sha256` as a PHP builtin
- regenerate PHP outputs and benchmarks for algorithms indices 429-479
- refresh progress documentation

## Testing
- `MOCHI_ALG_INDEX=429 MOCHI_BENCHMARK=1 go test ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags slow -count=1 -update-algorithms-php`
- `for i in $(seq 429 479); do MOCHI_ALG_INDEX=$i MOCHI_BENCHMARK=1 go test ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags slow -count=1 -update-algorithms-php >/tmp/test$i.log && echo "$i ok"; done`
- `MOCHI_ALG_INDEX=476 MOCHI_BENCHMARK=1 go test ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_689eed3e08408320855fc31a7accb616