### PR TITLE
mep-0012: flip status to Active

### DIFF
--- a/website/docs/mep/mep-0012.md
+++ b/website/docs/mep/mep-0012.md
@@ -2,7 +2,7 @@
 mep: 12
 title: Parametric Polymorphism
 author: Mochi core
-status: Draft
+status: Active
 type: Standards Track
 created: 2026-05-08
 sidebar_position: 12
@@ -17,7 +17,7 @@ description: System-F-lite call-site inference, fresh type variables, and the en
 | MEP      | 12                          |
 | Title    | Parametric Polymorphism     |
 | Author   | Mochi core                  |
-| Status   | Draft                       |
+| Status   | Active                      |
 | Type     | Standards Track             |
 | Created  | 2026-05-08                  |
 
@@ -364,20 +364,28 @@ time.
 
 The MEP-12 fixture set, pinned in MEP-9:
 
-- `generic_id_int_string` (valid). Asserts inferred result.
-- `generic_first_list_int` (valid). Asserts inferred element.
-- `generic_pair_arg_unify` (valid). Two arguments share `T`, both bind
-  to the same type.
-- `generic_pair_arg_conflict` (error T047). Two arguments share `T` but
-  bind to different types.
-- `generic_freshness_per_call` (valid). Two calls of the same function
-  with different argument types do not produce a unification error.
-- `generic_escaping_variable` (error T048). A declaration where `T`
-  appears only in the result.
-- `generic_constraint_arity_under` (error T049).
-- `generic_constraint_arity_over` (error T049).
-- `generic_explicit_type_arg` (valid). `id<int>(7)` typechecks and
-  the call site does not need argument-driven inference.
+- `user_generic_id` (valid, on disk). Exercises `fun id<T>(x: T): T`
+  and `fun pair<A, B>(...)` with inferred return types at each call
+  site. Replaces the speculative `generic_id_int_string` /
+  `generic_pair_arg_unify` pair.
+- `generic_builtins` (valid, on disk). Asserts inferred element types
+  through `first`, `last`, `push`, `keys`, `values`, etc.
+- `reduce_generic` (valid, on disk). Pins the parametric
+  `reduce<A, B>` signature; without MEP-12.2 the call site fell back
+  to `any` and required an explicit `as T` cast.
+- `generic_param_conflict` (error T047, on disk). Two arguments share
+  `T` but bind to incompatible types (`pair(1, "two")`).
+- `generic_freshness_per_call` (valid, **outstanding**, tracked in
+  MEP-12.6). Two calls of the same function with different argument
+  types do not produce a unification error.
+- `generic_escaping_variable` (error T048, **outstanding**). A
+  declaration where `T` appears only in the result. The fixture is
+  hard to author today because the body of such a function cannot
+  produce a `T` without an explicit cast, which fails T046 first.
+- `generic_constraint_arity_under`, `generic_constraint_arity_over`
+  (error T049, **outstanding**, blocked on MEP-12.5).
+- `generic_explicit_type_arg` (valid, **outstanding**, blocked on
+  MEP-12.5).
 
 ## Open Questions
 


### PR DESCRIPTION
MEP-12.1 (substitution machinery), 12.2 (user generics), 12.3 (T047
diagnostic) and 12.4 (parametric reduce) have all landed. Move the
header from Draft to Active and rewrite the Test obligations section
to name the fixtures that actually live in tests/types/, with the
still-outstanding ones explicitly flagged.

Tracking: #21330. Refs #85.