### PR TITLE
docs: add v0.10.67 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # 📦 CHANGELOG.md
 
+## [0.10.67] – 2025-08-16T10:44:34+00:00
+
+### Added
+
+* Scheme and TypeScript transpilers gain CSV load support.
+* Go transpiler reads files and adds `pow_int` and `nth_root` helpers.
+* Lua ships a Chebyshev distance algorithm; Kotlin adds Apriori and simplex implementations.
+
+### Changed
+
+* Racket defaults to safe indexing and sanitizes numeric operations.
+* Float formatting and numeric casts refined across languages.
+* Algorithm and benchmark outputs refreshed throughout the ecosystem.
+
+### Fixed
+
+* Swift resolves scoping, panic handling, array indexing, and substring issues.
+* For-loop scoping and parameter aliasing corrected across transpilers.
+* Python and Ruby improve built-in handling and string formatting.
+
 ## [0.10.66] – 2025-08-14T10:19:34+00:00
 
 ### Added

--- a/releases/v0.10.67.md
+++ b/releases/v0.10.67.md
@@ -1,0 +1,22 @@
+# Aug 2025 (v0.10.67)
+
+Released on Sat Aug 16 10:44:34 2025 +0000.
+
+Mochi v0.10.67 improves cross-language transpilers and refreshes algorithm outputs.
+
+## Transpilers
+
+- Zig handles field aliases and float casts.
+- Scheme transpiler adds CSV load and tolerant equality.
+- Swift fixes if scoping, panic handling, and safe substring usage.
+- Java refines nested list appends and floor division.
+- Go transpiler reads files and supports `pow_int` and `nth_root`.
+- Kotlin adds Apriori and simplex algorithms with better type tracking.
+- Lua introduces the Chebyshev distance algorithm.
+- C++ resets helper flags and improves parameter passing.
+
+## Algorithms
+
+- Expanded algorithm coverage for Kotlin, Pascal, and Rust.
+- Refreshed algorithm outputs across C, Erlang, Python, Ruby, and more.
+- Lua and others add new mathematical and graph algorithms.


### PR DESCRIPTION
## Summary
- document Mochi v0.10.67 release with a new changelog entry
- add detailed release notes covering transpiler improvements and algorithm updates

## Testing
- `npm test` *(fails: Missing script "test")*
- `go test ./... --vet=off -v`


------
https://chatgpt.com/codex/tasks/task_e_68a0614110a48320bca2f8c06ad5452c