### PR TITLE
mep-0010 B8: document recursive type policy + pin linked list fixture

### DIFF
--- a/tests/types/valid/recursive_linked_list.golden
+++ b/tests/types/valid/recursive_linked_list.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/recursive_linked_list.mochi
+++ b/tests/types/valid/recursive_linked_list.mochi
@@ -1,0 +1,16 @@
+// MEP-10 B8: a self-referential union (Cons/Nil) type checks
+// because the variants map is populated before fields resolve, so
+// the `tail: List` field can reference the enclosing union.
+type List =
+  Nil
+| Cons(head: int, tail: List)
+
+let three: List = Cons(3, Nil)
+let two: List = Cons(2, three)
+let one: List = Cons(1, two)
+
+let label: string = match one {
+  Nil => "empty"
+  Cons(h, t) => "non-empty"
+}
+expect label == "non-empty"

--- a/website/docs/mep/mep-0010.md
+++ b/website/docs/mep/mep-0010.md
@@ -147,11 +147,16 @@ The remaining hole is aliasing. Copying a let-bound list (or struct, or map) int
 
 #### B8. Recursive type definitions
 
-**Evidence.** `types/check.go:1292-1311` builds union types with a shared variants map so forward references resolve. Recursion in struct fields is permitted.
+**Policy.** Recursive types are permitted. The type-declaration walk in `types/check.go` (the union-build path under `TypeDecl`) installs the union into the env before its variants are resolved, so a variant field that names the enclosing union resolves without a forward-reference error. The classic Cons/Nil list and Tree (already pinned by `tests/interpreter/valid/tree_sum.mochi` and `tests/compiler/valid/union_inorder.mochi`) work today; the new fixture `tests/types/valid/recursive_linked_list.mochi` pins the linked-list shape at the type-check layer.
 
-**Impact.** Soundness is not at issue but unbounded recursive structures can cause runtime memory issues. JSON serialisation can loop.
+**Evidence.** `types/check.go` (union-build path under `TypeDecl`) and `Env.SetUnion` populate the variant map before fields are resolved, so a recursive variant field that names the enclosing union does not raise the unknown-type diagnostic.
 
-**Plan.** Document the policy. Add a fixture where a recursive linked list works. Add a runtime check for serialisation cycles.
+**Impact.** Soundness is not at issue. The remaining concern is runtime: JSON serialisation of an aggregate that contains a cycle (only reachable today via `var` aliasing) walks forever.
+
+**Plan.**
+
+1. **Closed.** Document the policy here and pin the linked-list fixture.
+2. **Deferred.** Add a runtime cycle check to `json()` (and `save("jsonl")`) so a cyclic aggregate raises a clear error rather than looping. Tracked under a follow-up task once the alias discipline from A3 lands; the cycle check is cheap to add but pointless to gate against until alias-induced cycles are observable at all.
 
 #### B9. Shadowing without warning
 


### PR DESCRIPTION
## Summary
- Closes the doc half of MEP-10 B8: recursive types are permitted and already work because the union-build path installs the union into env before its variant fields resolve.
- Pins the policy with a new linked-list fixture using Cons/Nil.
- Runtime cycle-check for json()/save() is deferred until A3 alias discipline lands.

Tracking: #21304

## Test plan
- [x] go test ./types/...