### PR TITLE
fs transpiler: handle int64 prints

### DIFF
--- a/tests/algorithms/transpiler/FS/data_structures/linked_list/doubly_linked_list.bench
+++ b/tests/algorithms/transpiler/FS/data_structures/linked_list/doubly_linked_list.bench
@@ -1,5 +1,5 @@
 {
   "duration_us": 571223,
-  "memory_bytes": 75192,
+  "memory_bytes": 38576,
   "name": "main"
 }

--- a/tests/algorithms/transpiler/FS/data_structures/linked_list/doubly_linked_list.fs
+++ b/tests/algorithms/transpiler/FS/data_structures/linked_list/doubly_linked_list.fs
@@ -1,4 +1,4 @@
-// Generated 2025-08-08 11:10 +0700
+// Generated 2025-08-24 22:16 +0700
 
 exception Break
 exception Continue
@@ -22,47 +22,40 @@ let _now () =
         int (System.DateTime.UtcNow.Ticks % 2147483647L)
 
 _initNow()
-let _dictAdd<'K,'V when 'K : equality> (d:System.Collections.Generic.IDictionary<'K,'V>) (k:'K) (v:'V) =
-    d.[k] <- v
-    d
-let _dictCreate<'K,'V when 'K : equality> (pairs:('K * 'V) list) : System.Collections.Generic.IDictionary<'K,'V> =
-    let d = System.Collections.Generic.Dictionary<'K, 'V>()
-    for (k, v) in pairs do
-        d.[k] <- v
-    upcast d
-let _dictGet<'K,'V when 'K : equality> (d:System.Collections.Generic.IDictionary<'K,'V>) (k:'K) : 'V =
-    match d.TryGetValue(k) with
-    | true, v -> v
-    | _ -> Unchecked.defaultof<'V>
 let _idx (arr:'a array) (i:int) : 'a =
     if not (obj.ReferenceEquals(arr, null)) && i >= 0 && i < arr.Length then arr.[i] else Unchecked.defaultof<'a>
 let rec _str v =
-    let s = sprintf "%A" v
-    s.Replace("[|", "[")
-     .Replace("|]", "]")
-     .Replace("; ", " ")
-     .Replace(";", "")
-     .Replace("\"", "")
+    match box v with
+    | :? float as f -> sprintf "%.10g" f
+    | :? int64 as n -> sprintf "%d" n
+    | _ ->
+        let s = sprintf "%A" v
+        s.Replace("[|", "[")
+         .Replace("|]", "]")
+         .Replace("; ", " ")
+         .Replace(";", "")
+         .Replace("L", "")
+         .Replace("\"", "")
 type DoublyLinkedList = {
-    mutable _data: int array
+    mutable _data: int64 array
 }
 type DeleteResult = {
     mutable _list: DoublyLinkedList
-    mutable _value: int
+    mutable _value: int64
 }
 let rec empty_list () =
     let mutable __ret : DoublyLinkedList = Unchecked.defaultof<DoublyLinkedList>
     try
-        __ret <- { _data = [||] }
+        __ret <- { _data = Array.empty<int64> }
         raise Return
         __ret
     with
         | Return -> __ret
 and length (_list: DoublyLinkedList) =
-    let mutable __ret : int = Unchecked.defaultof<int>
+    let mutable __ret : int64 = Unchecked.defaultof<int64>
     let mutable _list = _list
     try
-        __ret <- Seq.length (_list._data)
+        __ret <- int64 (Seq.length (_list._data))
         raise Return
         __ret
     with
@@ -83,74 +76,74 @@ and to_string (_list: DoublyLinkedList) =
         if (Seq.length (_list._data)) = 0 then
             __ret <- ""
             raise Return
-        let mutable s: string = _str (_idx (_list._data) (0))
-        let mutable i: int = 1
-        while i < (Seq.length (_list._data)) do
-            s <- (s + "->") + (_str (_idx (_list._data) (i)))
-            i <- i + 1
+        let mutable s: string = _str (_idx (_list._data) (int 0))
+        let mutable i: int64 = int64 1
+        while i < (int64 (Seq.length (_list._data))) do
+            s <- (s + "->") + (_str (_idx (_list._data) (int i)))
+            i <- i + (int64 1)
         __ret <- s
         raise Return
         __ret
     with
         | Return -> __ret
-and insert_nth (_list: DoublyLinkedList) (index: int) (_value: int) =
+and insert_nth (_list: DoublyLinkedList) (index: int64) (_value: int64) =
     let mutable __ret : DoublyLinkedList = Unchecked.defaultof<DoublyLinkedList>
     let mutable _list = _list
     let mutable index = index
     let mutable _value = _value
     try
-        if (index < 0) || (index > (Seq.length (_list._data))) then
-            failwith ("index out of range")
-        let mutable res: int array = [||]
-        let mutable i: int = 0
+        if (index < (int64 0)) || (index > (int64 (Seq.length (_list._data)))) then
+            ignore (failwith ("index out of range"))
+        let mutable res: int64 array = Array.empty<int64>
+        let mutable i: int64 = int64 0
         while i < index do
-            res <- Array.append res [|(_idx (_list._data) (i))|]
-            i <- i + 1
+            res <- Array.append res [|(_idx (_list._data) (int i))|]
+            i <- i + (int64 1)
         res <- Array.append res [|_value|]
-        while i < (Seq.length (_list._data)) do
-            res <- Array.append res [|(_idx (_list._data) (i))|]
-            i <- i + 1
+        while i < (int64 (Seq.length (_list._data))) do
+            res <- Array.append res [|(_idx (_list._data) (int i))|]
+            i <- i + (int64 1)
         __ret <- { _data = res }
         raise Return
         __ret
     with
         | Return -> __ret
-and insert_head (_list: DoublyLinkedList) (_value: int) =
+and insert_head (_list: DoublyLinkedList) (_value: int64) =
     let mutable __ret : DoublyLinkedList = Unchecked.defaultof<DoublyLinkedList>
     let mutable _list = _list
     let mutable _value = _value
     try
-        __ret <- insert_nth (_list) (0) (_value)
+        __ret <- insert_nth (_list) (int64 0) (_value)
         raise Return
         __ret
     with
         | Return -> __ret
-and insert_tail (_list: DoublyLinkedList) (_value: int) =
+and insert_tail (_list: DoublyLinkedList) (_value: int64) =
     let mutable __ret : DoublyLinkedList = Unchecked.defaultof<DoublyLinkedList>
     let mutable _list = _list
     let mutable _value = _value
     try
-        __ret <- insert_nth (_list) (Seq.length (_list._data)) (_value)
+        __ret <- insert_nth (_list) (int64 (Seq.length (_list._data))) (_value)
         raise Return
         __ret
     with
         | Return -> __ret
-and delete_nth (_list: DoublyLinkedList) (index: int) =
+and delete_nth (_list: DoublyLinkedList) (index: int64) =
     let mutable __ret : DeleteResult = Unchecked.defaultof<DeleteResult>
     let mutable _list = _list
     let mutable index = index
     try
-        if (index < 0) || (index >= (Seq.length (_list._data))) then
-            failwith ("index out of range")
-        let mutable res: int array = [||]
-        let mutable i: int = 0
-        let mutable removed: int = 0
-        while i < (Seq.length (_list._data)) do
+        if (index < (int64 0)) || (index >= (int64 (Seq.length (_list._data)))) then
+            ignore (failwith ("index out of range"))
+        let mutable res: int64 array = Array.empty<int64>
+        let mutable i: int64 = int64 0
+        let mutable removed: int64 = int64 0
+        while i < (int64 (Seq.length (_list._data))) do
             if i = index then
-                removed <- _idx (_list._data) (i)
+                removed <- _idx (_list._data) (int i)
             else
-                res <- Array.append res [|(_idx (_list._data) (i))|]
-            i <- i + 1
+                res <- Array.append res [|(_idx (_list._data) (int i))|]
+            i <- i + (int64 1)
         __ret <- { _list = { _data = res }; _value = removed }
         raise Return
         __ret
@@ -160,7 +153,7 @@ and delete_head (_list: DoublyLinkedList) =
     let mutable __ret : DeleteResult = Unchecked.defaultof<DeleteResult>
     let mutable _list = _list
     try
-        __ret <- delete_nth (_list) (0)
+        __ret <- delete_nth (_list) (int64 0)
         raise Return
         __ret
     with
@@ -169,25 +162,25 @@ and delete_tail (_list: DoublyLinkedList) =
     let mutable __ret : DeleteResult = Unchecked.defaultof<DeleteResult>
     let mutable _list = _list
     try
-        __ret <- delete_nth (_list) ((Seq.length (_list._data)) - 1)
+        __ret <- delete_nth (_list) (int64 ((Seq.length (_list._data)) - 1))
         raise Return
         __ret
     with
         | Return -> __ret
-and delete_value (_list: DoublyLinkedList) (_value: int) =
+and delete_value (_list: DoublyLinkedList) (_value: int64) =
     let mutable __ret : DeleteResult = Unchecked.defaultof<DeleteResult>
     let mutable _list = _list
     let mutable _value = _value
     try
-        let mutable idx: int = 0
+        let mutable idx: int64 = int64 0
         let mutable found: bool = false
         try
-            while idx < (Seq.length (_list._data)) do
+            while idx < (int64 (Seq.length (_list._data))) do
                 try
-                    if (_idx (_list._data) (idx)) = _value then
+                    if (_idx (_list._data) (int idx)) = _value then
                         found <- true
                         raise Break
-                    idx <- idx + 1
+                    idx <- idx + (int64 1)
                 with
                 | Continue -> ()
                 | Break -> raise Break
@@ -195,38 +188,38 @@ and delete_value (_list: DoublyLinkedList) (_value: int) =
         | Break -> ()
         | Continue -> ()
         if not found then
-            failwith ("value not found")
+            ignore (failwith ("value not found"))
         __ret <- delete_nth (_list) (idx)
         raise Return
         __ret
     with
         | Return -> __ret
 and main () =
-    let mutable __ret : unit = Unchecked.defaultof<unit>
+    let mutable __ret : obj = Unchecked.defaultof<obj>
     try
         let __bench_start = _now()
         let __mem_start = System.GC.GetTotalMemory(true)
         let mutable dll: DoublyLinkedList = empty_list()
-        dll <- insert_tail (dll) (1)
-        dll <- insert_tail (dll) (2)
-        dll <- insert_tail (dll) (3)
-        printfn "%s" (to_string (dll))
-        dll <- insert_head (dll) (0)
-        printfn "%s" (to_string (dll))
-        dll <- insert_nth (dll) (2) (9)
-        printfn "%s" (to_string (dll))
-        let mutable res: DeleteResult = delete_nth (dll) (2)
+        dll <- insert_tail (dll) (int64 1)
+        dll <- insert_tail (dll) (int64 2)
+        dll <- insert_tail (dll) (int64 3)
+        ignore (printfn "%s" (to_string (dll)))
+        dll <- insert_head (dll) (int64 0)
+        ignore (printfn "%s" (to_string (dll)))
+        dll <- insert_nth (dll) (int64 2) (int64 9)
+        ignore (printfn "%s" (to_string (dll)))
+        let mutable res: DeleteResult = delete_nth (dll) (int64 2)
         dll <- res._list
-        printfn "%d" (res._value)
-        printfn "%s" (to_string (dll))
+        ignore (printfn "%d" (res._value))
+        ignore (printfn "%s" (to_string (dll)))
         res <- delete_tail (dll)
         dll <- res._list
-        printfn "%d" (res._value)
-        printfn "%s" (to_string (dll))
-        res <- delete_value (dll) (1)
+        ignore (printfn "%d" (res._value))
+        ignore (printfn "%s" (to_string (dll)))
+        res <- delete_value (dll) (int64 1)
         dll <- res._list
-        printfn "%d" (res._value)
-        printfn "%s" (to_string (dll))
+        ignore (printfn "%d" (res._value))
+        ignore (printfn "%s" (to_string (dll)))
         let __bench_end = _now()
         let __mem_end = System.GC.GetTotalMemory(true)
         printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)
