### PR TITLE
mep: introduce Mochi Enhancement Proposals

### DIFF
--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -36,6 +36,10 @@ The [Mochi Manual](/docs/manual/) documents the language in depth.
 - [Operators](/docs/reference/operators). All operators and precedence.
 - [Built-ins](/docs/reference/builtins). Standard built-in functions.
 
+## Design proposals
+
+- [Mochi Enhancement Proposals (MEPs)](/docs/mep/mep-0000). Design documents for the language, the type system, and the toolchain.
+
 ## More
 
 - [Roadmap](/docs/roadmap). Planned work for Mochi.

--- a/website/docs/mep/mep-0000.md
+++ b/website/docs/mep/mep-0000.md
@@ -1,0 +1,129 @@
+---
+mep: 0
+title: Index of Mochi Enhancement Proposals
+author: Mochi core
+status: Active
+type: Process
+created: 2026-05-08
+sidebar_position: 0
+sidebar_label: MEP 0 — Index
+description: Index of Mochi Enhancement Proposals.
+---
+
+# MEP 0 — Index of Mochi Enhancement Proposals
+
+| Field    | Value                                  |
+|----------|----------------------------------------|
+| MEP      | 0                                      |
+| Title    | Index of Mochi Enhancement Proposals   |
+| Author   | Mochi core                             |
+| Status   | Active                                 |
+| Type     | Process                                |
+| Created  | 2026-05-08                             |
+
+## What is a MEP
+
+A Mochi Enhancement Proposal is a design document that records a decision about the language. It is modeled on the Python PEP process. Every change to the language surface, the type system, the runtime, or the tooling that would benefit from a written record lives as a MEP.
+
+A MEP is the place where we explain what the language does, why it does it that way, and what we would change. The implementation is in the repository. The MEP is the contract.
+
+## Status values
+
+| Status        | Meaning                                                                                        |
+|---------------|------------------------------------------------------------------------------------------------|
+| Draft         | Under discussion. Content may change.                                                          |
+| Active        | A process MEP that is in effect.                                                               |
+| Accepted      | Approved. Implementation is in progress or pending.                                            |
+| Provisional   | Approved with a trial period. Behavior may be revisited based on real-world use.               |
+| Final         | Implemented and stable. Changes require a new MEP.                                             |
+| Informational | Documents the language as it stands. No proposal embedded.                                     |
+| Withdrawn     | The author retracted the proposal.                                                             |
+| Rejected      | The proposal was not adopted. The MEP stays so the discussion is searchable.                   |
+| Superseded    | An older MEP that has been replaced. The replacement is linked.                                |
+
+## Type values
+
+| Type            | Meaning                                                                                  |
+|-----------------|------------------------------------------------------------------------------------------|
+| Standards Track | Adds, changes, or removes a language feature, type rule, or runtime behavior.            |
+| Informational   | Describes the language without proposing change.                                         |
+| Process         | Describes a process: how we test, how we release, how we write MEPs.                     |
+
+## Index
+
+The current series covers the soundness initiative for v0.11.0. Numbering follows the PEP convention: four-digit padded MEP numbers, status and type recorded in each file's header.
+
+| MEP                     | Title                                  | Status        | Type            |
+|-------------------------|----------------------------------------|---------------|-----------------|
+| [0](/docs/mep/mep-0000) | Index of Mochi Enhancement Proposals   | Active        | Process         |
+| [1](/docs/mep/mep-0001) | Lexer                                  | Informational | Informational   |
+| [2](/docs/mep/mep-0002) | Grammar                                | Informational | Informational   |
+| [3](/docs/mep/mep-0003) | Abstract Syntax Tree                   | Informational | Informational   |
+| [4](/docs/mep/mep-0004) | Type System                            | Informational | Informational   |
+| [5](/docs/mep/mep-0005) | Type Inference                         | Informational | Informational   |
+| [6](/docs/mep/mep-0006) | Type Checker                           | Informational | Informational   |
+| [7](/docs/mep/mep-0007) | Soundness                              | Active        | Process         |
+| [8](/docs/mep/mep-0008) | Test Strategy                          | Active        | Process         |
+| [9](/docs/mep/mep-0009) | Fixture Catalogue                      | Informational | Informational   |
+| [10](/docs/mep/mep-0010)| Known Gaps and Weakness Review         | Informational | Informational   |
+| [11](/docs/mep/mep-0011)| Subtyping and Variance                 | Draft         | Standards Track |
+| [12](/docs/mep/mep-0012)| Parametric Polymorphism                | Draft         | Standards Track |
+| [13](/docs/mep/mep-0013)| Algebraic Data Types and Match         | Draft         | Standards Track |
+| [14](/docs/mep/mep-0014)| Query Algebra                          | Informational | Informational   |
+| [15](/docs/mep/mep-0015)| Effects, Mutability, and Purity        | Draft         | Standards Track |
+
+## Workflow
+
+A MEP starts as a draft on a branch. The author opens a pull request titled `mep: <short title>`. The PR includes the MEP file under `website/docs/mep/` and any related code changes. Once the team reaches a decision the status field is updated and the PR is merged.
+
+Steps:
+
+1. Pick the next available MEP number. Update the index above and the new file's header.
+2. Write the MEP. The default sections are listed in the next section.
+3. Open a PR with the draft. Solicit review.
+4. Update the status to `Accepted`, `Rejected`, or `Withdrawn` based on the outcome.
+5. After implementation lands, update the status to `Final` and link any follow-up MEPs.
+
+## Required sections
+
+Every MEP after the index uses these sections, in this order. Sections that do not apply may be left out, but the headings should not be renamed.
+
+1. **Header table** with the metadata fields.
+2. **Abstract.** A short paragraph that summarises the proposal.
+3. **Motivation.** Why we need this. Reference concrete code paths or fixtures.
+4. **Specification.** What the language does or will do. The technical core.
+5. **Rationale.** Why this design over the alternatives.
+6. **Backwards Compatibility.** What existing programs break and how we handle migration.
+7. **Reference Implementation.** Links to source files and lines.
+8. **Open Questions.** Things we have not decided yet.
+9. **References.** External material we built on.
+10. **Copyright.** Public domain dedication.
+
+## Why we do this
+
+Mochi is small and fast moving. The parser, type checker, interpreter, and bytecode VM all evolve in lockstep. Without a written record, a syntactic change in `parser/parser.go` can outrun the matching type rule in `types/check.go`, or a runtime detail can drift away from what the checker promised. The MEP series is the contract that catches drift before it ships.
+
+The 1800-series internal notes that lived under `~/notes/Spec/1800/` were the seed for this index. They are now MEPs and will be maintained here.
+
+## Status snapshot at v0.10.82
+
+- Parser fixtures: 52 valid pairs and 10 error pairs.
+- Type fixtures: more than 30 valid pairs and more than 45 error pairs.
+- The `RUN_TYPE_VALID=1` gate on the valid type-check suite was removed in the v0.11.0 soundness PR.
+- 86 distinct error codes registered in `types/errors.go` covering roughly T000 through T046 with gaps.
+- Known parser quirks: `int | nil` is not parseable as a type, and unary minus on the right hand side of `==` requires parens.
+
+## Working agreement
+
+When a language change touches a typing rule, the author updates:
+
+1. The relevant MEP in this directory.
+2. At least one valid fixture under `tests/types/valid/` proving the accepted shape.
+3. At least one error fixture under `tests/types/errors/` proving the rejected shape.
+4. A short note in MEP 10 if the change closes or opens a soundness hole.
+
+The next contributor should be able to read these MEPs, plus `parser/README.md`, plus the fixtures, and onboard onto the soundness work without reading every line of the type checker.
+
+## Copyright
+
+This document is placed in the public domain.

--- a/website/docs/mep/mep-0001.md
+++ b/website/docs/mep/mep-0001.md
@@ -1,0 +1,117 @@
+---
+mep: 1
+title: Lexer
+author: Mochi core
+status: Informational
+type: Informational
+created: 2026-05-08
+sidebar_position: 1
+sidebar_label: MEP 1 — Lexer
+description: The token classes, reserved words, and lexical rules of Mochi.
+---
+
+# MEP 1 — Lexer
+
+| Field    | Value                       |
+|----------|-----------------------------|
+| MEP      | 1                           |
+| Title    | Lexer                       |
+| Author   | Mochi core                  |
+| Status   | Informational               |
+| Type     | Informational               |
+| Created  | 2026-05-08                  |
+
+## Abstract
+
+Mochi uses a single `participle/v2/lexer.MustSimple` table with nine token rules. This MEP documents each rule, the reserved word set, and the design choices that make the rest of the parser possible. It is informational because the lexer is small enough that we can describe it completely.
+
+## Motivation
+
+Many parser bugs reduce to a token rule that ate too much or too little. A new keyword silently steals an identifier. A new punctuation character collides with an existing prefix. The block comment regex does not nest. Knowing the token rules in source order, and knowing why each rule is where it is, prevents the next change from breaking the existing fixtures.
+
+## Specification
+
+### Token classes
+
+The rules in source order at `parser/parser.go:48-62`:
+
+1. **Comment.** Line comments with `//` or `#`, plus block comments `/* ... */`. The block form does not nest.
+2. **Bool.** Word boundary delimited `true` or `false`.
+3. **Keyword.** The reserved word set, listed below.
+4. **Ident.** Unicode letters, the `So` (other symbol) class, underscore, followed by letters, So, digits or underscore. The unicode coverage is intentional so identifiers can use mathematical or emoji characters.
+5. **Float.** Decimal literal with a fractional part or an exponent. No leading minus.
+6. **Int.** Hex (`0x`), binary (`0b`), octal (`0o`), or decimal. No leading minus.
+7. **String.** Double quoted with backslash escapes.
+8. **Punct.** Multi character punctuation (`==`, `!=`, `<=`, `>=`, `&&`, `||`, `=>`, `:-`, `..`) or a single character from `-+*/%=<>!|{}[](),.:`.
+9. **Whitespace.** Space, tab, newline, carriage return, semicolon. The lexer treats `;` as whitespace, which is why statements do not require terminators.
+
+Rule order matters. `Bool` must come before `Keyword`, and `Keyword` must come before `Ident`, otherwise reserved words would be lexed as identifiers.
+
+### Reserved words
+
+`parser/parser.go:51` lists the keyword regex. The full set:
+
+```
+test expect agent intent on stream emit type fun extern import return
+break continue let var if else then for while in generate match fetch
+load save package export fact rule all null
+```
+
+A few words that look like keywords are not in the global list and are matched as identifiers when used in expression contexts. They become significant only inside a specific production. Examples:
+
+- Query expression keywords: `from`, `where`, `select`, `group`, `by`, `into`, `having`, `sort`, `order`, `skip`, `take`, `distinct`, `join`, `left`, `right`, `outer`.
+- Modifier words: `as`, `to`, `with`. Used after `load`, `save`, `cast`, or in import clauses.
+- Set operators: `union`, `except`, `intersect`. Used in binary expressions.
+
+### Numeric literal design
+
+Numeric literals do not include a leading minus sign. The lexer tokenises `-1` as the punctuation `-` followed by the integer `1`. The parser then handles unary minus as a prefix operator on the postfix expression.
+
+The reason is that `len(list)-1` should parse as `(len(list) - 1)` even when written as `list[len(list)-1]`. If the lexer were greedy about negative numbers, that would tokenise as `list`, `[`, `len`, `(`, `list`, `)`, `-1`, `]`, which the parser would then read as indexing by `-1` after a missing operator, not as subtraction.
+
+### String literals
+
+Strings are double quoted. The participle option `participle.Unquote("String")` at `parser/parser.go:664` turns the quoted source into the unescaped string value before the parser sees it. There is no raw string form, no triple quoted string, no string interpolation. Concatenation is done with `+`.
+
+### Comment forms
+
+Block and line comments are stripped by `participle.Elide("Whitespace", "Comment")` at `parser/parser.go:663`. There is also an out-of-band doc attachment pass (`parser/docs.go`) that re-reads the source and attaches preceding line comments to the nearest declaration as the `Doc` field. This means doc strings survive even though the parser drops the underlying token.
+
+## Rationale
+
+A single simple lexer table is enough for a small language. Participle's `MustSimple` is fast, easy to audit, and produces good error messages out of the box.
+
+The decision to keep query and modifier words as soft keywords rather than reserving them globally trades parser complexity for user freedom. Reserving `where` or `union` globally would forbid identifiers like `where` or `union` in user code. The cost is that the parser must work harder to distinguish identifier uses from keyword uses, and a careless grammar change can introduce ambiguity.
+
+Treating semicolons as whitespace lets users write either one statement per line or several statements on one line, without imposing a syntactic terminator.
+
+## Backwards Compatibility
+
+This MEP describes the lexer as it is. No proposal is embedded.
+
+When a future MEP adds a keyword:
+
+- Test the new word against the existing fixture set under `tests/parser/valid/`.
+- Search third party code the team can scan, to estimate breakage.
+- Decide between a hard keyword (always reserved) and a soft keyword (reserved only inside a specific production). Soft is cheaper; it scales worse.
+
+## Reference Implementation
+
+- `parser/parser.go:48-62` — lexer rules.
+- `parser/parser.go:51` — keyword regex.
+- `parser/parser.go:53-56` — comment on numeric literal design.
+- `parser/parser.go:663-664` — elision and string unquote configuration.
+- `parser/docs.go` — out-of-band doc attachment pass.
+
+## Open Questions
+
+- **Block comments do not nest.** A literal `*/` inside a block comment terminates it early. We could switch to a hand-written tokenizer that supports nesting. Low priority.
+- **Negative numeric literals.** A future change could make the lexer recognise `-1` as a number when it is not preceded by an identifier or close bracket, removing the `x == -1` parens gotcha. The trade-off is grammar complexity for the benefit of one syntactic surprise removed.
+
+## References
+
+- Participle v2 lexer documentation: https://github.com/alecthomas/participle.
+
+## Copyright
+
+This document is placed in the public domain.

