### PR TITLE
Add Mochi solution for SPOJ DELCOMM

### DIFF
--- a/tests/spoj/human/x/mochi/409.in
+++ b/tests/spoj/human/x/mochi/409.in
@@ -1,0 +1,5 @@
+1
+
+-BP.EXE
+-BPC.EXE
++TURBO.EXE

--- a/tests/spoj/human/x/mochi/409.md
+++ b/tests/spoj/human/x/mochi/409.md
@@ -1,0 +1,27 @@
+# [DEL Command](https://www.spoj.com/problems/DELCOMM/)
+
+## Problem Summary
+Given a directory listing, some files are marked with `-` and must be deleted
+and others are marked with `+` and must be kept.  Determine whether a single
+MS-DOS `DEL` command using wildcards (`?` for one character and `*` only as the
+last character of the name or extension) can delete exactly the `-` files and
+none of the `+` files.
+
+## Algorithm
+1. **Separate names and extensions.**  For every file split the string at the
+   dot into a name (1–8 chars) and an optional extension (0–3 chars).
+2. **Generate candidate patterns for the name** and for the extension
+   independently.  From the delete list:
+   - If all lengths are equal, build a pattern of the same length where a
+     character is kept if all files agree, otherwise `?`.
+   - For every prefix length `p` of the shortest string, build the same prefix
+     pattern but append `*` so that additional characters are allowed.
+3. **Combine name and extension patterns.**  For each pair, verify that it
+   matches every `-` file and none of the `+` files by a simple matcher that
+   understands `?` and an optional trailing `*`.
+4. **Return the first valid wildcard** as `DEL <pattern>` or `IMPOSSIBLE` if no
+   pattern works.
+
+The number of candidate patterns is small (≤10 for the name × ≤5 for the
+extension).  Matching each pattern against all files is `O(N · L)` where `N ≤
+1000` and `L ≤ 11`, easily fast enough.

--- a/tests/spoj/human/x/mochi/409.mochi
+++ b/tests/spoj/human/x/mochi/409.mochi
@@ -1,0 +1,181 @@
+// Solution for SPOJ DELCOMM - DEL Command
+// https://www.spoj.com/problems/DELCOMM/
+
+fun splitFile(fn: string): list<string> {
+  var i = 0
+  while i < len(fn) {
+    let ch = fn[i:i+1]
+    if ch == "." {
+      return [fn[0:i], fn[i+1:len(fn)]]
+    }
+    i = i + 1
+  }
+  return [fn, ""]
+}
+
+fun genPatterns(parts: list<string>): list<string> {
+  var pats: list<string> = []
+  let n = len(parts)
+  var minLen = len(parts[0])
+  var sameLen = true
+  var i = 1
+  while i < n {
+    let l = len(parts[i])
+    if l < minLen { minLen = l }
+    if l != len(parts[0]) { sameLen = false }
+    i = i + 1
+  }
+  if sameLen {
+    var pat = ""
+    var pos = 0
+    let L = len(parts[0])
+    while pos < L {
+      let ch = parts[0][pos:pos+1]
+      var j = 1
+      while j < n {
+        if parts[j][pos:pos+1] != ch {
+          ch = "?"
+          break
+        }
+        j = j + 1
+      }
+      pat = pat + ch
+      pos = pos + 1
+    }
+    pats = append(pats, pat)
+  }
+  var p = 0
+  while p <= minLen {
+    var pat = ""
+    var pos = 0
+    while pos < p {
+      let ch = parts[0][pos:pos+1]
+      var j = 1
+      while j < n {
+        if parts[j][pos:pos+1] != ch {
+          ch = "?"
+          break
+        }
+        j = j + 1
+      }
+      pat = pat + ch
+      pos = pos + 1
+    }
+    pat = pat + "*"
+    pats = append(pats, pat)
+    p = p + 1
+  }
+  return pats
+}
+
+fun matchPart(pat: string, s: string): bool {
+  var hasStar = false
+  var plen = len(pat)
+  if plen > 0 && pat[plen-1:plen] == "*" {
+    hasStar = true
+    plen = plen - 1
+  }
+  if hasStar {
+    if len(s) < plen { return false }
+    var i = 0
+    while i < plen {
+      let pc = pat[i:i+1]
+      let sc = s[i:i+1]
+      if pc != "?" && pc != sc { return false }
+      i = i + 1
+    }
+    return true
+  } else {
+    if len(s) != plen { return false }
+    var i = 0
+    while i < plen {
+      let pc = pat[i:i+1]
+      let sc = s[i:i+1]
+      if pc != "?" && pc != sc { return false }
+      i = i + 1
+    }
+    return true
+  }
+}
+
+fun main() {
+  let tLine = input()
+  if tLine == nil { return }
+  let t = int(tLine)
+  // skip blank line after t
+  let _ = input()
+  var outputs: list<string> = []
+  var d = 0
+  while d < t {
+    var delNames: list<string> = []
+    var delExts: list<string> = []
+    var keepNames: list<string> = []
+    var keepExts: list<string> = []
+    while true {
+      var line = input()
+      if line == nil || line == "" { break }
+      let sign = line[0:1]
+      let fname = line[1:len(line)]
+      let parts = splitFile(fname)
+      let name = parts[0]
+      let ext = parts[1]
+      if sign == "-" {
+        delNames = append(delNames, name)
+        delExts = append(delExts, ext)
+      } else {
+        keepNames = append(keepNames, name)
+        keepExts = append(keepExts, ext)
+      }
+    }
+    let namePats = genPatterns(delNames)
+    let extPats = genPatterns(delExts)
+    var ans = ""
+    var i = 0
+    while i < len(namePats) && ans == "" {
+      var j = 0
+      while j < len(extPats) && ans == "" {
+        let np = namePats[i]
+        let ep = extPats[j]
+        var ok = true
+        var k = 0
+        while k < len(delNames) {
+          if matchPart(np, delNames[k]) == false || matchPart(ep, delExts[k]) == false {
+            ok = false
+            break
+          }
+          k = k + 1
+        }
+        if ok {
+          var m = 0
+          while m < len(keepNames) {
+            if matchPart(np, keepNames[m]) && matchPart(ep, keepExts[m]) {
+              ok = false
+              break
+            }
+            m = m + 1
+          }
+        }
+        if ok {
+          if ep != "" {
+            ans = "DEL " + np + "." + ep
+          } else {
+            ans = "DEL " + np
+          }
+        }
+        j = j + 1
+      }
+      i = i + 1
+    }
+    if ans == "" { ans = "IMPOSSIBLE" }
+    outputs = append(outputs, ans)
+    d = d + 1
+  }
+  var idx = 0
+  while idx < len(outputs) {
+    print(outputs[idx])
+    if idx + 1 < len(outputs) { print("") }
+    idx = idx + 1
+  }
+}
+
+main()

