### PR TITLE
docs: add v0.10.69 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # 📦 CHANGELOG.md
 
+## [0.10.69] – 2025-08-18T18:36:29+07:00
+
+### Added
+
+* Pascal transpiler supports hyperbolic math functions.
+* C transpiler handles string casts, list equality, and list literal concatenation.
+* Scheme adds SwapBenchMain helper and refreshed algorithm outputs.
+* Rust transpiler tracks closure parameter types and string indexing casts.
+* Erlang and Clojure transpilers expand algorithm outputs (indices 754–804 and 698–747).
+* PHP benchmarks track peak memory usage.
+
+### Changed
+
+* Kotlin updates convolution neural network benchmarks.
+* Java and Go map `exp`/`ln` to native math libraries.
+* Ruby transpiler honors user-defined math functions and optimizes `pow10`.
+* Python refines numeric string conversion.
+* C# trims float literal precision.
+
+### Fixed
+
+* F# transpiler improves int64 assignments.
+* C# transpiler resolves test data path handling.
+* Racket handles late variable declarations.
+* Pascal cleanup removes stale error logs.
+
 ## [0.10.68] – 2025-08-17T08:35:51+00:00
 
 ### Added

--- a/releases/v0.10.69.md
+++ b/releases/v0.10.69.md
@@ -1,0 +1,23 @@
+# Aug 2025 (v0.10.69)
+
+Released on Mon Aug 18 18:36:29 2025 +0700.
+
+Mochi v0.10.69 enhances numeric math and expands algorithm coverage across transpilers.
+
+## Transpilers
+
+- Pascal supports hyperbolic math functions and removes stale logs.
+- C transpiler handles string casts, list equality, and list literal concatenation.
+- Java and Go map `exp` and `ln` to native math libraries.
+- F# improves `int64` assignments.
+- Ruby honors user-defined math functions and folds `pow10` multiplications.
+- C# trims float literal precision and fixes test data paths starting at `tests/`.
+- Python refines numeric string conversion.
+- Scheme adds `SwapBenchMain` helper and refreshes algorithm outputs.
+- Rust tracks closure parameter types and supports string indexing casts.
+- PHP benchmarks now track peak memory usage.
+
+## Algorithms
+
+- Expanded algorithm outputs for Erlang (indices 754–804) and Clojure (698–747).
+- Updated convolution neural network benchmarks for Kotlin.


### PR DESCRIPTION
## Summary
- document v0.10.69 in CHANGELOG and releases

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a31058aec88320a63ea20289ccc5de