### PR TITLE
types: T025 for unknown type names (P8)

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -217,6 +217,7 @@ type TypeField struct {
 // --- Type System ---
 
 type TypeRef struct {
+	Pos     lexer.Position    `json:"pos,omitempty" parser:""`
 	Fun     *FunType          `json:"fun,omitempty" parser:"@@"`
 	Generic *GenericType      `json:"generic,omitempty" parser:"| @@"`
 	Struct  *InlineStructType `json:"struct,omitempty" parser:"| @@"`

--- a/tests/types/errors/unknown_type_name.err
+++ b/tests/types/errors/unknown_type_name.err
@@ -1,0 +1,8 @@
+1. error[T025]: unknown type: Int
+  --> tests/types/errors/unknown_type_name.mochi:2:12
+
+  2 | let count: Int = 0
+    |            ^
+
+help:
+  Ensure the type is defined before use.

--- a/tests/types/errors/unknown_type_name.mochi
+++ b/tests/types/errors/unknown_type_name.mochi
@@ -1,0 +1,2 @@
+// MEP-4 P8: a typo in a type position should not silently widen to `any`.
+let count: Int = 0

--- a/tests/types/errors/unknown_type_param.err
+++ b/tests/types/errors/unknown_type_param.err
@@ -1,0 +1,8 @@
+1. error[T025]: unknown type: Role
+  --> tests/types/errors/unknown_type_param.mochi:2:35
+
+  2 | type User = { name: string, role: Role }
+    |                                   ^
+
+help:
+  Ensure the type is defined before use.

--- a/tests/types/errors/unknown_type_param.mochi
+++ b/tests/types/errors/unknown_type_param.mochi
@@ -1,0 +1,2 @@
+// MEP-4 P8: an unknown struct field type fails with T025.
+type User = { name: string, role: Role }

--- a/types/check.go
+++ b/types/check.go
@@ -673,6 +673,9 @@ func Check(prog *parser.Program, env *Env) []error {
 			}
 		}
 	}
+	// Flush diagnostics raised in resolveTypeRef and other contexts
+	// that cannot return errors directly to a caller.
+	errs = append(errs, env.TakeDiagnostics()...)
 	return errs
 }
 
@@ -1408,6 +1411,8 @@ func resolveTypeRef(t *parser.TypeRef, env *Env) Type {
 		switch *t.Simple {
 		case "int":
 			return IntType{}
+		case "int64":
+			return Int64Type{}
 		case "float":
 			return FloatType{}
 		case "bigint":
@@ -1420,6 +1425,8 @@ func resolveTypeRef(t *parser.TypeRef, env *Env) Type {
 			return BoolType{}
 		case "unit":
 			return UnitType{}
+		case "any":
+			return AnyType{}
 		default:
 			if ut, ok := env.GetUnion(*t.Simple); ok {
 				return ut
@@ -1433,11 +1440,28 @@ func resolveTypeRef(t *parser.TypeRef, env *Env) Type {
 			if ut, ok := env.FindUnionByVariant(*t.Simple); ok {
 				return ut
 			}
+			if isTypeParamName(*t.Simple) {
+				return AnyType{}
+			}
+			env.RecordDiagnostic(errUnknownType(t.Pos, *t.Simple))
 			return AnyType{}
 		}
 	}
 
 	return AnyType{}
+}
+
+// isTypeParamName recognises single uppercase letters used as generic
+// type-parameter names (`T`, `K`, `V`). MEP 12 will plumb a real type-
+// parameter scope through resolveTypeRef; until then this heuristic
+// keeps the unknown-type-name diagnostic from firing on names that are
+// already valid in generic positions.
+func isTypeParamName(name string) bool {
+	if len(name) != 1 {
+		return false
+	}
+	c := name[0]
+	return c >= 'A' && c <= 'Z'
 }
 
 func resolveTypeName(name string, env *Env) Type {

--- a/types/env.go
+++ b/types/env.go
@@ -28,8 +28,35 @@ type Env struct {
 	funcs   map[string]*parser.FunStmt   // function declarations
 	models  map[string]ModelSpec         // model aliases
 
+	// diagnostics accumulates errors raised in contexts (such as
+	// resolveTypeRef) that cannot return errors to their caller. Only
+	// the root env holds the slice; helpers walk up to find it.
+	diagnostics []error
+
 	output io.Writer // default: os.Stdout
 	input  io.Reader // default: os.Stdin
+}
+
+// RecordDiagnostic appends an error to the root env's diagnostic list.
+// resolveTypeRef calls this when an unknown type name is encountered.
+func (e *Env) RecordDiagnostic(err error) {
+	root := e
+	for root.parent != nil {
+		root = root.parent
+	}
+	root.diagnostics = append(root.diagnostics, err)
+}
+
+// TakeDiagnostics returns and clears the accumulated diagnostics on the
+// root env. Check calls it once after every pass.
+func (e *Env) TakeDiagnostics() []error {
+	root := e
+	for root.parent != nil {
+		root = root.parent
+	}
+	out := root.diagnostics
+	root.diagnostics = nil
+	return out
 }
 
 // Types exposes the map of locally declared variable types.


### PR DESCRIPTION
Closes #21226. MEP 4 §6 priority-five item.

\`resolveTypeRef\` was returning \`AnyType{}\` on any unrecognised simple name. A typo in a type position silently downgraded the binding to \`any\`. Now it raises T025 \"unknown type\" with a position.

The wire-up needed three small pieces because \`resolveTypeRef\` cannot return an error to its caller:

- \`parser.TypeRef\` gains a \`Pos\` (participle populates it automatically).
- \`types.Env\` gains a root-level diagnostic sink (\`RecordDiagnostic\` / \`TakeDiagnostics\`).
- \`Check\` flushes the sink after the final pass.

While here, \`int64\` and \`any\` are now first-class cases in the primitive switch (previously they leaked through the fallback). Single uppercase letters stay silent so generics still work until MEP 12.

Tests:
- \`tests/types/errors/unknown_type_name.mochi\` — the canonical \`let count: Int = 0\` typo.
- \`tests/types/errors/unknown_type_param.mochi\` — unknown field type inside a struct.

Both anchor the diagnostic to the offending name's column.

Refs MEP 4 (#21223) §6 problem 8.