### PR TITLE
parser: drop dead lexer.Position anchor in normalize.go

### DIFF
--- a/parser/normalize.go
+++ b/parser/normalize.go
@@ -689,6 +689,3 @@ func normalizeQueryExpr(q *QueryExpr) error {
 	}
 	return nil
 }
-
-// avoid unused import in case lexer.Position is needed in future templates.
-var _ = lexer.Position{}


### PR DESCRIPTION
## Summary
- Remove the trailing `var _ = lexer.Position{}` anchor; `lexer.Position` is already used as a parameter type in `validatePatternShape`.

Closes #21374

## Test plan
- [x] `go test ./parser/...`