### PR TITLE
Add Lean solution for SPOJ HASHIT

### DIFF
--- a/tests/spoj/human/x/lean/29.in
+++ b/tests/spoj/human/x/lean/29.in
@@ -1,0 +1,13 @@
+1
+11
+ADD:marsz
+ADD:marsz
+ADD:Dabrowski
+ADD:z
+ADD:ziemii
+ADD:wloskiej
+ADD:do
+ADD:Polski
+DEL:od
+DEL:do
+DEL:wloskiej

--- a/tests/spoj/human/x/lean/29.lean
+++ b/tests/spoj/human/x/lean/29.lean
@@ -1,0 +1,73 @@
+/- Solution for SPOJ HASHIT - Hash it!
+https://www.spoj.com/problems/HASHIT/
+-/
+
+import Std
+open Std
+
+def hashKey (s : String) : Nat :=
+  let rec loop (cs : List Char) (i acc : Nat) : Nat :=
+    match cs with
+    | [] => acc
+    | c :: cs => loop cs (i + 1) (acc + c.toNat * (i + 1))
+  let h := loop s.toList 0 0
+  (19 * h) % 101
+
+def findIdx (table : Array String) (key : String) : Option Nat :=
+  let h := hashKey key
+  let rec loop (j : Nat) : Option Nat :=
+    if j == 20 then none else
+      let idx := (h + j*j + 23*j) % 101
+      if table.get! idx == key then some idx else loop (j + 1)
+  loop 0
+
+def insert (table : Array String) (key : String) : Array String :=
+  if (findIdx table key).isSome then table
+  else
+    let h := hashKey key
+    let rec loop (j : Nat) (tab : Array String) : Array String :=
+      if j == 20 then tab else
+        let idx := (h + j*j + 23*j) % 101
+        if tab.get! idx == "" then
+          tab.set! idx key
+        else
+          loop (j + 1) tab
+    loop 0 table
+
+
+def delete (table : Array String) (key : String) : Array String :=
+  match findIdx table key with
+  | none => table
+  | some idx => table.set! idx ""
+
+partial def processOps (h : IO.FS.Stream) (n : Nat) (table : Array String) : IO (Array String) := do
+  if n == 0 then
+    pure table
+  else
+    let line := (← h.getLine).trim
+    let parts := line.splitOn ":"
+    let table :=
+      match parts with
+      | ["ADD", key] => insert table key
+      | ["DEL", key] => delete table key
+      | _ => table
+    processOps h (n - 1) table
+
+partial def processCases (h : IO.FS.Stream) (t : Nat) : IO Unit := do
+  if t == 0 then
+    pure ()
+  else
+    let n := (← h.getLine).trim.toNat!
+    let table ← processOps h n (Array.mkArray 101 "")
+    let entries := (Array.range 101).foldl (fun acc i =>
+      let key := table.get! i
+      if key == "" then acc else acc.push (i, key)) #[]
+    IO.println entries.size
+    for (i, key) in entries do
+      IO.println s!"{i}:{key}"
+    processCases h (t - 1)
+
+def main : IO Unit := do
+  let h ← IO.getStdin
+  let t := (← h.getLine).trim.toNat!
+  processCases h t

--- a/tests/spoj/human/x/lean/29.out
+++ b/tests/spoj/human/x/lean/29.out
@@ -1,0 +1,6 @@
+5
+34:Dabrowski
+46:Polski
+63:marsz
+76:ziemii
+96:z

--- a/tests/spoj/x/human/lean/29.md
+++ b/tests/spoj/x/human/lean/29.md
@@ -1,0 +1,26 @@
+# Hash it!
+
+[Problem](https://www.spoj.com/problems/HASHIT/)
+
+## Algorithm
+
+We maintain a hash table of 101 slots. For a key `a₁a₂…aₙ` we compute
+
+```
+h = 19 * Σ ASCII(aᵢ) * (i)
+index = h mod 101
+```
+
+When inserting a key we probe up to twenty positions:
+`(index + j*j + 23*j) mod 101` for `j = 0…19`. If the key already
+exists we do nothing. Otherwise we place it into the first empty slot
+encountered.
+
+Deletion searches through the same probe sequence and marks the slot as
+empty if the key is found.
+
+After processing all operations we output the number of stored keys and
+all `index:key` pairs ordered by index.
+
+The probing is limited to at most twenty locations, so every operation
+runs in constant time.


### PR DESCRIPTION
## Summary
- add Lean implementation for HASHIT using open addressing hash table
- document algorithm for hash probing and collisions

## Testing
- `go test ./tests/spoj/human -run TestLeanSolutions -tags slow -v` *(fails: lean not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4f341f6c8320b304b9bfe550f7ee