### PR TITLE
MEP 4: link tracking issues for code gaps

### DIFF
--- a/website/docs/mep/mep-0004.md
+++ b/website/docs/mep/mep-0004.md
@@ -69,7 +69,7 @@ Structural kinds:
 
 Function kind:
 
-- `FuncType{Params, Return, Pure, Variadic}`. The `Pure` flag is computed but not enforced anywhere yet. The `Variadic` flag is exercised by builtins like `concat` and `range`.
+- `FuncType{Params, Return, Pure, Variadic}`. The `Pure` flag is computed but not enforced anywhere yet (tracked in [#21188](https://github.com/mochilang/mochi/issues/21188)). The `Variadic` flag is exercised by builtins like `concat` and `range`.
 
 Polymorphism kinds:
 
@@ -141,7 +141,7 @@ The actual rules used by `inferBinaryType`:
 - List plus list returns the same list type if elements agree, or `[any]` otherwise.
 - Otherwise `any`.
 
-The `+` rule on lists is silently widening, which is a soundness concern when one side is mutated.
+The `+` rule on lists silently widens to `[any]` on element type mismatch. This is a soundness gap tracked in [#21187](https://github.com/mochilang/mochi/issues/21187).
 
 ## Rationale
 
@@ -177,7 +177,7 @@ Three options were considered:
 
 Option 1 wins because it reuses the same `OptionType` shape that [MEP 10](/docs/mep/mep-0010) A2 gives `null` and [MEP 10](/docs/mep/mep-0010) C1 gives the `T?` shorthand. Option 2 needs a new operator; option 3 forces `in m` guards at every call site.
 
-Today the runtime returns the zero value of `V`. For non-zero-bearing types this is a progress violation. The current behaviour is pinned by `tests/types/valid/missing_map_key.mochi`; the future tightening is a deliberate breaking change tracked alongside [MEP 10](/docs/mep/mep-0010) A2.
+Today the runtime returns the zero value of `V`. For non-zero-bearing types this is a progress violation. The current behaviour is pinned by `tests/types/valid/missing_map_key.mochi`; the future tightening is a deliberate breaking change tracked in [#21186](https://github.com/mochilang/mochi/issues/21186) alongside [MEP 10](/docs/mep/mep-0010) A2.
 
 ## Open Questions
 


### PR DESCRIPTION
Links the three code-gap issues opened from MEP 4's audit:

- [#21186](https://github.com/mochilang/mochi/issues/21186) — Wire `OptionType` through inference for missing map key access
- [#21187](https://github.com/mochilang/mochi/issues/21187) — List `+` silently widens to `[any]` on element mismatch
- [#21188](https://github.com/mochilang/mochi/issues/21188) — Enforce `Pure` flag in query predicates