### PR TITLE
Update PHP algorithm output for happy number

### DIFF
--- a/tests/algorithms/x/PHP/maths/special_numbers/happy_number.bench
+++ b/tests/algorithms/x/PHP/maths/special_numbers/happy_number.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 205,
-  "memory_bytes": 37744,
+  "duration_us": 139,
+  "memory_bytes": 1675816,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/maths/special_numbers/happy_number.php
+++ b/tests/algorithms/x/PHP/maths/special_numbers/happy_number.php
@@ -27,9 +27,21 @@ function _intdiv($a, $b) {
     if (function_exists('bcdiv')) {
         $sa = is_int($a) ? strval($a) : (is_string($a) ? $a : sprintf('%.0f', $a));
         $sb = is_int($b) ? strval($b) : (is_string($b) ? $b : sprintf('%.0f', $b));
-        return intval(bcdiv($sa, $sb, 0));
+        $q = bcdiv($sa, $sb, 0);
+        $rem = bcmod($sa, $sb);
+        $neg = ((strpos($sa, '-') === 0) xor (strpos($sb, '-') === 0));
+        if ($neg && bccomp($rem, '0') != 0) {
+            $q = bcsub($q, '1');
+        }
+        return intval($q);
     }
-    return intdiv(intval($a), intval($b));
+    $ai = intval($a);
+    $bi = intval($b);
+    $q = intdiv($ai, $bi);
+    if ((($ai ^ $bi) < 0) && ($ai % $bi != 0)) {
+        $q -= 1;
+    }
+    return $q;
 }
 function _panic($msg) {
     fwrite(STDERR, strval($msg));
@@ -83,7 +95,7 @@ $__start = _now();
 };
   main();
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/transpiler/x/php/ALGORITHMS.md
+++ b/transpiler/x/php/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated PHP code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/PHP`.
-Last updated: 2025-08-25 08:45 GMT+7
+Last updated: 2025-08-25 22:34 GMT+7
 
 ## Algorithms Golden Test Checklist (1006/1077)
 | Index | Name | Status | Duration | Memory |
@@ -675,7 +675,7 @@ Last updated: 2025-08-25 08:45 GMT+7
 | 666 | maths/special_numbers/carmichael_number | ✓ | 6.367ms | 36.5 KB |
 | 667 | maths/special_numbers/catalan_number | ✓ | 69µs | 37.0 KB |
 | 668 | maths/special_numbers/hamming_numbers | ✓ | 174µs | 36.0 KB |
-| 669 | maths/special_numbers/happy_number | ✓ | 205µs | 36.9 KB |
+| 669 | maths/special_numbers/happy_number | ✓ | 139µs | 1.6 MB |
 | 670 | maths/special_numbers/harshad_numbers | ✓ | 420µs | 39.8 KB |
 | 671 | maths/special_numbers/hexagonal_number | ✓ | 47µs | 39.2 KB |
 | 672 | maths/special_numbers/krishnamurthy_number | ✓ | 124µs | 39.5 KB |


### PR DESCRIPTION
## Summary
- regenerate PHP output for maths/special_numbers/happy_number with improved integer division and benchmarking data
- refresh PHP algorithms progress table with latest metrics

## Testing
- `MOCHI_ALG_INDEX=669 go test ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags=slow`
- `for i in $(seq 669 718); do MOCHI_ALG_INDEX=$i go test ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags=slow; done`

------
https://chatgpt.com/codex/tasks/task_e_68ac814e86fc83208eb6348fdf96044e