### PR TITLE
mep3: audit AST doc and add missing parser fixtures

### DIFF
--- a/ast/convert.go
+++ b/ast/convert.go
@@ -183,6 +183,50 @@ func FromStatement(s *parser.Statement) *Node {
 		}
 		return n
 
+	case s.Import != nil:
+		n := &Node{Kind: "import", Value: s.Import.Path}
+		if s.Import.Lang != nil {
+			n.Children = append(n.Children, &Node{Kind: "lang", Value: *s.Import.Lang})
+		}
+		if s.Import.As != "" {
+			n.Children = append(n.Children, &Node{Kind: "as", Value: s.Import.As})
+		}
+		return n
+
+	case s.ExternType != nil:
+		return &Node{Kind: "extern_type", Value: s.ExternType.Name}
+
+	case s.ExternVar != nil:
+		return &Node{Kind: "extern_var", Value: s.ExternVar.Name(),
+			Children: []*Node{FromTypeRef(s.ExternVar.Type)}}
+
+	case s.ExternFun != nil:
+		n := &Node{Kind: "extern_fun", Value: s.ExternFun.Name()}
+		for _, p := range s.ExternFun.Params {
+			pn := &Node{Kind: "param", Value: p.Name}
+			if p.Type != nil {
+				pn.Children = append(pn.Children, FromTypeRef(p.Type))
+			}
+			n.Children = append(n.Children, pn)
+		}
+		if s.ExternFun.Return != nil {
+			n.Children = append(n.Children, &Node{Kind: "return", Children: []*Node{FromTypeRef(s.ExternFun.Return)}})
+		}
+		return n
+
+	case s.ExternObject != nil:
+		return &Node{Kind: "extern_object", Value: s.ExternObject.Name}
+
+	case s.Emit != nil:
+		n := &Node{Kind: "emit", Value: s.Emit.Stream}
+		for _, f := range s.Emit.Fields {
+			n.Children = append(n.Children, &Node{
+				Kind:     f.Name,
+				Children: []*Node{FromExpr(f.Value)},
+			})
+		}
+		return n
+
 	case s.Test != nil:
 		n := &Node{Kind: "test", Value: s.Test.Name}
 		n.Children = append(n.Children, mapStatements(s.Test.Body)...)

--- a/tests/parser/valid/agent_full.golden
+++ b/tests/parser/valid/agent_full.golden
@@ -53,8 +53,16 @@
     )
   )
   (let monitor (struct Monitor))
