### PR TITLE
MEP-13.6: implement match irredundancy check

### DIFF
--- a/tests/types/errors/match_arm_after_wildcard.err
+++ b/tests/types/errors/match_arm_after_wildcard.err
@@ -1,0 +1,8 @@
+1. error[T054]: redundant match arm: arm after catch-all is unreachable
+  --> tests/types/errors/match_arm_after_wildcard.mochi:11:3
+
+ 11 |   Square(s) => s
+    |   ^
+
+help:
+  Remove the arm or merge it with the earlier arm it duplicates. Mochi does not have pattern guards, so duplicate patterns can never both fire.

--- a/tests/types/errors/match_arm_after_wildcard.mochi
+++ b/tests/types/errors/match_arm_after_wildcard.mochi
@@ -1,0 +1,12 @@
+// MEP-13 §Irredundancy: once a catch-all `_` arm has fired, every
+// later arm is unreachable. T054 rejects the unreachable arm so the
+// author either drops the dead arm or reorders it ahead of the
+// wildcard.
+type Shape = Circle(r: int) | Square(s: int)
+
+let v: Shape = Circle(1)
+let n: int = match v {
+  Circle(r) => r
+  _ => 0
+  Square(s) => s
+}

--- a/tests/types/errors/match_redundant_literal.err
+++ b/tests/types/errors/match_redundant_literal.err
@@ -1,0 +1,8 @@
+1. error[T054]: redundant match arm: duplicate literal pattern
+  --> tests/types/errors/match_redundant_literal.mochi:9:3
+
+  9 |   1 => "uno"
+    |   ^
+
+help:
+  Remove the arm or merge it with the earlier arm it duplicates. Mochi does not have pattern guards, so duplicate patterns can never both fire.

--- a/tests/types/errors/match_redundant_literal.mochi
+++ b/tests/types/errors/match_redundant_literal.mochi
@@ -1,0 +1,11 @@
+// MEP-13 §Irredundancy: a literal pattern that repeats one already
+// listed in an earlier arm is unreachable. Literal-equality patterns
+// have no guard form, so the duplicate cannot fire on a different
+// predicate; T054 rejects it.
+let x: int = 1
+let label: string = match x {
+  1 => "one"
+  2 => "two"
+  1 => "uno"
+  _ => "other"
+}

--- a/tests/types/errors/match_redundant_variant.err
+++ b/tests/types/errors/match_redundant_variant.err
@@ -1,0 +1,8 @@
+1. error[T054]: redundant match arm: duplicate variant `Circle`
+  --> tests/types/errors/match_redundant_variant.mochi:11:3
+
+ 11 |   Circle(x) => x
+    |   ^
+
+help:
+  Remove the arm or merge it with the earlier arm it duplicates. Mochi does not have pattern guards, so duplicate patterns can never both fire.

--- a/tests/types/errors/match_redundant_variant.mochi
+++ b/tests/types/errors/match_redundant_variant.mochi
@@ -1,0 +1,12 @@
+// MEP-13 §Irredundancy: a match arm that names a variant already
+// covered by an earlier arm is unreachable. Mochi does not have
+// pattern guards, so the duplicate can never fire on a different
+// predicate; T054 rejects it.
+type Shape = Circle(r: int) | Square(s: int)
+
+let v: Shape = Circle(1)
+let n: int = match v {
+  Circle(r) => r
+  Square(s) => s
+  Circle(x) => x
+}

--- a/types/check_expr.go
+++ b/types/check_expr.go
@@ -1152,8 +1152,16 @@ func checkMatchExpr(m *parser.MatchExpr, env *Env, expected Type) (Type, error) 
 	// matched explicitly.
 	matchedVariants := map[string]bool{}
 	hasCatchAll := false