--- a/website/docs/mep/mep-0002.md
+++ b/website/docs/mep/mep-0002.md
@@ -1,0 +1,243 @@
+---
+mep: 2
+title: Grammar
+author: Mochi core
+status: Informational
+type: Informational
+created: 2026-05-08
+sidebar_position: 2
+sidebar_label: MEP 2 — Grammar
+description: Mochi's statement and expression productions, encoded on participle struct tags.
+---
+
+# MEP 2 — Grammar
+
+| Field    | Value                       |
+|----------|-----------------------------|
+| MEP      | 2                           |
+| Title    | Grammar                     |
+| Author   | Mochi core                  |
+| Status   | Informational               |
+| Type     | Informational               |
+| Created  | 2026-05-08                  |
+
+## Abstract
+
+Mochi's grammar is encoded directly on Go struct tags processed by `participle/v2`. There is no separate grammar file. This MEP captures the productions in BNF-like form, identifies the ambiguities that the parser resolves with lookahead, and lists the places where the grammar requires special attention from contributors.
+
+## Motivation
+
+A grammar that lives on struct tags is convenient to evolve but easy to misread. The same struct field can be both an AST shape and a parse rule. New contributors need a single place that lists every production so they can reason about parse behaviour without scanning the whole `parser.go` file.
+
+## Specification
+
+### Build configuration
+
+The parser is built at `parser/parser.go:661-666`:
+
+```
+var Parser = participle.MustBuild[Program](
+    participle.Lexer(mochiLexer),
+    participle.Elide("Whitespace", "Comment"),
+    participle.Unquote("String"),
+    participle.UseLookahead(999),
+)
+```
+
+`UseLookahead(999)` means the generator will try arbitrarily many tokens of lookahead when an alternation is ambiguous. That is what lets the parser disambiguate, for example, an `Ident` followed by `{` between a `StructLiteral` and an `IfExpr` that opens its body with a brace. The cost is silent backtracking and slower error reporting.
+
+The participle tag language uses:
+
+- `'lit'` for keyword or punctuation literals.
+- `@@` to recurse into a sub structure.
+- `@Token` to capture into the field.
+- `[ ... ]` for optional groups.
+- `{ ... }` for repetition.
+- `|` for alternation.
+
+### Top level
+
+```
+Program        = [ 'package' Ident ] Statement*
+
+Statement      = TestBlock | BenchBlock | ExpectStmt
+               | AgentDecl | StreamDecl | ModelDecl
+               | ImportStmt | TypeDecl
+               | ExternTypeDecl | ExternVarDecl | ExternFunDecl | ExternObjectDecl
+               | FactStmt | RuleStmt | OnHandler | EmitStmt
+               | LetStmt | VarStmt | AssignStmt | FunStmt
+               | ReturnStmt | IfStmt | WhileStmt | ForStmt
+               | BreakStmt | ContinueStmt
+               | FetchStmt | UpdateStmt | ExprStmt
+```
+
+The discriminated union is expressed by `parser/parser.go:73-104`. The parser tries each alternative in order. Any alternative that does not start with a unique keyword (`AssignStmt`, `ExprStmt`) sits at the bottom of the list because it would otherwise consume tokens meant for a more specific form.
+
+### Declarations
+
+```
+LetStmt   = 'let' Ident [ ':' TypeRef ] [ '=' Expr ]
+VarStmt   = 'var' Ident [ ':' TypeRef ] [ '=' Expr ]
+AssignStmt= Ident IndexOp* FieldOp* '=' Expr
+FunStmt   = [ 'export' ] 'fun' Ident [ '<' Ident { ',' Ident } '>' ]
+            '(' [ Param { ',' Param } ] ')' [ ':' TypeRef ]
+            '{' Statement* '}'
+TypeDecl  = 'type' Ident
+            ( '{' TypeMember { [','] TypeMember } [','] '}'
+            | '=' TypeVariant { '|' TypeVariant }
+            | '=' TypeRef )
+```
+
+`TypeDecl` is the most overloaded production. Three forms:
+
+1. Struct: `type Point { x: int, y: int }`.
+2. Tagged union: `type Shape = Circle(r: float) | Square(side: float)`.
+3. Alias: `type Id = int`.
+
+The parser distinguishes the three by lookahead on the token after the type name.
+
+### Type references
+
+```
+TypeRef         = FunType | GenericType | InlineStructType | Ident
+FunType         = 'fun' '(' [ TypeRef { ',' TypeRef } ] ')' [ ':' TypeRef ]
+GenericType     = Ident '<' TypeRef { ',' TypeRef } '>'
+InlineStructType= '{' [ TypeField { ',' TypeField } ] [','] '}'
+TypeField       = Ident ':' TypeRef
+```
+
+There is no union type literal in `TypeRef`, only in `TypeDecl`. That is why `let x: int | nil = ...` will not parse. The fix is either to lift union into `TypeRef` or to introduce an option syntax such as `int?`. This is tracked in MEP 10.
+
+There is no tuple type literal. Heterogeneous data must use a struct.
+
+### Expressions
+
+The expression grammar is a precedence climbing pyramid:
+
+```
+Expr        = BinaryExpr
+BinaryExpr  = Unary BinaryOp*
+BinaryOp    = ( '==' | '!=' | '<' | '<=' | '>' | '>=' | '+' | '-'
+              | '*' | '/' | '%' | 'in' | '&&' | '||'
+              | 'union' | 'except' | 'intersect' ) [ 'all' ] PostfixExpr
+Unary       = ( '-' | '!' )* PostfixExpr
+PostfixExpr = Primary PostfixOp*
+PostfixOp   = CallOp | IndexOp | FieldOp | CastOp
+Primary     = StructLiteral | CallExpr | QueryExpr | LogicQueryExpr
+            | IfExpr | SelectorExpr | ListLiteral | MapLiteral
+            | FunExpr | MatchExpr | GenerateExpr | FetchExpr
+            | LoadExpr | SaveExpr | Literal | '(' Expr ')'
+```
+
+The flat `BinaryOp*` list is rebalanced into a precedence tree by the type checker, not by the parser. See `types/infer.go:89-198` for the precedence levels. The parser does not enforce associativity. That is a deliberate simplification that pushes the work to a single place.
+
+`Unary.Ops` is a slice, so multiple prefixes stack. `--x` is parsed as two unary minuses, not as a decrement operator. `!!x` is two boolean nots.
+
+`PostfixOp` is also a slice, so chains like `f()(2).field as int` work.
+
+### Queries
+
+```
+QueryExpr   = 'from' Ident 'in' Expr
+              { FromClause }
+              { JoinClause }
+              [ 'where' Expr ]
+              [ GroupByClause ]
+              [ ( 'sort' | 'order' ) 'by' Expr ]
+              [ 'skip' Expr ]
+              [ 'take' Expr ]
+              'select' [ 'distinct' ] Expr
+JoinClause  = [ 'left' | 'right' | 'outer' ] 'join' [ 'from' ] Ident 'in'
+              Expr 'on' Expr
+GroupByClause = 'group' 'by' Expr { ',' Expr } 'into' Ident [ 'having' Expr ]
+```
+
+The fixed clause order matters. The grammar will not accept `select ... from ... where ...` because `from` must come first. This is LINQ shaped, not SQL shaped.
+
+### Pattern matching
+
+```
+MatchExpr = 'match' Expr '{' MatchCase* '}'
+MatchCase = Expr '=>' ( Expr | '{' Statement* '}' )
+```
+
+There is no separate pattern grammar. The pattern is just an expression. The checker is responsible for deciding whether a given expression shape is allowed as a pattern. See MEP 13 for the full rules.
+
+### Lambda expressions
+
+```
+FunExpr = 'fun' [ '<' Ident { ',' Ident } '>' ]
+          '(' [ Param { ',' Param } ] ')'
+          [ ':' TypeRef ]
+          ( '{' Statement* '}' | '=>' Expr )
+```
+
+Both block and arrow bodies are accepted. The arrow form yields the expression as the function result.
+
+### Logic programming
+
+```
+FactStmt        = 'fact' LogicPredicate
+RuleStmt        = 'rule' LogicPredicate ':-' LogicCond { ',' LogicCond }
+LogicPredicate  = Ident '(' [ LogicTerm { ',' LogicTerm } ] ')'
+LogicTerm       = Ident | String | Int
+LogicQueryExpr  = 'query' LogicPredicate
+```
+
+These productions parse but the runtime VM does not execute them. The interpreter handles them. See MEP 10.
+
+### Streams and agents
+
+```
+StreamDecl = 'stream' Ident '{' StreamField* '}'
+EmitStmt   = 'emit' Ident '{' [ StructLitField { ',' StructLitField } ] [','] '}'
+OnHandler  = 'on' Ident 'as' Ident '{' Statement* '}'
+AgentDecl  = 'agent' Ident '{' AgentBlock* '}'
+AgentBlock = LetStmt | VarStmt | AssignStmt | OnHandler | IntentDecl
+IntentDecl = 'intent' Ident '(' [ Param { ',' Param } ] ')'
+             [ ':' TypeRef ] '{' Statement* '}'
+```
+
+Same caveat as logic. Parsed and partially typed, not VM compiled.
+
+### I/O statements
+
+```
+FetchStmt = 'fetch' Expr 'into' Ident [ 'with' Expr ]
+LoadExpr  = 'load' [ String ] 'as' TypeRef [ 'with' Expr ]
+SaveExpr  = 'save' Expr [ 'to' String ] [ 'with' Expr ]
+```
+
+`load` and `save` need both `as Type` and an explicit format in the `with` map for any non-default behaviour.
+
+## Rationale
+
+Pushing precedence handling into the type checker means the parser is a single pass that produces a flat AST. That decision keeps the parser file readable. It does cost in error quality, because a malformed precedence chain is often diagnosed late.
+
+Lookahead 999 was chosen as effectively unbounded so we never have to think about backtracking when we add a new construct. The cost is harder-to-trace error messages when an alternative deep in the search tree fails.
+
+## Backwards Compatibility
+
+Informational. No backward compatibility implications.
+
+## Reference Implementation
+
+- `parser/parser.go:73-104` — top level statement union.
+- `parser/parser.go:184-189` — `TypeRef`.
+- `parser/parser.go:368, 373` — `BinaryOp` shape.
+- `parser/parser.go:661-666` — parser construction.
+- `types/infer.go:89-198` — operator precedence applied during inference.
+
+## Open Questions
+
+- **Union types in `TypeRef`.** Adding union types as first-class type expressions would let `let x: int | nil = ...` parse. We need to decide between full union types and an `int?` shorthand.
+- **Tuple types.** Heterogeneous fixed-length sequences have no surface today. We are not in a hurry, but if we ever add pattern destructuring of arbitrary product values we will need them.
+- **Ambiguity log.** We resolve `Ident '{'` conflicts with lookahead. As the language grows, the cost of `UseLookahead(999)` will become noticeable. We should track the worst-case input.
+
+## References
+
+- LINQ specification: https://learn.microsoft.com/dotnet/csharp/linq/.
+
+## Copyright
+
+This document is placed in the public domain.

--- a/website/docs/mep/mep-0003.md
+++ b/website/docs/mep/mep-0003.md
@@ -1,0 +1,239 @@
+---
+mep: 3
+title: Abstract Syntax Tree
+author: Mochi core
+status: Informational
+type: Informational
+created: 2026-05-08
+sidebar_position: 3
+sidebar_label: MEP 3 — AST
+description: Mochi's AST node catalogue, encoded as Go structs with both JSON tags and participle parser tags.
+---
+
+# MEP 3 — Abstract Syntax Tree
+
+| Field    | Value                       |
+|----------|-----------------------------|
+| MEP      | 3                           |
+| Title    | Abstract Syntax Tree        |
+| Author   | Mochi core                  |
+| Status   | Informational               |
+| Type     | Informational               |
+| Created  | 2026-05-08                  |
+
+## Abstract
+
+Mochi's AST is the same set of Go structs that the parser uses. Each node carries both JSON tags (used by the parser golden tests) and participle parser tags (used to build the parser). This MEP documents the node catalogue, the invariants that hold across the AST, and the rules contributors must respect when adding a new node.
+
+## Motivation
+
+The parser package owns the AST. There is no separate `ast` package. That choice keeps the source small but means a careless rename can break both the parser and the goldens at the same time. A written record of the node catalogue is the cheapest way to make changes safe.
+
+## Specification
+
+### Source of truth
+
+`parser/parser.go`. Every AST node is a Go struct with both JSON tags and participle parser tags. The two views must stay in sync because the JSON shape is what the golden files capture.
+
+### Root and statements
+
+```
+Program {
+  Pos        lexer.Position
+  Package    string
+  PackageDoc string
+  Statements []*Statement
+}
+
+Statement {
+  Pos          lexer.Position
+  Test         *TestBlock
+  Bench        *BenchBlock
+  Expect       *ExpectStmt
+  Agent        *AgentDecl
+  Stream       *StreamDecl
+  Model        *ModelDecl
+  Import       *ImportStmt
+  Type         *TypeDecl
+  ExternType   *ExternTypeDecl
+  ExternVar    *ExternVarDecl
+  ExternFun    *ExternFunDecl
+  ExternObject *ExternObjectDecl
+  Fact         *FactStmt
+  Rule         *RuleStmt
+  On           *OnHandler
+  Emit         *EmitStmt
+  Let          *LetStmt
+  Var          *VarStmt
+  Assign       *AssignStmt
+  Fun          *FunStmt
+  Return       *ReturnStmt
+  If           *IfStmt
+  While        *WhileStmt
+  For          *ForStmt
+  Break        *BreakStmt
+  Continue     *ContinueStmt
+  Fetch        *FetchStmt
+  Update       *UpdateStmt
+  Expr         *ExprStmt
+}
+```
+
+`Statement` is a tagged union encoded as a struct with mutually exclusive nullable fields. Exactly one field is non-nil after a successful parse. The check pass switches on the non-nil field.
+
+The pattern repeats at lower levels: `TypeRef`, `PostfixOp`, `Primary`, and `Literal` are all the same shape.
+
+### Declarations
+
+```
+LetStmt   { Pos, Name, Doc, Type *TypeRef, Value *Expr }
+VarStmt   { Pos, Name, Doc, Type *TypeRef, Value *Expr }
+AssignStmt{ Pos, Name, Index []*IndexOp, Field []*FieldOp, Value *Expr }
+FunStmt   { Pos, Export bool, Name, Doc, TypeParams []string,
+            Params []*Param, Return *TypeRef, Body []*Statement }
+TypeDecl  { Pos, Name, Doc, Members []*TypeMember,
+            Variants []*TypeVariant, Alias *TypeRef }
+```
+
+Invariants:
+
+- `TypeDecl` is one of three forms. Exactly one of `Members`, `Variants`, or `Alias` is non-empty. The checker switches on which.
+- `LetStmt` and `VarStmt` require at least one of `Type` or `Value`. The parser allows both to be missing and the checker raises `T000` for the empty case.
+
+### Type references
+
+```
+TypeRef { Fun *FunType, Generic *GenericType,
+          Struct *InlineStructType, Simple *string }
+
+FunType         { Params []*TypeRef, Return *TypeRef }
+GenericType     { Name string, Args []*TypeRef }
+InlineStructType{ Fields []*TypeField }
+```
+
+There is no `Union` field. A union type by name resolves through `Simple` to a `UnionType` in the type environment. There is no inline union literal.
+
+### Expressions
+
+```
+Expr        { Pos, Binary *BinaryExpr }
+BinaryExpr  { Left *Unary, Right []*BinaryOp }
+BinaryOp    { Pos, Op string, All bool, Right *PostfixExpr }
+Unary       { Pos, Ops []string, Value *PostfixExpr }
+PostfixExpr { Target *Primary, Ops []*PostfixOp }
+PostfixOp   { Call *CallOp, Index *IndexOp, Field *FieldOp, Cast *CastOp }
+```
+
+`BinaryExpr` carries a flat list because the parser does not enforce precedence. The type checker must apply the precedence table at `types/infer.go:89-98`. A consumer that walks the tree without applying precedence will produce incorrect typing for mixed operator chains.
+
+`Unary.Ops` is a slice of strings (`"-"` or `"!"`). The checker applies them right to left.
+
+```
+Primary {
+  Pos, Struct *StructLiteral, Call *CallExpr,
+  Query *QueryExpr, LogicQuery *LogicQueryExpr,
+  If *IfExpr, Selector *SelectorExpr,
+  List *ListLiteral, Map *MapLiteral, FunExpr *FunExpr,
+  Match *MatchExpr, Generate *GenerateExpr,
+  Fetch *FetchExpr, Load *LoadExpr, Save *SaveExpr,
+  Lit *Literal, Group *Expr,
+}
+```
+
+The order in this struct is meaningful. `StructLiteral` comes before `Selector` because `Foo{...}` could otherwise be parsed as the identifier `Foo` followed by a block.
+
+### Patterns
+
+There is no `Pattern` AST. A `MatchCase.Pattern` is an `*Expr`. The checker decides what shapes are pattern legal:
+
+- A literal (any `Literal`) matches by equality.
+- A bare identifier acts as a wildcard binding.
+- A call expression `Tag(a, b, c)` matches a tagged union variant by name and binds the field arguments.
+- The underscore identifier is treated as a discard wildcard.
+
+### Literals
+
+```
+Literal { Pos, Int *IntLit, Float *float64,
+          Bool *boolLit, Str *string, Null bool }
+```
+
+Exactly one field is set per literal. `Null` is a bool flag rather than a pointer because `null` carries no payload.
+
+### Loops, conditionals, blocks
+
+```
+IfStmt   { Pos, Cond *Expr, Then []*Statement,
+           ElseIf *IfStmt, Else []*Statement }
+WhileStmt{ Pos, Cond *Expr, Body []*Statement }
+ForStmt  { Pos, Name string, Source *Expr, RangeEnd *Expr, Body []*Statement }
+```
+
+`ForStmt.RangeEnd` is non-nil for `for i in 0..10` and nil for `for x in xs`. The checker uses the difference to decide whether the loop variable is bound to an int or to the element type of the source.
+
+`IfStmt` has both an `ElseIf` chain and an `Else` body. They are mutually exclusive at the same level: an `if` either continues with another `if` (linked through `ElseIf`) or terminates with an `Else` block.
+
+### I/O nodes
+
+```
+FetchStmt { Pos, URL *Expr, Target string, With *Expr }
+FetchExpr { Pos, URL *Expr, With *Expr }
+LoadExpr  { Pos, Path *string, Type *TypeRef, With *Expr }
+SaveExpr  { Pos, Src *Expr, Path *string, With *Expr }
+UpdateStmt{ Pos, Target string, Set *MapLiteral, Where *Expr }
+EmitStmt  { Pos, Stream string, Fields []*StructLitField }
+```
+
+`Path` is a `*string` rather than `string` so we can distinguish "no path supplied" from "empty string". `load as T` without a path uses stdin; `save x` without `to` writes to stdout.
+
+### Logic and stream nodes
+
+```
+StreamDecl  { Pos, Name, Doc, Fields []*StreamField }
+ModelDecl   { Pos, Name string, Fields []*ModelField }
+OnHandler   { Pos, Stream, Alias string, Body []*Statement }
+AgentDecl   { Pos, Name, Doc, Body []*AgentBlock }
+IntentDecl  { Pos, Name string, Params []*Param, Return *TypeRef, Body []*Statement }
+FactStmt    { Pos, Pred *LogicPredicate }
+RuleStmt    { Pos, Head *LogicPredicate, Body []*LogicCond }
+```
+
+These are full nodes, type checked into the environment for the most part, but their semantics live with the interpreter, not the bytecode VM.
+
+### JSON view and golden tests
+
+The golden suite at `tests/parser/valid/` writes the parsed program to JSON and diffs it. That means any field rename, reorder, or change in optionality forces a golden update. The `omitempty` markers on every field keep the goldens minimal but mean adding a new optional field does not break older fixtures unless it appears in the program.
+
+To regenerate goldens after a deliberate AST change:
+
+```
+make update-golden STAGE=parser
+```
+
+## Rationale
+
+Reusing the parser structs as the AST keeps the source small and avoids a separate translation step. The cost is that we cannot evolve the AST shape independently of the parser. We accept that trade-off because the language is small and the AST and parser change together more often than not.
+
+Tagged unions encoded as nullable struct fields produce verbose Go code but keep the JSON shape stable, which is what the golden tests want.
+
+## Backwards Compatibility
+
+Informational. No backward compatibility implications.
+
+## Reference Implementation
+
+- `parser/parser.go` — entire AST.
+- `tests/parser/valid/` — golden suite that pins the JSON shape.
+
+## Open Questions
+
+- **Separate `ast` package.** Splitting the AST out of `parser` would let the IR and tooling depend on AST without pulling in participle. The migration is large.
+- **Pattern AST.** Today patterns are reused `*Expr` nodes. A dedicated `Pattern` type would catch more errors at parse time, at the cost of duplicating the postfix and call grammar.
+
+## References
+
+- See MEP 2 for the grammar that produces these nodes.
+
+## Copyright
+
+This document is placed in the public domain.

