### PR TITLE
types: inferBinaryType reconciles list + with applyBinaryType (MEP-4 P6)

### DIFF
--- a/types/infer.go
+++ b/types/infer.go
@@ -142,8 +142,24 @@ func inferBinaryType(env *Env, b *parser.BinaryExpr) Type {
 					}
 					if ops[i] == "+" {
 						if ll, ok := left.(ListType); ok {
-							if rl, ok := right.(ListType); ok && equalTypes(ll.Elem, rl.Elem) {
-								res = ll
+							if rl, ok := right.(ListType); ok {
+								// Match applyBinaryType: unify on elem types
+								// so empty-list concatenation ([1] + []) keeps
+								// the concrete element type, but a genuine
+								// mismatch ([int] + [string]) infers AnyType
+								// rather than silently widening to [any]. The
+								// authoritative error is raised by
+								// applyBinaryType in types/check.go.
+								// See MEP 4 §6 problem 6.
+								if unify(ll.Elem, rl.Elem, nil) {
+									if IsAnyType(ll.Elem) {
+										res = rl
+									} else {
+										res = ll
+									}
+									break
+								}
+								res = AnyType{}
 								break
 							}
 							res = ListType{Elem: AnyType{}}

--- a/types/infer_listplus_test.go
+++ b/types/infer_listplus_test.go
@@ -1,0 +1,61 @@
+package types
+
+import (
+	"mochi/parser"
+	"testing"
+)
+
+// Pin the MEP 4 P6 fix to inferBinaryType for `list + list`.
+// Before P6 the inference path used equalTypes, which is strict, so
+// `[1, 2] + []` (right-hand elem AnyType from an empty-list literal)
+// would be silently widened to `[any]` even though applyBinaryType
+// accepted it as `[int]`. Heterogeneous concatenations like
+// `[1] + ["x"]` would also be inferred to `[any]` rather than the
+// honest AnyType that downstream tools can recognise.
+//
+// The new contract:
+//   - `[T] + []` infers to `[T]` (the more concrete elem wins).
+//   - `[T] + [U]` with T != U infers to `AnyType{}`.
+//   - applyBinaryType remains the authoritative error path.
+func TestInferListConcatElemTypes(t *testing.T) {
+	cases := []struct {
+		name   string
+		src    string
+		expect Type
+	}{
+		{
+			name:   "empty list keeps concrete elem",
+			src:    "[1, 2] + []",
+			expect: ListType{Elem: IntType{}},
+		},
+		{
+			name:   "empty list on left also keeps concrete elem",
+			src:    "[] + [1, 2]",
+			expect: ListType{Elem: IntType{}},
+		},
+		{
+			name:   "matching elem types preserved",
+			src:    "[1] + [2]",
+			expect: ListType{Elem: IntType{}},
+		},
+		{
+			name:   "heterogeneous elem types infer to AnyType",
+			src:    "[1] + [\"x\"]",
+			expect: AnyType{},
+		},
+	}
+
+	env := NewEnv(nil)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prog, err := parser.ParseString("let _ = " + tc.src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			got := ExprType(prog.Statements[0].Let.Value, env)
+			if !equalTypes(got, tc.expect) {
+				t.Fatalf("ExprType(%s) = %v, want %v", tc.src, got, tc.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- \`inferBinaryType\` used \`equalTypes\` for \`list + list\`, which disagrees with \`applyBinaryType\`'s permissive \`unify\` on AnyType wildcards
- \`[1] + []\` inferred to \`[any]\` even though Check passed it as \`[int]\`, and \`[int] + [string]\` silently widened to \`[any]\` from \`ExprType\` even though \`applyBinaryType\` raised T020
- Tools that consume \`ExprType\` directly (transpilers, query planners) saw a "valid" list type instead of an honest unknown
- Switch \`inferBinaryType\` to \`unify\` so empty-list concat preserves the concrete elem type, and infer \`AnyType{}\` for genuine mismatches; \`applyBinaryType\` continues to own the error path

## Test plan
- [x] new \`TestInferListConcatElemTypes\` (empty list on each side, matching elems, heterogeneous)
- [x] \`go test ./types/\`
- [x] \`go test ./...\` (no regressions)
- [x] heterogeneous \`[int] + [string]\` still raises T020 via \`mochi run\`

Closes #21238. Refs MEP 4 §6 problem 6.