### PR TITLE
dart: support dynamic map field selection

### DIFF
--- a/transpiler/x/dart/SPOJ.md
+++ b/transpiler/x/dart/SPOJ.md
@@ -2,13 +2,13 @@
 
 This checklist is auto-generated.
 Generated Dart code from programs in `tests/spoj/x/mochi` lives in `tests/spoj/x/dart`.
-Last updated: 2025-08-26 14:36 GMT+7
+Last updated: 2025-08-27 07:17 GMT+7
 
 ## SPOJ Golden Test Checklist (5/5)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
-| 1 | 1 | ✓ |  |  |
-| 2 | 2 | ✓ |  |  |
-| 3 | 3 | ✓ |  |  |
-| 4 | 4 | ✓ |  |  |
-| 5 | 5 | ✓ |  |  |
+| 10 | 10 | ✓ |  |  |
+| 6 | 6 | ✓ |  |  |
+| 7 | 7 | ✓ |  |  |
+| 8 | 8 | ✓ |  |  |
+| 9 | 9 | ✓ |  |  |

--- a/transpiler/x/dart/transpiler.go
+++ b/transpiler/x/dart/transpiler.go
@@ -242,6 +242,17 @@ var dartKeywords = map[string]struct{}{
 	"typedef": {}, "yield": {}, "try": {}, "throw": {},
 }
 
+var builtinTypes = map[string]struct{}{
+	"int":    {},
+	"double": {},
+	"num":    {},
+	"String": {},
+	"bool":   {},
+	"List":   {},
+	"Map":    {},
+	"BigInt": {},
+}
+
 func sanitize(name string) string {
 	if name == "_" {
 		return "__"
@@ -1979,7 +1990,13 @@ func (s *SelectorExpr) emit(w io.Writer) error {
 	t := inferType(s.Receiver)
 	optional := strings.HasSuffix(t, "?")
 	nonOpt := strings.TrimSuffix(t, "?")
-	if strings.HasPrefix(nonOpt, "Map<") {
+	if strings.HasPrefix(nonOpt, "Map<") || (nonOpt == "dynamic" && !(func() bool {
+		if n, ok := s.Receiver.(*Name); ok {
+			_, ok := builtinTypes[n.Name]
+			return ok
+		}
+		return false
+	})()) {
 		if err := s.Receiver.emit(w); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
- handle `.field` access on dynamic maps by falling back to index operations unless the receiver is a builtin type
- track Dart SPOJ progress for problems 6 through 10

## Testing
- `FROM_INDEX=6 TO_INDEX=10 MOCHI_BENCHMARK=1 go test -v -tags=slow ./transpiler/x/dart -run TestDartTranspiler_Spoj_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68ae4c6da9948320a26f6f15df549804