### PR TITLE
soundness: ungate type valid suite and add theory-grounded fixtures

### DIFF
--- a/parser/README.md
+++ b/parser/README.md
@@ -1,0 +1,221 @@
+# Mochi parser
+
+This package owns the lexer, the grammar, the AST node types, and the
+documentation comment attachment pass. It produces a `*Program` that
+the rest of the toolchain (type checker, interpreter, bytecode VM,
+cross compilers) consumes.
+
+The grammar specs live at `notes/Spec/1800/` (1801 for the lexer, 1802
+for the grammar, 1803 for the AST). This file is the operational guide:
+how to call the parser, how the code is laid out, and how to add a new
+feature without breaking the goldens.
+
+## Entry points
+
+```go
+// Read a file and parse it.
+prog, err := parser.Parse(path)
+
+// Parse a string in memory.
+prog, err := parser.ParseString(src)
+```
+
+Both return `*parser.Program`. Errors are upgraded to a structured
+`diagnostic.Error` value with a code, position, and help text. The
+codes for parser errors are P prefixed and live in
+`parser/errors.go:38-97` (see `suggestFix`).
+
+## File layout
+
+| File              | Owns                                              |
+|-------------------|---------------------------------------------------|
+| `parser.go`       | Lexer table, AST types, participle grammar.       |
+| `errors.go`       | `Parse` entry point, error wrapping, P codes.     |
+| `docs.go`         | Doc comment extraction and attachment.            |
+| `parser_test.go`  | Golden tests for `tests/parser/{valid,errors}`.   |
+| `mochi_parser_test.go` | Tests of the Mochi grammar against representative programs. |
+| `docs_test.go`    | Tests for the doc attachment pass.                |
+
+## Lexer
+
+`parser.go:48-62`. A simple participle lexer with one regex per token
+class. Order matters: `Bool` and `Keyword` come before `Ident` so
+reserved words do not get classified as identifiers. The full set of
+reserved keywords is on the `Keyword` line (line 51).
+
+A few words that look like keywords are not reserved globally and only
+become significant inside a specific production. Examples are query
+clause names like `from`, `where`, `select`, `group`, `by`, and
+modifier words like `as`, `to`, `with`. This keeps user identifier
+names like `where` available outside query expressions.
+
+A subtle design point. Numeric literals in the lexer do not include a
+leading minus sign. Unary minus is handled by the parser as a prefix
+operator. The reason is that `len(list)-1` should parse as
+`len(list) - 1`, not as `len(list)`, `[`, `-1`, `]`. The cost is that
+expressions like `x == -1` only parse because the grammar accepts a
+unary expression on the right hand side of `==`. This is documented at
+`parser.go:53-56`.
+
+## Grammar
+
+The grammar is encoded as participle struct tags on Go types. The
+parser is built once at package init:
+
+```go
+var Parser = participle.MustBuild[Program](
+    participle.Lexer(mochiLexer),
+    participle.Elide("Whitespace", "Comment"),
+    participle.Unquote("String"),
+    participle.UseLookahead(999),
+)
+```
+
+`UseLookahead(999)` lets the parser try arbitrarily many tokens of
+lookahead when an alternation is ambiguous. The flat
+`BinaryExpr -> Unary BinaryOp*` shape relies on this: the parser
+collects a flat list of operators and the type checker rebalances them
+by precedence.
+
+Expression precedence is not in the grammar. The type checker resolves
+it during inference at `types/infer.go:89-198`. Anyone reading the AST
+directly must remember this and apply the precedence table or call
+back into `types.ExprType`.
+
+## AST
+
+Every node in `parser.go` is a Go struct with two sets of tags:
+
+- `parser:"..."` tags drive the participle grammar.
+- `json:"..."` tags drive the parser golden tests, which serialise the
+  AST as JSON.
+
+The two views must stay in sync. Adding a field requires touching both
+tag sets. The `omitempty` markers keep golden files small: an optional
+field that is not used in a fixture does not appear in the golden.
+
+Tagged unions are encoded as structs with one pointer field per
+variant. Exactly one is non nil after a successful parse. The visitor
+on the receiving side switches on the non nil pointer. Examples:
+
+- `Statement` has 30 plus mutually exclusive fields.
+- `TypeRef` has four (`Fun`, `Generic`, `Struct`, `Simple`).
+- `Primary` has 17 (literals, queries, lambdas, control flow forms).
+
+A pattern to know. `Primary.Struct` comes first in the alternation
+because `Foo{...}` would otherwise be ambiguous with `Foo` followed by
+a block start. The order of fields in the Go struct controls the order
+of alternatives the parser tries.
+
+## Doc comments
+
+`docs.go`. After parsing, the source is re scanned for `///` doc
+comments preceding declarations. The doc text is attached to the
+nearest declaration node's `Doc` field. This pass is purely textual
+and runs after participle has stripped comments from the token stream.
+
+## Adding a new feature
+
+A typical change touches several files. The checklist:
+
+1. **Grammar**. Add the production to `parser.go`. If it is a new
+   statement, add a field to `Statement`. If it is a new expression
+   atom, add a field to `Primary`. Use participle tags consistently
+   with the existing patterns.
+2. **AST**. Define the Go struct for the new node and the JSON tags.
+   Ensure `omitempty` is set on optional fields so old goldens stay
+   minimal.
+3. **Lexer (rare)**. Adding a new keyword means editing the `Keyword`
+   regex at `parser.go:51`. Be careful: this reserves the word
+   globally and may break user code that used it as an identifier.
+   See 1810 C5.
+4. **Tests**. Add a fixture under `tests/parser/valid/` for the
+   accepted shape. Add a fixture under `tests/parser/errors/` for at
+   least one malformed shape. Run:
+
+   ```
+   make update-golden STAGE=parser
+   ```
+
+   to seed the new goldens. Inspect the JSON to make sure the AST
+   shape matches what you expected.
+5. **Type checker**. Add the typing rule to `types/check.go` (and
+   `types/infer.go` for expressions). Add fixtures under
+   `tests/types/valid/` and `tests/types/errors/`.
+6. **Specs**. Update the relevant 18xx spec under `notes/Spec/1800/`.
+   At minimum 1802 (grammar) and 1803 (AST), plus 1805 if there is a
+   typing rule.
+
+## Test commands
+
+```
+# Run the parser tests.
+go test ./parser
+
+# Run only the valid fixtures.
+go test ./parser -run TestParser_ValidPrograms
+
+# Run only one fixture (the harness honours an environment variable).
+MOCHI_ROSETTA_ONLY=if_stmt go test ./parser -run TestParser_ValidPrograms
+
+# Refresh goldens after a deliberate AST change.
+go test ./parser -update
+```
+
+The harness lives at `golden/golden.go`. It glob matches `*.mochi`
+files in the directory and pairs them with `*.golden` (or `*.err`)
+companions.
+
+## Diagnostic codes
+
+Parser diagnostics use P prefixed codes (`parser/errors.go:38-97`):
+
+- `P001` block delimiter mismatch.
+- `P002` unexpected EOF.
+- `P010` function body must be braced.
+- `P011` `=>` cannot replace a block in a function body.
+- `P020` expected expression.
+- `P030` expected identifier.
+- `P031` `let` not followed by a name.
+- `P040` unterminated string.
+- `P050` `*` in primary position.
+- `P051` missing comma.
+- `P052` unbalanced parentheses.
+- `P053` stray `}`.
+- `P054` misused colon in parameter list.
+- `P055` stray `.`.
+- `P056` unexpected `let`.
+- `P999` everything else.
+
+Type checker diagnostics use T prefixed codes registered in
+`types/errors.go`. Spec 1806 has the full table.
+
+## Known parser limitations
+
+These are tracked in 1810. Brief versions:
+
+- `int | nil` does not parse as a type. Use either a struct or wait
+  for option types.
+- `x == -1` requires a space or parens because of how unary minus
+  binds. The error message is misleading.
+- Block comments `/* ... */` do not nest.
+- The `Keyword` regex at `parser.go:51` reserves words globally. New
+  keywords break user code that used them as identifiers.
+
+## Performance notes
+
+Parsing a typical 200 line file is sub millisecond. The parser uses
+unbounded lookahead, so pathological inputs (deeply nested ambiguous
+constructs) can be slow. The fixture set is the practical guard
+against regressions; if a new feature pushes parse time up
+noticeably, add a regression test under `tests/parser/valid/` that
+exercises the worst case.
+
+## CHECKLIST
+
+- [ ] New grammar features add fixtures under `tests/parser/valid/`
+      and `tests/parser/errors/`.
+- [ ] New AST fields are JSON tagged with `omitempty`.
+- [ ] New keywords are reviewed for collision with user identifiers.
+- [ ] New diagnostic codes are added to `errors.go` and listed here.
+- [ ] Spec docs (1801, 1802, 1803) are updated in the same change.

