### PR TITLE
types: handle bare `return` in unit-returning functions (P19 follow-up)

### DIFF
--- a/tests/types/soundness/p19b_bare_return_unit.expect
+++ b/tests/types/soundness/p19b_bare_return_unit.expect
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/soundness/p19b_bare_return_unit.mochi
+++ b/tests/types/soundness/p19b_bare_return_unit.mochi
@@ -1,0 +1,7 @@
+// MEP-4 P19 follow-up (#21246): a bare `return` inside a unit-returning
+// function used to nil-deref the checker. The Return arm now treats a
+// missing value as `unit` and unifies it against the expected type.
+fun noop(): unit {
+  return
+}
+noop()

--- a/tests/types/soundness/p19c_bare_return_non_unit.error
+++ b/tests/types/soundness/p19c_bare_return_non_unit.error
@@ -1,0 +1,8 @@
+ 1. error[T010]: return type mismatch: expected int, got unit
+  --> tests/types/soundness/p19c_bare_return_non_unit.mochi:4:3
+
+  4 |   return
+    |   ^
+
+help:
+  Update the return value to match the function's return type.

--- a/tests/types/soundness/p19c_bare_return_non_unit.mochi
+++ b/tests/types/soundness/p19c_bare_return_non_unit.mochi
@@ -1,0 +1,5 @@
+// MEP-4 P19 follow-up: a bare `return` in a function that promised a
+// non-unit return type is a return-type mismatch, not a nil-deref panic.
+fun answer(): int {
+  return
+}

--- a/types/check.go
+++ b/types/check.go
@@ -1296,6 +1296,12 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 		return err
 
 	case s.Return != nil:
+		if s.Return.Value == nil {
+			if !unify(UnitType{}, expectedReturn, nil) {
+				return errReturnMismatch(s.Return.Pos, expectedReturn, UnitType{})
+			}
+			return nil
+		}
 		actual, err := checkExprWithExpected(s.Return.Value, env, expectedReturn)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary
- `checkStmt` forwarded `s.Return.Value` to `checkExprWithExpected` unconditionally, which nil-deref'd on `fun noop(): unit { return }`. The Return arm now treats a missing value as `unit` and unifies it against the declared return type.
- A bare return in a function declared with a non-unit return type now produces a clean T010 mismatch instead of a panic.
- Two soundness fixtures (`p19b_bare_return_unit`, `p19c_bare_return_non_unit`) lock the behaviour in both directions.

## Test plan
- [x] `go test ./types/... -run TestSoundness` (12 fixtures including the two new ones)
- [x] `go test ./types/...` (full types suite green)
- [x] `go run ./cmd/mochi run` on the unit and non-unit bare-return reproducers no longer panics.

Closes #21246. Refs MEP-4 §6 P19 (#21225).