### PR TITLE
mep2: audit grammar doc and add missing parser fixtures

### DIFF
--- a/ast/convert.go
+++ b/ast/convert.go
@@ -167,6 +167,20 @@ func FromStatement(s *parser.Statement) *Node {
 				n.Children = append(n.Children, FromStatement(&parser.Statement{Fun: m.Method}))
 			}
 		}
+		for _, v := range s.Type.Variants {
+			vn := &Node{Kind: "variant", Value: v.Name}
+			for _, f := range v.Fields {
+				vn.Children = append(vn.Children, &Node{
+					Kind:     "field",
+					Value:    f.Name,
+					Children: []*Node{FromTypeRef(f.Type)},
+				})
+			}
+			n.Children = append(n.Children, vn)
+		}
+		if s.Type.Alias != nil {
+			n.Children = append(n.Children, &Node{Kind: "alias", Children: []*Node{FromTypeRef(s.Type.Alias)}})
+		}
 		return n
 
 	case s.Test != nil:
@@ -181,6 +195,40 @@ func FromStatement(s *parser.Statement) *Node {
 
 	case s.Expect != nil:
 		return &Node{Kind: "expect", Children: []*Node{FromExpr(s.Expect.Value)}}
+
+	case s.Fetch != nil:
+		n := &Node{Kind: "fetch", Value: s.Fetch.Target}
+		n.Children = append(n.Children, FromExpr(s.Fetch.URL))
+		if s.Fetch.With != nil {
+			n.Children = append(n.Children, FromExpr(s.Fetch.With))
+		}
+		return n
+
+	case s.Fact != nil:
+		n := &Node{Kind: "fact", Value: s.Fact.Pred.Name}
+		for _, arg := range s.Fact.Pred.Args {
+			n.Children = append(n.Children, fromLogicTerm(arg))
+		}
+		return n
+
+	case s.Rule != nil:
+		head := &Node{Kind: "head", Value: s.Rule.Head.Name}
+		for _, arg := range s.Rule.Head.Args {
+			head.Children = append(head.Children, fromLogicTerm(arg))
+		}
+		n := &Node{Kind: "rule", Children: []*Node{head}}
+		for _, cond := range s.Rule.Body {
+			if cond.Pred != nil {
+				cn := &Node{Kind: "cond", Value: cond.Pred.Name}
+				for _, arg := range cond.Pred.Args {
+					cn.Children = append(cn.Children, fromLogicTerm(arg))
+				}
+				n.Children = append(n.Children, cn)
+			} else if cond.Neq != nil {
+				n.Children = append(n.Children, &Node{Kind: "neq", Value: cond.Neq.A + "!=" + cond.Neq.B})
+			}
+		}
+		return n
 
 	default:
 		return &Node{Kind: "unknown"}
@@ -622,8 +670,27 @@ func FromPrimary(p *parser.Primary) *Node {
 
 	case p.Group != nil:
 		return &Node{Kind: "group", Pos: p.Pos, Children: []*Node{FromExpr(p.Group)}}
+
+	case p.LogicQuery != nil:
+		n := &Node{Kind: "query_logic", Value: p.LogicQuery.Pred.Name, Pos: p.Pos}
+		for _, arg := range p.LogicQuery.Pred.Args {
+			n.Children = append(n.Children, fromLogicTerm(arg))
+		}
+		return n
 	}
 
+	return &Node{Kind: "unknown"}
+}
+
+func fromLogicTerm(t *parser.LogicTerm) *Node {
+	switch {
+	case t.Var != nil:
+		return &Node{Kind: "var", Value: *t.Var}
+	case t.Str != nil:
+		return &Node{Kind: "string", Value: *t.Str}
+	case t.Int != nil:
+		return &Node{Kind: "int", Value: fmt.Sprintf("%d", int(*t.Int))}
+	}
 	return &Node{Kind: "unknown"}
 }
 

--- a/tests/parser/valid/bench_block.golden
+++ b/tests/parser/valid/bench_block.golden
@@ -1,0 +1,13 @@
+(program
+  (bench "sum list"
+    (let xs
+      (list (int 1) (int 2) (int 3) (int 4) (int 5))
+    )
+    (let total
+      (binary +
+        (index (selector xs) (int 0))
+        (index (selector xs) (int 1))
+      )
+    )
+  )
+)

--- a/tests/parser/valid/bench_block.mochi
+++ b/tests/parser/valid/bench_block.mochi
@@ -1,0 +1,4 @@
+bench "sum list" {
+  let xs = [1, 2, 3, 4, 5]
+  let total = xs[0] + xs[1]
+}

--- a/tests/parser/valid/fetch_stmt.golden
+++ b/tests/parser/valid/fetch_stmt.golden
@@ -1,0 +1,9 @@
+(program
+  (fetch resp (string "https://api.example.com/users"))
+  (fetch data
+    (string "https://api.example.com/data")
+    (map
+      (entry (selector timeout) (int 30))
+    )
+  )
+)

--- a/tests/parser/valid/fetch_stmt.mochi
+++ b/tests/parser/valid/fetch_stmt.mochi
@@ -1,0 +1,2 @@
+fetch "https://api.example.com/users" into resp
+fetch "https://api.example.com/data" into data with { timeout: 30 }

