### PR TITLE
pascal: support hyperbolic math functions

### DIFF
--- a/tests/algorithms/x/Pascal/maths/tanh.bench
+++ b/tests/algorithms/x/Pascal/maths/tanh.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 1,
+  "duration_us": 0,
   "memory_bytes": 0,
   "name": "main"
 }

--- a/tests/algorithms/x/Pascal/matrix/count_negative_numbers_in_sorted_matrix.bench
+++ b/tests/algorithms/x/Pascal/matrix/count_negative_numbers_in_sorted_matrix.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 2108,
+  "duration_us": 1434,
   "memory_bytes": 8073344,
   "name": "main"
 }

--- a/tests/algorithms/x/Pascal/matrix/matrix_operation.bench
+++ b/tests/algorithms/x/Pascal/matrix/matrix_operation.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 1,
+  "duration_us": 0,
   "memory_bytes": 0,
   "name": "main"
 }

--- a/tests/algorithms/x/Pascal/matrix/rotate_matrix.bench
+++ b/tests/algorithms/x/Pascal/matrix/rotate_matrix.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 1,
+  "duration_us": 0,
   "memory_bytes": 1280,
   "name": "main"
 }

--- a/tests/algorithms/x/Pascal/matrix/searching_in_sorted_matrix.bench
+++ b/tests/algorithms/x/Pascal/matrix/searching_in_sorted_matrix.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 1,
+  "duration_us": 0,
   "memory_bytes": 0,
   "name": "main"
 }

--- a/tests/algorithms/x/Pascal/matrix/spiral_print.bench
+++ b/tests/algorithms/x/Pascal/matrix/spiral_print.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 1,
+  "duration_us": 0,
   "memory_bytes": 0,
   "name": "main"
 }

--- a/tests/algorithms/x/Pascal/networking_flow/ford_fulkerson.bench
+++ b/tests/algorithms/x/Pascal/networking_flow/ford_fulkerson.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 0,
+  "duration_us": 1,
   "memory_bytes": 544,
   "name": "main"
 }

--- a/tests/algorithms/x/Pascal/networking_flow/minimum_cut.bench
+++ b/tests/algorithms/x/Pascal/networking_flow/minimum_cut.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 1,
+  "duration_us": 0,
   "memory_bytes": 640,
   "name": "main"
 }

--- a/tests/algorithms/x/Pascal/neural_network/back_propagation_neural_network.bench
+++ b/tests/algorithms/x/Pascal/neural_network/back_propagation_neural_network.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 522,
+  "duration_us": 366,
   "memory_bytes": 0,
   "name": "main"
 }

--- a/tests/algorithms/x/Pascal/neural_network/simple_neural_network.bench
+++ b/tests/algorithms/x/Pascal/neural_network/simple_neural_network.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 147,
+  "duration_us": 104,
   "memory_bytes": 0,
   "name": "main"
 }

