### PR TITLE
kt: update convolution neural network benchmarks

### DIFF
--- a/tests/algorithms/x/Kotlin/neural_network/convolution_neural_network.bench
+++ b/tests/algorithms/x/Kotlin/neural_network/convolution_neural_network.bench
@@ -1,6 +1,3 @@
-Before training: [0.4950789572027328, 0.4852103276380401]
-Exception in thread "main" java.lang.ClassCastException: class java.util.ArrayList cannot be cast to class TrainSample (java.util.ArrayList is in module java.base of loader 'bootstrap'; TrainSample is in unnamed module of loader 'app')
-	at Convolution_neural_networkKt.train(convolution_neural_network.kt:267)
-	at Convolution_neural_networkKt.user_main(convolution_neural_network.kt:326)
-	at Convolution_neural_networkKt.main(convolution_neural_network.kt:335)
-	at Convolution_neural_networkKt.main(convolution_neural_network.kt)
+Before training: [0.49507895720273554, 0.48521032763804034]
+After training: [0.31835026986877996, 0.6607981045069524]
+{"duration_us":79691, "memory_bytes":108744, "name":"main"}

--- a/tests/algorithms/x/Kotlin/neural_network/convolution_neural_network.error
+++ b/tests/algorithms/x/Kotlin/neural_network/convolution_neural_network.error
@@ -1,7 +1,0 @@
-run: exit status 1
-Before training: [0.4950789572027328, 0.4852103276380401]
-Exception in thread "main" java.lang.ClassCastException: class java.util.ArrayList cannot be cast to class TrainSample (java.util.ArrayList is in module java.base of loader 'bootstrap'; TrainSample is in unnamed module of loader 'app')
-	at Convolution_neural_networkKt.train(convolution_neural_network.kt:267)
-	at Convolution_neural_networkKt.user_main(convolution_neural_network.kt:326)
-	at Convolution_neural_networkKt.main(convolution_neural_network.kt:335)
-	at Convolution_neural_networkKt.main(convolution_neural_network.kt)

