### PR TITLE
mep-0012.3: register T047/T048/T049 and wire T047/T048

### DIFF
--- a/types/check.go
+++ b/types/check.go
@@ -2097,6 +2097,15 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 			if next, err := Unify(at, expected, callSubst); err == nil {
 				callSubst = next
 			} else if !unify(at, expected, nil) {
+				// MEP-12.3: when a generic call fails to unify, surface
+				// T047 with the offending type parameter rather than the
+				// generic T007 mismatch. The legacy fallback above keeps
+				// non-generic calls on T007.
+				if len(ft.TypeParams) > 0 {
+					if name := firstFreeTypeVar(ft.Params[i], callSubst); name != "" {
+						return nil, errTypeParamConflict(p.Pos, name, expected, at)
+					}
+				}
 				return nil, errArgTypeMismatch(p.Pos, i, expected, at)
 			}
 		}
@@ -2145,6 +2154,15 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 		if p.Call.Func == "values" && len(argTypes) == 1 {
 			if mt, ok := argTypes[0].(MapType); ok {
 				ret = ListType{Elem: mt.Value}
+			}
+		}
+		// MEP-12.3: T048 when the declared generic result still mentions
+		// an unbound type parameter after argument unification. Only
+		// fire on full applications; partial application still carries
+		// the unbound var through the curried result.
+		if len(ft.TypeParams) > 0 && argCount == paramCount {
+			if name := firstFreeTypeVar(ret, callSubst); name != "" {
+				return nil, errTypeParamEscapes(p.Pos, name)
 			}
 		}
 		if argCount == paramCount {
@@ -2464,6 +2482,18 @@ func bareIdentName(e *parser.Expr) string {
 		return ""
 	}
 	return sel.Root
+}
+
+// firstFreeTypeVar returns the lexicographically first free TypeVar
+// name in t after applying sub, or "" if none. It powers the T047 and
+// T048 messages so the user sees the offending parameter rather than
+// the substitution-internal label.
+func firstFreeTypeVar(t Type, sub Subst) string {
+	free := FreeTypeVars(t, sub)
+	if len(free) == 0 {
+		return ""
+	}
+	return free[0]
 }
 
 // isAliasableAggregate reports whether t is a value kind whose storage

--- a/types/errors.go
+++ b/types/errors.go
@@ -67,6 +67,9 @@ var Errors = map[string]diagnostic.Template{
 	"T046": {Code: "T046", Message: "invalid cast: `%s` as `%s` is not allowed", Help: "Only numeric-tower, union-to-variant, map-to-struct, and any-related casts are allowed. Use a parsing function (e.g. `parseIntStr`) for string conversions."},
 	"T050": {Code: "T050", Message: "non-exhaustive match on union `%s`: missing variant(s) %s", Help: "Add an arm for each missing variant or use a wildcard `_` arm to cover the remainder."},
 	"T051": {Code: "T051", Message: "cannot alias immutable aggregate `%s` into a mutable binding", Help: "Aliasing a let-bound list, map, or struct into a `var` would let writes through the alias mutate the original. Clone explicitly (e.g. `[...xs]`, `{...m}`) or bind the source as `var`."},
+	"T047": {Code: "T047", Message: "cannot unify type parameter `%s`: %s vs %s", Help: "Two argument positions require incompatible bindings for the same generic parameter. Pick argument types that agree."},
+	"T048": {Code: "T048", Message: "type parameter `%s` escapes function result", Help: "The result type still mentions `%s` after argument unification. Constrain the parameter at a call argument or supply an explicit type argument."},
+	"T049": {Code: "T049", Message: "type argument arity mismatch for `%s`: expected %d, got %d", Help: "Supply exactly one type argument per declared type parameter."},
 }
 
 // --- Wrapper Functions ---
@@ -77,6 +80,21 @@ func errLetMissingTypeOrValue(pos lexer.Position) error {
 
 func errAliasImmutableAggregate(pos lexer.Position, src string) error {
 	return Errors["T051"].New(pos, src)
+}
+
+func errTypeParamConflict(pos lexer.Position, name string, bound, attempt Type) error {
+	return Errors["T047"].New(pos, name, bound, attempt)
+}
+
+func errTypeParamEscapes(pos lexer.Position, name string) error {
+	tmpl := Errors["T048"]
+	msg := fmt.Sprintf(tmpl.Message, name)
+	help := fmt.Sprintf(tmpl.Help, name)
+	return diagnostic.New(tmpl.Code, pos, msg, help)
+}
+
+func errTypeArgArity(pos lexer.Position, fn string, expected, actual int) error {
+	return Errors["T049"].New(pos, fn, expected, actual)
 }
 
 func errAssignUndeclared(pos lexer.Position, name string) error {


### PR DESCRIPTION
## Summary
- Register T047 (type-param unify conflict), T048 (escaping type param), T049 (type-arg arity)
- Wire T047 at the primary call site when `Unify` fails on a parameter that still has a free TypeVar
- Wire T048 after applying the running `Subst` to the return type when the result still has free TypeVars
- Add `firstFreeTypeVar` helper

T049 is registered now and consumed once the explicit type-arg syntax lands (#90).

Tracking: #21318. Refs #88, parent #85.

## Test plan
- [x] `go build ./...`
- [x] existing fixtures still pass (no behavioral change for already-bound calls)