### PR TITLE
website: make homepage code samples actually run

### DIFF
--- a/examples/website/.gitignore
+++ b/examples/website/.gitignore
@@ -1,0 +1,1 @@
+top.json

--- a/examples/website/README.md
+++ b/examples/website/README.md
@@ -1,0 +1,17 @@
+Source for the six code samples shown on https://mochi-lang.dev.
+
+Each `.mochi` file matches a tab in the homepage `CodeShowcase`. They are
+runnable end to end with the published `mochi` binary, and exist here so
+that homepage edits can be regression-tested against the real toolchain.
+
+```
+mochi run hello.mochi          # Sample 1: Hello, Mochi
+mochi run shapes.mochi         # Sample 2: Types and functions
+mochi run events.mochi         # Sample 3: Tagged unions
+mochi run summarize.mochi      # Sample 4: Generative AI (echo provider)
+mochi run top-products.mochi   # Sample 5: Datasets (reads products.json)
+mochi test math.mochi          # Sample 6: Tests
+```
+
+When the homepage in `website/src/pages/index.js` changes, update the
+matching file here and re-run the snippets to confirm they still execute.

--- a/examples/website/events.mochi
+++ b/examples/website/events.mochi
@@ -1,0 +1,23 @@
+// Sample 3 from mochi-lang.dev homepage: "Tagged unions"
+type Event =
+  Login(user: string)
+  | Message(from: string, body: string)
+  | Logout(user: string)
+
+fun describe(e: Event): string {
+  return match e {
+    Login(u) => u + " signed in"
+    Message(f, b) => f + " says: " + b
+    Logout(u) => u + " signed out"
+  }
+}
+
+let events = [
+  Login { user: "ada" },
+  Message { from: "lin", body: "hey" },
+  Logout { user: "ada" },
+]
+
+for e in events {
+  print(describe(e))
+}

--- a/examples/website/hello.mochi
+++ b/examples/website/hello.mochi
@@ -1,0 +1,7 @@
+// Sample 1 from mochi-lang.dev homepage: "Hello, Mochi"
+let name = "Mochi"
+print("Hello, " + name + "!")
+
+// Strings concatenate with + and interpolate via str()
+let answer = 42
+print("the answer is " + str(answer))

--- a/examples/website/math.mochi
+++ b/examples/website/math.mochi
@@ -1,0 +1,19 @@
+// Sample 6 from mochi-lang.dev homepage: "Tests"
+fun add(a: int, b: int): int {
+  return a + b
+}
+
+fun safe_div(a: int, b: int): int {
+  if b == 0 { return 0 - 1 }
+  return a / b
+}
+
+test "add is commutative" {
+  expect add(2, 3) == add(3, 2)
+}
+
+test "safe_div guards zero" {
+  expect safe_div(10, 2) == 5
+  let z = safe_div(10, 0)
+  expect z == 0 - 1
+}

--- a/examples/website/products.json
+++ b/examples/website/products.json
@@ -1,0 +1,7 @@
+[
+  {"name": "Laptop", "price": 1500},
+  {"name": "Phone", "price": 900},
+  {"name": "Tablet", "price": 600},
+  {"name": "Mouse", "price": 40},
+  {"name": "Keyboard", "price": 80}
+]

--- a/examples/website/shapes.mochi
+++ b/examples/website/shapes.mochi
@@ -1,0 +1,17 @@
+// Sample 2 from mochi-lang.dev homepage: "Types and functions"
+type Rectangle {
+  width: float
+  height: float
+}
+
+fun area(r: Rectangle): float {
+  return r.width * r.height
+}
+
+fun perimeter(r: Rectangle): float {
+  return 2.0 * (r.width + r.height)
+}
+
+let card = Rectangle { width: 3.0, height: 4.0 }
+print(area(card))
+print(perimeter(card))

--- a/examples/website/summarize.mochi
+++ b/examples/website/summarize.mochi
@@ -1,0 +1,13 @@
+// Sample 4 from mochi-lang.dev homepage: "Generative AI"
+// The "echo" provider is a built-in dummy that returns the prompt unchanged.
+// Swap to "openai", "anthropic", or "google" without changing the call site.
+model dummy {
+  provider: "echo"
+  name: "echo"
+}
+
+let summary = generate text {
+  model: "dummy",
+  prompt: "Explain bytecode in two sentences."
+}
+print(summary)

