### PR TITLE
feat: handle int casts in dart transpiler

### DIFF
--- a/tests/algorithms/x/Dart/maths/ceil.bench
+++ b/tests/algorithms/x/Dart/maths/ceil.bench
@@ -1,6 +1,1 @@
-Unhandled exception:
-type 'double' is not a subtype of type 'int' in type cast
-#0      ceil (file:///workspace/mochi/tests/algorithms/x/Dart/maths/ceil.dart:40:21)
-#1      main (file:///workspace/mochi/tests/algorithms/x/Dart/maths/ceil.dart:57:11)
-#2      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:314:19)
-#3      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:193:12)
+{"duration_us":0,"memory_bytes":0}

--- a/tests/algorithms/x/Dart/maths/ceil.dart
+++ b/tests/algorithms/x/Dart/maths/ceil.dart
@@ -14,8 +14,8 @@ String _substr(String s, num start, num end) {
 }
 
 int ceil(double x) {
-  int truncated = x as int;
-  double frac = x - (truncated as double);
+  int truncated = x.toInt();
+  double frac = x - (truncated.toDouble());
   if (frac <= 0.0) {
     return truncated;
   }

--- a/tests/algorithms/x/Dart/maths/ceil.error
+++ b/tests/algorithms/x/Dart/maths/ceil.error
@@ -1,7 +1,0 @@
-run: exit status 255
-Unhandled exception:
-type 'double' is not a subtype of type 'int' in type cast
-#0      ceil (file:///workspace/mochi/tests/algorithms/x/Dart/maths/ceil.dart:17:21)
-#1      main (file:///workspace/mochi/tests/algorithms/x/Dart/maths/ceil.dart:28:11)
-#2      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:314:19)
-#3      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:193:12)

--- a/tests/algorithms/x/Dart/maths/ceil.out
+++ b/tests/algorithms/x/Dart/maths/ceil.out
@@ -1,6 +1,9 @@
-Unhandled exception:
-type 'double' is not a subtype of type 'int' in type cast
-#0      ceil (file:///workspace/mochi/tests/algorithms/x/Dart/maths/ceil.dart:17:21)
-#1      main (file:///workspace/mochi/tests/algorithms/x/Dart/maths/ceil.dart:28:11)
-#2      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:314:19)
-#3      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:193:12)
+1
+-1
+0
+0
+2
+-1
+1
+-1
+1000000000

--- a/transpiler/x/dart/ALGORITHMS.md
+++ b/transpiler/x/dart/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated Dart code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Dart`.
-Last updated: 2025-08-16 09:41 GMT+7
+Last updated: 2025-08-16 11:58 GMT+7
 
-## Algorithms Golden Test Checklist (949/1077)
+## Algorithms Golden Test Checklist (950/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 16.068ms | 2.7 MB |
@@ -551,7 +551,7 @@ Last updated: 2025-08-16 09:41 GMT+7
 | 542 | maths/binary_multiplication | ✓ | 12.861ms | 9.8 MB |
 | 543 | maths/binomial_coefficient | ✓ | 7.503ms | 3.1 MB |
 | 544 | maths/binomial_distribution | ✓ | 15.961ms | 11.1 MB |
-| 545 | maths/ceil | error |  |  |
+| 545 | maths/ceil | ✓ |  |  |
 | 546 | maths/chebyshev_distance | ✓ | 13.256ms | 1.9 MB |
 | 547 | maths/check_polygon | error |  |  |
 | 548 | maths/chinese_remainder_theorem | ✓ | 9.241ms | 2.0 MB |

--- a/transpiler/x/dart/transpiler.go
+++ b/transpiler/x/dart/transpiler.go
@@ -3038,7 +3038,10 @@ func (c *CastExpr) emit(w io.Writer) error {
 	}
 	switch c.Type {
 	case "int":
-		_, err := io.WriteString(w, " as int")
+		_, err := io.WriteString(w, ".toInt()")
+		return err
+	case "double":
+		_, err := io.WriteString(w, ".toDouble()")
 		return err
 	case "num":
 		if valType != "num" && valType != "double" {
@@ -5908,6 +5911,8 @@ func convertPostfix(pf *parser.PostfixExpr) (Expr, error) {
 				expr = &CallExpr{Func: &Name{"_bigrat"}, Args: []Expr{expr}}
 			} else if typ == "double" {
 				expr = &CallExpr{Func: &SelectorExpr{Receiver: expr, Field: "toDouble"}}
+			} else if typ == "int" {
+				expr = &CallExpr{Func: &SelectorExpr{Receiver: expr, Field: "toInt"}}
 			} else {
 				expr = &CastExpr{Value: expr, Type: typ}
 			}


### PR DESCRIPTION
## Summary
- improve Dart transpiler cast handling by converting numeric casts to `toInt()`/`toDouble()`
- update algorithms artifacts for `maths/ceil`

## Testing
- `MOCHI_ALG_INDEX=545 go test -tags=slow ./transpiler/x/dart -run TestDartTranspiler_Algorithms_Golden -update-algorithms-dart`


------
https://chatgpt.com/codex/tasks/task_e_68a00dc4a6b08320a1f5aa0ab2980309