### PR TITLE
chore(lua): refresh algorithms progress

### DIFF
--- a/transpiler/x/lua/ALGORITHMS.md
+++ b/transpiler/x/lua/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Lua code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Lua`.
-Last updated: 2025-08-24 17:05 GMT+7
+Last updated: 2025-08-24 22:24 GMT+7
 
 ## Algorithms Golden Test Checklist (1054/1077)
 | Index | Name | Status | Duration | Memory |


### PR DESCRIPTION
## Summary
- refresh Lua algorithms progress metadata

## Testing
- `MOCHI_ALG_INDEX=225 go test -tags=slow ./transpiler/x/lua -run TestLuaTranspiler_Algorithms_Golden -count=1 -args -update-algorithms-lua`


------
https://chatgpt.com/codex/tasks/task_e_68ab2d0f6e8883209e8a628eaa1a717f