### PR TITLE
chore: update racket algorithm outputs

### DIFF
--- a/tests/algorithms/x/Racket/project_euler/problem_020/sol4.out
+++ b/tests/algorithms/x/Racket/project_euler/problem_020/sol4.out
@@ -1,2 +1,2 @@
 Enter the Number: 
-1
+648

--- a/transpiler/x/rkt/ALGORITHMS.md
+++ b/transpiler/x/rkt/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Racket code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Racket`.
-Last updated: 2025-08-23 06:50 UTC
+Last updated: 2025-08-23 08:45 UTC
 
 ## Algorithms Golden Test Checklist (911/1077)
 | Index | Name | Status | Duration | Memory |
@@ -837,24 +837,24 @@ Last updated: 2025-08-23 06:50 UTC
 | 828 | project_euler/problem_010/sol2 | ✓ | 3.893792s | 97.7 MB |
 | 829 | project_euler/problem_010/sol3 | ✓ | 35.945894s | 2.5 MB |
 | 830 | project_euler/problem_011/sol1 | ✓ | 1.702ms | 180.0 KB |
-| 831 | project_euler/problem_011/sol2 | ✓ | 1.53ms | 519.6 KB |
-| 832 | project_euler/problem_012/sol1 | ✓ | 577.908ms | 2.6 MB |
-| 833 | project_euler/problem_012/sol2 | ✓ | 588.338ms | 2.1 MB |
-| 834 | project_euler/problem_013/sol1 | ✓ | 7.852ms | 3.9 MB |
-| 835 | project_euler/problem_014/sol1 | ✓ | 1.875681s | 3.2 MB |
-| 836 | project_euler/problem_014/sol2 | ✓ | 282µs | 443.2 KB |
-| 837 | project_euler/problem_015/sol1 | ✓ | 84µs | 130.6 KB |
-| 838 | project_euler/problem_016/sol1 | ✓ | 393µs | 624.1 KB |
-| 839 | project_euler/problem_016/sol2 | ✓ | 1.070164s | 5.6 MB |
-| 840 | project_euler/problem_017/sol1 | ✓ | 426µs | 393.5 KB |
-| 841 | project_euler/problem_018/solution | ✓ | 249µs | 99.9 KB |
-| 842 | project_euler/problem_019/sol1 | ✓ | 1.673ms | 4.8 MB |
-| 843 | project_euler/problem_020/sol1 | ✓ | 106µs | 111.9 KB |
-| 844 | project_euler/problem_020/sol2 | ✓ | 138µs | 181.0 KB |
-| 845 | project_euler/problem_020/sol3 | ✓ | 144µs | 127.0 KB |
-| 846 | project_euler/problem_020/sol4 | ✓ | 48µs | 3.2 KB |
-| 847 | project_euler/problem_021/sol1 | ✓ | 310.23ms | 5.0 MB |
-| 848 | project_euler/problem_022/sol1 | ✓ | 44µs | 4.8 KB |
+| 831 | project_euler/problem_011/sol2 | ✓ | 1.204ms | 540.8 KB |
+| 832 | project_euler/problem_012/sol1 | ✓ | 405.379ms | 2.8 MB |
+| 833 | project_euler/problem_012/sol2 | ✓ | 414.849ms | 3.2 MB |
+| 834 | project_euler/problem_013/sol1 | ✓ | 4.743ms |  |
+| 835 | project_euler/problem_014/sol1 | ✓ | 1m3.32972s | 3.8 MB |
+| 836 | project_euler/problem_014/sol2 | ✓ | 203µs | 453.9 KB |
+| 837 | project_euler/problem_015/sol1 | ✓ | 58µs | 131.0 KB |
+| 838 | project_euler/problem_016/sol1 | ✓ | 224µs | 618.9 KB |
+| 839 | project_euler/problem_016/sol2 | ✓ | 3.815384s |  |
+| 840 | project_euler/problem_017/sol1 | ✓ | 304µs | 409.6 KB |
+| 841 | project_euler/problem_018/solution | ✓ | 166µs | 98.2 KB |
+| 842 | project_euler/problem_019/sol1 | ✓ | 1.329ms | 4.8 MB |
+| 843 | project_euler/problem_020/sol1 | ✓ | 74µs | 112.0 KB |
+| 844 | project_euler/problem_020/sol2 | ✓ | 102µs | 181.5 KB |
+| 845 | project_euler/problem_020/sol3 | ✓ | 103µs | 123.8 KB |
+| 846 | project_euler/problem_020/sol4 | ✓ | 102µs | 119.0 KB |
+| 847 | project_euler/problem_021/sol1 | ✓ | 196.142ms |  |
+| 848 | project_euler/problem_022/sol1 | ✓ | 28µs | 5.1 KB |
 | 849 | project_euler/problem_022/sol2 |   |  |  |
 | 850 | project_euler/problem_023/sol1 |   |  |  |
 | 851 | project_euler/problem_024/sol1 | ✓ | 31µs | 30.4 KB |


### PR DESCRIPTION
## Summary
- regenerate Project Euler problem 20 solution 4 output for Racket transpiler
- refresh Racket algorithms checklist

## Testing
- `MOCHI_ALGORITHMS_INDEX=831 go test -tags=slow ./transpiler/x/rkt -run TestRktTranspiler_Algorithms_Golden -count=1 -timeout=10m`
- `MOCHI_ALGORITHMS_INDEX=846 go test -tags=slow ./transpiler/x/rkt -run TestRktTranspiler_Algorithms_Golden -count=1 -timeout=10m`


------
https://chatgpt.com/codex/tasks/task_e_68a97ca1b56c8320b105fca9bdc0e0fa