### PR TITLE
tests: snapshot literal divide-by-zero acceptance

### DIFF
--- a/tests/types/valid/divide_by_zero_literal.golden
+++ b/tests/types/valid/divide_by_zero_literal.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/divide_by_zero_literal.mochi
+++ b/tests/types/valid/divide_by_zero_literal.mochi
@@ -1,0 +1,7 @@
+// Snapshot: the type checker accepts the literal divide-by-zero case.
+// MEP 7 lists this as a stuck state we want to rule out.
+// The runtime panic is pinned in tests/interpreter/errors/divide_by_zero.err.
+// Decision recorded on issue #21146: leave it to runtime for now;
+// the runtime error[I012] already names the line and column. If we
+// later add a checker rule, this file moves to tests/types/errors/.
+let x: int = 10 / 0

--- a/tests/types/valid/modulo_by_zero_literal.golden
+++ b/tests/types/valid/modulo_by_zero_literal.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/modulo_by_zero_literal.mochi
+++ b/tests/types/valid/modulo_by_zero_literal.mochi
@@ -1,0 +1,3 @@
+// Companion to divide_by_zero_literal.mochi. The checker also
+// accepts a literal-zero modulus today. See issue #21146.
+let r: int = 10 % 0


### PR DESCRIPTION
mep 7 lists division by zero as a stuck state we want to rule out. the runtime panic is already pinned by tests/interpreter/errors/divide_by_zero.err with error[I012].

the type checker does not flag the literal case (let x = 10 / 0). decision recorded on the linked issue: leave it to runtime for now. the runtime error already names the line and column, and a checker-level rule for the literal case is redundant since the non-literal case still has to be a runtime check.

this pr adds two snapshot fixtures pinning the current accept of 10 / 0 and 10 % 0 at type-check time. if we ever add a rejection rule the files move to tests/types/errors/.

Closes #21146
Refs #21142