### PR TITLE
types: Env.Copy preserves parent chain (MEP-4 P17)

### DIFF
--- a/types/env.go
+++ b/types/env.go
@@ -285,11 +285,16 @@ func (e *Env) GetFunc(name string) (*parser.FunStmt, bool) {
 	return nil, false
 }
 
-// Copy creates a shallow copy of the current environment with no parent.
-// Useful for closures capturing current bindings.
+// Copy creates a shallow copy of the current environment that keeps the
+// parent chain intact. The local maps are cloned so that mutations to the
+// copy do not leak back into the original scope, while the parent pointer
+// is preserved so lookups in the copy still see bindings from enclosing
+// scopes. This matches standard lexical-closure semantics and fixes MEP 4
+// §6 problem 17 where the previous flatten-and-detach behaviour dropped
+// outer-scope bindings from closures defined inside nested scopes.
 func (e *Env) Copy() *Env {
 	newEnv := &Env{
-		parent:  nil, // flatten parent chain
+		parent:  e.parent,
 		types:   make(map[string]Type, len(e.types)),
 		mut:     make(map[string]bool, len(e.mut)),
 		values:  make(map[string]any, len(e.values)),

--- a/types/env_copy_test.go
+++ b/types/env_copy_test.go
@@ -1,0 +1,30 @@
+package types
+
+import "testing"
+
+// Pin closure-style semantics for Env.Copy. Pre-MEP 4 P17 this method
+// detached the parent chain, so a closure created inside a function body
+// would silently lose bindings from enclosing scopes. The fix is to keep
+// the parent pointer; the local maps are still cloned so that writes to
+// the copy do not leak back into the original.
+func TestEnvCopyPreservesParentChain(t *testing.T) {
+	root := NewEnv(nil)
+	root.SetValue("outer", 100, false)
+
+	mid := NewEnv(root)
+	mid.SetValue("inner", 10, true)
+
+	cp := mid.Copy()
+
+	if v, err := cp.GetValue("inner"); err != nil || v != 10 {
+		t.Fatalf("local value lost: v=%v err=%v", v, err)
+	}
+	if v, err := cp.GetValue("outer"); err != nil || v != 100 {
+		t.Fatalf("outer value not visible through preserved parent: v=%v err=%v", v, err)
+	}
+
+	cp.SetValue("inner", 99, true)
+	if v, err := mid.GetValue("inner"); err != nil || v != 10 {
+		t.Fatalf("mutation on copy leaked into original: v=%v err=%v", v, err)
+	}
+}


### PR DESCRIPTION
## Summary
- `Env.Copy` previously did `parent: nil` and only cloned the receiver's local maps, so closures captured inside nested scopes silently lost outer-scope bindings
- Set `parent: e.parent` and keep the local-map clones so writes through the copy still don't leak back into the original scope
- Adds `TestEnvCopyPreservesParentChain` to pin the new behaviour and guard against regression

This isn't user-visible on `mochi run` (the VM resolves names at compile time) but it does affect the interpreter, `consteval`, and a few transpiler paths.

## Test plan
- [x] `go test ./types/`
- [x] `go test ./interpreter/`
- [x] `go test ./tests/...` (vm_extended passes)
- [x] manual: nested closure resolves an outer-scope binding via `mochi run`

Closes #21234. Refs MEP 4 §6 problem 17.