### PR TITLE
php: handle struct references in map literals

### DIFF
--- a/tests/algorithms/x/PHP/dynamic_programming/largest_divisible_subset.bench
+++ b/tests/algorithms/x/PHP/dynamic_programming/largest_divisible_subset.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 112,
-  "memory_bytes": 39008,
+  "duration_us": 163,
+  "memory_bytes": 1684216,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/dynamic_programming/largest_divisible_subset.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/largest_divisible_subset.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _str($x) {
     if (is_array($x)) {

--- a/tests/algorithms/x/PHP/dynamic_programming/longest_common_subsequence.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/longest_common_subsequence.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _str($x) {
     if (is_array($x)) {
@@ -74,7 +75,7 @@ function longest_common_subsequence($x, $y) {
 };
 }
 };
-  return ['length' => $dp[$m][$n], 'sequence' => $seq];
+  return ['length' => $dp[$m][$n], 'sequence' => &$seq];
 }
 $a = 'AGGTAB';
 $b = 'GXTXAYB';

--- a/tests/algorithms/x/PHP/dynamic_programming/longest_common_substring.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/longest_common_substring.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _append($arr, $x) {
     $arr[] = $x;

--- a/tests/algorithms/x/PHP/dynamic_programming/longest_increasing_subsequence.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/longest_increasing_subsequence.php
@@ -1,6 +1,8 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _len($x) {
+    if ($x === null) { return 0; }
     if (is_array($x)) { return count($x); }
     if (is_string($x)) { return strlen($x); }
     return strlen(strval($x));

--- a/tests/algorithms/x/PHP/dynamic_programming/longest_increasing_subsequence_iterative.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/longest_increasing_subsequence_iterative.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _str($x) {
     if (is_array($x)) {

--- a/tests/algorithms/x/PHP/dynamic_programming/longest_increasing_subsequence_o_nlogn.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/longest_increasing_subsequence_o_nlogn.php
@@ -1,16 +1,32 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
 function _intdiv($a, $b) {
+    if ($b === 0 || $b === '0') {
+        throw new DivisionByZeroError();
+    }
     if (function_exists('bcdiv')) {
         $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return intval(bcdiv($sa, $sb, 0));
+        $q = bcdiv($sa, $sb, 0);
+        $rem = bcmod($sa, $sb);
+        $neg = ((strpos($sa, '-') === 0) xor (strpos($sb, '-') === 0));
+        if ($neg && bccomp($rem, '0') != 0) {
+            $q = bcsub($q, '1');
+        }
+        return intval($q);
     }
-    return intdiv($a, $b);
+    $ai = intval($a);
+    $bi = intval($b);
+    $q = intdiv($ai, $bi);
+    if ((($ai ^ $bi) < 0) && ($ai % $bi != 0)) {
+        $q -= 1;
+    }
+    return $q;
 }
 function ceil_index($v, $left, $right, $key) {
   $l = $left;

--- a/tests/algorithms/x/PHP/dynamic_programming/longest_palindromic_subsequence.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/longest_palindromic_subsequence.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _str($x) {
     if (is_array($x)) {

--- a/tests/algorithms/x/PHP/dynamic_programming/matrix_chain_multiplication.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/matrix_chain_multiplication.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _append($arr, $x) {
     $arr[] = $x;

--- a/tests/algorithms/x/PHP/dynamic_programming/matrix_chain_order.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/matrix_chain_order.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _str($x) {
     if (is_array($x)) {
@@ -58,7 +59,7 @@ function matrix_chain_order($arr) {
 };
   $chain_length = $chain_length + 1;
 };
-  return ['matrix' => $m, 'solution' => $s];
+  return ['matrix' => &$m, 'solution' => &$s];
 }
 function optimal_parenthesization($s, $i, $j) {
   if ($i == $j) {

--- a/tests/algorithms/x/PHP/dynamic_programming/max_non_adjacent_sum.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/max_non_adjacent_sum.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _str($x) {
     if (is_array($x)) {

--- a/tests/algorithms/x/PHP/dynamic_programming/max_product_subarray.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/max_product_subarray.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function max_product_subarray($numbers) {
   if (count($numbers) == 0) {

--- a/tests/algorithms/x/PHP/dynamic_programming/max_subarray_sum.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/max_subarray_sum.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _str($x) {
     if (is_array($x)) {

--- a/tests/algorithms/x/PHP/dynamic_programming/min_distance_up_bottom.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/min_distance_up_bottom.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _str($x) {
     if (is_array($x)) {

--- a/tests/algorithms/x/PHP/dynamic_programming/minimum_coin_change.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/minimum_coin_change.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _append($arr, $x) {
     $arr[] = $x;

--- a/tests/algorithms/x/PHP/dynamic_programming/minimum_cost_path.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/minimum_cost_path.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _str($x) {
     if (is_array($x)) {

--- a/tests/algorithms/x/PHP/dynamic_programming/minimum_partition.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/minimum_partition.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _str($x) {
     if (is_array($x)) {
@@ -21,12 +22,27 @@ function _append($arr, $x) {
     return $arr;
 }
 function _intdiv($a, $b) {
+    if ($b === 0 || $b === '0') {
+        throw new DivisionByZeroError();
+    }
     if (function_exists('bcdiv')) {
         $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return intval(bcdiv($sa, $sb, 0));
+        $q = bcdiv($sa, $sb, 0);
+        $rem = bcmod($sa, $sb);
+        $neg = ((strpos($sa, '-') === 0) xor (strpos($sb, '-') === 0));
+        if ($neg && bccomp($rem, '0') != 0) {
+            $q = bcsub($q, '1');
+        }
+        return intval($q);
     }
-    return intdiv($a, $b);
+    $ai = intval($a);
+    $bi = intval($b);
+    $q = intdiv($ai, $bi);
+    if ((($ai ^ $bi) < 0) && ($ai % $bi != 0)) {
+        $q -= 1;
+    }
+    return $q;
 }
 function find_min($numbers) {
   $n = count($numbers);

--- a/tests/algorithms/x/PHP/dynamic_programming/minimum_size_subarray_sum.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/minimum_size_subarray_sum.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _str($x) {
     if (is_array($x)) {

--- a/tests/algorithms/x/PHP/dynamic_programming/minimum_squares_to_represent_a_number.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/minimum_squares_to_represent_a_number.php
@@ -1,8 +1,13 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
+}
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
 }
 function make_list($len, $value) {
   $arr = [];
@@ -22,7 +27,7 @@ function int_sqrt($n) {
 }
 function minimum_squares_to_represent_a_number($number) {
   if ($number < 0) {
-  $panic('the value of input must not be a negative number');
+  _panic('the value of input must not be a negative number');
 }
   if ($number == 0) {
   return 1;

--- a/tests/algorithms/x/PHP/dynamic_programming/minimum_steps_to_one.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/minimum_steps_to_one.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _str($x) {
     if (is_array($x)) {

--- a/tests/algorithms/x/PHP/dynamic_programming/minimum_tickets_cost.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/minimum_tickets_cost.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _str($x) {
     if (is_array($x)) {

--- a/tests/algorithms/x/PHP/dynamic_programming/optimal_binary_search_tree.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/optimal_binary_search_tree.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _str($x) {
     if (is_array($x)) {
@@ -132,7 +133,7 @@ The cost of optimal BST for given tree nodes is ' . _str($dp[0][$n - 1]) . '.'),
   print_binary_search_tree($root, $keys, 0, $n - 1, (-1), false);
 }
 function main() {
-  $nodes = [['key' => 12, 'freq' => 8], ['key' => 10, 'freq' => 34], ['key' => 20, 'freq' => 50], ['key' => 42, 'freq' => 3], ['key' => 25, 'freq' => 40], ['key' => 37, 'freq' => 30]];
+  $nodes = [['freq' => 8, 'key' => 12], ['freq' => 34, 'key' => 10], ['freq' => 50, 'key' => 20], ['freq' => 3, 'key' => 42], ['freq' => 40, 'key' => 25], ['freq' => 30, 'key' => 37]];
   find_optimal_binary_search_tree($nodes);
 }
 main();

--- a/tests/algorithms/x/PHP/dynamic_programming/palindrome_partitioning.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/palindrome_partitioning.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _append($arr, $x) {
     $arr[] = $x;

--- a/tests/algorithms/x/PHP/dynamic_programming/range_sum_query.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/range_sum_query.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _str($x) {
     if (is_array($x)) {
@@ -21,7 +22,7 @@ function _append($arr, $x) {
     return $arr;
 }
 function prefix_sum($arr, $queries) {
-  global $arr1, $queries1, $arr2, $queries2;
+  global $arr1, $arr2, $queries1, $queries2;
   $dp = [];
   $i = 0;
   while ($i < count($arr)) {

--- a/tests/algorithms/x/PHP/dynamic_programming/regex_match.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/regex_match.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _append($arr, $x) {
     $arr[] = $x;
@@ -10,20 +11,20 @@ function recursive_match($text, $pattern) {
 }
   if (strlen($text) == 0) {
   if (strlen($pattern) >= 2 && substr($pattern, strlen($pattern) - 1, strlen($pattern) - (strlen($pattern) - 1)) == '*') {
-  return recursive_match($text, substr($pattern, 0, strlen($pattern) - 2 - 0));
+  return recursive_match($text, substr($pattern, 0, strlen($pattern) - 2));
 };
   return false;
 }
   $last_text = substr($text, strlen($text) - 1, strlen($text) - (strlen($text) - 1));
   $last_pattern = substr($pattern, strlen($pattern) - 1, strlen($pattern) - (strlen($pattern) - 1));
   if ($last_text == $last_pattern || $last_pattern == '.') {
-  return recursive_match(substr($text, 0, strlen($text) - 1 - 0), substr($pattern, 0, strlen($pattern) - 1 - 0));
+  return recursive_match(substr($text, 0, strlen($text) - 1), substr($pattern, 0, strlen($pattern) - 1));
 }
   if ($last_pattern == '*') {
-  if (recursive_match(substr($text, 0, strlen($text) - 1 - 0), $pattern)) {
+  if (recursive_match(substr($text, 0, strlen($text) - 1), $pattern)) {
   return true;
 };
-  return recursive_match($text, substr($pattern, 0, strlen($pattern) - 2 - 0));
+  return recursive_match($text, substr($pattern, 0, strlen($pattern) - 2));
 }
   return false;
 }

--- a/tests/algorithms/x/PHP/dynamic_programming/rod_cutting.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/rod_cutting.php
@@ -1,15 +1,20 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
+}
 function enforce_args($n, $prices) {
   if ($n < 0) {
-  $panic('n must be non-negative');
+  _panic('n must be non-negative');
 }
   if ($n > count($prices)) {
-  $panic('price list is shorter than n');
+  _panic('price list is shorter than n');
 }
 }
 function bottom_up_cut_rod($n, $prices) {

--- a/tests/algorithms/x/PHP/dynamic_programming/smith_waterman.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/smith_waterman.php
@@ -1,11 +1,12 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
 function score_function($source_char, $target_char, $match_score, $mismatch_score, $gap_score) {
-  global $query, $subject, $score;
+  global $query, $score, $subject;
   if ($source_char == '-' || $target_char == '-') {
   return $gap_score;
 }

--- a/tests/algorithms/x/PHP/dynamic_programming/subset_generation.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/subset_generation.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 function _str($x) {
     if (is_array($x)) {

--- a/tests/algorithms/x/PHP/dynamic_programming/sum_of_subset.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/sum_of_subset.php
@@ -1,27 +1,11 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  function create_bool_matrix($rows, $cols) {
+function create_bool_matrix($rows, $cols) {
   $matrix = [];
   $i = 0;
   while ($i <= $rows) {
@@ -35,8 +19,8 @@ $__start = _now();
   $i = $i + 1;
 };
   return $matrix;
-};
-  function is_sum_subset($arr, $required_sum) {
+}
+function is_sum_subset($arr, $required_sum) {
   $arr_len = count($arr);
   $subset = create_bool_matrix($arr_len, $required_sum);
   $i = 0;
@@ -64,14 +48,6 @@ $__start = _now();
   $i = $i + 1;
 };
   return $subset[$arr_len][$required_sum];
-};
-  echo rtrim(json_encode(is_sum_subset([2, 4, 6, 8], 5), 1344)), PHP_EOL;
-  echo rtrim(json_encode(is_sum_subset([2, 4, 6, 8], 14), 1344)), PHP_EOL;
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+echo rtrim(json_encode(is_sum_subset([2, 4, 6, 8], 5), 1344)), PHP_EOL;
+echo rtrim(json_encode(is_sum_subset([2, 4, 6, 8], 14), 1344)), PHP_EOL;

--- a/tests/algorithms/x/PHP/dynamic_programming/trapped_water.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/trapped_water.php
@@ -1,20 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -39,9 +25,7 @@ function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  function make_list($len, $value) {
+function make_list($len, $value) {
   $arr = [];
   $i = 0;
   while ($i < $len) {
@@ -49,8 +33,8 @@ $__start = _now();
   $i = $i + 1;
 };
   return $arr;
-};
-  function trapped_rainwater($heights) {
+}
+function trapped_rainwater($heights) {
   if (count($heights) == 0) {
   return 0;
 }
@@ -95,14 +79,6 @@ $__start = _now();
   $i = $i + 1;
 };
   return $total;
-};
-  echo rtrim(_str(trapped_rainwater([0, 1, 0, 2, 1, 0, 1, 3, 2, 1, 2, 1]))), PHP_EOL;
-  echo rtrim(_str(trapped_rainwater([7, 1, 5, 3, 6, 4]))), PHP_EOL;
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+echo rtrim(_str(trapped_rainwater([0, 1, 0, 2, 1, 0, 1, 3, 2, 1, 2, 1]))), PHP_EOL;
+echo rtrim(_str(trapped_rainwater([7, 1, 5, 3, 6, 4]))), PHP_EOL;

--- a/tests/algorithms/x/PHP/dynamic_programming/tribonacci.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/tribonacci.php
@@ -1,27 +1,11 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  function tribonacci($num) {
+function tribonacci($num) {
   $dp = [];
   $i = 0;
   while ($i < $num) {
@@ -38,13 +22,5 @@ $__start = _now();
   $i = $i + 1;
 };
   return $dp;
-};
-  echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(tribonacci(8), 1344)))))), PHP_EOL;
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(tribonacci(8), 1344)))))), PHP_EOL;

--- a/tests/algorithms/x/PHP/dynamic_programming/viterbi.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/viterbi.php
@@ -1,20 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
@@ -23,13 +9,11 @@ function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  function mochi_key($state, $obs) {
+function mochi_key($state, $obs) {
   global $emit_p, $observations, $result, $start_p, $states, $trans_p;
   return $state . '|' . $obs;
-};
-  function viterbi($observations, $states, $start_p, $trans_p, $emit_p) {
+}
+function viterbi($observations, $states, $start_p, $trans_p, $emit_p) {
   global $result;
   if (count($observations) == 0 || count($states) == 0) {
   _panic('empty parameters');
@@ -99,8 +83,8 @@ $__start = _now();
   $idx = $idx - 1;
 };
   return $path;
-};
-  function join_words($words) {
+}
+function join_words($words) {
   global $emit_p, $observations, $result, $start_p, $states, $trans_p;
   $res = '';
   $i = 0;
@@ -112,19 +96,11 @@ $__start = _now();
   $i = $i + 1;
 };
   return $res;
-};
-  $observations = ['normal', 'cold', 'dizzy'];
-  $states = ['Healthy', 'Fever'];
-  $start_p = ['Healthy' => 0.6, 'Fever' => 0.4];
-  $trans_p = ['Healthy' => ['Healthy' => 0.7, 'Fever' => 0.3], 'Fever' => ['Healthy' => 0.4, 'Fever' => 0.6]];
-  $emit_p = ['Healthy' => ['normal' => 0.5, 'cold' => 0.4, 'dizzy' => 0.1], 'Fever' => ['normal' => 0.1, 'cold' => 0.3, 'dizzy' => 0.6]];
-  $result = viterbi($observations, $states, $start_p, $trans_p, $emit_p);
-  echo rtrim(join_words($result)), PHP_EOL;
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+$observations = ['normal', 'cold', 'dizzy'];
+$states = ['Healthy', 'Fever'];
+$start_p = ['Fever' => 0.4, 'Healthy' => 0.6];
+$trans_p = ['Fever' => ['Fever' => 0.6, 'Healthy' => 0.4], 'Healthy' => ['Fever' => 0.3, 'Healthy' => 0.7]];
+$emit_p = ['Fever' => ['cold' => 0.3, 'dizzy' => 0.6, 'normal' => 0.1], 'Healthy' => ['cold' => 0.4, 'dizzy' => 0.1, 'normal' => 0.5]];
+$result = viterbi($observations, $states, $start_p, $trans_p, $emit_p);
+echo rtrim(join_words($result)), PHP_EOL;

--- a/tests/algorithms/x/PHP/dynamic_programming/wildcard_matching.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/wildcard_matching.php
@@ -1,27 +1,11 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  function make_bool_list($n) {
+function make_bool_list($n) {
   $row = [];
   $i = 0;
   while ($i < $n) {
@@ -29,8 +13,8 @@ $__start = _now();
   $i = $i + 1;
 };
   return $row;
-};
-  function make_bool_matrix($rows, $cols) {
+}
+function make_bool_matrix($rows, $cols) {
   $matrix = [];
   $i = 0;
   while ($i < $rows) {
@@ -38,8 +22,8 @@ $__start = _now();
   $i = $i + 1;
 };
   return $matrix;
-};
-  function is_match($s, $p) {
+}
+function is_match($s, $p) {
   $n = strlen($s);
   $m = strlen($p);
   $dp = make_bool_matrix($n + 1, $m + 1);
@@ -71,22 +55,14 @@ $__start = _now();
   $i = $i + 1;
 };
   return $dp[$n][$m];
-};
-  function print_bool($b) {
+}
+function print_bool($b) {
   if ($b) {
   echo rtrim((true ? 'true' : 'false')), PHP_EOL;
 } else {
   echo rtrim((false ? 'true' : 'false')), PHP_EOL;
 }
-};
-  print_bool(is_match('abc', 'a*c'));
-  print_bool(is_match('abc', 'a*d'));
-  print_bool(is_match('baaabab', '*****ba*****ab'));
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+print_bool(is_match('abc', 'a*c'));
+print_bool(is_match('abc', 'a*d'));
+print_bool(is_match('baaabab', '*****ba*****ab'));

--- a/tests/algorithms/x/PHP/dynamic_programming/word_break.php
+++ b/tests/algorithms/x/PHP/dynamic_programming/word_break.php
@@ -1,34 +1,18 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  function build_set($words) {
+function build_set($words) {
   $m = [];
   foreach ($words as $w) {
   $m[$w] = true;
 };
   return $m;
-};
-  function word_break($s, $words) {
+}
+function word_break($s, $words) {
   $n = strlen($s);
   $dict = build_set($words);
   $dp = [];
@@ -54,22 +38,14 @@ $__start = _now();
   $i = $i + 1;
 };
   return $dp[$n];
-};
-  function print_bool($b) {
+}
+function print_bool($b) {
   if ($b) {
   echo rtrim((true ? 'true' : 'false')), PHP_EOL;
 } else {
   echo rtrim((false ? 'true' : 'false')), PHP_EOL;
 }
-};
-  print_bool(word_break('applepenapple', ['apple', 'pen']));
-  print_bool(word_break('catsandog', ['cats', 'dog', 'sand', 'and', 'cat']));
-  print_bool(word_break('cars', ['car', 'ca', 'rs']));
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+print_bool(word_break('applepenapple', ['apple', 'pen']));
+print_bool(word_break('catsandog', ['cats', 'dog', 'sand', 'and', 'cat']));
+print_bool(word_break('cars', ['car', 'ca', 'rs']));

--- a/tests/algorithms/x/PHP/electronics/apparent_power.php
+++ b/tests/algorithms/x/PHP/electronics/apparent_power.php
@@ -1,35 +1,19 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
-$__start_mem = memory_get_usage();
-$__start = _now();
-  $PI = 3.141592653589793;
-  function mochi_abs($x) {
+$PI = 3.141592653589793;
+function mochi_abs($x) {
   global $PI;
   if ($x < 0.0) {
   return -$x;
 }
   return $x;
-};
-  function to_radians($deg) {
+}
+function to_radians($deg) {
   global $PI;
   return $deg * $PI / 180.0;
-};
-  function sin_taylor($x) {
+}
+function sin_taylor($x) {
   global $PI;
   $term = $x;
   $sum = $x;
@@ -42,8 +26,8 @@ $__start = _now();
   $i = $i + 1;
 };
   return $sum;
-};
-  function cos_taylor($x) {
+}
+function cos_taylor($x) {
   global $PI;
   $term = 1.0;
   $sum = 1.0;
@@ -56,18 +40,18 @@ $__start = _now();
   $i = $i + 1;
 };
   return $sum;
-};
-  function rect($mag, $angle) {
+}
+function rect($mag, $angle) {
   global $PI;
   $c = cos_taylor($angle);
   $s = sin_taylor($angle);
   return [$mag * $c, $mag * $s];
-};
-  function multiply($a, $b) {
+}
+function multiply($a, $b) {
   global $PI;
   return [$a[0] * $b[0] - $a[1] * $b[1], $a[0] * $b[1] + $a[1] * $b[0]];
-};
-  function apparent_power($voltage, $current, $voltage_angle, $current_angle) {
+}
+function apparent_power($voltage, $current, $voltage_angle, $current_angle) {
   global $PI;
   $vrad = to_radians($voltage_angle);
   $irad = to_radians($current_angle);
@@ -75,16 +59,8 @@ $__start = _now();
   $irect = rect($current, $irad);
   $result = multiply($vrect, $irect);
   return $result;
-};
-  function approx_equal($a, $b, $eps) {
+}
+function approx_equal($a, $b, $eps) {
   global $PI;
   return mochi_abs($a[0] - $b[0]) < $eps && mochi_abs($a[1] - $b[1]) < $eps;
-};
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}

--- a/tests/algorithms/x/PHP/electronics/builtin_voltage.php
+++ b/tests/algorithms/x/PHP/electronics/builtin_voltage.php
@@ -1,20 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -35,9 +21,7 @@ function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  function pow10($n) {
+function pow10($n) {
   global $BOLTZMANN, $ELECTRON_VOLT, $TEMPERATURE;
   $result = 1.0;
   $i = 0;
@@ -46,11 +30,11 @@ $__start = _now();
   $i = $i + 1;
 };
   return $result;
-};
-  $BOLTZMANN = 1.380649 / pow10(23);
-  $ELECTRON_VOLT = 1.602176634 / pow10(19);
-  $TEMPERATURE = 300.0;
-  function ln_series($x) {
+}
+$BOLTZMANN = 1.380649 / pow10(23);
+$ELECTRON_VOLT = 1.602176634 / pow10(19);
+$TEMPERATURE = 300.0;
+function ln_series($x) {
   global $BOLTZMANN, $ELECTRON_VOLT, $TEMPERATURE;
   $t = ($x - 1.0) / ($x + 1.0);
   $term = $t;
@@ -62,8 +46,8 @@ $__start = _now();
   $n = $n + 2;
 };
   return 2.0 * $sum;
-};
-  function ln($x) {
+}
+function ln($x) {
   global $BOLTZMANN, $ELECTRON_VOLT, $TEMPERATURE;
   $y = $x;
   $k = 0;
@@ -76,8 +60,8 @@ $__start = _now();
   $k = $k - 1;
 };
   return ln_series($y) + (floatval($k)) * ln_series(10.0);
-};
-  function builtin_voltage($donor_conc, $acceptor_conc, $intrinsic_conc) {
+}
+function builtin_voltage($donor_conc, $acceptor_conc, $intrinsic_conc) {
   global $BOLTZMANN, $ELECTRON_VOLT, $TEMPERATURE;
   if ($donor_conc <= 0.0) {
   _panic('Donor concentration should be positive');
@@ -95,13 +79,5 @@ $__start = _now();
   _panic('Acceptor concentration should be greater than intrinsic concentration');
 }
   return $BOLTZMANN * $TEMPERATURE * ln(($donor_conc * $acceptor_conc) / ($intrinsic_conc * $intrinsic_conc)) / $ELECTRON_VOLT;
-};
-  echo rtrim(_str(builtin_voltage(pow10(17), pow10(17), pow10(10)))), PHP_EOL;
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+echo rtrim(_str(builtin_voltage(pow10(17), pow10(17), pow10(10)))), PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/capacitor_equivalence.php
+++ b/tests/algorithms/x/PHP/electronics/capacitor_equivalence.php
@@ -1,20 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -35,9 +21,7 @@ function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  function capacitor_parallel($capacitors) {
+function capacitor_parallel($capacitors) {
   $sum_c = 0.0;
   $i = 0;
   while ($i < count($capacitors)) {
@@ -50,8 +34,8 @@ $__start = _now();
   $i = $i + 1;
 };
   return $sum_c;
-};
-  function capacitor_series($capacitors) {
+}
+function capacitor_series($capacitors) {
   $first_sum = 0.0;
   $i = 0;
   while ($i < count($capacitors)) {
@@ -64,19 +48,11 @@ $__start = _now();
   $i = $i + 1;
 };
   return 1.0 / $first_sum;
-};
-  function main() {
+}
+function main() {
   $parallel = capacitor_parallel([5.71389, 12.0, 3.0]);
   $series = capacitor_series([5.71389, 12.0, 3.0]);
   echo rtrim(_str($parallel)), PHP_EOL;
   echo rtrim(_str($series)), PHP_EOL;
-};
-  main();
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+main();

--- a/tests/algorithms/x/PHP/electronics/carrier_concentration.php
+++ b/tests/algorithms/x/PHP/electronics/carrier_concentration.php
@@ -1,20 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -35,9 +21,7 @@ function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  function sqrtApprox($x) {
+function sqrtApprox($x) {
   global $r1, $r2, $r3;
   $guess = $x / 2.0;
   $i = 0;
@@ -46,8 +30,8 @@ $__start = _now();
   $i = $i + 1;
 };
   return $guess;
-};
-  function carrier_concentration($electron_conc, $hole_conc, $intrinsic_conc) {
+}
+function carrier_concentration($electron_conc, $hole_conc, $intrinsic_conc) {
   global $r1, $r2, $r3;
   $zero_count = 0;
   if ($electron_conc == 0.0) {
@@ -81,18 +65,10 @@ $__start = _now();
   return ['name' => 'intrinsic_conc', 'value' => sqrtApprox($electron_conc * $hole_conc)];
 }
   return ['name' => '', 'value' => -1.0];
-};
-  $r1 = carrier_concentration(25.0, 100.0, 0.0);
-  echo rtrim($r1['name'] . ', ' . _str($r1['value'])), PHP_EOL;
-  $r2 = carrier_concentration(0.0, 1600.0, 200.0);
-  echo rtrim($r2['name'] . ', ' . _str($r2['value'])), PHP_EOL;
-  $r3 = carrier_concentration(1000.0, 0.0, 1200.0);
-  echo rtrim($r3['name'] . ', ' . _str($r3['value'])), PHP_EOL;
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+$r1 = carrier_concentration(25.0, 100.0, 0.0);
+echo rtrim($r1['name'] . ', ' . _str($r1['value'])), PHP_EOL;
+$r2 = carrier_concentration(0.0, 1600.0, 200.0);
+echo rtrim($r2['name'] . ', ' . _str($r2['value'])), PHP_EOL;
+$r3 = carrier_concentration(1000.0, 0.0, 1200.0);
+echo rtrim($r3['name'] . ', ' . _str($r3['value'])), PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/charging_capacitor.php
+++ b/tests/algorithms/x/PHP/electronics/charging_capacitor.php
@@ -1,27 +1,11 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  function expApprox($x) {
+function expApprox($x) {
   $y = $x;
   $is_neg = false;
   if ($x < 0.0) {
@@ -40,8 +24,8 @@ $__start = _now();
   return 1.0 / $sum;
 }
   return $sum;
-};
-  function round3($x) {
+}
+function round3($x) {
   $scaled = $x * 1000.0;
   if ($scaled >= 0.0) {
   $scaled = $scaled + 0.5;
@@ -50,8 +34,8 @@ $__start = _now();
 }
   $scaled_int = intval($scaled);
   return (floatval($scaled_int)) / 1000.0;
-};
-  function charging_capacitor($source_voltage, $resistance, $capacitance, $time_sec) {
+}
+function charging_capacitor($source_voltage, $resistance, $capacitance, $time_sec) {
   if ($source_voltage <= 0.0) {
   _panic('Source voltage must be positive.');
 }
@@ -64,16 +48,8 @@ $__start = _now();
   $exponent = -$time_sec / ($resistance * $capacitance);
   $voltage = $source_voltage * (1.0 - expApprox($exponent));
   return round3($voltage);
-};
-  echo rtrim(json_encode(charging_capacitor(0.2, 0.9, 8.4, 0.5), 1344)), PHP_EOL;
-  echo rtrim(json_encode(charging_capacitor(2.2, 3.5, 2.4, 9.0), 1344)), PHP_EOL;
-  echo rtrim(json_encode(charging_capacitor(15.0, 200.0, 20.0, 2.0), 1344)), PHP_EOL;
-  echo rtrim(json_encode(charging_capacitor(20.0, 2000.0, 0.0003, 4.0), 1344)), PHP_EOL;
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+echo rtrim(json_encode(charging_capacitor(0.2, 0.9, 8.4, 0.5), 1344)), PHP_EOL;
+echo rtrim(json_encode(charging_capacitor(2.2, 3.5, 2.4, 9.0), 1344)), PHP_EOL;
+echo rtrim(json_encode(charging_capacitor(15.0, 200.0, 20.0, 2.0), 1344)), PHP_EOL;
+echo rtrim(json_encode(charging_capacitor(20.0, 2000.0, 0.0003, 4.0), 1344)), PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/charging_inductor.php
+++ b/tests/algorithms/x/PHP/electronics/charging_inductor.php
@@ -1,27 +1,11 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  function expApprox($x) {
+function expApprox($x) {
   if ($x < 0.0) {
   return 1.0 / expApprox(-$x);
 }
@@ -38,15 +22,15 @@ $__start = _now();
   $n = $n + 1;
 };
   return $sum;
-};
-  function mochi_floor($x) {
+}
+function mochi_floor($x) {
   $i = intval($x);
   if ((floatval($i)) > $x) {
   $i = $i - 1;
 }
   return floatval($i);
-};
-  function pow10($n) {
+}
+function pow10($n) {
   $result = 1.0;
   $i = 0;
   while ($i < $n) {
@@ -54,12 +38,12 @@ $__start = _now();
   $i = $i + 1;
 };
   return $result;
-};
-  function mochi_round($x, $n) {
+}
+function mochi_round($x, $n) {
   $m = pow10($n);
   return mochi_floor($x * $m + 0.5) / $m;
-};
-  function charging_inductor($source_voltage, $resistance, $inductance, $time) {
+}
+function charging_inductor($source_voltage, $resistance, $inductance, $time) {
   if ($source_voltage <= 0.0) {
   _panic('Source voltage must be positive.');
 }
@@ -72,15 +56,7 @@ $__start = _now();
   $exponent = (-$time * $resistance) / $inductance;
   $current = $source_voltage / $resistance * (1.0 - expApprox($exponent));
   return mochi_round($current, 3);
-};
-  echo rtrim(json_encode(charging_inductor(5.8, 1.5, 2.3, 2.0), 1344)), PHP_EOL;
-  echo rtrim(json_encode(charging_inductor(8.0, 5.0, 3.0, 2.0), 1344)), PHP_EOL;
-  echo rtrim(json_encode(charging_inductor(8.0, 500.0, 3.0, 2.0), 1344)), PHP_EOL;
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+echo rtrim(json_encode(charging_inductor(5.8, 1.5, 2.3, 2.0), 1344)), PHP_EOL;
+echo rtrim(json_encode(charging_inductor(8.0, 5.0, 3.0, 2.0), 1344)), PHP_EOL;
+echo rtrim(json_encode(charging_inductor(8.0, 500.0, 3.0, 2.0), 1344)), PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/circular_convolution.php
+++ b/tests/algorithms/x/PHP/electronics/circular_convolution.php
@@ -1,20 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -35,17 +21,15 @@ function _append($arr, $x) {
     $arr[] = $x;
     return $arr;
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  function mochi_floor($x) {
+function mochi_floor($x) {
   global $example1, $example2, $example3, $example4;
   $i = intval($x);
   if ((floatval($i)) > $x) {
   $i = $i - 1;
 }
   return floatval($i);
-};
-  function pow10($n) {
+}
+function pow10($n) {
   global $example1, $example2, $example3, $example4;
   $p = 1.0;
   $i = 0;
@@ -54,21 +38,21 @@ $__start = _now();
   $i = $i + 1;
 };
   return $p;
-};
-  function roundn($x, $n) {
+}
+function roundn($x, $n) {
   global $example1, $example2, $example3, $example4;
   $m = pow10($n);
   return mochi_floor($x * $m + 0.5) / $m;
-};
-  function pad($signal, $target) {
+}
+function pad($signal, $target) {
   global $example1, $example2, $example3, $example4;
   $s = $signal;
   while (count($s) < $target) {
   $s = _append($s, 0.0);
 };
   return $s;
-};
-  function circular_convolution($a, $b) {
+}
+function circular_convolution($a, $b) {
   global $example1, $example2, $example3, $example4;
   $n1 = count($a);
   $n2 = count($b);
@@ -90,20 +74,12 @@ $__start = _now();
   $i = $i + 1;
 };
   return $res;
-};
-  $example1 = circular_convolution([2.0, 1.0, 2.0, -1.0], [1.0, 2.0, 3.0, 4.0]);
-  echo rtrim(_str($example1)), PHP_EOL;
-  $example2 = circular_convolution([0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6], [0.1, 0.3, 0.5, 0.7, 0.9, 1.1, 1.3, 1.5]);
-  echo rtrim(_str($example2)), PHP_EOL;
-  $example3 = circular_convolution([-1.0, 1.0, 2.0, -2.0], [0.5, 1.0, -1.0, 2.0, 0.75]);
-  echo rtrim(_str($example3)), PHP_EOL;
-  $example4 = circular_convolution([1.0, -1.0, 2.0, 3.0, -1.0], [1.0, 2.0, 3.0]);
-  echo rtrim(_str($example4)), PHP_EOL;
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+$example1 = circular_convolution([2.0, 1.0, 2.0, -1.0], [1.0, 2.0, 3.0, 4.0]);
+echo rtrim(_str($example1)), PHP_EOL;
+$example2 = circular_convolution([0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6], [0.1, 0.3, 0.5, 0.7, 0.9, 1.1, 1.3, 1.5]);
+echo rtrim(_str($example2)), PHP_EOL;
+$example3 = circular_convolution([-1.0, 1.0, 2.0, -2.0], [0.5, 1.0, -1.0, 2.0, 0.75]);
+echo rtrim(_str($example3)), PHP_EOL;
+$example4 = circular_convolution([1.0, -1.0, 2.0, 3.0, -1.0], [1.0, 2.0, 3.0]);
+echo rtrim(_str($example4)), PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/coulombs_law.php
+++ b/tests/algorithms/x/PHP/electronics/coulombs_law.php
@@ -1,20 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -35,17 +21,15 @@ function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  $COULOMBS_CONSTANT = 8988000000.0;
-  function mochi_abs($x) {
+$COULOMBS_CONSTANT = 8988000000.0;
+function mochi_abs($x) {
   global $COULOMBS_CONSTANT;
   if ($x < 0.0) {
   return -$x;
 }
   return $x;
-};
-  function sqrtApprox($x) {
+}
+function sqrtApprox($x) {
   global $COULOMBS_CONSTANT;
   if ($x <= 0.0) {
   return 0.0;
@@ -57,8 +41,8 @@ $__start = _now();
   $i = $i + 1;
 };
   return $guess;
-};
-  function coulombs_law($force, $charge1, $charge2, $distance) {
+}
+function coulombs_law($force, $charge1, $charge2, $distance) {
   global $COULOMBS_CONSTANT;
   $charge_product = mochi_abs($charge1 * $charge2);
   $zero_count = 0;
@@ -82,33 +66,25 @@ $__start = _now();
 }
   if ($force == 0.0) {
   $f = $COULOMBS_CONSTANT * $charge_product / ($distance * $distance);
-  return ['force' => $f];
+  return ['force' => &$f];
 }
   if ($charge1 == 0.0) {
   $c1 = mochi_abs($force) * ($distance * $distance) / ($COULOMBS_CONSTANT * $charge2);
-  return ['charge1' => $c1];
+  return ['charge1' => &$c1];
 }
   if ($charge2 == 0.0) {
   $c2 = mochi_abs($force) * ($distance * $distance) / ($COULOMBS_CONSTANT * $charge1);
-  return ['charge2' => $c2];
+  return ['charge2' => &$c2];
 }
   $d = sqrtApprox($COULOMBS_CONSTANT * $charge_product / mochi_abs($force));
-  return ['distance' => $d];
-};
-  function print_map($m) {
+  return ['distance' => &$d];
+}
+function print_map($m) {
   global $COULOMBS_CONSTANT;
   foreach (array_keys($m) as $k) {
   echo rtrim('{"' . $k . '": ' . _str($m[$k]) . '}'), PHP_EOL;
 };
-};
-  print_map(coulombs_law(0.0, 3.0, 5.0, 2000.0));
-  print_map(coulombs_law(10.0, 3.0, 5.0, 0.0));
-  print_map(coulombs_law(10.0, 0.0, 5.0, 2000.0));
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+print_map(coulombs_law(0.0, 3.0, 5.0, 2000.0));
+print_map(coulombs_law(10.0, 3.0, 5.0, 0.0));
+print_map(coulombs_law(10.0, 0.0, 5.0, 2000.0));

--- a/tests/algorithms/x/PHP/electronics/electric_conductivity.php
+++ b/tests/algorithms/x/PHP/electronics/electric_conductivity.php
@@ -1,20 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -35,10 +21,8 @@ function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  $ELECTRON_CHARGE = 0.00000000000000000016021;
-  function electric_conductivity($conductivity, $electron_conc, $mobility) {
+$ELECTRON_CHARGE = 0.00000000000000000016021;
+function electric_conductivity($conductivity, $electron_conc, $mobility) {
   global $ELECTRON_CHARGE, $r1, $r2, $r3;
   $zero_count = 0;
   if ($conductivity == 0.0) {
@@ -69,18 +53,10 @@ $__start = _now();
   return ['kind' => 'electron_conc', 'value' => $conductivity / ($mobility * $ELECTRON_CHARGE)];
 }
   return ['kind' => 'mobility', 'value' => $conductivity / ($electron_conc * $ELECTRON_CHARGE)];
-};
-  $r1 = electric_conductivity(25.0, 100.0, 0.0);
-  $r2 = electric_conductivity(0.0, 1600.0, 200.0);
-  $r3 = electric_conductivity(1000.0, 0.0, 1200.0);
-  echo rtrim($r1['kind'] . ' ' . _str($r1['value'])), PHP_EOL;
-  echo rtrim($r2['kind'] . ' ' . _str($r2['value'])), PHP_EOL;
-  echo rtrim($r3['kind'] . ' ' . _str($r3['value'])), PHP_EOL;
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+$r1 = electric_conductivity(25.0, 100.0, 0.0);
+$r2 = electric_conductivity(0.0, 1600.0, 200.0);
+$r3 = electric_conductivity(1000.0, 0.0, 1200.0);
+echo rtrim($r1['kind'] . ' ' . _str($r1['value'])), PHP_EOL;
+echo rtrim($r2['kind'] . ' ' . _str($r2['value'])), PHP_EOL;
+echo rtrim($r3['kind'] . ' ' . _str($r3['value'])), PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/electric_power.php
+++ b/tests/algorithms/x/PHP/electronics/electric_power.php
@@ -1,20 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -35,16 +21,14 @@ function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  function absf($x) {
+function absf($x) {
   global $r1, $r2, $r3, $r4, $r5;
   if ($x < 0.0) {
   return -$x;
 }
   return $x;
-};
-  function pow10($n) {
+}
+function pow10($n) {
   global $r1, $r2, $r3, $r4, $r5;
   $p = 1.0;
   $i = 0;
@@ -53,13 +37,13 @@ $__start = _now();
   $i = $i + 1;
 };
   return $p;
-};
-  function round_to($x, $n) {
+}
+function round_to($x, $n) {
   global $r1, $r2, $r3, $r4, $r5;
   $m = pow10($n);
   return floor($x * $m + 0.5) / $m;
-};
-  function electric_power($voltage, $current, $power) {
+}
+function electric_power($voltage, $current, $power) {
   global $r1, $r2, $r3, $r4, $r5;
   $zeros = 0;
   if ($voltage == 0.0) {
@@ -93,26 +77,18 @@ $__start = _now();
 };
 };
 }
-};
-  function str_result($r) {
+}
+function str_result($r) {
   global $r1, $r2, $r3, $r4, $r5;
   return 'Result(name=\'' . $r['name'] . '\', value=' . _str($r['value']) . ')';
-};
-  $r1 = electric_power(0.0, 2.0, 5.0);
-  echo rtrim(str_result($r1)), PHP_EOL;
-  $r2 = electric_power(2.0, 2.0, 0.0);
-  echo rtrim(str_result($r2)), PHP_EOL;
-  $r3 = electric_power(-2.0, 3.0, 0.0);
-  echo rtrim(str_result($r3)), PHP_EOL;
-  $r4 = electric_power(2.2, 2.2, 0.0);
-  echo rtrim(str_result($r4)), PHP_EOL;
-  $r5 = electric_power(2.0, 0.0, 6.0);
-  echo rtrim(str_result($r5)), PHP_EOL;
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+$r1 = electric_power(0.0, 2.0, 5.0);
+echo rtrim(str_result($r1)), PHP_EOL;
+$r2 = electric_power(2.0, 2.0, 0.0);
+echo rtrim(str_result($r2)), PHP_EOL;
+$r3 = electric_power(-2.0, 3.0, 0.0);
+echo rtrim(str_result($r3)), PHP_EOL;
+$r4 = electric_power(2.2, 2.2, 0.0);
+echo rtrim(str_result($r4)), PHP_EOL;
+$r5 = electric_power(2.0, 0.0, 6.0);
+echo rtrim(str_result($r5)), PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/electrical_impedance.php
+++ b/tests/algorithms/x/PHP/electronics/electrical_impedance.php
@@ -1,27 +1,11 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  function sqrtApprox($x) {
+function sqrtApprox($x) {
   if ($x <= 0.0) {
   return 0.0;
 }
@@ -32,8 +16,8 @@ $__start = _now();
   $i = $i + 1;
 };
   return $guess;
-};
-  function electrical_impedance($resistance, $reactance, $impedance) {
+}
+function electrical_impedance($resistance, $reactance, $impedance) {
   $zero_count = 0;
   if ($resistance == 0.0) {
   $zero_count = $zero_count + 1;
@@ -49,29 +33,21 @@ $__start = _now();
 }
   if ($resistance == 0.0) {
   $value = sqrtApprox($impedance * $impedance - $reactance * $reactance);
-  return ['resistance' => $value];
+  return ['resistance' => &$value];
 } else {
   if ($reactance == 0.0) {
   $value = sqrtApprox($impedance * $impedance - $resistance * $resistance);
-  return ['reactance' => $value];
+  return ['reactance' => &$value];
 } else {
   if ($impedance == 0.0) {
   $value = sqrtApprox($resistance * $resistance + $reactance * $reactance);
-  return ['impedance' => $value];
+  return ['impedance' => &$value];
 } else {
   _panic('Exactly one argument must be 0');
 };
 };
 }
-};
-  echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(electrical_impedance(3.0, 4.0, 0.0), 1344)))))), PHP_EOL;
-  echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(electrical_impedance(0.0, 4.0, 5.0), 1344)))))), PHP_EOL;
-  echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(electrical_impedance(3.0, 0.0, 5.0), 1344)))))), PHP_EOL;
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(electrical_impedance(3.0, 4.0, 0.0), 1344)))))), PHP_EOL;
+echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(electrical_impedance(0.0, 4.0, 5.0), 1344)))))), PHP_EOL;
+echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(electrical_impedance(3.0, 0.0, 5.0), 1344)))))), PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/ic_555_timer.php
+++ b/tests/algorithms/x/PHP/electronics/ic_555_timer.php
@@ -1,45 +1,21 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  function astable_frequency($resistance_1, $resistance_2, $capacitance) {
+function astable_frequency($resistance_1, $resistance_2, $capacitance) {
   if ($resistance_1 <= 0.0 || $resistance_2 <= 0.0 || $capacitance <= 0.0) {
   _panic('All values must be positive');
 }
   return (1.44 / (($resistance_1 + 2.0 * $resistance_2) * $capacitance)) * 1000000.0;
-};
-  function astable_duty_cycle($resistance_1, $resistance_2) {
+}
+function astable_duty_cycle($resistance_1, $resistance_2) {
   if ($resistance_1 <= 0.0 || $resistance_2 <= 0.0) {
   _panic('All values must be positive');
 }
   return ($resistance_1 + $resistance_2) / ($resistance_1 + 2.0 * $resistance_2) * 100.0;
-};
-  echo rtrim(json_encode(astable_frequency(45.0, 45.0, 7.0), 1344)), PHP_EOL;
-  echo rtrim(json_encode(astable_duty_cycle(45.0, 45.0), 1344)), PHP_EOL;
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+echo rtrim(json_encode(astable_frequency(45.0, 45.0, 7.0), 1344)), PHP_EOL;
+echo rtrim(json_encode(astable_duty_cycle(45.0, 45.0), 1344)), PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/ind_reactance.php
+++ b/tests/algorithms/x/PHP/electronics/ind_reactance.php
@@ -1,28 +1,12 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  $PI = 3.141592653589793;
-  function ind_reactance($inductance, $frequency, $reactance) {
+$PI = 3.141592653589793;
+function ind_reactance($inductance, $frequency, $reactance) {
   global $PI;
   $zero_count = 0;
   if ($inductance == 0.0) {
@@ -53,15 +37,7 @@ $__start = _now();
   return ['frequency' => $reactance / (2.0 * $PI * $inductance)];
 }
   return ['reactance' => 2.0 * $PI * $frequency * $inductance];
-};
-  echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(ind_reactance(0.0, 10000.0, 50.0), 1344)))))), PHP_EOL;
-  echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(ind_reactance(0.035, 0.0, 50.0), 1344)))))), PHP_EOL;
-  echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(ind_reactance(0.000035, 1000.0, 0.0), 1344)))))), PHP_EOL;
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(ind_reactance(0.0, 10000.0, 50.0), 1344)))))), PHP_EOL;
+echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(ind_reactance(0.035, 0.0, 50.0), 1344)))))), PHP_EOL;
+echo str_replace('false', 'False', str_replace('true', 'True', str_replace('"', '\'', str_replace(':', ': ', str_replace(',', ', ', json_encode(ind_reactance(0.000035, 1000.0, 0.0), 1344)))))), PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/ohms_law.php
+++ b/tests/algorithms/x/PHP/electronics/ohms_law.php
@@ -1,23 +1,7 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
-$__start_mem = memory_get_usage();
-$__start = _now();
-  function ohms_law($voltage, $current, $resistance) {
+function ohms_law($voltage, $current, $resistance) {
   $zeros = 0;
   if ($voltage == 0.0) {
   $zeros = $zeros + 1;
@@ -43,15 +27,7 @@ $__start = _now();
   return ['current' => $voltage / $resistance];
 }
   return ['resistance' => $voltage / $current];
-};
-  echo str_replace('    ', '  ', json_encode(ohms_law(10.0, 0.0, 5.0), 128)), PHP_EOL;
-  echo str_replace('    ', '  ', json_encode(ohms_law(-10.0, 1.0, 0.0), 128)), PHP_EOL;
-  echo str_replace('    ', '  ', json_encode(ohms_law(0.0, -1.5, 2.0), 128)), PHP_EOL;
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+echo str_replace('    ', '  ', json_encode(ohms_law(10.0, 0.0, 5.0), 128)), PHP_EOL;
+echo str_replace('    ', '  ', json_encode(ohms_law(-10.0, 1.0, 0.0), 128)), PHP_EOL;
+echo str_replace('    ', '  ', json_encode(ohms_law(0.0, -1.5, 2.0), 128)), PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/real_and_reactive_power.php
+++ b/tests/algorithms/x/PHP/electronics/real_and_reactive_power.php
@@ -1,20 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -35,9 +21,7 @@ function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  function mochi_sqrt($x) {
+function mochi_sqrt($x) {
   if ($x <= 0.0) {
   return 0.0;
 }
@@ -48,30 +32,22 @@ $__start = _now();
   $i = $i + 1;
 };
   return $guess;
-};
-  function real_power($apparent_power, $power_factor) {
+}
+function real_power($apparent_power, $power_factor) {
   if ($power_factor < 0.0 - 1.0 || $power_factor > 1.0) {
   _panic('power_factor must be a valid float value between -1 and 1.');
 }
   return $apparent_power * $power_factor;
-};
-  function reactive_power($apparent_power, $power_factor) {
+}
+function reactive_power($apparent_power, $power_factor) {
   if ($power_factor < 0.0 - 1.0 || $power_factor > 1.0) {
   _panic('power_factor must be a valid float value between -1 and 1.');
 }
   return $apparent_power * mochi_sqrt(1.0 - $power_factor * $power_factor);
-};
-  echo rtrim(_str(real_power(100.0, 0.9))), PHP_EOL;
-  echo rtrim(_str(real_power(0.0, 0.8))), PHP_EOL;
-  echo rtrim(_str(real_power(100.0, -0.9))), PHP_EOL;
-  echo rtrim(_str(reactive_power(100.0, 0.9))), PHP_EOL;
-  echo rtrim(_str(reactive_power(0.0, 0.8))), PHP_EOL;
-  echo rtrim(_str(reactive_power(100.0, -0.9))), PHP_EOL;
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+echo rtrim(_str(real_power(100.0, 0.9))), PHP_EOL;
+echo rtrim(_str(real_power(0.0, 0.8))), PHP_EOL;
+echo rtrim(_str(real_power(100.0, -0.9))), PHP_EOL;
+echo rtrim(_str(reactive_power(100.0, 0.9))), PHP_EOL;
+echo rtrim(_str(reactive_power(0.0, 0.8))), PHP_EOL;
+echo rtrim(_str(reactive_power(100.0, -0.9))), PHP_EOL;

--- a/tests/algorithms/x/PHP/electronics/resistor_color_code.php
+++ b/tests/algorithms/x/PHP/electronics/resistor_color_code.php
@@ -1,20 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -35,14 +21,12 @@ function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  $valid_colors = ['Black', 'Brown', 'Red', 'Orange', 'Yellow', 'Green', 'Blue', 'Violet', 'Grey', 'White', 'Gold', 'Silver'];
-  $significant_figures_color_values = ['Black' => 0, 'Brown' => 1, 'Red' => 2, 'Orange' => 3, 'Yellow' => 4, 'Green' => 5, 'Blue' => 6, 'Violet' => 7, 'Grey' => 8, 'White' => 9];
-  $multiplier_color_values = ['Black' => 1.0, 'Brown' => 10.0, 'Red' => 100.0, 'Orange' => 1000.0, 'Yellow' => 10000.0, 'Green' => 100000.0, 'Blue' => 1000000.0, 'Violet' => 10000000.0, 'Grey' => 100000000.0, 'White' => 1000000000.0, 'Gold' => 0.1, 'Silver' => 0.01];
-  $tolerance_color_values = ['Brown' => 1.0, 'Red' => 2.0, 'Orange' => 0.05, 'Yellow' => 0.02, 'Green' => 0.5, 'Blue' => 0.25, 'Violet' => 0.1, 'Grey' => 0.01, 'Gold' => 5.0, 'Silver' => 10.0];
-  $temperature_coeffecient_color_values = ['Black' => 250, 'Brown' => 100, 'Red' => 50, 'Orange' => 15, 'Yellow' => 25, 'Green' => 20, 'Blue' => 10, 'Violet' => 5, 'Grey' => 1];
-  function contains($list, $value) {
+$valid_colors = ['Black', 'Brown', 'Red', 'Orange', 'Yellow', 'Green', 'Blue', 'Violet', 'Grey', 'White', 'Gold', 'Silver'];
+$significant_figures_color_values = ['Black' => 0, 'Blue' => 6, 'Brown' => 1, 'Green' => 5, 'Grey' => 8, 'Orange' => 3, 'Red' => 2, 'Violet' => 7, 'White' => 9, 'Yellow' => 4];
+$multiplier_color_values = ['Black' => 1.0, 'Blue' => 1000000.0, 'Brown' => 10.0, 'Gold' => 0.1, 'Green' => 100000.0, 'Grey' => 100000000.0, 'Orange' => 1000.0, 'Red' => 100.0, 'Silver' => 0.01, 'Violet' => 10000000.0, 'White' => 1000000000.0, 'Yellow' => 10000.0];
+$tolerance_color_values = ['Blue' => 0.25, 'Brown' => 1.0, 'Gold' => 5.0, 'Green' => 0.5, 'Grey' => 0.01, 'Orange' => 0.05, 'Red' => 2.0, 'Silver' => 10.0, 'Violet' => 0.1, 'Yellow' => 0.02];
+$temperature_coeffecient_color_values = ['Black' => 250, 'Blue' => 10, 'Brown' => 100, 'Green' => 20, 'Grey' => 1, 'Orange' => 15, 'Red' => 50, 'Violet' => 5, 'Yellow' => 25];
+function mochi_contains($list, $value) {
   global $multiplier_color_values, $significant_figures_color_values, $temperature_coeffecient_color_values, $tolerance_color_values, $valid_colors;
   foreach ($list as $c) {
   if ($c == $value) {
@@ -50,8 +34,8 @@ $__start = _now();
 }
 };
   return false;
-};
-  function get_significant_digits($colors) {
+}
+function get_significant_digits($colors) {
   global $multiplier_color_values, $significant_figures_color_values, $temperature_coeffecient_color_values, $tolerance_color_values, $valid_colors;
   $digit = 0;
   foreach ($colors as $color) {
@@ -61,29 +45,29 @@ $__start = _now();
   $digit = $digit * 10 + $significant_figures_color_values[$color];
 };
   return $digit;
-};
-  function get_multiplier($color) {
+}
+function get_multiplier($color) {
   global $multiplier_color_values, $significant_figures_color_values, $temperature_coeffecient_color_values, $tolerance_color_values, $valid_colors;
   if (!(isset($multiplier_color_values[$color]))) {
   _panic($color . ' is not a valid color for multiplier band');
 }
   return $multiplier_color_values[$color];
-};
-  function get_tolerance($color) {
+}
+function get_tolerance($color) {
   global $multiplier_color_values, $significant_figures_color_values, $temperature_coeffecient_color_values, $tolerance_color_values, $valid_colors;
   if (!(isset($tolerance_color_values[$color]))) {
   _panic($color . ' is not a valid color for tolerance band');
 }
   return $tolerance_color_values[$color];
-};
-  function get_temperature_coeffecient($color) {
+}
+function get_temperature_coeffecient($color) {
   global $multiplier_color_values, $significant_figures_color_values, $temperature_coeffecient_color_values, $tolerance_color_values, $valid_colors;
   if (!(isset($temperature_coeffecient_color_values[$color]))) {
   _panic($color . ' is not a valid color for temperature coeffecient band');
 }
   return $temperature_coeffecient_color_values[$color];
-};
-  function get_band_type_count($total, $typ) {
+}
+function get_band_type_count($total, $typ) {
   global $multiplier_color_values, $significant_figures_color_values, $temperature_coeffecient_color_values, $tolerance_color_values, $valid_colors;
   if ($total == 3) {
   if ($typ == 'significant') {
@@ -138,8 +122,8 @@ $__start = _now();
 };
 };
 }
-};
-  function check_validity($number_of_bands, $colors) {
+}
+function check_validity($number_of_bands, $colors) {
   global $multiplier_color_values, $significant_figures_color_values, $temperature_coeffecient_color_values, $tolerance_color_values, $valid_colors;
   if ($number_of_bands < 3 || $number_of_bands > 6) {
   _panic('Invalid number of bands. Resistor bands must be 3 to 6');
@@ -148,13 +132,13 @@ $__start = _now();
   _panic('Expecting ' . _str($number_of_bands) . ' colors, provided ' . _str(count($colors)) . ' colors');
 }
   foreach ($colors as $color) {
-  if (!contains($valid_colors, $color)) {
+  if (!mochi_contains($valid_colors, $color)) {
   _panic($color . ' is not a valid color');
 }
 };
   return true;
-};
-  function calculate_resistance($number_of_bands, $color_code_list) {
+}
+function calculate_resistance($number_of_bands, $color_code_list) {
   global $multiplier_color_values, $significant_figures_color_values, $temperature_coeffecient_color_values, $tolerance_color_values, $valid_colors;
   check_validity($number_of_bands, $color_code_list);
   $sig_count = get_band_type_count($number_of_bands, 'significant');
@@ -182,12 +166,4 @@ $__start = _now();
   $answer = $answer . _str($temp_coeff) . ' ppm/K';
 }
   return $answer;
-};
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}