--- a/tests/spoj/human/x/mochi/409.out
+++ b/tests/spoj/human/x/mochi/409.out
@@ -1,0 +1,1 @@
+DEL B*.EXE

--- a/tests/spoj/x/human/mochi/409.md
+++ b/tests/spoj/x/human/mochi/409.md
@@ -1,0 +1,27 @@
+# [DEL Command](https://www.spoj.com/problems/DELCOMM/)
+
+## Problem Summary
+Given a directory listing, some files are marked with `-` and must be deleted
+and others are marked with `+` and must be kept.  Determine whether a single
+MS-DOS `DEL` command using wildcards (`?` for one character and `*` only as the
+last character of the name or extension) can delete exactly the `-` files and
+none of the `+` files.
+
+## Algorithm
+1. **Separate names and extensions.**  For every file split the string at the
+   dot into a name (1–8 chars) and an optional extension (0–3 chars).
+2. **Generate candidate patterns for the name** and for the extension
+   independently.  From the delete list:
+   - If all lengths are equal, build a pattern of the same length where a
+     character is kept if all files agree, otherwise `?`.
+   - For every prefix length `p` of the shortest string, build the same prefix
+     pattern but append `*` so that additional characters are allowed.
+3. **Combine name and extension patterns.**  For each pair, verify that it
+   matches every `-` file and none of the `+` files by a simple matcher that
+   understands `?` and an optional trailing `*`.
+4. **Return the first valid wildcard** as `DEL <pattern>` or `IMPOSSIBLE` if no
+   pattern works.
+
+The number of candidate patterns is small (≤10 for the name × ≤5 for the
+extension).  Matching each pattern against all files is `O(N · L)` where `N ≤
+1000` and `L ≤ 11`, easily fast enough.


### PR DESCRIPTION
## Summary
- implement DEL Command solver in Mochi that synthesizes wildcard patterns to delete only desired files
- document algorithm and provide sample input/output for problem 409

## Testing
- `go test ./tests/spoj/human -run 'TestMochiSolutions/409$' -tags=slow`


------
https://chatgpt.com/codex/tasks/task_e_68afbe0c710c832095b78921d58d6fbf