### PR TITLE
website: clean up MEP sidebar labels and collapse icon

### DIFF
--- a/website/docs/mep/mep-0000.md
+++ b/website/docs/mep/mep-0000.md
@@ -6,7 +6,7 @@ status: Active
 type: Process
 created: 2026-05-08
 sidebar_position: 0
-sidebar_label: MEP 0 — Index
+sidebar_label: MEP 0. Index
 description: Index of Mochi Enhancement Proposals.
 ---
 

--- a/website/docs/mep/mep-0001.md
+++ b/website/docs/mep/mep-0001.md
@@ -6,7 +6,7 @@ status: Informational
 type: Informational
 created: 2026-05-08
 sidebar_position: 1
-sidebar_label: MEP 1 — Lexer
+sidebar_label: MEP 1. Lexer
 description: The token classes, reserved words, and lexical rules of Mochi.
 ---
 

--- a/website/docs/mep/mep-0002.md
+++ b/website/docs/mep/mep-0002.md
@@ -6,7 +6,7 @@ status: Informational
 type: Informational
 created: 2026-05-08
 sidebar_position: 2
-sidebar_label: MEP 2 — Grammar
+sidebar_label: MEP 2. Grammar
 description: Mochi's statement and expression productions, encoded on participle struct tags.
 ---
 

--- a/website/docs/mep/mep-0003.md
+++ b/website/docs/mep/mep-0003.md
@@ -6,7 +6,7 @@ status: Informational
 type: Informational
 created: 2026-05-08
 sidebar_position: 3
-sidebar_label: MEP 3 — AST
+sidebar_label: MEP 3. AST
 description: Mochi's AST node catalogue, encoded as Go structs with both JSON tags and participle parser tags.
 ---
 

--- a/website/docs/mep/mep-0004.md
+++ b/website/docs/mep/mep-0004.md
@@ -6,7 +6,7 @@ status: Informational
 type: Informational
 created: 2026-05-08
 sidebar_position: 4
-sidebar_label: MEP 4 — Type System
+sidebar_label: MEP 4. Type System
 description: Type kinds, equality, unification, and the numeric tower.
 ---
 

--- a/website/docs/mep/mep-0005.md
+++ b/website/docs/mep/mep-0005.md
@@ -6,7 +6,7 @@ status: Informational
 type: Informational
 created: 2026-05-08
 sidebar_position: 5
-sidebar_label: MEP 5 — Type Inference
+sidebar_label: MEP 5. Type Inference
 description: How Mochi infers types for declarations, expressions, control flow, and queries.
 ---
 

--- a/website/docs/mep/mep-0006.md
+++ b/website/docs/mep/mep-0006.md
@@ -6,7 +6,7 @@ status: Informational
 type: Informational
 created: 2026-05-08
 sidebar_position: 6
-sidebar_label: MEP 6 — Type Checker
+sidebar_label: MEP 6. Type Checker
 description: Entry point, builtin environment, statement walk, and the diagnostic catalogue.
 ---
 

--- a/website/docs/mep/mep-0007.md
+++ b/website/docs/mep/mep-0007.md
@@ -6,7 +6,7 @@ status: Active
 type: Process
 created: 2026-05-08
 sidebar_position: 7
-sidebar_label: MEP 7 — Soundness
+sidebar_label: MEP 7. Soundness
 description: Progress, preservation, and the test obligations that prove them.
 ---
 

--- a/website/docs/mep/mep-0008.md
+++ b/website/docs/mep/mep-0008.md
@@ -6,7 +6,7 @@ status: Active
 type: Process
 created: 2026-05-08
 sidebar_position: 8
-sidebar_label: MEP 8 — Test Strategy
+sidebar_label: MEP 8. Test Strategy
 description: The five test layers, the golden harness, and the TAPL chapter mapping.
 ---
 

--- a/website/docs/mep/mep-0009.md
+++ b/website/docs/mep/mep-0009.md
@@ -6,7 +6,7 @@ status: Informational
 type: Informational
 created: 2026-05-08
 sidebar_position: 9
