### PR TITLE
types: fix now() inference type; correct MEP 5 doc

### DIFF
--- a/tests/types/valid/now_returns_int64.golden
+++ b/tests/types/valid/now_returns_int64.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/now_returns_int64.mochi
+++ b/tests/types/valid/now_returns_int64.mochi
@@ -1,0 +1,1 @@
+let ts: int64 = now()

--- a/types/infer.go
+++ b/types/infer.go
@@ -496,7 +496,7 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 			}
 			return ListType{Elem: AnyType{}}
 		case "now":
-			return IntType{}
+			return Int64Type{}
 		case "to_string":
 			return StringType{}
 		case "to_json":

--- a/website/docs/mep/mep-0005.md
+++ b/website/docs/mep/mep-0005.md
@@ -60,7 +60,10 @@ The expression entry point delegates to `inferBinaryType`, which flattens preced
 
 Within a level the algorithm reduces left to right. The result type table per operator is in [MEP 4](/docs/mep/mep-0004) under "numeric tower" and the same logic in code at `types/infer.go:114-191`.
 
-A subtle order dependency exists in numeric mixes. Because the algorithm folds left to right, `bigint - float` and `float - bigint` can produce different result types depending on rule firing order. Fixtures for each pair are required (see [MEP 9](/docs/mep/mep-0009)).
+Two notes on result types that are not obvious from the table:
+
+- `&&` and `||` return `bool` only when both operands are already `bool`; any other operand combination returns `any`.
+- The float-widening rule for arithmetic (`+`, `-`, `*`, `/`, `%`) fires only when both sides are in {int, float, int64}. `bigint` and `bigrat` are excluded from that set, so mixing `float` with `bigint` produces `bigint`, not `float`. The left-to-right fold can change which rule fires on the second operation in a chain of three or more operands.
 
 ### Inference for declarations
 
@@ -80,24 +83,40 @@ var x : T = e    ->  Γ' = Γ ∪ { x : T },
 
 ### Inference for control flow
 
-- `if cond { ... }` requires `cond : bool` (`T040`). The body inherits the parent environment.
-- `while cond { ... }` requires `cond : bool`.
+- `if cond { ... }` requires `cond : bool` (T040). The body runs in a child scope.
+- `while cond { ... }` requires `cond : bool` (T040). The body runs in a child scope with loop context active.
 - `for x in source { ... }`:
   - if `source : [T]` then `x : T` in the body.
   - if `source : {K: V}` then `x : K` in the body (keys only).
   - if `source : string` then `x : string` in the body.
   - any other shape raises `T022`.
 - `for x in a..b { ... }` requires both bounds `: int` (or `: int64`) and binds `x` to the same type as `a`.
+- `break` and `continue` must appear inside a loop body (T045).
 
 ### Inference for collections
 
+**List literals**
+
 - `[]` with no hint has type `[any]`.
-- `[e1, ..., en]` has type `[T]` where `T` is the equal type of all `ei` if they agree, else `[any]`. Exception: if all elements are map literals with identical string keys and agreeing value types, `T` is promoted to an anonymous `StructType` rather than `MapType`.
 - `[]` hinted with `[T]` has type `[T]`.
-- `{}` with no hint has type `{any: any}`.
-- `{k1: v1, ..., kn: vn}` has type `{K: V}` where `K` is the equal type of all `ki` (else `any`) and same for `V`.
-- `xs[i]` for `xs : [T]` returns `T`; for `xs : string` returns `string`; for `xs : {K: V}` returns `OptionType{Elem: V}` — key absence is surfaced at the type level.
-- `xs[a:b]` requires `xs : [T]` or `string` and bounds `: int`. Returns the same kind. Maps reject slicing (`T017`).
+- `[e1, ..., en]` has type `[T]` where `T` is the common type of all `ei` if they agree, else `[any]`. Exception: if all elements are map literals with identical string keys and agreeing value types per field, `T` is promoted to an anonymous `StructType` rather than `MapType` (see map literals below).
+
+**Map literals**
+
+Map literals are inferred as either an anonymous `StructType` or a `MapType` depending on the keys:
+
+- `{k1: v1, ..., kn: vn}` where every key is a string literal or bare identifier infers to an anonymous `StructType{k1: T1, ..., kn: Tn}` where each `Ti` is `ExprType(vi)`.
+- `{k1: v1, ..., kn: vn}` where any key is a computed expression infers to `MapType{K: V}` where `K` is the common key type and `V` the common value type (both fall back to `any`).
+- `{}` with no hint has type `{any: any}` (MapType).
+- `{}` hinted with `{K: V}` has type `{K: V}`.
+
+**Indexing**
+
+- `xs[i]` for `xs : [T]` returns `T`.
+- `xs[i]` for `xs : string` returns `string`.
+- `xs[k]` for `xs : MapType{K, V}` returns `option[V]` — key absence is surfaced at the type level.
+- `xs[k]` for `xs : StructType{...}` with a known const string key returns the field type directly. Unknown key returns `any`.
+- `xs[a:b]` requires `xs : [T]` or `string` and bounds `: int`. Returns the same kind. Maps reject slicing (T017).
 
 ### Inference for queries
 


### PR DESCRIPTION
Closes #21198

## Code fix

`inferPrimaryType` returned `IntType{}` for `now()` but the builtin is registered as returning `Int64Type{}`. Fix: return `Int64Type{}` in the inference path so `ExprType(now_call)` agrees with the checker.

Golden test added: `now_returns_int64.mochi`.

## MEP 5 doc corrections

- **Map literal type**: `{k: v}` with const/identifier keys infers to anonymous `StructType`, not `MapType`. Empty `{}` and computed-key maps produce `MapType`. Previous doc was wrong.
- **`xs[k]` indexing**: `OptionType` wrapping is MapType-only. Struct field access returns the field type directly. Two cases now documented separately.
- **Order dependency claim removed**: "bigint - float and float - bigint produce different types" is false — both produce `BigIntType{}`. Replaced with accurate description of when 3+-operand chains are affected.
- **`&&`/`||` AnyType fallback**: documented (returns `any` for non-bool operands).
- **T040/T045**: added to `while` cond rule and `break`/`continue` rule.

## Test plan

- [ ] `go test ./...` passes
- [ ] `now_returns_int64.mochi` valid test passes