### PR TITLE
mep-0010 A4: enforce match exhaustiveness on union scrutinees

### DIFF
--- a/tests/types/errors/match_missing_variant.err
+++ b/tests/types/errors/match_missing_variant.err
@@ -1,0 +1,8 @@
+1. error[T050]: non-exhaustive match on union `Shape`: missing variant(s) `Triangle`
+  --> tests/types/errors/match_missing_variant.mochi:8:10
+
+  8 |   return match sh {
+    |          ^
+
+help:
+  Add an arm for each missing variant or use a wildcard `_` arm to cover the remainder.

--- a/tests/types/errors/match_missing_variant.mochi
+++ b/tests/types/errors/match_missing_variant.mochi
@@ -1,0 +1,12 @@
+// MEP-10 A4: match must cover every variant of a union scrutinee.
+type Shape =
+  Circle(r: int)
+| Square(s: int)
+| Triangle(base: int, height: int)
+
+fun classify(sh: Shape): string {
+  return match sh {
+    Circle(r) => "c"
+    Square(s) => "s"
+  }
+}

--- a/tests/types/valid/match_union_exhaustive_wildcard.golden
+++ b/tests/types/valid/match_union_exhaustive_wildcard.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/match_union_exhaustive_wildcard.mochi
+++ b/tests/types/valid/match_union_exhaustive_wildcard.mochi
@@ -1,0 +1,12 @@
+// MEP-10 A4: a wildcard `_` arm covers the remaining variants.
+type Shape =
+  Circle(r: int)
+| Square(s: int)
+| Triangle(base: int, height: int)
+
+let sh: Shape = Square(4)
+let kind: string = match sh {
+  Circle(r) => "circle"
+  _ => "polygon"
+}
+expect kind == "polygon"

--- a/types/check.go
+++ b/types/check.go
@@ -2414,6 +2414,12 @@ func checkMatchExpr(m *parser.MatchExpr, env *Env, expected Type) (Type, error) 
 		return nil, err
 	}
 	var resultType Type
