### PR TITLE
clj: handle ranged loops with control

### DIFF
--- a/tests/algorithms/x/Clojure/conversions/weight_conversion.bench
+++ b/tests/algorithms/x/Clojure/conversions/weight_conversion.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 54746,
-  "memory_bytes": 31963920,
+  "duration_us": 44516,
+  "memory_bytes": 32897968,
   "name": "main"
 }

--- a/tests/algorithms/x/Clojure/conversions/weight_conversion.clj
+++ b/tests/algorithms/x/Clojure/conversions/weight_conversion.clj
@@ -18,6 +18,20 @@
 (defn split [s sep]
   (clojure.string/split s (re-pattern sep)))
 
+(defn toi [s]
+  (int (Double/valueOf (str s))))
+
+(defn _ord [s]
+  (int (first s)))
+
+(defn mochi_str [v]
+  (cond (float? v) (let [s (str v)] (if (clojure.string/ends-with? s ".0") (subs s 0 (- (count s) 2)) s)) :else (str v)))
+
+(defn _fetch [url]
+  {:data [{:from "" :intensity {:actual 0 :forecast 0 :index ""} :to ""}]})
+
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
 (def ^:dynamic pow10_i nil)
 
 (def ^:dynamic pow10_result nil)
@@ -26,16 +40,16 @@
 
 (def ^:dynamic weight_conversion_has_to nil)
 
