### PR TITLE
Add Mochi solution for SPOJ problem 1704

### DIFF
--- a/tests/spoj/human/x/mochi/1704.in
+++ b/tests/spoj/human/x/mochi/1704.in
@@ -1,0 +1,24 @@
+3
+8 2
+Barney 2 Fred Ginger
+Ingrid 1 Nolan
+Cindy 1 Hal
+Jeff 2 Oliva Peter
+Don 2 Ingrid Jeff
+Fred 1 Kathy
+Andrea 4 Barney Cindy Don Eloise
+Hal 2 Lionel Mary
+6 1
+Phillip 5 Jim Phil Jane Joe Paul
+Jim 1 Jimmy
+Phil 1 Philly
+Jane 1 Janey
+Joe 1 Joey
+Paul 1 Pauly
+6 2
+Phillip 5 Jim Phil Jane Joe Paul
+Jim 1 Jimmy
+Phil 1 Philly
+Jane 1 Janey
+Joe 1 Joey
+Paul 1 Pauly

--- a/tests/spoj/human/x/mochi/1704.md
+++ b/tests/spoj/human/x/mochi/1704.md
@@ -1,0 +1,12 @@
+# [Countdown](https://www.spoj.com/problems/CDOWN/)
+
+## Problem Summary
+For each test case a family tree is given. Each description line lists a person and all of their children. Given an integer `d`, determine which people have the largest number of descendants exactly `d` generations away. Output the top three names, extended to include ties, along with their descendant counts.
+
+## Algorithm
+1. Build an adjacency map from every person to their list of children while collecting all names in the tree.
+2. For each person, perform a breadth‑first search over the tree limited to depth `d` and count nodes encountered exactly at depth `d`.
+3. Gather pairs of `(name, count)` for people with a non‑zero count and sort them by descending count and then ascending name.
+4. Output the first three pairs, and continue outputting further pairs while their counts equal the third place count.
+
+The search for each person visits at most all nodes in the tree, so with up to 1000 people the approach runs in `O(n^2)` time and uses `O(n)` additional space.

