### PR TITLE
java: refresh weird number algorithm

### DIFF
--- a/tests/algorithms/x/Java/maths/special_numbers/weird_number.bench
+++ b/tests/algorithms/x/Java/maths/special_numbers/weird_number.bench
@@ -1,4 +1,1 @@
-Exception in thread "main" java.lang.RuntimeException: factors 12 failed
-	at Main.run_tests(Main.java:84)
-	at Main.main(Main.java:131)
-	at Main.main(Main.java:148)
+{"duration_us": 37128, "memory_bytes": 39176, "name": "main"}

--- a/tests/algorithms/x/Java/maths/special_numbers/weird_number.java
+++ b/tests/algorithms/x/Java/maths/special_numbers/weird_number.java
@@ -24,10 +24,10 @@ arr[(int)((long)((long)(j_1) + 1L))] = (long)(tmp_1);
         long i_3 = 2L;
         while ((long)((long)(i_3) * (long)(i_3)) <= (long)(num)) {
             if (Math.floorMod(num, i_3) == 0L) {
-                values = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(values), java.util.stream.LongStream.of((long)(i_3))).toArray()));
+                values = ((long[])(appendLong(values, (long)(i_3))));
                 Object d_1 = Math.floorDiv(((long)(num)), ((long)(i_3)));
                 if (((Number)(d_1)).intValue() != (long)(i_3)) {
-                    values = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(values), java.util.stream.LongStream.of(((Number)(d_1)).longValue())).toArray()));
+                    values = ((long[])(appendLong(values, ((Number)(d_1)).longValue())));
                 }
             }
             i_3 = (long)((long)(i_3) + 1L);
@@ -147,6 +147,12 @@ possible_1[(int)((long)(s_1))] = true;
 
     static boolean[] appendBool(boolean[] arr, boolean v) {
         boolean[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
+    }
+
+    static long[] appendLong(long[] arr, long v) {
+        long[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
         out[arr.length] = v;
         return out;
     }

--- a/tests/algorithms/x/Java/maths/special_numbers/weird_number.out
+++ b/tests/algorithms/x/Java/maths/special_numbers/weird_number.out
@@ -1,4 +1,3 @@
-Exception in thread "main" java.lang.RuntimeException: factors 12 failed
-	at Main.run_tests(Main.java:84)
-	at Main.main(Main.java:131)
-	at Main.main(Main.java:145)
+69 is not weird.
+70 is weird.
+71 is not weird.

--- a/transpiler/x/java/ALGORITHMS.md
+++ b/transpiler/x/java/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Java code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Java`.
-Last updated: 2025-08-17 13:29 GMT+7
+Last updated: 2025-08-17 14:12 GMT+7
 
 ## Algorithms Golden Test Checklist (960/1077)
 | Index | Name | Status | Duration | Memory |
@@ -685,8 +685,8 @@ Last updated: 2025-08-17 13:29 GMT+7
 | 676 | maths/special_numbers/proth_number | ✓ | 52.0ms | 77.91KB |
 | 677 | maths/special_numbers/triangular_numbers | ✓ | 21.0ms | 552B |
 | 678 | maths/special_numbers/ugly_numbers | ✓ | 22.0ms | 968B |
-| 679 | maths/special_numbers/weird_number | ✓ |  |  |
-| 680 | maths/sum_of_arithmetic_series | ✓ | 14.0ms | 552B |
+| 679 | maths/special_numbers/weird_number | ✓ | 37.0ms | 38.26KB |
+| 680 | maths/sum_of_arithmetic_series | ✓ | 32.0ms | 552B |
 | 681 | maths/sum_of_digits | ✓ | 14.0ms | 968B |
 | 682 | maths/sum_of_geometric_progression | ✓ | 32.0ms | 10.25KB |
 | 683 | maths/sum_of_harmonic_series | ✓ | 51.0ms | 56.72KB |


### PR DESCRIPTION
## Summary
- replace LongStream concat usage with append helper for long arrays in weird_number Java output
- record correct weird number output and benchmark
- update algorithms progress documentation

## Testing
- `MOCHI_ALG_INDEX=679 go test ./transpiler/x/java -run TestJavaTranspiler_Algorithms_Golden -count=1 -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_68a17f9cd4a08320bde159b1453f4dbe