### PR TITLE
docs: add v0.10.73 release notes and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # 📦 CHANGELOG.md
 
+## [0.10.73] – 2025-08-25T08:22:15+07:00
+
+### Added
+
+- C transpiler handles map element assignment inside lists and pointer field access.
+- Rust transpiler supports function fields and empty list globals.
+- Zig transpiler supports field function calls and tracks mutable references.
+- Pascal transpiler allows calling function fields and array field assignments.
+- Dart adds a `ceil` builtin; Swift enables stack algorithms.
+- Kotlin adds `containsKey` for maps; C++ supports nested struct literals and index assignment.
+
+### Changed
+
+- TypeScript and Scala regenerate algorithm outputs; TypeScript refines loops, object formatting and map membership.
+- Zig preserves parameter names and allows const list initialization.
+- Scheme iterates without map keys and supports unordered variant fields.
+- Go, PHP, Python, Pascal and others refresh algorithm benchmarks and outputs.
+
+### Fixed
+
+- Python transpiler handles builtin name collisions and in-place append.
+- C transpiler fixes pointer assignments and list literal mapping.
+- Kotlin transpiler resolves function field handling and data directory ordering.
+- Java handles nested list literals, big integer ranges and negative array indices.
+- Clojure loop breaks, Erlang string formatting and Elixir return/union handling corrected.
+- C++ adjusts float formatting and ensures `cpp_int` headers.
+
 ## [0.10.72] – 2025-08-24T15:35:26+07:00
 
 ### Added

--- a/releases/v0.10.73.md
+++ b/releases/v0.10.73.md
@@ -1,0 +1,20 @@
+# Aug 2025 (v0.10.73)
+
+Released on Mon Aug 25 08:22:15 2025 +0700.
+
+Mochi v0.10.73 enhances multi-language transpilers and refreshes algorithm benchmarks.
+
+## Transpilers
+
+- C transpiler adds map element assignment inside lists, pointer field access and pointer args for structs.
+- Rust transpiler supports function fields and empty list globals.
+- Zig transpiler supports field function calls, preserves parameter names and tracks mutable references.
+- Scheme iterates lists without map keys and allows unordered variant fields.
+- Pascal transpiler supports calling function fields and array field assignment.
+- Python avoids builtin name collisions; PHP handles struct field slices and unordered fields.
+- Dart adds a `ceil` builtin; Swift enables stack algorithms; Kotlin adds `containsKey` for maps; C++ supports nested struct literals and index assignment.
+
+## Algorithms
+
+- Regenerates algorithm outputs across TypeScript, Scala, Go, Rust, Swift, Scheme, PHP, Python, Pascal, Kotlin, Java and more.
+- Adds a non-recursive segment tree example and new benchmark coverage including heap and circular linked list cases.


### PR DESCRIPTION
## Summary
- document v0.10.73 release and changelog

## Testing
- `npm test` *(fails: Missing script "test")*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68abbc017e648320a516f7f208df3bd0