### PR TITLE
Make MEP cross-references clickable

### DIFF
--- a/website/docs/mep/mep-0000.md
+++ b/website/docs/mep/mep-0000.md
@@ -120,7 +120,7 @@ When a language change touches a typing rule, the author updates:
 1. The relevant MEP in this directory.
 2. At least one valid fixture under `tests/types/valid/` proving the accepted shape.
 3. At least one error fixture under `tests/types/errors/` proving the rejected shape.
-4. A short note in MEP 10 if the change closes or opens a soundness hole.
+4. A short note in [MEP 10](/docs/mep/mep-0010) if the change closes or opens a soundness hole.
 
 The next contributor should be able to read these MEPs, plus `parser/README.md`, plus the fixtures, and onboard onto the soundness work without reading every line of the type checker.
 

--- a/website/docs/mep/mep-0002.md
+++ b/website/docs/mep/mep-0002.md
@@ -107,7 +107,7 @@ InlineStructType= '{' [ TypeField { ',' TypeField } ] [','] '}'
 TypeField       = Ident ':' TypeRef
 ```
 
-There is no union type literal in `TypeRef`, only in `TypeDecl`. That is why `let x: int | nil = ...` will not parse. The fix is either to lift union into `TypeRef` or to introduce an option syntax such as `int?`. This is tracked in MEP 10.
+There is no union type literal in `TypeRef`, only in `TypeDecl`. That is why `let x: int | nil = ...` will not parse. The fix is either to lift union into `TypeRef` or to introduce an option syntax such as `int?`. This is tracked in [MEP 10](/docs/mep/mep-0010).
 
 There is no tuple type literal. Heterogeneous data must use a struct.
 
@@ -162,7 +162,7 @@ MatchExpr = 'match' Expr '{' MatchCase* '}'
 MatchCase = Expr '=>' ( Expr | '{' Statement* '}' )
 ```
 
-There is no separate pattern grammar. The pattern is just an expression. The checker is responsible for deciding whether a given expression shape is allowed as a pattern. See MEP 13 for the full rules.
+There is no separate pattern grammar. The pattern is just an expression. The checker is responsible for deciding whether a given expression shape is allowed as a pattern. See [MEP 13](/docs/mep/mep-0013) for the full rules.
 
 ### Lambda expressions
 
