### PR TITLE
mep-0012.4: tighten concat and parametric variadic

### DIFF
--- a/tests/types/valid/concat_generic.golden
+++ b/tests/types/valid/concat_generic.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/concat_generic.mochi
+++ b/tests/types/valid/concat_generic.mochi
@@ -1,0 +1,10 @@
+// MEP-12.4: concat is generic in the element type. The variadic
+// unifier in checkPrimary pins T from the first argument; later
+// arguments whose element type disagrees would fail T047.
+let xs: list<int> = [1, 2]
+let ys: list<int> = [3, 4]
+let zs: list<int> = concat(xs, ys)
+expect len(zs) == 4
+
+let ss: list<string> = concat(["a"], ["b", "c"])
+expect len(ss) == 3

--- a/types/check.go
+++ b/types/check.go
@@ -506,11 +506,17 @@ func Check(prog *parser.Program, env *Env) []error {
 		Return: ListType{Elem: AnyType{}},
 		Pure:   true,
 	}, false)
+	// concat<T>(...xs: list<T>): list<T> - MEP-12.4. Every argument is
+	// a list<T>; the variadic unifier in checkPrimary pins T from the
+	// first argument and rejects any later argument whose element type
+	// disagrees with T047.
+	concatT := &TypeVar{Name: "T"}
 	env.SetVar("concat", FuncType{
-		Params:   []Type{},
-		Return:   ListType{Elem: AnyType{}},
-		Pure:     true,
-		Variadic: ListType{Elem: AnyType{}},
+		Params:     []Type{},
+		Return:     ListType{Elem: concatT},
+		Pure:       true,
+		Variadic:   ListType{Elem: concatT},
+		TypeParams: []string{"T"},
 	}, false)
 	// first<T>(xs: list<T>): T - MEP-12.4. Generic so the result of
 	// first(list<int>) is int rather than any, and the user no longer
@@ -2158,14 +2164,27 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 
 		if ft.Variadic != nil {
 			variadicType := ft.Variadic
+			variadicIsGeneric := len(FreeTypeVars(ft.Variadic, Subst{})) > 0
 			for i := fixed; i < argCount; i++ {
-				at, err := checkExprWithExpected(p.Call.Args[i], env, variadicType)
+				expected := callSubst.Apply(variadicType)
+				hint := expected
+				if variadicIsGeneric {
+					hint = nil
+				}
+				at, err := checkExprWithExpected(p.Call.Args[i], env, hint)
 				if err != nil {
 					return nil, err
 				}
 				argTypes[i] = at
-				if !unify(at, variadicType, nil) {
-					return nil, errArgTypeMismatch(p.Pos, i, variadicType, at)
+				if next, err := Unify(at, expected, callSubst); err == nil {
+					callSubst = next
+				} else if !unify(at, expected, nil) {
+					if len(ft.TypeParams) > 0 {
+						if name := structuralTypeVarName(variadicType); name != "" {
+							return nil, errTypeParamConflict(p.Pos, name, expected, at)
+						}
+					}
+					return nil, errArgTypeMismatch(p.Pos, i, expected, at)
 				}
 			}
 			if _, defined := env.GetFunc(p.Call.Func); !defined {


### PR DESCRIPTION
concat now declares concat<T>(...xs: list<T>): list<T>. The variadic
loop in checkPrimary is extended to call Unify when the variadic
parameter mentions a type variable, so the element type is pinned by
the first argument and later arguments whose element type disagrees
fail T047 instead of widening to list<any>.

Non-generic variadics (print, range) keep the legacy unify(at, ft)
path and behave exactly as before.

Tracking: #21336. Refs #89, #85.