### PR TITLE
types: add MEP-4 §6 soundness regression suite (P38)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,6 @@ jobs:
             -coverprofile=coverage.txt \
             -covermode=atomic \
             ./parser/... ./runtime/vm/...
+
+      - name: Run MEP-4 soundness suite
+        run: go test -vet=off -v ./types/... -run TestSoundness

--- a/tests/types/soundness/p06_list_plus_heterogeneous.error
+++ b/tests/types/soundness/p06_list_plus_heterogeneous.error
@@ -1,0 +1,8 @@
+ 1. error[T020]: operator `+` cannot be used on types [int] and [string]
+  --> tests/types/soundness/p06_list_plus_heterogeneous.mochi:2:19
+
+  2 | let _ = [1, 2, 3] + ["a", "b"]
+    |                   ^
+
+help:
+  Choose an operator that supports these operand types.

--- a/tests/types/soundness/p06_list_plus_heterogeneous.mochi
+++ b/tests/types/soundness/p06_list_plus_heterogeneous.mochi
@@ -1,0 +1,2 @@
+// MEP-4 P6: list `+` with mismatched element types is rejected.
+let _ = [1, 2, 3] + ["a", "b"]

--- a/tests/types/soundness/p06_list_plus_strict.expect
+++ b/tests/types/soundness/p06_list_plus_strict.expect
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/soundness/p06_list_plus_strict.mochi
+++ b/tests/types/soundness/p06_list_plus_strict.mochi
@@ -1,0 +1,3 @@
+// MEP-4 P6: list `+` on matching element types preserves the element type.
+let a: list<int> = [1, 2] + [3]
+let b: list<string> = ["x"] + ["y", "z"]

--- a/tests/types/soundness/p08_unknown_type_name.error
+++ b/tests/types/soundness/p08_unknown_type_name.error
@@ -1,0 +1,8 @@
+ 1. error[T025]: unknown type: Nope
+  --> tests/types/soundness/p08_unknown_type_name.mochi:2:8
+
+  2 | let x: Nope = 1
+    |        ^
+
+help:
+  Ensure the type is defined before use.

--- a/tests/types/soundness/p08_unknown_type_name.mochi
+++ b/tests/types/soundness/p08_unknown_type_name.mochi
@@ -1,0 +1,2 @@
+// MEP-4 P8: a reference to an undeclared type name is reported as T025.
+let x: Nope = 1

--- a/tests/types/soundness/p09_compare_struct_int.error
+++ b/tests/types/soundness/p09_compare_struct_int.error
@@ -1,0 +1,8 @@
+ 1. error[T013]: incompatible types in comparison
+  --> tests/types/soundness/p09_compare_struct_int.mochi:4:11
+
+  4 | let _ = u == 5
+    |           ^
+
+help:
+  Use comparable types like numbers or strings with `<`, `>`.

--- a/tests/types/soundness/p09_compare_struct_int.mochi
+++ b/tests/types/soundness/p09_compare_struct_int.mochi
@@ -1,0 +1,4 @@
+// MEP-4 P9: comparing a struct value with an int has no sensible meaning.
+type User { id: int }
+let u: User = User{id: 1}
+let _ = u == 5

--- a/tests/types/soundness/p11_union_order.expect
+++ b/tests/types/soundness/p11_union_order.expect
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/soundness/p11_union_order.mochi
+++ b/tests/types/soundness/p11_union_order.mochi
@@ -1,0 +1,14 @@
+// MEP-4 P11: union variants iterate in declaration order. Exhaustive match
+// must reach every arm in the order the user wrote them.
+type Shape =
+  Circle(r: int)
+| Square(s: int)
+| Triangle(b: int, h: int)
+
+let sh: Shape = Triangle(3, 4)
+let label: string = match sh {
+  Circle(_) => "c"
+  Square(_) => "s"
+  Triangle(_, _) => "t"
+}
+expect label == "t"

--- a/tests/types/soundness/p15_struct_equality.expect
+++ b/tests/types/soundness/p15_struct_equality.expect
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/soundness/p15_struct_equality.mochi
+++ b/tests/types/soundness/p15_struct_equality.mochi
@@ -1,0 +1,11 @@
+// MEP-4 P15: structural type equality (the equalTypes rewrite) keeps
+// nominally-equal struct types interchangeable when their shapes line up.
+type Pair {
+  x: int
+  y: int
+}
+
+let p1: Pair = Pair{x: 1, y: 2}
+let p2: Pair = Pair{x: p1.x, y: p1.y}
+expect p1.x == p2.x
+expect p1.y == p2.y

--- a/tests/types/soundness/p17_env_copy_closure.expect
+++ b/tests/types/soundness/p17_env_copy_closure.expect
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/soundness/p17_env_copy_closure.mochi
+++ b/tests/types/soundness/p17_env_copy_closure.mochi
@@ -1,0 +1,8 @@
+// MEP-4 P17: Env.Copy preserves the parent chain, so closures still see
+// names from their enclosing scope after the environment is captured.
+let base: int = 100
+fun makeAdder(n: int): fun(int): int {
+  return fun(x: int): int => x + n + base
+}
+let add10 = makeAdder(10)
+expect add10(7) == 117

--- a/tests/types/soundness/p18_setfunc_no_lowercase.error
+++ b/tests/types/soundness/p18_setfunc_no_lowercase.error
@@ -1,0 +1,8 @@
+ 1. error[T003]: unknown function: myfunc
+  --> tests/types/soundness/p18_setfunc_no_lowercase.mochi:6:9
+
+  6 | let _ = myfunc(5)
+    |         ^
+
+help:
+  Ensure the function is defined before it's called.

