### PR TITLE
types: tighten cross-kind comparison typing (P9)

### DIFF
--- a/tests/types/errors/compare_int_string.err
+++ b/tests/types/errors/compare_int_string.err
@@ -1,0 +1,8 @@
+1. error[T013]: incompatible types in comparison
+  --> tests/types/errors/compare_int_string.mochi:2:11
+
+  2 | let x = 1 == "y"
+    |           ^
+
+help:
+  Use comparable types like numbers or strings with `<`, `>`.

--- a/tests/types/errors/compare_int_string.mochi
+++ b/tests/types/errors/compare_int_string.mochi
@@ -1,0 +1,2 @@
+// MEP-4 P9: comparing across incompatible kinds must reject.
+let x = 1 == "y"

--- a/tests/types/errors/compare_struct_int.err
+++ b/tests/types/errors/compare_struct_int.err
@@ -1,0 +1,8 @@
+1. error[T013]: incompatible types in comparison
+  --> tests/types/errors/compare_struct_int.mochi:4:11
+
+  4 | let x = u == 5
+    |           ^
+
+help:
+  Use comparable types like numbers or strings with `<`, `>`.

--- a/tests/types/errors/compare_struct_int.mochi
+++ b/tests/types/errors/compare_struct_int.mochi
@@ -1,0 +1,4 @@
+// MEP-4 P9: a struct and an integer are not comparable.
+type User = { id: int }
+let u = User { id: 1 }
+let x = u == 5

--- a/tests/types/valid/compare_empty_list.golden
+++ b/tests/types/valid/compare_empty_list.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/compare_empty_list.mochi
+++ b/tests/types/valid/compare_empty_list.mochi
@@ -1,0 +1,4 @@
+// MEP-4 P9: comparing a typed list against the empty-list literal
+// continues to type-check (the empty literal carries element type `any`).
+let xs: list<int> = []
+expect xs == []

--- a/types/check.go
+++ b/types/check.go
@@ -1552,13 +1552,18 @@ func applyBinaryType(pos lexer.Position, op string, left, right Type) (Type, err
 			return nil, errOperatorMismatch(pos, op, left, right)
 		}
 	case "==", "!=", "<", "<=", ">", ">=":
-		if !unify(left, right, nil) {
-			if isNumeric(left) && isNumeric(right) {
-				return BoolType{}, nil
-			}
-			return nil, errIncompatibleComparison(pos)
+		// MEP 4 P9. The `any` short-circuit at the top of the function
+		// already handles the soundness escape hatch. Here, `unify` is
+		// used (not `equalTypes`) because empty-list literals carry
+		// element type `any`, and comparing `xs == []` is a common
+		// surface idiom that must continue to type-check.
+		if unify(left, right, nil) {
+			return BoolType{}, nil
 		}
-		return BoolType{}, nil
+		if isNumeric(left) && isNumeric(right) {
+			return BoolType{}, nil
+		}
+		return nil, errIncompatibleComparison(pos)
 	case "in":
 		switch rt := right.(type) {
 		case MapType:

--- a/types/infer.go
+++ b/types/infer.go
@@ -158,7 +158,20 @@ func inferBinaryType(env *Env, b *parser.BinaryExpr) Type {
 					}
 					res = AnyType{}
 				case "==", "!=", "<", "<=", ">", ">=":
-					res = BoolType{}
+					// MEP 4 P9: keep inference honest with the check
+					// pass. `any` keeps its escape-hatch behaviour;
+					// otherwise comparable operands must be equal-kinded
+					// or both numeric.
+					switch {
+					case IsAnyType(left) || IsAnyType(right):
+						res = BoolType{}
+					case equalTypes(left, right):
+						res = BoolType{}
+					case isNumeric(left) && isNumeric(right):
+						res = BoolType{}
+					default:
+						res = AnyType{}
+					}
 				case "&&", "||":
 					if isBool(left) && isBool(right) {
 						res = BoolType{}

--- a/types/infer_compare_test.go
+++ b/types/infer_compare_test.go
@@ -1,0 +1,48 @@
+package types_test
+
+import (
+	"mochi/parser"
+	"mochi/types"
+	"testing"
+)
+
+// inferRHS parses `let x = <expr>` and returns the inferred type of
+// the right-hand side under a fresh env.
+func inferRHS(t *testing.T, expr string) types.Type {
+	t.Helper()
+	src := "let x = " + expr + "\n"
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		t.Fatalf("parse %q: %v", src, err)
+	}
+	if len(prog.Statements) == 0 || prog.Statements[0].Let == nil {
+		t.Fatalf("expected a let stmt in %q", src)
+	}
+	return types.ExprType(prog.Statements[0].Let.Value, types.NewEnv(nil))
+}
+
+// TestInferComparisonHonest pins MEP-4 P9: inference must not claim a
+// cross-kind comparison has type `bool`. The check pass rejects the
+// program; inference should report `any` so downstream tools do not
+// silently consume a wrong type.
+func TestInferComparisonHonest(t *testing.T) {
+	cases := []struct {
+		name string
+		expr string
+		want string
+	}{
+		{"int_eq_int", `1 == 2`, "bool"},
+		{"int_lt_int", `1 < 2`, "bool"},
+		{"int_eq_string", `1 == "x"`, "any"},
+		{"struct_eq_int", `{a: 1} == 2`, "any"},
+		{"bool_eq_int", `true == 1`, "any"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := inferRHS(t, tc.expr)
+			if got == nil || got.String() != tc.want {
+				t.Fatalf("ExprType(%q) = %v, want %v", tc.expr, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #21228. MEP 4 §6 priority-five item.

\`inferBinaryType\` was returning \`bool\` for every comparison op regardless of operand types. The check pass already rejected the bad programs, so nothing reached runtime, but inference was claiming a wrong type for downstream consumers (LLM provider, code-gen helpers, query planner).

Inference now mirrors the check pass: \`any\` short-circuits to \`bool\`, then \`equalTypes(L, R)\` or both numeric to \`bool\`, else \`any\`.

\`applyBinaryType\` keeps using \`unify\` rather than the \`equalTypes\` prescription in MEP-4. The reason is in a comment in the diff: empty-list literals are typed \`list<any>\`, and \`xs == []\` is a common idiom that must continue to type-check. \`unify\` accepts that via its recursion into \`AnyType\` on the right; \`equalTypes\` does not. MEP-11 will make this principled when the wildcard is replaced with a deliberate cast.

Tests:
- \`compare_int_string\`, \`compare_struct_int\` — T013 rejects.
- \`compare_empty_list\` — \`xs == []\` keeps working.
- \`infer_compare_test.go\` — unit test on \`ExprType\` so a future regression on inference shows up immediately.

Refs MEP 4 (#21223) §6 problem 9.