### PR TITLE
fs transpiler: handle int/int64 assignments

### DIFF
--- a/tests/algorithms/transpiler/FS/dynamic_programming/largest_divisible_subset.bench
+++ b/tests/algorithms/transpiler/FS/dynamic_programming/largest_divisible_subset.bench
@@ -1,5 +1,5 @@
 {
   "duration_us": 571223,
-  "memory_bytes": 80080,
+  "memory_bytes": 59456,
   "name": "main"
 }

--- a/tests/algorithms/transpiler/FS/dynamic_programming/largest_divisible_subset.fs
+++ b/tests/algorithms/transpiler/FS/dynamic_programming/largest_divisible_subset.fs
@@ -1,4 +1,4 @@
-// Generated 2025-08-13 07:12 +0700
+// Generated 2025-08-25 08:35 +0700
 
 exception Return
 let mutable _nowSeed:int64 = 0L
@@ -30,69 +30,74 @@ let _arrset (arr:'a array) (i:int) (v:'a) : 'a array =
     a.[i] <- v
     a
 let rec _str v =
-    let s = sprintf "%A" v
-    let s = if s.EndsWith(".0") then s.Substring(0, s.Length - 2) else s
-    s.Replace("[|", "[")
-     .Replace("|]", "]")
-     .Replace("; ", " ")
-     .Replace(";", "")
-     .Replace("\"", "")
-let rec sort_list (nums: int array) =
-    let mutable __ret : int array = Unchecked.defaultof<int array>
+    match box v with
+    | :? float as f ->
+        if f = floor f then sprintf "%g.0" f else sprintf "%g" f
+    | :? int64 as n -> sprintf "%d" n
+    | _ ->
+        let s = sprintf "%A" v
+        s.Replace("[|", "[")
+         .Replace("|]", "]")
+         .Replace("; ", " ")
+         .Replace(";", "")
+         .Replace("L", "")
+         .Replace("\"", "")
+let rec sort_list (nums: int64 array) =
+    let mutable __ret : int64 array = Unchecked.defaultof<int64 array>
     let mutable nums = nums
     try
-        let mutable arr: int array = nums
-        let mutable i: int = 1
-        while i < (Seq.length (arr)) do
-            let key: int = _idx arr (int i)
-            let mutable j: int = i - 1
-            while (j >= 0) && ((_idx arr (int j)) > key) do
-                arr.[(j + 1)] <- _idx arr (int j)
-                j <- j - 1
-            arr.[(j + 1)] <- key
-            i <- i + 1
+        let mutable arr: int64 array = nums
+        let mutable i: int64 = int64 1
+        while i < (int64 (Seq.length (arr))) do
+            let key: int64 = _idx arr (int i)
+            let mutable j: int64 = i - (int64 1)
+            while (j >= (int64 0)) && ((_idx arr (int j)) > key) do
+                arr.[int (j + (int64 1))] <- _idx arr (int j)
+                j <- j - (int64 1)
+            arr.[int (j + (int64 1))] <- key
+            i <- i + (int64 1)
         __ret <- arr
         raise Return
         __ret
     with
         | Return -> __ret
-and largest_divisible_subset (items: int array) =
-    let mutable __ret : int array = Unchecked.defaultof<int array>
+and largest_divisible_subset (items: int64 array) =
+    let mutable __ret : int64 array = Unchecked.defaultof<int64 array>
     let mutable items = items
     try
         if (Seq.length (items)) = 0 then
-            __ret <- Array.empty<int>
+            __ret <- Array.empty<int64>
             raise Return
-        let mutable nums: int array = sort_list (items)
-        let n: int = Seq.length (nums)
-        let mutable memo: int array = Array.empty<int>
-        let mutable prev: int array = Array.empty<int>
-        let mutable i: int = 0
+        let mutable nums: int64 array = sort_list (items)
+        let n: int64 = int64 (Seq.length (nums))
+        let mutable memo: int64 array = Array.empty<int64>
+        let mutable prev: int64 array = Array.empty<int64>
+        let mutable i: int64 = int64 0
         while i < n do
-            memo <- Array.append memo [|1|]
+            memo <- Array.append memo [|int64 (1)|]
             prev <- Array.append prev [|i|]
-            i <- i + 1
-        i <- 0
+            i <- i + (int64 1)
+        i <- int64 0
         while i < n do
-            let mutable j: int = 0
+            let mutable j: int64 = int64 0
             while j < i do
-                if (((_idx nums (int j)) = 0) || (((((_idx nums (int i)) % (_idx nums (int j)) + (_idx nums (int j))) % (_idx nums (int j)))) = 0)) && (((_idx memo (int j)) + 1) > (_idx memo (int i))) then
-                    memo.[i] <- (_idx memo (int j)) + 1
-                    prev.[i] <- j
-                j <- j + 1
-            i <- i + 1
-        let mutable ans: int = 0 - 1
-        let mutable last_index: int = 0 - 1
-        i <- 0
+                if (((_idx nums (int j)) = (int64 0)) || (((((_idx nums (int i)) % (_idx nums (int j)) + (_idx nums (int j))) % (_idx nums (int j)))) = (int64 0))) && (((_idx memo (int j)) + (int64 1)) > (_idx memo (int i))) then
+                    memo.[int i] <- (_idx memo (int j)) + (int64 1)
+                    prev.[int i] <- j
+                j <- j + (int64 1)
+            i <- i + (int64 1)
+        let mutable ans: int64 = int64 (0 - 1)
+        let mutable last_index: int64 = int64 (0 - 1)
+        i <- int64 0
         while i < n do
             if (_idx memo (int i)) > ans then
                 ans <- _idx memo (int i)
                 last_index <- i
