### PR TITLE
types: close MEP-10 A5 (T046) and refresh MEP-9/10 docs

### DIFF
--- a/tests/dataset/tpc-h/q9.mochi
+++ b/tests/dataset/tpc-h/q9.mochi
@@ -57,7 +57,7 @@ let result =
         o.o_orderdate >= start_date && o.o_orderdate <= end_date
   group by {
     nation: n.n_name,
-    o_year: substring(o.o_orderdate, 0, 4) as int
+    o_year: int(substring(o.o_orderdate, 0, 4))
   } into g
   sort by [ g.key.nation, -g.key.o_year ]
   select {

--- a/tests/dataset/tpc-h/q9.plan
+++ b/tests/dataset/tpc-h/q9.plan
@@ -73,13 +73,12 @@ plan:
         )
         (entry
           (selector o_year)
-          (cast
+          (call int
             (call substring
               (selector o_orderdate (selector o))
               (int 0)
               (int 4)
             )
-            (type int)
           )
         )
       )

--- a/tests/types/errors/cast_int_as_string.err
+++ b/tests/types/errors/cast_int_as_string.err
@@ -1,0 +1,8 @@
+1. error[T046]: invalid cast: `int` as `string` is not allowed
+  --> tests/types/errors/cast_int_as_string.mochi:3:20
+
+  3 | let s: string = 42 as string
+    |                    ^
+
+help:
+  Only numeric-tower, union-to-variant, map-to-struct, and any-related casts are allowed. Use a parsing function (e.g. `parseIntStr`) for string conversions.

--- a/tests/types/errors/cast_int_as_string.mochi
+++ b/tests/types/errors/cast_int_as_string.mochi
@@ -1,0 +1,3 @@
+// MEP-10 A5: `int as string` is rejected at type-check time (T046).
+// Use the explicit `str(42)` conversion builtin instead.
+let s: string = 42 as string

--- a/tests/types/errors/cast_string_as_int.err
+++ b/tests/types/errors/cast_string_as_int.err
@@ -1,0 +1,8 @@
+1. error[T046]: invalid cast: `string` as `int` is not allowed
+  --> tests/types/errors/cast_string_as_int.mochi:3:22
+
+  3 | let n: int = "hello" as int
+    |                      ^
+
+help:
+  Only numeric-tower, union-to-variant, map-to-struct, and any-related casts are allowed. Use a parsing function (e.g. `parseIntStr`) for string conversions.

--- a/tests/types/errors/cast_string_as_int.mochi
+++ b/tests/types/errors/cast_string_as_int.mochi
@@ -1,0 +1,3 @@
+// MEP-10 A5: `string as int` is rejected at type-check time (T046).
+// Use the `int(...)` parsing builtin for an explicit conversion.
+let n: int = "hello" as int

--- a/tests/types/errors/missing_map_key_cast.err
+++ b/tests/types/errors/missing_map_key_cast.err
@@ -1,0 +1,8 @@
+1. error[T046]: invalid cast: `option[Point]` as `Point` is not allowed
+  --> tests/types/errors/missing_map_key_cast.mochi:7:31
+
+  7 | let p: Point = pts["missing"] as Point
+    |                               ^
+
+help:
+  Only numeric-tower, union-to-variant, map-to-struct, and any-related casts are allowed. Use a parsing function (e.g. `parseIntStr`) for string conversions.

--- a/tests/types/errors/missing_map_key_cast.mochi
+++ b/tests/types/errors/missing_map_key_cast.mochi
@@ -1,0 +1,7 @@
+// MEP-10 A5: map index returns `option[V]`. Silently casting the
+// option to its underlying type is rejected (T046). Use `match` or
+// the `?` unwrap operator (once MEP-4 A2 lands) to handle the absent
+// case explicitly.
+type Point { x: int, y: int }
+let pts: map<string, Point> = {"o": Point{x: 0, y: 0}}
+let p: Point = pts["missing"] as Point

--- a/tests/types/valid/cast_int_as_string.golden
+++ b/tests/types/valid/cast_int_as_string.golden
@@ -1,1 +1,0 @@
-✅ Type Check Passed

