### PR TITLE
types: remove int/int64 carve-out in equalTypes (P1)

### DIFF
--- a/types/equal_types_test.go
+++ b/types/equal_types_test.go
@@ -18,7 +18,8 @@ func TestEqualTypesByKind(t *testing.T) {
 	}{
 		// Reflexive primitives.
 		{"int=int", IntType{}, IntType{}, true},
-		{"int=int64 (carve-out)", IntType{}, Int64Type{}, true},
+		// P1 (task #104): carve-out removed. equalTypes is strict on kind.
+		{"int=int64 (strict)", IntType{}, Int64Type{}, false},
 		{"int=float", IntType{}, FloatType{}, false},
 		{"float=float", FloatType{}, FloatType{}, true},
 		{"bigint=bigint", BigIntType{}, BigIntType{}, true},

--- a/types/infer.go
+++ b/types/infer.go
@@ -830,12 +830,6 @@ func unionFieldPathType(ut UnionType, tail []string) (Type, bool) {
 //
 // See MEP 4 §6 problem 15.
 func equalTypes(a, b Type) bool {
-	// int/int64 carve-out. Both kinds use the same Go-level int64
-	// storage, and most numeric builtins return int64 while user code
-	// is typed at int.
-	if (isInt(a) || isInt64(a)) && (isInt(b) || isInt64(b)) {
-		return true
-	}
 	switch at := a.(type) {
 	case IntType:
 		_, ok := b.(IntType)


### PR DESCRIPTION
Closes task P1 (#104). equalTypes goes strict on numeric kind. The numeric tower relates int and int64 via Subtype (T-NumTower); equalTypes' job is structural equality.

Tracking: #21302

## Test plan
- [x] go test ./...
- [x] equal_types_test fixture flipped to pin the strict behaviour