### PR TITLE
java: handle big integers and object arrays

### DIFF
--- a/tests/algorithms/x/Java/sorts/heap_sort.bench
+++ b/tests/algorithms/x/Java/sorts/heap_sort.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 16343,
-  "memory_bytes": 792,
-  "name": "main"
-}
+{"duration_us": 27984, "memory_bytes": 9864, "name": "main"}

--- a/tests/algorithms/x/Java/sorts/heap_sort.java
+++ b/tests/algorithms/x/Java/sorts/heap_sort.java
@@ -1,49 +1,79 @@
 public class Main {
-    static int[] data = new int[0];
-    static int[] result = new int[0];
+    static java.math.BigInteger[] data = new java.math.BigInteger[0];
+    static java.math.BigInteger[] result = new java.math.BigInteger[0];
 
-    static void heapify(int[] arr, int index, int heap_size) {
-        int largest = index;
-        int left_index = 2 * index + 1;
-        int right_index = 2 * index + 2;
-        if (left_index < heap_size && arr[left_index] > arr[largest]) {
-            largest = left_index;
+    static void heapify(java.math.BigInteger[] arr, java.math.BigInteger index, java.math.BigInteger heap_size) {
+        java.math.BigInteger largest = index;
+        java.math.BigInteger left_index_1 = java.math.BigInteger.valueOf(2).multiply(index).add(java.math.BigInteger.valueOf(1));
+        java.math.BigInteger right_index_1 = java.math.BigInteger.valueOf(2).multiply(index).add(java.math.BigInteger.valueOf(2));
+        if (left_index_1.compareTo(heap_size) < 0 && arr[(int)(((java.math.BigInteger)(left_index_1)).longValue())].compareTo(arr[(int)(((java.math.BigInteger)(largest)).longValue())]) > 0) {
+            largest = left_index_1;
         }
-        if (right_index < heap_size && arr[right_index] > arr[largest]) {
-            largest = right_index;
+        if (right_index_1.compareTo(heap_size) < 0 && arr[(int)(((java.math.BigInteger)(right_index_1)).longValue())].compareTo(arr[(int)(((java.math.BigInteger)(largest)).longValue())]) > 0) {
+            largest = right_index_1;
         }
-        if (largest != index) {
-            int temp = arr[largest];
-arr[largest] = arr[index];
-arr[index] = temp;
-            heapify(((int[])(arr)), largest, heap_size);
+        if (largest.compareTo(index) != 0) {
+            java.math.BigInteger temp_1 = arr[(int)(((java.math.BigInteger)(largest)).longValue())];
+arr[(int)(((java.math.BigInteger)(largest)).longValue())] = arr[(int)(((java.math.BigInteger)(index)).longValue())];
+arr[(int)(((java.math.BigInteger)(index)).longValue())] = temp_1;
+            heapify(((java.math.BigInteger[])(arr)), largest, heap_size);
         }
     }
 
-    static int[] heap_sort(int[] arr) {
-        int n = arr.length;
-        int i = Math.floorDiv(n, 2) - 1;
-        while (i >= 0) {
-            heapify(((int[])(arr)), i, n);
-            i = i - 1;
+    static java.math.BigInteger[] heap_sort(java.math.BigInteger[] arr) {
+        java.math.BigInteger n = new java.math.BigInteger(String.valueOf(arr.length));
+        java.math.BigInteger i_1 = n.divide(java.math.BigInteger.valueOf(2)).subtract(java.math.BigInteger.valueOf(1));
+        while (i_1.compareTo(java.math.BigInteger.valueOf(0)) >= 0) {
+            heapify(((java.math.BigInteger[])(arr)), i_1, n);
+            i_1 = i_1.subtract(java.math.BigInteger.valueOf(1));
         }
-        i = n - 1;
-        while (i > 0) {
-            int temp_1 = arr[0];
-arr[0] = arr[i];
-arr[i] = temp_1;
-            heapify(((int[])(arr)), 0, i);
-            i = i - 1;
+        i_1 = n.subtract(java.math.BigInteger.valueOf(1));
+        while (i_1.compareTo(java.math.BigInteger.valueOf(0)) > 0) {
+            java.math.BigInteger temp_3 = arr[(int)(0L)];
+arr[(int)(0L)] = arr[(int)(((java.math.BigInteger)(i_1)).longValue())];
+arr[(int)(((java.math.BigInteger)(i_1)).longValue())] = temp_3;
+            heapify(((java.math.BigInteger[])(arr)), java.math.BigInteger.valueOf(0), i_1);
+            i_1 = i_1.subtract(java.math.BigInteger.valueOf(1));
         }
         return arr;
     }
     public static void main(String[] args) {
-        data = ((int[])(new int[]{3, 7, 9, 28, 123, -5, 8, -30, -200, 0, 4}));
-        result = ((int[])(heap_sort(((int[])(data)))));
-        System.out.println(java.util.Arrays.toString(result));
-        if (!(_p(result).equals(_p(new int[]{-200, -30, -5, 0, 3, 4, 7, 8, 9, 28, 123})))) {
-            throw new RuntimeException(String.valueOf("Assertion error"));
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            data = ((java.math.BigInteger[])(new java.math.BigInteger[]{java.math.BigInteger.valueOf(3), java.math.BigInteger.valueOf(7), java.math.BigInteger.valueOf(9), java.math.BigInteger.valueOf(28), java.math.BigInteger.valueOf(123), (java.math.BigInteger.valueOf(5)).negate(), java.math.BigInteger.valueOf(8), (java.math.BigInteger.valueOf(30)).negate(), (java.math.BigInteger.valueOf(200)).negate(), java.math.BigInteger.valueOf(0), java.math.BigInteger.valueOf(4)}));
+            result = ((java.math.BigInteger[])(heap_sort(((java.math.BigInteger[])(data)))));
+            System.out.println(java.util.Arrays.toString(result));
+            if (!(_p(result).equals(_p(new java.math.BigInteger[]{(java.math.BigInteger.valueOf(200)).negate(), (java.math.BigInteger.valueOf(30)).negate(), (java.math.BigInteger.valueOf(5)).negate(), java.math.BigInteger.valueOf(0), java.math.BigInteger.valueOf(3), java.math.BigInteger.valueOf(4), java.math.BigInteger.valueOf(7), java.math.BigInteger.valueOf(8), java.math.BigInteger.valueOf(9), java.math.BigInteger.valueOf(28), java.math.BigInteger.valueOf(123)})))) {
+                throw new RuntimeException(String.valueOf("Assertion error"));
+            }
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
+            return;
         }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
     }
 
     static String _p(Object v) {
@@ -58,6 +88,10 @@ arr[i] = temp_1;
             if (v instanceof short[]) return java.util.Arrays.toString((short[]) v);
             if (v instanceof float[]) return java.util.Arrays.toString((float[]) v);
             return java.util.Arrays.deepToString((Object[]) v);
+        }
+        if (v instanceof Double || v instanceof Float) {
+            double d = ((Number) v).doubleValue();
+            return String.valueOf(d);
         }
         return String.valueOf(v);
     }

--- a/tests/algorithms/x/Java/sorts/iterative_merge_sort.bench
+++ b/tests/algorithms/x/Java/sorts/iterative_merge_sort.bench
@@ -1,5 +1,1 @@
-{
-  "duration_us": 29232,
-  "memory_bytes": 56160,
-  "name": "main"
-}
+{"duration_us": 53357, "memory_bytes": 66072, "name": "main"}

--- a/tests/algorithms/x/Java/sorts/iterative_merge_sort.java
+++ b/tests/algorithms/x/Java/sorts/iterative_merge_sort.java
@@ -1,85 +1,115 @@
 public class Main {
 
-    static int[] merge(int[] a, int low, int mid, int high) {
-        int[] left = ((int[])(java.util.Arrays.copyOfRange(a, low, mid)));
-        int[] right = ((int[])(java.util.Arrays.copyOfRange(a, mid, high + 1)));
-        int[] result = ((int[])(new int[]{}));
-        while (left.length > 0 && right.length > 0) {
-            if (left[0] <= right[0]) {
-                result = ((int[])(java.util.stream.IntStream.concat(java.util.Arrays.stream(result), java.util.stream.IntStream.of(left[0])).toArray()));
-                left = ((int[])(java.util.Arrays.copyOfRange(left, 1, left.length)));
+    static java.math.BigInteger[] merge(java.math.BigInteger[] a, java.math.BigInteger low, java.math.BigInteger mid, java.math.BigInteger high) {
+        java.math.BigInteger[] left = ((java.math.BigInteger[])(java.util.Arrays.copyOfRange(a, (int)(((java.math.BigInteger)(low)).longValue()), (int)(((java.math.BigInteger)(mid)).longValue()))));
+        java.math.BigInteger[] right_1 = ((java.math.BigInteger[])(java.util.Arrays.copyOfRange(a, (int)(((java.math.BigInteger)(mid)).longValue()), (int)(((java.math.BigInteger)(high.add(java.math.BigInteger.valueOf(1)))).longValue()))));
+        java.math.BigInteger[] result_1 = ((java.math.BigInteger[])(new java.math.BigInteger[]{}));
+        while (new java.math.BigInteger(String.valueOf(left.length)).compareTo(java.math.BigInteger.valueOf(0)) > 0 && new java.math.BigInteger(String.valueOf(right_1.length)).compareTo(java.math.BigInteger.valueOf(0)) > 0) {
+            if (left[(int)(0L)].compareTo(right_1[(int)(0L)]) <= 0) {
+                result_1 = ((java.math.BigInteger[])(java.util.stream.Stream.concat(java.util.Arrays.stream(result_1), java.util.stream.Stream.of(left[(int)(0L)])).toArray(java.math.BigInteger[]::new)));
+                left = ((java.math.BigInteger[])(java.util.Arrays.copyOfRange(left, (int)(1L), (int)((long)(left.length)))));
             } else {
-                result = ((int[])(java.util.stream.IntStream.concat(java.util.Arrays.stream(result), java.util.stream.IntStream.of(right[0])).toArray()));
-                right = ((int[])(java.util.Arrays.copyOfRange(right, 1, right.length)));
+                result_1 = ((java.math.BigInteger[])(java.util.stream.Stream.concat(java.util.Arrays.stream(result_1), java.util.stream.Stream.of(right_1[(int)(0L)])).toArray(java.math.BigInteger[]::new)));
+                right_1 = ((java.math.BigInteger[])(java.util.Arrays.copyOfRange(right_1, (int)(1L), (int)((long)(right_1.length)))));
             }
         }
-        int i = 0;
-        while (i < left.length) {
-            result = ((int[])(java.util.stream.IntStream.concat(java.util.Arrays.stream(result), java.util.stream.IntStream.of(left[i])).toArray()));
-            i = i + 1;
+        java.math.BigInteger i_1 = java.math.BigInteger.valueOf(0);
+        while (i_1.compareTo(new java.math.BigInteger(String.valueOf(left.length))) < 0) {
+            result_1 = ((java.math.BigInteger[])(java.util.stream.Stream.concat(java.util.Arrays.stream(result_1), java.util.stream.Stream.of(left[(int)(((java.math.BigInteger)(i_1)).longValue())])).toArray(java.math.BigInteger[]::new)));
+            i_1 = i_1.add(java.math.BigInteger.valueOf(1));
         }
-        i = 0;
-        while (i < right.length) {
-            result = ((int[])(java.util.stream.IntStream.concat(java.util.Arrays.stream(result), java.util.stream.IntStream.of(right[i])).toArray()));
-            i = i + 1;
+        i_1 = java.math.BigInteger.valueOf(0);
+        while (i_1.compareTo(new java.math.BigInteger(String.valueOf(right_1.length))) < 0) {
+            result_1 = ((java.math.BigInteger[])(java.util.stream.Stream.concat(java.util.Arrays.stream(result_1), java.util.stream.Stream.of(right_1[(int)(((java.math.BigInteger)(i_1)).longValue())])).toArray(java.math.BigInteger[]::new)));
+            i_1 = i_1.add(java.math.BigInteger.valueOf(1));
         }
-        i = 0;
-        while (i < result.length) {
-a[low + i] = result[i];
-            i = i + 1;
+        i_1 = java.math.BigInteger.valueOf(0);
+        while (i_1.compareTo(new java.math.BigInteger(String.valueOf(result_1.length))) < 0) {
+a[(int)(((java.math.BigInteger)(low.add(i_1))).longValue())] = result_1[(int)(((java.math.BigInteger)(i_1)).longValue())];
+            i_1 = i_1.add(java.math.BigInteger.valueOf(1));
         }
         return a;
     }
 
-    static int[] iter_merge_sort(int[] items) {
-        int n = items.length;
-        if (n <= 1) {
+    static java.math.BigInteger[] iter_merge_sort(java.math.BigInteger[] items) {
+        java.math.BigInteger n = new java.math.BigInteger(String.valueOf(items.length));
+        if (n.compareTo(java.math.BigInteger.valueOf(1)) <= 0) {
             return items;
         }
-        int[] arr = ((int[])(java.util.Arrays.copyOfRange(items, 0, items.length)));
-        int p = 2;
-        while (p <= n) {
-            int i_1 = 0;
-            while (i_1 < n) {
-                int high = i_1 + p - 1;
-                if (high >= n) {
-                    high = n - 1;
+        java.math.BigInteger[] arr_1 = ((java.math.BigInteger[])(java.util.Arrays.copyOfRange(items, (int)(0L), (int)((long)(items.length)))));
+        java.math.BigInteger p_1 = java.math.BigInteger.valueOf(2);
+        while (p_1.compareTo(n) <= 0) {
+            java.math.BigInteger i_3 = java.math.BigInteger.valueOf(0);
+            while (i_3.compareTo(n) < 0) {
+                java.math.BigInteger high_1 = i_3.add(p_1).subtract(java.math.BigInteger.valueOf(1));
+                if (high_1.compareTo(n) >= 0) {
+                    high_1 = n.subtract(java.math.BigInteger.valueOf(1));
                 }
-                int low = i_1;
-                int mid = Math.floorDiv((low + high + 1), 2);
-                arr = ((int[])(merge(((int[])(arr)), low, mid, high)));
-                i_1 = i_1 + p;
+                java.math.BigInteger low_1 = i_3;
+                java.math.BigInteger mid_1 = (low_1.add(high_1).add(java.math.BigInteger.valueOf(1))).divide(java.math.BigInteger.valueOf(2));
+                arr_1 = ((java.math.BigInteger[])(merge(((java.math.BigInteger[])(arr_1)), low_1, mid_1, high_1)));
+                i_3 = i_3.add(p_1);
             }
-            if (p * 2 >= n) {
-                int mid2 = i_1 - p;
-                arr = ((int[])(merge(((int[])(arr)), 0, mid2, n - 1)));
+            if (p_1.multiply(java.math.BigInteger.valueOf(2)).compareTo(n) >= 0) {
+                java.math.BigInteger mid2_1 = i_3.subtract(p_1);
+                arr_1 = ((java.math.BigInteger[])(merge(((java.math.BigInteger[])(arr_1)), java.math.BigInteger.valueOf(0), mid2_1, n.subtract(java.math.BigInteger.valueOf(1)))));
                 break;
             }
-            p = p * 2;
+            p_1 = p_1.multiply(java.math.BigInteger.valueOf(2));
         }
-        return arr;
+        return arr_1;
     }
 
-    static String list_to_string(int[] arr) {
+    static String list_to_string(java.math.BigInteger[] arr) {
         String s = "[";
-        int i_2 = 0;
-        while (i_2 < arr.length) {
-            s = s + _p(_geti(arr, i_2));
-            if (i_2 < arr.length - 1) {
+        java.math.BigInteger i_5 = java.math.BigInteger.valueOf(0);
+        while (i_5.compareTo(new java.math.BigInteger(String.valueOf(arr.length))) < 0) {
+            s = s + _p(_geto(arr, ((Number)(i_5)).intValue()));
+            if (i_5.compareTo(new java.math.BigInteger(String.valueOf(arr.length)).subtract(java.math.BigInteger.valueOf(1))) < 0) {
                 s = s + ", ";
             }
-            i_2 = i_2 + 1;
+            i_5 = i_5.add(java.math.BigInteger.valueOf(1));
         }
         return s + "]";
     }
     public static void main(String[] args) {
-        System.out.println(list_to_string(((int[])(iter_merge_sort(((int[])(new int[]{5, 9, 8, 7, 1, 2, 7})))))));
-        System.out.println(list_to_string(((int[])(iter_merge_sort(((int[])(new int[]{1})))))));
-        System.out.println(list_to_string(((int[])(iter_merge_sort(((int[])(new int[]{2, 1})))))));
-        System.out.println(list_to_string(((int[])(iter_merge_sort(((int[])(new int[]{4, 3, 2, 1})))))));
-        System.out.println(list_to_string(((int[])(iter_merge_sort(((int[])(new int[]{5, 4, 3, 2, 1})))))));
-        System.out.println(list_to_string(((int[])(iter_merge_sort(((int[])(new int[]{-2, -9, -1, -4})))))));
-        System.out.println(list_to_string(((int[])(iter_merge_sort(((int[])(new int[]{})))))));
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            System.out.println(list_to_string(((java.math.BigInteger[])(iter_merge_sort(((java.math.BigInteger[])(new java.math.BigInteger[]{java.math.BigInteger.valueOf(5), java.math.BigInteger.valueOf(9), java.math.BigInteger.valueOf(8), java.math.BigInteger.valueOf(7), java.math.BigInteger.valueOf(1), java.math.BigInteger.valueOf(2), java.math.BigInteger.valueOf(7)})))))));
+            System.out.println(list_to_string(((java.math.BigInteger[])(iter_merge_sort(((java.math.BigInteger[])(new java.math.BigInteger[]{java.math.BigInteger.valueOf(1)})))))));
+            System.out.println(list_to_string(((java.math.BigInteger[])(iter_merge_sort(((java.math.BigInteger[])(new java.math.BigInteger[]{java.math.BigInteger.valueOf(2), java.math.BigInteger.valueOf(1)})))))));
+            System.out.println(list_to_string(((java.math.BigInteger[])(iter_merge_sort(((java.math.BigInteger[])(new java.math.BigInteger[]{java.math.BigInteger.valueOf(4), java.math.BigInteger.valueOf(3), java.math.BigInteger.valueOf(2), java.math.BigInteger.valueOf(1)})))))));
+            System.out.println(list_to_string(((java.math.BigInteger[])(iter_merge_sort(((java.math.BigInteger[])(new java.math.BigInteger[]{java.math.BigInteger.valueOf(5), java.math.BigInteger.valueOf(4), java.math.BigInteger.valueOf(3), java.math.BigInteger.valueOf(2), java.math.BigInteger.valueOf(1)})))))));
+            System.out.println(list_to_string(((java.math.BigInteger[])(iter_merge_sort(((java.math.BigInteger[])(new java.math.BigInteger[]{(java.math.BigInteger.valueOf(2)).negate(), (java.math.BigInteger.valueOf(9)).negate(), (java.math.BigInteger.valueOf(1)).negate(), (java.math.BigInteger.valueOf(4)).negate()})))))));
+            System.out.println(list_to_string(((java.math.BigInteger[])(iter_merge_sort(((java.math.BigInteger[])(new java.math.BigInteger[]{})))))));
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{\"duration_us\": " + _benchDuration + ", \"memory_bytes\": " + _benchMemory + ", \"name\": \"main\"}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
     }
 
     static String _p(Object v) {
@@ -95,10 +125,14 @@ a[low + i] = result[i];
             if (v instanceof float[]) return java.util.Arrays.toString((float[]) v);
             return java.util.Arrays.deepToString((Object[]) v);
         }
+        if (v instanceof Double || v instanceof Float) {
+            double d = ((Number) v).doubleValue();
+            return String.valueOf(d);
+        }
         return String.valueOf(v);
     }
 
-    static Integer _geti(int[] a, int i) {
+    static Object _geto(Object[] a, int i) {
         return (i >= 0 && i < a.length) ? a[i] : null;
     }
 }

--- a/transpiler/x/java/ALGORITHMS.md
+++ b/transpiler/x/java/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Java code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Java`.
-Last updated: 2025-08-23 15:36 GMT+7
+Last updated: 2025-08-24 09:12 GMT+7
 
 ## Algorithms Golden Test Checklist (978/1077)
 | Index | Name | Status | Duration | Memory |
@@ -962,10 +962,10 @@ Last updated: 2025-08-23 15:36 GMT+7
 | 953 | sorts/exchange_sort | ✓ | 13.0ms | 656B |
 | 954 | sorts/external_sort | ✓ | 32.0ms | 46.14KB |
 | 955 | sorts/gnome_sort | ✓ | 15.0ms | 496B |
-| 956 | sorts/heap_sort | ✓ | 16.0ms | 792B |
+| 956 | sorts/heap_sort | ✓ | 27.0ms | 9.63KB |
 | 957 | sorts/insertion_sort | ✓ | 13.0ms | 656B |
 | 958 | sorts/intro_sort | ✓ | 16.0ms | 784B |
-| 959 | sorts/iterative_merge_sort | ✓ | 29.0ms | 54.84KB |
+| 959 | sorts/iterative_merge_sort | ✓ | 53.0ms | 64.52KB |
 | 960 | sorts/merge_insertion_sort | ✓ | 28.0ms | 46.24KB |
 | 961 | sorts/merge_sort | ✓ | 26.0ms | 46.24KB |
 | 962 | sorts/msd_radix_sort | ✓ | 28.0ms | 46.37KB |


### PR DESCRIPTION
## Summary
- fix BigInteger negation emission
- use object array getter for non-primitive indexes
- regenerate Java outputs for heap_sort and iterative_merge_sort

## Testing
- `MOCHI_ALG_INDEX=956 go test ./transpiler/x/java -run TestJavaTranspiler_Algorithms_Golden -tags slow -v -count=1`
- `MOCHI_ALG_INDEX=959 go test ./transpiler/x/java -run TestJavaTranspiler_Algorithms_Golden -tags slow -v -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68aa71c5c5a883208efef00fd84a4112