### PR TITLE
mep-0010: close B3 list-element invariance under aliasing

### DIFF
--- a/tests/types/errors/list_alias_var_invariant.err
+++ b/tests/types/errors/list_alias_var_invariant.err
@@ -1,0 +1,8 @@
+1. error[T052]: cannot alias `xs` ([int]) into a binding of type [any]
+  --> tests/types/errors/list_alias_var_invariant.mochi:7:1
+
+  7 | var ys: list<any> = xs
+    | ^
+
+help:
+  Aliasing widens the source's element type, which would let a write through the alias deposit a value the source cannot hold. Aggregate element, key, and value types are invariant at aliasing sites. Clone explicitly (e.g. `[...xs]`, `{...m}`) or declare the destination with the source's exact element type.

--- a/tests/types/errors/list_alias_var_invariant.mochi
+++ b/tests/types/errors/list_alias_var_invariant.mochi
@@ -1,0 +1,7 @@
+// MEP-10 B3 / T052: aliasing a `list<int>` var into a `list<any>` var
+// would create a write hole. A later `ys[0] = "hello"` would deposit
+// a string into the int-typed storage that xs still reads from.
+// Element types are invariant at the aliasing point; the destination
+// must declare the source's exact element type or clone the list.
+var xs: list<int> = [1, 2, 3]
+var ys: list<any> = xs

--- a/types/check.go
+++ b/types/check.go
@@ -998,6 +998,19 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 				if !Assignable(exprType, typ) {
 					return errTypeMismatch(s.Var.Pos, typ, exprType)
 				}
