### PR TITLE
types: accept `unit` as a surface type (P19)

### DIFF
--- a/tests/types/errors/unit_assign_value.err
+++ b/tests/types/errors/unit_assign_value.err
@@ -1,0 +1,8 @@
+1. error[T008]: type mismatch: expected unit, got int
+  --> tests/types/errors/unit_assign_value.mochi:2:15
+
+  2 | let x: unit = 1
+    |               ^
+
+help:
+  Change the value to match the expected type.

--- a/tests/types/errors/unit_assign_value.mochi
+++ b/tests/types/errors/unit_assign_value.mochi
@@ -1,0 +1,2 @@
+// MEP-4 P19: a non-unit value cannot be bound to a unit-typed name.
+let x: unit = 1

--- a/tests/types/valid/unit_return.golden
+++ b/tests/types/valid/unit_return.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/unit_return.mochi
+++ b/tests/types/valid/unit_return.mochi
@@ -1,0 +1,9 @@
+// MEP-4 P19: `unit` is a surface-level type name.
+// A function declared with `: unit` may be referenced through a variable of
+// matching function type.
+fun greet(): unit {
+  print("hello")
+}
+
+let g: fun(): unit = greet
+g()

--- a/types/check.go
+++ b/types/check.go
@@ -1400,6 +1400,8 @@ func resolveTypeRef(t *parser.TypeRef, env *Env) Type {
 			return StringType{}
 		case "bool":
 			return BoolType{}
+		case "unit":
+			return UnitType{}
 		default:
 			if ut, ok := env.GetUnion(*t.Simple); ok {
 				return ut


### PR DESCRIPTION
Closes #21224. One of the MEP 4 §6 priority-five fixes.

`UnitType` is already what inference picks as the return type of a
function with no annotation (MEP 3 invariant 15). But `resolveTypeRef`
did not accept `unit` in a type-name position, so a programmer could
not declare `let f: fun(): unit = ...` even though it is the type the
inference already produces. Single new case in the primitive switch.

Tests:
- `tests/types/valid/unit_return.mochi` — `fun(): unit` plus assignment
  to a `fun(): unit` typed variable, then a call.
- `tests/types/errors/unit_assign_value.mochi` — `let x: unit = 1`
  rejects with T008, and the diagnostic prints `expected unit, got int`.

Refs MEP 4 (#21223) §6 problem 19.