--- a/tests/algorithms/x/PHP/electronics/resistor_equivalence.php
+++ b/tests/algorithms/x/PHP/electronics/resistor_equivalence.php
@@ -1,20 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
-}
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
 function _str($x) {
     if (is_array($x)) {
         $isList = array_keys($x) === range(0, count($x) - 1);
@@ -35,9 +21,7 @@ function _panic($msg) {
     fwrite(STDERR, strval($msg));
     exit(1);
 }
-$__start_mem = memory_get_usage();
-$__start = _now();
-  function resistor_parallel($resistors) {
+function resistor_parallel($resistors) {
   $sum = 0.0;
   $i = 0;
   while ($i < count($resistors)) {
@@ -49,8 +33,8 @@ $__start = _now();
   $i = $i + 1;
 };
   return 1.0 / $sum;
-};
-  function resistor_series($resistors) {
+}
+function resistor_series($resistors) {
   $sum = 0.0;
   $i = 0;
   while ($i < count($resistors)) {
@@ -62,18 +46,10 @@ $__start = _now();
   $i = $i + 1;
 };
   return $sum;
-};
-  function main() {
+}
+function main() {
   $resistors = [3.21389, 2.0, 3.0];
   echo rtrim('Parallel: ' . _str(resistor_parallel($resistors))), PHP_EOL;
   echo rtrim('Series: ' . _str(resistor_series($resistors))), PHP_EOL;
-};
-  main();
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+main();

--- a/tests/algorithms/x/PHP/file_transfer/tests/test_send_file.bench
+++ b/tests/algorithms/x/PHP/file_transfer/tests/test_send_file.bench
@@ -1,1 +1,5 @@
-Fatal error: Cannot redeclare function socket_bind() in /workspace/mochi/tests/algorithms/x/PHP/file_transfer/tests/test_send_file.php on line 42
+{
+  "duration_us": 138,
+  "memory_bytes": 1681184,
+  "name": "main"
+}

--- a/tests/algorithms/x/PHP/file_transfer/tests/test_send_file.error
+++ b/tests/algorithms/x/PHP/file_transfer/tests/test_send_file.error
@@ -1,3 +1,0 @@
-run: exit status 255
-
-Fatal error: Cannot redeclare function socket_bind() in /workspace/mochi/tests/algorithms/x/PHP/file_transfer/tests/test_send_file.php on line 42

--- a/tests/algorithms/x/PHP/file_transfer/tests/test_send_file.out
+++ b/tests/algorithms/x/PHP/file_transfer/tests/test_send_file.out
@@ -1,1 +1,1 @@
-Fatal error: Cannot redeclare function socket_bind() in /workspace/mochi/tests/algorithms/x/PHP/file_transfer/tests/test_send_file.php on line 24
+pass

--- a/tests/algorithms/x/PHP/file_transfer/tests/test_send_file.php
+++ b/tests/algorithms/x/PHP/file_transfer/tests/test_send_file.php
@@ -1,79 +1,57 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
-$now_seed = 0;
-$now_seeded = false;
-$s = getenv('MOCHI_NOW_SEED');
-if ($s !== false && $s !== '') {
-    $now_seed = intval($s);
-    $now_seeded = true;
+function make_conn_mock() {
+  return ['close_called' => 0, 'recv_called' => 0, 'send_called' => 0];
 }
-function _now() {
-    global $now_seed, $now_seeded;
-    if ($now_seeded) {
-        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
-        return $now_seed;
-    }
-    return hrtime(true);
-}
-function _len($x) {
-    if ($x === null) { return 0; }
-    if (is_array($x)) { return count($x); }
-    if (is_string($x)) { return strlen($x); }
-    return strlen(strval($x));
-}
-$__start_mem = memory_get_usage();
-$__start = _now();
-  function make_conn_mock() {
-  return ['recv_called' => 0, 'send_called' => 0, 'close_called' => 0];
-};
-  function conn_recv(&$conn, $size) {
+function conn_recv(&$conn, $size) {
   $conn['recv_called'] = $conn['recv_called'] + 1;
   return 0;
-};
-  function conn_send(&$conn, $data) {
+}
+function conn_send(&$conn, $data) {
   $conn['send_called'] = $conn['send_called'] + 1;
-};
-  function conn_close(&$conn) {
+}
+function conn_close(&$conn) {
   $conn['close_called'] = $conn['close_called'] + 1;
-};
-  function make_socket_mock($conn) {
-  return ['bind_called' => 0, 'listen_called' => 0, 'accept_called' => 0, 'shutdown_called' => 0, 'close_called' => 0, 'conn' => $conn];
-};
-  function socket_bind(&$sock) {
+}
+function make_socket_mock(&$conn) {
+  return ['accept_called' => 0, 'bind_called' => 0, 'close_called' => 0, 'conn' => &$conn, 'listen_called' => 0, 'shutdown_called' => 0];
+}
+function mochi_socket_bind(&$sock) {
   $sock['bind_called'] = $sock['bind_called'] + 1;
-};
-  function socket_listen(&$sock) {
+}
+function mochi_socket_listen(&$sock) {
   $sock['listen_called'] = $sock['listen_called'] + 1;
-};
-  function socket_accept(&$sock) {
+}
+function &mochi_socket_accept(&$sock) {
   $sock['accept_called'] = $sock['accept_called'] + 1;
   return $sock['conn'];
-};
-  function socket_shutdown(&$sock) {
+}
+function mochi_socket_shutdown(&$sock) {
   $sock['shutdown_called'] = $sock['shutdown_called'] + 1;
-};
-  function socket_close(&$sock) {
+}
+function mochi_socket_close(&$sock) {
   $sock['close_called'] = $sock['close_called'] + 1;
-};
-  function make_file_mock($values) {
-  return ['read_called' => 0, 'data' => $values];
-};
-  function file_read(&$f, $size) {
-  if ($f['read_called'] < _len($f['data'])) {
+}
+function make_file_mock($values) {
+  return ['data' => &$values, 'read_called' => 0];
+}
+function file_read(&$f, $size) {
+  if ($f['read_called'] < count($f['data'])) {
   $value = $f['data'][$f['read_called']];
   $f['read_called'] = $f['read_called'] + 1;
   return $value;
 }
   $f['read_called'] = $f['read_called'] + 1;
   return 0;
-};
-  function file_open() {
+}
+function file_open() {
   return make_file_mock([1, 0]);
-};
-  function send_file(&$sock, &$f) {
-  socket_bind($sock);
-  socket_listen($sock);
-  $conn = socket_accept($sock);
+}
+function send_file(&$sock, &$f) {
+  mochi_socket_bind($sock);
+  mochi_socket_listen($sock);
+  $conn =& mochi_socket_accept($sock);
   $_ = conn_recv($conn, 1024);
   $data = file_read($f, 1024);
   while ($data != 0) {
@@ -81,10 +59,10 @@ $__start = _now();
   $data = file_read($f, 1024);
 };
   conn_close($conn);
-  socket_shutdown($sock);
-  socket_close($sock);
-};
-  function test_send_file_running_as_expected() {
+  mochi_socket_shutdown($sock);
+  mochi_socket_close($sock);
+}
+function test_send_file_running_as_expected() {
   $conn = make_conn_mock();
   $sock = make_socket_mock($conn);
   $f = file_open();
@@ -93,13 +71,5 @@ $__start = _now();
   return 'pass';
 }
   return 'fail';
-};
-  echo rtrim(test_send_file_running_as_expected()), PHP_EOL;
-$__end = _now();
-$__end_mem = memory_get_peak_usage();
-$__duration = max(1, intdiv($__end - $__start, 1000));
-$__mem_diff = max(0, $__end_mem - $__start_mem);
-$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
-$__j = json_encode($__bench, 128);
-$__j = str_replace("    ", "  ", $__j);
-echo $__j, PHP_EOL;
+}
+echo rtrim(test_send_file_running_as_expected()), PHP_EOL;

--- a/transpiler/x/php/ALGORITHMS.md
+++ b/transpiler/x/php/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated PHP code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/PHP`.
-Last updated: 2025-08-25 00:10 GMT+7
+Last updated: 2025-08-25 08:45 GMT+7
 
-## Algorithms Golden Test Checklist (1005/1077)
+## Algorithms Golden Test Checklist (1006/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 117µs | 38.8 KB |
@@ -323,7 +323,7 @@ Last updated: 2025-08-25 00:10 GMT+7
 | 314 | dynamic_programming/iterating_through_submasks | ✓ | 133µs | 40.3 KB |
 | 315 | dynamic_programming/k_means_clustering_tensorflow | ✓ | 128µs | 37.0 KB |
 | 316 | dynamic_programming/knapsack | ✓ | 122µs | 68.7 KB |
-| 317 | dynamic_programming/largest_divisible_subset | ✓ | 112µs | 38.1 KB |
+| 317 | dynamic_programming/largest_divisible_subset | ✓ | 163µs | 1.6 MB |
 | 318 | dynamic_programming/longest_common_subsequence | ✓ | 99µs | 40.0 KB |
 | 319 | dynamic_programming/longest_common_substring | ✓ | 107µs | 38.5 KB |
 | 320 | dynamic_programming/longest_increasing_subsequence | ✓ | 1µs | 39.4 KB |
@@ -377,7 +377,7 @@ Last updated: 2025-08-25 00:10 GMT+7
 | 368 | electronics/wheatstone_bridge | ✓ | 51µs | 38.3 KB |
 | 369 | file_transfer/receive_file | ✓ | 43µs | 35.8 KB |
 | 370 | file_transfer/send_file | ✓ | 42µs | 35.3 KB |
-| 371 | file_transfer/tests/test_send_file | error |  |  |
+| 371 | file_transfer/tests/test_send_file | ✓ | 138µs | 1.6 MB |
 | 372 | financial/equated_monthly_installments | ✓ | 81µs | 39.0 KB |
 | 373 | financial/exponential_moving_average | ✓ | 109µs | 39.6 KB |
 | 374 | financial/interest | ✓ | 138µs | 40.4 KB |

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-Last updated: 2025-08-24 23:17 +0700
+Last updated: 2025-08-25 08:35 +0700
 
 ## VM Golden Test Checklist (103/105)
 - [x] append_builtin

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,4 +1,4 @@
-## Progress (2025-08-24 23:17 +0700)
+## Progress (2025-08-25 08:35 +0700)
 - Generated PHP for 103/105 programs
 - Updated README checklist and outputs
 - Enhanced printing to match golden format


### PR DESCRIPTION
## Summary
- retain variable references in PHP struct literals to preserve aliasing
- detect referenced parameters whose field name matches to pass by reference
- regenerate PHP algorithm fixtures and update progress documentation

## Testing
- `MOCHI_ALG_INDEX=317 go test ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags=slow -count=1`
- `for i in $(seq 317 366); do MOCHI_ALG_INDEX=$i go test ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags=slow -count=1; done`
- `MOCHI_ALG_INDEX=371 go test ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags=slow -count=1`
- `MOCHI_ALG_INDEX=371 MOCHI_BENCHMARK=1 go test ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags=slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68abbdff19a483209cb72a9b201accaf