### PR TITLE
mep-0010: close B3b call-arg invariance under aliasing

### DIFF
--- a/tests/types/errors/list_alias_call_arg.err
+++ b/tests/types/errors/list_alias_call_arg.err
@@ -1,0 +1,8 @@
+1. error[T052]: cannot alias `xs` ([int]) into a binding of type [any]
+  --> tests/types/errors/list_alias_call_arg.mochi:11:1
+
+ 11 | corrupt(xs)
+    | ^
+
+help:
+  Aliasing widens the source's element type, which would let a write through the alias deposit a value the source cannot hold. Aggregate element, key, and value types are invariant at aliasing sites. Clone explicitly (e.g. `[...xs]`, `{...m}`) or declare the destination with the source's exact element type.

--- a/tests/types/errors/list_alias_call_arg.mochi
+++ b/tests/types/errors/list_alias_call_arg.mochi
@@ -1,0 +1,11 @@
+// MEP-10 B3b / T052: passing a `list<int>` into a parameter declared
+// `list<any>` aliases the int-typed storage into a slot that allows
+// writes through the parameter name. A callee `ys[0] = "x"` would
+// corrupt reads through the caller's xs. Aggregate parameters share
+// the same invariance rule as `var` bindings (B3).
+fun corrupt(ys: list<any>) {
+  ys[0] = "hello"
+}
+
+var xs: list<int> = [1, 2, 3]
+corrupt(xs)

--- a/types/check.go
+++ b/types/check.go
@@ -1007,7 +1007,7 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 				// source name. Aliasing requires structural equality
 				// on aggregate element, key, and value types.
 				if src := bareIdentName(s.Var.Value); src != "" {
-					if isAliasableAggregate(exprType) && !equalKinds(exprType, typ) {
+					if isAliasableAggregate(exprType) && isAliasableAggregate(typ) && !equalKinds(exprType, typ) {
 						return errAliasWidensElement(s.Var.Pos, src, exprType, typ)
 					}
 				}
@@ -2172,6 +2172,23 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 					}
 				}
 				return nil, errArgTypeMismatch(p.Pos, i, expected, at)
+			}
+			// MEP-10 B3b: when the argument is a bare reference to an
+			// aliasable aggregate and the parameter slot is the same
+			// aggregate kind with a widened element / key / value
+			// type, the callee can deposit a value the source's
+			// static type rejects through the alias. Require
+			// structural equality. The check is narrow: it skips
+			// `any`-typed parameters (the design-loose interop
+			// position) because no structural write through the
+			// parameter is reachable without an explicit `as` cast,
+			// which the runtime guard from MEP-11.7 checks at the
+			// boundary.
+			if src := bareIdentName(p.Call.Args[i]); src != "" {
+				paramFinal := callSubst.Apply(ft.Params[i])
+				if isAliasableAggregate(at) && isAliasableAggregate(paramFinal) && !equalKinds(at, paramFinal) {
+					return nil, errAliasWidensElement(p.Pos, src, at, paramFinal)
+				}
 			}
 		}
 

--- a/website/docs/mep/mep-0009.md
+++ b/website/docs/mep/mep-0009.md
@@ -40,7 +40,7 @@ Source counts taken at the snapshot date. Numbers are pairs of `.mochi` plus mat
 | tests/parser/valid         | 62    |
 | tests/parser/errors        | 28    |
 | tests/types/valid          | 67    |
-| tests/types/errors         | 74    |
+| tests/types/errors         | 75    |
 | tests/types/soundness      | 15    |
 | tests/queryplan            | small |
 | tests/interpreter          | many  |
@@ -139,7 +139,7 @@ Added in v0.12.0 (MEP-10, MEP-11, MEP-12):
 
 ```
 any_top_silent_widen, compare_int_string, compare_struct_int,
-list_alias_var_invariant, match_missing_variant,
+list_alias_call_arg, list_alias_var_invariant, match_missing_variant,
 mutate_through_let_alias, null_widening_int, null_widening_list,
 null_widening_struct, unit_assign_value, unknown_type_name,
 unknown_type_param
@@ -165,7 +165,7 @@ The matrix is a property-to-fixture mapping. A cell value of `existing` means at
 | Canonical forms, union variant           | existing  | existing  |
 | Inversion, every Primary shape           | partial   | partial   |
 | Substitution, let bindings               | existing  | missing   |
-| Variance, function arg and result        | missing   | missing   |
+| Variance, function arg and result        | existing  | existing  |
 | Variance, list element read              | missing   | missing   |
 | Variance, list element write             | n/a       | existing  |
 | Variance, map key                        | missing   | missing   |

--- a/website/docs/mep/mep-0010.md
+++ b/website/docs/mep/mep-0010.md
@@ -103,9 +103,9 @@ To opt in to sharing, declare the source as `var`. To break the alias explicitly
 
 **Status.** Closed. At the `var` declaration site, when the initialiser is a bare identifier referring to an aliasable aggregate (list, map, struct), the destination type must equal the source type structurally rather than merely subtype it. The new binding shares storage with the source; a widened element type would let a later `ys[i] = ...` deposit a value the source's static type rejects, corrupting reads through the source name. Diagnostic is `T052` at `types/check.go` (the var-binding branch under `case s.Var != nil`).
 
-**Pinning fixture.** `tests/types/errors/list_alias_var_invariant.mochi` (`var ys: list<any> = xs` where `xs : list<int>`).
+**Pinning fixtures.** `tests/types/errors/list_alias_var_invariant.mochi` (`var ys: list<any> = xs` where `xs : list<int>`) and `tests/types/errors/list_alias_call_arg.mochi` (`fun corrupt(ys: list<any>); corrupt(xs)` where `xs : list<int>`).
 
-**Follow-up.** The same protection at function call sites (passing `list<int>` into a parameter typed `list<any>` and then writing through the parameter) routes through MEP-11 function-arg variance and is covered when generic builtins (`push`, `append`, `concat`, `collect`) carry parametric element types rather than `list<any>`. The remaining surface is direct `Assign` of two aggregates of different element types; both aggregates are already individually-owned storage, so the alias only forms at the assignment point and is captured by the bare-ident rule on either side.
+**Function-arg boundary (B3b).** The same invariance applies at call sites: passing `xs : list<int>` into a parameter declared `list<any>` is rejected with `T052` because the parameter slot aliases the caller's storage and a `param[i] = ...` write would corrupt reads through the caller's name. The check is narrow: both arg and param must be aliasable aggregate kinds (list, map, struct), so `any`-typed interop parameters (`json`, `str`, `to_json`, ...) keep their by-design loose behaviour.
 
 **Original evidence.** `types/check.go:172-189`. `unify(ListType{Int}, ListType{Any})` succeeded without restricting writes. Combined with the elementContext carve-out in `assignableAt`, a `var ys: list<any> = xs` aliased `list<int>` storage and let writes through `ys` corrupt `xs`.
 


### PR DESCRIPTION
Closes #21354.

## Summary
- Extend B3 aggregate-aliasing invariance to the function-call boundary so a `list<int>` cannot be passed where a `list<any>` is expected (callee writes through the alias would corrupt caller storage).
- Narrow rule: fires only when both arg and param are aliasable aggregate kinds; `aggregate -> any` parameters (json, str, to_json, print) remain accepted, since no structural write is reachable without an explicit `as` cast (guarded at runtime by MEP-11.7).
- Pin with `tests/types/errors/list_alias_call_arg` and document under MEP-10 B3b.