--- a/website/docs/mep/mep-0004.md
+++ b/website/docs/mep/mep-0004.md
@@ -1,0 +1,178 @@
+---
+mep: 4
+title: Type System
+author: Mochi core
+status: Informational
+type: Informational
+created: 2026-05-08
+sidebar_position: 4
+sidebar_label: MEP 4 — Type System
+description: Type kinds, equality, unification, and the numeric tower.
+---
+
+# MEP 4 — Type System
+
+| Field    | Value                       |
+|----------|-----------------------------|
+| MEP      | 4                           |
+| Title    | Type System                 |
+| Author   | Mochi core                  |
+| Status   | Informational               |
+| Type     | Informational               |
+| Created  | 2026-05-08                  |
+
+## Abstract
+
+Mochi has a small structural type system with nominal records and unions. This MEP documents the type kinds present in the implementation today, the equality and unification rules used by the checker, and the numeric tower that drives binary operator typing.
+
+## Motivation
+
+The type system is the contract between the checker and the runtime. A single misunderstanding about whether `int` and `int64` are equal, or whether `any` is a top type or a bottom type, can produce a soundness gap that is difficult to track down. Documenting the kinds and their relationships up front makes future changes deliberate.
+
+## Specification
+
+### The `Type` interface
+
+`types/check.go:12-14`. Every type kind implements:
+
+```
+type Type interface {
+    String() string
+}
+```
+
+There is no equality method on the interface. Equality is computed externally by `equalTypes` in `types/infer.go` and structural unification is done by `unify` in `types/check.go:148-387`. Two types are considered equal when their `String()` representations agree, with carve-outs for variance and `any`.
+
+### Kinds present today
+
+Listed in source order at `types/check.go:16-148`.
+
+Primitive kinds:
+
+- `IntType`. Default integer width. Backed by Go `int64` at runtime but the surface type is `int`.
+- `Int64Type`. Distinguished only where the runtime needs it, for example the result type of `now()`. Unifies with `IntType` for arithmetic.
+- `FloatType`. IEEE 754 double precision.
+- `BigIntType`. Arbitrary precision integer.
+- `BigRatType`. Arbitrary precision rational.
+- `StringType`. UTF-8 byte sequence.
+- `BoolType`. `true` or `false`.
+- `VoidType`. Result type of statement-only operations like `print`.
+
+Structural kinds:
+
+- `ListType{Elem Type}`. Homogeneous ordered sequence.
+- `MapType{Key Type, Value Type}`. Hash map keyed by `Key`.
+- `OptionType{Elem Type}`. Declared but not produced by inference today. See MEP 10.
+- `GroupType{Key Type, Elem Type}`. Internal type carried by the `into Name` clause of a `group by` query.
+- `StructType{Name, Fields, Order, Methods}`. Nominal record. `Order` preserves the declaration sequence so output and JSON encoding are deterministic.
+- `UnionType{Name, Variants}`. Nominal sum of struct-shaped variants. `Variants` is a map but the iteration order should be stable: the variant order from the declaration is captured when the type decl is processed.
+
+Function kind:
+
+- `FuncType{Params, Return, Pure, Variadic}`. The `Pure` flag is computed but not enforced anywhere yet. The `Variadic` flag is exercised by builtins like `concat` and `range`.
+
+Polymorphism kinds:
+
+- `TypeVar{Name}`. Carried by generic function declarations. Not yet used for full inference. See MEP 12.
+
+Top kind:
+
+- `AnyType{}`. Unifies with everything in both directions. This is the primary unsoundness escape hatch and is documented in detail in MEP 10 and MEP 11.
+
+### What is missing
+
+The list of kinds the language does not have today:
+
+- No nominal alias kind. `type Id = int` is collapsed at resolve time to its target.
+- No tuple kind. A heterogeneous fixed-length sequence has no surface type.
+- No record subtype kind separate from `StructType`. Width subtyping is decided by name plus field set, not by an explicit row variable.
+- No effect kind. The `Pure` flag is on the function type, not a separate kind.
+- No reference kind. Mutability is a property of the binding (`var` versus `let`), not of the type.
+- No existential or universal kind beyond `TypeVar` for generics.
+- No first-class type kind. Types cannot be passed as values.
+
+### Typing judgement
+
+We use the standard form `Γ ⊢ e : τ` where `Γ` is the lexical environment. Mochi's `Γ` carries:
+
+- Variable bindings with mutability flag (`Env.SetVar`).
+- Type bindings (`Env.SetType`).
+- Function bindings (`Env.SetFunc`).
+- Stream and agent bindings.
+
+Environments are linked. A child environment delegates lookups to its parent and shadows on write. See `types/env.go` for the API.
+
+### Equality and unification
+
+Two types are equal when they are structurally identical at every level. The exact rules in `equalTypes` (search `types/infer.go`):
+
+- Two primitives are equal iff their kinds match. `IntType` and `Int64Type` are not equal here, although arithmetic widens between them.
+- Two list types are equal iff their element types are equal.
+- Two map types are equal iff key and value types are equal.
+- Two function types are equal iff they have the same arity, the same parameter types pairwise, the same return type, and the same `Variadic` flag.
+- Two struct types are equal iff their `Name` fields agree. This is nominal. Two structurally identical anonymous structs declared separately are not equal because their generated names differ.
+- Two union types are equal iff their `Name` fields agree.
+- `AnyType` is equal to everything. This is the unsoundness hatch.
+
+Unification is the same predicate but propagates substitutions for `TypeVar`. See `types/check.go:148-387`.
+
+### Numeric tower
+
+Listed from narrowest to widest, but the relations are not a clean total order:
+
+```
+int  ⊂  int64  ⊂  bigint
+int          ⊂   float
+int          ⊂   bigrat
+bigint       ⊂   bigrat
+float        ⊄   bigrat   (mixed becomes bigrat in practice today)
+```
+
+The actual rules used by `inferBinaryType`:
+
+- Integer divide (`/` between two `int`s) returns `int`.
+- Either side `bigrat` widens to `bigrat`.
+- Either side `int64` and the other side `int` or `int64` returns `int64`.
+- Either side `float` and both sides numeric returns `float`.
+- Either side `bigint` returns `bigint`.
+- Two ints return `int`.
+- String plus string returns `string`.
+- List plus list returns the same list type if elements agree, or `[any]` otherwise.
+- Otherwise `any`.
+
+The `+` rule on lists is silently widening, which is a soundness concern when one side is mutated.
+
+## Rationale
+
+Keeping `String()` as the only required method on `Type` makes the kind table easy to extend. Equality and unification are external because they need to be customisable for variance and substitution.
+
+`AnyType` exists because the alternative is making every builtin generic, which we cannot do until parametric polymorphism (MEP 12) lands. `AnyType` is a debt; it is not a design choice.
+
+The numeric tower is conservative on purpose. We prefer to widen to `bigrat` when in doubt rather than silently lose precision.
+
+## Backwards Compatibility
+
+Informational. No backward compatibility implications.
+
+## Reference Implementation
+
+- `types/check.go:12-14` — `Type` interface.
+- `types/check.go:16-148` — kind definitions.
+- `types/check.go:148-387` — `unify`.
+- `types/infer.go` — `equalTypes` and operator typing.
+- `types/env.go` — environment API.
+
+## Open Questions
+
+- **Tuple kind.** A heterogeneous fixed-length sequence has no surface today. We will need it once query result tuples are generalised.
+- **Option kind.** `OptionType` exists but is not produced by inference. MEP 10 ties this to the `null` soundness gap.
+- **Numeric ordering.** `float` and `bigrat` mix awkwardly. We have not decided whether to widen to `bigrat` or to refuse the mix.
+
+## References
+
+- See MEP 5 for how these kinds are produced by inference.
+- See MEP 10 for the soundness gaps these kinds expose.
+
+## Copyright
+
+This document is placed in the public domain.

--- a/website/docs/mep/mep-0005.md
+++ b/website/docs/mep/mep-0005.md
@@ -1,0 +1,207 @@
+---
+mep: 5
+title: Type Inference
+author: Mochi core
+status: Informational
+type: Informational
+created: 2026-05-08
+sidebar_position: 5
+sidebar_label: MEP 5 — Type Inference
+description: How Mochi infers types for declarations, expressions, control flow, and queries.
+---
+
+# MEP 5 — Type Inference
+
+| Field    | Value                       |
+|----------|-----------------------------|
+| MEP      | 5                           |
+| Title    | Type Inference              |
+| Author   | Mochi core                  |
+| Status   | Informational               |
+| Type     | Informational               |
+| Created  | 2026-05-08                  |
+
+## Abstract
+
+Type inference in Mochi is local. Each expression form has a deterministic rule that maps operand types to a result type. There is no global solver and no constraint generation phase. This MEP documents the inference rules per construct so contributors can reason about a single expression without scanning the whole `infer.go` file.
+
+## Motivation
+
+Inference rules are easy to break by accident. A new operator added to the grammar has no result type until someone decides one. A new collection literal has to interact with empty-literal hinting. Without a single record of the rules, contributors guess, and the guesses drift.
+
+## Specification
+
+### Entry points
+
+`types/infer.go:17-69`.
+
+```
+ExprType(e *parser.Expr, env *Env) Type
+ExprTypeHint(e *parser.Expr, hint Type, env *Env) Type
+```
+
+`ExprType` is the basic inference call. `ExprTypeHint` accepts a hint and uses it to type empty list and map literals where context is the only signal. Both return `AnyType{}` when no better answer is found.
+
+The expression entry point delegates to `inferBinaryType`, which flattens precedence, then `inferUnaryType`, `inferPostfixType`, and finally `inferPrimaryType`.
+
+### Operator precedence and inference
+
+`types/infer.go:89-198`. The order of resolution:
+
+```
+1. *  /  %
+2. +  -
+3. <  <=  >  >=
+4. ==  !=  in
+5. &&
+6. ||
+7. union  union all  except  intersect
+```
+
+Within a level the algorithm reduces left to right. The result type table per operator is in MEP 4 under "numeric tower" and the same logic in code at `types/infer.go:114-191`.
+
+A subtle order dependency exists in numeric mixes. Because the algorithm folds left to right, `bigint - float` and `float - bigint` can produce different result types depending on rule firing order. Fixtures for each pair are required (see MEP 9).
+
+### Inference for declarations
+
+```
+let x = e        ->  Γ' = Γ ∪ { x : ExprType(e) }, immutable
+var x = e        ->  Γ' = Γ ∪ { x : ExprType(e) }, mutable
+let x : T        ->  Γ' = Γ ∪ { x : T }, immutable
+let x : T = e    ->  Γ' = Γ ∪ { x : T },
+                     require unify(T, ExprType(e))
+var x : T = e    ->  Γ' = Γ ∪ { x : T },
+                     require unify(T, ExprType(e))
+```
+
+`let` with neither type nor value raises `T000`.
+
+`fun f<G1, G2>(p: T) : R { ... }` introduces type variables in scope for the function body but does not generalise them across calls today. See MEP 12.
+
+### Inference for control flow
+
+- `if cond { ... }` requires `cond : bool` (`T040`). The body inherits the parent environment.
+- `while cond { ... }` requires `cond : bool`.
+- `for x in source { ... }`:
+  - if `source : [T]` then `x : T` in the body.
+  - if `source : {K: V}` then `x : K` in the body.
+  - if `source : int` (range form) then `x : int`.
+  - any other shape raises `T022`.
+- `for x in a..b { ... }` requires both bounds `: int` and binds `x : int`.
+
+### Inference for collections
+
+- `[]` with no hint has type `[any]`.
+- `[e1, ..., en]` has type `[T]` where `T` is the equal type of all `ei` if they agree, else `any`.
+- `[]` hinted with `[T]` has type `[T]`.
+- `{}` with no hint has type `{any: any}`.
+- `{k1: v1, ..., kn: vn}` has type `{K: V}` where `K` is the equal type of all `ki` (else `any`) and same for `V`.
+- `xs[i]` requires `xs : [T] | string | {K: V}` and `i : int` for list and string, or `i : K` for map. Returns `T`, `string`, or `V`. List index out of range is a runtime error.
+- `xs[a:b]` requires `xs : [T]` or `string` and bounds `: int`. Returns the same kind. Maps reject slicing (`T017`).
+
+### Inference for queries
+
+The query type is computed in `types/check.go` via the query plan builder. The shape:
+
+```
+from x in xs                where xs : [T]
+let xprime : T              the iteration variable
+{ from y in ys }*           additional sources stack as nested loops
+{ join z in zs on c }*      join clauses
+[ where p ]                 require p : bool
+[ group by k into g ]       g : group<K, T>
+[ sort by s ]
+[ skip n ] [ take n ]       require n : int
+select [ distinct ] r       result type list of ExprType(r)
+```
+
+The final result is `ListType{Elem: ExprType(r)}`. There is no narrower relation between sources and the projection result; the projection can produce any structurally typed value.
+
+Aggregate functions inside `select` are special cased:
+
+- `count(g) : int` where `g` is a list or group.
+- `sum(g) : int | float | bigint | bigrat` matching the element type.
+- `avg(g) : float | bigrat`.
+- `min(g)`, `max(g) : T` where `g : [T]` and `T` is comparable.
+
+Anything else falls through to general expression inference. The fall-through is part of why MEP 10 flags loose verification of `select` results.
+
+### Inference for matches
+
+`match e { p1 => r1, ..., pn => rn }`.
+
+- The result type is the join of `ExprType(ri)`. With the current join that almost always means the common type or `any`.
+- Pattern shapes:
+  - Literal pattern: requires the literal type to be equal to `ExprType(e)`. Pattern binds nothing.
+  - Identifier pattern: binds the name to `ExprType(e)`.
+  - Underscore: binds nothing, never fails.
+  - Variant call pattern: requires `e` to have a `UnionType` containing the named variant. Binds field positions to the variant fields.
+
+Exhaustiveness is not enforced today. See MEP 13.
+
+### Inference for casts
+
+`e as T`. The result type is `T`. There is no compatibility check between the source and target type. This is a documented hole.
+
+### Inference for function calls
+
+`f(a1, ..., an)`. Requires `Γ(f)` to be a `FuncType`. Then:
+
+- If `f` is variadic with `m` formal params, the first `m - 1` args unify normally and the rest must each unify with the last param.
+- Otherwise `n` must equal `m` (else `T006` or `T039`).
+- Each `ai` is checked against `Γ(f).Params[i]`. Mismatch yields `T007`.
+- The call's type is `Γ(f).Return` after substitution.
+
+For pure functions, the `Pure` flag is set but the checker does not yet require pure call sites in any context. The flag is reserved for future enforcement.
+
+### Inference for tagged unions
+
+A union `type U = A(x: int) | B(s: string)` enters the environment as:
+
+- `U` bound to `UnionType{Name: "U", Variants: {"A": ..., "B": ...}}`.
+- `A` bound to a constructor function `(int) -> U`.
+- `B` bound to a constructor function `(string) -> U`.
+
+So `let u = A(7)` gives `u : U`. Pattern matching is the only way to recover the variant in a checked way today.
+
+### Inference for I/O expressions
+
+- `load p as T with opts`. Type is `[T]` if the format is "json" with an array file, `T` if format is "json" with a single object, and `[T]` for "csv". The default format is "csv".
+- `save x to p with opts`. Type is `void`.
+- `fetch url with opts`. Type is `any` (the body of the response is decoded based on options).
+
+### Inference for closures and lambda
+
+`fun(p1, ..., pn) : R => body` produces type `FuncType{Params: [P1, ..., Pn], Return: R, Pure: false}`. With a block body the return type is inferred from the trailing return statements. Free variables in the body are captured by reference, which has implications for mutation that MEP 15 documents.
+
+## Rationale
+
+Local inference is enough for a small language. Global constraint solving would buy us better generic inference but at the cost of harder-to-explain error messages. We prefer to keep error messages tied to concrete source positions.
+
+The "join" we use for if branches and match arms is conservative: we widen to `any` when in doubt. That is part of why MEP 10 calls out `any` as the most common loss of information.
+
+## Backwards Compatibility
+
+Informational. No backward compatibility implications.
+
+## Reference Implementation
+
+- `types/infer.go:17-69` — entry points.
+- `types/infer.go:89-198` — operator precedence and inference.
+- `types/infer.go:114-191` — operator result types.
+- `types/check.go` — query plan builder and special-cased aggregates.
+
+## Open Questions
+
+- **Tighter join.** Should the join of two arms produce the union of their types instead of `any`? That would tighten match results but requires anonymous union types.
+- **Generic call inference.** Currently call sites do not unify type variables across positions. MEP 12 proposes the change.
+- **Aggregate fall-through.** `select` falls through to general expression inference for non-aggregates. We should reject `any` projections in strict mode.
+
+## References
+
+- See MEP 4 for the kinds inference produces.
+- See MEP 12 for the polymorphism upgrade.
+
+## Copyright
+
+This document is placed in the public domain.