--- a/examples/website/top-products.mochi
+++ b/examples/website/top-products.mochi
@@ -1,0 +1,19 @@
+// Sample 5 from mochi-lang.dev homepage: "Datasets"
+type Product {
+  name: string
+  price: int
+}
+
+let products = load "products.json" as Product with { format: "json" }
+
+let top = from p in products
+          where p.price >= 100
+          sort by -p.price
+          take 3
+          select { name: p.name, price: p.price }
+
+for item in top {
+  print(item.name + ", $" + str(item.price))
+}
+
+save top to "top.json"

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -112,75 +112,75 @@ the answer is 42`,
     description:
       'Define data with type. Write functions with fun. The compiler infers most annotations and rejects type errors at compile time.',
     filename: 'shapes.mochi',
-    code: `type Point {
-  x: float
-  y: float
+    code: `type Rectangle {
+  width: float
+  height: float
 }
 
-fun distance(a: Point, b: Point): float {
-  let dx = a.x - b.x
-  let dy = a.y - b.y
-  return (dx * dx + dy * dy) ** 0.5
+fun area(r: Rectangle): float {
+  return r.width * r.height
 }
 
-let origin = Point { x: 0.0, y: 0.0 }
-let target = Point { x: 3.0, y: 4.0 }
-print(distance(origin, target))`,
-    output: `5`,
+fun perimeter(r: Rectangle): float {
+  return 2.0 * (r.width + r.height)
+}
+
+let card = Rectangle { width: 3.0, height: 4.0 }
+print(area(card))
+print(perimeter(card))`,
+    output: `12
+14`,
   },
   {
-    label: 'Agents and streams',
-    hint: 'reactive in 12 lines',
+    label: 'Tagged unions',
+    hint: 'pattern matching with exhaustiveness',
     icon: <AgentIcon />,
     description:
-      'Agents hold state and react to events. Streams declare event shapes. Emit publishes one event. No message bus, no actor library.',
-    filename: 'inbox.mochi',
-    code: `stream Message { from: string, body: string }
+      'Tagged union types replace enums, sealed classes, and Option<T>. The match expression destructures variants with exhaustiveness checking at compile time.',
+    filename: 'events.mochi',
+    code: `type Event =
+  Login(user: string)
+  | Message(from: string, body: string)
+  | Logout(user: string)
 
-agent inbox {
-  var unread: int = 0
-
-  on Message as m {
-    unread = unread + 1
-    print("new from " + m.from)
-  }
-
-  intent count(): int {
-    return unread
+fun describe(e: Event): string {
+  return match e {
+    Login(u) => u + " signed in"
+    Message(f, b) => f + " says: " + b
+    Logout(u) => u + " signed out"
   }
 }
 
-let box = inbox {}
-emit Message { from: "ada", body: "hi" }
-emit Message { from: "lin", body: "hey" }
-print("unread = " + str(box.count()))`,
-    output: `new from ada
-new from lin
-unread = 2`,
+let events = [
+  Login { user: "ada" },
+  Message { from: "lin", body: "hey" },
+  Logout { user: "ada" },
+]
+
+for e in events {
+  print(describe(e))
+}`,
+    output: `ada signed in
+lin says: hey
+ada signed out`,
   },
   {
     label: 'Generative AI',
     hint: 'generate blocks in the grammar',
     icon: <BrainIcon />,
     description:
-      'Configure a provider once with a model block. Call any model with the same generate syntax. Structured output is one suffix, as json.',
+      'Configure a provider once with a model block. Call any model with the same generate syntax. Swap echo (the built-in dummy) for openai, anthropic, or google without touching the call site.',
     filename: 'summarize.mochi',
-    code: `model fast {
-  provider: "openai"
-  name: "gpt-5.5-mini"
-  temperature: 0.3
+    code: `model dummy {
+  provider: "echo"
+  name: "echo"
 }
 
 let summary = generate text {
-  model: "fast"
+  model: "dummy",
   prompt: "Explain bytecode in two sentences."
 }
-print(summary)
-
-let plan = generate text {
-  prompt: "Output a plan with title and steps."
-} as json
-print(plan["title"])`,
+print(summary)`,
   },
   {
     label: 'Datasets',
@@ -194,7 +194,7 @@ print(plan["title"])`,
   price: int
 }
 
-let products = load "products.json" as Product
+let products = load "products.json" as Product with { format: "json" }
 
 let top = from p in products
           where p.price >= 100
@@ -222,8 +222,8 @@ Tablet, $600`,
   return a + b
 }
 
-fun safe_div(a: int, b: int): int | nil {
-  if b == 0 { return nil }
+fun safe_div(a: int, b: int): int {
+  if b == 0 { return 0 - 1 }
   return a / b
 }
 
@@ -233,9 +233,11 @@ test "add is commutative" {
 
 test "safe_div guards zero" {
   expect safe_div(10, 2) == 5
-  expect safe_div(10, 0) == nil
+  let z = safe_div(10, 0)
+  expect z == 0 - 1
 }`,
-    output: `2 tests passed`,
+    output: `test add is commutative   ... ok
+test safe_div guards zero ... ok`,
   },
 ];
 


### PR DESCRIPTION
I tested the six "complete Mochi file" tabs on the homepage against the published v0.10.82 binary. Only the first one ran. The other five hit parse errors, runtime stack overflows, or needed an OpenAI key. This PR rewrites each broken sample to syntax that actually works today, and saves the source files under examples/website/ so we can re-run them whenever the homepage changes.

What changed per tab:

- Types and functions: the old code used `**` for exponentiation and called `sqrt`, neither of which exists in Mochi. Switched to a Rectangle with area and perimeter using only multiplication and addition.
- Agents and streams: instantiating an agent stack-overflows in the bytecode VM. The agent runtime never got wired into the VM, so even the canonical example in tests/interpreter/valid hits this. Replaced the tab with a tagged-union plus match example, which the VM does support cleanly.
- Generative AI: the original snippet pointed at gpt-5.5-mini and would not run without an API key. Switched to the built-in echo provider so the file runs locally with no setup. Dropped the second `as json` block since the bytecode VM does not implement structured-output decoding yet.
- Datasets: `load "products.json"` was defaulting to the CSV parser and choking on the JSON. Added `with { format: "json" }` and it parses correctly.
- Tests: the parser does not accept `int | nil` return types or unary minus on the right of `==`. Used an int sentinel and `0 - 1` as workarounds.

Hello, Mochi was already correct and is unchanged.

The agents-in-the-VM regression and the two parser gaps (inline union types, unary minus after `==`) are all real language issues. I left them out of this PR because each one is its own implementation task and the immediate priority is that what we link to from the homepage actually runs.

## Test plan

- [x] `mochi run` against each sample under examples/website/ on v0.10.82
- [x] `mochi test math.mochi` reports two passing tests
- [x] `npm run build` in website/ succeeds
- [ ] After merge, check https://mochi-lang.dev shows the new tabs and the CI deploy goes green