### PR TITLE
mep-0007: re-audit the VM gap list, dated 2026-05-08

### DIFF
--- a/website/docs/mep/mep-0007.md
+++ b/website/docs/mep/mep-0007.md
@@ -172,19 +172,16 @@ Listing the fixture column on the right is uncomfortable on purpose. Every blank
 
 ### Conformance between interpreter and bytecode VM
 
-A program that the type checker accepts and the interpreter executes should produce the same observable output when executed by the bytecode VM, with the documented exceptions below.
+A program that the type checker accepts and the interpreter executes should produce the same observable output when executed by the bytecode VM, with the documented exceptions below. Last audited 2026-05-08 against v0.10.82.
 
-| VM gap                          | Reason                          | Notes                                    |
-|---------------------------------|---------------------------------|------------------------------------------|
-| `agent` declarations            | Reactive runtime not in VM      | Interpreter only at v0.10.82             |
-| `intent` declarations           | Same as `agent`                 | Interpreter only at v0.10.82             |
-| `on` event handlers             | Same as `agent`                 | Interpreter only at v0.10.82             |
-| `emit` statements               | Same as `agent`                 | Interpreter only at v0.10.82             |
-| `fact` declarations             | Logic engine not in VM          | Interpreter only at v0.10.82             |
-| `rule` declarations             | Same as `fact`                  | Interpreter only at v0.10.82             |
-| `query` blocks against logic    | Same as `fact`                  | Dataset queries do work on VM            |
+| VM gap                       | Reason                          | Status at v0.10.82                              |
+|------------------------------|---------------------------------|-------------------------------------------------|
+| `intent` method calls        | Reactive runtime not on VM      | Calling an intent crashes the VM with stack overflow. |
+| `on` event handler dispatch  | Reactive runtime not on VM      | Declaration accepted; handler does not fire on emit. |
+| `emit` statement dispatch    | Reactive runtime not on VM      | Statement runs; no handler is invoked.          |
+| `query` against logic facts  | Logic engine not on VM          | Execution hangs; dataset queries are unaffected. |
 
-The conformance test set lives at `tests/vm/` and runs the same source through both backends, asserting equal stdout. The list above should be re-audited every release; if a feature has been wired through to bytecode, drop the row.
+`agent`, `stream`, `fact`, and `rule` declarations are accepted by the bytecode VM today. The gaps are in runtime dispatch and in the logic engine, not in the parser. `query` over dataset sources continues to work on the VM and is not on this list. The conformance test set lives at `tests/vm/` and runs the same source through both backends, asserting equal stdout. The audit method is to write a small probe per row (agent declaration, on/emit pair, intent call, fact/rule declaration, query over logic facts) and run it through `mochi run`, recording whether the program finishes with the expected output. This list should be re-audited every release; if a feature has been wired through to bytecode, drop the row and update the audit date.
 
 ## Rationale
 


### PR DESCRIPTION
audited the VM gap list in mep 7 against main on 2026-05-08. method: a small probe per gap row, run through mochi run, recorded the observed behaviour.

findings:

- agent declaration + instantiation: works.
- stream declaration: works.
- fact and rule declarations: accepted at parse and run time.
- on event handlers: declaration accepted; handler does not fire when the matching emit statement runs.
- emit statements: execute but do not invoke handlers.
- intent method calls: crash the VM with stack overflow at runtime.
- query against logic facts: execution hangs; dataset queries continue to work on the VM and are not on this list.

what changed in the doc:

- the table now lists only the four runtime gaps that exist today (intent calls, on dispatch, emit dispatch, logic-fact queries) instead of mixing declarations with semantics.
- the section heading carries the audit date.
- a paragraph below the table notes the audit method and which declarations the VM does accept.

intent stack overflow is a real bug worth its own issue. logging that as a follow-up.

Closes #21148
Refs #21142