### PR TITLE
mep-0004: sync type system doc to current state

### DIFF
--- a/website/docs/mep/mep-0004.md
+++ b/website/docs/mep/mep-0004.md
@@ -222,7 +222,7 @@ The current design has several known problems. They are listed below without rig
 
 **11. `UnionType.Variants` has no stable iteration order.** The text claims declaration order is preserved, but the field is a Go map. Downstream consumers that need stable order (the formatter, the C# emitter's switch table) reconstruct it from the parser tree. The fix is to add an `Order []string` parallel to `StructType.Order`.
 
-**12. `StructType.Methods` ties `types` to `parser`.** `Method.Decl` is a `*parser.FunStmt`. Any future split of the AST into its own package, as [MEP 3](/docs/mep/mep-0003) hints at, has to thread back through `types`. The fix is to keep only the method signature and a body handle, not the AST node.
+**12. `StructType.Methods` ties `types` to `parser`.** `Method.Decl` is a `*parser.FunStmt`, so the type system module depends on the parser AST. The fix is to keep only the method signature and an opaque body handle, not the AST node. [#21249](https://github.com/mochilang/mochi/issues/21249).
 
 **13. `Variadic` is a bool, not a varargs element type.** Nothing prevents a `FuncType` with `Variadic: true` and an empty `Params`. The convention "the last parameter is the variadic element" is enforced by the surface grammar, not by the type. The fix is to encode varargs as a separate field, or to split `Params` into a fixed prefix and a single variadic element.
 
@@ -230,7 +230,7 @@ The current design has several known problems. They are listed below without rig
 
 **15. `reflect.DeepEqual` is the equality fallback.** The fallback is used for kinds that have no special case, mostly `FuncType` and `StructType`. It walks pointer trees indiscriminately, which makes it sensitive to nested `*parser.FunStmt` references inside `Method.Decl`. The fix is an exhaustive switch over the kinds.
 
-**16. `Env` mixes static types with runtime values.** The `values` map on `types.Env` is a runtime concern that has no business being on a static-analysis struct. The fix is to split `types.Env` (static) and `runtime.Env` (values), with the latter embedding the former. The sweep touches the interpreter and the LLM provider boundaries.
+**16. `Env` mixes static types with runtime values.** The `values` map on `types.Env` is a runtime concern that has no business being on a static-analysis struct. The fix is to split `types.Env` (static) and `runtime.Env` (values), with the latter embedding the former. The sweep touches the interpreter and the LLM provider boundaries. [#21250](https://github.com/mochilang/mochi/issues/21250).
 
 **17. `Env.Copy` flattens the parent chain.** Closures capture by copy, but the flattening loses scope-shadowing information that downstream tools need. Worth replacing with a snapshot that keeps the chain.
 
@@ -238,7 +238,7 @@ The current design has several known problems. They are listed below without rig
 
 **19. `unit` is not a surface type.** The kind exists internally and the inference uses it. But the lexer does not accept `unit` as a type-name keyword, so a programmer cannot write `let f: fun() -> unit = ...`. The fix is one line in the lexer keyword list and one case in `resolveTypeRef`.
 
-**20. No nominal alias kind.** `type Id = int` collapses immediately. Error messages cannot say "expected `Id`, got `int`"; recursive aliases cannot be expressed. The fix is `AliasType{Name, Target}` that prints as `Name` and unifies as `Target`. The scope is bigger than the other items here and is a follow-up MEP.
+**20. No nominal alias kind.** `type Id = int` collapses immediately. Error messages cannot say "expected `Id`, got `int`"; recursive aliases cannot be expressed. The fix is `AliasType{Name, Target}` that prints as `Name` and unifies as `Target`. Scope is larger than the other items here and may grow into its own MEP. [#21251](https://github.com/mochilang/mochi/issues/21251).
 
 **21. No tuple kind.** Heterogeneous fixed-length sequences either promote to a generated struct or fall back to `[any]`. `TupleType{Elems []Type}` is the obvious addition; it adds unify and equality cases for one more kind.
 

--- a/website/docs/mep/mep-0004.md
+++ b/website/docs/mep/mep-0004.md
@@ -5,190 +5,459 @@ author: Mochi core
 status: Informational
 type: Informational
 created: 2026-05-08
+revised: 2026-05-11
 sidebar_position: 4
 sidebar_label: MEP 4. Type System
-description: Type kinds, equality, unification, and the numeric tower.
+description: Kinds, judgements, equality, unification, the numeric tower, and the soundness perimeter of Mochi's static type system.
 ---
 
 # MEP 4. Type System
 
-| Field    | Value                       |
-|----------|-----------------------------|
-| MEP      | 4                           |
-| Title    | Type System                 |
-| Author   | Mochi core                  |
-| Status   | Informational               |
-| Type     | Informational               |
-| Created  | 2026-05-08                  |
+| Field    | Value                                  |
+|----------|----------------------------------------|
+| MEP      | 4                                      |
+| Title    | Type System                            |
+| Author   | Mochi core                             |
+| Status   | Informational                          |
+| Type     | Informational                          |
+| Created  | 2026-05-08                             |
+| Revised  | 2026-05-11                             |
+| Requires | [MEP 2](/docs/mep/mep-0002), [MEP 3](/docs/mep/mep-0003) |
+| Informs  | [MEP 5](/docs/mep/mep-0005), [MEP 10](/docs/mep/mep-0010), [MEP 11](/docs/mep/mep-0011), [MEP 12](/docs/mep/mep-0012) |
 
 ## Abstract
 
-Mochi has a small structural type system with nominal records and unions. This MEP documents the type kinds present in the implementation today, the equality and unification rules used by the checker, and the numeric tower that drives binary operator typing.
+Mochi has a small, mostly monomorphic type system with nominal records and unions, a structural function arrow, and an explicit top type (`any`) used as an escape hatch where the checker cannot yet do better. This MEP catalogues the type kinds, fixes the equality and unification rules, states the numeric tower and operator typing as a single normative table, gives a typing judgement notation, and lists the soundness gaps that callers may not assume away. It is the contract every later type-system MEP refines, not replaces.
 
 ## Motivation
 
-The type system is the contract between the checker and the runtime. Misunderstandings about whether `int` and `int64` are equal, or whether `any` is a top type or a bottom type, produce soundness gaps that are hard to track down later. This MEP documents the kinds and their relationships so future changes are deliberate.
+The type system is the interface between the parser ([MEP 3](/docs/mep/mep-0003)) and every downstream consumer: the inference rules ([MEP 5](/docs/mep/mep-0005)), the runtime, the transpilers, and the documentation. Misunderstanding any one of the following produces soundness regressions that are hard to diagnose later:
+
+- Whether `int` and `int64` are *equal* or merely *unifiable*.
+- Whether `any` is a *top*, a *bottom*, or neither.
+- Whether `unify` performs *equality*, *subtyping*, or *both* depending on caller.
+- Which kinds exist *as types* versus which exist *only as runtime values*.
+
+This MEP fixes one answer per question and points at the code that implements it. Future revisions to the implementation must either keep the answer or update this document.
+
+## Terminology
+
+We use the standard programming-language-theory vocabulary throughout. The following short glossary pins the meaning we use in this document; see [Pierce, *Types and Programming Languages*](https://www.cis.upenn.edu/~bcpierce/tapl/), and [Harper, *Practical Foundations for Programming Languages*](https://www.cs.cmu.edu/~rwh/pfpl.html) for the canonical treatment.
+
+- **Type.** A static classifier for values. In Mochi every type implements the Go interface `Type` (see §3.1).
+- **Kind.** A category of types. Mochi's kinds are primitive (`int`, `bool`, etc.), structural (`list`, `map`), nominal (`StructType`, `UnionType`), function (`FuncType`), polymorphic (`TypeVar`), top (`AnyType`), and unit (`UnitType`). We say "kind" rather than "type constructor family" for brevity; the formal kind system is implicit.
+- **Nominal.** A type whose identity is its declared name. Two `StructType` values with the same field set but different `Name` fields are *not* equal.
+- **Structural.** A type whose identity is its shape. `ListType{Elem: IntType{}}` and a freshly constructed `ListType{Elem: IntType{}}` are equal.
+- **Monomorphic.** Without unresolved type variables. Most of Mochi today is monomorphic at use sites; `TypeVar` exists but is not yet propagated by inference (see [MEP 12](/docs/mep/mep-0012)).
+- **Top type.** A type that every other type is convertible to. In Mochi this is `AnyType`. It is a top *by `unify`*, but only equal-to-itself *by `equalTypes`*. See §3.5.
+- **Subtype, supertype.** `S ≤ T` reads "S is a subtype of T". Mochi has a small built-in subtype relation today (Int ≤ Int64 ≤ BigInt; struct variants ≤ union; etc.) and a proposed clean predicate in [MEP 11](/docs/mep/mep-0011).
+- **Unification.** A symmetric procedure that produces a substitution under which two types become structurally equal, or fails. Mochi's `unify` (§3.6) additionally treats `AnyType` as a wildcard.
+- **Typing judgement.** A statement of the form `Γ ⊢ e : τ`: under environment `Γ`, expression `e` has type `τ`. See §3.10.
+
+A note on words we *avoid*: "void" was the historical name for the unit type. It is now `unit` to remove the special case where `Return == nil` in the AST had to be reinterpreted as "no return value" by every consumer (see [MEP 3](/docs/mep/mep-0003) §"Soundness Enforced" invariant 15 and [#21221](https://github.com/mochilang/mochi/pull/21221)).
 
 ## Specification
 
-### The `Type` interface
+### 3.1 The `Type` interface
 
-`types/check.go` (around line 12). Every type kind implements:
-
-```
+```go
 type Type interface {
     String() string
 }
 ```
 
-There is no equality method on the interface. Equality is computed externally by `equalTypes` in `types/infer.go` (around line 828) and structural unification is done by `unify` in `types/check.go` (around line 144). The fallthrough case in `equalTypes` is `reflect.DeepEqual`, with explicit carve-outs for `Int`/`Int64` interop, union/struct member matching, and option types. `unify` uses a different rule for `AnyType`: see below.
+Every kind implements `String()` and nothing else. Equality, unification, and subtyping are *external* operations defined over the kind cases, not methods on the interface. This is a deliberate trade: it keeps the kind table easy to extend (a new kind requires one constructor and one `String()`) at the cost of forcing the comparison operators to enumerate cases. The trade is worth taking because the kind table changes more often than the comparison operators do.
 
-### Kinds present today
+### 3.2 Kind inventory
 
-Listed in source order at `types/check.go` (the kind block starts at line 16 with `IntType` and runs through the `FuncType.String()` method).
+The full kind catalogue, in source order at `types/check.go` (the block runs from `IntType` through `FuncType.String()`):
 
-Primitive kinds:
+#### Primitive kinds
 
-- `IntType`. Default integer width. Backed by Go `int64` at runtime but the surface type is `int`.
-- `Int64Type`. Distinguished only where the runtime needs it, for example the result type of `now()`. Unifies with `IntType` for arithmetic.
-- `FloatType`. IEEE 754 double precision.
-- `BigIntType`. Arbitrary precision integer.
-- `BigRatType`. Arbitrary precision rational.
-- `StringType`. UTF-8 byte sequence.
-- `BoolType`. `true` or `false`.
-- `UnitType`. Result type of statement-only operations like `print`, and the canonical default return for a block-bodied function or lambda with no annotated return ([MEP 3](/docs/mep/mep-0003) invariant 15). Printed as `unit`. The kind was named `VoidType` historically; the rename in [#21221](https://github.com/mochilang/mochi/pull/21221) removed the special case where `nil Return` had to be interpreted by every consumer.
+| Kind         | Surface name | Notes                                                                                                                                                |
+|--------------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `IntType`    | `int`        | Default integer width. Backed by Go `int64` at runtime; the surface name is `int`.                                                                   |
+| `Int64Type`  | `int64`      | Distinguished where the runtime exposes 64-bit results (`now()`). Unifies with `IntType` for arithmetic but is not equal to it under `equalTypes`.   |
+| `FloatType`  | `float`      | IEEE 754 binary64.                                                                                                                                   |
+| `BigIntType` | `bigint`     | Arbitrary precision integer.                                                                                                                         |
+| `BigRatType` | `bigrat`     | Arbitrary precision rational.                                                                                                                        |
+| `StringType` | `string`     | UTF-8 byte sequence with rune-aware operations at the runtime layer.                                                                                 |
+| `BoolType`   | `bool`       | Two-valued.                                                                                                                                          |
+| `UnitType`   | `unit`       | Result of statement-only operations (`print`, `json`) and the canonical default return of a block-bodied function with no annotation (cf. [MEP 3](/docs/mep/mep-0003) invariant 15). |
 
-Structural kinds:
+#### Structural kinds
 
-- `ListType{Elem Type}`. Homogeneous ordered sequence.
-- `MapType{Key Type, Value Type}`. Hash map keyed by `Key`.
-- `OptionType{Elem Type}`. Declared but not produced by inference today. See [MEP 10](/docs/mep/mep-0010).
-- `GroupType{Key Type, Elem Type}`. Internal type carried by the `into Name` clause of a `group by` query.
-- `StructType{Name, Fields, Order, Methods}`. Nominal record. `Order` preserves the declaration sequence so output and JSON encoding are deterministic.
-- `UnionType{Name, Variants}`. Nominal sum of struct-shaped variants. `Variants` is a map but the iteration order should be stable: the variant order from the declaration is captured when the type decl is processed.
+| Kind         | Surface name        | Notes                                                                                                                |
+|--------------|---------------------|----------------------------------------------------------------------------------------------------------------------|
+| `ListType`   | `[T]`               | Homogeneous, ordered, indexable from `0`.                                                                            |
+| `MapType`    | `map<K, V>`         | Unordered hash map keyed by `K`.                                                                                     |
+| `OptionType` | `option[T]`         | Currently *declared* but not *produced* by inference. Lookup `m[k]` returns the zero of `V` today (see §6 gap 3).    |
+| `GroupType`  | `group`             | Internal: carried by the `into Name` clause of a `group by` query in [MEP 5](/docs/mep/mep-0005).                    |
 
-Function kind:
+#### Nominal kinds
 
-- `FuncType{Params, Return, Pure, Variadic}`. The `Pure` flag is computed but not enforced anywhere yet (tracked in [#21188](https://github.com/mochilang/mochi/issues/21188)). The `Variadic` flag is exercised by builtins like `concat` and `range`.
+| Kind         | Surface name | Notes                                                                                                                                 |
+|--------------|--------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| `StructType` | `Name`       | Record. `Name`, `Fields map[string]Type`, `Order []string` (declaration order, preserved for deterministic JSON), `Methods`.          |
+| `UnionType`  | `Name`       | Closed sum of struct-shaped variants. `Variants map[string]StructType`; iteration order is captured from the type declaration.        |
 
-Polymorphism kinds:
+#### Function kind
 
-- `TypeVar{Name}`. Carried by generic function declarations. Not yet used for full inference. See [MEP 12](/docs/mep/mep-0012).
+| Kind       | Surface name              | Notes                                                                                                                                  |
+|------------|---------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| `FuncType` | `fun(A, B): R [pure]`     | `Params []Type`, `Return Type`, `Pure bool`, `Variadic bool`. `Pure` is computed but not enforced ([#21188](https://github.com/mochilang/mochi/issues/21188)). `Variadic` is exercised by `concat`, `range`, `print`. |
 
-Top kind:
+#### Polymorphism kind
 
-- `AnyType{}`. Unifies with everything in both directions. This is the primary unsoundness escape hatch and is documented in detail in [MEP 10](/docs/mep/mep-0010) and [MEP 11](/docs/mep/mep-0011).
+| Kind      | Surface name | Notes                                                                                                          |
+|-----------|--------------|----------------------------------------------------------------------------------------------------------------|
+| `TypeVar` | `T`, `U`, ...| Pointer type (`*TypeVar`). Carried by generic function declarations; not yet propagated by inference. See [MEP 12](/docs/mep/mep-0012). |
 
-### What is missing
+#### Top kind
 
-The list of kinds the language does not have today:
+| Kind      | Surface name | Notes                                                                                                                                               |
+|-----------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `AnyType` | `any`        | Behaves as a top type for `unify` (both directions). For `equalTypes` it is equal only to itself. This split is intentional but unsound; see [MEP 11](/docs/mep/mep-0011). |
 
-- No nominal alias kind. `type Id = int` is collapsed at resolve time to its target.
-- No tuple kind. A heterogeneous fixed-length sequence has no surface type.
-- No record subtype kind separate from `StructType`. Width subtyping is decided by name plus field set, not by an explicit row variable.
-- No effect kind. The `Pure` flag is on the function type, not a separate kind.
-- No reference kind. Mutability is a property of the binding (`var` versus `let`), not of the type.
-- No existential or universal kind beyond `TypeVar` for generics.
-- No first-class type kind. Types cannot be passed as values.
+### 3.3 What does *not* exist as a kind
 
-### Typing judgement
+Listing the explicit absences keeps consumers honest. None of the following are kinds today:
 
-We use the standard form `Γ ⊢ e : τ` where `Γ` is the lexical environment. Mochi's `Γ` carries:
+- **Nominal alias.** `type Id = int` is collapsed at type-resolution time to its target. There is no `AliasType` constructor.
+- **Tuple.** A heterogeneous fixed-length sequence has no surface type. Queries that produce tuples promote to `[any]` or to a generated `StructType`.
+- **Row variable.** Width subtyping is decided by name plus field set, not by an explicit row variable.
+- **Effect.** Purity is a flag on `FuncType`, not its own kind. There is no effect row.
+- **Reference / cell.** Mutability is a property of the *binding* (`var` vs `let`), not of the type. The type of a `var x: int` binding is `IntType`, not `Ref<IntType>`.
+- **Existential, universal.** Beyond `TypeVar` for parametric polymorphism, no quantification kinds exist.
+- **First-class type.** Types are not first-class values. There is no `Type: Type` reflection layer.
 
-- Variable bindings with mutability flag (`Env.SetVar`).
-- Type bindings (`Env.SetType`).
-- Function bindings (`Env.SetFunc`).
-- Stream and agent bindings.
+[MEP 10](/docs/mep/mep-0010) tracks which of these are gaps versus deliberate design.
 
-Environments are linked. A child environment delegates lookups to its parent and shadows on write. See `types/env.go` for the API.
+### 3.4 The typing context
 
-### Equality and unification
+The environment `Γ` is implemented by `types.Env` (`types/env.go`). It is a linked stack of frames; lookups consult the current frame, then walk to the parent. Each frame holds:
 
-The exact rules in `equalTypes` (`types/infer.go`):
+| Map         | Key            | Value                       | Purpose                                                                 |
+|-------------|----------------|-----------------------------|-------------------------------------------------------------------------|
+| `types`     | identifier     | `Type`                      | Variable and function types.                                            |
+| `mut`       | identifier     | `bool`                      | Whether the binding is mutable (`var`) or immutable (`let`).            |
+| `values`    | identifier     | `any`                       | Runtime values, used by the interpreter; ignored by the static checker. |
+| `funcs`     | identifier     | `*parser.FunStmt`           | Function declarations.                                                  |
+| `structs`   | type name      | `StructType`                | User-declared records.                                                  |
+| `unions`    | type name      | `UnionType`                 | User-declared sums.                                                     |
+| `streams`   | stream name    | `StructType`                | Declared stream row types.                                              |
+| `agents`    | agent name     | `*parser.AgentDecl`         | Agent declarations.                                                     |
+| `models`    | alias          | `ModelSpec`                 | LLM model aliases.                                                      |
 
-- `IntType` and `Int64Type` are equal to each other. The code has explicit carve-outs so `int64` result types (for example from `now()`) unify cleanly with `int` variables.
-- Two list types are equal iff their element types are equal.
-- Two map types are equal iff key and value types are equal.
-- Two function types are equal iff arity, parameter types, return type, and `Variadic` flag all match.
-- Two struct types are equal by `reflect.DeepEqual`; in practice names are unique so this reduces to name equality.
-- Two union types are equal by name.
-- A `StructType` is equal to a `UnionType` when the struct is one of the union's variants. This is what allows `match` arms typed as variant structs to satisfy a union binding.
-- `AnyType` is equal only to another `AnyType` in `equalTypes`. It is `unify` that accepts `AnyType` on either side as a match; that is the unsoundness escape hatch.
+The static type checker uses `types`, `mut`, `funcs`, `structs`, `unions`, `streams`, and `agents`. The remaining maps are runtime concerns surfaced on the same struct.
 
-Unification propagates substitutions for `TypeVar` on top of the equality rules. See `types/check.go` `unify` (around lines 144-381).
+### 3.5 Equality
 
-### Numeric tower
+`equalTypes(a, b Type) bool` in `types/infer.go` (around line 828) decides nominal equality plus a small set of carve-outs. The exact rules in source order:
 
-Listed from narrowest to widest, but the relations are not a clean total order:
+1. **`any` only equals `any`.** If either side is `AnyType`, the other must be `AnyType` too.
+2. **List equality is element equality.** `[T] = [U]` iff `equalTypes(T, U)`.
+3. **Map equality is component-wise.** `map<K1, V1> = map<K2, V2>` iff `equalTypes(K1, K2) && equalTypes(V1, V2)`.
+4. **Option equality is element equality.** `option[T] = option[U]` iff `equalTypes(T, U)`.
+5. **Union ⊇ Struct variant.** A `UnionType` is equal to a `StructType` whose name appears in `Variants`. This is what allows `match` arms typed as variant structs to satisfy a union binding.
+6. **`int64`/`int` interop.** `Int64Type = Int64Type | IntType` and the symmetric case. This is the single place in the type system where numeric widths are conflated at the equality layer (rather than only at the operator layer).
+7. **Two `int`s are equal.** Reflexive case for `IntType`.
+8. **Otherwise, `reflect.DeepEqual`.** Function types, struct types with identical content, and the rest reduce to DeepEqual. In practice, `StructType` names are unique within a scope so this collapses to name equality for structs.
+
+Equality is *not* symmetric in the special-cased rules. The symmetric clauses are written out explicitly; if a future kind is added that needs a symmetric carve-out, both directions must be enumerated.
+
+### 3.6 Unification
+
+`unify(a, b Type, subst Subst) bool` in `types/check.go` (around lines 144-381) is the workhorse used by the type checker wherever two types must be reconciled (argument vs. parameter, branch vs. expected, etc.). It is *not* the same relation as `equalTypes`. Its rules:
+
+1. **`any` is a wildcard.** If either side is `AnyType`, `unify` succeeds. This is the soundness escape hatch ([MEP 10](/docs/mep/mep-0010), [MEP 11](/docs/mep/mep-0011)).
+2. **`TypeVar` substitutes.** A `*TypeVar` on either side either binds via `subst` or, if `subst == nil`, succeeds only against the same `TypeVar` by name. The substitution map carries instantiations across a single unify call.
+3. **Composite kinds recurse.** `ListType`, `MapType`, `OptionType`, `GroupType`, `FuncType` unify component-wise.
+4. **`StructType` ↔ `StructType`.** Unifies if names match (or either is unnamed) and the field maps match component-wise.
+5. **`StructType` ↔ `UnionType`.** Unifies if the struct's name is among the union's variants, in which case it unifies with that variant.
+6. **`UnionType` ↔ `UnionType`.** Unifies iff their names are equal.
+7. **Numeric ladder.** `IntType` unifies with `IntType` or `BigIntType`. `Int64Type` unifies with `Int64Type` or `IntType`. `BigIntType` unifies with `BigIntType`, `IntType`, or `Int64Type`. `BigRatType` unifies with the entire integer-and-float chain. `FloatType` unifies only with `FloatType`. This is the *unification view* of the numeric tower (see §3.7 for the *operator view*).
+8. **`UnitType`, `BoolType`, `StringType`.** Reflexive only.
+
+The asymmetric `any` rule (`unify(t, any) = unify(any, t) = true`) is the load-bearing escape hatch behind most of Mochi's pragmatism. It is also the load-bearing reason the system is not fully sound ([MEP 11](/docs/mep/mep-0011) proposes a replacement).
+
+### 3.7 The numeric tower
+
+Three relations coexist on numeric kinds, and they are not the same:
 
 ```
-int  ⊂  int64  ⊂  bigint
-int          ⊂   float
-int          ⊂   bigrat
-bigint       ⊂   bigrat
-float        ⊄   bigrat   (mixed becomes bigrat in practice today)
+Equality (§3.5):  int = int                 int = int64                 (the only conflations)
+Unify   (§3.6):  IntType ↔ {IntType, BigIntType}
+                 Int64Type ↔ {Int64Type, IntType}
+                 BigIntType ↔ {BigIntType, IntType, Int64Type}
+                 BigRatType ↔ {BigRatType, FloatType, IntType, Int64Type, BigIntType}
+                 FloatType ↔ {FloatType}
+Operator widening (§3.8):  see table
 ```
 
-The actual rules used by `inferBinaryType`:
+The unify and operator views diverge deliberately: an `int + float` widens to `float` at the operator layer, but `IntType` does *not* unify with `FloatType`. The reason is that operators produce a fresh result type by the widening rule, whereas unify is asked at *argument-passing* sites where silent widening would lose information.
 
-- Integer divide (`/` between two `int`s) returns `int`.
-- Either side `bigrat` widens to `bigrat`.
-- Either side `int64` and the other side `int` or `int64` returns `int64`.
-- Either side `float` and both sides numeric returns `float`.
-- Either side `bigint` returns `bigint`.
-- Two ints return `int`.
-- String plus string returns `string`.
-- List plus list returns the same list type if elements agree, or `[any]` otherwise.
-- Otherwise `any`.
+### 3.8 Operator typing
 
-The `+` rule on lists silently widens to `[any]` on element type mismatch. This is a soundness gap tracked in [#21187](https://github.com/mochilang/mochi/issues/21187).
+The normative table for binary operators is the body of `inferBinaryType` in `types/infer.go` (around line 72). Precedence is decided by the parser ladder ([MEP 2](/docs/mep/mep-0002)); the table below is the per-operator *result type* once both operands have been inferred.
+
+Let `L` and `R` be the operand types. `+, -, *, /, %`:
+
+| Rule                                                                                       | Result          | Notes                                                                  |
+|--------------------------------------------------------------------------------------------|-----------------|------------------------------------------------------------------------|
+| `/` and both sides `int`                                                                   | `int`           | Integer division.                                                      |
+| One side `int64` and the other `int` or `int64`                                            | `int64`         | Widens to 64-bit.                                                      |
+| Either side `bigrat`                                                                       | `bigrat`        | Widens to arbitrary precision rational.                                |
+| Either side `float`, both sides any of `int`, `int64`, `float`                             | `float`         | IEEE 754 widening.                                                     |
+| Either side `bigint`                                                                       | `bigint`        | Arbitrary precision integer widening.                                  |
+| Both sides `int`                                                                           | `int`           | Reflexive.                                                             |
+| `+` with both sides list and element types equal                                           | `[T]`           | Same-typed concatenation.                                              |
+| `+` with both sides list, element types differ                                             | `[any]`         | Silent widening. Soundness gap [#21187](https://github.com/mochilang/mochi/issues/21187). |
+| `+` with both sides string                                                                 | `string`        | String concatenation.                                                  |
+| Otherwise                                                                                  | `any`           | Pragmatic fallback.                                                    |
+
+Comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`) return `bool`. They do not currently check that both operands are comparable; mixed-kind comparisons return `bool` regardless.
+
+Logical operators (`&&`, `||`) return `bool` when both operands are `bool`, otherwise `any`. The `any` fallback is more permissive than is sound; tightening it is gated on [MEP 11](/docs/mep/mep-0011).
+
+The membership operator `in` returns `bool` when the right operand is `map`, `list`, or `string`, otherwise `any`.
+
+Set-style operators on query results (`union`, `union_all`, `except`, `intersect`) take two lists and return the same list type when element types agree, `[any]` otherwise (the same silent widening as `+` on lists).
+
+### 3.9 Type formation
+
+`resolveTypeRef(t *parser.TypeRef, env *Env)` in `types/check.go` (around line 1346) maps surface type references (`int`, `[T]`, `fun(int): bool`, `User`) into the kind catalogue:
+
+1. **`Fun`.** `fun(P1, P2): R` produces `FuncType{Params, Return}`. A missing `Return` resolves to `UnitType` (canonicalised per [MEP 3](/docs/mep/mep-0003) invariant 15).
+2. **`Generic`.** `list<T>` and `map<K, V>` map to `ListType` and `MapType`. Unknown generic names resolve to `AnyType`.
+3. **`Struct`.** Inline structural records produce an unnamed `StructType` with `Name: ""`. Width-subtyping rules in §3.6 still apply.
+4. **`Simple`.** Names `int`, `int64` (resolved via env lookup), `float`, `bigint`, `bigrat`, `string`, `bool` map to their primitive kinds. Any other identifier is resolved by consulting the environment in this order: unions, structs, type aliases, variant-to-union lookup. A name that resolves to nothing falls through to `AnyType` (which is a known weakness; an unknown type should plausibly error).
+
+### 3.10 Typing judgement
+
+We use the standard form `Γ ⊢ e : τ` where `Γ` is the lexical environment of §3.4 and `e` is a parser expression. The inference rules per construct are stated in [MEP 5](/docs/mep/mep-0005); this MEP only fixes the judgement format and the structural rules.
+
+Selected rules (informal; the full list is in [MEP 5](/docs/mep/mep-0005)):
+
+```
+                  Γ(x) = τ
+        ───────────────────────────── (var)
+                Γ ⊢ x : τ
+
+   Γ ⊢ e1 : τ1     Γ ⊢ e2 : τ2     op(τ1, τ2) = τ
+        ─────────────────────────────────────────── (binop)
+                  Γ ⊢ e1 op e2 : τ
+
+   Γ ⊢ e : FuncType{Params: [σ1, ..., σn], Return: τ}
+   Γ ⊢ a_i : σ_i                    for each i
+        ─────────────────────────────────────────── (app)
+                 Γ ⊢ e(a1, ..., an) : τ
+
+   Γ, x_i : σ_i ⊢ body : τ
+        ─────────────────────────────────────────── (lam)
+        Γ ⊢ fun(x1: σ1, ..., xn: σn) → body :
+            FuncType{Params: [σ1, ..., σn], Return: τ}
+```
+
+`op` in `(binop)` is the function from §3.8 (operator typing). The substitution `Γ, x : σ` is "extend `Γ` with `x` bound to `σ` in a new scope". The judgement is *deterministic*: there is exactly one rule per syntactic form, so a given `Γ ⊢ e` has at most one type.
 
 ## Rationale
 
-Keeping `String()` as the only required method on `Type` makes the kind table easy to extend. Equality and unification are external because they need to be customisable for variance and substitution.
+### Why a tagged-union kind catalogue, not a class hierarchy
 
-`AnyType` exists because the alternative is making every builtin generic, which we cannot do until parametric polymorphism ([MEP 12](/docs/mep/mep-0012)) lands. `AnyType` is a debt; it is not a design choice.
+`Type` has one method (`String`). All comparison operators are external. This makes a new kind a one-file change in `types/check.go` (define the struct, give it a `String`, add cases to `unify` and `equalTypes`). A class hierarchy with `Equals` and `Unify` methods would force every comparison to be implemented per-kind, which both inflates the surface area and makes cross-cutting changes (a new universal rule like "`AnyType` unifies with everything") impossible to add in one place.
 
-The numeric tower is conservative on purpose. We prefer to widen to `bigrat` when in doubt rather than silently lose precision.
+The trade is well-known: it is the "expression problem" ([Wadler, 1998](https://homepages.inf.ed.ac.uk/wadler/papers/expression/expression.txt)). The choice optimises for *adding kinds* over *adding operations*, which matches Mochi's actual change history: the kind table has grown several times; the comparison operators have changed three times in three years.
 
-## Backwards Compatibility
+### Why `any` is a wildcard in `unify` but not in `equalTypes`
 
-Informational. No backward compatibility implications.
+This split lets `unify` be the "lenient" relation used at argument sites (where a stricter relation would force most builtins to be parameterised before [MEP 12](/docs/mep/mep-0012) lands) and `equalTypes` be the "strict" relation used by inference rules that have to decide whether to widen. The split is an unsoundness escape hatch (a `*FuncType` parameter accepting `AnyType` will be called with an arbitrary value at runtime), but the alternative is making every builtin generic, which we cannot do today. The cleanup is staged in [MEP 11](/docs/mep/mep-0011).
+
+### Why `int` and `int64` are distinguished
+
+Two reasons. First, the runtime exposes a 64-bit result from `now()`; collapsing the kind would lose the surface annotation that lets callers write `let t: int64 = now()`. Second, future architectures may make 32-bit `int` cheaper than 64-bit `int64`; keeping the kinds apart leaves that door open. The compromise is that arithmetic widens (§3.8) so the distinction does not propagate as a friction point through expressions.
+
+### Why `UnitType` instead of `nil` everywhere
+
+A block-bodied lambda with `Return == nil` in the AST used to be interpreted differently by every consumer: the checker treated it as "infer", the interpreter treated it as "no return", the transpilers had their own rules. Canonicalising at the type level to `UnitType` collapses this into one rule (`Return == nil ⇒ UnitType` at inference time) that consumers can rely on (cf. [MEP 3](/docs/mep/mep-0003) invariant 15).
+
+### Why no first-class type
+
+Reflection is expensive and most of Mochi's target audience (data pipelines, ad-hoc transforms) does not need it. The runtime carries enough tag information for `match` to work; full first-class types would force the runtime to ship a type registry, which raises the per-program startup cost and complicates the transpilers (which would need to emit type-tag machinery).
+
+## Soundness Properties
+
+A program that type-checks under the rules in this MEP has the following properties:
+
+1. **Progress, modulo `any`.** Every closed, well-typed term either is a value or reduces to one, unless it traffics in `AnyType`. `AnyType`-typed terms can fail at runtime with a tag-mismatch error.
+2. **Preservation, modulo `any`.** Reduction preserves the static type for terms not typed at `any`.
+3. **Pattern exhaustiveness is *not* enforced.** A `match` with missing arms passes the checker and produces a runtime error on an unmatched value. See [MEP 13](/docs/mep/mep-0013).
+4. **Pure functions are *flagged*, not enforced.** The `Pure` bit on `FuncType` is computed and propagated; nothing rejects a "pure" function that calls an impure one. [#21188](https://github.com/mochilang/mochi/issues/21188).
+
+The first two properties hold for the subset of programs that never use `any`, generic builtins, or untyped literals as input to operators. The "modulo `any`" phrasing is precise: the bigger the `any` perimeter in a program, the smaller the soundness guarantee.
+
+## Known Problems
+
+This is the full design-problem audit for Mochi's type system as of this revision. Problems are grouped by failure mode. Each entry states what is wrong, gives the evidence (file or example), names the fix, and either points at a tracking issue/MEP or states the fix is in scope for the next revision of this MEP. "Severity" is the worst-case impact: *soundness* (the system claims a guarantee it does not deliver), *coherence* (rules are mutually inconsistent), *representation* (the data shape causes bugs), *API* (the package surface is hard to use correctly), or *ergonomics* (the surface language surprises users).
+
+### 6.1 Soundness gaps
+
+Failures where a well-typed program may go wrong at runtime.
+
+1. **Map lookup returns the zero of `V`.** *Severity: soundness.* `m[k]` for an absent `k` does not return `option[V]`; it returns `V`'s zero. For kinds without a zero (e.g. `StructType` of a union variant), this is a progress violation. Pinned by `tests/types/valid/missing_map_key.mochi`. **Fix:** [MEP 10](/docs/mep/mep-0010) A2 / [#21186](https://github.com/mochilang/mochi/issues/21186).
+2. **List `+` silently widens to `[any]`.** *Severity: soundness.* `[1] + ["x"]` types as `[any]` without a diagnostic, downgrading the soundness of every subsequent operation on the list. **Fix:** [#21187](https://github.com/mochilang/mochi/issues/21187); replace silent widening with a `T015`-style mismatch error.
+3. **`Pure` flag is advisory.** *Severity: soundness (effect-level).* A function with `Pure: true` may call impure functions. The flag is propagated but never asserted. **Fix:** [#21188](https://github.com/mochilang/mochi/issues/21188); make `Pure` a property the checker enforces rather than computes.
+4. **`any` is a wildcard for `unify`.** *Severity: soundness.* `unify(any, T)` and `unify(T, any)` both succeed. This is the single largest source of imprecision; once typed against `any`, every subsequent unification with the same value succeeds. **Fix:** [MEP 11](/docs/mep/mep-0011) introduces a `subtype(s, t)` predicate; `any` becomes the syntactic top of *subtype*, with a deliberate cast at the boundary rather than a free pass through `unify`.
+5. **`null` literal types as `any`.** *Severity: soundness.* `inferPrimaryType` returns `AnyType{}` for `p.Lit.Null` (`types/infer.go` around line 312). This means `let x: User = null` succeeds. **Fix:** [MEP 10](/docs/mep/mep-0010) A2 ties null to `option[T]`; `inferPrimaryType` should return a fresh `OptionType{Elem: TypeVar{}}` and rely on the hint to resolve `Elem`.
+6. **Unknown simple type resolves to `any`.** *Severity: soundness.* `resolveTypeRef` (§3.9) returns `AnyType{}` if a simple name resolves to no struct, union, alias, or variant. A typo (`User`/`Usre`) silently downgrades to `any`. **Fix:** Reject in `resolveTypeRef` with a new `T0xx` "unknown type name" diagnostic. In scope for the next revision.
+7. **`OptionType` is not produced by inference.** *Severity: soundness (composed with gap 1).* The kind is declared and accepted by `resolveTypeRef`, but `inferPostfixType` only emits it for the *read* path of `map[k]`. There is no surface syntax for *constructing* an `option[T]`. **Fix:** Tied to gap 1 and [MEP 10](/docs/mep/mep-0010) A2.
+8. **Comparisons across incompatible kinds.** *Severity: soundness.* `1 == "x"` types as `bool` (always `false` at runtime) rather than raising. **Fix:** Tighten the `==`/`!=` rule in `inferBinaryType` to require either `equalTypes(L, R)` or that both sides are numeric.
+
+### 6.2 Coherence problems
+
+Failures where two relations on the same kinds disagree.
+
+9. **`equalTypes` and `unify` disagree on the numeric ladder.** *Severity: coherence.* `equalTypes(int, int64) == true` (via the carve-out at `types/infer.go:866-871`) but `unify(int, int64) == false` (the `IntType` case in `unify` accepts only `IntType` or `BigIntType`, not `Int64Type`). A caller that switches between the two relations gets different answers. **Fix:** Pick one. The right choice is to remove the `int`/`int64` carve-out from `equalTypes` and require an explicit cast for an `int64`-typed result to bind an `int`-typed variable. This is a breaking change for fixtures that depend on the conflation. Scope: a follow-up commit on this PR after MEP-5 is reviewed for impact.
+10. **`unify` doubles as equality and subtyping.** *Severity: coherence.* Most cases of `unify` are structural equality with `AnyType` and `*TypeVar` as wildcards. But the numeric cases (`IntType` accepting `BigIntType`, `BigRatType` accepting all numeric kinds, etc.) are *subtyping*, written as equality. A caller asking "are these the same?" gets "yes" for `int` and `bigint`, which is the wrong answer. **Fix:** [MEP 11](/docs/mep/mep-0011): split `unify` into a substitution-only relation and a separate `subtype(s, t)` that carries the numeric ladder.
+11. **`equalTypes` is symmetric in spelling but asymmetric in behaviour.** *Severity: coherence.* Each special case is written for both orderings (`isInt64(a) && (isInt64(b) || isInt(b))` *and* `isInt64(b) && (isInt64(a) || isInt(a))`). If a future kind adds a one-directional carve-out, the symmetry must be enumerated manually. **Fix:** Implement `equalTypes` as a single dispatch over the unordered pair, not as two ordered tests.
+
+### 6.3 Representation problems
+
+Failures where the data shape causes bugs in practice.
+
+12. **`StructType.Order` and `StructType.Fields` are redundant.** *Severity: representation.* The kind stores fields twice: once as a `map[string]Type` (`Fields`) and once as `[]string` (`Order`). The map gives O(1) lookup; the slice gives deterministic iteration. They can drift if a future code path updates one and not the other. **Fix:** Replace with a single ordered map (`[]Field` with `{Name string; Type Type}`) and provide an inline lookup helper. In scope for the next revision.
+13. **`UnionType.Variants` is a `map[string]StructType` with no order.** *Severity: representation.* The MEP says "the variant order from the declaration is captured when the type decl is processed", but the field is a Go map, whose iteration order is randomised. Several downstream consumers (compilers emitting `switch` tables, the formatter) need stable order and must reconstruct it from the parser tree. **Fix:** Add `Order []string` (parallel to `StructType.Order`) or switch to an ordered map. In scope for the next revision.
+14. **`StructType.Methods` causes a cycle with `parser.FunStmt`.** *Severity: representation.* `Method.Decl *parser.FunStmt` ties the `types` package to `parser` for method declarations. Any future split of the AST into its own package ([MEP 3](/docs/mep/mep-0003) §"Open questions") must thread this back through `types`. **Fix:** Replace `Decl *parser.FunStmt` with a smaller method-shape struct (`Name`, `Sig FuncType`, `BodyHandle`) that does not name the AST. Scope: tied to the AST extraction work in [MEP 3](/docs/mep/mep-0003).
+15. **`*TypeVar` is the only pointer kind.** *Severity: representation.* Every other kind is a value type with no methods on the pointer receiver. `*TypeVar` is a pointer because it carries identity (two distinct `*TypeVar` values with the same `Name` should be different variables). This special-case forces every `switch t := x.(type)` to spell `case *TypeVar` rather than `case TypeVar`. **Fix:** Either make `TypeVar` a value type and use a fresh-name source for identity, or document the rule that *all* polymorphic kinds use pointer receivers and apply it consistently when more land. In scope for the next revision, dependent on [MEP 12](/docs/mep/mep-0012).
+16. **`Variadic` is a `bool`, not a varargs-element type.** *Severity: representation.* `print(...args: any)` has `Params: [any], Variadic: true`. The "variadic element type" is the *last* element of `Params`, but this is a convention, not a structural property: nothing prevents `Variadic: true` with `len(Params) == 0`. **Fix:** Encode varargs as a dedicated `VariadicElem Type` field separate from the fixed parameters, or change `Params` to a discriminated `(fixed []Type, variadic Type)` pair. In scope for the next revision.
+17. **`reflect.DeepEqual` as the equality fallback is fragile.** *Severity: representation.* `FuncType.Pure`, `StructType.Methods[k].Decl`, and any nested map iteration can produce surprising mismatches under `DeepEqual` because the embedded `*parser.FunStmt` is a deep tree of pointers. Two structurally identical function types from different parses may compare unequal. **Fix:** Replace the fallback with an exhaustive switch over the kinds, removing `reflect.DeepEqual` entirely. In scope for the next revision.
+
+### 6.4 API problems
+
+Failures where the package surface invites misuse.
+
+18. **`types.Env` mixes static and runtime state.** *Severity: API.* The same struct holds `types map[string]Type` (used by the checker), `values map[string]any` (used by the interpreter), and `mut map[string]bool` (used by both). A consumer doing static analysis has to know not to touch `values`. **Fix:** Split into `types.Env` (static) and `runtime.Env` (values) with the latter embedding the former. Scope: a small follow-up MEP; out of scope for this revision.
+19. **`Env.Copy` flattens the parent chain.** *Severity: API.* Closures capture by copy, but the flattening loses scope-shadowing information that downstream tools (`go to definition`, the LSP) rely on. **Fix:** Replace `Copy` with `Snapshot` that returns a sealed-but-still-chained view. Scope: tied to LSP work, out of scope here.
+20. **`Env.SetFunc` lowercases names.** *Severity: API.* The method writes both `name` and `strings.ToLower(name)` into the function map (`types/env.go:262-269`). This is a backwards-compatibility shim for case-insensitive FFI lookups. It pollutes name resolution: `SetFunc("Print", f)` makes both `Print` and `print` lookup-resolvable. **Fix:** Move case-insensitive lookup to the FFI boundary; have `SetFunc` write exactly one key. Scope: requires sweeping the FFI callers; out of scope here.
+21. **`ExprType` is total: it returns `AnyType` on any nil input.** *Severity: API.* A consumer that walks a partially built AST cannot distinguish "no expression" from "expression of type `any`". **Fix:** Return `(Type, bool)` or document explicitly that `nil ⇒ any` is the contract and update [MEP 5](/docs/mep/mep-0005) to match. Scope: tied to [MEP 5](/docs/mep/mep-0005) refresh.
+
+### 6.5 Surface-language problems
+
+Failures that surprise the surface programmer.
+
+22. **No nominal alias kind.** *Severity: ergonomics.* `type Id = int` collapses immediately to `int`. Error messages cannot say "expected `Id`, got `int`"; they say "expected `int`, got `int`" after the resolution step swallows the alias. Recursive aliases (`type T = list<T>`) cannot be expressed at all. **Fix:** Add `AliasType{Name string; Target Type}` that prints as `Name` but unifies as `Target`. Scope: a follow-up MEP after MEP-5 stabilises.
+23. **No tuple kind.** *Severity: ergonomics.* Heterogeneous fixed-length sequences have no surface type. Queries that return tuples must promote to a `StructType` or `[any]`. **Fix:** Add `TupleType{Elems []Type}`. Scope: a follow-up MEP; gated on whether the query rewrite path in [MEP 5](/docs/mep/mep-0005) needs it first.
+24. **No row variable, so width subtyping is by struct name.** *Severity: ergonomics.* You cannot write "a function over any struct with a `name: string` field". **Fix:** Out of scope for this MEP; tracked as a future enhancement in [MEP 11](/docs/mep/mep-0011).
+25. **`unit` is not a surface type.** *Severity: ergonomics.* `UnitType` exists internally but no `let x: unit` is accepted by the parser ([MEP 2](/docs/mep/mep-0002)). The kind is canonical only in *inference*; callers writing function signatures cannot spell "no return" directly. **Fix:** Add `unit` to the simple-type lexer keywords and to `resolveTypeRef`'s switch in §3.9. In scope for the next revision.
+26. **First-class type missing.** *Severity: ergonomics.* `Type` is not a value-level concept. `match v { ... }` is the only form that branches on a runtime tag; there is no `typeof(x)` or `T :: Type` construct. **Fix:** Tracked in §7; not in scope for this MEP.
+
+### 6.6 Documentation problems
+
+Failures of *this* document.
+
+27. **Line numbers go stale.** *Severity: documentation.* Earlier revisions hard-coded `types/check.go:150-387`; refactors moved the function and the doc silently became a lie. **Fix:** The current revision states "around line N" everywhere. Continue this discipline in future edits.
+28. **No formal subtype relation written down.** *Severity: documentation.* The subtype relation is implicit in `unify`'s case bodies. **Fix:** Once [MEP 11](/docs/mep/mep-0011) lands, reference it from §3.6 as the normative source.
+
+## Proposed enhancements
+
+For each problem above the recommended fix is named in-line. The following five are in scope for follow-up commits on this PR (or the next revision of MEP-4), in priority order:
+
+1. Reject unknown simple type names in `resolveTypeRef` (problem 6). Surface as `T0xx`.
+2. Tighten `==`/`!=` on incompatible kinds (problem 8). Surface as `T0xx`.
+3. Add `Order` to `UnionType` for deterministic iteration (problem 13). No surface effect.
+4. Add `unit` as a surface keyword (problem 25). Pure additive.
+5. Replace `StructType.Fields + Order` with an ordered map (problem 12). API change to `types.StructType`; sweep callers.
+
+The remaining problems are gated on the cross-MEP roadmap: MEPs [10](/docs/mep/mep-0010), [11](/docs/mep/mep-0011), [12](/docs/mep/mep-0012), [13](/docs/mep/mep-0013), and the AST extraction in [MEP 3](/docs/mep/mep-0003) §"Open questions".
 
 ## Reference Implementation
 
-- `types/check.go`, `type Type` (around line 12): the interface.
-- `types/check.go`, `IntType` through `FuncType` (around lines 16-140): kind definitions.
-- `types/check.go`, `unify` (around lines 144-381): structural unification.
-- `types/infer.go`, `equalTypes` (around lines 828-876) and `inferBinaryType` (around line 72): operator typing.
-- `types/env.go`: environment API.
+| Concept           | Location                                                                                                  |
+|-------------------|-----------------------------------------------------------------------------------------------------------|
+| `Type` interface  | `types/check.go`, around line 12                                                                          |
+| Kind definitions  | `types/check.go`, `IntType` through `FuncType` (lines 16-140 today)                                        |
+| `unify`           | `types/check.go`, around lines 144-381                                                                    |
+| `equalTypes`      | `types/infer.go`, around lines 828-876                                                                    |
+| `inferBinaryType` | `types/infer.go`, around line 72                                                                          |
+| `resolveTypeRef`  | `types/check.go`, around line 1346                                                                        |
+| Environment       | `types/env.go`                                                                                            |
+| Purity analysis   | `types/pure.go`                                                                                           |
+| Tests             | `types/check_test.go`, `types/mep_obligations_test.go`, `types/mochi_typechecker_test.go`, and the `tests/types/{valid,errors}` golden corpora |
 
-## Pinned decisions
+Line numbers are stated as "around N" so that an unrelated refactor does not silently stale-mark the doc. The function names are stable.
+
+## How to teach this
+
+A learner coming from a language with classes will look for `Class` and find `StructType`; the rest of the kind table is the next ten minutes. A learner coming from Haskell will look for type classes and not find them (they are tracked in [MEP 12](/docs/mep/mep-0012) under "trait constraints"). A learner coming from TypeScript will recognise the structural function arrow and the (small) width subtyping on structs.
+
+The three things that surprise everyone:
+
+1. `any` makes `unify` accept anything, but `equalTypes` rejects everything against `any`. Pick the right relation for the question.
+2. `int` and `int64` are *unifiable* but not *equal*. Comparisons against the equality predicate must allow for the `int64` carve-out.
+3. A function's `Return == nil` after parsing means "the parser left it for inference"; the canonical *type* it inhabits is `UnitType`, not `nil`.
+
+If a reader leaves with those three, the rest of the doc is fluent reading.
+
+## Pinned Decisions
 
 ### Reading a missing map key
 
-Once [MEP 10](/docs/mep/mep-0010) A2 lands, `m[k]` for an absent key will infer to `OptionType{V}`. Callers must unwrap the option before using the value at type `V`.
+Once [MEP 10](/docs/mep/mep-0010) A2 lands, `m[k]` for an absent `k` will type as `option[V]`. Callers will be required to unwrap the option before using the value at type `V`. Three options were considered:
 
-Three options were considered:
-
-1. Type `m[k]` as `V?`. Picked.
-2. Require an explicit default, `m[k] ?? default`, with a checker error otherwise.
+1. Type `m[k]` as `option[V]`. *Picked.*
+2. Require an explicit default `m[k] ?? default`, with a checker error otherwise.
 3. Raise a typed runtime panic.
 
-Option 1 wins because it reuses the same `OptionType` shape that [MEP 10](/docs/mep/mep-0010) A2 gives `null` and [MEP 10](/docs/mep/mep-0010) C1 gives the `T?` shorthand. Option 2 needs a new operator; option 3 forces `in m` guards at every call site.
+Option 1 reuses the `OptionType` shape that [MEP 10](/docs/mep/mep-0010) A2 gives `null` and that [MEP 10](/docs/mep/mep-0010) C1 gives the `T?` shorthand. Option 2 needs a new operator and a per-callsite annotation. Option 3 forces an `in m` guard at every call site.
 
-Today the runtime returns the zero value of `V`. For non-zero-bearing types this is a progress violation. The current behaviour is pinned by `tests/types/valid/missing_map_key.mochi`; the future tightening is a deliberate breaking change tracked in [#21186](https://github.com/mochilang/mochi/issues/21186) alongside [MEP 10](/docs/mep/mep-0010) A2.
+Today the runtime returns the zero of `V`. For non-zero-bearing types this is a progress violation. The current behaviour is pinned by `tests/types/valid/missing_map_key.mochi`; the future tightening is a deliberate breaking change tracked in [#21186](https://github.com/mochilang/mochi/issues/21186) alongside [MEP 10](/docs/mep/mep-0010) A2.
+
+### `unit` rather than `void`
+
+The historical name was `VoidType` with surface form `void`. The rename to `UnitType` / `unit` (PR [#21221](https://github.com/mochilang/mochi/pull/21221)) removes the "nil means infer, not void" footgun documented at [MEP 3](/docs/mep/mep-0003) invariant 15. The rename is internal to Mochi; transpilers that emit `void` as a *target* language keyword (Go, Java, C, C++, C#, Dart) keep doing so.
 
 ## Open Questions
 
-- **Tuple kind.** No surface type for heterogeneous fixed-length sequences. Needed once query result tuples are generalised.
-- **Option kind.** `OptionType` exists but is not produced by inference today. Tied to the `null` soundness gap in [MEP 10](/docs/mep/mep-0010).
-- **Numeric ordering.** `float` and `bigrat` mix awkwardly. No decision yet on whether to widen to `bigrat` or reject the mix.
+- **Tuple kind.** There is no surface type for heterogeneous fixed-length sequences. Query result tuples promote to `[any]` or a generated struct. A `TupleType{Elem []Type}` would be the obvious addition; the trade is the additional unify and equality cases.
+- **Numeric ordering.** Mixing `float` and `bigrat` lands at `bigrat` today (§3.8). It is not obvious that this is the right choice; widening to `float` would preserve operator behaviour with the host architecture's primitives, while staying at `bigrat` preserves precision.
+- **Should `resolveTypeRef` reject unknown names?** Today it falls through to `AnyType`. A strict mode would surface typos at the type-resolution site.
+- **First-class generics on builtins.** `len`, `first`, `push` are declared with `any`-typed parameters. With [MEP 12](/docs/mep/mep-0012) they would become `len<T>(x: [T] | map<K, T> | string): int` and similar. The remaining question is the surface syntax: explicit type parameters (`len[int](xs)`) versus inference-only.
+
+## Future Work
+
+The roadmap intersects this MEP at four points:
+
+- [MEP 5](/docs/mep/mep-0005): Per-construct inference rules. Refines §3.10.
+- [MEP 10](/docs/mep/mep-0010): Catalogue of soundness gaps including the ones in §6.
+- [MEP 11](/docs/mep/mep-0011): A clean `subtype(s, t)` predicate replacing the `any` wildcard in `unify`.
+- [MEP 12](/docs/mep/mep-0012): Parametric polymorphism wiring `TypeVar` through call sites.
+
+When any of those lands, the relevant subsection here will be updated and an explicit cross-link to the implementing PR added.
+
+## Backwards Compatibility
+
+Informational. This MEP documents the type system as of [#21221](https://github.com/mochilang/mochi/pull/21221) and the subsequent doc sync ([#21223](https://github.com/mochilang/mochi/pull/21223)). Future revisions that change behaviour (rather than documentation) must announce the break in their own MEP and cross-link from here.
 
 ## References
 
-- [MEP 5](/docs/mep/mep-0005): how these kinds are produced by inference.
-- [MEP 10](/docs/mep/mep-0010): soundness gaps these kinds expose.
+### Programming language theory
+
+- [Pierce, Benjamin C. *Types and Programming Languages.* MIT Press, 2002.](https://www.cis.upenn.edu/~bcpierce/tapl/) Chapters 8 ("Typed Arithmetic Expressions") and 11 ("Simple Extensions") cover the core; chapter 15 ("Subtyping") covers the relation Mochi's `unify` plays with.
+- [Harper, Robert. *Practical Foundations for Programming Languages.* CUP, 2016.](https://www.cs.cmu.edu/~rwh/pfpl.html) Chapters 4 ("Statics") and 11 ("Sums") for the formal judgement notation we use.
+- [Cardelli, Luca, and Wegner, Peter. "On Understanding Types, Data Abstraction, and Polymorphism." *Computing Surveys*, 17(4), 1985.](https://dl.acm.org/doi/10.1145/6041.6042) The taxonomy of polymorphism that informs §3.2 (`AnyType`, `TypeVar`).
+- [Wadler, Philip. "The Expression Problem." 1998.](https://homepages.inf.ed.ac.uk/wadler/papers/expression/expression.txt) The trade-off behind the tagged-union kind catalogue.
+- [Damas, Luis, and Milner, Robin. "Principal type-schemes for functional programs." *POPL 1982.*](https://dl.acm.org/doi/10.1145/582153.582176) The original Hindley-Milner algorithm; Mochi's `unify` is a small subset, intentionally not yet doing principal-types inference.
+- [Reynolds, John C. "Towards a Theory of Type Structure." *Programming Symposium, 1974.*](https://link.springer.com/chapter/10.1007/3-540-06859-7_148) For the underlying notion of "kind" used in §3.2.
+
+### Cross-MEP
+
+- [MEP 2 (Grammar)](/docs/mep/mep-0002). Where the surface syntax that this MEP types is defined.
+- [MEP 3 (AST)](/docs/mep/mep-0003). The tree this MEP types. Invariant 15 (FunExpr default return) is load-bearing here.
+- [MEP 5 (Inference)](/docs/mep/mep-0005). The per-construct rules.
+- [MEP 10 (Known Gaps)](/docs/mep/mep-0010). The wider gap catalogue.
+- [MEP 11 (Subtyping)](/docs/mep/mep-0011). The `subtype` predicate that will replace `any`'s wildcard role.
+- [MEP 12 (Polymorphism)](/docs/mep/mep-0012). The plan for wiring `TypeVar`.
+- [MEP 13 (Pattern matching)](/docs/mep/mep-0013). The exhaustiveness work.
 
 ## Copyright
 

--- a/website/docs/mep/mep-0004.md
+++ b/website/docs/mep/mep-0004.md
@@ -8,57 +8,42 @@ created: 2026-05-08
 revised: 2026-05-11
 sidebar_position: 4
 sidebar_label: MEP 4. Type System
-description: Kinds, judgements, equality, unification, the numeric tower, and the soundness perimeter of Mochi's static type system.
+description: The kinds, the comparisons, the numeric tower, and the places where Mochi's type system does not yet do what it claims.
 ---
 
 # MEP 4. Type System
 
-| Field    | Value                                  |
-|----------|----------------------------------------|
-| MEP      | 4                                      |
-| Title    | Type System                            |
-| Author   | Mochi core                             |
-| Status   | Informational                          |
-| Type     | Informational                          |
-| Created  | 2026-05-08                             |
-| Revised  | 2026-05-11                             |
+| Field    | Value           |
+|----------|-----------------|
+| MEP      | 4               |
+| Title    | Type System     |
+| Author   | Mochi core      |
+| Status   | Informational   |
+| Type     | Informational   |
+| Created  | 2026-05-08      |
+| Revised  | 2026-05-11      |
 | Requires | [MEP 2](/docs/mep/mep-0002), [MEP 3](/docs/mep/mep-0003) |
 | Informs  | [MEP 5](/docs/mep/mep-0005), [MEP 10](/docs/mep/mep-0010), [MEP 11](/docs/mep/mep-0011), [MEP 12](/docs/mep/mep-0012) |
 
 ## Abstract
 
-Mochi has a small, mostly monomorphic type system with nominal records and unions, a structural function arrow, and an explicit top type (`any`) used as an escape hatch where the checker cannot yet do better. This MEP catalogues the type kinds, fixes the equality and unification rules, states the numeric tower and operator typing as a single normative table, gives a typing judgement notation, and lists the soundness gaps that callers may not assume away. It is the contract every later type-system MEP refines, not replaces.
+Mochi has a small type system: a handful of primitive kinds, lists and maps, nominal records and unions, a function arrow, and `any` as the escape hatch. There is no global solver. Equality, unification, and the numeric ladder are spelled out as code, not derived from a calculus. That makes the system easy to extend and easy to misread, and this document is the place to fix the misreading. The rules below are normative for consumers; the problem list near the end is the audit of what the system claims and what it actually delivers.
 
 ## Motivation
 
-The type system is the interface between the parser ([MEP 3](/docs/mep/mep-0003)) and every downstream consumer: the inference rules ([MEP 5](/docs/mep/mep-0005)), the runtime, the transpilers, and the documentation. Misunderstanding any one of the following produces soundness regressions that are hard to diagnose later:
+Most of the surprises in a small type system are not in the kinds, they are in the relations between kinds. Two of Mochi's relations, `unify` and `equalTypes`, disagree about whether `int` is the same type as `int64`. The function-purity flag is computed but never enforced. Reading a missing map key returns the zero value of the element type, which is fine for `int` and broken for a struct without a sensible zero. These are not abstract concerns. They are the kind of thing a reader of `types/check.go` will discover by accident, and a reader of the previous version of this document would not have learned at all.
 
-- Whether `int` and `int64` are *equal* or merely *unifiable*.
-- Whether `any` is a *top*, a *bottom*, or neither.
-- Whether `unify` performs *equality*, *subtyping*, or *both* depending on caller.
-- Which kinds exist *as types* versus which exist *only as runtime values*.
-
-This MEP fixes one answer per question and points at the code that implements it. Future revisions to the implementation must either keep the answer or update this document.
+A type system is a contract between the parser and everything downstream. When the contract is documented vaguely, downstream consumers end up encoding their own assumptions and the assumptions diverge. The point of this MEP is to write the contract down once, in language that survives a refactor.
 
 ## Terminology
 
-We use the standard programming-language-theory vocabulary throughout. The following short glossary pins the meaning we use in this document; see [Pierce, *Types and Programming Languages*](https://www.cis.upenn.edu/~bcpierce/tapl/), and [Harper, *Practical Foundations for Programming Languages*](https://www.cs.cmu.edu/~rwh/pfpl.html) for the canonical treatment.
+A few words are used throughout with their standard programming-language-theory meaning. *Kind* means a category of types, in the sense of [Pierce, TAPL](https://www.cis.upenn.edu/~bcpierce/tapl/) chapter 29: `IntType` is a kind, `ListType` is a kind constructor, and the language has no kind-of-kinds. *Nominal* types are equal only when their names match; *structural* types are equal when their shapes match. Mochi's records are nominal, its function arrows are structural. *Top* is the type every value is convertible to; in Mochi this is `any`. The judgement `Γ ⊢ e : τ` reads "under environment Γ, expression e has type τ" and is used in the inference rules below.
 
-- **Type.** A static classifier for values. In Mochi every type implements the Go interface `Type` (see §3.1).
-- **Kind.** A category of types. Mochi's kinds are primitive (`int`, `bool`, etc.), structural (`list`, `map`), nominal (`StructType`, `UnionType`), function (`FuncType`), polymorphic (`TypeVar`), top (`AnyType`), and unit (`UnitType`). We say "kind" rather than "type constructor family" for brevity; the formal kind system is implicit.
-- **Nominal.** A type whose identity is its declared name. Two `StructType` values with the same field set but different `Name` fields are *not* equal.
-- **Structural.** A type whose identity is its shape. `ListType{Elem: IntType{}}` and a freshly constructed `ListType{Elem: IntType{}}` are equal.
-- **Monomorphic.** Without unresolved type variables. Most of Mochi today is monomorphic at use sites; `TypeVar` exists but is not yet propagated by inference (see [MEP 12](/docs/mep/mep-0012)).
-- **Top type.** A type that every other type is convertible to. In Mochi this is `AnyType`. It is a top *by `unify`*, but only equal-to-itself *by `equalTypes`*. See §3.5.
-- **Subtype, supertype.** `S ≤ T` reads "S is a subtype of T". Mochi has a small built-in subtype relation today (Int ≤ Int64 ≤ BigInt; struct variants ≤ union; etc.) and a proposed clean predicate in [MEP 11](/docs/mep/mep-0011).
-- **Unification.** A symmetric procedure that produces a substitution under which two types become structurally equal, or fails. Mochi's `unify` (§3.6) additionally treats `AnyType` as a wildcard.
-- **Typing judgement.** A statement of the form `Γ ⊢ e : τ`: under environment `Γ`, expression `e` has type `τ`. See §3.10.
+One word is being retired. The kind that used to be called `void`, and is the result type of `print` and the default for a block-bodied function without a return annotation, is now `unit`. The rename landed in [#21221](https://github.com/mochilang/mochi/pull/21221) and is documented as [MEP 3](/docs/mep/mep-0003) invariant 15. The old name still appears in target-language transpilers where it is the *target* language's keyword, not Mochi's type.
 
-A note on words we *avoid*: "void" was the historical name for the unit type. It is now `unit` to remove the special case where `Return == nil` in the AST had to be reinterpreted as "no return value" by every consumer (see [MEP 3](/docs/mep/mep-0003) §"Soundness Enforced" invariant 15 and [#21221](https://github.com/mochilang/mochi/pull/21221)).
+## The Type interface
 
-## Specification
-
-### 3.1 The `Type` interface
+Every kind satisfies one Go interface:
 
 ```go
 type Type interface {
@@ -66,398 +51,259 @@ type Type interface {
 }
 ```
 
-Every kind implements `String()` and nothing else. Equality, unification, and subtyping are *external* operations defined over the kind cases, not methods on the interface. This is a deliberate trade: it keeps the kind table easy to extend (a new kind requires one constructor and one `String()`) at the cost of forcing the comparison operators to enumerate cases. The trade is worth taking because the kind table changes more often than the comparison operators do.
+Nothing else. Equality, unification, and subtyping are functions defined over the kind cases, not methods on the interface. This is a trade: adding a kind is a small change in `types/check.go` (define the struct, add a `String` method, add cases to `unify` and `equalTypes`) while adding a comparison rule touches every kind. The trade favours the change that happens more often, which in Mochi has been kind additions.
 
-### 3.2 Kind inventory
+## Kinds
 
-The full kind catalogue, in source order at `types/check.go` (the block runs from `IntType` through `FuncType.String()`):
+The catalogue lives in `types/check.go` and runs from `IntType` through `FuncType.String()`. The kinds split into six groups.
 
-#### Primitive kinds
+Primitive kinds carry no parameters. `IntType` is the default integer width and prints as `int`; the runtime stores it in a Go `int64` but the surface name stays `int`. `Int64Type` exists to give `now()` a return type that is honestly 64-bit, and to leave the door open if a future port wants to make `int` cheaper than `int64`. `FloatType` is IEEE 754 binary64. `BigIntType` and `BigRatType` are arbitrary precision integer and rational respectively. `StringType` is a UTF-8 byte sequence; the runtime adds rune-aware operations on top. `BoolType` is two-valued. `UnitType`, printed as `unit`, is the result of statement-only operations and the canonical default return for a block-bodied function with no annotation.
 
-| Kind         | Surface name | Notes                                                                                                                                                |
-|--------------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `IntType`    | `int`        | Default integer width. Backed by Go `int64` at runtime; the surface name is `int`.                                                                   |
-| `Int64Type`  | `int64`      | Distinguished where the runtime exposes 64-bit results (`now()`). Unifies with `IntType` for arithmetic but is not equal to it under `equalTypes`.   |
-| `FloatType`  | `float`      | IEEE 754 binary64.                                                                                                                                   |
-| `BigIntType` | `bigint`     | Arbitrary precision integer.                                                                                                                         |
-| `BigRatType` | `bigrat`     | Arbitrary precision rational.                                                                                                                        |
-| `StringType` | `string`     | UTF-8 byte sequence with rune-aware operations at the runtime layer.                                                                                 |
-| `BoolType`   | `bool`       | Two-valued.                                                                                                                                          |
-| `UnitType`   | `unit`       | Result of statement-only operations (`print`, `json`) and the canonical default return of a block-bodied function with no annotation (cf. [MEP 3](/docs/mep/mep-0003) invariant 15). |
+Structural kinds carry parameters and are equal by shape. `ListType{Elem}` is a homogeneous ordered sequence indexable from zero. `MapType{Key, Value}` is an unordered hash map. `OptionType{Elem}` is declared and accepted by the type resolver, but is not produced by inference today except for the read path of `m[k]`. `GroupType{Key, Elem}` is internal, carried by the `into Name` clause of a `group by` query; it shows up in [MEP 5](/docs/mep/mep-0005) and rarely outside the inference layer.
 
-#### Structural kinds
+Nominal kinds are equal by name. `StructType` carries `Name`, a `Fields map[string]Type`, an `Order []string` that preserves declaration order so JSON encoding is deterministic, and a `Methods map[string]Method` table. `UnionType` carries `Name` and `Variants map[string]StructType`; the variant order from the declaration is captured at type-declaration time but the map itself is unordered (see the problem list).
 
-| Kind         | Surface name        | Notes                                                                                                                |
-|--------------|---------------------|----------------------------------------------------------------------------------------------------------------------|
-| `ListType`   | `[T]`               | Homogeneous, ordered, indexable from `0`.                                                                            |
-| `MapType`    | `map<K, V>`         | Unordered hash map keyed by `K`.                                                                                     |
-| `OptionType` | `option[T]`         | Currently *declared* but not *produced* by inference. Lookup `m[k]` returns the zero of `V` today (see §6 gap 3).    |
-| `GroupType`  | `group`             | Internal: carried by the `into Name` clause of a `group by` query in [MEP 5](/docs/mep/mep-0005).                    |
+The function kind is `FuncType{Params, Return, Pure, Variadic}`. `Pure` is propagated but not enforced, tracked in [#21188](https://github.com/mochilang/mochi/issues/21188). `Variadic` is a bool that means "the last entry of `Params` is repeated"; nothing prevents a `FuncType` from carrying `Variadic: true` with an empty `Params`, which the language never produces but the type does not forbid.
 
-#### Nominal kinds
+The polymorphism kind is `TypeVar{Name}`, the only kind whose `String` method has a pointer receiver. It carries a name and exists for the surface syntax of generics; inference does not yet propagate it through call sites. The plan to wire it up is [MEP 12](/docs/mep/mep-0012).
 
-| Kind         | Surface name | Notes                                                                                                                                 |
-|--------------|--------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| `StructType` | `Name`       | Record. `Name`, `Fields map[string]Type`, `Order []string` (declaration order, preserved for deterministic JSON), `Methods`.          |
-| `UnionType`  | `Name`       | Closed sum of struct-shaped variants. `Variants map[string]StructType`; iteration order is captured from the type declaration.        |
+The top kind is `AnyType{}`. It prints as `any` and behaves as a wildcard in `unify` (in both directions) and as equal-only-to-itself in `equalTypes`. The split is the largest single source of imprecision in the system and is documented in detail in [MEP 11](/docs/mep/mep-0011).
 
-#### Function kind
+A few absences are worth naming explicitly. There is no nominal alias kind; `type Id = int` collapses to `int` at resolve time, which means a checker error message cannot say "expected `Id`, got `int`". There is no tuple kind; heterogeneous fixed-length sequences either get a generated struct or fall back to `[any]`. There is no row variable; width subtyping is decided by struct name plus field set. There is no effect kind; purity is a flag, not a row. There is no reference kind; mutability is a property of the binding (`var` versus `let`), not of the type. There is no first-class type; types are not values.
 
-| Kind       | Surface name              | Notes                                                                                                                                  |
-|------------|---------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
-| `FuncType` | `fun(A, B): R [pure]`     | `Params []Type`, `Return Type`, `Pure bool`, `Variadic bool`. `Pure` is computed but not enforced ([#21188](https://github.com/mochilang/mochi/issues/21188)). `Variadic` is exercised by `concat`, `range`, `print`. |
+## The typing context
 
-#### Polymorphism kind
+The environment Γ is `types.Env` in `types/env.go`. It is a linked stack of frames. Each frame holds maps for variable types, mutability flags, function declarations, struct types, union types, stream row types, agent declarations, and model aliases, plus a map of runtime values that the static checker should ignore. Lookups walk parents on miss. Scopes close by replacing `env` with `env.parent`. The runtime-values map is on the same struct as the static-type map, which is convenient for the interpreter and a layering wart for everything else; the problem list returns to this.
 
-| Kind      | Surface name | Notes                                                                                                          |
-|-----------|--------------|----------------------------------------------------------------------------------------------------------------|
-| `TypeVar` | `T`, `U`, ...| Pointer type (`*TypeVar`). Carried by generic function declarations; not yet propagated by inference. See [MEP 12](/docs/mep/mep-0012). |
+## Equality
 
-#### Top kind
+`equalTypes(a, b)` in `types/infer.go` (around line 828) decides whether two types are the same. The rules:
 
-| Kind      | Surface name | Notes                                                                                                                                               |
-|-----------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `AnyType` | `any`        | Behaves as a top type for `unify` (both directions). For `equalTypes` it is equal only to itself. This split is intentional but unsound; see [MEP 11](/docs/mep/mep-0011). |
+`any` is equal only to `any`. If either side is `AnyType`, the other side must also be. This is the strict reading of `any`; it is not the reading `unify` uses.
 
-### 3.3 What does *not* exist as a kind
+Composite kinds recurse on their parameters. `[T]` equals `[U]` when `T` equals `U`; map and option follow the same pattern.
 
-Listing the explicit absences keeps consumers honest. None of the following are kinds today:
+A `UnionType` is equal to a `StructType` whose name appears in the union's variants. This is what lets a `match` arm typed at a variant satisfy a union-typed binding.
 
-- **Nominal alias.** `type Id = int` is collapsed at type-resolution time to its target. There is no `AliasType` constructor.
-- **Tuple.** A heterogeneous fixed-length sequence has no surface type. Queries that produce tuples promote to `[any]` or to a generated `StructType`.
-- **Row variable.** Width subtyping is decided by name plus field set, not by an explicit row variable.
-- **Effect.** Purity is a flag on `FuncType`, not its own kind. There is no effect row.
-- **Reference / cell.** Mutability is a property of the *binding* (`var` vs `let`), not of the type. The type of a `var x: int` binding is `IntType`, not `Ref<IntType>`.
-- **Existential, universal.** Beyond `TypeVar` for parametric polymorphism, no quantification kinds exist.
-- **First-class type.** Types are not first-class values. There is no `Type: Type` reflection layer.
+The `int`/`int64` carve-out treats the two as equal in both directions, and either of them as equal to itself reflexively. This is the only place in the system where two distinct numeric kinds are conflated at the equality layer rather than only at the operator layer. The carve-out exists because `now()` returns `int64` and code that writes `let t = now()` would otherwise see a type-mismatch when `t` is later used in an `int` context. The cost is that `equalTypes` and `unify` disagree on this case; the problem list comes back to it.
 
-[MEP 10](/docs/mep/mep-0010) tracks which of these are gaps versus deliberate design.
+Everything else falls through to `reflect.DeepEqual`, which works because `StructType` names are unique and `FuncType` field sets are simple. The fallback is fragile around `Methods` because `Method.Decl` is a `*parser.FunStmt` and `DeepEqual` will walk the whole AST tree. In practice this has not bitten yet, but it is the kind of bug that surfaces months after it lands.
 
-### 3.4 The typing context
+## Unification
 
-The environment `Γ` is implemented by `types.Env` (`types/env.go`). It is a linked stack of frames; lookups consult the current frame, then walk to the parent. Each frame holds:
+`unify(a, b, subst)` in `types/check.go` (around lines 144 to 381) is the relation the checker uses to decide whether two types can be reconciled at an argument site or a branch boundary. It is not the same relation as `equalTypes`; the two were originally written for different jobs and have drifted.
 
-| Map         | Key            | Value                       | Purpose                                                                 |
-|-------------|----------------|-----------------------------|-------------------------------------------------------------------------|
-| `types`     | identifier     | `Type`                      | Variable and function types.                                            |
-| `mut`       | identifier     | `bool`                      | Whether the binding is mutable (`var`) or immutable (`let`).            |
-| `values`    | identifier     | `any`                       | Runtime values, used by the interpreter; ignored by the static checker. |
-| `funcs`     | identifier     | `*parser.FunStmt`           | Function declarations.                                                  |
-| `structs`   | type name      | `StructType`                | User-declared records.                                                  |
-| `unions`    | type name      | `UnionType`                 | User-declared sums.                                                     |
-| `streams`   | stream name    | `StructType`                | Declared stream row types.                                              |
-| `agents`    | agent name     | `*parser.AgentDecl`         | Agent declarations.                                                     |
-| `models`    | alias          | `ModelSpec`                 | LLM model aliases.                                                      |
+The rules.
 
-The static type checker uses `types`, `mut`, `funcs`, `structs`, `unions`, `streams`, and `agents`. The remaining maps are runtime concerns surfaced on the same struct.
+`any` is a wildcard in both directions. `unify(any, T) == unify(T, any) == true`. This is the escape hatch. A function typed `(any) -> any` accepts any argument and returns a value the caller has to take on faith. Tightening this without breaking too much existing code is the main job of [MEP 11](/docs/mep/mep-0011).
 
-### 3.5 Equality
+`*TypeVar` either substitutes through `subst` or, when `subst` is nil, succeeds only against another `*TypeVar` with the same name. The substitution carries instantiations across a single unify call; nested calls share the same map so a variable bound at one position is observed at the next.
 
-`equalTypes(a, b Type) bool` in `types/infer.go` (around line 828) decides nominal equality plus a small set of carve-outs. The exact rules in source order:
+Composite kinds recurse on their components. `[T]` unifies with `[U]` when `T` unifies with `U`. Map, option, group, and function arrows follow the same shape.
 
-1. **`any` only equals `any`.** If either side is `AnyType`, the other must be `AnyType` too.
-2. **List equality is element equality.** `[T] = [U]` iff `equalTypes(T, U)`.
-3. **Map equality is component-wise.** `map<K1, V1> = map<K2, V2>` iff `equalTypes(K1, K2) && equalTypes(V1, V2)`.
-4. **Option equality is element equality.** `option[T] = option[U]` iff `equalTypes(T, U)`.
-5. **Union ⊇ Struct variant.** A `UnionType` is equal to a `StructType` whose name appears in `Variants`. This is what allows `match` arms typed as variant structs to satisfy a union binding.
-6. **`int64`/`int` interop.** `Int64Type = Int64Type | IntType` and the symmetric case. This is the single place in the type system where numeric widths are conflated at the equality layer (rather than only at the operator layer).
-7. **Two `int`s are equal.** Reflexive case for `IntType`.
-8. **Otherwise, `reflect.DeepEqual`.** Function types, struct types with identical content, and the rest reduce to DeepEqual. In practice, `StructType` names are unique within a scope so this collapses to name equality for structs.
+A `StructType` unifies with a `StructType` when their names agree, or either is anonymous, and the field maps match component-wise. A `StructType` unifies with a `UnionType` when the struct's name appears in the variant set, in which case it unifies with that variant. Two `UnionType` values unify only when their names agree.
 
-Equality is *not* symmetric in the special-cased rules. The symmetric clauses are written out explicitly; if a future kind is added that needs a symmetric carve-out, both directions must be enumerated.
+The numeric kinds form a small subtyping ladder inside `unify`. `IntType` unifies with `IntType` or `BigIntType`. `Int64Type` unifies with `Int64Type` or `IntType`. `BigIntType` unifies with the integer family. `BigRatType` unifies with the entire integer-and-float chain. `FloatType` unifies only with itself. This is the *unification view* of the tower; the *operator view* below is different again. `UnitType`, `StringType`, and `BoolType` are reflexive only.
 
-### 3.6 Unification
+The shape of `unify` is "structural equality with `any` and `TypeVar` as wildcards", except for the numeric ladder, which is one-directional subtyping written in the same machine. The asymmetry is the second problem on the list and the proximate cause of the disagreement with `equalTypes`.
 
-`unify(a, b Type, subst Subst) bool` in `types/check.go` (around lines 144-381) is the workhorse used by the type checker wherever two types must be reconciled (argument vs. parameter, branch vs. expected, etc.). It is *not* the same relation as `equalTypes`. Its rules:
+## The numeric tower
 
-1. **`any` is a wildcard.** If either side is `AnyType`, `unify` succeeds. This is the soundness escape hatch ([MEP 10](/docs/mep/mep-0010), [MEP 11](/docs/mep/mep-0011)).
-2. **`TypeVar` substitutes.** A `*TypeVar` on either side either binds via `subst` or, if `subst == nil`, succeeds only against the same `TypeVar` by name. The substitution map carries instantiations across a single unify call.
-3. **Composite kinds recurse.** `ListType`, `MapType`, `OptionType`, `GroupType`, `FuncType` unify component-wise.
-4. **`StructType` ↔ `StructType`.** Unifies if names match (or either is unnamed) and the field maps match component-wise.
-5. **`StructType` ↔ `UnionType`.** Unifies if the struct's name is among the union's variants, in which case it unifies with that variant.
-6. **`UnionType` ↔ `UnionType`.** Unifies iff their names are equal.
-7. **Numeric ladder.** `IntType` unifies with `IntType` or `BigIntType`. `Int64Type` unifies with `Int64Type` or `IntType`. `BigIntType` unifies with `BigIntType`, `IntType`, or `Int64Type`. `BigRatType` unifies with the entire integer-and-float chain. `FloatType` unifies only with `FloatType`. This is the *unification view* of the numeric tower (see §3.7 for the *operator view*).
-8. **`UnitType`, `BoolType`, `StringType`.** Reflexive only.
-
-The asymmetric `any` rule (`unify(t, any) = unify(any, t) = true`) is the load-bearing escape hatch behind most of Mochi's pragmatism. It is also the load-bearing reason the system is not fully sound ([MEP 11](/docs/mep/mep-0011) proposes a replacement).
-
-### 3.7 The numeric tower
-
-Three relations coexist on numeric kinds, and they are not the same:
+Three relations on numeric kinds coexist and they are not the same:
 
 ```
-Equality (§3.5):  int = int                 int = int64                 (the only conflations)
-Unify   (§3.6):  IntType ↔ {IntType, BigIntType}
-                 Int64Type ↔ {Int64Type, IntType}
-                 BigIntType ↔ {BigIntType, IntType, Int64Type}
-                 BigRatType ↔ {BigRatType, FloatType, IntType, Int64Type, BigIntType}
-                 FloatType ↔ {FloatType}
-Operator widening (§3.8):  see table
+Equality:           int == int                 int == int64        (the only equal pairs)
+Unification:        IntType    <-> {IntType, BigIntType}
+                    Int64Type  <-> {Int64Type, IntType}
+                    BigIntType <-> {BigIntType, IntType, Int64Type}
+                    BigRatType <-> {BigRatType, FloatType, IntType, Int64Type, BigIntType}
+                    FloatType  <-> {FloatType}
+Operator widening:  see the operator table below
 ```
 
-The unify and operator views diverge deliberately: an `int + float` widens to `float` at the operator layer, but `IntType` does *not* unify with `FloatType`. The reason is that operators produce a fresh result type by the widening rule, whereas unify is asked at *argument-passing* sites where silent widening would lose information.
+The unification view and the operator view diverge on purpose. An `int + float` widens to `float` at the operator layer because that is the result of the addition; nothing has been *assigned* anywhere, so widening is harmless. At an argument site, where the type of the receiving variable is fixed, the same widening would silently drop precision, so `unify(IntType, FloatType)` is false. This split is principled and worth keeping. The split between `equalTypes` and `unify` on `int`/`int64` is not principled and is on the problem list.
 
-### 3.8 Operator typing
+## Operator typing
 
-The normative table for binary operators is the body of `inferBinaryType` in `types/infer.go` (around line 72). Precedence is decided by the parser ladder ([MEP 2](/docs/mep/mep-0002)); the table below is the per-operator *result type* once both operands have been inferred.
+`inferBinaryType` in `types/infer.go` (around line 72) decides the result type of a binary expression once both operands have been inferred. Precedence is decided by the parser ladder ([MEP 2](/docs/mep/mep-0002)); the table below is per-operator.
 
-Let `L` and `R` be the operand types. `+, -, *, /, %`:
+Arithmetic operators (`+`, `-`, `*`, `/`, `%`):
 
-| Rule                                                                                       | Result          | Notes                                                                  |
-|--------------------------------------------------------------------------------------------|-----------------|------------------------------------------------------------------------|
-| `/` and both sides `int`                                                                   | `int`           | Integer division.                                                      |
-| One side `int64` and the other `int` or `int64`                                            | `int64`         | Widens to 64-bit.                                                      |
-| Either side `bigrat`                                                                       | `bigrat`        | Widens to arbitrary precision rational.                                |
-| Either side `float`, both sides any of `int`, `int64`, `float`                             | `float`         | IEEE 754 widening.                                                     |
-| Either side `bigint`                                                                       | `bigint`        | Arbitrary precision integer widening.                                  |
-| Both sides `int`                                                                           | `int`           | Reflexive.                                                             |
-| `+` with both sides list and element types equal                                           | `[T]`           | Same-typed concatenation.                                              |
-| `+` with both sides list, element types differ                                             | `[any]`         | Silent widening. Soundness gap [#21187](https://github.com/mochilang/mochi/issues/21187). |
-| `+` with both sides string                                                                 | `string`        | String concatenation.                                                  |
-| Otherwise                                                                                  | `any`           | Pragmatic fallback.                                                    |
+| Operand shape                                              | Result   |
+|------------------------------------------------------------|----------|
+| `/` with both sides `int`                                  | `int`    |
+| One side `int64`, the other `int` or `int64`               | `int64`  |
+| Either side `bigrat`                                       | `bigrat` |
+| Either side `float`, both sides numeric                    | `float`  |
+| Either side `bigint`                                       | `bigint` |
+| Both sides `int`                                           | `int`    |
+| `+` on two lists with equal element type                   | `[T]`    |
+| `+` on two lists with differing element type               | `[any]`  |
+| `+` on two strings                                         | `string` |
+| Otherwise                                                  | `any`    |
 
-Comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`) return `bool`. They do not currently check that both operands are comparable; mixed-kind comparisons return `bool` regardless.
+The list `+` row that widens to `[any]` is a soundness gap, [#21187](https://github.com/mochilang/mochi/issues/21187). The general "otherwise → any" row is broader than is sound; tightening it is gated on [MEP 11](/docs/mep/mep-0011).
 
-Logical operators (`&&`, `||`) return `bool` when both operands are `bool`, otherwise `any`. The `any` fallback is more permissive than is sound; tightening it is gated on [MEP 11](/docs/mep/mep-0011).
+Comparison (`==`, `!=`, `<`, `<=`, `>`, `>=`) always returns `bool`. The checker does not currently require the operands to be comparable, so `1 == "x"` types as `bool` rather than producing a diagnostic.
 
-The membership operator `in` returns `bool` when the right operand is `map`, `list`, or `string`, otherwise `any`.
+Logical (`&&`, `||`) returns `bool` when both operands are `bool` and `any` otherwise. Membership (`in`) returns `bool` when the right side is a list, map, or string and `any` otherwise. The query set operators (`union`, `union_all`, `except`, `intersect`) take two lists and produce the list of equal element type, or `[any]` when the element types disagree.
 
-Set-style operators on query results (`union`, `union_all`, `except`, `intersect`) take two lists and return the same list type when element types agree, `[any]` otherwise (the same silent widening as `+` on lists).
+## Type formation
 
-### 3.9 Type formation
+`resolveTypeRef(t *parser.TypeRef, env *Env)` in `types/check.go` (around line 1346) maps surface type references into the kind catalogue. The four cases are straightforward.
 
-`resolveTypeRef(t *parser.TypeRef, env *Env)` in `types/check.go` (around line 1346) maps surface type references (`int`, `[T]`, `fun(int): bool`, `User`) into the kind catalogue:
+A `Fun` reference produces `FuncType`. Missing return annotation resolves to `UnitType` per [MEP 3](/docs/mep/mep-0003) invariant 15.
 
-1. **`Fun`.** `fun(P1, P2): R` produces `FuncType{Params, Return}`. A missing `Return` resolves to `UnitType` (canonicalised per [MEP 3](/docs/mep/mep-0003) invariant 15).
-2. **`Generic`.** `list<T>` and `map<K, V>` map to `ListType` and `MapType`. Unknown generic names resolve to `AnyType`.
-3. **`Struct`.** Inline structural records produce an unnamed `StructType` with `Name: ""`. Width-subtyping rules in §3.6 still apply.
-4. **`Simple`.** Names `int`, `int64` (resolved via env lookup), `float`, `bigint`, `bigrat`, `string`, `bool` map to their primitive kinds. Any other identifier is resolved by consulting the environment in this order: unions, structs, type aliases, variant-to-union lookup. A name that resolves to nothing falls through to `AnyType` (which is a known weakness; an unknown type should plausibly error).
+A `Generic` reference resolves `list<T>` and `map<K, V>` to `ListType` and `MapType`. Any other generic name resolves to `AnyType`. The fallthrough is broader than it should be; an unknown generic name is almost always a typo.
 
-### 3.10 Typing judgement
+A `Struct` reference (an inline structural record) produces an unnamed `StructType` with `Name: ""`. Width-subtyping rules still apply through the unification path.
 
-We use the standard form `Γ ⊢ e : τ` where `Γ` is the lexical environment of §3.4 and `e` is a parser expression. The inference rules per construct are stated in [MEP 5](/docs/mep/mep-0005); this MEP only fixes the judgement format and the structural rules.
+A `Simple` reference resolves names against the primitive set first, then walks the environment in this order: unions, structs, type aliases, variant-to-union. A name that finds nothing falls through to `AnyType`. This is the second silent-typo path and the same fix applies.
 
-Selected rules (informal; the full list is in [MEP 5](/docs/mep/mep-0005)):
+## The typing judgement
+
+Per-construct rules are in [MEP 5](/docs/mep/mep-0005). This MEP pins the notation. Γ is the environment of the previous section; `e` is a parser expression; `τ`, `σ` range over types. A handful of representative rules:
 
 ```
-                  Γ(x) = τ
-        ───────────────────────────── (var)
-                Γ ⊢ x : τ
+              Γ(x) = τ
+        ──────────────────── (var)
+              Γ ⊢ x : τ
 
-   Γ ⊢ e1 : τ1     Γ ⊢ e2 : τ2     op(τ1, τ2) = τ
-        ─────────────────────────────────────────── (binop)
-                  Γ ⊢ e1 op e2 : τ
+   Γ ⊢ e₁ : τ₁    Γ ⊢ e₂ : τ₂    op(τ₁, τ₂) = τ
+   ──────────────────────────────────────────── (binop)
+                 Γ ⊢ e₁ op e₂ : τ
 
-   Γ ⊢ e : FuncType{Params: [σ1, ..., σn], Return: τ}
-   Γ ⊢ a_i : σ_i                    for each i
-        ─────────────────────────────────────────── (app)
-                 Γ ⊢ e(a1, ..., an) : τ
+   Γ ⊢ e : FuncType{Params: [σ₁, ..., σₙ], Return: τ}
+   Γ ⊢ aᵢ : σᵢ                            for each i
+   ──────────────────────────────────────────────── (app)
+                Γ ⊢ e(a₁, ..., aₙ) : τ
 
-   Γ, x_i : σ_i ⊢ body : τ
-        ─────────────────────────────────────────── (lam)
-        Γ ⊢ fun(x1: σ1, ..., xn: σn) → body :
-            FuncType{Params: [σ1, ..., σn], Return: τ}
+   Γ, x_i : σᵢ ⊢ body : τ
+   ──────────────────────────────────────────────── (lam)
+   Γ ⊢ fun(x₁: σ₁, ..., xₙ: σₙ) → body :
+       FuncType{Params: [σ₁, ..., σₙ], Return: τ}
 ```
 
-`op` in `(binop)` is the function from §3.8 (operator typing). The substitution `Γ, x : σ` is "extend `Γ` with `x` bound to `σ` in a new scope". The judgement is *deterministic*: there is exactly one rule per syntactic form, so a given `Γ ⊢ e` has at most one type.
+`op` in `(binop)` is the table from the operator-typing section. `Γ, x : σ` extends Γ with a fresh binding in a new scope. The rules are deterministic in the sense that exactly one rule fires per syntactic form, so a given `Γ ⊢ e` has at most one type.
 
-## Rationale
+## Soundness, qualified
 
-### Why a tagged-union kind catalogue, not a class hierarchy
+The two classical soundness properties hold for the subset of programs that never touch `any`.
 
-`Type` has one method (`String`). All comparison operators are external. This makes a new kind a one-file change in `types/check.go` (define the struct, give it a `String`, add cases to `unify` and `equalTypes`). A class hierarchy with `Equals` and `Unify` methods would force every comparison to be implemented per-kind, which both inflates the surface area and makes cross-cutting changes (a new universal rule like "`AnyType` unifies with everything") impossible to add in one place.
+*Progress.* A closed, well-typed term that is not a value can take a reduction step. Under `any`, this fails: an `any`-typed value passed to a position expecting a struct field crashes with a tag mismatch.
 
-The trade is well-known: it is the "expression problem" ([Wadler, 1998](https://homepages.inf.ed.ac.uk/wadler/papers/expression/expression.txt)). The choice optimises for *adding kinds* over *adding operations*, which matches Mochi's actual change history: the kind table has grown several times; the comparison operators have changed three times in three years.
+*Preservation.* Reduction preserves the static type. Under `any`, this is vacuous because the static type is `any` and the dynamic type can be anything.
 
-### Why `any` is a wildcard in `unify` but not in `equalTypes`
+Two static checks that the system *does not* perform: pattern exhaustiveness in `match` is not enforced (a missing arm fails at runtime, see [MEP 13](/docs/mep/mep-0013)) and the `Pure` flag is computed but not asserted (a function flagged pure can call an impure one without complaint). Both are tracked.
 
-This split lets `unify` be the "lenient" relation used at argument sites (where a stricter relation would force most builtins to be parameterised before [MEP 12](/docs/mep/mep-0012) lands) and `equalTypes` be the "strict" relation used by inference rules that have to decide whether to widen. The split is an unsoundness escape hatch (a `*FuncType` parameter accepting `AnyType` will be called with an arbitrary value at runtime), but the alternative is making every builtin generic, which we cannot do today. The cleanup is staged in [MEP 11](/docs/mep/mep-0011).
+## Problems
 
-### Why `int` and `int64` are distinguished
+The current design has several known problems. They are listed below without rigid categories because the categories overlap (a coherence problem is usually also a soundness problem) and the reader is better served by a flat list with the fix attached.
 
-Two reasons. First, the runtime exposes a 64-bit result from `now()`; collapsing the kind would lose the surface annotation that lets callers write `let t: int64 = now()`. Second, future architectures may make 32-bit `int` cheaper than 64-bit `int64`; keeping the kinds apart leaves that door open. The compromise is that arithmetic widens (§3.8) so the distinction does not propagate as a friction point through expressions.
+**1. `unify` and `equalTypes` disagree on `int`/`int64`.** `equalTypes(int, int64)` is true, by a carve-out in `types/infer.go` around line 866. `unify(int, int64)` is false; the `IntType` case in `unify` accepts only `IntType` and `BigIntType`. A consumer that switches between the two relations gets different answers for the same pair. The fix is to remove the carve-out from `equalTypes` and require an explicit cast where today's code relies on the conflation. The break is small but real and would require sweeping the fixtures in `tests/types/valid`. A follow-up commit on this PR after [MEP 5](/docs/mep/mep-0005) is reviewed.
 
-### Why `UnitType` instead of `nil` everywhere
+**2. `unify` mixes substitution and subtyping.** Most cases of `unify` are structural equality with `any` and `*TypeVar` as wildcards, but the numeric arms are one-directional subtyping written in the same machine. A caller asking "are these the same?" gets "yes" for `int` and `bigint`. The fix is the predicate split in [MEP 11](/docs/mep/mep-0011): `unify` carries substitutions only and `subtype(s, t)` carries the numeric ladder.
 
-A block-bodied lambda with `Return == nil` in the AST used to be interpreted differently by every consumer: the checker treated it as "infer", the interpreter treated it as "no return", the transpilers had their own rules. Canonicalising at the type level to `UnitType` collapses this into one rule (`Return == nil ⇒ UnitType` at inference time) that consumers can rely on (cf. [MEP 3](/docs/mep/mep-0003) invariant 15).
+**3. `any` is a wildcard in `unify`.** This is the same problem from a different angle. Once a value is typed `any`, every subsequent unification with that value succeeds and propagates `any` further. [MEP 11](/docs/mep/mep-0011) replaces the wildcard with a deliberate cast at the boundary.
 
-### Why no first-class type
+**4. `null` literal types as `any`.** `inferPrimaryType` returns `AnyType` for `p.Lit.Null` in `types/infer.go` around line 312, so `let x: User = null` succeeds. Tying `null` to `OptionType` is the [MEP 10](/docs/mep/mep-0010) A2 fix; the inference should return `OptionType{Elem: fresh TypeVar}` and the hint should resolve the element type.
 
-Reflection is expensive and most of Mochi's target audience (data pipelines, ad-hoc transforms) does not need it. The runtime carries enough tag information for `match` to work; full first-class types would force the runtime to ship a type registry, which raises the per-program startup cost and complicates the transpilers (which would need to emit type-tag machinery).
+**5. Missing map key returns the zero of `V`.** `m[k]` for an absent `k` returns `V`'s zero rather than `option[V]`. For types without a sensible zero (a struct variant of a union, for instance) this is a progress violation. The current behaviour is pinned by `tests/types/valid/missing_map_key.mochi` so a fix is a deliberate break, [#21186](https://github.com/mochilang/mochi/issues/21186).
 
-## Soundness Properties
+**6. List `+` silently widens to `[any]`.** `[1] + ["x"]` types as `[any]` without a diagnostic. The fix is to replace the widening row in the operator table with a type-mismatch error, [#21187](https://github.com/mochilang/mochi/issues/21187).
 
-A program that type-checks under the rules in this MEP has the following properties:
+**7. `Pure` is advisory.** A `FuncType` with `Pure: true` may call impure functions. The flag is propagated but never checked. [#21188](https://github.com/mochilang/mochi/issues/21188).
 
-1. **Progress, modulo `any`.** Every closed, well-typed term either is a value or reduces to one, unless it traffics in `AnyType`. `AnyType`-typed terms can fail at runtime with a tag-mismatch error.
-2. **Preservation, modulo `any`.** Reduction preserves the static type for terms not typed at `any`.
-3. **Pattern exhaustiveness is *not* enforced.** A `match` with missing arms passes the checker and produces a runtime error on an unmatched value. See [MEP 13](/docs/mep/mep-0013).
-4. **Pure functions are *flagged*, not enforced.** The `Pure` bit on `FuncType` is computed and propagated; nothing rejects a "pure" function that calls an impure one. [#21188](https://github.com/mochilang/mochi/issues/21188).
+**8. Unknown simple type names resolve to `any`.** `resolveTypeRef` falls through to `AnyType` when a simple name finds neither a primitive, a struct, a union, an alias, nor a variant. A typo (`Usre` for `User`) downgrades the binding to `any` silently. The fix is a new `T0xx` "unknown type name" diagnostic; the change is local to `resolveTypeRef`.
 
-The first two properties hold for the subset of programs that never use `any`, generic builtins, or untyped literals as input to operators. The "modulo `any`" phrasing is precise: the bigger the `any` perimeter in a program, the smaller the soundness guarantee.
+**9. Comparisons across kinds.** `1 == "x"` types as `bool`. The fix is to require `equalTypes(L, R)` or both sides numeric in the comparison row of `inferBinaryType`.
 
-## Known Problems
+**10. `StructType.Order` and `StructType.Fields` are redundant.** The same fields are stored as a map (for lookup) and a slice (for iteration). They can drift. The fix is an ordered map type (a slice of `{Name, Type}` with an inline lookup helper); the cost is sweeping all consumers.
 
-This is the full design-problem audit for Mochi's type system as of this revision. Problems are grouped by failure mode. Each entry states what is wrong, gives the evidence (file or example), names the fix, and either points at a tracking issue/MEP or states the fix is in scope for the next revision of this MEP. "Severity" is the worst-case impact: *soundness* (the system claims a guarantee it does not deliver), *coherence* (rules are mutually inconsistent), *representation* (the data shape causes bugs), *API* (the package surface is hard to use correctly), or *ergonomics* (the surface language surprises users).
+**11. `UnionType.Variants` has no stable iteration order.** The text claims declaration order is preserved, but the field is a Go map. Downstream consumers that need stable order (the formatter, the C# emitter's switch table) reconstruct it from the parser tree. The fix is to add an `Order []string` parallel to `StructType.Order`.
 
-### 6.1 Soundness gaps
+**12. `StructType.Methods` ties `types` to `parser`.** `Method.Decl` is a `*parser.FunStmt`. Any future split of the AST into its own package, as [MEP 3](/docs/mep/mep-0003) hints at, has to thread back through `types`. The fix is to keep only the method signature and a body handle, not the AST node.
 
-Failures where a well-typed program may go wrong at runtime.
+**13. `Variadic` is a bool, not a varargs element type.** Nothing prevents a `FuncType` with `Variadic: true` and an empty `Params`. The convention "the last parameter is the variadic element" is enforced by the surface grammar, not by the type. The fix is to encode varargs as a separate field, or to split `Params` into a fixed prefix and a single variadic element.
 
-1. **Map lookup returns the zero of `V`.** *Severity: soundness.* `m[k]` for an absent `k` does not return `option[V]`; it returns `V`'s zero. For kinds without a zero (e.g. `StructType` of a union variant), this is a progress violation. Pinned by `tests/types/valid/missing_map_key.mochi`. **Fix:** [MEP 10](/docs/mep/mep-0010) A2 / [#21186](https://github.com/mochilang/mochi/issues/21186).
-2. **List `+` silently widens to `[any]`.** *Severity: soundness.* `[1] + ["x"]` types as `[any]` without a diagnostic, downgrading the soundness of every subsequent operation on the list. **Fix:** [#21187](https://github.com/mochilang/mochi/issues/21187); replace silent widening with a `T015`-style mismatch error.
-3. **`Pure` flag is advisory.** *Severity: soundness (effect-level).* A function with `Pure: true` may call impure functions. The flag is propagated but never asserted. **Fix:** [#21188](https://github.com/mochilang/mochi/issues/21188); make `Pure` a property the checker enforces rather than computes.
-4. **`any` is a wildcard for `unify`.** *Severity: soundness.* `unify(any, T)` and `unify(T, any)` both succeed. This is the single largest source of imprecision; once typed against `any`, every subsequent unification with the same value succeeds. **Fix:** [MEP 11](/docs/mep/mep-0011) introduces a `subtype(s, t)` predicate; `any` becomes the syntactic top of *subtype*, with a deliberate cast at the boundary rather than a free pass through `unify`.
-5. **`null` literal types as `any`.** *Severity: soundness.* `inferPrimaryType` returns `AnyType{}` for `p.Lit.Null` (`types/infer.go` around line 312). This means `let x: User = null` succeeds. **Fix:** [MEP 10](/docs/mep/mep-0010) A2 ties null to `option[T]`; `inferPrimaryType` should return a fresh `OptionType{Elem: TypeVar{}}` and rely on the hint to resolve `Elem`.
-6. **Unknown simple type resolves to `any`.** *Severity: soundness.* `resolveTypeRef` (§3.9) returns `AnyType{}` if a simple name resolves to no struct, union, alias, or variant. A typo (`User`/`Usre`) silently downgrades to `any`. **Fix:** Reject in `resolveTypeRef` with a new `T0xx` "unknown type name" diagnostic. In scope for the next revision.
-7. **`OptionType` is not produced by inference.** *Severity: soundness (composed with gap 1).* The kind is declared and accepted by `resolveTypeRef`, but `inferPostfixType` only emits it for the *read* path of `map[k]`. There is no surface syntax for *constructing* an `option[T]`. **Fix:** Tied to gap 1 and [MEP 10](/docs/mep/mep-0010) A2.
-8. **Comparisons across incompatible kinds.** *Severity: soundness.* `1 == "x"` types as `bool` (always `false` at runtime) rather than raising. **Fix:** Tighten the `==`/`!=` rule in `inferBinaryType` to require either `equalTypes(L, R)` or that both sides are numeric.
+**14. `*TypeVar` is the only pointer kind.** All other kinds are value types with no methods on a pointer receiver. The pointer is there because identity matters: two `*TypeVar` values with the same name are different variables. Every `switch x.(type)` has to remember the case is `*TypeVar`, not `TypeVar`. The pragmatic fix is to document the rule (polymorphism kinds use pointer receivers; if more arrive, they follow the same shape) once [MEP 12](/docs/mep/mep-0012) lands and the question becomes relevant.
 
-### 6.2 Coherence problems
+**15. `reflect.DeepEqual` is the equality fallback.** The fallback is used for kinds that have no special case, mostly `FuncType` and `StructType`. It walks pointer trees indiscriminately, which makes it sensitive to nested `*parser.FunStmt` references inside `Method.Decl`. The fix is an exhaustive switch over the kinds.
 
-Failures where two relations on the same kinds disagree.
+**16. `Env` mixes static types with runtime values.** The `values` map on `types.Env` is a runtime concern that has no business being on a static-analysis struct. The fix is to split `types.Env` (static) and `runtime.Env` (values), with the latter embedding the former. The sweep touches the interpreter and the LLM provider boundaries.
 
-9. **`equalTypes` and `unify` disagree on the numeric ladder.** *Severity: coherence.* `equalTypes(int, int64) == true` (via the carve-out at `types/infer.go:866-871`) but `unify(int, int64) == false` (the `IntType` case in `unify` accepts only `IntType` or `BigIntType`, not `Int64Type`). A caller that switches between the two relations gets different answers. **Fix:** Pick one. The right choice is to remove the `int`/`int64` carve-out from `equalTypes` and require an explicit cast for an `int64`-typed result to bind an `int`-typed variable. This is a breaking change for fixtures that depend on the conflation. Scope: a follow-up commit on this PR after MEP-5 is reviewed for impact.
-10. **`unify` doubles as equality and subtyping.** *Severity: coherence.* Most cases of `unify` are structural equality with `AnyType` and `*TypeVar` as wildcards. But the numeric cases (`IntType` accepting `BigIntType`, `BigRatType` accepting all numeric kinds, etc.) are *subtyping*, written as equality. A caller asking "are these the same?" gets "yes" for `int` and `bigint`, which is the wrong answer. **Fix:** [MEP 11](/docs/mep/mep-0011): split `unify` into a substitution-only relation and a separate `subtype(s, t)` that carries the numeric ladder.
-11. **`equalTypes` is symmetric in spelling but asymmetric in behaviour.** *Severity: coherence.* Each special case is written for both orderings (`isInt64(a) && (isInt64(b) || isInt(b))` *and* `isInt64(b) && (isInt64(a) || isInt(a))`). If a future kind adds a one-directional carve-out, the symmetry must be enumerated manually. **Fix:** Implement `equalTypes` as a single dispatch over the unordered pair, not as two ordered tests.
+**17. `Env.Copy` flattens the parent chain.** Closures capture by copy, but the flattening loses scope-shadowing information that downstream tools need. Worth replacing with a snapshot that keeps the chain.
 
-### 6.3 Representation problems
+**18. `SetFunc` lowercases names.** `types/env.go:262-269` writes both `name` and `strings.ToLower(name)` to the function map. The lowercased entry is for case-insensitive FFI lookups; the cost is that `SetFunc("Print", f)` makes both `Print` and `print` resolvable. The lowercase should live at the FFI boundary, not in the env.
 
-Failures where the data shape causes bugs in practice.
+**19. `unit` is not a surface type.** The kind exists internally and the inference uses it. But the lexer does not accept `unit` as a type-name keyword, so a programmer cannot write `let f: fun() -> unit = ...`. The fix is one line in the lexer keyword list and one case in `resolveTypeRef`.
 
-12. **`StructType.Order` and `StructType.Fields` are redundant.** *Severity: representation.* The kind stores fields twice: once as a `map[string]Type` (`Fields`) and once as `[]string` (`Order`). The map gives O(1) lookup; the slice gives deterministic iteration. They can drift if a future code path updates one and not the other. **Fix:** Replace with a single ordered map (`[]Field` with `{Name string; Type Type}`) and provide an inline lookup helper. In scope for the next revision.
-13. **`UnionType.Variants` is a `map[string]StructType` with no order.** *Severity: representation.* The MEP says "the variant order from the declaration is captured when the type decl is processed", but the field is a Go map, whose iteration order is randomised. Several downstream consumers (compilers emitting `switch` tables, the formatter) need stable order and must reconstruct it from the parser tree. **Fix:** Add `Order []string` (parallel to `StructType.Order`) or switch to an ordered map. In scope for the next revision.
-14. **`StructType.Methods` causes a cycle with `parser.FunStmt`.** *Severity: representation.* `Method.Decl *parser.FunStmt` ties the `types` package to `parser` for method declarations. Any future split of the AST into its own package ([MEP 3](/docs/mep/mep-0003) §"Open questions") must thread this back through `types`. **Fix:** Replace `Decl *parser.FunStmt` with a smaller method-shape struct (`Name`, `Sig FuncType`, `BodyHandle`) that does not name the AST. Scope: tied to the AST extraction work in [MEP 3](/docs/mep/mep-0003).
-15. **`*TypeVar` is the only pointer kind.** *Severity: representation.* Every other kind is a value type with no methods on the pointer receiver. `*TypeVar` is a pointer because it carries identity (two distinct `*TypeVar` values with the same `Name` should be different variables). This special-case forces every `switch t := x.(type)` to spell `case *TypeVar` rather than `case TypeVar`. **Fix:** Either make `TypeVar` a value type and use a fresh-name source for identity, or document the rule that *all* polymorphic kinds use pointer receivers and apply it consistently when more land. In scope for the next revision, dependent on [MEP 12](/docs/mep/mep-0012).
-16. **`Variadic` is a `bool`, not a varargs-element type.** *Severity: representation.* `print(...args: any)` has `Params: [any], Variadic: true`. The "variadic element type" is the *last* element of `Params`, but this is a convention, not a structural property: nothing prevents `Variadic: true` with `len(Params) == 0`. **Fix:** Encode varargs as a dedicated `VariadicElem Type` field separate from the fixed parameters, or change `Params` to a discriminated `(fixed []Type, variadic Type)` pair. In scope for the next revision.
-17. **`reflect.DeepEqual` as the equality fallback is fragile.** *Severity: representation.* `FuncType.Pure`, `StructType.Methods[k].Decl`, and any nested map iteration can produce surprising mismatches under `DeepEqual` because the embedded `*parser.FunStmt` is a deep tree of pointers. Two structurally identical function types from different parses may compare unequal. **Fix:** Replace the fallback with an exhaustive switch over the kinds, removing `reflect.DeepEqual` entirely. In scope for the next revision.
+**20. No nominal alias kind.** `type Id = int` collapses immediately. Error messages cannot say "expected `Id`, got `int`"; recursive aliases cannot be expressed. The fix is `AliasType{Name, Target}` that prints as `Name` and unifies as `Target`. The scope is bigger than the other items here and is a follow-up MEP.
 
-### 6.4 API problems
+**21. No tuple kind.** Heterogeneous fixed-length sequences either promote to a generated struct or fall back to `[any]`. `TupleType{Elems []Type}` is the obvious addition; it adds unify and equality cases for one more kind.
 
-Failures where the package surface invites misuse.
+**22. No row variable, no first-class type.** Both are intentional absences today. Row polymorphism is tracked as a future enhancement to [MEP 11](/docs/mep/mep-0011); first-class types are not currently planned.
 
-18. **`types.Env` mixes static and runtime state.** *Severity: API.* The same struct holds `types map[string]Type` (used by the checker), `values map[string]any` (used by the interpreter), and `mut map[string]bool` (used by both). A consumer doing static analysis has to know not to touch `values`. **Fix:** Split into `types.Env` (static) and `runtime.Env` (values) with the latter embedding the former. Scope: a small follow-up MEP; out of scope for this revision.
-19. **`Env.Copy` flattens the parent chain.** *Severity: API.* Closures capture by copy, but the flattening loses scope-shadowing information that downstream tools (`go to definition`, the LSP) rely on. **Fix:** Replace `Copy` with `Snapshot` that returns a sealed-but-still-chained view. Scope: tied to LSP work, out of scope here.
-20. **`Env.SetFunc` lowercases names.** *Severity: API.* The method writes both `name` and `strings.ToLower(name)` into the function map (`types/env.go:262-269`). This is a backwards-compatibility shim for case-insensitive FFI lookups. It pollutes name resolution: `SetFunc("Print", f)` makes both `Print` and `print` lookup-resolvable. **Fix:** Move case-insensitive lookup to the FFI boundary; have `SetFunc` write exactly one key. Scope: requires sweeping the FFI callers; out of scope here.
-21. **`ExprType` is total: it returns `AnyType` on any nil input.** *Severity: API.* A consumer that walks a partially built AST cannot distinguish "no expression" from "expression of type `any`". **Fix:** Return `(Type, bool)` or document explicitly that `nil ⇒ any` is the contract and update [MEP 5](/docs/mep/mep-0005) to match. Scope: tied to [MEP 5](/docs/mep/mep-0005) refresh.
+The list is long, but most entries are small. The five worth doing in the near term, in priority order, are 8 (unknown type names), 9 (comparison tightening), 11 (UnionType order), 19 (surface `unit`), and 10 or 13 (the StructType / Variadic representation fixes; whichever finds a volunteer first). The rest are gated on the type-system roadmap.
 
-### 6.5 Surface-language problems
+## Pinned decisions
 
-Failures that surprise the surface programmer.
+Two decisions are pinned by code already in the tree. They are recorded here so a future revision does not undo them by accident.
 
-22. **No nominal alias kind.** *Severity: ergonomics.* `type Id = int` collapses immediately to `int`. Error messages cannot say "expected `Id`, got `int`"; they say "expected `int`, got `int`" after the resolution step swallows the alias. Recursive aliases (`type T = list<T>`) cannot be expressed at all. **Fix:** Add `AliasType{Name string; Target Type}` that prints as `Name` but unifies as `Target`. Scope: a follow-up MEP after MEP-5 stabilises.
-23. **No tuple kind.** *Severity: ergonomics.* Heterogeneous fixed-length sequences have no surface type. Queries that return tuples must promote to a `StructType` or `[any]`. **Fix:** Add `TupleType{Elems []Type}`. Scope: a follow-up MEP; gated on whether the query rewrite path in [MEP 5](/docs/mep/mep-0005) needs it first.
-24. **No row variable, so width subtyping is by struct name.** *Severity: ergonomics.* You cannot write "a function over any struct with a `name: string` field". **Fix:** Out of scope for this MEP; tracked as a future enhancement in [MEP 11](/docs/mep/mep-0011).
-25. **`unit` is not a surface type.** *Severity: ergonomics.* `UnitType` exists internally but no `let x: unit` is accepted by the parser ([MEP 2](/docs/mep/mep-0002)). The kind is canonical only in *inference*; callers writing function signatures cannot spell "no return" directly. **Fix:** Add `unit` to the simple-type lexer keywords and to `resolveTypeRef`'s switch in §3.9. In scope for the next revision.
-26. **First-class type missing.** *Severity: ergonomics.* `Type` is not a value-level concept. `match v { ... }` is the only form that branches on a runtime tag; there is no `typeof(x)` or `T :: Type` construct. **Fix:** Tracked in §7; not in scope for this MEP.
+*Missing map key.* The runtime returns the zero of `V` today. The fix (`option[V]`) is a deliberate break tracked in [#21186](https://github.com/mochilang/mochi/issues/21186); the current behaviour is fixtured in `tests/types/valid/missing_map_key.mochi`. Anyone changing the inference rule must update the fixture and announce the break in the corresponding MEP.
 
-### 6.6 Documentation problems
+*`unit`, not `void`.* The kind was renamed in [#21221](https://github.com/mochilang/mochi/pull/21221) to remove the "nil means infer, not void" ambiguity in [MEP 3](/docs/mep/mep-0003) invariant 15. Transpilers that emit `void` as a target-language keyword (Go, Java, C, C++, C#, Dart) are unaffected; only Mochi's internal kind name moved.
 
-Failures of *this* document.
+## Reference implementation
 
-27. **Line numbers go stale.** *Severity: documentation.* Earlier revisions hard-coded `types/check.go:150-387`; refactors moved the function and the doc silently became a lie. **Fix:** The current revision states "around line N" everywhere. Continue this discipline in future edits.
-28. **No formal subtype relation written down.** *Severity: documentation.* The subtype relation is implicit in `unify`'s case bodies. **Fix:** Once [MEP 11](/docs/mep/mep-0011) lands, reference it from §3.6 as the normative source.
+| Concept           | Location                                                                 |
+|-------------------|--------------------------------------------------------------------------|
+| `Type` interface  | `types/check.go`, around line 12                                         |
+| Kind definitions  | `types/check.go`, `IntType` through `FuncType`                           |
+| `unify`           | `types/check.go`, around lines 144 to 381                                |
+| `equalTypes`      | `types/infer.go`, around lines 828 to 876                                |
+| `inferBinaryType` | `types/infer.go`, around line 72                                         |
+| `resolveTypeRef`  | `types/check.go`, around line 1346                                       |
+| Environment       | `types/env.go`                                                           |
+| Purity analysis   | `types/pure.go`                                                          |
+| Tests             | `types/check_test.go`, `types/mep_obligations_test.go`, the corpora in `tests/types/{valid,errors}` |
 
-## Proposed enhancements
+Line numbers are written as "around N" because they will drift; the function names are stable.
 
-For each problem above the recommended fix is named in-line. The following five are in scope for follow-up commits on this PR (or the next revision of MEP-4), in priority order:
+## Open questions
 
-1. Reject unknown simple type names in `resolveTypeRef` (problem 6). Surface as `T0xx`.
-2. Tighten `==`/`!=` on incompatible kinds (problem 8). Surface as `T0xx`.
-3. Add `Order` to `UnionType` for deterministic iteration (problem 13). No surface effect.
-4. Add `unit` as a surface keyword (problem 25). Pure additive.
-5. Replace `StructType.Fields + Order` with an ordered map (problem 12). API change to `types.StructType`; sweep callers.
+A few questions do not yet have answers worth pinning.
 
-The remaining problems are gated on the cross-MEP roadmap: MEPs [10](/docs/mep/mep-0010), [11](/docs/mep/mep-0011), [12](/docs/mep/mep-0012), [13](/docs/mep/mep-0013), and the AST extraction in [MEP 3](/docs/mep/mep-0003) §"Open questions".
+The right disposition for `float` mixed with `bigrat` is unclear. Today the result is `bigrat` because precision matters more than performance. An argument can be made the other way: most arithmetic is `float` and the implicit widening to `bigrat` is a surprise.
 
-## Reference Implementation
+The right surface for generics on builtins is open. `len`, `first`, and `append` are declared with `any` parameters because [MEP 12](/docs/mep/mep-0012) is not yet wired through. When it does land, the question is whether the surface syntax requires the type parameters (`len[int](xs)`) or relies on inference. The standard answer is inference-only with explicit parameters as a fallback, but the parser cost is not zero.
 
-| Concept           | Location                                                                                                  |
-|-------------------|-----------------------------------------------------------------------------------------------------------|
-| `Type` interface  | `types/check.go`, around line 12                                                                          |
-| Kind definitions  | `types/check.go`, `IntType` through `FuncType` (lines 16-140 today)                                        |
-| `unify`           | `types/check.go`, around lines 144-381                                                                    |
-| `equalTypes`      | `types/infer.go`, around lines 828-876                                                                    |
-| `inferBinaryType` | `types/infer.go`, around line 72                                                                          |
-| `resolveTypeRef`  | `types/check.go`, around line 1346                                                                        |
-| Environment       | `types/env.go`                                                                                            |
-| Purity analysis   | `types/pure.go`                                                                                           |
-| Tests             | `types/check_test.go`, `types/mep_obligations_test.go`, `types/mochi_typechecker_test.go`, and the `tests/types/{valid,errors}` golden corpora |
-
-Line numbers are stated as "around N" so that an unrelated refactor does not silently stale-mark the doc. The function names are stable.
-
-## How to teach this
-
-A learner coming from a language with classes will look for `Class` and find `StructType`; the rest of the kind table is the next ten minutes. A learner coming from Haskell will look for type classes and not find them (they are tracked in [MEP 12](/docs/mep/mep-0012) under "trait constraints"). A learner coming from TypeScript will recognise the structural function arrow and the (small) width subtyping on structs.
-
-The three things that surprise everyone:
-
-1. `any` makes `unify` accept anything, but `equalTypes` rejects everything against `any`. Pick the right relation for the question.
-2. `int` and `int64` are *unifiable* but not *equal*. Comparisons against the equality predicate must allow for the `int64` carve-out.
-3. A function's `Return == nil` after parsing means "the parser left it for inference"; the canonical *type* it inhabits is `UnitType`, not `nil`.
-
-If a reader leaves with those three, the rest of the doc is fluent reading.
-
-## Pinned Decisions
-
-### Reading a missing map key
-
-Once [MEP 10](/docs/mep/mep-0010) A2 lands, `m[k]` for an absent `k` will type as `option[V]`. Callers will be required to unwrap the option before using the value at type `V`. Three options were considered:
-
-1. Type `m[k]` as `option[V]`. *Picked.*
-2. Require an explicit default `m[k] ?? default`, with a checker error otherwise.
-3. Raise a typed runtime panic.
-
-Option 1 reuses the `OptionType` shape that [MEP 10](/docs/mep/mep-0010) A2 gives `null` and that [MEP 10](/docs/mep/mep-0010) C1 gives the `T?` shorthand. Option 2 needs a new operator and a per-callsite annotation. Option 3 forces an `in m` guard at every call site.
-
-Today the runtime returns the zero of `V`. For non-zero-bearing types this is a progress violation. The current behaviour is pinned by `tests/types/valid/missing_map_key.mochi`; the future tightening is a deliberate breaking change tracked in [#21186](https://github.com/mochilang/mochi/issues/21186) alongside [MEP 10](/docs/mep/mep-0010) A2.
-
-### `unit` rather than `void`
-
-The historical name was `VoidType` with surface form `void`. The rename to `UnitType` / `unit` (PR [#21221](https://github.com/mochilang/mochi/pull/21221)) removes the "nil means infer, not void" footgun documented at [MEP 3](/docs/mep/mep-0003) invariant 15. The rename is internal to Mochi; transpilers that emit `void` as a *target* language keyword (Go, Java, C, C++, C#, Dart) keep doing so.
-
-## Open Questions
-
-- **Tuple kind.** There is no surface type for heterogeneous fixed-length sequences. Query result tuples promote to `[any]` or a generated struct. A `TupleType{Elem []Type}` would be the obvious addition; the trade is the additional unify and equality cases.
-- **Numeric ordering.** Mixing `float` and `bigrat` lands at `bigrat` today (§3.8). It is not obvious that this is the right choice; widening to `float` would preserve operator behaviour with the host architecture's primitives, while staying at `bigrat` preserves precision.
-- **Should `resolveTypeRef` reject unknown names?** Today it falls through to `AnyType`. A strict mode would surface typos at the type-resolution site.
-- **First-class generics on builtins.** `len`, `first`, `push` are declared with `any`-typed parameters. With [MEP 12](/docs/mep/mep-0012) they would become `len<T>(x: [T] | map<K, T> | string): int` and similar. The remaining question is the surface syntax: explicit type parameters (`len[int](xs)`) versus inference-only.
-
-## Future Work
-
-The roadmap intersects this MEP at four points:
-
-- [MEP 5](/docs/mep/mep-0005): Per-construct inference rules. Refines §3.10.
-- [MEP 10](/docs/mep/mep-0010): Catalogue of soundness gaps including the ones in §6.
-- [MEP 11](/docs/mep/mep-0011): A clean `subtype(s, t)` predicate replacing the `any` wildcard in `unify`.
-- [MEP 12](/docs/mep/mep-0012): Parametric polymorphism wiring `TypeVar` through call sites.
-
-When any of those lands, the relevant subsection here will be updated and an explicit cross-link to the implementing PR added.
-
-## Backwards Compatibility
-
-Informational. This MEP documents the type system as of [#21221](https://github.com/mochilang/mochi/pull/21221) and the subsequent doc sync ([#21223](https://github.com/mochilang/mochi/pull/21223)). Future revisions that change behaviour (rather than documentation) must announce the break in their own MEP and cross-link from here.
+The right answer for `resolveTypeRef`'s `Generic` fallthrough is probably "error" rather than "any". The same applies to the `Simple` fallthrough. Both fixes are local; what is not local is the set of test fixtures that today rely on the silent downgrade.
 
 ## References
 
 ### Programming language theory
 
-- [Pierce, Benjamin C. *Types and Programming Languages.* MIT Press, 2002.](https://www.cis.upenn.edu/~bcpierce/tapl/) Chapters 8 ("Typed Arithmetic Expressions") and 11 ("Simple Extensions") cover the core; chapter 15 ("Subtyping") covers the relation Mochi's `unify` plays with.
-- [Harper, Robert. *Practical Foundations for Programming Languages.* CUP, 2016.](https://www.cs.cmu.edu/~rwh/pfpl.html) Chapters 4 ("Statics") and 11 ("Sums") for the formal judgement notation we use.
-- [Cardelli, Luca, and Wegner, Peter. "On Understanding Types, Data Abstraction, and Polymorphism." *Computing Surveys*, 17(4), 1985.](https://dl.acm.org/doi/10.1145/6041.6042) The taxonomy of polymorphism that informs §3.2 (`AnyType`, `TypeVar`).
-- [Wadler, Philip. "The Expression Problem." 1998.](https://homepages.inf.ed.ac.uk/wadler/papers/expression/expression.txt) The trade-off behind the tagged-union kind catalogue.
-- [Damas, Luis, and Milner, Robin. "Principal type-schemes for functional programs." *POPL 1982.*](https://dl.acm.org/doi/10.1145/582153.582176) The original Hindley-Milner algorithm; Mochi's `unify` is a small subset, intentionally not yet doing principal-types inference.
-- [Reynolds, John C. "Towards a Theory of Type Structure." *Programming Symposium, 1974.*](https://link.springer.com/chapter/10.1007/3-540-06859-7_148) For the underlying notion of "kind" used in §3.2.
+- Pierce, Benjamin C. [*Types and Programming Languages.*](https://www.cis.upenn.edu/~bcpierce/tapl/) MIT Press, 2002. Chapters 8 and 11 for the simply typed core; chapter 15 for the subtyping relation `unify` partially encodes.
+- Harper, Robert. [*Practical Foundations for Programming Languages.*](https://www.cs.cmu.edu/~rwh/pfpl.html) CUP, 2016. Chapter 4 for the judgement notation used above.
+- Cardelli, Luca, and Wegner, Peter. ["On Understanding Types, Data Abstraction, and Polymorphism."](https://dl.acm.org/doi/10.1145/6041.6042) *Computing Surveys* 17(4), 1985. The taxonomy behind the `AnyType` / `TypeVar` distinction.
+- Damas, Luis, and Milner, Robin. ["Principal type-schemes for functional programs."](https://dl.acm.org/doi/10.1145/582153.582176) *POPL*, 1982. The Hindley-Milner algorithm `unify` is a small subset of.
+- Wadler, Philip. ["The Expression Problem."](https://homepages.inf.ed.ac.uk/wadler/papers/expression/expression.txt) 1998. The trade behind the tagged-union kind catalogue.
+- Reynolds, John C. ["Towards a Theory of Type Structure."](https://link.springer.com/chapter/10.1007/3-540-06859-7_148) *Programming Symposium*, 1974. For the underlying notion of "kind".
 
 ### Cross-MEP
 
-- [MEP 2 (Grammar)](/docs/mep/mep-0002). Where the surface syntax that this MEP types is defined.
-- [MEP 3 (AST)](/docs/mep/mep-0003). The tree this MEP types. Invariant 15 (FunExpr default return) is load-bearing here.
-- [MEP 5 (Inference)](/docs/mep/mep-0005). The per-construct rules.
-- [MEP 10 (Known Gaps)](/docs/mep/mep-0010). The wider gap catalogue.
-- [MEP 11 (Subtyping)](/docs/mep/mep-0011). The `subtype` predicate that will replace `any`'s wildcard role.
-- [MEP 12 (Polymorphism)](/docs/mep/mep-0012). The plan for wiring `TypeVar`.
-- [MEP 13 (Pattern matching)](/docs/mep/mep-0013). The exhaustiveness work.
+- [MEP 2](/docs/mep/mep-0002) (Grammar): the surface syntax that resolves into the kind catalogue.
+- [MEP 3](/docs/mep/mep-0003) (AST): the tree this MEP types. Invariant 15 (FunExpr default return) is load-bearing here.
+- [MEP 5](/docs/mep/mep-0005) (Inference): the per-construct rules.
+- [MEP 10](/docs/mep/mep-0010) (Known gaps): the wider gap catalogue.
+- [MEP 11](/docs/mep/mep-0011) (Subtyping): the `subtype` predicate that replaces `any`'s wildcard role.
+- [MEP 12](/docs/mep/mep-0012) (Polymorphism): the `TypeVar` propagation plan.
+- [MEP 13](/docs/mep/mep-0013) (Pattern matching): the exhaustiveness work.
+
+## Backwards compatibility
+
+Informational. No behaviour change in this revision. Any future change to the rules above must be announced in its own MEP and cross-linked here.
 
 ## Copyright
 

--- a/website/docs/mep/mep-0004.md
+++ b/website/docs/mep/mep-0004.md
@@ -33,7 +33,7 @@ The type system is the contract between the checker and the runtime. Misundersta
 
 ### The `Type` interface
 
-`types/check.go:12-14`. Every type kind implements:
+`types/check.go` (around line 12). Every type kind implements:
 
 ```
 type Type interface {
@@ -41,11 +41,11 @@ type Type interface {
 }
 ```
 
-There is no equality method on the interface. Equality is computed externally by `equalTypes` in `types/infer.go` and structural unification is done by `unify` in `types/check.go:150-387`. The fallthrough case in `equalTypes` is `reflect.DeepEqual`, with explicit carve-outs for `Int`/`Int64` interop, union/struct member matching, and option types. `unify` uses a different rule for `AnyType`: see below.
+There is no equality method on the interface. Equality is computed externally by `equalTypes` in `types/infer.go` (around line 828) and structural unification is done by `unify` in `types/check.go` (around line 144). The fallthrough case in `equalTypes` is `reflect.DeepEqual`, with explicit carve-outs for `Int`/`Int64` interop, union/struct member matching, and option types. `unify` uses a different rule for `AnyType`: see below.
 
 ### Kinds present today
 
-Listed in source order at `types/check.go:16-140`.
+Listed in source order at `types/check.go` (the kind block starts at line 16 with `IntType` and runs through the `FuncType.String()` method).
 
 Primitive kinds:
 
@@ -56,7 +56,7 @@ Primitive kinds:
 - `BigRatType`. Arbitrary precision rational.
 - `StringType`. UTF-8 byte sequence.
 - `BoolType`. `true` or `false`.
-- `VoidType`. Result type of statement-only operations like `print`.
+- `UnitType`. Result type of statement-only operations like `print`, and the canonical default return for a block-bodied function or lambda with no annotated return ([MEP 3](/docs/mep/mep-0003) invariant 15). Printed as `unit`. The kind was named `VoidType` historically; the rename in [#21221](https://github.com/mochilang/mochi/pull/21221) removed the special case where `nil Return` had to be interpreted by every consumer.
 
 Structural kinds:
 
@@ -115,7 +115,7 @@ The exact rules in `equalTypes` (`types/infer.go`):
 - A `StructType` is equal to a `UnionType` when the struct is one of the union's variants. This is what allows `match` arms typed as variant structs to satisfy a union binding.
 - `AnyType` is equal only to another `AnyType` in `equalTypes`. It is `unify` that accepts `AnyType` on either side as a match; that is the unsoundness escape hatch.
 
-Unification propagates substitutions for `TypeVar` on top of the equality rules. See `types/check.go:150-387`.
+Unification propagates substitutions for `TypeVar` on top of the equality rules. See `types/check.go` `unify` (around lines 144-381).
 
 ### Numeric tower
 
@@ -157,10 +157,10 @@ Informational. No backward compatibility implications.
 
 ## Reference Implementation
 
-- `types/check.go:12-14`: `Type` interface.
-- `types/check.go:16-140`: kind definitions.
-- `types/check.go:150-387`: `unify`.
-- `types/infer.go`: `equalTypes` and operator typing.
+- `types/check.go`, `type Type` (around line 12): the interface.
+- `types/check.go`, `IntType` through `FuncType` (around lines 16-140): kind definitions.
+- `types/check.go`, `unify` (around lines 144-381): structural unification.
+- `types/infer.go`, `equalTypes` (around lines 828-876) and `inferBinaryType` (around line 72): operator typing.
 - `types/env.go`: environment API.
 
 ## Pinned decisions


### PR DESCRIPTION
## Summary

- Updates the §Kinds present today table for the VoidType -> UnitType rename that landed in #21221, and cross-links the rename rationale to MEP-3 invariant 15.
- Softens hard-coded source line ranges in MEP-4 to "around line N" so the doc does not silently stale-mark when types/check.go or types/infer.go grow.

This is the opening commit for the MEP-4 doc-sync work tracked in #21222. Follow-up commits in this PR will start chipping at the soundness gaps MEP-4 enumerates.

## Test plan

- [ ] CI green (build + tests)
- [ ] Docusaurus build clean