### PR TITLE
mep: pin let-mutation behaviour and correct mep 10 a3

### DIFF
--- a/tests/types/errors/mutate_through_let_field.err
+++ b/tests/types/errors/mutate_through_let_field.err
@@ -1,0 +1,8 @@
+1. error[T024]: cannot assign to `p` (immutable)
+  --> tests/types/errors/mutate_through_let_field.mochi:3:1
+
+  3 | p.x = 5
+    | ^
+
+help:
+  Use `var` to declare mutable variables.

--- a/tests/types/errors/mutate_through_let_field.mochi
+++ b/tests/types/errors/mutate_through_let_field.mochi
@@ -1,0 +1,3 @@
+type Point { x: int, y: int }
+let p: Point = Point{x: 1, y: 2}
+p.x = 5

--- a/tests/types/errors/mutate_through_let_index.err
+++ b/tests/types/errors/mutate_through_let_index.err
@@ -1,0 +1,8 @@
+1. error[T024]: cannot assign to `xs` (immutable)
+  --> tests/types/errors/mutate_through_let_index.mochi:2:1
+
+  2 | xs[0] = 5
+    | ^
+
+help:
+  Use `var` to declare mutable variables.

--- a/tests/types/errors/mutate_through_let_index.mochi
+++ b/tests/types/errors/mutate_through_let_index.mochi
@@ -1,0 +1,2 @@
+let xs: list<int> = [1, 2, 3]
+xs[0] = 5

--- a/tests/types/valid/mutate_through_let_alias.golden
+++ b/tests/types/valid/mutate_through_let_alias.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/mutate_through_let_alias.mochi
+++ b/tests/types/valid/mutate_through_let_alias.mochi
@@ -1,0 +1,15 @@
+// Snapshot: the direct path `let xs = [1]; xs[0] = 5` is correctly
+// rejected with T024 today (see tests/types/errors/mutate_through_let_*).
+// The remaining soundness hole is aliasing: copying a let-bound list
+// into a var binds the same underlying storage at runtime, so the
+// var-side index assignment mutates the let-side too.
+//
+// This file pins the alias path at type-check time. The runtime side is
+// observable: re-reading xs[0] after ys[0] = 99 returns 99. MEP 10 A3
+// owns the fix; the plan there names the direct path but the alias
+// path is the one that still leaks. When invariance under aliasing
+// (or some equivalent capture-style rule) lands this file moves to
+// tests/types/errors/.
+let xs: list<int> = [1, 2, 3]
+var ys: list<int> = xs
+ys[0] = 99

--- a/website/docs/mep/mep-0007.md
+++ b/website/docs/mep/mep-0007.md
@@ -164,7 +164,7 @@ The escape hatches we acknowledge. Each row points at the MEP that owns the fix 
 | `AnyType` unifies in both directions                 | MEP 11           | none yet, planned `any_top_silent_widen`     |
 | `as` cast accepted without compatibility check       | MEP 11           | none yet, planned `cast_int_as_string`       |
 | `null` is `any` rather than an option type           | MEP 4, MEP 10    | none yet                                     |
-| `let xs = [1]; xs[0] = 2` mutates an immutable bind  | MEP 15           | none yet, planned `mutate_through_let_index` |
+| Aliasing a `let` aggregate into a `var` allows a write through the alias to mutate the original | MEP 15 | `tests/types/valid/mutate_through_let_alias.mochi` |
 | Reading a missing map key returns the zero value     | MEP 4            | `tests/types/valid/missing_map_key.mochi`    |
 | Integer division by zero is a runtime panic, not a checker rejection | MEP 5 | none yet                            |
 

--- a/website/docs/mep/mep-0010.md
+++ b/website/docs/mep/mep-0010.md
@@ -57,17 +57,19 @@ A fixture pinned to current behaviour is not the same as endorsement. Some entri
 2. Introduce a `T?` syntactic shorthand for `OptionType{T}`.
 3. Add a check that requires explicit unwrap (`?` or `match`) before use as the underlying type.
 
-#### A3. Mutation through immutable bindings
+#### A3. Mutation through immutable bindings via aliasing
 
-**Evidence.** `types/check.go` around the `AssignStmt` walk. The mutability flag is consulted when the left hand side is a bare name but not when there are index or field operations.
+**Evidence.** `types/check.go:858-868` in the `AssignStmt` walk. The mutability flag is consulted before any index or field walk, so the direct path `let xs = [1]; xs[0] = 2` and `let p = Point{x: 1}; p.x = 2` are both rejected with `T024` today. Pinned by `tests/types/errors/mutate_through_let_index.mochi` and `tests/types/errors/mutate_through_let_field.mochi`.
 
-**Impact.** `let xs = [1]; xs[0] = 2` is accepted. The contract that `let` is immutable is not honoured under index or field assignment.
+The remaining hole is aliasing. Copying a let-bound list (or struct, or map) into a `var` binds the same underlying storage at runtime, so a write through the `var` mutates the `let` too. `tests/types/valid/mutate_through_let_alias.mochi` pins the type checker accepting the alias write; the runtime read after the write returns the mutated value.
+
+**Impact.** `let` does not guarantee that the value behind the binding does not change. A defensive reader cannot trust that a let-bound list seen earlier in a function still has the same elements after an unrelated call that received a copy of the binding.
 
 **Plan.**
 
-1. Tighten `checkAssignStmt` to inspect the mutability of the root binding, not just whether a top-level reassignment is happening.
-2. Add error code (next free) `T0xx`: cannot mutate through immutable binding.
-3. Add a fixture for both index and field mutation of a `let`.
+1. Pick a discipline. Two candidates: copy-on-write at the alias boundary (let-bound aggregates clone before binding into a `var`), or invariance under aliasing where assigning a let-bound aggregate to a `var` of the same type is a checker error.
+2. If invariance, add error code (next free) `T0xx`: cannot alias an immutable aggregate into a mutable binding.
+3. Move the alias fixture from `valid/` to `errors/` once the rule lands.
 
 #### A4. Match exhaustiveness not enforced
 


### PR DESCRIPTION
## Summary

- The direct path `let xs = [1]; xs[0] = 5` and the field-mutation equivalent are already rejected with T024. Issue #21143 was written assuming they slip through the checker; that part of MEP 10 A3 is stale.
- Pin the rejection in `tests/types/errors/mutate_through_let_index.mochi` and `tests/types/errors/mutate_through_let_field.mochi` so a regression is loud.
- The surviving hole is aliasing: copying a let-bound list into a var binds the same underlying storage, so a write through the var mutates the let. Pin this in `tests/types/valid/mutate_through_let_alias.mochi`.
- Rewrite MEP 10 A3 with the corrected evidence and two candidate fixes (copy-on-write at the alias boundary versus invariance under aliasing). Update the MEP 7 escape-hatch table.

Refs #21142, closes #21143.

## Test plan

- [x] `go test ./types/... -run "TestMEPObligations|TestTypeChecker"` passes.
- [x] `cd website && npm run build` succeeds.