### PR TITLE
chore: add v0.10.71 release notes and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # 📦 CHANGELOG.md
 
+## [0.10.71] – 2025-08-23T14:49:16+07:00
+
+### Added
+
+* `not` operator implemented for Zig, TypeScript, Scala, Rust, OCaml, Java and Lua transpilers.
+* `read_file` and `ord` builtins introduced across C, C++, Zig, TypeScript, Scheme, Scala, Rust, Racket, Ruby, Python, Pascal, PHP, OCaml, Kotlin, Go, Erlang, Clojure and Swift.
+* Big integer support improved with a C# BigInteger mode and C++ big integer printing.
+* Go transpiler gains `__name__` recognition and C adds nested list concatenation with a simple neural network algorithm.
+* New OHP transpiler and benchmarks expand algorithm coverage across languages.
+
+### Changed
+
+* Go runtime simplifies list printing and Ruby updates float formatting.
+* Algorithm and benchmark data refreshed for Racket, Dart and others.
+
+### Fixed
+
+* Python integer division for index expressions.
+* C map scoping and Java break detection.
+* Dart variable shadowing, Lua boolean string helpers and C++ digit-to-big-int casting issues.
+* Improved Scala case handling and Zig map mutability.
+
 ## [0.10.70] – 2025-08-22T14:19:51+07:00
 
 ### Added

--- a/releases/v0.10.71.md
+++ b/releases/v0.10.71.md
@@ -1,0 +1,17 @@
+# Aug 2025 (v0.10.71)
+
+Released on Sat Aug 23 14:49:16 2025 +0700.
+
+Mochi v0.10.71 introduces broad file I/O and logical operator support across transpilers, expands algorithm benchmarks, and improves big integer handling.
+
+## Transpilers
+
+- `not` operator implemented for Zig, TypeScript, Scala, Rust, OCaml, Java and Lua.
+- `read_file` and `ord` builtins added across C, C++, Zig, TypeScript, Scheme, Scala, Rust, Racket, Ruby, Python, Pascal, PHP, OCaml, Kotlin, Go, Erlang, Clojure and Swift.
+- C# gains a BigInteger mode while C++ adds big integer printing and parsing helpers.
+- Go transpiler adds `__name__` and improves list printing; C supports nested list concatenation and a simple neural network algorithm.
+- Introduces OHP transpiler with benchmarks for 50 string algorithms.
+
+## Algorithms
+
+- Expanded and refreshed algorithm outputs across Racket, Ruby, PHP, Dart and more.


### PR DESCRIPTION
## Summary
- document v0.10.71 in changelog
- add release notes for v0.10.71

## Testing
- `go test ./...` *(fails: command interrupted after long execution)*

------
https://chatgpt.com/codex/tasks/task_e_68a9735084bc83209e3895c0915afaeb