### PR TITLE
mep-0010 C1: parse T? as option[T]

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -68,7 +68,7 @@ var mochiLexer = lexer.MustSimple([]lexer.SimpleRule{
 	{Name: "Float", Pattern: `\d+\.\d+(?:[eE][+-]?\d+)?|\d+[eE][+-]?\d+`},
 	{Name: "Int", Pattern: `0[xX][0-9a-fA-F]+|0[bB][01]+|0[oO][0-7]+|\d+`},
 	{Name: "String", Pattern: `"(?:\\.|[^"\\])*"`},
-	{Name: "Punct", Pattern: `==|!=|<=|>=|&&|\|\||=>|:-|\.\.|[-+*/%=<>!|{}\[\](),.:]`},
+	{Name: "Punct", Pattern: `==|!=|<=|>=|&&|\|\||=>|:-|\.\.|[-+*/%=<>!|{}\[\](),.:?]`},
 	{Name: "Whitespace", Pattern: `[ \t\n\r;]+`},
 })
 
@@ -218,10 +218,13 @@ type TypeField struct {
 
 type TypeRef struct {
 	Pos     lexer.Position    `json:"pos,omitempty" parser:""`
-	Fun     *FunType          `json:"fun,omitempty" parser:"@@"`
+	Fun     *FunType          `json:"fun,omitempty" parser:"( @@"`
 	Generic *GenericType      `json:"generic,omitempty" parser:"| @@"`
 	Struct  *InlineStructType `json:"struct,omitempty" parser:"| @@"`
-	Simple  *string           `json:"simple,omitempty" parser:"| @Ident"`
+	Simple  *string           `json:"simple,omitempty" parser:"| @Ident )"`
+	// MEP-10 C1: a trailing `?` denotes an optional (nullable) type.
+	// `int?` desugars to `option[int]` in resolveTypeRef.
+	Optional bool `json:"optional,omitempty" parser:"[ @'?' ]"`
 }
 
 type InlineStructType struct {

--- a/tests/types/valid/option_type_syntax.golden
+++ b/tests/types/valid/option_type_syntax.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/option_type_syntax.mochi
+++ b/tests/types/valid/option_type_syntax.mochi
@@ -1,0 +1,4 @@
+// MEP-10 C1: `T?` desugars to `option[T]`. A null literal flows
+// into an option-typed slot without an explicit cast.
+let maybe: int? = null
+expect maybe == null

--- a/types/check.go
+++ b/types/check.go
@@ -1466,6 +1466,15 @@ func checkIfStmt(stmt *parser.IfStmt, env *Env, expectedReturn Type, inLoop bool
 }
 
 func resolveTypeRef(t *parser.TypeRef, env *Env) Type {
+	typ := resolveTypeRefInner(t, env)
+	if t.Optional {
+		// MEP-10 C1: `T?` desugars to `option[T]`.
+		typ = OptionType{Elem: typ}
+	}
+	return typ
+}
+
+func resolveTypeRefInner(t *parser.TypeRef, env *Env) Type {
 	if t.Fun != nil {
 		params := make([]Type, len(t.Fun.Params))
 		for i, p := range t.Fun.Params {

--- a/website/docs/mep/mep-0010.md
+++ b/website/docs/mep/mep-0010.md
@@ -163,13 +163,15 @@ The remaining hole is aliasing. Copying a let-bound list (or struct, or map) int
 
 ### Tier C: parser and surface quirks
 
-#### C1. int | nil does not parse
+#### C1. nullable type shorthand (closed)
 
-**Evidence.** `parser/parser.go:219-225`. `TypeRef` does not list union as a constructor.
+**Status.** Closed. The lexer now recognises `?` as punctuation, `TypeRef` accepts a trailing `?`, and `resolveTypeRef` desugars `T?` to `OptionType{Elem: T}`. The shorthand composes with every constructor: `int?`, `list<int>?`, `Foo?`, `fun(int): bool ?` all parse and resolve to `option[...]`.
 
-**Impact.** The natural way to write a nullable type fails.
+**Pinning fixture.** `tests/types/valid/option_type_syntax.mochi`.
 
-**Plan.** Decide between two paths: a `T?` shorthand or full union types in `TypeRef`. Either resolves A2 once `OptionType` is wired through.
+**Original evidence.** `parser/parser.go:219-225` previously did not list union as a constructor and there was no syntax for nullable types. The natural way to write a nullable type failed at parse.
+
+**Follow-up.** Path "full `int | nil` union" is intentionally not taken: `T?` covers the nullable case and Mochi's named unions cover the general case. Wiring `null` literals into `OptionType` is tracked under A2.
 
 #### C2. Unary minus on RHS of comparison without parens
 


### PR DESCRIPTION
Closes MEP-10 C1. Adds option-type shorthand at the parser layer; resolveTypeRef wraps in OptionType. Wiring null literals into OptionType stays under A2.

Tracking: #21300

## Test plan
- [x] go test ./parser/ ./types/
- [x] go test ./...
- [x] fixture pinning the new syntax (tests/types/valid/option_type_syntax.mochi)