### PR TITLE
feat(spoj): add lean solution for mark-up problem

### DIFF
--- a/tests/spoj/human/x/lean/872.in
+++ b/tests/spoj/human/x/lean/872.in
@@ -1,0 +1,9 @@
+\s18.\bMARKUP sample\b\s
+
+\*For bold statements use the \b command.\*
+
+If you wish to \iemphasize\i something use the \\i command.
+
+For titles use \s14BIG\s font sizes, 14 points usually works well.
+
+Remember that all of the commands toggle except for the \\s command.

--- a/tests/spoj/human/x/lean/872.lean
+++ b/tests/spoj/human/x/lean/872.lean
@@ -1,0 +1,65 @@
+/- Solution for SPOJ MARKUP - Mark-up
+https://www.spoj.com/problems/MARKUP/
+-/
+
+import Std
+open Std
+
+partial def skipDigits (s : String) (i : Nat) : Nat :=
+  if h : i < s.length then
+    let c := s.get ⟨i, h⟩
+    if c.isDigit then
+      skipDigits s (i+1)
+    else
+      i
+  else
+    i
+
+partial def skipNum (s : String) (i : Nat) : Nat :=
+  let j := skipDigits s i
+  if h : j < s.length then
+    let c := s.get ⟨j, h⟩
+    if c == '.' then
+      skipDigits s (j+1)
+    else
+      j
+  else
+    j
+
+partial def processAux (s : String) (i : Nat) (proc : Bool) (acc : String) : String :=
+  if h : i < s.length then
+    let c := s.get ⟨i, h⟩
+    if c == '\\' then
+      if h2 : i + 1 < s.length then
+        let d := s.get ⟨i+1, h2⟩
+        if proc then
+          if d == 'b' ∨ d == 'i' then
+            processAux s (i+2) proc acc
+          else if d == 's' then
+            let j := skipNum s (i+2)
+            processAux s j proc acc
+          else if d == '*' then
+            processAux s (i+2) (!proc) acc
+          else
+            processAux s (i+2) proc (acc.push d)
+        else
+          if d == '*' then
+            processAux s (i+2) (!proc) acc
+          else
+            processAux s (i+2) proc (acc.push '\\'.push d)
+      else
+        if proc then
+          processAux s (i+1) proc acc
+        else
+          processAux s (i+1) proc (acc.push '\\')
+    else
+      processAux s (i+1) proc (acc.push c)
+  else
+    acc
+
+def process (s : String) : String :=
+  processAux s 0 true ""
+
+def main : IO Unit := do
+  let input ← IO.getStdin.readToEnd
+  IO.print (process input)

--- a/tests/spoj/human/x/lean/872.out
+++ b/tests/spoj/human/x/lean/872.out
@@ -1,0 +1,9 @@
+MARKUP sample
+
+For bold statements use the \b command.
+
+If you wish to emphasize something use the \i command.
+
+For titles use BIG font sizes, 14 points usually works well.
+
+Remember that all of the commands toggle except for the \s command.

--- a/tests/spoj/x/human/lean/872.md
+++ b/tests/spoj/x/human/lean/872.md
@@ -1,0 +1,17 @@
+# [Mark-up](https://www.spoj.com/problems/MARKUP)
+
+## Problem Summary
+Given text containing a simple mark-up language, remove all formatting commands and output the plain text. Recognized commands begin with a backslash and include toggling bold or italics, setting a font size with an optional decimal number, and `\*` which toggles whether commands are processed.
+
+## Algorithm
+1. Read the entire input as a string while keeping a flag that indicates whether mark-up processing is enabled (initially on).
+2. Scan the string character by character:
+   - When not processing mark-ups, output every character verbatim except that `\*` still toggles processing back on.
+   - When processing mark-ups:
+     - `\b` and `\i` are removed.
+     - `\s` is removed along with any following digits and at most one decimal point and digits.
+     - `\*` toggles processing on/off without producing output.
+     - Any other `\x` outputs `x` literally.
+3. All non-mark-up characters are copied directly to the output.
+
+The procedure runs in a single pass over the input and uses constant additional memory.


### PR DESCRIPTION
## Summary
- add Lean implementation for SPOJ problem MARKUP
- document algorithm for stripping mark-up commands
- include sample I/O for regression testing

## Testing
- `go test ./tests/spoj/human -run Lean -tags slow -v` *(fails: lean not installed, tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b0047452fc832094afed3b2174325f