### PR TITLE
php transpiler: support slicing struct fields

### DIFF
--- a/tests/algorithms/x/PHP/data_structures/linked_list/doubly_linked_list.bench
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/doubly_linked_list.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 95,
+  "duration_us": 117,
   "memory_bytes": 1656352,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/linked_list/doubly_linked_list_two.bench
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/doubly_linked_list_two.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 181,
-  "memory_bytes": 97720,
+  "duration_us": 202,
+  "memory_bytes": 1645224,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/linked_list/doubly_linked_list_two.php
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/doubly_linked_list_two.php
@@ -1,5 +1,21 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,24 +36,26 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function empty_list() {
-  return ['nodes' => [], 'head_idx' => -1, 'tail_idx' => -1];
-}
-function get_head_data($ll) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function empty_list() {
+  return ['head_idx' => -1, 'nodes' => [], 'tail_idx' => -1];
+};
+  function get_head_data($ll) {
   if ($ll['head_idx'] == (-1)) {
   return -1;
 }
   $node = $ll['nodes'][$ll['head_idx']];
   return $node['data'];
-}
-function get_tail_data($ll) {
+};
+  function get_tail_data($ll) {
   if ($ll['tail_idx'] == (-1)) {
   return -1;
 }
   $node = $ll['nodes'][$ll['tail_idx']];
   return $node['data'];
-}
-function insert_before_node(&$ll, $idx, $new_idx) {
+};
+  function insert_before_node(&$ll, $idx, $new_idx) {
   $nodes = $ll['nodes'];
   $new_node = $nodes[$new_idx];
   $new_node['next_index'] = $idx;
@@ -55,8 +73,8 @@ function insert_before_node(&$ll, $idx, $new_idx) {
   $node['prev_index'] = $new_idx;
   $nodes[$idx] = $node;
   $ll['nodes'] = $nodes;
-}
-function insert_after_node(&$ll, $idx, $new_idx) {
+};
+  function insert_after_node(&$ll, $idx, $new_idx) {
   $nodes = $ll['nodes'];
   $new_node = $nodes[$new_idx];
   $new_node['prev_index'] = $idx;
@@ -74,26 +92,26 @@ function insert_after_node(&$ll, $idx, $new_idx) {
   $node['next_index'] = $new_idx;
   $nodes[$idx] = $node;
   $ll['nodes'] = $nodes;
-}
-function set_head(&$ll, $idx) {
+};
+  function set_head(&$ll, $idx) {
   if ($ll['head_idx'] == (-1)) {
   $ll['head_idx'] = $idx;
   $ll['tail_idx'] = $idx;
 } else {
   insert_before_node($ll, $ll['head_idx'], $idx);
 }
-}
-function set_tail(&$ll, $idx) {
+};
+  function set_tail(&$ll, $idx) {
   if ($ll['tail_idx'] == (-1)) {
   $ll['head_idx'] = $idx;
   $ll['tail_idx'] = $idx;
 } else {
   insert_after_node($ll, $ll['tail_idx'], $idx);
 }
-}
-function insert(&$ll, $value) {
+};
+  function insert(&$ll, $value) {
   $nodes = $ll['nodes'];
-  $nodes = _append($nodes, ['data' => $value, 'prev_index' => -1, 'next_index' => -1]);
+  $nodes = _append($nodes, ['data' => $value, 'next_index' => -1, 'prev_index' => -1]);
   $idx = count($nodes) - 1;
   $ll['nodes'] = $nodes;
   if ($ll['head_idx'] == (-1)) {
@@ -102,14 +120,14 @@ function insert(&$ll, $value) {
 } else {
   insert_after_node($ll, $ll['tail_idx'], $idx);
 }
-}
-function insert_at_position(&$ll, $position, $value) {
+};
+  function insert_at_position(&$ll, $position, $value) {
   $current = $ll['head_idx'];
   $current_pos = 1;
   while ($current != (-1)) {
   if ($current_pos == $position) {
   $nodes = $ll['nodes'];
-  $nodes = _append($nodes, ['data' => $value, 'prev_index' => -1, 'next_index' => -1]);
+  $nodes = _append($nodes, ['data' => $value, 'next_index' => -1, 'prev_index' => -1]);
   $new_idx = count($nodes) - 1;
   $ll['nodes'] = $nodes;
   insert_before_node($ll, $current, $new_idx);
@@ -120,8 +138,8 @@ function insert_at_position(&$ll, $position, $value) {
   $current_pos = $current_pos + 1;
 };
   insert($ll, $value);
-}
-function get_node($ll, $item) {
+};
+  function get_node($ll, $item) {
   $current = $ll['head_idx'];
   while ($current != (-1)) {
   $node = $ll['nodes'][$current];
@@ -131,8 +149,8 @@ function get_node($ll, $item) {
   $current = $node['next_index'];
 };
   return -1;
-}
-function remove_node_pointers(&$ll, $idx) {
+};
+  function remove_node_pointers(&$ll, $idx) {
   $nodes = $ll['nodes'];
   $node = $nodes[$idx];
   $nxt = $node['next_index'];
@@ -151,8 +169,8 @@ function remove_node_pointers(&$ll, $idx) {
   $node['prev_index'] = -1;
   $nodes[$idx] = $node;
   $ll['nodes'] = $nodes;
-}
-function delete_value(&$ll, $value) {
+};
+  function delete_value(&$ll, $value) {
   $idx = get_node($ll, $value);
   if ($idx == (-1)) {
   return;
@@ -166,14 +184,14 @@ function delete_value(&$ll, $value) {
   $ll['tail_idx'] = $node['prev_index'];
 }
   remove_node_pointers($ll, $idx);
-}
-function contains($ll, $value) {
+};
+  function mochi_contains($ll, $value) {
   return get_node($ll, $value) != (-1);
-}
-function is_empty($ll) {
+};
+  function is_empty($ll) {
   return $ll['head_idx'] == (-1);
-}
-function to_string($ll) {
+};
+  function to_string($ll) {
   $res = '';
   $first = true;
   $current = $ll['head_idx'];
@@ -189,16 +207,16 @@ function to_string($ll) {
   $current = $node['next_index'];
 };
   return $res;
-}
-function print_list($ll) {
+};
+  function print_list($ll) {
   $current = $ll['head_idx'];
   while ($current != (-1)) {
   $node = $ll['nodes'][$current];
   echo rtrim(_str($node['data'])), PHP_EOL;
   $current = $node['next_index'];
 };
-}
-function main() {
+};
+  function main() {
   $ll = empty_list();
   echo rtrim(_str(get_head_data($ll))), PHP_EOL;
   echo rtrim(_str(get_tail_data($ll))), PHP_EOL;
@@ -210,21 +228,21 @@ function main() {
   echo rtrim(_str(get_head_data($ll))), PHP_EOL;
   echo rtrim(_str(get_tail_data($ll))), PHP_EOL;
   $nodes = $ll['nodes'];
-  $nodes = _append($nodes, ['data' => 1000, 'prev_index' => -1, 'next_index' => -1]);
+  $nodes = _append($nodes, ['data' => 1000, 'next_index' => -1, 'prev_index' => -1]);
   $idx_head = count($nodes) - 1;
   $ll['nodes'] = $nodes;
   set_head($ll, $idx_head);
   $nodes = $ll['nodes'];
-  $nodes = _append($nodes, ['data' => 2000, 'prev_index' => -1, 'next_index' => -1]);
+  $nodes = _append($nodes, ['data' => 2000, 'next_index' => -1, 'prev_index' => -1]);
   $idx_tail = count($nodes) - 1;
   $ll['nodes'] = $nodes;
   set_tail($ll, $idx_tail);
   print_list($ll);
   echo rtrim(_str(is_empty($ll))), PHP_EOL;
   print_list($ll);
-  echo rtrim(_str(contains($ll, 10))), PHP_EOL;
+  echo rtrim(_str(mochi_contains($ll, 10))), PHP_EOL;
   delete_value($ll, 10);
-  echo rtrim(_str(contains($ll, 10))), PHP_EOL;
+  echo rtrim(_str(mochi_contains($ll, 10))), PHP_EOL;
   delete_value($ll, 2000);
   echo rtrim(_str(get_tail_data($ll))), PHP_EOL;
   delete_value($ll, 1000);
@@ -250,5 +268,13 @@ function main() {
   echo rtrim(to_string($ll2)), PHP_EOL;
   insert_at_position($ll2, 5, 50);
   echo rtrim(to_string($ll2)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/linked_list/floyds_cycle_detection.bench
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/floyds_cycle_detection.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 85,
-  "memory_bytes": 37600,
+  "duration_us": 99,
+  "memory_bytes": 1677664,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/linked_list/floyds_cycle_detection.php
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/floyds_cycle_detection.php
@@ -1,21 +1,39 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-$NULL = 0 - 1;
-function empty_list() {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $NULL = 0 - 1;
+  function empty_list() {
   global $NULL;
-  return ['next' => [], 'head' => $NULL];
-}
-function add_node($list, $value) {
+  return ['head' => $NULL, 'next' => []];
+};
+  function add_node($list, $value) {
   global $NULL;
   $nexts = $list['next'];
   $new_index = count($nexts);
   $nexts = _append($nexts, $NULL);
   if ($list['head'] == $NULL) {
-  return ['next' => $nexts, 'head' => $new_index];
+  return ['head' => $new_index, 'next' => $nexts];
 }
   $last = $list['head'];
   while ($nexts[$last] != $NULL) {
@@ -31,9 +49,9 @@ function add_node($list, $value) {
 }
   $i = $i + 1;
 };
-  return ['next' => $new_nexts, 'head' => $list['head']];
-}
-function set_next($list, $index, $next_index) {
+  return ['head' => $list['head'], 'next' => $new_nexts];
+};
+  function set_next($list, $index, $next_index) {
   global $NULL;
   $nexts = $list['next'];
   $new_nexts = [];
@@ -46,9 +64,9 @@ function set_next($list, $index, $next_index) {
 }
   $i = $i + 1;
 };
-  return ['next' => $new_nexts, 'head' => $list['head']];
-}
-function detect_cycle($list) {
+  return ['head' => $list['head'], 'next' => $new_nexts];
+};
+  function detect_cycle($list) {
   global $NULL;
   if ($list['head'] == $NULL) {
   return false;
@@ -64,8 +82,8 @@ function detect_cycle($list) {
 }
 };
   return false;
-}
-function main() {
+};
+  function main() {
   global $NULL;
   $ll = empty_list();
   $ll = add_node($ll, 1);
@@ -74,5 +92,13 @@ function main() {
   $ll = add_node($ll, 4);
   $ll = set_next($ll, 3, 1);
   echo rtrim(json_encode(detect_cycle($ll), 1344)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/linked_list/from_sequence.bench
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/from_sequence.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 132,
-  "memory_bytes": 37872,
+  "duration_us": 552,
+  "memory_bytes": 1676672,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/linked_list/from_sequence.php
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/from_sequence.php
@@ -1,5 +1,21 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,12 +36,18 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-$NIL = 0 - 1;
-$nodes = [];
-function make_linked_list($elements) {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $NIL = 0 - 1;
+  $nodes = [];
+  function make_linked_list($elements) {
   global $NIL, $nodes;
   if (count($elements) == 0) {
-  $panic('The Elements List is empty');
+  _panic('The Elements List is empty');
 }
   $nodes = [];
   $nodes = _append($nodes, ['data' => $elements[0], 'next' => $NIL]);
@@ -39,8 +61,8 @@ function make_linked_list($elements) {
   $i = $i + 1;
 };
   return $head;
-}
-function node_to_string($head) {
+};
+  function node_to_string($head) {
   global $NIL, $nodes;
   $s = '';
   $index = $head;
@@ -51,8 +73,8 @@ function node_to_string($head) {
 };
   $s = $s . '<END>';
   return $s;
-}
-function main() {
+};
+  function main() {
   global $NIL, $nodes;
   $list_data = [1, 3, 5, 32, 44, 12, 43];
   echo rtrim('List: ' . _str($list_data)), PHP_EOL;
@@ -60,5 +82,13 @@ function main() {
   $head = make_linked_list($list_data);
   echo rtrim('Linked List:'), PHP_EOL;
   echo rtrim(node_to_string($head)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/linked_list/has_loop.bench
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/has_loop.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 84,
-  "memory_bytes": 35960,
+  "duration_us": 123,
+  "memory_bytes": 1676720,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/linked_list/has_loop.php
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/has_loop.php
@@ -1,5 +1,21 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,7 +36,9 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function has_loop($nodes, $head) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function has_loop($nodes, $head) {
   $slow = $head;
   $fast = $head;
   while ($fast != 0 - 1) {
@@ -40,8 +58,8 @@ function has_loop($nodes, $head) {
 }
 };
   return false;
-}
-function make_nodes($values) {
+};
+  function make_nodes($values) {
   $nodes = [];
   $i = 0;
   while ($i < count($values)) {
@@ -50,8 +68,8 @@ function make_nodes($values) {
   $i = $i + 1;
 };
   return $nodes;
-}
-function main() {
+};
+  function main() {
   $list1 = make_nodes([1, 2, 3, 4]);
   echo rtrim(_str(has_loop($list1, 0))), PHP_EOL;
   $list1[3]['next'] = 1;
@@ -60,5 +78,13 @@ function main() {
   echo rtrim(_str(has_loop($list2, 0))), PHP_EOL;
   $list3 = make_nodes([1]);
   echo rtrim(_str(has_loop($list3, 0))), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/linked_list/is_palindrome.bench
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/is_palindrome.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 76,
-  "memory_bytes": 35168,
+  "duration_us": 100,
+  "memory_bytes": 1681376,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/linked_list/is_palindrome.php
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/is_palindrome.php
@@ -1,10 +1,28 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function is_palindrome($values) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function is_palindrome($values) {
   $stack = [];
   $fast = 0;
   $slow = 0;
@@ -26,12 +44,20 @@ function is_palindrome($values) {
   $slow = $slow + 1;
 };
   return true;
-}
-function main() {
+};
+  function main() {
   echo rtrim(json_encode(is_palindrome([]), 1344)), PHP_EOL;
   echo rtrim(json_encode(is_palindrome([1]), 1344)), PHP_EOL;
   echo rtrim(json_encode(is_palindrome([1, 2]), 1344)), PHP_EOL;
   echo rtrim(json_encode(is_palindrome([1, 2, 1]), 1344)), PHP_EOL;
   echo rtrim(json_encode(is_palindrome([1, 2, 2, 1]), 1344)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/linked_list/merge_two_lists.bench
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/merge_two_lists.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 145,
-  "memory_bytes": 38176,
+  "duration_us": 173,
+  "memory_bytes": 1672464,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/linked_list/merge_two_lists.php
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/merge_two_lists.php
@@ -1,6 +1,23 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _len($x) {
+    if ($x === null) { return 0; }
     if (is_array($x)) { return count($x); }
     if (is_string($x)) { return strlen($x); }
     return strlen(strval($x));
@@ -25,7 +42,9 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function sort_list($nums) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function sort_list($nums) {
   $arr = [];
   $i = 0;
   while ($i < count($nums)) {
@@ -46,14 +65,14 @@ function sort_list($nums) {
   $j = $j + 1;
 };
   return $arr;
-}
-function make_sorted_linked_list($ints) {
+};
+  function make_sorted_linked_list($ints) {
   return ['values' => sort_list($ints)];
-}
-function len_sll($sll) {
+};
+  function len_sll($sll) {
   return _len($sll['values']);
-}
-function str_sll($sll) {
+};
+  function str_sll($sll) {
   $res = '';
   $i = 0;
   while ($i < _len($sll['values'])) {
@@ -64,22 +83,22 @@ function str_sll($sll) {
   $i = $i + 1;
 };
   return $res;
-}
-function merge_lists($a, $b) {
+};
+  function merge_lists($a, $b) {
   $combined = [];
   $i = 0;
   while ($i < _len($a['values'])) {
-  $combined = _append($combined, $a[$values][$i]);
+  $combined = _append($combined, $a['values'][$i]);
   $i = $i + 1;
 };
   $i = 0;
   while ($i < _len($b['values'])) {
-  $combined = _append($combined, $b[$values][$i]);
+  $combined = _append($combined, $b['values'][$i]);
   $i = $i + 1;
 };
   return make_sorted_linked_list($combined);
-}
-function main() {
+};
+  function main() {
   $test_data_odd = [3, 9, -11, 0, 7, 5, 1, -1];
   $test_data_even = [4, 6, 2, 0, 8, 10, 3, -2];
   $sll_one = make_sorted_linked_list($test_data_odd);
@@ -87,5 +106,13 @@ function main() {
   $merged = merge_lists($sll_one, $sll_two);
   echo rtrim(_str(len_sll($merged))), PHP_EOL;
   echo rtrim(str_sll($merged)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/linked_list/middle_element_of_linked_list.bench
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/middle_element_of_linked_list.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 105,
-  "memory_bytes": 37704,
+  "duration_us": 102,
+  "memory_bytes": 1673736,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/linked_list/middle_element_of_linked_list.php
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/middle_element_of_linked_list.php
@@ -1,6 +1,23 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _len($x) {
+    if ($x === null) { return 0; }
     if (is_array($x)) { return count($x); }
     if (is_string($x)) { return strlen($x); }
     return strlen(strval($x));
@@ -9,10 +26,12 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function empty_list() {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function empty_list() {
   return ['data' => []];
-}
-function push($lst, $value) {
+};
+  function push($lst, $value) {
   $res = [$value];
   $i = 0;
   while ($i < _len($lst['data'])) {
@@ -20,8 +39,8 @@ function push($lst, $value) {
   $i = $i + 1;
 };
   return ['data' => $res];
-}
-function middle_element($lst) {
+};
+  function middle_element($lst) {
   $n = _len($lst['data']);
   if ($n == 0) {
   echo rtrim('No element found.'), PHP_EOL;
@@ -34,8 +53,8 @@ function middle_element($lst) {
   $slow = $slow + 1;
 };
   return $lst['data'][$slow];
-}
-function main() {
+};
+  function main() {
   $lst = empty_list();
   middle_element($lst);
   $lst = push($lst, 5);
@@ -61,5 +80,13 @@ function main() {
   $lst = push($lst, -20);
   echo rtrim(json_encode(-20, 1344)), PHP_EOL;
   echo rtrim(json_encode(middle_element($lst), 1344)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/linked_list/print_reverse.bench
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/print_reverse.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 80,
-  "memory_bytes": 38336,
+  "duration_us": 95,
+  "memory_bytes": 1673504,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/linked_list/print_reverse.php
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/print_reverse.php
@@ -1,6 +1,23 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _len($x) {
+    if ($x === null) { return 0; }
     if (is_array($x)) { return count($x); }
     if (is_string($x)) { return strlen($x); }
     return strlen(strval($x));
@@ -25,15 +42,21 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function empty_list() {
-  return ['data' => []];
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
 }
-function append_value($list, $value) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function empty_list() {
+  return ['data' => []];
+};
+  function append_value($list, $value) {
   $d = $list['data'];
   $d = _append($d, $value);
   return ['data' => $d];
-}
-function extend_list($list, $items) {
+};
+  function extend_list($list, $items) {
   $result = $list;
   $i = 0;
   while ($i < count($items)) {
@@ -41,8 +64,8 @@ function extend_list($list, $items) {
   $i = $i + 1;
 };
   return $result;
-}
-function to_string($list) {
+};
+  function to_string($list) {
   if (_len($list['data']) == 0) {
   return '';
 }
@@ -53,16 +76,16 @@ function to_string($list) {
   $i = $i + 1;
 };
   return $s;
-}
-function make_linked_list($items) {
+};
+  function make_linked_list($items) {
   if (count($items) == 0) {
-  $panic('The Elements List is empty');
+  _panic('The Elements List is empty');
 }
   $ll = empty_list();
   $ll = extend_list($ll, $items);
   return $ll;
-}
-function in_reverse($list) {
+};
+  function in_reverse($list) {
   if (_len($list['data']) == 0) {
   return '';
 }
@@ -74,10 +97,18 @@ function in_reverse($list) {
   $i = $i - 1;
 };
   return $s;
-}
-function main() {
+};
+  function main() {
   $linked_list = make_linked_list([14, 52, 14, 12, 43]);
   echo rtrim('Linked List:  ' . to_string($linked_list)), PHP_EOL;
   echo rtrim('Reverse List: ' . in_reverse($linked_list)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/linked_list/reverse_k_group.bench
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/reverse_k_group.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 74,
-  "memory_bytes": 39328,
+  "duration_us": 124,
+  "memory_bytes": 1674760,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/linked_list/reverse_k_group.php
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/reverse_k_group.php
@@ -1,6 +1,23 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _len($x) {
+    if ($x === null) { return 0; }
     if (is_array($x)) { return count($x); }
     if (is_string($x)) { return strlen($x); }
     return strlen(strval($x));
@@ -25,7 +42,9 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function to_string($list) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function to_string($list) {
   if (_len($list['data']) == 0) {
   return '';
 }
@@ -36,8 +55,8 @@ function to_string($list) {
   $i = $i + 1;
 };
   return $s;
-}
-function reverse_k_nodes($list, $k) {
+};
+  function reverse_k_nodes($list, $k) {
   if ($k <= 1) {
   return $list;
 }
@@ -66,12 +85,20 @@ function reverse_k_nodes($list, $k) {
   $i = $i + $k;
 };
   return ['data' => $res];
-}
-function main() {
+};
+  function main() {
   $ll = ['data' => [1, 2, 3, 4, 5]];
   echo rtrim('Original Linked List: ' . to_string($ll)), PHP_EOL;
   $k = 2;
   $ll = reverse_k_nodes($ll, $k);
   echo rtrim('After reversing groups of size ' . _str($k) . ': ' . to_string($ll)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/linked_list/rotate_to_the_right.bench
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/rotate_to_the_right.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 100,
-  "memory_bytes": 35792,
+  "duration_us": 112,
+  "memory_bytes": 1675336,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/linked_list/rotate_to_the_right.php
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/rotate_to_the_right.php
@@ -1,5 +1,21 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,7 +36,13 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function list_to_string($xs) {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function list_to_string($xs) {
   if (count($xs) == 0) {
   return '';
 }
@@ -31,13 +53,13 @@ function list_to_string($xs) {
   $i = $i + 1;
 };
   return $s;
-}
-function insert_node($xs, $data) {
+};
+  function insert_node($xs, $data) {
   return _append($xs, $data);
-}
-function rotate_to_the_right($xs, $places) {
+};
+  function rotate_to_the_right($xs, $places) {
   if (count($xs) == 0) {
-  $panic('The linked list is empty.');
+  _panic('The linked list is empty.');
 }
   $n = count($xs);
   $k = $places % $n;
@@ -57,8 +79,8 @@ function rotate_to_the_right($xs, $places) {
   $j = $j + 1;
 };
   return $res;
-}
-function main() {
+};
+  function main() {
   $head = [];
   $head = insert_node($head, 5);
   $head = insert_node($head, 1);
@@ -69,5 +91,13 @@ function main() {
   $places = 3;
   $new_head = rotate_to_the_right($head, $places);
   echo rtrim('After ' . _str($places) . ' iterations: ' . list_to_string($new_head)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/linked_list/singly_linked_list.bench
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/singly_linked_list.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 94,
-  "memory_bytes": 72472,
+  "duration_us": 389,
+  "memory_bytes": 1653800,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/linked_list/singly_linked_list.php
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/singly_linked_list.php
@@ -1,6 +1,23 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _len($x) {
+    if ($x === null) { return 0; }
     if (is_array($x)) { return count($x); }
     if (is_string($x)) { return strlen($x); }
     return strlen(strval($x));
@@ -25,16 +42,22 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function empty_list() {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function empty_list() {
   return ['data' => []];
-}
-function length($list) {
+};
+  function length($list) {
   return _len($list['data']);
-}
-function is_empty($list) {
+};
+  function is_empty($list) {
   return _len($list['data']) == 0;
-}
-function to_string($list) {
+};
+  function to_string($list) {
   if (_len($list['data']) == 0) {
   return '';
 }
@@ -45,10 +68,10 @@ function to_string($list) {
   $i = $i + 1;
 };
   return $s;
-}
-function insert_nth($list, $index, $value) {
+};
+  function insert_nth($list, $index, $value) {
   if ($index < 0 || $index > _len($list['data'])) {
-  $panic('index out of range');
+  _panic('index out of range');
 }
   $res = [];
   $i = 0;
@@ -62,16 +85,16 @@ function insert_nth($list, $index, $value) {
   $i = $i + 1;
 };
   return ['data' => $res];
-}
-function insert_head($list, $value) {
+};
+  function insert_head($list, $value) {
   return insert_nth($list, 0, $value);
-}
-function insert_tail($list, $value) {
+};
+  function insert_tail($list, $value) {
   return insert_nth($list, _len($list['data']), $value);
-}
-function delete_nth($list, $index) {
+};
+  function delete_nth($list, $index) {
   if ($index < 0 || $index >= _len($list['data'])) {
-  $panic('index out of range');
+  _panic('index out of range');
 }
   $res = [];
   $val = 0;
@@ -85,22 +108,22 @@ function delete_nth($list, $index) {
   $i = $i + 1;
 };
   return ['list' => ['data' => $res], 'value' => $val];
-}
-function delete_head($list) {
+};
+  function delete_head($list) {
   return delete_nth($list, 0);
-}
-function delete_tail($list) {
+};
+  function delete_tail($list) {
   return delete_nth($list, _len($list['data']) - 1);
-}
-function get_item($list, $index) {
+};
+  function get_item($list, $index) {
   if ($index < 0 || $index >= _len($list['data'])) {
-  $panic('index out of range');
+  _panic('index out of range');
 }
   return $list['data'][$index];
-}
-function set_item($list, $index, $value) {
+};
+  function set_item($list, $index, $value) {
   if ($index < 0 || $index >= _len($list['data'])) {
-  $panic('index out of range');
+  _panic('index out of range');
 }
   $res = [];
   $i = 0;
@@ -113,8 +136,8 @@ function set_item($list, $index, $value) {
   $i = $i + 1;
 };
   return ['data' => $res];
-}
-function reverse_list($list) {
+};
+  function reverse_list($list) {
   $res = [];
   $i = _len($list['data']) - 1;
   while ($i >= 0) {
@@ -122,8 +145,8 @@ function reverse_list($list) {
   $i = $i - 1;
 };
   return ['data' => $res];
-}
-function main() {
+};
+  function main() {
   $lst = empty_list();
   $i = 1;
   while ($i <= 5) {
@@ -146,5 +169,13 @@ function main() {
   echo rtrim(_str(get_item($lst, 1))), PHP_EOL;
   $lst = reverse_list($lst);
   echo rtrim(to_string($lst)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/linked_list/skip_list.bench
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/skip_list.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 109,
-  "memory_bytes": 74408,
+  "duration_us": 181,
+  "memory_bytes": 1657768,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/linked_list/skip_list.php
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/skip_list.php
@@ -1,5 +1,21 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,25 +36,27 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-$NIL = 0 - 1;
-$MAX_LEVEL = 6;
-$P = 0.5;
-$seed = 1;
-function random() {
-  global $NIL, $MAX_LEVEL, $P, $seed, $node_keys, $node_vals, $node_forwards, $level;
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $NIL = 0 - 1;
+  $MAX_LEVEL = 6;
+  $P = 0.5;
+  $seed = 1;
+  function random() {
+  global $MAX_LEVEL, $NIL, $P, $level, $node_forwards, $node_keys, $node_vals, $seed;
   $seed = ($seed * 13 + 7) % 100;
   return (floatval($seed)) / 100.0;
-}
-function random_level() {
-  global $NIL, $MAX_LEVEL, $P, $seed, $node_keys, $node_vals, $node_forwards, $level;
+};
+  function random_level() {
+  global $MAX_LEVEL, $NIL, $P, $level, $node_forwards, $node_keys, $node_vals, $seed;
   $lvl = 1;
   while (random() < $P && $lvl < $MAX_LEVEL) {
   $lvl = $lvl + 1;
 };
   return $lvl;
-}
-function empty_forward() {
-  global $NIL, $MAX_LEVEL, $P, $seed, $node_keys, $node_vals, $node_forwards, $level;
+};
+  function empty_forward() {
+  global $MAX_LEVEL, $NIL, $P, $level, $node_forwards, $node_keys, $node_vals, $seed;
   $f = [];
   $i = 0;
   while ($i < $MAX_LEVEL) {
@@ -46,20 +64,20 @@ function empty_forward() {
   $i = $i + 1;
 };
   return $f;
-}
-$node_keys = [];
-$node_vals = [];
-$node_forwards = [];
-$level = 1;
-function init() {
-  global $NIL, $MAX_LEVEL, $P, $seed, $node_keys, $node_vals, $node_forwards, $level;
+};
+  $node_keys = [];
+  $node_vals = [];
+  $node_forwards = [];
+  $level = 1;
+  function init() {
+  global $MAX_LEVEL, $NIL, $P, $level, $node_forwards, $node_keys, $node_vals, $seed;
   $node_keys = [-1];
   $node_vals = [0];
   $node_forwards = [empty_forward()];
   $level = 1;
-}
-function insert($key, $value) {
-  global $NIL, $MAX_LEVEL, $P, $seed, $node_keys, $node_vals, $node_forwards, $level;
+};
+  function insert($key, $value) {
+  global $MAX_LEVEL, $NIL, $P, $level, $node_forwards, $node_keys, $node_vals, $seed;
   $update = [];
   $i = 0;
   while ($i < $MAX_LEVEL) {
@@ -100,9 +118,9 @@ function insert($key, $value) {
   $i = $i + 1;
 };
   $node_forwards = _append($node_forwards, $forwards);
-}
-function find($key) {
-  global $NIL, $MAX_LEVEL, $P, $seed, $node_keys, $node_vals, $node_forwards, $level;
+};
+  function find($key) {
+  global $MAX_LEVEL, $NIL, $P, $level, $node_forwards, $node_keys, $node_vals, $seed;
   $x = 0;
   $i = $level - 1;
   while ($i >= 0) {
@@ -116,9 +134,9 @@ function find($key) {
   return $node_vals[$x];
 }
   return -1;
-}
-function delete($key) {
-  global $NIL, $MAX_LEVEL, $P, $seed, $node_keys, $node_vals, $node_forwards, $level;
+};
+  function delete($key) {
+  global $MAX_LEVEL, $NIL, $P, $level, $node_forwards, $node_keys, $node_vals, $seed;
   $update = [];
   $i = 0;
   while ($i < $MAX_LEVEL) {
@@ -148,9 +166,9 @@ function delete($key) {
   while ($level > 1 && $node_forwards[0][$level - 1] == $NIL) {
   $level = $level - 1;
 };
-}
-function to_string() {
-  global $NIL, $MAX_LEVEL, $P, $seed, $node_keys, $node_vals, $node_forwards, $level;
+};
+  function to_string() {
+  global $MAX_LEVEL, $NIL, $P, $level, $node_forwards, $node_keys, $node_vals, $seed;
   $s = '';
   $x = $node_forwards[0][0];
   while ($x != $NIL) {
@@ -161,9 +179,9 @@ function to_string() {
   $x = $node_forwards[$x][0];
 };
   return $s;
-}
-function main() {
-  global $NIL, $MAX_LEVEL, $P, $seed, $node_keys, $node_vals, $node_forwards, $level;
+};
+  function main() {
+  global $MAX_LEVEL, $NIL, $P, $level, $node_forwards, $node_keys, $node_vals, $seed;
   init();
   insert(2, 2);
   insert(4, 4);
@@ -173,5 +191,13 @@ function main() {
   insert(9, 4);
   delete(4);
   echo rtrim(to_string()), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/linked_list/swap_nodes.bench
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/swap_nodes.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 99,
-  "memory_bytes": 37968,
+  "duration_us": 247,
+  "memory_bytes": 1676168,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/linked_list/swap_nodes.php
+++ b/tests/algorithms/x/PHP/data_structures/linked_list/swap_nodes.php
@@ -1,6 +1,23 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _len($x) {
+    if ($x === null) { return 0; }
     if (is_array($x)) { return count($x); }
     if (is_string($x)) { return strlen($x); }
     return strlen(strval($x));
@@ -21,15 +38,17 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-function empty_list() {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function empty_list() {
   return ['data' => []];
-}
-function push($list, $value) {
+};
+  function push($list, $value) {
   $res = [$value];
   $res = array_merge($res, $list['data']);
   return ['data' => $res];
-}
-function swap_nodes($list, $v1, $v2) {
+};
+  function swap_nodes($list, $v1, $v2) {
   if ($v1 == $v2) {
   return $list;
 }
@@ -53,11 +72,11 @@ function swap_nodes($list, $v1, $v2) {
   $res[$idx1] = $res[$idx2];
   $res[$idx2] = $temp;
   return ['data' => $res];
-}
-function to_string($list) {
+};
+  function to_string($list) {
   return _str($list['data']);
-}
-function main() {
+};
+  function main() {
   $ll = empty_list();
   $i = 5;
   while ($i > 0) {
@@ -68,5 +87,13 @@ function main() {
   $ll = swap_nodes($ll, 1, 4);
   echo rtrim('Modified Linked List: ' . to_string($ll)), PHP_EOL;
   echo rtrim('After swapping the nodes whose data is 1 and 4.'), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/queues/circular_queue.bench
+++ b/tests/algorithms/x/PHP/data_structures/queues/circular_queue.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 98,
-  "memory_bytes": 41344,
+  "duration_us": 259,
+  "memory_bytes": 1675800,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/queues/circular_queue.php
+++ b/tests/algorithms/x/PHP/data_structures/queues/circular_queue.php
@@ -1,33 +1,55 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function create_queue($capacity) {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function create_queue($capacity) {
   $arr = [];
   $i = 0;
   while ($i < $capacity) {
   $arr = _append($arr, 0);
   $i = $i + 1;
 };
-  return ['data' => $arr, 'front' => 0, 'rear' => 0, 'size' => 0, 'capacity' => $capacity];
-}
-function length($q) {
+  return ['capacity' => $capacity, 'data' => $arr, 'front' => 0, 'rear' => 0, 'size' => 0];
+};
+  function length($q) {
   return $q['size'];
-}
-function is_empty($q) {
+};
+  function is_empty($q) {
   return $q['size'] == 0;
-}
-function front($q) {
+};
+  function front($q) {
   if (is_empty($q)) {
   return 0;
 }
   return $q['data'][$q['front']];
-}
-function enqueue(&$q, $value) {
+};
+  function enqueue($q, $value) {
   if ($q['size'] >= $q['capacity']) {
-  $panic('QUEUE IS FULL');
+  _panic('QUEUE IS FULL');
 }
   $arr = $q['data'];
   $arr[$q['rear']] = $value;
@@ -35,10 +57,10 @@ function enqueue(&$q, $value) {
   $q['rear'] = fmod(($q['rear'] + 1), $q['capacity']);
   $q['size'] = $q['size'] + 1;
   return $q;
-}
-function dequeue(&$q) {
+};
+  function dequeue(&$q) {
   if ($q['size'] == 0) {
-  $panic('UNDERFLOW');
+  _panic('UNDERFLOW');
 }
   $value = $q['data'][$q['front']];
   $arr2 = $q['data'];
@@ -47,8 +69,8 @@ function dequeue(&$q) {
   $q['front'] = fmod(($q['front'] + 1), $q['capacity']);
   $q['size'] = $q['size'] - 1;
   return ['queue' => $q, 'value' => $value];
-}
-function main() {
+};
+  function main() {
   $q = create_queue(5);
   echo rtrim(json_encode(is_empty($q), 1344)), PHP_EOL;
   $q = enqueue($q, 10);
@@ -61,5 +83,13 @@ function main() {
   echo rtrim(json_encode($r['value'], 1344)), PHP_EOL;
   echo rtrim(json_encode(front($q), 1344)), PHP_EOL;
   echo rtrim(json_encode(length($q), 1344)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/queues/circular_queue_linked_list.bench
+++ b/tests/algorithms/x/PHP/data_structures/queues/circular_queue_linked_list.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 132,
-  "memory_bytes": 42592,
+  "duration_us": 127,
+  "memory_bytes": 1670912,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/queues/double_ended_queue.bench
+++ b/tests/algorithms/x/PHP/data_structures/queues/double_ended_queue.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 135,
-  "memory_bytes": 42648,
+  "duration_us": 141,
+  "memory_bytes": 1664336,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/queues/double_ended_queue.php
+++ b/tests/algorithms/x/PHP/data_structures/queues/double_ended_queue.php
@@ -1,6 +1,23 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _len($x) {
+    if ($x === null) { return 0; }
     if (is_array($x)) { return count($x); }
     if (is_string($x)) { return strlen($x); }
     return strlen(strval($x));
@@ -25,13 +42,19 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function empty_deque() {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function empty_deque() {
   return ['data' => []];
-}
-function push_back($dq, $value) {
+};
+  function push_back($dq, $value) {
   return ['data' => _append($dq['data'], $value)];
-}
-function push_front($dq, $value) {
+};
+  function push_front($dq, $value) {
   $res = [$value];
   $i = 0;
   while ($i < _len($dq['data'])) {
@@ -39,8 +62,8 @@ function push_front($dq, $value) {
   $i = $i + 1;
 };
   return ['data' => $res];
-}
-function extend_back($dq, $values) {
+};
+  function extend_back($dq, $values) {
   $res = $dq['data'];
   $i = 0;
   while ($i < count($values)) {
@@ -48,8 +71,8 @@ function extend_back($dq, $values) {
   $i = $i + 1;
 };
   return ['data' => $res];
-}
-function extend_front($dq, $values) {
+};
+  function extend_front($dq, $values) {
   $res = [];
   $i = count($values) - 1;
   while ($i >= 0) {
@@ -62,10 +85,10 @@ function extend_front($dq, $values) {
   $j = $j + 1;
 };
   return ['data' => $res];
-}
-function pop_back($dq) {
+};
+  function pop_back($dq) {
   if (_len($dq['data']) == 0) {
-  $panic('pop from empty deque');
+  _panic('pop from empty deque');
 }
   $res = [];
   $i = 0;
@@ -74,10 +97,10 @@ function pop_back($dq) {
   $i = $i + 1;
 };
   return ['deque' => ['data' => $res], 'value' => $dq['data'][_len($dq['data']) - 1]];
-}
-function pop_front($dq) {
+};
+  function pop_front($dq) {
   if (_len($dq['data']) == 0) {
-  $panic('popleft from empty deque');
+  _panic('popleft from empty deque');
 }
   $res = [];
   $i = 1;
@@ -86,14 +109,14 @@ function pop_front($dq) {
   $i = $i + 1;
 };
   return ['deque' => ['data' => $res], 'value' => $dq['data'][0]];
-}
-function is_empty($dq) {
+};
+  function is_empty($dq) {
   return _len($dq['data']) == 0;
-}
-function length($dq) {
+};
+  function length($dq) {
   return _len($dq['data']);
-}
-function to_string($dq) {
+};
+  function to_string($dq) {
   if (_len($dq['data']) == 0) {
   return '[]';
 }
@@ -104,8 +127,8 @@ function to_string($dq) {
   $i = $i + 1;
 };
   return $s . ']';
-}
-function main() {
+};
+  function main() {
   $dq = empty_deque();
   $dq = push_back($dq, 2);
   $dq = push_front($dq, 1);
@@ -120,5 +143,13 @@ function main() {
   echo rtrim(json_encode($r['value'], 1344)), PHP_EOL;
   echo rtrim(to_string($dq)), PHP_EOL;
   echo rtrim(json_encode(is_empty(empty_deque()), 1344)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/queues/linked_queue.bench
+++ b/tests/algorithms/x/PHP/data_structures/queues/linked_queue.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 117,
-  "memory_bytes": 38104,
+  "duration_us": 156,
+  "memory_bytes": 1667736,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/queues/linked_queue.php
+++ b/tests/algorithms/x/PHP/data_structures/queues/linked_queue.php
@@ -1,6 +1,23 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _len($x) {
+    if ($x === null) { return 0; }
     if (is_array($x)) { return count($x); }
     if (is_string($x)) { return strlen($x); }
     return strlen(strval($x));
@@ -25,15 +42,21 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function new_queue() {
-  global $queue;
-  return ['nodes' => [], 'front' => 0 - 1, 'rear' => 0 - 1];
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
 }
-function is_empty($q) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function new_queue() {
+  global $queue;
+  return ['front' => 0 - 1, 'nodes' => [], 'rear' => 0 - 1];
+};
+  function is_empty($q) {
   global $queue;
   return $q['front'] == 0 - 1;
-}
-function put(&$q, $item) {
+};
+  function put(&$q, $item) {
   global $queue;
   $node = ['data' => $item, 'next' => 0 - 1];
   $q['nodes'] = _append($q['nodes'], $node);
@@ -47,11 +70,11 @@ function put(&$q, $item) {
   $q['nodes'] = $nodes;
   $q['rear'] = $idx;
 }
-}
-function get(&$q) {
+};
+  function get(&$q) {
   global $queue;
   if (is_empty($q)) {
-  $panic('dequeue from empty queue');
+  _panic('dequeue from empty queue');
 }
   $idx = $q['front'];
   $node = $q['nodes'][$idx];
@@ -60,8 +83,8 @@ function get(&$q) {
   $q['rear'] = 0 - 1;
 }
   return $node['data'];
-}
-function length($q) {
+};
+  function length($q) {
   global $queue;
   $count = 0;
   $idx = $q['front'];
@@ -70,8 +93,8 @@ function length($q) {
   $idx = $q['nodes'][$idx]['next'];
 };
   return $count;
-}
-function to_string($q) {
+};
+  function to_string($q) {
   global $queue;
   $res = '';
   $idx = $q['front'];
@@ -87,22 +110,30 @@ function to_string($q) {
   $idx = $node['next'];
 };
   return $res;
-}
-function clear(&$q) {
+};
+  function clear(&$q) {
   global $queue;
   $q['nodes'] = [];
   $q['front'] = 0 - 1;
   $q['rear'] = 0 - 1;
-}
-$queue = new_queue();
-echo rtrim(_str(is_empty($queue))), PHP_EOL;
-put($queue, '5');
-put($queue, '9');
-put($queue, 'python');
-echo rtrim(_str(is_empty($queue))), PHP_EOL;
-echo rtrim(get($queue)), PHP_EOL;
-put($queue, 'algorithms');
-echo rtrim(get($queue)), PHP_EOL;
-echo rtrim(get($queue)), PHP_EOL;
-echo rtrim(get($queue)), PHP_EOL;
-echo rtrim(_str(is_empty($queue))), PHP_EOL;
+};
+  $queue = new_queue();
+  echo rtrim(_str(is_empty($queue))), PHP_EOL;
+  put($queue, '5');
+  put($queue, '9');
+  put($queue, 'python');
+  echo rtrim(_str(is_empty($queue))), PHP_EOL;
+  echo rtrim(get($queue)), PHP_EOL;
+  put($queue, 'algorithms');
+  echo rtrim(get($queue)), PHP_EOL;
+  echo rtrim(get($queue)), PHP_EOL;
+  echo rtrim(get($queue)), PHP_EOL;
+  echo rtrim(_str(is_empty($queue))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/queues/priority_queue_using_list.bench
+++ b/tests/algorithms/x/PHP/data_structures/queues/priority_queue_using_list.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 161,
-  "memory_bytes": 77416,
+  "duration_us": 391,
+  "memory_bytes": 1638232,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/queues/queue_by_list.bench
+++ b/tests/algorithms/x/PHP/data_structures/queues/queue_by_list.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 90,
-  "memory_bytes": 38104,
+  "duration_us": 154,
+  "memory_bytes": 1666720,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/queues/queue_by_list.php
+++ b/tests/algorithms/x/PHP/data_structures/queues/queue_by_list.php
@@ -1,6 +1,23 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _len($x) {
+    if ($x === null) { return 0; }
     if (is_array($x)) { return count($x); }
     if (is_string($x)) { return strlen($x); }
     return strlen(strval($x));
@@ -25,16 +42,22 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function new_queue($items) {
-  global $q, $res, $front;
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function new_queue($items) {
+  global $front, $q, $res;
   return ['entries' => $items];
-}
-function len_queue($q) {
-  global $res, $front;
+};
+  function len_queue($q) {
+  global $front, $res;
   return _len($q['entries']);
-}
-function str_queue($q) {
-  global $res, $front;
+};
+  function str_queue($q) {
+  global $front, $res;
   $s = 'Queue((';
   $i = 0;
   while ($i < _len($q['entries'])) {
@@ -46,17 +69,17 @@ function str_queue($q) {
 };
   $s = $s . '))';
   return $s;
-}
-function put($q, $item) {
-  global $res, $front;
+};
+  function put($q, $item) {
+  global $front, $res;
   $e = $q['entries'];
   $e = _append($e, $item);
   return ['entries' => $e];
-}
-function get($q) {
-  global $res, $front;
+};
+  function get($q) {
+  global $front, $res;
   if (_len($q['entries']) == 0) {
-  $panic('Queue is empty');
+  _panic('Queue is empty');
 }
   $value = $q['entries'][0];
   $new_entries = [];
@@ -66,9 +89,9 @@ function get($q) {
   $i = $i + 1;
 };
   return ['queue' => ['entries' => $new_entries], 'value' => $value];
-}
-function rotate($q, $rotation) {
-  global $res, $front;
+};
+  function rotate($q, $rotation) {
+  global $front, $res;
   $e = $q['entries'];
   $r = 0;
   while ($r < $rotation) {
@@ -86,24 +109,32 @@ function rotate($q, $rotation) {
   $r = $r + 1;
 };
   return ['entries' => $e];
-}
-function get_front($q) {
-  global $res, $front;
+};
+  function get_front($q) {
+  global $front, $res;
   return $q['entries'][0];
-}
-$q = new_queue([]);
-echo rtrim(json_encode(len_queue($q), 1344)), PHP_EOL;
-$q = put($q, 10);
-$q = put($q, 20);
-$q = put($q, 30);
-$q = put($q, 40);
-echo rtrim(str_queue($q)), PHP_EOL;
-$res = get($q);
-$q = $res['queue'];
-echo rtrim(json_encode($res['value'], 1344)), PHP_EOL;
-echo rtrim(str_queue($q)), PHP_EOL;
-$q = rotate($q, 2);
-echo rtrim(str_queue($q)), PHP_EOL;
-$front = get_front($q);
-echo rtrim(json_encode($front, 1344)), PHP_EOL;
-echo rtrim(str_queue($q)), PHP_EOL;
+};
+  $q = new_queue([]);
+  echo rtrim(json_encode(len_queue($q), 1344)), PHP_EOL;
+  $q = put($q, 10);
+  $q = put($q, 20);
+  $q = put($q, 30);
+  $q = put($q, 40);
+  echo rtrim(str_queue($q)), PHP_EOL;
+  $res = get($q);
+  $q = $res['queue'];
+  echo rtrim(json_encode($res['value'], 1344)), PHP_EOL;
+  echo rtrim(str_queue($q)), PHP_EOL;
+  $q = rotate($q, 2);
+  echo rtrim(str_queue($q)), PHP_EOL;
+  $front = get_front($q);
+  echo rtrim(json_encode($front, 1344)), PHP_EOL;
+  echo rtrim(str_queue($q)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/queues/queue_by_two_stacks.bench
+++ b/tests/algorithms/x/PHP/data_structures/queues/queue_by_two_stacks.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 77,
-  "memory_bytes": 38160,
+  "duration_us": 92,
+  "memory_bytes": 1665144,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/queues/queue_by_two_stacks.php
+++ b/tests/algorithms/x/PHP/data_structures/queues/queue_by_two_stacks.php
@@ -1,6 +1,23 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _len($x) {
+    if ($x === null) { return 0; }
     if (is_array($x)) { return count($x); }
     if (is_string($x)) { return strlen($x); }
     return strlen(strval($x));
@@ -25,15 +42,21 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function new_queue($items) {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function new_queue($items) {
   global $q, $r1, $r2, $r3, $r4;
   return ['stack1' => $items, 'stack2' => []];
-}
-function len_queue($q) {
+};
+  function len_queue($q) {
   global $r1, $r2, $r3, $r4;
   return _len($q['stack1']) + _len($q['stack2']);
-}
-function str_queue($q) {
+};
+  function str_queue($q) {
   global $r1, $r2, $r3, $r4;
   $items = [];
   $i = _len($q['stack2']) - 1;
@@ -57,14 +80,14 @@ function str_queue($q) {
 };
   $s = $s . '))';
   return $s;
-}
-function put($q, $item) {
+};
+  function put($q, $item) {
   global $r1, $r2, $r3, $r4;
   $s1 = $q['stack1'];
   $s1 = _append($s1, $item);
   return ['stack1' => $s1, 'stack2' => $q['stack2']];
-}
-function get($q) {
+};
+  function get($q) {
   global $r1, $r2, $r3, $r4;
   $s1 = $q['stack1'];
   $s2 = $q['stack2'];
@@ -83,7 +106,7 @@ function get($q) {
 };
 }
   if (count($s2) == 0) {
-  $panic('Queue is empty');
+  _panic('Queue is empty');
 }
   $idx2 = count($s2) - 1;
   $value = $s2[$idx2];
@@ -95,19 +118,27 @@ function get($q) {
 };
   $s2 = $new_s2;
   return ['queue' => ['stack1' => $s1, 'stack2' => $s2], 'value' => $value];
-}
-$q = new_queue([10, 20, 30]);
-$r1 = get($q);
-$q = $r1['queue'];
-echo rtrim(json_encode($r1['value'], 1344)), PHP_EOL;
-$q = put($q, 40);
-$r2 = get($q);
-$q = $r2['queue'];
-echo rtrim(json_encode($r2['value'], 1344)), PHP_EOL;
-$r3 = get($q);
-$q = $r3['queue'];
-echo rtrim(json_encode($r3['value'], 1344)), PHP_EOL;
-echo rtrim(json_encode(len_queue($q), 1344)), PHP_EOL;
-$r4 = get($q);
-$q = $r4['queue'];
-echo rtrim(json_encode($r4['value'], 1344)), PHP_EOL;
+};
+  $q = new_queue([10, 20, 30]);
+  $r1 = get($q);
+  $q = $r1['queue'];
+  echo rtrim(json_encode($r1['value'], 1344)), PHP_EOL;
+  $q = put($q, 40);
+  $r2 = get($q);
+  $q = $r2['queue'];
+  echo rtrim(json_encode($r2['value'], 1344)), PHP_EOL;
+  $r3 = get($q);
+  $q = $r3['queue'];
+  echo rtrim(json_encode($r3['value'], 1344)), PHP_EOL;
+  echo rtrim(json_encode(len_queue($q), 1344)), PHP_EOL;
+  $r4 = get($q);
+  $q = $r4['queue'];
+  echo rtrim(json_encode($r4['value'], 1344)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/queues/queue_on_pseudo_stack.bench
+++ b/tests/algorithms/x/PHP/data_structures/queues/queue_on_pseudo_stack.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 83,
-  "memory_bytes": 42208,
+  "duration_us": 113,
+  "memory_bytes": 1666992,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/queues/queue_on_pseudo_stack.php
+++ b/tests/algorithms/x/PHP/data_structures/queues/queue_on_pseudo_stack.php
@@ -1,5 +1,21 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,14 +36,20 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function empty_queue() {
-  return ['stack' => [], 'length' => 0];
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
 }
-function put($q, $item) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function empty_queue() {
+  return ['length' => 0, 'stack' => []];
+};
+  function put($q, $item) {
   $s = _append($q['stack'], $item);
-  return ['stack' => $s, 'length' => $q['length'] + 1];
-}
-function drop_first($xs) {
+  return ['length' => $q['length'] + 1, 'stack' => $s];
+};
+  function drop_first($xs) {
   $res = [];
   $i = 1;
   while ($i < count($xs)) {
@@ -35,8 +57,8 @@ function drop_first($xs) {
   $i = $i + 1;
 };
   return $res;
-}
-function drop_last($xs) {
+};
+  function drop_last($xs) {
   $res = [];
   $i = 0;
   while ($i < count($xs) - 1) {
@@ -44,8 +66,8 @@ function drop_last($xs) {
   $i = $i + 1;
 };
   return $res;
-}
-function rotate($q, $rotation) {
+};
+  function rotate($q, $rotation) {
   $s = $q['stack'];
   $i = 0;
   while ($i < $rotation && count($s) > 0) {
@@ -54,30 +76,30 @@ function rotate($q, $rotation) {
   $s = _append($s, $temp);
   $i = $i + 1;
 };
-  return ['stack' => $s, 'length' => $q['length']];
-}
-function get($q) {
+  return ['length' => $q['length'], 'stack' => $s];
+};
+  function get($q) {
   if ($q['length'] == 0) {
-  $panic('queue empty');
+  _panic('queue empty');
 }
   $q1 = rotate($q, 1);
   $v = $q1['stack'][$q1['length'] - 1];
   $s = drop_last($q1['stack']);
-  $q2 = ['stack' => $s, 'length' => $q1['length']];
+  $q2 = ['length' => $q1['length'], 'stack' => $s];
   $q2 = rotate($q2, $q2['length'] - 1);
-  $q2 = ['stack' => $q2['stack'], 'length' => $q2['length'] - 1];
+  $q2 = ['length' => $q2['length'] - 1, 'stack' => $q2['stack']];
   return ['queue' => $q2, 'value' => $v];
-}
-function front($q) {
+};
+  function front($q) {
   $r = get($q);
   $q2 = put($r['queue'], $r['value']);
   $q2 = rotate($q2, $q2['length'] - 1);
   return ['queue' => $q2, 'value' => $r['value']];
-}
-function size($q) {
+};
+  function size($q) {
   return $q['length'];
-}
-function to_string($q) {
+};
+  function to_string($q) {
   $s = '<';
   if ($q['length'] > 0) {
   $s = $s . _str($q['stack'][0]);
@@ -89,8 +111,8 @@ function to_string($q) {
 }
   $s = $s . '>';
   return $s;
-}
-function main() {
+};
+  function main() {
   $q = empty_queue();
   $q = put($q, 1);
   $q = put($q, 2);
@@ -105,5 +127,13 @@ function main() {
   echo rtrim(json_encode($f['value'], 1344)), PHP_EOL;
   echo rtrim(to_string($q)), PHP_EOL;
   echo rtrim(json_encode(size($q), 1344)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/stacks/balanced_parentheses.bench
+++ b/tests/algorithms/x/PHP/data_structures/stacks/balanced_parentheses.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 109,
-  "memory_bytes": 40360,
+  "duration_us": 128,
+  "memory_bytes": 1680968,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/stacks/balanced_parentheses.php
+++ b/tests/algorithms/x/PHP/data_structures/stacks/balanced_parentheses.php
@@ -1,11 +1,29 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function pop_last($xs) {
-  global $tests, $idx;
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function pop_last($xs) {
+  global $idx, $tests;
   $res = [];
   $i = 0;
   while ($i < count($xs) - 1) {
@@ -13,9 +31,9 @@ function pop_last($xs) {
   $i = $i + 1;
 };
   return $res;
-}
-function balanced_parentheses($s) {
-  global $tests, $idx;
+};
+  function balanced_parentheses($s) {
+  global $idx, $tests;
   $stack = [];
   $pairs = ['(' => ')', '[' => ']', '{' => '}'];
   $i = 0;
@@ -38,10 +56,18 @@ function balanced_parentheses($s) {
   $i = $i + 1;
 };
   return count($stack) == 0;
-}
-$tests = ['([]{})', '[()]{}{[()()]()}', '[(])', '1+2*3-4', ''];
-$idx = 0;
-while ($idx < count($tests)) {
+};
+  $tests = ['([]{})', '[()]{}{[()()]()}', '[(])', '1+2*3-4', ''];
+  $idx = 0;
+  while ($idx < count($tests)) {
   echo rtrim(json_encode(balanced_parentheses($tests[$idx]), 1344)), PHP_EOL;
   $idx = $idx + 1;
 }
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/stacks/dijkstras_two_stack_algorithm.bench
+++ b/tests/algorithms/x/PHP/data_structures/stacks/dijkstras_two_stack_algorithm.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 91,
-  "memory_bytes": 41672,
+  "duration_us": 132,
+  "memory_bytes": 1670088,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/stacks/dijkstras_two_stack_algorithm.php
+++ b/tests/algorithms/x/PHP/data_structures/stacks/dijkstras_two_stack_algorithm.php
@@ -1,5 +1,21 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -21,18 +37,23 @@ function _append($arr, $x) {
     return $arr;
 }
 function _intdiv($a, $b) {
+    if ($b === 0 || $b === '0') {
+        throw new DivisionByZeroError();
+    }
     if (function_exists('bcdiv')) {
         $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
         return intval(bcdiv($sa, $sb, 0));
     }
-    return intdiv($a, $b);
+    return intdiv(intval($a), intval($b));
 }
-function is_digit($ch) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function is_digit($ch) {
   global $equation;
   return $ch == '0' || $ch == '1' || $ch == '2' || $ch == '3' || $ch == '4' || $ch == '5' || $ch == '6' || $ch == '7' || $ch == '8' || $ch == '9';
-}
-function slice_without_last_int($xs) {
+};
+  function slice_without_last_int($xs) {
   global $equation;
   $res = [];
   $i = 0;
@@ -41,8 +62,8 @@ function slice_without_last_int($xs) {
   $i = $i + 1;
 };
   return $res;
-}
-function slice_without_last_string($xs) {
+};
+  function slice_without_last_string($xs) {
   global $equation;
   $res = [];
   $i = 0;
@@ -51,8 +72,8 @@ function slice_without_last_string($xs) {
   $i = $i + 1;
 };
   return $res;
-}
-function dijkstras_two_stack_algorithm($equation) {
+};
+  function dijkstras_two_stack_algorithm($equation) {
   $operand_stack = [];
   $operator_stack = [];
   $idx = 0;
@@ -79,6 +100,14 @@ function dijkstras_two_stack_algorithm($equation) {
   $idx = $idx + 1;
 };
   return $operand_stack[count($operand_stack) - 1];
-}
-$equation = '(5 + ((4 * 2) * (2 + 3)))';
-echo rtrim($equation . ' = ' . _str(dijkstras_two_stack_algorithm($equation))), PHP_EOL;
+};
+  $equation = '(5 + ((4 * 2) * (2 + 3)))';
+  echo rtrim($equation . ' = ' . _str(dijkstras_two_stack_algorithm($equation))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/stacks/infix_to_postfix_conversion.bench
+++ b/tests/algorithms/x/PHP/data_structures/stacks/infix_to_postfix_conversion.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 140,
-  "memory_bytes": 38248,
+  "duration_us": 229,
+  "memory_bytes": 1668632,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/stacks/infix_to_prefix_conversion.bench
+++ b/tests/algorithms/x/PHP/data_structures/stacks/infix_to_prefix_conversion.bench
@@ -1,5 +1,5 @@
 {
   "duration_us": 1,
-  "memory_bytes": 37720,
+  "memory_bytes": 1669472,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/stacks/infix_to_prefix_conversion.php
+++ b/tests/algorithms/x/PHP/data_structures/stacks/infix_to_prefix_conversion.php
@@ -1,14 +1,36 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-$PRIORITY = ['^' => 3, '*' => 2, '/' => 2, '%' => 2, '+' => 1, '-' => 1];
-$LETTERS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-$DIGITS = '0123456789';
-function is_alpha($ch) {
-  global $PRIORITY, $LETTERS, $DIGITS;
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $PRIORITY = ['%' => 2, '*' => 2, '+' => 1, '-' => 1, '/' => 2, '^' => 3];
+  $LETTERS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  $DIGITS = '0123456789';
+  function is_alpha($ch) {
+  global $DIGITS, $LETTERS, $PRIORITY;
   $i = 0;
   while ($i < strlen($LETTERS)) {
   if (substr($LETTERS, $i, $i + 1 - $i) == $ch) {
@@ -17,9 +39,9 @@ function is_alpha($ch) {
   $i = $i + 1;
 };
   return false;
-}
-function is_digit($ch) {
-  global $PRIORITY, $LETTERS, $DIGITS;
+};
+  function is_digit($ch) {
+  global $DIGITS, $LETTERS, $PRIORITY;
   $i = 0;
   while ($i < strlen($DIGITS)) {
   if (substr($DIGITS, $i, $i + 1 - $i) == $ch) {
@@ -28,9 +50,9 @@ function is_digit($ch) {
   $i = $i + 1;
 };
   return false;
-}
-function reverse_string($s) {
-  global $PRIORITY, $LETTERS, $DIGITS;
+};
+  function reverse_string($s) {
+  global $DIGITS, $LETTERS, $PRIORITY;
   $out = '';
   $i = strlen($s) - 1;
   while ($i >= 0) {
@@ -38,9 +60,9 @@ function reverse_string($s) {
   $i = $i - 1;
 };
   return $out;
-}
-function infix_to_postfix($infix) {
-  global $PRIORITY, $LETTERS, $DIGITS;
+};
+  function infix_to_postfix($infix) {
+  global $DIGITS, $LETTERS, $PRIORITY;
   $stack = [];
   $post = [];
   $i = 0;
@@ -54,20 +76,20 @@ function infix_to_postfix($infix) {
 } else {
   if ($x == ')') {
   if (count($stack) == 0) {
-  $panic('list index out of range');
+  _panic('list index out of range');
 };
   while ($stack[count($stack) - 1] != '(') {
   $post = _append($post, $stack[count($stack) - 1]);
-  $stack = array_slice($stack, 0, count($stack) - 1 - 0);
+  $stack = array_slice($stack, 0, count($stack) - 1);
 };
-  $stack = array_slice($stack, 0, count($stack) - 1 - 0);
+  $stack = array_slice($stack, 0, count($stack) - 1);
 } else {
   if (count($stack) == 0) {
   $stack = _append($stack, $x);
 } else {
   while (count($stack) > 0 && $stack[count($stack) - 1] != '(' && $PRIORITY[$x] <= $PRIORITY[$stack[count($stack) - 1]]) {
   $post = _append($post, $stack[count($stack) - 1]);
-  $stack = array_slice($stack, 0, count($stack) - 1 - 0);
+  $stack = array_slice($stack, 0, count($stack) - 1);
 };
   $stack = _append($stack, $x);
 };
@@ -78,10 +100,10 @@ function infix_to_postfix($infix) {
 };
   while (count($stack) > 0) {
   if ($stack[count($stack) - 1] == '(') {
-  $panic('invalid expression');
+  _panic('invalid expression');
 }
   $post = _append($post, $stack[count($stack) - 1]);
-  $stack = array_slice($stack, 0, count($stack) - 1 - 0);
+  $stack = array_slice($stack, 0, count($stack) - 1);
 };
   $res = '';
   $j = 0;
@@ -90,9 +112,9 @@ function infix_to_postfix($infix) {
   $j = $j + 1;
 };
   return $res;
-}
-function infix_to_prefix($infix) {
-  global $PRIORITY, $LETTERS, $DIGITS;
+};
+  function infix_to_prefix($infix) {
+  global $DIGITS, $LETTERS, $PRIORITY;
   $reversed = '';
   $i = strlen($infix) - 1;
   while ($i >= 0) {
@@ -111,4 +133,12 @@ function infix_to_prefix($infix) {
   $postfix = infix_to_postfix($reversed);
   $prefix = reverse_string($postfix);
   return $prefix;
-}
+};
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/stacks/largest_rectangle_histogram.bench
+++ b/tests/algorithms/x/PHP/data_structures/stacks/largest_rectangle_histogram.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 90,
-  "memory_bytes": 40168,
+  "duration_us": 155,
+  "memory_bytes": 1677616,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/stacks/largest_rectangle_histogram.php
+++ b/tests/algorithms/x/PHP/data_structures/stacks/largest_rectangle_histogram.php
@@ -1,5 +1,21 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,7 +36,9 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function largest_rectangle_area($heights) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function largest_rectangle_area($heights) {
   $stack = [];
   $max_area = 0;
   $hs = $heights;
@@ -29,7 +47,7 @@ function largest_rectangle_area($heights) {
   while ($i < count($hs)) {
   while (count($stack) > 0 && $hs[$i] < $hs[$stack[count($stack) - 1]]) {
   $top = $stack[count($stack) - 1];
-  $stack = array_slice($stack, 0, count($stack) - 1 - 0);
+  $stack = array_slice($stack, 0, count($stack) - 1);
   $height = $hs[$top];
   $width = $i;
   if (count($stack) > 0) {
@@ -44,8 +62,16 @@ function largest_rectangle_area($heights) {
   $i = $i + 1;
 };
   return $max_area;
-}
-echo rtrim(_str(largest_rectangle_area([2, 1, 5, 6, 2, 3]))), PHP_EOL;
-echo rtrim(_str(largest_rectangle_area([2, 4]))), PHP_EOL;
-echo rtrim(_str(largest_rectangle_area([6, 2, 5, 4, 5, 1, 6]))), PHP_EOL;
-echo rtrim(_str(largest_rectangle_area([1]))), PHP_EOL;
+};
+  echo rtrim(_str(largest_rectangle_area([2, 1, 5, 6, 2, 3]))), PHP_EOL;
+  echo rtrim(_str(largest_rectangle_area([2, 4]))), PHP_EOL;
+  echo rtrim(_str(largest_rectangle_area([6, 2, 5, 4, 5, 1, 6]))), PHP_EOL;
+  echo rtrim(_str(largest_rectangle_area([1]))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/stacks/lexicographical_numbers.bench
+++ b/tests/algorithms/x/PHP/data_structures/stacks/lexicographical_numbers.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 132,
-  "memory_bytes": 36280,
+  "duration_us": 172,
+  "memory_bytes": 1673960,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/stacks/lexicographical_numbers.php
+++ b/tests/algorithms/x/PHP/data_structures/stacks/lexicographical_numbers.php
@@ -1,5 +1,21 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,13 +36,15 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function lexical_order($max_number) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function lexical_order($max_number) {
   $result = [];
   $stack = [1];
   while (count($stack) > 0) {
   $idx = count($stack) - 1;
   $num = $stack[$idx];
-  $stack = array_slice($stack, 0, $idx - 0);
+  $stack = array_slice($stack, 0, $idx);
   if ($num > $max_number) {
   continue;
 }
@@ -37,8 +55,8 @@ function lexical_order($max_number) {
   $stack = _append($stack, $num * 10);
 };
   return $result;
-}
-function join_ints($xs) {
+};
+  function join_ints($xs) {
   $res = '';
   $i = 0;
   while ($i < count($xs)) {
@@ -49,9 +67,17 @@ function join_ints($xs) {
   $i = $i + 1;
 };
   return $res;
-}
-echo rtrim(join_ints(lexical_order(13))), PHP_EOL;
-echo rtrim(_str(lexical_order(1))), PHP_EOL;
-echo rtrim(join_ints(lexical_order(20))), PHP_EOL;
-echo rtrim(join_ints(lexical_order(25))), PHP_EOL;
-echo rtrim(_str(lexical_order(12))), PHP_EOL;
+};
+  echo rtrim(join_ints(lexical_order(13))), PHP_EOL;
+  echo rtrim(_str(lexical_order(1))), PHP_EOL;
+  echo rtrim(join_ints(lexical_order(20))), PHP_EOL;
+  echo rtrim(join_ints(lexical_order(25))), PHP_EOL;
+  echo rtrim(_str(lexical_order(12))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/stacks/next_greater_element.bench
+++ b/tests/algorithms/x/PHP/data_structures/stacks/next_greater_element.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 165,
+  "memory_bytes": 1671888,
+  "name": "main"
+}

--- a/tests/algorithms/x/PHP/data_structures/stacks/next_greater_element.error
+++ b/tests/algorithms/x/PHP/data_structures/stacks/next_greater_element.error
@@ -1,8 +1,0 @@
-parse: error[P999]: /workspace/mochi/tests/github/TheAlgorithms/Mochi/data_structures/stacks/next_greater_element.mochi:18:5: unexpected token "expect" (expected <ident> (":" TypeRef)? ("=" Expr)?)
-  --> /workspace/mochi/tests/github/TheAlgorithms/Mochi/data_structures/stacks/next_greater_element.mochi:18:5
-
- 18 | let expect = [-5.0, 0.0, 5.0, 5.1, 11.0, 13.0, 21.0, -1.0, 4.0, -1.0, -10.0, -5.0, -1.0, 0.0, -1.0]
-    |     ^
-
-help:
-  Parse error occurred. Check syntax near this location.

--- a/tests/algorithms/x/PHP/data_structures/stacks/next_greater_element.php
+++ b/tests/algorithms/x/PHP/data_structures/stacks/next_greater_element.php
@@ -1,0 +1,127 @@
+<?php
+error_reporting(E_ALL & ~E_DEPRECATED);
+ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+function _str($x) {
+    if (is_array($x)) {
+        $isList = array_keys($x) === range(0, count($x) - 1);
+        if ($isList) {
+            $parts = [];
+            foreach ($x as $v) { $parts[] = _str($v); }
+            return '[' . implode(' ', $parts) . ']';
+        }
+        $parts = [];
+        foreach ($x as $k => $v) { $parts[] = _str($k) . ':' . _str($v); }
+        return 'map[' . implode(' ', $parts) . ']';
+    }
+    if (is_bool($x)) return $x ? 'true' : 'false';
+    if ($x === null) return 'null';
+    return strval($x);
+}
+function _append($arr, $x) {
+    $arr[] = $x;
+    return $arr;
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $arr = [-10.0, -5.0, 0.0, 5.0, 5.1, 11.0, 13.0, 21.0, 3.0, 4.0, -21.0, -10.0, -5.0, -1.0, 0.0];
+  $expected = [-5.0, 0.0, 5.0, 5.1, 11.0, 13.0, 21.0, -1.0, 4.0, -1.0, -10.0, -5.0, -1.0, 0.0, -1.0];
+  function next_greatest_element_slow($xs) {
+  global $arr, $expected;
+  $res = [];
+  $i = 0;
+  while ($i < count($xs)) {
+  $next = -1.0;
+  $j = $i + 1;
+  while ($j < count($xs)) {
+  if ($xs[$i] < $xs[$j]) {
+  $next = $xs[$j];
+  break;
+}
+  $j = $j + 1;
+};
+  $res = _append($res, $next);
+  $i = $i + 1;
+};
+  return $res;
+};
+  function next_greatest_element_fast($xs) {
+  global $arr, $expected;
+  $res = [];
+  $i = 0;
+  while ($i < count($xs)) {
+  $next = -1.0;
+  $j = $i + 1;
+  while ($j < count($xs)) {
+  $inner = $xs[$j];
+  if ($xs[$i] < $inner) {
+  $next = $inner;
+  break;
+}
+  $j = $j + 1;
+};
+  $res = _append($res, $next);
+  $i = $i + 1;
+};
+  return $res;
+};
+  function set_at_float($xs, $idx, $value) {
+  global $arr, $expected;
+  $i = 0;
+  $res = [];
+  while ($i < count($xs)) {
+  if ($i == $idx) {
+  $res = _append($res, $value);
+} else {
+  $res = _append($res, $xs[$i]);
+}
+  $i = $i + 1;
+};
+  return $res;
+};
+  function next_greatest_element($xs) {
+  global $arr, $expected;
+  $res = [];
+  $k = 0;
+  while ($k < count($xs)) {
+  $res = _append($res, -1.0);
+  $k = $k + 1;
+};
+  $stack = [];
+  $i = 0;
+  while ($i < count($xs)) {
+  while (count($stack) > 0 && $xs[$i] > $xs[$stack[count($stack) - 1]]) {
+  $idx = $stack[count($stack) - 1];
+  $stack = array_slice($stack, 0, count($stack) - 1);
+  $res = set_at_float($res, $idx, $xs[$i]);
+};
+  $stack = _append($stack, $i);
+  $i = $i + 1;
+};
+  return $res;
+};
+  echo rtrim(_str(next_greatest_element_slow($arr))), PHP_EOL;
+  echo rtrim(_str(next_greatest_element_fast($arr))), PHP_EOL;
+  echo rtrim(_str(next_greatest_element($arr))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/stacks/postfix_evaluation.bench
+++ b/tests/algorithms/x/PHP/data_structures/stacks/postfix_evaluation.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 114,
-  "memory_bytes": 37080,
+  "duration_us": 131,
+  "memory_bytes": 1663496,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/stacks/postfix_evaluation.php
+++ b/tests/algorithms/x/PHP/data_structures/stacks/postfix_evaluation.php
@@ -1,5 +1,21 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,7 +36,13 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function slice_without_last($xs) {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function slice_without_last($xs) {
   $res = [];
   $i = 0;
   while ($i < count($xs) - 1) {
@@ -28,12 +50,12 @@ function slice_without_last($xs) {
   $i = $i + 1;
 };
   return $res;
-}
-function parse_float($token) {
+};
+  function parse_float($token) {
   $sign = 1.0;
   $idx = 0;
   if (strlen($token) > 0) {
-  $first = substr($token, 0, 1 - 0);
+  $first = substr($token, 0, 1);
   if ($first == '-') {
   $sign = -1.0;
   $idx = 1;
@@ -60,8 +82,8 @@ function parse_float($token) {
 };
 }
   return $sign * $result;
-}
-function pow_float($base, $exp) {
+};
+  function pow_float($base, $exp) {
   $result = 1.0;
   $i = 0;
   $e = intval($exp);
@@ -70,8 +92,8 @@ function pow_float($base, $exp) {
   $i = $i + 1;
 };
   return $result;
-}
-function apply_op($a, $b, $op) {
+};
+  function apply_op($a, $b, $op) {
   if ($op == '+') {
   return $a + $b;
 }
@@ -88,8 +110,8 @@ function apply_op($a, $b, $op) {
   return pow_float($a, $b);
 }
   return 0.0;
-}
-function evaluate($tokens) {
+};
+  function evaluate($tokens) {
   if (count($tokens) == 0) {
   return 0.0;
 }
@@ -117,12 +139,20 @@ function evaluate($tokens) {
 }
 };
   if (count($stack) != 1) {
-  $panic('Invalid postfix expression');
+  _panic('Invalid postfix expression');
 }
   return $stack[0];
-}
-echo rtrim(_str(evaluate(['2', '1', '+', '3', '*']))), PHP_EOL;
-echo rtrim(_str(evaluate(['4', '13', '5', '/', '+']))), PHP_EOL;
-echo rtrim(_str(evaluate(['5', '6', '9', '*', '+']))), PHP_EOL;
-echo rtrim(_str(evaluate(['2', '-', '3', '+']))), PHP_EOL;
-echo rtrim(_str(evaluate([]))), PHP_EOL;
+};
+  echo rtrim(_str(evaluate(['2', '1', '+', '3', '*']))), PHP_EOL;
+  echo rtrim(_str(evaluate(['4', '13', '5', '/', '+']))), PHP_EOL;
+  echo rtrim(_str(evaluate(['5', '6', '9', '*', '+']))), PHP_EOL;
+  echo rtrim(_str(evaluate(['2', '-', '3', '+']))), PHP_EOL;
+  echo rtrim(_str(evaluate([]))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/stacks/prefix_evaluation.bench
+++ b/tests/algorithms/x/PHP/data_structures/stacks/prefix_evaluation.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 150,
-  "memory_bytes": 41304,
+  "duration_us": 223,
+  "memory_bytes": 1661400,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/stacks/prefix_evaluation.php
+++ b/tests/algorithms/x/PHP/data_structures/stacks/prefix_evaluation.php
@@ -1,5 +1,21 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,7 +36,9 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function split($s, $sep) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function split_custom($s, $sep) {
   global $test_expression, $test_expression2, $test_expression3;
   $res = [];
   $current = '';
@@ -37,10 +55,10 @@ function split($s, $sep) {
 };
   $res = _append($res, $current);
   return $res;
-}
-function tokenize($s) {
+};
+  function tokenize($s) {
   global $test_expression, $test_expression2, $test_expression3;
-  $parts = explode(' ', $s);
+  $parts = split_custom($s, ' ');
   $res = [];
   $i = 0;
   while ($i < count($parts)) {
@@ -51,12 +69,12 @@ function tokenize($s) {
   $i = $i + 1;
 };
   return $res;
-}
-function is_digit($ch) {
+};
+  function is_digit($ch) {
   global $test_expression, $test_expression2, $test_expression3;
   return $ch >= '0' && $ch <= '9';
-}
-function is_operand($token) {
+};
+  function is_operand($token) {
   global $test_expression, $test_expression2, $test_expression3;
   if ($token == '') {
   return false;
@@ -70,18 +88,18 @@ function is_operand($token) {
   $i = $i + 1;
 };
   return true;
-}
-function to_int($token) {
+};
+  function to_int($token) {
   global $test_expression, $test_expression2, $test_expression3;
   $res = 0;
   $i = 0;
   while ($i < strlen($token)) {
-  $res = $res * 10 + (ord(substr($token, $i, $i + 1 - $i)));
+  $res = $res * 10 + ((ctype_digit($token[$i]) ? intval($token[$i]) : ord($token[$i])));
   $i = $i + 1;
 };
   return $res;
-}
-function apply_op($op, $a, $b) {
+};
+  function apply_op($op, $a, $b) {
   global $test_expression, $test_expression2, $test_expression3;
   if ($op == '+') {
   return $a + $b;
@@ -96,8 +114,8 @@ function apply_op($op, $a, $b) {
   return $a / $b;
 }
   return 0.0;
-}
-function evaluate($expression) {
+};
+  function evaluate($expression) {
   global $test_expression, $test_expression2, $test_expression3;
   $tokens = tokenize($expression);
   $stack = [];
@@ -110,7 +128,7 @@ function evaluate($expression) {
 } else {
   $o1 = $stack[count($stack) - 1];
   $o2 = $stack[count($stack) - 2];
-  $stack = array_slice($stack, 0, count($stack) - 2 - 0);
+  $stack = array_slice($stack, 0, count($stack) - 2);
   $res = apply_op($token, $o1, $o2);
   $stack = _append($stack, $res);
 };
@@ -118,8 +136,8 @@ function evaluate($expression) {
   $i = $i - 1;
 };
   return $stack[0];
-}
-function eval_rec($tokens, $pos) {
+};
+  function eval_rec($tokens, $pos) {
   global $test_expression, $test_expression2, $test_expression3;
   $token = $tokens[$pos];
   $next = $pos + 1;
@@ -133,16 +151,24 @@ function eval_rec($tokens, $pos) {
   $b = $right[0];
   $p2 = $right[1];
   return [apply_op($token, $a, $b), $p2];
-}
-function evaluate_recursive($expression) {
+};
+  function evaluate_recursive($expression) {
   global $test_expression, $test_expression2, $test_expression3;
   $tokens = tokenize($expression);
   $res = eval_rec($tokens, 0);
   return $res[0];
-}
-$test_expression = '+ 9 * 2 6';
-echo rtrim(_str(evaluate($test_expression))), PHP_EOL;
-$test_expression2 = '/ * 10 2 + 4 1 ';
-echo rtrim(_str(evaluate($test_expression2))), PHP_EOL;
-$test_expression3 = '+ * 2 3 / 8 4';
-echo rtrim(_str(evaluate_recursive($test_expression3))), PHP_EOL;
+};
+  $test_expression = '+ 9 * 2 6';
+  echo rtrim(_str(evaluate($test_expression))), PHP_EOL;
+  $test_expression2 = '/ * 10 2 + 4 1 ';
+  echo rtrim(_str(evaluate($test_expression2))), PHP_EOL;
+  $test_expression3 = '+ * 2 3 / 8 4';
+  echo rtrim(_str(evaluate_recursive($test_expression3))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/stacks/stack.bench
+++ b/tests/algorithms/x/PHP/data_structures/stacks/stack.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 117,
-  "memory_bytes": 38560,
+  "duration_us": 151,
+  "memory_bytes": 1665496,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/stacks/stack.php
+++ b/tests/algorithms/x/PHP/data_structures/stacks/stack.php
@@ -1,6 +1,23 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _len($x) {
+    if ($x === null) { return 0; }
     if (is_array($x)) { return count($x); }
     if (is_string($x)) { return strlen($x); }
     return strlen(strval($x));
@@ -25,40 +42,46 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function make_stack($limit) {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function make_stack($limit) {
   return ['items' => [], 'limit' => $limit];
-}
-function is_empty($s) {
+};
+  function is_empty($s) {
   return _len($s['items']) == 0;
-}
-function size($s) {
+};
+  function size($s) {
   return _len($s['items']);
-}
-function is_full($s) {
+};
+  function is_full($s) {
   return _len($s['items']) >= $s['limit'];
-}
-function push(&$s, $item) {
+};
+  function push(&$s, $item) {
   if (is_full($s)) {
-  $panic('stack overflow');
+  _panic('stack overflow');
 }
   $s['items'] = _append($s['items'], $item);
-}
-function pop(&$s) {
+};
+  function pop(&$s) {
   if (is_empty($s)) {
-  $panic('stack underflow');
+  _panic('stack underflow');
 }
   $n = _len($s['items']);
   $val = $s['items'][$n - 1];
-  $s['items'] = array_slice($s['items'], 0, $n - 1 - 0);
+  $s['items'] = array_slice($s['items'], 0, $n - 1);
   return $val;
-}
-function peek($s) {
+};
+  function peek($s) {
   if (is_empty($s)) {
-  $panic('peek from empty stack');
+  _panic('peek from empty stack');
 }
   return $s['items'][_len($s['items']) - 1];
-}
-function contains($s, $item) {
+};
+  function mochi_contains($s, $item) {
   $i = 0;
   while ($i < _len($s['items'])) {
   if ($s['items'][$i] == $item) {
@@ -67,11 +90,11 @@ function contains($s, $item) {
   $i = $i + 1;
 };
   return false;
-}
-function stack_repr($s) {
+};
+  function stack_repr($s) {
   return _str($s['items']);
-}
-function main() {
+};
+  function main() {
   $s = make_stack(5);
   echo rtrim(_str(is_empty($s))), PHP_EOL;
   push($s, 0);
@@ -86,7 +109,15 @@ function main() {
   echo rtrim(stack_repr($s)), PHP_EOL;
   echo rtrim(_str(pop($s))), PHP_EOL;
   echo rtrim(_str(peek($s))), PHP_EOL;
-  echo rtrim(_str(contains($s, 1))), PHP_EOL;
-  echo rtrim(_str(contains($s, 9))), PHP_EOL;
-}
-main();
+  echo rtrim(_str(mochi_contains($s, 1))), PHP_EOL;
+  echo rtrim(_str(mochi_contains($s, 9))), PHP_EOL;
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/stacks/stack_using_two_queues.bench
+++ b/tests/algorithms/x/PHP/data_structures/stacks/stack_using_two_queues.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 97,
-  "memory_bytes": 37960,
+  "duration_us": 123,
+  "memory_bytes": 1669616,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/stacks/stack_using_two_queues.php
+++ b/tests/algorithms/x/PHP/data_structures/stacks/stack_using_two_queues.php
@@ -1,6 +1,23 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _len($x) {
+    if ($x === null) { return 0; }
     if (is_array($x)) { return count($x); }
     if (is_string($x)) { return strlen($x); }
     return strlen(strval($x));
@@ -25,11 +42,17 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function make_stack() {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function make_stack() {
   global $stack;
   return ['main_queue' => [], 'temp_queue' => []];
-}
-function push(&$s, $item) {
+};
+  function push(&$s, $item) {
   global $stack;
   $s['temp_queue'] = _append($s['temp_queue'], $item);
   while (_len($s['main_queue']) > 0) {
@@ -39,34 +62,42 @@ function push(&$s, $item) {
   $new_main = $s['temp_queue'];
   $s['temp_queue'] = $s['main_queue'];
   $s['main_queue'] = $new_main;
-}
-function pop(&$s) {
+};
+  function pop(&$s) {
   global $stack;
   if (_len($s['main_queue']) == 0) {
-  $panic('pop from empty stack');
+  _panic('pop from empty stack');
 }
   $item = $s['main_queue'][0];
   $s['main_queue'] = array_slice($s['main_queue'], 1, _len($s['main_queue']) - 1);
   return $item;
-}
-function peek($s) {
+};
+  function peek($s) {
   global $stack;
   if (_len($s['main_queue']) == 0) {
-  $panic('peek from empty stack');
+  _panic('peek from empty stack');
 }
   return $s['main_queue'][0];
-}
-function is_empty($s) {
+};
+  function is_empty($s) {
   global $stack;
   return _len($s['main_queue']) == 0;
-}
-$stack = make_stack();
-push($stack, 1);
-push($stack, 2);
-push($stack, 3);
-echo rtrim(_str(peek($stack))), PHP_EOL;
-echo rtrim(_str(pop($stack))), PHP_EOL;
-echo rtrim(_str(peek($stack))), PHP_EOL;
-echo rtrim(_str(pop($stack))), PHP_EOL;
-echo rtrim(_str(pop($stack))), PHP_EOL;
-echo rtrim(_str(is_empty($stack))), PHP_EOL;
+};
+  $stack = make_stack();
+  push($stack, 1);
+  push($stack, 2);
+  push($stack, 3);
+  echo rtrim(_str(peek($stack))), PHP_EOL;
+  echo rtrim(_str(pop($stack))), PHP_EOL;
+  echo rtrim(_str(peek($stack))), PHP_EOL;
+  echo rtrim(_str(pop($stack))), PHP_EOL;
+  echo rtrim(_str(pop($stack))), PHP_EOL;
+  echo rtrim(_str(is_empty($stack))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/stacks/stack_with_doubly_linked_list.bench
+++ b/tests/algorithms/x/PHP/data_structures/stacks/stack_with_doubly_linked_list.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 166,
-  "memory_bytes": 42376,
+  "duration_us": 136,
+  "memory_bytes": 1668928,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/stacks/stack_with_doubly_linked_list.php
+++ b/tests/algorithms/x/PHP/data_structures/stacks/stack_with_doubly_linked_list.php
@@ -1,5 +1,21 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,10 +36,12 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function empty_stack() {
-  return ['nodes' => [], 'head' => 0 - 1];
-}
-function push($stack, $value) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function empty_stack() {
+  return ['head' => 0 - 1, 'nodes' => []];
+};
+  function push($stack, $value) {
   $nodes = $stack['nodes'];
   $idx = count($nodes);
   $new_node = ['data' => $value, 'next' => $stack['head'], 'prev' => 0 - 1];
@@ -33,11 +51,11 @@ function push($stack, $value) {
   $head_node['prev'] = $idx;
   $nodes[$stack['head']] = $head_node;
 }
-  return ['nodes' => $nodes, 'head' => $idx];
-}
-function pop($stack) {
+  return ['head' => $idx, 'nodes' => $nodes];
+};
+  function pop($stack) {
   if ($stack['head'] == 0 - 1) {
-  return ['stack' => $stack, 'value' => 0, 'ok' => false];
+  return ['ok' => false, 'stack' => $stack, 'value' => 0];
 }
   $nodes = $stack['nodes'];
   $head_node = $nodes[$stack['head']];
@@ -48,17 +66,17 @@ function pop($stack) {
   $next_node['prev'] = 0 - 1;
   $nodes[$next_idx] = $next_node;
 }
-  $new_stack = ['nodes' => $nodes, 'head' => $next_idx];
-  return ['stack' => $new_stack, 'value' => $value, 'ok' => true];
-}
-function top($stack) {
+  $new_stack = ['head' => $next_idx, 'nodes' => $nodes];
+  return ['ok' => true, 'stack' => $new_stack, 'value' => $value];
+};
+  function top($stack) {
   if ($stack['head'] == 0 - 1) {
-  return ['value' => 0, 'ok' => false];
+  return ['ok' => false, 'value' => 0];
 }
   $node = $stack['nodes'][$stack['head']];
-  return ['value' => $node['data'], 'ok' => true];
-}
-function size($stack) {
+  return ['ok' => true, 'value' => $node['data']];
+};
+  function size($stack) {
   $count = 0;
   $idx = $stack['head'];
   while ($idx != 0 - 1) {
@@ -67,11 +85,11 @@ function size($stack) {
   $idx = $node['next'];
 };
   return $count;
-}
-function is_empty($stack) {
+};
+  function is_empty($stack) {
   return $stack['head'] == 0 - 1;
-}
-function print_stack($stack) {
+};
+  function print_stack($stack) {
   echo rtrim('stack elements are:'), PHP_EOL;
   $idx = $stack['head'];
   $s = '';
@@ -83,8 +101,8 @@ function print_stack($stack) {
   if (strlen($s) > 0) {
   echo rtrim($s), PHP_EOL;
 }
-}
-function main() {
+};
+  function main() {
   $stack = empty_stack();
   echo rtrim('Stack operations using Doubly LinkedList'), PHP_EOL;
   $stack = push($stack, 4);
@@ -105,5 +123,13 @@ function main() {
   $stack = $p['stack'];
   print_stack($stack);
   echo rtrim('stack is empty: ' . _str(is_empty($stack))), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/stacks/stack_with_singly_linked_list.bench
+++ b/tests/algorithms/x/PHP/data_structures/stacks/stack_with_singly_linked_list.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 80,
-  "memory_bytes": 37584,
+  "duration_us": 145,
+  "memory_bytes": 1671528,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/stacks/stack_with_singly_linked_list.php
+++ b/tests/algorithms/x/PHP/data_structures/stacks/stack_with_singly_linked_list.php
@@ -1,42 +1,64 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function empty_stack() {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function empty_stack() {
   return ['nodes' => [], 'top' => (-1)];
-}
-function is_empty($stack) {
+};
+  function is_empty($stack) {
   return $stack['top'] == (-1);
-}
-function push($stack, $item) {
-  $new_node = ['value' => $item, 'next' => $stack['top']];
+};
+  function push($stack, $item) {
+  $new_node = ['next' => $stack['top'], 'value' => $item];
   $new_nodes = $stack['nodes'];
   $new_nodes = _append($new_nodes, $new_node);
   $new_top = count($new_nodes) - 1;
   return ['nodes' => $new_nodes, 'top' => $new_top];
-}
-function pop($stack) {
+};
+  function pop($stack) {
   if ($stack['top'] == (-1)) {
-  $panic('pop from empty stack');
+  _panic('pop from empty stack');
 }
   $node = ($stack['nodes'][$stack['top']]);
   $new_top = $node['next'];
   $new_stack = ['nodes' => $stack['nodes'], 'top' => $new_top];
   return ['stack' => $new_stack, 'value' => $node['value']];
-}
-function peek($stack) {
+};
+  function peek($stack) {
   if ($stack['top'] == (-1)) {
-  $panic('peek from empty stack');
+  _panic('peek from empty stack');
 }
   $node = ($stack['nodes'][$stack['top']]);
   return $node['value'];
-}
-function clear($stack) {
+};
+  function clear($stack) {
   return ['nodes' => [], 'top' => (-1)];
-}
-function main() {
+};
+  function main() {
   $stack = empty_stack();
   echo rtrim(json_encode(is_empty($stack), 1344)), PHP_EOL;
   $stack = push($stack, '5');
@@ -57,5 +79,13 @@ function main() {
   $stack = $res['stack'];
   echo rtrim(json_encode($res['value'], 1344)), PHP_EOL;
   echo rtrim(json_encode(is_empty($stack), 1344)), PHP_EOL;
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/stacks/stock_span_problem.bench
+++ b/tests/algorithms/x/PHP/data_structures/stacks/stock_span_problem.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 124,
-  "memory_bytes": 39696,
+  "duration_us": 123,
+  "memory_bytes": 1682368,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/stacks/stock_span_problem.php
+++ b/tests/algorithms/x/PHP/data_structures/stacks/stock_span_problem.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -48,7 +49,7 @@ $__start = _now();
   $spans = calculation_span($price);
   print_array($spans);
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/data_structures/suffix_tree/example/example_usage.bench
+++ b/tests/algorithms/x/PHP/data_structures/suffix_tree/example/example_usage.bench
@@ -1,7 +1,5 @@
-Fatal error: Uncaught TypeError: array_slice(): Argument #1 ($array) must be of type array, string given in /workspace/mochi/tests/algorithms/x/PHP/data_structures/suffix_tree/example/example_usage.php:55
-Stack trace:
-#0 /workspace/mochi/tests/algorithms/x/PHP/data_structures/suffix_tree/example/example_usage.php(55): array_slice('monkey banana', 0, 3)
-#1 /workspace/mochi/tests/algorithms/x/PHP/data_structures/suffix_tree/example/example_usage.php(69): search(Array, 'ana')
-#2 /workspace/mochi/tests/algorithms/x/PHP/data_structures/suffix_tree/example/example_usage.php(74): main()
-#3 {main}
-  thrown in /workspace/mochi/tests/algorithms/x/PHP/data_structures/suffix_tree/example/example_usage.php on line 55
+{
+  "duration_us": 121,
+  "memory_bytes": 1679720,
+  "name": "main"
+}

--- a/tests/algorithms/x/PHP/data_structures/suffix_tree/example/example_usage.error
+++ b/tests/algorithms/x/PHP/data_structures/suffix_tree/example/example_usage.error
@@ -1,9 +1,0 @@
-run: exit status 255
-
-Fatal error: Uncaught TypeError: array_slice(): Argument #1 ($array) must be of type array, string given in /workspace/mochi/tests/algorithms/x/PHP/data_structures/suffix_tree/example/example_usage.php:38
-Stack trace:
-#0 /workspace/mochi/tests/algorithms/x/PHP/data_structures/suffix_tree/example/example_usage.php(38): array_slice('monkey banana', 0, 3)
-#1 /workspace/mochi/tests/algorithms/x/PHP/data_structures/suffix_tree/example/example_usage.php(52): search(Array, 'ana')
-#2 /workspace/mochi/tests/algorithms/x/PHP/data_structures/suffix_tree/example/example_usage.php(57): main()
-#3 {main}
-  thrown in /workspace/mochi/tests/algorithms/x/PHP/data_structures/suffix_tree/example/example_usage.php on line 38

--- a/tests/algorithms/x/PHP/data_structures/suffix_tree/example/example_usage.php
+++ b/tests/algorithms/x/PHP/data_structures/suffix_tree/example/example_usage.php
@@ -1,9 +1,20 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-function _len($x) {
-    if (is_array($x)) { return count($x); }
-    if (is_string($x)) { return strlen($x); }
-    return strlen(strval($x));
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
 }
 function _str($x) {
     if (is_array($x)) {
@@ -21,11 +32,13 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-function new_suffix_tree($text) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function new_suffix_tree($text) {
   return ['text' => $text];
-}
-function search($tree, $pattern) {
-  $n = _len($tree['text']);
+};
+  function search($tree, $pattern) {
+  $n = strlen($tree['text']);
   $m = strlen($pattern);
   if ($m == 0) {
   return true;
@@ -35,14 +48,14 @@ function search($tree, $pattern) {
 }
   $i = 0;
   while ($i <= $n - $m) {
-  if (array_slice($tree['text'], $i, $i + $m - $i) == $pattern) {
+  if (substr($tree['text'], $i, $i + $m - $i) == $pattern) {
   return true;
 }
   $i = $i + 1;
 };
   return false;
-}
-function main() {
+};
+  function main() {
   $text = 'monkey banana';
   $suffix_tree = new_suffix_tree($text);
   $patterns = ['ana', 'ban', 'na', 'xyz', 'mon'];
@@ -53,5 +66,13 @@ function main() {
   echo rtrim('Pattern \'' . $pattern . '\' found: ' . _str($found)), PHP_EOL;
   $i = $i + 1;
 };
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/suffix_tree/suffix_tree.bench
+++ b/tests/algorithms/x/PHP/data_structures/suffix_tree/suffix_tree.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 112,
-  "memory_bytes": 41168,
+  "duration_us": 211,
+  "memory_bytes": 1671160,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/suffix_tree/suffix_tree.php
+++ b/tests/algorithms/x/PHP/data_structures/suffix_tree/suffix_tree.php
@@ -1,5 +1,21 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,11 +36,13 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function new_node() {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function new_node() {
   global $st;
-  return ['children' => [], 'is_end_of_string' => false, 'start' => -1, 'end' => -1];
-}
-function has_key($m, $k) {
+  return ['children' => [], 'end' => -1, 'is_end_of_string' => false, 'start' => -1];
+};
+  function has_key($m, $k) {
   global $st;
   foreach (array_keys($m) as $key) {
   if ($key == $k) {
@@ -32,8 +50,8 @@ function has_key($m, $k) {
 }
 };
   return false;
-}
-function add_suffix(&$tree, $suffix, $index) {
+};
+  function add_suffix($tree, $suffix, $index) {
   global $st;
   $nodes = $tree['nodes'];
   $node_idx = 0;
@@ -59,8 +77,8 @@ function add_suffix(&$tree, $suffix, $index) {
   $nodes[$node_idx] = $node;
   $tree['nodes'] = $nodes;
   return $tree;
-}
-function build_suffix_tree($tree) {
+};
+  function build_suffix_tree($tree) {
   global $st;
   $text = $tree['text'];
   $n = strlen($text);
@@ -77,15 +95,15 @@ function build_suffix_tree($tree) {
   $i = $i + 1;
 };
   return $t;
-}
-function new_suffix_tree($text) {
+};
+  function new_suffix_tree($text) {
   global $st;
-  $tree = ['text' => $text, 'nodes' => []];
+  $tree = ['nodes' => [], 'text' => $text];
   $tree['nodes'] = _append($tree['nodes'], new_node());
   $tree = build_suffix_tree($tree);
   return $tree;
-}
-function search($tree, $pattern) {
+};
+  function search($tree, $pattern) {
   global $st;
   $node_idx = 0;
   $i = 0;
@@ -101,7 +119,15 @@ function search($tree, $pattern) {
   $i = $i + 1;
 };
   return true;
-}
-$st = new_suffix_tree('bananas');
-echo rtrim(_str(search($st, 'ana'))), PHP_EOL;
-echo rtrim(_str(search($st, 'apple'))), PHP_EOL;
+};
+  $st = new_suffix_tree('bananas');
+  echo rtrim(_str(search($st, 'ana'))), PHP_EOL;
+  echo rtrim(_str(search($st, 'apple'))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/suffix_tree/suffix_tree_node.bench
+++ b/tests/algorithms/x/PHP/data_structures/suffix_tree/suffix_tree_node.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 86,
-  "memory_bytes": 36584,
+  "duration_us": 114,
+  "memory_bytes": 1674144,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/suffix_tree/suffix_tree_node.php
+++ b/tests/algorithms/x/PHP/data_structures/suffix_tree/suffix_tree_node.php
@@ -1,5 +1,21 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -16,30 +32,40 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-function new_suffix_tree_node($children, $is_end_of_string, $start, $end, $suffix_link) {
-  global $root, $leaf, $nodes, $root_check, $leaf_check;
-  return ['children' => $children, 'is_end_of_string' => $is_end_of_string, 'start' => $start, 'end' => $end, 'suffix_link' => $suffix_link];
-}
-function empty_suffix_tree_node() {
-  global $root, $leaf, $nodes, $root_check, $leaf_check;
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function new_suffix_tree_node($children, $is_end_of_string, $start, $end, $suffix_link) {
+  global $leaf, $leaf_check, $nodes, $root, $root_check;
+  return ['children' => $children, 'end' => $end, 'is_end_of_string' => $is_end_of_string, 'start' => $start, 'suffix_link' => $suffix_link];
+};
+  function empty_suffix_tree_node() {
+  global $leaf, $leaf_check, $nodes, $root, $root_check;
   return new_suffix_tree_node([], false, 0 - 1, 0 - 1, 0 - 1);
-}
-function has_key($m, $k) {
-  global $root, $leaf, $nodes, $root_check, $leaf_check;
+};
+  function has_key($m, $k) {
+  global $leaf, $leaf_check, $nodes, $root, $root_check;
   foreach (array_keys($m) as $key) {
   if ($key == $k) {
   return true;
 }
 };
   return false;
-}
-$root = new_suffix_tree_node(['a' => 1], false, 0 - 1, 0 - 1, 0 - 1);
-$leaf = new_suffix_tree_node([], true, 0, 2, 0);
-$nodes = [$root, $leaf];
-$root_check = $nodes[0];
-$leaf_check = $nodes[1];
-echo rtrim(_str(has_key($root_check['children'], 'a'))), PHP_EOL;
-echo rtrim(_str($leaf_check['is_end_of_string'])), PHP_EOL;
-echo rtrim(_str($leaf_check['start'])), PHP_EOL;
-echo rtrim(_str($leaf_check['end'])), PHP_EOL;
-echo rtrim(_str($leaf_check['suffix_link'])), PHP_EOL;
+};
+  $root = new_suffix_tree_node(['a' => 1], false, 0 - 1, 0 - 1, 0 - 1);
+  $leaf = new_suffix_tree_node([], true, 0, 2, 0);
+  $nodes = [$root, $leaf];
+  $root_check = $nodes[0];
+  $leaf_check = $nodes[1];
+  echo rtrim(_str(has_key($root_check['children'], 'a'))), PHP_EOL;
+  echo rtrim(_str($leaf_check['is_end_of_string'])), PHP_EOL;
+  echo rtrim(_str($leaf_check['start'])), PHP_EOL;
+  echo rtrim(_str($leaf_check['end'])), PHP_EOL;
+  echo rtrim(_str($leaf_check['suffix_link'])), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/suffix_tree/tests/test_suffix_tree.bench
+++ b/tests/algorithms/x/PHP/data_structures/suffix_tree/tests/test_suffix_tree.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 93,
-  "memory_bytes": 36984,
+  "duration_us": 145,
+  "memory_bytes": 1673032,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/suffix_tree/tests/test_suffix_tree.php
+++ b/tests/algorithms/x/PHP/data_structures/suffix_tree/tests/test_suffix_tree.php
@@ -1,9 +1,20 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-function _len($x) {
-    if (is_array($x)) { return count($x); }
-    if (is_string($x)) { return strlen($x); }
-    return strlen(strval($x));
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
 }
 function _str($x) {
     if (is_array($x)) {
@@ -21,23 +32,25 @@ function _str($x) {
     if ($x === null) return 'null';
     return strval($x);
 }
-function suffix_tree_new($text) {
-  global $st, $patterns_exist, $i, $patterns_none, $substrings;
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function suffix_tree_new($text) {
+  global $i, $patterns_exist, $patterns_none, $st, $substrings;
   return ['text' => $text];
-}
-function suffix_tree_search($st, $pattern) {
-  global $text, $patterns_exist, $patterns_none, $substrings;
+};
+  function suffix_tree_search($st, $pattern) {
+  global $patterns_exist, $patterns_none, $substrings, $text;
   if (strlen($pattern) == 0) {
   return true;
 }
   $i = 0;
-  $n = _len($st['text']);
+  $n = strlen($st['text']);
   $m = strlen($pattern);
   while ($i <= $n - $m) {
   $j = 0;
   $found = true;
   while ($j < $m) {
-  if ($st['text'][$i + $j] != substr($pattern, $j, $j + 1 - $j)) {
+  if (substr($st['text'], $i + $j, $i + $j + 1 - ($i + $j)) != substr($pattern, $j, $j + 1 - $j)) {
   $found = false;
   break;
 }
@@ -49,26 +62,34 @@ function suffix_tree_search($st, $pattern) {
   $i = $i + 1;
 };
   return false;
-}
-$text = 'banana';
-$st = suffix_tree_new($text);
-$patterns_exist = ['ana', 'ban', 'na'];
-$i = 0;
-while ($i < count($patterns_exist)) {
+};
+  $text = 'banana';
+  $st = suffix_tree_new($text);
+  $patterns_exist = ['ana', 'ban', 'na'];
+  $i = 0;
+  while ($i < count($patterns_exist)) {
   echo rtrim(_str(suffix_tree_search($st, $patterns_exist[$i]))), PHP_EOL;
   $i = $i + 1;
 }
-$patterns_none = ['xyz', 'apple', 'cat'];
-$i = 0;
-while ($i < count($patterns_none)) {
+  $patterns_none = ['xyz', 'apple', 'cat'];
+  $i = 0;
+  while ($i < count($patterns_none)) {
   echo rtrim(_str(suffix_tree_search($st, $patterns_none[$i]))), PHP_EOL;
   $i = $i + 1;
 }
-echo rtrim(_str(suffix_tree_search($st, ''))), PHP_EOL;
-echo rtrim(_str(suffix_tree_search($st, $text))), PHP_EOL;
-$substrings = ['ban', 'ana', 'a', 'na'];
-$i = 0;
-while ($i < count($substrings)) {
+  echo rtrim(_str(suffix_tree_search($st, ''))), PHP_EOL;
+  echo rtrim(_str(suffix_tree_search($st, $text))), PHP_EOL;
+  $substrings = ['ban', 'ana', 'a', 'na'];
+  $i = 0;
+  while ($i < count($substrings)) {
   echo rtrim(_str(suffix_tree_search($st, $substrings[$i]))), PHP_EOL;
   $i = $i + 1;
 }
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/data_structures/trie/radix_tree.bench
+++ b/tests/algorithms/x/PHP/data_structures/trie/radix_tree.bench
@@ -1,16 +1,16 @@
-Warning: Undefined array key 3 in /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php on line 78
+Warning: Undefined array key 3 in /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php on line 84
 
-Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php on line 79
+Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php on line 85
 
-Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php on line 86
+Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php on line 92
 
-Fatal error: Uncaught TypeError: array_keys(): Argument #1 ($array) must be of type array, null given in /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php:149
+Fatal error: Uncaught TypeError: array_keys(): Argument #1 ($array) must be of type array, null given in /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php:155
 Stack trace:
-#0 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(149): array_keys(NULL)
-#1 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(87): has_key(NULL, 'd')
-#2 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(113): insert(Array, 3, 'danas')
-#3 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(73): insert(Array, 0, 'bandanas')
-#4 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(279): insert_many(Array, Array)
-#5 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(284): main()
+#0 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(155): array_keys(NULL)
+#1 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(93): has_key(NULL, 'd')
+#2 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(119): insert(Array, 3, 'danas')
+#3 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(79): insert(Array, 0, 'bandanas')
+#4 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(285): insert_many(Array, Array)
+#5 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(290): main()
 #6 {main}
-  thrown in /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php on line 149
+  thrown in /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php on line 155

--- a/tests/algorithms/x/PHP/data_structures/trie/radix_tree.error
+++ b/tests/algorithms/x/PHP/data_structures/trie/radix_tree.error
@@ -1,18 +1,18 @@
 run: exit status 255
 
-Warning: Undefined array key 3 in /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php on line 61
+Warning: Undefined array key 3 in /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php on line 84
 
-Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php on line 62
+Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php on line 85
 
-Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php on line 69
+Warning: Trying to access array offset on null in /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php on line 92
 
-Fatal error: Uncaught TypeError: array_keys(): Argument #1 ($array) must be of type array, null given in /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php:132
+Fatal error: Uncaught TypeError: array_keys(): Argument #1 ($array) must be of type array, null given in /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php:155
 Stack trace:
-#0 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(132): array_keys(NULL)
-#1 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(70): has_key(NULL, 'd')
-#2 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(96): insert(Array, 3, 'danas')
-#3 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(56): insert(Array, 0, 'bandanas')
-#4 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(262): insert_many(Array, Array)
-#5 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(267): main()
+#0 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(155): array_keys(NULL)
+#1 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(93): has_key(NULL, 'd')
+#2 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(119): insert(Array, 3, 'danas')
+#3 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(79): insert(Array, 0, 'bandanas')
+#4 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(285): insert_many(Array, Array)
+#5 /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php(290): main()
 #6 {main}
-  thrown in /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php on line 132
+  thrown in /workspace/mochi/tests/algorithms/x/PHP/data_structures/trie/radix_tree.php on line 155

--- a/tests/algorithms/x/PHP/data_structures/trie/trie.bench
+++ b/tests/algorithms/x/PHP/data_structures/trie/trie.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 160,
-  "memory_bytes": 74032,
+  "duration_us": 221,
+  "memory_bytes": 1659136,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/data_structures/trie/trie.php
+++ b/tests/algorithms/x/PHP/data_structures/trie/trie.php
@@ -1,6 +1,23 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _len($x) {
+    if ($x === null) { return 0; }
     if (is_array($x)) { return count($x); }
     if (is_string($x)) { return strlen($x); }
     return strlen(strval($x));
@@ -9,11 +26,13 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function new_trie() {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function new_trie() {
   global $trie;
   return ['nodes' => [['children' => [], 'is_leaf' => false]]];
-}
-function remove_key($m, $k) {
+};
+  function remove_key($m, $k) {
   global $trie;
   $out = [];
   foreach (array_keys($m) as $key) {
@@ -22,8 +41,8 @@ function remove_key($m, $k) {
 }
 };
   return $out;
-}
-function insert(&$trie, $word) {
+};
+  function insert(&$trie, $word) {
   $nodes = $trie['nodes'];
   $curr = 0;
   $i = 0;
@@ -50,13 +69,13 @@ function insert(&$trie, $word) {
   $node['is_leaf'] = true;
   $nodes[$curr] = $node;
   $trie['nodes'] = $nodes;
-}
-function insert_many(&$trie, $words) {
+};
+  function insert_many(&$trie, $words) {
   foreach ($words as $w) {
   insert($trie, $w);
 };
-}
-function find($trie, $word) {
+};
+  function find($trie, $word) {
   $nodes = $trie['nodes'];
   $curr = 0;
   $i = 0;
@@ -71,8 +90,8 @@ function find($trie, $word) {
 };
   $node = $nodes[$curr];
   return $node['is_leaf'];
-}
-function delete(&$trie, $word) {
+};
+  function delete(&$trie, $word) {
   $nodes = $trie['nodes'];
   $_delete = null;
 $_delete = function($idx, $pos) use (&$_delete, $trie, $word, &$nodes) {
@@ -105,8 +124,8 @@ $_delete = function($idx, $pos) use (&$_delete, $trie, $word, &$nodes) {
 };
   $_delete(0, 0);
   $trie['nodes'] = $nodes;
-}
-function print_words($trie) {
+};
+  function print_words($trie) {
   $dfs = null;
 $dfs = function($idx, $word) use (&$dfs, $trie) {
   $node = $trie['nodes'][$idx];
@@ -118,8 +137,8 @@ $dfs = function($idx, $word) use (&$dfs, $trie) {
 };
 };
   $dfs(0, '');
-}
-function test_trie() {
+};
+  function test_trie() {
   $words = ['banana', 'bananas', 'bandana', 'band', 'apple', 'all', 'beast'];
   $trie = new_trie();
   insert_many($trie, $words);
@@ -142,14 +161,22 @@ function test_trie() {
   $ok = $ok && ($t4 == false);
   $ok = $ok && find($trie, 'bananas');
   return $ok;
-}
-function print_results($msg, $passes) {
+};
+  function print_results($msg, $passes) {
   global $trie;
   if ($passes) {
   echo rtrim($msg . ' works!'), PHP_EOL;
 } else {
   echo rtrim($msg . ' doesn\'t work :('), PHP_EOL;
 }
-}
-$trie = new_trie();
-print_results('Testing trie functionality', test_trie());
+};
+  $trie = new_trie();
+  print_results('Testing trie functionality', test_trie());
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/digital_image_processing/change_brightness.bench
+++ b/tests/algorithms/x/PHP/digital_image_processing/change_brightness.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 84,
-  "memory_bytes": 36120,
+  "duration_us": 124,
+  "memory_bytes": 1676728,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/digital_image_processing/change_brightness.php
+++ b/tests/algorithms/x/PHP/digital_image_processing/change_brightness.php
@@ -1,10 +1,32 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function clamp($value) {
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function clamp($value) {
   global $sample;
   if ($value < 0) {
   return 0;
@@ -13,11 +35,11 @@ function clamp($value) {
   return 255;
 }
   return $value;
-}
-function change_brightness($img, $level) {
+};
+  function change_brightness($img, $level) {
   global $sample;
   if ($level < (-255) || $level > 255) {
-  $panic('level must be between -255 and 255');
+  _panic('level must be between -255 and 255');
 }
   $result = [];
   $i = 0;
@@ -32,7 +54,15 @@ function change_brightness($img, $level) {
   $i = $i + 1;
 };
   return $result;
-}
-$sample = [[100, 150], [200, 250]];
-echo rtrim(str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(change_brightness($sample, 30), 1344))))))), PHP_EOL;
-echo rtrim(str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(change_brightness($sample, -60), 1344))))))), PHP_EOL;
+};
+  $sample = [[100, 150], [200, 250]];
+  echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(change_brightness($sample, 30), 1344)))))), PHP_EOL;
+  echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(change_brightness($sample, -60), 1344)))))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/digital_image_processing/change_contrast.bench
+++ b/tests/algorithms/x/PHP/digital_image_processing/change_contrast.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 160,
-  "memory_bytes": 41024,
+  "duration_us": 309,
+  "memory_bytes": 1675736,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/digital_image_processing/change_contrast.php
+++ b/tests/algorithms/x/PHP/digital_image_processing/change_contrast.php
@@ -1,5 +1,21 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -20,7 +36,9 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function change_contrast($img, $level) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function change_contrast($img, $level) {
   global $image;
   $factor = (259.0 * ((floatval($level)) + 255.0)) / (255.0 * (259.0 - (floatval($level))));
   $result = [];
@@ -40,9 +58,9 @@ function change_contrast($img, $level) {
   $i = $i + 1;
 };
   return $result;
-}
-function print_image($img) {
-  global $image, $contrasted;
+};
+  function print_image($img) {
+  global $contrasted, $image;
   $i = 0;
   while ($i < count($img)) {
   $row = $img[$i];
@@ -55,10 +73,18 @@ function print_image($img) {
   echo rtrim($line), PHP_EOL;
   $i = $i + 1;
 };
-}
-$image = [[100, 125, 150], [175, 200, 225], [50, 75, 100]];
-echo rtrim('Original image:'), PHP_EOL;
-print_image($image);
-$contrasted = change_contrast($image, 170);
-echo rtrim('After contrast:'), PHP_EOL;
-print_image($contrasted);
+};
+  $image = [[100, 125, 150], [175, 200, 225], [50, 75, 100]];
+  echo rtrim('Original image:'), PHP_EOL;
+  print_image($image);
+  $contrasted = change_contrast($image, 170);
+  echo rtrim('After contrast:'), PHP_EOL;
+  print_image($contrasted);
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/digital_image_processing/convert_to_negative.bench
+++ b/tests/algorithms/x/PHP/digital_image_processing/convert_to_negative.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 89,
-  "memory_bytes": 36928,
+  "duration_us": 91,
+  "memory_bytes": 1681768,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/digital_image_processing/convert_to_negative.php
+++ b/tests/algorithms/x/PHP/digital_image_processing/convert_to_negative.php
@@ -1,10 +1,28 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-function convert_to_negative($img) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function convert_to_negative($img) {
   $result = [];
   $i = 0;
   while ($i < count($img)) {
@@ -22,10 +40,18 @@ function convert_to_negative($img) {
   $i = $i + 1;
 };
   return $result;
-}
-function main() {
+};
+  function main() {
   $image = [[[10, 20, 30], [0, 0, 0]], [[255, 255, 255], [100, 150, 200]]];
   $neg = convert_to_negative($image);
-  echo rtrim(str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode($neg, 1344))))))), PHP_EOL;
-}
-main();
+  echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode($neg, 1344)))))), PHP_EOL;
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/digital_image_processing/dithering/burkes.bench
+++ b/tests/algorithms/x/PHP/digital_image_processing/dithering/burkes.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 162,
-  "memory_bytes": 70744,
+  "duration_us": 180,
+  "memory_bytes": 1656568,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/digital_image_processing/dithering/burkes.php
+++ b/tests/algorithms/x/PHP/digital_image_processing/dithering/burkes.php
@@ -1,5 +1,21 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -21,20 +37,25 @@ function _append($arr, $x) {
     return $arr;
 }
 function _intdiv($a, $b) {
+    if ($b === 0 || $b === '0') {
+        throw new DivisionByZeroError();
+    }
     if (function_exists('bcdiv')) {
         $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
         return intval(bcdiv($sa, $sb, 0));
     }
-    return intdiv($a, $b);
+    return intdiv(intval($a), intval($b));
 }
-function get_greyscale($blue, $green, $red) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function get_greyscale($blue, $green, $red) {
   $b = floatval($blue);
   $g = floatval($green);
   $r = floatval($red);
   return intval((0.114 * $b + 0.587 * $g + 0.299 * $r));
-}
-function zeros($h, $w) {
+};
+  function zeros($h, $w) {
   $table = [];
   $i = 0;
   while ($i < $h) {
@@ -48,8 +69,8 @@ function zeros($h, $w) {
   $i = $i + 1;
 };
   return $table;
-}
-function burkes_dither($img, $threshold) {
+};
+  function burkes_dither($img, $threshold) {
   $height = count($img);
   $width = count($img[0]);
   $error_table = zeros($height + 1, $width + 4);
@@ -85,8 +106,8 @@ function burkes_dither($img, $threshold) {
   $y = $y + 1;
 };
   return $output;
-}
-function main() {
+};
+  function main() {
   $img = [[[0, 0, 0], [64, 64, 64], [128, 128, 128], [192, 192, 192]], [[255, 255, 255], [200, 200, 200], [150, 150, 150], [100, 100, 100]], [[30, 144, 255], [255, 0, 0], [0, 255, 0], [0, 0, 255]], [[50, 100, 150], [80, 160, 240], [70, 140, 210], [60, 120, 180]]];
   $result = burkes_dither($img, 128);
   $y = 0;
@@ -103,5 +124,13 @@ function main() {
   echo rtrim($line), PHP_EOL;
   $y = $y + 1;
 };
-}
-main();
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.bench
+++ b/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.bench
@@ -1,7 +1,7 @@
-Fatal error: Uncaught DivisionByZeroError: Division by zero in /workspace/mochi/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php:54
+Fatal error: Uncaught DivisionByZeroError: Division by zero in /workspace/mochi/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php:58
 Stack trace:
-#0 /workspace/mochi/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php(160): sqrtApprox(0.0)
-#1 /workspace/mochi/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php(246): sobel_filter(Array)
-#2 /workspace/mochi/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php(271): canny(Array, 20.0, 40.0, 128.0, 255.0)
+#0 /workspace/mochi/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php(164): sqrtApprox(0.0)
+#1 /workspace/mochi/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php(250): sobel_filter(Array)
+#2 /workspace/mochi/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php(275): canny(Array, 20.0, 40.0, 128.0, 255.0)
 #3 {main}
-  thrown in /workspace/mochi/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php on line 54
+  thrown in /workspace/mochi/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php on line 58

--- a/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.error
+++ b/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.error
@@ -1,9 +1,9 @@
 run: exit status 255
 
-Fatal error: Uncaught DivisionByZeroError: Division by zero in /workspace/mochi/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php:37
+Fatal error: Uncaught DivisionByZeroError: Division by zero in /workspace/mochi/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php:58
 Stack trace:
-#0 /workspace/mochi/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php(143): sqrtApprox(0.0)
-#1 /workspace/mochi/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php(229): sobel_filter(Array)
-#2 /workspace/mochi/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php(254): canny(Array, 20.0, 40.0, 128.0, 255.0)
+#0 /workspace/mochi/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php(164): sqrtApprox(0.0)
+#1 /workspace/mochi/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php(250): sobel_filter(Array)
+#2 /workspace/mochi/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php(275): canny(Array, 20.0, 40.0, 128.0, 255.0)
 #3 {main}
-  thrown in /workspace/mochi/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php on line 37
+  thrown in /workspace/mochi/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php on line 58

--- a/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php
+++ b/tests/algorithms/x/PHP/digital_image_processing/edge_detection/canny.php
@@ -1,5 +1,21 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -21,16 +37,21 @@ function _append($arr, $x) {
     return $arr;
 }
 function _intdiv($a, $b) {
+    if ($b === 0 || $b === '0') {
+        throw new DivisionByZeroError();
+    }
     if (function_exists('bcdiv')) {
         $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
         return intval(bcdiv($sa, $sb, 0));
     }
-    return intdiv($a, $b);
+    return intdiv(intval($a), intval($b));
 }
-$PI = 3.141592653589793;
-function sqrtApprox($x) {
-  global $PI, $GAUSSIAN_KERNEL, $SOBEL_GX, $SOBEL_GY, $image, $edges;
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $PI = 3.141592653589793;
+  function sqrtApprox($x) {
+  global $GAUSSIAN_KERNEL, $PI, $SOBEL_GX, $SOBEL_GY, $edges, $image;
   $guess = $x / 2.0;
   $i = 0;
   while ($i < 20) {
@@ -38,9 +59,9 @@ function sqrtApprox($x) {
   $i = $i + 1;
 };
   return $guess;
-}
-function atanApprox($x) {
-  global $PI, $GAUSSIAN_KERNEL, $SOBEL_GX, $SOBEL_GY, $image, $edges;
+};
+  function atanApprox($x) {
+  global $GAUSSIAN_KERNEL, $PI, $SOBEL_GX, $SOBEL_GY, $edges, $image;
   if ($x > 1.0) {
   return $PI / 2.0 - $x / ($x * $x + 0.28);
 }
@@ -48,9 +69,9 @@ function atanApprox($x) {
   return -$PI / 2.0 - $x / ($x * $x + 0.28);
 }
   return $x / (1.0 + 0.28 * $x * $x);
-}
-function atan2Approx($y, $x) {
-  global $PI, $GAUSSIAN_KERNEL, $SOBEL_GX, $SOBEL_GY, $image, $edges;
+};
+  function atan2Approx($y, $x) {
+  global $GAUSSIAN_KERNEL, $PI, $SOBEL_GX, $SOBEL_GY, $edges, $image;
   if ($x > 0.0) {
   $r = atanApprox($y / $x);
   return $r;
@@ -68,16 +89,16 @@ function atan2Approx($y, $x) {
   return -$PI / 2.0;
 }
   return 0.0;
-}
-function deg($rad) {
-  global $PI, $GAUSSIAN_KERNEL, $SOBEL_GX, $SOBEL_GY, $image, $edges;
+};
+  function deg($rad) {
+  global $GAUSSIAN_KERNEL, $PI, $SOBEL_GX, $SOBEL_GY, $edges, $image;
   return $rad * 180.0 / $PI;
-}
-$GAUSSIAN_KERNEL = [[0.0625, 0.125, 0.0625], [0.125, 0.25, 0.125], [0.0625, 0.125, 0.0625]];
-$SOBEL_GX = [[-1.0, 0.0, 1.0], [-2.0, 0.0, 2.0], [-1.0, 0.0, 1.0]];
-$SOBEL_GY = [[1.0, 2.0, 1.0], [0.0, 0.0, 0.0], [-1.0, -2.0, -1.0]];
-function zero_matrix($h, $w) {
-  global $PI, $GAUSSIAN_KERNEL, $SOBEL_GX, $SOBEL_GY, $image, $edges;
+};
+  $GAUSSIAN_KERNEL = [[0.0625, 0.125, 0.0625], [0.125, 0.25, 0.125], [0.0625, 0.125, 0.0625]];
+  $SOBEL_GX = [[-1.0, 0.0, 1.0], [-2.0, 0.0, 2.0], [-1.0, 0.0, 1.0]];
+  $SOBEL_GY = [[1.0, 2.0, 1.0], [0.0, 0.0, 0.0], [-1.0, -2.0, -1.0]];
+  function zero_matrix($h, $w) {
+  global $GAUSSIAN_KERNEL, $PI, $SOBEL_GX, $SOBEL_GY, $edges, $image;
   $out = [];
   $i = 0;
   while ($i < $h) {
@@ -91,9 +112,9 @@ function zero_matrix($h, $w) {
   $i = $i + 1;
 };
   return $out;
-}
-function convolve($img, $kernel) {
-  global $PI, $GAUSSIAN_KERNEL, $SOBEL_GX, $SOBEL_GY, $image, $edges;
+};
+  function convolve($img, $kernel) {
+  global $GAUSSIAN_KERNEL, $PI, $SOBEL_GX, $SOBEL_GY, $edges, $image;
   $h = count($img);
   $w = count($img[0]);
   $k = count($kernel);
@@ -121,13 +142,13 @@ function convolve($img, $kernel) {
   $y = $y + 1;
 };
   return $out;
-}
-function gaussian_blur($img) {
-  global $PI, $GAUSSIAN_KERNEL, $SOBEL_GX, $SOBEL_GY, $image, $edges;
+};
+  function gaussian_blur($img) {
+  global $GAUSSIAN_KERNEL, $PI, $SOBEL_GX, $SOBEL_GY, $edges, $image;
   return convolve($img, $GAUSSIAN_KERNEL);
-}
-function sobel_filter($img) {
-  global $PI, $GAUSSIAN_KERNEL, $SOBEL_GX, $SOBEL_GY, $image, $edges;
+};
+  function sobel_filter($img) {
+  global $GAUSSIAN_KERNEL, $PI, $SOBEL_GX, $SOBEL_GY, $edges, $image;
   $gx = convolve($img, $SOBEL_GX);
   $gy = convolve($img, $SOBEL_GY);
   $h = count($img);
@@ -146,10 +167,10 @@ function sobel_filter($img) {
 };
   $i = $i + 1;
 };
-  return ['grad' => $grad, 'dir' => $dir];
-}
-function suppress_non_maximum($h, $w, $direction, $grad) {
-  global $PI, $GAUSSIAN_KERNEL, $SOBEL_GX, $SOBEL_GY, $image, $edges;
+  return ['dir' => $dir, 'grad' => $grad];
+};
+  function suppress_non_maximum($h, $w, $direction, $grad) {
+  global $GAUSSIAN_KERNEL, $PI, $SOBEL_GX, $SOBEL_GY, $edges, $image;
   $dest = zero_matrix($h, $w);
   $r = 1;
   while ($r < $h - 1) {
@@ -183,9 +204,9 @@ function suppress_non_maximum($h, $w, $direction, $grad) {
   $r = $r + 1;
 };
   return $dest;
-}
-function double_threshold($h, $w, &$img, $low, $high, $weak, $strong) {
-  global $PI, $GAUSSIAN_KERNEL, $SOBEL_GX, $SOBEL_GY, $image, $edges;
+};
+  function double_threshold($h, $w, &$img, $low, $high, $weak, $strong) {
+  global $GAUSSIAN_KERNEL, $PI, $SOBEL_GX, $SOBEL_GY, $edges, $image;
   $r = 0;
   while ($r < $h) {
   $c = 0;
@@ -204,9 +225,9 @@ function double_threshold($h, $w, &$img, $low, $high, $weak, $strong) {
 };
   $r = $r + 1;
 };
-}
-function track_edge($h, $w, &$img, $weak, $strong) {
-  global $PI, $GAUSSIAN_KERNEL, $SOBEL_GX, $SOBEL_GY, $image, $edges;
+};
+  function track_edge($h, $w, &$img, $weak, $strong) {
+  global $GAUSSIAN_KERNEL, $PI, $SOBEL_GX, $SOBEL_GY, $edges, $image;
   $r = 1;
   while ($r < $h - 1) {
   $c = 1;
@@ -222,9 +243,9 @@ function track_edge($h, $w, &$img, $weak, $strong) {
 };
   $r = $r + 1;
 };
-}
-function canny($image, $low, $high, $weak, $strong) {
-  global $PI, $GAUSSIAN_KERNEL, $SOBEL_GX, $SOBEL_GY, $edges;
+};
+  function canny($image, $low, $high, $weak, $strong) {
+  global $GAUSSIAN_KERNEL, $PI, $SOBEL_GX, $SOBEL_GY, $edges;
   $blurred = gaussian_blur($image);
   $sob = sobel_filter($blurred);
   $grad = $sob['grad'];
@@ -235,9 +256,9 @@ function canny($image, $low, $high, $weak, $strong) {
   double_threshold($h, $w, $suppressed, $low, $high, $weak, $strong);
   track_edge($h, $w, $suppressed, $weak, $strong);
   return $suppressed;
-}
-function print_image($img) {
-  global $PI, $GAUSSIAN_KERNEL, $SOBEL_GX, $SOBEL_GY, $image, $edges;
+};
+  function print_image($img) {
+  global $GAUSSIAN_KERNEL, $PI, $SOBEL_GX, $SOBEL_GY, $edges, $image;
   $r = 0;
   while ($r < count($img)) {
   $c = 0;
@@ -249,7 +270,15 @@ function print_image($img) {
   echo rtrim($line), PHP_EOL;
   $r = $r + 1;
 };
-}
-$image = [[0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 255.0, 255.0, 255.0, 0.0], [0.0, 255.0, 255.0, 255.0, 0.0], [0.0, 255.0, 255.0, 255.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0]];
-$edges = canny($image, 20.0, 40.0, 128.0, 255.0);
-print_image($edges);
+};
+  $image = [[0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 255.0, 255.0, 255.0, 0.0], [0.0, 255.0, 255.0, 255.0, 0.0], [0.0, 255.0, 255.0, 255.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0]];
+  $edges = canny($image, 20.0, 40.0, 128.0, 255.0);
+  print_image($edges);
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/digital_image_processing/filters/bilateral_filter.bench
+++ b/tests/algorithms/x/PHP/digital_image_processing/filters/bilateral_filter.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 106,
-  "memory_bytes": 74736,
+  "duration_us": 151,
+  "memory_bytes": 1656984,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/digital_image_processing/filters/bilateral_filter.php
+++ b/tests/algorithms/x/PHP/digital_image_processing/filters/bilateral_filter.php
@@ -1,22 +1,43 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _intdiv($a, $b) {
+    if ($b === 0 || $b === '0') {
+        throw new DivisionByZeroError();
+    }
     if (function_exists('bcdiv')) {
         $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
         return intval(bcdiv($sa, $sb, 0));
     }
-    return intdiv($a, $b);
+    return intdiv(intval($a), intval($b));
 }
-$PI = 3.141592653589793;
-function mochi_abs($x) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $PI = 3.141592653589793;
+  function mochi_abs($x) {
   global $PI, $img, $result;
   if ($x < 0.0) {
   return -$x;
 }
   return $x;
-}
-function sqrtApprox($x) {
+};
+  function sqrtApprox($x) {
   global $PI, $img, $result;
   if ($x <= 0.0) {
   return 0.0;
@@ -28,8 +49,8 @@ function sqrtApprox($x) {
   $i = $i + 1;
 };
   return $guess;
-}
-function expApprox($x) {
+};
+  function expApprox($x) {
   global $PI, $img, $result;
   $term = 1.0;
   $sum = 1.0;
@@ -40,8 +61,8 @@ function expApprox($x) {
   $n = $n + 1;
 };
   return $sum;
-}
-function vec_gaussian($mat, $variance) {
+};
+  function vec_gaussian($mat, $variance) {
   global $PI, $img, $result;
   $i = 0;
   $out = [];
@@ -58,8 +79,8 @@ function vec_gaussian($mat, $variance) {
   $i = $i + 1;
 };
   return $out;
-}
-function get_slice($img, $x, $y, $kernel_size) {
+};
+  function get_slice($img, $x, $y, $kernel_size) {
   global $PI, $result;
   $half = _intdiv($kernel_size, 2);
   $i = $x - $half;
@@ -75,8 +96,8 @@ function get_slice($img, $x, $y, $kernel_size) {
   $i = $i + 1;
 };
   return $slice;
-}
-function get_gauss_kernel($kernel_size, $spatial_variance) {
+};
+  function get_gauss_kernel($kernel_size, $spatial_variance) {
   global $PI, $img, $result;
   $arr = [];
   $i = 0;
@@ -94,8 +115,8 @@ function get_gauss_kernel($kernel_size, $spatial_variance) {
   $i = $i + 1;
 };
   return vec_gaussian($arr, $spatial_variance);
-}
-function elementwise_sub($mat, $value) {
+};
+  function elementwise_sub($mat, $value) {
   global $PI, $img, $result;
   $res = [];
   $i = 0;
@@ -110,8 +131,8 @@ function elementwise_sub($mat, $value) {
   $i = $i + 1;
 };
   return $res;
-}
-function elementwise_mul($a, $b) {
+};
+  function elementwise_mul($a, $b) {
   global $PI, $img, $result;
   $res = [];
   $i = 0;
@@ -126,8 +147,8 @@ function elementwise_mul($a, $b) {
   $i = $i + 1;
 };
   return $res;
-}
-function matrix_sum($mat) {
+};
+  function matrix_sum($mat) {
   global $PI, $img, $result;
   $total = 0.0;
   $i = 0;
@@ -140,8 +161,8 @@ function matrix_sum($mat) {
   $i = $i + 1;
 };
   return $total;
-}
-function bilateral_filter($img, $spatial_variance, $intensity_variance, $kernel_size) {
+};
+  function bilateral_filter($img, $spatial_variance, $intensity_variance, $kernel_size) {
   global $PI, $result;
   $gauss_ker = get_gauss_kernel($kernel_size, $spatial_variance);
   $img_s = $img;
@@ -156,7 +177,15 @@ function bilateral_filter($img, $spatial_variance, $intensity_variance, $kernel_
   $val = matrix_sum($vals) / $sum_weights;
 }
   return $val;
-}
-$img = [[0.2, 0.3, 0.4], [0.3, 0.4, 0.5], [0.4, 0.5, 0.6]];
-$result = bilateral_filter($img, 1.0, 1.0, 3);
-echo rtrim(json_encode($result, 1344)), PHP_EOL;
+};
+  $img = [[0.2, 0.3, 0.4], [0.3, 0.4, 0.5], [0.4, 0.5, 0.6]];
+  $result = bilateral_filter($img, 1.0, 1.0, 3);
+  echo rtrim(json_encode($result, 1344)), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/digital_image_processing/filters/convolve.bench
+++ b/tests/algorithms/x/PHP/digital_image_processing/filters/convolve.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 188,
-  "memory_bytes": 74448,
+  "duration_us": 286,
+  "memory_bytes": 1658312,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/digital_image_processing/filters/convolve.php
+++ b/tests/algorithms/x/PHP/digital_image_processing/filters/convolve.php
@@ -1,5 +1,21 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -21,14 +37,19 @@ function _append($arr, $x) {
     return $arr;
 }
 function _intdiv($a, $b) {
+    if ($b === 0 || $b === '0') {
+        throw new DivisionByZeroError();
+    }
     if (function_exists('bcdiv')) {
         $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
         return intval(bcdiv($sa, $sb, 0));
     }
-    return intdiv($a, $b);
+    return intdiv(intval($a), intval($b));
 }
-function pad_edge($image, $pad_size) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function pad_edge($image, $pad_size) {
   global $laplace_kernel, $result;
   $height = count($image);
   $width = count($image[0]);
@@ -65,8 +86,8 @@ function pad_edge($image, $pad_size) {
   $i = $i + 1;
 };
   return $padded;
-}
-function im2col($image, $block_h, $block_w) {
+};
+  function im2col($image, $block_h, $block_w) {
   global $laplace_kernel, $result;
   $rows = count($image);
   $cols = count($image[0]);
@@ -93,8 +114,8 @@ function im2col($image, $block_h, $block_w) {
   $i = $i + 1;
 };
   return $image_array;
-}
-function flatten($matrix) {
+};
+  function flatten($matrix) {
   global $image, $laplace_kernel, $result;
   $out = [];
   $i = 0;
@@ -107,8 +128,8 @@ function flatten($matrix) {
   $i = $i + 1;
 };
   return $out;
-}
-function dot($a, $b) {
+};
+  function dot($a, $b) {
   global $image, $laplace_kernel, $result;
   $sum = 0;
   $i = 0;
@@ -117,8 +138,8 @@ function dot($a, $b) {
   $i = $i + 1;
 };
   return $sum;
-}
-function img_convolve($image, $kernel) {
+};
+  function img_convolve($image, $kernel) {
   global $laplace_kernel, $result;
   $height = count($image);
   $width = count($image[0]);
@@ -143,8 +164,8 @@ function img_convolve($image, $kernel) {
   $i = $i + 1;
 };
   return $dst;
-}
-function print_matrix($m) {
+};
+  function print_matrix($m) {
   global $image, $laplace_kernel, $result;
   $i = 0;
   while ($i < count($m)) {
@@ -160,8 +181,16 @@ function print_matrix($m) {
   echo rtrim($line), PHP_EOL;
   $i = $i + 1;
 };
-}
-$image = [[1, 2, 3, 0, 0], [4, 5, 6, 0, 0], [7, 8, 9, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]];
-$laplace_kernel = [[0, 1, 0], [1, -4, 1], [0, 1, 0]];
-$result = img_convolve($image, $laplace_kernel);
-print_matrix($result);
+};
+  $image = [[1, 2, 3, 0, 0], [4, 5, 6, 0, 0], [7, 8, 9, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]];
+  $laplace_kernel = [[0, 1, 0], [1, -4, 1], [0, 1, 0]];
+  $result = img_convolve($image, $laplace_kernel);
+  print_matrix($result);
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/tests/algorithms/x/PHP/digital_image_processing/filters/gabor_filter.bench
+++ b/tests/algorithms/x/PHP/digital_image_processing/filters/gabor_filter.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 101,
-  "memory_bytes": 40512,
+  "duration_us": 140,
+  "memory_bytes": 1670312,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/digital_image_processing/filters/gabor_filter.php
+++ b/tests/algorithms/x/PHP/digital_image_processing/filters/gabor_filter.php
@@ -1,23 +1,44 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
 function _intdiv($a, $b) {
+    if ($b === 0 || $b === '0') {
+        throw new DivisionByZeroError();
+    }
     if (function_exists('bcdiv')) {
         $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
         return intval(bcdiv($sa, $sb, 0));
     }
-    return intdiv($a, $b);
+    return intdiv(intval($a), intval($b));
 }
-$PI = 3.141592653589793;
-function to_radians($deg) {
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $PI = 3.141592653589793;
+  function to_radians($deg) {
   global $PI, $kernel;
   return $deg * $PI / 180.0;
-}
-function sin_taylor($x) {
+};
+  function sin_taylor($x) {
   global $PI, $kernel;
   $term = $x;
   $sum = $x;
@@ -30,8 +51,8 @@ function sin_taylor($x) {
   $i = $i + 1;
 };
   return $sum;
-}
-function cos_taylor($x) {
+};
+  function cos_taylor($x) {
   global $PI, $kernel;
   $term = 1.0;
   $sum = 1.0;
@@ -44,8 +65,8 @@ function cos_taylor($x) {
   $i = $i + 1;
 };
   return $sum;
-}
-function exp_taylor($x) {
+};
+  function exp_taylor($x) {
   global $PI, $kernel;
   $term = 1.0;
   $sum = 1.0;
@@ -56,8 +77,8 @@ function exp_taylor($x) {
   $i = $i + 1.0;
 };
   return $sum;
-}
-function gabor_filter_kernel($ksize, $sigma, $theta, $lambd, $gamma, $psi) {
+};
+  function gabor_filter_kernel($ksize, $sigma, $theta, $lambd, $gamma, $psi) {
   global $PI, $kernel;
   $size = $ksize;
   if ($size % 2 == 0) {
@@ -85,6 +106,14 @@ function gabor_filter_kernel($ksize, $sigma, $theta, $lambd, $gamma, $psi) {
   $y = $y + 1;
 };
   return $gabor;
-}
-$kernel = gabor_filter_kernel(3, 8.0, 0.0, 10.0, 0.0, 0.0);
-echo rtrim(str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode($kernel, 1344))))))), PHP_EOL;
+};
+  $kernel = gabor_filter_kernel(3, 8.0, 0.0, 10.0, 0.0, 0.0);
+  echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode($kernel, 1344)))))), PHP_EOL;
+$__end = _now();
+$__end_mem = memory_get_peak_usage(true);
+$__duration = max(1, intdiv($__end - $__start, 1000));
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;

--- a/transpiler/x/php/ALGORITHMS.md
+++ b/transpiler/x/php/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated PHP code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/PHP`.
-Last updated: 2025-08-24 17:12 GMT+7
+Last updated: 2025-08-24 22:26 GMT+7
 
-## Algorithms Golden Test Checklist (1002/1077)
+## Algorithms Golden Test Checklist (1004/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 117µs | 38.8 KB |
@@ -231,56 +231,56 @@ Last updated: 2025-08-24 17:12 GMT+7
 | 222 | data_structures/kd_tree/tests/test_kdtree | ✓ | 96µs | 1.6 MB |
 | 223 | data_structures/linked_list/circular_linked_list | ✓ | 94µs | 1.6 MB |
 | 224 | data_structures/linked_list/deque_doubly | ✓ | 103µs | 1.6 MB |
-| 225 | data_structures/linked_list/doubly_linked_list | ✓ | 95µs | 1.6 MB |
-| 226 | data_structures/linked_list/doubly_linked_list_two | ✓ | 181µs | 95.4 KB |
-| 227 | data_structures/linked_list/floyds_cycle_detection | ✓ | 85µs | 36.7 KB |
-| 228 | data_structures/linked_list/from_sequence | ✓ | 132µs | 37.0 KB |
-| 229 | data_structures/linked_list/has_loop | ✓ | 84µs | 35.1 KB |
-| 230 | data_structures/linked_list/is_palindrome | ✓ | 76µs | 34.3 KB |
-| 231 | data_structures/linked_list/merge_two_lists | ✓ | 145µs | 37.3 KB |
-| 232 | data_structures/linked_list/middle_element_of_linked_list | ✓ | 105µs | 36.8 KB |
-| 233 | data_structures/linked_list/print_reverse | ✓ | 80µs | 37.4 KB |
-| 234 | data_structures/linked_list/reverse_k_group | ✓ | 74µs | 38.4 KB |
-| 235 | data_structures/linked_list/rotate_to_the_right | ✓ | 100µs | 35.0 KB |
-| 236 | data_structures/linked_list/singly_linked_list | ✓ | 94µs | 70.8 KB |
-| 237 | data_structures/linked_list/skip_list | ✓ | 109µs | 72.7 KB |
-| 238 | data_structures/linked_list/swap_nodes | ✓ | 99µs | 37.1 KB |
-| 239 | data_structures/queues/circular_queue | ✓ | 98µs | 40.4 KB |
-| 240 | data_structures/queues/circular_queue_linked_list | ✓ | 132µs | 41.6 KB |
-| 241 | data_structures/queues/double_ended_queue | ✓ | 135µs | 41.6 KB |
-| 242 | data_structures/queues/linked_queue | ✓ | 117µs | 37.2 KB |
-| 243 | data_structures/queues/priority_queue_using_list | ✓ | 161µs | 75.6 KB |
-| 244 | data_structures/queues/queue_by_list | ✓ | 90µs | 37.2 KB |
-| 245 | data_structures/queues/queue_by_two_stacks | ✓ | 77µs | 37.3 KB |
-| 246 | data_structures/queues/queue_on_pseudo_stack | ✓ | 83µs | 41.2 KB |
-| 247 | data_structures/stacks/balanced_parentheses | ✓ | 109µs | 39.4 KB |
-| 248 | data_structures/stacks/dijkstras_two_stack_algorithm | ✓ | 91µs | 40.7 KB |
-| 249 | data_structures/stacks/infix_to_postfix_conversion | ✓ | 140µs | 37.4 KB |
-| 250 | data_structures/stacks/infix_to_prefix_conversion | ✓ | 1µs | 36.8 KB |
-| 251 | data_structures/stacks/largest_rectangle_histogram | ✓ | 90µs | 39.2 KB |
-| 252 | data_structures/stacks/lexicographical_numbers | ✓ | 132µs | 35.4 KB |
-| 253 | data_structures/stacks/next_greater_element | error |  |  |
-| 254 | data_structures/stacks/postfix_evaluation | ✓ | 114µs | 36.2 KB |
-| 255 | data_structures/stacks/prefix_evaluation | ✓ | 150µs | 40.3 KB |
-| 256 | data_structures/stacks/stack | ✓ | 117µs | 37.7 KB |
-| 257 | data_structures/stacks/stack_using_two_queues | ✓ | 97µs | 37.1 KB |
-| 258 | data_structures/stacks/stack_with_doubly_linked_list | ✓ | 166µs | 41.4 KB |
-| 259 | data_structures/stacks/stack_with_singly_linked_list | ✓ | 80µs | 36.7 KB |
-| 260 | data_structures/stacks/stock_span_problem | ✓ | 124µs | 38.8 KB |
-| 261 | data_structures/suffix_tree/example/example_usage | error |  |  |
-| 262 | data_structures/suffix_tree/suffix_tree | ✓ | 112µs | 40.2 KB |
-| 263 | data_structures/suffix_tree/suffix_tree_node | ✓ | 86µs | 35.7 KB |
-| 264 | data_structures/suffix_tree/tests/test_suffix_tree | ✓ | 93µs | 36.1 KB |
+| 225 | data_structures/linked_list/doubly_linked_list | ✓ | 117µs | 1.6 MB |
+| 226 | data_structures/linked_list/doubly_linked_list_two | ✓ | 202µs | 1.6 MB |
+| 227 | data_structures/linked_list/floyds_cycle_detection | ✓ | 99µs | 1.6 MB |
+| 228 | data_structures/linked_list/from_sequence | ✓ | 552µs | 1.6 MB |
+| 229 | data_structures/linked_list/has_loop | ✓ | 123µs | 1.6 MB |
+| 230 | data_structures/linked_list/is_palindrome | ✓ | 100µs | 1.6 MB |
+| 231 | data_structures/linked_list/merge_two_lists | ✓ | 173µs | 1.6 MB |
+| 232 | data_structures/linked_list/middle_element_of_linked_list | ✓ | 102µs | 1.6 MB |
+| 233 | data_structures/linked_list/print_reverse | ✓ | 95µs | 1.6 MB |
+| 234 | data_structures/linked_list/reverse_k_group | ✓ | 124µs | 1.6 MB |
+| 235 | data_structures/linked_list/rotate_to_the_right | ✓ | 112µs | 1.6 MB |
+| 236 | data_structures/linked_list/singly_linked_list | ✓ | 389µs | 1.6 MB |
+| 237 | data_structures/linked_list/skip_list | ✓ | 181µs | 1.6 MB |
+| 238 | data_structures/linked_list/swap_nodes | ✓ | 247µs | 1.6 MB |
+| 239 | data_structures/queues/circular_queue | ✓ | 259µs | 1.6 MB |
+| 240 | data_structures/queues/circular_queue_linked_list | ✓ | 127µs | 1.6 MB |
+| 241 | data_structures/queues/double_ended_queue | ✓ | 141µs | 1.6 MB |
+| 242 | data_structures/queues/linked_queue | ✓ | 156µs | 1.6 MB |
+| 243 | data_structures/queues/priority_queue_using_list | ✓ | 391µs | 1.6 MB |
+| 244 | data_structures/queues/queue_by_list | ✓ | 154µs | 1.6 MB |
+| 245 | data_structures/queues/queue_by_two_stacks | ✓ | 92µs | 1.6 MB |
+| 246 | data_structures/queues/queue_on_pseudo_stack | ✓ | 113µs | 1.6 MB |
+| 247 | data_structures/stacks/balanced_parentheses | ✓ | 128µs | 1.6 MB |
+| 248 | data_structures/stacks/dijkstras_two_stack_algorithm | ✓ | 132µs | 1.6 MB |
+| 249 | data_structures/stacks/infix_to_postfix_conversion | ✓ | 229µs | 1.6 MB |
+| 250 | data_structures/stacks/infix_to_prefix_conversion | ✓ | 1µs | 1.6 MB |
+| 251 | data_structures/stacks/largest_rectangle_histogram | ✓ | 155µs | 1.6 MB |
+| 252 | data_structures/stacks/lexicographical_numbers | ✓ | 172µs | 1.6 MB |
+| 253 | data_structures/stacks/next_greater_element | ✓ | 165µs | 1.6 MB |
+| 254 | data_structures/stacks/postfix_evaluation | ✓ | 131µs | 1.6 MB |
+| 255 | data_structures/stacks/prefix_evaluation | ✓ | 223µs | 1.6 MB |
+| 256 | data_structures/stacks/stack | ✓ | 151µs | 1.6 MB |
+| 257 | data_structures/stacks/stack_using_two_queues | ✓ | 123µs | 1.6 MB |
+| 258 | data_structures/stacks/stack_with_doubly_linked_list | ✓ | 136µs | 1.6 MB |
+| 259 | data_structures/stacks/stack_with_singly_linked_list | ✓ | 145µs | 1.6 MB |
+| 260 | data_structures/stacks/stock_span_problem | ✓ | 123µs | 1.6 MB |
+| 261 | data_structures/suffix_tree/example/example_usage | ✓ | 121µs | 1.6 MB |
+| 262 | data_structures/suffix_tree/suffix_tree | ✓ | 211µs | 1.6 MB |
+| 263 | data_structures/suffix_tree/suffix_tree_node | ✓ | 114µs | 1.6 MB |
+| 264 | data_structures/suffix_tree/tests/test_suffix_tree | ✓ | 145µs | 1.6 MB |
 | 265 | data_structures/trie/radix_tree | error |  |  |
-| 266 | data_structures/trie/trie | ✓ | 160µs | 72.3 KB |
-| 267 | digital_image_processing/change_brightness | ✓ | 84µs | 35.3 KB |
-| 268 | digital_image_processing/change_contrast | ✓ | 160µs | 40.1 KB |
-| 269 | digital_image_processing/convert_to_negative | ✓ | 89µs | 36.1 KB |
-| 270 | digital_image_processing/dithering/burkes | ✓ | 162µs | 69.1 KB |
+| 266 | data_structures/trie/trie | ✓ | 221µs | 1.6 MB |
+| 267 | digital_image_processing/change_brightness | ✓ | 124µs | 1.6 MB |
+| 268 | digital_image_processing/change_contrast | ✓ | 309µs | 1.6 MB |
+| 269 | digital_image_processing/convert_to_negative | ✓ | 91µs | 1.6 MB |
+| 270 | digital_image_processing/dithering/burkes | ✓ | 180µs | 1.6 MB |
 | 271 | digital_image_processing/edge_detection/canny | error |  |  |
-| 272 | digital_image_processing/filters/bilateral_filter | ✓ | 106µs | 73.0 KB |
-| 273 | digital_image_processing/filters/convolve | ✓ | 188µs | 72.7 KB |
-| 274 | digital_image_processing/filters/gabor_filter | ✓ | 101µs | 39.6 KB |
+| 272 | digital_image_processing/filters/bilateral_filter | ✓ | 151µs | 1.6 MB |
+| 273 | digital_image_processing/filters/convolve | ✓ | 286µs | 1.6 MB |
+| 274 | digital_image_processing/filters/gabor_filter | ✓ | 140µs | 1.6 MB |
 | 275 | digital_image_processing/filters/gaussian_filter | ✓ | 114µs | 40.4 KB |
 | 276 | digital_image_processing/filters/laplacian_filter | ✓ | 114µs | 71.3 KB |
 | 277 | digital_image_processing/filters/local_binary_pattern | ✓ | 91µs | 39.0 KB |

--- a/transpiler/x/php/transpiler.go
+++ b/transpiler/x/php/transpiler.go
@@ -4871,6 +4871,12 @@ func exprType(e Expr) types.Type {
 			return tt.Value
 		case types.StringType:
 			return types.StringType{}
+		case types.StructType:
+			if lit, ok := v.Index.(*StringLit); ok {
+				if field, ok := tt.Fields[lit.Value]; ok {
+					return field
+				}
+			}
 		}
 	case *SubstringExpr:
 		return types.StringType{}


### PR DESCRIPTION
## Summary
- support struct field type lookup so string slices use `substr`
- regenerate PHP algorithm fixtures and benchmarks for indices 225–274
- update ALGORITHMS.md

## Testing
- `MOCHI_ALG_INDEX=261 MOCHI_BENCHMARK=1 go test -run TestPHPTranspiler_Algorithms_Golden -tags slow ./transpiler/x/php -update-algorithms-php`
- `for i in $(seq 225 274); do MOCHI_ALG_INDEX=$i MOCHI_BENCHMARK=1 go test -run TestPHPTranspiler_Algorithms_Golden -tags slow ./transpiler/x/php -update-algorithms-php; done`

------
https://chatgpt.com/codex/tasks/task_e_68ab2d1af9148320930c9e179c0460d6