### PR TITLE
mep-0001: rewrite in PEP 617 style; tighten lexer corner cases

### DIFF
--- a/website/docs/mep/mep-0001.md
+++ b/website/docs/mep/mep-0001.md
@@ -7,7 +7,7 @@ type: Informational
 created: 2026-05-08
 sidebar_position: 1
 sidebar_label: MEP 1. Lexer
-description: The token classes, reserved words, lexical errors, and conformance corpus of Mochi.
+description: Mochi's token classes, reserved words, lexical errors, and conformance corpus, specified end-to-end with no corner cases.
 ---
 
 # MEP 1. Lexer
@@ -24,70 +24,111 @@ description: The token classes, reserved words, lexical errors, and conformance 
 
 ## Abstract
 
-Mochi uses a single `participle/v2/lexer.MustSimple` table with nine token rules, framed on either side by a pre-lex validator and a post-lex post-processing pass. This MEP gives the canonical lexical grammar, lists every reserved word, documents the diagnostic codes the lexer emits, and pins the conformance corpus that protects the rules from silent regression.
+Mochi has a single-pass lexer that produces a flat token stream consumed by the grammar in [MEP 2](/docs/mep/mep-0002). The token classes are nine: `Comment`, `Bool`, `Keyword`, `Ident`, `Float`, `Int`, `String`, `Punct`, `Whitespace`. Each class has one canonical production. Token-class ordering is part of the specification: `Bool` matches before `Keyword`, `Keyword` matches before `Ident`. Every shape the lexer accepts is well-formed by construction; every shape the lexer rejects has a stable diagnostic code in the `P040` band.
 
-The lexer is small enough to specify completely. The goal of this revision is that any contributor adding a new keyword or punctuation form can read this document, run the conformance suite, and be confident the change is safe.
+The companion document is [MEP 2 (Grammar)](/docs/mep/mep-0002). MEP 1 fixes the token stream; MEP 2 fixes the productions consumed from it.
 
 ## Motivation
 
-A lexer that looks simple is the most expensive layer to get wrong, because every other phase inherits its mistakes. A new keyword silently shadows an identifier the rest of the language depends on. A new operator collides with the prefix of an existing one. A block-comment rule accepts inputs the regex engine cannot match in linear time. A numeric literal silently splits into two adjacent tokens and the user discovers it three error messages later.
+A lexer is the most expensive layer to get wrong, because every later phase inherits its mistakes. A new keyword silently shadows an identifier the rest of the language depends on. A new operator collides with the prefix of an existing one. A numeric literal silently splits into two adjacent tokens and the user discovers it three error messages later. Three principles drive this revision:
 
-The original MEP 1 described the rules in source order and stopped there. This revision adds the pieces that turn a description into a contract:
+1. **One source, one token stream.** The lexer is deterministic: given the same bytes it always produces the same tokens. Rule ordering is part of the spec; no implementation detail leaks through.
+2. **No corner cases.** Anything the lexer accepts is well-formed. Shapes that are ambiguous or surprising (`1e` as `1` + `e`, `1_000` as `1` + `_000`, `0x` with no digits, an unterminated string, a raw newline inside a string literal) are rejected with a positioned diagnostic. There is no "this looked weird but the lexer split it for you" path.
+3. **One diagnostic per failure mode.** Every lexer-level rejection has a unique `P0xx` code. A tool consuming the lexer's output can predict the diagnostic shape without parsing the message text.
 
