### PR TITLE
Add Lean solution for SPOJ TRIP

### DIFF
--- a/tests/spoj/human/x/lean/33.in
+++ b/tests/spoj/human/x/lean/33.in
@@ -1,0 +1,3 @@
+1
+abcabcaa
+acbacba

--- a/tests/spoj/human/x/lean/33.lean
+++ b/tests/spoj/human/x/lean/33.lean
@@ -1,0 +1,72 @@
+/- Solution for SPOJ TRIP - Trip
+https://www.spoj.com/problems/TRIP
+-/
+
+import Std
+open Std
+
+-- compute all longest common subsequences of two strings
+partial def lcsAll (s1 s2 : String) : List String :=
+  let a := s1.toList.toArray
+  let b := s2.toList.toArray
+  let n := a.size
+  let m := b.size
+  -- DP table for LCS lengths
+  let mut dp : Array (Array Nat) := Array.mkArray (n+1) (Array.mkArray (m+1) 0)
+  for i in [0:n] do
+    dp := dp.set! i (Array.mkArray (m+1) 0)
+  for i in [1:n+1] do
+    let ai := a.get! (i-1)
+    for j in [1:m+1] do
+      let bj := b.get! (j-1)
+      let v := if ai = bj then
+        (dp.get! (i-1)).get! (j-1) + 1
+      else
+        Nat.max ((dp.get! (i-1)).get! j) ((dp.get! i).get! (j-1))
+      let row := (dp.get! i).set! j v
+      dp := dp.set! i row
+  -- memoized recursion to build all sequences
+  let rec build (i j : Nat)
+    : StateM (Std.HashMap (Nat × Nat) (List String)) (List String) := do
+      let memo ← get
+      match memo.find? (i, j) with
+      | some res => pure res
+      | none =>
+        let res ←
+          if i = n || j = m then
+            pure [""]
+          else if a.get! i = b.get! j then
+            let tails ← build (i+1) (j+1)
+            pure (tails.map (fun s => String.singleton (a.get! i) ++ s))
+          else
+            let len1 := (dp.get! (i+1)).get! j
+            let len2 := (dp.get! i).get! (j+1)
+            let mut acc : List String := []
+            if len1 ≥ len2 then
+              let l1 ← build (i+1) j
+              acc := acc ++ l1
+            if len2 ≥ len1 then
+              let l2 ← build i (j+1)
+              acc := acc ++ l2
+            pure acc.eraseDups
+        modify (fun m => m.insert (i, j) res)
+        pure res
+  let (ans, _) := (build 0 0).run Std.HashMap.empty
+  ans.eraseDups.qsort (fun a b => a < b)
+
+partial def solveCases (h : IO.FS.Stream) (t : Nat) (first : Bool) : IO Unit := do
+  if t = 0 then
+    pure ()
+  else
+    let s1 ← h.getLine
+    let s2 ← h.getLine
+    let res := lcsAll s1.trim s2.trim
+    if !first then IO.println ""
+    for s in res do
+      IO.println s
+    solveCases h (t-1) false
+
+def main : IO Unit := do
+  let h ← IO.getStdin
+  let t := (← h.getLine).trim.toNat!
+  solveCases h t true

--- a/tests/spoj/human/x/lean/33.out
+++ b/tests/spoj/human/x/lean/33.out
@@ -1,0 +1,7 @@
+ababa
+abaca
+abcba
+acaba
+acaca
+acbaa
+acbca

--- a/tests/spoj/x/human/lean/33.md
+++ b/tests/spoj/x/human/lean/33.md
@@ -1,0 +1,15 @@
+# [Trip](https://www.spoj.com/problems/TRIP)
+
+## Problem Summary
+Given two strings (up to 80 lowercase letters) describing the routes of Alice and Bob, output every distinct longest common subsequence of the two strings in lexicographic order. Multiple test cases are provided.
+
+## Algorithm
+1. Convert both strings to arrays of characters.
+2. Build a dynamic-programming table `dp` where `dp[i][j]` stores the length of the LCS of the suffixes starting at positions `i` and `j`.
+3. Reconstruct all LCS strings via memoized recursion:
+   - If the current characters match, prepend the character to every sequence from the state `(i+1, j+1)`.
+   - Otherwise, follow directions that preserve the optimal length: move to `(i+1, j)` when `dp[i+1][j] ≥ dp[i][j+1]` and to `(i, j+1)` when `dp[i][j+1] ≥ dp[i+1][j]`.
+   - Combine results from explored branches and remove duplicates.
+4. Sort the resulting strings lexicographically and print them, separating test cases with a blank line.
+
+This approach lists all longest common subsequences while avoiding redundant exploration through memoization and deduplication.


### PR DESCRIPTION
## Summary
- add Lean solution for SPOJ problem TRIP (ID 33) enumerating all longest common subsequences
- include sample input/output and problem explanation documentation

## Testing
- `go test ./tests/spoj/human -run TestLeanSolutions -tags=slow -v` *(fails: lean not installed, test skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68ad732703748320890315743b86e0ad