### PR TITLE
tpch q6: refresh plan golden to match post-P2 sum() typing

### DIFF
--- a/tests/dataset/tpc-h/q6.plan
+++ b/tests/dataset/tpc-h/q6.plan
@@ -1,4 +1,4 @@
-type: int
+type: any
 plan:
 (select
   (call sum


### PR DESCRIPTION
## Summary
- `tests/dataset/tpc-h/q6.plan` expected `type: int` from the days when `sum()` was hardcoded. Post-MEP-5 P2 (#21261), sum returns the element type; q6's `lineitem` literal widens to `map[string, any]` because field values are heterogeneous, so the projection is `any`. Update the golden to match. Closes #21278.

## Test plan
- [x] `go test ./runtime/data/... -run TestTPCHPlans/q6`
- [x] `go test ./...` (clean)