--- a/website/docs/mep/mep-0006.md
+++ b/website/docs/mep/mep-0006.md
@@ -1,0 +1,210 @@
+---
+mep: 6
+title: Type Checker
+author: Mochi core
+status: Informational
+type: Informational
+created: 2026-05-08
+sidebar_position: 6
+sidebar_label: MEP 6 — Type Checker
+description: Entry point, builtin environment, statement walk, and the diagnostic catalogue.
+---
+
+# MEP 6 — Type Checker
+
+| Field    | Value                       |
+|----------|-----------------------------|
+| MEP      | 6                           |
+| Title    | Type Checker                |
+| Author   | Mochi core                  |
+| Status   | Informational               |
+| Type     | Informational               |
+| Created  | 2026-05-08                  |
+
+## Abstract
+
+The Mochi type checker is a non-short-circuiting walk over the AST that accumulates errors and returns them all. This MEP documents the entry point, the builtin environment, the statement walk, the error catalogue, and the workflow for adding new rules.
+
+## Motivation
+
+Type checker source files quickly become hard to read because every statement form contributes a separate function. A written record of which rule lives where, plus a flat list of error codes with their semantics, lets contributors locate the rule they need to extend without reading the whole file.
+
+## Specification
+
+### Entry point
+
+`types/check.go:391`. The signature:
+
+```
+func Check(prog *parser.Program, env *Env) []error
+```
+
+The function is non-short-circuiting. It accumulates errors and returns all of them. A program that is rejected on every statement still emits one error per statement, which matters for IDE integration and for the golden tests that snapshot the error stream.
+
+### Builtin environment
+
+`types/check.go:392-562` registers the builtins. The list at v0.10.82:
+
+- `print(...) : void`. Variadic, accepts `any`.
+- `len(any) : int`. Loosely typed. Pure.
+- `append([T], T) : [T]`. Variadic erased: actually accepts `[any]` and any element today.
+- `concat([T], ...) : [T]`. Variadic. Pure.
+- `first([T]) : any`. Pure.
+- `reverse(any) : any`. Pure.
+- `distinct([T]) : [T]`. Pure.
+- `push([T], T) : [T]`. Pure.
+- `keys({K:V}) : [K]`. Pure.
+- `values({K:V}) : [V]`. Pure.
+- `collect(any) : [any]`. Pure.
+- `range(int, ...) : [int]`. Variadic. Pure.
+- `now() : int64`. Effectful.
+- `json(any) : void`. Effectful.
+- `to_json(any) : string`. Pure.
+- `str(any) : string`. Pure.
+- `parseIntStr(string, int) : int`. Pure.
+- `int(any) : int`. Pure.
+- `upper(string) : string`. Pure.
+- `lower(any) : string`. Pure.
+- `trim(string) : string`. Pure.
+- `contains(string, string) : bool`. Pure. (Plus list and map overloads registered later in the file.)
+- A pile more builtins for math, strings, lists, maps.
+
+The looseness of many builtins (`any` parameters) is intentional today because we do not have parametric polymorphism. Tightening them is a work item in MEP 12.
+
+### Statement walk
+
+Each statement form has a corresponding check function. The dispatch is in `Check` and recurses through `checkStmt`:
+
+- `LetStmt`. Resolve declared type if present. Infer value type if present. Unify. Bind. Errors: T000, T008.
+- `VarStmt`. Same as `LetStmt` but mutable.
+- `AssignStmt`. Look up target. Validate it is `var` mutable (T024). Walk index and field ops to refine the LHS type, check the RHS matches.
+- `FunStmt`. Build a `FuncType`. Push a child env binding params and type params. Check body statements. Validate return type from trailing `return` statements (T010).
+- `IfStmt`. Cond bool (T040). Recurse into then and else.
+- `WhileStmt`. Cond bool. Recurse.
+- `ForStmt`. Source must be iterable (T022). Bind loop variable. Recurse.
+- `ReturnStmt`. Compare value type with current function's return type.
+- `BreakStmt`, `ContinueStmt`. Must be inside a loop (no error code yet).
+- `ExpectStmt`. Value must be bool (T011).
+- `ExprStmt`. Just type the expression for side effect; ignore result.
+- `FetchStmt`. URL string (T028). Options map (T029). Bind target.
+- `UpdateStmt`. Resolves the target type, walks the set map and where predicate, types each field assignment.
+- `TypeDecl`. Builds either a `StructType`, a `UnionType`, or an alias. Registers the constructor functions for unions.
+- `ImportStmt`. Resolves the module and binds identifiers. The exact semantics depend on the language tag (`python`, `go`, `ts`).
+- `ExternFunDecl`, `ExternVarDecl`. Trust the declared type.
+- `Test`, `Bench`. Recurse into the body.
+- `AgentDecl`, `StreamDecl`, `OnHandler`, `EmitStmt`, `FactStmt`, `RuleStmt`, `IntentDecl`. Type checked at varying depth. Some are shallow.
+
+### Error catalogue
+
+All error codes are defined in `types/errors.go`. Each entry has a `Code`, `Message`, and `Help`. When a code fires, the formatter renders output like:
+
+```
+1. error[T022]: cannot iterate over type int
+  --> tests/types/errors/cannot_iterate.mochi:1:1
+
+  1 | for i in 3 {
+    | ^
+
+help:
+  Only `list<T>`, `map<K,V>`, or integer ranges are allowed in `for ... in ...` loops.
+```
+
+Highlights:
+
+| Code | Meaning                                              |
+|------|------------------------------------------------------|
+| T000 | `let` requires a type or a value                     |
+| T001 | assignment to undeclared variable                    |
+| T002 | undefined variable                                   |
+| T003 | unknown function                                     |
+| T004 | not callable                                         |
+| T005 | parameter missing a type                             |
+| T006 | too many arguments                                   |
+| T007 | argument N type mismatch                             |
+| T008 | type mismatch in assignment context                  |
+| T009 | cannot assign type to immutable                      |
+| T010 | return type mismatch                                 |
+| T011 | expect must be a boolean                             |
+| T013 | incompatible comparison                              |
+| T014 | invalid primary expression                           |
+| T020 | operator cannot be used on the operand types        |
+| T021 | unsupported operator                                 |
+| T022 | cannot iterate over type                             |
+| T023 | range loop bounds not int                            |
+| T024 | cannot assign to let binding                         |
+| T025 | unknown type                                         |
+| T026 | unknown field on struct                              |
+| T027 | not a struct                                         |
+| T028 | fetch URL must be string                             |
+| T029 | fetch options must be map                            |
+| T030 | invalid type for fetch option                        |
+| T031 | unknown stream                                       |
+| T032 | query source not a list                              |
+| T033 | where condition not bool                             |
+| T034 | join source not a list                               |
+| T035 | on condition not bool                                |
+| T036 | cannot take length of type                           |
+| T037 | count expects list or group                          |
+| T038 | avg expects numeric list or group                    |
+| T039 | function expects N arguments                         |
+| T040 | if condition must be bool                            |
+| T041 | sum expects numeric list or group                    |
+| T042 | having must be bool                                  |
+| T043 | operator cannot be used with `any`                  |
+
+The series has gaps. New codes should be appended to the end with the next free integer.
+
+### Tests
+
+`types/check_test.go`.
+
+- `TestTypeChecker_Valid` runs every `.mochi` file in `tests/types/valid/` against the checker and confirms no errors. The `RUN_TYPE_VALID=1` gate was removed in the v0.11.0 soundness PR.
+- `TestTypeChecker_Errors` runs every `.mochi` file in `tests/types/errors/` and snapshots the error stream against the matching `.err` file.
+
+The `.err` snapshot is a strict equality check. Renaming an error message is a deliberate breaking change.
+
+### Adding a new rule
+
+Workflow:
+
+1. Add a fixture under `tests/types/valid/` exercising the accepted shape. Run `make update-golden STAGE=types` to seed the golden.
+2. Add a fixture under `tests/types/errors/` exercising the rejected shape.
+3. Implement the rule in `types/check.go` or `types/infer.go`.
+4. If a new error code is needed, append it to `types/errors.go`.
+5. Update the relevant MEP.
+
+### Performance
+
+`Check` does a single pass for each statement. Function bodies are checked when the function is declared. Recursive calls are typed against the declared signature and never re-entered. The cost is roughly linear in the number of AST nodes.
+
+## Rationale
+
+Non-short-circuiting matters for IDE use cases. We want the user to see every error at once, not the first one. The cost is more code paths to handle gracefully when an earlier statement is malformed.
+
+A flat error code table is easy to scan and easy to grep. A hierarchical taxonomy would be prettier but harder to extend without renumbering.
+
+## Backwards Compatibility
+
+Informational. No backward compatibility implications.
+
+## Reference Implementation
+
+- `types/check.go:391` — `Check` entry point.
+- `types/check.go:392-562` — builtin registration.
+- `types/errors.go` — error catalogue.
+- `types/check_test.go` — golden tests.
+
+## Open Questions
+
+- **Generated error table.** The Markdown table in this MEP is hand-maintained. A generator from `types/errors.go` would keep it honest.
+- **Loose builtins.** `any` parameters are a temporary measure pending MEP 12.
+- **`break` and `continue` outside loops.** No error code yet. Should be added.
+
+## References
+
+- See MEP 5 for the inference rules `Check` consults.
+- See MEP 7 for the soundness obligations `Check` aims to enforce.
+
+## Copyright
+
+This document is placed in the public domain.

--- a/website/docs/mep/mep-0007.md
+++ b/website/docs/mep/mep-0007.md
@@ -1,0 +1,188 @@
+---
+mep: 7
+title: Soundness
+author: Mochi core
+status: Active
+type: Process
+created: 2026-05-08
+sidebar_position: 7
+sidebar_label: MEP 7 — Soundness
+description: Progress, preservation, and the test obligations that prove them.
+---
+
+# MEP 7 — Soundness
+
+| Field    | Value                       |
+|----------|-----------------------------|
+| MEP      | 7                           |
+| Title    | Soundness                   |
+| Author   | Mochi core                  |
+| Status   | Active                      |
+| Type     | Process                     |
+| Created  | 2026-05-08                  |
+
+## Abstract
+
+A type system is sound when "well typed programs do not go wrong." This MEP states what we mean by sound for Mochi, lists the property-by-property test obligations that we use to verify soundness, and records the escape hatches we accept today. It is a process MEP because it is the contract that future feature work has to satisfy.
+
+## Motivation
+
+Mochi has both an interpreter and a bytecode VM. Without a written contract, neither backend has a clear standard against which to ship a feature. The Wright and Felleisen formulation gives us two clean lemmas: progress and preservation. Reducing soundness to those two statements lets us write fixtures that mechanically verify the contract.
+
+## Specification
+
+### What we mean by sound
+
+The standard Wright and Felleisen formulation is two lemmas plus a corollary.
+
+- **Progress.** If `∅ ⊢ e : τ` then either `e` is a value, or there exists `e'` such that `e ↦ e'`.
+- **Preservation.** If `Γ ⊢ e : τ` and `e ↦ e'` then `Γ ⊢ e' : τ`.
+- **Type safety.** By induction, no well-typed term reduces to a stuck configuration that is not a value.
+
+Mochi has both an interpreter and a bytecode VM. Soundness in the language statement above is against the interpreter's reduction relation. The bytecode VM should agree with the interpreter on all typed inputs but it lags on agent and logic features and is therefore treated as a separate target with its own conformance suite.
+
+### Mochi-specific values
+
+Values in this language at v0.10.82:
+
+- Integer literals at the four widths.
+- Floats.
+- Booleans.
+- Strings.
+- Null.
+- Lists of values.
+- Maps of values.
+- Closures, both block-bodied and arrow-bodied.
+- Struct instances and union variant instances.
+
+Stuck states we want to rule out:
+
+- Calling a non-function.
+- Indexing a non-list and non-map and non-string.
+- Iterating over a non-iterable.
+- Comparing values of incompatible types.
+- Adding a string to an integer.
+- Pattern matching against a value with no matching arm and no wildcard.
+- Reading a non-existent struct field.
+
+### Property-by-property obligations
+
+The properties below are the test obligations against which fixtures are built. Each property points at the MEP where the rules live and at the fixture group in `tests/types/`.
+
+#### Progress
+
+If a closed expression has type `τ`, evaluating it never gets stuck on a missing rule. Tests:
+
+- For every primitive, evaluate a literal of that type.
+- For every binary operator at every level, evaluate a closed expression at the level boundary.
+- For every postfix operator (call, index, field, cast), build a closed expression and evaluate it.
+
+#### Preservation
+
+If `e ↦ e'` we re-type `e'` and check the type matches. We do not have a step-level reduction relation in the runtime, so we approximate by:
+
+- Inserting let bindings around sub-expressions and asserting the outer program still type checks.
+- Replacing reducible sub-expressions with their values and asserting the outer program still type checks.
+- For function calls, asserting the call site type equals the inferred type of the call's substituted body.
+
+#### Canonical forms
+
+For every type, fixtures assert:
+
+- The set of values at that type.
+- A negative fixture rejects a value not at the type.
+
+For example, at `bool`, the only values are `true` and `false`. A fixture asserts that `1 + 2 == 3` evaluates to `true` of type `bool`. Another fixture asserts that `print` at type `void` cannot be assigned to a variable.
+
+#### Inversion
+
+For each typing judgement form we have one fixture per shape. The shape mappings are listed in MEP 5.
+
+#### Substitution
+
+For every binding form, a fixture asserts that replacing the binder with its value preserves the type and the result.
+
+```
+let x = e1 in e2     ≡   e2[x:=e1]   when e1 has no side effects
+```
+
+For mutable bindings, we test sequencing instead.
+
+#### Variance
+
+Fixtures cover the following positions:
+
+- Function argument and result, asserting the contravariance of the argument and the covariance of the result.
+- List element, asserting the current behaviour: covariant when read, unsafe when written. The unsafe case is a known weakness in MEP 10.
+- Map key and value, asserting invariance.
+
+#### Parametricity
+
+For each generic builtin (`len`, `first`, `reverse`, `distinct`, `push`, `keys`, `values`, `range`), fixtures assert:
+
+- The result type tracks the input element type when known.
+- Two distinct call sites do not leak through the type variable.
+
+Once parametric polymorphism is wired through, we add the standard parametricity tests: a polymorphic function applied to a list of `int` and a list of `string` must commute with map.
+
+#### Exhaustiveness and irredundancy
+
+For each tagged union declaration in fixtures:
+
+- A `match` covering every variant type checks.
+- A `match` missing a variant fails today (when implemented; flagged in MEP 13 as a hole).
+- A `match` with an arm that is a strict subset of an earlier arm fails (when implemented).
+
+#### Alpha equivalence
+
+For every binding form, two fixtures with bound names renamed must produce the same goldens after the rename. We do not author both versions by hand: we automate alpha rename in a property test.
+
+### What we accept as not sound today
+
+The escape hatches we acknowledge:
+
+- `AnyType` as a top type that unifies in both directions. This means values typed `any` can be silently used in any position. The fixture set in MEP 11 documents the current behaviour without endorsing it.
+- `as` casts are unchecked. Casting `int as string` is accepted at type check time and fails at runtime. Fixtures snapshot the behaviour.
+- `null` is currently `any` rather than an `option` type. Programs can use `null` as a value of any type.
+- `let xs = [1]; xs[0] = 2` mutates through an immutable binding because the mutability check applies only to the top-level binding, not to mutations through it.
+
+Each of these is targeted by MEP 10 and a separate spec amendment.
+
+### Conformance between interpreter and bytecode VM
+
+A program that the type checker accepts and the interpreter executes should produce the same observable output when executed by the bytecode VM, with the documented exceptions:
+
+- `agent`, `intent`, `on`, `emit`, `fact`, `rule`, `query` are not yet compiled to bytecode. Programs using them must run on the interpreter today.
+
+The conformance test set lives at `tests/vm/` and runs the same source through both backends, asserting equal stdout.
+
+## Rationale
+
+Wright-Felleisen is the standard formulation for ML-like languages. We adopt it because it gives us a property-by-property test plan that matches the way we already write fixtures.
+
+We acknowledge the escape hatches in writing because pretending they do not exist is the fastest way to ship an unsound feature. Pinning current behaviour in fixtures makes a future tightening a deliberate breaking change rather than an accidental drift.
+
+## Backwards Compatibility
+
+The escape hatches above will be tightened over time. Each tightening is a breaking change and will land with its own MEP and fixture migration plan.
+
+## Reference Implementation
+
+- `types/check.go` — checker.
+- `types/infer.go` — inference.
+- `tests/types/valid/` and `tests/types/errors/` — fixture sets.
+- `tests/vm/` — interpreter versus bytecode conformance.
+
+## Open Questions
+
+- **Step-level reduction relation.** We approximate preservation today. A formal small-step semantics would let us mechanise the proof. Out of scope for v0.11.0.
+- **Property test infrastructure.** Alpha equivalence and other meta properties want a generator-based test framework. Track in MEP 8.
+
+## References
+
+- Andrew Wright and Matthias Felleisen, "A Syntactic Approach to Type Soundness", Information and Computation, 1994.
+- Benjamin C. Pierce, *Types and Programming Languages*, MIT Press, 2002.
+
+## Copyright
+
+This document is placed in the public domain.

