### PR TITLE
types: rewrite equalTypes as an exhaustive switch (MEP-4 P15)

### DIFF
--- a/types/equal_types_test.go
+++ b/types/equal_types_test.go
@@ -1,0 +1,106 @@
+package types
+
+import "testing"
+
+// Pin the post-MEP 4 P15 contract: equalTypes is a closed switch over the
+// known kinds (no reflect.DeepEqual fallback), so adding a new kind is a
+// deliberate edit rather than a silent acceptance. Each kind here has a
+// matching-equal case and a cross-kind not-equal case to lock the
+// per-kind behaviour.
+func TestEqualTypesByKind(t *testing.T) {
+	tv1 := &TypeVar{Name: "T"}
+	tv2 := &TypeVar{Name: "T"}
+
+	cases := []struct {
+		name string
+		a, b Type
+		want bool
+	}{
+		// Reflexive primitives.
+		{"int=int", IntType{}, IntType{}, true},
+		{"int=int64 (carve-out)", IntType{}, Int64Type{}, true},
+		{"int=float", IntType{}, FloatType{}, false},
+		{"float=float", FloatType{}, FloatType{}, true},
+		{"bigint=bigint", BigIntType{}, BigIntType{}, true},
+		{"bigrat=bigrat", BigRatType{}, BigRatType{}, true},
+		{"string=string", StringType{}, StringType{}, true},
+		{"string=int", StringType{}, IntType{}, false},
+		{"bool=bool", BoolType{}, BoolType{}, true},
+		{"unit=unit", UnitType{}, UnitType{}, true},
+		{"unit=int", UnitType{}, IntType{}, false},
+		{"any=any", AnyType{}, AnyType{}, true},
+		{"any=int", AnyType{}, IntType{}, false},
+		// Structural kinds.
+		{"list elem matches", ListType{Elem: IntType{}}, ListType{Elem: IntType{}}, true},
+		{"list elem differs", ListType{Elem: IntType{}}, ListType{Elem: StringType{}}, false},
+		{"map matches", MapType{Key: StringType{}, Value: IntType{}}, MapType{Key: StringType{}, Value: IntType{}}, true},
+		{"map value differs", MapType{Key: StringType{}, Value: IntType{}}, MapType{Key: StringType{}, Value: StringType{}}, false},
+		{"option matches", OptionType{Elem: IntType{}}, OptionType{Elem: IntType{}}, true},
+		{"option elem differs", OptionType{Elem: IntType{}}, OptionType{Elem: StringType{}}, false},
+		{"group matches", GroupType{Key: StringType{}, Elem: IntType{}}, GroupType{Key: StringType{}, Elem: IntType{}}, true},
+		// Struct/union name-based equality and struct-in-union carve-out.
+		{
+			"struct same name",
+			StructType{Name: "User", Fields: map[string]Type{"id": IntType{}}},
+			StructType{Name: "User", Fields: map[string]Type{"id": IntType{}}},
+			true,
+		},
+		{
+			"struct different name",
+			StructType{Name: "User"},
+			StructType{Name: "Admin"},
+			false,
+		},
+		{
+			"struct equals union it is a variant of",
+			StructType{Name: "Circle"},
+			UnionType{Name: "Shape", Variants: map[string]StructType{"Circle": {Name: "Circle"}}},
+			true,
+		},
+		{
+			"union equals struct that is one of its variants",
+			UnionType{Name: "Shape", Variants: map[string]StructType{"Square": {Name: "Square"}}},
+			StructType{Name: "Square"},
+			true,
+		},
+		{
+			"struct does not equal unrelated union",
+			StructType{Name: "Triangle"},
+			UnionType{Name: "Shape", Variants: map[string]StructType{"Circle": {Name: "Circle"}}},
+			false,
+		},
+		// Functions: arity, variadicity, return, and per-param equality.
+		{
+			"func match",
+			FuncType{Params: []Type{IntType{}}, Return: BoolType{}},
+			FuncType{Params: []Type{IntType{}}, Return: BoolType{}},
+			true,
+		},
+		{
+			"func variadic mismatch",
+			FuncType{Params: []Type{IntType{}}, Return: BoolType{}, Variadic: true},
+			FuncType{Params: []Type{IntType{}}, Return: BoolType{}},
+			false,
+		},
+		{
+			"func return mismatch",
+			FuncType{Params: []Type{IntType{}}, Return: BoolType{}},
+			FuncType{Params: []Type{IntType{}}, Return: IntType{}},
+			false,
+		},
+		// TypeVar identity by pointer, not name.
+		{"typevar same pointer", tv1, tv1, true},
+		{"typevar same name different pointer", tv1, tv2, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := equalTypes(tc.a, tc.b); got != tc.want {
+				t.Fatalf("equalTypes(%s, %s) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+			// Symmetry: equalTypes must agree in both directions.
+			if got := equalTypes(tc.b, tc.a); got != tc.want {
+				t.Fatalf("equalTypes(%s, %s) = %v (reverse), want %v", tc.b, tc.a, got, tc.want)
+			}
+		})
+	}
+}

--- a/types/infer.go
+++ b/types/infer.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"reflect"
 	"strings"
 
 	"mochi/ast"
@@ -825,54 +824,118 @@ func unionFieldPathType(ut UnionType, tail []string) (Type, bool) {
 	return result, true
 }
 
+// equalTypes is the structural-equality relation on Type kinds. Each kind
+// in the type-system table (types/check.go:16-140) gets its own case so a
+// new kind cannot be silently treated as equal by reflect.DeepEqual.
+// Equality is symmetric, so each case only needs to handle the matching
+// kind on the other side (with the explicit struct/union carve-out so a
+// struct counts as equal to a union it is a variant of).
+//
+// The int/int64 carve-out is preserved verbatim: until MEP 5 lands the
+// final numeric tower decision, the checker needs int and int64 to be
+// interchangeable. Tracked separately under MEP 4 §6 problem 1.
+//
+// See MEP 4 §6 problem 15.
 func equalTypes(a, b Type) bool {
-	if _, ok := a.(AnyType); ok {
-		_, ok2 := b.(AnyType)
-		return ok2
+	// int/int64 carve-out. Both kinds use the same Go-level int64
+	// storage, and most numeric builtins return int64 while user code
+	// is typed at int.
+	if (isInt(a) || isInt64(a)) && (isInt(b) || isInt64(b)) {
+		return true
 	}
-	if _, ok := b.(AnyType); ok {
-		_, ok2 := a.(AnyType)
-		return ok2
-	}
-	if la, ok := a.(ListType); ok {
-		if lb, ok := b.(ListType); ok {
-			return equalTypes(la.Elem, lb.Elem)
+	switch at := a.(type) {
+	case IntType:
+		_, ok := b.(IntType)
+		return ok
+	case Int64Type:
+		_, ok := b.(Int64Type)
+		return ok
+	case FloatType:
+		_, ok := b.(FloatType)
+		return ok
+	case BigIntType:
+		_, ok := b.(BigIntType)
+		return ok
+	case BigRatType:
+		_, ok := b.(BigRatType)
+		return ok
+	case StringType:
+		_, ok := b.(StringType)
+		return ok
+	case BoolType:
+		_, ok := b.(BoolType)
+		return ok
+	case UnitType:
+		_, ok := b.(UnitType)
+		return ok
+	case AnyType:
+		_, ok := b.(AnyType)
+		return ok
+	case ListType:
+		bt, ok := b.(ListType)
+		if !ok {
+			return false
 		}
-	}
-	if ma, ok := a.(MapType); ok {
-		if mb, ok := b.(MapType); ok {
-			return equalTypes(ma.Key, mb.Key) && equalTypes(ma.Value, mb.Value)
+		return equalTypes(at.Elem, bt.Elem)
+	case MapType:
+		bt, ok := b.(MapType)
+		if !ok {
+			return false
 		}
-	}
-	if oa, ok := a.(OptionType); ok {
-		if ob, ok := b.(OptionType); ok {
-			return equalTypes(oa.Elem, ob.Elem)
+		return equalTypes(at.Key, bt.Key) && equalTypes(at.Value, bt.Value)
+	case OptionType:
+		bt, ok := b.(OptionType)
+		if !ok {
+			return false
 		}
-	}
-	if ua, ok := a.(UnionType); ok {
-		if sb, ok := b.(StructType); ok {
-			if _, ok := ua.Variants[sb.Name]; ok {
-				return true
+		return equalTypes(at.Elem, bt.Elem)
+	case GroupType:
+		bt, ok := b.(GroupType)
+		if !ok {
+			return false
+		}
+		return equalTypes(at.Key, bt.Key) && equalTypes(at.Elem, bt.Elem)
+	case StructType:
+		switch bt := b.(type) {
+		case StructType:
+			return at.Name == bt.Name
+		case UnionType:
+			_, ok := bt.Variants[at.Name]
+			return ok
+		}
+		return false
+	case UnionType:
+		switch bt := b.(type) {
+		case UnionType:
+			return at.Name == bt.Name
+		case StructType:
+			_, ok := at.Variants[bt.Name]
+			return ok
+		}
+		return false
+	case FuncType:
+		bt, ok := b.(FuncType)
+		if !ok {
+			return false
+		}
+		if len(at.Params) != len(bt.Params) || at.Variadic != bt.Variadic {
+			return false
+		}
+		for i := range at.Params {
+			if !equalTypes(at.Params[i], bt.Params[i]) {
+				return false
 			}
 		}
-	}
-	if ub, ok := b.(UnionType); ok {
-		if sa, ok := a.(StructType); ok {
-			if _, ok := ub.Variants[sa.Name]; ok {
-				return true
-			}
+		return equalTypes(at.Return, bt.Return)
+	case *TypeVar:
+		bt, ok := b.(*TypeVar)
+		if !ok {
+			return false
 		}
+		// TypeVar identity is by pointer (MEP 4 §6 problem 14).
+		return at == bt
 	}
-	if isInt64(a) && (isInt64(b) || isInt(b)) {
-		return true
-	}
-	if isInt64(b) && (isInt64(a) || isInt(a)) {
-		return true
-	}
-	if isInt(a) && isInt(b) {
-		return true
-	}
-	return reflect.DeepEqual(a, b)
+	return false
 }
 
 func isInt64(t Type) bool  { _, ok := t.(Int64Type); return ok }


### PR DESCRIPTION
## Summary
- \`equalTypes\` used a chain of type asserts that fell through to \`reflect.DeepEqual\`; new kinds silently inherited DeepEqual behaviour with no compile-time signal
- Rewrite as a closed switch over the dynamic kind: every Type in the kind table has its own arm; \`*TypeVar\` uses pointer identity (MEP 4 §6 problem 14); the int/int64 carve-out is preserved at the top (deferred to MEP 5)
- Drop the \`reflect\` import from \`types/infer.go\`
- New \`TestEqualTypesByKind\` covers every kind in both directions plus the struct-as-union-variant carve-out

## Test plan
- [x] \`go test ./types/\`
- [x] \`go test ./...\` (no regressions)

Closes #21240. Refs MEP 4 §6 problem 15.