### PR TITLE
php: track peak memory in benchmarks

### DIFF
--- a/tests/algorithms/x/PHP/other/greedy.bench
+++ b/tests/algorithms/x/PHP/other/greedy.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 96,
-  "memory_bytes": 41136,
+  "duration_us": 122,
+  "memory_bytes": 1661936,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/other/greedy.php
+++ b/tests/algorithms/x/PHP/other/greedy.php
@@ -1,5 +1,21 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,23 +36,25 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function get_value($t) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function get_value($t) {
   global $food, $foods, $res, $value, $weight;
   return $t['value'];
-}
-function get_weight($t) {
+};
+  function get_weight($t) {
   global $food, $foods, $res, $value, $weight;
   return $t['weight'];
-}
-function get_name($t) {
+};
+  function get_name($t) {
   global $food, $foods, $res, $value, $weight;
   return $t['name'];
-}
-function value_weight($t) {
+};
+  function value_weight($t) {
   global $food, $foods, $res, $value, $weight;
   return $t['value'] / $t['weight'];
-}
-function build_menu($names, $values, $weights) {
+};
+  function build_menu($names, $values, $weights) {
   global $food, $foods, $res, $value, $weight;
   $menu = [];
   $i = 0;
@@ -45,8 +63,8 @@ function build_menu($names, $values, $weights) {
   $i = $i + 1;
 };
   return $menu;
-}
-function sort_desc($items, $key_func) {
+};
+  function sort_desc($items, $key_func) {
   global $food, $foods, $res, $value, $weight;
   $arr = [];
   $i = 0;
@@ -67,8 +85,8 @@ function sort_desc($items, $key_func) {
   $j = $j + 1;
 };
   return $arr;
-}
-function greedy($items, $max_cost, $key_func) {
+};
+  function greedy($items, $max_cost, $key_func) {
   global $food, $foods, $res, $value, $weight;
   $items_copy = sort_desc($items, $key_func);
   $result = [];
@@ -86,12 +104,12 @@ function greedy($items, $max_cost, $key_func) {
   $i = $i + 1;
 };
   return ['items' => $result, 'total_value' => $total_value];
-}
-function thing_to_string($t) {
+};
+  function thing_to_string($t) {
   global $food, $foods, $res, $value, $weight;
   return 'Thing(' . $t['name'] . ', ' . _str($t['value']) . ', ' . _str($t['weight']) . ')';
-}
-function list_to_string($ts) {
+};
+  function list_to_string($ts) {
   global $food, $foods, $res, $value, $weight;
   $s = '[';
   $i = 0;
@@ -104,12 +122,20 @@ function list_to_string($ts) {
 };
   $s = $s . ']';
   return $s;
-}
-$food = ['Burger', 'Pizza', 'Coca Cola', 'Rice', 'Sambhar', 'Chicken', 'Fries', 'Milk'];
-$value = [80.0, 100.0, 60.0, 70.0, 50.0, 110.0, 90.0, 60.0];
-$weight = [40.0, 60.0, 40.0, 70.0, 100.0, 85.0, 55.0, 70.0];
-$foods = build_menu($food, $value, $weight);
-echo rtrim(list_to_string($foods)), PHP_EOL;
-$res = greedy($foods, 500.0, 'get_value');
-echo rtrim(list_to_string($res['items'])), PHP_EOL;
-echo rtrim(_str($res['total_value'])), PHP_EOL;
+};
+  $food = ['Burger', 'Pizza', 'Coca Cola', 'Rice', 'Sambhar', 'Chicken', 'Fries', 'Milk'];
+  $value = [80.0, 100.0, 60.0, 70.0, 50.0, 110.0, 90.0, 60.0];
+  $weight = [40.0, 60.0, 40.0, 70.0, 100.0, 85.0, 55.0, 70.0];
+  $foods = build_menu($food, $value, $weight);
+  echo rtrim(list_to_string($foods)), PHP_EOL;
+  $res = greedy($foods, 500.0, 'get_value');
+  echo rtrim(list_to_string($res['items'])), PHP_EOL;
+  echo rtrim(_str($res['total_value'])), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/transpiler/x/php/ALGORITHMS.md
+++ b/transpiler/x/php/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated PHP code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/PHP`.
-Last updated: 2025-08-17 15:46 GMT+7
+Last updated: 2025-08-17 20:47 GMT+7
 
 ## Algorithms Golden Test Checklist (993/1077)
 | Index | Name | Status | Duration | Memory |
@@ -750,7 +750,7 @@ Last updated: 2025-08-17 15:46 GMT+7
 | 741 | other/doomsday | ✓ | 88µs | 35.9 KB |
 | 742 | other/fischer_yates_shuffle | ✓ | 323µs | 40.0 KB |
 | 743 | other/gauss_easter | ✓ | 118µs | 40.2 KB |
-| 744 | other/greedy | ✓ | 96µs | 40.2 KB |
+| 744 | other/greedy | ✓ | 122µs | 1.6 MB |
 | 745 | other/guess_the_number_search | ✓ | 205µs | 41.0 KB |
 | 746 | other/h_index | ✓ | 186µs | 39.5 KB |
 | 747 | other/least_recently_used | ✓ | 142µs | 41.0 KB |

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-Last updated: 2025-08-17 14:12 +0700
+Last updated: 2025-08-17 20:43 +0700
 
 ## VM Golden Test Checklist (103/105)
 - [x] append_builtin

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,4 +1,4 @@
-## Progress (2025-08-17 14:12 +0700)
+## Progress (2025-08-17 20:43 +0700)
 - Generated PHP for 103/105 programs
 - Updated README checklist and outputs
 - Enhanced printing to match golden format

--- a/transpiler/x/php/transpiler.go
+++ b/transpiler/x/php/transpiler.go
@@ -1465,7 +1465,7 @@ func (b *BenchStmt) emit(w io.Writer) {
 		}
 	}
 	io.WriteString(w, "$__end = _now();\n")
-	io.WriteString(w, "$__end_mem = memory_get_peak_usage();\n")
+	io.WriteString(w, "$__end_mem = memory_get_peak_usage(true);\n")
 	io.WriteString(w, "$__duration = max(1, intdiv($__end - $__start, 1000));\n")
 	io.WriteString(w, "$__mem_diff = max(0, $__end_mem - $__start_mem);\n")
 	fmt.Fprintf(w, "$__bench = [\"duration_us\" => $__duration, \"memory_bytes\" => $__mem_diff, \"name\" => %q];\n", b.Name)


### PR DESCRIPTION
## Summary
- track peak memory usage in PHP benchmark wrapper
- regenerate greedy algorithm output and benchmarks

## Testing
- `MOCHI_ALG_INDEX=744 MOCHI_BENCHMARK=1 go test ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68a1dc98fc008320b8b39a82670c6b5a