+				// MEP-10 B3: when the source is a bare identifier
+				// referring to an aliasable aggregate, the new binding
+				// shares storage with the source. A widened element
+				// type (e.g. `list<int>` into `list<any>`) lets a
+				// later `ys[i] = ...` deposit a value the source's
+				// static type rejects, corrupting reads through the
+				// source name. Aliasing requires structural equality
+				// on aggregate element, key, and value types.
+				if src := bareIdentName(s.Var.Value); src != "" {
+					if isAliasableAggregate(exprType) && !equalKinds(exprType, typ) {
+						return errAliasWidensElement(s.Var.Pos, src, exprType, typ)
+					}
+				}
 			}
 		} else if s.Var.Value != nil {
 			var err error

--- a/types/errors.go
+++ b/types/errors.go
@@ -70,6 +70,7 @@ var Errors = map[string]diagnostic.Template{
 	"T047": {Code: "T047", Message: "cannot unify type parameter `%s`: %s vs %s", Help: "Two argument positions require incompatible bindings for the same generic parameter. Pick argument types that agree."},
 	"T048": {Code: "T048", Message: "type parameter `%s` escapes function result", Help: "The result type still mentions `%s` after argument unification. Constrain the parameter at a call argument or supply an explicit type argument."},
 	"T049": {Code: "T049", Message: "type argument arity mismatch for `%s`: expected %d, got %d", Help: "Supply exactly one type argument per declared type parameter."},
+	"T052": {Code: "T052", Message: "cannot alias `%s` (%s) into a binding of type %s", Help: "Aliasing widens the source's element type, which would let a write through the alias deposit a value the source cannot hold. Aggregate element, key, and value types are invariant at aliasing sites. Clone explicitly (e.g. `[...xs]`, `{...m}`) or declare the destination with the source's exact element type."},
 }
 
 // --- Wrapper Functions ---
@@ -80,6 +81,10 @@ func errLetMissingTypeOrValue(pos lexer.Position) error {
 
 func errAliasImmutableAggregate(pos lexer.Position, src string) error {
 	return Errors["T051"].New(pos, src)
+}
+
+func errAliasWidensElement(pos lexer.Position, src string, srcT, dstT Type) error {
+	return Errors["T052"].New(pos, src, srcT, dstT)
 }
 
 func errTypeParamConflict(pos lexer.Position, name string, bound, attempt Type) error {

--- a/website/docs/mep/mep-0009.md
+++ b/website/docs/mep/mep-0009.md
@@ -39,8 +39,8 @@ Source counts taken at the snapshot date. Numbers are pairs of `.mochi` plus mat
 |----------------------------|-------|
 | tests/parser/valid         | 62    |
 | tests/parser/errors        | 28    |
-| tests/types/valid          | 64    |
-| tests/types/errors         | 71    |
+| tests/types/valid          | 67    |
+| tests/types/errors         | 74    |
 | tests/types/soundness      | 15    |
 | tests/queryplan            | small |
 | tests/interpreter          | many  |
@@ -139,9 +139,10 @@ Added in v0.12.0 (MEP-10, MEP-11, MEP-12):
 
 ```
 any_top_silent_widen, compare_int_string, compare_struct_int,
-match_missing_variant, mutate_through_let_alias, null_widening_int,
-null_widening_list, null_widening_struct, unit_assign_value,
-unknown_type_name, unknown_type_param
+list_alias_var_invariant, match_missing_variant,
+mutate_through_let_alias, null_widening_int, null_widening_list,
+null_widening_struct, unit_assign_value, unknown_type_name,
+unknown_type_param
 ```
 
 ### Coverage matrix
@@ -166,7 +167,7 @@ The matrix is a property-to-fixture mapping. A cell value of `existing` means at
 | Substitution, let bindings               | existing  | missing   |
 | Variance, function arg and result        | missing   | missing   |
 | Variance, list element read              | missing   | missing   |
-| Variance, list element write             | missing   | missing   |
+| Variance, list element write             | n/a       | existing  |
 | Variance, map key                        | missing   | missing   |
 | Variance, map value                      | missing   | missing   |
 | Parametricity, len                       | missing   | missing   |

--- a/website/docs/mep/mep-0010.md
+++ b/website/docs/mep/mep-0010.md
@@ -63,7 +63,7 @@ To opt in to sharing, declare the source as `var`. To break the alias explicitly
 
 **Original evidence.** `tests/types/valid/mutate_through_let_alias.mochi` used to pin the leak: the alias type-checked, and a write through the `var` mutated the `let` storage too.
 
-**Follow-up.** The "explicit clone" syntaxes (`[...xs]`, `{...m}`) are not yet a uniform language feature; today users rebuild the aggregate (`for x in xs { ... }`) or declare the source as `var`. The invariant-list-element half (B3) is still open; once it lands, both halves of the aliasing story are closed at the checker.
+**Follow-up.** The "explicit clone" syntaxes (`[...xs]`, `{...m}`) are not yet a uniform language feature; today users rebuild the aggregate (`for x in xs { ... }`) or declare the source as `var`. The invariant-list-element half (B3) landed alongside this rule, so both halves of the aliasing story are closed at the checker.
 
 #### A4. Match exhaustiveness not enforced (closed)
 
@@ -99,13 +99,15 @@ To opt in to sharing, declare the source as `var`. To break the alias explicitly
 
 **Plan.** Replace the cascade with a small lattice and join semantics so the result depends only on the operand kinds, not on which side they appear on.
 
-#### B3. List covariance without write protection
+#### B3. List covariance without write protection (closed)
 
-**Evidence.** `types/check.go:172-189`. `unify(ListType{Int}, ListType{Any})` succeeds without restricting writes.
+**Status.** Closed. At the `var` declaration site, when the initialiser is a bare identifier referring to an aliasable aggregate (list, map, struct), the destination type must equal the source type structurally rather than merely subtype it. The new binding shares storage with the source; a widened element type would let a later `ys[i] = ...` deposit a value the source's static type rejects, corrupting reads through the source name. Diagnostic is `T052` at `types/check.go` (the var-binding branch under `case s.Var != nil`).
 
-**Impact.** Once mutation through indices is tightened (A3), unsafe covariant aliasing becomes the next failure mode. Today the issue is masked because mutations slip through anyway.
+**Pinning fixture.** `tests/types/errors/list_alias_var_invariant.mochi` (`var ys: list<any> = xs` where `xs : list<int>`).
 
-**Plan.** After A3, treat list element type as invariant under aliasing. Allow read-only covariance only at expression positions that cannot be assigned through.
+**Follow-up.** The same protection at function call sites (passing `list<int>` into a parameter typed `list<any>` and then writing through the parameter) routes through MEP-11 function-arg variance and is covered when generic builtins (`push`, `append`, `concat`, `collect`) carry parametric element types rather than `list<any>`. The remaining surface is direct `Assign` of two aggregates of different element types; both aggregates are already individually-owned storage, so the alias only forms at the assignment point and is captured by the bare-ident rule on either side.
+
+**Original evidence.** `types/check.go:172-189`. `unify(ListType{Int}, ListType{Any})` succeeded without restricting writes. Combined with the elementContext carve-out in `assignableAt`, a `var ys: list<any> = xs` aliased `list<int>` storage and let writes through `ys` corrupt `xs`.
 
 #### B4. Pure flag enforcement narrow to query predicates
 


### PR DESCRIPTION
Closes #21346.

Rejects `var ys: list<any> = xs` where `xs : list<int>` (and analogous map / struct cases). Aliasing widens the source's element type and lets a later `ys[i] = ...` deposit a value the source's static type cannot hold, corrupting reads through the source name.

The check fires at `var` declarations when the initialiser is a bare identifier referring to an aliasable aggregate. It requires structural equality on aggregate element, key, and value types rather than subtype assignability. New diagnostic `T052`.

## Test plan

- [x] `tests/types/errors/list_alias_var_invariant.mochi` pins rejection
- [x] `go test ./...` clean