--- a/tests/types/valid/cast_int_as_string.mochi
+++ b/tests/types/valid/cast_int_as_string.mochi
@@ -1,8 +1,0 @@
-// Snapshot: the type checker accepts an int as string cast even though
-// the two types have no compatibility relation. The runtime raises
-// "cannot cast int to string" today.
-//
-// MEP 7 lists this as an escape hatch. MEP 11 owns the fix where the
-// checker rejects the cast at type-check time. When that lands this
-// file moves to tests/types/errors/.
-let s: string = 42 as string

--- a/tests/types/valid/cast_string_as_int.golden
+++ b/tests/types/valid/cast_string_as_int.golden
@@ -1,1 +1,0 @@
-✅ Type Check Passed

--- a/tests/types/valid/cast_string_as_int.mochi
+++ b/tests/types/valid/cast_string_as_int.mochi
@@ -1,3 +1,0 @@
-// Snapshot: the symmetric case of cast_int_as_string. Both directions
-// are accepted at type-check today, both panic at runtime.
-let n: int = "hello" as int

--- a/tests/types/valid/missing_map_key_cast.golden
+++ b/tests/types/valid/missing_map_key_cast.golden
@@ -1,1 +1,0 @@
-✅ Type Check Passed

--- a/tests/types/valid/missing_map_key_cast.mochi
+++ b/tests/types/valid/missing_map_key_cast.mochi
@@ -1,3 +1,0 @@
-type Point { x: int, y: int }
-let pts: map<string, Point> = {"o": Point{x: 0, y: 0}}
-let p: Point = pts["missing"] as Point

--- a/types/check.go
+++ b/types/check.go
@@ -1884,7 +1884,11 @@ func checkPostfix(p *parser.PostfixExpr, env *Env, expected Type) (Type, error) 
 				typ = curryFuncType(ft.Params[argCount:], ft.Return)
 			}
 		} else if cast := op.Cast; cast != nil {
-			typ = resolveTypeRef(cast.Type, env)
+			target := resolveTypeRef(cast.Type, env)
+			if !castOk(typ, target) {
+				return nil, errInvalidCast(op.Pos, typ, target)
+			}
+			typ = target
 		}
 	}
 
@@ -2779,6 +2783,39 @@ func isQueryExpr(e *parser.Expr) bool {
 			continue
 		}
 		return false
+	}
+	return false
+}
+
+// castOk reports whether an `e as T` expression should be accepted by
+// the type checker. The policy is deliberately narrow: every accepted
+// cast must have a well-defined runtime semantics. String parsing and
+// arbitrary cross-kind casts are rejected; use a parsing builtin
+// (`parseIntStr`, `int`, `str`, ...) for those.
+func castOk(from, to Type) bool {
+	if equalTypes(from, to) {
+		return true
+	}
+	if _, ok := from.(AnyType); ok {
+		return true
+	}
+	if _, ok := to.(AnyType); ok {
+		return true
+	}
+	if isNumeric(from) && isNumeric(to) {
+		return true
+	}
+	if u, ok := from.(UnionType); ok {
+		if s, ok := to.(StructType); ok {
+			if _, in := u.Variants[s.Name]; in {
+				return true
+			}
+		}
+	}
+	if _, ok := from.(MapType); ok {
+		if _, ok := to.(StructType); ok {
+			return true
+		}
 	}
 	return false
 }

--- a/types/errors.go
+++ b/types/errors.go
@@ -64,6 +64,7 @@ var Errors = map[string]diagnostic.Template{
 	"T040": {Code: "T040", Message: "`if` condition must be boolean", Help: "Ensure the condition evaluates to true or false."},
 	"T044": {Code: "T044", Message: "impure call to `%s` is not allowed in `%s` predicate", Help: "Only pure functions may be called inside `where` and `having` predicates."},
 	"T045": {Code: "T045", Message: "`%s` outside of loop", Help: "Move `%s` inside a `for` or `while` loop body."},
+	"T046": {Code: "T046", Message: "invalid cast: `%s` as `%s` is not allowed", Help: "Only numeric-tower, union-to-variant, map-to-struct, and any-related casts are allowed. Use a parsing function (e.g. `parseIntStr`) for string conversions."},
 }
 
 // --- Wrapper Functions ---
