### PR TITLE
Add Mochi solution for SPOJ JAVAC

### DIFF
--- a/tests/spoj/human/x/mochi/1163.in
+++ b/tests/spoj/human/x/mochi/1163.in
@@ -1,0 +1,4 @@
+long_and_mnemonic_identifier
+anotherExample
+i
+bad_Style

--- a/tests/spoj/human/x/mochi/1163.md
+++ b/tests/spoj/human/x/mochi/1163.md
@@ -1,0 +1,15 @@
+# [Java vs C ++](https://www.spoj.com/problems/JAVAC/)
+
+## Problem Summary
+Given an identifier, determine whether it's written in Java's camelCase or C++'s snake_case, convert it to the other style, or output `Error!` if it matches neither convention.
+
+## Algorithm
+1. **Validate identifier**
+   - Reject if it starts or ends with an underscore, begins with an uppercase letter, or contains `__`.
+   - While scanning, record whether underscores or uppercase letters appear; having both is invalid.
+2. **Determine style**
+   - If underscores were seen, treat as C++: remove each underscore and capitalize the next letter.
+   - Else if uppercase letters were seen, treat as Java: insert `_` before each uppercase letter and lowercase it.
+   - Otherwise the identifier is a single lowercase word and is printed unchanged.
+
+Each identifier is processed in `O(n)` time with `O(1)` additional memory.

--- a/tests/spoj/human/x/mochi/1163.mochi
+++ b/tests/spoj/human/x/mochi/1163.mochi
@@ -1,0 +1,89 @@
+// Solution for SPOJ JAVAC - Java vs C ++
+// https://www.spoj.com/problems/JAVAC/
+
+let low2up = {
+  "a":"A","b":"B","c":"C","d":"D","e":"E","f":"F","g":"G","h":"H","i":"I","j":"J",
+  "k":"K","l":"L","m":"M","n":"N","o":"O","p":"P","q":"Q","r":"R","s":"S","t":"T",
+  "u":"U","v":"V","w":"W","x":"X","y":"Y","z":"Z",
+}
+
+let up2low = {
+  "A":"a","B":"b","C":"c","D":"d","E":"e","F":"f","G":"g","H":"h","I":"i","J":"j",
+  "K":"k","L":"l","M":"m","N":"n","O":"o","P":"p","Q":"q","R":"r","S":"s","T":"t",
+  "U":"u","V":"v","W":"w","X":"x","Y":"y","Z":"z",
+}
+
+fun isUpper(ch: string): bool { return ch >= "A" && ch <= "Z" }
+
+fun toUpperChar(ch: string): string {
+  if ch in low2up { return low2up[ch] }
+  return ch
+}
+
+fun toLowerChar(ch: string): string {
+  if ch in up2low { return up2low[ch] }
+  return ch
+}
+
+fun translate(s: string): string {
+  if len(s) == 0 { return "Error!" }
+  let first = s[0:1]
+  if first == "_" || isUpper(first) { return "Error!" }
+  if s[len(s)-1:len(s)] == "_" { return "Error!" }
+  var hasUnder = false
+  var hasUpper = false
+  var i = 0
+  while i < len(s) {
+    let ch = s[i:i+1]
+    if ch == "_" {
+      hasUnder = true
+      if i+1 >= len(s) { return "Error!" }
+      if s[i+1:i+2] == "_" { return "Error!" }
+    } else if isUpper(ch) {
+      hasUpper = true
+    }
+    i = i + 1
+  }
+  if hasUnder && hasUpper { return "Error!" }
+  if hasUnder {
+    var res = ""
+    var j = 0
+    while j < len(s) {
+      let ch = s[j:j+1]
+      if ch == "_" {
+        j = j + 1
+        let next = s[j:j+1]
+        res = res + toUpperChar(next)
+      } else {
+        res = res + ch
+      }
+      j = j + 1
+    }
+    return res
+  }
+  if hasUpper {
+    var res2 = ""
+    var k = 0
+    while k < len(s) {
+      let ch = s[k:k+1]
+      if isUpper(ch) {
+        res2 = res2 + "_" + toLowerChar(ch)
+      } else {
+        res2 = res2 + ch
+      }
+      k = k + 1
+    }
+    return res2
+  }
+  return s
+}
+
+fun main() {
+  while true {
+    let line = input()
+    if line == "" { break }
+    print(translate(line))
+  }
+}
+
+main()

--- a/tests/spoj/human/x/mochi/1163.out
+++ b/tests/spoj/human/x/mochi/1163.out
@@ -1,0 +1,4 @@
+longAndMnemonicIdentifier
+another_example
+i
+Error!


### PR DESCRIPTION
## Summary
- add Mochi implementation for SPOJ problem JAVAC converting between Java camelCase and C++ snake_case
- document identifier conversion algorithm
- add sample I/O tests

## Testing
- `MOCHI_ROSETTA_ONLY=1163 go test -run TestMochiSolutions -tags=slow ./tests/spoj/human -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68b022cfb02c8320ab042ba7be7f82a8