### PR TITLE
Skip slow SPOJ tests by default

### DIFF
--- a/tests/spoj/doc.go
+++ b/tests/spoj/doc.go
@@ -1,0 +1,4 @@
+package spoj
+
+// This package contains slow SPOJ integration tests.
+// Tests are gated behind the `slow` build tag and skipped by default.

--- a/tests/spoj/spoj_slow_test.go
+++ b/tests/spoj/spoj_slow_test.go
@@ -1,3 +1,6 @@
+//go:build slow
+// +build slow
+
 package spoj
 
 import (

--- a/tests/spoj/spoj_vm_slow_test.go
+++ b/tests/spoj/spoj_vm_slow_test.go
@@ -1,3 +1,6 @@
+//go:build slow
+// +build slow
+
 package spoj_test
 
 import (


### PR DESCRIPTION
## Summary
- mark SPOJ tests with `slow` build tag and rename files
- add placeholder doc to keep SPOJ test package

## Testing
- `go test ./...`
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_68ad1a8ebf2083208229df24b35a5cb5