### PR TITLE
Add Lean solution for SPOJ BWHEELER

### DIFF
--- a/tests/spoj/human/x/lean/1874.in
+++ b/tests/spoj/human/x/lean/1874.in
@@ -1,0 +1,7 @@
+2
+bacab
+3
+rwlb
+11
+baaabaaaabbbaba
+0

--- a/tests/spoj/human/x/lean/1874.lean
+++ b/tests/spoj/human/x/lean/1874.lean
@@ -1,0 +1,56 @@
+/- Solution for SPOJ BWHEELER - Burrows Wheeler Precompression
+https://www.spoj.com/problems/BWHEELER/
+-/
+
+import Std
+open Std
+
+/-- Convert a lowercase character to an index 0..25. --/
+def idx (c : Char) : Nat := c.toNat - 'a'.toNat
+
+/-- Invert the Burrows–Wheeler transform given row `r` and last column `col`. --/
+def invBWT (r : Nat) (col : String) : String := Id.run do
+  let n := col.length
+  let lArr : Array Char := col.data.toArray
+  let fArr : Array Char := lArr.qsort (fun a b => a < b)
+  -- record positions of each char in first column
+  let mut pos : Array (Array Nat) := mkArray 26 #[]
+  for j in [0:n] do
+    let c := fArr.get! j
+    let i := idx c
+    pos := pos.set! i ((pos.get! i).push j)
+  -- build LF-mapping
+  let mut lf : Array Nat := mkArray n 0
+  let mut used : Array Nat := mkArray 26 0
+  for i in [0:n] do
+    let c := lArr.get! i
+    let ci := idx c
+    let k := used.get! ci
+    let j := (pos.get! ci).get! k
+    lf := lf.set! i j
+    used := used.set! ci (k + 1)
+  -- reconstruct string
+  let mut row := r - 1
+  let mut res : Array Char := mkArray n 'a'
+  for k in [0:n] do
+    res := res.set! (n - 1 - k) (lArr.get! row)
+    row := lf.get! row
+  return String.mk res.toList
+
+partial def loop (h : IO.FS.Stream) : IO Unit := do
+  let line ← h.getLine
+  let line := line.trim
+  if line.isEmpty then
+    pure ()
+  else
+    let r := line.toNat!
+    if r == 0 then
+      pure ()
+    else
+      let col ← h.getLine
+      let s := invBWT r (col.trim)
+      IO.println s
+      loop h
+
+def main : IO Unit := do
+  loop (← IO.getStdin)

--- a/tests/spoj/human/x/lean/1874.md
+++ b/tests/spoj/human/x/lean/1874.md
@@ -1,0 +1,16 @@
+# SPOJ BWHEELER - Burrows Wheeler Precompression
+
+[Problem Link](https://www.spoj.com/problems/BWHEELER/)
+
+We are given the row number `R` of the original string in the sorted matrix of all rotations and the last column string produced by the Burrows–Wheeler transform. The task is to recover the original string.
+
+## Algorithm
+
+1. Let `L` be the last column and `n = |L|`.
+2. Form the first column `F` by sorting `L`.
+3. For each character `c`, record the list of indices where `c` appears in `F`.
+4. Scan `L` from left to right and for each character pick the next index from the corresponding list in `F`; this builds an array `lf` mapping each row to the row that precedes it in the original string.
+5. Starting from row `R-1`, follow `lf` backwards `n` times, collecting the characters from `L` to reconstruct the string in reverse.
+6. Output the recovered string.
+
+Sorting dominates the runtime, giving `O(n log n)` complexity with `n \le 1000`.

--- a/tests/spoj/human/x/lean/1874.out
+++ b/tests/spoj/human/x/lean/1874.out
@@ -1,0 +1,3 @@
+abcba
+rbwl
+baaabbbbaaaaaab


### PR DESCRIPTION
## Summary
- implement inverse Burrows–Wheeler transform in Lean for SPOJ problem BWHEELER
- document algorithm and add sample test cases

## Testing
- `MOCHI_ROSETTA_ONLY=1874 go test -tags=slow ./tests/spoj/human -run TestLeanSolutions -v` (fails: lean toolchain not installed)

------
https://chatgpt.com/codex/tasks/task_e_68b2c2bf13d483208bea0f48985b6d41