### PR TITLE
types: introduce Subtype(s, t) predicate (MEP-11.1)

### DIFF
--- a/types/subtype.go
+++ b/types/subtype.go
@@ -1,0 +1,244 @@
+package types
+
+// Subtype reports whether s is a subtype of t under the rules laid out
+// in MEP-11 §Specification. The predicate is strict: AnyType only acts
+// as a top type when t is AnyType (T-Top). The reverse direction
+// (AnyType flowing into a concrete type without an explicit cast) is
+// rejected, which closes MEP-10 A1 at every call site that routes
+// through Subtype.
+//
+// Subtype is purely structural and has no side effects. It does not
+// allocate, and it does not produce substitutions; unification with
+// type variables is the job of the unifier in check.go. A caller that
+// needs both behaviors (the common case at a call site) runs the
+// unifier first, applies the substitution, and then asks Subtype
+// whether the inferred argument type is acceptable in the parameter
+// position.
+func Subtype(s, t Type) bool {
+	// T-Refl on identical kinds with no children handled by the
+	// per-kind branches below. The fast equality test catches the
+	// common case of two AnyType{} values, two IntType{} values, and
+	// so on without descending into structural rules.
+	if equalKinds(s, t) {
+		return true
+	}
+
+	// T-Top. Any concrete type widens to AnyType. The converse is not
+	// a rule: AnyType -> T requires an explicit cast (MEP-10 A1).
+	if _, ok := t.(AnyType); ok {
+		return true
+	}
+
+	switch sv := s.(type) {
+
+	case IntType:
+		switch t.(type) {
+		case Int64Type, BigIntType, BigRatType:
+			return true
+		}
+		return false
+
+	case Int64Type:
+		switch t.(type) {
+		case BigIntType, BigRatType:
+			return true
+		}
+		return false
+
+	case BigIntType:
+		_, ok := t.(BigRatType)
+		return ok
+
+	case FloatType:
+		_, ok := t.(BigRatType)
+		return ok
+
+	case ListType:
+		// MEP-11 §T-List-Read. List elements are covariant in read
+		// position only. Routing through Subtype is read position by
+		// construction; write position (assignment into an index) uses
+		// invariance via Equal (see MEP-11 §T-List-Inv).
+		tv, ok := t.(ListType)
+		if !ok {
+			return false
+		}
+		return Subtype(sv.Elem, tv.Elem)
+
+	case MapType:
+		// MEP-11 §T-Map-Inv. Maps are invariant in both key and value.
+		// We model invariance as Subtype(s, t) iff Equal(s.K, t.K) &&
+		// Equal(s.V, t.V). The Subtype call here intentionally bottoms
+		// out at structural equality on the children.
+		tv, ok := t.(MapType)
+		if !ok {
+			return false
+		}
+		return equalKinds(sv.Key, tv.Key) && equalKinds(sv.Value, tv.Value)
+
+	case OptionType:
+		// MEP-11 §T-Option-Cov. option[S] <: option[T] when S <: T.
+		tv, ok := t.(OptionType)
+		if !ok {
+			return false
+		}
+		return Subtype(sv.Elem, tv.Elem)
+
+	case StructType:
+		// MEP-11 §T-Struct-Nominal. Struct typing is nominal: two
+		// structs are related iff they share a declared name. The
+		// variant-to-union rule below handles the cross-kind case.
+		switch tv := t.(type) {
+		case StructType:
+			return sv.Name != "" && sv.Name == tv.Name
+		case UnionType:
+			// MEP-11 §T-Variant. A variant struct is a subtype of its
+			// declared union.
+			_, ok := tv.Variants[sv.Name]
+			return ok
+		}
+		return false
+
+	case UnionType:
+		tv, ok := t.(UnionType)
+		if !ok {
+			return false
+		}
+		return sv.Name != "" && sv.Name == tv.Name
+
+	case FuncType:
+		// MEP-11 §T-Fun. Functions are contravariant in arguments and
+		// covariant in the return.
+		tv, ok := t.(FuncType)
+		if !ok {
+			return false
+		}
+		if len(sv.Params) != len(tv.Params) {
+			return false
+		}
+		if (sv.Variadic == nil) != (tv.Variadic == nil) {
+			return false
+		}
+		for i := range sv.Params {
+			if !Subtype(tv.Params[i], sv.Params[i]) {
+				return false
+			}
+		}
+		if sv.Variadic != nil && !Subtype(tv.Variadic, sv.Variadic) {
+			return false
+		}
+		if sv.Return == nil || tv.Return == nil {
+			return sv.Return == tv.Return
+		}
+		return Subtype(sv.Return, tv.Return)
+
+	case GroupType:
+		tv, ok := t.(GroupType)
+		if !ok {
+			return false
+		}
+		return equalKinds(sv.Key, tv.Key) && equalKinds(sv.Elem, tv.Elem)
+	}
+
+	return false
+}
+
+// equalKinds is a small structural equality used by Subtype to discharge
+// T-Refl on compound kinds and to enforce the invariance rules on Map
+// and Group children. It deliberately does not call Subtype recursively
+// because invariance is *not* expressible as bidirectional subtyping
+// once AnyType is in play (Subtype(int, any) holds but Subtype(any, int)
+// does not, so the bidirectional formulation would silently re-admit
+// the implicit widening Subtype is designed to reject).
+func equalKinds(a, b Type) bool {
+	switch av := a.(type) {
+	case AnyType:
+		_, ok := b.(AnyType)
+		return ok
+	case IntType:
+		_, ok := b.(IntType)
+		return ok
+	case Int64Type:
+		_, ok := b.(Int64Type)
+		return ok
+	case BigIntType:
+		_, ok := b.(BigIntType)
+		return ok
+	case BigRatType:
+		_, ok := b.(BigRatType)
+		return ok
+	case FloatType:
+		_, ok := b.(FloatType)
+		return ok
+	case StringType:
+		_, ok := b.(StringType)
+		return ok
+	case BoolType:
+		_, ok := b.(BoolType)
+		return ok
+	case UnitType:
+		_, ok := b.(UnitType)
+		return ok
+	case ListType:
+		bv, ok := b.(ListType)
+		return ok && equalKinds(av.Elem, bv.Elem)
+	case MapType:
+		bv, ok := b.(MapType)
+		return ok && equalKinds(av.Key, bv.Key) && equalKinds(av.Value, bv.Value)
+	case OptionType:
+		bv, ok := b.(OptionType)
+		return ok && equalKinds(av.Elem, bv.Elem)
+	case GroupType:
+		bv, ok := b.(GroupType)
+		return ok && equalKinds(av.Key, bv.Key) && equalKinds(av.Elem, bv.Elem)
+	case StructType:
+		bv, ok := b.(StructType)
+		if !ok {
+			return false
+		}
+		if av.Name != "" || bv.Name != "" {
+			return av.Name == bv.Name
+		}
+		if len(av.Fields) != len(bv.Fields) {
+			return false
+		}
+		for i, f := range av.Fields {
+			if f.Name != bv.Fields[i].Name {
+				return false
+			}
+			if !equalKinds(f.Type, bv.Fields[i].Type) {
+				return false
+			}
+		}
+		return true
+	case UnionType:
+		bv, ok := b.(UnionType)
+		return ok && av.Name == bv.Name
+	case FuncType:
+		bv, ok := b.(FuncType)
+		if !ok {
+			return false
+		}
+		if len(av.Params) != len(bv.Params) {
+			return false
+		}
+		if (av.Variadic == nil) != (bv.Variadic == nil) {
+			return false
+		}
+		for i := range av.Params {
+			if !equalKinds(av.Params[i], bv.Params[i]) {
+				return false
+			}
+		}
+		if av.Variadic != nil && !equalKinds(av.Variadic, bv.Variadic) {
+			return false
+		}
+		if av.Return == nil || bv.Return == nil {
+			return av.Return == bv.Return
+		}
+		return equalKinds(av.Return, bv.Return)
+	case *TypeVar:
+		bv, ok := b.(*TypeVar)
+		return ok && av.Name == bv.Name
+	}
+	return false
+}

