### PR TITLE
mep-0013: sync doc with current state

### DIFF
--- a/website/docs/mep/mep-0013.md
+++ b/website/docs/mep/mep-0013.md
@@ -23,11 +23,27 @@ description: Struct and union typing rules, match exhaustiveness, irredundancy, 
 
 ## Abstract
 
-Mochi has product types (structs) and sum types (tagged unions). The grammar accepts both. Pattern matching exists but does not enforce exhaustiveness or irredundancy today. This MEP documents the typing rules, proposes the missing checks, and lists the fixtures that pin both the current behaviour and the target behaviour.
+Mochi has product types (structs) and sum types (tagged unions). The grammar accepts both. Pattern matching exists. Exhaustiveness on a union scrutinee is enforced; irredundancy is not. This MEP documents the typing rules, lists the fixtures that pin each obligation, and tracks the remaining gaps.
 
 ## Motivation
 
-Match exhaustiveness is the single largest class of type error that Mochi catches at runtime instead of at compile time. Adding a variant to a union and forgetting to update one of the matches on it produces a runtime crash that the type checker should have caught. This MEP closes that gap.
+A union with an unchecked match was the single largest class of type error that Mochi used to catch at runtime instead of at compile time. MEP-10 A4 closed the exhaustiveness half. The redundancy half (an arm that cannot fire because an earlier arm subsumes it) is still silently accepted. This MEP pins what is already in the checker and tracks the redundancy gap.
+
+## Status at a glance
+
+| Item                                                  | Status |
+|-------------------------------------------------------|--------|
+| Struct decl, literal, field access typing             | closed |
+| Struct literal with missing field                     | open (no pinning fixture) |
+| Struct literal with unknown field                     | open (covered by T026 at read sites; literal site needs a fixture) |
+| Union decl, variant constructor typing                | closed |
+| Variant constructor arity / field type mismatch       | partially pinned (`match_variant_arity`) |
+| Match result-type unification (MEP-5 [T-Match])       | closed |
+| Match exhaustiveness on union scrutinees (T050)       | closed (MEP-10 A4) |
+| Wildcard `_` covers remaining variants                | closed |
+| Match irredundancy (duplicate / unreachable arms)     | **open** |
+| Recursive variants (`type List = Cons(... List) \| Nil`) | works; needs pinning fixtures |
+| Generic ADTs (`type List<T> = ...`)                   | deferred (depends on MEP-12) |
 
 ## Specification
 
@@ -62,35 +78,44 @@ type Name = string
 
 The surface is documented in [MEP 2](/docs/mep/mep-0002) (grammar) and [MEP 3](/docs/mep/mep-0003) (AST). This MEP focuses on typing and pattern matching obligations.
 
-### Struct typing
+### Struct typing (closed)
 
-A struct declaration introduces:
+**Status.** Closed. A struct declaration introduces:
 
-- A `StructType` in the type environment under the declared name.
+- A `StructType` in the type environment under the declared name (`types/check.go` around the `case s.Type != nil` walk, lines around 859-925).
 - A constructor of type `fun(field1: T1, ...): Name` accessed as the type name in expression position.
 - A struct literal form `Name{field1: e1, field2: e2}`. Order is flexible; the literal matches by field name.
 
 Rules:
 
-- All fields must be present in a literal. There are no defaults today.
-- A field type mismatch raises `T008` or `T026` depending on shape.
 - Field access `s.f` requires `s : StructType{...}` containing `f`. Otherwise `T026` (unknown field) or `T027` (not a struct).
+- A field type mismatch in a literal raises `T008`.
 
-Methods (`type T { fun foo(...) }`) attach to the struct via the `Methods` map and become callable as `t.foo(...)`. The receiver is implicit.
+Methods (`type T { fun foo(...) }`) attach to the struct via the `Methods` map and become callable as `t.foo(...)`. The receiver is implicit; the second-pass method walk in the same code path inserts the field names and sibling methods into the method env.
 
