### PR TITLE
tests: snapshot unrelated-type as casts

### DIFF
--- a/tests/types/valid/cast_int_as_string.golden
+++ b/tests/types/valid/cast_int_as_string.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/cast_int_as_string.mochi
+++ b/tests/types/valid/cast_int_as_string.mochi
@@ -1,0 +1,8 @@
+// Snapshot: the type checker accepts an int as string cast even though
+// the two types have no compatibility relation. The runtime raises
+// "cannot cast int to string" today.
+//
+// MEP 7 lists this as an escape hatch. MEP 11 owns the fix where the
+// checker rejects the cast at type-check time. When that lands this
+// file moves to tests/types/errors/.
+let s: string = 42 as string

--- a/tests/types/valid/cast_string_as_bool.golden
+++ b/tests/types/valid/cast_string_as_bool.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/cast_string_as_bool.mochi
+++ b/tests/types/valid/cast_string_as_bool.mochi
@@ -1,0 +1,3 @@
+// Third probe in the cast snapshot family. string as bool is
+// unrelated and should be rejected by MEP 11. Today it typechecks.
+let b: bool = "true" as bool

--- a/tests/types/valid/cast_string_as_int.golden
+++ b/tests/types/valid/cast_string_as_int.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/cast_string_as_int.mochi
+++ b/tests/types/valid/cast_string_as_int.mochi
@@ -1,0 +1,3 @@
+// Snapshot: the symmetric case of cast_int_as_string. Both directions
+// are accepted at type-check today, both panic at runtime.
+let n: int = "hello" as int


### PR DESCRIPTION
adds three snapshot fixtures pinning today's behaviour for as casts between unrelated types: int as string, string as int, string as bool. all three typecheck today; all three panic at runtime with "cannot cast x to y".

mep 7 lists the unchecked as cast as an escape hatch and mep 11 owns the fix. when the checker tightens, these three files move from valid/ to errors/ and the diff tells the story.

audit note: the only other as-cast fixture in tests/types/valid is cast_expr.mochi (map literal as struct). that one is more nuanced because the map carries the right key set; it stays in valid/ until mep 11 decides whether the literal-to-struct cast is part of the tightening or a separate construction sugar.

Closes #21144
Refs #21142