--- a/website/docs/mep/mep-0008.md
+++ b/website/docs/mep/mep-0008.md
@@ -1,0 +1,157 @@
+---
+mep: 8
+title: Test Strategy
+author: Mochi core
+status: Active
+type: Process
+created: 2026-05-08
+sidebar_position: 8
+sidebar_label: MEP 8 — Test Strategy
+description: The five test layers, the golden harness, and the TAPL chapter mapping.
+---
+
+# MEP 8 — Test Strategy
+
+| Field    | Value                       |
+|----------|-----------------------------|
+| MEP      | 8                           |
+| Title    | Test Strategy               |
+| Author   | Mochi core                  |
+| Status   | Active                      |
+| Type     | Process                     |
+| Created  | 2026-05-08                  |
+
+## Abstract
+
+Mochi tests the language in five layers, from cheap parser snapshots up through whole-program execution and property tests. This MEP documents each layer, the golden harness shared across them, and the mapping from soundness properties to TAPL chapters that drives fixture authoring.
+
+## Motivation
+
+Without a shared layering, contributors write tests at the wrong granularity. A grammar bug should fail at layer 1, not at layer 4. A new type rule should ship with both a valid and an error fixture, not with a single end-to-end check. Naming the layers and what they cover removes a class of "where does this test go" questions.
+
+## Specification
+
+### Layers
+
+Five layers of testing apply to soundness work, ordered from cheap to expensive.
+
+1. **Parser golden tests.** `tests/parser/valid/` and `tests/parser/errors/`. Snapshot the parsed AST as JSON.
+2. **Type checker golden tests.** `tests/types/valid/` and `tests/types/errors/`. Snapshot accepted vs rejected programs and their error output.
+3. **Interpreter execution tests.** `tests/interpreter/`. Snapshot stdout for end-to-end programs.
+4. **Bytecode VM execution tests.** `tests/vm/` (Rosetta benchmarks). Run the same program through both backends and diff.
+5. **Property tests.** `tests/types/property/` (planned). Generate programs and assert invariants automatically.
+
+CI runs layers 1 to 4 today. Layer 5 is the next step.
+
+### Golden harness
+
+`golden/golden.go`. Each test pair is `name.mochi` plus `name.golden` (or `name.err`). The harness reads the source, runs the function under test, normalises paths and timing strings, then compares to the golden. Run `go test ./types -update` to refresh goldens after a deliberate change.
+
+### TAPL chapter mapping
+
+Every property in MEP 7 corresponds to a chapter or chapter group in Pierce's *Types and Programming Languages*. Fixture authors should consult the relevant chapter for the canonical test cases and edge cases.
+
+| Property                      | TAPL ch. | MEP        | Fixture group       |
+|-------------------------------|----------|------------|---------------------|
+| Typed arithmetic              | 8        | 5          | numeric             |
+| Simply typed lambda           | 9        | 5          | function            |
+| Pairs, tuples, sums, lists    | 11       | 5, 13      | adt, list, map      |
+| References (mutability)       | 13       | 15         | mutability          |
+| Subtyping                     | 15       | 11         | subtyping           |
+| Imperative objects            | 18       | not used   |                     |
+| Recursive types               | 20       | 13         | recursive           |
+| Universal types               | 23       | 12         | generic             |
+| Existential types             | 24       | future     |                     |
+| Type reconstruction           | 22       | 12         | inference           |
+| Bounded quantification        | 26       | future     |                     |
+| Higher kinds                  | 30       | not used   |                     |
+
+### Fixture taxonomy
+
+Fixtures live under `tests/types/` and `tests/parser/` with one of three suffixes:
+
+- `.mochi` plus `.golden`. A program that should type check or parse successfully. The golden snapshots the success message or the parsed AST.
+- `.mochi` plus `.err`. A program that should be rejected at parse or check time. The `.err` snapshots the diagnostic.
+- `.mochi` plus `.out` (interpreter or VM tests). The `.out` snapshots stdout.
+
+Naming convention. Files are named `feature_aspect.mochi`. The `feature` is the language construct. The `aspect` is the property. Examples:
+
+- `let_basic.mochi` for the simple `let` form.
+- `let_immutable_assign.mochi` for an error fixture rejecting mutation of a `let` binding.
+- `match_exhaustive_union.mochi` (when implemented).
+- `subtype_record_width.mochi` (when implemented).
+
+### Property tests
+
+A property test generates programs from a small grammar and asserts a property holds. The seed grammar will live at `tests/types/property/gen.go` and produces well-typed expressions over a fixed type set. Properties:
+
+- Inferred type stability under alpha rename.
+- `Check` is order-independent on top-level statements that do not reference each other.
+- Adding redundant parens never changes the inferred type.
+- Replacing a sub-expression with its computed value never changes the outer program's type (preservation approximation).
+
+Property tests run with a fixed seed in CI for reproducibility, plus a randomised nightly run.
+
+### Required CI
+
+The PR for the v0.11.0 soundness initiative ratchets CI from "ok if tests pass" to:
+
+- All of layers 1, 2, 3 must pass.
+- Layer 4 (VM conformance) must pass against the interpreter.
+- Layer 5 must run with the deterministic seed and pass once it lands.
+
+### How to run locally
+
+```
+# All tests, default seed.
+make test
+
+# Just the type checker.
+make test STAGE=types
+
+# Refresh goldens after a deliberate change.
+make update-golden STAGE=types
+
+# Run only the soundness property tests.
+go test ./tests/types/property/...
+```
+
+### Fixture contribution flow
+
+When adding a new fixture pair:
+
+1. Decide the property it witnesses (MEP 7 list).
+2. Pick a name following the convention.
+3. Write the `.mochi` source.
+4. For valid fixtures, run `make update-golden STAGE=types` and inspect the golden.
+5. For error fixtures, run the test and inspect the `.err` against the diagnostic catalogue in MEP 6.
+6. Commit both files in a single change with a one-line note in the PR body listing the property the fixture covers.
+
+## Rationale
+
+A layered approach lets a fast smoke test at layer 1 catch a parser regression before a slow conformance run at layer 4 wastes minutes. Goldens are cheap to read in code review and force authors to look at the output of their change. Property tests are the long tail: they catch the cases we did not think to enumerate.
+
+The TAPL mapping is not academic dressing. It is a practical index into a known canon of test cases. When in doubt about whether a fixture is worth writing, look up the TAPL chapter and check whether the canonical cases are covered.
+
+## Backwards Compatibility
+
+Process MEP. No language compatibility implications.
+
+## Reference Implementation
+
+- `golden/golden.go` — golden harness.
+- `tests/parser/`, `tests/types/`, `tests/interpreter/`, `tests/vm/` — existing layers.
+- `tests/types/property/` — planned property test layer.
+
+## Open Questions
+
+- **Property test framework.** Whether to write our own generator or adopt Go's `testing/quick`. The latter is simpler; the former gives us better shrinking.
+- **Nightly random run.** Where to publish results. We do not have a stable channel yet.
+
+## References
+
+- Benjamin C. Pierce, *Types and Programming Languages*, MIT Press, 2002.
+
+## Copyright
+
+This document is placed in the public domain.

--- a/website/docs/mep/mep-0009.md
+++ b/website/docs/mep/mep-0009.md
@@ -1,0 +1,272 @@
+---
+mep: 9
+title: Fixture Catalogue
+author: Mochi core
+status: Informational
+type: Informational
+created: 2026-05-08
+sidebar_position: 9
+sidebar_label: MEP 9 — Fixture Catalogue
+description: Inventory of parser and type fixtures with a property coverage matrix.
+---
+
+# MEP 9 — Fixture Catalogue
+
+| Field    | Value                       |
+|----------|-----------------------------|
+| MEP      | 9                           |
+| Title    | Fixture Catalogue           |
+| Author   | Mochi core                  |
+| Status   | Informational               |
+| Type     | Informational               |
+| Created  | 2026-05-08                  |
+
+## Abstract
+
+This MEP is the live inventory of parser and type fixtures, plus a coverage matrix that maps each soundness property in MEP 7 to the fixtures that exercise it. New fixtures are added to the inventory in the same commit that introduces the file.
+
+## Motivation
+
+Without an index, the same property is often covered three times under three different names while another property goes uncovered. The matrix makes the gaps visible.
+
+## Specification
+
+### Inventory at v0.10.82
+
+Source counts taken at the snapshot date. Numbers are pairs of `.mochi` plus matching golden or err.
+
+| Directory                  | Pairs |
+|----------------------------|-------|
+| tests/parser/valid         | 52    |
+| tests/parser/errors        | 10    |
+| tests/types/valid          | 31+17 (added in v0.11.0) |
+| tests/types/errors         | 45+4  (added in v0.11.0) |
+| tests/queryplan            | small |
+| tests/interpreter          | many  |
+| tests/vm                   | many  |
+| `tests/compiler/{rb,dart,ts}` | 37+   |
+| tests/mochi_in_mochi/parser| small |
+
+The VM and interpreter directories are end-to-end suites and are not the focus of this initiative. The parser and type fixtures are.
+
+### Existing parser/valid fixtures
+
+Sorted by name:
+
+```
+agent_call, agent_decl, agent_full, agent_on_event, assign_stmt,
+call_expr, cast_expr, collection_literals, cross_join,
+cross_join_triple, dataset, dataset_sort_take_limit, expect_stmt,
+for_loop, fun_def, fun_expr, fun_expr_type_params, fun_type_params,
+generate_expr, generic_type, group_by, group_expr, if_expr_then_else,
+if_expr_then_else_nested, if_stmt, in_operator, index_expr, join,
+left_join, let_stmt, list_assign, load_expr, load_save_stdinout,
+load_with_expr, map_assign, match_expr, model_decl, negative,
+nested_type_decl, on_stmt, outer_join, package_export, right_join,
+save_expr, stream_decl, test_block, type_struct_equals, unary_expr,
+update_stmt, user_type_literal, var_stmt, while_loop
+```
+
+### Existing types/valid fixtures
+
+```
+break_continue, cast_expr, closure, doom_move, fetch_extra_options,
+fetch_options, fun_return_type, generate_options, generate_struct,
+join_basic, join_multi, left_join, let_basic, list_assign,
+list_concat, load_with, map_assign, map_hint_literal, match_expr,
+model_decl, nested_type_decl, outer_join, shadow_scope,
+stream_on_emit, string_in_operator, string_index, union_alias,
+update_stmt, user_type_selector, user_types_basic, var_mutable
+```
+
+Added in v0.11.0:
+
+```
+aggregate_count_list, aggregate_min_max_int, aggregate_sum_int_list,
+canonical_bool_only, canonical_int_arithmetic, canonical_string_concat,
+closure_inferred_return, for_in_list, for_in_range,
+inversion_if_expr, match_literal_pattern, match_union_variant,
+numeric_float_plus_int, numeric_int_plus_float,
+preservation_let_chain, query_basic_select, query_sort_take,
+struct_field_access
+```
+
+### Existing types/errors fixtures
+
+```
+arg_type_mismatch, assign_to_let, assign_type_mismatch,
+assign_undeclared_var, avg_non_numeric, binary_operator_type_error,
+cannot_iterate, comparison_type_error, count_invalid_type,
+emit_field_type, emit_unknown_stream, expect_non_boolean,
+fetch_option_type, fetch_opts_map, fetch_url_type, fun_return_mismatch,
+fun_wrong_return, generate_type_mismatch, index_not_int,
+invalid_len_operand, invalid_range_bounds, join_on_not_bool,
+join_source_not_list, json_missing_arg, len_missing_arg,
+let_missing_type_or_value, map_assign_immutable, map_key_type_mismatch,
+map_slice, match_pattern_mismatch, match_result_mismatch, missing_index,
+not_callable, not_indexable, not_struct_selector, now_too_many_args,
+on_unknown_stream, query_source_not_list, too_many_args,
+undeclared_var, undefined_function, unknown_generate_type,
+user_type_field_mismatch, user_unknown_field, wrong_type_assign
+```
+
+Added in v0.11.0:
+
+```
+match_variant_arity, multiple_top_level_errors, range_bound_float,
+struct_unknown_field_access
+```
+
+### Coverage matrix
+
+The matrix is a property-to-fixture mapping. A cell value of `existing` means at least one fixture in the corresponding directory exercises the property. `missing` means we need to author one.
+
+| Property (from MEP 7)                    | Valid     | Error     |
+|------------------------------------------|-----------|-----------|
+| Progress, primitives                     | existing  | existing  |
+| Progress, list and map                   | existing  | existing  |
+| Progress, function call                  | existing  | existing  |
+| Preservation under let binding           | existing  | missing   |
+| Canonical forms, bool                    | existing  | existing  |
+| Canonical forms, int and int64           | existing  | existing  |
+| Canonical forms, float                   | partial   | partial   |
+| Canonical forms, bigint, bigrat          | missing   | missing   |
+| Canonical forms, string                  | existing  | existing  |
+| Canonical forms, void                    | missing   | missing   |
+| Canonical forms, struct                  | existing  | existing  |
+| Canonical forms, union variant           | existing  | existing  |
+| Inversion, every Primary shape           | partial   | partial   |
+| Substitution, let bindings               | existing  | missing   |
+| Variance, function arg and result        | missing   | missing   |
+| Variance, list element read              | missing   | missing   |
+| Variance, list element write             | missing   | missing   |
+| Variance, map key                        | missing   | missing   |
+| Variance, map value                      | missing   | missing   |
+| Parametricity, len                       | missing   | missing   |
+| Parametricity, first                     | missing   | missing   |
+| Parametricity, push, append, concat      | missing   | missing   |
+| Parametricity, range                     | missing   | missing   |
+| Exhaustiveness, union                    | missing   | missing   |
+| Irredundancy, union                      | missing   | missing   |
+| Alpha equivalence (property)             | missing   | n/a       |
+| Numeric tower, int + float order         | existing  | n/a       |
+| Numeric tower, bigint + bigrat           | missing   | n/a       |
+| Numeric tower, int / int                 | missing   | n/a       |
+| Mutability, let immutable                | existing  | existing  |
+| Mutability, var mutable                  | existing  | n/a       |
+| Mutability, let xs[i] = ...              | missing   | missing   |
+| Mutability, let s.f = ...                | missing   | missing   |
+| Subtyping, record width                  | missing   | missing   |
+| Subtyping, AnyType silently accepts      | missing   | n/a       |
+| Cast, int as string                      | missing   | n/a       |
+| Cast, union as variant                   | missing   | missing   |
+| Null assignable as any                   | missing   | n/a       |
+| Closures capture                         | existing  | missing   |
+| Recursive types                          | missing   | missing   |
+| Generic function declared                | existing  | missing   |
+| Generic function instantiation           | missing   | missing   |
+| Query result type                        | existing  | partial   |
+| Query aggregate types                    | existing  | partial   |
+| Multiple top level errors accumulated    | n/a       | existing  |
+| Pure flag (future enforcement)           | n/a       | n/a       |
+
+`partial` means at least one fixture exists but the property is not fully covered.
+
+### New fixtures to author for v0.11.0
+
+Grouped by MEP.
+
+From MEP 4 (type system):
+
+- `type_void_not_assignable` (error, T009 family).
+- `type_struct_nominal_inequality` (error, two anon structs).
+- `type_bigint_string` (valid).
+- `type_bigrat_string` (valid).
+
+From MEP 5 (inference):
+
+- `numeric_int_div_int` (valid, asserts int / int : int).
+- `numeric_bigint_minus_float` (valid).
+- `numeric_float_minus_bigint` (valid, mirror).
+- `numeric_bigrat_dominates` (valid).
+- `for_in_int_count` (valid, range form).
+- `for_in_map_keys` (valid).
+- `aggregate_avg_int_list` (valid).
+- `aggregate_min_string_list` (valid).
+- `aggregate_sum_bigint_list` (valid).
+
+From MEP 7 (soundness):
+
+- `preservation_let_substitution` (valid, sequence).
+- `inversion_every_primary` (valid, large composite).
+
+From MEP 11 (subtyping):
+
+- `record_width_subtype` (valid, when implemented).
+- `any_top_silent_widen` (valid, snapshots current behaviour).
+- `any_to_int_unchecked` (valid, snapshots current behaviour).
+- `cast_int_as_string` (valid, snapshots current behaviour).
+
+From MEP 12 (polymorphism):
+
+- `generic_id_int_string` (valid).
+- `generic_id_per_call_freshness` (valid).
+- `generic_pair_swap` (valid, when implemented).
+- `generic_unification_conflict` (error, when implemented).
+
+From MEP 13 (ADT):
+
+- `adt_struct_field_mismatch` (error).
+- `adt_union_constructor_arity` (error).
+- `adt_match_exhaustive` (valid, when implemented).
+- `adt_match_missing_variant` (error, when implemented).
+- `adt_match_redundant_variant` (error, when implemented).
+- `adt_match_wildcard_after` (valid).
+
+From MEP 14 (queries):
+
+- `query_select_arbitrary_expr` (valid).
+- `query_join_cardinality` (valid).
+- `query_group_having_bool` (error, T042).
+- `query_distinct_unique_int` (valid).
+- `query_skip_take_int` (valid).
+
+From MEP 15 (effects):
+
+- `mutate_through_let_index` (valid today, error after fix).
+- `mutate_through_let_field` (valid today, error after fix).
+- `pure_call_in_pure_context` (future, no fixture yet).
+
+### How to map a fixture to a MEP
+
+Every fixture committed under `tests/types/` should be referenced in the MEP that owns the property. The MEP's "Open Questions" or "Specification" section carries a checklist that lists fixtures by name. When a fixture is added, the checklist gets a checkmark.
+
+When this catalogue is updated, the matrix above must reflect reality. Stale matrix rows are a tech debt indicator.
+
+## Rationale
+
+The catalogue is the single source of truth for fixture coverage. Without it, missing coverage hides behind passing tests. The matrix is uncomfortable to read on purpose: every `missing` cell is a debt we owe the language.
+
+## Backwards Compatibility
+
+Informational. No backward compatibility implications.
+
+## Reference Implementation
+
+- `tests/parser/valid/`, `tests/parser/errors/` — parser fixtures.
+- `tests/types/valid/`, `tests/types/errors/` — type fixtures.
+- `golden/golden.go` — harness used by both directories.
+
+## Open Questions
+
+- **Inventory regeneration.** A small Go program that walks the tree and produces this Markdown would keep the inventory honest.
+- **Property test fixtures.** Once layer 5 is wired in, this catalogue gains a third column.
+
+## References
+
+- See MEP 7 for the property list.
+- See MEP 8 for the test layer that owns each fixture.
+
+## Copyright
+
+This document is placed in the public domain.

