### PR TITLE
mep-0010: mark B5 closed (generic functions unify across calls)

### DIFF
--- a/website/docs/mep/mep-0010.md
+++ b/website/docs/mep/mep-0010.md
@@ -115,13 +115,13 @@ To opt in to sharing, declare the source as `var`. To break the alias explicitly
 
 **Plan.** Extend the consumer set incrementally as the language gains pure positions. Each new position lands with a matching fixture pair.
 
-#### B5. Generic functions parse but do not unify across calls
+#### B5. Generic functions parse but do not unify across calls (closed)
 
-**Evidence.** `TypeVar` exists at `types/check.go:186-200` and is used in unification but is not produced by inference of a function call's result. Each call site re-infers from the declared signature.
+**Status.** Closed. `Env` carries a `typeParams` scope (`SetTypeParam` / `LookupTypeParam` in `types/env.go`), and `resolveTypeRefInner` consults it before the unknown-type diagnostic and the single-uppercase heuristic. Both the FunStmt prepass and the main FunStmt handler in `types/check.go` install a sigEnv with a fresh `*TypeVar` per declared `TypeParam`, then resolve params and return in that scope and set `FuncType.TypeParams`. At each call the primary call-site `Instantiate` freshens the quantified vars and the substitution-aware `Unify` constrains them across arguments. Conflicting unifications surface as `T047`; under-constrained results surface as `T048`.
 
-**Impact.** A function declared `fun id<T>(x: T): T` is callable but the caller always sees the type of `x` flow through the declaration in a loose way.
+**Pinning fixture.** `tests/types/valid/user_generic_id.mochi` exercises `id<T>(x: T): T` and `pair<A, B>(a: A, b: B): A` returning concrete types at distinct call sites without an `as T` cast.
 
-**Plan.** Wire `TypeVar` through inference. Build a small substitution solver so a call generates fresh variables and unifies arguments. Reject conflicting unifications with a new error code. See [MEP 12](/docs/mep/mep-0012).
+**Original evidence.** `TypeVar` existed at `types/check.go:186-200` and was used in unification but was not produced by inference of a function call's result. Each call site re-inferred from the declared signature, so `id<T>` parsed but was indistinguishable from a fixed `any` signature.
 
 #### B6. Query select fallback to any
 


### PR DESCRIPTION
## Summary
Move MEP-10 B5 from open to closed now that user-defined generic functions unify through call sites. Pin \`tests/types/valid/user_generic_id.mochi\` as the fixture.

Tracking: #21324. Refs #66, #76.

## Test plan
- [x] docs only