### PR TITLE
Add Mochi solution for SPOJ WSCIPHER

### DIFF
--- a/tests/spoj/human/x/mochi/899.in
+++ b/tests/spoj/human/x/mochi/899.in
@@ -1,0 +1,9 @@
+2 3 1
+_icuo_bfnwhoq_kxert
+1 1 1
+bcalmkyzx
+3 7 4
+wcb_mxfep_dorul_eov_qtkrhe_ozany_dgtoh_u_eji
+2 4 3
+cjvdksaltbmu
+0 0 0

--- a/tests/spoj/human/x/mochi/899.md
+++ b/tests/spoj/human/x/mochi/899.md
@@ -1,0 +1,11 @@
+# [Ws Cipher](https://www.spoj.com/problems/WSCIPHER/)
+
+## Problem Summary
+Given a line with keys \(k_1, k_2, k_3\) and a second line with an encrypted string, decrypt the message. Letters are partitioned into three groups: `a`–`i`, `j`–`r`, and `s`–`z` plus underscore. Within each group the characters were rotated left by the corresponding key during encryption. The input ends when all three keys are zero.
+
+## Algorithm
+1. Convert the message to an array of characters and record the indices belonging to each of the three groups.
+2. For each group, rotate the collected characters right by the given key (modulo the group length) and write them back to their recorded positions.
+3. Join all characters to form the decrypted string and print it.
+
+This processes each message in linear time with respect to its length.

--- a/tests/spoj/human/x/mochi/899.mochi
+++ b/tests/spoj/human/x/mochi/899.mochi
@@ -1,0 +1,90 @@
+// Solution for SPOJ WSCIPHER - Ws Cipher
+// https://www.spoj.com/problems/WSCIPHER/
+
+fun split(s: string): list<string> {
+  var res: list<string> = []
+  var cur = ""
+  var i = 0
+  while i < len(s) {
+    let ch = s[i:i+1]
+    if ch == " " || ch == "\t" {
+      if cur != "" { res = append(res, cur); cur = "" }
+    } else {
+      cur = cur + ch
+    }
+    i = i + 1
+  }
+  if cur != "" { res = append(res, cur) }
+  return res
+}
+
+fun rotate(chars: list<string>, idxs: list<int>, k: int): list<string> {
+  let m = len(idxs)
+  if m == 0 { return chars }
+  let r = k % m
+  if r == 0 { return chars }
+  var tmp: list<string> = []
+  var i = 0
+  while i < m {
+    let src = idxs[(i - r + m) % m]
+    tmp = append(tmp, chars[src])
+    i = i + 1
+  }
+  i = 0
+  while i < m {
+    chars[idxs[i]] = tmp[i]
+    i = i + 1
+  }
+  return chars
+}
+
+fun decrypt(msg: string, k1: int, k2: int, k3: int): string {
+  var chars: list<string> = []
+  var i = 0
+  while i < len(msg) {
+    chars = append(chars, msg[i:i+1])
+    i = i + 1
+  }
+  var g1: list<int> = []
+  var g2: list<int> = []
+  var g3: list<int> = []
+  i = 0
+  while i < len(chars) {
+    let ch = chars[i]
+    if ch >= "a" && ch <= "i" {
+      g1 = append(g1, i)
+    } else if ch >= "j" && ch <= "r" {
+      g2 = append(g2, i)
+    } else {
+      g3 = append(g3, i)
+    }
+    i = i + 1
+  }
+  chars = rotate(chars, g1, k1)
+  chars = rotate(chars, g2, k2)
+  chars = rotate(chars, g3, k3)
+  var res = ""
+  i = 0
+  while i < len(chars) {
+    res = res + chars[i]
+    i = i + 1
+  }
+  return res
+}
+
+fun main() {
+  while true {
+    var line = input()
+    if line == "" { break }
+    let parts = split(line)
+    if len(parts) < 3 { continue }
+    let k1 = int(parts[0])
+    let k2 = int(parts[1])
+    let k3 = int(parts[2])
+    if k1 == 0 && k2 == 0 && k3 == 0 { break }
+    let msg = input()
+    print(decrypt(msg, k1, k2, k3))
+  }
+}
+
+main()

--- a/tests/spoj/human/x/mochi/899.out
+++ b/tests/spoj/human/x/mochi/899.out
@@ -1,0 +1,4 @@
+the_quick_brown_fox
+abcklmxyz
+the_quick_brown_fox_jumped_over_the_lazy_dog
+ajsbktcludmv


### PR DESCRIPTION
## Summary
- implement Ws Cipher decryption in Mochi
- add sample IO and algorithm notes for SPOJ 899

## Testing
- `MOCHI_ROSETTA_ONLY=899 go test ./tests/spoj/human -run TestMochiSolutions -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68b0045844848320be522de35eb88b9e