### PR TITLE
Add Mochi solution for SPOJ HIKE

### DIFF
--- a/tests/spoj/human/x/mochi/402.in
+++ b/tests/spoj/human/x/mochi/402.in
@@ -1,0 +1,8 @@
+3 1 2 3
+r b r
+b b b
+r b r
+2 1 2 2
+y g
+g y
+0

--- a/tests/spoj/human/x/mochi/402.mochi
+++ b/tests/spoj/human/x/mochi/402.mochi
@@ -1,0 +1,100 @@
+// Solution for SPOJ HIKE - Hike on a Graph
+// https://www.spoj.com/problems/HIKE/
+
+type State { a: int, b: int, c: int, d: int }
+
+fun encode(a: int, b: int, c: int, n: int): int {
+  return ((a - 1) * n + (b - 1)) * n + (c - 1)
+}
+
+fun splitTokens(s: string): list<string> {
+  let parts = split(s, " ")
+  var res: list<string> = []
+  for p in parts {
+    if p != "" {
+      res = append(res, p)
+    }
+  }
+  return res
+}
+
+fun solve(n: int, p1: int, p2: int, p3: int, mat: list<list<string>>): string {
+  var queue: list<State> = [State { a: p1, b: p2, c: p3, d: 0 }]
+  var qi = 0
+  var visited: map<int, bool> = {}
+  visited[encode(p1, p2, p3, n)] = true
+  while qi < len(queue) {
+    let st = queue[qi]
+    qi = qi + 1
+    let a = st.a
+    let b = st.b
+    let c = st.c
+    let d = st.d
+    if a == b && b == c {
+      return str(d)
+    }
+    let col_bc = mat[b][c]
+    for x in 1..(n + 1) {
+      if mat[a][x] == col_bc {
+        let code = encode(x, b, c, n)
+        if visited[code] == nil {
+          visited[code] = true
+          queue = append(queue, State { a: x, b: b, c: c, d: d + 1 })
+        }
+      }
+    }
+    let col_ac = mat[a][c]
+    for x in 1..(n + 1) {
+      if mat[b][x] == col_ac {
+        let code = encode(a, x, c, n)
+        if visited[code] == nil {
+          visited[code] = true
+          queue = append(queue, State { a: a, b: x, c: c, d: d + 1 })
+        }
+      }
+    }
+    let col_ab = mat[a][b]
+    for x in 1..(n + 1) {
+      if mat[c][x] == col_ab {
+        let code = encode(a, b, x, n)
+        if visited[code] == nil {
+          visited[code] = true
+          queue = append(queue, State { a: a, b: b, c: x, d: d + 1 })
+        }
+      }
+    }
+  }
+  return "impossible"
+}
+
+fun main() {
+  while true {
+    let line = input()
+    if line == nil || line == "" { return }
+    let parts = splitTokens(line)
+    let n = int(parts[0])
+    if n == 0 { break }
+    let p1 = int(parts[1])
+    let p2 = int(parts[2])
+    let p3 = int(parts[3])
+    var mat: list<list<string>> = []
+    for i in 0..(n + 1) {
+      var row: list<string> = []
+      for j in 0..(n + 1) {
+        row = append(row, "")
+      }
+      mat = append(mat, row)
+    }
+    for i in 1..(n + 1) {
+      let rline = input()
+      let tokens = splitTokens(rline)
+      for j in 1..(n + 1) {
+        mat[i][j] = tokens[j - 1]
+      }
+    }
+    let ans = solve(n, p1, p2, p3, mat)
+    print(ans)
+  }
+}
+
+main()

--- a/tests/spoj/human/x/mochi/402.out
+++ b/tests/spoj/human/x/mochi/402.out
@@ -1,0 +1,2 @@
+2
+impossible

--- a/tests/spoj/x/human/mochi/402.md
+++ b/tests/spoj/x/human/mochi/402.md
@@ -1,0 +1,29 @@
+# [HIKE - Hike on a Graph](https://www.spoj.com/problems/HIKE/)
+
+We are given a complete undirected graph with coloured edges and three pieces
+at positions `p1`, `p2` and `p3`. Moving a piece from vertex `u` to `v` is only
+allowed when the colour of edge `(u,v)` matches the colour of the edge between
+the two *other* pieces. The task is to find the minimum number of moves to
+bring all three pieces to the same vertex or report that it is impossible.
+
+## Algorithm
+
+Treat the configuration of the game as a state `(a,b,c)` representing the
+locations of the three pieces. From any state we may move one piece along all
+edges whose colour equals the colour of the edge between the other two pieces.
+There are at most `n^3` states (`n ≤ 50`).
+
+Perform a breadth‑first search (BFS) starting from the initial state. For each
+state pop from the queue:
+
+1. If `a == b == c` we have gathered all pieces and the current distance is the
+   answer.
+2. Otherwise, for each piece generate all valid moves as described above and
+   push unseen states to the queue with distance +1. States are encoded as a
+   single integer `((a-1)*n + (b-1))*n + (c-1)` and stored in a visited set.
+
+If the BFS finishes without finding a state where all pieces coincide, the
+answer is `impossible`.
+
+The BFS explores `O(n^3)` states and each transition checks up to `n` edges, so
+the complexity is `O(n^3)` which is easily fast enough for `n ≤ 50`.


### PR DESCRIPTION
## Summary
- implement breadth-first search solution for SPOJ HIKE (Hike on a Graph) in Mochi
- add sample IO and algorithm documentation

## Testing
- `go test -tags slow ./tests/spoj/human -run TestMochiSolutions -count=1` *(fails: test timed out after 10m0s)*

------
https://chatgpt.com/codex/tasks/task_e_68afbe0126648320a299cb64d58a3d95