### PR TITLE
feat(scala): support ranged SPOJ transpiler tests

### DIFF
--- a/transpiler/x/scala/SPOJ.md
+++ b/transpiler/x/scala/SPOJ.md
@@ -1,10 +1,18 @@
 # Scala SPOJ Transpiler Output
 
-Completed programs: 1/1
-Last updated: 2025-08-26 11:25 +0700
+Completed programs: 6/9
+Last updated: 2025-08-26 11:55 +0700
 
 Checklist:
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | Life, the Universe, and Everything | ✓ | 183.317ms | 8.7 MB |
+| 2 | Prime Generator | ✓ | 183.317ms | 9.0 MB |
+| 3 | Substring Check (Bug Funny) | ✓ | 183.317ms | 8.7 MB |
+| 4 | Transform the Expression | ✓ | 183.317ms | 8.7 MB |
+| 5 | SPOJ Problem 5: The Next Palindrome | ✓ | 183.317ms | 8.7 MB |
+| 6 | Simple Arithmetics | error |  |  |
+| 7 | The Bulk | error |  |  |
+| 8 | Complete the Sequence! | error |  |  |
+| 9 | SPOJ Problem 9: Direct Visibility | ✓ | 183.317ms | 8.7 MB |

--- a/transpiler/x/scala/spoj_test.go
+++ b/transpiler/x/scala/spoj_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -18,79 +19,108 @@ import (
 	"mochi/types"
 )
 