-### Union typing
+**Pinning fixtures.** `tests/types/valid/struct_field_access.mochi` (literal + access flow), `tests/types/valid/user_types_basic.mochi`, `tests/types/valid/user_type_selector.mochi`, `tests/types/valid/nested_type_decl.mochi`; `tests/types/errors/struct_unknown_field_access.mochi`, `tests/types/errors/user_type_field_mismatch.mochi`, `tests/types/errors/not_struct_selector.mochi`.
 
-A union declaration introduces:
+**Follow-up.** Two literal-site obligations are not yet pinned by dedicated fixtures: a literal missing a declared field, and a literal naming a field that the struct does not declare. The checker should already reject both; an explicit fixture each turns "should already" into "is".
 
-- A `UnionType{Name, Variants}`.
+### Union typing (closed)
+
+**Status.** Closed. A union declaration introduces:
+
+- A `UnionType{Name, Variants, Order}` in the env (definition at `types/kinds.go:169`).
 - One constructor function per variant. `Circle(r: float) : Shape`.
 - Each variant is also a `StructType` under its name with the variant's fields, so `let c: Circle = Circle(1.0)` parses but the canonical type is `Shape`.
 
+The variants map is shared during the type decl walk so a variant can reference the union it belongs to. `type List = Cons(head: int, tail: List) | Nil` resolves cleanly.
+
 Rules:
 
-- A variant constructor must be called with the declared arity and field types.
-- A bare variant name (no parens) is rejected today, although the grammar may allow it. Document and pin the behaviour.
-- Recursion in variants (`type List = Cons(head: int, tail: List) | Nil`) is allowed because variants resolve in a shared map during the type decl walk.
+- A variant constructor must be called with the declared arity. Mismatch is `T008` (the constructor signature does not unify with the call).
+- A variant constructor must be called with matching field types. Same error path.
+- A bare variant name (no parens) in expression position is rejected at the type checker because the constructor has function type.
+
+**Pinning fixtures.** `tests/types/valid/match_union_variant.mochi`, `tests/types/valid/union_alias.mochi`, `tests/types/errors/match_variant_arity.mochi`.
+
+**Follow-up.** A dedicated `union_constructor_field_type` fixture (variant called with the right arity but the wrong field type) would round out the constructor obligation. A `recursive_list_length` fixture would pin the shared-variants resolution path.
 
 ### Match typing
 
@@ -103,99 +128,74 @@ Pattern shapes accepted today:
 - Underscore: matches anything, binds nothing.
 - Variant call: `Circle(r)`, `Rect(w, h)`. Matches a value of the named variant and binds field positions to the listed identifiers. The number of bindings must match the variant arity.
 
-Result type. The arm result type is the join of `ExprType(ri)`. With the current loose join this often degrades to `any` when arms differ. Tightening the join to a least upper bound is part of the v0.11.0 work.
+**Result type (closed).** MEP-5 [T-Match] requires every arm's result type to unify with the principal type. `checkMatchExpr` in `types/check_expr.go` (around lines 1138-1226) enforces this and emits `T008` on heterogeneous arms. Pinning fixtures: `tests/types/valid/match_expr.mochi`, `tests/types/valid/match_literal_pattern.mochi`, `tests/types/errors/match_result_mismatch.mochi`, `tests/types/errors/match_pattern_mismatch.mochi`.
 
-### Exhaustiveness
+### Exhaustiveness (closed, T050)
 
-Today: not enforced. A match on a `Shape` with only `Circle(_)` arms is accepted. The runtime raises an error when no arm matches.
-
-Target. Compute coverage during the match check:
-
-- For a scrutinee of `UnionType U`:
-  - Walk arms, mark each named variant covered.
-  - A bare identifier or underscore arm marks the rest covered, but only if it is the last arm.
-  - At the end, if any variant remains uncovered and there is no catch-all, raise an error with a list of missing variants.
-- For a scrutinee of any other type, exhaustiveness is not required. A wildcard or an identifier arm always covers the rest.
-
-The required diagnostic message:
+**Status.** Closed. `checkMatchExpr` walks the arms, marks each named variant as covered (call form `V(args)` via `matchedVariants[call.Func] = true`, bare-ident form via the lookup at the same site), and notes any wildcard `_` arm with `hasCatchAll`. After the arms loop, the missing-variant set is computed against `UnionType.Order`. If any variant remains uncovered and there is no catch-all, the match is rejected with `T050`.
 
 ```
-match is not exhaustive: missing cases for Square, Rect
+error[T050]: non-exhaustive match on union `Shape`: missing variant(s) `Triangle`
 ```
 
