### PR TITLE
docs: add v0.10.72 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # 📦 CHANGELOG.md
 
+## [0.10.72] – 2025-08-24T15:35:26+07:00
+
+### Added
+
+- Zig transpiler supports mutable list literals, dynamic ranges, float equality and arraylist APIs.
+- C transpiler adds runtime list allocation for top-level literals, map helpers, slice functions, map growth and user-defined concatenation, plus `while` loop pointer membership.
+- Scala introduces an `export` keyword and custom `contains` handling.
+- Pascal supports list-to-string conversion and JSONL loading.
+- Racket gains vector support.
+- Java handles BigInteger and object arrays; Go initializes maps on declaration and allows typed slice indices.
+
+### Changed
+
+- Algorithm outputs refreshed across TypeScript, Python, Ruby, Scala, Pascal, Clojure, C++ and more.
+- TypeScript and Go refine float equality and formatting.
+- Rust treats collection literals as non-const.
+
+### Fixed
+
+- C transpiler handles redeclarations, map resets and unary minus with ints.
+- File system maps int arrays to int64 arrays.
+- Erlang avoids variable reuse in mutated calls.
+- Python division heuristics corrected.
+
 ## [0.10.71] – 2025-08-23T14:49:16+07:00
 
 ### Added

--- a/releases/v0.10.72.md
+++ b/releases/v0.10.72.md
@@ -1,0 +1,25 @@
+# Aug 2025 (v0.10.72)
+
+Released on Sun Aug 24 15:35:26 2025 +0700.
+
+Mochi v0.10.72 expands cross-language transpiler capabilities, refreshes algorithm outputs, and resolves several code generation issues.
+
+## Transpilers
+
+- Zig transpiler supports mutable list literals, dynamic ranges, float equality, arraylist API and map lookups.
+- TypeScript resets bench flag, updates heap and radix outputs, and improves float equality.
+- Swift adds a heap sort example; Scheme adds sort outputs.
+- C transpiler allocates runtime lists for top-level literals, adds map struct helpers, slice functions, map growth, redeclaration and map reset handling, `while` loops and pointer membership, respects user-defined concatenation, and retains ints for unary minus.
+- Racket gains vector support.
+- Scala introduces custom `contains`, an append alias and an `export` keyword.
+- Pascal supports list-to-string conversion, JSONL loading, void returns and integer-keyed maps.
+- Rust improves function parameter handling and treats collection literals as non-const.
+- Java handles BigInteger and object arrays and supports BigInteger in list literals.
+- Go initializes maps on declaration, supports typed slice indices and refines float formatting.
+- Python, Ruby, Scala, TypeScript and others refresh algorithm outputs.
+
+## Algorithms
+
+- Added or regenerated Project Euler and algorithm outputs across C, C++, Clojure, Pascal, Ruby, TypeScript, Go, Scala, Racket and more.
+- Recorded failure case for Project Euler problem 22 solution 2 to track correctness.
+


### PR DESCRIPTION
## Summary
- document v0.10.72 release with git-based timestamp
- record highlights in changelog

## Testing
- `npm test` (fails: Missing script "test")
- `make test` (fails: interrupted, see log)

------
https://chatgpt.com/codex/tasks/task_e_68aacfa5d8f083208b8d462ec5c220e6