@@ -234,4 +227,4 @@ and main () =
         __ret
     with
         | Return -> __ret
-main()
+ignore (main())

--- a/transpiler/x/fs/ALGORITHMS.md
+++ b/transpiler/x/fs/ALGORITHMS.md
@@ -1,7 +1,7 @@
 # F# Algorithms Transpiler Output
 
 Completed programs: 951/1077
-Last updated: 2025-08-24 08:57 +0700
+Last updated: 2025-08-24 22:16 +0700
 
 Checklist:
 
@@ -231,7 +231,7 @@ Checklist:
 | 222 | data_structures/kd_tree/tests/test_kdtree | ✓ | 571.223ms | 32.8 KB |
 | 223 | data_structures/linked_list/circular_linked_list | ✓ | 571.223ms | 57.8 KB |
 | 224 | data_structures/linked_list/deque_doubly | ✓ | 571.223ms | 59.4 KB |
-| 225 | data_structures/linked_list/doubly_linked_list | ✓ | 571.223ms | 73.4 KB |
+| 225 | data_structures/linked_list/doubly_linked_list | ✓ | 571.223ms | 37.7 KB |
 | 226 | data_structures/linked_list/doubly_linked_list_two | ✓ | 571.223ms | 63.0 KB |
 | 227 | data_structures/linked_list/floyds_cycle_detection | ✓ | 571.223ms | 31.0 KB |
 | 228 | data_structures/linked_list/from_sequence | ✓ | 571.223ms | 60.6 KB |

