### PR TITLE
Add Mochi solution for SPOJ ZZPERM

### DIFF
--- a/tests/spoj/human/x/mochi/518.in
+++ b/tests/spoj/human/x/mochi/518.in
@@ -1,0 +1,5 @@
+j 1
+abc 2
+aaabc 1
+aaabb 2
+aaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbcccdd 123456

--- a/tests/spoj/human/x/mochi/518.md
+++ b/tests/spoj/human/x/mochi/518.md
@@ -1,0 +1,18 @@
+# [Zig-Zag Permutation](https://www.spoj.com/problems/ZZPERM/)
+
+## Problem Summary
+Given a multiset word `W` over letters `a`–`j` (letters provided in sorted order) and a number `D`, list the zig-zag permutations of `W` whose 1‑based lexicographic rank is divisible by `D`. A word is zig-zag if adjacent letters alternate between `>` and `<` comparisons. After the listed permutations, output the total count of zig-zag permutations of `W` and a blank line.
+
+## Algorithm
+1. Use a memoized recursion to count zig-zag permutations for any multiset prefix. The state is `(last letter, direction, counts)` where direction is:
+   - `-1` – no comparison yet,
+   - `0` – next letter must be smaller,
+   - `1` – next letter must be larger.
+2. For enumeration, perform lexicographic backtracking.
+   - At each node, iterate candidate letters respecting the required inequality.
+   - For each candidate, obtain the number of completions from the DP. If the interval of ranks covered by the branch contains no multiple of `D`, skip it by advancing the global rank by that count. Otherwise recurse into it.
+3. When all letters are used, output the word if the global rank is divisible by `D`, then increment the rank.
+4. The overall total is obtained by calling the counting DP on the initial state.
+
+## Complexity
+Let `n` be the length of `W` (≤ 64). The DP explores at most `O(10 · C(n+9,9))` states and each transition considers up to 10 letters. Only branches containing requested ranks are explored, keeping enumeration feasible.

