### PR TITLE
c transpiler: handle MapSI loop key types

### DIFF
--- a/transpiler/x/c/transpiler.go
+++ b/transpiler/x/c/transpiler.go
@@ -8454,6 +8454,8 @@ func compileStmt(env *types.Env, s *parser.Statement) (Stmt, error) {
 		}
 		srcExpr := convertExpr(s.For.Source)
 		if inferExprType(env, srcExpr) == "MapSI" {
+			env.SetVarDeep(s.For.Name, types.StringType{}, true)
+			varTypes[s.For.Name] = "const char*"
 			body, err := compileStmts(env, s.For.Body)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## Summary
- ensure for-in loops over MapSI set string key types

## Testing
- `MOCHI_ALG_INDEX=265 go test ./transpiler/x/c -run TestCTranspiler_Algorithms_Golden -tags=slow -count=1 -update-algorithms-c` *(fails: run: signal: segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2d0730e48320b22a870cf97d7bfa