--- a/tests/algorithms/x/Kotlin/neural_network/convolution_neural_network.kt
+++ b/tests/algorithms/x/Kotlin/neural_network/convolution_neural_network.kt
@@ -31,15 +31,15 @@ data class TrainSample(var image: MutableList<MutableList<Double>> = mutableList
 var seed: Int = (1).toInt()
 fun random(): Double {
     seed = (Math.floorMod(((seed * 13) + 7), 100)).toInt()
-    return ((seed.toDouble())) / 100.0
+    return (seed.toDouble()) / 100.0
 }
 
 fun sigmoid(x: Double): Double {
-    return 1.0 / (1.0 + exp(0.0 - x))
+    return 1.0 / (1.0 + kotlin.math.exp(0.0 - x))
 }
 
 fun to_float(x: Int): Double {
-    return x * 1.0
+    return (x).toDouble() * 1.0
 }
 
 fun exp(x: Double): Double {
@@ -68,7 +68,7 @@ fun convolve(data: MutableList<MutableList<Double>>, kernel: MutableList<Mutable
             while (a < size_kernel) {
                 var b: Int = (0).toInt()
                 while (b < size_kernel) {
-                    sum = sum + ((((data[i + a]!!) as MutableList<Double>))[j + b]!! * (((kernel[a]!!) as MutableList<Double>))[b]!!)
+                    sum = sum + (((data[i + a]!!) as MutableList<Double>)[j + b]!! * ((kernel[a]!!) as MutableList<Double>)[b]!!)
                     b = b + 1
                 }
                 a = a + 1
@@ -94,12 +94,12 @@ fun average_pool(map: MutableList<MutableList<Double>>, size: Int): MutableList<
             while (a < size) {
                 var b: Int = (0).toInt()
                 while (b < size) {
-                    sum = sum + (((map[i + a]!!) as MutableList<Double>))[j + b]!!
+                    sum = sum + ((map[i + a]!!) as MutableList<Double>)[j + b]!!
                     b = b + 1
                 }
                 a = a + 1
             }
-            row = run { val _tmp = row.toMutableList(); _tmp.add(sum / (((size * size).toDouble()))); _tmp }
+            row = run { val _tmp = row.toMutableList(); _tmp.add(sum / ((size * size).toDouble())); _tmp }
             j = j + size
         }
         out = run { val _tmp = out.toMutableList(); _tmp.add(row); _tmp }
@@ -115,8 +115,8 @@ fun flatten(maps: MutableList<MutableList<MutableList<Double>>>): MutableList<Do
         var j: Int = (0).toInt()
         while (j < (maps[i]!!).size) {
             var k: Int = (0).toInt()
-            while (k < ((((maps[i]!!) as MutableList<MutableList<Double>>))[j]!!).size) {
-                out = run { val _tmp = out.toMutableList(); _tmp.add(((((((maps[i]!!) as MutableList<MutableList<Double>>))[j]!!) as MutableList<Double>))[k]!!); _tmp }
+            while (k < (((maps[i]!!) as MutableList<MutableList<Double>>)[j]!!).size) {
+                out = run { val _tmp = out.toMutableList(); _tmp.add(((((maps[i]!!) as MutableList<MutableList<Double>>)[j]!!) as MutableList<Double>)[k]!!); _tmp }
                 k = k + 1
             }
             j = j + 1
@@ -134,7 +134,7 @@ fun vec_mul_mat(v: MutableList<Double>, m: MutableList<MutableList<Double>>): Mu
         var sum: Double = 0.0
         var i: Int = (0).toInt()
         while (i < v.size) {
-            sum = sum + (v[i]!! * (((m[i]!!) as MutableList<Double>))[j]!!)
+            sum = sum + (v[i]!! * ((m[i]!!) as MutableList<Double>)[j]!!)
             i = i + 1
         }
         res = run { val _tmp = res.toMutableList(); _tmp.add(sum); _tmp }
@@ -150,7 +150,7 @@ fun matT_vec_mul(m: MutableList<MutableList<Double>>, v: MutableList<Double>): M
         var sum: Double = 0.0
         var j: Int = (0).toInt()
         while (j < (m[i]!!).size) {
-            sum = sum + ((((m[i]!!) as MutableList<Double>))[j]!! * v[j]!!)
+            sum = sum + (((m[i]!!) as MutableList<Double>)[j]!! * v[j]!!)
             j = j + 1
         }
         res = run { val _tmp = res.toMutableList(); _tmp.add(sum); _tmp }
@@ -264,13 +264,13 @@ fun train(cnn: CNN, samples: MutableList<TrainSample>, epochs: Int): CNN {
     while (e < epochs) {
         var s: Int = (0).toInt()
         while (s < samples.size) {
-            var data: TrainSample = ((samples[s]!!.image) as TrainSample)
-            var target: TrainSample = ((samples[s]!!.target) as TrainSample)
+            var data: MutableList<MutableList<Double>> = samples[s]!!.image
+            var target: MutableList<Double> = samples[s]!!.target
             var maps: MutableList<MutableList<MutableList<Double>>> = mutableListOf<MutableList<MutableList<Double>>>()
             var i: Int = (0).toInt()
             while (i < (cnn.conv_kernels).size) {
-                var conv_map: MutableList<MutableList<Double>> = convolve((data as MutableList<MutableList<Double>>), (cnn.conv_kernels)[i]!!, cnn.conv_step, (cnn.conv_bias)[i]!!)
-                var pooled: MutableList<MutableList<Double>> = average_pool((conv_map as MutableList<MutableList<Double>>), cnn.pool_size)
+                var conv_map: MutableList<MutableList<Double>> = convolve(data, (cnn.conv_kernels)[i]!!, cnn.conv_step, (cnn.conv_bias)[i]!!)
+                var pooled: MutableList<MutableList<Double>> = average_pool(conv_map, cnn.pool_size)
                 maps = run { val _tmp = maps.toMutableList(); _tmp.add(pooled); _tmp }
                 i = i + 1
             }
@@ -279,15 +279,15 @@ fun train(cnn: CNN, samples: MutableList<TrainSample>, epochs: Int): CNN {
             var hidden_out: MutableList<Double> = vec_map_sig(hidden_net)
             var out_net: MutableList<Double> = vec_add(vec_mul_mat(hidden_out, w_out), b_out)
             var out: MutableList<Double> = vec_map_sig(out_net)
-            var error_out: MutableList<Double> = vec_sub((target as MutableList<Double>), out)
-            var pd_out: MutableList<Double> = vec_mul((error_out as MutableList<Double>), vec_mul(out, vec_sub(mutableListOf(1.0, 1.0), out)))
+            var error_out: MutableList<Double> = vec_sub(target, out)
+            var pd_out: MutableList<Double> = vec_mul(error_out, vec_mul(out, vec_sub(mutableListOf(1.0, 1.0), out)))
             var error_hidden: MutableList<Double> = matT_vec_mul(w_out, pd_out)
             var pd_hidden: MutableList<Double> = vec_mul(error_hidden, vec_mul(hidden_out, vec_sub(mutableListOf(1.0, 1.0), hidden_out)))
             var j: Int = (0).toInt()
             while (j < w_out.size) {
                 var k: Int = (0).toInt()
                 while (k < (w_out[j]!!).size) {
-                    _listSet(w_out[j]!!, k, (((w_out[j]!!) as MutableList<Double>))[k]!! + ((cnn.rate_weight * hidden_out[j]!!) * pd_out[k]!!))
+                    _listSet(w_out[j]!!, k, ((w_out[j]!!) as MutableList<Double>)[k]!! + ((cnn.rate_weight * hidden_out[j]!!) * pd_out[k]!!))
                     k = k + 1
                 }
                 j = j + 1
@@ -301,7 +301,7 @@ fun train(cnn: CNN, samples: MutableList<TrainSample>, epochs: Int): CNN {
             while (i_h < w_hidden.size) {
                 var j_h: Int = (0).toInt()
                 while (j_h < (w_hidden[i_h]!!).size) {
-                    _listSet(w_hidden[i_h]!!, j_h, (((w_hidden[i_h]!!) as MutableList<Double>))[j_h]!! + ((cnn.rate_weight * flat[i_h]!!) * pd_hidden[j_h]!!))
+                    _listSet(w_hidden[i_h]!!, j_h, ((w_hidden[i_h]!!) as MutableList<Double>)[j_h]!! + ((cnn.rate_weight * flat[i_h]!!) * pd_hidden[j_h]!!))
                     j_h = j_h + 1
                 }
                 i_h = i_h + 1

--- a/transpiler/x/kt/ALGORITHMS.md
+++ b/transpiler/x/kt/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated Kotlin code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Kotlin`.
-Last updated: 2025-08-17 15:35 GMT+7
+Last updated: 2025-08-17 21:04 GMT+7
 
-## Algorithms Golden Test Checklist (675/1077)
+## Algorithms Golden Test Checklist (676/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 30.54ms | 124.45KiB |
@@ -739,7 +739,7 @@ Last updated: 2025-08-17 15:35 GMT+7
 | 730 | neural_network/activation_functions/squareplus | ✓ | 27.83ms | 112.77KiB |
 | 731 | neural_network/activation_functions/swish | ✓ | 37.20ms | 112.73KiB |
 | 732 | neural_network/back_propagation_neural_network | ✓ | 919.51ms | 830.81KiB |
-| 733 | neural_network/convolution_neural_network | error |  |  |
+| 733 | neural_network/convolution_neural_network | ✓ | 79.69ms | 106.20KiB |
 | 734 | neural_network/input_data | ✓ | 21.02ms | 121.62KiB |
 | 735 | neural_network/simple_neural_network | ✓ | 161.52ms | 124.12KiB |
 | 736 | neural_network/two_hidden_layers_neural_network | ✓ | 58.44ms | 122.64KiB |


### PR DESCRIPTION
## Summary
- refresh Kotlin benchmark outputs for TheAlgorithms convolution neural network example
- regenerate Kotlin source and prune stale error artifact
- update Kotlin algorithms progress listing

## Testing
- `MOCHI_ALG_INDEX=733 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/kt -run TestKTTranspiler_Algorithms_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68a1daffdd388320a3c2f613c9603ceb