### PR TITLE
Update PHP algorithm benchmarks

### DIFF
--- a/tests/algorithms/x/PHP/machine_learning/xgboost_classifier.bench
+++ b/tests/algorithms/x/PHP/machine_learning/xgboost_classifier.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 126,
+  "duration_us": 175,
   "memory_bytes": 38024,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/machine_learning/xgboost_regressor.bench
+++ b/tests/algorithms/x/PHP/machine_learning/xgboost_regressor.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 98,
+  "duration_us": 144,
   "memory_bytes": 41896,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/abs.bench
+++ b/tests/algorithms/x/PHP/maths/abs.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 86,
+  "duration_us": 121,
   "memory_bytes": 38264,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/addition_without_arithmetic.bench
+++ b/tests/algorithms/x/PHP/maths/addition_without_arithmetic.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 358,
+  "duration_us": 361,
   "memory_bytes": 37168,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/aliquot_sum.bench
+++ b/tests/algorithms/x/PHP/maths/aliquot_sum.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 91,
+  "duration_us": 120,
   "memory_bytes": 36752,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/allocation_number.bench
+++ b/tests/algorithms/x/PHP/maths/allocation_number.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 102,
+  "duration_us": 131,
   "memory_bytes": 40472,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/arc_length.bench
+++ b/tests/algorithms/x/PHP/maths/arc_length.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 43,
+  "duration_us": 83,
   "memory_bytes": 39672,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/area.bench
+++ b/tests/algorithms/x/PHP/maths/area.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 83,
+  "duration_us": 123,
   "memory_bytes": 94928,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/area_under_curve.bench
+++ b/tests/algorithms/x/PHP/maths/area_under_curve.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 8967,
+  "duration_us": 12760,
   "memory_bytes": 39904,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/average_absolute_deviation.bench
+++ b/tests/algorithms/x/PHP/maths/average_absolute_deviation.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 49,
+  "duration_us": 66,
   "memory_bytes": 40264,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/average_mean.bench
+++ b/tests/algorithms/x/PHP/maths/average_mean.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 58,
+  "duration_us": 145,
   "memory_bytes": 39872,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/average_median.bench
+++ b/tests/algorithms/x/PHP/maths/average_median.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 77,
+  "duration_us": 194,
   "memory_bytes": 40336,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/average_mode.bench
+++ b/tests/algorithms/x/PHP/maths/average_mode.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 142,
+  "duration_us": 237,
   "memory_bytes": 72000,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/bailey_borwein_plouffe.bench
+++ b/tests/algorithms/x/PHP/maths/bailey_borwein_plouffe.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 1812763,
+  "duration_us": 3126549,
   "memory_bytes": 41280,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/basic_maths.bench
+++ b/tests/algorithms/x/PHP/maths/basic_maths.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 175,
+  "duration_us": 176,
   "memory_bytes": 74640,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/binary_exponentiation.bench
+++ b/tests/algorithms/x/PHP/maths/binary_exponentiation.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 97,
+  "duration_us": 69,
   "memory_bytes": 36984,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/binary_multiplication.bench
+++ b/tests/algorithms/x/PHP/maths/binary_multiplication.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 45,
+  "duration_us": 68,
   "memory_bytes": 36056,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/binomial_coefficient.bench
+++ b/tests/algorithms/x/PHP/maths/binomial_coefficient.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 71,
+  "duration_us": 125,
   "memory_bytes": 40640,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/ceil.bench
+++ b/tests/algorithms/x/PHP/maths/ceil.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 44,
+  "duration_us": 60,
   "memory_bytes": 39968,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/chebyshev_distance.bench
+++ b/tests/algorithms/x/PHP/maths/chebyshev_distance.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 97,
-  "memory_bytes": 41528,
+  "duration_us": 80,
+  "memory_bytes": 39352,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/chebyshev_distance.php
+++ b/tests/algorithms/x/PHP/maths/chebyshev_distance.php
@@ -15,41 +15,6 @@ function _now() {
     }
     return hrtime(true);
 }
-function _iadd($a, $b) {
-    if (function_exists('bcadd')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcadd($sa, $sb, 0);
-    }
-    return $a + $b;
-}
-function _isub($a, $b) {
-    if (function_exists('bcsub')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcsub($sa, $sb, 0);
-    }
-    return $a - $b;
-}
-function _imul($a, $b) {
-    if (function_exists('bcmul')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcmul($sa, $sb, 0);
-    }
-    return $a * $b;
-}
-function _idiv($a, $b) {
-    return _intdiv($a, $b);
-}
-function _imod($a, $b) {
-    if (function_exists('bcmod')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return intval(bcmod($sa, $sb));
-    }
-    return $a % $b;
-}
 function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
@@ -74,7 +39,7 @@ $__start = _now();
   if ($diff > $max_diff) {
   $max_diff = $diff;
 }
-  $i = _iadd($i, 1);
+  $i = $i + 1;
 };
   return $max_diff;
 };

--- a/tests/algorithms/x/PHP/maths/check_polygon.bench
+++ b/tests/algorithms/x/PHP/maths/check_polygon.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 150,
-  "memory_bytes": 42416,
+  "duration_us": 142,
+  "memory_bytes": 40208,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/check_polygon.php
+++ b/tests/algorithms/x/PHP/maths/check_polygon.php
@@ -31,41 +31,6 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-function _iadd($a, $b) {
-    if (function_exists('bcadd')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcadd($sa, $sb, 0);
-    }
-    return $a + $b;
-}
-function _isub($a, $b) {
-    if (function_exists('bcsub')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcsub($sa, $sb, 0);
-    }
-    return $a - $b;
-}
-function _imul($a, $b) {
-    if (function_exists('bcmul')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcmul($sa, $sb, 0);
-    }
-    return $a * $b;
-}
-function _idiv($a, $b) {
-    return _intdiv($a, $b);
-}
-function _imod($a, $b) {
-    if (function_exists('bcmod')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return intval(bcmod($sa, $sb));
-    }
-    return $a % $b;
-}
 function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
@@ -82,7 +47,7 @@ $__start = _now();
   if ($nums[$i] <= 0.0) {
   _panic('All values must be greater than 0');
 }
-  $i = _iadd($i, 1);
+  $i = $i + 1;
 };
   $total = 0.0;
   $max_side = 0.0;
@@ -93,7 +58,7 @@ $__start = _now();
   if ($v > $max_side) {
   $max_side = $v;
 }
-  $i = _iadd($i, 1);
+  $i = $i + 1;
 };
   return $max_side < ($total - $max_side);
 };

--- a/tests/algorithms/x/PHP/maths/chinese_remainder_theorem.bench
+++ b/tests/algorithms/x/PHP/maths/chinese_remainder_theorem.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 187,
-  "memory_bytes": 73352,
+  "duration_us": 142,
+  "memory_bytes": 37672,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/chinese_remainder_theorem.php
+++ b/tests/algorithms/x/PHP/maths/chinese_remainder_theorem.php
@@ -42,41 +42,6 @@ function _intdiv($a, $b) {
     }
     return intdiv($a, $b);
 }
-function _iadd($a, $b) {
-    if (function_exists('bcadd')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcadd($sa, $sb, 0);
-    }
-    return $a + $b;
-}
-function _isub($a, $b) {
-    if (function_exists('bcsub')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcsub($sa, $sb, 0);
-    }
-    return $a - $b;
-}
-function _imul($a, $b) {
-    if (function_exists('bcmul')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcmul($sa, $sb, 0);
-    }
-    return $a * $b;
-}
-function _idiv($a, $b) {
-    return _intdiv($a, $b);
-}
-function _imod($a, $b) {
-    if (function_exists('bcmod')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return intval(bcmod($sa, $sb));
-    }
-    return $a % $b;
-}
 $__start_mem = memory_get_usage();
 $__start = _now();
   function extended_euclid($a, $b) {
@@ -84,25 +49,25 @@ $__start = _now();
   if ($b == 0) {
   return ['x' => 1, 'y' => 0];
 }
-  $res = extended_euclid($b, _imod($a, $b));
+  $res = extended_euclid($b, $a % $b);
   $k = _intdiv($a, $b);
-  return ['x' => $res['y'], 'y' => _isub($res['x'], _imul($k, $res['y']))];
+  return ['x' => $res['y'], 'y' => $res['x'] - $k * $res['y']];
 };
   function chinese_remainder_theorem($n1, $r1, $n2, $r2) {
   global $e1, $e2;
   $res = extended_euclid($n1, $n2);
   $x = $res['x'];
   $y = $res['y'];
-  $m = _imul($n1, $n2);
-  $n = _iadd(_imul(_imul($r2, $x), $n1), _imul(_imul($r1, $y), $n2));
-  return _imod((_iadd((_imod($n, $m)), $m)), $m);
+  $m = $n1 * $n2;
+  $n = $r2 * $x * $n1 + $r1 * $y * $n2;
+  return (($n % $m) + $m) % $m;
 };
   function invert_modulo($a, $n) {
   global $e1, $e2;
   $res = extended_euclid($a, $n);
   $b = $res['x'];
   if ($b < 0) {
-  $b = _imod((_iadd(_imod($b, $n), $n)), $n);
+  $b = ($b % $n + $n) % $n;
 }
   return $b;
 };