-### Irredundancy
+The diagnostic helper is `errMatchNonExhaustive` at `types/errors.go:290`, which renders the missing names as a comma-separated list with `and` before the last item.
 
-Detect arms that cannot match because an earlier arm subsumes them:
+**Pinning fixtures.** `tests/types/valid/match_union_exhaustive_wildcard.mochi`, `tests/types/errors/match_missing_variant.mochi`.
 
-- Two arms with the same literal pattern: error.
-- A wildcard before any variant arm: error (the variant arm is unreachable).
-- Two arms with the same variant pattern: error if the bindings are disjoint or if either arm has no guard. Since we do not have pattern guards yet, the duplicate case always fires the error.
+**Follow-up.** The multi-missing case (two or more variants uncovered) is not yet pinned by a dedicated fixture; we want to assert the diagnostic lists both names.
+
+### Irredundancy (open)
+
+**Status.** Not enforced. Today the checker silently accepts:
+
+- Two arms with the same variant pattern.
+- Two arms with the same literal pattern.
+- An arm after a wildcard `_` arm (or a bare-identifier catch-all). The later arm can never fire.
+
+**Target.** Reject all three with a dedicated diagnostic. The check fits next to the existing `matchedVariants` walk: if `matchedVariants[v]` is already true when an arm names `v`, the arm is redundant; if `hasCatchAll` becomes true and more arms follow, those arms are redundant. A literal-pattern duplicate scan needs structural equality on the pattern literal.
+
+We do not have pattern guards yet, so a duplicate pattern always fires the error: there is no `case x => x > 0` form that would let a later duplicate fire on a different predicate.
 
 ### Recursive ADTs
 
-Support `type List = Cons(head: int, tail: List) | Nil`. Tests:
+**Status.** Works in the checker. The shared `variants` map in the union decl walk (`types/check.go` around lines 926-960) means a variant body can resolve a type reference to the union it belongs to. The same path is used for both `type Tree = Leaf | Node(...)` and `type List = Cons(head: int, tail: List) | Nil`.
 
-- A literal `Cons(1, Cons(2, Nil))` type checks.
-- Length defined as a recursive function over the list type checks.
-- A match on the list with both variants covered is exhaustive.
-- A match missing `Nil` is rejected.
+**Pinning fixtures.** None today specifically for the recursive case; this is the largest fixture gap. A `recursive_list_length` (valid, defines `len` recursively over `Cons | Nil`) and a `recursive_match_missing_nil` (error, exhaustiveness catches the missing terminator) would close it.
 
-### Generic ADTs (future)
+### Generic ADTs (deferred)
 
 The grammar does not support `type List<T> = Cons(head: T, tail: List<T>) | Nil` today. The required pieces:
 
-- Generic type declaration syntax.
-- Generic constructor types parameterised by the type parameters.
-- Generic match patterns that accept a type argument list at the variant call.
+- Generic type declaration syntax (parser change).
+- Generic constructor types parameterised by the type parameters (`FuncType` already supports this through the polymorphism work).
+- Generic match patterns that accept a type argument list at the variant call (or infer it from the scrutinee).
 
-We mark this as future work. The parser changes are non-trivial and [MEP 12](/docs/mep/mep-0012) (polymorphism) needs to land first.
-
-### Fixtures to author
-
-Existing positive fixtures:
-
-- `user_types_basic`, `user_type_selector`, `nested_type_decl`, `match_expr`, `union_alias`, `match_union_variant`, `match_literal_pattern`, `struct_field_access`.
-
-New for v0.11.0:
-
-- `adt_struct_field_present_required` (error, missing field).
-- `adt_struct_extra_field` (error, unknown field, T026).
-- `adt_union_constructor_arity` (error, exists as `match_variant_arity`).
-- `adt_union_constructor_field_type` (error).
-- `adt_match_exhaustive_simple` (valid).
-- `adt_match_missing_one` (error, after enforcement lands).
-- `adt_match_missing_two` (error, after enforcement lands; checks both names appear in the message).
-- `adt_match_redundant_variant` (error, after irredundancy lands).
-- `adt_match_wildcard_before_variant` (error, after irredundancy lands).
-- `adt_match_wildcard_last_ok` (valid).
-- `adt_recursive_list_length` (valid).
-- `adt_recursive_match_missing_nil` (error).
+We mark this as deferred. The parser change is non-trivial and [MEP 12](/docs/mep/mep-0012) (polymorphism) needs to land first.
 
 ## Rationale
 
