### PR TITLE
docs: add release notes for v0.10.75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # 📦 CHANGELOG.md
 
+## [0.10.75] – 2025-08-27T09:29:30+07:00
+
+### Added
+
+- Lean solutions for SPOJ problems like SEGVIS, CISTFILL, EXCHNG, Morse decoding, DANCE and more.
+- Mochi solutions for SPOJ challenges including PARTY, SHOP, Street Parade, DICE1, BRCKTS, BUNDLE and additional tasks.
+- Documentation updates for MARBLES, Easy Problem and SBANK algorithms.
+
+### Changed
+
+- Transpilers across Scala, Dart, PHP, Pascal, Go, TypeScript, Swift and others support dynamic map fields, typed indexes and nested index assignment.
+- SPOJ infrastructure reorganised with human-sourced tests and relocated outputs.
+
+### Fixed
+
+- Corrected division handling in the Python transpiler and map indexing in Scala.
+- Sanitized Go field names.
+
 ## [0.10.74] – 2025-08-26T11:00:15+07:00
 
 ### Added

--- a/releases/v0.10.75.md
+++ b/releases/v0.10.75.md
@@ -1,0 +1,20 @@
+# Aug 2025 (v0.10.75)
+
+Released on Wed Aug 27 09:29:30 2025 +0700.
+
+Mochi v0.10.75 expands SPOJ coverage with new Lean and Mochi solutions and upgrades transpilers with dynamic map handling and typed indices.
+
+## SPOJ Solutions
+
+- Adds Lean solutions for SEGVIS, CISTFILL, EXCHNG, Morse decoding, DANCE, EDIT1/EDIT2, BRICKS and more.
+- Introduces Mochi implementations for PARTY, SHOP, Street Parade, DICE1, BRCKTS, BUNDLE and other challenges.
+
+## Transpilers
+
+- Scala, Dart, PHP, Pascal, Go, TypeScript, Swift and others now support dynamic map field selection, typed indexes and nested index assignment.
+- Python, Scala and Go fixes improve division, map indexing and field name sanitization.
+- SPOJ benchmarks reorganised and tests draw from human-written sources.
+
+## Documentation
+
+- Clarifies algorithms for MARBLES, Easy Problem, SBANK and other problem statements.


### PR DESCRIPTION
## Summary
- document v0.10.75 release notes
- record v0.10.75 in changelog

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ae6e6479748320ba2fece880f3d8c2