### PR TITLE
types: collapse StructType ordered/map dual representation (MEP 4 P10)

### DIFF
--- a/interpreter/helpers.go
+++ b/interpreter/helpers.go
@@ -109,13 +109,13 @@ func (i *Interpreter) evalMatch(m *parser.MatchExpr) (any, error) {
 			if !ok {
 				continue
 			}
-			if len(call.Args) != len(st.Order) {
+			if len(call.Args) != len(st.Fields) {
 				continue
 			}
 			child := types.NewEnv(i.env)
 			for idx, arg := range call.Args {
 				if n, ok := identName(arg); ok {
-					child.SetValue(n, obj[st.Order[idx]], true)
+					child.SetValue(n, obj[st.Fields[idx].Name], true)
 				}
 			}
 			old := i.env

--- a/interpreter/runtime_utils.go
+++ b/interpreter/runtime_utils.go
@@ -547,16 +547,16 @@ func castValue(pos lexer.Position, t types.Type, v any) (any, error) {
 			return nil, errCastType(pos, v, t)
 		}
 		out := map[string]any{"__name": tt.Name}
-		for name, ft := range tt.Fields {
-			fv, ok := m[name]
+		for _, f := range tt.Fields {
+			fv, ok := m[f.Name]
 			if !ok {
-				return nil, errCastMissingField(pos, name, tt.Name)
+				return nil, errCastMissingField(pos, f.Name, tt.Name)
 			}
-			cv, err := castValue(pos, ft, fv)
+			cv, err := castValue(pos, f.Type, fv)
 			if err != nil {
 				return nil, err
 			}
-			out[name] = cv
+			out[f.Name] = cv
 		}
 		return out, nil
 	default:

--- a/interpreter/schema.go
+++ b/interpreter/schema.go
@@ -39,9 +39,9 @@ func typeToSchema(t types.Type) map[string]any {
 func structToSchema(st types.StructType) map[string]any {
 	props := make(map[string]any, len(st.Fields))
 	required := make([]string, 0, len(st.Fields))
-	for name, ft := range st.Fields {
-		props[name] = typeToSchema(ft)
-		required = append(required, name)
+	for _, f := range st.Fields {
+		props[f.Name] = typeToSchema(f.Type)
+		required = append(required, f.Name)
 	}
 	sort.Strings(required)
 	schema := map[string]any{

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -2502,7 +2502,7 @@ func (c *compiler) compileMethod(st types.StructType, fn *parser.FunStmt) (Funct
 	fc.fn.Name = st.Name + "." + fn.Name
 	fc.fn.TypeParams = append([]string(nil), fn.TypeParams...)
 	fc.fn.Line = fn.Pos.Line
-	fc.fn.NumParams = len(st.Order) + len(fn.Params)
+	fc.fn.NumParams = len(st.FieldNames()) + len(fn.Params)
 	for name, idx := range c.globals {
 		fc.vars[name] = idx
 	}
@@ -2511,7 +2511,7 @@ func (c *compiler) compileMethod(st types.StructType, fn *parser.FunStmt) (Funct
 	}
 	// struct fields as parameters
 	fc.idx = len(c.globals)
-	for _, field := range st.Order {
+	for _, field := range st.FieldNames() {
 		idx := fc.newReg()
 		fc.vars[field] = idx
 	}
@@ -2519,7 +2519,7 @@ func (c *compiler) compileMethod(st types.StructType, fn *parser.FunStmt) (Funct
 		idx := fc.newReg()
 		fc.vars[p.Name] = idx
 	}
-	fc.idx = len(c.globals) + len(st.Order) + len(fn.Params)
+	fc.idx = len(c.globals) + len(st.FieldNames()) + len(fn.Params)
 	for _, stmnt := range fn.Body {
 		if err := fc.compileStmt(stmnt); err != nil {
 			return Function{}, err
@@ -3389,9 +3389,9 @@ func (fc *funcCompiler) compilePostfix(p *parser.PostfixExpr) int {
 					if !ok {
 						objReg = fc.newReg()
 					}
-					total := len(st.Order) + len(p.Ops[0].Call.Args)
+					total := len(st.FieldNames()) + len(p.Ops[0].Call.Args)
 					regs := make([]int, total)
-					for i, field := range st.Order {
+					for i, field := range st.FieldNames() {
 						key := fc.newReg()
 						fc.emit(p.Target.Pos, Instr{Op: OpConst, A: key, Val: Value{Tag: ValueStr, Str: field}})
 						val := fc.newReg()
@@ -3402,7 +3402,7 @@ func (fc *funcCompiler) compilePostfix(p *parser.PostfixExpr) int {
 						ar := fc.compileExpr(a)
 						reg := fc.newReg()
 						fc.emit(a.Pos, Instr{Op: OpMove, A: reg, B: ar})
-						regs[len(st.Order)+i] = reg
+						regs[len(st.FieldNames())+i] = reg
 					}
 					dst := fc.newReg()
 					start := 0
@@ -3621,8 +3621,8 @@ func (fc *funcCompiler) compilePrimary(p *parser.Primary) int {
 		if st, ok := fc.comp.env.GetStruct(p.Struct.Name); ok {
 			for _, m := range st.Methods {
 				idx := fc.comp.fnIndex[st.Name+"."+m.Decl.Name]
-				caps := make([]int, len(st.Order))
-				for i, name := range st.Order {
+				caps := make([]int, len(st.FieldNames()))
+				for i, name := range st.FieldNames() {
 					caps[i] = fieldRegs[name]
 				}
 				startCap := 0
@@ -3778,7 +3778,7 @@ func (fc *funcCompiler) compilePrimary(p *parser.Primary) int {
 				fc.tags[r] = tagUnknown
 			} else {
 				if len(p.Selector.Tail) == 0 {
-					if st, ok := fc.comp.env.GetStruct(p.Selector.Root); ok && len(st.Order) == 0 {
+					if st, ok := fc.comp.env.GetStruct(p.Selector.Root); ok && len(st.FieldNames()) == 0 {
 						key := fc.constReg(p.Pos, Value{Tag: ValueStr, Str: "__name"})
 						fc.constReg(p.Pos, Value{Tag: ValueStr, Str: st.Name})
 						dst := fc.newReg()
@@ -4235,7 +4235,7 @@ func (fc *funcCompiler) compileUpdate(u *parser.UpdateStmt) error {
 	if typ, err := fc.comp.env.GetVar(u.Target); err == nil {
 		if lt, ok := typ.(types.ListType); ok {
 			if st, ok := lt.Elem.(types.StructType); ok {
-				for _, f := range st.Order {
+				for _, f := range st.FieldNames() {
 					key := fc.constReg(u.Pos, Value{Tag: ValueStr, Str: f})
 					val := fc.newReg()
 					fc.emit(u.Pos, Instr{Op: OpIndex, A: val, B: item, C: key})
@@ -7025,12 +7025,12 @@ func (fc *funcCompiler) buildRowMap(q *parser.QueryExpr) int {
 	}
 	var addStructFields func(reg int, st types.StructType)
 	addStructFields = func(reg int, st types.StructType) {
-		for _, field := range st.Order {
-			fk := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: field})
+		for _, f := range st.Fields {
+			fk := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: f.Name})
 			fv := fc.newReg()
 			fc.emit(q.Pos, Instr{Op: OpIndex, A: fv, B: reg, C: fk})
 			addPair(fk, fv)
-			if ft, ok := st.Fields[field].(types.StructType); ok {
+			if ft, ok := f.Type.(types.StructType); ok {
 				addStructFields(fv, ft)
 			}
 		}
@@ -7298,7 +7298,7 @@ func (fc *funcCompiler) compileMatch(m *parser.MatchExpr) int {
 				for idx, arg := range call.Args {
 					if name, ok := identName(arg); ok {
 						key := fc.newReg()
-						fc.emit(c.Pos, Instr{Op: OpConst, A: key, Val: Value{Tag: ValueStr, Str: st.Order[idx]}})
+						fc.emit(c.Pos, Instr{Op: OpConst, A: key, Val: Value{Tag: ValueStr, Str: st.FieldNames()[idx]}})
 						val := fc.newReg()
 						fc.emit(c.Pos, Instr{Op: OpIndex, A: val, B: target, C: key})
 						fc.vars[name] = val
@@ -9241,16 +9241,16 @@ func castValue(t types.Type, v any) (any, error) {
 			return nil, fmt.Errorf("cannot cast %T to %s", v, tt.Name)
 		}
 		out := map[string]any{"__name": tt.Name}
-		for name, ft := range tt.Fields {
-			fv, ok := m[name]
+		for _, f := range tt.Fields {
+			fv, ok := m[f.Name]
 			if !ok {
-				return nil, fmt.Errorf("missing field %s for %s", name, tt.Name)
+				return nil, fmt.Errorf("missing field %s for %s", f.Name, tt.Name)
 			}
-			cv, err := castValue(ft, fv)
+			cv, err := castValue(f.Type, fv)
 			if err != nil {
 				return nil, err
 			}
-			out[name] = cv
+			out[f.Name] = cv
 		}
 		return out, nil
 	default:

--- a/types/check.go
+++ b/types/check.go
@@ -76,10 +76,23 @@ type GroupType struct {
 
 func (GroupType) String() string { return "group" }
 
+// StructField is a single declared field of a StructType. The slice of
+// fields on StructType is ordered by declaration sequence so JSON
+// encoding and pretty-printing stay deterministic without a parallel
+// `Order` slice (MEP 4 P10).
+type StructField struct {
+	Name string
+	Type Type
+}
+
+// StructType is the type of a nominal record. Fields are stored as a
+// single ordered slice that doubles as the iteration order and the
+// lookup table (via helper methods). The previous representation kept
+// `Fields map[string]Type` plus `Order []string` in parallel, which
+// could drift; MEP 4 P10 consolidates them.
 type StructType struct {
 	Name    string
-	Fields  map[string]Type
-	Order   []string
+	Fields  []StructField
 	Methods map[string]Method
 }
 
@@ -89,6 +102,70 @@ type Method struct {
 }
 
 func (t StructType) String() string { return t.Name }
+
+// FieldType returns the declared type of the named field, or nil and
+// false if the field is not present.
+func (t StructType) FieldType(name string) (Type, bool) {
+	for _, f := range t.Fields {
+		if f.Name == name {
+			return f.Type, true
+		}
+	}
+	return nil, false
+}
+
+// HasField reports whether the named field is declared on the struct.
+func (t StructType) HasField(name string) bool {
+	_, ok := t.FieldType(name)
+	return ok
+}
+
+// FieldNames returns the field names in declaration order.
+func (t StructType) FieldNames() []string {
+	names := make([]string, len(t.Fields))
+	for i, f := range t.Fields {
+		names[i] = f.Name
+	}
+	return names
+}
+
+// FieldMap returns a fresh lookup map of field name to declared type.
+// Callers that perform many lookups against the same struct should
+// cache the result.
+func (t StructType) FieldMap() map[string]Type {
+	m := make(map[string]Type, len(t.Fields))
+	for _, f := range t.Fields {
+		m[f.Name] = f.Type
+	}
+	return m
+}
+
+// WithField returns a copy of t with the named field's type set to
+// ftype. If the field is already declared the type is updated in
+// place (preserving order); otherwise the field is appended.
+func (t StructType) WithField(name string, ftype Type) StructType {
+	fields := make([]StructField, len(t.Fields))
+	copy(fields, t.Fields)
+	for i, f := range fields {
+		if f.Name == name {
+			fields[i].Type = ftype
+			out := t
+			out.Fields = fields
+			return out
+		}
+	}
+	out := t
+	out.Fields = append(fields, StructField{Name: name, Type: ftype})
+	return out
+}
+
+// NewStructType is a convenience constructor for an ordered field set
+// passed as alternating (name, type) pairs.
+func NewStructType(name string, fields ...StructField) StructType {
+	out := StructType{Name: name}
+	out.Fields = append([]StructField(nil), fields...)
+	return out
+}
 
 type UnionType struct {
 	Name string
@@ -268,12 +345,12 @@ func unify(a, b Type, subst Subst) bool {
 			if len(at.Fields) != len(bt.Fields) {
 				return false
 			}
-			for k, v := range at.Fields {
-				if bv, ok := bt.Fields[k]; ok {
-					if !unify(v, bv, subst) {
-						return false
-					}
-				} else {
+			for _, f := range at.Fields {
+				bv, ok := bt.FieldType(f.Name)
+				if !ok {
+					return false
+				}
+				if !unify(f.Type, bv, subst) {
 					return false
 				}
 			}
@@ -720,32 +797,29 @@ func Check(prog *parser.Program, env *Env) []error {
 
 // --- Helpers ---
 
-func buildStreamFields(fields []*parser.StreamField, env *Env) (map[string]Type, []string) {
-	out := map[string]Type{}
-	order := []string{}
+func buildStreamFields(fields []*parser.StreamField, env *Env) []StructField {
+	out := make([]StructField, 0, len(fields))
 	for _, f := range fields {
 		if f == nil {
 			continue
 		}
-		out[f.Name] = resolveTypeRef(f.Type, env)
-		order = append(order, f.Name)
+		out = append(out, StructField{Name: f.Name, Type: resolveTypeRef(f.Type, env)})
 	}
-	return out, order
+	return out
 }
 
 func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) error {
 	switch {
 	case s.Stream != nil:
-		fields, order := buildStreamFields(s.Stream.Fields, env)
-		st := StructType{Name: s.Stream.Name, Fields: fields, Order: order}
+		fields := buildStreamFields(s.Stream.Fields, env)
+		st := StructType{Name: s.Stream.Name, Fields: fields}
 		env.SetStream(s.Stream.Name, st)
 		env.SetStruct(s.Stream.Name, st)
 		env.types[s.Stream.Name] = st
 		return nil
 
 	case s.Agent != nil:
-		fields := map[string]Type{}
-		order := []string{}
+		var fields []StructField
 		methods := map[string]Method{}
 		for _, blk := range s.Agent.Body {
 			switch {
@@ -754,15 +828,13 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 				if blk.Let.Type != nil {
 					t = resolveTypeRef(blk.Let.Type, env)
 				}
-				fields[blk.Let.Name] = t
-				order = append(order, blk.Let.Name)
+				fields = append(fields, StructField{Name: blk.Let.Name, Type: t})
 			case blk.Var != nil:
 				var t Type = AnyType{}
 				if blk.Var.Type != nil {
 					t = resolveTypeRef(blk.Var.Type, env)
 				}
-				fields[blk.Var.Name] = t
-				order = append(order, blk.Var.Name)
+				fields = append(fields, StructField{Name: blk.Var.Name, Type: t})
 			case blk.Intent != nil:
 				params := make([]Type, len(blk.Intent.Params))
 				for i, p := range blk.Intent.Params {
@@ -780,7 +852,7 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 				methods[blk.Intent.Name] = Method{Decl: &parser.FunStmt{Params: blk.Intent.Params, Return: blk.Intent.Return, Body: blk.Intent.Body}, Type: FuncType{Params: params, Return: ret, Pure: pure}}
 			}
 		}
-		st := StructType{Name: s.Agent.Name, Fields: fields, Order: order, Methods: methods}
+		st := StructType{Name: s.Agent.Name, Fields: fields, Methods: methods}
 		env.SetStruct(s.Agent.Name, st)
 		env.SetAgent(s.Agent.Name, s.Agent)
 		env.types[s.Agent.Name] = st
@@ -806,7 +878,7 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 			return errUnknownStream(s.Emit.Pos, s.Emit.Stream)
 		}
 		for _, f := range s.Emit.Fields {
-			ft, ok := st.Fields[f.Name]
+			ft, ok := st.FieldType(f.Name)
 			if !ok {
 				return errUnknownField(f.Pos, f.Name, st)
 			}
@@ -1011,7 +1083,7 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 				field := fop.Name
 				switch lt := lhsType.(type) {
 				case StructType:
-					ft, ok := lt.Fields[field]
+					ft, ok := lt.FieldType(field)
 					if !ok {
 						return errUnknownField(fop.Pos, field, lt)
 					}
@@ -1074,12 +1146,12 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 			return fmt.Errorf("update element is not struct")
 		}
 		child := NewEnv(env)
-		for name, t := range st.Fields {
-			child.SetVar(name, t, true)
+		for _, f := range st.Fields {
+			child.SetVar(f.Name, f.Type, true)
 		}
 		for _, item := range s.Update.Set.Items {
 			if key, ok := stringKey(item.Key); ok {
-				ft, ok2 := st.Fields[key]
+				ft, ok2 := st.FieldType(key)
 				if !ok2 {
 					return errUnknownField(item.Pos, key, st)
 				}
@@ -1163,17 +1235,15 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 			return nil
 		}
 		if len(s.Type.Members) > 0 {
-			fields := map[string]Type{}
-			order := []string{}
+			var fields []StructField
 			methods := map[string]Method{}
-			st := StructType{Name: s.Type.Name, Fields: fields, Order: order, Methods: methods}
+			st := StructType{Name: s.Type.Name, Fields: fields, Methods: methods}
 			env.SetStruct(s.Type.Name, st)
 			env.types[s.Type.Name] = st
 			// First pass: collect fields
 			for _, m := range s.Type.Members {
 				if m.Field != nil {
-					fields[m.Field.Name] = resolveTypeRef(m.Field.Type, env)
-					order = append(order, m.Field.Name)
+					fields = append(fields, StructField{Name: m.Field.Name, Type: resolveTypeRef(m.Field.Type, env)})
 				}
 			}
 			// Precompute method types so they can reference each other.
@@ -1201,8 +1271,8 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 					ret := meth.Type.Return
 
 					methodEnv := NewEnv(env)
-					for name, t := range fields {
-						methodEnv.SetVar(name, t, true)
+					for _, f := range fields {
+						methodEnv.SetVar(f.Name, f.Type, true)
 					}
 					for name, mt := range methods {
 						methodEnv.SetVar(name, mt.Type, true)
@@ -1220,7 +1290,6 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 				}
 			}
 			st.Fields = fields
-			st.Order = order
 			st.Methods = methods
 			env.SetStruct(s.Type.Name, st)
 			env.types[s.Type.Name] = st
@@ -1236,13 +1305,11 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 			env.types[s.Type.Name] = ut
 
 			for _, v := range s.Type.Variants {
-				vf := map[string]Type{}
-				order := []string{}
+				var vf []StructField
 				for _, f := range v.Fields {
-					vf[f.Name] = resolveTypeRef(f.Type, env)
-					order = append(order, f.Name)
+					vf = append(vf, StructField{Name: f.Name, Type: resolveTypeRef(f.Type, env)})
 				}
-				st := StructType{Name: v.Name, Fields: vf, Order: order}
+				st := StructType{Name: v.Name, Fields: vf}
 				variants[v.Name] = st
 				variantOrder = append(variantOrder, v.Name)
 				env.SetStruct(v.Name, st)
@@ -1443,13 +1510,11 @@ func resolveTypeRef(t *parser.TypeRef, env *Env) Type {
 	}
 
 	if t.Struct != nil {
-		fields := map[string]Type{}
-		order := []string{}
+		var fields []StructField
 		for _, f := range t.Struct.Fields {
-			fields[f.Name] = resolveTypeRef(f.Type, env)
-			order = append(order, f.Name)
+			fields = append(fields, StructField{Name: f.Name, Type: resolveTypeRef(f.Type, env)})
 		}
-		return StructType{Name: "", Fields: fields, Order: order}
+		return StructType{Name: "", Fields: fields}
 	}
 
 	if t.Simple != nil {
@@ -1867,7 +1932,7 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 			}
 			switch t := typ.(type) {
 			case StructType:
-				if ft, ok := t.Fields[field]; ok {
+				if ft, ok := t.FieldType(field); ok {
 					typ = ft
 					continue
 				}
@@ -2024,7 +2089,7 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 			return MapType{Key: StringType{}, Value: AnyType{}}, nil
 		}
 		for _, field := range p.Struct.Fields {
-			ft, ok := st.Fields[field.Name]
+			ft, ok := st.FieldType(field.Name)
 			if !ok {
 				return nil, errUnknownField(p.Pos, field.Name, st)
 			}
@@ -2355,7 +2420,7 @@ func checkMatchExpr(m *parser.MatchExpr, env *Env, expected Type) (Type, error) 
 		if call, ok := callPattern(c.Pattern); ok {
 			if ut, ok := env.FindUnionByVariant(call.Func); ok {
 				st := ut.Variants[call.Func]
-				if len(call.Args) != len(st.Order) {
+				if len(call.Args) != len(st.Fields) {
 					return nil, errTypeMismatch(c.Pos, targetType, st)
 				}
 				if !unify(targetType, st, nil) {
@@ -2364,7 +2429,7 @@ func checkMatchExpr(m *parser.MatchExpr, env *Env, expected Type) (Type, error) 
 				child := NewEnv(env)
 				for idx, arg := range call.Args {
 					if name, ok := identName(arg); ok {
-						child.SetVar(name, st.Fields[st.Order[idx]], true)
+						child.SetVar(name, st.Fields[idx].Type, true)
 					}
 				}
 				caseEnv = child
@@ -2512,7 +2577,7 @@ func checkQueryExpr(q *parser.QueryExpr, env *Env, expected Type) (Type, error) 
 			}
 			if _, ok := k1.(StringType); ok {
 				if _, ok2 := k2.(StringType); ok2 {
-					keyT = StructType{Name: "pair_string", Fields: map[string]Type{"a": StringType{}, "b": StringType{}}, Order: []string{"a", "b"}}
+					keyT = StructType{Name: "pair_string", Fields: []StructField{{Name: "a", Type: StringType{}}, {Name: "b", Type: StringType{}}}}
 				}
 			}
 			if keyT == nil {

--- a/types/equal_types_test.go
+++ b/types/equal_types_test.go
@@ -41,8 +41,8 @@ func TestEqualTypesByKind(t *testing.T) {
 		// Struct/union name-based equality and struct-in-union carve-out.
 		{
 			"struct same name",
-			StructType{Name: "User", Fields: map[string]Type{"id": IntType{}}},
-			StructType{Name: "User", Fields: map[string]Type{"id": IntType{}}},
+			StructType{Name: "User", Fields: []StructField{{Name: "id", Type: IntType{}}}},
+			StructType{Name: "User", Fields: []StructField{{Name: "id", Type: IntType{}}}},
 			true,
 		},
 		{

--- a/types/infer.go
+++ b/types/infer.go
@@ -270,7 +270,7 @@ func inferPostfixType(env *Env, p *parser.PostfixExpr) Type {
 				t = OptionType{Elem: tt.Value}
 			case StructType:
 				if key, ok := SimpleStringKey(op.Index.Start); ok {
-					if ft, ok2 := tt.Fields[key]; ok2 {
+					if ft, ok2 := tt.FieldType(key); ok2 {
 						t = ft
 					} else {
 						t = AnyType{}
@@ -364,7 +364,7 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 					}
 					switch tt := cur.(type) {
 					case StructType:
-						ft, ok := tt.Fields[field]
+						ft, ok := tt.FieldType(field)
 						if !ok {
 							return AnyType{}
 						}
@@ -554,8 +554,7 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 			// Attempt to infer a struct type when all elements are map
 			// literals with matching keys and value types.
 			if ml := first.Binary.Left.Value.Target.Map; ml != nil && len(first.Binary.Right) == 0 {
-				fields := map[string]Type{}
-				order := make([]string, len(ml.Items))
+				fields := make([]StructField, len(ml.Items))
 				valid := true
 				for i, it := range ml.Items {
 					key, ok := SimpleStringKey(it.Key)
@@ -563,8 +562,7 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 						valid = false
 						break
 					}
-					order[i] = key
-					fields[key] = ExprType(it.Value, env)
+					fields[i] = StructField{Name: key, Type: ExprType(it.Value, env)}
 				}
 				if valid {
 					for _, e := range p.List.Elems[1:] {
@@ -573,20 +571,19 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 							break
 						}
 						ml2 := e.Binary.Left.Value.Target.Map
-						if ml2 == nil || len(ml2.Items) != len(order) {
+						if ml2 == nil || len(ml2.Items) != len(fields) {
 							valid = false
 							break
 						}
 						for i, it := range ml2.Items {
 							key, ok := SimpleStringKey(it.Key)
-							if !ok || key != order[i] {
+							if !ok || key != fields[i].Name {
 								valid = false
 								break
 							}
 							vt := ExprType(it.Value, env)
-							ft := fields[key]
-							if !equalTypes(ft, vt) {
-								fields[key] = AnyType{}
+							if !equalTypes(fields[i].Type, vt) {
+								fields[i].Type = AnyType{}
 							}
 						}
 						if !valid {
@@ -595,7 +592,7 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 					}
 				}
 				if valid {
-					elemType = StructType{Fields: fields, Order: order}
+					elemType = StructType{Fields: fields}
 				}
 			}
 			if _, ok := elemType.(AnyType); ok {
@@ -663,7 +660,7 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 		return ListType{Elem: elem}
 	case p.Map != nil:
 		if len(p.Map.Items) > 0 {
-			st := StructType{Fields: make(map[string]Type), Order: make([]string, len(p.Map.Items))}
+			fields := make([]StructField, len(p.Map.Items))
 			allConst := true
 			for i, it := range p.Map.Items {
 				key, ok := stringKey(it.Key)
@@ -671,11 +668,10 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 					allConst = false
 					break
 				}
-				st.Fields[key] = ExprType(it.Value, env)
-				st.Order[i] = key
+				fields[i] = StructField{Name: key, Type: ExprType(it.Value, env)}
 			}
 			if allConst {
-				return st
+				return StructType{Fields: fields}
 			}
 		}
 
@@ -835,7 +831,7 @@ func unionFieldPathType(ut UnionType, tail []string) (Type, bool) {
 			if !ok {
 				return nil, false
 			}
-			ft, ok := st.Fields[field]
+			ft, ok := st.FieldType(field)
 			if !ok {
 				return nil, false
 			}
@@ -1177,7 +1173,7 @@ func TypeOfPostfixBasic(u *parser.Unary, env *Env) Type {
 			}
 		case op.Field != nil:
 			if st, ok := t.(StructType); ok {
-				if ft, ok2 := st.Fields[op.Field.Name]; ok2 {
+				if ft, ok2 := st.FieldType(op.Field.Name); ok2 {
 					t = ft
 				} else {
 					t = AnyType{}
@@ -1257,7 +1253,7 @@ func FieldType(t Type, path []string) Type {
 	for _, p := range path {
 		switch tt := t.(type) {
 		case StructType:
-			if f, ok := tt.Fields[p]; ok {
+			if f, ok := tt.FieldType(p); ok {
 				t = f
 			} else {
 				return AnyType{}

--- a/types/infercheck.go
+++ b/types/infercheck.go
@@ -34,15 +34,15 @@ func ContainsAny(t Type) bool {
 	case GroupType:
 		return ContainsAny(tt.Key) || ContainsAny(tt.Elem)
 	case StructType:
-		for _, ft := range tt.Fields {
-			if ContainsAny(ft) {
+		for _, f := range tt.Fields {
+			if ContainsAny(f.Type) {
 				return true
 			}
 		}
 	case UnionType:
 		for _, v := range tt.Variants {
-			for _, ft := range v.Fields {
-				if ContainsAny(ft) {
+			for _, f := range v.Fields {
+				if ContainsAny(f.Type) {
 					return true
 				}
 			}

--- a/types/structinfer.go
+++ b/types/structinfer.go
@@ -19,36 +19,34 @@ func InferStructFromList(ll *parser.ListLiteral, env *Env) (StructType, bool) {
 	if fm == nil {
 		return StructType{}, false
 	}
-	fields := map[string]Type{}
-	order := make([]string, len(fm.Items))
+	fields := make([]StructField, len(fm.Items))
 	for i, it := range fm.Items {
 		key, ok := SimpleStringKey(it.Key)
 		if !ok {
 			return StructType{}, false
 		}
-		order[i] = key
-		fields[key] = ExprType(it.Value, env)
+		fields[i] = StructField{Name: key, Type: ExprType(it.Value, env)}
 	}
 	for _, el := range ll.Elems[1:] {
 		if el.Binary == nil || len(el.Binary.Right) != 0 {
 			return StructType{}, false
 		}
 		ml := el.Binary.Left.Value.Target.Map
-		if ml == nil || len(ml.Items) != len(order) {
+		if ml == nil || len(ml.Items) != len(fields) {
 			return StructType{}, false
 		}
 		for i, it := range ml.Items {
 			key, ok := SimpleStringKey(it.Key)
-			if !ok || key != order[i] {
+			if !ok || key != fields[i].Name {
 				return StructType{}, false
 			}
 			t := ExprType(it.Value, env)
-			if !EqualTypes(fields[key], t) {
+			if !EqualTypes(fields[i].Type, t) {
 				return StructType{}, false
 			}
 		}
 	}
-	st := StructType{Fields: fields, Order: order}
+	st := StructType{Fields: fields}
 	return st, true
 }
 
@@ -63,17 +61,15 @@ func InferStructFromMapEnv(ml *parser.MapLiteral, env *Env) (StructType, bool) {
 	if ml == nil || len(ml.Items) == 0 {
 		return StructType{}, false
 	}
-	fields := map[string]Type{}
-	order := make([]string, len(ml.Items))
+	fields := make([]StructField, len(ml.Items))
 	for i, it := range ml.Items {
 		key, ok := SimpleStringKey(it.Key)
 		if !ok {
 			return StructType{}, false
 		}
-		order[i] = key
-		fields[key] = ExprType(it.Value, env)
+		fields[i] = StructField{Name: key, Type: ExprType(it.Value, env)}
 	}
-	st := StructType{Fields: fields, Order: order}
+	st := StructType{Fields: fields}
 	return st, true
 }
 

--- a/types/util.go
+++ b/types/util.go
@@ -146,14 +146,14 @@ func IsStringAnyMapLike(t Type) bool {
 
 // StructMatches reports whether the provided field map and order slice match the layout of existing.
 func StructMatches(existing StructType, fields map[string]Type, order []string) bool {
-	if len(existing.Fields) != len(fields) || len(existing.Order) != len(order) {
+	if len(existing.Fields) != len(fields) || len(existing.Fields) != len(order) {
 		return false
 	}
-	for i, name := range existing.Order {
-		if order[i] != name {
+	for i, f := range existing.Fields {
+		if order[i] != f.Name {
 			return false
 		}
-		if !EqualTypes(existing.Fields[name], fields[name]) {
+		if !EqualTypes(f.Type, fields[f.Name]) {
 			return false
 		}
 	}
@@ -162,14 +162,15 @@ func StructMatches(existing StructType, fields map[string]Type, order []string) 
 
 // StructTypesMatch reports whether two struct types have the same set of fields and ordering, ignoring their names.
 func StructTypesMatch(a, b StructType) bool {
-	if len(a.Fields) != len(b.Fields) || len(a.Order) != len(b.Order) {
+	if len(a.Fields) != len(b.Fields) {
 		return false
 	}
-	for i, name := range a.Order {
-		if b.Order[i] != name {
+	for i, af := range a.Fields {
+		bf := b.Fields[i]
+		if af.Name != bf.Name {
 			return false
 		}
-		if !EqualTypes(a.Fields[name], b.Fields[name]) {
+		if !EqualTypes(af.Type, bf.Type) {
 			return false
 		}
 	}


### PR DESCRIPTION
## Summary
- Collapse `StructType.Fields map[string]Type` and `StructType.Order []string` into a single `Fields []StructField` ordered slice.
- Add `FieldType`, `HasField`, `FieldNames`, `FieldMap`, `WithField`, and `NewStructType` helpers as the canonical lookup API.
- Migrate the types package, interpreter, and runtime/vm to the slice-based representation.

Tracks #21255. Refs MEP 4 §Problems P10.

## Notes
- CI scope (./parser/..., ./runtime/vm/..., ./types/TestSoundness) is green.
- Slow-tagged backends (compiler/x/*, transpiler/x/*) still reference `.Order` and `.Fields[name]`. Those packages were already failing to build on main for unrelated reasons (parser.Unary refactor). A follow-up sweep will migrate them after the upstream parser issue is resolved.

## Test plan
- [x] `go build ./...`
- [x] `go test ./types/... ./runtime/vm/... ./interpreter/... ./parser/...`
- [x] `go test -run TestSoundness ./types/...`