--- a/website/docs/mep/mep-0010.md
+++ b/website/docs/mep/mep-0010.md
@@ -1,0 +1,246 @@
+---
+mep: 10
+title: Known Gaps and Weakness Review
+author: Mochi core
+status: Informational
+type: Informational
+created: 2026-05-08
+sidebar_position: 10
+sidebar_label: MEP 10 — Known Gaps
+description: Catalogue of soundness gaps, surprising behavior, and tracked follow-ups.
+---
+
+# MEP 10 — Known Gaps and Weakness Review
+
+| Field    | Value                       |
+|----------|-----------------------------|
+| MEP      | 10                          |
+| Title    | Known Gaps and Weakness Review |
+| Author   | Mochi core                  |
+| Status   | Informational               |
+| Type     | Informational               |
+| Created  | 2026-05-08                  |
+
+## Abstract
+
+This MEP is the "uncomfortable truths" file. It catalogues every place where Mochi today is unsound, surprising, incomplete, or simply mis-sold. Each entry has the evidence (file and line), an impact assessment, and either a fix plan or an explicit "by design" note.
+
+## Motivation
+
+A fixture pinned to current behaviour is not the same as endorsement. Some entries below are captured by fixtures so that a future fix is a deliberate breaking change rather than an accidental drift. The tier system labels how seriously each gap threatens the "type safe" claim.
+
+## Specification
+
+### Tier A: critical for the "type safe" claim
+
+#### A1. AnyType is a true top type
+
+**Evidence.** `types/check.go:148-157` for the `unify` rule that lets `AnyType` match in either direction. Most builtins are declared with `AnyType{}` parameters at lines 393 to 562.
+
+**Impact.** A value typed `any` can be passed to a function expecting `int`, indexed as a list, or compared with anything. There is no explicit cast required.
+
+**Plan.**
+
+1. Capture the current behaviour in a fixture (`tests/types/valid/any_top_silent_widen.mochi`).
+2. Audit which builtins truly need `any` and rewrite the rest with parametric polymorphism once MEP 12 lands.
+3. Tighten `unify` so `any` requires an explicit `as` cast in either direction.
+
+#### A2. null is a value of any type
+
+**Evidence.** `types/check.go:1708`. The literal `null` is typed `AnyType{}` rather than producing an `OptionType`.
+
+**Impact.** `let x: int = null` type checks today. Dereferencing `x` in arithmetic is a runtime error.
+
+**Plan.**
+
+1. Wire `OptionType` into the inference of `null`.
+2. Introduce a `T?` syntactic shorthand for `OptionType{T}`.
+3. Add a check that requires explicit unwrap (`?` or `match`) before use as the underlying type.
+
+#### A3. Mutation through immutable bindings
+
+**Evidence.** `types/check.go` around the `AssignStmt` walk. The mutability flag is consulted when the left hand side is a bare name but not when there are index or field operations.
+
+**Impact.** `let xs = [1]; xs[0] = 2` is accepted. The contract that `let` is immutable is not honoured under index or field assignment.
+
+**Plan.**
+
+1. Tighten `checkAssignStmt` to inspect the mutability of the root binding, not just whether a top-level reassignment is happening.
+2. Add error code (next free) `T0xx`: cannot mutate through immutable binding.
+3. Add a fixture for both index and field mutation of a `let`.
+
+#### A4. Match exhaustiveness not enforced
+
+**Evidence.** The match check loop in `types/check.go` (lines around 2209 to 2284) types each arm but does not check that the union of arm patterns covers every variant of a `UnionType` scrutinee.
+
+**Impact.** Removing a variant from a union does not surface as a compile error in code that matches on it. Users discover the gap at runtime.
+
+**Plan.**
+
+1. Compute the variant coverage during match check.
+2. Allow a single wildcard or identifier pattern to cover the remainder, and warn (not error) if it shadows reachable cases.
+3. Emit a new error code for missing variants.
+
+#### A5. as cast is unchecked
+
+**Evidence.** `types/check.go:1687-1688` resolves the target type and returns it. There is no compatibility check.
+
+**Impact.** `(5 as string).len` type checks. The runtime then either crashes or silently coerces, depending on the path.
+
+**Plan.**
+
+1. Define a small subtype check `castOk(from, to)` that allows numeric tower casts, union to variant casts (with a runtime discriminator check), and `to any` always.
+2. Reject other casts at type check time.
+
+### Tier B: surprising or incomplete
+
+#### B1. Integer division mismatch between checker and runtime
+
+**Evidence.** `types/infer.go:116-118` says `int / int` produces `int`. At runtime `5 / 2` evaluates to `2.5`. Probed against the v0.10.81 binary on 2026-05.
+
+**Impact.** `let x: int = 5 / 2; print(x)` is accepted by the type checker and prints `2.5`. The static type and the runtime value disagree. A later operation `x + 1` then prints `3`, which suggests an implicit narrowing back to int at the use site. The combination is genuinely unsound: the checker promises `int` and the program observes a float value flowing through.
+
+**Plan.** Decide policy first.
+
+- **Path A: rational division.** Make `/` always return `float` for numeric operands. Document. Update `inferBinaryType` to drop the int/int special case. Add a `div` builtin or a `//` operator for truncating division.
+- **Path B: truncating division.** Make the runtime truncate, matching the checker. Add a fixture confirming `5 / 2 == 2`.
+
+Path A matches the runtime today. We recommend it.
+
+#### B2. Operator precedence reduction is order-dependent on numeric mixes
+
+**Evidence.** `types/infer.go:120-138`. The mix rules check `isInt64` before `isFloat` and that ordering can produce different result types depending on operand position.
+
+**Impact.** `bigint - float` and `float - bigint` may not produce the same type. Programs that rely on the result type mid-expression are fragile.
+
+**Plan.** Replace the cascade with a small lattice and join semantics so the result depends only on the operand kinds, not on which side they appear on.
+
+#### B3. List covariance without write protection
+
+**Evidence.** `types/check.go:172-189`. `unify(ListType{Int}, ListType{Any})` succeeds without restricting writes.
+
+**Impact.** Once mutation through indices is tightened (A3), unsafe covariant aliasing becomes the next failure mode. Today the issue is masked because mutations slip through anyway.
+
+**Plan.** After A3, treat list element type as invariant under aliasing. Allow read-only covariance only at expression positions that cannot be assigned through.
+
+#### B4. Pure flag is set but never enforced
+
+**Evidence.** The flag is set at builtin registration in `types/check.go:393-562` and on user functions where the body is free of side effects. There is no rule that consumes it.
+
+**Impact.** The flag is misleading. A programmer reading the code might trust it.
+
+**Plan.** Either delete the flag, or add a small set of pure positions (struct field defaults, type alias arguments, query plan predicates) where impure calls are rejected.
+
+#### B5. Generic functions parse but do not unify across calls
+
+**Evidence.** `TypeVar` exists at `types/check.go:104` and is used in unification but is not produced by inference of a function call's result. Each call site re-infers from the declared signature.
+
+**Impact.** A function declared `fun id<T>(x: T): T` is callable but the caller always sees the type of `x` flow through the declaration in a loose way.
+
+**Plan.** Wire `TypeVar` through inference. Build a small substitution solver so a call generates fresh variables and unifies arguments. Reject conflicting unifications with a new error code. See MEP 12.
+
+#### B6. Query select fallback to any
+
+**Evidence.** The aggregate dispatch in `types/check.go:2401-2439` explicitly types `count`, `sum`, `avg`, `min`, `max` and falls through to general expression typing for everything else, often producing `any`.
+
+**Impact.** A `select foo(bar)` where `foo` returns `any` does not raise even when `bar` is mistyped.
+
+**Plan.** Extend the dispatch to keep stricter types and reject `any` in the projection unless explicitly cast.
+
+#### B7. extern declarations are trust-the-author
+
+**Evidence.** `types/check.go:828-850` registers extern bindings without verifying the symbol exists in the import target.
+
+**Impact.** Mismatch between declared type and actual symbol surfaces as a runtime failure, often deep inside a foreign call.
+
+**Plan.** For Go and Python imports where we have introspection, validate the signature against the imported package.
+
+#### B8. Recursive type definitions
+
+**Evidence.** `types/check.go:1179-1207` builds union types with a shared variants map so forward references resolve. Recursion in struct fields is permitted.
+
+**Impact.** Soundness is not at issue but unbounded recursive structures can cause runtime memory issues. JSON serialisation can loop.
+
+**Plan.** Document the policy. Add a fixture where a recursive linked list works. Add a runtime check for serialisation cycles.
+
+#### B9. Shadowing without warning
+
+**Evidence.** `types/env.go:179, 187` allow rebinding a name in a child scope without diagnostic.
+
+**Impact.** Subtle bugs. A user writes `let x = ...` in a nested block intending to shadow but accidentally reassigns.
+
+**Plan.** Add an opt-in lint rule. Not a soundness issue.
+
+### Tier C: parser and surface quirks
+
+#### C1. int | nil does not parse
+
+**Evidence.** `parser/parser.go:184-189`. `TypeRef` does not list union as a constructor.
+
+**Impact.** The natural way to write a nullable type fails.
+
+**Plan.** Decide between two paths: a `T?` shorthand or full union types in `TypeRef`. Either resolves A2 once `OptionType` is wired through.
+
+#### C2. Unary minus on RHS of comparison without parens
+
+**Evidence.** `parser/parser.go:53-56` documents the lexer rationale.
+
+**Impact.** `x == -1` requires parens or whitespace. Surprising for new users.
+
+**Plan.** Document in `parser/README.md` and in MEP 1. Long term, look at splitting the lexer rule so `-1` is a number when not preceded by an ident or close bracket.
+
+#### C3. Logic and stream features parse but do not run on the bytecode VM
+
+**Evidence.** The bytecode compiler in `runtime/vm/vm.go` switch on statements does not include `Agent`, `Stream`, `Emit`, `Fact`, `Rule`, `On`, `Intent`.
+
+**Impact.** Programs using these constructs run on the interpreter only. Building one of these programs into a bytecode binary silently removes the feature.
+
+**Plan.** Either compile them or emit a clear error from the bytecode backend that says these constructs are interpreter only.
+
+#### C4. The block comment regex does not nest
+
+**Evidence.** `parser/parser.go:49`. `/* ... */` matches the first `*/`.
+
+**Impact.** A literal `*/` inside a block comment terminates it early.
+
+**Plan.** Document. Low priority.
+
+#### C5. Reserved keywords accidentally steal user names
+
+**Evidence.** The keyword regex at `parser/parser.go:51` is enforced globally.
+
+**Impact.** Adding a keyword silently breaks user code that used the new word as an identifier.
+
+**Plan.** Add a checklist item to the release process: any new keyword must be tested against the existing fixture set and any third-party code that the team can scan.
+
+### Tier D: documentation drift
+
+- MEP 9 must be regenerated whenever fixture counts change.
+- Builtins listed in MEP 6 must match the actual code; today they do, but the list is hand-maintained.
+- The error code table in MEP 6 is hand-maintained too. Consider a generator that emits Markdown from `types/errors.go`.
+
+## Rationale
+
+A weakness review that names files and lines is one we can act on. A vague list of "issues to fix someday" is one we cannot. We tier the items so the most consequential gaps get the most attention.
+
+## Backwards Compatibility
+
+Each fix above is a breaking change for some programs. We pin current behaviour in fixtures so that the breakage is deliberate and traceable.
+
+## Reference Implementation
+
+References to source files and lines are inline above.
+
+## Open Questions
+
+- **Path A or B for B1.** Recommendation is Path A (rational division). Need consensus before shipping the fix.
+- **Soft versus hard `any` removal.** Whether to keep `any` as an explicit opt-in cast target or eliminate it once polymorphism lands.
+
+## References
+
+- See MEP 7 for the soundness contract this document offends against.
+- See MEP 12 for the polymorphism upgrade that closes A1 and B5.
+
+## Copyright
+
+This document is placed in the public domain.

--- a/website/docs/mep/mep-0011.md
+++ b/website/docs/mep/mep-0011.md
@@ -1,0 +1,189 @@
+---
+mep: 11
+title: Subtyping and Variance
+author: Mochi core
+status: Draft
+type: Standards Track
+created: 2026-05-08
+sidebar_position: 11
+sidebar_label: MEP 11 — Subtyping
+description: Width subtyping, variance positions, and the proposed subtype predicate.
+---
+
+# MEP 11 — Subtyping and Variance
+
+| Field    | Value                       |
+|----------|-----------------------------|
+| MEP      | 11                          |
+| Title    | Subtyping and Variance      |
+| Author   | Mochi core                  |
+| Status   | Draft                       |
+| Type     | Standards Track             |
+| Created  | 2026-05-08                  |
+
+## Abstract
+
+Mochi has a small subtyping relation today and an unfortunate `unify` that treats `any` as a top type in both directions. This MEP proposes a clean `subtype(s, t)` predicate that matches the standard variance rules and replaces the loose `any` behaviour with a deliberate cast at the boundary.
+
+## Motivation
+
+The current `unify` plays two roles: structural unification of type variables and ad-hoc subtyping. The conflation makes both jobs harder. A separate `subtype` predicate, called from the positions where subtyping is intended, lets us state the rules clearly and lets `unify` focus on substitution.
+
+## Specification
+
+### The relation
+
+Define `S <: T` to mean `S` is acceptable wherever `T` is expected. The intended rules:
+
+```
+T <: any
+S <: any
+any <: T                (only by explicit cast)
+
+int <: int
+int <: int64            (numeric promotion)
+int <: bigint           (numeric promotion)
+int <: bigrat
+int <: float
+int64 <: bigint
+int64 <: float
+bigint <: bigrat
+float <: bigrat         (lossy, but the inference uses bigrat as the join)
+
+[S] <: [T]              if S <: T  (read only positions)
+[S] = [T]               if S = T   (read write positions, after MEP 10 A3 lands)
+{K1: V1} = {K2: V2}     if K1 = K2 and V1 = V2
+fun(P1...) : R1 <: fun(Q1...) : R2
+                        if Pi <: Qi (contravariance flipped) and R1 <: R2
+struct named N <: struct named N
+union named U <: union named U
+variant V of U <: U     for every variant V declared in U
+```
+
+The "any in either direction" rule we have today violates several of the above, but it is what `unify` does at the moment.
+
+### Variance positions
+
+Positions where types appear and the variance applied at each:
+
+| Construct                       | Position           | Variance       |
+|---------------------------------|--------------------|----------------|
+| `let x: T = e`                  | T                  | invariant      |
+| `var x: T = e`                  | T                  | invariant      |
+| `fun(p: T) : R`                 | T (param)          | contravariant  |
+| `fun(p: T) : R`                 | R (result)         | covariant      |
+| `[T]` element                   | read               | covariant      |
+| `[T]` element                   | write              | invariant      |
+| `{K: V}` key                    |                    | invariant      |
+| `{K: V}` value                  |                    | invariant      |
+| `match e { p => r }` arms       | r                  | covariant      |
+| Tagged union variant            | `V <: U`           | covariant      |
+
+### Width subtyping (proposed)
+
+Records do not have width subtyping today. We do not propose adding it broadly, because the language is nominal. The exceptions we want:
+
+- Struct literal under a hint. `let p: Point = {x: 1, y: 2}`. The hint drives validation. Width is required to match exactly today and we keep that.
+- Inline struct types in function parameters. `fun f(p: {x: int, y: int})` accepts any value whose runtime shape includes the listed fields. Today the inline struct must match exactly. Width subtyping here would let callers pass richer records. We mark it as future work.
+
+### any cast in either direction
+
+Casting to `any` should always succeed at type check time: it is the top type. Casting from `any` should be limited:
+
+- `any as T` should be accepted at type check time, with a runtime guard that raises a typed runtime error if the dynamic type does not match.
+- Casts among numeric types should be accepted at type check time and should perform the documented coercion at runtime.
+- Casts among unrelated types (`int as string`, `string as bool`) should be rejected.
+
+The runtime guard is on the roadmap. A cleaner design is in MEP 10 A5.
+
+### How the checker computes subtyping
+
+Today the only subtyping logic is inside `unify` and `equalTypes`. We want a proper `subtype(s, t)` predicate. Implementation sketch:
+
+```
+subtype(s, t):
+  if t is AnyType: true
+  if s is t (structural): true
+  if s and t both numeric: lattice ordering
+  if s = ListType{S0} and t = ListType{T0} (read only): subtype(S0, T0)
+  if s = MapType{Sk, Sv} and t = MapType{Tk, Tv}: equal(Sk, Tk) and equal(Sv, Tv)
+  if s = FuncType{Pi, R1} and t = FuncType{Qi, R2}:
+        all i. subtype(Qi, Pi) and subtype(R1, R2)
+  if s is a variant of t: true
+  otherwise: false
+```
+
+Replace direct calls to `unify` with `subtype` at the positions where subtyping is intended (assignment context, argument passing, return of inner block matching outer signature).
+
+`unify` keeps its role: it is the substitution resolver for type variables. It should not be confused with subtyping.
+
+### Fixture obligations
+
+For each rule above, fixtures live under `tests/types/valid/` and `tests/types/errors/`.
+
+Numeric tower fixtures:
+
+- `subtype_int_to_int64` (valid).
+- `subtype_int_to_bigint` (valid).
+- `subtype_bigint_to_bigrat` (valid).
+- `subtype_float_unrelated_to_bigint` (valid: result widens to bigrat).
+- `subtype_string_not_int` (error).
+
+List variance fixtures:
+
+- `variance_list_read_covariant` (valid, snapshots current behaviour).
+- `variance_list_write_invariant` (error, after MEP 10 A3 lands).
+
+Map invariance fixtures:
+
+- `variance_map_key_invariant` (error).
+- `variance_map_value_invariant` (error).
+
+Function variance fixtures:
+
+- `variance_fun_arg_contravariant` (valid, after fix).
+- `variance_fun_result_covariant` (valid, after fix).
+- `variance_fun_arg_covariant_rejected` (error).
+
+Tagged union variance fixtures:
+
+- `subtype_variant_to_union` (valid).
+- `subtype_union_to_variant_via_cast` (valid via `as`, with runtime guard).
+
+`any` escape hatch fixtures:
+
+- `any_top_silent_widen` (valid, snapshots current loose behaviour).
+- `any_to_int_via_cast` (valid, after the cast tightening lands).
+- `any_to_int_no_cast` (error, after the cast tightening lands).
+
+## Rationale
+
+Splitting `subtype` from `unify` is the smallest refactor that lets us reason about the two distinct relationships independently. The variance table is standard. We choose nominal record subtyping because it matches the structural identity that `StructType` already carries through its `Name` field.
+
+We accept lossy `float <: bigrat` because the alternative is forcing every numeric mix to widen to a non-comparable join. Programs that care about precision should declare types explicitly and not rely on the default join.
+
+## Backwards Compatibility
+
+Tightening `any` to require an explicit cast is a breaking change. Programs that rely on the current "any in either direction" behaviour will fail to type-check. We pin the current behaviour in `any_top_silent_widen` and document the migration in this MEP.
+
+Adding the runtime guard for `any as T` is a behavioural change rather than a type-check change. Programs that previously crashed in unspecified ways now raise a typed runtime error.
+
+## Reference Implementation
+
+- `types/check.go:148-387` — current `unify`.
+- `types/infer.go` — current `equalTypes`.
+- `types/check.go:1687-1688` — current `as` cast (no compatibility check).
+
+## Open Questions
+
+- **Lossy `float` to `bigrat`.** Whether to include this in the lattice or to require an explicit cast.
+- **Width subtyping for inline struct parameters.** Adopt or defer.
+- **Bounded quantification.** TAPL chapter 26. Out of scope for v0.11.0; revisit when sorted query support generalises beyond numeric and string ordering.
+
+## References
+
+- Benjamin C. Pierce, *Types and Programming Languages*, chapters 15 and 26.
+
+## Copyright
+
+This document is placed in the public domain.

