### PR TITLE
Fix Clojure transpiler addition type handling

### DIFF
--- a/tests/algorithms/x/Clojure/graphs/edmonds_karp_multiple_source_and_sink.bench
+++ b/tests/algorithms/x/Clojure/graphs/edmonds_karp_multiple_source_and_sink.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 41046,
+  "memory_bytes": 27099776,
+  "name": "main"
+}

--- a/tests/algorithms/x/Clojure/graphs/edmonds_karp_multiple_source_and_sink.clj
+++ b/tests/algorithms/x/Clojure/graphs/edmonds_karp_multiple_source_and_sink.clj
@@ -1,0 +1,114 @@
+(ns main (:refer-clojure :exclude [push_relabel_max_flow]))
+
+(require 'clojure.set)
+
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
+(defn padStart [s w p]
+  (loop [out (str s)] (if (< (count out) w) (recur (str p out)) out)))
+
+(defn indexOf [s sub]
+  (let [idx (clojure.string/index-of s sub)] (if (nil? idx) -1 idx)))
+
+(defn split [s sep]
+  (clojure.string/split s (re-pattern sep)))
+
+(defn toi [s]
+  (Integer/parseInt (str s)))
+
+(defn _fetch [url]
+  {:data [{:from "" :intensity {:actual 0 :forecast 0 :index ""} :to ""}]})
+
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
+(declare push_relabel_max_flow)
+
+(def ^:dynamic push_relabel_max_flow_bandwidth nil)
+
+(def ^:dynamic push_relabel_max_flow_c nil)
+
+(def ^:dynamic push_relabel_max_flow_capacity nil)
+
+(def ^:dynamic push_relabel_max_flow_delta nil)
+
+(def ^:dynamic push_relabel_max_flow_excesses nil)
+
+(def ^:dynamic push_relabel_max_flow_flow nil)
+
+(def ^:dynamic push_relabel_max_flow_g nil)
+
+(def ^:dynamic push_relabel_max_flow_heights nil)
+
+(def ^:dynamic push_relabel_max_flow_i nil)
+
+(def ^:dynamic push_relabel_max_flow_idx nil)
+
+(def ^:dynamic push_relabel_max_flow_j nil)
+
+(def ^:dynamic push_relabel_max_flow_last_row nil)
+
+(def ^:dynamic push_relabel_max_flow_max_input_flow nil)
+
+(def ^:dynamic push_relabel_max_flow_min_height nil)
+
+(def ^:dynamic push_relabel_max_flow_n nil)
+
+(def ^:dynamic push_relabel_max_flow_nb nil)
+
+(def ^:dynamic push_relabel_max_flow_new_graph nil)
+
+(def ^:dynamic push_relabel_max_flow_preflow nil)
+
+(def ^:dynamic push_relabel_max_flow_prev_height nil)
+
+(def ^:dynamic push_relabel_max_flow_r nil)
+
+(def ^:dynamic push_relabel_max_flow_row nil)
+
+(def ^:dynamic push_relabel_max_flow_row2 nil)
+
+(def ^:dynamic push_relabel_max_flow_sink_index nil)
+
+(def ^:dynamic push_relabel_max_flow_size nil)
+
+(def ^:dynamic push_relabel_max_flow_source_index nil)
+
+(def ^:dynamic push_relabel_max_flow_v nil)
+
+(def ^:dynamic push_relabel_max_flow_vertex nil)
+
+(def ^:dynamic push_relabel_max_flow_vertices_list nil)
+
+(def ^:dynamic push_relabel_max_flow_zero_row nil)
+
+(defn push_relabel_max_flow [push_relabel_max_flow_graph push_relabel_max_flow_sources push_relabel_max_flow_sinks]
+  (binding [push_relabel_max_flow_bandwidth nil push_relabel_max_flow_c nil push_relabel_max_flow_capacity nil push_relabel_max_flow_delta nil push_relabel_max_flow_excesses nil push_relabel_max_flow_flow nil push_relabel_max_flow_g nil push_relabel_max_flow_heights nil push_relabel_max_flow_i nil push_relabel_max_flow_idx nil push_relabel_max_flow_j nil push_relabel_max_flow_last_row nil push_relabel_max_flow_max_input_flow nil push_relabel_max_flow_min_height nil push_relabel_max_flow_n nil push_relabel_max_flow_nb nil push_relabel_max_flow_new_graph nil push_relabel_max_flow_preflow nil push_relabel_max_flow_prev_height nil push_relabel_max_flow_r nil push_relabel_max_flow_row nil push_relabel_max_flow_row2 nil push_relabel_max_flow_sink_index nil push_relabel_max_flow_size nil push_relabel_max_flow_source_index nil push_relabel_max_flow_v nil push_relabel_max_flow_vertex nil push_relabel_max_flow_vertices_list nil push_relabel_max_flow_zero_row nil] (try (do (when (or (= (count push_relabel_max_flow_sources) 0) (= (count push_relabel_max_flow_sinks) 0)) (throw (ex-info "return" {:v 0}))) (set! push_relabel_max_flow_g push_relabel_max_flow_graph) (set! push_relabel_max_flow_source_index (nth push_relabel_max_flow_sources 0)) (set! push_relabel_max_flow_sink_index (nth push_relabel_max_flow_sinks 0)) (when (or (> (count push_relabel_max_flow_sources) 1) (> (count push_relabel_max_flow_sinks) 1)) (do (set! push_relabel_max_flow_max_input_flow 0) (set! push_relabel_max_flow_i 0) (while (< push_relabel_max_flow_i (count push_relabel_max_flow_sources)) (do (set! push_relabel_max_flow_j 0) (while (< push_relabel_max_flow_j (count (nth push_relabel_max_flow_g (nth push_relabel_max_flow_sources push_relabel_max_flow_i)))) (do (set! push_relabel_max_flow_max_input_flow (+ push_relabel_max_flow_max_input_flow (nth (nth push_relabel_max_flow_g (nth push_relabel_max_flow_sources push_relabel_max_flow_i)) push_relabel_max_flow_j))) (set! push_relabel_max_flow_j (+ push_relabel_max_flow_j 1)))) (set! push_relabel_max_flow_i (+ push_relabel_max_flow_i 1)))) (set! push_relabel_max_flow_size (+ (count push_relabel_max_flow_g) 1)) (set! push_relabel_max_flow_new_graph []) (set! push_relabel_max_flow_zero_row []) (set! push_relabel_max_flow_j 0) (while (< push_relabel_max_flow_j push_relabel_max_flow_size) (do (set! push_relabel_max_flow_zero_row (conj push_relabel_max_flow_zero_row 0)) (set! push_relabel_max_flow_j (+ push_relabel_max_flow_j 1)))) (set! push_relabel_max_flow_new_graph (conj push_relabel_max_flow_new_graph push_relabel_max_flow_zero_row)) (set! push_relabel_max_flow_r 0) (while (< push_relabel_max_flow_r (count push_relabel_max_flow_g)) (do (set! push_relabel_max_flow_row [0]) (set! push_relabel_max_flow_c 0) (while (< push_relabel_max_flow_c (count (nth push_relabel_max_flow_g push_relabel_max_flow_r))) (do (set! push_relabel_max_flow_row (conj push_relabel_max_flow_row (nth (nth push_relabel_max_flow_g push_relabel_max_flow_r) push_relabel_max_flow_c))) (set! push_relabel_max_flow_c (+ push_relabel_max_flow_c 1)))) (set! push_relabel_max_flow_new_graph (conj push_relabel_max_flow_new_graph push_relabel_max_flow_row)) (set! push_relabel_max_flow_r (+ push_relabel_max_flow_r 1)))) (set! push_relabel_max_flow_g push_relabel_max_flow_new_graph) (set! push_relabel_max_flow_i 0) (while (< push_relabel_max_flow_i (count push_relabel_max_flow_sources)) (do (set! push_relabel_max_flow_g (assoc-in push_relabel_max_flow_g [0 (+ (nth push_relabel_max_flow_sources push_relabel_max_flow_i) 1)] push_relabel_max_flow_max_input_flow)) (set! push_relabel_max_flow_i (+ push_relabel_max_flow_i 1)))) (set! push_relabel_max_flow_source_index 0) (set! push_relabel_max_flow_size (+ (count push_relabel_max_flow_g) 1)) (set! push_relabel_max_flow_new_graph []) (set! push_relabel_max_flow_r 0) (while (< push_relabel_max_flow_r (count push_relabel_max_flow_g)) (do (set! push_relabel_max_flow_row2 (nth push_relabel_max_flow_g push_relabel_max_flow_r)) (set! push_relabel_max_flow_row2 (conj push_relabel_max_flow_row2 0)) (set! push_relabel_max_flow_new_graph (conj push_relabel_max_flow_new_graph push_relabel_max_flow_row2)) (set! push_relabel_max_flow_r (+ push_relabel_max_flow_r 1)))) (set! push_relabel_max_flow_last_row []) (set! push_relabel_max_flow_j 0) (while (< push_relabel_max_flow_j push_relabel_max_flow_size) (do (set! push_relabel_max_flow_last_row (conj push_relabel_max_flow_last_row 0)) (set! push_relabel_max_flow_j (+ push_relabel_max_flow_j 1)))) (set! push_relabel_max_flow_new_graph (conj push_relabel_max_flow_new_graph push_relabel_max_flow_last_row)) (set! push_relabel_max_flow_g push_relabel_max_flow_new_graph) (set! push_relabel_max_flow_i 0) (while (< push_relabel_max_flow_i (count push_relabel_max_flow_sinks)) (do (set! push_relabel_max_flow_g (assoc-in push_relabel_max_flow_g [(+ (nth push_relabel_max_flow_sinks push_relabel_max_flow_i) 1) (- push_relabel_max_flow_size 1)] push_relabel_max_flow_max_input_flow)) (set! push_relabel_max_flow_i (+ push_relabel_max_flow_i 1)))) (set! push_relabel_max_flow_sink_index (- push_relabel_max_flow_size 1)))) (set! push_relabel_max_flow_n (count push_relabel_max_flow_g)) (set! push_relabel_max_flow_preflow []) (set! push_relabel_max_flow_i 0) (while (< push_relabel_max_flow_i push_relabel_max_flow_n) (do (set! push_relabel_max_flow_row []) (set! push_relabel_max_flow_j 0) (while (< push_relabel_max_flow_j push_relabel_max_flow_n) (do (set! push_relabel_max_flow_row (conj push_relabel_max_flow_row 0)) (set! push_relabel_max_flow_j (+ push_relabel_max_flow_j 1)))) (set! push_relabel_max_flow_preflow (conj push_relabel_max_flow_preflow push_relabel_max_flow_row)) (set! push_relabel_max_flow_i (+ push_relabel_max_flow_i 1)))) (set! push_relabel_max_flow_heights []) (set! push_relabel_max_flow_i 0) (while (< push_relabel_max_flow_i push_relabel_max_flow_n) (do (set! push_relabel_max_flow_heights (conj push_relabel_max_flow_heights 0)) (set! push_relabel_max_flow_i (+ push_relabel_max_flow_i 1)))) (set! push_relabel_max_flow_excesses []) (set! push_relabel_max_flow_i 0) (while (< push_relabel_max_flow_i push_relabel_max_flow_n) (do (set! push_relabel_max_flow_excesses (conj push_relabel_max_flow_excesses 0)) (set! push_relabel_max_flow_i (+ push_relabel_max_flow_i 1)))) (set! push_relabel_max_flow_heights (assoc push_relabel_max_flow_heights push_relabel_max_flow_source_index push_relabel_max_flow_n)) (set! push_relabel_max_flow_i 0) (while (< push_relabel_max_flow_i push_relabel_max_flow_n) (do (set! push_relabel_max_flow_bandwidth (nth (nth push_relabel_max_flow_g push_relabel_max_flow_source_index) push_relabel_max_flow_i)) (set! push_relabel_max_flow_preflow (assoc-in push_relabel_max_flow_preflow [push_relabel_max_flow_source_index push_relabel_max_flow_i] (+ (nth (nth push_relabel_max_flow_preflow push_relabel_max_flow_source_index) push_relabel_max_flow_i) push_relabel_max_flow_bandwidth))) (set! push_relabel_max_flow_preflow (assoc-in push_relabel_max_flow_preflow [push_relabel_max_flow_i push_relabel_max_flow_source_index] (- (nth (nth push_relabel_max_flow_preflow push_relabel_max_flow_i) push_relabel_max_flow_source_index) push_relabel_max_flow_bandwidth))) (set! push_relabel_max_flow_excesses (assoc push_relabel_max_flow_excesses push_relabel_max_flow_i (+ (nth push_relabel_max_flow_excesses push_relabel_max_flow_i) push_relabel_max_flow_bandwidth))) (set! push_relabel_max_flow_i (+ push_relabel_max_flow_i 1)))) (set! push_relabel_max_flow_vertices_list []) (set! push_relabel_max_flow_i 0) (while (< push_relabel_max_flow_i push_relabel_max_flow_n) (do (when (and (not= push_relabel_max_flow_i push_relabel_max_flow_source_index) (not= push_relabel_max_flow_i push_relabel_max_flow_sink_index)) (set! push_relabel_max_flow_vertices_list (conj push_relabel_max_flow_vertices_list push_relabel_max_flow_i))) (set! push_relabel_max_flow_i (+ push_relabel_max_flow_i 1)))) (set! push_relabel_max_flow_idx 0) (loop [while_flag_1 true] (when (and while_flag_1 (< push_relabel_max_flow_idx (count push_relabel_max_flow_vertices_list))) (do (set! push_relabel_max_flow_v (nth push_relabel_max_flow_vertices_list push_relabel_max_flow_idx)) (set! push_relabel_max_flow_prev_height (nth push_relabel_max_flow_heights push_relabel_max_flow_v)) (loop [while_flag_2 true] (when (and while_flag_2 (> (nth push_relabel_max_flow_excesses push_relabel_max_flow_v) 0)) (do (set! push_relabel_max_flow_nb 0) (while (< push_relabel_max_flow_nb push_relabel_max_flow_n) (do (when (and (> (- (nth (nth push_relabel_max_flow_g push_relabel_max_flow_v) push_relabel_max_flow_nb) (nth (nth push_relabel_max_flow_preflow push_relabel_max_flow_v) push_relabel_max_flow_nb)) 0) (> (nth push_relabel_max_flow_heights push_relabel_max_flow_v) (nth push_relabel_max_flow_heights push_relabel_max_flow_nb))) (do (set! push_relabel_max_flow_delta (nth push_relabel_max_flow_excesses push_relabel_max_flow_v)) (set! push_relabel_max_flow_capacity (- (nth (nth push_relabel_max_flow_g push_relabel_max_flow_v) push_relabel_max_flow_nb) (nth (nth push_relabel_max_flow_preflow push_relabel_max_flow_v) push_relabel_max_flow_nb))) (when (> push_relabel_max_flow_delta push_relabel_max_flow_capacity) (set! push_relabel_max_flow_delta push_relabel_max_flow_capacity)) (set! push_relabel_max_flow_preflow (assoc-in push_relabel_max_flow_preflow [push_relabel_max_flow_v push_relabel_max_flow_nb] (+ (nth (nth push_relabel_max_flow_preflow push_relabel_max_flow_v) push_relabel_max_flow_nb) push_relabel_max_flow_delta))) (set! push_relabel_max_flow_preflow (assoc-in push_relabel_max_flow_preflow [push_relabel_max_flow_nb push_relabel_max_flow_v] (- (nth (nth push_relabel_max_flow_preflow push_relabel_max_flow_nb) push_relabel_max_flow_v) push_relabel_max_flow_delta))) (set! push_relabel_max_flow_excesses (assoc push_relabel_max_flow_excesses push_relabel_max_flow_v (- (nth push_relabel_max_flow_excesses push_relabel_max_flow_v) push_relabel_max_flow_delta))) (set! push_relabel_max_flow_excesses (assoc push_relabel_max_flow_excesses push_relabel_max_flow_nb (+ (nth push_relabel_max_flow_excesses push_relabel_max_flow_nb) push_relabel_max_flow_delta))))) (set! push_relabel_max_flow_nb (+ push_relabel_max_flow_nb 1)))) (set! push_relabel_max_flow_min_height (- 1)) (set! push_relabel_max_flow_nb 0) (while (< push_relabel_max_flow_nb push_relabel_max_flow_n) (do (when (> (- (nth (nth push_relabel_max_flow_g push_relabel_max_flow_v) push_relabel_max_flow_nb) (nth (nth push_relabel_max_flow_preflow push_relabel_max_flow_v) push_relabel_max_flow_nb)) 0) (when (or (= push_relabel_max_flow_min_height (- 1)) (< (nth push_relabel_max_flow_heights push_relabel_max_flow_nb) push_relabel_max_flow_min_height)) (set! push_relabel_max_flow_min_height (nth push_relabel_max_flow_heights push_relabel_max_flow_nb)))) (set! push_relabel_max_flow_nb (+ push_relabel_max_flow_nb 1)))) (if (not= push_relabel_max_flow_min_height (- 1)) (do (set! push_relabel_max_flow_heights (assoc push_relabel_max_flow_heights push_relabel_max_flow_v (+ push_relabel_max_flow_min_height 1))) (recur while_flag_2)) (recur false))))) (if (> (nth push_relabel_max_flow_heights push_relabel_max_flow_v) push_relabel_max_flow_prev_height) (do (set! push_relabel_max_flow_vertex (nth push_relabel_max_flow_vertices_list push_relabel_max_flow_idx)) (set! push_relabel_max_flow_j push_relabel_max_flow_idx) (while (> push_relabel_max_flow_j 0) (do (set! push_relabel_max_flow_vertices_list (assoc push_relabel_max_flow_vertices_list push_relabel_max_flow_j (nth push_relabel_max_flow_vertices_list (- push_relabel_max_flow_j 1)))) (set! push_relabel_max_flow_j (- push_relabel_max_flow_j 1)))) (set! push_relabel_max_flow_vertices_list (assoc push_relabel_max_flow_vertices_list 0 push_relabel_max_flow_vertex)) (set! push_relabel_max_flow_idx 0)) (set! push_relabel_max_flow_idx (+ push_relabel_max_flow_idx 1))) (cond :else (recur while_flag_1))))) (set! push_relabel_max_flow_flow 0) (set! push_relabel_max_flow_i 0) (while (< push_relabel_max_flow_i push_relabel_max_flow_n) (do (set! push_relabel_max_flow_flow (+ push_relabel_max_flow_flow (nth (nth push_relabel_max_flow_preflow push_relabel_max_flow_source_index) push_relabel_max_flow_i))) (set! push_relabel_max_flow_i (+ push_relabel_max_flow_i 1)))) (when (< push_relabel_max_flow_flow 0) (set! push_relabel_max_flow_flow (- push_relabel_max_flow_flow))) (throw (ex-info "return" {:v push_relabel_max_flow_flow}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
+
+(def ^:dynamic main_graph nil)
+
+(def ^:dynamic main_sources nil)
+
+(def ^:dynamic main_sinks nil)
+
+(def ^:dynamic main_result nil)
+
+(defn -main []
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (alter-var-root (var main_graph) (constantly [[0 7 0 0] [0 0 6 0] [0 0 0 8] [9 0 0 0]]))
+      (alter-var-root (var main_sources) (constantly [0]))
+      (alter-var-root (var main_sinks) (constantly [3]))
+      (alter-var-root (var main_result) (constantly (push_relabel_max_flow main_graph main_sources main_sinks)))
+      (println (str "maximum flow is " (str main_result)))
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
+
+(-main)

--- a/tests/algorithms/x/Clojure/graphs/edmonds_karp_multiple_source_and_sink.error
+++ b/tests/algorithms/x/Clojure/graphs/edmonds_karp_multiple_source_and_sink.error
@@ -1,8 +1,0 @@
-parse: error[P999]: /workspace/mochi/tests/github/TheAlgorithms/Mochi/graphs/edmonds_karp_multiple_source_and_sink.mochi:152:28: unexpected token "-" (expected PostfixExpr)
-  --> /workspace/mochi/tests/github/TheAlgorithms/Mochi/graphs/edmonds_karp_multiple_source_and_sink.mochi:152:28
-
-152 |           if min_height == -1 || heights[nb] < min_height {
-    |                            ^
-
-help:
-  Parse error occurred. Check syntax near this location.

--- a/tests/algorithms/x/Clojure/graphs/edmonds_karp_multiple_source_and_sink.out
+++ b/tests/algorithms/x/Clojure/graphs/edmonds_karp_multiple_source_and_sink.out
@@ -1,0 +1,1 @@
+maximum flow is 6

--- a/transpiler/x/clj/ALGORITHMS.md
+++ b/transpiler/x/clj/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated Clojure code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Clojure`.
-Last updated: 2025-08-16 11:56 GMT+7
+Last updated: 2025-08-16 12:20 GMT+7
 
-## Algorithms Golden Test Checklist (784/1077)
+## Algorithms Golden Test Checklist (785/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 50.25ms | 19.66MB |
@@ -428,7 +428,7 @@ Last updated: 2025-08-16 11:56 GMT+7
 | 419 | graphs/dijkstra_binary_grid | ✓ | 105.985ms | 22.07MB |
 | 420 | graphs/dinic | ✓ | 130.08ms | 26.16MB |
 | 421 | graphs/directed_and_undirected_weighted_graph | ✓ | 98.558ms | 17.89MB |
-| 422 | graphs/edmonds_karp_multiple_source_and_sink | error |  |  |
+| 422 | graphs/edmonds_karp_multiple_source_and_sink | ✓ | 41.046ms | 25.84MB |
 | 423 | graphs/eulerian_path_and_circuit_for_undirected_graph | ✓ | 51.653ms | 21.06MB |
 | 424 | graphs/even_tree | ✓ | 41.42ms | 20.93MB |
 | 425 | graphs/finding_bridges | ✓ | 97.715ms | 21.08MB |

--- a/transpiler/x/clj/README.md
+++ b/transpiler/x/clj/README.md
@@ -109,4 +109,4 @@ Compiled programs: 102/105
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
-Last updated: 2025-08-15 15:17 +0700
+Last updated: 2025-08-16 12:13 +0700

--- a/transpiler/x/clj/TASKS.md
+++ b/transpiler/x/clj/TASKS.md
@@ -1,3 +1,15 @@
+## Progress (2025-08-16 12:13 +0700)
+- clj: map exp to Math/exp
+- Regenerated golden files - 102/105 vm valid programs passing
+
+## Progress (2025-08-16 12:13 +0700)
+- clj: map exp to Math/exp
+- Regenerated golden files - 102/105 vm valid programs passing
+
+## Progress (2025-08-16 12:13 +0700)
+- clj: map exp to Math/exp
+- Regenerated golden files - 102/105 vm valid programs passing
+
 ## Progress (2025-08-15 15:17 +0700)
 - lua: update algorithm outputs
 - Regenerated golden files - 102/105 vm valid programs passing

--- a/transpiler/x/clj/transpiler.go
+++ b/transpiler/x/clj/transpiler.go
@@ -1700,11 +1700,15 @@ func applyBinOp(op string, left, right Node) Node {
 		if isStringNode(left) || isStringNode(right) {
 			return &List{Elems: []Node{Symbol("str"), left, right}}
 		}
-		if isNumberNode(left) || isNumberNode(right) {
-			// use + which supports arbitrary precision integers
-			return &List{Elems: []Node{Symbol("+"), left, right}}
-		}
-		return &List{Elems: []Node{Symbol("str"), left, right}}
+		// Default to numeric addition. Even if we can't determine the
+		// exact types of both operands (for example, complex nested
+		// expressions like nth on vectors), the Mochi type checker
+		// guarantees that `+` is only applied to numeric values unless
+		// one side is a string or vector as handled above.  Fallback to
+		// `+` avoids accidentally coercing numbers to strings which was
+		// previously causing runtime ClassCastException errors when
+		// numeric expressions were concatenated via `str`.
+		return &List{Elems: []Node{Symbol("+"), left, right}}
 	case "union":
 		setFn := func(x Node) Node { return &List{Elems: []Node{Symbol("set"), x}} }
 		u := &List{Elems: []Node{Symbol("clojure.set/union"), setFn(left), setFn(right)}}


### PR DESCRIPTION
## Summary
- ensure Clojure transpiler uses numeric `+` by default when operands aren't strings or vectors
- regenerate edmonds_karp_multiple_source_and_sink algorithm output and benchmarks
- update algorithm progress docs

## Testing
- `MOCHI_ALG_INDEX=422 go test ./transpiler/x/clj -run TestClojureTranspiler_Algorithms_Golden -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68a0136f9b84832093ea976436f8781e