--- a/tests/parser/valid/logic.golden
+++ b/tests/parser/valid/logic.golden
@@ -1,0 +1,16 @@
+(program
+  (fact parent (string tom) (string bob))
+  (fact parent (string bob) (string ann))
+  (rule
+    (head ancestor (var X) (var Y))
+    (cond parent (var X) (var Y))
+  )
+  (rule
+    (head ancestor (var X) (var Y))
+    (cond parent (var X) (var Z))
+    (cond ancestor (var Z) (var Y))
+  )
+  (let results
+    (query_logic ancestor (string tom) (var Y))
+  )
+)

--- a/tests/parser/valid/logic.mochi
+++ b/tests/parser/valid/logic.mochi
@@ -1,0 +1,7 @@
+fact parent("tom", "bob")
+fact parent("bob", "ann")
+
+rule ancestor(X, Y) :- parent(X, Y)
+rule ancestor(X, Y) :- parent(X, Z), ancestor(Z, Y)
+
+let results = query ancestor("tom", Y)

--- a/tests/parser/valid/type_alias.golden
+++ b/tests/parser/valid/type_alias.golden
@@ -1,0 +1,8 @@
+(program
+  (type Id (variant int))
+  (type Name (variant string))
+  (type Pair
+    (field first (type int))
+    (field second (type int))
+  )
+)

--- a/tests/parser/valid/type_alias.mochi
+++ b/tests/parser/valid/type_alias.mochi
@@ -1,0 +1,3 @@
+type Id = int
+type Name = string
+type Pair = { first: int, second: int }

--- a/tests/parser/valid/type_union_decl.golden
+++ b/tests/parser/valid/type_union_decl.golden
@@ -1,0 +1,22 @@
+(program
+  (type Shape
+    (variant Circle
+      (field r (type float))
+    )
+    (variant Square
+      (field side (type float))
+    )
+    (variant Rect
+      (field w (type float))
+      (field h (type float))
+    )
+  )
+  (type Result
+    (variant Ok
+      (field value (type int))
+    )
+    (variant Err
+      (field msg (type string))
+    )
+  )
+)

--- a/tests/parser/valid/type_union_decl.mochi
+++ b/tests/parser/valid/type_union_decl.mochi
@@ -1,0 +1,3 @@
+type Shape = Circle(r: float) | Square(side: float) | Rect(w: float, h: float)
+
+type Result = Ok(value: int) | Err(msg: string)

--- a/website/docs/mep/mep-0002.md
+++ b/website/docs/mep/mep-0002.md
@@ -83,16 +83,17 @@ FunStmt   = [ 'export' ] 'fun' Ident [ '<' Ident { ',' Ident } '>' ]
             '(' [ Param { ',' Param } ] ')' [ ':' TypeRef ]
             '{' Statement* '}'
 TypeDecl  = 'type' Ident
-            ( '{' TypeMember { [','] TypeMember } [','] '}'
+            ( [ '=' ] '{' TypeMember { [','] TypeMember } [','] '}'
             | '=' TypeVariant { '|' TypeVariant }
-            | '=' TypeRef )
+            | '=' FunType | '=' GenericType )
+TypeMember  = TypeField | FunStmt
 ```
 
 `TypeDecl` is the most overloaded production. Three forms:
 
-1. Struct: `type Point { x: int, y: int }`.
-2. Tagged union: `type Shape = Circle(r: float) | Square(side: float)`.
-3. Alias: `type Id = int`.
+1. Struct: `type Point { x: int, y: int }` (the `=` prefix is also accepted: `type Point = { ... }`).
+2. Tagged union / simple variant: `type Shape = Circle(r: float) | Square(side: float)`. A bare name like `type Id = int` also lands in this path — `int` is parsed as a single nameless variant. The checker distinguishes a true alias from a single-variant declaration.
+3. Function or generic alias: `type F = fun(int) : int` or `type MyList = list<int>`.
 
 The parser distinguishes the three by lookahead on the token after the type name.
 
@@ -179,6 +180,8 @@ Both block and arrow bodies are accepted. The arrow form yields the expression a
 ```
 FactStmt        = 'fact' LogicPredicate
 RuleStmt        = 'rule' LogicPredicate ':-' LogicCond { ',' LogicCond }
+LogicCond       = LogicPredicate | LogicNeq
+LogicNeq        = Ident '!=' Ident
 LogicPredicate  = Ident '(' [ LogicTerm { ',' LogicTerm } ] ')'
 LogicTerm       = Ident | String | Int
 LogicQueryExpr  = 'query' LogicPredicate
@@ -226,7 +229,7 @@ Informational. No backward compatibility implications.
 - `parser/parser.go:184-189` — `TypeRef`.
 - `parser/parser.go:368, 373` — `BinaryOp` shape.
 - `parser/parser.go:661-666` — parser construction.
-- `types/infer.go:89-198` — operator precedence applied during inference.
+- `types/infer.go:89-205` — operator precedence applied during inference.
 
 ## Open Questions
 


### PR DESCRIPTION
Closes #21177

**ast/convert.go:** fill four gaps — TypeDecl variants/alias, FetchStmt, Fact, Rule, LogicQueryExpr.

**New fixtures:** bench_block, fetch_stmt, logic, type_alias, type_union_decl.

**MEP 2 doc:** fix TypeDecl BNF (optional `=` on struct, TypeMember method form), add LogicNeq to LogicCond, fix stale line ref 89-198→89-205.