### PR TITLE
mep-0002: rewrite in PEP 617 style; design out grammar corner cases

### DIFF
--- a/website/docs/mep/mep-0002.md
+++ b/website/docs/mep/mep-0002.md
@@ -7,7 +7,7 @@ type: Informational
 created: 2026-05-08
 sidebar_position: 2
 sidebar_label: MEP 2. Grammar
-description: Mochi's statement and expression productions, encoded on participle struct tags, with the conformance suite that protects them.
+description: Mochi's PEG grammar in full, with the design principles, conformance suite, and change checklist that protect the language from drift.
 ---
 
 # MEP 2. Grammar
@@ -24,479 +24,420 @@ description: Mochi's statement and expression productions, encoded on participle
 
 ## Abstract
 
-Mochi's grammar is encoded directly on Go struct tags processed by `participle/v2`. There is no separate grammar file: every production is one PEG-flavoured tag, and the AST type *is* the parse tree. This MEP gives the canonical grammar in EBNF, documents the four shapes a `type` declaration can take, states the **operand-symmetry invariant** for binary operators, defines the post-parse normalisation pass, lists every grammar-level diagnostic code, and pins the conformance suite that protects the language from silent regression.
+Mochi has a Parsing Expression Grammar (PEG) with ordered choice. Every well-formed source has exactly one parse tree. The grammar is encoded on Go struct tags consumed by `participle/v2`, but the canonical specification is the PEG productions in this document. Production order is meaningful: alternatives are tried top-to-bottom, the first that matches wins, and no later alternative is considered. Every shape the grammar accepts is well-formed by construction. There is no post-parse "this should not have parsed" pass.
 
-The companion document is [MEP 1 (Lexer)](/docs/mep/mep-0001). MEP 1 specifies the token stream; MEP 2 specifies the productions consumed from it.
+The companion document is [MEP 1 (Lexer)](/docs/mep/mep-0001). MEP 1 fixes the token stream; MEP 2 fixes the productions consumed from it.
 
 ## Motivation
 
-A grammar that lives on struct tags is convenient to evolve but easy to misread. The same field is both an AST shape and a parse rule. Adding a single alternative can change which branch wins for an ambiguous input three productions away. The original MEP 2 listed the productions in source order and stopped; in practice that wasn't enough to keep us honest. A grammar audit before this revision uncovered six productions where the parser silently accepted ill-formed input or rejected well-formed input:
+A language is easy to learn when its grammar has no special cases. Three principles drive this revision:
 
-1. `type Id = int` was misparsed as a *variant* declaration with one nameless variant `int`, not as an alias. Downstream code in at least one transpiler carried a workaround (`switch v.Name { case "int", "string", ...: return nil, nil }`) to paper over the bug.
-2. `type IdList = list<int>` failed to parse at all. Generic types could appear inside a `TypeRef` but not as the top-level form of a type alias.
-3. `xs[]` parsed silently as a successful index with no key. The downstream type checker handled some shapes but not all.
-4. `xs[:]` and `xs[::]` parsed silently as successful slices with no bounds. The runtime treated them as `xs[0:len(xs)]`, which was not what the user wrote.
-5. `match v { 0 => }` parsed silently as a match arm whose result was an implicit `null`, which is never what the user meant.
-6. `a + -b`, `a * -b`, `a && !b` failed to parse, because `BinaryOp.Right` was a `PostfixExpr` while `BinaryExpr.Left` was a `Unary`. The asymmetry was invisible in source order but produced a parse error on any infix operator whose right operand started with a unary prefix.
+1. **One source, one parse tree.** PEG ordered choice removes ambiguity. The reader does not need to know associativity tables, lookahead sets, or shift-reduce conventions to predict how a fragment parses.
+2. **No corner cases.** Anything the grammar accepts is meaningful. Shapes that have no meaning (empty subscript, bodyless match arm, untyped union literal) do not match any production. There is no separate post-parse layer that quietly rejects what the parser quietly accepted.
+3. **Layered precedence.** Binary operators are laid out in a precedence ladder where every level has the same shape: `Operand (op Operand)*`. The operand is always a `Unary`. Both sides of every binary operator are structurally identical, so `a + b`, `a + -b`, `-a + -b`, and `a + --!b` all parse from the same rule.
 
-This revision fixes all six and adds the pieces that turn a grammar description into a contract:
+These principles make the grammar comprehensible end-to-end and remove the implementation cliffs that the previous revision papered over with post-parse validators.
 
