### PR TITLE
mep-0012.6: pin freshness-per-call fixture

### DIFF
--- a/tests/types/valid/generic_freshness_per_call.golden
+++ b/tests/types/valid/generic_freshness_per_call.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/generic_freshness_per_call.mochi
+++ b/tests/types/valid/generic_freshness_per_call.mochi
@@ -1,0 +1,13 @@
+// MEP-12 §Test obligations: freshness-per-call. Two calls of the
+// same generic function with disjoint argument types must not collide
+// on the shared type parameter. Each call site allocates fresh
+// TypeVars (T#N) via Instantiate so the substitution from call A
+// cannot poison call B.
+fun id<T>(x: T): T {
+  return x
+}
+
+let i: int = id(7)
+let s: string = id("seven")
+expect i == 7
+expect s == "seven"

--- a/website/docs/mep/mep-0012.md
+++ b/website/docs/mep/mep-0012.md
@@ -375,9 +375,11 @@ The MEP-12 fixture set, pinned in MEP-9:
   to `any` and required an explicit `as T` cast.
 - `generic_param_conflict` (error T047, on disk). Two arguments share
   `T` but bind to incompatible types (`pair(1, "two")`).
-- `generic_freshness_per_call` (valid, **outstanding**, tracked in
-  MEP-12.6). Two calls of the same function with different argument
-  types do not produce a unification error.
+- `generic_freshness_per_call` (valid, on disk). Two calls of the
+  same `fun id<T>(x: T): T` with disjoint argument types do not
+  produce a unification error: each call site allocates fresh
+  `TypeVar` instances via `Instantiate`, so the substitution from one
+  call cannot poison another.
 - `generic_escaping_variable` (error T048, **outstanding**). A
   declaration where `T` appears only in the result. The fixture is
   hard to author today because the body of such a function cannot


### PR DESCRIPTION
Two calls of fun id<T>(x: T): T with disjoint argument types must
return the right concrete result. The Instantiate freshening (T#N
suffix) guarantees the substitution from one call cannot poison
another. MEP-12 doc updated to mark the fixture as on disk.

Tracking: #21338. Refs #91, #85.