### PR TITLE
types: reject heterogeneous list literals (MEP-5 P1)

### DIFF
--- a/tests/types/soundness/mep5_p01_list_elements_disagree.error
+++ b/tests/types/soundness/mep5_p01_list_elements_disagree.error
@@ -1,0 +1,8 @@
+ 1. error[T008]: type mismatch: expected int, got string
+  --> tests/types/soundness/mep5_p01_list_elements_disagree.mochi:3:14
+
+  3 | let xs = [1, "two"]
+    |              ^
+
+help:
+  Change the value to match the expected type.

--- a/tests/types/soundness/mep5_p01_list_elements_disagree.mochi
+++ b/tests/types/soundness/mep5_p01_list_elements_disagree.mochi
@@ -1,0 +1,3 @@
+// MEP-5 P1: list literals with disagreeing element types must be rejected.
+// The prior rule silently widened to `any`, hiding the soundness hole.
+let xs = [1, "two"]

--- a/types/check.go
+++ b/types/check.go
@@ -2103,6 +2103,10 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 		return st, nil
 
 	case p.List != nil:
+		// MEP-5 §Collections [T-List]: every element must unify with the
+		// principal element type. The prior rule widened to AnyType when
+		// elements disagreed, masking the heterogeneity at type-check
+		// time. We now reject with T008.
 		var elemType Type = nil
 		for _, elem := range p.List.Elems {
 			t, err := checkExpr(elem, env)
@@ -2111,8 +2115,10 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 			}
 			if elemType == nil {
 				elemType = t
-			} else if !unify(elemType, t, nil) {
-				elemType = AnyType{} // fallback if mixed types
+				continue
+			}
+			if !unify(elemType, t, nil) {
+				return nil, errTypeMismatch(elem.Pos, elemType, t)
 			}
 		}
 		if elemType == nil {


### PR DESCRIPTION
## Summary
- Reject list literals with mixed element types in `checkPrimary` instead of silently widening to `[any]`. Surfaces a sub-fix of MEP-5 P1.
- Pin the rejection with a soundness fixture (`mep5_p01_list_elements_disagree`).

Closes #21269. Sub-task of MEP-5 §Problems P1.

## Test plan
- [x] `go test ./types/... -run TestSoundness`
- [x] `go test ./...` (only pre-existing `TestTPCHPlans/q6` golden mismatch — unrelated to this PR; CI does not run that package)