### PR TITLE
fix: handle int parsing and function names in C++ transpiler

### DIFF
--- a/transpiler/x/cpp/ALGORITHMS.md
+++ b/transpiler/x/cpp/ALGORITHMS.md
@@ -1,7 +1,7 @@
 # C++ Algorithms Transpiler Output
 
-Completed programs: 1026/1077
-Last updated: 2025-08-24 15:35 +0700
+Completed programs: 1027/1077
+Last updated: 2025-08-24 16:25 +0700
 
 Checklist:
 
@@ -160,7 +160,7 @@ Checklist:
 | 151 | conversions/weight_conversion | ✓ | 430.0µs | 3.81MB |
 | 152 | data_compression/burrows_wheeler | ✓ | 187.0µs | 3.59MB |
 | 153 | data_compression/huffman | ✓ | 344.0µs | 3.54MB |
-| 154 | data_compression/lempel_ziv |   |  |  |
+| 154 | data_compression/lempel_ziv | ✓ | 269.0µs | 3.51MB |
 | 155 | data_compression/lempel_ziv_decompress | ✓ | 94.0µs | 3.58MB |
 | 156 | data_compression/lz77 | ✓ | 250.0µs | 3.63MB |
 | 157 | data_compression/peak_signal_to_noise_ratio | ✓ | 9.0µs | 3.60MB |

--- a/transpiler/x/cpp/README.md
+++ b/transpiler/x/cpp/README.md
@@ -3,7 +3,7 @@
 This checklist is auto-generated.
 Generated C++ code for programs in `tests/vm/valid`. Each program has a `.cpp` file produced by the transpiler and a `.out` file containing its runtime output. Compilation or execution errors are captured in a `.error` file placed next to the source.
 
-Last updated: 2025-08-23 15:31 +0700
+Last updated: 2025-08-24 16:25 +0700
 
 ## VM Golden Test Checklist (103/105)
 - [x] append_builtin

--- a/transpiler/x/cpp/ROSETTA.md
+++ b/transpiler/x/cpp/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This directory stores C++ code generated from Mochi programs in `tests/rosetta/x/Mochi`. Each file is compiled and executed during tests. Successful runs keep the generated `.cpp` source along with a matching `.out` file. Failures are recorded in `.error` files when tests run with `-update`.
 
-Checklist of programs that currently transpile and run (437/491) - Last updated 2025-08-23 15:31 +0700:
+Checklist of programs that currently transpile and run (437/491) - Last updated 2025-08-24 16:25 +0700:
 | Index | Name | Status | Duration | Memory |
 | ---: | --- | :---: | ---: | ---: |
 | 1 | 100-doors-2 | ✓ | 273.0µs | 3.62MB |

--- a/transpiler/x/cpp/TASKS.md
+++ b/transpiler/x/cpp/TASKS.md
@@ -1,3 +1,8 @@
+## Progress (2025-08-24 16:25 +0700)
+- cpp: fallback to int64 without boost
+- Generated C++ for 103/105 programs
+- Updated README checklist and outputs
+
 ## Progress (2025-08-23 15:31 +0700)
 - ts: regenerate algorithms 791-841 and ensure newline
 - Generated C++ for 103/105 programs


### PR DESCRIPTION
## Summary
- include Boost cpp_int headers when only parsing big integers
- parse strings to ints with std::stoll when big-int support not needed
- ensure generated functions use safe names to avoid C++ keyword collisions

## Testing
- `MOCHI_ALGORITHMS_INDEX=154 go test -run TestCPPTranspiler_Algorithms_Golden -tags slow ./transpiler/x/cpp -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68aada92bef88320b4bc2b807d541340