### PR TITLE
dart: refine str helper and refresh squareplus benchmark

### DIFF
--- a/tests/algorithms/x/Dart/neural_network/activation_functions/squareplus.bench
+++ b/tests/algorithms/x/Dart/neural_network/activation_functions/squareplus.bench
@@ -1,1 +1,1 @@
-{"duration_us":22426,"memory_bytes":10752000,"name":"_start"}
+{"duration_us":15974,"memory_bytes":3276800,"name":"_start"}

--- a/tests/algorithms/x/Dart/neural_network/activation_functions/squareplus.dart
+++ b/tests/algorithms/x/Dart/neural_network/activation_functions/squareplus.dart
@@ -22,23 +22,6 @@ int _now() {
   return DateTime.now().microsecondsSinceEpoch;
 }
 
-dynamic _substr(dynamic s, num start, num end) {
-  int n = s.length;
-  int s0 = start.toInt();
-  int e0 = end.toInt();
-  if (s0 < 0) s0 += n;
-  if (e0 < 0) e0 += n;
-  if (s0 < 0) s0 = 0;
-  if (s0 > n) s0 = n;
-  if (e0 < 0) e0 = 0;
-  if (e0 > n) e0 = n;
-  if (s0 > e0) s0 = e0;
-  if (s is String) {
-    return s.substring(s0, e0);
-  }
-  return s.sublist(s0, e0);
-}
-
 String _str(dynamic v) { if (v is double && v == v.roundToDouble()) { var i = v.toInt(); if (i == 0) return '0'; return i.toString(); } return v.toString(); }
 
 double sqrtApprox(double x) {

--- a/transpiler/x/dart/ALGORITHMS.md
+++ b/transpiler/x/dart/ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Dart code from programs in `tests/github/TheAlgorithms/Mochi` lives in `tests/algorithms/x/Dart`.
-Last updated: 2025-08-24 23:27 GMT+7
+Last updated: 2025-08-26 08:46 GMT+7
 
 ## Algorithms Golden Test Checklist (1005/1077)
 | Index | Name | Status | Duration | Memory |
@@ -736,7 +736,7 @@ Last updated: 2025-08-24 23:27 GMT+7
 | 727 | neural_network/activation_functions/scaled_exponential_linear_unit | ✓ | 16.717ms | 10.5 MB |
 | 728 | neural_network/activation_functions/soboleva_modified_hyperbolic_tangent | ✓ | 12.776ms | 1.7 MB |
 | 729 | neural_network/activation_functions/softplus | ✓ | 14.247ms | 2.4 MB |
-| 730 | neural_network/activation_functions/squareplus | ✓ | 22.426ms | 10.3 MB |
+| 730 | neural_network/activation_functions/squareplus | ✓ | 15.974ms | 3.1 MB |
 | 731 | neural_network/activation_functions/swish | ✓ | 10.788ms | 4.1 MB |
 | 732 | neural_network/back_propagation_neural_network | ✓ | 262.235ms | 51.2 MB |
 | 733 | neural_network/convolution_neural_network | ✓ | 21.785ms | 7.6 MB |

--- a/transpiler/x/dart/README.md
+++ b/transpiler/x/dart/README.md
@@ -109,4 +109,4 @@ Generated Dart code for programs in `tests/vm/valid`. Each program has a `.dart`
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-_Last updated: 2025-08-24 23:17 +0700_
+_Last updated: 2025-08-26 08:36 +0700_

--- a/transpiler/x/dart/ROSETTA.md
+++ b/transpiler/x/dart/ROSETTA.md
@@ -499,4 +499,4 @@ Compiled and ran: 477/491
 | 490 | window-management | ✓ | 11.069ms | 2.1 MB |
 | 491 | zumkeller-numbers | ✓ | 1.389357s | 3.9 MB |
 
-_Last updated: 2025-08-24 23:17 +0700_
+_Last updated: 2025-08-26 08:36 +0700_

--- a/transpiler/x/dart/TASKS.md
+++ b/transpiler/x/dart/TASKS.md
@@ -1,10 +1,10 @@
-## Recent Enhancements (2025-08-24 23:17 +0700)
+## Recent Enhancements (2025-08-26 08:36 +0700)
 - Added query cross join support using collection `for` loops.
 - Removed `where`/`map` helpers for cleaner output.
 - Simplified join result collection for readability.
 - Enhanced type inference for query results.
 
-## Progress (2025-08-24 23:17 +0700)
+## Progress (2025-08-26 08:36 +0700)
 - VM valid 102/105
 
 # Dart Transpiler Tasks

--- a/transpiler/x/dart/transpiler.go
+++ b/transpiler/x/dart/transpiler.go
@@ -4754,7 +4754,7 @@ func Emit(w io.Writer, p *Program) error {
 		}
 	}
 	if useStr {
-		if _, err := io.WriteString(w, "String _str(dynamic v) => v.toString();\n\n"); err != nil {
+		if _, err := io.WriteString(w, "String _str(dynamic v) { if (v is double && v == v.roundToDouble()) { var i = v.toInt(); if (i == 0) return '0'; return i.toString(); } return v.toString(); }\n\n"); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary
- Improve Dart transpiler's `str` helper to format integer-valued floats cleanly.
- Regenerate Squareplus activation function output and benchmark.
- Update Dart algorithms table and timestamps after rerun.

## Testing
- `MOCHI_ALG_INDEX=730 MOCHI_BENCHMARK=1 go test ./transpiler/x/dart -run TestDartTranspiler_Algorithms_Golden -tags=slow -update-algorithms-dart -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68ad10a96b08832092e94d14ae359b35