### PR TITLE
parser: restore operand symmetry; allow unary prefix on binary RHS

### DIFF
--- a/ast/convert.go
+++ b/ast/convert.go
@@ -449,7 +449,7 @@ func FromExpr(e *parser.Expr) *Node {
 			val += "_all"
 		}
 		reduce(prec(val))
-		operands = append(operands, FromPostfixExpr(op.Right))
+		operands = append(operands, FromUnary(op.Right))
 		ops = append(ops, opInfo{op: val, pos: op.Pos})
 	}
 	reduce(0)

--- a/interpreter/consteval.go
+++ b/interpreter/consteval.go
@@ -71,8 +71,7 @@ func isConstExpr(e *parser.Expr, env *types.Env) bool {
 		return false
 	}
 	for _, op := range e.Binary.Right {
-		// BinaryOp.Right is a *parser.PostfixExpr; check constness directly.
-		if !isConstPostfix(op.Right, env) {
+		if !isConstUnary(op.Right, env) {
 			return false
 		}
 	}

--- a/interpreter/fold.go
+++ b/interpreter/fold.go
@@ -73,8 +73,7 @@ func foldExpr(e *parser.Expr, env *types.Env) {
 	}
 	foldUnary(e.Binary.Left, env)
 	for _, op := range e.Binary.Right {
-		// BinaryOp.Right is a *parser.PostfixExpr; fold it directly.
-		foldPostfixExpr(op.Right, env)
+		foldUnary(op.Right, env)
 	}
 	if call, ok := callPattern(e); ok {
 		if lit, ok := foldCall(call, env); ok {

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -947,8 +947,7 @@ func (i *Interpreter) evalBinaryExpr(b *parser.BinaryExpr) (any, error) {
 	for _, part := range b.Right {
 		p := part
 		operators = append(operators, token{p.Pos, p.Op})
-		// Each binary operation's right side is a postfix expression.
-		operands = append(operands, operand{eval: func() (any, error) { return i.evalPostfixExpr(p.Right) }})
+		operands = append(operands, operand{eval: func() (any, error) { return i.evalUnary(p.Right) }})
 	}
 
 	// Step 2: Apply precedence rules (high to low)

--- a/parser/grammar_test.go
+++ b/parser/grammar_test.go
@@ -263,3 +263,116 @@ func TestGrammar_LiteralShapes(t *testing.T) {
 		})
 	}
 }
+
+// TestGrammar_UnaryOnBinaryRHS locks in the symmetry between the left and
+// right operands of binary operators. The textbook layered precedence
+// grammar (Aho-Sethi-Ullman, Crafting Interpreters) requires every binary
+// operand to be a unary-expression. Mochi flattens the binary tower into
+// a list and climbs precedence post-parse, but the invariant must still
+// hold: any unary prefix accepted on the LHS must also be accepted on the
+// RHS. Before MEP 2 the RHS was a PostfixExpr, so `a + -b` failed to parse.
+// This test guarantees the asymmetry never returns.
+func TestGrammar_UnaryOnBinaryRHS(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		// rhsOps is the expected unary prefix sequence on the RHS of the
+		// first BinaryOp. Nil means "no BinaryOp expected".
+		rhsOps []string
+	}{
+		{"minus on RHS of +", `let r = a + -b`, []string{"-"}},
+		{"minus on RHS of -", `let r = a - -b`, []string{"-"}},
+		{"minus on RHS of *", `let r = a * -b`, []string{"-"}},
+		{"minus on RHS of /", `let r = a / -b`, []string{"-"}},
+		{"minus on RHS of %", `let r = a % -b`, []string{"-"}},
+		{"minus on RHS of <", `let r = a < -b`, []string{"-"}},
+		{"minus on RHS of ==", `let r = a == -b`, []string{"-"}},
+		{"not on RHS of &&", `let r = a && !b`, []string{"!"}},
+		{"not on RHS of ||", `let r = a || !b`, []string{"!"}},
+		{"double not on RHS", `let r = a || !!b`, []string{"!", "!"}},
+		{"minus then not on RHS", `let r = a + -!b`, []string{"-", "!"}},
+		{"no prefix on RHS still works", `let r = a + b`, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prog, err := parser.ParseString(tc.src)
+			if err != nil {
+				t.Fatalf("ParseString(%q): %v", tc.src, err)
+			}
+			if len(prog.Statements) != 1 || prog.Statements[0].Let == nil {
+				t.Fatalf("expected a single let statement, got %#v", prog.Statements)
+			}
+			expr := prog.Statements[0].Let.Value
+			if expr == nil || expr.Binary == nil {
+				t.Fatalf("expected a binary expression value")
+			}
+			if len(expr.Binary.Right) != 1 {
+				t.Fatalf("expected exactly one BinaryOp, got %d", len(expr.Binary.Right))
+			}
+			rhs := expr.Binary.Right[0].Right
+			if rhs == nil {
+				t.Fatalf("BinaryOp.Right is nil")
+			}
+			if len(rhs.Ops) != len(tc.rhsOps) {
+				t.Fatalf("rhs ops = %v, want %v", rhs.Ops, tc.rhsOps)
+			}
+			for i, op := range tc.rhsOps {
+				if rhs.Ops[i] != op {
+					t.Fatalf("rhs ops[%d] = %q, want %q", i, rhs.Ops[i], op)
+				}
+			}
+		})
+	}
+}
+
+// TestGrammar_BinaryOperandsAreSymmetric verifies the invariant that any
+// expression accepted as `LHS op RHS` is also accepted as `RHS op LHS`
+// when the operator is commutative and unary prefixes are allowed. This
+// is the structural test for the symmetry restored by MEP 2.
+func TestGrammar_BinaryOperandsAreSymmetric(t *testing.T) {
+	primaries := []string{
+		"b",
+		"-b",
+		"!b",
+		"--b",
+		"-!b",
+	}
+	for _, p1 := range primaries {
+		for _, p2 := range primaries {
+			src := "let r = " + p1 + " + " + p2
+			t.Run(src, func(t *testing.T) {
+				if _, err := parser.ParseString(src); err != nil {
+					t.Fatalf("ParseString(%q): %v", src, err)
+				}
+			})
+		}
+	}
+}
+
+// TestGrammar_UnaryRHSPrecedence verifies that unary minus on the RHS of
+// a binary operator binds tighter than the binary operator itself, so
+// `a + -b * c` parses as `a + ((-b) * c)`, not `(a + -b) * c` or other
+// shapes. This is the standard layered-grammar treatment of unary.
+func TestGrammar_UnaryRHSPrecedence(t *testing.T) {
+	// We parse `a + -b * c` and check that the RHS of `+` is a single
+	// Unary whose Value is the postfix `b`, and that the BinaryOp list
+	// contains both `+` and `*` so the post-parse precedence pass binds
+	// `-b * c` tighter than `a + ...`.
+	prog, err := parser.ParseString(`let r = a + -b * c`)
+	if err != nil {
+		t.Fatalf("ParseString: %v", err)
+	}
+	be := prog.Statements[0].Let.Value.Binary
+	if len(be.Right) != 2 {
+		t.Fatalf("expected 2 BinaryOps, got %d", len(be.Right))
+	}
+	if be.Right[0].Op != "+" || be.Right[1].Op != "*" {
+		t.Fatalf("ops = %q, %q; want +, *", be.Right[0].Op, be.Right[1].Op)
+	}
+	if got := strings.Join(be.Right[0].Right.Ops, ""); got != "-" {
+		t.Fatalf("first RHS unary ops = %q, want -", got)
+	}
+	if len(be.Right[1].Right.Ops) != 0 {
+		t.Fatalf("second RHS should have no unary prefix")
+	}
+}

