### PR TITLE
types: reject heterogeneous match arms (MEP-5 P5)

### DIFF
--- a/tests/types/soundness/mep5_p05_match_arms_disagree.error
+++ b/tests/types/soundness/mep5_p05_match_arms_disagree.error
@@ -1,0 +1,8 @@
+ 1. error[T008]: type mismatch: expected int, got string
+  --> tests/types/soundness/mep5_p05_match_arms_disagree.mochi:5:3
+
+  5 |   _ => "no"
+    |   ^
+
+help:
+  Change the value to match the expected type.

--- a/tests/types/soundness/mep5_p05_match_arms_disagree.mochi
+++ b/tests/types/soundness/mep5_p05_match_arms_disagree.mochi
@@ -1,0 +1,6 @@
+// MEP-5 P5: match arms with disagreeing types must be rejected.
+// The prior rule silently widened to `any`, hiding the soundness hole.
+let x = match 1 {
+  1 => 42
+  _ => "no"
+}

--- a/types/check.go
+++ b/types/check.go
@@ -2473,8 +2473,13 @@ func checkMatchExpr(m *parser.MatchExpr, env *Env, expected Type) (Type, error) 
 		}
 		if resultType == nil {
 			resultType = rType
-		} else if !unify(resultType, rType, nil) {
-			resultType = AnyType{}
+			continue
+		}
+		// MEP-5 §Match [T-Match]: every arm's result type must unify with
+		// the principal type. Heterogeneous arms are T008; the prior rule
+		// silently widened to AnyType.
+		if !unify(resultType, rType, nil) {
+			return nil, errTypeMismatch(c.Pos, resultType, rType)
 		}
 	}
 	if resultType == nil {

--- a/types/infer.go
+++ b/types/infer.go
@@ -702,14 +702,13 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 		}
 		return MapType{Key: keyType, Value: valType}
 	case p.Match != nil:
+		// MEP-5 §Match [T-Match]: the principal type is the first arm's
+		// type. Disagreement is rejected by the checker (T008); the
+		// inferrer must not silently widen to AnyType.
 		var rType Type
 		for _, cs := range p.Match.Cases {
-			t := ExprType(cs.Result, env)
-			if rType == nil {
-				rType = t
-			} else if !equalTypes(rType, t) {
-				rType = AnyType{}
-			}
+			rType = ExprType(cs.Result, env)
+			break
 		}
 		if rType == nil {
 			rType = AnyType{}

--- a/website/docs/mep/mep-0005.md
+++ b/website/docs/mep/mep-0005.md
@@ -144,7 +144,7 @@ Function declarations behave like `let f = fun(...) => ...`. Top-level functions
 Γ ⊢ while c { body } : unit
 ```
 
-The two arms of `if` must unify. A previous rule widened them to `any`; the new rule rejects with T030. Programs that relied on the loose join migrate by introducing an explicit `Option[T]` or by annotating the result.
+The two arms of `if` must unify. A previous rule widened them to `any`; the new rule rejects with T008. Programs that relied on the loose join migrate by introducing an explicit `Option[T]` or by annotating the result.
 
 ```
 Γ ⊢ xs : [τ]                Γ, x : τ ⊢ body : unit
@@ -241,7 +241,7 @@ There is no rule that gives an arbitrary type a `null` inhabitant. `nil` is not 
 provided  exhaustive(τ, {p₁ … pₙ})
 ```
 
-The single principal type `ρ` is the join of every arm's type. The join is defined by unification only; the previous fallback "widen to `any`" is removed. Heterogeneous arms are a diagnostic (T030).
+The single principal type `ρ` is the join of every arm's type. The join is defined by unification only; the previous fallback "widen to `any`" is removed. Heterogeneous arms are a diagnostic (T008).
 
 Exhaustiveness is enforced. The check is the algorithm in [MEP 13](/docs/mep/mep-0013). A match that omits a variant of a closed `UnionType` is rejected (T046). A wildcard `_` arm covers any residual case.
 
@@ -358,7 +358,7 @@ The following are concrete code-level defects against the rules above. Each is t
 
 **4. Cast `e as σ` has no compatibility check.** Documented hole; the rule in this MEP requires `subtype(ExprType(e), σ)`. Fix: gate `as` on the predicate from [MEP 11](/docs/mep/mep-0011).
 
-**5. Match arms widen to `any` on disagreement.** The check rejects heterogeneous arms; the inferrer widens. Fix: align the inferrer with the checker; add T030 diagnostic at the join point.
+**5. Match arms widen to `any` on disagreement.** The check rejects heterogeneous arms; the inferrer widens. Fix: align the inferrer with the checker; emit T008 at the join point.
 
 **6. `MapType` indexing producing `Option[V]` is inconsistent with other partial reads.** Struct field reads of an unknown name return `any`; query `select` of an unknown column does the same. The new rule is that partial reads return `Option`. Fix: rewrite the three loose paths.
 


### PR DESCRIPTION
Closes #21266. Part of MEP-5 (#21258).

`match` was widening to `AnyType{}` whenever arm result types disagreed. MEP-5 §Match [T-Match] specifies the principal type is the join of arm types and disagreement is a diagnostic.

- `types/check.go`: emit T008 (type mismatch) at the join point instead of widening.
- `types/infer.go`: return the first arm's type as the principal type. The checker is the source of truth for diagnostics; the inferrer is consulted by tooling that needs a definite answer.
- `mep-0005.md`: align doc to T008 (the placeholder T030 in the rewrite referenced a code already taken by fetch options).
- Fixture `mep5_p05_match_arms_disagree` pins the new behaviour.

This is a breaking change for programs that relied on the silent widening. None in the in-tree test corpus regress.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`