### PR TITLE
golden: fix RunWithSummary; correct MEP 8 doc

### DIFF
--- a/golden/golden.go
+++ b/golden/golden.go
@@ -130,6 +130,7 @@ func RunWithSummary(t *testing.T, dir, srcExt, goldenExt string, fn Runner) {
 	if len(files) == 0 {
 		t.Fatalf("no test files found: %s", pattern)
 	}
+	sort.Strings(files)
 
 	var passed, failed int
 	for _, src := range files {
@@ -212,7 +213,6 @@ func RunWithSummary(t *testing.T, dir, srcExt, goldenExt string, fn Runner) {
 			passed++
 		} else {
 			failed++
-			break
 		}
 	}
 

--- a/website/docs/mep/mep-0008.md
+++ b/website/docs/mep/mep-0008.md
@@ -35,17 +35,34 @@ Without a shared layering, contributors write tests at the wrong granularity. A 
 
 Five layers of testing apply to soundness work, ordered from cheap to expensive.
 
-1. **Parser golden tests.** `tests/parser/valid/` and `tests/parser/errors/`. Snapshot the parsed AST as JSON.
-2. **Type checker golden tests.** `tests/types/valid/` and `tests/types/errors/`. Snapshot accepted vs rejected programs and their error output.
-3. **Interpreter execution tests.** `tests/interpreter/`. Snapshot stdout for end-to-end programs.
-4. **Bytecode VM execution tests.** `tests/vm/` (Rosetta benchmarks). Run the same program through both backends and diff.
+1. **Parser golden tests.** `tests/parser/valid/` and `tests/parser/errors/`. Snapshot the parsed AST as JSON. Runner: `parser/parser_test.go`.
+2. **Type checker golden tests.** `tests/types/valid/` and `tests/types/errors/`. Snapshot accepted vs rejected programs and their error output. Runner: `types/check_test.go`.
+3. **Interpreter execution tests.** `tests/interpreter/valid/` and `tests/interpreter/errors/`. Snapshot stdout and runtime errors for end-to-end programs. Runner: `interpreter/interpreter_test.go`.
+4. **Bytecode VM execution tests.** `tests/vm/valid/`. Snapshot stdout for programs compiled and run through the VM. Runner: `runtime/vm/valid_golden_test.go` (tagged `//go:build slow`). Also produces `.ir.out` IR dump goldens.
 5. **Property tests.** `tests/types/property/` (planned). Generate programs and assert invariants automatically.
 
-CI runs layers 1 to 4 today. Layer 5 is the next step.
+CI runs layers 1–3 by default via `go test ./...`. Layer 4 is tagged `//go:build slow` and is not included in the default CI run; use `go test -tags slow ./runtime/vm/...` to run it locally. Layer 5 is not yet implemented.
 
 ### Golden harness
 
-`golden/golden.go`. Each test pair is `name.mochi` plus `name.golden` (or `name.err`). The harness reads the source, runs the function under test, normalises paths and timing strings, then compares to the golden. Run `go test ./types -update` to refresh goldens after a deliberate change.
+`golden/golden.go`. Each test pair is `name.mochi` plus a golden file. The harness reads the source, runs the function under test, normalises paths and timing strings, then compares to the golden.
+
+Three entry points:
+
+- `Run`: runs all fixtures, fails immediately on each mismatch, sorts alphabetically. Used by parser and type checker tests.
+- `RunWithSummary`: runs all fixtures, collects pass/fail counts, logs a summary at the end. Stops the suite on the first process error but continues past golden mismatches. Used by transpiler golden suites.
+- `RunFirstFailure`: runs fixtures in order, stops and reports the first failing program by name. Used when a short first-failure signal is more useful than a full list.
+
+To refresh goldens after a deliberate change, run `make update-golden STAGE=types` (or the equivalent stage name). This invokes `go test ./types -update --vet=off`.
+
+### Golden file extensions
+
+| Extension | Meaning                                               |
+|-----------|-------------------------------------------------------|
+| `.golden` | Parser or type checker valid test — snapshots the success output or parsed AST |
+| `.err`    | Parser, type checker, or interpreter error test — snapshots the diagnostic     |
+| `.out`    | Interpreter or VM execution test — snapshots stdout                            |
+| `.ir.out` | VM IR dump test — snapshots the compiled bytecode representation               |
 
 ### TAPL chapter mapping
 
@@ -97,7 +114,7 @@ Property tests run with a fixed seed in CI for reproducibility, plus a randomise
 The PR for the v0.11.0 soundness initiative ratchets CI from "ok if tests pass" to:
 
 - All of layers 1, 2, 3 must pass.
-- Layer 4 (VM conformance) must pass against the interpreter.
+- Layer 4 (VM golden tests) must pass when run with `-tags slow`.
 - Layer 5 must run with the deterministic seed and pass once it lands.
 
 ### How to run locally
@@ -111,6 +128,9 @@ make test STAGE=types
 
 # Refresh goldens after a deliberate change.
 make update-golden STAGE=types
+
+# Run the VM golden suite (slow-tagged).
+go test -tags slow ./runtime/vm/...
 
 # Run only the soundness property tests.
 go test ./tests/types/property/...
@@ -139,14 +159,16 @@ Process MEP. No language compatibility implications.
 
 ## Reference Implementation
 
-- `golden/golden.go` — golden harness.
-- `tests/parser/`, `tests/types/`, `tests/interpreter/`, `tests/vm/` — existing layers.
+- `golden/golden.go` — golden harness (`Run`, `RunWithSummary`, `RunFirstFailure`).
+- `tests/parser/`, `tests/types/`, `tests/interpreter/` — layers 1–3.
+- `tests/vm/valid/`, `runtime/vm/valid_golden_test.go` — layer 4 (slow-tagged).
 - `tests/types/property/` — planned property test layer.
 
 ## Open Questions
 
 - **Property test framework.** Whether to write our own generator or adopt Go's `testing/quick`. The latter is simpler; the former gives us better shrinking.
 - **Nightly random run.** Where to publish results. We do not have a stable channel yet.
+- **Layer 4 in CI.** The VM golden suite is slow-tagged and excluded from the default CI run. Either add a separate CI job with `-tags slow` or gate it on a nightly schedule.
 
 ## References
 


### PR DESCRIPTION
Closes #21200

## Code fixes (golden/golden.go)

- **Remove `break` from `RunWithSummary`**: it was stopping on the first failure, making the summary always "N passed, 1 failed" and effectively identical to `RunFirstFailure`. Now runs all fixtures and reports a true tally.
- **Add `sort.Strings(files)` to `RunWithSummary`**: `Run` and `RunFirstFailure` both sort; `RunWithSummary` did not. Without sorting, test execution order depends on filesystem inode order.

## MEP 8 doc corrections

- Layer 4: correct description (VM golden tests, `runtime/vm/valid_golden_test.go`, `.out` files, `//go:build slow` tag)
- CI: "CI runs layers 1–4" → layers 1–3 run by default; layer 4 requires `-tags slow`
- Add `.ir.out` extension to the golden file extension table
- Document all three harness entry points with their distinct semantics
- Add "Layer 4 in CI" open question

## Test plan

- [ ] `go test ./...` passes
- [ ] `go test ./golden/...` passes