### PR TITLE
mep-0010: close B3c index/field aliasing widen hole

### DIFF
--- a/tests/types/errors/list_alias_index.err
+++ b/tests/types/errors/list_alias_index.err
@@ -1,0 +1,8 @@
+1. error[T052]: cannot alias `rows[...]` ([int]) into a binding of type [any]
+  --> tests/types/errors/list_alias_index.mochi:7:1
+
+  7 | var r: list<any> = rows[0]
+    | ^
+
+help:
+  Aliasing widens the source's element type, which would let a write through the alias deposit a value the source cannot hold. Aggregate element, key, and value types are invariant at aliasing sites. Clone explicitly (e.g. `[...xs]`, `{...m}`) or declare the destination with the source's exact element type.

--- a/tests/types/errors/list_alias_index.mochi
+++ b/tests/types/errors/list_alias_index.mochi
@@ -1,0 +1,7 @@
+// MEP-10 B3c / T052: indexing a `list<list<int>>` returns live storage
+// that aliases the inner row. Binding it to a `list<any>` var would
+// let a later `r[i] = "..."` widen the row's element type and corrupt
+// reads through the parent. Aliasing requires structural equality at
+// index and field reads, not just bare identifiers.
+var rows: list<list<int>> = [[1, 2], [3, 4]]
+var r: list<any> = rows[0]

--- a/types/check.go
+++ b/types/check.go
@@ -998,15 +998,16 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 				if !Assignable(exprType, typ) {
 					return errTypeMismatch(s.Var.Pos, typ, exprType)
 				}
-				// MEP-10 B3: when the source is a bare identifier
-				// referring to an aliasable aggregate, the new binding
-				// shares storage with the source. A widened element
-				// type (e.g. `list<int>` into `list<any>`) lets a
-				// later `ys[i] = ...` deposit a value the source's
-				// static type rejects, corrupting reads through the
-				// source name. Aliasing requires structural equality
-				// on aggregate element, key, and value types.
-				if src := bareIdentName(s.Var.Value); src != "" {
+				// MEP-10 B3 / B3c: when the source expression names
+				// live aggregate storage (bare identifier, an index
+				// chain like `rows[0]`, or a field chain like
+				// `obj.f`), the new binding shares storage with the
+				// source. A widened element type lets a later
+				// `ys[i] = ...` deposit a value the source's static
+				// type rejects, corrupting reads through the source.
+				// Aliasing requires structural equality on aggregate
+				// element, key, and value types.
+				if src := aliasSourceLabel(s.Var.Value); src != "" {
 					if isAliasableAggregate(exprType) && isAliasableAggregate(typ) && !equalKinds(exprType, typ) {
 						return errAliasWidensElement(s.Var.Pos, src, exprType, typ)
 					}
@@ -2173,18 +2174,19 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 				}
 				return nil, errArgTypeMismatch(p.Pos, i, expected, at)
 			}
-			// MEP-10 B3b: when the argument is a bare reference to an
-			// aliasable aggregate and the parameter slot is the same
-			// aggregate kind with a widened element / key / value
-			// type, the callee can deposit a value the source's
-			// static type rejects through the alias. Require
-			// structural equality. The check is narrow: it skips
+			// MEP-10 B3b / B3c: when the argument names live
+			// aggregate storage (bare ident, `rows[i]`, `obj.f`)
+			// and the parameter slot is the same aggregate kind
+			// with a widened element / key / value type, the
+			// callee can deposit a value the source's static type
+			// rejects through the alias. Require structural
+			// equality. The check is narrow: it skips
 			// `any`-typed parameters (the design-loose interop
 			// position) because no structural write through the
 			// parameter is reachable without an explicit `as` cast,
 			// which the runtime guard from MEP-11.7 checks at the
 			// boundary.