-  (unknown)
-  (unknown)
+  (emit SensorReading
+    (id (string sensor-1))
+    (temperature (float 28))
+    (timestamp (call now))
+  )
+  (emit SensorReading
+    (id (string sensor-2))
+    (temperature (float 35.5))
+    (timestamp (call now))
+  )
   (let s
     (call
       (selector status (selector monitor))

--- a/tests/parser/valid/emit_stmt.golden
+++ b/tests/parser/valid/emit_stmt.golden
@@ -1,0 +1,7 @@
+(program
+  (stream Clicks (field "x:int") (field "y:int"))
+  (emit Clicks
+    (x (int 10))
+    (y (int 20))
+  )
+)

--- a/tests/parser/valid/emit_stmt.mochi
+++ b/tests/parser/valid/emit_stmt.mochi
@@ -1,0 +1,6 @@
+stream Clicks {
+  x: int
+  y: int
+}
+
+emit Clicks { x: 10, y: 20 }

--- a/tests/parser/valid/extern_decl.golden
+++ b/tests/parser/valid/extern_decl.golden
@@ -1,0 +1,12 @@
+(program
+  (extern_type Handle)
+  (extern_var Math.PI (type float))
+  (extern_fun Math.sqrt
+    (param x (type float))
+    (return (type float))
+  )
+  (extern_fun console.log
+    (param msg (type string))
+  )
+  (extern_object window)
+)

--- a/tests/parser/valid/extern_decl.mochi
+++ b/tests/parser/valid/extern_decl.mochi
@@ -1,0 +1,5 @@
+extern type Handle
+extern var Math.PI: float
+extern fun Math.sqrt(x: float) : float
+extern fun console.log(msg: string)
+extern object window

--- a/tests/parser/valid/import_stmt.golden
+++ b/tests/parser/valid/import_stmt.golden
@@ -1,0 +1,5 @@
+(program
+  (import mochi/math)
+  (import math (lang python) (as math))
+  (import mochi/io (as io))
+)

--- a/tests/parser/valid/import_stmt.mochi
+++ b/tests/parser/valid/import_stmt.mochi
@@ -1,0 +1,3 @@
+import "mochi/math"
+import python "math" as math
+import "mochi/io" as io

--- a/website/docs/mep/mep-0003.md
+++ b/website/docs/mep/mep-0003.md
@@ -86,6 +86,7 @@ The pattern repeats at lower levels: `TypeRef`, `PostfixOp`, `Primary`, and `Lit
 ### Declarations
 
 ```
+ImportStmt{ Pos, Lang *string, Path string, As string, Auto bool }
 LetStmt   { Pos, Name, Doc, Type *TypeRef, Value *Expr }
 VarStmt   { Pos, Name, Doc, Type *TypeRef, Value *Expr }
 AssignStmt{ Pos, Name, Index []*IndexOp, Field []*FieldOp, Value *Expr }
@@ -93,11 +94,18 @@ FunStmt   { Pos, Export bool, Name, Doc, TypeParams []string,
             Params []*Param, Return *TypeRef, Body []*Statement }
 TypeDecl  { Pos, Name, Doc, Members []*TypeMember,
             Variants []*TypeVariant, Alias *TypeRef }
+ExternTypeDecl  { Pos, Name string }
+ExternVarDecl   { Pos, Root string, Tail []string, Type *TypeRef }
+ExternFunDecl   { Pos, Root string, Tail []string,
+                  Params []*Param, Return *TypeRef }
+ExternObjectDecl{ Pos, Name string }
 ```
+
+`ImportStmt.Lang` is nil for a plain `import "path"`. `Auto` is set by `import "path" auto` to enable auto-import resolution.
 
 Invariants:
 
-- `TypeDecl` is one of three forms. Exactly one of `Members`, `Variants`, or `Alias` is non-empty. The checker switches on which.
+- `TypeDecl` uses three fields. `Members` is set for struct and struct-alias forms (`type P { ... }` and `type P = { ... }`). `Variants` is set for any `'=' Ident ...` form — including bare aliases like `type Id = int` (parsed as a single variant named `int`). `Alias` is set only for function-type or generic-type aliases such as `type F = fun(int):int` or `type L = list<int>`. The checker distinguishes a true alias from a single-variant declaration based on whether the sole variant has fields.
 - `LetStmt` and `VarStmt` require at least one of `Type` or `Value`. The parser allows both to be missing and the checker raises `T000` for the empty case.
 
 ### Type references
@@ -124,7 +132,7 @@ PostfixExpr { Target *Primary, Ops []*PostfixOp }
 PostfixOp   { Call *CallOp, Index *IndexOp, Field *FieldOp, Cast *CastOp }
 ```
 
-`BinaryExpr` carries a flat list because the parser does not enforce precedence. The type checker must apply the precedence table at `types/infer.go:89-98`. A consumer that walks the tree without applying precedence will produce incorrect typing for mixed operator chains.
+`BinaryExpr` carries a flat list because the parser does not enforce precedence. The type checker applies the precedence table defined at `types/infer.go:89-97` (the `levels` slice) across lines `89-205` (`inferBinaryType`). A consumer that walks the tree without applying precedence will produce incorrect typing for mixed operator chains.
 
 `Unary.Ops` is a slice of strings (`"-"` or `"!"`). The checker applies them right to left.
 
@@ -141,6 +149,8 @@ Primary {
 ```
 
 The order in this struct is meaningful. `StructLiteral` comes before `Selector` because `Foo{...}` could otherwise be parsed as the identifier `Foo` followed by a block.
+
+`FunExpr` carries two mutually exclusive body fields — `BlockBody []*Statement` for `fun() { ... }` and `ExprBody *Expr` for `fun() => expr`. Exactly one is non-nil after a successful parse.
 
 ### Patterns
 
@@ -192,11 +202,16 @@ EmitStmt  { Pos, Stream string, Fields []*StructLitField }
 StreamDecl  { Pos, Name, Doc, Fields []*StreamField }
 ModelDecl   { Pos, Name string, Fields []*ModelField }
 OnHandler   { Pos, Stream, Alias string, Body []*Statement }
+EmitStmt    { Pos, Stream string, Fields []*StructLitField }
 AgentDecl   { Pos, Name, Doc, Body []*AgentBlock }
+AgentBlock  { Let *LetStmt, Var *VarStmt, Assign *AssignStmt,
+              On *OnHandler, Intent *IntentDecl }
 IntentDecl  { Pos, Name string, Params []*Param, Return *TypeRef, Body []*Statement }
 FactStmt    { Pos, Pred *LogicPredicate }
 RuleStmt    { Pos, Head *LogicPredicate, Body []*LogicCond }
 ```
+
+`AgentBlock` is a tagged union like `Statement` but scoped to the agent body. `ModelDecl` has no `Doc` field (unlike `StreamDecl`).
 
 These are full nodes, type checked into the environment for the most part, but their semantics live with the interpreter, not the bytecode VM.
 


### PR DESCRIPTION
Closes #21179

**ast/convert.go:** add 6 missing statement converters — ImportStmt, ExternTypeDecl/Var/Fun/Object, EmitStmt.

**New fixtures:** import_stmt, extern_decl, emit_stmt.

**MEP 3 doc:** fix TypeDecl invariant, add AgentBlock + EmitStmt + Extern* docs, correct BinaryExpr line refs, document FunExpr body fields.