### PR TITLE
java transpiler: support not builtin

### DIFF
--- a/tests/algorithms/x/Java/strings/anagrams.bench
+++ b/tests/algorithms/x/Java/strings/anagrams.bench
@@ -1,0 +1,1 @@
+{"duration_us": 98107, "memory_bytes": 139112, "name": "main"}

--- a/tests/algorithms/x/Java/strings/anagrams.error
+++ b/tests/algorithms/x/Java/strings/anagrams.error
@@ -1,8 +1,0 @@
-parse: error[P999]: /workspace/mochi/tests/github/TheAlgorithms/Mochi/strings/anagrams.mochi:75:19: unexpected token "!" (expected PostfixExpr)
-  --> /workspace/mochi/tests/github/TheAlgorithms/Mochi/strings/anagrams.mochi:75:19
-
- 75 |     if w != "" && !(w in seen) {
-    |                   ^
-
-help:
-  Parse error occurred. Check syntax near this location.

--- a/tests/algorithms/x/Java/strings/anagrams.java
+++ b/tests/algorithms/x/Java/strings/anagrams.java
@@ -1,0 +1,144 @@
+public class Main {
+    static java.util.Map<String,String[]> word_by_signature = null;
+
+    static String[] split(String s, String sep) {
+        String[] res = ((String[])(new String[]{}));
+        String current_1 = "";
+        long i_1 = 0L;
+        while ((long)(i_1) < (long)(_runeLen(s))) {
+            String ch_1 = _substr(s, (int)((long)(i_1)), (int)((long)((long)(i_1) + 1L)));
+            if ((ch_1.equals(sep))) {
+                res = ((String[])(java.util.stream.Stream.concat(java.util.Arrays.stream(res), java.util.stream.Stream.of(current_1)).toArray(String[]::new)));
+                current_1 = "";
+            } else {
+                current_1 = current_1 + ch_1;
+            }
+            i_1 = (long)((long)(i_1) + 1L);
+        }
+        res = ((String[])(java.util.stream.Stream.concat(java.util.Arrays.stream(res), java.util.stream.Stream.of(current_1)).toArray(String[]::new)));
+        return res;
+    }
+
+    static String[] insertion_sort(String[] arr) {
+        String[] a = ((String[])(arr));
+        long i_3 = 1L;
+        while ((long)(i_3) < (long)(a.length)) {
+            String key_1 = a[(int)((long)(i_3))];
+            long j_1 = (long)((long)(i_3) - 1L);
+            while ((long)(j_1) >= 0L && (a[(int)((long)(j_1))].compareTo(key_1) > 0)) {
+a[(int)((long)((long)(j_1) + 1L))] = a[(int)((long)(j_1))];
+                j_1 = (long)((long)(j_1) - 1L);
+            }
+a[(int)((long)((long)(j_1) + 1L))] = key_1;
+            i_3 = (long)((long)(i_3) + 1L);
+        }
+        return a;
+    }
+
+    static String sort_chars(String word) {
+        String[] chars = ((String[])(new String[]{}));
+        long i_5 = 0L;
+        while ((long)(i_5) < (long)(_runeLen(word))) {
+            chars = ((String[])(java.util.stream.Stream.concat(java.util.Arrays.stream(chars), java.util.stream.Stream.of(_substr(word, (int)((long)(i_5)), (int)((long)((long)(i_5) + 1L))))).toArray(String[]::new)));
+            i_5 = (long)((long)(i_5) + 1L);
+        }
+        chars = ((String[])(insertion_sort(((String[])(chars)))));
+        String res_2 = "";
+        i_5 = 0L;
+        while ((long)(i_5) < (long)(chars.length)) {
+            res_2 = res_2 + chars[(int)((long)(i_5))];
+            i_5 = (long)((long)(i_5) + 1L);
+        }
+        return res_2;
+    }
+
+    static String[] unique_sorted(String[] words) {
+        java.util.Map<String,Boolean> seen = ((java.util.Map<String,Boolean>)(new java.util.LinkedHashMap<String, Boolean>()));
+        String[] res_4 = ((String[])(new String[]{}));
+        for (String w : words) {
+            if (!(w.equals("")) && !seen.containsKey(w)) {
+                res_4 = ((String[])(java.util.stream.Stream.concat(java.util.Arrays.stream(res_4), java.util.stream.Stream.of(w)).toArray(String[]::new)));
+seen.put(w, true);
+            }
+        }
+        res_4 = ((String[])(insertion_sort(((String[])(res_4)))));
+        return res_4;
+    }
+
+    static void build_map(String[] words) {
+        for (String w : words) {
+            String sig = String.valueOf(sort_chars(w));
+            String[] arr = ((String[])(new String[]{}));
+            if (word_by_signature.containsKey(sig)) {
+                arr = (String[])(((String[])(word_by_signature).get(sig)));
+            }
+            arr = ((String[])(java.util.stream.Stream.concat(java.util.Arrays.stream(arr), java.util.stream.Stream.of(w)).toArray(String[]::new)));
+word_by_signature.put(sig, ((String[])(arr)));
+        }
+    }
+
+    static String[] anagram(String my_word) {
+        String sig_1 = String.valueOf(sort_chars(my_word));
+        if (word_by_signature.containsKey(sig_1)) {
+            return ((String[])(word_by_signature).get(sig_1));
+        }
+        return new String[]{};
+    }
+
+    static void main() {
+        String text = String.valueOf(read_file("words.txt"));
+        String[] lines_1 = ((String[])(text.split(java.util.regex.Pattern.quote("\n"))));
+        String[] words_1 = ((String[])(unique_sorted(((String[])(lines_1)))));
+        build_map(((String[])(words_1)));
+        for (String w : words_1) {
+            String[] anas_1 = ((String[])(anagram(w)));
+            if ((long)(anas_1.length) > 1L) {
+                String line_1 = w + ":";
+                long i_7 = 0L;
+                while ((long)(i_7) < (long)(anas_1.length)) {
+                    if ((long)(i_7) > 0L) {
+                        line_1 = line_1 + ",";
+                    }
+                    line_1 = line_1 + anas_1[(int)((long)(i_7))];
+                    i_7 = (long)((long)(i_7) + 1L);
+                }
+                System.out.println(line_1);
+            }
+        }
+    }
+    public static void main(String[] args) {
+        word_by_signature = ((java.util.Map<String,String[]>)(new java.util.LinkedHashMap<String, String[]>()));
+        main();
+    }
+
+    static int _runeLen(String s) {
+        return s.codePointCount(0, s.length());
+    }
+
+    static String _substr(String s, int i, int j) {
+        int len = _runeLen(s);
+        if (i < 0) i = 0;
+        if (j > len) j = len;
+        if (i > j) i = j;
+        int start = s.offsetByCodePoints(0, i);
+        int end = s.offsetByCodePoints(0, j);
+        return s.substring(start, end);
+    }
+
+    static final String _dataDir = "strings";
+    static String read_file(String path) {
+        java.io.File f = new java.io.File(path);
+        if (!f.isAbsolute()) {
+            String root = System.getenv("MOCHI_ROOT");
+            if (root != null && !root.isEmpty()) {
+                java.io.File alt = new java.io.File(root + java.io.File.separator + "tests" + java.io.File.separator + "github" + java.io.File.separator + "TheAlgorithms" + java.io.File.separator + "Mochi" + java.io.File.separator + _dataDir, path);
+                if (alt.exists()) f = alt;
+            }
+        }
+        try {
+            return new String(java.nio.file.Files.readAllBytes(f.toPath()));
+        } catch (Exception e) {
+            return "";
+        }
+    }
+}

--- a/tests/algorithms/x/Java/strings/anagrams.out
+++ b/tests/algorithms/x/Java/strings/anagrams.out
@@ -1,0 +1,10 @@
+act:act,cat,tac
+bird:bird,drib
+cat:act,cat,tac
+dog:dog,god
+drib:bird,drib
+god:dog,god
+sett:sett,stet,test
+stet:sett,stet,test
+tac:act,cat,tac
+test:sett,stet,test

--- a/transpiler/x/java/ALGORITHMS.md
+++ b/transpiler/x/java/ALGORITHMS.md
@@ -2,13 +2,13 @@
 
 This checklist is auto-generated.
 Generated Java code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Java`.
-Last updated: 2025-08-22 23:24 GMT+7
+Last updated: 2025-08-23 13:52 GMT+7
 
-## Algorithms Golden Test Checklist (977/1077)
+## Algorithms Golden Test Checklist (978/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 40.0ms | 46.14KB |
-| 2 | backtracking/all_permutations | error | 42.0ms | 45.75KB |
+| 2 | backtracking/all_permutations | ✓ | 42.0ms | 45.75KB |
 | 3 | backtracking/all_subsequences | ✓ | 60.0ms | 45.54KB |
 | 4 | backtracking/coloring | ✓ | 42.0ms | 46.43KB |
 | 5 | backtracking/combination_sum | ✓ | 62.0ms | 46.14KB |
@@ -907,7 +907,7 @@ Last updated: 2025-08-22 23:24 GMT+7
 | 898 | project_euler/problem_069/sol1 | ✓ | 15.0ms | 664B |
 | 899 | project_euler/problem_070/sol1 | ✓ | 307.0ms | 46.79KB |
 | 900 | project_euler/problem_071/sol1 | ✓ | 25.0ms | 1.02KB |
-| 901 | project_euler/problem_072/sol1 | ✓ |  |  |
+| 901 | project_euler/problem_072/sol1 |   |  |  |
 | 902 | project_euler/problem_072/sol2 | ✓ | 46.0ms | 46.21KB |
 | 903 | project_euler/problem_073/sol1 | ✓ | 497.0ms | 784B |
 | 904 | project_euler/problem_074/sol1 | ✓ | 43.0ms | 222.55KB |
@@ -996,7 +996,7 @@ Last updated: 2025-08-22 23:24 GMT+7
 | 987 | sorts/wiggle_sort | ✓ | 30.0ms | 56.92KB |
 | 988 | strings/aho_corasick | ✓ | 26.0ms | 46.48KB |
 | 989 | strings/alternative_string_arrange | ✓ | 19.0ms | 33.07KB |
-| 990 | strings/anagrams | error |  |  |
+| 990 | strings/anagrams | ✓ | 98.0ms | 135.85KB |
 | 991 | strings/autocomplete_using_trie | ✓ | 25.0ms | 53.36KB |
 | 992 | strings/barcode_validator |   |  |  |
 | 993 | strings/bitap_string_match | ✓ | 27.0ms | 46.46KB |

--- a/transpiler/x/java/transpiler.go
+++ b/transpiler/x/java/transpiler.go
@@ -6042,6 +6042,9 @@ func compilePrimary(p *parser.Primary) (Expr, error) {
 			}
 			return &CallExpr{Func: "read_file", Args: args}, nil
 		}
+		if name == "not" && len(args) == 1 {
+			return &UnaryExpr{Op: "!", Value: args[0]}, nil
+		}
 		aliasName := resolveAlias(name)
 		if t, ok := varTypes[aliasName]; ok {
 			if strings.HasPrefix(t, "fn") {


### PR DESCRIPTION
## Summary
- map the `not` builtin to Java's `!` operator
- add Java output and benchmark for strings/anagrams

## Testing
- `MOCHI_ALG_INDEX=990 go test -tags slow -run TestJavaTranspiler_Algorithms_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68a963ec3d1c8320add026b2d4275571