### PR TITLE
clj: map exp to Math/exp

### DIFF
--- a/tests/algorithms/x/Clojure/machine_learning/apriori_algorithm.error
+++ b/tests/algorithms/x/Clojure/machine_learning/apriori_algorithm.error
@@ -1,6 +1,0 @@
-run: exit status 1
-Execution error (ClassCastException) at main/sort-strings (apriori_algorithm.clj:114).
-class java.lang.String cannot be cast to class java.lang.Number (java.lang.String and java.lang.Number are in module java.base of loader 'bootstrap')
-
-Full report at:
-/tmp/clojure-15751004108782462408.edn

--- a/transpiler/x/clj/ALGORITHMS.md
+++ b/transpiler/x/clj/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated Clojure code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Clojure`.
-Last updated: 2025-08-15 21:40 GMT+7
+Last updated: 2025-08-16 11:56 GMT+7
 
-## Algorithms Golden Test Checklist (783/1077)
+## Algorithms Golden Test Checklist (784/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 50.25ms | 19.66MB |
@@ -432,10 +432,10 @@ Last updated: 2025-08-15 21:40 GMT+7
 | 423 | graphs/eulerian_path_and_circuit_for_undirected_graph | ✓ | 51.653ms | 21.06MB |
 | 424 | graphs/even_tree | ✓ | 41.42ms | 20.93MB |
 | 425 | graphs/finding_bridges | ✓ | 97.715ms | 21.08MB |
-| 426 | graphs/frequent_pattern_graph_miner | ✓ | 80.875ms | 39.78MB |
-| 427 | graphs/g_topological_sort | ✓ | 33.552ms | 21.63MB |
-| 428 | graphs/gale_shapley_bigraph | ✓ | 53.458ms | 21.66MB |
-| 429 | graphs/graph_adjacency_list | ✓ | 57.603ms | 27.25MB |
+| 426 | graphs/frequent_pattern_graph_miner | ✓ | 73.632ms | 39.61MB |
+| 427 | graphs/g_topological_sort | ✓ | 44.021ms | 21.61MB |
+| 428 | graphs/gale_shapley_bigraph | ✓ | 65.588ms | 21.84MB |
+| 429 | graphs/graph_adjacency_list | ✓ | 55.512ms | 27.29MB |
 | 430 | graphs/graph_adjacency_matrix | ✓ | 49.376ms | 25.54MB |
 | 431 | graphs/graph_list | ✓ | 70.352ms | 21.08MB |
 | 432 | graphs/graphs_floyd_warshall | error | 46.461ms | 21.04MB |
@@ -503,7 +503,7 @@ Last updated: 2025-08-15 21:40 GMT+7
 | 494 | linear_algebra/src/test_linear_algebra | ✓ | 71.424ms | 36.83MB |
 | 495 | linear_algebra/src/transformations_2d | ✓ | 52.731ms | 24.04MB |
 | 496 | linear_programming/simplex | ✓ | 50.979ms | 24.63MB |
-| 497 | machine_learning/apriori_algorithm | error |  |  |
+| 497 | machine_learning/apriori_algorithm | ✓ |  |  |
 | 498 | machine_learning/astar | ✓ | 72.871ms | 27.39MB |
 | 499 | machine_learning/automatic_differentiation | ✓ | 51.588ms | 21.82MB |
 | 500 | machine_learning/data_transformations | ✓ | 80.927ms | 23.16MB |
@@ -706,7 +706,7 @@ Last updated: 2025-08-15 21:40 GMT+7
 | 697 | matrix/binary_search_matrix | ✓ | 45.522ms | 20.70MB |
 | 698 | matrix/count_islands_in_matrix | error |  |  |
 | 699 | matrix/count_negative_numbers_in_sorted_matrix | ✓ | 1.952115s | 54.85MB |
-| 700 | matrix/count_paths | ✓ | 56.189ms | 20.75MB |
+| 700 | matrix/count_paths | ✓ | 56.55ms | 21.30MB |
 | 701 | matrix/cramers_rule_2x2 | ✓ | 60.933ms | 21.03MB |
 | 702 | matrix/inverse_of_matrix | ✓ | 64.474ms | 27.05MB |
 | 703 | matrix/largest_square_area_in_matrix | ✓ | 47.372ms | 25.28MB |

--- a/transpiler/x/clj/transpiler.go
+++ b/transpiler/x/clj/transpiler.go
@@ -678,6 +678,7 @@ func transpileImportStmt(im *parser.ImportStmt) (Node, error) {
 			{Keyword("sqrt"), fn1("Math/sqrt", []string{"x"})},
 			{Keyword("pow"), fn1("Math/pow", []string{"x", "y"})},
 			{Keyword("sin"), fn1("Math/sin", []string{"x"})},
+			{Keyword("exp"), fn1("Math/exp", []string{"x"})},
 			{Keyword("log"), fn1("Math/log", []string{"x"})},
 			{Keyword("pi"), Symbol("Math/PI")},
 			{Keyword("e"), Symbol("Math/E")},


### PR DESCRIPTION
## Summary
- map Python's `math.exp` to Clojure `Math/exp`
- remove obsolete `apriori_algorithm.error`
- refresh algorithms table for Clojure transpiler

## Testing
- `MOCHI_ALG_INDEX=496 go test -tags=slow ./transpiler/x/clj -run TestClojureTranspiler_Algorithms_Golden -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68a00dbb26d88320833ec56aace841c3