### PR TITLE
types: pin bool result for comparison and connectives (MEP-5 P16)

### DIFF
--- a/types/infer.go
+++ b/types/infer.go
@@ -177,29 +177,18 @@ func inferBinaryType(env *Env, b *parser.BinaryExpr) Type {
 					// pass. `any` keeps its escape-hatch behaviour;
 					// otherwise comparable operands must be equal-kinded
 					// or both numeric.
-					switch {
-					case IsAnyType(left) || IsAnyType(right):
-						res = BoolType{}
-					case equalTypes(left, right):
-						res = BoolType{}
-					case isNumeric(left) && isNumeric(right):
-						res = BoolType{}
-					default:
-						res = AnyType{}
-					}
+					// Comparisons and equality are always bool-typed; the
+					// checker rejects nonsensical operand pairs separately
+					// (MEP-5 T-Eq / T-Cmp). The inferrer never widens to any.
+					res = BoolType{}
 				case "&&", "||":
-					if isBool(left) && isBool(right) {
-						res = BoolType{}
-					} else {
-						res = AnyType{}
-					}
+					// Boolean connectives are always bool-typed; the checker
+					// rejects non-bool operands (MEP-5 P16).
+					res = BoolType{}
 				case "in":
-					switch right.(type) {
-					case MapType, ListType, StringType:
-						res = BoolType{}
-					default:
-						res = AnyType{}
-					}
+					// `in` is always bool-typed; the checker rejects non-iterable
+					// right operands separately.
+					res = BoolType{}
 				case "union", "union_all", "except", "intersect":
 					if ll, ok := left.(ListType); ok {
 						if rl, ok := right.(ListType); ok {

--- a/types/infer_compare_test.go
+++ b/types/infer_compare_test.go
@@ -21,10 +21,13 @@ func inferRHS(t *testing.T, expr string) types.Type {
 	return types.ExprType(prog.Statements[0].Let.Value, types.NewEnv(nil))
 }
 
-// TestInferComparisonHonest pins MEP-4 P9: inference must not claim a
-// cross-kind comparison has type `bool`. The check pass rejects the
-// program; inference should report `any` so downstream tools do not
-// silently consume a wrong type.
+// TestInferComparisonHonest pins MEP-5 P16: comparisons and equality are
+// always bool-typed at the inference layer (the operator's principal
+// result kind is `bool`); cross-kind operand mismatches are reported by
+// the checker as T030, not by widening the inferrer's result to `any`.
+// This supersedes the previous MEP-4 P9 fallback that returned `any` so
+// downstream tools would not consume a wrong type: under MEP-5 the
+// inferrer never returns `any` as a fallback at all.
 func TestInferComparisonHonest(t *testing.T) {
 	cases := []struct {
 		name string
@@ -33,9 +36,9 @@ func TestInferComparisonHonest(t *testing.T) {
 	}{
 		{"int_eq_int", `1 == 2`, "bool"},
 		{"int_lt_int", `1 < 2`, "bool"},
-		{"int_eq_string", `1 == "x"`, "any"},
-		{"struct_eq_int", `{a: 1} == 2`, "any"},
-		{"bool_eq_int", `true == 1`, "any"},
+		{"int_eq_string", `1 == "x"`, "bool"},
+		{"struct_eq_int", `{a: 1} == 2`, "bool"},
+		{"bool_eq_int", `true == 1`, "bool"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #21262. Part of MEP-5 (#21258).

`inferBinaryType` fell back to `AnyType{}` for `==`, `!=`, `<`, `<=`, `>`, `>=`, `&&`, `||`, and `in` when operand types didn't line up. Under MEP-5's strict algebraic rules these always produce `bool`; soundness is enforced by the checker (T0xx), not by the inferrer silently widening to `any`.

This change collapses the comparison/connective/membership cases in `types/infer.go` to return `BoolType{}` directly and updates `TestInferComparisonHonest` to expect `bool` for cross-kind operands.

Supersedes the MEP-4 P9 decision: the prior agreement was for inferrer and checker to *agree* by both returning `any`, but MEP-5 takes the opposite stance — the inferrer reports the principal result type and the checker rejects ill-typed operands.

## Test plan
- [x] `go build ./...`
- [x] `go test ./types/...` (TestInferComparisonHonest updated)