### PR TITLE
mep-0006: refresh stale line refs; flag duplicate keys builtin

### DIFF
--- a/website/docs/mep/mep-0006.md
+++ b/website/docs/mep/mep-0006.md
@@ -33,7 +33,7 @@ Type checker source files quickly become hard to read because every statement fo
 
 ### Entry point
 
-`types/check.go:385`. The signature:
+`types/check.go:487`. The signature:
 
 ```
 func Check(prog *parser.Program, env *Env) []error
@@ -43,7 +43,7 @@ The function is non-short-circuiting. It accumulates errors and returns all of t
 
 ### Builtin environment
 
-`types/check.go:386-619` registers the builtins. The list at v0.10.82:
+`types/check.go:488-720` registers the builtins. The list at v0.10.82:
 
 - `print(...) : void`. Variadic, accepts `any`.
 - `len(any) : int`. Loosely typed. Pure.
@@ -79,6 +79,7 @@ Each statement form has a corresponding check function. The dispatch is in `Chec
 - `VarStmt`. Same as `LetStmt` but mutable.
 - `AssignStmt`. Look up target. Validate it is `var` mutable (T024). Walk index and field ops to refine the LHS type, check the RHS matches.
 - `FunStmt`. Build a `FuncType`. Push a child env binding params and type params. Check body statements. Validate return type from trailing `return` statements (T010).
+- `ModelStmt`. Bind the model identifier with the declared parameter and return types. Shallow today.
 - `IfStmt`. Cond bool (T040). Recurse into then, else-if, and else blocks. Each block gets a fresh child env.
 - `WhileStmt`. Cond bool (T040). Recurse body with loop context active.
 - `ForStmt`. Source must be iterable (T022). Bind loop variable. Recurse.
@@ -196,8 +197,8 @@ Informational. No backward compatibility implications.
 
 ## Reference Implementation
 
-- `types/check.go:385`: `Check` entry point.
-- `types/check.go:386-619`: builtin registration.
+- `types/check.go:487`: `Check` entry point.
+- `types/check.go:488-720`: builtin registration.
 - `types/errors.go`: error catalogue.
 - `types/check_test.go`: golden tests.
 
@@ -206,6 +207,10 @@ Informational. No backward compatibility implications.
 - **Generated error table.** The Markdown table in this MEP is hand-maintained. A generator from `types/errors.go` would keep it honest.
 - **Loose builtins.** `any` parameters are a temporary measure pending [MEP 12](/docs/mep/mep-0012).
 - **`break` and `continue` outside loops.** Implemented as T045.
+
+## Problems
+
+1. **`keys` is registered three times.** `types/check.go` calls `env.SetVar("keys", …)` at lines 529, 687, and 712. Only the last registration is visible at lookup time. Fix: collapse to a single registration and pick the intended signature.
 
 ## References
 


### PR DESCRIPTION
## Summary
- Refresh stale `types/check.go` line references in MEP-6 (385 → 487; 386-619 → 488-720).
- Add `ModelStmt` to the statement-walk list.
- Open a §Problems section with the duplicate `keys` registration (lines 529, 687, 712).

Closes #21272.

## Test plan
- [x] No code changes; doc-only update.