### PR TITLE
php: support generic slice helper

### DIFF
--- a/tests/algorithms/x/PHP/conversions/binary_to_hexadecimal.bench
+++ b/tests/algorithms/x/PHP/conversions/binary_to_hexadecimal.bench
@@ -1,6 +1,5 @@
-Fatal error: Uncaught TypeError: array_slice(): Argument #1 ($array) must be of type array, string given in /workspace/mochi/tests/algorithms/x/PHP/conversions/binary_to_hexadecimal.php:92
-Stack trace:
-#0 /workspace/mochi/tests/algorithms/x/PHP/conversions/binary_to_hexadecimal.php(92): array_slice('0000101011111', 0, 4)
-#1 /workspace/mochi/tests/algorithms/x/PHP/conversions/binary_to_hexadecimal.php(102): bin_to_hexadecimal('101011111')
-#2 {main}
-  thrown in /workspace/mochi/tests/algorithms/x/PHP/conversions/binary_to_hexadecimal.php on line 92
+{
+  "duration_us": 46,
+  "memory_bytes": 1672600,
+  "name": "main"
+}

--- a/tests/algorithms/x/PHP/conversions/binary_to_hexadecimal.error
+++ b/tests/algorithms/x/PHP/conversions/binary_to_hexadecimal.error
@@ -1,8 +1,0 @@
-run: exit status 255
-
-Fatal error: Uncaught TypeError: array_slice(): Argument #1 ($array) must be of type array, string given in /workspace/mochi/tests/algorithms/x/PHP/conversions/binary_to_hexadecimal.php:92
-Stack trace:
-#0 /workspace/mochi/tests/algorithms/x/PHP/conversions/binary_to_hexadecimal.php(92): array_slice('0000101011111', 0, 4)
-#1 /workspace/mochi/tests/algorithms/x/PHP/conversions/binary_to_hexadecimal.php(102): bin_to_hexadecimal('101011111')
-#2 {main}
-  thrown in /workspace/mochi/tests/algorithms/x/PHP/conversions/binary_to_hexadecimal.php on line 92

--- a/tests/algorithms/x/PHP/conversions/binary_to_hexadecimal.php
+++ b/tests/algorithms/x/PHP/conversions/binary_to_hexadecimal.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('memory_limit', '-1');
 $now_seed = 0;
 $now_seeded = false;
@@ -14,6 +15,18 @@ function _now() {
         return $now_seed;
     }
     return hrtime(true);
+}
+function _slice($x, $start, $length = null) {
+    if (is_string($x)) {
+        if ($length === null) return substr($x, $start);
+        return substr($x, $start, $length);
+    }
+    if ($length === null) return array_slice($x, $start);
+    return array_slice($x, $start, $length);
+}
+function _panic($msg) {
+    fwrite(STDERR, strval($msg));
+    exit(1);
 }
 $__start_mem = memory_get_usage();
 $__start = _now();
@@ -43,7 +56,7 @@ $__start = _now();
 };
   return $res;
 };