-            i <- i + 1
-        if last_index = (0 - 1) then
-            __ret <- Array.empty<int>
+            i <- i + (int64 1)
+        if last_index = (int64 (0 - 1)) then
+            __ret <- Array.empty<int64>
             raise Return
-        let mutable result: int array = unbox<int array> [|_idx nums (int last_index)|]
+        let mutable result: int64 array = unbox<int64 array> [|_idx nums (int last_index)|]
         while (_idx prev (int last_index)) <> last_index do
             last_index <- _idx prev (int last_index)
             result <- Array.append result [|(_idx nums (int last_index))|]
@@ -102,12 +107,12 @@ and largest_divisible_subset (items: int array) =
     with
         | Return -> __ret
 and main () =
-    let mutable __ret : unit = Unchecked.defaultof<unit>
+    let mutable __ret : obj = Unchecked.defaultof<obj>
     try
         let __bench_start = _now()
         let __mem_start = System.GC.GetTotalMemory(true)
         let items: int array = unbox<int array> [|1; 16; 7; 8; 4|]
-        let subset: int array = largest_divisible_subset (items)
+        let subset: int64 array = largest_divisible_subset (Array.map int64 items)
         ignore (printfn "%s" (((("The longest divisible subset of " + (_str (items))) + " is ") + (_str (subset))) + "."))
         let __bench_end = _now()
         let __mem_end = System.GC.GetTotalMemory(true)
@@ -116,4 +121,4 @@ and main () =
         __ret
     with
         | Return -> __ret
-main()
+ignore (main())

--- a/tests/algorithms/transpiler/FS/dynamic_programming/largest_divisible_subset.out
+++ b/tests/algorithms/transpiler/FS/dynamic_programming/largest_divisible_subset.out
@@ -1,1 +1,1 @@
-The longest divisible subset of [1 4 7 8 16] is [16 8 4 1].
+The longest divisible subset of [1 16 7 8 4] is [16 8 4 1].

--- a/transpiler/x/fs/ALGORITHMS.md
+++ b/transpiler/x/fs/ALGORITHMS.md
@@ -1,7 +1,7 @@
 # F# Algorithms Transpiler Output
 
 Completed programs: 951/1077
-Last updated: 2025-08-24 23:57 +0700
+Last updated: 2025-08-25 08:35 +0700
 
 Checklist:
 
@@ -323,7 +323,7 @@ Checklist:
 | 314 | dynamic_programming/iterating_through_submasks | ✓ | 571.223ms | 95.5 KB |
 | 315 | dynamic_programming/k_means_clustering_tensorflow | ✓ | 571.223ms | 82.0 KB |
 | 316 | dynamic_programming/knapsack | ✓ | 571.223ms | 83.6 KB |
-| 317 | dynamic_programming/largest_divisible_subset | ✓ | 571.223ms | 78.2 KB |
+| 317 | dynamic_programming/largest_divisible_subset | ✓ | 571.223ms | 58.1 KB |
 | 318 | dynamic_programming/longest_common_subsequence | ✓ | 571.223ms | 78.0 KB |
 | 319 | dynamic_programming/longest_common_substring | ✓ | 571.223ms | 38.9 KB |
 | 320 | dynamic_programming/longest_increasing_subsequence | ✓ | 571.223ms |  |

--- a/transpiler/x/fs/transpiler.go
+++ b/transpiler/x/fs/transpiler.go
@@ -1482,6 +1482,12 @@ func (a *AppendExpr) emit(w io.Writer) {
 			io.WriteString(w, ")|]")
 			return
 		}
+		if elemType == "int64" && it == "int" {
+			io.WriteString(w, "int64 (")
+			a.Elem.emit(w)
+			io.WriteString(w, ")|]")
+			return
+		}
 		if it == "obj" || it == "" {
 			io.WriteString(w, "unbox<")
 			io.WriteString(w, elemType)
@@ -4324,6 +4330,10 @@ func convertStmt(st *parser.Statement) (Stmt, error) {
 			if cur == "int" && t == "int64" {
 				e = &CastExpr{Expr: e, Type: "int"}
 				t = "int"
+			}
+			if cur == "int64" && t == "int" {
+				e = &CastExpr{Expr: e, Type: "int64"}
+				t = "int64"
 			}
 			if t == "array" {
 				if app, ok := e.(*AppendExpr); ok {


### PR DESCRIPTION
## Summary
- fix F# transpiler casts for int/int64 assignments and append
- add generated output for dynamic_programming/largest_divisible_subset

## Testing
- `MOCHI_ALGORITHMS_INDEX=317 go test ./transpiler/x/fs -run TestFSTranspiler_Algorithms_Golden -tags=slow -v`


------
https://chatgpt.com/codex/tasks/task_e_68abbdf2c6188320ab8d5f9e3a57a5fb