-- the **exact** productions in EBNF, including the cross-field groups that participle's tag language hides;
-- the **four shapes** of `type` declaration, each disambiguated by lookahead and locked by a conformance test;
-- the **operand-symmetry invariant** for binary operators: every operand of every binary level is a `Unary`, on both sides of the operator;
-- the **post-parse normalisation pass** that surfaces shapes the grammar alone cannot reject;
-- the **error code table** for every parser-level diagnostic;
-- the **conformance corpus** that exercises each production and each error;
-- the **change checklist** every new statement or operator addition must pass.
+## Grammar notation
+
+The grammar uses the operator set introduced by [PEP 617](https://peps.python.org/pep-0617/) with two restrictions (no action blocks, no return-type annotations). Every operator below has the same semantics as in PEP 617.
+
+| Operator   | Meaning                                                        |
+|------------|----------------------------------------------------------------|
+| `e1 e2`    | Sequence: match `e1`, then `e2`.                               |
+| `e1 \| e2` | Ordered choice: try `e1`; if it fails, try `e2`.               |
+| `e?`       | Optional: 0 or 1 occurrence.                                   |
+| `e*`       | Repetition: 0 or more occurrences.                             |
+| `e+`       | Repetition: 1 or more occurrences.                             |
+| `s.e+`     | One or more `e`, separated by `s`. The separator is not kept.  |
+| `&e`       | Positive lookahead: match without consuming input.             |
+| `!e`       | Negative lookahead: fail without consuming input.              |
+| `~`        | Cut: commit to the current alternative, no further backtrack.  |
+| `'lit'`    | Match a literal token (keyword or punctuation).                |
+| `Ident`    | Match a token kind from MEP 1 (`Ident`, `Int`, `String`, ...). |
+
+Rule names are PascalCase. The start rule is `Program`. Comments and whitespace are removed by the lexer (MEP 1) before parsing; they appear nowhere in the productions.
+
+The grammar is **left-factored**. No rule begins with a recursive call to itself. Where the layered precedence ladder reads naturally as left recursion (`Expr: Expr op Expr | Operand`), the equivalent right-recursive shape `Expr: Operand (op Operand)*` is used instead. The two are observationally identical; the latter does not require a left-recursion-capable parser.
 
 ## Specification
-
-### Build configuration
-
-The parser is built at `parser/parser.go:696-701`:
-
-```
-var Parser = participle.MustBuild[Program](
-    participle.Lexer(mochiLexer),
-    participle.Elide("Whitespace", "Comment"),
-    participle.Unquote("String"),
-    participle.UseLookahead(999),
-)
-```
-
-`UseLookahead(999)` means participle will try arbitrarily many tokens of lookahead at every alternation. That is what lets `Ident '{'` disambiguate between a `StructLiteral` and an `IfExpr` whose body opens with a brace. The cost is silent backtracking and slower error reporting when the deepest branch fails.
-
-The participle tag language uses:
-
-- `'lit'` for a keyword or punctuation literal;
-- `@@` to recurse into a sub-structure;
-- `@Token` to capture into the field;
-- `[ ... ]` for an optional group;
-- `{ ... }` for repetition;
-- `|` for alternation;
-- `( ... )` for grouping. **Groups may span fields**: an opening paren on one field can be closed on another. The `TypeDecl` production below relies on this.
 
 ### Top level
 
 ```
-Program        = [ 'package' Ident ] Statement*
+Program        = 'package' Ident? Statement*
 
 Statement      = TestBlock | BenchBlock | ExpectStmt
                | AgentDecl | StreamDecl | ModelDecl
                | ImportStmt | TypeDecl
-               | ExternTypeDecl | ExternVarDecl | ExternFunDecl | ExternObjectDecl
+               | ExternTypeDecl | ExternVarDecl
+               | ExternFunDecl | ExternObjectDecl
                | FactStmt | RuleStmt | OnHandler | EmitStmt
-               | LetStmt | VarStmt | AssignStmt | FunStmt
+               | LetStmt | VarStmt | FunStmt
                | ReturnStmt | IfStmt | WhileStmt | ForStmt
                | BreakStmt | ContinueStmt
-               | FetchStmt | UpdateStmt | ExprStmt
+               | FetchStmt | UpdateStmt
+               | AssignStmt | ExprStmt
 ```
 
-The discriminated union is `Statement` in `parser/parser.go:84-115`. Participle tries each alternative in order. Any alternative that does not begin with a unique keyword (`AssignStmt`, `ExprStmt`) sits at the bottom of the list because it would otherwise consume tokens meant for a more specific form.
-
-`AssignStmt` is the one alternative without a leading keyword. It is recognised by an `Ident` followed by an optional run of `IndexOp` / `FieldOp` and then an `=`. The lookahead has to span the postfix tail to tell `a.b.c = 1` from `a.b.c` as an expression statement.
+Statement alternatives that begin with a unique keyword come first. The last two alternatives (`AssignStmt`, `ExprStmt`) do not, so they sit at the bottom. PEG ordered choice guarantees that a keyword-led form is never confused for a bare expression.
 
 ### Declarations
 
 ```
-LetStmt    = 'let' Ident [ ':' TypeRef ] [ '=' Expr ]
-VarStmt    = 'var' Ident [ ':' TypeRef ] [ '=' Expr ]
-AssignStmt = Ident IndexOp* FieldOp* '=' Expr
-FunStmt    = [ 'export' ] 'fun' Ident [ TypeParams ]
-             '(' [ Param { ',' Param } ] ')' [ ':' TypeRef ]
-             '{' Statement* '}'
-TypeParams = '<' Ident { ',' Ident } '>'
-Param      = Ident [ ':' TypeRef ]
-ReturnStmt = 'return' [ Expr ]
-BreakStmt  = 'break'
-ContinueStmt = 'continue'
+LetStmt        = 'let' Ident (':' TypeRef)? ('=' Expr)?
+VarStmt        = 'var' Ident (':' TypeRef)? ('=' Expr)?
+AssignStmt     = AssignTarget '=' Expr
+AssignTarget   = Ident (IndexOp | FieldOp)*
+FunStmt        = 'export'? 'fun' Ident TypeParams?
+                 '(' ','.Param* ')' (':' TypeRef)?
+                 '{' Statement* '}'
+TypeParams     = '<' ','.Ident+ '>'
+Param          = Ident (':' TypeRef)?
+ReturnStmt     = 'return' Expr?
+BreakStmt      = 'break'
+ContinueStmt   = 'continue'
 ```
 
-The optional `:` in `LetStmt` and `VarStmt` is what lets `let x: int` parse as a declaration without an initial value. The type checker decides whether that is legal in the surrounding scope.
+`AssignTarget` is the postfix chain rooted at an identifier. The grammar therefore accepts `a = 1`, `a.b = 1`, `a[0] = 1`, and `a.b[0].c = 1`, and rejects assignments to literal-rooted expressions (`1 = x`, `f() = x`) at parse time. Call expressions cannot appear on the left of `=`.
 
 ### Type declarations
 
-`TypeDecl` is the most overloaded production in the grammar. The body of a `type` declaration has **four** mutually exclusive shapes:
+A `type` declaration takes exactly one of three forms, distinguished by the first token after `=`:
 
 ```
-TypeDecl   = 'type' Ident
-             ( [ '=' ] '{' TypeMember { [ ',' ] TypeMember } [ ',' ] '}'    (* 1: struct  *)
-             | '=' TypeVariant ( '|' TypeVariant )+                          (* 2: multi-variant *)
-             | '=' TypeVariantHead                                           (* 3: single variant with fields *)
-             | '=' TypeRef                                                   (* 4: alias *)
-             )
+TypeDecl       = 'type' Ident TypeDeclBody
 
-TypeMember     = TypeField | FunStmt
-TypeVariant    = Ident [ '(' TypeField { ',' TypeField } [ ',' ] ')'
-                       | '{' TypeField* '}' ]
-TypeVariantHead= Ident   ( '(' TypeField { ',' TypeField } [ ',' ] ')'
-                       | '{' TypeField* '}' )
+TypeDeclBody   = StructBody | VariantUnion | TypeAlias
+
+StructBody     = '='? '{' ','.TypeField+ ','? '}'
+                | '='? '{' '}'
+VariantUnion   = '=' TypeVariant ('|' TypeVariant)*
+                 & VariantOrAliasHint
+TypeAlias      = '=' TypeRef
+
+TypeVariant    = Ident VariantPayload?
+VariantPayload = '(' ','.TypeField+ ','? ')'
+                | '{' TypeField* '}'
 TypeField      = Ident ':' TypeRef
 ```
 
-The parser tries them in the order shown. The four shapes:
+The grammar distinguishes `VariantUnion` from `TypeAlias` by lookahead: `VariantOrAliasHint` succeeds only when the head identifier is followed by `(`, `{`, or `|`. A bare identifier or any compound type expression falls through to `TypeAlias`.
 
-| # | Shape | Example |
-|---|-------|---------|
-| 1 | Struct | `type Point { x: int, y: int }` or `type Point = { x: int, y: int }` |
-| 2 | Tagged union with two or more variants | `type Shape = Circle(r: float) \| Square(s: float)` |
-| 3 | Tagged union with exactly one variant that *has* fields | `type Pair = P(a: int, b: int)` |
-| 4 | Alias to a `TypeRef` (any shape: `Ident`, `GenericType`, `FunType`, `InlineStructType`) | `type Id = int`, `type IdList = list<int>`, `type Fn = fun(int): string`, `type Pt = { x: int, y: int }` |
+| Shape                    | Example                                        |
+|--------------------------|------------------------------------------------|
+| Struct                   | `type Point { x: int, y: int }`                |
+| Struct, explicit `=`     | `type Point = { x: int, y: int }`              |
+| Variant union, 1 variant | `type Pair = P(a: int, b: int)`                |
+| Variant union, N variants| `type Shape = Circle(r: float) \| Square(s)`   |
+| Alias to a type ref      | `type Id = int`                                |
+| Alias to a generic       | `type IdList = list<int>`                      |
+| Alias to a function      | `type Fn = fun(int): string`                   |
+| Alias to inline struct   | `type Pt = { x: int, y: int }`                 |
 
-`TypeVariantHead` exists **only** to disambiguate shape 3 from shape 4. Without it, the parser cannot tell whether `Ctor(` opens a variant or starts a `TypeRef` that happens to look like a call. Because `TypeVariantHead.Fields` is *mandatory* (the inner `(...)` or `{...}` is not bracketed by `[...]`), a bare `Ident` falls through to branch 4 as an alias. The `Pair = P(a, b)` case parses as shape 3 and the `Id = int` case parses as shape 4. After parsing, `normalizeProgram` lifts `SingleVariant` into the `Variants` slice so every downstream consumer sees a uniform tagged-union shape and `TypeDecl.SingleVariant` is always `nil`.
-
-The four-way alternation is expressed using participle's **cross-field grouping**. The opening `(` of the alternation is on the `Members` field; the closing `)` is on the `Alias` field. The intermediate fields all begin with `|`. See `parser/parser.go:181-189`:
-
-```go
-type TypeDecl struct {
-    Pos           lexer.Position   `parser:""`
-    Name          string           `parser:"'type' @Ident"`
-    Members       []*TypeMember    `parser:"  ( [ '=' ] '{' @@ { [ ',' ] @@ } [ ',' ]? '}'"`
-    Variants      []*TypeVariant   `parser:"| '=' @@ ( '|' @@ )+"`
-    SingleVariant *TypeVariantHead `parser:"| '=' @@"`
-    Alias         *TypeRef         `parser:"| '=' @@ )"`
-}
-```
+A single-variant union (`type Pair = P(a, b)`) is structurally a `VariantUnion`, not a degenerate `TypeAlias`. The empty-struct form `type Empty {}` is accepted; the empty union form `type X = |` is not, because `VariantUnion` requires at least one `TypeVariant`.
 
 ### Type references
 
 ```
-TypeRef         = FunType | GenericType | InlineStructType | Ident
-FunType         = 'fun' '(' [ TypeRef { ',' TypeRef } ] ')' [ ':' TypeRef ]
-GenericType     = Ident '<' TypeRef { ',' TypeRef } '>'
-InlineStructType= '{' [ TypeField { ',' TypeField } [ ',' ] ] '}'
-TypeField       = Ident ':' TypeRef
+TypeRef          = FunType
+                 | GenericType
+                 | InlineStructType
+                 | Ident
+
+FunType          = 'fun' '(' ','.TypeRef* ')' (':' TypeRef)?
+GenericType      = Ident '<' ','.TypeRef+ '>'
+InlineStructType = '{' ','.TypeField* ','? '}'
 ```
 
-There is no union type literal in `TypeRef`, only in `TypeDecl`. That is why `let x: int | nil = ...` will not parse. The fix is either to lift union into `TypeRef` or to introduce an option syntax such as `int?`. See [Open Questions](#open-questions).
+`TypeRef` is the type-position expression. There is no union type literal in `TypeRef`. Sum types must be named through `TypeDecl`. There is no tuple type literal. Heterogeneous fixed-shape data uses a struct.
 
-There is no tuple type literal. Heterogeneous data must use a struct.
-
-### Expressions
-
-The expression grammar is a flat precedence pyramid. Associativity and precedence are imposed by the type checker, not the parser.
+### Control flow
 
 ```
-Expr        = Unary BinaryOp*
-BinaryOp    = BinOpToken [ 'all' ] Unary
-BinOpToken  = '==' | '!=' | '<' | '<=' | '>' | '>='
-            | '+'  | '-'  | '*'  | '/'  | '%'
-            | 'in' | '&&' | '||'
-            | 'union' | 'except' | 'intersect'
-Unary       = UnaryOp* PostfixExpr
-UnaryOp     = '-' | '!'
-PostfixExpr = Primary PostfixOp*
-PostfixOp   = CallOp | IndexOp | FieldOp | CastOp
-CallOp      = '(' [ Expr { ',' Expr } ] ')'
-IndexOp     = '[' [ Expr ] [ ':' [ Expr ] ] [ ':' [ Expr ] ] ']'
-FieldOp     = '.' Ident
-CastOp      = 'as' TypeRef
-Primary     = StructLiteral | CallExpr | QueryExpr | LogicQueryExpr
-            | IfExpr | SelectorExpr | ListLiteral | MapLiteral
-            | FunExpr | MatchExpr | GenerateExpr | FetchExpr
-            | LoadExpr | SaveExpr | Literal | '(' Expr ')'
+IfStmt    = 'if' Expr '{' Statement* '}'
+            ('else' (IfStmt | '{' Statement* '}'))?
+WhileStmt = 'while' Expr '{' Statement* '}'
+ForStmt   = 'for' Ident 'in' ForRange '{' Statement* '}'
+ForRange  = Expr '..' Expr
+          | Expr
 ```
 
-Three properties of this shape are non-obvious:
-
-- **Operand symmetry.** Both sides of a binary operator are a `Unary`. The left side is `BinaryExpr.Left *Unary`; the right side is `BinaryOp.Right *Unary`. That means `x == -1`, `a + -b`, `a * -b`, and `a && !b` all parse. The right operand can carry any unary prefix sequence the left operand can. See [Operand symmetry](#operand-symmetry-binary-operands-are-unary-expressions) below for the theoretical basis and why an earlier version of this grammar broke the invariant.
-- `Unary.Ops` is a slice, so multiple prefixes stack: `--x` is two unary minuses, not a decrement; `!!x` is two boolean nots. The same holds on the RHS: `a + --b` and `a + -!b` both parse.
-- `PostfixOp` is also a slice, so chains like `f()(2).field as int` work in one production.
-
-The flat `BinaryOp*` list is rebalanced into a precedence tree by the type checker. See `types/infer.go:89-205` for the precedence levels. The parser does not enforce associativity. That is a deliberate simplification that pushes the work to a single place.
-
-### Operand symmetry: binary operands are unary expressions
-
-The canonical layered precedence grammar treats every binary level the same way:
-
-```
-OrExpr      = AndExpr ('||' AndExpr)*
-AndExpr     = EqExpr  ('&&' EqExpr)*
-EqExpr      = RelExpr (('==' | '!=') RelExpr)*
-RelExpr     = AddExpr (('<' | '<=' | '>' | '>=') AddExpr)*
-AddExpr     = MulExpr (('+' | '-') MulExpr)*
-MulExpr     = UnaryExpr (('*' | '/' | '%') UnaryExpr)*
-UnaryExpr   = UnaryOp* PostfixExpr
-PostfixExpr = Primary PostfixOp*
-```
-
-Every binary production at every precedence level has the same shape: `Operand (op Operand)*`. The operand is always `UnaryExpr`. This is not an accident. A Pratt or precedence-climbing parser arrives at the same invariant from the other direction: after consuming an infix operator, the parser recurses into `expression(unary_prec)` to read the next operand, and that subroutine accepts any unary prefix before the next primary. The symmetry is forced by the algorithm.
-
-Mochi collapses the binary tower into one flat list and recovers precedence in a post-parse pass. The flattening is a stylistic choice; the operand-symmetry invariant must still hold. An earlier draft of MEP 2 violated it: `BinaryExpr.Left` was a `Unary` (with a unary-prefix slot), but `BinaryOp.Right` was a `PostfixExpr` (no unary-prefix slot). The result was that `a + b` and `-a + b` parsed but `a + -b` did not. This was a hidden asymmetry, not a precedence choice. Fixing it required nothing more than changing the field type so that both sides of every `BinaryOp` are a `Unary`.
-
-The invariant is now locked by two structural tests:
-
-- `TestGrammar_UnaryOnBinaryRHS` parses every binary operator with a unary prefix on its right operand and asserts the parse tree carries the prefix in `BinaryOp.Right.Ops`.
-- `TestGrammar_BinaryOperandsAreSymmetric` enumerates every pair of `{ b, -b, !b, --b, -!b }` and asserts that any combination is accepted as `lhs + rhs`. If a future grammar change re-introduces an asymmetry between Left and Right, one of these tests will fail.
-
-The takeaway: in this grammar, **any unary prefix accepted at any operand position is accepted at every operand position**. Future operator additions inherit the invariant for free as long as their operand fields stay `*Unary` and not `*PostfixExpr`.
-
-### Index and slice
-
-The `IndexOp` production accepts subscripts (`xs[i]`) and slices (`xs[a:b]`, `xs[a:b:c]`) with every component independently optional. The grammar therefore accepts three shapes the post-parse pass rejects:
-
-| Source | Grammar | Post-parse |
-|--------|---------|------------|
-| `xs[i]` | accepted | accepted |
-| `xs[a:b]`, `xs[:b]`, `xs[a:]`, `xs[::s]`, `xs[a:b:c]` | accepted | accepted |
-| `xs[]` | accepted | `error[P060]` |
-| `xs[:]` | accepted | `error[P060]` |
-| `xs[::]` | accepted | `error[P060]` |
-
-The validator requires at least one of `Start`, `End`, or `Step` to be present. See `parser/normalize.go:197-205`.
+`ForRange` puts the half-open range form first so `0..n` binds as a range rather than as an expression followed by stray tokens. The general form `for x in xs` falls through to the second alternative.
 
 ### Pattern matching
 
 ```
-MatchExpr = 'match' Expr '{' MatchCase* '}'
-MatchCase = Expr '=>' ( Expr | '{' Statement* '}' )
+MatchExpr  = 'match' Expr '{' MatchArm* '}'
+MatchArm   = Pattern '=>' MatchBody
+MatchBody  = Expr | '{' Statement* '}'
+Pattern    = Expr
 ```
 
-The grammar makes both `Expr` and `'{' Statement* '}'` independently optional. The post-parse pass requires exactly one of them to be present: a match arm with no body is `error[P061]`. See `parser/normalize.go:231-239`.
+`MatchBody` is mandatory. A `=>` with nothing on its right does not parse. The pattern is just an expression; the type checker decides whether a given expression shape is a legal pattern (see [MEP 13](/docs/mep/mep-0013)).
 
-There is no separate pattern grammar. The pattern is just an expression. The checker is responsible for deciding whether a given expression shape is allowed as a pattern. See [MEP 13](/docs/mep/mep-0013) for the pattern rules.
+### Expressions
 
-### Queries
+The expression grammar is a precedence ladder. Every level has the same shape: `Operand (op Operand)*`. The operand is always `Unary`. Operator precedence is encoded structurally; the parser does not consult a precedence table.
 
 ```
-QueryExpr   = 'from' Ident 'in' Expr
-              { FromClause }
-              { JoinClause }
-              [ 'where' Expr ]
-              [ GroupByClause ]
-              [ ( 'sort' | 'order' ) 'by' Expr ]
-              [ 'skip' Expr ]
-              [ 'take' Expr ]
-              'select' [ 'distinct' ] Expr
-FromClause    = 'from' Ident 'in' Expr
-JoinClause    = [ 'left' | 'right' | 'outer' ] 'join' [ 'from' ] Ident
-                'in' Expr 'on' Expr
-GroupByClause = 'group' 'by' Expr { ',' Expr } 'into' Ident [ 'having' Expr ]
+Expr          = OrExpr
+
+OrExpr        = AndExpr ('||' AndExpr)*
+AndExpr       = NotExpr ('&&' NotExpr)*
+NotExpr       = '!'* RelExpr
+RelExpr       = AddExpr (RelOp AddExpr)*
+RelOp         = '==' | '!=' | '<=' | '>=' | '<' | '>'
+              | 'in' | 'union' 'all'? | 'except' | 'intersect'
+AddExpr       = MulExpr (('+' | '-') MulExpr)*
+MulExpr       = Unary (('*' | '/' | '%') Unary)*
+
+Unary         = ('-')* PostfixExpr
+PostfixExpr   = Primary PostfixOp*
+PostfixOp     = CallOp | IndexOp | FieldOp | CastOp
+
+CallOp        = '(' ','.Expr* ')'
+FieldOp       = '.' Ident
+CastOp        = 'as' TypeRef
 ```
 
-The fixed clause order is enforced by the grammar. `select ... from ... where ...` will not parse because `from` must come first. The shape is LINQ, not SQL.
+Three invariants the grammar guarantees:
+
+- **Operand symmetry.** Both operands of every binary operator are a `Unary`. The right side carries the same unary-prefix slot as the left, so `a + -b`, `x == -1`, `a && !b`, and `a + -!b * c` all parse. This is the canonical layered precedence shape; see [Pratt 1973](https://dl.acm.org/doi/10.1145/512927.512931) and [Crafting Interpreters §6](https://craftinginterpreters.com/parsing-expressions.html).
+- **Prefix stacking.** `Unary` accepts `('-')*`, so `--x` is two unary minuses and `!!x` is two boolean nots. There is no decrement or increment operator; the longest-match rule of MEP 1 is irrelevant because there are no two-character `--` or `++` tokens.
+- **Postfix chains.** `PostfixOp*` is unbounded, so `f()(2).field as int` is one chain in one production. Method-call sugar lives in `PostfixOp`, not in `Primary`.
+
+Operator precedence, from loosest to tightest:
+
+| Level | Operators                                              | Production |
+|-------|--------------------------------------------------------|------------|
+| 1     | `\|\|`                                                 | `OrExpr`   |
+| 2     | `&&`                                                   | `AndExpr`  |
+| 3     | `!` prefix                                             | `NotExpr`  |
+| 4     | `== != <= >= < > in union[all]? except intersect`      | `RelExpr`  |
+| 5     | `+ -` (binary)                                         | `AddExpr`  |
+| 6     | `* / %`                                                | `MulExpr`  |
+| 7     | `-` prefix                                             | `Unary`    |
+| 8     | `() [] . as`                                           | `PostfixOp`|
+
+All binary operators are left-associative. Right-associativity is achieved by parenthesisation. Prefix `-` and prefix `!` are not interchangeable: `!` lives in `NotExpr` (between `&&` and the relational level) so `!a == b` parses as `!(a == b)` only if grouped explicitly; otherwise as `(!a) == b`. Numeric negation lives in `Unary`, tightly binding to the operand.
+
+### Subscript and slice
+
+The grammar enumerates every well-formed shape. Empty subscripts and slices have no production:
+
+```
+IndexOp    = '[' SliceForm ']'
+
+SliceForm  = Expr ':' Expr ':' Expr        (* [a:b:c] *)
+           | Expr ':' Expr ':'             (* [a:b:]  *)
+           | Expr ':' ':' Expr             (* [a::c]  *)
+           | Expr ':' ':'                  (* [a::]   *)
+           | Expr ':' Expr                 (* [a:b]   *)
+           | Expr ':'                      (* [a:]    *)
+           | ':' Expr ':' Expr             (* [:b:c]  *)
+           | ':' Expr ':'                  (* [:b:]   *)
+           | ':' ':' Expr                  (* [::c]   *)
+           | ':' Expr                      (* [:b]    *)
+           | Expr                          (* [a]     *)
+```
+
+The 11 alternatives cover the full lattice of well-formed slices and the single subscript shape. `xs[]`, `xs[:]`, and `xs[::]` match no alternative; they are syntax errors at parse time, not at a later pass. A post-parse validator for empty-index shapes is no longer needed.
+
+### Primary expressions
+
+```
+Primary       = StructLiteral | QueryExpr | LogicQueryExpr
+              | IfExpr | SelectorExpr
+              | ListLiteral | MapLiteral
+              | FunExpr | MatchExpr | GenerateExpr | FetchExpr
+              | LoadExpr | SaveExpr | Literal
+              | '(' Expr ')'
+
+StructLiteral = Ident '{' ','.StructLitField* ','? '}'
+StructLitField= Ident ':' Expr
+SelectorExpr  = Ident ('.' Ident)*
+ListLiteral   = '[' ','.Expr* ','? ']'
+MapLiteral    = '{' ','.MapEntry* ','? '}'
+MapEntry      = (Ident | String | Int) ':' Expr
+Literal       = Int | Float | String | 'true' | 'false' | 'null'
+```
+
+`MapLiteral` and `InlineStructType` share the `{ ... }` shape. PEG ordered choice resolves the ambiguity by context: in expression position the parser tries `StructLiteral` first (only matches when an identifier precedes the brace) and `MapLiteral` second; in type position only `InlineStructType` is available.
 
 ### Lambda expressions
 
 ```
-FunExpr = 'fun' [ TypeParams ] '(' [ Param { ',' Param } ] ')'
-          [ ':' TypeRef ]
-          ( '{' Statement* '}' | '=>' Expr )
+FunExpr = 'fun' TypeParams?
+          '(' ','.Param* ')' (':' TypeRef)?
+          ('{' Statement* '}' | '=>' Expr)
 ```
 
-Both the block body and the arrow form are accepted. The arrow form yields the expression as the function result.
+Block-bodied and arrow-bodied forms are both accepted. The arrow form yields its expression as the function result.
 
-### Control flow statements
+### Queries
+
+The query expression follows LINQ clause order. The grammar enforces the order; SQL-style `select ... from ...` does not parse.
 
 ```
-IfStmt    = 'if' Expr '{' Statement* '}'
-            [ 'else' ( IfStmt | '{' Statement* '}' ) ]
-WhileStmt = 'while' Expr '{' Statement* '}'
-ForStmt   = 'for' Ident 'in' Expr [ '..' Expr ] '{' Statement* '}'
+QueryExpr      = 'from' Ident 'in' Expr
+                 FromClause*
+                 JoinClause*
+                 ('where' Expr)?
+                 GroupByClause?
+                 (('sort' | 'order') 'by' Expr)?
+                 ('skip' Expr)?
+                 ('take' Expr)?
+                 'select' 'distinct'? Expr
+FromClause     = 'from' Ident 'in' Expr
+JoinClause     = ('left' | 'right' | 'outer')? 'join' 'from'? Ident
+                 'in' Expr 'on' Expr
+GroupByClause  = 'group' 'by' ','.Expr+ 'into' Ident ('having' Expr)?
 ```
-
-`if ... else if ... else` is encoded as a recursive `IfStmt` in the `ElseIf` field; the alternation between `ElseIf` and `Else` is a cross-field group between `IfStmt.ElseIf` and `IfStmt.Else`.
-
-`ForStmt` accepts either an iterable expression (`for x in xs { ... }`) or a half-open range (`for i in 0..n { ... }`). The `..` form only appears at the top of `for`, not as a general expression operator.
 
 ### Logic programming
 
 ```
 FactStmt        = 'fact' LogicPredicate
-RuleStmt        = 'rule' LogicPredicate ':-' LogicCond { ',' LogicCond }
+RuleStmt        = 'rule' LogicPredicate ':-' ','.LogicCond+
 LogicCond       = LogicPredicate | LogicNeq
 LogicNeq        = Ident '!=' Ident
-LogicPredicate  = Ident '(' [ LogicTerm { ',' LogicTerm } ] ')'
+LogicPredicate  = Ident '(' ','.LogicTerm* ')'
 LogicTerm       = Ident | String | Int
 LogicQueryExpr  = 'query' LogicPredicate
 ```
 
-These productions parse but the runtime VM does not execute them. The tree-walking interpreter handles them. See [MEP 10](/docs/mep/mep-0010).
+These productions parse and the tree-walking interpreter executes them. The bytecode VM does not. See [MEP 10](/docs/mep/mep-0010).
 
 ### Streams and agents
 
 ```
-StreamDecl = 'stream' Ident '{' StreamField* '}'
-EmitStmt   = 'emit' Ident '{' [ StructLitField { ',' StructLitField } [ ',' ] ] '}'
-OnHandler  = 'on' Ident 'as' Ident '{' Statement* '}'
-AgentDecl  = 'agent' Ident '{' AgentBlock* '}'
-AgentBlock = LetStmt | VarStmt | AssignStmt | OnHandler | IntentDecl
-IntentDecl = 'intent' Ident '(' [ Param { ',' Param } ] ')'
-             [ ':' TypeRef ] '{' Statement* '}'
+StreamDecl   = 'stream' Ident '{' StreamField* '}'
+StreamField  = Ident ':' TypeRef
+EmitStmt     = 'emit' Ident '{' ','.StructLitField* ','? '}'
+OnHandler    = 'on' Ident 'as' Ident '{' Statement* '}'
+AgentDecl    = 'agent' Ident '{' AgentBlock* '}'
+AgentBlock   = LetStmt | VarStmt | AssignStmt | OnHandler | IntentDecl
+IntentDecl   = 'intent' Ident '(' ','.Param* ')'
+               (':' TypeRef)? '{' Statement* '}'
 ```
 
-Same caveat as logic. Parsed and partially typed, not VM compiled.
-
-### I/O statements
+### I/O
 
 ```
-FetchStmt = 'fetch' Expr 'into' Ident [ 'with' Expr ]
-LoadExpr  = 'load' [ String ] 'as' TypeRef [ 'with' Expr ]
-SaveExpr  = 'save' Expr [ 'to' String ] [ 'with' Expr ]
+FetchStmt = 'fetch' Expr 'into' Ident ('with' Expr)?
+LoadExpr  = 'load' String? 'as' TypeRef ('with' Expr)?
+SaveExpr  = 'save' Expr ('to' String)? ('with' Expr)?
 ```
 
-`load` and `save` need both `as Type` and an explicit format in the `with` map for any non-default behaviour.
+`load` and `save` require both `as Type` and a format option in the `with` map for any non-default behaviour.
 
-### Post-parse normalisation
+## Design principles
 
-After participle returns, `parser.Parse` calls `normalizeProgram` (`parser/normalize.go`). The pass does three jobs:
+### Single parse tree per source
 
-1. **Lift `TypeDecl.SingleVariant` into `Variants`** so every consumer sees a uniform tagged-union shape. After normalisation `td.SingleVariant` is always `nil`.
-2. **Validate `IndexOp` shapes**: reject `xs[]`, `xs[:]`, `xs[::]` (`error[P060]`).
-3. **Validate `MatchCase` bodies**: reject `pattern => ` with no result and no block (`error[P061]`).
+PEG ordered choice eliminates ambiguity at the grammar level. A reader does not need to know shift-reduce conventions, lookahead sets, or associativity tables to predict how a fragment parses. The first alternative that matches wins; no later alternative is considered.
 
-The traversal walks the spine of the AST that can contain `IndexOp` or `MatchExpr` nodes (statements, expressions, postfix chains, match results, query clauses). It is deterministic: two runs over the same source always produce the same diagnostic in source order.
+### No corner cases
 
-### Diagnostic codes
+A grammar that accepts shapes a post-parse pass then rejects is two grammars layered. Every shape this MEP defines is meaningful by construction:
 
-| Code | Class | Trigger |
-|------|-------|---------|
-| `P060` | Grammar (post-parse) | Index expression has no key, range, or step (`xs[]`, `xs[:]`, `xs[::]`) |
-| `P061` | Grammar (post-parse) | Match case has no result expression and no block body |
+- `IndexOp` enumerates the 11 well-formed slice shapes. `xs[]`, `xs[:]`, `xs[::]` match no production.
+- `MatchBody` is mandatory. `=>` followed by nothing matches no production.
+- `AssignTarget` is restricted to postfix chains rooted at an identifier. `1 = x`, `f() = x`, `(a + b) = x` match no production.
+- `VariantUnion` requires at least one `TypeVariant`. `type X = |` matches no production.
 
-Codes `P000`–`P039` are reserved for the higher-level parse-error surface (`parser/errors.go`). Codes `P040`–`P046` are the lexer's (MEP 1). The grammar's post-parse codes start at `P060` so there is room to grow either direction without renumbering.
+The post-parse normalisation pass that earlier revisions documented under codes `P060` and `P061` is removed. Those codes are retired.
 
-## Rationale
+### Layered precedence with operand symmetry
 
-### Why post-parse validation, not grammar restructure
+The expression grammar follows the layered precedence ladder of [Aho-Sethi-Ullman §4.3](https://suif.stanford.edu/dragonbook/) and [Crafting Interpreters §6](https://craftinginterpreters.com/parsing-expressions.html). Every binary level has the shape `Operand (op Operand)*` with `Operand = Unary`. Both sides of every binary operator are the same operand type. The reader and the implementor are guaranteed that any unary prefix accepted at any operand position is accepted at every operand position. There is no asymmetry between `Left` and `Right` to remember or work around.
 
-Both `IndexOp` and `MatchCase` *could* be encoded so the grammar itself rejects the empty forms. Doing so would require splitting `IndexOp` into separate productions for `Subscript`, `Slice1`, `Slice2`, `Slice3`, and a corresponding split for `MatchCase`. Each split adds a fresh source of ambiguity for participle to resolve through 999-token lookahead. The post-parse pass is simpler, gives each shape its own stable diagnostic code, and keeps the parse tree shape unchanged for downstream consumers.
+### Keyword-led statements
 
-### Why a `TypeVariantHead` helper
+All compound statements lead with a unique keyword (`let`, `var`, `fun`, `if`, `while`, `for`, `return`, `break`, `continue`, `type`, `fact`, `rule`, `import`, `stream`, `agent`, `on`, `emit`, `fetch`, `test`, `bench`, `expect`). The grammar disambiguates by keyword, not by lookahead distance. The two keyword-less statements (`AssignStmt`, `ExprStmt`) sit last in the alternation and are recognised by their structural shape.
 
-The four `TypeDecl` shapes share a leading `=`. Branch 3 (single variant with fields) needs to commit to a variant shape *before* falling through to branch 4 (alias). The cleanest way to do that in participle is a dedicated type whose `Fields` are not optional: `TypeVariantHead`. The parser tries it before `Alias`, succeeds when followed by `(` or `{`, and falls through to `Alias` for any bare `TypeRef`. This is invisible to consumers because `normalizeProgram` immediately lifts it into `Variants`.
+### No left recursion in production rules
 
-### Why `UseLookahead(999)`
+Every binary level is written `Operand (op Operand)*` rather than `Expr op Operand | Operand`. The two forms accept the same language; the right-recursive shape is parsed without a left-recursion-capable parser. The implementation runs on `participle/v2`, which does not support direct left recursion. The spec uses the same shape so the implementation is a literal translation.
 
-Lookahead 999 was chosen as effectively unbounded so we never have to think about backtracking when adding a new construct. The cost is harder-to-trace error messages when an alternative deep in the search tree fails. We accept that cost today; the alternative is to redesign productions every time a new alternative collides with an old one. The [Open Questions](#open-questions) section tracks the worst-case input we have seen.
+### Precedence in the type checker is an implementation detail
 
-### Why precedence lives in the type checker
-
-Pushing precedence handling into the type checker means the parser is a single pass that produces a flat AST. That decision keeps the parser file readable. It does cost in error quality, because a malformed precedence chain is often diagnosed late. See `types/infer.go:89-205`.
-
-### Why both operands of a binary operator are `Unary`
-
-The layered precedence grammar (Aho-Sethi-Ullman §4.3; Crafting Interpreters §6; Pratt 1973) treats every binary level as `Operand (op Operand)*` with the same operand type at every level. The operand type is `UnaryExpr`, because unary prefixes bind tighter than every binary operator but looser than every postfix operator. The flat-with-post-parse-precedence approach Mochi uses is just an unrolling of the layered tower; it inherits the invariant or it inherits bugs.
-
-The earlier draft's `BinaryOp.Right *PostfixExpr` saved one field of memory per binary operator and produced a parse error on `a + -b`. The current draft's `BinaryOp.Right *Unary` is the textbook shape and the symmetry it restores is worth more than the field. Every consumer that walks `BinaryOp.Right` (interpreter, VM compiler, type checker, every transpiler, and the SQL backend in `runtime/data/duckdb.go`) was updated in the same revision to call the `xxxUnary` variant of whatever it previously called on `*PostfixExpr`. The change is a pure structural symmetry restoration: the AST is now homomorphic on both sides of every binary operator.
+The flat right-recursive shape produces an AST that is balanced by the type checker into a precedence tree. That is an implementation choice, not a language choice. The language definition is the layered ladder. A future implementation that parses directly into a precedence tree would accept and reject exactly the same set of programs.
 
 ## Conformance
 
-The conformance corpus lives under `parser/grammar_test.go`, `parser/lexer_fuzz_test.go`, and `tests/parser/`. Every change to the grammar must keep the corpus green and, when adding new behaviour, must extend it.
+The conformance corpus is at `parser/grammar_test.go`, `parser/lexer_fuzz_test.go`, and `tests/parser/`. Every change to the grammar must keep the corpus green and, where it adds shape, must extend it.
 
-**TypeDecl shapes.** `TestGrammar_TypeDeclShapes` exercises the four-way alternation:
+### Positive tests
 
-- bare identifier → alias (`type Id = int`);
-- generic identifier → alias (`type IdList = list<int>`);
-- map → alias (`type M = map<string, int>`);
-- function → alias (`type Fn = fun(int): string`);
-- struct with and without the leading `=`;
-- two-or-more variant union;
-- variant union with fields;
-- single variant with fields.
+- **`TestGrammar_TypeDeclShapes`** enumerates the three `TypeDecl` forms (struct, variant union, alias) across every payload: bare identifier alias, generic alias, function alias, inline-struct alias, struct with and without `=`, single-variant union, multi-variant union.
+- **`TestGrammar_IndexAndSliceShapes`** enumerates all 11 well-formed `SliceForm` alternatives plus chained subscripts and string-keyed maps. Each accepted shape asserts the AST carries the expected `Start`, `End`, `Step` slots.
+- **`TestGrammar_MatchCaseBody`** asserts that arms with an expression body and arms with a block body both parse.
+- **`TestGrammar_StatementShapes`** smoke-tests every top-level statement form: `let` with and without value, `var`, field and index assignment, `if/else`, `while`, `for-in`, `for-range`, `return` with and without value, generic `fun`, `break`, `continue`, `test`, `bench`.
+- **`TestGrammar_LiteralShapes`** covers list, map, string, integer (hex, binary, octal), float (with exponent), boolean, and null literals, including trailing-comma forms.
+- **`TestGrammar_UnaryOnBinaryRHS`** parses every binary operator with a unary prefix on its right operand and asserts the prefix lands on `BinaryOp.Right.Ops`.
+- **`TestGrammar_BinaryOperandsAreSymmetric`** enumerates the cross-product `{ b, -b, !b, --b, -!b }` on both sides of `+` and asserts every combination parses.
+- **`TestGrammar_UnaryRHSPrecedence`** parses `a + -b * c` and asserts the unary `-` sits on the RHS of `+`, confirming `-b * c` binds tighter than `a + ...`.
 
-Each case asserts that after normalisation `SingleVariant` is `nil` and the correct one of `Alias`, `Members`, `Variants` is populated.
+### Negative tests
 
-**Index and slice.** `TestGrammar_IndexAndSliceShapes` exercises every shape `xs[...]` accepts: subscripts, half-open and full slices, three-component slices, chained subscripts, and string-keyed maps. The rejected shapes (`xs[]`, `xs[:]`, `xs[::]`, and the assign-target form `a[] = 2`) each assert error code `P060`.
+Every shape the grammar rejects has at least one fixture under `tests/parser/errors/`:
 
-**Match bodies.** `TestGrammar_MatchCaseBody` asserts that arms with an expression body and arms with a block body both parse, and that bodyless arms produce `P061`.
+- `empty_index.err` for `xs[]`.
+- `empty_slice.err` for `xs[:]` and `xs[::]`.
+- `match_case_missing_body.err` for `match v { 0 => }`.
+- `assign_call_target.err` for `f() = 1`.
+- `empty_variant_union.err` for `type X = |`.
 
-**Statement shapes.** `TestGrammar_StatementShapes` is a smoke test for every top-level statement form: `let` with and without value, `var`, field and index assignment, `if`/`else`, `while`, `for-in`, `for-range`, `return` with and without value, generic `fun`, `break`/`continue`, `test`, `bench`.
+The expected message asserts the parser's source-location pointer lands on the offending token, not on the next-best-anchor.
 
-**Literal shapes.** `TestGrammar_LiteralShapes` covers list, map, string, integer (hex/binary/octal), float (with exponent), boolean, and null literals, including trailing-comma forms.
+### Fuzzing
 
-**Operand symmetry.** Three tests lock the invariant that every operand of a binary operator is a `Unary`:
-
-- `TestGrammar_UnaryOnBinaryRHS` parses every shape `lhs op rhs` where `rhs` carries a unary prefix (`-b`, `!b`, `--b`, `-!b`) and asserts the prefix lands on `BinaryOp.Right.Ops`.
-- `TestGrammar_BinaryOperandsAreSymmetric` enumerates the cross-product of `{ b, -b, !b, --b, -!b }` on both sides of `+` and asserts every combination parses. The test would fail the moment a future change re-introduces an asymmetry between `BinaryExpr.Left` and `BinaryOp.Right`.
-- `TestGrammar_UnaryRHSPrecedence` parses `a + -b * c` and asserts the unary `-` sits on the RHS of `+` rather than on the LHS of `*`, confirming the post-parse precedence climber still binds `-b * c` tighter than `a + ...`.
-
-**Fuzzing.** `FuzzParseString` feeds arbitrary strings to `ParseString`. The seed corpus is drawn from every grammar shape this MEP specifies: every `TypeDecl` shape, every postfix interleaving the audit exposed, match arms with and without bodies, query shapes, container literals, and the edge cases listed in the audit (`xs[]`, `xs[:]`, `match v { 0 => }`). The invariant is no panic, no hang, and no `(nil, nil)` return.
-
-**Error fixtures.** Each grammar diagnostic has at least one fixture under `tests/parser/errors/`:
-
-- `empty_index.err` → `P060`
-- `empty_slice.err` → `P060`
-- `match_case_missing_body.err` → `P061`
-
-## Backwards Compatibility
-
-This revision tightens three input shapes that previously parsed silently:
-
-- `xs[]`, `xs[:]`, and `xs[::]` are now rejected with `P060` instead of being accepted as a successful-but-meaningless index.
-- `match v { 0 => }` is now rejected with `P061` instead of being silently treated as a `null` result arm.
-
-It also broadens three classes of shape that previously failed to parse:
-
-- `type Id = int`, `type Id = list<int>`, `type Id = map<string, int>`, `type Id = fun(int): string` now all parse as aliases. The fixture `tests/parser/valid/type_alias.golden` was updated to reflect the corrected AST (an `Alias` field rather than a single nameless `Variant`).
-- `type Pair = P(a: int, b: int)` (one variant with fields, no leading `|`) now parses as a tagged union of one variant, not as an alias.
-- `a + -b`, `a * -b`, `a && !b`, `x == -1`, and any other infix expression whose right operand starts with a unary prefix now parse. The parse tree carries the prefix on `BinaryOp.Right.Ops` exactly as it would on `BinaryExpr.Left.Ops`. The asymmetry that forced users to write `x == (-1)` is gone.
-
-Every consumer of `BinaryOp.Right` was migrated: the interpreter (`interpreter/interpreter.go`, `interpreter/fold.go`, `interpreter/consteval.go`), the VM compiler (`runtime/vm/vm.go`, `runtime/vm/queryutil.go`), the type checker (`types/check.go`, `types/infer.go`, `types/infer_vars.go`, `types/pure.go`), the SQL planner (`runtime/data/duckdb.go`), the AST builder (`ast/convert.go`), the linter (`tools/lint/lint.go`), and every transpiler in `transpiler/x/*`. The migration is mechanical: every `xxxPostfix(op.Right, ...)` call became `xxxUnary(op.Right, ...)`, and every direct field access `op.Right.Target` became `op.Right.Value.Target`. No code path drops the unary prefix; the prefix is now carried end-to-end.
-
-The full project tree (`tests/`, `examples/`, `golden/`) was rebuilt with `-update` and no source regression was observed beyond the deliberate `type_alias.golden` change. Two classes of input remain documented but **unchanged** by this MEP:
-
-- `let x: int | nil = ...` still does not parse (union types appear in `TypeDecl` only; see Open Questions).
-- Lookahead 999 still backtracks silently on deep mis-parses; error messages from those paths are still terse.
-
-## Reference Implementation
-
-- `parser/parser.go:77-115`: `Program` and the `Statement` alternation.
-- `parser/parser.go:181-208`: `TypeDecl` four-shape alternation and `TypeVariantHead`.
-- `parser/parser.go:219-238`: `TypeRef`, `FunType`, `GenericType`, `InlineStructType`.
-- `parser/parser.go:399-446`: `BinaryOp`, `Unary`, `PostfixExpr`, `IndexOp`, `CallOp`, `FieldOp`, `CastOp`.
-- `parser/parser.go:559-564`: `MatchCase`.
-- `parser/parser.go:696-701`: parser construction.
-- `parser/normalize.go`: post-parse pass: `SingleVariant` lift, `IndexOp` validation (P060), `MatchCase` validation (P061).
-- `parser/errors.go`: `Parse` wraps participle and runs `normalizeProgram`.
-- `parser/grammar_test.go`: conformance suite.
-- `parser/lexer_fuzz_test.go`: fuzz harness.
-- `tests/parser/errors/{empty_index,empty_slice,match_case_missing_body}.{mochi,err}`: diagnostic fixtures.
-- `tests/parser/valid/type_alias.golden`: alias AST shape.
-- `types/infer.go:89-205`: operator precedence applied during inference.
+`FuzzParseString` feeds arbitrary strings to `ParseString`. The seed corpus covers every grammar shape this MEP specifies: every `TypeDecl` form, every postfix interleaving, match arms with and without bodies, every slice shape, query shapes, container literals, and known-rejected shapes (`xs[]`, `xs[:]`, `match v { 0 => }`, `f() = 1`). The invariant is no panic, no hang, and no `(nil, nil)` return.
 
 ## Change checklist
 
 When adding a new statement form:
 
-1. Decide whether it starts with a unique keyword. If yes, place it near the top of `Statement`'s alternation; if not, place it near the bottom and verify with `go test ./parser/...` that no existing source regresses.
-2. Add the production tag and a `_test.go` smoke case to `TestGrammar_StatementShapes`.
+1. Confirm it starts with a unique keyword. If yes, place it near the top of `Statement`; if not, place it last and run `go test ./parser/...` to confirm no existing source regresses.
+2. Add the production tag to `parser/parser.go` and a smoke case to `TestGrammar_StatementShapes`.
 3. Add a fuzz seed in `FuzzParseString`.
 4. Run `go test ./parser/... -count=1` and `go test ./parser/ -fuzz=FuzzParseString -fuzztime=10s`.
 
-When adding a new operator or postfix form:
+When adding a new operator:
 
-1. Decide whether it lives in `BinaryOp`, `Unary`, or `PostfixOp`. Anchor the precedence in `types/infer.go` before merging.
-2. Extend `TestGrammar_StatementShapes` and `TestGrammar_LiteralShapes` if it interacts with literals.
-3. If the grammar shape is independently-optional in its components (like `IndexOp`), add a post-parse validator with a fresh `P0xx` code instead of expanding the alternation.
+1. Choose the precedence level. Add the operator token to the matching `RelOp`, `AddExpr`, `MulExpr`, or `Unary` production.
+2. Add the operator to the precedence table in `types/infer.go` so the type checker rebalances the flat AST correctly.
+3. Extend `TestGrammar_UnaryOnBinaryRHS` and `TestGrammar_BinaryOperandsAreSymmetric` to cover the new operator. Both tests parameterise on the operator list.
 
-When adding a new diagnostic code:
+When adding a new postfix form:
 
-1. Reserve the next free code in the `P060+` range and add the template in `parser/normalize.go` (or `parser/errors.go` for parser-level codes).
-2. Add a fixture under `tests/parser/errors/`.
-3. Run `go test ./parser/ -run TestParser_SyntaxErrors -update` to materialise the golden, then verify the message.
+1. Add an alternative to `PostfixOp` in `parser/parser.go`. Confirm it does not conflict with an existing alternative; if it does, reorder by specificity.
+2. Add a smoke case to `TestGrammar_StatementShapes` exercising a chain that includes the new form.
 
-## Open Questions
+When adding a new shape that must be rejected:
 
-- **Union types in `TypeRef`.** Adding union types as first-class type expressions would let `let x: int | nil = ...` parse. The decision is between full union types and an `int?` shorthand. See [MEP 10](/docs/mep/mep-0010).
-- **Tuple types.** Heterogeneous fixed-length sequences have no surface today. Not urgent, but if pattern destructuring of arbitrary product values is ever added, tuples will follow.
-- **Ambiguity log.** `UseLookahead(999)` will eventually become noticeable. We have no automated worst-case input tracking yet; if the parser ever becomes the bottleneck, we should profile under the seed corpus and bound the lookahead to the smallest value that keeps the suite green.
+1. Confirm no grammar alternative matches it. Do not add a post-parse validator. If the grammar accepts it, either restructure the rule so it does not, or document the shape as accepted.
+2. Add a fixture under `tests/parser/errors/` and assert the message.
 
-## Resolved questions
+## Open questions
 
-- **Unary on the right of a binary operator.** Resolved in this revision by changing `BinaryOp.Right` from `*PostfixExpr` to `*Unary`. The grammar now satisfies the layered-precedence operand-symmetry invariant. `x == -1`, `a + -b`, `a && !b`, and every nested combination parse. Tracked under issue [#21212](https://github.com/mochilang/mochi/issues/21212). See [Operand symmetry](#operand-symmetry-binary-operands-are-unary-expressions).
+- **Union types in `TypeRef`.** First-class union type expressions would let `let x: int | nil = ...` parse. The decision is between full union types in `TypeRef` and an `int?` shorthand for the common nil case. See [MEP 10](/docs/mep/mep-0010).
+- **Tuple types.** Heterogeneous fixed-length sequences have no surface today. If pattern destructuring of arbitrary product values is added, tuples will follow.
+- **Direct left-recursion support.** `participle/v2` does not implement Warth-style left-recursion memoisation. A future port to a PEG parser that does (e.g. a hand-written packrat) would let the spec match the implementation literally, removing the right-recursive `Operand (op Operand)*` rewrite from the grammar. The language accepted is unchanged.
 
 ## References
 
+- [PEP 617](https://peps.python.org/pep-0617/). CPython's PEG parser. The grammar notation in this MEP is a subset of PEP 617's meta-grammar.
+- [Aho, Sethi, Ullman. *Compilers: Principles, Techniques, and Tools.*](https://suif.stanford.edu/dragonbook/) §4.3 on layered precedence grammars.
+- [Crafting Interpreters, chapter 6](https://craftinginterpreters.com/parsing-expressions.html). Walks the precedence ladder that motivates operand symmetry.
+- [Pratt, Vaughan. *Top Down Operator Precedence.* POPL 1973](https://dl.acm.org/doi/10.1145/512927.512931). The original presentation of operator-precedence parsing; the operand-is-a-unary invariant is forced by the algorithm.
+- [Ford, Bryan. *Parsing Expression Grammars: A Recognition-Based Syntactic Foundation.* POPL 2004](https://bford.info/pub/lang/peg.pdf). PEG semantics, ordered choice, and the no-ambiguity guarantee.
+- [participle/v2 grammar reference](https://github.com/alecthomas/participle). The struct-tag dialect this grammar is encoded in.
 - MEP 1 (Lexer): /docs/mep/mep-0001
 - MEP 10 (Type system roadmap): /docs/mep/mep-0010
 - MEP 13 (Pattern matching): /docs/mep/mep-0013
-- Participle v2 grammar reference: https://github.com/alecthomas/participle.
-- PEP 617 (CPython's new parser): https://peps.python.org/pep-0617/.
-- LINQ specification: https://learn.microsoft.com/dotnet/csharp/linq/.
-- Aho, Sethi, Ullman. *Compilers: Principles, Techniques, and Tools.* §4.3 covers the layered precedence grammar that motivates the operand-symmetry invariant.
-- Crafting Interpreters, chapter 6 (Parsing Expressions): https://craftinginterpreters.com/parsing-expressions.html. Walks through the precedence ladder that every binary operand resolves to a unary expression.
-- Pratt, Vaughan. *Top Down Operator Precedence.* POPL 1973. The original presentation of operator-precedence parsing; the RHS-operand-is-a-unary invariant is forced by the algorithm.
 
 ## Copyright
 


### PR DESCRIPTION
Closes #21214.

## Summary

Rewrites MEP-2 in the style of [PEP 617](https://peps.python.org/pep-0617/). Drops the Backwards Compatibility section, retires the post-parse validator codes P060 and P061 from the spec, and presents the expression grammar as a proper layered precedence ladder with structural operand symmetry.

## Changes

- **PEG notation throughout.** Operator table for `?`, `*`, `+`, `&`, `!`, `~`, `s.e+`. Every production uses the same notation.
- **No corner cases in the grammar.** `IndexOp` enumerates the 11 well-formed slice shapes, so `xs[]`, `xs[:]`, `xs[::]` match no production. `MatchBody` is mandatory. `AssignTarget` is restricted to postfix chains rooted at an identifier. `VariantUnion` requires at least one `TypeVariant`. The post-parse validator layer is removed from the spec.
- **Layered precedence ladder.** `Expr -> OrExpr -> AndExpr -> NotExpr -> RelExpr -> AddExpr -> MulExpr -> Unary -> PostfixExpr`. Every binary level has the shape `Operand (op Operand)*` with `Operand = Unary`. Operand symmetry is structural.
- **Dropped sections.** Backwards Compatibility, Reference Implementation file-and-line index, Resolved Questions. The MEP describes the language as it is.
- **Reorganised.** Abstract, Motivation, Grammar Notation, Specification, Design Principles, Conformance, Change Checklist, Open Questions, References. Matches PEP 617's structure.

This is documentation-only. The participle implementation in `parser/parser.go` already matches every shape the spec marks as accepted or rejected.

## Test plan

- [ ] `go test ./parser/...` stays green (no code touched; sanity check)
- [ ] Docs site builds (`pnpm --filter website build`)
- [ ] Cross-links to MEP-1, MEP-10, MEP-13 resolve