### PR TITLE
types: align sum() return type with element type (MEP-5 P2)

### DIFF
--- a/types/check.go
+++ b/types/check.go
@@ -2617,11 +2617,9 @@ func checkQueryExpr(q *parser.QueryExpr, env *Env, expected Type) (Type, error) 
 				if _, ok := at.(AnyType); !ok && !isNumeric(at) {
 					return nil, errSumOperand(q.Select.Pos, at)
 				}
-				if _, ok := at.(FloatType); ok {
-					selT = FloatType{}
-				} else {
-					selT = IntType{}
-				}
+				// Preserve the element type per MEP-5 P2; widening to int/float
+				// lost precision for bigint/bigrat/int64 summands.
+				selT = at
 			case "avg":
 				if _, ok := at.(AnyType); !ok && !isNumeric(at) {
 					return nil, errSumOperand(q.Select.Pos, at)


### PR DESCRIPTION
Closes #21260. Part of MEP-5 (#21258).

`select sum(g)` over `g : [T]` was widening `T` to `int` or `float` in the aggregate special case. That dropped precision for `bigint`, `bigrat`, and `int64` summands. MEP-5 §Queries [T-Sum] specifies the return type matches the element type exactly.

This change preserves `at` as the result type in the `case "sum":` branch of `types/check.go`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./types/...`