### PR TITLE
Add Lean solution for SPOJ NSYSTEM

### DIFF
--- a/tests/spoj/human/x/lean/1699.in
+++ b/tests/spoj/human/x/lean/1699.in
@@ -1,0 +1,11 @@
+10
+xi x9i
+i 9i
+c2x2i 4c8x8i
+m2ci 4m7c9x8i
+9c9x9i i
+i 9m9c9x8i
+m i
+i m
+m9i i
+9m8c7xi c2x8i

--- a/tests/spoj/human/x/lean/1699.lean
+++ b/tests/spoj/human/x/lean/1699.lean
@@ -1,0 +1,54 @@
+/- Solution for SPOJ NSYSTEM - Numeral System
+https://www.spoj.com/problems/NSYSTEM/
+-/
+
+import Std
+open Std
+
+/-- Convert an MCXI-string to its numeric value. --/
+def parseMCXI (s : String) : Nat :=
+  let rec go : List Char → Nat
+  | [] => 0
+  | c :: cs =>
+      let letterVal : Char → Nat
+        | 'm' => 1000
+        | 'c' => 100
+        | 'x' => 10
+        | _   => 1
+      if c.isDigit then
+        match cs with
+        | l :: rest =>
+            let d := c.toNat - '0'.toNat
+            d * letterVal l + go rest
+        | [] => 0
+      else
+        letterVal c + go cs
+  go s.data
+
+/-- Convert a number (≤ 9999) to its MCXI-string. --/
+def encodeMCXI (n : Nat) : String :=
+  let rec build (n : Nat) (pairs : List (Nat × Char)) (acc : String) : String :=
+    match pairs with
+    | [] => acc
+    | (v, ch) :: ps =>
+        let q := n / v
+        let r := n % v
+        let part :=
+          if q == 0 then ""
+          else if q == 1 then String.singleton ch
+          else toString q ++ String.singleton ch
+        build r ps (acc ++ part)
+  build n [(1000,'m'), (100,'c'), (10,'x'), (1,'i')] ""
+
+/-- Main program: read input, sum pairs, output MCXI representation. --/
+def main : IO Unit := do
+  let data ← (← IO.getStdin).readToEnd
+  let tokens := data.split (fun c => c = ' ' || c = '\n' || c = '\t' || c = '\r') |>.filter (·.length > 0)
+  let t := (tokens[0]!).toNat!
+  let mut idx := 1
+  for _ in [0:t] do
+    let a := tokens[idx]!
+    let b := tokens[idx + 1]!
+    let sum := parseMCXI a + parseMCXI b
+    IO.println (encodeMCXI sum)
+    idx := idx + 2

--- a/tests/spoj/human/x/lean/1699.out
+++ b/tests/spoj/human/x/lean/1699.out
@@ -1,0 +1,10 @@
+3x
+x
+6cx
+5m9c9x9i
+m
+9m9c9x9i
+mi
+mi
+mx
+9m9c9x9i

--- a/tests/spoj/x/human/lean/1699.md
+++ b/tests/spoj/x/human/lean/1699.md
@@ -1,0 +1,14 @@
+# [Numeral System](https://www.spoj.com/problems/NSYSTEM)
+
+## Problem Summary
+Given two numbers in Prof. Hachioji's MCXI numeral system, compute their sum and output the result in the same MCXI format. Each MCXI string uses letters `m`, `c`, `x`, `i` representing 1000, 100, 10 and 1 respectively, optionally preceded by digits `2`–`9` to multiply the value of that letter. Each letter appears at most once and in the fixed order `m` → `c` → `x` → `i`.
+
+## Algorithm
+1. **Parsing**: For each MCXI string, traverse its characters. If a digit is found, multiply it by the value of the following letter and add to an accumulator. Otherwise, add the letter's value directly.
+2. **Addition**: Sum the integer values of the two parsed strings.
+3. **Encoding**: Convert the sum back to an MCXI string by processing the values in order `(1000,'m'), (100,'c'), (10,'x'), (1,'i')`. For each value:
+   - Compute the digit `q` as integer division by the value.
+   - If `q` is zero, skip.
+   - If `q` is one, append the letter; otherwise append `q` followed by the letter.
+
+This procedure guarantees a unique representation for numbers up to 9999 while using only simple arithmetic and string operations.


### PR DESCRIPTION
## Summary
- implement MCXI numeral system parser/encoder in Lean for SPOJ problem NSYSTEM
- add sample I/O and documentation for the problem

## Testing
- `MOCHI_ROSETTA_ONLY=1699 go test ./tests/spoj/human -run TestLeanSolutions -tags slow -v` *(fails: lean not installed, tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b17bd15cf8832083d35d275ac474ab