--- a/transpiler/x/pas/ALGORITHMS.md
+++ b/transpiler/x/pas/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Pascal code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Pascal`.
-Last updated: 2025-08-17 14:29 GMT+7
+Last updated: 2025-08-17 21:05 GMT+7
 
 ## Algorithms Golden Test Checklist (538/1077)
 | Index | Name | Status | Duration | Memory |
@@ -705,7 +705,7 @@ Last updated: 2025-08-17 14:29 GMT+7
 | 696 | maths/zellers_congruence | ✓ | 0ns | 17.34KB |
 | 697 | matrix/binary_search_matrix | ✓ | 0ns | 0B |
 | 698 | matrix/count_islands_in_matrix | ✓ | 0ns | 384B |
-| 699 | matrix/count_negative_numbers_in_sorted_matrix | ✓ | 2.0ms | 7.70MB |
+| 699 | matrix/count_negative_numbers_in_sorted_matrix | ✓ | 1.0ms | 7.70MB |
 | 700 | matrix/count_paths | ✓ | 0ns | 0B |
 | 701 | matrix/cramers_rule_2x2 | ✓ | 0ns | 0B |
 | 702 | matrix/inverse_of_matrix | ✓ | 0ns | 896B |
@@ -714,19 +714,19 @@ Last updated: 2025-08-17 14:29 GMT+7
 | 705 | matrix/matrix_class | ✓ | 1.0µs | 64B |
 | 706 | matrix/matrix_equalization | error |  |  |
 | 707 | matrix/matrix_multiplication_recursion | ✓ | 0ns | 1.31KB |
-| 708 | matrix/matrix_operation | ✓ | 1.0µs | 0B |
+| 708 | matrix/matrix_operation | ✓ | 0ns | 0B |
 | 709 | matrix/max_area_of_island | ✓ | 0ns | 8.28KB |
 | 710 | matrix/median_matrix | ✓ | 0ns | 512B |
 | 711 | matrix/nth_fibonacci_using_matrix_exponentiation | ✓ | 0ns | 0B |
 | 712 | matrix/pascal_triangle | ✓ | 0ns | 0B |
-| 713 | matrix/rotate_matrix | ✓ | 1.0µs | 1.25KB |
-| 714 | matrix/searching_in_sorted_matrix | ✓ | 1.0µs | 0B |
+| 713 | matrix/rotate_matrix | ✓ | 0ns | 1.25KB |
+| 714 | matrix/searching_in_sorted_matrix | ✓ | 0ns | 0B |
 | 715 | matrix/sherman_morrison | ✓ | 1.0µs | 0B |
-| 716 | matrix/spiral_print | ✓ | 1.0µs | 0B |
+| 716 | matrix/spiral_print | ✓ | 0ns | 0B |
 | 717 | matrix/tests/test_matrix_operation | ✓ | 0ns | 0B |
 | 718 | matrix/validate_sudoku_board | ✓ | 0ns | 41.81KB |
-| 719 | networking_flow/ford_fulkerson | ✓ | 0ns | 544B |
-| 720 | networking_flow/minimum_cut | ✓ | 1.0µs | 640B |
+| 719 | networking_flow/ford_fulkerson | ✓ | 1.0µs | 544B |
+| 720 | networking_flow/minimum_cut | ✓ | 0ns | 640B |
 | 721 | neural_network/activation_functions/binary_step | ✓ | 0ns | 0B |
 | 722 | neural_network/activation_functions/exponential_linear_unit | ✓ | 1.0µs | 192B |
 | 723 | neural_network/activation_functions/gaussian_error_linear_unit | ✓ | 0ns | 256B |
@@ -738,10 +738,10 @@ Last updated: 2025-08-17 14:29 GMT+7
 | 729 | neural_network/activation_functions/softplus | ✓ | 0ns | 0B |
 | 730 | neural_network/activation_functions/squareplus | ✓ | 1.0µs | 0B |
 | 731 | neural_network/activation_functions/swish | ✓ | 0ns | 0B |
-| 732 | neural_network/back_propagation_neural_network | ✓ | 522.0µs | 0B |
+| 732 | neural_network/back_propagation_neural_network | ✓ | 366.0µs | 0B |
 | 733 | neural_network/convolution_neural_network | ✓ | 1.0µs | 0B |
 | 734 | neural_network/input_data | ✓ | 0ns | 0B |
-| 735 | neural_network/simple_neural_network | ✓ | 147.0µs | 0B |
+| 735 | neural_network/simple_neural_network | ✓ | 104.0µs | 0B |
 | 736 | neural_network/two_hidden_layers_neural_network | ✓ | 1.0µs | 0B |
 | 737 | other/activity_selection | ✓ | 0ns | 128B |
 | 738 | other/alternative_list_arrange | error |  |  |

--- a/transpiler/x/pas/transpiler.go
+++ b/transpiler/x/pas/transpiler.go
@@ -4683,6 +4683,15 @@ func convertPostfix(env *types.Env, pf *parser.PostfixExpr) (Expr, error) {
 				} else if name == "ln" && len(args) == 1 {
 					currProg.UseMath = true
 					expr = &CallExpr{Name: "Ln", Args: args}
+				} else if name == "tanh" && len(args) == 1 {
+					currProg.UseMath = true
+					expr = &CallExpr{Name: "TanH", Args: args}
+				} else if name == "sinh" && len(args) == 1 {
+					currProg.UseMath = true
+					expr = &CallExpr{Name: "SinH", Args: args}
+				} else if name == "cosh" && len(args) == 1 {
+					currProg.UseMath = true
+					expr = &CallExpr{Name: "CosH", Args: args}
 				} else if name == "floor" && len(args) == 1 {
 					currProg.UseMath = true
 					expr = &CallExpr{Name: "Floor", Args: args}
@@ -4695,7 +4704,7 @@ func convertPostfix(env *types.Env, pf *parser.PostfixExpr) (Expr, error) {
 					switch t.Root {
 					case "math":
 						currProg.UseMath = true
-						mapped := map[string]string{"sqrt": "Sqrt", "pow": "Power", "sin": "Sin", "log": "Ln"}
+						mapped := map[string]string{"sqrt": "Sqrt", "pow": "Power", "sin": "Sin", "log": "Ln", "tanh": "TanH", "sinh": "SinH", "cosh": "CosH"}
 						if fn, ok := mapped[name]; ok {
 							var args []Expr
 							for _, a := range op.Call.Args {
@@ -5661,18 +5670,18 @@ func inferType(e Expr) string {
 			}
 		}
 		return "integer"
-       case *SliceExpr:
-               if v.String {
-                       return "string"
-               }
-               // Preserve the element type of the sliced expression so nested
-               // lists keep their alias information (e.g. IntArrayArray).
-               return inferType(v.Target)
-       case *SelectorExpr:
-               root := v.Root
-               if s, ok := lookupName(root); ok {
-                       root = s
-               }
+	case *SliceExpr:
+		if v.String {
+			return "string"
+		}
+		// Preserve the element type of the sliced expression so nested
+		// lists keep their alias information (e.g. IntArrayArray).
+		return inferType(v.Target)
+	case *SelectorExpr:
+		root := v.Root
+		if s, ok := lookupName(root); ok {
+			root = s
+		}
 		t, ok := currentVarTypes[root]
 		if !ok {
 			return ""


### PR DESCRIPTION
## Summary
- map tanh, sinh and cosh to Pascal's Math unit so hyperbolic calls compile
- refresh algorithm benchmarks for indices 686-735

## Testing
- `MOCHI_ALG_INDEX=686 MOCHI_BENCHMARK=1 go test ./transpiler/x/pas -tags slow -run TestPascalTranspiler_Algorithms_Golden -update-algorithms-pas -count=1`
- `for i in $(seq 689 735); do echo "Running index $i"; MOCHI_ALG_INDEX=$i MOCHI_BENCHMARK=1 go test ./transpiler/x/pas -tags slow -run TestPascalTranspiler_Algorithms_Golden -update-algorithms-pas -count=1; if [ $? -ne 0 ]; then echo "Failed at $i"; break; fi; done`


------
https://chatgpt.com/codex/tasks/task_e_68a1e02be6c4832090a72555dbb89175