@@ -251,6 +252,10 @@ func errArgCount(pos lexer.Position, name string, expected, actual int) error {
 
 func errIfCondBoolean(pos lexer.Position) error {
 	return Errors["T040"].New(pos)
+}
+
+func errInvalidCast(pos lexer.Position, from, to Type) error {
+	return Errors["T046"].New(pos, from, to)
 }
 
 func errBreakContinueOutsideLoop(pos lexer.Position, keyword string) error {

--- a/website/docs/mep/mep-0006.md
+++ b/website/docs/mep/mep-0006.md
@@ -159,6 +159,7 @@ Highlights:
 | T043 | operator cannot be used with `any`                   |
 | T044 | impure call not allowed in where/having predicate    |
 | T045 | break/continue outside of loop                       |
+| T046 | invalid cast: from-type as to-type is not allowed    |
 
 The series has gaps. New codes should be appended to the end with the next free integer.
 

--- a/website/docs/mep/mep-0007.md
+++ b/website/docs/mep/mep-0007.md
@@ -162,7 +162,7 @@ The escape hatches we acknowledge. Each row points at the MEP that owns the fix 
 | Escape hatch                                         | Tracked in       | Pinning fixture                              |
 |------------------------------------------------------|------------------|----------------------------------------------|
 | `AnyType` unifies in both directions                 | [MEP 11](/docs/mep/mep-0011)           | `tests/types/valid/any_top_silent_widen.mochi` |
-| `as` cast accepted without compatibility check       | [MEP 11](/docs/mep/mep-0011)           | `tests/types/valid/cast_int_as_string.mochi`   |
+| ~~`as` cast accepted without compatibility check~~ (closed, T046) | [MEP 10](/docs/mep/mep-0010) A5 | `tests/types/errors/cast_int_as_string.mochi`, `tests/types/errors/cast_string_as_int.mochi`, `tests/types/errors/missing_map_key_cast.mochi` |
 | `null` is `any` rather than an option type           | [MEP 4](/docs/mep/mep-0004), [MEP 10](/docs/mep/mep-0010)    | `tests/types/valid/null_widening_int.mochi`, `null_widening_list.mochi`, `null_widening_struct.mochi` |
 | Aliasing a `let` aggregate into a `var` allows a write through the alias to mutate the original | [MEP 15](/docs/mep/mep-0015) | `tests/types/valid/mutate_through_let_alias.mochi` |
 | Reading a missing map key returns the zero value (type-level fixed: map index now returns `option[V]`; runtime still returns zero value for untyped paths) | [MEP 4](/docs/mep/mep-0004) | `tests/types/errors/missing_map_key.mochi` |

--- a/website/docs/mep/mep-0009.md
+++ b/website/docs/mep/mep-0009.md
@@ -38,14 +38,17 @@ Source counts taken at the snapshot date. Numbers are pairs of `.mochi` plus mat
 | Directory                  | Pairs |
 |----------------------------|-------|
 | tests/parser/valid         | 62    |
-| tests/parser/errors        | 11    |
-| tests/types/valid          | 62    |
-| tests/types/errors         | 58    |
+| tests/parser/errors        | 28    |
+| tests/types/valid          | 65    |
+| tests/types/errors         | 62    |
+| tests/types/soundness      | 15    |
 | tests/queryplan            | small |
 | tests/interpreter          | many  |
 | tests/vm                   | many  |
 | `tests/compiler/{rb,dart,ts}` | 37+   |
 | tests/mochi_in_mochi/parser| small |
+
+`tests/types/soundness/` pins MEP-4/5 problem fixtures (`p06_*`, `p08_*`, `p09_*`, ..., `p19_*`, `mep5_p01_*`, `mep5_p05_*`, `mep5_p13_*`). Each pairs a `.mochi` source with either a `.expect` (current behaviour) or a `.error` (rejection text) sibling.
 
 The VM and interpreter directories are end-to-end suites and are not the focus of this initiative. The parser and type fixtures are.
 
@@ -85,10 +88,10 @@ Added in v0.11.0:
 
 ```
 aggregate_count_list, aggregate_min_max_int, aggregate_sum_int_list,
-canonical_bool_only, canonical_int_arithmetic, canonical_string_concat,
-cast_int_as_string, cast_string_as_bool, cast_string_as_int,
-closure_inferred_return, divide_by_zero_literal, for_in_list,
-for_in_range, if_while_checked, inversion_if_expr,
+any_top_silent_widen, canonical_bool_only, canonical_int_arithmetic,
+canonical_string_concat, cast_int_as_string, cast_string_as_bool,
+cast_string_as_int, closure_inferred_return, divide_by_zero_literal,
+for_in_list, for_in_range, if_while_checked, inversion_if_expr,
 match_literal_pattern, match_union_variant, missing_map_key_cast,
 modulo_by_zero_literal, mutate_through_let_alias, now_returns_int64,
 null_widening_int, null_widening_list, null_widening_struct,
@@ -140,7 +143,7 @@ The matrix is a property-to-fixture mapping. A cell value of `existing` means at
 | Canonical forms, float                   | partial   | partial   |
 | Canonical forms, bigint, bigrat          | missing   | missing   |
 | Canonical forms, string                  | existing  | existing  |
-| Canonical forms, void                    | missing   | missing   |
+| Canonical forms, unit                    | existing  | missing   |
 | Canonical forms, struct                  | existing  | existing  |
 | Canonical forms, union variant           | existing  | existing  |
 | Inversion, every Primary shape           | partial   | partial   |
@@ -165,8 +168,8 @@ The matrix is a property-to-fixture mapping. A cell value of `existing` means at
 | Mutability, let xs[i] = ...              | missing   | existing  |
 | Mutability, let s.f = ...                | missing   | existing  |
 | Subtyping, record width                  | missing   | missing   |
-| Subtyping, AnyType silently accepts      | missing   | n/a       |
-| Cast, int as string                      | missing   | n/a       |
+| Subtyping, AnyType silently accepts      | existing  | n/a       |
+| Cast, int as string                      | existing  | n/a       |
 | Cast, union as variant                   | missing   | missing   |
 | Null assignable as any                   | missing   | n/a       |
 | Closures capture                         | existing  | missing   |

--- a/website/docs/mep/mep-0009.md
+++ b/website/docs/mep/mep-0009.md
@@ -89,10 +89,9 @@ Added in v0.11.0:
 ```
 aggregate_count_list, aggregate_min_max_int, aggregate_sum_int_list,
 any_top_silent_widen, canonical_bool_only, canonical_int_arithmetic,
-canonical_string_concat, cast_int_as_string, cast_string_as_bool,
-cast_string_as_int, closure_inferred_return, divide_by_zero_literal,
-for_in_list, for_in_range, if_while_checked, inversion_if_expr,
-match_literal_pattern, match_union_variant, missing_map_key_cast,
+canonical_string_concat, cast_string_as_bool, closure_inferred_return,
+divide_by_zero_literal, for_in_list, for_in_range, if_while_checked,
+inversion_if_expr, match_literal_pattern, match_union_variant,
 modulo_by_zero_literal, mutate_through_let_alias, now_returns_int64,
 null_widening_int, null_widening_list, null_widening_struct,
 numeric_float_plus_int, numeric_int_plus_float, preservation_let_chain,
@@ -121,9 +120,10 @@ user_type_field_mismatch, user_unknown_field, wrong_type_assign
 Added in v0.11.0:
 
 ```
-break_outside_loop, continue_outside_loop, if_cond_not_bool,
-impure_in_where_rejected, list_concat_type_mismatch, match_variant_arity,
-missing_map_key, multiple_top_level_errors, mutate_through_let_field,
+break_outside_loop, cast_int_as_string, cast_string_as_int,
+continue_outside_loop, if_cond_not_bool, impure_in_where_rejected,
+list_concat_type_mismatch, match_variant_arity, missing_map_key,
+missing_map_key_cast, multiple_top_level_errors, mutate_through_let_field,
 mutate_through_let_index, range_bound_float, struct_unknown_field_access,
 while_cond_not_bool
 ```
@@ -169,7 +169,7 @@ The matrix is a property-to-fixture mapping. A cell value of `existing` means at
 | Mutability, let s.f = ...                | missing   | existing  |
 | Subtyping, record width                  | missing   | missing   |
 | Subtyping, AnyType silently accepts      | existing  | n/a       |
-| Cast, int as string                      | existing  | n/a       |
+| Cast, int as string                      | n/a       | existing  |
 | Cast, union as variant                   | missing   | missing   |
 | Null assignable as any                   | missing   | n/a       |
 | Closures capture                         | existing  | missing   |

--- a/website/docs/mep/mep-0010.md
+++ b/website/docs/mep/mep-0010.md
@@ -35,19 +35,19 @@ A fixture pinned to current behaviour is not the same as endorsement. Some entri
 
 #### A1. AnyType is a true top type
 
-**Evidence.** `types/check.go:148-157` for the `unify` rule that lets `AnyType` match in either direction. Most builtins are declared with `AnyType{}` parameters at lines 393 to 562.
+**Evidence.** `types/check.go:241-248` for the `unify` rule that lets `AnyType` match in either direction. Most builtins are declared with `AnyType{}` parameters at lines 488 to 720.
 
 **Impact.** A value typed `any` can be passed to a function expecting `int`, indexed as a list, or compared with anything. There is no explicit cast required.
 
 **Plan.**
 
-1. Capture the current behaviour in a fixture (`tests/types/valid/any_top_silent_widen.mochi`).
+1. Pinned by `tests/types/valid/any_top_silent_widen.mochi`.
 2. Audit which builtins truly need `any` and rewrite the rest with parametric polymorphism once [MEP 12](/docs/mep/mep-0012) lands.
 3. Tighten `unify` so `any` requires an explicit `as` cast in either direction.
 
 #### A2. null is a value of any type
 
-**Evidence.** `types/check.go:1708`. The literal `null` is typed `AnyType{}` rather than producing an `OptionType`.
+**Evidence.** `types/check.go:1906`. The literal `null` is typed `AnyType{}` rather than producing an `OptionType`.
 
 **Impact.** `let x: int = null` type checks today. Dereferencing `x` in arithmetic is a runtime error.
 
@@ -59,7 +59,7 @@ A fixture pinned to current behaviour is not the same as endorsement. Some entri
 
 #### A3. Mutation through immutable bindings via aliasing
 
-**Evidence.** `types/check.go:858-868` in the `AssignStmt` walk. The mutability flag is consulted before any index or field walk, so the direct path `let xs = [1]; xs[0] = 2` and `let p = Point{x: 1}; p.x = 2` are both rejected with `T024` today. Pinned by `tests/types/errors/mutate_through_let_index.mochi` and `tests/types/errors/mutate_through_let_field.mochi`.
+**Evidence.** `types/check.go:971-1080` in the `AssignStmt` walk. The mutability flag is consulted before any index or field walk, so the direct path `let xs = [1]; xs[0] = 2` and `let p = Point{x: 1}; p.x = 2` are both rejected with `T024` today. Pinned by `tests/types/errors/mutate_through_let_index.mochi` and `tests/types/errors/mutate_through_let_field.mochi`.
 
 The remaining hole is aliasing. Copying a let-bound list (or struct, or map) into a `var` binds the same underlying storage at runtime, so a write through the `var` mutates the `let` too. `tests/types/valid/mutate_through_let_alias.mochi` pins the type checker accepting the alias write; the runtime read after the write returns the mutated value.
 
@@ -73,7 +73,7 @@ The remaining hole is aliasing. Copying a let-bound list (or struct, or map) int
 
 #### A4. Match exhaustiveness not enforced
 
-**Evidence.** The match check loop in `types/check.go` (lines around 2209 to 2284) types each arm but does not check that the union of arm patterns covers every variant of a `UnionType` scrutinee.
+**Evidence.** `checkMatchExpr` in `types/check.go:2407` types each arm but does not check that the union of arm patterns covers every variant of a `UnionType` scrutinee.
 
 **Impact.** Removing a variant from a union does not surface as a compile error in code that matches on it. Users discover the gap at runtime.
 
@@ -85,7 +85,7 @@ The remaining hole is aliasing. Copying a let-bound list (or struct, or map) int
 
 #### A5. as cast is unchecked
 
-**Evidence.** `types/check.go:1687-1688` resolves the target type and returns it. There is no compatibility check.
+**Evidence.** `types/check.go:1886-1887` resolves the target type and returns it. There is no compatibility check.
 
 **Impact.** `(5 as string).len` type checks. The runtime then either crashes or silently coerces, depending on the path.
 
@@ -125,17 +125,17 @@ Path A matches the runtime today. We recommend it.
 
 **Plan.** After A3, treat list element type as invariant under aliasing. Allow read-only covariance only at expression positions that cannot be assigned through.
 
-#### B4. Pure flag is set but never enforced
+#### B4. Pure flag enforcement narrow to query predicates
 
-**Evidence.** The flag is set at builtin registration in `types/check.go:393-562` and on user functions where the body is free of side effects. There is no rule that consumes it.
+**Evidence.** The flag is set at builtin registration in `types/check.go:488-720` and on user functions via `isPureFunction` (called from declaration sites at `:759`, `:841`, `:1277`, `:1345`). It is consumed in one pure position: `where` and `having` predicates, where an impure call is rejected with `T044` ("impure call to `%s` is not allowed in `%s` predicate"). Pinned by `tests/types/valid/pure_in_where_ok.mochi` and `tests/types/errors/impure_in_where_rejected.mochi`.
 
-**Impact.** The flag is misleading. A programmer reading the code might trust it.
+**Impact.** The flag is honest for query predicates today but does not gate other positions where purity would matter (struct field defaults, type alias arguments, const-like let initialisers).
 
-**Plan.** Either delete the flag, or add a small set of pure positions (struct field defaults, type alias arguments, query plan predicates) where impure calls are rejected.
+**Plan.** Extend the consumer set incrementally as the language gains pure positions. Each new position lands with a matching fixture pair.
 
 #### B5. Generic functions parse but do not unify across calls
 
-**Evidence.** `TypeVar` exists at `types/check.go:104` and is used in unification but is not produced by inference of a function call's result. Each call site re-infers from the declared signature.
+**Evidence.** `TypeVar` exists at `types/check.go:186-200` and is used in unification but is not produced by inference of a function call's result. Each call site re-infers from the declared signature.
 
 **Impact.** A function declared `fun id<T>(x: T): T` is callable but the caller always sees the type of `x` flow through the declaration in a loose way.
 
@@ -143,7 +143,7 @@ Path A matches the runtime today. We recommend it.
 
 #### B6. Query select fallback to any
 
-**Evidence.** The aggregate dispatch in `types/check.go:2401-2439` explicitly types `count`, `sum`, `avg`, `min`, `max` and falls through to general expression typing for everything else, often producing `any`.
+**Evidence.** The aggregate dispatch in `types/check.go:2610-2700` (with `aggregateCallName` at `:2730`) explicitly types `count`, `sum`, `avg`, `min`, `max` and falls through to general expression typing for everything else, often producing `any`.
 
 **Impact.** A `select foo(bar)` where `foo` returns `any` does not raise even when `bar` is mistyped.
 
@@ -151,7 +151,7 @@ Path A matches the runtime today. We recommend it.
 
 #### B7. extern declarations are trust-the-author
 
-**Evidence.** `types/check.go:828-850` registers extern bindings without verifying the symbol exists in the import target.
+**Evidence.** `types/check.go:941-962` registers extern bindings without verifying the symbol exists in the import target.
 
 **Impact.** Mismatch between declared type and actual symbol surfaces as a runtime failure, often deep inside a foreign call.
 
@@ -159,7 +159,7 @@ Path A matches the runtime today. We recommend it.
 
 #### B8. Recursive type definitions
 
-**Evidence.** `types/check.go:1179-1207` builds union types with a shared variants map so forward references resolve. Recursion in struct fields is permitted.
+**Evidence.** `types/check.go:1292-1311` builds union types with a shared variants map so forward references resolve. Recursion in struct fields is permitted.
 
 **Impact.** Soundness is not at issue but unbounded recursive structures can cause runtime memory issues. JSON serialisation can loop.
 
@@ -167,7 +167,7 @@ Path A matches the runtime today. We recommend it.
 
 #### B9. Shadowing without warning
 
-**Evidence.** `types/env.go:179, 187` allow rebinding a name in a child scope without diagnostic.
+**Evidence.** `types/env.go:205, 213` (`SetVar` and `SetVarDeep`) allow rebinding a name in a child scope without diagnostic.
 
 **Impact.** Subtle bugs. A user writes `let x = ...` in a nested block intending to shadow but accidentally reassigns.
 
@@ -177,7 +177,7 @@ Path A matches the runtime today. We recommend it.
 
 #### C1. int | nil does not parse
 
-**Evidence.** `parser/parser.go:184-189`. `TypeRef` does not list union as a constructor.
+**Evidence.** `parser/parser.go:219-225`. `TypeRef` does not list union as a constructor.
 
 **Impact.** The natural way to write a nullable type fails.
 
@@ -185,7 +185,7 @@ Path A matches the runtime today. We recommend it.
 
 #### C2. Unary minus on RHS of comparison without parens
 
-**Evidence.** `parser/parser.go:53-56` documents the lexer rationale.
+**Evidence.** `parser/parser.go:54-57` documents the lexer rationale.
 
 **Impact.** `x == -1` requires parens. Inserting whitespace as `x == - 1` does not help; the parser sees `-` followed by `1` as a missing-operand prefix and fails the same way. Surprising for new users.
 
@@ -201,7 +201,7 @@ Path A matches the runtime today. We recommend it.
 
 #### C4. The block comment regex does not nest
 
-**Evidence.** `parser/parser.go:49`. `/* ... */` matches the first `*/`.
+**Evidence.** `parser/parser.go:64` (Comment regex). `/* ... */` matches the first `*/`.
 
 **Impact.** A literal `*/` inside a block comment terminates it early.
 
@@ -209,7 +209,7 @@ Path A matches the runtime today. We recommend it.
 
 #### C5. Reserved keywords accidentally steal user names
 
-**Evidence.** The keyword regex at `parser/parser.go:51` is enforced globally.
+**Evidence.** The keyword regex at `parser/parser.go:66` is enforced globally.
 
 **Impact.** Adding a keyword silently breaks user code that used the new word as an identifier.
 

--- a/website/docs/mep/mep-0010.md
+++ b/website/docs/mep/mep-0010.md
@@ -83,16 +83,13 @@ The remaining hole is aliasing. Copying a let-bound list (or struct, or map) int
 2. Allow a single wildcard or identifier pattern to cover the remainder, and warn (not error) if it shadows reachable cases.
 3. Emit a new error code for missing variants.
 
-#### A5. as cast is unchecked
+#### A5. as cast is unchecked (closed)
 
-**Evidence.** `types/check.go:1886-1887` resolves the target type and returns it. There is no compatibility check.
+**Status.** Closed. `castOk(from, to)` at `types/check.go` is consulted from the cast site in `checkPostfix`. Allowed: identity, `_ as any`, `any as _`, numeric-tower casts, union-to-variant (when the variant is in the union), and map-literal to struct. Anything else is rejected with `T046`. Use `int(...)`, `str(...)`, `parseIntStr(...)` for parsing.
 
-**Impact.** `(5 as string).len` type checks. The runtime then either crashes or silently coerces, depending on the path.
+**Pinning fixtures.** `tests/types/errors/cast_int_as_string.mochi`, `tests/types/errors/cast_string_as_int.mochi`, `tests/types/errors/missing_map_key_cast.mochi`.
 
-**Plan.**
-
-1. Define a small subtype check `castOk(from, to)` that allows numeric tower casts, union to variant casts (with a runtime discriminator check), and `to any` always.
-2. Reject other casts at type check time.
+**Original evidence.** `types/check.go:1886-1887` previously resolved the target type and returned it unchecked. `(5 as string).len` used to type check; the runtime then either crashed or silently coerced.
 
 ### Tier B: surprising or incomplete
 


### PR DESCRIPTION
## Summary
- MEP-10 A5 closed: `castOk(from, to)` gates `as`, new T046 diagnostic rejects non-identity/non-numeric/non-variant casts. Use `int(...)`, `str(...)`, `parseIntStr(...)` for parsing.
- Moves cast_int_as_string, cast_string_as_int, missing_map_key_cast from valid/ to errors/ with .err goldens.
- Fixes tpc-h q9 (substring-to-int via `int(...)` instead of `as int`) and refreshes its plan golden.
- MEP-6/7/9/10 doc refresh: T046 in catalogue, A5 escape hatch struck through, line refs to current offsets, B4 rewritten around T044 pure enforcement, MEP-9 fixture counts synced.

Tracked in #21281.

## Test plan
- [x] `go test ./types/... ./runtime/... ./tests/...`
- [x] `make update-golden STAGE=types` clean