--- a/transpiler/x/fs/transpiler.go
+++ b/transpiler/x/fs/transpiler.go
@@ -4999,7 +4999,7 @@ func convertPrimary(p *parser.Primary) (Expr, error) {
 				switch t {
 				case "bool":
 					return &CallExpr{Func: "printfn \"%b\"", Args: []Expr{args[0]}}, nil
-				case "int":
+				case "int", "int64":
 					return &CallExpr{Func: "printfn \"%d\"", Args: []Expr{args[0]}}, nil
 				case "float":
 					usesStr = true
@@ -5021,7 +5021,7 @@ func convertPrimary(p *parser.Primary) (Expr, error) {
 				switch inferType(a) {
 				case "bool":
 					elems[i] = &CallExpr{Func: "sprintf \"%b\"", Args: []Expr{a}}
-				case "int":
+				case "int", "int64":
 					elems[i] = &CallExpr{Func: "sprintf \"%d\"", Args: []Expr{a}}
 				case "float":
 					usesStr = true
@@ -5044,7 +5044,7 @@ func convertPrimary(p *parser.Primary) (Expr, error) {
 				case "bool":
 					b := &IfExpr{Cond: args[0], Then: &IntLit{Value: 1}, Else: &IntLit{Value: 0}}
 					return &CallExpr{Func: "printf \"%d\"", Args: []Expr{b}}, nil
-				case "int":
+				case "int", "int64":
 					return &CallExpr{Func: "printf \"%d\"", Args: []Expr{args[0]}}, nil
 				case "float":
 					usesStr = true
@@ -5066,7 +5066,7 @@ func convertPrimary(p *parser.Primary) (Expr, error) {
 				switch inferType(a) {
 				case "bool":
 					elems[i] = &CallExpr{Func: "sprintf \"%b\"", Args: []Expr{a}}
-				case "int":
+				case "int", "int64":
 					elems[i] = &CallExpr{Func: "sprintf \"%d\"", Args: []Expr{a}}
 				case "float":
 					elems[i] = &CallExpr{Func: "sprintf \"%g\"", Args: []Expr{a}}


### PR DESCRIPTION
## Summary
- handle int64 in F# transpiler print/stdout functions so values no longer keep `L` suffix
- regenerate doubly linked list algorithm artifacts and benchmarks
- refresh F# algorithms checklist

## Testing
- `MOCHI_ALGORITHMS_INDEX=225 go test -tags slow ./transpiler/x/fs -run TestFSTranspiler_Algorithms_Golden -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68ab2d0c8d7483208b2f51cbfb5ac8d4