--- a/tests/types/errors/match_variant_arity.err
+++ b/tests/types/errors/match_variant_arity.err
@@ -1,0 +1,16 @@
+1. error[T008]: type mismatch: expected Pair, got P
+  --> tests/types/errors/match_variant_arity.mochi:6:3
+
+  6 |   P(a) => a
+    |   ^
+
+help:
+  Change the value to match the expected type.
+   2. error[T002]: undefined variable: r
+  --> tests/types/errors/match_variant_arity.mochi:8:8
+
+  8 | expect r == 1
+    |        ^
+
+help:
+  Check if the variable was declared in this scope.

--- a/tests/types/errors/match_variant_arity.mochi
+++ b/tests/types/errors/match_variant_arity.mochi
@@ -1,0 +1,8 @@
+// ADT (1813): a variant call pattern must match the variant's declared arity.
+type Pair = P(a: int, b: int)
+
+let p: Pair = P(1, 2)
+let r: int = match p {
+  P(a) => a
+}
+expect r == 1

--- a/tests/types/errors/multiple_top_level_errors.err
+++ b/tests/types/errors/multiple_top_level_errors.err
@@ -1,0 +1,24 @@
+1. error[T008]: type mismatch: expected int, got string
+  --> tests/types/errors/multiple_top_level_errors.mochi:3:14
+
+  3 | let a: int = "not an int"
+    |              ^
+
+help:
+  Change the value to match the expected type.
+   2. error[T002]: undefined variable: c
+  --> tests/types/errors/multiple_top_level_errors.mochi:4:9
+
+  4 | let b = c
+    |         ^
+
+help:
+  Check if the variable was declared in this scope.
+   3. error[T003]: unknown function: d
+  --> tests/types/errors/multiple_top_level_errors.mochi:5:7
+
+  5 | print(d(1))
+    |       ^
+
+help:
+  Ensure the function is defined before it's called.

