### PR TITLE
mep-0011.7: doc runtime cast guard as closed

### DIFF
--- a/website/docs/mep/mep-0011.md
+++ b/website/docs/mep/mep-0011.md
@@ -151,12 +151,18 @@ is checked at runtime.
    `RuntimeError: cast from any to T but dynamic type was U`.
 ```
 
-The runtime guard is delivered in MEP-11.7 (see Reference Implementation
-below) and shipped with `OpCheckedCast` in the bytecode VM and the
-corresponding interpreter mirror. Casts already covered by
+The runtime guard is in place at both runtimes (MEP-11.7, closed). The
+bytecode VM's `OpCast` calls `castValue` in `runtime/vm/vm.go`, which
+inspects the dynamic tag and aborts with a `cannot cast %T to %s`
+error when the underlying value does not match the named type. The
+tree-walking interpreter mirrors the same predicate via
+`interpreter.applyCast` and `castValue` in
+`interpreter/runtime_utils.go`. Both predicates recurse structurally
+through `list<T>`, `map<K,V>`, and named struct types, so a cast like
+`xs as list<int>` checks each element. Casts already covered by
 [MEP 10](/docs/mep/mep-0010) A5 (`castOk`) keep their compile-time
-rejection. Programs that depended on `any` widening silently into a
-typed slot fail at the boundary and must insert an explicit `as`.
+rejection; the runtime guard catches the residual cases where the
+checker accepts the cast on type but cannot prove the dynamic tag.
 
 ### Splitting unify
 


### PR DESCRIPTION
## Summary
- Note in MEP-11 that both runtimes already enforce dynamic-tag checks at `as T` sites via `castValue`. Replaces the prior `OpCheckedCast` future-tense paragraph.

Tracking: #21316. Refs #83.

## Test plan
- [x] doc-only change; no code paths exercised