--- a/tests/spoj/human/x/mochi/518.mochi
+++ b/tests/spoj/human/x/mochi/518.mochi
@@ -1,0 +1,199 @@
+// Solution for SPOJ ZZPERM - Zig-Zag Permutation
+// https://www.spoj.com/problems/ZZPERM/
+
+let letters = "abcdefghij"
+
+// memoization table for counting permutations
+var memo: map<string,bigint> = {}
+
+fun encodeCounts(cnts: list<int>): string {
+  var s = ""
+  var i = 0
+  while i < len(cnts) {
+    if i > 0 { s = s + "," }
+    s = s + str(cnts[i])
+    i = i + 1
+  }
+  return s
+}
+
+fun key(last: int, dir: int, cnts: list<int>): string {
+  return str(last) + "|" + str(dir) + "|" + encodeCounts(cnts)
+}
+
+// dir: -1 = no expectation yet, 0 = next must be smaller, 1 = next must be greater
+fun countZig(last: int, dir: int, cnts: list<int>, rem: int): bigint {
+  let k = key(last, dir, cnts)
+  if memo[k] != nil { return memo[k] as bigint }
+  var total: bigint = 0 as bigint
+  if rem == 0 {
+    total = 1 as bigint
+  } else if last == 0 - 1 {
+    var i = 0
+    while i < 10 {
+      if cnts[i] > 0 {
+        cnts[i] = cnts[i] - 1
+        total = total + countZig(i, 0 - 1, cnts, rem - 1)
+        cnts[i] = cnts[i] + 1
+      }
+      i = i + 1
+    }
+  } else if dir == 0 - 1 {
+    var i = 0
+    while i < 10 {
+      if cnts[i] > 0 && i != last {
+        cnts[i] = cnts[i] - 1
+        var ndir = 0
+        if i > last { ndir = 0 } else { ndir = 1 }
+        total = total + countZig(i, ndir, cnts, rem - 1)
+        cnts[i] = cnts[i] + 1
+      }
+      i = i + 1
+    }
+  } else if dir == 0 {
+    var i = 0
+    while i < last {
+      if cnts[i] > 0 {
+        cnts[i] = cnts[i] - 1
+        total = total + countZig(i, 1, cnts, rem - 1)
+        cnts[i] = cnts[i] + 1
+      }
+      i = i + 1
+    }
+  } else { // dir == 1
+    var i = last + 1
+    while i < 10 {
+      if cnts[i] > 0 {
+        cnts[i] = cnts[i] - 1
+        total = total + countZig(i, 0, cnts, rem - 1)
+        cnts[i] = cnts[i] + 1
+      }
+      i = i + 1
+    }
+  }
+  memo[k] = total
+  return total
+}
+
+var D: bigint = 0 as bigint
+var R: bigint = 1 as bigint
+
+fun hasMultiple(r: bigint, cnt: bigint): bool {
+  let rem: bigint = r % D
+  var gap: bigint = D - rem
+  if gap == D { gap = 0 as bigint }
+  return gap < cnt
+}
+
+fun gen(prefix: string, last: int, dir: int, cnts: list<int>, rem: int) {
+  if rem == 0 {
+    if R % D == 0 { print(prefix) }
+    R = R + 1
+    return
+  }
+  if last == 0 - 1 {
+    var i = 0
+    while i < 10 {
+      if cnts[i] > 0 {
+        cnts[i] = cnts[i] - 1
+        let cnt: bigint = countZig(i, 0 - 1, cnts, rem - 1)
+        if hasMultiple(R, cnt) {
+          gen(prefix + letters[i:i+1], i, 0 - 1, cnts, rem - 1)
+        } else {
+          R = R + cnt
+        }
+        cnts[i] = cnts[i] + 1
+      }
+      i = i + 1
+    }
+  } else if dir == 0 - 1 {
+    var i = 0
+    while i < 10 {
+      if cnts[i] > 0 && i != last {
+        cnts[i] = cnts[i] - 1
+        var ndir = 0
+        if i > last { ndir = 0 } else { ndir = 1 }
+        let cnt: bigint = countZig(i, ndir, cnts, rem - 1)
+        if hasMultiple(R, cnt) {
+          gen(prefix + letters[i:i+1], i, ndir, cnts, rem - 1)
+        } else {
+          R = R + cnt
+        }
+        cnts[i] = cnts[i] + 1
+      }
+      i = i + 1
+    }
+  } else if dir == 0 {
+    var i = 0
+    while i < last {
+      if cnts[i] > 0 {
+        cnts[i] = cnts[i] - 1
+        let cnt: bigint = countZig(i, 1, cnts, rem - 1)
+        if hasMultiple(R, cnt) {
+          gen(prefix + letters[i:i+1], i, 1, cnts, rem - 1)
+        } else {
+          R = R + cnt
+        }
+        cnts[i] = cnts[i] + 1
+      }
+      i = i + 1
+    }
+  } else { // dir == 1
+    var i = last + 1
+    while i < 10 {
+      if cnts[i] > 0 {
+        cnts[i] = cnts[i] - 1
+        let cnt: bigint = countZig(i, 0, cnts, rem - 1)
+        if hasMultiple(R, cnt) {
+          gen(prefix + letters[i:i+1], i, 0, cnts, rem - 1)
+        } else {
+          R = R + cnt
+        }
+        cnts[i] = cnts[i] + 1
+      }
+      i = i + 1
+    }
+  }
+}
+
+fun parseLine(line: string): map<string, any> {
+  var i = 0
+  while i < len(line) && line[i:i+1] != " " { i = i + 1 }
+  let w = line[0:i]
+  i = i + 1
+  let dStr = line[i:len(line)]
+  return {"w": w, "d": dStr}
+}
+
+fun main() {
+  while true {
+    let line = input()
+    if line == "" { break }
+    let p = parseLine(line)
+    let w = p["w"] as string
+    let dStr = p["d"] as string
+    D = dStr as bigint
+    var cnts: list<int> = []
+    var j = 0
+    while j < 10 { cnts = append(cnts, 0); j = j + 1 }
+    j = 0
+    while j < len(w) {
+      let ch = w[j:j+1]
+      var idx = 0
+      while idx < 10 {
+        if letters[idx:idx+1] == ch { break }
+        idx = idx + 1
+      }
+      cnts[idx] = cnts[idx] + 1
+      j = j + 1
+    }
+    memo = {}
+    let total: bigint = countZig(0 - 1, 0 - 1, cnts, len(w))
+    R = 1 as bigint
+    gen("", 0 - 1, 0 - 1, cnts, len(w))
+    print(str(total))
+    print("")
+  }
+}
+
+main()

--- a/tests/spoj/human/x/mochi/518.out
+++ b/tests/spoj/human/x/mochi/518.out
@@ -1,0 +1,16 @@
+j
+1
+
+bac
+cab
+4
+
+abaca
+acaba
+2
+
+1
+
+babacbcabacabadabababababababababadab
+213216
+


### PR DESCRIPTION
## Summary
- add Mochi implementation for SPOJ ZZPERM (Zig-Zag Permutation)
- include sample input, output and algorithm notes

## Testing
- `go test ./tests/spoj/human -run TestMochiSolutions/518 -tags slow -count=1` *(timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68afc68fe9988320b8a38b0e44faf8e7