### PR TITLE
mep-0009: refresh fixture counts and add v0.12.0 entries

### DIFF
--- a/website/docs/mep/mep-0009.md
+++ b/website/docs/mep/mep-0009.md
@@ -39,8 +39,8 @@ Source counts taken at the snapshot date. Numbers are pairs of `.mochi` plus mat
 |----------------------------|-------|
 | tests/parser/valid         | 62    |
 | tests/parser/errors        | 28    |
-| tests/types/valid          | 65    |
-| tests/types/errors         | 62    |
+| tests/types/valid          | 64    |
+| tests/types/errors         | 71    |
 | tests/types/soundness      | 15    |
 | tests/queryplan            | small |
 | tests/interpreter          | many  |
@@ -88,14 +88,21 @@ Added in v0.11.0:
 
 ```
 aggregate_count_list, aggregate_min_max_int, aggregate_sum_int_list,
-any_top_silent_widen, canonical_bool_only, canonical_int_arithmetic,
-canonical_string_concat, cast_string_as_bool, closure_inferred_return,
-divide_by_zero_literal, for_in_list, for_in_range, if_while_checked,
-inversion_if_expr, match_literal_pattern, match_union_variant,
-modulo_by_zero_literal, mutate_through_let_alias, now_returns_int64,
-null_widening_int, null_widening_list, null_widening_struct,
-numeric_float_plus_int, numeric_int_plus_float, preservation_let_chain,
-pure_in_where_ok, query_basic_select, query_sort_take, struct_field_access
+canonical_bool_only, canonical_int_arithmetic, canonical_string_concat,
+cast_string_as_bool, closure_inferred_return, divide_by_zero_literal,
+for_in_list, for_in_range, if_while_checked, inversion_if_expr,
+match_literal_pattern, match_union_variant, modulo_by_zero_literal,
+now_returns_int64, numeric_float_plus_int, numeric_int_plus_float,
+preservation_let_chain, pure_in_where_ok, query_basic_select,
+query_sort_take, struct_field_access
+```
+
+Added in v0.12.0 (MEP-10, MEP-11, MEP-12):
+
+```
+compare_empty_list, generic_builtins, int_div_truncates,
+match_union_exhaustive_wildcard, option_type_syntax,
+recursive_linked_list, reduce_generic, unit_return, user_generic_id
 ```
 
 ### Existing types/errors fixtures
@@ -126,6 +133,15 @@ list_concat_type_mismatch, match_variant_arity, missing_map_key,
 missing_map_key_cast, multiple_top_level_errors, mutate_through_let_field,
 mutate_through_let_index, range_bound_float, struct_unknown_field_access,
 while_cond_not_bool
+```
+
+Added in v0.12.0 (MEP-10, MEP-11, MEP-12):
+
+```
+any_top_silent_widen, compare_int_string, compare_struct_int,
+match_missing_variant, mutate_through_let_alias, null_widening_int,
+null_widening_list, null_widening_struct, unit_assign_value,
+unknown_type_name, unknown_type_param
 ```
 
 ### Coverage matrix


### PR DESCRIPTION
## Summary
Counts and named-fixture lists in MEP-9 drifted from disk during the MEP-10/11/12 rollout. \`types/valid\` is 64 (doc said 65), \`types/errors\` is 71 (doc said 62). The v0.11.0 lists also misclassified a few names that actually landed in this cycle. Move them to a new v0.12.0 section and correct the totals.

Tracking: #21326. Refs #105.

## Test plan
- [x] docs only