@@ -110,9 +75,9 @@ $__start = _now();
   global $e1, $e2;
   $x = invert_modulo($n1, $n2);
   $y = invert_modulo($n2, $n1);
-  $m = _imul($n1, $n2);
-  $n = _iadd(_imul(_imul($r2, $x), $n1), _imul(_imul($r1, $y), $n2));
-  return _imod((_iadd((_imod($n, $m)), $m)), $m);
+  $m = $n1 * $n2;
+  $n = $r2 * $x * $n1 + $r1 * $y * $n2;
+  return (($n % $m) + $m) % $m;
 };
   $e1 = extended_euclid(10, 6);
   echo rtrim(_str($e1['x']) . ',' . _str($e1['y'])), PHP_EOL;

--- a/tests/algorithms/x/PHP/maths/chudnovsky_algorithm.bench
+++ b/tests/algorithms/x/PHP/maths/chudnovsky_algorithm.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 93,
-  "memory_bytes": 43824,
+  "duration_us": 58,
+  "memory_bytes": 41488,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/chudnovsky_algorithm.php
+++ b/tests/algorithms/x/PHP/maths/chudnovsky_algorithm.php
@@ -42,41 +42,6 @@ function _intdiv($a, $b) {
     }
     return intdiv($a, $b);
 }
-function _iadd($a, $b) {
-    if (function_exists('bcadd')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcadd($sa, $sb, 0);
-    }
-    return $a + $b;
-}
-function _isub($a, $b) {
-    if (function_exists('bcsub')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcsub($sa, $sb, 0);
-    }
-    return $a - $b;
-}
-function _imul($a, $b) {
-    if (function_exists('bcmul')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcmul($sa, $sb, 0);
-    }
-    return $a * $b;
-}
-function _idiv($a, $b) {
-    return _intdiv($a, $b);
-}
-function _imod($a, $b) {
-    if (function_exists('bcmod')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return intval(bcmod($sa, $sb));
-    }
-    return $a % $b;
-}
 function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
@@ -92,7 +57,7 @@ $__start = _now();
   $i = 0;
   while ($i < 20) {
   $guess = ($guess + $x / $guess) / 2.0;
-  $i = _iadd($i, 1);
+  $i = $i + 1;
 };
   return $guess;
 };
@@ -101,7 +66,7 @@ $__start = _now();
   $i = 2;
   while ($i <= $n) {
   $result = $result * (floatval($i));
-  $i = _iadd($i, 1);
+  $i = $i + 1;
 };
   return $result;
 };
@@ -109,15 +74,15 @@ $__start = _now();
   if ($n < 1) {
   _panic('Undefined for non-natural numbers');
 }
-  $iterations = _intdiv((_iadd($n, 13)), 14);
+  $iterations = _intdiv(($n + 13), 14);
   $constant_term = 426880.0 * sqrtApprox(10005.0);
   $exponential_term = 1.0;
   $linear_term = 13591409.0;
   $partial_sum = $linear_term;
   $k = 1;
   while ($k < $iterations) {
-  $k6 = _imul(6, $k);
-  $k3 = _imul(3, $k);
+  $k6 = 6 * $k;
+  $k3 = 3 * $k;
   $fact6k = factorial_float($k6);
   $fact3k = factorial_float($k3);
   $factk = factorial_float($k);
@@ -125,7 +90,7 @@ $__start = _now();
   $linear_term = $linear_term + 545140134.0;
   $exponential_term = $exponential_term * (-262537412640768000.0);
   $partial_sum = $partial_sum + $multinomial * $linear_term / $exponential_term;
-  $k = _iadd($k, 1);
+  $k = $k + 1;
 };
   return $constant_term / $partial_sum;
 };

--- a/tests/algorithms/x/PHP/maths/collatz_sequence.bench
+++ b/tests/algorithms/x/PHP/maths/collatz_sequence.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 151,
+  "duration_us": 218,
   "memory_bytes": 37784,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/combinations.bench
+++ b/tests/algorithms/x/PHP/maths/combinations.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 83,
-  "memory_bytes": 39424,
+  "duration_us": 70,
+  "memory_bytes": 37152,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/combinations.php
+++ b/tests/algorithms/x/PHP/maths/combinations.php
@@ -42,41 +42,6 @@ function _intdiv($a, $b) {
     }
     return intdiv($a, $b);
 }
-function _iadd($a, $b) {
-    if (function_exists('bcadd')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcadd($sa, $sb, 0);
-    }
-    return $a + $b;
-}
-function _isub($a, $b) {
-    if (function_exists('bcsub')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcsub($sa, $sb, 0);
-    }
-    return $a - $b;
-}
-function _imul($a, $b) {
-    if (function_exists('bcmul')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcmul($sa, $sb, 0);
-    }
-    return $a * $b;
-}
-function _idiv($a, $b) {
-    return _intdiv($a, $b);
-}
-function _imod($a, $b) {
-    if (function_exists('bcmod')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return intval(bcmod($sa, $sb));
-    }
-    return $a % $b;
-}
 function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
@@ -90,9 +55,9 @@ $__start = _now();
   $res = 1;
   $i = 0;
   while ($i < $k) {
-  $res = _imul($res, (_isub($n, $i)));
-  $res = _intdiv($res, (_iadd($i, 1)));
-  $i = _iadd($i, 1);
+  $res = $res * ($n - $i);
+  $res = _intdiv($res, ($i + 1));
+  $i = $i + 1;
 };
   return $res;
 };

--- a/tests/algorithms/x/PHP/maths/continued_fraction.bench
+++ b/tests/algorithms/x/PHP/maths/continued_fraction.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 137,
-  "memory_bytes": 41256,
+  "duration_us": 141,
+  "memory_bytes": 41304,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/continued_fraction.php
+++ b/tests/algorithms/x/PHP/maths/continued_fraction.php
@@ -36,6 +36,9 @@ function _append($arr, $x) {
     return $arr;
 }
 function _intdiv($a, $b) {
+    if ($b === 0 || $b === '0') {
+        throw new DivisionByZeroError();
+    }
     if (function_exists('bcdiv')) {
         $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));

--- a/tests/algorithms/x/PHP/maths/decimal_isolate.bench
+++ b/tests/algorithms/x/PHP/maths/decimal_isolate.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 88,
+  "duration_us": 70,
   "memory_bytes": 36800,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/decimal_to_fraction.bench
