### PR TITLE
php: regenerate hardy ramanujan algorithm output

### DIFF
--- a/tests/algorithms/x/PHP/maths/hardy_ramanujanalgo.bench
+++ b/tests/algorithms/x/PHP/maths/hardy_ramanujanalgo.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 106,
-  "memory_bytes": 37840,
+  "duration_us": 84,
+  "memory_bytes": 37968,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/hardy_ramanujanalgo.php
+++ b/tests/algorithms/x/PHP/maths/hardy_ramanujanalgo.php
@@ -1,20 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -32,6 +18,9 @@ function _str($x) {
     return strval($x);
 }
 function _intdiv($a, $b) {
+    if ($b === 0 || $b === '0') {
+        throw new DivisionByZeroError();
+    }
     if (function_exists('bcdiv')) {
         $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
@@ -39,9 +28,7 @@ function _intdiv($a, $b) {
     }
     return intdiv($a, $b);
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  function exact_prime_factor_count($n) {
+function exact_prime_factor_count($n) {
   $count = 0;
   $num = $n;
   if ($num % 2 == 0) {
@@ -64,8 +51,8 @@ $__start = _now();
   $count = $count + 1;
 }
   return $count;
-};
-  function ln($x) {
+}
+function ln($x) {
   $ln2 = 0.6931471805599453;
   $y = $x;
   $k = 0.0;
@@ -87,31 +74,23 @@ $__start = _now();
   $n = $n + 2;
 };
   return $k + 2.0 * $sum;
-};
-  function mochi_floor($x) {
+}
+function mochi_floor($x) {
   $i = intval($x);
   if ((floatval($i)) > $x) {
   $i = $i - 1;
 }
   return floatval($i);
-};
-  function round4($x) {
+}
+function round4($x) {
   $m = 10000.0;
   return mochi_floor($x * $m + 0.5) / $m;
-};
-  function main() {
+}
+function main() {
   $n = 51242183;
   $count = exact_prime_factor_count($n);
   echo rtrim('The number of distinct prime factors is/are ' . _str($count)), PHP_EOL;
   $loglog = ln(ln(floatval($n)));
   echo rtrim('The value of log(log(n)) is ' . _str(round4($loglog))), PHP_EOL;
-};
-  main();
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+main();

--- a/transpiler/x/php/ALGORITHMS.md
+++ b/transpiler/x/php/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated PHP code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/PHP`.
-Last updated: 2025-08-16 20:02 GMT+7
+Last updated: 2025-08-17 09:12 GMT+7
 
 ## Algorithms Golden Test Checklist (990/1077)
 | Index | Name | Status | Duration | Memory |
@@ -584,7 +584,7 @@ Last updated: 2025-08-16 20:02 GMT+7
 | 575 | maths/geometric_mean | error |  |  |
 | 576 | maths/germain_primes | ✓ | 92µs | 37.7 KB |
 | 577 | maths/greatest_common_divisor | ✓ | 167µs | 37.5 KB |
-| 578 | maths/hardy_ramanujanalgo | ✓ | 106µs | 37.0 KB |
+| 578 | maths/hardy_ramanujanalgo | ✓ | 84µs | 37.1 KB |
 | 579 | maths/integer_square_root | ✓ | 144µs | 36.9 KB |
 | 580 | maths/interquartile_range | ✓ | 186µs | 37.8 KB |
 | 581 | maths/is_int_palindrome | ✓ | 79µs | 40.1 KB |

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-Last updated: 2025-08-16 19:42 +0700
+Last updated: 2025-08-17 09:08 +0700
 
 ## VM Golden Test Checklist (103/105)
 - [x] append_builtin

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,4 +1,4 @@
-## Progress (2025-08-16 19:42 +0700)
+## Progress (2025-08-17 09:08 +0700)
 - Generated PHP for 103/105 programs
 - Updated README checklist and outputs
 - Enhanced printing to match golden format


### PR DESCRIPTION
## Summary
- regenerate PHP output for `maths/hardy_ramanujanalgo`
- refresh benchmark and checklist metadata for PHP transpiler

## Testing
- `MOCHI_ALG_INDEX=578 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -update-algorithms-php`
- `MOCHI_ALG_INDEX=578 go test -tags slow ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden`


------
https://chatgpt.com/codex/tasks/task_e_68a139c60ed48320b409e5e21a43d073