### PR TITLE
website: fix MEP 6 doc correctness

### DIFF
--- a/website/docs/mep/mep-0006.md
+++ b/website/docs/mep/mep-0006.md
@@ -33,7 +33,7 @@ Type checker source files quickly become hard to read because every statement fo
 
 ### Entry point
 
-`types/check.go:391`. The signature:
+`types/check.go:385`. The signature:
 
 ```
 func Check(prog *parser.Program, env *Env) []error
@@ -43,7 +43,7 @@ The function is non-short-circuiting. It accumulates errors and returns all of t
 
 ### Builtin environment
 
-`types/check.go:392-562` registers the builtins. The list at v0.10.82:
+`types/check.go:386-619` registers the builtins. The list at v0.10.82:
 
 - `print(...) : void`. Variadic, accepts `any`.
 - `len(any) : int`. Loosely typed. Pure.
@@ -122,16 +122,21 @@ Highlights:
 | T006 | too many arguments                                   |
 | T007 | argument N type mismatch                             |
 | T008 | type mismatch in assignment context                  |
-| T009 | cannot assign type to immutable                      |
+| T009 | type mismatch in assignment (use `var` for mutation) |
 | T010 | return type mismatch                                 |
 | T011 | expect must be a boolean                             |
 | T013 | incompatible comparison                              |
 | T014 | invalid primary expression                           |
-| T020 | operator cannot be used on the operand types        |
+| T015 | index must be an integer                             |
+| T016 | missing index expression                             |
+| T017 | slicing not allowed on map                           |
+| T018 | type does not support indexing                       |
+| T019 | map key type mismatch                                |
+| T020 | operator cannot be used on the operand types         |
 | T021 | unsupported operator                                 |
 | T022 | cannot iterate over type                             |
 | T023 | range loop bounds not int                            |
-| T024 | cannot assign to let binding                         |
+| T024 | cannot assign to immutable binding                   |
 | T025 | unknown type                                         |
 | T026 | unknown field on struct                              |
 | T027 | not a struct                                         |
@@ -150,7 +155,8 @@ Highlights:
 | T040 | if condition must be bool                            |
 | T041 | sum expects numeric list or group                    |
 | T042 | having must be bool                                  |
-| T043 | operator cannot be used with `any`                  |
+| T043 | operator cannot be used with `any`                   |
+| T044 | impure call not allowed in where/having predicate    |
 
 The series has gaps. New codes should be appended to the end with the next free integer.
 
@@ -158,7 +164,7 @@ The series has gaps. New codes should be appended to the end with the next free 
 
 `types/check_test.go`.
 
-- `TestTypeChecker_Valid` runs every `.mochi` file in `tests/types/valid/` against the checker and confirms no errors. The `RUN_TYPE_VALID=1` gate was removed in the v0.11.0 soundness PR.
+- `TestTypeChecker_Valid` runs every `.mochi` file in `tests/types/valid/` against the checker and confirms no errors.
 - `TestTypeChecker_Errors` runs every `.mochi` file in `tests/types/errors/` and snapshots the error stream against the matching `.err` file.
 
 The `.err` snapshot is a strict equality check. Renaming an error message is a deliberate breaking change.
@@ -189,10 +195,10 @@ Informational. No backward compatibility implications.
 
 ## Reference Implementation
 
-- `types/check.go:391` — `Check` entry point.
-- `types/check.go:392-562` — builtin registration.
-- `types/errors.go` — error catalogue.
-- `types/check_test.go` — golden tests.
+- `types/check.go:385`: `Check` entry point.
+- `types/check.go:386-619`: builtin registration.
+- `types/errors.go`: error catalogue.
+- `types/check_test.go`: golden tests.
 
 ## Open Questions
 


### PR DESCRIPTION
Closes #21194

## Summary

- Correct `Check` entry point line ref (391 -> 385) and builtin registration range (392-562 -> 386-619)
- Add missing error codes T015-T019 and T044 to the catalogue table
- Fix T009 and T024 descriptions to match actual error messages
- Remove stale `RUN_TYPE_VALID=1` gate mention
- Replace em-dashes with colons in Reference Implementation

## Test plan

- [ ] Doc-only change; verify Docusaurus build renders correctly