-  function slice($s, $start, $end) {
+  function mochi_slice($s, $start, $end) {
   $res = '';
   $i = $start;
   while ($i < $end) {
@@ -67,18 +80,18 @@ $__start = _now();
   function bin_to_hexadecimal($binary_str) {
   $s = strip_spaces($binary_str);
   if (strlen($s) == 0) {
-  $panic('Empty string was passed to the function');
+  _panic('Empty string was passed to the function');
 }
   $is_negative = false;
-  if (substr($s, 0, 0 + 1 - 0) == '-') {
+  if (substr($s, 0, 0 + 1) == '-') {
   $is_negative = true;
-  $s = array_slice($s, 1, strlen($s) - 1);
+  $s = _slice($s, 1, strlen($s) - 1);
 }
   $i = 0;
   while ($i < strlen($s)) {
   $c = substr($s, $i, $i + 1 - $i);
   if ($c != '0' && $c != '1') {
-  $panic('Non-binary value was passed to the function');
+  _panic('Non-binary value was passed to the function');
 }
   $i = $i + 1;
 };
@@ -89,7 +102,7 @@ $__start = _now();
   $res = '0x';
   $j = 0;
   while ($j < strlen($s)) {
-  $chunk = array_slice($s, $j, $j + 4 - $j);
+  $chunk = _slice($s, $j, $j + 4 - $j);
   $val = bits_to_int($chunk);
   $res = $res . substr($digits, $val, $val + 1 - $val);
   $j = $j + 4;
@@ -103,7 +116,7 @@ $__start = _now();
   echo rtrim(bin_to_hexadecimal(' 1010   ')), PHP_EOL;
   echo rtrim(bin_to_hexadecimal('-11101')), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/tests/algorithms/x/PHP/networking_flow/ford_fulkerson.bench
+++ b/tests/algorithms/x/PHP/networking_flow/ford_fulkerson.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 115,
-  "memory_bytes": 40952,
+  "duration_us": 99,
+  "memory_bytes": 1673512,
   "name": "main"
 }

--- a/tests/algorithms/x/PHP/networking_flow/ford_fulkerson.php
+++ b/tests/algorithms/x/PHP/networking_flow/ford_fulkerson.php
@@ -107,7 +107,7 @@ $__start = _now();
   $graph = [[0, 16, 13, 0, 0, 0], [0, 0, 10, 12, 0, 0], [0, 4, 0, 0, 14, 0], [0, 0, 9, 0, 0, 20], [0, 0, 0, 7, 0, 4], [0, 0, 0, 0, 0, 0]];
   echo rtrim(_str(ford_fulkerson($graph, 0, 5))), PHP_EOL;
 $__end = _now();
-$__end_mem = memory_get_peak_usage();
+$__end_mem = memory_get_peak_usage(true);
 $__duration = max(1, intdiv($__end - $__start, 1000));
 $__mem_diff = max(0, $__end_mem - $__start_mem);
 $__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];

--- a/transpiler/x/php/ALGORITHMS.md
+++ b/transpiler/x/php/ALGORITHMS.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated PHP code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/PHP`.
-Last updated: 2025-08-25 22:41 GMT+7
+Last updated: 2025-08-26 00:06 GMT+7
 
-## Algorithms Golden Test Checklist (1006/1077)
+## Algorithms Golden Test Checklist (1007/1077)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | backtracking/all_combinations | ✓ | 117µs | 38.8 KB |
@@ -129,7 +129,7 @@ Last updated: 2025-08-25 22:41 GMT+7
 | 120 | computer_vision/pooling_functions | ✓ | 152µs | 37.4 KB |
 | 121 | conversions/astronomical_length_scale_conversion | ✓ | 106µs | 36.5 KB |
 | 122 | conversions/binary_to_decimal | ✓ | 91µs | 39.6 KB |
-| 123 | conversions/binary_to_hexadecimal | error |  |  |
+| 123 | conversions/binary_to_hexadecimal | ✓ | 46µs | 1.6 MB |
 | 124 | conversions/binary_to_octal | ✓ | 99µs | 40.1 KB |
 | 125 | conversions/convert_number_to_words | ✓ | 331µs | 71.9 KB |
 | 126 | conversions/decimal_to_any | ✓ | 158µs | 34.8 KB |
@@ -725,7 +725,7 @@ Last updated: 2025-08-25 22:41 GMT+7
 | 716 | matrix/spiral_print | ✓ | 195µs | 37.2 KB |
 | 717 | matrix/tests/test_matrix_operation | ✓ | 170µs | 74.2 KB |
 | 718 | matrix/validate_sudoku_board | ✓ | 181µs | 39.3 KB |
-| 719 | networking_flow/ford_fulkerson | ✓ | 115µs | 40.0 KB |
+| 719 | networking_flow/ford_fulkerson | ✓ | 99µs | 1.6 MB |
 | 720 | networking_flow/minimum_cut | ✓ | 332µs | 40.1 KB |
 | 721 | neural_network/activation_functions/binary_step | ✓ | 86µs | 35.8 KB |
 | 722 | neural_network/activation_functions/exponential_linear_unit | ✓ | 203µs | 38.8 KB |

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-Last updated: 2025-08-25 08:35 +0700
+Last updated: 2025-08-25 23:46 +0700
 
 ## VM Golden Test Checklist (103/105)
 - [x] append_builtin

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,4 +1,4 @@
-## Progress (2025-08-25 08:35 +0700)
+## Progress (2025-08-25 23:46 +0700)
 - Generated PHP for 103/105 programs
 - Updated README checklist and outputs
 - Enhanced printing to match golden format


### PR DESCRIPTION
## Summary
- add runtime `_slice` helper that handles strings and arrays
- wire PHP transpiler to emit `_slice` for built-in `slice`
- refresh golden files for `binary_to_hexadecimal` and benchmark `ford_fulkerson`

## Testing
- `MOCHI_BENCHMARK=1 MOCHI_ALG_INDEX=123 go test -count=1 ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags=slow -update-algorithms-php`
- `MOCHI_BENCHMARK=1 MOCHI_ALG_INDEX=719 go test -count=1 ./transpiler/x/php -run TestPHPTranspiler_Algorithms_Golden -tags=slow -update-algorithms-php`


------
https://chatgpt.com/codex/tasks/task_e_68ac935c0e1c8320b9db0711cbf314cf