### PR TITLE
mep-0012.4: retype reduce as generic

### DIFF
--- a/tests/types/valid/reduce_generic.golden
+++ b/tests/types/valid/reduce_generic.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/reduce_generic.mochi
+++ b/tests/types/valid/reduce_generic.mochi
@@ -1,0 +1,7 @@
+fun add(acc: int, v: int): int {
+  return acc + v
+}
+
+let nums = [1, 2, 3, 4, 5]
+let total: int = reduce(nums, add, 0)
+print(total)

--- a/types/check.go
+++ b/types/check.go
@@ -734,10 +734,20 @@ func Check(prog *parser.Program, env *Env) []error {
 		Return: FloatType{},
 		Pure:   true,
 	}, false)
+	// reduce is generic over the list element type and the accumulator
+	// type (MEP-12.4):
+	//     reduce<A, B>(xs: list<A>, fn: fun(B, A): B, init: B): B
+	reduceA := &TypeVar{Name: "A"}
+	reduceB := &TypeVar{Name: "B"}
 	env.SetVar("reduce", FuncType{
-		Params: []Type{AnyType{}, AnyType{}, AnyType{}},
-		Return: AnyType{},
-		Pure:   true,
+		Params: []Type{
+			ListType{Elem: reduceA},
+			FuncType{Params: []Type{reduceB, reduceA}, Return: reduceB},
+			reduceB,
+		},
+		Return:     reduceB,
+		Pure:       true,
+		TypeParams: []string{"A", "B"},
 	}, false)
 	env.SetVar("eval", FuncType{
 		Params: []Type{StringType{}},


### PR DESCRIPTION
## Summary
- Retype \`reduce\` from \`(any, any, any) -> any\` to \`reduce<A, B>(xs: list<A>, fn: fun(B, A): B, init: B): B\`
- New fixture \`tests/types/valid/reduce_generic.mochi\` exercises the inferred result type without an \`as T\` cast

Tracking: #21320. Refs #89, parent #85.

## Test plan
- [x] \`go test ./types/...\`