### PR TITLE
docs: add v0.10.68 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # 📦 CHANGELOG.md
 
+## [0.10.68] – 2025-08-17T08:35:51+00:00
+
+### Added
+
+* `points_are_collinear_3d` and gradient descent implementations across languages.
+* Algorithm outputs expanded for Kotlin, Ruby, F#, Pascal and Erlang through index 737.
+* Refreshed Hardy–Ramanujan, weird number and other math benchmarks.
+
+### Changed
+
+* PHP, Kotlin and Go transpilers improve numeric helpers and precision.
+* Float formatting and string indexing refined for C, C++, Lua, TypeScript and others.
+* Benchmarks updated, including Project Euler problem 71 and Go primelib.
+
+### Fixed
+
+* String index and digit cast issues in Dart, Java, C and PHP transpilers.
+* OCaml and Erlang reset state and loop handling, reducing warnings.
+* Removed stale error files and improved Python memory reporting.
+
 ## [0.10.67] – 2025-08-16T10:44:34+00:00
 
 ### Added

--- a/releases/v0.10.68.md
+++ b/releases/v0.10.68.md
@@ -1,0 +1,24 @@
+# Aug 2025 (v0.10.68)
+
+Released on Sun Aug 17 08:35:51 2025 +0000.
+
+Mochi v0.10.68 broadens algorithm coverage and sharpens numeric handling across transpilers.
+
+## Transpilers
+
+- PHP casts operands in `intdiv` and supports the `panic` builtin.
+- Kotlin maps `ln` and `exp` to `kotlin.math` and widens algorithm support.
+- Go folds `pow10` to reduce floating-point error.
+- Dart and Java refine string index and digit casts.
+- C and C++ improve float formatting and indexing safety.
+- Zig enables custom floor functions and adds collinear point detection.
+- Lua prints float decimals and streamlines iteration.
+- Scheme, Racket, and Erlang polish numeric conversions and indexing.
+
+## Algorithms
+
+- Added `points_are_collinear_3d` and gradient descent implementations.
+- Expanded algorithm outputs for Kotlin, Ruby, F#, Pascal, and Erlang through index 737.
+- Refreshed Hardy–Ramanujan, weird number, and other math benchmarks across languages.
+- Updated benchmarks including Project Euler problem 71 and Go's primelib.
+- Improved Python benchmark memory reporting and removed stale error logs.


### PR DESCRIPTION
## Summary
- document v0.10.68 release with date-based changelog
- add release notes outlining transpiler improvements and algorithm updates

## Testing
- `npm test` *(fails: Missing script "test")*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a194d439a08320bec92379ea3c3c47