### PR TITLE
mep: list bench, model, update as soft keywords in mep 1

### DIFF
--- a/website/docs/mep/mep-0001.md
+++ b/website/docs/mep/mep-0001.md
@@ -57,11 +57,14 @@ break continue let var if else then for while in generate match fetch
 load save package export fact rule all null
 ```
 
-A few words that look like keywords are not in the global list and are matched as identifiers when used in expression contexts. They become significant only inside a specific production. Examples:
+A few words that look like keywords are not in the global list and are matched as identifiers when used in expression contexts. They become significant only inside a specific production. The list:
 
+- Declaration words: `bench`, `model`, `update`. Used to introduce a `BenchBlock`, a `ModelDecl`, or an `UpdateStmt`.
 - Query expression keywords: `from`, `where`, `select`, `group`, `by`, `into`, `having`, `sort`, `order`, `skip`, `take`, `distinct`, `join`, `left`, `right`, `outer`.
 - Modifier words: `as`, `to`, `with`. Used after `load`, `save`, `cast`, or in import clauses.
 - Set operators: `union`, `except`, `intersect`. Used in binary expressions.
+
+All four buckets parse as `Ident` outside their production. `let bench = 1` is accepted today; the same is true for every word above.
 
 ### Numeric literal design
 


### PR DESCRIPTION
## Summary

- The soft-keyword section in MEP 1 listed three buckets (query, modifier, set operators) but omitted `bench`, `model`, and `update`, all of which are real productions and all of which parse as `Ident` outside their production.
- Add a fourth bullet for declaration words and reframe the section as the full list rather than examples.

Refs #21159, closes #21161.

## Test plan

- [x] `cd website && npm run build` succeeds.