--- a/tests/spoj/human/x/mochi/1704.mochi
+++ b/tests/spoj/human/x/mochi/1704.mochi
@@ -1,0 +1,141 @@
+// Solution for SPOJ CDOWN - Countdown
+// https://www.spoj.com/problems/CDOWN/
+
+fun splitSpaces(s: string): list<string> {
+  var parts: list<string> = []
+  var cur = ""
+  var i = 0
+  while i < len(s) {
+    let ch = s[i:i+1]
+    if ch == " " || ch == "\t" || ch == "\r" || ch == "\n" {
+      if len(cur) > 0 { parts = append(parts, cur); cur = "" }
+    } else {
+      cur = cur + ch
+    }
+    i = i + 1
+  }
+  if len(cur) > 0 { parts = append(parts, cur) }
+  return parts
+}
+
+let digits = {
+  "0":0,"1":1,"2":2,"3":3,"4":4,
+  "5":5,"6":6,"7":7,"8":8,"9":9,
+}
+
+fun parseIntStr(str: string): int {
+  var i = 0
+  var n = 0
+  while i < len(str) {
+    n = n * 10 + (digits[str[i:i+1]] as int)
+    i = i + 1
+  }
+  return n
+}
+
+type Node = { name: string, depth: int }
+
+fun countDesc(root: string, d: int, adj: map<string,list<string>>): int {
+  var q: list<Node> = [Node{ name: root, depth: 0 }]
+  var qi = 0
+  var cnt = 0
+  while qi < len(q) {
+    let cur = q[qi]
+    qi = qi + 1
+    if cur.depth == d {
+      cnt = cnt + 1
+      continue
+    }
+    if cur.depth > d { continue }
+    let childs = adj[cur.name]
+    if childs != nil {
+      var j = 0
+      while j < len(childs) {
+        q = append(q, Node{ name: childs[j], depth: cur.depth + 1 })
+        j = j + 1
+      }
+    }
+  }
+  return cnt
+}
+
+type Pair = { name: string, c: int }
+
+fun sortPairs(arr: list<Pair>): list<Pair> {
+  var i = 1
+  while i < len(arr) {
+    var j = i
+    while j > 0 {
+      let a = arr[j-1]
+      let b = arr[j]
+      if a.c > b.c || (a.c == b.c && a.name <= b.name) { break }
+      arr[j-1] = b
+      arr[j] = a
+      j = j - 1
+    }
+    i = i + 1
+  }
+  return arr
+}
+
+fun main() {
+  let tLine = input()
+  if tLine == "" || tLine == nil { return }
+  let t = parseIntStr(tLine)
+  var cs = 0
+  while cs < t {
+    var line = input()
+    while line == "" || line == nil { line = input() }
+    let first = splitSpaces(line)
+    let n = parseIntStr(first[0])
+    let d = parseIntStr(first[1])
+    var adj: map<string,list<string>> = {}
+    var names: map<string,bool> = {}
+    var i = 0
+    while i < n {
+      var ln = input()
+      while ln == "" || ln == nil { ln = input() }
+      let parts = splitSpaces(ln)
+      let name = parts[0]
+      let m = parseIntStr(parts[1])
+      var childs: list<string> = []
+      var j = 0
+      while j < m {
+        let ch = parts[2 + j]
+        childs = append(childs, ch)
+        if adj[ch] == nil { adj[ch] = [] }
+        names[ch] = true
+        j = j + 1
+      }
+      adj[name] = childs
+      names[name] = true
+      i = i + 1
+    }
+    var res: list<Pair> = []
+    for name, _ in names {
+      let c = countDesc(name, d, adj)
+      if c > 0 {
+        res = append(res, Pair{ name: name, c: c })
+      }
+    }
+    if len(res) > 1 {
+      res = sortPairs(res)
+    }
+    print("Tree " + str(cs + 1) + ":")
+    if len(res) > 0 {
+      var limit = 3
+      if len(res) < limit { limit = len(res) }
+      var last = res[limit - 1].c
+      var k = 0
+      while k < len(res) && (k < limit || res[k].c == last) {
+        let p = res[k]
+        print(p.name + " " + str(p.c))
+        k = k + 1
+      }
+    }
+    cs = cs + 1
+    if cs < t { print("") }
+  }
+}
+
+main()

--- a/tests/spoj/human/x/mochi/1704.out
+++ b/tests/spoj/human/x/mochi/1704.out
@@ -1,0 +1,15 @@
+Tree 1:
+Andrea 5
+Don 3
+Cindy 2
+
+Tree 2:
+Phillip 5
+Jane 1
+Jim 1
+Joe 1
+Paul 1
+Phil 1
+
+Tree 3:
+Phillip 5

--- a/tests/spoj/x/human/mochi/1704.md
+++ b/tests/spoj/x/human/mochi/1704.md
@@ -1,0 +1,12 @@
+# [Countdown](https://www.spoj.com/problems/CDOWN/)
+
+## Problem Summary
+For each test case a family tree is given. Each description line lists a person and all of their children. Given an integer `d`, determine which people have the largest number of descendants exactly `d` generations away. Output the top three names, extended to include ties, along with their descendant counts.
+
+## Algorithm
+1. Build an adjacency map from every person to their list of children while collecting all names in the tree.
+2. For each person, perform a breadth‑first search over the tree limited to depth `d` and count nodes encountered exactly at depth `d`.
+3. Gather pairs of `(name, count)` for people with a non‑zero count and sort them by descending count and then ascending name.
+4. Output the first three pairs, and continue outputting further pairs while their counts equal the third place count.
+
+The search for each person visits at most all nodes in the tree, so with up to 1000 people the approach runs in `O(n^2)` time and uses `O(n)` additional space.


### PR DESCRIPTION
## Summary
- add test input/output and Mochi implementation for SPOJ problem 1704
- document algorithm for breadth-first search counting d-generation descendants

## Testing
- `go test ./tests/spoj/human -run TestMochiSolutions -tags slow` *(failed: command produced no output and did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b230b64883208ff50972eaf582be