### PR TITLE
java: streamline benchmark emission and update gradient descent

### DIFF
--- a/tests/algorithms/x/Java/machine_learning/gradient_descent.bench
+++ b/tests/algorithms/x/Java/machine_learning/gradient_descent.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 50711,
-  "memory_bytes": 50648,
-  "name": "main"
-}
+{"duration_us": 50378, "memory_bytes": 50512, "name": "main"}

--- a/tests/algorithms/x/Java/machine_learning/gradient_descent.java
+++ b/tests/algorithms/x/Java/machine_learning/gradient_descent.java
@@ -104,11 +104,41 @@ public class Main {
         }
     }
     public static void main(String[] args) {
-        train_data = ((DataPoint[])(new DataPoint[]{new DataPoint(new double[]{5.0, 2.0, 3.0}, 15.0), new DataPoint(new double[]{6.0, 5.0, 9.0}, 25.0), new DataPoint(new double[]{11.0, 12.0, 13.0}, 41.0), new DataPoint(new double[]{1.0, 1.0, 1.0}, 8.0), new DataPoint(new double[]{11.0, 12.0, 13.0}, 41.0)}));
-        test_data = ((DataPoint[])(new DataPoint[]{new DataPoint(new double[]{515.0, 22.0, 13.0}, 555.0), new DataPoint(new double[]{61.0, 35.0, 49.0}, 150.0)}));
-        parameter_vector = ((double[])(run_gradient_descent(((DataPoint[])(train_data)), ((double[])(parameter_vector)))));
-        System.out.println("\nTesting gradient descent for a linear hypothesis function.\n");
-        test_gradient_descent(((DataPoint[])(test_data)), ((double[])(parameter_vector)));
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            train_data = ((DataPoint[])(new DataPoint[]{new DataPoint(new double[]{5.0, 2.0, 3.0}, 15.0), new DataPoint(new double[]{6.0, 5.0, 9.0}, 25.0), new DataPoint(new double[]{11.0, 12.0, 13.0}, 41.0), new DataPoint(new double[]{1.0, 1.0, 1.0}, 8.0), new DataPoint(new double[]{11.0, 12.0, 13.0}, 41.0)}));
+            test_data = ((DataPoint[])(new DataPoint[]{new DataPoint(new double[]{515.0, 22.0, 13.0}, 555.0), new DataPoint(new double[]{61.0, 35.0, 49.0}, 150.0)}));
+            parameter_vector = ((double[])(run_gradient_descent(((DataPoint[])(train_data)), ((double[])(parameter_vector)))));
+            System.out.println("\nTesting gradient descent for a linear hypothesis function.\n");
+            test_gradient_descent(((DataPoint[])(test_data)), ((double[])(parameter_vector)));
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
     }
 
     static double[] appendDouble(double[] arr, double v) {

--- a/transpiler/x/java/ALGORITHMS.md
+++ b/transpiler/x/java/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Java code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Java`.
-Last updated: 2025-08-16 21:34 GMT+7
+Last updated: 2025-08-17 08:58 GMT+7
 
 ## Algorithms Golden Test Checklist (954/1077)
 | Index | Name | Status | Duration | Memory |
@@ -512,7 +512,7 @@ Last updated: 2025-08-16 21:34 GMT+7
 | 503 | machine_learning/forecasting/run | ✓ | 30.0ms | 57.38KB |
 | 504 | machine_learning/frequent_pattern_growth | error |  |  |
 | 505 | machine_learning/gradient_boosting_classifier | ✓ | 30.0ms | 63.75KB |
-| 506 | machine_learning/gradient_descent | ✓ | 50.0ms | 49.46KB |
+| 506 | machine_learning/gradient_descent | ✓ | 50.0ms | 49.33KB |
 | 507 | machine_learning/k_means_clust | ✓ | 48.0ms | 59.05KB |
 | 508 | machine_learning/k_nearest_neighbours | ✓ | 55.0ms | 50.16KB |
 | 509 | machine_learning/linear_discriminant_analysis | ✓ | 46.0ms | 58.00KB |

--- a/transpiler/x/java/transpiler.go
+++ b/transpiler/x/java/transpiler.go
@@ -2194,11 +2194,7 @@ func (b *BenchStmt) emit(w io.Writer, indent string) {
 	emitBlock(w, indent+"    ", b.Body)
 	fmt.Fprint(w, indent+"    long _benchDuration = _now() - _benchStart;\n")
 	fmt.Fprint(w, indent+"    long _benchMemory = _mem() - _benchMem;\n")
-	fmt.Fprint(w, indent+"    System.out.println(\"{\");\n")
-	fmt.Fprint(w, indent+"    System.out.println(\"  \\\"duration_us\\\": \" + _benchDuration + \",\");\n")
-	fmt.Fprint(w, indent+"    System.out.println(\"  \\\"memory_bytes\\\": \" + _benchMemory + \",\");\n")
-	fmt.Fprintf(w, indent+"    System.out.println(\"  \\\"name\\\": \\\"%s\\\"\");\n", b.Name)
-	fmt.Fprint(w, indent+"    System.out.println(\"}\");\n")
+	fmt.Fprintf(w, indent+"    System.out.println(\"{\\\"duration_us\\\": \" + _benchDuration + \", \\\"memory_bytes\\\": \" + _benchMemory + \", \\\"name\\\": \\\"%s\\\"}\");\n", b.Name)
 	fmt.Fprint(w, indent+"    return;\n")
 	fmt.Fprint(w, indent+"}\n")
 }


### PR DESCRIPTION
## Summary
- simplify Java benchmark emission by consolidating JSON output into a single println
- regenerate gradient_descent example with benchmark instrumentation
- refresh algorithms progress table for updated metrics

## Testing
- `MOCHI_ALG_INDEX=506 MOCHI_BENCHMARK=1 go test ./transpiler/x/java -run TestJavaTranspiler_Algorithms_Golden -update-algorithms-java -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_68a135b418888320a6848397e975d2a4