### PR TITLE
tests: pin xs[len(xs)-1] parses as subtraction

### DIFF
--- a/tests/parser/valid/index_len_minus_one.golden
+++ b/tests/parser/valid/index_len_minus_one.golden
@@ -1,0 +1,15 @@
+(program
+  (let xs
+    (type list (type int))
+    (list (int 10) (int 20) (int 30))
+  )
+  (call print
+    (index
+      (selector xs)
+      (binary -
+        (call len (selector xs))
+        (int 1)
+      )
+    )
+  )
+)

--- a/tests/parser/valid/index_len_minus_one.mochi
+++ b/tests/parser/valid/index_len_minus_one.mochi
@@ -1,0 +1,2 @@
+let xs: list<int> = [10, 20, 30]
+print(xs[len(xs)-1])


### PR DESCRIPTION
## Summary

- MEP 1 explains that numeric literals do not include a leading minus so that `xs[len(xs)-1]` parses as `xs[(len(xs) - 1)]` rather than as a two-argument index. The rationale had no fixture today.
- Add `tests/parser/valid/index_len_minus_one.{mochi,golden}` asserting the AST is a binary minus inside an index, so a future lexer change that makes `-1` greedy fails the test.

Refs #21159, closes #21164.

## Test plan

- [x] `go test ./parser/... -run TestParser_ValidPrograms/index_len_minus_one` passes.