### PR TITLE
feat(dart): handle substring casts when parsing ints

### DIFF
--- a/transpiler/x/dart/ALGORITHMS.md
+++ b/transpiler/x/dart/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Dart code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Dart`.
-Last updated: 2025-08-17 12:37 GMT+7
+Last updated: 2025-08-17 13:23 GMT+7
 
 ## Algorithms Golden Test Checklist (996/1077)
 | Index | Name | Status | Duration | Memory |

--- a/transpiler/x/dart/transpiler.go
+++ b/transpiler/x/dart/transpiler.go
@@ -3026,6 +3026,16 @@ func (c *CastExpr) emit(w io.Writer) error {
 
 	if cType == "int" {
 		if call, ok := c.Value.(*CallExpr); ok {
+			if sel, ok := call.Func.(*SelectorExpr); ok && sel.Field == "substring" {
+				if _, err := io.WriteString(w, "int.parse("); err != nil {
+					return err
+				}
+				if err := c.Value.emit(w); err != nil {
+					return err
+				}
+				_, err := io.WriteString(w, ")")
+				return err
+			}
 			if name, ok := call.Func.(*Name); ok && name.Name == "_substr" {
 				if _, err := io.WriteString(w, "int.parse("); err != nil {
 					return err


### PR DESCRIPTION
## Summary
- extend Dart transpiler casts to parse substring slices as ints
- regenerate algorithms table

## Testing
- `MOCHI_ALG_INDEX=681 go test -run TestDartTranspiler_Algorithms_Golden -tags slow ./transpiler/x/dart -update-algorithms-dart`
- `MOCHI_ALG_INDEX=681 MOCHI_BENCHMARK=1 go test -run TestDartTranspiler_Algorithms_Golden -tags slow ./transpiler/x/dart -update-algorithms-dart`


------
https://chatgpt.com/codex/tasks/task_e_68a1737c0d0c8320b64f69412ad8a7c2