+func indexRange() (int, int) {
+	from := 1
+	to := 1
+	if v := os.Getenv("FROM_INDEX"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			from = n
+			to = n
+		}
+	}
+	if v := os.Getenv("TO_INDEX"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= from {
+			to = n
+		}
+	}
+	return from, to
+}
+
 func TestScalaTranspiler_SPOJ_Golden(t *testing.T) {
 	ensureScala(t)
 	root := repoRoot()
-	src := filepath.Join(root, "tests", "spoj", "x", "mochi", "1.mochi")
 	outDir := filepath.Join(root, "tests", "spoj", "x", "scala")
 	os.MkdirAll(outDir, 0o755)
 	t.Cleanup(updateSPOJChecklist)
 
+	from, to := indexRange()
+
 	bench := true
 	scalat.SetBenchMain(bench)
 
-	codePath := filepath.Join(outDir, "1.scala")
-	outPath := filepath.Join(outDir, "1.out")
-	errPath := filepath.Join(outDir, "1.error")
-	benchPath := filepath.Join(outDir, "1.bench")
-	inPath := filepath.Join(outDir, "1.in")
-
-	prog, err := parser.Parse(src)
-	if err != nil {
-		_ = os.WriteFile(errPath, []byte(err.Error()), 0o644)
-		t.Fatalf("parse: %v", err)
-	}
-	env := types.NewEnv(nil)
-	if errs := types.Check(prog, env); len(errs) > 0 {
-		_ = os.WriteFile(errPath, []byte(errs[0].Error()), 0o644)
-		t.Fatalf("type: %v", errs[0])
-	}
-	ast, err := scalat.Transpile(prog, env, bench)
-	if err != nil {
-		_ = os.WriteFile(errPath, []byte(err.Error()), 0o644)
-		t.Fatalf("transpile: %v", err)
-	}
-	code := scalat.Emit(ast)
-	if err := os.WriteFile(codePath, code, 0o644); err != nil {
-		t.Fatalf("write code: %v", err)
-	}
-	tmp := t.TempDir()
-	if out, err := exec.Command("scalac", "-d", tmp, codePath).CombinedOutput(); err != nil {
-		_ = os.WriteFile(errPath, append([]byte(err.Error()+"\n"), out...), 0o644)
-		t.Fatalf("compile: %v", err)
-	}
-	cmd := exec.Command("scala", "-cp", tmp, "Main")
-	cmd.Env = append(os.Environ(), "MOCHI_BENCHMARK=1")
-	if data, err := os.ReadFile(inPath); err == nil {
-		cmd.Stdin = bytes.NewReader(data)
-	}
-	want, _ := os.ReadFile(outPath)
-	want = bytes.TrimSpace(want)
-
-	outBytes, err := cmd.CombinedOutput()
-	got := bytes.TrimSpace(outBytes)
-	if err != nil {
-		_ = os.WriteFile(errPath, append([]byte(err.Error()+"\n"), got...), 0o644)
-		t.Fatalf("run: %v", err)
-	}
-	_ = os.Remove(errPath)
-
-	benchData := got
-	outPart := got
-	if idx := bytes.LastIndexByte(got, '{'); idx >= 0 {
-		outPart = bytes.TrimSpace(got[:idx])
-		benchData = got[idx:]
-	} else {
-		benchData = nil
-	}
-	_ = os.WriteFile(outPath, outPart, 0o644)
-	if benchData != nil {
-		_ = os.WriteFile(benchPath, benchData, 0o644)
-	}
-	if want != nil && len(want) > 0 {
-		if !bytes.Equal(outPart, want) {
-			t.Errorf("output mismatch\nGot: %s\nWant: %s", outPart, want)
+	for idx := from; idx <= to; idx++ {
+		src := filepath.Join(root, "tests", "spoj", "x", "mochi", fmt.Sprintf("%d.mochi", idx))
+		if _, err := os.Stat(src); err != nil {
+			t.Logf("skip %d: %v", idx, err)
+			continue
 		}
+		idx := idx
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			codePath := filepath.Join(outDir, fmt.Sprintf("%d.scala", idx))
+			outPath := filepath.Join(outDir, fmt.Sprintf("%d.out", idx))
+			errPath := filepath.Join(outDir, fmt.Sprintf("%d.error", idx))
+			benchPath := filepath.Join(outDir, fmt.Sprintf("%d.bench", idx))
+
+			prog, err := parser.Parse(src)
+			if err != nil {
+				_ = os.WriteFile(errPath, []byte(err.Error()), 0o644)
+				t.Fatalf("parse: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				_ = os.WriteFile(errPath, []byte(errs[0].Error()), 0o644)
+				t.Fatalf("type: %v", errs[0])
+			}
+			ast, err := scalat.Transpile(prog, env, bench)
+			if err != nil {
+				_ = os.WriteFile(errPath, []byte(err.Error()), 0o644)
+				t.Fatalf("transpile: %v", err)
+			}
+			code := scalat.Emit(ast)
+			if err := os.WriteFile(codePath, code, 0o644); err != nil {
+				t.Fatalf("write code: %v", err)
+			}
+			tmp := t.TempDir()
+			if out, err := exec.Command("scalac", "-d", tmp, codePath).CombinedOutput(); err != nil {
+				_ = os.WriteFile(errPath, append([]byte(err.Error()+"\n"), out...), 0o644)
+				t.Fatalf("compile: %v", err)
+			}
+			cmd := exec.Command("scala", "-cp", tmp, "Main")
+			cmd.Env = append(os.Environ(), "MOCHI_BENCHMARK=1")
+			inPath := filepath.Join(root, "tests", "spoj", "x", "mochi", fmt.Sprintf("%d.in", idx))
+			if data, err := os.ReadFile(inPath); err == nil {
+				cmd.Stdin = bytes.NewReader(data)
+			}
+			wantPath := filepath.Join(root, "tests", "spoj", "x", "mochi", fmt.Sprintf("%d.out", idx))
+			want, _ := os.ReadFile(wantPath)
+			want = bytes.TrimSpace(want)
+
+			outBytes, err := cmd.CombinedOutput()
+			got := bytes.TrimSpace(outBytes)
+			if err != nil {
+				_ = os.WriteFile(errPath, append([]byte(err.Error()+"\n"), got...), 0o644)
+				t.Fatalf("run: %v", err)
+			}
+			_ = os.Remove(errPath)
+
+			benchData := got
+			outPart := got
+			if j := bytes.LastIndexByte(got, '{'); j >= 0 {
+				outPart = bytes.TrimSpace(got[:j])
+				benchData = got[j:]
+			} else {
+				benchData = nil
+			}
+			_ = os.WriteFile(outPath, outPart, 0o644)
+			if benchData != nil {
+				_ = os.WriteFile(benchPath, benchData, 0o644)
+			}
+			if want != nil && len(want) > 0 {
+				if !bytes.Equal(outPart, want) {
+					t.Errorf("output mismatch\nGot: %s\nWant: %s", outPart, want)
+				}
+			}
+		})
 	}
 }
 
@@ -107,28 +137,50 @@ func updateSPOJChecklist() {
 		Mem    string
 	}
 
-	idx := 1
-	name := "Life, the Universe, and Everything"
-	status := " "
-	dur := ""
-	mem := ""
-	if _, err := os.Stat(filepath.Join(outDir, "1.error")); err == nil {
-		status = "error"
-	} else if _, err := os.Stat(filepath.Join(outDir, "1.scala")); err == nil {
-		status = "✓"
-		if data, err := os.ReadFile(filepath.Join(outDir, "1.bench")); err == nil {
-			var r struct {
-				DurationUS  int64 `json:"duration_us"`
-				MemoryBytes int64 `json:"memory_bytes"`
-			}
-			data = bytes.TrimSpace(data)
-			if json.Unmarshal(data, &r) == nil && r.DurationUS > 0 {
-				dur = humanDuration(r.DurationUS)
-				mem = humanSize(r.MemoryBytes)
+	from, to := indexRange()
+	var rows []row
+	for idx := from; idx <= to; idx++ {
+		mdPath := filepath.Join(root, "tests", "spoj", "x", "mochi", fmt.Sprintf("%d.md", idx))
+		if _, err := os.Stat(mdPath); err != nil {
+			continue
+		}
+		name := fmt.Sprintf("Problem %d", idx)
+		if data, err := os.ReadFile(mdPath); err == nil {
+			line := strings.SplitN(string(data), "\n", 2)[0]
+			if strings.HasPrefix(line, "# [") {
+				if i := strings.Index(line, "]"); i > 3 {
+					inner := line[3:i]
+					if j := strings.Index(inner, " - "); j >= 0 {
+						name = inner[j+3:]
+					} else {
+						name = inner
+					}
+				}
+			} else if strings.HasPrefix(line, "# ") {
+				name = strings.TrimSpace(line[2:])
 			}
 		}
+		status := " "
+		dur := ""
+		mem := ""
+		if _, err := os.Stat(filepath.Join(outDir, fmt.Sprintf("%d.error", idx))); err == nil {
+			status = "error"
+		} else if _, err := os.Stat(filepath.Join(outDir, fmt.Sprintf("%d.scala", idx))); err == nil {
+			status = "✓"
+			if data, err := os.ReadFile(filepath.Join(outDir, fmt.Sprintf("%d.bench", idx))); err == nil {
+				var r struct {
+					DurationUS  int64 `json:"duration_us"`
+					MemoryBytes int64 `json:"memory_bytes"`
+				}
+				data = bytes.TrimSpace(data)
+				if json.Unmarshal(data, &r) == nil && r.DurationUS > 0 {
+					dur = humanDuration(r.DurationUS)
+					mem = humanSize(r.MemoryBytes)
+				}
+			}
+		}
+		rows = append(rows, row{Index: idx, Name: name, Status: status, Dur: dur, Mem: mem})
 	}
-	rows := []row{{Index: idx, Name: name, Status: status, Dur: dur, Mem: mem}}
 
 	var lines []string
 	lines = append(lines, "| Index | Name | Status | Duration | Memory |")
@@ -147,13 +199,14 @@ func updateSPOJChecklist() {
 		}
 	}
 	var buf bytes.Buffer
-	buf.WriteString("# Scala SPOJ Transpiler Output\n\n")
-	fmt.Fprintf(&buf, "Completed programs: %d/%d\n", func() int {
-		if status == "✓" {
-			return 1
+	compiled := 0
+	for _, r := range rows {
+		if r.Status == "✓" {
+			compiled++
 		}
-		return 0
-	}(), 1)
+	}
+	buf.WriteString("# Scala SPOJ Transpiler Output\n\n")
+	fmt.Fprintf(&buf, "Completed programs: %d/%d\n", compiled, len(rows))
 	fmt.Fprintf(&buf, "Last updated: %s\n\n", ts)
 	buf.WriteString("Checklist:\n\n")
 	buf.WriteString(strings.Join(lines, "\n"))

--- a/transpiler/x/scala/transpiler.go
+++ b/transpiler/x/scala/transpiler.go
@@ -2349,6 +2349,8 @@ func Transpile(prog *parser.Program, env *types.Env, bench bool) (*Program, erro
 	needsBreaks = false
 	needsJSON = false
 	needsBigInt = false
+	needsFloorDiv = false
+	needsFloorMod = false
 	needsBigRat = false
 	needsMD5 = false
 	useNow = false


### PR DESCRIPTION
## Summary
- allow Scala SPOJ tests to run across a range of problem indexes
- generate SPOJ checklist dynamically with parsed problem names
- reset floor division/mod flags between transpiler runs

## Testing
- `FROM_INDEX=1 TO_INDEX=10 go test ./transpiler/x/scala -run SPOJ -tags slow -count=1 -v` *(fails: run: exit status 1; parse: unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3ee3f3948320b303845c25588394