### PR TITLE
spoj: add Cable TV Network writeup and fix Lean solution

### DIFF
--- a/tests/spoj/human/x/lean/300.lean
+++ b/tests/spoj/human/x/lean/300.lean
@@ -10,7 +10,7 @@ private def isConnected (adj : Array (Array Bool)) (n : Nat) : Bool :=
   if n = 0 then true
   else
     Id.run do
-      let mut vis : Array Bool := Array.mkArray n false
+      let mut vis : Array Bool := Array.replicate n false
       let mut q : Array Nat := #[0]
       vis := vis.set! 0 true
       let mut qi := 0
@@ -41,7 +41,7 @@ private def buildCap (adj : Array (Array Bool)) (n s t : Nat) : Array (Array Nat
   Id.run do
     let size := 2 * n
     let inf := n
-    let mut cap : Array (Array Nat) := Array.mkArray size (Array.mkArray size 0)
+      let mut cap : Array (Array Nat) := Array.replicate size (Array.replicate size 0)
     -- split vertices
     for v in [0:n] do
       let c := if v = s || v = t then inf else 1
@@ -63,7 +63,7 @@ private def maxFlow (capInit : Array (Array Nat)) (s t : Nat) : Nat :=
     let mut total := 0
     let inf := 1000000 -- big enough
     while true do
-      let mut parent : Array (Option Nat) := Array.mkArray n none
+      let mut parent : Array (Option Nat) := Array.replicate n none
       parent := parent.set! s (some s)
       let mut q : Array Nat := #[s]
       let mut qi := 0
@@ -116,7 +116,7 @@ partial def solve (toks : Array String) (idx t : Nat) : IO Unit := do
   else
     let n := toks[idx]!.toNat!
     let m := toks[idx+1]!.toNat!
-    let mut adj : Array (Array Bool) := Array.mkArray n (Array.mkArray n false)
+    let mut adj : Array (Array Bool) := Array.replicate n (Array.replicate n false)
     let mut i := 0
     let mut id := idx + 2
     while i < m do

--- a/tests/spoj/human/x/lean/300.md
+++ b/tests/spoj/human/x/lean/300.md
@@ -1,0 +1,21 @@
+# [Cable TV Network](https://www.spoj.com/problems/CABLETV/)
+
+## Problem Summary
+Given a cable network with `n` relays and `m` bidirectional cables, compute the *safety factor*:
+- `n` if the network stays connected no matter how many relays are removed (complete graph).
+- Otherwise, the smallest number of relays whose removal disconnects the network.
+An empty network or a single relay is considered connected. Input contains up to 20 test cases with `n ≤ 50`.
+
+## Algorithm
+1. Build an `n × n` adjacency matrix from the list of cables.
+2. If the graph is disconnected (BFS from any node fails to visit all vertices), the answer is `0`.
+3. If every pair of vertices is connected, return `n`.
+4. Otherwise, for every ordered pair of distinct vertices `(s, t)`:
+   - Split each vertex `v` into `v_in` and `v_out` with an edge of capacity `1` between them (capacity `n` for `s` and `t`).
+   - For every original edge `(u, v)` add edges `u_out → v_in` and `v_out → u_in` with infinite capacity.
+   - Run Edmonds–Karp max flow from `s_out` to `t_in`. The resulting flow is the minimum vertex cut separating `s` and `t`.
+   - Keep the smallest cut value over all pairs.
+5. Output this minimum as the safety factor.
+
+## Complexity
+With `n ≤ 50`, the constructed flow network has `2n` nodes. Edmonds–Karp runs in `O(VE^2)` and we run it for `O(n^2)` pairs, leading to `O(n^4)` time in the worst case, which is feasible for the given limits.


### PR DESCRIPTION
## Summary
- replace deprecated `Array.mkArray` with `Array.replicate` in the Lean solution for CABLETV
- document the Cable TV Network algorithm and problem summary

## Testing
- `go test ./tests/spoj/human -run TestLeanSolutions/300 -tags=slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68aee00e0de083209c8da9b59695feda