### PR TITLE
types: document *TypeVar pointer-receiver convention (MEP-4 P14)

### DIFF
--- a/types/check.go
+++ b/types/check.go
@@ -101,6 +101,16 @@ type AnyType struct{}
 
 func (AnyType) String() string { return "any" }
 
+// TypeVar is the polymorphism kind used to represent a generic type
+// parameter. Its methods take a pointer receiver because identity, not
+// value, is what distinguishes two type variables: a fresh `*TypeVar`
+// with the same `Name` as an existing one must compare unequal under
+// unification. Every other kind in this package is a value type with
+// value receivers. If a future kind needs the same identity semantics
+// (a `RowVar` for row polymorphism is the obvious candidate, planned
+// under MEP 11), it should follow the same convention so callers can
+// rely on a single discriminator (`x.(*TypeVar)` vs `x.(SomeValueKind)`).
+// See MEP 4 §6 problem 14 and MEP 12.
 type TypeVar struct {
 	Name string
 }


### PR DESCRIPTION
## Summary
- Add a doc comment to `TypeVar` explaining why it uses pointer receivers while every other kind in the package is a value type
- Identity (not value) is what distinguishes two type variables, so a fresh `*TypeVar` with the same `Name` must compare unequal under unification
- Notes the convention so future identity-bearing kinds (planned `RowVar` under MEP 11) keep `x.(*TypeVar)` viable as the single discriminator

## Test plan
- [x] `go test ./types/`
- [x] Existing TypeVar consumers unchanged (doc-only)

Closes #21232. Refs MEP 4 §6 problem 14.