### PR TITLE
Add SPOJ problem index pages 11-30

### DIFF
--- a/tests/spoj/index/11.jsonl
+++ b/tests/spoj/index/11.jsonl
@@ -1,0 +1,50 @@
+{"id":1875,"name":"Cool Numbers","url":"https://www.spoj.com/problems/COOLNUMS","users":168,"accepted":30.21}
+{"id":1876,"name":"Dragon Curves","url":"https://www.spoj.com/problems/DRAGONCU","users":176,"accepted":50.23}
+{"id":1877,"name":"Enrich my purse","url":"https://www.spoj.com/problems/EPURSE","users":153,"accepted":27.01}
+{"id":1878,"name":"Farmers Cattle","url":"https://www.spoj.com/problems/FCATTLE","users":57,"accepted":36.89}
+{"id":1879,"name":"Game Time","url":"https://www.spoj.com/problems/GAMETIME","users":101,"accepted":22.17}
+{"id":1880,"name":"Hanoi Calls","url":"https://www.spoj.com/problems/HANOICAL","users":205,"accepted":54.44}
+{"id":1881,"name":"Instruction Decoder","url":"https://www.spoj.com/problems/ICODER","users":668,"accepted":50.81}
+{"id":1960,"name":"Rectangles","url":"https://www.spoj.com/problems/RECTANGL","users":173,"accepted":16.61}
+{"id":1961,"name":"Roman Roads","url":"https://www.spoj.com/problems/ROMANRDS","users":103,"accepted":31.59}
+{"id":1962,"name":"Circles","url":"https://www.spoj.com/problems/CIRCLES","users":62,"accepted":20.12}
+{"id":1963,"name":"Image Projections","url":"https://www.spoj.com/problems/IMGPROJ","users":109,"accepted":34.26}
+{"id":1964,"name":"Tree cut","url":"https://www.spoj.com/problems/MMCUT","users":149,"accepted":38.1}
+{"id":1965,"name":"Set Cover","url":"https://www.spoj.com/problems/SETCOV","users":25,"accepted":10.92}
+{"id":1966,"name":"Ski Valley","url":"https://www.spoj.com/problems/SKIVALL","users":117,"accepted":18.43}
+{"id":1991,"name":"Another Continuous Fractions Problem","url":"https://www.spoj.com/problems/ACFRAC","users":84,"accepted":19.97}
+{"id":2000,"name":"Boxes (Hard)","url":"https://www.spoj.com/problems/BOX","users":17,"accepted":2.95}
+{"id":2002,"name":"Random Number Generator","url":"https://www.spoj.com/problems/RNG","users":98,"accepted":40.62}
+{"id":2005,"name":"Minus Operation","url":"https://www.spoj.com/problems/MINUS","users":307,"accepted":33.47}
+{"id":2006,"name":"Load Balancing","url":"https://www.spoj.com/problems/BALIFE","users":1910,"accepted":47.55}
+{"id":2007,"name":"Another Very Easy Problem! WOW!!!","url":"https://www.spoj.com/problems/COUNT","users":792,"accepted":39.13}
+{"id":2008,"name":"Dab of Backpack","url":"https://www.spoj.com/problems/BACKPACK","users":674,"accepted":23.8}
+{"id":2009,"name":"Cryptography","url":"https://www.spoj.com/problems/CRYPTO","users":142,"accepted":4.79}
+{"id":2019,"name":"The Rolling Ball","url":"https://www.spoj.com/problems/ROLLBALL","users":4,"accepted":5.48}
+{"id":2022,"name":"Truth Or Lie","url":"https://www.spoj.com/problems/TRUTHORL","users":104,"accepted":21.17}
+{"id":2023,"name":"One Instruction Computer Simulator","url":"https://www.spoj.com/problems/ONEINSTR","users":47,"accepted":10.58}
+{"id":2031,"name":"Please help You-Know-Who","url":"https://www.spoj.com/problems/YKH","users":39,"accepted":28.65}
+{"id":2038,"name":"Rectangle Tiling","url":"https://www.spoj.com/problems/TILING","users":116,"accepted":41.61}
+{"id":2047,"name":"Stone Removing Game","url":"https://www.spoj.com/problems/REMGAME","users":133,"accepted":37.96}
+{"id":2050,"name":"Strange Billboard","url":"https://www.spoj.com/problems/CERC07B","users":805,"accepted":60.55}
+{"id":2051,"name":"Cell Phone","url":"https://www.spoj.com/problems/CERC07C","users":161,"accepted":31.43}
+{"id":2052,"name":"Hexagonal Parcels","url":"https://www.spoj.com/problems/CERC07H","users":76,"accepted":28.93}
+{"id":2053,"name":"Key Task","url":"https://www.spoj.com/problems/CERC07K","users":1188,"accepted":31.78}
+{"id":2054,"name":"Gates of Logic","url":"https://www.spoj.com/problems/CERC07L","users":37,"accepted":22.91}
+{"id":2055,"name":"Weird Numbers","url":"https://www.spoj.com/problems/CERC07N","users":346,"accepted":35.99}
+{"id":2056,"name":"Rectangular Polygon","url":"https://www.spoj.com/problems/CERC07P","users":135,"accepted":48.12}
+{"id":2058,"name":"Reaux! Sham! Beaux!","url":"https://www.spoj.com/problems/CERC07R","users":664,"accepted":32.9}
+{"id":2059,"name":"Robotic Sort","url":"https://www.spoj.com/problems/CERC07S","users":736,"accepted":33.1}
+{"id":2060,"name":"Tough Water Level","url":"https://www.spoj.com/problems/CERC07W","users":36,"accepted":18.21}
+{"id":2070,"name":"Minimum Distance","url":"https://www.spoj.com/problems/MINDIST","users":86,"accepted":16.85}
+{"id":2123,"name":"Candy I","url":"https://www.spoj.com/problems/CANDY","users":29111,"accepted":44.22}
+{"id":2124,"name":"Last Non-Zero Digit of Factorials","url":"https://www.spoj.com/problems/FCTRL4","users":488,"accepted":25.49}
+{"id":2125,"name":"Number Labyrinth","url":"https://www.spoj.com/problems/LABYR2","users":64,"accepted":25.55}
+{"id":2127,"name":"Rain","url":"https://www.spoj.com/problems/RAIN3","users":438,"accepted":40.61}
+{"id":2128,"name":"K-In-A-Row","url":"https://www.spoj.com/problems/KROW","users":446,"accepted":33.76}
+{"id":2129,"name":"Cake","url":"https://www.spoj.com/problems/CAKE2","users":70,"accepted":21.59}
+{"id":2130,"name":"Trolls","url":"https://www.spoj.com/problems/TROLLS","users":29,"accepted":39.19}
+{"id":2131,"name":"Get Back!","url":"https://www.spoj.com/problems/GETBACK","users":55,"accepted":40.67}
+{"id":2132,"name":"Puzzle","url":"https://www.spoj.com/problems/PUZZLE2","users":89,"accepted":32.68}
+{"id":2136,"name":"Candy II","url":"https://www.spoj.com/problems/CANDY2","users":613,"accepted":46}
+{"id":2138,"name":"Pibonacci","url":"https://www.spoj.com/problems/PIB","users":48,"accepted":14.11}

