### PR TITLE
mep: pin missing-map-key behaviour to option type

### DIFF
--- a/tests/types/valid/missing_map_key.golden
+++ b/tests/types/valid/missing_map_key.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/missing_map_key.mochi
+++ b/tests/types/valid/missing_map_key.mochi
@@ -1,0 +1,12 @@
+// Snapshot: reading m[k] for an absent k returns the zero value of the
+// map's value type today. For non-zero-bearing types this is a progress
+// violation: the program does not get stuck and does not panic, it just
+// silently produces a fake value.
+//
+// MEP 4 pins the future behaviour to option 1: m[k] should infer to v?
+// (OptionType{V}) once OptionType is wired through inference. This is
+// the path that lines up with MEP 10 A2 and C1. When that lands this
+// fixture moves to tests/types/errors/ with code T0xx.
+type Point { x: int, y: int }
+let pts: map<string, Point> = {"o": Point{x: 0, y: 0}}
+let p: Point = pts["missing"]

--- a/website/docs/mep/mep-0004.md
+++ b/website/docs/mep/mep-0004.md
@@ -162,10 +162,26 @@ Informational. No backward compatibility implications.
 - `types/infer.go` — `equalTypes` and operator typing.
 - `types/env.go` — environment API.
 
+## Pinned decisions
+
+### Reading a missing map key
+
+For `m: map<K, V>` and a key `k` that is not present in `m`, the expression `m[k]` will infer to `OptionType{V}`. Callers must unwrap the option before using the value at type `V`. The runtime will produce the absent variant instead of the zero value.
+
+We considered three options before pinning this:
+
+1. Type `m[k]` as `V?`. Picked.
+2. Require an explicit default at the call site, for example `m[k] ?? default`, with a checker error otherwise.
+3. Raise a typed runtime panic.
+
+Option 1 wins on consistency. MEP 10 A2 already commits `OptionType` as the destination for `null` and MEP 10 C1 adds the `T?` shorthand. Once that work lands, missing-key access slots into the same shape without introducing a second mechanism (no new `??` operator, no new panic class). Option 2 would require a new operator and option 3 would force defensive `in m` checks at every call site.
+
+This is a deferred change. Today the runtime returns the zero value of `V`, which for non-zero-bearing types is a progress violation. The current behaviour is pinned by `tests/types/valid/missing_map_key.mochi` so the future tightening is a deliberate breaking change. The implementation work is tracked alongside MEP 10 A2.
+
 ## Open Questions
 
 - **Tuple kind.** A heterogeneous fixed-length sequence has no surface today. We will need it once query result tuples are generalised.
-- **Option kind.** `OptionType` exists but is not produced by inference. MEP 10 ties this to the `null` soundness gap.
+- **Option kind.** `OptionType` exists but is not produced by inference. MEP 10 ties this to the `null` soundness gap and to the missing-map-key decision above.
 - **Numeric ordering.** `float` and `bigrat` mix awkwardly. We have not decided whether to widen to `bigrat` or to refuse the mix.
 
 ## References

--- a/website/docs/mep/mep-0007.md
+++ b/website/docs/mep/mep-0007.md
@@ -165,7 +165,7 @@ The escape hatches we acknowledge. Each row points at the MEP that owns the fix 
 | `as` cast accepted without compatibility check       | MEP 11           | none yet, planned `cast_int_as_string`       |
 | `null` is `any` rather than an option type           | MEP 4, MEP 10    | none yet                                     |
 | `let xs = [1]; xs[0] = 2` mutates an immutable bind  | MEP 15           | none yet, planned `mutate_through_let_index` |
-| Reading a missing map key returns the zero value     | MEP 4            | none yet                                     |
+| Reading a missing map key returns the zero value     | MEP 4            | `tests/types/valid/missing_map_key.mochi`    |
 | Integer division by zero is a runtime panic, not a checker rejection | MEP 5 | none yet                            |
 
 Listing the fixture column on the right is uncomfortable on purpose. Every blank cell is a bug we have decided not to flag yet; the decision should be deliberate.


### PR DESCRIPTION
## Summary

- Picks option 1 from #21147: `m[k]` for an absent `k` will infer to `v?` once `OptionType` is wired through inference.
- Records the decision and rationale in MEP 4 (lines up with MEP 10 A2 for null and MEP 10 C1 for the `T?` shorthand, no new operator or panic class).
- Pins today's zero-value behaviour in `tests/types/valid/missing_map_key.mochi` so the eventual fix is a deliberate breaking change.
- Updates the MEP 7 escape-hatch table to point at the new fixture.

Refs #21142, closes #21147.

## Test plan

- [x] `go test ./types/... -run "TestMEPObligations|TestTypeChecker_Valid"` passes.
- [x] `cd website && npm run build` succeeds.