### PR TITLE
types: pre-register type names so forward refs in fun signatures still resolve (P8 follow-up)

### DIFF
--- a/tests/types/soundness/p08b_forward_struct_ref.expect
+++ b/tests/types/soundness/p08b_forward_struct_ref.expect
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/soundness/p08b_forward_struct_ref.mochi
+++ b/tests/types/soundness/p08b_forward_struct_ref.mochi
@@ -1,0 +1,15 @@
+// MEP-4 P8 follow-up (#21245): functions can reference struct types that
+// are declared later in the file. Type names are pre-registered before
+// the function-decl pass walks signatures.
+fun id(p: Pair): Pair {
+  return p
+}
+
+type Pair {
+  x: int
+  y: int
+}
+
+let p: Pair = Pair{x: 1, y: 2}
+let q: Pair = id(p)
+expect q.x == 1

--- a/types/check.go
+++ b/types/check.go
@@ -634,6 +634,35 @@ func Check(prog *parser.Program, env *Env) []error {
 
 	var errs []error
 
+	// Pre-pass: register struct and union name stubs so the function pass
+	// below can resolve forward references in parameter and return types.
+	// The dedicated type-declaration pass that follows replaces each stub
+	// with the fully populated shape.
+	for _, stmt := range prog.Statements {
+		if stmt.Type == nil {
+			continue
+		}
+		if len(stmt.Type.Members) > 0 {
+			stub := StructType{Name: stmt.Type.Name}
+			env.SetStruct(stmt.Type.Name, stub)
+			env.types[stmt.Type.Name] = stub
+			continue
+		}
+		if len(stmt.Type.Variants) > 0 {
+			variants := map[string]StructType{}
+			for _, v := range stmt.Type.Variants {
+				vs := StructType{Name: v.Name}
+				variants[v.Name] = vs
+				env.SetStruct(v.Name, vs)
+			}
+			stub := UnionType{Name: stmt.Type.Name, Variants: variants}
+			env.SetUnion(stmt.Type.Name, stub)
+			env.types[stmt.Type.Name] = stub
+		}
+		// Type aliases are handled during the dedicated pass; the right
+		// hand side may itself be a forward reference.
+	}
+
 	// First pass: gather all function declarations so methods defined in types
 	// can reference them regardless of order in the source file.
 	for _, stmt := range prog.Statements {


### PR DESCRIPTION
## Summary
- Adds a name-only pre-pass in `types.Check` that registers each top-level struct/union name with a stub before the function-decl pass runs, so forward references in parameter and return types resolve to the stub instead of tripping T025.
- The dedicated type-declaration pass below still replaces the stub with the fully populated shape; the final function-body pass re-resolves signatures against the populated env, so callers see real fields.
- New soundness fixture `p08b_forward_struct_ref` covers the canonical reproducer (`fun id(p: Pair): Pair` declared before `type Pair { x: int, y: int }`).

## Test plan
- [x] `go test ./types/... -run TestSoundness` (10 fixtures including the new one)
- [x] `go test ./types/...` (full types suite green)
- [x] `go test ./parser/...` and `go test ./runtime/...` (no regressions)
- [x] Reverted the pre-pass locally and confirmed the new fixture turns red as expected.

Closes #21245. Refs MEP-4 §6 P8 (#21227).