### PR TITLE
types: encode varargs as a separate FuncType field (MEP-4 P13)

### DIFF
--- a/compiler/x/rust/compiler.go
+++ b/compiler/x/rust/compiler.go
@@ -3940,7 +3940,7 @@ func (c *Compiler) compileCall(call *parser.CallExpr) (string, error) {
 					}
 				}
 			}
-			if !ft.Variadic && len(args) < len(ft.Params) {
+			if ft.Variadic == nil && len(args) < len(ft.Params) {
 				missing := len(ft.Params) - len(args)
 				params := make([]string, missing)
 				for i := range params {

--- a/compiler/x/ts/helpers.go
+++ b/compiler/x/ts/helpers.go
@@ -316,11 +316,10 @@ func tsType(t types.Type) string {
 	case types.FuncType:
 		var args []string
 		for i, p := range tt.Params {
-			arg := fmt.Sprintf("p%d: %s", i, tsType(p))
-			if tt.Variadic && i == len(tt.Params)-1 {
-				arg = "..." + arg
-			}
-			args = append(args, arg)
+			args = append(args, fmt.Sprintf("p%d: %s", i, tsType(p)))
+		}
+		if tt.Variadic != nil {
+			args = append(args, fmt.Sprintf("...p%d: %s[]", len(tt.Params), tsType(tt.Variadic)))
 		}
 		ret := tsType(tt.Return)
 		return fmt.Sprintf("(%s) => %s", strings.Join(args, ", "), ret)

--- a/transpiler/x/clj/transpiler.go
+++ b/transpiler/x/clj/transpiler.go
@@ -3406,7 +3406,7 @@ func transpileCall(c *parser.CallExpr) (Node, error) {
 		} else if transpileEnv != nil {
 			if typ, err := transpileEnv.GetVar(string(sym)); err == nil {
 				callArity := len(elems) - 1
-				if ft, ok := typ.(types.FuncType); ok && !ft.Variadic && len(ft.Params) > callArity {
+				if ft, ok := typ.(types.FuncType); ok && ft.Variadic == nil && len(ft.Params) > callArity {
 					elems = append([]Node{Symbol("partial"), sym}, elems[1:]...)
 					return &List{Elems: elems}, nil
 				}

--- a/types/check.go
+++ b/types/check.go
@@ -122,11 +122,15 @@ type TypeVar struct {
 
 func (t *TypeVar) String() string { return t.Name }
 
+// FuncType is the type of a function value. Params is the fixed prefix
+// of parameter types. Variadic is the element type of the trailing
+// varargs sequence, or nil if the function is not variadic (MEP 4 P13).
+// Pure is the inferred purity flag (MEP 4 P7).
 type FuncType struct {
 	Params   []Type
 	Return   Type
 	Pure     bool
-	Variadic bool
+	Variadic Type
 }
 
 func (f FuncType) String() string {
@@ -137,11 +141,11 @@ func (f FuncType) String() string {
 		}
 		s += p.String()
 	}
-	if f.Variadic {
+	if f.Variadic != nil {
 		if len(f.Params) > 0 {
-			s += ", ..."
+			s += ", ..." + f.Variadic.String()
 		} else {
-			s += "..."
+			s += "..." + f.Variadic.String()
 		}
 	}
 	s += ")"
@@ -309,13 +313,19 @@ func unify(a, b Type, subst Subst) bool {
 
 	case FuncType:
 		bt, ok := b.(FuncType)
-		if !ok || at.Variadic != bt.Variadic || len(at.Params) != len(bt.Params) {
+		if !ok || len(at.Params) != len(bt.Params) {
+			return false
+		}
+		if (at.Variadic == nil) != (bt.Variadic == nil) {
 			return false
 		}
 		for i := range at.Params {
 			if !unify(at.Params[i], bt.Params[i], subst) {
 				return false
 			}
+		}
+		if at.Variadic != nil && !unify(at.Variadic, bt.Variadic, subst) {
+			return false
 		}
 		return unify(at.Return, bt.Return, subst)
 
@@ -399,9 +409,9 @@ func unify(a, b Type, subst Subst) bool {
 
 func Check(prog *parser.Program, env *Env) []error {
 	env.SetVar("print", FuncType{
-		Params:   []Type{AnyType{}},
+		Params:   []Type{},
 		Return:   UnitType{},
-		Variadic: true,
+		Variadic: AnyType{},
 	}, false)
 	env.SetVar("len", FuncType{
 		Params: []Type{AnyType{}}, // loosely typed
@@ -414,10 +424,10 @@ func Check(prog *parser.Program, env *Env) []error {
 		Pure:   true,
 	}, false)
 	env.SetVar("concat", FuncType{
-		Params:   []Type{ListType{Elem: AnyType{}}},
+		Params:   []Type{},
 		Return:   ListType{Elem: AnyType{}},
 		Pure:     true,
-		Variadic: true,
+		Variadic: ListType{Elem: AnyType{}},
 	}, false)
 	env.SetVar("first", FuncType{
 		Params: []Type{ListType{Elem: AnyType{}}},
@@ -455,10 +465,10 @@ func Check(prog *parser.Program, env *Env) []error {
 		Pure:   true,
 	}, false)
 	env.SetVar("range", FuncType{
-		Params:   []Type{IntType{}},
+		Params:   []Type{},
 		Return:   ListType{Elem: IntType{}},
 		Pure:     true,
-		Variadic: true,
+		Variadic: IntType{},
 	}, false)
 	env.SetVar("now", FuncType{
 		Params: []Type{},
@@ -1923,7 +1933,7 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 		argCount := len(p.Call.Args)
 		paramCount := len(ft.Params)
 
-		if exp, ok := builtinArity[p.Call.Func]; ok && !ft.Variadic {
+		if exp, ok := builtinArity[p.Call.Func]; ok && ft.Variadic == nil {
 			if _, defined := env.GetFunc(p.Call.Func); !defined {
 				if argCount != exp {
 					return nil, errArgCount(p.Pos, p.Call.Func, exp, argCount)
@@ -1931,15 +1941,13 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 			}
 		}
 
-		if !ft.Variadic && argCount > paramCount {
+		if ft.Variadic == nil && argCount > paramCount {
 			return nil, errTooManyArgs(p.Pos, paramCount, argCount)
 		}
 
-		// check fixed parameters
+		// Params is the fixed prefix; ft.Variadic (if non-nil) types the
+		// trailing varargs sequence (MEP 4 P13).
 		fixed := paramCount
-		if ft.Variadic && paramCount > 0 {
-			fixed = paramCount - 1
-		}
 
 		argTypes := make([]Type, argCount)
 		for i := 0; i < argCount && i < fixed; i++ {
@@ -1953,13 +1961,8 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 			}
 		}
 
-		var variadicType Type
-		if ft.Variadic {
-			if paramCount == 0 {
-				variadicType = AnyType{}
-			} else {
-				variadicType = ft.Params[paramCount-1]
-			}
+		if ft.Variadic != nil {
+			variadicType := ft.Variadic
 			for i := fixed; i < argCount; i++ {
 				at, err := checkExprWithExpected(p.Call.Args[i], env, variadicType)
 				if err != nil {

--- a/types/equal_types_test.go
+++ b/types/equal_types_test.go
@@ -78,7 +78,7 @@ func TestEqualTypesByKind(t *testing.T) {
 		},
 		{
 			"func variadic mismatch",
-			FuncType{Params: []Type{IntType{}}, Return: BoolType{}, Variadic: true},
+			FuncType{Params: []Type{IntType{}}, Return: BoolType{}, Variadic: IntType{}},
 			FuncType{Params: []Type{IntType{}}, Return: BoolType{}},
 			false,
 		},

--- a/types/infer.go
+++ b/types/infer.go
@@ -947,13 +947,19 @@ func equalTypes(a, b Type) bool {
 		if !ok {
 			return false
 		}
-		if len(at.Params) != len(bt.Params) || at.Variadic != bt.Variadic {
+		if len(at.Params) != len(bt.Params) {
+			return false
+		}
+		if (at.Variadic == nil) != (bt.Variadic == nil) {
 			return false
 		}
 		for i := range at.Params {
 			if !equalTypes(at.Params[i], bt.Params[i]) {
 				return false
 			}
+		}
+		if at.Variadic != nil && !equalTypes(at.Variadic, bt.Variadic) {
+			return false
 		}
 		return equalTypes(at.Return, bt.Return)
 	case *TypeVar:

--- a/website/docs/mep/mep-0004.md
+++ b/website/docs/mep/mep-0004.md
@@ -63,7 +63,7 @@ Structural kinds carry parameters and are equal by shape. `ListType{Elem}` is a 
 
 Nominal kinds are equal by name. `StructType` carries `Name`, a `Fields map[string]Type`, an `Order []string` that preserves declaration order so JSON encoding is deterministic, and a `Methods map[string]Method` table. `UnionType` carries `Name` and `Variants map[string]StructType`; the variant order from the declaration is captured at type-declaration time but the map itself is unordered (see the problem list).
 
-The function kind is `FuncType{Params, Return, Pure, Variadic}`. `Pure` is propagated but not enforced, tracked in [#21188](https://github.com/mochilang/mochi/issues/21188). `Variadic` is a bool that means "the last entry of `Params` is repeated"; nothing prevents a `FuncType` from carrying `Variadic: true` with an empty `Params`, which the language never produces but the type does not forbid.
+The function kind is `FuncType{Params, Return, Pure, Variadic}`. `Pure` is propagated but not enforced, tracked in [#21188](https://github.com/mochilang/mochi/issues/21188). `Variadic` is the variadic element type and is nil when the function is not variadic; `Params` is the fixed prefix. The split (rather than the older "last entry of `Params` is repeated" convention) was the MEP-4 P13 fix, landed in [#21253](https://github.com/mochilang/mochi/issues/21253).
 
 The polymorphism kind is `TypeVar{Name}`, the only kind whose `String` method has a pointer receiver. It carries a name and exists for the surface syntax of generics; inference does not yet propagate it through call sites. The plan to wire it up is [MEP 12](/docs/mep/mep-0012).
 
@@ -224,7 +224,7 @@ The current design has several known problems. They are listed below without rig
 
 **12. `StructType.Methods` ties `types` to `parser`.** `Method.Decl` is a `*parser.FunStmt`, so the type system module depends on the parser AST. The fix is to keep only the method signature and an opaque body handle, not the AST node. [#21249](https://github.com/mochilang/mochi/issues/21249).
 
-**13. `Variadic` is a bool, not a varargs element type.** Nothing prevents a `FuncType` with `Variadic: true` and an empty `Params`. The convention "the last parameter is the variadic element" is enforced by the surface grammar, not by the type. The fix is to encode varargs as a separate field, or to split `Params` into a fixed prefix and a single variadic element.
+**13. `Variadic` was a bool, not a varargs element type. Fixed.** The original `FuncType.Variadic` was a `bool`, and the convention "the last parameter is the variadic element" was enforced by the surface grammar rather than by the type. `Variadic` is now a `Type` field that carries the variadic element type directly (nil when the function is not variadic) and `Params` is the strict fixed prefix. [#21253](https://github.com/mochilang/mochi/issues/21253).
 
 **14. `*TypeVar` is the only pointer kind.** All other kinds are value types with no methods on a pointer receiver. The pointer is there because identity matters: two `*TypeVar` values with the same name are different variables. Every `switch x.(type)` has to remember the case is `*TypeVar`, not `TypeVar`. The pragmatic fix is to document the rule (polymorphism kinds use pointer receivers; if more arrive, they follow the same shape) once [MEP 12](/docs/mep/mep-0012) lands and the question becomes relevant.
 


### PR DESCRIPTION
## Summary

- Replaces `FuncType.Variadic bool` with `FuncType.Variadic Type` so the variadic element type is a first-class field rather than an implicit convention on the last `Params` entry. Empty `Params` with a variadic element is now the normal shape for `print`, `concat`, and `range`.
- Builtin declarations move the variadic element out of `Params` and into the new field. Checker call-site, `equalTypes`, `unify`, and the TS/Rust/Clojure backends migrate to `ft.Variadic == nil` / `ft.Variadic != nil` checks.
- MEP-4 §Kinds and §Problems P13 are updated to describe the new representation and mark the problem fixed.

Closes #21253. Part of #21222.

## Test plan

- [x] `go build ./...`
- [x] `go test ./types/... -count=1`
- [x] `go test ./parser/... ./runtime/vm/...` (CI suite)