### PR TITLE
mep-0012.2: wire TypeVar through user-defined generic functions

### DIFF
--- a/tests/types/valid/user_generic_id.golden
+++ b/tests/types/valid/user_generic_id.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/user_generic_id.mochi
+++ b/tests/types/valid/user_generic_id.mochi
@@ -1,0 +1,14 @@
+fun id<T>(x: T): T {
+  return x
+}
+
+fun pair<A, B>(a: A, b: B): A {
+  return a
+}
+
+let n: int = id(5)
+let s: string = id("hello")
+let first: int = pair(1, "two")
+print(n)
+print(s)
+print(first)

--- a/types/check.go
+++ b/types/check.go
@@ -789,20 +789,32 @@ func Check(prog *parser.Program, env *Env) []error {
 	// can reference them regardless of order in the source file.
 	for _, stmt := range prog.Statements {
 		if stmt.Fun != nil {
+			sigEnv := env
+			if len(stmt.Fun.TypeParams) > 0 {
+				sigEnv = NewEnv(env)
+				for _, tp := range stmt.Fun.TypeParams {
+					sigEnv.SetTypeParam(tp, &TypeVar{Name: tp})
+				}
+			}
 			params := make([]Type, len(stmt.Fun.Params))
 			for i, p := range stmt.Fun.Params {
 				if p.Type != nil {
-					params[i] = resolveTypeRef(p.Type, env)
+					params[i] = resolveTypeRef(p.Type, sigEnv)
 				} else {
 					params[i] = AnyType{}
 				}
 			}
 			var ret Type = UnitType{}
 			if stmt.Fun.Return != nil {
-				ret = resolveTypeRef(stmt.Fun.Return, env)
+				ret = resolveTypeRef(stmt.Fun.Return, sigEnv)
 			}
 			pure := isPureFunction(stmt.Fun, env)
-			env.SetVar(stmt.Fun.Name, FuncType{Params: params, Return: ret, Pure: pure}, false)
+			env.SetVar(stmt.Fun.Name, FuncType{
+				Params:     params,
+				Return:     ret,
+				Pure:       pure,
+				TypeParams: append([]string(nil), stmt.Fun.TypeParams...),
+			}, false)
 			env.SetFunc(stmt.Fun.Name, stmt.Fun)
 		}
 	}
@@ -1390,6 +1402,13 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 
 	case s.Fun != nil:
 		name := s.Fun.Name
+		sigEnv := env
+		if len(s.Fun.TypeParams) > 0 {
+			sigEnv = NewEnv(env)
+			for _, tp := range s.Fun.TypeParams {
+				sigEnv.SetTypeParam(tp, &TypeVar{Name: tp})
+			}
+		}
 		params := []Type{}
 		for _, p := range s.Fun.Params {
 			if p.Type == nil {
@@ -1397,18 +1416,23 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 				// annotations by defaulting them to `any`.
 				params = append(params, AnyType{})
 			} else {
-				params = append(params, resolveTypeRef(p.Type, env))
+				params = append(params, resolveTypeRef(p.Type, sigEnv))
 			}
 		}
 		var ret Type = AnyType{}
 		if s.Fun.Return != nil {
-			ret = resolveTypeRef(s.Fun.Return, env)
+			ret = resolveTypeRef(s.Fun.Return, sigEnv)
 		}
 		pure := isPureFunction(s.Fun, env)
-		env.SetVar(name, FuncType{Params: params, Return: ret, Pure: pure}, false)
+		env.SetVar(name, FuncType{
+			Params:     params,
+			Return:     ret,
+			Pure:       pure,
+			TypeParams: append([]string(nil), s.Fun.TypeParams...),
+		}, false)
 		env.SetFunc(name, s.Fun)
 
-		child := NewEnv(env)
+		child := NewEnv(sigEnv)
 		for i, p := range s.Fun.Params {
 			child.SetVar(p.Name, params[i], true)
 		}
@@ -1598,6 +1622,9 @@ func resolveTypeRefInner(t *parser.TypeRef, env *Env) Type {
 		case "any":
 			return AnyType{}
 		default:
+			if tv, ok := env.LookupTypeParam(*t.Simple); ok {
+				return tv
+			}
 			if ut, ok := env.GetUnion(*t.Simple); ok {
 				return ut
 			}

--- a/types/env.go
+++ b/types/env.go
@@ -28,6 +28,13 @@ type Env struct {
 	funcs   map[string]*parser.FunStmt   // function declarations
 	models  map[string]ModelSpec         // model aliases
 
+	// typeParams holds the active generic type parameters in this scope.
+	// resolveTypeRef consults this so that names like `T` and `K` inside
+	// a `fun foo<T, K>(...)` signature resolve to the same TypeVar
+	// instance across the parameter list and return type. Populated by
+	// the function-decl walks in check.go.
+	typeParams map[string]*TypeVar
+
 	// diagnostics accumulates errors raised in contexts (such as
 	// resolveTypeRef) that cannot return errors to their caller. Only
 	// the root env holds the slice; helpers walk up to find it.
@@ -84,6 +91,7 @@ func NewEnv(parent *Env) *Env {
 		values:  make(map[string]any),
 		funcs:   make(map[string]*parser.FunStmt),
 		models:  make(map[string]ModelSpec),
+		typeParams: make(map[string]*TypeVar),
 		output:  out,
 		input:   in,
 	}
@@ -147,6 +155,24 @@ func (e *Env) GetStream(name string) (StructType, bool) {
 		return e.parent.GetStream(name)
 	}
 	return StructType{}, false
+}
+
+// SetTypeParam registers a generic type-parameter name in the current
+// scope. resolveTypeRef consults LookupTypeParam to resolve such names.
+func (e *Env) SetTypeParam(name string, tv *TypeVar) {
+	e.typeParams[name] = tv
+}
+
+// LookupTypeParam searches for a generic type-parameter binding in the
+// current scope and parents.
+func (e *Env) LookupTypeParam(name string) (*TypeVar, bool) {
+	if tv, ok := e.typeParams[name]; ok {
+		return tv, true
+	}
+	if e.parent != nil {
+		return e.parent.LookupTypeParam(name)
+	}
+	return nil, false
 }
 
 // LookupType searches for a named type in the current scope and parents.


### PR DESCRIPTION
## Summary
- Env grows a \`typeParams\` map plus \`SetTypeParam\` / \`LookupTypeParam\`
- \`resolveTypeRefInner\` consults the typeParams scope so a name like \`T\` declared in the enclosing \`fun\` resolves to its TypeVar
- Both the FunStmt prepass and the main handler install a sigEnv with fresh TypeVars per declared TypeParam, resolve params and return in that scope, and set \`FuncType.TypeParams\`
- The body checks under sigEnv via the body's child env, so a parameter \`x: T\` inside the body matches the same TypeVar as the signature
- Call-site Instantiate + Subst-aware Unify (already in place for builtins) handles the rest

New fixture exercises \`id<T>(x: T): T\` and \`pair<A, B>(a: A, b: B): A\` returning concrete types at distinct call sites without any \`as T\` cast.

Tracking: #21322. Refs #87, #66, parent #85.

## Test plan
- [x] \`go test ./types/...\`
- [x] \`go test ./...\` (no failures)