### PR TITLE
kt: handle int overflow in arithmetic

### DIFF
--- a/tests/algorithms/x/Kotlin/maths/special_numbers/pronic_number.bench
+++ b/tests/algorithms/x/Kotlin/maths/special_numbers/pronic_number.bench
@@ -1,6 +1,2 @@
-Exception in thread "main" java.lang.RuntimeException: 2147441940 should be pronic
-	at Pronic_numberKt.panic(pronic_number.kt:1)
-	at Pronic_numberKt.test_is_pronic(pronic_number.kt:74)
-	at Pronic_numberKt.user_main(pronic_number.kt:79)
-	at Pronic_numberKt.main(pronic_number.kt:88)
-	at Pronic_numberKt.main(pronic_number.kt)
+true
+{"duration_us":11721, "memory_bytes":145504, "name":"main"}

--- a/tests/algorithms/x/Kotlin/maths/special_numbers/pronic_number.error
+++ b/tests/algorithms/x/Kotlin/maths/special_numbers/pronic_number.error
@@ -1,7 +1,0 @@
-run: exit status 1
-Exception in thread "main" java.lang.RuntimeException: 2147441940 should be pronic
-	at Pronic_numberKt.panic(pronic_number.kt:1)
-	at Pronic_numberKt.test_is_pronic(pronic_number.kt:48)
-	at Pronic_numberKt.user_main(pronic_number.kt:53)
-	at Pronic_numberKt.main(pronic_number.kt:58)
-	at Pronic_numberKt.main(pronic_number.kt)

--- a/tests/algorithms/x/Kotlin/maths/special_numbers/pronic_number.kt
+++ b/tests/algorithms/x/Kotlin/maths/special_numbers/pronic_number.kt
@@ -1,9 +1,37 @@
+val _dataDir = "/workspace/mochi/tests/github/TheAlgorithms/Mochi/maths/special_numbers"
+
 fun panic(msg: String): Nothing { throw RuntimeException(msg) }
+
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
 
 fun int_sqrt(n: Int): Int {
     var r: Int = (0).toInt()
-    while (((r + 1) * (r + 1)) <= n) {
-        r = r + 1
+    while ((((r).toLong() + (1).toLong()) * ((r).toLong() + (1).toLong())) <= n) {
+        r = ((r).toLong() + (1).toLong()).toInt()
     }
     return r
 }
@@ -16,7 +44,7 @@ fun is_pronic(n: Int): Boolean {
         return false
     }
     var root: Int = (int_sqrt(n)).toInt()
-    return n == (root * (root + 1))
+    return (n).toLong() == ((root).toLong() * ((root).toLong() + (1).toLong()))
 }
 
 fun test_is_pronic(): Unit {
@@ -55,5 +83,17 @@ fun user_main(): Unit {
 }
 
 fun main() {
-    user_main()
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
 }

--- a/tests/algorithms/x/Kotlin/maths/special_numbers/pronic_number.out
+++ b/tests/algorithms/x/Kotlin/maths/special_numbers/pronic_number.out
@@ -1,6 +1,1 @@
-Exception in thread "main" java.lang.RuntimeException: 2147441940 should be pronic
-	at Pronic_numberKt.panic(pronic_number.kt:1)
-	at Pronic_numberKt.test_is_pronic(pronic_number.kt:48)
-	at Pronic_numberKt.user_main(pronic_number.kt:53)
-	at Pronic_numberKt.main(pronic_number.kt:58)
-	at Pronic_numberKt.main(pronic_number.kt)
+true

--- a/tests/algorithms/x/Kotlin/matrix/matrix_equalization.error
+++ b/tests/algorithms/x/Kotlin/matrix/matrix_equalization.error
@@ -9,6 +9,6 @@ Exception in thread "main" java.lang.IndexOutOfBoundsException: Index -214748364
 	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302)
 	at java.base/java.util.Objects.checkIndex(Objects.java:385)
 	at java.base/java.util.ArrayList.get(ArrayList.java:427)