@@ -187,7 +187,7 @@ LogicTerm       = Ident | String | Int
 LogicQueryExpr  = 'query' LogicPredicate
 ```
 
-These productions parse but the runtime VM does not execute them. The interpreter handles them. See MEP 10.
+These productions parse but the runtime VM does not execute them. The interpreter handles them. See [MEP 10](/docs/mep/mep-0010).
 
 ### Streams and agents
 

--- a/website/docs/mep/mep-0003.md
+++ b/website/docs/mep/mep-0003.md
@@ -247,7 +247,7 @@ Informational. No backward compatibility implications.
 
 ## References
 
-- See MEP 2 for the grammar that produces these nodes.
+- See [MEP 2](/docs/mep/mep-0002) for the grammar that produces these nodes.
 
 ## Copyright
 

--- a/website/docs/mep/mep-0004.md
+++ b/website/docs/mep/mep-0004.md
@@ -62,7 +62,7 @@ Structural kinds:
 
 - `ListType{Elem Type}`. Homogeneous ordered sequence.
 - `MapType{Key Type, Value Type}`. Hash map keyed by `Key`.
-- `OptionType{Elem Type}`. Declared but not produced by inference today. See MEP 10.
+- `OptionType{Elem Type}`. Declared but not produced by inference today. See [MEP 10](/docs/mep/mep-0010).
 - `GroupType{Key Type, Elem Type}`. Internal type carried by the `into Name` clause of a `group by` query.
 - `StructType{Name, Fields, Order, Methods}`. Nominal record. `Order` preserves the declaration sequence so output and JSON encoding are deterministic.
 - `UnionType{Name, Variants}`. Nominal sum of struct-shaped variants. `Variants` is a map but the iteration order should be stable: the variant order from the declaration is captured when the type decl is processed.
@@ -73,11 +73,11 @@ Function kind:
 
 Polymorphism kinds:
 
-- `TypeVar{Name}`. Carried by generic function declarations. Not yet used for full inference. See MEP 12.
+- `TypeVar{Name}`. Carried by generic function declarations. Not yet used for full inference. See [MEP 12](/docs/mep/mep-0012).
 
 Top kind:
 
-- `AnyType{}`. Unifies with everything in both directions. This is the primary unsoundness escape hatch and is documented in detail in MEP 10 and MEP 11.
+- `AnyType{}`. Unifies with everything in both directions. This is the primary unsoundness escape hatch and is documented in detail in [MEP 10](/docs/mep/mep-0010) and [MEP 11](/docs/mep/mep-0011).
 
 ### What is missing
 
@@ -146,7 +146,7 @@ The `+` rule on lists is silently widening, which is a soundness concern when on
 
 Keeping `String()` as the only required method on `Type` makes the kind table easy to extend. Equality and unification are external because they need to be customisable for variance and substitution.
 
-`AnyType` exists because the alternative is making every builtin generic, which we cannot do until parametric polymorphism (MEP 12) lands. `AnyType` is a debt; it is not a design choice.
+`AnyType` exists because the alternative is making every builtin generic, which we cannot do until parametric polymorphism ([MEP 12](/docs/mep/mep-0012)) lands. `AnyType` is a debt; it is not a design choice.
 
 The numeric tower is conservative on purpose. We prefer to widen to `bigrat` when in doubt rather than silently lose precision.
 
@@ -174,20 +174,20 @@ We considered three options before pinning this:
 2. Require an explicit default at the call site, for example `m[k] ?? default`, with a checker error otherwise.
 3. Raise a typed runtime panic.
 
-Option 1 wins on consistency. MEP 10 A2 already commits `OptionType` as the destination for `null` and MEP 10 C1 adds the `T?` shorthand. Once that work lands, missing-key access slots into the same shape without introducing a second mechanism (no new `??` operator, no new panic class). Option 2 would require a new operator and option 3 would force defensive `in m` checks at every call site.
+Option 1 wins on consistency. [MEP 10](/docs/mep/mep-0010) A2 already commits `OptionType` as the destination for `null` and [MEP 10](/docs/mep/mep-0010) C1 adds the `T?` shorthand. Once that work lands, missing-key access slots into the same shape without introducing a second mechanism (no new `??` operator, no new panic class). Option 2 would require a new operator and option 3 would force defensive `in m` checks at every call site.
 
-This is a deferred change. Today the runtime returns the zero value of `V`, which for non-zero-bearing types is a progress violation. The current behaviour is pinned by `tests/types/valid/missing_map_key.mochi` so the future tightening is a deliberate breaking change. The implementation work is tracked alongside MEP 10 A2.
+This is a deferred change. Today the runtime returns the zero value of `V`, which for non-zero-bearing types is a progress violation. The current behaviour is pinned by `tests/types/valid/missing_map_key.mochi` so the future tightening is a deliberate breaking change. The implementation work is tracked alongside [MEP 10](/docs/mep/mep-0010) A2.
 
 ## Open Questions
 
 - **Tuple kind.** A heterogeneous fixed-length sequence has no surface today. We will need it once query result tuples are generalised.
-- **Option kind.** `OptionType` exists but is not produced by inference. MEP 10 ties this to the `null` soundness gap and to the missing-map-key decision above.
+- **Option kind.** `OptionType` exists but is not produced by inference. [MEP 10](/docs/mep/mep-0010) ties this to the `null` soundness gap and to the missing-map-key decision above.
 - **Numeric ordering.** `float` and `bigrat` mix awkwardly. We have not decided whether to widen to `bigrat` or to refuse the mix.
 
 ## References
 
-- See MEP 5 for how these kinds are produced by inference.
-- See MEP 10 for the soundness gaps these kinds expose.
+- See [MEP 5](/docs/mep/mep-0005) for how these kinds are produced by inference.
+- See [MEP 10](/docs/mep/mep-0010) for the soundness gaps these kinds expose.
 
 ## Copyright
 

--- a/website/docs/mep/mep-0005.md
+++ b/website/docs/mep/mep-0005.md
@@ -58,9 +58,9 @@ The expression entry point delegates to `inferBinaryType`, which flattens preced
 7. union  union all  except  intersect
 ```
 
-Within a level the algorithm reduces left to right. The result type table per operator is in MEP 4 under "numeric tower" and the same logic in code at `types/infer.go:114-191`.
+Within a level the algorithm reduces left to right. The result type table per operator is in [MEP 4](/docs/mep/mep-0004) under "numeric tower" and the same logic in code at `types/infer.go:114-191`.
 
-A subtle order dependency exists in numeric mixes. Because the algorithm folds left to right, `bigint - float` and `float - bigint` can produce different result types depending on rule firing order. Fixtures for each pair are required (see MEP 9).
+A subtle order dependency exists in numeric mixes. Because the algorithm folds left to right, `bigint - float` and `float - bigint` can produce different result types depending on rule firing order. Fixtures for each pair are required (see [MEP 9](/docs/mep/mep-0009)).
 
 ### Inference for declarations
 
@@ -76,7 +76,7 @@ var x : T = e    ->  Γ' = Γ ∪ { x : T },
 
 `let` with neither type nor value raises `T000`.
 
-`fun f<G1, G2>(p: T) : R { ... }` introduces type variables in scope for the function body but does not generalise them across calls today. See MEP 12.
+`fun f<G1, G2>(p: T) : R { ... }` introduces type variables in scope for the function body but does not generalise them across calls today. See [MEP 12](/docs/mep/mep-0012).
 
 ### Inference for control flow
 
@@ -124,7 +124,7 @@ Aggregate functions inside `select` are special cased:
 - `avg(g) : float | bigrat`.
 - `min(g)`, `max(g) : T` where `g : [T]` and `T` is comparable.
 
-Anything else falls through to general expression inference. The fall-through is part of why MEP 10 flags loose verification of `select` results.
+Anything else falls through to general expression inference. The fall-through is part of why [MEP 10](/docs/mep/mep-0010) flags loose verification of `select` results.
 
 ### Inference for matches
 
@@ -137,7 +137,7 @@ Anything else falls through to general expression inference. The fall-through is
   - Underscore: binds nothing, never fails.
   - Variant call pattern: requires `e` to have a `UnionType` containing the named variant. Binds field positions to the variant fields.
 
