### PR TITLE
rust transpiler: add readFile alias

### DIFF
--- a/transpiler/x/rs/SPOJ.md
+++ b/transpiler/x/rs/SPOJ.md
@@ -2,17 +2,18 @@
 
 This checklist is auto-generated.
 Generated Rust code from programs in `tests/spoj/x/mochi` lives in `tests/spoj/x/rs`.
-Last updated: 2025-08-26 12:09 GMT+7
+Last updated: 2025-08-26 14:33 GMT+7
 
-## SPOJ Golden Test Checklist (6/9)
+## SPOJ Golden Test Checklist (7/10)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:------:|---------:|-------:|
-| 1 | Life, the Universe, and Everything | ✓ | 571.0ms | 2.08MB |
-| 2 | PRIME1 - Prime Generator | ✓ | 571.0ms | 2.45MB |
-| 3 | 3 | ✓ | 571.0ms | 2.11MB |
-| 4 | SPOJ ONP - Transform the Expression | ✓ | 571.0ms | 1.98MB |
-| 5 | 5 | ✓ | 571.0ms | 2.14MB |
+| 1 | Life, the Universe, and Everything | ✓ | 571.0ms | 1.94MB |
+| 2 | PRIME1 - Prime Generator | ✓ | 571.0ms | 2.39MB |
+| 3 | 3 | ✓ | 571.0ms | 2.01MB |
+| 4 | SPOJ ONP - Transform the Expression | ✓ | 571.0ms | 2.04MB |
+| 5 | 5 | ✓ | 571.0ms | 1.98MB |
 | 6 | Simple Arithmetics |   |  |  |
 | 7 | The Bulk |   |  |  |
 | 8 | Complete the Sequence! |   |  |  |
-| 9 | 9 | ✓ | 571.0ms | 2.07MB |
+| 9 | 9 | ✓ | 571.0ms | 2.11MB |
+| 12 | MMIND - The Game of Master-Mind | ✓ | 571.0ms | 2.15MB |

--- a/transpiler/x/rs/transpiler.go
+++ b/transpiler/x/rs/transpiler.go
@@ -5383,12 +5383,13 @@ func compilePrimary(p *parser.Primary) (Expr, error) {
 				return &IntCastExpr{Expr: args[0]}, nil
 			}
 		}
-		if name == "read_file" && len(args) == 1 {
-			if _, ok := funReturns["read_file"]; ok {
-				// user-defined read_file
+		if (name == "read_file" || name == "readFile") && len(args) == 1 {
+			// allow camelCase alias `readFile` for convenience
+			if _, ok := funReturns["read_file"]; ok || (name == "readFile" && funReturns["readFile"] != "") {
+				// user-defined function with same name; treat as normal call
 			} else {
 				useReadFile = true
-				funReturns[name] = "String"
+				funReturns["read_file"] = "String"
 				if inferType(args[0]) == "String" {
 					if _, ok := args[0].(*StringLit); !ok {
 						args[0] = &MethodCallExpr{Receiver: args[0], Name: "as_str"}


### PR DESCRIPTION
## Summary
- handle `readFile` as an alias for the `read_file` builtin in Rust transpiler
- regenerate Rust SPOJ progress table

## Testing
- `go test -run TestRustTranspiler_SPOJ_Golden -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68ad619b6b7c8320ae149e3d9aa25c8c