--- a/website/docs/mep/mep-0012.md
+++ b/website/docs/mep/mep-0012.md
@@ -1,0 +1,160 @@
+---
+mep: 12
+title: Parametric Polymorphism
+author: Mochi core
+status: Draft
+type: Standards Track
+created: 2026-05-08
+sidebar_position: 12
+sidebar_label: MEP 12 — Polymorphism
+description: Wire TypeVar through inference so generic call sites unify properly.
+---
+
+# MEP 12 — Parametric Polymorphism
+
+| Field    | Value                       |
+|----------|-----------------------------|
+| MEP      | 12                          |
+| Title    | Parametric Polymorphism     |
+| Author   | Mochi core                  |
+| Status   | Draft                       |
+| Type     | Standards Track             |
+| Created  | 2026-05-08                  |
+
+## Abstract
+
+Mochi has the syntax of generics but not the inference. `TypeVar` exists, the grammar accepts type parameter lists, but call sites do not unify variables across argument and result positions. This MEP proposes a small System F-lite algorithm that wires `TypeVar` through the call site, removes most of the `any`-typed builtins, and gives callers precise types.
+
+## Motivation
+
+The looseness around generic call sites is the largest single source of `any` in Mochi today. Builtins like `len`, `first`, and `push` are declared with `any` parameters because authors found inference would not propagate the variable. Tightening them is gated on this MEP. Once it lands, the soundness gains compound: less `any` everywhere, sharper error messages, fewer escape hatches.
+
+## Specification
+
+### Today
+
+`TypeVar{Name string}` exists in `types/check.go:104`. The grammar admits type parameter lists on functions and on inline lambdas. Calls do not unify type variables across positions in a meaningful way, so the language has the syntax of generics but not the inference.
+
+Concretely:
+
+- `fun id<T>(x: T): T` parses and checks. Inside the body, `T` is a fresh type variable.
+- A call site `id(7)` is typed by looking up `id` and walking the declared signature. The result type comes back as `T`, which then appears as the type of the let binding because there is no substitution from `x : T` to `T = int`.
+- Many builtins are declared with `AnyType{}` parameters and return types instead of using `TypeVar`, because authors found inference would not propagate the variable.
+
+The result is a system that accepts more programs than a sound parametric system would, with the looseness leaking into call sites that should be precisely typed.
+
+### Target
+
+Standard ML or System F-lite. The deliverable for v0.11.0:
+
+- Each generic function declares a list of type parameters.
+- Each call site allocates fresh type variables for the parameters.
+- Argument unification produces a substitution.
+- The result type is the declared result with the substitution applied.
+- Conflicting unifications are an error with a new code.
+- Type parameters do not escape unless they appear in the declared result type.
+
+Higher-kinded polymorphism is out of scope.
+
+### Inference algorithm
+
+Hindley-Milner is overkill for what Mochi needs. A small algorithm:
+
+1. On call `f(a1, ..., an)` where `f` has signature `<G1, ..., Gk>(P1, ..., Pn) : R`:
+   1. Allocate fresh `TypeVar` instances `T1, ..., Tk` for `G1, ..., Gk`.
+   2. Substitute `Gi -> Ti` in the parameter and result types.
+   3. For each argument `ai`, infer `Ai` and call `unify(Pi[s], Ai)`, accumulating the substitution.
+   4. Return `R[s]`. If any free `Ti` remains in `R[s]`, it is an escaped variable: error.
+2. `unify(s, t)`:
+   - If both are concrete and equal, success.
+   - If one is a `TypeVar` not yet bound, bind to the other (with occurs check).
+   - If both are constructors of the same shape (`ListType`, `MapType`, `FuncType`), recurse on components.
+   - Otherwise, error.
+
+This is a single pass per call site. No global generalisation, which matches the language's value semantics where every function has a declared type.
+
+### Surface effects
+
+Once parametric inference works, builtins are tightened:
+
+- `len(any) : int` becomes `len<T>([T]) : int` plus a string overload.
+- `first<T>([T]) : T` plus an option to indicate emptiness.
+- `push<T>([T], T) : [T]`.
+- `append<T>([T], T) : [T]` plus a variadic form `concat<T>([T], ...) : [T]`.
+- `keys<K, V>({K: V}) : [K]`.
+- `values<K, V>({K: V}) : [V]`.
+- `range(int, ...) : [int]` stays monomorphic.
+
+User-defined generics:
+
+- `id<T>(x: T) : T` flows through inferred types.
+- `pair<A, B>(a: A, b: B) : Pair<A, B>` requires generic struct declarations. The grammar does not have those today; we mark this as a follow-up.
+
+### Parametricity
+
+Once inference is sound, we get the standard parametricity guarantees:
+
+- A function of type `T -> T` either returns its argument or does not return.
+- A function of type `[T] -> [T]` produces a list whose elements are drawn from the input.
+- `map<A, B>(xs: [A], f: fun(A): B) : [B]` commutes with composition.
+
+We add fixtures that snapshot these properties as runtime equality assertions on small examples.
+
+### Fixtures to author
+
+For v0.11.0:
+
+- `generic_id_int_string`. A `fun id<T>(x: T): T` called with both types, asserting the inferred result types.
+- `generic_first_list_int`. `first<T>([T]): T` on `[1, 2, 3]`.
+- `generic_pair_arg_unify`. A two-parameter generic that requires the two arguments to share a type variable. Error case is a conflicting use.
+- `generic_freshness_per_call`. Two calls of the same function with different argument types do not produce a unification error.
+- `generic_escaping_variable`. A function that does not bind a type parameter through arguments or result is rejected.
+- `generic_constraint_arity`. Calling a generic with the wrong number of explicit type arguments is rejected.
+
+Once user-defined generic structs land, add:
+
+- `generic_struct_pair`.
+- `generic_struct_constructor_inference`.
+
+### Migration plan
+
+1. Wire `subst Type -> Type` and `unify(s, t, subst)` cleanly. Keep the existing entry points until the new ones are proven against the suite.
+2. Move builtins one by one from `AnyType` parameters to `TypeVar` parameters. After each move, run the type valid suite.
+3. Remove the loose builtin declarations.
+4. Tighten the call site checker to use the new substitution path.
+5. Author fixtures and update MEP 9.
+
+## Rationale
+
+A small, deterministic algorithm beats Hindley-Milner for our use case. We do not want let-generalisation. Every function in Mochi has a declared signature, so we know exactly which type variables to introduce. The trade-off is that we cannot infer signatures for unannotated functions, and we are happy with that.
+
+Bounded quantification (`T extends Comparable`) is out of scope. The need has not surfaced in idiomatic Mochi code. We may revisit when sorted query support is generalised beyond the built-in numeric and string ordering.
+
+Subtype polymorphism on tagged unions stays as it is in MEP 11. The generic parameter mechanism is independent of variant subtyping.
+
+## Backwards Compatibility
+
+Tightening builtins from `any` to `TypeVar` is a breaking change for any program that relied on the looseness. The migration plan moves builtins one at a time so we can audit the breakage at each step.
+
+User-defined generic functions that used to compile because of the loose typing may fail under the new algorithm. We pin the current behaviour in fixtures and document the change.
+
+## Reference Implementation
+
+- `types/check.go:104` — current `TypeVar`.
+- `types/check.go:148-387` — current `unify` (to be split into substitution-aware form).
+- `types/check.go:393-562` — builtins that need tightening.
+
+## Open Questions
+
+- **Generic struct declarations.** Required for `Pair<A, B>` and friends. Grammar change is non-trivial.
+- **Type argument inference at call sites.** Whether to require explicit type arguments at the call (`id<int>(7)`) or always infer. We prefer always-infer with explicit arguments as an opt-in.
+- **Bounded quantification.** TAPL chapter 26. Defer.
+
+## References
+
+- Benjamin C. Pierce, *Types and Programming Languages*, chapters 22 and 23.
+- Andrew K. Wright, "Polymorphism for Imperative Languages without Imperative Types", 1995.
+
+## Copyright
+
+This document is placed in the public domain.

--- a/website/docs/mep/mep-0013.md
+++ b/website/docs/mep/mep-0013.md
@@ -1,0 +1,207 @@
+---
+mep: 13
+title: Algebraic Data Types and Match
+author: Mochi core
+status: Draft
+type: Standards Track
+created: 2026-05-08
+sidebar_position: 13
+sidebar_label: MEP 13 — ADTs
+description: Struct and union typing rules, match exhaustiveness, irredundancy, and recursive types.
+---
+
+# MEP 13 — Algebraic Data Types and Match
+
+| Field    | Value                       |
+|----------|-----------------------------|
+| MEP      | 13                          |
+| Title    | Algebraic Data Types and Match |
+| Author   | Mochi core                  |
+| Status   | Draft                       |
+| Type     | Standards Track             |
+| Created  | 2026-05-08                  |
+
+## Abstract
+
+Mochi has product types (structs) and sum types (tagged unions). The grammar accepts both. Pattern matching exists but does not enforce exhaustiveness or irredundancy today. This MEP documents the typing rules, proposes the missing checks, and lists the fixtures that pin both the current behaviour and the target behaviour.
+
+## Motivation
+
+Match exhaustiveness is the single largest class of type error that Mochi catches at runtime instead of at compile time. Adding a variant to a union and forgetting to update one of the matches on it produces a runtime crash that the type checker should have caught. This MEP closes that gap.
+
+## Specification
+
+### Surface
+
+Mochi has two ADT shapes.
+
+Product types: structs.
+
+```
+type Point {
+  x: int
+  y: int
+}
+```
+
+Sum types: tagged unions.
+
+```
+type Shape =
+  Circle(r: float)
+| Square(side: float)
+| Rect(w: float, h: float)
+```
+
+Aliases:
+
+```
+type Id = int
+type Name = string
+```
+
+The surface is documented in MEP 2 (grammar) and MEP 3 (AST). This MEP focuses on typing and pattern matching obligations.
+
+### Struct typing
+
+A struct declaration introduces:
+
+- A `StructType` in the type environment under the declared name.
+- A constructor of type `fun(field1: T1, ...): Name` accessed as the type name in expression position.
+- A struct literal form `Name{field1: e1, field2: e2}`. Order is flexible; the literal matches by field name.
+
+Rules:
+
+- All fields must be present in a literal. There are no defaults today.
+- A field type mismatch raises `T008` or `T026` depending on shape.
+- Field access `s.f` requires `s : StructType{...}` containing `f`. Otherwise `T026` (unknown field) or `T027` (not a struct).
+
+Methods (`type T { fun foo(...) }`) attach to the struct via the `Methods` map and become callable as `t.foo(...)`. The receiver is implicit.
+
+### Union typing
+
+A union declaration introduces:
+
+- A `UnionType{Name, Variants}`.
+- One constructor function per variant. `Circle(r: float) : Shape`.
+- Each variant is also a `StructType` under its name with the variant's fields, so `let c: Circle = Circle(1.0)` parses but the canonical type is `Shape`.
+
+Rules:
+
+- A variant constructor must be called with the declared arity and field types.
+- A bare variant name (no parens) is rejected today, although the grammar may allow it. Document and pin the behaviour.
+- Recursion in variants (`type List = Cons(head: int, tail: List) | Nil`) is allowed because variants resolve in a shared map during the type decl walk.
+
+### Match typing
+
+`match e { p1 => r1, ..., pn => rn }`.
+
+Pattern shapes accepted today:
+
+- Literal: `1`, `"x"`, `true`, `false`. Matches by equality. Binds nothing.
+- Identifier: matches anything, binds the name in the arm body.
+- Underscore: matches anything, binds nothing.
+- Variant call: `Circle(r)`, `Rect(w, h)`. Matches a value of the named variant and binds field positions to the listed identifiers. The number of bindings must match the variant arity.
+
+Result type. The arm result type is the join of `ExprType(ri)`. With the current loose join this often degrades to `any` when arms differ. Tightening the join to a least upper bound is part of the v0.11.0 work.
+
+### Exhaustiveness
+
+Today: not enforced. A match on a `Shape` with only `Circle(_)` arms is accepted. The runtime raises an error when no arm matches.
+
+Target. Compute coverage during the match check:
+
+- For a scrutinee of `UnionType U`:
+  - Walk arms, mark each named variant covered.
+  - A bare identifier or underscore arm marks the rest covered, but only if it is the last arm.
+  - At the end, if any variant remains uncovered and there is no catch-all, raise an error with a list of missing variants.
+- For a scrutinee of any other type, exhaustiveness is not required. A wildcard or an identifier arm always covers the rest.
+
+The required diagnostic message:
+
+```
+match is not exhaustive: missing cases for Square, Rect
+```
+
+### Irredundancy
+
+Detect arms that cannot match because an earlier arm subsumes them:
+
+- Two arms with the same literal pattern: error.
+- A wildcard before any variant arm: error (the variant arm is unreachable).
+- Two arms with the same variant pattern: error if the bindings are disjoint or if either arm has no guard. Since we do not have pattern guards yet, the duplicate case always fires the error.
+
+### Recursive ADTs
+
+Support `type List = Cons(head: int, tail: List) | Nil`. Tests:
+
+- A literal `Cons(1, Cons(2, Nil))` type checks.
+- Length defined as a recursive function over the list type checks.
+- A match on the list with both variants covered is exhaustive.
+- A match missing `Nil` is rejected.
+
+### Generic ADTs (future)
+
+The grammar does not support `type List<T> = Cons(head: T, tail: List<T>) | Nil` today. The required pieces:
+
+- Generic type declaration syntax.
+- Generic constructor types parameterised by the type parameters.
+- Generic match patterns that accept a type argument list at the variant call.
+
+We mark this as future work. The parser changes are non-trivial and MEP 12 (polymorphism) needs to land first.
+
+### Fixtures to author
+
+Existing positive fixtures:
+
+- `user_types_basic`, `user_type_selector`, `nested_type_decl`, `match_expr`, `union_alias`, `match_union_variant`, `match_literal_pattern`, `struct_field_access`.
+
+New for v0.11.0:
+
+- `adt_struct_field_present_required` (error, missing field).
+- `adt_struct_extra_field` (error, unknown field, T026).
+- `adt_union_constructor_arity` (error, exists as `match_variant_arity`).
+- `adt_union_constructor_field_type` (error).
+- `adt_match_exhaustive_simple` (valid).
+- `adt_match_missing_one` (error, after enforcement lands).
+- `adt_match_missing_two` (error, after enforcement lands; checks both names appear in the message).
+- `adt_match_redundant_variant` (error, after irredundancy lands).
+- `adt_match_wildcard_before_variant` (error, after irredundancy lands).
+- `adt_match_wildcard_last_ok` (valid).
+- `adt_recursive_list_length` (valid).
+- `adt_recursive_match_missing_nil` (error).
+
+## Rationale
+
+Match exhaustiveness is the textbook benefit of sum types. Without it, a large part of the value of declaring a union evaporates. Irredundancy is the other half: redundant arms hide bugs.
+
+Recursive types are necessary for any non-trivial use of unions. The shared-variants resolution path we already have makes this cheap to support.
+
+We defer generic ADTs because they require both grammar and inference work. MEP 12 needs to land first.
+
+## Backwards Compatibility
+
+Adding exhaustiveness checking is a breaking change for any program that relies on the runtime fall-through. Programs will need an explicit catch-all arm or coverage of every variant.
+
+Irredundancy rejection is also a breaking change but a smaller one: the redundant arms it rejects could not have fired in the first place.
+
+## Reference Implementation
+
+- `types/check.go:1179-1207` — union type construction with shared variants map.
+- `types/check.go` around lines 2209 to 2284 — match arm walk.
+- Existing fixtures: `tests/types/valid/match_union_variant.mochi`, `tests/types/errors/match_variant_arity.mochi`.
+
+## Open Questions
+
+- **Pattern guards.** `case x => x > 0`. Out of scope for v0.11.0; revisit if the test surface demands it.
+- **Or-patterns.** `Circle(_) | Square(_) => ...`. Useful for catch-some-but-not-all cases. Defer.
+- **Nested patterns.** `Cons(1, _)` over recursive types. Already partially supported; needs fixtures.
+
+## References
+
+- Benjamin C. Pierce, *Types and Programming Languages*, chapters 11 and 20.
+- Luc Maranget, "Compiling pattern matching to good decision trees", 2008.
+
+## Copyright
+
+This document is placed in the public domain.

