### PR TITLE
types: substitution-aware Unify and Subst algebra (MEP-12.1)

### DIFF
--- a/types/poly.go
+++ b/types/poly.go
@@ -1,0 +1,160 @@
+package types
+
+import (
+	"fmt"
+	"sort"
+	"sync/atomic"
+)
+
+// Polymorphism helpers used by the MEP-12 call-site algorithm. The
+// pieces here are the textbook generalise / instantiate primitives.
+// They are kept in their own file so the call-site walk in check.go
+// can read like the pseudocode in website/docs/mep/mep-0012.md
+// §Algorithm rather than re-deriving the substitution mechanics every
+// time. See also website/docs/mep/mep-0005.md P11.
+
+// freshCounter is the monotonic source of unique TypeVar suffixes. A
+// counter (rather than a UUID or random string) keeps test output
+// stable and short. Reset is exported only for tests.
+var freshCounter uint64
+
+// FreshTypeVar returns a TypeVar whose name is `base` decorated with a
+// monotonically increasing suffix, so distinct call sites of a generic
+// function get distinct variables.
+//
+//	FreshTypeVar("T") -> *TypeVar{Name: "T#1"}
+//	FreshTypeVar("T") -> *TypeVar{Name: "T#2"}
+//
+// The `#` separator is not a valid identifier character in surface
+// Mochi, which guarantees a fresh variable can never collide with a
+// user-declared name. The pointer-receiver identity rule on TypeVar
+// (see check.go) ensures that two FreshTypeVar results with the same
+// suffix would still be distinct values; the unique suffix is purely
+// for diagnostic clarity.
+func FreshTypeVar(base string) *TypeVar {
+	if base == "" {
+		base = "T"
+	}
+	n := atomic.AddUint64(&freshCounter, 1)
+	return &TypeVar{Name: fmt.Sprintf("%s#%d", base, n)}
+}
+
+// ResetFreshCounter rewinds the fresh-variable counter. Test-only.
+func ResetFreshCounter() { atomic.StoreUint64(&freshCounter, 0) }
+
+// Instantiate replaces every TypeVar in t whose name is listed in
+// `params` with a fresh TypeVar, and returns both the rewritten type
+// and the substitution used. This is the operation the MEP-12 call
+// site runs to turn a declared scheme `<T, U>(T, U) : T` into a fresh
+// pair of variables at each call.
+//
+// Variables in t whose names are not in `params` are left alone.
+// That matches the prenex-only design from MEP-12 §"Why prenex only":
+// only the function-level parameters are quantified; any nested
+// variables are either captured from the outer scope or already
+// flagged as escaping by T048.
+func Instantiate(t Type, params []string) (Type, Subst) {
+	if len(params) == 0 || t == nil {
+		return t, Subst{}
+	}
+	sub := Subst{}
+	for _, name := range params {
+		sub[name] = FreshTypeVar(name)
+	}
+	return sub.Apply(t), sub
+}
+
+// FreeTypeVars returns the names of every TypeVar that appears free
+// in t under sub. The result is deterministic: names are returned in
+// sorted order so callers building diagnostic strings get a stable
+// rendering.
+func FreeTypeVars(t Type, sub Subst) []string {
+	seen := map[string]struct{}{}
+	collectFreeVars(t, sub, seen)
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func collectFreeVars(t Type, sub Subst, seen map[string]struct{}) {
+	if t == nil {
+		return
+	}
+	switch v := t.(type) {
+	case *TypeVar:
+		if u, ok := sub[v.Name]; ok {
+			collectFreeVars(u, sub, seen)
+			return
+		}
+		seen[v.Name] = struct{}{}
+	case ListType:
+		collectFreeVars(v.Elem, sub, seen)
+	case MapType:
+		collectFreeVars(v.Key, sub, seen)
+		collectFreeVars(v.Value, sub, seen)
+	case OptionType:
+		collectFreeVars(v.Elem, sub, seen)
+	case GroupType:
+		collectFreeVars(v.Key, sub, seen)
+		collectFreeVars(v.Elem, sub, seen)
+	case FuncType:
+		for _, p := range v.Params {
+			collectFreeVars(p, sub, seen)
+		}
+		if v.Variadic != nil {
+			collectFreeVars(v.Variadic, sub, seen)
+		}
+		collectFreeVars(v.Return, sub, seen)
+	case StructType:
+		for _, f := range v.Fields {
+			collectFreeVars(f.Type, sub, seen)
+		}
+	}
+}
+
+// Generalise returns the list of TypeVar names that are free in t but
+// not free in any binding currently visible through `env`. Those names
+// are the candidates to quantify at the declaration site. Names free
+// in env are *not* generalised because they are captured from an outer
+// scope and would change meaning if rebound at a call.
+//
+// The returned names are sorted. The returned type is t unchanged;
+// generalisation in Mochi does not rewrite the type itself because
+// type parameters are explicit at the FunDecl syntax level (MEP-12
+// §"Why not Hindley-Milner"). The helper is still useful as a check
+// for escaping variables (MEP-12 §Diagnostics T048): if Generalise
+// returns names that the declaration did not list as parameters, those
+// are escaping variables.
+func Generalise(t Type, env *Env) ([]string, Type) {
+	free := FreeTypeVars(t, nil)
+	if env == nil {
+		return free, t
+	}
+	captured := envFreeVars(env)
+	out := free[:0]
+	for _, name := range free {
+		if _, ok := captured[name]; ok {
+			continue
+		}
+		out = append(out, name)
+	}
+	return out, t
+}
+
+// envFreeVars returns the set of TypeVar names that appear free in any
+// binding visible through env. We walk every name in env, including
+// names shadowed by inner scopes, because a variable captured by an
+// outer binding remains captured even if the inner scope rebinds the
+// surface name to a different type.
+func envFreeVars(env *Env) map[string]struct{} {
+	seen := map[string]struct{}{}
+	for e := env; e != nil; e = e.parent {
+		for _, t := range e.types {
+			collectFreeVars(t, nil, seen)
+		}
+	}
+	return seen
+}

--- a/types/poly_test.go
+++ b/types/poly_test.go
@@ -1,0 +1,106 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+)
+
+// MEP-5 P11 / MEP-12 §Algorithm: generalise / instantiate primitives.
+
+func TestFreshTypeVar_UniqueAcrossCalls(t *testing.T) {
+	ResetFreshCounter()
+	a := FreshTypeVar("T")
+	b := FreshTypeVar("T")
+	if a == b {
+		t.Error("FreshTypeVar must return distinct pointers")
+	}
+	if a.Name == b.Name {
+		t.Errorf("FreshTypeVar names collided: %s vs %s", a.Name, b.Name)
+	}
+}
+
+func TestInstantiate_ReplacesNamedParams(t *testing.T) {
+	ResetFreshCounter()
+	scheme := FuncType{
+		Params: []Type{&TypeVar{Name: "T"}, &TypeVar{Name: "U"}},
+		Return: &TypeVar{Name: "T"},
+	}
+	got, sub := Instantiate(scheme, []string{"T", "U"})
+	ft := got.(FuncType)
+	tv0 := ft.Params[0].(*TypeVar)
+	tv1 := ft.Params[1].(*TypeVar)
+	if tv0.Name == "T" || tv1.Name == "U" {
+		t.Errorf("Instantiate left original names: %v", ft)
+	}
+	if !reflect.DeepEqual(ft.Return, tv0) {
+		t.Errorf("return should share the fresh T variable, got %s vs %s",
+			ft.Return, tv0)
+	}
+	if _, ok := sub["T"]; !ok {
+		t.Errorf("substitution missing T binding: %v", sub)
+	}
+}
+
+func TestInstantiate_LeavesUnboundVariables(t *testing.T) {
+	scheme := ListType{Elem: &TypeVar{Name: "X"}}
+	got, _ := Instantiate(scheme, []string{"T"})
+	if !reflect.DeepEqual(got, scheme) {
+		t.Errorf("non-parameter var X should not be rewritten, got %s", got)
+	}
+}
+
+func TestInstantiate_EmptyParams(t *testing.T) {
+	scheme := IntType{}
+	got, sub := Instantiate(scheme, nil)
+	if !reflect.DeepEqual(got, scheme) {
+		t.Errorf("Instantiate with no params should return t unchanged")
+	}
+	if len(sub) != 0 {
+		t.Errorf("empty params should produce empty substitution")
+	}
+}
+
+func TestFreeTypeVars_Sorted(t *testing.T) {
+	t1 := &TypeVar{Name: "T"}
+	t2 := &TypeVar{Name: "A"}
+	got := FreeTypeVars(FuncType{Params: []Type{t1, t2}, Return: t1}, nil)
+	want := []string{"A", "T"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("want %v sorted, got %v", want, got)
+	}
+}
+
+func TestFreeTypeVars_SkipsBound(t *testing.T) {
+	sub := Subst{"T": IntType{}}
+	got := FreeTypeVars(ListType{Elem: &TypeVar{Name: "T"}}, sub)
+	if len(got) != 0 {
+		t.Errorf("bound T should not appear in free vars, got %v", got)
+	}
+}
+
+func TestFreeTypeVars_FollowsTransitiveSubst(t *testing.T) {
+	sub := Subst{"T": &TypeVar{Name: "U"}}
+	got := FreeTypeVars(&TypeVar{Name: "T"}, sub)
+	if !reflect.DeepEqual(got, []string{"U"}) {
+		t.Errorf("want [U] after chasing T -> U, got %v", got)
+	}
+}
+
+func TestGeneralise_DropsCapturedNames(t *testing.T) {
+	parent := NewEnv(nil)
+	parent.SetVar("outer", &TypeVar{Name: "T"}, false)
+	env := NewEnv(parent)
+
+	body := FuncType{
+		Params: []Type{&TypeVar{Name: "T"}, &TypeVar{Name: "U"}},
+		Return: &TypeVar{Name: "U"},
+	}
+	params, _ := Generalise(body, env)
+	if reflect.DeepEqual(params, []string{"T", "U"}) {
+		t.Errorf("T is captured by outer scope; should not be generalised: %v", params)
+	}
+	want := []string{"U"}
+	if !reflect.DeepEqual(params, want) {
+		t.Errorf("want %v, got %v", want, params)
+	}
+}

