### PR TITLE
docs: add release notes for v0.10.76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # 📦 CHANGELOG.md
 
+## [0.10.76] – 2025-08-27T19:43:42+07:00
+
+### Added
+
+- Mochi solutions for SPOJ problems including RATTERN, PHDISP, LANDSCAP, AROUND, Expedition, LAZYCOWS, COINS, MIXTURES, POKER, SEQ, ROADS, CALLS, Bishops, PLATON, PITPAIR and more.
+- Lean solutions for challenges like Cable TV Network, OFBEAT, TWORK, POLYEQ, PON, NETADMIN, LIFTS, NAPTIME and many others.
+- Algorithm writeups for Cable TV Network, HARDQ, FSHEEP, MLAND, RENT and SERVERS.
+
+### Changed
+
+- Tidied the PHDISP solution for clarity.
+
+### Fixed
+
+- No fixes.
+
 ## [0.10.75] – 2025-08-27T09:29:30+07:00
 
 ### Added

--- a/releases/v0.10.76.md
+++ b/releases/v0.10.76.md
@@ -1,0 +1,18 @@
+# Aug 2025 (v0.10.76)
+
+Released on Wed Aug 27 19:43:42 2025 +0700.
+
+Mochi v0.10.76 broadens SPOJ coverage with fresh Mochi and Lean solutions and adds new algorithm writeups.
+
+## SPOJ Solutions
+
+- Mochi implementations for problems such as RATTERN, PHDISP, LANDSCAP, AROUND, Expedition, LAZYCOWS, COINS, MIXTURES, POKER, SEQ, ROADS, CALLS, Bishops, PLATON, PITPAIR and more.
+- Lean solutions for challenges like Cable TV Network, OFBEAT, TWORK, POLYEQ, PON, NETADMIN, LIFTS, NAPTIME and many additional problems.
+
+## Documentation
+
+- Algorithm writeups for Cable TV Network, HARDQ, FSHEEP, MLAND, RENT and SERVERS.
+
+## Refactors
+
+- Tidies the PHDISP solution for clarity.


### PR DESCRIPTION
## Summary
- document v0.10.76 in CHANGELOG
- add release notes file with git-based date

## Testing
- `npm test` (fails: Missing script "test")
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68af153efe5c8320b2fdf035b6271e33