### PR TITLE
website: show products.json input on the Datasets sample

### DIFF
--- a/examples/website/products.json
+++ b/examples/website/products.json
@@ -1,7 +1,7 @@
 [
-  {"name": "Laptop", "price": 1500},
-  {"name": "Phone", "price": 900},
-  {"name": "Tablet", "price": 600},
-  {"name": "Mouse", "price": 40},
+  {"name": "Laptop",   "price": 1500},
+  {"name": "Phone",    "price": 900},
+  {"name": "Tablet",   "price": 600},
+  {"name": "Mouse",    "price": 40},
   {"name": "Keyboard", "price": 80}
 ]

--- a/examples/website/top-products.mochi
+++ b/examples/website/top-products.mochi
@@ -16,4 +16,4 @@ for item in top {
   print(item.name + ", $" + str(item.price))
 }
 
-save top to "top.json"
+save top to "top.json" with { format: "json" }

--- a/website/src/components/CodeShowcase/index.js
+++ b/website/src/components/CodeShowcase/index.js
@@ -50,6 +50,17 @@ export default function CodeShowcase({ title, lede, samples }) {
                 {sample.code}
               </CodeBlock>
             </div>
+            {sample.input ? (
+              <div className={styles.inputWrap}>
+                <div className={styles.outputLabel}>Input</div>
+                <CodeBlock
+                  language={sample.input.language || 'json'}
+                  title={sample.input.filename}
+                >
+                  {sample.input.code}
+                </CodeBlock>
+              </div>
+            ) : null}
             {sample.output ? (
               <div className={styles.outputWrap}>
                 <div className={styles.outputLabel}>Output</div>

--- a/website/src/components/CodeShowcase/styles.module.css
+++ b/website/src/components/CodeShowcase/styles.module.css
@@ -154,6 +154,14 @@
   margin: 0;
 }
 
+.inputWrap {
+  margin-top: 1rem;
+}
+
+.inputWrap :global(.theme-code-block) {
+  margin: 0;
+}
+
 .outputWrap {
   margin-top: 1rem;
 }

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -206,7 +206,18 @@ for item in top {
   print(item.name + ", $" + str(item.price))
 }
 
-save top to "top.json"`,
+save top to "top.json" with { format: "json" }`,
+    input: {
+      filename: 'products.json',
+      language: 'json',
+      code: `[
+  {"name": "Laptop",   "price": 1500},
+  {"name": "Phone",    "price": 900},
+  {"name": "Tablet",   "price": 600},
+  {"name": "Mouse",    "price": 40},
+  {"name": "Keyboard", "price": 80}
+]`,
+    },
     output: `Laptop, $1500
 Phone, $900
 Tablet, $600`,


### PR DESCRIPTION
The Datasets tab loads products.json but the homepage never showed what was in that file, so the Laptop/Phone/Tablet output looked like it came out of nowhere. This PR adds an Input panel to CodeShowcase that renders the source file alongside the .mochi code, and wires products.json into sample 5.

While I was in there I noticed `save top to "top.json"` was silently writing CSV because the format inference only kicks in for load, not save. Added `with { format: "json" }` to the save call so the round-trip actually produces valid JSON, matching what the snippet visually implies.

Also synced examples/website/products.json with the formatting shown on the homepage so the regression fixture and the page do not drift.

## Test plan

- [x] `mochi run top-products.mochi` against examples/website/products.json prints the three lines, and top.json now contains valid JSON
- [x] `npm run build` in website/ succeeds
- [ ] After merge, confirm the new Input panel renders on https://mochi-lang.dev for the Datasets tab