### PR TITLE
mep-0010 A2: type null as option[any]

### DIFF
--- a/tests/types/errors/impure_in_where_rejected.err
+++ b/tests/types/errors/impure_in_where_rejected.err
@@ -1,7 +1,7 @@
 1. error[T044]: impure call to `print` is not allowed in `where` predicate
   --> tests/types/errors/impure_in_where_rejected.mochi:2:33
 
-  2 | let result = from x in xs where print(x) == null select x
+  2 | let result = from x in xs where print(x) == print(x) select x
     |                                 ^
 
 help:

--- a/tests/types/errors/impure_in_where_rejected.mochi
+++ b/tests/types/errors/impure_in_where_rejected.mochi
@@ -1,2 +1,2 @@
 let xs = [1, 2, 3, 4]
-let result = from x in xs where print(x) == null select x
+let result = from x in xs where print(x) == print(x) select x

--- a/tests/types/errors/null_widening_int.err
+++ b/tests/types/errors/null_widening_int.err
@@ -1,0 +1,8 @@
+1. error[T008]: type mismatch: expected int, got option[any]
+  --> tests/types/errors/null_widening_int.mochi:3:14
+
+  3 | let x: int = null
+    |              ^
+
+help:
+  Change the value to match the expected type.

--- a/tests/types/errors/null_widening_int.mochi
+++ b/tests/types/errors/null_widening_int.mochi
@@ -1,0 +1,3 @@
+// MEP-10 A2: `null` is `option[any]` and does not flow into a non-option
+// slot like `int`. Use `int?` if you need a nullable integer.
+let x: int = null

--- a/tests/types/errors/null_widening_list.err
+++ b/tests/types/errors/null_widening_list.err
@@ -1,0 +1,8 @@
+1. error[T008]: type mismatch: expected [int], got option[any]
+  --> tests/types/errors/null_widening_list.mochi:3:21
+
+  3 | let xs: list<int> = null
+    |                     ^
+
+help:
+  Change the value to match the expected type.

--- a/tests/types/errors/null_widening_list.mochi
+++ b/tests/types/errors/null_widening_list.mochi
@@ -1,0 +1,3 @@
+// MEP-10 A2: `null` is `option[any]` and does not flow into a non-option
+// list slot. Use `list<int>?` for a nullable list binding.
+let xs: list<int> = null

--- a/tests/types/errors/null_widening_struct.err
+++ b/tests/types/errors/null_widening_struct.err
@@ -1,0 +1,8 @@
+1. error[T008]: type mismatch: expected Point, got option[any]
+  --> tests/types/errors/null_widening_struct.mochi:7:16
+
+  7 | let p: Point = null
+    |                ^
+
+help:
+  Change the value to match the expected type.

--- a/tests/types/errors/null_widening_struct.mochi
+++ b/tests/types/errors/null_widening_struct.mochi
@@ -1,0 +1,7 @@
+// MEP-10 A2: `null` is `option[any]` and does not flow into a non-option
+// struct slot. Use `Point?` if you need a nullable struct binding.
+type Point {
+  x: int
+  y: int
+}
+let p: Point = null

--- a/tests/types/valid/null_widening_int.mochi
+++ b/tests/types/valid/null_widening_int.mochi
@@ -1,5 +1,0 @@
-// Snapshot: null leaks into a typed int position.
-// MEP 4 lists null as a candidate for an option type.
-// MEP 7 lists this as an escape hatch in the "not sound today" table.
-// When that fix lands this file should move to tests/types/errors/.
-let x: int = null

--- a/tests/types/valid/null_widening_list.mochi
+++ b/tests/types/valid/null_widening_list.mochi
@@ -1,3 +1,0 @@
-// Snapshot: null leaks into a typed list position.
-// See MEP 4 and MEP 7.
-let xs: list<int> = null

--- a/tests/types/valid/null_widening_struct.mochi
+++ b/tests/types/valid/null_widening_struct.mochi
@@ -1,8 +1,0 @@
-// Snapshot: null leaks into a typed struct position.
-// See MEP 4 and MEP 7. When null becomes an option type
-// this file moves to tests/types/errors/.
-type Point {
-  x: int
-  y: int
-}
-let p: Point = null

--- a/types/check.go
+++ b/types/check.go
@@ -1917,7 +1917,12 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 		case p.Lit.Bool != nil:
 			return BoolType{}, nil
 		case p.Lit.Null:
-			return AnyType{}, nil
+			// MEP-10 A2: `null` is the lone value of `option[any]`. It
+			// unifies with any other option type via the top-level any
+			// case in `unify`, and against `any` itself via the top
+			// short-circuit. A non-option target like `int` no longer
+			// accepts `null` without an explicit option-typed slot.
+			return OptionType{Elem: AnyType{}}, nil
 		}
 
 	case p.Selector != nil:

--- a/website/docs/mep/mep-0010.md
+++ b/website/docs/mep/mep-0010.md
@@ -45,17 +45,15 @@ A fixture pinned to current behaviour is not the same as endorsement. Some entri
 2. Audit which builtins truly need `any` and rewrite the rest with parametric polymorphism once [MEP 12](/docs/mep/mep-0012) lands.
 3. Tighten `unify` so `any` requires an explicit `as` cast in either direction.
 
-#### A2. null is a value of any type
+#### A2. null is a value of any type (closed)
 
-**Evidence.** `types/check.go:1906`. The literal `null` is typed `AnyType{}` rather than producing an `OptionType`.
+**Status.** Closed. `checkPrimary` in `types/check.go` types the `null` literal as `OptionType{Elem: AnyType{}}`. `null` unifies with any other `OptionType{T}` via the elem-level `any` short-circuit in `unify`, and with `AnyType` itself via the top-level `any` short-circuit. A non-option target like `int`, `list<int>`, or a struct name rejects `null` with `T008`.
 
-**Impact.** `let x: int = null` type checks today. Dereferencing `x` in arithmetic is a runtime error.
+**Pinning fixtures.** `tests/types/valid/option_type_syntax.mochi` for the accepted form (`let maybe: int? = null`). `tests/types/errors/null_widening_int.mochi`, `tests/types/errors/null_widening_list.mochi`, `tests/types/errors/null_widening_struct.mochi` for the rejected forms.
 
-**Plan.**
+**Original evidence.** `checkPrimary` previously returned `AnyType{}` for `null`. `let x: int = null` type checked today and dereferencing `x` in arithmetic was a runtime error.
 
-1. Wire `OptionType` into the inference of `null`.
-2. Introduce a `T?` syntactic shorthand for `OptionType{T}`.
-3. Add a check that requires explicit unwrap (`?` or `match`) before use as the underlying type.
+**Follow-up.** Explicit unwrap discipline (`?` accessor or `match` form) before use as the underlying type is tracked separately; today the option type is a marker that affects assignment compatibility, not a forced-unwrap site.
 
 #### A3. Mutation through immutable bindings via aliasing
 


### PR DESCRIPTION
## Summary
- Closes MEP-10 A2: null now types as option[any] and is rejected when assigned to a non-option slot.
- Moves the three null_widening snapshot fixtures from valid/ to errors/.
- Refreshes impure_in_where_rejected so the where clause types as bool and the purity diagnostic remains the first failure.

Tracking: #21306

## Test plan
- [x] go test ./types/...
- [x] go test ./...