### PR TITLE
clojure: handle heap mutation in transpiler

### DIFF
--- a/tests/algorithms/x/Clojure/data_structures/heap/heap_generic.bench
+++ b/tests/algorithms/x/Clojure/data_structures/heap/heap_generic.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 86735,
+  "memory_bytes": 28738032,
+  "name": "main"
+}

--- a/tests/algorithms/x/Clojure/data_structures/heap/heap_generic.clj
+++ b/tests/algorithms/x/Clojure/data_structures/heap/heap_generic.clj
@@ -46,6 +46,8 @@
 
 (def ^:dynamic delete_item_pm nil)
 
+(def ^:dynamic extract_top_h nil)
+
 (def ^:dynamic extract_top_top nil)
 
 (def ^:dynamic get_top_arr nil)
@@ -56,9 +58,13 @@
 
 (def ^:dynamic get_valid_parent_vp nil)
 
+(def ^:dynamic heapify_down_h nil)
+
 (def ^:dynamic heapify_down_idx nil)
 
 (def ^:dynamic heapify_down_vp nil)
+
+(def ^:dynamic heapify_up_h nil)
 
 (def ^:dynamic heapify_up_idx nil)
 
@@ -119,26 +125,26 @@
 (defn get_valid_parent [get_valid_parent_h get_valid_parent_i]
   (binding [get_valid_parent_l nil get_valid_parent_r nil get_valid_parent_vp nil] (try (do (set! get_valid_parent_vp get_valid_parent_i) (set! get_valid_parent_l (left get_valid_parent_i (:size get_valid_parent_h))) (when (and (not= get_valid_parent_l -1) (= (cmp get_valid_parent_h get_valid_parent_l get_valid_parent_vp) false)) (set! get_valid_parent_vp get_valid_parent_l)) (set! get_valid_parent_r (right get_valid_parent_i (:size get_valid_parent_h))) (when (and (not= get_valid_parent_r -1) (= (cmp get_valid_parent_h get_valid_parent_r get_valid_parent_vp) false)) (set! get_valid_parent_vp get_valid_parent_r)) (throw (ex-info "return" {:v get_valid_parent_vp}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
 
-(defn heapify_up [heapify_up_h heapify_up_index]
-  (binding [heapify_up_idx nil heapify_up_p nil] (do (set! heapify_up_idx heapify_up_index) (set! heapify_up_p (parent heapify_up_idx)) (while (and (not= heapify_up_p -1) (= (cmp heapify_up_h heapify_up_idx heapify_up_p) false)) (do (let [__res (swap heapify_up_h heapify_up_idx heapify_up_p)] (do (set! heapify_up_h swap_h) __res)) (set! heapify_up_idx heapify_up_p) (set! heapify_up_p (parent heapify_up_p)))))))
+(defn heapify_up [heapify_up_h_p heapify_up_index]
+  (binding [heapify_up_h heapify_up_h_p heapify_up_idx nil heapify_up_p nil] (try (do (set! heapify_up_idx heapify_up_index) (set! heapify_up_p (parent heapify_up_idx)) (while (and (not= heapify_up_p -1) (= (cmp heapify_up_h heapify_up_idx heapify_up_p) false)) (do (let [__res (swap heapify_up_h heapify_up_idx heapify_up_p)] (do (set! heapify_up_h swap_h) __res)) (set! heapify_up_idx heapify_up_p) (set! heapify_up_p (parent heapify_up_p))))) (finally (alter-var-root (var heapify_up_h) (constantly heapify_up_h))))))
 
-(defn heapify_down [heapify_down_h heapify_down_index]
-  (binding [heapify_down_idx nil heapify_down_vp nil] (do (set! heapify_down_idx heapify_down_index) (set! heapify_down_vp (get_valid_parent heapify_down_h heapify_down_idx)) (while (not= heapify_down_vp heapify_down_idx) (do (let [__res (swap heapify_down_h heapify_down_idx heapify_down_vp)] (do (set! heapify_down_h swap_h) __res)) (set! heapify_down_idx heapify_down_vp) (set! heapify_down_vp (get_valid_parent heapify_down_h heapify_down_idx)))))))
+(defn heapify_down [heapify_down_h_p heapify_down_index]
+  (binding [heapify_down_h heapify_down_h_p heapify_down_idx nil heapify_down_vp nil] (try (do (set! heapify_down_idx heapify_down_index) (set! heapify_down_vp (get_valid_parent heapify_down_h heapify_down_idx)) (while (not= heapify_down_vp heapify_down_idx) (do (let [__res (swap heapify_down_h heapify_down_idx heapify_down_vp)] (do (set! heapify_down_h swap_h) __res)) (set! heapify_down_idx heapify_down_vp) (set! heapify_down_vp (get_valid_parent heapify_down_h heapify_down_idx))))) (finally (alter-var-root (var heapify_down_h) (constantly heapify_down_h))))))
 
 (defn update_item [update_item_h_p update_item_item update_item_item_value]
-  (binding [update_item_h update_item_h_p update_item_arr nil update_item_index nil update_item_pm nil] (try (do (set! update_item_pm (:pos_map update_item_h)) (when (= (get update_item_pm update_item_item) 0) (throw (ex-info "return" {:v nil}))) (set! update_item_index (- (get update_item_pm update_item_item) 1)) (set! update_item_arr (:arr update_item_h)) (set! update_item_arr (assoc update_item_arr update_item_index [update_item_item ((:key update_item_h) update_item_item_value)])) (set! update_item_h (assoc update_item_h :arr update_item_arr)) (set! update_item_h (assoc update_item_h :pos_map update_item_pm)) (heapify_up update_item_h update_item_index) (heapify_down update_item_h update_item_index)) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))) (finally (alter-var-root (var update_item_h) (constantly update_item_h))))))
+  (binding [update_item_h update_item_h_p update_item_arr nil update_item_index nil update_item_pm nil] (try (do (set! update_item_pm (:pos_map update_item_h)) (when (= (get update_item_pm update_item_item) 0) (throw (ex-info "return" {:v nil}))) (set! update_item_index (- (get update_item_pm update_item_item) 1)) (set! update_item_arr (:arr update_item_h)) (set! update_item_arr (assoc update_item_arr update_item_index [update_item_item ((:key update_item_h) update_item_item_value)])) (set! update_item_h (assoc update_item_h :arr update_item_arr)) (set! update_item_h (assoc update_item_h :pos_map update_item_pm)) (let [__res (heapify_up update_item_h update_item_index)] (do (set! update_item_h heapify_up_h) __res)) (let [__res (heapify_down update_item_h update_item_index)] (do (set! update_item_h heapify_down_h) __res))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))) (finally (alter-var-root (var update_item_h) (constantly update_item_h))))))
 
 (defn delete_item [delete_item_h_p delete_item_item]
-  (binding [delete_item_h delete_item_h_p delete_item_arr nil delete_item_index nil delete_item_last_index nil delete_item_moved nil delete_item_pm nil] (try (do (set! delete_item_pm (:pos_map delete_item_h)) (when (= (get delete_item_pm delete_item_item) 0) (throw (ex-info "return" {:v nil}))) (set! delete_item_index (- (get delete_item_pm delete_item_item) 1)) (set! delete_item_pm (assoc delete_item_pm delete_item_item 0)) (set! delete_item_arr (:arr delete_item_h)) (set! delete_item_last_index (- (:size delete_item_h) 1)) (when (not= delete_item_index delete_item_last_index) (do (set! delete_item_arr (assoc delete_item_arr delete_item_index (get delete_item_arr delete_item_last_index))) (set! delete_item_moved (get (get delete_item_arr delete_item_index) 0)) (set! delete_item_pm (assoc delete_item_pm delete_item_moved (+ delete_item_index 1))))) (set! delete_item_h (assoc delete_item_h :size (- (:size delete_item_h) 1))) (set! delete_item_h (assoc delete_item_h :arr delete_item_arr)) (set! delete_item_h (assoc delete_item_h :pos_map delete_item_pm)) (when (> (:size delete_item_h) delete_item_index) (do (heapify_up delete_item_h delete_item_index) (heapify_down delete_item_h delete_item_index)))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))) (finally (alter-var-root (var delete_item_h) (constantly delete_item_h))))))
+  (binding [delete_item_h delete_item_h_p delete_item_arr nil delete_item_index nil delete_item_last_index nil delete_item_moved nil delete_item_pm nil] (try (do (set! delete_item_pm (:pos_map delete_item_h)) (when (= (get delete_item_pm delete_item_item) 0) (throw (ex-info "return" {:v nil}))) (set! delete_item_index (- (get delete_item_pm delete_item_item) 1)) (set! delete_item_pm (assoc delete_item_pm delete_item_item 0)) (set! delete_item_arr (:arr delete_item_h)) (set! delete_item_last_index (- (:size delete_item_h) 1)) (when (not= delete_item_index delete_item_last_index) (do (set! delete_item_arr (assoc delete_item_arr delete_item_index (get delete_item_arr delete_item_last_index))) (set! delete_item_moved (get (get delete_item_arr delete_item_index) 0)) (set! delete_item_pm (assoc delete_item_pm delete_item_moved (+ delete_item_index 1))))) (set! delete_item_h (assoc delete_item_h :size (- (:size delete_item_h) 1))) (set! delete_item_h (assoc delete_item_h :arr delete_item_arr)) (set! delete_item_h (assoc delete_item_h :pos_map delete_item_pm)) (when (> (:size delete_item_h) delete_item_index) (do (let [__res (heapify_up delete_item_h delete_item_index)] (do (set! delete_item_h heapify_up_h) __res)) (let [__res (heapify_down delete_item_h delete_item_index)] (do (set! delete_item_h heapify_down_h) __res))))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))) (finally (alter-var-root (var delete_item_h) (constantly delete_item_h))))))
 
 (defn insert_item [insert_item_h_p insert_item_item insert_item_item_value]
-  (binding [insert_item_h insert_item_h_p insert_item_arr nil insert_item_arr_len nil insert_item_pm nil] (try (do (set! insert_item_arr (:arr insert_item_h)) (set! insert_item_arr_len (count insert_item_arr)) (if (= insert_item_arr_len (:size insert_item_h)) (set! insert_item_arr (conj insert_item_arr [insert_item_item ((:key insert_item_h) insert_item_item_value)])) (set! insert_item_arr (assoc insert_item_arr (:size insert_item_h) [insert_item_item ((:key insert_item_h) insert_item_item_value)]))) (set! insert_item_pm (:pos_map insert_item_h)) (set! insert_item_pm (assoc insert_item_pm insert_item_item (+ (:size insert_item_h) 1))) (set! insert_item_h (assoc insert_item_h :size (+ (:size insert_item_h) 1))) (set! insert_item_h (assoc insert_item_h :arr insert_item_arr)) (set! insert_item_h (assoc insert_item_h :pos_map insert_item_pm)) (heapify_up insert_item_h (- (:size insert_item_h) 1))) (finally (alter-var-root (var insert_item_h) (constantly insert_item_h))))))
+  (binding [insert_item_h insert_item_h_p insert_item_arr nil insert_item_arr_len nil insert_item_pm nil] (try (do (set! insert_item_arr (:arr insert_item_h)) (set! insert_item_arr_len (count insert_item_arr)) (if (= insert_item_arr_len (:size insert_item_h)) (set! insert_item_arr (conj insert_item_arr [insert_item_item ((:key insert_item_h) insert_item_item_value)])) (set! insert_item_arr (assoc insert_item_arr (:size insert_item_h) [insert_item_item ((:key insert_item_h) insert_item_item_value)]))) (set! insert_item_pm (:pos_map insert_item_h)) (set! insert_item_pm (assoc insert_item_pm insert_item_item (+ (:size insert_item_h) 1))) (set! insert_item_h (assoc insert_item_h :size (+ (:size insert_item_h) 1))) (set! insert_item_h (assoc insert_item_h :arr insert_item_arr)) (set! insert_item_h (assoc insert_item_h :pos_map insert_item_pm)) (let [__res (heapify_up insert_item_h (- (:size insert_item_h) 1))] (do (set! insert_item_h heapify_up_h) __res))) (finally (alter-var-root (var insert_item_h) (constantly insert_item_h))))))
 
 (defn get_top [get_top_h]
   (binding [get_top_arr nil] (try (do (set! get_top_arr (:arr get_top_h)) (if (> (:size get_top_h) 0) (get get_top_arr 0) [])) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
 
-(defn extract_top [extract_top_h]
-  (binding [extract_top_top nil] (try (do (set! extract_top_top (get_top extract_top_h)) (when (> (count extract_top_top) 0) (let [__res (delete_item extract_top_h (nth extract_top_top 0))] (do (set! extract_top_h delete_item_h) __res))) (throw (ex-info "return" {:v extract_top_top}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))))))
+(defn extract_top [extract_top_h_p]
+  (binding [extract_top_h extract_top_h_p extract_top_top nil] (try (do (set! extract_top_top (get_top extract_top_h)) (when (> (count extract_top_top) 0) (let [__res (delete_item extract_top_h (nth extract_top_top 0))] (do (set! extract_top_h delete_item_h) __res))) (throw (ex-info "return" {:v extract_top_top}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e))) (finally (alter-var-root (var extract_top_h) (constantly extract_top_h))))))
 
 (defn identity [identity_x]
   (try (throw (ex-info "return" {:v identity_x})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
@@ -157,17 +163,17 @@
       (let [__res (insert_item main_h 6 31)] (do (alter-var-root (var main_h) (constantly insert_item_h)) __res))
       (let [__res (insert_item main_h 7 37)] (do (alter-var-root (var main_h) (constantly insert_item_h)) __res))
       (println (mochi_str (get_top main_h)))
-      (println (mochi_str (extract_top main_h)))
-      (println (mochi_str (extract_top main_h)))
-      (println (mochi_str (extract_top main_h)))
+      (println (mochi_str (let [__res (extract_top main_h)] (do (alter-var-root (var main_h) (constantly extract_top_h)) __res))))
+      (println (mochi_str (let [__res (extract_top main_h)] (do (alter-var-root (var main_h) (constantly extract_top_h)) __res))))
+      (println (mochi_str (let [__res (extract_top main_h)] (do (alter-var-root (var main_h) (constantly extract_top_h)) __res))))
       (alter-var-root (var main_h) (constantly (new_heap negate)))
       (let [__res (insert_item main_h 5 34)] (do (alter-var-root (var main_h) (constantly insert_item_h)) __res))
       (let [__res (insert_item main_h 6 31)] (do (alter-var-root (var main_h) (constantly insert_item_h)) __res))
       (let [__res (insert_item main_h 7 37)] (do (alter-var-root (var main_h) (constantly insert_item_h)) __res))
       (println (mochi_str (get_top main_h)))
-      (println (mochi_str (extract_top main_h)))
-      (println (mochi_str (extract_top main_h)))
-      (println (mochi_str (extract_top main_h)))
+      (println (mochi_str (let [__res (extract_top main_h)] (do (alter-var-root (var main_h) (constantly extract_top_h)) __res))))
+      (println (mochi_str (let [__res (extract_top main_h)] (do (alter-var-root (var main_h) (constantly extract_top_h)) __res))))
+      (println (mochi_str (let [__res (extract_top main_h)] (do (alter-var-root (var main_h) (constantly extract_top_h)) __res))))
       (let [__res (insert_item main_h 8 45)] (do (alter-var-root (var main_h) (constantly insert_item_h)) __res))
       (let [__res (insert_item main_h 9 40)] (do (alter-var-root (var main_h) (constantly insert_item_h)) __res))
       (let [__res (insert_item main_h 10 50)] (do (alter-var-root (var main_h) (constantly insert_item_h)) __res))

--- a/tests/algorithms/x/Clojure/data_structures/heap/heap_generic.error
+++ b/tests/algorithms/x/Clojure/data_structures/heap/heap_generic.error
@@ -1,6 +1,0 @@
-run: exit status 1
-Syntax error (IllegalArgumentException) compiling fn* at (/workspace/mochi/tests/algorithms/x/Clojure/data_structures/heap/heap_generic.clj:122:1).
-Cannot assign to non-mutable: heapify_up_h
-
-Full report at:
-/tmp/clojure-14031695727101753618.edn

--- a/tests/algorithms/x/Clojure/data_structures/heap/heap_generic.out
+++ b/tests/algorithms/x/Clojure/data_structures/heap/heap_generic.out
@@ -1,5 +1,11 @@
-Syntax error (IllegalArgumentException) compiling fn* at (/workspace/mochi/tests/algorithms/x/Clojure/data_structures/heap/heap_generic.clj:122:1).
-Cannot assign to non-mutable: heapify_up_h
-
-Full report at:
-/tmp/clojure-14031695727101753618.edn
+[7 37]
+[7 37]
+[5 34]
+[6 31]
+[6 -31]
+[6 -31]
+[5 -34]
+[7 -37]
+[9 -40]
+[10 -30]
+[9 -40]

--- a/transpiler/x/clj/ALGORITHMS.md
+++ b/transpiler/x/clj/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated Clojure code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Clojure`.
-Last updated: 2025-08-24 22:25 GMT+7
+Last updated: 2025-08-24 23:29 GMT+7
 
-## Algorithms Golden Test Checklist (846/1077)
+## Algorithms Golden Test Checklist (847/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 50.25ms | 19.66MB |
@@ -219,7 +219,7 @@ Last updated: 2025-08-24 22:25 GMT+7
 | 210 | data_structures/hashing/tests/test_hash_map | ✓ | 39.012ms | 25.22MB |
 | 211 | data_structures/heap/binomial_heap | error | 37.39ms | 22.43MB |
 | 212 | data_structures/heap/heap | error |  |  |
-| 213 | data_structures/heap/heap_generic | error |  |  |
+| 213 | data_structures/heap/heap_generic | ✓ | 86.735ms | 27.41MB |
 | 214 | data_structures/heap/max_heap | ✓ | 46.134ms | 23.17MB |
 | 215 | data_structures/heap/min_heap | error |  |  |
 | 216 | data_structures/heap/randomized_heap | error |  |  |


### PR DESCRIPTION
## Summary
- track mutating function calls when gathering mutated parameters
- ensure mutated params create dynamic vars in generated Clojure
- add Clojure output for `heap_generic` algorithm

## Testing
- `MOCHI_ALG_INDEX=213 go test ./transpiler/x/clj -run TestClojureTranspiler_Algorithms_Golden -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68ab3b7d35048320bc4e2333c6d623f4