### PR TITLE
Add SPOJ index pages 2-10

### DIFF
--- a/tests/spoj/index/10.jsonl
+++ b/tests/spoj/index/10.jsonl
@@ -1,0 +1,50 @@
+{"id":1748,"name":"Sequence Partitioning II","url":"https://www.spoj.com/problems/SEQPAR2","users":60,"accepted":24.84}
+{"id":1754,"name":"Divisor Summation (Hard)","url":"https://www.spoj.com/problems/DIVSUM2","users":1340,"accepted":15.68}
+{"id":1771,"name":"Yet Another N-Queen Problem","url":"https://www.spoj.com/problems/NQUEEN","users":326,"accepted":24.55}
+{"id":1772,"name":"Find The Determinant II","url":"https://www.spoj.com/problems/DETER2","users":101,"accepted":30.87}
+{"id":1774,"name":"All Discs Considered","url":"https://www.spoj.com/problems/ALL","users":523,"accepted":28.49}
+{"id":1775,"name":"Boolean Logic","url":"https://www.spoj.com/problems/BOOLE","users":104,"accepted":23.24}
+{"id":1776,"name":"DNA Laboratory","url":"https://www.spoj.com/problems/DNALAB","users":112,"accepted":11.02}
+{"id":1784,"name":"IOICamp Sequence","url":"https://www.spoj.com/problems/ICAMPSEQ","users":325,"accepted":12.8}
+{"id":1785,"name":"Code","url":"https://www.spoj.com/problems/CODE","users":231,"accepted":26.44}
+{"id":1786,"name":"In Danger","url":"https://www.spoj.com/problems/DANGER","users":4395,"accepted":53.61}
+{"id":1787,"name":"Run Length Encoding","url":"https://www.spoj.com/problems/ENCONDIN","users":861,"accepted":19.62}
+{"id":1788,"name":"Fractan","url":"https://www.spoj.com/problems/FRACTAN","users":49,"accepted":30.6}
+{"id":1789,"name":"Huffman´s Greed","url":"https://www.spoj.com/problems/GREEDULM","users":91,"accepted":46.67}
+{"id":1790,"name":"Binary Search Heap Construction","url":"https://www.spoj.com/problems/HEAPULM","users":331,"accepted":23.46}
+{"id":1793,"name":"Text Generater II","url":"https://www.spoj.com/problems/GEN2","users":57,"accepted":30.59}
+{"id":1794,"name":"Greedy Hydra II","url":"https://www.spoj.com/problems/DRAGON2","users":76,"accepted":18.57}
+{"id":1797,"name":"Cardsharper","url":"https://www.spoj.com/problems/CARD","users":7,"accepted":22.06}
+{"id":1798,"name":"Assistance Required","url":"https://www.spoj.com/problems/ASSIST","users":2380,"accepted":44.79}
+{"id":1799,"name":"The Bottom of a Graph","url":"https://www.spoj.com/problems/BOTTOM","users":1735,"accepted":32.47}
+{"id":1800,"name":"Fixed Partition Contest Management","url":"https://www.spoj.com/problems/CONTEST","users":63,"accepted":36.99}
+{"id":1801,"name":"Drink, on Ice","url":"https://www.spoj.com/problems/DRINK","users":522,"accepted":42.66}
+{"id":1802,"name":"Edge","url":"https://www.spoj.com/problems/EDGE","users":420,"accepted":59.75}
+{"id":1803,"name":"Fold","url":"https://www.spoj.com/problems/FOLD","users":60,"accepted":43.21}
+{"id":1804,"name":"Genetic Code","url":"https://www.spoj.com/problems/GENETIC","users":268,"accepted":47.34}
+{"id":1805,"name":"Largest Rectangle in a Histogram","url":"https://www.spoj.com/problems/HISTOGRA","users":8738,"accepted":28.39}
+{"id":1810,"name":"Nuclear Plants","url":"https://www.spoj.com/problems/ORZ","users":22,"accepted":11.9}
+{"id":1811,"name":"Longest Common Substring","url":"https://www.spoj.com/problems/LCS","users":3518,"accepted":22.35}
+{"id":1812,"name":"Longest Common Substring II","url":"https://www.spoj.com/problems/LCS2","users":2094,"accepted":18.36}
+{"id":1815,"name":"Problems Collection (Volume X)","url":"https://www.spoj.com/problems/WA","users":77,"accepted":7.26}
+{"id":1825,"name":"Free tour II","url":"https://www.spoj.com/problems/FTOUR2","users":571,"accepted":14.29}
+{"id":1833,"name":"Sudoku","url":"https://www.spoj.com/problems/SUDOKU2","users":54,"accepted":30.66}
+{"id":1835,"name":"The SetStack Computer","url":"https://www.spoj.com/problems/SETSTACK","users":170,"accepted":28.83}
+{"id":1837,"name":"Pie","url":"https://www.spoj.com/problems/PIE","users":4126,"accepted":30.44}
+{"id":1838,"name":"Ticket to Ride","url":"https://www.spoj.com/problems/TICKET","users":91,"accepted":41.94}
+{"id":1839,"name":"The Bookcase","url":"https://www.spoj.com/problems/BOOKCASE","users":131,"accepted":37.88}
+{"id":1840,"name":"Printer Queue","url":"https://www.spoj.com/problems/PQUEUE","users":2992,"accepted":48.1}
+{"id":1841,"name":"Prime Path","url":"https://www.spoj.com/problems/PPATH","users":10588,"accepted":57.99}
+{"id":1842,"name":"Lineland Airport","url":"https://www.spoj.com/problems/LINELAND","users":37,"accepted":18.84}
+{"id":1843,"name":"Leonardo Notebook","url":"https://www.spoj.com/problems/LEONARDO","users":381,"accepted":34.8}
+{"id":1845,"name":"Mice and Maze","url":"https://www.spoj.com/problems/MICEMAZE","users":5565,"accepted":35.94}
+{"id":1846,"name":"Project File Dependencies","url":"https://www.spoj.com/problems/PFDEP","users":2150,"accepted":41.1}
+{"id":1847,"name":"No Change","url":"https://www.spoj.com/problems/NOCHANGE","users":1683,"accepted":36.15}
+{"id":1865,"name":"Making Waves","url":"https://www.spoj.com/problems/MKWAVES","users":190,"accepted":43.81}
+{"id":1866,"name":"Making Pals","url":"https://www.spoj.com/problems/MKPALS","users":202,"accepted":43.77}
+{"id":1868,"name":"Making Money","url":"https://www.spoj.com/problems/MKMONEY","users":801,"accepted":36.83}
+{"id":1869,"name":"Making Mountains Out Of Molehills","url":"https://www.spoj.com/problems/MKMOOM","users":17,"accepted":16.41}
+{"id":1870,"name":"Making Labels","url":"https://www.spoj.com/problems/MKLABELS","users":1700,"accepted":59.54}
+{"id":1871,"name":"Making A Budget","url":"https://www.spoj.com/problems/MKBUDGET","users":873,"accepted":48.56}
+{"id":1873,"name":"Accumulate Cargo","url":"https://www.spoj.com/problems/ACARGO","users":91,"accepted":26.79}
+{"id":1874,"name":"Burrows Wheeler Precompression","url":"https://www.spoj.com/problems/BWHEELER","users":426,"accepted":34.11}

