### PR TITLE
mep-0010: close B3e literal-element aliasing widen hole

### DIFF
--- a/tests/types/errors/list_alias_literal_elem.err
+++ b/tests/types/errors/list_alias_literal_elem.err
@@ -1,0 +1,8 @@
+1. error[T052]: cannot alias `xs` ([int]) into a binding of type [any]
+  --> tests/types/errors/list_alias_literal_elem.mochi:6:29
+
+  6 | var bag: list<list<any>> = [xs]
+    |                             ^
+
+help:
+  Aliasing widens the source's element type, which would let a write through the alias deposit a value the source cannot hold. Aggregate element, key, and value types are invariant at aliasing sites. Clone explicitly (e.g. `[...xs]`, `{...m}`) or declare the destination with the source's exact element type.

--- a/tests/types/errors/list_alias_literal_elem.mochi
+++ b/tests/types/errors/list_alias_literal_elem.mochi
@@ -1,0 +1,6 @@
+// MEP-10 B3e / T052: a list literal `[xs]` used as a `list<list<any>>`
+// stores a reference to xs inside bag. A later `bag[0][i] = "..."`
+// would corrupt reads through xs. Aggregate invariance applies to
+// element expressions inside literals at structural aggregate slots.
+var xs: list<int> = [1, 2, 3]
+var bag: list<list<any>> = [xs]

--- a/types/check.go
+++ b/types/check.go
@@ -1012,6 +1012,13 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 						return errAliasWidensElement(s.Var.Pos, src, exprType, typ)
 					}
 				}
+				// MEP-10 B3e: when the value is a list or map
+				// literal targeting a structural aggregate slot,
+				// reject element expressions that name live
+				// aggregate storage of a narrower element type.
+				if err := checkLiteralAliasElements(s.Var.Value, env, typ); err != nil {
+					return err
+				}
 			}
 		} else if s.Var.Value != nil {
 			var err error
@@ -1207,6 +1214,11 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 				if isAliasableAggregate(rhsType) && isAliasableAggregate(lhsType) && !equalKinds(rhsType, lhsType) {
 					return errAliasWidensElement(s.Assign.Pos, src, rhsType, lhsType)
 				}
+			}
+			// MEP-10 B3e at index/field LHS: literal RHS may still
+			// contain alias source elements (`bag[0] = [xs]`).
+			if err := checkLiteralAliasElements(s.Assign.Value, env, lhsType); err != nil {
+				return err
 			}
 		}
 		if len(s.Assign.Index) == 0 && len(s.Assign.Field) == 0 {
@@ -2658,6 +2670,74 @@ func aliasSourceLabel(e *parser.Expr) string {
 		}
 	}
 	return label
+}
+
+// checkLiteralAliasElements walks list and map literals in e and
+// rejects element expressions that name live aggregate storage
+// (via aliasSourceLabel) when the expected element / value type is
+// a structural aggregate widening the source's element type.
+// MEP-10 B3e: `var bag: list<list<any>> = [xs]` where `xs : list<int>`
+// stores a reference to xs in bag; a later `bag[0][i] = ...` would
+// corrupt reads through xs. Recurses into nested literals so deeper
+// shapes (`list<list<list<any>>>` from `[[xs]]`) are caught too.
+func checkLiteralAliasElements(e *parser.Expr, env *Env, expected Type) error {
+	if e == nil || e.Binary == nil || len(e.Binary.Right) != 0 {
+		return nil
+	}
+	u := e.Binary.Left
+	if u == nil || len(u.Ops) != 0 || u.Value == nil {
+		return nil
+	}
+	px := u.Value
+	if len(px.Ops) != 0 || px.Target == nil {
+		return nil
+	}
+	target := px.Target
+	switch et := expected.(type) {
+	case ListType:
+		if target.List == nil {
+			return nil
+		}
+		for _, el := range target.List.Elems {
+			if err := checkOneLiteralAliasElem(el, env, et.Elem); err != nil {
+				return err
+			}
+			if err := checkLiteralAliasElements(el, env, et.Elem); err != nil {
+				return err
+			}
+		}
+	case MapType:
+		if target.Map == nil {
+			return nil
+		}
+		for _, kv := range target.Map.Items {
+			if err := checkOneLiteralAliasElem(kv.Value, env, et.Value); err != nil {
+				return err
+			}
+			if err := checkLiteralAliasElements(kv.Value, env, et.Value); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func checkOneLiteralAliasElem(e *parser.Expr, env *Env, expected Type) error {
+	src := aliasSourceLabel(e)
+	if src == "" {
+		return nil
+	}
+	if !isAliasableAggregate(expected) {
+		return nil
+	}
+	actT, err := checkExpr(e, env)
+	if err != nil {
+		return nil
+	}
+	if isAliasableAggregate(actT) && !equalKinds(actT, expected) {
+		return errAliasWidensElement(e.Pos, src, actT, expected)
+	}
+	return nil
 }
 
 // firstFreeTypeVar returns the lexicographically first free TypeVar

--- a/website/docs/mep/mep-0010.md
+++ b/website/docs/mep/mep-0010.md
@@ -111,6 +111,8 @@ To opt in to sharing, declare the source as `var`. To break the alias explicitly
 
 **Index and field assignment LHS (B3d).** Symmetric to B3c on the write side: `bag[0] = xs` where `bag : list<list<any>>` and `xs : list<int>` is rejected. The slot type widens the source's element type, and a later `bag[0][i] = ...` would corrupt reads through `xs`. The same applies to `obj.f = xs`. Pinning fixture: `tests/types/errors/list_alias_lhs_index.mochi`.
 
+**Literal element positions (B3e).** A list or map literal whose element expressions name live aggregate storage is rejected when the target slot widens the source's element type. `var bag: list<list<any>> = [xs]` and `bag[0] = [xs]` where `xs : list<int>` are caught at the inner position via `checkLiteralAliasElements`, which recurses into nested literals. Fresh-value elements (other literals, calls, computed values) keep working. Pinning fixture: `tests/types/errors/list_alias_literal_elem.mochi`.
+
 **Original evidence.** `types/check.go:172-189`. `unify(ListType{Int}, ListType{Any})` succeeded without restricting writes. Combined with the elementContext carve-out in `assignableAt`, a `var ys: list<any> = xs` aliased `list<int>` storage and let writes through `ys` corrupt `xs`.
 
 #### B4. Pure flag enforcement narrow to query predicates


### PR DESCRIPTION
Closes #21360.

## Summary
- Recurse into list and map literals at structural aggregate slots; reject element expressions that name live aggregate storage of a narrower element type. Hooked into var binding and index/field assignment LHS.
- Rejects `var bag: list<list<any>> = [xs]` and `bag[0] = [xs]` where `xs : list<int>`. Nested forms also caught.
- Fresh-value elements (other literals, calls, computed values) keep working.
- Pin with `tests/types/errors/list_alias_literal_elem.mochi`.