### PR TITLE
docs: release notes for v0.10.79

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # 📦 CHANGELOG.md
 
+## [0.10.79] – 2025-08-30T03:46:25+00:00
+
+### Added
+
+- Mochi solutions for SPOJ problems: COVER2, BRCKGAME, CHAIN, Sum of Digits, ARCTAN, PT07Z, PT07Y Is it a tree, 1435 Vertex Cover, Equation, KPSUM, KPPOLY, Goods.
+- Lean solutions for SPOJ problems: COVER2, BRCKGAME, DELCOMM2, CHAIN, CLEVER, ARCTAN, PT07Z, 1436, PT07X, 1434, KPSUM, KPPOLY, FIRM, quilt problem.
+
 ## [0.10.78] – 2025-08-29T09:06:46+07:00
 
 ### Added

--- a/releases/v0.10.79.md
+++ b/releases/v0.10.79.md
@@ -1,0 +1,11 @@
+# Aug 2025 (v0.10.79)
+
+Released on Sat Aug 30 03:46:25 2025 +0000.
+
+Mochi v0.10.79 introduces additional SPOJ solutions in both Mochi and Lean.
+
+## SPOJ Solutions
+
+- Mochi implementations for problems such as COVER2, BRCKGAME, CHAIN, Sum of Digits, ARCTAN, PT07Z, PT07Y Is it a tree, 1435 Vertex Cover, Equation, KPSUM, KPPOLY, Goods.
+- Lean solutions for problems including COVER2, BRCKGAME, DELCOMM2, CHAIN, CLEVER, ARCTAN, PT07Z, 1436, PT07X, 1434, KPSUM, KPPOLY, FIRM, quilt problem.
+


### PR DESCRIPTION
## Summary
- add release note for v0.10.79
- update changelog for v0.10.79

## Testing
- `npm test` (fails: Missing script "test")
- `go test ./...` (interrupted: signal interrupt)

------
https://chatgpt.com/codex/tasks/task_e_68b273ca19cc83209a7a8f033066d9f7