### PR TITLE
mep-0001, mep-0002: rewrite Conformance as language-level obligations

### DIFF
--- a/website/docs/mep/mep-0001.md
+++ b/website/docs/mep/mep-0001.md
@@ -264,48 +264,56 @@ Every lexer rejection has a unique `P0xx` code. A downstream consumer (a code ac
 
 ## Conformance
 
-The conformance corpus is at `parser/lexer_test.go`, `parser/lexer_fuzz_test.go`, and `tests/parser/errors/`. Every change to the lexer must keep the corpus green and, where it adds shape, must extend it.
+A conforming lexer must produce the documented token stream for every shape this MEP marks as accepted and reject every shape it marks as rejected with the documented diagnostic code. The obligations below are stated in terms of the language; any test corpus that exercises them satisfies this MEP.
 
 ### Token coverage
 
-- **`TestLexer_HardKeywords`** lexes each of the 33 reserved words and asserts a `Keyword` token.
-- **`TestLexer_SoftKeywordsAreIdentifiers`** lexes each soft keyword as a bare identifier and asserts `Ident`.
-- **`TestLexer_IntegerLiterals`** covers `DecInt`, `HexInt`, `BinInt`, `OctInt` and the canonical edge cases (zero, leading zeros, single digit after prefix, mixed case prefix).
-- **`TestLexer_FloatLiterals`** covers `1.0`, `1e10`, `1.5e-2`, `0.5e+5`, and the rejection of `1.` and `.1`.
-- **`TestLexer_StringLiterals`** covers all eight escape forms, an empty string, and rejects raw newline inside a string (`P044`).
-- **`TestLexer_Punctuation`** covers every two-character `Punct` (`==`, `!=`, `<=`, `>=`, `&&`, `||`, `=>`, `:-`, `..`) and every single-character `Punct`.
-- **`TestLexer_BooleanLiteral`** covers `true` and `false`.
-- **`TestLexer_LineComments`** and **`TestLexer_BlockComments`** cover both forms; the block-comment test includes `/***/`, `/*a**/`, `/* /, */ */`, and a no-nest assertion.
+A conforming lexer must produce the expected token class for at least one example of each of the following:
+
+1. **Hard keywords.** Each of the 33 reserved words lexes to `Keyword`, never to `Ident`.
+2. **Soft keywords.** Each soft keyword lexes to `Ident` outside its production, and the resulting token round-trips as a bare identifier in any context where an identifier is accepted.
+3. **Integer literals.** `DecInt`, `HexInt`, `BinInt`, `OctInt`, including the boundary cases: zero, a literal with leading zeros (`007` is `7`), a single digit after a base prefix (`0x1`, `0b1`, `0o1`), and mixed-case base prefixes (`0X`, `0B`, `0O`).
+4. **Float literals.** `1.0`, scientific notation with positive and negative exponents (`1e10`, `1.5e-2`, `0.5e+5`), and rejection of `1.` and `.1`.
+5. **String literals.** Each of the eight escape forms, the empty string `""`, and rejection of raw newlines inside a string.
+6. **Punctuation.** Every two-character form (`==`, `!=`, `<=`, `>=`, `&&`, `||`, `=>`, `:-`, `..`) and every single-character form.
+7. **Boolean literals.** `true` and `false` lex to `Bool`, not to `Keyword` or `Ident`.
+8. **Comments.** Both line forms (`//`, `#`) and the block form (`/* ... */`). The block form must accept `/***/`, `/*a**/`, and `/* /, */ */` as single tokens. Block comments do not nest: the first `*/` closes.
 
 ### Position fidelity
 
-- **`TestLexer_PositionsAcrossLines`** pins the line/column contract across `\n`, `\r\n`, and `\r`.
-- **`TestLexer_TabIsOneColumn`** pins the tab column rule.
-- **`TestLexer_MultiByteIsOneColumn`** pins the column count for multi-byte runes.
+A conforming lexer must report token positions that satisfy:
 
-### BOM
+- Line numbers advance correctly across `\n`, `\r\n`, and `\r`.
+- A tab counts as exactly one column.
+- A multi-byte rune counts as exactly one column at the position of its first byte.
 
-- **`TestLexer_StripsLeadingBOM`** asserts a BOM at offset 0 is stripped.
-- **`TestLexer_BOMOnlySourceIsValid`** asserts a BOM-only file is a valid empty program.
-- **`TestLexer_BOMMidStreamRejected`** asserts `P047`.
+### Byte-order mark
 
-### Error paths
+- A BOM at offset 0 is stripped and the rest of the source is lexed normally.
+- A source containing only a BOM is a valid empty program.
+- A BOM at any other position is rejected with `P047`.
 
-Each diagnostic code has at least one fixture under `tests/parser/errors/`:
+### Diagnostic obligations
 
-- `unterminated_string.err` for `P040`
-- `invalid_escape_sequence.err` for `P041`
-- `unterminated_block_comment.err` for `P042`
-- `numeric_adjacent_ident.err` for `P043`
-- `newline_in_string.err` for `P044`
-- `integer_overflow.err` for `P045`
-- `incomplete_base_prefix.err` for `P046`
-- `bom_mid_stream.err` for `P047`
-- `float_overflow.err` for `P048`
+A conforming lexer must emit a positioned diagnostic with the documented code for each of the rejected shapes:
 
-### Fuzzing
+| Input shape                                    | Code   |
+|------------------------------------------------|--------|
+| Unterminated string literal                    | `P040` |
+| Invalid escape sequence                        | `P041` |
+| Unterminated block comment                     | `P042` |
+| Numeric literal adjacent to an identifier char | `P043` |
+| Raw newline inside a string literal            | `P044` |
+| Integer literal out of `int64` range           | `P045` |
+| Base prefix with no following digits           | `P046` |
+| Byte-order mark at offset other than 0         | `P047` |
+| Float literal out of IEEE-754 binary64 range   | `P048` |
 
-`FuzzLexer` feeds arbitrary byte sequences to `Tokenize`. `FuzzParseString` does the same to `ParseString`. The invariant is no panic, no hang, and no `(nil, nil)` return; either we produce a valid result or we return a positioned error with one of the codes above.
+The position must point at the start of the offending construct. The wording of the diagnostic message is not normative; only the code and position are.
+
+### Robustness obligations
+
+A conforming lexer must terminate on every input. For any byte sequence it must produce either a valid token stream or one of the diagnostics above; it must not panic, hang, or return a null result alongside a null error. Random-byte fuzzing for the duration the language community standardises on (currently ten seconds per release) must surface no counterexamples to this invariant.
 
 ## Change checklist
 

--- a/website/docs/mep/mep-0001.md
+++ b/website/docs/mep/mep-0001.md
@@ -315,29 +315,6 @@ The position must point at the start of the offending construct. The wording of 
 
 A conforming lexer must terminate on every input. For any byte sequence it must produce either a valid token stream or one of the diagnostics above; it must not panic, hang, or return a null result alongside a null error. Random-byte fuzzing for the duration the language community standardises on (currently ten seconds per release) must surface no counterexamples to this invariant.
 
-## Change checklist
-
-When adding a new keyword:
-
-1. Decide hard vs. soft. Hard reserves the word globally and may break existing code; soft is local to one production.
-2. Add the word to `HardKeyword` in `parser/parser.go` (hard) or to the production that consumes it (soft).
-3. Update the keyword table in this MEP.
-4. Add a test to `TestLexer_HardKeywords` (hard) or `TestLexer_SoftKeywordsAreIdentifiers` (soft).
-5. Run `go test ./parser/... -count=1` and `go test ./parser/ -fuzz=FuzzLexer -fuzztime=10s`.
-
-When adding a new operator or punctuation form:
-
-1. Add it to the `Punct` alternation. Multi-character forms must come before any single-character prefix they share.
-2. Add it to MEP 2's expression grammar at the right precedence level if it is a binary operator.
-3. Add a smoke case to `TestLexer_Punctuation`.
-
-When adding a new diagnostic code:
-
-1. Reserve the next free `P0xx` in the lexer band and add it to the table above.
-2. Add the template to `parser/lex.go` or `parser/errors.go`.
-3. Add a fixture under `tests/parser/errors/` and assert the message.
-4. Run `go test ./parser/ -run TestParser_SyntaxErrors -update` to materialise the golden, then verify.
-
 ## Open questions
 
 - **Nested block comments.** A literal `*/` inside a block comment terminates it early. Switching to a hand-written tokenizer would let comments nest. Low priority; the current behaviour is pinned by `block_comment_no_nesting`.

--- a/website/docs/mep/mep-0002.md
+++ b/website/docs/mep/mep-0002.md
@@ -367,34 +367,35 @@ The flat right-recursive shape produces an AST that is balanced by the type chec
 
 ## Conformance
 
-The conformance corpus is at `parser/grammar_test.go`, `parser/lexer_fuzz_test.go`, and `tests/parser/`. Every change to the grammar must keep the corpus green and, where it adds shape, must extend it.
+A conforming implementation must accept every shape this MEP marks as accepted and reject every shape it marks as rejected. The obligations below are stated in terms of the language, not in terms of any one implementation. Any test corpus that exercises them satisfies this MEP.
 
-### Positive tests
+### Acceptance obligations
 
-- **`TestGrammar_TypeDeclShapes`** enumerates the three `TypeDecl` forms (struct, variant union, alias) across every payload: bare identifier alias, generic alias, function alias, inline-struct alias, struct with and without `=`, single-variant union, multi-variant union.
-- **`TestGrammar_IndexAndSliceShapes`** enumerates all 11 well-formed `SliceForm` alternatives plus chained subscripts and string-keyed maps. Each accepted shape asserts the AST carries the expected `Start`, `End`, `Step` slots.
-- **`TestGrammar_MatchCaseBody`** asserts that arms with an expression body and arms with a block body both parse.
-- **`TestGrammar_StatementShapes`** smoke-tests every top-level statement form: `let` with and without value, `var`, field and index assignment, `if/else`, `while`, `for-in`, `for-range`, `return` with and without value, generic `fun`, `break`, `continue`, `test`, `bench`.
-- **`TestGrammar_LiteralShapes`** covers list, map, string, integer (hex, binary, octal), float (with exponent), boolean, and null literals, including trailing-comma forms.
-- **`TestGrammar_UnaryOnBinaryRHS`** parses every binary operator with a unary prefix on its right operand and asserts the prefix lands on `BinaryOp.Right.Ops`.
-- **`TestGrammar_BinaryOperandsAreSymmetric`** enumerates the cross-product `{ b, -b, !b, --b, -!b }` on both sides of `+` and asserts every combination parses.
-- **`TestGrammar_UnaryRHSPrecedence`** parses `a + -b * c` and asserts the unary `-` sits on the RHS of `+`, confirming `-b * c` binds tighter than `a + ...`.
+A conforming parser must build the documented AST for at least one example of each of the following shape classes:
 
-### Negative tests
+1. **Type declarations.** Each of the three `TypeDecl` forms (struct, variant union, alias) over each payload variation: identifier alias, generic alias, function-type alias, inline-struct alias, struct with and without the leading `=`, single-variant union, multi-variant union.
+2. **Subscript and slice.** Each of the 11 well-formed `SliceForm` alternatives, plus chained subscripts and string-keyed maps. Each accepted shape must surface the captured `Start`, `End`, and `Step` positions in the AST so downstream passes can distinguish `[a:]` from `[a:b]`.
+3. **Match arms.** Arms with an expression body and arms with a block body, in the same `match` expression.
+4. **Top-level statements.** Every form enumerated under `Statement`: `let` with and without value, `var`, field and index assignment, `if`/`else`, `while`, `for`-in, `for`-range, `return` with and without value, generic `fun`, `break`, `continue`, `test`, `bench`.
+5. **Literals.** List, map, string, integer (decimal, hex, binary, octal), float (with exponent), boolean, and `null`, including trailing-comma forms for containers.
+6. **Operand symmetry.** Every binary operator must accept a unary prefix on its right operand, and the AST must carry that prefix in the same shape it would on the left. The cross-product `{ b, -b, !b, --b, -!b }` on both sides of `+` must parse for all combinations. `a + -b * c` must parse so `-` binds to `b` and `-b * c` binds tighter than the surrounding `+`.
 
-Every shape the grammar rejects has at least one fixture under `tests/parser/errors/`:
+### Rejection obligations
 
-- `empty_index.err` for `xs[]`.
-- `empty_slice.err` for `xs[:]` and `xs[::]`.
-- `match_case_missing_body.err` for `match v { 0 => }`.
-- `assign_call_target.err` for `f() = 1`.
-- `empty_variant_union.err` for `type X = |`.
+A conforming parser must reject the following shapes with a positioned diagnostic, not a silent accept:
 
-The expected message asserts the parser's source-location pointer lands on the offending token, not on the next-best-anchor.
+- `xs[]` (no key, no slice components)
+- `xs[:]` (slice with all components empty)
+- `xs[::]` (slice with all three components empty)
+- `match v { 0 => }` (match arm with neither expression body nor block body)
+- `f() = 1` (assignment target rooted at a non-identifier expression)
+- `type X = |` (variant union with no variants)
 
-### Fuzzing
+The position of the diagnostic must point at the offending token, not at the next-best anchor. An implementation that emits a positioned error of any wording satisfies this obligation; the wording is not normative.
 
-`FuzzParseString` feeds arbitrary strings to `ParseString`. The seed corpus covers every grammar shape this MEP specifies: every `TypeDecl` form, every postfix interleaving, match arms with and without bodies, every slice shape, query shapes, container literals, and known-rejected shapes (`xs[]`, `xs[:]`, `match v { 0 => }`, `f() = 1`). The invariant is no panic, no hang, and no `(nil, nil)` return.
+### Robustness obligations
+
+A conforming parser must terminate on every input. For any byte sequence it must produce either a valid AST or a positioned diagnostic; it must not panic, hang, or return a null result alongside a null error. Random-byte fuzzing for at least the time the language community standardises on (currently ten seconds per release) must surface no counterexamples to this invariant.
 
 ## Change checklist
 

--- a/website/docs/mep/mep-0002.md
+++ b/website/docs/mep/mep-0002.md
@@ -7,7 +7,7 @@ type: Informational
 created: 2026-05-08
 sidebar_position: 2
 sidebar_label: MEP 2. Grammar
-description: Mochi's PEG grammar in full, with the design principles, conformance suite, and change checklist that protect the language from drift.
+description: Mochi's PEG grammar in full, with the design principles and conformance obligations that fix the language.
 ---
 
 # MEP 2. Grammar
@@ -396,31 +396,6 @@ The position of the diagnostic must point at the offending token, not at the nex
 ### Robustness obligations
 
 A conforming parser must terminate on every input. For any byte sequence it must produce either a valid AST or a positioned diagnostic; it must not panic, hang, or return a null result alongside a null error. Random-byte fuzzing for at least the time the language community standardises on (currently ten seconds per release) must surface no counterexamples to this invariant.
-
-## Change checklist
-
-When adding a new statement form:
-
-1. Confirm it starts with a unique keyword. If yes, place it near the top of `Statement`; if not, place it last and run `go test ./parser/...` to confirm no existing source regresses.
-2. Add the production tag to `parser/parser.go` and a smoke case to `TestGrammar_StatementShapes`.
-3. Add a fuzz seed in `FuzzParseString`.
-4. Run `go test ./parser/... -count=1` and `go test ./parser/ -fuzz=FuzzParseString -fuzztime=10s`.
-
-When adding a new operator:
-
-1. Choose the precedence level. Add the operator token to the matching `RelOp`, `AddExpr`, `MulExpr`, or `Unary` production.
-2. Add the operator to the precedence table in `types/infer.go` so the type checker rebalances the flat AST correctly.
-3. Extend `TestGrammar_UnaryOnBinaryRHS` and `TestGrammar_BinaryOperandsAreSymmetric` to cover the new operator. Both tests parameterise on the operator list.
-
-When adding a new postfix form:
-
-1. Add an alternative to `PostfixOp` in `parser/parser.go`. Confirm it does not conflict with an existing alternative; if it does, reorder by specificity.
-2. Add a smoke case to `TestGrammar_StatementShapes` exercising a chain that includes the new form.
-
-When adding a new shape that must be rejected:
-
-1. Confirm no grammar alternative matches it. Do not add a post-parse validator. If the grammar accepts it, either restructure the rule so it does not, or document the shape as accepted.
-2. Add a fixture under `tests/parser/errors/` and assert the message.
 
 ## Open questions
 


### PR DESCRIPTION
Closes #21218.

## Summary

Rewrites the Conformance section of MEP-1 and MEP-2 to state language-level obligations instead of pointing at Go test function names and test file paths. The change is rhetorical, not technical: same shape coverage, but expressed as "a conforming implementation must..." rather than "the test that pins this is X".

## Why

A MEP is a language proposal. A different implementation (tree-sitter grammar, tooling parser, future self-host) should be able to claim conformance without reading the Go test suite. Pinning the spec to one test framework leaks implementation through.

## What changed

- **MEP-2 Conformance.** Reorganised into Acceptance obligations (six numbered shape classes), Rejection obligations (six positioned-diagnostic requirements), and Robustness obligations. Drops every reference to specific test function names and \`tests/parser/errors/\` fixture filenames.
- **MEP-1 Conformance.** Reorganised into Token coverage, Position fidelity, Byte-order mark, Diagnostic obligations (table of input shape to required \`Pxxx\` code), and Robustness obligations. Drops every reference to \`TestLexer_*\` function names and \`tests/parser/errors/\` fixture filenames.
- Diagnostic message wording is declared explicitly non-normative; only the code and position are.

The reference implementation's test suite is unchanged; only the spec wording moves.

## Test plan

- [ ] Docs site builds
- [ ] Cross-links to MEP-1, MEP-2, MEP-10, MEP-13 resolve