### PR TITLE
Add Clojure transpiled algorithm hardy_ramanujanalgo

### DIFF
--- a/tests/algorithms/x/Clojure/maths/hardy_ramanujanalgo.bench
+++ b/tests/algorithms/x/Clojure/maths/hardy_ramanujanalgo.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 62421,
-  "memory_bytes": 22912168,
+  "duration_us": 33745,
+  "memory_bytes": 22621224,
   "name": "main"
 }

--- a/tests/algorithms/x/Clojure/maths/hardy_ramanujanalgo.clj
+++ b/tests/algorithms/x/Clojure/maths/hardy_ramanujanalgo.clj
@@ -17,6 +17,9 @@
 (defn toi [s]
   (Integer/parseInt (str s)))
 
+(defn _fetch [url]
+  {:data [{:from "" :intensity {:actual 0 :forecast 0 :index ""} :to ""}]})
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare exact_prime_factor_count ln floor round4 main)
@@ -50,16 +53,16 @@
 (def ^:dynamic round4_m nil)
 
 (defn exact_prime_factor_count [exact_prime_factor_count_n]
-  (binding [count_v nil exact_prime_factor_count_i nil exact_prime_factor_count_num nil] (try (do (set! count_v 0) (set! exact_prime_factor_count_num exact_prime_factor_count_n) (when (= (mod exact_prime_factor_count_num 2) 0) (do (set! count_v (+ count_v 1)) (while (= (mod exact_prime_factor_count_num 2) 0) (set! exact_prime_factor_count_num (quot exact_prime_factor_count_num 2))))) (set! exact_prime_factor_count_i 3) (while (<= (* exact_prime_factor_count_i exact_prime_factor_count_i) exact_prime_factor_count_num) (do (when (= (mod exact_prime_factor_count_num exact_prime_factor_count_i) 0) (do (set! count_v (+ count_v 1)) (while (= (mod exact_prime_factor_count_num exact_prime_factor_count_i) 0) (set! exact_prime_factor_count_num (quot exact_prime_factor_count_num exact_prime_factor_count_i))))) (set! exact_prime_factor_count_i (+ exact_prime_factor_count_i 2)))) (when (> exact_prime_factor_count_num 2) (set! count_v (+ count_v 1))) (throw (ex-info "return" {:v count_v}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
+  (binding [count_v nil exact_prime_factor_count_i nil exact_prime_factor_count_num nil] (try (do (set! count_v 0) (set! exact_prime_factor_count_num exact_prime_factor_count_n) (when (= (mod exact_prime_factor_count_num 2) 0) (do (set! count_v (+ count_v 1)) (while (= (mod exact_prime_factor_count_num 2) 0) (set! exact_prime_factor_count_num (/ exact_prime_factor_count_num 2))))) (set! exact_prime_factor_count_i 3) (while (<= (* exact_prime_factor_count_i exact_prime_factor_count_i) exact_prime_factor_count_num) (do (when (= (mod exact_prime_factor_count_num exact_prime_factor_count_i) 0) (do (set! count_v (+ count_v 1)) (while (= (mod exact_prime_factor_count_num exact_prime_factor_count_i) 0) (set! exact_prime_factor_count_num (/ exact_prime_factor_count_num exact_prime_factor_count_i))))) (set! exact_prime_factor_count_i (+ exact_prime_factor_count_i 2)))) (when (> exact_prime_factor_count_num 2) (set! count_v (+ count_v 1))) (throw (ex-info "return" {:v count_v}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
 
 (defn ln [ln_x]
-  (binding [ln_k nil ln_ln2 nil ln_n nil ln_sum nil ln_t nil ln_term nil ln_y nil] (try (do (set! ln_ln2 0.6931471805599453) (set! ln_y ln_x) (set! ln_k 0.0) (while (> ln_y 2.0) (do (set! ln_y (/ ln_y 2.0)) (set! ln_k (+ ln_k ln_ln2)))) (while (< ln_y 1.0) (do (set! ln_y (* ln_y 2.0)) (set! ln_k (- ln_k ln_ln2)))) (set! ln_t (quot (- ln_y 1.0) (+ ln_y 1.0))) (set! ln_term ln_t) (set! ln_sum 0.0) (set! ln_n 1) (while (<= ln_n 19) (do (set! ln_sum (+ ln_sum (quot ln_term (double ln_n)))) (set! ln_term (* (* ln_term ln_t) ln_t)) (set! ln_n (+ ln_n 2)))) (throw (ex-info "return" {:v (+ ln_k (* 2.0 ln_sum))}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
+  (binding [ln_k nil ln_ln2 nil ln_n nil ln_sum nil ln_t nil ln_term nil ln_y nil] (try (do (set! ln_ln2 0.6931471805599453) (set! ln_y ln_x) (set! ln_k 0.0) (while (> ln_y 2.0) (do (set! ln_y (/ ln_y 2.0)) (set! ln_k (+ ln_k ln_ln2)))) (while (< ln_y 1.0) (do (set! ln_y (* ln_y 2.0)) (set! ln_k (- ln_k ln_ln2)))) (set! ln_t (/ (- ln_y 1.0) (+ ln_y 1.0))) (set! ln_term ln_t) (set! ln_sum 0.0) (set! ln_n 1) (while (<= ln_n 19) (do (set! ln_sum (+ ln_sum (/ ln_term (double ln_n)))) (set! ln_term (* (* ln_term ln_t) ln_t)) (set! ln_n (+ ln_n 2)))) (throw (ex-info "return" {:v (+ ln_k (* 2.0 ln_sum))}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
 
 (defn floor [floor_x]
   (binding [floor_i nil] (try (do (set! floor_i (long floor_x)) (when (> (double floor_i) floor_x) (set! floor_i (- floor_i 1))) (throw (ex-info "return" {:v (double floor_i)}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
 
 (defn round4 [round4_x]
-  (binding [round4_m nil] (try (do (set! round4_m 10000.0) (throw (ex-info "return" {:v (quot (floor (+ (* round4_x round4_m) 0.5)) round4_m)}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
+  (binding [round4_m nil] (try (do (set! round4_m 10000.0) (throw (ex-info "return" {:v (/ (floor (+ (* round4_x round4_m) 0.5)) round4_m)}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
 
 (defn main []
   (binding [count_v nil main_loglog nil main_n nil] (do (set! main_n 51242183) (set! count_v (exact_prime_factor_count main_n)) (println (str "The number of distinct prime factors is/are " (str count_v))) (set! main_loglog (ln (ln (double main_n)))) (println (str "The value of log(log(n)) is " (str (round4 main_loglog)))))))

--- a/tests/algorithms/x/Clojure/maths/hardy_ramanujanalgo.out
+++ b/tests/algorithms/x/Clojure/maths/hardy_ramanujanalgo.out
@@ -1,2 +1,2 @@
 The number of distinct prime factors is/are 3
-The value of log(log(n)) is 2.0
+The value of log(log(n)) is 2.8765

--- a/transpiler/x/clj/ALGORITHMS.md
+++ b/transpiler/x/clj/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Clojure code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Clojure`.
-Last updated: 2025-08-16 19:57 GMT+7
+Last updated: 2025-08-17 09:11 GMT+7
 
 ## Algorithms Golden Test Checklist (790/1077)
 | Index | Name | Status | Duration | Memory |
@@ -584,7 +584,7 @@ Last updated: 2025-08-16 19:57 GMT+7
 | 575 | maths/geometric_mean | error |  |  |
 | 576 | maths/germain_primes | ✓ | 65.705ms | 20.74MB |
 | 577 | maths/greatest_common_divisor | ✓ | 65.714ms | 19.57MB |
-| 578 | maths/hardy_ramanujanalgo | ✓ | 62.421ms | 21.85MB |
+| 578 | maths/hardy_ramanujanalgo | ✓ | 33.745ms | 21.57MB |
 | 579 | maths/integer_square_root | ✓ | 71.366ms | 21.72MB |
 | 580 | maths/interquartile_range | ✓ | 74.362ms | 22.56MB |
 | 581 | maths/is_int_palindrome | ✓ | 32.38ms | 19.48MB |


### PR DESCRIPTION
## Summary
- transpile maths/hardy_ramanujanalgo Mochi program to Clojure and record its benchmark and expected output
- update Clojure transpiler algorithms progress

## Testing
- `MOCHI_ALG_INDEX=578 go test ./transpiler/x/clj -run TestClojureTranspiler_Algorithms_Golden -count=1 -tags=slow -v`


------
https://chatgpt.com/codex/tasks/task_e_68a139b958388320bdd77aabc1af6fe4