### PR TITLE
Add Mochi solution for SPOJ TAUT

### DIFF
--- a/tests/spoj/human/x/mochi/147.in
+++ b/tests/spoj/human/x/mochi/147.in
@@ -1,0 +1,8 @@
+7
+IIpqDpNp
+NCNpp
+Iaz
+NNNNNNNp
+IIqrIIpqIpr
+Ipp
+Ezz

--- a/tests/spoj/human/x/mochi/147.md
+++ b/tests/spoj/human/x/mochi/147.md
@@ -1,0 +1,22 @@
+# [Tautology](https://www.spoj.com/problems/TAUT/)
+
+## Problem Summary
+Given a logical expression in prefix notation using operators:
+- `C` – conjunction (and)
+- `D` – disjunction (or)
+- `I` – implication
+- `E` – equivalence
+- `N` – negation
+
+Variables are lowercase letters. For each expression, determine whether it is always true regardless of variable assignments.
+
+## Algorithm
+1. Extract the set of distinct variables appearing in the expression.
+2. Enumerate all `2^n` assignments for these variables (`n ≤ 16`).
+3. For each assignment evaluate the expression by scanning it from right to left:
+   - Push variable values on a stack.
+   - On `N` negate the top of the stack.
+   - For `C`, `D`, `I`, `E` pop the two top values, compute the operator result, and push it back.
+4. If any assignment evaluates to false, the expression is not a tautology; otherwise it is.
+
+This brute-force search is feasible because of the small variable limit and expression length (≤ 111 characters).

--- a/tests/spoj/human/x/mochi/147.mochi
+++ b/tests/spoj/human/x/mochi/147.mochi
@@ -1,0 +1,88 @@
+// Solution for SPOJ TAUT - Tautology
+// https://www.spoj.com/problems/TAUT/
+
+fun uniqueVars(expr: string): list<string> {
+  var vars: list<string> = []
+  var i = 0
+  while i < len(expr) {
+    let ch = expr[i:i+1]
+    if ch >= "a" && ch <= "z" {
+      var found = false
+      var j = 0
+      while j < len(vars) {
+        if vars[j] == ch { found = true; break }
+        j = j + 1
+      }
+      if !found { vars = append(vars, ch) }
+    }
+    i = i + 1
+  }
+  return vars
+}
+
+fun evalExpr(expr: string, env: map<string,bool>): bool {
+  var stack: list<bool> = []
+  var i = len(expr) - 1
+  while i >= 0 {
+    let ch = expr[i:i+1]
+    if ch >= "a" && ch <= "z" {
+      stack = append(stack, env[ch] as bool)
+    } else if ch == "N" {
+      let v = stack[len(stack)-1]
+      stack[len(stack)-1] = !v
+    } else {
+      let a = stack[len(stack)-1]
+      stack = stack[0:len(stack)-1]
+      let b = stack[len(stack)-1]
+      stack = stack[0:len(stack)-1]
+      var res = false
+      if ch == "C" { res = a && b }
+      if ch == "D" { res = a || b }
+      if ch == "I" { res = (!a) || b }
+      if ch == "E" { res = (a == b) }
+      stack = append(stack, res)
+    }
+    i = i - 1
+  }
+  return stack[0]
+}
+
+fun main() {
+  let tLine = input()
+  if tLine == "" { return }
+  let t = int(tLine)
+  var idx = 0
+  while idx < t {
+    let expr = input()
+    let vars = uniqueVars(expr)
+    let n = len(vars)
+    var limit = 1
+    var tmp = 0
+    while tmp < n {
+      limit = limit * 2
+      tmp = tmp + 1
+    }
+    var mask = 0
+    var taut = true
+    while mask < limit {
+      var env: map<string,bool> = {}
+      var m = mask
+      var j = 0
+      while j < n {
+        let v = (m % 2) == 1
+        env[vars[j]] = v
+        m = m / 2
+        j = j + 1
+      }
+      if !evalExpr(expr, env) {
+        taut = false
+        break
+      }
+      mask = mask + 1
+    }
+    if taut { print("YES") } else { print("NO") }
+    idx = idx + 1
+  }
+}
+
+main()

--- a/tests/spoj/human/x/mochi/147.out
+++ b/tests/spoj/human/x/mochi/147.out
@@ -1,0 +1,7 @@
+YES
+YES
+NO
+NO
+YES
+YES
+YES

--- a/tests/spoj/x/human/mochi/147.md
+++ b/tests/spoj/x/human/mochi/147.md
@@ -1,0 +1,22 @@
+# [Tautology](https://www.spoj.com/problems/TAUT/)
+
+## Problem Summary
+Given a logical expression in prefix notation using operators:
+- `C` – conjunction (and)
+- `D` – disjunction (or)
+- `I` – implication
+- `E` – equivalence
+- `N` – negation
+
+Variables are lowercase letters. For each expression, determine whether it is always true regardless of variable assignments.
+
+## Algorithm
+1. Extract the set of distinct variables appearing in the expression.
+2. Enumerate all `2^n` assignments for these variables (`n ≤ 16`).
+3. For each assignment evaluate the expression by scanning it from right to left:
+   - Push variable values on a stack.
+   - On `N` negate the top of the stack.
+   - For `C`, `D`, `I`, `E` pop the two top values, compute the operator result, and push it back.
+4. If any assignment evaluates to false, the expression is not a tautology; otherwise it is.
+
+This brute-force search is feasible because of the small variable limit and expression length (≤ 111 characters).


### PR DESCRIPTION
## Summary
- add Mochi implementation for SPOJ problem TAUT (Tautology)
- include sample input/output and documentation

## Testing
- `go run /tmp/run_mochi.go`
- `go test ./tests/spoj/human -run TestMochiSolutions -tags slow -count=1` *(timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7b4c0c90832092f578cdcbb652b2