### PR TITLE
MEP-13.2: enforce struct literal completeness

### DIFF
--- a/tests/types/errors/struct_literal_missing_field.err
+++ b/tests/types/errors/struct_literal_missing_field.err
@@ -1,0 +1,8 @@
+1. error[T053]: struct literal `Point` is missing required field(s) `y`
+  --> tests/types/errors/struct_literal_missing_field.mochi:10:16
+
+ 10 | let _: Point = Point{x: 3}
+    |                ^
+
+help:
+  Provide a value for every declared field. Mochi structs do not have field defaults.

--- a/tests/types/errors/struct_literal_missing_field.mochi
+++ b/tests/types/errors/struct_literal_missing_field.mochi
@@ -1,0 +1,10 @@
+// MEP-13 §Struct typing: every declared field must be supplied in a
+// struct literal. There are no field defaults today, so an omitted
+// field would leave the struct value with a missing slot that
+// downstream reads observe as `nil` at runtime.
+type Point {
+  x: int
+  y: int
+}
+
+let _: Point = Point{x: 3}

--- a/tests/types/errors/struct_literal_missing_fields_two.err
+++ b/tests/types/errors/struct_literal_missing_fields_two.err
@@ -1,0 +1,8 @@
+1. error[T053]: struct literal `Box` is missing required field(s) `h` and `d`
+  --> tests/types/errors/struct_literal_missing_fields_two.mochi:9:14
+
+  9 | let _: Box = Box{w: 1}
+    |              ^
+
+help:
+  Provide a value for every declared field. Mochi structs do not have field defaults.

--- a/tests/types/errors/struct_literal_missing_fields_two.mochi
+++ b/tests/types/errors/struct_literal_missing_fields_two.mochi
@@ -1,0 +1,9 @@
+// MEP-13 §Struct typing: when two or more fields are omitted, every
+// missing name appears in the diagnostic so the fix is mechanical.
+type Box {
+  w: int
+  h: int
+  d: int
+}
+
+let _: Box = Box{w: 1}

--- a/tests/types/errors/struct_literal_unknown_field.err
+++ b/tests/types/errors/struct_literal_unknown_field.err
@@ -1,0 +1,8 @@
+1. error[T026]: unknown field `z` on Point
+  --> tests/types/errors/struct_literal_unknown_field.mochi:9:16
+
+  9 | let _: Point = Point{x: 1, y: 2, z: 3}
+    |                ^
+
+help:
+  Check the struct definition for valid fields.

--- a/tests/types/errors/struct_literal_unknown_field.mochi
+++ b/tests/types/errors/struct_literal_unknown_field.mochi
@@ -1,0 +1,9 @@
+// MEP-13 §Struct typing: a struct literal that names a field the type
+// did not declare is rejected with T026. There is no implicit
+// extension of struct shape from literal context.
+type Point {
+  x: int
+  y: int
+}
+
+let _: Point = Point{x: 1, y: 2, z: 3}

--- a/types/check_expr.go
+++ b/types/check_expr.go
@@ -623,6 +623,7 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 			}
 			return MapType{Key: StringType{}, Value: AnyType{}}, nil
 		}
