### PR TITLE
fix(java): handle slices and inference

### DIFF
--- a/tests/algorithms/x/Java/maths/tanh.bench
+++ b/tests/algorithms/x/Java/maths/tanh.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 49080,
-  "memory_bytes": 58184,
-  "name": "main"
-}
+{"duration_us": 22554, "memory_bytes": 10704, "name": "main"}

--- a/tests/algorithms/x/Java/maths/tanh.java
+++ b/tests/algorithms/x/Java/maths/tanh.java
@@ -2,42 +2,42 @@ public class Main {
 
     static double expApprox(double x) {
         boolean neg = false;
-        double y = x;
-        if (x < 0.0) {
+        double y_1 = (double)(x);
+        if ((double)(x) < (double)(0.0)) {
             neg = true;
-            y = -x;
+            y_1 = (double)(-x);
         }
-        double term = 1.0;
-        double sum = 1.0;
-        int n = 1;
-        while (n < 30) {
-            term = term * y / (((Number)(n)).doubleValue());
-            sum = sum + term;
-            n = n + 1;
+        double term_1 = (double)(1.0);
+        double sum_1 = (double)(1.0);
+        long n_1 = 1L;
+        while ((long)(n_1) < 30L) {
+            term_1 = (double)((double)((double)(term_1) * (double)(y_1)) / (double)((((Number)(n_1)).doubleValue())));
+            sum_1 = (double)((double)(sum_1) + (double)(term_1));
+            n_1 = (long)((long)(n_1) + 1L);
         }
         if (neg) {
-            return 1.0 / sum;
+            return (double)(1.0) / (double)(sum_1);
         }
-        return sum;
+        return sum_1;
     }
 
     static double[] tangent_hyperbolic(double[] vector) {
         double[] result = ((double[])(new double[]{}));
-        int i = 0;
-        while (i < vector.length) {
-            double x = vector[i];
-            double t = (2.0 / (1.0 + expApprox(-2.0 * x))) - 1.0;
-            result = ((double[])(java.util.stream.DoubleStream.concat(java.util.Arrays.stream(result), java.util.stream.DoubleStream.of(t)).toArray()));
-            i = i + 1;
+        long i_1 = 0L;
+        while ((long)(i_1) < (long)(vector.length)) {
+            double x_1 = (double)(vector[(int)((long)(i_1))]);
+            double t_1 = (double)((double)(((double)(2.0) / (double)(((double)(1.0) + (double)(expApprox((double)((double)(-2.0) * (double)(x_1)))))))) - (double)(1.0));
+            result = ((double[])(appendDouble(result, (double)(t_1))));
+            i_1 = (long)((long)(i_1) + 1L);
         }
         return result;
     }
 
     static void main() {
         double[] v1 = ((double[])(new double[]{1.0, 5.0, 6.0, -0.67}));
-        double[] v2 = ((double[])(new double[]{8.0, 10.0, 2.0, -0.98, 13.0}));
+        double[] v2_1 = ((double[])(new double[]{8.0, 10.0, 2.0, -0.98, 13.0}));
         System.out.println(_p(tangent_hyperbolic(((double[])(v1)))));
-        System.out.println(_p(tangent_hyperbolic(((double[])(v2)))));
+        System.out.println(_p(tangent_hyperbolic(((double[])(v2_1)))));
     }
     public static void main(String[] args) {
         {
@@ -46,11 +46,7 @@ public class Main {
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -77,6 +73,12 @@ public class Main {
         return rt.totalMemory() - rt.freeMemory();
     }
 
+    static double[] appendDouble(double[] arr, double v) {
+        double[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
+    }
+
     static String _p(Object v) {
         if (v == null) return "<nil>";
         if (v.getClass().isArray()) {
@@ -89,6 +91,10 @@ public class Main {
             if (v instanceof short[]) return java.util.Arrays.toString((short[]) v);
             if (v instanceof float[]) return java.util.Arrays.toString((float[]) v);
             return java.util.Arrays.deepToString((Object[]) v);
+        }
+        if (v instanceof Double || v instanceof Float) {
+            double d = ((Number) v).doubleValue();
+            return String.valueOf(d);
         }
         return String.valueOf(v);
     }

--- a/tests/algorithms/x/Java/maths/test_factorial.bench
+++ b/tests/algorithms/x/Java/maths/test_factorial.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 25464,
-  "memory_bytes": 448,
-  "name": "main"
-}
+{"duration_us": 23327, "memory_bytes": 448, "name": "main"}

--- a/tests/algorithms/x/Java/maths/test_factorial.java
+++ b/tests/algorithms/x/Java/maths/test_factorial.java
@@ -1,63 +1,63 @@
 public class Main {
 
-    static int factorial(int n) {
-        if (n < 0) {
+    static long factorial(long n) {
+        if ((long)(n) < 0L) {
             throw new RuntimeException(String.valueOf("factorial() not defined for negative values"));
         }
-        int value = 1;
-        int i = 1;
-        while (i <= n) {
-            value = value * i;
-            i = i + 1;
+        long value_1 = 1L;
+        long i_1 = 1L;
+        while ((long)(i_1) <= (long)(n)) {
+            value_1 = (long)((long)(value_1) * (long)(i_1));
+            i_1 = (long)((long)(i_1) + 1L);
         }
-        return value;
+        return value_1;
     }
 
-    static int factorial_recursive(int n) {
-        if (n < 0) {
+    static long factorial_recursive(long n) {
+        if ((long)(n) < 0L) {
             throw new RuntimeException(String.valueOf("factorial() not defined for negative values"));
         }
-        if (n <= 1) {
+        if ((long)(n) <= 1L) {
             return 1;
         }
-        return n * factorial_recursive(n - 1);
+        return (long)(n) * (long)(factorial_recursive((long)((long)(n) - 1L)));
     }
 
     static void test_zero() {
-        if (factorial(0) != 1) {
+        if ((long)(factorial(0L)) != 1L) {
             throw new RuntimeException(String.valueOf("factorial(0) failed"));
         }
-        if (factorial_recursive(0) != 1) {
+        if ((long)(factorial_recursive(0L)) != 1L) {
             throw new RuntimeException(String.valueOf("factorial_recursive(0) failed"));
         }
     }
 
     static void test_positive_integers() {
-        if (factorial(1) != 1) {
+        if ((long)(factorial(1L)) != 1L) {
             throw new RuntimeException(String.valueOf("factorial(1) failed"));
         }
-        if (factorial_recursive(1) != 1) {
+        if ((long)(factorial_recursive(1L)) != 1L) {
             throw new RuntimeException(String.valueOf("factorial_recursive(1) failed"));
         }
-        if (factorial(5) != 120) {
+        if ((long)(factorial(5L)) != 120L) {
             throw new RuntimeException(String.valueOf("factorial(5) failed"));
         }
-        if (factorial_recursive(5) != 120) {
+        if ((long)(factorial_recursive(5L)) != 120L) {
             throw new RuntimeException(String.valueOf("factorial_recursive(5) failed"));
         }
-        if (factorial(7) != 5040) {
+        if ((long)(factorial(7L)) != 5040L) {
             throw new RuntimeException(String.valueOf("factorial(7) failed"));
         }
-        if (factorial_recursive(7) != 5040) {
+        if ((long)(factorial_recursive(7L)) != 5040L) {
             throw new RuntimeException(String.valueOf("factorial_recursive(7) failed"));
         }
     }
 
     static void test_large_number() {
-        if (factorial(10) != 3628800) {
+        if ((long)(factorial(10L)) != 3628800L) {
             throw new RuntimeException(String.valueOf("factorial(10) failed"));
         }
-        if (factorial_recursive(10) != 3628800) {
+        if ((long)(factorial_recursive(10L)) != 3628800L) {
             throw new RuntimeException(String.valueOf("factorial_recursive(10) failed"));
         }
     }
@@ -70,7 +70,7 @@ public class Main {
 
     static void main() {
         run_tests();
-        System.out.println(factorial(6));
+        System.out.println(factorial(6L));
     }
     public static void main(String[] args) {
         {
@@ -79,11 +79,7 @@ public class Main {
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/maths/test_prime_check.bench
+++ b/tests/algorithms/x/Java/maths/test_prime_check.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 30135,
-  "memory_bytes": 768,
-  "name": "main"
-}
+{"duration_us": 30260, "memory_bytes": 976, "name": "main"}

--- a/tests/algorithms/x/Java/maths/test_prime_check.java
+++ b/tests/algorithms/x/Java/maths/test_prime_check.java
@@ -1,24 +1,24 @@
 public class Main {
 
-    static boolean is_prime(int number) {
-        if (number < 0) {
+    static boolean is_prime(long number) {
+        if ((long)(number) < 0L) {
             throw new RuntimeException(String.valueOf("is_prime() only accepts positive integers"));
         }
-        if (number < 2) {
+        if ((long)(number) < 2L) {
             return false;
         }
-        if (number < 4) {
+        if ((long)(number) < 4L) {
             return true;
         }
-        if (Math.floorMod(number, 2) == 0 || Math.floorMod(number, 3) == 0) {
+        if (Math.floorMod(number, 2) == 0L || Math.floorMod(number, 3) == 0L) {
             return false;
         }
-        int i = 5;
-        while (i * i <= number) {
-            if (Math.floorMod(number, i) == 0 || Math.floorMod(number, (i + 2)) == 0) {
+        long i_1 = 5L;
+        while ((long)((long)(i_1) * (long)(i_1)) <= (long)(number)) {
+            if (Math.floorMod(number, i_1) == 0L || Math.floorMod(number, ((long)(i_1) + 2L)) == 0L) {
                 return false;
             }
-            i = i + 6;
+            i_1 = (long)((long)(i_1) + 6L);
         }
         return true;
     }
@@ -26,30 +26,26 @@ public class Main {
         {
             long _benchStart = _now();
             long _benchMem = _mem();
-            System.out.println(_p(is_prime(2)));
-            System.out.println(_p(is_prime(3)));
-            System.out.println(_p(is_prime(5)));
-            System.out.println(_p(is_prime(7)));
-            System.out.println(_p(is_prime(11)));
-            System.out.println(_p(is_prime(13)));
-            System.out.println(_p(is_prime(17)));
-            System.out.println(_p(is_prime(19)));
-            System.out.println(_p(is_prime(23)));
-            System.out.println(_p(is_prime(29)));
-            System.out.println(_p(is_prime(0)));
-            System.out.println(_p(is_prime(1)));
-            System.out.println(_p(is_prime(4)));
-            System.out.println(_p(is_prime(6)));
-            System.out.println(_p(is_prime(9)));
-            System.out.println(_p(is_prime(15)));
-            System.out.println(_p(is_prime(105)));
+            System.out.println(_p(is_prime(2L)));
+            System.out.println(_p(is_prime(3L)));
+            System.out.println(_p(is_prime(5L)));
+            System.out.println(_p(is_prime(7L)));
+            System.out.println(_p(is_prime(11L)));
+            System.out.println(_p(is_prime(13L)));
+            System.out.println(_p(is_prime(17L)));
+            System.out.println(_p(is_prime(19L)));
+            System.out.println(_p(is_prime(23L)));
+            System.out.println(_p(is_prime(29L)));
+            System.out.println(_p(is_prime(0L)));
+            System.out.println(_p(is_prime(1L)));
+            System.out.println(_p(is_prime(4L)));
+            System.out.println(_p(is_prime(6L)));
+            System.out.println(_p(is_prime(9L)));
+            System.out.println(_p(is_prime(15L)));
+            System.out.println(_p(is_prime(105L)));
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -88,6 +84,10 @@ public class Main {
             if (v instanceof short[]) return java.util.Arrays.toString((short[]) v);
             if (v instanceof float[]) return java.util.Arrays.toString((float[]) v);
             return java.util.Arrays.deepToString((Object[]) v);
+        }
+        if (v instanceof Double || v instanceof Float) {
+            double d = ((Number) v).doubleValue();
+            return String.valueOf(d);
         }
         return String.valueOf(v);
     }

--- a/tests/algorithms/x/Java/maths/three_sum.bench
+++ b/tests/algorithms/x/Java/maths/three_sum.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 31369,
-  "memory_bytes": 656,
-  "name": "main"
-}
+{"duration_us": 43822, "memory_bytes": 46552, "name": "main"}

--- a/tests/algorithms/x/Java/maths/three_sum.java
+++ b/tests/algorithms/x/Java/maths/three_sum.java
@@ -1,71 +1,67 @@
 public class Main {
 
-    static int[] bubble_sort(int[] nums) {
-        int[] arr = ((int[])(nums));
-        int n = arr.length;
-        int i = 0;
-        while (i < n) {
-            int j = 0;
-            while (j < n - 1) {
-                if (arr[j] > arr[j + 1]) {
-                    int temp = arr[j];
-arr[j] = arr[j + 1];
-arr[j + 1] = temp;
+    static long[] bubble_sort(long[] nums) {
+        long[] arr = ((long[])(nums));
+        long n_1 = (long)(arr.length);
+        long i_1 = 0L;
+        while ((long)(i_1) < (long)(n_1)) {
+            long j_1 = 0L;
+            while ((long)(j_1) < (long)((long)(n_1) - 1L)) {
+                if ((long)(arr[(int)((long)(j_1))]) > (long)(arr[(int)((long)((long)(j_1) + 1L))])) {
+                    long temp_1 = (long)(arr[(int)((long)(j_1))]);
+arr[(int)((long)(j_1))] = (long)(arr[(int)((long)((long)(j_1) + 1L))]);
+arr[(int)((long)((long)(j_1) + 1L))] = (long)(temp_1);
                 }
-                j = j + 1;
+                j_1 = (long)((long)(j_1) + 1L);
             }
-            i = i + 1;
+            i_1 = (long)((long)(i_1) + 1L);
         }
         return arr;
     }
 
-    static int[][] three_sum(int[] nums) {
-        int[] sorted = ((int[])(bubble_sort(((int[])(nums)))));
-        int[][] res = ((int[][])(new int[][]{}));
-        int n_1 = sorted.length;
-        int i_1 = 0;
-        while (i_1 < n_1 - 2) {
-            if (i_1 == 0 || sorted[i_1] != sorted[i_1 - 1]) {
-                int low = i_1 + 1;
-                int high = n_1 - 1;
-                int c = 0 - sorted[i_1];
-                while (low < high) {
-                    int s = sorted[low] + sorted[high];
-                    if (s == c) {
-                        int[] triple = ((int[])(new int[]{sorted[i_1], sorted[low], sorted[high]}));
-                        res = ((int[][])(appendObj(res, triple)));
-                        while (low < high && sorted[low] == sorted[low + 1]) {
-                            low = low + 1;
+    static long[][] three_sum(long[] nums) {
+        long[] sorted = ((long[])(bubble_sort(((long[])(nums)))));
+        long[][] res_1 = ((long[][])(new long[][]{}));
+        long n_3 = (long)(sorted.length);
+        long i_3 = 0L;
+        while ((long)(i_3) < (long)((long)(n_3) - 2L)) {
+            if ((long)(i_3) == 0L || (long)(sorted[(int)((long)(i_3))]) != (long)(sorted[(int)((long)((long)(i_3) - 1L))])) {
+                long low_1 = (long)((long)(i_3) + 1L);
+                long high_1 = (long)((long)(n_3) - 1L);
+                long c_1 = (long)(0L - (long)(sorted[(int)((long)(i_3))]));
+                while ((long)(low_1) < (long)(high_1)) {
+                    long s_1 = (long)((long)(sorted[(int)((long)(low_1))]) + (long)(sorted[(int)((long)(high_1))]));
+                    if ((long)(s_1) == (long)(c_1)) {
+                        long[] triple_1 = ((long[])(new long[]{sorted[(int)((long)(i_3))], sorted[(int)((long)(low_1))], sorted[(int)((long)(high_1))]}));
+                        res_1 = ((long[][])(java.util.stream.Stream.concat(java.util.Arrays.stream(res_1), java.util.stream.Stream.of(new long[][]{triple_1})).toArray(long[][]::new)));
+                        while ((long)(low_1) < (long)(high_1) && (long)(sorted[(int)((long)(low_1))]) == (long)(sorted[(int)((long)((long)(low_1) + 1L))])) {
+                            low_1 = (long)((long)(low_1) + 1L);
                         }
-                        while (low < high && sorted[high] == sorted[high - 1]) {
-                            high = high - 1;
+                        while ((long)(low_1) < (long)(high_1) && (long)(sorted[(int)((long)(high_1))]) == (long)(sorted[(int)((long)((long)(high_1) - 1L))])) {
+                            high_1 = (long)((long)(high_1) - 1L);
                         }
-                        low = low + 1;
-                        high = high - 1;
-                    } else                     if (s < c) {
-                        low = low + 1;
+                        low_1 = (long)((long)(low_1) + 1L);
+                        high_1 = (long)((long)(high_1) - 1L);
+                    } else                     if ((long)(s_1) < (long)(c_1)) {
+                        low_1 = (long)((long)(low_1) + 1L);
                     } else {
-                        high = high - 1;
+                        high_1 = (long)((long)(high_1) - 1L);
                     }
                 }
             }
-            i_1 = i_1 + 1;
+            i_3 = (long)((long)(i_3) + 1L);
         }
-        return res;
+        return res_1;
     }
     public static void main(String[] args) {
         {
             long _benchStart = _now();
             long _benchMem = _mem();
-            System.out.println(_p(three_sum(((int[])(new int[]{-1, 0, 1, 2, -1, -4})))));
-            System.out.println(_p(three_sum(((int[])(new int[]{1, 2, 3, 4})))));
+            System.out.println(_p(three_sum(((long[])(new long[]{-1, 0, 1, 2, -1, -4})))));
+            System.out.println(_p(three_sum(((long[])(new long[]{1, 2, 3, 4})))));
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -92,12 +88,6 @@ arr[j + 1] = temp;
         return rt.totalMemory() - rt.freeMemory();
     }
 
-    static <T> T[] appendObj(T[] arr, T v) {
-        T[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
-        out[arr.length] = v;
-        return out;
-    }
-
     static String _p(Object v) {
         if (v == null) return "<nil>";
         if (v.getClass().isArray()) {
@@ -110,6 +100,10 @@ arr[j + 1] = temp;
             if (v instanceof short[]) return java.util.Arrays.toString((short[]) v);
             if (v instanceof float[]) return java.util.Arrays.toString((float[]) v);
             return java.util.Arrays.deepToString((Object[]) v);
+        }
+        if (v instanceof Double || v instanceof Float) {
+            double d = ((Number) v).doubleValue();
+            return String.valueOf(d);
         }
         return String.valueOf(v);
     }

--- a/tests/algorithms/x/Java/maths/trapezoidal_rule.bench
+++ b/tests/algorithms/x/Java/maths/trapezoidal_rule.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 50169,
-  "memory_bytes": 66160,
-  "name": "main"
-}
+{"duration_us": 39081, "memory_bytes": 48664, "name": "main"}

--- a/tests/algorithms/x/Java/maths/trapezoidal_rule.java
+++ b/tests/algorithms/x/Java/maths/trapezoidal_rule.java
@@ -1,55 +1,47 @@
 public class Main {
-    static double a_1;
-    static double b_1;
-    static double steps;
-    static double[] boundary;
-    static double y_1;
+    static double a_2 = (double)(0.0);
+    static double b_2 = (double)(1.0);
+    static double steps = (double)(10.0);
+    static double[] boundary = ((double[])(new double[]{a_2, b_2}));
+    static double y_2;
 
     static double f(double x) {
-        return x * x;
+        return (double)(x) * (double)(x);
     }
 
     static double[] make_points(double a, double b, double h) {
         double[] xs = ((double[])(new double[]{}));
-        double x = a + h;
-        while (x <= (b - h)) {
-            xs = ((double[])(java.util.stream.DoubleStream.concat(java.util.Arrays.stream(xs), java.util.stream.DoubleStream.of(x)).toArray()));
-            x = x + h;
+        double x_1 = (double)((double)(a) + (double)(h));
+        while ((double)(x_1) <= (double)(((double)(b) - (double)(h)))) {
+            xs = ((double[])(appendDouble(xs, (double)(x_1))));
+            x_1 = (double)((double)(x_1) + (double)(h));
         }
         return xs;
     }
 
     static double trapezoidal_rule(double[] boundary, double steps) {
-        double h = (boundary[1] - boundary[0]) / steps;
-        double a = boundary[0];
-        double b = boundary[1];
-        double[] xs_1 = ((double[])(make_points(a, b, h)));
-        double y = (h / 2.0) * f(a);
-        int i = 0;
-        while (i < xs_1.length) {
-            y = y + h * f(xs_1[i]);
-            i = i + 1;
+        double h = (double)((double)(((double)(boundary[(int)(1L)]) - (double)(boundary[(int)(0L)]))) / (double)(steps));
+        double a_1 = (double)(boundary[(int)(0L)]);
+        double b_1 = (double)(boundary[(int)(1L)]);
+        double[] xs_2 = ((double[])(make_points((double)(a_1), (double)(b_1), (double)(h))));
+        double y_1 = (double)((double)(((double)(h) / (double)(2.0))) * (double)(f((double)(a_1))));
+        long i_1 = 0L;
+        while ((long)(i_1) < (long)(xs_2.length)) {
+            y_1 = (double)((double)(y_1) + (double)((double)(h) * (double)(f((double)(xs_2[(int)((long)(i_1))])))));
+            i_1 = (long)((long)(i_1) + 1L);
         }
-        y = y + (h / 2.0) * f(b);
-        return y;
+        y_1 = (double)((double)(y_1) + (double)((double)(((double)(h) / (double)(2.0))) * (double)(f((double)(b_1)))));
+        return y_1;
     }
     public static void main(String[] args) {
         {
             long _benchStart = _now();
             long _benchMem = _mem();
-            a_1 = 0.0;
-            b_1 = 1.0;
-            steps = 10.0;
-            boundary = ((double[])(new double[]{a_1, b_1}));
-            y_1 = trapezoidal_rule(((double[])(boundary)), steps);
-            System.out.println("y = " + _p(y_1));
+            y_2 = (double)(trapezoidal_rule(((double[])(boundary)), (double)(steps)));
+            System.out.println("y = " + _p(y_2));
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -76,6 +68,12 @@ public class Main {
         return rt.totalMemory() - rt.freeMemory();
     }
 
+    static double[] appendDouble(double[] arr, double v) {
+        double[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
+    }
+
     static String _p(Object v) {
         if (v == null) return "<nil>";
         if (v.getClass().isArray()) {
@@ -88,6 +86,10 @@ public class Main {
             if (v instanceof short[]) return java.util.Arrays.toString((short[]) v);
             if (v instanceof float[]) return java.util.Arrays.toString((float[]) v);
             return java.util.Arrays.deepToString((Object[]) v);
+        }
+        if (v instanceof Double || v instanceof Float) {
+            double d = ((Number) v).doubleValue();
+            return String.valueOf(d);
         }
         return String.valueOf(v);
     }

--- a/tests/algorithms/x/Java/maths/triplet_sum.bench
+++ b/tests/algorithms/x/Java/maths/triplet_sum.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 77722,
-  "memory_bytes": 101880,
-  "name": "main"
-}
+{"duration_us": 54143, "memory_bytes": 86512, "name": "main"}

--- a/tests/algorithms/x/Java/maths/triplet_sum.java
+++ b/tests/algorithms/x/Java/maths/triplet_sum.java
@@ -1,138 +1,138 @@
 public class Main {
 
-    static int[] bubble_sort(int[] nums) {
-        int[] arr = ((int[])(new int[]{}));
-        int i = 0;
-        while (i < nums.length) {
-            arr = ((int[])(java.util.stream.IntStream.concat(java.util.Arrays.stream(arr), java.util.stream.IntStream.of(nums[i])).toArray()));
-            i = i + 1;
+    static long[] bubble_sort(long[] nums) {
+        long[] arr = ((long[])(new long[]{}));
+        long i_1 = 0L;
+        while ((long)(i_1) < (long)(nums.length)) {
+            arr = ((long[])(appendLong(arr, (long)(nums[(int)((long)(i_1))]))));
+            i_1 = (long)((long)(i_1) + 1L);
         }
-        int n = arr.length;
-        int a = 0;
-        while (a < n) {
-            int b = 0;
-            while (b < n - a - 1) {
-                if (arr[b] > arr[b + 1]) {
-                    int tmp = arr[b];
-arr[b] = arr[b + 1];
-arr[b + 1] = tmp;
+        long n_1 = (long)(arr.length);
+        long a_1 = 0L;
+        while ((long)(a_1) < (long)(n_1)) {
+            long b_1 = 0L;
+            while ((long)(b_1) < (long)((long)((long)(n_1) - (long)(a_1)) - 1L)) {
+                if ((long)(arr[(int)((long)(b_1))]) > (long)(arr[(int)((long)((long)(b_1) + 1L))])) {
+                    long tmp_1 = (long)(arr[(int)((long)(b_1))]);
+arr[(int)((long)(b_1))] = (long)(arr[(int)((long)((long)(b_1) + 1L))]);
+arr[(int)((long)((long)(b_1) + 1L))] = (long)(tmp_1);
                 }
-                b = b + 1;
+                b_1 = (long)((long)(b_1) + 1L);
             }
-            a = a + 1;
+            a_1 = (long)((long)(a_1) + 1L);
         }
         return arr;
     }
 
-    static int[] sort3(int[] xs) {
-        int[] arr_1 = ((int[])(new int[]{}));
-        int i_1 = 0;
-        while (i_1 < xs.length) {
-            arr_1 = ((int[])(java.util.stream.IntStream.concat(java.util.Arrays.stream(arr_1), java.util.stream.IntStream.of(xs[i_1])).toArray()));
-            i_1 = i_1 + 1;
+    static long[] sort3(long[] xs) {
+        long[] arr_1 = ((long[])(new long[]{}));
+        long i_3 = 0L;
+        while ((long)(i_3) < (long)(xs.length)) {
+            arr_1 = ((long[])(appendLong(arr_1, (long)(xs[(int)((long)(i_3))]))));
+            i_3 = (long)((long)(i_3) + 1L);
         }
-        int n_1 = arr_1.length;
-        int a_1 = 0;
-        while (a_1 < n_1) {
-            int b_1 = 0;
-            while (b_1 < n_1 - a_1 - 1) {
-                if (arr_1[b_1] > arr_1[b_1 + 1]) {
-                    int tmp_1 = arr_1[b_1];
-arr_1[b_1] = arr_1[b_1 + 1];
-arr_1[b_1 + 1] = tmp_1;
+        long n_3 = (long)(arr_1.length);
+        long a_3 = 0L;
+        while ((long)(a_3) < (long)(n_3)) {
+            long b_3 = 0L;
+            while ((long)(b_3) < (long)((long)((long)(n_3) - (long)(a_3)) - 1L)) {
+                if ((long)(arr_1[(int)((long)(b_3))]) > (long)(arr_1[(int)((long)((long)(b_3) + 1L))])) {
+                    long tmp_3 = (long)(arr_1[(int)((long)(b_3))]);
+arr_1[(int)((long)(b_3))] = (long)(arr_1[(int)((long)((long)(b_3) + 1L))]);
+arr_1[(int)((long)((long)(b_3) + 1L))] = (long)(tmp_3);
                 }
-                b_1 = b_1 + 1;
+                b_3 = (long)((long)(b_3) + 1L);
             }
-            a_1 = a_1 + 1;
+            a_3 = (long)((long)(a_3) + 1L);
         }
         return arr_1;
     }
 
-    static int[] triplet_sum1(int[] arr, int target) {
-        int i_2 = 0;
-        while (i_2 < arr.length - 2) {
-            int j = i_2 + 1;
-            while (j < arr.length - 1) {
-                int k = j + 1;
-                while (k < arr.length) {
-                    if (arr[i_2] + arr[j] + arr[k] == target) {
-                        return sort3(((int[])(new int[]{arr[i_2], arr[j], arr[k]})));
+    static long[] triplet_sum1(long[] arr, long target) {
+        long i_4 = 0L;
+        while ((long)(i_4) < (long)((long)(arr.length) - 2L)) {
+            long j_1 = (long)((long)(i_4) + 1L);
+            while ((long)(j_1) < (long)((long)(arr.length) - 1L)) {
+                long k_1 = (long)((long)(j_1) + 1L);
+                while ((long)(k_1) < (long)(arr.length)) {
+                    if ((long)((long)((long)(arr[(int)((long)(i_4))]) + (long)(arr[(int)((long)(j_1))])) + (long)(arr[(int)((long)(k_1))])) == (long)(target)) {
+                        return sort3(((long[])(new long[]{arr[(int)((long)(i_4))], arr[(int)((long)(j_1))], arr[(int)((long)(k_1))]})));
                     }
-                    k = k + 1;
+                    k_1 = (long)((long)(k_1) + 1L);
                 }
-                j = j + 1;
+                j_1 = (long)((long)(j_1) + 1L);
             }
-            i_2 = i_2 + 1;
+            i_4 = (long)((long)(i_4) + 1L);
         }
-        return new int[]{0, 0, 0};
+        return new long[]{0, 0, 0};
     }
 
-    static int[] triplet_sum2(int[] arr, int target) {
-        int[] sorted = ((int[])(bubble_sort(((int[])(arr)))));
-        int n_2 = sorted.length;
-        int i_3 = 0;
-        while (i_3 < n_2 - 2) {
-            int left = i_3 + 1;
-            int right = n_2 - 1;
-            while (left < right) {
-                int s = sorted[i_3] + sorted[left] + sorted[right];
-                if (s == target) {
-                    return new int[]{sorted[i_3], sorted[left], sorted[right]};
+    static long[] triplet_sum2(long[] arr, long target) {
+        long[] sorted = ((long[])(bubble_sort(((long[])(arr)))));
+        long n_5 = (long)(sorted.length);
+        long i_6 = 0L;
+        while ((long)(i_6) < (long)((long)(n_5) - 2L)) {
+            long left_1 = (long)((long)(i_6) + 1L);
+            long right_1 = (long)((long)(n_5) - 1L);
+            while ((long)(left_1) < (long)(right_1)) {
+                long s_1 = (long)((long)((long)(sorted[(int)((long)(i_6))]) + (long)(sorted[(int)((long)(left_1))])) + (long)(sorted[(int)((long)(right_1))]));
+                if ((long)(s_1) == (long)(target)) {
+                    return new long[]{sorted[(int)((long)(i_6))], sorted[(int)((long)(left_1))], sorted[(int)((long)(right_1))]};
                 }
-                if (s < target) {
-                    left = left + 1;
+                if ((long)(s_1) < (long)(target)) {
+                    left_1 = (long)((long)(left_1) + 1L);
                 } else {
-                    right = right - 1;
+                    right_1 = (long)((long)(right_1) - 1L);
                 }
             }
-            i_3 = i_3 + 1;
+            i_6 = (long)((long)(i_6) + 1L);
         }
-        return new int[]{0, 0, 0};
+        return new long[]{0, 0, 0};
     }
 
-    static boolean list_equal(int[] a, int[] b) {
-        if (a.length != b.length) {
+    static boolean list_equal(long[] a, long[] b) {
+        if ((long)(a.length) != (long)(b.length)) {
             return false;
         }
-        int i_4 = 0;
-        while (i_4 < a.length) {
-            if (a[i_4] != b[i_4]) {
+        long i_8 = 0L;
+        while ((long)(i_8) < (long)(a.length)) {
+            if ((long)(a[(int)((long)(i_8))]) != (long)(b[(int)((long)(i_8))])) {
                 return false;
             }
-            i_4 = i_4 + 1;
+            i_8 = (long)((long)(i_8) + 1L);
         }
         return true;
     }
 
     static void test_triplet_sum() {
-        int[] arr1 = ((int[])(new int[]{13, 29, 7, 23, 5}));
-        if (!(Boolean)list_equal(((int[])(triplet_sum1(((int[])(arr1)), 35))), ((int[])(new int[]{5, 7, 23})))) {
+        long[] arr1 = ((long[])(new long[]{13, 29, 7, 23, 5}));
+        if (!(Boolean)list_equal(((long[])(triplet_sum1(((long[])(arr1)), 35L))), ((long[])(new long[]{5, 7, 23})))) {
             throw new RuntimeException(String.valueOf("ts1 case1 failed"));
         }
-        if (!(Boolean)list_equal(((int[])(triplet_sum2(((int[])(arr1)), 35))), ((int[])(new int[]{5, 7, 23})))) {
+        if (!(Boolean)list_equal(((long[])(triplet_sum2(((long[])(arr1)), 35L))), ((long[])(new long[]{5, 7, 23})))) {
             throw new RuntimeException(String.valueOf("ts2 case1 failed"));
         }
-        int[] arr2 = ((int[])(new int[]{37, 9, 19, 50, 44}));
-        if (!(Boolean)list_equal(((int[])(triplet_sum1(((int[])(arr2)), 65))), ((int[])(new int[]{9, 19, 37})))) {
+        long[] arr2_1 = ((long[])(new long[]{37, 9, 19, 50, 44}));
+        if (!(Boolean)list_equal(((long[])(triplet_sum1(((long[])(arr2_1)), 65L))), ((long[])(new long[]{9, 19, 37})))) {
             throw new RuntimeException(String.valueOf("ts1 case2 failed"));
         }
-        if (!(Boolean)list_equal(((int[])(triplet_sum2(((int[])(arr2)), 65))), ((int[])(new int[]{9, 19, 37})))) {
+        if (!(Boolean)list_equal(((long[])(triplet_sum2(((long[])(arr2_1)), 65L))), ((long[])(new long[]{9, 19, 37})))) {
             throw new RuntimeException(String.valueOf("ts2 case2 failed"));
         }
-        int[] arr3 = ((int[])(new int[]{6, 47, 27, 1, 15}));
-        if (!(Boolean)list_equal(((int[])(triplet_sum1(((int[])(arr3)), 11))), ((int[])(new int[]{0, 0, 0})))) {
+        long[] arr3_1 = ((long[])(new long[]{6, 47, 27, 1, 15}));
+        if (!(Boolean)list_equal(((long[])(triplet_sum1(((long[])(arr3_1)), 11L))), ((long[])(new long[]{0, 0, 0})))) {
             throw new RuntimeException(String.valueOf("ts1 case3 failed"));
         }
-        if (!(Boolean)list_equal(((int[])(triplet_sum2(((int[])(arr3)), 11))), ((int[])(new int[]{0, 0, 0})))) {
+        if (!(Boolean)list_equal(((long[])(triplet_sum2(((long[])(arr3_1)), 11L))), ((long[])(new long[]{0, 0, 0})))) {
             throw new RuntimeException(String.valueOf("ts2 case3 failed"));
         }
     }
 
     static void main() {
         test_triplet_sum();
-        int[] sample = ((int[])(new int[]{13, 29, 7, 23, 5}));
-        int[] res = ((int[])(triplet_sum2(((int[])(sample)), 35)));
-        System.out.println(_p(_geti(res, 0)) + " " + _p(_geti(res, 1)) + " " + _p(_geti(res, 2)));
+        long[] sample_1 = ((long[])(new long[]{13, 29, 7, 23, 5}));
+        long[] res_1 = ((long[])(triplet_sum2(((long[])(sample_1)), 35L)));
+        System.out.println(_p(_geti(res_1, ((Number)(0)).intValue())) + " " + _p(_geti(res_1, ((Number)(1)).intValue())) + " " + _p(_geti(res_1, ((Number)(2)).intValue())));
     }
     public static void main(String[] args) {
         {
@@ -141,11 +141,7 @@ arr_1[b_1 + 1] = tmp_1;
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -172,6 +168,12 @@ arr_1[b_1 + 1] = tmp_1;
         return rt.totalMemory() - rt.freeMemory();
     }
 
+    static long[] appendLong(long[] arr, long v) {
+        long[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
+    }
+
     static String _p(Object v) {
         if (v == null) return "<nil>";
         if (v.getClass().isArray()) {
@@ -185,10 +187,14 @@ arr_1[b_1 + 1] = tmp_1;
             if (v instanceof float[]) return java.util.Arrays.toString((float[]) v);
             return java.util.Arrays.deepToString((Object[]) v);
         }
+        if (v instanceof Double || v instanceof Float) {
+            double d = ((Number) v).doubleValue();
+            return String.valueOf(d);
+        }
         return String.valueOf(v);
     }
 
-    static Integer _geti(int[] a, int i) {
+    static Long _geti(long[] a, int i) {
         return (i >= 0 && i < a.length) ? a[i] : null;
     }
 }

--- a/tests/algorithms/x/Java/maths/twin_prime.bench
+++ b/tests/algorithms/x/Java/maths/twin_prime.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 30061,
-  "memory_bytes": 664,
-  "name": "main"
-}
+{"duration_us": 25124, "memory_bytes": 552, "name": "main"}

--- a/tests/algorithms/x/Java/maths/twin_prime.java
+++ b/tests/algorithms/x/Java/maths/twin_prime.java
@@ -1,50 +1,50 @@
 public class Main {
 
-    static boolean is_prime(int n) {
-        if (n < 2) {
+    static boolean is_prime(long n) {
+        if ((long)(n) < 2L) {
             return false;
         }
-        if (Math.floorMod(n, 2) == 0) {
-            return n == 2;
+        if (Math.floorMod(n, 2) == 0L) {
+            return (long)(n) == 2L;
         }
-        int i = 3;
-        while (i * i <= n) {
-            if (Math.floorMod(n, i) == 0) {
+        long i_1 = 3L;
+        while ((long)((long)(i_1) * (long)(i_1)) <= (long)(n)) {
+            if (Math.floorMod(n, i_1) == 0L) {
                 return false;
             }
-            i = i + 2;
+            i_1 = (long)((long)(i_1) + 2L);
         }
         return true;
     }
 
-    static int twin_prime(int number) {
-        if (((Boolean)(is_prime(number))) && ((Boolean)(is_prime(number + 2)))) {
-            return number + 2;
+    static long twin_prime(long number) {
+        if (is_prime((long)(number)) && is_prime((long)((long)(number) + 2L))) {
+            return (long)(number) + 2L;
         }
         return -1;
     }
 
     static void test_twin_prime() {
-        if (twin_prime(3) != 5) {
+        if ((long)(twin_prime(3L)) != 5L) {
             throw new RuntimeException(String.valueOf("twin_prime(3) failed"));
         }
-        if (twin_prime(4) != (-1)) {
+        if ((long)(twin_prime(4L)) != (long)((-1))) {
             throw new RuntimeException(String.valueOf("twin_prime(4) failed"));
         }
-        if (twin_prime(5) != 7) {
+        if ((long)(twin_prime(5L)) != 7L) {
             throw new RuntimeException(String.valueOf("twin_prime(5) failed"));
         }
-        if (twin_prime(17) != 19) {
+        if ((long)(twin_prime(17L)) != 19L) {
             throw new RuntimeException(String.valueOf("twin_prime(17) failed"));
         }
-        if (twin_prime(0) != (-1)) {
+        if ((long)(twin_prime(0L)) != (long)((-1))) {
             throw new RuntimeException(String.valueOf("twin_prime(0) failed"));
         }
     }
 
     static void main() {
         test_twin_prime();
-        System.out.println(twin_prime(3));
+        System.out.println(twin_prime(3L));
     }
     public static void main(String[] args) {
         {
@@ -53,11 +53,7 @@ public class Main {
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/maths/two_pointer.bench
+++ b/tests/algorithms/x/Java/maths/two_pointer.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 20388,
-  "memory_bytes": 600,
-  "name": "main"
-}
+{"duration_us": 23952, "memory_bytes": 600, "name": "main"}

--- a/tests/algorithms/x/Java/maths/two_pointer.java
+++ b/tests/algorithms/x/Java/maths/two_pointer.java
@@ -2,16 +2,16 @@ public class Main {
 
     static long[] two_pointer(long[] nums, long target) {
         long i = 0L;
-        long j_1 = (long)((long)(nums.length) - (long)(1));
+        long j_1 = (long)((long)(nums.length) - 1L);
         while ((long)(i) < (long)(j_1)) {
-            long s_1 = (long)(nums[(int)((long)(i))] + nums[(int)((long)(j_1))]);
-            if ((long)(s_1) == target) {
+            long s_1 = (long)((long)(nums[(int)((long)(i))]) + (long)(nums[(int)((long)(j_1))]));
+            if ((long)(s_1) == (long)(target)) {
                 return new long[]{i, j_1};
             }
-            if ((long)(s_1) < target) {
-                i = (long)((long)(i) + (long)(1));
+            if ((long)(s_1) < (long)(target)) {
+                i = (long)((long)(i) + 1L);
             } else {
-                j_1 = (long)((long)(j_1) - (long)(1));
+                j_1 = (long)((long)(j_1) - 1L);
             }
         }
         return new long[]{};
@@ -33,13 +33,13 @@ public class Main {
         if (!java.util.Arrays.equals(two_pointer(((long[])(new long[]{1, 3, 3})), 6L), new long[]{1, 2})) {
             throw new RuntimeException(String.valueOf("case5"));
         }
-        if ((long)(two_pointer(((long[])(new long[]{2, 7, 11, 15})), 8L).length) != (long)(0)) {
+        if ((long)(two_pointer(((long[])(new long[]{2, 7, 11, 15})), 8L).length) != 0L) {
             throw new RuntimeException(String.valueOf("case6"));
         }
-        if ((long)(two_pointer(((long[])(new long[]{0, 3, 6, 9, 12, 15, 18, 21, 24, 27})), 19L).length) != (long)(0)) {
+        if ((long)(two_pointer(((long[])(new long[]{0, 3, 6, 9, 12, 15, 18, 21, 24, 27})), 19L).length) != 0L) {
             throw new RuntimeException(String.valueOf("case7"));
         }
-        if ((long)(two_pointer(((long[])(new long[]{1, 2, 3})), 6L).length) != (long)(0)) {
+        if ((long)(two_pointer(((long[])(new long[]{1, 2, 3})), 6L).length) != 0L) {
             throw new RuntimeException(String.valueOf("case8"));
         }
     }
@@ -49,6 +49,36 @@ public class Main {
         System.out.println(two_pointer(((long[])(new long[]{2, 7, 11, 15})), 9L));
     }
     public static void main(String[] args) {
-        main();
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
     }
 }

--- a/tests/algorithms/x/Java/maths/two_sum.bench
+++ b/tests/algorithms/x/Java/maths/two_sum.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 24856,
-  "memory_bytes": 992,
-  "name": "main"
-}
+{"duration_us": 22706, "memory_bytes": 872, "name": "main"}

--- a/tests/algorithms/x/Java/maths/two_sum.java
+++ b/tests/algorithms/x/Java/maths/two_sum.java
@@ -1,31 +1,27 @@
 public class Main {
 
-    static int[] two_sum(int[] nums, int target) {
-        java.util.Map<Integer,Integer> chk_map = ((java.util.Map<Integer,Integer>)(new java.util.LinkedHashMap<Integer, Integer>()));
-        int idx = 0;
-        while (idx < nums.length) {
-            int val = nums[idx];
-            int compl = target - val;
-            if (((Boolean)(chk_map.containsKey(compl)))) {
-                return new int[]{(int)(((int)(chk_map).getOrDefault(compl, 0))) - 1, idx};
+    static long[] two_sum(long[] nums, long target) {
+        java.util.Map<Long,Long> chk_map = ((java.util.Map<Long,Long>)(new java.util.LinkedHashMap<Long, Long>()));
+        long idx_1 = 0L;
+        while ((long)(idx_1) < (long)(nums.length)) {
+            long val_1 = (long)(nums[(int)((long)(idx_1))]);
+            long compl_1 = (long)((long)(target) - (long)(val_1));
+            if (chk_map.containsKey(compl_1)) {
+                return new long[]{(long)(((long)(chk_map).getOrDefault(compl_1, 0L))) - 1L, idx_1};
             }
-chk_map.put(val, idx + 1);
-            idx = idx + 1;
+chk_map.put(val_1, (long)((long)(idx_1) + 1L));
+            idx_1 = (long)((long)(idx_1) + 1L);
         }
-        return new int[]{};
+        return new long[]{};
     }
     public static void main(String[] args) {
         {
             long _benchStart = _now();
             long _benchMem = _mem();
-            System.out.println(_p(two_sum(((int[])(new int[]{2, 7, 11, 15})), 9)));
+            System.out.println(_p(two_sum(((long[])(new long[]{2, 7, 11, 15})), 9L)));
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -64,6 +60,10 @@ chk_map.put(val, idx + 1);
             if (v instanceof short[]) return java.util.Arrays.toString((short[]) v);
             if (v instanceof float[]) return java.util.Arrays.toString((float[]) v);
             return java.util.Arrays.deepToString((Object[]) v);
+        }
+        if (v instanceof Double || v instanceof Float) {
+            double d = ((Number) v).doubleValue();
+            return String.valueOf(d);
         }
         return String.valueOf(v);
     }

--- a/tests/algorithms/x/Java/maths/volume.bench
+++ b/tests/algorithms/x/Java/maths/volume.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 53076,
-  "memory_bytes": 52016,
-  "name": "main"
-}
+{"duration_us": 44502, "memory_bytes": 52120, "name": "main"}

--- a/tests/algorithms/x/Java/maths/volume.java
+++ b/tests/algorithms/x/Java/maths/volume.java
@@ -1,177 +1,171 @@
 public class Main {
-    static double PI;
-    static double SQRT5;
+    static double PI = (double)(3.141592653589793);
+    static double SQRT5 = (double)(2.23606797749979);
 
     static double minf(double a, double b) {
-        if (a < b) {
+        if ((double)(a) < (double)(b)) {
             return a;
         }
         return b;
     }
 
     static double maxf(double a, double b) {
-        if (a > b) {
+        if ((double)(a) > (double)(b)) {
             return a;
         }
         return b;
     }
 
     static double vol_cube(double side_length) {
-        if (side_length < 0.0) {
+        if ((double)(side_length) < (double)(0.0)) {
             throw new RuntimeException(String.valueOf("vol_cube() only accepts non-negative values"));
         }
-        return side_length * side_length * side_length;
+        return (double)((double)(side_length) * (double)(side_length)) * (double)(side_length);
     }
 
     static double vol_spherical_cap(double height, double radius) {
-        if (height < 0.0 || radius < 0.0) {
+        if ((double)(height) < (double)(0.0) || (double)(radius) < (double)(0.0)) {
             throw new RuntimeException(String.valueOf("vol_spherical_cap() only accepts non-negative values"));
         }
-        return (1.0 / 3.0) * PI * height * height * (3.0 * radius - height);
+        return (double)((double)((double)((double)(((double)(1.0) / (double)(3.0))) * (double)(PI)) * (double)(height)) * (double)(height)) * (double)(((double)((double)(3.0) * (double)(radius)) - (double)(height)));
     }
 
     static double vol_sphere(double radius) {
-        if (radius < 0.0) {
+        if ((double)(radius) < (double)(0.0)) {
             throw new RuntimeException(String.valueOf("vol_sphere() only accepts non-negative values"));
         }
-        return (4.0 / 3.0) * PI * radius * radius * radius;
+        return (double)((double)((double)((double)(((double)(4.0) / (double)(3.0))) * (double)(PI)) * (double)(radius)) * (double)(radius)) * (double)(radius);
     }
 
     static double vol_spheres_intersect(double radius_1, double radius_2, double centers_distance) {
-        if (radius_1 < 0.0 || radius_2 < 0.0 || centers_distance < 0.0) {
+        if ((double)(radius_1) < (double)(0.0) || (double)(radius_2) < (double)(0.0) || (double)(centers_distance) < (double)(0.0)) {
             throw new RuntimeException(String.valueOf("vol_spheres_intersect() only accepts non-negative values"));
         }
-        if (centers_distance == 0.0) {
-            return vol_sphere(minf(radius_1, radius_2));
+        if ((double)(centers_distance) == (double)(0.0)) {
+            return vol_sphere((double)(minf((double)(radius_1), (double)(radius_2))));
         }
-        double h1 = (radius_1 - radius_2 + centers_distance) * (radius_1 + radius_2 - centers_distance) / (2.0 * centers_distance);
-        double h2 = (radius_2 - radius_1 + centers_distance) * (radius_2 + radius_1 - centers_distance) / (2.0 * centers_distance);
-        return vol_spherical_cap(h1, radius_2) + vol_spherical_cap(h2, radius_1);
+        double h1_1 = (double)((double)((double)(((double)((double)(radius_1) - (double)(radius_2)) + (double)(centers_distance))) * (double)(((double)((double)(radius_1) + (double)(radius_2)) - (double)(centers_distance)))) / (double)(((double)(2.0) * (double)(centers_distance))));
+        double h2_1 = (double)((double)((double)(((double)((double)(radius_2) - (double)(radius_1)) + (double)(centers_distance))) * (double)(((double)((double)(radius_2) + (double)(radius_1)) - (double)(centers_distance)))) / (double)(((double)(2.0) * (double)(centers_distance))));
+        return (double)(vol_spherical_cap((double)(h1_1), (double)(radius_2))) + (double)(vol_spherical_cap((double)(h2_1), (double)(radius_1)));
     }
 
     static double vol_spheres_union(double radius_1, double radius_2, double centers_distance) {
-        if (radius_1 <= 0.0 || radius_2 <= 0.0 || centers_distance < 0.0) {
+        if ((double)(radius_1) <= (double)(0.0) || (double)(radius_2) <= (double)(0.0) || (double)(centers_distance) < (double)(0.0)) {
             throw new RuntimeException(String.valueOf("vol_spheres_union() only accepts non-negative values, non-zero radius"));
         }
-        if (centers_distance == 0.0) {
-            return vol_sphere(maxf(radius_1, radius_2));
+        if ((double)(centers_distance) == (double)(0.0)) {
+            return vol_sphere((double)(maxf((double)(radius_1), (double)(radius_2))));
         }
-        return vol_sphere(radius_1) + vol_sphere(radius_2) - vol_spheres_intersect(radius_1, radius_2, centers_distance);
+        return (double)((double)(vol_sphere((double)(radius_1))) + (double)(vol_sphere((double)(radius_2)))) - (double)(vol_spheres_intersect((double)(radius_1), (double)(radius_2), (double)(centers_distance)));
     }
 
     static double vol_cuboid(double width, double height, double length) {
-        if (width < 0.0 || height < 0.0 || length < 0.0) {
+        if ((double)(width) < (double)(0.0) || (double)(height) < (double)(0.0) || (double)(length) < (double)(0.0)) {
             throw new RuntimeException(String.valueOf("vol_cuboid() only accepts non-negative values"));
         }
-        return width * height * length;
+        return (double)((double)(width) * (double)(height)) * (double)(length);
     }
 
     static double vol_cone(double area_of_base, double height) {
-        if (height < 0.0 || area_of_base < 0.0) {
+        if ((double)(height) < (double)(0.0) || (double)(area_of_base) < (double)(0.0)) {
             throw new RuntimeException(String.valueOf("vol_cone() only accepts non-negative values"));
         }
-        return area_of_base * height / 3.0;
+        return (double)((double)(area_of_base) * (double)(height)) / (double)(3.0);
     }
 
     static double vol_right_circ_cone(double radius, double height) {
-        if (height < 0.0 || radius < 0.0) {
+        if ((double)(height) < (double)(0.0) || (double)(radius) < (double)(0.0)) {
             throw new RuntimeException(String.valueOf("vol_right_circ_cone() only accepts non-negative values"));
         }
-        return PI * radius * radius * height / 3.0;
+        return (double)((double)((double)((double)(PI) * (double)(radius)) * (double)(radius)) * (double)(height)) / (double)(3.0);
     }
 
     static double vol_prism(double area_of_base, double height) {
-        if (height < 0.0 || area_of_base < 0.0) {
+        if ((double)(height) < (double)(0.0) || (double)(area_of_base) < (double)(0.0)) {
             throw new RuntimeException(String.valueOf("vol_prism() only accepts non-negative values"));
         }
-        return area_of_base * height;
+        return (double)(area_of_base) * (double)(height);
     }
 
     static double vol_pyramid(double area_of_base, double height) {
-        if (height < 0.0 || area_of_base < 0.0) {
+        if ((double)(height) < (double)(0.0) || (double)(area_of_base) < (double)(0.0)) {
             throw new RuntimeException(String.valueOf("vol_pyramid() only accepts non-negative values"));
         }
-        return area_of_base * height / 3.0;
+        return (double)((double)(area_of_base) * (double)(height)) / (double)(3.0);
     }
 
     static double vol_hemisphere(double radius) {
-        if (radius < 0.0) {
+        if ((double)(radius) < (double)(0.0)) {
             throw new RuntimeException(String.valueOf("vol_hemisphere() only accepts non-negative values"));
         }
-        return radius * radius * radius * PI * 2.0 / 3.0;
+        return (double)((double)((double)((double)((double)(radius) * (double)(radius)) * (double)(radius)) * (double)(PI)) * (double)(2.0)) / (double)(3.0);
     }
 
     static double vol_circular_cylinder(double radius, double height) {
-        if (height < 0.0 || radius < 0.0) {
+        if ((double)(height) < (double)(0.0) || (double)(radius) < (double)(0.0)) {
             throw new RuntimeException(String.valueOf("vol_circular_cylinder() only accepts non-negative values"));
         }
-        return radius * radius * height * PI;
+        return (double)((double)((double)(radius) * (double)(radius)) * (double)(height)) * (double)(PI);
     }
 
     static double vol_hollow_circular_cylinder(double inner_radius, double outer_radius, double height) {
-        if (inner_radius < 0.0 || outer_radius < 0.0 || height < 0.0) {
+        if ((double)(inner_radius) < (double)(0.0) || (double)(outer_radius) < (double)(0.0) || (double)(height) < (double)(0.0)) {
             throw new RuntimeException(String.valueOf("vol_hollow_circular_cylinder() only accepts non-negative values"));
         }
-        if (outer_radius <= inner_radius) {
+        if ((double)(outer_radius) <= (double)(inner_radius)) {
             throw new RuntimeException(String.valueOf("outer_radius must be greater than inner_radius"));
         }
-        return PI * (outer_radius * outer_radius - inner_radius * inner_radius) * height;
+        return (double)((double)(PI) * (double)(((double)((double)(outer_radius) * (double)(outer_radius)) - (double)((double)(inner_radius) * (double)(inner_radius))))) * (double)(height);
     }
 
     static double vol_conical_frustum(double height, double radius_1, double radius_2) {
-        if (radius_1 < 0.0 || radius_2 < 0.0 || height < 0.0) {
+        if ((double)(radius_1) < (double)(0.0) || (double)(radius_2) < (double)(0.0) || (double)(height) < (double)(0.0)) {
             throw new RuntimeException(String.valueOf("vol_conical_frustum() only accepts non-negative values"));
         }
-        return (1.0 / 3.0) * PI * height * (radius_1 * radius_1 + radius_2 * radius_2 + radius_1 * radius_2);
+        return (double)((double)((double)(((double)(1.0) / (double)(3.0))) * (double)(PI)) * (double)(height)) * (double)(((double)((double)((double)(radius_1) * (double)(radius_1)) + (double)((double)(radius_2) * (double)(radius_2))) + (double)((double)(radius_1) * (double)(radius_2))));
     }
 
     static double vol_torus(double torus_radius, double tube_radius) {
-        if (torus_radius < 0.0 || tube_radius < 0.0) {
+        if ((double)(torus_radius) < (double)(0.0) || (double)(tube_radius) < (double)(0.0)) {
             throw new RuntimeException(String.valueOf("vol_torus() only accepts non-negative values"));
         }
-        return 2.0 * PI * PI * torus_radius * tube_radius * tube_radius;
+        return (double)((double)((double)((double)((double)(2.0) * (double)(PI)) * (double)(PI)) * (double)(torus_radius)) * (double)(tube_radius)) * (double)(tube_radius);
     }
 
     static double vol_icosahedron(double tri_side) {
-        if (tri_side < 0.0) {
+        if ((double)(tri_side) < (double)(0.0)) {
             throw new RuntimeException(String.valueOf("vol_icosahedron() only accepts non-negative values"));
         }
-        return tri_side * tri_side * tri_side * (3.0 + SQRT5) * 5.0 / 12.0;
+        return (double)((double)((double)((double)((double)(tri_side) * (double)(tri_side)) * (double)(tri_side)) * (double)(((double)(3.0) + (double)(SQRT5)))) * (double)(5.0)) / (double)(12.0);
     }
 
     static void main() {
         System.out.println("Volumes:");
-        System.out.println("Cube: " + _p(vol_cube(2.0)));
-        System.out.println("Cuboid: " + _p(vol_cuboid(2.0, 2.0, 2.0)));
-        System.out.println("Cone: " + _p(vol_cone(2.0, 2.0)));
-        System.out.println("Right Circular Cone: " + _p(vol_right_circ_cone(2.0, 2.0)));
-        System.out.println("Prism: " + _p(vol_prism(2.0, 2.0)));
-        System.out.println("Pyramid: " + _p(vol_pyramid(2.0, 2.0)));
-        System.out.println("Sphere: " + _p(vol_sphere(2.0)));
-        System.out.println("Hemisphere: " + _p(vol_hemisphere(2.0)));
-        System.out.println("Circular Cylinder: " + _p(vol_circular_cylinder(2.0, 2.0)));
-        System.out.println("Torus: " + _p(vol_torus(2.0, 2.0)));
-        System.out.println("Conical Frustum: " + _p(vol_conical_frustum(2.0, 2.0, 4.0)));
-        System.out.println("Spherical cap: " + _p(vol_spherical_cap(1.0, 2.0)));
-        System.out.println("Spheres intersection: " + _p(vol_spheres_intersect(2.0, 2.0, 1.0)));
-        System.out.println("Spheres union: " + _p(vol_spheres_union(2.0, 2.0, 1.0)));
-        System.out.println("Hollow Circular Cylinder: " + _p(vol_hollow_circular_cylinder(1.0, 2.0, 3.0)));
-        System.out.println("Icosahedron: " + _p(vol_icosahedron(2.5)));
+        System.out.println("Cube: " + _p(vol_cube((double)(2.0))));
+        System.out.println("Cuboid: " + _p(vol_cuboid((double)(2.0), (double)(2.0), (double)(2.0))));
+        System.out.println("Cone: " + _p(vol_cone((double)(2.0), (double)(2.0))));
+        System.out.println("Right Circular Cone: " + _p(vol_right_circ_cone((double)(2.0), (double)(2.0))));
+        System.out.println("Prism: " + _p(vol_prism((double)(2.0), (double)(2.0))));
+        System.out.println("Pyramid: " + _p(vol_pyramid((double)(2.0), (double)(2.0))));
+        System.out.println("Sphere: " + _p(vol_sphere((double)(2.0))));
+        System.out.println("Hemisphere: " + _p(vol_hemisphere((double)(2.0))));
+        System.out.println("Circular Cylinder: " + _p(vol_circular_cylinder((double)(2.0), (double)(2.0))));
+        System.out.println("Torus: " + _p(vol_torus((double)(2.0), (double)(2.0))));
+        System.out.println("Conical Frustum: " + _p(vol_conical_frustum((double)(2.0), (double)(2.0), (double)(4.0))));
+        System.out.println("Spherical cap: " + _p(vol_spherical_cap((double)(1.0), (double)(2.0))));
+        System.out.println("Spheres intersection: " + _p(vol_spheres_intersect((double)(2.0), (double)(2.0), (double)(1.0))));
+        System.out.println("Spheres union: " + _p(vol_spheres_union((double)(2.0), (double)(2.0), (double)(1.0))));
+        System.out.println("Hollow Circular Cylinder: " + _p(vol_hollow_circular_cylinder((double)(1.0), (double)(2.0), (double)(3.0))));
+        System.out.println("Icosahedron: " + _p(vol_icosahedron((double)(2.5))));
     }
     public static void main(String[] args) {
         {
             long _benchStart = _now();
             long _benchMem = _mem();
-            PI = 3.141592653589793;
-            SQRT5 = 2.23606797749979;
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -210,6 +204,10 @@ public class Main {
             if (v instanceof short[]) return java.util.Arrays.toString((short[]) v);
             if (v instanceof float[]) return java.util.Arrays.toString((float[]) v);
             return java.util.Arrays.deepToString((Object[]) v);
+        }
+        if (v instanceof Double || v instanceof Float) {
+            double d = ((Number) v).doubleValue();
+            return String.valueOf(d);
         }
         return String.valueOf(v);
     }

--- a/tests/algorithms/x/Java/maths/zellers_congruence.bench
+++ b/tests/algorithms/x/Java/maths/zellers_congruence.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 59756,
-  "memory_bytes": 80152,
-  "name": "main"
-}
+{"duration_us": 57890, "memory_bytes": 80264, "name": "main"}

--- a/tests/algorithms/x/Java/maths/zellers_congruence.java
+++ b/tests/algorithms/x/Java/maths/zellers_congruence.java
@@ -1,63 +1,63 @@
 public class Main {
 
-    static int parse_decimal(String s) {
-        int value = 0;
-        int i = 0;
-        while (i < _runeLen(s)) {
-            String c = s.substring(i, i+1);
-            if ((c.compareTo("0") < 0) || (c.compareTo("9") > 0)) {
+    static long parse_decimal(String s) {
+        long value = 0L;
+        long i_1 = 0L;
+        while ((long)(i_1) < (long)(_runeLen(s))) {
+            String c_1 = s.substring((int)((long)(i_1)), (int)((long)(i_1))+1);
+            if ((c_1.compareTo("0") < 0) || (c_1.compareTo("9") > 0)) {
                 throw new RuntimeException(String.valueOf("invalid literal"));
             }
-            value = value * 10 + (Integer.parseInt(c));
-            i = i + 1;
+            value = (long)((long)((long)(value) * 10L) + (long)((Integer.parseInt(c_1))));
+            i_1 = (long)((long)(i_1) + 1L);
         }
         return value;
     }
 
     static String zeller_day(String date_input) {
-        java.util.Map<Integer,String> days = ((java.util.Map<Integer,String>)(new java.util.LinkedHashMap<Integer, String>(java.util.Map.ofEntries(java.util.Map.entry(0, "Sunday"), java.util.Map.entry(1, "Monday"), java.util.Map.entry(2, "Tuesday"), java.util.Map.entry(3, "Wednesday"), java.util.Map.entry(4, "Thursday"), java.util.Map.entry(5, "Friday"), java.util.Map.entry(6, "Saturday")))));
-        if (_runeLen(date_input) != 10) {
+        java.util.Map<Long,String> days = ((java.util.Map<Long,String>)(new java.util.LinkedHashMap<Long, String>(java.util.Map.ofEntries(java.util.Map.entry(0L, "Sunday"), java.util.Map.entry(1L, "Monday"), java.util.Map.entry(2L, "Tuesday"), java.util.Map.entry(3L, "Wednesday"), java.util.Map.entry(4L, "Thursday"), java.util.Map.entry(5L, "Friday"), java.util.Map.entry(6L, "Saturday")))));
+        if ((long)(_runeLen(date_input)) != 10L) {
             throw new RuntimeException(String.valueOf("Must be 10 characters long"));
         }
-        int m = parse_decimal(date_input.substring(0, 2));
-        if (m <= 0 || m >= 13) {
+        long m_1 = (long)(parse_decimal(_substr(date_input, (int)(0L), (int)(2L))));
+        if ((long)(m_1) <= 0L || (long)(m_1) >= 13L) {
             throw new RuntimeException(String.valueOf("Month must be between 1 - 12"));
         }
-        String sep1 = date_input.substring(2, 2+1);
-        if (!(sep1.equals("-")) && !(sep1.equals("/"))) {
+        String sep1_1 = date_input.substring((int)(2L), (int)(2L)+1);
+        if (!(sep1_1.equals("-")) && !(sep1_1.equals("/"))) {
             throw new RuntimeException(String.valueOf("Date separator must be '-' or '/'"));
         }
-        int d = parse_decimal(date_input.substring(3, 5));
-        if (d <= 0 || d >= 32) {
+        long d_1 = (long)(parse_decimal(_substr(date_input, (int)(3L), (int)(5L))));
+        if ((long)(d_1) <= 0L || (long)(d_1) >= 32L) {
             throw new RuntimeException(String.valueOf("Date must be between 1 - 31"));
         }
-        String sep2 = date_input.substring(5, 5+1);
-        if (!(sep2.equals("-")) && !(sep2.equals("/"))) {
+        String sep2_1 = date_input.substring((int)(5L), (int)(5L)+1);
+        if (!(sep2_1.equals("-")) && !(sep2_1.equals("/"))) {
             throw new RuntimeException(String.valueOf("Date separator must be '-' or '/'"));
         }
-        int y = parse_decimal(date_input.substring(6, 10));
-        if (y <= 45 || y >= 8500) {
+        long y_1 = (long)(parse_decimal(_substr(date_input, (int)(6L), (int)(10L))));
+        if ((long)(y_1) <= 45L || (long)(y_1) >= 8500L) {
             throw new RuntimeException(String.valueOf("Year out of range. There has to be some sort of limit...right?"));
         }
-        int year = y;
-        int month = m;
-        if (month <= 2) {
-            year = year - 1;
-            month = month + 12;
+        long year_1 = (long)(y_1);
+        long month_1 = (long)(m_1);
+        if ((long)(month_1) <= 2L) {
+            year_1 = (long)((long)(year_1) - 1L);
+            month_1 = (long)((long)(month_1) + 12L);
         }
-        int c_1 = Math.floorDiv(year, 100);
-        int k = Math.floorMod(year, 100);
-        int t = ((Number)(2.6 * (((Number)(month)).doubleValue()) - 5.39)).intValue();
-        Object u = Math.floorDiv(c_1, 4);
-        int v = Math.floorDiv(k, 4);
-        int x = d + k;
-        int z = t + ((Number)(u)).intValue() + v + x;
-        int w = z - (2 * c_1);
-        int f = Math.floorMod(w, 7);
-        if (f < 0) {
-            f = f + 7;
+        long c_3 = Math.floorDiv(year_1, 100);
+        long k_1 = Math.floorMod(year_1, 100);
+        long t_1 = (long)(((Number)((double)((double)(2.6) * (double)((((Number)(month_1)).doubleValue()))) - (double)(5.39))).intValue());
+        Object u_1 = Math.floorDiv(c_3, 4);
+        long v_1 = Math.floorDiv(k_1, 4);
+        long x_1 = (long)((long)(d_1) + (long)(k_1));
+        long z_1 = (long)((long)((long)((long)(t_1) + ((Number)(u_1)).intValue()) + (long)(v_1)) + (long)(x_1));
+        long w_1 = (long)((long)(z_1) - (long)((2L * (long)(c_3))));
+        long f_1 = Math.floorMod(w_1, 7);
+        if ((long)(f_1) < 0L) {
+            f_1 = (long)((long)(f_1) + 7L);
         }
-        return ((String)(days).get(f));
+        return ((String)(days).get(f_1));
     }
 
     static String zeller(String date_input) {
@@ -67,14 +67,14 @@ public class Main {
 
     static void test_zeller() {
         String[] inputs = ((String[])(new String[]{"01-31-2010", "02-01-2010", "11-26-2024", "07-04-1776"}));
-        String[] expected = ((String[])(new String[]{"Sunday", "Monday", "Tuesday", "Thursday"}));
-        int i_1 = 0;
-        while (i_1 < inputs.length) {
-            String res = String.valueOf(zeller_day(inputs[i_1]));
-            if (!(res.equals(expected[i_1]))) {
+        String[] expected_1 = ((String[])(new String[]{"Sunday", "Monday", "Tuesday", "Thursday"}));
+        long i_3 = 0L;
+        while ((long)(i_3) < (long)(inputs.length)) {
+            String res_1 = String.valueOf(zeller_day(inputs[(int)((long)(i_3))]));
+            if (!(res_1.equals(expected_1[(int)((long)(i_3))]))) {
                 throw new RuntimeException(String.valueOf("zeller test failed"));
             }
-            i_1 = i_1 + 1;
+            i_3 = (long)((long)(i_3) + 1L);
         }
     }
 
@@ -89,11 +89,7 @@ public class Main {
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -122,5 +118,15 @@ public class Main {
 
     static int _runeLen(String s) {
         return s.codePointCount(0, s.length());
+    }
+
+    static String _substr(String s, int i, int j) {
+        int len = _runeLen(s);
+        if (i < 0) i = 0;
+        if (j > len) j = len;
+        if (i > j) i = j;
+        int start = s.offsetByCodePoints(0, i);
+        int end = s.offsetByCodePoints(0, j);
+        return s.substring(start, end);
     }
 }

--- a/tests/algorithms/x/Java/matrix/binary_search_matrix.bench
+++ b/tests/algorithms/x/Java/matrix/binary_search_matrix.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 33146,
-  "memory_bytes": 872,
-  "name": "main"
-}
+{"duration_us": 25627, "memory_bytes": 1184, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/binary_search_matrix.java
+++ b/tests/algorithms/x/Java/matrix/binary_search_matrix.java
@@ -1,41 +1,41 @@
 public class Main {
 
-    static int binary_search(int[] arr, int lower_bound, int upper_bound, int value) {
-        int r = Math.floorDiv((lower_bound + upper_bound), 2);
-        if (arr[r] == value) {
+    static long binary_search(long[] arr, long lower_bound, long upper_bound, long value) {
+        long r = Math.floorDiv(((long)(((long)(lower_bound) + (long)(upper_bound)))), ((long)(2)));
+        if ((long)(arr[(int)((long)(r))]) == (long)(value)) {
             return r;
         }
-        if (lower_bound >= upper_bound) {
+        if ((long)(lower_bound) >= (long)(upper_bound)) {
             return -1;
         }
-        if (arr[r] < value) {
-            return binary_search(((int[])(arr)), r + 1, upper_bound, value);
+        if ((long)(arr[(int)((long)(r))]) < (long)(value)) {
+            return binary_search(((long[])(arr)), (long)((long)(r) + 1L), (long)(upper_bound), (long)(value));
         }
-        return binary_search(((int[])(arr)), lower_bound, r - 1, value);
+        return binary_search(((long[])(arr)), (long)(lower_bound), (long)((long)(r) - 1L), (long)(value));
     }
 
-    static int[] mat_bin_search(int value, int[][] matrix) {
-        int index = 0;
-        if (matrix[index][0] == value) {
-            return new int[]{index, 0};
+    static long[] mat_bin_search(long value, long[][] matrix) {
+        long index = 0L;
+        if ((long)(matrix[(int)((long)(index))][(int)(0L)]) == (long)(value)) {
+            return new long[]{index, 0};
         }
-        while (index < matrix.length && matrix[index][0] < value) {
-            int r_1 = binary_search(((int[])(matrix[index])), 0, matrix[index].length - 1, value);
-            if (r_1 != (-1)) {
-                return new int[]{index, r_1};
+        while ((long)(index) < (long)(matrix.length) && (long)(matrix[(int)((long)(index))][(int)(0L)]) < (long)(value)) {
+            long r_2 = (long)(binary_search(((long[])(matrix[(int)((long)(index))])), 0L, (long)((long)(matrix[(int)((long)(index))].length) - 1L), (long)(value)));
+            if ((long)(r_2) != (long)((-1))) {
+                return new long[]{index, r_2};
             }
-            index = index + 1;
+            index = (long)((long)(index) + 1L);
         }
-        return new int[]{-1, -1};
+        return new long[]{-1, -1};
     }
 
     static void main() {
-        int[] row = ((int[])(new int[]{1, 4, 7, 11, 15}));
-        System.out.println(_p(binary_search(((int[])(row)), 0, row.length - 1, 1)));
-        System.out.println(_p(binary_search(((int[])(row)), 0, row.length - 1, 23)));
-        int[][] matrix = ((int[][])(new int[][]{new int[]{1, 4, 7, 11, 15}, new int[]{2, 5, 8, 12, 19}, new int[]{3, 6, 9, 16, 22}, new int[]{10, 13, 14, 17, 24}, new int[]{18, 21, 23, 26, 30}}));
-        System.out.println(_p(mat_bin_search(1, ((int[][])(matrix)))));
-        System.out.println(_p(mat_bin_search(34, ((int[][])(matrix)))));
+        long[] row = ((long[])(new long[]{1, 4, 7, 11, 15}));
+        System.out.println(_p(binary_search(((long[])(row)), 0L, (long)((long)(row.length) - 1L), 1L)));
+        System.out.println(_p(binary_search(((long[])(row)), 0L, (long)((long)(row.length) - 1L), 23L)));
+        long[][] matrix_1 = ((long[][])(new long[][]{new long[]{1, 4, 7, 11, 15}, new long[]{2, 5, 8, 12, 19}, new long[]{3, 6, 9, 16, 22}, new long[]{10, 13, 14, 17, 24}, new long[]{18, 21, 23, 26, 30}}));
+        System.out.println(_p(mat_bin_search(1L, ((long[][])(matrix_1)))));
+        System.out.println(_p(mat_bin_search(34L, ((long[][])(matrix_1)))));
     }
     public static void main(String[] args) {
         {
@@ -44,11 +44,7 @@ public class Main {
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -87,6 +83,10 @@ public class Main {
             if (v instanceof short[]) return java.util.Arrays.toString((short[]) v);
             if (v instanceof float[]) return java.util.Arrays.toString((float[]) v);
             return java.util.Arrays.deepToString((Object[]) v);
+        }
+        if (v instanceof Double || v instanceof Float) {
+            double d = ((Number) v).doubleValue();
+            return String.valueOf(d);
         }
         return String.valueOf(v);
     }

--- a/tests/algorithms/x/Java/matrix/count_islands_in_matrix.bench
+++ b/tests/algorithms/x/Java/matrix/count_islands_in_matrix.bench
@@ -1,5 +1,1 @@
-Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 5
-	at Main.is_safe(Main.java:7)
-	at Main.dfs(Main.java:21)
-	at Main.count_islands(Main.java:49)
-	at Main.main(Main.java:63)
+{"duration_us": 46521, "memory_bytes": 46448, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/count_islands_in_matrix.error
+++ b/tests/algorithms/x/Java/matrix/count_islands_in_matrix.error
@@ -1,6 +1,0 @@
-run: exit status 1
-Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 5
-	at Main.is_safe(Main.java:7)
-	at Main.dfs(Main.java:21)
-	at Main.count_islands(Main.java:49)
-	at Main.main(Main.java:63)

--- a/tests/algorithms/x/Java/matrix/count_islands_in_matrix.java
+++ b/tests/algorithms/x/Java/matrix/count_islands_in_matrix.java
@@ -1,73 +1,71 @@
 public class Main {
-    static int[][] grid;
+    static long[][] grid = ((long[][])(new long[][]{new long[]{1, 1, 0, 0, 0}, new long[]{0, 1, 0, 0, 1}, new long[]{1, 0, 0, 1, 1}, new long[]{0, 0, 0, 0, 0}, new long[]{1, 0, 1, 0, 1}}));
 
-    static boolean is_safe(int[][] grid, boolean[][] visited, int row, int col) {
-        int rows = grid.length;
-        int cols = grid[0].length;
-        boolean visited_cell = visited[row][col];
-        boolean within_bounds = row >= 0 && row < rows && col >= 0 && col < cols;
-        boolean not_visited = visited_cell == false;
-        return within_bounds && not_visited && grid[row][col] == 1;
+    static boolean is_safe(long[][] grid, boolean[][] visited, long row, long col) {
+        long rows = (long)(grid.length);
+        long cols_1 = (long)(grid[(int)(0L)].length);
+        boolean within_bounds_1 = (long)(row) >= 0L && (long)(row) < (long)(rows) && (long)(col) >= 0L && (long)(col) < (long)(cols_1);
+        if (!within_bounds_1) {
+            return false;
+        }
+        boolean visited_cell_1 = visited[(int)((long)(row))][(int)((long)(col))];
+        boolean not_visited_1 = (visited_cell_1 == false);
+        return not_visited_1 && (long)(grid[(int)((long)(row))][(int)((long)(col))]) == 1L;
     }
 
-    static void dfs(int[][] grid, boolean[][] visited, int row, int col) {
-        int[] row_nbr = ((int[])(new int[]{-1, -1, -1, 0, 0, 1, 1, 1}));
-        int[] col_nbr = ((int[])(new int[]{-1, 0, 1, -1, 1, -1, 0, 1}));
-visited[row][col] = true;
-        int k = 0;
-        while (k < 8) {
-            int new_row = row + row_nbr[k];
-            int new_col = col + col_nbr[k];
-            if (((Boolean)(is_safe(((int[][])(grid)), ((boolean[][])(visited)), new_row, new_col)))) {
-                dfs(((int[][])(grid)), ((boolean[][])(visited)), new_row, new_col);
+    static void dfs(long[][] grid, boolean[][] visited, long row, long col) {
+        long[] row_nbr = ((long[])(new long[]{-1, -1, -1, 0, 0, 1, 1, 1}));
+        long[] col_nbr_1 = ((long[])(new long[]{-1, 0, 1, -1, 1, -1, 0, 1}));
+visited[(int)((long)(row))][(int)((long)(col))] = true;
+        long k_1 = 0L;
+        while ((long)(k_1) < 8L) {
+            long new_row_1 = (long)((long)(row) + (long)(row_nbr[(int)((long)(k_1))]));
+            long new_col_1 = (long)((long)(col) + (long)(col_nbr_1[(int)((long)(k_1))]));
+            if (is_safe(((long[][])(grid)), ((boolean[][])(visited)), (long)(new_row_1), (long)(new_col_1))) {
+                dfs(((long[][])(grid)), ((boolean[][])(visited)), (long)(new_row_1), (long)(new_col_1));
             }
-            k = k + 1;
+            k_1 = (long)((long)(k_1) + 1L);
         }
     }
 
-    static int count_islands(int[][] grid) {
-        int rows_1 = grid.length;
-        int cols_1 = grid[0].length;
-        boolean[][] visited = ((boolean[][])(new boolean[][]{}));
-        int i = 0;
-        while (i < rows_1) {
-            boolean[] row_list = ((boolean[])(new boolean[]{}));
-            int j = 0;
-            while (j < cols_1) {
-                row_list = ((boolean[])(appendBool(row_list, false)));
-                j = j + 1;
+    static long count_islands(long[][] grid) {
+        long rows_1 = (long)(grid.length);
+        long cols_3 = (long)(grid[(int)(0L)].length);
+        boolean[][] visited_1 = ((boolean[][])(new boolean[][]{}));
+        long i_1 = 0L;
+        while ((long)(i_1) < (long)(rows_1)) {
+            boolean[] row_list_1 = ((boolean[])(new boolean[]{}));
+            long j_1 = 0L;
+            while ((long)(j_1) < (long)(cols_3)) {
+                row_list_1 = ((boolean[])(appendBool(row_list_1, false)));
+                j_1 = (long)((long)(j_1) + 1L);
             }
-            visited = ((boolean[][])(appendObj(visited, row_list)));
-            i = i + 1;
+            visited_1 = ((boolean[][])(java.util.stream.Stream.concat(java.util.Arrays.stream(visited_1), java.util.stream.Stream.of(new boolean[][]{row_list_1})).toArray(boolean[][]::new)));
+            i_1 = (long)((long)(i_1) + 1L);
         }
-        int count = 0;
-        i = 0;
-        while (i < rows_1) {
-            int j_1 = 0;
-            while (j_1 < cols_1) {
-                if (!(Boolean)visited[i][j_1] && grid[i][j_1] == 1) {
-                    dfs(((int[][])(grid)), ((boolean[][])(visited)), i, j_1);
-                    count = count + 1;
+        long count_1 = 0L;
+        i_1 = 0L;
+        while ((long)(i_1) < (long)(rows_1)) {
+            long j_3 = 0L;
+            while ((long)(j_3) < (long)(cols_3)) {
+                if (!visited_1[(int)((long)(i_1))][(int)((long)(j_3))] && (long)(grid[(int)((long)(i_1))][(int)((long)(j_3))]) == 1L) {
+                    dfs(((long[][])(grid)), ((boolean[][])(visited_1)), (long)(i_1), (long)(j_3));
+                    count_1 = (long)((long)(count_1) + 1L);
                 }
-                j_1 = j_1 + 1;
+                j_3 = (long)((long)(j_3) + 1L);
             }
-            i = i + 1;
+            i_1 = (long)((long)(i_1) + 1L);
         }
-        return count;
+        return count_1;
     }
     public static void main(String[] args) {
         {
             long _benchStart = _now();
             long _benchMem = _mem();
-            grid = ((int[][])(new int[][]{new int[]{1, 1, 0, 0, 0}, new int[]{0, 1, 0, 0, 1}, new int[]{1, 0, 0, 1, 1}, new int[]{0, 0, 0, 0, 0}, new int[]{1, 0, 1, 0, 1}}));
-            System.out.println(count_islands(((int[][])(grid))));
+            System.out.println(count_islands(((long[][])(grid))));
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -96,12 +94,6 @@ visited[row][col] = true;
 
     static boolean[] appendBool(boolean[] arr, boolean v) {
         boolean[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
-        out[arr.length] = v;
-        return out;
-    }
-
-    static <T> T[] appendObj(T[] arr, T v) {
-        T[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
         out[arr.length] = v;
         return out;
     }

--- a/tests/algorithms/x/Java/matrix/count_negative_numbers_in_sorted_matrix.bench
+++ b/tests/algorithms/x/Java/matrix/count_negative_numbers_in_sorted_matrix.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 5380895,
-  "memory_bytes": 8108088,
-  "name": "main"
-}
+{"duration_us": 6011519, "memory_bytes": 16190736, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/count_negative_numbers_in_sorted_matrix.java
+++ b/tests/algorithms/x/Java/matrix/count_negative_numbers_in_sorted_matrix.java
@@ -1,100 +1,100 @@
 public class Main {
-    static int[][] grid;
-    static int[][][] test_grids;
-    static int[] results_bin = new int[0];
-    static int i_4 = 0;
-    static int[] results_brute = new int[0];
-    static int[] results_break = new int[0];
+    static long[][] grid;
+    static long[][][] test_grids;
+    static long[] results_bin = ((long[])(new long[]{}));
+    static long i_8 = 0L;
+    static long[] results_brute = ((long[])(new long[]{}));
+    static long[] results_break = ((long[])(new long[]{}));
 
-    static int[][] generate_large_matrix() {
-        int[][] result = ((int[][])(new int[][]{}));
-        int i = 0;
-        while (i < 1000) {
-            int[] row = ((int[])(new int[]{}));
-            int j = 1000 - i;
-            while (j > (-1000 - i)) {
-                row = ((int[])(java.util.stream.IntStream.concat(java.util.Arrays.stream(row), java.util.stream.IntStream.of(j)).toArray()));
-                j = j - 1;
+    static long[][] generate_large_matrix() {
+        long[][] result = ((long[][])(new long[][]{}));
+        long i_1 = 0L;
+        while ((long)(i_1) < 1000L) {
+            long[] row_1 = ((long[])(new long[]{}));
+            long j_1 = (long)(1000L - (long)(i_1));
+            while ((long)(j_1) > (long)(((long)(-1000) - (long)(i_1)))) {
+                row_1 = ((long[])(appendLong(row_1, (long)(j_1))));
+                j_1 = (long)((long)(j_1) - 1L);
             }
-            result = ((int[][])(appendObj(result, row)));
-            i = i + 1;
+            result = ((long[][])(java.util.stream.Stream.concat(java.util.Arrays.stream(result), java.util.stream.Stream.of(new long[][]{row_1})).toArray(long[][]::new)));
+            i_1 = (long)((long)(i_1) + 1L);
         }
         return result;
     }
 
-    static int find_negative_index(int[] arr) {
-        int left = 0;
-        int right = arr.length - 1;
-        if (arr.length == 0) {
+    static long find_negative_index(long[] arr) {
+        long left = 0L;
+        long right_1 = (long)((long)(arr.length) - 1L);
+        if ((long)(arr.length) == 0L) {
             return 0;
         }
-        if (arr[0] < 0) {
+        if ((long)(arr[(int)(0L)]) < 0L) {
             return 0;
         }
-        while (left <= right) {
-            int mid = Math.floorDiv((left + right), 2);
-            int num = arr[mid];
-            if (num < 0) {
-                if (mid == 0) {
+        while ((long)(left) <= (long)(right_1)) {
+            long mid_1 = Math.floorDiv(((long)(left) + (long)(right_1)), 2);
+            long num_1 = (long)(arr[(int)((long)(mid_1))]);
+            if ((long)(num_1) < 0L) {
+                if ((long)(mid_1) == 0L) {
                     return 0;
                 }
-                if (arr[mid - 1] >= 0) {
-                    return mid;
+                if ((long)(arr[(int)((long)((long)(mid_1) - 1L))]) >= 0L) {
+                    return mid_1;
                 }
-                right = mid - 1;
+                right_1 = (long)((long)(mid_1) - 1L);
             } else {
-                left = mid + 1;
+                left = (long)((long)(mid_1) + 1L);
             }
         }
         return arr.length;
     }
 
-    static int count_negatives_binary_search(int[][] grid) {
-        int total = 0;
-        int bound = grid[0].length;
-        int i_1 = 0;
-        while (i_1 < grid.length) {
-            int[] row_1 = ((int[])(grid[i_1]));
-            int idx = find_negative_index(((int[])(java.util.Arrays.copyOfRange(row_1, 0, bound))));
-            bound = idx;
-            total = total + idx;
-            i_1 = i_1 + 1;
+    static long count_negatives_binary_search(long[][] grid) {
+        long total = 0L;
+        long bound_1 = (long)(grid[(int)(0L)].length);
+        long i_3 = 0L;
+        while ((long)(i_3) < (long)(grid.length)) {
+            long[] row_3 = ((long[])(grid[(int)((long)(i_3))]));
+            long idx_1 = (long)(find_negative_index(((long[])(java.util.Arrays.copyOfRange(row_3, (int)(0L), (int)((long)(bound_1)))))));
+            bound_1 = (long)(idx_1);
+            total = (long)((long)(total) + (long)(idx_1));
+            i_3 = (long)((long)(i_3) + 1L);
         }
-        return (grid.length * grid[0].length) - total;
+        return (long)(((long)(grid.length) * (long)(grid[(int)(0L)].length))) - (long)(total);
     }
 
-    static int count_negatives_brute_force(int[][] grid) {
-        int count = 0;
-        int i_2 = 0;
-        while (i_2 < grid.length) {
-            int[] row_2 = ((int[])(grid[i_2]));
-            int j_1 = 0;
-            while (j_1 < row_2.length) {
-                if (row_2[j_1] < 0) {
-                    count = count + 1;
+    static long count_negatives_brute_force(long[][] grid) {
+        long count = 0L;
+        long i_5 = 0L;
+        while ((long)(i_5) < (long)(grid.length)) {
+            long[] row_5 = ((long[])(grid[(int)((long)(i_5))]));
+            long j_3 = 0L;
+            while ((long)(j_3) < (long)(row_5.length)) {
+                if ((long)(row_5[(int)((long)(j_3))]) < 0L) {
+                    count = (long)((long)(count) + 1L);
                 }
-                j_1 = j_1 + 1;
+                j_3 = (long)((long)(j_3) + 1L);
             }
-            i_2 = i_2 + 1;
+            i_5 = (long)((long)(i_5) + 1L);
         }
         return count;
     }
 
-    static int count_negatives_brute_force_with_break(int[][] grid) {
-        int total_1 = 0;
-        int i_3 = 0;
-        while (i_3 < grid.length) {
-            int[] row_3 = ((int[])(grid[i_3]));
-            int j_2 = 0;
-            while (j_2 < row_3.length) {
-                int number = row_3[j_2];
-                if (number < 0) {
-                    total_1 = total_1 + (row_3.length - j_2);
+    static long count_negatives_brute_force_with_break(long[][] grid) {
+        long total_1 = 0L;
+        long i_7 = 0L;
+        while ((long)(i_7) < (long)(grid.length)) {
+            long[] row_7 = ((long[])(grid[(int)((long)(i_7))]));
+            long j_5 = 0L;
+            while ((long)(j_5) < (long)(row_7.length)) {
+                long number_1 = (long)(row_7[(int)((long)(j_5))]);
+                if ((long)(number_1) < 0L) {
+                    total_1 = (long)((long)(total_1) + (long)(((long)(row_7.length) - (long)(j_5))));
                     break;
                 }
-                j_2 = j_2 + 1;
+                j_5 = (long)((long)(j_5) + 1L);
             }
-            i_3 = i_3 + 1;
+            i_7 = (long)((long)(i_7) + 1L);
         }
         return total_1;
     }
@@ -102,36 +102,28 @@ public class Main {
         {
             long _benchStart = _now();
             long _benchMem = _mem();
-            grid = ((int[][])(generate_large_matrix()));
-            test_grids = ((int[][][])(new int[][][]{new int[][]{new int[]{4, 3, 2, -1}, new int[]{3, 2, 1, -1}, new int[]{1, 1, -1, -2}, new int[]{-1, -1, -2, -3}}, new int[][]{new int[]{3, 2}, new int[]{1, 0}}, new int[][]{new int[]{7, 7, 6}}, new int[][]{new int[]{7, 7, 6}, new int[]{-1, -2, -3}}, grid}));
-            results_bin = ((int[])(new int[]{}));
-            i_4 = 0;
-            while (i_4 < test_grids.length) {
-                results_bin = ((int[])(java.util.stream.IntStream.concat(java.util.Arrays.stream(results_bin), java.util.stream.IntStream.of(count_negatives_binary_search(((int[][])(test_grids[i_4]))))).toArray()));
-                i_4 = i_4 + 1;
+            grid = ((long[][])(generate_large_matrix()));
+            test_grids = ((long[][][])(new long[][][]{new long[][]{new long[]{4, 3, 2, -1}, new long[]{3, 2, 1, -1}, new long[]{1, 1, -1, -2}, new long[]{-1, -1, -2, -3}}, new long[][]{new long[]{3, 2}, new long[]{1, 0}}, new long[][]{new long[]{7, 7, 6}}, new long[][]{new long[]{7, 7, 6}, new long[]{-1, -2, -3}}, grid}));
+            while ((long)(i_8) < (long)(test_grids.length)) {
+                results_bin = ((long[])(appendLong(results_bin, (long)(count_negatives_binary_search(((long[][])(test_grids[(int)((long)(i_8))])))))));
+                i_8 = (long)((long)(i_8) + 1L);
             }
             System.out.println(_p(results_bin));
-            results_brute = ((int[])(new int[]{}));
-            i_4 = 0;
-            while (i_4 < test_grids.length) {
-                results_brute = ((int[])(java.util.stream.IntStream.concat(java.util.Arrays.stream(results_brute), java.util.stream.IntStream.of(count_negatives_brute_force(((int[][])(test_grids[i_4]))))).toArray()));
-                i_4 = i_4 + 1;
+            i_8 = 0L;
+            while ((long)(i_8) < (long)(test_grids.length)) {
+                results_brute = ((long[])(appendLong(results_brute, (long)(count_negatives_brute_force(((long[][])(test_grids[(int)((long)(i_8))])))))));
+                i_8 = (long)((long)(i_8) + 1L);
             }
             System.out.println(_p(results_brute));
-            results_break = ((int[])(new int[]{}));
-            i_4 = 0;
-            while (i_4 < test_grids.length) {
-                results_break = ((int[])(java.util.stream.IntStream.concat(java.util.Arrays.stream(results_break), java.util.stream.IntStream.of(count_negatives_brute_force_with_break(((int[][])(test_grids[i_4]))))).toArray()));
-                i_4 = i_4 + 1;
+            i_8 = 0L;
+            while ((long)(i_8) < (long)(test_grids.length)) {
+                results_break = ((long[])(appendLong(results_break, (long)(count_negatives_brute_force_with_break(((long[][])(test_grids[(int)((long)(i_8))])))))));
+                i_8 = (long)((long)(i_8) + 1L);
             }
             System.out.println(_p(results_break));
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -158,8 +150,8 @@ public class Main {
         return rt.totalMemory() - rt.freeMemory();
     }
 
-    static <T> T[] appendObj(T[] arr, T v) {
-        T[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+    static long[] appendLong(long[] arr, long v) {
+        long[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
         out[arr.length] = v;
         return out;
     }
@@ -176,6 +168,10 @@ public class Main {
             if (v instanceof short[]) return java.util.Arrays.toString((short[]) v);
             if (v instanceof float[]) return java.util.Arrays.toString((float[]) v);
             return java.util.Arrays.deepToString((Object[]) v);
+        }
+        if (v instanceof Double || v instanceof Float) {
+            double d = ((Number) v).doubleValue();
+            return String.valueOf(d);
         }
         return String.valueOf(v);
     }

--- a/tests/algorithms/x/Java/matrix/count_paths.bench
+++ b/tests/algorithms/x/Java/matrix/count_paths.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 30576,
-  "memory_bytes": 992,
-  "name": "main"
-}
+{"duration_us": 39219, "memory_bytes": 46976, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/count_paths.java
+++ b/tests/algorithms/x/Java/matrix/count_paths.java
@@ -1,53 +1,53 @@
 public class Main {
 
-    static int depth_first_search(int[][] grid, int row, int col, boolean[][] visit) {
-        int row_length = grid.length;
-        int col_length = grid[0].length;
-        if (row < 0 || col < 0 || row == row_length || col == col_length) {
+    static long depth_first_search(long[][] grid, long row, long col, boolean[][] visit) {
+        long row_length = (long)(grid.length);
+        long col_length_1 = (long)(grid[(int)(0L)].length);
+        if ((long)(row) < 0L || (long)(col) < 0L || (long)(row) == (long)(row_length) || (long)(col) == (long)(col_length_1)) {
             return 0;
         }
-        if (((Boolean)(visit[row][col]))) {
+        if (visit[(int)((long)(row))][(int)((long)(col))]) {
             return 0;
         }
-        if (grid[row][col] == 1) {
+        if ((long)(grid[(int)((long)(row))][(int)((long)(col))]) == 1L) {
             return 0;
         }
-        if (row == row_length - 1 && col == col_length - 1) {
+        if ((long)(row) == (long)((long)(row_length) - 1L) && (long)(col) == (long)((long)(col_length_1) - 1L)) {
             return 1;
         }
-visit[row][col] = true;
-        int count = 0;
-        count = count + depth_first_search(((int[][])(grid)), row + 1, col, ((boolean[][])(visit)));
-        count = count + depth_first_search(((int[][])(grid)), row - 1, col, ((boolean[][])(visit)));
-        count = count + depth_first_search(((int[][])(grid)), row, col + 1, ((boolean[][])(visit)));
-        count = count + depth_first_search(((int[][])(grid)), row, col - 1, ((boolean[][])(visit)));
-visit[row][col] = false;
-        return count;
+visit[(int)((long)(row))][(int)((long)(col))] = true;
+        long count_1 = 0L;
+        count_1 = (long)((long)(count_1) + (long)(depth_first_search(((long[][])(grid)), (long)((long)(row) + 1L), (long)(col), ((boolean[][])(visit)))));
+        count_1 = (long)((long)(count_1) + (long)(depth_first_search(((long[][])(grid)), (long)((long)(row) - 1L), (long)(col), ((boolean[][])(visit)))));
+        count_1 = (long)((long)(count_1) + (long)(depth_first_search(((long[][])(grid)), (long)(row), (long)((long)(col) + 1L), ((boolean[][])(visit)))));
+        count_1 = (long)((long)(count_1) + (long)(depth_first_search(((long[][])(grid)), (long)(row), (long)((long)(col) - 1L), ((boolean[][])(visit)))));
+visit[(int)((long)(row))][(int)((long)(col))] = false;
+        return count_1;
     }
 
-    static int count_paths(int[][] grid) {
-        int rows = grid.length;
-        int cols = grid[0].length;
-        boolean[][] visit = ((boolean[][])(new boolean[][]{}));
-        int i = 0;
-        while (i < rows) {
-            boolean[] row_visit = ((boolean[])(new boolean[]{}));
-            int j = 0;
-            while (j < cols) {
-                row_visit = ((boolean[])(appendBool(row_visit, false)));
-                j = j + 1;
+    static long count_paths(long[][] grid) {
+        long rows = (long)(grid.length);
+        long cols_1 = (long)(grid[(int)(0L)].length);
+        boolean[][] visit_1 = ((boolean[][])(new boolean[][]{}));
+        long i_1 = 0L;
+        while ((long)(i_1) < (long)(rows)) {
+            boolean[] row_visit_1 = ((boolean[])(new boolean[]{}));
+            long j_1 = 0L;
+            while ((long)(j_1) < (long)(cols_1)) {
+                row_visit_1 = ((boolean[])(appendBool(row_visit_1, false)));
+                j_1 = (long)((long)(j_1) + 1L);
             }
-            visit = ((boolean[][])(appendObj(visit, row_visit)));
-            i = i + 1;
+            visit_1 = ((boolean[][])(java.util.stream.Stream.concat(java.util.Arrays.stream(visit_1), java.util.stream.Stream.of(new boolean[][]{row_visit_1})).toArray(boolean[][]::new)));
+            i_1 = (long)((long)(i_1) + 1L);
         }
-        return depth_first_search(((int[][])(grid)), 0, 0, ((boolean[][])(visit)));
+        return depth_first_search(((long[][])(grid)), 0L, 0L, ((boolean[][])(visit_1)));
     }
 
     static void main() {
-        int[][] grid1 = ((int[][])(new int[][]{new int[]{0, 0, 0, 0}, new int[]{1, 1, 0, 0}, new int[]{0, 0, 0, 1}, new int[]{0, 1, 0, 0}}));
-        System.out.println(_p(count_paths(((int[][])(grid1)))));
-        int[][] grid2 = ((int[][])(new int[][]{new int[]{0, 0, 0, 0, 0}, new int[]{0, 1, 1, 1, 0}, new int[]{0, 1, 1, 1, 0}, new int[]{0, 0, 0, 0, 0}}));
-        System.out.println(_p(count_paths(((int[][])(grid2)))));
+        long[][] grid1 = ((long[][])(new long[][]{new long[]{0, 0, 0, 0}, new long[]{1, 1, 0, 0}, new long[]{0, 0, 0, 1}, new long[]{0, 1, 0, 0}}));
+        System.out.println(_p(count_paths(((long[][])(grid1)))));
+        long[][] grid2_1 = ((long[][])(new long[][]{new long[]{0, 0, 0, 0, 0}, new long[]{0, 1, 1, 1, 0}, new long[]{0, 1, 1, 1, 0}, new long[]{0, 0, 0, 0, 0}}));
+        System.out.println(_p(count_paths(((long[][])(grid2_1)))));
     }
     public static void main(String[] args) {
         {
@@ -56,11 +56,7 @@ visit[row][col] = false;
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -93,12 +89,6 @@ visit[row][col] = false;
         return out;
     }
 
-    static <T> T[] appendObj(T[] arr, T v) {
-        T[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
-        out[arr.length] = v;
-        return out;
-    }
-
     static String _p(Object v) {
         if (v == null) return "<nil>";
         if (v.getClass().isArray()) {
@@ -111,6 +101,10 @@ visit[row][col] = false;
             if (v instanceof short[]) return java.util.Arrays.toString((short[]) v);
             if (v instanceof float[]) return java.util.Arrays.toString((float[]) v);
             return java.util.Arrays.deepToString((Object[]) v);
+        }
+        if (v instanceof Double || v instanceof Float) {
+            double d = ((Number) v).doubleValue();
+            return String.valueOf(d);
         }
         return String.valueOf(v);
     }

--- a/tests/algorithms/x/Java/matrix/cramers_rule_2x2.bench
+++ b/tests/algorithms/x/Java/matrix/cramers_rule_2x2.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 27504,
-  "memory_bytes": 496,
-  "name": "main"
-}
+{"duration_us": 21398, "memory_bytes": 496, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/cramers_rule_2x2.java
+++ b/tests/algorithms/x/Java/matrix/cramers_rule_2x2.java
@@ -1,42 +1,42 @@
 public class Main {
 
     static double[] cramers_rule_2x2(double[] eq1, double[] eq2) {
-        if (eq1.length != 3 || eq2.length != 3) {
+        if ((long)(eq1.length) != 3L || (long)(eq2.length) != 3L) {
             throw new RuntimeException(String.valueOf("Please enter a valid equation."));
         }
-        if (eq1[0] == 0.0 && eq1[1] == 0.0 && eq2[0] == 0.0 && eq2[1] == 0.0) {
+        if ((double)(eq1[(int)(0L)]) == (double)(0.0) && (double)(eq1[(int)(1L)]) == (double)(0.0) && (double)(eq2[(int)(0L)]) == (double)(0.0) && (double)(eq2[(int)(1L)]) == (double)(0.0)) {
             throw new RuntimeException(String.valueOf("Both a & b of two equations can't be zero."));
         }
-        double a1 = eq1[0];
-        double b1 = eq1[1];
-        double c1 = eq1[2];
-        double a2 = eq2[0];
-        double b2 = eq2[1];
-        double c2 = eq2[2];
-        double determinant = a1 * b2 - a2 * b1;
-        double determinant_x = c1 * b2 - c2 * b1;
-        double determinant_y = a1 * c2 - a2 * c1;
-        if (determinant == 0.0) {
-            if (determinant_x == 0.0 && determinant_y == 0.0) {
+        double a1_1 = (double)(eq1[(int)(0L)]);
+        double b1_1 = (double)(eq1[(int)(1L)]);
+        double c1_1 = (double)(eq1[(int)(2L)]);
+        double a2_1 = (double)(eq2[(int)(0L)]);
+        double b2_1 = (double)(eq2[(int)(1L)]);
+        double c2_1 = (double)(eq2[(int)(2L)]);
+        double determinant_1 = (double)((double)((double)(a1_1) * (double)(b2_1)) - (double)((double)(a2_1) * (double)(b1_1)));
+        double determinant_x_1 = (double)((double)((double)(c1_1) * (double)(b2_1)) - (double)((double)(c2_1) * (double)(b1_1)));
+        double determinant_y_1 = (double)((double)((double)(a1_1) * (double)(c2_1)) - (double)((double)(a2_1) * (double)(c1_1)));
+        if ((double)(determinant_1) == (double)(0.0)) {
+            if ((double)(determinant_x_1) == (double)(0.0) && (double)(determinant_y_1) == (double)(0.0)) {
                 throw new RuntimeException(String.valueOf("Infinite solutions. (Consistent system)"));
             }
             throw new RuntimeException(String.valueOf("No solution. (Inconsistent system)"));
         }
-        if (determinant_x == 0.0 && determinant_y == 0.0) {
+        if ((double)(determinant_x_1) == (double)(0.0) && (double)(determinant_y_1) == (double)(0.0)) {
             return new double[]{0.0, 0.0};
         }
-        double x = determinant_x / determinant;
-        double y = determinant_y / determinant;
-        return new double[]{x, y};
+        double x_1 = (double)((double)(determinant_x_1) / (double)(determinant_1));
+        double y_1 = (double)((double)(determinant_y_1) / (double)(determinant_1));
+        return new double[]{x_1, y_1};
     }
 
     static void test_cramers_rule_2x2() {
         double[] r1 = ((double[])(cramers_rule_2x2(((double[])(new double[]{2.0, 3.0, 0.0})), ((double[])(new double[]{5.0, 1.0, 0.0})))));
-        if (r1[0] != 0.0 || r1[1] != 0.0) {
+        if ((double)(r1[(int)(0L)]) != (double)(0.0) || (double)(r1[(int)(1L)]) != (double)(0.0)) {
             throw new RuntimeException(String.valueOf("Test1 failed"));
         }
-        double[] r2 = ((double[])(cramers_rule_2x2(((double[])(new double[]{0.0, 4.0, 50.0})), ((double[])(new double[]{2.0, 0.0, 26.0})))));
-        if (r2[0] != 13.0 || r2[1] != 12.5) {
+        double[] r2_1 = ((double[])(cramers_rule_2x2(((double[])(new double[]{0.0, 4.0, 50.0})), ((double[])(new double[]{2.0, 0.0, 26.0})))));
+        if ((double)(r2_1[(int)(0L)]) != (double)(13.0) || (double)(r2_1[(int)(1L)]) != (double)(12.5)) {
             throw new RuntimeException(String.valueOf("Test2 failed"));
         }
     }
@@ -52,11 +52,7 @@ public class Main {
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/matrix/inverse_of_matrix.bench
+++ b/tests/algorithms/x/Java/matrix/inverse_of_matrix.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 28718,
-  "memory_bytes": 704,
-  "name": "main"
-}
+{"duration_us": 25774, "memory_bytes": 496, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/inverse_of_matrix.java
+++ b/tests/algorithms/x/Java/matrix/inverse_of_matrix.java
@@ -1,40 +1,40 @@
 public class Main {
-    static double[][] m2 = new double[0][];
-    static double[][] m3 = new double[0][];
+    static double[][] m2 = ((double[][])(new double[][]{new double[]{2.0, 5.0}, new double[]{2.0, 0.0}}));
+    static double[][] m3 = ((double[][])(new double[][]{new double[]{2.0, 5.0, 7.0}, new double[]{2.0, 0.0, 1.0}, new double[]{1.0, 2.0, 3.0}}));
 
     static double[][] inverse_of_matrix(double[][] matrix) {
-        if (matrix.length == 2 && matrix[0].length == 2 && matrix[1].length == 2) {
-            double det = matrix[0][0] * matrix[1][1] - matrix[1][0] * matrix[0][1];
-            if (det == 0.0) {
+        if ((long)(matrix.length) == 2L && (long)(matrix[(int)(0L)].length) == 2L && (long)(matrix[(int)(1L)].length) == 2L) {
+            double det = (double)((double)((double)(matrix[(int)(0L)][(int)(0L)]) * (double)(matrix[(int)(1L)][(int)(1L)])) - (double)((double)(matrix[(int)(1L)][(int)(0L)]) * (double)(matrix[(int)(0L)][(int)(1L)])));
+            if ((double)(det) == (double)(0.0)) {
                 System.out.println("This matrix has no inverse.");
                 return new double[][]{};
             }
-            return new double[][]{new double[]{matrix[1][1] / det, -matrix[0][1] / det}, new double[]{-matrix[1][0] / det, matrix[0][0] / det}};
-        } else         if (matrix.length == 3 && matrix[0].length == 3 && matrix[1].length == 3 && matrix[2].length == 3) {
-            double det_1 = matrix[0][0] * matrix[1][1] * matrix[2][2] + matrix[0][1] * matrix[1][2] * matrix[2][0] + matrix[0][2] * matrix[1][0] * matrix[2][1] - (matrix[0][2] * matrix[1][1] * matrix[2][0] + matrix[0][1] * matrix[1][0] * matrix[2][2] + matrix[0][0] * matrix[1][2] * matrix[2][1]);
-            if (det_1 == 0.0) {
+            return new double[][]{new double[]{(double)(matrix[(int)(1L)][(int)(1L)]) / (double)(det), (double)(-matrix[(int)(0L)][(int)(1L)]) / (double)(det)}, new double[]{(double)(-matrix[(int)(1L)][(int)(0L)]) / (double)(det), (double)(matrix[(int)(0L)][(int)(0L)]) / (double)(det)}};
+        } else         if ((long)(matrix.length) == 3L && (long)(matrix[(int)(0L)].length) == 3L && (long)(matrix[(int)(1L)].length) == 3L && (long)(matrix[(int)(2L)].length) == 3L) {
+            double det_1 = (double)((double)((double)((double)((double)((double)(matrix[(int)(0L)][(int)(0L)]) * (double)(matrix[(int)(1L)][(int)(1L)])) * (double)(matrix[(int)(2L)][(int)(2L)])) + (double)((double)((double)(matrix[(int)(0L)][(int)(1L)]) * (double)(matrix[(int)(1L)][(int)(2L)])) * (double)(matrix[(int)(2L)][(int)(0L)]))) + (double)((double)((double)(matrix[(int)(0L)][(int)(2L)]) * (double)(matrix[(int)(1L)][(int)(0L)])) * (double)(matrix[(int)(2L)][(int)(1L)]))) - (double)(((double)((double)((double)((double)(matrix[(int)(0L)][(int)(2L)]) * (double)(matrix[(int)(1L)][(int)(1L)])) * (double)(matrix[(int)(2L)][(int)(0L)])) + (double)((double)((double)(matrix[(int)(0L)][(int)(1L)]) * (double)(matrix[(int)(1L)][(int)(0L)])) * (double)(matrix[(int)(2L)][(int)(2L)]))) + (double)((double)((double)(matrix[(int)(0L)][(int)(0L)]) * (double)(matrix[(int)(1L)][(int)(2L)])) * (double)(matrix[(int)(2L)][(int)(1L)])))));
+            if ((double)(det_1) == (double)(0.0)) {
                 System.out.println("This matrix has no inverse.");
                 return new double[][]{};
             }
             double[][] cof = ((double[][])(new double[][]{new double[]{0.0, 0.0, 0.0}, new double[]{0.0, 0.0, 0.0}, new double[]{0.0, 0.0, 0.0}}));
-cof[0][0] = matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1];
-cof[0][1] = -(matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0]);
-cof[0][2] = matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0];
-cof[1][0] = -(matrix[0][1] * matrix[2][2] - matrix[0][2] * matrix[2][1]);
-cof[1][1] = matrix[0][0] * matrix[2][2] - matrix[0][2] * matrix[2][0];
-cof[1][2] = -(matrix[0][0] * matrix[2][1] - matrix[0][1] * matrix[2][0]);
-cof[2][0] = matrix[0][1] * matrix[1][2] - matrix[0][2] * matrix[1][1];
-cof[2][1] = -(matrix[0][0] * matrix[1][2] - matrix[0][2] * matrix[1][0]);
-cof[2][2] = matrix[0][0] * matrix[1][1] - matrix[0][1] * matrix[1][0];
+cof[(int)(0L)][(int)(0L)] = (double)((double)((double)(matrix[(int)(1L)][(int)(1L)]) * (double)(matrix[(int)(2L)][(int)(2L)])) - (double)((double)(matrix[(int)(1L)][(int)(2L)]) * (double)(matrix[(int)(2L)][(int)(1L)])));
+cof[(int)(0L)][(int)(1L)] = (double)(-((double)((double)(matrix[(int)(1L)][(int)(0L)]) * (double)(matrix[(int)(2L)][(int)(2L)])) - (double)((double)(matrix[(int)(1L)][(int)(2L)]) * (double)(matrix[(int)(2L)][(int)(0L)]))));
+cof[(int)(0L)][(int)(2L)] = (double)((double)((double)(matrix[(int)(1L)][(int)(0L)]) * (double)(matrix[(int)(2L)][(int)(1L)])) - (double)((double)(matrix[(int)(1L)][(int)(1L)]) * (double)(matrix[(int)(2L)][(int)(0L)])));
+cof[(int)(1L)][(int)(0L)] = (double)(-((double)((double)(matrix[(int)(0L)][(int)(1L)]) * (double)(matrix[(int)(2L)][(int)(2L)])) - (double)((double)(matrix[(int)(0L)][(int)(2L)]) * (double)(matrix[(int)(2L)][(int)(1L)]))));
+cof[(int)(1L)][(int)(1L)] = (double)((double)((double)(matrix[(int)(0L)][(int)(0L)]) * (double)(matrix[(int)(2L)][(int)(2L)])) - (double)((double)(matrix[(int)(0L)][(int)(2L)]) * (double)(matrix[(int)(2L)][(int)(0L)])));
+cof[(int)(1L)][(int)(2L)] = (double)(-((double)((double)(matrix[(int)(0L)][(int)(0L)]) * (double)(matrix[(int)(2L)][(int)(1L)])) - (double)((double)(matrix[(int)(0L)][(int)(1L)]) * (double)(matrix[(int)(2L)][(int)(0L)]))));
+cof[(int)(2L)][(int)(0L)] = (double)((double)((double)(matrix[(int)(0L)][(int)(1L)]) * (double)(matrix[(int)(1L)][(int)(2L)])) - (double)((double)(matrix[(int)(0L)][(int)(2L)]) * (double)(matrix[(int)(1L)][(int)(1L)])));
+cof[(int)(2L)][(int)(1L)] = (double)(-((double)((double)(matrix[(int)(0L)][(int)(0L)]) * (double)(matrix[(int)(1L)][(int)(2L)])) - (double)((double)(matrix[(int)(0L)][(int)(2L)]) * (double)(matrix[(int)(1L)][(int)(0L)]))));
+cof[(int)(2L)][(int)(2L)] = (double)((double)((double)(matrix[(int)(0L)][(int)(0L)]) * (double)(matrix[(int)(1L)][(int)(1L)])) - (double)((double)(matrix[(int)(0L)][(int)(1L)]) * (double)(matrix[(int)(1L)][(int)(0L)])));
             double[][] inv = ((double[][])(new double[][]{new double[]{0.0, 0.0, 0.0}, new double[]{0.0, 0.0, 0.0}, new double[]{0.0, 0.0, 0.0}}));
-            int i = 0;
-            while (i < 3) {
-                int j = 0;
-                while (j < 3) {
-inv[i][j] = cof[j][i] / det_1;
-                    j = j + 1;
+            long i = 0L;
+            while ((long)(i) < 3L) {
+                long j = 0L;
+                while ((long)(j) < 3L) {
+inv[(int)((long)(i))][(int)((long)(j))] = (double)((double)(cof[(int)((long)(j))][(int)((long)(i))]) / (double)(det_1));
+                    j = (long)((long)(j) + 1L);
                 }
-                i = i + 1;
+                i = (long)((long)(i) + 1L);
             }
             return inv;
         }
@@ -45,17 +45,11 @@ inv[i][j] = cof[j][i] / det_1;
         {
             long _benchStart = _now();
             long _benchMem = _mem();
-            m2 = ((double[][])(new double[][]{new double[]{2.0, 5.0}, new double[]{2.0, 0.0}}));
             System.out.println(inverse_of_matrix(((double[][])(m2))));
-            m3 = ((double[][])(new double[][]{new double[]{2.0, 5.0, 7.0}, new double[]{2.0, 0.0, 1.0}, new double[]{1.0, 2.0, 3.0}}));
             System.out.println(inverse_of_matrix(((double[][])(m3))));
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/matrix/largest_square_area_in_matrix.bench
+++ b/tests/algorithms/x/Java/matrix/largest_square_area_in_matrix.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 39384,
-  "memory_bytes": 49920,
-  "name": "main"
-}
+{"duration_us": 42090, "memory_bytes": 46952, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/largest_square_area_in_matrix.java
+++ b/tests/algorithms/x/Java/matrix/largest_square_area_in_matrix.java
@@ -1,17 +1,17 @@
 public class Main {
-    static long[][] sample;
+    static long[][] sample = ((long[][])(new long[][]{new long[]{1, 1}, new long[]{1, 1}}));
 
     static long update_area_of_max_square(long row, long col, long rows, long cols, long[][] mat, long[] largest_square_area) {
-        if (row >= rows || col >= cols) {
+        if ((long)(row) >= (long)(rows) || (long)(col) >= (long)(cols)) {
             return 0;
         }
-        long right_1 = update_area_of_max_square(row, col + 1, rows, cols, ((long[][])(mat)), ((long[])(largest_square_area)));
-        long diagonal_1 = update_area_of_max_square(row + 1, col + 1, rows, cols, ((long[][])(mat)), ((long[])(largest_square_area)));
-        long down_1 = update_area_of_max_square(row + 1, col, rows, cols, ((long[][])(mat)), ((long[])(largest_square_area)));
-        if (mat[(int)((long)(row))][(int)((long)(col))] == 1) {
-            long sub_1 = 1 + _minLong(new long[]{right_1, diagonal_1, down_1});
-            if (sub_1 > largest_square_area[(int)((long)(0))]) {
-largest_square_area[(int)((long)(0))] = sub_1;
+        long right_1 = (long)(update_area_of_max_square((long)(row), (long)((long)(col) + 1L), (long)(rows), (long)(cols), ((long[][])(mat)), ((long[])(largest_square_area))));
+        long diagonal_1 = (long)(update_area_of_max_square((long)((long)(row) + 1L), (long)((long)(col) + 1L), (long)(rows), (long)(cols), ((long[][])(mat)), ((long[])(largest_square_area))));
+        long down_1 = (long)(update_area_of_max_square((long)((long)(row) + 1L), (long)(col), (long)(rows), (long)(cols), ((long[][])(mat)), ((long[])(largest_square_area))));
+        if ((long)(mat[(int)((long)(row))][(int)((long)(col))]) == 1L) {
+            long sub_1 = (long)(1L + (long)(_minLong(new long[]{right_1, diagonal_1, down_1})));
+            if ((long)(sub_1) > (long)(largest_square_area[(int)(0L)])) {
+largest_square_area[(int)(0L)] = (long)(sub_1);
             }
             return sub_1;
         } else {
@@ -21,26 +21,26 @@ largest_square_area[(int)((long)(0))] = sub_1;
 
     static long largest_square_area_in_matrix_top_down(long rows, long cols, long[][] mat) {
         long[] largest = ((long[])(new long[]{0}));
-        update_area_of_max_square(0L, 0L, rows, cols, ((long[][])(mat)), ((long[])(largest)));
-        return largest[(int)((long)(0))];
+        update_area_of_max_square(0L, 0L, (long)(rows), (long)(cols), ((long[][])(mat)), ((long[])(largest)));
+        return largest[(int)(0L)];
     }
 
     static long update_area_of_max_square_with_dp(long row, long col, long rows, long cols, long[][] mat, long[][] dp_array, long[] largest_square_area) {
-        if (row >= rows || col >= cols) {
+        if ((long)(row) >= (long)(rows) || (long)(col) >= (long)(cols)) {
             return 0;
         }
-        if (dp_array[(int)((long)(row))][(int)((long)(col))] != (-1)) {
+        if ((long)(dp_array[(int)((long)(row))][(int)((long)(col))]) != (long)((-1))) {
             return dp_array[(int)((long)(row))][(int)((long)(col))];
         }
-        long right_3 = update_area_of_max_square_with_dp(row, col + 1, rows, cols, ((long[][])(mat)), ((long[][])(dp_array)), ((long[])(largest_square_area)));
-        long diagonal_3 = update_area_of_max_square_with_dp(row + 1, col + 1, rows, cols, ((long[][])(mat)), ((long[][])(dp_array)), ((long[])(largest_square_area)));
-        long down_3 = update_area_of_max_square_with_dp(row + 1, col, rows, cols, ((long[][])(mat)), ((long[][])(dp_array)), ((long[])(largest_square_area)));
-        if (mat[(int)((long)(row))][(int)((long)(col))] == 1) {
-            long sub_3 = 1 + _minLong(new long[]{right_3, diagonal_3, down_3});
-            if (sub_3 > largest_square_area[(int)((long)(0))]) {
-largest_square_area[(int)((long)(0))] = sub_3;
+        long right_3 = (long)(update_area_of_max_square_with_dp((long)(row), (long)((long)(col) + 1L), (long)(rows), (long)(cols), ((long[][])(mat)), ((long[][])(dp_array)), ((long[])(largest_square_area))));
+        long diagonal_3 = (long)(update_area_of_max_square_with_dp((long)((long)(row) + 1L), (long)((long)(col) + 1L), (long)(rows), (long)(cols), ((long[][])(mat)), ((long[][])(dp_array)), ((long[])(largest_square_area))));
+        long down_3 = (long)(update_area_of_max_square_with_dp((long)((long)(row) + 1L), (long)(col), (long)(rows), (long)(cols), ((long[][])(mat)), ((long[][])(dp_array)), ((long[])(largest_square_area))));
+        if ((long)(mat[(int)((long)(row))][(int)((long)(col))]) == 1L) {
+            long sub_3 = (long)(1L + (long)(_minLong(new long[]{right_3, diagonal_3, down_3})));
+            if ((long)(sub_3) > (long)(largest_square_area[(int)(0L)])) {
+largest_square_area[(int)(0L)] = (long)(sub_3);
             }
-dp_array[(int)((long)(row))][(int)((long)(col))] = sub_3;
+dp_array[(int)((long)(row))][(int)((long)(col))] = (long)(sub_3);
             return sub_3;
         } else {
 dp_array[(int)((long)(row))][(int)((long)(col))] = 0L;
@@ -52,53 +52,53 @@ dp_array[(int)((long)(row))][(int)((long)(col))] = 0L;
         long[] largest_1 = ((long[])(new long[]{0}));
         long[][] dp_array_1 = ((long[][])(new long[][]{}));
         long r_1 = 0L;
-        while (r_1 < rows) {
+        while ((long)(r_1) < (long)(rows)) {
             long[] row_list_1 = ((long[])(new long[]{}));
             long c_1 = 0L;
-            while (c_1 < cols) {
-                row_list_1 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(row_list_1), java.util.stream.LongStream.of(-1)).toArray()));
-                c_1 = c_1 + 1;
+            while ((long)(c_1) < (long)(cols)) {
+                row_list_1 = ((long[])(appendLong(row_list_1, (long)(-1))));
+                c_1 = (long)((long)(c_1) + 1L);
             }
-            dp_array_1 = ((long[][])(java.util.stream.Stream.concat(java.util.Arrays.stream(dp_array_1), java.util.stream.Stream.of(row_list_1)).toArray(long[][]::new)));
-            r_1 = r_1 + 1;
+            dp_array_1 = ((long[][])(java.util.stream.Stream.concat(java.util.Arrays.stream(dp_array_1), java.util.stream.Stream.of(new long[][]{row_list_1})).toArray(long[][]::new)));
+            r_1 = (long)((long)(r_1) + 1L);
         }
-        update_area_of_max_square_with_dp(0L, 0L, rows, cols, ((long[][])(mat)), ((long[][])(dp_array_1)), ((long[])(largest_1)));
-        return largest_1[(int)((long)(0))];
+        update_area_of_max_square_with_dp(0L, 0L, (long)(rows), (long)(cols), ((long[][])(mat)), ((long[][])(dp_array_1)), ((long[])(largest_1)));
+        return largest_1[(int)(0L)];
     }
 
     static long largest_square_area_in_matrix_bottom_up(long rows, long cols, long[][] mat) {
         long[][] dp_array_2 = ((long[][])(new long[][]{}));
         long r_3 = 0L;
-        while (r_3 <= rows) {
+        while ((long)(r_3) <= (long)(rows)) {
             long[] row_list_3 = ((long[])(new long[]{}));
             long c_3 = 0L;
-            while (c_3 <= cols) {
-                row_list_3 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(row_list_3), java.util.stream.LongStream.of(0L)).toArray()));
-                c_3 = c_3 + 1;
+            while ((long)(c_3) <= (long)(cols)) {
+                row_list_3 = ((long[])(appendLong(row_list_3, 0L)));
+                c_3 = (long)((long)(c_3) + 1L);
             }
-            dp_array_2 = ((long[][])(java.util.stream.Stream.concat(java.util.Arrays.stream(dp_array_2), java.util.stream.Stream.of(row_list_3)).toArray(long[][]::new)));
-            r_3 = r_3 + 1;
+            dp_array_2 = ((long[][])(java.util.stream.Stream.concat(java.util.Arrays.stream(dp_array_2), java.util.stream.Stream.of(new long[][]{row_list_3})).toArray(long[][]::new)));
+            r_3 = (long)((long)(r_3) + 1L);
         }
         long largest_3 = 0L;
-        long row_1 = rows - 1;
-        while (row_1 >= 0) {
-            long col_1 = cols - 1;
-            while (col_1 >= 0) {
-                long right_5 = dp_array_2[(int)((long)(row_1))][(int)((long)(col_1 + 1))];
-                long diagonal_5 = dp_array_2[(int)((long)(row_1 + 1))][(int)((long)(col_1 + 1))];
-                long bottom_1 = dp_array_2[(int)((long)(row_1 + 1))][(int)((long)(col_1))];
-                if (mat[(int)((long)(row_1))][(int)((long)(col_1))] == 1) {
-                    long value_1 = 1 + _minLong(new long[]{right_5, diagonal_5, bottom_1});
-dp_array_2[(int)((long)(row_1))][(int)((long)(col_1))] = value_1;
-                    if (value_1 > largest_3) {
-                        largest_3 = value_1;
+        long row_1 = (long)((long)(rows) - 1L);
+        while ((long)(row_1) >= 0L) {
+            long col_1 = (long)((long)(cols) - 1L);
+            while ((long)(col_1) >= 0L) {
+                long right_5 = (long)(dp_array_2[(int)((long)(row_1))][(int)((long)((long)(col_1) + 1L))]);
+                long diagonal_5 = (long)(dp_array_2[(int)((long)((long)(row_1) + 1L))][(int)((long)((long)(col_1) + 1L))]);
+                long bottom_1 = (long)(dp_array_2[(int)((long)((long)(row_1) + 1L))][(int)((long)(col_1))]);
+                if ((long)(mat[(int)((long)(row_1))][(int)((long)(col_1))]) == 1L) {
+                    long value_1 = (long)(1L + (long)(_minLong(new long[]{right_5, diagonal_5, bottom_1})));
+dp_array_2[(int)((long)(row_1))][(int)((long)(col_1))] = (long)(value_1);
+                    if ((long)(value_1) > (long)(largest_3)) {
+                        largest_3 = (long)(value_1);
                     }
                 } else {
 dp_array_2[(int)((long)(row_1))][(int)((long)(col_1))] = 0L;
                 }
-                col_1 = col_1 - 1;
+                col_1 = (long)((long)(col_1) - 1L);
             }
-            row_1 = row_1 - 1;
+            row_1 = (long)((long)(row_1) - 1L);
         }
         return largest_3;
     }
@@ -106,52 +106,87 @@ dp_array_2[(int)((long)(row_1))][(int)((long)(col_1))] = 0L;
     static long largest_square_area_in_matrix_bottom_up_space_optimization(long rows, long cols, long[][] mat) {
         long[] current_row = ((long[])(new long[]{}));
         long i_1 = 0L;
-        while (i_1 <= cols) {
-            current_row = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(current_row), java.util.stream.LongStream.of(0L)).toArray()));
-            i_1 = i_1 + 1;
+        while ((long)(i_1) <= (long)(cols)) {
+            current_row = ((long[])(appendLong(current_row, 0L)));
+            i_1 = (long)((long)(i_1) + 1L);
         }
         long[] next_row_1 = ((long[])(new long[]{}));
         long j_1 = 0L;
-        while (j_1 <= cols) {
-            next_row_1 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(next_row_1), java.util.stream.LongStream.of(0L)).toArray()));
-            j_1 = j_1 + 1;
+        while ((long)(j_1) <= (long)(cols)) {
+            next_row_1 = ((long[])(appendLong(next_row_1, 0L)));
+            j_1 = (long)((long)(j_1) + 1L);
         }
         long largest_5 = 0L;
-        long row_3 = rows - 1;
-        while (row_3 >= 0) {
-            long col_3 = cols - 1;
-            while (col_3 >= 0) {
-                long right_7 = current_row[(int)((long)(col_3 + 1))];
-                long diagonal_7 = next_row_1[(int)((long)(col_3 + 1))];
-                long bottom_3 = next_row_1[(int)((long)(col_3))];
-                if (mat[(int)((long)(row_3))][(int)((long)(col_3))] == 1) {
-                    long value_3 = 1 + _minLong(new long[]{right_7, diagonal_7, bottom_3});
-current_row[(int)((long)(col_3))] = value_3;
-                    if (value_3 > largest_5) {
-                        largest_5 = value_3;
+        long row_3 = (long)((long)(rows) - 1L);
+        while ((long)(row_3) >= 0L) {
+            long col_3 = (long)((long)(cols) - 1L);
+            while ((long)(col_3) >= 0L) {
+                long right_7 = (long)(current_row[(int)((long)((long)(col_3) + 1L))]);
+                long diagonal_7 = (long)(next_row_1[(int)((long)((long)(col_3) + 1L))]);
+                long bottom_3 = (long)(next_row_1[(int)((long)(col_3))]);
+                if ((long)(mat[(int)((long)(row_3))][(int)((long)(col_3))]) == 1L) {
+                    long value_3 = (long)(1L + (long)(_minLong(new long[]{right_7, diagonal_7, bottom_3})));
+current_row[(int)((long)(col_3))] = (long)(value_3);
+                    if ((long)(value_3) > (long)(largest_5)) {
+                        largest_5 = (long)(value_3);
                     }
                 } else {
 current_row[(int)((long)(col_3))] = 0L;
                 }
-                col_3 = col_3 - 1;
+                col_3 = (long)((long)(col_3) - 1L);
             }
             next_row_1 = ((long[])(current_row));
             current_row = ((long[])(new long[]{}));
             long t_1 = 0L;
-            while (t_1 <= cols) {
-                current_row = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(current_row), java.util.stream.LongStream.of(0L)).toArray()));
-                t_1 = t_1 + 1;
+            while ((long)(t_1) <= (long)(cols)) {
+                current_row = ((long[])(appendLong(current_row, 0L)));
+                t_1 = (long)((long)(t_1) + 1L);
             }
-            row_3 = row_3 - 1;
+            row_3 = (long)((long)(row_3) - 1L);
         }
         return largest_5;
     }
     public static void main(String[] args) {
-        sample = ((long[][])(new long[][]{new long[]{1, 1}, new long[]{1, 1}}));
-        System.out.println(largest_square_area_in_matrix_top_down(2L, 2L, ((long[][])(sample))));
-        System.out.println(largest_square_area_in_matrix_top_down_with_dp(2L, 2L, ((long[][])(sample))));
-        System.out.println(largest_square_area_in_matrix_bottom_up(2L, 2L, ((long[][])(sample))));
-        System.out.println(largest_square_area_in_matrix_bottom_up_space_optimization(2L, 2L, ((long[][])(sample))));
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            System.out.println(largest_square_area_in_matrix_top_down(2L, 2L, ((long[][])(sample))));
+            System.out.println(largest_square_area_in_matrix_top_down_with_dp(2L, 2L, ((long[][])(sample))));
+            System.out.println(largest_square_area_in_matrix_bottom_up(2L, 2L, ((long[][])(sample))));
+            System.out.println(largest_square_area_in_matrix_bottom_up_space_optimization(2L, 2L, ((long[][])(sample))));
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static long[] appendLong(long[] arr, long v) {
+        long[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
     }
 
     static long _minLong(long[] arr) {

--- a/tests/algorithms/x/Java/matrix/matrix_based_game.bench
+++ b/tests/algorithms/x/Java/matrix/matrix_based_game.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 62759,
-  "memory_bytes": 66568,
-  "name": "main"
-}
+{"duration_us": 57038, "memory_bytes": 67744, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/matrix_based_game.java
+++ b/tests/algorithms/x/Java/matrix/matrix_based_game.java
@@ -1,8 +1,8 @@
 public class Main {
     static class Coord {
-        int x;
-        int y;
-        Coord(int x, int y) {
+        long x;
+        long y;
+        Coord(long x, long y) {
             this.x = x;
             this.y = y;
         }
@@ -14,8 +14,8 @@ public class Main {
 
     static class PlayResult {
         String[][] matrix;
-        int score;
-        PlayResult(String[][] matrix, int score) {
+        long score;
+        PlayResult(String[][] matrix, long score) {
             this.matrix = matrix;
             this.score = score;
         }
@@ -30,275 +30,275 @@ public class Main {
         return ((ch.compareTo("0") >= 0) && (ch.compareTo("9") <= 0)) || ((ch.compareTo("A") >= 0) && (ch.compareTo("Z") <= 0)) || ((ch.compareTo("a") >= 0) && (ch.compareTo("z") <= 0));
     }
 
-    static int to_int(String token) {
-        int res = 0;
-        int i = 0;
-        while (i < _runeLen(token)) {
-            res = res * 10 + (Integer.parseInt(_substr(token, i, i + 1)));
-            i = i + 1;
+    static long to_int(String token) {
+        long res = 0L;
+        long i_1 = 0L;
+        while ((long)(i_1) < (long)(_runeLen(token))) {
+            res = (long)((long)((long)(res) * 10L) + (long)((Integer.parseInt(_substr(token, (int)((long)(i_1)), (int)((long)((long)(i_1) + 1L)))))));
+            i_1 = (long)((long)(i_1) + 1L);
         }
         return res;
     }
 
     static String[] split(String s, String sep) {
         String[] res_1 = ((String[])(new String[]{}));
-        String current = "";
-        int i_1 = 0;
-        while (i_1 < _runeLen(s)) {
-            String ch = _substr(s, i_1, i_1 + 1);
-            if ((ch.equals(sep))) {
-                res_1 = ((String[])(java.util.stream.Stream.concat(java.util.Arrays.stream(res_1), java.util.stream.Stream.of(current)).toArray(String[]::new)));
-                current = "";
+        String current_1 = "";
+        long i_3 = 0L;
+        while ((long)(i_3) < (long)(_runeLen(s))) {
+            String ch_1 = _substr(s, (int)((long)(i_3)), (int)((long)((long)(i_3) + 1L)));
+            if ((ch_1.equals(sep))) {
+                res_1 = ((String[])(java.util.stream.Stream.concat(java.util.Arrays.stream(res_1), java.util.stream.Stream.of(current_1)).toArray(String[]::new)));
+                current_1 = "";
             } else {
-                current = current + ch;
+                current_1 = current_1 + ch_1;
             }
-            i_1 = i_1 + 1;
+            i_3 = (long)((long)(i_3) + 1L);
         }
-        res_1 = ((String[])(java.util.stream.Stream.concat(java.util.Arrays.stream(res_1), java.util.stream.Stream.of(current)).toArray(String[]::new)));
+        res_1 = ((String[])(java.util.stream.Stream.concat(java.util.Arrays.stream(res_1), java.util.stream.Stream.of(current_1)).toArray(String[]::new)));
         return res_1;
     }
 
     static Coord[] parse_moves(String input_str) {
         String[] pairs = ((String[])(input_str.split(java.util.regex.Pattern.quote(","))));
-        Coord[] moves = ((Coord[])(new Coord[]{}));
-        int i_2 = 0;
-        while (i_2 < pairs.length) {
-            String pair = pairs[i_2];
-            String[] numbers = ((String[])(new String[]{}));
-            String num = "";
-            int j = 0;
-            while (j < _runeLen(pair)) {
-                String ch_1 = _substr(pair, j, j + 1);
-                if ((ch_1.equals(" "))) {
-                    if (!(num.equals(""))) {
-                        numbers = ((String[])(java.util.stream.Stream.concat(java.util.Arrays.stream(numbers), java.util.stream.Stream.of(num)).toArray(String[]::new)));
-                        num = "";
+        Coord[] moves_1 = ((Coord[])(new Coord[]{}));
+        long i_5 = 0L;
+        while ((long)(i_5) < (long)(pairs.length)) {
+            String pair_1 = pairs[(int)((long)(i_5))];
+            String[] numbers_1 = ((String[])(new String[]{}));
+            String num_1 = "";
+            long j_1 = 0L;
+            while ((long)(j_1) < (long)(_runeLen(pair_1))) {
+                String ch_3 = _substr(pair_1, (int)((long)(j_1)), (int)((long)((long)(j_1) + 1L)));
+                if ((ch_3.equals(" "))) {
+                    if (!(num_1.equals(""))) {
+                        numbers_1 = ((String[])(java.util.stream.Stream.concat(java.util.Arrays.stream(numbers_1), java.util.stream.Stream.of(num_1)).toArray(String[]::new)));
+                        num_1 = "";
                     }
                 } else {
-                    num = num + ch_1;
+                    num_1 = num_1 + ch_3;
                 }
-                j = j + 1;
+                j_1 = (long)((long)(j_1) + 1L);
             }
-            if (!(num.equals(""))) {
-                numbers = ((String[])(java.util.stream.Stream.concat(java.util.Arrays.stream(numbers), java.util.stream.Stream.of(num)).toArray(String[]::new)));
+            if (!(num_1.equals(""))) {
+                numbers_1 = ((String[])(java.util.stream.Stream.concat(java.util.Arrays.stream(numbers_1), java.util.stream.Stream.of(num_1)).toArray(String[]::new)));
             }
-            if (numbers.length != 2) {
+            if ((long)(numbers_1.length) != 2L) {
                 throw new RuntimeException(String.valueOf("Each move must have exactly two numbers."));
             }
-            int x = to_int(numbers[0]);
-            int y = to_int(numbers[1]);
-            moves = ((Coord[])(java.util.stream.Stream.concat(java.util.Arrays.stream(moves), java.util.stream.Stream.of(new Coord(x, y))).toArray(Coord[]::new)));
-            i_2 = i_2 + 1;
+            long x_1 = (long)(to_int(numbers_1[(int)(0L)]));
+            long y_1 = (long)(to_int(numbers_1[(int)(1L)]));
+            moves_1 = ((Coord[])(java.util.stream.Stream.concat(java.util.Arrays.stream(moves_1), java.util.stream.Stream.of(new Coord(x_1, y_1))).toArray(Coord[]::new)));
+            i_5 = (long)((long)(i_5) + 1L);
         }
-        return moves;
+        return moves_1;
     }
 
-    static void validate_matrix_size(int size) {
-        if (size <= 0) {
+    static void validate_matrix_size(long size) {
+        if ((long)(size) <= 0L) {
             throw new RuntimeException(String.valueOf("Matrix size must be a positive integer."));
         }
     }
 
-    static void validate_matrix_content(String[] matrix, int size) {
-        if (matrix.length != size) {
+    static void validate_matrix_content(String[] matrix, long size) {
+        if ((long)(matrix.length) != (long)(size)) {
             throw new RuntimeException(String.valueOf("The matrix dont match with size."));
         }
-        int i_3 = 0;
-        while (i_3 < size) {
-            String row = matrix[i_3];
-            if (_runeLen(row) != size) {
+        long i_7 = 0L;
+        while ((long)(i_7) < (long)(size)) {
+            String row_1 = matrix[(int)((long)(i_7))];
+            if ((long)(_runeLen(row_1)) != (long)(size)) {
                 throw new RuntimeException(String.valueOf("Each row in the matrix must have exactly " + _p(size) + " characters."));
             }
-            int j_1 = 0;
-            while (j_1 < size) {
-                String ch_2 = _substr(row, j_1, j_1 + 1);
-                if (!(Boolean)is_alnum(ch_2)) {
+            long j_3 = 0L;
+            while ((long)(j_3) < (long)(size)) {
+                String ch_5 = _substr(row_1, (int)((long)(j_3)), (int)((long)((long)(j_3) + 1L)));
+                if (!(Boolean)is_alnum(ch_5)) {
                     throw new RuntimeException(String.valueOf("Matrix rows can only contain letters and numbers."));
                 }
-                j_1 = j_1 + 1;
+                j_3 = (long)((long)(j_3) + 1L);
             }
-            i_3 = i_3 + 1;
+            i_7 = (long)((long)(i_7) + 1L);
         }
     }
 
-    static void validate_moves(Coord[] moves, int size) {
-        int i_4 = 0;
-        while (i_4 < moves.length) {
-            Coord mv = moves[i_4];
-            if (mv.x < 0 || mv.x >= size || mv.y < 0 || mv.y >= size) {
+    static void validate_moves(Coord[] moves, long size) {
+        long i_8 = 0L;
+        while ((long)(i_8) < (long)(moves.length)) {
+            Coord mv_1 = moves[(int)((long)(i_8))];
+            if ((long)(mv_1.x) < 0L || (long)(mv_1.x) >= (long)(size) || (long)(mv_1.y) < 0L || (long)(mv_1.y) >= (long)(size)) {
                 throw new RuntimeException(String.valueOf("Move is out of bounds for a matrix."));
             }
-            i_4 = i_4 + 1;
+            i_8 = (long)((long)(i_8) + 1L);
         }
     }
 
-    static boolean contains(Coord[] pos, int r, int c) {
-        int i_5 = 0;
-        while (i_5 < pos.length) {
-            Coord p = pos[i_5];
-            if (p.x == r && p.y == c) {
+    static boolean contains(Coord[] pos, long r, long c) {
+        long i_9 = 0L;
+        while ((long)(i_9) < (long)(pos.length)) {
+            Coord p_1 = pos[(int)((long)(i_9))];
+            if ((long)(p_1.x) == (long)(r) && (long)(p_1.y) == (long)(c)) {
                 return true;
             }
-            i_5 = i_5 + 1;
+            i_9 = (long)((long)(i_9) + 1L);
         }
         return false;
     }
 
-    static Coord[] find_repeat(String[][] matrix_g, int row, int column, int size) {
-        column = size - 1 - column;
-        Coord[] visited = ((Coord[])(new Coord[]{}));
-        Coord[] repeated = ((Coord[])(new Coord[]{}));
-        String color = matrix_g[column][row];
-        if ((color.equals("-"))) {
-            return repeated;
+    static Coord[] find_repeat(String[][] matrix_g, long row, long column, long size) {
+        column = (long)((long)((long)(size) - 1L) - (long)(column));
+        Coord[] visited_1 = ((Coord[])(new Coord[]{}));
+        Coord[] repeated_1 = ((Coord[])(new Coord[]{}));
+        String color_1 = matrix_g[(int)((long)(column))][(int)((long)(row))];
+        if ((color_1.equals("-"))) {
+            return repeated_1;
         }
-        Coord[] stack = ((Coord[])(new Coord[]{new Coord(column, row)}));
-        while (stack.length > 0) {
-            int idx = stack.length - 1;
-            Coord pos = stack[idx];
-            stack = ((Coord[])(java.util.Arrays.copyOfRange(stack, 0, idx)));
-            if (pos.x < 0 || pos.x >= size || pos.y < 0 || pos.y >= size) {
+        Coord[] stack_1 = ((Coord[])(new Coord[]{new Coord(column, row)}));
+        while ((long)(stack_1.length) > 0L) {
+            long idx_1 = (long)((long)(stack_1.length) - 1L);
+            Coord pos_1 = stack_1[(int)((long)(idx_1))];
+            stack_1 = ((Coord[])(java.util.Arrays.copyOfRange(stack_1, (int)(0L), (int)((long)(idx_1)))));
+            if ((long)(pos_1.x) < 0L || (long)(pos_1.x) >= (long)(size) || (long)(pos_1.y) < 0L || (long)(pos_1.y) >= (long)(size)) {
                 continue;
             }
-            if (((Boolean)(contains(((Coord[])(visited)), pos.x, pos.y)))) {
+            if (contains(((Coord[])(visited_1)), (long)(pos_1.x), (long)(pos_1.y))) {
                 continue;
             }
-            visited = ((Coord[])(java.util.stream.Stream.concat(java.util.Arrays.stream(visited), java.util.stream.Stream.of(pos)).toArray(Coord[]::new)));
-            if ((matrix_g[pos.x][pos.y].equals(color))) {
-                repeated = ((Coord[])(java.util.stream.Stream.concat(java.util.Arrays.stream(repeated), java.util.stream.Stream.of(pos)).toArray(Coord[]::new)));
-                stack = ((Coord[])(java.util.stream.Stream.concat(java.util.Arrays.stream(stack), java.util.stream.Stream.of(new Coord(pos.x - 1, pos.y))).toArray(Coord[]::new)));
-                stack = ((Coord[])(java.util.stream.Stream.concat(java.util.Arrays.stream(stack), java.util.stream.Stream.of(new Coord(pos.x + 1, pos.y))).toArray(Coord[]::new)));
-                stack = ((Coord[])(java.util.stream.Stream.concat(java.util.Arrays.stream(stack), java.util.stream.Stream.of(new Coord(pos.x, pos.y - 1))).toArray(Coord[]::new)));
-                stack = ((Coord[])(java.util.stream.Stream.concat(java.util.Arrays.stream(stack), java.util.stream.Stream.of(new Coord(pos.x, pos.y + 1))).toArray(Coord[]::new)));
+            visited_1 = ((Coord[])(java.util.stream.Stream.concat(java.util.Arrays.stream(visited_1), java.util.stream.Stream.of(pos_1)).toArray(Coord[]::new)));
+            if ((matrix_g[(int)((long)(pos_1.x))][(int)((long)(pos_1.y))].equals(color_1))) {
+                repeated_1 = ((Coord[])(java.util.stream.Stream.concat(java.util.Arrays.stream(repeated_1), java.util.stream.Stream.of(pos_1)).toArray(Coord[]::new)));
+                stack_1 = ((Coord[])(java.util.stream.Stream.concat(java.util.Arrays.stream(stack_1), java.util.stream.Stream.of(new Coord((long)(pos_1.x) - 1L, pos_1.y))).toArray(Coord[]::new)));
+                stack_1 = ((Coord[])(java.util.stream.Stream.concat(java.util.Arrays.stream(stack_1), java.util.stream.Stream.of(new Coord((long)(pos_1.x) + 1L, pos_1.y))).toArray(Coord[]::new)));
+                stack_1 = ((Coord[])(java.util.stream.Stream.concat(java.util.Arrays.stream(stack_1), java.util.stream.Stream.of(new Coord(pos_1.x, (long)(pos_1.y) - 1L))).toArray(Coord[]::new)));
+                stack_1 = ((Coord[])(java.util.stream.Stream.concat(java.util.Arrays.stream(stack_1), java.util.stream.Stream.of(new Coord(pos_1.x, (long)(pos_1.y) + 1L))).toArray(Coord[]::new)));
             }
         }
-        return repeated;
+        return repeated_1;
     }
 
-    static int increment_score(int count) {
-        return Math.floorDiv(count * (count + 1), 2);
+    static long increment_score(long count) {
+        return ((long)(Math.floorDiv(((long)((long)(count) * (long)(((long)(count) + 1L)))), ((long)(2)))));
     }
 
-    static String[][] move_x(String[][] matrix_g, int column, int size) {
+    static String[][] move_x(String[][] matrix_g, long column, long size) {
         String[] new_list = ((String[])(new String[]{}));
-        int row_1 = 0;
-        while (row_1 < size) {
-            String val = matrix_g[row_1][column];
-            if (!(val.equals("-"))) {
-                new_list = ((String[])(java.util.stream.Stream.concat(java.util.Arrays.stream(new_list), java.util.stream.Stream.of(val)).toArray(String[]::new)));
+        long row_3 = 0L;
+        while ((long)(row_3) < (long)(size)) {
+            String val_1 = matrix_g[(int)((long)(row_3))][(int)((long)(column))];
+            if (!(val_1.equals("-"))) {
+                new_list = ((String[])(java.util.stream.Stream.concat(java.util.Arrays.stream(new_list), java.util.stream.Stream.of(val_1)).toArray(String[]::new)));
             } else {
-                new_list = ((String[])(concat(new String[]{val}, new_list)));
+                new_list = ((String[])(concat(new String[]{val_1}, new_list)));
             }
-            row_1 = row_1 + 1;
+            row_3 = (long)((long)(row_3) + 1L);
         }
-        row_1 = 0;
-        while (row_1 < size) {
-matrix_g[row_1][column] = new_list[row_1];
-            row_1 = row_1 + 1;
+        row_3 = 0L;
+        while ((long)(row_3) < (long)(size)) {
+matrix_g[(int)((long)(row_3))][(int)((long)(column))] = new_list[(int)((long)(row_3))];
+            row_3 = (long)((long)(row_3) + 1L);
         }
         return matrix_g;
     }
 
-    static String[][] move_y(String[][] matrix_g, int size) {
-        int[] empty_cols = ((int[])(new int[]{}));
-        int column = size - 1;
-        while (column >= 0) {
-            int row_2 = 0;
-            boolean all_empty = true;
-            while (row_2 < size) {
-                if (!(matrix_g[row_2][column].equals("-"))) {
-                    all_empty = false;
+    static String[][] move_y(String[][] matrix_g, long size) {
+        long[] empty_cols = ((long[])(new long[]{}));
+        long column_1 = (long)((long)(size) - 1L);
+        while ((long)(column_1) >= 0L) {
+            long row_5 = 0L;
+            boolean all_empty_1 = true;
+            while ((long)(row_5) < (long)(size)) {
+                if (!(matrix_g[(int)((long)(row_5))][(int)((long)(column_1))].equals("-"))) {
+                    all_empty_1 = false;
                     break;
                 }
-                row_2 = row_2 + 1;
+                row_5 = (long)((long)(row_5) + 1L);
             }
-            if (all_empty) {
-                empty_cols = ((int[])(java.util.stream.IntStream.concat(java.util.Arrays.stream(empty_cols), java.util.stream.IntStream.of(column)).toArray()));
+            if (all_empty_1) {
+                empty_cols = ((long[])(appendLong(empty_cols, (long)(column_1))));
             }
-            column = column - 1;
+            column_1 = (long)((long)(column_1) - 1L);
         }
-        int i_6 = 0;
-        while (i_6 < empty_cols.length) {
-            int col = empty_cols[i_6];
-            int c = col + 1;
-            while (c < size) {
-                int r = 0;
-                while (r < size) {
-matrix_g[r][c - 1] = matrix_g[r][c];
-                    r = r + 1;
+        long i_11 = 0L;
+        while ((long)(i_11) < (long)(empty_cols.length)) {
+            long col_1 = (long)(empty_cols[(int)((long)(i_11))]);
+            long c_1 = (long)((long)(col_1) + 1L);
+            while ((long)(c_1) < (long)(size)) {
+                long r_2 = 0L;
+                while ((long)(r_2) < (long)(size)) {
+matrix_g[(int)((long)(r_2))][(int)((long)((long)(c_1) - 1L))] = matrix_g[(int)((long)(r_2))][(int)((long)(c_1))];
+                    r_2 = (long)((long)(r_2) + 1L);
                 }
-                c = c + 1;
+                c_1 = (long)((long)(c_1) + 1L);
             }
-            int r_1 = 0;
-            while (r_1 < size) {
-matrix_g[r_1][size - 1] = "-";
-                r_1 = r_1 + 1;
+            long r_3 = 0L;
+            while ((long)(r_3) < (long)(size)) {
+matrix_g[(int)((long)(r_3))][(int)((long)((long)(size) - 1L))] = "-";
+                r_3 = (long)((long)(r_3) + 1L);
             }
-            i_6 = i_6 + 1;
+            i_11 = (long)((long)(i_11) + 1L);
         }
         return matrix_g;
     }
 
-    static PlayResult play(String[][] matrix_g, int pos_x, int pos_y, int size) {
-        Coord[] same_colors = ((Coord[])(find_repeat(((String[][])(matrix_g)), pos_x, pos_y, size)));
-        if (same_colors.length != 0) {
-            int i_7 = 0;
-            while (i_7 < same_colors.length) {
-                Coord p_1 = same_colors[i_7];
-matrix_g[p_1.x][p_1.y] = "-";
-                i_7 = i_7 + 1;
+    static PlayResult play(String[][] matrix_g, long pos_x, long pos_y, long size) {
+        Coord[] same_colors = ((Coord[])(find_repeat(((String[][])(matrix_g)), (long)(pos_x), (long)(pos_y), (long)(size))));
+        if ((long)(same_colors.length) != 0L) {
+            long i_13 = 0L;
+            while ((long)(i_13) < (long)(same_colors.length)) {
+                Coord p_3 = same_colors[(int)((long)(i_13))];
+matrix_g[(int)((long)(p_3.x))][(int)((long)(p_3.y))] = "-";
+                i_13 = (long)((long)(i_13) + 1L);
             }
-            int column_1 = 0;
-            while (column_1 < size) {
-                matrix_g = ((String[][])(move_x(((String[][])(matrix_g)), column_1, size)));
-                column_1 = column_1 + 1;
+            long column_3 = 0L;
+            while ((long)(column_3) < (long)(size)) {
+                matrix_g = ((String[][])(move_x(((String[][])(matrix_g)), (long)(column_3), (long)(size))));
+                column_3 = (long)((long)(column_3) + 1L);
             }
-            matrix_g = ((String[][])(move_y(((String[][])(matrix_g)), size)));
+            matrix_g = ((String[][])(move_y(((String[][])(matrix_g)), (long)(size))));
         }
-        int sc = increment_score(same_colors.length);
-        return new PlayResult(matrix_g, sc);
+        long sc_1 = (long)(increment_score((long)(same_colors.length)));
+        return new PlayResult(matrix_g, sc_1);
     }
 
     static String[][] build_matrix(String[] matrix) {
         String[][] res_2 = ((String[][])(new String[][]{}));
-        int i_8 = 0;
-        while (i_8 < matrix.length) {
-            String row_3 = matrix[i_8];
-            String[] row_list = ((String[])(new String[]{}));
-            int j_2 = 0;
-            while (j_2 < _runeLen(row_3)) {
-                row_list = ((String[])(java.util.stream.Stream.concat(java.util.Arrays.stream(row_list), java.util.stream.Stream.of(_substr(row_3, j_2, j_2 + 1))).toArray(String[]::new)));
-                j_2 = j_2 + 1;
+        long i_15 = 0L;
+        while ((long)(i_15) < (long)(matrix.length)) {
+            String row_7 = matrix[(int)((long)(i_15))];
+            String[] row_list_1 = ((String[])(new String[]{}));
+            long j_5 = 0L;
+            while ((long)(j_5) < (long)(_runeLen(row_7))) {
+                row_list_1 = ((String[])(java.util.stream.Stream.concat(java.util.Arrays.stream(row_list_1), java.util.stream.Stream.of(_substr(row_7, (int)((long)(j_5)), (int)((long)((long)(j_5) + 1L))))).toArray(String[]::new)));
+                j_5 = (long)((long)(j_5) + 1L);
             }
-            res_2 = ((String[][])(appendObj(res_2, row_list)));
-            i_8 = i_8 + 1;
+            res_2 = ((String[][])(java.util.stream.Stream.concat(java.util.Arrays.stream(res_2), java.util.stream.Stream.of(new String[][]{row_list_1})).toArray(String[][]::new)));
+            i_15 = (long)((long)(i_15) + 1L);
         }
         return res_2;
     }
 
-    static int process_game(int size, String[] matrix, Coord[] moves) {
+    static long process_game(long size, String[] matrix, Coord[] moves) {
         String[][] game_matrix = ((String[][])(build_matrix(((String[])(matrix)))));
-        int total = 0;
-        int i_9 = 0;
-        while (i_9 < moves.length) {
-            Coord mv_1 = moves[i_9];
-            PlayResult res_3 = play(((String[][])(game_matrix)), mv_1.x, mv_1.y, size);
-            game_matrix = ((String[][])(res_3.matrix));
-            total = total + res_3.score;
-            i_9 = i_9 + 1;
+        long total_1 = 0L;
+        long i_17 = 0L;
+        while ((long)(i_17) < (long)(moves.length)) {
+            Coord mv_3 = moves[(int)((long)(i_17))];
+            PlayResult res_4 = play(((String[][])(game_matrix)), (long)(mv_3.x), (long)(mv_3.y), (long)(size));
+            game_matrix = ((String[][])(res_4.matrix));
+            total_1 = (long)((long)(total_1) + (long)(res_4.score));
+            i_17 = (long)((long)(i_17) + 1L);
         }
-        return total;
+        return total_1;
     }
 
     static void main() {
-        int size = 4;
-        String[] matrix = ((String[])(new String[]{"RRBG", "RBBG", "YYGG", "XYGG"}));
-        Coord[] moves_1 = ((Coord[])(parse_moves("0 1,1 1")));
-        validate_matrix_size(size);
-        validate_matrix_content(((String[])(matrix)), size);
-        validate_moves(((Coord[])(moves_1)), size);
-        int score = process_game(size, ((String[])(matrix)), ((Coord[])(moves_1)));
-        System.out.println(_p(score));
+        long size = 4L;
+        String[] matrix_1 = ((String[])(new String[]{"RRBG", "RBBG", "YYGG", "XYGG"}));
+        Coord[] moves_3 = ((Coord[])(parse_moves("0 1,1 1")));
+        validate_matrix_size((long)(size));
+        validate_matrix_content(((String[])(matrix_1)), (long)(size));
+        validate_moves(((Coord[])(moves_3)), (long)(size));
+        long score_1 = (long)(process_game((long)(size), ((String[])(matrix_1)), ((Coord[])(moves_3))));
+        System.out.println(_p(score_1));
     }
     public static void main(String[] args) {
         {
@@ -307,11 +307,7 @@ matrix_g[p_1.x][p_1.y] = "-";
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -338,15 +334,18 @@ matrix_g[p_1.x][p_1.y] = "-";
         return rt.totalMemory() - rt.freeMemory();
     }
 
-    static <T> T[] appendObj(T[] arr, T v) {
-        T[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+    static long[] appendLong(long[] arr, long v) {
+        long[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
         out[arr.length] = v;
         return out;
     }
 
-    static <T> T[] concat(T[] a, T[] b) {
-        T[] out = java.util.Arrays.copyOf(a, a.length + b.length);
-        System.arraycopy(b, 0, out, a.length, b.length);
+    static Object concat(Object a, Object b) {
+        int len1 = java.lang.reflect.Array.getLength(a);
+        int len2 = java.lang.reflect.Array.getLength(b);
+        Object out = java.lang.reflect.Array.newInstance(a.getClass().getComponentType(), len1 + len2);
+        System.arraycopy(a, 0, out, 0, len1);
+        System.arraycopy(b, 0, out, len1, len2);
         return out;
     }
 
@@ -355,6 +354,10 @@ matrix_g[p_1.x][p_1.y] = "-";
     }
 
     static String _substr(String s, int i, int j) {
+        int len = _runeLen(s);
+        if (i < 0) i = 0;
+        if (j > len) j = len;
+        if (i > j) i = j;
         int start = s.offsetByCodePoints(0, i);
         int end = s.offsetByCodePoints(0, j);
         return s.substring(start, end);
@@ -372,6 +375,10 @@ matrix_g[p_1.x][p_1.y] = "-";
             if (v instanceof short[]) return java.util.Arrays.toString((short[]) v);
             if (v instanceof float[]) return java.util.Arrays.toString((float[]) v);
             return java.util.Arrays.deepToString((Object[]) v);
+        }
+        if (v instanceof Double || v instanceof Float) {
+            double d = ((Number) v).doubleValue();
+            return String.valueOf(d);
         }
         return String.valueOf(v);
     }

--- a/tests/algorithms/x/Java/matrix/matrix_class.bench
+++ b/tests/algorithms/x/Java/matrix/matrix_class.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 51442,
-  "memory_bytes": 114128,
-  "name": "main"
-}
+{"duration_us": 64236, "memory_bytes": 114128, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/matrix_class.java
+++ b/tests/algorithms/x/Java/matrix/matrix_class.java
@@ -20,7 +20,7 @@ public class Main {
         if ((long)(r) == 0L) {
             return new Matrix(new double[][]{}, 0, 0);
         }
-        long c_1 = (long)(values[(int)((long)(0))].length);
+        long c_1 = (long)(values[(int)(0L)].length);
         long i_1 = 0L;
         while ((long)(i_1) < (long)(r)) {
             if ((long)(values[(int)((long)(i_1))].length) != (long)(c_1)) {
@@ -133,15 +133,15 @@ public class Main {
             return 0.0;
         }
         if ((long)(m.rows) == 1L) {
-            return m.data[(int)((long)(0))][(int)((long)(0))];
+            return m.data[(int)(0L)][(int)(0L)];
         }
         if ((long)(m.rows) == 2L) {
-            return (double)((double)(m.data[(int)((long)(0))][(int)((long)(0))]) * (double)(m.data[(int)((long)(1))][(int)((long)(1))])) - (double)((double)(m.data[(int)((long)(0))][(int)((long)(1))]) * (double)(m.data[(int)((long)(1))][(int)((long)(0))]));
+            return (double)((double)(m.data[(int)(0L)][(int)(0L)]) * (double)(m.data[(int)(1L)][(int)(1L)])) - (double)((double)(m.data[(int)(0L)][(int)(1L)]) * (double)(m.data[(int)(1L)][(int)(0L)]));
         }
         double sum_1 = (double)(0.0);
         long j_11 = 0L;
         while ((long)(j_11) < (long)(m.cols)) {
-            sum_1 = (double)((double)(sum_1) + (double)((double)(m.data[(int)((long)(0))][(int)((long)(j_11))]) * (double)(matrix_cofactor(m, 0L, (long)(j_11)))));
+            sum_1 = (double)((double)(sum_1) + (double)((double)(m.data[(int)(0L)][(int)((long)(j_11))]) * (double)(matrix_cofactor(m, 0L, (long)(j_11)))));
             j_11 = (long)((long)(j_11) + 1L);
         }
         return sum_1;
@@ -354,11 +354,7 @@ public class Main {
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/matrix/matrix_equalization.bench
+++ b/tests/algorithms/x/Java/matrix/matrix_equalization.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 28565,
-  "memory_bytes": 48312,
-  "name": "main"
-}
+{"duration_us": 23099, "memory_bytes": 968, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/matrix_equalization.java
+++ b/tests/algorithms/x/Java/matrix/matrix_equalization.java
@@ -15,7 +15,7 @@ public class Main {
                 j_1 = (long)((long)(j_1) + 1L);
             }
             if (!found_1) {
-                res = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(res), java.util.stream.LongStream.of((long)(v_1))).toArray()));
+                res = ((long[])(appendLong(res, (long)(v_1))));
             }
             i_1 = (long)((long)(i_1) + 1L);
         }
@@ -59,11 +59,7 @@ public class Main {
             System.out.println(_p(array_equalization(((long[])(new long[]{1, 2, 3})), 2147483647L)));
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -88,6 +84,12 @@ public class Main {
         Runtime rt = Runtime.getRuntime();
         rt.gc();
         return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static long[] appendLong(long[] arr, long v) {
+        long[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
     }
 
     static String _p(Object v) {

--- a/tests/algorithms/x/Java/matrix/matrix_multiplication_recursion.bench
+++ b/tests/algorithms/x/Java/matrix/matrix_multiplication_recursion.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 30395,
-  "memory_bytes": 49280,
-  "name": "main"
-}
+{"duration_us": 39473, "memory_bytes": 46512, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/matrix_multiplication_recursion.java
+++ b/tests/algorithms/x/Java/matrix/matrix_multiplication_recursion.java
@@ -18,7 +18,7 @@ public class Main {
 
     static long[][] matrix_multiply(long[][] a, long[][] b) {
         long rows = (long)(a.length);
-        long cols_1 = (long)(b[(int)((long)(0))].length);
+        long cols_1 = (long)(b[(int)(0L)].length);
         long inner_1 = (long)(b.length);
         long[][] result_1 = ((long[][])(new long[][]{}));
         long i_3 = 0L;
@@ -32,7 +32,7 @@ public class Main {
                     sum_1 = (long)((long)(sum_1) + (long)((long)(a[(int)((long)(i_3))][(int)((long)(k_1))]) * (long)(b[(int)((long)(k_1))][(int)((long)(j_1))])));
                     k_1 = (long)((long)(k_1) + 1L);
                 }
-                row_1 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(row_1), java.util.stream.LongStream.of((long)(sum_1))).toArray()));
+                row_1 = ((long[])(appendLong(row_1, (long)(sum_1))));
                 j_1 = (long)((long)(j_1) + 1L);
             }
             result_1 = ((long[][])(java.util.stream.Stream.concat(java.util.Arrays.stream(result_1), java.util.stream.Stream.of(new long[][]{row_1})).toArray(long[][]::new)));
@@ -65,14 +65,14 @@ result[(int)((long)(i))][(int)((long)(j))] = (long)((long)(result[(int)((long)(i
             throw new RuntimeException(String.valueOf("Invalid matrix dimensions"));
         }
         long n_2 = (long)(a.length);
-        long m_1 = (long)(b[(int)((long)(0))].length);
+        long m_1 = (long)(b[(int)(0L)].length);
         long[][] result_3 = ((long[][])(new long[][]{}));
         long i_5 = 0L;
         while ((long)(i_5) < (long)(n_2)) {
             long[] row_3 = ((long[])(new long[]{}));
             long j_3 = 0L;
             while ((long)(j_3) < (long)(m_1)) {
-                row_3 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(row_3), java.util.stream.LongStream.of(0L)).toArray()));
+                row_3 = ((long[])(appendLong(row_3, 0L)));
                 j_3 = (long)((long)(j_3) + 1L);
             }
             result_3 = ((long[][])(java.util.stream.Stream.concat(java.util.Arrays.stream(result_3), java.util.stream.Stream.of(new long[][]{row_3})).toArray(long[][]::new)));
@@ -89,11 +89,7 @@ result[(int)((long)(i))][(int)((long)(j))] = (long)((long)(result[(int)((long)(i
             System.out.println(matrix_multiply_recursive(((long[][])(matrix_count_up)), ((long[][])(matrix_unordered))));
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -118,5 +114,11 @@ result[(int)((long)(i))][(int)((long)(j))] = (long)((long)(result[(int)((long)(i
         Runtime rt = Runtime.getRuntime();
         rt.gc();
         return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static long[] appendLong(long[] arr, long v) {
+        long[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
     }
 }

--- a/tests/algorithms/x/Java/matrix/matrix_operation.bench
+++ b/tests/algorithms/x/Java/matrix/matrix_operation.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 47545,
-  "memory_bytes": 120024,
-  "name": "main"
-}
+{"duration_us": 75140, "memory_bytes": 120024, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/matrix_operation.java
+++ b/tests/algorithms/x/Java/matrix/matrix_operation.java
@@ -1,8 +1,8 @@
 public class Main {
 
     static double[][] add(double[][][] matrices) {
-        long rows = (long)(matrices[(int)((long)(0))].length);
-        long cols_1 = (long)(matrices[(int)((long)(0))][(int)((long)(0))].length);
+        long rows = (long)(matrices[(int)(0L)].length);
+        long cols_1 = (long)(matrices[(int)(0L)][(int)(0L)].length);
         long r_1 = 0L;
         double[][] result_1 = ((double[][])(new double[][]{}));
         while ((long)(r_1) < (long)(rows)) {
@@ -26,7 +26,7 @@ public class Main {
 
     static double[][] subtract(double[][] a, double[][] b) {
         long rows_1 = (long)(a.length);
-        long cols_3 = (long)(a[(int)((long)(0))].length);
+        long cols_3 = (long)(a[(int)(0L)].length);
         long r_3 = 0L;
         double[][] result_3 = ((double[][])(new double[][]{}));
         while ((long)(r_3) < (long)(rows_1)) {
@@ -60,9 +60,9 @@ public class Main {
 
     static double[][] multiply(double[][] a, double[][] b) {
         long rowsA = (long)(a.length);
-        long colsA_1 = (long)(a[(int)((long)(0))].length);
+        long colsA_1 = (long)(a[(int)(0L)].length);
         long rowsB_1 = (long)(b.length);
-        long colsB_1 = (long)(b[(int)((long)(0))].length);
+        long colsB_1 = (long)(b[(int)(0L)].length);
         double[][] result_6 = ((double[][])(new double[][]{}));
         long i_3 = 0L;
         while ((long)(i_3) < (long)(rowsA)) {
@@ -106,7 +106,7 @@ public class Main {
 
     static double[][] transpose(double[][] matrix) {
         long rows_2 = (long)(matrix.length);
-        long cols_5 = (long)(matrix[(int)((long)(0))].length);
+        long cols_5 = (long)(matrix[(int)(0L)].length);
         double[][] result_9 = ((double[][])(new double[][]{}));
         long c_5 = 0L;
         while ((long)(c_5) < (long)(cols_5)) {
@@ -144,14 +144,14 @@ public class Main {
 
     static double determinant(double[][] matrix) {
         if ((long)(matrix.length) == 1L) {
-            return matrix[(int)((long)(0))][(int)((long)(0))];
+            return matrix[(int)(0L)][(int)(0L)];
         }
         double det_1 = (double)(0.0);
         long c_7 = 0L;
-        while ((long)(c_7) < (long)(matrix[(int)((long)(0))].length)) {
+        while ((long)(c_7) < (long)(matrix[(int)(0L)].length)) {
             double[][] sub_1 = ((double[][])(minor(((double[][])(matrix)), 0L, (long)(c_7))));
             double sign_1 = (double)(Math.floorMod(c_7, 2) == 0L ? 1.0 : -1.0);
-            det_1 = (double)((double)(det_1) + (double)((double)((double)(matrix[(int)((long)(0))][(int)((long)(c_7))]) * (double)(determinant(((double[][])(sub_1))))) * (double)(sign_1)));
+            det_1 = (double)((double)(det_1) + (double)((double)((double)(matrix[(int)(0L)][(int)((long)(c_7))]) * (double)(determinant(((double[][])(sub_1))))) * (double)(sign_1)));
             c_7 = (long)((long)(c_7) + 1L);
         }
         return det_1;
@@ -212,11 +212,7 @@ public class Main {
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/matrix/max_area_of_island.bench
+++ b/tests/algorithms/x/Java/matrix/max_area_of_island.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 38338,
-  "memory_bytes": 79816,
-  "name": "main"
-}
+{"duration_us": 56671, "memory_bytes": 79816, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/max_area_of_island.java
+++ b/tests/algorithms/x/Java/matrix/max_area_of_island.java
@@ -15,7 +15,7 @@ public class Main {
 
     static long depth_first_search(long row, long col, java.util.Map<String,Boolean> seen, long[][] mat) {
         long rows = (long)(mat.length);
-        long cols_1 = (long)(mat[(int)((long)(0))].length);
+        long cols_1 = (long)(mat[(int)(0L)].length);
         String key_1 = String.valueOf(encode((long)(row), (long)(col)));
         if (is_safe((long)(row), (long)(col), (long)(rows), (long)(cols_1)) && (!(Boolean)has(seen, key_1)) && (long)(mat[(int)((long)(row))][(int)((long)(col))]) == 1L) {
 seen.put(key_1, true);
@@ -57,11 +57,7 @@ seen.put(key_1, true);
             System.out.println(find_max_area(((long[][])(matrix))));
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/matrix/median_matrix.bench
+++ b/tests/algorithms/x/Java/matrix/median_matrix.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 27791,
-  "memory_bytes": 48312,
-  "name": "main"
-}
+{"duration_us": 27210, "memory_bytes": 1072, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/median_matrix.java
+++ b/tests/algorithms/x/Java/matrix/median_matrix.java
@@ -28,13 +28,13 @@ arr[(int)((long)((long)(j_1) + 1L))] = (long)(temp_1);
             long[] row_1 = ((long[])(matrix[(int)((long)(i_3))]));
             long j_3 = 0L;
             while ((long)(j_3) < (long)(row_1.length)) {
-                linear = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(linear), java.util.stream.LongStream.of((long)(row_1[(int)((long)(j_3))]))).toArray()));
+                linear = ((long[])(appendLong(linear, (long)(row_1[(int)((long)(j_3))]))));
                 j_3 = (long)((long)(j_3) + 1L);
             }
             i_3 = (long)((long)(i_3) + 1L);
         }
         long[] sorted_1 = ((long[])(bubble_sort(((long[])(linear)))));
-        long mid_1 = (long)((long)(((long)(sorted_1.length) - 1L)) / 2L);
+        long mid_1 = Math.floorDiv(((long)(sorted_1.length) - 1L), 2);
         return sorted_1[(int)((long)(mid_1))];
     }
     public static void main(String[] args) {
@@ -45,11 +45,7 @@ arr[(int)((long)((long)(j_1) + 1L))] = (long)(temp_1);
             System.out.println(_p(median(((long[][])(matrix2)))));
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -74,6 +70,12 @@ arr[(int)((long)((long)(j_1) + 1L))] = (long)(temp_1);
         Runtime rt = Runtime.getRuntime();
         rt.gc();
         return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static long[] appendLong(long[] arr, long v) {
+        long[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
     }
 
     static String _p(Object v) {

--- a/tests/algorithms/x/Java/matrix/nth_fibonacci_using_matrix_exponentiation.bench
+++ b/tests/algorithms/x/Java/matrix/nth_fibonacci_using_matrix_exponentiation.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 53349,
-  "memory_bytes": 105296,
-  "name": "main"
-}
+{"duration_us": 64643, "memory_bytes": 102528, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/nth_fibonacci_using_matrix_exponentiation.java
+++ b/tests/algorithms/x/Java/matrix/nth_fibonacci_using_matrix_exponentiation.java
@@ -14,7 +14,7 @@ public class Main {
                     val_1 = (long)((long)(val_1) + (long)((long)(matrix_a[(int)((long)(i_1))][(int)((long)(k_1))]) * (long)(matrix_b[(int)((long)(k_1))][(int)((long)(j_1))])));
                     k_1 = (long)((long)(k_1) + 1L);
                 }
-                row_1 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(row_1), java.util.stream.LongStream.of((long)(val_1))).toArray()));
+                row_1 = ((long[])(appendLong(row_1, (long)(val_1))));
                 j_1 = (long)((long)(j_1) + 1L);
             }
             matrix_c_1 = ((long[][])(java.util.stream.Stream.concat(java.util.Arrays.stream(matrix_c_1), java.util.stream.Stream.of(new long[][]{row_1})).toArray(long[][]::new)));
@@ -31,9 +31,9 @@ public class Main {
             long j_3 = 0L;
             while ((long)(j_3) < (long)(n)) {
                 if ((long)(i_3) == (long)(j_3)) {
-                    row_3 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(row_3), java.util.stream.LongStream.of(1L)).toArray()));
+                    row_3 = ((long[])(appendLong(row_3, 1L)));
                 } else {
-                    row_3 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(row_3), java.util.stream.LongStream.of(0L)).toArray()));
+                    row_3 = ((long[])(appendLong(row_3, 0L)));
                 }
                 j_3 = (long)((long)(j_3) + 1L);
             }
@@ -55,9 +55,9 @@ public class Main {
                 res_matrix_1 = ((long[][])(multiply(((long[][])(res_matrix_1)), ((long[][])(fib_matrix_1)))));
             }
             fib_matrix_1 = ((long[][])(multiply(((long[][])(fib_matrix_1)), ((long[][])(fib_matrix_1)))));
-            m_1 = (long)((long)(m_1) / 2L);
+            m_1 = Math.floorDiv(m_1, 2);
         }
-        return res_matrix_1[(int)((long)(0))][(int)((long)(0))];
+        return res_matrix_1[(int)(0L)][(int)(0L)];
     }
 
     static long nth_fibonacci_bruteforce(long n) {
@@ -107,11 +107,7 @@ public class Main {
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -136,6 +132,12 @@ public class Main {
         Runtime rt = Runtime.getRuntime();
         rt.gc();
         return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static long[] appendLong(long[] arr, long v) {
+        long[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
     }
 
     static int _runeLen(String s) {

--- a/tests/algorithms/x/Java/matrix/pascal_triangle.bench
+++ b/tests/algorithms/x/Java/matrix/pascal_triangle.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 39294,
-  "memory_bytes": 58192,
-  "name": "main"
-}
+{"duration_us": 51375, "memory_bytes": 55424, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/pascal_triangle.java
+++ b/tests/algorithms/x/Java/matrix/pascal_triangle.java
@@ -5,11 +5,11 @@ public class Main {
         long i_1 = 0L;
         while ((long)(i_1) <= (long)(current_row_idx)) {
             if ((long)(i_1) == 0L || (long)(i_1) == (long)(current_row_idx)) {
-                row = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(row), java.util.stream.LongStream.of(1L)).toArray()));
+                row = ((long[])(appendLong(row, 1L)));
             } else {
                 long left_1 = (long)(triangle[(int)((long)((long)(current_row_idx) - 1L))][(int)((long)((long)(i_1) - 1L))]);
                 long right_1 = (long)(triangle[(int)((long)((long)(current_row_idx) - 1L))][(int)((long)(i_1))]);
-                row = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(row), java.util.stream.LongStream.of((long)((long)(left_1) + (long)(right_1)))).toArray()));
+                row = ((long[])(appendLong(row, (long)((long)(left_1) + (long)(right_1)))));
             }
             i_1 = (long)((long)(i_1) + 1L);
         }
@@ -70,11 +70,7 @@ public class Main {
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -99,6 +95,12 @@ public class Main {
         Runtime rt = Runtime.getRuntime();
         rt.gc();
         return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static long[] appendLong(long[] arr, long v) {
+        long[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
     }
 
     static String _p(Object v) {

--- a/tests/algorithms/x/Java/matrix/rotate_matrix.bench
+++ b/tests/algorithms/x/Java/matrix/rotate_matrix.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 53479,
-  "memory_bytes": 99936,
-  "name": "main"
-}
+{"duration_us": 58640, "memory_bytes": 97168, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/rotate_matrix.java
+++ b/tests/algorithms/x/Java/matrix/rotate_matrix.java
@@ -22,7 +22,7 @@ public class Main {
             long[] row_1 = ((long[])(new long[]{}));
             long x_1 = 0L;
             while ((long)(x_1) < (long)(size)) {
-                row_1 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(row_1), java.util.stream.LongStream.of((long)((long)(1L + (long)(x_1)) + (long)((long)(y_1) * (long)(size))))).toArray()));
+                row_1 = ((long[])(appendLong(row_1, (long)((long)(1L + (long)(x_1)) + (long)((long)(y_1) * (long)(size))))));
                 x_1 = (long)((long)(x_1) + 1L);
             }
             mat_1 = ((long[][])(java.util.stream.Stream.concat(java.util.Arrays.stream(mat_1), java.util.stream.Stream.of(new long[][]{row_1})).toArray(long[][]::new)));
@@ -39,7 +39,7 @@ public class Main {
             long[] row_3 = ((long[])(new long[]{}));
             long j_1 = 0L;
             while ((long)(j_1) < (long)(n)) {
-                row_3 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(row_3), java.util.stream.LongStream.of((long)(mat[(int)((long)(j_1))][(int)((long)(i_1))]))).toArray()));
+                row_3 = ((long[])(appendLong(row_3, (long)(mat[(int)((long)(j_1))][(int)((long)(i_1))]))));
                 j_1 = (long)((long)(j_1) + 1L);
             }
             result_1 = ((long[][])(java.util.stream.Stream.concat(java.util.Arrays.stream(result_1), java.util.stream.Stream.of(new long[][]{row_3})).toArray(long[][]::new)));
@@ -65,7 +65,7 @@ public class Main {
             long[] row_5 = ((long[])(new long[]{}));
             long j_3 = (long)((long)(mat[(int)((long)(i_5))].length) - 1L);
             while ((long)(j_3) >= 0L) {
-                row_5 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(row_5), java.util.stream.LongStream.of((long)(mat[(int)((long)(i_5))][(int)((long)(j_3))]))).toArray()));
+                row_5 = ((long[])(appendLong(row_5, (long)(mat[(int)((long)(i_5))][(int)((long)(j_3))]))));
                 j_3 = (long)((long)(j_3) - 1L);
             }
             result_3 = ((long[][])(java.util.stream.Stream.concat(java.util.Arrays.stream(result_3), java.util.stream.Stream.of(new long[][]{row_5})).toArray(long[][]::new)));
@@ -137,11 +137,7 @@ public class Main {
             print_matrix(((long[][])(r270)));
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -166,6 +162,12 @@ public class Main {
         Runtime rt = Runtime.getRuntime();
         rt.gc();
         return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static long[] appendLong(long[] arr, long v) {
+        long[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
     }
 
     static String _p(Object v) {

--- a/tests/algorithms/x/Java/matrix/searching_in_sorted_matrix.bench
+++ b/tests/algorithms/x/Java/matrix/searching_in_sorted_matrix.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 39105,
-  "memory_bytes": 106992,
-  "name": "main"
-}
+{"duration_us": 62133, "memory_bytes": 106992, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/searching_in_sorted_matrix.java
+++ b/tests/algorithms/x/Java/matrix/searching_in_sorted_matrix.java
@@ -19,11 +19,11 @@ public class Main {
 
     static void main() {
         double[][] mat = ((double[][])(new double[][]{new double[]{2.0, 5.0, 7.0}, new double[]{4.0, 8.0, 13.0}, new double[]{9.0, 11.0, 15.0}, new double[]{12.0, 17.0, 20.0}}));
-        search_in_sorted_matrix(((double[][])(mat)), (long)(mat.length), (long)(mat[(int)((long)(0))].length), (double)(5.0));
-        search_in_sorted_matrix(((double[][])(mat)), (long)(mat.length), (long)(mat[(int)((long)(0))].length), (double)(21.0));
+        search_in_sorted_matrix(((double[][])(mat)), (long)(mat.length), (long)(mat[(int)(0L)].length), (double)(5.0));
+        search_in_sorted_matrix(((double[][])(mat)), (long)(mat.length), (long)(mat[(int)(0L)].length), (double)(21.0));
         double[][] mat2_1 = ((double[][])(new double[][]{new double[]{2.1, 5.0, 7.0}, new double[]{4.0, 8.0, 13.0}, new double[]{9.0, 11.0, 15.0}, new double[]{12.0, 17.0, 20.0}}));
-        search_in_sorted_matrix(((double[][])(mat2_1)), (long)(mat2_1.length), (long)(mat2_1[(int)((long)(0))].length), (double)(2.1));
-        search_in_sorted_matrix(((double[][])(mat2_1)), (long)(mat2_1.length), (long)(mat2_1[(int)((long)(0))].length), (double)(2.2));
+        search_in_sorted_matrix(((double[][])(mat2_1)), (long)(mat2_1.length), (long)(mat2_1[(int)(0L)].length), (double)(2.1));
+        search_in_sorted_matrix(((double[][])(mat2_1)), (long)(mat2_1.length), (long)(mat2_1[(int)(0L)].length), (double)(2.2));
     }
     public static void main(String[] args) {
         {
@@ -32,11 +32,7 @@ public class Main {
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/matrix/sherman_morrison.bench
+++ b/tests/algorithms/x/Java/matrix/sherman_morrison.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 31442,
-  "memory_bytes": 67928,
-  "name": "main"
-}
+{"duration_us": 51771, "memory_bytes": 67928, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/sherman_morrison.java
+++ b/tests/algorithms/x/Java/matrix/sherman_morrison.java
@@ -33,7 +33,7 @@ public class Main {
 
     static Matrix matrix_from_lists(double[][] vals) {
         long r_2 = (long)(vals.length);
-        long c_3 = (long)((long)(r_2) == 0L ? 0 : vals[(int)((long)(0))].length);
+        long c_3 = (long)((long)(r_2) == 0L ? 0 : vals[(int)(0L)].length);
         return new Matrix(vals, r_2, c_3);
     }
 
@@ -157,7 +157,7 @@ public class Main {
     static Matrix sherman_morrison(Matrix ainv, Matrix u, Matrix v) {
         Matrix vt = matrix_transpose(v);
         Matrix vu_1 = matrix_mul(matrix_mul(vt, ainv), u);
-        double factor_1 = (double)((double)(vu_1.data[(int)((long)(0))][(int)((long)(0))]) + (double)(1.0));
+        double factor_1 = (double)((double)(vu_1.data[(int)(0L)][(int)(0L)]) + (double)(1.0));
         if ((double)(factor_1) == (double)(0.0)) {
             return new Matrix(new double[][]{}, 0, 0);
         }
@@ -182,11 +182,7 @@ public class Main {
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/matrix/spiral_print.bench
+++ b/tests/algorithms/x/Java/matrix/spiral_print.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 29311,
-  "memory_bytes": 48536,
-  "name": "main"
-}
+{"duration_us": 22220, "memory_bytes": 1192, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/spiral_print.java
+++ b/tests/algorithms/x/Java/matrix/spiral_print.java
@@ -4,7 +4,7 @@ public class Main {
         if ((long)(matrix.length) == 0L) {
             return false;
         }
-        long cols_1 = (long)(matrix[(int)((long)(0))].length);
+        long cols_1 = (long)(matrix[(int)(0L)].length);
         for (long[] row : matrix) {
             if ((long)(row.length) != (long)(cols_1)) {
                 return false;
@@ -18,7 +18,7 @@ public class Main {
             return new long[]{};
         }
         long rows_1 = (long)(matrix.length);
-        long cols_3 = (long)(matrix[(int)((long)(0))].length);
+        long cols_3 = (long)(matrix[(int)(0L)].length);
         long top_1 = 0L;
         long bottom_1 = (long)((long)(rows_1) - 1L);
         long left_1 = 0L;
@@ -27,20 +27,20 @@ public class Main {
         while ((long)(left_1) <= (long)(right_1) && (long)(top_1) <= (long)(bottom_1)) {
             long i_1 = (long)(left_1);
             while ((long)(i_1) <= (long)(right_1)) {
-                result_1 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(result_1), java.util.stream.LongStream.of((long)(matrix[(int)((long)(top_1))][(int)((long)(i_1))]))).toArray()));
+                result_1 = ((long[])(appendLong(result_1, (long)(matrix[(int)((long)(top_1))][(int)((long)(i_1))]))));
                 i_1 = (long)((long)(i_1) + 1L);
             }
             top_1 = (long)((long)(top_1) + 1L);
             i_1 = (long)(top_1);
             while ((long)(i_1) <= (long)(bottom_1)) {
-                result_1 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(result_1), java.util.stream.LongStream.of((long)(matrix[(int)((long)(i_1))][(int)((long)(right_1))]))).toArray()));
+                result_1 = ((long[])(appendLong(result_1, (long)(matrix[(int)((long)(i_1))][(int)((long)(right_1))]))));
                 i_1 = (long)((long)(i_1) + 1L);
             }
             right_1 = (long)((long)(right_1) - 1L);
             if ((long)(top_1) <= (long)(bottom_1)) {
                 i_1 = (long)(right_1);
                 while ((long)(i_1) >= (long)(left_1)) {
-                    result_1 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(result_1), java.util.stream.LongStream.of((long)(matrix[(int)((long)(bottom_1))][(int)((long)(i_1))]))).toArray()));
+                    result_1 = ((long[])(appendLong(result_1, (long)(matrix[(int)((long)(bottom_1))][(int)((long)(i_1))]))));
                     i_1 = (long)((long)(i_1) - 1L);
                 }
                 bottom_1 = (long)((long)(bottom_1) - 1L);
@@ -48,7 +48,7 @@ public class Main {
             if ((long)(left_1) <= (long)(right_1)) {
                 i_1 = (long)(bottom_1);
                 while ((long)(i_1) >= (long)(top_1)) {
-                    result_1 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(result_1), java.util.stream.LongStream.of((long)(matrix[(int)((long)(i_1))][(int)((long)(left_1))]))).toArray()));
+                    result_1 = ((long[])(appendLong(result_1, (long)(matrix[(int)((long)(i_1))][(int)((long)(left_1))]))));
                     i_1 = (long)((long)(i_1) - 1L);
                 }
                 left_1 = (long)((long)(left_1) + 1L);
@@ -75,11 +75,7 @@ public class Main {
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -104,6 +100,12 @@ public class Main {
         Runtime rt = Runtime.getRuntime();
         rt.gc();
         return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static long[] appendLong(long[] arr, long v) {
+        long[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
     }
 
     static String _p(Object v) {

--- a/tests/algorithms/x/Java/matrix/tests/test_matrix_operation.bench
+++ b/tests/algorithms/x/Java/matrix/tests/test_matrix_operation.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 29264,
-  "memory_bytes": 59392,
-  "name": "main"
-}
+{"duration_us": 45562, "memory_bytes": 59392, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/tests/test_matrix_operation.java
+++ b/tests/algorithms/x/Java/matrix/tests/test_matrix_operation.java
@@ -1,7 +1,7 @@
 public class Main {
 
     static void check_matrix(double[][] mat) {
-        if ((long)(mat.length) < 2L || (long)(mat[(int)((long)(0))].length) < 2L) {
+        if ((long)(mat.length) < 2L || (long)(mat[(int)(0L)].length) < 2L) {
             throw new RuntimeException(String.valueOf("Expected a matrix with at least 2x2 dimensions"));
         }
     }
@@ -9,11 +9,11 @@ public class Main {
     static double[][] add(double[][] a, double[][] b) {
         check_matrix(((double[][])(a)));
         check_matrix(((double[][])(b)));
-        if ((long)(a.length) != (long)(b.length) || (long)(a[(int)((long)(0))].length) != (long)(b[(int)((long)(0))].length)) {
+        if ((long)(a.length) != (long)(b.length) || (long)(a[(int)(0L)].length) != (long)(b[(int)(0L)].length)) {
             throw new RuntimeException(String.valueOf("Matrices must have the same dimensions"));
         }
         long rows_1 = (long)(a.length);
-        long cols_1 = (long)(a[(int)((long)(0))].length);
+        long cols_1 = (long)(a[(int)(0L)].length);
         double[][] result_1 = ((double[][])(new double[][]{}));
         long i_1 = 0L;
         while ((long)(i_1) < (long)(rows_1)) {
@@ -32,11 +32,11 @@ public class Main {
     static double[][] subtract(double[][] a, double[][] b) {
         check_matrix(((double[][])(a)));
         check_matrix(((double[][])(b)));
-        if ((long)(a.length) != (long)(b.length) || (long)(a[(int)((long)(0))].length) != (long)(b[(int)((long)(0))].length)) {
+        if ((long)(a.length) != (long)(b.length) || (long)(a[(int)(0L)].length) != (long)(b[(int)(0L)].length)) {
             throw new RuntimeException(String.valueOf("Matrices must have the same dimensions"));
         }
         long rows_3 = (long)(a.length);
-        long cols_3 = (long)(a[(int)((long)(0))].length);
+        long cols_3 = (long)(a[(int)(0L)].length);
         double[][] result_3 = ((double[][])(new double[][]{}));
         long i_3 = 0L;
         while ((long)(i_3) < (long)(rows_3)) {
@@ -55,7 +55,7 @@ public class Main {
     static double[][] scalar_multiply(double[][] a, double s) {
         check_matrix(((double[][])(a)));
         long rows_5 = (long)(a.length);
-        long cols_5 = (long)(a[(int)((long)(0))].length);
+        long cols_5 = (long)(a[(int)(0L)].length);
         double[][] result_5 = ((double[][])(new double[][]{}));
         long i_5 = 0L;
         while ((long)(i_5) < (long)(rows_5)) {
@@ -74,11 +74,11 @@ public class Main {
     static double[][] multiply(double[][] a, double[][] b) {
         check_matrix(((double[][])(a)));
         check_matrix(((double[][])(b)));
-        if ((long)(a[(int)((long)(0))].length) != (long)(b.length)) {
+        if ((long)(a[(int)(0L)].length) != (long)(b.length)) {
             throw new RuntimeException(String.valueOf("Invalid dimensions for matrix multiplication"));
         }
         long rows_7 = (long)(a.length);
-        long cols_7 = (long)(b[(int)((long)(0))].length);
+        long cols_7 = (long)(b[(int)(0L)].length);
         double[][] result_7 = ((double[][])(new double[][]{}));
         long i_7 = 0L;
         while ((long)(i_7) < (long)(rows_7)) {
@@ -123,7 +123,7 @@ public class Main {
     static double[][] transpose(double[][] a) {
         check_matrix(((double[][])(a)));
         long rows_9 = (long)(a.length);
-        long cols_9 = (long)(a[(int)((long)(0))].length);
+        long cols_9 = (long)(a[(int)(0L)].length);
         double[][] result_10 = ((double[][])(new double[][]{}));
         long j_11 = 0L;
         while ((long)(j_11) < (long)(cols_9)) {
@@ -157,11 +157,7 @@ public class Main {
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/matrix/validate_sudoku_board.bench
+++ b/tests/algorithms/x/Java/matrix/validate_sudoku_board.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 28503,
-  "memory_bytes": 49496,
-  "name": "main"
-}
+{"duration_us": 47375, "memory_bytes": 49600, "name": "main"}

--- a/tests/algorithms/x/Java/matrix/validate_sudoku_board.java
+++ b/tests/algorithms/x/Java/matrix/validate_sudoku_board.java
@@ -31,7 +31,7 @@ public class Main {
                 if ((value_1.equals(EMPTY_CELL))) {
                     continue;
                 }
-                long box_1 = (long)((long)((long)(((Number)((long)(r) / 3L)).intValue()) * 3L) + (long)(((Number)((long)(c) / 3L)).intValue()));
+                long box_1 = (long)((long)((long)(((Number)(Math.floorDiv(r, 3))).intValue()) * 3L) + (long)(((Number)(Math.floorDiv(c, 3))).intValue()));
                 if (java.util.Arrays.asList(rows_1[(int)((long)(r))]).contains(value_1) || java.util.Arrays.asList(cols_1[(int)((long)(c))]).contains(value_1) || java.util.Arrays.asList(boxes_1[(int)((long)(box_1))]).contains(value_1)) {
                     return false;
                 }
@@ -50,11 +50,7 @@ boxes_1[(int)((long)(box_1))] = ((String[])(java.util.stream.Stream.concat(java.
             System.out.println(is_valid_sudoku_board(((String[][])(invalid_board))));
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/networking_flow/ford_fulkerson.bench
+++ b/tests/algorithms/x/Java/networking_flow/ford_fulkerson.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 32205,
-  "memory_bytes": 48312,
-  "name": "main"
-}
+{"duration_us": 25044, "memory_bytes": 968, "name": "main"}

--- a/tests/algorithms/x/Java/networking_flow/ford_fulkerson.java
+++ b/tests/algorithms/x/Java/networking_flow/ford_fulkerson.java
@@ -10,7 +10,7 @@ public class Main {
             i_1 = (long)((long)(i_1) + 1L);
         }
         long[] queue_1 = ((long[])(new long[]{}));
-        queue_1 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(queue_1), java.util.stream.LongStream.of((long)(source))).toArray()));
+        queue_1 = ((long[])(appendLong(queue_1, (long)(source))));
 visited[(int)((long)(source))] = true;
         long head_1 = 0L;
         while ((long)(head_1) < (long)(queue_1.length)) {
@@ -21,7 +21,7 @@ visited[(int)((long)(source))] = true;
             while ((long)(ind_1) < (long)(row_1.length)) {
                 long capacity_1 = (long)(row_1[(int)((long)(ind_1))]);
                 if ((visited[(int)((long)(ind_1))] == false) && (long)(capacity_1) > 0L) {
-                    queue_1 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(queue_1), java.util.stream.LongStream.of((long)(ind_1))).toArray()));
+                    queue_1 = ((long[])(appendLong(queue_1, (long)(ind_1))));
 visited[(int)((long)(ind_1))] = true;
 parent[(int)((long)(ind_1))] = (long)(u_1);
                 }
@@ -35,7 +35,7 @@ parent[(int)((long)(ind_1))] = (long)(u_1);
         long[] parent = ((long[])(new long[]{}));
         long i_3 = 0L;
         while ((long)(i_3) < (long)(graph.length)) {
-            parent = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(parent), java.util.stream.LongStream.of((long)(-1))).toArray()));
+            parent = ((long[])(appendLong(parent, (long)(-1))));
             i_3 = (long)((long)(i_3) + 1L);
         }
         long max_flow_1 = 0L;
@@ -73,11 +73,7 @@ parent[(int)((long)(j_1))] = (long)(-1);
             System.out.println(_p(ford_fulkerson(((long[][])(graph)), 0L, 5L)));
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -106,6 +102,12 @@ parent[(int)((long)(j_1))] = (long)(-1);
 
     static boolean[] appendBool(boolean[] arr, boolean v) {
         boolean[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
+    }
+
+    static long[] appendLong(long[] arr, long v) {
+        long[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
         out[arr.length] = v;
         return out;
     }

--- a/tests/algorithms/x/Java/networking_flow/minimum_cut.bench
+++ b/tests/algorithms/x/Java/networking_flow/minimum_cut.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 30129,
-  "memory_bytes": 49880,
-  "name": "main"
-}
+{"duration_us": 45622, "memory_bytes": 47112, "name": "main"}

--- a/tests/algorithms/x/Java/networking_flow/minimum_cut.java
+++ b/tests/algorithms/x/Java/networking_flow/minimum_cut.java
@@ -18,7 +18,7 @@ visited[(int)((long)(s))] = true;
             long ind_1 = 0L;
             while ((long)(ind_1) < (long)(graph[(int)((long)(u_1))].length)) {
                 if ((visited[(int)((long)(ind_1))] == false) && (long)(graph[(int)((long)(u_1))][(int)((long)(ind_1))]) > 0L) {
-                    queue_1 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(queue_1), java.util.stream.LongStream.of((long)(ind_1))).toArray()));
+                    queue_1 = ((long[])(appendLong(queue_1, (long)(ind_1))));
 visited[(int)((long)(ind_1))] = true;
 parent[(int)((long)(ind_1))] = (long)(u_1);
                 }
@@ -33,7 +33,7 @@ parent[(int)((long)(ind_1))] = (long)(u_1);
         long[] parent_1 = ((long[])(new long[]{}));
         long i_3 = 0L;
         while ((long)(i_3) < (long)(g.length)) {
-            parent_1 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(parent_1), java.util.stream.LongStream.of((long)(-1))).toArray()));
+            parent_1 = ((long[])(appendLong(parent_1, (long)(-1))));
             i_3 = (long)((long)(i_3) + 1L);
         }
         long[][] temp_1 = ((long[][])(new long[][]{}));
@@ -42,7 +42,7 @@ parent[(int)((long)(ind_1))] = (long)(u_1);
             long[] row_1 = ((long[])(new long[]{}));
             long j_1 = 0L;
             while ((long)(j_1) < (long)(g[(int)((long)(i_3))].length)) {
-                row_1 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(row_1), java.util.stream.LongStream.of((long)(g[(int)((long)(i_3))][(int)((long)(j_1))]))).toArray()));
+                row_1 = ((long[])(appendLong(row_1, (long)(g[(int)((long)(i_3))][(int)((long)(j_1))]))));
                 j_1 = (long)((long)(j_1) + 1L);
             }
             temp_1 = ((long[][])(java.util.stream.Stream.concat(java.util.Arrays.stream(temp_1), java.util.stream.Stream.of(new long[][]{row_1})).toArray(long[][]::new)));
@@ -71,7 +71,7 @@ g[(int)((long)(v_1))][(int)((long)(u_3))] = (long)((long)(g[(int)((long)(v_1))][
         i_3 = 0L;
         while ((long)(i_3) < (long)(g.length)) {
             long j_3 = 0L;
-            while ((long)(j_3) < (long)(g[(int)((long)(0))].length)) {
+            while ((long)(j_3) < (long)(g[(int)(0L)].length)) {
                 if ((long)(g[(int)((long)(i_3))][(int)((long)(j_3))]) == 0L && (long)(temp_1[(int)((long)(i_3))][(int)((long)(j_3))]) > 0L) {
                     res_1 = ((long[][])(java.util.stream.Stream.concat(java.util.Arrays.stream(res_1), java.util.stream.Stream.of(new long[][]{new long[]{i_3, j_3}})).toArray(long[][]::new)));
                 }
@@ -89,11 +89,7 @@ g[(int)((long)(v_1))][(int)((long)(u_3))] = (long)((long)(g[(int)((long)(v_1))][
             System.out.println(_p(result));
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -122,6 +118,12 @@ g[(int)((long)(v_1))][(int)((long)(u_3))] = (long)((long)(g[(int)((long)(v_1))][
 
     static boolean[] appendBool(boolean[] arr, boolean v) {
         boolean[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
+    }
+
+    static long[] appendLong(long[] arr, long v) {
+        long[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
         out[arr.length] = v;
         return out;
     }

--- a/tests/algorithms/x/Java/neural_network/activation_functions/binary_step.bench
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/binary_step.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 28893,
-  "memory_bytes": 47896,
-  "name": "main"
-}
+{"duration_us": 30040, "memory_bytes": 552, "name": "main"}

--- a/tests/algorithms/x/Java/neural_network/activation_functions/binary_step.java
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/binary_step.java
@@ -5,9 +5,9 @@ public class Main {
         long i_1 = 0L;
         while ((long)(i_1) < (long)(vector.length)) {
             if ((double)(vector[(int)((long)(i_1))]) >= (double)(0.0)) {
-                out = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(out), java.util.stream.LongStream.of(1L)).toArray()));
+                out = ((long[])(appendLong(out, 1L)));
             } else {
-                out = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(out), java.util.stream.LongStream.of(0L)).toArray()));
+                out = ((long[])(appendLong(out, 0L)));
             }
             i_1 = (long)((long)(i_1) + 1L);
         }
@@ -26,11 +26,7 @@ public class Main {
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -55,5 +51,11 @@ public class Main {
         Runtime rt = Runtime.getRuntime();
         rt.gc();
         return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static long[] appendLong(long[] arr, long v) {
+        long[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
     }
 }

--- a/tests/algorithms/x/Java/neural_network/activation_functions/exponential_linear_unit.bench
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/exponential_linear_unit.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 18245,
-  "memory_bytes": 10704,
-  "name": "main"
-}
+{"duration_us": 26422, "memory_bytes": 10704, "name": "main"}

--- a/tests/algorithms/x/Java/neural_network/activation_functions/exponential_linear_unit.java
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/exponential_linear_unit.java
@@ -39,11 +39,7 @@ public class Main {
             System.out.println(_p(exponential_linear_unit(((double[])(new double[]{-9.2, -0.3, 0.45, -4.56})), (double)(0.067))));
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/neural_network/activation_functions/gaussian_error_linear_unit.bench
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/gaussian_error_linear_unit.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 17943,
-  "memory_bytes": 640,
-  "name": "main"
-}
+{"duration_us": 23054, "memory_bytes": 640, "name": "main"}

--- a/tests/algorithms/x/Java/neural_network/activation_functions/gaussian_error_linear_unit.java
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/gaussian_error_linear_unit.java
@@ -46,11 +46,7 @@ public class Main {
             System.out.println(gaussian_error_linear_unit(((double[])(new double[]{-3.0}))));
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/neural_network/activation_functions/leaky_rectified_linear_unit.bench
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/leaky_rectified_linear_unit.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 17003,
-  "memory_bytes": 10896,
-  "name": "main"
-}
+{"duration_us": 25667, "memory_bytes": 10896, "name": "main"}

--- a/tests/algorithms/x/Java/neural_network/activation_functions/leaky_rectified_linear_unit.java
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/leaky_rectified_linear_unit.java
@@ -30,11 +30,7 @@ public class Main {
             System.out.println(_p(result2));
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/neural_network/activation_functions/mish.bench
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/mish.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 22109,
-  "memory_bytes": 10704,
-  "name": "main"
-}
+{"duration_us": 22453, "memory_bytes": 10704, "name": "main"}

--- a/tests/algorithms/x/Java/neural_network/activation_functions/mish.java
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/mish.java
@@ -82,11 +82,7 @@ public class Main {
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/neural_network/activation_functions/rectified_linear_unit.bench
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/rectified_linear_unit.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 16479,
-  "memory_bytes": 10704,
-  "name": "main"
-}
+{"duration_us": 27634, "memory_bytes": 10704, "name": "main"}

--- a/tests/algorithms/x/Java/neural_network/activation_functions/rectified_linear_unit.java
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/rectified_linear_unit.java
@@ -21,11 +21,7 @@ public class Main {
             System.out.println(_p(relu(((double[])(new double[]{-1.0, 0.0, 5.0})))));
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/neural_network/activation_functions/scaled_exponential_linear_unit.bench
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/scaled_exponential_linear_unit.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 17643,
-  "memory_bytes": 600,
-  "name": "main"
-}
+{"duration_us": 25258, "memory_bytes": 600, "name": "main"}

--- a/tests/algorithms/x/Java/neural_network/activation_functions/scaled_exponential_linear_unit.java
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/scaled_exponential_linear_unit.java
@@ -31,11 +31,7 @@ public class Main {
             System.out.println(scaled_exponential_linear_unit(((double[])(new double[]{1.3, 4.7, 8.2})), (double)(1.6732), (double)(1.0507)));
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/neural_network/activation_functions/soboleva_modified_hyperbolic_tangent.bench
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/soboleva_modified_hyperbolic_tangent.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 17741,
-  "memory_bytes": 10824,
-  "name": "main"
-}
+{"duration_us": 30804, "memory_bytes": 10824, "name": "main"}

--- a/tests/algorithms/x/Java/neural_network/activation_functions/soboleva_modified_hyperbolic_tangent.java
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/soboleva_modified_hyperbolic_tangent.java
@@ -37,11 +37,7 @@ public class Main {
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/neural_network/activation_functions/softplus.java
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/softplus.java
@@ -57,11 +57,7 @@ public class Main {
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/neural_network/activation_functions/squareplus.bench
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/squareplus.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 17560,
-  "memory_bytes": 10704,
-  "name": "main"
-}
+{"duration_us": 27816, "memory_bytes": 10704, "name": "main"}

--- a/tests/algorithms/x/Java/neural_network/activation_functions/squareplus.java
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/squareplus.java
@@ -38,11 +38,7 @@ public class Main {
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/neural_network/activation_functions/swish.bench
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/swish.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 15738,
-  "memory_bytes": 10816,
-  "name": "main"
-}
+{"duration_us": 27400, "memory_bytes": 10816, "name": "main"}

--- a/tests/algorithms/x/Java/neural_network/activation_functions/swish.java
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/swish.java
@@ -90,11 +90,7 @@ public class Main {
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/neural_network/back_propagation_neural_network.bench
+++ b/tests/algorithms/x/Java/neural_network/back_propagation_neural_network.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 495571,
-  "memory_bytes": 51528,
-  "name": "main"
-}
+{"duration_us": 764199, "memory_bytes": 51392, "name": "main"}

--- a/tests/algorithms/x/Java/neural_network/back_propagation_neural_network.java
+++ b/tests/algorithms/x/Java/neural_network/back_propagation_neural_network.java
@@ -127,7 +127,7 @@ public class Main {
     }
 
     static double[] matTvec(double[][] mat, double[] vec) {
-        long cols = (long)(mat[(int)((long)(0))].length);
+        long cols = (long)(mat[(int)(0L)].length);
         double[] res_4 = ((double[])(new double[]{}));
         long j_3 = 0L;
         while ((long)(j_3) < (long)(cols)) {
@@ -328,11 +328,7 @@ layers[(int)((long)(i_27))] = layer_3;
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/neural_network/convolution_neural_network.bench
+++ b/tests/algorithms/x/Java/neural_network/convolution_neural_network.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 36414,
-  "memory_bytes": 58784,
-  "name": "main"
-}
+{"duration_us": 56213, "memory_bytes": 58784, "name": "main"}

--- a/tests/algorithms/x/Java/neural_network/convolution_neural_network.java
+++ b/tests/algorithms/x/Java/neural_network/convolution_neural_network.java
@@ -141,7 +141,7 @@ public class Main {
     }
 
     static double[] vec_mul_mat(double[] v, double[][] m) {
-        long cols = (long)(m[(int)((long)(0))].length);
+        long cols = (long)(m[(int)(0L)].length);
         double[] res_1 = ((double[])(new double[]{}));
         long j_7 = 0L;
         while ((long)(j_7) < (long)(cols)) {
@@ -347,11 +347,7 @@ b_hidden_3[(int)((long)(j_15))] = (double)((double)(b_hidden_3[(int)((long)(j_15
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/tests/algorithms/x/Java/neural_network/input_data.bench
+++ b/tests/algorithms/x/Java/neural_network/input_data.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 29617,
-  "memory_bytes": 50368,
-  "name": "main"
-}
+{"duration_us": 45828, "memory_bytes": 47712, "name": "main"}

--- a/tests/algorithms/x/Java/neural_network/input_data.java
+++ b/tests/algorithms/x/Java/neural_network/input_data.java
@@ -57,9 +57,9 @@ public class Main {
             long j_1 = 0L;
             while ((long)(j_1) < (long)(num_classes)) {
                 if ((long)(j_1) == (long)(labels[(int)((long)(i_1))])) {
-                    row_1 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(row_1), java.util.stream.LongStream.of(1L)).toArray()));
+                    row_1 = ((long[])(appendLong(row_1, 1L)));
                 } else {
-                    row_1 = ((long[])(java.util.stream.LongStream.concat(java.util.Arrays.stream(row_1), java.util.stream.LongStream.of(0L)).toArray()));
+                    row_1 = ((long[])(appendLong(row_1, 0L)));
                 }
                 j_1 = (long)((long)(j_1) + 1L);
             }
@@ -80,8 +80,8 @@ public class Main {
             long[][] images_rest_1 = ((long[][])(java.util.Arrays.copyOfRange(ds.images, (int)((long)(start)), (int)((long)(ds.num_examples)))));
             long[][] labels_rest_1 = ((long[][])(java.util.Arrays.copyOfRange(ds.labels, (int)((long)(start)), (int)((long)(ds.num_examples)))));
             long new_index_1 = (long)((long)(batch_size) - (long)(rest_1));
-            long[][] images_new_1 = ((long[][])(java.util.Arrays.copyOfRange(ds.images, (int)((long)(0)), (int)((long)(new_index_1)))));
-            long[][] labels_new_1 = ((long[][])(java.util.Arrays.copyOfRange(ds.labels, (int)((long)(0)), (int)((long)(new_index_1)))));
+            long[][] images_new_1 = ((long[][])(java.util.Arrays.copyOfRange(ds.images, (int)(0L), (int)((long)(new_index_1)))));
+            long[][] labels_new_1 = ((long[][])(java.util.Arrays.copyOfRange(ds.labels, (int)(0L), (int)((long)(new_index_1)))));
             long[][] batch_images_2 = ((long[][])(concat(images_rest_1, images_new_1)));
             long[][] batch_labels_2 = ((long[][])(concat(labels_rest_1, labels_new_1)));
             DataSet new_ds_2 = new DataSet(ds.images, ds.labels, ds.num_examples, new_index_1, (long)(ds.epochs_completed) + 1L);
@@ -98,8 +98,8 @@ public class Main {
     static Datasets read_data_sets(long[][] train_images, long[] train_labels_raw, long[][] test_images, long[] test_labels_raw, long validation_size, long num_classes) {
         long[][] train_labels = ((long[][])(dense_to_one_hot(((long[])(train_labels_raw)), (long)(num_classes))));
         long[][] test_labels_1 = ((long[][])(dense_to_one_hot(((long[])(test_labels_raw)), (long)(num_classes))));
-        long[][] validation_images_1 = ((long[][])(java.util.Arrays.copyOfRange(train_images, (int)((long)(0)), (int)((long)(validation_size)))));
-        long[][] validation_labels_1 = ((long[][])(java.util.Arrays.copyOfRange(train_labels, (int)((long)(0)), (int)((long)(validation_size)))));
+        long[][] validation_images_1 = ((long[][])(java.util.Arrays.copyOfRange(train_images, (int)(0L), (int)((long)(validation_size)))));
+        long[][] validation_labels_1 = ((long[][])(java.util.Arrays.copyOfRange(train_labels, (int)(0L), (int)((long)(validation_size)))));
         long[][] train_images_rest_1 = ((long[][])(java.util.Arrays.copyOfRange(train_images, (int)((long)(validation_size)), (int)((long)(train_images.length)))));
         long[][] train_labels_rest_1 = ((long[][])(java.util.Arrays.copyOfRange(train_labels, (int)((long)(validation_size)), (int)((long)(train_labels.length)))));
         DataSet train_1 = new_dataset(((long[][])(train_images_rest_1)), ((long[][])(train_labels_rest_1)));
@@ -135,11 +135,7 @@ public class Main {
             main();
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }
@@ -166,9 +162,18 @@ public class Main {
         return rt.totalMemory() - rt.freeMemory();
     }
 
-    static <T> T[] concat(T[] a, T[] b) {
-        T[] out = java.util.Arrays.copyOf(a, a.length + b.length);
-        System.arraycopy(b, 0, out, a.length, b.length);
+    static long[] appendLong(long[] arr, long v) {
+        long[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
+    }
+
+    static Object concat(Object a, Object b) {
+        int len1 = java.lang.reflect.Array.getLength(a);
+        int len2 = java.lang.reflect.Array.getLength(b);
+        Object out = java.lang.reflect.Array.newInstance(a.getClass().getComponentType(), len1 + len2);
+        System.arraycopy(a, 0, out, 0, len1);
+        System.arraycopy(b, 0, out, len1, len2);
         return out;
     }
 

--- a/tests/algorithms/x/Java/neural_network/simple_neural_network.bench
+++ b/tests/algorithms/x/Java/neural_network/simple_neural_network.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 96982,
-  "memory_bytes": 10832,
-  "name": "main"
-}
+{"duration_us": 129010, "memory_bytes": 10696, "name": "main"}

--- a/tests/algorithms/x/Java/neural_network/simple_neural_network.java
+++ b/tests/algorithms/x/Java/neural_network/simple_neural_network.java
@@ -63,11 +63,7 @@ public class Main {
             System.out.println(result);
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
-            System.out.println("{");
-            System.out.println("  \"duration_us\": " + _benchDuration + ",");
-            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
-            System.out.println("  \"name\": \"main\"");
-            System.out.println("}");
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
             return;
         }
     }

--- a/transpiler/x/java/ALGORITHMS.md
+++ b/transpiler/x/java/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated Java code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Java`.
-Last updated: 2025-08-17 14:12 GMT+7
+Last updated: 2025-08-17 15:35 GMT+7
 
-## Algorithms Golden Test Checklist (960/1077)
+## Algorithms Golden Test Checklist (961/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 40.0ms | 46.14KB |
@@ -692,56 +692,56 @@ Last updated: 2025-08-17 14:12 GMT+7
 | 683 | maths/sum_of_harmonic_series | ✓ | 51.0ms | 56.72KB |
 | 684 | maths/sumset | ✓ | 49.0ms | 46.25KB |
 | 685 | maths/sylvester_sequence | ✓ | 24.0ms | 664B |
-| 686 | maths/tanh | ✓ | 49.0ms | 56.82KB |
-| 687 | maths/test_factorial | ✓ | 25.0ms | 448B |
-| 688 | maths/test_prime_check | ✓ | 30.0ms | 768B |
-| 689 | maths/three_sum | ✓ | 31.0ms | 656B |
-| 690 | maths/trapezoidal_rule | ✓ | 50.0ms | 64.61KB |
-| 691 | maths/triplet_sum | ✓ | 77.0ms | 99.49KB |
-| 692 | maths/twin_prime | ✓ | 30.0ms | 664B |
-| 693 | maths/two_pointer | ✓ | 20.0ms | 600B |
-| 694 | maths/two_sum | ✓ | 24.0ms | 992B |
-| 695 | maths/volume | ✓ | 53.0ms | 50.80KB |
-| 696 | maths/zellers_congruence | ✓ | 59.0ms | 78.27KB |
-| 697 | matrix/binary_search_matrix | ✓ | 33.0ms | 872B |
-| 698 | matrix/count_islands_in_matrix | error |  |  |
-| 699 | matrix/count_negative_numbers_in_sorted_matrix | ✓ | 5.38s | 7.73MB |
-| 700 | matrix/count_paths | ✓ | 30.0ms | 992B |
-| 701 | matrix/cramers_rule_2x2 | ✓ | 27.0ms | 496B |
-| 702 | matrix/inverse_of_matrix | ✓ | 28.0ms | 704B |
-| 703 | matrix/largest_square_area_in_matrix | ✓ | 39.0ms | 48.75KB |
-| 704 | matrix/matrix_based_game | ✓ | 62.0ms | 65.01KB |
-| 705 | matrix/matrix_class | ✓ | 51.0ms | 111.45KB |
-| 706 | matrix/matrix_equalization | ✓ | 28.0ms | 47.18KB |
-| 707 | matrix/matrix_multiplication_recursion | ✓ | 30.0ms | 48.12KB |
-| 708 | matrix/matrix_operation | ✓ | 47.0ms | 117.21KB |
-| 709 | matrix/max_area_of_island | ✓ | 38.0ms | 77.95KB |
-| 710 | matrix/median_matrix | ✓ | 27.0ms | 47.18KB |
-| 711 | matrix/nth_fibonacci_using_matrix_exponentiation | ✓ | 53.0ms | 102.83KB |
-| 712 | matrix/pascal_triangle | ✓ | 39.0ms | 56.83KB |
-| 713 | matrix/rotate_matrix | ✓ | 53.0ms | 97.59KB |
-| 714 | matrix/searching_in_sorted_matrix | ✓ | 39.0ms | 104.48KB |
-| 715 | matrix/sherman_morrison | ✓ | 31.0ms | 66.34KB |
-| 716 | matrix/spiral_print | ✓ | 29.0ms | 47.40KB |
-| 717 | matrix/tests/test_matrix_operation | ✓ | 29.0ms | 58.00KB |
-| 718 | matrix/validate_sudoku_board | ✓ | 28.0ms | 48.34KB |
-| 719 | networking_flow/ford_fulkerson | ✓ | 32.0ms | 47.18KB |
-| 720 | networking_flow/minimum_cut | ✓ | 30.0ms | 48.71KB |
-| 721 | neural_network/activation_functions/binary_step | ✓ | 28.0ms | 46.77KB |
-| 722 | neural_network/activation_functions/exponential_linear_unit | ✓ | 18.0ms | 10.45KB |
-| 723 | neural_network/activation_functions/gaussian_error_linear_unit | ✓ | 17.0ms | 640B |
-| 724 | neural_network/activation_functions/leaky_rectified_linear_unit | ✓ | 17.0ms | 10.64KB |
+| 686 | maths/tanh | ✓ | 22.0ms | 10.45KB |
+| 687 | maths/test_factorial | ✓ | 23.0ms | 448B |
+| 688 | maths/test_prime_check | ✓ | 30.0ms | 976B |
+| 689 | maths/three_sum | ✓ | 43.0ms | 45.46KB |
+| 690 | maths/trapezoidal_rule | ✓ | 39.0ms | 47.52KB |
+| 691 | maths/triplet_sum | ✓ | 54.0ms | 84.48KB |
+| 692 | maths/twin_prime | ✓ | 25.0ms | 552B |
+| 693 | maths/two_pointer | ✓ | 23.0ms | 600B |
+| 694 | maths/two_sum | ✓ | 22.0ms | 872B |
+| 695 | maths/volume | ✓ | 44.0ms | 50.90KB |
+| 696 | maths/zellers_congruence | ✓ | 57.0ms | 78.38KB |
+| 697 | matrix/binary_search_matrix | ✓ | 25.0ms | 1.16KB |
+| 698 | matrix/count_islands_in_matrix | ✓ | 46.0ms | 45.36KB |
+| 699 | matrix/count_negative_numbers_in_sorted_matrix | ✓ | 6.01s | 15.44MB |
+| 700 | matrix/count_paths | ✓ | 39.0ms | 45.88KB |
+| 701 | matrix/cramers_rule_2x2 | ✓ | 21.0ms | 496B |
+| 702 | matrix/inverse_of_matrix | ✓ | 25.0ms | 496B |
+| 703 | matrix/largest_square_area_in_matrix | ✓ | 42.0ms | 45.85KB |
+| 704 | matrix/matrix_based_game | ✓ | 57.0ms | 66.16KB |
+| 705 | matrix/matrix_class | ✓ | 64.0ms | 111.45KB |
+| 706 | matrix/matrix_equalization | ✓ | 23.0ms | 968B |
+| 707 | matrix/matrix_multiplication_recursion | ✓ | 39.0ms | 45.42KB |
+| 708 | matrix/matrix_operation | ✓ | 75.0ms | 117.21KB |
+| 709 | matrix/max_area_of_island | ✓ | 56.0ms | 77.95KB |
+| 710 | matrix/median_matrix | ✓ | 27.0ms | 1.05KB |
+| 711 | matrix/nth_fibonacci_using_matrix_exponentiation | ✓ | 64.0ms | 100.12KB |
+| 712 | matrix/pascal_triangle | ✓ | 51.0ms | 54.12KB |
+| 713 | matrix/rotate_matrix | ✓ | 58.0ms | 94.89KB |
+| 714 | matrix/searching_in_sorted_matrix | ✓ | 62.0ms | 104.48KB |
+| 715 | matrix/sherman_morrison | ✓ | 51.0ms | 66.34KB |
+| 716 | matrix/spiral_print | ✓ | 22.0ms | 1.16KB |
+| 717 | matrix/tests/test_matrix_operation | ✓ | 45.0ms | 58.00KB |
+| 718 | matrix/validate_sudoku_board | ✓ | 47.0ms | 48.44KB |
+| 719 | networking_flow/ford_fulkerson | ✓ | 25.0ms | 968B |
+| 720 | networking_flow/minimum_cut | ✓ | 45.0ms | 46.01KB |
+| 721 | neural_network/activation_functions/binary_step | ✓ | 30.0ms | 552B |
+| 722 | neural_network/activation_functions/exponential_linear_unit | ✓ | 26.0ms | 10.45KB |
+| 723 | neural_network/activation_functions/gaussian_error_linear_unit | ✓ | 23.0ms | 640B |
+| 724 | neural_network/activation_functions/leaky_rectified_linear_unit | ✓ | 25.0ms | 10.64KB |
 | 725 | neural_network/activation_functions/mish | ✓ | 22.0ms | 10.45KB |
-| 726 | neural_network/activation_functions/rectified_linear_unit | ✓ | 16.0ms | 10.45KB |
-| 727 | neural_network/activation_functions/scaled_exponential_linear_unit | ✓ | 17.0ms | 600B |
-| 728 | neural_network/activation_functions/soboleva_modified_hyperbolic_tangent | ✓ | 17.0ms | 10.57KB |
+| 726 | neural_network/activation_functions/rectified_linear_unit | ✓ | 27.0ms | 10.45KB |
+| 727 | neural_network/activation_functions/scaled_exponential_linear_unit | ✓ | 25.0ms | 600B |
+| 728 | neural_network/activation_functions/soboleva_modified_hyperbolic_tangent | ✓ | 30.0ms | 10.57KB |
 | 729 | neural_network/activation_functions/softplus | error |  |  |
-| 730 | neural_network/activation_functions/squareplus | ✓ | 17.0ms | 10.45KB |
-| 731 | neural_network/activation_functions/swish | ✓ | 15.0ms | 10.56KB |
-| 732 | neural_network/back_propagation_neural_network | ✓ | 495.0ms | 50.32KB |
-| 733 | neural_network/convolution_neural_network | ✓ | 36.0ms | 57.41KB |
-| 734 | neural_network/input_data | ✓ | 29.0ms | 49.19KB |
-| 735 | neural_network/simple_neural_network | ✓ | 96.0ms | 10.58KB |
+| 730 | neural_network/activation_functions/squareplus | ✓ | 27.0ms | 10.45KB |
+| 731 | neural_network/activation_functions/swish | ✓ | 27.0ms | 10.56KB |
+| 732 | neural_network/back_propagation_neural_network | ✓ | 764.0ms | 50.19KB |
+| 733 | neural_network/convolution_neural_network | ✓ | 56.0ms | 57.41KB |
+| 734 | neural_network/input_data | ✓ | 45.0ms | 46.59KB |
+| 735 | neural_network/simple_neural_network | ✓ | 129.0ms | 10.45KB |
 | 736 | neural_network/two_hidden_layers_neural_network | ✓ | 34.0ms | 47.07KB |
 | 737 | other/activity_selection | ✓ | 32.0ms | 77.77KB |
 | 738 | other/alternative_list_arrange | ✓ | 28.0ms | 56.45KB |


### PR DESCRIPTION
## Summary
- normalize `int` types to `long` for consistent numeric inference
- avoid extra parens when slicing strings
- skip default return when `if` branches already return
- regenerate Java algorithm outputs for indices 686-735 with benchmarks

## Testing
- `for i in $(seq 686 735); do MOCHI_ALG_INDEX=$i MOCHI_BENCHMARK=1 go test -tags=slow ./transpiler/x/java -run TestJavaTranspiler_Algorithms_Golden -update-algorithms-java > /tmp/test_$i.log; done`


------
https://chatgpt.com/codex/tasks/task_e_68a19088d5fc83209d6e73570e062c1e