### PR TITLE
Add SPOJ index pages 31-80

### DIFF
--- a/tests/spoj/index/31.jsonl
+++ b/tests/spoj/index/31.jsonl
@@ -1,0 +1,50 @@
+{"id":8056,"name":"Regex Edit Distance","url":"https://www.spoj.com/problems/AMR10B","users":36,"accepted":43}
+{"id":8057,"name":"Square Free Factorization","url":"https://www.spoj.com/problems/AMR10C","users":1445,"accepted":41.58}
+{"id":8058,"name":"Soccer Teams","url":"https://www.spoj.com/problems/AMR10D","users":144,"accepted":25.54}
+{"id":8059,"name":"Stocks Prediction","url":"https://www.spoj.com/problems/AMR10E","users":90,"accepted":33.13}
+{"id":8061,"name":"Christmas Play","url":"https://www.spoj.com/problems/AMR10G","users":7791,"accepted":48.26}
+{"id":8062,"name":"Shopping Rush","url":"https://www.spoj.com/problems/AMR10H","users":73,"accepted":63.26}
+{"id":8063,"name":"Dividing Stones","url":"https://www.spoj.com/problems/AMR10I","users":167,"accepted":26.3}
+{"id":8064,"name":"Mixing Chemicals","url":"https://www.spoj.com/problems/AMR10J","users":187,"accepted":24.16}
+{"id":8073,"name":"The area of the union of circles","url":"https://www.spoj.com/problems/CIRU","users":466,"accepted":20.53}
+{"id":8074,"name":"God of Number Theory","url":"https://www.spoj.com/problems/NUMG","users":35,"accepted":37.1}
+{"id":8075,"name":"Sequence","url":"https://www.spoj.com/problems/SEQN","users":59,"accepted":26.63}
+{"id":8093,"name":"Sevenk Love Oimaster","url":"https://www.spoj.com/problems/JZPGYZ","users":578,"accepted":24.52}
+{"id":8097,"name":"Islands","url":"https://www.spoj.com/problems/IOIISL08","users":73,"accepted":46.82}
+{"id":8099,"name":"Crash´s number table","url":"https://www.spoj.com/problems/TABLE","users":188,"accepted":23.45}
+{"id":8100,"name":"Shifting Lights","url":"https://www.spoj.com/problems/SHLIGHTS","users":229,"accepted":31.2}
+{"id":8104,"name":"Friendly Knights","url":"https://www.spoj.com/problems/KFRIENDS","users":151,"accepted":45.76}
+{"id":8105,"name":"Dot Product Maximization","url":"https://www.spoj.com/problems/DPMAX","users":80,"accepted":16.63}
+{"id":8106,"name":"Normalized Form","url":"https://www.spoj.com/problems/ACPC10C","users":278,"accepted":36.76}
+{"id":8108,"name":"POLYU","url":"https://www.spoj.com/problems/POLYU","users":34,"accepted":26.24}
+{"id":8119,"name":"CIRU2","url":"https://www.spoj.com/problems/CIRUT","users":175,"accepted":36.22}
+{"id":8129,"name":"Sky Lift","url":"https://www.spoj.com/problems/SKY","users":142,"accepted":25.6}
+{"id":8132,"name":"Street Trees","url":"https://www.spoj.com/problems/STREETR","users":3081,"accepted":47}
+{"id":8139,"name":"Chairs","url":"https://www.spoj.com/problems/CHAIR","users":563,"accepted":37.84}
+{"id":8177,"name":"Beautiful numbers EXTREME","url":"https://www.spoj.com/problems/JZPEXT","users":290,"accepted":27.46}
+{"id":8184,"name":"Bureaucracy","url":"https://www.spoj.com/problems/BUREAU","users":571,"accepted":29.72}
+{"id":8189,"name":"Circles On A Screen","url":"https://www.spoj.com/problems/CIRCSCR","users":83,"accepted":28.67}
+{"id":8217,"name":"XOR Maximization","url":"https://www.spoj.com/problems/XMAX","users":1744,"accepted":23.12}
+{"id":8222,"name":"Substrings","url":"https://www.spoj.com/problems/NSUBSTR","users":1322,"accepted":30.1}
+{"id":8238,"name":"N-Factorful","url":"https://www.spoj.com/problems/NFACTOR","users":2779,"accepted":26.8}
+{"id":8263,"name":"Big Pyramid","url":"https://www.spoj.com/problems/EMILABC","users":51,"accepted":62.92}
+{"id":8265,"name":"Zero Count","url":"https://www.spoj.com/problems/ZEROCNT","users":15,"accepted":12.03}
+{"id":8277,"name":"Number of Prime Strings","url":"https://www.spoj.com/problems/PSTR","users":112,"accepted":19.95}
+{"id":8281,"name":"Combination Of Integers","url":"https://www.spoj.com/problems/INTCOMB","users":69,"accepted":29.49}
+{"id":8282,"name":"Distance","url":"https://www.spoj.com/problems/DIST","users":52,"accepted":23.74}
+{"id":8283,"name":"Non-Decreasing Numbers","url":"https://www.spoj.com/problems/NONDEC","users":31,"accepted":20.49}
+{"id":8284,"name":"Weighted Sum","url":"https://www.spoj.com/problems/WEIGHT","users":516,"accepted":17.89}
+{"id":8285,"name":"Rectangles in a Matrix","url":"https://www.spoj.com/problems/RECTMAT","users":7,"accepted":17.11}
+{"id":8286,"name":"Perfect Matching","url":"https://www.spoj.com/problems/MATCH","users":92,"accepted":19.19}
+{"id":8288,"name":"Fast Food Restaurant","url":"https://www.spoj.com/problems/FASTFOOD","users":106,"accepted":29.95}
+{"id":8316,"name":"Win gold medal","url":"https://www.spoj.com/problems/WINGOLD","users":55,"accepted":26.03}
+{"id":8317,"name":"Red Balls","url":"https://www.spoj.com/problems/SIGNGAME","users":47,"accepted":44.77}
+{"id":8318,"name":"color the balls","url":"https://www.spoj.com/problems/PLAYSIGN","users":69,"accepted":42.8}
+{"id":8319,"name":"GLJIVE","url":"https://www.spoj.com/problems/GLJIVE","users":4406,"accepted":35.24}
+{"id":8320,"name":"Spreadsheet scrolling","url":"https://www.spoj.com/problems/SCROLL","users":78,"accepted":29.61}
+{"id":8321,"name":"Chocolate distribution","url":"https://www.spoj.com/problems/CHOCDIST","users":116,"accepted":23.97}
+{"id":8323,"name":"Triangle equality","url":"https://www.spoj.com/problems/TRIEQUAL","users":60,"accepted":35.34}
+{"id":8324,"name":"Military patrol","url":"https://www.spoj.com/problems/MILPATR","users":57,"accepted":30.77}
+{"id":8325,"name":"Partitioning the plane","url":"https://www.spoj.com/problems/PARTPLNE","users":42,"accepted":42.17}
+{"id":8326,"name":"Leaky containers","url":"https://www.spoj.com/problems/LEAKCONT","users":33,"accepted":40.78}
+{"id":8327,"name":"Progressive progressions","url":"https://www.spoj.com/problems/PROGPROG","users":57,"accepted":60.29}

--- a/tests/spoj/index/31.md
+++ b/tests/spoj/index/31.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 8056 | [Regex Edit Distance](https://www.spoj.com/problems/AMR10B) | 36 | 43.00 |
+| 8057 | [Square Free Factorization](https://www.spoj.com/problems/AMR10C) | 1445 | 41.58 |
+| 8058 | [Soccer Teams](https://www.spoj.com/problems/AMR10D) | 144 | 25.54 |
+| 8059 | [Stocks Prediction](https://www.spoj.com/problems/AMR10E) | 90 | 33.13 |
+| 8061 | [Christmas Play](https://www.spoj.com/problems/AMR10G) | 7791 | 48.26 |
+| 8062 | [Shopping Rush](https://www.spoj.com/problems/AMR10H) | 73 | 63.26 |
+| 8063 | [Dividing Stones](https://www.spoj.com/problems/AMR10I) | 167 | 26.30 |
+| 8064 | [Mixing Chemicals](https://www.spoj.com/problems/AMR10J) | 187 | 24.16 |
+| 8073 | [The area of the union of circles](https://www.spoj.com/problems/CIRU) | 466 | 20.53 |
+| 8074 | [God of Number Theory](https://www.spoj.com/problems/NUMG) | 35 | 37.10 |
+| 8075 | [Sequence](https://www.spoj.com/problems/SEQN) | 59 | 26.63 |
+| 8093 | [Sevenk Love Oimaster](https://www.spoj.com/problems/JZPGYZ) | 578 | 24.52 |
+| 8097 | [Islands](https://www.spoj.com/problems/IOIISL08) | 73 | 46.82 |
+| 8099 | [Crash´s number table](https://www.spoj.com/problems/TABLE) | 188 | 23.45 |
+| 8100 | [Shifting Lights](https://www.spoj.com/problems/SHLIGHTS) | 229 | 31.20 |
+| 8104 | [Friendly Knights](https://www.spoj.com/problems/KFRIENDS) | 151 | 45.76 |
+| 8105 | [Dot Product Maximization](https://www.spoj.com/problems/DPMAX) | 80 | 16.63 |
+| 8106 | [Normalized Form](https://www.spoj.com/problems/ACPC10C) | 278 | 36.76 |
+| 8108 | [POLYU](https://www.spoj.com/problems/POLYU) | 34 | 26.24 |
+| 8119 | [CIRU2](https://www.spoj.com/problems/CIRUT) | 175 | 36.22 |
+| 8129 | [Sky Lift](https://www.spoj.com/problems/SKY) | 142 | 25.60 |
+| 8132 | [Street Trees](https://www.spoj.com/problems/STREETR) | 3081 | 47.00 |
+| 8139 | [Chairs](https://www.spoj.com/problems/CHAIR) | 563 | 37.84 |
+| 8177 | [Beautiful numbers EXTREME](https://www.spoj.com/problems/JZPEXT) | 290 | 27.46 |
+| 8184 | [Bureaucracy](https://www.spoj.com/problems/BUREAU) | 571 | 29.72 |
+| 8189 | [Circles On A Screen](https://www.spoj.com/problems/CIRCSCR) | 83 | 28.67 |
+| 8217 | [XOR Maximization](https://www.spoj.com/problems/XMAX) | 1744 | 23.12 |
+| 8222 | [Substrings](https://www.spoj.com/problems/NSUBSTR) | 1322 | 30.10 |
+| 8238 | [N-Factorful](https://www.spoj.com/problems/NFACTOR) | 2779 | 26.80 |
+| 8263 | [Big Pyramid](https://www.spoj.com/problems/EMILABC) | 51 | 62.92 |
+| 8265 | [Zero Count](https://www.spoj.com/problems/ZEROCNT) | 15 | 12.03 |
+| 8277 | [Number of Prime Strings](https://www.spoj.com/problems/PSTR) | 112 | 19.95 |
+| 8281 | [Combination Of Integers](https://www.spoj.com/problems/INTCOMB) | 69 | 29.49 |
+| 8282 | [Distance](https://www.spoj.com/problems/DIST) | 52 | 23.74 |
+| 8283 | [Non-Decreasing Numbers](https://www.spoj.com/problems/NONDEC) | 31 | 20.49 |
+| 8284 | [Weighted Sum](https://www.spoj.com/problems/WEIGHT) | 516 | 17.89 |
+| 8285 | [Rectangles in a Matrix](https://www.spoj.com/problems/RECTMAT) | 7 | 17.11 |
+| 8286 | [Perfect Matching](https://www.spoj.com/problems/MATCH) | 92 | 19.19 |
+| 8288 | [Fast Food Restaurant](https://www.spoj.com/problems/FASTFOOD) | 106 | 29.95 |
+| 8316 | [Win gold medal](https://www.spoj.com/problems/WINGOLD) | 55 | 26.03 |
+| 8317 | [Red Balls](https://www.spoj.com/problems/SIGNGAME) | 47 | 44.77 |
+| 8318 | [color the balls](https://www.spoj.com/problems/PLAYSIGN) | 69 | 42.80 |
+| 8319 | [GLJIVE](https://www.spoj.com/problems/GLJIVE) | 4406 | 35.24 |
+| 8320 | [Spreadsheet scrolling](https://www.spoj.com/problems/SCROLL) | 78 | 29.61 |
+| 8321 | [Chocolate distribution](https://www.spoj.com/problems/CHOCDIST) | 116 | 23.97 |
+| 8323 | [Triangle equality](https://www.spoj.com/problems/TRIEQUAL) | 60 | 35.34 |
+| 8324 | [Military patrol](https://www.spoj.com/problems/MILPATR) | 57 | 30.77 |
+| 8325 | [Partitioning the plane](https://www.spoj.com/problems/PARTPLNE) | 42 | 42.17 |
+| 8326 | [Leaky containers](https://www.spoj.com/problems/LEAKCONT) | 33 | 40.78 |
+| 8327 | [Progressive progressions](https://www.spoj.com/problems/PROGPROG) | 57 | 60.29 |

--- a/tests/spoj/index/32.jsonl
+++ b/tests/spoj/index/32.jsonl
@@ -1,0 +1,50 @@
+{"id":8328,"name":"Move the books","url":"https://www.spoj.com/problems/MOVEBOOK","users":27,"accepted":24.19}
+{"id":8329,"name":"Road trip","url":"https://www.spoj.com/problems/ROADTRIP","users":82,"accepted":39.22}
+{"id":8330,"name":"Giant fountain","url":"https://www.spoj.com/problems/GNTFNTN","users":37,"accepted":43.17}
+{"id":8331,"name":"Sister cities","url":"https://www.spoj.com/problems/SSTRCITS","users":39,"accepted":50}
+{"id":8332,"name":"Ski slopes","url":"https://www.spoj.com/problems/SKISLOPE","users":29,"accepted":22.58}
+{"id":8333,"name":"Place-name game","url":"https://www.spoj.com/problems/PLCNMGME","users":75,"accepted":36.34}
+{"id":8334,"name":"Enumeration of rationals","url":"https://www.spoj.com/problems/ENUMRTNL","users":92,"accepted":17.28}
+{"id":8335,"name":"Counting the teams","url":"https://www.spoj.com/problems/CNTTEAMS","users":30,"accepted":34.31}
+{"id":8349,"name":"BRODOVI","url":"https://www.spoj.com/problems/BRODOVI","users":620,"accepted":43.77}
+{"id":8351,"name":"KOSARK","url":"https://www.spoj.com/problems/MIDO","users":852,"accepted":42.9}
+{"id":8363,"name":"COSTLY CHESS","url":"https://www.spoj.com/problems/CCHESS","users":1753,"accepted":43}
+{"id":8371,"name":"TRIANGULAR PRISM","url":"https://www.spoj.com/problems/PRISMSA","users":2095,"accepted":68.42}
+{"id":8372,"name":"Triple Sums","url":"https://www.spoj.com/problems/TSUM","users":413,"accepted":27.33}
+{"id":8374,"name":"PARKET","url":"https://www.spoj.com/problems/PARKET1","users":1854,"accepted":56.2}
+{"id":8391,"name":"The Ball","url":"https://www.spoj.com/problems/BALL","users":126,"accepted":10.63}
+{"id":8392,"name":"Youtube","url":"https://www.spoj.com/problems/YOUTUBE","users":234,"accepted":23}
+{"id":8398,"name":"Quadratic Equation","url":"https://www.spoj.com/problems/QUADRATE","users":605,"accepted":29.01}
+{"id":8406,"name":"Temple Queues","url":"https://www.spoj.com/problems/TEMPLEQ","users":296,"accepted":19.34}
+{"id":8407,"name":"Candies and Milestones","url":"https://www.spoj.com/problems/CANDYSTN","users":480,"accepted":21.94}
+{"id":8408,"name":"Min  Max 01 Path","url":"https://www.spoj.com/problems/MNMXPATH","users":108,"accepted":28.27}
+{"id":8409,"name":"Favorite Sub Hair","url":"https://www.spoj.com/problems/FAVSUBS","users":98,"accepted":39.25}
+{"id":8410,"name":"Snaky Numbers","url":"https://www.spoj.com/problems/SNAKYNUM","users":84,"accepted":38.82}
+{"id":8418,"name":"Revenge of the squares","url":"https://www.spoj.com/problems/SQUA_REV","users":89,"accepted":36.83}
+{"id":8419,"name":"Traversing Grid","url":"https://www.spoj.com/problems/BTCODE_A","users":341,"accepted":22.88}
+{"id":8420,"name":"Finding Minimum","url":"https://www.spoj.com/problems/BTCODE_B","users":75,"accepted":36.9}
+{"id":8421,"name":"Fun With Inequalities","url":"https://www.spoj.com/problems/BTCODE_C","users":144,"accepted":37.89}
+{"id":8422,"name":"Maximum Profit","url":"https://www.spoj.com/problems/BTCODE_D","users":923,"accepted":53.13}
+{"id":8423,"name":"Recover Polynomials","url":"https://www.spoj.com/problems/BTCODE_E","users":58,"accepted":49.68}
+{"id":8424,"name":"Life Game","url":"https://www.spoj.com/problems/BTCODE_F","users":156,"accepted":52.29}
+{"id":8425,"name":"Coloring Trees","url":"https://www.spoj.com/problems/BTCODE_G","users":324,"accepted":30.46}
+{"id":8426,"name":"Trie Expectation","url":"https://www.spoj.com/problems/BTCODE_H","users":170,"accepted":62.16}
+{"id":8427,"name":"Permutation Game","url":"https://www.spoj.com/problems/BTCODE_I","users":34,"accepted":40.38}
+{"id":8428,"name":"Grid Tiling","url":"https://www.spoj.com/problems/BTCODE_J","users":25,"accepted":23.49}
+{"id":8429,"name":"Array Sorting","url":"https://www.spoj.com/problems/BTCODE_K","users":67,"accepted":17.23}
+{"id":8433,"name":"Revenge of the squares (variation)","url":"https://www.spoj.com/problems/SQUAREV1","users":490,"accepted":49.27}
+{"id":8434,"name":"Kolica","url":"https://www.spoj.com/problems/KOLICA","users":67,"accepted":39.81}
+{"id":8442,"name":"Problem 3","url":"https://www.spoj.com/problems/NOVICE43","users":728,"accepted":54.44}
+{"id":8449,"name":"Plotting functions (variation)","url":"https://www.spoj.com/problems/PLOT1","users":24,"accepted":22.14}
+{"id":8456,"name":"PRIMITIVEROOTS","url":"https://www.spoj.com/problems/PROBLEM4","users":373,"accepted":46.23}
+{"id":8461,"name":"Adventure in Moving","url":"https://www.spoj.com/problems/AVDM","users":44,"accepted":28.43}
+{"id":8462,"name":"Barn Allocation","url":"https://www.spoj.com/problems/BARN","users":215,"accepted":56.89}
+{"id":8467,"name":"GRADE POINT AVERAGE","url":"https://www.spoj.com/problems/GPA1","users":634,"accepted":30.08}
+{"id":8478,"name":"Ancient Pocket Calculator","url":"https://www.spoj.com/problems/POCALC1","users":7,"accepted":4.25}
+{"id":8491,"name":"Messy Phone List","url":"https://www.spoj.com/problems/PHONMESS","users":54,"accepted":19.69}
+{"id":8495,"name":"Maximum Subset of Array","url":"https://www.spoj.com/problems/MAXSUB","users":735,"accepted":27.8}
+{"id":8496,"name":"No Squares Numbers","url":"https://www.spoj.com/problems/NOSQ","users":845,"accepted":35.11}
+{"id":8505,"name":"Nacci Fear","url":"https://www.spoj.com/problems/NACCI","users":320,"accepted":40.37}
+{"id":8507,"name":"Party Switching","url":"https://www.spoj.com/problems/PSWITCH","users":246,"accepted":28.74}
+{"id":8542,"name":"Modern Pocket Calculator","url":"https://www.spoj.com/problems/POCALC2","users":35,"accepted":9.05}
+{"id":8545,"name":"Subset sum","url":"https://www.spoj.com/problems/MAIN72","users":1941,"accepted":40.11}

--- a/tests/spoj/index/32.md
+++ b/tests/spoj/index/32.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 8328 | [Move the books](https://www.spoj.com/problems/MOVEBOOK) | 27 | 24.19 |
+| 8329 | [Road trip](https://www.spoj.com/problems/ROADTRIP) | 82 | 39.22 |
+| 8330 | [Giant fountain](https://www.spoj.com/problems/GNTFNTN) | 37 | 43.17 |
+| 8331 | [Sister cities](https://www.spoj.com/problems/SSTRCITS) | 39 | 50.00 |
+| 8332 | [Ski slopes](https://www.spoj.com/problems/SKISLOPE) | 29 | 22.58 |
+| 8333 | [Place-name game](https://www.spoj.com/problems/PLCNMGME) | 75 | 36.34 |
+| 8334 | [Enumeration of rationals](https://www.spoj.com/problems/ENUMRTNL) | 92 | 17.28 |
+| 8335 | [Counting the teams](https://www.spoj.com/problems/CNTTEAMS) | 30 | 34.31 |
+| 8349 | [BRODOVI](https://www.spoj.com/problems/BRODOVI) | 620 | 43.77 |
+| 8351 | [KOSARK](https://www.spoj.com/problems/MIDO) | 852 | 42.90 |
+| 8363 | [COSTLY CHESS](https://www.spoj.com/problems/CCHESS) | 1753 | 43.00 |
+| 8371 | [TRIANGULAR PRISM](https://www.spoj.com/problems/PRISMSA) | 2095 | 68.42 |
+| 8372 | [Triple Sums](https://www.spoj.com/problems/TSUM) | 413 | 27.33 |
+| 8374 | [PARKET](https://www.spoj.com/problems/PARKET1) | 1854 | 56.20 |
+| 8391 | [The Ball](https://www.spoj.com/problems/BALL) | 126 | 10.63 |
+| 8392 | [Youtube](https://www.spoj.com/problems/YOUTUBE) | 234 | 23.00 |
+| 8398 | [Quadratic Equation](https://www.spoj.com/problems/QUADRATE) | 605 | 29.01 |
+| 8406 | [Temple Queues](https://www.spoj.com/problems/TEMPLEQ) | 296 | 19.34 |
+| 8407 | [Candies and Milestones](https://www.spoj.com/problems/CANDYSTN) | 480 | 21.94 |
+| 8408 | [Min  Max 01 Path](https://www.spoj.com/problems/MNMXPATH) | 108 | 28.27 |
+| 8409 | [Favorite Sub Hair](https://www.spoj.com/problems/FAVSUBS) | 98 | 39.25 |
+| 8410 | [Snaky Numbers](https://www.spoj.com/problems/SNAKYNUM) | 84 | 38.82 |
+| 8418 | [Revenge of the squares](https://www.spoj.com/problems/SQUA_REV) | 89 | 36.83 |
+| 8419 | [Traversing Grid](https://www.spoj.com/problems/BTCODE_A) | 341 | 22.88 |
+| 8420 | [Finding Minimum](https://www.spoj.com/problems/BTCODE_B) | 75 | 36.90 |
+| 8421 | [Fun With Inequalities](https://www.spoj.com/problems/BTCODE_C) | 144 | 37.89 |
+| 8422 | [Maximum Profit](https://www.spoj.com/problems/BTCODE_D) | 923 | 53.13 |
+| 8423 | [Recover Polynomials](https://www.spoj.com/problems/BTCODE_E) | 58 | 49.68 |
+| 8424 | [Life Game](https://www.spoj.com/problems/BTCODE_F) | 156 | 52.29 |
+| 8425 | [Coloring Trees](https://www.spoj.com/problems/BTCODE_G) | 324 | 30.46 |
+| 8426 | [Trie Expectation](https://www.spoj.com/problems/BTCODE_H) | 170 | 62.16 |
+| 8427 | [Permutation Game](https://www.spoj.com/problems/BTCODE_I) | 34 | 40.38 |
+| 8428 | [Grid Tiling](https://www.spoj.com/problems/BTCODE_J) | 25 | 23.49 |
+| 8429 | [Array Sorting](https://www.spoj.com/problems/BTCODE_K) | 67 | 17.23 |
+| 8433 | [Revenge of the squares (variation)](https://www.spoj.com/problems/SQUAREV1) | 490 | 49.27 |
+| 8434 | [Kolica](https://www.spoj.com/problems/KOLICA) | 67 | 39.81 |
+| 8442 | [Problem 3](https://www.spoj.com/problems/NOVICE43) | 728 | 54.44 |
+| 8449 | [Plotting functions (variation)](https://www.spoj.com/problems/PLOT1) | 24 | 22.14 |
+| 8456 | [PRIMITIVEROOTS](https://www.spoj.com/problems/PROBLEM4) | 373 | 46.23 |
+| 8461 | [Adventure in Moving](https://www.spoj.com/problems/AVDM) | 44 | 28.43 |
+| 8462 | [Barn Allocation](https://www.spoj.com/problems/BARN) | 215 | 56.89 |
+| 8467 | [GRADE POINT AVERAGE](https://www.spoj.com/problems/GPA1) | 634 | 30.08 |
+| 8478 | [Ancient Pocket Calculator](https://www.spoj.com/problems/POCALC1) | 7 | 4.25 |
+| 8491 | [Messy Phone List](https://www.spoj.com/problems/PHONMESS) | 54 | 19.69 |
+| 8495 | [Maximum Subset of Array](https://www.spoj.com/problems/MAXSUB) | 735 | 27.80 |
+| 8496 | [No Squares Numbers](https://www.spoj.com/problems/NOSQ) | 845 | 35.11 |
+| 8505 | [Nacci Fear](https://www.spoj.com/problems/NACCI) | 320 | 40.37 |
+| 8507 | [Party Switching](https://www.spoj.com/problems/PSWITCH) | 246 | 28.74 |
+| 8542 | [Modern Pocket Calculator](https://www.spoj.com/problems/POCALC2) | 35 | 9.05 |
+| 8545 | [Subset sum](https://www.spoj.com/problems/MAIN72) | 1941 | 40.11 |

--- a/tests/spoj/index/33.jsonl
+++ b/tests/spoj/index/33.jsonl
@@ -1,0 +1,50 @@
+{"id":8546,"name":"Manoj and Pankaj","url":"https://www.spoj.com/problems/MAIN73","users":51,"accepted":18.32}
+{"id":8547,"name":"Euclids algorithm revisited","url":"https://www.spoj.com/problems/MAIN74","users":1469,"accepted":22.83}
+{"id":8549,"name":"BST again","url":"https://www.spoj.com/problems/MAIN75","users":95,"accepted":17.08}
+{"id":8550,"name":"Longest Square Factor","url":"https://www.spoj.com/problems/LSQF","users":75,"accepted":18.47}
+{"id":8551,"name":"Colours A, B, C, D","url":"https://www.spoj.com/problems/ABCD","users":2165,"accepted":21.23}
+{"id":8558,"name":"Linear Equation Solver","url":"https://www.spoj.com/problems/LINQSOLV","users":22,"accepted":34.09}
+{"id":8574,"name":"Four in a row","url":"https://www.spoj.com/problems/FOUROW","users":23,"accepted":17.12}
+{"id":8578,"name":"Reverse the Sequence","url":"https://www.spoj.com/problems/REVSEQ","users":89,"accepted":38.72}
+{"id":8583,"name":"Garden","url":"https://www.spoj.com/problems/NPOWM","users":20,"accepted":61.11}
+{"id":8586,"name":"Factorial factorisation","url":"https://www.spoj.com/problems/PRIME","users":45,"accepted":20.18}
+{"id":8591,"name":"Prime Permutations","url":"https://www.spoj.com/problems/PRIMPERM","users":110,"accepted":30.96}
+{"id":8593,"name":"Covering the Corral","url":"https://www.spoj.com/problems/CORRAL","users":12,"accepted":36.96}
+{"id":8594,"name":"Tails all the way","url":"https://www.spoj.com/problems/TAILS","users":293,"accepted":34.63}
+{"id":8596,"name":"Wood, Axe and Grass","url":"https://www.spoj.com/problems/WAGE","users":520,"accepted":57.84}
+{"id":8598,"name":"Traverse through the board","url":"https://www.spoj.com/problems/TRAVERSE","users":671,"accepted":53.44}
+{"id":8611,"name":"Non-Decreasing Digits","url":"https://www.spoj.com/problems/NY10E","users":3731,"accepted":54.83}
+{"id":8612,"name":"Penney Game","url":"https://www.spoj.com/problems/NY10A","users":7743,"accepted":67.22}
+{"id":8624,"name":"Nim-B Sum","url":"https://www.spoj.com/problems/NY10B","users":629,"accepted":61.4}
+{"id":8625,"name":"Just The Simple Fax","url":"https://www.spoj.com/problems/NY10C","users":79,"accepted":41.89}
+{"id":8626,"name":"Show Me The Fax","url":"https://www.spoj.com/problems/NY10D","users":111,"accepted":43.2}
+{"id":8627,"name":"I2C","url":"https://www.spoj.com/problems/NY10F","users":35,"accepted":24.85}
+{"id":8628,"name":"Selling Land","url":"https://www.spoj.com/problems/NWERC10G","users":73,"accepted":47.78}
+{"id":8629,"name":"Stock Prices","url":"https://www.spoj.com/problems/NWERC10H","users":103,"accepted":45.7}
+{"id":8651,"name":"Alien arithmetic","url":"https://www.spoj.com/problems/ALIENS1","users":45,"accepted":18.37}
+{"id":8657,"name":"The Bovine Accordion and Banjo Orchestra","url":"https://www.spoj.com/problems/BAABO","users":8,"accepted":22.81}
+{"id":8661,"name":"Bogosort","url":"https://www.spoj.com/problems/CHEFFEB","users":46,"accepted":15.27}
+{"id":8663,"name":"Squares Game","url":"https://www.spoj.com/problems/CHEFMAR","users":34,"accepted":33.05}
+{"id":8666,"name":"Maximum - Profit -- Version II","url":"https://www.spoj.com/problems/ITRIX_C","users":101,"accepted":45}
+{"id":8667,"name":"Board-Queries","url":"https://www.spoj.com/problems/ITRIX_D","users":51,"accepted":21.28}
+{"id":8668,"name":"THE BLACK AND WHITE QUEENS","url":"https://www.spoj.com/problems/ITRIX_E","users":84,"accepted":43.03}
+{"id":8670,"name":"THE MAX LINES","url":"https://www.spoj.com/problems/MAXLN","users":8045,"accepted":36.87}
+{"id":8720,"name":"Looks like Nim - but it is not","url":"https://www.spoj.com/problems/GAME2","users":92,"accepted":21.45}
+{"id":8725,"name":"Closest Point Pair","url":"https://www.spoj.com/problems/CLOPPAIR","users":2057,"accepted":20.73}
+{"id":8728,"name":"Hierarchy","url":"https://www.spoj.com/problems/MAKETREE","users":1809,"accepted":29.86}
+{"id":8732,"name":"Best Fit","url":"https://www.spoj.com/problems/BFIT","users":196,"accepted":30.84}
+{"id":8734,"name":"Charlie and the Chocolate Factory","url":"https://www.spoj.com/problems/CHARLIE","users":44,"accepted":17.63}
+{"id":8735,"name":"Suffix Of Cube","url":"https://www.spoj.com/problems/CUBEND","users":102,"accepted":43.91}
+{"id":8747,"name":"Substrings II","url":"https://www.spoj.com/problems/NSUBSTR2","users":163,"accepted":11.2}
+{"id":8750,"name":"Wordplay","url":"https://www.spoj.com/problems/WORD","users":99,"accepted":26.48}
+{"id":8756,"name":"Shake Shake Shaky","url":"https://www.spoj.com/problems/MAIN8_C","users":2455,"accepted":23.9}
+{"id":8757,"name":"Coing tossing","url":"https://www.spoj.com/problems/MAIN8_D","users":165,"accepted":61.61}
+{"id":8758,"name":"Cover the string","url":"https://www.spoj.com/problems/MAIN8_E","users":223,"accepted":23.17}
+{"id":8759,"name":"Alpine Skiing","url":"https://www.spoj.com/problems/SKIING","users":54,"accepted":38.37}
+{"id":8785,"name":"Cut the Silver Bar","url":"https://www.spoj.com/problems/SILVER","users":5378,"accepted":54.45}
+{"id":8786,"name":"The Longest Chain of Domino Tiles","url":"https://www.spoj.com/problems/DOMINO1","users":297,"accepted":32.1}
+{"id":8791,"name":"Dynamic LCA","url":"https://www.spoj.com/problems/DYNALCA","users":493,"accepted":29.65}
+{"id":8793,"name":"Separate Points","url":"https://www.spoj.com/problems/SPOINTS","users":125,"accepted":24.17}
+{"id":8794,"name":"Swimming Jam","url":"https://www.spoj.com/problems/SWJAM","users":51,"accepted":33.33}
+{"id":8795,"name":"Twenty Questions","url":"https://www.spoj.com/problems/TWENTYQ","users":44,"accepted":21.94}
+{"id":8796,"name":"Cubist Artwork","url":"https://www.spoj.com/problems/CUBARTWK","users":657,"accepted":68.27}

--- a/tests/spoj/index/33.md
+++ b/tests/spoj/index/33.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 8546 | [Manoj and Pankaj](https://www.spoj.com/problems/MAIN73) | 51 | 18.32 |
+| 8547 | [Euclids algorithm revisited](https://www.spoj.com/problems/MAIN74) | 1469 | 22.83 |
+| 8549 | [BST again](https://www.spoj.com/problems/MAIN75) | 95 | 17.08 |
+| 8550 | [Longest Square Factor](https://www.spoj.com/problems/LSQF) | 75 | 18.47 |
+| 8551 | [Colours A, B, C, D](https://www.spoj.com/problems/ABCD) | 2165 | 21.23 |
+| 8558 | [Linear Equation Solver](https://www.spoj.com/problems/LINQSOLV) | 22 | 34.09 |
+| 8574 | [Four in a row](https://www.spoj.com/problems/FOUROW) | 23 | 17.12 |
+| 8578 | [Reverse the Sequence](https://www.spoj.com/problems/REVSEQ) | 89 | 38.72 |
+| 8583 | [Garden](https://www.spoj.com/problems/NPOWM) | 20 | 61.11 |
+| 8586 | [Factorial factorisation](https://www.spoj.com/problems/PRIME) | 45 | 20.18 |
+| 8591 | [Prime Permutations](https://www.spoj.com/problems/PRIMPERM) | 110 | 30.96 |
+| 8593 | [Covering the Corral](https://www.spoj.com/problems/CORRAL) | 12 | 36.96 |
+| 8594 | [Tails all the way](https://www.spoj.com/problems/TAILS) | 293 | 34.63 |
+| 8596 | [Wood, Axe and Grass](https://www.spoj.com/problems/WAGE) | 520 | 57.84 |
+| 8598 | [Traverse through the board](https://www.spoj.com/problems/TRAVERSE) | 671 | 53.44 |
+| 8611 | [Non-Decreasing Digits](https://www.spoj.com/problems/NY10E) | 3731 | 54.83 |
+| 8612 | [Penney Game](https://www.spoj.com/problems/NY10A) | 7743 | 67.22 |
+| 8624 | [Nim-B Sum](https://www.spoj.com/problems/NY10B) | 629 | 61.40 |
+| 8625 | [Just The Simple Fax](https://www.spoj.com/problems/NY10C) | 79 | 41.89 |
+| 8626 | [Show Me The Fax](https://www.spoj.com/problems/NY10D) | 111 | 43.20 |
+| 8627 | [I2C](https://www.spoj.com/problems/NY10F) | 35 | 24.85 |
+| 8628 | [Selling Land](https://www.spoj.com/problems/NWERC10G) | 73 | 47.78 |
+| 8629 | [Stock Prices](https://www.spoj.com/problems/NWERC10H) | 103 | 45.70 |
+| 8651 | [Alien arithmetic](https://www.spoj.com/problems/ALIENS1) | 45 | 18.37 |
+| 8657 | [The Bovine Accordion and Banjo Orchestra](https://www.spoj.com/problems/BAABO) | 8 | 22.81 |
+| 8661 | [Bogosort](https://www.spoj.com/problems/CHEFFEB) | 46 | 15.27 |
+| 8663 | [Squares Game](https://www.spoj.com/problems/CHEFMAR) | 34 | 33.05 |
+| 8666 | [Maximum - Profit -- Version II](https://www.spoj.com/problems/ITRIX_C) | 101 | 45.00 |
+| 8667 | [Board-Queries](https://www.spoj.com/problems/ITRIX_D) | 51 | 21.28 |
+| 8668 | [THE BLACK AND WHITE QUEENS](https://www.spoj.com/problems/ITRIX_E) | 84 | 43.03 |
+| 8670 | [THE MAX LINES](https://www.spoj.com/problems/MAXLN) | 8045 | 36.87 |
+| 8720 | [Looks like Nim - but it is not](https://www.spoj.com/problems/GAME2) | 92 | 21.45 |
+| 8725 | [Closest Point Pair](https://www.spoj.com/problems/CLOPPAIR) | 2057 | 20.73 |
+| 8728 | [Hierarchy](https://www.spoj.com/problems/MAKETREE) | 1809 | 29.86 |
+| 8732 | [Best Fit](https://www.spoj.com/problems/BFIT) | 196 | 30.84 |
+| 8734 | [Charlie and the Chocolate Factory](https://www.spoj.com/problems/CHARLIE) | 44 | 17.63 |
+| 8735 | [Suffix Of Cube](https://www.spoj.com/problems/CUBEND) | 102 | 43.91 |
+| 8747 | [Substrings II](https://www.spoj.com/problems/NSUBSTR2) | 163 | 11.20 |
+| 8750 | [Wordplay](https://www.spoj.com/problems/WORD) | 99 | 26.48 |
+| 8756 | [Shake Shake Shaky](https://www.spoj.com/problems/MAIN8_C) | 2455 | 23.90 |
+| 8757 | [Coing tossing](https://www.spoj.com/problems/MAIN8_D) | 165 | 61.61 |
+| 8758 | [Cover the string](https://www.spoj.com/problems/MAIN8_E) | 223 | 23.17 |
+| 8759 | [Alpine Skiing](https://www.spoj.com/problems/SKIING) | 54 | 38.37 |
+| 8785 | [Cut the Silver Bar](https://www.spoj.com/problems/SILVER) | 5378 | 54.45 |
+| 8786 | [The Longest Chain of Domino Tiles](https://www.spoj.com/problems/DOMINO1) | 297 | 32.10 |
+| 8791 | [Dynamic LCA](https://www.spoj.com/problems/DYNALCA) | 493 | 29.65 |
+| 8793 | [Separate Points](https://www.spoj.com/problems/SPOINTS) | 125 | 24.17 |
+| 8794 | [Swimming Jam](https://www.spoj.com/problems/SWJAM) | 51 | 33.33 |
+| 8795 | [Twenty Questions](https://www.spoj.com/problems/TWENTYQ) | 44 | 21.94 |
+| 8796 | [Cubist Artwork](https://www.spoj.com/problems/CUBARTWK) | 657 | 68.27 |

--- a/tests/spoj/index/34.jsonl
+++ b/tests/spoj/index/34.jsonl
@@ -1,0 +1,50 @@
+{"id":8816,"name":"Mravograd","url":"https://www.spoj.com/problems/MRAVOGRA","users":28,"accepted":28.36}
+{"id":8820,"name":"Okret","url":"https://www.spoj.com/problems/OKRET","users":51,"accepted":21.61}
+{"id":8836,"name":"Yet Another Sequence Problem","url":"https://www.spoj.com/problems/SEQ7","users":78,"accepted":23.49}
+{"id":8839,"name":"Longest Common Difference Subsequence","url":"https://www.spoj.com/problems/LCDS","users":75,"accepted":25.06}
+{"id":8841,"name":"Avaricious Maryanna","url":"https://www.spoj.com/problems/AVARY","users":77,"accepted":37.9}
+{"id":8842,"name":"Boring Homework","url":"https://www.spoj.com/problems/BWORK","users":154,"accepted":42.75}
+{"id":8843,"name":"Complete the Set","url":"https://www.spoj.com/problems/COMPLETE","users":57,"accepted":32.13}
+{"id":8844,"name":"Detection of Extraterrestrial","url":"https://www.spoj.com/problems/DETECT","users":126,"accepted":36.51}
+{"id":8845,"name":"Entertainment","url":"https://www.spoj.com/problems/TENNIS","users":52,"accepted":39.11}
+{"id":8846,"name":"Fudan Extracurricular Lives","url":"https://www.spoj.com/problems/MAHJONG","users":7,"accepted":25}
+{"id":8848,"name":"Herbicide","url":"https://www.spoj.com/problems/HERBICID","users":19,"accepted":18.87}
+{"id":8849,"name":"Imitation","url":"https://www.spoj.com/problems/IMITATE","users":28,"accepted":24.82}
+{"id":8850,"name":"Juice Extractor","url":"https://www.spoj.com/problems/JUICE","users":125,"accepted":16.41}
+{"id":8869,"name":"Roti Prata","url":"https://www.spoj.com/problems/PRATA","users":7429,"accepted":39.46}
+{"id":8886,"name":"Guess number!","url":"https://www.spoj.com/problems/GNUM","users":21,"accepted":5.9}
+{"id":8894,"name":"Double Time","url":"https://www.spoj.com/problems/DOUTI","users":33,"accepted":47.87}
+{"id":8895,"name":"Power Crisis","url":"https://www.spoj.com/problems/POCRI","users":442,"accepted":33.89}
+{"id":8896,"name":"Pattern Matching","url":"https://www.spoj.com/problems/PATT","users":32,"accepted":26.58}
+{"id":8910,"name":"Probablistic OR","url":"https://www.spoj.com/problems/PROBOR","users":176,"accepted":58.46}
+{"id":8916,"name":"Villages by the River","url":"https://www.spoj.com/problems/VILLAGES","users":279,"accepted":24.41}
+{"id":8917,"name":"How Many Plusses","url":"https://www.spoj.com/problems/PLUSEVI","users":181,"accepted":31.21}
+{"id":8930,"name":"Party!","url":"https://www.spoj.com/problems/PAAAARTY","users":67,"accepted":19.63}
+{"id":8945,"name":"Grid points (speed variation)","url":"https://www.spoj.com/problems/GRIDPNTS","users":31,"accepted":24.38}
+{"id":8951,"name":"brownie","url":"https://www.spoj.com/problems/XIXO","users":73,"accepted":49.17}
+{"id":8952,"name":"Catapult that ball","url":"https://www.spoj.com/problems/THRBL","users":3195,"accepted":26.31}
+{"id":8971,"name":"LQDNUMBERS","url":"https://www.spoj.com/problems/LQDNUMS","users":36,"accepted":35.04}
+{"id":8980,"name":"Cost","url":"https://www.spoj.com/problems/KOICOST","users":1261,"accepted":29.17}
+{"id":8982,"name":"Representatives","url":"https://www.spoj.com/problems/KOIREP","users":442,"accepted":31.5}
+{"id":8985,"name":"Line up","url":"https://www.spoj.com/problems/KOILINE","users":415,"accepted":51.69}
+{"id":8989,"name":"Funny programming contest","url":"https://www.spoj.com/problems/FUPRCO","users":38,"accepted":19.84}
+{"id":8991,"name":"Number Guessing Game 2","url":"https://www.spoj.com/problems/GUESSLNK","users":132,"accepted":35.6}
+{"id":8992,"name":"A los saltos","url":"https://www.spoj.com/problems/SALTOS","users":39,"accepted":29.81}
+{"id":8995,"name":"CANDY","url":"https://www.spoj.com/problems/LQDCANDY","users":1347,"accepted":38.35}
+{"id":9000,"name":"Bob and his new kite factory","url":"https://www.spoj.com/problems/KITEPRBL","users":2,"accepted":1.14}
+{"id":9012,"name":"Maximum Self-Matching","url":"https://www.spoj.com/problems/MAXMATCH","users":756,"accepted":46.8}
+{"id":9030,"name":"Bob and his towers","url":"https://www.spoj.com/problems/KVALTWR","users":40,"accepted":30.12}
+{"id":9032,"name":"Cube Free Numbers","url":"https://www.spoj.com/problems/CUBEFR","users":4167,"accepted":31.77}
+{"id":9034,"name":"Help Tohu","url":"https://www.spoj.com/problems/TOHU","users":2317,"accepted":45.36}
+{"id":9038,"name":"Chessboard Billiard","url":"https://www.spoj.com/problems/BISHOP2","users":53,"accepted":26.07}
+{"id":9040,"name":"Tug of War","url":"https://www.spoj.com/problems/TUG","users":623,"accepted":25.8}
+{"id":9042,"name":"HQNP Incomputable","url":"https://www.spoj.com/problems/HQNP","users":48,"accepted":33.33}
+{"id":9046,"name":"Clock Hands","url":"https://www.spoj.com/problems/HANDS","users":378,"accepted":22.32}
+{"id":9050,"name":"Tohu again","url":"https://www.spoj.com/problems/TOHU2","users":865,"accepted":29.24}
+{"id":9055,"name":"Most Frequent Value","url":"https://www.spoj.com/problems/FREQ2","users":821,"accepted":23.65}
+{"id":9063,"name":"Shuffling cards","url":"https://www.spoj.com/problems/SHUFFLEK","users":16,"accepted":28.92}
+{"id":9066,"name":"Sum of Distinct Numbers","url":"https://www.spoj.com/problems/XXXXXXXX","users":358,"accepted":14.71}
+{"id":9070,"name":"Lightning Conductor","url":"https://www.spoj.com/problems/LIGHTIN","users":684,"accepted":34.82}
+{"id":9076,"name":"Hablu and Bablu","url":"https://www.spoj.com/problems/HABLU","users":160,"accepted":18.76}
+{"id":9081,"name":"Snail family problems","url":"https://www.spoj.com/problems/INCEST","users":85,"accepted":23.48}
+{"id":9084,"name":"Journey to Mars","url":"https://www.spoj.com/problems/JRNTMRS","users":106,"accepted":23.55}

--- a/tests/spoj/index/34.md
+++ b/tests/spoj/index/34.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 8816 | [Mravograd](https://www.spoj.com/problems/MRAVOGRA) | 28 | 28.36 |
+| 8820 | [Okret](https://www.spoj.com/problems/OKRET) | 51 | 21.61 |
+| 8836 | [Yet Another Sequence Problem](https://www.spoj.com/problems/SEQ7) | 78 | 23.49 |
+| 8839 | [Longest Common Difference Subsequence](https://www.spoj.com/problems/LCDS) | 75 | 25.06 |
+| 8841 | [Avaricious Maryanna](https://www.spoj.com/problems/AVARY) | 77 | 37.90 |
+| 8842 | [Boring Homework](https://www.spoj.com/problems/BWORK) | 154 | 42.75 |
+| 8843 | [Complete the Set](https://www.spoj.com/problems/COMPLETE) | 57 | 32.13 |
+| 8844 | [Detection of Extraterrestrial](https://www.spoj.com/problems/DETECT) | 126 | 36.51 |
+| 8845 | [Entertainment](https://www.spoj.com/problems/TENNIS) | 52 | 39.11 |
+| 8846 | [Fudan Extracurricular Lives](https://www.spoj.com/problems/MAHJONG) | 7 | 25.00 |
+| 8848 | [Herbicide](https://www.spoj.com/problems/HERBICID) | 19 | 18.87 |
+| 8849 | [Imitation](https://www.spoj.com/problems/IMITATE) | 28 | 24.82 |
+| 8850 | [Juice Extractor](https://www.spoj.com/problems/JUICE) | 125 | 16.41 |
+| 8869 | [Roti Prata](https://www.spoj.com/problems/PRATA) | 7429 | 39.46 |
+| 8886 | [Guess number!](https://www.spoj.com/problems/GNUM) | 21 | 5.90 |
+| 8894 | [Double Time](https://www.spoj.com/problems/DOUTI) | 33 | 47.87 |
+| 8895 | [Power Crisis](https://www.spoj.com/problems/POCRI) | 442 | 33.89 |
+| 8896 | [Pattern Matching](https://www.spoj.com/problems/PATT) | 32 | 26.58 |
+| 8910 | [Probablistic OR](https://www.spoj.com/problems/PROBOR) | 176 | 58.46 |
+| 8916 | [Villages by the River](https://www.spoj.com/problems/VILLAGES) | 279 | 24.41 |
+| 8917 | [How Many Plusses](https://www.spoj.com/problems/PLUSEVI) | 181 | 31.21 |
+| 8930 | [Party!](https://www.spoj.com/problems/PAAAARTY) | 67 | 19.63 |
+| 8945 | [Grid points (speed variation)](https://www.spoj.com/problems/GRIDPNTS) | 31 | 24.38 |
+| 8951 | [brownie](https://www.spoj.com/problems/XIXO) | 73 | 49.17 |
+| 8952 | [Catapult that ball](https://www.spoj.com/problems/THRBL) | 3195 | 26.31 |
+| 8971 | [LQDNUMBERS](https://www.spoj.com/problems/LQDNUMS) | 36 | 35.04 |
+| 8980 | [Cost](https://www.spoj.com/problems/KOICOST) | 1261 | 29.17 |
+| 8982 | [Representatives](https://www.spoj.com/problems/KOIREP) | 442 | 31.50 |
+| 8985 | [Line up](https://www.spoj.com/problems/KOILINE) | 415 | 51.69 |
+| 8989 | [Funny programming contest](https://www.spoj.com/problems/FUPRCO) | 38 | 19.84 |
+| 8991 | [Number Guessing Game 2](https://www.spoj.com/problems/GUESSLNK) | 132 | 35.60 |
+| 8992 | [A los saltos](https://www.spoj.com/problems/SALTOS) | 39 | 29.81 |
+| 8995 | [CANDY](https://www.spoj.com/problems/LQDCANDY) | 1347 | 38.35 |
+| 9000 | [Bob and his new kite factory](https://www.spoj.com/problems/KITEPRBL) | 2 | 1.14 |
+| 9012 | [Maximum Self-Matching](https://www.spoj.com/problems/MAXMATCH) | 756 | 46.80 |
+| 9030 | [Bob and his towers](https://www.spoj.com/problems/KVALTWR) | 40 | 30.12 |
+| 9032 | [Cube Free Numbers](https://www.spoj.com/problems/CUBEFR) | 4167 | 31.77 |
+| 9034 | [Help Tohu](https://www.spoj.com/problems/TOHU) | 2317 | 45.36 |
+| 9038 | [Chessboard Billiard](https://www.spoj.com/problems/BISHOP2) | 53 | 26.07 |
+| 9040 | [Tug of War](https://www.spoj.com/problems/TUG) | 623 | 25.80 |
+| 9042 | [HQNP Incomputable](https://www.spoj.com/problems/HQNP) | 48 | 33.33 |
+| 9046 | [Clock Hands](https://www.spoj.com/problems/HANDS) | 378 | 22.32 |
+| 9050 | [Tohu again](https://www.spoj.com/problems/TOHU2) | 865 | 29.24 |
+| 9055 | [Most Frequent Value](https://www.spoj.com/problems/FREQ2) | 821 | 23.65 |
+| 9063 | [Shuffling cards](https://www.spoj.com/problems/SHUFFLEK) | 16 | 28.92 |
+| 9066 | [Sum of Distinct Numbers](https://www.spoj.com/problems/XXXXXXXX) | 358 | 14.71 |
+| 9070 | [Lightning Conductor](https://www.spoj.com/problems/LIGHTIN) | 684 | 34.82 |
+| 9076 | [Hablu and Bablu](https://www.spoj.com/problems/HABLU) | 160 | 18.76 |
+| 9081 | [Snail family problems](https://www.spoj.com/problems/INCEST) | 85 | 23.48 |
+| 9084 | [Journey to Mars](https://www.spoj.com/problems/JRNTMRS) | 106 | 23.55 |

--- a/tests/spoj/index/35.jsonl
+++ b/tests/spoj/index/35.jsonl
@@ -1,0 +1,50 @@
+{"id":9086,"name":"Formula 3D","url":"https://www.spoj.com/problems/JZPFOR","users":6,"accepted":9.86}
+{"id":9096,"name":"Bob and magical scale","url":"https://www.spoj.com/problems/MGCSCLS","users":73,"accepted":26.03}
+{"id":9097,"name":"Derangements HARD","url":"https://www.spoj.com/problems/NOVICE65","users":120,"accepted":50}
+{"id":9098,"name":"Long Common Subsequence","url":"https://www.spoj.com/problems/LCS3","users":196,"accepted":36.48}
+{"id":9103,"name":"Special Numbers","url":"https://www.spoj.com/problems/NOVICE63","users":759,"accepted":30.05}
+{"id":9104,"name":"Match the words","url":"https://www.spoj.com/problems/NOVICE62","users":418,"accepted":50.39}
+{"id":9117,"name":"Faculty Dividing Powers","url":"https://www.spoj.com/problems/GCPC11A","users":375,"accepted":22.55}
+{"id":9118,"name":"Genetic Fraud","url":"https://www.spoj.com/problems/GCPC11B","users":152,"accepted":29.47}
+{"id":9119,"name":"Indiana Jones and the lost Soccer Cup","url":"https://www.spoj.com/problems/GCPC11C","users":378,"accepted":29.07}
+{"id":9120,"name":"Magic Star","url":"https://www.spoj.com/problems/GCPC11D","users":174,"accepted":52.72}
+{"id":9121,"name":"Magical Crafting","url":"https://www.spoj.com/problems/GCPC11E","users":58,"accepted":46.94}
+{"id":9122,"name":"Diary","url":"https://www.spoj.com/problems/GCPC11F","users":1066,"accepted":35.71}
+{"id":9123,"name":"Security Zone","url":"https://www.spoj.com/problems/GCPC11G","users":39,"accepted":27.45}
+{"id":9124,"name":"Sightseeing","url":"https://www.spoj.com/problems/GCPC11H","users":120,"accepted":17.92}
+{"id":9125,"name":"Suiting Weavers","url":"https://www.spoj.com/problems/GCPC11I","users":91,"accepted":29.52}
+{"id":9126,"name":"Time to live","url":"https://www.spoj.com/problems/GCPC11J","users":2058,"accepted":37.7}
+{"id":9137,"name":"Pyramid Sums","url":"https://www.spoj.com/problems/PYRSUM","users":96,"accepted":35.6}
+{"id":9138,"name":"Pyramid Sums 2","url":"https://www.spoj.com/problems/PYRSUM2","users":114,"accepted":33.61}
+{"id":9161,"name":"Legendre symbol","url":"https://www.spoj.com/problems/LEGRENDS","users":190,"accepted":45.42}
+{"id":9185,"name":"TORNJEVI","url":"https://www.spoj.com/problems/TORNJEVI","users":223,"accepted":33.37}
+{"id":9190,"name":"Perfect Maze","url":"https://www.spoj.com/problems/TREEMAZE","users":31,"accepted":1.73}
+{"id":9199,"name":"Circular Track","url":"https://www.spoj.com/problems/SPEED","users":3350,"accepted":40.29}
+{"id":9213,"name":"Mafia","url":"https://www.spoj.com/problems/MAFBOI08","users":53,"accepted":23.93}
+{"id":9219,"name":"Nikhil Problem","url":"https://www.spoj.com/problems/BHAT007","users":225,"accepted":45.88}
+{"id":9242,"name":"B Beware, the end of the world","url":"https://www.spoj.com/problems/AHORCADO","users":32,"accepted":24.88}
+{"id":9255,"name":"Publication","url":"https://www.spoj.com/problems/PUBLICAT","users":42,"accepted":60.75}
+{"id":9260,"name":"Perfect Road","url":"https://www.spoj.com/problems/PERFECTR","users":16,"accepted":20.37}
+{"id":9331,"name":"DCD","url":"https://www.spoj.com/problems/DCD","users":64,"accepted":52.07}
+{"id":9334,"name":"Point in tetrahedron","url":"https://www.spoj.com/problems/TETRAHED","users":141,"accepted":57.59}
+{"id":9340,"name":"Arbitrage","url":"https://www.spoj.com/problems/ARBITRAG","users":1946,"accepted":39.49}
+{"id":9367,"name":"Segment Flip","url":"https://www.spoj.com/problems/SFLIP","users":89,"accepted":10.64}
+{"id":9378,"name":"Landfill","url":"https://www.spoj.com/problems/LANDFILL","users":70,"accepted":42.44}
+{"id":9382,"name":"Complan Carnival","url":"https://www.spoj.com/problems/CARNIVAL","users":41,"accepted":34.62}
+{"id":9385,"name":"Strictly not a Prime","url":"https://www.spoj.com/problems/MAIN111","users":368,"accepted":28.66}
+{"id":9386,"name":"Re-Arrange II","url":"https://www.spoj.com/problems/MAIN112","users":277,"accepted":44.26}
+{"id":9387,"name":"Special String","url":"https://www.spoj.com/problems/MAIN113","users":1111,"accepted":39.62}
+{"id":9430,"name":"The game of 31","url":"https://www.spoj.com/problems/GAME31","users":165,"accepted":39.3}
+{"id":9433,"name":"Buzzwords","url":"https://www.spoj.com/problems/BUZZW","users":87,"accepted":32.21}
+{"id":9434,"name":"New Horizons","url":"https://www.spoj.com/problems/NEWH","users":11,"accepted":31.75}
+{"id":9440,"name":"To Add or to Multiply","url":"https://www.spoj.com/problems/ADDMUL","users":19,"accepted":16.26}
+{"id":9443,"name":"Trial of Doom","url":"https://www.spoj.com/problems/YALOP","users":30,"accepted":29.2}
+{"id":9444,"name":"Block Drop","url":"https://www.spoj.com/problems/BLOCKDRO","users":25,"accepted":27.33}
+{"id":9445,"name":"Attack of the Clones","url":"https://www.spoj.com/problems/CLONES","users":29,"accepted":52.31}
+{"id":9446,"name":"Shortest Circuit Evaluation","url":"https://www.spoj.com/problems/SHORTCIR","users":28,"accepted":43.75}
+{"id":9447,"name":"Genetics","url":"https://www.spoj.com/problems/GENETICS","users":47,"accepted":33.53}
+{"id":9448,"name":"Swarm of Polygons","url":"https://www.spoj.com/problems/SWARM","users":39,"accepted":31.21}
+{"id":9458,"name":"Ghosts having fun","url":"https://www.spoj.com/problems/GHOSTS","users":223,"accepted":12.2}
+{"id":9459,"name":"Connecting three towns (variation)","url":"https://www.spoj.com/problems/THREETW1","users":56,"accepted":24.43}
+{"id":9489,"name":"Johny Hates Math","url":"https://www.spoj.com/problems/ANARC07J","users":26,"accepted":7.19}
+{"id":9493,"name":"Advanced Fruits","url":"https://www.spoj.com/problems/ADFRUITS","users":2261,"accepted":37.53}

--- a/tests/spoj/index/35.md
+++ b/tests/spoj/index/35.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 9086 | [Formula 3D](https://www.spoj.com/problems/JZPFOR) | 6 | 9.86 |
+| 9096 | [Bob and magical scale](https://www.spoj.com/problems/MGCSCLS) | 73 | 26.03 |
+| 9097 | [Derangements HARD](https://www.spoj.com/problems/NOVICE65) | 120 | 50.00 |
+| 9098 | [Long Common Subsequence](https://www.spoj.com/problems/LCS3) | 196 | 36.48 |
+| 9103 | [Special Numbers](https://www.spoj.com/problems/NOVICE63) | 759 | 30.05 |
+| 9104 | [Match the words](https://www.spoj.com/problems/NOVICE62) | 418 | 50.39 |
+| 9117 | [Faculty Dividing Powers](https://www.spoj.com/problems/GCPC11A) | 375 | 22.55 |
+| 9118 | [Genetic Fraud](https://www.spoj.com/problems/GCPC11B) | 152 | 29.47 |
+| 9119 | [Indiana Jones and the lost Soccer Cup](https://www.spoj.com/problems/GCPC11C) | 378 | 29.07 |
+| 9120 | [Magic Star](https://www.spoj.com/problems/GCPC11D) | 174 | 52.72 |
+| 9121 | [Magical Crafting](https://www.spoj.com/problems/GCPC11E) | 58 | 46.94 |
+| 9122 | [Diary](https://www.spoj.com/problems/GCPC11F) | 1066 | 35.71 |
+| 9123 | [Security Zone](https://www.spoj.com/problems/GCPC11G) | 39 | 27.45 |
+| 9124 | [Sightseeing](https://www.spoj.com/problems/GCPC11H) | 120 | 17.92 |
+| 9125 | [Suiting Weavers](https://www.spoj.com/problems/GCPC11I) | 91 | 29.52 |
+| 9126 | [Time to live](https://www.spoj.com/problems/GCPC11J) | 2058 | 37.70 |
+| 9137 | [Pyramid Sums](https://www.spoj.com/problems/PYRSUM) | 96 | 35.60 |
+| 9138 | [Pyramid Sums 2](https://www.spoj.com/problems/PYRSUM2) | 114 | 33.61 |
+| 9161 | [Legendre symbol](https://www.spoj.com/problems/LEGRENDS) | 190 | 45.42 |
+| 9185 | [TORNJEVI](https://www.spoj.com/problems/TORNJEVI) | 223 | 33.37 |
+| 9190 | [Perfect Maze](https://www.spoj.com/problems/TREEMAZE) | 31 | 1.73 |
+| 9199 | [Circular Track](https://www.spoj.com/problems/SPEED) | 3350 | 40.29 |
+| 9213 | [Mafia](https://www.spoj.com/problems/MAFBOI08) | 53 | 23.93 |
+| 9219 | [Nikhil Problem](https://www.spoj.com/problems/BHAT007) | 225 | 45.88 |
+| 9242 | [B Beware, the end of the world](https://www.spoj.com/problems/AHORCADO) | 32 | 24.88 |
+| 9255 | [Publication](https://www.spoj.com/problems/PUBLICAT) | 42 | 60.75 |
+| 9260 | [Perfect Road](https://www.spoj.com/problems/PERFECTR) | 16 | 20.37 |
+| 9331 | [DCD](https://www.spoj.com/problems/DCD) | 64 | 52.07 |
+| 9334 | [Point in tetrahedron](https://www.spoj.com/problems/TETRAHED) | 141 | 57.59 |
+| 9340 | [Arbitrage](https://www.spoj.com/problems/ARBITRAG) | 1946 | 39.49 |
+| 9367 | [Segment Flip](https://www.spoj.com/problems/SFLIP) | 89 | 10.64 |
+| 9378 | [Landfill](https://www.spoj.com/problems/LANDFILL) | 70 | 42.44 |
+| 9382 | [Complan Carnival](https://www.spoj.com/problems/CARNIVAL) | 41 | 34.62 |
+| 9385 | [Strictly not a Prime](https://www.spoj.com/problems/MAIN111) | 368 | 28.66 |
+| 9386 | [Re-Arrange II](https://www.spoj.com/problems/MAIN112) | 277 | 44.26 |
+| 9387 | [Special String](https://www.spoj.com/problems/MAIN113) | 1111 | 39.62 |
+| 9430 | [The game of 31](https://www.spoj.com/problems/GAME31) | 165 | 39.30 |
+| 9433 | [Buzzwords](https://www.spoj.com/problems/BUZZW) | 87 | 32.21 |
+| 9434 | [New Horizons](https://www.spoj.com/problems/NEWH) | 11 | 31.75 |
+| 9440 | [To Add or to Multiply](https://www.spoj.com/problems/ADDMUL) | 19 | 16.26 |
+| 9443 | [Trial of Doom](https://www.spoj.com/problems/YALOP) | 30 | 29.20 |
+| 9444 | [Block Drop](https://www.spoj.com/problems/BLOCKDRO) | 25 | 27.33 |
+| 9445 | [Attack of the Clones](https://www.spoj.com/problems/CLONES) | 29 | 52.31 |
+| 9446 | [Shortest Circuit Evaluation](https://www.spoj.com/problems/SHORTCIR) | 28 | 43.75 |
+| 9447 | [Genetics](https://www.spoj.com/problems/GENETICS) | 47 | 33.53 |
+| 9448 | [Swarm of Polygons](https://www.spoj.com/problems/SWARM) | 39 | 31.21 |
+| 9458 | [Ghosts having fun](https://www.spoj.com/problems/GHOSTS) | 223 | 12.20 |
+| 9459 | [Connecting three towns (variation)](https://www.spoj.com/problems/THREETW1) | 56 | 24.43 |
+| 9489 | [Johny Hates Math](https://www.spoj.com/problems/ANARC07J) | 26 | 7.19 |
+| 9493 | [Advanced Fruits](https://www.spoj.com/problems/ADFRUITS) | 2261 | 37.53 |

--- a/tests/spoj/index/36.jsonl
+++ b/tests/spoj/index/36.jsonl
@@ -1,0 +1,50 @@
+{"id":9494,"name":"Just Add It","url":"https://www.spoj.com/problems/ZSUM","users":6460,"accepted":46.85}
+{"id":9503,"name":"Working in Beijing","url":"https://www.spoj.com/problems/WORKB","users":645,"accepted":49.07}
+{"id":9504,"name":"Paint on a Wall","url":"https://www.spoj.com/problems/PAINTWAL","users":26,"accepted":42.31}
+{"id":9505,"name":"Distinct Subtrees","url":"https://www.spoj.com/problems/DSUBTREE","users":21,"accepted":25.27}
+{"id":9506,"name":"Jimmy´s Travel Plan","url":"https://www.spoj.com/problems/DIST2","users":23,"accepted":40.66}
+{"id":9507,"name":"Mario and Mushrooms","url":"https://www.spoj.com/problems/MARIO2","users":345,"accepted":56.94}
+{"id":9508,"name":"Magic Bitwise AND Operation","url":"https://www.spoj.com/problems/AND","users":107,"accepted":12.7}
+{"id":9509,"name":"Shortest Path on a Cylinder","url":"https://www.spoj.com/problems/CYLINDES","users":28,"accepted":31.51}
+{"id":9510,"name":"Ads Proposal","url":"https://www.spoj.com/problems/ADSPROP","users":72,"accepted":26.14}
+{"id":9511,"name":"24-Puzzle","url":"https://www.spoj.com/problems/PUZZLE24","users":24,"accepted":17.76}
+{"id":9512,"name":"Bombing","url":"https://www.spoj.com/problems/BOMB2","users":89,"accepted":23.46}
+{"id":9513,"name":"Game","url":"https://www.spoj.com/problems/TETRISGM","users":20,"accepted":18.58}
+{"id":9515,"name":"Dwarven Sniper´s Hunting","url":"https://www.spoj.com/problems/HUNT1","users":18,"accepted":39.34}
+{"id":9516,"name":"XOR Equations","url":"https://www.spoj.com/problems/XOREQ","users":18,"accepted":20}
+{"id":9517,"name":"Unlock the Cellphone","url":"https://www.spoj.com/problems/UNLOCK","users":12,"accepted":23.64}
+{"id":9518,"name":"The Time of Day","url":"https://www.spoj.com/problems/LCM","users":39,"accepted":21.98}
+{"id":9519,"name":"Distinct Submatrices","url":"https://www.spoj.com/problems/DSUBMTR","users":26,"accepted":14.22}
+{"id":9520,"name":"Tanks","url":"https://www.spoj.com/problems/TANKS","users":16,"accepted":12.67}
+{"id":9525,"name":"Cipher","url":"https://www.spoj.com/problems/CIPHERJ","users":101,"accepted":21.1}
+{"id":9527,"name":"Department","url":"https://www.spoj.com/problems/DEPARTJ","users":11,"accepted":7.37}
+{"id":9528,"name":"Johns Trip","url":"https://www.spoj.com/problems/JTRIP","users":21,"accepted":29.29}
+{"id":9529,"name":"Maya Calendar","url":"https://www.spoj.com/problems/MAYCA","users":221,"accepted":30.6}
+{"id":9532,"name":"Transportation","url":"https://www.spoj.com/problems/TRANSJ","users":22,"accepted":28.57}
+{"id":9534,"name":"Turn on the lights","url":"https://www.spoj.com/problems/JZPLIT","users":71,"accepted":32.55}
+{"id":9535,"name":"Turn on the lights 2","url":"https://www.spoj.com/problems/JZPLIT2","users":23,"accepted":32.97}
+{"id":9543,"name":"Dynamic Congruence Equation System","url":"https://www.spoj.com/problems/DCES","users":10,"accepted":54.97}
+{"id":9547,"name":"Counting d-pairs","url":"https://www.spoj.com/problems/DPAIR","users":138,"accepted":30.45}
+{"id":9569,"name":"Sum of Pairwise Products","url":"https://www.spoj.com/problems/PAIRSUM","users":841,"accepted":31.5}
+{"id":9570,"name":"Counting binary strings","url":"https://www.spoj.com/problems/STRCOUNT","users":340,"accepted":53.21}
+{"id":9576,"name":"Dynamic Graph Connectivity","url":"https://www.spoj.com/problems/DYNACON2","users":328,"accepted":38.05}
+{"id":9577,"name":"Dynamic Tree Connectivity","url":"https://www.spoj.com/problems/DYNACON1","users":651,"accepted":28.53}
+{"id":9587,"name":"The Prime conjecture","url":"https://www.spoj.com/problems/PRIMEZUK","users":574,"accepted":34.49}
+{"id":9636,"name":"A Canvas Building","url":"https://www.spoj.com/problems/ACANVAS","users":71,"accepted":18.04}
+{"id":9637,"name":"Black and White","url":"https://www.spoj.com/problems/BANDW","users":2183,"accepted":54.18}
+{"id":9638,"name":"Circuits","url":"https://www.spoj.com/problems/CIRCUITS","users":25,"accepted":9.33}
+{"id":9640,"name":"Equilibrium","url":"https://www.spoj.com/problems/EQUI","users":256,"accepted":28.14}
+{"id":9641,"name":"Factory of Bridges","url":"https://www.spoj.com/problems/FBRIDGES","users":69,"accepted":26.01}
+{"id":9642,"name":"Getting There Fast","url":"https://www.spoj.com/problems/GETFAST","users":19,"accepted":17.69}
+{"id":9643,"name":"He is Lazy","url":"https://www.spoj.com/problems/HEISLAZY","users":157,"accepted":41.73}
+{"id":9644,"name":"Imperialism","url":"https://www.spoj.com/problems/IMPER","users":174,"accepted":30.69}
+{"id":9645,"name":"Joy of CompuTenis","url":"https://www.spoj.com/problems/JOCTENIS","users":9,"accepted":15.38}
+{"id":9650,"name":"Mega Inversions","url":"https://www.spoj.com/problems/TRIPINV","users":617,"accepted":42.94}
+{"id":9652,"name":"Robots on a grid","url":"https://www.spoj.com/problems/ROBOTGRI","users":865,"accepted":19.47}
+{"id":9655,"name":"Elevator Trouble","url":"https://www.spoj.com/problems/ELEVTRBL","users":4328,"accepted":32.38}
+{"id":9685,"name":"Zombie’s Treasure Chest","url":"https://www.spoj.com/problems/ZTC","users":83,"accepted":13.68}
+{"id":9686,"name":"Yummy Triangular Pizza","url":"https://www.spoj.com/problems/YUMMY","users":485,"accepted":65.64}
+{"id":9687,"name":"Xavier is Learning to Count","url":"https://www.spoj.com/problems/XC","users":46,"accepted":20.05}
+{"id":9689,"name":"Very Boring Homework","url":"https://www.spoj.com/problems/VBWORK","users":16,"accepted":33.33}
+{"id":9690,"name":"Universal Question Answering System","url":"https://www.spoj.com/problems/UQAS","users":26,"accepted":24}
+{"id":9691,"name":"Triangles and Quadrangle","url":"https://www.spoj.com/problems/TQ","users":17,"accepted":13.25}

--- a/tests/spoj/index/36.md
+++ b/tests/spoj/index/36.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 9494 | [Just Add It](https://www.spoj.com/problems/ZSUM) | 6460 | 46.85 |
+| 9503 | [Working in Beijing](https://www.spoj.com/problems/WORKB) | 645 | 49.07 |
+| 9504 | [Paint on a Wall](https://www.spoj.com/problems/PAINTWAL) | 26 | 42.31 |
+| 9505 | [Distinct Subtrees](https://www.spoj.com/problems/DSUBTREE) | 21 | 25.27 |
+| 9506 | [Jimmy´s Travel Plan](https://www.spoj.com/problems/DIST2) | 23 | 40.66 |
+| 9507 | [Mario and Mushrooms](https://www.spoj.com/problems/MARIO2) | 345 | 56.94 |
+| 9508 | [Magic Bitwise AND Operation](https://www.spoj.com/problems/AND) | 107 | 12.70 |
+| 9509 | [Shortest Path on a Cylinder](https://www.spoj.com/problems/CYLINDES) | 28 | 31.51 |
+| 9510 | [Ads Proposal](https://www.spoj.com/problems/ADSPROP) | 72 | 26.14 |
+| 9511 | [24-Puzzle](https://www.spoj.com/problems/PUZZLE24) | 24 | 17.76 |
+| 9512 | [Bombing](https://www.spoj.com/problems/BOMB2) | 89 | 23.46 |
+| 9513 | [Game](https://www.spoj.com/problems/TETRISGM) | 20 | 18.58 |
+| 9515 | [Dwarven Sniper´s Hunting](https://www.spoj.com/problems/HUNT1) | 18 | 39.34 |
+| 9516 | [XOR Equations](https://www.spoj.com/problems/XOREQ) | 18 | 20.00 |
+| 9517 | [Unlock the Cellphone](https://www.spoj.com/problems/UNLOCK) | 12 | 23.64 |
+| 9518 | [The Time of Day](https://www.spoj.com/problems/LCM) | 39 | 21.98 |
+| 9519 | [Distinct Submatrices](https://www.spoj.com/problems/DSUBMTR) | 26 | 14.22 |
+| 9520 | [Tanks](https://www.spoj.com/problems/TANKS) | 16 | 12.67 |
+| 9525 | [Cipher](https://www.spoj.com/problems/CIPHERJ) | 101 | 21.10 |
+| 9527 | [Department](https://www.spoj.com/problems/DEPARTJ) | 11 | 7.37 |
+| 9528 | [Johns Trip](https://www.spoj.com/problems/JTRIP) | 21 | 29.29 |
+| 9529 | [Maya Calendar](https://www.spoj.com/problems/MAYCA) | 221 | 30.60 |
+| 9532 | [Transportation](https://www.spoj.com/problems/TRANSJ) | 22 | 28.57 |
+| 9534 | [Turn on the lights](https://www.spoj.com/problems/JZPLIT) | 71 | 32.55 |
+| 9535 | [Turn on the lights 2](https://www.spoj.com/problems/JZPLIT2) | 23 | 32.97 |
+| 9543 | [Dynamic Congruence Equation System](https://www.spoj.com/problems/DCES) | 10 | 54.97 |
+| 9547 | [Counting d-pairs](https://www.spoj.com/problems/DPAIR) | 138 | 30.45 |
+| 9569 | [Sum of Pairwise Products](https://www.spoj.com/problems/PAIRSUM) | 841 | 31.50 |
+| 9570 | [Counting binary strings](https://www.spoj.com/problems/STRCOUNT) | 340 | 53.21 |
+| 9576 | [Dynamic Graph Connectivity](https://www.spoj.com/problems/DYNACON2) | 328 | 38.05 |
+| 9577 | [Dynamic Tree Connectivity](https://www.spoj.com/problems/DYNACON1) | 651 | 28.53 |
+| 9587 | [The Prime conjecture](https://www.spoj.com/problems/PRIMEZUK) | 574 | 34.49 |
+| 9636 | [A Canvas Building](https://www.spoj.com/problems/ACANVAS) | 71 | 18.04 |
+| 9637 | [Black and White](https://www.spoj.com/problems/BANDW) | 2183 | 54.18 |
+| 9638 | [Circuits](https://www.spoj.com/problems/CIRCUITS) | 25 | 9.33 |
+| 9640 | [Equilibrium](https://www.spoj.com/problems/EQUI) | 256 | 28.14 |
+| 9641 | [Factory of Bridges](https://www.spoj.com/problems/FBRIDGES) | 69 | 26.01 |
+| 9642 | [Getting There Fast](https://www.spoj.com/problems/GETFAST) | 19 | 17.69 |
+| 9643 | [He is Lazy](https://www.spoj.com/problems/HEISLAZY) | 157 | 41.73 |
+| 9644 | [Imperialism](https://www.spoj.com/problems/IMPER) | 174 | 30.69 |
+| 9645 | [Joy of CompuTenis](https://www.spoj.com/problems/JOCTENIS) | 9 | 15.38 |
+| 9650 | [Mega Inversions](https://www.spoj.com/problems/TRIPINV) | 617 | 42.94 |
+| 9652 | [Robots on a grid](https://www.spoj.com/problems/ROBOTGRI) | 865 | 19.47 |
+| 9655 | [Elevator Trouble](https://www.spoj.com/problems/ELEVTRBL) | 4328 | 32.38 |
+| 9685 | [Zombie’s Treasure Chest](https://www.spoj.com/problems/ZTC) | 83 | 13.68 |
+| 9686 | [Yummy Triangular Pizza](https://www.spoj.com/problems/YUMMY) | 485 | 65.64 |
+| 9687 | [Xavier is Learning to Count](https://www.spoj.com/problems/XC) | 46 | 20.05 |
+| 9689 | [Very Boring Homework](https://www.spoj.com/problems/VBWORK) | 16 | 33.33 |
+| 9690 | [Universal Question Answering System](https://www.spoj.com/problems/UQAS) | 26 | 24.00 |
+| 9691 | [Triangles and Quadrangle](https://www.spoj.com/problems/TQ) | 17 | 13.25 |

--- a/tests/spoj/index/37.jsonl
+++ b/tests/spoj/index/37.jsonl
@@ -1,0 +1,50 @@
+{"id":9692,"name":"Share the Cakes","url":"https://www.spoj.com/problems/CAKE4","users":10,"accepted":9.32}
+{"id":9693,"name":"Revenge of Fibonacci","url":"https://www.spoj.com/problems/REVFIB","users":97,"accepted":31.16}
+{"id":9694,"name":"Quelling Blade","url":"https://www.spoj.com/problems/QB","users":10,"accepted":31.58}
+{"id":9721,"name":"2s Complement","url":"https://www.spoj.com/problems/CODESPTA","users":179,"accepted":32.17}
+{"id":9722,"name":"Insertion Sort","url":"https://www.spoj.com/problems/CODESPTB","users":4072,"accepted":31.43}
+{"id":9723,"name":"Card Shuffling","url":"https://www.spoj.com/problems/CODESPTC","users":41,"accepted":26.23}
+{"id":9725,"name":"Queens on a Board","url":"https://www.spoj.com/problems/CODESPTD","users":54,"accepted":50.38}
+{"id":9734,"name":"Hacking the random number generator","url":"https://www.spoj.com/problems/HACKRNDM","users":5882,"accepted":39.02}
+{"id":9746,"name":"Bytelandian Tours","url":"https://www.spoj.com/problems/CODESPTE","users":14,"accepted":16.67}
+{"id":9748,"name":"Palindromes","url":"https://www.spoj.com/problems/CODESPTF","users":94,"accepted":26.06}
+{"id":9749,"name":"Cliques","url":"https://www.spoj.com/problems/CODESPTG","users":70,"accepted":28.68}
+{"id":9750,"name":"Polygon Diagonals","url":"https://www.spoj.com/problems/CODESPTH","users":29,"accepted":27.75}
+{"id":9751,"name":"Repairing Roads","url":"https://www.spoj.com/problems/CODESPTI","users":21,"accepted":11.02}
+{"id":9753,"name":"Tuple Division","url":"https://www.spoj.com/problems/TUPLEDIV","users":17,"accepted":3.92}
+{"id":9755,"name":"Grey Area","url":"https://www.spoj.com/problems/SCPC11A","users":301,"accepted":62.05}
+{"id":9756,"name":"Alaska","url":"https://www.spoj.com/problems/SCPC11B","users":2938,"accepted":35.86}
+{"id":9759,"name":"GO","url":"https://www.spoj.com/problems/SCPC11F","users":102,"accepted":49.05}
+{"id":9760,"name":"Indomie","url":"https://www.spoj.com/problems/SCPC11G","users":112,"accepted":47.9}
+{"id":9761,"name":"Dolls","url":"https://www.spoj.com/problems/SCPC11H","users":111,"accepted":32.25}
+{"id":9788,"name":"Friends of Friends","url":"https://www.spoj.com/problems/FACEFRND","users":7149,"accepted":63.27}
+{"id":9805,"name":"Be Awesome As Barney Stinson","url":"https://www.spoj.com/problems/BEHAPPY","users":1859,"accepted":68.29}
+{"id":9817,"name":"Shortcut","url":"https://www.spoj.com/problems/WPC4C","users":54,"accepted":25.94}
+{"id":9820,"name":"Through the troops","url":"https://www.spoj.com/problems/WPC4F","users":2055,"accepted":44.41}
+{"id":9832,"name":"Matrix inverse","url":"https://www.spoj.com/problems/MIFF","users":88,"accepted":59.49}
+{"id":9842,"name":"Yet Another Fancy Game","url":"https://www.spoj.com/problems/GAME3","users":243,"accepted":23.66}
+{"id":9856,"name":"The Glazier","url":"https://www.spoj.com/problems/GLASS","users":72,"accepted":47.16}
+{"id":9857,"name":"Eight Directions Crossword","url":"https://www.spoj.com/problems/EIGHT","users":137,"accepted":14.94}
+{"id":9858,"name":"Štef and Barica","url":"https://www.spoj.com/problems/WALK1","users":76,"accepted":37.31}
+{"id":9860,"name":"The Glazier 2","url":"https://www.spoj.com/problems/GLASS2","users":43,"accepted":64.56}
+{"id":9861,"name":"Hotels Along the Croatian Coast","url":"https://www.spoj.com/problems/HOTELS","users":9057,"accepted":41.78}
+{"id":9862,"name":"Help the Airline Company","url":"https://www.spoj.com/problems/REMOVE","users":15,"accepted":19.23}
+{"id":9887,"name":"Binomial coefficients","url":"https://www.spoj.com/problems/NWERC11A","users":170,"accepted":27.1}
+{"id":9888,"name":"Bird tree","url":"https://www.spoj.com/problems/NWERC11B","users":305,"accepted":65.36}
+{"id":9889,"name":"Movie collection","url":"https://www.spoj.com/problems/NWERC11C","users":217,"accepted":43.72}
+{"id":9890,"name":"Piece it together","url":"https://www.spoj.com/problems/NWERC11D","users":97,"accepted":24.14}
+{"id":9891,"name":"Please, go first","url":"https://www.spoj.com/problems/NWERC11E","users":221,"accepted":54.66}
+{"id":9892,"name":"Pool construction","url":"https://www.spoj.com/problems/NWERC11F","users":92,"accepted":57.26}
+{"id":9893,"name":"Smoking gun","url":"https://www.spoj.com/problems/NWERC11G","users":41,"accepted":27.46}
+{"id":9894,"name":"Tichu","url":"https://www.spoj.com/problems/NWERC11H","users":80,"accepted":38.63}
+{"id":9895,"name":"Tracking RFIDs","url":"https://www.spoj.com/problems/NWERC11I","users":52,"accepted":30.77}
+{"id":9896,"name":"Train delays","url":"https://www.spoj.com/problems/NWERC11J","users":47,"accepted":26.15}
+{"id":9916,"name":"Help Dr Whooves","url":"https://www.spoj.com/problems/PONY1","users":57,"accepted":44.65}
+{"id":9921,"name":"ABC Path","url":"https://www.spoj.com/problems/ABCPATH","users":7882,"accepted":21.89}
+{"id":9934,"name":"Alice and Bob","url":"https://www.spoj.com/problems/ALICE","users":163,"accepted":34.48}
+{"id":9935,"name":"Break the Chocolate","url":"https://www.spoj.com/problems/BC","users":1655,"accepted":34.58}
+{"id":9936,"name":"Construct the Great Wall","url":"https://www.spoj.com/problems/CGW","users":13,"accepted":42.86}
+{"id":9938,"name":"Disney Fastpass","url":"https://www.spoj.com/problems/DISNEY","users":37,"accepted":25.32}
+{"id":9939,"name":"Eliminate the Conﬂict","url":"https://www.spoj.com/problems/EC","users":50,"accepted":39.59}
+{"id":9940,"name":"Fruit Ninja","url":"https://www.spoj.com/problems/FNINJA","users":41,"accepted":27.73}
+{"id":9941,"name":"GRE Words","url":"https://www.spoj.com/problems/GRE","users":129,"accepted":20.7}

--- a/tests/spoj/index/37.md
+++ b/tests/spoj/index/37.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 9692 | [Share the Cakes](https://www.spoj.com/problems/CAKE4) | 10 | 9.32 |
+| 9693 | [Revenge of Fibonacci](https://www.spoj.com/problems/REVFIB) | 97 | 31.16 |
+| 9694 | [Quelling Blade](https://www.spoj.com/problems/QB) | 10 | 31.58 |
+| 9721 | [2s Complement](https://www.spoj.com/problems/CODESPTA) | 179 | 32.17 |
+| 9722 | [Insertion Sort](https://www.spoj.com/problems/CODESPTB) | 4072 | 31.43 |
+| 9723 | [Card Shuffling](https://www.spoj.com/problems/CODESPTC) | 41 | 26.23 |
+| 9725 | [Queens on a Board](https://www.spoj.com/problems/CODESPTD) | 54 | 50.38 |
+| 9734 | [Hacking the random number generator](https://www.spoj.com/problems/HACKRNDM) | 5882 | 39.02 |
+| 9746 | [Bytelandian Tours](https://www.spoj.com/problems/CODESPTE) | 14 | 16.67 |
+| 9748 | [Palindromes](https://www.spoj.com/problems/CODESPTF) | 94 | 26.06 |
+| 9749 | [Cliques](https://www.spoj.com/problems/CODESPTG) | 70 | 28.68 |
+| 9750 | [Polygon Diagonals](https://www.spoj.com/problems/CODESPTH) | 29 | 27.75 |
+| 9751 | [Repairing Roads](https://www.spoj.com/problems/CODESPTI) | 21 | 11.02 |
+| 9753 | [Tuple Division](https://www.spoj.com/problems/TUPLEDIV) | 17 | 3.92 |
+| 9755 | [Grey Area](https://www.spoj.com/problems/SCPC11A) | 301 | 62.05 |
+| 9756 | [Alaska](https://www.spoj.com/problems/SCPC11B) | 2938 | 35.86 |
+| 9759 | [GO](https://www.spoj.com/problems/SCPC11F) | 102 | 49.05 |
+| 9760 | [Indomie](https://www.spoj.com/problems/SCPC11G) | 112 | 47.90 |
+| 9761 | [Dolls](https://www.spoj.com/problems/SCPC11H) | 111 | 32.25 |
+| 9788 | [Friends of Friends](https://www.spoj.com/problems/FACEFRND) | 7149 | 63.27 |
+| 9805 | [Be Awesome As Barney Stinson](https://www.spoj.com/problems/BEHAPPY) | 1859 | 68.29 |
+| 9817 | [Shortcut](https://www.spoj.com/problems/WPC4C) | 54 | 25.94 |
+| 9820 | [Through the troops](https://www.spoj.com/problems/WPC4F) | 2055 | 44.41 |
+| 9832 | [Matrix inverse](https://www.spoj.com/problems/MIFF) | 88 | 59.49 |
+| 9842 | [Yet Another Fancy Game](https://www.spoj.com/problems/GAME3) | 243 | 23.66 |
+| 9856 | [The Glazier](https://www.spoj.com/problems/GLASS) | 72 | 47.16 |
+| 9857 | [Eight Directions Crossword](https://www.spoj.com/problems/EIGHT) | 137 | 14.94 |
+| 9858 | [Štef and Barica](https://www.spoj.com/problems/WALK1) | 76 | 37.31 |
+| 9860 | [The Glazier 2](https://www.spoj.com/problems/GLASS2) | 43 | 64.56 |
+| 9861 | [Hotels Along the Croatian Coast](https://www.spoj.com/problems/HOTELS) | 9057 | 41.78 |
+| 9862 | [Help the Airline Company](https://www.spoj.com/problems/REMOVE) | 15 | 19.23 |
+| 9887 | [Binomial coefficients](https://www.spoj.com/problems/NWERC11A) | 170 | 27.10 |
+| 9888 | [Bird tree](https://www.spoj.com/problems/NWERC11B) | 305 | 65.36 |
+| 9889 | [Movie collection](https://www.spoj.com/problems/NWERC11C) | 217 | 43.72 |
+| 9890 | [Piece it together](https://www.spoj.com/problems/NWERC11D) | 97 | 24.14 |
+| 9891 | [Please, go first](https://www.spoj.com/problems/NWERC11E) | 221 | 54.66 |
+| 9892 | [Pool construction](https://www.spoj.com/problems/NWERC11F) | 92 | 57.26 |
+| 9893 | [Smoking gun](https://www.spoj.com/problems/NWERC11G) | 41 | 27.46 |
+| 9894 | [Tichu](https://www.spoj.com/problems/NWERC11H) | 80 | 38.63 |
+| 9895 | [Tracking RFIDs](https://www.spoj.com/problems/NWERC11I) | 52 | 30.77 |
+| 9896 | [Train delays](https://www.spoj.com/problems/NWERC11J) | 47 | 26.15 |
+| 9916 | [Help Dr Whooves](https://www.spoj.com/problems/PONY1) | 57 | 44.65 |
+| 9921 | [ABC Path](https://www.spoj.com/problems/ABCPATH) | 7882 | 21.89 |
+| 9934 | [Alice and Bob](https://www.spoj.com/problems/ALICE) | 163 | 34.48 |
+| 9935 | [Break the Chocolate](https://www.spoj.com/problems/BC) | 1655 | 34.58 |
+| 9936 | [Construct the Great Wall](https://www.spoj.com/problems/CGW) | 13 | 42.86 |
+| 9938 | [Disney Fastpass](https://www.spoj.com/problems/DISNEY) | 37 | 25.32 |
+| 9939 | [Eliminate the Conﬂict](https://www.spoj.com/problems/EC) | 50 | 39.59 |
+| 9940 | [Fruit Ninja](https://www.spoj.com/problems/FNINJA) | 41 | 27.73 |
+| 9941 | [GRE Words](https://www.spoj.com/problems/GRE) | 129 | 20.70 |

--- a/tests/spoj/index/38.jsonl
+++ b/tests/spoj/index/38.jsonl
@@ -1,0 +1,50 @@
+{"id":9942,"name":"Holiday Accommodation","url":"https://www.spoj.com/problems/HOLI","users":1117,"accepted":26.13}
+{"id":9943,"name":"Isabella Message","url":"https://www.spoj.com/problems/ISAB","users":69,"accepted":24.22}
+{"id":9944,"name":"Ji-Tu Problem","url":"https://www.spoj.com/problems/JITU","users":17,"accepted":11.23}
+{"id":9948,"name":"Will it ever stop","url":"https://www.spoj.com/problems/WILLITST","users":17944,"accepted":43.01}
+{"id":9950,"name":"IQ Team","url":"https://www.spoj.com/problems/IQTEAM","users":44,"accepted":43.31}
+{"id":9952,"name":"111…1 Squared","url":"https://www.spoj.com/problems/GUANGGUN","users":1793,"accepted":46.4}
+{"id":9964,"name":"Fibonacci vs Polynomial","url":"https://www.spoj.com/problems/PIBO","users":130,"accepted":40.9}
+{"id":9967,"name":"Playing with Words","url":"https://www.spoj.com/problems/PWORDS","users":36,"accepted":31.95}
+{"id":9968,"name":"Magic Crystals and Laser Beams","url":"https://www.spoj.com/problems/MCLB","users":179,"accepted":23.53}
+{"id":9969,"name":"Road Network","url":"https://www.spoj.com/problems/RDNWK","users":307,"accepted":21.94}
+{"id":9970,"name":"The Egyptian Parliament","url":"https://www.spoj.com/problems/EGYPAR","users":50,"accepted":18.91}
+{"id":9971,"name":"Adventurous Chess Masters","url":"https://www.spoj.com/problems/ACHESS","users":25,"accepted":45.16}
+{"id":9972,"name":"The SKey","url":"https://www.spoj.com/problems/SKEY","users":84,"accepted":16.62}
+{"id":9973,"name":"Problem Set Score","url":"https://www.spoj.com/problems/PROSCORE","users":918,"accepted":39.55}
+{"id":9974,"name":"Men From Mars","url":"https://www.spoj.com/problems/MENMARS","users":22,"accepted":37.7}
+{"id":9975,"name":"No Stories Any More!","url":"https://www.spoj.com/problems/FSEQ","users":48,"accepted":30.28}
+{"id":9985,"name":"Distance","url":"https://www.spoj.com/problems/DISTX","users":63,"accepted":23.06}
+{"id":10050,"name":"Power Tower City","url":"https://www.spoj.com/problems/POWTOW","users":146,"accepted":66.89}
+{"id":10069,"name":"Kompići","url":"https://www.spoj.com/problems/KOMPICI","users":842,"accepted":68.47}
+{"id":10070,"name":"Trick or Treat","url":"https://www.spoj.com/problems/TRICKTRT","users":253,"accepted":67}
+{"id":10071,"name":"Working at the Restaurant","url":"https://www.spoj.com/problems/RESTAURN","users":39,"accepted":40.38}
+{"id":10072,"name":"Lights","url":"https://www.spoj.com/problems/LIGHTS2","users":63,"accepted":47.47}
+{"id":10073,"name":"Darts","url":"https://www.spoj.com/problems/DARTS","users":37,"accepted":60}
+{"id":10074,"name":"Genetics","url":"https://www.spoj.com/problems/GENETIC2","users":9,"accepted":33.33}
+{"id":10075,"name":"Haunted Graveyard","url":"https://www.spoj.com/problems/GRAVEYRD","users":42,"accepted":19.17}
+{"id":10076,"name":"Slalom","url":"https://www.spoj.com/problems/SLALOM2","users":32,"accepted":33.67}
+{"id":10077,"name":"Routing","url":"https://www.spoj.com/problems/ROUTING","users":23,"accepted":43.55}
+{"id":10078,"name":"Happy Telephones","url":"https://www.spoj.com/problems/HAPPYTL","users":294,"accepted":48.89}
+{"id":10079,"name":"Stammering Aliens","url":"https://www.spoj.com/problems/STAMMER","users":167,"accepted":32.18}
+{"id":10080,"name":"Lawn Mower","url":"https://www.spoj.com/problems/LAWNMWR","users":231,"accepted":52.57}
+{"id":10081,"name":"Periodic Points","url":"https://www.spoj.com/problems/PERIODIC","users":12,"accepted":35.9}
+{"id":10082,"name":"Comparing Answers","url":"https://www.spoj.com/problems/CMPANS","users":64,"accepted":13.14}
+{"id":10084,"name":"Fake Scoreboard","url":"https://www.spoj.com/problems/FAKESCOR","users":24,"accepted":45.95}
+{"id":10085,"name":"Palindromic DNA","url":"https://www.spoj.com/problems/PALINDNA","users":20,"accepted":27.78}
+{"id":10086,"name":"Jumping Monkey","url":"https://www.spoj.com/problems/JMPMNKEY","users":59,"accepted":25.95}
+{"id":10087,"name":"Sensor Network","url":"https://www.spoj.com/problems/SENSORNT","users":27,"accepted":20.95}
+{"id":10088,"name":"Assembly Line","url":"https://www.spoj.com/problems/ASSEMBLY","users":37,"accepted":33.33}
+{"id":10089,"name":"Locks and Keys","url":"https://www.spoj.com/problems/LOCKKEY","users":18,"accepted":33.73}
+{"id":10091,"name":"Three-sided Dice","url":"https://www.spoj.com/problems/DICE","users":31,"accepted":22}
+{"id":10092,"name":"Party Night","url":"https://www.spoj.com/problems/PRTYNGHT","users":30,"accepted":30}
+{"id":10095,"name":"Caper Pizza","url":"https://www.spoj.com/problems/CAPPIZZA","users":29,"accepted":26.47}
+{"id":10096,"name":"Lights (Extreme)","url":"https://www.spoj.com/problems/LIGHTS3","users":56,"accepted":29.8}
+{"id":10105,"name":"Alphabet Soup","url":"https://www.spoj.com/problems/ALPHSOUP","users":31,"accepted":42.57}
+{"id":10106,"name":"Coin Collecting","url":"https://www.spoj.com/problems/COIN","users":48,"accepted":35.03}
+{"id":10107,"name":"Cybercrime Donut Investigation","url":"https://www.spoj.com/problems/DONUT","users":56,"accepted":25.17}
+{"id":10108,"name":"Distributing Ballot Boxes","url":"https://www.spoj.com/problems/BALLOT","users":1165,"accepted":36.21}
+{"id":10109,"name":"Game, Set and Match","url":"https://www.spoj.com/problems/GSM","users":100,"accepted":65.96}
+{"id":10110,"name":"Guess the Numbers","url":"https://www.spoj.com/problems/GUESSNM2","users":124,"accepted":44.36}
+{"id":10111,"name":"Nonnegative Partial Sums","url":"https://www.spoj.com/problems/PARSUMS","users":534,"accepted":30.05}
+{"id":10112,"name":"Peer Review","url":"https://www.spoj.com/problems/REVIEW","users":116,"accepted":32.79}

--- a/tests/spoj/index/38.md
+++ b/tests/spoj/index/38.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 9942 | [Holiday Accommodation](https://www.spoj.com/problems/HOLI) | 1117 | 26.13 |
+| 9943 | [Isabella Message](https://www.spoj.com/problems/ISAB) | 69 | 24.22 |
+| 9944 | [Ji-Tu Problem](https://www.spoj.com/problems/JITU) | 17 | 11.23 |
+| 9948 | [Will it ever stop](https://www.spoj.com/problems/WILLITST) | 17944 | 43.01 |
+| 9950 | [IQ Team](https://www.spoj.com/problems/IQTEAM) | 44 | 43.31 |
+| 9952 | [111…1 Squared](https://www.spoj.com/problems/GUANGGUN) | 1793 | 46.40 |
+| 9964 | [Fibonacci vs Polynomial](https://www.spoj.com/problems/PIBO) | 130 | 40.90 |
+| 9967 | [Playing with Words](https://www.spoj.com/problems/PWORDS) | 36 | 31.95 |
+| 9968 | [Magic Crystals and Laser Beams](https://www.spoj.com/problems/MCLB) | 179 | 23.53 |
+| 9969 | [Road Network](https://www.spoj.com/problems/RDNWK) | 307 | 21.94 |
+| 9970 | [The Egyptian Parliament](https://www.spoj.com/problems/EGYPAR) | 50 | 18.91 |
+| 9971 | [Adventurous Chess Masters](https://www.spoj.com/problems/ACHESS) | 25 | 45.16 |
+| 9972 | [The SKey](https://www.spoj.com/problems/SKEY) | 84 | 16.62 |
+| 9973 | [Problem Set Score](https://www.spoj.com/problems/PROSCORE) | 918 | 39.55 |
+| 9974 | [Men From Mars](https://www.spoj.com/problems/MENMARS) | 22 | 37.70 |
+| 9975 | [No Stories Any More!](https://www.spoj.com/problems/FSEQ) | 48 | 30.28 |
+| 9985 | [Distance](https://www.spoj.com/problems/DISTX) | 63 | 23.06 |
+| 10050 | [Power Tower City](https://www.spoj.com/problems/POWTOW) | 146 | 66.89 |
+| 10069 | [Kompići](https://www.spoj.com/problems/KOMPICI) | 842 | 68.47 |
+| 10070 | [Trick or Treat](https://www.spoj.com/problems/TRICKTRT) | 253 | 67.00 |
+| 10071 | [Working at the Restaurant](https://www.spoj.com/problems/RESTAURN) | 39 | 40.38 |
+| 10072 | [Lights](https://www.spoj.com/problems/LIGHTS2) | 63 | 47.47 |
+| 10073 | [Darts](https://www.spoj.com/problems/DARTS) | 37 | 60.00 |
+| 10074 | [Genetics](https://www.spoj.com/problems/GENETIC2) | 9 | 33.33 |
+| 10075 | [Haunted Graveyard](https://www.spoj.com/problems/GRAVEYRD) | 42 | 19.17 |
+| 10076 | [Slalom](https://www.spoj.com/problems/SLALOM2) | 32 | 33.67 |
+| 10077 | [Routing](https://www.spoj.com/problems/ROUTING) | 23 | 43.55 |
+| 10078 | [Happy Telephones](https://www.spoj.com/problems/HAPPYTL) | 294 | 48.89 |
+| 10079 | [Stammering Aliens](https://www.spoj.com/problems/STAMMER) | 167 | 32.18 |
+| 10080 | [Lawn Mower](https://www.spoj.com/problems/LAWNMWR) | 231 | 52.57 |
+| 10081 | [Periodic Points](https://www.spoj.com/problems/PERIODIC) | 12 | 35.90 |
+| 10082 | [Comparing Answers](https://www.spoj.com/problems/CMPANS) | 64 | 13.14 |
+| 10084 | [Fake Scoreboard](https://www.spoj.com/problems/FAKESCOR) | 24 | 45.95 |
+| 10085 | [Palindromic DNA](https://www.spoj.com/problems/PALINDNA) | 20 | 27.78 |
+| 10086 | [Jumping Monkey](https://www.spoj.com/problems/JMPMNKEY) | 59 | 25.95 |
+| 10087 | [Sensor Network](https://www.spoj.com/problems/SENSORNT) | 27 | 20.95 |
+| 10088 | [Assembly Line](https://www.spoj.com/problems/ASSEMBLY) | 37 | 33.33 |
+| 10089 | [Locks and Keys](https://www.spoj.com/problems/LOCKKEY) | 18 | 33.73 |
+| 10091 | [Three-sided Dice](https://www.spoj.com/problems/DICE) | 31 | 22.00 |
+| 10092 | [Party Night](https://www.spoj.com/problems/PRTYNGHT) | 30 | 30.00 |
+| 10095 | [Caper Pizza](https://www.spoj.com/problems/CAPPIZZA) | 29 | 26.47 |
+| 10096 | [Lights (Extreme)](https://www.spoj.com/problems/LIGHTS3) | 56 | 29.80 |
+| 10105 | [Alphabet Soup](https://www.spoj.com/problems/ALPHSOUP) | 31 | 42.57 |
+| 10106 | [Coin Collecting](https://www.spoj.com/problems/COIN) | 48 | 35.03 |
+| 10107 | [Cybercrime Donut Investigation](https://www.spoj.com/problems/DONUT) | 56 | 25.17 |
+| 10108 | [Distributing Ballot Boxes](https://www.spoj.com/problems/BALLOT) | 1165 | 36.21 |
+| 10109 | [Game, Set and Match](https://www.spoj.com/problems/GSM) | 100 | 65.96 |
+| 10110 | [Guess the Numbers](https://www.spoj.com/problems/GUESSNM2) | 124 | 44.36 |
+| 10111 | [Nonnegative Partial Sums](https://www.spoj.com/problems/PARSUMS) | 534 | 30.05 |
+| 10112 | [Peer Review](https://www.spoj.com/problems/REVIEW) | 116 | 32.79 |

--- a/tests/spoj/index/39.jsonl
+++ b/tests/spoj/index/39.jsonl
@@ -1,0 +1,50 @@
+{"id":10113,"name":"Regular Convex Polygon","url":"https://www.spoj.com/problems/REGPOLYG","users":101,"accepted":30.4}
+{"id":10114,"name":"Remoteland","url":"https://www.spoj.com/problems/RMTLAND","users":135,"accepted":56}
+{"id":10128,"name":"Treasures and Vikings","url":"https://www.spoj.com/problems/TANDV","users":82,"accepted":25.06}
+{"id":10141,"name":"STRAZA","url":"https://www.spoj.com/problems/STRAZA","users":48,"accepted":40}
+{"id":10145,"name":"Birthday Cake","url":"https://www.spoj.com/problems/BCAKE","users":260,"accepted":36.32}
+{"id":10186,"name":"Divisor Digits","url":"https://www.spoj.com/problems/PUCMM025","users":1290,"accepted":30.93}
+{"id":10210,"name":"After Party Transfers","url":"https://www.spoj.com/problems/TRANSFER","users":39,"accepted":4.99}
+{"id":10228,"name":"Magic Grid","url":"https://www.spoj.com/problems/AMR11A","users":1802,"accepted":26.43}
+{"id":10229,"name":"Save the Students","url":"https://www.spoj.com/problems/AMR11B","users":182,"accepted":25.94}
+{"id":10230,"name":"Robbing Gringotts","url":"https://www.spoj.com/problems/AMR11C","users":56,"accepted":11.07}
+{"id":10231,"name":"Wizarding Duel","url":"https://www.spoj.com/problems/AMR11D","users":75,"accepted":19.48}
+{"id":10232,"name":"Distinct Primes","url":"https://www.spoj.com/problems/AMR11E","users":5928,"accepted":45.49}
+{"id":10233,"name":"Magical Bridges","url":"https://www.spoj.com/problems/AMR11F","users":170,"accepted":27.03}
+{"id":10235,"name":"Array Diversity","url":"https://www.spoj.com/problems/AMR11H","users":192,"accepted":23.96}
+{"id":10236,"name":"Generations","url":"https://www.spoj.com/problems/AMR11I","users":57,"accepted":20.53}
+{"id":10237,"name":"Goblin Wars","url":"https://www.spoj.com/problems/AMR11J","users":408,"accepted":25.98}
+{"id":10239,"name":"Between the Mountains","url":"https://www.spoj.com/problems/ACPC11B","users":5822,"accepted":39.21}
+{"id":10240,"name":"Circleland","url":"https://www.spoj.com/problems/ACPC11C","users":713,"accepted":31.9}
+{"id":10242,"name":"Dice on a Board","url":"https://www.spoj.com/problems/ACPC11D","users":20,"accepted":31.76}
+{"id":10264,"name":"Meteors","url":"https://www.spoj.com/problems/METEORS","users":1622,"accepted":28.01}
+{"id":10265,"name":"Subdivision of the kingdom","url":"https://www.spoj.com/problems/DIVIDEKR","users":40,"accepted":29.56}
+{"id":10270,"name":"Temperature","url":"https://www.spoj.com/problems/TEMPERAT","users":279,"accepted":34.9}
+{"id":10283,"name":"ALL IZZ WELL","url":"https://www.spoj.com/problems/ALLIZWEL","users":3491,"accepted":31.38}
+{"id":10285,"name":"Why this kolaveri di","url":"https://www.spoj.com/problems/WTK","users":1430,"accepted":53.2}
+{"id":10286,"name":"DOTA HEROES","url":"https://www.spoj.com/problems/DOTAA","users":6106,"accepted":44.9}
+{"id":10292,"name":"Shell game","url":"https://www.spoj.com/problems/SHELL","users":504,"accepted":19.05}
+{"id":10293,"name":"FANCY NUMBERS","url":"https://www.spoj.com/problems/FANCY","users":1731,"accepted":50.15}
+{"id":10328,"name":"TRIVIADOR","url":"https://www.spoj.com/problems/TWOKINGS","users":174,"accepted":31.47}
+{"id":10334,"name":"SOLDIERS","url":"https://www.spoj.com/problems/SOLDIERS","users":755,"accepted":28.51}
+{"id":10346,"name":"Streets of distortion","url":"https://www.spoj.com/problems/DISTO","users":111,"accepted":37.71}
+{"id":10354,"name":"Count Strings","url":"https://www.spoj.com/problems/CTSTRING","users":29,"accepted":4.44}
+{"id":10355,"name":"Coin Tosses","url":"https://www.spoj.com/problems/COINTOSS","users":398,"accepted":34.06}
+{"id":10366,"name":"Play with Dates","url":"https://www.spoj.com/problems/CODEIT03","users":1433,"accepted":38.74}
+{"id":10376,"name":"String Factorization!","url":"https://www.spoj.com/problems/ABA12B","users":47,"accepted":10.76}
+{"id":10377,"name":"project groups","url":"https://www.spoj.com/problems/MECGROUP","users":132,"accepted":51.55}
+{"id":10380,"name":"prayatna PR","url":"https://www.spoj.com/problems/CAM5","users":5302,"accepted":43.08}
+{"id":10381,"name":"Search in the dictionary!","url":"https://www.spoj.com/problems/DICT","users":1435,"accepted":26.12}
+{"id":10394,"name":"Buying Apples!","url":"https://www.spoj.com/problems/ABA12C","users":5609,"accepted":34.87}
+{"id":10395,"name":"Sum of divisors!","url":"https://www.spoj.com/problems/ABA12D","users":2383,"accepted":27.06}
+{"id":10399,"name":"Conga line","url":"https://www.spoj.com/problems/CONGA","users":369,"accepted":36.43}
+{"id":10401,"name":"Aliens at the train","url":"https://www.spoj.com/problems/ALIEN","users":4476,"accepted":29.28}
+{"id":10405,"name":"Shooting the balloons!","url":"https://www.spoj.com/problems/ABA12E","users":345,"accepted":35.95}
+{"id":10415,"name":"Dracula","url":"https://www.spoj.com/problems/DRACULA","users":145,"accepted":22.25}
+{"id":10416,"name":"Van Helsings gun","url":"https://www.spoj.com/problems/VHELSING","users":1445,"accepted":54.45}
+{"id":10419,"name":"Polish Language","url":"https://www.spoj.com/problems/POLISH","users":104,"accepted":26.31}
+{"id":10420,"name":"Hardware upgrade","url":"https://www.spoj.com/problems/IOPC1200","users":55,"accepted":30.04}
+{"id":10421,"name":"Run, Snipe, Run","url":"https://www.spoj.com/problems/SNIPE","users":76,"accepted":30.09}
+{"id":10422,"name":"Rubiks cube","url":"https://www.spoj.com/problems/IOPC1201","users":58,"accepted":44.63}
+{"id":10424,"name":"To Poland","url":"https://www.spoj.com/problems/TOPOLAND","users":272,"accepted":30.5}
+{"id":10425,"name":"Security System","url":"https://www.spoj.com/problems/SECSYS","users":29,"accepted":53.42}

--- a/tests/spoj/index/39.md
+++ b/tests/spoj/index/39.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 10113 | [Regular Convex Polygon](https://www.spoj.com/problems/REGPOLYG) | 101 | 30.40 |
+| 10114 | [Remoteland](https://www.spoj.com/problems/RMTLAND) | 135 | 56.00 |
+| 10128 | [Treasures and Vikings](https://www.spoj.com/problems/TANDV) | 82 | 25.06 |
+| 10141 | [STRAZA](https://www.spoj.com/problems/STRAZA) | 48 | 40.00 |
+| 10145 | [Birthday Cake](https://www.spoj.com/problems/BCAKE) | 260 | 36.32 |
+| 10186 | [Divisor Digits](https://www.spoj.com/problems/PUCMM025) | 1290 | 30.93 |
+| 10210 | [After Party Transfers](https://www.spoj.com/problems/TRANSFER) | 39 | 4.99 |
+| 10228 | [Magic Grid](https://www.spoj.com/problems/AMR11A) | 1802 | 26.43 |
+| 10229 | [Save the Students](https://www.spoj.com/problems/AMR11B) | 182 | 25.94 |
+| 10230 | [Robbing Gringotts](https://www.spoj.com/problems/AMR11C) | 56 | 11.07 |
+| 10231 | [Wizarding Duel](https://www.spoj.com/problems/AMR11D) | 75 | 19.48 |
+| 10232 | [Distinct Primes](https://www.spoj.com/problems/AMR11E) | 5928 | 45.49 |
+| 10233 | [Magical Bridges](https://www.spoj.com/problems/AMR11F) | 170 | 27.03 |
+| 10235 | [Array Diversity](https://www.spoj.com/problems/AMR11H) | 192 | 23.96 |
+| 10236 | [Generations](https://www.spoj.com/problems/AMR11I) | 57 | 20.53 |
+| 10237 | [Goblin Wars](https://www.spoj.com/problems/AMR11J) | 408 | 25.98 |
+| 10239 | [Between the Mountains](https://www.spoj.com/problems/ACPC11B) | 5822 | 39.21 |
+| 10240 | [Circleland](https://www.spoj.com/problems/ACPC11C) | 713 | 31.90 |
+| 10242 | [Dice on a Board](https://www.spoj.com/problems/ACPC11D) | 20 | 31.76 |
+| 10264 | [Meteors](https://www.spoj.com/problems/METEORS) | 1622 | 28.01 |
+| 10265 | [Subdivision of the kingdom](https://www.spoj.com/problems/DIVIDEKR) | 40 | 29.56 |
+| 10270 | [Temperature](https://www.spoj.com/problems/TEMPERAT) | 279 | 34.90 |
+| 10283 | [ALL IZZ WELL](https://www.spoj.com/problems/ALLIZWEL) | 3491 | 31.38 |
+| 10285 | [Why this kolaveri di](https://www.spoj.com/problems/WTK) | 1430 | 53.20 |
+| 10286 | [DOTA HEROES](https://www.spoj.com/problems/DOTAA) | 6106 | 44.90 |
+| 10292 | [Shell game](https://www.spoj.com/problems/SHELL) | 504 | 19.05 |
+| 10293 | [FANCY NUMBERS](https://www.spoj.com/problems/FANCY) | 1731 | 50.15 |
+| 10328 | [TRIVIADOR](https://www.spoj.com/problems/TWOKINGS) | 174 | 31.47 |
+| 10334 | [SOLDIERS](https://www.spoj.com/problems/SOLDIERS) | 755 | 28.51 |
+| 10346 | [Streets of distortion](https://www.spoj.com/problems/DISTO) | 111 | 37.71 |
+| 10354 | [Count Strings](https://www.spoj.com/problems/CTSTRING) | 29 | 4.44 |
+| 10355 | [Coin Tosses](https://www.spoj.com/problems/COINTOSS) | 398 | 34.06 |
+| 10366 | [Play with Dates](https://www.spoj.com/problems/CODEIT03) | 1433 | 38.74 |
+| 10376 | [String Factorization!](https://www.spoj.com/problems/ABA12B) | 47 | 10.76 |
+| 10377 | [project groups](https://www.spoj.com/problems/MECGROUP) | 132 | 51.55 |
+| 10380 | [prayatna PR](https://www.spoj.com/problems/CAM5) | 5302 | 43.08 |
+| 10381 | [Search in the dictionary!](https://www.spoj.com/problems/DICT) | 1435 | 26.12 |
+| 10394 | [Buying Apples!](https://www.spoj.com/problems/ABA12C) | 5609 | 34.87 |
+| 10395 | [Sum of divisors!](https://www.spoj.com/problems/ABA12D) | 2383 | 27.06 |
+| 10399 | [Conga line](https://www.spoj.com/problems/CONGA) | 369 | 36.43 |
+| 10401 | [Aliens at the train](https://www.spoj.com/problems/ALIEN) | 4476 | 29.28 |
+| 10405 | [Shooting the balloons!](https://www.spoj.com/problems/ABA12E) | 345 | 35.95 |
+| 10415 | [Dracula](https://www.spoj.com/problems/DRACULA) | 145 | 22.25 |
+| 10416 | [Van Helsings gun](https://www.spoj.com/problems/VHELSING) | 1445 | 54.45 |
+| 10419 | [Polish Language](https://www.spoj.com/problems/POLISH) | 104 | 26.31 |
+| 10420 | [Hardware upgrade](https://www.spoj.com/problems/IOPC1200) | 55 | 30.04 |
+| 10421 | [Run, Snipe, Run](https://www.spoj.com/problems/SNIPE) | 76 | 30.09 |
+| 10422 | [Rubiks cube](https://www.spoj.com/problems/IOPC1201) | 58 | 44.63 |
+| 10424 | [To Poland](https://www.spoj.com/problems/TOPOLAND) | 272 | 30.50 |
+| 10425 | [Security System](https://www.spoj.com/problems/SECSYS) | 29 | 53.42 |

--- a/tests/spoj/index/40.jsonl
+++ b/tests/spoj/index/40.jsonl
@@ -1,0 +1,50 @@
+{"id":10437,"name":"Quadrilaterals","url":"https://www.spoj.com/problems/IOPC1202","users":75,"accepted":25.42}
+{"id":10438,"name":"Crazy texting","url":"https://www.spoj.com/problems/IOPC1203","users":174,"accepted":25.98}
+{"id":10439,"name":"Walking Robot","url":"https://www.spoj.com/problems/WALKROBO","users":114,"accepted":46.15}
+{"id":10440,"name":"Friends","url":"https://www.spoj.com/problems/FRNDS","users":38,"accepted":20.42}
+{"id":10442,"name":"Candy Distribution","url":"https://www.spoj.com/problems/CADYDIST","users":3931,"accepted":37.55}
+{"id":10443,"name":"Bridges","url":"https://www.spoj.com/problems/BRDGS","users":2,"accepted":2.82}
+{"id":10444,"name":"Coding","url":"https://www.spoj.com/problems/CODING2","users":101,"accepted":35.61}
+{"id":10446,"name":"Sicrano","url":"https://www.spoj.com/problems/SICRANO","users":511,"accepted":23.74}
+{"id":10447,"name":"Contaminated City","url":"https://www.spoj.com/problems/CONTCITY","users":70,"accepted":13.74}
+{"id":10449,"name":"Resource Management","url":"https://www.spoj.com/problems/RESOURCE","users":15,"accepted":18}
+{"id":10450,"name":"Amoeba","url":"https://www.spoj.com/problems/AMOEBA","users":101,"accepted":17.24}
+{"id":10451,"name":"Stun Boosting","url":"https://www.spoj.com/problems/STUN","users":19,"accepted":25.68}
+{"id":10452,"name":"Caprica Cities","url":"https://www.spoj.com/problems/CAPRICA","users":165,"accepted":38.31}
+{"id":10453,"name":"Spring Loaded","url":"https://www.spoj.com/problems/SPRING","users":160,"accepted":31.3}
+{"id":10454,"name":"Greens Land","url":"https://www.spoj.com/problems/GREENLAN","users":100,"accepted":28.54}
+{"id":10460,"name":"A function over factors","url":"https://www.spoj.com/problems/IOPC1204","users":102,"accepted":32.78}
+{"id":10461,"name":"The magical escape","url":"https://www.spoj.com/problems/IOPC1205","users":31,"accepted":40.52}
+{"id":10463,"name":"COUNT PAREN","url":"https://www.spoj.com/problems/PAREN","users":194,"accepted":60.61}
+{"id":10464,"name":"Reverse Engineering","url":"https://www.spoj.com/problems/RE1","users":142,"accepted":48.93}
+{"id":10465,"name":"One Theorem, One Year","url":"https://www.spoj.com/problems/OTOY1","users":50,"accepted":43.62}
+{"id":10466,"name":"Enough of analyzing, let’s play","url":"https://www.spoj.com/problems/EALP1","users":262,"accepted":45.78}
+{"id":10471,"name":"Aliens at the train, again!","url":"https://www.spoj.com/problems/ALIEN2","users":815,"accepted":44.66}
+{"id":10476,"name":"Fair bases","url":"https://www.spoj.com/problems/IOPC1206","users":38,"accepted":32.69}
+{"id":10477,"name":"GM plants","url":"https://www.spoj.com/problems/IOPC1207","users":344,"accepted":29.22}
+{"id":10500,"name":"Haybale stacking","url":"https://www.spoj.com/problems/HAYBALE","users":4023,"accepted":34.69}
+{"id":10502,"name":"Video game combos","url":"https://www.spoj.com/problems/VIDEO","users":397,"accepted":38.27}
+{"id":10506,"name":"Prendonians","url":"https://www.spoj.com/problems/PRENDON","users":52,"accepted":26.42}
+{"id":10507,"name":"Cheese-rolling World Cup","url":"https://www.spoj.com/problems/CHEESE","users":57,"accepted":33.18}
+{"id":10508,"name":"Buttons","url":"https://www.spoj.com/problems/BTTNS","users":47,"accepted":24.03}
+{"id":10509,"name":"Cards","url":"https://www.spoj.com/problems/CRDS","users":13536,"accepted":34.03}
+{"id":10510,"name":"Sorting Machine","url":"https://www.spoj.com/problems/SRTMACH","users":28,"accepted":44.44}
+{"id":10514,"name":"K12 - Building Construction","url":"https://www.spoj.com/problems/KOPC12A","users":2068,"accepted":26.47}
+{"id":10515,"name":"K12-Combinations","url":"https://www.spoj.com/problems/KOPC12B","users":412,"accepted":28.02}
+{"id":10517,"name":"K12-Generating Big Numbers II","url":"https://www.spoj.com/problems/KOPC12D","users":83,"accepted":45.02}
+{"id":10519,"name":"K12-Bored of Suffixes and Prefixes","url":"https://www.spoj.com/problems/KOPC12G","users":96,"accepted":43.49}
+{"id":10522,"name":"K12-OE Numbers","url":"https://www.spoj.com/problems/KOPC12H","users":238,"accepted":50.18}
+{"id":10537,"name":"Edit Distance Again","url":"https://www.spoj.com/problems/EDIT","users":2546,"accepted":42.24}
+{"id":10538,"name":"Derp","url":"https://www.spoj.com/problems/DERP","users":61,"accepted":40}
+{"id":10539,"name":"Bunnies","url":"https://www.spoj.com/problems/BUNNIES","users":36,"accepted":11.34}
+{"id":10547,"name":"Delivery Route","url":"https://www.spoj.com/problems/DELIVER","users":63,"accepted":19.24}
+{"id":10557,"name":"MINI IN DANGER!!!","url":"https://www.spoj.com/problems/MINI","users":34,"accepted":46.9}
+{"id":10565,"name":"Alice Sieve","url":"https://www.spoj.com/problems/ALICESIE","users":5079,"accepted":53.39}
+{"id":10568,"name":"Graph Cut","url":"https://www.spoj.com/problems/GRAPHCUT","users":112,"accepted":38.16}
+{"id":10570,"name":"Longest Common Substring","url":"https://www.spoj.com/problems/LONGCS","users":920,"accepted":30.38}
+{"id":10571,"name":"Soccer Challenge","url":"https://www.spoj.com/problems/SOCCERCH","users":30,"accepted":34.78}
+{"id":10572,"name":"Cheating on the contest","url":"https://www.spoj.com/problems/CHEATCON","users":30,"accepted":7.4}
+{"id":10573,"name":"Problem Offensive Strategy","url":"https://www.spoj.com/problems/OFFSTRAT","users":72,"accepted":23.25}
+{"id":10574,"name":"Soccer Ceremony","url":"https://www.spoj.com/problems/SCCCER","users":26,"accepted":40.43}
+{"id":10575,"name":"The Yellow Brick Road","url":"https://www.spoj.com/problems/YELBRICK","users":1280,"accepted":49.52}
+{"id":10576,"name":"Exclusive Security","url":"https://www.spoj.com/problems/EXCLSEC","users":99,"accepted":26.77}

--- a/tests/spoj/index/40.md
+++ b/tests/spoj/index/40.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 10437 | [Quadrilaterals](https://www.spoj.com/problems/IOPC1202) | 75 | 25.42 |
+| 10438 | [Crazy texting](https://www.spoj.com/problems/IOPC1203) | 174 | 25.98 |
+| 10439 | [Walking Robot](https://www.spoj.com/problems/WALKROBO) | 114 | 46.15 |
+| 10440 | [Friends](https://www.spoj.com/problems/FRNDS) | 38 | 20.42 |
+| 10442 | [Candy Distribution](https://www.spoj.com/problems/CADYDIST) | 3931 | 37.55 |
+| 10443 | [Bridges](https://www.spoj.com/problems/BRDGS) | 2 | 2.82 |
+| 10444 | [Coding](https://www.spoj.com/problems/CODING2) | 101 | 35.61 |
+| 10446 | [Sicrano](https://www.spoj.com/problems/SICRANO) | 511 | 23.74 |
+| 10447 | [Contaminated City](https://www.spoj.com/problems/CONTCITY) | 70 | 13.74 |
+| 10449 | [Resource Management](https://www.spoj.com/problems/RESOURCE) | 15 | 18.00 |
+| 10450 | [Amoeba](https://www.spoj.com/problems/AMOEBA) | 101 | 17.24 |
+| 10451 | [Stun Boosting](https://www.spoj.com/problems/STUN) | 19 | 25.68 |
+| 10452 | [Caprica Cities](https://www.spoj.com/problems/CAPRICA) | 165 | 38.31 |
+| 10453 | [Spring Loaded](https://www.spoj.com/problems/SPRING) | 160 | 31.30 |
+| 10454 | [Greens Land](https://www.spoj.com/problems/GREENLAN) | 100 | 28.54 |
+| 10460 | [A function over factors](https://www.spoj.com/problems/IOPC1204) | 102 | 32.78 |
+| 10461 | [The magical escape](https://www.spoj.com/problems/IOPC1205) | 31 | 40.52 |
+| 10463 | [COUNT PAREN](https://www.spoj.com/problems/PAREN) | 194 | 60.61 |
+| 10464 | [Reverse Engineering](https://www.spoj.com/problems/RE1) | 142 | 48.93 |
+| 10465 | [One Theorem, One Year](https://www.spoj.com/problems/OTOY1) | 50 | 43.62 |
+| 10466 | [Enough of analyzing, let’s play](https://www.spoj.com/problems/EALP1) | 262 | 45.78 |
+| 10471 | [Aliens at the train, again!](https://www.spoj.com/problems/ALIEN2) | 815 | 44.66 |
+| 10476 | [Fair bases](https://www.spoj.com/problems/IOPC1206) | 38 | 32.69 |
+| 10477 | [GM plants](https://www.spoj.com/problems/IOPC1207) | 344 | 29.22 |
+| 10500 | [Haybale stacking](https://www.spoj.com/problems/HAYBALE) | 4023 | 34.69 |
+| 10502 | [Video game combos](https://www.spoj.com/problems/VIDEO) | 397 | 38.27 |
+| 10506 | [Prendonians](https://www.spoj.com/problems/PRENDON) | 52 | 26.42 |
+| 10507 | [Cheese-rolling World Cup](https://www.spoj.com/problems/CHEESE) | 57 | 33.18 |
+| 10508 | [Buttons](https://www.spoj.com/problems/BTTNS) | 47 | 24.03 |
+| 10509 | [Cards](https://www.spoj.com/problems/CRDS) | 13536 | 34.03 |
+| 10510 | [Sorting Machine](https://www.spoj.com/problems/SRTMACH) | 28 | 44.44 |
+| 10514 | [K12 - Building Construction](https://www.spoj.com/problems/KOPC12A) | 2068 | 26.47 |
+| 10515 | [K12-Combinations](https://www.spoj.com/problems/KOPC12B) | 412 | 28.02 |
+| 10517 | [K12-Generating Big Numbers II](https://www.spoj.com/problems/KOPC12D) | 83 | 45.02 |
+| 10519 | [K12-Bored of Suffixes and Prefixes](https://www.spoj.com/problems/KOPC12G) | 96 | 43.49 |
+| 10522 | [K12-OE Numbers](https://www.spoj.com/problems/KOPC12H) | 238 | 50.18 |
+| 10537 | [Edit Distance Again](https://www.spoj.com/problems/EDIT) | 2546 | 42.24 |
+| 10538 | [Derp](https://www.spoj.com/problems/DERP) | 61 | 40.00 |
+| 10539 | [Bunnies](https://www.spoj.com/problems/BUNNIES) | 36 | 11.34 |
+| 10547 | [Delivery Route](https://www.spoj.com/problems/DELIVER) | 63 | 19.24 |
+| 10557 | [MINI IN DANGER!!!](https://www.spoj.com/problems/MINI) | 34 | 46.90 |
+| 10565 | [Alice Sieve](https://www.spoj.com/problems/ALICESIE) | 5079 | 53.39 |
+| 10568 | [Graph Cut](https://www.spoj.com/problems/GRAPHCUT) | 112 | 38.16 |
+| 10570 | [Longest Common Substring](https://www.spoj.com/problems/LONGCS) | 920 | 30.38 |
+| 10571 | [Soccer Challenge](https://www.spoj.com/problems/SOCCERCH) | 30 | 34.78 |
+| 10572 | [Cheating on the contest](https://www.spoj.com/problems/CHEATCON) | 30 | 7.40 |
+| 10573 | [Problem Offensive Strategy](https://www.spoj.com/problems/OFFSTRAT) | 72 | 23.25 |
+| 10574 | [Soccer Ceremony](https://www.spoj.com/problems/SCCCER) | 26 | 40.43 |
+| 10575 | [The Yellow Brick Road](https://www.spoj.com/problems/YELBRICK) | 1280 | 49.52 |
+| 10576 | [Exclusive Security](https://www.spoj.com/problems/EXCLSEC) | 99 | 26.77 |

--- a/tests/spoj/index/41.jsonl
+++ b/tests/spoj/index/41.jsonl
@@ -1,0 +1,50 @@
+{"id":10579,"name":"Desrugenstein","url":"https://www.spoj.com/problems/DESRUG","users":120,"accepted":49.34}
+{"id":10581,"name":"Ball Stacking Again","url":"https://www.spoj.com/problems/BALLSAG","users":158,"accepted":30.86}
+{"id":10582,"name":"subarrays","url":"https://www.spoj.com/problems/ARRAYSUB","users":9557,"accepted":34.36}
+{"id":10585,"name":"Searching God","url":"https://www.spoj.com/problems/SEAGOD","users":83,"accepted":25.98}
+{"id":10586,"name":"Problems in Moria","url":"https://www.spoj.com/problems/PROBMOR","users":41,"accepted":28.98}
+{"id":10587,"name":"Enemies","url":"https://www.spoj.com/problems/ENEM","users":43,"accepted":37.5}
+{"id":10588,"name":"Portal","url":"https://www.spoj.com/problems/PORTALUN","users":110,"accepted":35.35}
+{"id":10589,"name":"King","url":"https://www.spoj.com/problems/KING","users":70,"accepted":29.77}
+{"id":10594,"name":"Decoding Number Stations with Dr Whooves","url":"https://www.spoj.com/problems/PONY2","users":61,"accepted":28.05}
+{"id":10596,"name":"Monkey and apples","url":"https://www.spoj.com/problems/MON2012","users":164,"accepted":17.14}
+{"id":10605,"name":"Counting Formations","url":"https://www.spoj.com/problems/FORMAT1","users":17,"accepted":41.54}
+{"id":10606,"name":"Balanced Numbers","url":"https://www.spoj.com/problems/BALNUM","users":645,"accepted":29.01}
+{"id":10607,"name":"Delivery","url":"https://www.spoj.com/problems/TWODEL","users":33,"accepted":19.17}
+{"id":10608,"name":"Unique Strings","url":"https://www.spoj.com/problems/UNICA","users":71,"accepted":48.7}
+{"id":10611,"name":"Ranges","url":"https://www.spoj.com/problems/RRANGE","users":176,"accepted":19.62}
+{"id":10612,"name":"Funny Areas","url":"https://www.spoj.com/problems/FUNAREA","users":98,"accepted":33.33}
+{"id":10620,"name":"KNJIGE","url":"https://www.spoj.com/problems/KNJIGE","users":1448,"accepted":44.45}
+{"id":10621,"name":"MONO","url":"https://www.spoj.com/problems/MONO","users":22,"accepted":15.58}
+{"id":10622,"name":"DIFERENCIJA","url":"https://www.spoj.com/problems/DIFERENC","users":599,"accepted":46.32}
+{"id":10623,"name":"ZNANSTVENIK","url":"https://www.spoj.com/problems/ZNANSTVE","users":261,"accepted":31.34}
+{"id":10628,"name":"Count on a tree","url":"https://www.spoj.com/problems/COT","users":2623,"accepted":17.41}
+{"id":10639,"name":"The Blind Passenger","url":"https://www.spoj.com/problems/MYQ1","users":1998,"accepted":44.71}
+{"id":10640,"name":"The Wild Wizard","url":"https://www.spoj.com/problems/MYQ2","users":97,"accepted":26.76}
+{"id":10641,"name":"The Dating Dress Problem","url":"https://www.spoj.com/problems/MYQ3","users":41,"accepted":23.01}
+{"id":10643,"name":"The Nerd Factor","url":"https://www.spoj.com/problems/MYQ5","users":204,"accepted":47}
+{"id":10644,"name":"Serve The Street","url":"https://www.spoj.com/problems/MYQ6","users":140,"accepted":26.07}
+{"id":10645,"name":"The Rail Network Renovation","url":"https://www.spoj.com/problems/MYQ7","users":100,"accepted":33.39}
+{"id":10646,"name":"The National Game","url":"https://www.spoj.com/problems/MYQ8","users":50,"accepted":30.3}
+{"id":10647,"name":"Divide And Conquer","url":"https://www.spoj.com/problems/MYQ9","users":13,"accepted":17.28}
+{"id":10648,"name":"DUGDUG","url":"https://www.spoj.com/problems/DUGDUG","users":50,"accepted":25.38}
+{"id":10649,"name":"Mirror Number","url":"https://www.spoj.com/problems/MYQ10","users":209,"accepted":22.02}
+{"id":10667,"name":"PASIJANS","url":"https://www.spoj.com/problems/FLLM","users":69,"accepted":48.52}
+{"id":10675,"name":"GENIJALAC","url":"https://www.spoj.com/problems/IWGBST","users":47,"accepted":51.02}
+{"id":10676,"name":"0110SS","url":"https://www.spoj.com/problems/IWGBS","users":1772,"accepted":41.09}
+{"id":10677,"name":"Joseph’s Problem","url":"https://www.spoj.com/problems/NAGAY","users":202,"accepted":54.58}
+{"id":10683,"name":"DRIVE","url":"https://www.spoj.com/problems/BYTESB","users":1,"accepted":1.37}
+{"id":10699,"name":"Symmetry","url":"https://www.spoj.com/problems/SYM12","users":30,"accepted":30.66}
+{"id":10701,"name":"The Lazy Gamer","url":"https://www.spoj.com/problems/MYQ11","users":17,"accepted":14}
+{"id":10704,"name":"The Great Escape","url":"https://www.spoj.com/problems/MYQ12","users":36,"accepted":28.72}
+{"id":10707,"name":"Count on a tree II","url":"https://www.spoj.com/problems/COT2","users":3534,"accepted":19.59}
+{"id":10711,"name":"VUK","url":"https://www.spoj.com/problems/NAGAY1","users":194,"accepted":54.01}
+{"id":10712,"name":"Easy Calculation","url":"https://www.spoj.com/problems/TRIGALGE","users":1377,"accepted":35.93}
+{"id":10725,"name":"String Subsequence","url":"https://www.spoj.com/problems/STRSEQ","users":75,"accepted":17.78}
+{"id":10730,"name":"Michel and the championship","url":"https://www.spoj.com/problems/CHAMPS","users":119,"accepted":11.54}
+{"id":10732,"name":"Trapezoid","url":"https://www.spoj.com/problems/TRAPEZBO","users":56,"accepted":32.56}
+{"id":10738,"name":"Ra-One Numbers","url":"https://www.spoj.com/problems/RAONE","users":1700,"accepted":33.49}
+{"id":10790,"name":"G-One Numbers","url":"https://www.spoj.com/problems/GONE","users":2531,"accepted":47.49}
+{"id":10798,"name":"Wachovia Bank","url":"https://www.spoj.com/problems/WACHOVIA","users":4059,"accepted":46.73}
+{"id":10799,"name":"Happiness at the lowest cost","url":"https://www.spoj.com/problems/RS2D","users":17,"accepted":5.44}
+{"id":10800,"name":"GAME","url":"https://www.spoj.com/problems/GAMECG","users":25,"accepted":12.8}

--- a/tests/spoj/index/41.md
+++ b/tests/spoj/index/41.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 10579 | [Desrugenstein](https://www.spoj.com/problems/DESRUG) | 120 | 49.34 |
+| 10581 | [Ball Stacking Again](https://www.spoj.com/problems/BALLSAG) | 158 | 30.86 |
+| 10582 | [subarrays](https://www.spoj.com/problems/ARRAYSUB) | 9557 | 34.36 |
+| 10585 | [Searching God](https://www.spoj.com/problems/SEAGOD) | 83 | 25.98 |
+| 10586 | [Problems in Moria](https://www.spoj.com/problems/PROBMOR) | 41 | 28.98 |
+| 10587 | [Enemies](https://www.spoj.com/problems/ENEM) | 43 | 37.50 |
+| 10588 | [Portal](https://www.spoj.com/problems/PORTALUN) | 110 | 35.35 |
+| 10589 | [King](https://www.spoj.com/problems/KING) | 70 | 29.77 |
+| 10594 | [Decoding Number Stations with Dr Whooves](https://www.spoj.com/problems/PONY2) | 61 | 28.05 |
+| 10596 | [Monkey and apples](https://www.spoj.com/problems/MON2012) | 164 | 17.14 |
+| 10605 | [Counting Formations](https://www.spoj.com/problems/FORMAT1) | 17 | 41.54 |
+| 10606 | [Balanced Numbers](https://www.spoj.com/problems/BALNUM) | 645 | 29.01 |
+| 10607 | [Delivery](https://www.spoj.com/problems/TWODEL) | 33 | 19.17 |
+| 10608 | [Unique Strings](https://www.spoj.com/problems/UNICA) | 71 | 48.70 |
+| 10611 | [Ranges](https://www.spoj.com/problems/RRANGE) | 176 | 19.62 |
+| 10612 | [Funny Areas](https://www.spoj.com/problems/FUNAREA) | 98 | 33.33 |
+| 10620 | [KNJIGE](https://www.spoj.com/problems/KNJIGE) | 1448 | 44.45 |
+| 10621 | [MONO](https://www.spoj.com/problems/MONO) | 22 | 15.58 |
+| 10622 | [DIFERENCIJA](https://www.spoj.com/problems/DIFERENC) | 599 | 46.32 |
+| 10623 | [ZNANSTVENIK](https://www.spoj.com/problems/ZNANSTVE) | 261 | 31.34 |
+| 10628 | [Count on a tree](https://www.spoj.com/problems/COT) | 2623 | 17.41 |
+| 10639 | [The Blind Passenger](https://www.spoj.com/problems/MYQ1) | 1998 | 44.71 |
+| 10640 | [The Wild Wizard](https://www.spoj.com/problems/MYQ2) | 97 | 26.76 |
+| 10641 | [The Dating Dress Problem](https://www.spoj.com/problems/MYQ3) | 41 | 23.01 |
+| 10643 | [The Nerd Factor](https://www.spoj.com/problems/MYQ5) | 204 | 47.00 |
+| 10644 | [Serve The Street](https://www.spoj.com/problems/MYQ6) | 140 | 26.07 |
+| 10645 | [The Rail Network Renovation](https://www.spoj.com/problems/MYQ7) | 100 | 33.39 |
+| 10646 | [The National Game](https://www.spoj.com/problems/MYQ8) | 50 | 30.30 |
+| 10647 | [Divide And Conquer](https://www.spoj.com/problems/MYQ9) | 13 | 17.28 |
+| 10648 | [DUGDUG](https://www.spoj.com/problems/DUGDUG) | 50 | 25.38 |
+| 10649 | [Mirror Number](https://www.spoj.com/problems/MYQ10) | 209 | 22.02 |
+| 10667 | [PASIJANS](https://www.spoj.com/problems/FLLM) | 69 | 48.52 |
+| 10675 | [GENIJALAC](https://www.spoj.com/problems/IWGBST) | 47 | 51.02 |
+| 10676 | [0110SS](https://www.spoj.com/problems/IWGBS) | 1772 | 41.09 |
+| 10677 | [Joseph’s Problem](https://www.spoj.com/problems/NAGAY) | 202 | 54.58 |
+| 10683 | [DRIVE](https://www.spoj.com/problems/BYTESB) | 1 | 1.37 |
+| 10699 | [Symmetry](https://www.spoj.com/problems/SYM12) | 30 | 30.66 |
+| 10701 | [The Lazy Gamer](https://www.spoj.com/problems/MYQ11) | 17 | 14.00 |
+| 10704 | [The Great Escape](https://www.spoj.com/problems/MYQ12) | 36 | 28.72 |
+| 10707 | [Count on a tree II](https://www.spoj.com/problems/COT2) | 3534 | 19.59 |
+| 10711 | [VUK](https://www.spoj.com/problems/NAGAY1) | 194 | 54.01 |
+| 10712 | [Easy Calculation](https://www.spoj.com/problems/TRIGALGE) | 1377 | 35.93 |
+| 10725 | [String Subsequence](https://www.spoj.com/problems/STRSEQ) | 75 | 17.78 |
+| 10730 | [Michel and the championship](https://www.spoj.com/problems/CHAMPS) | 119 | 11.54 |
+| 10732 | [Trapezoid](https://www.spoj.com/problems/TRAPEZBO) | 56 | 32.56 |
+| 10738 | [Ra-One Numbers](https://www.spoj.com/problems/RAONE) | 1700 | 33.49 |
+| 10790 | [G-One Numbers](https://www.spoj.com/problems/GONE) | 2531 | 47.49 |
+| 10798 | [Wachovia Bank](https://www.spoj.com/problems/WACHOVIA) | 4059 | 46.73 |
+| 10799 | [Happiness at the lowest cost](https://www.spoj.com/problems/RS2D) | 17 | 5.44 |
+| 10800 | [GAME](https://www.spoj.com/problems/GAMECG) | 25 | 12.80 |

--- a/tests/spoj/index/42.jsonl
+++ b/tests/spoj/index/42.jsonl
@@ -1,0 +1,50 @@
+{"id":10802,"name":"Sum of Tetranacci numbers","url":"https://www.spoj.com/problems/TETRAHRD","users":318,"accepted":38.94}
+{"id":10809,"name":"Unlock it !","url":"https://www.spoj.com/problems/DCEPC204","users":86,"accepted":30.27}
+{"id":10810,"name":"Its a Murder!","url":"https://www.spoj.com/problems/DCEPC206","users":2402,"accepted":22.15}
+{"id":10814,"name":"Unique Paths","url":"https://www.spoj.com/problems/DCEPC202","users":130,"accepted":46.01}
+{"id":10815,"name":"Finally a Treat","url":"https://www.spoj.com/problems/DCEPC207","users":295,"accepted":33.64}
+{"id":10818,"name":"Medium Factorization","url":"https://www.spoj.com/problems/FACTCG2","users":1893,"accepted":14.61}
+{"id":10819,"name":"BF Vector","url":"https://www.spoj.com/problems/BFTAB","users":83,"accepted":55.84}
+{"id":10820,"name":"Obsession","url":"https://www.spoj.com/problems/DCEPC203","users":39,"accepted":24.38}
+{"id":10822,"name":"The Prime Minister","url":"https://www.spoj.com/problems/DCEPC200","users":29,"accepted":13.79}
+{"id":10841,"name":"Supplying the Suppliers","url":"https://www.spoj.com/problems/SUPSUP","users":20,"accepted":40.13}
+{"id":10877,"name":"Decoys and Diversions","url":"https://www.spoj.com/problems/DECOY","users":49,"accepted":18.97}
+{"id":10883,"name":"Customs","url":"https://www.spoj.com/problems/CUSTOMSL","users":19,"accepted":25.96}
+{"id":10919,"name":"I Hate Parenthesis","url":"https://www.spoj.com/problems/FERT21_1","users":97,"accepted":30.21}
+{"id":10930,"name":"Dixon Dominoes","url":"https://www.spoj.com/problems/DIXDOOM","users":22,"accepted":25}
+{"id":10931,"name":"Online Bridge Searching","url":"https://www.spoj.com/problems/ONBRIDGE","users":108,"accepted":34.59}
+{"id":10945,"name":"Foodie Golu","url":"https://www.spoj.com/problems/DCEPC301","users":63,"accepted":28.36}
+{"id":10958,"name":"Vero Dominoes","url":"https://www.spoj.com/problems/VERODOOM","users":419,"accepted":45.3}
+{"id":10966,"name":"Aritho-geometric Series (AGS)","url":"https://www.spoj.com/problems/AGS","users":203,"accepted":10.23}
+{"id":10968,"name":"LUCIFER Number","url":"https://www.spoj.com/problems/LUCIFER","users":1624,"accepted":62.4}
+{"id":11050,"name":"R  Numbers","url":"https://www.spoj.com/problems/ITRIX12E","users":267,"accepted":55.65}
+{"id":11054,"name":"Discords Dilemma","url":"https://www.spoj.com/problems/PONY3","users":28,"accepted":26.14}
+{"id":11063,"name":"AP - Complete The Series (Easy)","url":"https://www.spoj.com/problems/AP2","users":13030,"accepted":37.13}
+{"id":11066,"name":"AP - Complete The Series v2","url":"https://www.spoj.com/problems/AP3","users":1117,"accepted":14.23}
+{"id":11090,"name":"Large banner","url":"https://www.spoj.com/problems/BANNER","users":33,"accepted":32.26}
+{"id":11102,"name":"SelfDescribingSequenceProblem","url":"https://www.spoj.com/problems/MAIN12A","users":830,"accepted":47.7}
+{"id":11103,"name":"PrimeFactorofLCM","url":"https://www.spoj.com/problems/MAIN12B","users":600,"accepted":25.75}
+{"id":11105,"name":"Email ID","url":"https://www.spoj.com/problems/MAIN12C","users":75,"accepted":21.91}
+{"id":11116,"name":"Discord is Cornered","url":"https://www.spoj.com/problems/PONY4","users":30,"accepted":51.19}
+{"id":11117,"name":"Restacking haybales 2012","url":"https://www.spoj.com/problems/RESTACK","users":253,"accepted":59.32}
+{"id":11157,"name":"The Great Escape","url":"https://www.spoj.com/problems/GREAT_E","users":83,"accepted":45.79}
+{"id":11165,"name":"Magic Strawberries","url":"https://www.spoj.com/problems/STRAWB","users":182,"accepted":22.75}
+{"id":11175,"name":"The Ball Game","url":"https://www.spoj.com/problems/IEEEBGAM","users":2291,"accepted":44.1}
+{"id":11178,"name":"Save money for YTU","url":"https://www.spoj.com/problems/MONEYYTU","users":131,"accepted":44.13}
+{"id":11179,"name":"Korra in the Spirit World","url":"https://www.spoj.com/problems/SPWORLD","users":26,"accepted":41.24}
+{"id":11180,"name":"369 Numbers","url":"https://www.spoj.com/problems/NUMTSN","users":894,"accepted":12.74}
+{"id":11181,"name":"Build the Tower","url":"https://www.spoj.com/problems/BUILDTOW","users":524,"accepted":41.77}
+{"id":11198,"name":"Ipad Testing","url":"https://www.spoj.com/problems/IPAD","users":51,"accepted":42.08}
+{"id":11202,"name":"Number Theory","url":"https://www.spoj.com/problems/NUMTRY","users":37,"accepted":31.44}
+{"id":11244,"name":"GP - Complete the Series v1 ()","url":"https://www.spoj.com/problems/GP1","users":289,"accepted":21.45}
+{"id":11267,"name":"Arnook Defensive Line","url":"https://www.spoj.com/problems/KL11B","users":45,"accepted":27.33}
+{"id":11273,"name":"Team Nim","url":"https://www.spoj.com/problems/TEAMNIM","users":84,"accepted":20.8}
+{"id":11274,"name":"Lights and Switches","url":"https://www.spoj.com/problems/LIGHTPZ","users":60,"accepted":29.84}
+{"id":11276,"name":"Adventure","url":"https://www.spoj.com/problems/ADVNTURE","users":49,"accepted":38.25}
+{"id":11300,"name":"Fun with numbers","url":"https://www.spoj.com/problems/NUMPLAY","users":301,"accepted":35.34}
+{"id":11321,"name":"G-One Sort","url":"https://www.spoj.com/problems/GONESORT","users":782,"accepted":37.62}
+{"id":11326,"name":"Arithmetic Evaluation","url":"https://www.spoj.com/problems/ARTHEVAL","users":362,"accepted":40.31}
+{"id":11334,"name":"Lucifer Sort","url":"https://www.spoj.com/problems/LUCISORT","users":7,"accepted":1.14}
+{"id":11345,"name":"lcm addition","url":"https://www.spoj.com/problems/ADDLCM","users":78,"accepted":32.11}
+{"id":11354,"name":"Amusing numbers","url":"https://www.spoj.com/problems/TSHOW1","users":3254,"accepted":59.78}
+{"id":11355,"name":"SQUARE TO SQUARE","url":"https://www.spoj.com/problems/SQ2SQ","users":23,"accepted":18.22}

--- a/tests/spoj/index/42.md
+++ b/tests/spoj/index/42.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 10802 | [Sum of Tetranacci numbers](https://www.spoj.com/problems/TETRAHRD) | 318 | 38.94 |
+| 10809 | [Unlock it !](https://www.spoj.com/problems/DCEPC204) | 86 | 30.27 |
+| 10810 | [Its a Murder!](https://www.spoj.com/problems/DCEPC206) | 2402 | 22.15 |
+| 10814 | [Unique Paths](https://www.spoj.com/problems/DCEPC202) | 130 | 46.01 |
+| 10815 | [Finally a Treat](https://www.spoj.com/problems/DCEPC207) | 295 | 33.64 |
+| 10818 | [Medium Factorization](https://www.spoj.com/problems/FACTCG2) | 1893 | 14.61 |
+| 10819 | [BF Vector](https://www.spoj.com/problems/BFTAB) | 83 | 55.84 |
+| 10820 | [Obsession](https://www.spoj.com/problems/DCEPC203) | 39 | 24.38 |
+| 10822 | [The Prime Minister](https://www.spoj.com/problems/DCEPC200) | 29 | 13.79 |
+| 10841 | [Supplying the Suppliers](https://www.spoj.com/problems/SUPSUP) | 20 | 40.13 |
+| 10877 | [Decoys and Diversions](https://www.spoj.com/problems/DECOY) | 49 | 18.97 |
+| 10883 | [Customs](https://www.spoj.com/problems/CUSTOMSL) | 19 | 25.96 |
+| 10919 | [I Hate Parenthesis](https://www.spoj.com/problems/FERT21_1) | 97 | 30.21 |
+| 10930 | [Dixon Dominoes](https://www.spoj.com/problems/DIXDOOM) | 22 | 25.00 |
+| 10931 | [Online Bridge Searching](https://www.spoj.com/problems/ONBRIDGE) | 108 | 34.59 |
+| 10945 | [Foodie Golu](https://www.spoj.com/problems/DCEPC301) | 63 | 28.36 |
+| 10958 | [Vero Dominoes](https://www.spoj.com/problems/VERODOOM) | 419 | 45.30 |
+| 10966 | [Aritho-geometric Series (AGS)](https://www.spoj.com/problems/AGS) | 203 | 10.23 |
+| 10968 | [LUCIFER Number](https://www.spoj.com/problems/LUCIFER) | 1624 | 62.40 |
+| 11050 | [R  Numbers](https://www.spoj.com/problems/ITRIX12E) | 267 | 55.65 |
+| 11054 | [Discords Dilemma](https://www.spoj.com/problems/PONY3) | 28 | 26.14 |
+| 11063 | [AP - Complete The Series (Easy)](https://www.spoj.com/problems/AP2) | 13030 | 37.13 |
+| 11066 | [AP - Complete The Series v2](https://www.spoj.com/problems/AP3) | 1117 | 14.23 |
+| 11090 | [Large banner](https://www.spoj.com/problems/BANNER) | 33 | 32.26 |
+| 11102 | [SelfDescribingSequenceProblem](https://www.spoj.com/problems/MAIN12A) | 830 | 47.70 |
+| 11103 | [PrimeFactorofLCM](https://www.spoj.com/problems/MAIN12B) | 600 | 25.75 |
+| 11105 | [Email ID](https://www.spoj.com/problems/MAIN12C) | 75 | 21.91 |
+| 11116 | [Discord is Cornered](https://www.spoj.com/problems/PONY4) | 30 | 51.19 |
+| 11117 | [Restacking haybales 2012](https://www.spoj.com/problems/RESTACK) | 253 | 59.32 |
+| 11157 | [The Great Escape](https://www.spoj.com/problems/GREAT_E) | 83 | 45.79 |
+| 11165 | [Magic Strawberries](https://www.spoj.com/problems/STRAWB) | 182 | 22.75 |
+| 11175 | [The Ball Game](https://www.spoj.com/problems/IEEEBGAM) | 2291 | 44.10 |
+| 11178 | [Save money for YTU](https://www.spoj.com/problems/MONEYYTU) | 131 | 44.13 |
+| 11179 | [Korra in the Spirit World](https://www.spoj.com/problems/SPWORLD) | 26 | 41.24 |
+| 11180 | [369 Numbers](https://www.spoj.com/problems/NUMTSN) | 894 | 12.74 |
+| 11181 | [Build the Tower](https://www.spoj.com/problems/BUILDTOW) | 524 | 41.77 |
+| 11198 | [Ipad Testing](https://www.spoj.com/problems/IPAD) | 51 | 42.08 |
+| 11202 | [Number Theory](https://www.spoj.com/problems/NUMTRY) | 37 | 31.44 |
+| 11244 | [GP - Complete the Series v1 ()](https://www.spoj.com/problems/GP1) | 289 | 21.45 |
+| 11267 | [Arnook Defensive Line](https://www.spoj.com/problems/KL11B) | 45 | 27.33 |
+| 11273 | [Team Nim](https://www.spoj.com/problems/TEAMNIM) | 84 | 20.80 |
+| 11274 | [Lights and Switches](https://www.spoj.com/problems/LIGHTPZ) | 60 | 29.84 |
+| 11276 | [Adventure](https://www.spoj.com/problems/ADVNTURE) | 49 | 38.25 |
+| 11300 | [Fun with numbers](https://www.spoj.com/problems/NUMPLAY) | 301 | 35.34 |
+| 11321 | [G-One Sort](https://www.spoj.com/problems/GONESORT) | 782 | 37.62 |
+| 11326 | [Arithmetic Evaluation](https://www.spoj.com/problems/ARTHEVAL) | 362 | 40.31 |
+| 11334 | [Lucifer Sort](https://www.spoj.com/problems/LUCISORT) | 7 | 1.14 |
+| 11345 | [lcm addition](https://www.spoj.com/problems/ADDLCM) | 78 | 32.11 |
+| 11354 | [Amusing numbers](https://www.spoj.com/problems/TSHOW1) | 3254 | 59.78 |
+| 11355 | [SQUARE TO SQUARE](https://www.spoj.com/problems/SQ2SQ) | 23 | 18.22 |

--- a/tests/spoj/index/43.jsonl
+++ b/tests/spoj/index/43.jsonl
@@ -1,0 +1,50 @@
+{"id":11371,"name":"Answer the boss!","url":"https://www.spoj.com/problems/RPLA","users":1234,"accepted":35.17}
+{"id":11372,"name":"Blueberries","url":"https://www.spoj.com/problems/RPLB","users":2249,"accepted":33.64}
+{"id":11373,"name":"Coke madness","url":"https://www.spoj.com/problems/RPLC","users":3878,"accepted":35.07}
+{"id":11374,"name":"Database","url":"https://www.spoj.com/problems/RPLD","users":2096,"accepted":34.27}
+{"id":11375,"name":"Espionage","url":"https://www.spoj.com/problems/RPLE","users":1525,"accepted":42.28}
+{"id":11383,"name":"Fast Sum of two to an exponent","url":"https://www.spoj.com/problems/FAST2","users":1067,"accepted":30.24}
+{"id":11384,"name":"Zoom Operation","url":"https://www.spoj.com/problems/ZOOMOP2","users":4,"accepted":16}
+{"id":11386,"name":"Recycled Numbers","url":"https://www.spoj.com/problems/GCJ2012C","users":198,"accepted":31.86}
+{"id":11391,"name":"EASY MATH","url":"https://www.spoj.com/problems/EASYMATH","users":1458,"accepted":20.31}
+{"id":11401,"name":"Bazinga!","url":"https://www.spoj.com/problems/DCEPC505","users":742,"accepted":22.74}
+{"id":11402,"name":"The Indian Connection","url":"https://www.spoj.com/problems/DCEPC504","users":2298,"accepted":36.29}
+{"id":11404,"name":"Save Thy Toys","url":"https://www.spoj.com/problems/DCEPC501","users":2828,"accepted":30.19}
+{"id":11405,"name":"Just Like the Good Old Days","url":"https://www.spoj.com/problems/DCEPC502","users":88,"accepted":40.78}
+{"id":11407,"name":"Tied Down","url":"https://www.spoj.com/problems/TDOWN","users":20,"accepted":28.24}
+{"id":11409,"name":"Fibonacci With a Twist","url":"https://www.spoj.com/problems/FIBTWIST","users":1011,"accepted":31.32}
+{"id":11414,"name":"Combat on a tree","url":"https://www.spoj.com/problems/COT3","users":255,"accepted":31.06}
+{"id":11440,"name":"Unlock it ! Part 2","url":"https://www.spoj.com/problems/DCEPC604","users":48,"accepted":22.88}
+{"id":11443,"name":"Davids Greed","url":"https://www.spoj.com/problems/DAVIDG","users":253,"accepted":26.22}
+{"id":11444,"name":"MAXOR","url":"https://www.spoj.com/problems/MAXOR","users":114,"accepted":35.95}
+{"id":11458,"name":"Ninja","url":"https://www.spoj.com/problems/VUDBOL5","users":125,"accepted":15.62}
+{"id":11460,"name":"Planning Poker","url":"https://www.spoj.com/problems/VUDBOL7","users":258,"accepted":42.05}
+{"id":11461,"name":"Book Shelves","url":"https://www.spoj.com/problems/SHELF","users":79,"accepted":20.87}
+{"id":11469,"name":"Balanced Cow Subsets","url":"https://www.spoj.com/problems/SUBSET","users":442,"accepted":26.43}
+{"id":11470,"name":"To the moon","url":"https://www.spoj.com/problems/TTM","users":1129,"accepted":23.19}
+{"id":11472,"name":"Amazing Maze","url":"https://www.spoj.com/problems/DCEPC701","users":262,"accepted":28.97}
+{"id":11473,"name":"NOS","url":"https://www.spoj.com/problems/DCEPC702","users":188,"accepted":26.28}
+{"id":11474,"name":"Totient Game","url":"https://www.spoj.com/problems/DCEPC703","users":46,"accepted":37.65}
+{"id":11476,"name":"Weird Points","url":"https://www.spoj.com/problems/DCEPC705","users":186,"accepted":27.97}
+{"id":11477,"name":"Meeting For Party","url":"https://www.spoj.com/problems/DCEPC706","users":490,"accepted":28.25}
+{"id":11482,"name":"Count on a trie","url":"https://www.spoj.com/problems/COT4","users":78,"accepted":12.38}
+{"id":11493,"name":"Goto \u0026 labels","url":"https://www.spoj.com/problems/RPLG","users":64,"accepted":30.83}
+{"id":11494,"name":"Hard Launching","url":"https://www.spoj.com/problems/RPLH","users":1637,"accepted":59.38}
+{"id":11495,"name":"Ignore the bounds","url":"https://www.spoj.com/problems/RPLI","users":20,"accepted":16}
+{"id":11496,"name":"Just the distance","url":"https://www.spoj.com/problems/RPLJ","users":22,"accepted":12.75}
+{"id":11509,"name":"IPL - CRICKET TOURNAMENT","url":"https://www.spoj.com/problems/IPL1","users":83,"accepted":25.84}
+{"id":11515,"name":"I AM VERY BUSY","url":"https://www.spoj.com/problems/BUSYMAN","users":8629,"accepted":45.09}
+{"id":11516,"name":"VALIDATE THE MAZE","url":"https://www.spoj.com/problems/MAKEMAZE","users":3178,"accepted":32.2}
+{"id":11517,"name":"GAMING ARENA","url":"https://www.spoj.com/problems/GAMARENA","users":61,"accepted":40.34}
+{"id":11521,"name":"Dominant Strings","url":"https://www.spoj.com/problems/DOMINST","users":78,"accepted":34.81}
+{"id":11540,"name":"Training","url":"https://www.spoj.com/problems/TRAIN07","users":18,"accepted":26.67}
+{"id":11560,"name":"A Summatory","url":"https://www.spoj.com/problems/PUCMM210","users":1646,"accepted":26.01}
+{"id":11564,"name":"E 23 Stairs pattern","url":"https://www.spoj.com/problems/PUCMM215","users":140,"accepted":39.7}
+{"id":11573,"name":"A Famous ICPC Team","url":"https://www.spoj.com/problems/TEAM2","users":2046,"accepted":37.72}
+{"id":11574,"name":"A Famous Stone Collector","url":"https://www.spoj.com/problems/STONE2","users":129,"accepted":36.09}
+{"id":11575,"name":"A Famous Equation","url":"https://www.spoj.com/problems/EQ2","users":81,"accepted":27.32}
+{"id":11576,"name":"A Famous King’s Trip","url":"https://www.spoj.com/problems/TRIP2","users":25,"accepted":10.72}
+{"id":11577,"name":"The Famous ICPC Team Again","url":"https://www.spoj.com/problems/MEDIAN3","users":83,"accepted":30.89}
+{"id":11578,"name":"A Famous City","url":"https://www.spoj.com/problems/CITY2","users":805,"accepted":31}
+{"id":11579,"name":"Two Famous Companies","url":"https://www.spoj.com/problems/COMPANYS","users":235,"accepted":22.02}
+{"id":11580,"name":"A Famous Game","url":"https://www.spoj.com/problems/PRLGAME2","users":409,"accepted":34.93}

--- a/tests/spoj/index/43.md
+++ b/tests/spoj/index/43.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 11371 | [Answer the boss!](https://www.spoj.com/problems/RPLA) | 1234 | 35.17 |
+| 11372 | [Blueberries](https://www.spoj.com/problems/RPLB) | 2249 | 33.64 |
+| 11373 | [Coke madness](https://www.spoj.com/problems/RPLC) | 3878 | 35.07 |
+| 11374 | [Database](https://www.spoj.com/problems/RPLD) | 2096 | 34.27 |
+| 11375 | [Espionage](https://www.spoj.com/problems/RPLE) | 1525 | 42.28 |
+| 11383 | [Fast Sum of two to an exponent](https://www.spoj.com/problems/FAST2) | 1067 | 30.24 |
+| 11384 | [Zoom Operation](https://www.spoj.com/problems/ZOOMOP2) | 4 | 16.00 |
+| 11386 | [Recycled Numbers](https://www.spoj.com/problems/GCJ2012C) | 198 | 31.86 |
+| 11391 | [EASY MATH](https://www.spoj.com/problems/EASYMATH) | 1458 | 20.31 |
+| 11401 | [Bazinga!](https://www.spoj.com/problems/DCEPC505) | 742 | 22.74 |
+| 11402 | [The Indian Connection](https://www.spoj.com/problems/DCEPC504) | 2298 | 36.29 |
+| 11404 | [Save Thy Toys](https://www.spoj.com/problems/DCEPC501) | 2828 | 30.19 |
+| 11405 | [Just Like the Good Old Days](https://www.spoj.com/problems/DCEPC502) | 88 | 40.78 |
+| 11407 | [Tied Down](https://www.spoj.com/problems/TDOWN) | 20 | 28.24 |
+| 11409 | [Fibonacci With a Twist](https://www.spoj.com/problems/FIBTWIST) | 1011 | 31.32 |
+| 11414 | [Combat on a tree](https://www.spoj.com/problems/COT3) | 255 | 31.06 |
+| 11440 | [Unlock it ! Part 2](https://www.spoj.com/problems/DCEPC604) | 48 | 22.88 |
+| 11443 | [Davids Greed](https://www.spoj.com/problems/DAVIDG) | 253 | 26.22 |
+| 11444 | [MAXOR](https://www.spoj.com/problems/MAXOR) | 114 | 35.95 |
+| 11458 | [Ninja](https://www.spoj.com/problems/VUDBOL5) | 125 | 15.62 |
+| 11460 | [Planning Poker](https://www.spoj.com/problems/VUDBOL7) | 258 | 42.05 |
+| 11461 | [Book Shelves](https://www.spoj.com/problems/SHELF) | 79 | 20.87 |
+| 11469 | [Balanced Cow Subsets](https://www.spoj.com/problems/SUBSET) | 442 | 26.43 |
+| 11470 | [To the moon](https://www.spoj.com/problems/TTM) | 1129 | 23.19 |
+| 11472 | [Amazing Maze](https://www.spoj.com/problems/DCEPC701) | 262 | 28.97 |
+| 11473 | [NOS](https://www.spoj.com/problems/DCEPC702) | 188 | 26.28 |
+| 11474 | [Totient Game](https://www.spoj.com/problems/DCEPC703) | 46 | 37.65 |
+| 11476 | [Weird Points](https://www.spoj.com/problems/DCEPC705) | 186 | 27.97 |
+| 11477 | [Meeting For Party](https://www.spoj.com/problems/DCEPC706) | 490 | 28.25 |
+| 11482 | [Count on a trie](https://www.spoj.com/problems/COT4) | 78 | 12.38 |
+| 11493 | [Goto & labels](https://www.spoj.com/problems/RPLG) | 64 | 30.83 |
+| 11494 | [Hard Launching](https://www.spoj.com/problems/RPLH) | 1637 | 59.38 |
+| 11495 | [Ignore the bounds](https://www.spoj.com/problems/RPLI) | 20 | 16.00 |
+| 11496 | [Just the distance](https://www.spoj.com/problems/RPLJ) | 22 | 12.75 |
+| 11509 | [IPL - CRICKET TOURNAMENT](https://www.spoj.com/problems/IPL1) | 83 | 25.84 |
+| 11515 | [I AM VERY BUSY](https://www.spoj.com/problems/BUSYMAN) | 8629 | 45.09 |
+| 11516 | [VALIDATE THE MAZE](https://www.spoj.com/problems/MAKEMAZE) | 3178 | 32.20 |
+| 11517 | [GAMING ARENA](https://www.spoj.com/problems/GAMARENA) | 61 | 40.34 |
+| 11521 | [Dominant Strings](https://www.spoj.com/problems/DOMINST) | 78 | 34.81 |
+| 11540 | [Training](https://www.spoj.com/problems/TRAIN07) | 18 | 26.67 |
+| 11560 | [A Summatory](https://www.spoj.com/problems/PUCMM210) | 1646 | 26.01 |
+| 11564 | [E 23 Stairs pattern](https://www.spoj.com/problems/PUCMM215) | 140 | 39.70 |
+| 11573 | [A Famous ICPC Team](https://www.spoj.com/problems/TEAM2) | 2046 | 37.72 |
+| 11574 | [A Famous Stone Collector](https://www.spoj.com/problems/STONE2) | 129 | 36.09 |
+| 11575 | [A Famous Equation](https://www.spoj.com/problems/EQ2) | 81 | 27.32 |
+| 11576 | [A Famous King’s Trip](https://www.spoj.com/problems/TRIP2) | 25 | 10.72 |
+| 11577 | [The Famous ICPC Team Again](https://www.spoj.com/problems/MEDIAN3) | 83 | 30.89 |
+| 11578 | [A Famous City](https://www.spoj.com/problems/CITY2) | 805 | 31.00 |
+| 11579 | [Two Famous Companies](https://www.spoj.com/problems/COMPANYS) | 235 | 22.02 |
+| 11580 | [A Famous Game](https://www.spoj.com/problems/PRLGAME2) | 409 | 34.93 |

--- a/tests/spoj/index/44.jsonl
+++ b/tests/spoj/index/44.jsonl
@@ -1,0 +1,50 @@
+{"id":11582,"name":"A Famous Grid","url":"https://www.spoj.com/problems/SPIRALGR","users":196,"accepted":16.9}
+{"id":11601,"name":"With a Pit of Death","url":"https://www.spoj.com/problems/DOJO","users":521,"accepted":28.82}
+{"id":11603,"name":"Polynomial f(x) to Polynomial h(x)","url":"https://www.spoj.com/problems/POLTOPOL","users":77,"accepted":57.39}
+{"id":11604,"name":"The return of the Cake","url":"https://www.spoj.com/problems/REBOUND","users":916,"accepted":27.78}
+{"id":11613,"name":"Aho-Corasick Trie","url":"https://www.spoj.com/problems/AHOCUR","users":53,"accepted":11.03}
+{"id":11642,"name":"MAKESUM","url":"https://www.spoj.com/problems/MAKESUM","users":113,"accepted":35.51}
+{"id":11676,"name":"Counting diff-pairs","url":"https://www.spoj.com/problems/CPAIR2","users":207,"accepted":21.41}
+{"id":11695,"name":"A Summatory (HARD)","url":"https://www.spoj.com/problems/ASUMHARD","users":102,"accepted":29.89}
+{"id":11707,"name":"Wrong directions","url":"https://www.spoj.com/problems/WRONG","users":50,"accepted":30.81}
+{"id":11712,"name":"Red Cross Hospital","url":"https://www.spoj.com/problems/REDCROSS","users":21,"accepted":25.22}
+{"id":11718,"name":"Boa viagem, Roim","url":"https://www.spoj.com/problems/ROIM","users":75,"accepted":16.16}
+{"id":11723,"name":"HELP ABHISHEK(version-II)","url":"https://www.spoj.com/problems/COMPLEX2","users":38,"accepted":58.19}
+{"id":11736,"name":"Prime Time","url":"https://www.spoj.com/problems/PTIME","users":2167,"accepted":48.58}
+{"id":11756,"name":"Teaming up for the competition","url":"https://www.spoj.com/problems/PONY5","users":35,"accepted":33.99}
+{"id":11769,"name":"Kind and gently","url":"https://www.spoj.com/problems/RPLK","users":106,"accepted":53.23}
+{"id":11770,"name":"Lifesavers","url":"https://www.spoj.com/problems/RPLL","users":82,"accepted":26.71}
+{"id":11771,"name":"Mountain Cave","url":"https://www.spoj.com/problems/RPLM","users":16,"accepted":8.31}
+{"id":11772,"name":"Negative Score","url":"https://www.spoj.com/problems/RPLN","users":3451,"accepted":34.17}
+{"id":11777,"name":"Easy Sequence!","url":"https://www.spoj.com/problems/SEQAGAIN","users":157,"accepted":25.76}
+{"id":11789,"name":"Aliens at the subway","url":"https://www.spoj.com/problems/ALIEN3","users":78,"accepted":18.13}
+{"id":11808,"name":"Max 2214","url":"https://www.spoj.com/problems/MAX2214","users":11,"accepted":11.7}
+{"id":11813,"name":"Count weighted paths","url":"https://www.spoj.com/problems/CNTPATHS","users":23,"accepted":42.86}
+{"id":11814,"name":"Eko","url":"https://www.spoj.com/problems/EKO","users":16700,"accepted":26.93}
+{"id":11830,"name":"DOJO Corridor I","url":"https://www.spoj.com/problems/DOJ1","users":32,"accepted":31.63}
+{"id":11834,"name":"DOJO Corridor II","url":"https://www.spoj.com/problems/DOJ2","users":27,"accepted":30.85}
+{"id":11840,"name":"Sum of Squares with Segment Tree","url":"https://www.spoj.com/problems/SEGSQRSS","users":2086,"accepted":51.04}
+{"id":11844,"name":"Binary Sequence of Prime Number","url":"https://www.spoj.com/problems/BSPRIME","users":240,"accepted":20.94}
+{"id":11848,"name":"Power with Combinatorics","url":"https://www.spoj.com/problems/POWPOW","users":436,"accepted":20.36}
+{"id":11851,"name":"Power with Combinatorics(HARD)","url":"https://www.spoj.com/problems/POWPOW2","users":130,"accepted":13.2}
+{"id":11871,"name":"Captain Qs Treasure","url":"https://www.spoj.com/problems/FUKU11G","users":13,"accepted":63.64}
+{"id":11873,"name":"Round Trip","url":"https://www.spoj.com/problems/FUKU11J","users":9,"accepted":8.7}
+{"id":11875,"name":"Jobs","url":"https://www.spoj.com/problems/POSAO","users":361,"accepted":38.89}
+{"id":11885,"name":"Drawing Triangles with Brainf##k","url":"https://www.spoj.com/problems/BFTRI","users":46,"accepted":33.68}
+{"id":11895,"name":"DONALDO","url":"https://www.spoj.com/problems/DONALDO","users":518,"accepted":24.81}
+{"id":11899,"name":"Queen Game","url":"https://www.spoj.com/problems/PK11E","users":21,"accepted":22.7}
+{"id":11900,"name":"Spelling Suggestion","url":"https://www.spoj.com/problems/PK11F","users":8,"accepted":12.86}
+{"id":11901,"name":"Paths in a Tree","url":"https://www.spoj.com/problems/PK11I","users":24,"accepted":26.19}
+{"id":11904,"name":"A Classic Myth - Flatland Superhero","url":"https://www.spoj.com/problems/FLATAND","users":11,"accepted":41.18}
+{"id":11905,"name":"Tree Count","url":"https://www.spoj.com/problems/TRECOUNT","users":45,"accepted":40.36}
+{"id":11906,"name":"Rescue On Time","url":"https://www.spoj.com/problems/ROT","users":26,"accepted":33}
+{"id":11909,"name":"C You and Me","url":"https://www.spoj.com/problems/PUCMM223","users":95,"accepted":45.36}
+{"id":11921,"name":"Ball Stack","url":"https://www.spoj.com/problems/BALLLSTA","users":43,"accepted":54.78}
+{"id":11931,"name":"AMZ Word","url":"https://www.spoj.com/problems/AMZSEQ","users":1708,"accepted":64.76}
+{"id":11932,"name":"Amz Rock","url":"https://www.spoj.com/problems/AMZRCK","users":1785,"accepted":61.76}
+{"id":11933,"name":"DIAGONAL","url":"https://www.spoj.com/problems/DIG","users":962,"accepted":24.58}
+{"id":11935,"name":"Decorating the Palace","url":"https://www.spoj.com/problems/DEC123","users":23,"accepted":40.62}
+{"id":11946,"name":"Zig-Zag Permutation 2","url":"https://www.spoj.com/problems/ZZPERM2","users":7,"accepted":25.49}
+{"id":11947,"name":"Counting Words","url":"https://www.spoj.com/problems/GSWORDS","users":169,"accepted":26.66}
+{"id":11948,"name":"Dark Assault","url":"https://www.spoj.com/problems/DARKASLT","users":31,"accepted":30.47}
+{"id":11952,"name":"Intergalactic Highways","url":"https://www.spoj.com/problems/IGALAXY","users":151,"accepted":29.02}

--- a/tests/spoj/index/44.md
+++ b/tests/spoj/index/44.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 11582 | [A Famous Grid](https://www.spoj.com/problems/SPIRALGR) | 196 | 16.90 |
+| 11601 | [With a Pit of Death](https://www.spoj.com/problems/DOJO) | 521 | 28.82 |
+| 11603 | [Polynomial f(x) to Polynomial h(x)](https://www.spoj.com/problems/POLTOPOL) | 77 | 57.39 |
+| 11604 | [The return of the Cake](https://www.spoj.com/problems/REBOUND) | 916 | 27.78 |
+| 11613 | [Aho-Corasick Trie](https://www.spoj.com/problems/AHOCUR) | 53 | 11.03 |
+| 11642 | [MAKESUM](https://www.spoj.com/problems/MAKESUM) | 113 | 35.51 |
+| 11676 | [Counting diff-pairs](https://www.spoj.com/problems/CPAIR2) | 207 | 21.41 |
+| 11695 | [A Summatory (HARD)](https://www.spoj.com/problems/ASUMHARD) | 102 | 29.89 |
+| 11707 | [Wrong directions](https://www.spoj.com/problems/WRONG) | 50 | 30.81 |
+| 11712 | [Red Cross Hospital](https://www.spoj.com/problems/REDCROSS) | 21 | 25.22 |
+| 11718 | [Boa viagem, Roim](https://www.spoj.com/problems/ROIM) | 75 | 16.16 |
+| 11723 | [HELP ABHISHEK(version-II)](https://www.spoj.com/problems/COMPLEX2) | 38 | 58.19 |
+| 11736 | [Prime Time](https://www.spoj.com/problems/PTIME) | 2167 | 48.58 |
+| 11756 | [Teaming up for the competition](https://www.spoj.com/problems/PONY5) | 35 | 33.99 |
+| 11769 | [Kind and gently](https://www.spoj.com/problems/RPLK) | 106 | 53.23 |
+| 11770 | [Lifesavers](https://www.spoj.com/problems/RPLL) | 82 | 26.71 |
+| 11771 | [Mountain Cave](https://www.spoj.com/problems/RPLM) | 16 | 8.31 |
+| 11772 | [Negative Score](https://www.spoj.com/problems/RPLN) | 3451 | 34.17 |
+| 11777 | [Easy Sequence!](https://www.spoj.com/problems/SEQAGAIN) | 157 | 25.76 |
+| 11789 | [Aliens at the subway](https://www.spoj.com/problems/ALIEN3) | 78 | 18.13 |
+| 11808 | [Max 2214](https://www.spoj.com/problems/MAX2214) | 11 | 11.70 |
+| 11813 | [Count weighted paths](https://www.spoj.com/problems/CNTPATHS) | 23 | 42.86 |
+| 11814 | [Eko](https://www.spoj.com/problems/EKO) | 16700 | 26.93 |
+| 11830 | [DOJO Corridor I](https://www.spoj.com/problems/DOJ1) | 32 | 31.63 |
+| 11834 | [DOJO Corridor II](https://www.spoj.com/problems/DOJ2) | 27 | 30.85 |
+| 11840 | [Sum of Squares with Segment Tree](https://www.spoj.com/problems/SEGSQRSS) | 2086 | 51.04 |
+| 11844 | [Binary Sequence of Prime Number](https://www.spoj.com/problems/BSPRIME) | 240 | 20.94 |
+| 11848 | [Power with Combinatorics](https://www.spoj.com/problems/POWPOW) | 436 | 20.36 |
+| 11851 | [Power with Combinatorics(HARD)](https://www.spoj.com/problems/POWPOW2) | 130 | 13.20 |
+| 11871 | [Captain Qs Treasure](https://www.spoj.com/problems/FUKU11G) | 13 | 63.64 |
+| 11873 | [Round Trip](https://www.spoj.com/problems/FUKU11J) | 9 | 8.70 |
+| 11875 | [Jobs](https://www.spoj.com/problems/POSAO) | 361 | 38.89 |
+| 11885 | [Drawing Triangles with Brainf##k](https://www.spoj.com/problems/BFTRI) | 46 | 33.68 |
+| 11895 | [DONALDO](https://www.spoj.com/problems/DONALDO) | 518 | 24.81 |
+| 11899 | [Queen Game](https://www.spoj.com/problems/PK11E) | 21 | 22.70 |
+| 11900 | [Spelling Suggestion](https://www.spoj.com/problems/PK11F) | 8 | 12.86 |
+| 11901 | [Paths in a Tree](https://www.spoj.com/problems/PK11I) | 24 | 26.19 |
+| 11904 | [A Classic Myth - Flatland Superhero](https://www.spoj.com/problems/FLATAND) | 11 | 41.18 |
+| 11905 | [Tree Count](https://www.spoj.com/problems/TRECOUNT) | 45 | 40.36 |
+| 11906 | [Rescue On Time](https://www.spoj.com/problems/ROT) | 26 | 33.00 |
+| 11909 | [C You and Me](https://www.spoj.com/problems/PUCMM223) | 95 | 45.36 |
+| 11921 | [Ball Stack](https://www.spoj.com/problems/BALLLSTA) | 43 | 54.78 |
+| 11931 | [AMZ Word](https://www.spoj.com/problems/AMZSEQ) | 1708 | 64.76 |
+| 11932 | [Amz Rock](https://www.spoj.com/problems/AMZRCK) | 1785 | 61.76 |
+| 11933 | [DIAGONAL](https://www.spoj.com/problems/DIG) | 962 | 24.58 |
+| 11935 | [Decorating the Palace](https://www.spoj.com/problems/DEC123) | 23 | 40.62 |
+| 11946 | [Zig-Zag Permutation 2](https://www.spoj.com/problems/ZZPERM2) | 7 | 25.49 |
+| 11947 | [Counting Words](https://www.spoj.com/problems/GSWORDS) | 169 | 26.66 |
+| 11948 | [Dark Assault](https://www.spoj.com/problems/DARKASLT) | 31 | 30.47 |
+| 11952 | [Intergalactic Highways](https://www.spoj.com/problems/IGALAXY) | 151 | 29.02 |

--- a/tests/spoj/index/45.jsonl
+++ b/tests/spoj/index/45.jsonl
@@ -1,0 +1,50 @@
+{"id":11956,"name":"Addicted","url":"https://www.spoj.com/problems/TLL237","users":57,"accepted":57.24}
+{"id":11962,"name":"Arya Rage","url":"https://www.spoj.com/problems/MNNITAR","users":327,"accepted":42.46}
+{"id":11963,"name":"Packing Rectangles","url":"https://www.spoj.com/problems/PACKRECT","users":40,"accepted":51.65}
+{"id":11984,"name":"Dome of Circus","url":"https://www.spoj.com/problems/DOMECIR","users":21,"accepted":45.95}
+{"id":11985,"name":"Gao on a tree","url":"https://www.spoj.com/problems/GOT","users":869,"accepted":15.27}
+{"id":11986,"name":"ROMAN NUMERALS","url":"https://www.spoj.com/problems/ROMAN008","users":145,"accepted":33.76}
+{"id":11997,"name":"Trip To London","url":"https://www.spoj.com/problems/DCEPC803","users":153,"accepted":52.68}
+{"id":11998,"name":"Totient Fever","url":"https://www.spoj.com/problems/DCEPC804","users":72,"accepted":43.66}
+{"id":12001,"name":"Bit by Bit","url":"https://www.spoj.com/problems/DCEPC807","users":144,"accepted":37.28}
+{"id":12004,"name":"Cousin Wars","url":"https://www.spoj.com/problems/DCEPC810","users":36,"accepted":19.86}
+{"id":12005,"name":"Grass Planting","url":"https://www.spoj.com/problems/GRASSPLA","users":608,"accepted":45.24}
+{"id":12007,"name":"Fibonaccibonacci (easy)","url":"https://www.spoj.com/problems/FRS2","users":115,"accepted":29.03}
+{"id":12008,"name":"Fibonacci recursive sequences (medium)","url":"https://www.spoj.com/problems/FRSKT","users":50,"accepted":26.95}
+{"id":12009,"name":"Fibonacci recursive sequences (hard)","url":"https://www.spoj.com/problems/FRSKH","users":27,"accepted":10.05}
+{"id":12012,"name":"grace marks","url":"https://www.spoj.com/problems/MTHUR","users":229,"accepted":22.97}
+{"id":12030,"name":"Blackout","url":"https://www.spoj.com/problems/BLACKOUT","users":376,"accepted":44.48}
+{"id":12056,"name":"Nubulsa Expo","url":"https://www.spoj.com/problems/FZ10B","users":9,"accepted":8.57}
+{"id":12076,"name":"Longest Common Subsequence","url":"https://www.spoj.com/problems/LCS0","users":148,"accepted":4.66}
+{"id":12107,"name":"All Possible Barns","url":"https://www.spoj.com/problems/ALLBARN2","users":34,"accepted":25.23}
+{"id":12108,"name":"Linear Garden","url":"https://www.spoj.com/problems/LINEGAR","users":78,"accepted":35.09}
+{"id":12125,"name":"Fibonacci With a Square Root","url":"https://www.spoj.com/problems/FIBOSQRT","users":151,"accepted":33.42}
+{"id":12150,"name":"Just Next !!!","url":"https://www.spoj.com/problems/JNEXT","users":6663,"accepted":23.11}
+{"id":12151,"name":"Pizzamania","url":"https://www.spoj.com/problems/OPCPIZZA","users":2184,"accepted":28.64}
+{"id":12183,"name":"Help the Commander in Chief","url":"https://www.spoj.com/problems/KFSTB","users":915,"accepted":29.09}
+{"id":12209,"name":"Morenas Candy Shop ( Easy )","url":"https://www.spoj.com/problems/MORENA","users":258,"accepted":33.33}
+{"id":12210,"name":"High and Low","url":"https://www.spoj.com/problems/HILO","users":65,"accepted":12.96}
+{"id":12236,"name":"Cloud Computing","url":"https://www.spoj.com/problems/CLOUDMG","users":39,"accepted":34.46}
+{"id":12240,"name":"Multinomial numbers","url":"https://www.spoj.com/problems/HS12MULT","users":19,"accepted":39.29}
+{"id":12241,"name":"Classification from Erdős and Selfridge","url":"https://www.spoj.com/problems/HS12PRIM","users":32,"accepted":19.6}
+{"id":12243,"name":"Natalia Spins The Roulette","url":"https://www.spoj.com/problems/ROULETTD","users":54,"accepted":51.39}
+{"id":12244,"name":"Natalia Has Another Problem","url":"https://www.spoj.com/problems/NATALIAS","users":115,"accepted":47.52}
+{"id":12245,"name":"Natalia Plays a Game","url":"https://www.spoj.com/problems/NATALIAG","users":931,"accepted":44.08}
+{"id":12249,"name":"Spiderman vs Sandman","url":"https://www.spoj.com/problems/SPIDY","users":111,"accepted":27.03}
+{"id":12250,"name":"Buzz Trouble","url":"https://www.spoj.com/problems/BUZZOFF","users":204,"accepted":40.4}
+{"id":12251,"name":"Mad Hulk","url":"https://www.spoj.com/problems/MADHULK","users":12,"accepted":15}
+{"id":12260,"name":"Devlali Numbers","url":"https://www.spoj.com/problems/HARSHAD","users":726,"accepted":37.85}
+{"id":12262,"name":"Mirror Strings !!!","url":"https://www.spoj.com/problems/MSUBSTR","users":948,"accepted":33.54}
+{"id":12277,"name":"The Trip","url":"https://www.spoj.com/problems/OPCTRIP","users":118,"accepted":31.34}
+{"id":12295,"name":"Smallest Inverse Euler Totient Function","url":"https://www.spoj.com/problems/INVPHI","users":234,"accepted":22.87}
+{"id":12304,"name":"Smallest Inverse Sum of Divisors","url":"https://www.spoj.com/problems/INVDIV","users":99,"accepted":26.65}
+{"id":12318,"name":"My Reaction when there is no internet connection","url":"https://www.spoj.com/problems/NITT1","users":32,"accepted":25.93}
+{"id":12319,"name":"hai jolly jolly jolly","url":"https://www.spoj.com/problems/NITT2","users":1273,"accepted":33.95}
+{"id":12321,"name":"NSquare Sum ( Easy )","url":"https://www.spoj.com/problems/NSQUARE","users":95,"accepted":60.22}
+{"id":12322,"name":"NSquare Sum ( Medium )","url":"https://www.spoj.com/problems/NSQUARE2","users":64,"accepted":35.65}
+{"id":12323,"name":"Minimum Knight moves !!!","url":"https://www.spoj.com/problems/NAKANJ","users":8683,"accepted":42.62}
+{"id":12324,"name":"Tiles","url":"https://www.spoj.com/problems/NITT4","users":100,"accepted":21.57}
+{"id":12326,"name":"Dating Rishi","url":"https://www.spoj.com/problems/NITT8","users":637,"accepted":36.27}
+{"id":12352,"name":"HNumbers","url":"https://www.spoj.com/problems/HNUMBERS","users":202,"accepted":27.56}
+{"id":12357,"name":"Subset and upset (HARD)","url":"https://www.spoj.com/problems/SUBSHARD","users":128,"accepted":40.98}
+{"id":12363,"name":"Red And Green","url":"https://www.spoj.com/problems/RANDG","users":257,"accepted":40.14}

--- a/tests/spoj/index/45.md
+++ b/tests/spoj/index/45.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 11956 | [Addicted](https://www.spoj.com/problems/TLL237) | 57 | 57.24 |
+| 11962 | [Arya Rage](https://www.spoj.com/problems/MNNITAR) | 327 | 42.46 |
+| 11963 | [Packing Rectangles](https://www.spoj.com/problems/PACKRECT) | 40 | 51.65 |
+| 11984 | [Dome of Circus](https://www.spoj.com/problems/DOMECIR) | 21 | 45.95 |
+| 11985 | [Gao on a tree](https://www.spoj.com/problems/GOT) | 869 | 15.27 |
+| 11986 | [ROMAN NUMERALS](https://www.spoj.com/problems/ROMAN008) | 145 | 33.76 |
+| 11997 | [Trip To London](https://www.spoj.com/problems/DCEPC803) | 153 | 52.68 |
+| 11998 | [Totient Fever](https://www.spoj.com/problems/DCEPC804) | 72 | 43.66 |
+| 12001 | [Bit by Bit](https://www.spoj.com/problems/DCEPC807) | 144 | 37.28 |
+| 12004 | [Cousin Wars](https://www.spoj.com/problems/DCEPC810) | 36 | 19.86 |
+| 12005 | [Grass Planting](https://www.spoj.com/problems/GRASSPLA) | 608 | 45.24 |
+| 12007 | [Fibonaccibonacci (easy)](https://www.spoj.com/problems/FRS2) | 115 | 29.03 |
+| 12008 | [Fibonacci recursive sequences (medium)](https://www.spoj.com/problems/FRSKT) | 50 | 26.95 |
+| 12009 | [Fibonacci recursive sequences (hard)](https://www.spoj.com/problems/FRSKH) | 27 | 10.05 |
+| 12012 | [grace marks](https://www.spoj.com/problems/MTHUR) | 229 | 22.97 |
+| 12030 | [Blackout](https://www.spoj.com/problems/BLACKOUT) | 376 | 44.48 |
+| 12056 | [Nubulsa Expo](https://www.spoj.com/problems/FZ10B) | 9 | 8.57 |
+| 12076 | [Longest Common Subsequence](https://www.spoj.com/problems/LCS0) | 148 | 4.66 |
+| 12107 | [All Possible Barns](https://www.spoj.com/problems/ALLBARN2) | 34 | 25.23 |
+| 12108 | [Linear Garden](https://www.spoj.com/problems/LINEGAR) | 78 | 35.09 |
+| 12125 | [Fibonacci With a Square Root](https://www.spoj.com/problems/FIBOSQRT) | 151 | 33.42 |
+| 12150 | [Just Next !!!](https://www.spoj.com/problems/JNEXT) | 6663 | 23.11 |
+| 12151 | [Pizzamania](https://www.spoj.com/problems/OPCPIZZA) | 2184 | 28.64 |
+| 12183 | [Help the Commander in Chief](https://www.spoj.com/problems/KFSTB) | 915 | 29.09 |
+| 12209 | [Morenas Candy Shop ( Easy )](https://www.spoj.com/problems/MORENA) | 258 | 33.33 |
+| 12210 | [High and Low](https://www.spoj.com/problems/HILO) | 65 | 12.96 |
+| 12236 | [Cloud Computing](https://www.spoj.com/problems/CLOUDMG) | 39 | 34.46 |
+| 12240 | [Multinomial numbers](https://www.spoj.com/problems/HS12MULT) | 19 | 39.29 |
+| 12241 | [Classification from Erdős and Selfridge](https://www.spoj.com/problems/HS12PRIM) | 32 | 19.60 |
+| 12243 | [Natalia Spins The Roulette](https://www.spoj.com/problems/ROULETTD) | 54 | 51.39 |
+| 12244 | [Natalia Has Another Problem](https://www.spoj.com/problems/NATALIAS) | 115 | 47.52 |
+| 12245 | [Natalia Plays a Game](https://www.spoj.com/problems/NATALIAG) | 931 | 44.08 |
+| 12249 | [Spiderman vs Sandman](https://www.spoj.com/problems/SPIDY) | 111 | 27.03 |
+| 12250 | [Buzz Trouble](https://www.spoj.com/problems/BUZZOFF) | 204 | 40.40 |
+| 12251 | [Mad Hulk](https://www.spoj.com/problems/MADHULK) | 12 | 15.00 |
+| 12260 | [Devlali Numbers](https://www.spoj.com/problems/HARSHAD) | 726 | 37.85 |
+| 12262 | [Mirror Strings !!!](https://www.spoj.com/problems/MSUBSTR) | 948 | 33.54 |
+| 12277 | [The Trip](https://www.spoj.com/problems/OPCTRIP) | 118 | 31.34 |
+| 12295 | [Smallest Inverse Euler Totient Function](https://www.spoj.com/problems/INVPHI) | 234 | 22.87 |
+| 12304 | [Smallest Inverse Sum of Divisors](https://www.spoj.com/problems/INVDIV) | 99 | 26.65 |
+| 12318 | [My Reaction when there is no internet connection](https://www.spoj.com/problems/NITT1) | 32 | 25.93 |
+| 12319 | [hai jolly jolly jolly](https://www.spoj.com/problems/NITT2) | 1273 | 33.95 |
+| 12321 | [NSquare Sum ( Easy )](https://www.spoj.com/problems/NSQUARE) | 95 | 60.22 |
+| 12322 | [NSquare Sum ( Medium )](https://www.spoj.com/problems/NSQUARE2) | 64 | 35.65 |
+| 12323 | [Minimum Knight moves !!!](https://www.spoj.com/problems/NAKANJ) | 8683 | 42.62 |
+| 12324 | [Tiles](https://www.spoj.com/problems/NITT4) | 100 | 21.57 |
+| 12326 | [Dating Rishi](https://www.spoj.com/problems/NITT8) | 637 | 36.27 |
+| 12352 | [HNumbers](https://www.spoj.com/problems/HNUMBERS) | 202 | 27.56 |
+| 12357 | [Subset and upset (HARD)](https://www.spoj.com/problems/SUBSHARD) | 128 | 40.98 |
+| 12363 | [Red And Green](https://www.spoj.com/problems/RANDG) | 257 | 40.14 |

--- a/tests/spoj/index/46.jsonl
+++ b/tests/spoj/index/46.jsonl
@@ -1,0 +1,50 @@
+{"id":12364,"name":"Awari 2","url":"https://www.spoj.com/problems/TAP2012A","users":364,"accepted":48.94}
+{"id":12365,"name":"Ball of Reconciliation","url":"https://www.spoj.com/problems/TAP2012B","users":344,"accepted":52.28}
+{"id":12366,"name":"Cantor","url":"https://www.spoj.com/problems/TAP2012C","users":209,"accepted":46.83}
+{"id":12367,"name":"Designing T-Shirts","url":"https://www.spoj.com/problems/TAP2012D","users":269,"accepted":32.61}
+{"id":12368,"name":"Emma s Domino","url":"https://www.spoj.com/problems/TAP2012E","users":96,"accepted":32.19}
+{"id":12369,"name":"Fixture","url":"https://www.spoj.com/problems/TAP2012F","users":113,"accepted":35.7}
+{"id":12370,"name":"Generating Alien DNA","url":"https://www.spoj.com/problems/TAP2012G","users":31,"accepted":16.67}
+{"id":12371,"name":"High Mountains","url":"https://www.spoj.com/problems/TAP2012H","users":42,"accepted":13.07}
+{"id":12397,"name":"Johnny plays with connect 4","url":"https://www.spoj.com/problems/LCPC12B","users":54,"accepted":30.73}
+{"id":12398,"name":"Johnny Listens to Music","url":"https://www.spoj.com/problems/LCPC12C","users":89,"accepted":34.04}
+{"id":12399,"name":"Johnny Hates Climbing","url":"https://www.spoj.com/problems/LCPC12D","users":115,"accepted":23.72}
+{"id":12400,"name":"Johnnys Empire","url":"https://www.spoj.com/problems/LCPC12E","users":538,"accepted":43.46}
+{"id":12407,"name":"Johnny The Gambler","url":"https://www.spoj.com/problems/LCPC12F","users":963,"accepted":20.71}
+{"id":12408,"name":"Johnny Studies Genetics","url":"https://www.spoj.com/problems/LCPC12G","users":42,"accepted":37.68}
+{"id":12409,"name":"Johnny at school","url":"https://www.spoj.com/problems/LCPC12H","users":74,"accepted":23.92}
+{"id":12413,"name":"Toward Infinity","url":"https://www.spoj.com/problems/PONY6","users":24,"accepted":38.26}
+{"id":12421,"name":"Chocolate Distribution","url":"https://www.spoj.com/problems/KSELECT","users":45,"accepted":23.93}
+{"id":12436,"name":"The One-Dimensional Pool Table","url":"https://www.spoj.com/problems/THEPOOL","users":63,"accepted":41.35}
+{"id":12446,"name":"BHAAD MEI JAAO","url":"https://www.spoj.com/problems/JUNL","users":111,"accepted":52.75}
+{"id":12448,"name":"How Many Games?","url":"https://www.spoj.com/problems/GAMES","users":3759,"accepted":22.37}
+{"id":12462,"name":"Boggle Scoring","url":"https://www.spoj.com/problems/BOGGLE","users":543,"accepted":48.24}
+{"id":12471,"name":"DIE HARD","url":"https://www.spoj.com/problems/DIEHARD","users":7982,"accepted":38.7}
+{"id":12474,"name":"MAXIMUM WOOD CUTTER","url":"https://www.spoj.com/problems/MAXWOODS","users":1564,"accepted":41.85}
+{"id":12556,"name":"Another Traffic Problem","url":"https://www.spoj.com/problems/CDC12_A","users":38,"accepted":16.16}
+{"id":12557,"name":"Basic Routines","url":"https://www.spoj.com/problems/CDC12_B","users":98,"accepted":19.23}
+{"id":12558,"name":"Collision Issue","url":"https://www.spoj.com/problems/CDC12_C","users":73,"accepted":36.33}
+{"id":12559,"name":"Drastic Race","url":"https://www.spoj.com/problems/CDC12_D","users":51,"accepted":36.42}
+{"id":12560,"name":"External Falling Objects","url":"https://www.spoj.com/problems/CDC12_E","users":60,"accepted":40.08}
+{"id":12561,"name":"Forbidden Machine","url":"https://www.spoj.com/problems/CDC12_F","users":55,"accepted":21.77}
+{"id":12562,"name":"Glory War","url":"https://www.spoj.com/problems/CDC12_G","users":36,"accepted":33.5}
+{"id":12563,"name":"Halt The War","url":"https://www.spoj.com/problems/CDC12_H","users":401,"accepted":29.64}
+{"id":12579,"name":"Search Insert Delete","url":"https://www.spoj.com/problems/SID","users":104,"accepted":10.65}
+{"id":12600,"name":"Blade Master","url":"https://www.spoj.com/problems/BMASTER","users":16,"accepted":39.66}
+{"id":12609,"name":"Different Vectors","url":"https://www.spoj.com/problems/DIFFV","users":43,"accepted":36.27}
+{"id":12612,"name":"Path of the righteous man","url":"https://www.spoj.com/problems/RIOI_2_3","users":502,"accepted":36.14}
+{"id":12651,"name":"Finding Fishes","url":"https://www.spoj.com/problems/FISHES","users":46,"accepted":27.87}
+{"id":12660,"name":"Co-Prime","url":"https://www.spoj.com/problems/LCPC11B","users":281,"accepted":26.74}
+{"id":12713,"name":"Strings","url":"https://www.spoj.com/problems/STRSOCU","users":38,"accepted":22.86}
+{"id":12714,"name":"Fatawy","url":"https://www.spoj.com/problems/FATAWY","users":148,"accepted":25.64}
+{"id":12721,"name":"Pell (Mid pelling)","url":"https://www.spoj.com/problems/PELL2","users":45,"accepted":34.03}
+{"id":12726,"name":"XOR Game","url":"https://www.spoj.com/problems/QN01","users":541,"accepted":43.97}
+{"id":12734,"name":"Seating Arrangement","url":"https://www.spoj.com/problems/QN02","users":165,"accepted":60.52}
+{"id":12746,"name":"Colorful Circle (EASY)","url":"https://www.spoj.com/problems/CRCLE_UI","users":483,"accepted":20.99}
+{"id":12749,"name":"Dynamic Assignment Problem","url":"https://www.spoj.com/problems/DAP","users":16,"accepted":54.64}
+{"id":12802,"name":"Yet Another Counting Problem","url":"https://www.spoj.com/problems/TRI2","users":13,"accepted":46.77}
+{"id":12803,"name":"Graph","url":"https://www.spoj.com/problems/GRAPH2","users":8,"accepted":15}
+{"id":12804,"name":"Spy","url":"https://www.spoj.com/problems/SPY2","users":6,"accepted":12.24}
+{"id":12805,"name":"Age of Empires","url":"https://www.spoj.com/problems/AGE2","users":3,"accepted":6.41}
+{"id":12806,"name":"Blackjack","url":"https://www.spoj.com/problems/BLACJACK","users":7,"accepted":16}
+{"id":12807,"name":"Recursive Sequence (Version X)","url":"https://www.spoj.com/problems/SPP2","users":12,"accepted":16.28}

--- a/tests/spoj/index/46.md
+++ b/tests/spoj/index/46.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 12364 | [Awari 2](https://www.spoj.com/problems/TAP2012A) | 364 | 48.94 |
+| 12365 | [Ball of Reconciliation](https://www.spoj.com/problems/TAP2012B) | 344 | 52.28 |
+| 12366 | [Cantor](https://www.spoj.com/problems/TAP2012C) | 209 | 46.83 |
+| 12367 | [Designing T-Shirts](https://www.spoj.com/problems/TAP2012D) | 269 | 32.61 |
+| 12368 | [Emma s Domino](https://www.spoj.com/problems/TAP2012E) | 96 | 32.19 |
+| 12369 | [Fixture](https://www.spoj.com/problems/TAP2012F) | 113 | 35.70 |
+| 12370 | [Generating Alien DNA](https://www.spoj.com/problems/TAP2012G) | 31 | 16.67 |
+| 12371 | [High Mountains](https://www.spoj.com/problems/TAP2012H) | 42 | 13.07 |
+| 12397 | [Johnny plays with connect 4](https://www.spoj.com/problems/LCPC12B) | 54 | 30.73 |
+| 12398 | [Johnny Listens to Music](https://www.spoj.com/problems/LCPC12C) | 89 | 34.04 |
+| 12399 | [Johnny Hates Climbing](https://www.spoj.com/problems/LCPC12D) | 115 | 23.72 |
+| 12400 | [Johnnys Empire](https://www.spoj.com/problems/LCPC12E) | 538 | 43.46 |
+| 12407 | [Johnny The Gambler](https://www.spoj.com/problems/LCPC12F) | 963 | 20.71 |
+| 12408 | [Johnny Studies Genetics](https://www.spoj.com/problems/LCPC12G) | 42 | 37.68 |
+| 12409 | [Johnny at school](https://www.spoj.com/problems/LCPC12H) | 74 | 23.92 |
+| 12413 | [Toward Infinity](https://www.spoj.com/problems/PONY6) | 24 | 38.26 |
+| 12421 | [Chocolate Distribution](https://www.spoj.com/problems/KSELECT) | 45 | 23.93 |
+| 12436 | [The One-Dimensional Pool Table](https://www.spoj.com/problems/THEPOOL) | 63 | 41.35 |
+| 12446 | [BHAAD MEI JAAO](https://www.spoj.com/problems/JUNL) | 111 | 52.75 |
+| 12448 | [How Many Games?](https://www.spoj.com/problems/GAMES) | 3759 | 22.37 |
+| 12462 | [Boggle Scoring](https://www.spoj.com/problems/BOGGLE) | 543 | 48.24 |
+| 12471 | [DIE HARD](https://www.spoj.com/problems/DIEHARD) | 7982 | 38.70 |
+| 12474 | [MAXIMUM WOOD CUTTER](https://www.spoj.com/problems/MAXWOODS) | 1564 | 41.85 |
+| 12556 | [Another Traffic Problem](https://www.spoj.com/problems/CDC12_A) | 38 | 16.16 |
+| 12557 | [Basic Routines](https://www.spoj.com/problems/CDC12_B) | 98 | 19.23 |
+| 12558 | [Collision Issue](https://www.spoj.com/problems/CDC12_C) | 73 | 36.33 |
+| 12559 | [Drastic Race](https://www.spoj.com/problems/CDC12_D) | 51 | 36.42 |
+| 12560 | [External Falling Objects](https://www.spoj.com/problems/CDC12_E) | 60 | 40.08 |
+| 12561 | [Forbidden Machine](https://www.spoj.com/problems/CDC12_F) | 55 | 21.77 |
+| 12562 | [Glory War](https://www.spoj.com/problems/CDC12_G) | 36 | 33.50 |
+| 12563 | [Halt The War](https://www.spoj.com/problems/CDC12_H) | 401 | 29.64 |
+| 12579 | [Search Insert Delete](https://www.spoj.com/problems/SID) | 104 | 10.65 |
+| 12600 | [Blade Master](https://www.spoj.com/problems/BMASTER) | 16 | 39.66 |
+| 12609 | [Different Vectors](https://www.spoj.com/problems/DIFFV) | 43 | 36.27 |
+| 12612 | [Path of the righteous man](https://www.spoj.com/problems/RIOI_2_3) | 502 | 36.14 |
+| 12651 | [Finding Fishes](https://www.spoj.com/problems/FISHES) | 46 | 27.87 |
+| 12660 | [Co-Prime](https://www.spoj.com/problems/LCPC11B) | 281 | 26.74 |
+| 12713 | [Strings](https://www.spoj.com/problems/STRSOCU) | 38 | 22.86 |
+| 12714 | [Fatawy](https://www.spoj.com/problems/FATAWY) | 148 | 25.64 |
+| 12721 | [Pell (Mid pelling)](https://www.spoj.com/problems/PELL2) | 45 | 34.03 |
+| 12726 | [XOR Game](https://www.spoj.com/problems/QN01) | 541 | 43.97 |
+| 12734 | [Seating Arrangement](https://www.spoj.com/problems/QN02) | 165 | 60.52 |
+| 12746 | [Colorful Circle (EASY)](https://www.spoj.com/problems/CRCLE_UI) | 483 | 20.99 |
+| 12749 | [Dynamic Assignment Problem](https://www.spoj.com/problems/DAP) | 16 | 54.64 |
+| 12802 | [Yet Another Counting Problem](https://www.spoj.com/problems/TRI2) | 13 | 46.77 |
+| 12803 | [Graph](https://www.spoj.com/problems/GRAPH2) | 8 | 15.00 |
+| 12804 | [Spy](https://www.spoj.com/problems/SPY2) | 6 | 12.24 |
+| 12805 | [Age of Empires](https://www.spoj.com/problems/AGE2) | 3 | 6.41 |
+| 12806 | [Blackjack](https://www.spoj.com/problems/BLACJACK) | 7 | 16.00 |
+| 12807 | [Recursive Sequence (Version X)](https://www.spoj.com/problems/SPP2) | 12 | 16.28 |

--- a/tests/spoj/index/47.jsonl
+++ b/tests/spoj/index/47.jsonl
@@ -1,0 +1,50 @@
+{"id":12808,"name":"Yet-Yet Another Counting Problem","url":"https://www.spoj.com/problems/TREEII","users":48,"accepted":64.13}
+{"id":12809,"name":"Yet Another Mathematical Problem","url":"https://www.spoj.com/problems/MATHII","users":55,"accepted":43.74}
+{"id":12810,"name":"Yet Another Multiple Problem","url":"https://www.spoj.com/problems/MULTII","users":328,"accepted":22.52}
+{"id":12824,"name":"Print Big Binary Numbers","url":"https://www.spoj.com/problems/PBBN2","users":6,"accepted":29.59}
+{"id":12855,"name":"Teleport","url":"https://www.spoj.com/problems/TPORT","users":4,"accepted":12.5}
+{"id":12866,"name":"Nlogonian Tickets","url":"https://www.spoj.com/problems/NTICKETS","users":333,"accepted":20.94}
+{"id":12880,"name":"Sheep","url":"https://www.spoj.com/problems/KOZE","users":2011,"accepted":46.23}
+{"id":12887,"name":"Ant Colony Optimization","url":"https://www.spoj.com/problems/DCEPCA02","users":45,"accepted":62.39}
+{"id":12889,"name":"MAD","url":"https://www.spoj.com/problems/DCEPCA10","users":164,"accepted":21.01}
+{"id":12893,"name":"Short Select","url":"https://www.spoj.com/problems/DCEPCA04","users":47,"accepted":42.38}
+{"id":12902,"name":"Good Luck","url":"https://www.spoj.com/problems/DCEPCA01","users":83,"accepted":43.49}
+{"id":12903,"name":"Saving BOB - 2","url":"https://www.spoj.com/problems/DCEPCA08","users":13,"accepted":28.72}
+{"id":12908,"name":"Binary Matrix","url":"https://www.spoj.com/problems/BNMT","users":19,"accepted":9.48}
+{"id":12912,"name":"Saving BOB","url":"https://www.spoj.com/problems/DCEPCA06","users":99,"accepted":38.31}
+{"id":12914,"name":"Totient Extreme","url":"https://www.spoj.com/problems/DCEPCA03","users":1805,"accepted":40.28}
+{"id":12916,"name":"MMM","url":"https://www.spoj.com/problems/DCEPCA09","users":95,"accepted":18.85}
+{"id":12933,"name":"n-divisors","url":"https://www.spoj.com/problems/NDIV","users":2340,"accepted":19.39}
+{"id":12943,"name":"Counting","url":"https://www.spoj.com/problems/RIOI_3_2","users":81,"accepted":46.7}
+{"id":12958,"name":"Another Gift Problem","url":"https://www.spoj.com/problems/VPL0_A","users":42,"accepted":19.75}
+{"id":12959,"name":"Basic Grapes Instinct","url":"https://www.spoj.com/problems/VPL0_B","users":231,"accepted":46.21}
+{"id":12960,"name":"Collision on Christmas Eve","url":"https://www.spoj.com/problems/VPL0_C","users":47,"accepted":20.95}
+{"id":12961,"name":"Drastic Grapes","url":"https://www.spoj.com/problems/VPL0_D","users":43,"accepted":33.53}
+{"id":12964,"name":"Count on a treap","url":"https://www.spoj.com/problems/COT5","users":10,"accepted":30.99}
+{"id":12969,"name":"To inifinity and Beyond","url":"https://www.spoj.com/problems/BUZZ","users":67,"accepted":25.82}
+{"id":12978,"name":"SHAPE GAME","url":"https://www.spoj.com/problems/SGAME","users":446,"accepted":37.75}
+{"id":12981,"name":"Fences","url":"https://www.spoj.com/problems/CEOI08A","users":33,"accepted":21.46}
+{"id":13002,"name":"For Loops Challenge","url":"https://www.spoj.com/problems/PFORLOOP","users":282,"accepted":38.12}
+{"id":13007,"name":"Easy Programming Tutorials","url":"https://www.spoj.com/problems/EPTT","users":281,"accepted":30.58}
+{"id":13015,"name":"Counting Primes","url":"https://www.spoj.com/problems/CNTPRIME","users":1471,"accepted":22.53}
+{"id":13020,"name":"Help MR  BEAN","url":"https://www.spoj.com/problems/BEANGAME","users":13,"accepted":9.26}
+{"id":13031,"name":"Vision Field","url":"https://www.spoj.com/problems/VISION","users":28,"accepted":24.04}
+{"id":13041,"name":"The Black Riders","url":"https://www.spoj.com/problems/AMR12A","users":196,"accepted":40.1}
+{"id":13042,"name":"Gandalf vs the Balrog","url":"https://www.spoj.com/problems/AMR12B","users":365,"accepted":50.71}
+{"id":13043,"name":"The Mirror of Galadriel","url":"https://www.spoj.com/problems/AMR12D","users":5980,"accepted":64.5}
+{"id":13044,"name":"Dyslexic Gollum","url":"https://www.spoj.com/problems/AMR12E","users":124,"accepted":29.11}
+{"id":13045,"name":"Denethors Decryption of Dequeue permutations","url":"https://www.spoj.com/problems/AMR12F","users":24,"accepted":35.05}
+{"id":13046,"name":"The Glittering Caves of Aglarond","url":"https://www.spoj.com/problems/AMR12G","users":919,"accepted":34.88}
+{"id":13047,"name":"Saruman of Many Colours","url":"https://www.spoj.com/problems/AMR12I","users":403,"accepted":37.94}
+{"id":13048,"name":"Escape from the Mines","url":"https://www.spoj.com/problems/AMR12J","users":69,"accepted":24.27}
+{"id":13049,"name":"The Loyalty of the Orcs","url":"https://www.spoj.com/problems/AMR12K","users":93,"accepted":28.67}
+{"id":13050,"name":"Entmoot","url":"https://www.spoj.com/problems/AMR12C","users":80,"accepted":29.17}
+{"id":13051,"name":"Wormtongues Mind","url":"https://www.spoj.com/problems/AMR12H","users":69,"accepted":51.96}
+{"id":13055,"name":"New Year Train","url":"https://www.spoj.com/problems/IZHONYT","users":58,"accepted":56.17}
+{"id":13076,"name":"Slikar","url":"https://www.spoj.com/problems/CSLIKAR","users":233,"accepted":31.96}
+{"id":13078,"name":"The Mad Numerologist","url":"https://www.spoj.com/problems/MADN","users":198,"accepted":32.65}
+{"id":13090,"name":"New Strategy","url":"https://www.spoj.com/problems/PCPC12D","users":145,"accepted":33.53}
+{"id":13091,"name":"Snakes and Ladders","url":"https://www.spoj.com/problems/PCPC12E","users":113,"accepted":17.95}
+{"id":13092,"name":"Snakes and Ladders Again","url":"https://www.spoj.com/problems/PCPC12F","users":90,"accepted":15.04}
+{"id":13093,"name":"Mosque","url":"https://www.spoj.com/problems/PCPC12G","users":49,"accepted":39.05}
+{"id":13094,"name":"Beggars","url":"https://www.spoj.com/problems/PCPC12H","users":48,"accepted":27.62}

--- a/tests/spoj/index/47.md
+++ b/tests/spoj/index/47.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 12808 | [Yet-Yet Another Counting Problem](https://www.spoj.com/problems/TREEII) | 48 | 64.13 |
+| 12809 | [Yet Another Mathematical Problem](https://www.spoj.com/problems/MATHII) | 55 | 43.74 |
+| 12810 | [Yet Another Multiple Problem](https://www.spoj.com/problems/MULTII) | 328 | 22.52 |
+| 12824 | [Print Big Binary Numbers](https://www.spoj.com/problems/PBBN2) | 6 | 29.59 |
+| 12855 | [Teleport](https://www.spoj.com/problems/TPORT) | 4 | 12.50 |
+| 12866 | [Nlogonian Tickets](https://www.spoj.com/problems/NTICKETS) | 333 | 20.94 |
+| 12880 | [Sheep](https://www.spoj.com/problems/KOZE) | 2011 | 46.23 |
+| 12887 | [Ant Colony Optimization](https://www.spoj.com/problems/DCEPCA02) | 45 | 62.39 |
+| 12889 | [MAD](https://www.spoj.com/problems/DCEPCA10) | 164 | 21.01 |
+| 12893 | [Short Select](https://www.spoj.com/problems/DCEPCA04) | 47 | 42.38 |
+| 12902 | [Good Luck](https://www.spoj.com/problems/DCEPCA01) | 83 | 43.49 |
+| 12903 | [Saving BOB - 2](https://www.spoj.com/problems/DCEPCA08) | 13 | 28.72 |
+| 12908 | [Binary Matrix](https://www.spoj.com/problems/BNMT) | 19 | 9.48 |
+| 12912 | [Saving BOB](https://www.spoj.com/problems/DCEPCA06) | 99 | 38.31 |
+| 12914 | [Totient Extreme](https://www.spoj.com/problems/DCEPCA03) | 1805 | 40.28 |
+| 12916 | [MMM](https://www.spoj.com/problems/DCEPCA09) | 95 | 18.85 |
+| 12933 | [n-divisors](https://www.spoj.com/problems/NDIV) | 2340 | 19.39 |
+| 12943 | [Counting](https://www.spoj.com/problems/RIOI_3_2) | 81 | 46.70 |
+| 12958 | [Another Gift Problem](https://www.spoj.com/problems/VPL0_A) | 42 | 19.75 |
+| 12959 | [Basic Grapes Instinct](https://www.spoj.com/problems/VPL0_B) | 231 | 46.21 |
+| 12960 | [Collision on Christmas Eve](https://www.spoj.com/problems/VPL0_C) | 47 | 20.95 |
+| 12961 | [Drastic Grapes](https://www.spoj.com/problems/VPL0_D) | 43 | 33.53 |
+| 12964 | [Count on a treap](https://www.spoj.com/problems/COT5) | 10 | 30.99 |
+| 12969 | [To inifinity and Beyond](https://www.spoj.com/problems/BUZZ) | 67 | 25.82 |
+| 12978 | [SHAPE GAME](https://www.spoj.com/problems/SGAME) | 446 | 37.75 |
+| 12981 | [Fences](https://www.spoj.com/problems/CEOI08A) | 33 | 21.46 |
+| 13002 | [For Loops Challenge](https://www.spoj.com/problems/PFORLOOP) | 282 | 38.12 |
+| 13007 | [Easy Programming Tutorials](https://www.spoj.com/problems/EPTT) | 281 | 30.58 |
+| 13015 | [Counting Primes](https://www.spoj.com/problems/CNTPRIME) | 1471 | 22.53 |
+| 13020 | [Help MR  BEAN](https://www.spoj.com/problems/BEANGAME) | 13 | 9.26 |
+| 13031 | [Vision Field](https://www.spoj.com/problems/VISION) | 28 | 24.04 |
+| 13041 | [The Black Riders](https://www.spoj.com/problems/AMR12A) | 196 | 40.10 |
+| 13042 | [Gandalf vs the Balrog](https://www.spoj.com/problems/AMR12B) | 365 | 50.71 |
+| 13043 | [The Mirror of Galadriel](https://www.spoj.com/problems/AMR12D) | 5980 | 64.50 |
+| 13044 | [Dyslexic Gollum](https://www.spoj.com/problems/AMR12E) | 124 | 29.11 |
+| 13045 | [Denethors Decryption of Dequeue permutations](https://www.spoj.com/problems/AMR12F) | 24 | 35.05 |
+| 13046 | [The Glittering Caves of Aglarond](https://www.spoj.com/problems/AMR12G) | 919 | 34.88 |
+| 13047 | [Saruman of Many Colours](https://www.spoj.com/problems/AMR12I) | 403 | 37.94 |
+| 13048 | [Escape from the Mines](https://www.spoj.com/problems/AMR12J) | 69 | 24.27 |
+| 13049 | [The Loyalty of the Orcs](https://www.spoj.com/problems/AMR12K) | 93 | 28.67 |
+| 13050 | [Entmoot](https://www.spoj.com/problems/AMR12C) | 80 | 29.17 |
+| 13051 | [Wormtongues Mind](https://www.spoj.com/problems/AMR12H) | 69 | 51.96 |
+| 13055 | [New Year Train](https://www.spoj.com/problems/IZHONYT) | 58 | 56.17 |
+| 13076 | [Slikar](https://www.spoj.com/problems/CSLIKAR) | 233 | 31.96 |
+| 13078 | [The Mad Numerologist](https://www.spoj.com/problems/MADN) | 198 | 32.65 |
+| 13090 | [New Strategy](https://www.spoj.com/problems/PCPC12D) | 145 | 33.53 |
+| 13091 | [Snakes and Ladders](https://www.spoj.com/problems/PCPC12E) | 113 | 17.95 |
+| 13092 | [Snakes and Ladders Again](https://www.spoj.com/problems/PCPC12F) | 90 | 15.04 |
+| 13093 | [Mosque](https://www.spoj.com/problems/PCPC12G) | 49 | 39.05 |
+| 13094 | [Beggars](https://www.spoj.com/problems/PCPC12H) | 48 | 27.62 |

--- a/tests/spoj/index/48.jsonl
+++ b/tests/spoj/index/48.jsonl
@@ -1,0 +1,50 @@
+{"id":13095,"name":"peaks","url":"https://www.spoj.com/problems/PCPC12I","users":80,"accepted":32.28}
+{"id":13096,"name":"Amr Samir","url":"https://www.spoj.com/problems/PCPC12J","users":921,"accepted":31.22}
+{"id":13105,"name":"DNA","url":"https://www.spoj.com/problems/MUTDNA","users":692,"accepted":33.58}
+{"id":13106,"name":"KOSARE","url":"https://www.spoj.com/problems/KOSARE","users":382,"accepted":50.71}
+{"id":13114,"name":"SQL Queries","url":"https://www.spoj.com/problems/PUCMM331","users":16,"accepted":52.63}
+{"id":13116,"name":"Dividing Xorland","url":"https://www.spoj.com/problems/PUCMM333","users":31,"accepted":48.57}
+{"id":13117,"name":"White Hats","url":"https://www.spoj.com/problems/PUCMM334","users":618,"accepted":37.56}
+{"id":13118,"name":"The Rook and The Rookette","url":"https://www.spoj.com/problems/PUCMM335","users":35,"accepted":26.46}
+{"id":13120,"name":"FizzBuzz Happy 2013","url":"https://www.spoj.com/problems/ADITYA13","users":12,"accepted":35}
+{"id":13150,"name":"Magic Sticks","url":"https://www.spoj.com/problems/STICKS","users":20,"accepted":23.41}
+{"id":13156,"name":"Tom and Jerry","url":"https://www.spoj.com/problems/MAY99_1","users":30,"accepted":13.65}
+{"id":13165,"name":"Totient in permutation (easy)","url":"https://www.spoj.com/problems/TIP1","users":308,"accepted":20.75}
+{"id":13166,"name":"Totient in permutation (medium)","url":"https://www.spoj.com/problems/TIP2","users":21,"accepted":49.44}
+{"id":13167,"name":"Totient in permutation (hard)","url":"https://www.spoj.com/problems/TIP3","users":7,"accepted":11.84}
+{"id":13223,"name":"The BrainFast Processing! Classical version","url":"https://www.spoj.com/problems/FAST_BF","users":9,"accepted":38.75}
+{"id":13303,"name":"Tic-tac-toe 3","url":"https://www.spoj.com/problems/OVOXO","users":12,"accepted":21.74}
+{"id":13362,"name":"Median of sub-sequences","url":"https://www.spoj.com/problems/KMEDIAL","users":37,"accepted":20.28}
+{"id":13363,"name":"WIND VANE","url":"https://www.spoj.com/problems/WINDVANE","users":394,"accepted":31.48}
+{"id":13364,"name":"THE N WITTY FRIENDS","url":"https://www.spoj.com/problems/WITTY","users":49,"accepted":22.3}
+{"id":13365,"name":"Move the boulder","url":"https://www.spoj.com/problems/BOULDER","users":10,"accepted":15.96}
+{"id":13367,"name":"EVEN COUNT","url":"https://www.spoj.com/problems/GEEKOUNT","users":352,"accepted":23.15}
+{"id":13369,"name":"Cut on a tree","url":"https://www.spoj.com/problems/COT6","users":12,"accepted":6.63}
+{"id":13376,"name":"The new President","url":"https://www.spoj.com/problems/PRESIDEN","users":392,"accepted":31.47}
+{"id":13381,"name":"Manku Word","url":"https://www.spoj.com/problems/MAY99_2","users":2117,"accepted":47.15}
+{"id":13382,"name":"Kindergarten Painting Competition","url":"https://www.spoj.com/problems/KINDERPC","users":40,"accepted":39.13}
+{"id":13384,"name":"Nice Binary Trees","url":"https://www.spoj.com/problems/NICEBTRE","users":1840,"accepted":39.88}
+{"id":13388,"name":"Easy Jug","url":"https://www.spoj.com/problems/MAY99_3","users":2159,"accepted":42.07}
+{"id":13398,"name":"Contest Hall Preparation","url":"https://www.spoj.com/problems/CONHONPR","users":341,"accepted":43.46}
+{"id":13399,"name":"Rachu","url":"https://www.spoj.com/problems/MAY99_4","users":1051,"accepted":33.69}
+{"id":13404,"name":"The Encrypted Password","url":"https://www.spoj.com/problems/ICPC12C","users":166,"accepted":36.06}
+{"id":13405,"name":"MayanCalendar","url":"https://www.spoj.com/problems/APCER","users":125,"accepted":55.48}
+{"id":13419,"name":"Modular Fibonacci Period","url":"https://www.spoj.com/problems/PISANO","users":93,"accepted":24.62}
+{"id":13420,"name":"Fimodacci","url":"https://www.spoj.com/problems/FMODF","users":37,"accepted":11.95}
+{"id":13444,"name":"Counting Lucky Numbers","url":"https://www.spoj.com/problems/CNT_LUCK","users":174,"accepted":29.91}
+{"id":13447,"name":"Crayon","url":"https://www.spoj.com/problems/CRAYON","users":147,"accepted":26.7}
+{"id":13469,"name":"FOREVER ALONE","url":"https://www.spoj.com/problems/ALONE","users":95,"accepted":39.58}
+{"id":13500,"name":"Discord is at it again","url":"https://www.spoj.com/problems/PONY8","users":36,"accepted":39.78}
+{"id":13508,"name":"Madotsuki Pattern","url":"https://www.spoj.com/problems/MDT1","users":14,"accepted":44.12}
+{"id":13511,"name":"Determine the vismin value !","url":"https://www.spoj.com/problems/KOSPC13B","users":41,"accepted":28.32}
+{"id":13523,"name":"Card Meets (medium)","url":"https://www.spoj.com/problems/GUMATH2","users":56,"accepted":29.43}
+{"id":13529,"name":"Special Graph","url":"https://www.spoj.com/problems/SPECIALG","users":83,"accepted":12.43}
+{"id":13545,"name":"Room Change","url":"https://www.spoj.com/problems/CHGROOM","users":142,"accepted":37.92}
+{"id":13577,"name":"Card Game","url":"https://www.spoj.com/problems/HC12","users":501,"accepted":24.46}
+{"id":13588,"name":"One X LIS","url":"https://www.spoj.com/problems/ONEXLIS","users":75,"accepted":21.14}
+{"id":13591,"name":"Factor y Hell","url":"https://www.spoj.com/problems/FCTRHELL","users":9,"accepted":18.64}
+{"id":13592,"name":"Expected Time to Love","url":"https://www.spoj.com/problems/PRLOVE","users":49,"accepted":20.4}
+{"id":13621,"name":"Security","url":"https://www.spoj.com/problems/HC12II","users":27,"accepted":28.32}
+{"id":13622,"name":"Dead Pixels","url":"https://www.spoj.com/problems/HC12III","users":25,"accepted":22.7}
+{"id":13626,"name":"Charu and Coin Distribution","url":"https://www.spoj.com/problems/CBANK","users":418,"accepted":41.26}
+{"id":13630,"name":"BATMAN1","url":"https://www.spoj.com/problems/BAT1","users":595,"accepted":38.54}

--- a/tests/spoj/index/48.md
+++ b/tests/spoj/index/48.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 13095 | [peaks](https://www.spoj.com/problems/PCPC12I) | 80 | 32.28 |
+| 13096 | [Amr Samir](https://www.spoj.com/problems/PCPC12J) | 921 | 31.22 |
+| 13105 | [DNA](https://www.spoj.com/problems/MUTDNA) | 692 | 33.58 |
+| 13106 | [KOSARE](https://www.spoj.com/problems/KOSARE) | 382 | 50.71 |
+| 13114 | [SQL Queries](https://www.spoj.com/problems/PUCMM331) | 16 | 52.63 |
+| 13116 | [Dividing Xorland](https://www.spoj.com/problems/PUCMM333) | 31 | 48.57 |
+| 13117 | [White Hats](https://www.spoj.com/problems/PUCMM334) | 618 | 37.56 |
+| 13118 | [The Rook and The Rookette](https://www.spoj.com/problems/PUCMM335) | 35 | 26.46 |
+| 13120 | [FizzBuzz Happy 2013](https://www.spoj.com/problems/ADITYA13) | 12 | 35.00 |
+| 13150 | [Magic Sticks](https://www.spoj.com/problems/STICKS) | 20 | 23.41 |
+| 13156 | [Tom and Jerry](https://www.spoj.com/problems/MAY99_1) | 30 | 13.65 |
+| 13165 | [Totient in permutation (easy)](https://www.spoj.com/problems/TIP1) | 308 | 20.75 |
+| 13166 | [Totient in permutation (medium)](https://www.spoj.com/problems/TIP2) | 21 | 49.44 |
+| 13167 | [Totient in permutation (hard)](https://www.spoj.com/problems/TIP3) | 7 | 11.84 |
+| 13223 | [The BrainFast Processing! Classical version](https://www.spoj.com/problems/FAST_BF) | 9 | 38.75 |
+| 13303 | [Tic-tac-toe 3](https://www.spoj.com/problems/OVOXO) | 12 | 21.74 |
+| 13362 | [Median of sub-sequences](https://www.spoj.com/problems/KMEDIAL) | 37 | 20.28 |
+| 13363 | [WIND VANE](https://www.spoj.com/problems/WINDVANE) | 394 | 31.48 |
+| 13364 | [THE N WITTY FRIENDS](https://www.spoj.com/problems/WITTY) | 49 | 22.30 |
+| 13365 | [Move the boulder](https://www.spoj.com/problems/BOULDER) | 10 | 15.96 |
+| 13367 | [EVEN COUNT](https://www.spoj.com/problems/GEEKOUNT) | 352 | 23.15 |
+| 13369 | [Cut on a tree](https://www.spoj.com/problems/COT6) | 12 | 6.63 |
+| 13376 | [The new President](https://www.spoj.com/problems/PRESIDEN) | 392 | 31.47 |
+| 13381 | [Manku Word](https://www.spoj.com/problems/MAY99_2) | 2117 | 47.15 |
+| 13382 | [Kindergarten Painting Competition](https://www.spoj.com/problems/KINDERPC) | 40 | 39.13 |
+| 13384 | [Nice Binary Trees](https://www.spoj.com/problems/NICEBTRE) | 1840 | 39.88 |
+| 13388 | [Easy Jug](https://www.spoj.com/problems/MAY99_3) | 2159 | 42.07 |
+| 13398 | [Contest Hall Preparation](https://www.spoj.com/problems/CONHONPR) | 341 | 43.46 |
+| 13399 | [Rachu](https://www.spoj.com/problems/MAY99_4) | 1051 | 33.69 |
+| 13404 | [The Encrypted Password](https://www.spoj.com/problems/ICPC12C) | 166 | 36.06 |
+| 13405 | [MayanCalendar](https://www.spoj.com/problems/APCER) | 125 | 55.48 |
+| 13419 | [Modular Fibonacci Period](https://www.spoj.com/problems/PISANO) | 93 | 24.62 |
+| 13420 | [Fimodacci](https://www.spoj.com/problems/FMODF) | 37 | 11.95 |
+| 13444 | [Counting Lucky Numbers](https://www.spoj.com/problems/CNT_LUCK) | 174 | 29.91 |
+| 13447 | [Crayon](https://www.spoj.com/problems/CRAYON) | 147 | 26.70 |
+| 13469 | [FOREVER ALONE](https://www.spoj.com/problems/ALONE) | 95 | 39.58 |
+| 13500 | [Discord is at it again](https://www.spoj.com/problems/PONY8) | 36 | 39.78 |
+| 13508 | [Madotsuki Pattern](https://www.spoj.com/problems/MDT1) | 14 | 44.12 |
+| 13511 | [Determine the vismin value !](https://www.spoj.com/problems/KOSPC13B) | 41 | 28.32 |
+| 13523 | [Card Meets (medium)](https://www.spoj.com/problems/GUMATH2) | 56 | 29.43 |
+| 13529 | [Special Graph](https://www.spoj.com/problems/SPECIALG) | 83 | 12.43 |
+| 13545 | [Room Change](https://www.spoj.com/problems/CHGROOM) | 142 | 37.92 |
+| 13577 | [Card Game](https://www.spoj.com/problems/HC12) | 501 | 24.46 |
+| 13588 | [One X LIS](https://www.spoj.com/problems/ONEXLIS) | 75 | 21.14 |
+| 13591 | [Factor y Hell](https://www.spoj.com/problems/FCTRHELL) | 9 | 18.64 |
+| 13592 | [Expected Time to Love](https://www.spoj.com/problems/PRLOVE) | 49 | 20.40 |
+| 13621 | [Security](https://www.spoj.com/problems/HC12II) | 27 | 28.32 |
+| 13622 | [Dead Pixels](https://www.spoj.com/problems/HC12III) | 25 | 22.70 |
+| 13626 | [Charu and Coin Distribution](https://www.spoj.com/problems/CBANK) | 418 | 41.26 |
+| 13630 | [BATMAN1](https://www.spoj.com/problems/BAT1) | 595 | 38.54 |

--- a/tests/spoj/index/49.jsonl
+++ b/tests/spoj/index/49.jsonl
@@ -1,0 +1,50 @@
+{"id":13631,"name":"BATMAN2","url":"https://www.spoj.com/problems/BAT2","users":602,"accepted":27.51}
+{"id":13643,"name":"BATMAN3","url":"https://www.spoj.com/problems/BAT3","users":916,"accepted":41.67}
+{"id":13646,"name":"BATMAN4","url":"https://www.spoj.com/problems/BAT4","users":155,"accepted":32.79}
+{"id":13647,"name":"Tjandra 19th birthday (EASY)","url":"https://www.spoj.com/problems/TJANDRAS","users":72,"accepted":40.58}
+{"id":13651,"name":"Check","url":"https://www.spoj.com/problems/KNGCHECK","users":136,"accepted":42.99}
+{"id":13683,"name":"Transitive Closure","url":"https://www.spoj.com/problems/TRANCLS","users":248,"accepted":37.02}
+{"id":13686,"name":"finding maximum possible number","url":"https://www.spoj.com/problems/MAX_NUM","users":368,"accepted":22.05}
+{"id":13707,"name":"SHAHBAG","url":"https://www.spoj.com/problems/SHAHBG","users":1469,"accepted":39.21}
+{"id":13738,"name":"Happy Valentine Day (Valentine Maze Game)","url":"https://www.spoj.com/problems/A_W_S_N","users":149,"accepted":36.46}
+{"id":13745,"name":"Crack the Safe","url":"https://www.spoj.com/problems/SAFECRAC","users":610,"accepted":53.22}
+{"id":13753,"name":"Amazing Prime Sequence","url":"https://www.spoj.com/problems/APS","users":3360,"accepted":29.93}
+{"id":13768,"name":"An Experiment by Penny","url":"https://www.spoj.com/problems/CRAN01","users":607,"accepted":59.7}
+{"id":13769,"name":"Roommate Agreement","url":"https://www.spoj.com/problems/CRAN02","users":1493,"accepted":31.46}
+{"id":13780,"name":"Audition","url":"https://www.spoj.com/problems/CRAN04","users":656,"accepted":24.08}
+{"id":13789,"name":"Loving Power","url":"https://www.spoj.com/problems/LOVINGPW","users":118,"accepted":39.59}
+{"id":13799,"name":"Naive Loki","url":"https://www.spoj.com/problems/NAIVELOK","users":121,"accepted":36.1}
+{"id":13801,"name":"Dexter Rank","url":"https://www.spoj.com/problems/DEXTER","users":16,"accepted":14.5}
+{"id":13805,"name":"X-MEN","url":"https://www.spoj.com/problems/XMEN","users":911,"accepted":27.76}
+{"id":13806,"name":"Chaos In Arkham","url":"https://www.spoj.com/problems/CHAOS_CC","users":52,"accepted":18.77}
+{"id":13807,"name":"Rage Drug","url":"https://www.spoj.com/problems/RDRUG","users":35,"accepted":36.13}
+{"id":13808,"name":"Colors","url":"https://www.spoj.com/problems/COLOR_CC","users":30,"accepted":22.04}
+{"id":13809,"name":"ISRANK","url":"https://www.spoj.com/problems/ISRANK","users":22,"accepted":34.09}
+{"id":13815,"name":"India in Box","url":"https://www.spoj.com/problems/INBOX","users":26,"accepted":15.77}
+{"id":13816,"name":"Pheversos Game","url":"https://www.spoj.com/problems/PGAME","users":8,"accepted":34.59}
+{"id":13826,"name":"The Grandslam of Grandslams!","url":"https://www.spoj.com/problems/WIMB","users":16,"accepted":22.22}
+{"id":13829,"name":"Tjandra 19th birthday present (HARD)","url":"https://www.spoj.com/problems/TJANDRA2","users":36,"accepted":37.59}
+{"id":13833,"name":"Super Borboletas World","url":"https://www.spoj.com/problems/SBW","users":14,"accepted":24.32}
+{"id":13838,"name":"Mosty! Find Gn","url":"https://www.spoj.com/problems/M_SEQ","users":564,"accepted":49.87}
+{"id":13866,"name":"Discrete Roots","url":"https://www.spoj.com/problems/DISCRT","users":300,"accepted":52.69}
+{"id":13868,"name":"Roads of NITT","url":"https://www.spoj.com/problems/NITTROAD","users":624,"accepted":29.4}
+{"id":13875,"name":"Knifes Are Fun","url":"https://www.spoj.com/problems/JOKER1","users":1304,"accepted":43.43}
+{"id":13881,"name":"FUN WITH LETTERS","url":"https://www.spoj.com/problems/FUNNUMS","users":242,"accepted":28.47}
+{"id":13882,"name":"THE WITTY BOY","url":"https://www.spoj.com/problems/WITTYBOY","users":4,"accepted":4.18}
+{"id":13884,"name":"FLING1","url":"https://www.spoj.com/problems/FLING1","users":57,"accepted":23.74}
+{"id":13886,"name":"BLOCK_D SOLVER","url":"https://www.spoj.com/problems/BLOCK_D","users":18,"accepted":19.33}
+{"id":13895,"name":"Party Time","url":"https://www.spoj.com/problems/PARTYTIM","users":2,"accepted":14.29}
+{"id":13913,"name":"Real Mangoes for Ranjith","url":"https://www.spoj.com/problems/MANGOES","users":1939,"accepted":41.78}
+{"id":13918,"name":"String Queries","url":"https://www.spoj.com/problems/STRINGQ","users":34,"accepted":27.56}
+{"id":13925,"name":"ZEROES IN RANGE V2","url":"https://www.spoj.com/problems/RANGZER2","users":244,"accepted":37.97}
+{"id":13926,"name":"Flipping Slipping of grids","url":"https://www.spoj.com/problems/GRIDFLIP","users":8,"accepted":19.23}
+{"id":13940,"name":"Fibonacci vs Polynomial (HARD)","url":"https://www.spoj.com/problems/PIBO2","users":20,"accepted":24.03}
+{"id":13941,"name":"The AMSCO cipher","url":"https://www.spoj.com/problems/AMSCO1","users":250,"accepted":38.05}
+{"id":13945,"name":"GHALIBS CHALLENGE","url":"https://www.spoj.com/problems/GHALIBC","users":4,"accepted":15.87}
+{"id":13948,"name":"Disjoint Subtrees","url":"https://www.spoj.com/problems/KAYKAY","users":22,"accepted":45.41}
+{"id":13953,"name":"Divide Polygon (HARD)","url":"https://www.spoj.com/problems/DTPOLY2","users":18,"accepted":21.08}
+{"id":13977,"name":"Thousands ByteMan March","url":"https://www.spoj.com/problems/TMB","users":24,"accepted":34.03}
+{"id":13978,"name":"Billion ByteMan March","url":"https://www.spoj.com/problems/BBM","users":7,"accepted":25.86}
+{"id":13980,"name":"Sudoku goblin","url":"https://www.spoj.com/problems/SUDOGOB","users":83,"accepted":42.62}
+{"id":13989,"name":"Helping Susy","url":"https://www.spoj.com/problems/SUSY","users":40,"accepted":30.71}
+{"id":13990,"name":"Web islands","url":"https://www.spoj.com/problems/WEBISL","users":585,"accepted":33.02}

--- a/tests/spoj/index/49.md
+++ b/tests/spoj/index/49.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 13631 | [BATMAN2](https://www.spoj.com/problems/BAT2) | 602 | 27.51 |
+| 13643 | [BATMAN3](https://www.spoj.com/problems/BAT3) | 916 | 41.67 |
+| 13646 | [BATMAN4](https://www.spoj.com/problems/BAT4) | 155 | 32.79 |
+| 13647 | [Tjandra 19th birthday (EASY)](https://www.spoj.com/problems/TJANDRAS) | 72 | 40.58 |
+| 13651 | [Check](https://www.spoj.com/problems/KNGCHECK) | 136 | 42.99 |
+| 13683 | [Transitive Closure](https://www.spoj.com/problems/TRANCLS) | 248 | 37.02 |
+| 13686 | [finding maximum possible number](https://www.spoj.com/problems/MAX_NUM) | 368 | 22.05 |
+| 13707 | [SHAHBAG](https://www.spoj.com/problems/SHAHBG) | 1469 | 39.21 |
+| 13738 | [Happy Valentine Day (Valentine Maze Game)](https://www.spoj.com/problems/A_W_S_N) | 149 | 36.46 |
+| 13745 | [Crack the Safe](https://www.spoj.com/problems/SAFECRAC) | 610 | 53.22 |
+| 13753 | [Amazing Prime Sequence](https://www.spoj.com/problems/APS) | 3360 | 29.93 |
+| 13768 | [An Experiment by Penny](https://www.spoj.com/problems/CRAN01) | 607 | 59.70 |
+| 13769 | [Roommate Agreement](https://www.spoj.com/problems/CRAN02) | 1493 | 31.46 |
+| 13780 | [Audition](https://www.spoj.com/problems/CRAN04) | 656 | 24.08 |
+| 13789 | [Loving Power](https://www.spoj.com/problems/LOVINGPW) | 118 | 39.59 |
+| 13799 | [Naive Loki](https://www.spoj.com/problems/NAIVELOK) | 121 | 36.10 |
+| 13801 | [Dexter Rank](https://www.spoj.com/problems/DEXTER) | 16 | 14.50 |
+| 13805 | [X-MEN](https://www.spoj.com/problems/XMEN) | 911 | 27.76 |
+| 13806 | [Chaos In Arkham](https://www.spoj.com/problems/CHAOS_CC) | 52 | 18.77 |
+| 13807 | [Rage Drug](https://www.spoj.com/problems/RDRUG) | 35 | 36.13 |
+| 13808 | [Colors](https://www.spoj.com/problems/COLOR_CC) | 30 | 22.04 |
+| 13809 | [ISRANK](https://www.spoj.com/problems/ISRANK) | 22 | 34.09 |
+| 13815 | [India in Box](https://www.spoj.com/problems/INBOX) | 26 | 15.77 |
+| 13816 | [Pheversos Game](https://www.spoj.com/problems/PGAME) | 8 | 34.59 |
+| 13826 | [The Grandslam of Grandslams!](https://www.spoj.com/problems/WIMB) | 16 | 22.22 |
+| 13829 | [Tjandra 19th birthday present (HARD)](https://www.spoj.com/problems/TJANDRA2) | 36 | 37.59 |
+| 13833 | [Super Borboletas World](https://www.spoj.com/problems/SBW) | 14 | 24.32 |
+| 13838 | [Mosty! Find Gn](https://www.spoj.com/problems/M_SEQ) | 564 | 49.87 |
+| 13866 | [Discrete Roots](https://www.spoj.com/problems/DISCRT) | 300 | 52.69 |
+| 13868 | [Roads of NITT](https://www.spoj.com/problems/NITTROAD) | 624 | 29.40 |
+| 13875 | [Knifes Are Fun](https://www.spoj.com/problems/JOKER1) | 1304 | 43.43 |
+| 13881 | [FUN WITH LETTERS](https://www.spoj.com/problems/FUNNUMS) | 242 | 28.47 |
+| 13882 | [THE WITTY BOY](https://www.spoj.com/problems/WITTYBOY) | 4 | 4.18 |
+| 13884 | [FLING1](https://www.spoj.com/problems/FLING1) | 57 | 23.74 |
+| 13886 | [BLOCK_D SOLVER](https://www.spoj.com/problems/BLOCK_D) | 18 | 19.33 |
+| 13895 | [Party Time](https://www.spoj.com/problems/PARTYTIM) | 2 | 14.29 |
+| 13913 | [Real Mangoes for Ranjith](https://www.spoj.com/problems/MANGOES) | 1939 | 41.78 |
+| 13918 | [String Queries](https://www.spoj.com/problems/STRINGQ) | 34 | 27.56 |
+| 13925 | [ZEROES IN RANGE V2](https://www.spoj.com/problems/RANGZER2) | 244 | 37.97 |
+| 13926 | [Flipping Slipping of grids](https://www.spoj.com/problems/GRIDFLIP) | 8 | 19.23 |
+| 13940 | [Fibonacci vs Polynomial (HARD)](https://www.spoj.com/problems/PIBO2) | 20 | 24.03 |
+| 13941 | [The AMSCO cipher](https://www.spoj.com/problems/AMSCO1) | 250 | 38.05 |
+| 13945 | [GHALIBS CHALLENGE](https://www.spoj.com/problems/GHALIBC) | 4 | 15.87 |
+| 13948 | [Disjoint Subtrees](https://www.spoj.com/problems/KAYKAY) | 22 | 45.41 |
+| 13953 | [Divide Polygon (HARD)](https://www.spoj.com/problems/DTPOLY2) | 18 | 21.08 |
+| 13977 | [Thousands ByteMan March](https://www.spoj.com/problems/TMB) | 24 | 34.03 |
+| 13978 | [Billion ByteMan March](https://www.spoj.com/problems/BBM) | 7 | 25.86 |
+| 13980 | [Sudoku goblin](https://www.spoj.com/problems/SUDOGOB) | 83 | 42.62 |
+| 13989 | [Helping Susy](https://www.spoj.com/problems/SUSY) | 40 | 30.71 |
+| 13990 | [Web islands](https://www.spoj.com/problems/WEBISL) | 585 | 33.02 |

--- a/tests/spoj/index/50.jsonl
+++ b/tests/spoj/index/50.jsonl
@@ -1,0 +1,50 @@
+{"id":14031,"name":"Spring Primality","url":"https://www.spoj.com/problems/VPL1_AA","users":22,"accepted":19.08}
+{"id":14032,"name":"Summer Game","url":"https://www.spoj.com/problems/VPL1_AB","users":38,"accepted":43.38}
+{"id":14033,"name":"Late Summer Searching","url":"https://www.spoj.com/problems/VPL1_AC","users":12,"accepted":33.33}
+{"id":14034,"name":"Autumn Leaves","url":"https://www.spoj.com/problems/VPL1_AD","users":13,"accepted":38.89}
+{"id":14035,"name":"Winter Crush","url":"https://www.spoj.com/problems/VPL1_AE","users":27,"accepted":36.84}
+{"id":14049,"name":"Annual Day","url":"https://www.spoj.com/problems/VOLNTEER","users":91,"accepted":20.65}
+{"id":14055,"name":"The Wind Waker","url":"https://www.spoj.com/problems/WWAKER","users":31,"accepted":33.63}
+{"id":14122,"name":"Inverse of Recurrence Problem With a Square Root","url":"https://www.spoj.com/problems/IRECSQRT","users":61,"accepted":49.14}
+{"id":14138,"name":"Amazing Factor Sequence","url":"https://www.spoj.com/problems/AFS","users":2351,"accepted":37.23}
+{"id":14156,"name":"Movie Theatre Madness","url":"https://www.spoj.com/problems/THEATRE","users":446,"accepted":53.3}
+{"id":14168,"name":"Amazing Factor Sequence (medium)","url":"https://www.spoj.com/problems/AFS2","users":231,"accepted":29.52}
+{"id":14175,"name":"Power Factor Sum Sum (hard)","url":"https://www.spoj.com/problems/AFSK","users":44,"accepted":34.82}
+{"id":14181,"name":"LIFE IS A RACE","url":"https://www.spoj.com/problems/LIFERACE","users":12,"accepted":27.47}
+{"id":14329,"name":"Magic of the locker","url":"https://www.spoj.com/problems/LOCKER","users":2623,"accepted":19.41}
+{"id":14330,"name":"Power of Phi(medium)","url":"https://www.spoj.com/problems/POWERPHI","users":165,"accepted":31.2}
+{"id":14334,"name":"Evil Overlord Cypher","url":"https://www.spoj.com/problems/DIXIE001","users":67,"accepted":27.18}
+{"id":14387,"name":"Science","url":"https://www.spoj.com/problems/SCIENCE","users":23,"accepted":26.19}
+{"id":14435,"name":"Decipher the AMSCO cipher","url":"https://www.spoj.com/problems/AMSCO2","users":96,"accepted":59.18}
+{"id":14441,"name":"Three Circle Problem (EASY)","url":"https://www.spoj.com/problems/CIRCLE_E","users":2018,"accepted":55.69}
+{"id":14443,"name":"Three Circle Problem (HARD)","url":"https://www.spoj.com/problems/CIRCLE_H","users":50,"accepted":28.88}
+{"id":14507,"name":"GAME2","url":"https://www.spoj.com/problems/AUTOMATA","users":104,"accepted":25.04}
+{"id":14542,"name":"Pythagorean triples (medium)","url":"https://www.spoj.com/problems/PYTRIP2","users":141,"accepted":18.27}
+{"id":14543,"name":"Range Sum","url":"https://www.spoj.com/problems/RANGESUM","users":1013,"accepted":38.06}
+{"id":14629,"name":"Play with Binary Numbers","url":"https://www.spoj.com/problems/HAP01","users":509,"accepted":39.37}
+{"id":14664,"name":"Shared cathetus (easy)","url":"https://www.spoj.com/problems/CATHETEN","users":112,"accepted":42.61}
+{"id":14665,"name":"Delta catheti (hard)","url":"https://www.spoj.com/problems/DELTACAT","users":3,"accepted":15.56}
+{"id":14697,"name":"Loop Expectation","url":"https://www.spoj.com/problems/LOOPEXP","users":675,"accepted":49.41}
+{"id":14700,"name":"Delta catheti II (Hard)","url":"https://www.spoj.com/problems/DELTACA2","users":3,"accepted":6.06}
+{"id":14742,"name":"Building Bridges(HARD)","url":"https://www.spoj.com/problems/BRDGHRD","users":452,"accepted":24.04}
+{"id":14751,"name":"Self Descriptive Number","url":"https://www.spoj.com/problems/SELFDESN","users":49,"accepted":56.81}
+{"id":14761,"name":"Almost-isosceles Pythagorean triple (easy)","url":"https://www.spoj.com/problems/ALMISPY","users":67,"accepted":41.93}
+{"id":14819,"name":"Permutation Generator","url":"https://www.spoj.com/problems/PERMTGEN","users":37,"accepted":30.29}
+{"id":14820,"name":"Return of the Digger","url":"https://www.spoj.com/problems/RETDIG","users":13,"accepted":17.59}
+{"id":14821,"name":"Traffic Lights","url":"https://www.spoj.com/problems/TLIGHTS","users":51,"accepted":58.41}
+{"id":14822,"name":"Battleships","url":"https://www.spoj.com/problems/BSHIP","users":128,"accepted":30.23}
+{"id":14823,"name":"Advanced Battleships","url":"https://www.spoj.com/problems/ABSHIP","users":52,"accepted":13.75}
+{"id":14830,"name":"The Codefather","url":"https://www.spoj.com/problems/CFATHER","users":17,"accepted":14.01}
+{"id":14831,"name":"Your Rank is Pure","url":"https://www.spoj.com/problems/GCJPURE","users":102,"accepted":49.01}
+{"id":14833,"name":"The Fox and the Wolf","url":"https://www.spoj.com/problems/FOXWOLF","users":17,"accepted":26.81}
+{"id":14834,"name":"Foxlings","url":"https://www.spoj.com/problems/FOXLINGS","users":1305,"accepted":29.55}
+{"id":14839,"name":"Boxdropper","url":"https://www.spoj.com/problems/BOXD","users":21,"accepted":34.78}
+{"id":14844,"name":"All Your Base","url":"https://www.spoj.com/problems/GCJ1C09A","users":542,"accepted":30.18}
+{"id":14845,"name":"Center of Mass","url":"https://www.spoj.com/problems/GCJ1C09B","users":136,"accepted":26.73}
+{"id":14846,"name":"Bribe the Prisoners","url":"https://www.spoj.com/problems/GCJ1C09C","users":407,"accepted":31.94}
+{"id":14848,"name":"Boxlings","url":"https://www.spoj.com/problems/BOXLINGS","users":20,"accepted":25}
+{"id":14856,"name":"Crazy Shopkeeper","url":"https://www.spoj.com/problems/CRAZYSK","users":620,"accepted":33.09}
+{"id":14858,"name":"digit count","url":"https://www.spoj.com/problems/DIGCNT","users":43,"accepted":23.67}
+{"id":14862,"name":"Union Laser","url":"https://www.spoj.com/problems/ULASER","users":31,"accepted":47.34}
+{"id":14864,"name":"Sales","url":"https://www.spoj.com/problems/SALES","users":27,"accepted":25.85}
+{"id":14871,"name":"STUDENTS","url":"https://www.spoj.com/problems/AU7_5","users":472,"accepted":48.61}

--- a/tests/spoj/index/50.md
+++ b/tests/spoj/index/50.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 14031 | [Spring Primality](https://www.spoj.com/problems/VPL1_AA) | 22 | 19.08 |
+| 14032 | [Summer Game](https://www.spoj.com/problems/VPL1_AB) | 38 | 43.38 |
+| 14033 | [Late Summer Searching](https://www.spoj.com/problems/VPL1_AC) | 12 | 33.33 |
+| 14034 | [Autumn Leaves](https://www.spoj.com/problems/VPL1_AD) | 13 | 38.89 |
+| 14035 | [Winter Crush](https://www.spoj.com/problems/VPL1_AE) | 27 | 36.84 |
+| 14049 | [Annual Day](https://www.spoj.com/problems/VOLNTEER) | 91 | 20.65 |
+| 14055 | [The Wind Waker](https://www.spoj.com/problems/WWAKER) | 31 | 33.63 |
+| 14122 | [Inverse of Recurrence Problem With a Square Root](https://www.spoj.com/problems/IRECSQRT) | 61 | 49.14 |
+| 14138 | [Amazing Factor Sequence](https://www.spoj.com/problems/AFS) | 2351 | 37.23 |
+| 14156 | [Movie Theatre Madness](https://www.spoj.com/problems/THEATRE) | 446 | 53.30 |
+| 14168 | [Amazing Factor Sequence (medium)](https://www.spoj.com/problems/AFS2) | 231 | 29.52 |
+| 14175 | [Power Factor Sum Sum (hard)](https://www.spoj.com/problems/AFSK) | 44 | 34.82 |
+| 14181 | [LIFE IS A RACE](https://www.spoj.com/problems/LIFERACE) | 12 | 27.47 |
+| 14329 | [Magic of the locker](https://www.spoj.com/problems/LOCKER) | 2623 | 19.41 |
+| 14330 | [Power of Phi(medium)](https://www.spoj.com/problems/POWERPHI) | 165 | 31.20 |
+| 14334 | [Evil Overlord Cypher](https://www.spoj.com/problems/DIXIE001) | 67 | 27.18 |
+| 14387 | [Science](https://www.spoj.com/problems/SCIENCE) | 23 | 26.19 |
+| 14435 | [Decipher the AMSCO cipher](https://www.spoj.com/problems/AMSCO2) | 96 | 59.18 |
+| 14441 | [Three Circle Problem (EASY)](https://www.spoj.com/problems/CIRCLE_E) | 2018 | 55.69 |
+| 14443 | [Three Circle Problem (HARD)](https://www.spoj.com/problems/CIRCLE_H) | 50 | 28.88 |
+| 14507 | [GAME2](https://www.spoj.com/problems/AUTOMATA) | 104 | 25.04 |
+| 14542 | [Pythagorean triples (medium)](https://www.spoj.com/problems/PYTRIP2) | 141 | 18.27 |
+| 14543 | [Range Sum](https://www.spoj.com/problems/RANGESUM) | 1013 | 38.06 |
+| 14629 | [Play with Binary Numbers](https://www.spoj.com/problems/HAP01) | 509 | 39.37 |
+| 14664 | [Shared cathetus (easy)](https://www.spoj.com/problems/CATHETEN) | 112 | 42.61 |
+| 14665 | [Delta catheti (hard)](https://www.spoj.com/problems/DELTACAT) | 3 | 15.56 |
+| 14697 | [Loop Expectation](https://www.spoj.com/problems/LOOPEXP) | 675 | 49.41 |
+| 14700 | [Delta catheti II (Hard)](https://www.spoj.com/problems/DELTACA2) | 3 | 6.06 |
+| 14742 | [Building Bridges(HARD)](https://www.spoj.com/problems/BRDGHRD) | 452 | 24.04 |
+| 14751 | [Self Descriptive Number](https://www.spoj.com/problems/SELFDESN) | 49 | 56.81 |
+| 14761 | [Almost-isosceles Pythagorean triple (easy)](https://www.spoj.com/problems/ALMISPY) | 67 | 41.93 |
+| 14819 | [Permutation Generator](https://www.spoj.com/problems/PERMTGEN) | 37 | 30.29 |
+| 14820 | [Return of the Digger](https://www.spoj.com/problems/RETDIG) | 13 | 17.59 |
+| 14821 | [Traffic Lights](https://www.spoj.com/problems/TLIGHTS) | 51 | 58.41 |
+| 14822 | [Battleships](https://www.spoj.com/problems/BSHIP) | 128 | 30.23 |
+| 14823 | [Advanced Battleships](https://www.spoj.com/problems/ABSHIP) | 52 | 13.75 |
+| 14830 | [The Codefather](https://www.spoj.com/problems/CFATHER) | 17 | 14.01 |
+| 14831 | [Your Rank is Pure](https://www.spoj.com/problems/GCJPURE) | 102 | 49.01 |
+| 14833 | [The Fox and the Wolf](https://www.spoj.com/problems/FOXWOLF) | 17 | 26.81 |
+| 14834 | [Foxlings](https://www.spoj.com/problems/FOXLINGS) | 1305 | 29.55 |
+| 14839 | [Boxdropper](https://www.spoj.com/problems/BOXD) | 21 | 34.78 |
+| 14844 | [All Your Base](https://www.spoj.com/problems/GCJ1C09A) | 542 | 30.18 |
+| 14845 | [Center of Mass](https://www.spoj.com/problems/GCJ1C09B) | 136 | 26.73 |
+| 14846 | [Bribe the Prisoners](https://www.spoj.com/problems/GCJ1C09C) | 407 | 31.94 |
+| 14848 | [Boxlings](https://www.spoj.com/problems/BOXLINGS) | 20 | 25.00 |
+| 14856 | [Crazy Shopkeeper](https://www.spoj.com/problems/CRAZYSK) | 620 | 33.09 |
+| 14858 | [digit count](https://www.spoj.com/problems/DIGCNT) | 43 | 23.67 |
+| 14862 | [Union Laser](https://www.spoj.com/problems/ULASER) | 31 | 47.34 |
+| 14864 | [Sales](https://www.spoj.com/problems/SALES) | 27 | 25.85 |
+| 14871 | [STUDENTS](https://www.spoj.com/problems/AU7_5) | 472 | 48.61 |

--- a/tests/spoj/index/51.jsonl
+++ b/tests/spoj/index/51.jsonl
@@ -1,0 +1,50 @@
+{"id":14883,"name":"Box Factory","url":"https://www.spoj.com/problems/GCJ121CC","users":15,"accepted":33.96}
+{"id":14886,"name":"Matts Trip","url":"https://www.spoj.com/problems/MATT","users":74,"accepted":19.38}
+{"id":14887,"name":"Good Travels","url":"https://www.spoj.com/problems/GOODA","users":640,"accepted":29.21}
+{"id":14888,"name":"Good Predictions","url":"https://www.spoj.com/problems/GOODB","users":1101,"accepted":42.46}
+{"id":14889,"name":"Good Strategy","url":"https://www.spoj.com/problems/GOODC","users":56,"accepted":38.86}
+{"id":14890,"name":"Good Code","url":"https://www.spoj.com/problems/GOODD","users":57,"accepted":22.69}
+{"id":14891,"name":"Good Debugging","url":"https://www.spoj.com/problems/GOODE","users":60,"accepted":41.22}
+{"id":14892,"name":"Good Aim","url":"https://www.spoj.com/problems/GOODF","users":37,"accepted":31.79}
+{"id":14893,"name":"Good Inflation","url":"https://www.spoj.com/problems/GOODG","users":195,"accepted":28.52}
+{"id":14894,"name":"Good Celebration","url":"https://www.spoj.com/problems/GOODH","users":27,"accepted":20.1}
+{"id":14905,"name":"Zig when you zag","url":"https://www.spoj.com/problems/ZIGZAG2","users":36,"accepted":30.05}
+{"id":14923,"name":"King Graffs Defense","url":"https://www.spoj.com/problems/GRAFFDEF","users":482,"accepted":25.51}
+{"id":14924,"name":"King Graffs Tolls","url":"https://www.spoj.com/problems/GRAFFTOL","users":35,"accepted":40}
+{"id":14925,"name":"King Graffs Trip","url":"https://www.spoj.com/problems/GRAFFTRI","users":26,"accepted":20.71}
+{"id":14926,"name":"abdou set","url":"https://www.spoj.com/problems/KIMO1","users":61,"accepted":46.99}
+{"id":14928,"name":"Pyramidal Constructions","url":"https://www.spoj.com/problems/PIRACON","users":336,"accepted":48.77}
+{"id":14929,"name":"Subsequence","url":"https://www.spoj.com/problems/SUBSN","users":178,"accepted":12.79}
+{"id":14930,"name":"Princess Farida","url":"https://www.spoj.com/problems/FARIDA","users":12246,"accepted":26.8}
+{"id":14932,"name":"Lowest Common Ancestor","url":"https://www.spoj.com/problems/LCA","users":7927,"accepted":29.24}
+{"id":14935,"name":"Cactus","url":"https://www.spoj.com/problems/CAC","users":219,"accepted":20.06}
+{"id":14943,"name":"Dynamically-Rooted Tree","url":"https://www.spoj.com/problems/DRTREE","users":340,"accepted":31.13}
+{"id":14944,"name":"Reindeer Games","url":"https://www.spoj.com/problems/SANTA1","users":116,"accepted":22}
+{"id":14946,"name":"Travelling Santa","url":"https://www.spoj.com/problems/SANTA2","users":56,"accepted":34.11}
+{"id":14947,"name":"Breaking and Entering","url":"https://www.spoj.com/problems/SANTA3","users":27,"accepted":36.08}
+{"id":14949,"name":"HELPER","url":"https://www.spoj.com/problems/HELPER","users":13,"accepted":39.47}
+{"id":14955,"name":"Dancing Cows","url":"https://www.spoj.com/problems/DCOWS","users":597,"accepted":24.93}
+{"id":14956,"name":"Submerging Islands","url":"https://www.spoj.com/problems/SUBMERGE","users":4711,"accepted":39.67}
+{"id":14957,"name":"Chinese game","url":"https://www.spoj.com/problems/CHIGAME","users":26,"accepted":24.19}
+{"id":14961,"name":"Maximum Girth","url":"https://www.spoj.com/problems/MAXGRITH","users":648,"accepted":55.43}
+{"id":14971,"name":"The Foxens Treasure","url":"https://www.spoj.com/problems/UOFTAB","users":231,"accepted":35.31}
+{"id":14972,"name":"Foxhole","url":"https://www.spoj.com/problems/UOFTAC","users":235,"accepted":32.67}
+{"id":14973,"name":"Reverse Fox Hunt","url":"https://www.spoj.com/problems/UOFTAD","users":81,"accepted":46.3}
+{"id":14974,"name":"Foxling Feeding Frenzy","url":"https://www.spoj.com/problems/UOFTAE","users":466,"accepted":42.09}
+{"id":14975,"name":"Foxic Expressions","url":"https://www.spoj.com/problems/UOFTAF","users":87,"accepted":15.24}
+{"id":14977,"name":"Attack of the Bloons","url":"https://www.spoj.com/problems/UOFTBB","users":370,"accepted":45.8}
+{"id":14978,"name":"Homemade Asteroids","url":"https://www.spoj.com/problems/UOFTBC","users":67,"accepted":25.67}
+{"id":14979,"name":"Diablo Bot","url":"https://www.spoj.com/problems/UOFTBD","users":78,"accepted":13.73}
+{"id":14980,"name":"MVP","url":"https://www.spoj.com/problems/UOFTBE","users":29,"accepted":44.83}
+{"id":14981,"name":"Light Cycling","url":"https://www.spoj.com/problems/UOFTBF","users":78,"accepted":14.41}
+{"id":14991,"name":"Your Rank is Pure (EXTREME ver)","url":"https://www.spoj.com/problems/EGCJPURE","users":8,"accepted":26.12}
+{"id":15038,"name":"Yell Classico","url":"https://www.spoj.com/problems/CLASSICO","users":214,"accepted":38.37}
+{"id":15060,"name":"Elegant Diamond","url":"https://www.spoj.com/problems/GCJ102A","users":17,"accepted":52.63}
+{"id":15061,"name":"World Cup 2010","url":"https://www.spoj.com/problems/GCJ102B","users":28,"accepted":42.67}
+{"id":15062,"name":"Bacteria","url":"https://www.spoj.com/problems/GCJ102C","users":16,"accepted":31.37}
+{"id":15073,"name":"Team Slide Treasure Hunt Race","url":"https://www.spoj.com/problems/SLIDE","users":91,"accepted":33.6}
+{"id":15074,"name":"Tourney","url":"https://www.spoj.com/problems/TOURNEY","users":149,"accepted":36.87}
+{"id":15075,"name":"A Romantic Dinner Outing","url":"https://www.spoj.com/problems/RDINNER","users":22,"accepted":17.77}
+{"id":15076,"name":"A Romantic Movie Outing","url":"https://www.spoj.com/problems/RMOVIE","users":27,"accepted":18.39}
+{"id":15086,"name":"Land Acquisition","url":"https://www.spoj.com/problems/ACQUIRE","users":1500,"accepted":29.48}
+{"id":15088,"name":"Ancient Aliens","url":"https://www.spoj.com/problems/BFDIV","users":5,"accepted":42.62}

--- a/tests/spoj/index/51.md
+++ b/tests/spoj/index/51.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 14883 | [Box Factory](https://www.spoj.com/problems/GCJ121CC) | 15 | 33.96 |
+| 14886 | [Matts Trip](https://www.spoj.com/problems/MATT) | 74 | 19.38 |
+| 14887 | [Good Travels](https://www.spoj.com/problems/GOODA) | 640 | 29.21 |
+| 14888 | [Good Predictions](https://www.spoj.com/problems/GOODB) | 1101 | 42.46 |
+| 14889 | [Good Strategy](https://www.spoj.com/problems/GOODC) | 56 | 38.86 |
+| 14890 | [Good Code](https://www.spoj.com/problems/GOODD) | 57 | 22.69 |
+| 14891 | [Good Debugging](https://www.spoj.com/problems/GOODE) | 60 | 41.22 |
+| 14892 | [Good Aim](https://www.spoj.com/problems/GOODF) | 37 | 31.79 |
+| 14893 | [Good Inflation](https://www.spoj.com/problems/GOODG) | 195 | 28.52 |
+| 14894 | [Good Celebration](https://www.spoj.com/problems/GOODH) | 27 | 20.10 |
+| 14905 | [Zig when you zag](https://www.spoj.com/problems/ZIGZAG2) | 36 | 30.05 |
+| 14923 | [King Graffs Defense](https://www.spoj.com/problems/GRAFFDEF) | 482 | 25.51 |
+| 14924 | [King Graffs Tolls](https://www.spoj.com/problems/GRAFFTOL) | 35 | 40.00 |
+| 14925 | [King Graffs Trip](https://www.spoj.com/problems/GRAFFTRI) | 26 | 20.71 |
+| 14926 | [abdou set](https://www.spoj.com/problems/KIMO1) | 61 | 46.99 |
+| 14928 | [Pyramidal Constructions](https://www.spoj.com/problems/PIRACON) | 336 | 48.77 |
+| 14929 | [Subsequence](https://www.spoj.com/problems/SUBSN) | 178 | 12.79 |
+| 14930 | [Princess Farida](https://www.spoj.com/problems/FARIDA) | 12246 | 26.80 |
+| 14932 | [Lowest Common Ancestor](https://www.spoj.com/problems/LCA) | 7927 | 29.24 |
+| 14935 | [Cactus](https://www.spoj.com/problems/CAC) | 219 | 20.06 |
+| 14943 | [Dynamically-Rooted Tree](https://www.spoj.com/problems/DRTREE) | 340 | 31.13 |
+| 14944 | [Reindeer Games](https://www.spoj.com/problems/SANTA1) | 116 | 22.00 |
+| 14946 | [Travelling Santa](https://www.spoj.com/problems/SANTA2) | 56 | 34.11 |
+| 14947 | [Breaking and Entering](https://www.spoj.com/problems/SANTA3) | 27 | 36.08 |
+| 14949 | [HELPER](https://www.spoj.com/problems/HELPER) | 13 | 39.47 |
+| 14955 | [Dancing Cows](https://www.spoj.com/problems/DCOWS) | 597 | 24.93 |
+| 14956 | [Submerging Islands](https://www.spoj.com/problems/SUBMERGE) | 4711 | 39.67 |
+| 14957 | [Chinese game](https://www.spoj.com/problems/CHIGAME) | 26 | 24.19 |
+| 14961 | [Maximum Girth](https://www.spoj.com/problems/MAXGRITH) | 648 | 55.43 |
+| 14971 | [The Foxens Treasure](https://www.spoj.com/problems/UOFTAB) | 231 | 35.31 |
+| 14972 | [Foxhole](https://www.spoj.com/problems/UOFTAC) | 235 | 32.67 |
+| 14973 | [Reverse Fox Hunt](https://www.spoj.com/problems/UOFTAD) | 81 | 46.30 |
+| 14974 | [Foxling Feeding Frenzy](https://www.spoj.com/problems/UOFTAE) | 466 | 42.09 |
+| 14975 | [Foxic Expressions](https://www.spoj.com/problems/UOFTAF) | 87 | 15.24 |
+| 14977 | [Attack of the Bloons](https://www.spoj.com/problems/UOFTBB) | 370 | 45.80 |
+| 14978 | [Homemade Asteroids](https://www.spoj.com/problems/UOFTBC) | 67 | 25.67 |
+| 14979 | [Diablo Bot](https://www.spoj.com/problems/UOFTBD) | 78 | 13.73 |
+| 14980 | [MVP](https://www.spoj.com/problems/UOFTBE) | 29 | 44.83 |
+| 14981 | [Light Cycling](https://www.spoj.com/problems/UOFTBF) | 78 | 14.41 |
+| 14991 | [Your Rank is Pure (EXTREME ver)](https://www.spoj.com/problems/EGCJPURE) | 8 | 26.12 |
+| 15038 | [Yell Classico](https://www.spoj.com/problems/CLASSICO) | 214 | 38.37 |
+| 15060 | [Elegant Diamond](https://www.spoj.com/problems/GCJ102A) | 17 | 52.63 |
+| 15061 | [World Cup 2010](https://www.spoj.com/problems/GCJ102B) | 28 | 42.67 |
+| 15062 | [Bacteria](https://www.spoj.com/problems/GCJ102C) | 16 | 31.37 |
+| 15073 | [Team Slide Treasure Hunt Race](https://www.spoj.com/problems/SLIDE) | 91 | 33.60 |
+| 15074 | [Tourney](https://www.spoj.com/problems/TOURNEY) | 149 | 36.87 |
+| 15075 | [A Romantic Dinner Outing](https://www.spoj.com/problems/RDINNER) | 22 | 17.77 |
+| 15076 | [A Romantic Movie Outing](https://www.spoj.com/problems/RMOVIE) | 27 | 18.39 |
+| 15086 | [Land Acquisition](https://www.spoj.com/problems/ACQUIRE) | 1500 | 29.48 |
+| 15088 | [Ancient Aliens](https://www.spoj.com/problems/BFDIV) | 5 | 42.62 |

--- a/tests/spoj/index/52.jsonl
+++ b/tests/spoj/index/52.jsonl
@@ -1,0 +1,50 @@
+{"id":15089,"name":"Farmer Joe","url":"https://www.spoj.com/problems/BFMUL","users":6,"accepted":14.86}
+{"id":15091,"name":"One Good Base Deserves Another","url":"https://www.spoj.com/problems/BFBASE","users":3,"accepted":28.57}
+{"id":15092,"name":"A Kleene Implementation","url":"https://www.spoj.com/problems/BFREGEX1","users":5,"accepted":34.04}
+{"id":15143,"name":"play with prime numbers (I)","url":"https://www.spoj.com/problems/POP1","users":35,"accepted":17.29}
+{"id":15148,"name":"play with prime numbers (II)","url":"https://www.spoj.com/problems/POP2","users":35,"accepted":20.83}
+{"id":15149,"name":"play with prime numbers (III)(hard )","url":"https://www.spoj.com/problems/POP3","users":29,"accepted":42.6}
+{"id":15164,"name":"primes triangle (I)","url":"https://www.spoj.com/problems/PTRI","users":78,"accepted":7.11}
+{"id":15165,"name":"primes triangle (II)","url":"https://www.spoj.com/problems/PTR2","users":18,"accepted":26.38}
+{"id":15190,"name":"MAXIMUM RARITY","url":"https://www.spoj.com/problems/SBO","users":90,"accepted":35.38}
+{"id":15208,"name":"Minimum Cost","url":"https://www.spoj.com/problems/MC","users":1478,"accepted":57.34}
+{"id":15215,"name":"David and his Obsession","url":"https://www.spoj.com/problems/PUCMM009","users":429,"accepted":41.23}
+{"id":15241,"name":"Luis Quest","url":"https://www.spoj.com/problems/VPL2_AA","users":1249,"accepted":60.64}
+{"id":15242,"name":"Betos Quest","url":"https://www.spoj.com/problems/VPL2_AB","users":32,"accepted":26.79}
+{"id":15243,"name":"Primos Quest","url":"https://www.spoj.com/problems/VPL2_AC","users":175,"accepted":38.49}
+{"id":15244,"name":"Davids Quest","url":"https://www.spoj.com/problems/VPL2_AD","users":44,"accepted":46.15}
+{"id":15248,"name":"Swap (Easy - Level 2)","url":"https://www.spoj.com/problems/SWAP_ESY","users":17,"accepted":30.86}
+{"id":15249,"name":"Swap (Medium - Level 200)","url":"https://www.spoj.com/problems/SWAP_MED","users":6,"accepted":19.81}
+{"id":15250,"name":"Swap (Hard - Level 1000)","url":"https://www.spoj.com/problems/SWAP_HRD","users":6,"accepted":23.47}
+{"id":15252,"name":"Humans Life Code","url":"https://www.spoj.com/problems/MOSTYCOD","users":9,"accepted":47.22}
+{"id":15256,"name":"Partition function (EASY)","url":"https://www.spoj.com/problems/PARCARD1","users":103,"accepted":39.65}
+{"id":15257,"name":"Partition function (HARD)","url":"https://www.spoj.com/problems/PARCARD2","users":7,"accepted":3.16}
+{"id":15259,"name":"Large Knapsack","url":"https://www.spoj.com/problems/LKS","users":2288,"accepted":26.11}
+{"id":15266,"name":"III Powers","url":"https://www.spoj.com/problems/THRPWRS","users":131,"accepted":63.12}
+{"id":15267,"name":"FRIEND CIRCLE","url":"https://www.spoj.com/problems/FRNDCIRC","users":1436,"accepted":28.4}
+{"id":15270,"name":"A plus B","url":"https://www.spoj.com/problems/ICKAPLSB","users":12,"accepted":5.56}
+{"id":15285,"name":"Defend The Rohan","url":"https://www.spoj.com/problems/ROHAAN","users":1350,"accepted":43.24}
+{"id":15310,"name":"Peter Quest","url":"https://www.spoj.com/problems/VPL2_BC","users":178,"accepted":49.05}
+{"id":15312,"name":"Annoying Coins Quest","url":"https://www.spoj.com/problems/VPL2_BE","users":30,"accepted":42.32}
+{"id":15328,"name":"Hunter x Hunter","url":"https://www.spoj.com/problems/HXH","users":74,"accepted":13.42}
+{"id":15336,"name":"Hello Intercal!","url":"https://www.spoj.com/problems/ICKHELLO","users":169,"accepted":58.9}
+{"id":15360,"name":"World Record Lunch","url":"https://www.spoj.com/problems/WRLUNCH","users":23,"accepted":12.41}
+{"id":15376,"name":"Running Median","url":"https://www.spoj.com/problems/RMID","users":1179,"accepted":26.19}
+{"id":15381,"name":"Cut The Rope","url":"https://www.spoj.com/problems/BFGCD","users":3,"accepted":16.28}
+{"id":15382,"name":"Factorial (Again!)","url":"https://www.spoj.com/problems/FCTRL5","users":4,"accepted":33.33}
+{"id":15383,"name":"Transform the Expression (Again!)","url":"https://www.spoj.com/problems/BFONP","users":7,"accepted":31.25}
+{"id":15429,"name":"Counting Ids","url":"https://www.spoj.com/problems/UCV2013A","users":2007,"accepted":49.49}
+{"id":15430,"name":"Alice in Amsterdam, I mean Wonderland","url":"https://www.spoj.com/problems/UCV2013B","users":144,"accepted":23.57}
+{"id":15431,"name":"Farmer Cream","url":"https://www.spoj.com/problems/UCV2013C","users":543,"accepted":53.23}
+{"id":15432,"name":"Distributing V-Energy","url":"https://www.spoj.com/problems/UCV2013D","users":25,"accepted":32.63}
+{"id":15433,"name":"Greedy Walking","url":"https://www.spoj.com/problems/UCV2013E","users":505,"accepted":51.4}
+{"id":15434,"name":"Life on Fornax","url":"https://www.spoj.com/problems/UCV2013F","users":29,"accepted":64.98}
+{"id":15435,"name":"Schedules","url":"https://www.spoj.com/problems/UCV2013G","users":28,"accepted":12.25}
+{"id":15436,"name":"Slick","url":"https://www.spoj.com/problems/UCV2013H","users":2260,"accepted":32.7}
+{"id":15437,"name":"Tambourine","url":"https://www.spoj.com/problems/UCV2013I","users":1497,"accepted":49.95}
+{"id":15438,"name":"Valences","url":"https://www.spoj.com/problems/UCV2013J","users":1281,"accepted":41.62}
+{"id":15439,"name":"Zombie Outbreak","url":"https://www.spoj.com/problems/UCV2013K","users":75,"accepted":22.86}
+{"id":15453,"name":"Yet Another Electronic Device!!!","url":"https://www.spoj.com/problems/KCARRY","users":89,"accepted":47.88}
+{"id":15454,"name":"How to Handle the Fans","url":"https://www.spoj.com/problems/AKVQLD03","users":1530,"accepted":50.54}
+{"id":15460,"name":"Selling Art","url":"https://www.spoj.com/problems/SELLINGA","users":9,"accepted":12.5}
+{"id":15498,"name":"Kawigi quote","url":"https://www.spoj.com/problems/KIMO4","users":25,"accepted":32.11}

--- a/tests/spoj/index/52.md
+++ b/tests/spoj/index/52.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 15089 | [Farmer Joe](https://www.spoj.com/problems/BFMUL) | 6 | 14.86 |
+| 15091 | [One Good Base Deserves Another](https://www.spoj.com/problems/BFBASE) | 3 | 28.57 |
+| 15092 | [A Kleene Implementation](https://www.spoj.com/problems/BFREGEX1) | 5 | 34.04 |
+| 15143 | [play with prime numbers (I)](https://www.spoj.com/problems/POP1) | 35 | 17.29 |
+| 15148 | [play with prime numbers (II)](https://www.spoj.com/problems/POP2) | 35 | 20.83 |
+| 15149 | [play with prime numbers (III)(hard )](https://www.spoj.com/problems/POP3) | 29 | 42.60 |
+| 15164 | [primes triangle (I)](https://www.spoj.com/problems/PTRI) | 78 | 7.11 |
+| 15165 | [primes triangle (II)](https://www.spoj.com/problems/PTR2) | 18 | 26.38 |
+| 15190 | [MAXIMUM RARITY](https://www.spoj.com/problems/SBO) | 90 | 35.38 |
+| 15208 | [Minimum Cost](https://www.spoj.com/problems/MC) | 1478 | 57.34 |
+| 15215 | [David and his Obsession](https://www.spoj.com/problems/PUCMM009) | 429 | 41.23 |
+| 15241 | [Luis Quest](https://www.spoj.com/problems/VPL2_AA) | 1249 | 60.64 |
+| 15242 | [Betos Quest](https://www.spoj.com/problems/VPL2_AB) | 32 | 26.79 |
+| 15243 | [Primos Quest](https://www.spoj.com/problems/VPL2_AC) | 175 | 38.49 |
+| 15244 | [Davids Quest](https://www.spoj.com/problems/VPL2_AD) | 44 | 46.15 |
+| 15248 | [Swap (Easy - Level 2)](https://www.spoj.com/problems/SWAP_ESY) | 17 | 30.86 |
+| 15249 | [Swap (Medium - Level 200)](https://www.spoj.com/problems/SWAP_MED) | 6 | 19.81 |
+| 15250 | [Swap (Hard - Level 1000)](https://www.spoj.com/problems/SWAP_HRD) | 6 | 23.47 |
+| 15252 | [Humans Life Code](https://www.spoj.com/problems/MOSTYCOD) | 9 | 47.22 |
+| 15256 | [Partition function (EASY)](https://www.spoj.com/problems/PARCARD1) | 103 | 39.65 |
+| 15257 | [Partition function (HARD)](https://www.spoj.com/problems/PARCARD2) | 7 | 3.16 |
+| 15259 | [Large Knapsack](https://www.spoj.com/problems/LKS) | 2288 | 26.11 |
+| 15266 | [III Powers](https://www.spoj.com/problems/THRPWRS) | 131 | 63.12 |
+| 15267 | [FRIEND CIRCLE](https://www.spoj.com/problems/FRNDCIRC) | 1436 | 28.40 |
+| 15270 | [A plus B](https://www.spoj.com/problems/ICKAPLSB) | 12 | 5.56 |
+| 15285 | [Defend The Rohan](https://www.spoj.com/problems/ROHAAN) | 1350 | 43.24 |
+| 15310 | [Peter Quest](https://www.spoj.com/problems/VPL2_BC) | 178 | 49.05 |
+| 15312 | [Annoying Coins Quest](https://www.spoj.com/problems/VPL2_BE) | 30 | 42.32 |
+| 15328 | [Hunter x Hunter](https://www.spoj.com/problems/HXH) | 74 | 13.42 |
+| 15336 | [Hello Intercal!](https://www.spoj.com/problems/ICKHELLO) | 169 | 58.90 |
+| 15360 | [World Record Lunch](https://www.spoj.com/problems/WRLUNCH) | 23 | 12.41 |
+| 15376 | [Running Median](https://www.spoj.com/problems/RMID) | 1179 | 26.19 |
+| 15381 | [Cut The Rope](https://www.spoj.com/problems/BFGCD) | 3 | 16.28 |
+| 15382 | [Factorial (Again!)](https://www.spoj.com/problems/FCTRL5) | 4 | 33.33 |
+| 15383 | [Transform the Expression (Again!)](https://www.spoj.com/problems/BFONP) | 7 | 31.25 |
+| 15429 | [Counting Ids](https://www.spoj.com/problems/UCV2013A) | 2007 | 49.49 |
+| 15430 | [Alice in Amsterdam, I mean Wonderland](https://www.spoj.com/problems/UCV2013B) | 144 | 23.57 |
+| 15431 | [Farmer Cream](https://www.spoj.com/problems/UCV2013C) | 543 | 53.23 |
+| 15432 | [Distributing V-Energy](https://www.spoj.com/problems/UCV2013D) | 25 | 32.63 |
+| 15433 | [Greedy Walking](https://www.spoj.com/problems/UCV2013E) | 505 | 51.40 |
+| 15434 | [Life on Fornax](https://www.spoj.com/problems/UCV2013F) | 29 | 64.98 |
+| 15435 | [Schedules](https://www.spoj.com/problems/UCV2013G) | 28 | 12.25 |
+| 15436 | [Slick](https://www.spoj.com/problems/UCV2013H) | 2260 | 32.70 |
+| 15437 | [Tambourine](https://www.spoj.com/problems/UCV2013I) | 1497 | 49.95 |
+| 15438 | [Valences](https://www.spoj.com/problems/UCV2013J) | 1281 | 41.62 |
+| 15439 | [Zombie Outbreak](https://www.spoj.com/problems/UCV2013K) | 75 | 22.86 |
+| 15453 | [Yet Another Electronic Device!!!](https://www.spoj.com/problems/KCARRY) | 89 | 47.88 |
+| 15454 | [How to Handle the Fans](https://www.spoj.com/problems/AKVQLD03) | 1530 | 50.54 |
+| 15460 | [Selling Art](https://www.spoj.com/problems/SELLINGA) | 9 | 12.50 |
+| 15498 | [Kawigi quote](https://www.spoj.com/problems/KIMO4) | 25 | 32.11 |

--- a/tests/spoj/index/53.jsonl
+++ b/tests/spoj/index/53.jsonl
@@ -1,0 +1,50 @@
+{"id":15506,"name":"Helping Igor","url":"https://www.spoj.com/problems/IGOR","users":102,"accepted":34.84}
+{"id":15541,"name":"Simplified Hangul","url":"https://www.spoj.com/problems/SHANGUL","users":44,"accepted":47.5}
+{"id":15551,"name":"Do You Even Lift","url":"https://www.spoj.com/problems/DYEL","users":24,"accepted":36.86}
+{"id":15553,"name":"Hamsters","url":"https://www.spoj.com/problems/STC00","users":61,"accepted":33.63}
+{"id":15554,"name":"Niceness of the string","url":"https://www.spoj.com/problems/IITKWPCA","users":1170,"accepted":36.63}
+{"id":15555,"name":"Check the coprimeness","url":"https://www.spoj.com/problems/IITKWPCB","users":3263,"accepted":50.32}
+{"id":15556,"name":"Count right angle triangles","url":"https://www.spoj.com/problems/IITKWPCC","users":53,"accepted":24.7}
+{"id":15557,"name":"Partition the sticks","url":"https://www.spoj.com/problems/IITKWPCD","users":110,"accepted":34.84}
+{"id":15558,"name":"Let us play with strings","url":"https://www.spoj.com/problems/IITKWPCE","users":320,"accepted":38.41}
+{"id":15559,"name":"Help Feluda with mathematical equations","url":"https://www.spoj.com/problems/IITKWPCF","users":277,"accepted":23.3}
+{"id":15560,"name":"Help the old King","url":"https://www.spoj.com/problems/IITKWPCG","users":554,"accepted":37.22}
+{"id":15561,"name":"Find Number Of Pair of Friends","url":"https://www.spoj.com/problems/IITKWPCH","users":469,"accepted":32.15}
+{"id":15562,"name":"Find Lexicographically Smallest Permutation","url":"https://www.spoj.com/problems/IITKWPCI","users":364,"accepted":40.51}
+{"id":15563,"name":"Check the string Powers","url":"https://www.spoj.com/problems/IITKWPCJ","users":494,"accepted":29.11}
+{"id":15565,"name":"Find Distances In A Plane","url":"https://www.spoj.com/problems/IITKWPCL","users":52,"accepted":16.73}
+{"id":15566,"name":"Coprime Again","url":"https://www.spoj.com/problems/IITKWPCM","users":73,"accepted":26.66}
+{"id":15567,"name":"Playing With Balls","url":"https://www.spoj.com/problems/IITKWPCN","users":1776,"accepted":65.35}
+{"id":15568,"name":"Fire Extinguishers","url":"https://www.spoj.com/problems/STC01","users":19,"accepted":45.28}
+{"id":15569,"name":"Antisymmetry","url":"https://www.spoj.com/problems/STC02","users":417,"accepted":40.8}
+{"id":15571,"name":"Difference","url":"https://www.spoj.com/problems/STC04","users":147,"accepted":33.39}
+{"id":15572,"name":"Garden","url":"https://www.spoj.com/problems/STC05","users":22,"accepted":24.59}
+{"id":15573,"name":"Keyboard","url":"https://www.spoj.com/problems/STC06","users":16,"accepted":28.17}
+{"id":15574,"name":"Railway","url":"https://www.spoj.com/problems/STC07","users":19,"accepted":23.03}
+{"id":15575,"name":"Kangaroos","url":"https://www.spoj.com/problems/STC08","users":20,"accepted":23.78}
+{"id":15576,"name":"Aesthetic Text","url":"https://www.spoj.com/problems/STC09","users":16,"accepted":22.08}
+{"id":15577,"name":"Blockade","url":"https://www.spoj.com/problems/STC10","users":513,"accepted":44.28}
+{"id":15609,"name":"Spiky Mazes","url":"https://www.spoj.com/problems/SPIKES","users":1051,"accepted":35.05}
+{"id":15620,"name":"Postering","url":"https://www.spoj.com/problems/POSTERIN","users":729,"accepted":33.94}
+{"id":15621,"name":"Tie the Rope","url":"https://www.spoj.com/problems/TIEROPE","users":93,"accepted":22.31}
+{"id":15627,"name":"Create Collections","url":"https://www.spoj.com/problems/IITKWPCO","users":1611,"accepted":33.7}
+{"id":15631,"name":"On the Plus Side","url":"https://www.spoj.com/problems/PLUS","users":43,"accepted":32.26}
+{"id":15634,"name":"Lennys Lucky Lotto Lists","url":"https://www.spoj.com/problems/GNYR04C","users":239,"accepted":31.74}
+{"id":15636,"name":"Histology Assistant","url":"https://www.spoj.com/problems/GNYR04I","users":10,"accepted":22.37}
+{"id":15637,"name":"Mr Youngs Picture Permutations","url":"https://www.spoj.com/problems/GNYR04H","users":700,"accepted":42.84}
+{"id":15648,"name":"Commando","url":"https://www.spoj.com/problems/APIO10A","users":869,"accepted":33.51}
+{"id":15649,"name":"Unequalled Consumption","url":"https://www.spoj.com/problems/NWERC05","users":14,"accepted":23.53}
+{"id":15650,"name":"Dark roads","url":"https://www.spoj.com/problems/ULM09","users":1565,"accepted":36.49}
+{"id":15655,"name":"Product of factorials","url":"https://www.spoj.com/problems/FACTMUL","users":1344,"accepted":23.5}
+{"id":15671,"name":"Product of factorials (medium)","url":"https://www.spoj.com/problems/FACTMULM","users":23,"accepted":28.65}
+{"id":15728,"name":"The Sierpinski Fractal","url":"https://www.spoj.com/problems/ULM02","users":120,"accepted":27}
+{"id":15733,"name":"Hall of Fountains","url":"https://www.spoj.com/problems/ULM2H","users":22,"accepted":50.35}
+{"id":15734,"name":"California Jones and the Gate to Freedom","url":"https://www.spoj.com/problems/ULM02C","users":36,"accepted":53.01}
+{"id":15735,"name":"Balanced Food","url":"https://www.spoj.com/problems/ULM02B","users":10,"accepted":19.61}
+{"id":15736,"name":"Breaking String","url":"https://www.spoj.com/problems/BRKSTRNG","users":776,"accepted":37.92}
+{"id":15766,"name":"Enjoy Sum with Operations","url":"https://www.spoj.com/problems/SUMSUM","users":376,"accepted":27.18}
+{"id":15769,"name":"Enjoy Adding GP to Series","url":"https://www.spoj.com/problems/ADDGP","users":63,"accepted":26.67}
+{"id":15783,"name":"Coder Express 3!!","url":"https://www.spoj.com/problems/CODERE3","users":1276,"accepted":47.77}
+{"id":15827,"name":"Vending Machine","url":"https://www.spoj.com/problems/AUT","users":36,"accepted":8.81}
+{"id":15847,"name":"Equalize the Sectors","url":"https://www.spoj.com/problems/SECTORS","users":158,"accepted":59.9}
+{"id":15849,"name":"Find the Treasure","url":"https://www.spoj.com/problems/DIGOKEYS","users":692,"accepted":23.68}

--- a/tests/spoj/index/53.md
+++ b/tests/spoj/index/53.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 15506 | [Helping Igor](https://www.spoj.com/problems/IGOR) | 102 | 34.84 |
+| 15541 | [Simplified Hangul](https://www.spoj.com/problems/SHANGUL) | 44 | 47.50 |
+| 15551 | [Do You Even Lift](https://www.spoj.com/problems/DYEL) | 24 | 36.86 |
+| 15553 | [Hamsters](https://www.spoj.com/problems/STC00) | 61 | 33.63 |
+| 15554 | [Niceness of the string](https://www.spoj.com/problems/IITKWPCA) | 1170 | 36.63 |
+| 15555 | [Check the coprimeness](https://www.spoj.com/problems/IITKWPCB) | 3263 | 50.32 |
+| 15556 | [Count right angle triangles](https://www.spoj.com/problems/IITKWPCC) | 53 | 24.70 |
+| 15557 | [Partition the sticks](https://www.spoj.com/problems/IITKWPCD) | 110 | 34.84 |
+| 15558 | [Let us play with strings](https://www.spoj.com/problems/IITKWPCE) | 320 | 38.41 |
+| 15559 | [Help Feluda with mathematical equations](https://www.spoj.com/problems/IITKWPCF) | 277 | 23.30 |
+| 15560 | [Help the old King](https://www.spoj.com/problems/IITKWPCG) | 554 | 37.22 |
+| 15561 | [Find Number Of Pair of Friends](https://www.spoj.com/problems/IITKWPCH) | 469 | 32.15 |
+| 15562 | [Find Lexicographically Smallest Permutation](https://www.spoj.com/problems/IITKWPCI) | 364 | 40.51 |
+| 15563 | [Check the string Powers](https://www.spoj.com/problems/IITKWPCJ) | 494 | 29.11 |
+| 15565 | [Find Distances In A Plane](https://www.spoj.com/problems/IITKWPCL) | 52 | 16.73 |
+| 15566 | [Coprime Again](https://www.spoj.com/problems/IITKWPCM) | 73 | 26.66 |
+| 15567 | [Playing With Balls](https://www.spoj.com/problems/IITKWPCN) | 1776 | 65.35 |
+| 15568 | [Fire Extinguishers](https://www.spoj.com/problems/STC01) | 19 | 45.28 |
+| 15569 | [Antisymmetry](https://www.spoj.com/problems/STC02) | 417 | 40.80 |
+| 15571 | [Difference](https://www.spoj.com/problems/STC04) | 147 | 33.39 |
+| 15572 | [Garden](https://www.spoj.com/problems/STC05) | 22 | 24.59 |
+| 15573 | [Keyboard](https://www.spoj.com/problems/STC06) | 16 | 28.17 |
+| 15574 | [Railway](https://www.spoj.com/problems/STC07) | 19 | 23.03 |
+| 15575 | [Kangaroos](https://www.spoj.com/problems/STC08) | 20 | 23.78 |
+| 15576 | [Aesthetic Text](https://www.spoj.com/problems/STC09) | 16 | 22.08 |
+| 15577 | [Blockade](https://www.spoj.com/problems/STC10) | 513 | 44.28 |
+| 15609 | [Spiky Mazes](https://www.spoj.com/problems/SPIKES) | 1051 | 35.05 |
+| 15620 | [Postering](https://www.spoj.com/problems/POSTERIN) | 729 | 33.94 |
+| 15621 | [Tie the Rope](https://www.spoj.com/problems/TIEROPE) | 93 | 22.31 |
+| 15627 | [Create Collections](https://www.spoj.com/problems/IITKWPCO) | 1611 | 33.70 |
+| 15631 | [On the Plus Side](https://www.spoj.com/problems/PLUS) | 43 | 32.26 |
+| 15634 | [Lennys Lucky Lotto Lists](https://www.spoj.com/problems/GNYR04C) | 239 | 31.74 |
+| 15636 | [Histology Assistant](https://www.spoj.com/problems/GNYR04I) | 10 | 22.37 |
+| 15637 | [Mr Youngs Picture Permutations](https://www.spoj.com/problems/GNYR04H) | 700 | 42.84 |
+| 15648 | [Commando](https://www.spoj.com/problems/APIO10A) | 869 | 33.51 |
+| 15649 | [Unequalled Consumption](https://www.spoj.com/problems/NWERC05) | 14 | 23.53 |
+| 15650 | [Dark roads](https://www.spoj.com/problems/ULM09) | 1565 | 36.49 |
+| 15655 | [Product of factorials](https://www.spoj.com/problems/FACTMUL) | 1344 | 23.50 |
+| 15671 | [Product of factorials (medium)](https://www.spoj.com/problems/FACTMULM) | 23 | 28.65 |
+| 15728 | [The Sierpinski Fractal](https://www.spoj.com/problems/ULM02) | 120 | 27.00 |
+| 15733 | [Hall of Fountains](https://www.spoj.com/problems/ULM2H) | 22 | 50.35 |
+| 15734 | [California Jones and the Gate to Freedom](https://www.spoj.com/problems/ULM02C) | 36 | 53.01 |
+| 15735 | [Balanced Food](https://www.spoj.com/problems/ULM02B) | 10 | 19.61 |
+| 15736 | [Breaking String](https://www.spoj.com/problems/BRKSTRNG) | 776 | 37.92 |
+| 15766 | [Enjoy Sum with Operations](https://www.spoj.com/problems/SUMSUM) | 376 | 27.18 |
+| 15769 | [Enjoy Adding GP to Series](https://www.spoj.com/problems/ADDGP) | 63 | 26.67 |
+| 15783 | [Coder Express 3!!](https://www.spoj.com/problems/CODERE3) | 1276 | 47.77 |
+| 15827 | [Vending Machine](https://www.spoj.com/problems/AUT) | 36 | 8.81 |
+| 15847 | [Equalize the Sectors](https://www.spoj.com/problems/SECTORS) | 158 | 59.90 |
+| 15849 | [Find the Treasure](https://www.spoj.com/problems/DIGOKEYS) | 692 | 23.68 |

--- a/tests/spoj/index/54.jsonl
+++ b/tests/spoj/index/54.jsonl
@@ -1,0 +1,50 @@
+{"id":15850,"name":"Game","url":"https://www.spoj.com/problems/DGAME","users":61,"accepted":41.09}
+{"id":15851,"name":"Permutations","url":"https://www.spoj.com/problems/PSERVICE","users":18,"accepted":32.93}
+{"id":15864,"name":"SUMMING","url":"https://www.spoj.com/problems/SUMMING","users":10,"accepted":8.45}
+{"id":15867,"name":"Great Warrior","url":"https://www.spoj.com/problems/SNGGW","users":128,"accepted":66.67}
+{"id":15891,"name":"Prime Generator The Easiest Question Ever","url":"https://www.spoj.com/problems/SNGPG","users":1180,"accepted":46.46}
+{"id":15892,"name":"Cave","url":"https://www.spoj.com/problems/CAVE2","users":16,"accepted":16.42}
+{"id":15914,"name":"Update Sub-Matrix \u0026 Query Sub-Matrix","url":"https://www.spoj.com/problems/USUBQSUB","users":95,"accepted":35.62}
+{"id":15961,"name":"MAXSET","url":"https://www.spoj.com/problems/MAXSET","users":48,"accepted":34.74}
+{"id":15963,"name":"Help Donn","url":"https://www.spoj.com/problems/HELPDONN","users":95,"accepted":42.42}
+{"id":15965,"name":"PLAY WITH MATH","url":"https://www.spoj.com/problems/ENIGMATH","users":6902,"accepted":46.49}
+{"id":15980,"name":"Ascending Fibonacci Numbers","url":"https://www.spoj.com/problems/ASCDFIB","users":807,"accepted":17.23}
+{"id":15994,"name":"Boxes of Chocolate","url":"https://www.spoj.com/problems/BOXSCHOC","users":92,"accepted":24.72}
+{"id":15995,"name":"Self Numbers","url":"https://www.spoj.com/problems/MCUR98","users":904,"accepted":38.32}
+{"id":15996,"name":"Number Magic II","url":"https://www.spoj.com/problems/SNGNM2","users":27,"accepted":26.28}
+{"id":16017,"name":"The Triangle Game","url":"https://www.spoj.com/problems/MCU20A","users":56,"accepted":47.59}
+{"id":16018,"name":"Edge Detection","url":"https://www.spoj.com/problems/MCU20E","users":14,"accepted":53.33}
+{"id":16030,"name":"Psycho","url":"https://www.spoj.com/problems/PSYCHON","users":858,"accepted":20.71}
+{"id":16033,"name":"Tip Top Game","url":"https://www.spoj.com/problems/TIPTOP","users":1769,"accepted":27.18}
+{"id":16034,"name":"Minimum Number","url":"https://www.spoj.com/problems/MINNUM","users":498,"accepted":16.17}
+{"id":16035,"name":"Fone Frequencies","url":"https://www.spoj.com/problems/OU7","users":34,"accepted":43.96}
+{"id":16046,"name":"Help Professor","url":"https://www.spoj.com/problems/HPPROF","users":402,"accepted":47.67}
+{"id":16048,"name":"Help Rarity Collect Crystals","url":"https://www.spoj.com/problems/PONY9","users":25,"accepted":22.39}
+{"id":16062,"name":"Count Primes","url":"https://www.spoj.com/problems/SNGCP","users":45,"accepted":25.2}
+{"id":16063,"name":"Hackers","url":"https://www.spoj.com/problems/TREEBA","users":61,"accepted":21.64}
+{"id":16102,"name":"Can you play carrom !!!","url":"https://www.spoj.com/problems/CARRHIM","users":213,"accepted":21.58}
+{"id":16121,"name":"MODIFY SEQUENCE","url":"https://www.spoj.com/problems/NITK06","users":2380,"accepted":48.49}
+{"id":16128,"name":"THE INDIAN OCEAN","url":"https://www.spoj.com/problems/NITK07","users":53,"accepted":9.67}
+{"id":16134,"name":"Save the cows!","url":"https://www.spoj.com/problems/COD1","users":61,"accepted":12.82}
+{"id":16138,"name":"Deconnecting","url":"https://www.spoj.com/problems/CODGRF","users":62,"accepted":31.22}
+{"id":16139,"name":"Naya Shatranj (New Chess)","url":"https://www.spoj.com/problems/CODCHESS","users":1937,"accepted":68.39}
+{"id":16177,"name":"Hashcodes and primes","url":"https://www.spoj.com/problems/CODHASH","users":25,"accepted":44.44}
+{"id":16178,"name":"Change","url":"https://www.spoj.com/problems/TPC07","users":61,"accepted":10.26}
+{"id":16179,"name":"Platinum Relic!","url":"https://www.spoj.com/problems/PTRELIC","users":68,"accepted":22.62}
+{"id":16180,"name":"Ratar","url":"https://www.spoj.com/problems/RATAR","users":83,"accepted":27.27}
+{"id":16184,"name":"Megatron and his rage","url":"https://www.spoj.com/problems/CODFURY","users":1140,"accepted":32.55}
+{"id":16185,"name":"Mining your own business","url":"https://www.spoj.com/problems/BUSINESS","users":630,"accepted":20.8}
+{"id":16207,"name":"Football Fever","url":"https://www.spoj.com/problems/DCEPC11F","users":78,"accepted":44.16}
+{"id":16208,"name":"Challenge Accepted","url":"https://www.spoj.com/problems/DCEPC11C","users":24,"accepted":21.34}
+{"id":16210,"name":"Impossible Boss","url":"https://www.spoj.com/problems/DCEPC11I","users":180,"accepted":21.68}
+{"id":16211,"name":"Boring Factorials","url":"https://www.spoj.com/problems/DCEPC11B","users":1913,"accepted":34.83}
+{"id":16212,"name":"Jailbreak","url":"https://www.spoj.com/problems/DCEPC11J","users":80,"accepted":50.24}
+{"id":16214,"name":"Pabbu-pneumonia","url":"https://www.spoj.com/problems/CODPABBU","users":59,"accepted":25.61}
+{"id":16240,"name":"Easy Password","url":"https://www.spoj.com/problems/DCEPC11E","users":42,"accepted":5.12}
+{"id":16242,"name":"Dexters Trampoline","url":"https://www.spoj.com/problems/DTRAP","users":61,"accepted":50}
+{"id":16243,"name":"Anagrams","url":"https://www.spoj.com/problems/ANAGR","users":260,"accepted":25.34}
+{"id":16244,"name":"Kusac","url":"https://www.spoj.com/problems/KUSAC","users":411,"accepted":36.44}
+{"id":16245,"name":"Living with Courage","url":"https://www.spoj.com/problems/COURAGE","users":580,"accepted":37.6}
+{"id":16248,"name":"Clones","url":"https://www.spoj.com/problems/NCLNE","users":588,"accepted":44.15}
+{"id":16250,"name":"Dilemma","url":"https://www.spoj.com/problems/GDIL","users":79,"accepted":52.87}
+{"id":16254,"name":"Running Median Again","url":"https://www.spoj.com/problems/RMID2","users":1809,"accepted":22.59}

--- a/tests/spoj/index/54.md
+++ b/tests/spoj/index/54.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 15850 | [Game](https://www.spoj.com/problems/DGAME) | 61 | 41.09 |
+| 15851 | [Permutations](https://www.spoj.com/problems/PSERVICE) | 18 | 32.93 |
+| 15864 | [SUMMING](https://www.spoj.com/problems/SUMMING) | 10 | 8.45 |
+| 15867 | [Great Warrior](https://www.spoj.com/problems/SNGGW) | 128 | 66.67 |
+| 15891 | [Prime Generator The Easiest Question Ever](https://www.spoj.com/problems/SNGPG) | 1180 | 46.46 |
+| 15892 | [Cave](https://www.spoj.com/problems/CAVE2) | 16 | 16.42 |
+| 15914 | [Update Sub-Matrix & Query Sub-Matrix](https://www.spoj.com/problems/USUBQSUB) | 95 | 35.62 |
+| 15961 | [MAXSET](https://www.spoj.com/problems/MAXSET) | 48 | 34.74 |
+| 15963 | [Help Donn](https://www.spoj.com/problems/HELPDONN) | 95 | 42.42 |
+| 15965 | [PLAY WITH MATH](https://www.spoj.com/problems/ENIGMATH) | 6902 | 46.49 |
+| 15980 | [Ascending Fibonacci Numbers](https://www.spoj.com/problems/ASCDFIB) | 807 | 17.23 |
+| 15994 | [Boxes of Chocolate](https://www.spoj.com/problems/BOXSCHOC) | 92 | 24.72 |
+| 15995 | [Self Numbers](https://www.spoj.com/problems/MCUR98) | 904 | 38.32 |
+| 15996 | [Number Magic II](https://www.spoj.com/problems/SNGNM2) | 27 | 26.28 |
+| 16017 | [The Triangle Game](https://www.spoj.com/problems/MCU20A) | 56 | 47.59 |
+| 16018 | [Edge Detection](https://www.spoj.com/problems/MCU20E) | 14 | 53.33 |
+| 16030 | [Psycho](https://www.spoj.com/problems/PSYCHON) | 858 | 20.71 |
+| 16033 | [Tip Top Game](https://www.spoj.com/problems/TIPTOP) | 1769 | 27.18 |
+| 16034 | [Minimum Number](https://www.spoj.com/problems/MINNUM) | 498 | 16.17 |
+| 16035 | [Fone Frequencies](https://www.spoj.com/problems/OU7) | 34 | 43.96 |
+| 16046 | [Help Professor](https://www.spoj.com/problems/HPPROF) | 402 | 47.67 |
+| 16048 | [Help Rarity Collect Crystals](https://www.spoj.com/problems/PONY9) | 25 | 22.39 |
+| 16062 | [Count Primes](https://www.spoj.com/problems/SNGCP) | 45 | 25.20 |
+| 16063 | [Hackers](https://www.spoj.com/problems/TREEBA) | 61 | 21.64 |
+| 16102 | [Can you play carrom !!!](https://www.spoj.com/problems/CARRHIM) | 213 | 21.58 |
+| 16121 | [MODIFY SEQUENCE](https://www.spoj.com/problems/NITK06) | 2380 | 48.49 |
+| 16128 | [THE INDIAN OCEAN](https://www.spoj.com/problems/NITK07) | 53 | 9.67 |
+| 16134 | [Save the cows!](https://www.spoj.com/problems/COD1) | 61 | 12.82 |
+| 16138 | [Deconnecting](https://www.spoj.com/problems/CODGRF) | 62 | 31.22 |
+| 16139 | [Naya Shatranj (New Chess)](https://www.spoj.com/problems/CODCHESS) | 1937 | 68.39 |
+| 16177 | [Hashcodes and primes](https://www.spoj.com/problems/CODHASH) | 25 | 44.44 |
+| 16178 | [Change](https://www.spoj.com/problems/TPC07) | 61 | 10.26 |
+| 16179 | [Platinum Relic!](https://www.spoj.com/problems/PTRELIC) | 68 | 22.62 |
+| 16180 | [Ratar](https://www.spoj.com/problems/RATAR) | 83 | 27.27 |
+| 16184 | [Megatron and his rage](https://www.spoj.com/problems/CODFURY) | 1140 | 32.55 |
+| 16185 | [Mining your own business](https://www.spoj.com/problems/BUSINESS) | 630 | 20.80 |
+| 16207 | [Football Fever](https://www.spoj.com/problems/DCEPC11F) | 78 | 44.16 |
+| 16208 | [Challenge Accepted](https://www.spoj.com/problems/DCEPC11C) | 24 | 21.34 |
+| 16210 | [Impossible Boss](https://www.spoj.com/problems/DCEPC11I) | 180 | 21.68 |
+| 16211 | [Boring Factorials](https://www.spoj.com/problems/DCEPC11B) | 1913 | 34.83 |
+| 16212 | [Jailbreak](https://www.spoj.com/problems/DCEPC11J) | 80 | 50.24 |
+| 16214 | [Pabbu-pneumonia](https://www.spoj.com/problems/CODPABBU) | 59 | 25.61 |
+| 16240 | [Easy Password](https://www.spoj.com/problems/DCEPC11E) | 42 | 5.12 |
+| 16242 | [Dexters Trampoline](https://www.spoj.com/problems/DTRAP) | 61 | 50.00 |
+| 16243 | [Anagrams](https://www.spoj.com/problems/ANAGR) | 260 | 25.34 |
+| 16244 | [Kusac](https://www.spoj.com/problems/KUSAC) | 411 | 36.44 |
+| 16245 | [Living with Courage](https://www.spoj.com/problems/COURAGE) | 580 | 37.60 |
+| 16248 | [Clones](https://www.spoj.com/problems/NCLNE) | 588 | 44.15 |
+| 16250 | [Dilemma](https://www.spoj.com/problems/GDIL) | 79 | 52.87 |
+| 16254 | [Running Median Again](https://www.spoj.com/problems/RMID2) | 1809 | 22.59 |

--- a/tests/spoj/index/55.jsonl
+++ b/tests/spoj/index/55.jsonl
@@ -1,0 +1,50 @@
+{"id":16267,"name":"Real Numbers","url":"https://www.spoj.com/problems/REALNO","users":172,"accepted":17.97}
+{"id":16272,"name":"Nanoworld","url":"https://www.spoj.com/problems/NANO","users":42,"accepted":31.11}
+{"id":16275,"name":"On the side of the road","url":"https://www.spoj.com/problems/TAP2013A","users":85,"accepted":21.63}
+{"id":16277,"name":"Little Red-Cap","url":"https://www.spoj.com/problems/TAP2013C","users":225,"accepted":34.75}
+{"id":16278,"name":"Watching the game","url":"https://www.spoj.com/problems/TAP2013D","users":75,"accepted":32.9}
+{"id":16279,"name":"Escaping from escaping","url":"https://www.spoj.com/problems/TAP2013E","users":172,"accepted":29.37}
+{"id":16280,"name":"Flowers of Babylon","url":"https://www.spoj.com/problems/TAP2013F","users":51,"accepted":17.21}
+{"id":16281,"name":"War","url":"https://www.spoj.com/problems/TAP2013G","users":1107,"accepted":48.1}
+{"id":16282,"name":"Horace and his primes","url":"https://www.spoj.com/problems/TAP2013H","users":263,"accepted":40.98}
+{"id":16283,"name":"Treasure Island","url":"https://www.spoj.com/problems/TAP2013I","users":136,"accepted":24.94}
+{"id":16284,"name":"Game of stones","url":"https://www.spoj.com/problems/TAP2013J","users":103,"accepted":57.68}
+{"id":16297,"name":"Sir and The ICC Ratings","url":"https://www.spoj.com/problems/ICC","users":28,"accepted":22.67}
+{"id":16300,"name":"Playing with isosceles triangle","url":"https://www.spoj.com/problems/TRIISO","users":322,"accepted":27.32}
+{"id":16307,"name":"Game of stones II","url":"https://www.spoj.com/problems/GOSTONES","users":24,"accepted":37.72}
+{"id":16381,"name":"Help Vishnu with his points","url":"https://www.spoj.com/problems/RUMMY","users":20,"accepted":49.12}
+{"id":16389,"name":"Play with Strings","url":"https://www.spoj.com/problems/MY02","users":46,"accepted":23.2}
+{"id":16409,"name":"Lopov","url":"https://www.spoj.com/problems/LOPOV","users":320,"accepted":28.75}
+{"id":16410,"name":"Organizator","url":"https://www.spoj.com/problems/ORGNZ","users":80,"accepted":34.82}
+{"id":16411,"name":"Slasticar","url":"https://www.spoj.com/problems/SLAST","users":24,"accepted":55.17}
+{"id":16420,"name":"Even Numbers","url":"https://www.spoj.com/problems/EC_CONB","users":5278,"accepted":48.04}
+{"id":16480,"name":"Decrypt the message !","url":"https://www.spoj.com/problems/DCRYPT","users":1046,"accepted":36.98}
+{"id":16482,"name":"Make them equal !","url":"https://www.spoj.com/problems/MKEQUAL","users":2130,"accepted":52.84}
+{"id":16483,"name":"Lucky Cities","url":"https://www.spoj.com/problems/LUCKY","users":37,"accepted":18.72}
+{"id":16487,"name":"Update the array !","url":"https://www.spoj.com/problems/UPDATEIT","users":5026,"accepted":38.77}
+{"id":16549,"name":"Query on a tree VI","url":"https://www.spoj.com/problems/QTREE6","users":554,"accepted":19.76}
+{"id":16554,"name":"Linearian Colony","url":"https://www.spoj.com/problems/COLONY","users":866,"accepted":42.7}
+{"id":16556,"name":"Triangle","url":"https://www.spoj.com/problems/PEGS","users":59,"accepted":47.87}
+{"id":16557,"name":"HTML Formatting","url":"https://www.spoj.com/problems/FORMAT","users":31,"accepted":20.11}
+{"id":16580,"name":"Query on a tree VII","url":"https://www.spoj.com/problems/QTREE7","users":282,"accepted":18.24}
+{"id":16607,"name":"Sweets","url":"https://www.spoj.com/problems/IE1","users":175,"accepted":32.82}
+{"id":16636,"name":"Journey","url":"https://www.spoj.com/problems/IE2","users":59,"accepted":26.42}
+{"id":16639,"name":"Endless Knight","url":"https://www.spoj.com/problems/IE4","users":57,"accepted":25.82}
+{"id":16686,"name":"Some Sums","url":"https://www.spoj.com/problems/SOMESUMS","users":26,"accepted":28.37}
+{"id":16696,"name":"Nadal vs Djokovic","url":"https://www.spoj.com/problems/RAFANOLE","users":155,"accepted":28.99}
+{"id":16716,"name":"Help Your Commander","url":"https://www.spoj.com/problems/HELPCOMM","users":15,"accepted":44.19}
+{"id":16758,"name":"Divisible by 6 and 9","url":"https://www.spoj.com/problems/SNGDIV69","users":126,"accepted":36.28}
+{"id":16776,"name":"Modems","url":"https://www.spoj.com/problems/EC_MODE","users":220,"accepted":30.49}
+{"id":16778,"name":"Sir and the Guitar","url":"https://www.spoj.com/problems/CSHOWB","users":151,"accepted":55.18}
+{"id":16793,"name":"Statistics Applied","url":"https://www.spoj.com/problems/EC_ESTA","users":214,"accepted":22.15}
+{"id":16809,"name":"Estimation","url":"https://www.spoj.com/problems/EST","users":174,"accepted":10.09}
+{"id":16825,"name":"Divisors","url":"https://www.spoj.com/problems/EC_DIVS","users":93,"accepted":17.93}
+{"id":16909,"name":"Critical Edges","url":"https://www.spoj.com/problems/EC_P","users":1914,"accepted":28.74}
+{"id":16956,"name":"Encoded Coordinates","url":"https://www.spoj.com/problems/ENCODE","users":27,"accepted":33.02}
+{"id":17002,"name":"Psycho Function","url":"https://www.spoj.com/problems/PSYCHO2","users":75,"accepted":33.8}
+{"id":17110,"name":"Black Widow Rings","url":"https://www.spoj.com/problems/BWIDOW","users":2727,"accepted":52.18}
+{"id":17112,"name":"Training Land of Fury","url":"https://www.spoj.com/problems/NFURY","users":1391,"accepted":47.65}
+{"id":17113,"name":"Finding the Tesserect","url":"https://www.spoj.com/problems/TESSER","users":926,"accepted":37.23}
+{"id":17123,"name":"Destroying the Weapon Warehouse","url":"https://www.spoj.com/problems/IMBOX","users":242,"accepted":49.5}
+{"id":17124,"name":"Chess Board of Avengers","url":"https://www.spoj.com/problems/AVCHESS","users":37,"accepted":40}
+{"id":17125,"name":"Thor vs Frost Giants","url":"https://www.spoj.com/problems/TBATTLE","users":190,"accepted":28.28}

--- a/tests/spoj/index/55.md
+++ b/tests/spoj/index/55.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 16267 | [Real Numbers](https://www.spoj.com/problems/REALNO) | 172 | 17.97 |
+| 16272 | [Nanoworld](https://www.spoj.com/problems/NANO) | 42 | 31.11 |
+| 16275 | [On the side of the road](https://www.spoj.com/problems/TAP2013A) | 85 | 21.63 |
+| 16277 | [Little Red-Cap](https://www.spoj.com/problems/TAP2013C) | 225 | 34.75 |
+| 16278 | [Watching the game](https://www.spoj.com/problems/TAP2013D) | 75 | 32.90 |
+| 16279 | [Escaping from escaping](https://www.spoj.com/problems/TAP2013E) | 172 | 29.37 |
+| 16280 | [Flowers of Babylon](https://www.spoj.com/problems/TAP2013F) | 51 | 17.21 |
+| 16281 | [War](https://www.spoj.com/problems/TAP2013G) | 1107 | 48.10 |
+| 16282 | [Horace and his primes](https://www.spoj.com/problems/TAP2013H) | 263 | 40.98 |
+| 16283 | [Treasure Island](https://www.spoj.com/problems/TAP2013I) | 136 | 24.94 |
+| 16284 | [Game of stones](https://www.spoj.com/problems/TAP2013J) | 103 | 57.68 |
+| 16297 | [Sir and The ICC Ratings](https://www.spoj.com/problems/ICC) | 28 | 22.67 |
+| 16300 | [Playing with isosceles triangle](https://www.spoj.com/problems/TRIISO) | 322 | 27.32 |
+| 16307 | [Game of stones II](https://www.spoj.com/problems/GOSTONES) | 24 | 37.72 |
+| 16381 | [Help Vishnu with his points](https://www.spoj.com/problems/RUMMY) | 20 | 49.12 |
+| 16389 | [Play with Strings](https://www.spoj.com/problems/MY02) | 46 | 23.20 |
+| 16409 | [Lopov](https://www.spoj.com/problems/LOPOV) | 320 | 28.75 |
+| 16410 | [Organizator](https://www.spoj.com/problems/ORGNZ) | 80 | 34.82 |
+| 16411 | [Slasticar](https://www.spoj.com/problems/SLAST) | 24 | 55.17 |
+| 16420 | [Even Numbers](https://www.spoj.com/problems/EC_CONB) | 5278 | 48.04 |
+| 16480 | [Decrypt the message !](https://www.spoj.com/problems/DCRYPT) | 1046 | 36.98 |
+| 16482 | [Make them equal !](https://www.spoj.com/problems/MKEQUAL) | 2130 | 52.84 |
+| 16483 | [Lucky Cities](https://www.spoj.com/problems/LUCKY) | 37 | 18.72 |
+| 16487 | [Update the array !](https://www.spoj.com/problems/UPDATEIT) | 5026 | 38.77 |
+| 16549 | [Query on a tree VI](https://www.spoj.com/problems/QTREE6) | 554 | 19.76 |
+| 16554 | [Linearian Colony](https://www.spoj.com/problems/COLONY) | 866 | 42.70 |
+| 16556 | [Triangle](https://www.spoj.com/problems/PEGS) | 59 | 47.87 |
+| 16557 | [HTML Formatting](https://www.spoj.com/problems/FORMAT) | 31 | 20.11 |
+| 16580 | [Query on a tree VII](https://www.spoj.com/problems/QTREE7) | 282 | 18.24 |
+| 16607 | [Sweets](https://www.spoj.com/problems/IE1) | 175 | 32.82 |
+| 16636 | [Journey](https://www.spoj.com/problems/IE2) | 59 | 26.42 |
+| 16639 | [Endless Knight](https://www.spoj.com/problems/IE4) | 57 | 25.82 |
+| 16686 | [Some Sums](https://www.spoj.com/problems/SOMESUMS) | 26 | 28.37 |
+| 16696 | [Nadal vs Djokovic](https://www.spoj.com/problems/RAFANOLE) | 155 | 28.99 |
+| 16716 | [Help Your Commander](https://www.spoj.com/problems/HELPCOMM) | 15 | 44.19 |
+| 16758 | [Divisible by 6 and 9](https://www.spoj.com/problems/SNGDIV69) | 126 | 36.28 |
+| 16776 | [Modems](https://www.spoj.com/problems/EC_MODE) | 220 | 30.49 |
+| 16778 | [Sir and the Guitar](https://www.spoj.com/problems/CSHOWB) | 151 | 55.18 |
+| 16793 | [Statistics Applied](https://www.spoj.com/problems/EC_ESTA) | 214 | 22.15 |
+| 16809 | [Estimation](https://www.spoj.com/problems/EST) | 174 | 10.09 |
+| 16825 | [Divisors](https://www.spoj.com/problems/EC_DIVS) | 93 | 17.93 |
+| 16909 | [Critical Edges](https://www.spoj.com/problems/EC_P) | 1914 | 28.74 |
+| 16956 | [Encoded Coordinates](https://www.spoj.com/problems/ENCODE) | 27 | 33.02 |
+| 17002 | [Psycho Function](https://www.spoj.com/problems/PSYCHO2) | 75 | 33.80 |
+| 17110 | [Black Widow Rings](https://www.spoj.com/problems/BWIDOW) | 2727 | 52.18 |
+| 17112 | [Training Land of Fury](https://www.spoj.com/problems/NFURY) | 1391 | 47.65 |
+| 17113 | [Finding the Tesserect](https://www.spoj.com/problems/TESSER) | 926 | 37.23 |
+| 17123 | [Destroying the Weapon Warehouse](https://www.spoj.com/problems/IMBOX) | 242 | 49.50 |
+| 17124 | [Chess Board of Avengers](https://www.spoj.com/problems/AVCHESS) | 37 | 40.00 |
+| 17125 | [Thor vs Frost Giants](https://www.spoj.com/problems/TBATTLE) | 190 | 28.28 |

--- a/tests/spoj/index/56.jsonl
+++ b/tests/spoj/index/56.jsonl
@@ -1,0 +1,50 @@
+{"id":17128,"name":"Putnik","url":"https://www.spoj.com/problems/PUTNIK","users":101,"accepted":48.67}
+{"id":17143,"name":"Make Psycho","url":"https://www.spoj.com/problems/PSYCHO3","users":227,"accepted":25}
+{"id":17150,"name":"Palin Square","url":"https://www.spoj.com/problems/PLSQUARE","users":116,"accepted":31.96}
+{"id":17247,"name":"Digit Sum","url":"https://www.spoj.com/problems/PR003004","users":3860,"accepted":37.83}
+{"id":17258,"name":"Yungom","url":"https://www.spoj.com/problems/HPREFIX","users":21,"accepted":38.27}
+{"id":17261,"name":"Bank robbery","url":"https://www.spoj.com/problems/BANKROB","users":254,"accepted":29.9}
+{"id":17267,"name":"Alturas de NoMeAcuerdo","url":"https://www.spoj.com/problems/ALTURAS","users":80,"accepted":63.36}
+{"id":17302,"name":"Servers","url":"https://www.spoj.com/problems/SERVS","users":165,"accepted":29.53}
+{"id":17303,"name":"Board","url":"https://www.spoj.com/problems/BOARD1","users":203,"accepted":31.03}
+{"id":17309,"name":"Operation Bits","url":"https://www.spoj.com/problems/OPBIT","users":417,"accepted":57.36}
+{"id":17320,"name":"Guess The Number With Lies v3","url":"https://www.spoj.com/problems/GUESSN3","users":7,"accepted":24.66}
+{"id":17382,"name":"Airplane Parking","url":"https://www.spoj.com/problems/HFLY","users":21,"accepted":28.28}
+{"id":17394,"name":"Bits Game","url":"https://www.spoj.com/problems/DCEPC12B","users":50,"accepted":34.44}
+{"id":17396,"name":"Dazzling Pearls","url":"https://www.spoj.com/problems/DCEPC12D","users":19,"accepted":17.19}
+{"id":17397,"name":"End of Fun","url":"https://www.spoj.com/problems/DCEPC12E","users":358,"accepted":27.71}
+{"id":17398,"name":"Fitting in the Team","url":"https://www.spoj.com/problems/DCEPC12F","users":18,"accepted":12.06}
+{"id":17399,"name":"G Force","url":"https://www.spoj.com/problems/DCEPC12G","users":368,"accepted":33.18}
+{"id":17400,"name":"Height of Expectation","url":"https://www.spoj.com/problems/DCEPC12H","users":344,"accepted":53.36}
+{"id":17402,"name":"Joy of Arbitrage","url":"https://www.spoj.com/problems/DCEPC12J","users":19,"accepted":16.91}
+{"id":17406,"name":"Cheating a Boolean Tree","url":"https://www.spoj.com/problems/GCJ082A","users":125,"accepted":35.57}
+{"id":17443,"name":"Magical Bus Journey","url":"https://www.spoj.com/problems/MABJ","users":62,"accepted":31.52}
+{"id":17504,"name":"Run length encoding","url":"https://www.spoj.com/problems/RLE","users":1034,"accepted":39.2}
+{"id":17539,"name":"Cows Language","url":"https://www.spoj.com/problems/COWWORDS","users":36,"accepted":41.88}
+{"id":17559,"name":"Two Game","url":"https://www.spoj.com/problems/TWOGAME","users":327,"accepted":37.27}
+{"id":17617,"name":"WHAT A CO-ACCIDENT","url":"https://www.spoj.com/problems/SYNC13C","users":1504,"accepted":60.62}
+{"id":17624,"name":"Cooperation in geometry !","url":"https://www.spoj.com/problems/GCOOP","users":24,"accepted":11.95}
+{"id":17626,"name":"Eat all the brownies !","url":"https://www.spoj.com/problems/CUTCAKE","users":1671,"accepted":42.03}
+{"id":17627,"name":"Family members","url":"https://www.spoj.com/problems/FAMWEALT","users":432,"accepted":60.12}
+{"id":17660,"name":"The Bridge to Home","url":"https://www.spoj.com/problems/WAYHOME","users":122,"accepted":36.19}
+{"id":17705,"name":"Gopu and Combinatorics on Graphs","url":"https://www.spoj.com/problems/SPCE","users":85,"accepted":45.42}
+{"id":17707,"name":"Constructible Regular Polygons","url":"https://www.spoj.com/problems/POLCONST","users":511,"accepted":55.88}
+{"id":17711,"name":"Gopu and Create Collections Part Two","url":"https://www.spoj.com/problems/SPCJ","users":266,"accepted":29.3}
+{"id":17714,"name":"Gopu and function","url":"https://www.spoj.com/problems/SPCM","users":234,"accepted":37.24}
+{"id":17717,"name":"Gopu and Counting Bitwise Prime Numbers","url":"https://www.spoj.com/problems/SPCO","users":225,"accepted":19.81}
+{"id":17725,"name":"Bad XOR","url":"https://www.spoj.com/problems/BADXOR","users":1048,"accepted":23.81}
+{"id":17730,"name":"Maximum Radius","url":"https://www.spoj.com/problems/MAXRAD","users":115,"accepted":29.52}
+{"id":17731,"name":"Buying Integers","url":"https://www.spoj.com/problems/BUYINT","users":111,"accepted":40.73}
+{"id":17732,"name":"Salary Management","url":"https://www.spoj.com/problems/SALMAN","users":236,"accepted":19.26}
+{"id":17755,"name":"Tree and Palindrome","url":"https://www.spoj.com/problems/TREEPAL","users":152,"accepted":21.08}
+{"id":17761,"name":"Gopu and Digits Divisibility","url":"https://www.spoj.com/problems/SPCQ","users":2637,"accepted":42.99}
+{"id":17779,"name":"Charlie and the Chocolate Factory","url":"https://www.spoj.com/problems/CHARCHOC","users":4,"accepted":7.81}
+{"id":17789,"name":"Space Bridges","url":"https://www.spoj.com/problems/SPACEBRG","users":27,"accepted":40.2}
+{"id":17804,"name":"Gopu And Palindromes","url":"https://www.spoj.com/problems/SPCS","users":618,"accepted":58.93}
+{"id":17819,"name":"XYI","url":"https://www.spoj.com/problems/XYI","users":360,"accepted":38.55}
+{"id":17821,"name":"My Name is UMMM!","url":"https://www.spoj.com/problems/MNIU","users":32,"accepted":22.16}
+{"id":17877,"name":"Two Swamills","url":"https://www.spoj.com/problems/SAWMILL","users":142,"accepted":51.84}
+{"id":17918,"name":"Gopu and Validity of Arrangement","url":"https://www.spoj.com/problems/SPCU","users":1658,"accepted":43.31}
+{"id":17943,"name":"Mickey Mouse Magic Trick v3","url":"https://www.spoj.com/problems/MMMAGIC3","users":75,"accepted":36.63}
+{"id":17944,"name":"Mickey Mouse Magic Trick v4","url":"https://www.spoj.com/problems/MMMAGIC4","users":46,"accepted":56.59}
+{"id":17945,"name":"Mickey Mouse Magic Trick v5","url":"https://www.spoj.com/problems/MMMAGIC5","users":28,"accepted":39.13}

--- a/tests/spoj/index/56.md
+++ b/tests/spoj/index/56.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 17128 | [Putnik](https://www.spoj.com/problems/PUTNIK) | 101 | 48.67 |
+| 17143 | [Make Psycho](https://www.spoj.com/problems/PSYCHO3) | 227 | 25.00 |
+| 17150 | [Palin Square](https://www.spoj.com/problems/PLSQUARE) | 116 | 31.96 |
+| 17247 | [Digit Sum](https://www.spoj.com/problems/PR003004) | 3860 | 37.83 |
+| 17258 | [Yungom](https://www.spoj.com/problems/HPREFIX) | 21 | 38.27 |
+| 17261 | [Bank robbery](https://www.spoj.com/problems/BANKROB) | 254 | 29.90 |
+| 17267 | [Alturas de NoMeAcuerdo](https://www.spoj.com/problems/ALTURAS) | 80 | 63.36 |
+| 17302 | [Servers](https://www.spoj.com/problems/SERVS) | 165 | 29.53 |
+| 17303 | [Board](https://www.spoj.com/problems/BOARD1) | 203 | 31.03 |
+| 17309 | [Operation Bits](https://www.spoj.com/problems/OPBIT) | 417 | 57.36 |
+| 17320 | [Guess The Number With Lies v3](https://www.spoj.com/problems/GUESSN3) | 7 | 24.66 |
+| 17382 | [Airplane Parking](https://www.spoj.com/problems/HFLY) | 21 | 28.28 |
+| 17394 | [Bits Game](https://www.spoj.com/problems/DCEPC12B) | 50 | 34.44 |
+| 17396 | [Dazzling Pearls](https://www.spoj.com/problems/DCEPC12D) | 19 | 17.19 |
+| 17397 | [End of Fun](https://www.spoj.com/problems/DCEPC12E) | 358 | 27.71 |
+| 17398 | [Fitting in the Team](https://www.spoj.com/problems/DCEPC12F) | 18 | 12.06 |
+| 17399 | [G Force](https://www.spoj.com/problems/DCEPC12G) | 368 | 33.18 |
+| 17400 | [Height of Expectation](https://www.spoj.com/problems/DCEPC12H) | 344 | 53.36 |
+| 17402 | [Joy of Arbitrage](https://www.spoj.com/problems/DCEPC12J) | 19 | 16.91 |
+| 17406 | [Cheating a Boolean Tree](https://www.spoj.com/problems/GCJ082A) | 125 | 35.57 |
+| 17443 | [Magical Bus Journey](https://www.spoj.com/problems/MABJ) | 62 | 31.52 |
+| 17504 | [Run length encoding](https://www.spoj.com/problems/RLE) | 1034 | 39.20 |
+| 17539 | [Cows Language](https://www.spoj.com/problems/COWWORDS) | 36 | 41.88 |
+| 17559 | [Two Game](https://www.spoj.com/problems/TWOGAME) | 327 | 37.27 |
+| 17617 | [WHAT A CO-ACCIDENT](https://www.spoj.com/problems/SYNC13C) | 1504 | 60.62 |
+| 17624 | [Cooperation in geometry !](https://www.spoj.com/problems/GCOOP) | 24 | 11.95 |
+| 17626 | [Eat all the brownies !](https://www.spoj.com/problems/CUTCAKE) | 1671 | 42.03 |
+| 17627 | [Family members](https://www.spoj.com/problems/FAMWEALT) | 432 | 60.12 |
+| 17660 | [The Bridge to Home](https://www.spoj.com/problems/WAYHOME) | 122 | 36.19 |
+| 17705 | [Gopu and Combinatorics on Graphs](https://www.spoj.com/problems/SPCE) | 85 | 45.42 |
+| 17707 | [Constructible Regular Polygons](https://www.spoj.com/problems/POLCONST) | 511 | 55.88 |
+| 17711 | [Gopu and Create Collections Part Two](https://www.spoj.com/problems/SPCJ) | 266 | 29.30 |
+| 17714 | [Gopu and function](https://www.spoj.com/problems/SPCM) | 234 | 37.24 |
+| 17717 | [Gopu and Counting Bitwise Prime Numbers](https://www.spoj.com/problems/SPCO) | 225 | 19.81 |
+| 17725 | [Bad XOR](https://www.spoj.com/problems/BADXOR) | 1048 | 23.81 |
+| 17730 | [Maximum Radius](https://www.spoj.com/problems/MAXRAD) | 115 | 29.52 |
+| 17731 | [Buying Integers](https://www.spoj.com/problems/BUYINT) | 111 | 40.73 |
+| 17732 | [Salary Management](https://www.spoj.com/problems/SALMAN) | 236 | 19.26 |
+| 17755 | [Tree and Palindrome](https://www.spoj.com/problems/TREEPAL) | 152 | 21.08 |
+| 17761 | [Gopu and Digits Divisibility](https://www.spoj.com/problems/SPCQ) | 2637 | 42.99 |
+| 17779 | [Charlie and the Chocolate Factory](https://www.spoj.com/problems/CHARCHOC) | 4 | 7.81 |
+| 17789 | [Space Bridges](https://www.spoj.com/problems/SPACEBRG) | 27 | 40.20 |
+| 17804 | [Gopu And Palindromes](https://www.spoj.com/problems/SPCS) | 618 | 58.93 |
+| 17819 | [XYI](https://www.spoj.com/problems/XYI) | 360 | 38.55 |
+| 17821 | [My Name is UMMM!](https://www.spoj.com/problems/MNIU) | 32 | 22.16 |
+| 17877 | [Two Swamills](https://www.spoj.com/problems/SAWMILL) | 142 | 51.84 |
+| 17918 | [Gopu and Validity of Arrangement](https://www.spoj.com/problems/SPCU) | 1658 | 43.31 |
+| 17943 | [Mickey Mouse Magic Trick v3](https://www.spoj.com/problems/MMMAGIC3) | 75 | 36.63 |
+| 17944 | [Mickey Mouse Magic Trick v4](https://www.spoj.com/problems/MMMAGIC4) | 46 | 56.59 |
+| 17945 | [Mickey Mouse Magic Trick v5](https://www.spoj.com/problems/MMMAGIC5) | 28 | 39.13 |

--- a/tests/spoj/index/57.jsonl
+++ b/tests/spoj/index/57.jsonl
@@ -1,0 +1,50 @@
+{"id":17946,"name":"Mickey Mouse Magic Trick v6","url":"https://www.spoj.com/problems/MMMAGIC6","users":42,"accepted":31.18}
+{"id":17955,"name":"Lalith Dosa","url":"https://www.spoj.com/problems/DOSA","users":423,"accepted":26.23}
+{"id":18050,"name":"Robert Langdon \u0026 Class Attendance","url":"https://www.spoj.com/problems/RLCAT","users":40,"accepted":25.51}
+{"id":18056,"name":"Robert Langdon \u0026 Cipher","url":"https://www.spoj.com/problems/RLCIPHER","users":567,"accepted":50.57}
+{"id":18094,"name":"Robert Langdon \u0026 Florence","url":"https://www.spoj.com/problems/RLTOUR","users":181,"accepted":64.31}
+{"id":18095,"name":"Faridi and Yadav","url":"https://www.spoj.com/problems/CHOTU","users":1004,"accepted":56.56}
+{"id":18102,"name":"New year love story","url":"https://www.spoj.com/problems/QTGIFT1","users":83,"accepted":26.67}
+{"id":18149,"name":"Rama and Friends","url":"https://www.spoj.com/problems/GSHOP","users":998,"accepted":28.67}
+{"id":18150,"name":"SHAKTIMAN AND KILWISH","url":"https://www.spoj.com/problems/SHAKTI","users":2824,"accepted":63.67}
+{"id":18153,"name":"Robert Langdon \u0026 The Rule of Three","url":"https://www.spoj.com/problems/RLTHREE","users":41,"accepted":36.36}
+{"id":18155,"name":"abs(a-b) I","url":"https://www.spoj.com/problems/ABSP1","users":4689,"accepted":47.93}
+{"id":18164,"name":"Atoms in the Lab","url":"https://www.spoj.com/problems/ATOMS","users":3844,"accepted":25.8}
+{"id":18165,"name":"Coprime Pairs","url":"https://www.spoj.com/problems/NCOPRIME","users":15,"accepted":16.67}
+{"id":18167,"name":"SubXor","url":"https://www.spoj.com/problems/SUBXOR","users":1899,"accepted":30.8}
+{"id":18168,"name":"Entangled Circles","url":"https://www.spoj.com/problems/TWOCIR","users":19,"accepted":22.43}
+{"id":18170,"name":"Takeover Wars","url":"https://www.spoj.com/problems/TKV1000","users":18,"accepted":15.49}
+{"id":18174,"name":"REAL ROOTS","url":"https://www.spoj.com/problems/RROOT","users":1287,"accepted":60.04}
+{"id":18176,"name":"FRIENDSHIP!!!","url":"https://www.spoj.com/problems/FRND","users":631,"accepted":26.94}
+{"id":18180,"name":"Love Story 1","url":"https://www.spoj.com/problems/PIHU1","users":1142,"accepted":26.38}
+{"id":18182,"name":"Naughty and Balls","url":"https://www.spoj.com/problems/NAUGHTY","users":361,"accepted":41.69}
+{"id":18183,"name":"Drunk Game","url":"https://www.spoj.com/problems/DRUNK","users":41,"accepted":39.19}
+{"id":18184,"name":"Durins Day","url":"https://www.spoj.com/problems/DURIN","users":40,"accepted":54.17}
+{"id":18185,"name":"Give Away","url":"https://www.spoj.com/problems/GIVEAWAY","users":1340,"accepted":22.43}
+{"id":18186,"name":"Machine Mayhem","url":"https://www.spoj.com/problems/MACHMAY","users":15,"accepted":28.17}
+{"id":18187,"name":"Ingredients","url":"https://www.spoj.com/problems/INGRED","users":294,"accepted":31.69}
+{"id":18188,"name":"Queen and Stable Relationships","url":"https://www.spoj.com/problems/QSTABLE","users":21,"accepted":14.74}
+{"id":18201,"name":"RK Sorting","url":"https://www.spoj.com/problems/RKS","users":1382,"accepted":38.78}
+{"id":18202,"name":"HUGE GCD","url":"https://www.spoj.com/problems/HG","users":687,"accepted":33.32}
+{"id":18240,"name":"GENIE SEQUENCE","url":"https://www.spoj.com/problems/KURUK14","users":1561,"accepted":42.18}
+{"id":18243,"name":"Maggu and Strings","url":"https://www.spoj.com/problems/IITWPC4A","users":600,"accepted":33.3}
+{"id":18245,"name":"Maggu and Triangles","url":"https://www.spoj.com/problems/IITWPC4B","users":423,"accepted":31.5}
+{"id":18246,"name":"Maggu and Vectors","url":"https://www.spoj.com/problems/IITWPC4C","users":85,"accepted":25.9}
+{"id":18247,"name":"Arrangement Validity","url":"https://www.spoj.com/problems/IITWPC4D","users":223,"accepted":36.23}
+{"id":18248,"name":"Maggu’s Solar Panels","url":"https://www.spoj.com/problems/IITWPC4E","users":49,"accepted":31.75}
+{"id":18249,"name":"Gopu and the Grid Problem","url":"https://www.spoj.com/problems/IITWPC4F","users":78,"accepted":33.78}
+{"id":18261,"name":"Maggu and Weird things","url":"https://www.spoj.com/problems/IITWPC4G","users":25,"accepted":22.45}
+{"id":18273,"name":"Encode Integer","url":"https://www.spoj.com/problems/SNGINT","users":837,"accepted":25.51}
+{"id":18283,"name":"Maggu and Cuteness of Strings","url":"https://www.spoj.com/problems/IITWPC4H","users":171,"accepted":40.17}
+{"id":18284,"name":"Petya and the Road Repairs","url":"https://www.spoj.com/problems/IITWPC4I","users":891,"accepted":24.02}
+{"id":18286,"name":"Gopu and Fishes","url":"https://www.spoj.com/problems/IITWPC4J","users":108,"accepted":47.4}
+{"id":18287,"name":"Maggu and Magguness Level","url":"https://www.spoj.com/problems/IITWPC4K","users":50,"accepted":33.5}
+{"id":18289,"name":"Maggu and Mystery","url":"https://www.spoj.com/problems/IITWPC4L","users":19,"accepted":31.08}
+{"id":18297,"name":"Problem4","url":"https://www.spoj.com/problems/CODEM4","users":541,"accepted":32.38}
+{"id":18302,"name":"Identity crisis","url":"https://www.spoj.com/problems/IDC1948","users":223,"accepted":28.37}
+{"id":18336,"name":"Search Bit Sum","url":"https://www.spoj.com/problems/BIT2","users":166,"accepted":37.34}
+{"id":18393,"name":"Hamiltonian Cycles","url":"https://www.spoj.com/problems/IE5","users":27,"accepted":17.67}
+{"id":18408,"name":"The Valentine Confession","url":"https://www.spoj.com/problems/CRNVALEN","users":581,"accepted":28.58}
+{"id":18425,"name":"Polynomial Multiplication","url":"https://www.spoj.com/problems/POLYMUL","users":1742,"accepted":39.44}
+{"id":18438,"name":"Happy Valentine Day (Valentine Adventure Game)","url":"https://www.spoj.com/problems/VAL_GAM4","users":11,"accepted":24.56}
+{"id":18450,"name":"Largest Increasing Sub-Matrix","url":"https://www.spoj.com/problems/MXSBMTRX","users":12,"accepted":12.24}

--- a/tests/spoj/index/57.md
+++ b/tests/spoj/index/57.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 17946 | [Mickey Mouse Magic Trick v6](https://www.spoj.com/problems/MMMAGIC6) | 42 | 31.18 |
+| 17955 | [Lalith Dosa](https://www.spoj.com/problems/DOSA) | 423 | 26.23 |
+| 18050 | [Robert Langdon & Class Attendance](https://www.spoj.com/problems/RLCAT) | 40 | 25.51 |
+| 18056 | [Robert Langdon & Cipher](https://www.spoj.com/problems/RLCIPHER) | 567 | 50.57 |
+| 18094 | [Robert Langdon & Florence](https://www.spoj.com/problems/RLTOUR) | 181 | 64.31 |
+| 18095 | [Faridi and Yadav](https://www.spoj.com/problems/CHOTU) | 1004 | 56.56 |
+| 18102 | [New year love story](https://www.spoj.com/problems/QTGIFT1) | 83 | 26.67 |
+| 18149 | [Rama and Friends](https://www.spoj.com/problems/GSHOP) | 998 | 28.67 |
+| 18150 | [SHAKTIMAN AND KILWISH](https://www.spoj.com/problems/SHAKTI) | 2824 | 63.67 |
+| 18153 | [Robert Langdon & The Rule of Three](https://www.spoj.com/problems/RLTHREE) | 41 | 36.36 |
+| 18155 | [abs(a-b) I](https://www.spoj.com/problems/ABSP1) | 4689 | 47.93 |
+| 18164 | [Atoms in the Lab](https://www.spoj.com/problems/ATOMS) | 3844 | 25.80 |
+| 18165 | [Coprime Pairs](https://www.spoj.com/problems/NCOPRIME) | 15 | 16.67 |
+| 18167 | [SubXor](https://www.spoj.com/problems/SUBXOR) | 1899 | 30.80 |
+| 18168 | [Entangled Circles](https://www.spoj.com/problems/TWOCIR) | 19 | 22.43 |
+| 18170 | [Takeover Wars](https://www.spoj.com/problems/TKV1000) | 18 | 15.49 |
+| 18174 | [REAL ROOTS](https://www.spoj.com/problems/RROOT) | 1287 | 60.04 |
+| 18176 | [FRIENDSHIP!!!](https://www.spoj.com/problems/FRND) | 631 | 26.94 |
+| 18180 | [Love Story 1](https://www.spoj.com/problems/PIHU1) | 1142 | 26.38 |
+| 18182 | [Naughty and Balls](https://www.spoj.com/problems/NAUGHTY) | 361 | 41.69 |
+| 18183 | [Drunk Game](https://www.spoj.com/problems/DRUNK) | 41 | 39.19 |
+| 18184 | [Durins Day](https://www.spoj.com/problems/DURIN) | 40 | 54.17 |
+| 18185 | [Give Away](https://www.spoj.com/problems/GIVEAWAY) | 1340 | 22.43 |
+| 18186 | [Machine Mayhem](https://www.spoj.com/problems/MACHMAY) | 15 | 28.17 |
+| 18187 | [Ingredients](https://www.spoj.com/problems/INGRED) | 294 | 31.69 |
+| 18188 | [Queen and Stable Relationships](https://www.spoj.com/problems/QSTABLE) | 21 | 14.74 |
+| 18201 | [RK Sorting](https://www.spoj.com/problems/RKS) | 1382 | 38.78 |
+| 18202 | [HUGE GCD](https://www.spoj.com/problems/HG) | 687 | 33.32 |
+| 18240 | [GENIE SEQUENCE](https://www.spoj.com/problems/KURUK14) | 1561 | 42.18 |
+| 18243 | [Maggu and Strings](https://www.spoj.com/problems/IITWPC4A) | 600 | 33.30 |
+| 18245 | [Maggu and Triangles](https://www.spoj.com/problems/IITWPC4B) | 423 | 31.50 |
+| 18246 | [Maggu and Vectors](https://www.spoj.com/problems/IITWPC4C) | 85 | 25.90 |
+| 18247 | [Arrangement Validity](https://www.spoj.com/problems/IITWPC4D) | 223 | 36.23 |
+| 18248 | [Maggu’s Solar Panels](https://www.spoj.com/problems/IITWPC4E) | 49 | 31.75 |
+| 18249 | [Gopu and the Grid Problem](https://www.spoj.com/problems/IITWPC4F) | 78 | 33.78 |
+| 18261 | [Maggu and Weird things](https://www.spoj.com/problems/IITWPC4G) | 25 | 22.45 |
+| 18273 | [Encode Integer](https://www.spoj.com/problems/SNGINT) | 837 | 25.51 |
+| 18283 | [Maggu and Cuteness of Strings](https://www.spoj.com/problems/IITWPC4H) | 171 | 40.17 |
+| 18284 | [Petya and the Road Repairs](https://www.spoj.com/problems/IITWPC4I) | 891 | 24.02 |
+| 18286 | [Gopu and Fishes](https://www.spoj.com/problems/IITWPC4J) | 108 | 47.40 |
+| 18287 | [Maggu and Magguness Level](https://www.spoj.com/problems/IITWPC4K) | 50 | 33.50 |
+| 18289 | [Maggu and Mystery](https://www.spoj.com/problems/IITWPC4L) | 19 | 31.08 |
+| 18297 | [Problem4](https://www.spoj.com/problems/CODEM4) | 541 | 32.38 |
+| 18302 | [Identity crisis](https://www.spoj.com/problems/IDC1948) | 223 | 28.37 |
+| 18336 | [Search Bit Sum](https://www.spoj.com/problems/BIT2) | 166 | 37.34 |
+| 18393 | [Hamiltonian Cycles](https://www.spoj.com/problems/IE5) | 27 | 17.67 |
+| 18408 | [The Valentine Confession](https://www.spoj.com/problems/CRNVALEN) | 581 | 28.58 |
+| 18425 | [Polynomial Multiplication](https://www.spoj.com/problems/POLYMUL) | 1742 | 39.44 |
+| 18438 | [Happy Valentine Day (Valentine Adventure Game)](https://www.spoj.com/problems/VAL_GAM4) | 11 | 24.56 |
+| 18450 | [Largest Increasing Sub-Matrix](https://www.spoj.com/problems/MXSBMTRX) | 12 | 12.24 |

--- a/tests/spoj/index/58.jsonl
+++ b/tests/spoj/index/58.jsonl
@@ -1,0 +1,50 @@
+{"id":18457,"name":"Very Friends","url":"https://www.spoj.com/problems/VFRIENDS","users":249,"accepted":27.97}
+{"id":18458,"name":"Very Friends 2","url":"https://www.spoj.com/problems/VFRIEND2","users":40,"accepted":19.45}
+{"id":18465,"name":"A Subtle Surf","url":"https://www.spoj.com/problems/UOFTCC","users":204,"accepted":43.41}
+{"id":18466,"name":"A Frightening Evening","url":"https://www.spoj.com/problems/UOFTCD","users":124,"accepted":29.53}
+{"id":18467,"name":"A Brief Expedition","url":"https://www.spoj.com/problems/UOFTCE","users":277,"accepted":54.42}
+{"id":18468,"name":"A Pleasant Stroll","url":"https://www.spoj.com/problems/UOFTCF","users":138,"accepted":35.42}
+{"id":18469,"name":"Office Mates","url":"https://www.spoj.com/problems/UOFTCG","users":53,"accepted":32.46}
+{"id":18510,"name":"Ross generates Data","url":"https://www.spoj.com/problems/AKVOD05","users":98,"accepted":17.18}
+{"id":18511,"name":"Cartman and Butters Game","url":"https://www.spoj.com/problems/AKVOD06","users":22,"accepted":29.17}
+{"id":18521,"name":"Fortunate Wheels","url":"https://www.spoj.com/problems/FBWHEELS","users":7,"accepted":34.78}
+{"id":18522,"name":"Tours","url":"https://www.spoj.com/problems/FBTOURS","users":26,"accepted":21.76}
+{"id":18530,"name":"Font Size","url":"https://www.spoj.com/problems/FONTSIZE","users":207,"accepted":13.87}
+{"id":18531,"name":"Barrelrider","url":"https://www.spoj.com/problems/BRLRIDER","users":21,"accepted":56.25}
+{"id":18532,"name":"Tree _order","url":"https://www.spoj.com/problems/TREEORD","users":1245,"accepted":47.28}
+{"id":18598,"name":"Encode Message","url":"https://www.spoj.com/problems/SNGMSG","users":875,"accepted":63.46}
+{"id":18637,"name":"Lawrence of Arabia","url":"https://www.spoj.com/problems/LAWRENCE","users":61,"accepted":28.11}
+{"id":18660,"name":"Product of factorials (easy)","url":"https://www.spoj.com/problems/FACTMULN","users":115,"accepted":27.2}
+{"id":18662,"name":"Product of factorials (again)","url":"https://www.spoj.com/problems/FACTMULO","users":86,"accepted":31.5}
+{"id":18666,"name":"Radiation","url":"https://www.spoj.com/problems/UVA1","users":36,"accepted":20}
+{"id":18667,"name":"Product of factorials (hard)","url":"https://www.spoj.com/problems/FACTMULP","users":46,"accepted":27.1}
+{"id":18714,"name":"Can You Make It Empty 2","url":"https://www.spoj.com/problems/EMTY2","users":1324,"accepted":29.23}
+{"id":18715,"name":"Boring Factorials (Reloaded)","url":"https://www.spoj.com/problems/BORING","users":66,"accepted":10.31}
+{"id":18799,"name":"Boring Factorials (Extended)","url":"https://www.spoj.com/problems/BORING2","users":15,"accepted":13.37}
+{"id":18829,"name":"Special Set","url":"https://www.spoj.com/problems/SPEC_SET","users":118,"accepted":27.1}
+{"id":18857,"name":"Gopi and Sandwich","url":"https://www.spoj.com/problems/GOPI_SW","users":284,"accepted":44.16}
+{"id":18878,"name":"Topper Rama Rao","url":"https://www.spoj.com/problems/HLP_RAMS","users":1046,"accepted":48.41}
+{"id":18905,"name":"Kapti and Balu","url":"https://www.spoj.com/problems/NR1","users":41,"accepted":32.7}
+{"id":18915,"name":"Anils Proposal","url":"https://www.spoj.com/problems/ANIL_PRO","users":31,"accepted":18.9}
+{"id":18917,"name":"Dukkar and Pikka","url":"https://www.spoj.com/problems/DUKKAR","users":313,"accepted":56.43}
+{"id":18932,"name":"Sum of primes (reverse mode)","url":"https://www.spoj.com/problems/SUMPRIM2","users":23,"accepted":17.53}
+{"id":18937,"name":"Touch of Venom","url":"https://www.spoj.com/problems/VENOM","users":1406,"accepted":23.29}
+{"id":18939,"name":"K-th smallest number","url":"https://www.spoj.com/problems/KSMALL","users":219,"accepted":13.94}
+{"id":18940,"name":"Face the mate","url":"https://www.spoj.com/problems/FACENEMY","users":161,"accepted":20.93}
+{"id":18941,"name":"True Friends","url":"https://www.spoj.com/problems/TFRIENDS","users":1027,"accepted":51.19}
+{"id":18945,"name":"Car with powers","url":"https://www.spoj.com/problems/POWERCAR","users":308,"accepted":29.73}
+{"id":18963,"name":"Bhagat The Bit Man","url":"https://www.spoj.com/problems/NR2","users":661,"accepted":31.69}
+{"id":18964,"name":"Sum of subsequences","url":"https://www.spoj.com/problems/BLSUMSEQ","users":28,"accepted":22.76}
+{"id":18965,"name":"Milk Scheduling","url":"https://www.spoj.com/problems/MSCHED","users":1056,"accepted":25.57}
+{"id":18966,"name":"Vacation Planning","url":"https://www.spoj.com/problems/VACATION","users":141,"accepted":25.83}
+{"id":19037,"name":"Magical colorful cats (easy)","url":"https://www.spoj.com/problems/COLORCAT","users":20,"accepted":19.57}
+{"id":19039,"name":"Krypt in Time","url":"https://www.spoj.com/problems/KIT","users":299,"accepted":41.91}
+{"id":19084,"name":"Huge Pascal triangle","url":"https://www.spoj.com/problems/DUKKAR2","users":34,"accepted":47.92}
+{"id":19125,"name":"Hexadecimal value of Pi","url":"https://www.spoj.com/problems/PIHEX2","users":36,"accepted":58.04}
+{"id":19133,"name":"Base Conversion","url":"https://www.spoj.com/problems/BASECONV","users":9,"accepted":12.72}
+{"id":19139,"name":"Boiling Vegetables","url":"https://www.spoj.com/problems/BOILING","users":31,"accepted":37.96}
+{"id":19142,"name":"BSTRING","url":"https://www.spoj.com/problems/INS14A","users":141,"accepted":33.82}
+{"id":19143,"name":"TRISQRS","url":"https://www.spoj.com/problems/INS14B","users":172,"accepted":38.08}
+{"id":19144,"name":"Digo plays with Numbers","url":"https://www.spoj.com/problems/INS14C","users":726,"accepted":40.73}
+{"id":19145,"name":"Digo Needs Guns","url":"https://www.spoj.com/problems/INS14D","users":192,"accepted":51.59}
+{"id":19146,"name":"Glorious Gamblers","url":"https://www.spoj.com/problems/INS14E","users":141,"accepted":55.52}

--- a/tests/spoj/index/58.md
+++ b/tests/spoj/index/58.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 18457 | [Very Friends](https://www.spoj.com/problems/VFRIENDS) | 249 | 27.97 |
+| 18458 | [Very Friends 2](https://www.spoj.com/problems/VFRIEND2) | 40 | 19.45 |
+| 18465 | [A Subtle Surf](https://www.spoj.com/problems/UOFTCC) | 204 | 43.41 |
+| 18466 | [A Frightening Evening](https://www.spoj.com/problems/UOFTCD) | 124 | 29.53 |
+| 18467 | [A Brief Expedition](https://www.spoj.com/problems/UOFTCE) | 277 | 54.42 |
+| 18468 | [A Pleasant Stroll](https://www.spoj.com/problems/UOFTCF) | 138 | 35.42 |
+| 18469 | [Office Mates](https://www.spoj.com/problems/UOFTCG) | 53 | 32.46 |
+| 18510 | [Ross generates Data](https://www.spoj.com/problems/AKVOD05) | 98 | 17.18 |
+| 18511 | [Cartman and Butters Game](https://www.spoj.com/problems/AKVOD06) | 22 | 29.17 |
+| 18521 | [Fortunate Wheels](https://www.spoj.com/problems/FBWHEELS) | 7 | 34.78 |
+| 18522 | [Tours](https://www.spoj.com/problems/FBTOURS) | 26 | 21.76 |
+| 18530 | [Font Size](https://www.spoj.com/problems/FONTSIZE) | 207 | 13.87 |
+| 18531 | [Barrelrider](https://www.spoj.com/problems/BRLRIDER) | 21 | 56.25 |
+| 18532 | [Tree _order](https://www.spoj.com/problems/TREEORD) | 1245 | 47.28 |
+| 18598 | [Encode Message](https://www.spoj.com/problems/SNGMSG) | 875 | 63.46 |
+| 18637 | [Lawrence of Arabia](https://www.spoj.com/problems/LAWRENCE) | 61 | 28.11 |
+| 18660 | [Product of factorials (easy)](https://www.spoj.com/problems/FACTMULN) | 115 | 27.20 |
+| 18662 | [Product of factorials (again)](https://www.spoj.com/problems/FACTMULO) | 86 | 31.50 |
+| 18666 | [Radiation](https://www.spoj.com/problems/UVA1) | 36 | 20.00 |
+| 18667 | [Product of factorials (hard)](https://www.spoj.com/problems/FACTMULP) | 46 | 27.10 |
+| 18714 | [Can You Make It Empty 2](https://www.spoj.com/problems/EMTY2) | 1324 | 29.23 |
+| 18715 | [Boring Factorials (Reloaded)](https://www.spoj.com/problems/BORING) | 66 | 10.31 |
+| 18799 | [Boring Factorials (Extended)](https://www.spoj.com/problems/BORING2) | 15 | 13.37 |
+| 18829 | [Special Set](https://www.spoj.com/problems/SPEC_SET) | 118 | 27.10 |
+| 18857 | [Gopi and Sandwich](https://www.spoj.com/problems/GOPI_SW) | 284 | 44.16 |
+| 18878 | [Topper Rama Rao](https://www.spoj.com/problems/HLP_RAMS) | 1046 | 48.41 |
+| 18905 | [Kapti and Balu](https://www.spoj.com/problems/NR1) | 41 | 32.70 |
+| 18915 | [Anils Proposal](https://www.spoj.com/problems/ANIL_PRO) | 31 | 18.90 |
+| 18917 | [Dukkar and Pikka](https://www.spoj.com/problems/DUKKAR) | 313 | 56.43 |
+| 18932 | [Sum of primes (reverse mode)](https://www.spoj.com/problems/SUMPRIM2) | 23 | 17.53 |
+| 18937 | [Touch of Venom](https://www.spoj.com/problems/VENOM) | 1406 | 23.29 |
+| 18939 | [K-th smallest number](https://www.spoj.com/problems/KSMALL) | 219 | 13.94 |
+| 18940 | [Face the mate](https://www.spoj.com/problems/FACENEMY) | 161 | 20.93 |
+| 18941 | [True Friends](https://www.spoj.com/problems/TFRIENDS) | 1027 | 51.19 |
+| 18945 | [Car with powers](https://www.spoj.com/problems/POWERCAR) | 308 | 29.73 |
+| 18963 | [Bhagat The Bit Man](https://www.spoj.com/problems/NR2) | 661 | 31.69 |
+| 18964 | [Sum of subsequences](https://www.spoj.com/problems/BLSUMSEQ) | 28 | 22.76 |
+| 18965 | [Milk Scheduling](https://www.spoj.com/problems/MSCHED) | 1056 | 25.57 |
+| 18966 | [Vacation Planning](https://www.spoj.com/problems/VACATION) | 141 | 25.83 |
+| 19037 | [Magical colorful cats (easy)](https://www.spoj.com/problems/COLORCAT) | 20 | 19.57 |
+| 19039 | [Krypt in Time](https://www.spoj.com/problems/KIT) | 299 | 41.91 |
+| 19084 | [Huge Pascal triangle](https://www.spoj.com/problems/DUKKAR2) | 34 | 47.92 |
+| 19125 | [Hexadecimal value of Pi](https://www.spoj.com/problems/PIHEX2) | 36 | 58.04 |
+| 19133 | [Base Conversion](https://www.spoj.com/problems/BASECONV) | 9 | 12.72 |
+| 19139 | [Boiling Vegetables](https://www.spoj.com/problems/BOILING) | 31 | 37.96 |
+| 19142 | [BSTRING](https://www.spoj.com/problems/INS14A) | 141 | 33.82 |
+| 19143 | [TRISQRS](https://www.spoj.com/problems/INS14B) | 172 | 38.08 |
+| 19144 | [Digo plays with Numbers](https://www.spoj.com/problems/INS14C) | 726 | 40.73 |
+| 19145 | [Digo Needs Guns](https://www.spoj.com/problems/INS14D) | 192 | 51.59 |
+| 19146 | [Glorious Gamblers](https://www.spoj.com/problems/INS14E) | 141 | 55.52 |

--- a/tests/spoj/index/59.jsonl
+++ b/tests/spoj/index/59.jsonl
@@ -1,0 +1,50 @@
+{"id":19147,"name":"Save CodeVillage","url":"https://www.spoj.com/problems/INS14F","users":114,"accepted":32.43}
+{"id":19148,"name":"Kill them All","url":"https://www.spoj.com/problems/INS14G","users":129,"accepted":23.6}
+{"id":19149,"name":"Virus Revisited","url":"https://www.spoj.com/problems/INS14H","users":94,"accepted":28.65}
+{"id":19150,"name":"Infinite Sequence","url":"https://www.spoj.com/problems/INS14I","users":154,"accepted":30.2}
+{"id":19151,"name":"Checkers","url":"https://www.spoj.com/problems/INS14J","users":52,"accepted":57.03}
+{"id":19152,"name":"Digo Goes Training","url":"https://www.spoj.com/problems/INS14K","users":240,"accepted":46.18}
+{"id":19153,"name":"Rooted Trees","url":"https://www.spoj.com/problems/INS14L","users":43,"accepted":21.51}
+{"id":19154,"name":"Terrorist Attack","url":"https://www.spoj.com/problems/INS14M","users":23,"accepted":35.46}
+{"id":19174,"name":"Khairy and Gold Alloys","url":"https://www.spoj.com/problems/WAL3A","users":147,"accepted":47.36}
+{"id":19216,"name":"Super Mario Revisited","url":"https://www.spoj.com/problems/SMARIO","users":22,"accepted":7.24}
+{"id":19224,"name":"Lights, Snakes and Cages","url":"https://www.spoj.com/problems/CAGES","users":93,"accepted":16.64}
+{"id":19270,"name":"SIR CHIRAG AND MAGIC NUMBERS","url":"https://www.spoj.com/problems/SIRNUMS","users":138,"accepted":44.55}
+{"id":19274,"name":"Operators","url":"https://www.spoj.com/problems/BLOPER","users":604,"accepted":20.39}
+{"id":19276,"name":"Peculiar Permutivores","url":"https://www.spoj.com/problems/BFPRMCYC","users":6,"accepted":36.36}
+{"id":19288,"name":"Sword Game","url":"https://www.spoj.com/problems/WPC5C","users":17,"accepted":20.91}
+{"id":19290,"name":"Parade","url":"https://www.spoj.com/problems/WPC5F","users":38,"accepted":42.97}
+{"id":19291,"name":"Structures","url":"https://www.spoj.com/problems/WPC5A","users":137,"accepted":28.38}
+{"id":19292,"name":"Complicated Calculations","url":"https://www.spoj.com/problems/WPC5D","users":97,"accepted":51.57}
+{"id":19293,"name":"Galaxy distances","url":"https://www.spoj.com/problems/WPC5E","users":69,"accepted":25.85}
+{"id":19295,"name":"The dilemma of Idli","url":"https://www.spoj.com/problems/WPC5G","users":30,"accepted":41.28}
+{"id":19297,"name":"Nymphs from H10","url":"https://www.spoj.com/problems/WPC5H","users":36,"accepted":35.65}
+{"id":19301,"name":"Operators (new ver)","url":"https://www.spoj.com/problems/BLOPER2","users":47,"accepted":6.88}
+{"id":19308,"name":"LCM","url":"https://www.spoj.com/problems/WPC5I","users":390,"accepted":18.71}
+{"id":19320,"name":"Draw Skyline Graph","url":"https://www.spoj.com/problems/SKYLINE2","users":109,"accepted":20.02}
+{"id":19329,"name":"Group Viva","url":"https://www.spoj.com/problems/GRUPVIVA","users":91,"accepted":35.46}
+{"id":19334,"name":"Khaolin Temple","url":"https://www.spoj.com/problems/KHAOTMPL","users":24,"accepted":27.22}
+{"id":19335,"name":"Machau vs Maggu","url":"https://www.spoj.com/problems/MACVSMAG","users":10,"accepted":12.82}
+{"id":19367,"name":"St Bernard and Gravity","url":"https://www.spoj.com/problems/BGRAVITY","users":75,"accepted":11.04}
+{"id":19382,"name":"Stock","url":"https://www.spoj.com/problems/STK","users":99,"accepted":32.39}
+{"id":19406,"name":"Fibonacci extraction Sum","url":"https://www.spoj.com/problems/FIBOSUM2","users":54,"accepted":26.08}
+{"id":19416,"name":"Potions Class","url":"https://www.spoj.com/problems/POTIONS","users":159,"accepted":37.4}
+{"id":19490,"name":"Pair and unpair weightest string","url":"https://www.spoj.com/problems/PAUWS","users":84,"accepted":47.33}
+{"id":19543,"name":"Can you answer these queries VIII","url":"https://www.spoj.com/problems/GSS8","users":216,"accepted":26.27}
+{"id":19545,"name":"Black and White beads","url":"https://www.spoj.com/problems/BWB","users":247,"accepted":34.25}
+{"id":19551,"name":"A Colorful world","url":"https://www.spoj.com/problems/CWORLD","users":89,"accepted":31.99}
+{"id":19561,"name":"New Binary","url":"https://www.spoj.com/problems/NBIN","users":298,"accepted":42.68}
+{"id":19568,"name":"Prime queries","url":"https://www.spoj.com/problems/PRMQUER","users":442,"accepted":22.99}
+{"id":19576,"name":"Popeye and the magical land","url":"https://www.spoj.com/problems/PAML","users":192,"accepted":50.32}
+{"id":19578,"name":"Chipmunks with Brain","url":"https://www.spoj.com/problems/CWB","users":84,"accepted":38.64}
+{"id":19684,"name":"Symmetric matrix","url":"https://www.spoj.com/problems/MATPROD","users":8,"accepted":21.35}
+{"id":19686,"name":"Mining Camps","url":"https://www.spoj.com/problems/MCAMP","users":80,"accepted":10.89}
+{"id":19687,"name":"Symmetric matrix 2","url":"https://www.spoj.com/problems/MATPROD2","users":0,"accepted":0}
+{"id":19722,"name":"Modular Tetration","url":"https://www.spoj.com/problems/MTETRA","users":46,"accepted":70.37}
+{"id":19786,"name":"Mr Toothless and His GCD Operation","url":"https://www.spoj.com/problems/GGD","users":391,"accepted":30.76}
+{"id":19795,"name":"Psycho34 (easy)","url":"https://www.spoj.com/problems/PSYCHOT","users":61,"accepted":22.81}
+{"id":19899,"name":"Middle Earth","url":"https://www.spoj.com/problems/MIDEARTH","users":51,"accepted":12.24}
+{"id":19913,"name":"Counting Pythagorean Triples","url":"https://www.spoj.com/problems/PYTRIP3","users":21,"accepted":14.74}
+{"id":19954,"name":"Travelling Knight 2","url":"https://www.spoj.com/problems/KN2","users":16,"accepted":12.25}
+{"id":19957,"name":"GETTING AN AP","url":"https://www.spoj.com/problems/APPROB","users":493,"accepted":36.88}
+{"id":19971,"name":"100pct failure in 72 hours","url":"https://www.spoj.com/problems/HAL9000","users":8,"accepted":42.03}

--- a/tests/spoj/index/59.md
+++ b/tests/spoj/index/59.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 19147 | [Save CodeVillage](https://www.spoj.com/problems/INS14F) | 114 | 32.43 |
+| 19148 | [Kill them All](https://www.spoj.com/problems/INS14G) | 129 | 23.60 |
+| 19149 | [Virus Revisited](https://www.spoj.com/problems/INS14H) | 94 | 28.65 |
+| 19150 | [Infinite Sequence](https://www.spoj.com/problems/INS14I) | 154 | 30.20 |
+| 19151 | [Checkers](https://www.spoj.com/problems/INS14J) | 52 | 57.03 |
+| 19152 | [Digo Goes Training](https://www.spoj.com/problems/INS14K) | 240 | 46.18 |
+| 19153 | [Rooted Trees](https://www.spoj.com/problems/INS14L) | 43 | 21.51 |
+| 19154 | [Terrorist Attack](https://www.spoj.com/problems/INS14M) | 23 | 35.46 |
+| 19174 | [Khairy and Gold Alloys](https://www.spoj.com/problems/WAL3A) | 147 | 47.36 |
+| 19216 | [Super Mario Revisited](https://www.spoj.com/problems/SMARIO) | 22 | 7.24 |
+| 19224 | [Lights, Snakes and Cages](https://www.spoj.com/problems/CAGES) | 93 | 16.64 |
+| 19270 | [SIR CHIRAG AND MAGIC NUMBERS](https://www.spoj.com/problems/SIRNUMS) | 138 | 44.55 |
+| 19274 | [Operators](https://www.spoj.com/problems/BLOPER) | 604 | 20.39 |
+| 19276 | [Peculiar Permutivores](https://www.spoj.com/problems/BFPRMCYC) | 6 | 36.36 |
+| 19288 | [Sword Game](https://www.spoj.com/problems/WPC5C) | 17 | 20.91 |
+| 19290 | [Parade](https://www.spoj.com/problems/WPC5F) | 38 | 42.97 |
+| 19291 | [Structures](https://www.spoj.com/problems/WPC5A) | 137 | 28.38 |
+| 19292 | [Complicated Calculations](https://www.spoj.com/problems/WPC5D) | 97 | 51.57 |
+| 19293 | [Galaxy distances](https://www.spoj.com/problems/WPC5E) | 69 | 25.85 |
+| 19295 | [The dilemma of Idli](https://www.spoj.com/problems/WPC5G) | 30 | 41.28 |
+| 19297 | [Nymphs from H10](https://www.spoj.com/problems/WPC5H) | 36 | 35.65 |
+| 19301 | [Operators (new ver)](https://www.spoj.com/problems/BLOPER2) | 47 | 6.88 |
+| 19308 | [LCM](https://www.spoj.com/problems/WPC5I) | 390 | 18.71 |
+| 19320 | [Draw Skyline Graph](https://www.spoj.com/problems/SKYLINE2) | 109 | 20.02 |
+| 19329 | [Group Viva](https://www.spoj.com/problems/GRUPVIVA) | 91 | 35.46 |
+| 19334 | [Khaolin Temple](https://www.spoj.com/problems/KHAOTMPL) | 24 | 27.22 |
+| 19335 | [Machau vs Maggu](https://www.spoj.com/problems/MACVSMAG) | 10 | 12.82 |
+| 19367 | [St Bernard and Gravity](https://www.spoj.com/problems/BGRAVITY) | 75 | 11.04 |
+| 19382 | [Stock](https://www.spoj.com/problems/STK) | 99 | 32.39 |
+| 19406 | [Fibonacci extraction Sum](https://www.spoj.com/problems/FIBOSUM2) | 54 | 26.08 |
+| 19416 | [Potions Class](https://www.spoj.com/problems/POTIONS) | 159 | 37.40 |
+| 19490 | [Pair and unpair weightest string](https://www.spoj.com/problems/PAUWS) | 84 | 47.33 |
+| 19543 | [Can you answer these queries VIII](https://www.spoj.com/problems/GSS8) | 216 | 26.27 |
+| 19545 | [Black and White beads](https://www.spoj.com/problems/BWB) | 247 | 34.25 |
+| 19551 | [A Colorful world](https://www.spoj.com/problems/CWORLD) | 89 | 31.99 |
+| 19561 | [New Binary](https://www.spoj.com/problems/NBIN) | 298 | 42.68 |
+| 19568 | [Prime queries](https://www.spoj.com/problems/PRMQUER) | 442 | 22.99 |
+| 19576 | [Popeye and the magical land](https://www.spoj.com/problems/PAML) | 192 | 50.32 |
+| 19578 | [Chipmunks with Brain](https://www.spoj.com/problems/CWB) | 84 | 38.64 |
+| 19684 | [Symmetric matrix](https://www.spoj.com/problems/MATPROD) | 8 | 21.35 |
+| 19686 | [Mining Camps](https://www.spoj.com/problems/MCAMP) | 80 | 10.89 |
+| 19687 | [Symmetric matrix 2](https://www.spoj.com/problems/MATPROD2) | 0 | 0.00 |
+| 19722 | [Modular Tetration](https://www.spoj.com/problems/MTETRA) | 46 | 70.37 |
+| 19786 | [Mr Toothless and His GCD Operation](https://www.spoj.com/problems/GGD) | 391 | 30.76 |
+| 19795 | [Psycho34 (easy)](https://www.spoj.com/problems/PSYCHOT) | 61 | 22.81 |
+| 19899 | [Middle Earth](https://www.spoj.com/problems/MIDEARTH) | 51 | 12.24 |
+| 19913 | [Counting Pythagorean Triples](https://www.spoj.com/problems/PYTRIP3) | 21 | 14.74 |
+| 19954 | [Travelling Knight 2](https://www.spoj.com/problems/KN2) | 16 | 12.25 |
+| 19957 | [GETTING AN AP](https://www.spoj.com/problems/APPROB) | 493 | 36.88 |
+| 19971 | [100pct failure in 72 hours](https://www.spoj.com/problems/HAL9000) | 8 | 42.03 |

--- a/tests/spoj/index/60.jsonl
+++ b/tests/spoj/index/60.jsonl
@@ -1,0 +1,50 @@
+{"id":19975,"name":"Amazing Prime Sequence (hard)","url":"https://www.spoj.com/problems/APS2","users":96,"accepted":44.42}
+{"id":19976,"name":"HYPERCUBES","url":"https://www.spoj.com/problems/CUBE","users":122,"accepted":45.32}
+{"id":19985,"name":"GCD Extreme (hard)","url":"https://www.spoj.com/problems/GCDEX2","users":358,"accepted":36.57}
+{"id":19991,"name":"In case of failure","url":"https://www.spoj.com/problems/FAILURE","users":136,"accepted":40.19}
+{"id":19996,"name":"Moon Safari (medium)","url":"https://www.spoj.com/problems/MOON1","users":82,"accepted":40.81}
+{"id":19997,"name":"Moon Safari (Hard)","url":"https://www.spoj.com/problems/MOON2","users":51,"accepted":50.25}
+{"id":20038,"name":"Easiest Loop 1","url":"https://www.spoj.com/problems/SNGLOOP1","users":379,"accepted":48.58}
+{"id":20041,"name":"Hippo and Bloody Jungle","url":"https://www.spoj.com/problems/HIPPO","users":43,"accepted":21.74}
+{"id":20050,"name":"Love Story 2","url":"https://www.spoj.com/problems/PIHU2","users":89,"accepted":38.29}
+{"id":20063,"name":"Large subsequence Problem","url":"https://www.spoj.com/problems/LARSUBP","users":453,"accepted":42.16}
+{"id":20100,"name":"Honda and Kagawa","url":"https://www.spoj.com/problems/HONDA","users":383,"accepted":45.81}
+{"id":20167,"name":"Array with Hudai Calculation","url":"https://www.spoj.com/problems/ARRHUDAI","users":51,"accepted":24.51}
+{"id":20170,"name":"Coloring Segments","url":"https://www.spoj.com/problems/COLORSEG","users":92,"accepted":20.64}
+{"id":20172,"name":"Divisiblity by 3","url":"https://www.spoj.com/problems/DIVISION","users":589,"accepted":30.54}
+{"id":20173,"name":"Counting Divisors (square)","url":"https://www.spoj.com/problems/DIVCNT2","users":485,"accepted":21.72}
+{"id":20174,"name":"Counting Divisors (cube)","url":"https://www.spoj.com/problems/DIVCNT3","users":401,"accepted":35.71}
+{"id":20196,"name":"The Magical Bag","url":"https://www.spoj.com/problems/DIVEQL","users":199,"accepted":38.44}
+{"id":20327,"name":"Triangles","url":"https://www.spoj.com/problems/BOI02TRI","users":30,"accepted":28.82}
+{"id":20562,"name":"Tracy and Charlie","url":"https://www.spoj.com/problems/TANDC","users":48,"accepted":56}
+{"id":20563,"name":"Minion Circle","url":"https://www.spoj.com/problems/MCIRCLE","users":24,"accepted":35}
+{"id":20635,"name":"Dortmund Dilemma","url":"https://www.spoj.com/problems/DORTMUND","users":22,"accepted":48.33}
+{"id":20637,"name":"Ajob Subsequence","url":"https://www.spoj.com/problems/AJOB","users":78,"accepted":39.11}
+{"id":20644,"name":"Zero Query","url":"https://www.spoj.com/problems/ZQUERY","users":764,"accepted":19.49}
+{"id":20654,"name":"Interesting Subset","url":"https://www.spoj.com/problems/INTSUB","users":97,"accepted":23.84}
+{"id":20673,"name":"Count The Indexes","url":"https://www.spoj.com/problems/CNTINDX","users":253,"accepted":29.6}
+{"id":20689,"name":"WA,RTE and Placements","url":"https://www.spoj.com/problems/WRP","users":28,"accepted":41.08}
+{"id":20752,"name":"LAZY FRIENDS","url":"https://www.spoj.com/problems/GEMS","users":40,"accepted":37.09}
+{"id":20775,"name":"Roger and tree","url":"https://www.spoj.com/problems/RTREE","users":342,"accepted":27.74}
+{"id":20845,"name":"Interesting Numbers","url":"https://www.spoj.com/problems/INUM","users":221,"accepted":24.19}
+{"id":20846,"name":"Interesting Selection","url":"https://www.spoj.com/problems/ISELECT","users":129,"accepted":43.94}
+{"id":20848,"name":"Interesting Game","url":"https://www.spoj.com/problems/IGAME","users":60,"accepted":44.68}
+{"id":20849,"name":"Interesting queries","url":"https://www.spoj.com/problems/IQUERY","users":46,"accepted":34.12}
+{"id":20863,"name":"Largest Submatrix","url":"https://www.spoj.com/problems/MINSUB","users":82,"accepted":27.21}
+{"id":20872,"name":"Counting Pairwise Coprime Triples","url":"https://www.spoj.com/problems/PCOPTRIP","users":50,"accepted":52.45}
+{"id":20926,"name":"Special Numbers (Reverse and Add)","url":"https://www.spoj.com/problems/REVADD","users":21,"accepted":11.94}
+{"id":20930,"name":"Progression","url":"https://www.spoj.com/problems/EC_SER","users":26,"accepted":8.01}
+{"id":20931,"name":"Square-Free Product (Hard)","url":"https://www.spoj.com/problems/PUCMMT02","users":65,"accepted":36.36}
+{"id":20951,"name":"Pebbles","url":"https://www.spoj.com/problems/SNIM","users":71,"accepted":59.31}
+{"id":20957,"name":"Alia and 3 Khans","url":"https://www.spoj.com/problems/KHANS","users":77,"accepted":31.54}
+{"id":20970,"name":"Alia and Handsome Devil","url":"https://www.spoj.com/problems/HDEVIL","users":399,"accepted":30.65}
+{"id":20971,"name":"Alia and Substrings","url":"https://www.spoj.com/problems/HAGU","users":27,"accepted":22.29}
+{"id":20972,"name":"Alia and Cryptography","url":"https://www.spoj.com/problems/CONOR","users":101,"accepted":45.45}
+{"id":20977,"name":"Car Game","url":"https://www.spoj.com/problems/UCBINTB","users":51,"accepted":33.8}
+{"id":20979,"name":"Good","url":"https://www.spoj.com/problems/UCBINTC","users":88,"accepted":40.43}
+{"id":20980,"name":"Chicken Joggers","url":"https://www.spoj.com/problems/UCBINTD","users":19,"accepted":41.27}
+{"id":20984,"name":"Music Academy","url":"https://www.spoj.com/problems/UCBINTF","users":70,"accepted":47.64}
+{"id":20985,"name":"Archipelago","url":"https://www.spoj.com/problems/UCBINTG","users":106,"accepted":62.77}
+{"id":20986,"name":"Hypertubes","url":"https://www.spoj.com/problems/UCBINTH","users":52,"accepted":43.84}
+{"id":20987,"name":"Sequence","url":"https://www.spoj.com/problems/UCBINTI","users":31,"accepted":24.85}
+{"id":21049,"name":"Under Construction Forever","url":"https://www.spoj.com/problems/UCF","users":17,"accepted":40.91}

--- a/tests/spoj/index/60.md
+++ b/tests/spoj/index/60.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 19975 | [Amazing Prime Sequence (hard)](https://www.spoj.com/problems/APS2) | 96 | 44.42 |
+| 19976 | [HYPERCUBES](https://www.spoj.com/problems/CUBE) | 122 | 45.32 |
+| 19985 | [GCD Extreme (hard)](https://www.spoj.com/problems/GCDEX2) | 358 | 36.57 |
+| 19991 | [In case of failure](https://www.spoj.com/problems/FAILURE) | 136 | 40.19 |
+| 19996 | [Moon Safari (medium)](https://www.spoj.com/problems/MOON1) | 82 | 40.81 |
+| 19997 | [Moon Safari (Hard)](https://www.spoj.com/problems/MOON2) | 51 | 50.25 |
+| 20038 | [Easiest Loop 1](https://www.spoj.com/problems/SNGLOOP1) | 379 | 48.58 |
+| 20041 | [Hippo and Bloody Jungle](https://www.spoj.com/problems/HIPPO) | 43 | 21.74 |
+| 20050 | [Love Story 2](https://www.spoj.com/problems/PIHU2) | 89 | 38.29 |
+| 20063 | [Large subsequence Problem](https://www.spoj.com/problems/LARSUBP) | 453 | 42.16 |
+| 20100 | [Honda and Kagawa](https://www.spoj.com/problems/HONDA) | 383 | 45.81 |
+| 20167 | [Array with Hudai Calculation](https://www.spoj.com/problems/ARRHUDAI) | 51 | 24.51 |
+| 20170 | [Coloring Segments](https://www.spoj.com/problems/COLORSEG) | 92 | 20.64 |
+| 20172 | [Divisiblity by 3](https://www.spoj.com/problems/DIVISION) | 589 | 30.54 |
+| 20173 | [Counting Divisors (square)](https://www.spoj.com/problems/DIVCNT2) | 485 | 21.72 |
+| 20174 | [Counting Divisors (cube)](https://www.spoj.com/problems/DIVCNT3) | 401 | 35.71 |
+| 20196 | [The Magical Bag](https://www.spoj.com/problems/DIVEQL) | 199 | 38.44 |
+| 20327 | [Triangles](https://www.spoj.com/problems/BOI02TRI) | 30 | 28.82 |
+| 20562 | [Tracy and Charlie](https://www.spoj.com/problems/TANDC) | 48 | 56.00 |
+| 20563 | [Minion Circle](https://www.spoj.com/problems/MCIRCLE) | 24 | 35.00 |
+| 20635 | [Dortmund Dilemma](https://www.spoj.com/problems/DORTMUND) | 22 | 48.33 |
+| 20637 | [Ajob Subsequence](https://www.spoj.com/problems/AJOB) | 78 | 39.11 |
+| 20644 | [Zero Query](https://www.spoj.com/problems/ZQUERY) | 764 | 19.49 |
+| 20654 | [Interesting Subset](https://www.spoj.com/problems/INTSUB) | 97 | 23.84 |
+| 20673 | [Count The Indexes](https://www.spoj.com/problems/CNTINDX) | 253 | 29.60 |
+| 20689 | [WA,RTE and Placements](https://www.spoj.com/problems/WRP) | 28 | 41.08 |
+| 20752 | [LAZY FRIENDS](https://www.spoj.com/problems/GEMS) | 40 | 37.09 |
+| 20775 | [Roger and tree](https://www.spoj.com/problems/RTREE) | 342 | 27.74 |
+| 20845 | [Interesting Numbers](https://www.spoj.com/problems/INUM) | 221 | 24.19 |
+| 20846 | [Interesting Selection](https://www.spoj.com/problems/ISELECT) | 129 | 43.94 |
+| 20848 | [Interesting Game](https://www.spoj.com/problems/IGAME) | 60 | 44.68 |
+| 20849 | [Interesting queries](https://www.spoj.com/problems/IQUERY) | 46 | 34.12 |
+| 20863 | [Largest Submatrix](https://www.spoj.com/problems/MINSUB) | 82 | 27.21 |
+| 20872 | [Counting Pairwise Coprime Triples](https://www.spoj.com/problems/PCOPTRIP) | 50 | 52.45 |
+| 20926 | [Special Numbers (Reverse and Add)](https://www.spoj.com/problems/REVADD) | 21 | 11.94 |
+| 20930 | [Progression](https://www.spoj.com/problems/EC_SER) | 26 | 8.01 |
+| 20931 | [Square-Free Product (Hard)](https://www.spoj.com/problems/PUCMMT02) | 65 | 36.36 |
+| 20951 | [Pebbles](https://www.spoj.com/problems/SNIM) | 71 | 59.31 |
+| 20957 | [Alia and 3 Khans](https://www.spoj.com/problems/KHANS) | 77 | 31.54 |
+| 20970 | [Alia and Handsome Devil](https://www.spoj.com/problems/HDEVIL) | 399 | 30.65 |
+| 20971 | [Alia and Substrings](https://www.spoj.com/problems/HAGU) | 27 | 22.29 |
+| 20972 | [Alia and Cryptography](https://www.spoj.com/problems/CONOR) | 101 | 45.45 |
+| 20977 | [Car Game](https://www.spoj.com/problems/UCBINTB) | 51 | 33.80 |
+| 20979 | [Good](https://www.spoj.com/problems/UCBINTC) | 88 | 40.43 |
+| 20980 | [Chicken Joggers](https://www.spoj.com/problems/UCBINTD) | 19 | 41.27 |
+| 20984 | [Music Academy](https://www.spoj.com/problems/UCBINTF) | 70 | 47.64 |
+| 20985 | [Archipelago](https://www.spoj.com/problems/UCBINTG) | 106 | 62.77 |
+| 20986 | [Hypertubes](https://www.spoj.com/problems/UCBINTH) | 52 | 43.84 |
+| 20987 | [Sequence](https://www.spoj.com/problems/UCBINTI) | 31 | 24.85 |
+| 21049 | [Under Construction Forever](https://www.spoj.com/problems/UCF) | 17 | 40.91 |

--- a/tests/spoj/index/61.jsonl
+++ b/tests/spoj/index/61.jsonl
@@ -1,0 +1,50 @@
+{"id":21057,"name":"Super Lucky Palindromes","url":"https://www.spoj.com/problems/CTPLUCKY","users":33,"accepted":27.59}
+{"id":21058,"name":"Dirty Plates","url":"https://www.spoj.com/problems/CTPDIRTY","users":27,"accepted":32.65}
+{"id":21061,"name":"Yet Another Subset Sum Problem","url":"https://www.spoj.com/problems/YASSP","users":48,"accepted":34.44}
+{"id":21068,"name":"Popular","url":"https://www.spoj.com/problems/TPCPPLAR","users":48,"accepted":25}
+{"id":21083,"name":"Lexicographically Smallest","url":"https://www.spoj.com/problems/LEXSTR","users":250,"accepted":33.2}
+{"id":21085,"name":"Palindrome Merge","url":"https://www.spoj.com/problems/TPCPALIN","users":35,"accepted":28.24}
+{"id":21092,"name":"DRAW TABLE","url":"https://www.spoj.com/problems/FRMT","users":47,"accepted":53.79}
+{"id":21096,"name":"Word Counting 2","url":"https://www.spoj.com/problems/WORDCNT2","users":175,"accepted":29.7}
+{"id":21104,"name":"Jarin Loves New Task","url":"https://www.spoj.com/problems/JLNT","users":49,"accepted":38.2}
+{"id":21132,"name":"Palindromes","url":"https://www.spoj.com/problems/APIO14_A","users":105,"accepted":36.2}
+{"id":21135,"name":"Distinct Viewpoints","url":"https://www.spoj.com/problems/BFCC","users":2,"accepted":23.08}
+{"id":21155,"name":"Manoj and Fire","url":"https://www.spoj.com/problems/MANJFIRE","users":25,"accepted":21.16}
+{"id":21169,"name":"Balanced base-3","url":"https://www.spoj.com/problems/TAP2014B","users":519,"accepted":52.53}
+{"id":21170,"name":"Constellation of the parallelogram","url":"https://www.spoj.com/problems/TAP2014C","users":92,"accepted":26.64}
+{"id":21171,"name":"Fractal domino","url":"https://www.spoj.com/problems/TAP2014D","users":18,"accepted":53.52}
+{"id":21172,"name":"Erdos et al","url":"https://www.spoj.com/problems/TAP2014E","users":141,"accepted":36.84}
+{"id":21173,"name":"String fertilization","url":"https://www.spoj.com/problems/TAP2014F","users":61,"accepted":41.89}
+{"id":21174,"name":"Gallantry","url":"https://www.spoj.com/problems/TAP2014G","users":397,"accepted":51.22}
+{"id":21175,"name":"Rush hour","url":"https://www.spoj.com/problems/TAP2014H","users":145,"accepted":41.81}
+{"id":21176,"name":"Stapled intervals","url":"https://www.spoj.com/problems/TAP2014I","users":51,"accepted":58.86}
+{"id":21177,"name":"Distracted judges","url":"https://www.spoj.com/problems/TAP2014J","users":324,"accepted":44.91}
+{"id":21178,"name":"Encryption kit","url":"https://www.spoj.com/problems/TAP2014K","users":56,"accepted":29.58}
+{"id":21187,"name":"Increasing Shortest Path","url":"https://www.spoj.com/problems/ACPC13","users":34,"accepted":20.25}
+{"id":21193,"name":"Adjusting Ducks","url":"https://www.spoj.com/problems/ADJDUCKS","users":67,"accepted":31.82}
+{"id":21284,"name":"Can You Make It Empty 3","url":"https://www.spoj.com/problems/EMTY3","users":95,"accepted":31.16}
+{"id":21326,"name":"Akbar , The great","url":"https://www.spoj.com/problems/AKBAR","users":2720,"accepted":16.04}
+{"id":21332,"name":"Pigeonhole Tower","url":"https://www.spoj.com/problems/PHT","users":1755,"accepted":35.68}
+{"id":21347,"name":"Tulip And Numbers","url":"https://www.spoj.com/problems/TULIPNUM","users":1035,"accepted":21.4}
+{"id":21352,"name":"Avantgarde and Bicycle","url":"https://www.spoj.com/problems/CLZBICYC","users":29,"accepted":42.5}
+{"id":21353,"name":"Avantgarde and Doughnut","url":"https://www.spoj.com/problems/CLZDOUGH","users":23,"accepted":44.87}
+{"id":21354,"name":"String Problem","url":"https://www.spoj.com/problems/CLZSTRNG","users":28,"accepted":33.33}
+{"id":21356,"name":"Divisible Number Sum","url":"https://www.spoj.com/problems/NAJ0001","users":51,"accepted":17.82}
+{"id":21357,"name":"Crucial Equation","url":"https://www.spoj.com/problems/CEQU","users":6387,"accepted":38.05}
+{"id":21360,"name":"Suffix Equal Prefix","url":"https://www.spoj.com/problems/SUFEQPRE","users":545,"accepted":29.38}
+{"id":21394,"name":"Ohani And The Series","url":"https://www.spoj.com/problems/OHANISER","users":605,"accepted":42.18}
+{"id":21395,"name":"Ohani And Binary Search Tree","url":"https://www.spoj.com/problems/OHANIBTR","users":130,"accepted":36.05}
+{"id":21396,"name":"Taklu Kuddus","url":"https://www.spoj.com/problems/TKUDDUS","users":107,"accepted":8.26}
+{"id":21407,"name":"2x2 Subgrid Sum Problem (medium)","url":"https://www.spoj.com/problems/GRIDSUM1","users":22,"accepted":21.29}
+{"id":21409,"name":"2x2 Subgrid Sum Problem (generalized)","url":"https://www.spoj.com/problems/GRIDSUM3","users":6,"accepted":17.02}
+{"id":21414,"name":"Count The Indexes 2","url":"https://www.spoj.com/problems/CNTINDX2","users":45,"accepted":19.13}
+{"id":21418,"name":"Interesting Game with Polygons","url":"https://www.spoj.com/problems/HCT00001","users":36,"accepted":28.02}
+{"id":21456,"name":"I Ken Bit Yu","url":"https://www.spoj.com/problems/NPC2014A","users":117,"accepted":30.96}
+{"id":21457,"name":"House Fence","url":"https://www.spoj.com/problems/NPC2014B","users":158,"accepted":28.32}
+{"id":21458,"name":"Satay Skewer","url":"https://www.spoj.com/problems/NPC2014C","users":84,"accepted":27.94}
+{"id":21460,"name":"Tresi and Girls","url":"https://www.spoj.com/problems/NPC2014E","users":68,"accepted":22.78}
+{"id":21461,"name":"Field","url":"https://www.spoj.com/problems/NPC2014F","users":281,"accepted":37.99}
+{"id":21462,"name":"Final Assignment","url":"https://www.spoj.com/problems/NPC2014G","users":59,"accepted":25.18}
+{"id":21463,"name":"Arithmetic Rectangle","url":"https://www.spoj.com/problems/NPC2014H","users":36,"accepted":20.52}
+{"id":21524,"name":"Pattern Find","url":"https://www.spoj.com/problems/NAJPF","users":5040,"accepted":38.7}
+{"id":21525,"name":"Red John is Back","url":"https://www.spoj.com/problems/PPBRJB","users":317,"accepted":53.56}

--- a/tests/spoj/index/61.md
+++ b/tests/spoj/index/61.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 21057 | [Super Lucky Palindromes](https://www.spoj.com/problems/CTPLUCKY) | 33 | 27.59 |
+| 21058 | [Dirty Plates](https://www.spoj.com/problems/CTPDIRTY) | 27 | 32.65 |
+| 21061 | [Yet Another Subset Sum Problem](https://www.spoj.com/problems/YASSP) | 48 | 34.44 |
+| 21068 | [Popular](https://www.spoj.com/problems/TPCPPLAR) | 48 | 25.00 |
+| 21083 | [Lexicographically Smallest](https://www.spoj.com/problems/LEXSTR) | 250 | 33.20 |
+| 21085 | [Palindrome Merge](https://www.spoj.com/problems/TPCPALIN) | 35 | 28.24 |
+| 21092 | [DRAW TABLE](https://www.spoj.com/problems/FRMT) | 47 | 53.79 |
+| 21096 | [Word Counting 2](https://www.spoj.com/problems/WORDCNT2) | 175 | 29.70 |
+| 21104 | [Jarin Loves New Task](https://www.spoj.com/problems/JLNT) | 49 | 38.20 |
+| 21132 | [Palindromes](https://www.spoj.com/problems/APIO14_A) | 105 | 36.20 |
+| 21135 | [Distinct Viewpoints](https://www.spoj.com/problems/BFCC) | 2 | 23.08 |
+| 21155 | [Manoj and Fire](https://www.spoj.com/problems/MANJFIRE) | 25 | 21.16 |
+| 21169 | [Balanced base-3](https://www.spoj.com/problems/TAP2014B) | 519 | 52.53 |
+| 21170 | [Constellation of the parallelogram](https://www.spoj.com/problems/TAP2014C) | 92 | 26.64 |
+| 21171 | [Fractal domino](https://www.spoj.com/problems/TAP2014D) | 18 | 53.52 |
+| 21172 | [Erdos et al](https://www.spoj.com/problems/TAP2014E) | 141 | 36.84 |
+| 21173 | [String fertilization](https://www.spoj.com/problems/TAP2014F) | 61 | 41.89 |
+| 21174 | [Gallantry](https://www.spoj.com/problems/TAP2014G) | 397 | 51.22 |
+| 21175 | [Rush hour](https://www.spoj.com/problems/TAP2014H) | 145 | 41.81 |
+| 21176 | [Stapled intervals](https://www.spoj.com/problems/TAP2014I) | 51 | 58.86 |
+| 21177 | [Distracted judges](https://www.spoj.com/problems/TAP2014J) | 324 | 44.91 |
+| 21178 | [Encryption kit](https://www.spoj.com/problems/TAP2014K) | 56 | 29.58 |
+| 21187 | [Increasing Shortest Path](https://www.spoj.com/problems/ACPC13) | 34 | 20.25 |
+| 21193 | [Adjusting Ducks](https://www.spoj.com/problems/ADJDUCKS) | 67 | 31.82 |
+| 21284 | [Can You Make It Empty 3](https://www.spoj.com/problems/EMTY3) | 95 | 31.16 |
+| 21326 | [Akbar , The great](https://www.spoj.com/problems/AKBAR) | 2720 | 16.04 |
+| 21332 | [Pigeonhole Tower](https://www.spoj.com/problems/PHT) | 1755 | 35.68 |
+| 21347 | [Tulip And Numbers](https://www.spoj.com/problems/TULIPNUM) | 1035 | 21.40 |
+| 21352 | [Avantgarde and Bicycle](https://www.spoj.com/problems/CLZBICYC) | 29 | 42.50 |
+| 21353 | [Avantgarde and Doughnut](https://www.spoj.com/problems/CLZDOUGH) | 23 | 44.87 |
+| 21354 | [String Problem](https://www.spoj.com/problems/CLZSTRNG) | 28 | 33.33 |
+| 21356 | [Divisible Number Sum](https://www.spoj.com/problems/NAJ0001) | 51 | 17.82 |
+| 21357 | [Crucial Equation](https://www.spoj.com/problems/CEQU) | 6387 | 38.05 |
+| 21360 | [Suffix Equal Prefix](https://www.spoj.com/problems/SUFEQPRE) | 545 | 29.38 |
+| 21394 | [Ohani And The Series](https://www.spoj.com/problems/OHANISER) | 605 | 42.18 |
+| 21395 | [Ohani And Binary Search Tree](https://www.spoj.com/problems/OHANIBTR) | 130 | 36.05 |
+| 21396 | [Taklu Kuddus](https://www.spoj.com/problems/TKUDDUS) | 107 | 8.26 |
+| 21407 | [2x2 Subgrid Sum Problem (medium)](https://www.spoj.com/problems/GRIDSUM1) | 22 | 21.29 |
+| 21409 | [2x2 Subgrid Sum Problem (generalized)](https://www.spoj.com/problems/GRIDSUM3) | 6 | 17.02 |
+| 21414 | [Count The Indexes 2](https://www.spoj.com/problems/CNTINDX2) | 45 | 19.13 |
+| 21418 | [Interesting Game with Polygons](https://www.spoj.com/problems/HCT00001) | 36 | 28.02 |
+| 21456 | [I Ken Bit Yu](https://www.spoj.com/problems/NPC2014A) | 117 | 30.96 |
+| 21457 | [House Fence](https://www.spoj.com/problems/NPC2014B) | 158 | 28.32 |
+| 21458 | [Satay Skewer](https://www.spoj.com/problems/NPC2014C) | 84 | 27.94 |
+| 21460 | [Tresi and Girls](https://www.spoj.com/problems/NPC2014E) | 68 | 22.78 |
+| 21461 | [Field](https://www.spoj.com/problems/NPC2014F) | 281 | 37.99 |
+| 21462 | [Final Assignment](https://www.spoj.com/problems/NPC2014G) | 59 | 25.18 |
+| 21463 | [Arithmetic Rectangle](https://www.spoj.com/problems/NPC2014H) | 36 | 20.52 |
+| 21524 | [Pattern Find](https://www.spoj.com/problems/NAJPF) | 5040 | 38.70 |
+| 21525 | [Red John is Back](https://www.spoj.com/problems/PPBRJB) | 317 | 53.56 |

--- a/tests/spoj/index/62.jsonl
+++ b/tests/spoj/index/62.jsonl
@@ -1,0 +1,50 @@
+{"id":21526,"name":"Rotating Cube","url":"https://www.spoj.com/problems/PPBRQ","users":114,"accepted":52.67}
+{"id":21572,"name":"Marble \u0026 store","url":"https://www.spoj.com/problems/NAJMS","users":135,"accepted":19.58}
+{"id":21585,"name":"Hazzat’s Query","url":"https://www.spoj.com/problems/NAJHQ","users":79,"accepted":25.88}
+{"id":21597,"name":"The Hack","url":"https://www.spoj.com/problems/HACK14","users":21,"accepted":12.94}
+{"id":21599,"name":"POWER LEFT","url":"https://www.spoj.com/problems/KINJUTSU","users":113,"accepted":21.17}
+{"id":21615,"name":"Playing with GCD","url":"https://www.spoj.com/problems/NAJPWG","users":1033,"accepted":34.6}
+{"id":21616,"name":"Game of chocolate","url":"https://www.spoj.com/problems/NAJGC","users":588,"accepted":31.08}
+{"id":21635,"name":"Beautiful Mountains","url":"https://www.spoj.com/problems/MOUNTAIN","users":21,"accepted":32.99}
+{"id":21636,"name":"Electric Car Rally","url":"https://www.spoj.com/problems/CARRALLY","users":15,"accepted":44.9}
+{"id":21640,"name":"Nested Palindromes","url":"https://www.spoj.com/problems/NESPALIN","users":28,"accepted":17.99}
+{"id":21642,"name":"Tsunami","url":"https://www.spoj.com/problems/TSUNAMI","users":145,"accepted":40.88}
+{"id":21643,"name":"Unhappy Numbers","url":"https://www.spoj.com/problems/UNHAPPY","users":53,"accepted":37.91}
+{"id":21644,"name":"Walls","url":"https://www.spoj.com/problems/WALLSPRO","users":25,"accepted":16.92}
+{"id":21671,"name":"Jumppy and the Grid","url":"https://www.spoj.com/problems/JUMPPY","users":63,"accepted":33.1}
+{"id":21672,"name":"Frustrated CR and His Class","url":"https://www.spoj.com/problems/FRSCR","users":43,"accepted":27.69}
+{"id":21683,"name":"Bhagat and String","url":"https://www.spoj.com/problems/BGTSTR","users":30,"accepted":28.67}
+{"id":21690,"name":"Power the Power Up","url":"https://www.spoj.com/problems/POWERUP","users":516,"accepted":17.85}
+{"id":21692,"name":"CURD PRODUCERS","url":"https://www.spoj.com/problems/CURDPROD","users":535,"accepted":42.01}
+{"id":21751,"name":"Help the Heroes","url":"https://www.spoj.com/problems/DBALLZ","users":393,"accepted":32.32}
+{"id":21807,"name":"Path Finding In the Country","url":"https://www.spoj.com/problems/PFND","users":103,"accepted":38.6}
+{"id":21834,"name":"Sadde and His City","url":"https://www.spoj.com/problems/SACITY","users":45,"accepted":21.63}
+{"id":21853,"name":"Rivals","url":"https://www.spoj.com/problems/RIVALS","users":511,"accepted":33.85}
+{"id":21854,"name":"TEMPLE_RUN","url":"https://www.spoj.com/problems/TEMPLE01","users":34,"accepted":30.38}
+{"id":21858,"name":"Christmas is coming","url":"https://www.spoj.com/problems/QTGIFT3","users":29,"accepted":12.69}
+{"id":21861,"name":"I Love Strings","url":"https://www.spoj.com/problems/STRNGSLV","users":57,"accepted":18.37}
+{"id":21962,"name":"GREAT SWERC","url":"https://www.spoj.com/problems/SWERC14A","users":22,"accepted":57.78}
+{"id":21963,"name":"Flowery Trails","url":"https://www.spoj.com/problems/SWERC14B","users":47,"accepted":43.26}
+{"id":21964,"name":"Golf Bot","url":"https://www.spoj.com/problems/SWERC14C","users":85,"accepted":36.36}
+{"id":21965,"name":"Book Club","url":"https://www.spoj.com/problems/SWERC14D","users":33,"accepted":37.11}
+{"id":21966,"name":"Ricochet Robots","url":"https://www.spoj.com/problems/SWERC14E","users":26,"accepted":50}
+{"id":21967,"name":"City Park","url":"https://www.spoj.com/problems/SWERC14F","users":25,"accepted":39.56}
+{"id":21968,"name":"Playing with Geometry","url":"https://www.spoj.com/problems/SWERC14G","users":18,"accepted":61.29}
+{"id":21969,"name":"Money Transfers","url":"https://www.spoj.com/problems/SWERC14H","users":10,"accepted":21.67}
+{"id":21970,"name":"Safe Secret","url":"https://www.spoj.com/problems/SWERC14I","users":19,"accepted":32.2}
+{"id":21971,"name":"The Big Painting","url":"https://www.spoj.com/problems/SWERC14J","users":46,"accepted":22.07}
+{"id":22002,"name":"English","url":"https://www.spoj.com/problems/STRANG","users":18,"accepted":19.51}
+{"id":22037,"name":"Shortest Paths","url":"https://www.spoj.com/problems/SPATHS","users":28,"accepted":16.83}
+{"id":22086,"name":"Prime Power Test","url":"https://www.spoj.com/problems/PRIMEPOW","users":16,"accepted":13.58}
+{"id":22090,"name":"Prime Power Test (Hard)","url":"https://www.spoj.com/problems/PRIMPOW2","users":11,"accepted":19.14}
+{"id":22177,"name":"RajaRani","url":"https://www.spoj.com/problems/MARRIAGE","users":9,"accepted":8.33}
+{"id":22253,"name":"Distributing sweets","url":"https://www.spoj.com/problems/DSWEETS","users":109,"accepted":21.13}
+{"id":22268,"name":"Euler Totient Function Sieve","url":"https://www.spoj.com/problems/ETFS","users":404,"accepted":19.49}
+{"id":22269,"name":"Periodic function, trip 1","url":"https://www.spoj.com/problems/PERIOD1","users":19,"accepted":29.33}
+{"id":22270,"name":"Periodic function, trip 2","url":"https://www.spoj.com/problems/PERIOD2","users":38,"accepted":44.65}
+{"id":22271,"name":"Periodic function, trip 3","url":"https://www.spoj.com/problems/PERIOD3","users":13,"accepted":52.07}
+{"id":22274,"name":"Missing Side","url":"https://www.spoj.com/problems/CIRCIRC","users":94,"accepted":18.25}
+{"id":22275,"name":"Collecting Candies","url":"https://www.spoj.com/problems/GSCANDY","users":70,"accepted":28.34}
+{"id":22303,"name":"Mau-Mau","url":"https://www.spoj.com/problems/MAUMAU","users":78,"accepted":16.67}
+{"id":22315,"name":"Periodic function, trip 3 (easy)","url":"https://www.spoj.com/problems/PERIOD4","users":16,"accepted":25.71}
+{"id":22319,"name":"Polynomial Table","url":"https://www.spoj.com/problems/POLYTABL","users":11,"accepted":28.88}

--- a/tests/spoj/index/62.md
+++ b/tests/spoj/index/62.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 21526 | [Rotating Cube](https://www.spoj.com/problems/PPBRQ) | 114 | 52.67 |
+| 21572 | [Marble & store](https://www.spoj.com/problems/NAJMS) | 135 | 19.58 |
+| 21585 | [Hazzat’s Query](https://www.spoj.com/problems/NAJHQ) | 79 | 25.88 |
+| 21597 | [The Hack](https://www.spoj.com/problems/HACK14) | 21 | 12.94 |
+| 21599 | [POWER LEFT](https://www.spoj.com/problems/KINJUTSU) | 113 | 21.17 |
+| 21615 | [Playing with GCD](https://www.spoj.com/problems/NAJPWG) | 1033 | 34.60 |
+| 21616 | [Game of chocolate](https://www.spoj.com/problems/NAJGC) | 588 | 31.08 |
+| 21635 | [Beautiful Mountains](https://www.spoj.com/problems/MOUNTAIN) | 21 | 32.99 |
+| 21636 | [Electric Car Rally](https://www.spoj.com/problems/CARRALLY) | 15 | 44.90 |
+| 21640 | [Nested Palindromes](https://www.spoj.com/problems/NESPALIN) | 28 | 17.99 |
+| 21642 | [Tsunami](https://www.spoj.com/problems/TSUNAMI) | 145 | 40.88 |
+| 21643 | [Unhappy Numbers](https://www.spoj.com/problems/UNHAPPY) | 53 | 37.91 |
+| 21644 | [Walls](https://www.spoj.com/problems/WALLSPRO) | 25 | 16.92 |
+| 21671 | [Jumppy and the Grid](https://www.spoj.com/problems/JUMPPY) | 63 | 33.10 |
+| 21672 | [Frustrated CR and His Class](https://www.spoj.com/problems/FRSCR) | 43 | 27.69 |
+| 21683 | [Bhagat and String](https://www.spoj.com/problems/BGTSTR) | 30 | 28.67 |
+| 21690 | [Power the Power Up](https://www.spoj.com/problems/POWERUP) | 516 | 17.85 |
+| 21692 | [CURD PRODUCERS](https://www.spoj.com/problems/CURDPROD) | 535 | 42.01 |
+| 21751 | [Help the Heroes](https://www.spoj.com/problems/DBALLZ) | 393 | 32.32 |
+| 21807 | [Path Finding In the Country](https://www.spoj.com/problems/PFND) | 103 | 38.60 |
+| 21834 | [Sadde and His City](https://www.spoj.com/problems/SACITY) | 45 | 21.63 |
+| 21853 | [Rivals](https://www.spoj.com/problems/RIVALS) | 511 | 33.85 |
+| 21854 | [TEMPLE_RUN](https://www.spoj.com/problems/TEMPLE01) | 34 | 30.38 |
+| 21858 | [Christmas is coming](https://www.spoj.com/problems/QTGIFT3) | 29 | 12.69 |
+| 21861 | [I Love Strings](https://www.spoj.com/problems/STRNGSLV) | 57 | 18.37 |
+| 21962 | [GREAT SWERC](https://www.spoj.com/problems/SWERC14A) | 22 | 57.78 |
+| 21963 | [Flowery Trails](https://www.spoj.com/problems/SWERC14B) | 47 | 43.26 |
+| 21964 | [Golf Bot](https://www.spoj.com/problems/SWERC14C) | 85 | 36.36 |
+| 21965 | [Book Club](https://www.spoj.com/problems/SWERC14D) | 33 | 37.11 |
+| 21966 | [Ricochet Robots](https://www.spoj.com/problems/SWERC14E) | 26 | 50.00 |
+| 21967 | [City Park](https://www.spoj.com/problems/SWERC14F) | 25 | 39.56 |
+| 21968 | [Playing with Geometry](https://www.spoj.com/problems/SWERC14G) | 18 | 61.29 |
+| 21969 | [Money Transfers](https://www.spoj.com/problems/SWERC14H) | 10 | 21.67 |
+| 21970 | [Safe Secret](https://www.spoj.com/problems/SWERC14I) | 19 | 32.20 |
+| 21971 | [The Big Painting](https://www.spoj.com/problems/SWERC14J) | 46 | 22.07 |
+| 22002 | [English](https://www.spoj.com/problems/STRANG) | 18 | 19.51 |
+| 22037 | [Shortest Paths](https://www.spoj.com/problems/SPATHS) | 28 | 16.83 |
+| 22086 | [Prime Power Test](https://www.spoj.com/problems/PRIMEPOW) | 16 | 13.58 |
+| 22090 | [Prime Power Test (Hard)](https://www.spoj.com/problems/PRIMPOW2) | 11 | 19.14 |
+| 22177 | [RajaRani](https://www.spoj.com/problems/MARRIAGE) | 9 | 8.33 |
+| 22253 | [Distributing sweets](https://www.spoj.com/problems/DSWEETS) | 109 | 21.13 |
+| 22268 | [Euler Totient Function Sieve](https://www.spoj.com/problems/ETFS) | 404 | 19.49 |
+| 22269 | [Periodic function, trip 1](https://www.spoj.com/problems/PERIOD1) | 19 | 29.33 |
+| 22270 | [Periodic function, trip 2](https://www.spoj.com/problems/PERIOD2) | 38 | 44.65 |
+| 22271 | [Periodic function, trip 3](https://www.spoj.com/problems/PERIOD3) | 13 | 52.07 |
+| 22274 | [Missing Side](https://www.spoj.com/problems/CIRCIRC) | 94 | 18.25 |
+| 22275 | [Collecting Candies](https://www.spoj.com/problems/GSCANDY) | 70 | 28.34 |
+| 22303 | [Mau-Mau](https://www.spoj.com/problems/MAUMAU) | 78 | 16.67 |
+| 22315 | [Periodic function, trip 3 (easy)](https://www.spoj.com/problems/PERIOD4) | 16 | 25.71 |
+| 22319 | [Polynomial Table](https://www.spoj.com/problems/POLYTABL) | 11 | 28.88 |

--- a/tests/spoj/index/63.jsonl
+++ b/tests/spoj/index/63.jsonl
@@ -1,0 +1,50 @@
+{"id":22320,"name":"Polynomial Drawing","url":"https://www.spoj.com/problems/POLYDRAW","users":2,"accepted":9.52}
+{"id":22329,"name":"Chicks","url":"https://www.spoj.com/problems/CHICKEGG","users":98,"accepted":38.7}
+{"id":22331,"name":"Intersection Query","url":"https://www.spoj.com/problems/ZQUERY2","users":18,"accepted":19.85}
+{"id":22337,"name":"Stick values","url":"https://www.spoj.com/problems/BOBERT","users":130,"accepted":41.66}
+{"id":22343,"name":"Norma","url":"https://www.spoj.com/problems/NORMA2","users":256,"accepted":28.17}
+{"id":22366,"name":"Badminton Tournament - Easy","url":"https://www.spoj.com/problems/BAD","users":214,"accepted":35.8}
+{"id":22379,"name":"Mobile Company 2","url":"https://www.spoj.com/problems/SELLPHN2","users":73,"accepted":30.7}
+{"id":22382,"name":"Euler Totient Function Depth","url":"https://www.spoj.com/problems/ETFD","users":397,"accepted":37.11}
+{"id":22384,"name":"Saving Planet Bomber (Easy)","url":"https://www.spoj.com/problems/BOMBER1","users":46,"accepted":41.84}
+{"id":22393,"name":"KATHTHI","url":"https://www.spoj.com/problems/KATHTHI","users":2200,"accepted":33.36}
+{"id":22403,"name":"Divisors of factorial","url":"https://www.spoj.com/problems/DIVFACT","users":1984,"accepted":29.89}
+{"id":22412,"name":"Divisors of factorial (hard)","url":"https://www.spoj.com/problems/DIVFACT3","users":187,"accepted":46.46}
+{"id":22441,"name":"Black and White Tiles","url":"https://www.spoj.com/problems/TILE001","users":33,"accepted":22.94}
+{"id":22455,"name":"SUM OF PRODUCT","url":"https://www.spoj.com/problems/SUMPRO","users":1080,"accepted":17.7}
+{"id":22461,"name":"Smallest Number","url":"https://www.spoj.com/problems/SMALL","users":775,"accepted":27.58}
+{"id":22463,"name":"Smallest Number (medium)","url":"https://www.spoj.com/problems/SMALLM","users":70,"accepted":21.04}
+{"id":22528,"name":"Paths in a Tree","url":"https://www.spoj.com/problems/CQM1TREE","users":45,"accepted":26.64}
+{"id":22529,"name":"Dandiya Night and Violence","url":"https://www.spoj.com/problems/DANDVIOL","users":61,"accepted":37.24}
+{"id":22530,"name":"Tinku got a job","url":"https://www.spoj.com/problems/TINKUJOB","users":21,"accepted":20.92}
+{"id":22531,"name":"Yo Yo Jagdish Singh","url":"https://www.spoj.com/problems/YOYOCQM","users":115,"accepted":44.29}
+{"id":22532,"name":"Cool Problem","url":"https://www.spoj.com/problems/COOLPROB","users":21,"accepted":55.32}
+{"id":22534,"name":"Birthday Gift for SJ","url":"https://www.spoj.com/problems/PRJAN15B","users":151,"accepted":55.45}
+{"id":22535,"name":"String Play","url":"https://www.spoj.com/problems/PRJAN15C","users":46,"accepted":42.62}
+{"id":22549,"name":"Divisors of factorial (extreme)","url":"https://www.spoj.com/problems/DIVFACT4","users":95,"accepted":26.95}
+{"id":22552,"name":"Flow on Tree","url":"https://www.spoj.com/problems/PRJAN15E","users":45,"accepted":40.28}
+{"id":22553,"name":"Stack Overflow","url":"https://www.spoj.com/problems/PRJAN15F","users":136,"accepted":26.56}
+{"id":22554,"name":"Kingdom","url":"https://www.spoj.com/problems/PRJAN15G","users":41,"accepted":45.39}
+{"id":22560,"name":"Valid Path","url":"https://www.spoj.com/problems/RTREE2","users":67,"accepted":35.74}
+{"id":22561,"name":"Roger and tree III","url":"https://www.spoj.com/problems/RTREE3","users":32,"accepted":14.49}
+{"id":22675,"name":"A conjecture of Paul Erdős (hard)","url":"https://www.spoj.com/problems/PAUL2","users":5,"accepted":5.81}
+{"id":22740,"name":"Another Valentine Maze Game (1D)","url":"https://www.spoj.com/problems/AVMG1","users":44,"accepted":48.05}
+{"id":22741,"name":"Another Valentine Maze Game (2D)","url":"https://www.spoj.com/problems/AVMG2","users":11,"accepted":21.19}
+{"id":22766,"name":"Make Sets","url":"https://www.spoj.com/problems/MSET","users":33,"accepted":57.69}
+{"id":22774,"name":"Help Kejriwal","url":"https://www.spoj.com/problems/HK","users":33,"accepted":53.19}
+{"id":22776,"name":"Balika Vadhu and Alok Nath","url":"https://www.spoj.com/problems/BVAAN","users":1202,"accepted":33.53}
+{"id":22784,"name":"Pythagorean Triple Counting","url":"https://www.spoj.com/problems/PTC","users":39,"accepted":52.76}
+{"id":22804,"name":"Knapsack","url":"https://www.spoj.com/problems/KNPSACK","users":56,"accepted":30.87}
+{"id":23132,"name":"Travelling cost","url":"https://www.spoj.com/problems/TRVCOST","users":1645,"accepted":33.19}
+{"id":23134,"name":"Help Me Please!","url":"https://www.spoj.com/problems/DCEPC13F","users":33,"accepted":26.9}
+{"id":23147,"name":"The Ultimate Riddle","url":"https://www.spoj.com/problems/DCEPC13D","users":156,"accepted":37.27}
+{"id":23153,"name":"Equivalent Passwords","url":"https://www.spoj.com/problems/EQUIPASS","users":77,"accepted":36.16}
+{"id":23185,"name":"Pencil Game","url":"https://www.spoj.com/problems/VNACM14H","users":24,"accepted":28.44}
+{"id":23237,"name":"Feast Coins","url":"https://www.spoj.com/problems/FEAST","users":105,"accepted":41.93}
+{"id":23336,"name":"Make Triangle","url":"https://www.spoj.com/problems/TRNGL","users":90,"accepted":26.06}
+{"id":23350,"name":"Mineral Farm","url":"https://www.spoj.com/problems/MFARM","users":18,"accepted":20.13}
+{"id":23351,"name":"Hiccup And Lucky Dragons","url":"https://www.spoj.com/problems/HALD","users":19,"accepted":11.65}
+{"id":23383,"name":"ISOMORPH","url":"https://www.spoj.com/problems/EE4371","users":29,"accepted":43.52}
+{"id":23429,"name":"Grid Arithmetic","url":"https://www.spoj.com/problems/BYU15W_2","users":51,"accepted":43.57}
+{"id":23435,"name":"Game Calculator","url":"https://www.spoj.com/problems/BYU15W_4","users":1,"accepted":1.79}
+{"id":23492,"name":"One piece","url":"https://www.spoj.com/problems/QTDIVIDE","users":102,"accepted":32.67}

--- a/tests/spoj/index/63.md
+++ b/tests/spoj/index/63.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 22320 | [Polynomial Drawing](https://www.spoj.com/problems/POLYDRAW) | 2 | 9.52 |
+| 22329 | [Chicks](https://www.spoj.com/problems/CHICKEGG) | 98 | 38.70 |
+| 22331 | [Intersection Query](https://www.spoj.com/problems/ZQUERY2) | 18 | 19.85 |
+| 22337 | [Stick values](https://www.spoj.com/problems/BOBERT) | 130 | 41.66 |
+| 22343 | [Norma](https://www.spoj.com/problems/NORMA2) | 256 | 28.17 |
+| 22366 | [Badminton Tournament - Easy](https://www.spoj.com/problems/BAD) | 214 | 35.80 |
+| 22379 | [Mobile Company 2](https://www.spoj.com/problems/SELLPHN2) | 73 | 30.70 |
+| 22382 | [Euler Totient Function Depth](https://www.spoj.com/problems/ETFD) | 397 | 37.11 |
+| 22384 | [Saving Planet Bomber (Easy)](https://www.spoj.com/problems/BOMBER1) | 46 | 41.84 |
+| 22393 | [KATHTHI](https://www.spoj.com/problems/KATHTHI) | 2200 | 33.36 |
+| 22403 | [Divisors of factorial](https://www.spoj.com/problems/DIVFACT) | 1984 | 29.89 |
+| 22412 | [Divisors of factorial (hard)](https://www.spoj.com/problems/DIVFACT3) | 187 | 46.46 |
+| 22441 | [Black and White Tiles](https://www.spoj.com/problems/TILE001) | 33 | 22.94 |
+| 22455 | [SUM OF PRODUCT](https://www.spoj.com/problems/SUMPRO) | 1080 | 17.70 |
+| 22461 | [Smallest Number](https://www.spoj.com/problems/SMALL) | 775 | 27.58 |
+| 22463 | [Smallest Number (medium)](https://www.spoj.com/problems/SMALLM) | 70 | 21.04 |
+| 22528 | [Paths in a Tree](https://www.spoj.com/problems/CQM1TREE) | 45 | 26.64 |
+| 22529 | [Dandiya Night and Violence](https://www.spoj.com/problems/DANDVIOL) | 61 | 37.24 |
+| 22530 | [Tinku got a job](https://www.spoj.com/problems/TINKUJOB) | 21 | 20.92 |
+| 22531 | [Yo Yo Jagdish Singh](https://www.spoj.com/problems/YOYOCQM) | 115 | 44.29 |
+| 22532 | [Cool Problem](https://www.spoj.com/problems/COOLPROB) | 21 | 55.32 |
+| 22534 | [Birthday Gift for SJ](https://www.spoj.com/problems/PRJAN15B) | 151 | 55.45 |
+| 22535 | [String Play](https://www.spoj.com/problems/PRJAN15C) | 46 | 42.62 |
+| 22549 | [Divisors of factorial (extreme)](https://www.spoj.com/problems/DIVFACT4) | 95 | 26.95 |
+| 22552 | [Flow on Tree](https://www.spoj.com/problems/PRJAN15E) | 45 | 40.28 |
+| 22553 | [Stack Overflow](https://www.spoj.com/problems/PRJAN15F) | 136 | 26.56 |
+| 22554 | [Kingdom](https://www.spoj.com/problems/PRJAN15G) | 41 | 45.39 |
+| 22560 | [Valid Path](https://www.spoj.com/problems/RTREE2) | 67 | 35.74 |
+| 22561 | [Roger and tree III](https://www.spoj.com/problems/RTREE3) | 32 | 14.49 |
+| 22675 | [A conjecture of Paul Erdős (hard)](https://www.spoj.com/problems/PAUL2) | 5 | 5.81 |
+| 22740 | [Another Valentine Maze Game (1D)](https://www.spoj.com/problems/AVMG1) | 44 | 48.05 |
+| 22741 | [Another Valentine Maze Game (2D)](https://www.spoj.com/problems/AVMG2) | 11 | 21.19 |
+| 22766 | [Make Sets](https://www.spoj.com/problems/MSET) | 33 | 57.69 |
+| 22774 | [Help Kejriwal](https://www.spoj.com/problems/HK) | 33 | 53.19 |
+| 22776 | [Balika Vadhu and Alok Nath](https://www.spoj.com/problems/BVAAN) | 1202 | 33.53 |
+| 22784 | [Pythagorean Triple Counting](https://www.spoj.com/problems/PTC) | 39 | 52.76 |
+| 22804 | [Knapsack](https://www.spoj.com/problems/KNPSACK) | 56 | 30.87 |
+| 23132 | [Travelling cost](https://www.spoj.com/problems/TRVCOST) | 1645 | 33.19 |
+| 23134 | [Help Me Please!](https://www.spoj.com/problems/DCEPC13F) | 33 | 26.90 |
+| 23147 | [The Ultimate Riddle](https://www.spoj.com/problems/DCEPC13D) | 156 | 37.27 |
+| 23153 | [Equivalent Passwords](https://www.spoj.com/problems/EQUIPASS) | 77 | 36.16 |
+| 23185 | [Pencil Game](https://www.spoj.com/problems/VNACM14H) | 24 | 28.44 |
+| 23237 | [Feast Coins](https://www.spoj.com/problems/FEAST) | 105 | 41.93 |
+| 23336 | [Make Triangle](https://www.spoj.com/problems/TRNGL) | 90 | 26.06 |
+| 23350 | [Mineral Farm](https://www.spoj.com/problems/MFARM) | 18 | 20.13 |
+| 23351 | [Hiccup And Lucky Dragons](https://www.spoj.com/problems/HALD) | 19 | 11.65 |
+| 23383 | [ISOMORPH](https://www.spoj.com/problems/EE4371) | 29 | 43.52 |
+| 23429 | [Grid Arithmetic](https://www.spoj.com/problems/BYU15W_2) | 51 | 43.57 |
+| 23435 | [Game Calculator](https://www.spoj.com/problems/BYU15W_4) | 1 | 1.79 |
+| 23492 | [One piece](https://www.spoj.com/problems/QTDIVIDE) | 102 | 32.67 |

--- a/tests/spoj/index/64.jsonl
+++ b/tests/spoj/index/64.jsonl
@@ -1,0 +1,50 @@
+{"id":23507,"name":"Retrovirus","url":"https://www.spoj.com/problems/RETRO","users":94,"accepted":36.11}
+{"id":23511,"name":"Segfault","url":"https://www.spoj.com/problems/SEGFAULT","users":16,"accepted":11.93}
+{"id":23515,"name":"The Last String Bender","url":"https://www.spoj.com/problems/STAVATAR","users":138,"accepted":27.65}
+{"id":23516,"name":"One day with string","url":"https://www.spoj.com/problems/ODWS","users":238,"accepted":36.45}
+{"id":23530,"name":"Suffixes","url":"https://www.spoj.com/problems/SUFFIX","users":22,"accepted":19.01}
+{"id":23536,"name":"Front","url":"https://www.spoj.com/problems/FRONT","users":163,"accepted":26}
+{"id":23538,"name":"Carina","url":"https://www.spoj.com/problems/CARINA","users":21,"accepted":12.11}
+{"id":23539,"name":"Split","url":"https://www.spoj.com/problems/SPLITS","users":35,"accepted":13.84}
+{"id":23541,"name":"CWC-2015","url":"https://www.spoj.com/problems/CWC2015","users":152,"accepted":18.25}
+{"id":23737,"name":"Ogledala","url":"https://www.spoj.com/problems/OGLEDALA","users":54,"accepted":37.5}
+{"id":23742,"name":"Dolan and Nephews","url":"https://www.spoj.com/problems/CARDFLIP","users":55,"accepted":38.51}
+{"id":23772,"name":"Zamena","url":"https://www.spoj.com/problems/ZAMENA","users":57,"accepted":29.93}
+{"id":23776,"name":"K-Query Online","url":"https://www.spoj.com/problems/KQUERYO","users":2054,"accepted":40.12}
+{"id":23806,"name":"Yossy, The King of IRYUDAT","url":"https://www.spoj.com/problems/YOSSY","users":48,"accepted":5.51}
+{"id":23821,"name":"Magic Schools","url":"https://www.spoj.com/problems/HCMUS20A","users":29,"accepted":20.65}
+{"id":23842,"name":"Professor Farouk Question","url":"https://www.spoj.com/problems/PROFF","users":584,"accepted":33.76}
+{"id":23847,"name":"Acm Teams","url":"https://www.spoj.com/problems/ACMT","users":1667,"accepted":40.48}
+{"id":23861,"name":"Fingerprints","url":"https://www.spoj.com/problems/FINGP","users":269,"accepted":34.41}
+{"id":23875,"name":"Another Version of Inversion","url":"https://www.spoj.com/problems/DCEPC14A","users":71,"accepted":32.13}
+{"id":23877,"name":"The Long Pile Game","url":"https://www.spoj.com/problems/DCEPC14C","users":36,"accepted":25.38}
+{"id":23878,"name":"Finding GP","url":"https://www.spoj.com/problems/DCEPC14D","users":31,"accepted":46.58}
+{"id":23880,"name":"The Toy Store","url":"https://www.spoj.com/problems/DCEPC14F","users":19,"accepted":36.36}
+{"id":23881,"name":"God of Nim","url":"https://www.spoj.com/problems/DCEPC14G","users":205,"accepted":47.85}
+{"id":23882,"name":"Watchers On The Wall","url":"https://www.spoj.com/problems/DCEPC14H","users":32,"accepted":20.47}
+{"id":23925,"name":"Vitaliy and Pie","url":"https://www.spoj.com/problems/VAPI01","users":618,"accepted":42.21}
+{"id":23930,"name":"Overlapping Words","url":"https://www.spoj.com/problems/OVERLAP","users":28,"accepted":24.16}
+{"id":23938,"name":"Save the Scofield !!","url":"https://www.spoj.com/problems/UJ01","users":274,"accepted":32.04}
+{"id":23963,"name":"Easy Factorials","url":"https://www.spoj.com/problems/EASYFACT","users":118,"accepted":17.21}
+{"id":23969,"name":"Helping Jar Jar Binks","url":"https://www.spoj.com/problems/JARJAR","users":84,"accepted":21.95}
+{"id":23976,"name":"Mohib and series","url":"https://www.spoj.com/problems/MOHIB","users":1773,"accepted":47.07}
+{"id":24032,"name":"The art of tree numbers","url":"https://www.spoj.com/problems/TREENUM2","users":148,"accepted":29.1}
+{"id":24191,"name":"Eagle and Dogs","url":"https://www.spoj.com/problems/EAGLE1","users":674,"accepted":18.82}
+{"id":24247,"name":"Monkey King","url":"https://www.spoj.com/problems/MONKK","users":117,"accepted":21.08}
+{"id":24258,"name":"Fata7y Ya Warda!","url":"https://www.spoj.com/problems/DRUIDEOI","users":145,"accepted":34.3}
+{"id":24313,"name":"Kule","url":"https://www.spoj.com/problems/SIOKULE","users":20,"accepted":17.16}
+{"id":24689,"name":"Fibo and non fibo","url":"https://www.spoj.com/problems/POWFIB","users":317,"accepted":32.62}
+{"id":24730,"name":"Magical colorful cats (hard)","url":"https://www.spoj.com/problems/BLCATS","users":15,"accepted":25.53}
+{"id":24772,"name":"Manipulate Dwarfs","url":"https://www.spoj.com/problems/DWARFLOG","users":143,"accepted":30.95}
+{"id":24957,"name":"Petya Brother and Repairment of Roads","url":"https://www.spoj.com/problems/PETYABRO","users":174,"accepted":28.3}
+{"id":24979,"name":"She was in Love with BST","url":"https://www.spoj.com/problems/LOVEBIRDS","users":225,"accepted":43.69}
+{"id":24998,"name":"PLAYING WITH BITS","url":"https://www.spoj.com/problems/BITPLAY","users":796,"accepted":22}
+{"id":24999,"name":"1807","url":"https://www.spoj.com/problems/SMILEY1807","users":527,"accepted":38.37}
+{"id":25000,"name":"Checking cubes.","url":"https://www.spoj.com/problems/BOKAM143SOU","users":258,"accepted":47.71}
+{"id":25001,"name":"Red Blue Line Segments","url":"https://www.spoj.com/problems/CS345A1","users":319,"accepted":19.5}
+{"id":25015,"name":"Subsequences with modulo","url":"https://www.spoj.com/problems/KNMD","users":65,"accepted":21.26}
+{"id":25024,"name":"Nth Prime","url":"https://www.spoj.com/problems/NTHPRIME","users":114,"accepted":17.33}
+{"id":25048,"name":"Robot","url":"https://www.spoj.com/problems/ROOBOT","users":82,"accepted":25.91}
+{"id":25067,"name":"Fibonacci Polynomial","url":"https://www.spoj.com/problems/FIBPOL","users":238,"accepted":41.45}
+{"id":25131,"name":"Largest Odd Divisor","url":"https://www.spoj.com/problems/DOL","users":1438,"accepted":33.6}
+{"id":25144,"name":"Truncky Numbers","url":"https://www.spoj.com/problems/ADST01","users":349,"accepted":29.04}

--- a/tests/spoj/index/64.md
+++ b/tests/spoj/index/64.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 23507 | [Retrovirus](https://www.spoj.com/problems/RETRO) | 94 | 36.11 |
+| 23511 | [Segfault](https://www.spoj.com/problems/SEGFAULT) | 16 | 11.93 |
+| 23515 | [The Last String Bender](https://www.spoj.com/problems/STAVATAR) | 138 | 27.65 |
+| 23516 | [One day with string](https://www.spoj.com/problems/ODWS) | 238 | 36.45 |
+| 23530 | [Suffixes](https://www.spoj.com/problems/SUFFIX) | 22 | 19.01 |
+| 23536 | [Front](https://www.spoj.com/problems/FRONT) | 163 | 26.00 |
+| 23538 | [Carina](https://www.spoj.com/problems/CARINA) | 21 | 12.11 |
+| 23539 | [Split](https://www.spoj.com/problems/SPLITS) | 35 | 13.84 |
+| 23541 | [CWC-2015](https://www.spoj.com/problems/CWC2015) | 152 | 18.25 |
+| 23737 | [Ogledala](https://www.spoj.com/problems/OGLEDALA) | 54 | 37.50 |
+| 23742 | [Dolan and Nephews](https://www.spoj.com/problems/CARDFLIP) | 55 | 38.51 |
+| 23772 | [Zamena](https://www.spoj.com/problems/ZAMENA) | 57 | 29.93 |
+| 23776 | [K-Query Online](https://www.spoj.com/problems/KQUERYO) | 2054 | 40.12 |
+| 23806 | [Yossy, The King of IRYUDAT](https://www.spoj.com/problems/YOSSY) | 48 | 5.51 |
+| 23821 | [Magic Schools](https://www.spoj.com/problems/HCMUS20A) | 29 | 20.65 |
+| 23842 | [Professor Farouk Question](https://www.spoj.com/problems/PROFF) | 584 | 33.76 |
+| 23847 | [Acm Teams](https://www.spoj.com/problems/ACMT) | 1667 | 40.48 |
+| 23861 | [Fingerprints](https://www.spoj.com/problems/FINGP) | 269 | 34.41 |
+| 23875 | [Another Version of Inversion](https://www.spoj.com/problems/DCEPC14A) | 71 | 32.13 |
+| 23877 | [The Long Pile Game](https://www.spoj.com/problems/DCEPC14C) | 36 | 25.38 |
+| 23878 | [Finding GP](https://www.spoj.com/problems/DCEPC14D) | 31 | 46.58 |
+| 23880 | [The Toy Store](https://www.spoj.com/problems/DCEPC14F) | 19 | 36.36 |
+| 23881 | [God of Nim](https://www.spoj.com/problems/DCEPC14G) | 205 | 47.85 |
+| 23882 | [Watchers On The Wall](https://www.spoj.com/problems/DCEPC14H) | 32 | 20.47 |
+| 23925 | [Vitaliy and Pie](https://www.spoj.com/problems/VAPI01) | 618 | 42.21 |
+| 23930 | [Overlapping Words](https://www.spoj.com/problems/OVERLAP) | 28 | 24.16 |
+| 23938 | [Save the Scofield !!](https://www.spoj.com/problems/UJ01) | 274 | 32.04 |
+| 23963 | [Easy Factorials](https://www.spoj.com/problems/EASYFACT) | 118 | 17.21 |
+| 23969 | [Helping Jar Jar Binks](https://www.spoj.com/problems/JARJAR) | 84 | 21.95 |
+| 23976 | [Mohib and series](https://www.spoj.com/problems/MOHIB) | 1773 | 47.07 |
+| 24032 | [The art of tree numbers](https://www.spoj.com/problems/TREENUM2) | 148 | 29.10 |
+| 24191 | [Eagle and Dogs](https://www.spoj.com/problems/EAGLE1) | 674 | 18.82 |
+| 24247 | [Monkey King](https://www.spoj.com/problems/MONKK) | 117 | 21.08 |
+| 24258 | [Fata7y Ya Warda!](https://www.spoj.com/problems/DRUIDEOI) | 145 | 34.30 |
+| 24313 | [Kule](https://www.spoj.com/problems/SIOKULE) | 20 | 17.16 |
+| 24689 | [Fibo and non fibo](https://www.spoj.com/problems/POWFIB) | 317 | 32.62 |
+| 24730 | [Magical colorful cats (hard)](https://www.spoj.com/problems/BLCATS) | 15 | 25.53 |
+| 24772 | [Manipulate Dwarfs](https://www.spoj.com/problems/DWARFLOG) | 143 | 30.95 |
+| 24957 | [Petya Brother and Repairment of Roads](https://www.spoj.com/problems/PETYABRO) | 174 | 28.30 |
+| 24979 | [She was in Love with BST](https://www.spoj.com/problems/LOVEBIRDS) | 225 | 43.69 |
+| 24998 | [PLAYING WITH BITS](https://www.spoj.com/problems/BITPLAY) | 796 | 22.00 |
+| 24999 | [1807](https://www.spoj.com/problems/SMILEY1807) | 527 | 38.37 |
+| 25000 | [Checking cubes.](https://www.spoj.com/problems/BOKAM143SOU) | 258 | 47.71 |
+| 25001 | [Red Blue Line Segments](https://www.spoj.com/problems/CS345A1) | 319 | 19.50 |
+| 25015 | [Subsequences with modulo](https://www.spoj.com/problems/KNMD) | 65 | 21.26 |
+| 25024 | [Nth Prime](https://www.spoj.com/problems/NTHPRIME) | 114 | 17.33 |
+| 25048 | [Robot](https://www.spoj.com/problems/ROOBOT) | 82 | 25.91 |
+| 25067 | [Fibonacci Polynomial](https://www.spoj.com/problems/FIBPOL) | 238 | 41.45 |
+| 25131 | [Largest Odd Divisor](https://www.spoj.com/problems/DOL) | 1438 | 33.60 |
+| 25144 | [Truncky Numbers](https://www.spoj.com/problems/ADST01) | 349 | 29.04 |

--- a/tests/spoj/index/65.jsonl
+++ b/tests/spoj/index/65.jsonl
@@ -1,0 +1,50 @@
+{"id":25158,"name":"Star","url":"https://www.spoj.com/problems/STARSBC","users":314,"accepted":34.6}
+{"id":25176,"name":"Compare Substring","url":"https://www.spoj.com/problems/CMPSSTR","users":139,"accepted":44.15}
+{"id":25178,"name":"Elegant Permuted Sum","url":"https://www.spoj.com/problems/ELPESUM","users":139,"accepted":35.67}
+{"id":25179,"name":"Kaos","url":"https://www.spoj.com/problems/KAOS","users":280,"accepted":40.63}
+{"id":25180,"name":"Gyanbabas Admission Test","url":"https://www.spoj.com/problems/SUBPAL","users":81,"accepted":19.61}
+{"id":25182,"name":"Acceptable numbers","url":"https://www.spoj.com/problems/KBASEEN","users":64,"accepted":16.24}
+{"id":25214,"name":"Ohani And The Game","url":"https://www.spoj.com/problems/OHANIGAME","users":81,"accepted":19.43}
+{"id":25236,"name":"Defense of a kingdom 2","url":"https://www.spoj.com/problems/DEFKIN2","users":119,"accepted":45.51}
+{"id":25283,"name":"ChickenLove","url":"https://www.spoj.com/problems/FOODIES","users":192,"accepted":18.69}
+{"id":25309,"name":"Save Area 11","url":"https://www.spoj.com/problems/SVAREA11","users":128,"accepted":30.74}
+{"id":25311,"name":"Candies","url":"https://www.spoj.com/problems/ICANDIES","users":1096,"accepted":35.86}
+{"id":25334,"name":"Eefun Guessing Words","url":"https://www.spoj.com/problems/NPC2015A","users":386,"accepted":22.91}
+{"id":25335,"name":"Eefun the Accountant","url":"https://www.spoj.com/problems/NPC2015B","users":12,"accepted":17.09}
+{"id":25336,"name":"Eefun Plays Doto","url":"https://www.spoj.com/problems/NPC2015C","users":4,"accepted":8.74}
+{"id":25337,"name":"Eefun is not so Fun","url":"https://www.spoj.com/problems/NPC2015D","users":160,"accepted":30.7}
+{"id":25338,"name":"Eefun Plays LOL","url":"https://www.spoj.com/problems/NPC2015E","users":59,"accepted":12.15}
+{"id":25339,"name":"Eefun and Doors","url":"https://www.spoj.com/problems/NPC2015F","users":11,"accepted":25.76}
+{"id":25365,"name":"Hexagram","url":"https://www.spoj.com/problems/HEXGRAM","users":43,"accepted":46.34}
+{"id":25382,"name":"Meetings","url":"https://www.spoj.com/problems/MEETINGS","users":20,"accepted":17.87}
+{"id":25383,"name":"New Lottery Game","url":"https://www.spoj.com/problems/LOTGAME","users":50,"accepted":19.67}
+{"id":25384,"name":"Shuffles","url":"https://www.spoj.com/problems/SHUFFLES","users":47,"accepted":50}
+{"id":25393,"name":"Do It Wrong, Get It Right","url":"https://www.spoj.com/problems/DWRONG","users":58,"accepted":37.3}
+{"id":25396,"name":"A Terribly Grimm Problem","url":"https://www.spoj.com/problems/GRIMM","users":21,"accepted":30.1}
+{"id":25417,"name":"You Win!","url":"https://www.spoj.com/problems/YOUWIN","users":35,"accepted":35.16}
+{"id":25450,"name":"When Does The World End","url":"https://www.spoj.com/problems/PONY10","users":5,"accepted":4.27}
+{"id":25452,"name":"Teaching Hazard","url":"https://www.spoj.com/problems/BUD13TLB","users":11,"accepted":33.33}
+{"id":25458,"name":"Boxes","url":"https://www.spoj.com/problems/BUD13TLF","users":98,"accepted":38.02}
+{"id":25471,"name":"AM FM","url":"https://www.spoj.com/problems/TAP2015A","users":39,"accepted":12.33}
+{"id":25472,"name":"Good kg of Flauta bread","url":"https://www.spoj.com/problems/TAP2015B","users":80,"accepted":53.85}
+{"id":25473,"name":"CompuTenis reloaded","url":"https://www.spoj.com/problems/TAP2015C","users":245,"accepted":35.24}
+{"id":25474,"name":"Happiness for all","url":"https://www.spoj.com/problems/TAP2015D","users":107,"accepted":40.54}
+{"id":25475,"name":"Perfect packing","url":"https://www.spoj.com/problems/TAP2015E","users":15,"accepted":51.24}
+{"id":25476,"name":"Induced favoritism","url":"https://www.spoj.com/problems/TAP2015F","users":47,"accepted":29.65}
+{"id":25477,"name":"Generating alien DNA II","url":"https://www.spoj.com/problems/TAP2015G","users":35,"accepted":18.09}
+{"id":25478,"name":"Hugo s homework","url":"https://www.spoj.com/problems/TAP2015H","users":418,"accepted":49.08}
+{"id":25480,"name":"Invading aliens","url":"https://www.spoj.com/problems/TAP2015I","users":19,"accepted":18.35}
+{"id":25481,"name":"Game of stones II","url":"https://www.spoj.com/problems/TAP2015J","users":41,"accepted":20.93}
+{"id":25482,"name":"Kimetto Kipsang and Kipchoge","url":"https://www.spoj.com/problems/TAP2015K","users":44,"accepted":21.48}
+{"id":25528,"name":"LUTRIJA","url":"https://www.spoj.com/problems/LUTRIJA","users":8,"accepted":11.76}
+{"id":25584,"name":"Factorial Modulo","url":"https://www.spoj.com/problems/FCDC","users":425,"accepted":24.95}
+{"id":25585,"name":"Hablu Wants to Buy","url":"https://www.spoj.com/problems/HMBY","users":1000,"accepted":55.67}
+{"id":25684,"name":"Jolly Kingdom","url":"https://www.spoj.com/problems/JOLLYKINGDOM","users":17,"accepted":16.28}
+{"id":25690,"name":"Laser Beam","url":"https://www.spoj.com/problems/LASER_BEAM","users":75,"accepted":26.3}
+{"id":25728,"name":"One of the Simpsons symbols","url":"https://www.spoj.com/problems/NNUM","users":287,"accepted":67.24}
+{"id":25773,"name":"Bit Difference","url":"https://www.spoj.com/problems/BITDIFF","users":422,"accepted":34.92}
+{"id":25779,"name":"Cinema Conundrum","url":"https://www.spoj.com/problems/CINEMACON","users":124,"accepted":35.9}
+{"id":25780,"name":"Decreasing Number of Visible Box","url":"https://www.spoj.com/problems/VISIBLEBOX","users":253,"accepted":39.68}
+{"id":25782,"name":"Fury Road","url":"https://www.spoj.com/problems/FURYROAD","users":93,"accepted":44.93}
+{"id":25783,"name":"Highly Spiritual Baba","url":"https://www.spoj.com/problems/HIGHBABA","users":127,"accepted":31.99}
+{"id":25784,"name":"Bubble Sort","url":"https://www.spoj.com/problems/BUBBLESORT","users":742,"accepted":21.44}

--- a/tests/spoj/index/65.md
+++ b/tests/spoj/index/65.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 25158 | [Star](https://www.spoj.com/problems/STARSBC) | 314 | 34.60 |
+| 25176 | [Compare Substring](https://www.spoj.com/problems/CMPSSTR) | 139 | 44.15 |
+| 25178 | [Elegant Permuted Sum](https://www.spoj.com/problems/ELPESUM) | 139 | 35.67 |
+| 25179 | [Kaos](https://www.spoj.com/problems/KAOS) | 280 | 40.63 |
+| 25180 | [Gyanbabas Admission Test](https://www.spoj.com/problems/SUBPAL) | 81 | 19.61 |
+| 25182 | [Acceptable numbers](https://www.spoj.com/problems/KBASEEN) | 64 | 16.24 |
+| 25214 | [Ohani And The Game](https://www.spoj.com/problems/OHANIGAME) | 81 | 19.43 |
+| 25236 | [Defense of a kingdom 2](https://www.spoj.com/problems/DEFKIN2) | 119 | 45.51 |
+| 25283 | [ChickenLove](https://www.spoj.com/problems/FOODIES) | 192 | 18.69 |
+| 25309 | [Save Area 11](https://www.spoj.com/problems/SVAREA11) | 128 | 30.74 |
+| 25311 | [Candies](https://www.spoj.com/problems/ICANDIES) | 1096 | 35.86 |
+| 25334 | [Eefun Guessing Words](https://www.spoj.com/problems/NPC2015A) | 386 | 22.91 |
+| 25335 | [Eefun the Accountant](https://www.spoj.com/problems/NPC2015B) | 12 | 17.09 |
+| 25336 | [Eefun Plays Doto](https://www.spoj.com/problems/NPC2015C) | 4 | 8.74 |
+| 25337 | [Eefun is not so Fun](https://www.spoj.com/problems/NPC2015D) | 160 | 30.70 |
+| 25338 | [Eefun Plays LOL](https://www.spoj.com/problems/NPC2015E) | 59 | 12.15 |
+| 25339 | [Eefun and Doors](https://www.spoj.com/problems/NPC2015F) | 11 | 25.76 |
+| 25365 | [Hexagram](https://www.spoj.com/problems/HEXGRAM) | 43 | 46.34 |
+| 25382 | [Meetings](https://www.spoj.com/problems/MEETINGS) | 20 | 17.87 |
+| 25383 | [New Lottery Game](https://www.spoj.com/problems/LOTGAME) | 50 | 19.67 |
+| 25384 | [Shuffles](https://www.spoj.com/problems/SHUFFLES) | 47 | 50.00 |
+| 25393 | [Do It Wrong, Get It Right](https://www.spoj.com/problems/DWRONG) | 58 | 37.30 |
+| 25396 | [A Terribly Grimm Problem](https://www.spoj.com/problems/GRIMM) | 21 | 30.10 |
+| 25417 | [You Win!](https://www.spoj.com/problems/YOUWIN) | 35 | 35.16 |
+| 25450 | [When Does The World End](https://www.spoj.com/problems/PONY10) | 5 | 4.27 |
+| 25452 | [Teaching Hazard](https://www.spoj.com/problems/BUD13TLB) | 11 | 33.33 |
+| 25458 | [Boxes](https://www.spoj.com/problems/BUD13TLF) | 98 | 38.02 |
+| 25471 | [AM FM](https://www.spoj.com/problems/TAP2015A) | 39 | 12.33 |
+| 25472 | [Good kg of Flauta bread](https://www.spoj.com/problems/TAP2015B) | 80 | 53.85 |
+| 25473 | [CompuTenis reloaded](https://www.spoj.com/problems/TAP2015C) | 245 | 35.24 |
+| 25474 | [Happiness for all](https://www.spoj.com/problems/TAP2015D) | 107 | 40.54 |
+| 25475 | [Perfect packing](https://www.spoj.com/problems/TAP2015E) | 15 | 51.24 |
+| 25476 | [Induced favoritism](https://www.spoj.com/problems/TAP2015F) | 47 | 29.65 |
+| 25477 | [Generating alien DNA II](https://www.spoj.com/problems/TAP2015G) | 35 | 18.09 |
+| 25478 | [Hugo s homework](https://www.spoj.com/problems/TAP2015H) | 418 | 49.08 |
+| 25480 | [Invading aliens](https://www.spoj.com/problems/TAP2015I) | 19 | 18.35 |
+| 25481 | [Game of stones II](https://www.spoj.com/problems/TAP2015J) | 41 | 20.93 |
+| 25482 | [Kimetto Kipsang and Kipchoge](https://www.spoj.com/problems/TAP2015K) | 44 | 21.48 |
+| 25528 | [LUTRIJA](https://www.spoj.com/problems/LUTRIJA) | 8 | 11.76 |
+| 25584 | [Factorial Modulo](https://www.spoj.com/problems/FCDC) | 425 | 24.95 |
+| 25585 | [Hablu Wants to Buy](https://www.spoj.com/problems/HMBY) | 1000 | 55.67 |
+| 25684 | [Jolly Kingdom](https://www.spoj.com/problems/JOLLYKINGDOM) | 17 | 16.28 |
+| 25690 | [Laser Beam](https://www.spoj.com/problems/LASER_BEAM) | 75 | 26.30 |
+| 25728 | [One of the Simpsons symbols](https://www.spoj.com/problems/NNUM) | 287 | 67.24 |
+| 25773 | [Bit Difference](https://www.spoj.com/problems/BITDIFF) | 422 | 34.92 |
+| 25779 | [Cinema Conundrum](https://www.spoj.com/problems/CINEMACON) | 124 | 35.90 |
+| 25780 | [Decreasing Number of Visible Box](https://www.spoj.com/problems/VISIBLEBOX) | 253 | 39.68 |
+| 25782 | [Fury Road](https://www.spoj.com/problems/FURYROAD) | 93 | 44.93 |
+| 25783 | [Highly Spiritual Baba](https://www.spoj.com/problems/HIGHBABA) | 127 | 31.99 |
+| 25784 | [Bubble Sort](https://www.spoj.com/problems/BUBBLESORT) | 742 | 21.44 |

--- a/tests/spoj/index/66.jsonl
+++ b/tests/spoj/index/66.jsonl
@@ -1,0 +1,50 @@
+{"id":25785,"name":"Ecstasy","url":"https://www.spoj.com/problems/NECSTASY","users":68,"accepted":32}
+{"id":25789,"name":"Laser Maze","url":"https://www.spoj.com/problems/LASER","users":50,"accepted":52.8}
+{"id":25803,"name":"Help BTW","url":"https://www.spoj.com/problems/HELPBTW","users":131,"accepted":12.46}
+{"id":25810,"name":"Divisibility Test","url":"https://www.spoj.com/problems/MATNUM","users":63,"accepted":13.25}
+{"id":25818,"name":"NEKAMELEONI","url":"https://www.spoj.com/problems/NEKAMELEONI","users":15,"accepted":10.94}
+{"id":25819,"name":"DOMINO","url":"https://www.spoj.com/problems/DOMINO8","users":21,"accepted":27.78}
+{"id":25844,"name":"Find the max XOR value","url":"https://www.spoj.com/problems/MAXXOR","users":644,"accepted":59.48}
+{"id":25854,"name":"Palindrome Or Not","url":"https://www.spoj.com/problems/PLNDROME","users":339,"accepted":16.59}
+{"id":25862,"name":"Divisor Game","url":"https://www.spoj.com/problems/SIMPGAME","users":53,"accepted":17.72}
+{"id":25867,"name":"Divisible Fibonacci Numbers","url":"https://www.spoj.com/problems/DIVFIBS","users":210,"accepted":25.85}
+{"id":25889,"name":"Drawing Lines","url":"https://www.spoj.com/problems/DRWLNS","users":37,"accepted":22.09}
+{"id":25891,"name":"Peculiar Number","url":"https://www.spoj.com/problems/PCLNMBR","users":237,"accepted":41.69}
+{"id":25892,"name":"Palindrome in a Tree","url":"https://www.spoj.com/problems/PLNDTREE","users":155,"accepted":35.99}
+{"id":25893,"name":"Longest Perfect Increasing Subsequence","url":"https://www.spoj.com/problems/LPIS","users":700,"accepted":39.62}
+{"id":25924,"name":"Cricket Selection","url":"https://www.spoj.com/problems/CRICKDP","users":80,"accepted":25.62}
+{"id":25942,"name":"Ball sum","url":"https://www.spoj.com/problems/BALLSUM","users":1800,"accepted":35.19}
+{"id":25959,"name":"Next Lexicographically Greater Substring","url":"https://www.spoj.com/problems/NEXTLEX","users":49,"accepted":22.46}
+{"id":25960,"name":"Cat and Mouse I","url":"https://www.spoj.com/problems/CATMO1","users":61,"accepted":15.6}
+{"id":25962,"name":"Essay","url":"https://www.spoj.com/problems/ESSY","users":71,"accepted":32.78}
+{"id":25967,"name":"Social Network Community","url":"https://www.spoj.com/problems/SOCNETC","users":1030,"accepted":31.25}
+{"id":25977,"name":"Matrix","url":"https://www.spoj.com/problems/GSMATRIX","users":90,"accepted":37.22}
+{"id":26017,"name":"GCD OF MATRIX","url":"https://www.spoj.com/problems/GCDMAT","users":335,"accepted":41.45}
+{"id":26045,"name":"GCD OF MATRIX (hard)","url":"https://www.spoj.com/problems/GCDMAT2","users":139,"accepted":28.32}
+{"id":26054,"name":"BMW","url":"https://www.spoj.com/problems/MARYBMW","users":687,"accepted":16.39}
+{"id":26073,"name":"Counting Divisors","url":"https://www.spoj.com/problems/DIVCNT1","users":143,"accepted":25.84}
+{"id":26108,"name":"Trending GCD","url":"https://www.spoj.com/problems/TRENDGCD","users":160,"accepted":38.36}
+{"id":26119,"name":"Revenge of Arjuna","url":"https://www.spoj.com/problems/THEWAR","users":37,"accepted":36.96}
+{"id":26132,"name":"Sum the Decimal-part II","url":"https://www.spoj.com/problems/SUMDEC2","users":56,"accepted":39.29}
+{"id":26176,"name":"HARRY POTTER AND THE FORBIDDEN FOREST","url":"https://www.spoj.com/problems/HPFORF","users":87,"accepted":27.56}
+{"id":26179,"name":"Windy Cannon","url":"https://www.spoj.com/problems/JC15A","users":295,"accepted":36.11}
+{"id":26180,"name":"Folding Stick","url":"https://www.spoj.com/problems/JC15B","users":28,"accepted":55.17}
+{"id":26181,"name":"Walking Jumper","url":"https://www.spoj.com/problems/JC15C","users":5,"accepted":24.24}
+{"id":26182,"name":"Perfect Superstring","url":"https://www.spoj.com/problems/JC15D","users":11,"accepted":64.71}
+{"id":26183,"name":"Laser Beam 2.0","url":"https://www.spoj.com/problems/JC15E","users":4,"accepted":5.71}
+{"id":26184,"name":"Colorful Beads","url":"https://www.spoj.com/problems/JC15F","users":38,"accepted":37.12}
+{"id":26187,"name":"Captain Claw","url":"https://www.spoj.com/problems/CLAW","users":60,"accepted":23.64}
+{"id":26193,"name":"Lost and survived","url":"https://www.spoj.com/problems/LOSTNSURVIVED","users":840,"accepted":35.36}
+{"id":26194,"name":"The wit of Tenali Raman","url":"https://www.spoj.com/problems/TENALI","users":15,"accepted":23.48}
+{"id":26212,"name":"Keyur and Mohib Tree","url":"https://www.spoj.com/problems/MOHIBTREE","users":218,"accepted":40.63}
+{"id":26214,"name":"Pisano Factors","url":"https://www.spoj.com/problems/PFACTORS","users":27,"accepted":30.06}
+{"id":26257,"name":"detective sherlock holmes","url":"https://www.spoj.com/problems/DSH","users":217,"accepted":26.42}
+{"id":26301,"name":"Bits. Exponents and Gcd","url":"https://www.spoj.com/problems/TOUGH","users":160,"accepted":31.67}
+{"id":26305,"name":"Lights On!","url":"https://www.spoj.com/problems/TURNLT","users":323,"accepted":26.13}
+{"id":26306,"name":"Pointers","url":"https://www.spoj.com/problems/INC2015F","users":26,"accepted":33.33}
+{"id":26308,"name":"Get higher and higher","url":"https://www.spoj.com/problems/MAXI","users":145,"accepted":39.44}
+{"id":26314,"name":"Corn Headache","url":"https://www.spoj.com/problems/CORN","users":362,"accepted":35.04}
+{"id":26315,"name":"Crazy Smoker","url":"https://www.spoj.com/problems/CRZYSMKR","users":1353,"accepted":35.3}
+{"id":26319,"name":"I LOVE Kd-TREES","url":"https://www.spoj.com/problems/ILKQUERY","users":227,"accepted":41.62}
+{"id":26344,"name":"Related or not","url":"https://www.spoj.com/problems/NINJA1","users":369,"accepted":52.35}
+{"id":26345,"name":"PATHETIC STRINGS","url":"https://www.spoj.com/problems/NINJA2","users":75,"accepted":26.25}

--- a/tests/spoj/index/66.md
+++ b/tests/spoj/index/66.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 25785 | [Ecstasy](https://www.spoj.com/problems/NECSTASY) | 68 | 32.00 |
+| 25789 | [Laser Maze](https://www.spoj.com/problems/LASER) | 50 | 52.80 |
+| 25803 | [Help BTW](https://www.spoj.com/problems/HELPBTW) | 131 | 12.46 |
+| 25810 | [Divisibility Test](https://www.spoj.com/problems/MATNUM) | 63 | 13.25 |
+| 25818 | [NEKAMELEONI](https://www.spoj.com/problems/NEKAMELEONI) | 15 | 10.94 |
+| 25819 | [DOMINO](https://www.spoj.com/problems/DOMINO8) | 21 | 27.78 |
+| 25844 | [Find the max XOR value](https://www.spoj.com/problems/MAXXOR) | 644 | 59.48 |
+| 25854 | [Palindrome Or Not](https://www.spoj.com/problems/PLNDROME) | 339 | 16.59 |
+| 25862 | [Divisor Game](https://www.spoj.com/problems/SIMPGAME) | 53 | 17.72 |
+| 25867 | [Divisible Fibonacci Numbers](https://www.spoj.com/problems/DIVFIBS) | 210 | 25.85 |
+| 25889 | [Drawing Lines](https://www.spoj.com/problems/DRWLNS) | 37 | 22.09 |
+| 25891 | [Peculiar Number](https://www.spoj.com/problems/PCLNMBR) | 237 | 41.69 |
+| 25892 | [Palindrome in a Tree](https://www.spoj.com/problems/PLNDTREE) | 155 | 35.99 |
+| 25893 | [Longest Perfect Increasing Subsequence](https://www.spoj.com/problems/LPIS) | 700 | 39.62 |
+| 25924 | [Cricket Selection](https://www.spoj.com/problems/CRICKDP) | 80 | 25.62 |
+| 25942 | [Ball sum](https://www.spoj.com/problems/BALLSUM) | 1800 | 35.19 |
+| 25959 | [Next Lexicographically Greater Substring](https://www.spoj.com/problems/NEXTLEX) | 49 | 22.46 |
+| 25960 | [Cat and Mouse I](https://www.spoj.com/problems/CATMO1) | 61 | 15.60 |
+| 25962 | [Essay](https://www.spoj.com/problems/ESSY) | 71 | 32.78 |
+| 25967 | [Social Network Community](https://www.spoj.com/problems/SOCNETC) | 1030 | 31.25 |
+| 25977 | [Matrix](https://www.spoj.com/problems/GSMATRIX) | 90 | 37.22 |
+| 26017 | [GCD OF MATRIX](https://www.spoj.com/problems/GCDMAT) | 335 | 41.45 |
+| 26045 | [GCD OF MATRIX (hard)](https://www.spoj.com/problems/GCDMAT2) | 139 | 28.32 |
+| 26054 | [BMW](https://www.spoj.com/problems/MARYBMW) | 687 | 16.39 |
+| 26073 | [Counting Divisors](https://www.spoj.com/problems/DIVCNT1) | 143 | 25.84 |
+| 26108 | [Trending GCD](https://www.spoj.com/problems/TRENDGCD) | 160 | 38.36 |
+| 26119 | [Revenge of Arjuna](https://www.spoj.com/problems/THEWAR) | 37 | 36.96 |
+| 26132 | [Sum the Decimal-part II](https://www.spoj.com/problems/SUMDEC2) | 56 | 39.29 |
+| 26176 | [HARRY POTTER AND THE FORBIDDEN FOREST](https://www.spoj.com/problems/HPFORF) | 87 | 27.56 |
+| 26179 | [Windy Cannon](https://www.spoj.com/problems/JC15A) | 295 | 36.11 |
+| 26180 | [Folding Stick](https://www.spoj.com/problems/JC15B) | 28 | 55.17 |
+| 26181 | [Walking Jumper](https://www.spoj.com/problems/JC15C) | 5 | 24.24 |
+| 26182 | [Perfect Superstring](https://www.spoj.com/problems/JC15D) | 11 | 64.71 |
+| 26183 | [Laser Beam 2.0](https://www.spoj.com/problems/JC15E) | 4 | 5.71 |
+| 26184 | [Colorful Beads](https://www.spoj.com/problems/JC15F) | 38 | 37.12 |
+| 26187 | [Captain Claw](https://www.spoj.com/problems/CLAW) | 60 | 23.64 |
+| 26193 | [Lost and survived](https://www.spoj.com/problems/LOSTNSURVIVED) | 840 | 35.36 |
+| 26194 | [The wit of Tenali Raman](https://www.spoj.com/problems/TENALI) | 15 | 23.48 |
+| 26212 | [Keyur and Mohib Tree](https://www.spoj.com/problems/MOHIBTREE) | 218 | 40.63 |
+| 26214 | [Pisano Factors](https://www.spoj.com/problems/PFACTORS) | 27 | 30.06 |
+| 26257 | [detective sherlock holmes](https://www.spoj.com/problems/DSH) | 217 | 26.42 |
+| 26301 | [Bits. Exponents and Gcd](https://www.spoj.com/problems/TOUGH) | 160 | 31.67 |
+| 26305 | [Lights On!](https://www.spoj.com/problems/TURNLT) | 323 | 26.13 |
+| 26306 | [Pointers](https://www.spoj.com/problems/INC2015F) | 26 | 33.33 |
+| 26308 | [Get higher and higher](https://www.spoj.com/problems/MAXI) | 145 | 39.44 |
+| 26314 | [Corn Headache](https://www.spoj.com/problems/CORN) | 362 | 35.04 |
+| 26315 | [Crazy Smoker](https://www.spoj.com/problems/CRZYSMKR) | 1353 | 35.30 |
+| 26319 | [I LOVE Kd-TREES](https://www.spoj.com/problems/ILKQUERY) | 227 | 41.62 |
+| 26344 | [Related or not](https://www.spoj.com/problems/NINJA1) | 369 | 52.35 |
+| 26345 | [PATHETIC STRINGS](https://www.spoj.com/problems/NINJA2) | 75 | 26.25 |

--- a/tests/spoj/index/67.jsonl
+++ b/tests/spoj/index/67.jsonl
@@ -1,0 +1,50 @@
+{"id":26346,"name":"STUNNING GCD","url":"https://www.spoj.com/problems/NINJA3","users":646,"accepted":37.25}
+{"id":26347,"name":"HELP SHELDON","url":"https://www.spoj.com/problems/NINJA4","users":605,"accepted":40.39}
+{"id":26348,"name":"K NUMBERS","url":"https://www.spoj.com/problems/NINJA5","users":285,"accepted":38.44}
+{"id":26349,"name":"TRAVELLING DILEMMA","url":"https://www.spoj.com/problems/NINJA6","users":45,"accepted":27.42}
+{"id":26350,"name":"TWO SEQUENCES PROBLEM","url":"https://www.spoj.com/problems/NINJA7","users":271,"accepted":31.69}
+{"id":26352,"name":"George vs Kramer","url":"https://www.spoj.com/problems/NINJA8","users":54,"accepted":46.79}
+{"id":26368,"name":"Power and Mod","url":"https://www.spoj.com/problems/PWRANDMOD","users":271,"accepted":19.6}
+{"id":26385,"name":"Harish and his rooks puzzle","url":"https://www.spoj.com/problems/HARISH_PUZZLE","users":230,"accepted":32.39}
+{"id":26445,"name":"Alicias Afternoon Amble","url":"https://www.spoj.com/problems/AMBLE","users":189,"accepted":57.07}
+{"id":26450,"name":"Palindromic Primes (Hard)","url":"https://www.spoj.com/problems/PALPRIM","users":41,"accepted":25.37}
+{"id":26527,"name":"DIVSEQ","url":"https://www.spoj.com/problems/DIVSEQ","users":238,"accepted":46.49}
+{"id":26561,"name":"Pair Divisible 2","url":"https://www.spoj.com/problems/PAIRDIV2","users":20,"accepted":10.3}
+{"id":26575,"name":"Grand Reward","url":"https://www.spoj.com/problems/GR","users":435,"accepted":59.06}
+{"id":26607,"name":"CODER FIRST PROBLEM","url":"https://www.spoj.com/problems/CDRSANJ","users":1377,"accepted":56.54}
+{"id":26646,"name":"An easy Problem","url":"https://www.spoj.com/problems/ADDAP","users":69,"accepted":55.22}
+{"id":26647,"name":"Factorial and divisorss","url":"https://www.spoj.com/problems/FACTDIV","users":104,"accepted":47.29}
+{"id":26663,"name":"Theater shade in Berland","url":"https://www.spoj.com/problems/TAXI2","users":28,"accepted":11.96}
+{"id":26685,"name":"I Love Kd-Trees II","url":"https://www.spoj.com/problems/ILKQUERY2","users":135,"accepted":36.01}
+{"id":26695,"name":"Atul and Aastha Chronicles 2","url":"https://www.spoj.com/problems/AAC2","users":146,"accepted":37.89}
+{"id":26703,"name":"All about Sorting!","url":"https://www.spoj.com/problems/MINDIFF","users":87,"accepted":42.28}
+{"id":26705,"name":"Path Game","url":"https://www.spoj.com/problems/PATHGAME","users":92,"accepted":54.31}
+{"id":26706,"name":"Sort Machine","url":"https://www.spoj.com/problems/SORTMAC","users":215,"accepted":26.76}
+{"id":26719,"name":"Gutibazi","url":"https://www.spoj.com/problems/NUMPATH","users":498,"accepted":47.69}
+{"id":26721,"name":"I LOVE Kd-TREES III","url":"https://www.spoj.com/problems/ILKQUERYIII","users":83,"accepted":17.28}
+{"id":26743,"name":"Wonowon","url":"https://www.spoj.com/problems/WONOWON","users":148,"accepted":66.23}
+{"id":26744,"name":"Coverage","url":"https://www.spoj.com/problems/SERCOVERAGE","users":27,"accepted":36.94}
+{"id":26745,"name":"Grid","url":"https://www.spoj.com/problems/SERGRID","users":672,"accepted":33.11}
+{"id":26746,"name":"Gears","url":"https://www.spoj.com/problems/SERGEARS","users":44,"accepted":29.81}
+{"id":26771,"name":"Almost Prime Numbers Again","url":"https://www.spoj.com/problems/KPRIMESB","users":332,"accepted":19.58}
+{"id":26772,"name":"Lets Be An Anagrammatist","url":"https://www.spoj.com/problems/ANGRMTST","users":37,"accepted":12.9}
+{"id":26773,"name":"Secret Key","url":"https://www.spoj.com/problems/ICCSECRET","users":38,"accepted":56.94}
+{"id":26777,"name":"Mr. Ant \u0026 His Problem","url":"https://www.spoj.com/problems/ANTP","users":243,"accepted":35.32}
+{"id":26778,"name":"NO GCD","url":"https://www.spoj.com/problems/NGCD","users":105,"accepted":22.58}
+{"id":26788,"name":"Tiho Brdo","url":"https://www.spoj.com/problems/SHILL","users":34,"accepted":33.06}
+{"id":26790,"name":"Stockade","url":"https://www.spoj.com/problems/STO","users":47,"accepted":37.33}
+{"id":26799,"name":"Counter-Smack","url":"https://www.spoj.com/problems/COU","users":63,"accepted":20.65}
+{"id":26843,"name":"Who is the Best?","url":"https://www.spoj.com/problems/INS16F","users":10,"accepted":26.53}
+{"id":26845,"name":"Daenerys wants to Conquer","url":"https://www.spoj.com/problems/INS16H","users":10,"accepted":48.48}
+{"id":26893,"name":"Pristojba","url":"https://www.spoj.com/problems/PRISTOJBA","users":19,"accepted":14.89}
+{"id":26913,"name":"SUPER CELL","url":"https://www.spoj.com/problems/SCELL","users":37,"accepted":20.08}
+{"id":26914,"name":"Collecting Mango","url":"https://www.spoj.com/problems/CMG","users":743,"accepted":18.76}
+{"id":26916,"name":"Extremely Lagged Fibonacci","url":"https://www.spoj.com/problems/EXLAGFIB","users":31,"accepted":33.91}
+{"id":26928,"name":"The Crossover","url":"https://www.spoj.com/problems/CROSSOVER","users":105,"accepted":16.88}
+{"id":26952,"name":"Game Of Ones","url":"https://www.spoj.com/problems/GOO","users":1097,"accepted":40.38}
+{"id":26953,"name":"Kuchu the Bookworm","url":"https://www.spoj.com/problems/BOOKWORM","users":52,"accepted":13.79}
+{"id":26954,"name":"k Alternating Sum","url":"https://www.spoj.com/problems/KALTSUM","users":81,"accepted":31.75}
+{"id":26955,"name":"The Maximize Sum","url":"https://www.spoj.com/problems/TMSUM","users":261,"accepted":24.62}
+{"id":26958,"name":"Spaceship","url":"https://www.spoj.com/problems/SPACESHIP","users":34,"accepted":43.36}
+{"id":26978,"name":"Hofstadter–Conway 10000 dollar sequence","url":"https://www.spoj.com/problems/HC10000","users":11,"accepted":42.05}
+{"id":27000,"name":"Shoot and kill","url":"https://www.spoj.com/problems/BGSHOOT","users":336,"accepted":23.82}

--- a/tests/spoj/index/67.md
+++ b/tests/spoj/index/67.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 26346 | [STUNNING GCD](https://www.spoj.com/problems/NINJA3) | 646 | 37.25 |
+| 26347 | [HELP SHELDON](https://www.spoj.com/problems/NINJA4) | 605 | 40.39 |
+| 26348 | [K NUMBERS](https://www.spoj.com/problems/NINJA5) | 285 | 38.44 |
+| 26349 | [TRAVELLING DILEMMA](https://www.spoj.com/problems/NINJA6) | 45 | 27.42 |
+| 26350 | [TWO SEQUENCES PROBLEM](https://www.spoj.com/problems/NINJA7) | 271 | 31.69 |
+| 26352 | [George vs Kramer](https://www.spoj.com/problems/NINJA8) | 54 | 46.79 |
+| 26368 | [Power and Mod](https://www.spoj.com/problems/PWRANDMOD) | 271 | 19.60 |
+| 26385 | [Harish and his rooks puzzle](https://www.spoj.com/problems/HARISH_PUZZLE) | 230 | 32.39 |
+| 26445 | [Alicias Afternoon Amble](https://www.spoj.com/problems/AMBLE) | 189 | 57.07 |
+| 26450 | [Palindromic Primes (Hard)](https://www.spoj.com/problems/PALPRIM) | 41 | 25.37 |
+| 26527 | [DIVSEQ](https://www.spoj.com/problems/DIVSEQ) | 238 | 46.49 |
+| 26561 | [Pair Divisible 2](https://www.spoj.com/problems/PAIRDIV2) | 20 | 10.30 |
+| 26575 | [Grand Reward](https://www.spoj.com/problems/GR) | 435 | 59.06 |
+| 26607 | [CODER FIRST PROBLEM](https://www.spoj.com/problems/CDRSANJ) | 1377 | 56.54 |
+| 26646 | [An easy Problem](https://www.spoj.com/problems/ADDAP) | 69 | 55.22 |
+| 26647 | [Factorial and divisorss](https://www.spoj.com/problems/FACTDIV) | 104 | 47.29 |
+| 26663 | [Theater shade in Berland](https://www.spoj.com/problems/TAXI2) | 28 | 11.96 |
+| 26685 | [I Love Kd-Trees II](https://www.spoj.com/problems/ILKQUERY2) | 135 | 36.01 |
+| 26695 | [Atul and Aastha Chronicles 2](https://www.spoj.com/problems/AAC2) | 146 | 37.89 |
+| 26703 | [All about Sorting!](https://www.spoj.com/problems/MINDIFF) | 87 | 42.28 |
+| 26705 | [Path Game](https://www.spoj.com/problems/PATHGAME) | 92 | 54.31 |
+| 26706 | [Sort Machine](https://www.spoj.com/problems/SORTMAC) | 215 | 26.76 |
+| 26719 | [Gutibazi](https://www.spoj.com/problems/NUMPATH) | 498 | 47.69 |
+| 26721 | [I LOVE Kd-TREES III](https://www.spoj.com/problems/ILKQUERYIII) | 83 | 17.28 |
+| 26743 | [Wonowon](https://www.spoj.com/problems/WONOWON) | 148 | 66.23 |
+| 26744 | [Coverage](https://www.spoj.com/problems/SERCOVERAGE) | 27 | 36.94 |
+| 26745 | [Grid](https://www.spoj.com/problems/SERGRID) | 672 | 33.11 |
+| 26746 | [Gears](https://www.spoj.com/problems/SERGEARS) | 44 | 29.81 |
+| 26771 | [Almost Prime Numbers Again](https://www.spoj.com/problems/KPRIMESB) | 332 | 19.58 |
+| 26772 | [Lets Be An Anagrammatist](https://www.spoj.com/problems/ANGRMTST) | 37 | 12.90 |
+| 26773 | [Secret Key](https://www.spoj.com/problems/ICCSECRET) | 38 | 56.94 |
+| 26777 | [Mr. Ant & His Problem](https://www.spoj.com/problems/ANTP) | 243 | 35.32 |
+| 26778 | [NO GCD](https://www.spoj.com/problems/NGCD) | 105 | 22.58 |
+| 26788 | [Tiho Brdo](https://www.spoj.com/problems/SHILL) | 34 | 33.06 |
+| 26790 | [Stockade](https://www.spoj.com/problems/STO) | 47 | 37.33 |
+| 26799 | [Counter-Smack](https://www.spoj.com/problems/COU) | 63 | 20.65 |
+| 26843 | [Who is the Best?](https://www.spoj.com/problems/INS16F) | 10 | 26.53 |
+| 26845 | [Daenerys wants to Conquer](https://www.spoj.com/problems/INS16H) | 10 | 48.48 |
+| 26893 | [Pristojba](https://www.spoj.com/problems/PRISTOJBA) | 19 | 14.89 |
+| 26913 | [SUPER CELL](https://www.spoj.com/problems/SCELL) | 37 | 20.08 |
+| 26914 | [Collecting Mango](https://www.spoj.com/problems/CMG) | 743 | 18.76 |
+| 26916 | [Extremely Lagged Fibonacci](https://www.spoj.com/problems/EXLAGFIB) | 31 | 33.91 |
+| 26928 | [The Crossover](https://www.spoj.com/problems/CROSSOVER) | 105 | 16.88 |
+| 26952 | [Game Of Ones](https://www.spoj.com/problems/GOO) | 1097 | 40.38 |
+| 26953 | [Kuchu the Bookworm](https://www.spoj.com/problems/BOOKWORM) | 52 | 13.79 |
+| 26954 | [k Alternating Sum](https://www.spoj.com/problems/KALTSUM) | 81 | 31.75 |
+| 26955 | [The Maximize Sum](https://www.spoj.com/problems/TMSUM) | 261 | 24.62 |
+| 26958 | [Spaceship](https://www.spoj.com/problems/SPACESHIP) | 34 | 43.36 |
+| 26978 | [Hofstadter–Conway 10000 dollar sequence](https://www.spoj.com/problems/HC10000) | 11 | 42.05 |
+| 27000 | [Shoot and kill](https://www.spoj.com/problems/BGSHOOT) | 336 | 23.82 |

--- a/tests/spoj/index/68.jsonl
+++ b/tests/spoj/index/68.jsonl
@@ -1,0 +1,50 @@
+{"id":27039,"name":"Assembly line","url":"https://www.spoj.com/problems/EIUASSEMBLY","users":553,"accepted":25.21}
+{"id":27092,"name":"Balanced Diet","url":"https://www.spoj.com/problems/FN16DIET","users":16,"accepted":22.89}
+{"id":27093,"name":"Branch Assignment","url":"https://www.spoj.com/problems/FN16ASGN","users":29,"accepted":39.58}
+{"id":27094,"name":"Ceiling Function","url":"https://www.spoj.com/problems/FN16CEIL","users":149,"accepted":44.52}
+{"id":27095,"name":"Clock Breaking","url":"https://www.spoj.com/problems/FN16CLK","users":21,"accepted":58.7}
+{"id":27096,"name":"Forever Young","url":"https://www.spoj.com/problems/FN16BASE","users":33,"accepted":23.81}
+{"id":27097,"name":"Longest Rivers","url":"https://www.spoj.com/problems/FN16RIVER","users":9,"accepted":16.46}
+{"id":27098,"name":"Oil","url":"https://www.spoj.com/problems/FN16OIL","users":88,"accepted":26.84}
+{"id":27099,"name":"Road Times","url":"https://www.spoj.com/problems/FN16ROAD","users":7,"accepted":32.5}
+{"id":27101,"name":"String Theory","url":"https://www.spoj.com/problems/FN16QUOT","users":28,"accepted":31.37}
+{"id":27102,"name":"Swap Space","url":"https://www.spoj.com/problems/FN16SWAP","users":129,"accepted":38.77}
+{"id":27103,"name":"What Really Happened on Mars?","url":"https://www.spoj.com/problems/FN16MARS","users":10,"accepted":38.46}
+{"id":27194,"name":"Summer Trip","url":"https://www.spoj.com/problems/IAPCR2F","users":221,"accepted":23.98}
+{"id":27195,"name":"Find The Number","url":"https://www.spoj.com/problems/IAPCR2D","users":217,"accepted":37.66}
+{"id":27196,"name":"Study Room","url":"https://www.spoj.com/problems/IAPCR2C","users":443,"accepted":52.27}
+{"id":27198,"name":"Ballons Revisited","url":"https://www.spoj.com/problems/IAPCR2E","users":99,"accepted":21.33}
+{"id":27213,"name":"Periodic function, trip 5","url":"https://www.spoj.com/problems/PERIOD5","users":11,"accepted":55.58}
+{"id":27217,"name":"Minimum Sum","url":"https://www.spoj.com/problems/SQRMINSUM","users":189,"accepted":41.37}
+{"id":27218,"name":"Segmentation","url":"https://www.spoj.com/problems/HJB","users":35,"accepted":41.5}
+{"id":27219,"name":"Time for Revenge","url":"https://www.spoj.com/problems/MOWGLI","users":74,"accepted":32.76}
+{"id":27225,"name":"Knight Move","url":"https://www.spoj.com/problems/KNMOVE","users":465,"accepted":30.07}
+{"id":27234,"name":"Sums of 2 and 3","url":"https://www.spoj.com/problems/ORDSUM23","users":971,"accepted":35.89}
+{"id":27248,"name":"Funny Modular Sequence","url":"https://www.spoj.com/problems/FUNMODSEQ","users":84,"accepted":35.36}
+{"id":27261,"name":"Matrices with XOR property","url":"https://www.spoj.com/problems/VECTAR1","users":68,"accepted":20.91}
+{"id":27267,"name":"Changus Final Battle","url":"https://www.spoj.com/problems/VECTAR4","users":266,"accepted":54.72}
+{"id":27268,"name":"Count Subsets","url":"https://www.spoj.com/problems/VECTAR5","users":221,"accepted":45.57}
+{"id":27269,"name":"Cube Numbers","url":"https://www.spoj.com/problems/CUBNUM","users":615,"accepted":30.99}
+{"id":27301,"name":"2D arrays with XOR property","url":"https://www.spoj.com/problems/XORRAY","users":18,"accepted":32}
+{"id":27303,"name":"Count Doubles","url":"https://www.spoj.com/problems/CNTDO","users":629,"accepted":34.48}
+{"id":27307,"name":"Alternating Sequences","url":"https://www.spoj.com/problems/ALTSEQ","users":2123,"accepted":32.6}
+{"id":27308,"name":"One more weird game","url":"https://www.spoj.com/problems/OMWG","users":402,"accepted":55.38}
+{"id":27313,"name":"Number of Binary Trees","url":"https://www.spoj.com/problems/VECTAR6","users":80,"accepted":45.73}
+{"id":27317,"name":"Number of score sequences","url":"https://www.spoj.com/problems/VECTAR7","users":84,"accepted":48.54}
+{"id":27318,"name":"Primal Fear","url":"https://www.spoj.com/problems/VECTAR8","users":1738,"accepted":21.96}
+{"id":27319,"name":"Mangu Numbers","url":"https://www.spoj.com/problems/VECTAR9","users":115,"accepted":36.08}
+{"id":27320,"name":"Card Game","url":"https://www.spoj.com/problems/VECTAR10","users":359,"accepted":38.8}
+{"id":27321,"name":"Increasing numbers","url":"https://www.spoj.com/problems/NDS","users":584,"accepted":23.8}
+{"id":27337,"name":"LIS and tree","url":"https://www.spoj.com/problems/LISTREE","users":42,"accepted":29.06}
+{"id":27339,"name":"Queue of Soldiers","url":"https://www.spoj.com/problems/AR2015PE","users":16,"accepted":44.23}
+{"id":27340,"name":"Terrorists","url":"https://www.spoj.com/problems/AR2015PC","users":21,"accepted":23.49}
+{"id":27341,"name":"Jumping Joey","url":"https://www.spoj.com/problems/AR2015PF","users":6,"accepted":18.42}
+{"id":27342,"name":"Automatic Scholarship Calculation","url":"https://www.spoj.com/problems/AR2015PH","users":18,"accepted":44.62}
+{"id":27367,"name":"Game of Squares","url":"https://www.spoj.com/problems/VECTAR11","users":464,"accepted":40.73}
+{"id":27369,"name":"Gupta ji Birthday !!","url":"https://www.spoj.com/problems/SHUB1307","users":128,"accepted":32.68}
+{"id":27375,"name":"Garden of Mangu","url":"https://www.spoj.com/problems/VECTAR12","users":87,"accepted":46.18}
+{"id":27377,"name":"Bono v3","url":"https://www.spoj.com/problems/BLBONO","users":65,"accepted":20.93}
+{"id":27378,"name":"Legend of Heta","url":"https://www.spoj.com/problems/BLHETA","users":69,"accepted":18.56}
+{"id":27379,"name":"Unique Code","url":"https://www.spoj.com/problems/BLUNIQ","users":130,"accepted":19.74}
+{"id":27380,"name":"Painting Hat","url":"https://www.spoj.com/problems/BLCONE","users":257,"accepted":47.7}
+{"id":27381,"name":"Emoticon","url":"https://www.spoj.com/problems/BLKEK","users":862,"accepted":49.81}

--- a/tests/spoj/index/68.md
+++ b/tests/spoj/index/68.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 27039 | [Assembly line](https://www.spoj.com/problems/EIUASSEMBLY) | 553 | 25.21 |
+| 27092 | [Balanced Diet](https://www.spoj.com/problems/FN16DIET) | 16 | 22.89 |
+| 27093 | [Branch Assignment](https://www.spoj.com/problems/FN16ASGN) | 29 | 39.58 |
+| 27094 | [Ceiling Function](https://www.spoj.com/problems/FN16CEIL) | 149 | 44.52 |
+| 27095 | [Clock Breaking](https://www.spoj.com/problems/FN16CLK) | 21 | 58.70 |
+| 27096 | [Forever Young](https://www.spoj.com/problems/FN16BASE) | 33 | 23.81 |
+| 27097 | [Longest Rivers](https://www.spoj.com/problems/FN16RIVER) | 9 | 16.46 |
+| 27098 | [Oil](https://www.spoj.com/problems/FN16OIL) | 88 | 26.84 |
+| 27099 | [Road Times](https://www.spoj.com/problems/FN16ROAD) | 7 | 32.50 |
+| 27101 | [String Theory](https://www.spoj.com/problems/FN16QUOT) | 28 | 31.37 |
+| 27102 | [Swap Space](https://www.spoj.com/problems/FN16SWAP) | 129 | 38.77 |
+| 27103 | [What Really Happened on Mars?](https://www.spoj.com/problems/FN16MARS) | 10 | 38.46 |
+| 27194 | [Summer Trip](https://www.spoj.com/problems/IAPCR2F) | 221 | 23.98 |
+| 27195 | [Find The Number](https://www.spoj.com/problems/IAPCR2D) | 217 | 37.66 |
+| 27196 | [Study Room](https://www.spoj.com/problems/IAPCR2C) | 443 | 52.27 |
+| 27198 | [Ballons Revisited](https://www.spoj.com/problems/IAPCR2E) | 99 | 21.33 |
+| 27213 | [Periodic function, trip 5](https://www.spoj.com/problems/PERIOD5) | 11 | 55.58 |
+| 27217 | [Minimum Sum](https://www.spoj.com/problems/SQRMINSUM) | 189 | 41.37 |
+| 27218 | [Segmentation](https://www.spoj.com/problems/HJB) | 35 | 41.50 |
+| 27219 | [Time for Revenge](https://www.spoj.com/problems/MOWGLI) | 74 | 32.76 |
+| 27225 | [Knight Move](https://www.spoj.com/problems/KNMOVE) | 465 | 30.07 |
+| 27234 | [Sums of 2 and 3](https://www.spoj.com/problems/ORDSUM23) | 971 | 35.89 |
+| 27248 | [Funny Modular Sequence](https://www.spoj.com/problems/FUNMODSEQ) | 84 | 35.36 |
+| 27261 | [Matrices with XOR property](https://www.spoj.com/problems/VECTAR1) | 68 | 20.91 |
+| 27267 | [Changus Final Battle](https://www.spoj.com/problems/VECTAR4) | 266 | 54.72 |
+| 27268 | [Count Subsets](https://www.spoj.com/problems/VECTAR5) | 221 | 45.57 |
+| 27269 | [Cube Numbers](https://www.spoj.com/problems/CUBNUM) | 615 | 30.99 |
+| 27301 | [2D arrays with XOR property](https://www.spoj.com/problems/XORRAY) | 18 | 32.00 |
+| 27303 | [Count Doubles](https://www.spoj.com/problems/CNTDO) | 629 | 34.48 |
+| 27307 | [Alternating Sequences](https://www.spoj.com/problems/ALTSEQ) | 2123 | 32.60 |
+| 27308 | [One more weird game](https://www.spoj.com/problems/OMWG) | 402 | 55.38 |
+| 27313 | [Number of Binary Trees](https://www.spoj.com/problems/VECTAR6) | 80 | 45.73 |
+| 27317 | [Number of score sequences](https://www.spoj.com/problems/VECTAR7) | 84 | 48.54 |
+| 27318 | [Primal Fear](https://www.spoj.com/problems/VECTAR8) | 1738 | 21.96 |
+| 27319 | [Mangu Numbers](https://www.spoj.com/problems/VECTAR9) | 115 | 36.08 |
+| 27320 | [Card Game](https://www.spoj.com/problems/VECTAR10) | 359 | 38.80 |
+| 27321 | [Increasing numbers](https://www.spoj.com/problems/NDS) | 584 | 23.80 |
+| 27337 | [LIS and tree](https://www.spoj.com/problems/LISTREE) | 42 | 29.06 |
+| 27339 | [Queue of Soldiers](https://www.spoj.com/problems/AR2015PE) | 16 | 44.23 |
+| 27340 | [Terrorists](https://www.spoj.com/problems/AR2015PC) | 21 | 23.49 |
+| 27341 | [Jumping Joey](https://www.spoj.com/problems/AR2015PF) | 6 | 18.42 |
+| 27342 | [Automatic Scholarship Calculation](https://www.spoj.com/problems/AR2015PH) | 18 | 44.62 |
+| 27367 | [Game of Squares](https://www.spoj.com/problems/VECTAR11) | 464 | 40.73 |
+| 27369 | [Gupta ji Birthday !!](https://www.spoj.com/problems/SHUB1307) | 128 | 32.68 |
+| 27375 | [Garden of Mangu](https://www.spoj.com/problems/VECTAR12) | 87 | 46.18 |
+| 27377 | [Bono v3](https://www.spoj.com/problems/BLBONO) | 65 | 20.93 |
+| 27378 | [Legend of Heta](https://www.spoj.com/problems/BLHETA) | 69 | 18.56 |
+| 27379 | [Unique Code](https://www.spoj.com/problems/BLUNIQ) | 130 | 19.74 |
+| 27380 | [Painting Hat](https://www.spoj.com/problems/BLCONE) | 257 | 47.70 |
+| 27381 | [Emoticon](https://www.spoj.com/problems/BLKEK) | 862 | 49.81 |

--- a/tests/spoj/index/69.jsonl
+++ b/tests/spoj/index/69.jsonl
@@ -1,0 +1,50 @@
+{"id":27429,"name":"Changu Mangu in a Football Team","url":"https://www.spoj.com/problems/VECTAR13","users":83,"accepted":20.19}
+{"id":27433,"name":"Divisible Fibonacci Numbers","url":"https://www.spoj.com/problems/DIVFIBS2","users":29,"accepted":29.33}
+{"id":27450,"name":"Changu with subsequences","url":"https://www.spoj.com/problems/VECTAR14","users":38,"accepted":36.31}
+{"id":27483,"name":"Counting Words","url":"https://www.spoj.com/problems/REDRONESIA","users":49,"accepted":49.6}
+{"id":27484,"name":"Zeros in Fibonacci period","url":"https://www.spoj.com/problems/Z124","users":14,"accepted":39.08}
+{"id":27487,"name":"Police Men","url":"https://www.spoj.com/problems/POLICEMEN","users":307,"accepted":44.15}
+{"id":27491,"name":"Bidding Game","url":"https://www.spoj.com/problems/BIDGAME","users":10,"accepted":27.84}
+{"id":27493,"name":"Even Frequency","url":"https://www.spoj.com/problems/EVENFRQ","users":72,"accepted":29.59}
+{"id":27494,"name":"Happiness","url":"https://www.spoj.com/problems/HAPPINESS","users":9,"accepted":14.78}
+{"id":27496,"name":"Again Eid Salami","url":"https://www.spoj.com/problems/EIDSALAMI2","users":129,"accepted":45.61}
+{"id":27497,"name":"Binary Protean Number","url":"https://www.spoj.com/problems/BINPRNUM","users":144,"accepted":45.38}
+{"id":27498,"name":"Votka and String","url":"https://www.spoj.com/problems/VOTAS","users":83,"accepted":33.53}
+{"id":27519,"name":"Zeros of the fundamental Fibonacci period","url":"https://www.spoj.com/problems/Z124H","users":13,"accepted":21.5}
+{"id":27520,"name":"Laser","url":"https://www.spoj.com/problems/LAS","users":43,"accepted":19.94}
+{"id":27521,"name":"Domino's effect","url":"https://www.spoj.com/problems/DOM","users":15,"accepted":31.43}
+{"id":27561,"name":"Greatest Common Divisor Of Three Integers","url":"https://www.spoj.com/problems/GDCOFTI","users":1748,"accepted":40.32}
+{"id":27683,"name":"Inquire","url":"https://www.spoj.com/problems/UFPR14D","users":764,"accepted":54.72}
+{"id":27942,"name":"Product it again","url":"https://www.spoj.com/problems/PROD1GCD","users":149,"accepted":33.08}
+{"id":28009,"name":"Balance the parentheses","url":"https://www.spoj.com/problems/BALANCE1PARA","users":19,"accepted":20.54}
+{"id":28079,"name":"Maximum Child Sum","url":"https://www.spoj.com/problems/MAXCHILDSUM","users":105,"accepted":23.04}
+{"id":28163,"name":"OR","url":"https://www.spoj.com/problems/EXPOR","users":130,"accepted":22.1}
+{"id":28164,"name":"Cats Invitation","url":"https://www.spoj.com/problems/CATINV","users":84,"accepted":28.9}
+{"id":28179,"name":"Appending String","url":"https://www.spoj.com/problems/GOC11A","users":254,"accepted":44.8}
+{"id":28180,"name":"Sanvi Hates Palindrome","url":"https://www.spoj.com/problems/GOC11B","users":62,"accepted":36.32}
+{"id":28265,"name":"Ada and Rain","url":"https://www.spoj.com/problems/ADARAIN","users":425,"accepted":55.36}
+{"id":28286,"name":"Archery Training","url":"https://www.spoj.com/problems/BLMIRINA","users":182,"accepted":33.13}
+{"id":28287,"name":"Mayonnaise Arrow","url":"https://www.spoj.com/problems/BLMIRANA","users":37,"accepted":12.64}
+{"id":28288,"name":"Super Amoeba","url":"https://www.spoj.com/problems/BLAMOEBA","users":204,"accepted":37.7}
+{"id":28302,"name":"Ada and Plus","url":"https://www.spoj.com/problems/ADAPLUS","users":165,"accepted":44.24}
+{"id":28303,"name":"Ada and Plants","url":"https://www.spoj.com/problems/ADAPLANT","users":325,"accepted":33.81}
+{"id":28304,"name":"Ada and Teams","url":"https://www.spoj.com/problems/ADATEAMS","users":882,"accepted":39.47}
+{"id":28305,"name":"Ada and Indexing","url":"https://www.spoj.com/problems/ADAINDEX","users":2335,"accepted":42.8}
+{"id":28306,"name":"Ada and Queue","url":"https://www.spoj.com/problems/ADAQUEUE","users":2509,"accepted":26}
+{"id":28307,"name":"Ada and Game","url":"https://www.spoj.com/problems/ADAGAME","users":629,"accepted":31.61}
+{"id":28308,"name":"Ada and Spring Cleaning","url":"https://www.spoj.com/problems/ADACLEAN","users":1601,"accepted":20.68}
+{"id":28315,"name":"Shoumiks Weakness","url":"https://www.spoj.com/problems/WEAKSMK","users":14,"accepted":22.33}
+{"id":28352,"name":"Friend Zoned","url":"https://www.spoj.com/problems/FRNDZND","users":291,"accepted":63.72}
+{"id":28404,"name":"Ada and Field","url":"https://www.spoj.com/problems/ADAFIELD","users":577,"accepted":25.44}
+{"id":28409,"name":"Ada and Cycle","url":"https://www.spoj.com/problems/ADACYCLE","users":1162,"accepted":25.65}
+{"id":28413,"name":"Ada and Fence","url":"https://www.spoj.com/problems/ADAFENCE","users":45,"accepted":27.93}
+{"id":28449,"name":"Ada and List","url":"https://www.spoj.com/problems/ADALIST","users":335,"accepted":22.69}
+{"id":28450,"name":"Ada and Path","url":"https://www.spoj.com/problems/ADAPATH","users":109,"accepted":30.98}
+{"id":28451,"name":"Ada and Cities","url":"https://www.spoj.com/problems/ADACITY","users":154,"accepted":30.51}
+{"id":28456,"name":"Finding the way","url":"https://www.spoj.com/problems/TAP2016B","users":21,"accepted":10.62}
+{"id":28457,"name":"Correlations","url":"https://www.spoj.com/problems/TAP2016C","users":94,"accepted":29.4}
+{"id":28458,"name":"Drawing triangles","url":"https://www.spoj.com/problems/TAP2016D","users":28,"accepted":8.62}
+{"id":28459,"name":"Grumpy uncle","url":"https://www.spoj.com/problems/TAP2016E","users":41,"accepted":33.33}
+{"id":28460,"name":"Congratulations, Fidel!","url":"https://www.spoj.com/problems/TAP2016F","users":44,"accepted":15.11}
+{"id":28461,"name":"Efficient managing","url":"https://www.spoj.com/problems/TAP2016G","users":48,"accepted":27.22}
+{"id":28462,"name":"New TAP","url":"https://www.spoj.com/problems/TAP2016H","users":40,"accepted":34.18}

--- a/tests/spoj/index/69.md
+++ b/tests/spoj/index/69.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 27429 | [Changu Mangu in a Football Team](https://www.spoj.com/problems/VECTAR13) | 83 | 20.19 |
+| 27433 | [Divisible Fibonacci Numbers](https://www.spoj.com/problems/DIVFIBS2) | 29 | 29.33 |
+| 27450 | [Changu with subsequences](https://www.spoj.com/problems/VECTAR14) | 38 | 36.31 |
+| 27483 | [Counting Words](https://www.spoj.com/problems/REDRONESIA) | 49 | 49.60 |
+| 27484 | [Zeros in Fibonacci period](https://www.spoj.com/problems/Z124) | 14 | 39.08 |
+| 27487 | [Police Men](https://www.spoj.com/problems/POLICEMEN) | 307 | 44.15 |
+| 27491 | [Bidding Game](https://www.spoj.com/problems/BIDGAME) | 10 | 27.84 |
+| 27493 | [Even Frequency](https://www.spoj.com/problems/EVENFRQ) | 72 | 29.59 |
+| 27494 | [Happiness](https://www.spoj.com/problems/HAPPINESS) | 9 | 14.78 |
+| 27496 | [Again Eid Salami](https://www.spoj.com/problems/EIDSALAMI2) | 129 | 45.61 |
+| 27497 | [Binary Protean Number](https://www.spoj.com/problems/BINPRNUM) | 144 | 45.38 |
+| 27498 | [Votka and String](https://www.spoj.com/problems/VOTAS) | 83 | 33.53 |
+| 27519 | [Zeros of the fundamental Fibonacci period](https://www.spoj.com/problems/Z124H) | 13 | 21.50 |
+| 27520 | [Laser](https://www.spoj.com/problems/LAS) | 43 | 19.94 |
+| 27521 | [Domino's effect](https://www.spoj.com/problems/DOM) | 15 | 31.43 |
+| 27561 | [Greatest Common Divisor Of Three Integers](https://www.spoj.com/problems/GDCOFTI) | 1748 | 40.32 |
+| 27683 | [Inquire](https://www.spoj.com/problems/UFPR14D) | 764 | 54.72 |
+| 27942 | [Product it again](https://www.spoj.com/problems/PROD1GCD) | 149 | 33.08 |
+| 28009 | [Balance the parentheses](https://www.spoj.com/problems/BALANCE1PARA) | 19 | 20.54 |
+| 28079 | [Maximum Child Sum](https://www.spoj.com/problems/MAXCHILDSUM) | 105 | 23.04 |
+| 28163 | [OR](https://www.spoj.com/problems/EXPOR) | 130 | 22.10 |
+| 28164 | [Cats Invitation](https://www.spoj.com/problems/CATINV) | 84 | 28.90 |
+| 28179 | [Appending String](https://www.spoj.com/problems/GOC11A) | 254 | 44.80 |
+| 28180 | [Sanvi Hates Palindrome](https://www.spoj.com/problems/GOC11B) | 62 | 36.32 |
+| 28265 | [Ada and Rain](https://www.spoj.com/problems/ADARAIN) | 425 | 55.36 |
+| 28286 | [Archery Training](https://www.spoj.com/problems/BLMIRINA) | 182 | 33.13 |
+| 28287 | [Mayonnaise Arrow](https://www.spoj.com/problems/BLMIRANA) | 37 | 12.64 |
+| 28288 | [Super Amoeba](https://www.spoj.com/problems/BLAMOEBA) | 204 | 37.70 |
+| 28302 | [Ada and Plus](https://www.spoj.com/problems/ADAPLUS) | 165 | 44.24 |
+| 28303 | [Ada and Plants](https://www.spoj.com/problems/ADAPLANT) | 325 | 33.81 |
+| 28304 | [Ada and Teams](https://www.spoj.com/problems/ADATEAMS) | 882 | 39.47 |
+| 28305 | [Ada and Indexing](https://www.spoj.com/problems/ADAINDEX) | 2335 | 42.80 |
+| 28306 | [Ada and Queue](https://www.spoj.com/problems/ADAQUEUE) | 2509 | 26.00 |
+| 28307 | [Ada and Game](https://www.spoj.com/problems/ADAGAME) | 629 | 31.61 |
+| 28308 | [Ada and Spring Cleaning](https://www.spoj.com/problems/ADACLEAN) | 1601 | 20.68 |
+| 28315 | [Shoumiks Weakness](https://www.spoj.com/problems/WEAKSMK) | 14 | 22.33 |
+| 28352 | [Friend Zoned](https://www.spoj.com/problems/FRNDZND) | 291 | 63.72 |
+| 28404 | [Ada and Field](https://www.spoj.com/problems/ADAFIELD) | 577 | 25.44 |
+| 28409 | [Ada and Cycle](https://www.spoj.com/problems/ADACYCLE) | 1162 | 25.65 |
+| 28413 | [Ada and Fence](https://www.spoj.com/problems/ADAFENCE) | 45 | 27.93 |
+| 28449 | [Ada and List](https://www.spoj.com/problems/ADALIST) | 335 | 22.69 |
+| 28450 | [Ada and Path](https://www.spoj.com/problems/ADAPATH) | 109 | 30.98 |
+| 28451 | [Ada and Cities](https://www.spoj.com/problems/ADACITY) | 154 | 30.51 |
+| 28456 | [Finding the way](https://www.spoj.com/problems/TAP2016B) | 21 | 10.62 |
+| 28457 | [Correlations](https://www.spoj.com/problems/TAP2016C) | 94 | 29.40 |
+| 28458 | [Drawing triangles](https://www.spoj.com/problems/TAP2016D) | 28 | 8.62 |
+| 28459 | [Grumpy uncle](https://www.spoj.com/problems/TAP2016E) | 41 | 33.33 |
+| 28460 | [Congratulations, Fidel!](https://www.spoj.com/problems/TAP2016F) | 44 | 15.11 |
+| 28461 | [Efficient managing](https://www.spoj.com/problems/TAP2016G) | 48 | 27.22 |
+| 28462 | [New TAP](https://www.spoj.com/problems/TAP2016H) | 40 | 34.18 |

--- a/tests/spoj/index/70.jsonl
+++ b/tests/spoj/index/70.jsonl
@@ -1,0 +1,50 @@
+{"id":28463,"name":"Insect invasion","url":"https://www.spoj.com/problems/TAP2016I","users":21,"accepted":9.9}
+{"id":28464,"name":"Joining lines","url":"https://www.spoj.com/problems/TAP2016J","users":61,"accepted":24.43}
+{"id":28465,"name":"Koalas","url":"https://www.spoj.com/problems/TAP2016K","users":17,"accepted":15.24}
+{"id":28466,"name":"Leonardo de Pisa","url":"https://www.spoj.com/problems/TAP2016L","users":51,"accepted":17.44}
+{"id":28479,"name":"Single substitutions","url":"https://www.spoj.com/problems/REDSUBLIA","users":67,"accepted":30.27}
+{"id":28547,"name":"Ada and Easy Game","url":"https://www.spoj.com/problems/ADAGAME2","users":101,"accepted":28.8}
+{"id":28597,"name":"Guess the Queue","url":"https://www.spoj.com/problems/BDOI16A","users":202,"accepted":26.06}
+{"id":28598,"name":"Beautiful Factorial Game","url":"https://www.spoj.com/problems/BDOI16B","users":200,"accepted":30.14}
+{"id":28599,"name":"Counting Magical Permutatitons","url":"https://www.spoj.com/problems/BDOI16C","users":62,"accepted":29.08}
+{"id":28600,"name":"One Punch Man","url":"https://www.spoj.com/problems/BDOI16D","users":70,"accepted":34.27}
+{"id":28601,"name":"Village Fair","url":"https://www.spoj.com/problems/BDOI16E","users":118,"accepted":18.71}
+{"id":28604,"name":"Sinha and Eggs","url":"https://www.spoj.com/problems/SINEGGS","users":555,"accepted":36.95}
+{"id":28607,"name":"Descending Alternating Sums","url":"https://www.spoj.com/problems/DALTSUM","users":137,"accepted":38.38}
+{"id":28609,"name":"Boat Burglary","url":"https://www.spoj.com/problems/BURGLARY","users":155,"accepted":14.43}
+{"id":28632,"name":"Ghost Town","url":"https://www.spoj.com/problems/COUNT1IT","users":290,"accepted":41.17}
+{"id":28653,"name":"Urinals","url":"https://www.spoj.com/problems/URI","users":11,"accepted":10.71}
+{"id":28740,"name":"Try to complete","url":"https://www.spoj.com/problems/TRYCOMP","users":664,"accepted":25.5}
+{"id":28742,"name":"Pizza Store and Gasoline","url":"https://www.spoj.com/problems/GASOLINE","users":69,"accepted":44.86}
+{"id":28743,"name":"Game of Iron Thrones","url":"https://www.spoj.com/problems/GOIT","users":53,"accepted":50.97}
+{"id":28744,"name":"Coin Fight","url":"https://www.spoj.com/problems/KATHTHI2","users":42,"accepted":26.09}
+{"id":28784,"name":"IIITM Student","url":"https://www.spoj.com/problems/IIITMSTUD","users":98,"accepted":53.29}
+{"id":28798,"name":"Yet Another Xor Sequence","url":"https://www.spoj.com/problems/YAXS","users":116,"accepted":46.56}
+{"id":29335,"name":"Movie Fan","url":"https://www.spoj.com/problems/MOVIFAN","users":152,"accepted":66.08}
+{"id":29363,"name":"How many can you sort?","url":"https://www.spoj.com/problems/SORTMUCH","users":83,"accepted":48.64}
+{"id":29367,"name":"VEGETABLE SHOPKEEPER 3","url":"https://www.spoj.com/problems/WEIGHT3","users":111,"accepted":40.7}
+{"id":29431,"name":"Counting WOW-Substrings","url":"https://www.spoj.com/problems/WOWSUBSTR","users":149,"accepted":34.56}
+{"id":29434,"name":"Counting WOW-Substrings2","url":"https://www.spoj.com/problems/WOWSUBSTR2","users":107,"accepted":45.2}
+{"id":29448,"name":"Coincidence","url":"https://www.spoj.com/problems/BLLUCK","users":96,"accepted":32.42}
+{"id":29452,"name":"Width of The Lost Box","url":"https://www.spoj.com/problems/LOSTBOX","users":41,"accepted":20.14}
+{"id":29454,"name":"Martian Colony","url":"https://www.spoj.com/problems/MARSCOL","users":25,"accepted":36.47}
+{"id":29455,"name":"Alphabetic Rope","url":"https://www.spoj.com/problems/AROPE","users":237,"accepted":36.27}
+{"id":29458,"name":"Alphabetic Rope2","url":"https://www.spoj.com/problems/AROPE2","users":122,"accepted":49.7}
+{"id":29461,"name":"Alphabetic Rope3","url":"https://www.spoj.com/problems/AROPE3","users":148,"accepted":56.88}
+{"id":29695,"name":"GO GOA GONE","url":"https://www.spoj.com/problems/ALCATRAZ2","users":900,"accepted":25}
+{"id":30009,"name":"Game of MODs","url":"https://www.spoj.com/problems/GMMOD","users":48,"accepted":24.51}
+{"id":30116,"name":"Can you draw it or not?","url":"https://www.spoj.com/problems/DRAWIT","users":201,"accepted":38.49}
+{"id":30347,"name":"Runner Game","url":"https://www.spoj.com/problems/NPC2016A","users":260,"accepted":31.14}
+{"id":30349,"name":"Strange Waca","url":"https://www.spoj.com/problems/NPC2016C","users":45,"accepted":20.53}
+{"id":30351,"name":"Quest Hunter","url":"https://www.spoj.com/problems/NPC2016E","users":15,"accepted":23.81}
+{"id":30394,"name":"Prime is fun","url":"https://www.spoj.com/problems/ARRPRM","users":87,"accepted":35.71}
+{"id":30396,"name":"Easy GCD","url":"https://www.spoj.com/problems/GCDEASY","users":101,"accepted":32.08}
+{"id":30452,"name":"Moumita and Assignments","url":"https://www.spoj.com/problems/MAS","users":86,"accepted":13.25}
+{"id":30454,"name":"Luke vs. Darth Vader","url":"https://www.spoj.com/problems/LVADER","users":225,"accepted":22.33}
+{"id":30499,"name":"TWO STRINGS","url":"https://www.spoj.com/problems/HARSTR","users":26,"accepted":28.75}
+{"id":30500,"name":"THE HONEYCOMB MAZE","url":"https://www.spoj.com/problems/ALCATRAZ3","users":652,"accepted":27.17}
+{"id":30669,"name":"Ada and Trip","url":"https://www.spoj.com/problems/ADATRIP","users":989,"accepted":31.1}
+{"id":30690,"name":"Ada and Nucleobase","url":"https://www.spoj.com/problems/ADAMATCH","users":526,"accepted":43.98}
+{"id":30691,"name":"Ada and Diary","url":"https://www.spoj.com/problems/ADAHACK","users":63,"accepted":18.28}
+{"id":30692,"name":"Ada and Rain II","url":"https://www.spoj.com/problems/ADARAINB","users":123,"accepted":51.6}
+{"id":30734,"name":"Ada and Orange Tree","url":"https://www.spoj.com/problems/ADAORANG","users":398,"accepted":23.35}

--- a/tests/spoj/index/70.md
+++ b/tests/spoj/index/70.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 28463 | [Insect invasion](https://www.spoj.com/problems/TAP2016I) | 21 | 9.90 |
+| 28464 | [Joining lines](https://www.spoj.com/problems/TAP2016J) | 61 | 24.43 |
+| 28465 | [Koalas](https://www.spoj.com/problems/TAP2016K) | 17 | 15.24 |
+| 28466 | [Leonardo de Pisa](https://www.spoj.com/problems/TAP2016L) | 51 | 17.44 |
+| 28479 | [Single substitutions](https://www.spoj.com/problems/REDSUBLIA) | 67 | 30.27 |
+| 28547 | [Ada and Easy Game](https://www.spoj.com/problems/ADAGAME2) | 101 | 28.80 |
+| 28597 | [Guess the Queue](https://www.spoj.com/problems/BDOI16A) | 202 | 26.06 |
+| 28598 | [Beautiful Factorial Game](https://www.spoj.com/problems/BDOI16B) | 200 | 30.14 |
+| 28599 | [Counting Magical Permutatitons](https://www.spoj.com/problems/BDOI16C) | 62 | 29.08 |
+| 28600 | [One Punch Man](https://www.spoj.com/problems/BDOI16D) | 70 | 34.27 |
+| 28601 | [Village Fair](https://www.spoj.com/problems/BDOI16E) | 118 | 18.71 |
+| 28604 | [Sinha and Eggs](https://www.spoj.com/problems/SINEGGS) | 555 | 36.95 |
+| 28607 | [Descending Alternating Sums](https://www.spoj.com/problems/DALTSUM) | 137 | 38.38 |
+| 28609 | [Boat Burglary](https://www.spoj.com/problems/BURGLARY) | 155 | 14.43 |
+| 28632 | [Ghost Town](https://www.spoj.com/problems/COUNT1IT) | 290 | 41.17 |
+| 28653 | [Urinals](https://www.spoj.com/problems/URI) | 11 | 10.71 |
+| 28740 | [Try to complete](https://www.spoj.com/problems/TRYCOMP) | 664 | 25.50 |
+| 28742 | [Pizza Store and Gasoline](https://www.spoj.com/problems/GASOLINE) | 69 | 44.86 |
+| 28743 | [Game of Iron Thrones](https://www.spoj.com/problems/GOIT) | 53 | 50.97 |
+| 28744 | [Coin Fight](https://www.spoj.com/problems/KATHTHI2) | 42 | 26.09 |
+| 28784 | [IIITM Student](https://www.spoj.com/problems/IIITMSTUD) | 98 | 53.29 |
+| 28798 | [Yet Another Xor Sequence](https://www.spoj.com/problems/YAXS) | 116 | 46.56 |
+| 29335 | [Movie Fan](https://www.spoj.com/problems/MOVIFAN) | 152 | 66.08 |
+| 29363 | [How many can you sort?](https://www.spoj.com/problems/SORTMUCH) | 83 | 48.64 |
+| 29367 | [VEGETABLE SHOPKEEPER 3](https://www.spoj.com/problems/WEIGHT3) | 111 | 40.70 |
+| 29431 | [Counting WOW-Substrings](https://www.spoj.com/problems/WOWSUBSTR) | 149 | 34.56 |
+| 29434 | [Counting WOW-Substrings2](https://www.spoj.com/problems/WOWSUBSTR2) | 107 | 45.20 |
+| 29448 | [Coincidence](https://www.spoj.com/problems/BLLUCK) | 96 | 32.42 |
+| 29452 | [Width of The Lost Box](https://www.spoj.com/problems/LOSTBOX) | 41 | 20.14 |
+| 29454 | [Martian Colony](https://www.spoj.com/problems/MARSCOL) | 25 | 36.47 |
+| 29455 | [Alphabetic Rope](https://www.spoj.com/problems/AROPE) | 237 | 36.27 |
+| 29458 | [Alphabetic Rope2](https://www.spoj.com/problems/AROPE2) | 122 | 49.70 |
+| 29461 | [Alphabetic Rope3](https://www.spoj.com/problems/AROPE3) | 148 | 56.88 |
+| 29695 | [GO GOA GONE](https://www.spoj.com/problems/ALCATRAZ2) | 900 | 25.00 |
+| 30009 | [Game of MODs](https://www.spoj.com/problems/GMMOD) | 48 | 24.51 |
+| 30116 | [Can you draw it or not?](https://www.spoj.com/problems/DRAWIT) | 201 | 38.49 |
+| 30347 | [Runner Game](https://www.spoj.com/problems/NPC2016A) | 260 | 31.14 |
+| 30349 | [Strange Waca](https://www.spoj.com/problems/NPC2016C) | 45 | 20.53 |
+| 30351 | [Quest Hunter](https://www.spoj.com/problems/NPC2016E) | 15 | 23.81 |
+| 30394 | [Prime is fun](https://www.spoj.com/problems/ARRPRM) | 87 | 35.71 |
+| 30396 | [Easy GCD](https://www.spoj.com/problems/GCDEASY) | 101 | 32.08 |
+| 30452 | [Moumita and Assignments](https://www.spoj.com/problems/MAS) | 86 | 13.25 |
+| 30454 | [Luke vs. Darth Vader](https://www.spoj.com/problems/LVADER) | 225 | 22.33 |
+| 30499 | [TWO STRINGS](https://www.spoj.com/problems/HARSTR) | 26 | 28.75 |
+| 30500 | [THE HONEYCOMB MAZE](https://www.spoj.com/problems/ALCATRAZ3) | 652 | 27.17 |
+| 30669 | [Ada and Trip](https://www.spoj.com/problems/ADATRIP) | 989 | 31.10 |
+| 30690 | [Ada and Nucleobase](https://www.spoj.com/problems/ADAMATCH) | 526 | 43.98 |
+| 30691 | [Ada and Diary](https://www.spoj.com/problems/ADAHACK) | 63 | 18.28 |
+| 30692 | [Ada and Rain II](https://www.spoj.com/problems/ADARAINB) | 123 | 51.60 |
+| 30734 | [Ada and Orange Tree](https://www.spoj.com/problems/ADAORANG) | 398 | 23.35 |

--- a/tests/spoj/index/71.jsonl
+++ b/tests/spoj/index/71.jsonl
@@ -1,0 +1,50 @@
+{"id":30735,"name":"Ada and Island","url":"https://www.spoj.com/problems/ADASEA","users":622,"accepted":34.97}
+{"id":30737,"name":"Ada and Homework","url":"https://www.spoj.com/problems/ADAHW","users":68,"accepted":25.33}
+{"id":30738,"name":"Ada and Coins","url":"https://www.spoj.com/problems/ADACOINS","users":857,"accepted":31.72}
+{"id":30739,"name":"Ada and Manure","url":"https://www.spoj.com/problems/ADADUNG","users":316,"accepted":58.59}
+{"id":30755,"name":"Ada and GCD","url":"https://www.spoj.com/problems/ADAGCD","users":457,"accepted":21.94}
+{"id":30756,"name":"Ada and Numbering","url":"https://www.spoj.com/problems/ADANUM","users":130,"accepted":17.5}
+{"id":30757,"name":"Ada and Carrot","url":"https://www.spoj.com/problems/ADACAROT","users":137,"accepted":35.25}
+{"id":30759,"name":"Ada and Species","url":"https://www.spoj.com/problems/ADACABAA","users":133,"accepted":26.33}
+{"id":30760,"name":"Ada and Travelling Salesman","url":"https://www.spoj.com/problems/ADASALES","users":188,"accepted":27.13}
+{"id":30783,"name":"Ada and Cucumber","url":"https://www.spoj.com/problems/ADAPICK","users":110,"accepted":19.44}
+{"id":30785,"name":"Ada and Apple","url":"https://www.spoj.com/problems/ADAAPPLE","users":209,"accepted":25.05}
+{"id":30787,"name":"Ada and Aphids","url":"https://www.spoj.com/problems/ADAAPHID","users":209,"accepted":30.62}
+{"id":30826,"name":"Bernoulli numbers","url":"https://www.spoj.com/problems/BERNULLI","users":7,"accepted":15.08}
+{"id":30827,"name":"THE LAST SHOT","url":"https://www.spoj.com/problems/LASTSHOT","users":659,"accepted":29.07}
+{"id":30828,"name":"Class Leader","url":"https://www.spoj.com/problems/CLSLDR","users":217,"accepted":11.63}
+{"id":30893,"name":"Sabbir and Game","url":"https://www.spoj.com/problems/SABBIRGAME","users":810,"accepted":34.47}
+{"id":30906,"name":"Ada and Unique Vegetable","url":"https://www.spoj.com/problems/ADAUNIQ","users":482,"accepted":35.27}
+{"id":30919,"name":"Sabbir and gcd problem","url":"https://www.spoj.com/problems/GCDS","users":335,"accepted":22.99}
+{"id":30922,"name":"Ada and Plum","url":"https://www.spoj.com/problems/ADAVISIT","users":153,"accepted":45.87}
+{"id":30944,"name":"Jerry and his cheese","url":"https://www.spoj.com/problems/JERRY","users":32,"accepted":23.79}
+{"id":30945,"name":"Non Coprime Sequences","url":"https://www.spoj.com/problems/COPSEQ","users":22,"accepted":20.43}
+{"id":30947,"name":"Sabbir and gifts","url":"https://www.spoj.com/problems/SGIFT","users":373,"accepted":32.88}
+{"id":30961,"name":"Non Coprime Sequences(Hard)","url":"https://www.spoj.com/problems/COPSEQH","users":17,"accepted":7.32}
+{"id":30973,"name":"Ada and Tomato","url":"https://www.spoj.com/problems/ADATOMAT","users":64,"accepted":18.05}
+{"id":31036,"name":"Ada and Mulberry","url":"https://www.spoj.com/problems/ADABERRY","users":123,"accepted":12.76}
+{"id":31040,"name":"Namit In Trouble","url":"https://www.spoj.com/problems/NGIRL","users":862,"accepted":23.83}
+{"id":31052,"name":"PLAYGAME","url":"https://www.spoj.com/problems/PLAYGAME","users":717,"accepted":42.82}
+{"id":31099,"name":"Ada and CAPTCHA","url":"https://www.spoj.com/problems/ADAROBOT","users":179,"accepted":17.39}
+{"id":31221,"name":"Zen And His Crush","url":"https://www.spoj.com/problems/ZCR","users":415,"accepted":67.17}
+{"id":31230,"name":"TV Schedule","url":"https://www.spoj.com/problems/URJC2_A","users":81,"accepted":51.58}
+{"id":31231,"name":"Playing Darts","url":"https://www.spoj.com/problems/URJC2_B","users":34,"accepted":29.5}
+{"id":31234,"name":"Stressful Activities","url":"https://www.spoj.com/problems/URJC2_E","users":71,"accepted":41}
+{"id":31235,"name":"Fractals","url":"https://www.spoj.com/problems/URJC2_F","users":61,"accepted":44.04}
+{"id":31279,"name":"Eat Pray Love","url":"https://www.spoj.com/problems/AGPC01G","users":135,"accepted":61.99}
+{"id":31280,"name":"Ada and Zoo","url":"https://www.spoj.com/problems/ADAZOO","users":35,"accepted":34.3}
+{"id":31290,"name":"Math is Love","url":"https://www.spoj.com/problems/MATHLOVE","users":1206,"accepted":41.1}
+{"id":31341,"name":"Just One Swap","url":"https://www.spoj.com/problems/JOSWAP","users":185,"accepted":28.68}
+{"id":31342,"name":"Simple Path","url":"https://www.spoj.com/problems/SIMPLEPATH","users":32,"accepted":25.74}
+{"id":31374,"name":"Matrix Multiplication 2K","url":"https://www.spoj.com/problems/MATRMUL0","users":35,"accepted":32.82}
+{"id":31396,"name":"Binary Game Reloaded","url":"https://www.spoj.com/problems/BG2","users":37,"accepted":47.87}
+{"id":31412,"name":"ShaatChara","url":"https://www.spoj.com/problems/GAMEMVS","users":74,"accepted":51.7}
+{"id":31428,"name":"Fibonacci Polynomial","url":"https://www.spoj.com/problems/FIBONOMIAL","users":135,"accepted":36.63}
+{"id":31430,"name":"Highschool Homework","url":"https://www.spoj.com/problems/HSHW","users":52,"accepted":21.49}
+{"id":31502,"name":"University Homework","url":"https://www.spoj.com/problems/UNIHW","users":56,"accepted":29.11}
+{"id":31557,"name":"Halum and Candies","url":"https://www.spoj.com/problems/HALCAND","users":69,"accepted":30.65}
+{"id":31591,"name":"All in One","url":"https://www.spoj.com/problems/ALLIN1","users":110,"accepted":8.9}
+{"id":31755,"name":"Januarius, The Travelling Clairvoyant","url":"https://www.spoj.com/problems/JAN","users":25,"accepted":29.14}
+{"id":31756,"name":"The Idol","url":"https://www.spoj.com/problems/IDO","users":18,"accepted":19.83}
+{"id":31772,"name":"Boss Baby","url":"https://www.spoj.com/problems/NAJBB","users":13,"accepted":17.09}
+{"id":31884,"name":"RPS Warfare","url":"https://www.spoj.com/problems/RPSWAR","users":21,"accepted":18.68}

--- a/tests/spoj/index/71.md
+++ b/tests/spoj/index/71.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 30735 | [Ada and Island](https://www.spoj.com/problems/ADASEA) | 622 | 34.97 |
+| 30737 | [Ada and Homework](https://www.spoj.com/problems/ADAHW) | 68 | 25.33 |
+| 30738 | [Ada and Coins](https://www.spoj.com/problems/ADACOINS) | 857 | 31.72 |
+| 30739 | [Ada and Manure](https://www.spoj.com/problems/ADADUNG) | 316 | 58.59 |
+| 30755 | [Ada and GCD](https://www.spoj.com/problems/ADAGCD) | 457 | 21.94 |
+| 30756 | [Ada and Numbering](https://www.spoj.com/problems/ADANUM) | 130 | 17.50 |
+| 30757 | [Ada and Carrot](https://www.spoj.com/problems/ADACAROT) | 137 | 35.25 |
+| 30759 | [Ada and Species](https://www.spoj.com/problems/ADACABAA) | 133 | 26.33 |
+| 30760 | [Ada and Travelling Salesman](https://www.spoj.com/problems/ADASALES) | 188 | 27.13 |
+| 30783 | [Ada and Cucumber](https://www.spoj.com/problems/ADAPICK) | 110 | 19.44 |
+| 30785 | [Ada and Apple](https://www.spoj.com/problems/ADAAPPLE) | 209 | 25.05 |
+| 30787 | [Ada and Aphids](https://www.spoj.com/problems/ADAAPHID) | 209 | 30.62 |
+| 30826 | [Bernoulli numbers](https://www.spoj.com/problems/BERNULLI) | 7 | 15.08 |
+| 30827 | [THE LAST SHOT](https://www.spoj.com/problems/LASTSHOT) | 659 | 29.07 |
+| 30828 | [Class Leader](https://www.spoj.com/problems/CLSLDR) | 217 | 11.63 |
+| 30893 | [Sabbir and Game](https://www.spoj.com/problems/SABBIRGAME) | 810 | 34.47 |
+| 30906 | [Ada and Unique Vegetable](https://www.spoj.com/problems/ADAUNIQ) | 482 | 35.27 |
+| 30919 | [Sabbir and gcd problem](https://www.spoj.com/problems/GCDS) | 335 | 22.99 |
+| 30922 | [Ada and Plum](https://www.spoj.com/problems/ADAVISIT) | 153 | 45.87 |
+| 30944 | [Jerry and his cheese](https://www.spoj.com/problems/JERRY) | 32 | 23.79 |
+| 30945 | [Non Coprime Sequences](https://www.spoj.com/problems/COPSEQ) | 22 | 20.43 |
+| 30947 | [Sabbir and gifts](https://www.spoj.com/problems/SGIFT) | 373 | 32.88 |
+| 30961 | [Non Coprime Sequences(Hard)](https://www.spoj.com/problems/COPSEQH) | 17 | 7.32 |
+| 30973 | [Ada and Tomato](https://www.spoj.com/problems/ADATOMAT) | 64 | 18.05 |
+| 31036 | [Ada and Mulberry](https://www.spoj.com/problems/ADABERRY) | 123 | 12.76 |
+| 31040 | [Namit In Trouble](https://www.spoj.com/problems/NGIRL) | 862 | 23.83 |
+| 31052 | [PLAYGAME](https://www.spoj.com/problems/PLAYGAME) | 717 | 42.82 |
+| 31099 | [Ada and CAPTCHA](https://www.spoj.com/problems/ADAROBOT) | 179 | 17.39 |
+| 31221 | [Zen And His Crush](https://www.spoj.com/problems/ZCR) | 415 | 67.17 |
+| 31230 | [TV Schedule](https://www.spoj.com/problems/URJC2_A) | 81 | 51.58 |
+| 31231 | [Playing Darts](https://www.spoj.com/problems/URJC2_B) | 34 | 29.50 |
+| 31234 | [Stressful Activities](https://www.spoj.com/problems/URJC2_E) | 71 | 41.00 |
+| 31235 | [Fractals](https://www.spoj.com/problems/URJC2_F) | 61 | 44.04 |
+| 31279 | [Eat Pray Love](https://www.spoj.com/problems/AGPC01G) | 135 | 61.99 |
+| 31280 | [Ada and Zoo](https://www.spoj.com/problems/ADAZOO) | 35 | 34.30 |
+| 31290 | [Math is Love](https://www.spoj.com/problems/MATHLOVE) | 1206 | 41.10 |
+| 31341 | [Just One Swap](https://www.spoj.com/problems/JOSWAP) | 185 | 28.68 |
+| 31342 | [Simple Path](https://www.spoj.com/problems/SIMPLEPATH) | 32 | 25.74 |
+| 31374 | [Matrix Multiplication 2K](https://www.spoj.com/problems/MATRMUL0) | 35 | 32.82 |
+| 31396 | [Binary Game Reloaded](https://www.spoj.com/problems/BG2) | 37 | 47.87 |
+| 31412 | [ShaatChara](https://www.spoj.com/problems/GAMEMVS) | 74 | 51.70 |
+| 31428 | [Fibonacci Polynomial](https://www.spoj.com/problems/FIBONOMIAL) | 135 | 36.63 |
+| 31430 | [Highschool Homework](https://www.spoj.com/problems/HSHW) | 52 | 21.49 |
+| 31502 | [University Homework](https://www.spoj.com/problems/UNIHW) | 56 | 29.11 |
+| 31557 | [Halum and Candies](https://www.spoj.com/problems/HALCAND) | 69 | 30.65 |
+| 31591 | [All in One](https://www.spoj.com/problems/ALLIN1) | 110 | 8.90 |
+| 31755 | [Januarius, The Travelling Clairvoyant](https://www.spoj.com/problems/JAN) | 25 | 29.14 |
+| 31756 | [The Idol](https://www.spoj.com/problems/IDO) | 18 | 19.83 |
+| 31772 | [Boss Baby](https://www.spoj.com/problems/NAJBB) | 13 | 17.09 |
+| 31884 | [RPS Warfare](https://www.spoj.com/problems/RPSWAR) | 21 | 18.68 |

--- a/tests/spoj/index/72.jsonl
+++ b/tests/spoj/index/72.jsonl
@@ -1,0 +1,50 @@
+{"id":31893,"name":"Fibonacci and Easy GCD","url":"https://www.spoj.com/problems/INS17M","users":68,"accepted":28.92}
+{"id":31894,"name":"House Buying Optimizations","url":"https://www.spoj.com/problems/HOUSEBUY","users":10,"accepted":25.66}
+{"id":31897,"name":"If Chain","url":"https://www.spoj.com/problems/IFCHAIN","users":27,"accepted":46.53}
+{"id":31902,"name":"Paragliding Trip","url":"https://www.spoj.com/problems/PARAG","users":25,"accepted":31.36}
+{"id":31928,"name":"Those College Days!","url":"https://www.spoj.com/problems/IIITD1","users":237,"accepted":28.53}
+{"id":31938,"name":"SLIS","url":"https://www.spoj.com/problems/QUERYIT","users":144,"accepted":39.49}
+{"id":31970,"name":"Urdhva - Tiryag Bhyam","url":"https://www.spoj.com/problems/URD","users":85,"accepted":31.08}
+{"id":31971,"name":"NEO","url":"https://www.spoj.com/problems/NEO2","users":10,"accepted":3.44}
+{"id":31972,"name":"Ada and Power","url":"https://www.spoj.com/problems/ADAPOWER","users":65,"accepted":41.29}
+{"id":31973,"name":"THE SHORTEST PATH","url":"https://www.spoj.com/problems/ALCATRAZ4","users":37,"accepted":32.05}
+{"id":31974,"name":"Ada and Birthday","url":"https://www.spoj.com/problems/ADAGIFT","users":47,"accepted":25.16}
+{"id":31975,"name":"Ada and Scarecrow","url":"https://www.spoj.com/problems/ADACROW","users":14,"accepted":16.06}
+{"id":31976,"name":"Ada and Tulips","url":"https://www.spoj.com/problems/ADASEED","users":20,"accepted":18.8}
+{"id":31979,"name":"Ada and Party","url":"https://www.spoj.com/problems/ADAPARTY","users":25,"accepted":56.36}
+{"id":32028,"name":"Ada and Parties","url":"https://www.spoj.com/problems/ADAPARTI","users":4,"accepted":1.24}
+{"id":32029,"name":"Ada and Connections","url":"https://www.spoj.com/problems/ADACON","users":77,"accepted":12.86}
+{"id":32058,"name":"Harbinger vs Sciencepal","url":"https://www.spoj.com/problems/R6PL","users":175,"accepted":35.54}
+{"id":32059,"name":"Ada and Taxes","url":"https://www.spoj.com/problems/ADATAXES","users":113,"accepted":36.48}
+{"id":32065,"name":"Save Lord Tachanka","url":"https://www.spoj.com/problems/TACHANKA","users":0,"accepted":0}
+{"id":32079,"name":"Ada and Greenflies","url":"https://www.spoj.com/problems/ADAGF","users":210,"accepted":45.83}
+{"id":32086,"name":"The Permutation Game Again","url":"https://www.spoj.com/problems/TPGA","users":165,"accepted":44.52}
+{"id":32088,"name":"Chessboard State 1: National Chess Tournament","url":"https://www.spoj.com/problems/CSTATE1","users":15,"accepted":23.11}
+{"id":32091,"name":"Chessboard State 2: International Chess Tournament","url":"https://www.spoj.com/problems/CSTATE2","users":6,"accepted":17.14}
+{"id":32092,"name":"Chessboard State 3: Intergalactic Chess Tournament","url":"https://www.spoj.com/problems/CSTATE3","users":6,"accepted":42.25}
+{"id":32093,"name":"Where The Friends Meet!","url":"https://www.spoj.com/problems/WTFM","users":42,"accepted":28.89}
+{"id":32103,"name":"Degree of a Tree","url":"https://www.spoj.com/problems/TREEDEGREE","users":231,"accepted":30.62}
+{"id":32125,"name":"Flirtatious Verma","url":"https://www.spoj.com/problems/VDATE","users":95,"accepted":23.28}
+{"id":32192,"name":"SUMMATION","url":"https://www.spoj.com/problems/SUMMATION","users":578,"accepted":23.13}
+{"id":32199,"name":"Ada and Cherry","url":"https://www.spoj.com/problems/ADACHERY","users":164,"accepted":36.26}
+{"id":32201,"name":"Right Shift","url":"https://www.spoj.com/problems/RSHIFT","users":221,"accepted":11.26}
+{"id":32202,"name":"Share It","url":"https://www.spoj.com/problems/SHAREIT","users":17,"accepted":25}
+{"id":32222,"name":"Ada and Panels","url":"https://www.spoj.com/problems/ADAPANEL","users":71,"accepted":44.2}
+{"id":32223,"name":"Ada and Lychees","url":"https://www.spoj.com/problems/ADALICI","users":18,"accepted":22.97}
+{"id":32235,"name":"SOLVEIT","url":"https://www.spoj.com/problems/SOLVEIT","users":344,"accepted":25.79}
+{"id":32245,"name":"Apoorv and Maximum Inversion","url":"https://www.spoj.com/problems/SAS001","users":150,"accepted":33.15}
+{"id":32257,"name":"Apoorv and Math problem","url":"https://www.spoj.com/problems/SAS002","users":174,"accepted":14.96}
+{"id":32259,"name":"Walk home together","url":"https://www.spoj.com/problems/WHT","users":40,"accepted":9.88}
+{"id":32271,"name":"KNIGHTS level testing","url":"https://www.spoj.com/problems/KNIGHTSG","users":11,"accepted":21.13}
+{"id":32302,"name":"Ada and Replant","url":"https://www.spoj.com/problems/ADAGROW","users":22,"accepted":24.66}
+{"id":32439,"name":"Ada and Bloom","url":"https://www.spoj.com/problems/ADABLOOM","users":59,"accepted":25.06}
+{"id":32446,"name":"Sanvi and Magical Numbers","url":"https://www.spoj.com/problems/SANVI","users":13,"accepted":26.83}
+{"id":32468,"name":"Frog Party","url":"https://www.spoj.com/problems/FROGPARTY","users":69,"accepted":27.38}
+{"id":32469,"name":"Minions v/s Minions","url":"https://www.spoj.com/problems/MINVSMIN","users":66,"accepted":49.15}
+{"id":32529,"name":"Nearest Neighbor Search","url":"https://www.spoj.com/problems/NNS","users":21,"accepted":32.76}
+{"id":32567,"name":"First to meet the spaceship","url":"https://www.spoj.com/problems/MEETSHIP","users":32,"accepted":11.98}
+{"id":32577,"name":"Ada and Terramorphing","url":"https://www.spoj.com/problems/ADAPHOTO","users":280,"accepted":12.11}
+{"id":32578,"name":"Meh and Mini Splendor","url":"https://www.spoj.com/problems/SPLEND1","users":11,"accepted":62.5}
+{"id":32579,"name":"Ada and Expenses","url":"https://www.spoj.com/problems/ADASUM","users":376,"accepted":51.23}
+{"id":32595,"name":"Ada and Servers","url":"https://www.spoj.com/problems/ADABASH","users":29,"accepted":22.78}
+{"id":32679,"name":"Ada and Roads","url":"https://www.spoj.com/problems/ADAROADS","users":16,"accepted":53.85}

--- a/tests/spoj/index/72.md
+++ b/tests/spoj/index/72.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 31893 | [Fibonacci and Easy GCD](https://www.spoj.com/problems/INS17M) | 68 | 28.92 |
+| 31894 | [House Buying Optimizations](https://www.spoj.com/problems/HOUSEBUY) | 10 | 25.66 |
+| 31897 | [If Chain](https://www.spoj.com/problems/IFCHAIN) | 27 | 46.53 |
+| 31902 | [Paragliding Trip](https://www.spoj.com/problems/PARAG) | 25 | 31.36 |
+| 31928 | [Those College Days!](https://www.spoj.com/problems/IIITD1) | 237 | 28.53 |
+| 31938 | [SLIS](https://www.spoj.com/problems/QUERYIT) | 144 | 39.49 |
+| 31970 | [Urdhva - Tiryag Bhyam](https://www.spoj.com/problems/URD) | 85 | 31.08 |
+| 31971 | [NEO](https://www.spoj.com/problems/NEO2) | 10 | 3.44 |
+| 31972 | [Ada and Power](https://www.spoj.com/problems/ADAPOWER) | 65 | 41.29 |
+| 31973 | [THE SHORTEST PATH](https://www.spoj.com/problems/ALCATRAZ4) | 37 | 32.05 |
+| 31974 | [Ada and Birthday](https://www.spoj.com/problems/ADAGIFT) | 47 | 25.16 |
+| 31975 | [Ada and Scarecrow](https://www.spoj.com/problems/ADACROW) | 14 | 16.06 |
+| 31976 | [Ada and Tulips](https://www.spoj.com/problems/ADASEED) | 20 | 18.80 |
+| 31979 | [Ada and Party](https://www.spoj.com/problems/ADAPARTY) | 25 | 56.36 |
+| 32028 | [Ada and Parties](https://www.spoj.com/problems/ADAPARTI) | 4 | 1.24 |
+| 32029 | [Ada and Connections](https://www.spoj.com/problems/ADACON) | 77 | 12.86 |
+| 32058 | [Harbinger vs Sciencepal](https://www.spoj.com/problems/R6PL) | 175 | 35.54 |
+| 32059 | [Ada and Taxes](https://www.spoj.com/problems/ADATAXES) | 113 | 36.48 |
+| 32065 | [Save Lord Tachanka](https://www.spoj.com/problems/TACHANKA) | 0 | 0.00 |
+| 32079 | [Ada and Greenflies](https://www.spoj.com/problems/ADAGF) | 210 | 45.83 |
+| 32086 | [The Permutation Game Again](https://www.spoj.com/problems/TPGA) | 165 | 44.52 |
+| 32088 | [Chessboard State 1: National Chess Tournament](https://www.spoj.com/problems/CSTATE1) | 15 | 23.11 |
+| 32091 | [Chessboard State 2: International Chess Tournament](https://www.spoj.com/problems/CSTATE2) | 6 | 17.14 |
+| 32092 | [Chessboard State 3: Intergalactic Chess Tournament](https://www.spoj.com/problems/CSTATE3) | 6 | 42.25 |
+| 32093 | [Where The Friends Meet!](https://www.spoj.com/problems/WTFM) | 42 | 28.89 |
+| 32103 | [Degree of a Tree](https://www.spoj.com/problems/TREEDEGREE) | 231 | 30.62 |
+| 32125 | [Flirtatious Verma](https://www.spoj.com/problems/VDATE) | 95 | 23.28 |
+| 32192 | [SUMMATION](https://www.spoj.com/problems/SUMMATION) | 578 | 23.13 |
+| 32199 | [Ada and Cherry](https://www.spoj.com/problems/ADACHERY) | 164 | 36.26 |
+| 32201 | [Right Shift](https://www.spoj.com/problems/RSHIFT) | 221 | 11.26 |
+| 32202 | [Share It](https://www.spoj.com/problems/SHAREIT) | 17 | 25.00 |
+| 32222 | [Ada and Panels](https://www.spoj.com/problems/ADAPANEL) | 71 | 44.20 |
+| 32223 | [Ada and Lychees](https://www.spoj.com/problems/ADALICI) | 18 | 22.97 |
+| 32235 | [SOLVEIT](https://www.spoj.com/problems/SOLVEIT) | 344 | 25.79 |
+| 32245 | [Apoorv and Maximum Inversion](https://www.spoj.com/problems/SAS001) | 150 | 33.15 |
+| 32257 | [Apoorv and Math problem](https://www.spoj.com/problems/SAS002) | 174 | 14.96 |
+| 32259 | [Walk home together](https://www.spoj.com/problems/WHT) | 40 | 9.88 |
+| 32271 | [KNIGHTS level testing](https://www.spoj.com/problems/KNIGHTSG) | 11 | 21.13 |
+| 32302 | [Ada and Replant](https://www.spoj.com/problems/ADAGROW) | 22 | 24.66 |
+| 32439 | [Ada and Bloom](https://www.spoj.com/problems/ADABLOOM) | 59 | 25.06 |
+| 32446 | [Sanvi and Magical Numbers](https://www.spoj.com/problems/SANVI) | 13 | 26.83 |
+| 32468 | [Frog Party](https://www.spoj.com/problems/FROGPARTY) | 69 | 27.38 |
+| 32469 | [Minions v/s Minions](https://www.spoj.com/problems/MINVSMIN) | 66 | 49.15 |
+| 32529 | [Nearest Neighbor Search](https://www.spoj.com/problems/NNS) | 21 | 32.76 |
+| 32567 | [First to meet the spaceship](https://www.spoj.com/problems/MEETSHIP) | 32 | 11.98 |
+| 32577 | [Ada and Terramorphing](https://www.spoj.com/problems/ADAPHOTO) | 280 | 12.11 |
+| 32578 | [Meh and Mini Splendor](https://www.spoj.com/problems/SPLEND1) | 11 | 62.50 |
+| 32579 | [Ada and Expenses](https://www.spoj.com/problems/ADASUM) | 376 | 51.23 |
+| 32595 | [Ada and Servers](https://www.spoj.com/problems/ADABASH) | 29 | 22.78 |
+| 32679 | [Ada and Roads](https://www.spoj.com/problems/ADAROADS) | 16 | 53.85 |

--- a/tests/spoj/index/73.jsonl
+++ b/tests/spoj/index/73.jsonl
@@ -1,0 +1,50 @@
+{"id":32683,"name":"Ada and Kohlrabi","url":"https://www.spoj.com/problems/ADAKOHL","users":73,"accepted":19.22}
+{"id":32724,"name":"nth number","url":"https://www.spoj.com/problems/THREENUMBERS","users":643,"accepted":24.6}
+{"id":32745,"name":"Ada and Harvest","url":"https://www.spoj.com/problems/ADACROP","users":294,"accepted":27.42}
+{"id":32791,"name":"Billi and Kaddu","url":"https://www.spoj.com/problems/BILLI","users":39,"accepted":41.26}
+{"id":32840,"name":"Ada and Digits","url":"https://www.spoj.com/problems/ADADIG","users":182,"accepted":41.2}
+{"id":32843,"name":"Ada and TicTacToe","url":"https://www.spoj.com/problems/ADAQUBIC","users":52,"accepted":20.51}
+{"id":32856,"name":"Ada and Contact","url":"https://www.spoj.com/problems/ADAPHONE","users":34,"accepted":25.69}
+{"id":32857,"name":"Angry Siam","url":"https://www.spoj.com/problems/HRSIAM","users":62,"accepted":34.21}
+{"id":32878,"name":"N..K..Divide","url":"https://www.spoj.com/problems/NKDIV","users":67,"accepted":21.74}
+{"id":32879,"name":"Mahammad and strings","url":"https://www.spoj.com/problems/SORTOUT","users":89,"accepted":10.98}
+{"id":32895,"name":"Match me if you can","url":"https://www.spoj.com/problems/STRMATCH","users":231,"accepted":10.25}
+{"id":32899,"name":"Mean of array","url":"https://www.spoj.com/problems/MEANARR","users":230,"accepted":34.39}
+{"id":32900,"name":"K-dominant array","url":"https://www.spoj.com/problems/KDOMINO","users":381,"accepted":31.53}
+{"id":32940,"name":"Alien Language","url":"https://www.spoj.com/problems/CODWRECK4","users":74,"accepted":40.77}
+{"id":32943,"name":"Ada and Unstable Sort","url":"https://www.spoj.com/problems/ADAUSORT","users":594,"accepted":41.47}
+{"id":32944,"name":"Ada and Friends","url":"https://www.spoj.com/problems/ADAFRIEN","users":966,"accepted":39}
+{"id":32945,"name":"Ada and Subsequence","url":"https://www.spoj.com/problems/ADASEQEN","users":1049,"accepted":46.74}
+{"id":32946,"name":"Ada and Branches","url":"https://www.spoj.com/problems/ADABRANC","users":342,"accepted":36.32}
+{"id":32947,"name":"Ada and Trees","url":"https://www.spoj.com/problems/ADATREE","users":199,"accepted":33.29}
+{"id":32948,"name":"Ada and Fimbers","url":"https://www.spoj.com/problems/ADAFIMBR","users":109,"accepted":26.63}
+{"id":32949,"name":"Ada and Digits 2","url":"https://www.spoj.com/problems/ADADIGIT","users":78,"accepted":33.12}
+{"id":32950,"name":"Ada and Plants 2","url":"https://www.spoj.com/problems/ADAPLNTS","users":84,"accepted":50.2}
+{"id":32951,"name":"Ada and Substring","url":"https://www.spoj.com/problems/ADASTRNG","users":429,"accepted":36.94}
+{"id":32952,"name":"Ada and Football","url":"https://www.spoj.com/problems/ADAFTBLL","users":235,"accepted":37.72}
+{"id":32961,"name":"Ada and Jobs","url":"https://www.spoj.com/problems/ADAJOBS","users":158,"accepted":10.37}
+{"id":33008,"name":"Ada and Squares","url":"https://www.spoj.com/problems/ADASQR","users":59,"accepted":38.53}
+{"id":33017,"name":"Ada and Mold","url":"https://www.spoj.com/problems/ADAMOLD","users":184,"accepted":35.64}
+{"id":33019,"name":"Catering Contracts","url":"https://www.spoj.com/problems/CATER","users":93,"accepted":34.31}
+{"id":33022,"name":"Ada and Hose","url":"https://www.spoj.com/problems/ADAHOSE","users":29,"accepted":49.19}
+{"id":33039,"name":"Amazing Factor Sequence (hard)","url":"https://www.spoj.com/problems/AFS3","users":22,"accepted":60}
+{"id":33046,"name":"Factorial Modulo Prime","url":"https://www.spoj.com/problems/FACTMODP","users":33,"accepted":16.38}
+{"id":33048,"name":"Find Linear Recurrence","url":"https://www.spoj.com/problems/FINDLR","users":24,"accepted":34.8}
+{"id":33049,"name":"Ada and Chess","url":"https://www.spoj.com/problems/ADACHESS","users":44,"accepted":18.6}
+{"id":33059,"name":"Ada and Palaces","url":"https://www.spoj.com/problems/ADACHES2","users":204,"accepted":66.42}
+{"id":33062,"name":"LCM Pesticide","url":"https://www.spoj.com/problems/LCMP","users":11,"accepted":35.94}
+{"id":33126,"name":"Ada and Lemon 1","url":"https://www.spoj.com/problems/ADALEMON","users":19,"accepted":42.75}
+{"id":33147,"name":"Ada and Lemon 2","url":"https://www.spoj.com/problems/ADACITRS","users":13,"accepted":47.22}
+{"id":33210,"name":"Ada and Alley","url":"https://www.spoj.com/problems/ADACUT","users":380,"accepted":37.33}
+{"id":33263,"name":"Ada and Tomel","url":"https://www.spoj.com/problems/ADATOMEL","users":42,"accepted":36.3}
+{"id":33299,"name":"Ada and Furrows","url":"https://www.spoj.com/problems/ADAFUROW","users":160,"accepted":60.89}
+{"id":33324,"name":"Ada and Salesman","url":"https://www.spoj.com/problems/ADASALE","users":42,"accepted":52.88}
+{"id":33331,"name":"Ada and Graft","url":"https://www.spoj.com/problems/ADAGRAFT","users":102,"accepted":50}
+{"id":33372,"name":"Lannister Army","url":"https://www.spoj.com/problems/LARMY","users":411,"accepted":20.99}
+{"id":33557,"name":"Ada and Banquet","url":"https://www.spoj.com/problems/ADABANKET","users":320,"accepted":58.51}
+{"id":33773,"name":"Ada and Dahlia","url":"https://www.spoj.com/problems/ADAHLIA","users":28,"accepted":17.56}
+{"id":33777,"name":"NT Games","url":"https://www.spoj.com/problems/NTG","users":77,"accepted":41.92}
+{"id":33795,"name":"Taskin and apple tree","url":"https://www.spoj.com/problems/TAKIN","users":322,"accepted":27.49}
+{"id":33820,"name":"Ada and Game of Divisors","url":"https://www.spoj.com/problems/ADAGAME4","users":124,"accepted":46.3}
+{"id":33906,"name":"Ada and Sets","url":"https://www.spoj.com/problems/ADASETS","users":49,"accepted":52.63}
+{"id":33932,"name":"Ada and Prime","url":"https://www.spoj.com/problems/ADAPRIME","users":83,"accepted":22.78}

--- a/tests/spoj/index/73.md
+++ b/tests/spoj/index/73.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 32683 | [Ada and Kohlrabi](https://www.spoj.com/problems/ADAKOHL) | 73 | 19.22 |
+| 32724 | [nth number](https://www.spoj.com/problems/THREENUMBERS) | 643 | 24.60 |
+| 32745 | [Ada and Harvest](https://www.spoj.com/problems/ADACROP) | 294 | 27.42 |
+| 32791 | [Billi and Kaddu](https://www.spoj.com/problems/BILLI) | 39 | 41.26 |
+| 32840 | [Ada and Digits](https://www.spoj.com/problems/ADADIG) | 182 | 41.20 |
+| 32843 | [Ada and TicTacToe](https://www.spoj.com/problems/ADAQUBIC) | 52 | 20.51 |
+| 32856 | [Ada and Contact](https://www.spoj.com/problems/ADAPHONE) | 34 | 25.69 |
+| 32857 | [Angry Siam](https://www.spoj.com/problems/HRSIAM) | 62 | 34.21 |
+| 32878 | [N..K..Divide](https://www.spoj.com/problems/NKDIV) | 67 | 21.74 |
+| 32879 | [Mahammad and strings](https://www.spoj.com/problems/SORTOUT) | 89 | 10.98 |
+| 32895 | [Match me if you can](https://www.spoj.com/problems/STRMATCH) | 231 | 10.25 |
+| 32899 | [Mean of array](https://www.spoj.com/problems/MEANARR) | 230 | 34.39 |
+| 32900 | [K-dominant array](https://www.spoj.com/problems/KDOMINO) | 381 | 31.53 |
+| 32940 | [Alien Language](https://www.spoj.com/problems/CODWRECK4) | 74 | 40.77 |
+| 32943 | [Ada and Unstable Sort](https://www.spoj.com/problems/ADAUSORT) | 594 | 41.47 |
+| 32944 | [Ada and Friends](https://www.spoj.com/problems/ADAFRIEN) | 966 | 39.00 |
+| 32945 | [Ada and Subsequence](https://www.spoj.com/problems/ADASEQEN) | 1049 | 46.74 |
+| 32946 | [Ada and Branches](https://www.spoj.com/problems/ADABRANC) | 342 | 36.32 |
+| 32947 | [Ada and Trees](https://www.spoj.com/problems/ADATREE) | 199 | 33.29 |
+| 32948 | [Ada and Fimbers](https://www.spoj.com/problems/ADAFIMBR) | 109 | 26.63 |
+| 32949 | [Ada and Digits 2](https://www.spoj.com/problems/ADADIGIT) | 78 | 33.12 |
+| 32950 | [Ada and Plants 2](https://www.spoj.com/problems/ADAPLNTS) | 84 | 50.20 |
+| 32951 | [Ada and Substring](https://www.spoj.com/problems/ADASTRNG) | 429 | 36.94 |
+| 32952 | [Ada and Football](https://www.spoj.com/problems/ADAFTBLL) | 235 | 37.72 |
+| 32961 | [Ada and Jobs](https://www.spoj.com/problems/ADAJOBS) | 158 | 10.37 |
+| 33008 | [Ada and Squares](https://www.spoj.com/problems/ADASQR) | 59 | 38.53 |
+| 33017 | [Ada and Mold](https://www.spoj.com/problems/ADAMOLD) | 184 | 35.64 |
+| 33019 | [Catering Contracts](https://www.spoj.com/problems/CATER) | 93 | 34.31 |
+| 33022 | [Ada and Hose](https://www.spoj.com/problems/ADAHOSE) | 29 | 49.19 |
+| 33039 | [Amazing Factor Sequence (hard)](https://www.spoj.com/problems/AFS3) | 22 | 60.00 |
+| 33046 | [Factorial Modulo Prime](https://www.spoj.com/problems/FACTMODP) | 33 | 16.38 |
+| 33048 | [Find Linear Recurrence](https://www.spoj.com/problems/FINDLR) | 24 | 34.80 |
+| 33049 | [Ada and Chess](https://www.spoj.com/problems/ADACHESS) | 44 | 18.60 |
+| 33059 | [Ada and Palaces](https://www.spoj.com/problems/ADACHES2) | 204 | 66.42 |
+| 33062 | [LCM Pesticide](https://www.spoj.com/problems/LCMP) | 11 | 35.94 |
+| 33126 | [Ada and Lemon 1](https://www.spoj.com/problems/ADALEMON) | 19 | 42.75 |
+| 33147 | [Ada and Lemon 2](https://www.spoj.com/problems/ADACITRS) | 13 | 47.22 |
+| 33210 | [Ada and Alley](https://www.spoj.com/problems/ADACUT) | 380 | 37.33 |
+| 33263 | [Ada and Tomel](https://www.spoj.com/problems/ADATOMEL) | 42 | 36.30 |
+| 33299 | [Ada and Furrows](https://www.spoj.com/problems/ADAFUROW) | 160 | 60.89 |
+| 33324 | [Ada and Salesman](https://www.spoj.com/problems/ADASALE) | 42 | 52.88 |
+| 33331 | [Ada and Graft](https://www.spoj.com/problems/ADAGRAFT) | 102 | 50.00 |
+| 33372 | [Lannister Army](https://www.spoj.com/problems/LARMY) | 411 | 20.99 |
+| 33557 | [Ada and Banquet](https://www.spoj.com/problems/ADABANKET) | 320 | 58.51 |
+| 33773 | [Ada and Dahlia](https://www.spoj.com/problems/ADAHLIA) | 28 | 17.56 |
+| 33777 | [NT Games](https://www.spoj.com/problems/NTG) | 77 | 41.92 |
+| 33795 | [Taskin and apple tree](https://www.spoj.com/problems/TAKIN) | 322 | 27.49 |
+| 33820 | [Ada and Game of Divisors](https://www.spoj.com/problems/ADAGAME4) | 124 | 46.30 |
+| 33906 | [Ada and Sets](https://www.spoj.com/problems/ADASETS) | 49 | 52.63 |
+| 33932 | [Ada and Prime](https://www.spoj.com/problems/ADAPRIME) | 83 | 22.78 |

--- a/tests/spoj/index/74.jsonl
+++ b/tests/spoj/index/74.jsonl
@@ -1,0 +1,50 @@
+{"id":33963,"name":"Ada and Palace Game","url":"https://www.spoj.com/problems/ADAGAME5","users":22,"accepted":26.12}
+{"id":33976,"name":"Ada and Christmas","url":"https://www.spoj.com/problems/ADAXMAS","users":13,"accepted":51.16}
+{"id":33999,"name":"Ada and Primal Fear","url":"https://www.spoj.com/problems/ADAFEAR","users":31,"accepted":27.22}
+{"id":34007,"name":"Adrita and Marbles","url":"https://www.spoj.com/problems/ADAM1","users":229,"accepted":47.45}
+{"id":34009,"name":"Counting Child","url":"https://www.spoj.com/problems/CTTC","users":467,"accepted":55.71}
+{"id":34011,"name":"Jalil Got TLE","url":"https://www.spoj.com/problems/JGTLE","users":525,"accepted":26.05}
+{"id":34012,"name":"Adrita and Her Bike Ride","url":"https://www.spoj.com/problems/ADRABR","users":158,"accepted":32.79}
+{"id":34013,"name":"Seetha’s Unique Game","url":"https://www.spoj.com/problems/SEUG","users":322,"accepted":59.15}
+{"id":34020,"name":"Ada and Pet","url":"https://www.spoj.com/problems/ADAPET","users":654,"accepted":26.99}
+{"id":34021,"name":"Prefix Square Free Words","url":"https://www.spoj.com/problems/PSFWORDS","users":10,"accepted":12.04}
+{"id":34025,"name":"Palindrome Maker","url":"https://www.spoj.com/problems/PALMKR","users":81,"accepted":58.33}
+{"id":34032,"name":"Chiaki With Intervals","url":"https://www.spoj.com/problems/INTDSET","users":31,"accepted":44.58}
+{"id":34063,"name":"Chiaki With Intervals (Easy)","url":"https://www.spoj.com/problems/INTDSET2","users":22,"accepted":27.96}
+{"id":34096,"name":"Counting Divisors (general)","url":"https://www.spoj.com/problems/DIVCNTK","users":366,"accepted":36.88}
+{"id":34103,"name":"Chiaki Sequence","url":"https://www.spoj.com/problems/A001856","users":13,"accepted":23.94}
+{"id":34112,"name":"The Sum of Unitary Divisors","url":"https://www.spoj.com/problems/UDIVSUM","users":91,"accepted":31.09}
+{"id":34117,"name":"Just a Palindrome","url":"https://www.spoj.com/problems/JUSTAPAL","users":29,"accepted":8.76}
+{"id":34118,"name":"Prime Pesticide","url":"https://www.spoj.com/problems/PRIMEP","users":25,"accepted":16.83}
+{"id":34127,"name":"Gray Code and Twos Complement","url":"https://www.spoj.com/problems/GCATC","users":17,"accepted":11.8}
+{"id":34183,"name":"Tower of Hanoi Movement - Hard","url":"https://www.spoj.com/problems/TOHMOVE2","users":96,"accepted":27.27}
+{"id":34222,"name":"Bucket Selection","url":"https://www.spoj.com/problems/SELECTION","users":25,"accepted":15.76}
+{"id":34229,"name":"\"Operation - Modulo\"","url":"https://www.spoj.com/problems/OPMODULO","users":951,"accepted":19.44}
+{"id":34247,"name":"Agent prefix","url":"https://www.spoj.com/problems/AGPREFX","users":56,"accepted":38.22}
+{"id":34254,"name":"Huseyn and his game","url":"https://www.spoj.com/problems/HUSGAME","users":111,"accepted":29.39}
+{"id":34260,"name":"Signpost reading","url":"https://www.spoj.com/problems/SIGNPOST","users":28,"accepted":20.41}
+{"id":34275,"name":"Game Store","url":"https://www.spoj.com/problems/GMSTRE","users":212,"accepted":48.72}
+{"id":34282,"name":"Traffic Planning","url":"https://www.spoj.com/problems/TRFPLN","users":18,"accepted":30.56}
+{"id":34301,"name":"Map Exploration Cost","url":"https://www.spoj.com/problems/MAPEXC","users":25,"accepted":39.29}
+{"id":34314,"name":"Spaceships in Space","url":"https://www.spoj.com/problems/SPA","users":21,"accepted":33.94}
+{"id":34315,"name":"The Chase","url":"https://www.spoj.com/problems/CHA","users":5,"accepted":8.22}
+{"id":34327,"name":"Cyclic Counting Gamble","url":"https://www.spoj.com/problems/CCGAMBLE","users":17,"accepted":12.84}
+{"id":34352,"name":"Cake Walk","url":"https://www.spoj.com/problems/CKEWLK","users":54,"accepted":38.89}
+{"id":34353,"name":"Smelly Toilets","url":"https://www.spoj.com/problems/SMTOILET","users":9,"accepted":16.95}
+{"id":34356,"name":"Ludic Numbers (medium)","url":"https://www.spoj.com/problems/LUDIC1","users":61,"accepted":30.32}
+{"id":34357,"name":"Ludic Numbers (hard)","url":"https://www.spoj.com/problems/LUDIC2","users":4,"accepted":14.63}
+{"id":34359,"name":"Triangle on Binary Tree","url":"https://www.spoj.com/problems/TRIBT","users":37,"accepted":49.57}
+{"id":34370,"name":"Incomplete hierarchy","url":"https://www.spoj.com/problems/PODUZECE","users":21,"accepted":11.59}
+{"id":34373,"name":"Clickbait","url":"https://www.spoj.com/problems/CLCKBAIT","users":25,"accepted":33.93}
+{"id":34374,"name":"Samvel and Boxes","url":"https://www.spoj.com/problems/SAMBOX","users":55,"accepted":31.29}
+{"id":34376,"name":"Difference One Swaps","url":"https://www.spoj.com/problems/SWAPDIFF1","users":75,"accepted":48.6}
+{"id":34377,"name":"Digit Subsequence","url":"https://www.spoj.com/problems/YOSEQ","users":256,"accepted":35.84}
+{"id":34379,"name":"Another Travelling Salesman Problem","url":"https://www.spoj.com/problems/YOSALES","users":12,"accepted":12.28}
+{"id":34380,"name":"Even Semiprime Runs","url":"https://www.spoj.com/problems/EVENSEMIP","users":27,"accepted":63.45}
+{"id":34385,"name":"Pripyat","url":"https://www.spoj.com/problems/PRIPYAT","users":6,"accepted":26.09}
+{"id":34409,"name":"Disconnected country","url":"https://www.spoj.com/problems/DISGRAPH","users":49,"accepted":22.2}
+{"id":34480,"name":"Profiling","url":"https://www.spoj.com/problems/PROFILING","users":97,"accepted":28.64}
+{"id":34481,"name":"Galactic Division","url":"https://www.spoj.com/problems/GALACDIV","users":9,"accepted":6.67}
+{"id":34482,"name":"Allowed Factors","url":"https://www.spoj.com/problems/ALWFACT","users":77,"accepted":27.64}
+{"id":34484,"name":"Candy pair","url":"https://www.spoj.com/problems/CANPR","users":64,"accepted":42.15}
+{"id":34499,"name":"So Many Squares","url":"https://www.spoj.com/problems/SQRPERF","users":27,"accepted":23.76}

--- a/tests/spoj/index/74.md
+++ b/tests/spoj/index/74.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 33963 | [Ada and Palace Game](https://www.spoj.com/problems/ADAGAME5) | 22 | 26.12 |
+| 33976 | [Ada and Christmas](https://www.spoj.com/problems/ADAXMAS) | 13 | 51.16 |
+| 33999 | [Ada and Primal Fear](https://www.spoj.com/problems/ADAFEAR) | 31 | 27.22 |
+| 34007 | [Adrita and Marbles](https://www.spoj.com/problems/ADAM1) | 229 | 47.45 |
+| 34009 | [Counting Child](https://www.spoj.com/problems/CTTC) | 467 | 55.71 |
+| 34011 | [Jalil Got TLE](https://www.spoj.com/problems/JGTLE) | 525 | 26.05 |
+| 34012 | [Adrita and Her Bike Ride](https://www.spoj.com/problems/ADRABR) | 158 | 32.79 |
+| 34013 | [Seetha’s Unique Game](https://www.spoj.com/problems/SEUG) | 322 | 59.15 |
+| 34020 | [Ada and Pet](https://www.spoj.com/problems/ADAPET) | 654 | 26.99 |
+| 34021 | [Prefix Square Free Words](https://www.spoj.com/problems/PSFWORDS) | 10 | 12.04 |
+| 34025 | [Palindrome Maker](https://www.spoj.com/problems/PALMKR) | 81 | 58.33 |
+| 34032 | [Chiaki With Intervals](https://www.spoj.com/problems/INTDSET) | 31 | 44.58 |
+| 34063 | [Chiaki With Intervals (Easy)](https://www.spoj.com/problems/INTDSET2) | 22 | 27.96 |
+| 34096 | [Counting Divisors (general)](https://www.spoj.com/problems/DIVCNTK) | 366 | 36.88 |
+| 34103 | [Chiaki Sequence](https://www.spoj.com/problems/A001856) | 13 | 23.94 |
+| 34112 | [The Sum of Unitary Divisors](https://www.spoj.com/problems/UDIVSUM) | 91 | 31.09 |
+| 34117 | [Just a Palindrome](https://www.spoj.com/problems/JUSTAPAL) | 29 | 8.76 |
+| 34118 | [Prime Pesticide](https://www.spoj.com/problems/PRIMEP) | 25 | 16.83 |
+| 34127 | [Gray Code and Twos Complement](https://www.spoj.com/problems/GCATC) | 17 | 11.80 |
+| 34183 | [Tower of Hanoi Movement - Hard](https://www.spoj.com/problems/TOHMOVE2) | 96 | 27.27 |
+| 34222 | [Bucket Selection](https://www.spoj.com/problems/SELECTION) | 25 | 15.76 |
+| 34229 | ["Operation - Modulo"](https://www.spoj.com/problems/OPMODULO) | 951 | 19.44 |
+| 34247 | [Agent prefix](https://www.spoj.com/problems/AGPREFX) | 56 | 38.22 |
+| 34254 | [Huseyn and his game](https://www.spoj.com/problems/HUSGAME) | 111 | 29.39 |
+| 34260 | [Signpost reading](https://www.spoj.com/problems/SIGNPOST) | 28 | 20.41 |
+| 34275 | [Game Store](https://www.spoj.com/problems/GMSTRE) | 212 | 48.72 |
+| 34282 | [Traffic Planning](https://www.spoj.com/problems/TRFPLN) | 18 | 30.56 |
+| 34301 | [Map Exploration Cost](https://www.spoj.com/problems/MAPEXC) | 25 | 39.29 |
+| 34314 | [Spaceships in Space](https://www.spoj.com/problems/SPA) | 21 | 33.94 |
+| 34315 | [The Chase](https://www.spoj.com/problems/CHA) | 5 | 8.22 |
+| 34327 | [Cyclic Counting Gamble](https://www.spoj.com/problems/CCGAMBLE) | 17 | 12.84 |
+| 34352 | [Cake Walk](https://www.spoj.com/problems/CKEWLK) | 54 | 38.89 |
+| 34353 | [Smelly Toilets](https://www.spoj.com/problems/SMTOILET) | 9 | 16.95 |
+| 34356 | [Ludic Numbers (medium)](https://www.spoj.com/problems/LUDIC1) | 61 | 30.32 |
+| 34357 | [Ludic Numbers (hard)](https://www.spoj.com/problems/LUDIC2) | 4 | 14.63 |
+| 34359 | [Triangle on Binary Tree](https://www.spoj.com/problems/TRIBT) | 37 | 49.57 |
+| 34370 | [Incomplete hierarchy](https://www.spoj.com/problems/PODUZECE) | 21 | 11.59 |
+| 34373 | [Clickbait](https://www.spoj.com/problems/CLCKBAIT) | 25 | 33.93 |
+| 34374 | [Samvel and Boxes](https://www.spoj.com/problems/SAMBOX) | 55 | 31.29 |
+| 34376 | [Difference One Swaps](https://www.spoj.com/problems/SWAPDIFF1) | 75 | 48.60 |
+| 34377 | [Digit Subsequence](https://www.spoj.com/problems/YOSEQ) | 256 | 35.84 |
+| 34379 | [Another Travelling Salesman Problem](https://www.spoj.com/problems/YOSALES) | 12 | 12.28 |
+| 34380 | [Even Semiprime Runs](https://www.spoj.com/problems/EVENSEMIP) | 27 | 63.45 |
+| 34385 | [Pripyat](https://www.spoj.com/problems/PRIPYAT) | 6 | 26.09 |
+| 34409 | [Disconnected country](https://www.spoj.com/problems/DISGRAPH) | 49 | 22.20 |
+| 34480 | [Profiling](https://www.spoj.com/problems/PROFILING) | 97 | 28.64 |
+| 34481 | [Galactic Division](https://www.spoj.com/problems/GALACDIV) | 9 | 6.67 |
+| 34482 | [Allowed Factors](https://www.spoj.com/problems/ALWFACT) | 77 | 27.64 |
+| 34484 | [Candy pair](https://www.spoj.com/problems/CANPR) | 64 | 42.15 |
+| 34499 | [So Many Squares](https://www.spoj.com/problems/SQRPERF) | 27 | 23.76 |

--- a/tests/spoj/index/75.jsonl
+++ b/tests/spoj/index/75.jsonl
@@ -1,0 +1,50 @@
+{"id":34501,"name":"Divisible Strings","url":"https://www.spoj.com/problems/DIVSTR","users":218,"accepted":28.77}
+{"id":34502,"name":"ZERO TRIPLET","url":"https://www.spoj.com/problems/THRSUM","users":84,"accepted":16.11}
+{"id":34536,"name":"MultiSort","url":"https://www.spoj.com/problems/MULSORT","users":179,"accepted":21.36}
+{"id":34537,"name":"Prime Lover Finding","url":"https://www.spoj.com/problems/PLOVER","users":67,"accepted":29.43}
+{"id":34542,"name":"Lord of Light","url":"https://www.spoj.com/problems/PKPLOL","users":312,"accepted":36}
+{"id":34545,"name":"Tama Starks Prime Apprenticeship","url":"https://www.spoj.com/problems/NASPRIM","users":53,"accepted":18.47}
+{"id":34549,"name":"Mysteriousness of a Logical Expression","url":"https://www.spoj.com/problems/MYLOGEXP","users":66,"accepted":10.93}
+{"id":34551,"name":"Stopping-off Cities","url":"https://www.spoj.com/problems/STOPCITY","users":72,"accepted":18.08}
+{"id":34557,"name":"Apoorv Loves Primes","url":"https://www.spoj.com/problems/SAS003","users":54,"accepted":44.61}
+{"id":34565,"name":"Tetrahedrons in the country","url":"https://www.spoj.com/problems/TTRGRAPH","users":55,"accepted":43.88}
+{"id":34575,"name":"A New Task for Ibrahim","url":"https://www.spoj.com/problems/IBIGAME","users":39,"accepted":52.48}
+{"id":34610,"name":"Sharmeen Loves Mozahid Loves Sharmeen [ HARD ]","url":"https://www.spoj.com/problems/MOZHSLM","users":168,"accepted":42.29}
+{"id":34612,"name":"Can Sharmeen Solve it? [ HARD  ]","url":"https://www.spoj.com/problems/MOZHCAN","users":30,"accepted":28.44}
+{"id":34615,"name":"Sharmeen Loves Substring [ HARD ]","url":"https://www.spoj.com/problems/MOZHSLS","users":83,"accepted":37.43}
+{"id":34616,"name":"Taming the Dragon","url":"https://www.spoj.com/problems/DRAGKING","users":102,"accepted":32.64}
+{"id":34617,"name":"Palindrome Lover","url":"https://www.spoj.com/problems/PL","users":179,"accepted":25.25}
+{"id":34619,"name":"Pizza Prize","url":"https://www.spoj.com/problems/PPR","users":131,"accepted":46.88}
+{"id":34621,"name":"NARUTO AND HILLS","url":"https://www.spoj.com/problems/NARHIL","users":48,"accepted":38.03}
+{"id":34622,"name":"NICE  SEQUENCES","url":"https://www.spoj.com/problems/NICESEQ","users":165,"accepted":50.66}
+{"id":34623,"name":"Jeremías y sus loros","url":"https://www.spoj.com/problems/JBIRDS","users":329,"accepted":68}
+{"id":34624,"name":"Longest palindrome with no adjacent duplicates","url":"https://www.spoj.com/problems/LNGPALN","users":95,"accepted":31.59}
+{"id":34636,"name":"Richie Rich and Keen Bean","url":"https://www.spoj.com/problems/ATMCMXNG","users":51,"accepted":45.24}
+{"id":34648,"name":"Seven","url":"https://www.spoj.com/problems/SE7EN","users":45,"accepted":44.44}
+{"id":34670,"name":"TWISTED ARRAY","url":"https://www.spoj.com/problems/ARRTWIST","users":206,"accepted":40.55}
+{"id":34681,"name":"Lovely Kitty","url":"https://www.spoj.com/problems/AVLVKT","users":36,"accepted":23.58}
+{"id":34682,"name":"Good Elements","url":"https://www.spoj.com/problems/OVGDEL","users":146,"accepted":29.56}
+{"id":34683,"name":"Billing Issue","url":"https://www.spoj.com/problems/NABILISU","users":397,"accepted":49.53}
+{"id":34684,"name":"Secret Service Agent","url":"https://www.spoj.com/problems/RZSCSRVC","users":35,"accepted":41.86}
+{"id":34685,"name":"Playing With Subarray","url":"https://www.spoj.com/problems/MOZPWS","users":123,"accepted":37.39}
+{"id":34686,"name":"Meet Her Fast!","url":"https://www.spoj.com/problems/ASHMHF","users":144,"accepted":42.05}
+{"id":34705,"name":"Secret Recipe","url":"https://www.spoj.com/problems/SKS001","users":158,"accepted":39.82}
+{"id":34719,"name":"Gift Arrangement","url":"https://www.spoj.com/problems/GIFTARNG","users":18,"accepted":38.6}
+{"id":34736,"name":"Beautiful Girl","url":"https://www.spoj.com/problems/BGIRL","users":151,"accepted":42.12}
+{"id":34742,"name":"Help Robin!!","url":"https://www.spoj.com/problems/CHUNK1","users":16,"accepted":7.87}
+{"id":34743,"name":"Popatlal ki shaadi","url":"https://www.spoj.com/problems/CHUNK2","users":313,"accepted":20.62}
+{"id":34812,"name":"Kth Power Summation","url":"https://www.spoj.com/problems/KPOWERSUM","users":61,"accepted":16.64}
+{"id":34826,"name":"Shinchan and Magic Card","url":"https://www.spoj.com/problems/SHINCARD","users":117,"accepted":45.52}
+{"id":34863,"name":"A Cumulative Sum Problem","url":"https://www.spoj.com/problems/OVICUMSUM","users":39,"accepted":22.31}
+{"id":34864,"name":"Large Sum","url":"https://www.spoj.com/problems/OVISLARSUM","users":236,"accepted":18.39}
+{"id":34865,"name":"Scary Secret Diary","url":"https://www.spoj.com/problems/TAHSINREC","users":23,"accepted":39.36}
+{"id":34867,"name":"Coding Test","url":"https://www.spoj.com/problems/REAYZCODETST","users":159,"accepted":24.22}
+{"id":34875,"name":"Minimum Stocks","url":"https://www.spoj.com/problems/MINSTOCK","users":674,"accepted":25.46}
+{"id":34886,"name":"Impress zing","url":"https://www.spoj.com/problems/ZING01","users":110,"accepted":23.79}
+{"id":34908,"name":"Cheesy line","url":"https://www.spoj.com/problems/ZING02","users":66,"accepted":31.34}
+{"id":34909,"name":"Keyword Finder","url":"https://www.spoj.com/problems/SHAKILKEYWORD","users":105,"accepted":29.6}
+{"id":34910,"name":"Easy Math","url":"https://www.spoj.com/problems/PRADIPSUM","users":620,"accepted":18.42}
+{"id":34923,"name":"Hack the Password","url":"https://www.spoj.com/problems/NABILHACKER","users":431,"accepted":22.82}
+{"id":34929,"name":"x-Xor It!","url":"https://www.spoj.com/problems/XORX","users":354,"accepted":27.99}
+{"id":34945,"name":"Euler Puzzle","url":"https://www.spoj.com/problems/CIRCLEDIV","users":138,"accepted":38.49}
+{"id":34973,"name":"Yet Another Subset Sum Problem","url":"https://www.spoj.com/problems/SUBSUMP","users":4,"accepted":2.56}

--- a/tests/spoj/index/75.md
+++ b/tests/spoj/index/75.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 34501 | [Divisible Strings](https://www.spoj.com/problems/DIVSTR) | 218 | 28.77 |
+| 34502 | [ZERO TRIPLET](https://www.spoj.com/problems/THRSUM) | 84 | 16.11 |
+| 34536 | [MultiSort](https://www.spoj.com/problems/MULSORT) | 179 | 21.36 |
+| 34537 | [Prime Lover Finding](https://www.spoj.com/problems/PLOVER) | 67 | 29.43 |
+| 34542 | [Lord of Light](https://www.spoj.com/problems/PKPLOL) | 312 | 36.00 |
+| 34545 | [Tama Starks Prime Apprenticeship](https://www.spoj.com/problems/NASPRIM) | 53 | 18.47 |
+| 34549 | [Mysteriousness of a Logical Expression](https://www.spoj.com/problems/MYLOGEXP) | 66 | 10.93 |
+| 34551 | [Stopping-off Cities](https://www.spoj.com/problems/STOPCITY) | 72 | 18.08 |
+| 34557 | [Apoorv Loves Primes](https://www.spoj.com/problems/SAS003) | 54 | 44.61 |
+| 34565 | [Tetrahedrons in the country](https://www.spoj.com/problems/TTRGRAPH) | 55 | 43.88 |
+| 34575 | [A New Task for Ibrahim](https://www.spoj.com/problems/IBIGAME) | 39 | 52.48 |
+| 34610 | [Sharmeen Loves Mozahid Loves Sharmeen [ HARD ]](https://www.spoj.com/problems/MOZHSLM) | 168 | 42.29 |
+| 34612 | [Can Sharmeen Solve it? [ HARD  ]](https://www.spoj.com/problems/MOZHCAN) | 30 | 28.44 |
+| 34615 | [Sharmeen Loves Substring [ HARD ]](https://www.spoj.com/problems/MOZHSLS) | 83 | 37.43 |
+| 34616 | [Taming the Dragon](https://www.spoj.com/problems/DRAGKING) | 102 | 32.64 |
+| 34617 | [Palindrome Lover](https://www.spoj.com/problems/PL) | 179 | 25.25 |
+| 34619 | [Pizza Prize](https://www.spoj.com/problems/PPR) | 131 | 46.88 |
+| 34621 | [NARUTO AND HILLS](https://www.spoj.com/problems/NARHIL) | 48 | 38.03 |
+| 34622 | [NICE  SEQUENCES](https://www.spoj.com/problems/NICESEQ) | 165 | 50.66 |
+| 34623 | [Jeremías y sus loros](https://www.spoj.com/problems/JBIRDS) | 329 | 68.00 |
+| 34624 | [Longest palindrome with no adjacent duplicates](https://www.spoj.com/problems/LNGPALN) | 95 | 31.59 |
+| 34636 | [Richie Rich and Keen Bean](https://www.spoj.com/problems/ATMCMXNG) | 51 | 45.24 |
+| 34648 | [Seven](https://www.spoj.com/problems/SE7EN) | 45 | 44.44 |
+| 34670 | [TWISTED ARRAY](https://www.spoj.com/problems/ARRTWIST) | 206 | 40.55 |
+| 34681 | [Lovely Kitty](https://www.spoj.com/problems/AVLVKT) | 36 | 23.58 |
+| 34682 | [Good Elements](https://www.spoj.com/problems/OVGDEL) | 146 | 29.56 |
+| 34683 | [Billing Issue](https://www.spoj.com/problems/NABILISU) | 397 | 49.53 |
+| 34684 | [Secret Service Agent](https://www.spoj.com/problems/RZSCSRVC) | 35 | 41.86 |
+| 34685 | [Playing With Subarray](https://www.spoj.com/problems/MOZPWS) | 123 | 37.39 |
+| 34686 | [Meet Her Fast!](https://www.spoj.com/problems/ASHMHF) | 144 | 42.05 |
+| 34705 | [Secret Recipe](https://www.spoj.com/problems/SKS001) | 158 | 39.82 |
+| 34719 | [Gift Arrangement](https://www.spoj.com/problems/GIFTARNG) | 18 | 38.60 |
+| 34736 | [Beautiful Girl](https://www.spoj.com/problems/BGIRL) | 151 | 42.12 |
+| 34742 | [Help Robin!!](https://www.spoj.com/problems/CHUNK1) | 16 | 7.87 |
+| 34743 | [Popatlal ki shaadi](https://www.spoj.com/problems/CHUNK2) | 313 | 20.62 |
+| 34812 | [Kth Power Summation](https://www.spoj.com/problems/KPOWERSUM) | 61 | 16.64 |
+| 34826 | [Shinchan and Magic Card](https://www.spoj.com/problems/SHINCARD) | 117 | 45.52 |
+| 34863 | [A Cumulative Sum Problem](https://www.spoj.com/problems/OVICUMSUM) | 39 | 22.31 |
+| 34864 | [Large Sum](https://www.spoj.com/problems/OVISLARSUM) | 236 | 18.39 |
+| 34865 | [Scary Secret Diary](https://www.spoj.com/problems/TAHSINREC) | 23 | 39.36 |
+| 34867 | [Coding Test](https://www.spoj.com/problems/REAYZCODETST) | 159 | 24.22 |
+| 34875 | [Minimum Stocks](https://www.spoj.com/problems/MINSTOCK) | 674 | 25.46 |
+| 34886 | [Impress zing](https://www.spoj.com/problems/ZING01) | 110 | 23.79 |
+| 34908 | [Cheesy line](https://www.spoj.com/problems/ZING02) | 66 | 31.34 |
+| 34909 | [Keyword Finder](https://www.spoj.com/problems/SHAKILKEYWORD) | 105 | 29.60 |
+| 34910 | [Easy Math](https://www.spoj.com/problems/PRADIPSUM) | 620 | 18.42 |
+| 34923 | [Hack the Password](https://www.spoj.com/problems/NABILHACKER) | 431 | 22.82 |
+| 34929 | [x-Xor It!](https://www.spoj.com/problems/XORX) | 354 | 27.99 |
+| 34945 | [Euler Puzzle](https://www.spoj.com/problems/CIRCLEDIV) | 138 | 38.49 |
+| 34973 | [Yet Another Subset Sum Problem](https://www.spoj.com/problems/SUBSUMP) | 4 | 2.56 |

--- a/tests/spoj/index/76.jsonl
+++ b/tests/spoj/index/76.jsonl
@@ -1,0 +1,50 @@
+{"id":34975,"name":"Prime Friendly Numbers","url":"https://www.spoj.com/problems/PRMFN","users":45,"accepted":20.11}
+{"id":35028,"name":"Long Tiling","url":"https://www.spoj.com/problems/LNTILING","users":41,"accepted":21.5}
+{"id":35075,"name":"Teleporters and Gems","url":"https://www.spoj.com/problems/TLPNGEM","users":55,"accepted":52.38}
+{"id":35088,"name":"A Complex Cone","url":"https://www.spoj.com/problems/ACC","users":58,"accepted":22.46}
+{"id":35140,"name":"Count Pairs","url":"https://www.spoj.com/problems/ILD18ACP","users":65,"accepted":25.92}
+{"id":35144,"name":"High CG Boy","url":"https://www.spoj.com/problems/CGBOY","users":291,"accepted":46.06}
+{"id":35145,"name":"Love Guru","url":"https://www.spoj.com/problems/LOVEGURU","users":118,"accepted":23.11}
+{"id":35146,"name":"Make IUT Great Again","url":"https://www.spoj.com/problems/MIUTGA","users":21,"accepted":23.48}
+{"id":35147,"name":"Bermuda Love Triangle","url":"https://www.spoj.com/problems/BEMINE","users":48,"accepted":58.6}
+{"id":35150,"name":"Line Follower Robot","url":"https://www.spoj.com/problems/ILOVEGEO","users":19,"accepted":45.28}
+{"id":35151,"name":"Beautiful Roll Numbers","url":"https://www.spoj.com/problems/NUMBERTH","users":75,"accepted":65.19}
+{"id":35152,"name":"Best Saved For The Last","url":"https://www.spoj.com/problems/HEADBANG","users":14,"accepted":24.44}
+{"id":35154,"name":"Coder Or NonCoder","url":"https://www.spoj.com/problems/CODECODE","users":272,"accepted":44.6}
+{"id":35155,"name":"Professional Stalker","url":"https://www.spoj.com/problems/BHAGO","users":12,"accepted":17.86}
+{"id":35196,"name":"Pandas are the best Lovers","url":"https://www.spoj.com/problems/PALOVE","users":28,"accepted":47.47}
+{"id":35276,"name":"Smallest on the Stack","url":"https://www.spoj.com/problems/MINSTACK","users":912,"accepted":15.08}
+{"id":35277,"name":"DNA of Elf","url":"https://www.spoj.com/problems/DNAOFELF","users":20,"accepted":31.3}
+{"id":35278,"name":"Earth Sled Tour","url":"https://www.spoj.com/problems/CNURI18H","users":31,"accepted":28.77}
+{"id":35281,"name":"Noel and His Reindeer","url":"https://www.spoj.com/problems/DABRI001","users":32,"accepted":35.43}
+{"id":35283,"name":"Full Sleigh","url":"https://www.spoj.com/problems/TRENOLOT","users":21,"accepted":22.64}
+{"id":35284,"name":"Digit Root","url":"https://www.spoj.com/problems/DIGITROOT","users":107,"accepted":36.34}
+{"id":35287,"name":"Magical Matrices","url":"https://www.spoj.com/problems/MAGMAT","users":1,"accepted":1.02}
+{"id":35295,"name":"zig-zag on the golden river","url":"https://www.spoj.com/problems/GRZZ","users":124,"accepted":22.97}
+{"id":35301,"name":"Evaluate Escape Character","url":"https://www.spoj.com/problems/ESCAPE1","users":21,"accepted":41.91}
+{"id":35337,"name":"Faketorial Hashing","url":"https://www.spoj.com/problems/FAKEHASH","users":15,"accepted":10.63}
+{"id":35363,"name":"The World of Charges","url":"https://www.spoj.com/problems/CHARGY","users":174,"accepted":36.78}
+{"id":35381,"name":"VALENTINE","url":"https://www.spoj.com/problems/KUMAR2019","users":42,"accepted":27.5}
+{"id":35435,"name":"love and traffic","url":"https://www.spoj.com/problems/LTRAFFIC","users":55,"accepted":52.25}
+{"id":35535,"name":"Bill of Fare","url":"https://www.spoj.com/problems/BILFAR","users":0,"accepted":0}
+{"id":35552,"name":"Fibonacci Power Sum","url":"https://www.spoj.com/problems/FIBPWSUM","users":39,"accepted":39.1}
+{"id":35582,"name":"Fibonacci Power Sum (hard)","url":"https://www.spoj.com/problems/FIBPSUM2","users":21,"accepted":39.05}
+{"id":35631,"name":"Moon Safari (Extreme)","url":"https://www.spoj.com/problems/MOON4","users":10,"accepted":33.7}
+{"id":35669,"name":"Consecutive Letters","url":"https://www.spoj.com/problems/CONSEC","users":582,"accepted":26.74}
+{"id":35672,"name":"Try to learn properly","url":"https://www.spoj.com/problems/LDP","users":47,"accepted":16.17}
+{"id":35674,"name":"COLORFUL ARRAY","url":"https://www.spoj.com/problems/CLFLARR","users":1772,"accepted":41.33}
+{"id":35675,"name":"Primes in GCD Table (Hard)","url":"https://www.spoj.com/problems/PGCD2","users":14,"accepted":25.27}
+{"id":35716,"name":"Trending GCD (Hard)","url":"https://www.spoj.com/problems/TGCD2","users":17,"accepted":46.15}
+{"id":35810,"name":"Prismata","url":"https://www.spoj.com/problems/PRISMATA","users":5,"accepted":5.71}
+{"id":35954,"name":"New Data Type","url":"https://www.spoj.com/problems/NDT","users":123,"accepted":18.92}
+{"id":35956,"name":"Square Free Number","url":"https://www.spoj.com/problems/SFN","users":69,"accepted":38.31}
+{"id":35988,"name":"Power Play","url":"https://www.spoj.com/problems/BAPPP","users":25,"accepted":20.86}
+{"id":36122,"name":"Machine Cooling","url":"https://www.spoj.com/problems/MACHCOOL","users":51,"accepted":61.54}
+{"id":36123,"name":"Plant the potatoes","url":"https://www.spoj.com/problems/POTATOPL","users":18,"accepted":15.15}
+{"id":36132,"name":"Rightful Distribution","url":"https://www.spoj.com/problems/SK_001","users":157,"accepted":40.91}
+{"id":36134,"name":"Ono at the river 1","url":"https://www.spoj.com/problems/ONORIVER1","users":15,"accepted":18.11}
+{"id":36142,"name":"Random modulo n","url":"https://www.spoj.com/problems/RANDMOD","users":79,"accepted":60.59}
+{"id":36144,"name":"The Cow Gathering","url":"https://www.spoj.com/problems/COWGATH","users":38,"accepted":26.74}
+{"id":36145,"name":"Machine Cooling II","url":"https://www.spoj.com/problems/MACHCOOL2","users":38,"accepted":18.87}
+{"id":36166,"name":"Lucifer and Magical Substrings","url":"https://www.spoj.com/problems/MAGSUB1","users":105,"accepted":46.38}
+{"id":36199,"name":"Subset with all Digits","url":"https://www.spoj.com/problems/THECODE","users":246,"accepted":33.86}

--- a/tests/spoj/index/76.md
+++ b/tests/spoj/index/76.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 34975 | [Prime Friendly Numbers](https://www.spoj.com/problems/PRMFN) | 45 | 20.11 |
+| 35028 | [Long Tiling](https://www.spoj.com/problems/LNTILING) | 41 | 21.50 |
+| 35075 | [Teleporters and Gems](https://www.spoj.com/problems/TLPNGEM) | 55 | 52.38 |
+| 35088 | [A Complex Cone](https://www.spoj.com/problems/ACC) | 58 | 22.46 |
+| 35140 | [Count Pairs](https://www.spoj.com/problems/ILD18ACP) | 65 | 25.92 |
+| 35144 | [High CG Boy](https://www.spoj.com/problems/CGBOY) | 291 | 46.06 |
+| 35145 | [Love Guru](https://www.spoj.com/problems/LOVEGURU) | 118 | 23.11 |
+| 35146 | [Make IUT Great Again](https://www.spoj.com/problems/MIUTGA) | 21 | 23.48 |
+| 35147 | [Bermuda Love Triangle](https://www.spoj.com/problems/BEMINE) | 48 | 58.60 |
+| 35150 | [Line Follower Robot](https://www.spoj.com/problems/ILOVEGEO) | 19 | 45.28 |
+| 35151 | [Beautiful Roll Numbers](https://www.spoj.com/problems/NUMBERTH) | 75 | 65.19 |
+| 35152 | [Best Saved For The Last](https://www.spoj.com/problems/HEADBANG) | 14 | 24.44 |
+| 35154 | [Coder Or NonCoder](https://www.spoj.com/problems/CODECODE) | 272 | 44.60 |
+| 35155 | [Professional Stalker](https://www.spoj.com/problems/BHAGO) | 12 | 17.86 |
+| 35196 | [Pandas are the best Lovers](https://www.spoj.com/problems/PALOVE) | 28 | 47.47 |
+| 35276 | [Smallest on the Stack](https://www.spoj.com/problems/MINSTACK) | 912 | 15.08 |
+| 35277 | [DNA of Elf](https://www.spoj.com/problems/DNAOFELF) | 20 | 31.30 |
+| 35278 | [Earth Sled Tour](https://www.spoj.com/problems/CNURI18H) | 31 | 28.77 |
+| 35281 | [Noel and His Reindeer](https://www.spoj.com/problems/DABRI001) | 32 | 35.43 |
+| 35283 | [Full Sleigh](https://www.spoj.com/problems/TRENOLOT) | 21 | 22.64 |
+| 35284 | [Digit Root](https://www.spoj.com/problems/DIGITROOT) | 107 | 36.34 |
+| 35287 | [Magical Matrices](https://www.spoj.com/problems/MAGMAT) | 1 | 1.02 |
+| 35295 | [zig-zag on the golden river](https://www.spoj.com/problems/GRZZ) | 124 | 22.97 |
+| 35301 | [Evaluate Escape Character](https://www.spoj.com/problems/ESCAPE1) | 21 | 41.91 |
+| 35337 | [Faketorial Hashing](https://www.spoj.com/problems/FAKEHASH) | 15 | 10.63 |
+| 35363 | [The World of Charges](https://www.spoj.com/problems/CHARGY) | 174 | 36.78 |
+| 35381 | [VALENTINE](https://www.spoj.com/problems/KUMAR2019) | 42 | 27.50 |
+| 35435 | [love and traffic](https://www.spoj.com/problems/LTRAFFIC) | 55 | 52.25 |
+| 35535 | [Bill of Fare](https://www.spoj.com/problems/BILFAR) | 0 | 0.00 |
+| 35552 | [Fibonacci Power Sum](https://www.spoj.com/problems/FIBPWSUM) | 39 | 39.10 |
+| 35582 | [Fibonacci Power Sum (hard)](https://www.spoj.com/problems/FIBPSUM2) | 21 | 39.05 |
+| 35631 | [Moon Safari (Extreme)](https://www.spoj.com/problems/MOON4) | 10 | 33.70 |
+| 35669 | [Consecutive Letters](https://www.spoj.com/problems/CONSEC) | 582 | 26.74 |
+| 35672 | [Try to learn properly](https://www.spoj.com/problems/LDP) | 47 | 16.17 |
+| 35674 | [COLORFUL ARRAY](https://www.spoj.com/problems/CLFLARR) | 1772 | 41.33 |
+| 35675 | [Primes in GCD Table (Hard)](https://www.spoj.com/problems/PGCD2) | 14 | 25.27 |
+| 35716 | [Trending GCD (Hard)](https://www.spoj.com/problems/TGCD2) | 17 | 46.15 |
+| 35810 | [Prismata](https://www.spoj.com/problems/PRISMATA) | 5 | 5.71 |
+| 35954 | [New Data Type](https://www.spoj.com/problems/NDT) | 123 | 18.92 |
+| 35956 | [Square Free Number](https://www.spoj.com/problems/SFN) | 69 | 38.31 |
+| 35988 | [Power Play](https://www.spoj.com/problems/BAPPP) | 25 | 20.86 |
+| 36122 | [Machine Cooling](https://www.spoj.com/problems/MACHCOOL) | 51 | 61.54 |
+| 36123 | [Plant the potatoes](https://www.spoj.com/problems/POTATOPL) | 18 | 15.15 |
+| 36132 | [Rightful Distribution](https://www.spoj.com/problems/SK_001) | 157 | 40.91 |
+| 36134 | [Ono at the river 1](https://www.spoj.com/problems/ONORIVER1) | 15 | 18.11 |
+| 36142 | [Random modulo n](https://www.spoj.com/problems/RANDMOD) | 79 | 60.59 |
+| 36144 | [The Cow Gathering](https://www.spoj.com/problems/COWGATH) | 38 | 26.74 |
+| 36145 | [Machine Cooling II](https://www.spoj.com/problems/MACHCOOL2) | 38 | 18.87 |
+| 36166 | [Lucifer and Magical Substrings](https://www.spoj.com/problems/MAGSUB1) | 105 | 46.38 |
+| 36199 | [Subset with all Digits](https://www.spoj.com/problems/THECODE) | 246 | 33.86 |

--- a/tests/spoj/index/77.jsonl
+++ b/tests/spoj/index/77.jsonl
@@ -1,0 +1,50 @@
+{"id":36226,"name":"Reduce the array","url":"https://www.spoj.com/problems/REDARR2","users":796,"accepted":30.08}
+{"id":36238,"name":"Color Play","url":"https://www.spoj.com/problems/RGBRED","users":210,"accepted":24.3}
+{"id":36266,"name":"Nahid The Reporter","url":"https://www.spoj.com/problems/MASUMREPORT","users":18,"accepted":31.03}
+{"id":36324,"name":"Richest_Beggar","url":"https://www.spoj.com/problems/RCB","users":183,"accepted":35.41}
+{"id":36342,"name":"Lasertag","url":"https://www.spoj.com/problems/LASERTAG","users":11,"accepted":33.93}
+{"id":36387,"name":"Honest Rectangle","url":"https://www.spoj.com/problems/RECTANGLE","users":23,"accepted":34.19}
+{"id":36413,"name":"Two Sum Query","url":"https://www.spoj.com/problems/TWOSUMQUERY","users":65,"accepted":33.83}
+{"id":36423,"name":"One Eight_Nine","url":"https://www.spoj.com/problems/OEN","users":197,"accepted":36.11}
+{"id":36424,"name":"Abul and Prime Numbers","url":"https://www.spoj.com/problems/APM","users":277,"accepted":44.21}
+{"id":36441,"name":"Funny Prime Factorization","url":"https://www.spoj.com/problems/SITB","users":72,"accepted":3.8}
+{"id":36528,"name":"Being a centipede is tough","url":"https://www.spoj.com/problems/VZLA2019B","users":53,"accepted":64.95}
+{"id":36529,"name":"Challenge Accepted!","url":"https://www.spoj.com/problems/VZLA2019C","users":47,"accepted":29.05}
+{"id":36530,"name":"Drawing Polygrams","url":"https://www.spoj.com/problems/VZLA2019D","users":53,"accepted":30.11}
+{"id":36531,"name":"Empanadas","url":"https://www.spoj.com/problems/VZLA2019E","users":79,"accepted":55.19}
+{"id":36532,"name":"Friendship","url":"https://www.spoj.com/problems/VZLA2019F","users":22,"accepted":34.04}
+{"id":36533,"name":"Gentleman s Wallet","url":"https://www.spoj.com/problems/VZLA2019G","users":55,"accepted":41.34}
+{"id":36534,"name":"Heroes","url":"https://www.spoj.com/problems/VZLA2019H","users":8,"accepted":29.63}
+{"id":36537,"name":"Koala Fan","url":"https://www.spoj.com/problems/VZLA2019K","users":50,"accepted":25.36}
+{"id":36538,"name":"Learn You a Haskell for Great Good!","url":"https://www.spoj.com/problems/VZLA2019L","users":11,"accepted":30.23}
+{"id":36563,"name":"Hard Fibonacci","url":"https://www.spoj.com/problems/FIBHARD","users":93,"accepted":24.56}
+{"id":36577,"name":"K-transfer journey","url":"https://www.spoj.com/problems/KTRANS","users":27,"accepted":39}
+{"id":36583,"name":"Game of Square","url":"https://www.spoj.com/problems/CBIT01","users":137,"accepted":28.32}
+{"id":36644,"name":"Minimum string moves","url":"https://www.spoj.com/problems/ILD18MSM","users":0,"accepted":0}
+{"id":36653,"name":"Blind Escape II","url":"https://www.spoj.com/problems/BLINDESC","users":12,"accepted":56}
+{"id":36667,"name":"Solution to all the problems","url":"https://www.spoj.com/problems/KTH_INDEX","users":155,"accepted":21.42}
+{"id":36668,"name":"Not So Blind Escape","url":"https://www.spoj.com/problems/NBLINDESC","users":10,"accepted":30.12}
+{"id":36670,"name":"Bipartite Permutation","url":"https://www.spoj.com/problems/BPM","users":370,"accepted":46.45}
+{"id":36671,"name":"Bipartite Permutation (Hard)","url":"https://www.spoj.com/problems/BPM2","users":52,"accepted":16.43}
+{"id":36674,"name":"PIZZA","url":"https://www.spoj.com/problems/MOHIBPIZ","users":495,"accepted":18.13}
+{"id":36704,"name":"Projectile Motion","url":"https://www.spoj.com/problems/PROJECTILE","users":9,"accepted":5.73}
+{"id":36710,"name":"To the Bird-planet","url":"https://www.spoj.com/problems/TTBRM","users":44,"accepted":19.94}
+{"id":36712,"name":"Trailing digits","url":"https://www.spoj.com/problems/TRAILDIG","users":62,"accepted":12.73}
+{"id":36718,"name":"Fashionable self-describing numbers","url":"https://www.spoj.com/problems/SELFNUM","users":51,"accepted":17.33}
+{"id":36789,"name":"Linear Diophantine Equation","url":"https://www.spoj.com/problems/COUNTDIO","users":12,"accepted":16.57}
+{"id":36797,"name":"GOOD COMMUNICATION","url":"https://www.spoj.com/problems/GCOM","users":16,"accepted":30.69}
+{"id":36860,"name":"Epidemic Control","url":"https://www.spoj.com/problems/IBONEC","users":36,"accepted":58.59}
+{"id":36861,"name":"Yet Another Perfect Square Equation","url":"https://www.spoj.com/problems/PERFSQNUM","users":61,"accepted":31.97}
+{"id":36886,"name":"Absurdistans Teaparties","url":"https://www.spoj.com/problems/TEAPARTY","users":20,"accepted":29.41}
+{"id":36896,"name":"Supraiden","url":"https://www.spoj.com/problems/SUPRAID","users":0,"accepted":0}
+{"id":36936,"name":"K-Divisors","url":"https://www.spoj.com/problems/KDIV","users":17,"accepted":17.02}
+{"id":36937,"name":"Random Magic Trick","url":"https://www.spoj.com/problems/RANAGIC","users":19,"accepted":41.18}
+{"id":36941,"name":"AND Queries","url":"https://www.spoj.com/problems/ANDQQ","users":22,"accepted":30.94}
+{"id":36946,"name":"March Of The King","url":"https://www.spoj.com/problems/CHECKMEET","users":16,"accepted":17.24}
+{"id":36951,"name":"HowManyLis","url":"https://www.spoj.com/problems/HMLIS","users":162,"accepted":17.18}
+{"id":36998,"name":"Superpowertree","url":"https://www.spoj.com/problems/POWTREE","users":25,"accepted":28.57}
+{"id":37053,"name":"Trailing Zeros","url":"https://www.spoj.com/problems/ALIEN0","users":60,"accepted":52}
+{"id":37114,"name":"PermRLE","url":"https://www.spoj.com/problems/GCJ08RND2PD","users":15,"accepted":28.33}
+{"id":37169,"name":"Boba Inversion","url":"https://www.spoj.com/problems/BOBAINV","users":108,"accepted":33.41}
+{"id":37175,"name":"Submatrix Sum of a Sparse Matrix","url":"https://www.spoj.com/problems/BUZZ95","users":11,"accepted":30.43}
+{"id":37226,"name":"Recursive Sequence (Version III)","url":"https://www.spoj.com/problems/SPP3","users":9,"accepted":15.94}

--- a/tests/spoj/index/77.md
+++ b/tests/spoj/index/77.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 36226 | [Reduce the array](https://www.spoj.com/problems/REDARR2) | 796 | 30.08 |
+| 36238 | [Color Play](https://www.spoj.com/problems/RGBRED) | 210 | 24.30 |
+| 36266 | [Nahid The Reporter](https://www.spoj.com/problems/MASUMREPORT) | 18 | 31.03 |
+| 36324 | [Richest_Beggar](https://www.spoj.com/problems/RCB) | 183 | 35.41 |
+| 36342 | [Lasertag](https://www.spoj.com/problems/LASERTAG) | 11 | 33.93 |
+| 36387 | [Honest Rectangle](https://www.spoj.com/problems/RECTANGLE) | 23 | 34.19 |
+| 36413 | [Two Sum Query](https://www.spoj.com/problems/TWOSUMQUERY) | 65 | 33.83 |
+| 36423 | [One Eight_Nine](https://www.spoj.com/problems/OEN) | 197 | 36.11 |
+| 36424 | [Abul and Prime Numbers](https://www.spoj.com/problems/APM) | 277 | 44.21 |
+| 36441 | [Funny Prime Factorization](https://www.spoj.com/problems/SITB) | 72 | 3.80 |
+| 36528 | [Being a centipede is tough](https://www.spoj.com/problems/VZLA2019B) | 53 | 64.95 |
+| 36529 | [Challenge Accepted!](https://www.spoj.com/problems/VZLA2019C) | 47 | 29.05 |
+| 36530 | [Drawing Polygrams](https://www.spoj.com/problems/VZLA2019D) | 53 | 30.11 |
+| 36531 | [Empanadas](https://www.spoj.com/problems/VZLA2019E) | 79 | 55.19 |
+| 36532 | [Friendship](https://www.spoj.com/problems/VZLA2019F) | 22 | 34.04 |
+| 36533 | [Gentleman s Wallet](https://www.spoj.com/problems/VZLA2019G) | 55 | 41.34 |
+| 36534 | [Heroes](https://www.spoj.com/problems/VZLA2019H) | 8 | 29.63 |
+| 36537 | [Koala Fan](https://www.spoj.com/problems/VZLA2019K) | 50 | 25.36 |
+| 36538 | [Learn You a Haskell for Great Good!](https://www.spoj.com/problems/VZLA2019L) | 11 | 30.23 |
+| 36563 | [Hard Fibonacci](https://www.spoj.com/problems/FIBHARD) | 93 | 24.56 |
+| 36577 | [K-transfer journey](https://www.spoj.com/problems/KTRANS) | 27 | 39.00 |
+| 36583 | [Game of Square](https://www.spoj.com/problems/CBIT01) | 137 | 28.32 |
+| 36644 | [Minimum string moves](https://www.spoj.com/problems/ILD18MSM) | 0 | 0.00 |
+| 36653 | [Blind Escape II](https://www.spoj.com/problems/BLINDESC) | 12 | 56.00 |
+| 36667 | [Solution to all the problems](https://www.spoj.com/problems/KTH_INDEX) | 155 | 21.42 |
+| 36668 | [Not So Blind Escape](https://www.spoj.com/problems/NBLINDESC) | 10 | 30.12 |
+| 36670 | [Bipartite Permutation](https://www.spoj.com/problems/BPM) | 370 | 46.45 |
+| 36671 | [Bipartite Permutation (Hard)](https://www.spoj.com/problems/BPM2) | 52 | 16.43 |
+| 36674 | [PIZZA](https://www.spoj.com/problems/MOHIBPIZ) | 495 | 18.13 |
+| 36704 | [Projectile Motion](https://www.spoj.com/problems/PROJECTILE) | 9 | 5.73 |
+| 36710 | [To the Bird-planet](https://www.spoj.com/problems/TTBRM) | 44 | 19.94 |
+| 36712 | [Trailing digits](https://www.spoj.com/problems/TRAILDIG) | 62 | 12.73 |
+| 36718 | [Fashionable self-describing numbers](https://www.spoj.com/problems/SELFNUM) | 51 | 17.33 |
+| 36789 | [Linear Diophantine Equation](https://www.spoj.com/problems/COUNTDIO) | 12 | 16.57 |
+| 36797 | [GOOD COMMUNICATION](https://www.spoj.com/problems/GCOM) | 16 | 30.69 |
+| 36860 | [Epidemic Control](https://www.spoj.com/problems/IBONEC) | 36 | 58.59 |
+| 36861 | [Yet Another Perfect Square Equation](https://www.spoj.com/problems/PERFSQNUM) | 61 | 31.97 |
+| 36886 | [Absurdistans Teaparties](https://www.spoj.com/problems/TEAPARTY) | 20 | 29.41 |
+| 36896 | [Supraiden](https://www.spoj.com/problems/SUPRAID) | 0 | 0.00 |
+| 36936 | [K-Divisors](https://www.spoj.com/problems/KDIV) | 17 | 17.02 |
+| 36937 | [Random Magic Trick](https://www.spoj.com/problems/RANAGIC) | 19 | 41.18 |
+| 36941 | [AND Queries](https://www.spoj.com/problems/ANDQQ) | 22 | 30.94 |
+| 36946 | [March Of The King](https://www.spoj.com/problems/CHECKMEET) | 16 | 17.24 |
+| 36951 | [HowManyLis](https://www.spoj.com/problems/HMLIS) | 162 | 17.18 |
+| 36998 | [Superpowertree](https://www.spoj.com/problems/POWTREE) | 25 | 28.57 |
+| 37053 | [Trailing Zeros](https://www.spoj.com/problems/ALIEN0) | 60 | 52.00 |
+| 37114 | [PermRLE](https://www.spoj.com/problems/GCJ08RND2PD) | 15 | 28.33 |
+| 37169 | [Boba Inversion](https://www.spoj.com/problems/BOBAINV) | 108 | 33.41 |
+| 37175 | [Submatrix Sum of a Sparse Matrix](https://www.spoj.com/problems/BUZZ95) | 11 | 30.43 |
+| 37226 | [Recursive Sequence (Version III)](https://www.spoj.com/problems/SPP3) | 9 | 15.94 |

--- a/tests/spoj/index/78.jsonl
+++ b/tests/spoj/index/78.jsonl
@@ -1,0 +1,50 @@
+{"id":37272,"name":"Dinostratus Matrices","url":"https://www.spoj.com/problems/DINOMAT","users":7,"accepted":46.58}
+{"id":37375,"name":"Kingdom of Equality","url":"https://www.spoj.com/problems/KEQUALITY","users":14,"accepted":40.62}
+{"id":37380,"name":"Acronym","url":"https://www.spoj.com/problems/ACRYM","users":34,"accepted":24.32}
+{"id":37387,"name":"Modulo Sequence","url":"https://www.spoj.com/problems/MODSEQ","users":57,"accepted":14.71}
+{"id":37388,"name":"Balls and Queries","url":"https://www.spoj.com/problems/QBALL","users":60,"accepted":41.61}
+{"id":37389,"name":"Weird Construction","url":"https://www.spoj.com/problems/KONSTRAKSCHION","users":21,"accepted":9.54}
+{"id":37390,"name":"Colored Development","url":"https://www.spoj.com/problems/BANSTAND","users":33,"accepted":42.05}
+{"id":37391,"name":"Development Colored","url":"https://www.spoj.com/problems/STANDBAN","users":21,"accepted":36.45}
+{"id":37402,"name":"The Attack Titan","url":"https://www.spoj.com/problems/RKRCTAN","users":138,"accepted":27.5}
+{"id":37420,"name":"Anti Hash","url":"https://www.spoj.com/problems/AHASH","users":37,"accepted":15.45}
+{"id":37422,"name":"Recurrence Power Sum","url":"https://www.spoj.com/problems/RECPWSUM","users":29,"accepted":19.25}
+{"id":37443,"name":"Acronym II","url":"https://www.spoj.com/problems/ACRYM2","users":30,"accepted":15.05}
+{"id":37444,"name":"Anti Hash II","url":"https://www.spoj.com/problems/AHASH2","users":7,"accepted":44.19}
+{"id":37446,"name":"Breaking Math","url":"https://www.spoj.com/problems/BBAD","users":7,"accepted":21.51}
+{"id":37474,"name":"Shuffling Problem","url":"https://www.spoj.com/problems/SHP","users":106,"accepted":23.06}
+{"id":37475,"name":"Base Exploration","url":"https://www.spoj.com/problems/BSEXP","users":87,"accepted":20.73}
+{"id":37476,"name":"Personal LCM","url":"https://www.spoj.com/problems/PRLCM","users":45,"accepted":13.46}
+{"id":37514,"name":"A Summatory (Extreme)","url":"https://www.spoj.com/problems/ASUMEXTR","users":49,"accepted":23.08}
+{"id":37921,"name":"Birthday Present","url":"https://www.spoj.com/problems/HBD","users":41,"accepted":32.41}
+{"id":37922,"name":"See you again?","url":"https://www.spoj.com/problems/DST","users":60,"accepted":23.15}
+{"id":38294,"name":"Square Pentagon","url":"https://www.spoj.com/problems/SQPENT","users":114,"accepted":44.29}
+{"id":38331,"name":"Comet Number","url":"https://www.spoj.com/problems/CPDUEL5A","users":89,"accepted":35.73}
+{"id":38365,"name":"Asacoco Prescription","url":"https://www.spoj.com/problems/CPDUEL5B","users":46,"accepted":19.71}
+{"id":38389,"name":"Phasmophobia","url":"https://www.spoj.com/problems/CPDUEL5C","users":30,"accepted":31.58}
+{"id":38602,"name":"Unique Sequence","url":"https://www.spoj.com/problems/FLT","users":73,"accepted":46.49}
+{"id":39219,"name":"Brenden Politeness Filter","url":"https://www.spoj.com/problems/BPF1","users":46,"accepted":48}
+{"id":39762,"name":"TABTABTAB","url":"https://www.spoj.com/problems/TABY","users":64,"accepted":25.13}
+{"id":39786,"name":"Selling Greeting Cards","url":"https://www.spoj.com/problems/SLNCRD","users":98,"accepted":25.62}
+{"id":39924,"name":"Precious Prizes","url":"https://www.spoj.com/problems/PRIZES","users":51,"accepted":30.62}
+{"id":40016,"name":"Robot World","url":"https://www.spoj.com/problems/ROBOWORLD","users":72,"accepted":11.84}
+{"id":40083,"name":"Just Primes","url":"https://www.spoj.com/problems/JPM","users":124,"accepted":29.9}
+{"id":40084,"name":"Just Primes II","url":"https://www.spoj.com/problems/JPM2","users":29,"accepted":38.36}
+{"id":40148,"name":"Distinct Cyclings","url":"https://www.spoj.com/problems/CYCLINGS","users":15,"accepted":26.56}
+{"id":40192,"name":"Battle Of The Bastards - Kings Vs Rooks","url":"https://www.spoj.com/problems/BATTLECRY","users":18,"accepted":26.88}
+{"id":40379,"name":"Arithmetic Progression Query","url":"https://www.spoj.com/problems/UPDTARR","users":91,"accepted":30.43}
+{"id":40457,"name":"Mines of Moria","url":"https://www.spoj.com/problems/MORIA","users":20,"accepted":31.25}
+{"id":40459,"name":"The triangle of Pascal modulo 2","url":"https://www.spoj.com/problems/TRIMOD2","users":43,"accepted":52.87}
+{"id":40468,"name":"Mines of Moria II","url":"https://www.spoj.com/problems/MORIA2","users":15,"accepted":49.5}
+{"id":40469,"name":"Watching over the Mines of Moria","url":"https://www.spoj.com/problems/MORIA3","users":25,"accepted":46.25}
+{"id":40501,"name":"A Simple Sieve","url":"https://www.spoj.com/problems/ASSIEVE","users":7,"accepted":8.7}
+{"id":40636,"name":"Stacks of boxes","url":"https://www.spoj.com/problems/STACKOFBOXES","users":54,"accepted":29.96}
+{"id":40639,"name":"Escape the New America","url":"https://www.spoj.com/problems/RDR2_1","users":33,"accepted":31.4}
+{"id":40642,"name":"Chips Challenge","url":"https://www.spoj.com/problems/CHIPSLL","users":28,"accepted":43.85}
+{"id":40643,"name":"The Revenge Of Anti Hash","url":"https://www.spoj.com/problems/AHASHREV","users":13,"accepted":18.64}
+{"id":40667,"name":"Ambitious XOXO","url":"https://www.spoj.com/problems/DEV_CP","users":47,"accepted":51.05}
+{"id":40672,"name":"Where Proofless Assumption Fails","url":"https://www.spoj.com/problems/XUDOKU","users":70,"accepted":42.61}
+{"id":40808,"name":"Crowded Music Festival","url":"https://www.spoj.com/problems/FESTIVAL","users":49,"accepted":49.22}
+{"id":40945,"name":"Internet Spamming","url":"https://www.spoj.com/problems/SPAM_ATX","users":26,"accepted":27.74}
+{"id":40982,"name":"Teleporters and Gems II","url":"https://www.spoj.com/problems/TLPNGEM2","users":35,"accepted":19.52}
+{"id":41044,"name":"Układanie kart - Card stacking","url":"https://www.spoj.com/problems/MWPZ017","users":32,"accepted":42.86}

--- a/tests/spoj/index/78.md
+++ b/tests/spoj/index/78.md
@@ -1,0 +1,52 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 37272 | [Dinostratus Matrices](https://www.spoj.com/problems/DINOMAT) | 7 | 46.58 |
+| 37375 | [Kingdom of Equality](https://www.spoj.com/problems/KEQUALITY) | 14 | 40.62 |
+| 37380 | [Acronym](https://www.spoj.com/problems/ACRYM) | 34 | 24.32 |
+| 37387 | [Modulo Sequence](https://www.spoj.com/problems/MODSEQ) | 57 | 14.71 |
+| 37388 | [Balls and Queries](https://www.spoj.com/problems/QBALL) | 60 | 41.61 |
+| 37389 | [Weird Construction](https://www.spoj.com/problems/KONSTRAKSCHION) | 21 | 9.54 |
+| 37390 | [Colored Development](https://www.spoj.com/problems/BANSTAND) | 33 | 42.05 |
+| 37391 | [Development Colored](https://www.spoj.com/problems/STANDBAN) | 21 | 36.45 |
+| 37402 | [The Attack Titan](https://www.spoj.com/problems/RKRCTAN) | 138 | 27.50 |
+| 37420 | [Anti Hash](https://www.spoj.com/problems/AHASH) | 37 | 15.45 |
+| 37422 | [Recurrence Power Sum](https://www.spoj.com/problems/RECPWSUM) | 29 | 19.25 |
+| 37443 | [Acronym II](https://www.spoj.com/problems/ACRYM2) | 30 | 15.05 |
+| 37444 | [Anti Hash II](https://www.spoj.com/problems/AHASH2) | 7 | 44.19 |
+| 37446 | [Breaking Math](https://www.spoj.com/problems/BBAD) | 7 | 21.51 |
+| 37474 | [Shuffling Problem](https://www.spoj.com/problems/SHP) | 106 | 23.06 |
+| 37475 | [Base Exploration](https://www.spoj.com/problems/BSEXP) | 87 | 20.73 |
+| 37476 | [Personal LCM](https://www.spoj.com/problems/PRLCM) | 45 | 13.46 |
+| 37514 | [A Summatory (Extreme)](https://www.spoj.com/problems/ASUMEXTR) | 49 | 23.08 |
+| 37921 | [Birthday Present](https://www.spoj.com/problems/HBD) | 41 | 32.41 |
+| 37922 | [See you again?](https://www.spoj.com/problems/DST) | 60 | 23.15 |
+| 38294 | [Square Pentagon](https://www.spoj.com/problems/SQPENT) | 114 | 44.29 |
+| 38331 | [Comet Number](https://www.spoj.com/problems/CPDUEL5A) | 89 | 35.73 |
+| 38365 | [Asacoco Prescription](https://www.spoj.com/problems/CPDUEL5B) | 46 | 19.71 |
+| 38389 | [Phasmophobia](https://www.spoj.com/problems/CPDUEL5C) | 30 | 31.58 |
+| 38602 | [Unique Sequence](https://www.spoj.com/problems/FLT) | 73 | 46.49 |
+| 39219 | [Brenden Politeness Filter](https://www.spoj.com/problems/BPF1) | 46 | 48.00 |
+| 39762 | [TABTABTAB](https://www.spoj.com/problems/TABY) | 64 | 25.13 |
+| 39786 | [Selling Greeting Cards](https://www.spoj.com/problems/SLNCRD) | 98 | 25.62 |
+| 39924 | [Precious Prizes](https://www.spoj.com/problems/PRIZES) | 51 | 30.62 |
+| 40016 | [Robot World](https://www.spoj.com/problems/ROBOWORLD) | 72 | 11.84 |
+| 40083 | [Just Primes](https://www.spoj.com/problems/JPM) | 124 | 29.90 |
+| 40084 | [Just Primes II](https://www.spoj.com/problems/JPM2) | 29 | 38.36 |
+| 40148 | [Distinct Cyclings](https://www.spoj.com/problems/CYCLINGS) | 15 | 26.56 |
+| 40192 | [Battle Of The Bastards - Kings Vs Rooks](https://www.spoj.com/problems/BATTLECRY) | 18 | 26.88 |
+| 40379 | [Arithmetic Progression Query](https://www.spoj.com/problems/UPDTARR) | 91 | 30.43 |
+| 40457 | [Mines of Moria](https://www.spoj.com/problems/MORIA) | 20 | 31.25 |
+| 40459 | [The triangle of Pascal modulo 2](https://www.spoj.com/problems/TRIMOD2) | 43 | 52.87 |
+| 40468 | [Mines of Moria II](https://www.spoj.com/problems/MORIA2) | 15 | 49.50 |
+| 40469 | [Watching over the Mines of Moria](https://www.spoj.com/problems/MORIA3) | 25 | 46.25 |
+| 40501 | [A Simple Sieve](https://www.spoj.com/problems/ASSIEVE) | 7 | 8.70 |
+| 40636 | [Stacks of boxes](https://www.spoj.com/problems/STACKOFBOXES) | 54 | 29.96 |
+| 40639 | [Escape the New America](https://www.spoj.com/problems/RDR2_1) | 33 | 31.40 |
+| 40642 | [Chips Challenge](https://www.spoj.com/problems/CHIPSLL) | 28 | 43.85 |
+| 40643 | [The Revenge Of Anti Hash](https://www.spoj.com/problems/AHASHREV) | 13 | 18.64 |
+| 40667 | [Ambitious XOXO](https://www.spoj.com/problems/DEV_CP) | 47 | 51.05 |
+| 40672 | [Where Proofless Assumption Fails](https://www.spoj.com/problems/XUDOKU) | 70 | 42.61 |
+| 40808 | [Crowded Music Festival](https://www.spoj.com/problems/FESTIVAL) | 49 | 49.22 |
+| 40945 | [Internet Spamming](https://www.spoj.com/problems/SPAM_ATX) | 26 | 27.74 |
+| 40982 | [Teleporters and Gems II](https://www.spoj.com/problems/TLPNGEM2) | 35 | 19.52 |
+| 41044 | [Układanie kart - Card stacking](https://www.spoj.com/problems/MWPZ017) | 32 | 42.86 |

--- a/tests/spoj/index/79.jsonl
+++ b/tests/spoj/index/79.jsonl
@@ -1,0 +1,24 @@
+{"id":41128,"name":"Pierwiastkowanie","url":"https://www.spoj.com/problems/MPPZC","users":40,"accepted":39.5}
+{"id":41212,"name":"Bankomat","url":"https://www.spoj.com/problems/SP2004X","users":36,"accepted":39.45}
+{"id":41213,"name":"Diamond Collector","url":"https://www.spoj.com/problems/WTPZ2002C","users":29,"accepted":45.71}
+{"id":41215,"name":"Diamonds","url":"https://www.spoj.com/problems/WTPZ2001G","users":26,"accepted":15.66}
+{"id":41374,"name":"Digit Shifts","url":"https://www.spoj.com/problems/DIGSHIFT","users":18,"accepted":7.6}
+{"id":41455,"name":"....","url":"https://www.spoj.com/problems/CAN_U_GO","users":11,"accepted":14.55}
+{"id":41507,"name":"GCD Product Sum","url":"https://www.spoj.com/problems/GCDPRDSM","users":52,"accepted":31.17}
+{"id":41657,"name":"GCD Goodness","url":"https://www.spoj.com/problems/GCDGOOD","users":30,"accepted":30.62}
+{"id":41790,"name":"Spy Reloaded","url":"https://www.spoj.com/problems/SPY3","users":6,"accepted":8.43}
+{"id":41823,"name":"Martia Auris 3020","url":"https://www.spoj.com/problems/MARTIA_AURIS","users":8,"accepted":45.83}
+{"id":41834,"name":"Anagrams and GCD","url":"https://www.spoj.com/problems/ANAGCD","users":10,"accepted":6.08}
+{"id":41890,"name":"Anagrams and Divisibility","url":"https://www.spoj.com/problems/ANADIV","users":9,"accepted":5.17}
+{"id":41944,"name":"BitPlay69","url":"https://www.spoj.com/problems/BT69","users":279,"accepted":31.85}
+{"id":42049,"name":"Maximum Sum of the Array","url":"https://www.spoj.com/problems/MASUM","users":116,"accepted":8.8}
+{"id":42340,"name":"Bracket Check","url":"https://www.spoj.com/problems/BRCKTCHK","users":261,"accepted":32.93}
+{"id":42487,"name":"The 3n + 1 problem","url":"https://www.spoj.com/problems/PCSKREAA","users":69,"accepted":27.22}
+{"id":42488,"name":"Minesweeper","url":"https://www.spoj.com/problems/PCSKREAB","users":48,"accepted":29.63}
+{"id":42526,"name":"Village Unity","url":"https://www.spoj.com/problems/VILUNIT","users":6,"accepted":9.72}
+{"id":42529,"name":"Robert Plays The Viola","url":"https://www.spoj.com/problems/MUSVIOMG","users":39,"accepted":45.54}
+{"id":42535,"name":"Hugo\"s Tennis Training","url":"https://www.spoj.com/problems/TEWBMCUL","users":46,"accepted":48.54}
+{"id":42546,"name":"Hu-Gi-Oh","url":"https://www.spoj.com/problems/TSPMOHUG","users":45,"accepted":37.31}
+{"id":42570,"name":"Big J Walks Around the school","url":"https://www.spoj.com/problems/MGSINFOA","users":9,"accepted":68.75}
+{"id":42571,"name":"Russian Year 5 Problem","url":"https://www.spoj.com/problems/MGSINFOB","users":7,"accepted":17.5}
+{"id":42573,"name":"Seating Plan","url":"https://www.spoj.com/problems/CFONISMG","users":1,"accepted":9.09}

--- a/tests/spoj/index/79.md
+++ b/tests/spoj/index/79.md
@@ -1,0 +1,26 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 41128 | [Pierwiastkowanie](https://www.spoj.com/problems/MPPZC) | 40 | 39.50 |
+| 41212 | [Bankomat](https://www.spoj.com/problems/SP2004X) | 36 | 39.45 |
+| 41213 | [Diamond Collector](https://www.spoj.com/problems/WTPZ2002C) | 29 | 45.71 |
+| 41215 | [Diamonds](https://www.spoj.com/problems/WTPZ2001G) | 26 | 15.66 |
+| 41374 | [Digit Shifts](https://www.spoj.com/problems/DIGSHIFT) | 18 | 7.60 |
+| 41455 | [....](https://www.spoj.com/problems/CAN_U_GO) | 11 | 14.55 |
+| 41507 | [GCD Product Sum](https://www.spoj.com/problems/GCDPRDSM) | 52 | 31.17 |
+| 41657 | [GCD Goodness](https://www.spoj.com/problems/GCDGOOD) | 30 | 30.62 |
+| 41790 | [Spy Reloaded](https://www.spoj.com/problems/SPY3) | 6 | 8.43 |
+| 41823 | [Martia Auris 3020](https://www.spoj.com/problems/MARTIA_AURIS) | 8 | 45.83 |
+| 41834 | [Anagrams and GCD](https://www.spoj.com/problems/ANAGCD) | 10 | 6.08 |
+| 41890 | [Anagrams and Divisibility](https://www.spoj.com/problems/ANADIV) | 9 | 5.17 |
+| 41944 | [BitPlay69](https://www.spoj.com/problems/BT69) | 279 | 31.85 |
+| 42049 | [Maximum Sum of the Array](https://www.spoj.com/problems/MASUM) | 116 | 8.80 |
+| 42340 | [Bracket Check](https://www.spoj.com/problems/BRCKTCHK) | 261 | 32.93 |
+| 42487 | [The 3n + 1 problem](https://www.spoj.com/problems/PCSKREAA) | 69 | 27.22 |
+| 42488 | [Minesweeper](https://www.spoj.com/problems/PCSKREAB) | 48 | 29.63 |
+| 42526 | [Village Unity](https://www.spoj.com/problems/VILUNIT) | 6 | 9.72 |
+| 42529 | [Robert Plays The Viola](https://www.spoj.com/problems/MUSVIOMG) | 39 | 45.54 |
+| 42535 | [Hugo"s Tennis Training](https://www.spoj.com/problems/TEWBMCUL) | 46 | 48.54 |
+| 42546 | [Hu-Gi-Oh](https://www.spoj.com/problems/TSPMOHUG) | 45 | 37.31 |
+| 42570 | [Big J Walks Around the school](https://www.spoj.com/problems/MGSINFOA) | 9 | 68.75 |
+| 42571 | [Russian Year 5 Problem](https://www.spoj.com/problems/MGSINFOB) | 7 | 17.50 |
+| 42573 | [Seating Plan](https://www.spoj.com/problems/CFONISMG) | 1 | 9.09 |

--- a/tests/spoj/index/80.jsonl
+++ b/tests/spoj/index/80.jsonl
@@ -1,0 +1,24 @@
+{"id":41128,"name":"Pierwiastkowanie","url":"https://www.spoj.com/problems/MPPZC","users":40,"accepted":39.5}
+{"id":41212,"name":"Bankomat","url":"https://www.spoj.com/problems/SP2004X","users":36,"accepted":39.45}
+{"id":41213,"name":"Diamond Collector","url":"https://www.spoj.com/problems/WTPZ2002C","users":29,"accepted":45.71}
+{"id":41215,"name":"Diamonds","url":"https://www.spoj.com/problems/WTPZ2001G","users":26,"accepted":15.66}
+{"id":41374,"name":"Digit Shifts","url":"https://www.spoj.com/problems/DIGSHIFT","users":18,"accepted":7.6}
+{"id":41455,"name":"....","url":"https://www.spoj.com/problems/CAN_U_GO","users":11,"accepted":14.55}
+{"id":41507,"name":"GCD Product Sum","url":"https://www.spoj.com/problems/GCDPRDSM","users":52,"accepted":31.17}
+{"id":41657,"name":"GCD Goodness","url":"https://www.spoj.com/problems/GCDGOOD","users":30,"accepted":30.62}
+{"id":41790,"name":"Spy Reloaded","url":"https://www.spoj.com/problems/SPY3","users":6,"accepted":8.43}
+{"id":41823,"name":"Martia Auris 3020","url":"https://www.spoj.com/problems/MARTIA_AURIS","users":8,"accepted":45.83}
+{"id":41834,"name":"Anagrams and GCD","url":"https://www.spoj.com/problems/ANAGCD","users":10,"accepted":6.08}
+{"id":41890,"name":"Anagrams and Divisibility","url":"https://www.spoj.com/problems/ANADIV","users":9,"accepted":5.17}
+{"id":41944,"name":"BitPlay69","url":"https://www.spoj.com/problems/BT69","users":279,"accepted":31.85}
+{"id":42049,"name":"Maximum Sum of the Array","url":"https://www.spoj.com/problems/MASUM","users":116,"accepted":8.8}
+{"id":42340,"name":"Bracket Check","url":"https://www.spoj.com/problems/BRCKTCHK","users":261,"accepted":32.93}
+{"id":42487,"name":"The 3n + 1 problem","url":"https://www.spoj.com/problems/PCSKREAA","users":69,"accepted":27.22}
+{"id":42488,"name":"Minesweeper","url":"https://www.spoj.com/problems/PCSKREAB","users":48,"accepted":29.63}
+{"id":42526,"name":"Village Unity","url":"https://www.spoj.com/problems/VILUNIT","users":6,"accepted":9.72}
+{"id":42529,"name":"Robert Plays The Viola","url":"https://www.spoj.com/problems/MUSVIOMG","users":39,"accepted":45.54}
+{"id":42535,"name":"Hugo\"s Tennis Training","url":"https://www.spoj.com/problems/TEWBMCUL","users":46,"accepted":48.54}
+{"id":42546,"name":"Hu-Gi-Oh","url":"https://www.spoj.com/problems/TSPMOHUG","users":45,"accepted":37.31}
+{"id":42570,"name":"Big J Walks Around the school","url":"https://www.spoj.com/problems/MGSINFOA","users":9,"accepted":68.75}
+{"id":42571,"name":"Russian Year 5 Problem","url":"https://www.spoj.com/problems/MGSINFOB","users":7,"accepted":17.5}
+{"id":42573,"name":"Seating Plan","url":"https://www.spoj.com/problems/CFONISMG","users":1,"accepted":9.09}

--- a/tests/spoj/index/80.md
+++ b/tests/spoj/index/80.md
@@ -1,0 +1,26 @@
+| ID | Name | Users | ACC% |
+|---|---|---|---|
+| 41128 | [Pierwiastkowanie](https://www.spoj.com/problems/MPPZC) | 40 | 39.50 |
+| 41212 | [Bankomat](https://www.spoj.com/problems/SP2004X) | 36 | 39.45 |
+| 41213 | [Diamond Collector](https://www.spoj.com/problems/WTPZ2002C) | 29 | 45.71 |
+| 41215 | [Diamonds](https://www.spoj.com/problems/WTPZ2001G) | 26 | 15.66 |
+| 41374 | [Digit Shifts](https://www.spoj.com/problems/DIGSHIFT) | 18 | 7.60 |
+| 41455 | [....](https://www.spoj.com/problems/CAN_U_GO) | 11 | 14.55 |
+| 41507 | [GCD Product Sum](https://www.spoj.com/problems/GCDPRDSM) | 52 | 31.17 |
+| 41657 | [GCD Goodness](https://www.spoj.com/problems/GCDGOOD) | 30 | 30.62 |
+| 41790 | [Spy Reloaded](https://www.spoj.com/problems/SPY3) | 6 | 8.43 |
+| 41823 | [Martia Auris 3020](https://www.spoj.com/problems/MARTIA_AURIS) | 8 | 45.83 |
+| 41834 | [Anagrams and GCD](https://www.spoj.com/problems/ANAGCD) | 10 | 6.08 |
+| 41890 | [Anagrams and Divisibility](https://www.spoj.com/problems/ANADIV) | 9 | 5.17 |
+| 41944 | [BitPlay69](https://www.spoj.com/problems/BT69) | 279 | 31.85 |
+| 42049 | [Maximum Sum of the Array](https://www.spoj.com/problems/MASUM) | 116 | 8.80 |
+| 42340 | [Bracket Check](https://www.spoj.com/problems/BRCKTCHK) | 261 | 32.93 |
+| 42487 | [The 3n + 1 problem](https://www.spoj.com/problems/PCSKREAA) | 69 | 27.22 |
+| 42488 | [Minesweeper](https://www.spoj.com/problems/PCSKREAB) | 48 | 29.63 |
+| 42526 | [Village Unity](https://www.spoj.com/problems/VILUNIT) | 6 | 9.72 |
+| 42529 | [Robert Plays The Viola](https://www.spoj.com/problems/MUSVIOMG) | 39 | 45.54 |
+| 42535 | [Hugo"s Tennis Training](https://www.spoj.com/problems/TEWBMCUL) | 46 | 48.54 |
+| 42546 | [Hu-Gi-Oh](https://www.spoj.com/problems/TSPMOHUG) | 45 | 37.31 |
+| 42570 | [Big J Walks Around the school](https://www.spoj.com/problems/MGSINFOA) | 9 | 68.75 |
+| 42571 | [Russian Year 5 Problem](https://www.spoj.com/problems/MGSINFOB) | 7 | 17.50 |
+| 42573 | [Seating Plan](https://www.spoj.com/problems/CFONISMG) | 1 | 9.09 |


### PR DESCRIPTION
## Summary
- Generate SPOJ problem listings for pages 31-80
- Store listings in both Markdown and JSONL formats

## Testing
- `go test ./tools/spoj -run TestListAndDownload -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68ad6c86b0c88320ae8818f979473319