+		provided := make(map[string]bool, len(p.Struct.Fields))
 		for _, field := range p.Struct.Fields {
 			ft, ok := st.FieldType(field.Name)
 			if !ok {
@@ -635,6 +636,20 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 			if !unify(ft, valT, nil) {
 				return nil, errTypeMismatch(field.Value.Pos, ft, valT)
 			}
+			provided[field.Name] = true
+		}
+		// MEP-13 §Struct typing: every declared field must be provided.
+		// There are no field defaults today, so an omitted field would
+		// leave the struct value with a missing slot that downstream
+		// reads observe as nil.
+		var missing []string
+		for _, f := range st.Fields {
+			if !provided[f.Name] {
+				missing = append(missing, f.Name)
+			}
+		}
+		if len(missing) > 0 {
+			return nil, errStructMissingField(p.Pos, st.Name, missing)
 		}
 		return st, nil
 

--- a/types/errors.go
+++ b/types/errors.go
@@ -71,6 +71,7 @@ var Errors = map[string]diagnostic.Template{
 	"T048": {Code: "T048", Message: "type parameter `%s` escapes function result", Help: "The result type still mentions `%s` after argument unification. Constrain the parameter at a call argument or supply an explicit type argument."},
 	"T049": {Code: "T049", Message: "type argument arity mismatch for `%s`: expected %d, got %d", Help: "Supply exactly one type argument per declared type parameter."},
 	"T052": {Code: "T052", Message: "cannot alias `%s` (%s) into a binding of type %s", Help: "Aliasing widens the source's element type, which would let a write through the alias deposit a value the source cannot hold. Aggregate element, key, and value types are invariant at aliasing sites. Clone explicitly (e.g. `[...xs]`, `{...m}`) or declare the destination with the source's exact element type."},
+	"T053": {Code: "T053", Message: "struct literal `%s` is missing required field(s) %s", Help: "Provide a value for every declared field. Mochi structs do not have field defaults."},
 }
 
 // --- Wrapper Functions ---
@@ -285,6 +286,29 @@ func errIfCondBoolean(pos lexer.Position) error {
 
 func errInvalidCast(pos lexer.Position, from, to Type) error {
 	return Errors["T046"].New(pos, from, to)
+}
+
+func errStructMissingField(pos lexer.Position, structName string, missing []string) error {
+	var quoted []string
+	for _, name := range missing {
+		quoted = append(quoted, "`"+name+"`")
+	}
+	list := ""
+	switch len(quoted) {
+	case 1:
+		list = quoted[0]
+	case 2:
+		list = quoted[0] + " and " + quoted[1]
+	default:
+		for i, q := range quoted {
+			if i == len(quoted)-1 {
+				list += "and " + q
+			} else {
+				list += q + ", "
+			}
+		}
+	}
+	return Errors["T053"].New(pos, structName, list)
 }
 
 func errMatchNonExhaustive(pos lexer.Position, unionName string, missing []string) error {

--- a/website/docs/mep/mep-0013.md
+++ b/website/docs/mep/mep-0013.md
@@ -34,8 +34,8 @@ A union with an unchecked match was the single largest class of type error that 
 | Item                                                  | Status |
 |-------------------------------------------------------|--------|
 | Struct decl, literal, field access typing             | closed |
-| Struct literal with missing field                     | open (no pinning fixture) |
-| Struct literal with unknown field                     | open (covered by T026 at read sites; literal site needs a fixture) |
+| Struct literal with missing field (T053)              | closed |
+| Struct literal with unknown field (T026)              | closed |
 | Union decl, variant constructor typing                | closed |
 | Variant constructor arity / field type mismatch       | partially pinned (`match_variant_arity`) |
 | Match result-type unification (MEP-5 [T-Match])       | closed |
@@ -88,14 +88,13 @@ The surface is documented in [MEP 2](/docs/mep/mep-0002) (grammar) and [MEP 3](/
 
 Rules:
 
+- All fields must be present in a literal. Omitted fields raise `T053` (struct literal missing required field). There are no field defaults.
+- An unknown field name in a literal raises `T026`. A field value whose type does not unify with the declared field type raises `T008`.
 - Field access `s.f` requires `s : StructType{...}` containing `f`. Otherwise `T026` (unknown field) or `T027` (not a struct).
-- A field type mismatch in a literal raises `T008`.
 
 Methods (`type T { fun foo(...) }`) attach to the struct via the `Methods` map and become callable as `t.foo(...)`. The receiver is implicit; the second-pass method walk in the same code path inserts the field names and sibling methods into the method env.
 
-**Pinning fixtures.** `tests/types/valid/struct_field_access.mochi` (literal + access flow), `tests/types/valid/user_types_basic.mochi`, `tests/types/valid/user_type_selector.mochi`, `tests/types/valid/nested_type_decl.mochi`; `tests/types/errors/struct_unknown_field_access.mochi`, `tests/types/errors/user_type_field_mismatch.mochi`, `tests/types/errors/not_struct_selector.mochi`.
-
-**Follow-up.** Two literal-site obligations are not yet pinned by dedicated fixtures: a literal missing a declared field, and a literal naming a field that the struct does not declare. The checker should already reject both; an explicit fixture each turns "should already" into "is".
+**Pinning fixtures.** `tests/types/valid/struct_field_access.mochi` (literal + access flow), `tests/types/valid/user_types_basic.mochi`, `tests/types/valid/user_type_selector.mochi`, `tests/types/valid/nested_type_decl.mochi`; `tests/types/errors/struct_unknown_field_access.mochi`, `tests/types/errors/user_type_field_mismatch.mochi`, `tests/types/errors/not_struct_selector.mochi`, `tests/types/errors/struct_literal_missing_field.mochi`, `tests/types/errors/struct_literal_missing_fields_two.mochi`, `tests/types/errors/struct_literal_unknown_field.mochi`.
 
 ### Union typing (closed)
 
@@ -188,8 +187,9 @@ Exhaustiveness already shipped. Irredundancy rejection is a breaking change, but
 
 - `types/kinds.go:169` — `UnionType{Name, Variants, Order}`.
 - `types/check.go` `case s.Type != nil` walk (around lines 859-960) — struct and union construction. Union decls use a shared variants map so recursive references resolve correctly during the walk.
+- `types/check_expr.go` around line 615 — struct literal walk, completeness check (`T053`).
 - `types/check_expr.go` around lines 1138-1226 — `checkMatchExpr`: arm walk, `matchedVariants` map, `hasCatchAll` flag, and the post-loop `T050` emit against `UnionType.Order`.
-- `types/errors.go:290` — `errMatchNonExhaustive` (`T050` formatter).
+- `types/errors.go` — `errMatchNonExhaustive` (T050) and `errStructMissingField` (T053) formatters.
 
 ## Open Questions
 


### PR DESCRIPTION
Closes #21386.

A struct literal that omits any declared field now raises T053 with the missing names listed. Previously the check walked only provided fields and left omitted slots nil at runtime.

Three fixtures pin the behaviour: missing single field, multi-missing message format, and extra field still rejected via T026.