-Match exhaustiveness is the textbook benefit of sum types. Without it, a large part of the value of declaring a union evaporates. Irredundancy is the other half: redundant arms hide bugs.
+Match exhaustiveness is the textbook benefit of sum types. It landed under MEP-10 A4. Irredundancy is the remaining textbook half: redundant arms hide bugs, since the redundancy means the author thought a different value would arrive than the type can actually carry.
 
-Recursive types are necessary for any non-trivial use of unions. The shared-variants resolution path we already have makes this cheap to support.
+Recursive types are necessary for any non-trivial use of unions. The shared-variants resolution path already supports them; the only missing piece is the fixtures that pin the support.
 
-We defer generic ADTs because they require both grammar and inference work. [MEP 12](/docs/mep/mep-0012) needs to land first.
+We defer generic ADTs because they require both grammar and inference work. MEP-12 needs to land first.
 
 ## Backwards Compatibility
 
-Adding exhaustiveness checking is a breaking change for any program that relies on the runtime fall-through. Programs will need an explicit catch-all arm or coverage of every variant.
-
-Irredundancy rejection is also a breaking change but a smaller one: the redundant arms it rejects could not have fired in the first place.
+Exhaustiveness already shipped. Irredundancy rejection is a breaking change, but a small one: the redundant arms it would reject could never have fired in the first place.
 
 ## Reference Implementation
 
-- `types/check.go:1179-1207` — union type construction with shared variants map.
-- `types/check.go` around lines 2209 to 2284 — match arm walk.
-- Existing fixtures: `tests/types/valid/match_union_variant.mochi`, `tests/types/errors/match_variant_arity.mochi`.
+- `types/kinds.go:169` — `UnionType{Name, Variants, Order}`.
+- `types/check.go` `case s.Type != nil` walk (around lines 859-960) — struct and union construction. Union decls use a shared variants map so recursive references resolve correctly during the walk.
+- `types/check_expr.go` around lines 1138-1226 — `checkMatchExpr`: arm walk, `matchedVariants` map, `hasCatchAll` flag, and the post-loop `T050` emit against `UnionType.Order`.
+- `types/errors.go:290` — `errMatchNonExhaustive` (`T050` formatter).
 
 ## Open Questions
 
-- **Pattern guards.** `case x => x > 0`. Out of scope for v0.11.0; revisit if the test surface demands it.
+- **Pattern guards.** `case x => x > 0`. Out of scope; revisit if the test surface demands it.
 - **Or-patterns.** `Circle(_) | Square(_) => ...`. Useful for catch-some-but-not-all cases. Defer.
-- **Nested patterns.** `Cons(1, _)` over recursive types. Already partially supported; needs fixtures.
+- **Nested patterns.** `Cons(1, _)` over recursive types. Already partially supported; needs fixtures alongside the recursive-ADT pinning.
 
 ## References
 


### PR DESCRIPTION
## Summary
- Rewrite MEP-13 in the MEP-10 \`Status / Pinning fixtures / Follow-up\` style.
- Add a status table at the top: struct/union/match-result/exhaustiveness all closed; irredundancy and recursive-ADT pinning open; generic ADTs deferred.
- Replace fictional \`adt_*\` fixture names with the real names (\`match_union_variant\`, \`match_missing_variant\`, \`match_union_exhaustive_wildcard\`, \`match_variant_arity\`, etc).
- Refresh stale Reference Implementation line numbers (the file references are post-split: \`types/kinds.go\`, \`types/check.go\`, \`types/check_expr.go\`, \`types/errors.go\`).

Closes #21384

## Test plan
- [x] Doc-only change; no code touched.