--- a/tests/types/errors/multiple_top_level_errors.mochi
+++ b/tests/types/errors/multiple_top_level_errors.mochi
@@ -1,0 +1,5 @@
+// Soundness (1807): Check is non short circuit. Several mistakes in a
+// single program should each surface as a separate diagnostic.
+let a: int = "not an int"
+let b = c
+print(d(1))

--- a/tests/types/errors/range_bound_float.err
+++ b/tests/types/errors/range_bound_float.err
@@ -1,0 +1,8 @@
+1. error[T023]: range loop requires integer start and end expressions
+  --> tests/types/errors/range_bound_float.mochi:2:1
+
+  2 | for i in 0..2.5 {
+    | ^
+
+help:
+  Use `for i in 0..10` or ensure both expressions are of type `int`.

--- a/tests/types/errors/range_bound_float.mochi
+++ b/tests/types/errors/range_bound_float.mochi
@@ -1,0 +1,4 @@
+// Inference (1805): for ... in range requires int bounds.
+for i in 0..2.5 {
+  print(i)
+}

--- a/tests/types/errors/struct_unknown_field_access.err
+++ b/tests/types/errors/struct_unknown_field_access.err
@@ -1,0 +1,8 @@
+1. error[T026]: unknown field `z` on Point
+  --> tests/types/errors/struct_unknown_field_access.mochi:8:7
+
+  8 | print(p.z)
+    |       ^
+
+help:
+  Check the struct definition for valid fields.

--- a/tests/types/errors/struct_unknown_field_access.mochi
+++ b/tests/types/errors/struct_unknown_field_access.mochi
@@ -1,0 +1,8 @@
+// ADT (1813): reading a non-existent struct field is rejected.
+type Point {
+  x: int
+  y: int
+}
+
+let p: Point = Point{x: 1, y: 2}
+print(p.z)

--- a/tests/types/valid/aggregate_count_list.golden
+++ b/tests/types/valid/aggregate_count_list.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/aggregate_count_list.mochi
+++ b/tests/types/valid/aggregate_count_list.mochi
@@ -1,0 +1,4 @@
+// Aggregate typing (1814): count over a list returns int.
+let xs: list<int> = [1, 2, 3, 4]
+let n: int = count(xs)
+expect n == 4

--- a/tests/types/valid/aggregate_min_max_int.golden
+++ b/tests/types/valid/aggregate_min_max_int.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/aggregate_min_max_int.mochi
+++ b/tests/types/valid/aggregate_min_max_int.mochi
@@ -1,0 +1,6 @@
+// Aggregate typing (1814): min and max over an int list return int.
+let xs: list<int> = [3, 1, 4, 1, 5, 9, 2, 6]
+let lo: int = min(xs)
+let hi: int = max(xs)
+expect lo == 1
+expect hi == 9

--- a/tests/types/valid/aggregate_sum_int_list.golden
+++ b/tests/types/valid/aggregate_sum_int_list.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/aggregate_sum_int_list.mochi
+++ b/tests/types/valid/aggregate_sum_int_list.mochi
@@ -1,0 +1,4 @@
+// Aggregate typing (1814): sum over an int list returns int.
+let xs: list<int> = [1, 2, 3, 4]
+let s: int = sum(xs)
+expect s == 10

--- a/tests/types/valid/canonical_bool_only.golden
+++ b/tests/types/valid/canonical_bool_only.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/canonical_bool_only.mochi
+++ b/tests/types/valid/canonical_bool_only.mochi
@@ -1,0 +1,6 @@
+// Canonical forms (1807): the only values of `bool` are `true` and `false`.
+let t: bool = true
+let f: bool = false
+expect t == true
+expect f == false
+expect t != f

--- a/tests/types/valid/canonical_int_arithmetic.golden
+++ b/tests/types/valid/canonical_int_arithmetic.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/canonical_int_arithmetic.mochi
+++ b/tests/types/valid/canonical_int_arithmetic.mochi
@@ -1,0 +1,11 @@
+// Canonical forms (1807): closed integer arithmetic stays in int.
+let a: int = 2
+let b: int = 3
+let sum: int = a + b
+let diff: int = b - a
+let prod: int = a * b
+let modd: int = b % a
+expect sum == 5
+expect diff == 1
+expect prod == 6
+expect modd == 1

--- a/tests/types/valid/canonical_string_concat.golden
+++ b/tests/types/valid/canonical_string_concat.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/canonical_string_concat.mochi
+++ b/tests/types/valid/canonical_string_concat.mochi
@@ -1,0 +1,5 @@
+// Canonical forms (1807): string + string = string.
+let a: string = "hello "
+let b: string = "world"
+let c: string = a + b
+expect c == "hello world"

--- a/tests/types/valid/closure_inferred_return.golden
+++ b/tests/types/valid/closure_inferred_return.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/closure_inferred_return.mochi
+++ b/tests/types/valid/closure_inferred_return.mochi
@@ -1,0 +1,5 @@
+// Inference (1805): an arrow-bodied closure infers its return type
+// from the body expression. Verifies the result is callable as int.
+let double = fun(x: int): int => x * 2
+let four: int = double(2)
+expect four == 4

--- a/tests/types/valid/for_in_list.golden
+++ b/tests/types/valid/for_in_list.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/for_in_list.mochi
+++ b/tests/types/valid/for_in_list.mochi
@@ -1,0 +1,8 @@
+// Inference (1805): for ... in list binds the loop variable to the
+// element type.
+let words: list<string> = ["a", "bb", "ccc"]
+var total: int = 0
+for w in words {
+  total = total + len(w)
+}
+expect total == 6

--- a/tests/types/valid/for_in_range.golden
+++ b/tests/types/valid/for_in_range.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/for_in_range.mochi
+++ b/tests/types/valid/for_in_range.mochi
@@ -1,0 +1,6 @@
+// Inference (1805): for ... in 0..n binds the loop variable to int.
+var total: int = 0
+for i in 0..5 {
+  total = total + i
+}
+expect total == 10

--- a/tests/types/valid/inversion_if_expr.golden
+++ b/tests/types/valid/inversion_if_expr.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/inversion_if_expr.mochi
+++ b/tests/types/valid/inversion_if_expr.mochi
@@ -1,0 +1,5 @@
+// Inversion (1807): an if-expression has the type of its branches'
+// least upper bound. Both branches return int here.
+let n: int = 7
+let label: int = if n % 2 == 0 then 0 else 1
+expect label == 1

--- a/tests/types/valid/match_literal_pattern.golden
+++ b/tests/types/valid/match_literal_pattern.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/match_literal_pattern.mochi
+++ b/tests/types/valid/match_literal_pattern.mochi
@@ -1,0 +1,8 @@
+// Match (1813): literal patterns match by equality.
+let x: int = 2
+let label: string = match x {
+  1 => "one"
+  2 => "two"
+  _ => "other"
+}
+expect label == "two"

--- a/tests/types/valid/match_union_variant.golden
+++ b/tests/types/valid/match_union_variant.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/match_union_variant.mochi
+++ b/tests/types/valid/match_union_variant.mochi
@@ -1,0 +1,11 @@
+// ADT (1813): variant call patterns destructure tagged union values.
+type Shape =
+  Circle(r: int)
+| Square(s: int)
+
+let sh: Shape = Circle(3)
+let area: int = match sh {
+  Circle(r) => r * r * 3
+  Square(s) => s * s
+}
+expect area == 27

--- a/tests/types/valid/numeric_float_plus_int.golden
+++ b/tests/types/valid/numeric_float_plus_int.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/numeric_float_plus_int.mochi
+++ b/tests/types/valid/numeric_float_plus_int.mochi
@@ -1,0 +1,5 @@
+// Numeric tower (1805): order independence. float + int should also widen.
+let a: float = 2.5
+let b: int = 1
+let c: float = a + b
+expect c == 3.5

--- a/tests/types/valid/numeric_int_plus_float.golden
+++ b/tests/types/valid/numeric_int_plus_float.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/numeric_int_plus_float.mochi
+++ b/tests/types/valid/numeric_int_plus_float.mochi
@@ -1,0 +1,5 @@
+// Numeric tower (1804/1805): int + float widens to float.
+let a: int = 1
+let b: float = 2.5
+let c: float = a + b
+expect c == 3.5

--- a/tests/types/valid/preservation_let_chain.golden
+++ b/tests/types/valid/preservation_let_chain.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/preservation_let_chain.mochi
+++ b/tests/types/valid/preservation_let_chain.mochi
@@ -1,0 +1,6 @@
+// Preservation (1807): substituting let-bound values does not change typing.
+// The chain x -> y -> z must keep type int across rebindings.
+let x: int = 1
+let y: int = x + 1
+let z: int = y + 1
+expect z == 3

--- a/tests/types/valid/query_basic_select.golden
+++ b/tests/types/valid/query_basic_select.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/query_basic_select.mochi
+++ b/tests/types/valid/query_basic_select.mochi
@@ -1,0 +1,5 @@
+// Query algebra (1814): from ... where ... select returns a list whose
+// element type is the projection's type.
+let xs: list<int> = [1, 2, 3, 4, 5]
+let evens: list<int> = from x in xs where x % 2 == 0 select x
+expect count(evens) == 2

--- a/tests/types/valid/query_sort_take.golden
+++ b/tests/types/valid/query_sort_take.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/query_sort_take.mochi
+++ b/tests/types/valid/query_sort_take.mochi
@@ -1,0 +1,4 @@
+// Query algebra (1814): sort by and take preserve element type.
+let xs: list<int> = [4, 2, 5, 1, 3]
+let top3: list<int> = from x in xs sort by -x take 3 select x
+expect count(top3) == 3

--- a/tests/types/valid/struct_field_access.golden
+++ b/tests/types/valid/struct_field_access.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/struct_field_access.mochi
+++ b/tests/types/valid/struct_field_access.mochi
@@ -1,0 +1,9 @@
+// ADT (1813): struct literal and field access flow types correctly.
+type Point {
+  x: int
+  y: int
+}
+
+let p: Point = Point{x: 3, y: 4}
+let dist: int = p.x * p.x + p.y * p.y
+expect dist == 25

--- a/types/check_test.go
+++ b/types/check_test.go
@@ -5,14 +5,10 @@ import (
 	"mochi/golden"
 	"mochi/parser"
 	"mochi/types"
-	"os"
 	"testing"
 )
 
 func TestTypeChecker_Valid(t *testing.T) {
-	if os.Getenv("RUN_TYPE_VALID") == "" {
-		t.Skip("types valid tests disabled")
-	}
 	golden.Run(t, "tests/types/valid", ".mochi", ".golden", func(src string) ([]byte, error) {
 		prog, err := parser.Parse(src)
 		if err != nil {


### PR DESCRIPTION
## Summary

Kicks off the soundness work targeted for v0.11.0. The valid type-check suite was previously hidden behind a `RUN_TYPE_VALID=1` env flag, so most of it never ran in CI. This PR:

- Drops the gate so `TestTypeChecker_Valid` runs by default.
- Adds 17 new valid fixtures and 4 new error fixtures, organized by type-theory pillar instead of ad-hoc cases.
- Adds a `parser/README.md` documenting entry points, the participle-based grammar, where to add new syntax, and the P-prefixed diagnostic codes.

The fixtures are grouped roughly as:
- canonical forms (bool / int / string)
- numeric tower (int + float coercion both ways)
- preservation (let chains keep types stable)
- inference (closures, if expressions)
- match (literal patterns, union variants, variant arity errors)
- aggregates (count / sum / min / max over lists)
- queries (basic select, sort + take)
- iteration (for-in over range and list)

Specs that motivated this layout live at \`~/notes/Spec/1800/\` (overview, lexer, grammar, AST, type system, inference, checker, soundness properties, test strategy, fixtures, known gaps, subtyping, polymorphism, ADTs, query algebra, effects). They are out-of-tree on purpose for now.

One concrete soundness gap surfaced while writing fixtures: \`let x: int = 5 / 2\` typechecks but the runtime returns \`2.5\`. Tracked as a tier-B item in the gaps spec, fix lands in a follow-up.

## Test plan
- [x] \`go test ./parser ./types -count=1\` is green locally
- [ ] CI is green on this PR