### PR TITLE
go transpiler: add safe int casts

### DIFF
--- a/transpiler/x/go/SPOJ.md
+++ b/transpiler/x/go/SPOJ.md
@@ -1,18 +1,18 @@
 # Go SPOJ Transpiler Output
 
-Completed programs: 1/9
-Last updated: 2025-08-26 11:25 +0700
+Completed programs: 7/9
+Last updated: 2025-08-26 11:55 +0700
 
 Checklist:
 
 | Index | Status | Duration | Memory |
 |------:|--------|---------:|-------:|
-| 1 | ✓ | 711.0µs | 5.02KB |
-| 2 |   |  |  |
-| 3 |   |  |  |
-| 4 |   |  |  |
-| 5 |   |  |  |
-| 6 |   |  |  |
+| 1 | ✓ | 485.0µs | 5.02KB |
+| 2 | ✓ | 2.0ms | 280.93KB |
+| 3 | ✓ | 716.0µs | 1.24KB |
+| 4 | ✓ | 339.0µs | 4.95KB |
+| 5 | ✓ | 218.0µs | 4.00KB |
+| 6 | ✓ | 364.0µs | 4.49KB |
 | 7 |   |  |  |
 | 8 |   |  |  |
-| 9 |   |  |  |
+| 9 | ✓ | 226.0µs | 4.00KB |


### PR DESCRIPTION
## Summary
- fix casts from `any` to `int` by using type assertions or `_toInt`
- provide `_toInt` helper for dynamic numeric conversion
- update SPOJ progress for Go transpiler

## Testing
- `for i in $(seq 1 10); do MOCHI_SPOJ_INDEX=$i go test ./transpiler/x/go -run Spoj -tags slow -count=1 || true; done`


------
https://chatgpt.com/codex/tasks/task_e_68ad3ec893a4832083044a09a0db1801