### PR TITLE
Add Lean solution for SPOJ INDEXGEN

### DIFF
--- a/tests/spoj/human/x/lean/901.in
+++ b/tests/spoj/human/x/lean/901.in
@@ -1,0 +1,10 @@
+Call me Ishmael.
+*
+One {fish $unary}, two {fish$ binary},&red {fish $ scarlet}, blue {fish$azure}. & By { Dr. Seuss }.
+*
+This is a {simple } & & { document} that &{
+simply %simple
+$adverb
+} & {illustrates %vision} &&&&& one {simple-minded% simple} {Judge}'s {vision} for what a {document } might { look % vision} like.
+*
+**

--- a/tests/spoj/human/x/lean/901.lean
+++ b/tests/spoj/human/x/lean/901.lean
@@ -1,0 +1,140 @@
+/- Solution for SPOJ Index Generation
+https://www.spoj.com/problems/INDEXGEN/
+-/
+
+import Std
+open Std
+
+structure PEntry where
+  pages : Std.HashSet Nat := {}
+  subs  : Std.HashMap String (Std.HashSet Nat) := {}
+
+def addPrimary (m : Std.HashMap String PEntry) (p : String) (pg : Nat) : Std.HashMap String PEntry :=
+  let e := m.findD p {}
+  let e := {e with pages := e.pages.insert pg}
+  m.insert p e
+
+def addSecondary (m : Std.HashMap String PEntry) (p s : String) (pg : Nat) : Std.HashMap String PEntry :=
+  let e := m.findD p {}
+  let sp := e.subs.findD s {}
+  let e := {e with subs := e.subs.insert s (sp.insert pg)}
+  m.insert p e
+
+partial def parseMarker (cs : List Char) : String × List Char :=
+  let rec loop : List Char → Option Char → List Char → String × List Char
+    | [], _, acc => (String.mk (acc.reverse), [])
+    | c :: rest, prev, acc =>
+        if c = '}' then
+          (String.mk (acc.reverse), rest)
+        else
+          let c' := if c = '\n' then ' ' else c
+          let nxt := match rest with
+            | [] => none
+            | d :: _ => some (if d = '\n' then ' ' else d)
+          let skip := c' = ' ' ∧ ((prev = none) ∨ prev = some '%' ∨ prev = some '$' ∨ nxt = some '%' ∨ nxt = some '$' ∨ nxt = some '}')
+          if skip then
+            loop rest prev acc
+          else
+            loop rest (some c') (c' :: acc)
+  loop cs none []
+
+partial def findIdx? (cs : List Char) (ch : Char) : Option Nat :=
+  let rec go : List Char → Nat → Option Nat
+    | [], _ => none
+    | c :: rest, i => if c = ch then some i else go rest (i+1)
+  go cs 0
+
+partial def substring (cs : List Char) (start stop : Nat) : String :=
+  String.mk <| (cs.drop start).take (stop - start)
+
+partial def substringToEnd (cs : List Char) (start : Nat) : String :=
+  String.mk <| cs.drop start
+
+partial def processMarker (m : Std.HashMap String PEntry) (content : String) (pg : Nat) : Std.HashMap String PEntry :=
+  let cs := content.data.toList
+  let idxPct := findIdx? cs '%'
+  let idxDol := findIdx? cs '$'
+  match idxPct, idxDol with
+  | none, none => addPrimary m content pg
+  | some p, none => addPrimary m (substringToEnd cs (p+1)) pg
+  | none, some d =>
+      let prim := substring cs 0 d
+      let sec := substringToEnd cs (d+1)
+      addSecondary m prim sec pg
+  | some p, some d =>
+      let prim := substring cs (p+1) d
+      let sec := substringToEnd cs (d+1)
+      addSecondary m prim sec pg
+
+partial def process (cs : List Char) (pg : Nat) (m : Std.HashMap String PEntry) : Std.HashMap String PEntry :=
+  match cs with
+  | [] => m
+  | c :: rest =>
+      if c = '&' then
+        process rest (pg+1) m
+      else if c = '{' then
+        let (content, rest') := parseMarker rest
+        let m := processMarker m content pg
+        process rest' pg m
+      else
+        process rest pg m
+
+partial def formatPages (s : Std.HashSet Nat) : String :=
+  let lst := s.toList.qsort (fun x y => x < y)
+  String.intercalate ", " (lst.map toString)
+
+partial def buildOutput (m : Std.HashMap String PEntry) : List String :=
+  let entries := m.toList.qsort (fun a b => a.fst.toLower < b.fst.toLower)
+  entries.foldl (fun acc (name, pe) =>
+    let line :=
+      let pages := formatPages pe.pages
+      if pages = "" then name else name ++ ", " ++ pages
+    let subs := pe.subs.toList.qsort (fun a b => a.fst.toLower < b.fst.toLower)
+    let subsLines := subs.map (fun (s, set) =>
+      let pg := formatPages set
+      "+ " ++ s ++ ", " ++ pg)
+    acc ++ (line :: subsLines)
+  ) []
+
+partial def processDoc (lines : List String) : List String :=
+  let text := String.intercalate "\n" lines
+  let chars := text.data.toList
+  let m := process chars 1 {}
+  buildOutput m
+
+partial def loopDocs (docs : List (List String)) (n : Nat) : List String :=
+  match docs with
+  | [] => []
+  | d :: ds =>
+      let header := s!"DOCUMENT {n}"
+      let body := processDoc d
+      header :: body ++ loopDocs ds (n+1)
+
+partial def splitDocs (lines : List String) : List (List String) :=
+  let rec go (ls acc cur) :=
+    match ls with
+    | [] => (cur.reverse) :: acc
+    | l :: ls' =>
+        if l = "*" then
+          go ls' ((cur.reverse) :: acc) []
+        else
+          go ls' acc (l :: cur)
+  (go lines [] []).reverse
+
+partial def readInput : IO (List String) := do
+  let rec collect (acc : List String) := do
+    let l ← IO.getLine
+    if l.trim = "**" then
+      pure (acc.reverse)
+    else
+      collect (l :: acc)
+  collect []
+
+partial def main : IO Unit := do
+  let lines ← readInput
+  let docs := splitDocs lines
+  let output := loopDocs docs 1
+  for line in output do
+    IO.println line
+
+#eval main

--- a/tests/spoj/human/x/lean/901.md
+++ b/tests/spoj/human/x/lean/901.md
@@ -1,0 +1,16 @@
+# Index Generation
+
+[Problem link](https://www.spoj.com/problems/INDEXGEN/)
+
+We scan each document character by character while tracking the current page.
+Markers delimited by `{` and `}` may span lines; newlines inside markers become
+spaces.  Spaces directly inside the braces or next to `%` and `$` are removed.
+
+After cleaning a marker we parse optional primary (`%`) and secondary (`$`)
+entries.  If `$` appears without `%`, the text before `$` is the primary entry.
+A marker adds the current page to either the primary or the secondary entry.
+
+Page numbers are stored in sets to avoid duplicates.  For each primary we keep a
+map of its secondary entries and their page sets.  When a document is processed
+we print primary entries sorted case-insensitively; secondaries under each
+primary are sorted similarly.  Page lists are output in ascending order.

--- a/tests/spoj/human/x/lean/901.out
+++ b/tests/spoj/human/x/lean/901.out
@@ -1,0 +1,14 @@
+DOCUMENT 1
+DOCUMENT 2
+Dr. Seuss, 3
+fish
++ azure, 2
++ binary, 1
++ scarlet, 2
++ unary, 1
+DOCUMENT 3
+document, 3, 10
+Judge, 10
+simple, 1, 10
++ adverb, 4
+vision, 5, 10

--- a/tests/spoj/x/human/lean/901.md
+++ b/tests/spoj/x/human/lean/901.md
@@ -1,0 +1,17 @@
+# Index Generation
+
+We scan each document character by character while tracking the current page.
+A marker is introduced by `{` and closed by `}`; markers may span multiple lines so
+newlines inside markers are converted to spaces.  Spaces immediately after `{`,
+before `}`, or adjacent to `%` or `$` are ignored.
+
+From the cleaned marker we extract optional primary (`%`) and secondary (`$`)
+entries.  If only `$` appears the text before `$` becomes the primary entry.  A
+marker contributes the current page to either the primary or secondary entry
+depending on whether `$` is present.
+
+All page numbers for an entry are stored in sets to remove duplicates.  For each
+primary we also store a map of its secondary entries.  After processing a
+document we output primary entries sorted case-insensitively; each secondary
+entry under a primary is also sorted.  Page lists are printed in ascending order
+after the entry name, separated by commas.


### PR DESCRIPTION
## Summary
- implement Lean solution for SPOJ problem INDEXGEN (Index Generation)
- add sample input/output and algorithm notes

## Testing
- `go test -tags slow ./tests/spoj/human -run TestLeanSolutions -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68b00733850c8320b0e4a22b34edb957