### PR TITLE
MEP 4 cleanup: factual fixes, correct line refs, remove em-dashes

### DIFF
--- a/website/docs/mep/mep-0004.md
+++ b/website/docs/mep/mep-0004.md
@@ -27,7 +27,7 @@ Mochi has a small structural type system with nominal records and unions. This M
 
 ## Motivation
 
-The type system is the contract between the checker and the runtime. A single misunderstanding about whether `int` and `int64` are equal, or whether `any` is a top type or a bottom type, can produce a soundness gap that is difficult to track down. Documenting the kinds and their relationships up front makes future changes deliberate.
+The type system is the contract between the checker and the runtime. Misunderstandings about whether `int` and `int64` are equal, or whether `any` is a top type or a bottom type, produce soundness gaps that are hard to track down later. This MEP documents the kinds and their relationships so future changes are deliberate.
 
 ## Specification
 
@@ -41,11 +41,11 @@ type Type interface {
 }
 ```
 
-There is no equality method on the interface. Equality is computed externally by `equalTypes` in `types/infer.go` and structural unification is done by `unify` in `types/check.go:148-387`. Two types are considered equal when their `String()` representations agree, with carve-outs for variance and `any`.
+There is no equality method on the interface. Equality is computed externally by `equalTypes` in `types/infer.go` and structural unification is done by `unify` in `types/check.go:150-387`. The fallthrough case in `equalTypes` is `reflect.DeepEqual`, with explicit carve-outs for `Int`/`Int64` interop, union/struct member matching, and option types. `unify` uses a different rule for `AnyType`: see below.
 
 ### Kinds present today
 
-Listed in source order at `types/check.go:16-148`.
+Listed in source order at `types/check.go:16-140`.
 
 Primitive kinds:
 
@@ -104,17 +104,18 @@ Environments are linked. A child environment delegates lookups to its parent and
 
 ### Equality and unification
 
-Two types are equal when they are structurally identical at every level. The exact rules in `equalTypes` (search `types/infer.go`):
+The exact rules in `equalTypes` (`types/infer.go`):
 
-- Two primitives are equal iff their kinds match. `IntType` and `Int64Type` are not equal here, although arithmetic widens between them.
+- `IntType` and `Int64Type` are equal to each other. The code has explicit carve-outs so `int64` result types (for example from `now()`) unify cleanly with `int` variables.
 - Two list types are equal iff their element types are equal.
 - Two map types are equal iff key and value types are equal.
-- Two function types are equal iff they have the same arity, the same parameter types pairwise, the same return type, and the same `Variadic` flag.
-- Two struct types are equal iff their `Name` fields agree. This is nominal. Two structurally identical anonymous structs declared separately are not equal because their generated names differ.
-- Two union types are equal iff their `Name` fields agree.
-- `AnyType` is equal to everything. This is the unsoundness hatch.
+- Two function types are equal iff arity, parameter types, return type, and `Variadic` flag all match.
+- Two struct types are equal by `reflect.DeepEqual`; in practice names are unique so this reduces to name equality.
+- Two union types are equal by name.
+- A `StructType` is equal to a `UnionType` when the struct is one of the union's variants. This is what allows `match` arms typed as variant structs to satisfy a union binding.
+- `AnyType` is equal only to another `AnyType` in `equalTypes`. It is `unify` that accepts `AnyType` on either side as a match; that is the unsoundness escape hatch.
 
-Unification is the same predicate but propagates substitutions for `TypeVar`. See `types/check.go:148-387`.
+Unification propagates substitutions for `TypeVar` on top of the equality rules. See `types/check.go:150-387`.
 
 ### Numeric tower
 
@@ -156,38 +157,38 @@ Informational. No backward compatibility implications.
 
 ## Reference Implementation
 
-- `types/check.go:12-14` — `Type` interface.
-- `types/check.go:16-148` — kind definitions.
-- `types/check.go:148-387` — `unify`.
-- `types/infer.go` — `equalTypes` and operator typing.
-- `types/env.go` — environment API.
+- `types/check.go:12-14`: `Type` interface.
+- `types/check.go:16-140`: kind definitions.
+- `types/check.go:150-387`: `unify`.
+- `types/infer.go`: `equalTypes` and operator typing.
+- `types/env.go`: environment API.
 
 ## Pinned decisions
 
 ### Reading a missing map key
 
-For `m: map<K, V>` and a key `k` that is not present in `m`, the expression `m[k]` will infer to `OptionType{V}`. Callers must unwrap the option before using the value at type `V`. The runtime will produce the absent variant instead of the zero value.
+Once [MEP 10](/docs/mep/mep-0010) A2 lands, `m[k]` for an absent key will infer to `OptionType{V}`. Callers must unwrap the option before using the value at type `V`.
 
-We considered three options before pinning this:
+Three options were considered:
 
 1. Type `m[k]` as `V?`. Picked.
-2. Require an explicit default at the call site, for example `m[k] ?? default`, with a checker error otherwise.
+2. Require an explicit default, `m[k] ?? default`, with a checker error otherwise.
 3. Raise a typed runtime panic.
 
-Option 1 wins on consistency. [MEP 10](/docs/mep/mep-0010) A2 already commits `OptionType` as the destination for `null` and [MEP 10](/docs/mep/mep-0010) C1 adds the `T?` shorthand. Once that work lands, missing-key access slots into the same shape without introducing a second mechanism (no new `??` operator, no new panic class). Option 2 would require a new operator and option 3 would force defensive `in m` checks at every call site.
+Option 1 wins because it reuses the same `OptionType` shape that [MEP 10](/docs/mep/mep-0010) A2 gives `null` and [MEP 10](/docs/mep/mep-0010) C1 gives the `T?` shorthand. Option 2 needs a new operator; option 3 forces `in m` guards at every call site.
 
-This is a deferred change. Today the runtime returns the zero value of `V`, which for non-zero-bearing types is a progress violation. The current behaviour is pinned by `tests/types/valid/missing_map_key.mochi` so the future tightening is a deliberate breaking change. The implementation work is tracked alongside [MEP 10](/docs/mep/mep-0010) A2.
+Today the runtime returns the zero value of `V`. For non-zero-bearing types this is a progress violation. The current behaviour is pinned by `tests/types/valid/missing_map_key.mochi`; the future tightening is a deliberate breaking change tracked alongside [MEP 10](/docs/mep/mep-0010) A2.
 
 ## Open Questions
 
-- **Tuple kind.** A heterogeneous fixed-length sequence has no surface today. We will need it once query result tuples are generalised.
-- **Option kind.** `OptionType` exists but is not produced by inference. [MEP 10](/docs/mep/mep-0010) ties this to the `null` soundness gap and to the missing-map-key decision above.
-- **Numeric ordering.** `float` and `bigrat` mix awkwardly. We have not decided whether to widen to `bigrat` or to refuse the mix.
+- **Tuple kind.** No surface type for heterogeneous fixed-length sequences. Needed once query result tuples are generalised.
+- **Option kind.** `OptionType` exists but is not produced by inference today. Tied to the `null` soundness gap in [MEP 10](/docs/mep/mep-0010).
+- **Numeric ordering.** `float` and `bigrat` mix awkwardly. No decision yet on whether to widen to `bigrat` or reject the mix.
 
 ## References
 
-- See [MEP 5](/docs/mep/mep-0005) for how these kinds are produced by inference.
-- See [MEP 10](/docs/mep/mep-0010) for the soundness gaps these kinds expose.
+- [MEP 5](/docs/mep/mep-0005): how these kinds are produced by inference.
+- [MEP 10](/docs/mep/mep-0010): soundness gaps these kinds expose.
 
 ## Copyright
 


### PR DESCRIPTION
Closes #21183

## Summary
- `equalTypes` uses `reflect.DeepEqual` not `String()` comparison
- `IntType`/`Int64Type` are equal in `equalTypes` (the doc said they were not)
- `AnyType` only equals `AnyType` in `equalTypes`; the unsoundness lives in `unify`
- Document the union/struct member equality rule (variant struct equals parent union)
- Correct line refs: kinds `16-148` → `16-140`, unify `148-387` → `150-387`
- Remove em-dashes from Reference Implementation section
- Trim verbose sentences in Motivation and Pinned Decisions

## Test plan
- [ ] Verify code at `types/check.go:150` is `func unify`
- [ ] Verify code at `types/check.go:16-140` covers all kind structs
- [ ] Verify `equalTypes` at `types/infer.go:840` matches the documented rules