### PR TITLE
types: route let/var binding through Assignable (MEP-11.2)

### DIFF
--- a/types/check.go
+++ b/types/check.go
@@ -888,7 +888,11 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 				if err != nil {
 					return err
 				}
-				if !unify(typ, exprType, nil) {
+				// MEP-11.2: route the let-binding check through
+				// Assignable rather than unify. Direction matters:
+				// the value flows into the declared slot, so we ask
+				// `Assignable(rhs, declared)` not the symmetric form.
+				if !Assignable(exprType, typ) {
 					return errTypeMismatch(s.Let.Pos, typ, exprType)
 				}
 			}
@@ -914,7 +918,9 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 				if err != nil {
 					return err
 				}
-				if !unify(typ, exprType, nil) {
+				// MEP-11.2: route the var-binding check through
+				// Assignable; see the matching change on Let above.
+				if !Assignable(exprType, typ) {
 					return errTypeMismatch(s.Var.Pos, typ, exprType)
 				}
 			}
@@ -1678,24 +1684,15 @@ func applyBinaryType(pos lexer.Position, op string, left, right Type) (Type, err
 	case "+", "-", "*", "/", "%":
 		switch {
 		case isNumeric(left) && isNumeric(right):
-			if op == "/" {
-				if _, ok := left.(IntType); ok {
-					if _, ok2 := right.(IntType); ok2 {
-						return IntType{}, nil
-					}
-				}
-			}
-			if unify(left, BigRatType{}, nil) || unify(right, BigRatType{}, nil) {
-				return BigRatType{}, nil
-			}
-			if unify(left, FloatType{}, nil) || unify(right, FloatType{}, nil) {
-				return FloatType{}, nil
-			}
-			if unify(left, BigIntType{}, nil) || unify(right, BigIntType{}, nil) {
-				return BigIntType{}, nil
-			}
-			if unify(left, Int64Type{}, nil) || unify(right, Int64Type{}, nil) {
-				return Int64Type{}, nil
+			// MEP-10 B2: numeric mix is the lattice join. The same
+			// helper drives inferBinaryType so the inferrer and the
+			// checker agree on the result type kind. Without this,
+			// inferring `int + int = int` while the checker reports
+			// `bigint` produced spurious "expected int, got bigint"
+			// errors at let-binding sites once MEP-11.2 routed those
+			// through Subtype.
+			if joined, ok := numericJoin(left, right); ok {
+				return joined, nil
 			}
 			return IntType{}, nil
 		case op == "+" && (unify(left, StringType{}, nil) || unify(right, StringType{}, nil)):

--- a/types/subtype.go
+++ b/types/subtype.go
@@ -142,6 +142,46 @@ func Subtype(s, t Type) bool {
 	return false
 }
 
+// Assignable reports whether a value of type src can flow into a
+// position declared to accept dst, under the relaxed rules used today
+// while the MEP-10 A1 any-audit is in flight (MEP-11.2). It is
+// Subtype plus an explicit allowance for AnyType on either side.
+//
+// The helper exists so that let / var / assign / argument / return
+// all share one call site. The MEP-11.3 (any-tightening) task then
+// removes the AnyType-on-source escape to close MEP-10 A1 without
+// having to re-route every individual call site again. Callers that
+// need permanent looseness route through an explicit `as any` cast
+// once #79 lands.
+func Assignable(src, dst Type) bool {
+	if _, ok := src.(AnyType); ok {
+		return true
+	}
+	if _, ok := dst.(AnyType); ok {
+		return true
+	}
+	// Empty collection literals carry an `any` element type
+	// (`[]` is `[any]`, `{}` is `{any: any}`). Until MEP-12 wires
+	// generic literals through inference, treat those shapes as
+	// assignable into any concrete collection. The recursion is on
+	// the same boundary as Subtype's structural rules.
+	switch sv := src.(type) {
+	case ListType:
+		if dv, ok := dst.(ListType); ok {
+			return Assignable(sv.Elem, dv.Elem)
+		}
+	case MapType:
+		if dv, ok := dst.(MapType); ok {
+			return Assignable(sv.Key, dv.Key) && Assignable(sv.Value, dv.Value)
+		}
+	case OptionType:
+		if dv, ok := dst.(OptionType); ok {
+			return Assignable(sv.Elem, dv.Elem)
+		}
+	}
+	return Subtype(src, dst)
+}
+
 // equalKinds is a small structural equality used by Subtype to discharge
 // T-Refl on compound kinds and to enforce the invariance rules on Map
 // and Group children. It deliberately does not call Subtype recursively


### PR DESCRIPTION
## Summary
- New \`Assignable(src, dst)\` helper in \`types/subtype.go\` wrapping \`Subtype\` with explicit AnyType escape + empty-collection peel-through.
- \`check.go\` Let / Var statement bindings now call \`Assignable(rhs, declared)\` instead of symmetric \`unify\`.
- \`applyBinaryType\` shares the MEP-10 B2 \`numericJoin\` lattice with \`inferBinaryType\`.

Prep for MEP-11.3 (#79), which removes the AnyType escape.

Tracking: #21296.

## Test plan
- [x] \`go test ./types/\`
- [x] \`go test ./...\` no new failures