--- a/tests/types/soundness/p18_setfunc_no_lowercase.mochi
+++ b/tests/types/soundness/p18_setfunc_no_lowercase.mochi
@@ -1,0 +1,6 @@
+// MEP-4 P18: SetFunc no longer auto-aliases function names to lowercase,
+// so calling a lower-cased spelling of a CamelCase function is undefined.
+fun MyFunc(x: int): int {
+  return x * 2
+}
+let _ = myfunc(5)

--- a/tests/types/soundness/p19_unit_surface_type.expect
+++ b/tests/types/soundness/p19_unit_surface_type.expect
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/soundness/p19_unit_surface_type.mochi
+++ b/tests/types/soundness/p19_unit_surface_type.mochi
@@ -1,0 +1,7 @@
+// MEP-4 P19: `unit` is a first-class surface type, usable as a return
+// annotation and as the element type of a function-typed binding.
+fun noop(): unit {
+  print("noop")
+}
+let n: fun(): unit = noop
+n()

--- a/types/soundness_test.go
+++ b/types/soundness_test.go
@@ -1,0 +1,111 @@
+package types_test
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"mochi/parser"
+	"mochi/types"
+)
+
+var updateSoundness = flag.Bool("update-soundness", false, "update .expect/.error fixtures from current checker output")
+
+// TestSoundness exercises the MEP-4 §6 fixes. Each fixture has a header
+// comment naming the problem number, plus a sibling `.expect` file (asserts
+// type check passes) or `.error` file (asserts type check fails with the
+// recorded diagnostic). Regressing any fix here means the fixture flips.
+func TestSoundness(t *testing.T) {
+	dir := filepath.Join("..", "tests", "types", "soundness")
+	files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
+	if err != nil {
+		t.Fatalf("glob %s: %v", dir, err)
+	}
+	if len(files) == 0 {
+		t.Fatalf("no soundness fixtures found in %s", dir)
+	}
+	sort.Strings(files)
+
+	for _, src := range files {
+		src := src
+		name := strings.TrimSuffix(filepath.Base(src), ".mochi")
+		t.Run(name, func(t *testing.T) {
+			expectPath := strings.TrimSuffix(src, ".mochi") + ".expect"
+			errorPath := strings.TrimSuffix(src, ".mochi") + ".error"
+			hasExpect := fileExists(expectPath)
+			hasError := fileExists(errorPath)
+			if hasExpect == hasError {
+				t.Fatalf("fixture %s must have exactly one of .expect or .error (have expect=%v error=%v)", filepath.Base(src), hasExpect, hasError)
+			}
+
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse %s: %v", src, err)
+			}
+
+			env := types.NewEnv(nil)
+			errs := types.Check(prog, env)
+
+			if hasExpect {
+				if len(errs) > 0 {
+					t.Fatalf("expected type check to pass, got %d error(s):\n%s", len(errs), formatErrs(errs))
+				}
+				compareOrUpdate(t, expectPath, "✅ Type Check Passed\n")
+				return
+			}
+
+			if len(errs) == 0 {
+				t.Fatalf("expected at least one type error, got none")
+			}
+			compareOrUpdate(t, errorPath, formatErrs(errs))
+		})
+	}
+}
+
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+func formatErrs(errs []error) string {
+	var b strings.Builder
+	for i, e := range errs {
+		fmt.Fprintf(&b, "%2d. %v\n", i+1, e)
+	}
+	return b.String()
+}
+
+// soundnessPathRE strips any absolute path prefix up to the soundness dir so
+// fixtures stay portable across checkouts.
+var soundnessPathRE = regexp.MustCompile(`[^ \n\t]*tests/types/soundness/`)
+
+func normalizeSoundness(s string) string {
+	s = soundnessPathRE.ReplaceAllString(s, "tests/types/soundness/")
+	s = strings.TrimRight(s, "\n") + "\n"
+	return s
+}
+
+func compareOrUpdate(t *testing.T, path, got string) {
+	t.Helper()
+	got = normalizeSoundness(got)
+	if *updateSoundness {
+		if err := os.WriteFile(path, []byte(got), 0644); err != nil {
+			t.Fatalf("update %s: %v", path, err)
+		}
+		t.Logf("updated %s", path)
+		return
+	}
+	wantBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v (run with -update-soundness to create)", path, err)
+	}
+	want := normalizeSoundness(string(wantBytes))
+	if got != want {
+		t.Errorf("mismatch in %s\n--- got ---\n%s--- want ---\n%s", filepath.Base(path), got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `tests/types/soundness/` with one fixture per closed MEP-4 §6 fix (P6, P8, P9, P11, P15, P17, P18, P19), each pointing back to the proposal in a header comment.
- New `types/soundness_test.go` driver walks the dir and asserts every fixture matches its sibling `.expect` or `.error`. Pass `-update-soundness` to refresh after intentional changes.
- Extends `.github/workflows/test.yml` with a "Run MEP-4 soundness suite" step so the corpus runs on every PR alongside parser and VM tests.

## Test plan
- [x] `go test ./types/... -run TestSoundness -v` (all 9 fixtures pass)
- [x] `go test ./types/...` (full types suite green)
- [x] Toggle each fix off locally to confirm the matching fixture turns red.

Closes #21243. Refs MEP-4 §6.