--- a/tests/spoj/index/11.md
+++ b/tests/spoj/index/11.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 1875 | [Cool Numbers](https://www.spoj.com/problems/COOLNUMS) | 168 | 30.21 |
+| 1876 | [Dragon Curves](https://www.spoj.com/problems/DRAGONCU) | 176 | 50.23 |
+| 1877 | [Enrich my purse](https://www.spoj.com/problems/EPURSE) | 153 | 27.01 |
+| 1878 | [Farmers Cattle](https://www.spoj.com/problems/FCATTLE) | 57 | 36.89 |
+| 1879 | [Game Time](https://www.spoj.com/problems/GAMETIME) | 101 | 22.17 |
+| 1880 | [Hanoi Calls](https://www.spoj.com/problems/HANOICAL) | 205 | 54.44 |
+| 1881 | [Instruction Decoder](https://www.spoj.com/problems/ICODER) | 668 | 50.81 |
+| 1960 | [Rectangles](https://www.spoj.com/problems/RECTANGL) | 173 | 16.61 |
+| 1961 | [Roman Roads](https://www.spoj.com/problems/ROMANRDS) | 103 | 31.59 |
+| 1962 | [Circles](https://www.spoj.com/problems/CIRCLES) | 62 | 20.12 |
+| 1963 | [Image Projections](https://www.spoj.com/problems/IMGPROJ) | 109 | 34.26 |
+| 1964 | [Tree cut](https://www.spoj.com/problems/MMCUT) | 149 | 38.10 |
+| 1965 | [Set Cover](https://www.spoj.com/problems/SETCOV) | 25 | 10.92 |
+| 1966 | [Ski Valley](https://www.spoj.com/problems/SKIVALL) | 117 | 18.43 |
+| 1991 | [Another Continuous Fractions Problem](https://www.spoj.com/problems/ACFRAC) | 84 | 19.97 |
+| 2000 | [Boxes (Hard)](https://www.spoj.com/problems/BOX) | 17 | 2.95 |
+| 2002 | [Random Number Generator](https://www.spoj.com/problems/RNG) | 98 | 40.62 |
+| 2005 | [Minus Operation](https://www.spoj.com/problems/MINUS) | 307 | 33.47 |
+| 2006 | [Load Balancing](https://www.spoj.com/problems/BALIFE) | 1910 | 47.55 |
+| 2007 | [Another Very Easy Problem! WOW!!!](https://www.spoj.com/problems/COUNT) | 792 | 39.13 |
+| 2008 | [Dab of Backpack](https://www.spoj.com/problems/BACKPACK) | 674 | 23.80 |
+| 2009 | [Cryptography](https://www.spoj.com/problems/CRYPTO) | 142 | 4.79 |
+| 2019 | [The Rolling Ball](https://www.spoj.com/problems/ROLLBALL) | 4 | 5.48 |
+| 2022 | [Truth Or Lie](https://www.spoj.com/problems/TRUTHORL) | 104 | 21.17 |
+| 2023 | [One Instruction Computer Simulator](https://www.spoj.com/problems/ONEINSTR) | 47 | 10.58 |
+| 2031 | [Please help You-Know-Who](https://www.spoj.com/problems/YKH) | 39 | 28.65 |
+| 2038 | [Rectangle Tiling](https://www.spoj.com/problems/TILING) | 116 | 41.61 |
+| 2047 | [Stone Removing Game](https://www.spoj.com/problems/REMGAME) | 133 | 37.96 |
+| 2050 | [Strange Billboard](https://www.spoj.com/problems/CERC07B) | 805 | 60.55 |
+| 2051 | [Cell Phone](https://www.spoj.com/problems/CERC07C) | 161 | 31.43 |
+| 2052 | [Hexagonal Parcels](https://www.spoj.com/problems/CERC07H) | 76 | 28.93 |
+| 2053 | [Key Task](https://www.spoj.com/problems/CERC07K) | 1188 | 31.78 |
+| 2054 | [Gates of Logic](https://www.spoj.com/problems/CERC07L) | 37 | 22.91 |
+| 2055 | [Weird Numbers](https://www.spoj.com/problems/CERC07N) | 346 | 35.99 |
+| 2056 | [Rectangular Polygon](https://www.spoj.com/problems/CERC07P) | 135 | 48.12 |
+| 2058 | [Reaux! Sham! Beaux!](https://www.spoj.com/problems/CERC07R) | 664 | 32.90 |
+| 2059 | [Robotic Sort](https://www.spoj.com/problems/CERC07S) | 736 | 33.10 |
+| 2060 | [Tough Water Level](https://www.spoj.com/problems/CERC07W) | 36 | 18.21 |
+| 2070 | [Minimum Distance](https://www.spoj.com/problems/MINDIST) | 86 | 16.85 |
+| 2123 | [Candy I](https://www.spoj.com/problems/CANDY) | 29111 | 44.22 |
+| 2124 | [Last Non-Zero Digit of Factorials](https://www.spoj.com/problems/FCTRL4) | 488 | 25.49 |
+| 2125 | [Number Labyrinth](https://www.spoj.com/problems/LABYR2) | 64 | 25.55 |
+| 2127 | [Rain](https://www.spoj.com/problems/RAIN3) | 438 | 40.61 |
+| 2128 | [K-In-A-Row](https://www.spoj.com/problems/KROW) | 446 | 33.76 |
+| 2129 | [Cake](https://www.spoj.com/problems/CAKE2) | 70 | 21.59 |
+| 2130 | [Trolls](https://www.spoj.com/problems/TROLLS) | 29 | 39.19 |
+| 2131 | [Get Back!](https://www.spoj.com/problems/GETBACK) | 55 | 40.67 |
+| 2132 | [Puzzle](https://www.spoj.com/problems/PUZZLE2) | 89 | 32.68 |
+| 2136 | [Candy II](https://www.spoj.com/problems/CANDY2) | 613 | 46.00 |
+| 2138 | [Pibonacci](https://www.spoj.com/problems/PIB) | 48 | 14.11 |

--- a/tests/spoj/index/12.jsonl
+++ b/tests/spoj/index/12.jsonl
@@ -1,0 +1,50 @@
+{"id":2139,"name":"Gossipers","url":"https://www.spoj.com/problems/GOSSIPER","users":602,"accepted":31.76}
+{"id":2140,"name":"(un)Fair Play","url":"https://www.spoj.com/problems/FAIRONOT","users":75,"accepted":38.08}
+{"id":2141,"name":"Golden Garden","url":"https://www.spoj.com/problems/GARDEN","users":17,"accepted":12.2}
+{"id":2142,"name":"Arranging Flowers","url":"https://www.spoj.com/problems/FLOWERS","users":25,"accepted":9.87}
+{"id":2143,"name":"Dependency Problems","url":"https://www.spoj.com/problems/DEPEND","users":521,"accepted":38.96}
+{"id":2144,"name":"K Edge-disjoint Branchings","url":"https://www.spoj.com/problems/FOREST","users":9,"accepted":12.39}
+{"id":2147,"name":"Root of a Linear Equation","url":"https://www.spoj.com/problems/ROOT","users":66,"accepted":8.9}
+{"id":2148,"name":"Candy III","url":"https://www.spoj.com/problems/CANDY3","users":20551,"accepted":25.33}
+{"id":2149,"name":"Biased Standings","url":"https://www.spoj.com/problems/BAISED","users":3676,"accepted":33.66}
+{"id":2150,"name":"Counting Subsequences","url":"https://www.spoj.com/problems/SUBSEQ","users":1031,"accepted":29.42}
+{"id":2151,"name":"Digital Calculator","url":"https://www.spoj.com/problems/CALCULAT","users":23,"accepted":5.69}
+{"id":2152,"name":"Hilbert Curve","url":"https://www.spoj.com/problems/FRACTAL","users":13,"accepted":16.29}
+{"id":2153,"name":"Internet is Faulty","url":"https://www.spoj.com/problems/IMATCH","users":69,"accepted":38.54}
+{"id":2154,"name":"Kruskal","url":"https://www.spoj.com/problems/KRUSKAL","users":85,"accepted":14.03}
+{"id":2157,"name":"Anti-Blot System","url":"https://www.spoj.com/problems/ABSYS","users":12965,"accepted":45.24}
+{"id":2159,"name":"Delicious Cake","url":"https://www.spoj.com/problems/CAKE3","users":30,"accepted":14.64}
+{"id":2160,"name":"Here-There","url":"https://www.spoj.com/problems/HERE","users":30,"accepted":24.76}
+{"id":2161,"name":"Pixel Shuffle","url":"https://www.spoj.com/problems/JPIX","users":34,"accepted":21.03}
+{"id":2162,"name":"Towers of Powers","url":"https://www.spoj.com/problems/TOWER","users":26,"accepted":13.87}
+{"id":2171,"name":"Ambiguous Codes","url":"https://www.spoj.com/problems/AMCODES","users":85,"accepted":39.47}
+{"id":2172,"name":"Ballroom Lights","url":"https://www.spoj.com/problems/BALLIGHT","users":35,"accepted":32.94}
+{"id":2173,"name":"Car Plates Competition","url":"https://www.spoj.com/problems/CPC","users":261,"accepted":42.05}
+{"id":2174,"name":"Drop the Triples","url":"https://www.spoj.com/problems/DTT","users":122,"accepted":29.04}
+{"id":2175,"name":"Emoticons","url":"https://www.spoj.com/problems/EMOTICON","users":332,"accepted":22.01}
+{"id":2176,"name":"Finding Seats","url":"https://www.spoj.com/problems/FSEATS","users":223,"accepted":14.99}
+{"id":2177,"name":"Galou is back!","url":"https://www.spoj.com/problems/GALOU","users":226,"accepted":31.01}
+{"id":2178,"name":"He is offside!","url":"https://www.spoj.com/problems/OFFSIDE","users":8446,"accepted":50.13}
+{"id":2179,"name":"ICPC Scoreboard","url":"https://www.spoj.com/problems/ICPCS","users":180,"accepted":29.76}
+{"id":2180,"name":"Justice League","url":"https://www.spoj.com/problems/JLEAGUE","users":83,"accepted":48.97}
+{"id":2185,"name":"Musical Optimization","url":"https://www.spoj.com/problems/MUSIC","users":73,"accepted":43.15}
+{"id":2189,"name":"Making Pairs","url":"https://www.spoj.com/problems/MKPAIRS","users":47,"accepted":15.9}
+{"id":2202,"name":"Tan and His Interesting Game","url":"https://www.spoj.com/problems/TAN1","users":46,"accepted":25.18}
+{"id":2270,"name":"Balloons in a Box","url":"https://www.spoj.com/problems/BALLOON","users":172,"accepted":23.77}
+{"id":2271,"name":"Undecodable Codes","url":"https://www.spoj.com/problems/UCODES","users":48,"accepted":12.27}
+{"id":2272,"name":"Crossing the Desert","url":"https://www.spoj.com/problems/DESERT","users":54,"accepted":20.12}
+{"id":2273,"name":"Ferries","url":"https://www.spoj.com/problems/FERRY","users":32,"accepted":18.75}
+{"id":2274,"name":"Island Hopping","url":"https://www.spoj.com/problems/ISLHOP","users":207,"accepted":25.14}
+{"id":2275,"name":"Toil for Oil","url":"https://www.spoj.com/problems/OIL","users":15,"accepted":28.65}
+{"id":2276,"name":"Partitions","url":"https://www.spoj.com/problems/RECTNG2","users":24,"accepted":13.02}
+{"id":2277,"name":"Silly Sort","url":"https://www.spoj.com/problems/SSORT","users":882,"accepted":55.45}
+{"id":2317,"name":"Bracket Sequence","url":"https://www.spoj.com/problems/LEXBRAC","users":57,"accepted":23.73}
+{"id":2318,"name":"Overlapping Words","url":"https://www.spoj.com/problems/WORDS","users":90,"accepted":22.4}
+{"id":2319,"name":"Sequence","url":"https://www.spoj.com/problems/BIGSEQ","users":218,"accepted":28.12}
+{"id":2320,"name":"Manhattan","url":"https://www.spoj.com/problems/DISTANCE","users":703,"accepted":32.39}
+{"id":2321,"name":"Segments","url":"https://www.spoj.com/problems/SEGMENTS","users":156,"accepted":13.93}
+{"id":2322,"name":"Tree Game","url":"https://www.spoj.com/problems/TREEGAME","users":325,"accepted":43.37}
+{"id":2323,"name":"Broken Compass","url":"https://www.spoj.com/problems/COMPASS","users":47,"accepted":13.78}
+{"id":2324,"name":"Mario","url":"https://www.spoj.com/problems/MARIOGAM","users":63,"accepted":14}
+{"id":2325,"name":"String Distance","url":"https://www.spoj.com/problems/STRDIST","users":214,"accepted":21.51}
+{"id":2371,"name":"Another Longest Increasing Subsequence Problem","url":"https://www.spoj.com/problems/LIS2","users":843,"accepted":13.68}

--- a/tests/spoj/index/12.md
+++ b/tests/spoj/index/12.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 2139 | [Gossipers](https://www.spoj.com/problems/GOSSIPER) | 602 | 31.76 |
+| 2140 | [(un)Fair Play](https://www.spoj.com/problems/FAIRONOT) | 75 | 38.08 |
+| 2141 | [Golden Garden](https://www.spoj.com/problems/GARDEN) | 17 | 12.20 |
+| 2142 | [Arranging Flowers](https://www.spoj.com/problems/FLOWERS) | 25 | 9.87 |
+| 2143 | [Dependency Problems](https://www.spoj.com/problems/DEPEND) | 521 | 38.96 |
+| 2144 | [K Edge-disjoint Branchings](https://www.spoj.com/problems/FOREST) | 9 | 12.39 |
+| 2147 | [Root of a Linear Equation](https://www.spoj.com/problems/ROOT) | 66 | 8.90 |
+| 2148 | [Candy III](https://www.spoj.com/problems/CANDY3) | 20551 | 25.33 |
+| 2149 | [Biased Standings](https://www.spoj.com/problems/BAISED) | 3676 | 33.66 |
+| 2150 | [Counting Subsequences](https://www.spoj.com/problems/SUBSEQ) | 1031 | 29.42 |
+| 2151 | [Digital Calculator](https://www.spoj.com/problems/CALCULAT) | 23 | 5.69 |
+| 2152 | [Hilbert Curve](https://www.spoj.com/problems/FRACTAL) | 13 | 16.29 |
+| 2153 | [Internet is Faulty](https://www.spoj.com/problems/IMATCH) | 69 | 38.54 |
+| 2154 | [Kruskal](https://www.spoj.com/problems/KRUSKAL) | 85 | 14.03 |
+| 2157 | [Anti-Blot System](https://www.spoj.com/problems/ABSYS) | 12965 | 45.24 |
+| 2159 | [Delicious Cake](https://www.spoj.com/problems/CAKE3) | 30 | 14.64 |
+| 2160 | [Here-There](https://www.spoj.com/problems/HERE) | 30 | 24.76 |
+| 2161 | [Pixel Shuffle](https://www.spoj.com/problems/JPIX) | 34 | 21.03 |
+| 2162 | [Towers of Powers](https://www.spoj.com/problems/TOWER) | 26 | 13.87 |
+| 2171 | [Ambiguous Codes](https://www.spoj.com/problems/AMCODES) | 85 | 39.47 |
+| 2172 | [Ballroom Lights](https://www.spoj.com/problems/BALLIGHT) | 35 | 32.94 |
+| 2173 | [Car Plates Competition](https://www.spoj.com/problems/CPC) | 261 | 42.05 |
+| 2174 | [Drop the Triples](https://www.spoj.com/problems/DTT) | 122 | 29.04 |
+| 2175 | [Emoticons](https://www.spoj.com/problems/EMOTICON) | 332 | 22.01 |
+| 2176 | [Finding Seats](https://www.spoj.com/problems/FSEATS) | 223 | 14.99 |
+| 2177 | [Galou is back!](https://www.spoj.com/problems/GALOU) | 226 | 31.01 |
+| 2178 | [He is offside!](https://www.spoj.com/problems/OFFSIDE) | 8446 | 50.13 |
+| 2179 | [ICPC Scoreboard](https://www.spoj.com/problems/ICPCS) | 180 | 29.76 |
+| 2180 | [Justice League](https://www.spoj.com/problems/JLEAGUE) | 83 | 48.97 |
+| 2185 | [Musical Optimization](https://www.spoj.com/problems/MUSIC) | 73 | 43.15 |
+| 2189 | [Making Pairs](https://www.spoj.com/problems/MKPAIRS) | 47 | 15.90 |
+| 2202 | [Tan and His Interesting Game](https://www.spoj.com/problems/TAN1) | 46 | 25.18 |
+| 2270 | [Balloons in a Box](https://www.spoj.com/problems/BALLOON) | 172 | 23.77 |
+| 2271 | [Undecodable Codes](https://www.spoj.com/problems/UCODES) | 48 | 12.27 |
+| 2272 | [Crossing the Desert](https://www.spoj.com/problems/DESERT) | 54 | 20.12 |
+| 2273 | [Ferries](https://www.spoj.com/problems/FERRY) | 32 | 18.75 |
+| 2274 | [Island Hopping](https://www.spoj.com/problems/ISLHOP) | 207 | 25.14 |
+| 2275 | [Toil for Oil](https://www.spoj.com/problems/OIL) | 15 | 28.65 |
+| 2276 | [Partitions](https://www.spoj.com/problems/RECTNG2) | 24 | 13.02 |
+| 2277 | [Silly Sort](https://www.spoj.com/problems/SSORT) | 882 | 55.45 |
+| 2317 | [Bracket Sequence](https://www.spoj.com/problems/LEXBRAC) | 57 | 23.73 |
+| 2318 | [Overlapping Words](https://www.spoj.com/problems/WORDS) | 90 | 22.40 |
+| 2319 | [Sequence](https://www.spoj.com/problems/BIGSEQ) | 218 | 28.12 |
+| 2320 | [Manhattan](https://www.spoj.com/problems/DISTANCE) | 703 | 32.39 |
+| 2321 | [Segments](https://www.spoj.com/problems/SEGMENTS) | 156 | 13.93 |
+| 2322 | [Tree Game](https://www.spoj.com/problems/TREEGAME) | 325 | 43.37 |
+| 2323 | [Broken Compass](https://www.spoj.com/problems/COMPASS) | 47 | 13.78 |
+| 2324 | [Mario](https://www.spoj.com/problems/MARIOGAM) | 63 | 14.00 |
+| 2325 | [String Distance](https://www.spoj.com/problems/STRDIST) | 214 | 21.51 |
+| 2371 | [Another Longest Increasing Subsequence Problem](https://www.spoj.com/problems/LIS2) | 843 | 13.68 |

--- a/tests/spoj/index/13.jsonl
+++ b/tests/spoj/index/13.jsonl
@@ -1,0 +1,50 @@
+{"id":2412,"name":"Arranging Amplifiers","url":"https://www.spoj.com/problems/ARRANGE","users":3282,"accepted":27.22}
+{"id":2413,"name":"Building Beacons","url":"https://www.spoj.com/problems/BUILD","users":42,"accepted":19.84}
+{"id":2414,"name":"Calculate The Cost","url":"https://www.spoj.com/problems/CCOST","users":343,"accepted":22.38}
+{"id":2415,"name":"Kirchhof Law","url":"https://www.spoj.com/problems/RESIST","users":105,"accepted":21.42}
+{"id":2416,"name":"Distinct Subsequences","url":"https://www.spoj.com/problems/DSUBSEQ","users":3779,"accepted":36.34}
+{"id":2417,"name":"Eliminate The Enemies","url":"https://www.spoj.com/problems/ENEMY","users":22,"accepted":19.74}
+{"id":2418,"name":"Flying Frogs","url":"https://www.spoj.com/problems/FFROG","users":63,"accepted":35.71}
+{"id":2419,"name":"G-Line Grid","url":"https://www.spoj.com/problems/GLGRID","users":4,"accepted":3.31}
+{"id":2420,"name":"Hospital at Hands","url":"https://www.spoj.com/problems/HHAND","users":31,"accepted":23.44}
+{"id":2421,"name":"Incrementing The Integer","url":"https://www.spoj.com/problems/ININT","users":53,"accepted":24.29}
+{"id":2422,"name":"Jazzy Job","url":"https://www.spoj.com/problems/JAZZYJOB","users":66,"accepted":32.22}
+{"id":2423,"name":"Minimal Triangulations of Graphs","url":"https://www.spoj.com/problems/MINTRIAN","users":31,"accepted":35.09}
+{"id":2426,"name":"Palindromes","url":"https://www.spoj.com/problems/PLD","users":1026,"accepted":24.8}
+{"id":2450,"name":"Counting Rabbits","url":"https://www.spoj.com/problems/RABBIT1","users":1240,"accepted":34.33}
+{"id":2485,"name":"Phone Lines","url":"https://www.spoj.com/problems/PHONELIN","users":19,"accepted":14.19}
+{"id":2511,"name":"Magic Program IV","url":"https://www.spoj.com/problems/MAGIC4","users":27,"accepted":17.99}
+{"id":2525,"name":"Encoding","url":"https://www.spoj.com/problems/GNY07C","users":752,"accepted":29.15}
+{"id":2526,"name":"Decoding","url":"https://www.spoj.com/problems/GNY07D","users":1041,"accepted":36.51}
+{"id":2527,"name":"Flipping Burned Pancakes","url":"https://www.spoj.com/problems/GNY07E","users":265,"accepted":52.59}
+{"id":2528,"name":"Monkey Vines","url":"https://www.spoj.com/problems/GNY07F","users":780,"accepted":43.22}
+{"id":2529,"name":"Model Rocket Height","url":"https://www.spoj.com/problems/GNY07G","users":87,"accepted":54.86}
+{"id":2530,"name":"Tiling a Grid With Dominoes","url":"https://www.spoj.com/problems/GNY07H","users":2440,"accepted":64.86}
+{"id":2531,"name":"Spatial Concepts Test","url":"https://www.spoj.com/problems/GNY07I","users":74,"accepted":66.39}
+{"id":2565,"name":"Another Permutation Problem","url":"https://www.spoj.com/problems/PERMUT3","users":59,"accepted":23.46}
+{"id":2631,"name":"Chomp","url":"https://www.spoj.com/problems/CLK","users":111,"accepted":45.7}
+{"id":2643,"name":"Starcraft I","url":"https://www.spoj.com/problems/SC1","users":58,"accepted":22.3}
+{"id":2648,"name":"Archiver","url":"https://www.spoj.com/problems/KPARCH","users":47,"accepted":13.74}
+{"id":2649,"name":"Weird sorting","url":"https://www.spoj.com/problems/KPSORT","users":61,"accepted":25.64}
+{"id":2658,"name":"Art of War","url":"https://www.spoj.com/problems/WAR","users":17,"accepted":15.09}
+{"id":2660,"name":"Example","url":"https://www.spoj.com/problems/EXAMPLE","users":13,"accepted":17.99}
+{"id":2661,"name":"Illumination","url":"https://www.spoj.com/problems/ILLUM","users":10,"accepted":4.44}
+{"id":2662,"name":"Put a Point in a Hyperspace","url":"https://www.spoj.com/problems/PUTIN","users":19,"accepted":10}
+{"id":2666,"name":"Query on a tree IV","url":"https://www.spoj.com/problems/QTREE4","users":745,"accepted":13.53}
+{"id":2668,"name":"Polygon","url":"https://www.spoj.com/problems/POLYSSQ","users":68,"accepted":20.45}
+{"id":2670,"name":"Count Minimum Spanning Trees","url":"https://www.spoj.com/problems/MSTS","users":189,"accepted":17.41}
+{"id":2678,"name":"Closest distance","url":"https://www.spoj.com/problems/GANNHAT","users":167,"accepted":13.83}
+{"id":2699,"name":"Recursive Sequence (Version II)","url":"https://www.spoj.com/problems/SPP","users":1013,"accepted":26.12}
+{"id":2709,"name":"Untitled Problem","url":"https://www.spoj.com/problems/UNTITLED","users":30,"accepted":16.67}
+{"id":2713,"name":"Can you answer these queries IV","url":"https://www.spoj.com/problems/GSS4","users":4355,"accepted":17.72}
+{"id":2714,"name":"Cow Cars","url":"https://www.spoj.com/problems/COWCAR","users":670,"accepted":37.51}
+{"id":2715,"name":"Glasnici","url":"https://www.spoj.com/problems/GLASNICI","users":348,"accepted":37.42}
+{"id":2716,"name":"Maximal Quadrilateral Area","url":"https://www.spoj.com/problems/QUADAREA","users":6255,"accepted":50.22}
+{"id":2727,"name":"Army Strength","url":"https://www.spoj.com/problems/ARMY","users":14565,"accepted":41.23}
+{"id":2728,"name":"Breaking in","url":"https://www.spoj.com/problems/BREAK","users":304,"accepted":26.86}
+{"id":2731,"name":"Inventing Test Data","url":"https://www.spoj.com/problems/INVENT","users":555,"accepted":24.97}
+{"id":2733,"name":"K Equal Digits","url":"https://www.spoj.com/problems/KEQ","users":16,"accepted":13.65}
+{"id":2734,"name":"Large party","url":"https://www.spoj.com/problems/LARGE","users":40,"accepted":26.19}
+{"id":2735,"name":"Simplify the Railroad System","url":"https://www.spoj.com/problems/RAIL","users":62,"accepted":35.19}
+{"id":2737,"name":"Perfect Rhyme","url":"https://www.spoj.com/problems/PRHYME","users":437,"accepted":16.99}
+{"id":2738,"name":"Number Guessing Game","url":"https://www.spoj.com/problems/GUESSING","users":4631,"accepted":62.51}

--- a/tests/spoj/index/13.md
+++ b/tests/spoj/index/13.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 2412 | [Arranging Amplifiers](https://www.spoj.com/problems/ARRANGE) | 3282 | 27.22 |
+| 2413 | [Building Beacons](https://www.spoj.com/problems/BUILD) | 42 | 19.84 |
+| 2414 | [Calculate The Cost](https://www.spoj.com/problems/CCOST) | 343 | 22.38 |
+| 2415 | [Kirchhof Law](https://www.spoj.com/problems/RESIST) | 105 | 21.42 |
+| 2416 | [Distinct Subsequences](https://www.spoj.com/problems/DSUBSEQ) | 3779 | 36.34 |
+| 2417 | [Eliminate The Enemies](https://www.spoj.com/problems/ENEMY) | 22 | 19.74 |
+| 2418 | [Flying Frogs](https://www.spoj.com/problems/FFROG) | 63 | 35.71 |
+| 2419 | [G-Line Grid](https://www.spoj.com/problems/GLGRID) | 4 | 3.31 |
+| 2420 | [Hospital at Hands](https://www.spoj.com/problems/HHAND) | 31 | 23.44 |
+| 2421 | [Incrementing The Integer](https://www.spoj.com/problems/ININT) | 53 | 24.29 |
+| 2422 | [Jazzy Job](https://www.spoj.com/problems/JAZZYJOB) | 66 | 32.22 |
+| 2423 | [Minimal Triangulations of Graphs](https://www.spoj.com/problems/MINTRIAN) | 31 | 35.09 |
+| 2426 | [Palindromes](https://www.spoj.com/problems/PLD) | 1026 | 24.80 |
+| 2450 | [Counting Rabbits](https://www.spoj.com/problems/RABBIT1) | 1240 | 34.33 |
+| 2485 | [Phone Lines](https://www.spoj.com/problems/PHONELIN) | 19 | 14.19 |
+| 2511 | [Magic Program IV](https://www.spoj.com/problems/MAGIC4) | 27 | 17.99 |
+| 2525 | [Encoding](https://www.spoj.com/problems/GNY07C) | 752 | 29.15 |
+| 2526 | [Decoding](https://www.spoj.com/problems/GNY07D) | 1041 | 36.51 |
+| 2527 | [Flipping Burned Pancakes](https://www.spoj.com/problems/GNY07E) | 265 | 52.59 |
+| 2528 | [Monkey Vines](https://www.spoj.com/problems/GNY07F) | 780 | 43.22 |
+| 2529 | [Model Rocket Height](https://www.spoj.com/problems/GNY07G) | 87 | 54.86 |
+| 2530 | [Tiling a Grid With Dominoes](https://www.spoj.com/problems/GNY07H) | 2440 | 64.86 |
+| 2531 | [Spatial Concepts Test](https://www.spoj.com/problems/GNY07I) | 74 | 66.39 |
+| 2565 | [Another Permutation Problem](https://www.spoj.com/problems/PERMUT3) | 59 | 23.46 |
+| 2631 | [Chomp](https://www.spoj.com/problems/CLK) | 111 | 45.70 |
+| 2643 | [Starcraft I](https://www.spoj.com/problems/SC1) | 58 | 22.30 |
+| 2648 | [Archiver](https://www.spoj.com/problems/KPARCH) | 47 | 13.74 |
+| 2649 | [Weird sorting](https://www.spoj.com/problems/KPSORT) | 61 | 25.64 |
+| 2658 | [Art of War](https://www.spoj.com/problems/WAR) | 17 | 15.09 |
+| 2660 | [Example](https://www.spoj.com/problems/EXAMPLE) | 13 | 17.99 |
+| 2661 | [Illumination](https://www.spoj.com/problems/ILLUM) | 10 | 4.44 |
+| 2662 | [Put a Point in a Hyperspace](https://www.spoj.com/problems/PUTIN) | 19 | 10.00 |
+| 2666 | [Query on a tree IV](https://www.spoj.com/problems/QTREE4) | 745 | 13.53 |
+| 2668 | [Polygon](https://www.spoj.com/problems/POLYSSQ) | 68 | 20.45 |
+| 2670 | [Count Minimum Spanning Trees](https://www.spoj.com/problems/MSTS) | 189 | 17.41 |
+| 2678 | [Closest distance](https://www.spoj.com/problems/GANNHAT) | 167 | 13.83 |
+| 2699 | [Recursive Sequence (Version II)](https://www.spoj.com/problems/SPP) | 1013 | 26.12 |
+| 2709 | [Untitled Problem](https://www.spoj.com/problems/UNTITLED) | 30 | 16.67 |
+| 2713 | [Can you answer these queries IV](https://www.spoj.com/problems/GSS4) | 4355 | 17.72 |
+| 2714 | [Cow Cars](https://www.spoj.com/problems/COWCAR) | 670 | 37.51 |
+| 2715 | [Glasnici](https://www.spoj.com/problems/GLASNICI) | 348 | 37.42 |
+| 2716 | [Maximal Quadrilateral Area](https://www.spoj.com/problems/QUADAREA) | 6255 | 50.22 |
+| 2727 | [Army Strength](https://www.spoj.com/problems/ARMY) | 14565 | 41.23 |
+| 2728 | [Breaking in](https://www.spoj.com/problems/BREAK) | 304 | 26.86 |
+| 2731 | [Inventing Test Data](https://www.spoj.com/problems/INVENT) | 555 | 24.97 |
+| 2733 | [K Equal Digits](https://www.spoj.com/problems/KEQ) | 16 | 13.65 |
+| 2734 | [Large party](https://www.spoj.com/problems/LARGE) | 40 | 26.19 |
+| 2735 | [Simplify the Railroad System](https://www.spoj.com/problems/RAIL) | 62 | 35.19 |
+| 2737 | [Perfect Rhyme](https://www.spoj.com/problems/PRHYME) | 437 | 16.99 |
+| 2738 | [Number Guessing Game](https://www.spoj.com/problems/GUESSING) | 4631 | 62.51 |

--- a/tests/spoj/index/14.jsonl
+++ b/tests/spoj/index/14.jsonl
@@ -1,0 +1,50 @@
+{"id":2742,"name":"Summing Sums","url":"https://www.spoj.com/problems/SUMSUMS","users":921,"accepted":19.11}
+{"id":2743,"name":"Prefix Tiling","url":"https://www.spoj.com/problems/PRETILE","users":166,"accepted":27.86}
+{"id":2815,"name":"Increasing Subsequences","url":"https://www.spoj.com/problems/INCSEQ","users":2184,"accepted":28.17}
+{"id":2816,"name":"Common Subsequences","url":"https://www.spoj.com/problems/CSUBSEQS","users":222,"accepted":28.72}
+{"id":2817,"name":"Distinct Increasing Subsequences","url":"https://www.spoj.com/problems/INCDSEQ","users":795,"accepted":24.57}
+{"id":2826,"name":"Round-Robin Scheduling","url":"https://www.spoj.com/problems/RRSCHED","users":650,"accepted":36.17}
+{"id":2829,"name":"Time Limit Exceeded","url":"https://www.spoj.com/problems/TLE","users":259,"accepted":21.6}
+{"id":2832,"name":"Find The Determinant III","url":"https://www.spoj.com/problems/DETER3","users":308,"accepted":20.46}
+{"id":2833,"name":"Super Dice Game","url":"https://www.spoj.com/problems/SDGAME","users":24,"accepted":9.63}
+{"id":2835,"name":"Memory Limit Exceeded","url":"https://www.spoj.com/problems/MLE","users":91,"accepted":31.4}
+{"id":2852,"name":"Broken Keyboard","url":"https://www.spoj.com/problems/BROKEN","users":1219,"accepted":31.72}
+{"id":2853,"name":"Decode the Strings","url":"https://www.spoj.com/problems/PDECODE","users":432,"accepted":39.64}
+{"id":2855,"name":"Forest","url":"https://www.spoj.com/problems/FOREST2","users":62,"accepted":12.68}
+{"id":2856,"name":"Help Bob","url":"https://www.spoj.com/problems/HELPBOB","users":278,"accepted":31.72}
+{"id":2877,"name":"Another understanding of Super Dice Game","url":"https://www.spoj.com/problems/SDGAME2","users":67,"accepted":10.34}
+{"id":2878,"name":"Knights of the Round Table","url":"https://www.spoj.com/problems/KNIGHTS","users":562,"accepted":22.72}
+{"id":2879,"name":"The Cow Doctor","url":"https://www.spoj.com/problems/DOCTOR","users":145,"accepted":33.46}
+{"id":2880,"name":"Wild West","url":"https://www.spoj.com/problems/WILD","users":103,"accepted":42.23}
+{"id":2881,"name":"Find the Clones","url":"https://www.spoj.com/problems/CLONE","users":2056,"accepted":44.57}
+{"id":2882,"name":"The Warehouse","url":"https://www.spoj.com/problems/WARE","users":27,"accepted":30.66}
+{"id":2883,"name":"Widget Factory","url":"https://www.spoj.com/problems/WIDGET","users":167,"accepted":34.83}
+{"id":2884,"name":"Martian Mining","url":"https://www.spoj.com/problems/MARTIAN","users":2326,"accepted":47.78}
+{"id":2885,"name":"Word Rings","url":"https://www.spoj.com/problems/WORDRING","users":401,"accepted":15.76}
+{"id":2898,"name":"Party of Cloaked Killers","url":"https://www.spoj.com/problems/PARTY2","users":28,"accepted":16.23}
+{"id":2899,"name":"Volunteers","url":"https://www.spoj.com/problems/VOL","users":60,"accepted":45}
+{"id":2901,"name":"One Geometry Problem","url":"https://www.spoj.com/problems/GEOPROB","users":1827,"accepted":36.14}
+{"id":2902,"name":"Candy IV","url":"https://www.spoj.com/problems/CANDY4","users":33,"accepted":46.46}
+{"id":2903,"name":"Transportation","url":"https://www.spoj.com/problems/TRANSP1","users":11,"accepted":19.12}
+{"id":2905,"name":"Not a Triangle","url":"https://www.spoj.com/problems/NOTATRI","users":5052,"accepted":38.67}
+{"id":2906,"name":"GCD2","url":"https://www.spoj.com/problems/GCD2","users":6866,"accepted":36.49}
+{"id":2916,"name":"Can you answer these queries V","url":"https://www.spoj.com/problems/GSS5","users":2877,"accepted":26.7}
+{"id":2939,"name":"Query on a tree V","url":"https://www.spoj.com/problems/QTREE5","users":1918,"accepted":28.72}
+{"id":2940,"name":"Untitled Problem II","url":"https://www.spoj.com/problems/UNTITLE1","users":126,"accepted":15.45}
+{"id":2944,"name":"Emmons","url":"https://www.spoj.com/problems/SHOOTING","users":7,"accepted":7.19}
+{"id":2946,"name":"Eclipse","url":"https://www.spoj.com/problems/ECLIPSE","users":24,"accepted":9.76}
+{"id":2961,"name":"Triomino Game","url":"https://www.spoj.com/problems/TRIOMINO","users":240,"accepted":28.24}
+{"id":2962,"name":"Painting Blocks (Act I)","url":"https://www.spoj.com/problems/PAINTBLK","users":113,"accepted":57.95}
+{"id":2963,"name":"Painting Blocks (Act II)","url":"https://www.spoj.com/problems/PAINTBLC","users":61,"accepted":21.28}
+{"id":3002,"name":"Electrophoretic","url":"https://www.spoj.com/problems/ELECTRO","users":15,"accepted":20.93}
+{"id":3003,"name":"Median Filter","url":"https://www.spoj.com/problems/FILTER","users":21,"accepted":43.26}
+{"id":3004,"name":"Life Game","url":"https://www.spoj.com/problems/LIFEGAME","users":76,"accepted":35.47}
+{"id":3005,"name":"Subdividing a Land","url":"https://www.spoj.com/problems/LAND","users":28,"accepted":33.02}
+{"id":3006,"name":"Connect Line Segments","url":"https://www.spoj.com/problems/LINE","users":79,"accepted":24.38}
+{"id":3007,"name":"Oil Company","url":"https://www.spoj.com/problems/OILCOMP","users":178,"accepted":25.08}
+{"id":3008,"name":"Finding the Top RPS Player","url":"https://www.spoj.com/problems/RPS","users":183,"accepted":65.9}
+{"id":3009,"name":"Revenge of Voronoi","url":"https://www.spoj.com/problems/VORONOI","users":14,"accepted":30.26}
+{"id":3010,"name":"Castle Wall","url":"https://www.spoj.com/problems/WALL","users":26,"accepted":20.15}
+{"id":3023,"name":"Binary multiplication","url":"https://www.spoj.com/problems/MUL2COM","users":229,"accepted":25.04}
+{"id":3033,"name":"Help the soldier","url":"https://www.spoj.com/problems/SOLDIER","users":1251,"accepted":29.03}
+{"id":3070,"name":"How many subsequences","url":"https://www.spoj.com/problems/SEQ5","users":99,"accepted":9.9}

--- a/tests/spoj/index/14.md
+++ b/tests/spoj/index/14.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 2742 | [Summing Sums](https://www.spoj.com/problems/SUMSUMS) | 921 | 19.11 |
+| 2743 | [Prefix Tiling](https://www.spoj.com/problems/PRETILE) | 166 | 27.86 |
+| 2815 | [Increasing Subsequences](https://www.spoj.com/problems/INCSEQ) | 2184 | 28.17 |
+| 2816 | [Common Subsequences](https://www.spoj.com/problems/CSUBSEQS) | 222 | 28.72 |
+| 2817 | [Distinct Increasing Subsequences](https://www.spoj.com/problems/INCDSEQ) | 795 | 24.57 |
+| 2826 | [Round-Robin Scheduling](https://www.spoj.com/problems/RRSCHED) | 650 | 36.17 |
+| 2829 | [Time Limit Exceeded](https://www.spoj.com/problems/TLE) | 259 | 21.60 |
+| 2832 | [Find The Determinant III](https://www.spoj.com/problems/DETER3) | 308 | 20.46 |
+| 2833 | [Super Dice Game](https://www.spoj.com/problems/SDGAME) | 24 | 9.63 |
+| 2835 | [Memory Limit Exceeded](https://www.spoj.com/problems/MLE) | 91 | 31.40 |
+| 2852 | [Broken Keyboard](https://www.spoj.com/problems/BROKEN) | 1219 | 31.72 |
+| 2853 | [Decode the Strings](https://www.spoj.com/problems/PDECODE) | 432 | 39.64 |
+| 2855 | [Forest](https://www.spoj.com/problems/FOREST2) | 62 | 12.68 |
+| 2856 | [Help Bob](https://www.spoj.com/problems/HELPBOB) | 278 | 31.72 |
+| 2877 | [Another understanding of Super Dice Game](https://www.spoj.com/problems/SDGAME2) | 67 | 10.34 |
+| 2878 | [Knights of the Round Table](https://www.spoj.com/problems/KNIGHTS) | 562 | 22.72 |
+| 2879 | [The Cow Doctor](https://www.spoj.com/problems/DOCTOR) | 145 | 33.46 |
+| 2880 | [Wild West](https://www.spoj.com/problems/WILD) | 103 | 42.23 |
+| 2881 | [Find the Clones](https://www.spoj.com/problems/CLONE) | 2056 | 44.57 |
+| 2882 | [The Warehouse](https://www.spoj.com/problems/WARE) | 27 | 30.66 |
+| 2883 | [Widget Factory](https://www.spoj.com/problems/WIDGET) | 167 | 34.83 |
+| 2884 | [Martian Mining](https://www.spoj.com/problems/MARTIAN) | 2326 | 47.78 |
+| 2885 | [Word Rings](https://www.spoj.com/problems/WORDRING) | 401 | 15.76 |
+| 2898 | [Party of Cloaked Killers](https://www.spoj.com/problems/PARTY2) | 28 | 16.23 |
+| 2899 | [Volunteers](https://www.spoj.com/problems/VOL) | 60 | 45.00 |
+| 2901 | [One Geometry Problem](https://www.spoj.com/problems/GEOPROB) | 1827 | 36.14 |
+| 2902 | [Candy IV](https://www.spoj.com/problems/CANDY4) | 33 | 46.46 |
+| 2903 | [Transportation](https://www.spoj.com/problems/TRANSP1) | 11 | 19.12 |
+| 2905 | [Not a Triangle](https://www.spoj.com/problems/NOTATRI) | 5052 | 38.67 |
+| 2906 | [GCD2](https://www.spoj.com/problems/GCD2) | 6866 | 36.49 |
+| 2916 | [Can you answer these queries V](https://www.spoj.com/problems/GSS5) | 2877 | 26.70 |
+| 2939 | [Query on a tree V](https://www.spoj.com/problems/QTREE5) | 1918 | 28.72 |
+| 2940 | [Untitled Problem II](https://www.spoj.com/problems/UNTITLE1) | 126 | 15.45 |
+| 2944 | [Emmons](https://www.spoj.com/problems/SHOOTING) | 7 | 7.19 |
+| 2946 | [Eclipse](https://www.spoj.com/problems/ECLIPSE) | 24 | 9.76 |
+| 2961 | [Triomino Game](https://www.spoj.com/problems/TRIOMINO) | 240 | 28.24 |
+| 2962 | [Painting Blocks (Act I)](https://www.spoj.com/problems/PAINTBLK) | 113 | 57.95 |
+| 2963 | [Painting Blocks (Act II)](https://www.spoj.com/problems/PAINTBLC) | 61 | 21.28 |
+| 3002 | [Electrophoretic](https://www.spoj.com/problems/ELECTRO) | 15 | 20.93 |
+| 3003 | [Median Filter](https://www.spoj.com/problems/FILTER) | 21 | 43.26 |
+| 3004 | [Life Game](https://www.spoj.com/problems/LIFEGAME) | 76 | 35.47 |
+| 3005 | [Subdividing a Land](https://www.spoj.com/problems/LAND) | 28 | 33.02 |
+| 3006 | [Connect Line Segments](https://www.spoj.com/problems/LINE) | 79 | 24.38 |
+| 3007 | [Oil Company](https://www.spoj.com/problems/OILCOMP) | 178 | 25.08 |
+| 3008 | [Finding the Top RPS Player](https://www.spoj.com/problems/RPS) | 183 | 65.90 |
+| 3009 | [Revenge of Voronoi](https://www.spoj.com/problems/VORONOI) | 14 | 30.26 |
+| 3010 | [Castle Wall](https://www.spoj.com/problems/WALL) | 26 | 20.15 |
+| 3023 | [Binary multiplication](https://www.spoj.com/problems/MUL2COM) | 229 | 25.04 |
+| 3033 | [Help the soldier](https://www.spoj.com/problems/SOLDIER) | 1251 | 29.03 |
+| 3070 | [How many subsequences](https://www.spoj.com/problems/SEQ5) | 99 | 9.90 |

--- a/tests/spoj/index/15.jsonl
+++ b/tests/spoj/index/15.jsonl
@@ -1,0 +1,50 @@
+{"id":3078,"name":"Copying DNA","url":"https://www.spoj.com/problems/COPYDNA","users":48,"accepted":21.17}
+{"id":3105,"name":"Power Modulo Inverted","url":"https://www.spoj.com/problems/MOD","users":1145,"accepted":27.48}
+{"id":3106,"name":"Dictionary Subsequences","url":"https://www.spoj.com/problems/DICTSUB","users":169,"accepted":18.43}
+{"id":3107,"name":"Odd Numbers of Divisors","url":"https://www.spoj.com/problems/ODDDIV","users":1072,"accepted":18.44}
+{"id":3108,"name":"Charlesbert and Merangelou","url":"https://www.spoj.com/problems/GRAPHGAM","users":75,"accepted":44.44}
+{"id":3109,"name":"Longest Common Prefix","url":"https://www.spoj.com/problems/STRLCP","users":395,"accepted":25.45}
+{"id":3110,"name":"Palindromic Number","url":"https://www.spoj.com/problems/PALNUM","users":101,"accepted":21.07}
+{"id":3111,"name":"Stabards","url":"https://www.spoj.com/problems/STABARDS","users":166,"accepted":43.65}
+{"id":3112,"name":"Strings","url":"https://www.spoj.com/problems/STSTRING","users":269,"accepted":31.38}
+{"id":3133,"name":"Here We Go(relians) Again","url":"https://www.spoj.com/problems/GORELIAN","users":171,"accepted":40.3}
+{"id":3166,"name":"Permutation Exponentiation","url":"https://www.spoj.com/problems/PERMSG","users":36,"accepted":14.93}
+{"id":3184,"name":"Game of Lines","url":"https://www.spoj.com/problems/LINES","users":1315,"accepted":27.76}
+{"id":3195,"name":"Doors and Penguins","url":"https://www.spoj.com/problems/DOORSPEN","users":243,"accepted":27.37}
+{"id":3196,"name":"Divisibility Relation","url":"https://www.spoj.com/problems/DIVREL","users":291,"accepted":21.1}
+{"id":3197,"name":"Tree Construction","url":"https://www.spoj.com/problems/TREECST","users":64,"accepted":20.1}
+{"id":3208,"name":"Yet Another Longest Palindrome Problem","url":"https://www.spoj.com/problems/PALIM","users":69,"accepted":13.9}
+{"id":3249,"name":"Typesettin","url":"https://www.spoj.com/problems/TYPESET","users":36,"accepted":46.67}
+{"id":3251,"name":"Slink","url":"https://www.spoj.com/problems/SLINK","users":15,"accepted":34.04}
+{"id":3253,"name":"Electronic Document Security","url":"https://www.spoj.com/problems/EDS","users":156,"accepted":61.07}
+{"id":3254,"name":"Guard","url":"https://www.spoj.com/problems/GUARD","users":15,"accepted":43.24}
+{"id":3261,"name":"Race Against Time","url":"https://www.spoj.com/problems/RACETIME","users":1177,"accepted":24.82}
+{"id":3266,"name":"K-query","url":"https://www.spoj.com/problems/KQUERY","users":6104,"accepted":25.53}
+{"id":3267,"name":"D-query","url":"https://www.spoj.com/problems/DQUERY","users":13933,"accepted":28.54}
+{"id":3273,"name":"Order statistic set","url":"https://www.spoj.com/problems/ORDERSET","users":3436,"accepted":26.88}
+{"id":3305,"name":"Roman Patrollers","url":"https://www.spoj.com/problems/SA04C","users":53,"accepted":59.35}
+{"id":3306,"name":"Very Special Boxes","url":"https://www.spoj.com/problems/SA04D","users":114,"accepted":31.96}
+{"id":3307,"name":"Hex Tile Equations","url":"https://www.spoj.com/problems/HEXTILE","users":37,"accepted":42.34}
+{"id":3308,"name":"The Bridges of San Mochti","url":"https://www.spoj.com/problems/BRIDGES2","users":68,"accepted":56.25}
+{"id":3309,"name":"Bulletin Board","url":"https://www.spoj.com/problems/BULLETIN","users":24,"accepted":22.07}
+{"id":3310,"name":"Serial Numbers","url":"https://www.spoj.com/problems/SERIALN","users":35,"accepted":29.84}
+{"id":3314,"name":"Umnozak","url":"https://www.spoj.com/problems/UMNOZAK","users":115,"accepted":30.02}
+{"id":3322,"name":"Doubled Numbers","url":"https://www.spoj.com/problems/DOUBLE","users":169,"accepted":49.36}
+{"id":3347,"name":"Cestarine","url":"https://www.spoj.com/problems/HIGHWAY","users":64,"accepted":29.1}
+{"id":3359,"name":"Stack","url":"https://www.spoj.com/problems/STACK","users":50,"accepted":16.63}
+{"id":3360,"name":"Digital Image Recognition","url":"https://www.spoj.com/problems/IMGREC2","users":28,"accepted":20.48}
+{"id":3361,"name":"Cavli","url":"https://www.spoj.com/problems/CAVLI","users":43,"accepted":43.2}
+{"id":3362,"name":"Setnja","url":"https://www.spoj.com/problems/SETNJA","users":249,"accepted":21.51}
+{"id":3363,"name":"Svada","url":"https://www.spoj.com/problems/SVADA","users":496,"accepted":28.88}
+{"id":3372,"name":"Round Table","url":"https://www.spoj.com/problems/ROUNDT","users":61,"accepted":43.81}
+{"id":3373,"name":"Permutation Code","url":"https://www.spoj.com/problems/PERMCODE","users":43,"accepted":56.1}
+{"id":3374,"name":"Scavenger Hunt","url":"https://www.spoj.com/problems/SCAVHUNT","users":1375,"accepted":50.52}
+{"id":3375,"name":"Stamps","url":"https://www.spoj.com/problems/STAMPS","users":13787,"accepted":41.72}
+{"id":3376,"name":"Parking Lot","url":"https://www.spoj.com/problems/PARKINGL","users":143,"accepted":20.4}
+{"id":3377,"name":"A Bug’s Life","url":"https://www.spoj.com/problems/BUGLIFE","users":15905,"accepted":27.71}
+{"id":3379,"name":"String Shuffle","url":"https://www.spoj.com/problems/SSHUFFLE","users":400,"accepted":65.69}
+{"id":3380,"name":"Tourist","url":"https://www.spoj.com/problems/TOURIST","users":1163,"accepted":37.75}
+{"id":3381,"name":"Highways","url":"https://www.spoj.com/problems/HIGHWAYS","users":4512,"accepted":38.25}
+{"id":3382,"name":"Monster Trap","url":"https://www.spoj.com/problems/MONSTER","users":32,"accepted":24.06}
+{"id":3385,"name":"Yoda Goes Palindromic !","url":"https://www.spoj.com/problems/YODA","users":586,"accepted":30.53}
+{"id":3387,"name":"Changing Maze","url":"https://www.spoj.com/problems/CHMAZE","users":626,"accepted":29.79}

--- a/tests/spoj/index/15.md
+++ b/tests/spoj/index/15.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 3078 | [Copying DNA](https://www.spoj.com/problems/COPYDNA) | 48 | 21.17 |
+| 3105 | [Power Modulo Inverted](https://www.spoj.com/problems/MOD) | 1145 | 27.48 |
+| 3106 | [Dictionary Subsequences](https://www.spoj.com/problems/DICTSUB) | 169 | 18.43 |
+| 3107 | [Odd Numbers of Divisors](https://www.spoj.com/problems/ODDDIV) | 1072 | 18.44 |
+| 3108 | [Charlesbert and Merangelou](https://www.spoj.com/problems/GRAPHGAM) | 75 | 44.44 |
+| 3109 | [Longest Common Prefix](https://www.spoj.com/problems/STRLCP) | 395 | 25.45 |
+| 3110 | [Palindromic Number](https://www.spoj.com/problems/PALNUM) | 101 | 21.07 |
+| 3111 | [Stabards](https://www.spoj.com/problems/STABARDS) | 166 | 43.65 |
+| 3112 | [Strings](https://www.spoj.com/problems/STSTRING) | 269 | 31.38 |
+| 3133 | [Here We Go(relians) Again](https://www.spoj.com/problems/GORELIAN) | 171 | 40.30 |
+| 3166 | [Permutation Exponentiation](https://www.spoj.com/problems/PERMSG) | 36 | 14.93 |
+| 3184 | [Game of Lines](https://www.spoj.com/problems/LINES) | 1315 | 27.76 |
+| 3195 | [Doors and Penguins](https://www.spoj.com/problems/DOORSPEN) | 243 | 27.37 |
+| 3196 | [Divisibility Relation](https://www.spoj.com/problems/DIVREL) | 291 | 21.10 |
+| 3197 | [Tree Construction](https://www.spoj.com/problems/TREECST) | 64 | 20.10 |
+| 3208 | [Yet Another Longest Palindrome Problem](https://www.spoj.com/problems/PALIM) | 69 | 13.90 |
+| 3249 | [Typesettin](https://www.spoj.com/problems/TYPESET) | 36 | 46.67 |
+| 3251 | [Slink](https://www.spoj.com/problems/SLINK) | 15 | 34.04 |
+| 3253 | [Electronic Document Security](https://www.spoj.com/problems/EDS) | 156 | 61.07 |
+| 3254 | [Guard](https://www.spoj.com/problems/GUARD) | 15 | 43.24 |
+| 3261 | [Race Against Time](https://www.spoj.com/problems/RACETIME) | 1177 | 24.82 |
+| 3266 | [K-query](https://www.spoj.com/problems/KQUERY) | 6104 | 25.53 |
+| 3267 | [D-query](https://www.spoj.com/problems/DQUERY) | 13933 | 28.54 |
+| 3273 | [Order statistic set](https://www.spoj.com/problems/ORDERSET) | 3436 | 26.88 |
+| 3305 | [Roman Patrollers](https://www.spoj.com/problems/SA04C) | 53 | 59.35 |
+| 3306 | [Very Special Boxes](https://www.spoj.com/problems/SA04D) | 114 | 31.96 |
+| 3307 | [Hex Tile Equations](https://www.spoj.com/problems/HEXTILE) | 37 | 42.34 |
+| 3308 | [The Bridges of San Mochti](https://www.spoj.com/problems/BRIDGES2) | 68 | 56.25 |
+| 3309 | [Bulletin Board](https://www.spoj.com/problems/BULLETIN) | 24 | 22.07 |
+| 3310 | [Serial Numbers](https://www.spoj.com/problems/SERIALN) | 35 | 29.84 |
+| 3314 | [Umnozak](https://www.spoj.com/problems/UMNOZAK) | 115 | 30.02 |
+| 3322 | [Doubled Numbers](https://www.spoj.com/problems/DOUBLE) | 169 | 49.36 |
+| 3347 | [Cestarine](https://www.spoj.com/problems/HIGHWAY) | 64 | 29.10 |
+| 3359 | [Stack](https://www.spoj.com/problems/STACK) | 50 | 16.63 |
+| 3360 | [Digital Image Recognition](https://www.spoj.com/problems/IMGREC2) | 28 | 20.48 |
+| 3361 | [Cavli](https://www.spoj.com/problems/CAVLI) | 43 | 43.20 |
+| 3362 | [Setnja](https://www.spoj.com/problems/SETNJA) | 249 | 21.51 |
+| 3363 | [Svada](https://www.spoj.com/problems/SVADA) | 496 | 28.88 |
+| 3372 | [Round Table](https://www.spoj.com/problems/ROUNDT) | 61 | 43.81 |
+| 3373 | [Permutation Code](https://www.spoj.com/problems/PERMCODE) | 43 | 56.10 |
+| 3374 | [Scavenger Hunt](https://www.spoj.com/problems/SCAVHUNT) | 1375 | 50.52 |
+| 3375 | [Stamps](https://www.spoj.com/problems/STAMPS) | 13787 | 41.72 |
+| 3376 | [Parking Lot](https://www.spoj.com/problems/PARKINGL) | 143 | 20.40 |
+| 3377 | [A Bug’s Life](https://www.spoj.com/problems/BUGLIFE) | 15905 | 27.71 |
+| 3379 | [String Shuffle](https://www.spoj.com/problems/SSHUFFLE) | 400 | 65.69 |
+| 3380 | [Tourist](https://www.spoj.com/problems/TOURIST) | 1163 | 37.75 |
+| 3381 | [Highways](https://www.spoj.com/problems/HIGHWAYS) | 4512 | 38.25 |
+| 3382 | [Monster Trap](https://www.spoj.com/problems/MONSTER) | 32 | 24.06 |
+| 3385 | [Yoda Goes Palindromic !](https://www.spoj.com/problems/YODA) | 586 | 30.53 |
+| 3387 | [Changing Maze](https://www.spoj.com/problems/CHMAZE) | 626 | 29.79 |

--- a/tests/spoj/index/16.jsonl
+++ b/tests/spoj/index/16.jsonl
@@ -1,0 +1,50 @@
+{"id":3388,"name":"Double Near Palindromes","url":"https://www.spoj.com/problems/DNPALIN","users":456,"accepted":34.21}
+{"id":3389,"name":"The Knights of the Round Circle","url":"https://www.spoj.com/problems/KNIGHTSR","users":450,"accepted":66.78}
+{"id":3390,"name":"Tribe Council","url":"https://www.spoj.com/problems/TRIBE2","users":63,"accepted":21.41}
+{"id":3393,"name":"Knot or Not","url":"https://www.spoj.com/problems/NOTOKNOT","users":10,"accepted":16.67}
+{"id":3394,"name":"Lagrange’s Four-Square Theorem","url":"https://www.spoj.com/problems/LAGRANGE","users":532,"accepted":46.08}
+{"id":3405,"name":"Almost Shortest Path","url":"https://www.spoj.com/problems/SAMER08A","users":1712,"accepted":31.36}
+{"id":3406,"name":"Bases","url":"https://www.spoj.com/problems/SAMER08B","users":72,"accepted":20.81}
+{"id":3407,"name":"Candy","url":"https://www.spoj.com/problems/SAMER08C","users":1368,"accepted":42.64}
+{"id":3408,"name":"DNA Sequences","url":"https://www.spoj.com/problems/SAMER08D","users":1991,"accepted":26.13}
+{"id":3409,"name":"Electricity","url":"https://www.spoj.com/problems/SAMER08E","users":811,"accepted":47.73}
+{"id":3410,"name":"Feynman","url":"https://www.spoj.com/problems/SAMER08F","users":34519,"accepted":57.48}
+{"id":3411,"name":"Pole Position","url":"https://www.spoj.com/problems/SAMER08G","users":920,"accepted":47.42}
+{"id":3412,"name":"Higgs Boson","url":"https://www.spoj.com/problems/SAMER08H","users":52,"accepted":19.09}
+{"id":3413,"name":"Traveling Shoemaker Problem","url":"https://www.spoj.com/problems/SAMER08I","users":77,"accepted":17.32}
+{"id":3414,"name":"Bora Bora","url":"https://www.spoj.com/problems/SAMER08J","users":148,"accepted":49.39}
+{"id":3415,"name":"Shrinking Polygons","url":"https://www.spoj.com/problems/SAMER08K","users":237,"accepted":19.53}
+{"id":3420,"name":"Falling Ice","url":"https://www.spoj.com/problems/FALLINGI","users":7,"accepted":12.5}
+{"id":3426,"name":"Ouroboros Snake","url":"https://www.spoj.com/problems/OROSNAKE","users":86,"accepted":52.26}
+{"id":3436,"name":"Histogram","url":"https://www.spoj.com/problems/HIST2","users":1544,"accepted":44.28}
+{"id":3442,"name":"The last digit","url":"https://www.spoj.com/problems/LASTDIG","users":30091,"accepted":26.98}
+{"id":3459,"name":"SkyScrapers","url":"https://www.spoj.com/problems/CEPC08B","users":375,"accepted":38.37}
+{"id":3461,"name":"Song Contest","url":"https://www.spoj.com/problems/SONG","users":16,"accepted":15.74}
+{"id":3462,"name":"The Skatepark´s New Ramps","url":"https://www.spoj.com/problems/RAMP","users":9,"accepted":9.71}
+{"id":3463,"name":"Robintron","url":"https://www.spoj.com/problems/ROBIN","users":8,"accepted":22.06}
+{"id":3464,"name":"Clock","url":"https://www.spoj.com/problems/CLOCK1","users":66,"accepted":36.9}
+{"id":3465,"name":"Drive through MegaCity","url":"https://www.spoj.com/problems/DRIVE","users":24,"accepted":20.97}
+{"id":3466,"name":"Another Longest Common Subsequence Problem","url":"https://www.spoj.com/problems/CS","users":6,"accepted":5.66}
+{"id":3476,"name":"Deposit","url":"https://www.spoj.com/problems/DEPOSIT","users":235,"accepted":38.24}
+{"id":3477,"name":"Baby","url":"https://www.spoj.com/problems/BABY","users":955,"accepted":46.67}
+{"id":3482,"name":"Alias","url":"https://www.spoj.com/problems/ALIAS","users":7,"accepted":31.82}
+{"id":3483,"name":"Begin","url":"https://www.spoj.com/problems/BEGIN","users":4,"accepted":7.94}
+{"id":3484,"name":"Crossbits","url":"https://www.spoj.com/problems/CROSSBIT","users":99,"accepted":15.25}
+{"id":3485,"name":"Disputes","url":"https://www.spoj.com/problems/DISPUTES","users":86,"accepted":63.75}
+{"id":3486,"name":"Elimination","url":"https://www.spoj.com/problems/ELIM","users":75,"accepted":30.31}
+{"id":3488,"name":"The  Top-Code","url":"https://www.spoj.com/problems/TOPCODE","users":60,"accepted":21.73}
+{"id":3490,"name":"Hidden Triangle","url":"https://www.spoj.com/problems/HIDTRI","users":12,"accepted":26.87}
+{"id":3492,"name":"Braille Transcription","url":"https://www.spoj.com/problems/BRAILLE","users":16,"accepted":14.16}
+{"id":3495,"name":"The Nobel Thief","url":"https://www.spoj.com/problems/NBLTHIEF","users":14,"accepted":51.52}
+{"id":3505,"name":"Prime Number Theorem","url":"https://www.spoj.com/problems/CPRIME","users":1538,"accepted":28.13}
+{"id":3533,"name":"Game on board","url":"https://www.spoj.com/problems/BGAME","users":26,"accepted":31.14}
+{"id":3543,"name":"Matrica","url":"https://www.spoj.com/problems/MATRICA","users":56,"accepted":39.9}
+{"id":3544,"name":"Binary Search Tree","url":"https://www.spoj.com/problems/BST","users":611,"accepted":21.01}
+{"id":3545,"name":"Najkraci","url":"https://www.spoj.com/problems/NAJKRACI","users":188,"accepted":28.95}
+{"id":3565,"name":"Choosing Gloves","url":"https://www.spoj.com/problems/GLOVE","users":89,"accepted":23.25}
+{"id":3576,"name":"Boy Scouts","url":"https://www.spoj.com/problems/BOYSCOUT","users":145,"accepted":28.31}
+{"id":3577,"name":"Parity","url":"https://www.spoj.com/problems/PARITY","users":83,"accepted":19.98}
+{"id":3578,"name":"Hashing","url":"https://www.spoj.com/problems/HASH","users":43,"accepted":12.06}
+{"id":3579,"name":"Disjoint Paths","url":"https://www.spoj.com/problems/DISJPATH","users":318,"accepted":20.79}
+{"id":3581,"name":"Tree Similarity","url":"https://www.spoj.com/problems/TREESIM","users":26,"accepted":37.66}
+{"id":3582,"name":"Restaurant Tab","url":"https://www.spoj.com/problems/RSTAURNT","users":24,"accepted":21.9}

--- a/tests/spoj/index/16.md
+++ b/tests/spoj/index/16.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 3388 | [Double Near Palindromes](https://www.spoj.com/problems/DNPALIN) | 456 | 34.21 |
+| 3389 | [The Knights of the Round Circle](https://www.spoj.com/problems/KNIGHTSR) | 450 | 66.78 |
+| 3390 | [Tribe Council](https://www.spoj.com/problems/TRIBE2) | 63 | 21.41 |
+| 3393 | [Knot or Not](https://www.spoj.com/problems/NOTOKNOT) | 10 | 16.67 |
+| 3394 | [Lagrange’s Four-Square Theorem](https://www.spoj.com/problems/LAGRANGE) | 532 | 46.08 |
+| 3405 | [Almost Shortest Path](https://www.spoj.com/problems/SAMER08A) | 1712 | 31.36 |
+| 3406 | [Bases](https://www.spoj.com/problems/SAMER08B) | 72 | 20.81 |
+| 3407 | [Candy](https://www.spoj.com/problems/SAMER08C) | 1368 | 42.64 |
+| 3408 | [DNA Sequences](https://www.spoj.com/problems/SAMER08D) | 1991 | 26.13 |
+| 3409 | [Electricity](https://www.spoj.com/problems/SAMER08E) | 811 | 47.73 |
+| 3410 | [Feynman](https://www.spoj.com/problems/SAMER08F) | 34519 | 57.48 |
+| 3411 | [Pole Position](https://www.spoj.com/problems/SAMER08G) | 920 | 47.42 |
+| 3412 | [Higgs Boson](https://www.spoj.com/problems/SAMER08H) | 52 | 19.09 |
+| 3413 | [Traveling Shoemaker Problem](https://www.spoj.com/problems/SAMER08I) | 77 | 17.32 |
+| 3414 | [Bora Bora](https://www.spoj.com/problems/SAMER08J) | 148 | 49.39 |
+| 3415 | [Shrinking Polygons](https://www.spoj.com/problems/SAMER08K) | 237 | 19.53 |
+| 3420 | [Falling Ice](https://www.spoj.com/problems/FALLINGI) | 7 | 12.50 |
+| 3426 | [Ouroboros Snake](https://www.spoj.com/problems/OROSNAKE) | 86 | 52.26 |
+| 3436 | [Histogram](https://www.spoj.com/problems/HIST2) | 1544 | 44.28 |
+| 3442 | [The last digit](https://www.spoj.com/problems/LASTDIG) | 30091 | 26.98 |
+| 3459 | [SkyScrapers](https://www.spoj.com/problems/CEPC08B) | 375 | 38.37 |
+| 3461 | [Song Contest](https://www.spoj.com/problems/SONG) | 16 | 15.74 |
+| 3462 | [The Skatepark´s New Ramps](https://www.spoj.com/problems/RAMP) | 9 | 9.71 |
+| 3463 | [Robintron](https://www.spoj.com/problems/ROBIN) | 8 | 22.06 |
+| 3464 | [Clock](https://www.spoj.com/problems/CLOCK1) | 66 | 36.90 |
+| 3465 | [Drive through MegaCity](https://www.spoj.com/problems/DRIVE) | 24 | 20.97 |
+| 3466 | [Another Longest Common Subsequence Problem](https://www.spoj.com/problems/CS) | 6 | 5.66 |
+| 3476 | [Deposit](https://www.spoj.com/problems/DEPOSIT) | 235 | 38.24 |
+| 3477 | [Baby](https://www.spoj.com/problems/BABY) | 955 | 46.67 |
+| 3482 | [Alias](https://www.spoj.com/problems/ALIAS) | 7 | 31.82 |
+| 3483 | [Begin](https://www.spoj.com/problems/BEGIN) | 4 | 7.94 |
+| 3484 | [Crossbits](https://www.spoj.com/problems/CROSSBIT) | 99 | 15.25 |
+| 3485 | [Disputes](https://www.spoj.com/problems/DISPUTES) | 86 | 63.75 |
+| 3486 | [Elimination](https://www.spoj.com/problems/ELIM) | 75 | 30.31 |
+| 3488 | [The  Top-Code](https://www.spoj.com/problems/TOPCODE) | 60 | 21.73 |
+| 3490 | [Hidden Triangle](https://www.spoj.com/problems/HIDTRI) | 12 | 26.87 |
+| 3492 | [Braille Transcription](https://www.spoj.com/problems/BRAILLE) | 16 | 14.16 |
+| 3495 | [The Nobel Thief](https://www.spoj.com/problems/NBLTHIEF) | 14 | 51.52 |
+| 3505 | [Prime Number Theorem](https://www.spoj.com/problems/CPRIME) | 1538 | 28.13 |
+| 3533 | [Game on board](https://www.spoj.com/problems/BGAME) | 26 | 31.14 |
+| 3543 | [Matrica](https://www.spoj.com/problems/MATRICA) | 56 | 39.90 |
+| 3544 | [Binary Search Tree](https://www.spoj.com/problems/BST) | 611 | 21.01 |
+| 3545 | [Najkraci](https://www.spoj.com/problems/NAJKRACI) | 188 | 28.95 |
+| 3565 | [Choosing Gloves](https://www.spoj.com/problems/GLOVE) | 89 | 23.25 |
+| 3576 | [Boy Scouts](https://www.spoj.com/problems/BOYSCOUT) | 145 | 28.31 |
+| 3577 | [Parity](https://www.spoj.com/problems/PARITY) | 83 | 19.98 |
+| 3578 | [Hashing](https://www.spoj.com/problems/HASH) | 43 | 12.06 |
+| 3579 | [Disjoint Paths](https://www.spoj.com/problems/DISJPATH) | 318 | 20.79 |
+| 3581 | [Tree Similarity](https://www.spoj.com/problems/TREESIM) | 26 | 37.66 |
+| 3582 | [Restaurant Tab](https://www.spoj.com/problems/RSTAURNT) | 24 | 21.90 |

--- a/tests/spoj/index/17.jsonl
+++ b/tests/spoj/index/17.jsonl
@@ -1,0 +1,50 @@
+{"id":3587,"name":"Prime Again","url":"https://www.spoj.com/problems/PAGAIN","users":879,"accepted":16.45}
+{"id":3591,"name":"Patting Heads","url":"https://www.spoj.com/problems/PATHEADS","users":659,"accepted":35.33}
+{"id":3605,"name":"Minimum Rotations","url":"https://www.spoj.com/problems/MINMOVE","users":921,"accepted":19.12}
+{"id":3638,"name":"Word Counting","url":"https://www.spoj.com/problems/WORDCNT","users":2642,"accepted":21.09}
+{"id":3639,"name":"Lucky Numbers","url":"https://www.spoj.com/problems/LUCKYNUM","users":733,"accepted":34.15}
+{"id":3640,"name":"Hanoi Subway System Construction","url":"https://www.spoj.com/problems/HNSUBWAY","users":36,"accepted":40.78}
+{"id":3641,"name":"Earthquakes","url":"https://www.spoj.com/problems/EARTHQK","users":26,"accepted":36.14}
+{"id":3642,"name":"Pretty Printing","url":"https://www.spoj.com/problems/PRETTYP","users":40,"accepted":22.01}
+{"id":3643,"name":"Traffic Network","url":"https://www.spoj.com/problems/TRAFFICN","users":2120,"accepted":18.3}
+{"id":3644,"name":"Winning Strategy","url":"https://www.spoj.com/problems/WINSTRAT","users":35,"accepted":18.4}
+{"id":3645,"name":"Farthest Headquarters","url":"https://www.spoj.com/problems/HEADQRT","users":60,"accepted":26.8}
+{"id":3646,"name":"Adventure Tourism","url":"https://www.spoj.com/problems/ATOURISM","users":46,"accepted":14.43}
+{"id":3647,"name":"Moebius","url":"https://www.spoj.com/problems/MOEBIUS","users":2,"accepted":2.36}
+{"id":3678,"name":"Cattle Bruisers","url":"https://www.spoj.com/problems/CATTLEB","users":91,"accepted":26.33}
+{"id":3679,"name":"Moo University - Emergency Pizza Order","url":"https://www.spoj.com/problems/MOOPIZZA","users":37,"accepted":27.4}
+{"id":3693,"name":"Maximum Sum","url":"https://www.spoj.com/problems/KGSS","users":6610,"accepted":42.43}
+{"id":3713,"name":"Primitive Root","url":"https://www.spoj.com/problems/PROOT","users":613,"accepted":30.6}
+{"id":3723,"name":"Snooker","url":"https://www.spoj.com/problems/SNOOKER","users":459,"accepted":50.51}
+{"id":3724,"name":"Rainbow Ride","url":"https://www.spoj.com/problems/RAINBOW","users":496,"accepted":36.12}
+{"id":3725,"name":"Taming a T-REX","url":"https://www.spoj.com/problems/TREX","users":151,"accepted":44.34}
+{"id":3732,"name":"Slikar","url":"https://www.spoj.com/problems/SLIKAR","users":213,"accepted":52.05}
+{"id":3733,"name":"Trezor","url":"https://www.spoj.com/problems/TREZOR","users":105,"accepted":52.34}
+{"id":3734,"name":"Periodni","url":"https://www.spoj.com/problems/PERIODNI","users":654,"accepted":38.68}
+{"id":3749,"name":"Subset Sums","url":"https://www.spoj.com/problems/SUBSUMS","users":4221,"accepted":26.66}
+{"id":3752,"name":"JEDNAKOST","url":"https://www.spoj.com/problems/JEDNAKOS","users":601,"accepted":18.46}
+{"id":3753,"name":"GONDOR","url":"https://www.spoj.com/problems/GONDOR","users":395,"accepted":53.39}
+{"id":3754,"name":"MAJMUN","url":"https://www.spoj.com/problems/MAJMUN","users":77,"accepted":40.47}
+{"id":3762,"name":"Bread Tree","url":"https://www.spoj.com/problems/BRTREE","users":163,"accepted":13.66}
+{"id":3763,"name":"George","url":"https://www.spoj.com/problems/GEORGE","users":528,"accepted":52.53}
+{"id":3791,"name":"Street","url":"https://www.spoj.com/problems/STREET","users":669,"accepted":51.43}
+{"id":3831,"name":"Lubenica","url":"https://www.spoj.com/problems/LUBEN","users":204,"accepted":42.5}
+{"id":3832,"name":"Kruska","url":"https://www.spoj.com/problems/KRUS","users":107,"accepted":46.57}
+{"id":3833,"name":"Tresnja","url":"https://www.spoj.com/problems/TRES","users":128,"accepted":52.33}
+{"id":3861,"name":"Laser Phones","url":"https://www.spoj.com/problems/MLASERP","users":1419,"accepted":28.88}
+{"id":3863,"name":"Area of circles","url":"https://www.spoj.com/problems/VCIRCLES","users":314,"accepted":29.44}
+{"id":3865,"name":"Reljef","url":"https://www.spoj.com/problems/RELJEF","users":94,"accepted":39.09}
+{"id":3866,"name":"Finding Palindromes","url":"https://www.spoj.com/problems/VPALIN","users":256,"accepted":19.58}
+{"id":3867,"name":"Who is The Boss","url":"https://www.spoj.com/problems/VBOSS","users":170,"accepted":25.29}
+{"id":3868,"name":"Total Flow","url":"https://www.spoj.com/problems/MTOTALF","users":1398,"accepted":36.29}
+{"id":3870,"name":"Military Story","url":"https://www.spoj.com/problems/VMILI","users":286,"accepted":28.81}
+{"id":3871,"name":"GCD Extreme","url":"https://www.spoj.com/problems/GCDEX","users":3088,"accepted":29.47}
+{"id":3872,"name":"Party At School","url":"https://www.spoj.com/problems/VPARTY","users":58,"accepted":24.87}
+{"id":3876,"name":"Tablica","url":"https://www.spoj.com/problems/TABLIC","users":206,"accepted":58.65}
+{"id":3877,"name":"Cvjetici","url":"https://www.spoj.com/problems/CVJETICI","users":986,"accepted":48.67}
+{"id":3878,"name":"Rectangles Perimeter","url":"https://www.spoj.com/problems/MMAXPER","users":2702,"accepted":49.87}
+{"id":3881,"name":"Majstor","url":"https://www.spoj.com/problems/MAJSTOR","users":735,"accepted":53.98}
+{"id":3882,"name":"Cijevi","url":"https://www.spoj.com/problems/CIJEVI","users":261,"accepted":38.2}
+{"id":3883,"name":"LATGACH3","url":"https://www.spoj.com/problems/M3TILE","users":3203,"accepted":56.57}
+{"id":3884,"name":"When (You Believe)","url":"https://www.spoj.com/problems/WHEN","users":24,"accepted":9.17}
+{"id":3885,"name":"Coins Game","url":"https://www.spoj.com/problems/MCOINS","users":5493,"accepted":45.27}

--- a/tests/spoj/index/17.md
+++ b/tests/spoj/index/17.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 3587 | [Prime Again](https://www.spoj.com/problems/PAGAIN) | 879 | 16.45 |
+| 3591 | [Patting Heads](https://www.spoj.com/problems/PATHEADS) | 659 | 35.33 |
+| 3605 | [Minimum Rotations](https://www.spoj.com/problems/MINMOVE) | 921 | 19.12 |
+| 3638 | [Word Counting](https://www.spoj.com/problems/WORDCNT) | 2642 | 21.09 |
+| 3639 | [Lucky Numbers](https://www.spoj.com/problems/LUCKYNUM) | 733 | 34.15 |
+| 3640 | [Hanoi Subway System Construction](https://www.spoj.com/problems/HNSUBWAY) | 36 | 40.78 |
+| 3641 | [Earthquakes](https://www.spoj.com/problems/EARTHQK) | 26 | 36.14 |
+| 3642 | [Pretty Printing](https://www.spoj.com/problems/PRETTYP) | 40 | 22.01 |
+| 3643 | [Traffic Network](https://www.spoj.com/problems/TRAFFICN) | 2120 | 18.30 |
+| 3644 | [Winning Strategy](https://www.spoj.com/problems/WINSTRAT) | 35 | 18.40 |
+| 3645 | [Farthest Headquarters](https://www.spoj.com/problems/HEADQRT) | 60 | 26.80 |
+| 3646 | [Adventure Tourism](https://www.spoj.com/problems/ATOURISM) | 46 | 14.43 |
+| 3647 | [Moebius](https://www.spoj.com/problems/MOEBIUS) | 2 | 2.36 |
+| 3678 | [Cattle Bruisers](https://www.spoj.com/problems/CATTLEB) | 91 | 26.33 |
+| 3679 | [Moo University - Emergency Pizza Order](https://www.spoj.com/problems/MOOPIZZA) | 37 | 27.40 |
+| 3693 | [Maximum Sum](https://www.spoj.com/problems/KGSS) | 6610 | 42.43 |
+| 3713 | [Primitive Root](https://www.spoj.com/problems/PROOT) | 613 | 30.60 |
+| 3723 | [Snooker](https://www.spoj.com/problems/SNOOKER) | 459 | 50.51 |
+| 3724 | [Rainbow Ride](https://www.spoj.com/problems/RAINBOW) | 496 | 36.12 |
+| 3725 | [Taming a T-REX](https://www.spoj.com/problems/TREX) | 151 | 44.34 |
+| 3732 | [Slikar](https://www.spoj.com/problems/SLIKAR) | 213 | 52.05 |
+| 3733 | [Trezor](https://www.spoj.com/problems/TREZOR) | 105 | 52.34 |
+| 3734 | [Periodni](https://www.spoj.com/problems/PERIODNI) | 654 | 38.68 |
+| 3749 | [Subset Sums](https://www.spoj.com/problems/SUBSUMS) | 4221 | 26.66 |
+| 3752 | [JEDNAKOST](https://www.spoj.com/problems/JEDNAKOS) | 601 | 18.46 |
+| 3753 | [GONDOR](https://www.spoj.com/problems/GONDOR) | 395 | 53.39 |
+| 3754 | [MAJMUN](https://www.spoj.com/problems/MAJMUN) | 77 | 40.47 |
+| 3762 | [Bread Tree](https://www.spoj.com/problems/BRTREE) | 163 | 13.66 |
+| 3763 | [George](https://www.spoj.com/problems/GEORGE) | 528 | 52.53 |
+| 3791 | [Street](https://www.spoj.com/problems/STREET) | 669 | 51.43 |
+| 3831 | [Lubenica](https://www.spoj.com/problems/LUBEN) | 204 | 42.50 |
+| 3832 | [Kruska](https://www.spoj.com/problems/KRUS) | 107 | 46.57 |
+| 3833 | [Tresnja](https://www.spoj.com/problems/TRES) | 128 | 52.33 |
+| 3861 | [Laser Phones](https://www.spoj.com/problems/MLASERP) | 1419 | 28.88 |
+| 3863 | [Area of circles](https://www.spoj.com/problems/VCIRCLES) | 314 | 29.44 |
+| 3865 | [Reljef](https://www.spoj.com/problems/RELJEF) | 94 | 39.09 |
+| 3866 | [Finding Palindromes](https://www.spoj.com/problems/VPALIN) | 256 | 19.58 |
+| 3867 | [Who is The Boss](https://www.spoj.com/problems/VBOSS) | 170 | 25.29 |
+| 3868 | [Total Flow](https://www.spoj.com/problems/MTOTALF) | 1398 | 36.29 |
+| 3870 | [Military Story](https://www.spoj.com/problems/VMILI) | 286 | 28.81 |
+| 3871 | [GCD Extreme](https://www.spoj.com/problems/GCDEX) | 3088 | 29.47 |
+| 3872 | [Party At School](https://www.spoj.com/problems/VPARTY) | 58 | 24.87 |
+| 3876 | [Tablica](https://www.spoj.com/problems/TABLIC) | 206 | 58.65 |
+| 3877 | [Cvjetici](https://www.spoj.com/problems/CVJETICI) | 986 | 48.67 |
+| 3878 | [Rectangles Perimeter](https://www.spoj.com/problems/MMAXPER) | 2702 | 49.87 |
+| 3881 | [Majstor](https://www.spoj.com/problems/MAJSTOR) | 735 | 53.98 |
+| 3882 | [Cijevi](https://www.spoj.com/problems/CIJEVI) | 261 | 38.20 |
+| 3883 | [LATGACH3](https://www.spoj.com/problems/M3TILE) | 3203 | 56.57 |
+| 3884 | [When (You Believe)](https://www.spoj.com/problems/WHEN) | 24 | 9.17 |
+| 3885 | [Coins Game](https://www.spoj.com/problems/MCOINS) | 5493 | 45.27 |

--- a/tests/spoj/index/18.jsonl
+++ b/tests/spoj/index/18.jsonl
@@ -1,0 +1,50 @@
+{"id":3889,"name":"Closest Number","url":"https://www.spoj.com/problems/MCLONUM","users":195,"accepted":30.29}
+{"id":3890,"name":"Rectangles  Counting","url":"https://www.spoj.com/problems/MRECTCNT","users":175,"accepted":33.61}
+{"id":3893,"name":"Space settlement","url":"https://www.spoj.com/problems/SPACESET","users":67,"accepted":31.56}
+{"id":3894,"name":"Bouncing Balls","url":"https://www.spoj.com/problems/BOBALLS","users":28,"accepted":31.54}
+{"id":3895,"name":"Matrix Game","url":"https://www.spoj.com/problems/MTRGAME","users":26,"accepted":21.77}
+{"id":3896,"name":"Maximal Independent Set","url":"https://www.spoj.com/problems/MAXISET","users":61,"accepted":25.19}
+{"id":3897,"name":"Convex Polygons","url":"https://www.spoj.com/problems/CVXPOLY","users":124,"accepted":30.86}
+{"id":3898,"name":"Even Palindrome","url":"https://www.spoj.com/problems/PALDR","users":251,"accepted":10.23}
+{"id":3899,"name":"Finding Fractions","url":"https://www.spoj.com/problems/FINFRAC","users":174,"accepted":29.46}
+{"id":3900,"name":"MinCut Query","url":"https://www.spoj.com/problems/MCQUERY","users":78,"accepted":28.99}
+{"id":3901,"name":"Black and White Nim","url":"https://www.spoj.com/problems/BNWNIM","users":55,"accepted":39.23}
+{"id":3902,"name":"Fight with functions","url":"https://www.spoj.com/problems/FWFUNC","users":21,"accepted":6.52}
+{"id":3909,"name":"CALCULATE POW(2004,X) MOD 29","url":"https://www.spoj.com/problems/MMOD29","users":279,"accepted":56.7}
+{"id":3912,"name":"Color a tree","url":"https://www.spoj.com/problems/MTREECOL","users":298,"accepted":31.76}
+{"id":3915,"name":"Star Polygon or Not","url":"https://www.spoj.com/problems/MPOLSTAR","users":40,"accepted":54.74}
+{"id":3920,"name":"Lucius Dungeon","url":"https://www.spoj.com/problems/BYTESE1","users":1752,"accepted":38.84}
+{"id":3921,"name":"The Great Ball","url":"https://www.spoj.com/problems/BYTESE2","users":3950,"accepted":39.19}
+{"id":3922,"name":"Mystical River","url":"https://www.spoj.com/problems/BYTESM1","users":128,"accepted":25.67}
+{"id":3923,"name":"Philosophers Stone","url":"https://www.spoj.com/problems/BYTESM2","users":12860,"accepted":43.53}
+{"id":3924,"name":"Filchs Dilemna","url":"https://www.spoj.com/problems/BYTESH1","users":533,"accepted":65.21}
+{"id":3926,"name":"Manhattan Wire","url":"https://www.spoj.com/problems/MMAHWIRE","users":80,"accepted":14.07}
+{"id":3927,"name":"Polygon on the Grid","url":"https://www.spoj.com/problems/MPOLGRID","users":23,"accepted":30.34}
+{"id":3928,"name":"Counting Digits","url":"https://www.spoj.com/problems/MDIGITS","users":1304,"accepted":46.48}
+{"id":3929,"name":"Different Digits","url":"https://www.spoj.com/problems/MDIGITS1","users":74,"accepted":22.75}
+{"id":3930,"name":"Group Partition","url":"https://www.spoj.com/problems/MPART","users":71,"accepted":30.23}
+{"id":3931,"name":"Maximum Triangle Area","url":"https://www.spoj.com/problems/MTRIAREA","users":283,"accepted":29.27}
+{"id":3932,"name":"Point Connection Game in a Circle","url":"https://www.spoj.com/problems/MCIRGAME","users":768,"accepted":35.47}
+{"id":3933,"name":"Minimum Permutation","url":"https://www.spoj.com/problems/MMINPER","users":187,"accepted":38.34}
+{"id":3934,"name":"Recaman’s Sequence","url":"https://www.spoj.com/problems/MRECAMAN","users":3536,"accepted":53.87}
+{"id":3935,"name":"SHIFT Operator on Matrix","url":"https://www.spoj.com/problems/MMATRIX","users":191,"accepted":42.38}
+{"id":3936,"name":"Repair City Hall","url":"https://www.spoj.com/problems/MCITYHAL","users":248,"accepted":50.82}
+{"id":3937,"name":"Wooden Sticks","url":"https://www.spoj.com/problems/MSTICK","users":681,"accepted":36.97}
+{"id":3939,"name":"Search of Concatenated Strings","url":"https://www.spoj.com/problems/MCONSTR","users":28,"accepted":24.4}
+{"id":3940,"name":"Sum of Primes","url":"https://www.spoj.com/problems/MPRIME1","users":236,"accepted":63.84}
+{"id":3941,"name":"Kth Shortest Path","url":"https://www.spoj.com/problems/MKTHPATH","users":25,"accepted":24.3}
+{"id":3942,"name":"Cleaning Robot","url":"https://www.spoj.com/problems/MCLEAN","users":34,"accepted":65.28}
+{"id":3943,"name":"Nested Dolls","url":"https://www.spoj.com/problems/MDOLLS","users":1239,"accepted":23.66}
+{"id":3944,"name":"Bee Walk","url":"https://www.spoj.com/problems/MBEEWALK","users":1434,"accepted":56.39}
+{"id":3946,"name":"K-th Number","url":"https://www.spoj.com/problems/MKTHNUM","users":5812,"accepted":35.36}
+{"id":3948,"name":"Polynomial Evaluation - Angry Teacher","url":"https://www.spoj.com/problems/MPOLEVAL","users":31,"accepted":15.1}
+{"id":3953,"name":"Paid Roads","url":"https://www.spoj.com/problems/MMINPAID","users":261,"accepted":27.57}
+{"id":3961,"name":"Journey with Pigs","url":"https://www.spoj.com/problems/MJOURNEY","users":133,"accepted":41.31}
+{"id":3962,"name":"ELEVATOR II","url":"https://www.spoj.com/problems/MELE2","users":101,"accepted":43.31}
+{"id":3964,"name":"Investment Money","url":"https://www.spoj.com/problems/MINVEST","users":627,"accepted":25.73}
+{"id":3965,"name":"Minimax Triangulation","url":"https://www.spoj.com/problems/MMINMAX","users":60,"accepted":40}
+{"id":3969,"name":"M\u0026M Game","url":"https://www.spoj.com/problems/MMMGAME","users":1319,"accepted":42.34}
+{"id":3970,"name":"Convert to Decimal Base System","url":"https://www.spoj.com/problems/MCONVERT","users":56,"accepted":37.34}
+{"id":3972,"name":"Stargates","url":"https://www.spoj.com/problems/STARGATE","users":49,"accepted":14.12}
+{"id":3973,"name":"0 0 Pairs","url":"https://www.spoj.com/problems/M00PAIR","users":806,"accepted":27.34}
+{"id":3974,"name":"Another Tree Problem","url":"https://www.spoj.com/problems/MTREE","users":647,"accepted":32.53}

--- a/tests/spoj/index/18.md
+++ b/tests/spoj/index/18.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 3889 | [Closest Number](https://www.spoj.com/problems/MCLONUM) | 195 | 30.29 |
+| 3890 | [Rectangles  Counting](https://www.spoj.com/problems/MRECTCNT) | 175 | 33.61 |
+| 3893 | [Space settlement](https://www.spoj.com/problems/SPACESET) | 67 | 31.56 |
+| 3894 | [Bouncing Balls](https://www.spoj.com/problems/BOBALLS) | 28 | 31.54 |
+| 3895 | [Matrix Game](https://www.spoj.com/problems/MTRGAME) | 26 | 21.77 |
+| 3896 | [Maximal Independent Set](https://www.spoj.com/problems/MAXISET) | 61 | 25.19 |
+| 3897 | [Convex Polygons](https://www.spoj.com/problems/CVXPOLY) | 124 | 30.86 |
+| 3898 | [Even Palindrome](https://www.spoj.com/problems/PALDR) | 251 | 10.23 |
+| 3899 | [Finding Fractions](https://www.spoj.com/problems/FINFRAC) | 174 | 29.46 |
+| 3900 | [MinCut Query](https://www.spoj.com/problems/MCQUERY) | 78 | 28.99 |
+| 3901 | [Black and White Nim](https://www.spoj.com/problems/BNWNIM) | 55 | 39.23 |
+| 3902 | [Fight with functions](https://www.spoj.com/problems/FWFUNC) | 21 | 6.52 |
+| 3909 | [CALCULATE POW(2004,X) MOD 29](https://www.spoj.com/problems/MMOD29) | 279 | 56.70 |
+| 3912 | [Color a tree](https://www.spoj.com/problems/MTREECOL) | 298 | 31.76 |
+| 3915 | [Star Polygon or Not](https://www.spoj.com/problems/MPOLSTAR) | 40 | 54.74 |
+| 3920 | [Lucius Dungeon](https://www.spoj.com/problems/BYTESE1) | 1752 | 38.84 |
+| 3921 | [The Great Ball](https://www.spoj.com/problems/BYTESE2) | 3950 | 39.19 |
+| 3922 | [Mystical River](https://www.spoj.com/problems/BYTESM1) | 128 | 25.67 |
+| 3923 | [Philosophers Stone](https://www.spoj.com/problems/BYTESM2) | 12860 | 43.53 |
+| 3924 | [Filchs Dilemna](https://www.spoj.com/problems/BYTESH1) | 533 | 65.21 |
+| 3926 | [Manhattan Wire](https://www.spoj.com/problems/MMAHWIRE) | 80 | 14.07 |
+| 3927 | [Polygon on the Grid](https://www.spoj.com/problems/MPOLGRID) | 23 | 30.34 |
+| 3928 | [Counting Digits](https://www.spoj.com/problems/MDIGITS) | 1304 | 46.48 |
+| 3929 | [Different Digits](https://www.spoj.com/problems/MDIGITS1) | 74 | 22.75 |
+| 3930 | [Group Partition](https://www.spoj.com/problems/MPART) | 71 | 30.23 |
+| 3931 | [Maximum Triangle Area](https://www.spoj.com/problems/MTRIAREA) | 283 | 29.27 |
+| 3932 | [Point Connection Game in a Circle](https://www.spoj.com/problems/MCIRGAME) | 768 | 35.47 |
+| 3933 | [Minimum Permutation](https://www.spoj.com/problems/MMINPER) | 187 | 38.34 |
+| 3934 | [Recaman’s Sequence](https://www.spoj.com/problems/MRECAMAN) | 3536 | 53.87 |
+| 3935 | [SHIFT Operator on Matrix](https://www.spoj.com/problems/MMATRIX) | 191 | 42.38 |
+| 3936 | [Repair City Hall](https://www.spoj.com/problems/MCITYHAL) | 248 | 50.82 |
+| 3937 | [Wooden Sticks](https://www.spoj.com/problems/MSTICK) | 681 | 36.97 |
+| 3939 | [Search of Concatenated Strings](https://www.spoj.com/problems/MCONSTR) | 28 | 24.40 |
+| 3940 | [Sum of Primes](https://www.spoj.com/problems/MPRIME1) | 236 | 63.84 |
+| 3941 | [Kth Shortest Path](https://www.spoj.com/problems/MKTHPATH) | 25 | 24.30 |
+| 3942 | [Cleaning Robot](https://www.spoj.com/problems/MCLEAN) | 34 | 65.28 |
+| 3943 | [Nested Dolls](https://www.spoj.com/problems/MDOLLS) | 1239 | 23.66 |
+| 3944 | [Bee Walk](https://www.spoj.com/problems/MBEEWALK) | 1434 | 56.39 |
+| 3946 | [K-th Number](https://www.spoj.com/problems/MKTHNUM) | 5812 | 35.36 |
+| 3948 | [Polynomial Evaluation - Angry Teacher](https://www.spoj.com/problems/MPOLEVAL) | 31 | 15.10 |
+| 3953 | [Paid Roads](https://www.spoj.com/problems/MMINPAID) | 261 | 27.57 |
+| 3961 | [Journey with Pigs](https://www.spoj.com/problems/MJOURNEY) | 133 | 41.31 |
+| 3962 | [ELEVATOR II](https://www.spoj.com/problems/MELE2) | 101 | 43.31 |
+| 3964 | [Investment Money](https://www.spoj.com/problems/MINVEST) | 627 | 25.73 |
+| 3965 | [Minimax Triangulation](https://www.spoj.com/problems/MMINMAX) | 60 | 40.00 |
+| 3969 | [M&M Game](https://www.spoj.com/problems/MMMGAME) | 1319 | 42.34 |
+| 3970 | [Convert to Decimal Base System](https://www.spoj.com/problems/MCONVERT) | 56 | 37.34 |
+| 3972 | [Stargates](https://www.spoj.com/problems/STARGATE) | 49 | 14.12 |
+| 3973 | [0 0 Pairs](https://www.spoj.com/problems/M00PAIR) | 806 | 27.34 |
+| 3974 | [Another Tree Problem](https://www.spoj.com/problems/MTREE) | 647 | 32.53 |

--- a/tests/spoj/index/19.jsonl
+++ b/tests/spoj/index/19.jsonl
@@ -1,0 +1,50 @@
+{"id":3975,"name":"Most Servings Meal","url":"https://www.spoj.com/problems/MKUHAR","users":354,"accepted":26.37}
+{"id":3977,"name":"Police Query","url":"https://www.spoj.com/problems/POLQUERY","users":302,"accepted":17.37}
+{"id":3978,"name":"Distance Query","url":"https://www.spoj.com/problems/DISQUERY","users":1945,"accepted":33.21}
+{"id":3979,"name":"Whirligig number","url":"https://www.spoj.com/problems/MZVRK","users":1030,"accepted":38.07}
+{"id":3980,"name":"Point Visible","url":"https://www.spoj.com/problems/MPOINT","users":48,"accepted":27.4}
+{"id":3981,"name":"Shortest Regular Bracket","url":"https://www.spoj.com/problems/MBRACKET","users":82,"accepted":33.78}
+{"id":3982,"name":"String problem","url":"https://www.spoj.com/problems/MSTRING","users":608,"accepted":48.82}
+{"id":3983,"name":"Right Triangle Counting","url":"https://www.spoj.com/problems/RIGHTTRI","users":190,"accepted":17.72}
+{"id":3999,"name":"FROGGER","url":"https://www.spoj.com/problems/FROGGER","users":104,"accepted":26.72}
+{"id":4000,"name":"GALLUP","url":"https://www.spoj.com/problems/GALLUP","users":70,"accepted":46.54}
+{"id":4003,"name":"Subway planning","url":"https://www.spoj.com/problems/SUBWAYPL","users":43,"accepted":18.68}
+{"id":4004,"name":"Exploding CPU","url":"https://www.spoj.com/problems/CPU","users":146,"accepted":46.49}
+{"id":4008,"name":"Con Voi","url":"https://www.spoj.com/problems/MCONVOI","users":9,"accepted":57.69}
+{"id":4010,"name":"Chặt cây","url":"https://www.spoj.com/problems/OPTCUT","users":11,"accepted":22.58}
+{"id":4021,"name":"Bipalindrome","url":"https://www.spoj.com/problems/MBIPALIN","users":183,"accepted":30.77}
+{"id":4031,"name":"Mass of Molecule","url":"https://www.spoj.com/problems/MMASS","users":2610,"accepted":48.17}
+{"id":4033,"name":"Phone List","url":"https://www.spoj.com/problems/PHONELST","users":7326,"accepted":31.83}
+{"id":4034,"name":"Pizza Delivery","url":"https://www.spoj.com/problems/MDOSTAVA","users":53,"accepted":16.55}
+{"id":4035,"name":"NERED","url":"https://www.spoj.com/problems/MNERED","users":395,"accepted":57.76}
+{"id":4036,"name":"Cuckoo Hashing","url":"https://www.spoj.com/problems/CUCKOO","users":152,"accepted":27.39}
+{"id":4038,"name":"Counting The Way of Bracket Replacement","url":"https://www.spoj.com/problems/MREPLBRC","users":440,"accepted":38.68}
+{"id":4052,"name":"Game","url":"https://www.spoj.com/problems/MGAME1","users":75,"accepted":29.27}
+{"id":4053,"name":"Card Sorting","url":"https://www.spoj.com/problems/MCARDS","users":695,"accepted":43.65}
+{"id":4060,"name":"A game with probability","url":"https://www.spoj.com/problems/KPGAME","users":210,"accepted":22.15}
+{"id":4061,"name":"Polygon","url":"https://www.spoj.com/problems/MPOLY","users":215,"accepted":31.41}
+{"id":4062,"name":"Rob Mini-Safe","url":"https://www.spoj.com/problems/MSAFE","users":114,"accepted":39.46}
+{"id":4063,"name":"Sell Pigs","url":"https://www.spoj.com/problems/MPIGS","users":479,"accepted":52.07}
+{"id":4069,"name":"Morphing is Fun","url":"https://www.spoj.com/problems/MORPH","users":29,"accepted":16.07}
+{"id":4070,"name":"Two Professors","url":"https://www.spoj.com/problems/TWOPROF","users":104,"accepted":14.12}
+{"id":4082,"name":"BLAST","url":"https://www.spoj.com/problems/MBLAST","users":1760,"accepted":51.73}
+{"id":4083,"name":"Tele Broadcast","url":"https://www.spoj.com/problems/MTELE","users":67,"accepted":50.26}
+{"id":4097,"name":"Locomotive","url":"https://www.spoj.com/problems/MTRAIN","users":35,"accepted":38.3}
+{"id":4100,"name":"Sum of Vectors","url":"https://www.spoj.com/problems/MVECTOR","users":103,"accepted":29.6}
+{"id":4103,"name":"Extend to Palindrome","url":"https://www.spoj.com/problems/EPALIN","users":2582,"accepted":30.54}
+{"id":4110,"name":"Fast Maximum Flow","url":"https://www.spoj.com/problems/FASTFLOW","users":3051,"accepted":34.25}
+{"id":4141,"name":"Euler Totient Function","url":"https://www.spoj.com/problems/ETF","users":12018,"accepted":38.99}
+{"id":4142,"name":"Ellipse","url":"https://www.spoj.com/problems/ELLIPSE","users":21,"accepted":9.46}
+{"id":4154,"name":"IZBORI","url":"https://www.spoj.com/problems/IZBORI","users":42,"accepted":26.67}
+{"id":4155,"name":"OTOCI","url":"https://www.spoj.com/problems/OTOCI","users":512,"accepted":45.42}
+{"id":4156,"name":"PLAHTE","url":"https://www.spoj.com/problems/PLAHTE","users":69,"accepted":35.77}
+{"id":4157,"name":"Domino","url":"https://www.spoj.com/problems/DOMINO2","users":56,"accepted":49.8}
+{"id":4160,"name":"A1 Road","url":"https://www.spoj.com/problems/MA1","users":89,"accepted":50.9}
+{"id":4164,"name":"A conjecture of Paul Erdős","url":"https://www.spoj.com/problems/HS08PAUL","users":2668,"accepted":43.75}
+{"id":4166,"name":"Four colors","url":"https://www.spoj.com/problems/HS08FOUR","users":104,"accepted":22.01}
+{"id":4168,"name":"Square-free integers","url":"https://www.spoj.com/problems/SQFREE","users":779,"accepted":46.19}
+{"id":4172,"name":"Multiplicative digital root","url":"https://www.spoj.com/problems/DROOT","users":77,"accepted":24.16}
+{"id":4176,"name":"A Knightly Pursuit","url":"https://www.spoj.com/problems/KPURSUIT","users":67,"accepted":29.28}
+{"id":4177,"name":"Herding","url":"https://www.spoj.com/problems/HERDING","users":2730,"accepted":35.22}
+{"id":4178,"name":"Distance on a square lattice","url":"https://www.spoj.com/problems/LATTICE","users":130,"accepted":54.41}
+{"id":4179,"name":"Temptation Island","url":"https://www.spoj.com/problems/TEMPTISL","users":654,"accepted":45.05}

--- a/tests/spoj/index/19.md
+++ b/tests/spoj/index/19.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 3975 | [Most Servings Meal](https://www.spoj.com/problems/MKUHAR) | 354 | 26.37 |
+| 3977 | [Police Query](https://www.spoj.com/problems/POLQUERY) | 302 | 17.37 |
+| 3978 | [Distance Query](https://www.spoj.com/problems/DISQUERY) | 1945 | 33.21 |
+| 3979 | [Whirligig number](https://www.spoj.com/problems/MZVRK) | 1030 | 38.07 |
+| 3980 | [Point Visible](https://www.spoj.com/problems/MPOINT) | 48 | 27.40 |
+| 3981 | [Shortest Regular Bracket](https://www.spoj.com/problems/MBRACKET) | 82 | 33.78 |
+| 3982 | [String problem](https://www.spoj.com/problems/MSTRING) | 608 | 48.82 |
+| 3983 | [Right Triangle Counting](https://www.spoj.com/problems/RIGHTTRI) | 190 | 17.72 |
+| 3999 | [FROGGER](https://www.spoj.com/problems/FROGGER) | 104 | 26.72 |
+| 4000 | [GALLUP](https://www.spoj.com/problems/GALLUP) | 70 | 46.54 |
+| 4003 | [Subway planning](https://www.spoj.com/problems/SUBWAYPL) | 43 | 18.68 |
+| 4004 | [Exploding CPU](https://www.spoj.com/problems/CPU) | 146 | 46.49 |
+| 4008 | [Con Voi](https://www.spoj.com/problems/MCONVOI) | 9 | 57.69 |
+| 4010 | [Chặt cây](https://www.spoj.com/problems/OPTCUT) | 11 | 22.58 |
+| 4021 | [Bipalindrome](https://www.spoj.com/problems/MBIPALIN) | 183 | 30.77 |
+| 4031 | [Mass of Molecule](https://www.spoj.com/problems/MMASS) | 2610 | 48.17 |
+| 4033 | [Phone List](https://www.spoj.com/problems/PHONELST) | 7326 | 31.83 |
+| 4034 | [Pizza Delivery](https://www.spoj.com/problems/MDOSTAVA) | 53 | 16.55 |
+| 4035 | [NERED](https://www.spoj.com/problems/MNERED) | 395 | 57.76 |
+| 4036 | [Cuckoo Hashing](https://www.spoj.com/problems/CUCKOO) | 152 | 27.39 |
+| 4038 | [Counting The Way of Bracket Replacement](https://www.spoj.com/problems/MREPLBRC) | 440 | 38.68 |
+| 4052 | [Game](https://www.spoj.com/problems/MGAME1) | 75 | 29.27 |
+| 4053 | [Card Sorting](https://www.spoj.com/problems/MCARDS) | 695 | 43.65 |
+| 4060 | [A game with probability](https://www.spoj.com/problems/KPGAME) | 210 | 22.15 |
+| 4061 | [Polygon](https://www.spoj.com/problems/MPOLY) | 215 | 31.41 |
+| 4062 | [Rob Mini-Safe](https://www.spoj.com/problems/MSAFE) | 114 | 39.46 |
+| 4063 | [Sell Pigs](https://www.spoj.com/problems/MPIGS) | 479 | 52.07 |
+| 4069 | [Morphing is Fun](https://www.spoj.com/problems/MORPH) | 29 | 16.07 |
+| 4070 | [Two Professors](https://www.spoj.com/problems/TWOPROF) | 104 | 14.12 |
+| 4082 | [BLAST](https://www.spoj.com/problems/MBLAST) | 1760 | 51.73 |
+| 4083 | [Tele Broadcast](https://www.spoj.com/problems/MTELE) | 67 | 50.26 |
+| 4097 | [Locomotive](https://www.spoj.com/problems/MTRAIN) | 35 | 38.30 |
+| 4100 | [Sum of Vectors](https://www.spoj.com/problems/MVECTOR) | 103 | 29.60 |
+| 4103 | [Extend to Palindrome](https://www.spoj.com/problems/EPALIN) | 2582 | 30.54 |
+| 4110 | [Fast Maximum Flow](https://www.spoj.com/problems/FASTFLOW) | 3051 | 34.25 |
+| 4141 | [Euler Totient Function](https://www.spoj.com/problems/ETF) | 12018 | 38.99 |
+| 4142 | [Ellipse](https://www.spoj.com/problems/ELLIPSE) | 21 | 9.46 |
+| 4154 | [IZBORI](https://www.spoj.com/problems/IZBORI) | 42 | 26.67 |
+| 4155 | [OTOCI](https://www.spoj.com/problems/OTOCI) | 512 | 45.42 |
+| 4156 | [PLAHTE](https://www.spoj.com/problems/PLAHTE) | 69 | 35.77 |
+| 4157 | [Domino](https://www.spoj.com/problems/DOMINO2) | 56 | 49.80 |
+| 4160 | [A1 Road](https://www.spoj.com/problems/MA1) | 89 | 50.90 |
+| 4164 | [A conjecture of Paul Erdős](https://www.spoj.com/problems/HS08PAUL) | 2668 | 43.75 |
+| 4166 | [Four colors](https://www.spoj.com/problems/HS08FOUR) | 104 | 22.01 |
+| 4168 | [Square-free integers](https://www.spoj.com/problems/SQFREE) | 779 | 46.19 |
+| 4172 | [Multiplicative digital root](https://www.spoj.com/problems/DROOT) | 77 | 24.16 |
+| 4176 | [A Knightly Pursuit](https://www.spoj.com/problems/KPURSUIT) | 67 | 29.28 |
+| 4177 | [Herding](https://www.spoj.com/problems/HERDING) | 2730 | 35.22 |
+| 4178 | [Distance on a square lattice](https://www.spoj.com/problems/LATTICE) | 130 | 54.41 |
+| 4179 | [Temptation Island](https://www.spoj.com/problems/TEMPTISL) | 654 | 45.05 |

--- a/tests/spoj/index/20.jsonl
+++ b/tests/spoj/index/20.jsonl
@@ -1,0 +1,50 @@
+{"id":4180,"name":"Pizza Location","url":"https://www.spoj.com/problems/PIZZALOC","users":576,"accepted":18.59}
+{"id":4181,"name":"MELE3","url":"https://www.spoj.com/problems/MELE3","users":616,"accepted":42.69}
+{"id":4182,"name":"Candy (Again)","url":"https://www.spoj.com/problems/FCANDY","users":236,"accepted":18.78}
+{"id":4185,"name":"Cube","url":"https://www.spoj.com/problems/CCCCUBE","users":57,"accepted":35.57}
+{"id":4186,"name":"Break a New RSA system","url":"https://www.spoj.com/problems/HS08CODE","users":138,"accepted":34.12}
+{"id":4188,"name":"Amazing equality","url":"https://www.spoj.com/problems/HS08EQ","users":42,"accepted":13.88}
+{"id":4189,"name":"Landing","url":"https://www.spoj.com/problems/LANDING","users":6,"accepted":3.09}
+{"id":4191,"name":"Sky Code","url":"https://www.spoj.com/problems/MSKYCODE","users":774,"accepted":29.57}
+{"id":4194,"name":"Another Lucky Numbers","url":"https://www.spoj.com/problems/MSE08G","users":142,"accepted":33.44}
+{"id":4195,"name":"GCD Determinant","url":"https://www.spoj.com/problems/MSE08H","users":273,"accepted":45.3}
+{"id":4197,"name":"Dominoes","url":"https://www.spoj.com/problems/DOMINOES","users":125,"accepted":23.08}
+{"id":4198,"name":"Lego","url":"https://www.spoj.com/problems/LEGO","users":195,"accepted":25.4}
+{"id":4200,"name":"Hamster flight","url":"https://www.spoj.com/problems/HAMSTER1","users":1160,"accepted":45.54}
+{"id":4201,"name":"Coder Ratings","url":"https://www.spoj.com/problems/RATING","users":1397,"accepted":35.83}
+{"id":4202,"name":"Brackets Parade","url":"https://www.spoj.com/problems/BRPAR","users":238,"accepted":45.03}
+{"id":4203,"name":"Double Queue","url":"https://www.spoj.com/problems/MSE07B","users":84,"accepted":41.38}
+{"id":4204,"name":"Showstopper","url":"https://www.spoj.com/problems/MSE07E","users":89,"accepted":22.45}
+{"id":4206,"name":"Fast Maximum Matching","url":"https://www.spoj.com/problems/MATCHING","users":2085,"accepted":29.45}
+{"id":4210,"name":"Fast Maximum Matching","url":"https://www.spoj.com/problems/FMATCH","users":19,"accepted":48.08}
+{"id":4211,"name":"Fast Maximum Flow","url":"https://www.spoj.com/problems/FFLOW","users":21,"accepted":24.62}
+{"id":4212,"name":"Another Longest Increasing Subsequence Problem","url":"https://www.spoj.com/problems/LIS2VN","users":14,"accepted":42.5}
+{"id":4225,"name":"Payment System","url":"https://www.spoj.com/problems/MSE06E","users":31,"accepted":61.9}
+{"id":4226,"name":"Japan","url":"https://www.spoj.com/problems/MSE06H","users":1803,"accepted":23.39}
+{"id":4227,"name":"\"Shortest\" pair of paths","url":"https://www.spoj.com/problems/MSE06I","users":214,"accepted":41.11}
+{"id":4235,"name":"Wandering Queen","url":"https://www.spoj.com/problems/QUEEN","users":867,"accepted":14.97}
+{"id":4259,"name":"Pilots","url":"https://www.spoj.com/problems/MPILOT","users":1750,"accepted":31.7}
+{"id":4273,"name":"Train TimeTable","url":"https://www.spoj.com/problems/TTTABLE","users":426,"accepted":34.14}
+{"id":4275,"name":"rotate it","url":"https://www.spoj.com/problems/BFROTATE","users":40,"accepted":55.7}
+{"id":4278,"name":"Battlefield","url":"https://www.spoj.com/problems/FIELD","users":8,"accepted":38.89}
+{"id":4300,"name":"Rectangles","url":"https://www.spoj.com/problems/AE00","users":27060,"accepted":49.75}
+{"id":4302,"name":"(K,N)-Knight","url":"https://www.spoj.com/problems/AE2B","users":315,"accepted":25.2}
+{"id":4303,"name":"Dice","url":"https://www.spoj.com/problems/AE2A","users":929,"accepted":15.72}
+{"id":4305,"name":"Drilling","url":"https://www.spoj.com/problems/AE3A","users":121,"accepted":20.15}
+{"id":4306,"name":"The way to Bytemountain","url":"https://www.spoj.com/problems/AE4B","users":34,"accepted":41.3}
+{"id":4307,"name":"Stamps","url":"https://www.spoj.com/problems/AE4A","users":33,"accepted":41.94}
+{"id":4308,"name":"Byteantean towns","url":"https://www.spoj.com/problems/AE5B1","users":58,"accepted":24.65}
+{"id":4309,"name":"Circular game","url":"https://www.spoj.com/problems/AE5A1","users":35,"accepted":19.7}
+{"id":4310,"name":"Permutacja","url":"https://www.spoj.com/problems/AE5B2","users":170,"accepted":38.96}
+{"id":4311,"name":"Quasi-template","url":"https://www.spoj.com/problems/AE5A2","users":62,"accepted":34.52}
+{"id":4318,"name":"Catch Fish","url":"https://www.spoj.com/problems/MFISH","users":508,"accepted":33.21}
+{"id":4324,"name":"The fate of the pineapple","url":"https://www.spoj.com/problems/EVERLAST","users":46,"accepted":28.98}
+{"id":4329,"name":"Counting K-Rectangle","url":"https://www.spoj.com/problems/KRECT","users":389,"accepted":30.05}
+{"id":4343,"name":"Empty Boxes","url":"https://www.spoj.com/problems/EBOXES","users":3582,"accepted":65.99}
+{"id":4350,"name":"Giá trị lớn nhất 3","url":"https://www.spoj.com/problems/QMAX3VN","users":419,"accepted":23.5}
+{"id":4354,"name":"Snowflakes","url":"https://www.spoj.com/problems/TWINSNOW","users":862,"accepted":25.55}
+{"id":4361,"name":"Connected Points","url":"https://www.spoj.com/problems/CONNECTE","users":11,"accepted":31.82}
+{"id":4378,"name":"Twofive","url":"https://www.spoj.com/problems/TABLE5X5","users":66,"accepted":26.45}
+{"id":4390,"name":"Cards shuffing","url":"https://www.spoj.com/problems/CARDSHUF","users":123,"accepted":27.18}
+{"id":4407,"name":"Counting Arborescence","url":"https://www.spoj.com/problems/DAGCNT","users":101,"accepted":34.02}
+{"id":4408,"name":"Build a Fence","url":"https://www.spoj.com/problems/FENCE1","users":12325,"accepted":44.81}

--- a/tests/spoj/index/20.md
+++ b/tests/spoj/index/20.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 4180 | [Pizza Location](https://www.spoj.com/problems/PIZZALOC) | 576 | 18.59 |
+| 4181 | [MELE3](https://www.spoj.com/problems/MELE3) | 616 | 42.69 |
+| 4182 | [Candy (Again)](https://www.spoj.com/problems/FCANDY) | 236 | 18.78 |
+| 4185 | [Cube](https://www.spoj.com/problems/CCCCUBE) | 57 | 35.57 |
+| 4186 | [Break a New RSA system](https://www.spoj.com/problems/HS08CODE) | 138 | 34.12 |
+| 4188 | [Amazing equality](https://www.spoj.com/problems/HS08EQ) | 42 | 13.88 |
+| 4189 | [Landing](https://www.spoj.com/problems/LANDING) | 6 | 3.09 |
+| 4191 | [Sky Code](https://www.spoj.com/problems/MSKYCODE) | 774 | 29.57 |
+| 4194 | [Another Lucky Numbers](https://www.spoj.com/problems/MSE08G) | 142 | 33.44 |
+| 4195 | [GCD Determinant](https://www.spoj.com/problems/MSE08H) | 273 | 45.30 |
+| 4197 | [Dominoes](https://www.spoj.com/problems/DOMINOES) | 125 | 23.08 |
+| 4198 | [Lego](https://www.spoj.com/problems/LEGO) | 195 | 25.40 |
+| 4200 | [Hamster flight](https://www.spoj.com/problems/HAMSTER1) | 1160 | 45.54 |
+| 4201 | [Coder Ratings](https://www.spoj.com/problems/RATING) | 1397 | 35.83 |
+| 4202 | [Brackets Parade](https://www.spoj.com/problems/BRPAR) | 238 | 45.03 |
+| 4203 | [Double Queue](https://www.spoj.com/problems/MSE07B) | 84 | 41.38 |
+| 4204 | [Showstopper](https://www.spoj.com/problems/MSE07E) | 89 | 22.45 |
+| 4206 | [Fast Maximum Matching](https://www.spoj.com/problems/MATCHING) | 2085 | 29.45 |
+| 4210 | [Fast Maximum Matching](https://www.spoj.com/problems/FMATCH) | 19 | 48.08 |
+| 4211 | [Fast Maximum Flow](https://www.spoj.com/problems/FFLOW) | 21 | 24.62 |
+| 4212 | [Another Longest Increasing Subsequence Problem](https://www.spoj.com/problems/LIS2VN) | 14 | 42.50 |
+| 4225 | [Payment System](https://www.spoj.com/problems/MSE06E) | 31 | 61.90 |
+| 4226 | [Japan](https://www.spoj.com/problems/MSE06H) | 1803 | 23.39 |
+| 4227 | ["Shortest" pair of paths](https://www.spoj.com/problems/MSE06I) | 214 | 41.11 |
+| 4235 | [Wandering Queen](https://www.spoj.com/problems/QUEEN) | 867 | 14.97 |
+| 4259 | [Pilots](https://www.spoj.com/problems/MPILOT) | 1750 | 31.70 |
+| 4273 | [Train TimeTable](https://www.spoj.com/problems/TTTABLE) | 426 | 34.14 |
+| 4275 | [rotate it](https://www.spoj.com/problems/BFROTATE) | 40 | 55.70 |
+| 4278 | [Battlefield](https://www.spoj.com/problems/FIELD) | 8 | 38.89 |
+| 4300 | [Rectangles](https://www.spoj.com/problems/AE00) | 27060 | 49.75 |
+| 4302 | [(K,N)-Knight](https://www.spoj.com/problems/AE2B) | 315 | 25.20 |
+| 4303 | [Dice](https://www.spoj.com/problems/AE2A) | 929 | 15.72 |
+| 4305 | [Drilling](https://www.spoj.com/problems/AE3A) | 121 | 20.15 |
+| 4306 | [The way to Bytemountain](https://www.spoj.com/problems/AE4B) | 34 | 41.30 |
+| 4307 | [Stamps](https://www.spoj.com/problems/AE4A) | 33 | 41.94 |
+| 4308 | [Byteantean towns](https://www.spoj.com/problems/AE5B1) | 58 | 24.65 |
+| 4309 | [Circular game](https://www.spoj.com/problems/AE5A1) | 35 | 19.70 |
+| 4310 | [Permutacja](https://www.spoj.com/problems/AE5B2) | 170 | 38.96 |
+| 4311 | [Quasi-template](https://www.spoj.com/problems/AE5A2) | 62 | 34.52 |
+| 4318 | [Catch Fish](https://www.spoj.com/problems/MFISH) | 508 | 33.21 |
+| 4324 | [The fate of the pineapple](https://www.spoj.com/problems/EVERLAST) | 46 | 28.98 |
+| 4329 | [Counting K-Rectangle](https://www.spoj.com/problems/KRECT) | 389 | 30.05 |
+| 4343 | [Empty Boxes](https://www.spoj.com/problems/EBOXES) | 3582 | 65.99 |
+| 4350 | [Giá trị lớn nhất 3](https://www.spoj.com/problems/QMAX3VN) | 419 | 23.50 |
+| 4354 | [Snowflakes](https://www.spoj.com/problems/TWINSNOW) | 862 | 25.55 |
+| 4361 | [Connected Points](https://www.spoj.com/problems/CONNECTE) | 11 | 31.82 |
+| 4378 | [Twofive](https://www.spoj.com/problems/TABLE5X5) | 66 | 26.45 |
+| 4390 | [Cards shuffing](https://www.spoj.com/problems/CARDSHUF) | 123 | 27.18 |
+| 4407 | [Counting Arborescence](https://www.spoj.com/problems/DAGCNT) | 101 | 34.02 |
+| 4408 | [Build a Fence](https://www.spoj.com/problems/FENCE1) | 12325 | 44.81 |

--- a/tests/spoj/index/21.jsonl
+++ b/tests/spoj/index/21.jsonl
@@ -1,0 +1,50 @@
+{"id":4409,"name":"Circle vs Triangle","url":"https://www.spoj.com/problems/AREA1","users":61,"accepted":19.83}
+{"id":4410,"name":"Repair the Door","url":"https://www.spoj.com/problems/REPAIR1","users":62,"accepted":22.96}
+{"id":4411,"name":"Counting Expressions","url":"https://www.spoj.com/problems/EXPR3","users":29,"accepted":31.96}
+{"id":4412,"name":"Factorization, Factorization, Factorization","url":"https://www.spoj.com/problems/FACTOR1","users":56,"accepted":41.44}
+{"id":4413,"name":"Gem","url":"https://www.spoj.com/problems/GEM","users":99,"accepted":40}
+{"id":4414,"name":"Highway","url":"https://www.spoj.com/problems/HIGHWAY1","users":74,"accepted":23.42}
+{"id":4415,"name":"Power of Integer","url":"https://www.spoj.com/problems/INTEGER1","users":277,"accepted":22.01}
+{"id":4416,"name":"Jumping Hands","url":"https://www.spoj.com/problems/JUMP1","users":210,"accepted":65.74}
+{"id":4420,"name":"Counting Graphs","url":"https://www.spoj.com/problems/KPGRAPHS","users":76,"accepted":36.64}
+{"id":4421,"name":"Irreducible polynomials over GF2","url":"https://www.spoj.com/problems/GF2","users":64,"accepted":18.04}
+{"id":4429,"name":"Spelling Lists","url":"https://www.spoj.com/problems/MIB","users":194,"accepted":32.41}
+{"id":4452,"name":"Simple Arithmetics II","url":"https://www.spoj.com/problems/ARITH2","users":7512,"accepted":42.28}
+{"id":4453,"name":"Bouncing Balls II","url":"https://www.spoj.com/problems/BOBALLS2","users":227,"accepted":27.98}
+{"id":4454,"name":"Brackets II","url":"https://www.spoj.com/problems/BRCKTS2","users":417,"accepted":36.21}
+{"id":4455,"name":"Going to the Movies","url":"https://www.spoj.com/problems/MOVIE","users":89,"accepted":36.79}
+{"id":4456,"name":"Jumbo Airlines","url":"https://www.spoj.com/problems/AIRLINES","users":76,"accepted":36.79}
+{"id":4457,"name":"Shopping II","url":"https://www.spoj.com/problems/SHOP2","users":153,"accepted":35.05}
+{"id":4458,"name":"Rainbow","url":"https://www.spoj.com/problems/RAINBOW2","users":38,"accepted":19.53}
+{"id":4459,"name":"Muzidabutur","url":"https://www.spoj.com/problems/MUZIDA","users":34,"accepted":26.8}
+{"id":4461,"name":"A Famous Airport Manager","url":"https://www.spoj.com/problems/AIRLINE2","users":27,"accepted":17.18}
+{"id":4465,"name":"The Ant","url":"https://www.spoj.com/problems/ANTTT","users":745,"accepted":25.96}
+{"id":4477,"name":"Flower growing","url":"https://www.spoj.com/problems/FLOWGROW","users":116,"accepted":22.11}
+{"id":4478,"name":"Counting Expressions II","url":"https://www.spoj.com/problems/EXPR4","users":14,"accepted":17.65}
+{"id":4480,"name":"Chaos Strings","url":"https://www.spoj.com/problems/MCHAOS","users":533,"accepted":30.1}
+{"id":4483,"name":"Roads Repair","url":"https://www.spoj.com/problems/MROADS","users":182,"accepted":32.65}
+{"id":4485,"name":"MobiZone vs VinaGone","url":"https://www.spoj.com/problems/MOBIVINA","users":338,"accepted":33.88}
+{"id":4487,"name":"Can you answer these queries VI","url":"https://www.spoj.com/problems/GSS6","users":1362,"accepted":23.61}
+{"id":4491,"name":"Primes in GCD Table","url":"https://www.spoj.com/problems/PGCD","users":857,"accepted":36.8}
+{"id":4523,"name":"Binomial Coefficients","url":"https://www.spoj.com/problems/UCI2009B","users":210,"accepted":41.58}
+{"id":4525,"name":"Digger Octaves","url":"https://www.spoj.com/problems/UCI2009D","users":391,"accepted":35.55}
+{"id":4528,"name":"Frog Wrestling","url":"https://www.spoj.com/problems/FROGS","users":69,"accepted":37.5}
+{"id":4532,"name":"String reduction","url":"https://www.spoj.com/problems/STREDUCE","users":169,"accepted":16.71}
+{"id":4533,"name":"Determinant of Banded Matrices","url":"https://www.spoj.com/problems/BANDMATR","users":21,"accepted":33.91}
+{"id":4546,"name":"Tobo or not Tobo","url":"https://www.spoj.com/problems/ANARC08A","users":268,"accepted":19.47}
+{"id":4549,"name":"Adding Sevens","url":"https://www.spoj.com/problems/ANARC08B","users":1934,"accepted":33.28}
+{"id":4551,"name":"Match Maker","url":"https://www.spoj.com/problems/ANARC08C","users":63,"accepted":22.91}
+{"id":4552,"name":"Adding up Triangles","url":"https://www.spoj.com/problems/ANARC08D","users":140,"accepted":35.23}
+{"id":4555,"name":"Einbahnstrasse","url":"https://www.spoj.com/problems/ANARC08F","users":490,"accepted":26.56}
+{"id":4556,"name":"Think I will Buy Me a Football Team","url":"https://www.spoj.com/problems/ANARC08G","users":2189,"accepted":45.16}
+{"id":4557,"name":"Musical Chairs","url":"https://www.spoj.com/problems/ANARC08H","users":2497,"accepted":46.81}
+{"id":4558,"name":"I Speak Whales","url":"https://www.spoj.com/problems/ANARC08I","users":188,"accepted":42.51}
+{"id":4559,"name":"A Day at the Races","url":"https://www.spoj.com/problems/ANARC08J","users":128,"accepted":17.79}
+{"id":4560,"name":"The Double HeLiX","url":"https://www.spoj.com/problems/ANARC05B","users":8973,"accepted":37.55}
+{"id":4564,"name":"Chop Ahoy! Revisited!","url":"https://www.spoj.com/problems/ANARC05H","users":2967,"accepted":50.87}
+{"id":4565,"name":"What is your Logo","url":"https://www.spoj.com/problems/ANARC05I","users":920,"accepted":46.03}
+{"id":4568,"name":"Rotating Rings","url":"https://www.spoj.com/problems/ANARC07C","users":298,"accepted":29.72}
+{"id":4569,"name":"Let go to the movies","url":"https://www.spoj.com/problems/ANARC07G","users":161,"accepted":18.26}
+{"id":4574,"name":"Riding in cycles","url":"https://www.spoj.com/problems/CYCLERUN","users":44,"accepted":23.96}
+{"id":4580,"name":"ABCDEF","url":"https://www.spoj.com/problems/ABCDEF","users":7920,"accepted":29.35}
+{"id":4585,"name":"Star Wars","url":"https://www.spoj.com/problems/GCJ08C","users":76,"accepted":35.69}

--- a/tests/spoj/index/21.md
+++ b/tests/spoj/index/21.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 4409 | [Circle vs Triangle](https://www.spoj.com/problems/AREA1) | 61 | 19.83 |
+| 4410 | [Repair the Door](https://www.spoj.com/problems/REPAIR1) | 62 | 22.96 |
+| 4411 | [Counting Expressions](https://www.spoj.com/problems/EXPR3) | 29 | 31.96 |
+| 4412 | [Factorization, Factorization, Factorization](https://www.spoj.com/problems/FACTOR1) | 56 | 41.44 |
+| 4413 | [Gem](https://www.spoj.com/problems/GEM) | 99 | 40.00 |
+| 4414 | [Highway](https://www.spoj.com/problems/HIGHWAY1) | 74 | 23.42 |
+| 4415 | [Power of Integer](https://www.spoj.com/problems/INTEGER1) | 277 | 22.01 |
+| 4416 | [Jumping Hands](https://www.spoj.com/problems/JUMP1) | 210 | 65.74 |
+| 4420 | [Counting Graphs](https://www.spoj.com/problems/KPGRAPHS) | 76 | 36.64 |
+| 4421 | [Irreducible polynomials over GF2](https://www.spoj.com/problems/GF2) | 64 | 18.04 |
+| 4429 | [Spelling Lists](https://www.spoj.com/problems/MIB) | 194 | 32.41 |
+| 4452 | [Simple Arithmetics II](https://www.spoj.com/problems/ARITH2) | 7512 | 42.28 |
+| 4453 | [Bouncing Balls II](https://www.spoj.com/problems/BOBALLS2) | 227 | 27.98 |
+| 4454 | [Brackets II](https://www.spoj.com/problems/BRCKTS2) | 417 | 36.21 |
+| 4455 | [Going to the Movies](https://www.spoj.com/problems/MOVIE) | 89 | 36.79 |
+| 4456 | [Jumbo Airlines](https://www.spoj.com/problems/AIRLINES) | 76 | 36.79 |
+| 4457 | [Shopping II](https://www.spoj.com/problems/SHOP2) | 153 | 35.05 |
+| 4458 | [Rainbow](https://www.spoj.com/problems/RAINBOW2) | 38 | 19.53 |
+| 4459 | [Muzidabutur](https://www.spoj.com/problems/MUZIDA) | 34 | 26.80 |
+| 4461 | [A Famous Airport Manager](https://www.spoj.com/problems/AIRLINE2) | 27 | 17.18 |
+| 4465 | [The Ant](https://www.spoj.com/problems/ANTTT) | 745 | 25.96 |
+| 4477 | [Flower growing](https://www.spoj.com/problems/FLOWGROW) | 116 | 22.11 |
+| 4478 | [Counting Expressions II](https://www.spoj.com/problems/EXPR4) | 14 | 17.65 |
+| 4480 | [Chaos Strings](https://www.spoj.com/problems/MCHAOS) | 533 | 30.10 |
+| 4483 | [Roads Repair](https://www.spoj.com/problems/MROADS) | 182 | 32.65 |
+| 4485 | [MobiZone vs VinaGone](https://www.spoj.com/problems/MOBIVINA) | 338 | 33.88 |
+| 4487 | [Can you answer these queries VI](https://www.spoj.com/problems/GSS6) | 1362 | 23.61 |
+| 4491 | [Primes in GCD Table](https://www.spoj.com/problems/PGCD) | 857 | 36.80 |
+| 4523 | [Binomial Coefficients](https://www.spoj.com/problems/UCI2009B) | 210 | 41.58 |
+| 4525 | [Digger Octaves](https://www.spoj.com/problems/UCI2009D) | 391 | 35.55 |
+| 4528 | [Frog Wrestling](https://www.spoj.com/problems/FROGS) | 69 | 37.50 |
+| 4532 | [String reduction](https://www.spoj.com/problems/STREDUCE) | 169 | 16.71 |
+| 4533 | [Determinant of Banded Matrices](https://www.spoj.com/problems/BANDMATR) | 21 | 33.91 |
+| 4546 | [Tobo or not Tobo](https://www.spoj.com/problems/ANARC08A) | 268 | 19.47 |
+| 4549 | [Adding Sevens](https://www.spoj.com/problems/ANARC08B) | 1934 | 33.28 |
+| 4551 | [Match Maker](https://www.spoj.com/problems/ANARC08C) | 63 | 22.91 |
+| 4552 | [Adding up Triangles](https://www.spoj.com/problems/ANARC08D) | 140 | 35.23 |
+| 4555 | [Einbahnstrasse](https://www.spoj.com/problems/ANARC08F) | 490 | 26.56 |
+| 4556 | [Think I will Buy Me a Football Team](https://www.spoj.com/problems/ANARC08G) | 2189 | 45.16 |
+| 4557 | [Musical Chairs](https://www.spoj.com/problems/ANARC08H) | 2497 | 46.81 |
+| 4558 | [I Speak Whales](https://www.spoj.com/problems/ANARC08I) | 188 | 42.51 |
+| 4559 | [A Day at the Races](https://www.spoj.com/problems/ANARC08J) | 128 | 17.79 |
+| 4560 | [The Double HeLiX](https://www.spoj.com/problems/ANARC05B) | 8973 | 37.55 |
+| 4564 | [Chop Ahoy! Revisited!](https://www.spoj.com/problems/ANARC05H) | 2967 | 50.87 |
+| 4565 | [What is your Logo](https://www.spoj.com/problems/ANARC05I) | 920 | 46.03 |
+| 4568 | [Rotating Rings](https://www.spoj.com/problems/ANARC07C) | 298 | 29.72 |
+| 4569 | [Let go to the movies](https://www.spoj.com/problems/ANARC07G) | 161 | 18.26 |
+| 4574 | [Riding in cycles](https://www.spoj.com/problems/CYCLERUN) | 44 | 23.96 |
+| 4580 | [ABCDEF](https://www.spoj.com/problems/ABCDEF) | 7920 | 29.35 |
+| 4585 | [Star Wars](https://www.spoj.com/problems/GCJ08C) | 76 | 35.69 |

--- a/tests/spoj/index/22.jsonl
+++ b/tests/spoj/index/22.jsonl
@@ -1,0 +1,50 @@
+{"id":4586,"name":"Texas Trip","url":"https://www.spoj.com/problems/WLOO0707","users":70,"accepted":38.84}
+{"id":4587,"name":"Electric Fences","url":"https://www.spoj.com/problems/FENCE3","users":144,"accepted":33.33}
+{"id":4588,"name":"SETI","url":"https://www.spoj.com/problems/NWERC04H","users":130,"accepted":66.67}
+{"id":4593,"name":"Arithmetic sequence","url":"https://www.spoj.com/problems/ARITHSEQ","users":67,"accepted":9.55}
+{"id":4644,"name":"Proving Equivalences","url":"https://www.spoj.com/problems/PMATRIX","users":199,"accepted":28.66}
+{"id":4656,"name":"Cross Mountain Climb","url":"https://www.spoj.com/problems/CCROSS","users":72,"accepted":31.44}
+{"id":4657,"name":"Gas Wars","url":"https://www.spoj.com/problems/GASWARS","users":145,"accepted":35.87}
+{"id":4658,"name":"Help Hemant Verma","url":"https://www.spoj.com/problems/HHEMANT","users":51,"accepted":14.2}
+{"id":4666,"name":"Wireless","url":"https://www.spoj.com/problems/WIRELESS","users":128,"accepted":37.02}
+{"id":4667,"name":"Gremlins","url":"https://www.spoj.com/problems/GREMLINS","users":56,"accepted":29.1}
+{"id":4669,"name":"Cross Mountain Climb Extreme","url":"https://www.spoj.com/problems/CCROSSX","users":36,"accepted":16.43}
+{"id":4672,"name":"Yanu in Movie theatre","url":"https://www.spoj.com/problems/FUNPROB","users":1725,"accepted":44.85}
+{"id":4681,"name":"Twice","url":"https://www.spoj.com/problems/TWICE","users":287,"accepted":21.21}
+{"id":4717,"name":"Grid Points in a Triangle","url":"https://www.spoj.com/problems/GPINTRI","users":99,"accepted":46.63}
+{"id":4761,"name":"Strategy game","url":"https://www.spoj.com/problems/HS09GAME","users":43,"accepted":55.73}
+{"id":4784,"name":"Diophantine equation","url":"https://www.spoj.com/problems/HS09EQ","users":155,"accepted":40.59}
+{"id":4785,"name":"Starship","url":"https://www.spoj.com/problems/HS09SHIP","users":16,"accepted":31.25}
+{"id":4828,"name":"ZSequence","url":"https://www.spoj.com/problems/ZSEQ","users":53,"accepted":18.8}
+{"id":4839,"name":"Ant","url":"https://www.spoj.com/problems/PA06ANT","users":194,"accepted":38.89}
+{"id":4871,"name":"Bridge","url":"https://www.spoj.com/problems/BRI","users":161,"accepted":24.59}
+{"id":4881,"name":"Words on graphs","url":"https://www.spoj.com/problems/AMBIG","users":108,"accepted":11.94}
+{"id":4882,"name":"Counting in a DAG","url":"https://www.spoj.com/problems/DAGCNT2","users":181,"accepted":11.99}
+{"id":4908,"name":"Run-Length Mathematics","url":"https://www.spoj.com/problems/RLM","users":721,"accepted":41.17}
+{"id":4941,"name":"Integer Factorization (20 digits)","url":"https://www.spoj.com/problems/FACT1","users":611,"accepted":55.38}
+{"id":4942,"name":"Integer Factorization (15 digits)","url":"https://www.spoj.com/problems/FACT0","users":3676,"accepted":32.73}
+{"id":4948,"name":"Integer Factorization (29 digits)","url":"https://www.spoj.com/problems/FACT2","users":124,"accepted":14.89}
+{"id":4951,"name":"Bridges! More bridges!","url":"https://www.spoj.com/problems/BRII","users":47,"accepted":16.63}
+{"id":4987,"name":"Goal for Raúl","url":"https://www.spoj.com/problems/GOALFR","users":548,"accepted":30.11}
+{"id":4988,"name":"Madrids One Way Streets","url":"https://www.spoj.com/problems/MOWS","users":201,"accepted":29}
+{"id":4993,"name":"Traveling Salesman","url":"https://www.spoj.com/problems/FAKETSP","users":1043,"accepted":37.18}
+{"id":5010,"name":"Lost in Madrid","url":"https://www.spoj.com/problems/LIM","users":194,"accepted":31.49}
+{"id":5011,"name":"Library for Madrid","url":"https://www.spoj.com/problems/LFM","users":59,"accepted":42.62}
+{"id":5014,"name":"Crazy Receptionist","url":"https://www.spoj.com/problems/CRAZYR","users":11,"accepted":11.72}
+{"id":5015,"name":"Decode the Castanets","url":"https://www.spoj.com/problems/CASTANET","users":36,"accepted":40.68}
+{"id":5016,"name":"Guernica","url":"https://www.spoj.com/problems/GUERNICA","users":26,"accepted":61.54}
+{"id":5018,"name":"Street Gambler","url":"https://www.spoj.com/problems/STRGAMB","users":31,"accepted":47.83}
+{"id":5084,"name":"Discrete Math Problem","url":"https://www.spoj.com/problems/GCD3","users":287,"accepted":31.66}
+{"id":5091,"name":"Feline Olympics - Mouseball","url":"https://www.spoj.com/problems/MBALL","users":600,"accepted":39.35}
+{"id":5093,"name":"Pretty Functions","url":"https://www.spoj.com/problems/PRETTY","users":43,"accepted":22.67}
+{"id":5102,"name":"Mystic  Craft","url":"https://www.spoj.com/problems/MYSTIC","users":57,"accepted":46.2}
+{"id":5103,"name":"Top 10","url":"https://www.spoj.com/problems/TOP10","users":43,"accepted":15.98}
+{"id":5104,"name":"Spam Detection","url":"https://www.spoj.com/problems/SPAMD","users":16,"accepted":15.97}
+{"id":5107,"name":"Playing with Marbles","url":"https://www.spoj.com/problems/TUTMRBL","users":796,"accepted":23.72}
+{"id":5115,"name":"Two \"Ways\"","url":"https://www.spoj.com/problems/SPHIWAY","users":67,"accepted":15.62}
+{"id":5117,"name":"Wine trading in Gergovia","url":"https://www.spoj.com/problems/GERGOVIA","users":5438,"accepted":33.76}
+{"id":5120,"name":"Minimal Possible String","url":"https://www.spoj.com/problems/MINSEQ","users":61,"accepted":5.32}
+{"id":5128,"name":"Bomb the Bridge","url":"https://www.spoj.com/problems/BOMB","users":46,"accepted":30.8}
+{"id":5142,"name":"A Pair of Graphs","url":"https://www.spoj.com/problems/PAIRGRPH","users":70,"accepted":54.23}
+{"id":5143,"name":"Binary Integer","url":"https://www.spoj.com/problems/BNYINT","users":53,"accepted":50}
+{"id":5144,"name":"Cryptography Reloaded (Act I)","url":"https://www.spoj.com/problems/CRYPTO6","users":34,"accepted":26.43}

--- a/tests/spoj/index/22.md
+++ b/tests/spoj/index/22.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 4586 | [Texas Trip](https://www.spoj.com/problems/WLOO0707) | 70 | 38.84 |
+| 4587 | [Electric Fences](https://www.spoj.com/problems/FENCE3) | 144 | 33.33 |
+| 4588 | [SETI](https://www.spoj.com/problems/NWERC04H) | 130 | 66.67 |
+| 4593 | [Arithmetic sequence](https://www.spoj.com/problems/ARITHSEQ) | 67 | 9.55 |
+| 4644 | [Proving Equivalences](https://www.spoj.com/problems/PMATRIX) | 199 | 28.66 |
+| 4656 | [Cross Mountain Climb](https://www.spoj.com/problems/CCROSS) | 72 | 31.44 |
+| 4657 | [Gas Wars](https://www.spoj.com/problems/GASWARS) | 145 | 35.87 |
+| 4658 | [Help Hemant Verma](https://www.spoj.com/problems/HHEMANT) | 51 | 14.20 |
+| 4666 | [Wireless](https://www.spoj.com/problems/WIRELESS) | 128 | 37.02 |
+| 4667 | [Gremlins](https://www.spoj.com/problems/GREMLINS) | 56 | 29.10 |
+| 4669 | [Cross Mountain Climb Extreme](https://www.spoj.com/problems/CCROSSX) | 36 | 16.43 |
+| 4672 | [Yanu in Movie theatre](https://www.spoj.com/problems/FUNPROB) | 1725 | 44.85 |
+| 4681 | [Twice](https://www.spoj.com/problems/TWICE) | 287 | 21.21 |
+| 4717 | [Grid Points in a Triangle](https://www.spoj.com/problems/GPINTRI) | 99 | 46.63 |
+| 4761 | [Strategy game](https://www.spoj.com/problems/HS09GAME) | 43 | 55.73 |
+| 4784 | [Diophantine equation](https://www.spoj.com/problems/HS09EQ) | 155 | 40.59 |
+| 4785 | [Starship](https://www.spoj.com/problems/HS09SHIP) | 16 | 31.25 |
+| 4828 | [ZSequence](https://www.spoj.com/problems/ZSEQ) | 53 | 18.80 |
+| 4839 | [Ant](https://www.spoj.com/problems/PA06ANT) | 194 | 38.89 |
+| 4871 | [Bridge](https://www.spoj.com/problems/BRI) | 161 | 24.59 |
+| 4881 | [Words on graphs](https://www.spoj.com/problems/AMBIG) | 108 | 11.94 |
+| 4882 | [Counting in a DAG](https://www.spoj.com/problems/DAGCNT2) | 181 | 11.99 |
+| 4908 | [Run-Length Mathematics](https://www.spoj.com/problems/RLM) | 721 | 41.17 |
+| 4941 | [Integer Factorization (20 digits)](https://www.spoj.com/problems/FACT1) | 611 | 55.38 |
+| 4942 | [Integer Factorization (15 digits)](https://www.spoj.com/problems/FACT0) | 3676 | 32.73 |
+| 4948 | [Integer Factorization (29 digits)](https://www.spoj.com/problems/FACT2) | 124 | 14.89 |
+| 4951 | [Bridges! More bridges!](https://www.spoj.com/problems/BRII) | 47 | 16.63 |
+| 4987 | [Goal for Raúl](https://www.spoj.com/problems/GOALFR) | 548 | 30.11 |
+| 4988 | [Madrids One Way Streets](https://www.spoj.com/problems/MOWS) | 201 | 29.00 |
+| 4993 | [Traveling Salesman](https://www.spoj.com/problems/FAKETSP) | 1043 | 37.18 |
+| 5010 | [Lost in Madrid](https://www.spoj.com/problems/LIM) | 194 | 31.49 |
+| 5011 | [Library for Madrid](https://www.spoj.com/problems/LFM) | 59 | 42.62 |
+| 5014 | [Crazy Receptionist](https://www.spoj.com/problems/CRAZYR) | 11 | 11.72 |
+| 5015 | [Decode the Castanets](https://www.spoj.com/problems/CASTANET) | 36 | 40.68 |
+| 5016 | [Guernica](https://www.spoj.com/problems/GUERNICA) | 26 | 61.54 |
+| 5018 | [Street Gambler](https://www.spoj.com/problems/STRGAMB) | 31 | 47.83 |
+| 5084 | [Discrete Math Problem](https://www.spoj.com/problems/GCD3) | 287 | 31.66 |
+| 5091 | [Feline Olympics - Mouseball](https://www.spoj.com/problems/MBALL) | 600 | 39.35 |
+| 5093 | [Pretty Functions](https://www.spoj.com/problems/PRETTY) | 43 | 22.67 |
+| 5102 | [Mystic  Craft](https://www.spoj.com/problems/MYSTIC) | 57 | 46.20 |
+| 5103 | [Top 10](https://www.spoj.com/problems/TOP10) | 43 | 15.98 |
+| 5104 | [Spam Detection](https://www.spoj.com/problems/SPAMD) | 16 | 15.97 |
+| 5107 | [Playing with Marbles](https://www.spoj.com/problems/TUTMRBL) | 796 | 23.72 |
+| 5115 | [Two "Ways"](https://www.spoj.com/problems/SPHIWAY) | 67 | 15.62 |
+| 5117 | [Wine trading in Gergovia](https://www.spoj.com/problems/GERGOVIA) | 5438 | 33.76 |
+| 5120 | [Minimal Possible String](https://www.spoj.com/problems/MINSEQ) | 61 | 5.32 |
+| 5128 | [Bomb the Bridge](https://www.spoj.com/problems/BOMB) | 46 | 30.80 |
+| 5142 | [A Pair of Graphs](https://www.spoj.com/problems/PAIRGRPH) | 70 | 54.23 |
+| 5143 | [Binary Integer](https://www.spoj.com/problems/BNYINT) | 53 | 50.00 |
+| 5144 | [Cryptography Reloaded (Act I)](https://www.spoj.com/problems/CRYPTO6) | 34 | 26.43 |

--- a/tests/spoj/index/23.jsonl
+++ b/tests/spoj/index/23.jsonl
@@ -1,0 +1,50 @@
+{"id":5145,"name":"Déjà vu","url":"https://www.spoj.com/problems/DEJAVU","users":17,"accepted":15.03}
+{"id":5146,"name":"Experiment on a … Cable","url":"https://www.spoj.com/problems/CABLEXPR","users":16,"accepted":36.36}
+{"id":5147,"name":"Fire-Control System","url":"https://www.spoj.com/problems/FCSYS","users":37,"accepted":22.4}
+{"id":5148,"name":"Get-Together at Stockholm","url":"https://www.spoj.com/problems/STCKHOLM","users":56,"accepted":48.36}
+{"id":5149,"name":"History of Languages","url":"https://www.spoj.com/problems/HISTORY","users":32,"accepted":17.7}
+{"id":5150,"name":"Junk-Mail Filter","url":"https://www.spoj.com/problems/JMFILTER","users":141,"accepted":22.2}
+{"id":5151,"name":"Alice’s Cube","url":"https://www.spoj.com/problems/ALICECUB","users":516,"accepted":29.3}
+{"id":5152,"name":"Brute-force Algorithm EXTREME","url":"https://www.spoj.com/problems/BFALG","users":103,"accepted":22.25}
+{"id":5153,"name":"Compressed String","url":"https://www.spoj.com/problems/COMPRESS","users":46,"accepted":28.21}
+{"id":5154,"name":"Cryptography Reloaded (Act II)","url":"https://www.spoj.com/problems/CRYPTO7","users":36,"accepted":27.49}
+{"id":5155,"name":"Exciting Time","url":"https://www.spoj.com/problems/TETRIS2D","users":45,"accepted":13.96}
+{"id":5156,"name":"Flowers Placement","url":"https://www.spoj.com/problems/FLOWERS2","users":43,"accepted":31.33}
+{"id":5157,"name":"Game Simulator","url":"https://www.spoj.com/problems/TRACTOR","users":23,"accepted":9.09}
+{"id":5158,"name":"Heroes Arrangement","url":"https://www.spoj.com/problems/HEROARR","users":17,"accepted":12.94}
+{"id":5159,"name":"Island Explorer","url":"https://www.spoj.com/problems/IEXPOLRE","users":37,"accepted":16}
+{"id":5160,"name":"Jinyuetuan Puzzle","url":"https://www.spoj.com/problems/O2JAM","users":45,"accepted":37.7}
+{"id":5161,"name":"Factorial vs Power","url":"https://www.spoj.com/problems/FACVSPOW","users":1139,"accepted":25.96}
+{"id":5163,"name":"Tower of Vientiane","url":"https://www.spoj.com/problems/VIENTIAN","users":105,"accepted":34.94}
+{"id":5182,"name":"Double Sorting","url":"https://www.spoj.com/problems/PAIRSORT","users":15,"accepted":8.7}
+{"id":5196,"name":"Monotonous numbers","url":"https://www.spoj.com/problems/MONONUM","users":635,"accepted":48.16}
+{"id":5197,"name":"Differential Diagnosis","url":"https://www.spoj.com/problems/DIFFDIAG","users":65,"accepted":24.32}
+{"id":5240,"name":"Area of a Garden","url":"https://www.spoj.com/problems/GARDENAR","users":1702,"accepted":47.2}
+{"id":5271,"name":"A Coin Game","url":"https://www.spoj.com/problems/XOINC","users":554,"accepted":31.99}
+{"id":5294,"name":"Recurrence","url":"https://www.spoj.com/problems/REC","users":262,"accepted":14.44}
+{"id":5295,"name":"Adjacent Bit Counts","url":"https://www.spoj.com/problems/GNYR09F","users":3774,"accepted":64}
+{"id":5296,"name":"Air Combat","url":"https://www.spoj.com/problems/COMBAT","users":71,"accepted":15.71}
+{"id":5298,"name":"Interval Challenge","url":"https://www.spoj.com/problems/INTERVA2","users":143,"accepted":16.92}
+{"id":5300,"name":"Mexican Standoff","url":"https://www.spoj.com/problems/MEXICAN","users":26,"accepted":24.19}
+{"id":5301,"name":"Query Problem","url":"https://www.spoj.com/problems/QUERYSTR","users":695,"accepted":37.33}
+{"id":5317,"name":"Tetravex Puzzle","url":"https://www.spoj.com/problems/TETRAVEX","users":284,"accepted":46.25}
+{"id":5373,"name":"Four Mines","url":"https://www.spoj.com/problems/MINES4","users":14,"accepted":6.25}
+{"id":5446,"name":"Fishing Net","url":"https://www.spoj.com/problems/FISHNET","users":176,"accepted":31.96}
+{"id":5449,"name":"Seinfeld","url":"https://www.spoj.com/problems/ANARC09A","users":9559,"accepted":40.06}
+{"id":5450,"name":"Tiles of Tetris, Not!","url":"https://www.spoj.com/problems/ANARC09B","users":3205,"accepted":36.04}
+{"id":5451,"name":"Not So Flat After All","url":"https://www.spoj.com/problems/ANARC09C","users":1128,"accepted":42.94}
+{"id":5452,"name":"Hop Do not Walk","url":"https://www.spoj.com/problems/ANARC09D","users":148,"accepted":35.23}
+{"id":5453,"name":"Air Strike","url":"https://www.spoj.com/problems/ANARC09F","users":178,"accepted":23.78}
+{"id":5462,"name":"Art Plagiarism","url":"https://www.spoj.com/problems/AP","users":13,"accepted":21.84}
+{"id":5463,"name":"Bird or not bird","url":"https://www.spoj.com/problems/BIRD","users":119,"accepted":38.48}
+{"id":5464,"name":"Counting triangles","url":"https://www.spoj.com/problems/CT","users":213,"accepted":29.16}
+{"id":5465,"name":"Deliver pizza","url":"https://www.spoj.com/problems/DP","users":407,"accepted":22.9}
+{"id":5466,"name":"Electronic queue","url":"https://www.spoj.com/problems/EQ","users":166,"accepted":38.11}
+{"id":5467,"name":"Finding password","url":"https://www.spoj.com/problems/FP","users":185,"accepted":16.97}
+{"id":5468,"name":"Going to school","url":"https://www.spoj.com/problems/GS","users":330,"accepted":36.17}
+{"id":5469,"name":"Houses","url":"https://www.spoj.com/problems/HOUSES2","users":46,"accepted":25.56}
+{"id":5511,"name":"Heavy Sequences","url":"https://www.spoj.com/problems/HSEQ","users":84,"accepted":18.41}
+{"id":5522,"name":"Buy Your House","url":"https://www.spoj.com/problems/PHU09H","users":17,"accepted":39.62}
+{"id":5523,"name":"Highway Patrol","url":"https://www.spoj.com/problems/PHU09K","users":19,"accepted":42.39}
+{"id":5530,"name":"Math with Bases (Easy)","url":"https://www.spoj.com/problems/BSMATH1","users":67,"accepted":24.73}
+{"id":5531,"name":"Kutevi Hard","url":"https://www.spoj.com/problems/KUTH","users":90,"accepted":43.4}

--- a/tests/spoj/index/23.md
+++ b/tests/spoj/index/23.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 5145 | [Déjà vu](https://www.spoj.com/problems/DEJAVU) | 17 | 15.03 |
+| 5146 | [Experiment on a … Cable](https://www.spoj.com/problems/CABLEXPR) | 16 | 36.36 |
+| 5147 | [Fire-Control System](https://www.spoj.com/problems/FCSYS) | 37 | 22.40 |
+| 5148 | [Get-Together at Stockholm](https://www.spoj.com/problems/STCKHOLM) | 56 | 48.36 |
+| 5149 | [History of Languages](https://www.spoj.com/problems/HISTORY) | 32 | 17.70 |
+| 5150 | [Junk-Mail Filter](https://www.spoj.com/problems/JMFILTER) | 141 | 22.20 |
+| 5151 | [Alice’s Cube](https://www.spoj.com/problems/ALICECUB) | 516 | 29.30 |
+| 5152 | [Brute-force Algorithm EXTREME](https://www.spoj.com/problems/BFALG) | 103 | 22.25 |
+| 5153 | [Compressed String](https://www.spoj.com/problems/COMPRESS) | 46 | 28.21 |
+| 5154 | [Cryptography Reloaded (Act II)](https://www.spoj.com/problems/CRYPTO7) | 36 | 27.49 |
+| 5155 | [Exciting Time](https://www.spoj.com/problems/TETRIS2D) | 45 | 13.96 |
+| 5156 | [Flowers Placement](https://www.spoj.com/problems/FLOWERS2) | 43 | 31.33 |
+| 5157 | [Game Simulator](https://www.spoj.com/problems/TRACTOR) | 23 | 9.09 |
+| 5158 | [Heroes Arrangement](https://www.spoj.com/problems/HEROARR) | 17 | 12.94 |
+| 5159 | [Island Explorer](https://www.spoj.com/problems/IEXPOLRE) | 37 | 16.00 |
+| 5160 | [Jinyuetuan Puzzle](https://www.spoj.com/problems/O2JAM) | 45 | 37.70 |
+| 5161 | [Factorial vs Power](https://www.spoj.com/problems/FACVSPOW) | 1139 | 25.96 |
+| 5163 | [Tower of Vientiane](https://www.spoj.com/problems/VIENTIAN) | 105 | 34.94 |
+| 5182 | [Double Sorting](https://www.spoj.com/problems/PAIRSORT) | 15 | 8.70 |
+| 5196 | [Monotonous numbers](https://www.spoj.com/problems/MONONUM) | 635 | 48.16 |
+| 5197 | [Differential Diagnosis](https://www.spoj.com/problems/DIFFDIAG) | 65 | 24.32 |
+| 5240 | [Area of a Garden](https://www.spoj.com/problems/GARDENAR) | 1702 | 47.20 |
+| 5271 | [A Coin Game](https://www.spoj.com/problems/XOINC) | 554 | 31.99 |
+| 5294 | [Recurrence](https://www.spoj.com/problems/REC) | 262 | 14.44 |
+| 5295 | [Adjacent Bit Counts](https://www.spoj.com/problems/GNYR09F) | 3774 | 64.00 |
+| 5296 | [Air Combat](https://www.spoj.com/problems/COMBAT) | 71 | 15.71 |
+| 5298 | [Interval Challenge](https://www.spoj.com/problems/INTERVA2) | 143 | 16.92 |
+| 5300 | [Mexican Standoff](https://www.spoj.com/problems/MEXICAN) | 26 | 24.19 |
+| 5301 | [Query Problem](https://www.spoj.com/problems/QUERYSTR) | 695 | 37.33 |
+| 5317 | [Tetravex Puzzle](https://www.spoj.com/problems/TETRAVEX) | 284 | 46.25 |
+| 5373 | [Four Mines](https://www.spoj.com/problems/MINES4) | 14 | 6.25 |
+| 5446 | [Fishing Net](https://www.spoj.com/problems/FISHNET) | 176 | 31.96 |
+| 5449 | [Seinfeld](https://www.spoj.com/problems/ANARC09A) | 9559 | 40.06 |
+| 5450 | [Tiles of Tetris, Not!](https://www.spoj.com/problems/ANARC09B) | 3205 | 36.04 |
+| 5451 | [Not So Flat After All](https://www.spoj.com/problems/ANARC09C) | 1128 | 42.94 |
+| 5452 | [Hop Do not Walk](https://www.spoj.com/problems/ANARC09D) | 148 | 35.23 |
+| 5453 | [Air Strike](https://www.spoj.com/problems/ANARC09F) | 178 | 23.78 |
+| 5462 | [Art Plagiarism](https://www.spoj.com/problems/AP) | 13 | 21.84 |
+| 5463 | [Bird or not bird](https://www.spoj.com/problems/BIRD) | 119 | 38.48 |
+| 5464 | [Counting triangles](https://www.spoj.com/problems/CT) | 213 | 29.16 |
+| 5465 | [Deliver pizza](https://www.spoj.com/problems/DP) | 407 | 22.90 |
+| 5466 | [Electronic queue](https://www.spoj.com/problems/EQ) | 166 | 38.11 |
+| 5467 | [Finding password](https://www.spoj.com/problems/FP) | 185 | 16.97 |
+| 5468 | [Going to school](https://www.spoj.com/problems/GS) | 330 | 36.17 |
+| 5469 | [Houses](https://www.spoj.com/problems/HOUSES2) | 46 | 25.56 |
+| 5511 | [Heavy Sequences](https://www.spoj.com/problems/HSEQ) | 84 | 18.41 |
+| 5522 | [Buy Your House](https://www.spoj.com/problems/PHU09H) | 17 | 39.62 |
+| 5523 | [Highway Patrol](https://www.spoj.com/problems/PHU09K) | 19 | 42.39 |
+| 5530 | [Math with Bases (Easy)](https://www.spoj.com/problems/BSMATH1) | 67 | 24.73 |
+| 5531 | [Kutevi Hard](https://www.spoj.com/problems/KUTH) | 90 | 43.40 |

--- a/tests/spoj/index/24.jsonl
+++ b/tests/spoj/index/24.jsonl
@@ -1,0 +1,50 @@
+{"id":5541,"name":"Sequoiadendron","url":"https://www.spoj.com/problems/SEQUOIA","users":66,"accepted":44.25}
+{"id":5542,"name":"Counting pairs","url":"https://www.spoj.com/problems/CPAIR","users":135,"accepted":26.54}
+{"id":5566,"name":"Math with Bases","url":"https://www.spoj.com/problems/BSMATH2","users":15,"accepted":10.78}
+{"id":5609,"name":"Knight Moves","url":"https://www.spoj.com/problems/KMOVES","users":107,"accepted":40.69}
+{"id":5637,"name":"LL and ErBao","url":"https://www.spoj.com/problems/ISUN1","users":5,"accepted":41.43}
+{"id":5638,"name":"Mobile Service Hard","url":"https://www.spoj.com/problems/SERVICEH","users":91,"accepted":22.09}
+{"id":5640,"name":"Fractions on Tree","url":"https://www.spoj.com/problems/NG0FRCTN","users":930,"accepted":61.3}
+{"id":5649,"name":"Divide Polygon","url":"https://www.spoj.com/problems/DTPOLY","users":48,"accepted":22.95}
+{"id":5652,"name":"Snow White and the N dwarfs","url":"https://www.spoj.com/problems/PATULJCI","users":1027,"accepted":18.07}
+{"id":5672,"name":"Captain Selection","url":"https://www.spoj.com/problems/CAPTAIN","users":10,"accepted":26.42}
+{"id":5673,"name":"Fractions on Tree ( reloaded !)","url":"https://www.spoj.com/problems/NG1FRCTN","users":248,"accepted":38.33}
+{"id":5699,"name":"The last digit re-visited","url":"https://www.spoj.com/problems/LASTDIG2","users":7470,"accepted":31.71}
+{"id":5703,"name":"Primes of Lambda","url":"https://www.spoj.com/problems/LPRIME","users":24,"accepted":26.83}
+{"id":5725,"name":"123 Sequence","url":"https://www.spoj.com/problems/KSEQ","users":124,"accepted":24.09}
+{"id":5732,"name":"Paradox","url":"https://www.spoj.com/problems/PARADOX","users":1240,"accepted":27.86}
+{"id":5830,"name":"Alternating Permutations","url":"https://www.spoj.com/problems/ALTPERM","users":65,"accepted":39.22}
+{"id":5831,"name":"Permutation Jumping","url":"https://www.spoj.com/problems/PERMJUMP","users":137,"accepted":59.48}
+{"id":5832,"name":"AND Rounds","url":"https://www.spoj.com/problems/ANDROUND","users":1702,"accepted":24.89}
+{"id":5833,"name":"XOR Rounds","url":"https://www.spoj.com/problems/XORROUND","users":360,"accepted":30.83}
+{"id":5885,"name":"Troops of Sand Monsters","url":"https://www.spoj.com/problems/TROOPS","users":114,"accepted":17.47}
+{"id":5902,"name":"Tri","url":"https://www.spoj.com/problems/CEOI09TR","users":79,"accepted":20.26}
+{"id":5911,"name":"Square-free Integers Factorization","url":"https://www.spoj.com/problems/SQFFACT","users":20,"accepted":30.67}
+{"id":5917,"name":"Factorial length","url":"https://www.spoj.com/problems/LENGFACT","users":3478,"accepted":34.57}
+{"id":5969,"name":"Finding Maximum","url":"https://www.spoj.com/problems/FINDMAX","users":109,"accepted":30.31}
+{"id":5970,"name":"Finding Primes","url":"https://www.spoj.com/problems/FINDPRM","users":1345,"accepted":27.95}
+{"id":5971,"name":"LCM Sum","url":"https://www.spoj.com/problems/LCMSUM","users":3941,"accepted":26.28}
+{"id":5972,"name":"Maximum Sum Sequences","url":"https://www.spoj.com/problems/MAXSUMSQ","users":1159,"accepted":20.63}
+{"id":5973,"name":"Selecting Teams","url":"https://www.spoj.com/problems/SELTEAM","users":234,"accepted":23.28}
+{"id":5975,"name":"Travelling Knight","url":"https://www.spoj.com/problems/TRKNIGHT","users":54,"accepted":32.69}
+{"id":5976,"name":"Traversing Grid","url":"https://www.spoj.com/problems/TRGRID","users":3721,"accepted":58.56}
+{"id":5977,"name":"Weird Function","url":"https://www.spoj.com/problems/WEIRDFN","users":1155,"accepted":18.97}
+{"id":5978,"name":"Frequent Prime Ranges","url":"https://www.spoj.com/problems/FRQPRIME","users":717,"accepted":28.8}
+{"id":5979,"name":"Yet Another Permutations Problem","url":"https://www.spoj.com/problems/YAPP","users":1358,"accepted":49.53}
+{"id":5980,"name":"Matrix Game","url":"https://www.spoj.com/problems/MATGAME","users":967,"accepted":29.09}
+{"id":6035,"name":"Dinner","url":"https://www.spoj.com/problems/DINGRP","users":163,"accepted":27.24}
+{"id":6041,"name":"Mountain Walking","url":"https://www.spoj.com/problems/QCJ1","users":481,"accepted":42.72}
+{"id":6042,"name":"Another Box Problem","url":"https://www.spoj.com/problems/QCJ2","users":847,"accepted":49.9}
+{"id":6043,"name":"The Game","url":"https://www.spoj.com/problems/QCJ3","users":944,"accepted":39.6}
+{"id":6044,"name":"Minimum Diameter Circle","url":"https://www.spoj.com/problems/QCJ4","users":449,"accepted":27.84}
+{"id":6052,"name":"PBCGAME","url":"https://www.spoj.com/problems/PBCGAME","users":85,"accepted":27.45}
+{"id":6059,"name":"Another GCD problem","url":"https://www.spoj.com/problems/GCDSQF","users":342,"accepted":45.2}
+{"id":6072,"name":"Chocolate","url":"https://www.spoj.com/problems/SOCOLA","users":161,"accepted":21.61}
+{"id":6168,"name":"Building Bridges","url":"https://www.spoj.com/problems/BRIDGE","users":1665,"accepted":25.98}
+{"id":6169,"name":"Standing Sequence","url":"https://www.spoj.com/problems/SSEQ","users":122,"accepted":28.6}
+{"id":6170,"name":"Homecoming","url":"https://www.spoj.com/problems/HOMEC","users":32,"accepted":30.77}
+{"id":6171,"name":"Majority","url":"https://www.spoj.com/problems/MAJOR","users":5349,"accepted":43.19}
+{"id":6172,"name":"OAE","url":"https://www.spoj.com/problems/OAE","users":1230,"accepted":42.03}
+{"id":6187,"name":"Jane and Tarzan","url":"https://www.spoj.com/problems/JANE","users":219,"accepted":24.61}
+{"id":6219,"name":"Edit distance","url":"https://www.spoj.com/problems/EDIST","users":13243,"accepted":33.14}
+{"id":6221,"name":"Increasing Powers of K","url":"https://www.spoj.com/problems/INCPOWK","users":360,"accepted":27.59}

--- a/tests/spoj/index/24.md
+++ b/tests/spoj/index/24.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 5541 | [Sequoiadendron](https://www.spoj.com/problems/SEQUOIA) | 66 | 44.25 |
+| 5542 | [Counting pairs](https://www.spoj.com/problems/CPAIR) | 135 | 26.54 |
+| 5566 | [Math with Bases](https://www.spoj.com/problems/BSMATH2) | 15 | 10.78 |
+| 5609 | [Knight Moves](https://www.spoj.com/problems/KMOVES) | 107 | 40.69 |
+| 5637 | [LL and ErBao](https://www.spoj.com/problems/ISUN1) | 5 | 41.43 |
+| 5638 | [Mobile Service Hard](https://www.spoj.com/problems/SERVICEH) | 91 | 22.09 |
+| 5640 | [Fractions on Tree](https://www.spoj.com/problems/NG0FRCTN) | 930 | 61.30 |
+| 5649 | [Divide Polygon](https://www.spoj.com/problems/DTPOLY) | 48 | 22.95 |
+| 5652 | [Snow White and the N dwarfs](https://www.spoj.com/problems/PATULJCI) | 1027 | 18.07 |
+| 5672 | [Captain Selection](https://www.spoj.com/problems/CAPTAIN) | 10 | 26.42 |
+| 5673 | [Fractions on Tree ( reloaded !)](https://www.spoj.com/problems/NG1FRCTN) | 248 | 38.33 |
+| 5699 | [The last digit re-visited](https://www.spoj.com/problems/LASTDIG2) | 7470 | 31.71 |
+| 5703 | [Primes of Lambda](https://www.spoj.com/problems/LPRIME) | 24 | 26.83 |
+| 5725 | [123 Sequence](https://www.spoj.com/problems/KSEQ) | 124 | 24.09 |
+| 5732 | [Paradox](https://www.spoj.com/problems/PARADOX) | 1240 | 27.86 |
+| 5830 | [Alternating Permutations](https://www.spoj.com/problems/ALTPERM) | 65 | 39.22 |
+| 5831 | [Permutation Jumping](https://www.spoj.com/problems/PERMJUMP) | 137 | 59.48 |
+| 5832 | [AND Rounds](https://www.spoj.com/problems/ANDROUND) | 1702 | 24.89 |
+| 5833 | [XOR Rounds](https://www.spoj.com/problems/XORROUND) | 360 | 30.83 |
+| 5885 | [Troops of Sand Monsters](https://www.spoj.com/problems/TROOPS) | 114 | 17.47 |
+| 5902 | [Tri](https://www.spoj.com/problems/CEOI09TR) | 79 | 20.26 |
+| 5911 | [Square-free Integers Factorization](https://www.spoj.com/problems/SQFFACT) | 20 | 30.67 |
+| 5917 | [Factorial length](https://www.spoj.com/problems/LENGFACT) | 3478 | 34.57 |
+| 5969 | [Finding Maximum](https://www.spoj.com/problems/FINDMAX) | 109 | 30.31 |
+| 5970 | [Finding Primes](https://www.spoj.com/problems/FINDPRM) | 1345 | 27.95 |
+| 5971 | [LCM Sum](https://www.spoj.com/problems/LCMSUM) | 3941 | 26.28 |
+| 5972 | [Maximum Sum Sequences](https://www.spoj.com/problems/MAXSUMSQ) | 1159 | 20.63 |
+| 5973 | [Selecting Teams](https://www.spoj.com/problems/SELTEAM) | 234 | 23.28 |
+| 5975 | [Travelling Knight](https://www.spoj.com/problems/TRKNIGHT) | 54 | 32.69 |
+| 5976 | [Traversing Grid](https://www.spoj.com/problems/TRGRID) | 3721 | 58.56 |
+| 5977 | [Weird Function](https://www.spoj.com/problems/WEIRDFN) | 1155 | 18.97 |
+| 5978 | [Frequent Prime Ranges](https://www.spoj.com/problems/FRQPRIME) | 717 | 28.80 |
+| 5979 | [Yet Another Permutations Problem](https://www.spoj.com/problems/YAPP) | 1358 | 49.53 |
+| 5980 | [Matrix Game](https://www.spoj.com/problems/MATGAME) | 967 | 29.09 |
+| 6035 | [Dinner](https://www.spoj.com/problems/DINGRP) | 163 | 27.24 |
+| 6041 | [Mountain Walking](https://www.spoj.com/problems/QCJ1) | 481 | 42.72 |
+| 6042 | [Another Box Problem](https://www.spoj.com/problems/QCJ2) | 847 | 49.90 |
+| 6043 | [The Game](https://www.spoj.com/problems/QCJ3) | 944 | 39.60 |
+| 6044 | [Minimum Diameter Circle](https://www.spoj.com/problems/QCJ4) | 449 | 27.84 |
+| 6052 | [PBCGAME](https://www.spoj.com/problems/PBCGAME) | 85 | 27.45 |
+| 6059 | [Another GCD problem](https://www.spoj.com/problems/GCDSQF) | 342 | 45.20 |
+| 6072 | [Chocolate](https://www.spoj.com/problems/SOCOLA) | 161 | 21.61 |
+| 6168 | [Building Bridges](https://www.spoj.com/problems/BRIDGE) | 1665 | 25.98 |
+| 6169 | [Standing Sequence](https://www.spoj.com/problems/SSEQ) | 122 | 28.60 |
+| 6170 | [Homecoming](https://www.spoj.com/problems/HOMEC) | 32 | 30.77 |
+| 6171 | [Majority](https://www.spoj.com/problems/MAJOR) | 5349 | 43.19 |
+| 6172 | [OAE](https://www.spoj.com/problems/OAE) | 1230 | 42.03 |
+| 6187 | [Jane and Tarzan](https://www.spoj.com/problems/JANE) | 219 | 24.61 |
+| 6219 | [Edit distance](https://www.spoj.com/problems/EDIST) | 13243 | 33.14 |
+| 6221 | [Increasing Powers of K](https://www.spoj.com/problems/INCPOWK) | 360 | 27.59 |

--- a/tests/spoj/index/25.jsonl
+++ b/tests/spoj/index/25.jsonl
@@ -1,0 +1,50 @@
+{"id":6230,"name":"Dictionary order","url":"https://www.spoj.com/problems/GSP1","users":6,"accepted":9.64}
+{"id":6236,"name":"Matches","url":"https://www.spoj.com/problems/FERT21_0","users":458,"accepted":22.1}
+{"id":6256,"name":"Inversion Count","url":"https://www.spoj.com/problems/INVCNT","users":18062,"accepted":32.03}
+{"id":6264,"name":"Rank of a Fraction","url":"https://www.spoj.com/problems/FNRANK","users":132,"accepted":31.92}
+{"id":6285,"name":"Another Game With Numbers","url":"https://www.spoj.com/problems/NGM2","users":1332,"accepted":31.23}
+{"id":6286,"name":"Sum of products","url":"https://www.spoj.com/problems/SUMMUL","users":386,"accepted":36.84}
+{"id":6288,"name":"Treeramids","url":"https://www.spoj.com/problems/PYRA","users":1095,"accepted":51.95}
+{"id":6289,"name":"Bomberman","url":"https://www.spoj.com/problems/BOMBER","users":214,"accepted":25.76}
+{"id":6290,"name":"Robbery 2","url":"https://www.spoj.com/problems/ROBBERY2","users":807,"accepted":32.9}
+{"id":6292,"name":"Shmoogle Wave","url":"https://www.spoj.com/problems/SHMOOGLE","users":17,"accepted":23.01}
+{"id":6294,"name":"Yodaness Level","url":"https://www.spoj.com/problems/YODANESS","users":3571,"accepted":49.31}
+{"id":6296,"name":"Experiment","url":"https://www.spoj.com/problems/EXPER","users":34,"accepted":23.08}
+{"id":6297,"name":"Decipher","url":"https://www.spoj.com/problems/ROOTCIPH","users":4008,"accepted":44.7}
+{"id":6299,"name":"Move Marbles","url":"https://www.spoj.com/problems/MOVMRBL","users":22,"accepted":5.52}
+{"id":6322,"name":"The hunt for Gollum","url":"https://www.spoj.com/problems/ARDA1","users":710,"accepted":23.02}
+{"id":6325,"name":"Many polygons","url":"https://www.spoj.com/problems/NGON","users":202,"accepted":26.44}
+{"id":6340,"name":"ZUMA","url":"https://www.spoj.com/problems/ZUMA","users":513,"accepted":45.87}
+{"id":6356,"name":"Rock-Paper-Scissors-Lizard-Spock","url":"https://www.spoj.com/problems/RPSSL","users":178,"accepted":42.29}
+{"id":6377,"name":"Two Array Problem","url":"https://www.spoj.com/problems/SAMTWARR","users":189,"accepted":28.02}
+{"id":6408,"name":"Counting Triangles 2","url":"https://www.spoj.com/problems/KKKCT2","users":66,"accepted":34.52}
+{"id":6450,"name":"PP numbers","url":"https://www.spoj.com/problems/MB1","users":886,"accepted":41.94}
+{"id":6470,"name":"Finding the Kth Prime","url":"https://www.spoj.com/problems/TDKPRIME","users":7859,"accepted":27.23}
+{"id":6471,"name":"Printing some primes","url":"https://www.spoj.com/problems/TDPRIMES","users":7800,"accepted":28.88}
+{"id":6477,"name":"Bowling","url":"https://www.spoj.com/problems/BOWLING1","users":526,"accepted":28.74}
+{"id":6478,"name":"Hamster Flight 2","url":"https://www.spoj.com/problems/HAMSTER2","users":67,"accepted":33.33}
+{"id":6479,"name":"The Very Greatest Common Divisor","url":"https://www.spoj.com/problems/VGCD","users":95,"accepted":10.11}
+{"id":6488,"name":"Printing some primes (Hard)","url":"https://www.spoj.com/problems/PRIMES2","users":198,"accepted":15.47}
+{"id":6489,"name":"Finding the Kth Prime (Hard)","url":"https://www.spoj.com/problems/KPRIMES2","users":95,"accepted":10.45}
+{"id":6499,"name":"Breaking Chocolates","url":"https://www.spoj.com/problems/BCHOCO","users":104,"accepted":18.89}
+{"id":6500,"name":"Counting Diameter","url":"https://www.spoj.com/problems/DCOUNT","users":38,"accepted":28.21}
+{"id":6503,"name":"Travelling Salesman Again !","url":"https://www.spoj.com/problems/TSPAGAIN","users":92,"accepted":35.17}
+{"id":6517,"name":"Farmer Sepp","url":"https://www.spoj.com/problems/JOCHEF","users":340,"accepted":22.09}
+{"id":6556,"name":"N DIV PHI_N","url":"https://www.spoj.com/problems/NDIVPHI","users":749,"accepted":38.38}
+{"id":6560,"name":"N DIV PHI_N (Hard)","url":"https://www.spoj.com/problems/NDIVPHI2","users":168,"accepted":21.34}
+{"id":6562,"name":"Esferas","url":"https://www.spoj.com/problems/PRUBALL","users":628,"accepted":61}
+{"id":6576,"name":"Divide and Conquer","url":"https://www.spoj.com/problems/DIVCON","users":62,"accepted":16.51}
+{"id":6578,"name":"Segment Tree","url":"https://www.spoj.com/problems/SEGTREE","users":53,"accepted":9.91}
+{"id":6622,"name":"Islands and Hotel Chains","url":"https://www.spoj.com/problems/HCHAINS","users":66,"accepted":9.68}
+{"id":6624,"name":"Snowball Game","url":"https://www.spoj.com/problems/SNOWGAME","users":53,"accepted":31.43}
+{"id":6650,"name":"Consecutive sequence","url":"https://www.spoj.com/problems/SEQ6","users":324,"accepted":45.08}
+{"id":6652,"name":"Skiers","url":"https://www.spoj.com/problems/SKIVER1","users":35,"accepted":47.26}
+{"id":6665,"name":"Easy Longest Common Substring","url":"https://www.spoj.com/problems/ELCS","users":149,"accepted":23.11}
+{"id":6678,"name":"Load Testing","url":"https://www.spoj.com/problems/GCJ101C","users":204,"accepted":59.78}
+{"id":6681,"name":"Point on the side of the rectangle","url":"https://www.spoj.com/problems/MRECT1","users":138,"accepted":44.69}
+{"id":6690,"name":"A - Comparison Expressions","url":"https://www.spoj.com/problems/BOCOMP","users":57,"accepted":33.22}
+{"id":6691,"name":"Picking Up Chicks","url":"https://www.spoj.com/problems/GCJ101BB","users":2261,"accepted":32.18}
+{"id":6692,"name":"B - Esperanto Lessons","url":"https://www.spoj.com/problems/BOLESSON","users":69,"accepted":64.8}
+{"id":6693,"name":"C - Karaoke","url":"https://www.spoj.com/problems/BOKO","users":26,"accepted":56}
+{"id":6694,"name":"D - Playing with Marbles","url":"https://www.spoj.com/problems/BOMARBLE","users":3504,"accepted":66.68}
+{"id":6695,"name":"E - Publish of Perish","url":"https://www.spoj.com/problems/BOPERISH","users":714,"accepted":39.98}

--- a/tests/spoj/index/25.md
+++ b/tests/spoj/index/25.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 6230 | [Dictionary order](https://www.spoj.com/problems/GSP1) | 6 | 9.64 |
+| 6236 | [Matches](https://www.spoj.com/problems/FERT21_0) | 458 | 22.10 |
+| 6256 | [Inversion Count](https://www.spoj.com/problems/INVCNT) | 18062 | 32.03 |
+| 6264 | [Rank of a Fraction](https://www.spoj.com/problems/FNRANK) | 132 | 31.92 |
+| 6285 | [Another Game With Numbers](https://www.spoj.com/problems/NGM2) | 1332 | 31.23 |
+| 6286 | [Sum of products](https://www.spoj.com/problems/SUMMUL) | 386 | 36.84 |
+| 6288 | [Treeramids](https://www.spoj.com/problems/PYRA) | 1095 | 51.95 |
+| 6289 | [Bomberman](https://www.spoj.com/problems/BOMBER) | 214 | 25.76 |
+| 6290 | [Robbery 2](https://www.spoj.com/problems/ROBBERY2) | 807 | 32.90 |
+| 6292 | [Shmoogle Wave](https://www.spoj.com/problems/SHMOOGLE) | 17 | 23.01 |
+| 6294 | [Yodaness Level](https://www.spoj.com/problems/YODANESS) | 3571 | 49.31 |
+| 6296 | [Experiment](https://www.spoj.com/problems/EXPER) | 34 | 23.08 |
+| 6297 | [Decipher](https://www.spoj.com/problems/ROOTCIPH) | 4008 | 44.70 |
+| 6299 | [Move Marbles](https://www.spoj.com/problems/MOVMRBL) | 22 | 5.52 |
+| 6322 | [The hunt for Gollum](https://www.spoj.com/problems/ARDA1) | 710 | 23.02 |
+| 6325 | [Many polygons](https://www.spoj.com/problems/NGON) | 202 | 26.44 |
+| 6340 | [ZUMA](https://www.spoj.com/problems/ZUMA) | 513 | 45.87 |
+| 6356 | [Rock-Paper-Scissors-Lizard-Spock](https://www.spoj.com/problems/RPSSL) | 178 | 42.29 |
+| 6377 | [Two Array Problem](https://www.spoj.com/problems/SAMTWARR) | 189 | 28.02 |
+| 6408 | [Counting Triangles 2](https://www.spoj.com/problems/KKKCT2) | 66 | 34.52 |
+| 6450 | [PP numbers](https://www.spoj.com/problems/MB1) | 886 | 41.94 |
+| 6470 | [Finding the Kth Prime](https://www.spoj.com/problems/TDKPRIME) | 7859 | 27.23 |
+| 6471 | [Printing some primes](https://www.spoj.com/problems/TDPRIMES) | 7800 | 28.88 |
+| 6477 | [Bowling](https://www.spoj.com/problems/BOWLING1) | 526 | 28.74 |
+| 6478 | [Hamster Flight 2](https://www.spoj.com/problems/HAMSTER2) | 67 | 33.33 |
+| 6479 | [The Very Greatest Common Divisor](https://www.spoj.com/problems/VGCD) | 95 | 10.11 |
+| 6488 | [Printing some primes (Hard)](https://www.spoj.com/problems/PRIMES2) | 198 | 15.47 |
+| 6489 | [Finding the Kth Prime (Hard)](https://www.spoj.com/problems/KPRIMES2) | 95 | 10.45 |
+| 6499 | [Breaking Chocolates](https://www.spoj.com/problems/BCHOCO) | 104 | 18.89 |
+| 6500 | [Counting Diameter](https://www.spoj.com/problems/DCOUNT) | 38 | 28.21 |
+| 6503 | [Travelling Salesman Again !](https://www.spoj.com/problems/TSPAGAIN) | 92 | 35.17 |
+| 6517 | [Farmer Sepp](https://www.spoj.com/problems/JOCHEF) | 340 | 22.09 |
+| 6556 | [N DIV PHI_N](https://www.spoj.com/problems/NDIVPHI) | 749 | 38.38 |
+| 6560 | [N DIV PHI_N (Hard)](https://www.spoj.com/problems/NDIVPHI2) | 168 | 21.34 |
+| 6562 | [Esferas](https://www.spoj.com/problems/PRUBALL) | 628 | 61.00 |
+| 6576 | [Divide and Conquer](https://www.spoj.com/problems/DIVCON) | 62 | 16.51 |
+| 6578 | [Segment Tree](https://www.spoj.com/problems/SEGTREE) | 53 | 9.91 |
+| 6622 | [Islands and Hotel Chains](https://www.spoj.com/problems/HCHAINS) | 66 | 9.68 |
+| 6624 | [Snowball Game](https://www.spoj.com/problems/SNOWGAME) | 53 | 31.43 |
+| 6650 | [Consecutive sequence](https://www.spoj.com/problems/SEQ6) | 324 | 45.08 |
+| 6652 | [Skiers](https://www.spoj.com/problems/SKIVER1) | 35 | 47.26 |
+| 6665 | [Easy Longest Common Substring](https://www.spoj.com/problems/ELCS) | 149 | 23.11 |
+| 6678 | [Load Testing](https://www.spoj.com/problems/GCJ101C) | 204 | 59.78 |
+| 6681 | [Point on the side of the rectangle](https://www.spoj.com/problems/MRECT1) | 138 | 44.69 |
+| 6690 | [A - Comparison Expressions](https://www.spoj.com/problems/BOCOMP) | 57 | 33.22 |
+| 6691 | [Picking Up Chicks](https://www.spoj.com/problems/GCJ101BB) | 2261 | 32.18 |
+| 6692 | [B - Esperanto Lessons](https://www.spoj.com/problems/BOLESSON) | 69 | 64.80 |
+| 6693 | [C - Karaoke](https://www.spoj.com/problems/BOKO) | 26 | 56.00 |
+| 6694 | [D - Playing with Marbles](https://www.spoj.com/problems/BOMARBLE) | 3504 | 66.68 |
+| 6695 | [E - Publish of Perish](https://www.spoj.com/problems/BOPERISH) | 714 | 39.98 |

--- a/tests/spoj/index/26.jsonl
+++ b/tests/spoj/index/26.jsonl
@@ -1,0 +1,50 @@
+{"id":6700,"name":"Make it Smooth","url":"https://www.spoj.com/problems/GCJ101AB","users":72,"accepted":20.61}
+{"id":6706,"name":"Making Chess Boards","url":"https://www.spoj.com/problems/CT101CC","users":27,"accepted":22.88}
+{"id":6709,"name":"Multiplying by Rotation","url":"https://www.spoj.com/problems/MBR","users":92,"accepted":51.94}
+{"id":6711,"name":"Transform a Sequence","url":"https://www.spoj.com/problems/BLOCK","users":40,"accepted":30.43}
+{"id":6717,"name":"Two Paths","url":"https://www.spoj.com/problems/TWOPATHS","users":231,"accepted":17.81}
+{"id":6720,"name":"Paper Fold","url":"https://www.spoj.com/problems/PFOLD","users":19,"accepted":12.21}
+{"id":6726,"name":"Goldbach graphs","url":"https://www.spoj.com/problems/GOLDG","users":35,"accepted":57.14}
+{"id":6731,"name":"Coeficientes","url":"https://www.spoj.com/problems/COEF","users":1260,"accepted":50.09}
+{"id":6732,"name":"Camels","url":"https://www.spoj.com/problems/CT14E","users":88,"accepted":37.93}
+{"id":6738,"name":"Nice Quadrangles","url":"https://www.spoj.com/problems/CHEFMAY","users":180,"accepted":40.97}
+{"id":6767,"name":"Sequence Function","url":"https://www.spoj.com/problems/SEQFUN","users":14,"accepted":18.52}
+{"id":6772,"name":"Happy Coins","url":"https://www.spoj.com/problems/HC","users":2457,"accepted":55.25}
+{"id":6773,"name":"Dinostratus Numbers","url":"https://www.spoj.com/problems/DINONUM","users":95,"accepted":18.13}
+{"id":6779,"name":"Can you answer these queries VII","url":"https://www.spoj.com/problems/GSS7","users":1439,"accepted":19.41}
+{"id":6803,"name":"Absurd prices","url":"https://www.spoj.com/problems/ABSURD","users":388,"accepted":23.82}
+{"id":6804,"name":"Cheating or Not","url":"https://www.spoj.com/problems/CHEATING","users":19,"accepted":15.38}
+{"id":6805,"name":"Counter attack","url":"https://www.spoj.com/problems/CATTACK","users":177,"accepted":60.98}
+{"id":6818,"name":"Capital City","url":"https://www.spoj.com/problems/CAPCITY","users":2951,"accepted":39.46}
+{"id":6819,"name":"Yet Another Assignment Problem","url":"https://www.spoj.com/problems/ASSIGN5","users":42,"accepted":11.26}
+{"id":6823,"name":"Seller Bob","url":"https://www.spoj.com/problems/CFJUN21","users":73,"accepted":21.72}
+{"id":6824,"name":"Flag","url":"https://www.spoj.com/problems/CTFLAG","users":78,"accepted":24.84}
+{"id":6825,"name":"Field Plan","url":"https://www.spoj.com/problems/FPLAN","users":105,"accepted":30.22}
+{"id":6826,"name":"Hacking","url":"https://www.spoj.com/problems/HACKING","users":129,"accepted":14}
+{"id":6827,"name":"Last Minute Construction","url":"https://www.spoj.com/problems/LMCONSTR","users":24,"accepted":17.36}
+{"id":6828,"name":"Lineup","url":"https://www.spoj.com/problems/LINEUP","users":704,"accepted":32.08}
+{"id":6829,"name":"Polynomial","url":"https://www.spoj.com/problems/POLYNOM","users":194,"accepted":30.39}
+{"id":6830,"name":"Soccer Bets","url":"https://www.spoj.com/problems/SBETS","users":1600,"accepted":51.2}
+{"id":6831,"name":"Two Ball Game","url":"https://www.spoj.com/problems/TBGAME","users":66,"accepted":28.12}
+{"id":6832,"name":"To Score or not to score","url":"https://www.spoj.com/problems/TOSCORE","users":46,"accepted":29.01}
+{"id":6851,"name":"Fence","url":"https://www.spoj.com/problems/CT10R3B","users":43,"accepted":24.4}
+{"id":6852,"name":"Fish","url":"https://www.spoj.com/problems/CT16E","users":185,"accepted":30.37}
+{"id":6860,"name":"Asistent","url":"https://www.spoj.com/problems/ASISTENT","users":25,"accepted":13.45}
+{"id":6885,"name":"Wonkas Oompa-Impa Dilemma","url":"https://www.spoj.com/problems/WONKA1","users":15,"accepted":21.74}
+{"id":6893,"name":"Power Sums","url":"https://www.spoj.com/problems/PWSUM","users":107,"accepted":57.01}
+{"id":6895,"name":"Maximum Edge of Powers of Permutation","url":"https://www.spoj.com/problems/MEPPERM","users":12,"accepted":21.39}
+{"id":6898,"name":"Substring Problem","url":"https://www.spoj.com/problems/SUB_PROB","users":851,"accepted":15.2}
+{"id":6906,"name":"Raining Parabolas","url":"https://www.spoj.com/problems/RPAR","users":257,"accepted":21.65}
+{"id":6917,"name":"Catch Sheep","url":"https://www.spoj.com/problems/XYYHHTT","users":40,"accepted":25.41}
+{"id":6926,"name":"Tree game","url":"https://www.spoj.com/problems/CT23E","users":55,"accepted":9.34}
+{"id":6949,"name":"PIN","url":"https://www.spoj.com/problems/CTOI10D2","users":144,"accepted":28.36}
+{"id":6950,"name":"A HUGE TOWER","url":"https://www.spoj.com/problems/CTOI10D3","users":131,"accepted":48.34}
+{"id":6951,"name":"MP3 Player","url":"https://www.spoj.com/problems/CTOI10D1","users":42,"accepted":28.57}
+{"id":6956,"name":"IOI2009 Mecho","url":"https://www.spoj.com/problems/CTOI09_1","users":167,"accepted":18.36}
+{"id":6957,"name":"Partial Palindrome","url":"https://www.spoj.com/problems/PARTPAL","users":3,"accepted":5.43}
+{"id":6977,"name":"Odd Independent Sets","url":"https://www.spoj.com/problems/INDEPCNT","users":17,"accepted":51.28}
+{"id":6978,"name":"Check 1324","url":"https://www.spoj.com/problems/PERMPATT","users":101,"accepted":23.08}
+{"id":6981,"name":"The Least Number","url":"https://www.spoj.com/problems/RNDORDER","users":23,"accepted":24.43}
+{"id":6985,"name":"Rearranging Digits","url":"https://www.spoj.com/problems/ARRANGE2","users":56,"accepted":22.53}
+{"id":6986,"name":"Summing Slopes","url":"https://www.spoj.com/problems/SUMSLOPE","users":61,"accepted":28.79}
+{"id":6988,"name":"Beer Machines","url":"https://www.spoj.com/problems/STJEPAN","users":33,"accepted":17.36}

--- a/tests/spoj/index/26.md
+++ b/tests/spoj/index/26.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 6700 | [Make it Smooth](https://www.spoj.com/problems/GCJ101AB) | 72 | 20.61 |
+| 6706 | [Making Chess Boards](https://www.spoj.com/problems/CT101CC) | 27 | 22.88 |
+| 6709 | [Multiplying by Rotation](https://www.spoj.com/problems/MBR) | 92 | 51.94 |
+| 6711 | [Transform a Sequence](https://www.spoj.com/problems/BLOCK) | 40 | 30.43 |
+| 6717 | [Two Paths](https://www.spoj.com/problems/TWOPATHS) | 231 | 17.81 |
+| 6720 | [Paper Fold](https://www.spoj.com/problems/PFOLD) | 19 | 12.21 |
+| 6726 | [Goldbach graphs](https://www.spoj.com/problems/GOLDG) | 35 | 57.14 |
+| 6731 | [Coeficientes](https://www.spoj.com/problems/COEF) | 1260 | 50.09 |
+| 6732 | [Camels](https://www.spoj.com/problems/CT14E) | 88 | 37.93 |
+| 6738 | [Nice Quadrangles](https://www.spoj.com/problems/CHEFMAY) | 180 | 40.97 |
+| 6767 | [Sequence Function](https://www.spoj.com/problems/SEQFUN) | 14 | 18.52 |
+| 6772 | [Happy Coins](https://www.spoj.com/problems/HC) | 2457 | 55.25 |
+| 6773 | [Dinostratus Numbers](https://www.spoj.com/problems/DINONUM) | 95 | 18.13 |
+| 6779 | [Can you answer these queries VII](https://www.spoj.com/problems/GSS7) | 1439 | 19.41 |
+| 6803 | [Absurd prices](https://www.spoj.com/problems/ABSURD) | 388 | 23.82 |
+| 6804 | [Cheating or Not](https://www.spoj.com/problems/CHEATING) | 19 | 15.38 |
+| 6805 | [Counter attack](https://www.spoj.com/problems/CATTACK) | 177 | 60.98 |
+| 6818 | [Capital City](https://www.spoj.com/problems/CAPCITY) | 2951 | 39.46 |
+| 6819 | [Yet Another Assignment Problem](https://www.spoj.com/problems/ASSIGN5) | 42 | 11.26 |
+| 6823 | [Seller Bob](https://www.spoj.com/problems/CFJUN21) | 73 | 21.72 |
+| 6824 | [Flag](https://www.spoj.com/problems/CTFLAG) | 78 | 24.84 |
+| 6825 | [Field Plan](https://www.spoj.com/problems/FPLAN) | 105 | 30.22 |
+| 6826 | [Hacking](https://www.spoj.com/problems/HACKING) | 129 | 14.00 |
+| 6827 | [Last Minute Construction](https://www.spoj.com/problems/LMCONSTR) | 24 | 17.36 |
+| 6828 | [Lineup](https://www.spoj.com/problems/LINEUP) | 704 | 32.08 |
+| 6829 | [Polynomial](https://www.spoj.com/problems/POLYNOM) | 194 | 30.39 |
+| 6830 | [Soccer Bets](https://www.spoj.com/problems/SBETS) | 1600 | 51.20 |
+| 6831 | [Two Ball Game](https://www.spoj.com/problems/TBGAME) | 66 | 28.12 |
+| 6832 | [To Score or not to score](https://www.spoj.com/problems/TOSCORE) | 46 | 29.01 |
+| 6851 | [Fence](https://www.spoj.com/problems/CT10R3B) | 43 | 24.40 |
+| 6852 | [Fish](https://www.spoj.com/problems/CT16E) | 185 | 30.37 |
+| 6860 | [Asistent](https://www.spoj.com/problems/ASISTENT) | 25 | 13.45 |
+| 6885 | [Wonkas Oompa-Impa Dilemma](https://www.spoj.com/problems/WONKA1) | 15 | 21.74 |
+| 6893 | [Power Sums](https://www.spoj.com/problems/PWSUM) | 107 | 57.01 |
+| 6895 | [Maximum Edge of Powers of Permutation](https://www.spoj.com/problems/MEPPERM) | 12 | 21.39 |
+| 6898 | [Substring Problem](https://www.spoj.com/problems/SUB_PROB) | 851 | 15.20 |
+| 6906 | [Raining Parabolas](https://www.spoj.com/problems/RPAR) | 257 | 21.65 |
+| 6917 | [Catch Sheep](https://www.spoj.com/problems/XYYHHTT) | 40 | 25.41 |
+| 6926 | [Tree game](https://www.spoj.com/problems/CT23E) | 55 | 9.34 |
+| 6949 | [PIN](https://www.spoj.com/problems/CTOI10D2) | 144 | 28.36 |
+| 6950 | [A HUGE TOWER](https://www.spoj.com/problems/CTOI10D3) | 131 | 48.34 |
+| 6951 | [MP3 Player](https://www.spoj.com/problems/CTOI10D1) | 42 | 28.57 |
+| 6956 | [IOI2009 Mecho](https://www.spoj.com/problems/CTOI09_1) | 167 | 18.36 |
+| 6957 | [Partial Palindrome](https://www.spoj.com/problems/PARTPAL) | 3 | 5.43 |
+| 6977 | [Odd Independent Sets](https://www.spoj.com/problems/INDEPCNT) | 17 | 51.28 |
+| 6978 | [Check 1324](https://www.spoj.com/problems/PERMPATT) | 101 | 23.08 |
+| 6981 | [The Least Number](https://www.spoj.com/problems/RNDORDER) | 23 | 24.43 |
+| 6985 | [Rearranging Digits](https://www.spoj.com/problems/ARRANGE2) | 56 | 22.53 |
+| 6986 | [Summing Slopes](https://www.spoj.com/problems/SUMSLOPE) | 61 | 28.79 |
+| 6988 | [Beer Machines](https://www.spoj.com/problems/STJEPAN) | 33 | 17.36 |

--- a/tests/spoj/index/27.jsonl
+++ b/tests/spoj/index/27.jsonl
@@ -1,0 +1,50 @@
+{"id":6999,"name":"Avoiding SOS Grids","url":"https://www.spoj.com/problems/AVOIDSOS","users":69,"accepted":10.71}
+{"id":7001,"name":"Visible Lattice Points","url":"https://www.spoj.com/problems/VLATTICE","users":562,"accepted":30.19}
+{"id":7002,"name":"Buildings","url":"https://www.spoj.com/problems/BUILDING","users":81,"accepted":37.9}
+{"id":7010,"name":"Police Business","url":"https://www.spoj.com/problems/ACAB","users":6,"accepted":25}
+{"id":7015,"name":"Party","url":"https://www.spoj.com/problems/CFPARTY","users":1054,"accepted":50.97}
+{"id":7019,"name":"Zig-Zag rabbit","url":"https://www.spoj.com/problems/ZIGZAG","users":596,"accepted":36.47}
+{"id":7022,"name":"Cow Patterns","url":"https://www.spoj.com/problems/CPATTERN","users":128,"accepted":26.15}
+{"id":7023,"name":"Cookies","url":"https://www.spoj.com/problems/KOLACI","users":19,"accepted":28.8}
+{"id":7025,"name":"Roads in Berland","url":"https://www.spoj.com/problems/CT25C","users":135,"accepted":33.29}
+{"id":7034,"name":"Crashing Robots","url":"https://www.spoj.com/problems/CROBOTS","users":171,"accepted":47.9}
+{"id":7035,"name":"The Embarrassed Cryptographer","url":"https://www.spoj.com/problems/CRYPTON","users":356,"accepted":32.14}
+{"id":7050,"name":"Necklace Decomposition","url":"https://www.spoj.com/problems/NECKDEC","users":48,"accepted":60.61}
+{"id":7099,"name":"Advanced Edit Distance","url":"https://www.spoj.com/problems/ADVEDIST","users":410,"accepted":31.96}
+{"id":7100,"name":"Back To The Polygon","url":"https://www.spoj.com/problems/BACKTPOL","users":88,"accepted":34.8}
+{"id":7101,"name":"Charly And Nito","url":"https://www.spoj.com/problems/CANDN","users":314,"accepted":37.22}
+{"id":7102,"name":"Doing The Word Wrap","url":"https://www.spoj.com/problems/DTWW","users":175,"accepted":38.33}
+{"id":7103,"name":"Edit Distance","url":"https://www.spoj.com/problems/EDDIST","users":74,"accepted":18.02}
+{"id":7104,"name":"Feanor The Elf","url":"https://www.spoj.com/problems/FTHEELF","users":733,"accepted":40.24}
+{"id":7107,"name":"G Key","url":"https://www.spoj.com/problems/GK","users":87,"accepted":44.98}
+{"id":7108,"name":"Heptadecimal Numbers","url":"https://www.spoj.com/problems/HEPNUM","users":1231,"accepted":35.72}
+{"id":7109,"name":"Indicator of progression","url":"https://www.spoj.com/problems/INDIPROG","users":325,"accepted":23.89}
+{"id":7132,"name":"Headshot","url":"https://www.spoj.com/problems/HEADSHOT","users":1407,"accepted":37.4}
+{"id":7133,"name":"Garden 2005","url":"https://www.spoj.com/problems/IOIGARD","users":69,"accepted":23.42}
+{"id":7150,"name":"Palindrome 2000","url":"https://www.spoj.com/problems/IOIPALIN","users":3297,"accepted":27.6}
+{"id":7152,"name":"Boundary 2003","url":"https://www.spoj.com/problems/IOIBOUND","users":18,"accepted":12.34}
+{"id":7155,"name":"Test","url":"https://www.spoj.com/problems/CF25E","users":420,"accepted":19.22}
+{"id":7168,"name":"Termites strike back","url":"https://www.spoj.com/problems/TERMITES","users":19,"accepted":39.66}
+{"id":7169,"name":"Pizza","url":"https://www.spoj.com/problems/EGYPIZZA","users":6438,"accepted":29.98}
+{"id":7184,"name":"Axis of Symmetry","url":"https://www.spoj.com/problems/AXIS","users":71,"accepted":18.88}
+{"id":7185,"name":"Bye Bye Cakes","url":"https://www.spoj.com/problems/BYECAKES","users":3669,"accepted":38.67}
+{"id":7186,"name":"Counting Pascal","url":"https://www.spoj.com/problems/COUNTPAS","users":134,"accepted":29.77}
+{"id":7187,"name":"Dinosaur Menace","url":"https://www.spoj.com/problems/DINOSM","users":184,"accepted":8.83}
+{"id":7188,"name":"Escape from Jail","url":"https://www.spoj.com/problems/ESJAIL","users":629,"accepted":30.98}
+{"id":7189,"name":"Falta Envido","url":"https://www.spoj.com/problems/FALTAENV","users":182,"accepted":36.33}
+{"id":7190,"name":"Guess the Number","url":"https://www.spoj.com/problems/GUESSTHE","users":2237,"accepted":33.37}
+{"id":7191,"name":"Hexagonal Board","url":"https://www.spoj.com/problems/HEXBOARD","users":546,"accepted":62.2}
+{"id":7192,"name":"Integral Maximization","url":"https://www.spoj.com/problems/INTEGMAX","users":375,"accepted":38.35}
+{"id":7193,"name":"The Pharaoh Curse","url":"https://www.spoj.com/problems/CURSE","users":16,"accepted":21.05}
+{"id":7200,"name":"Strange Calendar","url":"https://www.spoj.com/problems/CAL","users":76,"accepted":47.81}
+{"id":7208,"name":"Black or White","url":"https://www.spoj.com/problems/BORW","users":1481,"accepted":42.47}
+{"id":7209,"name":"Closest Triplet","url":"https://www.spoj.com/problems/CLOSEST","users":333,"accepted":29.85}
+{"id":7210,"name":"Draw Mountains","url":"https://www.spoj.com/problems/DRAWM","users":337,"accepted":44.38}
+{"id":7211,"name":"Elastic Bands","url":"https://www.spoj.com/problems/ELASTIC","users":49,"accepted":55.97}
+{"id":7212,"name":"Find String Roots","url":"https://www.spoj.com/problems/FINDSR","users":2181,"accepted":34.82}
+{"id":7216,"name":"The Clocks","url":"https://www.spoj.com/problems/CLOCKS","users":280,"accepted":40.5}
+{"id":7217,"name":"Training for final","url":"https://www.spoj.com/problems/TRIKA","users":2099,"accepted":45.55}
+{"id":7230,"name":"Garbage Collection","url":"https://www.spoj.com/problems/GARBAGE","users":159,"accepted":39.8}
+{"id":7231,"name":"Homework","url":"https://www.spoj.com/problems/HOMEW","users":232,"accepted":21.58}
+{"id":7232,"name":"Inversion Sort","url":"https://www.spoj.com/problems/INVESORT","users":172,"accepted":16.33}
+{"id":7239,"name":"Cells","url":"https://www.spoj.com/problems/IPCELLS","users":81,"accepted":47.22}

--- a/tests/spoj/index/27.md
+++ b/tests/spoj/index/27.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 6999 | [Avoiding SOS Grids](https://www.spoj.com/problems/AVOIDSOS) | 69 | 10.71 |
+| 7001 | [Visible Lattice Points](https://www.spoj.com/problems/VLATTICE) | 562 | 30.19 |
+| 7002 | [Buildings](https://www.spoj.com/problems/BUILDING) | 81 | 37.90 |
+| 7010 | [Police Business](https://www.spoj.com/problems/ACAB) | 6 | 25.00 |
+| 7015 | [Party](https://www.spoj.com/problems/CFPARTY) | 1054 | 50.97 |
+| 7019 | [Zig-Zag rabbit](https://www.spoj.com/problems/ZIGZAG) | 596 | 36.47 |
+| 7022 | [Cow Patterns](https://www.spoj.com/problems/CPATTERN) | 128 | 26.15 |
+| 7023 | [Cookies](https://www.spoj.com/problems/KOLACI) | 19 | 28.80 |
+| 7025 | [Roads in Berland](https://www.spoj.com/problems/CT25C) | 135 | 33.29 |
+| 7034 | [Crashing Robots](https://www.spoj.com/problems/CROBOTS) | 171 | 47.90 |
+| 7035 | [The Embarrassed Cryptographer](https://www.spoj.com/problems/CRYPTON) | 356 | 32.14 |
+| 7050 | [Necklace Decomposition](https://www.spoj.com/problems/NECKDEC) | 48 | 60.61 |
+| 7099 | [Advanced Edit Distance](https://www.spoj.com/problems/ADVEDIST) | 410 | 31.96 |
+| 7100 | [Back To The Polygon](https://www.spoj.com/problems/BACKTPOL) | 88 | 34.80 |
+| 7101 | [Charly And Nito](https://www.spoj.com/problems/CANDN) | 314 | 37.22 |
+| 7102 | [Doing The Word Wrap](https://www.spoj.com/problems/DTWW) | 175 | 38.33 |
+| 7103 | [Edit Distance](https://www.spoj.com/problems/EDDIST) | 74 | 18.02 |
+| 7104 | [Feanor The Elf](https://www.spoj.com/problems/FTHEELF) | 733 | 40.24 |
+| 7107 | [G Key](https://www.spoj.com/problems/GK) | 87 | 44.98 |
+| 7108 | [Heptadecimal Numbers](https://www.spoj.com/problems/HEPNUM) | 1231 | 35.72 |
+| 7109 | [Indicator of progression](https://www.spoj.com/problems/INDIPROG) | 325 | 23.89 |
+| 7132 | [Headshot](https://www.spoj.com/problems/HEADSHOT) | 1407 | 37.40 |
+| 7133 | [Garden 2005](https://www.spoj.com/problems/IOIGARD) | 69 | 23.42 |
+| 7150 | [Palindrome 2000](https://www.spoj.com/problems/IOIPALIN) | 3297 | 27.60 |
+| 7152 | [Boundary 2003](https://www.spoj.com/problems/IOIBOUND) | 18 | 12.34 |
+| 7155 | [Test](https://www.spoj.com/problems/CF25E) | 420 | 19.22 |
+| 7168 | [Termites strike back](https://www.spoj.com/problems/TERMITES) | 19 | 39.66 |
+| 7169 | [Pizza](https://www.spoj.com/problems/EGYPIZZA) | 6438 | 29.98 |
+| 7184 | [Axis of Symmetry](https://www.spoj.com/problems/AXIS) | 71 | 18.88 |
+| 7185 | [Bye Bye Cakes](https://www.spoj.com/problems/BYECAKES) | 3669 | 38.67 |
+| 7186 | [Counting Pascal](https://www.spoj.com/problems/COUNTPAS) | 134 | 29.77 |
+| 7187 | [Dinosaur Menace](https://www.spoj.com/problems/DINOSM) | 184 | 8.83 |
+| 7188 | [Escape from Jail](https://www.spoj.com/problems/ESJAIL) | 629 | 30.98 |
+| 7189 | [Falta Envido](https://www.spoj.com/problems/FALTAENV) | 182 | 36.33 |
+| 7190 | [Guess the Number](https://www.spoj.com/problems/GUESSTHE) | 2237 | 33.37 |
+| 7191 | [Hexagonal Board](https://www.spoj.com/problems/HEXBOARD) | 546 | 62.20 |
+| 7192 | [Integral Maximization](https://www.spoj.com/problems/INTEGMAX) | 375 | 38.35 |
+| 7193 | [The Pharaoh Curse](https://www.spoj.com/problems/CURSE) | 16 | 21.05 |
+| 7200 | [Strange Calendar](https://www.spoj.com/problems/CAL) | 76 | 47.81 |
+| 7208 | [Black or White](https://www.spoj.com/problems/BORW) | 1481 | 42.47 |
+| 7209 | [Closest Triplet](https://www.spoj.com/problems/CLOSEST) | 333 | 29.85 |
+| 7210 | [Draw Mountains](https://www.spoj.com/problems/DRAWM) | 337 | 44.38 |
+| 7211 | [Elastic Bands](https://www.spoj.com/problems/ELASTIC) | 49 | 55.97 |
+| 7212 | [Find String Roots](https://www.spoj.com/problems/FINDSR) | 2181 | 34.82 |
+| 7216 | [The Clocks](https://www.spoj.com/problems/CLOCKS) | 280 | 40.50 |
+| 7217 | [Training for final](https://www.spoj.com/problems/TRIKA) | 2099 | 45.55 |
+| 7230 | [Garbage Collection](https://www.spoj.com/problems/GARBAGE) | 159 | 39.80 |
+| 7231 | [Homework](https://www.spoj.com/problems/HOMEW) | 232 | 21.58 |
+| 7232 | [Inversion Sort](https://www.spoj.com/problems/INVESORT) | 172 | 16.33 |
+| 7239 | [Cells](https://www.spoj.com/problems/IPCELLS) | 81 | 47.22 |

--- a/tests/spoj/index/28.jsonl
+++ b/tests/spoj/index/28.jsonl
@@ -1,0 +1,50 @@
+{"id":7240,"name":"Playground","url":"https://www.spoj.com/problems/PLYGRND","users":208,"accepted":41.97}
+{"id":7248,"name":"Chess part1","url":"https://www.spoj.com/problems/ROOKS","users":104,"accepted":23.55}
+{"id":7249,"name":"Perfume","url":"https://www.spoj.com/problems/PERFUME","users":115,"accepted":16}
+{"id":7250,"name":"Blocks for kids","url":"https://www.spoj.com/problems/PBOARD","users":102,"accepted":40.56}
+{"id":7258,"name":"Lexicographical Substring Search","url":"https://www.spoj.com/problems/SUBLEX","users":2291,"accepted":22.73}
+{"id":7259,"name":"Light Switching","url":"https://www.spoj.com/problems/LITE","users":4672,"accepted":34.23}
+{"id":7260,"name":"Number Game","url":"https://www.spoj.com/problems/NUMGAME","users":94,"accepted":26.01}
+{"id":7264,"name":"Digital LED Number","url":"https://www.spoj.com/problems/DIGNUM","users":554,"accepted":28.35}
+{"id":7286,"name":"Collect Diamonds","url":"https://www.spoj.com/problems/COLDIAM","users":20,"accepted":25.93}
+{"id":7296,"name":"Trees Again","url":"https://www.spoj.com/problems/CNTTREE","users":168,"accepted":47.65}
+{"id":7297,"name":"Placing Coins on a Grid","url":"https://www.spoj.com/problems/GRIDCOIN","users":61,"accepted":32.53}
+{"id":7299,"name":"Multiples of 3","url":"https://www.spoj.com/problems/MULTQ3","users":3773,"accepted":23.61}
+{"id":7301,"name":"Lucky Controller","url":"https://www.spoj.com/problems/LCKYCONT","users":10,"accepted":30.91}
+{"id":7322,"name":"Prime Pattern","url":"https://www.spoj.com/problems/CHEFJUN","users":97,"accepted":36.16}
+{"id":7323,"name":"Happy Days","url":"https://www.spoj.com/problems/CHEFJUL","users":47,"accepted":44.74}
+{"id":7333,"name":"Shuffle Music","url":"https://www.spoj.com/problems/SHUFFLEN","users":9,"accepted":26.67}
+{"id":7335,"name":"Spheres","url":"https://www.spoj.com/problems/KULE","users":129,"accepted":9.54}
+{"id":7336,"name":"Mastermind","url":"https://www.spoj.com/problems/MSTRMND","users":493,"accepted":36.2}
+{"id":7337,"name":"Shuffling","url":"https://www.spoj.com/problems/SHUFFLE1","users":24,"accepted":18.09}
+{"id":7356,"name":"Iterated Bitcount Function","url":"https://www.spoj.com/problems/ITERBIT","users":36,"accepted":16.47}
+{"id":7363,"name":"Tree Sum","url":"https://www.spoj.com/problems/TREESUM","users":187,"accepted":36.46}
+{"id":7378,"name":"Manhattan Companies","url":"https://www.spoj.com/problems/MCOMP","users":16,"accepted":10.96}
+{"id":7380,"name":"Factorial challenge","url":"https://www.spoj.com/problems/FUNFACT","users":344,"accepted":31.51}
+{"id":7386,"name":"Activities","url":"https://www.spoj.com/problems/ACTIV","users":1445,"accepted":25.55}
+{"id":7387,"name":"Airplane Parking","url":"https://www.spoj.com/problems/PKA","users":56,"accepted":23.53}
+{"id":7389,"name":"Rating Hazard","url":"https://www.spoj.com/problems/PKD","users":25,"accepted":19.44}
+{"id":7402,"name":"Repair Depots","url":"https://www.spoj.com/problems/PC8H","users":14,"accepted":43.9}
+{"id":7403,"name":"Messy Administration","url":"https://www.spoj.com/problems/MESS","users":14,"accepted":30.88}
+{"id":7404,"name":"Just on Time","url":"https://www.spoj.com/problems/ONTIME","users":16,"accepted":35.38}
+{"id":7405,"name":"Delicious Pancakes","url":"https://www.spoj.com/problems/PANCAKES","users":736,"accepted":27.06}
+{"id":7406,"name":"Beehive Numbers","url":"https://www.spoj.com/problems/BEENUMS","users":9215,"accepted":58.91}
+{"id":7408,"name":"Camelot","url":"https://www.spoj.com/problems/CAMELOT","users":64,"accepted":30.88}
+{"id":7409,"name":"Drawing Quadrilaterals","url":"https://www.spoj.com/problems/DRAWQUAD","users":51,"accepted":11.46}
+{"id":7422,"name":"Escape from Jail Again","url":"https://www.spoj.com/problems/ESCJAILA","users":460,"accepted":42.4}
+{"id":7423,"name":"File Recover Testing","url":"https://www.spoj.com/problems/FILRTEST","users":926,"accepted":35.6}
+{"id":7424,"name":"Girls and Boys","url":"https://www.spoj.com/problems/GIRLSNBS","users":12344,"accepted":46.94}
+{"id":7425,"name":"Hackers","url":"https://www.spoj.com/problems/HACKERS","users":174,"accepted":31.29}
+{"id":7426,"name":"Imperial Units","url":"https://www.spoj.com/problems/IMPUNITS","users":506,"accepted":45.76}
+{"id":7427,"name":"Jara’s Legacy","url":"https://www.spoj.com/problems/JARA","users":83,"accepted":39.9}
+{"id":7430,"name":"Tower Of Hanoi - Revisited","url":"https://www.spoj.com/problems/RANJAN02","users":2144,"accepted":50.9}
+{"id":7486,"name":"Rooks","url":"https://www.spoj.com/problems/BIO1","users":231,"accepted":28.49}
+{"id":7487,"name":"Flibonakki","url":"https://www.spoj.com/problems/FLIB","users":867,"accepted":29.53}
+{"id":7488,"name":"LCM GCD Love","url":"https://www.spoj.com/problems/LGLOVE","users":187,"accepted":19.17}
+{"id":7489,"name":"Slow Growing Bacteria","url":"https://www.spoj.com/problems/SBACT","users":87,"accepted":11.57}
+{"id":7490,"name":"Biology","url":"https://www.spoj.com/problems/BIO","users":14,"accepted":5.93}
+{"id":7507,"name":"Wonderful Randomized Sum","url":"https://www.spoj.com/problems/CF33C","users":385,"accepted":40.79}
+{"id":7555,"name":"A - Crazy Rows","url":"https://www.spoj.com/problems/HAROWS","users":186,"accepted":25.98}
+{"id":7556,"name":"B - Stock Charts","url":"https://www.spoj.com/problems/HASTOCK","users":45,"accepted":40.48}
+{"id":7558,"name":"D - Alphabetomials","url":"https://www.spoj.com/problems/HAALPHA","users":14,"accepted":41.46}
+{"id":7559,"name":"E - Football Team","url":"https://www.spoj.com/problems/HATEAM","users":9,"accepted":12.5}

--- a/tests/spoj/index/28.md
+++ b/tests/spoj/index/28.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 7240 | [Playground](https://www.spoj.com/problems/PLYGRND) | 208 | 41.97 |
+| 7248 | [Chess part1](https://www.spoj.com/problems/ROOKS) | 104 | 23.55 |
+| 7249 | [Perfume](https://www.spoj.com/problems/PERFUME) | 115 | 16.00 |
+| 7250 | [Blocks for kids](https://www.spoj.com/problems/PBOARD) | 102 | 40.56 |
+| 7258 | [Lexicographical Substring Search](https://www.spoj.com/problems/SUBLEX) | 2291 | 22.73 |
+| 7259 | [Light Switching](https://www.spoj.com/problems/LITE) | 4672 | 34.23 |
+| 7260 | [Number Game](https://www.spoj.com/problems/NUMGAME) | 94 | 26.01 |
+| 7264 | [Digital LED Number](https://www.spoj.com/problems/DIGNUM) | 554 | 28.35 |
+| 7286 | [Collect Diamonds](https://www.spoj.com/problems/COLDIAM) | 20 | 25.93 |
+| 7296 | [Trees Again](https://www.spoj.com/problems/CNTTREE) | 168 | 47.65 |
+| 7297 | [Placing Coins on a Grid](https://www.spoj.com/problems/GRIDCOIN) | 61 | 32.53 |
+| 7299 | [Multiples of 3](https://www.spoj.com/problems/MULTQ3) | 3773 | 23.61 |
+| 7301 | [Lucky Controller](https://www.spoj.com/problems/LCKYCONT) | 10 | 30.91 |
+| 7322 | [Prime Pattern](https://www.spoj.com/problems/CHEFJUN) | 97 | 36.16 |
+| 7323 | [Happy Days](https://www.spoj.com/problems/CHEFJUL) | 47 | 44.74 |
+| 7333 | [Shuffle Music](https://www.spoj.com/problems/SHUFFLEN) | 9 | 26.67 |
+| 7335 | [Spheres](https://www.spoj.com/problems/KULE) | 129 | 9.54 |
+| 7336 | [Mastermind](https://www.spoj.com/problems/MSTRMND) | 493 | 36.20 |
+| 7337 | [Shuffling](https://www.spoj.com/problems/SHUFFLE1) | 24 | 18.09 |
+| 7356 | [Iterated Bitcount Function](https://www.spoj.com/problems/ITERBIT) | 36 | 16.47 |
+| 7363 | [Tree Sum](https://www.spoj.com/problems/TREESUM) | 187 | 36.46 |
+| 7378 | [Manhattan Companies](https://www.spoj.com/problems/MCOMP) | 16 | 10.96 |
+| 7380 | [Factorial challenge](https://www.spoj.com/problems/FUNFACT) | 344 | 31.51 |
+| 7386 | [Activities](https://www.spoj.com/problems/ACTIV) | 1445 | 25.55 |
+| 7387 | [Airplane Parking](https://www.spoj.com/problems/PKA) | 56 | 23.53 |
+| 7389 | [Rating Hazard](https://www.spoj.com/problems/PKD) | 25 | 19.44 |
+| 7402 | [Repair Depots](https://www.spoj.com/problems/PC8H) | 14 | 43.90 |
+| 7403 | [Messy Administration](https://www.spoj.com/problems/MESS) | 14 | 30.88 |
+| 7404 | [Just on Time](https://www.spoj.com/problems/ONTIME) | 16 | 35.38 |
+| 7405 | [Delicious Pancakes](https://www.spoj.com/problems/PANCAKES) | 736 | 27.06 |
+| 7406 | [Beehive Numbers](https://www.spoj.com/problems/BEENUMS) | 9215 | 58.91 |
+| 7408 | [Camelot](https://www.spoj.com/problems/CAMELOT) | 64 | 30.88 |
+| 7409 | [Drawing Quadrilaterals](https://www.spoj.com/problems/DRAWQUAD) | 51 | 11.46 |
+| 7422 | [Escape from Jail Again](https://www.spoj.com/problems/ESCJAILA) | 460 | 42.40 |
+| 7423 | [File Recover Testing](https://www.spoj.com/problems/FILRTEST) | 926 | 35.60 |
+| 7424 | [Girls and Boys](https://www.spoj.com/problems/GIRLSNBS) | 12344 | 46.94 |
+| 7425 | [Hackers](https://www.spoj.com/problems/HACKERS) | 174 | 31.29 |
+| 7426 | [Imperial Units](https://www.spoj.com/problems/IMPUNITS) | 506 | 45.76 |
+| 7427 | [Jara’s Legacy](https://www.spoj.com/problems/JARA) | 83 | 39.90 |
+| 7430 | [Tower Of Hanoi - Revisited](https://www.spoj.com/problems/RANJAN02) | 2144 | 50.90 |
+| 7486 | [Rooks](https://www.spoj.com/problems/BIO1) | 231 | 28.49 |
+| 7487 | [Flibonakki](https://www.spoj.com/problems/FLIB) | 867 | 29.53 |
+| 7488 | [LCM GCD Love](https://www.spoj.com/problems/LGLOVE) | 187 | 19.17 |
+| 7489 | [Slow Growing Bacteria](https://www.spoj.com/problems/SBACT) | 87 | 11.57 |
+| 7490 | [Biology](https://www.spoj.com/problems/BIO) | 14 | 5.93 |
+| 7507 | [Wonderful Randomized Sum](https://www.spoj.com/problems/CF33C) | 385 | 40.79 |
+| 7555 | [A - Crazy Rows](https://www.spoj.com/problems/HAROWS) | 186 | 25.98 |
+| 7556 | [B - Stock Charts](https://www.spoj.com/problems/HASTOCK) | 45 | 40.48 |
+| 7558 | [D - Alphabetomials](https://www.spoj.com/problems/HAALPHA) | 14 | 41.46 |
+| 7559 | [E - Football Team](https://www.spoj.com/problems/HATEAM) | 9 | 12.50 |

--- a/tests/spoj/index/29.jsonl
+++ b/tests/spoj/index/29.jsonl
@@ -1,0 +1,50 @@
+{"id":7560,"name":"F - Interesting Ranges","url":"https://www.spoj.com/problems/HARANGES","users":13,"accepted":21.33}
+{"id":7561,"name":"Lexicographic position","url":"https://www.spoj.com/problems/LEXIPOS","users":36,"accepted":34.81}
+{"id":7563,"name":"Hi6","url":"https://www.spoj.com/problems/HISIX","users":39,"accepted":16.67}
+{"id":7565,"name":"Another Sorting Algorithm","url":"https://www.spoj.com/problems/IITD1","users":33,"accepted":15.06}
+{"id":7566,"name":"Expected Cycle Sums","url":"https://www.spoj.com/problems/IITD5","users":52,"accepted":47.89}
+{"id":7567,"name":"Divisor Summation Powered","url":"https://www.spoj.com/problems/IITD4","users":368,"accepted":21.41}
+{"id":7579,"name":"Power Calculus","url":"https://www.spoj.com/problems/YOKOF","users":326,"accepted":49.33}
+{"id":7581,"name":"The Best Name for Your Baby","url":"https://www.spoj.com/problems/YOKOH","users":13,"accepted":33.33}
+{"id":7583,"name":"Cubic Eight-Puzzle","url":"https://www.spoj.com/problems/YOKOC","users":31,"accepted":30.57}
+{"id":7586,"name":"Number of Palindromes","url":"https://www.spoj.com/problems/NUMOFPAL","users":1425,"accepted":46.7}
+{"id":7588,"name":"Wise And Miser","url":"https://www.spoj.com/problems/MISERMAN","users":5517,"accepted":67.31}
+{"id":7589,"name":"Cave Crisis","url":"https://www.spoj.com/problems/PC8C","users":13,"accepted":54.84}
+{"id":7599,"name":"Optimal Strategy for the ICPC","url":"https://www.spoj.com/problems/PC8F","users":10,"accepted":21.15}
+{"id":7600,"name":"Milk Trading","url":"https://www.spoj.com/problems/MLK","users":186,"accepted":30.71}
+{"id":7602,"name":"New Game with a Chess Piece","url":"https://www.spoj.com/problems/CF36D","users":231,"accepted":31.37}
+{"id":7603,"name":"Fibonacci Factor","url":"https://www.spoj.com/problems/FIBFACT","users":26,"accepted":25.49}
+{"id":7623,"name":"Divisors VI","url":"https://www.spoj.com/problems/DIVISER9","users":28,"accepted":14.54}
+{"id":7627,"name":"Driving Direction","url":"https://www.spoj.com/problems/NE06D","users":14,"accepted":49.02}
+{"id":7628,"name":"Mathematics","url":"https://www.spoj.com/problems/MATHS","users":67,"accepted":29.05}
+{"id":7629,"name":"Building Ports","url":"https://www.spoj.com/problems/BPORT","users":45,"accepted":12.44}
+{"id":7630,"name":"SHOPPERS","url":"https://www.spoj.com/problems/SHOPPERS","users":150,"accepted":36.75}
+{"id":7632,"name":"Architecture","url":"https://www.spoj.com/problems/ARCHI","users":20,"accepted":24.24}
+{"id":7637,"name":"Road Map","url":"https://www.spoj.com/problems/RANJAN05","users":79,"accepted":54.9}
+{"id":7666,"name":"Telecommunications","url":"https://www.spoj.com/problems/TELECOM","users":26,"accepted":28.3}
+{"id":7668,"name":"Pebble Solver","url":"https://www.spoj.com/problems/PEBBLE","users":2009,"accepted":50.46}
+{"id":7676,"name":"Sum of Digits","url":"https://www.spoj.com/problems/CPCRC1C","users":5029,"accepted":38.78}
+{"id":7680,"name":"Electrical Engineering","url":"https://www.spoj.com/problems/ELEC","users":17,"accepted":33.97}
+{"id":7683,"name":"Powered and Squared","url":"https://www.spoj.com/problems/CSQUARE","users":717,"accepted":27.21}
+{"id":7685,"name":"Flowers","url":"https://www.spoj.com/problems/FLWRS","users":352,"accepted":32.98}
+{"id":7691,"name":"Homo or Hetero","url":"https://www.spoj.com/problems/HOMO","users":1676,"accepted":36.26}
+{"id":7692,"name":"Chemistry","url":"https://www.spoj.com/problems/CHEM","users":72,"accepted":13.88}
+{"id":7693,"name":"Environmental Engineering","url":"https://www.spoj.com/problems/ENVIRON","users":38,"accepted":39.23}
+{"id":7696,"name":"Encryption","url":"https://www.spoj.com/problems/CENCRY","users":1003,"accepted":35.87}
+{"id":7704,"name":"Civil Engineering","url":"https://www.spoj.com/problems/CIVIL","users":640,"accepted":44.59}
+{"id":7709,"name":"Jumping Zippy","url":"https://www.spoj.com/problems/JZPCIR","users":68,"accepted":54.35}
+{"id":7718,"name":"Number of common divisors","url":"https://www.spoj.com/problems/COMDIV","users":7282,"accepted":24.44}
+{"id":7733,"name":"Happy Numbers I","url":"https://www.spoj.com/problems/HPYNOS","users":9403,"accepted":53.36}
+{"id":7734,"name":"Twist and whirl - want to cheat","url":"https://www.spoj.com/problems/TWIST","users":245,"accepted":45.51}
+{"id":7737,"name":"Escape","url":"https://www.spoj.com/problems/BOI7ESC","users":57,"accepted":34.36}
+{"id":7739,"name":"Sound","url":"https://www.spoj.com/problems/BOI7SOU","users":484,"accepted":33.86}
+{"id":7740,"name":"Fence","url":"https://www.spoj.com/problems/BOI7FEN","users":22,"accepted":22.45}
+{"id":7741,"name":"Sequence","url":"https://www.spoj.com/problems/BOI7SEQ","users":814,"accepted":30.33}
+{"id":7742,"name":"Onotole needs your help","url":"https://www.spoj.com/problems/OLOLO","users":10152,"accepted":41.09}
+{"id":7745,"name":"Bingo!","url":"https://www.spoj.com/problems/MBINGO","users":758,"accepted":38.89}
+{"id":7746,"name":"Cocircular Points","url":"https://www.spoj.com/problems/MCOCIR","users":63,"accepted":16.78}
+{"id":7753,"name":"Happy Numbers II","url":"https://www.spoj.com/problems/HPYNOSII","users":651,"accepted":15.95}
+{"id":7757,"name":"Flowers Flourish from France","url":"https://www.spoj.com/problems/MFLAR10","users":3173,"accepted":53.08}
+{"id":7758,"name":"Growing Strings","url":"https://www.spoj.com/problems/MGLAR10","users":176,"accepted":32.47}
+{"id":7759,"name":"Hyperactive Girl","url":"https://www.spoj.com/problems/MHLAR10","users":109,"accepted":40.49}
+{"id":7760,"name":"Kids’ Wishes","url":"https://www.spoj.com/problems/MKLAR10","users":95,"accepted":31.93}

--- a/tests/spoj/index/29.md
+++ b/tests/spoj/index/29.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 7560 | [F - Interesting Ranges](https://www.spoj.com/problems/HARANGES) | 13 | 21.33 |
+| 7561 | [Lexicographic position](https://www.spoj.com/problems/LEXIPOS) | 36 | 34.81 |
+| 7563 | [Hi6](https://www.spoj.com/problems/HISIX) | 39 | 16.67 |
+| 7565 | [Another Sorting Algorithm](https://www.spoj.com/problems/IITD1) | 33 | 15.06 |
+| 7566 | [Expected Cycle Sums](https://www.spoj.com/problems/IITD5) | 52 | 47.89 |
+| 7567 | [Divisor Summation Powered](https://www.spoj.com/problems/IITD4) | 368 | 21.41 |
+| 7579 | [Power Calculus](https://www.spoj.com/problems/YOKOF) | 326 | 49.33 |
+| 7581 | [The Best Name for Your Baby](https://www.spoj.com/problems/YOKOH) | 13 | 33.33 |
+| 7583 | [Cubic Eight-Puzzle](https://www.spoj.com/problems/YOKOC) | 31 | 30.57 |
+| 7586 | [Number of Palindromes](https://www.spoj.com/problems/NUMOFPAL) | 1425 | 46.70 |
+| 7588 | [Wise And Miser](https://www.spoj.com/problems/MISERMAN) | 5517 | 67.31 |
+| 7589 | [Cave Crisis](https://www.spoj.com/problems/PC8C) | 13 | 54.84 |
+| 7599 | [Optimal Strategy for the ICPC](https://www.spoj.com/problems/PC8F) | 10 | 21.15 |
+| 7600 | [Milk Trading](https://www.spoj.com/problems/MLK) | 186 | 30.71 |
+| 7602 | [New Game with a Chess Piece](https://www.spoj.com/problems/CF36D) | 231 | 31.37 |
+| 7603 | [Fibonacci Factor](https://www.spoj.com/problems/FIBFACT) | 26 | 25.49 |
+| 7623 | [Divisors VI](https://www.spoj.com/problems/DIVISER9) | 28 | 14.54 |
+| 7627 | [Driving Direction](https://www.spoj.com/problems/NE06D) | 14 | 49.02 |
+| 7628 | [Mathematics](https://www.spoj.com/problems/MATHS) | 67 | 29.05 |
+| 7629 | [Building Ports](https://www.spoj.com/problems/BPORT) | 45 | 12.44 |
+| 7630 | [SHOPPERS](https://www.spoj.com/problems/SHOPPERS) | 150 | 36.75 |
+| 7632 | [Architecture](https://www.spoj.com/problems/ARCHI) | 20 | 24.24 |
+| 7637 | [Road Map](https://www.spoj.com/problems/RANJAN05) | 79 | 54.90 |
+| 7666 | [Telecommunications](https://www.spoj.com/problems/TELECOM) | 26 | 28.30 |
+| 7668 | [Pebble Solver](https://www.spoj.com/problems/PEBBLE) | 2009 | 50.46 |
+| 7676 | [Sum of Digits](https://www.spoj.com/problems/CPCRC1C) | 5029 | 38.78 |
+| 7680 | [Electrical Engineering](https://www.spoj.com/problems/ELEC) | 17 | 33.97 |
+| 7683 | [Powered and Squared](https://www.spoj.com/problems/CSQUARE) | 717 | 27.21 |
+| 7685 | [Flowers](https://www.spoj.com/problems/FLWRS) | 352 | 32.98 |
+| 7691 | [Homo or Hetero](https://www.spoj.com/problems/HOMO) | 1676 | 36.26 |
+| 7692 | [Chemistry](https://www.spoj.com/problems/CHEM) | 72 | 13.88 |
+| 7693 | [Environmental Engineering](https://www.spoj.com/problems/ENVIRON) | 38 | 39.23 |
+| 7696 | [Encryption](https://www.spoj.com/problems/CENCRY) | 1003 | 35.87 |
+| 7704 | [Civil Engineering](https://www.spoj.com/problems/CIVIL) | 640 | 44.59 |
+| 7709 | [Jumping Zippy](https://www.spoj.com/problems/JZPCIR) | 68 | 54.35 |
+| 7718 | [Number of common divisors](https://www.spoj.com/problems/COMDIV) | 7282 | 24.44 |
+| 7733 | [Happy Numbers I](https://www.spoj.com/problems/HPYNOS) | 9403 | 53.36 |
+| 7734 | [Twist and whirl - want to cheat](https://www.spoj.com/problems/TWIST) | 245 | 45.51 |
+| 7737 | [Escape](https://www.spoj.com/problems/BOI7ESC) | 57 | 34.36 |
+| 7739 | [Sound](https://www.spoj.com/problems/BOI7SOU) | 484 | 33.86 |
+| 7740 | [Fence](https://www.spoj.com/problems/BOI7FEN) | 22 | 22.45 |
+| 7741 | [Sequence](https://www.spoj.com/problems/BOI7SEQ) | 814 | 30.33 |
+| 7742 | [Onotole needs your help](https://www.spoj.com/problems/OLOLO) | 10152 | 41.09 |
+| 7745 | [Bingo!](https://www.spoj.com/problems/MBINGO) | 758 | 38.89 |
+| 7746 | [Cocircular Points](https://www.spoj.com/problems/MCOCIR) | 63 | 16.78 |
+| 7753 | [Happy Numbers II](https://www.spoj.com/problems/HPYNOSII) | 651 | 15.95 |
+| 7757 | [Flowers Flourish from France](https://www.spoj.com/problems/MFLAR10) | 3173 | 53.08 |
+| 7758 | [Growing Strings](https://www.spoj.com/problems/MGLAR10) | 176 | 32.47 |
+| 7759 | [Hyperactive Girl](https://www.spoj.com/problems/MHLAR10) | 109 | 40.49 |
+| 7760 | [Kids’ Wishes](https://www.spoj.com/problems/MKLAR10) | 95 | 31.93 |

--- a/tests/spoj/index/30.jsonl
+++ b/tests/spoj/index/30.jsonl
@@ -1,0 +1,50 @@
+{"id":7761,"name":"Jollo","url":"https://www.spoj.com/problems/MJLAR10","users":398,"accepted":40.15}
+{"id":7762,"name":"Electric Needs","url":"https://www.spoj.com/problems/MELAR10","users":25,"accepted":38}
+{"id":7763,"name":"Ingenious Metro","url":"https://www.spoj.com/problems/MILAR10","users":83,"accepted":67.02}
+{"id":7772,"name":"Help a researcher","url":"https://www.spoj.com/problems/HLPRSRCH","users":62,"accepted":48.95}
+{"id":7777,"name":"National Treasure","url":"https://www.spoj.com/problems/ANARC09J","users":35,"accepted":31.5}
+{"id":7778,"name":"Land Division","url":"https://www.spoj.com/problems/ANARC09H","users":40,"accepted":43.5}
+{"id":7779,"name":"Stock Chase","url":"https://www.spoj.com/problems/ANARC09G","users":76,"accepted":30.19}
+{"id":7782,"name":"Largest Labeled Common Ancestor","url":"https://www.spoj.com/problems/LLCA","users":208,"accepted":57.44}
+{"id":7783,"name":"Commuting Functions","url":"https://www.spoj.com/problems/COMFUNC","users":49,"accepted":25.94}
+{"id":7804,"name":"Defense of a Kingdom","url":"https://www.spoj.com/problems/DEFKIN","users":5225,"accepted":25.18}
+{"id":7805,"name":"Kitchen Robot","url":"https://www.spoj.com/problems/KITROB","users":90,"accepted":32.24}
+{"id":7807,"name":"The Lucky Prisoner","url":"https://www.spoj.com/problems/LPRISON","users":27,"accepted":9.84}
+{"id":7809,"name":"Cow Photographs","url":"https://www.spoj.com/problems/COWPIC","users":173,"accepted":36.01}
+{"id":7826,"name":"Tree Isomorphism","url":"https://www.spoj.com/problems/TREEISO","users":615,"accepted":23.57}
+{"id":7851,"name":"Stacks of Zippy","url":"https://www.spoj.com/problems/JZPSTA","users":19,"accepted":16.41}
+{"id":7857,"name":"Tower Game (Hard)","url":"https://www.spoj.com/problems/ADV04A1","users":62,"accepted":14.63}
+{"id":7859,"name":"Upper Right King (Hard)","url":"https://www.spoj.com/problems/ADV04B1","users":171,"accepted":37.39}
+{"id":7860,"name":"Deal or No Deal","url":"https://www.spoj.com/problems/ADV04C","users":13,"accepted":30.77}
+{"id":7861,"name":"UFO","url":"https://www.spoj.com/problems/ADV04D","users":40,"accepted":30.48}
+{"id":7862,"name":"Prisoner of Benda","url":"https://www.spoj.com/problems/ADV04E","users":27,"accepted":25.83}
+{"id":7864,"name":"Four Chips (Hard)","url":"https://www.spoj.com/problems/ADV04F1","users":167,"accepted":30.31}
+{"id":7866,"name":"Regular expressions (Hard)","url":"https://www.spoj.com/problems/ADV04G1","users":140,"accepted":27.33}
+{"id":7868,"name":"Join","url":"https://www.spoj.com/problems/ADV04H","users":20,"accepted":46.74}
+{"id":7870,"name":"Invisible point","url":"https://www.spoj.com/problems/ADV04J","users":1671,"accepted":42.96}
+{"id":7874,"name":"Calculator","url":"https://www.spoj.com/problems/ADV04K","users":29,"accepted":24.36}
+{"id":7875,"name":"Miles and kilometers","url":"https://www.spoj.com/problems/ADV04L","users":612,"accepted":47.06}
+{"id":7881,"name":"Ljutnja","url":"https://www.spoj.com/problems/C1LJUTNJ","users":641,"accepted":24.32}
+{"id":7882,"name":"Tabovi","url":"https://www.spoj.com/problems/C1TABOVI","users":333,"accepted":49.56}
+{"id":7884,"name":"Crni","url":"https://www.spoj.com/problems/C2CRNI","users":60,"accepted":55.93}
+{"id":7886,"name":"Boards (Hard)","url":"https://www.spoj.com/problems/ADV04I1","users":40,"accepted":37.14}
+{"id":7891,"name":"Fibonacci Sequence","url":"https://www.spoj.com/problems/SPFIBO","users":102,"accepted":30.56}
+{"id":7897,"name":"Skyline","url":"https://www.spoj.com/problems/SKYLINE","users":948,"accepted":32.61}
+{"id":7934,"name":"Operating System Problems (Task Scheduling)","url":"https://www.spoj.com/problems/OSPROB1","users":141,"accepted":55.39}
+{"id":7946,"name":"Check Ramsey","url":"https://www.spoj.com/problems/HS10RMSY","users":13,"accepted":19.48}
+{"id":7947,"name":"Almost square factorisation","url":"https://www.spoj.com/problems/HS10SQFT","users":123,"accepted":52.29}
+{"id":7960,"name":"Multiplicative Palindrome","url":"https://www.spoj.com/problems/MULPAL","users":34,"accepted":27.78}
+{"id":7969,"name":"A Knights’ Tale","url":"https://www.spoj.com/problems/ACPC10G","users":80,"accepted":22.93}
+{"id":7970,"name":"Jumping Beans","url":"https://www.spoj.com/problems/ACPC10H","users":63,"accepted":27.96}
+{"id":7971,"name":"The Cyber Traveling Salesman","url":"https://www.spoj.com/problems/ACPC10I","users":38,"accepted":36}
+{"id":7972,"name":"World of cubes","url":"https://www.spoj.com/problems/ACPC10F","users":37,"accepted":16.88}
+{"id":7973,"name":"Sometimes, a penalty is good!","url":"https://www.spoj.com/problems/ACPC10E","users":1207,"accepted":29.59}
+{"id":7974,"name":"What’s Next","url":"https://www.spoj.com/problems/ACPC10A","users":51385,"accepted":35.4}
+{"id":7975,"name":"Tri graphs","url":"https://www.spoj.com/problems/ACPC10D","users":4870,"accepted":29.14}
+{"id":7976,"name":"Sum the Square","url":"https://www.spoj.com/problems/ACPC10B","users":560,"accepted":26.24}
+{"id":8001,"name":"Fibonacci Sum","url":"https://www.spoj.com/problems/FIBOSUM","users":6990,"accepted":27.94}
+{"id":8002,"name":"Horrible Queries","url":"https://www.spoj.com/problems/HORRIBLE","users":11148,"accepted":29.79}
+{"id":8004,"name":"Tree Topology","url":"https://www.spoj.com/problems/TTOP","users":87,"accepted":46.61}
+{"id":8042,"name":"Possible Friends","url":"https://www.spoj.com/problems/SOCIALNE","users":1185,"accepted":37.22}
+{"id":8044,"name":"Fantastic Discovery","url":"https://www.spoj.com/problems/IMMERSED","users":314,"accepted":42.7}
+{"id":8055,"name":"Playground","url":"https://www.spoj.com/problems/AMR10A","users":280,"accepted":25.94}

--- a/tests/spoj/index/30.md
+++ b/tests/spoj/index/30.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 7761 | [Jollo](https://www.spoj.com/problems/MJLAR10) | 398 | 40.15 |
+| 7762 | [Electric Needs](https://www.spoj.com/problems/MELAR10) | 25 | 38.00 |
+| 7763 | [Ingenious Metro](https://www.spoj.com/problems/MILAR10) | 83 | 67.02 |
+| 7772 | [Help a researcher](https://www.spoj.com/problems/HLPRSRCH) | 62 | 48.95 |
+| 7777 | [National Treasure](https://www.spoj.com/problems/ANARC09J) | 35 | 31.50 |
+| 7778 | [Land Division](https://www.spoj.com/problems/ANARC09H) | 40 | 43.50 |
+| 7779 | [Stock Chase](https://www.spoj.com/problems/ANARC09G) | 76 | 30.19 |
+| 7782 | [Largest Labeled Common Ancestor](https://www.spoj.com/problems/LLCA) | 208 | 57.44 |
+| 7783 | [Commuting Functions](https://www.spoj.com/problems/COMFUNC) | 49 | 25.94 |
+| 7804 | [Defense of a Kingdom](https://www.spoj.com/problems/DEFKIN) | 5225 | 25.18 |
+| 7805 | [Kitchen Robot](https://www.spoj.com/problems/KITROB) | 90 | 32.24 |
+| 7807 | [The Lucky Prisoner](https://www.spoj.com/problems/LPRISON) | 27 | 9.84 |
+| 7809 | [Cow Photographs](https://www.spoj.com/problems/COWPIC) | 173 | 36.01 |
+| 7826 | [Tree Isomorphism](https://www.spoj.com/problems/TREEISO) | 615 | 23.57 |
+| 7851 | [Stacks of Zippy](https://www.spoj.com/problems/JZPSTA) | 19 | 16.41 |
+| 7857 | [Tower Game (Hard)](https://www.spoj.com/problems/ADV04A1) | 62 | 14.63 |
+| 7859 | [Upper Right King (Hard)](https://www.spoj.com/problems/ADV04B1) | 171 | 37.39 |
+| 7860 | [Deal or No Deal](https://www.spoj.com/problems/ADV04C) | 13 | 30.77 |
+| 7861 | [UFO](https://www.spoj.com/problems/ADV04D) | 40 | 30.48 |
+| 7862 | [Prisoner of Benda](https://www.spoj.com/problems/ADV04E) | 27 | 25.83 |
+| 7864 | [Four Chips (Hard)](https://www.spoj.com/problems/ADV04F1) | 167 | 30.31 |
+| 7866 | [Regular expressions (Hard)](https://www.spoj.com/problems/ADV04G1) | 140 | 27.33 |
+| 7868 | [Join](https://www.spoj.com/problems/ADV04H) | 20 | 46.74 |
+| 7870 | [Invisible point](https://www.spoj.com/problems/ADV04J) | 1671 | 42.96 |
+| 7874 | [Calculator](https://www.spoj.com/problems/ADV04K) | 29 | 24.36 |
+| 7875 | [Miles and kilometers](https://www.spoj.com/problems/ADV04L) | 612 | 47.06 |
+| 7881 | [Ljutnja](https://www.spoj.com/problems/C1LJUTNJ) | 641 | 24.32 |
+| 7882 | [Tabovi](https://www.spoj.com/problems/C1TABOVI) | 333 | 49.56 |
+| 7884 | [Crni](https://www.spoj.com/problems/C2CRNI) | 60 | 55.93 |
+| 7886 | [Boards (Hard)](https://www.spoj.com/problems/ADV04I1) | 40 | 37.14 |
+| 7891 | [Fibonacci Sequence](https://www.spoj.com/problems/SPFIBO) | 102 | 30.56 |
+| 7897 | [Skyline](https://www.spoj.com/problems/SKYLINE) | 948 | 32.61 |
+| 7934 | [Operating System Problems (Task Scheduling)](https://www.spoj.com/problems/OSPROB1) | 141 | 55.39 |
+| 7946 | [Check Ramsey](https://www.spoj.com/problems/HS10RMSY) | 13 | 19.48 |
+| 7947 | [Almost square factorisation](https://www.spoj.com/problems/HS10SQFT) | 123 | 52.29 |
+| 7960 | [Multiplicative Palindrome](https://www.spoj.com/problems/MULPAL) | 34 | 27.78 |
+| 7969 | [A Knights’ Tale](https://www.spoj.com/problems/ACPC10G) | 80 | 22.93 |
+| 7970 | [Jumping Beans](https://www.spoj.com/problems/ACPC10H) | 63 | 27.96 |
+| 7971 | [The Cyber Traveling Salesman](https://www.spoj.com/problems/ACPC10I) | 38 | 36.00 |
+| 7972 | [World of cubes](https://www.spoj.com/problems/ACPC10F) | 37 | 16.88 |
+| 7973 | [Sometimes, a penalty is good!](https://www.spoj.com/problems/ACPC10E) | 1207 | 29.59 |
+| 7974 | [What’s Next](https://www.spoj.com/problems/ACPC10A) | 51385 | 35.40 |
+| 7975 | [Tri graphs](https://www.spoj.com/problems/ACPC10D) | 4870 | 29.14 |
+| 7976 | [Sum the Square](https://www.spoj.com/problems/ACPC10B) | 560 | 26.24 |
+| 8001 | [Fibonacci Sum](https://www.spoj.com/problems/FIBOSUM) | 6990 | 27.94 |
+| 8002 | [Horrible Queries](https://www.spoj.com/problems/HORRIBLE) | 11148 | 29.79 |
+| 8004 | [Tree Topology](https://www.spoj.com/problems/TTOP) | 87 | 46.61 |
+| 8042 | [Possible Friends](https://www.spoj.com/problems/SOCIALNE) | 1185 | 37.22 |
+| 8044 | [Fantastic Discovery](https://www.spoj.com/problems/IMMERSED) | 314 | 42.70 |
+| 8055 | [Playground](https://www.spoj.com/problems/AMR10A) | 280 | 25.94 |


### PR DESCRIPTION
## Summary
- Fetch and store SPOJ problem listings for pages 11-30 using the existing List helper
- Save each page's results as markdown and JSONL under `tests/spoj/index`

## Testing
- `go run /tmp/spoj_dl.go`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ad67c37ba48320b9fa8b782dc7b5e2