### PR TITLE
tests: snapshot null widening into typed positions

### DIFF
--- a/tests/types/valid/null_widening_int.golden
+++ b/tests/types/valid/null_widening_int.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/null_widening_int.mochi
+++ b/tests/types/valid/null_widening_int.mochi
@@ -1,0 +1,5 @@
+// Snapshot: null leaks into a typed int position.
+// MEP 4 lists null as a candidate for an option type.
+// MEP 7 lists this as an escape hatch in the "not sound today" table.
+// When that fix lands this file should move to tests/types/errors/.
+let x: int = null

--- a/tests/types/valid/null_widening_list.golden
+++ b/tests/types/valid/null_widening_list.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/null_widening_list.mochi
+++ b/tests/types/valid/null_widening_list.mochi
@@ -1,0 +1,3 @@
+// Snapshot: null leaks into a typed list position.
+// See MEP 4 and MEP 7.
+let xs: list<int> = null

--- a/tests/types/valid/null_widening_struct.golden
+++ b/tests/types/valid/null_widening_struct.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/null_widening_struct.mochi
+++ b/tests/types/valid/null_widening_struct.mochi
@@ -1,0 +1,8 @@
+// Snapshot: null leaks into a typed struct position.
+// See MEP 4 and MEP 7. When null becomes an option type
+// this file moves to tests/types/errors/.
+type Point {
+  x: int
+  y: int
+}
+let p: Point = null


### PR DESCRIPTION
adds three snapshot fixtures under tests/types/valid pinning the current accept of null at int, list, and struct positions.

mep 7 lists this as an escape hatch in the not-sound-today table. mep 4 owns the eventual fix where null becomes an option type. when that fix lands the three fixtures move from valid/ to errors/ and the diff tells the story.

no behaviour change.

Closes #21145
Refs #21142