### PR TITLE
tests: pin unicode and emoji identifiers

### DIFF
--- a/tests/parser/valid/unicode_identifier.golden
+++ b/tests/parser/valid/unicode_identifier.golden
@@ -1,0 +1,8 @@
+(program
+  (let "π" (float 3.14))
+  (let "θ_max" (int 90))
+  (let "🎯" (int 1))
+  (call print (selector "π"))
+  (call print (selector "θ_max"))
+  (call print (selector "🎯"))
+)

--- a/tests/parser/valid/unicode_identifier.mochi
+++ b/tests/parser/valid/unicode_identifier.mochi
@@ -1,0 +1,6 @@
+let π = 3.14
+let θ_max = 90
+let 🎯 = 1
+print(π)
+print(θ_max)
+print(🎯)


### PR DESCRIPTION
## Summary

- MEP 1 promises that identifiers can use unicode letters, the `So` (other symbol) class, and underscore. That promise had no fixture today.
- Add `tests/parser/valid/unicode_identifier.{mochi,golden}` covering a greek letter, an emoji, and a mixed unicode plus ascii identifier so a future regex change that drops `\p{So}` or narrows `\p{L}` fails the test.

Refs #21159, closes #21163.

## Test plan

- [x] `go test ./parser/... -run TestParser_ValidPrograms/unicode_identifier` passes.