-Exhaustiveness is not enforced today. See MEP 13.
+Exhaustiveness is not enforced today. See [MEP 13](/docs/mep/mep-0013).
 
 ### Inference for casts
 
@@ -172,13 +172,13 @@ So `let u = A(7)` gives `u : U`. Pattern matching is the only way to recover the
 
 ### Inference for closures and lambda
 
-`fun(p1, ..., pn) : R => body` produces type `FuncType{Params: [P1, ..., Pn], Return: R, Pure: false}`. With a block body the return type is inferred from the trailing return statements. Free variables in the body are captured by reference, which has implications for mutation that MEP 15 documents.
+`fun(p1, ..., pn) : R => body` produces type `FuncType{Params: [P1, ..., Pn], Return: R, Pure: false}`. With a block body the return type is inferred from the trailing return statements. Free variables in the body are captured by reference, which has implications for mutation that [MEP 15](/docs/mep/mep-0015) documents.
 
 ## Rationale
 
 Local inference is enough for a small language. Global constraint solving would buy us better generic inference but at the cost of harder-to-explain error messages. We prefer to keep error messages tied to concrete source positions.
 
-The "join" we use for if branches and match arms is conservative: we widen to `any` when in doubt. That is part of why MEP 10 calls out `any` as the most common loss of information.
+The "join" we use for if branches and match arms is conservative: we widen to `any` when in doubt. That is part of why [MEP 10](/docs/mep/mep-0010) calls out `any` as the most common loss of information.
 
 ## Backwards Compatibility
 
@@ -194,13 +194,13 @@ Informational. No backward compatibility implications.
 ## Open Questions
 
 - **Tighter join.** Should the join of two arms produce the union of their types instead of `any`? That would tighten match results but requires anonymous union types.
-- **Generic call inference.** Currently call sites do not unify type variables across positions. MEP 12 proposes the change.
+- **Generic call inference.** Currently call sites do not unify type variables across positions. [MEP 12](/docs/mep/mep-0012) proposes the change.
 - **Aggregate fall-through.** `select` falls through to general expression inference for non-aggregates. We should reject `any` projections in strict mode.
 
 ## References
 
-- See MEP 4 for the kinds inference produces.
-- See MEP 12 for the polymorphism upgrade.
+- See [MEP 4](/docs/mep/mep-0004) for the kinds inference produces.
+- See [MEP 12](/docs/mep/mep-0012) for the polymorphism upgrade.
 
 ## Copyright
 

--- a/website/docs/mep/mep-0006.md
+++ b/website/docs/mep/mep-0006.md
@@ -69,7 +69,7 @@ The function is non-short-circuiting. It accumulates errors and returns all of t
 - `contains(string, string) : bool`. Pure. (Plus list and map overloads registered later in the file.)
 - A pile more builtins for math, strings, lists, maps.
 
-The looseness of many builtins (`any` parameters) is intentional today because we do not have parametric polymorphism. Tightening them is a work item in MEP 12.
+The looseness of many builtins (`any` parameters) is intentional today because we do not have parametric polymorphism. Tightening them is a work item in [MEP 12](/docs/mep/mep-0012).
 
 ### Statement walk
 
@@ -197,13 +197,13 @@ Informational. No backward compatibility implications.
 ## Open Questions
 
 - **Generated error table.** The Markdown table in this MEP is hand-maintained. A generator from `types/errors.go` would keep it honest.
-- **Loose builtins.** `any` parameters are a temporary measure pending MEP 12.
+- **Loose builtins.** `any` parameters are a temporary measure pending [MEP 12](/docs/mep/mep-0012).
 - **`break` and `continue` outside loops.** No error code yet. Should be added.
 
 ## References
 
-- See MEP 5 for the inference rules `Check` consults.
-- See MEP 7 for the soundness obligations `Check` aims to enforce.
+- See [MEP 5](/docs/mep/mep-0005) for the inference rules `Check` consults.
+- See [MEP 7](/docs/mep/mep-0007) for the soundness obligations `Check` aims to enforce.
 
 ## Copyright
 

--- a/website/docs/mep/mep-0007.md
+++ b/website/docs/mep/mep-0007.md
@@ -65,27 +65,27 @@ Stuck states we want to rule out:
 - Pattern matching against a value with no matching arm and no wildcard.
 - Reading a non-existent struct field.
 - Dividing an integer by zero. The runtime raises today; the type system does not flag the literal case.
-- Reading a missing map key without a default. Today the runtime returns the zero value of the map's value type, which violates progress for non-zero-bearing types. Tracked in MEP 4.
+- Reading a missing map key without a default. Today the runtime returns the zero value of the map's value type, which violates progress for non-zero-bearing types. Tracked in [MEP 4](/docs/mep/mep-0004).
 
 ### Property-by-property obligations
 
-The properties below are the test obligations against which fixtures are built. Each property points at the MEP where the rules live and at the fixture group in `tests/types/`. The full coverage matrix lives in MEP 9; the table here is the inline summary for reviewers who want to confirm a property has at least one fixture without leaving this MEP.
+The properties below are the test obligations against which fixtures are built. Each property points at the MEP where the rules live and at the fixture group in `tests/types/`. The full coverage matrix lives in [MEP 9](/docs/mep/mep-0009); the table here is the inline summary for reviewers who want to confirm a property has at least one fixture without leaving this MEP.
 
 | Property              | Source MEP | Fixture pointer                                  |
 |-----------------------|------------|--------------------------------------------------|
