### PR TITLE
lua transpiler: ignore metadata in len helper

### DIFF
--- a/transpiler/x/lua/ALGORITHMS.md
+++ b/transpiler/x/lua/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Lua code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Lua`.
-Last updated: 2025-08-19 16:46 GMT+7
+Last updated: 2025-08-22 13:11 GMT+7
 
 ## Algorithms Golden Test Checklist (1049/1077)
 | Index | Name | Status | Duration | Memory |

--- a/transpiler/x/lua/README.md
+++ b/transpiler/x/lua/README.md
@@ -4,7 +4,7 @@ Generated Lua code for programs in `tests/vm/valid`. Each program has a `.lua` f
 
 Transpiled programs: 104/105
 
-Last updated: 2025-08-16 11:48 GMT+7
+Last updated: 2025-08-22 13:05 GMT+7
 
 Checklist:
 

--- a/transpiler/x/lua/TASKS.md
+++ b/transpiler/x/lua/TASKS.md
@@ -1,3 +1,415 @@
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-22 13:05 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
 ## Progress (2025-08-16 11:48 GMT+7)
 - 104/105 VM tests passing
 - Added float literal support

--- a/transpiler/x/lua/transpiler.go
+++ b/transpiler/x/lua/transpiler.go
@@ -82,7 +82,11 @@ local function _len(v)
     return #v.items
   elseif type(v) == 'table' and (v[1] == nil or v[0] ~= nil) then
     local c = 0
-    for _ in pairs(v) do c = c + 1 end
+    for k in pairs(v) do
+      if k ~= '__name' and k ~= '__order' then
+        c = c + 1
+      end
+    end
     return c
   elseif type(v) == 'string' then
     local l = utf8.len(v)


### PR DESCRIPTION
## Summary
- ignore `__name` and `__order` keys in Lua `_len` helper so struct metadata doesn't affect length
- refresh Lua algorithms progress docs

## Testing
- `MOCHI_ALG_INDEX=732 go test -run TestLuaTranspiler_Algorithms_Golden -tags=slow -count=1 -update-algorithms-lua`
- `for i in $(seq 732 781); do echo "Running $i"; MOCHI_ALG_INDEX=$i go test -run TestLuaTranspiler_Algorithms_Golden -tags=slow -count=1 >/tmp/log$i && tail -n 2 /tmp/log$i; done`


------
https://chatgpt.com/codex/tasks/task_e_68a808a3fefc832099db6c2ee8a32e81