### PR TITLE
kt: update algorithm benchmark

### DIFF
--- a/tests/algorithms/x/Kotlin/data_structures/binary_tree/binary_tree_mirror.bench
+++ b/tests/algorithms/x/Kotlin/data_structures/binary_tree/binary_tree_mirror.bench
@@ -1,3 +1,3 @@
 Binary tree: {1=[2, 3], 2=[4, 5], 3=[6, 7], 7=[8, 9]}
 Binary tree mirror: {1=[3, 2], 2=[5, 4], 3=[7, 6], 7=[9, 8]}
-{"duration_us":28590, "memory_bytes":123480, "name":"main"}
+{"duration_us":21382, "memory_bytes":124416, "name":"main"}

--- a/tests/algorithms/x/Kotlin/data_structures/binary_tree/binary_tree_mirror.kt
+++ b/tests/algorithms/x/Kotlin/data_structures/binary_tree/binary_tree_mirror.kt
@@ -1,7 +1,41 @@
+val _dataDir = "/workspace/mochi/tests/github/TheAlgorithms/Mochi/data_structures/binary_tree"
+
 fun panic(msg: String): Nothing { throw RuntimeException(msg) }
 
+fun _numToStr(v: Number): String {
+    val d = v.toDouble()
+    val i = d.toLong()
+    return if (d == i.toDouble()) i.toString() else d.toString()
+}
+
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
 fun binary_tree_mirror_dict(tree: MutableMap<Int, MutableList<Int>>, root: Int): Unit {
-    if ((root == 0) || (!(root in tree) as Boolean)) {
+    if ((root == 0) || (!(tree.containsKey(root)) as Boolean)) {
         return
     }
     var children: MutableList<Int> = (tree)[root] as MutableList<Int>
@@ -16,8 +50,8 @@ fun binary_tree_mirror(binary_tree: MutableMap<Int, MutableList<Int>>, root: Int
     if (binary_tree.size == 0) {
         panic("binary tree cannot be empty")
     }
-    if (!(root in binary_tree)) {
-        panic(("root " + root.toString()) + " is not present in the binary_tree")
+    if (!(binary_tree.containsKey(root))) {
+        panic(("root " + _numToStr(root)) + " is not present in the binary_tree")
     }
     var tree_copy: MutableMap<Int, MutableList<Int>> = mutableMapOf<Int, MutableList<Int>>()
     for (k in binary_tree.keys) {
@@ -28,12 +62,24 @@ fun binary_tree_mirror(binary_tree: MutableMap<Int, MutableList<Int>>, root: Int
 }
 
 fun user_main(): Unit {
-    var binary_tree: MutableMap<Int, MutableList<Int>> = (mutableMapOf<Int, MutableList<Int>>(1 to (mutableListOf(2, 3)), 2 to (mutableListOf(4, 5)), 3 to (mutableListOf(6, 7)), 7 to (mutableListOf(8, 9))) as MutableMap<Int, MutableList<Int>>)
+    var binary_tree: MutableMap<Int, MutableList<Int>> = mutableMapOf<Int, MutableList<Int>>(1 to (mutableListOf(2, 3)), 2 to (mutableListOf(4, 5)), 3 to (mutableListOf(6, 7)), 7 to (mutableListOf(8, 9))) as MutableMap<Int, MutableList<Int>>
     println("Binary tree: " + binary_tree.toString())
     var mirrored: MutableMap<Int, MutableList<Int>> = binary_tree_mirror(binary_tree, 1)
     println("Binary tree mirror: " + mirrored.toString())
 }
 
 fun main() {
-    user_main()
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
 }

--- a/transpiler/x/kt/ALGORITHMS.md
+++ b/transpiler/x/kt/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Kotlin code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Kotlin`.
-Last updated: 2025-08-24 15:46 GMT+7
+Last updated: 2025-08-24 17:03 GMT+7
 
 ## Algorithms Golden Test Checklist (677/1077)
 | Index | Name | Status | Duration | Memory |
@@ -181,7 +181,7 @@ Last updated: 2025-08-24 15:46 GMT+7
 | 172 | data_structures/binary_tree/basic_binary_tree | ✓ | 9.61ms | 133.72KiB |
 | 173 | data_structures/binary_tree/binary_search_tree | error |  |  |
 | 174 | data_structures/binary_tree/binary_search_tree_recursive | error |  |  |
-| 175 | data_structures/binary_tree/binary_tree_mirror | ✓ | 28.59ms | 120.59KiB |
+| 175 | data_structures/binary_tree/binary_tree_mirror | ✓ | 21.38ms | 121.50KiB |
 | 176 | data_structures/binary_tree/binary_tree_node_sum | ✓ | 8.43ms | 134.14KiB |
 | 177 | data_structures/binary_tree/binary_tree_path_sum |   |  |  |
 | 178 | data_structures/binary_tree/diff_views_of_binary_tree | error |  |  |

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -1606,7 +1606,7 @@ func (b *BinaryExpr) emit(w io.Writer) {
 	}
 	if b.Op == "in" {
 		rType := guessType(b.Right)
-		if strings.HasPrefix(rType, "Map<") || strings.HasPrefix(rType, "MutableMap<") {
+		if strings.Contains(rType, "Map<") {
 			if _, ok := b.Right.(*BinaryExpr); ok {
 				io.WriteString(w, "(")
 				emitOperand(b.Right, b.Left)


### PR DESCRIPTION
## Summary
- handle map membership checks with `containsKey` in Kotlin emitter
- regenerate binary_tree_mirror Kotlin output with benchmarking data

## Testing
- `MOCHI_BENCHMARK=1 MOCHI_ALG_INDEX=175 ALGORITHMS_MAX=1 go test ./transpiler/x/kt -run TestKTTranspiler_Algorithms_Golden -update-algorithms-kt -count=1 -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_68aae28b1518832090fad8ed4caba52a