+	// MEP-13 §Irredundancy: a literal pattern that repeats an earlier
+	// one is rejected, as are any arms that follow a catch-all. We do
+	// not have pattern guards, so two arms with the same pattern can
+	// never both fire.
+	seenLiterals := map[string]bool{}
 	for _, c := range m.Cases {
 		caseEnv := env
+		if hasCatchAll {
+			return nil, errMatchArmRedundant(c.Pos, "arm after catch-all is unreachable")
+		}
 		if call, ok := callPattern(c.Pattern); ok {
 			if ut, ok := env.FindUnionByVariant(call.Func); ok {
 				st := ut.Variants[call.Func]
@@ -1162,6 +1170,9 @@ func checkMatchExpr(m *parser.MatchExpr, env *Env, expected Type) (Type, error) 
 				}
 				if !unify(targetType, st, nil) {
 					return nil, errTypeMismatch(c.Pos, targetType, st)
+				}
+				if matchedVariants[call.Func] {
+					return nil, errMatchArmRedundant(c.Pos, "duplicate variant `"+call.Func+"`")
 				}
 				matchedVariants[call.Func] = true
 				child := NewEnv(env)
@@ -1177,6 +1188,9 @@ func checkMatchExpr(m *parser.MatchExpr, env *Env, expected Type) (Type, error) 
 				st := ut.Variants[ident]
 				if !unify(targetType, st, nil) {
 					return nil, errTypeMismatch(c.Pos, targetType, st)
+				}
+				if matchedVariants[ident] {
+					return nil, errMatchArmRedundant(c.Pos, "duplicate variant `"+ident+"`")
 				}
 				matchedVariants[ident] = true
 			} else if !isUnderscoreExpr(c.Pattern) {
@@ -1197,6 +1211,12 @@ func checkMatchExpr(m *parser.MatchExpr, env *Env, expected Type) (Type, error) 
 			}
 			if !unify(targetType, pType, nil) {
 				return nil, errTypeMismatch(c.Pos, targetType, pType)
+			}
+			if key := literalPatternKey(c.Pattern); key != "" {
+				if seenLiterals[key] {
+					return nil, errMatchArmRedundant(c.Pos, "duplicate literal pattern")
+				}
+				seenLiterals[key] = true
 			}
 		} else {
 			hasCatchAll = true
@@ -1993,6 +2013,42 @@ func checkBuiltinCall(name string, args []Type, pos lexer.Position) error {
 		return nil
 	}
 	return nil
+}
+
+// literalPatternKey returns a canonical string key for a literal pattern
+// in a match arm, or "" if e is not a literal. The key is used by the
+// MEP-13 §Irredundancy check to detect a duplicate literal pattern
+// across arms; the position is irrelevant for equality, only the
+// literal value matters.
+func literalPatternKey(e *parser.Expr) string {
+	if e == nil {
+		return ""
+	}
+	if len(e.Binary.Right) != 0 {
+		return ""
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return ""
+	}
+	p := u.Value
+	if len(p.Ops) != 0 || p.Target.Lit == nil {
+		return ""
+	}
+	lit := p.Target.Lit
+	switch {
+	case lit.Int != nil:
+		return fmt.Sprintf("int:%d", int(*lit.Int))
+	case lit.Float != nil:
+		return fmt.Sprintf("float:%v", *lit.Float)
+	case lit.Str != nil:
+		return fmt.Sprintf("str:%q", *lit.Str)
+	case lit.Bool != nil:
+		return fmt.Sprintf("bool:%v", bool(*lit.Bool))
+	case lit.Null:
+		return "null"
+	}
+	return ""
 }
 
 func callPattern(e *parser.Expr) (*parser.CallExpr, bool) {

--- a/types/errors.go
+++ b/types/errors.go
@@ -72,6 +72,7 @@ var Errors = map[string]diagnostic.Template{
 	"T049": {Code: "T049", Message: "type argument arity mismatch for `%s`: expected %d, got %d", Help: "Supply exactly one type argument per declared type parameter."},
 	"T052": {Code: "T052", Message: "cannot alias `%s` (%s) into a binding of type %s", Help: "Aliasing widens the source's element type, which would let a write through the alias deposit a value the source cannot hold. Aggregate element, key, and value types are invariant at aliasing sites. Clone explicitly (e.g. `[...xs]`, `{...m}`) or declare the destination with the source's exact element type."},
 	"T053": {Code: "T053", Message: "struct literal `%s` is missing required field(s) %s", Help: "Provide a value for every declared field. Mochi structs do not have field defaults."},
+	"T054": {Code: "T054", Message: "redundant match arm: %s", Help: "Remove the arm or merge it with the earlier arm it duplicates. Mochi does not have pattern guards, so duplicate patterns can never both fire."},
 }
 
 // --- Wrapper Functions ---
@@ -309,6 +310,10 @@ func errStructMissingField(pos lexer.Position, structName string, missing []stri
 		}
 	}
 	return Errors["T053"].New(pos, structName, list)