-	at Matrix_equalizationKt.array_equalization(matrix_equalization.kt:67)
-	at Matrix_equalizationKt.main(matrix_equalization.kt:91)
+	at Matrix_equalizationKt.array_equalization(matrix_equalization.kt:43)
+	at Matrix_equalizationKt.main(matrix_equalization.kt:63)
 	at Matrix_equalizationKt.main(matrix_equalization.kt)

--- a/tests/algorithms/x/Kotlin/matrix/matrix_equalization.kt
+++ b/tests/algorithms/x/Kotlin/matrix/matrix_equalization.kt
@@ -1,33 +1,9 @@
+val _dataDir = "/workspace/mochi/tests/github/TheAlgorithms/Mochi/matrix"
+
 fun _numToStr(v: Number): String {
     val d = v.toDouble()
     val i = d.toLong()
     return if (d == i.toDouble()) i.toString() else d.toString()
-}
-
-var _nowSeed = 0L
-var _nowSeeded = false
-fun _now(): Long {
-    if (!_nowSeeded) {
-        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
-            _nowSeed = it
-            _nowSeeded = true
-        }
-    }
-    return if (_nowSeeded) {
-        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
-        kotlin.math.abs(_nowSeed)
-    } else {
-        kotlin.math.abs(System.nanoTime())
-    }
-}
-
-fun toJson(v: Any?): String = when (v) {
-    null -> "null"
-    is String -> "\"" + v.replace("\"", "\\\"") + "\""
-    is Boolean, is Number -> v.toString()
-    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
-    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
-    else -> toJson(v.toString())
 }
 
 fun unique(nums: MutableList<Int>): MutableList<Int> {
@@ -42,12 +18,12 @@ fun unique(nums: MutableList<Int>): MutableList<Int> {
                 found = true
                 break
             }
-            j = j + 1
+            j = ((j).toLong() + (1).toLong()).toInt()
         }
         if (!found) {
             res = run { val _tmp = res.toMutableList(); _tmp.add(v); _tmp }
         }
-        i = i + 1
+        i = ((i).toLong() + (1).toLong()).toInt()
     }
     return res
 }
@@ -65,36 +41,24 @@ fun array_equalization(vector: MutableList<Int>, step_size: Int): Int {
         var updates: Int = (0).toInt()
         while (idx < vector.size) {
             if (vector[idx]!! != target) {
-                updates = updates + 1
-                idx = idx + step_size
+                updates = ((updates).toLong() + (1).toLong()).toInt()
+                idx = ((idx).toLong() + (step_size).toLong()).toInt()
             } else {
-                idx = idx + 1
+                idx = ((idx).toLong() + (1).toLong()).toInt()
             }
         }
         if (updates < min_updates) {
             min_updates = updates
         }
-        i = i + 1
+        i = ((i).toLong() + (1).toLong()).toInt()
     }
     return min_updates
 }
 
 fun main() {
-    run {
-        System.gc()
-        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
-        val _start = _now()
-        println(_numToStr(array_equalization(mutableListOf(1, 1, 6, 2, 4, 6, 5, 1, 7, 2, 2, 1, 7, 2, 2), 4)))
-        println(_numToStr(array_equalization(mutableListOf(22, 81, 88, 71, 22, 81, 632, 81, 81, 22, 92), 2)))
-        println(_numToStr(array_equalization(mutableListOf(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), 5)))
-        println(_numToStr(array_equalization(mutableListOf(22, 22, 22, 33, 33, 33), 2)))
-        println(_numToStr(array_equalization(mutableListOf(1, 2, 3), 2147483647)))
-        System.gc()
-        val _end = _now()
-        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
-        val _durationUs = (_end - _start) / 1000
-        val _memDiff = kotlin.math.abs(_endMem - _startMem)
-        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
-        println(toJson(_res))
-    }
+    println(_numToStr(array_equalization(mutableListOf(1, 1, 6, 2, 4, 6, 5, 1, 7, 2, 2, 1, 7, 2, 2), 4)))
+    println(_numToStr(array_equalization(mutableListOf(22, 81, 88, 71, 22, 81, 632, 81, 81, 22, 92), 2)))
+    println(_numToStr(array_equalization(mutableListOf(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), 5)))
+    println(_numToStr(array_equalization(mutableListOf(22, 22, 22, 33, 33, 33), 2)))
+    println(_numToStr(array_equalization(mutableListOf(1, 2, 3), 2147483647)))
 }

