### PR TITLE
java transpiler: map exp/ln to Math library

### DIFF
--- a/tests/algorithms/x/Java/neural_network/activation_functions/softplus.bench
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/softplus.bench
@@ -1,5 +1,1 @@
-Exception in thread "main" java.lang.RuntimeException: ln domain error
-	at Main.ln(Main.java:5)
-	at Main.softplus(Main.java:38)
-	at Main.main(Main.java:49)
-	at Main.main(Main.java:57)
+{"duration_us": 21739, "memory_bytes": 10704, "name": "main"}

--- a/tests/algorithms/x/Java/neural_network/activation_functions/softplus.error
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/softplus.error
@@ -1,6 +1,0 @@
-run: exit status 1
-Exception in thread "main" java.lang.RuntimeException: ln domain error
-	at Main.ln(Main.java:5)
-	at Main.softplus(Main.java:38)
-	at Main.main(Main.java:49)
-	at Main.main(Main.java:57)

--- a/tests/algorithms/x/Java/neural_network/activation_functions/softplus.java
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/softplus.java
@@ -35,7 +35,7 @@ public class Main {
         long i_1 = 0L;
         while ((long)(i_1) < (long)(vector.length)) {
             double x_1 = (double)(vector[(int)((long)(i_1))]);
-            double value_1 = (double)(ln((double)((double)(1.0) + (double)(exp((double)(x_1))))));
+            double value_1 = (double)(Math.log((double)(1.0) + (double)(Math.exp(x_1))));
             result = ((double[])(appendDouble(result, (double)(value_1))));
             i_1 = (long)((long)(i_1) + 1L);
         }

--- a/tests/algorithms/x/Java/neural_network/activation_functions/softplus.out
+++ b/tests/algorithms/x/Java/neural_network/activation_functions/softplus.out
@@ -1,5 +1,2 @@
-Exception in thread "main" java.lang.RuntimeException: ln domain error
-	at Main.ln(Main.java:5)
-	at Main.softplus(Main.java:38)
-	at Main.main(Main.java:49)
-	at Main.main(Main.java:54)
+[2.3955454645979626, 1.0374879504858856, 0.1269280110429726, 0.022124216454879247]
+[1.01034297700481E-4, 0.554355244468527, 0.9432489459974548, 0.010407710341623785]

--- a/transpiler/x/java/ALGORITHMS.md
+++ b/transpiler/x/java/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated Java code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Java`.
-Last updated: 2025-08-17 15:35 GMT+7
+Last updated: 2025-08-17 20:47 GMT+7
 
-## Algorithms Golden Test Checklist (961/1077)
+## Algorithms Golden Test Checklist (962/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 40.0ms | 46.14KB |
@@ -735,7 +735,7 @@ Last updated: 2025-08-17 15:35 GMT+7
 | 726 | neural_network/activation_functions/rectified_linear_unit | ✓ | 27.0ms | 10.45KB |
 | 727 | neural_network/activation_functions/scaled_exponential_linear_unit | ✓ | 25.0ms | 600B |
 | 728 | neural_network/activation_functions/soboleva_modified_hyperbolic_tangent | ✓ | 30.0ms | 10.57KB |
-| 729 | neural_network/activation_functions/softplus | error |  |  |
+| 729 | neural_network/activation_functions/softplus | ✓ | 21.0ms | 10.45KB |
 | 730 | neural_network/activation_functions/squareplus | ✓ | 27.0ms | 10.45KB |
 | 731 | neural_network/activation_functions/swish | ✓ | 27.0ms | 10.56KB |
 | 732 | neural_network/back_propagation_neural_network | ✓ | 764.0ms | 50.19KB |

--- a/transpiler/x/java/transpiler.go
+++ b/transpiler/x/java/transpiler.go
@@ -5872,7 +5872,17 @@ func compilePostfix(pf *parser.PostfixExpr) (Expr, error) {
 					}
 				}
 			} else if v, ok := expr.(*VarExpr); ok {
-				if v.Name == "int" && len(args) == 1 {
+				if (v.Name == "exp" || v.Name == "math.exp") && len(args) == 1 {
+					expr = &CallExpr{Func: "Math.exp", Args: args}
+					if funcRet != nil {
+						funcRet["Math.exp"] = "double"
+					}
+				} else if (v.Name == "ln" || v.Name == "log" || v.Name == "math.log") && len(args) == 1 {
+					expr = &CallExpr{Func: "Math.log", Args: args}
+					if funcRet != nil {
+						funcRet["Math.log"] = "double"
+					}
+				} else if v.Name == "int" && len(args) == 1 {
 					expr = &IntCastExpr{Value: args[0]}
 				} else if t, ok := varTypes[v.Name]; ok {
 					if strings.HasPrefix(t, "fn") || strings.HasPrefix(t, "java.util.function.Function") {
@@ -6081,6 +6091,18 @@ func compilePrimary(p *parser.Primary) (Expr, error) {
 		}
 		if name == "abs" && len(args) == 1 {
 			return &CallExpr{Func: "Math.abs", Args: args}, nil
+		}
+		if name == "exp" && len(args) == 1 {
+			if funcRet != nil {
+				funcRet["Math.exp"] = "double"
+			}
+			return &CallExpr{Func: "Math.exp", Args: args}, nil
+		}
+		if (name == "ln" || name == "log") && len(args) == 1 {
+			if funcRet != nil {
+				funcRet["Math.log"] = "double"
+			}
+			return &CallExpr{Func: "Math.log", Args: args}, nil
 		}
 		if name == "floor" && len(args) == 1 {
 			return &CallExpr{Func: "Math.floor", Args: args}, nil


### PR DESCRIPTION
## Summary
- map calls to `exp` and `ln` to Java's `Math` library
- regenerate `softplus` algorithm outputs and benchmarks

## Testing
- `MOCHI_ALG_INDEX=729 go test ./transpiler/x/java -run TestJavaTranspiler_Algorithms_Golden -tags slow -count=1 -update-algorithms-java`
- `MOCHI_ALG_INDEX=729 MOCHI_BENCHMARK=1 go test ./transpiler/x/java -run TestJavaTranspiler_Algorithms_Golden -tags slow -count=1 -update-algorithms-java`
- `for i in $(seq 730 778); do echo "Running index $i"; MOCHI_ALG_INDEX=$i MOCHI_BENCHMARK=1 go test ./transpiler/x/java -run TestJavaTranspiler_Algorithms_Golden -tags slow -count=1 -update-algorithms-java >/tmp/testlog && tail -n 2 /tmp/testlog; done`


------
https://chatgpt.com/codex/tasks/task_e_68a1da9134a88320be0debbe5b9ea431