### PR TITLE
Add Mochi solution for SPOJ UPSUB

### DIFF
--- a/tests/spoj/human/x/mochi/1031.in
+++ b/tests/spoj/human/x/mochi/1031.in
@@ -1,0 +1,2 @@
+1
+abcbcbcd

--- a/tests/spoj/human/x/mochi/1031.md
+++ b/tests/spoj/human/x/mochi/1031.md
@@ -1,0 +1,17 @@
+# [Up Subsequence](https://www.spoj.com/problems/UPSUB/)
+
+## Problem Summary
+Given a string `x` (length up to 100), output all maximal upsubsequences—i.e. all longest non-decreasing subsequences—in lexicographical order for each test case.
+
+## Algorithm
+1. For each index `i` of the string, compute the length of the longest non-decreasing subsequence starting at `i`:
+   - Traverse indices from right to left.
+   - `dp[i] = 1 + max(dp[j])` over `j > i` with `x[j] >= x[i]` (or 1 if none).
+   - Track the overall maximum length `L`.
+2. Enumerate all subsequences of length `L` using depth-first search:
+   - Start from positions where `dp[i] == L`.
+   - When moving from `i` to `j`, require `j > i`, `x[j] >= x[i]` and `dp[j] == dp[i]-1`.
+   - Collect resulting strings when `dp[i] == 1`, using a map to avoid duplicates.
+3. Sort the collected subsequences lexicographically and print each, followed by a blank line after every test case.
+
+This runs in `O(n^2 + k log k)` time per test case, where `n` ≤ 100 and `k` is the number of maximal subsequences, using `O(n)` additional space.

--- a/tests/spoj/human/x/mochi/1031.mochi
+++ b/tests/spoj/human/x/mochi/1031.mochi
@@ -1,0 +1,92 @@
+// Solution for SPOJ UPSUB - Up Subsequence
+// https://www.spoj.com/problems/UPSUB/
+
+var s: string
+var n: int
+var dp: list<int>
+var seen: map<string,bool>
+
+fun dfs(i: int, cur: string, acc: list<string>): list<string> {
+  if dp[i] == 1 {
+    if !seen[cur] {
+      seen[cur] = true
+      acc = append(acc, cur)
+    }
+    return acc
+  }
+  var j = i + 1
+  while j < n {
+    if s[j:j+1] >= s[i:i+1] && dp[j] == dp[i] - 1 {
+      acc = dfs(j, cur + s[j:j+1], acc)
+    }
+    j = j + 1
+  }
+  return acc
+}
+
+fun sortStrings(arr: list<string>): list<string> {
+  var i = 1
+  while i < len(arr) {
+    var j = i
+    while j > 0 && arr[j-1] > arr[j] {
+      let tmp = arr[j-1]
+      arr[j-1] = arr[j]
+      arr[j] = tmp
+      j = j - 1
+    }
+    i = i + 1
+  }
+  return arr
+}
+
+fun main() {
+  let tLine = input()
+  if tLine == "" { return }
+  let t = int(tLine)
+  var case = 0
+  while case < t {
+    var line = input()
+    while line == "" { line = input() }
+    s = line
+    n = len(s)
+    dp = []
+    var i = 0
+    while i < n { dp = append(dp, 1); i = i + 1 }
+    i = n - 1
+    while i >= 0 {
+      var j = i + 1
+      var best = 1
+      while j < n {
+        if s[j:j+1] >= s[i:i+1] {
+          let v = 1 + dp[j]
+          if v > best { best = v }
+        }
+        j = j + 1
+      }
+      dp[i] = best
+      i = i - 1
+    }
+    var maxLen = 0
+    i = 0
+    while i < n { if dp[i] > maxLen { maxLen = dp[i] }; i = i + 1 }
+    seen = {}
+    var results: list<string> = []
+    i = 0
+    while i < n {
+      if dp[i] == maxLen {
+        results = dfs(i, s[i:i+1], results)
+      }
+      i = i + 1
+    }
+    results = sortStrings(results)
+    var k = 0
+    while k < len(results) {
+      print(results[k])
+      k = k + 1
+    }
+    print("")
+    case = case + 1
+  }
+}
+
+main()

--- a/tests/spoj/human/x/mochi/1031.out
+++ b/tests/spoj/human/x/mochi/1031.out
@@ -1,0 +1,4 @@
+abbbcd
+abbccd
+abcccd
+

--- a/tests/spoj/x/human/mochi/1031.md
+++ b/tests/spoj/x/human/mochi/1031.md
@@ -1,0 +1,17 @@
+# [Up Subsequence](https://www.spoj.com/problems/UPSUB/)
+
+## Problem Summary
+Given a string `x` (length up to 100), output all maximal upsubsequences—i.e. all longest non-decreasing subsequences—in lexicographical order for each test case.
+
+## Algorithm
+1. For each index `i` of the string, compute the length of the longest non-decreasing subsequence starting at `i`:
+   - Traverse indices from right to left.
+   - `dp[i] = 1 + max(dp[j])` over `j > i` with `x[j] >= x[i]` (or 1 if none).
+   - Track the overall maximum length `L`.
+2. Enumerate all subsequences of length `L` using depth-first search:
+   - Start from positions where `dp[i] == L`.
+   - When moving from `i` to `j`, require `j > i`, `x[j] >= x[i]` and `dp[j] == dp[i]-1`.
+   - Collect resulting strings when `dp[i] == 1`, using a map to avoid duplicates.
+3. Sort the collected subsequences lexicographically and print each, followed by a blank line after every test case.
+
+This runs in `O(n^2 + k log k)` time per test case, where `n` ≤ 100 and `k` is the number of maximal subsequences, using `O(n)` additional space.


### PR DESCRIPTION
## Summary
- add Mochi implementation for SPOJ problem UPSUB (Up Subsequence)
- document algorithm and sample IO for problem 1031

## Testing
- `go test ./tests/spoj/human -run TestMochiSolutions/1031 -tags=slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68b01e4be3008320b438d08d578f3627