### PR TITLE
mep-0010: close B3d index/field LHS aliasing widen hole

### DIFF
--- a/tests/types/errors/list_alias_lhs_index.err
+++ b/tests/types/errors/list_alias_lhs_index.err
@@ -1,0 +1,8 @@
+1. error[T052]: cannot alias `xs` ([int]) into a binding of type [any]
+  --> tests/types/errors/list_alias_lhs_index.mochi:7:1
+
+  7 | bag[0] = xs
+    | ^
+
+help:
+  Aliasing widens the source's element type, which would let a write through the alias deposit a value the source cannot hold. Aggregate element, key, and value types are invariant at aliasing sites. Clone explicitly (e.g. `[...xs]`, `{...m}`) or declare the destination with the source's exact element type.

--- a/tests/types/errors/list_alias_lhs_index.mochi
+++ b/tests/types/errors/list_alias_lhs_index.mochi
@@ -1,0 +1,7 @@
+// MEP-10 B3d / T052: assigning a `list<int>` into a `list<any>` slot
+// reached via `bag[0]` aliases the int-typed storage into a slot whose
+// element type allows writes that the source cannot hold. A later
+// `bag[0][0] = "boom"` would corrupt reads through `xs`.
+var xs: list<int> = [1, 2, 3]
+var bag: list<list<any>> = [[]]
+bag[0] = xs

--- a/types/check.go
+++ b/types/check.go
@@ -1193,6 +1193,22 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 		if !unify(lhsType, rhsType, nil) {
 			return errCannotAssign(s.Assign.Pos, rhsType, s.Assign.Name, lhsType)
 		}
+		// MEP-10 B3d: when the LHS targets a slot reached through an
+		// index or field (`bag[i]`, `r.items`) and the RHS names live
+		// aggregate storage, the assignment aliases the RHS into a slot
+		// with a widened element type. A later write through
+		// `bag[i][j]` would deposit a value the RHS's static type
+		// rejects, corrupting reads through the RHS name. Require
+		// structural equality at the slot type. Fresh-value RHS
+		// (literals, calls, computed values) keep working since
+		// aliasSourceLabel only fires on live-storage paths.
+		if len(s.Assign.Index) > 0 || len(s.Assign.Field) > 0 {
+			if src := aliasSourceLabel(s.Assign.Value); src != "" {
+				if isAliasableAggregate(rhsType) && isAliasableAggregate(lhsType) && !equalKinds(rhsType, lhsType) {
+					return errAliasWidensElement(s.Assign.Pos, src, rhsType, lhsType)
+				}
+			}
+		}
 		if len(s.Assign.Index) == 0 && len(s.Assign.Field) == 0 {
 			if ContainsAny(rhsType) {
 				if _, ok := lhsType.(AnyType); ok {

--- a/website/docs/mep/mep-0010.md
+++ b/website/docs/mep/mep-0010.md
@@ -109,6 +109,8 @@ To opt in to sharing, declare the source as `var`. To break the alias explicitly
 
 **Index and field reads (B3c).** Reads like `rows[0]` and `obj.items` return live storage that aliases the parent cell; `var r: list<any> = rows[0]` where `rows : list<list<int>>` and `corrupt(rows[0])` where `corrupt(ys: list<any>)` are now rejected with `T052` for the same reason. The check uses `aliasSourceLabel` so the diagnostic surfaces the read path (`rows[...]`, `obj.items`) instead of just an identifier. Pinning fixture: `tests/types/errors/list_alias_index.mochi`.
 
+**Index and field assignment LHS (B3d).** Symmetric to B3c on the write side: `bag[0] = xs` where `bag : list<list<any>>` and `xs : list<int>` is rejected. The slot type widens the source's element type, and a later `bag[0][i] = ...` would corrupt reads through `xs`. The same applies to `obj.f = xs`. Pinning fixture: `tests/types/errors/list_alias_lhs_index.mochi`.
+
 **Original evidence.** `types/check.go:172-189`. `unify(ListType{Int}, ListType{Any})` succeeded without restricting writes. Combined with the elementContext carve-out in `assignableAt`, a `var ys: list<any> = xs` aliased `list<int>` storage and let writes through `ys` corrupt `xs`.
 
 #### B4. Pure flag enforcement narrow to query predicates


### PR DESCRIPTION
Closes #21358.

## Summary
- Reject `bag[0] = xs` where `bag : list<list<any>>` and `xs : list<int>` (T052). The slot type widens the source's element type, and a later `bag[0][i] = ...` would corrupt reads through xs. Same for `obj.f = xs`.
- Fires only when the LHS targets an index or field slot and the RHS names live aggregate storage. Fresh-value RHS (literals, calls, computed values) keep working.
- Pin with `tests/types/errors/list_alias_lhs_index.mochi`.