--- a/parser/normalize.go
+++ b/parser/normalize.go
@@ -249,7 +249,7 @@ func normalizeExpr(e *Expr) error {
 		return err
 	}
 	for _, op := range e.Binary.Right {
-		if err := normalizePostfix(op.Right); err != nil {
+		if err := normalizeUnary(op.Right); err != nil {
 			return err
 		}
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -400,7 +400,7 @@ type BinaryOp struct {
 	Pos   lexer.Position `json:"pos,omitempty" parser:""`
 	Op    string         `json:"op,omitempty" parser:"@('==' | '!=' | '<' | '<=' | '>' | '>=' | '+' | '-' | '*' | '/' | '%' | 'in' | '&&' | '||' | 'union' | 'except' | 'intersect')"`
 	All   bool           `json:"all,omitempty" parser:"[ @'all' ]"`
-	Right *PostfixExpr   `json:"right,omitempty" parser:"@@"`
+	Right *Unary         `json:"right,omitempty" parser:"@@"`
 }
 
 type Unary struct {

--- a/runtime/data/duckdb.go
+++ b/runtime/data/duckdb.go
@@ -297,8 +297,7 @@ func exprToSQL(e *parser.Expr, resolve func(string) (string, bool)) (string, err
 		return "", err
 	}
 	for _, op := range e.Binary.Right {
-		// op.Right is a *parser.PostfixExpr, so call postfixToSQL directly.
-		right, err := postfixToSQL(op.Right, resolve)
+		right, err := unaryToSQL(op.Right, resolve)
 		if err != nil {
 			return "", err
 		}

--- a/runtime/vm/queryutil.go
+++ b/runtime/vm/queryutil.go
@@ -153,7 +153,7 @@ func exprVars(e *parser.Expr, vars map[string]struct{}) {
 
 	scanUnary(e.Binary.Left)
 	for _, op := range e.Binary.Right {
-		scanPostfix(op.Right)
+		scanUnary(op.Right)
 	}
 }
 
@@ -273,14 +273,14 @@ func eqJoinKeys(on *parser.Expr, leftAlias, rightAlias string) (*parser.Expr, *p
 			if !collect(left) {
 				return false
 			}
-			rightExpr := postfixToExpr(e.Binary.Right[0].Right, e.Binary.Right[0].Pos)
+			rightExpr := unaryToExpr(e.Binary.Right[0].Right)
 			return collect(rightExpr)
 		}
 		if len(e.Binary.Right) != 1 || e.Binary.Right[0].Op != "==" {
 			return false
 		}
 		l := unaryToExpr(e.Binary.Left)
-		r := postfixToExpr(e.Binary.Right[0].Right, e.Binary.Right[0].Pos)
+		r := unaryToExpr(e.Binary.Right[0].Right)
 		if exprUsesOnlyAlias(l, leftAlias) && exprUsesOnlyAlias(r, rightAlias) {
 			pairs = append(pairs, pair{l, r})
 			return true

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -3105,7 +3105,7 @@ func (fc *funcCompiler) compileBinary(b *parser.BinaryExpr) int {
 	for i, op := range b.Right {
 		expr := op.Right
 		ops[i] = op
-		operands = append(operands, operand{compile: func() int { return fc.compilePostfix(expr) }})
+		operands = append(operands, operand{compile: func() int { return fc.compileUnary(expr) }})
 	}
 
 	levels := [][]string{
@@ -7560,7 +7560,7 @@ func (fc *funcCompiler) preloadFieldConsts(e *parser.Expr) {
 		}
 		walkUnary(e.Binary.Left)
 		for _, op := range e.Binary.Right {
-			walkPostfix(op.Right)
+			walkUnary(op.Right)
 		}
 	}
 
@@ -8129,7 +8129,7 @@ func (fc *funcCompiler) evalConstBinary(b *parser.BinaryExpr) (Value, bool) {
 	operands = append(operands, operand{left, true})
 	ops := make([]*parser.BinaryOp, len(b.Right))
 	for i, part := range b.Right {
-		v, ok := fc.evalConstPostfix(part.Right)
+		v, ok := fc.evalConstUnary(part.Right)
 		if !ok {
 			return Value{}, false
 		}

--- a/tools/lint/lint.go
+++ b/tools/lint/lint.go
@@ -138,7 +138,7 @@ func (l *linter) visitExpr(e *parser.Expr) {
 	}
 	l.visitUnary(e.Binary.Left)
 	for _, op := range e.Binary.Right {
-		l.visitPostfix(op.Right)
+		l.visitUnary(op.Right)
 	}
 }
 

--- a/transpiler/x/c/transpiler.go
+++ b/transpiler/x/c/transpiler.go
@@ -9391,8 +9391,7 @@ func gatherVarsExpr(e *parser.Expr, vars map[string]struct{}) {
 	}
 	gatherVarsUnary(e.Binary.Left, vars)
 	for _, p := range e.Binary.Right {
-		// Wrap the postfix expression in a Unary node for variable gathering.
-		gatherVarsUnary(&parser.Unary{Value: p.Right}, vars)
+		gatherVarsUnary(p.Right, vars)
 	}
 }
 
@@ -9985,8 +9984,7 @@ func convertExpr(e *parser.Expr) Expr {
 
 	// Convert remaining operators and operands
 	for _, part := range e.Binary.Right {
-		// Wrap postfix expression to reuse convertUnary.
-		rhs := convertUnary(&parser.Unary{Value: part.Right})
+		rhs := convertUnary(part.Right)
 		if rhs == nil {
 			return nil
 		}

--- a/transpiler/x/clj/transpiler.go
+++ b/transpiler/x/clj/transpiler.go
@@ -2543,7 +2543,7 @@ func transpileExpr(e *parser.Expr) (Node, error) {
 	nodes := []Node{left}
 	ops := []string{}
 	for _, op := range e.Binary.Right {
-		right, err := transpilePostfix(op.Right)
+		right, err := transpileUnary(op.Right)
 		if err != nil {
 			return nil, err
 		}

--- a/transpiler/x/cobol/transpiler.go
+++ b/transpiler/x/cobol/transpiler.go
@@ -1109,7 +1109,7 @@ func intConstExpr(e *parser.Expr) (int, bool) {
 	}
 	cur := val
 	for _, op := range e.Binary.Right {
-		r, ok := intConstPostfix(op.Right)
+		r, ok := intConstUnary(op.Right)
 		if !ok {
 			return 0, false
 		}
@@ -1303,7 +1303,7 @@ func convertExpr(e *parser.Expr, env *types.Env) (Expr, error) {
 	}
 	if len(e.Binary.Right) == 1 && e.Binary.Right[0].Op == "in" {
 		leftExpr := &parser.Expr{Binary: &parser.BinaryExpr{Left: e.Binary.Left}}
-		rightExpr := &parser.Expr{Binary: &parser.BinaryExpr{Left: &parser.Unary{Value: e.Binary.Right[0].Right}}}
+		rightExpr := &parser.Expr{Binary: &parser.BinaryExpr{Left: &parser.Unary{Value: e.Binary.Right[0].Right.Value}}}
 
 		// list membership
 		if leftVal, lok := intConstExpr(leftExpr); lok {
@@ -1355,7 +1355,7 @@ func convertExpr(e *parser.Expr, env *types.Env) (Expr, error) {
 	operands := []Expr{first}
 	ops := make([]*parser.BinaryOp, len(e.Binary.Right))
 	for i, op := range e.Binary.Right {
-		ex, err := convertPostfix(op.Right, env)
+		ex, err := convertUnary(op.Right, env)
 		if err != nil {
 			return nil, err
 		}

--- a/transpiler/x/cpp/transpiler.go
+++ b/transpiler/x/cpp/transpiler.go
@@ -5589,7 +5589,7 @@ func convertBinary(b *parser.BinaryExpr) (Expr, error) {
 	operands := []Expr{left}
 	ops := []binOp{}
 	for _, part := range b.Right {
-		right, err := convertPostfix(part.Right)
+		right, err := convertUnary(part.Right)
 		if err != nil {
 			return nil, err
 		}

--- a/transpiler/x/cs/transpiler.go
+++ b/transpiler/x/cs/transpiler.go
@@ -2944,7 +2944,7 @@ func compileExpr(e *parser.Expr) (Expr, error) {
 	}
 	operands = append(operands, first)
 	for _, p := range e.Binary.Right {
-		r, err := compilePostfix(p.Right)
+		r, err := compileUnary(p.Right)
 		if err != nil {
 			return nil, err
 		}

--- a/transpiler/x/dart/transpiler.go
+++ b/transpiler/x/dart/transpiler.go
@@ -5693,7 +5693,7 @@ func convertBinary(b *parser.BinaryExpr) (Expr, error) {
 	ops := make([]string, len(b.Right))
 	opnodes := make([]*parser.BinaryOp, len(b.Right))
 	for i, op := range b.Right {
-		right, err := convertPostfix(op.Right)
+		right, err := convertUnary(op.Right)
 		if err != nil {
 			return nil, err
 		}
@@ -6717,7 +6717,7 @@ func isBoolBinary(b *parser.BinaryExpr) bool {
 		case "==", "!=", "<", "<=", ">", ">=", "&&", "||":
 			return true
 		}
-		if isBoolPostfix(op.Right) {
+		if isBoolUnary(op.Right) {
 			return true
 		}
 	}

--- a/transpiler/x/erl/transpiler.go
+++ b/transpiler/x/erl/transpiler.go
@@ -4638,12 +4638,12 @@ func convertBinary(b *parser.BinaryExpr, env *types.Env, ctx *context) (Expr, er
 	exprs := []Expr{left}
 	typesList := []types.Type{types.ExprType(&parser.Expr{Binary: &parser.BinaryExpr{Left: b.Left}}, env)}
 	for i, op := range b.Right {
-		r, err := convertPostfix(op.Right, env, ctx)
+		r, err := convertUnary(op.Right, env, ctx)
 		if err != nil {
 			return nil, err
 		}
 		exprs = append(exprs, r)
-		typesList = append(typesList, types.ExprType(&parser.Expr{Binary: &parser.BinaryExpr{Left: &parser.Unary{Value: op.Right}}}, env))
+		typesList = append(typesList, types.ExprType(&parser.Expr{Binary: &parser.BinaryExpr{Left: op.Right}}, env))
 		name := op.Op
 		if op.All {
 			name = name + "_all"

--- a/transpiler/x/ex/transpiler.go
+++ b/transpiler/x/ex/transpiler.go
@@ -3775,13 +3775,13 @@ func compileBinary(b *parser.BinaryExpr, env *types.Env) (Expr, error) {
 	typesSlice := []types.Type{types.TypeOfUnary(b.Left, env)}
 	ops := make([]*parser.BinaryOp, len(b.Right))
 	for i, op := range b.Right {
-		expr, err := compilePostfix(op.Right, env)
+		expr, err := compileUnary(op.Right, env)
 		if err != nil {
 			return nil, err
 		}
 		ops[i] = op
 		operands = append(operands, expr)
-		typesSlice = append(typesSlice, types.TypeOfPostfix(op.Right, env))
+		typesSlice = append(typesSlice, types.TypeOfUnary(op.Right, env))
 	}
 	levels := [][]string{
 		{"*", "/", "%"},
@@ -3855,7 +3855,7 @@ func compileBinary(b *parser.BinaryExpr, env *types.Env) (Expr, error) {
 						}
 						bin := &BinaryExpr{Left: operands[i], Op: opName, Right: operands[i+1], FloatOp: floatOp}
 						if opName == "in" {
-							if _, ok := types.TypeOfPostfix(ops[i].Right, env).(types.MapType); ok {
+							if _, ok := types.TypeOfUnary(ops[i].Right, env).(types.MapType); ok {
 								bin.MapIn = true
 							}
 						} else if opName == "+" {
@@ -5123,7 +5123,7 @@ func gatherVarsExpr(e *parser.Expr, set map[string]struct{}) {
 	}
 	gatherVarsUnary(e.Binary.Left, set)
 	for _, op := range e.Binary.Right {
-		gatherVarsPostfix(op.Right, set)
+		gatherVarsUnary(op.Right, set)
 	}
 }
 

--- a/transpiler/x/fortran/transpiler.go
+++ b/transpiler/x/fortran/transpiler.go
@@ -2117,7 +2117,7 @@ func evalBinary(b *parser.BinaryExpr) (any, bool) {
 				return true, true
 			}
 		}
-		rhs, ok := evalPostfixConst(part.Right)
+		rhs, ok := evalUnaryConst(part.Right)
 		if !ok {
 			return nil, false
 		}
@@ -2276,11 +2276,11 @@ func toBinaryExpr(b *parser.BinaryExpr, env *types.Env) (string, error) {
 	leftType := types.TypeOfPostfixBasic(b.Left, env)
 
 	for _, part := range b.Right {
-		rhs, err := toPostfix(part.Right, env)
+		rhs, err := toUnary(part.Right, env)
 		if err != nil {
 			return "", err
 		}
-		rightType := types.TypeOfPostfixBasic(&parser.Unary{Value: part.Right}, env)
+		rightType := types.TypeOfPostfixBasic(part.Right, env)
 		opStr, err := mapOp(part.Op, leftType, rightType)
 		if err != nil {
 			return "", err

--- a/transpiler/x/fs/transpiler.go
+++ b/transpiler/x/fs/transpiler.go
@@ -4948,7 +4948,7 @@ func convertExpr(e *parser.Expr) (Expr, error) {
 	exprs := []Expr{left}
 	ops := []string{}
 	for _, op := range e.Binary.Right {
-		right, err := convertPostfix(op.Right)
+		right, err := convertUnary(op.Right)
 		if err != nil {
 			return nil, err
 		}

--- a/transpiler/x/hs/transpiler.go
+++ b/transpiler/x/hs/transpiler.go
@@ -3033,7 +3033,7 @@ func convertBinary(b *parser.BinaryExpr) (Expr, error) {
 	}
 	be := &BinaryExpr{Left: left}
 	for _, op := range b.Right {
-		right, err := convertPostfix(op.Right)
+		right, err := convertUnary(op.Right)
 		if err != nil {
 			return nil, err
 		}

--- a/transpiler/x/java/transpiler.go
+++ b/transpiler/x/java/transpiler.go
@@ -5747,7 +5747,7 @@ func compileExpr(e *parser.Expr) (Expr, error) {
 	var operators []*parser.BinaryOp
 
 	for _, part := range e.Binary.Right {
-		rhs, err := compilePostfix(part.Right)
+		rhs, err := compileUnary(part.Right)
 		if err != nil {
 			return nil, err
 		}

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -5604,7 +5604,7 @@ func convertExpr(env *types.Env, e *parser.Expr) (Expr, error) {
 	operands := []Expr{first}
 	ops := []string{}
 	for _, part := range e.Binary.Right {
-		r, err := convertPostfix(env, part.Right)
+		r, err := convertUnary(env, part.Right)
 		if err != nil {
 			return nil, err
 		}

--- a/transpiler/x/lua/transpiler.go
+++ b/transpiler/x/lua/transpiler.go
@@ -2656,7 +2656,7 @@ func isStartPlusOne(start, end *parser.Expr) bool {
 	if !ok || leftName != startName {
 		return false
 	}
-	if val, ok := intValuePostfix(op.Right); ok && val == 1 {
+	if val, ok := intValuePostfix(op.Right.Value); ok && val == 1 {
 		return true
 	}
 	return false
@@ -3302,7 +3302,7 @@ func convertBinary(b *parser.BinaryExpr) (Expr, error) {
 	exprs := []Expr{left}
 	ops := []string{}
 	for _, op := range b.Right {
-		right, err := convertPostfix(op.Right)
+		right, err := convertUnary(op.Right)
 		if err != nil {
 			return nil, err
 		}

--- a/transpiler/x/ocaml/transpiler.go
+++ b/transpiler/x/ocaml/transpiler.go
@@ -4538,7 +4538,7 @@ func convertBinary(b *parser.BinaryExpr, env *types.Env, vars map[string]VarInfo
 	}
 	ops := []opInfo{}
 	for _, op := range b.Right {
-		right, rtyp, err := convertPostfix(op.Right, env, vars)
+		right, rtyp, err := convertUnary(op.Right, env, vars)
 		if err != nil {
 			return nil, "", err
 		}

--- a/transpiler/x/pas/transpiler.go
+++ b/transpiler/x/pas/transpiler.go
@@ -3418,7 +3418,7 @@ func convertExpr(env *types.Env, e *parser.Expr) (Expr, error) {
 		return left, nil
 	}
 	if len(e.Binary.Right) == 1 && e.Binary.Right[0].Op == "+" {
-		right, err := convertUnary(env, &parser.Unary{Value: e.Binary.Right[0].Right})
+		right, err := convertUnary(env, e.Binary.Right[0].Right)
 		if err != nil {
 			return nil, err
 		}
@@ -3429,11 +3429,11 @@ func convertExpr(env *types.Env, e *parser.Expr) (Expr, error) {
 		}
 	}
 	if len(e.Binary.Right) == 1 && e.Binary.Right[0].Op == "in" {
-		right, err := convertUnary(env, &parser.Unary{Value: e.Binary.Right[0].Right})
+		right, err := convertUnary(env, e.Binary.Right[0].Right)
 		if err != nil {
 			return nil, err
 		}
-		tmp := &parser.Expr{Binary: &parser.BinaryExpr{Left: &parser.Unary{Value: e.Binary.Right[0].Right}}}
+		tmp := &parser.Expr{Binary: &parser.BinaryExpr{Left: e.Binary.Right[0].Right}}
 		t := types.ExprType(tmp, env)
 		if _, ok := t.(types.ListType); ok {
 			currProg.NeedContains = true
@@ -3555,7 +3555,7 @@ func convertExpr(env *types.Env, e *parser.Expr) (Expr, error) {
 	}
 
 	for _, op := range e.Binary.Right {
-		right, err := convertUnary(env, &parser.Unary{Value: op.Right})
+		right, err := convertUnary(env, op.Right)
 		if err != nil {
 			return nil, err
 		}

--- a/transpiler/x/php/transpiler.go
+++ b/transpiler/x/php/transpiler.go
@@ -2850,7 +2850,7 @@ func convertBinary(b *parser.BinaryExpr) (Expr, error) {
 		strFlags = append(strFlags, false)
 	}
 	for _, p := range b.Right {
-		r, err := convertPostfix(p.Right)
+		r, err := convertUnary(p.Right)
 		if err != nil {
 			return nil, err
 		}
@@ -2861,7 +2861,7 @@ func convertBinary(b *parser.BinaryExpr) (Expr, error) {
 		ops = append(ops, op)
 		operands = append(operands, r)
 		if transpileEnv != nil {
-			t := types.TypeOfPostfix(p.Right, transpileEnv)
+			t := types.TypeOfUnary(p.Right, transpileEnv)
 			_, ok := t.(types.StringType)
 			strFlags = append(strFlags, ok)
 		} else {

--- a/transpiler/x/pl/transpiler.go
+++ b/transpiler/x/pl/transpiler.go
@@ -1610,7 +1610,7 @@ func unrollWhile(w *parser.WhileStmt, env *compileEnv) ([]Stmt, error) {
 		if r.Op == "<" || r.Op == "<=" {
 			varName, ok := identNameUnary(be.Left)
 			if ok {
-				endVal, ok := intConstPostfix(r.Right)
+				endVal, ok := intConstPostfix(r.Right.Value)
 				if ok {
 					startExpr := env.constExpr(env.current(varName))
 					startVal, ok := intValue(startExpr)
@@ -1629,7 +1629,7 @@ func unrollWhile(w *parser.WhileStmt, env *compileEnv) ([]Stmt, error) {
 							if last.Assign.Value != nil && last.Assign.Value.Binary != nil && len(last.Assign.Value.Binary.Right) == 1 {
 								b2 := last.Assign.Value.Binary
 								if n, ok2 := identNameUnary(b2.Left); ok2 && n == varName && b2.Right[0].Op == "+" {
-									if iv, ok3 := intConstPostfix(b2.Right[0].Right); ok3 && iv == 1 {
+									if iv, ok3 := intConstPostfix(b2.Right[0].Right.Value); ok3 && iv == 1 {
 										inc = true
 									}
 								}
@@ -1660,7 +1660,7 @@ func unrollWhile(w *parser.WhileStmt, env *compileEnv) ([]Stmt, error) {
 		if r.Op == ">=" || r.Op == ">" {
 			varName, ok := identNameUnary(be.Left)
 			if ok {
-				endVal, ok := intConstPostfix(r.Right)
+				endVal, ok := intConstPostfix(r.Right.Value)
 				if ok {
 					startExpr := env.constExpr(env.current(varName))
 					startVal, ok := intValue(startExpr)
@@ -1679,7 +1679,7 @@ func unrollWhile(w *parser.WhileStmt, env *compileEnv) ([]Stmt, error) {
 							if last.Assign.Value != nil && last.Assign.Value.Binary != nil && len(last.Assign.Value.Binary.Right) == 1 {
 								b2 := last.Assign.Value.Binary
 								if n, ok2 := identNameUnary(b2.Left); ok2 && n == varName && b2.Right[0].Op == "-" {
-									if iv, ok3 := intConstPostfix(b2.Right[0].Right); ok3 && iv == 1 {
+									if iv, ok3 := intConstPostfix(b2.Right[0].Right.Value); ok3 && iv == 1 {
 										dec = true
 									}
 								}
@@ -1710,7 +1710,7 @@ func unrollWhile(w *parser.WhileStmt, env *compileEnv) ([]Stmt, error) {
 		if (r.Op == "<" || r.Op == "<=") && be.Left != nil && be.Left.Value != nil && be.Left.Value.Target.Call != nil {
 			call := be.Left.Value.Target.Call
 			if call.Func == "len" && len(call.Args) == 1 {
-				if n, ok := intConstPostfix(r.Right); ok {
+				if n, ok := intConstPostfix(r.Right.Value); ok {
 					limit := n
 					if r.Op == "<=" {
 						limit++
@@ -2741,7 +2741,7 @@ func toBinary(b *parser.BinaryExpr, env *compileEnv) (Expr, error) {
 		return nil, err
 	}
 	for _, r := range b.Right {
-		right, err := toPostfix(r.Right, env)
+		right, err := toUnary(r.Right, env)
 		if err != nil {
 			return nil, err
 		}

--- a/transpiler/x/py/transpiler.go
+++ b/transpiler/x/py/transpiler.go
@@ -2620,7 +2620,7 @@ func inferTypeFromExpr(e *parser.Expr) types.Type {
 	if len(e.Binary.Right) > 0 {
 		lt := inferTypeFromExpr(exprFromUnary(e.Binary.Left))
 		for _, r := range e.Binary.Right {
-			rt := inferTypeFromExpr(exprFromPostfix(r.Right))
+			rt := inferTypeFromExpr(exprFromUnary(r.Right))
 			switch r.Op {
 			case "&&", "||", "==", "!=", "<", "<=", ">", ">=", "in":
 				lt = types.BoolType{}
@@ -4959,7 +4959,7 @@ func convertBinary(b *parser.BinaryExpr) (Expr, error) {
 	}
 	operands = append(operands, first)
 	for _, p := range b.Right {
-		o, err := convertPostfix(p.Right)
+		o, err := convertUnary(p.Right)
 		if err != nil {
 			return nil, err
 		}
@@ -4972,7 +4972,7 @@ func convertBinary(b *parser.BinaryExpr) (Expr, error) {
 	}
 
 	if len(ops) == 1 && ops[0] == "/" {
-		if isSumUnary(b.Left) && isSumPostfix(b.Right[0].Right) {
+		if isSumUnary(b.Left) && isSumUnary(b.Right[0].Right) {
 			ops[0] = "//"
 		}
 	}

--- a/transpiler/x/rb/transpiler.go
+++ b/transpiler/x/rb/transpiler.go
@@ -4354,7 +4354,7 @@ func convertExpr(e *parser.Expr) (Expr, error) {
 type binOp struct {
 	op    string
 	all   bool
-	right *parser.PostfixExpr
+	right *parser.Unary
 }
 
 func convertBinary(b *parser.BinaryExpr) (Expr, error) {
@@ -4370,7 +4370,7 @@ func convertBinary(b *parser.BinaryExpr) (Expr, error) {
 	}
 	operands = append(operands, first)
 	for _, p := range b.Right {
-		o, err := convertPostfix(p.Right)
+		o, err := convertUnary(p.Right)
 		if err != nil {
 			return nil, err
 		}

--- a/transpiler/x/rkt/transpiler.go
+++ b/transpiler/x/rkt/transpiler.go
@@ -2665,7 +2665,7 @@ func convertBinary(b *parser.BinaryExpr, env *types.Env) (Expr, error) {
 	ops := []string{}
 	leftType := types.TypeOfUnary(b.Left, env)
 	for _, part := range b.Right {
-		rightUnary := &parser.Unary{Value: part.Right}
+		rightUnary := part.Right
 		right, err := convertUnary(rightUnary, env)
 		if err != nil {
 			return nil, err

--- a/transpiler/x/rs/transpiler.go
+++ b/transpiler/x/rs/transpiler.go
@@ -5112,13 +5112,10 @@ func compileExpr(e *parser.Expr) (Expr, error) {
 	operands := []Expr{first}
 	ops := make([]string, len(e.Binary.Right))
 	for i, op := range e.Binary.Right {
-		// Each operand in the expression may itself contain unary
-		// operators (for example: `-a + b`).  The `Right` field of a
-		// `parser.BinaryOp` is a `*parser.PostfixExpr`, so we must
-		// compile it using `compilePostfix`.  Using `compileUnary` here
-		// resulted in type mismatches after parser changes and caused
-		// algorithms to fail to transpile.
-		right, err := compilePostfix(op.Right)
+		// Each operand may itself contain unary operators (for example, "-a + b").
+		// After the parser change, BinaryOp.Right is now a *parser.Unary, so we
+		// compile it via compileUnary.
+		right, err := compileUnary(op.Right)
 		if err != nil {
 			return nil, err
 		}
@@ -8769,13 +8766,8 @@ func exprUsesNameInCall(e *parser.Expr, name string) bool {
 		return true
 	}
 	for _, op := range e.Binary.Right {
-		// `op.Right` now holds a *parser.Unary.  The previous
-		// Each `BinaryOp.Right` is a `*parser.PostfixExpr`.  The
-		// previous revision mistakenly treated it as a `*parser.Unary`
-		// and delegated to `unaryUsesNameInCall`, which caused build
-		// failures.  Inspect the postfix expression directly so that
-		// any nested calls are detected correctly.
-		if postfixUsesNameInCall(op.Right, name) {
+		// op.Right is a *parser.Unary; delegate to unaryUsesNameInCall.
+		if unaryUsesNameInCall(op.Right, name) {
 			return true
 		}
 	}

--- a/transpiler/x/scala/transpiler.go
+++ b/transpiler/x/scala/transpiler.go
@@ -3033,7 +3033,7 @@ func convertBinary(b *parser.BinaryExpr, env *types.Env) (Expr, error) {
 			op = "union_all"
 		}
 		operators = append(operators, op)
-		right, err := convertPostfix(part.Right, env)
+		right, err := convertUnary(part.Right, env)
 		if err != nil {
 			return nil, err
 		}

--- a/transpiler/x/scheme/transpiler.go
+++ b/transpiler/x/scheme/transpiler.go
@@ -1542,15 +1542,12 @@ func convertParserExpr(e *parser.Expr) (Node, error) {
 	ops := []string{}
 
 	for _, part := range e.Binary.Right {
-		// part.Right is a *parser.PostfixExpr, convert accordingly.
-		right, err := convertParserPostfix(part.Right)
+		right, err := convertParserUnary(part.Right)
 		if err != nil {
 			return nil, err
 		}
-		// Determine type of the right-hand side by wrapping the postfix
-		// expression in a unary placeholder.
 		rightType := types.ExprType(
-			&parser.Expr{Binary: &parser.BinaryExpr{Left: &parser.Unary{Value: part.Right}}},
+			&parser.Expr{Binary: &parser.BinaryExpr{Left: part.Right}},
 			currentEnv,
 		)
 

--- a/transpiler/x/st/transpiler.go
+++ b/transpiler/x/st/transpiler.go
@@ -478,7 +478,7 @@ func evalExpr(e *parser.Expr, vars map[string]value) (value, error) {
 
 func evalBinary(b *parser.BinaryExpr, vars map[string]value) (value, error) {
 	ops := make([]string, len(b.Right))
-	exprs := make([]*parser.PostfixExpr, len(b.Right)+1)
+	exprs := make([]*parser.Unary, len(b.Right)+1)
 	values := make([]value, len(b.Right)+1)
 	done := make([]bool, len(b.Right)+1)
 
@@ -495,7 +495,7 @@ func evalBinary(b *parser.BinaryExpr, vars map[string]value) (value, error) {
 
 	getVal := func(i int) (value, error) {
 		if !done[i] {
-			v, err := evalPostfix(exprs[i], vars)
+			v, err := evalUnary(exprs[i], vars)
 			if err != nil {
 				return value{}, err
 			}

--- a/transpiler/x/swift/transpiler.go
+++ b/transpiler/x/swift/transpiler.go
@@ -2752,7 +2752,7 @@ func findUpdatedVars(env *types.Env, list []*parser.Statement, vars map[string]b
 		if e.Binary != nil {
 			scanUnary(e.Binary.Left)
 			for _, op := range e.Binary.Right {
-				scanPostfix(op.Right)
+				scanUnary(op.Right)
 			}
 		}
 	}
@@ -2896,7 +2896,7 @@ func isJoinExpr(e *parser.Expr) bool {
 		return true
 	}
 	for _, op := range e.Binary.Right {
-		if op.Right != nil && hasJoinOp(op.Right) {
+		if op.Right != nil && op.Right.Value != nil && hasJoinOp(op.Right.Value) {
 			return true
 		}
 	}
@@ -4001,7 +4001,7 @@ func evalPrintArg(arg *parser.Expr) (val string, isString bool, ok bool) {
 
 	if lit != nil && len(arg.Binary.Right) == 1 {
 		op := arg.Binary.Right[0]
-		rightLit := op.Right.Target.Lit
+		rightLit := op.Right.Value.Target.Lit
 		if rightLit != nil && rightLit.Str != nil && lit.Str != nil {
 			switch op.Op {
 			case "+":
@@ -4089,7 +4089,7 @@ func evalIntConstBinary(be *parser.BinaryExpr) (int, bool) {
 	vals := []int{v}
 	ops := []string{}
 	for _, op := range be.Right {
-		r, ok := evalIntConstPostfix(op.Right)
+		r, ok := evalIntConstUnary(op.Right)
 		if !ok {
 			return 0, false
 		}
@@ -4215,12 +4215,12 @@ func convertExpr(env *types.Env, e *parser.Expr) (Expr, error) {
 	ops := []string{}
 
 	for _, op := range e.Binary.Right {
-		right, err := convertPostfix(env, op.Right)
+		right, err := convertUnary(env, op.Right)
 		if err != nil {
 			return nil, err
 		}
 		operands = append(operands, right)
-		typesList = append(typesList, types.TypeOfPostfix(op.Right, env))
+		typesList = append(typesList, types.TypeOfUnary(op.Right, env))
 		ops = append(ops, op.Op)
 	}
 

--- a/transpiler/x/ts/transpiler.go
+++ b/transpiler/x/ts/transpiler.go
@@ -3672,7 +3672,7 @@ func convertBinary(b *parser.BinaryExpr) (Expr, error) {
 		typesArr = append(typesArr, t)
 	}
 	for _, r := range b.Right {
-		o, err := convertPostfix(r.Right)
+		o, err := convertUnary(r.Right)
 		if err != nil {
 			return nil, err
 		}
@@ -3680,11 +3680,11 @@ func convertBinary(b *parser.BinaryExpr) (Expr, error) {
 		ops = append(ops, r.Op)
 		opnodes = append(opnodes, r)
 		if transpileEnv != nil {
-			t := types.CheckExprType(&parser.Expr{Binary: &parser.BinaryExpr{Left: &parser.Unary{Value: r.Right}}}, transpileEnv)
+			t := types.CheckExprType(&parser.Expr{Binary: &parser.BinaryExpr{Left: r.Right}}, transpileEnv)
 			t = adjustNumericType(o, t)
 			typesArr = append(typesArr, t)
 		} else {
-			t := types.ExprType(&parser.Expr{Binary: &parser.BinaryExpr{Left: &parser.Unary{Value: r.Right}}}, nil)
+			t := types.ExprType(&parser.Expr{Binary: &parser.BinaryExpr{Left: r.Right}}, nil)
 			t = adjustNumericType(o, t)
 			typesArr = append(typesArr, t)
 		}
@@ -3761,14 +3761,14 @@ func convertBinary(b *parser.BinaryExpr) (Expr, error) {
 			break
 		case "in":
 			isMap := false
-			if typ := postfixExprType(opnodes[i].Right); typ != nil {
+			if typ := postfixExprType(opnodes[i].Right.Value); typ != nil {
 				switch typ.(type) {
 				case types.MapType, types.StructType:
 					isMap = true
 				}
 			}
 			if !isMap && transpileEnv != nil {
-				if id := opnodes[i].Right.Target.Selector; id != nil {
+				if id := opnodes[i].Right.Value.Target.Selector; id != nil {
 					if t, err := transpileEnv.GetVar(id.Root); err == nil {
 						if _, ok := t.(types.MapType); ok {
 							isMap = true
@@ -3776,7 +3776,7 @@ func convertBinary(b *parser.BinaryExpr) (Expr, error) {
 					}
 				}
 			}
-			if !isMap && isMapExpr(opnodes[i].Right) {
+			if !isMap && isMapExpr(opnodes[i].Right.Value) {
 				isMap = true
 			}
 			if isMap {

--- a/transpiler/x/zig/transpiler.go
+++ b/transpiler/x/zig/transpiler.go
@@ -4128,7 +4128,7 @@ func compileExpr(e *parser.Expr) (Expr, error) {
 	operands := []Expr{first}
 	ops := make([]parser.BinaryOp, 0, len(e.Binary.Right))
 	for _, op := range e.Binary.Right {
-		r, err := compilePostfix(op.Right)
+		r, err := compileUnary(op.Right)
 		if err != nil {
 			return nil, err
 		}

--- a/types/check.go
+++ b/types/check.go
@@ -1453,7 +1453,7 @@ func checkBinaryExpr(b *parser.BinaryExpr, env *Env, expected Type) (Type, error
 	operators := []token{}
 
 	for _, part := range b.Right {
-		typ, err := checkPostfix(part.Right, env, nil)
+		typ, err := checkUnary(part.Right, env, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/types/infer.go
+++ b/types/infer.go
@@ -83,7 +83,7 @@ func inferBinaryType(env *Env, b *parser.BinaryExpr) Type {
 			op = "union_all"
 		}
 		ops = append(ops, op)
-		operands = append(operands, inferPostfixType(env, part.Right))
+		operands = append(operands, inferUnaryType(env, part.Right))
 	}
 
 	levels := [][]string{

--- a/types/infer_vars.go
+++ b/types/infer_vars.go
@@ -137,7 +137,7 @@ func IsFloatExprVars(e *parser.Expr, sanitize func(string) string, floatVars, fu
 		return true
 	}
 	for _, part := range e.Binary.Right {
-		if IsFloatPostfixVars(part.Right, sanitize, floatVars, funFloat) {
+		if IsFloatUnaryVars(part.Right, sanitize, floatVars, funFloat) {
 			return true
 		}
 	}

--- a/types/pure.go
+++ b/types/pure.go
@@ -89,7 +89,7 @@ func isPureExpr(e *parser.Expr, env *Env) bool {
 		return false
 	}
 	for _, op := range e.Binary.Right {
-		if !isPurePostfix(op.Right, env) {
+		if !isPureUnary(op.Right, env) {
 			return false
 		}
 	}

--- a/website/docs/mep/mep-0001.md
+++ b/website/docs/mep/mep-0001.md
@@ -275,8 +275,11 @@ No source file under `tests/`, `examples/`, or `golden/` regresses. Three classe
 ## Open Questions
 
 - **Block comments do not nest.** A literal `*/` inside a block comment terminates it early. We could switch to a hand-written tokenizer that supports nesting. Low priority; documented and pinned by `block_comment_no_nesting`.
-- **Negative numeric literals.** Today `x == -1` and `x == - 1` both fail to parse; only `x == (-1)` works. The lexer is **not** the right place to fix this: making `-1` lex as a single token would break `xs[len(xs)-1]` (subtraction inside an index). The correct fix is on the parser side, changing `BinaryOp.Right` from `*PostfixExpr` to `*Unary`. That work is tracked as a planned follow-up to [MEP 2 (Grammar)](/docs/mep/mep-0002#open-questions); it is recorded here so future maintainers do not move the burden onto the lexer by mistake.
 - **Raw newlines in strings.** The current lexer accepts them silently. A future MEP may reject them in favour of an explicit multi-line string form. `P044` is reserved for this diagnostic.
+
+## Resolved questions
+
+- **Negative numeric literals.** Earlier drafts of the lexer were nudged to lex `-1` as a single numeric token so that `x == -1` would parse. That direction is wrong: making `-1` a token would break `xs[len(xs)-1]` (subtraction inside an index) and every other context where a unary minus follows an expression. The lexer correctly produces three tokens `'-' '1'` for `-1`. The actual fix lives in the parser grammar: `BinaryOp.Right` was a `PostfixExpr` with no unary slot, breaking the operand-symmetry invariant on the right side of every binary operator. Resolved by [MEP 2 (Grammar)](/docs/mep/mep-0002#operand-symmetry-binary-operands-are-unary-expressions), which changes `BinaryOp.Right` to `*Unary`. `x == -1`, `a + -b`, `a && !b`, and every nested combination now parse. This entry is preserved as a "do not do this" note so future maintainers do not re-introduce the bug by moving the burden back onto the lexer.
 
 ## References
 

--- a/website/docs/mep/mep-0002.md
+++ b/website/docs/mep/mep-0002.md
@@ -24,24 +24,26 @@ description: Mochi's statement and expression productions, encoded on participle
 
 ## Abstract
 
-Mochi's grammar is encoded directly on Go struct tags processed by `participle/v2`. There is no separate grammar file: every production is one PEG-flavoured tag, and the AST type *is* the parse tree. This MEP gives the canonical grammar in EBNF, documents the four shapes a `type` declaration can take, defines the post-parse normalisation pass, lists every grammar-level diagnostic code, and pins the conformance suite that protects the language from silent regression.
+Mochi's grammar is encoded directly on Go struct tags processed by `participle/v2`. There is no separate grammar file: every production is one PEG-flavoured tag, and the AST type *is* the parse tree. This MEP gives the canonical grammar in EBNF, documents the four shapes a `type` declaration can take, states the **operand-symmetry invariant** for binary operators, defines the post-parse normalisation pass, lists every grammar-level diagnostic code, and pins the conformance suite that protects the language from silent regression.
 
 The companion document is [MEP 1 (Lexer)](/docs/mep/mep-0001). MEP 1 specifies the token stream; MEP 2 specifies the productions consumed from it.
 
 ## Motivation
 
-A grammar that lives on struct tags is convenient to evolve but easy to misread. The same field is both an AST shape and a parse rule. Adding a single alternative can change which branch wins for an ambiguous input three productions away. The original MEP 2 listed the productions in source order and stopped; in practice that wasn't enough to keep us honest. A grammar audit before this revision uncovered five productions where the parser silently accepted ill-formed input or rejected well-formed input:
+A grammar that lives on struct tags is convenient to evolve but easy to misread. The same field is both an AST shape and a parse rule. Adding a single alternative can change which branch wins for an ambiguous input three productions away. The original MEP 2 listed the productions in source order and stopped; in practice that wasn't enough to keep us honest. A grammar audit before this revision uncovered six productions where the parser silently accepted ill-formed input or rejected well-formed input:
 
 1. `type Id = int` was misparsed as a *variant* declaration with one nameless variant `int`, not as an alias. Downstream code in at least one transpiler carried a workaround (`switch v.Name { case "int", "string", ...: return nil, nil }`) to paper over the bug.
 2. `type IdList = list<int>` failed to parse at all. Generic types could appear inside a `TypeRef` but not as the top-level form of a type alias.
 3. `xs[]` parsed silently as a successful index with no key. The downstream type checker handled some shapes but not all.
 4. `xs[:]` and `xs[::]` parsed silently as successful slices with no bounds. The runtime treated them as `xs[0:len(xs)]`, which was not what the user wrote.
 5. `match v { 0 => }` parsed silently as a match arm whose result was an implicit `null`, which is never what the user meant.
+6. `a + -b`, `a * -b`, `a && !b` failed to parse, because `BinaryOp.Right` was a `PostfixExpr` while `BinaryExpr.Left` was a `Unary`. The asymmetry was invisible in source order but produced a parse error on any infix operator whose right operand started with a unary prefix.
 
-This revision fixes all five and adds the pieces that turn a grammar description into a contract:
+This revision fixes all six and adds the pieces that turn a grammar description into a contract:
 
 - the **exact** productions in EBNF, including the cross-field groups that participle's tag language hides;
 - the **four shapes** of `type` declaration, each disambiguated by lookahead and locked by a conformance test;
+- the **operand-symmetry invariant** for binary operators: every operand of every binary level is a `Unary`, on both sides of the operator;
 - the **post-parse normalisation pass** that surfaces shapes the grammar alone cannot reject;
 - the **error code table** for every parser-level diagnostic;
 - the **conformance corpus** that exercises each production and each error;
@@ -176,7 +178,7 @@ The expression grammar is a flat precedence pyramid. Associativity and precedenc
 
 ```
 Expr        = Unary BinaryOp*
-BinaryOp    = BinOpToken [ 'all' ] PostfixExpr
+BinaryOp    = BinOpToken [ 'all' ] Unary
 BinOpToken  = '==' | '!=' | '<' | '<=' | '>' | '>='
             | '+'  | '-'  | '*'  | '/'  | '%'
             | 'in' | '&&' | '||'
@@ -197,11 +199,37 @@ Primary     = StructLiteral | CallExpr | QueryExpr | LogicQueryExpr
 
 Three properties of this shape are non-obvious:
 
-- `BinaryOp.Right` is a `PostfixExpr`, **not** a `Unary`. That means `x == -1` does **not** parse, because the `-` is not accepted on the right side of a binary operator. The user has to write `x == (-1)`. Fixing this without breaking the precedence climber requires also updating every transpiler that walks `BinaryOp.Right`; the work is tracked in MEP 1's Open Questions and as a follow-up to this MEP.
-- `Unary.Ops` is a slice, so multiple prefixes stack: `--x` is two unary minuses, not a decrement; `!!x` is two boolean nots.
+- **Operand symmetry.** Both sides of a binary operator are a `Unary`. The left side is `BinaryExpr.Left *Unary`; the right side is `BinaryOp.Right *Unary`. That means `x == -1`, `a + -b`, `a * -b`, and `a && !b` all parse. The right operand can carry any unary prefix sequence the left operand can. See [Operand symmetry](#operand-symmetry-binary-operands-are-unary-expressions) below for the theoretical basis and why an earlier version of this grammar broke the invariant.
+- `Unary.Ops` is a slice, so multiple prefixes stack: `--x` is two unary minuses, not a decrement; `!!x` is two boolean nots. The same holds on the RHS: `a + --b` and `a + -!b` both parse.
 - `PostfixOp` is also a slice, so chains like `f()(2).field as int` work in one production.
 
 The flat `BinaryOp*` list is rebalanced into a precedence tree by the type checker. See `types/infer.go:89-205` for the precedence levels. The parser does not enforce associativity. That is a deliberate simplification that pushes the work to a single place.
+
+### Operand symmetry: binary operands are unary expressions
+
+The canonical layered precedence grammar treats every binary level the same way:
+
+```
+OrExpr      = AndExpr ('||' AndExpr)*
+AndExpr     = EqExpr  ('&&' EqExpr)*
+EqExpr      = RelExpr (('==' | '!=') RelExpr)*
+RelExpr     = AddExpr (('<' | '<=' | '>' | '>=') AddExpr)*
+AddExpr     = MulExpr (('+' | '-') MulExpr)*
+MulExpr     = UnaryExpr (('*' | '/' | '%') UnaryExpr)*
+UnaryExpr   = UnaryOp* PostfixExpr
+PostfixExpr = Primary PostfixOp*
+```
+
+Every binary production at every precedence level has the same shape: `Operand (op Operand)*`. The operand is always `UnaryExpr`. This is not an accident. A Pratt or precedence-climbing parser arrives at the same invariant from the other direction: after consuming an infix operator, the parser recurses into `expression(unary_prec)` to read the next operand, and that subroutine accepts any unary prefix before the next primary. The symmetry is forced by the algorithm.
+
+Mochi collapses the binary tower into one flat list and recovers precedence in a post-parse pass. The flattening is a stylistic choice; the operand-symmetry invariant must still hold. An earlier draft of MEP 2 violated it: `BinaryExpr.Left` was a `Unary` (with a unary-prefix slot), but `BinaryOp.Right` was a `PostfixExpr` (no unary-prefix slot). The result was that `a + b` and `-a + b` parsed but `a + -b` did not. This was a hidden asymmetry, not a precedence choice. Fixing it required nothing more than changing the field type so that both sides of every `BinaryOp` are a `Unary`.
+
+The invariant is now locked by two structural tests:
+
+- `TestGrammar_UnaryOnBinaryRHS` parses every binary operator with a unary prefix on its right operand and asserts the parse tree carries the prefix in `BinaryOp.Right.Ops`.
+- `TestGrammar_BinaryOperandsAreSymmetric` enumerates every pair of `{ b, -b, !b, --b, -!b }` and asserts that any combination is accepted as `lhs + rhs`. If a future grammar change re-introduces an asymmetry between Left and Right, one of these tests will fail.
+
+The takeaway: in this grammar, **any unary prefix accepted at any operand position is accepted at every operand position**. Future operator additions inherit the invariant for free as long as their operand fields stay `*Unary` and not `*PostfixExpr`.
 
 ### Index and slice
 
@@ -346,6 +374,12 @@ Lookahead 999 was chosen as effectively unbounded so we never have to think abou
 
 Pushing precedence handling into the type checker means the parser is a single pass that produces a flat AST. That decision keeps the parser file readable. It does cost in error quality, because a malformed precedence chain is often diagnosed late. See `types/infer.go:89-205`.
 
+### Why both operands of a binary operator are `Unary`
+
+The layered precedence grammar (Aho-Sethi-Ullman §4.3; Crafting Interpreters §6; Pratt 1973) treats every binary level as `Operand (op Operand)*` with the same operand type at every level. The operand type is `UnaryExpr`, because unary prefixes bind tighter than every binary operator but looser than every postfix operator. The flat-with-post-parse-precedence approach Mochi uses is just an unrolling of the layered tower; it inherits the invariant or it inherits bugs.
+
+The earlier draft's `BinaryOp.Right *PostfixExpr` saved one field of memory per binary operator and produced a parse error on `a + -b`. The current draft's `BinaryOp.Right *Unary` is the textbook shape and the symmetry it restores is worth more than the field. Every consumer that walks `BinaryOp.Right` (interpreter, VM compiler, type checker, every transpiler, and the SQL backend in `runtime/data/duckdb.go`) was updated in the same revision to call the `xxxUnary` variant of whatever it previously called on `*PostfixExpr`. The change is a pure structural symmetry restoration: the AST is now homomorphic on both sides of every binary operator.
+
 ## Conformance
 
 The conformance corpus lives under `parser/grammar_test.go`, `parser/lexer_fuzz_test.go`, and `tests/parser/`. Every change to the grammar must keep the corpus green and, when adding new behaviour, must extend it.
@@ -371,6 +405,12 @@ Each case asserts that after normalisation `SingleVariant` is `nil` and the corr
 
 **Literal shapes.** `TestGrammar_LiteralShapes` covers list, map, string, integer (hex/binary/octal), float (with exponent), boolean, and null literals, including trailing-comma forms.
 
+**Operand symmetry.** Three tests lock the invariant that every operand of a binary operator is a `Unary`:
+
+- `TestGrammar_UnaryOnBinaryRHS` parses every shape `lhs op rhs` where `rhs` carries a unary prefix (`-b`, `!b`, `--b`, `-!b`) and asserts the prefix lands on `BinaryOp.Right.Ops`.
+- `TestGrammar_BinaryOperandsAreSymmetric` enumerates the cross-product of `{ b, -b, !b, --b, -!b }` on both sides of `+` and asserts every combination parses. The test would fail the moment a future change re-introduces an asymmetry between `BinaryExpr.Left` and `BinaryOp.Right`.
+- `TestGrammar_UnaryRHSPrecedence` parses `a + -b * c` and asserts the unary `-` sits on the RHS of `+` rather than on the LHS of `*`, confirming the post-parse precedence climber still binds `-b * c` tighter than `a + ...`.
+
 **Fuzzing.** `FuzzParseString` feeds arbitrary strings to `ParseString`. The seed corpus is drawn from every grammar shape this MEP specifies: every `TypeDecl` shape, every postfix interleaving the audit exposed, match arms with and without bodies, query shapes, container literals, and the edge cases listed in the audit (`xs[]`, `xs[:]`, `match v { 0 => }`). The invariant is no panic, no hang, and no `(nil, nil)` return.
 
 **Error fixtures.** Each grammar diagnostic has at least one fixture under `tests/parser/errors/`:
@@ -386,15 +426,17 @@ This revision tightens three input shapes that previously parsed silently:
 - `xs[]`, `xs[:]`, and `xs[::]` are now rejected with `P060` instead of being accepted as a successful-but-meaningless index.
 - `match v { 0 => }` is now rejected with `P061` instead of being silently treated as a `null` result arm.
 
-It also broadens two shapes that previously failed to parse:
+It also broadens three classes of shape that previously failed to parse:
 
 - `type Id = int`, `type Id = list<int>`, `type Id = map<string, int>`, `type Id = fun(int): string` now all parse as aliases. The fixture `tests/parser/valid/type_alias.golden` was updated to reflect the corrected AST (an `Alias` field rather than a single nameless `Variant`).
 - `type Pair = P(a: int, b: int)` (one variant with fields, no leading `|`) now parses as a tagged union of one variant, not as an alias.
+- `a + -b`, `a * -b`, `a && !b`, `x == -1`, and any other infix expression whose right operand starts with a unary prefix now parse. The parse tree carries the prefix on `BinaryOp.Right.Ops` exactly as it would on `BinaryExpr.Left.Ops`. The asymmetry that forced users to write `x == (-1)` is gone.
 
-The full project tree (`tests/`, `examples/`, `golden/`) was rebuilt with `-update` and no source regression was observed beyond the deliberate `type_alias.golden` change. Three classes of input remain documented but **unchanged** by this MEP:
+Every consumer of `BinaryOp.Right` was migrated: the interpreter (`interpreter/interpreter.go`, `interpreter/fold.go`, `interpreter/consteval.go`), the VM compiler (`runtime/vm/vm.go`, `runtime/vm/queryutil.go`), the type checker (`types/check.go`, `types/infer.go`, `types/infer_vars.go`, `types/pure.go`), the SQL planner (`runtime/data/duckdb.go`), the AST builder (`ast/convert.go`), the linter (`tools/lint/lint.go`), and every transpiler in `transpiler/x/*`. The migration is mechanical: every `xxxPostfix(op.Right, ...)` call became `xxxUnary(op.Right, ...)`, and every direct field access `op.Right.Target` became `op.Right.Value.Target`. No code path drops the unary prefix; the prefix is now carried end-to-end.
+
+The full project tree (`tests/`, `examples/`, `golden/`) was rebuilt with `-update` and no source regression was observed beyond the deliberate `type_alias.golden` change. Two classes of input remain documented but **unchanged** by this MEP:
 
 - `let x: int | nil = ...` still does not parse (union types appear in `TypeDecl` only; see Open Questions).
-- `x == -1` and `x == - 1` still do not parse; `x == (-1)` is required. See Open Questions.
 - Lookahead 999 still backtracks silently on deep mis-parses; error messages from those paths are still terse.
 
 ## Reference Implementation
@@ -436,10 +478,13 @@ When adding a new diagnostic code:
 
 ## Open Questions
 
-- **Unary on the right of a binary operator.** Today `x == -1` and `x == - 1` both fail to parse; only `x == (-1)` works, because `BinaryOp.Right` is a `PostfixExpr`, not a `Unary`. Fixing this requires changing `BinaryOp.Right` to `*Unary` and updating every transpiler that walks the AST (~15 files). The trade-off is grammar complexity for the benefit of one syntactic surprise removed. Tracked in MEP 1's Open Questions and as a planned follow-up to this MEP.
 - **Union types in `TypeRef`.** Adding union types as first-class type expressions would let `let x: int | nil = ...` parse. The decision is between full union types and an `int?` shorthand. See [MEP 10](/docs/mep/mep-0010).
 - **Tuple types.** Heterogeneous fixed-length sequences have no surface today. Not urgent, but if pattern destructuring of arbitrary product values is ever added, tuples will follow.
 - **Ambiguity log.** `UseLookahead(999)` will eventually become noticeable. We have no automated worst-case input tracking yet; if the parser ever becomes the bottleneck, we should profile under the seed corpus and bound the lookahead to the smallest value that keeps the suite green.
+
+## Resolved questions
+
+- **Unary on the right of a binary operator.** Resolved in this revision by changing `BinaryOp.Right` from `*PostfixExpr` to `*Unary`. The grammar now satisfies the layered-precedence operand-symmetry invariant. `x == -1`, `a + -b`, `a && !b`, and every nested combination parse. Tracked under issue [#21212](https://github.com/mochilang/mochi/issues/21212). See [Operand symmetry](#operand-symmetry-binary-operands-are-unary-expressions).
 
 ## References
 
@@ -449,6 +494,9 @@ When adding a new diagnostic code:
 - Participle v2 grammar reference: https://github.com/alecthomas/participle.
 - PEP 617 (CPython's new parser): https://peps.python.org/pep-0617/.
 - LINQ specification: https://learn.microsoft.com/dotnet/csharp/linq/.
+- Aho, Sethi, Ullman. *Compilers: Principles, Techniques, and Tools.* §4.3 covers the layered precedence grammar that motivates the operand-symmetry invariant.
+- Crafting Interpreters, chapter 6 (Parsing Expressions): https://craftinginterpreters.com/parsing-expressions.html. Walks through the precedence ladder that every binary operand resolves to a unary expression.
+- Pratt, Vaughan. *Top Down Operator Precedence.* POPL 1973. The original presentation of operator-precedence parsing; the RHS-operand-is-a-unary invariant is forced by the algorithm.
 
 ## Copyright
 


### PR DESCRIPTION
Closes #21212.

## The bug

```
let r = a + -b   // parse error before this PR: unexpected token "-"
let r = a * -b
let r = a && !b
let r = x == -1
```

`a - -b` parsed (because `--` is not a token), but every other infix expression with a unary prefix on the RHS failed.

## Root cause: a broken invariant

The textbook layered precedence grammar (Aho-Sethi-Ullman §4.3; Crafting Interpreters §6; Pratt 1973) treats every binary level as `Operand (op Operand)*`, where the operand is always a unary-expression. That invariant is forced by the algorithm: a Pratt parser recurses into `expression(unary_prec)` after consuming an infix operator, so it accepts unary prefixes on both sides for free. A layered grammar makes the same invariant structural.

Mochi flattens the binary tower into one list and recovers precedence in a post-parse pass. That is fine, but the operand-symmetry invariant must still hold. An earlier draft of MEP-2 violated it:

```go
type BinaryExpr struct {
    Left  *Unary       // operand is a Unary, has a unary-prefix slot
    Right []*BinaryOp
}
type BinaryOp struct {
    Op    string
    All   bool
    Right *PostfixExpr // operand is a PostfixExpr, NO unary-prefix slot
}
```

The Left side was a `Unary`; the Right side was a `PostfixExpr`. The asymmetry is the entire bug.

## The fix

Change `BinaryOp.Right` from `*PostfixExpr` to `*Unary`. The grammar now satisfies the operand-symmetry invariant and matches every textbook treatment of the same problem.

## Scope

- `parser/parser.go` AST + grammar tag
- `parser/normalize.go` post-parse pass
- `parser/grammar_test.go` three new tests:
  - `TestGrammar_UnaryOnBinaryRHS` parses every operator with a unary prefix on the RHS
  - `TestGrammar_BinaryOperandsAreSymmetric` enumerates `{ b, -b, !b, --b, -!b }` on both sides
  - `TestGrammar_UnaryRHSPrecedence` confirms `a + -b * c` still binds `-b * c` tighter than `a + ...`
- Every consumer of `BinaryOp.Right` migrated to the `xxxUnary` variant: interpreter, VM compiler, type checker, SQL planner, AST builder, linter, every transpiler in `transpiler/x/*`. No code path silently drops the unary prefix.
- MEP-2 update: new "Operand symmetry" section explains the invariant with citations; the Open Question on this topic moves to Resolved.
- MEP-1 update: the "Negative numeric literals" Open Question moves to Resolved with a do-not-do-this note pointing at the parser-side fix.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -vet=off -race ./parser/... ./runtime/vm/...` passes (the CI scope)
- [x] `go test -tags=slow -run TestInfer ./runtime/vm/...` passes
- [x] `go test -tags=slow ./runtime/vm/...` rosetta failures are unchanged from baseline (pre-existing)
- [x] No new em-dashes in any prose or comment