### PR TITLE
kt: map ln and exp to kotlin.math

### DIFF
--- a/tests/algorithms/x/Kotlin/neural_network/activation_functions/softplus.kt
+++ b/tests/algorithms/x/Kotlin/neural_network/activation_functions/softplus.kt
@@ -36,7 +36,7 @@ fun ln(x: Double): Double {
     var sum: Double = 0.0
     var k: Int = (0).toInt()
     while (k < 10) {
-        var denom: Double = (((2 * k) + 1).toDouble())
+        var denom: Double = ((2 * k) + 1).toDouble()
         sum = sum + (term / denom)
         term = term * y2
         k = k + 1
@@ -49,7 +49,7 @@ fun exp(x: Double): Double {
     var sum: Double = 1.0
     var n: Int = (1).toInt()
     while (n < 20) {
-        term = (term * x) / ((n.toDouble()))
+        term = (term * x) / (n.toDouble())
         sum = sum + term
         n = n + 1
     }

--- a/transpiler/x/kt/ALGORITHMS.md
+++ b/transpiler/x/kt/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Kotlin code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Kotlin`.
-Last updated: 2025-08-17 13:38 GMT+7
+Last updated: 2025-08-17 14:19 GMT+7
 
 ## Algorithms Golden Test Checklist (674/1077)
 | Index | Name | Status | Duration | Memory |

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -3004,11 +3004,11 @@ func kotlinZeroValue(t types.Type) string {
 
 func guessType(e Expr) string {
 	switch v := e.(type) {
-        case *IntLit:
-                if v.Value >= 2147483647 || v.Value <= -2147483648 {
-                        return "Long"
-                }
-                return "Int"
+	case *IntLit:
+		if v.Value >= 2147483647 || v.Value <= -2147483648 {
+			return "Long"
+		}
+		return "Int"
 	case *FloatLit:
 		return "Double"
 	case *CharLit:
@@ -5644,6 +5644,22 @@ func convertPostfix(env *types.Env, p *parser.PostfixExpr) (Expr, error) {
 	expr, err := convertPrimary(env, p.Target)
 	if err != nil {
 		return nil, err
+	}
+	if v, ok := expr.(*VarRef); ok && len(p.Ops) == 1 && p.Ops[0].Call != nil {
+		args := make([]Expr, len(p.Ops[0].Call.Args))
+		for i, a := range p.Ops[0].Call.Args {
+			ex, err := convertExpr(env, a)
+			if err != nil {
+				return nil, err
+			}
+			args[i] = ex
+		}
+		switch v.Name {
+		case "ln":
+			return &CallExpr{Func: "kotlin.math.ln", Args: args}, nil
+		case "exp":
+			return &CallExpr{Func: "kotlin.math.exp", Args: args}, nil
+		}
 	}
 	baseIsMap := types.IsMapPrimary(p.Target, env)
 	if !baseIsMap {


### PR DESCRIPTION
## Summary
- call into `kotlin.math.ln` and `kotlin.math.exp` when Mochi code invokes `ln` or `exp`
- refresh Kotlin algorithms status

## Testing
- `MOCHI_ALG_INDEX=729 MOCHI_BENCHMARK=1 go test ./transpiler/x/kt -run TestKTTranspiler_Algorithms_Golden -tags slow -update-algorithms-kt`


------
https://chatgpt.com/codex/tasks/task_e_68a17ff9db208320bfe941c0bc911706