### PR TITLE
zig: avoid leaking scoped variable declarations

### DIFF
--- a/transpiler/x/zig/transpiler.go
+++ b/transpiler/x/zig/transpiler.go
@@ -134,17 +134,21 @@ func pushAliasScope() {
 }
 
 func popAliasScope() {
-	if len(aliasStack) == 0 {
-		return
-	}
-	// remove type information for names declared in this scope but keep
-	// nameCounts intact so that generated identifiers remain globally
-	// unique and cannot accidentally shadow names from outer scopes.
-	for _, name := range namesStack[len(namesStack)-1] {
-		delete(varTypes, name)
-	}
-	aliasStack = aliasStack[:len(aliasStack)-1]
-	namesStack = namesStack[:len(namesStack)-1]
+        if len(aliasStack) == 0 {
+                return
+        }
+        // remove type information for names declared in this scope but keep
+        // nameCounts intact so that generated identifiers remain globally
+        // unique and cannot accidentally shadow names from outer scopes.
+       for _, name := range namesStack[len(namesStack)-1] {
+               delete(varTypes, name)
+               // also clear tracked variable declarations so temporary
+               // identifiers from an inner scope don't leak into outer
+               // scopes and interfere with later analyses
+               delete(varDecls, name)
+       }
+        aliasStack = aliasStack[:len(aliasStack)-1]
+        namesStack = namesStack[:len(namesStack)-1]
 }
 
 func uniqueName(name string) string {


### PR DESCRIPTION
## Summary
- clear tracked variable declarations when leaving a scope so inner-scope names don't interfere with later analysis

## Testing
- `go test ./transpiler/x/zig -run Test -tags=slow`
- `go test ./tests/spoj/human -run Zig -tags=slow`


------
https://chatgpt.com/codex/tasks/task_e_68ad3eec41208320b8c9c30dd2841962