### PR TITLE
types: drop the FFI lowercase alias from Env.SetFunc (MEP-4 P18)

### DIFF
--- a/types/env.go
+++ b/types/env.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"mochi/parser"
 	"os"
-	"strings"
 )
 
 // ModelSpec defines a named model configuration.
@@ -258,15 +257,11 @@ func (e *Env) GetValue(name string) (any, error) {
 
 // --- Function Binding ---
 
-// SetFunc binds a named function.
+// SetFunc binds a named function. The binding is stored under the exact
+// name; case-folded aliases (if any) belong in the FFI layer that owns
+// the name-mangling policy, not in the language-level binding API.
 func (e *Env) SetFunc(name string, fn *parser.FunStmt) {
 	e.funcs[name] = fn
-	lower := strings.ToLower(name)
-	if lower != name {
-		if _, ok := e.funcs[lower]; !ok {
-			e.funcs[lower] = fn
-		}
-	}
 }
 
 // SetFuncType binds a function name to its static type.

--- a/types/env_setfunc_test.go
+++ b/types/env_setfunc_test.go
@@ -1,0 +1,25 @@
+package types
+
+import (
+	"mochi/parser"
+	"testing"
+)
+
+// Pin the post-MEP 4 P18 contract: SetFunc stores under the exact name
+// only. Earlier the binder auto-added a strings.ToLower alias so a
+// `SetFunc("MyFunc", ...)` could also be retrieved as `myfunc`. Nothing
+// in-tree relied on this lookup form, and the FFI layer is the proper
+// owner of any name-mangling policy.
+func TestSetFuncStoresExactNameOnly(t *testing.T) {
+	env := NewEnv(nil)
+	fn := &parser.FunStmt{Name: "MyFunc"}
+
+	env.SetFunc("MyFunc", fn)
+
+	if got, ok := env.GetFunc("MyFunc"); !ok || got != fn {
+		t.Fatalf("exact-case lookup failed: got=%v ok=%v", got, ok)
+	}
+	if _, ok := env.GetFunc("myfunc"); ok {
+		t.Fatalf("lowercase alias should no longer be added by SetFunc")
+	}
+}


### PR DESCRIPTION
## Summary
- \`SetFunc\` was registering both the exact name and a \`strings.ToLower\` alias on every camelCase function, but nothing in-tree ever looks up the lowercase variant
- Drop the alias so \`SetFunc\` is purely a language-level binding API; any FFI name-mangling policy should live in the FFI layer
- Pin the new contract with \`TestSetFuncStoresExactNameOnly\`

## Test plan
- [x] \`go test ./types/\`
- [x] \`go test ./interpreter/ ./parser/\`
- [x] \`go test ./...\` (no regressions; transpiler suites also clean)

Closes #21236. Refs MEP 4 §6 problem 18.