### PR TITLE
fs transpiler: improve int64 assignment and map detection

### DIFF
--- a/tests/algorithms/transpiler/FS/other/linear_congruential_generator.bench
+++ b/tests/algorithms/transpiler/FS/other/linear_congruential_generator.bench
@@ -1,5 +1,5 @@
 {
   "duration_us": -693671,
-  "memory_bytes": 79856,
+  "memory_bytes": 76976,
   "name": "main"
 }

--- a/tests/algorithms/transpiler/FS/other/linear_congruential_generator.fs
+++ b/tests/algorithms/transpiler/FS/other/linear_congruential_generator.fs
@@ -1,4 +1,4 @@
-// Generated 2025-08-12 16:24 +0700
+// Generated 2025-08-17 20:31 +0700
 
 exception Return
 let mutable _nowSeed:int64 = 0L
@@ -20,13 +20,15 @@ let _now () =
 
 _initNow()
 let rec _str v =
-    let s = sprintf "%A" v
-    let s = if s.EndsWith(".0") then s.Substring(0, s.Length - 2) else s
-    s.Replace("[|", "[")
-     .Replace("|]", "]")
-     .Replace("; ", " ")
-     .Replace(";", "")
-     .Replace("\"", "")
+    match box v with
+    | :? float as f -> sprintf "%.10g" f
+    | _ ->
+        let s = sprintf "%A" v
+        s.Replace("[|", "[")
+         .Replace("|]", "]")
+         .Replace("; ", " ")
+         .Replace(";", "")
+         .Replace("\"", "")
 type LCG = {
     mutable _multiplier: int64
     mutable _increment: int64

--- a/transpiler/x/fs/ALGORITHMS.md
+++ b/transpiler/x/fs/ALGORITHMS.md
@@ -1,7 +1,7 @@
 # F# Algorithms Transpiler Output
 
 Completed programs: 928/1077
-Last updated: 2025-08-17 13:56 +0700
+Last updated: 2025-08-17 20:31 +0700
 
 Checklist:
 
@@ -744,7 +744,7 @@ Checklist:
 | 735 | neural_network/simple_neural_network | ✓ | 571.223ms | 37.2 KB |
 | 736 | neural_network/two_hidden_layers_neural_network | ✓ | 571.223ms | 77.6 KB |
 | 737 | other/activity_selection | ✓ | 571.223ms | 55.2 KB |
-| 738 | other/alternative_list_arrange | ✓ | 571.223ms | 99.6 KB |
+| 738 | other/alternative_list_arrange | ✓ | 571.223ms | 99.4 KB |
 | 739 | other/bankers_algorithm | ✓ | 571.223ms | 79.5 KB |
 | 740 | other/davis_putnam_logemann_loveland | ✓ | 571.223ms | 33.2 KB |
 | 741 | other/doomsday | ✓ | 571.223ms | 32.3 KB |
@@ -755,7 +755,7 @@ Checklist:
 | 746 | other/h_index | ✓ | 571.223ms | 78.1 KB |
 | 747 | other/least_recently_used | ✓ | 571.223ms | 78.2 KB |
 | 748 | other/lfu_cache | ✓ | 571.223ms | 82.1 KB |
-| 749 | other/linear_congruential_generator | ✓ |  | 78.0 KB |
+| 749 | other/linear_congruential_generator | ✓ |  | 75.2 KB |
 | 750 | other/lru_cache | ✓ | 571.223ms | 79.3 KB |
 | 751 | other/magicdiamondpattern | ✓ | 571.223ms | 31.1 KB |
 | 752 | other/majority_vote_algorithm | ✓ | 571.223ms | 78.3 KB |

--- a/transpiler/x/fs/README.md
+++ b/transpiler/x/fs/README.md
@@ -112,4 +112,4 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-Last updated: 2025-08-17 12:28 +0700
+Last updated: 2025-08-17 20:31 +0700

--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-08-17 20:31 +0700)
+- dart: handle num casts as double
+- Generated F# for 103/105 programs (103 passing)
+
 ## Progress (2025-08-17 12:28 +0700)
 - feat(fs): add points_are_collinear_3d
 - Generated F# for 103/105 programs (103 passing)


### PR DESCRIPTION
## Summary
- handle assignments where int64 values target int variables by promoting target types
- restrict dictionary updates to declared map types to avoid misclassifying arrays
- regenerate F# output for linear_congruential_generator

## Testing
- `MOCHI_ALGORITHMS_INDEX=749 go test -run TestFSTranspiler_Algorithms_Golden -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68a1da0dbf388320b5feaf97b6f6ad77