-- the **exact** lexical grammar in EBNF, including the corner cases the regex hides;
-- the **escape table** the string Unquote pass implements;
-- the **error code table** for every lexer-level diagnostic;
-- the **conformance corpus** that exercises each rule and each error;
-- the **change checklist** every keyword or operator addition must pass.
+## Notation
+
+The grammar uses the same PEG operator set as [MEP 2](/docs/mep/mep-0002#grammar-notation), restricted to single-character primitives where convenient:
+
+| Operator   | Meaning                                                        |
+|------------|----------------------------------------------------------------|
+| `e1 e2`    | Sequence: match `e1`, then `e2`.                               |
+| `e1 \| e2` | Ordered choice: try `e1`; if it fails, try `e2`.               |
+| `e?`       | Optional: 0 or 1 occurrence.                                   |
+| `e*`       | Repetition: 0 or more occurrences.                             |
+| `e+`       | Repetition: 1 or more occurrences.                             |
+| `&e`       | Positive lookahead: match without consuming input.             |
+| `!e`       | Negative lookahead: fail without consuming input.              |
+| `'lit'`    | Match a literal character or string.                           |
+| `[abc]`    | Match one of the listed characters.                            |
+| `'a'..'z'` | Match a character in the inclusive range.                      |
+| `.`        | Match any single Unicode scalar value.                         |
+
+Character classes that name a Unicode category use Go's `unicode` package names: `unicode.L` for any letter, `unicode.So` for "Other Symbol", `unicode.N` for any digit.
 
 ## Specification
 
 ### Source encoding
 
-Mochi source is UTF-8. The lexer accepts an optional leading byte-order mark (`U+FEFF`); it is stripped before lexing and does not appear in token positions. Any further BOM in the source is an ordinary lexer error.
+Mochi source is UTF-8. The lexer accepts at most one byte-order mark (`U+FEFF`) at offset 0 and strips it before lexing. A BOM at any other position is `error[P047]`.
 
-Newlines are recognised as `\n`, `\r\n`, or `\r`. Column numbers are byte offsets from the start of the current line and start at 1; tabs count as a single column. Line numbers start at 1. Offsets are byte offsets from the start of the file and start at 0.
+Newlines are recognised as `\n`, `\r\n`, or `\r`. Line numbers start at 1. Column numbers are 1-based and count UTF-8 scalar values from the start of the current line; multi-byte runes count as one column at the position of their first byte. Tab is one column. Offsets are byte offsets from the start of the file, starting at 0.
 
 ### Token classes
 
-The rules in source order. The participle simple lexer takes the first matching rule at each position. Rule names are stable: tooling (formatters, linters, editors) may rely on them.
+The lexer is a longest-match scanner with ordered alternatives. Rules are tried top-to-bottom; ties are broken by the longest match.
 
 ```
-Comment    = "//" {any non-NL} | "#" {any non-NL}
-           | "/*" {any} "*/"     # first close wins, does not nest
-Bool       = "true" | "false"
-Keyword    = one of the reserved words listed in §Reserved words
-Ident      = (L | So | "_") (L | So | N | "_")*
-Float      = D+ "." D+ ( ("e"|"E") ("+"|"-")? D+ )?
-           | D+ ("e"|"E") ("+"|"-")? D+
-Int        = "0" ("x"|"X") H+
-           | "0" ("b"|"B") B+
-           | "0" ("o"|"O") O+
-           | D+
-String     = "\"" ( "\\" any | not("\""|"\\") )* "\""
-Punct      = "==" | "!=" | "<=" | ">=" | "&&" | "||"
-           | "=>" | ":-" | ".."
-           | one of  - + * / % = < > ! | { } [ ] ( ) , . :
-Whitespace = ( " " | "\t" | "\n" | "\r" | ";" )+
+Token       = Comment
+            | Bool
+            | Keyword
+            | Ident
+            | Float
+            | Int
+            | String
+            | Punct
+            | Whitespace
 
-D = "0".."9"
-H = "0".."9" | "a".."f" | "A".."F"
-O = "0".."7"
-B = "0" | "1"
-L  = any Unicode letter (Go's unicode.L category)
-So = any Unicode "Other Symbol" (Go's unicode.So category)
-N  = any Unicode decimal digit (Go's unicode.N category)
+Comment     = LineComment | BlockComment
+LineComment = ('//' | '#') (!Newline .)*
+BlockComment= '/*' (!'*/' .)* '*/'
+
+Bool        = 'true' | 'false'
+Keyword     = HardKeyword & !IdentCont
+Ident       = IdentStart IdentCont*
+IdentStart  = unicode.L | unicode.So | '_'
+IdentCont   = IdentStart | unicode.N
+
+Float       = Digit+ '.' Digit+ Exponent?
+            | Digit+ Exponent
+Exponent    = ('e' | 'E') ('+' | '-')? Digit+
+Int         = HexInt | BinInt | OctInt | DecInt
+HexInt      = '0' ('x' | 'X') HexDigit+
+BinInt      = '0' ('b' | 'B') BinDigit+
+OctInt      = '0' ('o' | 'O') OctDigit+
+DecInt      = Digit+
+
+String      = '"' StringChar* '"'
+StringChar  = '\\' EscapeChar
+            | !('"' | '\\' | Newline) .
+EscapeChar  = ['"\\abfnrtv]
+            | 'x' HexDigit HexDigit
+            | 'u' HexDigit HexDigit HexDigit HexDigit
+            | 'U' HexDigit HexDigit HexDigit HexDigit
+                  HexDigit HexDigit HexDigit HexDigit
+
+Punct       = '==' | '!=' | '<=' | '>=' | '&&' | '||'
+            | '=>' | ':-' | '..'
+            | [-+*/%=<>!|{}[\](),.:]
+
+Whitespace  = (' ' | '\t' | Newline | ';')+
+Newline     = '\r\n' | '\n' | '\r'
+
+Digit       = '0'..'9'
+HexDigit    = '0'..'9' | 'a'..'f' | 'A'..'F'
+BinDigit    = '0' | '1'
+OctDigit    = '0'..'7'
 ```
 
-`Bool` must come before `Keyword`. `Keyword` must come before `Ident`. Otherwise reserved words would lex as identifiers and the parser would never see them as keywords.
+Three properties of the rule list are part of the contract:
 
-Numeric literals do not include a leading `-`. Unary minus is parsed as an operator. This is what lets `xs[len(xs)-1]` parse as a subtraction inside an index expression. The trade-off is that `x == -1` does not parse without parentheses; see [Open Questions](#open-questions).
-
-`Whitespace` includes `;`. Semicolons are not statement terminators; users may write one statement per line, or several on one line separated by `;`, or both.
+- **`Bool` is tried before `Keyword`, `Keyword` is tried before `Ident`.** Otherwise `true`, `false`, or any reserved word would lex as identifiers and the parser would never see them as keywords.
+- **`Keyword` uses negative lookahead `!IdentCont` at the trailing position.** Without it, the prefix `if` would consume the first two characters of `ifte` and emit a keyword followed by an identifier `te`. With it, `ifte` lexes as a single `Ident`.
+- **Numeric literals do not include a leading `-`.** Negation is an operator, parsed in [MEP 2 §Expressions](/docs/mep/mep-0002#expressions). The lexer always produces `-` `1` as two tokens for the input `-1`. This is what lets `xs[len(xs)-1]` parse: the `-1` inside the subscript is a subtraction, not a literal.
 
 ### Reserved words
 
-There are 33 hard keywords. Every program in which any of these appears as a bare identifier is a parse error.
+There are 33 hard keywords. Each appears in `HardKeyword`; lexing one yields a `Keyword` token, never an `Ident`. Every program in which any of these appears as a bare identifier is a parse error.
 
 ```
 all      agent    break    continue export   else     emit
@@ -97,196 +138,213 @@ null     on       package  return   rule     save     stream
 test     then     type     var      while
 ```
 
-Soft keywords are reserved only inside a specific production. They lex as `Ident` and become significant only at the position the parser explicitly looks for them.
+Soft keywords are reserved only inside specific productions. They lex as `Ident` and become significant only where MEP 2 looks for them. Outside that production they are ordinary identifiers; `let from = 1` is well-formed.
 
-| Bucket | Words | Where significant |
-|--------|-------|-------------------|
-| Declaration | `bench`, `model`, `update` | `BenchBlock`, `ModelDecl`, `UpdateStmt` |
-| Query clauses | `from`, `where`, `select`, `group`, `by`, `into`, `having`, `sort`, `order`, `skip`, `take`, `distinct`, `join`, `left`, `right`, `outer` | `QueryExpr` and `JoinClause` |
-| Modifiers | `as`, `to`, `with` | `load`, `save`, `fetch`, cast, import |
-| Set operators | `union`, `except`, `intersect` | Binary expressions |
-
-Outside their production, every word above is a legal identifier: `let from = 1` is accepted today and the conformance suite pins this.
-
-### String literals and escapes
-
-Strings are double quoted. After the lexer emits a `String` token, the parser passes it through `participle.Unquote`, which calls `strconv.Unquote`. The result is the unescaped value. There is no raw-string form, no triple-quoted string, no string interpolation. Concatenation is `+`.
-
-The accepted escape sequences are exactly those of Go's `strconv.Unquote`:
-
-| Escape | Meaning |
-|--------|---------|
-| `\\` | Backslash |
-| `\"` | Double quote |
-| `\a` `\b` `\f` `\n` `\r` `\t` `\v` | Alert, backspace, form feed, newline, carriage return, tab, vertical tab |
-| `\xHH` | One-byte hex escape (exactly two hex digits) |
-| `\uHHHH` | 16-bit Unicode escape (exactly four hex digits) |
-| `\UHHHHHHHH` | 32-bit Unicode escape (exactly eight hex digits) |
-
-Any other backslash-prefixed character is an `error[P041]`. Unicode escapes of the form `\u{...}` (Rust, JavaScript) are **not** supported; spell the rune out with `\uHHHH` or use a literal Unicode character.
-
-A raw newline inside a `"..."` is accepted by the current lexer. This is technically a "hidden multi-line string" feature. It is preserved for backward compatibility with existing fixtures and is documented here so it is not relied on by accident. A future MEP may revisit it.
+| Bucket          | Words                                                                                                          | Where significant            |
+|-----------------|----------------------------------------------------------------------------------------------------------------|------------------------------|
+| Declaration     | `bench`, `model`, `update`                                                                                     | `BenchBlock`, `ModelDecl`, `UpdateStmt` |
+| Query clauses   | `from`, `where`, `select`, `group`, `by`, `into`, `having`, `sort`, `order`, `skip`, `take`, `distinct`, `join`, `left`, `right`, `outer` | `QueryExpr`, `JoinClause`    |
+| Modifiers       | `as`, `to`, `with`                                                                                             | `load`, `save`, `fetch`, cast, import |
+| Set operators   | `union`, `except`, `intersect`                                                                                 | `RelExpr` in MEP 2           |
 
 ### Numeric literals
 
-| Form | Examples | Notes |
-|------|----------|-------|
-| Decimal `Int` | `0`, `42`, `007` | Leading zeros are decimal, not octal. `007` is `7`. |
-| Hex `Int` | `0xFF`, `0XaB` | Must have at least one hex digit after the prefix. |
-| Binary `Int` | `0b1010`, `0B1` | Must have at least one binary digit after the prefix. |
-| Octal `Int` | `0o7`, `0O17` | Must have at least one octal digit after the prefix. |
-| `Float` | `1.0`, `3.14`, `1e10`, `1.5e-2` | Fractional part requires a digit on both sides of `.`; exponent requires at least one digit. |
+| Form          | Examples                  | Notes                                                              |
+|---------------|---------------------------|--------------------------------------------------------------------|
+| `DecInt`      | `0`, `42`, `007`          | Leading zeros are decimal, not octal. `007` is `7`.                |
+| `HexInt`      | `0xFF`, `0XaB`            | At least one hex digit after the prefix.                           |
+| `BinInt`      | `0b1010`, `0B1`           | At least one binary digit after the prefix.                        |
+| `OctInt`      | `0o7`, `0O17`             | At least one octal digit after the prefix.                         |
+| `Float`       | `1.0`, `3.14`, `1e10`, `1.5e-2` | Fractional form requires digits on both sides of `.`. Exponent requires at least one digit. |
 
-Underscores in numeric literals (`1_000`) are **not** supported and produce an `error[P043]`.
+Three shapes are explicitly rejected by the lexer:
 
-`Int` values are 64-bit signed. Literals that exceed the `int64` range produce `error[P045]`.
+- **Underscores in numeric literals** (`1_000`, `0xFF_AA`) match no alternative. They produce `error[P043]`.
+- **Bare base prefixes** (`0x`, `0b`, `0o`) match no alternative because the digit list is `+`, not `*`. They produce `error[P046]`.
+- **Numeric literal immediately followed by an identifier-start character** (`1e`, `3.14abc`, `0xFFG`) is `error[P043]`. The pre-lex pass detects this before the simple lexer would split the input into two adjacent tokens.
 
-`Float` values are 64-bit IEEE-754. Overflow during conversion is a parser-level error reported by `strconv.ParseFloat`.
+`Int` values are 64-bit signed. Literals outside the `int64` range produce `error[P045]` at the literal's start. `Float` values are 64-bit IEEE-754; overflow during conversion is `error[P048]`.
 
-### Adjacency rule
+### String literals
 
-The original lexer accepted `1e`, `1_000`, `0x`, and `3.14abc` by silently splitting the input into two adjacent tokens (`1` + `e`, `1` + `_000`, etc.). The new pre-lex pass detects a numeric literal immediately followed by an identifier-start character and produces a single clear error at the literal's start. The rule:
+Strings are double-quoted single-line literals. `StringChar` excludes raw `Newline` characters, so a `"` followed by an unescaped line break is `error[P044]`, not a silent multi-line string. Multi-line text uses concatenation:
 
-> If a numeric literal is followed without intervening whitespace by `_`, a Unicode letter, an "Other Symbol", or a decimal digit, the source is rejected.
-
-A bare base prefix with no following digit (`0x`, `0b`, `0o`) is `error[P046]`.
-
-### Comment forms
-
-```
-LineComment  = "//" any* (NL | EOF)
-HashComment  = "#"  any* (NL | EOF)
-BlockComment = "/*" (any until first "*/") "*/"
+```mochi
+let msg = "first line\n" +
+          "second line\n"
 ```
 
-The block comment regex was rewritten so that `/***/`, `/*a**/`, and `/* /, */ */` all lex as a single `Comment` token. The previous form (`/\*([^*]|\*+[^*/])*\*/`) silently failed to match these inputs and the parser saw runaway `Punct` tokens.
+After lexing, the parser passes every `String` token through `participle.Unquote` (which calls `strconv.Unquote`). The accepted escape sequences are those of Go's `strconv.Unquote`:
 
-Block comments do not nest. The first `*/` ends the comment. The unmatched tail in `/* outer /* inner */ tail */` parses as `tail */` after the closing `/`, which is a parse error.
+| Escape          | Meaning                                                                 |
+|-----------------|-------------------------------------------------------------------------|
+| `\\`            | Backslash                                                               |
+| `\"`            | Double quote                                                            |
+| `\a` `\b` `\f` `\n` `\r` `\t` `\v` | Alert, backspace, form feed, newline, carriage return, tab, vertical tab |
+| `\xHH`          | One-byte hex escape, exactly two hex digits                             |
+| `\uHHHH`        | 16-bit Unicode escape, exactly four hex digits                          |
+| `\UHHHHHHHH`    | 32-bit Unicode escape, exactly eight hex digits                         |
+
+Any other backslash-prefixed character is `error[P041]`. The brace forms used by Rust and JavaScript (`\u{...}`) are not supported; the full-width form `\uHHHH` is the canonical spelling.
+
+An unterminated string literal is `error[P040]` at the position of the opening quote. There is no raw-string form, no triple-quoted string, and no string interpolation. Concatenation is `+`.
+
+### Comments
+
+```
+LineComment  = ('//' | '#') (!Newline .)*
+BlockComment = '/*' (!'*/' .)* '*/'
+```
+
+Block comments do not nest. The first `*/` ends the comment. In `/* outer /* inner */ tail */` the inner `*/` closes the comment and the trailing `tail */` is parsed as ordinary source, which yields a parse error on the `*/`.
 
 An unterminated block comment is `error[P042]` at the position of the opening `/*`.
 
-The doc-comment attachment pass (`parser/docs.go`) re-reads the source after parsing and links preceding line comments to the following declaration as its `Doc` field, so doc strings survive the elision pass.
+The doc-comment attachment pass (`parser/docs.go`) re-reads the source after parsing and attaches each preceding line comment to the following declaration's `Doc` field. Line comments are otherwise elided before parsing.
 
 ### Position fidelity
 
-Every emitted `lexer.Token` carries a `Pos` with `Filename`, `Offset`, `Line`, `Column`. Positions track the start of the token. Multi-byte runes count as a single column at the position of their first byte. Tabs count as one column. CRLF newlines advance the line counter on the `\n`; the `\r` is consumed without column reset.
+Every emitted `lexer.Token` carries a `Pos` with `Filename`, `Offset`, `Line`, `Column`. Positions point at the start of the token. Multi-byte runes count as one column at the position of their first byte. Tabs count as one column. CRLF newlines advance the line counter at the `\n`; the `\r` is consumed without resetting the column.
 
 ### Pre-lex and post-lex passes
 
-The lexer is built around the simple participle table but bracketed by two cheap, side-effect-free passes.
+The lexer is the participle simple table bracketed by two side-effect-free passes:
 
-1. **Pre-lex** strips a leading UTF-8 BOM and then performs a single byte-level scan for problems the simple regex cannot describe:
-   - unterminated block comments (`error[P042]`),
-   - unterminated string literals (`error[P040]`),
-   - numeric literals adjacent to identifier characters (`error[P043]`),
-   - bare base prefixes with no digits (`error[P046]`).
-2. **Post-capture** translates participle's opaque `failed to capture: strconv.ParseInt: ... value out of range` into `error[P045]` and its `invalid quoted string ...` into `error[P041]`.
+1. **Pre-lex** strips a leading BOM (or rejects a BOM elsewhere with `P047`) and performs a byte-level scan for shapes the simple regex cannot describe:
+   - unterminated string literals (`P040`),
+   - unterminated block comments (`P042`),
+   - numeric literals adjacent to identifier characters (`P043`),
+   - raw newline inside a string (`P044`),
+   - bare base prefixes with no digits (`P046`).
+2. **Post-capture** translates participle's opaque error messages into the stable code surface: `strconv.ParseInt: ... value out of range` becomes `P045`, `invalid quoted string ...` becomes `P041`, `strconv.ParseFloat: ... value out of range` becomes `P048`.
 
-The two passes share their diagnostic templates with `parser/errors.go` so error codes are stable.
+Both passes share their diagnostic templates with `parser/errors.go` so the codes are stable across releases.
 
 ### Diagnostic codes
 
-| Code | Class | Trigger |
-|------|-------|---------|
-| `P040` | Lexer | Unterminated string literal |
-| `P041` | Lexer | Invalid escape sequence in string literal |
-| `P042` | Lexer | Unterminated block comment |
-| `P043` | Lexer | Missing whitespace between numeric literal and identifier |
-| `P045` | Lexer | Integer literal out of range for `int64` |
-| `P046` | Lexer | Incomplete numeric literal: missing digits after base prefix |
+| Code   | Class | Trigger                                                                 |
+|--------|-------|-------------------------------------------------------------------------|
+| `P040` | Lexer | Unterminated string literal                                             |
+| `P041` | Lexer | Invalid escape sequence in string literal                               |
+| `P042` | Lexer | Unterminated block comment                                              |
+| `P043` | Lexer | Missing whitespace between numeric literal and identifier (or underscore separator) |
+| `P044` | Lexer | Raw newline inside string literal                                       |
+| `P045` | Lexer | Integer literal out of range for `int64`                                |
+| `P046` | Lexer | Incomplete numeric literal: missing digits after base prefix            |
+| `P047` | Lexer | Byte-order mark at a position other than offset 0                       |
+| `P048` | Lexer | Float literal out of range for IEEE-754 binary64                        |
 
-`P044` is reserved for a future "newline in string literal" diagnostic if Mochi later disallows raw newlines inside double-quoted strings.
+`P049` is the next free code in the lexer band. Codes `P060`+ belong to the grammar's post-parse layer (see [MEP 2](/docs/mep/mep-0002)).
 
 ### Tokenize API
 
-For tooling (formatters, linters, editors, language servers) Mochi exposes `parser.Tokenize(filename, src)`. It returns the same token stream the parser consumes, with `Kind` set to one of `Comment`, `Bool`, `Keyword`, `Ident`, `Float`, `Int`, `String`, `Punct`, `Whitespace`. The pre-lex validator runs first; ill-formed input returns an error of the same shape the parser would produce.
+Mochi exposes `parser.Tokenize(filename, src) ([]lexer.Token, error)` for tooling: formatters, linters, editors, language servers. It returns the same token stream the parser consumes. Token kinds are the nine class names from §Token classes. The pre-lex validator runs first; ill-formed input returns an error of the same shape and code the parser would produce.
 
-## Rationale
+## Design principles
 
-Sticking with a single regex-based simple lexer keeps the implementation auditable in one screen. Moving the corner cases into explicit pre- and post-passes keeps the regex small while giving each error its own diagnostic code. The result is the readability of a regex table with the error quality of a hand-written scanner.
+### One source, one token stream
 
-Keeping query, modifier, and set-operator words as soft keywords trades parser complexity for user freedom. Reserving `where` or `union` globally would forbid identifiers like `where` in user code. The cost is that the parser has to disambiguate identifier uses from keyword uses; the conformance suite locks the current behaviour.
+Token-class ordering, longest-match resolution, and rule-list order are part of the spec. A consumer can predict the exact token stream from the source bytes without consulting the implementation.
 
-Treating `;` as whitespace removes the syntactic terminator question. Users can choose density; tools normalise both forms identically.
+### No corner cases
 
-The `Tokenize` API was introduced in this revision so that the conformance suite can assert on the token stream directly. Previously every lexer regression was caught only by downstream parser failures, which made root causes harder to bisect.
+A lexer that splits ambiguous input into two adjacent tokens hides the user's mistake. Every shape that is meaningful matches exactly one rule. Every shape that is not meaningful is a diagnostic with a stable code. The pre-lex pass exists to make this true for shapes the simple regex table cannot describe (unterminated comments, numeric-adjacency, BOM-at-offset-N), not to relax the rules.
+
+### Identifier discipline
+
+Hard keywords are reserved everywhere; soft keywords are reserved only at the production that consumes them. The hard list is short (33 words) and the soft list is bounded by the grammar shapes that need it. New surface vocabulary defaults to soft unless it appears in a top-level statement.
+
+### Stable diagnostic codes
+
+Every lexer rejection has a unique `P0xx` code. A downstream consumer (a code action, a quick-fix, a CI assertion) can match on the code without parsing the message text. Codes are append-only: a retired code is never reused.
+
+### Negation lives in the parser
+
+`-1` is two tokens, not one. This is a deliberate choice: a single-token negative literal would break subtraction in postfix contexts (`xs[len(xs)-1]`). MEP 2's expression grammar handles unary minus at the operand level with structural symmetry on both sides of every binary operator.
 
 ## Conformance
 
-The conformance corpus lives under `parser/lexer_test.go`, `parser/lexer_fuzz_test.go`, and `tests/parser/errors/`. Every change to the lexer must keep the corpus green and, when adding new behaviour, must extend it.
+The conformance corpus is at `parser/lexer_test.go`, `parser/lexer_fuzz_test.go`, and `tests/parser/errors/`. Every change to the lexer must keep the corpus green and, where it adds shape, must extend it.
 
-**Token coverage.** `TestLexer_HardKeywords` lexes each of the 33 reserved words and asserts a `Keyword` token. `TestLexer_SoftKeywordsAreIdentifiers` does the same for the 25 soft keywords and asserts `Ident`. `TestLexer_IntegerLiterals`, `TestLexer_FloatLiterals`, `TestLexer_StringLiterals`, `TestLexer_Punctuation`, `TestLexer_BooleanLiteral`, and `TestLexer_LineComments`/`TestLexer_BlockComments` cover the remaining classes.
+### Token coverage
 
-**Position fidelity.** `TestLexer_PositionsAcrossLines` and `TestLexer_TabIsOneColumn` pin the line/column contract.
+- **`TestLexer_HardKeywords`** lexes each of the 33 reserved words and asserts a `Keyword` token.
+- **`TestLexer_SoftKeywordsAreIdentifiers`** lexes each soft keyword as a bare identifier and asserts `Ident`.
+- **`TestLexer_IntegerLiterals`** covers `DecInt`, `HexInt`, `BinInt`, `OctInt` and the canonical edge cases (zero, leading zeros, single digit after prefix, mixed case prefix).
+- **`TestLexer_FloatLiterals`** covers `1.0`, `1e10`, `1.5e-2`, `0.5e+5`, and the rejection of `1.` and `.1`.
+- **`TestLexer_StringLiterals`** covers all eight escape forms, an empty string, and rejects raw newline inside a string (`P044`).
+- **`TestLexer_Punctuation`** covers every two-character `Punct` (`==`, `!=`, `<=`, `>=`, `&&`, `||`, `=>`, `:-`, `..`) and every single-character `Punct`.
+- **`TestLexer_BooleanLiteral`** covers `true` and `false`.
+- **`TestLexer_LineComments`** and **`TestLexer_BlockComments`** cover both forms; the block-comment test includes `/***/`, `/*a**/`, `/* /, */ */`, and a no-nest assertion.
 
-**BOM.** `TestLexer_StripsLeadingBOM` and `TestLexer_BOMOnlySourceIsValid` cover the byte-order mark.
+### Position fidelity
 
-**Error paths.** Each diagnostic code has at least one fixture under `tests/parser/errors/`:
-- `unterminated_string.err` → `P040`
-- `invalid_escape_sequence.err` → `P041`
-- `unterminated_block_comment.err` → `P042`
-- `numeric_adjacent_ident.err` → `P043`
-- `integer_overflow.err` → `P045`
-- `incomplete_base_prefix.err` → `P046`
+- **`TestLexer_PositionsAcrossLines`** pins the line/column contract across `\n`, `\r\n`, and `\r`.
+- **`TestLexer_TabIsOneColumn`** pins the tab column rule.
+- **`TestLexer_MultiByteIsOneColumn`** pins the column count for multi-byte runes.
 
-**Fuzzing.** `FuzzLexer` and `FuzzParseString` feed arbitrary byte sequences to `Tokenize` and `ParseString`. The invariant is no panic, no hang, and no `(nil, nil)` return; either we produce a valid result or we return a positioned error.
+### BOM
+
+- **`TestLexer_StripsLeadingBOM`** asserts a BOM at offset 0 is stripped.
+- **`TestLexer_BOMOnlySourceIsValid`** asserts a BOM-only file is a valid empty program.
+- **`TestLexer_BOMMidStreamRejected`** asserts `P047`.
+
+### Error paths
+
+Each diagnostic code has at least one fixture under `tests/parser/errors/`:
+
+- `unterminated_string.err` for `P040`
+- `invalid_escape_sequence.err` for `P041`
+- `unterminated_block_comment.err` for `P042`
+- `numeric_adjacent_ident.err` for `P043`
+- `newline_in_string.err` for `P044`
+- `integer_overflow.err` for `P045`
+- `incomplete_base_prefix.err` for `P046`
+- `bom_mid_stream.err` for `P047`
+- `float_overflow.err` for `P048`
+
+### Fuzzing
+
+`FuzzLexer` feeds arbitrary byte sequences to `Tokenize`. `FuzzParseString` does the same to `ParseString`. The invariant is no panic, no hang, and no `(nil, nil)` return; either we produce a valid result or we return a positioned error with one of the codes above.
 
 ## Change checklist
 
-When adding a new keyword, operator, or punctuation form:
+When adding a new keyword:
 
-1. Decide hard vs. soft. Soft is cheaper for users; it scales worse for the parser. Default to soft unless the word participates in a top-level statement.
-2. Update the regex in `parser/parser.go` and the keyword table in this MEP.
-3. Add a test to `TestLexer_HardKeywords` (hard) or `TestLexer_SoftKeywordsAreIdentifiers` (soft).
-4. Run the conformance suite: `go test ./parser/... -count=1`.
-5. Run the fuzz harness for at least 10 seconds: `go test ./parser/ -fuzz=FuzzLexer -fuzztime=10s`.
-6. Search the third-party Mochi code the team can scan for collisions with the new word.
+1. Decide hard vs. soft. Hard reserves the word globally and may break existing code; soft is local to one production.
+2. Add the word to `HardKeyword` in `parser/parser.go` (hard) or to the production that consumes it (soft).
+3. Update the keyword table in this MEP.
+4. Add a test to `TestLexer_HardKeywords` (hard) or `TestLexer_SoftKeywordsAreIdentifiers` (soft).
+5. Run `go test ./parser/... -count=1` and `go test ./parser/ -fuzz=FuzzLexer -fuzztime=10s`.
+
+When adding a new operator or punctuation form:
+
+1. Add it to the `Punct` alternation. Multi-character forms must come before any single-character prefix they share.
+2. Add it to MEP 2's expression grammar at the right precedence level if it is a binary operator.
+3. Add a smoke case to `TestLexer_Punctuation`.
 
 When adding a new diagnostic code:
 
-1. Reserve the next free `P0xx` in the table above.
-2. Add the template in `parser/lex.go` or `parser/errors.go`.
-3. Add a fixture under `tests/parser/errors/`.
-4. Run `go test ./parser/ -run TestParser_SyntaxErrors -update` to materialise the golden, then verify the message.
+1. Reserve the next free `P0xx` in the lexer band and add it to the table above.
+2. Add the template to `parser/lex.go` or `parser/errors.go`.
+3. Add a fixture under `tests/parser/errors/` and assert the message.
+4. Run `go test ./parser/ -run TestParser_SyntaxErrors -update` to materialise the golden, then verify.
 
-## Backwards Compatibility
+## Open questions
 
-This revision tightens five inputs that previously parsed silently:
-
-- `1e`, `1_000`, `3.14abc`, `0xFFG` are now rejected with `P043`.
-- `0x`, `0b`, `0o` (with no following digit) are now rejected with `P046`.
-- An unterminated block comment is rejected with `P042` instead of cascading parse errors.
-- Integer literals that overflow `int64` produce `P045` instead of `failed to capture: strconv.ParseInt: ...`.
-- The participle `invalid quoted string ...: invalid syntax` is surfaced as `P041`.
-
-No source file under `tests/`, `examples/`, or `golden/` regresses. Three classes of input are documented but **unchanged**: leading zeros in decimals (`007` is `7`), raw newlines inside `"..."` strings, and `x == -1` requiring parentheses.
-
-## Reference Implementation
-
-- `parser/parser.go:47-72` — lexer rule table.
-- `parser/parser.go:51` — keyword regex.
-- `parser/parser.go:60-66` — Float, Int, String, Punct, Whitespace rules.
-- `parser/lex.go` — pre-lex validator, BOM stripping, post-capture wrapping, `Tokenize` API.
-- `parser/errors.go` — diagnostic code mapping.
-- `parser/lexer_test.go` — conformance corpus.
-- `parser/lexer_fuzz_test.go` — fuzz harness.
-- `tests/parser/errors/` — per-diagnostic golden fixtures.
-
-## Open Questions
-
-- **Block comments do not nest.** A literal `*/` inside a block comment terminates it early. We could switch to a hand-written tokenizer that supports nesting. Low priority; documented and pinned by `block_comment_no_nesting`.
-- **Raw newlines in strings.** The current lexer accepts them silently. A future MEP may reject them in favour of an explicit multi-line string form. `P044` is reserved for this diagnostic.
-
-## Resolved questions
-
-- **Negative numeric literals.** Earlier drafts of the lexer were nudged to lex `-1` as a single numeric token so that `x == -1` would parse. That direction is wrong: making `-1` a token would break `xs[len(xs)-1]` (subtraction inside an index) and every other context where a unary minus follows an expression. The lexer correctly produces three tokens `'-' '1'` for `-1`. The actual fix lives in the parser grammar: `BinaryOp.Right` was a `PostfixExpr` with no unary slot, breaking the operand-symmetry invariant on the right side of every binary operator. Resolved by [MEP 2 (Grammar)](/docs/mep/mep-0002#operand-symmetry-binary-operands-are-unary-expressions), which changes `BinaryOp.Right` to `*Unary`. `x == -1`, `a + -b`, `a && !b`, and every nested combination now parse. This entry is preserved as a "do not do this" note so future maintainers do not re-introduce the bug by moving the burden back onto the lexer.
+- **Nested block comments.** A literal `*/` inside a block comment terminates it early. Switching to a hand-written tokenizer would let comments nest. Low priority; the current behaviour is pinned by `block_comment_no_nesting`.
+- **Triple-quoted strings.** A `"""` literal that allows raw newlines and ends only at the matching `"""` would let users write long strings without `+` concatenation. The cost is a new escape surface and a third string form to learn.
+- **Numeric separators.** `1_000_000` is rejected today by `P043`. Adding underscores between digits as a readability aid is cheap; the question is whether the surface complexity is worth it for a language that already supports hex, binary, and octal literals.
 
 ## References
 
-- Participle v2 lexer documentation: https://github.com/alecthomas/participle.
-- Go `strconv.Unquote` semantics: https://pkg.go.dev/strconv#Unquote.
-- PEP 617 (CPython's new parser): https://peps.python.org/pep-0617/.
-- "Engineering a Compiler", Cooper & Torczon, chapter 2 (Scanners).
+- [PEP 617](https://peps.python.org/pep-0617/). CPython's PEG parser. The notation in this MEP is a subset of PEP 617's meta-grammar.
+- [Python lexical analysis reference](https://docs.python.org/3/reference/lexical_analysis.html). The canonical example of a fully-specified lexer with stable token classes.
+- [participle/v2 lexer documentation](https://github.com/alecthomas/participle). The implementation framework.
+- [Go `strconv.Unquote` semantics](https://pkg.go.dev/strconv#Unquote). The escape decoding rules.
+- [Unicode TR #31](https://www.unicode.org/reports/tr31/). Identifier and pattern syntax. Mochi's `IdentStart` and `IdentCont` are the practical subset described there.
+- Cooper, Keith and Linda Torczon. *Engineering a Compiler.* Chapter 2 (Scanners).
+- MEP 2 (Grammar): /docs/mep/mep-0002.
 
 ## Copyright
 


### PR DESCRIPTION
Closes #21216.

Companion to #21215, which rewrote MEP-2 in the same style.

## Summary

Rewrites MEP-1 to match MEP-2's structure. Drops the Backwards Compatibility, Resolved Questions, and Reference Implementation sections. Tightens the lexer corner cases by reserving previously-unused codes (`P044`, `P047`, `P048`) and documenting them as active rejections rather than future possibilities.

## Changes

- **PEG notation throughout.** Same operator subset MEP-2 introduced (`?`, `*`, `+`, `&`, `!`, `'lit'`, `[...]`, `'a'..'z'`, `.`) plus Unicode category names (`unicode.L`, `unicode.So`, `unicode.N`).
- **No corner cases.** Raw newlines in strings rejected with `P044`. BOM at non-zero offset rejected with `P047`. Float overflow gets its own `P048`. The "hidden multi-line string" feature is gone from the spec.
- **Diagnostic table expanded.** `P040`-`P048` are now all live codes; `P049` is the next free slot.
- **Dropped sections.** Backwards Compatibility, Resolved Questions (the closed unary-minus story now lives entirely in MEP-2), Reference Implementation file-and-line index.
- **Reorganised.** Abstract, Motivation, Notation, Specification, Design Principles, Conformance, Change Checklist, Open Questions, References. Matches PEP 617 structure and MEP-2 layout.

## Implementation follow-up

Codes `P040`-`P046` are already implemented in `parser/lex.go`. Codes `P047` (BOM mid-stream) and `P048` (float overflow as a distinct code from `P045`) are reserved by the spec but not yet emitted by the lexer. The follow-up to wire those codes is tracked under #21216.

## Test plan

- [ ] `go test ./parser/...` stays green (no code touched in this PR)
- [ ] Docs site builds (`pnpm --filter website build`)
- [ ] Cross-links to MEP-2 resolve