### PR TITLE
docs: add release notes for v0.10.78

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # 📦 CHANGELOG.md
 
+## [0.10.78] – 2025-08-29T09:06:46+07:00
+
+### Added
+
+- Mochi solutions for SPOJ problems like QUILT, DEL Command II, polygon encoder, 1043, 871, GEOM, NGM, CATM, CZ_PROB1, KPMATRIX, CHASE, PARTSUM, SUMFOUR, CFRAC2, CNHARD, CNEASY, ORIGLIFE and more.
+- Lean solutions for SPOJ challenges including POLYCODE, MAXIMUS, GEOM, NGM, CATM, CZ_PROB1, KPMAZE, KPMATRIX, PALACE, SORTBIT, Dead Fraction, TOE2, TOE1, NSTEPS, Sudoku, CTRICK and others.
+- Algorithm writeups for SORTBIT, Sudoku solving approach, Repeats and DIV.
+
+### Changed
+
+- Removed unused variable.
+
+### Fixed
+
+- No fixes.
+
 ## [0.10.77] – 2025-08-28T09:26:37+07:00
 
 ### Added

--- a/releases/v0.10.78.md
+++ b/releases/v0.10.78.md
@@ -1,0 +1,14 @@
+# Aug 2025 (v0.10.78)
+
+Released on Fri Aug 29 09:06:46 2025 +0700.
+
+Mochi v0.10.78 adds more SPOJ solutions across Mochi and Lean and expands algorithm documentation.
+
+## SPOJ Solutions
+
+- Mochi implementations for problems such as QUILT, DEL Command II, polygon encoder, 1043, 871, GEOM, NGM, CATM, CZ_PROB1, KPMATRIX, CHASE, PARTSUM, SUMFOUR, CFRAC2, CNHARD, CNEASY, ORIGLIFE and more.
+- Lean solutions for challenges including POLYCODE, MAXIMUS, GEOM, NGM, CATM, CZ_PROB1, KPMAZE, KPMATRIX, PALACE, SORTBIT, Dead Fraction, TOE2, TOE1, NSTEPS, Sudoku, CTRICK and many others.
+
+## Documentation
+
+- Added algorithm notes for SORTBIT, Sudoku solving approach, Repeats and DIV.


### PR DESCRIPTION
## Summary
- add changelog entry for v0.10.78
- document release details in `releases/v0.10.78.md`

## Testing
- `npm test` *(fails: Missing script)*
- `go test ./parser`
- `go test ./...` *(interrupted: signal: interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b15f4a2f648320aca330f00763058e