### PR TITLE
lua: update algorithms benchmarks

### DIFF
--- a/transpiler/x/lua/ALGORITHMS.md
+++ b/transpiler/x/lua/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Lua code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Lua`.
-Last updated: 2025-08-23 14:57 GMT+7
+Last updated: 2025-08-24 09:02 GMT+7
 
 ## Algorithms Golden Test Checklist (1054/1077)
 | Index | Name | Status | Duration | Memory |

--- a/transpiler/x/lua/README.md
+++ b/transpiler/x/lua/README.md
@@ -4,7 +4,7 @@ Generated Lua code for programs in `tests/vm/valid`. Each program has a `.lua` f
 
 Transpiled programs: 104/105
 
-Last updated: 2025-08-22 23:09 GMT+7
+Last updated: 2025-08-24 08:57 GMT+7
 
 Checklist:
 

--- a/transpiler/x/lua/TASKS.md
+++ b/transpiler/x/lua/TASKS.md
@@ -1,3 +1,203 @@
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
+## Progress (2025-08-24 08:57 GMT+7)
+- 104/105 VM tests passing
+- Added float literal support
+
 ## Progress (2025-08-22 23:09 GMT+7)
 - 104/105 VM tests passing
 - Added float literal support


### PR DESCRIPTION
## Summary
- regenerate Lua algorithm artifacts with benchmarking
- refresh Lua transpiler docs and progress tracking

## Testing
- `MOCHI_ALG_INDEX=956 go test ./transpiler/x/lua -run TestLuaTranspiler_Algorithms_Golden -tags slow -count=1 -update-algorithms-lua`
- `for i in $(seq 957 1005); do MOCHI_ALG_INDEX=$i go test ./transpiler/x/lua -run TestLuaTranspiler_Algorithms_Golden -tags slow -count=1 >/tmp/test_$i.log && tail -n 1 /tmp/test_$i.log; done`

------
https://chatgpt.com/codex/tasks/task_e_68aa71c270008320a2e1551a5aa853d5