### PR TITLE
docs: add v0.10.74 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # 📦 CHANGELOG.md
 
+## [0.10.74] – 2025-08-26T11:00:15+07:00
+
+### Added
+
+- SPOJ `TEST` solutions in C, C++, C#, COBOL, Dart, Elixir, Erlang, Fortran, Go, Haskell, Java, Kotlin, Lua, OCaml, Pascal, PHP, Prolog, Python, Racket, Ruby, Rust, Scala, Scheme, Smalltalk, Swift, TypeScript, Zig and more.
+- Additional SPOJ solutions including `BULK`, `CMEXPR`, `CMPLS`, `PALIN`, `ONP`, `SBSTR1`, `ARITH`, `PRIME1` and `Direct Visibility`.
+- SPOJ scraper and downloader utility.
+
+### Changed
+
+- Transpilers handle nested list returns, string/float map literals, dynamic indexes and CSV/list string marshaling.
+- Enhanced float precision, big-integer casts, char literal handling and algorithm fixture regeneration across languages.
+
+### Fixed
+
+- Corrected big-integer casts in C# and Java.
+- Addressed nested list and map handling in the C transpiler and string representations in Erlang and PHP.
+
 ## [0.10.73] – 2025-08-25T08:22:15+07:00
 
 ### Added

--- a/releases/v0.10.74.md
+++ b/releases/v0.10.74.md
@@ -1,0 +1,19 @@
+# Aug 2025 (v0.10.74)
+
+Released on Tue Aug 26 11:00:15 2025 +0700.
+
+Mochi v0.10.74 broadens algorithm coverage with SPOJ problem solutions and upgrades multi-language transpilers.
+
+## SPOJ Solutions
+
+- Adds `TEST` solutions in C, C++, C#, COBOL, Dart, Elixir, Erlang, Fortran, Go, Haskell, Java, Kotlin, Lua, OCaml, Pascal, PHP, Prolog, Python, Racket, Ruby, Rust, Scala, Scheme, Smalltalk, Swift, TypeScript, Zig and more.
+- Introduces solutions for `BULK`, `CMEXPR`, `CMPLS`, `PALIN`, `ONP`, `SBSTR1`, `ARITH` and `PRIME1`.
+- Provides a scraper and downloader to fetch SPOJ problem data.
+
+## Transpilers
+
+- C transpiler supports nested list returns, struct typedef maps and string→float map literals.
+- C++, Zig and others enhance float precision and constant list handling.
+- Java, C#, F# and Go refine big-integer casts, dynamic indexes and CSV/list string marshaling.
+- Erlang, PHP, Pascal and Scheme improve string representations, record dependencies and equality helpers.
+- Regenerates algorithm fixtures and benchmarks across languages.


### PR DESCRIPTION
## Summary
- document v0.10.74 release with new SPOJ solutions and transpiler improvements
- update changelog with timestamped entry

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68ad3191f6d083209d4280f4b1b40759