### PR TITLE
feat(spoj): add Mochi solution for HASHIT

### DIFF
--- a/tests/spoj/human/x/mochi/29.in
+++ b/tests/spoj/human/x/mochi/29.in
@@ -1,0 +1,13 @@
+1
+11
+ADD:marsz
+ADD:marsz
+ADD:Dabrowski
+ADD:z
+ADD:ziemii
+ADD:wloskiej
+ADD:do
+ADD:Polski
+DEL:od
+DEL:do
+DEL:wloskiej

--- a/tests/spoj/human/x/mochi/29.md
+++ b/tests/spoj/human/x/mochi/29.md
@@ -1,0 +1,27 @@
+# [Hash it!](https://www.spoj.com/problems/HASHIT/)
+
+## Problem Summary
+Maintain a hash table of 101 slots that stores string keys (up to 15 letters).
+For each test case, process up to 1000 operations of the form `ADD:key` or
+`DEL:key`. The hash function is
+
+`hash(key) = (19 * sum_{i=1..n} ASCII(key[i]) * i) mod 101`.
+
+Collisions are resolved by probing indices
+`(hash + j^2 + 23*j) mod 101` for `j = 0..19`.  Ignore attempts to insert
+a key that already exists and deletions of absent keys.  After all operations,
+output the number of stored keys and each `index:key` pair in ascending index
+order.
+
+## Algorithm
+1. Implement `ord` to convert letters and `_` to their ASCII codes.
+2. Compute `hash(key)` using the given formula.
+3. To search for a key, probe up to 20 positions using the quadratic sequence.
+4. For `ADD`, first check whether the key already exists; if not, insert it at
+   the first empty probed slot.
+5. For `DEL`, locate the key using probing and mark the slot as empty.
+6. After processing all operations, count and print non-empty slots followed by
+each `index:key` pair sorted by index.
+
+This approach keeps operations `O(1)` on average while following the specified
+probing strategy.

--- a/tests/spoj/human/x/mochi/29.mochi
+++ b/tests/spoj/human/x/mochi/29.mochi
@@ -1,0 +1,129 @@
+// Solution for SPOJ HASHIT - Hash it!
+// https://www.spoj.com/problems/HASHIT/
+
+fun split(s: string, sep: string): list<string> {
+  var parts: list<string> = []
+  var cur: string = ""
+  var i: int = 0
+  while i < len(s) {
+    if len(sep) > 0 && i + len(sep) <= len(s) && substring(s, i, i + len(sep)) == sep {
+      parts = append(parts, cur)
+      cur = ""
+      i = i + len(sep)
+    } else {
+      cur = cur + s[i:i+1]
+      i = i + 1
+    }
+  }
+  parts = append(parts, cur)
+  return parts
+}
+
+fun buildASCII(): map<string,int> {
+  var m: map<string,int> = {}
+  let upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  var i = 0
+  while i < len(upper) {
+    m[upper[i:i+1]] = 65 + i
+    i = i + 1
+  }
+  let lower = "abcdefghijklmnopqrstuvwxyz"
+  i = 0
+  while i < len(lower) {
+    m[lower[i:i+1]] = 97 + i
+    i = i + 1
+  }
+  m["_"] = 95
+  return m
+}
+let ascii = buildASCII()
+
+fun ord(ch: string): int { return ascii[ch] as int }
+
+fun hashKey(key: string): int {
+  var sum = 0
+  var i = 0
+  while i < len(key) {
+    sum = sum + ord(key[i:i+1]) * (i + 1)
+    i = i + 1
+  }
+  return (19 * sum) % 101
+}
+
+fun findIndex(table: list<string>, key: string): int {
+  let h = hashKey(key)
+  var j = 0
+  while j < 20 {
+    let idx = (h + j*j + 23*j) % 101
+    if table[idx] == key { return idx }
+    j = j + 1
+  }
+  return 0 - 1
+}
+
+fun insert(table: list<string>, key: string): list<string> {
+  if findIndex(table, key) != 0 - 1 { return table }
+  let h = hashKey(key)
+  var j = 0
+  while j < 20 {
+    let idx = (h + j*j + 23*j) % 101
+    if table[idx] == "" {
+      table[idx] = key
+      break
+    }
+    j = j + 1
+  }
+  return table
+}
+
+fun deleteKey(table: list<string>, key: string): list<string> {
+  let idx = findIndex(table, key)
+  if idx != 0 - 1 { table[idx] = "" }
+  return table
+}
+
+fun main() {
+  let tLine = input()
+  if tLine == "" { return }
+  let t = tLine as int
+  var case = 0
+  while case < t {
+    let n = input() as int
+    var table: list<string> = []
+    var k = 0
+    while k < 101 {
+      table = append(table, "")
+      k = k + 1
+    }
+    var i = 0
+    while i < n {
+      let line = input()
+      let parts = split(line, ":")
+      let action = parts[0]
+      let key = parts[1]
+      if action == "ADD" {
+        table = insert(table, key)
+      } else if action == "DEL" {
+        table = deleteKey(table, key)
+      }
+      i = i + 1
+    }
+    var count = 0
+    k = 0
+    while k < 101 {
+      if table[k] != "" { count = count + 1 }
+      k = k + 1
+    }
+    print(str(count))
+    k = 0
+    while k < 101 {
+      if table[k] != "" {
+        print(str(k) + ":" + table[k])
+      }
+      k = k + 1
+    }
+    case = case + 1
+  }
+}
+
+main()

--- a/tests/spoj/human/x/mochi/29.out
+++ b/tests/spoj/human/x/mochi/29.out
@@ -1,0 +1,6 @@
+5
+34:Dabrowski
+46:Polski
+63:marsz
+76:ziemii
+96:z


### PR DESCRIPTION
## Summary
- add Mochi implementation for SPOJ problem HASHIT using custom ASCII hashing and quadratic probing
- document algorithm and provide sample input/output tests

## Testing
- `go test ./tests/spoj/human -run TestMochiSolutions/29 -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_68ad67517a60832087f78cd536853a23