### PR TITLE
MEP 7: pin obligations to fixtures and list two more stuck states

### DIFF
--- a/website/docs/mep/mep-0007.md
+++ b/website/docs/mep/mep-0007.md
@@ -64,10 +64,28 @@ Stuck states we want to rule out:
 - Adding a string to an integer.
 - Pattern matching against a value with no matching arm and no wildcard.
 - Reading a non-existent struct field.
+- Dividing an integer by zero. The runtime raises today; the type system does not flag the literal case.
+- Reading a missing map key without a default. Today the runtime returns the zero value of the map's value type, which violates progress for non-zero-bearing types. Tracked in MEP 4.
 
 ### Property-by-property obligations
 
-The properties below are the test obligations against which fixtures are built. Each property points at the MEP where the rules live and at the fixture group in `tests/types/`.
+The properties below are the test obligations against which fixtures are built. Each property points at the MEP where the rules live and at the fixture group in `tests/types/`. The full coverage matrix lives in MEP 9; the table here is the inline summary for reviewers who want to confirm a property has at least one fixture without leaving this MEP.
+
+| Property              | Source MEP | Fixture pointer                                  |
+|-----------------------|------------|--------------------------------------------------|
+| Progress, primitives  | MEP 4      | `tests/types/valid/canonical_*`                  |
+| Progress, list/map    | MEP 4      | `tests/types/valid/list_*`, `map_*`              |
+| Progress, function    | MEP 4      | `tests/types/valid/closure_*`                    |
+| Preservation          | MEP 5      | `tests/types/valid/preservation_let_chain.mochi` |
+| Inversion             | MEP 5      | `tests/types/valid/inversion_*`                  |
+| Canonical, bool       | MEP 4      | `tests/types/valid/canonical_bool_only.mochi`    |
+| Canonical, int        | MEP 4      | `tests/types/valid/canonical_int_arithmetic.mochi` |
+| Canonical, string     | MEP 4      | `tests/types/valid/canonical_string_concat.mochi` |
+| Substitution          | MEP 5      | `tests/types/valid/preservation_let_chain.mochi` |
+| Variance              | MEP 11     | none yet, tracked in MEP 11                      |
+| Parametricity         | MEP 12     | none yet, tracked in MEP 12                      |
+| Exhaustiveness        | MEP 13     | `tests/types/valid/match_union_variant.mochi`    |
+| Alpha equivalence     | MEP 8      | none yet, awaiting property-test layer           |
 
 #### Progress
 
@@ -139,22 +157,34 @@ For every binding form, two fixtures with bound names renamed must produce the s
 
 ### What we accept as not sound today
 
-The escape hatches we acknowledge:
+The escape hatches we acknowledge. Each row points at the MEP that owns the fix and at the fixture pinning current behaviour, when one exists.
 
-- `AnyType` as a top type that unifies in both directions. This means values typed `any` can be silently used in any position. The fixture set in MEP 11 documents the current behaviour without endorsing it.
-- `as` casts are unchecked. Casting `int as string` is accepted at type check time and fails at runtime. Fixtures snapshot the behaviour.
-- `null` is currently `any` rather than an `option` type. Programs can use `null` as a value of any type.
-- `let xs = [1]; xs[0] = 2` mutates through an immutable binding because the mutability check applies only to the top-level binding, not to mutations through it.
+| Escape hatch                                         | Tracked in       | Pinning fixture                              |
+|------------------------------------------------------|------------------|----------------------------------------------|
+| `AnyType` unifies in both directions                 | MEP 11           | none yet, planned `any_top_silent_widen`     |
+| `as` cast accepted without compatibility check       | MEP 11           | none yet, planned `cast_int_as_string`       |
+| `null` is `any` rather than an option type           | MEP 4, MEP 10    | none yet                                     |
+| `let xs = [1]; xs[0] = 2` mutates an immutable bind  | MEP 15           | none yet, planned `mutate_through_let_index` |
+| Reading a missing map key returns the zero value     | MEP 4            | none yet                                     |
+| Integer division by zero is a runtime panic, not a checker rejection | MEP 5 | none yet                            |
 
-Each of these is targeted by MEP 10 and a separate spec amendment.
+Listing the fixture column on the right is uncomfortable on purpose. Every blank cell is a bug we have decided not to flag yet; the decision should be deliberate.
 
 ### Conformance between interpreter and bytecode VM
 
-A program that the type checker accepts and the interpreter executes should produce the same observable output when executed by the bytecode VM, with the documented exceptions:
+A program that the type checker accepts and the interpreter executes should produce the same observable output when executed by the bytecode VM, with the documented exceptions below.
 
-- `agent`, `intent`, `on`, `emit`, `fact`, `rule`, `query` are not yet compiled to bytecode. Programs using them must run on the interpreter today.
+| VM gap                          | Reason                          | Notes                                    |
+|---------------------------------|---------------------------------|------------------------------------------|
+| `agent` declarations            | Reactive runtime not in VM      | Interpreter only at v0.10.82             |
+| `intent` declarations           | Same as `agent`                 | Interpreter only at v0.10.82             |
+| `on` event handlers             | Same as `agent`                 | Interpreter only at v0.10.82             |
+| `emit` statements               | Same as `agent`                 | Interpreter only at v0.10.82             |
+| `fact` declarations             | Logic engine not in VM          | Interpreter only at v0.10.82             |
+| `rule` declarations             | Same as `fact`                  | Interpreter only at v0.10.82             |
+| `query` blocks against logic    | Same as `fact`                  | Dataset queries do work on VM            |
 
-The conformance test set lives at `tests/vm/` and runs the same source through both backends, asserting equal stdout.
+The conformance test set lives at `tests/vm/` and runs the same source through both backends, asserting equal stdout. The list above should be re-audited every release; if a feature has been wired through to bytecode, drop the row.
 
 ## Rationale
 


### PR DESCRIPTION
documents the small enhancements to mep 7 that came out of reviewing the soundness chapter. the sub-issues under #21142 track the implementation work; this pr is the prose update.

changes:

- inline obligations table that names the fixture file or glob for each soundness property. saves the reviewer from bouncing to mep 9 to confirm a property is exercised.
- two new stuck states added to the rule-out list: integer division by zero, and reading a missing map key without a default. neither is flagged today; both belong on the list because the type-system claim is that well typed programs do not get stuck.
- escape hatch list reformatted as a table with a tracking-mep column and a pinning-fixture column. blanks in the fixture column are deliberate, each is a known unpinned bug.
- conformance section reformatted as a table so the vm-gap inventory is scannable; the section heading now suggests a re-audit per release.

Refs #21142