### PR TITLE
Add Mochi solution for SPOJ MARKUP (872)

### DIFF
--- a/tests/spoj/human/x/mochi/872.in
+++ b/tests/spoj/human/x/mochi/872.in
@@ -1,0 +1,9 @@
+\s18.\bMARKUP sample\b\s
+
+\*For bold statements use the \b command.\*
+
+If you wish to \iemphasize\i something use the \\i command.
+
+For titles use \s14BIG\s font sizes, 14 points usually works well.
+
+Remember that all of the commands toggle except for the \\s command.

--- a/tests/spoj/human/x/mochi/872.md
+++ b/tests/spoj/human/x/mochi/872.md
@@ -1,0 +1,21 @@
+# [Mark-up](https://www.spoj.com/problems/MARKUP/)
+
+## Problem Summary
+Remove markup commands from a text stream. Commands begin with a backslash and include:
+`\b` (bold toggle), `\i` (italics toggle), `\sN` (set font size to number `N` or restore if missing),
+and `\*` (toggle markup processing). While processing is off, all sequences are treated literally
+until another `\*` is seen. Unknown commands output the character following the backslash.
+
+## Algorithm
+1. Maintain a boolean `on` indicating whether markup processing is active (initially `true`).
+2. Read the input character by character. For each character:
+   - If `on` and the character is `\`:
+     - `\b` or `\i`: consume command, toggling state but producing no output.
+     - `\s`: consume the command and any following digits and optional decimal point.
+     - `\*`: set `on = false`.
+     - Otherwise: output the next character after the backslash.
+   - If `!on` and the sequence `\*` appears: set `on = true` and consume it.
+   - Otherwise output the character unchanged.
+3. Continue until EOF, preserving newlines between lines.
+
+This single pass over the input runs in linear time `O(n)`.

--- a/tests/spoj/human/x/mochi/872.mochi
+++ b/tests/spoj/human/x/mochi/872.mochi
@@ -1,0 +1,66 @@
+// Solution for SPOJ MARKUP - Mark-up
+// https://www.spoj.com/problems/MARKUP/
+
+var processing = true
+
+fun handle(line: string): string {
+  var out = ""
+  var i = 0
+  while i < len(line) {
+    let ch = line[i:i+1]
+    if processing {
+      if ch == "\\" {
+        if i + 1 >= len(line) { break }
+        let cmd = line[i+1:i+2]
+        if cmd == "b" || cmd == "i" {
+          i = i + 2
+        } else if cmd == "s" {
+          i = i + 2
+          while i < len(line) {
+            let c = line[i:i+1]
+            if (c >= "0" && c <= "9") || c == "." {
+              i = i + 1
+            } else {
+              break
+            }
+          }
+        } else if cmd == "*" {
+          processing = false
+          i = i + 2
+        } else {
+          out = out + cmd
+          i = i + 2
+        }
+      } else {
+        out = out + ch
+        i = i + 1
+      }
+    } else {
+      if ch == "\\" && i + 1 < len(line) && line[i+1:i+2] == "*" {
+        processing = true
+        i = i + 2
+      } else {
+        out = out + ch
+        i = i + 1
+      }
+    }
+  }
+  return out
+}
+
+fun main() {
+  var prevEmpty = false
+  while true {
+    let line = input()
+    if line == "" {
+      if prevEmpty { break }
+      print(handle(line))
+      prevEmpty = true
+    } else {
+      print(handle(line))
+      prevEmpty = false
+    }
+  }
+}
+
+main()

--- a/tests/spoj/human/x/mochi/872.out
+++ b/tests/spoj/human/x/mochi/872.out
@@ -1,0 +1,9 @@
+MARKUP sample
+
+For bold statements use the \b command.
+
+If you wish to emphasize something use the \i command.
+
+For titles use BIG font sizes, 14 points usually works well.
+
+Remember that all of the commands toggle except for the \s command.

--- a/tests/spoj/x/human/mochi/872.md
+++ b/tests/spoj/x/human/mochi/872.md
@@ -1,0 +1,21 @@
+# [Mark-up](https://www.spoj.com/problems/MARKUP/)
+
+## Problem Summary
+Remove markup commands from a text stream. Commands begin with a backslash and include:
+`\b` (bold toggle), `\i` (italics toggle), `\sN` (set font size to number `N` or restore if missing),
+and `\*` (toggle markup processing). While processing is off, all sequences are treated literally
+until another `\*` is seen. Unknown commands output the character following the backslash.
+
+## Algorithm
+1. Maintain a boolean `on` indicating whether markup processing is active (initially `true`).
+2. Read the input character by character. For each character:
+   - If `on` and the character is `\`:
+     - `\b` or `\i`: consume command, toggling state but producing no output.
+     - `\s`: consume the command and any following digits and optional decimal point.
+     - `\*`: set `on = false`.
+     - Otherwise: output the next character after the backslash.
+   - If `!on` and the sequence `\*` appears: set `on = true` and consume it.
+   - Otherwise output the character unchanged.
+3. Continue until EOF, preserving newlines between lines.
+
+This single pass over the input runs in linear time `O(n)`.


### PR DESCRIPTION
## Summary
- implement parser that strips font markup commands for SPOJ MARKUP
- add sample input/output and documentation

## Testing
- `go test ./tests/spoj/human -run 'TestMochiSolutions/872' -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68b00454a7e083208ef08bd4392799f9