### PR TITLE
docs: add release notes for v0.10.80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # 📦 CHANGELOG.md
 
+## [0.10.80] – 2025-08-31T02:56:47+00:00
+
+### Added
+
+- Mochi solutions for SPOJ problems such as GSS3, SCALE, PRMLX, Two Ends, SQCOUNT, RELINETS, QKP, ACMAKER, Cleaning Robot, problem 1701, TRSTAGE, NSYSTEM, Polygonal Line Search, OFORTUNE, WIJGT, COCONUTS, EASYPROB, LOGIC2, 1685 Grocery Store, Frequent Values, EXPRESS, Cylinder, Treasury, HALLOW, Text Generator, Fusion Cube, 1674, 1673, GIWED, AMATH, TREEOI14, GSS2, ZOO, BACKUP, MOBILE2, MKJUMPS, BLUEEQ3, Ranklist Sorting, MOLE, POLEVAL, the PT07 series, problems 1478 and 1476, Play with Digit Seven, problem 1473, Tom and Jerry, PEARL, SEQ2, problem 1487, Search in XML and more.
+- Lean solutions for SPOJ problems including NSYSTEM, Polygonal Line Search, 1697, WIJGT, GRC, COCONUTS, HARDP, 1688, LOGIC2, GROCERY, Frequent Values, EXPRESS, Cylinder, Treasury, 1677, GEN, FUSION, EXPLOSN, AMBM, GIWED, AMATH, TREEOI14, ZOO, BACKUP, Mobiles, MKJUMPS, BLUEEQ3, RSORTING, MOLE, POLEVAL, the PT07 series, PEARL, SEQ2, RAIN2, CASHIER, chris, EDIT3, ROBOT, problem 1461, GALAXY, AEROLITE, BLUEEQ2, BLUEEQ and more.
+- Documentation for Swamp Things solution.
+
+### Changed
+
+- No changes.
+
+### Fixed
+
+- No fixes.
+
 ## [0.10.79] – 2025-08-30T03:46:25+00:00
 
 ### Added

--- a/releases/v0.10.80.md
+++ b/releases/v0.10.80.md
@@ -1,0 +1,14 @@
+# Aug 2025 (v0.10.80)
+
+Released on Sun Aug 31 02:56:47 2025 +0000.
+
+Mochi v0.10.80 adds another batch of SPOJ problem solutions in both Mochi and Lean.
+
+## SPOJ Solutions
+
+- Mochi implementations for problems such as GSS3, SCALE, PRMLX, Two Ends, SQCOUNT, RELINETS, QKP, ACMAKER, Cleaning Robot, problem 1701, TRSTAGE and more.
+- Lean implementations for challenges like NSYSTEM, Polygonal Line Search, 1697, WIJGT, GRC, COCONUTS, HARDP, 1688, LOGIC2, GROCERY, Frequent Values, EXPRESS, Cylinder, Treasury and more.
+
+## Documentation
+
+- Added writeup for the Swamp Things solution.


### PR DESCRIPTION
## Summary
- document v0.10.80 release details and SPOJ additions
- update changelog for v0.10.80

## Testing
- `npm test` (fails: Missing script: "test")
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b3b825229483208a36188a9a4dd736