--- a/tests/algorithms/x/Kotlin/matrix/matrix_equalization.out
+++ b/tests/algorithms/x/Kotlin/matrix/matrix_equalization.out
@@ -8,6 +8,6 @@ Exception in thread "main" java.lang.IndexOutOfBoundsException: Index -214748364
 	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302)
 	at java.base/java.util.Objects.checkIndex(Objects.java:385)
 	at java.base/java.util.ArrayList.get(ArrayList.java:427)
-	at Matrix_equalizationKt.array_equalization(matrix_equalization.kt:41)
-	at Matrix_equalizationKt.main(matrix_equalization.kt:61)
+	at Matrix_equalizationKt.array_equalization(matrix_equalization.kt:43)
+	at Matrix_equalizationKt.main(matrix_equalization.kt:63)
 	at Matrix_equalizationKt.main(matrix_equalization.kt)

--- a/transpiler/x/kt/ALGORITHMS.md
+++ b/transpiler/x/kt/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated Kotlin code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Kotlin`.
-Last updated: 2025-08-25 08:43 GMT+7
+Last updated: 2025-08-25 22:45 GMT+7
 
-## Algorithms Golden Test Checklist (720/1077)
+## Algorithms Golden Test Checklist (721/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 30.54ms | 124.45KiB |
@@ -681,7 +681,7 @@ Last updated: 2025-08-25 08:43 GMT+7
 | 672 | maths/special_numbers/krishnamurthy_number | ✓ | 9.14ms | 134.19KiB |
 | 673 | maths/special_numbers/perfect_number | ✓ | 22.64ms | 123.50KiB |
 | 674 | maths/special_numbers/polygonal_numbers | ✓ | 10.94ms | 130.52KiB |
-| 675 | maths/special_numbers/pronic_number | error |  |  |
+| 675 | maths/special_numbers/pronic_number | ✓ | 11.72ms | 142.09KiB |
 | 676 | maths/special_numbers/proth_number | ✓ | 23.89ms | 122.56KiB |
 | 677 | maths/special_numbers/triangular_numbers | ✓ | 7.31ms | 134.19KiB |
 | 678 | maths/special_numbers/ugly_numbers | ✓ | 25.17ms | 124.03KiB |

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -1869,7 +1869,11 @@ func (s *AssignStmt) emit(w io.Writer, indentLevel int) {
 	if typ == "Int" {
 		io.WriteString(w, "(")
 		s.Value.emit(w)
-		io.WriteString(w, ").toInt()")
+		if valType == "Long" {
+			io.WriteString(w, ").coerceAtMost(Int.MAX_VALUE.toLong()).toInt()")
+		} else {
+			io.WriteString(w, ").toInt()")
+		}
 		return
 	}
 	if typ == "Long" && valType != "Long" {
@@ -3265,6 +3269,9 @@ func guessType(e Expr) string {
 			if lt == "Double" || rt == "Double" {
 				return "Double"
 			}
+			if lt == "Int" && rt == "Int" {
+				return "Long"
+			}
 			return "Int"
 		}
 		if v.Op == "*" {
@@ -3281,6 +3288,9 @@ func guessType(e Expr) string {
 			}
 			if lt == "Double" || rt == "Double" {
 				return "Double"
+			}
+			if lt == "Int" && rt == "Int" {
+				return "Long"
 			}
 			return "Int"
 		}


### PR DESCRIPTION
## Summary
- widen Kotlin type inference for integer arithmetic to use `Long` results
- clamp long results when assigning to `Int` variables
- regenerate algorithm artifacts for pronic number and matrix equalization

## Testing
- `MOCHI_ALG_INDEX=675 go test ./transpiler/x/kt -run TestKTTranspiler_Algorithms_Golden -tags slow -update-algorithms-kt`
- `MOCHI_BENCHMARK=1 MOCHI_ALG_INDEX=675 go test ./transpiler/x/kt -run TestKTTranspiler_Algorithms_Golden -tags slow -update-algorithms-kt`


------
https://chatgpt.com/codex/tasks/task_e_68ac8145f0608320acbf65c2e736ece2