### PR TITLE
mep: correct x == -1 whitespace remedy claim

### DIFF
--- a/website/docs/mep/mep-0001.md
+++ b/website/docs/mep/mep-0001.md
@@ -106,7 +106,7 @@ When a future MEP adds a keyword:
 ## Open Questions
 
 - **Block comments do not nest.** A literal `*/` inside a block comment terminates it early. We could switch to a hand-written tokenizer that supports nesting. Low priority.
-- **Negative numeric literals.** A future change could make the lexer recognise `-1` as a number when it is not preceded by an identifier or close bracket, removing the `x == -1` parens gotcha. The trade-off is grammar complexity for the benefit of one syntactic surprise removed.
+- **Negative numeric literals.** A future change could make the lexer recognise `-1` as a number when it is not preceded by an identifier or close bracket, removing the `x == -1` parens gotcha. Today `x == -1` and `x == - 1` both fail to parse; only `x == (-1)` works. The trade-off is grammar complexity for the benefit of one syntactic surprise removed.
 
 ## References
 

--- a/website/docs/mep/mep-0010.md
+++ b/website/docs/mep/mep-0010.md
@@ -187,7 +187,7 @@ Path A matches the runtime today. We recommend it.
 
 **Evidence.** `parser/parser.go:53-56` documents the lexer rationale.
 
-**Impact.** `x == -1` requires parens or whitespace. Surprising for new users.
+**Impact.** `x == -1` requires parens. Inserting whitespace as `x == - 1` does not help; the parser sees `-` followed by `1` as a missing-operand prefix and fails the same way. Surprising for new users.
 
 **Plan.** Document in `parser/README.md` and in MEP 1. Long term, look at splitting the lexer rule so `-1` is a number when not preceded by an ident or close bracket.
 


### PR DESCRIPTION
## Summary

- Both MEP 1 and MEP 10 C2 said the `x == -1` gotcha could be fixed by parens or whitespace. The whitespace remedy is wrong: `x == - 1` produces the same parse error as `x == -1`. Only `x == (-1)` parses today.
- Correct both docs to drop the whitespace remedy.

Refs #21159, closes #21160.

## Test plan

- [x] `cd website && npm run build` succeeds.