### PR TITLE
mep-0009: refresh catalogue counts and v0.12 entries

### DIFF
--- a/website/docs/mep/mep-0009.md
+++ b/website/docs/mep/mep-0009.md
@@ -39,8 +39,8 @@ Source counts taken at the snapshot date. Numbers are pairs of `.mochi` plus mat
 |----------------------------|-------|
 | tests/parser/valid         | 62    |
 | tests/parser/errors        | 28    |
-| tests/types/valid          | 67    |
-| tests/types/errors         | 76    |
+| tests/types/valid          | 72    |
+| tests/types/errors         | 90    |
 | tests/types/soundness      | 15    |
 | tests/queryplan            | small |
 | tests/interpreter          | many  |
@@ -100,9 +100,11 @@ query_sort_take, struct_field_access
 Added in v0.12.0 (MEP-10, MEP-11, MEP-12):
 
 ```
-compare_empty_list, generic_builtins, int_div_truncates,
+compare_empty_list, concat_generic, generic_builtins,
+generic_freshness_per_call, int_div_truncates,
 match_union_exhaustive_wildcard, option_type_syntax,
-recursive_linked_list, reduce_generic, unit_return, user_generic_id
+recursive_linked_list, reduce_generic, reverse_result_shape,
+unit_return, user_generic_id
 ```
 
 ### Existing types/errors fixtures
@@ -139,10 +141,16 @@ Added in v0.12.0 (MEP-10, MEP-11, MEP-12):
 
 ```
 any_top_silent_widen, compare_int_string, compare_struct_int,
-list_alias_call_arg, list_alias_index, list_alias_var_invariant, match_missing_variant,
+generic_escaping_variable, generic_param_conflict,
+list_alias_call_arg, list_alias_index, list_alias_var_invariant,
+match_arm_after_wildcard, match_missing_variant,
+match_redundant_literal, match_redundant_variant,
 mutate_through_let_alias, null_widening_int, null_widening_list,
-null_widening_struct, unit_assign_value, unknown_type_name,
-unknown_type_param
+null_widening_struct, query_group_having_bool_required,
+query_skip_int_required, query_take_int_required,
+query_where_bool_required, struct_literal_missing_field,
+struct_literal_missing_fields_two, struct_literal_unknown_field,
+unit_assign_value, unknown_type_name, unknown_type_param
 ```
 
 ### Coverage matrix
@@ -170,9 +178,9 @@ The matrix is a property-to-fixture mapping. A cell value of `existing` means at
 | Variance, list element write             | n/a       | existing  |
 | Variance, map key                        | missing   | missing   |
 | Variance, map value                      | missing   | missing   |
-| Parametricity, len                       | missing   | missing   |
-| Parametricity, first                     | missing   | missing   |
-| Parametricity, push, append, concat      | missing   | missing   |
+| Parametricity, len                       | existing  | missing   |
+| Parametricity, first                     | existing  | missing   |
+| Parametricity, push, append, concat      | existing  | missing   |
 | Parametricity, range                     | missing   | missing   |
 | Exhaustiveness, union                    | missing   | missing   |
 | Irredundancy, union                      | missing   | missing   |
@@ -191,8 +199,8 @@ The matrix is a property-to-fixture mapping. A cell value of `existing` means at
 | Null assignable as any                   | missing   | n/a       |
 | Closures capture                         | existing  | missing   |
 | Recursive types                          | missing   | missing   |
-| Generic function declared                | existing  | missing   |
-| Generic function instantiation           | missing   | missing   |
+| Generic function declared                | existing  | existing  |
+| Generic function instantiation           | existing  | existing  |
 | Query result type                        | existing  | partial   |
 | Query aggregate types                    | existing  | partial   |
 | Multiple top level errors accumulated    | n/a       | existing  |


### PR DESCRIPTION
Counts: 139 valid, 144 errors. Adds the new generic_* fixtures
landed for MEP-12 to the v0.12 lists. Coverage matrix bumped for
parametricity (len, first, push/append/concat) and generic
instantiation, all now existing.

Tracking: #21344. Refs #105.