### PR TITLE
types: dedup keys builtin registration (MEP-6 P1)

### DIFF
--- a/types/check.go
+++ b/types/check.go
@@ -684,11 +684,6 @@ func Check(prog *parser.Program, env *Env) []error {
 		Return: IntType{},
 		Pure:   true,
 	}, false)
-	env.SetVar("keys", FuncType{
-		Params: []Type{MapType{Key: AnyType{}, Value: AnyType{}}},
-		Return: ListType{Elem: AnyType{}},
-		Pure:   true,
-	}, false)
 	env.SetVar("min", FuncType{
 		Params: []Type{AnyType{}},
 		Return: AnyType{},
@@ -707,11 +702,6 @@ func Check(prog *parser.Program, env *Env) []error {
 	env.SetVar("reduce", FuncType{
 		Params: []Type{AnyType{}, AnyType{}, AnyType{}},
 		Return: AnyType{},
-		Pure:   true,
-	}, false)
-	env.SetVar("keys", FuncType{
-		Params: []Type{AnyType{}},
-		Return: ListType{Elem: AnyType{}},
 		Pure:   true,
 	}, false)
 	env.SetVar("eval", FuncType{


### PR DESCRIPTION
## Summary
- Remove two redundant `keys` registrations in `types/check.go`. The strict signature `keys(map[any,any]) -> [any]` is now the single live registration.

Closes #21274. Tracked by MEP-6 §Problems #1.

## Test plan
- [x] `go test ./types/... ./parser/... ./runtime/vm/...`
- [x] `go test ./...` — no new failures (`TestTPCHPlans/q6` pre-existing, unrelated)