### PR TITLE
MEP-13.3: pin union constructor obligations

### DIFF
--- a/tests/types/errors/union_constructor_field_type.err
+++ b/tests/types/errors/union_constructor_field_type.err
@@ -1,0 +1,8 @@
+1. error[T008]: type mismatch: expected int, got string
+  --> tests/types/errors/union_constructor_field_type.mochi:9:23
+
+  9 | let c: Shape = Circle("not an int")
+    |                       ^
+
+help:
+  Change the value to match the expected type.

--- a/tests/types/errors/union_constructor_field_type.mochi
+++ b/tests/types/errors/union_constructor_field_type.mochi
@@ -1,0 +1,9 @@
+// MEP-13 §Union typing: a variant constructor called with the right
+// arity but a field value whose type does not unify with the declared
+// field type is rejected with T008. The constructor surface is a
+// FuncType, so this rides the standard call-argument check.
+type Shape =
+  Circle(r: int)
+| Square(s: int)
+
+let c: Shape = Circle("not an int")

--- a/tests/types/errors/union_constructor_too_many_args.err
+++ b/tests/types/errors/union_constructor_too_many_args.err
@@ -1,0 +1,8 @@
+1. error[T006]: too many arguments: expected 2, got 3
+  --> tests/types/errors/union_constructor_too_many_args.mochi:9:16
+
+  9 | let r: Shape = Rect(1, 2, 3)
+    |                ^
+
+help:
+  Remove extra arguments or update the function definition.

--- a/tests/types/errors/union_constructor_too_many_args.mochi
+++ b/tests/types/errors/union_constructor_too_many_args.mochi
@@ -1,0 +1,9 @@
+// MEP-13 §Union typing: a variant constructor called with more
+// arguments than declared is rejected with T006. The constructor
+// surface is a FuncType, so this is the same arity check that fires
+// on any non-variadic call.
+type Shape =
+  Circle(r: int)
+| Rect(w: int, h: int)
+
+let r: Shape = Rect(1, 2, 3)

--- a/website/docs/mep/mep-0013.md
+++ b/website/docs/mep/mep-0013.md
@@ -37,7 +37,7 @@ A union with an unchecked match was the single largest class of type error that 
 | Struct literal with missing field (T053)              | closed |
 | Struct literal with unknown field (T026)              | closed |
 | Union decl, variant constructor typing                | closed |
-| Variant constructor arity / field type mismatch       | partially pinned (`match_variant_arity`) |
+| Variant constructor arity / field type mismatch       | closed |
 | Match result-type unification (MEP-5 [T-Match])       | closed |
 | Match exhaustiveness on union scrutinees (T050)       | closed (MEP-10 A4) |
 | Wildcard `_` covers remaining variants                | closed |
@@ -112,9 +112,9 @@ Rules:
 - A variant constructor must be called with matching field types. Same error path.
 - A bare variant name (no parens) in expression position is rejected at the type checker because the constructor has function type.
 
-**Pinning fixtures.** `tests/types/valid/match_union_variant.mochi`, `tests/types/valid/union_alias.mochi`, `tests/types/errors/match_variant_arity.mochi`.
+**Pinning fixtures.** `tests/types/valid/match_union_variant.mochi`, `tests/types/valid/union_alias.mochi`, `tests/types/errors/match_variant_arity.mochi`, `tests/types/errors/union_constructor_field_type.mochi` (wrong field type, T008), `tests/types/errors/union_constructor_too_many_args.mochi` (over-arity, T006).
 
-**Follow-up.** A dedicated `union_constructor_field_type` fixture (variant called with the right arity but the wrong field type) would round out the constructor obligation. A `recursive_list_length` fixture would pin the shared-variants resolution path.
+**Follow-up.** A `recursive_list_length` fixture would pin the shared-variants resolution path.
 
 ### Match typing
 


### PR DESCRIPTION
Closes #21390.

Two fixtures pin the variant constructor call: wrong field type → T008, over-arity → T006. Both already worked; this turns "should already" into "is".