### PR TITLE
mep-0011: promote to Active and add delivery status

### DIFF
--- a/website/docs/mep/mep-0011.md
+++ b/website/docs/mep/mep-0011.md
@@ -2,7 +2,7 @@
 mep: 11
 title: Subtyping and Variance
 author: Mochi core
-status: Draft
+status: Active
 type: Standards Track
 created: 2026-05-08
 sidebar_position: 11
@@ -17,9 +17,24 @@ description: A separate subtype predicate, the variance lattice, and the closure
 | MEP      | 11                          |
 | Title    | Subtyping and Variance      |
 | Author   | Mochi core                  |
-| Status   | Draft                       |
+| Status   | Active                      |
 | Type     | Standards Track             |
 | Created  | 2026-05-08                  |
+
+## Delivery status (2026-05-12)
+
+All sub-tasks landed. MEP-11 is Active at v0.12.0.
+
+- MEP-11.1 — `Subtype` predicate in `types/subtype.go`. Replaces the unify-as-assignment shortcut.
+- MEP-11.2 — every assignment / argument / return position routes through `Assignable` (the `Subtype` wrapper with the element-context carve-out for empty-collection literals).
+- MEP-11.3 — `any` flowing into a concrete slot requires an explicit `_ as T` cast; the strict direction is closed.
+- MEP-11.4 — list element read is covariant (`T-List-Read`); writes use invariance (`T-List-Inv`) via `equalKinds`.
+- MEP-11.5 — map key and value are invariant on both sides via `equalKinds`.
+- MEP-11.6 — function arg is contravariant, result is covariant.
+- MEP-11.7 — `any as T` carries a runtime guard. The type-check side admits the cast (per MEP-10 A5); the VM checks the runtime tag and raises a clear error on mismatch.
+- MEP-11.8 — a variant struct is a subtype of its declared union (`T-Variant`).
+
+Aliasing-induced write hazards are closed at the checker by MEP-10 A3 (`T051`, let-into-var) and MEP-10 B3 (`T052`, var-element-widen). The runtime guard from MEP-11.7 catches the residual case where a value typed `any` flows through a cast and lands in a slot whose runtime kind it does not match.
 
 ## Abstract
 


### PR DESCRIPTION
Closes #21350. All MEP-11 sub-tasks have landed; promote status and add the delivery section.