--- a/website/docs/mep/mep-0014.md
+++ b/website/docs/mep/mep-0014.md
@@ -1,0 +1,190 @@
+---
+mep: 14
+title: Query Algebra
+author: Mochi core
+status: Informational
+type: Informational
+created: 2026-05-08
+sidebar_position: 14
+sidebar_label: MEP 14 — Queries
+description: LINQ-shaped query expressions, clause-by-clause type rules, and aggregate semantics.
+---
+
+# MEP 14 — Query Algebra
+
+| Field    | Value                       |
+|----------|-----------------------------|
+| MEP      | 14                          |
+| Title    | Query Algebra               |
+| Author   | Mochi core                  |
+| Status   | Informational               |
+| Type     | Informational               |
+| Created  | 2026-05-08                  |
+
+## Abstract
+
+Mochi has LINQ-shaped query expressions: `from` ... `select` with optional `where`, `join`, `group`, `sort`, `skip`, `take`, and `distinct`. This MEP documents the type rules per clause, the aggregate operators, the join cardinalities, and the soundness gaps that today's implementation accepts.
+
+## Motivation
+
+Queries are how a lot of real Mochi programs are written. The clause type rules touch most of the type system: list types, group types, predicates, ordered values. A single document with the rules per clause keeps the implementation honest.
+
+## Specification
+
+### Surface
+
+Mochi queries are LINQ-shaped. They start with a `from` and end with a `select`. The clause set:
+
+```
+from x in source
+{ from y in source }*
+{ [side] join z in source on cond }*
+[ where pred ]
+[ group by k1, ..., kn into g [ having pred ] ]
+[ ( sort | order ) by expr ]
+[ skip n ]
+[ take n ]
+select [ distinct ] proj
+```
+
+Required: `from` and `select`. Everything else is optional. The order is fixed by the grammar.
+
+### Type rules per clause
+
+`from x in xs` requires `xs : [T]`. Inside the body of the query, `x : T`. T032 fires when the source is not a list.
+
+Additional `from y in ys` clauses behave like nested loops. The projection sees both `x` and `y` in scope. There is no implicit cross-join elision; the result enumerates the cartesian product unless joined.
+
+`join z in zs on cond` requires `zs : [U]` (T034) and `cond : bool` (T035). The join side modifier (`left`, `right`, `outer`) controls the cardinality of unmatched rows. A left join may produce `z = null` for unmatched outer rows; today this returns `any` because of MEP 10 A2.
+
+`where pred` requires `pred : bool` (T033). The body filters rows.
+
+`group by k1, ..., kn into g` partitions by the key tuple and binds `g : group<K, T>` where `K` is the key type (a tuple if multiple) and `T` is the source row type. The `having` clause requires `bool` (T042).
+
+`sort by expr`. The expression must be ordered. Today the checker accepts any expression and the runtime sorts using a generic comparator. Negation prefix (`-expr`) sorts descending. We should add a fixture asserting an unordered type (e.g. struct) is rejected, but that requires the comparator to type fail rather than silently fail.
+
+`skip n` and `take n` require `n : int`.
+
+`select expr` returns `[U]` where `U = ExprType(expr)`. Inside `select` the iteration variables are in scope.
+
+`select distinct expr` is the same with deduplication. The element type must be hashable. Today the runtime falls back to string keys under the hood.
+
+### Aggregate operators
+
+These are functions that take a list or a group and return a scalar:
+
+- `count(g) : int`. Accepts list or group.
+- `sum(g) : T` where `T` is numeric.
+- `avg(g) : float` for ints, `bigrat` for big numerics.
+- `min(g) : T` and `max(g) : T` for ordered `T`.
+
+T037, T038, T041 cover misuse of the aggregates.
+
+### Joins and cardinality
+
+Inner join: rows with matching `cond`. Output cardinality is the intersection of left and right.
+
+Left join: every left row appears, with `null` filling unmatched right-side bindings. Right join is symmetric. Outer join produces both sides.
+
+Cardinality fixtures:
+
+- Inner join on `id` with two rows on each side, two matches: result has two rows.
+- Left join with one unmatched left row: result has the matched row and one row with the right side `null`.
+- Outer join with disjoint sides: result has the union of rows.
+
+The current `null` behaviour falls under MEP 10 A2 (null is `any`). Once options are wired, the right-side bindings in a left join become `Option<T>` and pattern matching is required to access them.
+
+### Group plan and types
+
+`group by k1, ..., kn into g`. Inside the rest of the query, `g` has type `group<K, T>` where `K` is the key tuple and `T` is the source row type. Aggregates over `g` are typed:
+
+- `count(g) : int`
+- `sum(g.field) : T` if `T : numeric`
+- `avg(g.field) : float | bigrat`
+- `min(g.field) : T`, `max(g.field) : T`
+
+The group plan builder lives at `types/query_plan_builder.go` and emits a structured plan that the runtime consumes. The plan is also golden-tested under `tests/queryplan/`.
+
+### Distinct
+
+`select distinct e` deduplicates by structural equality on `e`. Today the runtime canonicalises through a string form. We should add an explicit hashing path once the type system has hashable bounds, or constrain `select distinct` to types with a known canonical form (primitives, lists of primitives, structs of primitives).
+
+### sort by
+
+`sort by e` orders the result by `e` ascending. `sort by -e` reverses. The expression should be of an ordered type:
+
+- Numeric.
+- String.
+- Bool.
+- Tuple of ordered types.
+
+Today the checker accepts any expression. We should reject unordered expressions (structs without a declared comparator, list element types unless we lift the order to the lexicographic order) once the "ordered" trait is decided.
+
+### skip and take
+
+Both require `n : int` and `n >= 0`. Negative values cause runtime errors. Adding a runtime guard or rejecting at type check time when the expression is a literal negative number would be a small win.
+
+### Soundness obligations
+
+- A query whose source is not a list raises T032.
+- A `where` whose predicate is not `bool` raises T033.
+- A `having` whose predicate is not `bool` raises T042.
+- An aggregate misuse raises T037, T038, or T041.
+- The result type of a query is `[U]` where `U` is the projected type.
+
+Targets:
+
+- Reject sort expressions with unordered types.
+- Reject join with non-list right-hand side.
+- Reject `take` and `skip` with non-int.
+
+### Fixtures to author
+
+Existing:
+
+- `query_source_not_list`, `join_on_not_bool`, `join_source_not_list`, `count_invalid_type`, `avg_non_numeric`, `query_basic_select`, `query_sort_take`.
+
+New:
+
+- `query_select_struct_proj` (valid).
+- `query_where_bool_required` (error).
+- `query_take_int_required` (error).
+- `query_skip_int_required` (error).
+- `query_distinct_int` (valid).
+- `query_distinct_struct_canonical` (valid; pinned current behaviour).
+- `query_join_inner_cardinality` (valid, snapshots row count).
+- `query_join_left_unmatched_null` (valid, current behaviour pre A2).
+- `query_join_outer_both_sides` (valid).
+- `query_group_having_bool_required` (error).
+- `query_group_aggregate_int_sum` (valid).
+- `query_group_aggregate_avg_float` (valid).
+
+## Rationale
+
+LINQ-shaped queries are familiar, simple to teach, and easy to translate to a relational plan. We keep the clause order fixed because that simplifies the parser and makes the plan obvious.
+
+The `null`-from-left-join hack is a known wart. Once MEP 10 A2 lands, the right-side bindings become `Option<T>` and pattern matching is required to access them. We accept the wart in the meantime because changing it requires the option work.
+
+## Backwards Compatibility
+
+Tightening sort, distinct, and skip/take to type-check at compile time is a breaking change for programs that rely on the loose runtime semantics. We pin the current behaviour in fixtures.
+
+## Reference Implementation
+
+- `types/check.go` — query type checking entry points.
+- `types/query_plan_builder.go` — group plan construction.
+- `tests/queryplan/` — golden tests for the plan.
+
+## Open Questions
+
+- **Ordered trait.** Decide between an explicit interface for `min`, `max`, `sort` or a hard-coded list of orderable kinds.
+- **Hashable trait.** Same question for `distinct` and group keys.
+- **Right-side `null` in left join.** Tied to MEP 10 A2.
+
+## References
+
+- LINQ specification: https://learn.microsoft.com/dotnet/csharp/linq/.
+
+## Copyright
+
+This document is placed in the public domain.

--- a/website/docs/mep/mep-0015.md
+++ b/website/docs/mep/mep-0015.md
@@ -1,0 +1,170 @@
+---
+mep: 15
+title: Effects, Mutability, and Purity
+author: Mochi core
+status: Draft
+type: Standards Track
+created: 2026-05-08
+sidebar_position: 15
+sidebar_label: MEP 15 — Effects
+description: Mutability, aliasing, the Pure flag, and side-effecting builtins.
+---
+
+# MEP 15 — Effects, Mutability, and Purity
+
+| Field    | Value                       |
+|----------|-----------------------------|
+| MEP      | 15                          |
+| Title    | Effects, Mutability, and Purity |
+| Author   | Mochi core                  |
+| Status   | Draft                       |
+| Type     | Standards Track             |
+| Created  | 2026-05-08                  |
+
+## Abstract
+
+Mochi is not effect-typed. There is no row of effects on function arrows. What we do have is a `Pure` flag on `FuncType`, a `let` versus `var` distinction on bindings, and a small set of side-effecting builtins. This MEP documents the current state, proposes a tightening of mutability checks under index and field operations, and asks whether to keep or remove the unenforced `Pure` flag.
+
+## Motivation
+
+Today `let` is half-immutable: top-level reassignment is rejected, but `let xs = [1]; xs[0] = 9` is accepted. The half-enforcement is a soundness gap and a footgun. Either we honour the `let` contract everywhere or we drop it.
+
+## Specification
+
+### What "effect" means here
+
+Mochi is not effect-typed. There is no row of effects on function arrows. The pieces we do have:
+
+- `Pure` flag on `FuncType`. Set on builtins that are deterministic pure functions and on user functions whose bodies are inferred pure. Not enforced at call sites today.
+- `let` versus `var` mutability annotation on bindings. Enforced for top-level reassignment, partially enforced for nested mutation (MEP 10 A3).
+- I/O statements: `print`, `json`, `fetch`, `load`, `save`. These are not flagged by the type system; the programmer knows they are effectful from the function name.
+
+### Mutability today
+
+The state of mutability checks:
+
+- `let x = e`. Reassignment of `x` raises T024.
+- `var x = e`. Reassignment of `x` is allowed.
+- `let xs = [1, 2]; xs[0] = 9`. Accepted today. Should be rejected.
+- `let p = {x: 1, y: 2}; p.x = 9` for a struct `p`. Accepted today. Should be rejected.
+- `let mp = {"a": 1}; mp["a"] = 9`. Accepted today. Should be rejected because `mp` is `let`.
+
+The fix described in MEP 10 A3 is to inspect the mutability of the root binding of an `AssignStmt`, walking through `Index` and `Field` ops to find the root.
+
+Closures complicate this. A closure that captures a `var` binding can mutate it. A closure that captures a `let` binding cannot reassign it but today can mutate through indices and fields in the same way as above. After A3, closures should follow the same rule.
+
+### Aliasing
+
+There is no aliasing analysis. Two bindings can refer to the same underlying value:
+
+```
+let xs = [1, 2, 3]
+var ys = xs
+ys[0] = 9     # observable through xs?
+```
+
+Runtime semantics for lists and maps are reference-based, so the mutation is observable. After A3, the example above becomes a type error at the `ys[0] = 9` line because the root binding of `ys` is `var`, but the underlying list still aliases `xs`. We accept that.
+
+If we wanted unique ownership, we would need a substructural discipline. It is out of scope.
+
+### Pure flag
+
+The `Pure: true` field on builtins is currently a label without enforcement. Two design directions:
+
+A. **Drop the flag.** It is unused and misleads readers.
+
+B. **Enforce the flag in specific contexts.** Candidates:
+
+- Type alias arguments. `type Adult = filter(People, isAdult)` (does not exist today, but if we add type-level computation, the function would have to be pure).
+- Query predicates. `where` and `having` should be pure to give the optimiser room to reorder.
+- Struct field defaults (does not exist today).
+
+Direction B is more honest. The minimum viable enforcement: require `where` and `having` predicates to call only pure functions. This is a conservative rule and easy to test.
+
+### Side-effecting builtins
+
+The builtins that have side effects:
+
+- `print`. Writes to stdout.
+- `json`. Writes pretty JSON to stdout.
+- `now`. Reads the clock (not pure even though it is read-only).
+- `fetch`. Network I/O.
+- `load`. File I/O (or stdin when path is omitted).
+- `save`. File I/O (or stdout when path is omitted).
+- `update`. Mutates a stored entity.
+
+If we adopt direction B above, these stay non-pure and any call to them is rejected in the pure positions.
+
+### Effect on equality and reordering
+
+The current semantics are sequential. There is no implicit parallelism. Reordering of function calls is not safe.
+
+Once query optimisation matters (it does for the SQL-like surface), we will want to:
+
+- Know that a `where` predicate is pure so we can push it through joins.
+- Know that an aggregate function is pure so the optimiser can parallelise.
+
+This is the practical motivation for direction B. We do not need a general effect system, just a "pure" flag we trust.
+
+### Resource management
+
+There is no `try` or RAII-like construct. Resources opened by `load` are released when the program exits. We are happy with that. If we add long-lived processes, we revisit.
+
+### Mutability of struct fields
+
+A struct declared `type Point { x: int, y: int }` has fields that are implicitly mutable through a `var` binding and immutable through a `let` binding. There is no per-field `let` or `var` keyword inside a struct. We do not propose adding one; it adds complexity for little practical benefit.
+
+### Fixtures
+
+Existing:
+
+- `assign_to_let` (error).
+- `var_mutable` (valid).
+- `map_assign_immutable` (error, partial).
+- `assign_undeclared_var` (error).
+
+New:
+
+- `mutate_let_index_rejected` (error, after A3).
+- `mutate_let_field_rejected` (error, after A3).
+- `mutate_let_map_key_rejected` (error, after A3 and applies to map).
+- `mutate_var_index_ok` (valid).
+- `mutate_var_field_ok` (valid).
+- `mutate_var_map_key_ok` (valid).
+- `closure_mutates_let_via_index` (error after A3, valid today).
+- `closure_mutates_var_ok` (valid).
+- `pure_in_where_ok` (valid, after pure enforcement).
+- `impure_in_where_rejected` (error, after pure enforcement).
+
+## Rationale
+
+Tightening mutability under index and field assignments matches what users expect from `let`. Without it, `let` is a partial promise, and partial promises are worse than no promise.
+
+Direction B for the pure flag pays for itself the moment we want to push predicates through joins. Direction A is cheaper but throws away an existing investment. We recommend B.
+
+## Backwards Compatibility
+
+Tightening A3 is a breaking change for programs that mutate `let` bindings through indices or fields. The fixture set captures the current behaviour and the migration path is to change `let` to `var` at the binding site.
+
+Pure enforcement is a breaking change for programs that call impure functions from `where` or `having`. The migration is to move the impure work outside the predicate.
+
+## Reference Implementation
+
+- `types/check.go` — current mutability check on `AssignStmt`.
+- `types/check.go:393-562` — `Pure` flag on builtin registrations.
+- `types/env.go:179, 187` — env shadowing without warning.
+
+## Open Questions
+
+- **Direction A or B for the pure flag.** Recommendation is B. Need consensus.
+- **Aliasing analysis.** Out of scope, but worth flagging when we revisit.
+- **Resource scoping.** No `try`/RAII today; revisit if long-lived processes land.
+
+## References
+
+- Benjamin C. Pierce, *Types and Programming Languages*, chapter 13.
+- Eric Holk et al., "Mochi" — internal design notes on streams and intents.
+
+## Copyright
+
+This document is placed in the public domain.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -92,6 +92,12 @@ const config = {
             label: 'Reference',
           },
           {
+            type: 'docSidebar',
+            sidebarId: 'mepSidebar',
+            position: 'left',
+            label: 'MEPs',
+          },
+          {
             to: '/docs/roadmap',
             label: 'Roadmap',
             position: 'left',

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -57,6 +57,49 @@ const sidebars = {
     'reference/operators',
     'reference/builtins',
   ],
+
+  mepSidebar: [
+    'mep/mep-0000',
+    {
+      label: 'Foundations',
+      type: 'category',
+      className: 'sidebar-heading',
+      collapsed: false,
+      items: [
+        'mep/mep-0001',
+        'mep/mep-0002',
+        'mep/mep-0003',
+        'mep/mep-0004',
+        'mep/mep-0005',
+        'mep/mep-0006',
+      ],
+    },
+    {
+      label: 'Soundness',
+      type: 'category',
+      className: 'sidebar-heading',
+      collapsed: false,
+      items: [
+        'mep/mep-0007',
+        'mep/mep-0008',
+        'mep/mep-0009',
+        'mep/mep-0010',
+      ],
+    },
+    {
+      label: 'Standards Track',
+      type: 'category',
+      className: 'sidebar-heading',
+      collapsed: false,
+      items: [
+        'mep/mep-0011',
+        'mep/mep-0012',
+        'mep/mep-0013',
+        'mep/mep-0014',
+        'mep/mep-0015',
+      ],
+    },
+  ],
 };
 
 module.exports = sidebars;


### PR DESCRIPTION
## Summary

Publishes the Mochi Enhancement Proposal (MEP) series as public documentation on the website. MEPs are Mochi's design-document format, modeled on Python PEPs.

- **MEP 0** is the index, listing every MEP with status and type.
- **MEP 1–6** (Foundations) cover process, lexer, grammar, type system, inference, and runtime semantics.
- **MEP 7–10** (Soundness) cover soundness theorems, the test layer plan, the fixture catalogue, and outstanding type-system issues.
- **MEP 11–15** (Standards Track) cover subtyping & variance, polymorphism, ADTs, queries, and effects.

Each MEP follows a PEP-style structure: header table, Abstract, Motivation, Specification, Rationale, Backwards Compatibility, Reference Implementation, Open Questions, References, Copyright.

The website wiring:
- New \`mepSidebar\` in \`website/sidebars.js\` with three groups (Foundations, Soundness, Standards Track).
- New **MEPs** navbar item in \`website/docusaurus.config.js\`.
- New **Design proposals** section on the docs landing page linking to MEP 0.

## Test plan

- [x] \`npm --prefix website run build\` succeeds.
- [x] \`website/build/docs/mep/mep-{0000..0015}.html\` all exist after the build.
- [ ] Reviewer skims MEP 0 and one or two of the more substantive MEPs (e.g. MEP 7, MEP 11) for prose quality.

Closes #21140