-			if src := bareIdentName(p.Call.Args[i]); src != "" {
+			if src := aliasSourceLabel(p.Call.Args[i]); src != "" {
 				paramFinal := callSubst.Apply(ft.Params[i])
 				if isAliasableAggregate(at) && isAliasableAggregate(paramFinal) && !equalKinds(at, paramFinal) {
 					return nil, errAliasWidensElement(p.Pos, src, at, paramFinal)
@@ -2600,6 +2602,46 @@ func bareIdentName(e *parser.Expr) string {
 		return ""
 	}
 	return sel.Root
+}
+
+// aliasSourceLabel returns a short human-readable name for the
+// aliasable source expression e: a bare identifier, an index chain
+// (`rows[0]`), or a field chain (`obj.f`). It returns "" when the
+// expression cannot name live storage (literals, calls, casts,
+// computed values). MEP-10 B3c uses this to widen B3 beyond bare
+// identifiers so index/field reads of aliasable aggregates also
+// reject element-widening alias targets.
+func aliasSourceLabel(e *parser.Expr) string {
+	if e == nil || e.Binary == nil || len(e.Binary.Right) != 0 {
+		return ""
+	}
+	u := e.Binary.Left
+	if u == nil || len(u.Ops) != 0 || u.Value == nil {
+		return ""
+	}
+	px := u.Value
+	if px.Target == nil {
+		return ""
+	}
+	sel := px.Target.Selector
+	if sel == nil {
+		return ""
+	}
+	label := sel.Root
+	for _, t := range sel.Tail {
+		label += "." + t
+	}
+	for _, op := range px.Ops {
+		switch {
+		case op.Field != nil:
+			label += "." + op.Field.Name
+		case op.Index != nil:
+			label += "[...]"
+		default:
+			return ""
+		}
+	}
+	return label
 }
 
 // firstFreeTypeVar returns the lexicographically first free TypeVar

--- a/website/docs/mep/mep-0009.md
+++ b/website/docs/mep/mep-0009.md
@@ -40,7 +40,7 @@ Source counts taken at the snapshot date. Numbers are pairs of `.mochi` plus mat
 | tests/parser/valid         | 62    |
 | tests/parser/errors        | 28    |
 | tests/types/valid          | 67    |
-| tests/types/errors         | 75    |
+| tests/types/errors         | 76    |
 | tests/types/soundness      | 15    |
 | tests/queryplan            | small |
 | tests/interpreter          | many  |
@@ -139,7 +139,7 @@ Added in v0.12.0 (MEP-10, MEP-11, MEP-12):
 
 ```
 any_top_silent_widen, compare_int_string, compare_struct_int,
-list_alias_call_arg, list_alias_var_invariant, match_missing_variant,
+list_alias_call_arg, list_alias_index, list_alias_var_invariant, match_missing_variant,
 mutate_through_let_alias, null_widening_int, null_widening_list,
 null_widening_struct, unit_assign_value, unknown_type_name,
 unknown_type_param

--- a/website/docs/mep/mep-0010.md
+++ b/website/docs/mep/mep-0010.md
@@ -107,6 +107,8 @@ To opt in to sharing, declare the source as `var`. To break the alias explicitly
 
 **Function-arg boundary (B3b).** The same invariance applies at call sites: passing `xs : list<int>` into a parameter declared `list<any>` is rejected with `T052` because the parameter slot aliases the caller's storage and a `param[i] = ...` write would corrupt reads through the caller's name. The check is narrow: both arg and param must be aliasable aggregate kinds (list, map, struct), so `any`-typed interop parameters (`json`, `str`, `to_json`, ...) keep their by-design loose behaviour.
 
+**Index and field reads (B3c).** Reads like `rows[0]` and `obj.items` return live storage that aliases the parent cell; `var r: list<any> = rows[0]` where `rows : list<list<int>>` and `corrupt(rows[0])` where `corrupt(ys: list<any>)` are now rejected with `T052` for the same reason. The check uses `aliasSourceLabel` so the diagnostic surfaces the read path (`rows[...]`, `obj.items`) instead of just an identifier. Pinning fixture: `tests/types/errors/list_alias_index.mochi`.
+
 **Original evidence.** `types/check.go:172-189`. `unify(ListType{Int}, ListType{Any})` succeeded without restricting writes. Combined with the elementContext carve-out in `assignableAt`, a `var ys: list<any> = xs` aliased `list<int>` storage and let writes through `ys` corrupt `xs`.
 
 #### B4. Pure flag enforcement narrow to query predicates


### PR DESCRIPTION
Closes #21356.

## Summary
- Extend T052 to index and field reads: `var r: list<any> = rows[0]` and `corrupt(rows[0])` rejected for the same reason as the bare-ident cases (parent storage aliased; widened element type lets a later write corrupt parent reads).
- New `aliasSourceLabel` helper surfaces the read path (`rows[...]`, `obj.items`) in the diagnostic.
- Pin with `tests/types/errors/list_alias_index.mochi`.