--- a/types/subst.go
+++ b/types/subst.go
@@ -1,0 +1,327 @@
+package types
+
+import "fmt"
+
+// MEP-12.1 substitution-aware unification.
+//
+// The pre-MEP-12 unifier in check.go takes a Subst map but uses it only
+// as a side-channel for fresh TypeVar binding; it returns a bool and
+// gives no diagnostic when unification fails. The MEP-12 algorithm
+// needs three things the legacy path does not provide:
+//
+//  1. A proper occurs check, so we cannot bind `T ↦ List<T>` and loop.
+//  2. A way to compose substitutions, so a single call site that binds
+//     `T` from argument 1 can apply that binding when typing argument 2.
+//  3. A non-bool failure signal, so the call-site walk can attach a
+//     diagnostic (T047) to a specific argument position.
+//
+// `Apply`, `Compose`, `Unify` here form the algebra the algorithm in
+// website/docs/mep/mep-0012.md §Algorithm needs. They live next to the
+// legacy `unify` rather than replacing it because the legacy path is
+// shared with non-generic call sites; the cut-over is the MEP-11.2 /
+// MEP-12.2 task. See website/docs/mep/mep-0011.md §"Splitting unify"
+// for the long-term layering.
+
+// Apply walks t and substitutes every bound *TypeVar with its image
+// under sub. Free type variables (those without a binding) are left
+// alone. The returned type shares structure with t where no
+// substitution fires; do not mutate it.
+func (sub Subst) Apply(t Type) Type {
+	if sub == nil || t == nil {
+		return t
+	}
+	switch v := t.(type) {
+	case *TypeVar:
+		if u, ok := sub[v.Name]; ok {
+			// Chase transitively so Apply is idempotent even when
+			// substitutions chain (T1 ↦ T2 ↦ int).
+			return sub.Apply(u)
+		}
+		return t
+	case ListType:
+		return ListType{Elem: sub.Apply(v.Elem)}
+	case MapType:
+		return MapType{Key: sub.Apply(v.Key), Value: sub.Apply(v.Value)}
+	case OptionType:
+		return OptionType{Elem: sub.Apply(v.Elem)}
+	case GroupType:
+		return GroupType{Key: sub.Apply(v.Key), Elem: sub.Apply(v.Elem)}
+	case FuncType:
+		params := make([]Type, len(v.Params))
+		for i, p := range v.Params {
+			params[i] = sub.Apply(p)
+		}
+		out := FuncType{
+			Params: params,
+			Return: sub.Apply(v.Return),
+			Pure:   v.Pure,
+		}
+		if v.Variadic != nil {
+			out.Variadic = sub.Apply(v.Variadic)
+		}
+		return out
+	case StructType:
+		// Struct field types may contain free type variables once
+		// generic struct declarations land (MEP-12 Open Questions).
+		// Walk them now so the helper is ready.
+		fields := make([]StructField, len(v.Fields))
+		for i, f := range v.Fields {
+			fields[i] = StructField{Name: f.Name, Type: sub.Apply(f.Type)}
+		}
+		out := v
+		out.Fields = fields
+		return out
+	case UnionType:
+		// Unions are nominal and their variant set is fixed at
+		// declaration; we return as-is rather than rebuilding the
+		// variant map. Variant struct field types do not refer to
+		// type variables that escape the declaration site today.
+		return v
+	}
+	return t
+}
+
+// Compose returns sub ∘ other: the substitution obtained by applying
+// `sub` to every image in `other` and then taking the union, with
+// `sub`'s direct bindings winning on conflict. This matches the usual
+// left-to-right reading where `sub` is the most recent solver state.
+func (sub Subst) Compose(other Subst) Subst {
+	out := make(Subst, len(sub)+len(other))
+	for k, v := range other {
+		out[k] = sub.Apply(v)
+	}
+	for k, v := range sub {
+		out[k] = v
+	}
+	return out
+}
+
+// Bind adds the mapping name ↦ t to sub. It runs the occurs check
+// described in MEP-12 §Algorithm: binding `T ↦ τ` where `τ` mentions
+// `T` fails with a structural error rather than producing an infinite
+// type. Binding a variable to itself is a no-op.
+func (sub Subst) Bind(name string, t Type) error {
+	if v, ok := t.(*TypeVar); ok && v.Name == name {
+		return nil
+	}
+	if occurs(name, t, sub) {
+		return fmt.Errorf("occurs check failed: %s in %s", name, t)
+	}
+	sub[name] = t
+	return nil
+}
+
+// occurs reports whether the variable named `name` appears free in t
+// under the current substitution. The substitution is followed so that
+// `α ↦ β, β ↦ List<α>` is detected as a cycle even though the direct
+// image of α does not mention α.
+func occurs(name string, t Type, sub Subst) bool {
+	switch v := t.(type) {
+	case *TypeVar:
+		if v.Name == name {
+			return true
+		}
+		if u, ok := sub[v.Name]; ok {
+			return occurs(name, u, sub)
+		}
+		return false
+	case ListType:
+		return occurs(name, v.Elem, sub)
+	case MapType:
+		return occurs(name, v.Key, sub) || occurs(name, v.Value, sub)
+	case OptionType:
+		return occurs(name, v.Elem, sub)
+	case GroupType:
+		return occurs(name, v.Key, sub) || occurs(name, v.Elem, sub)
+	case FuncType:
+		for _, p := range v.Params {
+			if occurs(name, p, sub) {
+				return true
+			}
+		}
+		if v.Variadic != nil && occurs(name, v.Variadic, sub) {
+			return true
+		}
+		return occurs(name, v.Return, sub)
+	case StructType:
+		for _, f := range v.Fields {
+			if occurs(name, f.Type, sub) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
+// Unify is the MEP-12 §Algorithm substitution-aware unifier. Given two
+// types and a starting substitution, it returns the extended
+// substitution that makes the two types equal under Apply, or an error
+// describing the structural mismatch.
+//
+// Unify is symmetric on every kind except the AnyType / TypeVar
+// boundary cases:
+//
+//   - Two TypeVars bind one to the other (the surviving one is the
+//     left operand by convention).
+//   - A TypeVar on either side binds to the other type with an occurs
+//     check, regardless of which side it sits on.
+//   - AnyType against any other kind succeeds without binding. This
+//     mirrors the legacy unifier so call sites that escape into `any`
+//     at the boundary keep working; MEP-10 A1 closeout (rejecting the
+//     reverse direction implicitly) happens in the Subtype predicate,
+//     not here. The two concerns are deliberately separated per
+//     MEP-11 §"Splitting unify".
+//
+// The returned substitution is a fresh map; the input `sub` is not
+// mutated. Callers that want in-place behaviour can simply rebind.
+func Unify(a, b Type, sub Subst) (Subst, error) {
+	if sub == nil {
+		sub = Subst{}
+	}
+	out := make(Subst, len(sub))
+	for k, v := range sub {
+		out[k] = v
+	}
+	if err := unifyInto(a, b, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func unifyInto(a, b Type, sub Subst) error {
+	a = sub.Apply(a)
+	b = sub.Apply(b)
+
+	if _, ok := a.(AnyType); ok {
+		return nil
+	}
+	if _, ok := b.(AnyType); ok {
+		return nil
+	}
+
+	if av, ok := a.(*TypeVar); ok {
+		if bv, ok := b.(*TypeVar); ok && av.Name == bv.Name {
+			return nil
+		}
+		return sub.Bind(av.Name, b)
+	}
+	if bv, ok := b.(*TypeVar); ok {
+		return sub.Bind(bv.Name, a)
+	}
+
+	switch av := a.(type) {
+	case ListType:
+		bv, ok := b.(ListType)
+		if !ok {
+			return mismatch(a, b)
+		}
+		return unifyInto(av.Elem, bv.Elem, sub)
+	case MapType:
+		bv, ok := b.(MapType)
+		if !ok {
+			return mismatch(a, b)
+		}
+		if err := unifyInto(av.Key, bv.Key, sub); err != nil {
+			return err
+		}
+		return unifyInto(av.Value, bv.Value, sub)
+	case OptionType:
+		bv, ok := b.(OptionType)
+		if !ok {
+			return mismatch(a, b)
+		}
+		return unifyInto(av.Elem, bv.Elem, sub)
+	case GroupType:
+		bv, ok := b.(GroupType)
+		if !ok {
+			return mismatch(a, b)
+		}
+		if err := unifyInto(av.Key, bv.Key, sub); err != nil {
+			return err
+		}
+		return unifyInto(av.Elem, bv.Elem, sub)
+	case FuncType:
+		bv, ok := b.(FuncType)
+		if !ok {
+			return mismatch(a, b)
+		}
+		if len(av.Params) != len(bv.Params) {
+			return mismatch(a, b)
+		}
+		if (av.Variadic == nil) != (bv.Variadic == nil) {
+			return mismatch(a, b)
+		}
+		for i := range av.Params {
+			if err := unifyInto(av.Params[i], bv.Params[i], sub); err != nil {
+				return err
+			}
+		}
+		if av.Variadic != nil {
+			if err := unifyInto(av.Variadic, bv.Variadic, sub); err != nil {
+				return err
+			}
+		}
+		return unifyInto(av.Return, bv.Return, sub)
+	case StructType:
+		bv, ok := b.(StructType)
+		if !ok {
+			return mismatch(a, b)
+		}
+		if av.Name != bv.Name {
+			return mismatch(a, b)
+		}
+		return nil
+	case UnionType:
+		bv, ok := b.(UnionType)
+		if !ok {
+			return mismatch(a, b)
+		}
+		if av.Name != bv.Name {
+			return mismatch(a, b)
+		}
+		return nil
+	}
+
+	if sameAtomic(a, b) {
+		return nil
+	}
+	return mismatch(a, b)
+}
+
+// sameAtomic compares two atomic kinds (those without children). Only
+// atomic kinds reach this branch; compound kinds are handled by the
+// switch in unifyInto.
+func sameAtomic(a, b Type) bool {
+	switch a.(type) {
+	case IntType:
+		_, ok := b.(IntType)
+		return ok
+	case Int64Type:
+		_, ok := b.(Int64Type)
+		return ok
+	case BigIntType:
+		_, ok := b.(BigIntType)
+		return ok
+	case BigRatType:
+		_, ok := b.(BigRatType)
+		return ok
+	case FloatType:
+		_, ok := b.(FloatType)
+		return ok
+	case StringType:
+		_, ok := b.(StringType)
+		return ok
+	case BoolType:
+		_, ok := b.(BoolType)
+		return ok
+	case UnitType:
+		_, ok := b.(UnitType)
+		return ok
+	}
+	return false
+}
+
+func mismatch(a, b Type) error {
+	return fmt.Errorf("cannot unify %s with %s", a, b)
+}

--- a/types/subst_test.go
+++ b/types/subst_test.go
@@ -1,0 +1,211 @@
+package types
+
+import "testing"
+
+// MEP-12.1 fixtures the substitution algebra and the new Unify against
+// the rules in website/docs/mep/mep-0012.md §Algorithm.
+
+func TestApply_LeavesFreeVars(t *testing.T) {
+	tv := &TypeVar{Name: "T"}
+	sub := Subst{}
+	if got := sub.Apply(tv); got != tv {
+		t.Errorf("free var should be returned unchanged")
+	}
+}
+
+func TestApply_SubstitutesBoundVar(t *testing.T) {
+	tv := &TypeVar{Name: "T"}
+	sub := Subst{"T": IntType{}}
+	got := sub.Apply(tv)
+	if _, ok := got.(IntType); !ok {
+		t.Errorf("Apply did not substitute T ↦ int, got %s", got)
+	}
+}
+
+func TestApply_ChainsTransitively(t *testing.T) {
+	sub := Subst{
+		"T": &TypeVar{Name: "U"},
+		"U": StringType{},
+	}
+	got := sub.Apply(&TypeVar{Name: "T"})
+	if _, ok := got.(StringType); !ok {
+		t.Errorf("Apply did not chain T -> U -> string, got %s", got)
+	}
+}
+
+func TestApply_WalksList(t *testing.T) {
+	sub := Subst{"T": IntType{}}
+	got := sub.Apply(ListType{Elem: &TypeVar{Name: "T"}})
+	lt, ok := got.(ListType)
+	if !ok {
+		t.Fatalf("want ListType, got %T", got)
+	}
+	if _, ok := lt.Elem.(IntType); !ok {
+		t.Errorf("want [int], got %s", got)
+	}
+}
+
+func TestApply_WalksFunc(t *testing.T) {
+	sub := Subst{"T": IntType{}, "U": StringType{}}
+	got := sub.Apply(FuncType{
+		Params: []Type{&TypeVar{Name: "T"}},
+		Return: &TypeVar{Name: "U"},
+	})
+	ft := got.(FuncType)
+	if _, ok := ft.Params[0].(IntType); !ok {
+		t.Errorf("want param int, got %s", ft.Params[0])
+	}
+	if _, ok := ft.Return.(StringType); !ok {
+		t.Errorf("want return string, got %s", ft.Return)
+	}
+}
+
+func TestCompose_AppliesLeftToRight(t *testing.T) {
+	left := Subst{"U": StringType{}}
+	right := Subst{"T": &TypeVar{Name: "U"}}
+	c := left.Compose(right)
+	got := c.Apply(&TypeVar{Name: "T"})
+	if _, ok := got.(StringType); !ok {
+		t.Errorf("compose did not chain T -> U -> string, got %s", got)
+	}
+}
+
+func TestBind_OccursCheck(t *testing.T) {
+	sub := Subst{}
+	err := sub.Bind("T", ListType{Elem: &TypeVar{Name: "T"}})
+	if err == nil {
+		t.Error("expected occurs check failure for T ↦ [T]")
+	}
+}
+
+func TestBind_OccursCheckThroughSubstitution(t *testing.T) {
+	// T ↦ U, then U ↦ [T] should fail the occurs check transitively.
+	sub := Subst{"U": &TypeVar{Name: "T"}}
+	err := sub.Bind("T", ListType{Elem: &TypeVar{Name: "U"}})
+	if err == nil {
+		t.Error("expected occurs check failure for transitive cycle")
+	}
+}
+
+func TestBind_SelfIsNoOp(t *testing.T) {
+	sub := Subst{}
+	if err := sub.Bind("T", &TypeVar{Name: "T"}); err != nil {
+		t.Errorf("self-bind should succeed silently, got %v", err)
+	}
+	if _, ok := sub["T"]; ok {
+		t.Errorf("self-bind should not record a mapping")
+	}
+}
+
+func TestUnify_TypeVarOnLeft(t *testing.T) {
+	sub, err := Unify(&TypeVar{Name: "T"}, IntType{}, nil)
+	if err != nil {
+		t.Fatalf("unify failed: %v", err)
+	}
+	if _, ok := sub["T"].(IntType); !ok {
+		t.Errorf("want T ↦ int, got %v", sub)
+	}
+}
+
+func TestUnify_TypeVarOnRight(t *testing.T) {
+	sub, err := Unify(IntType{}, &TypeVar{Name: "T"}, nil)
+	if err != nil {
+		t.Fatalf("unify failed: %v", err)
+	}
+	if _, ok := sub["T"].(IntType); !ok {
+		t.Errorf("want T ↦ int, got %v", sub)
+	}
+}
+
+func TestUnify_PropagatesAcrossArgs(t *testing.T) {
+	// Simulates `pair(1, 1)` where both arguments bind T to int.
+	sub, err := Unify(&TypeVar{Name: "T"}, IntType{}, nil)
+	if err != nil {
+		t.Fatalf("first unify failed: %v", err)
+	}
+	sub, err = Unify(&TypeVar{Name: "T"}, IntType{}, sub)
+	if err != nil {
+		t.Fatalf("second unify failed: %v", err)
+	}
+	if _, ok := sub["T"].(IntType); !ok {
+		t.Errorf("want T ↦ int, got %v", sub)
+	}
+}
+
+func TestUnify_ConflictAcrossArgs(t *testing.T) {
+	// Simulates `pair(1, "a")` where T binds to two different types.
+	sub, err := Unify(&TypeVar{Name: "T"}, IntType{}, nil)
+	if err != nil {
+		t.Fatalf("first unify failed: %v", err)
+	}
+	_, err = Unify(&TypeVar{Name: "T"}, StringType{}, sub)
+	if err == nil {
+		t.Error("expected T047 conflict for T ↦ int then T ↦ string")
+	}
+}
+
+func TestUnify_AnyAbsorbs(t *testing.T) {
+	// AnyType keeps the legacy escape-hatch behaviour; the strict
+	// rule lives in Subtype.
+	if _, err := Unify(AnyType{}, IntType{}, nil); err != nil {
+		t.Errorf("unify(any, int) want success: %v", err)
+	}
+	if _, err := Unify(IntType{}, AnyType{}, nil); err != nil {
+		t.Errorf("unify(int, any) want success: %v", err)
+	}
+}
+
+func TestUnify_ListRecurses(t *testing.T) {
+	sub, err := Unify(
+		ListType{Elem: &TypeVar{Name: "T"}},
+		ListType{Elem: IntType{}},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unify failed: %v", err)
+	}
+	if _, ok := sub["T"].(IntType); !ok {
+		t.Errorf("want T ↦ int via list, got %v", sub)
+	}
+}
+
+func TestUnify_FuncStructural(t *testing.T) {
+	sub, err := Unify(
+		FuncType{Params: []Type{&TypeVar{Name: "T"}}, Return: &TypeVar{Name: "T"}},
+		FuncType{Params: []Type{IntType{}}, Return: IntType{}},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unify failed: %v", err)
+	}
+	if _, ok := sub["T"].(IntType); !ok {
+		t.Errorf("want T ↦ int, got %v", sub)
+	}
+}
+
+func TestUnify_OccursCheckRejects(t *testing.T) {
+	_, err := Unify(
+		&TypeVar{Name: "T"},
+		ListType{Elem: &TypeVar{Name: "T"}},
+		nil,
+	)
+	if err == nil {
+		t.Error("expected occurs check failure for T ↦ [T]")
+	}
+}
+
+func TestUnify_Mismatch(t *testing.T) {
+	if _, err := Unify(IntType{}, StringType{}, nil); err == nil {
+		t.Error("expected mismatch error for int vs string")
+	}
+}
+
+func TestUnify_DoesNotMutateInput(t *testing.T) {
+	sub := Subst{}
+	if _, err := Unify(&TypeVar{Name: "T"}, IntType{}, sub); err != nil {
+		t.Fatalf("unify failed: %v", err)
+	}
+	if _, ok := sub["T"]; ok {
+		t.Errorf("Unify must not mutate the input substitution")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds \`types/subst.go\` with \`Apply\`, \`Compose\`, \`Bind\` methods on \`Subst\` plus a new top-level \`Unify(s, t, sub) (Subst, error)\` per MEP-12 §Algorithm.
- Adds \`types/subst_test.go\` pinning idempotent Apply, transitive substitution chaining, occurs check (direct + transitive), non-mutation of inputs, T047-style conflict detection across argument positions.
- Purely additive. Legacy package-private \`unify\` in \`check.go\` is untouched; call sites move under MEP-12.2 (#87).

Tracking: #21288.

## Test plan
- [x] \`go test ./types/ -run 'TestApply|TestCompose|TestBind|TestUnify'\`
- [x] \`go test ./types/\` full
- [x] \`go build ./...\`