### PR TITLE
website: one-line dataset query under the Datasets sample

### DIFF
--- a/website/src/components/CodeShowcase/index.js
+++ b/website/src/components/CodeShowcase/index.js
@@ -67,6 +67,19 @@ export default function CodeShowcase({ title, lede, samples }) {
                 <CodeBlock language="text">{sample.output}</CodeBlock>
               </div>
             ) : null}
+            {sample.alt ? (
+              <div className={styles.altWrap}>
+                <div className={styles.outputLabel}>
+                  {sample.alt.heading || 'Or as one expression'}
+                </div>
+                <CodeBlock language={sample.alt.language || 'mochi'}>
+                  {sample.alt.code}
+                </CodeBlock>
+                {sample.alt.output ? (
+                  <CodeBlock language="text">{sample.alt.output}</CodeBlock>
+                ) : null}
+              </div>
+            ) : null}
           </div>
         </div>
       </div>

--- a/website/src/components/CodeShowcase/styles.module.css
+++ b/website/src/components/CodeShowcase/styles.module.css
@@ -162,6 +162,18 @@
   margin: 0;
 }
 
+.altWrap {
+  margin-top: 1rem;
+}
+
+.altWrap :global(.theme-code-block) {
+  margin: 0 0 0.4rem 0;
+}
+
+.altWrap :global(.theme-code-block):last-child {
+  margin: 0;
+}
+
 .outputWrap {
   margin-top: 1rem;
 }

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -221,6 +221,13 @@ save top to "top.json" with { format: "json" }`,
     output: `Laptop, $1500
 Phone, $900
 Tablet, $600`,
+    alt: {
+      heading: 'Or as one expression',
+      code: `print(from p in load "products.json" as {name: string, price: int} with { format: "json" }
+      where p.price >= 100 sort by -p.price take 3
+      select p.name + " $" + str(p.price))`,
+      output: `["Laptop $1500", "Phone $900", "Tablet $600"]`,
+    },
   },
   {
     label: 'Tests',


### PR DESCRIPTION
## Summary
- Datasets tab now shows a second snippet under the multi-line program: the same load/filter/sort/take/select pipeline written as one expression that prints the formatted list.
- CodeShowcase grows an optional alt panel (heading + code + output) so other samples can use the same pattern later.
- One-liner runs against v0.10.82 against the same products.json that ships in examples/website.

## Test plan
- [x] mochi run on the one-liner produces `["Laptop $1500", "Phone $900", "Tablet $600"]`
- [x] npm run build passes locally