-| Progress, primitives  | MEP 4      | `tests/types/valid/canonical_*`                  |
-| Progress, list/map    | MEP 4      | `tests/types/valid/list_*`, `tests/types/valid/map_*` |
-| Progress, function    | MEP 4      | `tests/types/valid/closure_*`                    |
-| Preservation          | MEP 5      | `tests/types/valid/preservation_let_chain.mochi` |
-| Inversion             | MEP 5      | `tests/types/valid/inversion_*`                  |
-| Canonical, bool       | MEP 4      | `tests/types/valid/canonical_bool_only.mochi`    |
-| Canonical, int        | MEP 4      | `tests/types/valid/canonical_int_arithmetic.mochi` |
-| Canonical, string     | MEP 4      | `tests/types/valid/canonical_string_concat.mochi` |
-| Substitution          | MEP 5      | `tests/types/valid/preservation_let_chain.mochi` |
-| Variance              | MEP 11     | none yet, tracked in MEP 11                      |
-| Parametricity         | MEP 12     | none yet, tracked in MEP 12                      |
-| Exhaustiveness        | MEP 13     | `tests/types/valid/match_union_variant.mochi`    |
-| Alpha equivalence     | MEP 8      | none yet, awaiting property-test layer           |
+| Progress, primitives  | [MEP 4](/docs/mep/mep-0004)      | `tests/types/valid/canonical_*`                  |
+| Progress, list/map    | [MEP 4](/docs/mep/mep-0004)      | `tests/types/valid/list_*`, `tests/types/valid/map_*` |
+| Progress, function    | [MEP 4](/docs/mep/mep-0004)      | `tests/types/valid/closure_*`                    |
+| Preservation          | [MEP 5](/docs/mep/mep-0005)      | `tests/types/valid/preservation_let_chain.mochi` |
+| Inversion             | [MEP 5](/docs/mep/mep-0005)      | `tests/types/valid/inversion_*`                  |
+| Canonical, bool       | [MEP 4](/docs/mep/mep-0004)      | `tests/types/valid/canonical_bool_only.mochi`    |
+| Canonical, int        | [MEP 4](/docs/mep/mep-0004)      | `tests/types/valid/canonical_int_arithmetic.mochi` |
+| Canonical, string     | [MEP 4](/docs/mep/mep-0004)      | `tests/types/valid/canonical_string_concat.mochi` |
+| Substitution          | [MEP 5](/docs/mep/mep-0005)      | `tests/types/valid/preservation_let_chain.mochi` |
+| Variance              | [MEP 11](/docs/mep/mep-0011)     | none yet, tracked in [MEP 11](/docs/mep/mep-0011)                      |
+| Parametricity         | [MEP 12](/docs/mep/mep-0012)     | none yet, tracked in [MEP 12](/docs/mep/mep-0012)                      |
+| Exhaustiveness        | [MEP 13](/docs/mep/mep-0013)     | `tests/types/valid/match_union_variant.mochi`    |
+| Alpha equivalence     | [MEP 8](/docs/mep/mep-0008)      | none yet, awaiting property-test layer           |
 
 #### Progress
 
@@ -114,7 +114,7 @@ For example, at `bool`, the only values are `true` and `false`. A fixture assert
 
 #### Inversion
 
-For each typing judgement form we have one fixture per shape. The shape mappings are listed in MEP 5.
+For each typing judgement form we have one fixture per shape. The shape mappings are listed in [MEP 5](/docs/mep/mep-0005).
 
 #### Substitution
 
@@ -131,7 +131,7 @@ For mutable bindings, we test sequencing instead.
 Fixtures cover the following positions:
 
 - Function argument and result, asserting the contravariance of the argument and the covariance of the result.
-- List element, asserting the current behaviour: covariant when read, unsafe when written. The unsafe case is a known weakness in MEP 10.
+- List element, asserting the current behaviour: covariant when read, unsafe when written. The unsafe case is a known weakness in [MEP 10](/docs/mep/mep-0010).
 - Map key and value, asserting invariance.
 
 #### Parametricity
@@ -148,7 +148,7 @@ Once parametric polymorphism is wired through, we add the standard parametricity
 For each tagged union declaration in fixtures:
 
 - A `match` covering every variant type checks.
-- A `match` missing a variant fails today (when implemented; flagged in MEP 13 as a hole).
+- A `match` missing a variant fails today (when implemented; flagged in [MEP 13](/docs/mep/mep-0013) as a hole).
 - A `match` with an arm that is a strict subset of an earlier arm fails (when implemented).
 
 #### Alpha equivalence
@@ -161,12 +161,12 @@ The escape hatches we acknowledge. Each row points at the MEP that owns the fix 
 
 | Escape hatch                                         | Tracked in       | Pinning fixture                              |
 |------------------------------------------------------|------------------|----------------------------------------------|
