### PR TITLE
Add Mochi solution for SPOJ GAME (385)

### DIFF
--- a/tests/spoj/human/x/mochi/385.in
+++ b/tests/spoj/human/x/mochi/385.in
@@ -1,0 +1,17 @@
+3
+A
+B
+C
+A B
+B C
+5
+A
+B
+C
+D
+E
+A B
+C D
+A E
+C E
+0

--- a/tests/spoj/human/x/mochi/385.mochi
+++ b/tests/spoj/human/x/mochi/385.mochi
@@ -1,0 +1,153 @@
+// Solution for SPOJ GAME - Game schedule required
+// https://www.spoj.com/problems/GAME/
+
+type Pair { w: int, l: int }
+
+fun splitSpaces(s: string): list<string> {
+  var parts: list<string> = []
+  var cur = ""
+  var i = 0
+  while i < len(s) {
+    let ch = s[i:i+1]
+    if ch == " " {
+      if len(cur) > 0 { parts = append(parts, cur); cur = "" }
+    } else {
+      cur = cur + ch
+    }
+    i = i + 1
+  }
+  if len(cur) > 0 { parts = append(parts, cur) }
+  return parts
+}
+
+fun makeAdj(n: int): list<list<int>> {
+  var g: list<list<int>> = []
+  var i = 0
+  while i < n {
+    g = append(g, [])
+    i = i + 1
+  }
+  return g
+}
+
+fun dfs(u: int, p: int, adj: list<list<int>>, alive: list<bool>, matched: list<bool>): list<Pair> {
+  var res: list<Pair> = []
+  var i = 0
+  while i < len(adj[u]) {
+    let v = adj[u][i]
+    if alive[v] == false || v == p { i = i + 1; continue }
+    let child = dfs(v, u, adj, alive, matched)
+    var j = 0
+    while j < len(child) {
+      res = append(res, child[j])
+      j = j + 1
+    }
+    if matched[u] == false && matched[v] == false {
+      res = append(res, Pair{ w: u, l: v })
+      matched[u] = true
+      matched[v] = true
+    }
+    i = i + 1
+  }
+  return res
+}
+
+fun main() {
+  while true {
+    var line = input()
+    if line == nil || line == "" { return }
+    let n = int(line)
+    if n == 0 { break }
+    var names: list<string> = []
+    var idx: map<string,int> = {}
+    var i = 0
+    while i < n {
+      var name = input()
+      if name == "" { continue }
+      names = append(names, name)
+      idx[name] = i
+      i = i + 1
+    }
+    var adj = makeAdj(n)
+    var j = 0
+    while j < n-1 {
+      var l = input()
+      if l == "" { continue }
+      let parts = splitSpaces(l)
+      let a = idx[parts[0]] as int
+      let b = idx[parts[1]] as int
+      adj[a] = append(adj[a], b)
+      adj[b] = append(adj[b], a)
+      j = j + 1
+    }
+    var alive: list<bool> = []
+    i = 0
+    while i < n {
+      alive = append(alive, true)
+      i = i + 1
+    }
+    var remaining = n
+    var round = 1
+    while remaining > 1 {
+      var matched: list<bool> = []
+      i = 0
+      while i < n {
+        matched = append(matched, false)
+        i = i + 1
+      }
+      var root = 0
+      i = 0
+      while i < n {
+        if alive[i] { root = i; break }
+        i = i + 1
+      }
+      let matches = dfs(root, -1, adj, alive, matched)
+      var wildcard = -1
+      i = 0
+      while i < n {
+        if alive[i] && matched[i] == false {
+          wildcard = i
+          break
+        }
+        i = i + 1
+      }
+      print("Round #" + str(round))
+      round = round + 1
+      var k = 0
+      while k < len(matches) {
+        let m = matches[k]
+        print(names[m.w] + " defeats " + names[m.l])
+        k = k + 1
+      }
+      if wildcard >= 0 {
+        print(names[wildcard] + " advances with wildcard")
+      }
+      k = 0
+      while k < len(matches) {
+        let m = matches[k]
+        alive[m.l] = false
+        remaining = remaining - 1
+        // remove loser from winner's adjacency list
+        var nl: list<int> = []
+        var t = 0
+        while t < len(adj[m.w]) {
+          let x = adj[m.w][t]
+          if x != m.l { nl = append(nl, x) }
+          t = t + 1
+        }
+        adj[m.w] = nl
+        k = k + 1
+      }
+    }
+    var winner = 0
+    i = 0
+    while i < n {
+      if alive[i] { winner = i }
+      i = i + 1
+    }
+    print("Winner: " + names[winner])
+    print("")
+  }
+}
+
+main()

--- a/tests/spoj/human/x/mochi/385.out
+++ b/tests/spoj/human/x/mochi/385.out
@@ -1,0 +1,17 @@
+Round #1
+B defeats C
+A advances with wildcard
+Round #2
+A defeats B
+Winner: A
+
+Round #1
+A defeats B
+C defeats D
+E advances with wildcard
+Round #2
+E defeats C
+A advances with wildcard
+Round #3
+A defeats E
+Winner: A

--- a/tests/spoj/x/human/mochi/385.md
+++ b/tests/spoj/x/human/mochi/385.md
@@ -1,0 +1,16 @@
+# [Game schedule required](https://www.spoj.com/problems/GAME/)
+
+## Problem Summary
+Given \(n\) teams and a list of \(n-1\) games that Sheikh Abdul wants to see, distribute the games into rounds of an elimination tournament. In each round every remaining team plays at most one game; if the number of teams is even every team plays exactly one, otherwise exactly one team receives a wildcard. After all rounds only one team remains and is declared the winner. A schedule always exists for the provided data and any valid schedule may be printed.
+
+## Algorithm
+The list of games forms a tree because there are \(n\) teams and \(n-1\) games. Root this tree at an arbitrary team which becomes the eventual champion. For each round:
+
+1. Perform a depth–first search starting at the root. When returning from a child node, if neither the child nor the parent have been paired in this round, pair them with the parent as the winner. Collect all such matches; they form a maximum matching of the current tree.
+2. Any remaining unmatched team becomes the wildcard (when the number of teams is odd).
+3. Output all matches as "winner defeats loser" and the wildcard if present. Remove the losers from the tree and repeat.
+
+The process continues until one team remains. Each round eliminates as many teams as possible while respecting the one-game-per-team rule, and because the graph is a tree the DFS greedy pairing always yields a valid schedule.
+
+## Complexity
+Building the schedule requires \(O(n^2)\) time in the worst case: there are at most \(n-1\) rounds and each DFS over the shrinking tree touches up to \(n\) nodes. The memory usage is \(O(n)\).


### PR DESCRIPTION
## Summary
- implement tree-based tournament scheduler for SPOJ GAME
- add sample I/O and explanation for Mochi

## Testing
- `go test ./tests/spoj/human -run TestMochiSolutions/385 -tags=slow`


------
https://chatgpt.com/codex/tasks/task_e_68af15b7472083208726ad6095ffc107