### PR TITLE
php: update benchmarks for algorithms 752-801

### DIFF
--- a/tests/algorithms/x/PHP/other/majority_vote_algorithm.bench
+++ b/tests/algorithms/x/PHP/other/majority_vote_algorithm.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 150,
-  "memory_bytes": 37784,
+  "duration_us": 208,
+  "memory_bytes": 1669888,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/other/majority_vote_algorithm.php
+++ b/tests/algorithms/x/PHP/other/majority_vote_algorithm.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -118,7 +119,7 @@ $__start = _now();
 };
   main();
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/other/maximum_subsequence.bench
+++ b/tests/algorithms/x/PHP/other/maximum_subsequence.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 115,
-  "memory_bytes": 39328,
+  "duration_us": 320,
+  "memory_bytes": 1682608,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/other/maximum_subsequence.php
+++ b/tests/algorithms/x/PHP/other/maximum_subsequence.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -45,7 +46,7 @@ $__start = _now();
   echo rtrim(json_encode(max_subsequence_sum([1, 2, 3, 4, -2]), 1344)), PHP_EOL;
   echo rtrim(json_encode(max_subsequence_sum([-2, -3, -1, -4, -6]), 1344)), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/other/nested_brackets.bench
+++ b/tests/algorithms/x/PHP/other/nested_brackets.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 211,
-  "memory_bytes": 38896,
+  "duration_us": 174,
+  "memory_bytes": 1672912,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/other/nested_brackets.php
+++ b/tests/algorithms/x/PHP/other/nested_brackets.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -77,7 +78,7 @@ $__start = _now();
 };
   main();
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/other/number_container_system.bench
+++ b/tests/algorithms/x/PHP/other/number_container_system.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 102,
-  "memory_bytes": 37416,
+  "duration_us": 137,
+  "memory_bytes": 1664920,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/other/number_container_system.php
+++ b/tests/algorithms/x/PHP/other/number_container_system.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -28,12 +29,12 @@ function _intdiv($a, $b) {
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
         return intval(bcdiv($sa, $sb, 0));
     }
