### PR TITLE
types: UnionType.Order for stable iteration (P11)

### DIFF
--- a/types/check.go
+++ b/types/check.go
@@ -91,8 +91,13 @@ type Method struct {
 func (t StructType) String() string { return t.Name }
 
 type UnionType struct {
-	Name     string
+	Name string
+	// Variants stores the per-variant struct type keyed by variant name.
+	// Order preserves the declaration order of variants and is the
+	// canonical iteration sequence (MEP 4 P11). Variants is kept in
+	// sync but is not authoritative for ordering.
 	Variants map[string]StructType
+	Order    []string
 }
 
 func (t UnionType) String() string { return t.Name }
@@ -1173,7 +1178,8 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 			// Build the union with a shared variants map so recursive
 			// references resolve correctly as variants are populated.
 			variants := map[string]StructType{}
-			ut := UnionType{Name: s.Type.Name, Variants: variants}
+			variantOrder := make([]string, 0, len(s.Type.Variants))
+			ut := UnionType{Name: s.Type.Name, Variants: variants, Order: variantOrder}
 			env.SetUnion(s.Type.Name, ut)
 			env.types[s.Type.Name] = ut
 
@@ -1186,6 +1192,7 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 				}
 				st := StructType{Name: v.Name, Fields: vf, Order: order}
 				variants[v.Name] = st
+				variantOrder = append(variantOrder, v.Name)
 				env.SetStruct(v.Name, st)
 				params := make([]Type, 0, len(v.Fields))
 				for _, f := range v.Fields {
@@ -1196,6 +1203,7 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 					env.SetVar(v.Name, UnionType{Name: s.Type.Name, Variants: nil}, false)
 				}
 			}
+			ut.Order = variantOrder
 			env.SetUnion(s.Type.Name, ut)
 			env.types[s.Type.Name] = ut
 			return nil

--- a/types/union_order_test.go
+++ b/types/union_order_test.go
@@ -1,0 +1,42 @@
+package types_test
+
+import (
+	"mochi/parser"
+	"mochi/types"
+	"testing"
+)
+
+// TestUnionTypeOrder pins MEP-4 P11: UnionType.Order preserves the
+// declaration order of variants. A future change that drops the Order
+// field or populates it inconsistently must update this test.
+func TestUnionTypeOrder(t *testing.T) {
+	src := `
+type Shape = Circle(r: float) | Square(side: float) | Triangle(a: int, b: int, c: int)
+`
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) != 0 {
+		t.Fatalf("check: %v", errs)
+	}
+	ut, ok := env.GetUnion("Shape")
+	if !ok {
+		t.Fatalf("union Shape not in env")
+	}
+	want := []string{"Circle", "Square", "Triangle"}
+	if got := ut.Order; len(got) != len(want) {
+		t.Fatalf("Order len=%d, want %d (got %v)", len(got), len(want), got)
+	}
+	for i, name := range want {
+		if ut.Order[i] != name {
+			t.Errorf("Order[%d] = %q, want %q", i, ut.Order[i], name)
+		}
+	}
+	for _, name := range want {
+		if _, ok := ut.Variants[name]; !ok {
+			t.Errorf("variant %q missing from Variants map", name)
+		}
+	}
+}


### PR DESCRIPTION
Closes #21230. MEP 4 §6 priority-five item.

\`UnionType.Variants\` is a Go map and has no stable iteration order, so the formatter, the C# switch-table emitter, and the OCaml/Pascal/Scheme/Zig backends were reconstructing declaration order from the parser tree.

UnionType now carries \`Order []string\` populated from the type-decl checker in declaration order. The map stays for lookup; the slice is the canonical iteration sequence. Additive change: existing iteration over \`Variants\` keeps working and consumers can migrate to \`Order\` opportunistically.

Test: \`types/union_order_test.go\` pins a three-variant declaration against \`Order\` and confirms \`Variants\` still contains every name.

Refs MEP 4 (#21223) §6 problem 11.