### PR TITLE
mep-0009: sync fixture catalogue to current state on disk

### DIFF
--- a/website/docs/mep/mep-0009.md
+++ b/website/docs/mep/mep-0009.md
@@ -37,10 +37,10 @@ Source counts taken at the snapshot date. Numbers are pairs of `.mochi` plus mat
 
 | Directory                  | Pairs |
 |----------------------------|-------|
-| tests/parser/valid         | 52    |
-| tests/parser/errors        | 10    |
-| tests/types/valid          | 31+17 (added in v0.11.0) |
-| tests/types/errors         | 45+4  (added in v0.11.0) |
+| tests/parser/valid         | 62    |
+| tests/parser/errors        | 11    |
+| tests/types/valid          | 62    |
+| tests/types/errors         | 58    |
 | tests/queryplan            | small |
 | tests/interpreter          | many  |
 | tests/vm                   | many  |
@@ -55,16 +55,18 @@ Sorted by name:
 
 ```
 agent_call, agent_decl, agent_full, agent_on_event, assign_stmt,
-call_expr, cast_expr, collection_literals, cross_join,
-cross_join_triple, dataset, dataset_sort_take_limit, expect_stmt,
-for_loop, fun_def, fun_expr, fun_expr_type_params, fun_type_params,
-generate_expr, generic_type, group_by, group_expr, if_expr_then_else,
-if_expr_then_else_nested, if_stmt, in_operator, index_expr, join,
-left_join, let_stmt, list_assign, load_expr, load_save_stdinout,
-load_with_expr, map_assign, match_expr, model_decl, negative,
+bench_block, call_expr, cast_expr, collection_literals, cross_join,
+cross_join_triple, dataset, dataset_sort_take_limit, emit_stmt,
+expect_stmt, extern_decl, fetch_stmt, for_loop, fun_def, fun_expr,
+fun_expr_type_params, fun_type_params, generate_expr, generic_type,
+group_by, group_expr, if_expr_then_else, if_expr_then_else_nested,
+if_stmt, import_stmt, in_operator, index_expr, index_len_minus_one,
+join, left_join, let_stmt, list_assign, load_expr, load_save_stdinout,
+load_with_expr, logic, map_assign, match_expr, model_decl, negative,
 nested_type_decl, on_stmt, outer_join, package_export, right_join,
-save_expr, stream_decl, test_block, type_struct_equals, unary_expr,
-update_stmt, user_type_literal, var_stmt, while_loop
+save_expr, stream_decl, test_block, type_alias, type_struct_equals,
+type_union_decl, unary_expr, unicode_identifier, update_stmt,
+user_type_literal, var_stmt, while_loop
 ```
 
 ### Existing types/valid fixtures
@@ -84,11 +86,14 @@ Added in v0.11.0:
 ```
 aggregate_count_list, aggregate_min_max_int, aggregate_sum_int_list,
 canonical_bool_only, canonical_int_arithmetic, canonical_string_concat,
-closure_inferred_return, for_in_list, for_in_range,
-inversion_if_expr, match_literal_pattern, match_union_variant,
-numeric_float_plus_int, numeric_int_plus_float,
-preservation_let_chain, query_basic_select, query_sort_take,
-struct_field_access
+cast_int_as_string, cast_string_as_bool, cast_string_as_int,
+closure_inferred_return, divide_by_zero_literal, for_in_list,
+for_in_range, if_while_checked, inversion_if_expr,
+match_literal_pattern, match_union_variant, missing_map_key_cast,
+modulo_by_zero_literal, mutate_through_let_alias, now_returns_int64,
+null_widening_int, null_widening_list, null_widening_struct,
+numeric_float_plus_int, numeric_int_plus_float, preservation_let_chain,
+pure_in_where_ok, query_basic_select, query_sort_take, struct_field_access
 ```
 
 ### Existing types/errors fixtures
@@ -113,8 +118,11 @@ user_type_field_mismatch, user_unknown_field, wrong_type_assign
 Added in v0.11.0:
 
 ```
-match_variant_arity, multiple_top_level_errors, range_bound_float,
-struct_unknown_field_access
+break_outside_loop, continue_outside_loop, if_cond_not_bool,
+impure_in_where_rejected, list_concat_type_mismatch, match_variant_arity,
+missing_map_key, multiple_top_level_errors, mutate_through_let_field,
+mutate_through_let_index, range_bound_float, struct_unknown_field_access,
+while_cond_not_bool
 ```
 
 ### Coverage matrix
@@ -154,8 +162,8 @@ The matrix is a property-to-fixture mapping. A cell value of `existing` means at
 | Numeric tower, int / int                 | missing   | n/a       |
 | Mutability, let immutable                | existing  | existing  |
 | Mutability, var mutable                  | existing  | n/a       |
-| Mutability, let xs[i] = ...              | missing   | missing   |
-| Mutability, let s.f = ...                | missing   | missing   |
+| Mutability, let xs[i] = ...              | missing   | existing  |
+| Mutability, let s.f = ...                | missing   | existing  |
 | Subtyping, record width                  | missing   | missing   |
 | Subtyping, AnyType silently accepts      | missing   | n/a       |
 | Cast, int as string                      | missing   | n/a       |
@@ -168,7 +176,7 @@ The matrix is a property-to-fixture mapping. A cell value of `existing` means at
 | Query result type                        | existing  | partial   |
 | Query aggregate types                    | existing  | partial   |
 | Multiple top level errors accumulated    | n/a       | existing  |
-| Pure flag (future enforcement)           | n/a       | n/a       |
+| Pure flag enforcement in where/having    | existing  | existing  |
 
 `partial` means at least one fixture exists but the property is not fully covered.
 
@@ -205,7 +213,6 @@ From [MEP 11](/docs/mep/mep-0011) (subtyping):
 - `record_width_subtype` (valid, when implemented).
 - `any_top_silent_widen` (valid, snapshots current behaviour).
 - `any_to_int_unchecked` (valid, snapshots current behaviour).
-- `cast_int_as_string` (valid, snapshots current behaviour).
 
 From [MEP 12](/docs/mep/mep-0012) (polymorphism):
 
@@ -233,8 +240,6 @@ From [MEP 14](/docs/mep/mep-0014) (queries):
 
 From [MEP 15](/docs/mep/mep-0015) (effects):
 
-- `mutate_through_let_index` (valid today, error after fix).
-- `mutate_through_let_field` (valid today, error after fix).
 - `pure_call_in_pure_context` (future, no fixture yet).
 
 ### How to map a fixture to a MEP


### PR DESCRIPTION
Closes #21204

Updates MEP 9 to reflect all fixtures added during the v0.11.0 audit:
- All four inventory counts corrected.
- parser/valid list gets 10 new names.
- types/valid v0.11.0 section gets 13 new names.
- types/errors v0.11.0 section gets 9 new names.
- Coverage matrix: Mutability xs[i]/s.f flip to `existing` in error column; Pure flag row updated.
- Remove 3 completed "to author" items.