### PR TITLE
types: numeric mix lattice (MEP-10 B2)

### DIFF
--- a/types/infer.go
+++ b/types/infer.go
@@ -112,31 +112,11 @@ func inferBinaryType(env *Env, b *parser.BinaryExpr) Type {
 				var res Type
 				switch ops[i] {
 				case "+", "-", "*", "/", "%":
-					if ops[i] == "/" && isInt(left) && isInt(right) {
-						res = IntType{}
-						break
-					}
-					if (isInt64(left) && (isInt64(right) || isInt(right))) ||
-						(isInt64(right) && isInt(left)) {
-						res = Int64Type{}
-						break
-					}
-					if isBigRat(left) || isBigRat(right) {
-						res = BigRatType{}
-						break
-					}
-					if (isFloat(left) || isFloat(right)) &&
-						(isInt(left) || isFloat(left) || isInt64(left)) &&
-						(isInt(right) || isFloat(right) || isInt64(right)) {
-						res = FloatType{}
-						break
-					}
-					if isBigInt(left) || isBigInt(right) {
-						res = BigIntType{}
-						break
-					}
-					if isInt(left) && isInt(right) {
-						res = IntType{}
+					// MEP-10 B2: numeric mix is the lattice join. Replaces
+					// the prior order-dependent cascade so `bigint - float`
+					// and `float - bigint` produce the same result type.
+					if joined, ok := numericJoin(left, right); ok {
+						res = joined
 						break
 					}
 					if ops[i] == "+" {
@@ -955,6 +935,73 @@ func equalTypes(a, b Type) bool {
 		return at == bt
 	}
 	return false
+}
+
+// numericJoin returns the lattice join of two numeric kinds, or
+// (nil, false) if either operand is not numeric. The lattice is:
+//
+//	int <: int64 <: bigint <: bigrat
+//	             float <: bigrat
+//
+// The two integer-side and float-side chains meet at bigrat. This is
+// the soundness fix for MEP-10 B2: the prior cascade was order-
+// dependent so `bigint - float` and `float - bigint` could produce
+// different result types. The lattice is symmetric by construction.
+func numericJoin(a, b Type) (Type, bool) {
+	ra, ok := numericRank(a)
+	if !ok {
+		return nil, false
+	}
+	rb, ok := numericRank(b)
+	if !ok {
+		return nil, false
+	}
+	const (
+		rInt    = 0
+		rInt64  = 1
+		rBigInt = 2
+		rFloat  = 3
+		rBigRat = 4
+	)
+	// Float absorbs int and int64 (matches runtime coercion) but
+	// promotes to bigrat when paired with bigint or bigrat so we do
+	// not silently lose precision on a value too large for IEEE 754.
+	if ra == rFloat || rb == rFloat {
+		if ra == rBigInt || rb == rBigInt || ra == rBigRat || rb == rBigRat {
+			return BigRatType{}, true
+		}
+		return FloatType{}, true
+	}
+	if ra > rb {
+		ra, rb = rb, ra
+	}
+	switch rb {
+	case rInt:
+		return IntType{}, true
+	case rInt64:
+		return Int64Type{}, true
+	case rBigInt:
+		return BigIntType{}, true
+	case rBigRat:
+		return BigRatType{}, true
+	}
+	return nil, false
+}
+
+func numericRank(t Type) (int, bool) {
+	switch t.(type) {
+	case IntType:
+		return 0, true
+	case Int64Type:
+		return 1, true
+	case BigIntType:
+		return 2, true
+	case FloatType:
+		return 3, true
+	case BigRatType:
+		return 4, true
+	}
+	return 0, false
 }
 
 func isInt64(t Type) bool  { _, ok := t.(Int64Type); return ok }

--- a/types/numeric_lattice_test.go
+++ b/types/numeric_lattice_test.go
@@ -1,0 +1,63 @@
+package types
+
+import "testing"
+
+// MEP-10 B2: numeric mix lattice. The join must be symmetric in its
+// operands so `bigint - float` and `float - bigint` produce the same
+// result type.
+
+func TestNumericJoin_Symmetric(t *testing.T) {
+	pairs := []struct {
+		a, b Type
+		want Type
+	}{
+		{IntType{}, IntType{}, IntType{}},
+		{IntType{}, Int64Type{}, Int64Type{}},
+		{IntType{}, BigIntType{}, BigIntType{}},
+		{IntType{}, FloatType{}, FloatType{}},
+		{IntType{}, BigRatType{}, BigRatType{}},
+
+		{Int64Type{}, Int64Type{}, Int64Type{}},
+		{Int64Type{}, BigIntType{}, BigIntType{}},
+		{Int64Type{}, FloatType{}, FloatType{}},
+		{Int64Type{}, BigRatType{}, BigRatType{}},
+
+		{BigIntType{}, BigIntType{}, BigIntType{}},
+		{BigIntType{}, FloatType{}, BigRatType{}}, // meet at bigrat
+		{BigIntType{}, BigRatType{}, BigRatType{}},
+
+		{FloatType{}, FloatType{}, FloatType{}},
+		{FloatType{}, BigRatType{}, BigRatType{}},
+
+		{BigRatType{}, BigRatType{}, BigRatType{}},
+	}
+	for _, p := range pairs {
+		got, ok := numericJoin(p.a, p.b)
+		if !ok {
+			t.Errorf("join(%s, %s) returned !ok", p.a, p.b)
+			continue
+		}
+		if got.String() != p.want.String() {
+			t.Errorf("join(%s, %s) = %s want %s", p.a, p.b, got, p.want)
+		}
+		// Symmetry obligation: swap operands and assert same result.
+		got2, _ := numericJoin(p.b, p.a)
+		if got.String() != got2.String() {
+			t.Errorf("join(%s, %s) = %s but join(%s, %s) = %s",
+				p.a, p.b, got, p.b, p.a, got2)
+		}
+	}
+}
+
+func TestNumericJoin_RejectsNonNumeric(t *testing.T) {
+	cases := []struct{ a, b Type }{
+		{IntType{}, StringType{}},
+		{BoolType{}, IntType{}},
+		{ListType{Elem: IntType{}}, IntType{}},
+	}
+	for _, c := range cases {
+		if _, ok := numericJoin(c.a, c.b); ok {
+			t.Errorf("join(%s, %s) should reject non-numeric", c.a, c.b)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Replaces order-dependent numeric cascade in \`types/infer.go inferBinaryType\` with a symmetric lattice helper \`numericJoin\`.
- New \`types/numeric_lattice_test.go\` covers every pair and explicitly asserts symmetry.

Lattice:
- int <: int64 <: bigint <: bigrat
- float <: bigrat
- int/int64 + float = float (matches runtime)
- bigint + float = bigrat (no silent precision loss)

Tracking: #21292.

## Test plan
- [x] \`go test ./types/ -run TestNumericJoin\`
- [x] \`go test ./types/\` full
- [x] \`go test ./...\` no new failures