### PR TITLE
mep-0012.4: pin reverse return type to argument shape

### DIFF
--- a/tests/types/valid/reverse_result_shape.golden
+++ b/tests/types/valid/reverse_result_shape.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/reverse_result_shape.mochi
+++ b/tests/types/valid/reverse_result_shape.mochi
@@ -1,0 +1,11 @@
+// MEP-12.4: reverse's return type mirrors the argument's static
+// shape. For list<T> the result is list<T>; for string it is string.
+// Before this, the return was widened to any and consumers needed an
+// explicit cast.
+let xs: list<int> = [1, 2, 3]
+let ys: list<int> = reverse(xs)
+expect len(ys) == 3
+expect ys[0] == 3
+
+let s: string = reverse("abc")
+expect s == "cba"

--- a/types/check.go
+++ b/types/check.go
@@ -2203,6 +2203,20 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 					ret = ListType{Elem: mt.Value}
 				}
 			}
+			// MEP-12.4: reverse mirrors its argument's static shape.
+			// The declared signature stays loose (any -> any) so the
+			// list-or-string discriminator in checkBuiltinCall still
+			// applies; the post-process here pins the return type at
+			// the call site, so reverse([1,2,3]) types as list<int>
+			// rather than any.
+			if p.Call.Func == "reverse" && len(argTypes) == 1 {
+				switch at := argTypes[0].(type) {
+				case ListType:
+					ret = at
+				case StringType:
+					ret = StringType{}
+				}
+			}
 			return ret, nil
 		}
 		if _, defined := env.GetFunc(p.Call.Func); !defined {
@@ -2219,6 +2233,15 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 		if p.Call.Func == "values" && len(argTypes) == 1 {
 			if mt, ok := argTypes[0].(MapType); ok {
 				ret = ListType{Elem: mt.Value}
+			}
+		}
+		// MEP-12.4: reverse mirrors its argument's static shape.
+		if p.Call.Func == "reverse" && len(argTypes) == 1 {
+			switch at := argTypes[0].(type) {
+			case ListType:
+				ret = at
+			case StringType:
+				ret = StringType{}
 			}
 		}
 		// MEP-12.3: T048 when the declared generic result still mentions


### PR DESCRIPTION
reverse keeps its loose any -> any declared signature, because the
list-or-string discriminator in checkBuiltinCall rejects everything
else. The post-process in checkPrimary now pins the return at the
call site: reverse(list<T>) types as list<T> and reverse(string) as
string, so consumers no longer need an as-cast.

Both the variadic and non-variadic branches of the call dispatcher
carry the override (parallel to the existing keys/values overrides)
to stay consistent regardless of which branch the resolver lands in.

Tracking: #21340. Refs #89, #85.