### PR TITLE
mep-0005: mark P5 and P13 fixed with PR refs

### DIFF
--- a/website/docs/mep/mep-0005.md
+++ b/website/docs/mep/mep-0005.md
@@ -358,7 +358,7 @@ The following are concrete code-level defects against the rules above. Each is t
 
 **4. Cast `e as σ` has no compatibility check.** Documented hole; the rule in this MEP requires `subtype(ExprType(e), σ)`. Fix: gate `as` on the predicate from [MEP 11](/docs/mep/mep-0011).
 
-**5. Match arms widen to `any` on disagreement.** The check rejects heterogeneous arms; the inferrer widens. Fix: align the inferrer with the checker; emit T008 at the join point.
+**5. Match arms widen to `any` on disagreement.** The check rejects heterogeneous arms; the inferrer widens. Fixed in [#21267](https://github.com/mochilang/mochi/pull/21267).
 
 **6. `MapType` indexing producing `Option[V]` is inconsistent with other partial reads.** Struct field reads of an unknown name return `any`; query `select` of an unknown column does the same. The new rule is that partial reads return `Option`. Fix: rewrite the three loose paths.
 
@@ -374,7 +374,7 @@ The following are concrete code-level defects against the rules above. Each is t
 
 **12. Equality (`==`, `!=`) accepts cross-kind operands when one is `any`.** Tracked as part of removing the implicit `any`; covered by problem 1 but called out separately because the check.go path is distinct from the infer.go path.
 
-**13. `for x in source` for unknown source falls back to `x : any`.** Per the rules above, an unknown source is T022. Fix: remove the AnyType branch in the ForList/ForMap/ForStr/ForRange dispatch.
+**13. `for x in source` for unknown source falls back to `x : any`.** Per the rules above, an unknown source is T022. Fixed in [#21265](https://github.com/mochilang/mochi/pull/21265).
 
 **14. `select r` in a query falls through to general expression inference.** Under the new rule the projection's type must be principal, not `any`. Fix: extract a query-select rule and remove the fall-through.
 


### PR DESCRIPTION
Doc-only. Updates the MEP-5 §Problems list to mark P5 (match arm widening) and P13 (for-loop AnyType source) as fixed with their respective PR numbers.

Part of MEP-5 (#21258).

## Test plan
- [x] Doc renders (manual review)