### PR TITLE
kt: fix field access types and struct name conflicts

### DIFF
--- a/tests/algorithms/x/Kotlin/neural_network/back_propagation_neural_network.bench
+++ b/tests/algorithms/x/Kotlin/neural_network/back_propagation_neural_network.bench
@@ -1,5 +1,2 @@
-Exception in thread "main" java.lang.ClassCastException: class java.util.ArrayList cannot be cast to class Layer (java.util.ArrayList is in module java.base of loader 'bootstrap'; Layer is in unnamed module of loader 'app')
-	at Back_propagation_neural_networkKt.train(back_propagation_neural_network.kt:288)
-	at Back_propagation_neural_networkKt.user_main(back_propagation_neural_network.kt:318)
-	at Back_propagation_neural_networkKt.main(back_propagation_neural_network.kt:327)
-	at Back_propagation_neural_networkKt.main(back_propagation_neural_network.kt)
+0.0
+{"duration_us":919515, "memory_bytes":850752, "name":"main"}

--- a/tests/algorithms/x/Kotlin/neural_network/back_propagation_neural_network.error
+++ b/tests/algorithms/x/Kotlin/neural_network/back_propagation_neural_network.error
@@ -1,4 +1,0 @@
-kotlinc: exit status 1
-/workspace/mochi/tests/algorithms/x/Kotlin/neural_network/back_propagation_neural_network.kt:289:71: error: type mismatch: inferred type is Layer but MutableList<Double> was expected
-            var grad: MutableList<Double> = calc_gradient(ydata[i]!!, out)
-                                                                      ^

--- a/tests/algorithms/x/Kotlin/neural_network/back_propagation_neural_network.kt
+++ b/tests/algorithms/x/Kotlin/neural_network/back_propagation_neural_network.kt
@@ -32,12 +32,12 @@ data class Layer(var units: Int = 0, var weight: MutableList<MutableList<Double>
 data class Data(var x: MutableList<MutableList<Double>> = mutableListOf<MutableList<Double>>(), var y: MutableList<MutableList<Double>> = mutableListOf<MutableList<Double>>())
 var seed: Int = (1).toInt()
 fun rand(): Int {
-    seed = (((Math.floorMod((((seed * 1103515245) + 12345).toLong()), 2147483648L)).toInt())).toInt()
+    seed = (((Math.floorMod((((seed * 1103515245) + 12345).toLong()), (2147483648L).toInt())).toInt())).toInt()
     return seed
 }
 
 fun random(): Double {
-    return (1.0 * rand()) / 2147483648.0
+    return (1.0 * (rand()).toDouble()) / 2147483648.0
 }
 
 fun expApprox(x: Double): Double {
@@ -285,7 +285,7 @@ fun train(layers: MutableList<Layer>, xdata: MutableList<MutableList<Double>>, y
         var i: Int = (0).toInt()
         while (i < xdata.size) {
             layers = forward(layers, xdata[i]!!)
-            var out: Layer = ((layers[layers.size - 1]!!.output) as Layer)
+            var out: MutableList<Double> = layers[layers.size - 1]!!.output
             var grad: MutableList<Double> = calc_gradient(ydata[i]!!, out)
             layers = backward(layers, grad)
             i = i + 1

--- a/tests/algorithms/x/Kotlin/neural_network/back_propagation_neural_network.out
+++ b/tests/algorithms/x/Kotlin/neural_network/back_propagation_neural_network.out
@@ -1,5 +1,1 @@
-Exception in thread "main" java.lang.ClassCastException: class java.util.ArrayList cannot be cast to class Layer (java.util.ArrayList is in module java.base of loader 'bootstrap'; Layer is in unnamed module of loader 'app')
-	at Back_propagation_neural_networkKt.train(back_propagation_neural_network.kt:262)
-	at Back_propagation_neural_networkKt.user_main(back_propagation_neural_network.kt:292)
-	at Back_propagation_neural_networkKt.main(back_propagation_neural_network.kt:297)
-	at Back_propagation_neural_networkKt.main(back_propagation_neural_network.kt)
+0.0

--- a/transpiler/x/kt/ALGORITHMS.md
+++ b/transpiler/x/kt/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated Kotlin code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Kotlin`.
-Last updated: 2025-08-15 10:36 GMT+7
+Last updated: 2025-08-16 09:50 GMT+7
 
-## Algorithms Golden Test Checklist (549/1077)
+## Algorithms Golden Test Checklist (550/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 30.54ms | 124.45KiB |
@@ -738,7 +738,7 @@ Last updated: 2025-08-15 10:36 GMT+7
 | 729 | neural_network/activation_functions/softplus | error |  |  |
 | 730 | neural_network/activation_functions/squareplus | ✓ | 27.83ms | 112.77KiB |
 | 731 | neural_network/activation_functions/swish | ✓ | 37.20ms | 112.73KiB |
-| 732 | neural_network/back_propagation_neural_network | error |  |  |
+| 732 | neural_network/back_propagation_neural_network | ✓ | 919.51ms | 830.81KiB |
 | 733 | neural_network/convolution_neural_network | error |  |  |
 | 734 | neural_network/input_data | ✓ | 21.02ms | 121.62KiB |
 | 735 | neural_network/simple_neural_network | ✓ | 161.52ms | 124.12KiB |


### PR DESCRIPTION
## Summary
- ensure field access after indexing infers correct element type
- avoid Kotlin built-in name clashes by renaming struct declarations
- regenerate Kotlin algorithm output for back_propagation_neural_network

## Testing
- `MOCHI_ALG_INDEX=732 go test -tags slow -count=1 ./transpiler/x/kt -run TestKTTranspiler_Algorithms_Golden -update-algorithms-kt`
- `MOCHI_BENCHMARK=1 MOCHI_ALG_INDEX=732 go test -tags slow -count=1 ./transpiler/x/kt -run TestKTTranspiler_Algorithms_Golden -update-algorithms-kt`


------
https://chatgpt.com/codex/tasks/task_e_689fec69258c8320a50b37314b24c58c