### PR TITLE
mep-0012.3: surface T047 on generic argument conflict

### DIFF
--- a/tests/types/errors/generic_param_conflict.err
+++ b/tests/types/errors/generic_param_conflict.err
@@ -1,0 +1,8 @@
+1. error[T047]: cannot unify type parameter `T`: int vs string
+  --> tests/types/errors/generic_param_conflict.mochi:5:7
+
+  5 | print(pair(1, "two"))
+    |       ^
+
+help:
+  Two argument positions require incompatible bindings for the same generic parameter. Pick argument types that agree.

--- a/tests/types/errors/generic_param_conflict.mochi
+++ b/tests/types/errors/generic_param_conflict.mochi
@@ -1,0 +1,5 @@
+fun pair<T>(a: T, b: T): T {
+  return a
+}
+
+print(pair(1, "two"))

--- a/types/check.go
+++ b/types/check.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/alecthomas/participle/v2/lexer"
 	"mochi/parser"
@@ -2117,13 +2118,17 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 		argTypes := make([]Type, argCount)
 		for i := 0; i < argCount && i < fixed; i++ {
 			expected := callSubst.Apply(ft.Params[i])
-			// MEP-12.2: if the expected param still contains unbound
-			// TypeVars after substitution, skip the hint-driven check
-			// (it routes through Subtype, which has no TypeVar rule) and
-			// let the call-site unifier bind the var from the inferred
-			// argument type instead.
+			// MEP-12.2/12.3: when the original parameter mentions any
+			// TypeVar quantified by this signature, never propagate the
+			// hint. Two cases:
+			//   (1) the var is still unbound: Subtype has no TypeVar
+			//       rule, so the hint-driven check would mishandle it.
+			//   (2) the var was bound by an earlier argument: forcing
+			//       the bound type as a hint would surface a T008 in
+			//       place of the more informative T047 unify-conflict
+			//       diagnostic the call-site Unify produces below.
 			hint := expected
-			if len(FreeTypeVars(expected, callSubst)) > 0 {
+			if len(FreeTypeVars(ft.Params[i], Subst{})) > 0 {
 				hint = nil
 			}
 			at, err := checkExprWithExpected(p.Call.Args[i], env, hint)
@@ -2139,7 +2144,11 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 				// generic T007 mismatch. The legacy fallback above keeps
 				// non-generic calls on T007.
 				if len(ft.TypeParams) > 0 {
-					if name := firstFreeTypeVar(ft.Params[i], callSubst); name != "" {
+					// Use the structural TypeVar name from the
+					// pre-substitution param so we can report the
+					// original declared name (e.g. `T`) even after
+					// Instantiate freshened it to `T#1`.
+					if name := structuralTypeVarName(ft.Params[i]); name != "" {
 						return nil, errTypeParamConflict(p.Pos, name, expected, at)
 					}
 				}
@@ -2531,6 +2540,22 @@ func firstFreeTypeVar(t Type, sub Subst) string {
 		return ""
 	}
 	return free[0]
+}
+
+// structuralTypeVarName returns the first TypeVar's declared name found
+// in t, ignoring substitutions. The "T#N" suffix introduced by
+// FreshTypeVar is stripped so the caller surfaces the user-declared
+// parameter name (e.g. "T") in diagnostics.
+func structuralTypeVarName(t Type) string {
+	free := FreeTypeVars(t, Subst{})
+	if len(free) == 0 {
+		return ""
+	}
+	name := free[0]
+	if i := strings.IndexByte(name, '#'); i >= 0 {
+		return name[:i]
+	}
+	return name
 }
 
 // isAliasableAggregate reports whether t is a value kind whose storage

--- a/types/subst.go
+++ b/types/subst.go
@@ -52,9 +52,10 @@ func (sub Subst) Apply(t Type) Type {
 			params[i] = sub.Apply(p)
 		}
 		out := FuncType{
-			Params: params,
-			Return: sub.Apply(v.Return),
-			Pure:   v.Pure,
+			Params:     params,
+			Return:     sub.Apply(v.Return),
+			Pure:       v.Pure,
+			TypeParams: append([]string(nil), v.TypeParams...),
 		}
 		if v.Variadic != nil {
 			out.Variadic = sub.Apply(v.Variadic)
@@ -193,13 +194,10 @@ func unifyInto(a, b Type, sub Subst) error {
 	a = sub.Apply(a)
 	b = sub.Apply(b)
 
-	if _, ok := a.(AnyType); ok {
-		return nil
-	}
-	if _, ok := b.(AnyType); ok {
-		return nil
-	}
-
+	// TypeVar before AnyType: when one side is a TypeVar and the other
+	// is AnyType, bind the var to any. Otherwise the any short-circuit
+	// below would leave the var unbound and the call-site escape check
+	// (T048) would fire even though the call is well-formed.
 	if av, ok := a.(*TypeVar); ok {
 		if bv, ok := b.(*TypeVar); ok && av.Name == bv.Name {
 			return nil
@@ -208,6 +206,13 @@ func unifyInto(a, b Type, sub Subst) error {
 	}
 	if bv, ok := b.(*TypeVar); ok {
 		return sub.Bind(bv.Name, a)
+	}
+
+	if _, ok := a.(AnyType); ok {
+		return nil
+	}
+	if _, ok := b.(AnyType); ok {
+		return nil
 	}
 
 	switch av := a.(type) {


### PR DESCRIPTION
## Summary
Three fixes to make T047 reachable on a generic argument conflict:

1. **\`Subst.Apply\` on FuncType** now preserves \`TypeParams\`. Without this, the post-Instantiate FuncType looked non-generic and the call-site T047/T048 guards never fired.
2. **\`unifyInto\` reordered**. When one side is a TypeVar and the other is AnyType, bind the var to any. Before, the AnyType short-circuit ran first and left the var unbound, so \`max(list<any>)\` fired a spurious T048.
3. **Hint suppression on generic positions**. \`checkExprWithExpected\` is now called with no hint whenever the original parameter structurally contains a TypeVar. Propagating a substituted hint surfaced T008 in place of T047.

T047 messages report the original declared name (e.g. \`T\`) by stripping the \`#N\` suffix from the fresh internal label.

Fixture: \`tests/types/errors/generic_param_conflict.mochi\` pins T047 for \`pair<T>(a: T, b: T)\` called with mismatched argument types.

Tracking: #21328. Refs #88, parent #85.

## Test plan
- [x] \`go test ./types/...\`
- [x] \`go test ./...\` (q15/q2 plan tests pass — fix 2 covers the regression that surfaced)