### PR TITLE
types: reject `for x in any` source (MEP-5 P13)

### DIFF
--- a/tests/types/soundness/mep5_p13_for_any_source.error
+++ b/tests/types/soundness/mep5_p13_for_any_source.error
@@ -1,0 +1,8 @@
+ 1. error[T022]: cannot iterate over type any
+  --> tests/types/soundness/mep5_p13_for_any_source.mochi:4:3
+
+  4 |   for x in xs {
+    |   ^
+
+help:
+  Only `list<T>`, `map<K,V>`, or integer ranges are allowed in `for ... in ...` loops.

--- a/tests/types/soundness/mep5_p13_for_any_source.mochi
+++ b/tests/types/soundness/mep5_p13_for_any_source.mochi
@@ -1,0 +1,7 @@
+// MEP-5 P13: `for x in source` where source has type `any` is T022.
+// The prior behaviour silently bound `x : any`, masking a soundness hole.
+fun iter(xs: any) {
+  for x in xs {
+    print(x)
+  }
+}

--- a/types/check.go
+++ b/types/check.go
@@ -1201,7 +1201,8 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 				elemType = IntType{}
 			}
 		} else {
-			// It's a collection loop: `for x in collection`
+			// MEP-5 §Inference for control flow [T-ForList, T-ForMap, T-ForStr]:
+			// any other shape (including bare `any`) is T022.
 			switch t := sourceType.(type) {
 			case ListType:
 				elemType = t.Elem
@@ -1209,8 +1210,6 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 				elemType = t.Key // loop iterates over keys
 			case StringType:
 				elemType = StringType{}
-			case AnyType:
-				elemType = AnyType{}
 			default:
 				return errCannotIterate(s.For.Pos, sourceType)
 			}


### PR DESCRIPTION
Closes #21264. Part of MEP-5 (#21258).

The `for x in source` checker had a special case binding `x : any` when `source` was `AnyType{}`. That silently propagated `any` into the loop body. MEP-5 §Inference for control flow specifies T022 for any source shape other than `[τ]`, `{κ:υ}`, or `string`.

This removes the `case AnyType:` branch in `types/check.go` and adds soundness fixture `mep5_p13_for_any_source` to pin the diagnostic.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`