-| `AnyType` unifies in both directions                 | MEP 11           | none yet, planned `any_top_silent_widen`     |
-| `as` cast accepted without compatibility check       | MEP 11           | none yet, planned `cast_int_as_string`       |
-| `null` is `any` rather than an option type           | MEP 4, MEP 10    | none yet                                     |
-| Aliasing a `let` aggregate into a `var` allows a write through the alias to mutate the original | MEP 15 | `tests/types/valid/mutate_through_let_alias.mochi` |
-| Reading a missing map key returns the zero value     | MEP 4            | `tests/types/valid/missing_map_key.mochi`    |
-| Integer division by zero is a runtime panic, not a checker rejection | MEP 5 | none yet                            |
+| `AnyType` unifies in both directions                 | [MEP 11](/docs/mep/mep-0011)           | none yet, planned `any_top_silent_widen`     |
+| `as` cast accepted without compatibility check       | [MEP 11](/docs/mep/mep-0011)           | none yet, planned `cast_int_as_string`       |
+| `null` is `any` rather than an option type           | [MEP 4](/docs/mep/mep-0004), [MEP 10](/docs/mep/mep-0010)    | none yet                                     |
+| Aliasing a `let` aggregate into a `var` allows a write through the alias to mutate the original | [MEP 15](/docs/mep/mep-0015) | `tests/types/valid/mutate_through_let_alias.mochi` |
+| Reading a missing map key returns the zero value     | [MEP 4](/docs/mep/mep-0004)            | `tests/types/valid/missing_map_key.mochi`    |
+| Integer division by zero is a runtime panic, not a checker rejection | [MEP 5](/docs/mep/mep-0005) | none yet                            |
 
 Listing the fixture column on the right is uncomfortable on purpose. Every blank cell is a bug we have decided not to flag yet; the decision should be deliberate.
 
@@ -203,7 +203,7 @@ The escape hatches above will be tightened over time. Each tightening is a break
 ## Open Questions
 
 - **Step-level reduction relation.** We approximate preservation today. A formal small-step semantics would let us mechanise the proof. Out of scope for v0.11.0.
-- **Property test infrastructure.** Alpha equivalence and other meta properties want a generator-based test framework. Track in MEP 8.
+- **Property test infrastructure.** Alpha equivalence and other meta properties want a generator-based test framework. Track in [MEP 8](/docs/mep/mep-0008).
 
 ## References
 

--- a/website/docs/mep/mep-0008.md
+++ b/website/docs/mep/mep-0008.md
@@ -49,7 +49,7 @@ CI runs layers 1 to 4 today. Layer 5 is the next step.
 
 ### TAPL chapter mapping
 
-Every property in MEP 7 corresponds to a chapter or chapter group in Pierce's *Types and Programming Languages*. Fixture authors should consult the relevant chapter for the canonical test cases and edge cases.
+Every property in [MEP 7](/docs/mep/mep-0007) corresponds to a chapter or chapter group in Pierce's *Types and Programming Languages*. Fixture authors should consult the relevant chapter for the canonical test cases and edge cases.
 
 | Property                      | TAPL ch. | MEP        | Fixture group       |
 |-------------------------------|----------|------------|---------------------|
@@ -120,11 +120,11 @@ go test ./tests/types/property/...
 
 When adding a new fixture pair:
 
-1. Decide the property it witnesses (MEP 7 list).
+1. Decide the property it witnesses ([MEP 7](/docs/mep/mep-0007) list).
 2. Pick a name following the convention.
 3. Write the `.mochi` source.
 4. For valid fixtures, run `make update-golden STAGE=types` and inspect the golden.
-5. For error fixtures, run the test and inspect the `.err` against the diagnostic catalogue in MEP 6.
+5. For error fixtures, run the test and inspect the `.err` against the diagnostic catalogue in [MEP 6](/docs/mep/mep-0006).
 6. Commit both files in a single change with a one-line note in the PR body listing the property the fixture covers.
 
 ## Rationale

--- a/website/docs/mep/mep-0009.md
+++ b/website/docs/mep/mep-0009.md
@@ -23,7 +23,7 @@ description: Inventory of parser and type fixtures with a property coverage matr
 
 ## Abstract
 
-This MEP is the live inventory of parser and type fixtures, plus a coverage matrix that maps each soundness property in MEP 7 to the fixtures that exercise it. New fixtures are added to the inventory in the same commit that introduces the file.
+This MEP is the live inventory of parser and type fixtures, plus a coverage matrix that maps each soundness property in [MEP 7](/docs/mep/mep-0007) to the fixtures that exercise it. New fixtures are added to the inventory in the same commit that introduces the file.
 
 ## Motivation
 
@@ -121,7 +121,7 @@ struct_unknown_field_access
 
 The matrix is a property-to-fixture mapping. A cell value of `existing` means at least one fixture in the corresponding directory exercises the property. `missing` means we need to author one.
 
-| Property (from MEP 7)                    | Valid     | Error     |
+| Property (from [MEP 7](/docs/mep/mep-0007))                    | Valid     | Error     |
 |------------------------------------------|-----------|-----------|
 | Progress, primitives                     | existing  | existing  |
 | Progress, list and map                   | existing  | existing  |
@@ -176,14 +176,14 @@ The matrix is a property-to-fixture mapping. A cell value of `existing` means at
 
 Grouped by MEP.
 
-From MEP 4 (type system):
+From [MEP 4](/docs/mep/mep-0004) (type system):
 
 - `type_void_not_assignable` (error, T009 family).
 - `type_struct_nominal_inequality` (error, two anon structs).
 - `type_bigint_string` (valid).
 - `type_bigrat_string` (valid).
 