-    return intdiv($a, $b);
+    return intdiv(intval($a), intval($b));
 }
 $__start_mem = memory_get_usage();
 $__start = _now();
   function remove_at($xs, $idx) {
-  global $nm, $im, $cont;
+  global $cont, $im, $nm;
   $res = [];
   $i = 0;
   while ($i < count($xs)) {
@@ -45,7 +46,7 @@ $__start = _now();
   return $res;
 };
   function insert_at($xs, $idx, $val) {
-  global $nm, $im, $cont;
+  global $cont, $im, $nm;
   $res = [];
   $i = 0;
   while ($i < count($xs)) {
@@ -61,7 +62,7 @@ $__start = _now();
   return $res;
 };
   function binary_search_delete($array, $item) {
-  global $nm, $im, $cont;
+  global $cont, $im, $nm;
   $low = 0;
   $high = count($array) - 1;
   $arr = $array;
@@ -82,7 +83,7 @@ $__start = _now();
   return $arr;
 };
   function binary_search_insert($array, $index) {
-  global $nm, $im, $cont;
+  global $cont, $im, $nm;
   $low = 0;
   $high = count($array) - 1;
   $arr = $array;
@@ -103,7 +104,7 @@ $__start = _now();
   return $arr;
 };
   function change($cont, $idx, $num) {
-  global $nm, $im;
+  global $im, $nm;
   $numbermap = $cont['numbermap'];
   $indexmap = $cont['indexmap'];
   if (array_key_exists($idx, $indexmap)) {
@@ -124,7 +125,7 @@ $__start = _now();
   return ['numbermap' => $numbermap, 'indexmap' => $indexmap];
 };
   function find($cont, $num) {
-  global $nm, $im;
+  global $im, $nm;
   $numbermap = $cont['numbermap'];
   if (array_key_exists($num, $numbermap)) {
   $arr = $numbermap[$num];
@@ -144,7 +145,7 @@ $__start = _now();
   echo rtrim(json_encode(find($cont, 10), 1344)), PHP_EOL;
   echo rtrim(json_encode(find($cont, 20), 1344)), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/other/quine.bench
+++ b/tests/algorithms/x/PHP/other/quine.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 52,
-  "memory_bytes": 36096,
+  "duration_us": 53,
+  "memory_bytes": 1687648,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/other/quine.php
+++ b/tests/algorithms/x/PHP/other/quine.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -27,7 +28,7 @@ print(code)
 ';
   echo rtrim($code), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/other/scoring_algorithm.bench
+++ b/tests/algorithms/x/PHP/other/scoring_algorithm.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 165,
-  "memory_bytes": 40184,
+  "duration_us": 278,
+  "memory_bytes": 1668776,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/other/scoring_algorithm.php
+++ b/tests/algorithms/x/PHP/other/scoring_algorithm.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -38,7 +39,7 @@ function _append($arr, $x) {
 $__start_mem = memory_get_usage();
 $__start = _now();
   function get_data($source_data) {
-  global $vehicles, $weights, $result;
+  global $result, $vehicles, $weights;
   $data_lists = [];
   $i = 0;
   while ($i < count($source_data)) {
@@ -57,7 +58,7 @@ $__start = _now();
   return $data_lists;
 };
   function calculate_each_score($data_lists, $weights) {
-  global $vehicles, $result;
+  global $result, $vehicles;
   $score_lists = [];
   $i = 0;
   while ($i < count($data_lists)) {
@@ -105,7 +106,7 @@ $__start = _now();
   return $score_lists;
 };
   function generate_final_scores($score_lists) {
-  global $vehicles, $weights, $result;
+  global $result, $vehicles, $weights;
   $count = count($score_lists[0]);
   $final_scores = [];
   $i = 0;
@@ -126,7 +127,7 @@ $__start = _now();
   return $final_scores;
 };
   function procentual_proximity($source_data, $weights) {
-  global $vehicles, $result;
+  global $result, $vehicles;
   $data_lists = get_data($source_data);
   $score_lists = calculate_each_score($data_lists, $weights);
   $final_scores = generate_final_scores($score_lists);
@@ -145,7 +146,7 @@ $__start = _now();
   $result = procentual_proximity($vehicles, $weights);
   echo rtrim(_str($result)), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/other/sdes.bench
+++ b/tests/algorithms/x/PHP/other/sdes.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 236,
-  "memory_bytes": 72392,
+  "duration_us": 189,
+  "memory_bytes": 1645672,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/other/sdes.php
+++ b/tests/algorithms/x/PHP/other/sdes.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -40,12 +41,12 @@ function _intdiv($a, $b) {
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
         return intval(bcdiv($sa, $sb, 0));
     }
-    return intdiv($a, $b);
+    return intdiv(intval($a), intval($b));
 }
 $__start_mem = memory_get_usage();
 $__start = _now();
   function apply_table($inp, $table) {
-  global $p4_table, $key, $message, $p8_table, $p10_table, $IP, $IP_inv, $expansion, $s0, $s1, $temp, $left, $right, $key1, $key2, $CT, $PT;
+  global $CT, $IP, $IP_inv, $PT, $expansion, $key, $key1, $key2, $left, $message, $p10_table, $p4_table, $p8_table, $right, $s0, $s1, $temp;
   $res = '';
   $i = 0;
   while ($i < count($table)) {
@@ -59,11 +60,11 @@ $__start = _now();
   return $res;
 };
   function left_shift($data) {
-  global $p4_table, $key, $message, $p8_table, $p10_table, $IP, $IP_inv, $expansion, $s0, $s1, $temp, $left, $right, $key1, $key2, $CT, $PT;
+  global $CT, $IP, $IP_inv, $PT, $expansion, $key, $key1, $key2, $left, $message, $p10_table, $p4_table, $p8_table, $right, $s0, $s1, $temp;
   return substr($data, 1, strlen($data) - 1) . substr($data, 0, 1);
 };
   function mochi_xor($a, $b) {
-  global $p4_table, $key, $message, $p8_table, $p10_table, $IP, $IP_inv, $expansion, $s0, $s1, $temp, $left, $right, $key1, $key2, $CT, $PT;
+  global $CT, $IP, $IP_inv, $PT, $expansion, $key, $key1, $key2, $left, $message, $p10_table, $p4_table, $p8_table, $right, $s0, $s1, $temp;
   $res = '';
   $i = 0;
   while ($i < strlen($a) && $i < strlen($b)) {
@@ -77,7 +78,7 @@ $__start = _now();
   return $res;
 };
   function int_to_binary($n) {
-  global $p4_table, $key, $message, $p8_table, $p10_table, $IP, $IP_inv, $expansion, $s0, $s1, $temp, $left, $right, $key1, $key2, $CT, $PT;
+  global $CT, $IP, $IP_inv, $PT, $expansion, $key, $key1, $key2, $left, $message, $p10_table, $p4_table, $p8_table, $right, $s0, $s1, $temp;
   if ($n == 0) {
   return '0';
 }
@@ -90,7 +91,7 @@ $__start = _now();
   return $res;
 };
   function pad_left($s, $width) {
-  global $p4_table, $key, $message, $p8_table, $p10_table, $IP, $IP_inv, $expansion, $s0, $s1, $temp, $left, $right, $key1, $key2, $CT, $PT;
+  global $CT, $IP, $IP_inv, $PT, $expansion, $key, $key1, $key2, $left, $message, $p10_table, $p4_table, $p8_table, $right, $s0, $s1, $temp;
   $res = $s;
   while (strlen($res) < $width) {
   $res = '0' . $res;
@@ -98,7 +99,7 @@ $__start = _now();
   return $res;
 };
   function bin_to_int($s) {
-  global $p4_table, $key, $message, $p8_table, $p10_table, $IP, $IP_inv, $expansion, $s0, $s1, $temp, $left, $right, $key1, $key2, $CT, $PT;
+  global $CT, $IP, $IP_inv, $PT, $expansion, $key, $key1, $key2, $left, $message, $p10_table, $p4_table, $p8_table, $right, $s0, $s1, $temp;
   $result = 0;
   $i = 0;
   while ($i < strlen($s)) {
@@ -109,7 +110,7 @@ $__start = _now();
   return $result;
 };
   function apply_sbox($s, $data) {
-  global $p4_table, $key, $message, $p8_table, $p10_table, $IP, $IP_inv, $expansion, $s0, $s1, $temp, $left, $right, $key1, $key2, $CT, $PT;
+  global $CT, $IP, $IP_inv, $PT, $expansion, $key, $key1, $key2, $left, $message, $p10_table, $p4_table, $p8_table, $right, $s0, $s1, $temp;
   $row_bits = substr($data, 0, 1) . substr($data, strlen($data) - 1, strlen($data) - (strlen($data) - 1));
   $col_bits = substr($data, 1, 3 - 1);
   $row = bin_to_int($row_bits);
@@ -120,7 +121,7 @@ $__start = _now();
 };
   $p4_table = [2, 4, 3, 1];
   function f($expansion, $s0, $s1, $key, $message) {
-  global $p4_table, $p8_table, $p10_table, $IP, $IP_inv, $key1, $key2, $CT, $PT;
+  global $CT, $IP, $IP_inv, $PT, $key1, $key2, $p10_table, $p4_table, $p8_table;
   $left = substr($message, 0, 4);
   $right = substr($message, 4, 8 - 4);
   $temp = apply_table($right, $expansion);
@@ -166,7 +167,7 @@ $__start = _now();
   $PT = apply_table($temp, $IP_inv);
   echo rtrim('Plain text after decypting is: ' . $PT), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/other/tower_of_hanoi.bench
+++ b/tests/algorithms/x/PHP/other/tower_of_hanoi.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 51,
-  "memory_bytes": 36368,
+  "duration_us": 64,
+  "memory_bytes": 1685112,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/other/tower_of_hanoi.php
+++ b/tests/algorithms/x/PHP/other/tower_of_hanoi.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -31,7 +32,7 @@ $__start = _now();
   $height = 3;
   move_tower($height, 'A', 'B', 'C');
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/other/word_search.bench
+++ b/tests/algorithms/x/PHP/other/word_search.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 343,
-  "memory_bytes": 39904,
+  "duration_us": 242,
+  "memory_bytes": 1663056,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/other/word_search.php
+++ b/tests/algorithms/x/PHP/other/word_search.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -173,7 +174,7 @@ $__start = _now();
 };
   main();
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/altitude_pressure.bench
+++ b/tests/algorithms/x/PHP/physics/altitude_pressure.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 78,
-  "memory_bytes": 40224,
+  "duration_us": 138,
+  "memory_bytes": 1677008,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/altitude_pressure.php
+++ b/tests/algorithms/x/PHP/physics/altitude_pressure.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -37,7 +38,7 @@ function _panic($msg) {
 }
 $__start_mem = memory_get_usage();
 $__start = _now();
-  function to_float($x) {
+  function mochi_to_float($x) {
   return $x * 1.0;
 };
   function ln($x) {
@@ -58,16 +59,9 @@ $__start = _now();
   return 2.0 * $sum;
 };
   function mochi_exp($x) {
-  $term = 1.0;
-  $sum = 1.0;
-  $n = 1;
-  while ($n < 20) {
-  $term = $term * $x / floatval($n);
-  $sum = $sum + $term;
-  $n = $n + 1;
-};
-  return $sum;
-};
+  return exp($x);
+}
+;
   function pow_float($base, $exponent) {
   return mochi_exp($exponent * ln($base));
 };
@@ -85,7 +79,7 @@ $__start = _now();
   echo rtrim(_str(get_altitude_at_pressure(101325.0))), PHP_EOL;
   echo rtrim(_str(get_altitude_at_pressure(80000.0))), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/archimedes_principle_of_buoyant_force.bench
+++ b/tests/algorithms/x/PHP/physics/archimedes_principle_of_buoyant_force.bench
@@ -1,5 +1,5 @@
 {
   "duration_us": 1,
-  "memory_bytes": 36416,
+  "memory_bytes": 1684752,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/archimedes_principle_of_buoyant_force.php
+++ b/tests/algorithms/x/PHP/physics/archimedes_principle_of_buoyant_force.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -41,7 +42,7 @@ $__start = _now();
   return $res;
 };
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/basic_orbital_capture.bench
+++ b/tests/algorithms/x/PHP/physics/basic_orbital_capture.bench
@@ -1,1 +1,1 @@
-Fatal error: Cannot redeclare function sqrt() in /workspace/mochi/tests/algorithms/x/PHP/physics/basic_orbital_capture.php on line 53
+capture_area failed

--- a/tests/algorithms/x/PHP/physics/basic_orbital_capture.error
+++ b/tests/algorithms/x/PHP/physics/basic_orbital_capture.error
@@ -1,3 +1,2 @@
-run: exit status 255
-
-Fatal error: Cannot redeclare function sqrt() in /workspace/mochi/tests/algorithms/x/PHP/physics/basic_orbital_capture.php on line 53
+run: exit status 1
+capture_area failed

--- a/tests/algorithms/x/PHP/physics/basic_orbital_capture.php
+++ b/tests/algorithms/x/PHP/physics/basic_orbital_capture.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -41,7 +42,7 @@ $__start = _now();
   $C = 299792458.0;
   $PI = 3.141592653589793;
   function pow10($n) {
-  global $G, $C, $PI;
+  global $C, $G, $PI;
   $result = 1.0;
   $i = 0;
   while ($i < $n) {
@@ -50,8 +51,8 @@ $__start = _now();
 };
   return $result;
 };
-  function sqrt($x) {
-  global $G, $C, $PI;
+  function mochi_sqrt($x) {
+  global $C, $G, $PI;
   if ($x <= 0.0) {
   return 0.0;
 }
@@ -64,14 +65,14 @@ $__start = _now();
   return $guess;
 };
   function mochi_abs($x) {
-  global $G, $C, $PI;
+  global $C, $G, $PI;
   if ($x < 0.0) {
   return -$x;
 }
   return $x;
 };
   function capture_radii($target_body_radius, $target_body_mass, $projectile_velocity) {
-  global $G, $C, $PI;
+  global $C, $G, $PI;
   if ($target_body_mass < 0.0) {
   _panic('Mass cannot be less than 0');
 }
@@ -83,11 +84,11 @@ $__start = _now();
 }
   $escape_velocity_squared = (2.0 * $G * $target_body_mass) / $target_body_radius;
   $denom = $projectile_velocity * $projectile_velocity;
-  $capture_radius = $target_body_radius * sqrt(1.0 + $escape_velocity_squared / $denom);
+  $capture_radius = $target_body_radius * mochi_sqrt(1.0 + $escape_velocity_squared / $denom);
   return $capture_radius;
 };
   function capture_area($capture_radius) {
-  global $G, $C, $PI;
+  global $C, $G, $PI;
   if ($capture_radius < 0.0) {
   _panic('Cannot have a capture radius less than 0');
 }
@@ -95,26 +96,26 @@ $__start = _now();
   return $sigma;
 };
   function run_tests() {
-  global $G, $C, $PI;
-  $r = capture_radii(6.957 * pow10(8), 1.99 * pow10(30), 25000.0);
-  if (mochi_abs($r - 1.720959069143714 * pow10(10)) > 1.0) {
+  global $C, $G, $PI;
+  $r = capture_radii(695699999.999999985078603, 1989999999999999991118215802998.747676610946655, 25000.0);
+  if (mochi_abs($r - 17209590691.437139930997091) > 1.0) {
   _panic('capture_radii failed');
 }
   $a = capture_area($r);
-  if (mochi_abs($a - 9.304455331801812 * pow10(20)) > 1.0) {
+  if (mochi_abs($a - 930445533180181172383.527155034244061) > 1.0) {
   _panic('capture_area failed');
 }
 };
   function main() {
-  global $G, $C, $PI;
+  global $C, $G, $PI;
   run_tests();
-  $r = capture_radii(6.957 * pow10(8), 1.99 * pow10(30), 25000.0);
+  $r = capture_radii(695699999.999999985078603, 1989999999999999991118215802998.747676610946655, 25000.0);
   echo rtrim(_str($r)), PHP_EOL;
   echo rtrim(_str(capture_area($r))), PHP_EOL;
 };
   main();
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/casimir_effect.bench
+++ b/tests/algorithms/x/PHP/physics/casimir_effect.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 338,
-  "memory_bytes": 38584,
+  "duration_us": 171,
+  "memory_bytes": 1672832,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/casimir_effect.php
+++ b/tests/algorithms/x/PHP/physics/casimir_effect.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -103,7 +104,7 @@ $__start = _now();
 };
   main();
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/center_of_mass.bench
+++ b/tests/algorithms/x/PHP/physics/center_of_mass.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 104,
-  "memory_bytes": 40432,
+  "duration_us": 114,
+  "memory_bytes": 1672032,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/center_of_mass.php
+++ b/tests/algorithms/x/PHP/physics/center_of_mass.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -83,7 +84,7 @@ $__start = _now();
   $r2 = center_of_mass([['x' => 1.0, 'y' => 2.0, 'z' => 3.0, 'mass' => 4.0], ['x' => 5.0, 'y' => 6.0, 'z' => 7.0, 'mass' => 8.0], ['x' => 9.0, 'y' => 10.0, 'z' => 11.0, 'mass' => 12.0]]);
   echo rtrim(coord_to_string($r2)), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/centripetal_force.bench
+++ b/tests/algorithms/x/PHP/physics/centripetal_force.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 74,
-  "memory_bytes": 40056,
+  "duration_us": 62,
+  "memory_bytes": 1677112,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/centripetal_force.php
+++ b/tests/algorithms/x/PHP/physics/centripetal_force.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -76,7 +77,7 @@ $__start = _now();
   show(12.25, 40.0, 25.0);
   show(50.0, 100.0, 50.0);
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/coulombs_law.bench
+++ b/tests/algorithms/x/PHP/physics/coulombs_law.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 14197,
-  "memory_bytes": 36920,
+  "duration_us": 153,
+  "memory_bytes": 1670296,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/coulombs_law.php
+++ b/tests/algorithms/x/PHP/physics/coulombs_law.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -40,7 +41,7 @@ function _intdiv($a, $b) {
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
         return intval(bcdiv($sa, $sb, 0));
     }
-    return intdiv($a, $b);
+    return intdiv(intval($a), intval($b));
 }
 function _panic($msg) {
     fwrite(STDERR, strval($msg));
@@ -81,7 +82,7 @@ $__start = _now();
   echo rtrim(format2(coulombs_law(-5.0, -8.0, 10.0))), PHP_EOL;
   echo rtrim(format2(coulombs_law(50.0, 100.0, 50.0))), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/doppler_frequency.bench
+++ b/tests/algorithms/x/PHP/physics/doppler_frequency.bench
@@ -1,5 +1,5 @@
 {
   "duration_us": 59,
-  "memory_bytes": 39504,
+  "memory_bytes": 1678488,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/doppler_frequency.php
+++ b/tests/algorithms/x/PHP/physics/doppler_frequency.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -66,7 +67,7 @@ $__start = _now();
 };
   main();
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/escape_velocity.bench
+++ b/tests/algorithms/x/PHP/physics/escape_velocity.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 95,
-  "memory_bytes": 35816,
+  "duration_us": 69,
+  "memory_bytes": 1680376,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/escape_velocity.php
+++ b/tests/algorithms/x/PHP/physics/escape_velocity.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -66,11 +67,11 @@ $__start = _now();
   $velocity = sqrt_newton(2.0 * $G * $mass / $radius);
   return round3($velocity);
 };
-  echo rtrim(json_encode(escape_velocity(5972000000000000419220214.0, 6371000.0), 1344)), PHP_EOL;
-  echo rtrim(json_encode(escape_velocity(73479999999999998649969.0, 1737000.0), 1344)), PHP_EOL;
-  echo rtrim(json_encode(escape_velocity(1897999999999999909405801191.0, 69911000.0), 1344)), PHP_EOL;
+  echo rtrim(json_encode(escape_velocity(5972000000000000419220214.098459109663963, 6371000.000000000440536), 1344)), PHP_EOL;
+  echo rtrim(json_encode(escape_velocity(73479999999999998649968.802055809646845, 1737000.000000000099476), 1344)), PHP_EOL;
+  echo rtrim(json_encode(escape_velocity(1897999999999999909405801190.587226301431656, 69911000.000000003140599), 1344)), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/grahams_law.bench
+++ b/tests/algorithms/x/PHP/physics/grahams_law.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 98,
-  "memory_bytes": 37608,
+  "duration_us": 110,
+  "memory_bytes": 1670928,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/grahams_law.php
+++ b/tests/algorithms/x/PHP/physics/grahams_law.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -17,7 +18,7 @@ function _now() {
 }
 $__start_mem = memory_get_usage();
 $__start = _now();
-  function to_float($x) {
+  function mochi_to_float($x) {
   return $x * 1.0;
 };
   function round6($x) {
@@ -89,7 +90,7 @@ $__start = _now();
   echo rtrim(json_encode(first_molar_mass(2.0, 1.408943, 0.709752), 1344)), PHP_EOL;
   echo rtrim(json_encode(second_molar_mass(2.0, 1.408943, 0.709752), 1344)), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/horizontal_projectile_motion.bench
+++ b/tests/algorithms/x/PHP/physics/horizontal_projectile_motion.bench
@@ -1,1 +1,5 @@
-Fatal error: Cannot redeclare function sin() in /workspace/mochi/tests/algorithms/x/PHP/physics/horizontal_projectile_motion.php on line 31
+{
+  "duration_us": 60,
+  "memory_bytes": 1671088,
+  "name": "main"
+}

--- a/tests/algorithms/x/PHP/physics/horizontal_projectile_motion.php
+++ b/tests/algorithms/x/PHP/physics/horizontal_projectile_motion.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -25,11 +26,11 @@ $__start = _now();
   $TWO_PI = 6.283185307179586;
   $g = 9.80665;
   function _mod($x, $m) {
-  global $PI, $TWO_PI, $g, $v0, $angle;
+  global $PI, $TWO_PI, $angle, $g, $v0;
   return $x - (floatval(intval($x / $m))) * $m;
 };
   function mochi_sin($x) {
-  global $PI, $TWO_PI, $g, $v0, $angle;
+  global $PI, $TWO_PI, $angle, $g, $v0;
   $y = _mod($x + $PI, $TWO_PI) - $PI;
   $y2 = $y * $y;
   $y3 = $y2 * $y;
@@ -38,11 +39,11 @@ $__start = _now();
   return $y - $y3 / 6.0 + $y5 / 120.0 - $y7 / 5040.0;
 };
   function deg_to_rad($deg) {
-  global $PI, $TWO_PI, $g, $v0, $angle;
+  global $PI, $TWO_PI, $angle, $g, $v0;
   return $deg * $PI / 180.0;
 };
   function mochi_floor($x) {
-  global $PI, $TWO_PI, $g, $v0, $angle;
+  global $PI, $TWO_PI, $angle, $g, $v0;
   $i = intval($x);
   if ((floatval($i)) > $x) {
   $i = $i - 1;
@@ -50,7 +51,7 @@ $__start = _now();
   return floatval($i);
 };
   function pow10($n) {
-  global $PI, $TWO_PI, $g, $v0, $angle;
+  global $PI, $TWO_PI, $angle, $g, $v0;
   $result = 1.0;
   $i = 0;
   while ($i < $n) {
@@ -60,7 +61,7 @@ $__start = _now();
   return $result;
 };
   function mochi_round($x, $n) {
-  global $PI, $TWO_PI, $g, $v0, $angle;
+  global $PI, $TWO_PI, $angle, $g, $v0;
   $m = pow10($n);
   $y = mochi_floor($x * $m + 0.5);
   return $y / $m;
@@ -99,7 +100,7 @@ $__start = _now();
   echo rtrim(json_encode(max_height($v0, $angle), 1344)), PHP_EOL;
   echo rtrim(json_encode(total_time($v0, $angle), 1344)), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/hubble_parameter.bench
+++ b/tests/algorithms/x/PHP/physics/hubble_parameter.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 109,
-  "memory_bytes": 38968,
+  "duration_us": 106,
+  "memory_bytes": 1678680,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/hubble_parameter.php
+++ b/tests/algorithms/x/PHP/physics/hubble_parameter.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -75,7 +76,7 @@ $__start = _now();
 };
   main();
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/ideal_gas_law.bench
+++ b/tests/algorithms/x/PHP/physics/ideal_gas_law.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 83,
-  "memory_bytes": 35704,
+  "duration_us": 82,
+  "memory_bytes": 1676184,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/ideal_gas_law.php
+++ b/tests/algorithms/x/PHP/physics/ideal_gas_law.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -55,7 +56,7 @@ $__start = _now();
   echo rtrim(json_encode(temperature_of_gas_system(2.0, 100.0, 5.0), 1344)), PHP_EOL;
   echo rtrim(json_encode(moles_of_gas_system(100.0, 5.0, 10.0), 1344)), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/in_static_equilibrium.bench
+++ b/tests/algorithms/x/PHP/physics/in_static_equilibrium.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 116,
-  "memory_bytes": 36936,
+  "duration_us": 196,
+  "memory_bytes": 1660464,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/in_static_equilibrium.php
+++ b/tests/algorithms/x/PHP/physics/in_static_equilibrium.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -36,11 +37,11 @@ $__start = _now();
   $PI = 3.141592653589793;
   $TWO_PI = 6.283185307179586;
   function _mod($x, $m) {
-  global $PI, $TWO_PI, $forces1, $location1, $forces2, $location2, $forces3, $location3, $forces4, $location4;
+  global $PI, $TWO_PI, $forces1, $forces2, $forces3, $forces4, $location1, $location2, $location3, $location4;
   return $x - (floatval(intval($x / $m))) * $m;
 };
   function sin_approx($x) {
-  global $PI, $TWO_PI, $forces1, $location1, $forces2, $location2, $forces3, $location3, $forces4, $location4;
+  global $PI, $TWO_PI, $forces1, $forces2, $forces3, $forces4, $location1, $location2, $location3, $location4;
   $y = _mod($x + $PI, $TWO_PI) - $PI;
   $y2 = $y * $y;
   $y3 = $y2 * $y;
@@ -49,7 +50,7 @@ $__start = _now();
   return $y - $y3 / 6.0 + $y5 / 120.0 - $y7 / 5040.0;
 };
   function cos_approx($x) {
-  global $PI, $TWO_PI, $forces1, $location1, $forces2, $location2, $forces3, $location3, $forces4, $location4;
+  global $PI, $TWO_PI, $forces1, $forces2, $forces3, $forces4, $location1, $location2, $location3, $location4;
   $y = _mod($x + $PI, $TWO_PI) - $PI;
   $y2 = $y * $y;
   $y4 = $y2 * $y2;
@@ -57,12 +58,12 @@ $__start = _now();
   return 1.0 - $y2 / 2.0 + $y4 / 24.0 - $y6 / 720.0;
 };
   function polar_force($magnitude, $angle, $radian_mode) {
-  global $PI, $TWO_PI, $forces1, $location1, $forces2, $location2, $forces3, $location3, $forces4, $location4;
+  global $PI, $TWO_PI, $forces1, $forces2, $forces3, $forces4, $location1, $location2, $location3, $location4;
   $theta = ($radian_mode ? $angle : $angle * $PI / 180.0);
   return [$magnitude * cos_approx($theta), $magnitude * sin_approx($theta)];
 };
   function abs_float($x) {
-  global $PI, $TWO_PI, $forces1, $location1, $forces2, $location2, $forces3, $location3, $forces4, $location4;
+  global $PI, $TWO_PI, $forces1, $forces2, $forces3, $forces4, $location1, $location2, $location3, $location4;
   if ($x < 0.0) {
   return -$x;
 } else {
@@ -70,7 +71,7 @@ $__start = _now();
 }
 };
   function in_static_equilibrium($forces, $location, $eps) {
-  global $PI, $TWO_PI, $forces1, $location1, $forces2, $location2, $forces3, $location3, $forces4, $location4;
+  global $PI, $TWO_PI, $forces1, $forces2, $forces3, $forces4, $location1, $location2, $location3, $location4;
   $sum_moments = 0.0;
   $i = 0;
   $n = count($forces);
@@ -96,7 +97,7 @@ $__start = _now();
   $location4 = [[0.0, 0.0], [6.0, 0.0], [10.0, 0.0], [12.0, 0.0]];
   echo rtrim(_str(in_static_equilibrium($forces4, $location4, 0.1))), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/kinetic_energy.bench
+++ b/tests/algorithms/x/PHP/physics/kinetic_energy.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 75,
-  "memory_bytes": 36192,
+  "duration_us": 159,
+  "memory_bytes": 1680128,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/kinetic_energy.php
+++ b/tests/algorithms/x/PHP/physics/kinetic_energy.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -39,7 +40,7 @@ $__start = _now();
   echo rtrim(json_encode(kinetic_energy(2.0, 2.0), 1344)), PHP_EOL;
   echo rtrim(json_encode(kinetic_energy(100.0, 100.0), 1344)), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/lens_formulae.bench
+++ b/tests/algorithms/x/PHP/physics/lens_formulae.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 116,
-  "memory_bytes": 36720,
+  "duration_us": 62,
+  "memory_bytes": 1673864,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/lens_formulae.php
+++ b/tests/algorithms/x/PHP/physics/lens_formulae.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -62,7 +63,7 @@ $__start = _now();
   echo rtrim(_str(image_distance(50.0, 40.0))), PHP_EOL;
   echo rtrim(_str(image_distance(5.3, 7.9))), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/lorentz_transformation_four_vector.bench
+++ b/tests/algorithms/x/PHP/physics/lorentz_transformation_four_vector.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 198,
-  "memory_bytes": 37432,
+  "duration_us": 221,
+  "memory_bytes": 1666688,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/lorentz_transformation_four_vector.php
+++ b/tests/algorithms/x/PHP/physics/lorentz_transformation_four_vector.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -102,7 +103,7 @@ $__start = _now();
   $v = transform(29979245.0, [1.0, 2.0, 3.0, 4.0]);
   echo rtrim(_str($v)), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/malus_law.bench
+++ b/tests/algorithms/x/PHP/physics/malus_law.bench
@@ -1,1 +1,5 @@
-Fatal error: Cannot redeclare function cos() in /workspace/mochi/tests/algorithms/x/PHP/physics/malus_law.php on line 46
+{
+  "duration_us": 44,
+  "memory_bytes": 1677576,
+  "name": "main"
+}

--- a/tests/algorithms/x/PHP/physics/malus_law.php
+++ b/tests/algorithms/x/PHP/physics/malus_law.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -80,7 +81,7 @@ $__start = _now();
 };
   main();
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/mass_energy_equivalence.bench
+++ b/tests/algorithms/x/PHP/physics/mass_energy_equivalence.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 63,
-  "memory_bytes": 36416,
+  "duration_us": 145,
+  "memory_bytes": 1675552,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/mass_energy_equivalence.php
+++ b/tests/algorithms/x/PHP/physics/mass_energy_equivalence.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -59,7 +60,7 @@ $__start = _now();
   echo rtrim(_str(mass_from_energy(320.0))), PHP_EOL;
   echo rtrim(_str(mass_from_energy(0.0))), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/mirror_formulae.bench
+++ b/tests/algorithms/x/PHP/physics/mirror_formulae.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 39,
-  "memory_bytes": 39216,
+  "duration_us": 57,
+  "memory_bytes": 1670968,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/mirror_formulae.php
+++ b/tests/algorithms/x/PHP/physics/mirror_formulae.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -104,7 +105,7 @@ $__start = _now();
 };
   main();
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/n_body_simulation.bench
+++ b/tests/algorithms/x/PHP/physics/n_body_simulation.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 177,
-  "memory_bytes": 38176,
+  "duration_us": 145,
+  "memory_bytes": 1666248,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/n_body_simulation.php
+++ b/tests/algorithms/x/PHP/physics/n_body_simulation.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -103,7 +104,7 @@ $__start = _now();
 };
   main();
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/newtons_law_of_gravitation.bench
+++ b/tests/algorithms/x/PHP/physics/newtons_law_of_gravitation.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 177,
-  "memory_bytes": 37296,
+  "duration_us": 129,
+  "memory_bytes": 1668896,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/newtons_law_of_gravitation.php
+++ b/tests/algorithms/x/PHP/physics/newtons_law_of_gravitation.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -103,7 +104,7 @@ $__start = _now();
   echo rtrim($r3['kind'] . ' ' . _str($r3['value'])), PHP_EOL;
   echo rtrim($r4['kind'] . ' ' . _str($r4['value'])), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/newtons_second_law_of_motion.bench
+++ b/tests/algorithms/x/PHP/physics/newtons_second_law_of_motion.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 55,
-  "memory_bytes": 40400,
+  "duration_us": 68,
+  "memory_bytes": 1682624,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/newtons_second_law_of_motion.php
+++ b/tests/algorithms/x/PHP/physics/newtons_second_law_of_motion.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -45,7 +46,7 @@ $__start = _now();
   $force = newtons_second_law_of_motion($mass, $acceleration);
   echo rtrim('The force is ' . _str($force) . ' N'), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/orbital_transfer_work.bench
+++ b/tests/algorithms/x/PHP/physics/orbital_transfer_work.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 142,
-  "memory_bytes": 41320,
+  "duration_us": 203,
+  "memory_bytes": 1663368,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/orbital_transfer_work.php
+++ b/tests/algorithms/x/PHP/physics/orbital_transfer_work.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -40,7 +41,7 @@ function _intdiv($a, $b) {
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
         return intval(bcdiv($sa, $sb, 0));
     }
-    return intdiv($a, $b);
+    return intdiv(intval($a), intval($b));
 }
 function _panic($msg) {
     fwrite(STDERR, strval($msg));
@@ -126,23 +127,23 @@ $__start = _now();
   return format_scientific_3($work);
 };
   function test_orbital_transfer_work() {
-  if (orbital_transfer_work(5972000000000000419220214.0, 1000.0, 6371000.0, 7000000.0) != '2.811e+09') {
+  if (orbital_transfer_work(5972000000000000419220214.098459109663963, 1000.0, 6371000.000000000440536, 7000000.0) != '2.811e+09') {
   _panic('case1 failed');
 }
-  if (orbital_transfer_work(5972000000000000419220214.0, 500.0, 7000000.0, 6371000.0) != '-1.405e+09') {
+  if (orbital_transfer_work(5972000000000000419220214.098459109663963, 500.0, 7000000.0, 6371000.000000000440536) != '-1.405e+09') {
   _panic('case2 failed');
 }
-  if (orbital_transfer_work(1989000000000000101252339845814.0, 1000.0, 150000000000.0, 228000000000.0) != '1.514e+11') {
+  if (orbital_transfer_work(1989000000000000101252339845814.27648663520813, 1000.0, 150000000000.0, 227999999999.999980460074767) != '1.514e+11') {
   _panic('case3 failed');
 }
 };
   function main() {
   test_orbital_transfer_work();
-  echo rtrim(orbital_transfer_work(5972000000000000419220214.0, 1000.0, 6371000.0, 7000000.0)), PHP_EOL;
+  echo rtrim(orbital_transfer_work(5972000000000000419220214.098459109663963, 1000.0, 6371000.000000000440536, 7000000.0)), PHP_EOL;
 };
   main();
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/period_of_pendulum.bench
+++ b/tests/algorithms/x/PHP/physics/period_of_pendulum.bench
@@ -1,1 +1,5 @@
-Fatal error: Cannot redeclare function sqrt() in /workspace/mochi/tests/algorithms/x/PHP/physics/period_of_pendulum.php on line 42
+{
+  "duration_us": 248,
+  "memory_bytes": 1675272,
+  "name": "main"
+}

--- a/tests/algorithms/x/PHP/physics/period_of_pendulum.php
+++ b/tests/algorithms/x/PHP/physics/period_of_pendulum.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -40,7 +41,7 @@ $__start = _now();
   $PI = 3.141592653589793;
   $G = 9.80665;
   function mochi_sqrt($x) {
-  global $PI, $G;
+  global $G, $PI;
   if ($x <= 0.0) {
   return 0.0;
 }
@@ -53,7 +54,7 @@ $__start = _now();
   return $guess;
 };
   function period_of_pendulum($length) {
-  global $PI, $G;
+  global $G, $PI;
   if ($length < 0.0) {
   _panic('The length should be non-negative');
 }
@@ -64,7 +65,7 @@ $__start = _now();
   echo rtrim(_str(period_of_pendulum(5.63))), PHP_EOL;
   echo rtrim(_str(period_of_pendulum(0.0))), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/photoelectric_effect.bench
+++ b/tests/algorithms/x/PHP/physics/photoelectric_effect.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 58,
-  "memory_bytes": 36120,
+  "duration_us": 52,
+  "memory_bytes": 1674712,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/photoelectric_effect.php
+++ b/tests/algorithms/x/PHP/physics/photoelectric_effect.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -38,7 +39,7 @@ function _panic($msg) {
 $__start_mem = memory_get_usage();
 $__start = _now();
   function pow10($exp) {
-  global $PLANCK_CONSTANT_JS, $PLANCK_CONSTANT_EVS;
+  global $PLANCK_CONSTANT_EVS, $PLANCK_CONSTANT_JS;
   $result = 1.0;
   $i = 0;
   while ($i < $exp) {
@@ -50,7 +51,7 @@ $__start = _now();
   $PLANCK_CONSTANT_JS = 6.6261 / pow10(34);
   $PLANCK_CONSTANT_EVS = 4.1357 / pow10(15);
   function maximum_kinetic_energy($frequency, $work_function, $in_ev) {
-  global $PLANCK_CONSTANT_JS, $PLANCK_CONSTANT_EVS;
+  global $PLANCK_CONSTANT_EVS, $PLANCK_CONSTANT_JS;
   if ($frequency < 0.0) {
   _panic('Frequency can\'t be negative.');
 }
@@ -64,7 +65,7 @@ $__start = _now();
   echo rtrim(_str(maximum_kinetic_energy(1000000.0, 2.0, true))), PHP_EOL;
   echo rtrim(_str(maximum_kinetic_energy(10000000000000000.0, 2.0, true))), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/potential_energy.bench
+++ b/tests/algorithms/x/PHP/physics/potential_energy.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 118,
-  "memory_bytes": 39672,
+  "duration_us": 124,
+  "memory_bytes": 1684488,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/potential_energy.php
+++ b/tests/algorithms/x/PHP/physics/potential_energy.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -36,7 +37,7 @@ $__start = _now();
   echo rtrim(json_encode(potential_energy(10.0, 5.0), 1344)), PHP_EOL;
   echo rtrim(json_encode(potential_energy(2.0, 8.0), 1344)), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/rainfall_intensity.bench
+++ b/tests/algorithms/x/PHP/physics/rainfall_intensity.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 68,
-  "memory_bytes": 36784,
+  "duration_us": 99,
+  "memory_bytes": 1666976,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/rainfall_intensity.php
+++ b/tests/algorithms/x/PHP/physics/rainfall_intensity.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -120,7 +121,7 @@ $__start = _now();
   $r3 = rainfall_intensity(1000.0, 0.2, 11.6, 0.81, 5.0, 60.0);
   echo rtrim(_str($r3)), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/reynolds_number.bench
+++ b/tests/algorithms/x/PHP/physics/reynolds_number.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 40,
-  "memory_bytes": 39600,
+  "duration_us": 100,
+  "memory_bytes": 1679464,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/reynolds_number.php
+++ b/tests/algorithms/x/PHP/physics/reynolds_number.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -38,7 +39,7 @@ $__start = _now();
   echo rtrim(json_encode(reynolds_number(450.0, 3.86, 0.078, 0.23), 1344)), PHP_EOL;
   echo rtrim(json_encode(reynolds_number(234.0, -4.5, 0.3, 0.44), 1344)), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/rms_speed_of_molecule.bench
+++ b/tests/algorithms/x/PHP/physics/rms_speed_of_molecule.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 41,
-  "memory_bytes": 40440,
+  "duration_us": 67,
+  "memory_bytes": 1678232,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/rms_speed_of_molecule.php
+++ b/tests/algorithms/x/PHP/physics/rms_speed_of_molecule.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -69,7 +70,7 @@ $__start = _now();
   $vrms = rms_speed_of_molecule(300.0, 28.0);
   echo rtrim('Vrms of Nitrogen gas at 300 K is ' . _str($vrms) . ' m/s'), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/shear_stress.bench
+++ b/tests/algorithms/x/PHP/physics/shear_stress.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 150,
-  "memory_bytes": 40616,
+  "duration_us": 86,
+  "memory_bytes": 1676496,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/shear_stress.php
+++ b/tests/algorithms/x/PHP/physics/shear_stress.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -86,7 +87,7 @@ $__start = _now();
   $r3 = shear_stress(1000.0, 0.0, 1200.0);
   echo rtrim(str_result($r3)), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/speed_of_sound.bench
+++ b/tests/algorithms/x/PHP/physics/speed_of_sound.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 33,
-  "memory_bytes": 39840,
+  "duration_us": 221,
+  "memory_bytes": 1679160,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/speed_of_sound.php
+++ b/tests/algorithms/x/PHP/physics/speed_of_sound.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -61,7 +62,7 @@ $__start = _now();
   echo rtrim(_str(speed_of_sound_in_a_fluid(998.0, 2150000000.0))), PHP_EOL;
   echo rtrim(_str(speed_of_sound_in_a_fluid(13600.0, 28500000000.0))), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/speeds_of_gas_molecules.bench
+++ b/tests/algorithms/x/PHP/physics/speeds_of_gas_molecules.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 45,
-  "memory_bytes": 36544,
+  "duration_us": 106,
+  "memory_bytes": 1672688,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/speeds_of_gas_molecules.php
+++ b/tests/algorithms/x/PHP/physics/speeds_of_gas_molecules.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -81,7 +82,7 @@ $__start = _now();
   echo rtrim(_str(mps_speed_of_molecule(273.0, 0.028))), PHP_EOL;
   echo rtrim(_str(mps_speed_of_molecule(300.0, 0.032))), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/physics/terminal_velocity.bench
+++ b/tests/algorithms/x/PHP/physics/terminal_velocity.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 41,
-  "memory_bytes": 40136,
+  "duration_us": 105,
+  "memory_bytes": 1674280,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/physics/terminal_velocity.php
+++ b/tests/algorithms/x/PHP/physics/terminal_velocity.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -65,7 +66,7 @@ $__start = _now();
   echo rtrim(_str(terminal_velocity(2.0, 100.0, 0.45, 0.23))), PHP_EOL;
   echo rtrim(_str(terminal_velocity(5.0, 50.0, 0.2, 0.5))), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/project_euler/problem_001/sol1.bench
+++ b/tests/algorithms/x/PHP/project_euler/problem_001/sol1.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 56,
-  "memory_bytes": 36096,
+  "duration_us": 230,
+  "memory_bytes": 1677104,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/project_euler/problem_001/sol1.php
+++ b/tests/algorithms/x/PHP/project_euler/problem_001/sol1.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -51,7 +52,7 @@ $__start = _now();
   echo rtrim(_str(solution(-7))), PHP_EOL;
   echo rtrim(_str(solution(1000))), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/project_euler/problem_001/sol2.bench
+++ b/tests/algorithms/x/PHP/project_euler/problem_001/sol2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 59,
-  "memory_bytes": 41152,
+  "duration_us": 67,
+  "memory_bytes": 1677112,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/project_euler/problem_001/sol2.php
+++ b/tests/algorithms/x/PHP/project_euler/problem_001/sol2.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -40,7 +41,7 @@ function _intdiv($a, $b) {
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
         return intval(bcdiv($sa, $sb, 0));
     }
-    return intdiv($a, $b);
+    return intdiv(intval($a), intval($b));
 }
 $__start_mem = memory_get_usage();
 $__start = _now();
@@ -56,7 +57,7 @@ $__start = _now();
 };
   echo rtrim('solution() = ' . _str(sum_of_multiples(1000))), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/project_euler/problem_001/sol3.bench
+++ b/tests/algorithms/x/PHP/project_euler/problem_001/sol3.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 63,
-  "memory_bytes": 40184,
+  "duration_us": 86,
+  "memory_bytes": 1680528,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/project_euler/problem_001/sol3.php
+++ b/tests/algorithms/x/PHP/project_euler/problem_001/sol3.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -77,7 +78,7 @@ $__start = _now();
 };
   echo rtrim(_str(solution(1000))), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/project_euler/problem_001/sol4.bench
+++ b/tests/algorithms/x/PHP/project_euler/problem_001/sol4.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 2715,
-  "memory_bytes": 45344,
+  "duration_us": 4047,
+  "memory_bytes": 1673872,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/project_euler/problem_001/sol4.php
+++ b/tests/algorithms/x/PHP/project_euler/problem_001/sol4.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -41,7 +42,7 @@ function _panic($msg) {
 }
 $__start_mem = memory_get_usage();
 $__start = _now();
-  function contains($xs, $value) {
+  function mochi_contains($xs, $value) {
   $i = 0;
   while ($i < count($xs)) {
   if ($xs[$i] == $value) {
@@ -78,7 +79,7 @@ $__start = _now();
   $i = 0;
   while ($i < count($zmulti)) {
   $v = $zmulti[$i];
-  if (!contains($collection, $v)) {
+  if (!mochi_contains($collection, $v)) {
   $collection = _append($collection, $v);
 }
   $i = $i + 1;
@@ -86,7 +87,7 @@ $__start = _now();
   $i = 0;
   while ($i < count($xmulti)) {
   $v = $xmulti[$i];
-  if (!contains($collection, $v)) {
+  if (!mochi_contains($collection, $v)) {
   $collection = _append($collection, $v);
 }
   $i = $i + 1;
@@ -119,7 +120,7 @@ $__start = _now();
 };
   main();
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/project_euler/problem_001/sol5.bench
+++ b/tests/algorithms/x/PHP/project_euler/problem_001/sol5.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 41,
-  "memory_bytes": 39808,
+  "duration_us": 64,
+  "memory_bytes": 1681488,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/project_euler/problem_001/sol5.php
+++ b/tests/algorithms/x/PHP/project_euler/problem_001/sol5.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -49,7 +50,7 @@ $__start = _now();
   echo rtrim(_str(solution(10))), PHP_EOL;
   echo rtrim(_str(solution(600))), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/project_euler/problem_001/sol6.bench
+++ b/tests/algorithms/x/PHP/project_euler/problem_001/sol6.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 51,
-  "memory_bytes": 36736,
+  "duration_us": 107,
+  "memory_bytes": 1682152,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/project_euler/problem_001/sol6.php
+++ b/tests/algorithms/x/PHP/project_euler/problem_001/sol6.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -53,7 +54,7 @@ $__start = _now();
 };
   main();
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/project_euler/problem_001/sol7.bench
+++ b/tests/algorithms/x/PHP/project_euler/problem_001/sol7.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 64,
-  "memory_bytes": 40152,
+  "duration_us": 82,
+  "memory_bytes": 1682608,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/project_euler/problem_001/sol7.php
+++ b/tests/algorithms/x/PHP/project_euler/problem_001/sol7.php
@@ -1,5 +1,21 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,7 +32,9 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-function solution($n) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function solution($n) {
   $result = 0;
   $i = 0;
   while ($i < $n) {
@@ -26,5 +44,13 @@ function solution($n) {
   $i = $i + 1;
 };
   return $result;
-}
-echo rtrim(_str(solution(1000))), PHP_EOL;
+};
+  echo rtrim(_str(solution(1000))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/transpiler/x/php/ALGORITHMS.md
+++ b/transpiler/x/php/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated PHP code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/PHP`.
-Last updated: 2025-08-17 20:47 GMT+7
+Last updated: 2025-08-19 16:47 GMT+7
 
 ## Algorithms Golden Test Checklist (993/1077)
 | Index | Name | Status | Duration | Memory |
@@ -758,56 +758,56 @@ Last updated: 2025-08-17 20:47 GMT+7
 | 749 | other/linear_congruential_generator | ✓ | 78µs | 38.9 KB |
 | 750 | other/lru_cache | ✓ | 104µs | 75.3 KB |
 | 751 | other/magicdiamondpattern | ✓ | 56µs | 35.6 KB |
-| 752 | other/majority_vote_algorithm | ✓ | 150µs | 36.9 KB |
-| 753 | other/maximum_subsequence | ✓ | 115µs | 38.4 KB |
-| 754 | other/nested_brackets | ✓ | 211µs | 38.0 KB |
-| 755 | other/number_container_system | ✓ | 102µs | 36.5 KB |
-| 756 | other/quine | ✓ | 52µs | 35.2 KB |
-| 757 | other/scoring_algorithm | ✓ | 165µs | 39.2 KB |
-| 758 | other/sdes | ✓ | 236µs | 70.7 KB |
-| 759 | other/tower_of_hanoi | ✓ | 51µs | 35.5 KB |
-| 760 | other/word_search | ✓ | 343µs | 39.0 KB |
-| 761 | physics/altitude_pressure | ✓ | 78µs | 39.3 KB |
-| 762 | physics/archimedes_principle_of_buoyant_force | ✓ | 1µs | 35.6 KB |
+| 752 | other/majority_vote_algorithm | ✓ | 208µs | 1.6 MB |
+| 753 | other/maximum_subsequence | ✓ | 320µs | 1.6 MB |
+| 754 | other/nested_brackets | ✓ | 174µs | 1.6 MB |
+| 755 | other/number_container_system | ✓ | 137µs | 1.6 MB |
+| 756 | other/quine | ✓ | 53µs | 1.6 MB |
+| 757 | other/scoring_algorithm | ✓ | 278µs | 1.6 MB |
+| 758 | other/sdes | ✓ | 189µs | 1.6 MB |
+| 759 | other/tower_of_hanoi | ✓ | 64µs | 1.6 MB |
+| 760 | other/word_search | ✓ | 242µs | 1.6 MB |
+| 761 | physics/altitude_pressure | ✓ | 138µs | 1.6 MB |
+| 762 | physics/archimedes_principle_of_buoyant_force | ✓ | 1µs | 1.6 MB |
 | 763 | physics/basic_orbital_capture | error |  |  |
-| 764 | physics/casimir_effect | ✓ | 338µs | 37.7 KB |
-| 765 | physics/center_of_mass | ✓ | 104µs | 39.5 KB |
-| 766 | physics/centripetal_force | ✓ | 74µs | 39.1 KB |
-| 767 | physics/coulombs_law | ✓ | 14.197ms | 36.1 KB |
-| 768 | physics/doppler_frequency | ✓ | 59µs | 38.6 KB |
-| 769 | physics/escape_velocity | ✓ | 95µs | 35.0 KB |
-| 770 | physics/grahams_law | ✓ | 98µs | 36.7 KB |
-| 771 | physics/horizontal_projectile_motion | ✓ |  |  |
-| 772 | physics/hubble_parameter | ✓ | 109µs | 38.1 KB |
-| 773 | physics/ideal_gas_law | ✓ | 83µs | 34.9 KB |
-| 774 | physics/in_static_equilibrium | ✓ | 116µs | 36.1 KB |
-| 775 | physics/kinetic_energy | ✓ | 75µs | 35.3 KB |
-| 776 | physics/lens_formulae | ✓ | 116µs | 35.9 KB |
-| 777 | physics/lorentz_transformation_four_vector | ✓ | 198µs | 36.6 KB |
-| 778 | physics/malus_law | ✓ |  |  |
-| 779 | physics/mass_energy_equivalence | ✓ | 63µs | 35.6 KB |
-| 780 | physics/mirror_formulae | ✓ | 39µs | 38.3 KB |
-| 781 | physics/n_body_simulation | ✓ | 177µs | 37.3 KB |
-| 782 | physics/newtons_law_of_gravitation | ✓ | 177µs | 36.4 KB |
-| 783 | physics/newtons_second_law_of_motion | ✓ | 55µs | 39.5 KB |
-| 784 | physics/orbital_transfer_work | ✓ | 142µs | 40.4 KB |
-| 785 | physics/period_of_pendulum | ✓ |  |  |
-| 786 | physics/photoelectric_effect | ✓ | 58µs | 35.3 KB |
-| 787 | physics/potential_energy | ✓ | 118µs | 38.7 KB |
-| 788 | physics/rainfall_intensity | ✓ | 68µs | 35.9 KB |
-| 789 | physics/reynolds_number | ✓ | 40µs | 38.7 KB |
-| 790 | physics/rms_speed_of_molecule | ✓ | 41µs | 39.5 KB |
-| 791 | physics/shear_stress | ✓ | 150µs | 39.7 KB |
-| 792 | physics/speed_of_sound | ✓ | 33µs | 38.9 KB |
-| 793 | physics/speeds_of_gas_molecules | ✓ | 45µs | 35.7 KB |
-| 794 | physics/terminal_velocity | ✓ | 41µs | 39.2 KB |
-| 795 | project_euler/problem_001/sol1 | ✓ | 56µs | 35.2 KB |
-| 796 | project_euler/problem_001/sol2 | ✓ | 59µs | 40.2 KB |
-| 797 | project_euler/problem_001/sol3 | ✓ | 63µs | 39.2 KB |
-| 798 | project_euler/problem_001/sol4 | ✓ | 2.715ms | 44.3 KB |
-| 799 | project_euler/problem_001/sol5 | ✓ | 41µs | 38.9 KB |
-| 800 | project_euler/problem_001/sol6 | ✓ | 51µs | 35.9 KB |
-| 801 | project_euler/problem_001/sol7 | ✓ | 64µs | 39.2 KB |
+| 764 | physics/casimir_effect | ✓ | 171µs | 1.6 MB |
+| 765 | physics/center_of_mass | ✓ | 114µs | 1.6 MB |
+| 766 | physics/centripetal_force | ✓ | 62µs | 1.6 MB |
+| 767 | physics/coulombs_law | ✓ | 153µs | 1.6 MB |
+| 768 | physics/doppler_frequency | ✓ | 59µs | 1.6 MB |
+| 769 | physics/escape_velocity | ✓ | 69µs | 1.6 MB |
+| 770 | physics/grahams_law | ✓ | 110µs | 1.6 MB |
+| 771 | physics/horizontal_projectile_motion | ✓ | 60µs | 1.6 MB |
+| 772 | physics/hubble_parameter | ✓ | 106µs | 1.6 MB |
+| 773 | physics/ideal_gas_law | ✓ | 82µs | 1.6 MB |
+| 774 | physics/in_static_equilibrium | ✓ | 196µs | 1.6 MB |
+| 775 | physics/kinetic_energy | ✓ | 159µs | 1.6 MB |
+| 776 | physics/lens_formulae | ✓ | 62µs | 1.6 MB |
+| 777 | physics/lorentz_transformation_four_vector | ✓ | 221µs | 1.6 MB |
+| 778 | physics/malus_law | ✓ | 44µs | 1.6 MB |
+| 779 | physics/mass_energy_equivalence | ✓ | 145µs | 1.6 MB |
+| 780 | physics/mirror_formulae | ✓ | 57µs | 1.6 MB |
+| 781 | physics/n_body_simulation | ✓ | 145µs | 1.6 MB |
+| 782 | physics/newtons_law_of_gravitation | ✓ | 129µs | 1.6 MB |
+| 783 | physics/newtons_second_law_of_motion | ✓ | 68µs | 1.6 MB |
+| 784 | physics/orbital_transfer_work | ✓ | 203µs | 1.6 MB |
+| 785 | physics/period_of_pendulum | ✓ | 248µs | 1.6 MB |
+| 786 | physics/photoelectric_effect | ✓ | 52µs | 1.6 MB |
+| 787 | physics/potential_energy | ✓ | 124µs | 1.6 MB |
+| 788 | physics/rainfall_intensity | ✓ | 99µs | 1.6 MB |
+| 789 | physics/reynolds_number | ✓ | 100µs | 1.6 MB |
+| 790 | physics/rms_speed_of_molecule | ✓ | 67µs | 1.6 MB |
+| 791 | physics/shear_stress | ✓ | 86µs | 1.6 MB |
+| 792 | physics/speed_of_sound | ✓ | 221µs | 1.6 MB |
+| 793 | physics/speeds_of_gas_molecules | ✓ | 106µs | 1.6 MB |
+| 794 | physics/terminal_velocity | ✓ | 105µs | 1.6 MB |
+| 795 | project_euler/problem_001/sol1 | ✓ | 230µs | 1.6 MB |
+| 796 | project_euler/problem_001/sol2 | ✓ | 67µs | 1.6 MB |
+| 797 | project_euler/problem_001/sol3 | ✓ | 86µs | 1.6 MB |
+| 798 | project_euler/problem_001/sol4 | ✓ | 4.047ms | 1.6 MB |
+| 799 | project_euler/problem_001/sol5 | ✓ | 64µs | 1.6 MB |
+| 800 | project_euler/problem_001/sol6 | ✓ | 107µs | 1.6 MB |
+| 801 | project_euler/problem_001/sol7 | ✓ | 82µs | 1.6 MB |
 | 802 | project_euler/problem_002/sol1 | ✓ | 43µs | 39.5 KB |
 | 803 | project_euler/problem_002/sol2 | ✓ | 36µs | 39.5 KB |
 | 804 | project_euler/problem_002/sol3 | ✓ | 142µs | 39.5 KB |

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-Last updated: 2025-08-17 20:43 +0700
+Last updated: 2025-08-19 09:22 +0700
 
 ## VM Golden Test Checklist (103/105)
 - [x] append_builtin

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,4 +1,4 @@
-## Progress (2025-08-17 20:43 +0700)
+## Progress (2025-08-19 09:22 +0700)
 - Generated PHP for 103/105 programs
 - Updated README checklist and outputs
 - Enhanced printing to match golden format


### PR DESCRIPTION
## Summary
- regenerate PHP transpiled code and benchmarks for algorithms 752-801
- update algorithms progress report

## Testing
- `MOCHI_ALG_INDEX=752 MOCHI_BENCHMARK=1 go test -tags=slow ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden`


------
https://chatgpt.com/codex/tasks/task_e_68a4462e88308320ae1e6aef8fe885d2