+	// MEP-10 A4: track variant coverage when the scrutinee is a union.
+	// A wildcard `_` (or an identifier binding that does not name a
+	// variant) covers the remainder; otherwise every variant must be
+	// matched explicitly.
+	matchedVariants := map[string]bool{}
+	hasCatchAll := false
 	for _, c := range m.Cases {
 		caseEnv := env
 		if call, ok := callPattern(c.Pattern); ok {
@@ -2425,6 +2431,7 @@ func checkMatchExpr(m *parser.MatchExpr, env *Env, expected Type) (Type, error) 
 				if !unify(targetType, st, nil) {
 					return nil, errTypeMismatch(c.Pos, targetType, st)
 				}
+				matchedVariants[call.Func] = true
 				child := NewEnv(env)
 				for idx, arg := range call.Args {
 					if name, ok := identName(arg); ok {
@@ -2439,6 +2446,7 @@ func checkMatchExpr(m *parser.MatchExpr, env *Env, expected Type) (Type, error) 
 				if !unify(targetType, st, nil) {
 					return nil, errTypeMismatch(c.Pos, targetType, st)
 				}
+				matchedVariants[ident] = true
 			} else if !isUnderscoreExpr(c.Pattern) {
 				pType, err := checkExpr(c.Pattern, env)
 				if err != nil {
@@ -2447,6 +2455,8 @@ func checkMatchExpr(m *parser.MatchExpr, env *Env, expected Type) (Type, error) 
 				if !unify(targetType, pType, nil) {
 					return nil, errTypeMismatch(c.Pos, targetType, pType)
 				}
+			} else {
+				hasCatchAll = true
 			}
 		} else if !isUnderscoreExpr(c.Pattern) {
 			pType, err := checkExpr(c.Pattern, env)
@@ -2456,6 +2466,8 @@ func checkMatchExpr(m *parser.MatchExpr, env *Env, expected Type) (Type, error) 
 			if !unify(targetType, pType, nil) {
 				return nil, errTypeMismatch(c.Pos, targetType, pType)
 			}
+		} else {
+			hasCatchAll = true
 		}
 		if c.Result == nil {
 			for _, st := range c.Block {
@@ -2479,6 +2491,21 @@ func checkMatchExpr(m *parser.MatchExpr, env *Env, expected Type) (Type, error) 
 		// silently widened to AnyType.
 		if !unify(resultType, rType, nil) {
 			return nil, errTypeMismatch(c.Pos, resultType, rType)
+		}
+	}
+	// MEP-10 A4: when the scrutinee is a union, every variant must be
+	// covered by an explicit arm or a wildcard `_` arm. The check runs
+	// after all arms have been typed so the error pinpoints the match
+	// site rather than an arbitrary arm.
+	if ut, ok := targetType.(UnionType); ok && !hasCatchAll {
+		var missing []string
+		for _, name := range ut.Order {
+			if !matchedVariants[name] {
+				missing = append(missing, name)
+			}
+		}
+		if len(missing) > 0 {
+			return nil, errMatchNonExhaustive(m.Pos, ut.Name, missing)
 		}
 	}
 	if resultType == nil {

--- a/types/errors.go
+++ b/types/errors.go
@@ -65,6 +65,7 @@ var Errors = map[string]diagnostic.Template{
 	"T044": {Code: "T044", Message: "impure call to `%s` is not allowed in `%s` predicate", Help: "Only pure functions may be called inside `where` and `having` predicates."},
 	"T045": {Code: "T045", Message: "`%s` outside of loop", Help: "Move `%s` inside a `for` or `while` loop body."},
 	"T046": {Code: "T046", Message: "invalid cast: `%s` as `%s` is not allowed", Help: "Only numeric-tower, union-to-variant, map-to-struct, and any-related casts are allowed. Use a parsing function (e.g. `parseIntStr`) for string conversions."},
+	"T050": {Code: "T050", Message: "non-exhaustive match on union `%s`: missing variant(s) %s", Help: "Add an arm for each missing variant or use a wildcard `_` arm to cover the remainder."},
 }
 
 // --- Wrapper Functions ---
@@ -256,6 +257,29 @@ func errIfCondBoolean(pos lexer.Position) error {
 
 func errInvalidCast(pos lexer.Position, from, to Type) error {
 	return Errors["T046"].New(pos, from, to)
+}
+
+func errMatchNonExhaustive(pos lexer.Position, unionName string, missing []string) error {
+	var quoted []string
+	for _, name := range missing {
+		quoted = append(quoted, "`"+name+"`")
+	}
+	list := ""
+	switch len(quoted) {
+	case 1:
+		list = quoted[0]
+	case 2:
+		list = quoted[0] + " and " + quoted[1]
+	default:
+		for i, q := range quoted {
+			if i == len(quoted)-1 {
+				list += "and " + q
+			} else {
+				list += q + ", "
+			}
+		}
+	}
+	return Errors["T050"].New(pos, unionName, list)
 }
 
 func errBreakContinueOutsideLoop(pos lexer.Position, keyword string) error {

--- a/website/docs/mep/mep-0006.md
+++ b/website/docs/mep/mep-0006.md
@@ -160,6 +160,7 @@ Highlights:
 | T044 | impure call not allowed in where/having predicate    |
 | T045 | break/continue outside of loop                       |
 | T046 | invalid cast: from-type as to-type is not allowed    |
+| T050 | non-exhaustive match on union: missing variant(s)    |
 
 The series has gaps. New codes should be appended to the end with the next free integer.
 

--- a/website/docs/mep/mep-0010.md
+++ b/website/docs/mep/mep-0010.md
@@ -71,17 +71,13 @@ The remaining hole is aliasing. Copying a let-bound list (or struct, or map) int
 2. If invariance, add error code (next free) `T0xx`: cannot alias an immutable aggregate into a mutable binding.
 3. Move the alias fixture from `valid/` to `errors/` once the rule lands.
 
-#### A4. Match exhaustiveness not enforced
+#### A4. Match exhaustiveness not enforced (closed)
 
-**Evidence.** `checkMatchExpr` in `types/check.go:2407` types each arm but does not check that the union of arm patterns covers every variant of a `UnionType` scrutinee.
+**Status.** Closed. `checkMatchExpr` in `types/check.go` collects the variant names matched by each arm and, after the arms loop, compares them against `UnionType.Order`. Any uncovered variant is reported with `T050` unless a wildcard `_` arm appears in the match. Variant arms (both bare `V` and call-form `V(args)`) and wildcard arms are recognised; literal and expression arms do not contribute to coverage and so still require either a full enumeration of variants or a `_` arm.
 
-**Impact.** Removing a variant from a union does not surface as a compile error in code that matches on it. Users discover the gap at runtime.
+**Pinning fixtures.** `tests/types/valid/match_union_exhaustive_wildcard.mochi`, `tests/types/errors/match_missing_variant.mochi`.
 
-**Plan.**
-
-1. Compute the variant coverage during match check.
-2. Allow a single wildcard or identifier pattern to cover the remainder, and warn (not error) if it shadows reachable cases.
-3. Emit a new error code for missing variants.
+**Original evidence.** `checkMatchExpr` previously typed each arm but did not check that the union of arm patterns covered every variant of a `UnionType` scrutinee. Removing a variant from a union did not surface as a compile error in code that matched on it; users discovered the gap at runtime.
 
 #### A5. as cast is unchecked (closed)
 


### PR DESCRIPTION
Closes MEP-10 A4. `checkMatchExpr` now tracks matched variants and wildcard arms; uncovered union variants without a `_` arm are reported as `T050`.

Tracking: #21298

## Test plan
- [x] `go test ./types/`
- [x] `go test ./...`
- [x] new fixtures pinning the valid (wildcard) and error (missing variant) cases