+}
+
+func errMatchArmRedundant(pos lexer.Position, reason string) error {
+	return Errors["T054"].New(pos, reason)
 }
 
 func errMatchNonExhaustive(pos lexer.Position, unionName string, missing []string) error {

--- a/website/docs/mep/mep-0013.md
+++ b/website/docs/mep/mep-0013.md
@@ -23,11 +23,11 @@ description: Struct and union typing rules, match exhaustiveness, irredundancy, 
 
 ## Abstract
 
-Mochi has product types (structs) and sum types (tagged unions). The grammar accepts both. Pattern matching exists. Exhaustiveness on a union scrutinee is enforced; irredundancy is not. This MEP documents the typing rules, lists the fixtures that pin each obligation, and tracks the remaining gaps.
+Mochi has product types (structs) and sum types (tagged unions). The grammar accepts both. Pattern matching is checked for exhaustiveness on a union scrutinee (T050) and for irredundancy on any scrutinee (T054). This MEP documents the typing rules and lists the fixtures that pin each obligation.
 
 ## Motivation
 
-A union with an unchecked match was the single largest class of type error that Mochi used to catch at runtime instead of at compile time. MEP-10 A4 closed the exhaustiveness half. The redundancy half (an arm that cannot fire because an earlier arm subsumes it) is still silently accepted. This MEP pins what is already in the checker and tracks the redundancy gap.
+A union with an unchecked match was the single largest class of type error that Mochi used to catch at runtime instead of at compile time. MEP-10 A4 closed the exhaustiveness half. MEP-13 closes the irredundancy half (an arm that cannot fire because an earlier arm subsumes it) and pins every shape of the struct- and union-typing surface with a dedicated fixture.
 
 ## Status at a glance
 
@@ -41,7 +41,7 @@ A union with an unchecked match was the single largest class of type error that 
 | Match result-type unification (MEP-5 [T-Match])       | closed |
 | Match exhaustiveness on union scrutinees (T050)       | closed (MEP-10 A4) |
 | Wildcard `_` covers remaining variants                | closed |
-| Match irredundancy (duplicate / unreachable arms)     | **open** |
+| Match irredundancy (duplicate / unreachable arms)     | closed (T054) |
 | Recursive variants (`type List = Cons(... List) \| Nil`) | works; needs pinning fixtures |
 | Generic ADTs (`type List<T> = ...`)                   | deferred (depends on MEP-12) |
 
@@ -143,17 +143,17 @@ The diagnostic helper is `errMatchNonExhaustive` at `types/errors.go:290`, which
 
 **Follow-up.** The multi-missing case (two or more variants uncovered) is not yet pinned by a dedicated fixture; we want to assert the diagnostic lists both names.
 
-### Irredundancy (open)
+### Irredundancy (closed, T054)
 
-**Status.** Not enforced. Today the checker silently accepts:
+**Status.** Closed. `checkMatchExpr` rejects three shapes of redundant arm with `T054`:
 
-- Two arms with the same variant pattern.
-- Two arms with the same literal pattern.
-- An arm after a wildcard `_` arm (or a bare-identifier catch-all). The later arm can never fire.
+- A variant pattern that names a variant already covered by an earlier arm. Detected at the same site that sets `matchedVariants[v] = true`; the second visit fires the error.
+- A literal pattern that repeats one already seen in an earlier arm. The `literalPatternKey` helper canonicalises the literal to a string key (`int:N`, `str:"..."`, `bool:true`, etc.) so the duplicate check is a map lookup.
+- An arm that follows a catch-all (wildcard `_` or bare-identifier catch-all). The check runs at the top of every arm walk: if `hasCatchAll` is already true, the arm is unreachable.
 
-**Target.** Reject all three with a dedicated diagnostic. The check fits next to the existing `matchedVariants` walk: if `matchedVariants[v]` is already true when an arm names `v`, the arm is redundant; if `hasCatchAll` becomes true and more arms follow, those arms are redundant. A literal-pattern duplicate scan needs structural equality on the pattern literal.
+Mochi does not have pattern guards, so a duplicate pattern can never fire on a different predicate; there is no `case x => x > 0` form that would let two arms with the same head pattern both be live.
 
-We do not have pattern guards yet, so a duplicate pattern always fires the error: there is no `case x => x > 0` form that would let a later duplicate fire on a different predicate.
+**Pinning fixtures.** `tests/types/errors/match_redundant_variant.mochi`, `tests/types/errors/match_redundant_literal.mochi`, `tests/types/errors/match_arm_after_wildcard.mochi`.
 
 ### Recursive ADTs
 
@@ -181,15 +181,16 @@ We defer generic ADTs because they require both grammar and inference work. MEP-
 
 ## Backwards Compatibility
 
-Exhaustiveness already shipped. Irredundancy rejection is a breaking change, but a small one: the redundant arms it would reject could never have fired in the first place.
+Exhaustiveness already shipped. Irredundancy rejection is a breaking change, but a small one: the redundant arms it now rejects could never have fired in the first place.
 
 ## Reference Implementation
 
 - `types/kinds.go:169` — `UnionType{Name, Variants, Order}`.
 - `types/check.go` `case s.Type != nil` walk (around lines 859-960) — struct and union construction. Union decls use a shared variants map so recursive references resolve correctly during the walk.
 - `types/check_expr.go` around line 615 — struct literal walk, completeness check (`T053`).
-- `types/check_expr.go` around lines 1138-1226 — `checkMatchExpr`: arm walk, `matchedVariants` map, `hasCatchAll` flag, and the post-loop `T050` emit against `UnionType.Order`.
-- `types/errors.go` — `errMatchNonExhaustive` (T050) and `errStructMissingField` (T053) formatters.
+- `types/check_expr.go` around lines 1138-1240 — `checkMatchExpr`: arm walk, `matchedVariants` map, `hasCatchAll` flag, `seenLiterals` map, irredundancy emits (`T054`), and the post-loop `T050` emit against `UnionType.Order`.
+- `types/check_expr.go` `literalPatternKey` — canonical string key for literal pattern equality.
+- `types/errors.go` — `errMatchNonExhaustive` (T050), `errStructMissingField` (T053), `errMatchArmRedundant` (T054) formatters.
 
 ## Open Questions
 


### PR DESCRIPTION
Closes #21394.

Three new redundancy shapes are rejected with T054: duplicate variant pattern, duplicate literal pattern, and any arm after a catch-all (\`_\` or bare-identifier catch-all). Mochi has no pattern guards, so duplicates can never fire on different predicates; the rejected arms were always dead code.

Three pinning fixtures land alongside the check.