--- a/tests/spoj/index/10.md
+++ b/tests/spoj/index/10.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 1748 | [Sequence Partitioning II](https://www.spoj.com/problems/SEQPAR2) | 60 | 24.84 |
+| 1754 | [Divisor Summation (Hard)](https://www.spoj.com/problems/DIVSUM2) | 1340 | 15.68 |
+| 1771 | [Yet Another N-Queen Problem](https://www.spoj.com/problems/NQUEEN) | 326 | 24.55 |
+| 1772 | [Find The Determinant II](https://www.spoj.com/problems/DETER2) | 101 | 30.87 |
+| 1774 | [All Discs Considered](https://www.spoj.com/problems/ALL) | 523 | 28.49 |
+| 1775 | [Boolean Logic](https://www.spoj.com/problems/BOOLE) | 104 | 23.24 |
+| 1776 | [DNA Laboratory](https://www.spoj.com/problems/DNALAB) | 112 | 11.02 |
+| 1784 | [IOICamp Sequence](https://www.spoj.com/problems/ICAMPSEQ) | 325 | 12.80 |
+| 1785 | [Code](https://www.spoj.com/problems/CODE) | 231 | 26.44 |
+| 1786 | [In Danger](https://www.spoj.com/problems/DANGER) | 4395 | 53.61 |
+| 1787 | [Run Length Encoding](https://www.spoj.com/problems/ENCONDIN) | 861 | 19.62 |
+| 1788 | [Fractan](https://www.spoj.com/problems/FRACTAN) | 49 | 30.60 |
+| 1789 | [Huffman´s Greed](https://www.spoj.com/problems/GREEDULM) | 91 | 46.67 |
+| 1790 | [Binary Search Heap Construction](https://www.spoj.com/problems/HEAPULM) | 331 | 23.46 |
+| 1793 | [Text Generater II](https://www.spoj.com/problems/GEN2) | 57 | 30.59 |
+| 1794 | [Greedy Hydra II](https://www.spoj.com/problems/DRAGON2) | 76 | 18.57 |
+| 1797 | [Cardsharper](https://www.spoj.com/problems/CARD) | 7 | 22.06 |
+| 1798 | [Assistance Required](https://www.spoj.com/problems/ASSIST) | 2380 | 44.79 |
+| 1799 | [The Bottom of a Graph](https://www.spoj.com/problems/BOTTOM) | 1735 | 32.47 |
+| 1800 | [Fixed Partition Contest Management](https://www.spoj.com/problems/CONTEST) | 63 | 36.99 |
+| 1801 | [Drink, on Ice](https://www.spoj.com/problems/DRINK) | 522 | 42.66 |
+| 1802 | [Edge](https://www.spoj.com/problems/EDGE) | 420 | 59.75 |
+| 1803 | [Fold](https://www.spoj.com/problems/FOLD) | 60 | 43.21 |
+| 1804 | [Genetic Code](https://www.spoj.com/problems/GENETIC) | 268 | 47.34 |
+| 1805 | [Largest Rectangle in a Histogram](https://www.spoj.com/problems/HISTOGRA) | 8738 | 28.39 |
+| 1810 | [Nuclear Plants](https://www.spoj.com/problems/ORZ) | 22 | 11.90 |
+| 1811 | [Longest Common Substring](https://www.spoj.com/problems/LCS) | 3518 | 22.35 |
+| 1812 | [Longest Common Substring II](https://www.spoj.com/problems/LCS2) | 2094 | 18.36 |
+| 1815 | [Problems Collection (Volume X)](https://www.spoj.com/problems/WA) | 77 | 7.26 |
+| 1825 | [Free tour II](https://www.spoj.com/problems/FTOUR2) | 571 | 14.29 |
+| 1833 | [Sudoku](https://www.spoj.com/problems/SUDOKU2) | 54 | 30.66 |
+| 1835 | [The SetStack Computer](https://www.spoj.com/problems/SETSTACK) | 170 | 28.83 |
+| 1837 | [Pie](https://www.spoj.com/problems/PIE) | 4126 | 30.44 |
+| 1838 | [Ticket to Ride](https://www.spoj.com/problems/TICKET) | 91 | 41.94 |
+| 1839 | [The Bookcase](https://www.spoj.com/problems/BOOKCASE) | 131 | 37.88 |
+| 1840 | [Printer Queue](https://www.spoj.com/problems/PQUEUE) | 2992 | 48.10 |
+| 1841 | [Prime Path](https://www.spoj.com/problems/PPATH) | 10588 | 57.99 |
+| 1842 | [Lineland Airport](https://www.spoj.com/problems/LINELAND) | 37 | 18.84 |
+| 1843 | [Leonardo Notebook](https://www.spoj.com/problems/LEONARDO) | 381 | 34.80 |
+| 1845 | [Mice and Maze](https://www.spoj.com/problems/MICEMAZE) | 5565 | 35.94 |
+| 1846 | [Project File Dependencies](https://www.spoj.com/problems/PFDEP) | 2150 | 41.10 |
+| 1847 | [No Change](https://www.spoj.com/problems/NOCHANGE) | 1683 | 36.15 |
+| 1865 | [Making Waves](https://www.spoj.com/problems/MKWAVES) | 190 | 43.81 |
+| 1866 | [Making Pals](https://www.spoj.com/problems/MKPALS) | 202 | 43.77 |
+| 1868 | [Making Money](https://www.spoj.com/problems/MKMONEY) | 801 | 36.83 |
+| 1869 | [Making Mountains Out Of Molehills](https://www.spoj.com/problems/MKMOOM) | 17 | 16.41 |
+| 1870 | [Making Labels](https://www.spoj.com/problems/MKLABELS) | 1700 | 59.54 |
+| 1871 | [Making A Budget](https://www.spoj.com/problems/MKBUDGET) | 873 | 48.56 |
+| 1873 | [Accumulate Cargo](https://www.spoj.com/problems/ACARGO) | 91 | 26.79 |
+| 1874 | [Burrows Wheeler Precompression](https://www.spoj.com/problems/BWHEELER) | 426 | 34.11 |

--- a/tests/spoj/index/2.jsonl
+++ b/tests/spoj/index/2.jsonl
@@ -1,0 +1,50 @@
+{"id":115,"name":"Family","url":"https://www.spoj.com/problems/FAMILY","users":79,"accepted":12.22}
+{"id":116,"name":"Intervals","url":"https://www.spoj.com/problems/INTERVAL","users":1191,"accepted":24.23}
+{"id":118,"name":"Rhombs","url":"https://www.spoj.com/problems/RHOMBS","users":113,"accepted":42.32}
+{"id":119,"name":"Servers","url":"https://www.spoj.com/problems/SERVERS","users":116,"accepted":19.59}
+{"id":120,"name":"Solitaire","url":"https://www.spoj.com/problems/SOLIT","users":370,"accepted":23.48}
+{"id":121,"name":"Timetable","url":"https://www.spoj.com/problems/TTABLE","users":62,"accepted":16.39}
+{"id":122,"name":"Voracious Steve","url":"https://www.spoj.com/problems/STEVE","users":275,"accepted":29.95}
+{"id":123,"name":"Paying in Byteland","url":"https://www.spoj.com/problems/PAYING","users":479,"accepted":46.72}
+{"id":130,"name":"Rent your airplane and make money","url":"https://www.spoj.com/problems/RENT","users":3386,"accepted":28.65}
+{"id":131,"name":"Square dance","url":"https://www.spoj.com/problems/SQDANCE","users":353,"accepted":50.19}
+{"id":132,"name":"Help R2-D2!","url":"https://www.spoj.com/problems/HELPR2D2","users":771,"accepted":29.7}
+{"id":134,"name":"Phony Primes","url":"https://www.spoj.com/problems/PHONY","users":183,"accepted":19.22}
+{"id":135,"name":"Men at work","url":"https://www.spoj.com/problems/MAWORK","users":268,"accepted":38.56}
+{"id":136,"name":"Transformation","url":"https://www.spoj.com/problems/TRANS","users":83,"accepted":32.18}
+{"id":137,"name":"Partition","url":"https://www.spoj.com/problems/PARTIT","users":787,"accepted":36.71}
+{"id":138,"name":"Election Posters","url":"https://www.spoj.com/problems/POSTERS","users":2340,"accepted":25.83}
+{"id":139,"name":"The Long and Narrow Maze","url":"https://www.spoj.com/problems/MAZE","users":211,"accepted":20.16}
+{"id":140,"name":"The Loner","url":"https://www.spoj.com/problems/LONER","users":160,"accepted":21.49}
+{"id":142,"name":"Johnny and the Glue","url":"https://www.spoj.com/problems/GLUE","users":110,"accepted":38.36}
+{"id":145,"name":"Aliens","url":"https://www.spoj.com/problems/ALIENS","users":435,"accepted":30}
+{"id":146,"name":"Fast Multiplication Again","url":"https://www.spoj.com/problems/MULTIPLY","users":36,"accepted":10.19}
+{"id":147,"name":"Tautology","url":"https://www.spoj.com/problems/TAUT","users":778,"accepted":37.37}
+{"id":148,"name":"Land for Motorways","url":"https://www.spoj.com/problems/MLAND","users":215,"accepted":41.02}
+{"id":149,"name":"Fencing in the Sheep","url":"https://www.spoj.com/problems/FSHEEP","users":102,"accepted":12.99}
+{"id":150,"name":"Where to Drink the Plonk?","url":"https://www.spoj.com/problems/PLONK","users":508,"accepted":35.63}
+{"id":151,"name":"The Courier","url":"https://www.spoj.com/problems/COURIER","users":1069,"accepted":35.62}
+{"id":153,"name":"Balancing the Stone","url":"https://www.spoj.com/problems/SCALES","users":329,"accepted":33.03}
+{"id":154,"name":"Sweet and Sour Rock","url":"https://www.spoj.com/problems/ROCK","users":3446,"accepted":51.14}
+{"id":160,"name":"Choosing a Palindromic Sequence","url":"https://www.spoj.com/problems/PALSEC","users":98,"accepted":32.39}
+{"id":174,"name":"Paint templates","url":"https://www.spoj.com/problems/PAINTTMP","users":60,"accepted":38.04}
+{"id":175,"name":"Polygon","url":"https://www.spoj.com/problems/POLY1","users":72,"accepted":22.47}
+{"id":176,"name":"Sum of one-sequence","url":"https://www.spoj.com/problems/SUM1SEQ","users":671,"accepted":33.6}
+{"id":177,"name":"AB-words","url":"https://www.spoj.com/problems/ABWORDS","users":16,"accepted":1.21}
+{"id":178,"name":"Road net","url":"https://www.spoj.com/problems/ROADNET","users":2394,"accepted":49.63}
+{"id":179,"name":"Word equations","url":"https://www.spoj.com/problems/WORDEQ","users":188,"accepted":21.95}
+{"id":180,"name":"How to pack containers","url":"https://www.spoj.com/problems/CONTPACK","users":108,"accepted":36.13}
+{"id":181,"name":"Scuba diver","url":"https://www.spoj.com/problems/SCUBADIV","users":3904,"accepted":26.07}
+{"id":182,"name":"Window","url":"https://www.spoj.com/problems/WINDOW1","users":50,"accepted":30.62}
+{"id":183,"name":"Assembler circuits","url":"https://www.spoj.com/problems/ASCIRC","users":61,"accepted":31.78}
+{"id":184,"name":"Automatic Teller Machines","url":"https://www.spoj.com/problems/ATMS","users":212,"accepted":34.19}
+{"id":185,"name":"Chase","url":"https://www.spoj.com/problems/CHASE1","users":221,"accepted":24.8}
+{"id":186,"name":"The lightest language","url":"https://www.spoj.com/problems/LITELANG","users":184,"accepted":26.49}
+{"id":187,"name":"Flat broken lines","url":"https://www.spoj.com/problems/FLBRKLIN","users":102,"accepted":39.34}
+{"id":188,"name":"Rectangles","url":"https://www.spoj.com/problems/RECTNG1","users":187,"accepted":12.84}
+{"id":196,"name":"Musketeers","url":"https://www.spoj.com/problems/MUSKET","users":510,"accepted":30.46}
+{"id":199,"name":"Empty Cuboids","url":"https://www.spoj.com/problems/EMPTY","users":149,"accepted":35.55}
+{"id":200,"name":"Monodigital Representations","url":"https://www.spoj.com/problems/MONODIG","users":168,"accepted":30.27}
+{"id":201,"name":"The Game of Polygons","url":"https://www.spoj.com/problems/POLYGAME","users":256,"accepted":39.01}
+{"id":202,"name":"Rockets","url":"https://www.spoj.com/problems/ROCKETS","users":60,"accepted":12.32}
+{"id":203,"name":"Potholers","url":"https://www.spoj.com/problems/POTHOLE","users":2290,"accepted":26.51}

--- a/tests/spoj/index/2.md
+++ b/tests/spoj/index/2.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 115 | [Family](https://www.spoj.com/problems/FAMILY) | 79 | 12.22 |
+| 116 | [Intervals](https://www.spoj.com/problems/INTERVAL) | 1191 | 24.23 |
+| 118 | [Rhombs](https://www.spoj.com/problems/RHOMBS) | 113 | 42.32 |
+| 119 | [Servers](https://www.spoj.com/problems/SERVERS) | 116 | 19.59 |
+| 120 | [Solitaire](https://www.spoj.com/problems/SOLIT) | 370 | 23.48 |
+| 121 | [Timetable](https://www.spoj.com/problems/TTABLE) | 62 | 16.39 |
+| 122 | [Voracious Steve](https://www.spoj.com/problems/STEVE) | 275 | 29.95 |
+| 123 | [Paying in Byteland](https://www.spoj.com/problems/PAYING) | 479 | 46.72 |
+| 130 | [Rent your airplane and make money](https://www.spoj.com/problems/RENT) | 3386 | 28.65 |
+| 131 | [Square dance](https://www.spoj.com/problems/SQDANCE) | 353 | 50.19 |
+| 132 | [Help R2-D2!](https://www.spoj.com/problems/HELPR2D2) | 771 | 29.70 |
+| 134 | [Phony Primes](https://www.spoj.com/problems/PHONY) | 183 | 19.22 |
+| 135 | [Men at work](https://www.spoj.com/problems/MAWORK) | 268 | 38.56 |
+| 136 | [Transformation](https://www.spoj.com/problems/TRANS) | 83 | 32.18 |
+| 137 | [Partition](https://www.spoj.com/problems/PARTIT) | 787 | 36.71 |
+| 138 | [Election Posters](https://www.spoj.com/problems/POSTERS) | 2340 | 25.83 |
+| 139 | [The Long and Narrow Maze](https://www.spoj.com/problems/MAZE) | 211 | 20.16 |
+| 140 | [The Loner](https://www.spoj.com/problems/LONER) | 160 | 21.49 |
+| 142 | [Johnny and the Glue](https://www.spoj.com/problems/GLUE) | 110 | 38.36 |
+| 145 | [Aliens](https://www.spoj.com/problems/ALIENS) | 435 | 30.00 |
+| 146 | [Fast Multiplication Again](https://www.spoj.com/problems/MULTIPLY) | 36 | 10.19 |
+| 147 | [Tautology](https://www.spoj.com/problems/TAUT) | 778 | 37.37 |
+| 148 | [Land for Motorways](https://www.spoj.com/problems/MLAND) | 215 | 41.02 |
+| 149 | [Fencing in the Sheep](https://www.spoj.com/problems/FSHEEP) | 102 | 12.99 |
+| 150 | [Where to Drink the Plonk?](https://www.spoj.com/problems/PLONK) | 508 | 35.63 |
+| 151 | [The Courier](https://www.spoj.com/problems/COURIER) | 1069 | 35.62 |
+| 153 | [Balancing the Stone](https://www.spoj.com/problems/SCALES) | 329 | 33.03 |
+| 154 | [Sweet and Sour Rock](https://www.spoj.com/problems/ROCK) | 3446 | 51.14 |
+| 160 | [Choosing a Palindromic Sequence](https://www.spoj.com/problems/PALSEC) | 98 | 32.39 |
+| 174 | [Paint templates](https://www.spoj.com/problems/PAINTTMP) | 60 | 38.04 |
+| 175 | [Polygon](https://www.spoj.com/problems/POLY1) | 72 | 22.47 |
+| 176 | [Sum of one-sequence](https://www.spoj.com/problems/SUM1SEQ) | 671 | 33.60 |
+| 177 | [AB-words](https://www.spoj.com/problems/ABWORDS) | 16 | 1.21 |
+| 178 | [Road net](https://www.spoj.com/problems/ROADNET) | 2394 | 49.63 |
+| 179 | [Word equations](https://www.spoj.com/problems/WORDEQ) | 188 | 21.95 |
+| 180 | [How to pack containers](https://www.spoj.com/problems/CONTPACK) | 108 | 36.13 |
+| 181 | [Scuba diver](https://www.spoj.com/problems/SCUBADIV) | 3904 | 26.07 |
+| 182 | [Window](https://www.spoj.com/problems/WINDOW1) | 50 | 30.62 |
+| 183 | [Assembler circuits](https://www.spoj.com/problems/ASCIRC) | 61 | 31.78 |
+| 184 | [Automatic Teller Machines](https://www.spoj.com/problems/ATMS) | 212 | 34.19 |
+| 185 | [Chase](https://www.spoj.com/problems/CHASE1) | 221 | 24.80 |
+| 186 | [The lightest language](https://www.spoj.com/problems/LITELANG) | 184 | 26.49 |
+| 187 | [Flat broken lines](https://www.spoj.com/problems/FLBRKLIN) | 102 | 39.34 |
+| 188 | [Rectangles](https://www.spoj.com/problems/RECTNG1) | 187 | 12.84 |
+| 196 | [Musketeers](https://www.spoj.com/problems/MUSKET) | 510 | 30.46 |
+| 199 | [Empty Cuboids](https://www.spoj.com/problems/EMPTY) | 149 | 35.55 |
+| 200 | [Monodigital Representations](https://www.spoj.com/problems/MONODIG) | 168 | 30.27 |
+| 201 | [The Game of Polygons](https://www.spoj.com/problems/POLYGAME) | 256 | 39.01 |
+| 202 | [Rockets](https://www.spoj.com/problems/ROCKETS) | 60 | 12.32 |
+| 203 | [Potholers](https://www.spoj.com/problems/POTHOLE) | 2290 | 26.51 |

--- a/tests/spoj/index/3.jsonl
+++ b/tests/spoj/index/3.jsonl
@@ -1,0 +1,50 @@
+{"id":204,"name":"Sleepwalker","url":"https://www.spoj.com/problems/SLEEP","users":96,"accepted":26.01}
+{"id":205,"name":"Icerink","url":"https://www.spoj.com/problems/ICERINK","users":8,"accepted":12.22}
+{"id":206,"name":"Bitmap","url":"https://www.spoj.com/problems/BITMAP","users":9653,"accepted":28.28}
+{"id":207,"name":"Three-coloring of binary trees","url":"https://www.spoj.com/problems/THREECOL","users":886,"accepted":36.08}
+{"id":208,"name":"Store-keeper","url":"https://www.spoj.com/problems/STORE","users":135,"accepted":15.52}
+{"id":209,"name":"The Map","url":"https://www.spoj.com/problems/MAP","users":248,"accepted":39.91}
+{"id":210,"name":"The Altars","url":"https://www.spoj.com/problems/ALTARS","users":53,"accepted":15.87}
+{"id":211,"name":"Primitivus recurencis","url":"https://www.spoj.com/problems/PRIMIT","users":285,"accepted":27.89}
+{"id":212,"name":"Water among Cubes","url":"https://www.spoj.com/problems/WATER","users":1612,"accepted":26.41}
+{"id":215,"name":"Panic in the Plazas","url":"https://www.spoj.com/problems/PANIC","users":89,"accepted":20.84}
+{"id":217,"name":"Soldiers on Parade","url":"https://www.spoj.com/problems/SOPARADE","users":130,"accepted":28.09}
+{"id":220,"name":"Relevant Phrases of Annihilation","url":"https://www.spoj.com/problems/PHRASES","users":697,"accepted":23.26}
+{"id":224,"name":"Vonny and her dominos","url":"https://www.spoj.com/problems/VONNY","users":692,"accepted":51.85}
+{"id":226,"name":"Jewelry and Fashion","url":"https://www.spoj.com/problems/JEWELS","users":20,"accepted":26.36}
+{"id":227,"name":"Ordering the Soldiers","url":"https://www.spoj.com/problems/ORDERS","users":1477,"accepted":33.29}
+{"id":228,"name":"Shamans","url":"https://www.spoj.com/problems/SHAMAN","users":144,"accepted":21.2}
+{"id":229,"name":"Sorting is easy","url":"https://www.spoj.com/problems/SORTING","users":118,"accepted":18.18}
+{"id":231,"name":"The Zebra Crossing","url":"https://www.spoj.com/problems/ZEBRA","users":29,"accepted":10.91}
+{"id":234,"name":"Getting Rid of the Holidays (Act I)","url":"https://www.spoj.com/problems/HOLIDAY1","users":100,"accepted":13.81}
+{"id":235,"name":"Very Fast Multiplication","url":"https://www.spoj.com/problems/VFMUL","users":1360,"accepted":28.08}
+{"id":236,"name":"Converting number formats","url":"https://www.spoj.com/problems/ROMAN","users":154,"accepted":40}
+{"id":237,"name":"Sums in a Triangle","url":"https://www.spoj.com/problems/SUMITR","users":3593,"accepted":42.51}
+{"id":238,"name":"Getting Rid of the Holidays (Act II)","url":"https://www.spoj.com/problems/HOLIDAY2","users":85,"accepted":16.32}
+{"id":239,"name":"Tour de Byteland","url":"https://www.spoj.com/problems/BTOUR","users":91,"accepted":24.45}
+{"id":241,"name":"Arranging the Blocks","url":"https://www.spoj.com/problems/BLOCKS","users":54,"accepted":12.78}
+{"id":243,"name":"Stable Marriage Problem","url":"https://www.spoj.com/problems/STABLEMP","users":1566,"accepted":40.69}
+{"id":245,"name":"Square Root","url":"https://www.spoj.com/problems/SQRROOT","users":596,"accepted":13.24}
+{"id":247,"name":"Chocolate","url":"https://www.spoj.com/problems/CHOCOLA","users":5960,"accepted":43.3}
+{"id":260,"name":"Containers","url":"https://www.spoj.com/problems/CTAIN","users":298,"accepted":46.22}
+{"id":261,"name":"Triangle Partitioning","url":"https://www.spoj.com/problems/TRIPART","users":205,"accepted":58.33}
+{"id":262,"name":"Connections","url":"https://www.spoj.com/problems/CONNECT","users":114,"accepted":28.93}
+{"id":263,"name":"Period","url":"https://www.spoj.com/problems/PERIOD","users":3052,"accepted":40.03}
+{"id":264,"name":"Corporative Network","url":"https://www.spoj.com/problems/CORNET","users":611,"accepted":25.39}
+{"id":272,"name":"Cave Exploration","url":"https://www.spoj.com/problems/CAVE","users":43,"accepted":10.19}
+{"id":274,"name":"Johnny and the Watermelon Plantation","url":"https://www.spoj.com/problems/WMELON","users":218,"accepted":24.52}
+{"id":275,"name":"The Water Ringroad","url":"https://www.spoj.com/problems/WATERWAY","users":7,"accepted":19.15}
+{"id":277,"name":"City Game","url":"https://www.spoj.com/problems/CTGAME","users":1334,"accepted":39.33}
+{"id":278,"name":"Bicycle","url":"https://www.spoj.com/problems/BICYCLE","users":62,"accepted":13.55}
+{"id":279,"name":"Interesting number","url":"https://www.spoj.com/problems/INUMBER","users":845,"accepted":24.2}
+{"id":280,"name":"Lifts","url":"https://www.spoj.com/problems/LIFTS","users":45,"accepted":17.61}
+{"id":283,"name":"Naptime","url":"https://www.spoj.com/problems/NAPTIME","users":672,"accepted":26.43}
+{"id":286,"name":"Selfish Cities","url":"https://www.spoj.com/problems/SCITIES","users":711,"accepted":39.03}
+{"id":287,"name":"Smart Network Administrator","url":"https://www.spoj.com/problems/NETADMIN","users":458,"accepted":23.72}
+{"id":288,"name":"Prime or Not","url":"https://www.spoj.com/problems/PON","users":5460,"accepted":19.3}
+{"id":290,"name":"Polynomial Equations","url":"https://www.spoj.com/problems/POLYEQ","users":66,"accepted":21.91}
+{"id":291,"name":"Cube Root","url":"https://www.spoj.com/problems/CUBERT","users":255,"accepted":16.67}
+{"id":292,"name":"Alibaba","url":"https://www.spoj.com/problems/ALIBB","users":187,"accepted":23.39}
+{"id":293,"name":"Officers on the Beat","url":"https://www.spoj.com/problems/OFBEAT","users":11,"accepted":16.23}
+{"id":296,"name":"Teamwork is Crucial","url":"https://www.spoj.com/problems/TWORK","users":71,"accepted":29.97}
+{"id":297,"name":"Aggressive cows","url":"https://www.spoj.com/problems/AGGRCOW","users":47403,"accepted":35.98}

--- a/tests/spoj/index/3.md
+++ b/tests/spoj/index/3.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 204 | [Sleepwalker](https://www.spoj.com/problems/SLEEP) | 96 | 26.01 |
+| 205 | [Icerink](https://www.spoj.com/problems/ICERINK) | 8 | 12.22 |
+| 206 | [Bitmap](https://www.spoj.com/problems/BITMAP) | 9653 | 28.28 |
+| 207 | [Three-coloring of binary trees](https://www.spoj.com/problems/THREECOL) | 886 | 36.08 |
+| 208 | [Store-keeper](https://www.spoj.com/problems/STORE) | 135 | 15.52 |
+| 209 | [The Map](https://www.spoj.com/problems/MAP) | 248 | 39.91 |
+| 210 | [The Altars](https://www.spoj.com/problems/ALTARS) | 53 | 15.87 |
+| 211 | [Primitivus recurencis](https://www.spoj.com/problems/PRIMIT) | 285 | 27.89 |
+| 212 | [Water among Cubes](https://www.spoj.com/problems/WATER) | 1612 | 26.41 |
+| 215 | [Panic in the Plazas](https://www.spoj.com/problems/PANIC) | 89 | 20.84 |
+| 217 | [Soldiers on Parade](https://www.spoj.com/problems/SOPARADE) | 130 | 28.09 |
+| 220 | [Relevant Phrases of Annihilation](https://www.spoj.com/problems/PHRASES) | 697 | 23.26 |
+| 224 | [Vonny and her dominos](https://www.spoj.com/problems/VONNY) | 692 | 51.85 |
+| 226 | [Jewelry and Fashion](https://www.spoj.com/problems/JEWELS) | 20 | 26.36 |
+| 227 | [Ordering the Soldiers](https://www.spoj.com/problems/ORDERS) | 1477 | 33.29 |
+| 228 | [Shamans](https://www.spoj.com/problems/SHAMAN) | 144 | 21.20 |
+| 229 | [Sorting is easy](https://www.spoj.com/problems/SORTING) | 118 | 18.18 |
+| 231 | [The Zebra Crossing](https://www.spoj.com/problems/ZEBRA) | 29 | 10.91 |
+| 234 | [Getting Rid of the Holidays (Act I)](https://www.spoj.com/problems/HOLIDAY1) | 100 | 13.81 |
+| 235 | [Very Fast Multiplication](https://www.spoj.com/problems/VFMUL) | 1360 | 28.08 |
+| 236 | [Converting number formats](https://www.spoj.com/problems/ROMAN) | 154 | 40.00 |
+| 237 | [Sums in a Triangle](https://www.spoj.com/problems/SUMITR) | 3593 | 42.51 |
+| 238 | [Getting Rid of the Holidays (Act II)](https://www.spoj.com/problems/HOLIDAY2) | 85 | 16.32 |
+| 239 | [Tour de Byteland](https://www.spoj.com/problems/BTOUR) | 91 | 24.45 |
+| 241 | [Arranging the Blocks](https://www.spoj.com/problems/BLOCKS) | 54 | 12.78 |
+| 243 | [Stable Marriage Problem](https://www.spoj.com/problems/STABLEMP) | 1566 | 40.69 |
+| 245 | [Square Root](https://www.spoj.com/problems/SQRROOT) | 596 | 13.24 |
+| 247 | [Chocolate](https://www.spoj.com/problems/CHOCOLA) | 5960 | 43.30 |
+| 260 | [Containers](https://www.spoj.com/problems/CTAIN) | 298 | 46.22 |
+| 261 | [Triangle Partitioning](https://www.spoj.com/problems/TRIPART) | 205 | 58.33 |
+| 262 | [Connections](https://www.spoj.com/problems/CONNECT) | 114 | 28.93 |
+| 263 | [Period](https://www.spoj.com/problems/PERIOD) | 3052 | 40.03 |
+| 264 | [Corporative Network](https://www.spoj.com/problems/CORNET) | 611 | 25.39 |
+| 272 | [Cave Exploration](https://www.spoj.com/problems/CAVE) | 43 | 10.19 |
+| 274 | [Johnny and the Watermelon Plantation](https://www.spoj.com/problems/WMELON) | 218 | 24.52 |
+| 275 | [The Water Ringroad](https://www.spoj.com/problems/WATERWAY) | 7 | 19.15 |
+| 277 | [City Game](https://www.spoj.com/problems/CTGAME) | 1334 | 39.33 |
+| 278 | [Bicycle](https://www.spoj.com/problems/BICYCLE) | 62 | 13.55 |
+| 279 | [Interesting number](https://www.spoj.com/problems/INUMBER) | 845 | 24.20 |
+| 280 | [Lifts](https://www.spoj.com/problems/LIFTS) | 45 | 17.61 |
+| 283 | [Naptime](https://www.spoj.com/problems/NAPTIME) | 672 | 26.43 |
+| 286 | [Selfish Cities](https://www.spoj.com/problems/SCITIES) | 711 | 39.03 |
+| 287 | [Smart Network Administrator](https://www.spoj.com/problems/NETADMIN) | 458 | 23.72 |
+| 288 | [Prime or Not](https://www.spoj.com/problems/PON) | 5460 | 19.30 |
+| 290 | [Polynomial Equations](https://www.spoj.com/problems/POLYEQ) | 66 | 21.91 |
+| 291 | [Cube Root](https://www.spoj.com/problems/CUBERT) | 255 | 16.67 |
+| 292 | [Alibaba](https://www.spoj.com/problems/ALIBB) | 187 | 23.39 |
+| 293 | [Officers on the Beat](https://www.spoj.com/problems/OFBEAT) | 11 | 16.23 |
+| 296 | [Teamwork is Crucial](https://www.spoj.com/problems/TWORK) | 71 | 29.97 |
+| 297 | [Aggressive cows](https://www.spoj.com/problems/AGGRCOW) | 47403 | 35.98 |

--- a/tests/spoj/index/4.jsonl
+++ b/tests/spoj/index/4.jsonl
@@ -1,0 +1,50 @@
+{"id":300,"name":"Cable TV Network","url":"https://www.spoj.com/problems/CABLETV","users":751,"accepted":37.73}
+{"id":301,"name":"Booklets","url":"https://www.spoj.com/problems/BOOK","users":190,"accepted":41.49}
+{"id":302,"name":"Count on Cantor","url":"https://www.spoj.com/problems/CANTON","users":13080,"accepted":61.26}
+{"id":303,"name":"The Unstable Cube","url":"https://www.spoj.com/problems/UCUBE","users":50,"accepted":27.75}
+{"id":309,"name":"The Room Pattern","url":"https://www.spoj.com/problems/RATTERN","users":48,"accepted":14.99}
+{"id":318,"name":"Pythagorean Legacy","url":"https://www.spoj.com/problems/PITPAIR","users":35,"accepted":19.69}
+{"id":325,"name":"The Tall Windmills","url":"https://www.spoj.com/problems/WINDMILL","users":82,"accepted":22.57}
+{"id":327,"name":"Platon and Socrates","url":"https://www.spoj.com/problems/PLATON","users":51,"accepted":12.63}
+{"id":328,"name":"Bishops","url":"https://www.spoj.com/problems/BISHOPS","users":8988,"accepted":32.04}
+{"id":329,"name":"Calls","url":"https://www.spoj.com/problems/CALLS","users":129,"accepted":29.63}
+{"id":332,"name":"Hard Question","url":"https://www.spoj.com/problems/HARDQ","users":106,"accepted":33.05}
+{"id":334,"name":"The Philosophical Dispute","url":"https://www.spoj.com/problems/PHDISP","users":62,"accepted":37.31}
+{"id":336,"name":"Exchange Operations","url":"https://www.spoj.com/problems/EOPERA","users":90,"accepted":20}
+{"id":338,"name":"Roads","url":"https://www.spoj.com/problems/ROADS","users":1397,"accepted":23.97}
+{"id":339,"name":"Recursive Sequence","url":"https://www.spoj.com/problems/SEQ","users":3834,"accepted":50.31}
+{"id":344,"name":"Poker","url":"https://www.spoj.com/problems/POKER","users":900,"accepted":37.66}
+{"id":345,"name":"Mixtures","url":"https://www.spoj.com/problems/MIXTURES","users":9206,"accepted":36.22}
+{"id":346,"name":"Bytelandian gold coins","url":"https://www.spoj.com/problems/COINS","users":25999,"accepted":25.22}
+{"id":347,"name":"Lazy Cows","url":"https://www.spoj.com/problems/LAZYCOWS","users":268,"accepted":28.41}
+{"id":348,"name":"Expedition","url":"https://www.spoj.com/problems/EXPEDI","users":2264,"accepted":20.72}
+{"id":349,"name":"Around the world","url":"https://www.spoj.com/problems/AROUND","users":88,"accepted":25.36}
+{"id":350,"name":"Landscaping","url":"https://www.spoj.com/problems/LANDSCAP","users":99,"accepted":30.08}
+{"id":351,"name":"Ha-noi!","url":"https://www.spoj.com/problems/HAN01","users":386,"accepted":42.45}
+{"id":359,"name":"Alpha Centauri Tennis","url":"https://www.spoj.com/problems/ACT","users":1755,"accepted":50.27}
+{"id":362,"name":"Ignore the Garbage","url":"https://www.spoj.com/problems/IGARB","users":425,"accepted":43.75}
+{"id":363,"name":"Crane Operator","url":"https://www.spoj.com/problems/COPER","users":5,"accepted":2.71}
+{"id":364,"name":"Pocket Money","url":"https://www.spoj.com/problems/LISA","users":2248,"accepted":38.59}
+{"id":365,"name":"Phidias","url":"https://www.spoj.com/problems/PHIDIAS","users":1224,"accepted":47.26}
+{"id":366,"name":"Farmer","url":"https://www.spoj.com/problems/FARMER","users":271,"accepted":17.1}
+{"id":367,"name":"Empodia","url":"https://www.spoj.com/problems/EMPODIA","users":165,"accepted":27.51}
+{"id":368,"name":"Cobbled streets","url":"https://www.spoj.com/problems/CSTREET","users":5441,"accepted":50.87}
+{"id":369,"name":"Math I","url":"https://www.spoj.com/problems/MATH1","users":89,"accepted":25.23}
+{"id":370,"name":"Ones and zeros","url":"https://www.spoj.com/problems/ONEZERO","users":4519,"accepted":30.1}
+{"id":371,"name":"Boxes","url":"https://www.spoj.com/problems/BOXES","users":552,"accepted":35.66}
+{"id":372,"name":"The Benefactor","url":"https://www.spoj.com/problems/BENEFACT","users":3098,"accepted":35.38}
+{"id":373,"name":"Greedy island","url":"https://www.spoj.com/problems/GREED","users":516,"accepted":33.62}
+{"id":374,"name":"Count maximum matrices","url":"https://www.spoj.com/problems/MATRIX","users":241,"accepted":20.85}
+{"id":375,"name":"Query on a tree","url":"https://www.spoj.com/problems/QTREE","users":5882,"accepted":17.59}
+{"id":376,"name":"A concrete simulation","url":"https://www.spoj.com/problems/ACS","users":1734,"accepted":34.37}
+{"id":377,"name":"Taxi","url":"https://www.spoj.com/problems/TAXI","users":1245,"accepted":28.48}
+{"id":379,"name":"Ambiguous Permutations","url":"https://www.spoj.com/problems/PERMUT2","users":12374,"accepted":59.61}
+{"id":380,"name":"Bullshit Bingo","url":"https://www.spoj.com/problems/BINGO","users":722,"accepted":33.74}
+{"id":381,"name":"106 miles to Chicago","url":"https://www.spoj.com/problems/CHICAGO","users":3220,"accepted":36.51}
+{"id":382,"name":"Decorate the wall","url":"https://www.spoj.com/problems/DECORATE","users":216,"accepted":34.95}
+{"id":383,"name":"European railroad tracks","url":"https://www.spoj.com/problems/EUROPEAN","users":227,"accepted":30.31}
+{"id":384,"name":"Any fool can do it","url":"https://www.spoj.com/problems/FOOL","users":389,"accepted":32.52}
+{"id":385,"name":"Game schedule required","url":"https://www.spoj.com/problems/GAME","users":156,"accepted":29.07}
+{"id":386,"name":"Help the problem setter","url":"https://www.spoj.com/problems/HELP","users":105,"accepted":45.45}
+{"id":387,"name":"Travelling tours","url":"https://www.spoj.com/problems/TOURS","users":312,"accepted":53.92}
+{"id":388,"name":"Menu","url":"https://www.spoj.com/problems/MENU","users":352,"accepted":19}

--- a/tests/spoj/index/4.md
+++ b/tests/spoj/index/4.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 300 | [Cable TV Network](https://www.spoj.com/problems/CABLETV) | 751 | 37.73 |
+| 301 | [Booklets](https://www.spoj.com/problems/BOOK) | 190 | 41.49 |
+| 302 | [Count on Cantor](https://www.spoj.com/problems/CANTON) | 13080 | 61.26 |
+| 303 | [The Unstable Cube](https://www.spoj.com/problems/UCUBE) | 50 | 27.75 |
+| 309 | [The Room Pattern](https://www.spoj.com/problems/RATTERN) | 48 | 14.99 |
+| 318 | [Pythagorean Legacy](https://www.spoj.com/problems/PITPAIR) | 35 | 19.69 |
+| 325 | [The Tall Windmills](https://www.spoj.com/problems/WINDMILL) | 82 | 22.57 |
+| 327 | [Platon and Socrates](https://www.spoj.com/problems/PLATON) | 51 | 12.63 |
+| 328 | [Bishops](https://www.spoj.com/problems/BISHOPS) | 8988 | 32.04 |
+| 329 | [Calls](https://www.spoj.com/problems/CALLS) | 129 | 29.63 |
+| 332 | [Hard Question](https://www.spoj.com/problems/HARDQ) | 106 | 33.05 |
+| 334 | [The Philosophical Dispute](https://www.spoj.com/problems/PHDISP) | 62 | 37.31 |
+| 336 | [Exchange Operations](https://www.spoj.com/problems/EOPERA) | 90 | 20.00 |
+| 338 | [Roads](https://www.spoj.com/problems/ROADS) | 1397 | 23.97 |
+| 339 | [Recursive Sequence](https://www.spoj.com/problems/SEQ) | 3834 | 50.31 |
+| 344 | [Poker](https://www.spoj.com/problems/POKER) | 900 | 37.66 |
+| 345 | [Mixtures](https://www.spoj.com/problems/MIXTURES) | 9206 | 36.22 |
+| 346 | [Bytelandian gold coins](https://www.spoj.com/problems/COINS) | 25999 | 25.22 |
+| 347 | [Lazy Cows](https://www.spoj.com/problems/LAZYCOWS) | 268 | 28.41 |
+| 348 | [Expedition](https://www.spoj.com/problems/EXPEDI) | 2264 | 20.72 |
+| 349 | [Around the world](https://www.spoj.com/problems/AROUND) | 88 | 25.36 |
+| 350 | [Landscaping](https://www.spoj.com/problems/LANDSCAP) | 99 | 30.08 |
+| 351 | [Ha-noi!](https://www.spoj.com/problems/HAN01) | 386 | 42.45 |
+| 359 | [Alpha Centauri Tennis](https://www.spoj.com/problems/ACT) | 1755 | 50.27 |
+| 362 | [Ignore the Garbage](https://www.spoj.com/problems/IGARB) | 425 | 43.75 |
+| 363 | [Crane Operator](https://www.spoj.com/problems/COPER) | 5 | 2.71 |
+| 364 | [Pocket Money](https://www.spoj.com/problems/LISA) | 2248 | 38.59 |
+| 365 | [Phidias](https://www.spoj.com/problems/PHIDIAS) | 1224 | 47.26 |
+| 366 | [Farmer](https://www.spoj.com/problems/FARMER) | 271 | 17.10 |
+| 367 | [Empodia](https://www.spoj.com/problems/EMPODIA) | 165 | 27.51 |
+| 368 | [Cobbled streets](https://www.spoj.com/problems/CSTREET) | 5441 | 50.87 |
+| 369 | [Math I](https://www.spoj.com/problems/MATH1) | 89 | 25.23 |
+| 370 | [Ones and zeros](https://www.spoj.com/problems/ONEZERO) | 4519 | 30.10 |
+| 371 | [Boxes](https://www.spoj.com/problems/BOXES) | 552 | 35.66 |
+| 372 | [The Benefactor](https://www.spoj.com/problems/BENEFACT) | 3098 | 35.38 |
+| 373 | [Greedy island](https://www.spoj.com/problems/GREED) | 516 | 33.62 |
+| 374 | [Count maximum matrices](https://www.spoj.com/problems/MATRIX) | 241 | 20.85 |
+| 375 | [Query on a tree](https://www.spoj.com/problems/QTREE) | 5882 | 17.59 |
+| 376 | [A concrete simulation](https://www.spoj.com/problems/ACS) | 1734 | 34.37 |
+| 377 | [Taxi](https://www.spoj.com/problems/TAXI) | 1245 | 28.48 |
+| 379 | [Ambiguous Permutations](https://www.spoj.com/problems/PERMUT2) | 12374 | 59.61 |
+| 380 | [Bullshit Bingo](https://www.spoj.com/problems/BINGO) | 722 | 33.74 |
+| 381 | [106 miles to Chicago](https://www.spoj.com/problems/CHICAGO) | 3220 | 36.51 |
+| 382 | [Decorate the wall](https://www.spoj.com/problems/DECORATE) | 216 | 34.95 |
+| 383 | [European railroad tracks](https://www.spoj.com/problems/EUROPEAN) | 227 | 30.31 |
+| 384 | [Any fool can do it](https://www.spoj.com/problems/FOOL) | 389 | 32.52 |
+| 385 | [Game schedule required](https://www.spoj.com/problems/GAME) | 156 | 29.07 |
+| 386 | [Help the problem setter](https://www.spoj.com/problems/HELP) | 105 | 45.45 |
+| 387 | [Travelling tours](https://www.spoj.com/problems/TOURS) | 312 | 53.92 |
+| 388 | [Menu](https://www.spoj.com/problems/MENU) | 352 | 19.00 |

--- a/tests/spoj/index/5.jsonl
+++ b/tests/spoj/index/5.jsonl
@@ -1,0 +1,50 @@
+{"id":389,"name":"Use of Hospital Facilities","url":"https://www.spoj.com/problems/HOSPITAL","users":53,"accepted":15.47}
+{"id":390,"name":"Billiard","url":"https://www.spoj.com/problems/BILLIARD","users":903,"accepted":54.53}
+{"id":391,"name":"Railroads","url":"https://www.spoj.com/problems/RAILROAD","users":90,"accepted":17.63}
+{"id":392,"name":"Spin","url":"https://www.spoj.com/problems/SPIN","users":44,"accepted":26.63}
+{"id":393,"name":"Hexagon","url":"https://www.spoj.com/problems/HEXAGON","users":77,"accepted":48.65}
+{"id":394,"name":"Alphacode","url":"https://www.spoj.com/problems/ACODE","users":22942,"accepted":27.41}
+{"id":395,"name":"Anti-prime Sequences","url":"https://www.spoj.com/problems/APRIME","users":349,"accepted":47.83}
+{"id":396,"name":"Hit or Miss","url":"https://www.spoj.com/problems/HITOMISS","users":133,"accepted":43.1}
+{"id":397,"name":"I Conduit","url":"https://www.spoj.com/problems/CONDUIT","users":196,"accepted":15.57}
+{"id":398,"name":"Roll Playing Games","url":"https://www.spoj.com/problems/RPGAMES","users":121,"accepted":14.67}
+{"id":399,"name":"Team Rankings","url":"https://www.spoj.com/problems/TRANK","users":391,"accepted":53.58}
+{"id":400,"name":"To and Fro","url":"https://www.spoj.com/problems/TOANDFRO","users":23446,"accepted":55.6}
+{"id":401,"name":"Translations","url":"https://www.spoj.com/problems/TRANSL","users":137,"accepted":38.07}
+{"id":402,"name":"Hike on a Graph","url":"https://www.spoj.com/problems/HIKE","users":780,"accepted":40.27}
+{"id":403,"name":"Sort fractions","url":"https://www.spoj.com/problems/FRACTION","users":714,"accepted":33.12}
+{"id":404,"name":"Scanner","url":"https://www.spoj.com/problems/SCANNER","users":59,"accepted":12.57}
+{"id":405,"name":"Tin Cutter","url":"https://www.spoj.com/problems/TCUTTER","users":141,"accepted":29.59}
+{"id":406,"name":"Logic","url":"https://www.spoj.com/problems/LOGIC","users":112,"accepted":23.23}
+{"id":407,"name":"Random Number","url":"https://www.spoj.com/problems/RNUMBER","users":48,"accepted":29.13}
+{"id":408,"name":"Jill Rides Again","url":"https://www.spoj.com/problems/JRIDE","users":968,"accepted":34.25}
+{"id":409,"name":"DEL Command","url":"https://www.spoj.com/problems/DELCOMM","users":79,"accepted":17.6}
+{"id":410,"name":"Variable Radix Huffman Encoding","url":"https://www.spoj.com/problems/VHUFFM","users":180,"accepted":19.26}
+{"id":411,"name":"Number of quite different words","url":"https://www.spoj.com/problems/NUMQDW","users":244,"accepted":33.93}
+{"id":412,"name":"K-path cover","url":"https://www.spoj.com/problems/COVER","users":186,"accepted":20.48}
+{"id":413,"name":"Word Puzzles","url":"https://www.spoj.com/problems/WPUZZLES","users":377,"accepted":18.26}
+{"id":414,"name":"Equatorial Bonfire","url":"https://www.spoj.com/problems/BONFIRE","users":79,"accepted":28.98}
+{"id":416,"name":"Divisibility by 15","url":"https://www.spoj.com/problems/DIV15","users":1027,"accepted":15.51}
+{"id":417,"name":"The lazy programmer","url":"https://www.spoj.com/problems/LAZYPROG","users":653,"accepted":20.27}
+{"id":418,"name":"Necklace","url":"https://www.spoj.com/problems/NECKLACE","users":45,"accepted":16.92}
+{"id":419,"name":"Transposing is Fun","url":"https://www.spoj.com/problems/TRANSP","users":307,"accepted":36.88}
+{"id":421,"name":"Another Road Problem","url":"https://www.spoj.com/problems/AROAD","users":71,"accepted":25.06}
+{"id":422,"name":"Transposing is Even More Fun","url":"https://www.spoj.com/problems/TRANSP2","users":314,"accepted":26}
+{"id":423,"name":"Assignments","url":"https://www.spoj.com/problems/ASSIGN","users":4830,"accepted":33.69}
+{"id":428,"name":"Particular Palindromes","url":"https://www.spoj.com/problems/PARTPALI","users":501,"accepted":32.2}
+{"id":449,"name":"Simple Numbers with Fractions Conversion","url":"https://www.spoj.com/problems/TCNUMFL","users":37,"accepted":15.96}
+{"id":479,"name":"Permutation generator","url":"https://www.spoj.com/problems/TPERML","users":135,"accepted":28.24}
+{"id":481,"name":"Roots of polynomial","url":"https://www.spoj.com/problems/KMSL4B","users":46,"accepted":27.34}
+{"id":484,"name":"Fossil in the Ice","url":"https://www.spoj.com/problems/TFOSS","users":453,"accepted":22.4}
+{"id":503,"name":"Prime Intervals","url":"https://www.spoj.com/problems/PRINT","users":1821,"accepted":16.11}
+{"id":515,"name":"Collatz","url":"https://www.spoj.com/problems/CLTZ","users":450,"accepted":43.13}
+{"id":518,"name":"Zig-Zag Permutation","url":"https://www.spoj.com/problems/ZZPERM","users":51,"accepted":31.25}
+{"id":526,"name":"Divisors","url":"https://www.spoj.com/problems/DIV","users":1714,"accepted":43.74}
+{"id":530,"name":"Divisors 2","url":"https://www.spoj.com/problems/DIV2","users":936,"accepted":52.47}
+{"id":598,"name":"Increasing Subsequences","url":"https://www.spoj.com/problems/INCR","users":148,"accepted":34.62}
+{"id":660,"name":"Dungeon of Death","url":"https://www.spoj.com/problems/QUEST4","users":1355,"accepted":42.8}
+{"id":661,"name":"Nail Them","url":"https://www.spoj.com/problems/QUEST5","users":971,"accepted":42.99}
+{"id":665,"name":"String it out","url":"https://www.spoj.com/problems/SUBS","users":1221,"accepted":38.85}
+{"id":666,"name":"Con-Junctions","url":"https://www.spoj.com/problems/VOCV","users":1005,"accepted":40.97}
+{"id":676,"name":"Sorting is not easy","url":"https://www.spoj.com/problems/LSORT","users":542,"accepted":39.75}
+{"id":677,"name":"A place for the brewery","url":"https://www.spoj.com/problems/BROW","users":219,"accepted":28.3}

--- a/tests/spoj/index/5.md
+++ b/tests/spoj/index/5.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 389 | [Use of Hospital Facilities](https://www.spoj.com/problems/HOSPITAL) | 53 | 15.47 |
+| 390 | [Billiard](https://www.spoj.com/problems/BILLIARD) | 903 | 54.53 |
+| 391 | [Railroads](https://www.spoj.com/problems/RAILROAD) | 90 | 17.63 |
+| 392 | [Spin](https://www.spoj.com/problems/SPIN) | 44 | 26.63 |
+| 393 | [Hexagon](https://www.spoj.com/problems/HEXAGON) | 77 | 48.65 |
+| 394 | [Alphacode](https://www.spoj.com/problems/ACODE) | 22942 | 27.41 |
+| 395 | [Anti-prime Sequences](https://www.spoj.com/problems/APRIME) | 349 | 47.83 |
+| 396 | [Hit or Miss](https://www.spoj.com/problems/HITOMISS) | 133 | 43.10 |
+| 397 | [I Conduit](https://www.spoj.com/problems/CONDUIT) | 196 | 15.57 |
+| 398 | [Roll Playing Games](https://www.spoj.com/problems/RPGAMES) | 121 | 14.67 |
+| 399 | [Team Rankings](https://www.spoj.com/problems/TRANK) | 391 | 53.58 |
+| 400 | [To and Fro](https://www.spoj.com/problems/TOANDFRO) | 23446 | 55.60 |
+| 401 | [Translations](https://www.spoj.com/problems/TRANSL) | 137 | 38.07 |
+| 402 | [Hike on a Graph](https://www.spoj.com/problems/HIKE) | 780 | 40.27 |
+| 403 | [Sort fractions](https://www.spoj.com/problems/FRACTION) | 714 | 33.12 |
+| 404 | [Scanner](https://www.spoj.com/problems/SCANNER) | 59 | 12.57 |
+| 405 | [Tin Cutter](https://www.spoj.com/problems/TCUTTER) | 141 | 29.59 |
+| 406 | [Logic](https://www.spoj.com/problems/LOGIC) | 112 | 23.23 |
+| 407 | [Random Number](https://www.spoj.com/problems/RNUMBER) | 48 | 29.13 |
+| 408 | [Jill Rides Again](https://www.spoj.com/problems/JRIDE) | 968 | 34.25 |
+| 409 | [DEL Command](https://www.spoj.com/problems/DELCOMM) | 79 | 17.60 |
+| 410 | [Variable Radix Huffman Encoding](https://www.spoj.com/problems/VHUFFM) | 180 | 19.26 |
+| 411 | [Number of quite different words](https://www.spoj.com/problems/NUMQDW) | 244 | 33.93 |
+| 412 | [K-path cover](https://www.spoj.com/problems/COVER) | 186 | 20.48 |
+| 413 | [Word Puzzles](https://www.spoj.com/problems/WPUZZLES) | 377 | 18.26 |
+| 414 | [Equatorial Bonfire](https://www.spoj.com/problems/BONFIRE) | 79 | 28.98 |
+| 416 | [Divisibility by 15](https://www.spoj.com/problems/DIV15) | 1027 | 15.51 |
+| 417 | [The lazy programmer](https://www.spoj.com/problems/LAZYPROG) | 653 | 20.27 |
+| 418 | [Necklace](https://www.spoj.com/problems/NECKLACE) | 45 | 16.92 |
+| 419 | [Transposing is Fun](https://www.spoj.com/problems/TRANSP) | 307 | 36.88 |
+| 421 | [Another Road Problem](https://www.spoj.com/problems/AROAD) | 71 | 25.06 |
+| 422 | [Transposing is Even More Fun](https://www.spoj.com/problems/TRANSP2) | 314 | 26.00 |
+| 423 | [Assignments](https://www.spoj.com/problems/ASSIGN) | 4830 | 33.69 |
+| 428 | [Particular Palindromes](https://www.spoj.com/problems/PARTPALI) | 501 | 32.20 |
+| 449 | [Simple Numbers with Fractions Conversion](https://www.spoj.com/problems/TCNUMFL) | 37 | 15.96 |
+| 479 | [Permutation generator](https://www.spoj.com/problems/TPERML) | 135 | 28.24 |
+| 481 | [Roots of polynomial](https://www.spoj.com/problems/KMSL4B) | 46 | 27.34 |
+| 484 | [Fossil in the Ice](https://www.spoj.com/problems/TFOSS) | 453 | 22.40 |
+| 503 | [Prime Intervals](https://www.spoj.com/problems/PRINT) | 1821 | 16.11 |
+| 515 | [Collatz](https://www.spoj.com/problems/CLTZ) | 450 | 43.13 |
+| 518 | [Zig-Zag Permutation](https://www.spoj.com/problems/ZZPERM) | 51 | 31.25 |
+| 526 | [Divisors](https://www.spoj.com/problems/DIV) | 1714 | 43.74 |
+| 530 | [Divisors 2](https://www.spoj.com/problems/DIV2) | 936 | 52.47 |
+| 598 | [Increasing Subsequences](https://www.spoj.com/problems/INCR) | 148 | 34.62 |
+| 660 | [Dungeon of Death](https://www.spoj.com/problems/QUEST4) | 1355 | 42.80 |
+| 661 | [Nail Them](https://www.spoj.com/problems/QUEST5) | 971 | 42.99 |
+| 665 | [String it out](https://www.spoj.com/problems/SUBS) | 1221 | 38.85 |
+| 666 | [Con-Junctions](https://www.spoj.com/problems/VOCV) | 1005 | 40.97 |
+| 676 | [Sorting is not easy](https://www.spoj.com/problems/LSORT) | 542 | 39.75 |
+| 677 | [A place for the brewery](https://www.spoj.com/problems/BROW) | 219 | 28.30 |

--- a/tests/spoj/index/6.jsonl
+++ b/tests/spoj/index/6.jsonl
@@ -1,0 +1,50 @@
+{"id":681,"name":"Building the Tower","url":"https://www.spoj.com/problems/HANOI07","users":104,"accepted":20.25}
+{"id":682,"name":"Pairs of Integers","url":"https://www.spoj.com/problems/PAIRINT","users":207,"accepted":25.57}
+{"id":684,"name":"Another Assignment Problem","url":"https://www.spoj.com/problems/ASSIGN4","users":107,"accepted":12.48}
+{"id":685,"name":"Partition the sequence","url":"https://www.spoj.com/problems/SEQPAR","users":243,"accepted":21.13}
+{"id":687,"name":"Repeats","url":"https://www.spoj.com/problems/REPEATS","users":981,"accepted":25.39}
+{"id":688,"name":"Toy Cars","url":"https://www.spoj.com/problems/SAM","users":644,"accepted":18.47}
+{"id":693,"name":"Lethal Warfare","url":"https://www.spoj.com/problems/LWAR","users":365,"accepted":46.51}
+{"id":694,"name":"Distinct Substrings","url":"https://www.spoj.com/problems/DISUBSTR","users":5775,"accepted":26.61}
+{"id":695,"name":"Unite Fast","url":"https://www.spoj.com/problems/UFAST","users":138,"accepted":27.81}
+{"id":696,"name":"Truth or not","url":"https://www.spoj.com/problems/LIAR","users":275,"accepted":22}
+{"id":697,"name":"Matrix Words","url":"https://www.spoj.com/problems/MWORDS","users":97,"accepted":24.43}
+{"id":698,"name":"Plane Hopping","url":"https://www.spoj.com/problems/PLHOP","users":289,"accepted":25.31}
+{"id":699,"name":"Huge Knap Sack","url":"https://www.spoj.com/problems/HKNAP","users":141,"accepted":25.06}
+{"id":700,"name":"Branch Prediction","url":"https://www.spoj.com/problems/BPRED","users":78,"accepted":19.21}
+{"id":702,"name":"Barn Expansion","url":"https://www.spoj.com/problems/EXPAND","users":155,"accepted":23.36}
+{"id":703,"name":"Mobile Service","url":"https://www.spoj.com/problems/SERVICE","users":1164,"accepted":23.13}
+{"id":704,"name":"Remove The String","url":"https://www.spoj.com/problems/PSTRING","users":661,"accepted":15.29}
+{"id":705,"name":"New Distinct Substrings","url":"https://www.spoj.com/problems/SUBST1","users":3887,"accepted":26.8}
+{"id":707,"name":"Triple-Free Sets","url":"https://www.spoj.com/problems/TFSETS","users":208,"accepted":38.93}
+{"id":709,"name":"The day of the competitors","url":"https://www.spoj.com/problems/NICEDAY","users":1566,"accepted":28.81}
+{"id":726,"name":"Promotion","url":"https://www.spoj.com/problems/PRO","users":2102,"accepted":28.17}
+{"id":729,"name":"Move your armies","url":"https://www.spoj.com/problems/MAXIMUS","users":80,"accepted":19.85}
+{"id":733,"name":"Mountain Walking","url":"https://www.spoj.com/problems/MTWALK","users":764,"accepted":25.66}
+{"id":734,"name":"Ivan and his interesting game","url":"https://www.spoj.com/problems/IVAN","users":232,"accepted":32.99}
+{"id":735,"name":"Minimum Diameter Spanning Tree","url":"https://www.spoj.com/problems/MDST","users":198,"accepted":34.33}
+{"id":738,"name":"Another Counting Problem","url":"https://www.spoj.com/problems/TREE","users":235,"accepted":40.65}
+{"id":739,"name":"The Moronic Cowmpouter","url":"https://www.spoj.com/problems/NEG2","users":3062,"accepted":50.64}
+{"id":740,"name":"Treats for the Cows","url":"https://www.spoj.com/problems/TRT","users":8622,"accepted":42.73}
+{"id":741,"name":"Steady Cow Assignment","url":"https://www.spoj.com/problems/STEAD","users":533,"accepted":32.89}
+{"id":744,"name":"Longest Permutation","url":"https://www.spoj.com/problems/LPERMUT","users":619,"accepted":19.85}
+{"id":757,"name":"Thermal Luminescence","url":"https://www.spoj.com/problems/TEM","users":131,"accepted":37.64}
+{"id":760,"name":"Convex Hull 3D","url":"https://www.spoj.com/problems/CH3D","users":125,"accepted":41.33}
+{"id":780,"name":"The Archipelago","url":"https://www.spoj.com/problems/ARCHPLG","users":40,"accepted":41.41}
+{"id":827,"name":"Trigonometric optimization","url":"https://www.spoj.com/problems/TRIOPT","users":84,"accepted":27.33}
+{"id":839,"name":"Optimal Marks","url":"https://www.spoj.com/problems/OPTM","users":861,"accepted":24.7}
+{"id":850,"name":"Soccer Choreography","url":"https://www.spoj.com/problems/WM06","users":4,"accepted":3.8}
+{"id":861,"name":"Counting inversions","url":"https://www.spoj.com/problems/SWAPS","users":465,"accepted":19.98}
+{"id":866,"name":"DNA Translation","url":"https://www.spoj.com/problems/DNA","users":117,"accepted":21.44}
+{"id":867,"name":"Perfect Cubes","url":"https://www.spoj.com/problems/CUBES","users":2239,"accepted":47.91}
+{"id":869,"name":"Galactic Import","url":"https://www.spoj.com/problems/IMPORT","users":142,"accepted":45.76}
+{"id":870,"name":"Basically Speaking","url":"https://www.spoj.com/problems/BASE","users":1447,"accepted":43.91}
+{"id":871,"name":"Letter Sequence Analysis","url":"https://www.spoj.com/problems/SEQUENCE","users":108,"accepted":43.03}
+{"id":872,"name":"Mark-up","url":"https://www.spoj.com/problems/MARKUP","users":126,"accepted":30.18}
+{"id":898,"name":"Transmitters","url":"https://www.spoj.com/problems/TRANSMIT","users":335,"accepted":49.08}
+{"id":899,"name":"Ws Cipher","url":"https://www.spoj.com/problems/WSCIPHER","users":841,"accepted":38.4}
+{"id":900,"name":"Split Windows","url":"https://www.spoj.com/problems/SPLIT","users":33,"accepted":56.45}
+{"id":901,"name":"Index Generation","url":"https://www.spoj.com/problems/INDEXGEN","users":43,"accepted":54.26}
+{"id":902,"name":"Hangover","url":"https://www.spoj.com/problems/HANGOVER","users":17907,"accepted":62.79}
+{"id":903,"name":"Double Vision","url":"https://www.spoj.com/problems/DOUBLEVI","users":67,"accepted":57.04}
+{"id":904,"name":"Image Perimeters","url":"https://www.spoj.com/problems/IMAGE","users":334,"accepted":59.31}

--- a/tests/spoj/index/6.md
+++ b/tests/spoj/index/6.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 681 | [Building the Tower](https://www.spoj.com/problems/HANOI07) | 104 | 20.25 |
+| 682 | [Pairs of Integers](https://www.spoj.com/problems/PAIRINT) | 207 | 25.57 |
+| 684 | [Another Assignment Problem](https://www.spoj.com/problems/ASSIGN4) | 107 | 12.48 |
+| 685 | [Partition the sequence](https://www.spoj.com/problems/SEQPAR) | 243 | 21.13 |
+| 687 | [Repeats](https://www.spoj.com/problems/REPEATS) | 981 | 25.39 |
+| 688 | [Toy Cars](https://www.spoj.com/problems/SAM) | 644 | 18.47 |
+| 693 | [Lethal Warfare](https://www.spoj.com/problems/LWAR) | 365 | 46.51 |
+| 694 | [Distinct Substrings](https://www.spoj.com/problems/DISUBSTR) | 5775 | 26.61 |
+| 695 | [Unite Fast](https://www.spoj.com/problems/UFAST) | 138 | 27.81 |
+| 696 | [Truth or not](https://www.spoj.com/problems/LIAR) | 275 | 22.00 |
+| 697 | [Matrix Words](https://www.spoj.com/problems/MWORDS) | 97 | 24.43 |
+| 698 | [Plane Hopping](https://www.spoj.com/problems/PLHOP) | 289 | 25.31 |
+| 699 | [Huge Knap Sack](https://www.spoj.com/problems/HKNAP) | 141 | 25.06 |
+| 700 | [Branch Prediction](https://www.spoj.com/problems/BPRED) | 78 | 19.21 |
+| 702 | [Barn Expansion](https://www.spoj.com/problems/EXPAND) | 155 | 23.36 |
+| 703 | [Mobile Service](https://www.spoj.com/problems/SERVICE) | 1164 | 23.13 |
+| 704 | [Remove The String](https://www.spoj.com/problems/PSTRING) | 661 | 15.29 |
+| 705 | [New Distinct Substrings](https://www.spoj.com/problems/SUBST1) | 3887 | 26.80 |
+| 707 | [Triple-Free Sets](https://www.spoj.com/problems/TFSETS) | 208 | 38.93 |
+| 709 | [The day of the competitors](https://www.spoj.com/problems/NICEDAY) | 1566 | 28.81 |
+| 726 | [Promotion](https://www.spoj.com/problems/PRO) | 2102 | 28.17 |
+| 729 | [Move your armies](https://www.spoj.com/problems/MAXIMUS) | 80 | 19.85 |
+| 733 | [Mountain Walking](https://www.spoj.com/problems/MTWALK) | 764 | 25.66 |
+| 734 | [Ivan and his interesting game](https://www.spoj.com/problems/IVAN) | 232 | 32.99 |
+| 735 | [Minimum Diameter Spanning Tree](https://www.spoj.com/problems/MDST) | 198 | 34.33 |
+| 738 | [Another Counting Problem](https://www.spoj.com/problems/TREE) | 235 | 40.65 |
+| 739 | [The Moronic Cowmpouter](https://www.spoj.com/problems/NEG2) | 3062 | 50.64 |
+| 740 | [Treats for the Cows](https://www.spoj.com/problems/TRT) | 8622 | 42.73 |
+| 741 | [Steady Cow Assignment](https://www.spoj.com/problems/STEAD) | 533 | 32.89 |
+| 744 | [Longest Permutation](https://www.spoj.com/problems/LPERMUT) | 619 | 19.85 |
+| 757 | [Thermal Luminescence](https://www.spoj.com/problems/TEM) | 131 | 37.64 |
+| 760 | [Convex Hull 3D](https://www.spoj.com/problems/CH3D) | 125 | 41.33 |
+| 780 | [The Archipelago](https://www.spoj.com/problems/ARCHPLG) | 40 | 41.41 |
+| 827 | [Trigonometric optimization](https://www.spoj.com/problems/TRIOPT) | 84 | 27.33 |
+| 839 | [Optimal Marks](https://www.spoj.com/problems/OPTM) | 861 | 24.70 |
+| 850 | [Soccer Choreography](https://www.spoj.com/problems/WM06) | 4 | 3.80 |
+| 861 | [Counting inversions](https://www.spoj.com/problems/SWAPS) | 465 | 19.98 |
+| 866 | [DNA Translation](https://www.spoj.com/problems/DNA) | 117 | 21.44 |
+| 867 | [Perfect Cubes](https://www.spoj.com/problems/CUBES) | 2239 | 47.91 |
+| 869 | [Galactic Import](https://www.spoj.com/problems/IMPORT) | 142 | 45.76 |
+| 870 | [Basically Speaking](https://www.spoj.com/problems/BASE) | 1447 | 43.91 |
+| 871 | [Letter Sequence Analysis](https://www.spoj.com/problems/SEQUENCE) | 108 | 43.03 |
+| 872 | [Mark-up](https://www.spoj.com/problems/MARKUP) | 126 | 30.18 |
+| 898 | [Transmitters](https://www.spoj.com/problems/TRANSMIT) | 335 | 49.08 |
+| 899 | [Ws Cipher](https://www.spoj.com/problems/WSCIPHER) | 841 | 38.40 |
+| 900 | [Split Windows](https://www.spoj.com/problems/SPLIT) | 33 | 56.45 |
+| 901 | [Index Generation](https://www.spoj.com/problems/INDEXGEN) | 43 | 54.26 |
+| 902 | [Hangover](https://www.spoj.com/problems/HANGOVER) | 17907 | 62.79 |
+| 903 | [Double Vision](https://www.spoj.com/problems/DOUBLEVI) | 67 | 57.04 |
+| 904 | [Image Perimeters](https://www.spoj.com/problems/IMAGE) | 334 | 59.31 |

--- a/tests/spoj/index/7.jsonl
+++ b/tests/spoj/index/7.jsonl
@@ -1,0 +1,50 @@
+{"id":912,"name":"Submatrix of submatrix","url":"https://www.spoj.com/problems/MATRIX2","users":174,"accepted":27.01}
+{"id":913,"name":"Query on a tree II","url":"https://www.spoj.com/problems/QTREE2","users":4766,"accepted":20.93}
+{"id":944,"name":"Free Tour","url":"https://www.spoj.com/problems/FTOUR","users":19,"accepted":3.72}
+{"id":962,"name":"Intergalactic Map","url":"https://www.spoj.com/problems/IM","users":568,"accepted":23.4}
+{"id":964,"name":"Entrapment","url":"https://www.spoj.com/problems/EN","users":340,"accepted":24.01}
+{"id":967,"name":"Parking Bay","url":"https://www.spoj.com/problems/PB","users":565,"accepted":48.93}
+{"id":972,"name":"Birthday","url":"https://www.spoj.com/problems/BIRTHDAY","users":126,"accepted":18.75}
+{"id":987,"name":"Mobile","url":"https://www.spoj.com/problems/MOBILE","users":76,"accepted":16.14}
+{"id":996,"name":"Continuous Fractions","url":"https://www.spoj.com/problems/CFRAC","users":279,"accepted":37.54}
+{"id":999,"name":"Generalized Matrioshkas","url":"https://www.spoj.com/problems/MATRIOSH","users":420,"accepted":32.59}
+{"id":1000,"name":"Equidivisions","url":"https://www.spoj.com/problems/EQDIV","users":654,"accepted":23.39}
+{"id":1001,"name":"Babylonian Roulette","url":"https://www.spoj.com/problems/BROUL","users":666,"accepted":50.46}
+{"id":1002,"name":"Uncle Jack","url":"https://www.spoj.com/problems/UJ","users":2970,"accepted":39.6}
+{"id":1003,"name":"Little Quilt","url":"https://www.spoj.com/problems/QUILT","users":171,"accepted":39.89}
+{"id":1004,"name":"Polygon Encoder","url":"https://www.spoj.com/problems/POLYCODE","users":64,"accepted":11.12}
+{"id":1021,"name":"Aibohphobia","url":"https://www.spoj.com/problems/AIBOHP","users":10725,"accepted":36.22}
+{"id":1022,"name":"Angels and Devils","url":"https://www.spoj.com/problems/ANGELS","users":673,"accepted":31.14}
+{"id":1024,"name":"Complete Chess Boards","url":"https://www.spoj.com/problems/COMCB","users":536,"accepted":54.96}
+{"id":1025,"name":"Fashion Shows","url":"https://www.spoj.com/problems/FASHION","users":27871,"accepted":46.43}
+{"id":1026,"name":"Favorite Dice","url":"https://www.spoj.com/problems/FAVDICE","users":5481,"accepted":63.83}
+{"id":1027,"name":"Fool the Police","url":"https://www.spoj.com/problems/FPOLICE","users":1655,"accepted":27.12}
+{"id":1028,"name":"Hubulullu","url":"https://www.spoj.com/problems/HUBULLU","users":8257,"accepted":58.72}
+{"id":1029,"name":"Matrix Summation","url":"https://www.spoj.com/problems/MATSUM","users":3554,"accepted":20.15}
+{"id":1030,"name":"Triple Fat Ladies","url":"https://www.spoj.com/problems/EIGHTS","users":19215,"accepted":51.74}
+{"id":1031,"name":"Up Subsequence","url":"https://www.spoj.com/problems/UPSUB","users":733,"accepted":32.7}
+{"id":1043,"name":"Can you answer these queries I","url":"https://www.spoj.com/problems/GSS1","users":14301,"accepted":19.03}
+{"id":1108,"name":"Card Trick","url":"https://www.spoj.com/problems/CTRICK","users":2242,"accepted":50.39}
+{"id":1110,"name":"Sudoku","url":"https://www.spoj.com/problems/SUDOKU","users":540,"accepted":40.12}
+{"id":1112,"name":"Number Steps","url":"https://www.spoj.com/problems/NSTEPS","users":34148,"accepted":43.04}
+{"id":1161,"name":"Tic-Tac-Toe ( I )","url":"https://www.spoj.com/problems/TOE1","users":3380,"accepted":22.83}
+{"id":1162,"name":"Tic-Tac-Toe ( II )","url":"https://www.spoj.com/problems/TOE2","users":2409,"accepted":30.37}
+{"id":1163,"name":"Java vs C ++","url":"https://www.spoj.com/problems/JAVAC","users":5524,"accepted":22.88}
+{"id":1166,"name":"Dead Fraction","url":"https://www.spoj.com/problems/DEADFR","users":323,"accepted":23.36}
+{"id":1167,"name":"Move To Invert","url":"https://www.spoj.com/problems/MINCOUNT","users":2461,"accepted":31.8}
+{"id":1182,"name":"Sorted bit squence","url":"https://www.spoj.com/problems/SORTBIT","users":296,"accepted":42.31}
+{"id":1183,"name":"Accomodate the palace","url":"https://www.spoj.com/problems/PALACE","users":555,"accepted":52.75}
+{"id":1267,"name":"Origin of Life","url":"https://www.spoj.com/problems/ORIGLIFE","users":41,"accepted":25.1}
+{"id":1268,"name":"CN Tower (Easy)","url":"https://www.spoj.com/problems/CNEASY","users":1123,"accepted":30.75}
+{"id":1269,"name":"CN Tower (Hard)","url":"https://www.spoj.com/problems/CNHARD","users":27,"accepted":11.58}
+{"id":1270,"name":"Paint By Numbers","url":"https://www.spoj.com/problems/PNTBYNUM","users":28,"accepted":23.24}
+{"id":1285,"name":"Continuous Fractions Again","url":"https://www.spoj.com/problems/CFRAC2","users":376,"accepted":41.86}
+{"id":1296,"name":"4 values whose sum is 0","url":"https://www.spoj.com/problems/SUMFOUR","users":5117,"accepted":24.88}
+{"id":1325,"name":"Partial Sums","url":"https://www.spoj.com/problems/PARTSUM","users":225,"accepted":24.79}
+{"id":1326,"name":"A Chase In WonderLand","url":"https://www.spoj.com/problems/CHASE","users":411,"accepted":13.56}
+{"id":1329,"name":"Matrix","url":"https://www.spoj.com/problems/KPMATRIX","users":414,"accepted":17.21}
+{"id":1335,"name":"Maze","url":"https://www.spoj.com/problems/KPMAZE","users":67,"accepted":17.93}
+{"id":1391,"name":"Summing to a Square Prime","url":"https://www.spoj.com/problems/CZ_PROB1","users":1428,"accepted":53.97}
+{"id":1418,"name":"The Cats and the Mouse","url":"https://www.spoj.com/problems/CATM","users":3001,"accepted":33.76}
+{"id":1419,"name":"A Game with Numbers","url":"https://www.spoj.com/problems/NGM","users":12076,"accepted":61.48}
+{"id":1420,"name":"Geometry and a Square","url":"https://www.spoj.com/problems/GEOM","users":276,"accepted":34.08}

--- a/tests/spoj/index/7.md
+++ b/tests/spoj/index/7.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 912 | [Submatrix of submatrix](https://www.spoj.com/problems/MATRIX2) | 174 | 27.01 |
+| 913 | [Query on a tree II](https://www.spoj.com/problems/QTREE2) | 4766 | 20.93 |
+| 944 | [Free Tour](https://www.spoj.com/problems/FTOUR) | 19 | 3.72 |
+| 962 | [Intergalactic Map](https://www.spoj.com/problems/IM) | 568 | 23.40 |
+| 964 | [Entrapment](https://www.spoj.com/problems/EN) | 340 | 24.01 |
+| 967 | [Parking Bay](https://www.spoj.com/problems/PB) | 565 | 48.93 |
+| 972 | [Birthday](https://www.spoj.com/problems/BIRTHDAY) | 126 | 18.75 |
+| 987 | [Mobile](https://www.spoj.com/problems/MOBILE) | 76 | 16.14 |
+| 996 | [Continuous Fractions](https://www.spoj.com/problems/CFRAC) | 279 | 37.54 |
+| 999 | [Generalized Matrioshkas](https://www.spoj.com/problems/MATRIOSH) | 420 | 32.59 |
+| 1000 | [Equidivisions](https://www.spoj.com/problems/EQDIV) | 654 | 23.39 |
+| 1001 | [Babylonian Roulette](https://www.spoj.com/problems/BROUL) | 666 | 50.46 |
+| 1002 | [Uncle Jack](https://www.spoj.com/problems/UJ) | 2970 | 39.60 |
+| 1003 | [Little Quilt](https://www.spoj.com/problems/QUILT) | 171 | 39.89 |
+| 1004 | [Polygon Encoder](https://www.spoj.com/problems/POLYCODE) | 64 | 11.12 |
+| 1021 | [Aibohphobia](https://www.spoj.com/problems/AIBOHP) | 10725 | 36.22 |
+| 1022 | [Angels and Devils](https://www.spoj.com/problems/ANGELS) | 673 | 31.14 |
+| 1024 | [Complete Chess Boards](https://www.spoj.com/problems/COMCB) | 536 | 54.96 |
+| 1025 | [Fashion Shows](https://www.spoj.com/problems/FASHION) | 27871 | 46.43 |
+| 1026 | [Favorite Dice](https://www.spoj.com/problems/FAVDICE) | 5481 | 63.83 |
+| 1027 | [Fool the Police](https://www.spoj.com/problems/FPOLICE) | 1655 | 27.12 |
+| 1028 | [Hubulullu](https://www.spoj.com/problems/HUBULLU) | 8257 | 58.72 |
+| 1029 | [Matrix Summation](https://www.spoj.com/problems/MATSUM) | 3554 | 20.15 |
+| 1030 | [Triple Fat Ladies](https://www.spoj.com/problems/EIGHTS) | 19215 | 51.74 |
+| 1031 | [Up Subsequence](https://www.spoj.com/problems/UPSUB) | 733 | 32.70 |
+| 1043 | [Can you answer these queries I](https://www.spoj.com/problems/GSS1) | 14301 | 19.03 |
+| 1108 | [Card Trick](https://www.spoj.com/problems/CTRICK) | 2242 | 50.39 |
+| 1110 | [Sudoku](https://www.spoj.com/problems/SUDOKU) | 540 | 40.12 |
+| 1112 | [Number Steps](https://www.spoj.com/problems/NSTEPS) | 34148 | 43.04 |
+| 1161 | [Tic-Tac-Toe ( I )](https://www.spoj.com/problems/TOE1) | 3380 | 22.83 |
+| 1162 | [Tic-Tac-Toe ( II )](https://www.spoj.com/problems/TOE2) | 2409 | 30.37 |
+| 1163 | [Java vs C ++](https://www.spoj.com/problems/JAVAC) | 5524 | 22.88 |
+| 1166 | [Dead Fraction](https://www.spoj.com/problems/DEADFR) | 323 | 23.36 |
+| 1167 | [Move To Invert](https://www.spoj.com/problems/MINCOUNT) | 2461 | 31.80 |
+| 1182 | [Sorted bit squence](https://www.spoj.com/problems/SORTBIT) | 296 | 42.31 |
+| 1183 | [Accomodate the palace](https://www.spoj.com/problems/PALACE) | 555 | 52.75 |
+| 1267 | [Origin of Life](https://www.spoj.com/problems/ORIGLIFE) | 41 | 25.10 |
+| 1268 | [CN Tower (Easy)](https://www.spoj.com/problems/CNEASY) | 1123 | 30.75 |
+| 1269 | [CN Tower (Hard)](https://www.spoj.com/problems/CNHARD) | 27 | 11.58 |
+| 1270 | [Paint By Numbers](https://www.spoj.com/problems/PNTBYNUM) | 28 | 23.24 |
+| 1285 | [Continuous Fractions Again](https://www.spoj.com/problems/CFRAC2) | 376 | 41.86 |
+| 1296 | [4 values whose sum is 0](https://www.spoj.com/problems/SUMFOUR) | 5117 | 24.88 |
+| 1325 | [Partial Sums](https://www.spoj.com/problems/PARTSUM) | 225 | 24.79 |
+| 1326 | [A Chase In WonderLand](https://www.spoj.com/problems/CHASE) | 411 | 13.56 |
+| 1329 | [Matrix](https://www.spoj.com/problems/KPMATRIX) | 414 | 17.21 |
+| 1335 | [Maze](https://www.spoj.com/problems/KPMAZE) | 67 | 17.93 |
+| 1391 | [Summing to a Square Prime](https://www.spoj.com/problems/CZ_PROB1) | 1428 | 53.97 |
+| 1418 | [The Cats and the Mouse](https://www.spoj.com/problems/CATM) | 3001 | 33.76 |
+| 1419 | [A Game with Numbers](https://www.spoj.com/problems/NGM) | 12076 | 61.48 |
+| 1420 | [Geometry and a Square](https://www.spoj.com/problems/GEOM) | 276 | 34.08 |

--- a/tests/spoj/index/8.jsonl
+++ b/tests/spoj/index/8.jsonl
@@ -1,0 +1,50 @@
+{"id":1421,"name":"Goods","url":"https://www.spoj.com/problems/FIRM","users":148,"accepted":30.65}
+{"id":1431,"name":"Projections Of A Polygon","url":"https://www.spoj.com/problems/KPPOLY","users":122,"accepted":10.39}
+{"id":1433,"name":"The Sum","url":"https://www.spoj.com/problems/KPSUM","users":310,"accepted":17.68}
+{"id":1434,"name":"Equation","url":"https://www.spoj.com/problems/KPEQU","users":421,"accepted":33.46}
+{"id":1435,"name":"Vertex Cover","url":"https://www.spoj.com/problems/PT07X","users":4155,"accepted":34.36}
+{"id":1436,"name":"Is it a tree","url":"https://www.spoj.com/problems/PT07Y","users":21129,"accepted":35.3}
+{"id":1437,"name":"Longest path in a tree","url":"https://www.spoj.com/problems/PT07Z","users":20160,"accepted":39.55}
+{"id":1440,"name":"Use of Function Arctan","url":"https://www.spoj.com/problems/ARCTAN","users":543,"accepted":29.24}
+{"id":1441,"name":"The Clever Typist","url":"https://www.spoj.com/problems/CLEVER","users":34,"accepted":8.28}
+{"id":1442,"name":"Strange Food Chain","url":"https://www.spoj.com/problems/CHAIN","users":950,"accepted":19.73}
+{"id":1444,"name":"DEL Command II","url":"https://www.spoj.com/problems/DELCOMM2","users":41,"accepted":9.82}
+{"id":1447,"name":"A Game of Toy Bricks","url":"https://www.spoj.com/problems/BRCKGAME","users":42,"accepted":27.12}
+{"id":1448,"name":"3D Cover","url":"https://www.spoj.com/problems/COVER2","users":100,"accepted":27.12}
+{"id":1451,"name":"01 Sequence","url":"https://www.spoj.com/problems/SEQ1","users":99,"accepted":28.74}
+{"id":1452,"name":"Birthday Cake","url":"https://www.spoj.com/problems/CAKE","users":109,"accepted":26.35}
+{"id":1453,"name":"Optimal Connected Subset","url":"https://www.spoj.com/problems/OPTSUB","users":159,"accepted":47.19}
+{"id":1454,"name":"Memory Distribution","url":"https://www.spoj.com/problems/MEMDIS","users":27,"accepted":18}
+{"id":1455,"name":"Program Analyser","url":"https://www.spoj.com/problems/ANALYSER","users":29,"accepted":14.57}
+{"id":1456,"name":"The Secret of a Lost City","url":"https://www.spoj.com/problems/LOSTCT","users":23,"accepted":24.17}
+{"id":1457,"name":"Help Blue Mary Please! (Act I)","url":"https://www.spoj.com/problems/BLUEEQ","users":13,"accepted":1.74}
+{"id":1458,"name":"Help Blue Mary Please! (Act II)","url":"https://www.spoj.com/problems/BLUEEQ2","users":85,"accepted":17.83}
+{"id":1459,"name":"The Secret of an Aerolite","url":"https://www.spoj.com/problems/AEROLITE","users":265,"accepted":43.62}
+{"id":1460,"name":"A Simple Calculator in the Galaxy","url":"https://www.spoj.com/problems/GALAXY","users":35,"accepted":37.96}
+{"id":1461,"name":"Greedy Hydra","url":"https://www.spoj.com/problems/DRAGON","users":196,"accepted":33.33}
+{"id":1462,"name":"Barbarians","url":"https://www.spoj.com/problems/BARB","users":56,"accepted":15.42}
+{"id":1463,"name":"Robot Number M","url":"https://www.spoj.com/problems/ROBOT","users":80,"accepted":46.91}
+{"id":1464,"name":"Editor II","url":"https://www.spoj.com/problems/EDIT3","users":65,"accepted":18.83}
+{"id":1465,"name":"On the Way to Find Chris","url":"https://www.spoj.com/problems/CHRIS","users":62,"accepted":15.35}
+{"id":1466,"name":"Blue Mary Needs Help Again","url":"https://www.spoj.com/problems/CASHIER","users":226,"accepted":20.82}
+{"id":1468,"name":"Outside it is now raining","url":"https://www.spoj.com/problems/RAIN2","users":32,"accepted":23.33}
+{"id":1470,"name":"Another Sequence Problem","url":"https://www.spoj.com/problems/SEQ2","users":197,"accepted":24.56}
+{"id":1471,"name":"A Game of Pearls","url":"https://www.spoj.com/problems/PRLGAME","users":45,"accepted":30.86}
+{"id":1472,"name":"Tom and Jerry","url":"https://www.spoj.com/problems/TOMJERRY","users":67,"accepted":38.12}
+{"id":1473,"name":"Lemon Tree in the Moonlight","url":"https://www.spoj.com/problems/LEMON","users":28,"accepted":19.74}
+{"id":1475,"name":"Play with Digit Seven","url":"https://www.spoj.com/problems/WORMS","users":136,"accepted":38.22}
+{"id":1476,"name":"Maximum Profit","url":"https://www.spoj.com/problems/PROFIT","users":372,"accepted":32.3}
+{"id":1477,"name":"Play with a Tree","url":"https://www.spoj.com/problems/PT07A","users":95,"accepted":15.49}
+{"id":1478,"name":"The Easiest Problem","url":"https://www.spoj.com/problems/PT07B","users":75,"accepted":9.2}
+{"id":1479,"name":"The GbAaY Kingdom","url":"https://www.spoj.com/problems/PT07C","users":136,"accepted":19.18}
+{"id":1480,"name":"Let us count 1 2 3","url":"https://www.spoj.com/problems/PT07D","users":94,"accepted":16.28}
+{"id":1482,"name":"A short vacation in Disneyland","url":"https://www.spoj.com/problems/PT07F","users":236,"accepted":14.8}
+{"id":1483,"name":"Colorful Lights Party","url":"https://www.spoj.com/problems/PT07G","users":13,"accepted":10.22}
+{"id":1484,"name":"Search in XML","url":"https://www.spoj.com/problems/PT07H","users":20,"accepted":3.07}
+{"id":1487,"name":"Query on a tree III","url":"https://www.spoj.com/problems/PT07J","users":586,"accepted":18.62}
+{"id":1505,"name":"Whac-a-Mole","url":"https://www.spoj.com/problems/MOLE","users":44,"accepted":16.67}
+{"id":1526,"name":"Ranklist Sorting","url":"https://www.spoj.com/problems/RSORTING","users":28,"accepted":13.1}
+{"id":1536,"name":"Help Blue Mary Please! (Act III)","url":"https://www.spoj.com/problems/BLUEEQ3","users":30,"accepted":14.42}
+{"id":1538,"name":"Making Jumps","url":"https://www.spoj.com/problems/MKJUMPS","users":1466,"accepted":38.91}
+{"id":1552,"name":"Mobiles","url":"https://www.spoj.com/problems/MOBILE2","users":192,"accepted":28.32}
+{"id":1553,"name":"Backup Files","url":"https://www.spoj.com/problems/BACKUP","users":987,"accepted":21.5}

--- a/tests/spoj/index/8.md
+++ b/tests/spoj/index/8.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 1421 | [Goods](https://www.spoj.com/problems/FIRM) | 148 | 30.65 |
+| 1431 | [Projections Of A Polygon](https://www.spoj.com/problems/KPPOLY) | 122 | 10.39 |
+| 1433 | [The Sum](https://www.spoj.com/problems/KPSUM) | 310 | 17.68 |
+| 1434 | [Equation](https://www.spoj.com/problems/KPEQU) | 421 | 33.46 |
+| 1435 | [Vertex Cover](https://www.spoj.com/problems/PT07X) | 4155 | 34.36 |
+| 1436 | [Is it a tree](https://www.spoj.com/problems/PT07Y) | 21129 | 35.30 |
+| 1437 | [Longest path in a tree](https://www.spoj.com/problems/PT07Z) | 20160 | 39.55 |
+| 1440 | [Use of Function Arctan](https://www.spoj.com/problems/ARCTAN) | 543 | 29.24 |
+| 1441 | [The Clever Typist](https://www.spoj.com/problems/CLEVER) | 34 | 8.28 |
+| 1442 | [Strange Food Chain](https://www.spoj.com/problems/CHAIN) | 950 | 19.73 |
+| 1444 | [DEL Command II](https://www.spoj.com/problems/DELCOMM2) | 41 | 9.82 |
+| 1447 | [A Game of Toy Bricks](https://www.spoj.com/problems/BRCKGAME) | 42 | 27.12 |
+| 1448 | [3D Cover](https://www.spoj.com/problems/COVER2) | 100 | 27.12 |
+| 1451 | [01 Sequence](https://www.spoj.com/problems/SEQ1) | 99 | 28.74 |
+| 1452 | [Birthday Cake](https://www.spoj.com/problems/CAKE) | 109 | 26.35 |
+| 1453 | [Optimal Connected Subset](https://www.spoj.com/problems/OPTSUB) | 159 | 47.19 |
+| 1454 | [Memory Distribution](https://www.spoj.com/problems/MEMDIS) | 27 | 18.00 |
+| 1455 | [Program Analyser](https://www.spoj.com/problems/ANALYSER) | 29 | 14.57 |
+| 1456 | [The Secret of a Lost City](https://www.spoj.com/problems/LOSTCT) | 23 | 24.17 |
+| 1457 | [Help Blue Mary Please! (Act I)](https://www.spoj.com/problems/BLUEEQ) | 13 | 1.74 |
+| 1458 | [Help Blue Mary Please! (Act II)](https://www.spoj.com/problems/BLUEEQ2) | 85 | 17.83 |
+| 1459 | [The Secret of an Aerolite](https://www.spoj.com/problems/AEROLITE) | 265 | 43.62 |
+| 1460 | [A Simple Calculator in the Galaxy](https://www.spoj.com/problems/GALAXY) | 35 | 37.96 |
+| 1461 | [Greedy Hydra](https://www.spoj.com/problems/DRAGON) | 196 | 33.33 |
+| 1462 | [Barbarians](https://www.spoj.com/problems/BARB) | 56 | 15.42 |
+| 1463 | [Robot Number M](https://www.spoj.com/problems/ROBOT) | 80 | 46.91 |
+| 1464 | [Editor II](https://www.spoj.com/problems/EDIT3) | 65 | 18.83 |
+| 1465 | [On the Way to Find Chris](https://www.spoj.com/problems/CHRIS) | 62 | 15.35 |
+| 1466 | [Blue Mary Needs Help Again](https://www.spoj.com/problems/CASHIER) | 226 | 20.82 |
+| 1468 | [Outside it is now raining](https://www.spoj.com/problems/RAIN2) | 32 | 23.33 |
+| 1470 | [Another Sequence Problem](https://www.spoj.com/problems/SEQ2) | 197 | 24.56 |
+| 1471 | [A Game of Pearls](https://www.spoj.com/problems/PRLGAME) | 45 | 30.86 |
+| 1472 | [Tom and Jerry](https://www.spoj.com/problems/TOMJERRY) | 67 | 38.12 |
+| 1473 | [Lemon Tree in the Moonlight](https://www.spoj.com/problems/LEMON) | 28 | 19.74 |
+| 1475 | [Play with Digit Seven](https://www.spoj.com/problems/WORMS) | 136 | 38.22 |
+| 1476 | [Maximum Profit](https://www.spoj.com/problems/PROFIT) | 372 | 32.30 |
+| 1477 | [Play with a Tree](https://www.spoj.com/problems/PT07A) | 95 | 15.49 |
+| 1478 | [The Easiest Problem](https://www.spoj.com/problems/PT07B) | 75 | 9.20 |
+| 1479 | [The GbAaY Kingdom](https://www.spoj.com/problems/PT07C) | 136 | 19.18 |
+| 1480 | [Let us count 1 2 3](https://www.spoj.com/problems/PT07D) | 94 | 16.28 |
+| 1482 | [A short vacation in Disneyland](https://www.spoj.com/problems/PT07F) | 236 | 14.80 |
+| 1483 | [Colorful Lights Party](https://www.spoj.com/problems/PT07G) | 13 | 10.22 |
+| 1484 | [Search in XML](https://www.spoj.com/problems/PT07H) | 20 | 3.07 |
+| 1487 | [Query on a tree III](https://www.spoj.com/problems/PT07J) | 586 | 18.62 |
+| 1505 | [Whac-a-Mole](https://www.spoj.com/problems/MOLE) | 44 | 16.67 |
+| 1526 | [Ranklist Sorting](https://www.spoj.com/problems/RSORTING) | 28 | 13.10 |
+| 1536 | [Help Blue Mary Please! (Act III)](https://www.spoj.com/problems/BLUEEQ3) | 30 | 14.42 |
+| 1538 | [Making Jumps](https://www.spoj.com/problems/MKJUMPS) | 1466 | 38.91 |
+| 1552 | [Mobiles](https://www.spoj.com/problems/MOBILE2) | 192 | 28.32 |
+| 1553 | [Backup Files](https://www.spoj.com/problems/BACKUP) | 987 | 21.50 |

--- a/tests/spoj/index/9.jsonl
+++ b/tests/spoj/index/9.jsonl
@@ -1,0 +1,50 @@
+{"id":1554,"name":"Zoo","url":"https://www.spoj.com/problems/ZOO","users":115,"accepted":28.6}
+{"id":1557,"name":"Can you answer these queries II","url":"https://www.spoj.com/problems/GSS2","users":1782,"accepted":25.03}
+{"id":1644,"name":"Trees","url":"https://www.spoj.com/problems/TREEOI14","users":39,"accepted":14.13}
+{"id":1671,"name":"Another Mathematical Problem","url":"https://www.spoj.com/problems/AMATH","users":69,"accepted":12.36}
+{"id":1672,"name":"The Great Indian Wedding","url":"https://www.spoj.com/problems/GIWED","users":52,"accepted":26.03}
+{"id":1673,"name":"Ambitious Manager","url":"https://www.spoj.com/problems/AMBM","users":464,"accepted":36.31}
+{"id":1674,"name":"The Explosion","url":"https://www.spoj.com/problems/EXPLOSN","users":159,"accepted":24.04}
+{"id":1675,"name":"Fusion Cube","url":"https://www.spoj.com/problems/FUSION","users":87,"accepted":50.77}
+{"id":1676,"name":"Text Generator","url":"https://www.spoj.com/problems/GEN","users":260,"accepted":21.88}
+{"id":1677,"name":"Halloween treats","url":"https://www.spoj.com/problems/HALLOW","users":1008,"accepted":39.32}
+{"id":1678,"name":"Royal Treasury","url":"https://www.spoj.com/problems/TREASURY","users":74,"accepted":11.36}
+{"id":1681,"name":"Cylinder","url":"https://www.spoj.com/problems/CYLINDER","users":927,"accepted":38.24}
+{"id":1683,"name":"Expressions","url":"https://www.spoj.com/problems/EXPRESS","users":359,"accepted":40}
+{"id":1684,"name":"Frequent values","url":"https://www.spoj.com/problems/FREQUENT","users":3990,"accepted":27.65}
+{"id":1685,"name":"Grocery store","url":"https://www.spoj.com/problems/GROCERY","users":202,"accepted":24.26}
+{"id":1687,"name":"Logic II","url":"https://www.spoj.com/problems/LOGIC2","users":36,"accepted":17.65}
+{"id":1688,"name":"A Very Easy Problem!","url":"https://www.spoj.com/problems/EASYPROB","users":6171,"accepted":49.09}
+{"id":1689,"name":"Hard Problem","url":"https://www.spoj.com/problems/HARDP","users":19,"accepted":26.67}
+{"id":1693,"name":"Coconuts","url":"https://www.spoj.com/problems/COCONUTS","users":965,"accepted":29.86}
+{"id":1695,"name":"Grandpa’s Rubik Cube","url":"https://www.spoj.com/problems/GRC","users":111,"accepted":60.94}
+{"id":1696,"name":"Will Indiana Jones Get There","url":"https://www.spoj.com/problems/WIJGT","users":129,"accepted":27.69}
+{"id":1697,"name":"Ohgas' Fortune","url":"https://www.spoj.com/problems/OFORTUNE","users":715,"accepted":64.53}
+{"id":1698,"name":"Polygonal Line Search","url":"https://www.spoj.com/problems/PLSEARCH","users":164,"accepted":62.75}
+{"id":1699,"name":"Numeral System","url":"https://www.spoj.com/problems/NSYSTEM","users":2247,"accepted":67.36}
+{"id":1700,"name":"Traveling by Stagecoach","url":"https://www.spoj.com/problems/TRSTAGE","users":476,"accepted":39.35}
+{"id":1701,"name":"Earth Observation with a Mobile Robot Team","url":"https://www.spoj.com/problems/EOWAMRT","users":14,"accepted":40.54}
+{"id":1702,"name":"Cleaning Robot","url":"https://www.spoj.com/problems/CLEANRBT","users":1592,"accepted":34.21}
+{"id":1703,"name":"ACM (ACronymMaker)","url":"https://www.spoj.com/problems/ACMAKER","users":1097,"accepted":29.71}
+{"id":1704,"name":"Countdown","url":"https://www.spoj.com/problems/CDOWN","users":306,"accepted":25.66}
+{"id":1705,"name":"The Game of Efil","url":"https://www.spoj.com/problems/GAMEFIL","users":91,"accepted":50}
+{"id":1706,"name":"Queens, Knights and Pawns","url":"https://www.spoj.com/problems/QKP","users":854,"accepted":32.96}
+{"id":1707,"name":"Reliable Nets","url":"https://www.spoj.com/problems/RELINETS","users":342,"accepted":31.53}
+{"id":1708,"name":"Square Count","url":"https://www.spoj.com/problems/SQCOUNT","users":75,"accepted":30.98}
+{"id":1709,"name":"Swamp Things","url":"https://www.spoj.com/problems/SWTHIN","users":290,"accepted":40.4}
+{"id":1710,"name":"Two Ends","url":"https://www.spoj.com/problems/TWENDS","users":3787,"accepted":41.58}
+{"id":1712,"name":"Permalex","url":"https://www.spoj.com/problems/PRMLX","users":174,"accepted":19.5}
+{"id":1713,"name":"Funny scales","url":"https://www.spoj.com/problems/SCALE","users":563,"accepted":30.57}
+{"id":1715,"name":"Another Necklace Problem","url":"https://www.spoj.com/problems/NCKLCE","users":52,"accepted":18.42}
+{"id":1716,"name":"Can you answer these queries III","url":"https://www.spoj.com/problems/GSS3","users":12096,"accepted":43.8}
+{"id":1722,"name":"Life, the Universe, and Everything II","url":"https://www.spoj.com/problems/RP","users":68,"accepted":28.49}
+{"id":1723,"name":"Bee Maja","url":"https://www.spoj.com/problems/BMJ","users":561,"accepted":53.62}
+{"id":1724,"name":"Counting Triangles","url":"https://www.spoj.com/problems/TRICOUNT","users":13197,"accepted":34}
+{"id":1725,"name":"The Importance","url":"https://www.spoj.com/problems/IMPORT1","users":101,"accepted":38.54}
+{"id":1726,"name":"Exchange","url":"https://www.spoj.com/problems/EXCHANGE","users":24,"accepted":7.92}
+{"id":1728,"name":"Common Permutation","url":"https://www.spoj.com/problems/CPRMT","users":4199,"accepted":46.7}
+{"id":1730,"name":"Counting Triangles II","url":"https://www.spoj.com/problems/TCOUNT2","users":404,"accepted":20.83}
+{"id":1731,"name":"Counting Triangles III","url":"https://www.spoj.com/problems/TCOUNT3","users":266,"accepted":33.78}
+{"id":1739,"name":"Yet Another Equation","url":"https://www.spoj.com/problems/EQU2","users":236,"accepted":41.45}
+{"id":1741,"name":"Tetris 3D","url":"https://www.spoj.com/problems/TETRIS3D","users":189,"accepted":32.59}
+{"id":1744,"name":"Evaluate the polynomial","url":"https://www.spoj.com/problems/POLEVAL","users":2638,"accepted":48.77}

--- a/tests/spoj/index/9.md
+++ b/tests/spoj/index/9.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 1554 | [Zoo](https://www.spoj.com/problems/ZOO) | 115 | 28.60 |
+| 1557 | [Can you answer these queries II](https://www.spoj.com/problems/GSS2) | 1782 | 25.03 |
+| 1644 | [Trees](https://www.spoj.com/problems/TREEOI14) | 39 | 14.13 |
+| 1671 | [Another Mathematical Problem](https://www.spoj.com/problems/AMATH) | 69 | 12.36 |
+| 1672 | [The Great Indian Wedding](https://www.spoj.com/problems/GIWED) | 52 | 26.03 |
+| 1673 | [Ambitious Manager](https://www.spoj.com/problems/AMBM) | 464 | 36.31 |
+| 1674 | [The Explosion](https://www.spoj.com/problems/EXPLOSN) | 159 | 24.04 |
+| 1675 | [Fusion Cube](https://www.spoj.com/problems/FUSION) | 87 | 50.77 |
+| 1676 | [Text Generator](https://www.spoj.com/problems/GEN) | 260 | 21.88 |
+| 1677 | [Halloween treats](https://www.spoj.com/problems/HALLOW) | 1008 | 39.32 |
+| 1678 | [Royal Treasury](https://www.spoj.com/problems/TREASURY) | 74 | 11.36 |
+| 1681 | [Cylinder](https://www.spoj.com/problems/CYLINDER) | 927 | 38.24 |
+| 1683 | [Expressions](https://www.spoj.com/problems/EXPRESS) | 359 | 40.00 |
+| 1684 | [Frequent values](https://www.spoj.com/problems/FREQUENT) | 3990 | 27.65 |
+| 1685 | [Grocery store](https://www.spoj.com/problems/GROCERY) | 202 | 24.26 |
+| 1687 | [Logic II](https://www.spoj.com/problems/LOGIC2) | 36 | 17.65 |
+| 1688 | [A Very Easy Problem!](https://www.spoj.com/problems/EASYPROB) | 6171 | 49.09 |
+| 1689 | [Hard Problem](https://www.spoj.com/problems/HARDP) | 19 | 26.67 |
+| 1693 | [Coconuts](https://www.spoj.com/problems/COCONUTS) | 965 | 29.86 |
+| 1695 | [Grandpa’s Rubik Cube](https://www.spoj.com/problems/GRC) | 111 | 60.94 |
+| 1696 | [Will Indiana Jones Get There](https://www.spoj.com/problems/WIJGT) | 129 | 27.69 |
+| 1697 | [Ohgas' Fortune](https://www.spoj.com/problems/OFORTUNE) | 715 | 64.53 |
+| 1698 | [Polygonal Line Search](https://www.spoj.com/problems/PLSEARCH) | 164 | 62.75 |
+| 1699 | [Numeral System](https://www.spoj.com/problems/NSYSTEM) | 2247 | 67.36 |
+| 1700 | [Traveling by Stagecoach](https://www.spoj.com/problems/TRSTAGE) | 476 | 39.35 |
+| 1701 | [Earth Observation with a Mobile Robot Team](https://www.spoj.com/problems/EOWAMRT) | 14 | 40.54 |
+| 1702 | [Cleaning Robot](https://www.spoj.com/problems/CLEANRBT) | 1592 | 34.21 |
+| 1703 | [ACM (ACronymMaker)](https://www.spoj.com/problems/ACMAKER) | 1097 | 29.71 |
+| 1704 | [Countdown](https://www.spoj.com/problems/CDOWN) | 306 | 25.66 |
+| 1705 | [The Game of Efil](https://www.spoj.com/problems/GAMEFIL) | 91 | 50.00 |
+| 1706 | [Queens, Knights and Pawns](https://www.spoj.com/problems/QKP) | 854 | 32.96 |
+| 1707 | [Reliable Nets](https://www.spoj.com/problems/RELINETS) | 342 | 31.53 |
+| 1708 | [Square Count](https://www.spoj.com/problems/SQCOUNT) | 75 | 30.98 |
+| 1709 | [Swamp Things](https://www.spoj.com/problems/SWTHIN) | 290 | 40.40 |
+| 1710 | [Two Ends](https://www.spoj.com/problems/TWENDS) | 3787 | 41.58 |
+| 1712 | [Permalex](https://www.spoj.com/problems/PRMLX) | 174 | 19.50 |
+| 1713 | [Funny scales](https://www.spoj.com/problems/SCALE) | 563 | 30.57 |
+| 1715 | [Another Necklace Problem](https://www.spoj.com/problems/NCKLCE) | 52 | 18.42 |
+| 1716 | [Can you answer these queries III](https://www.spoj.com/problems/GSS3) | 12096 | 43.80 |
+| 1722 | [Life, the Universe, and Everything II](https://www.spoj.com/problems/RP) | 68 | 28.49 |
+| 1723 | [Bee Maja](https://www.spoj.com/problems/BMJ) | 561 | 53.62 |
+| 1724 | [Counting Triangles](https://www.spoj.com/problems/TRICOUNT) | 13197 | 34.00 |
+| 1725 | [The Importance](https://www.spoj.com/problems/IMPORT1) | 101 | 38.54 |
+| 1726 | [Exchange](https://www.spoj.com/problems/EXCHANGE) | 24 | 7.92 |
+| 1728 | [Common Permutation](https://www.spoj.com/problems/CPRMT) | 4199 | 46.70 |
+| 1730 | [Counting Triangles II](https://www.spoj.com/problems/TCOUNT2) | 404 | 20.83 |
+| 1731 | [Counting Triangles III](https://www.spoj.com/problems/TCOUNT3) | 266 | 33.78 |
+| 1739 | [Yet Another Equation](https://www.spoj.com/problems/EQU2) | 236 | 41.45 |
+| 1741 | [Tetris 3D](https://www.spoj.com/problems/TETRIS3D) | 189 | 32.59 |
+| 1744 | [Evaluate the polynomial](https://www.spoj.com/problems/POLEVAL) | 2638 | 48.77 |


### PR DESCRIPTION
## Summary
- Downloaded SPOJ problem listings for pages 2–10 using the existing `List` helper.
- Stored markdown and JSONL files under `tests/spoj/index` for these pages.

## Testing
- `go test ./tools/spoj -run TestListAndDownload -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68ad67b9eb808320bddb751017a8790e