-From MEP 5 (inference):
+From [MEP 5](/docs/mep/mep-0005) (inference):
 
 - `numeric_int_div_int` (valid, asserts int / int : int).
 - `numeric_bigint_minus_float` (valid).
@@ -195,26 +195,26 @@ From MEP 5 (inference):
 - `aggregate_min_string_list` (valid).
 - `aggregate_sum_bigint_list` (valid).
 
-From MEP 7 (soundness):
+From [MEP 7](/docs/mep/mep-0007) (soundness):
 
 - `preservation_let_substitution` (valid, sequence).
 - `inversion_every_primary` (valid, large composite).
 
-From MEP 11 (subtyping):
+From [MEP 11](/docs/mep/mep-0011) (subtyping):
 
 - `record_width_subtype` (valid, when implemented).
 - `any_top_silent_widen` (valid, snapshots current behaviour).
 - `any_to_int_unchecked` (valid, snapshots current behaviour).
 - `cast_int_as_string` (valid, snapshots current behaviour).
 
-From MEP 12 (polymorphism):
+From [MEP 12](/docs/mep/mep-0012) (polymorphism):
 
 - `generic_id_int_string` (valid).
 - `generic_id_per_call_freshness` (valid).
 - `generic_pair_swap` (valid, when implemented).
 - `generic_unification_conflict` (error, when implemented).
 
-From MEP 13 (ADT):
+From [MEP 13](/docs/mep/mep-0013) (ADT):
 
 - `adt_struct_field_mismatch` (error).
 - `adt_union_constructor_arity` (error).
@@ -223,7 +223,7 @@ From MEP 13 (ADT):
 - `adt_match_redundant_variant` (error, when implemented).
 - `adt_match_wildcard_after` (valid).
 
-From MEP 14 (queries):
+From [MEP 14](/docs/mep/mep-0014) (queries):
 
 - `query_select_arbitrary_expr` (valid).
 - `query_join_cardinality` (valid).
@@ -231,7 +231,7 @@ From MEP 14 (queries):
 - `query_distinct_unique_int` (valid).
 - `query_skip_take_int` (valid).
 
-From MEP 15 (effects):
+From [MEP 15](/docs/mep/mep-0015) (effects):
 
 - `mutate_through_let_index` (valid today, error after fix).
 - `mutate_through_let_field` (valid today, error after fix).
@@ -264,8 +264,8 @@ Informational. No backward compatibility implications.
 
 ## References
 
-- See MEP 7 for the property list.
-- See MEP 8 for the test layer that owns each fixture.
+- See [MEP 7](/docs/mep/mep-0007) for the property list.
+- See [MEP 8](/docs/mep/mep-0008) for the test layer that owns each fixture.
 
 ## Copyright
 

--- a/website/docs/mep/mep-0010.md
+++ b/website/docs/mep/mep-0010.md
@@ -42,7 +42,7 @@ A fixture pinned to current behaviour is not the same as endorsement. Some entri
 **Plan.**
 
 1. Capture the current behaviour in a fixture (`tests/types/valid/any_top_silent_widen.mochi`).
-2. Audit which builtins truly need `any` and rewrite the rest with parametric polymorphism once MEP 12 lands.
+2. Audit which builtins truly need `any` and rewrite the rest with parametric polymorphism once [MEP 12](/docs/mep/mep-0012) lands.
 3. Tighten `unify` so `any` requires an explicit `as` cast in either direction.
 
 #### A2. null is a value of any type
@@ -139,7 +139,7 @@ Path A matches the runtime today. We recommend it.
 
 **Impact.** A function declared `fun id<T>(x: T): T` is callable but the caller always sees the type of `x` flow through the declaration in a loose way.
 
-**Plan.** Wire `TypeVar` through inference. Build a small substitution solver so a call generates fresh variables and unifies arguments. Reject conflicting unifications with a new error code. See MEP 12.
+**Plan.** Wire `TypeVar` through inference. Build a small substitution solver so a call generates fresh variables and unifies arguments. Reject conflicting unifications with a new error code. See [MEP 12](/docs/mep/mep-0012).
 
 #### B6. Query select fallback to any
 
@@ -189,7 +189,7 @@ Path A matches the runtime today. We recommend it.
 
 **Impact.** `x == -1` requires parens. Inserting whitespace as `x == - 1` does not help; the parser sees `-` followed by `1` as a missing-operand prefix and fails the same way. Surprising for new users.
 
-**Plan.** Document in `parser/README.md` and in MEP 1. Long term, look at splitting the lexer rule so `-1` is a number when not preceded by an ident or close bracket.
+**Plan.** Document in `parser/README.md` and in [MEP 1](/docs/mep/mep-0001). Long term, look at splitting the lexer rule so `-1` is a number when not preceded by an ident or close bracket.
 
 #### C3. Logic and stream features parse but do not run on the bytecode VM
 
@@ -217,9 +217,9 @@ Path A matches the runtime today. We recommend it.
 
 ### Tier D: documentation drift
 
