### PR TITLE
Use local Clojure jar in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,3 +349,5 @@ zig-x86_64-linux-0.15.0-dev.1147+69cf40da6/
 !tests/rosetta/transpiler/OCaml/*.bench
 !tests/rosetta/transpiler/OCaml/*.out
 !tests/rosetta/transpiler/OCaml/*.error
+# Local JDK for Clojure tests
+jdk-*/

--- a/tests/algorithms/x/Clojure/matrix/binary_search_matrix.bench
+++ b/tests/algorithms/x/Clojure/matrix/binary_search_matrix.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 45522,
-  "memory_bytes": 21704552,
+  "duration_us": 73268,
+  "memory_bytes": 24678760,
   "name": "main"
 }

--- a/tests/algorithms/x/Clojure/matrix/binary_search_matrix.clj
+++ b/tests/algorithms/x/Clojure/matrix/binary_search_matrix.clj
@@ -17,6 +17,12 @@
 (defn toi [s]
   (Integer/parseInt (str s)))
 
+(defn mochi_str [v]
+  (cond (float? v) (let [s (str v)] (if (clojure.string/ends-with? s ".0") (subs s 0 (- (count s) 2)) s)) :else (str v)))
+
+(defn _fetch [url]
+  {:data [{:from "" :intensity {:actual 0 :forecast 0 :index ""} :to ""}]})
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare binary_search mat_bin_search main)
@@ -38,7 +44,7 @@
   (binding [mat_bin_search_index nil mat_bin_search_r nil] (try (do (set! mat_bin_search_index 0) (when (= (nth (nth mat_bin_search_matrix mat_bin_search_index) 0) mat_bin_search_value) (throw (ex-info "return" {:v [mat_bin_search_index 0]}))) (while (and (< mat_bin_search_index (count mat_bin_search_matrix)) (< (nth (nth mat_bin_search_matrix mat_bin_search_index) 0) mat_bin_search_value)) (do (set! mat_bin_search_r (binary_search (nth mat_bin_search_matrix mat_bin_search_index) 0 (- (count (nth mat_bin_search_matrix mat_bin_search_index)) 1) mat_bin_search_value)) (when (not= mat_bin_search_r (- 1)) (throw (ex-info "return" {:v [mat_bin_search_index mat_bin_search_r]}))) (set! mat_bin_search_index (+ mat_bin_search_index 1)))) (throw (ex-info "return" {:v [(- 1) (- 1)]}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
 
 (defn main []
-  (binding [main_matrix nil main_row nil] (do (set! main_row [1 4 7 11 15]) (println (str (binary_search main_row 0 (- (count main_row) 1) 1))) (println (str (binary_search main_row 0 (- (count main_row) 1) 23))) (set! main_matrix [[1 4 7 11 15] [2 5 8 12 19] [3 6 9 16 22] [10 13 14 17 24] [18 21 23 26 30]]) (println (str (mat_bin_search 1 main_matrix))) (println (str (mat_bin_search 34 main_matrix))))))
+  (binding [main_matrix nil main_row nil] (do (set! main_row [1 4 7 11 15]) (println (mochi_str (binary_search main_row 0 (- (count main_row) 1) 1))) (println (mochi_str (binary_search main_row 0 (- (count main_row) 1) 23))) (set! main_matrix [[1 4 7 11 15] [2 5 8 12 19] [3 6 9 16 22] [10 13 14 17 24] [18 21 23 26 30]]) (println (mochi_str (mat_bin_search 1 main_matrix))) (println (mochi_str (mat_bin_search 34 main_matrix))))))
 
 (defn -main []
   (let [rt (Runtime/getRuntime)

--- a/tests/rosetta/transpiler/Clojure/100-doors-2.clj
+++ b/tests/rosetta/transpiler/Clojure/100-doors-2.clj
@@ -2,24 +2,42 @@
 
 (require 'clojure.set)
 
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
+(defn padStart [s w p]
+  (loop [out (str s)] (if (< (count out) w) (recur (str p out)) out)))
+
+(defn indexOf [s sub]
+  (let [idx (clojure.string/index-of s sub)] (if (nil? idx) -1 idx)))
+
+(defn split [s sep]
+  (clojure.string/split s (re-pattern sep)))
+
+(defn toi [s]
+  (Integer/parseInt (str s)))
+
+(defn mochi_str [v]
+  (cond (float? v) (let [s (str v)] (if (clojure.string/ends-with? s ".0") (subs s 0 (- (count s) 2)) s)) :else (str v)))
+
+(defn _fetch [url]
+  {:data [{:from "" :intensity {:actual 0 :forecast 0 :index ""} :to ""}]})
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
-(def door 1)
+(def ^:dynamic main_current nil)
 
-(def incrementer 0)
+(def ^:dynamic main_door nil)
+
+(def ^:dynamic main_incrementer nil)
+
+(def ^:dynamic main_line nil)
+
+(def ^:dynamic main_door 1)
+
+(def ^:dynamic main_incrementer 0)
 
 (defn -main []
-  (let [rt (Runtime/getRuntime)
-    start-mem (- (.totalMemory rt) (.freeMemory rt))
-    start (System/nanoTime)]
-      (doseq [current (range 1 101)] (do (def line (str (str "Door " (str current)) " ")) (if (= current door) (do (def line (str line "Open")) (def incrementer (+ incrementer 1)) (def door (+ (+ door (* 2 incrementer)) 1))) (def line (str line "Closed"))) (println line)))
-      (System/gc)
-      (let [end (System/nanoTime)
-        end-mem (- (.totalMemory rt) (.freeMemory rt))
-        duration-us (quot (- end start) 1000)
-        memory-bytes (Math/abs ^long (- end-mem start-mem))]
-        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
-      )
-    ))
+  (doseq [main_current (range 1 101)] (do (def ^:dynamic main_line (str (str "Door " (mochi_str main_current)) " ")) (if (= main_current main_door) (do (alter-var-root (var main_line) (constantly (str main_line "Open"))) (alter-var-root (var main_incrementer) (constantly (+ main_incrementer 1))) (alter-var-root (var main_door) (constantly (+ (+ main_door (* 2 main_incrementer)) 1)))) (alter-var-root (var main_line) (constantly (str main_line "Closed")))) (println main_line))))
 
 (-main)

--- a/transpiler/x/clj/ALGORITHMS.md
+++ b/transpiler/x/clj/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated Clojure code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Clojure`.
-Last updated: 2025-08-17 13:39 GMT+7
+Last updated: 2025-08-17 14:52 GMT+7
 
-## Algorithms Golden Test Checklist (785/1077)
+## Algorithms Golden Test Checklist (788/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 50.25ms | 19.66MB |
@@ -703,29 +703,29 @@ Last updated: 2025-08-17 13:39 GMT+7
 | 694 | maths/two_sum | ✓ | 49.669ms | 19.24MB |
 | 695 | maths/volume | ✓ | 34.554ms | 27.80MB |
 | 696 | maths/zellers_congruence | error |  |  |
-| 697 | matrix/binary_search_matrix | ✓ | 45.522ms | 20.70MB |
-| 698 | matrix/count_islands_in_matrix | error | 76.836ms | 22.16MB |
+| 697 | matrix/binary_search_matrix | ✓ | 73.268ms | 23.54MB |
+| 698 | matrix/count_islands_in_matrix | error |  |  |
 | 699 | matrix/count_negative_numbers_in_sorted_matrix | ✓ | 1.952115s | 54.85MB |
 | 700 | matrix/count_paths | ✓ | 56.55ms | 21.30MB |
 | 701 | matrix/cramers_rule_2x2 | ✓ | 60.933ms | 21.03MB |
 | 702 | matrix/inverse_of_matrix | ✓ | 64.474ms | 27.05MB |
 | 703 | matrix/largest_square_area_in_matrix | ✓ | 47.372ms | 25.28MB |
-| 704 | matrix/matrix_based_game | error | 61.416ms | 30.59MB |
-| 705 | matrix/matrix_class | ✓ | 80.167ms | 1.11MB |
+| 704 | matrix/matrix_based_game | ✓ | 61.416ms | 30.59MB |
+| 705 | matrix/matrix_class | ✓ |  |  |
 | 706 | matrix/matrix_equalization | ✓ | 47.481ms | 20.64MB |
 | 707 | matrix/matrix_multiplication_recursion | ✓ | 77.995ms | 22.70MB |
 | 708 | matrix/matrix_operation | ✓ | 76.924ms | 27.25MB |
 | 709 | matrix/max_area_of_island | ✓ | 157.616ms | 21.97MB |
 | 710 | matrix/median_matrix | ✓ | 46.979ms | 21.07MB |
-| 711 | matrix/nth_fibonacci_using_matrix_exponentiation | error |  |  |
+| 711 | matrix/nth_fibonacci_using_matrix_exponentiation | ✓ |  |  |
 | 712 | matrix/pascal_triangle | ✓ | 62.931ms | 21.35MB |
 | 713 | matrix/rotate_matrix | ✓ | 51.071ms | 24.17MB |
 | 714 | matrix/searching_in_sorted_matrix | ✓ | 39.079ms | 20.56MB |
 | 715 | matrix/sherman_morrison | ✓ | 49.305ms | 26.13MB |
 | 716 | matrix/spiral_print | ✓ | 63.517ms | 22.35MB |
 | 717 | matrix/tests/test_matrix_operation | ✓ | 75.464ms | 25.25MB |
-| 718 | matrix/validate_sudoku_board | error |  |  |
-| 719 | networking_flow/ford_fulkerson | ✓ | 61.233ms | 21.89MB |
+| 718 | matrix/validate_sudoku_board | ✓ |  |  |
+| 719 | networking_flow/ford_fulkerson | ✓ |  |  |
 | 720 | networking_flow/minimum_cut | ✓ | 77.986ms | 23.97MB |
 | 721 | neural_network/activation_functions/binary_step | ✓ | 56.957ms | 19.85MB |
 | 722 | neural_network/activation_functions/exponential_linear_unit | ✓ | 63.032ms | 20.59MB |

--- a/transpiler/x/clj/README.md
+++ b/transpiler/x/clj/README.md
@@ -109,4 +109,4 @@ Compiled programs: 102/105
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
-Last updated: 2025-08-17 12:03 +0700
+Last updated: 2025-08-17 14:42 +0700

--- a/transpiler/x/clj/ROSETTA.md
+++ b/transpiler/x/clj/ROSETTA.md
@@ -1,7 +1,7 @@
 # Clojure Rosetta Transpiler
 
 Completed: 253/491
-Last updated: 2025-08-04 17:16 +0700
+Last updated: 2025-08-17 14:53 +0700
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|

--- a/transpiler/x/clj/TASKS.md
+++ b/transpiler/x/clj/TASKS.md
@@ -1,3 +1,11 @@
+## Progress (2025-08-17 14:42 +0700)
+- fix(dart): handle string digit casts
+- Regenerated golden files - 102/105 vm valid programs passing
+
+## Progress (2025-08-17 14:42 +0700)
+- fix(dart): handle string digit casts
+- Regenerated golden files - 102/105 vm valid programs passing
+
 ## Progress (2025-08-17 12:03 +0700)
 - php: regenerate hardy ramanujan algorithm output
 - Regenerated golden files - 102/105 vm valid programs passing

--- a/transpiler/x/clj/algorithms_test.go
+++ b/transpiler/x/clj/algorithms_test.go
@@ -9,7 +9,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -70,15 +69,15 @@ func runAlgorithmCase(t *testing.T, file string) {
 		t.Fatalf("write code: %v", err)
 	}
 
-        cmd := exec.Command("clojure", codePath)
+	cmd := cljCommand(codePath)
 	cmd.Env = append(os.Environ(), "MOCHI_BENCHMARK=1")
 	if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
 		cmd.Stdin = bytes.NewReader(data)
 	}
 	out, err := cmd.CombinedOutput()
-        got := bytes.TrimSpace(out)
-        warn := []byte("WARNING: Implicit use of clojure.main with options is deprecated, use -M\n")
-        got = bytes.TrimPrefix(got, warn)
+	got := bytes.TrimSpace(out)
+	warn := []byte("WARNING: Implicit use of clojure.main with options is deprecated, use -M\n")
+	got = bytes.TrimPrefix(got, warn)
 	if err != nil {
 		if algUpdateEnabled() {
 			_ = os.WriteFile(errPath, append([]byte("run: "+err.Error()+"\n"), out...), 0o644)

--- a/transpiler/x/clj/rosetta_test.go
+++ b/transpiler/x/clj/rosetta_test.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -93,7 +92,7 @@ func compileRunClojureRosetta(t *testing.T, srcPath, outDir, name string) {
 	if err := os.WriteFile(cljPath, code, 0o644); err != nil {
 		t.Fatalf("write clj: %v", err)
 	}
-	cmd := exec.Command("clojure", cljPath)
+	cmd := cljCommand(cljPath)
 	cmd.Env = append(os.Environ(), "MOCHI_NOW_SEED=1")
 	if data, err := os.ReadFile(strings.TrimSuffix(srcPath, ".mochi") + ".in"); err == nil {
 		cmd.Stdin = bytes.NewReader(data)

--- a/transpiler/x/clj/transpiler.go
+++ b/transpiler/x/clj/transpiler.go
@@ -1763,7 +1763,10 @@ func applyBinOp(op string, left, right Node) Node {
 		inter := &List{Elems: []Node{Symbol("clojure.set/intersection"), &List{Elems: []Node{Symbol("set"), left}}, &List{Elems: []Node{Symbol("set"), right}}}}
 		return &List{Elems: []Node{Symbol("vec"), inter}}
 	case "/":
-		if isIntNode(left) && isIntNode(right) {
+		// Clojure's `/` yields rational numbers when both operands are
+		// integers, whereas Mochi uses truncating integer division in
+		// that case. Use `quot` unless either operand is a float.
+		if !isFloatNode(left) && !isFloatNode(right) {
 			return &List{Elems: []Node{Symbol("quot"), left, right}}
 		}
 		return &List{Elems: []Node{Symbol(sym), left, right}}


### PR DESCRIPTION
## Summary
- Run Clojure test programs via `java` using locally downloaded jars
- Add helper to construct Clojure command and ensure required jars exist
- Handle integer division using `quot` when no operands are floats
- Add ignore rule for local JDK artifacts

## Testing
- `MOCHI_ALG_INDEX=697 go test -tags=slow ./transpiler/x/clj -run TestClojureTranspiler_Algorithms_Golden -count=1 -v`
- `MOCHI_ROSETTA_INDEX=1 go test -tags=slow ./transpiler/x/clj -run TestRosettaClojure -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_68a1870e14a48320abfe240cd1247b63