+++ b/tests/algorithms/x/PHP/maths/decimal_to_fraction.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 176,
-  "memory_bytes": 73240,
+  "duration_us": 181,
+  "memory_bytes": 73496,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/decimal_to_fraction.php
+++ b/tests/algorithms/x/PHP/maths/decimal_to_fraction.php
@@ -31,6 +31,10 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
 $__start_mem = memory_get_usage();
 $__start = _now();
   function pow10($n) {
@@ -60,11 +64,11 @@ $__start = _now();
 };
   function parse_decimal($s) {
   if (strlen($s) == 0) {
-  $panic('invalid number');
+  _panic('invalid number');
 }
   $idx = 0;
   $sign = 1;
-  $first = substr($s, 0, 1 - 0);
+  $first = substr($s, 0, 1);
   if ($first == '-') {
   $sign = -1;
   $idx = 1;
@@ -115,16 +119,16 @@ $__start = _now();
   $exp_str = $exp_str . $c;
   $idx = $idx + 1;
 } else {
-  $panic('invalid number');
+  _panic('invalid number');
 }
 };
   if (strlen($exp_str) == 0) {
-  $panic('invalid number');
+  _panic('invalid number');
 };
   $exp = $exp_sign * intval($exp_str);
 }
   if ($idx != strlen($s)) {
-  $panic('invalid number');
+  _panic('invalid number');
 }
   if (strlen($int_part) == 0) {
   $int_part = '0';
@@ -156,7 +160,7 @@ $__start = _now();
 };
   function assert_fraction($name, $fr, $num, $den) {
   if ($fr['numerator'] != $num || $fr['denominator'] != $den) {
-  $panic($name);
+  _panic($name);
 }
 };
   function test_decimal_to_fraction() {

--- a/tests/algorithms/x/PHP/maths/dodecahedron.bench
+++ b/tests/algorithms/x/PHP/maths/dodecahedron.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 100,
-  "memory_bytes": 37288,
+  "duration_us": 57,
+  "memory_bytes": 37896,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/dodecahedron.php
+++ b/tests/algorithms/x/PHP/maths/dodecahedron.php
@@ -15,6 +15,10 @@ function _now() {
     }
     return hrtime(true);
 }
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
 $__start_mem = memory_get_usage();
 $__start = _now();
   function sqrtApprox($x) {
@@ -37,7 +41,7 @@ $__start = _now();
 };
   function dodecahedron_surface_area($edge) {
   if ($edge <= 0) {
-  $panic('Length must be a positive.');
+  _panic('Length must be a positive.');
 }
   $term = sqrtApprox(25.0 + 10.0 * sqrtApprox(5.0));
   $e = floatval($edge);
@@ -45,7 +49,7 @@ $__start = _now();
 };
   function dodecahedron_volume($edge) {
   if ($edge <= 0) {
-  $panic('Length must be a positive.');
+  _panic('Length must be a positive.');
 }
   $term = (15.0 + 7.0 * sqrtApprox(5.0)) / 4.0;
   $e = floatval($edge);
@@ -53,16 +57,16 @@ $__start = _now();
 };
   function test_dodecahedron() {
   if (!approx_equal(dodecahedron_surface_area(5), 516.1432201766901, 0.0001)) {
-  $panic('surface area 5 failed');
+  _panic('surface area 5 failed');
 }
   if (!approx_equal(dodecahedron_surface_area(10), 2064.5728807067603, 0.0001)) {
-  $panic('surface area 10 failed');
+  _panic('surface area 10 failed');
 }
   if (!approx_equal(dodecahedron_volume(5), 957.8898700780791, 0.0001)) {
-  $panic('volume 5 failed');
+  _panic('volume 5 failed');
 }
   if (!approx_equal(dodecahedron_volume(10), 7663.118960624633, 0.0001)) {
-  $panic('volume 10 failed');
+  _panic('volume 10 failed');
 }
 };
   function main() {

--- a/tests/algorithms/x/PHP/maths/double_factorial.bench
+++ b/tests/algorithms/x/PHP/maths/double_factorial.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 52,
-  "memory_bytes": 39480,
+  "duration_us": 66,
+  "memory_bytes": 39928,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/double_factorial.php
+++ b/tests/algorithms/x/PHP/maths/double_factorial.php
@@ -15,11 +15,15 @@ function _now() {
     }
     return hrtime(true);
 }
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
 $__start_mem = memory_get_usage();
 $__start = _now();
   function double_factorial_recursive($n) {
   if ($n < 0) {
-  $panic('double_factorial_recursive() not defined for negative values');
+  _panic('double_factorial_recursive() not defined for negative values');
 }
   if ($n <= 1) {
   return 1;
@@ -28,7 +32,7 @@ $__start = _now();
 };
   function double_factorial_iterative($n) {
   if ($n < 0) {
-  $panic('double_factorial_iterative() not defined for negative values');
+  _panic('double_factorial_iterative() not defined for negative values');
 }
   $result = 1;
   $i = $n;
@@ -40,33 +44,33 @@ $__start = _now();
 };
   function test_double_factorial() {
   if (double_factorial_recursive(0) != 1) {
-  $panic('0!! recursive failed');
+  _panic('0!! recursive failed');
 }
   if (double_factorial_iterative(0) != 1) {
-  $panic('0!! iterative failed');
+  _panic('0!! iterative failed');
 }
   if (double_factorial_recursive(1) != 1) {
-  $panic('1!! recursive failed');
+  _panic('1!! recursive failed');
 }
   if (double_factorial_iterative(1) != 1) {
-  $panic('1!! iterative failed');
+  _panic('1!! iterative failed');
 }
   if (double_factorial_recursive(5) != 15) {
-  $panic('5!! recursive failed');
+  _panic('5!! recursive failed');
 }
   if (double_factorial_iterative(5) != 15) {
-  $panic('5!! iterative failed');
+  _panic('5!! iterative failed');
 }
   if (double_factorial_recursive(6) != 48) {
-  $panic('6!! recursive failed');
+  _panic('6!! recursive failed');
 }
   if (double_factorial_iterative(6) != 48) {
-  $panic('6!! iterative failed');
+  _panic('6!! iterative failed');
 }
   $n = 0;
   while ($n <= 10) {
   if (double_factorial_recursive($n) != double_factorial_iterative($n)) {
-  $panic('double factorial mismatch');
+  _panic('double factorial mismatch');
 }
   $n = $n + 1;
 };

--- a/tests/algorithms/x/PHP/maths/dual_number_automatic_differentiation.bench
+++ b/tests/algorithms/x/PHP/maths/dual_number_automatic_differentiation.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 196,
-  "memory_bytes": 75048,
+  "duration_us": 241,
+  "memory_bytes": 75336,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/dual_number_automatic_differentiation.php
+++ b/tests/algorithms/x/PHP/maths/dual_number_automatic_differentiation.php
@@ -16,6 +16,7 @@ function _now() {
     return hrtime(true);
 }
 function _len($x) {
+    if ($x === null) { return 0; }
     if (is_array($x)) { return count($x); }
     if (is_string($x)) { return strlen($x); }
     return strlen(strval($x));
@@ -23,6 +24,10 @@ function _len($x) {
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
+}
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
 }
 $__start_mem = memory_get_usage();
 $__start = _now();
@@ -129,7 +134,7 @@ $__start = _now();
 };
   function dual_pow($x, $n) {
   if ($n < 0) {
-  $panic('power must be a positive integer');
+  _panic('power must be a positive integer');
 }
   if ($n == 0) {
   return ['real' => 1.0, 'duals' => []];
@@ -165,28 +170,28 @@ $f1 = function($x) use (&$f1) {
   return dual_pow($x, 2);
 };
   if (differentiate($f1, 2.0, 2) != 2.0) {
-  $panic('f1 failed');
+  _panic('f1 failed');
 }
   $f2 = null;
 $f2 = function($x) use (&$f2, $f1) {
   return dual_mul(dual_pow($x, 2), dual_pow($x, 4));
 };
   if (differentiate($f2, 9.0, 2) != 196830.0) {
-  $panic('f2 failed');
+  _panic('f2 failed');
 }
   $f3 = null;
 $f3 = function($y) use (&$f3, $f1, $f2) {
   return dual_mul_real(dual_pow(dual_add_real($y, 3.0), 6), 0.5);
 };
   if (differentiate($f3, 3.5, 4) != 7605.0) {
-  $panic('f3 failed');
+  _panic('f3 failed');
 }
   $f4 = null;
 $f4 = function($y) use (&$f4, $f1, $f2, $f3) {
   return dual_pow($y, 2);
 };
   if (differentiate($f4, 4.0, 3) != 0.0) {
-  $panic('f4 failed');
+  _panic('f4 failed');
 }
 };
   function main() {

--- a/tests/algorithms/x/PHP/maths/entropy.bench
+++ b/tests/algorithms/x/PHP/maths/entropy.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 607,
+  "duration_us": 689,
   "memory_bytes": 38032,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/entropy.php
+++ b/tests/algorithms/x/PHP/maths/entropy.php
@@ -71,7 +71,7 @@ $__start = _now();
 } else {
   $single[$last] = 1;
 }
-  $first = substr($text, 0, 1 - 0);
+  $first = substr($text, 0, 1);
   $pair0 = ' ' . $first;
   $double[$pair0] = 1;
   $i = 0;

--- a/tests/algorithms/x/PHP/maths/euclidean_distance.bench
+++ b/tests/algorithms/x/PHP/maths/euclidean_distance.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 143,
+  "duration_us": 176,
   "memory_bytes": 35672,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/euler_method.bench
+++ b/tests/algorithms/x/PHP/maths/euler_method.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 634,
-  "memory_bytes": 38160,
+  "duration_us": 734,
+  "memory_bytes": 38288,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/euler_method.php
+++ b/tests/algorithms/x/PHP/maths/euler_method.php
@@ -19,6 +19,10 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
 $__start_mem = memory_get_usage();
 $__start = _now();
   function ceil_int($x) {
@@ -60,7 +64,7 @@ $f = function($x, $y) use ($f) {
   $ys = explicit_euler($f, 1.0, 0.0, 0.01, 5.0);
   $last = $ys[count($ys) - 1];
   if (abs_float($last - 144.77277243257308) > 0.001) {
-  $panic('explicit_euler failed');
+  _panic('explicit_euler failed');
 }
 };
   function main() {

--- a/tests/algorithms/x/PHP/maths/euler_modified.bench
+++ b/tests/algorithms/x/PHP/maths/euler_modified.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 175,
+  "duration_us": 150,
   "memory_bytes": 36928,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/eulers_totient.bench
+++ b/tests/algorithms/x/PHP/maths/eulers_totient.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 127,
-  "memory_bytes": 38664,
+  "duration_us": 162,
+  "memory_bytes": 38640,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/eulers_totient.php
+++ b/tests/algorithms/x/PHP/maths/eulers_totient.php
@@ -35,6 +35,10 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
 $__start_mem = memory_get_usage();
 $__start = _now();
   function totient($n) {
@@ -76,7 +80,7 @@ $__start = _now();
   $idx = 0;
   while ($idx < count($expected)) {
   if ($res[$idx] != $expected[$idx]) {
-  $panic('totient mismatch at ' . _str($idx));
+  _panic('totient mismatch at ' . _str($idx));
 }
   $idx = $idx + 1;
 };

--- a/tests/algorithms/x/PHP/maths/extended_euclidean_algorithm.bench
+++ b/tests/algorithms/x/PHP/maths/extended_euclidean_algorithm.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 138,
-  "memory_bytes": 38096,
+  "duration_us": 161,
+  "memory_bytes": 38464,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/extended_euclidean_algorithm.php
+++ b/tests/algorithms/x/PHP/maths/extended_euclidean_algorithm.php
@@ -32,12 +32,19 @@ function _str($x) {
     return strval($x);
 }
 function _intdiv($a, $b) {
+    if ($b === 0 || $b === '0') {
+        throw new DivisionByZeroError();
+    }
     if (function_exists('bcdiv')) {
         $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
         return intval(bcdiv($sa, $sb, 0));
     }
     return intdiv($a, $b);
+}
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
 }
 $__start_mem = memory_get_usage();
 $__start = _now();
@@ -83,31 +90,31 @@ $__start = _now();
   function test_extended_euclidean_algorithm() {
   $r1 = extended_euclidean_algorithm(1, 24);
   if (($r1['x'] != 1) || ($r1['y'] != 0)) {
-  $panic('test1 failed');
+  _panic('test1 failed');
 }
   $r2 = extended_euclidean_algorithm(8, 14);
   if (($r2['x'] != 2) || ($r2['y'] != (-1))) {
-  $panic('test2 failed');
+  _panic('test2 failed');
 }
   $r3 = extended_euclidean_algorithm(240, 46);
   if (($r3['x'] != (-9)) || ($r3['y'] != 47)) {
-  $panic('test3 failed');
+  _panic('test3 failed');
 }
   $r4 = extended_euclidean_algorithm(1, -4);
   if (($r4['x'] != 1) || ($r4['y'] != 0)) {
-  $panic('test4 failed');
+  _panic('test4 failed');
 }
   $r5 = extended_euclidean_algorithm(-2, -4);
   if (($r5['x'] != (-1)) || ($r5['y'] != 0)) {
-  $panic('test5 failed');
+  _panic('test5 failed');
 }
   $r6 = extended_euclidean_algorithm(0, -4);
   if (($r6['x'] != 0) || ($r6['y'] != (-1))) {
-  $panic('test6 failed');
+  _panic('test6 failed');
 }
   $r7 = extended_euclidean_algorithm(2, 0);
   if (($r7['x'] != 1) || ($r7['y'] != 0)) {
-  $panic('test7 failed');
+  _panic('test7 failed');
 }
 };
   function main() {

--- a/tests/algorithms/x/PHP/maths/factorial.bench
+++ b/tests/algorithms/x/PHP/maths/factorial.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 158,
-  "memory_bytes": 36688,
+  "duration_us": 59,
+  "memory_bytes": 36912,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/factorial.php
+++ b/tests/algorithms/x/PHP/maths/factorial.php
@@ -15,11 +15,15 @@ function _now() {
     }
     return hrtime(true);
 }
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
 $__start_mem = memory_get_usage();
 $__start = _now();
   function factorial($n) {
   if ($n < 0) {
-  $panic('factorial() not defined for negative values');
+  _panic('factorial() not defined for negative values');
 }
   $value = 1;
   $i = 1;
@@ -31,7 +35,7 @@ $__start = _now();
 };
   function factorial_recursive($n) {
   if ($n < 0) {
-  $panic('factorial() not defined for negative values');
+  _panic('factorial() not defined for negative values');
 }
   if ($n <= 1) {
   return 1;
@@ -42,12 +46,12 @@ $__start = _now();
   $i = 0;
   while ($i <= 10) {
   if (factorial($i) != factorial_recursive($i)) {
-  $panic('mismatch between factorial and factorial_recursive');
+  _panic('mismatch between factorial and factorial_recursive');
 }
   $i = $i + 1;
 };
   if (factorial(6) != 720) {
-  $panic('factorial(6) should be 720');
+  _panic('factorial(6) should be 720');
 }
 };
   function main() {

--- a/tests/algorithms/x/PHP/maths/factors.bench
+++ b/tests/algorithms/x/PHP/maths/factors.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 195,
-  "memory_bytes": 37832,
+  "duration_us": 220,
+  "memory_bytes": 38424,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/factors.php
+++ b/tests/algorithms/x/PHP/maths/factors.php
@@ -36,12 +36,19 @@ function _append($arr, $x) {
     return $arr;
 }
 function _intdiv($a, $b) {
+    if ($b === 0 || $b === '0') {
+        throw new DivisionByZeroError();
+    }
     if (function_exists('bcdiv')) {
         $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
         return intval(bcdiv($sa, $sb, 0));
     }
     return intdiv($a, $b);
+}
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
 }
 $__start_mem = memory_get_usage();
 $__start = _now();
@@ -77,16 +84,16 @@ $__start = _now();
 };
   function run_tests() {
   if (factors_of_a_number(1) != [1]) {
-  $panic('case1 failed');
+  _panic('case1 failed');
 }
   if (factors_of_a_number(5) != [1, 5]) {
-  $panic('case2 failed');
+  _panic('case2 failed');
 }
   if (factors_of_a_number(24) != [1, 2, 3, 4, 6, 8, 12, 24]) {
-  $panic('case3 failed');
+  _panic('case3 failed');
 }
   if (factors_of_a_number(-24) != []) {
-  $panic('case4 failed');
+  _panic('case4 failed');
 }
 };
   function main() {

--- a/tests/algorithms/x/PHP/maths/fast_inverse_sqrt.bench
+++ b/tests/algorithms/x/PHP/maths/fast_inverse_sqrt.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 951,
-  "memory_bytes": 72000,
+  "duration_us": 964,
+  "memory_bytes": 72944,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/fast_inverse_sqrt.php
+++ b/tests/algorithms/x/PHP/maths/fast_inverse_sqrt.php
@@ -32,12 +32,19 @@ function _str($x) {
     return strval($x);
 }
 function _intdiv($a, $b) {
+    if ($b === 0 || $b === '0') {
+        throw new DivisionByZeroError();
+    }
     if (function_exists('bcdiv')) {
         $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
         return intval(bcdiv($sa, $sb, 0));
     }
     return intdiv($a, $b);
+}
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
 }
 $__start_mem = memory_get_usage();
 $__start = _now();
@@ -149,7 +156,7 @@ $__start = _now();
 };
   function fast_inverse_sqrt($number) {
   if ($number <= 0.0) {
-  $panic('Input must be a positive number.');
+  _panic('Input must be a positive number.');
 }
   $i = float_to_bits($number);
   $magic = 1597463007;
@@ -160,20 +167,20 @@ $__start = _now();
 };
   function test_fast_inverse_sqrt() {
   if (absf(fast_inverse_sqrt(10.0) - 0.3156857923527257) > 0.0001) {
-  $panic('fast_inverse_sqrt(10) failed');
+  _panic('fast_inverse_sqrt(10) failed');
 }
   if (absf(fast_inverse_sqrt(4.0) - 0.49915357479239103) > 0.0001) {
-  $panic('fast_inverse_sqrt(4) failed');
+  _panic('fast_inverse_sqrt(4) failed');
 }
   if (absf(fast_inverse_sqrt(4.1) - 0.4932849504615651) > 0.0001) {
-  $panic('fast_inverse_sqrt(4.1) failed');
+  _panic('fast_inverse_sqrt(4.1) failed');
 }
   $i = 50;
   while ($i < 60) {
   $y = fast_inverse_sqrt(floatval($i));
   $actual = 1.0 / sqrtApprox(floatval($i));
   if (!is_close($y, $actual, 0.00132)) {
-  $panic('relative error too high');
+  _panic('relative error too high');
 }
   $i = $i + 1;
 };

--- a/tests/algorithms/x/PHP/maths/fermat_little_theorem.bench
+++ b/tests/algorithms/x/PHP/maths/fermat_little_theorem.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 133,
-  "memory_bytes": 40072,
+  "duration_us": 186,
+  "memory_bytes": 40120,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/fermat_little_theorem.php
+++ b/tests/algorithms/x/PHP/maths/fermat_little_theorem.php
@@ -16,6 +16,9 @@ function _now() {
     return hrtime(true);
 }
 function _intdiv($a, $b) {
+    if ($b === 0 || $b === '0') {
+        throw new DivisionByZeroError();
+    }
     if (function_exists('bcdiv')) {
         $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
@@ -26,7 +29,7 @@ function _intdiv($a, $b) {
 $__start_mem = memory_get_usage();
 $__start = _now();
   function binary_exponentiation($a, $n, $mod) {
-  global $p, $left, $right_fast, $right_naive;
+  global $left, $p, $right_fast, $right_naive;
   if ($n == 0) {
   return 1;
 }
@@ -37,7 +40,7 @@ $__start = _now();
   return ($b * $b) % $mod;
 };
   function naive_exponent_mod($a, $n, $mod) {
-  global $p, $b, $left, $right_fast, $right_naive;
+  global $b, $left, $p, $right_fast, $right_naive;
   $result = 1;
   $i = 0;
   while ($i < $n) {
@@ -47,7 +50,7 @@ $__start = _now();
   return $result;
 };
   function print_bool($b) {
-  global $p, $a, $left, $right_fast, $right_naive;
+  global $a, $left, $p, $right_fast, $right_naive;
   if ($b) {
   echo rtrim((true ? 'true' : 'false')), PHP_EOL;
 } else {

--- a/tests/algorithms/x/PHP/maths/fibonacci.bench
+++ b/tests/algorithms/x/PHP/maths/fibonacci.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 418,
-  "memory_bytes": 80160,
+  "duration_us": 275,
+  "memory_bytes": 77280,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/fibonacci.php
+++ b/tests/algorithms/x/PHP/maths/fibonacci.php
@@ -46,41 +46,6 @@ function _intdiv($a, $b) {
     }
     return intdiv($a, $b);
 }
-function _iadd($a, $b) {
-    if (function_exists('bcadd')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcadd($sa, $sb, 0);
-    }
-    return $a + $b;
-}
-function _isub($a, $b) {
-    if (function_exists('bcsub')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcsub($sa, $sb, 0);
-    }
-    return $a - $b;
-}
-function _imul($a, $b) {
-    if (function_exists('bcmul')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcmul($sa, $sb, 0);
-    }
-    return $a * $b;
-}
-function _idiv($a, $b) {
-    return _intdiv($a, $b);
-}
-function _imod($a, $b) {
-    if (function_exists('bcmod')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return intval(bcmod($sa, $sb));
-    }
-    return $a % $b;
-}
 function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
@@ -96,7 +61,7 @@ $__start = _now();
   $i = 0;
   while ($i < 10) {
   $guess = ($guess + $x / $guess) / 2.0;
-  $i = _iadd($i, 1);
+  $i = $i + 1;
 };
   return $guess;
 };
@@ -106,7 +71,7 @@ $__start = _now();
   $i = 0;
   while ($i < $n) {
   $res = $res * $x;
-  $i = _iadd($i, 1);
+  $i = $i + 1;
 };
   return $res;
 };
@@ -128,8 +93,8 @@ $__start = _now();
   $fib = [0, 1];
   $i = 2;
   while ($i <= $n) {
-  $fib = _append($fib, _iadd($fib[_isub($i, 1)], $fib[_isub($i, 2)]));
-  $i = _iadd($i, 1);
+  $fib = _append($fib, $fib[$i - 1] + $fib[$i - 2]);
+  $i = $i + 1;
 };
   return $fib;
 };
@@ -141,7 +106,7 @@ $__start = _now();
   if ($i < 2) {
   return $i;
 }
-  return _iadd(fib_recursive_term(_isub($i, 1)), fib_recursive_term(_isub($i, 2)));
+  return fib_recursive_term($i - 1) + fib_recursive_term($i - 2);
 };
   function fib_recursive($n) {
   global $fib_cache_global, $fib_memo_cache;
@@ -152,7 +117,7 @@ $__start = _now();
   $i = 0;
   while ($i <= $n) {
   $res = _append($res, fib_recursive_term($i));
-  $i = _iadd($i, 1);
+  $i = $i + 1;
 };
   return $res;
 };
@@ -168,7 +133,7 @@ $__start = _now();
   if (array_key_exists($i, $fib_cache_global)) {
   return $fib_cache_global[$i];
 }
-  $val = _iadd(fib_recursive_cached_term(_isub($i, 1)), fib_recursive_cached_term(_isub($i, 2)));
+  $val = fib_recursive_cached_term($i - 1) + fib_recursive_cached_term($i - 2);
   $fib_cache_global[$i] = $val;
   return $val;
 };
@@ -181,7 +146,7 @@ $__start = _now();
   $j = 0;
   while ($j <= $n) {
   $res = _append($res, fib_recursive_cached_term($j));
-  $j = _iadd($j, 1);
+  $j = $j + 1;
 };
   return $res;
 };
@@ -191,7 +156,7 @@ $__start = _now();
   if (array_key_exists($num, $fib_memo_cache)) {
   return $fib_memo_cache[$num];
 }
-  $value = _iadd(fib_memoization_term(_isub($num, 1)), fib_memoization_term(_isub($num, 2)));
+  $value = fib_memoization_term($num - 1) + fib_memoization_term($num - 2);
   $fib_memo_cache[$num] = $value;
   return $value;
 };
@@ -204,7 +169,7 @@ $__start = _now();
   $i = 0;
   while ($i <= $n) {
   $out = _append($out, fib_memoization_term($i));
-  $i = _iadd($i, 1);
+  $i = $i + 1;
 };
   return $out;
 };
@@ -223,16 +188,16 @@ $__start = _now();
   while ($i <= $n) {
   $val = roundf(powf($phi, $i) / $sqrt5);
   $res = _append($res, $val);
-  $i = _iadd($i, 1);
+  $i = $i + 1;
 };
   return $res;
 };
   function matrix_mul($a, $b) {
   global $fib_cache_global, $fib_memo_cache;
-  $a00 = _iadd(_imul($a[0][0], $b[0][0]), _imul($a[0][1], $b[1][0]));
-  $a01 = _iadd(_imul($a[0][0], $b[0][1]), _imul($a[0][1], $b[1][1]));
-  $a10 = _iadd(_imul($a[1][0], $b[0][0]), _imul($a[1][1], $b[1][0]));
-  $a11 = _iadd(_imul($a[1][0], $b[0][1]), _imul($a[1][1], $b[1][1]));
+  $a00 = $a[0][0] * $b[0][0] + $a[0][1] * $b[1][0];
+  $a01 = $a[0][0] * $b[0][1] + $a[0][1] * $b[1][1];
+  $a10 = $a[1][0] * $b[0][0] + $a[1][1] * $b[1][0];
+  $a11 = $a[1][0] * $b[0][1] + $a[1][1] * $b[1][1];
   return [[$a00, $a01], [$a10, $a11]];
 };
   function matrix_pow($m, $power) {
@@ -244,7 +209,7 @@ $__start = _now();
   $base = $m;
   $p = $power;
   while ($p > 0) {
-  if (_imod($p, 2) == 1) {
+  if ($p % 2 == 1) {
   $result = matrix_mul($result, $base);
 }
   $base = matrix_mul($base, $base);
@@ -261,7 +226,7 @@ $__start = _now();
   return 0;
 }
   $m = [[1, 1], [1, 0]];
-  $res = matrix_pow($m, _isub($n, 1));
+  $res = matrix_pow($m, $n - 1);
   return $res[0][0];
 };
   function run_tests() {

--- a/tests/algorithms/x/PHP/maths/find_max.bench
+++ b/tests/algorithms/x/PHP/maths/find_max.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 128,
-  "memory_bytes": 37800,
+  "duration_us": 109,
+  "memory_bytes": 38136,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/find_max.php
+++ b/tests/algorithms/x/PHP/maths/find_max.php
@@ -16,12 +16,19 @@ function _now() {
     return hrtime(true);
 }
 function _intdiv($a, $b) {
+    if ($b === 0 || $b === '0') {
+        throw new DivisionByZeroError();
+    }
     if (function_exists('bcdiv')) {
         $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
         return intval(bcdiv($sa, $sb, 0));
     }
     return intdiv($a, $b);
+}
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
 }
 $__start_mem = memory_get_usage();
 $__start = _now();
@@ -33,7 +40,7 @@ $__start = _now();
 };
   function find_max_iterative($nums) {
   if (count($nums) == 0) {
-  $panic('find_max_iterative() arg is an empty sequence');
+  _panic('find_max_iterative() arg is an empty sequence');
 }
   $max_num = $nums[0];
   $i = 0;
@@ -49,10 +56,10 @@ $__start = _now();
   function find_max_recursive($nums, $left, $right) {
   $n = count($nums);
   if ($n == 0) {
-  $panic('find_max_recursive() arg is an empty sequence');
+  _panic('find_max_recursive() arg is an empty sequence');
 }
   if ($left >= $n || $left < (0 - $n) || $right >= $n || $right < (0 - $n)) {
-  $panic('list index out of range');
+  _panic('list index out of range');
 }
   $l = normalize_index($left, $n);
   $r = normalize_index($right, $n);
@@ -70,13 +77,13 @@ $__start = _now();
   function test_find_max() {
   $arr = [2.0, 4.0, 9.0, 7.0, 19.0, 94.0, 5.0];
   if (find_max_iterative($arr) != 94.0) {
-  $panic('find_max_iterative failed');
+  _panic('find_max_iterative failed');
 }
   if (find_max_recursive($arr, 0, count($arr) - 1) != 94.0) {
-  $panic('find_max_recursive failed');
+  _panic('find_max_recursive failed');
 }
   if (find_max_recursive($arr, -count($arr), -1) != 94.0) {
-  $panic('negative index handling failed');
+  _panic('negative index handling failed');
 }
 };
   function main() {

--- a/tests/algorithms/x/PHP/maths/find_min.bench
+++ b/tests/algorithms/x/PHP/maths/find_min.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 134,
-  "memory_bytes": 41144,
+  "duration_us": 166,
+  "memory_bytes": 40584,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/find_min.php
+++ b/tests/algorithms/x/PHP/maths/find_min.php
@@ -32,6 +32,9 @@ function _str($x) {
     return strval($x);
 }
 function _intdiv($a, $b) {
+    if ($b === 0 || $b === '0') {
+        throw new DivisionByZeroError();
+    }
     if (function_exists('bcdiv')) {
         $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
@@ -39,11 +42,15 @@ function _intdiv($a, $b) {
     }
     return intdiv($a, $b);
 }
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
 $__start_mem = memory_get_usage();
 $__start = _now();
   function find_min_iterative($nums) {
   if (count($nums) == 0) {
-  $panic('find_min_iterative() arg is an empty sequence');
+  _panic('find_min_iterative() arg is an empty sequence');
 }
   $min_num = $nums[0];
   $i = 0;
@@ -59,10 +66,10 @@ $__start = _now();
   function find_min_recursive($nums, $left, $right) {
   $n = count($nums);
   if ($n == 0) {
-  $panic('find_min_recursive() arg is an empty sequence');
+  _panic('find_min_recursive() arg is an empty sequence');
 }
   if ($left >= $n || $left < (0 - $n) || $right >= $n || $right < (0 - $n)) {
-  $panic('list index out of range');
+  _panic('list index out of range');
 }
   $l = $left;
   $r = $right;
@@ -86,28 +93,28 @@ $__start = _now();
   function test_find_min() {
   $a = [3.0, 2.0, 1.0];
   if (find_min_iterative($a) != 1.0) {
-  $panic('iterative test1 failed');
+  _panic('iterative test1 failed');
 }
   if (find_min_recursive($a, 0, count($a) - 1) != 1.0) {
-  $panic('recursive test1 failed');
+  _panic('recursive test1 failed');
 }
   $b = [-3.0, -2.0, -1.0];
   if (find_min_iterative($b) != (-3.0)) {
-  $panic('iterative test2 failed');
+  _panic('iterative test2 failed');
 }
   if (find_min_recursive($b, 0, count($b) - 1) != (-3.0)) {
-  $panic('recursive test2 failed');
+  _panic('recursive test2 failed');
 }
   $c = [3.0, -3.0, 0.0];
   if (find_min_iterative($c) != (-3.0)) {
-  $panic('iterative test3 failed');
+  _panic('iterative test3 failed');
 }
   if (find_min_recursive($c, 0, count($c) - 1) != (-3.0)) {
-  $panic('recursive test3 failed');
+  _panic('recursive test3 failed');
 }
   $d = [1.0, 3.0, 5.0, 7.0, 9.0, 2.0, 4.0, 6.0, 8.0, 10.0];
   if (find_min_recursive($d, (0 - count($d)), (0 - 1)) != 1.0) {
-  $panic('negative index test failed');
+  _panic('negative index test failed');
 }
 };
   function main() {

--- a/tests/algorithms/x/PHP/maths/floor.bench
+++ b/tests/algorithms/x/PHP/maths/floor.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 76,
-  "memory_bytes": 36928,
+  "duration_us": 80,
+  "memory_bytes": 37056,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/floor.php
+++ b/tests/algorithms/x/PHP/maths/floor.php
@@ -31,6 +31,10 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
 $__start_mem = memory_get_usage();
 $__start = _now();
   function mochi_floor($x) {
@@ -46,7 +50,7 @@ $__start = _now();
   $idx = 0;
   while ($idx < count($nums)) {
   if (mochi_floor($nums[$idx]) != $expected[$idx]) {
-  $panic('floor test failed');
+  _panic('floor test failed');
 }
   $idx = $idx + 1;
 };

--- a/tests/algorithms/x/PHP/maths/gamma.bench
+++ b/tests/algorithms/x/PHP/maths/gamma.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 1515259,
-  "memory_bytes": 72936,
+  "duration_us": 189913,
+  "memory_bytes": 38184,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/gamma.php
+++ b/tests/algorithms/x/PHP/maths/gamma.php
@@ -15,41 +15,6 @@ function _now() {
     }
     return hrtime(true);
 }
-function _iadd($a, $b) {
-    if (function_exists('bcadd')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcadd($sa, $sb, 0);
-    }
-    return $a + $b;
-}
-function _isub($a, $b) {
-    if (function_exists('bcsub')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcsub($sa, $sb, 0);
-    }
-    return $a - $b;
-}
-function _imul($a, $b) {
-    if (function_exists('bcmul')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return bcmul($sa, $sb, 0);
-    }
-    return $a * $b;
-}
-function _idiv($a, $b) {
-    return _intdiv($a, $b);
-}
-function _imod($a, $b) {
-    if (function_exists('bcmod')) {
-        $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
-        $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return intval(bcmod($sa, $sb));
-    }
-    return $a % $b;
-}
 function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
@@ -73,7 +38,7 @@ $__start = _now();
   $i = 0;
   while ($i < 20) {
   $guess = ($guess + $x / $guess) / 2.0;
-  $i = _iadd($i, 1);
+  $i = $i + 1;
 };
   return $guess;
 };
@@ -88,10 +53,10 @@ $__start = _now();
   $sum = 0.0;
   $k = 0;
   while ($k < 10) {
-  $denom = floatval((_iadd(_imul(2, $k), 1)));
+  $denom = floatval((2 * $k + 1));
   $sum = $sum + $term / $denom;
   $term = $term * $y2;
-  $k = _iadd($k, 1);
+  $k = $k + 1;
 };
   return 2.0 * $sum;
 };
@@ -103,7 +68,7 @@ $__start = _now();
   while ($n < 20) {
   $term = $term * $x / (floatval($n));
   $sum = $sum + $term;
-  $n = _iadd($n, 1);
+  $n = $n + 1;
 };
   return $sum;
 };

--- a/tests/algorithms/x/PHP/maths/gaussian.bench
+++ b/tests/algorithms/x/PHP/maths/gaussian.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 62,
+  "duration_us": 68,
   "memory_bytes": 36360,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/gcd_of_n_numbers.bench
+++ b/tests/algorithms/x/PHP/maths/gcd_of_n_numbers.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 79,
-  "memory_bytes": 40184,
+  "duration_us": 105,
+  "memory_bytes": 40376,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/gcd_of_n_numbers.php
+++ b/tests/algorithms/x/PHP/maths/gcd_of_n_numbers.php
@@ -31,6 +31,10 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
 $__start_mem = memory_get_usage();
 $__start = _now();
   function gcd($a, $b) {
@@ -48,17 +52,17 @@ $__start = _now();
 };
   function get_greatest_common_divisor($nums) {
   if (count($nums) == 0) {
-  $panic('at least one number is required');
+  _panic('at least one number is required');
 }
   $g = $nums[0];
   if ($g <= 0) {
-  $panic('numbers must be integer and greater than zero');
+  _panic('numbers must be integer and greater than zero');
 }
   $i = 1;
   while ($i < count($nums)) {
   $n = $nums[$i];
   if ($n <= 0) {
-  $panic('numbers must be integer and greater than zero');
+  _panic('numbers must be integer and greater than zero');
 }
   $g = gcd($g, $n);
   $i = $i + 1;

--- a/tests/algorithms/x/PHP/maths/geometric_mean.bench
+++ b/tests/algorithms/x/PHP/maths/geometric_mean.bench
@@ -1,8 +1,1 @@
-Warning: Undefined variable $panic in /workspace/mochi/tests/algorithms/x/PHP/maths/geometric_mean.php on line 95
-
-Fatal error: Uncaught Error: Value of type null is not callable in /workspace/mochi/tests/algorithms/x/PHP/maths/geometric_mean.php:95
-Stack trace:
-#0 /workspace/mochi/tests/algorithms/x/PHP/maths/geometric_mean.php(103): test_compute_geometric_mean()
-#1 /workspace/mochi/tests/algorithms/x/PHP/maths/geometric_mean.php(106): main()
-#2 {main}
-  thrown in /workspace/mochi/tests/algorithms/x/PHP/maths/geometric_mean.php on line 95
+test4 failed

--- a/tests/algorithms/x/PHP/maths/geometric_mean.php
+++ b/tests/algorithms/x/PHP/maths/geometric_mean.php
@@ -1,16 +1,33 @@
 <?php
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-function mochi_abs($x) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function mochi_abs($x) {
   if ($x < 0.0) {
   return -$x;
 }
   return $x;
-}
-function pow_int($base, $exp) {
+};
+  function pow_int($base, $exp) {
   $result = 1.0;
   $i = 0;
   while ($i < $exp) {
@@ -18,8 +35,8 @@ function pow_int($base, $exp) {
   $i = $i + 1;
 };
   return $result;
-}
-function nth_root($x, $n) {
+};
+  function nth_root($x, $n) {
   if ($x == 0.0) {
   return 0.0;
 }
@@ -31,16 +48,16 @@ function nth_root($x, $n) {
   $i = $i + 1;
 };
   return $guess;
-}
-function round_nearest($x) {
+};
+  function round_nearest($x) {
   if ($x >= 0.0) {
   $n = intval(($x + 0.5));
   return floatval($n);
 }
   $n = intval(($x - 0.5));
   return floatval($n);
-}
-function compute_geometric_mean($nums) {
+};
+  function compute_geometric_mean($nums) {
   if (count($nums) == 0) {
   _panic('no numbers');
 }
@@ -62,8 +79,8 @@ function compute_geometric_mean($nums) {
   $mean = $possible;
 }
   return $mean;
-}
-function test_compute_geometric_mean() {
+};
+  function test_compute_geometric_mean() {
   $eps = 0.0001;
   $m1 = compute_geometric_mean([2.0, 8.0]);
   if (mochi_abs($m1 - 4.0) > $eps) {
@@ -85,9 +102,17 @@ function test_compute_geometric_mean() {
   if (mochi_abs($m5 + 5.0) > $eps) {
   _panic('test5 failed');
 }
-}
-function main() {
+};
+  function main() {
   test_compute_geometric_mean();
   echo rtrim(json_encode(compute_geometric_mean([-3.0, -27.0]), 1344)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage();
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/transpiler/x/php/ALGORITHMS.md
+++ b/transpiler/x/php/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated PHP code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/PHP`.
-Last updated: 2025-08-16 12:04 GMT+7
+Last updated: 2025-08-16 14:59 GMT+7
 
 ## Algorithms Golden Test Checklist (990/1077)
 | Index | Name | Status | Duration | Memory |
@@ -531,56 +531,56 @@ Last updated: 2025-08-16 12:04 GMT+7
 | 522 | machine_learning/similarity_search | ✓ | 125µs | 39.3 KB |
 | 523 | machine_learning/support_vector_machines | ✓ | 925µs | 35.3 KB |
 | 524 | machine_learning/word_frequency_functions | ✓ | 405µs | 74.8 KB |
-| 525 | machine_learning/xgboost_classifier | ✓ | 126µs | 37.1 KB |
-| 526 | machine_learning/xgboost_regressor | ✓ | 98µs | 40.9 KB |
-| 527 | maths/abs | ✓ | 86µs | 37.4 KB |
-| 528 | maths/addition_without_arithmetic | ✓ | 358µs | 36.3 KB |
-| 529 | maths/aliquot_sum | ✓ | 91µs | 35.9 KB |
-| 530 | maths/allocation_number | ✓ | 102µs | 39.5 KB |
-| 531 | maths/arc_length | ✓ | 43µs | 38.7 KB |
-| 532 | maths/area | ✓ | 83µs | 92.7 KB |
-| 533 | maths/area_under_curve | ✓ | 8.967ms | 39.0 KB |
-| 534 | maths/average_absolute_deviation | ✓ | 49µs | 39.3 KB |
-| 535 | maths/average_mean | ✓ | 58µs | 38.9 KB |
-| 536 | maths/average_median | ✓ | 77µs | 39.4 KB |
-| 537 | maths/average_mode | ✓ | 142µs | 70.3 KB |
-| 538 | maths/bailey_borwein_plouffe | ✓ | 1.812763s | 40.3 KB |
+| 525 | machine_learning/xgboost_classifier | ✓ | 175µs | 37.1 KB |
+| 526 | machine_learning/xgboost_regressor | ✓ | 144µs | 40.9 KB |
+| 527 | maths/abs | ✓ | 121µs | 37.4 KB |
+| 528 | maths/addition_without_arithmetic | ✓ | 361µs | 36.3 KB |
+| 529 | maths/aliquot_sum | ✓ | 120µs | 35.9 KB |
+| 530 | maths/allocation_number | ✓ | 131µs | 39.5 KB |
+| 531 | maths/arc_length | ✓ | 83µs | 38.7 KB |
+| 532 | maths/area | ✓ | 123µs | 92.7 KB |
+| 533 | maths/area_under_curve | ✓ | 12.76ms | 39.0 KB |
+| 534 | maths/average_absolute_deviation | ✓ | 66µs | 39.3 KB |
+| 535 | maths/average_mean | ✓ | 145µs | 38.9 KB |
+| 536 | maths/average_median | ✓ | 194µs | 39.4 KB |
+| 537 | maths/average_mode | ✓ | 237µs | 70.3 KB |
+| 538 | maths/bailey_borwein_plouffe | ✓ | 3.126549s | 40.3 KB |
 | 539 | maths/base_neg2_conversion | ✓ | 100µs | 38.0 KB |
-| 540 | maths/basic_maths | ✓ | 175µs | 72.9 KB |
-| 541 | maths/binary_exponentiation | ✓ | 97µs | 36.1 KB |
-| 542 | maths/binary_multiplication | ✓ | 45µs | 35.2 KB |
-| 543 | maths/binomial_coefficient | ✓ | 71µs | 39.7 KB |
+| 540 | maths/basic_maths | ✓ | 176µs | 72.9 KB |
+| 541 | maths/binary_exponentiation | ✓ | 69µs | 36.1 KB |
+| 542 | maths/binary_multiplication | ✓ | 68µs | 35.2 KB |
+| 543 | maths/binomial_coefficient | ✓ | 125µs | 39.7 KB |
 | 544 | maths/binomial_distribution | ✓ | 1µs | 34.3 KB |
-| 545 | maths/ceil | ✓ | 44µs | 39.0 KB |
-| 546 | maths/chebyshev_distance | ✓ | 97µs | 40.6 KB |
-| 547 | maths/check_polygon | ✓ | 150µs | 41.4 KB |
-| 548 | maths/chinese_remainder_theorem | ✓ | 187µs | 71.6 KB |
-| 549 | maths/chudnovsky_algorithm | ✓ | 93µs | 42.8 KB |
-| 550 | maths/collatz_sequence | ✓ | 151µs | 36.9 KB |
-| 551 | maths/combinations | ✓ | 83µs | 38.5 KB |
-| 552 | maths/continued_fraction | ✓ | 137µs | 40.3 KB |
-| 553 | maths/decimal_isolate | ✓ | 88µs | 35.9 KB |
-| 554 | maths/decimal_to_fraction | ✓ | 176µs | 71.5 KB |
-| 555 | maths/dodecahedron | ✓ | 100µs | 36.4 KB |
-| 556 | maths/double_factorial | ✓ | 52µs | 38.6 KB |
-| 557 | maths/dual_number_automatic_differentiation | ✓ | 196µs | 73.3 KB |
-| 558 | maths/entropy | ✓ | 607µs | 37.1 KB |
-| 559 | maths/euclidean_distance | ✓ | 143µs | 34.8 KB |
-| 560 | maths/euler_method | ✓ | 634µs | 37.3 KB |
-| 561 | maths/euler_modified | ✓ | 175µs | 36.1 KB |
-| 562 | maths/eulers_totient | ✓ | 127µs | 37.8 KB |
-| 563 | maths/extended_euclidean_algorithm | ✓ | 138µs | 37.2 KB |
-| 564 | maths/factorial | ✓ | 158µs | 35.8 KB |
-| 565 | maths/factors | ✓ | 195µs | 36.9 KB |
-| 566 | maths/fast_inverse_sqrt | ✓ | 951µs | 70.3 KB |
-| 567 | maths/fermat_little_theorem | ✓ | 133µs | 39.1 KB |
-| 568 | maths/fibonacci | ✓ | 418µs | 78.3 KB |
-| 569 | maths/find_max | ✓ | 128µs | 36.9 KB |
-| 570 | maths/find_min | ✓ | 134µs | 40.2 KB |
-| 571 | maths/floor | ✓ | 76µs | 36.1 KB |
-| 572 | maths/gamma | ✓ | 1.515259s | 71.2 KB |
-| 573 | maths/gaussian | ✓ | 62µs | 35.5 KB |
-| 574 | maths/gcd_of_n_numbers | ✓ | 79µs | 39.2 KB |
+| 545 | maths/ceil | ✓ | 60µs | 39.0 KB |
+| 546 | maths/chebyshev_distance | ✓ | 80µs | 38.4 KB |
+| 547 | maths/check_polygon | ✓ | 142µs | 39.3 KB |
+| 548 | maths/chinese_remainder_theorem | ✓ | 142µs | 36.8 KB |
+| 549 | maths/chudnovsky_algorithm | ✓ | 58µs | 40.5 KB |
+| 550 | maths/collatz_sequence | ✓ | 218µs | 36.9 KB |
+| 551 | maths/combinations | ✓ | 70µs | 36.3 KB |
+| 552 | maths/continued_fraction | ✓ | 141µs | 40.3 KB |
+| 553 | maths/decimal_isolate | ✓ | 70µs | 35.9 KB |
+| 554 | maths/decimal_to_fraction | ✓ | 181µs | 71.8 KB |
+| 555 | maths/dodecahedron | ✓ | 57µs | 37.0 KB |
+| 556 | maths/double_factorial | ✓ | 66µs | 39.0 KB |
+| 557 | maths/dual_number_automatic_differentiation | ✓ | 241µs | 73.6 KB |
+| 558 | maths/entropy | ✓ | 689µs | 37.1 KB |
+| 559 | maths/euclidean_distance | ✓ | 176µs | 34.8 KB |
+| 560 | maths/euler_method | ✓ | 734µs | 37.4 KB |
+| 561 | maths/euler_modified | ✓ | 150µs | 36.1 KB |
+| 562 | maths/eulers_totient | ✓ | 162µs | 37.7 KB |
+| 563 | maths/extended_euclidean_algorithm | ✓ | 161µs | 37.6 KB |
+| 564 | maths/factorial | ✓ | 59µs | 36.0 KB |
+| 565 | maths/factors | ✓ | 220µs | 37.5 KB |
+| 566 | maths/fast_inverse_sqrt | ✓ | 964µs | 71.2 KB |
+| 567 | maths/fermat_little_theorem | ✓ | 186µs | 39.2 KB |
+| 568 | maths/fibonacci | ✓ | 275µs | 75.5 KB |
+| 569 | maths/find_max | ✓ | 109µs | 37.2 KB |
+| 570 | maths/find_min | ✓ | 166µs | 39.6 KB |
+| 571 | maths/floor | ✓ | 80µs | 36.2 KB |
+| 572 | maths/gamma | ✓ | 189.913ms | 37.3 KB |
+| 573 | maths/gaussian | ✓ | 68µs | 35.5 KB |
+| 574 | maths/gcd_of_n_numbers | ✓ | 105µs | 39.4 KB |
 | 575 | maths/geometric_mean | error |  |  |
 | 576 | maths/germain_primes | ✓ | 92µs | 37.7 KB |
 | 577 | maths/greatest_common_divisor | ✓ | 167µs | 37.5 KB |

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-Last updated: 2025-08-16 11:48 +0700
+Last updated: 2025-08-16 14:44 +0700
 
 ## VM Golden Test Checklist (103/105)
 - [x] append_builtin

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,4 +1,4 @@
-## Progress (2025-08-16 11:48 +0700)
+## Progress (2025-08-16 14:44 +0700)
 - Generated PHP for 103/105 programs
 - Updated README checklist and outputs
 - Enhanced printing to match golden format


### PR DESCRIPTION
## Summary
- refresh PHP algorithm benchmark data for indices 525-575
- skip index 539 (base_neg2_conversion) due to timeout
- regenerate algorithm progress and VM documentation

## Testing
- `for i in $(seq 525 574); do MOCHI_ALG_INDEX=$i MOCHI_BENCHMARK=1 go test ./transpiler/x/php -tags=slow -run TestPHPTranspiler_Algorithms_Golden -count=1 -update-algorithms-php || break; done` *(fails at index 539: timeout)*
- `for i in $(seq 540 575); do MOCHI_ALG_INDEX=$i MOCHI_BENCHMARK=1 go test ./transpiler/x/php -tags=slow -run TestPHPTranspiler_Algorithms_Golden -count=1 -update-algorithms-php || break; done`

------
https://chatgpt.com/codex/tasks/task_e_68a036ce76a48320b850ac250b2d8af7