### PR TITLE
mep-0012.3: T048 message cleanup, escape fixture

### DIFF
--- a/tests/types/errors/generic_escaping_variable.err
+++ b/tests/types/errors/generic_escaping_variable.err
@@ -1,0 +1,8 @@
+1. error[T048]: type parameter `T` escapes function result
+  --> tests/types/errors/generic_escaping_variable.mochi:4:7
+
+  4 | print(ghost(1))
+    |       ^
+
+help:
+  The result type still mentions `T` after argument unification. Constrain the parameter at a call argument or supply an explicit type argument.

--- a/tests/types/errors/generic_escaping_variable.mochi
+++ b/tests/types/errors/generic_escaping_variable.mochi
@@ -1,0 +1,4 @@
+fun ghost<T>(x: any): T {
+  return x as T
+}
+print(ghost(1))

--- a/types/check.go
+++ b/types/check.go
@@ -2581,7 +2581,11 @@ func firstFreeTypeVar(t Type, sub Subst) string {
 	if len(free) == 0 {
 		return ""
 	}
-	return free[0]
+	name := free[0]
+	if i := strings.IndexByte(name, '#'); i >= 0 {
+		return name[:i]
+	}
+	return name
 }
 
 // structuralTypeVarName returns the first TypeVar's declared name found

--- a/website/docs/mep/mep-0012.md
+++ b/website/docs/mep/mep-0012.md
@@ -380,10 +380,11 @@ The MEP-12 fixture set, pinned in MEP-9:
   produce a unification error: each call site allocates fresh
   `TypeVar` instances via `Instantiate`, so the substitution from one
   call cannot poison another.
-- `generic_escaping_variable` (error T048, **outstanding**). A
-  declaration where `T` appears only in the result. The fixture is
-  hard to author today because the body of such a function cannot
-  produce a `T` without an explicit cast, which fails T046 first.
+- `generic_escaping_variable` (error T048, on disk). A function
+  whose `T` is unconstrained by any argument (`fun ghost<T>(x: any): T`)
+  raises T048 at the call site. The body uses `x as T` to placate the
+  return-type check; the `any as T` cast is admitted by T046 because
+  any-related casts are allowed.
 - `generic_constraint_arity_under`, `generic_constraint_arity_over`
   (error T049, **outstanding**, blocked on MEP-12.5).
 - `generic_explicit_type_arg` (valid, **outstanding**, blocked on


### PR DESCRIPTION
firstFreeTypeVar strips the freshening suffix (#N) the same way
structuralTypeVarName does for T047, so users see T not T#1.

Adds generic_escaping_variable fixture: a function whose T appears
only in the result (fun ghost<T>(x: any): T). The body uses x as T,
admitted by T046 as an any-related cast.

MEP-12 doc updated.

Tracking: #21342. Refs #88, #91, #85.