-(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
-
 (declare pow10 weight_conversion)
 
+(declare _read_file)
+
 (defn pow10 [pow10_exp]
-  (binding [pow10_i nil pow10_result nil] (try (do (set! pow10_result 1.0) (if (>= pow10_exp 0) (do (set! pow10_i 0) (while (< pow10_i pow10_exp) (do (set! pow10_result (* pow10_result 10.0)) (set! pow10_i (+ pow10_i 1))))) (do (set! pow10_i 0) (while (< pow10_i (- 0 pow10_exp)) (do (set! pow10_result (/ pow10_result 10.0)) (set! pow10_i (+ pow10_i 1)))))) (throw (ex-info "return" {:v pow10_result}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
+  (binding [pow10_i nil pow10_result nil] (try (do (set! pow10_result 1.0) (if (>= pow10_exp 0) (do (set! pow10_i 0) (while (< pow10_i pow10_exp) (do (set! pow10_result (* pow10_result 10.0)) (set! pow10_i (+ pow10_i 1))))) (do (set! pow10_i 0) (while (< pow10_i (- pow10_exp)) (do (set! pow10_result (/ pow10_result 10.0)) (set! pow10_i (+ pow10_i 1)))))) (throw (ex-info "return" {:v pow10_result}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
 
-(def ^:dynamic main_KILOGRAM_CHART {"kilogram" 1.0 "gram" 1000.0 "milligram" 1000000.0 "metric-ton" 0.001 "long-ton" 0.0009842073 "short-ton" 0.0011023122 "pound" 2.2046244202 "stone" 0.1574731728 "ounce" 35.273990723 "carrat" 5000.0 "atomic-mass-unit" (* 6.022136652 (pow10 26))})
+(def ^:dynamic main_KILOGRAM_CHART nil)
 
-(def ^:dynamic main_WEIGHT_TYPE_CHART {"kilogram" 1.0 "gram" 0.001 "milligram" 0.000001 "metric-ton" 1000.0 "long-ton" 1016.04608 "short-ton" 907.184 "pound" 0.453592 "stone" 6.35029 "ounce" 0.0283495 "carrat" 0.0002 "atomic-mass-unit" (* 1.660540199 (pow10 (- 27)))})
+(def ^:dynamic main_WEIGHT_TYPE_CHART nil)
 
 (defn weight_conversion [weight_conversion_from_type weight_conversion_to_type weight_conversion_value]
   (binding [weight_conversion_has_from nil weight_conversion_has_to nil] (try (do (set! weight_conversion_has_to (in weight_conversion_to_type main_KILOGRAM_CHART)) (set! weight_conversion_has_from (in weight_conversion_from_type main_WEIGHT_TYPE_CHART)) (when (and weight_conversion_has_to weight_conversion_has_from) (throw (ex-info "return" {:v (* (* weight_conversion_value (get main_KILOGRAM_CHART weight_conversion_to_type)) (get main_WEIGHT_TYPE_CHART weight_conversion_from_type))}))) (println "Invalid 'from_type' or 'to_type'") (throw (ex-info "return" {:v 0.0}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
@@ -44,6 +58,8 @@
   (let [rt (Runtime/getRuntime)
     start-mem (- (.totalMemory rt) (.freeMemory rt))
     start (System/nanoTime)]
+      (alter-var-root (var main_KILOGRAM_CHART) (constantly {"atomic-mass-unit" (* 6.022136652 (pow10 26)) "carrat" 5000.0 "gram" 1000.0 "kilogram" 1.0 "long-ton" 0.0009842073 "metric-ton" 0.001 "milligram" 1000000.0 "ounce" 35.273990723 "pound" 2.2046244202 "short-ton" 0.0011023122 "stone" 0.1574731728}))
+      (alter-var-root (var main_WEIGHT_TYPE_CHART) (constantly {"atomic-mass-unit" (* 1.660540199 (pow10 (- 27))) "carrat" 0.0002 "gram" 0.001 "kilogram" 1.0 "long-ton" 1016.04608 "metric-ton" 1000.0 "milligram" 0.000001 "ounce" 0.0283495 "pound" 0.453592 "short-ton" 907.184 "stone" 6.35029}))
       (println (weight_conversion "kilogram" "gram" 1.0))
       (println (weight_conversion "gram" "pound" 3.0))
       (println (weight_conversion "ounce" "kilogram" 3.0))

--- a/tests/algorithms/x/Clojure/data_compression/lempel_ziv.bench
+++ b/tests/algorithms/x/Clojure/data_compression/lempel_ziv.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 40049,
+  "memory_bytes": 22524216,
+  "name": "main"
+}

--- a/tests/algorithms/x/Clojure/data_compression/lempel_ziv.error
+++ b/tests/algorithms/x/Clojure/data_compression/lempel_ziv.error
@@ -1,6 +1,0 @@
-run: exit status 1
-Execution error (NullPointerException) at main/to-binary (lempel_ziv.clj:42).
-Cannot invoke "Object.getClass()" because "x" is null
-
-Full report at:
-/tmp/clojure-10212620006849779618.edn

--- a/tests/algorithms/x/Clojure/data_compression/lempel_ziv.out
+++ b/tests/algorithms/x/Clojure/data_compression/lempel_ziv.out
@@ -1,5 +1,1 @@
-Execution error (NullPointerException) at main/to-binary (lempel_ziv.clj:42).
-Cannot invoke "Object.getClass()" because "x" is null
-
-Full report at:
-/tmp/clojure-10212620006849779618.edn
+01010111010011001

--- a/tests/algorithms/x/Clojure/data_compression/run_length_encoding.bench
+++ b/tests/algorithms/x/Clojure/data_compression/run_length_encoding.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 37869,
+  "memory_bytes": 22967976,
+  "name": "main"
+}

--- a/tests/algorithms/x/Clojure/data_compression/run_length_encoding.clj
+++ b/tests/algorithms/x/Clojure/data_compression/run_length_encoding.clj
@@ -14,9 +14,23 @@
 (defn split [s sep]
   (clojure.string/split s (re-pattern sep)))
 
+(defn toi [s]
+  (int (Double/valueOf (str s))))
+
+(defn _ord [s]
+  (int (first s)))
+
+(defn mochi_str [v]
+  (cond (float? v) (let [s (str v)] (if (clojure.string/ends-with? s ".0") (subs s 0 (- (count s) 2)) s)) :else (str v)))
+
+(defn _fetch [url]
+  {:data [{:from "" :intensity {:actual 0 :forecast 0 :index ""} :to ""}]})
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare run_length_encode run_length_decode)
+
+(declare _read_file)
 
 (def ^:dynamic count_v nil)
 
@@ -35,31 +49,37 @@
 (def ^:dynamic run_length_encode_i nil)
 
 (defn run_length_encode [run_length_encode_text]
-  (binding [count_v nil run_length_encode_encoded nil run_length_encode_i nil] (try (do (when (= (count run_length_encode_text) 0) (throw (ex-info "return" {:v ""}))) (set! run_length_encode_encoded "") (set! count_v 1) (set! run_length_encode_i 0) (while (< run_length_encode_i (count run_length_encode_text)) (do (if (and (< (+ run_length_encode_i 1) (count run_length_encode_text)) (= (nth run_length_encode_text run_length_encode_i) (nth run_length_encode_text (+ run_length_encode_i 1)))) (set! count_v (+ count_v 1)) (do (set! run_length_encode_encoded (str (str run_length_encode_encoded (nth run_length_encode_text run_length_encode_i)) (str count_v))) (set! count_v 1))) (set! run_length_encode_i (+ run_length_encode_i 1)))) (throw (ex-info "return" {:v run_length_encode_encoded}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
+  (binding [count_v nil run_length_encode_encoded nil run_length_encode_i nil] (try (do (when (= (count run_length_encode_text) 0) (throw (ex-info "return" {:v ""}))) (set! run_length_encode_encoded "") (set! count_v 1) (set! run_length_encode_i 0) (while (< run_length_encode_i (count run_length_encode_text)) (do (if (and (< (+ run_length_encode_i 1) (count run_length_encode_text)) (= (subs run_length_encode_text run_length_encode_i (+ run_length_encode_i 1)) (subs run_length_encode_text (+ run_length_encode_i 1) (+ (+ run_length_encode_i 1) 1)))) (set! count_v (+ count_v 1)) (do (set! run_length_encode_encoded (str (str run_length_encode_encoded (subs run_length_encode_text run_length_encode_i (+ run_length_encode_i 1))) (mochi_str count_v))) (set! count_v 1))) (set! run_length_encode_i (+ run_length_encode_i 1)))) (throw (ex-info "return" {:v run_length_encode_encoded}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
 
 (defn run_length_decode [run_length_decode_encoded]
-  (binding [count_v nil run_length_decode_ch nil run_length_decode_i nil run_length_decode_j nil run_length_decode_num_str nil run_length_decode_res nil] (try (do (set! run_length_decode_res "") (set! run_length_decode_i 0) (while (< run_length_decode_i (count run_length_decode_encoded)) (do (set! run_length_decode_ch (nth run_length_decode_encoded run_length_decode_i)) (set! run_length_decode_i (+ run_length_decode_i 1)) (set! run_length_decode_num_str "") (while (and (and (< run_length_decode_i (count run_length_decode_encoded)) (>= (compare (nth run_length_decode_encoded run_length_decode_i) "0") 0)) (<= (compare (nth run_length_decode_encoded run_length_decode_i) "9") 0)) (do (set! run_length_decode_num_str (str run_length_decode_num_str (nth run_length_decode_encoded run_length_decode_i))) (set! run_length_decode_i (+ run_length_decode_i 1)))) (set! count_v (Integer/parseInt run_length_decode_num_str)) (set! run_length_decode_j 0) (while (< run_length_decode_j count_v) (do (set! run_length_decode_res (str run_length_decode_res run_length_decode_ch)) (set! run_length_decode_j (+ run_length_decode_j 1)))))) (throw (ex-info "return" {:v run_length_decode_res}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
+  (binding [count_v nil run_length_decode_ch nil run_length_decode_i nil run_length_decode_j nil run_length_decode_num_str nil run_length_decode_res nil] (try (do (set! run_length_decode_res "") (set! run_length_decode_i 0) (while (< run_length_decode_i (count run_length_decode_encoded)) (do (set! run_length_decode_ch (subs run_length_decode_encoded run_length_decode_i (+ run_length_decode_i 1))) (set! run_length_decode_i (+ run_length_decode_i 1)) (set! run_length_decode_num_str "") (while (and (and (< run_length_decode_i (count run_length_decode_encoded)) (>= (compare (subs run_length_decode_encoded run_length_decode_i (+ run_length_decode_i 1)) "0") 0)) (<= (compare (subs run_length_decode_encoded run_length_decode_i (+ run_length_decode_i 1)) "9") 0)) (do (set! run_length_decode_num_str (str run_length_decode_num_str (subs run_length_decode_encoded run_length_decode_i (+ run_length_decode_i 1)))) (set! run_length_decode_i (+ run_length_decode_i 1)))) (set! count_v (toi run_length_decode_num_str)) (set! run_length_decode_j 0) (while (< run_length_decode_j count_v) (do (set! run_length_decode_res (str run_length_decode_res run_length_decode_ch)) (set! run_length_decode_j (+ run_length_decode_j 1)))))) (throw (ex-info "return" {:v run_length_decode_res}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
 
-(def ^:dynamic main_example1 "AAAABBBCCDAA")
+(def ^:dynamic main_example1 nil)
 
-(def ^:dynamic main_encoded1 (run_length_encode main_example1))
+(def ^:dynamic main_encoded1 nil)
 
-(def ^:dynamic main_example2 "A")
+(def ^:dynamic main_example2 nil)
 
-(def ^:dynamic main_encoded2 (run_length_encode main_example2))
+(def ^:dynamic main_encoded2 nil)
 
-(def ^:dynamic main_example3 "AAADDDDDDFFFCCCAAVVVV")
+(def ^:dynamic main_example3 nil)
 
-(def ^:dynamic main_encoded3 (run_length_encode main_example3))
+(def ^:dynamic main_encoded3 nil)
 
 (defn -main []
   (let [rt (Runtime/getRuntime)
     start-mem (- (.totalMemory rt) (.freeMemory rt))
     start (System/nanoTime)]
+      (alter-var-root (var main_example1) (constantly "AAAABBBCCDAA"))
+      (alter-var-root (var main_encoded1) (constantly (run_length_encode main_example1)))
       (println main_encoded1)
       (println (run_length_decode main_encoded1))
+      (alter-var-root (var main_example2) (constantly "A"))
+      (alter-var-root (var main_encoded2) (constantly (run_length_encode main_example2)))
       (println main_encoded2)
       (println (run_length_decode main_encoded2))
+      (alter-var-root (var main_example3) (constantly "AAADDDDDDFFFCCCAAVVVV"))
+      (alter-var-root (var main_encoded3) (constantly (run_length_encode main_example3)))
       (println main_encoded3)
       (println (run_length_decode main_encoded3))
       (System/gc)

--- a/tests/algorithms/x/Clojure/data_compression/run_length_encoding.error
+++ b/tests/algorithms/x/Clojure/data_compression/run_length_encoding.error
@@ -1,7 +1,0 @@
-run: exit status 1
-A4B3C2D1A2
-Execution error (ClassCastException) at java.lang.Character/compareTo (Character.java:180).
-class java.lang.String cannot be cast to class java.lang.Character (java.lang.String and java.lang.Character are in module java.base of loader 'bootstrap')
-
-Full report at:
-/tmp/clojure-16254765995738881671.edn

--- a/tests/algorithms/x/Clojure/data_compression/run_length_encoding.out
+++ b/tests/algorithms/x/Clojure/data_compression/run_length_encoding.out
@@ -1,6 +1,6 @@
 A4B3C2D1A2
-Execution error (ClassCastException) at java.lang.Character/compareTo (Character.java:180).
-class java.lang.String cannot be cast to class java.lang.Character (java.lang.String and java.lang.Character are in module java.base of loader 'bootstrap')
-
-Full report at:
-/tmp/clojure-16254765995738881671.edn
+AAAABBBCCDAA
+A1
+A
+A3D6F3C3A2V4
+AAADDDDDDFFFCCCAAVVVV

--- a/tests/algorithms/x/Clojure/data_structures/arrays/find_triplets_with_0_sum.bench
+++ b/tests/algorithms/x/Clojure/data_structures/arrays/find_triplets_with_0_sum.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 63648,
+  "memory_bytes": 27058240,
+  "name": "main"
+}

--- a/tests/algorithms/x/Clojure/data_structures/arrays/find_triplets_with_0_sum.clj
+++ b/tests/algorithms/x/Clojure/data_structures/arrays/find_triplets_with_0_sum.clj
@@ -14,11 +14,31 @@
 (defn split [s sep]
   (clojure.string/split s (re-pattern sep)))
 
+(defn toi [s]
+  (int (Double/valueOf (str s))))
+
+(defn _ord [s]
+  (int (first s)))
+
+(defn mochi_str [v]
+  (cond (float? v) (let [s (str v)] (if (clojure.string/ends-with? s ".0") (subs s 0 (- (count s) 2)) s)) :else (str v)))
+
+(defn _fetch [url]
+  {:data [{:from "" :intensity {:actual 0 :forecast 0 :index ""} :to ""}]})
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare sort_triplet contains_triplet contains_int find_triplets_with_0_sum find_triplets_with_0_sum_hashing)
 
+(declare _read_file)
+
+(def ^:dynamic contains_int_i nil)
+
+(def ^:dynamic contains_triplet_i nil)
+
 (def ^:dynamic contains_triplet_item nil)
+
+(def ^:dynamic contains_triplet_j nil)
 
 (def ^:dynamic contains_triplet_same nil)
 
@@ -29,6 +49,10 @@
 (def ^:dynamic find_triplets_with_0_sum_c nil)
 
 (def ^:dynamic find_triplets_with_0_sum_hashing_current_sum nil)
+
+(def ^:dynamic find_triplets_with_0_sum_hashing_i nil)
+
+(def ^:dynamic find_triplets_with_0_sum_hashing_j nil)
 
 (def ^:dynamic find_triplets_with_0_sum_hashing_other nil)
 
@@ -41,6 +65,12 @@
 (def ^:dynamic find_triplets_with_0_sum_hashing_target_sum nil)
 
 (def ^:dynamic find_triplets_with_0_sum_hashing_trip nil)
+
+(def ^:dynamic find_triplets_with_0_sum_i nil)
+
+(def ^:dynamic find_triplets_with_0_sum_j nil)
+
+(def ^:dynamic find_triplets_with_0_sum_k nil)
 
 (def ^:dynamic find_triplets_with_0_sum_n nil)
 
@@ -60,29 +90,29 @@
   (binding [sort_triplet_t nil sort_triplet_x nil sort_triplet_y nil sort_triplet_z nil] (try (do (set! sort_triplet_x sort_triplet_a) (set! sort_triplet_y sort_triplet_b) (set! sort_triplet_z sort_triplet_c) (when (> sort_triplet_x sort_triplet_y) (do (set! sort_triplet_t sort_triplet_x) (set! sort_triplet_x sort_triplet_y) (set! sort_triplet_y sort_triplet_t))) (when (> sort_triplet_y sort_triplet_z) (do (set! sort_triplet_t sort_triplet_y) (set! sort_triplet_y sort_triplet_z) (set! sort_triplet_z sort_triplet_t))) (when (> sort_triplet_x sort_triplet_y) (do (set! sort_triplet_t sort_triplet_x) (set! sort_triplet_x sort_triplet_y) (set! sort_triplet_y sort_triplet_t))) (throw (ex-info "return" {:v [sort_triplet_x sort_triplet_y sort_triplet_z]}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
 
 (defn contains_triplet [contains_triplet_arr contains_triplet_target]
-  (binding [contains_triplet_item nil contains_triplet_same nil] (try (do (dotimes [i (count contains_triplet_arr)] (do (set! contains_triplet_item (nth contains_triplet_arr i)) (set! contains_triplet_same true) (loop [j_seq (count contains_triplet_target)] (when (seq j_seq) (let [j (first j_seq)] (cond (not= (nth contains_triplet_item j) (nth contains_triplet_target j)) (do (set! contains_triplet_same false) (recur nil)) :else (recur (rest j_seq)))))) (when contains_triplet_same (throw (ex-info "return" {:v true}))))) (throw (ex-info "return" {:v false}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
+  (binding [contains_triplet_i nil contains_triplet_item nil contains_triplet_j nil contains_triplet_same nil] (try (do (loop [contains_triplet_i_seq (range (count contains_triplet_arr))] (when (seq contains_triplet_i_seq) (let [contains_triplet_i (first contains_triplet_i_seq)] (do (set! contains_triplet_item (nth contains_triplet_arr contains_triplet_i)) (set! contains_triplet_same true) (loop [contains_triplet_j_seq (range (count contains_triplet_target))] (when (seq contains_triplet_j_seq) (let [contains_triplet_j (first contains_triplet_j_seq)] (cond (not= (nth contains_triplet_item contains_triplet_j) (nth contains_triplet_target contains_triplet_j)) (do (set! contains_triplet_same false) (recur nil)) :else (recur (rest contains_triplet_j_seq)))))) (when contains_triplet_same (throw (ex-info "return" {:v true}))) (cond :else (recur (rest contains_triplet_i_seq))))))) (throw (ex-info "return" {:v false}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
 
 (defn contains_int [contains_int_arr contains_int_value]
-  (try (do (dotimes [i (count contains_int_arr)] (when (= (nth contains_int_arr i) contains_int_value) (throw (ex-info "return" {:v true})))) (throw (ex-info "return" {:v false}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+  (binding [contains_int_i nil] (try (do (dotimes [contains_int_i (count contains_int_arr)] (when (= (nth contains_int_arr contains_int_i) contains_int_value) (throw (ex-info "return" {:v true})))) (throw (ex-info "return" {:v false}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
 
 (defn find_triplets_with_0_sum [find_triplets_with_0_sum_nums]
-  (binding [find_triplets_with_0_sum_a nil find_triplets_with_0_sum_b nil find_triplets_with_0_sum_c nil find_triplets_with_0_sum_n nil find_triplets_with_0_sum_result nil find_triplets_with_0_sum_trip nil] (try (do (set! find_triplets_with_0_sum_n (count find_triplets_with_0_sum_nums)) (set! find_triplets_with_0_sum_result []) (dotimes [i find_triplets_with_0_sum_n] (doseq [j (range (+ i 1) find_triplets_with_0_sum_n)] (doseq [k (range (+ j 1) find_triplets_with_0_sum_n)] (do (set! find_triplets_with_0_sum_a (nth find_triplets_with_0_sum_nums i)) (set! find_triplets_with_0_sum_b (nth find_triplets_with_0_sum_nums j)) (set! find_triplets_with_0_sum_c (nth find_triplets_with_0_sum_nums k)) (when (= (+ (+ find_triplets_with_0_sum_a find_triplets_with_0_sum_b) find_triplets_with_0_sum_c) 0) (do (set! find_triplets_with_0_sum_trip (sort_triplet find_triplets_with_0_sum_a find_triplets_with_0_sum_b find_triplets_with_0_sum_c)) (when (not (contains_triplet find_triplets_with_0_sum_result find_triplets_with_0_sum_trip)) (set! find_triplets_with_0_sum_result (conj find_triplets_with_0_sum_result find_triplets_with_0_sum_trip))))))))) (throw (ex-info "return" {:v find_triplets_with_0_sum_result}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
+  (binding [find_triplets_with_0_sum_a nil find_triplets_with_0_sum_b nil find_triplets_with_0_sum_c nil find_triplets_with_0_sum_i nil find_triplets_with_0_sum_j nil find_triplets_with_0_sum_k nil find_triplets_with_0_sum_n nil find_triplets_with_0_sum_result nil find_triplets_with_0_sum_trip nil] (try (do (set! find_triplets_with_0_sum_n (count find_triplets_with_0_sum_nums)) (set! find_triplets_with_0_sum_result []) (dotimes [find_triplets_with_0_sum_i find_triplets_with_0_sum_n] (doseq [find_triplets_with_0_sum_j (range (+ find_triplets_with_0_sum_i 1) find_triplets_with_0_sum_n)] (doseq [find_triplets_with_0_sum_k (range (+ find_triplets_with_0_sum_j 1) find_triplets_with_0_sum_n)] (do (set! find_triplets_with_0_sum_a (nth find_triplets_with_0_sum_nums find_triplets_with_0_sum_i)) (set! find_triplets_with_0_sum_b (nth find_triplets_with_0_sum_nums find_triplets_with_0_sum_j)) (set! find_triplets_with_0_sum_c (nth find_triplets_with_0_sum_nums find_triplets_with_0_sum_k)) (when (= (+ (+ find_triplets_with_0_sum_a find_triplets_with_0_sum_b) find_triplets_with_0_sum_c) 0) (do (set! find_triplets_with_0_sum_trip (sort_triplet find_triplets_with_0_sum_a find_triplets_with_0_sum_b find_triplets_with_0_sum_c)) (when (not (contains_triplet find_triplets_with_0_sum_result find_triplets_with_0_sum_trip)) (set! find_triplets_with_0_sum_result (conj find_triplets_with_0_sum_result find_triplets_with_0_sum_trip))))))))) (throw (ex-info "return" {:v find_triplets_with_0_sum_result}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
 
 (defn find_triplets_with_0_sum_hashing [find_triplets_with_0_sum_hashing_arr]
-  (binding [find_triplets_with_0_sum_hashing_current_sum nil find_triplets_with_0_sum_hashing_other nil find_triplets_with_0_sum_hashing_output nil find_triplets_with_0_sum_hashing_required nil find_triplets_with_0_sum_hashing_seen nil find_triplets_with_0_sum_hashing_target_sum nil find_triplets_with_0_sum_hashing_trip nil] (try (do (set! find_triplets_with_0_sum_hashing_target_sum 0) (set! find_triplets_with_0_sum_hashing_output []) (dotimes [i (count find_triplets_with_0_sum_hashing_arr)] (do (set! find_triplets_with_0_sum_hashing_seen []) (set! find_triplets_with_0_sum_hashing_current_sum (- find_triplets_with_0_sum_hashing_target_sum (nth find_triplets_with_0_sum_hashing_arr i))) (doseq [j (range (+ i 1) (count find_triplets_with_0_sum_hashing_arr))] (do (set! find_triplets_with_0_sum_hashing_other (nth find_triplets_with_0_sum_hashing_arr j)) (set! find_triplets_with_0_sum_hashing_required (- find_triplets_with_0_sum_hashing_current_sum find_triplets_with_0_sum_hashing_other)) (when (contains_int find_triplets_with_0_sum_hashing_seen find_triplets_with_0_sum_hashing_required) (do (set! find_triplets_with_0_sum_hashing_trip (sort_triplet (nth find_triplets_with_0_sum_hashing_arr i) find_triplets_with_0_sum_hashing_other find_triplets_with_0_sum_hashing_required)) (when (not (contains_triplet find_triplets_with_0_sum_hashing_output find_triplets_with_0_sum_hashing_trip)) (set! find_triplets_with_0_sum_hashing_output (conj find_triplets_with_0_sum_hashing_output find_triplets_with_0_sum_hashing_trip))))) (set! find_triplets_with_0_sum_hashing_seen (conj find_triplets_with_0_sum_hashing_seen find_triplets_with_0_sum_hashing_other)))))) (throw (ex-info "return" {:v find_triplets_with_0_sum_hashing_output}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
+  (binding [find_triplets_with_0_sum_hashing_current_sum nil find_triplets_with_0_sum_hashing_i nil find_triplets_with_0_sum_hashing_j nil find_triplets_with_0_sum_hashing_other nil find_triplets_with_0_sum_hashing_output nil find_triplets_with_0_sum_hashing_required nil find_triplets_with_0_sum_hashing_seen nil find_triplets_with_0_sum_hashing_target_sum nil find_triplets_with_0_sum_hashing_trip nil] (try (do (set! find_triplets_with_0_sum_hashing_target_sum 0) (set! find_triplets_with_0_sum_hashing_output []) (dotimes [find_triplets_with_0_sum_hashing_i (count find_triplets_with_0_sum_hashing_arr)] (do (set! find_triplets_with_0_sum_hashing_seen []) (set! find_triplets_with_0_sum_hashing_current_sum (- find_triplets_with_0_sum_hashing_target_sum (nth find_triplets_with_0_sum_hashing_arr find_triplets_with_0_sum_hashing_i))) (doseq [find_triplets_with_0_sum_hashing_j (range (+ find_triplets_with_0_sum_hashing_i 1) (count find_triplets_with_0_sum_hashing_arr))] (do (set! find_triplets_with_0_sum_hashing_other (nth find_triplets_with_0_sum_hashing_arr find_triplets_with_0_sum_hashing_j)) (set! find_triplets_with_0_sum_hashing_required (- find_triplets_with_0_sum_hashing_current_sum find_triplets_with_0_sum_hashing_other)) (when (contains_int find_triplets_with_0_sum_hashing_seen find_triplets_with_0_sum_hashing_required) (do (set! find_triplets_with_0_sum_hashing_trip (sort_triplet (nth find_triplets_with_0_sum_hashing_arr find_triplets_with_0_sum_hashing_i) find_triplets_with_0_sum_hashing_other find_triplets_with_0_sum_hashing_required)) (when (not (contains_triplet find_triplets_with_0_sum_hashing_output find_triplets_with_0_sum_hashing_trip)) (set! find_triplets_with_0_sum_hashing_output (conj find_triplets_with_0_sum_hashing_output find_triplets_with_0_sum_hashing_trip))))) (set! find_triplets_with_0_sum_hashing_seen (conj find_triplets_with_0_sum_hashing_seen find_triplets_with_0_sum_hashing_other)))))) (throw (ex-info "return" {:v find_triplets_with_0_sum_hashing_output}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
 
 (defn -main []
   (let [rt (Runtime/getRuntime)
     start-mem (- (.totalMemory rt) (.freeMemory rt))
     start (System/nanoTime)]
-      (println (str (find_triplets_with_0_sum [(- 1) 0 1 2 (- 1) (- 4)])))
-      (println (str (find_triplets_with_0_sum [])))
-      (println (str (find_triplets_with_0_sum [0 0 0])))
-      (println (str (find_triplets_with_0_sum [1 2 3 0 (- 1) (- 2) (- 3)])))
-      (println (str (find_triplets_with_0_sum_hashing [(- 1) 0 1 2 (- 1) (- 4)])))
-      (println (str (find_triplets_with_0_sum_hashing [])))
-      (println (str (find_triplets_with_0_sum_hashing [0 0 0])))
-      (println (str (find_triplets_with_0_sum_hashing [1 2 3 0 (- 1) (- 2) (- 3)])))
+      (println (mochi_str (find_triplets_with_0_sum [(- 1) 0 1 2 (- 1) (- 4)])))
+      (println (mochi_str (find_triplets_with_0_sum [])))
+      (println (mochi_str (find_triplets_with_0_sum [0 0 0])))
+      (println (mochi_str (find_triplets_with_0_sum [1 2 3 0 (- 1) (- 2) (- 3)])))
+      (println (mochi_str (find_triplets_with_0_sum_hashing [(- 1) 0 1 2 (- 1) (- 4)])))
+      (println (mochi_str (find_triplets_with_0_sum_hashing [])))
+      (println (mochi_str (find_triplets_with_0_sum_hashing [0 0 0])))
+      (println (mochi_str (find_triplets_with_0_sum_hashing [1 2 3 0 (- 1) (- 2) (- 3)])))
       (System/gc)
       (let [end (System/nanoTime)
         end-mem (- (.totalMemory rt) (.freeMemory rt))

--- a/tests/algorithms/x/Clojure/data_structures/arrays/find_triplets_with_0_sum.error
+++ b/tests/algorithms/x/Clojure/data_structures/arrays/find_triplets_with_0_sum.error
@@ -1,6 +1,0 @@
-run: exit status 1
-Execution error (IllegalArgumentException) at main/contains-triplet (find_triplets_with_0_sum.clj:63).
-Don't know how to create ISeq from: java.lang.Integer
-
-Full report at:
-/tmp/clojure-15858499948997077198.edn

--- a/tests/algorithms/x/Clojure/data_structures/arrays/find_triplets_with_0_sum.out
+++ b/tests/algorithms/x/Clojure/data_structures/arrays/find_triplets_with_0_sum.out
@@ -1,5 +1,8 @@
-Execution error (IllegalArgumentException) at main/contains-triplet (find_triplets_with_0_sum.clj:63).
-Don't know how to create ISeq from: java.lang.Integer
-
-Full report at:
-/tmp/clojure-15858499948997077198.edn
+[[-1 0 1] [-1 -1 2]]
+[]
+[[0 0 0]]
+[[-3 1 2] [-1 0 1] [-2 0 2] [-3 0 3] [-2 -1 3]]
+[[-1 0 1] [-1 -1 2]]
+[]
+[[0 0 0]]
+[[-1 0 1] [-3 1 2] [-2 0 2] [-2 -1 3] [-3 0 3]]

--- a/transpiler/x/clj/ALGORITHMS.md
+++ b/transpiler/x/clj/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated Clojure code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Clojure`.
-Last updated: 2025-08-23 15:48 GMT+7
+Last updated: 2025-08-24 16:33 GMT+7
 
-## Algorithms Golden Test Checklist (845/1077)
+## Algorithms Golden Test Checklist (848/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 50.25ms | 19.66MB |
@@ -157,16 +157,16 @@ Last updated: 2025-08-23 15:48 GMT+7
 | 148 | conversions/temperature_conversions | ✓ | 62.781ms | 24.65MB |
 | 149 | conversions/time_conversions | error |  |  |
 | 150 | conversions/volume_conversions | ✓ | 55.438ms | 20.79MB |
-| 151 | conversions/weight_conversion | ✓ | 54.746ms | 30.48MB |
+| 151 | conversions/weight_conversion | ✓ | 44.516ms | 31.37MB |
 | 152 | data_compression/burrows_wheeler | ✓ | 53.116ms | 22.92MB |
 | 153 | data_compression/huffman | ✓ | 62.483ms | 24.72MB |
-| 154 | data_compression/lempel_ziv | error |  |  |
+| 154 | data_compression/lempel_ziv | ✓ | 40.049ms | 21.48MB |
 | 155 | data_compression/lempel_ziv_decompress | ✓ | 63.159ms | 21.35MB |
 | 156 | data_compression/lz77 | ✓ | 50.902ms | 24.38MB |
 | 157 | data_compression/peak_signal_to_noise_ratio | ✓ | 45.789ms | 21.66MB |
-| 158 | data_compression/run_length_encoding | error |  |  |
+| 158 | data_compression/run_length_encoding | ✓ | 37.869ms | 21.90MB |
 | 159 | data_structures/arrays/equilibrium_index_in_array | ✓ | 53.382ms | 19.89MB |
-| 160 | data_structures/arrays/find_triplets_with_0_sum | error |  |  |
+| 160 | data_structures/arrays/find_triplets_with_0_sum | ✓ | 63.648ms | 25.80MB |
 | 161 | data_structures/arrays/index_2d_array_in_1d | error |  |  |
 | 162 | data_structures/arrays/kth_largest_element | ✓ | 54.633ms | 20.55MB |
 | 163 | data_structures/arrays/median_two_array | ✓ | 48.805ms | 21.07MB |

--- a/transpiler/x/clj/transpiler.go
+++ b/transpiler/x/clj/transpiler.go
@@ -4037,8 +4037,12 @@ func transpileForStmt(f *parser.ForStmt) (Node, error) {
 			return nil, err
 		}
 		if isZeroNode(start) {
-			useDotimes = true
-			seq = end
+			if useCtrl {
+				seq = &List{Elems: []Node{Symbol("range"), end}}
+			} else {
+				useDotimes = true
+				seq = end
+			}
 		} else {
 			seq = &List{Elems: []Node{Symbol("range"), start, end}}
 		}


### PR DESCRIPTION
## Summary
- fix Clojure transpiler to emit `(range end)` for zero-based loops when break/continue are present
- refresh weight conversion, LZW compression, run-length encoding, and 0-sum triplet algorithm outputs and benches
- update Clojure algorithms progress table

## Testing
- `MOCHI_ALG_INDEX=151 go test ./transpiler/x/clj -run TestClojureTranspiler_Algorithms_Golden -tags=slow -count=1 -v`
- `MOCHI_ALG_INDEX=154 go test ./transpiler/x/clj -run TestClojureTranspiler_Algorithms_Golden -tags=slow -count=1 -v`
- `MOCHI_ALG_INDEX=158 go test ./transpiler/x/clj -run TestClojureTranspiler_Algorithms_Golden -tags=slow -count=1 -v`
- `MOCHI_ALG_INDEX=160 go test ./transpiler/x/clj -run TestClojureTranspiler_Algorithms_Golden -tags=slow -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_68aadb160b848320a426a7dfe032f05c