### PR TITLE
kt: add neural network benchmark and Math.floorMod mapping

### DIFF
--- a/tests/algorithms/x/Kotlin/neural_network/back_propagation_neural_network.bench
+++ b/tests/algorithms/x/Kotlin/neural_network/back_propagation_neural_network.bench
@@ -1,2 +1,2 @@
 0.0
-{"duration_us":919515, "memory_bytes":850752, "name":"main"}
+{"duration_us":720401, "memory_bytes":843696, "name":"main"}

--- a/tests/algorithms/x/Kotlin/neural_network/back_propagation_neural_network.kt
+++ b/tests/algorithms/x/Kotlin/neural_network/back_propagation_neural_network.kt
@@ -32,7 +32,7 @@ data class Layer(var units: Int = 0, var weight: MutableList<MutableList<Double>
 data class Data(var x: MutableList<MutableList<Double>> = mutableListOf<MutableList<Double>>(), var y: MutableList<MutableList<Double>> = mutableListOf<MutableList<Double>>())
 var seed: Int = (1).toInt()
 fun rand(): Int {
-    seed = (((Math.floorMod((((seed * 1103515245) + 12345).toLong()), (2147483648L).toInt())).toInt())).toInt()
+    seed = ((Math.floorMod((((seed * 1103515245) + 12345).toLong()), 2147483648L)).toInt()).toInt()
     return seed
 }
 
@@ -51,11 +51,11 @@ fun expApprox(x: Double): Double {
     var sum: Double = 1.0
     var n: Int = (1).toInt()
     while (n < 30) {
-        term = (term * y) / ((n.toDouble()))
+        term = (term * y) / (n.toDouble())
         sum = sum + term
         n = n + 1
     }
-    if ((is_neg as Boolean)) {
+    if (is_neg as Boolean) {
         return 1.0 / sum
     }
     return sum
@@ -113,7 +113,7 @@ fun matvec(mat: MutableList<MutableList<Double>>, vec: MutableList<Double>): Mut
         var s: Double = 0.0
         var j: Int = (0).toInt()
         while (j < vec.size) {
-            s = s + ((((mat[i]!!) as MutableList<Double>))[j]!! * vec[j]!!)
+            s = s + (((mat[i]!!) as MutableList<Double>)[j]!! * vec[j]!!)
             j = j + 1
         }
         res = run { val _tmp = res.toMutableList(); _tmp.add(s); _tmp }
@@ -130,7 +130,7 @@ fun matTvec(mat: MutableList<MutableList<Double>>, vec: MutableList<Double>): Mu
         var s: Double = 0.0
         var i: Int = (0).toInt()
         while (i < mat.size) {
-            s = s + ((((mat[i]!!) as MutableList<Double>))[j]!! * vec[i]!!)
+            s = s + (((mat[i]!!) as MutableList<Double>)[j]!! * vec[i]!!)
             i = i + 1
         }
         res = run { val _tmp = res.toMutableList(); _tmp.add(s); _tmp }
@@ -192,7 +192,7 @@ fun mat_scalar_mul(mat: MutableList<MutableList<Double>>, s: Double): MutableLis
         var row: MutableList<Double> = mutableListOf<Double>()
         var j: Int = (0).toInt()
         while (j < (mat[i]!!).size) {
-            row = run { val _tmp = row.toMutableList(); _tmp.add((((mat[i]!!) as MutableList<Double>))[j]!! * s); _tmp }
+            row = run { val _tmp = row.toMutableList(); _tmp.add(((mat[i]!!) as MutableList<Double>)[j]!! * s); _tmp }
             j = j + 1
         }
         res = run { val _tmp = res.toMutableList(); _tmp.add(row); _tmp }
@@ -208,7 +208,7 @@ fun mat_sub(a: MutableList<MutableList<Double>>, b: MutableList<MutableList<Doub
         var row: MutableList<Double> = mutableListOf<Double>()
         var j: Int = (0).toInt()
         while (j < (a[i]!!).size) {
-            row = run { val _tmp = row.toMutableList(); _tmp.add((((a[i]!!) as MutableList<Double>))[j]!! - (((b[i]!!) as MutableList<Double>))[j]!!); _tmp }
+            row = run { val _tmp = row.toMutableList(); _tmp.add(((a[i]!!) as MutableList<Double>)[j]!! - ((b[i]!!) as MutableList<Double>)[j]!!); _tmp }
             j = j + 1
         }
         res = run { val _tmp = res.toMutableList(); _tmp.add(row); _tmp }

--- a/transpiler/x/kt/ALGORITHMS.md
+++ b/transpiler/x/kt/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Kotlin code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Kotlin`.
-Last updated: 2025-08-17 21:04 GMT+7
+Last updated: 2025-08-22 13:11 GMT+7
 
 ## Algorithms Golden Test Checklist (676/1077)
 | Index | Name | Status | Duration | Memory |
@@ -738,7 +738,7 @@ Last updated: 2025-08-17 21:04 GMT+7
 | 729 | neural_network/activation_functions/softplus | ✓ | 21.05ms | 112.81KiB |
 | 730 | neural_network/activation_functions/squareplus | ✓ | 27.83ms | 112.77KiB |
 | 731 | neural_network/activation_functions/swish | ✓ | 37.20ms | 112.73KiB |
-| 732 | neural_network/back_propagation_neural_network | ✓ | 919.51ms | 830.81KiB |
+| 732 | neural_network/back_propagation_neural_network | ✓ | 720.40ms | 823.92KiB |
 | 733 | neural_network/convolution_neural_network | ✓ | 79.69ms | 106.20KiB |
 | 734 | neural_network/input_data | ✓ | 21.02ms | 121.62KiB |
 | 735 | neural_network/simple_neural_network | ✓ | 161.52ms | 124.12KiB |

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -311,6 +311,7 @@ return x / pow2(n)
 		"_sha256":         "MutableList<Int>",
 		"indexOf":         "Int",
 		"split":           "MutableList<String>",
+		"Math.floorMod":   "Long",
 	}
 }
 
@@ -5904,44 +5905,44 @@ func convertPostfix(env *types.Env, p *parser.PostfixExpr) (Expr, error) {
 }
 
 func convertPrimary(env *types.Env, p *parser.Primary) (Expr, error) {
-        switch {
-        case p.Call != nil:
-               if p.Call.Func == "ln" || p.Call.Func == "exp" {
-                       args := make([]Expr, len(p.Call.Args))
-                       for i, a := range p.Call.Args {
-                               ex, err := convertExpr(env, a)
-                               if err != nil {
-                                       return nil, err
-                               }
-                               args[i] = ex
-                       }
-                       if p.Call.Func == "ln" {
-                               return &CallExpr{Func: "kotlin.math.ln", Args: args}, nil
-                       }
-                       return &CallExpr{Func: "kotlin.math.exp", Args: args}, nil
-               }
-               if localFuncs[p.Call.Func] {
-                       args := make([]Expr, len(p.Call.Args))
-                       var paramTypes []types.Type
-                       if t, err := env.GetVar(p.Call.Func); err == nil {
-                               if ft, ok := t.(types.FuncType); ok {
-                                       paramTypes = ft.Params
-                               }
-                       }
-                       for i, a := range p.Call.Args {
-                               ex, err := convertExpr(env, a)
-                               if err != nil {
-                                       return nil, err
-                               }
-                               if ll, ok := ex.(*ListLit); ok && len(ll.Elems) == 0 && i < len(paramTypes) {
-                                       pt := kotlinTypeFromType(paramTypes[i])
-                                       if strings.HasPrefix(pt, "MutableList<") {
-                                               elem := strings.TrimSuffix(strings.TrimPrefix(pt, "MutableList<"), ">")
-                                               ex = &TypedListLit{ElemType: elem, Elems: nil}
-                                       } else if strings.HasPrefix(pt, "MutableMap<") {
-                                               part := strings.TrimSuffix(strings.TrimPrefix(pt, "MutableMap<"), ">")
-                                               if idx := strings.Index(part, ","); idx >= 0 {
-                                                       k := strings.TrimSpace(part[:idx])
+	switch {
+	case p.Call != nil:
+		if p.Call.Func == "ln" || p.Call.Func == "exp" {
+			args := make([]Expr, len(p.Call.Args))
+			for i, a := range p.Call.Args {
+				ex, err := convertExpr(env, a)
+				if err != nil {
+					return nil, err
+				}
+				args[i] = ex
+			}
+			if p.Call.Func == "ln" {
+				return &CallExpr{Func: "kotlin.math.ln", Args: args}, nil
+			}
+			return &CallExpr{Func: "kotlin.math.exp", Args: args}, nil
+		}
+		if localFuncs[p.Call.Func] {
+			args := make([]Expr, len(p.Call.Args))
+			var paramTypes []types.Type
+			if t, err := env.GetVar(p.Call.Func); err == nil {
+				if ft, ok := t.(types.FuncType); ok {
+					paramTypes = ft.Params
+				}
+			}
+			for i, a := range p.Call.Args {
+				ex, err := convertExpr(env, a)
+				if err != nil {
+					return nil, err
+				}
+				if ll, ok := ex.(*ListLit); ok && len(ll.Elems) == 0 && i < len(paramTypes) {
+					pt := kotlinTypeFromType(paramTypes[i])
+					if strings.HasPrefix(pt, "MutableList<") {
+						elem := strings.TrimSuffix(strings.TrimPrefix(pt, "MutableList<"), ">")
+						ex = &TypedListLit{ElemType: elem, Elems: nil}
+					} else if strings.HasPrefix(pt, "MutableMap<") {
+						part := strings.TrimSuffix(strings.TrimPrefix(pt, "MutableMap<"), ">")
+						if idx := strings.Index(part, ","); idx >= 0 {
+							k := strings.TrimSpace(part[:idx])
 							v := strings.TrimSpace(part[idx+1:])
 							ex = &CastExpr{Value: &MapLit{Items: nil}, Type: "MutableMap<" + k + ", " + v + ">"}
 						}


### PR DESCRIPTION
## Summary
- add Math.floorMod return type mapping to Kotlin transpiler
- generate Kotlin code and benchmark output for back_propagation_neural_network algorithm
- refresh ALGORITHMS.md with latest benchmark stats

## Testing
- `MOCHI_BENCHMARK=1 MOCHI_ALG_INDEX=732 go test ./transpiler/x/kt -tags slow -run TestKTTranspiler_Algorithms_Golden -count=1 -update-algorithms-kt`


------
https://chatgpt.com/codex/tasks/task_e_68a808aca02883209b815700836f12c2