-sidebar_label: MEP 9 — Fixture Catalogue
+sidebar_label: MEP 9. Fixture Catalogue
 description: Inventory of parser and type fixtures with a property coverage matrix.
 ---
 

--- a/website/docs/mep/mep-0010.md
+++ b/website/docs/mep/mep-0010.md
@@ -6,7 +6,7 @@ status: Informational
 type: Informational
 created: 2026-05-08
 sidebar_position: 10
-sidebar_label: MEP 10 — Known Gaps
+sidebar_label: MEP 10. Known Gaps
 description: Catalogue of soundness gaps, surprising behavior, and tracked follow-ups.
 ---
 

--- a/website/docs/mep/mep-0011.md
+++ b/website/docs/mep/mep-0011.md
@@ -6,7 +6,7 @@ status: Draft
 type: Standards Track
 created: 2026-05-08
 sidebar_position: 11
-sidebar_label: MEP 11 — Subtyping
+sidebar_label: MEP 11. Subtyping
 description: Width subtyping, variance positions, and the proposed subtype predicate.
 ---
 

--- a/website/docs/mep/mep-0012.md
+++ b/website/docs/mep/mep-0012.md
@@ -6,7 +6,7 @@ status: Draft
 type: Standards Track
 created: 2026-05-08
 sidebar_position: 12
-sidebar_label: MEP 12 — Polymorphism
+sidebar_label: MEP 12. Polymorphism
 description: Wire TypeVar through inference so generic call sites unify properly.
 ---
 

--- a/website/docs/mep/mep-0013.md
+++ b/website/docs/mep/mep-0013.md
@@ -6,7 +6,7 @@ status: Draft
 type: Standards Track
 created: 2026-05-08
 sidebar_position: 13
-sidebar_label: MEP 13 — ADTs
+sidebar_label: MEP 13. ADTs
 description: Struct and union typing rules, match exhaustiveness, irredundancy, and recursive types.
 ---
 

--- a/website/docs/mep/mep-0014.md
+++ b/website/docs/mep/mep-0014.md
@@ -6,7 +6,7 @@ status: Informational
 type: Informational
 created: 2026-05-08
 sidebar_position: 14
-sidebar_label: MEP 14 — Queries
+sidebar_label: MEP 14. Queries
 description: LINQ-shaped query expressions, clause-by-clause type rules, and aggregate semantics.
 ---
 

--- a/website/docs/mep/mep-0015.md
+++ b/website/docs/mep/mep-0015.md
@@ -6,7 +6,7 @@ status: Draft
 type: Standards Track
 created: 2026-05-08
 sidebar_position: 15
-sidebar_label: MEP 15 — Effects
+sidebar_label: MEP 15. Effects
 description: Mutability, aliasing, the Pure flag, and side-effecting builtins.
 ---
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -347,6 +347,33 @@ h4:hover .hash-link {
   display: none;
 }
 
+/* Sidebar collapse/toggle button — replace heavy « with a thin chevron */
+button[class*="collapseSidebarButton"] {
+  border-top: 1px solid var(--mochi-border) !important;
+  background: transparent !important;
+  opacity: 0.5;
+  transition: opacity 0.15s, background 0.15s;
+}
+
+button[class*="collapseSidebarButton"]:hover {
+  opacity: 1;
+  background: var(--mochi-bg-elevated) !important;
+}
+
+button[class*="collapseSidebarButton"] svg {
+  display: none;
+}
+
+button[class*="collapseSidebarButton"]::after {
+  content: "";
+  display: block;
+  width: 14px;
+  height: 14px;
+  background-color: var(--mochi-text-muted);
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='15 18 9 12 15 6'/%3E%3C/svg%3E") center/contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='15 18 9 12 15 6'/%3E%3C/svg%3E") center/contain no-repeat;
+}
+
 /* Right-side TOC */
 .table-of-contents {
   font-size: 0.85rem;


### PR DESCRIPTION
Closes #21172

- Replace em-dashes with dots in all 16 MEP sidebar_label entries
- Override Docusaurus sidebar collapse button to use a thin chevron SVG mask instead of the default «