### PR TITLE
tests: pin block comments do not nest

### DIFF
--- a/tests/parser/errors/block_comment_no_nesting.err
+++ b/tests/parser/errors/block_comment_no_nesting.err
@@ -1,0 +1,8 @@
+error[P999]: tests/parser/errors/block_comment_no_nesting.mochi:1:36: unexpected token "/" (expected PostfixExpr)
+  --> tests/parser/errors/block_comment_no_nesting.mochi:1:36
+
+  1 | let x = /* outer /* inner */ tail */ 1
+    |                                    ^
+
+help:
+  Parse error occurred. Check syntax near this location.

--- a/tests/parser/errors/block_comment_no_nesting.mochi
+++ b/tests/parser/errors/block_comment_no_nesting.mochi
@@ -1,0 +1,1 @@
+let x = /* outer /* inner */ tail */ 1


### PR DESCRIPTION
## Summary

- MEP 1 says block comments use a simple `/* ... */` regex that does not nest. A future contributor switching to a hand-written tokenizer with nesting would silently change parse behaviour for users who relied on the early termination.
- Add `tests/parser/errors/block_comment_no_nesting.{mochi,err}` so the rejection is locked in.

Refs #21159, closes #21162.

## Test plan

- [x] `go test ./parser/... -run TestParser_SyntaxErrors/block_comment_no_nesting` passes.