### PR TITLE
mep-0007: fix escape hatch row and VM conformance description

### DIFF
--- a/website/docs/mep/mep-0007.md
+++ b/website/docs/mep/mep-0007.md
@@ -165,7 +165,7 @@ The escape hatches we acknowledge. Each row points at the MEP that owns the fix 
 | `as` cast accepted without compatibility check       | [MEP 11](/docs/mep/mep-0011)           | none yet, planned `cast_int_as_string`       |
 | `null` is `any` rather than an option type           | [MEP 4](/docs/mep/mep-0004), [MEP 10](/docs/mep/mep-0010)    | none yet                                     |
 | Aliasing a `let` aggregate into a `var` allows a write through the alias to mutate the original | [MEP 15](/docs/mep/mep-0015) | `tests/types/valid/mutate_through_let_alias.mochi` |
-| Reading a missing map key returns the zero value     | [MEP 4](/docs/mep/mep-0004)            | `tests/types/valid/missing_map_key.mochi`    |
+| Reading a missing map key returns the zero value (type-level fixed: map index now returns `option[V]`; runtime still returns zero value for untyped paths) | [MEP 4](/docs/mep/mep-0004) | `tests/types/errors/missing_map_key.mochi` |
 | Integer division by zero is a runtime panic, not a checker rejection | [MEP 5](/docs/mep/mep-0005) | none yet                            |
 
 Listing the fixture column on the right is uncomfortable on purpose. Every blank cell is a bug we have decided not to flag yet; the decision should be deliberate.
@@ -181,7 +181,7 @@ A program that the type checker accepts and the interpreter executes should prod
 | `emit` statement dispatch    | Reactive runtime not on VM      | Statement runs; no handler is invoked.          |
 | `query` against logic facts  | Logic engine not on VM          | Execution hangs; dataset queries are unaffected. |
 
-`agent`, `stream`, `fact`, and `rule` declarations are accepted by the bytecode VM today. The gaps are in runtime dispatch and in the logic engine, not in the parser. `query` over dataset sources continues to work on the VM and is not on this list. The conformance test set lives at `tests/vm/` and runs the same source through both backends, asserting equal stdout. The audit method is to write a small probe per row (agent declaration, on/emit pair, intent call, fact/rule declaration, query over logic facts) and run it through `mochi run`, recording whether the program finishes with the expected output. This list should be re-audited every release; if a feature has been wired through to bytecode, drop the row and update the audit date.
+`agent`, `stream`, `fact`, and `rule` declarations are accepted by the bytecode VM today. The gaps are in runtime dispatch and in the logic engine, not in the parser. `query` over dataset sources continues to work on the VM and is not on this list. The conformance test set lives at `tests/vm/valid/` and is run by `runtime/vm/valid_golden_test.go` (tagged `//go:build slow`); each `.mochi` source is compiled and executed through the VM and its stdout is compared against a `.out` golden file. There is no automated two-backend diff; interpreter vs VM divergence is caught by auditing manually. The audit method is to write a small probe per row (agent declaration, on/emit pair, intent call, fact/rule declaration, query over logic facts) and run it through `mochi run`, recording whether the program finishes with the expected output. This list should be re-audited every release; if a feature has been wired through to bytecode, drop the row and update the audit date.
 
 ## Rationale
 


### PR DESCRIPTION
Closes #21202

- Missing map key escape hatch: type-level protection is in place (map index returns `option[V]`); update pinning fixture path from `valid/` to `errors/` and note partial fix.
- VM conformance paragraph: replace incorrect "two-backend stdout diff" claim with accurate description of golden file comparison via `runtime/vm/valid_golden_test.go`.