-- MEP 9 must be regenerated whenever fixture counts change.
-- Builtins listed in MEP 6 must match the actual code; today they do, but the list is hand-maintained.
-- The error code table in MEP 6 is hand-maintained too. Consider a generator that emits Markdown from `types/errors.go`.
+- [MEP 9](/docs/mep/mep-0009) must be regenerated whenever fixture counts change.
+- Builtins listed in [MEP 6](/docs/mep/mep-0006) must match the actual code; today they do, but the list is hand-maintained.
+- The error code table in [MEP 6](/docs/mep/mep-0006) is hand-maintained too. Consider a generator that emits Markdown from `types/errors.go`.
 
 ## Rationale
 
@@ -240,8 +240,8 @@ References to source files and lines are inline above.
 
 ## References
 
-- See MEP 7 for the soundness contract this document offends against.
-- See MEP 12 for the polymorphism upgrade that closes A1 and B5.
+- See [MEP 7](/docs/mep/mep-0007) for the soundness contract this document offends against.
+- See [MEP 12](/docs/mep/mep-0012) for the polymorphism upgrade that closes A1 and B5.
 
 ## Copyright
 

--- a/website/docs/mep/mep-0011.md
+++ b/website/docs/mep/mep-0011.md
@@ -51,7 +51,7 @@ bigint <: bigrat
 float <: bigrat         (lossy, but the inference uses bigrat as the join)
 
 [S] <: [T]              if S <: T  (read only positions)
-[S] = [T]               if S = T   (read write positions, after MEP 10 A3 lands)
+[S] = [T]               if S = T   (read write positions, after [MEP 10](/docs/mep/mep-0010) A3 lands)
 {K1: V1} = {K2: V2}     if K1 = K2 and V1 = V2
 fun(P1...) : R1 <: fun(Q1...) : R2
                         if Pi <: Qi (contravariance flipped) and R1 <: R2
@@ -94,7 +94,7 @@ Casting to `any` should always succeed at type check time: it is the top type. C
 - Casts among numeric types should be accepted at type check time and should perform the documented coercion at runtime.
 - Casts among unrelated types (`int as string`, `string as bool`) should be rejected.
 
-The runtime guard is on the roadmap. A cleaner design is in MEP 10 A5.
+The runtime guard is on the roadmap. A cleaner design is in [MEP 10](/docs/mep/mep-0010) A5.
 
 ### How the checker computes subtyping
 
@@ -132,7 +132,7 @@ Numeric tower fixtures:
 List variance fixtures:
 
 - `variance_list_read_covariant` (valid, snapshots current behaviour).
-- `variance_list_write_invariant` (error, after MEP 10 A3 lands).
+- `variance_list_write_invariant` (error, after [MEP 10](/docs/mep/mep-0010) A3 lands).
 
 Map invariance fixtures:
 

--- a/website/docs/mep/mep-0012.md
+++ b/website/docs/mep/mep-0012.md
@@ -122,7 +122,7 @@ Once user-defined generic structs land, add:
 2. Move builtins one by one from `AnyType` parameters to `TypeVar` parameters. After each move, run the type valid suite.
 3. Remove the loose builtin declarations.
 4. Tighten the call site checker to use the new substitution path.
-5. Author fixtures and update MEP 9.
+5. Author fixtures and update [MEP 9](/docs/mep/mep-0009).
 
 ## Rationale
 
@@ -130,7 +130,7 @@ A small, deterministic algorithm beats Hindley-Milner for our use case. We do no
 
 Bounded quantification (`T extends Comparable`) is out of scope. The need has not surfaced in idiomatic Mochi code. We may revisit when sorted query support is generalised beyond the built-in numeric and string ordering.
 
-Subtype polymorphism on tagged unions stays as it is in MEP 11. The generic parameter mechanism is independent of variant subtyping.
+Subtype polymorphism on tagged unions stays as it is in [MEP 11](/docs/mep/mep-0011). The generic parameter mechanism is independent of variant subtyping.
 
 ## Backwards Compatibility
 

