### PR TITLE
mep-0007: sync stale pinning-fixture pointers

### DIFF
--- a/tests/types/valid/any_top_silent_widen.golden
+++ b/tests/types/valid/any_top_silent_widen.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/any_top_silent_widen.mochi
+++ b/tests/types/valid/any_top_silent_widen.mochi
@@ -1,0 +1,11 @@
+// Snapshot: AnyType unifies with concrete types in both directions, so an
+// `any`-typed binding can flow into any concrete position without a
+// diagnostic. The checker accepts the program below today.
+//
+// MEP 7 lists this as the "AnyType unifies in both directions" escape hatch.
+// MEP 5 §Inference closes it by treating `any` as a top with no automatic
+// promotion; MEP 11 owns the subtyping decision. When that fix lands this
+// file moves to tests/types/errors/.
+let x: any = 1
+let y: int = x
+let z = x + 1

--- a/website/docs/mep/mep-0007.md
+++ b/website/docs/mep/mep-0007.md
@@ -161,12 +161,12 @@ The escape hatches we acknowledge. Each row points at the MEP that owns the fix 
 
 | Escape hatch                                         | Tracked in       | Pinning fixture                              |
 |------------------------------------------------------|------------------|----------------------------------------------|
-| `AnyType` unifies in both directions                 | [MEP 11](/docs/mep/mep-0011)           | none yet, planned `any_top_silent_widen`     |
-| `as` cast accepted without compatibility check       | [MEP 11](/docs/mep/mep-0011)           | none yet, planned `cast_int_as_string`       |
-| `null` is `any` rather than an option type           | [MEP 4](/docs/mep/mep-0004), [MEP 10](/docs/mep/mep-0010)    | none yet                                     |
+| `AnyType` unifies in both directions                 | [MEP 11](/docs/mep/mep-0011)           | `tests/types/valid/any_top_silent_widen.mochi` |
+| `as` cast accepted without compatibility check       | [MEP 11](/docs/mep/mep-0011)           | `tests/types/valid/cast_int_as_string.mochi`   |
+| `null` is `any` rather than an option type           | [MEP 4](/docs/mep/mep-0004), [MEP 10](/docs/mep/mep-0010)    | `tests/types/valid/null_widening_int.mochi`, `null_widening_list.mochi`, `null_widening_struct.mochi` |
 | Aliasing a `let` aggregate into a `var` allows a write through the alias to mutate the original | [MEP 15](/docs/mep/mep-0015) | `tests/types/valid/mutate_through_let_alias.mochi` |
 | Reading a missing map key returns the zero value (type-level fixed: map index now returns `option[V]`; runtime still returns zero value for untyped paths) | [MEP 4](/docs/mep/mep-0004) | `tests/types/errors/missing_map_key.mochi` |
-| Integer division by zero is a runtime panic, not a checker rejection | [MEP 5](/docs/mep/mep-0005) | none yet                            |
+| Integer division by zero is a runtime panic, not a checker rejection | [MEP 5](/docs/mep/mep-0005) | `tests/types/valid/divide_by_zero_literal.mochi` |
 
 Listing the fixture column on the right is uncomfortable on purpose. Every blank cell is a bug we have decided not to flag yet; the decision should be deliberate.
 


### PR DESCRIPTION
## Summary
- Update the §What we accept as not sound today table to point at the existing pinning fixtures (`cast_int_as_string`, `divide_by_zero_literal`, `null_widening_{int,list,struct}`).
- Add the missing `any_top_silent_widen.mochi` pinning fixture for the "AnyType unifies in both directions" escape hatch and reference it from the table.

Closes #21276.

## Test plan
- [x] `go test ./types/... -run TestTypeChecker_Valid`