--- a/types/subtype_test.go
+++ b/types/subtype_test.go
@@ -1,0 +1,173 @@
+package types
+
+import "testing"
+
+// MEP-11.1 fixtures the Subtype predicate against the rules in
+// website/docs/mep/mep-0011.md §Specification.
+
+func TestSubtype_Reflexivity(t *testing.T) {
+	cases := []Type{
+		IntType{}, Int64Type{}, BigIntType{}, BigRatType{}, FloatType{},
+		StringType{}, BoolType{}, UnitType{}, AnyType{},
+		ListType{Elem: IntType{}},
+		MapType{Key: StringType{}, Value: IntType{}},
+		OptionType{Elem: IntType{}},
+	}
+	for _, c := range cases {
+		if !Subtype(c, c) {
+			t.Errorf("Subtype(%s, %s) want true", c, c)
+		}
+	}
+}
+
+func TestSubtype_AnyIsTop(t *testing.T) {
+	// MEP-11 T-Top: every concrete type widens to any.
+	if !Subtype(IntType{}, AnyType{}) {
+		t.Error("Subtype(int, any) want true")
+	}
+	if !Subtype(ListType{Elem: IntType{}}, AnyType{}) {
+		t.Error("Subtype([int], any) want true")
+	}
+	// MEP-10 A1 closeout: any does NOT silently flow into a concrete
+	// type. An explicit cast is required at the call site.
+	if Subtype(AnyType{}, IntType{}) {
+		t.Error("Subtype(any, int) want false (MEP-10 A1)")
+	}
+	if Subtype(AnyType{}, ListType{Elem: IntType{}}) {
+		t.Error("Subtype(any, [int]) want false (MEP-10 A1)")
+	}
+}
+
+func TestSubtype_NumericTower(t *testing.T) {
+	// MEP-11 T-NumTower: int <: int64 <: bigint <: bigrat, float <: bigrat.
+	want := []struct {
+		s, t Type
+		ok   bool
+	}{
+		{IntType{}, Int64Type{}, true},
+		{IntType{}, BigIntType{}, true},
+		{IntType{}, BigRatType{}, true},
+		{Int64Type{}, BigIntType{}, true},
+		{Int64Type{}, BigRatType{}, true},
+		{BigIntType{}, BigRatType{}, true},
+		{FloatType{}, BigRatType{}, true},
+
+		// Widening only flows in one direction.
+		{Int64Type{}, IntType{}, false},
+		{BigIntType{}, IntType{}, false},
+		{BigRatType{}, FloatType{}, false},
+		{FloatType{}, IntType{}, false},
+		{IntType{}, FloatType{}, false},
+	}
+	for _, c := range want {
+		got := Subtype(c.s, c.t)
+		if got != c.ok {
+			t.Errorf("Subtype(%s, %s) = %v want %v", c.s, c.t, got, c.ok)
+		}
+	}
+}
+
+func TestSubtype_ListCovariant(t *testing.T) {
+	// T-List-Read: covariant in read position.
+	if !Subtype(ListType{Elem: IntType{}}, ListType{Elem: BigIntType{}}) {
+		t.Error("[int] <: [bigint] want true")
+	}
+	if Subtype(ListType{Elem: BigIntType{}}, ListType{Elem: IntType{}}) {
+		t.Error("[bigint] <: [int] want false")
+	}
+	// [int] <: [any] but [any] is not <: [int].
+	if !Subtype(ListType{Elem: IntType{}}, ListType{Elem: AnyType{}}) {
+		t.Error("[int] <: [any] want true")
+	}
+	if Subtype(ListType{Elem: AnyType{}}, ListType{Elem: IntType{}}) {
+		t.Error("[any] <: [int] want false")
+	}
+}
+
+func TestSubtype_MapInvariant(t *testing.T) {
+	// T-Map-Inv: maps are invariant in both children.
+	if Subtype(
+		MapType{Key: StringType{}, Value: IntType{}},
+		MapType{Key: StringType{}, Value: BigIntType{}},
+	) {
+		t.Error("{string:int} <: {string:bigint} want false (invariant)")
+	}
+	if Subtype(
+		MapType{Key: StringType{}, Value: IntType{}},
+		MapType{Key: StringType{}, Value: AnyType{}},
+	) {
+		t.Error("{string:int} <: {string:any} want false (invariant)")
+	}
+	if !Subtype(
+		MapType{Key: StringType{}, Value: IntType{}},
+		MapType{Key: StringType{}, Value: IntType{}},
+	) {
+		t.Error("{string:int} <: {string:int} want true")
+	}
+}
+
+func TestSubtype_OptionCovariant(t *testing.T) {
+	// T-Option-Cov: option[S] <: option[T] when S <: T.
+	if !Subtype(OptionType{Elem: IntType{}}, OptionType{Elem: BigIntType{}}) {
+		t.Error("option[int] <: option[bigint] want true")
+	}
+	if Subtype(OptionType{Elem: BigIntType{}}, OptionType{Elem: IntType{}}) {
+		t.Error("option[bigint] <: option[int] want false")
+	}
+}
+
+func TestSubtype_FunctionVariance(t *testing.T) {
+	// T-Fun: contravariant args, covariant result.
+	// (bigint) -> int  <:  (int) -> bigint
+	wider := FuncType{Params: []Type{BigIntType{}}, Return: IntType{}}
+	narrower := FuncType{Params: []Type{IntType{}}, Return: BigIntType{}}
+	if !Subtype(wider, narrower) {
+		t.Error("(bigint)->int <: (int)->bigint want true (T-Fun)")
+	}
+	if Subtype(narrower, wider) {
+		t.Error("(int)->bigint <: (bigint)->int want false")
+	}
+}
+
+func TestSubtype_VariantToUnion(t *testing.T) {
+	// T-Variant: a declared variant struct is a subtype of its union.
+	leaf := StructType{Name: "Leaf"}
+	node := StructType{Name: "Node"}
+	tree := UnionType{
+		Name:     "Tree",
+		Variants: map[string]StructType{"Leaf": leaf, "Node": node},
+		Order:    []string{"Leaf", "Node"},
+	}
+	if !Subtype(leaf, tree) {
+		t.Error("Leaf <: Tree want true")
+	}
+	other := StructType{Name: "Other"}
+	if Subtype(other, tree) {
+		t.Error("Other <: Tree want false (not a declared variant)")
+	}
+}
+
+func TestSubtype_StructNominal(t *testing.T) {
+	// T-Struct-Nominal: identity by name only.
+	a := StructType{Name: "P", Fields: []StructField{{Name: "x", Type: IntType{}}}}
+	b := StructType{Name: "P", Fields: []StructField{{Name: "x", Type: IntType{}}}}
+	c := StructType{Name: "Q", Fields: []StructField{{Name: "x", Type: IntType{}}}}
+	if !Subtype(a, b) {
+		t.Error("P <: P want true")
+	}
+	if Subtype(a, c) {
+		t.Error("P <: Q want false (nominal)")
+	}
+}
+
+func TestSubtype_StringBoolUnit(t *testing.T) {
+	if Subtype(StringType{}, IntType{}) {
+		t.Error("string <: int want false")
+	}
+	if Subtype(BoolType{}, IntType{}) {
+		t.Error("bool <: int want false")
+	}
+	if Subtype(UnitType{}, AnyType{}) != true {
+		t.Error("unit <: any want true")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `types/subtype.go` with the strict `Subtype(s, t) bool` predicate from MEP-11.
- Adds `types/subtype_test.go` pinning T-Refl, T-Top, T-NumTower, T-List-Read, T-Map-Inv, T-Option-Cov, T-Fun, T-Variant, T-Struct-Nominal.
- Purely additive. No existing call site routes through `Subtype` yet (#78).

Closes the foundation step for MEP-10 A1 (any flows up but not down) and unblocks MEP-11.2 onward.

Tracking: #21286.

## Test plan
- [x] `go test ./types/ -run TestSubtype`
- [x] `go test ./types/` full
- [x] `go build ./...`