--- a/website/docs/mep/mep-0013.md
+++ b/website/docs/mep/mep-0013.md
@@ -60,7 +60,7 @@ type Id = int
 type Name = string
 ```
 
-The surface is documented in MEP 2 (grammar) and MEP 3 (AST). This MEP focuses on typing and pattern matching obligations.
+The surface is documented in [MEP 2](/docs/mep/mep-0002) (grammar) and [MEP 3](/docs/mep/mep-0003) (AST). This MEP focuses on typing and pattern matching obligations.
 
 ### Struct typing
 
@@ -148,7 +148,7 @@ The grammar does not support `type List<T> = Cons(head: T, tail: List<T>) | Nil`
 - Generic constructor types parameterised by the type parameters.
 - Generic match patterns that accept a type argument list at the variant call.
 
-We mark this as future work. The parser changes are non-trivial and MEP 12 (polymorphism) needs to land first.
+We mark this as future work. The parser changes are non-trivial and [MEP 12](/docs/mep/mep-0012) (polymorphism) needs to land first.
 
 ### Fixtures to author
 
@@ -177,7 +177,7 @@ Match exhaustiveness is the textbook benefit of sum types. Without it, a large p
 
 Recursive types are necessary for any non-trivial use of unions. The shared-variants resolution path we already have makes this cheap to support.
 
-We defer generic ADTs because they require both grammar and inference work. MEP 12 needs to land first.
+We defer generic ADTs because they require both grammar and inference work. [MEP 12](/docs/mep/mep-0012) needs to land first.
 
 ## Backwards Compatibility
 

--- a/website/docs/mep/mep-0014.md
+++ b/website/docs/mep/mep-0014.md
@@ -55,7 +55,7 @@ Required: `from` and `select`. Everything else is optional. The order is fixed b
 
 Additional `from y in ys` clauses behave like nested loops. The projection sees both `x` and `y` in scope. There is no implicit cross-join elision; the result enumerates the cartesian product unless joined.
 
-`join z in zs on cond` requires `zs : [U]` (T034) and `cond : bool` (T035). The join side modifier (`left`, `right`, `outer`) controls the cardinality of unmatched rows. A left join may produce `z = null` for unmatched outer rows; today this returns `any` because of MEP 10 A2.
+`join z in zs on cond` requires `zs : [U]` (T034) and `cond : bool` (T035). The join side modifier (`left`, `right`, `outer`) controls the cardinality of unmatched rows. A left join may produce `z = null` for unmatched outer rows; today this returns `any` because of [MEP 10](/docs/mep/mep-0010) A2.
 
 `where pred` requires `pred : bool` (T033). The body filters rows.
 
@@ -92,7 +92,7 @@ Cardinality fixtures:
 - Left join with one unmatched left row: result has the matched row and one row with the right side `null`.
 - Outer join with disjoint sides: result has the union of rows.
 
-The current `null` behaviour falls under MEP 10 A2 (null is `any`). Once options are wired, the right-side bindings in a left join become `Option<T>` and pattern matching is required to access them.
+The current `null` behaviour falls under [MEP 10](/docs/mep/mep-0010) A2 (null is `any`). Once options are wired, the right-side bindings in a left join become `Option<T>` and pattern matching is required to access them.
 
 ### Group plan and types
 
@@ -163,7 +163,7 @@ New:
 
 LINQ-shaped queries are familiar, simple to teach, and easy to translate to a relational plan. We keep the clause order fixed because that simplifies the parser and makes the plan obvious.
 
-The `null`-from-left-join hack is a known wart. Once MEP 10 A2 lands, the right-side bindings become `Option<T>` and pattern matching is required to access them. We accept the wart in the meantime because changing it requires the option work.
+The `null`-from-left-join hack is a known wart. Once [MEP 10](/docs/mep/mep-0010) A2 lands, the right-side bindings become `Option<T>` and pattern matching is required to access them. We accept the wart in the meantime because changing it requires the option work.
 
 ## Backwards Compatibility
 
@@ -179,7 +179,7 @@ Tightening sort, distinct, and skip/take to type-check at compile time is a brea
 
 - **Ordered trait.** Decide between an explicit interface for `min`, `max`, `sort` or a hard-coded list of orderable kinds.
 - **Hashable trait.** Same question for `distinct` and group keys.
-- **Right-side `null` in left join.** Tied to MEP 10 A2.
+- **Right-side `null` in left join.** Tied to [MEP 10](/docs/mep/mep-0010) A2.
 
 ## References
 

--- a/website/docs/mep/mep-0015.md
+++ b/website/docs/mep/mep-0015.md
@@ -36,7 +36,7 @@ Today `let` is half-immutable: top-level reassignment is rejected, but `let xs =
 Mochi is not effect-typed. There is no row of effects on function arrows. The pieces we do have:
 
 - `Pure` flag on `FuncType`. Set on builtins that are deterministic pure functions and on user functions whose bodies are inferred pure. Not enforced at call sites today.
-- `let` versus `var` mutability annotation on bindings. Enforced for top-level reassignment, partially enforced for nested mutation (MEP 10 A3).
+- `let` versus `var` mutability annotation on bindings. Enforced for top-level reassignment, partially enforced for nested mutation ([MEP 10](/docs/mep/mep-0010) A3).
 - I/O statements: `print`, `json`, `fetch`, `load`, `save`. These are not flagged by the type system; the programmer knows they are effectful from the function name.
 
 ### Mutability today
@@ -49,7 +49,7 @@ The state of mutability checks:
 - `let p = {x: 1, y: 2}; p.x = 9` for a struct `p`. Accepted today. Should be rejected.
 - `let mp = {"a": 1}; mp["a"] = 9`. Accepted today. Should be rejected because `mp` is `let`.
 
-The fix described in MEP 10 A3 is to inspect the mutability of the root binding of an `AssignStmt`, walking through `Index` and `Field` ops to find the root.
+The fix described in [MEP 10](/docs/mep/mep-0010) A3 is to inspect the mutability of the root binding of an `AssignStmt`, walking through `Index` and `Field` ops to find the root.
 
 Closures complicate this. A closure that captures a `var` binding can mutate it. A closure that captures a `let` binding cannot reassign it but today can mutate through indices and fields in the same way as above. After A3, closures should follow the same rule.
 


### PR DESCRIPTION
Closes #21181

## Summary
- Replace every bare `MEP N` text reference with a Markdown hyperlink `[MEP N](/docs/mep/mep-000N)` across all 16 MEP docs
- 15 files changed, 90 link substitutions
- Skips frontmatter fields, H1 headings, and per-file metadata table rows

## Test plan
- [ ] Verify links resolve correctly in local Docusaurus dev server
- [ ] Spot-check a few cross-references in rendered output