### PR TITLE
MEP-14.1: sync doc with current state

### DIFF
--- a/website/docs/mep/mep-0014.md
+++ b/website/docs/mep/mep-0014.md
@@ -29,6 +29,27 @@ Mochi has LINQ-shaped query expressions: `from` ... `select` with optional `wher
 
 Queries are how a lot of real Mochi programs are written. The clause type rules touch most of the type system: list types, group types, predicates, ordered values. A single document with the rules per clause keeps the implementation honest.
 
+## Status at a glance
+
+| Item                                                              | Status |
+|-------------------------------------------------------------------|--------|
+| `from` source must be list/group (T032)                           | closed |
+| Additional `from` clauses (cross-join nested loops)               | closed |
+| `join` source must be list/group (T034)                           | closed |
+| `join ... on cond` requires bool (T035)                           | closed |
+| `where pred` requires bool (T033)                                 | closed |
+| Pure predicate in `where` and `having` (T044)                     | closed |
+| `group by ... into g`: group binding shape                        | closed |
+| `having pred` requires bool (T042)                                | closed |
+| Aggregate misuse: `sum`/`avg` on non-numeric (T038, T041)         | closed |
+| Aggregate misuse: `count` on non list/group (T037)                | closed |
+| Aggregate `avg(...): float`, `sum(...): T`, `count(...): int`     | closed |
+| Result shape: `[U]` where `U = ExprType(select)`                  | closed |
+| `skip n` and `take n` require `n : int`                           | **open** |
+| `sort by e` requires `e` of an ordered type                       | **open** |
+| `select distinct e` requires `e` of a hashable type               | **open** |
+| Left-join right-side binding becomes `Option<T>` (MEP-10 A2)      | deferred (depends on MEP-10) |
+
 ## Specification
 
 ### Surface
@@ -51,34 +72,32 @@ Required: `from` and `select`. Everything else is optional. The order is fixed b
 
 ### Type rules per clause
 
-`from x in xs` requires `xs : [T]`. Inside the body of the query, `x : T`. T032 fires when the source is not a list.
+`from x in xs` requires `xs : [T]`. Inside the body of the query, `x : T`. T032 fires when the source is not a list (or group, which also iterates as `T`).
 
 Additional `from y in ys` clauses behave like nested loops. The projection sees both `x` and `y` in scope. There is no implicit cross-join elision; the result enumerates the cartesian product unless joined.
 
 `join z in zs on cond` requires `zs : [U]` (T034) and `cond : bool` (T035). The join side modifier (`left`, `right`, `outer`) controls the cardinality of unmatched rows. A left join may produce `z = null` for unmatched outer rows; today this returns `any` because of [MEP 10](/docs/mep/mep-0010) A2.
 
-`where pred` requires `pred : bool` (T033). The body filters rows.
+`where pred` requires `pred : bool` (T033). Calls inside the predicate must be pure; impure calls raise T044.
 
-`group by k1, ..., kn into g` partitions by the key tuple and binds `g : group<K, T>` where `K` is the key type (a tuple if multiple) and `T` is the source row type. The `having` clause requires `bool` (T042).
+`group by k1, ..., kn into g` partitions by the key tuple and binds `g : group<K, T>` where `K` is the key type and `T` is the source row type. Today the key shape is special-cased: one expression keeps its source type, two `string` expressions form a `pair_string` struct, and any other multi-key shape falls back to `any`. The `having` clause requires `bool` (T042) and its calls must be pure (T044).
 
-`sort by expr`. The expression must be ordered. Today the checker accepts any expression and the runtime sorts using a generic comparator. Negation prefix (`-expr`) sorts descending. We should add a fixture asserting an unordered type (e.g. struct) is rejected, but that requires the comparator to type fail rather than silently fail.
+`sort by expr`. The expression must be ordered. Today the checker accepts any expression and the runtime sorts using a generic comparator. Negation prefix (`-expr`) sorts descending. **Open**: reject unordered expressions (structs without a declared comparator, list element types unless we lift the order to lexicographic) once the "ordered" trait is decided.
 
-`skip n` and `take n` require `n : int`.
+`skip n` and `take n` require `n : int`. **Open**: the checker accepts any expression today and the runtime coerces / errors.
 
 `select expr` returns `[U]` where `U = ExprType(expr)`. Inside `select` the iteration variables are in scope.
 
-`select distinct expr` is the same with deduplication. The element type must be hashable. Today the runtime falls back to string keys under the hood.
+`select distinct expr` is the same with deduplication. The element type must be hashable. Today the runtime falls back to a canonical string form. **Open**: constrain `select distinct` to types with a known canonical form once a hashable trait is decided.
 
 ### Aggregate operators
 
 These are functions that take a list or a group and return a scalar:
 
-- `count(g) : int`. Accepts list or group.
-- `sum(g) : T` where `T` is numeric.
-- `avg(g) : float` for ints, `bigrat` for big numerics.
-- `min(g) : T` and `max(g) : T` for ordered `T`.
-
-T037, T038, T041 cover misuse of the aggregates.
+- `count(g) : int`. Accepts list or group. Anything else raises T037.
+- `sum(g) : T` where `T` is numeric. Non-numeric raises T041. The element type is preserved (MEP-5 P2), so a `[bigint]` sum stays `bigint`.
+- `avg(g) : float` for numerics. Non-numeric raises T038.
+- `min(g) : T` and `max(g) : T` for ordered `T`. Today rejected only on non-numeric (`min/max() expects numeric expression`); a future MEP may broaden to ordered.
 
 ### Joins and cardinality
 
@@ -96,35 +115,26 @@ The current `null` behaviour falls under [MEP 10](/docs/mep/mep-0010) A2 (null i
 
 ### Group plan and types
 
-`group by k1, ..., kn into g`. Inside the rest of the query, `g` has type `group<K, T>` where `K` is the key tuple and `T` is the source row type. Aggregates over `g` are typed:
+`group by k1, ..., kn into g`. Inside the rest of the query, `g` has type `group<K, T>` where `K` is the key (single key for one expression, `pair_string` for two strings, `any` otherwise today) and `T` is the source row type. Aggregates over `g` are typed:
 
 - `count(g) : int`
 - `sum(g.field) : T` if `T : numeric`
-- `avg(g.field) : float | bigrat`
+- `avg(g.field) : float`
 - `min(g.field) : T`, `max(g.field) : T`
 
 The group plan builder lives at `types/query_plan_builder.go` and emits a structured plan that the runtime consumes. The plan is also golden-tested under `tests/queryplan/`.
 
-### Distinct
+### Distinct, sort, skip, take (open soundness)
 
-`select distinct e` deduplicates by structural equality on `e`. Today the runtime canonicalises through a string form. We should add an explicit hashing path once the type system has hashable bounds, or constrain `select distinct` to types with a known canonical form (primitives, lists of primitives, structs of primitives).
+These clauses are accepted by the checker without a per-clause type rule. They are the largest soundness gap in the query algebra today:
 
-### sort by
+- `select distinct e` deduplicates by structural equality on `e`. The runtime canonicalises through a string form. The checker does not constrain `e` at all.
+- `sort by e` orders the result by `e` ascending. The expression should be of an ordered type, but the checker accepts any expression.
+- `skip n` and `take n` should require `n : int` (and `n >= 0`). Today the checker accepts any expression.
 
-`sort by e` orders the result by `e` ascending. `sort by -e` reverses. The expression should be of an ordered type:
+The first cut targeted for closure is `skip`/`take` (well-defined, no trait machinery required). `sort by` and `distinct` need an ordered/hashable trait decision; they remain open in this MEP.
 
-- Numeric.
-- String.
-- Bool.
-- Tuple of ordered types.
-
-Today the checker accepts any expression. We should reject unordered expressions (structs without a declared comparator, list element types unless we lift the order to the lexicographic order) once the "ordered" trait is decided.
-
-### skip and take
-
-Both require `n : int` and `n >= 0`. Negative values cause runtime errors. Adding a runtime guard or rejecting at type check time when the expression is a literal negative number would be a small win.
-
-### Soundness obligations
+### Soundness obligations (current)
 
 - A query whose source is not a list raises T032.
 - A `where` whose predicate is not `bool` raises T033.
@@ -132,32 +142,23 @@ Both require `n : int` and `n >= 0`. Negative values cause runtime errors. Addin
 - An aggregate misuse raises T037, T038, or T041.
 - The result type of a query is `[U]` where `U` is the projected type.
 
-Targets:
+### Soundness targets
 
-- Reject sort expressions with unordered types.
-- Reject join with non-list right-hand side.
+- Reject `sort by` on unordered types.
+- Reject `select distinct` on non-hashable types.
 - Reject `take` and `skip` with non-int.
 
-### Fixtures to author
+### Fixtures
 
-Existing:
+Existing (committed in `tests/types/`):
 
-- `query_source_not_list`, `join_on_not_bool`, `join_source_not_list`, `count_invalid_type`, `avg_non_numeric`, `query_basic_select`, `query_sort_take`.
+- Valid: `query_basic_select`, `query_sort_take`, `join_basic`, `join_multi`.
+- Error: `query_source_not_list` (T032), `join_on_not_bool` (T035), `join_source_not_list` (T034), `count_invalid_type` (T037), `avg_non_numeric` (T038).
 
-New:
+Pinning gaps (closure plan):
 
-- `query_select_struct_proj` (valid).
-- `query_where_bool_required` (error).
-- `query_take_int_required` (error).
-- `query_skip_int_required` (error).
-- `query_distinct_int` (valid).
-- `query_distinct_struct_canonical` (valid; pinned current behaviour).
-- `query_join_inner_cardinality` (valid, snapshots row count).
-- `query_join_left_unmatched_null` (valid, current behaviour pre A2).
-- `query_join_outer_both_sides` (valid).
-- `query_group_having_bool_required` (error).
-- `query_group_aggregate_int_sum` (valid).
-- `query_group_aggregate_avg_float` (valid).
+- Valid: `query_select_struct_proj`, `query_distinct_int`, `query_distinct_struct_canonical`, `query_join_inner_cardinality`, `query_join_left_unmatched_null`, `query_join_outer_both_sides`, `query_group_aggregate_int_sum`, `query_group_aggregate_avg_float`.
+- Error: `query_where_bool_required` (T033), `query_group_having_bool_required` (T042), `query_take_int_required` (new code), `query_skip_int_required` (new code).
 
 ## Rationale
 
@@ -167,12 +168,13 @@ The `null`-from-left-join hack is a known wart. Once [MEP 10](/docs/mep/mep-0010
 
 ## Backwards Compatibility
 
-Tightening sort, distinct, and skip/take to type-check at compile time is a breaking change for programs that rely on the loose runtime semantics. We pin the current behaviour in fixtures.
+Tightening sort, distinct, and skip/take to type-check at compile time is a breaking change for programs that rely on the loose runtime semantics. We pin the current behaviour in fixtures before tightening, so the closure for each gap is visible as a diff against a known baseline.
 
 ## Reference Implementation
 
-- `types/check.go` — query type checking entry points.
+- `types/check_expr.go:1252` — `checkQueryExpr`: source, from, join, where, group, having, and aggregate select; emits T032, T033, T034, T035, T037, T038, T041, T042, T044.
 - `types/query_plan_builder.go` — group plan construction.
+- `types/errors.go` — query-related diagnostic helpers (`errQuerySourceList`, `errWhereBoolean`, `errJoinSourceList`, `errJoinOnBoolean`, `errHavingBoolean`, `errSumOperand`, `errImpurePredicate`).
 - `tests/queryplan/` — golden tests for the plan.
 
 ## Open Questions


### PR DESCRIPTION
## Summary
- Add a Status-at-a-glance table to MEP-14 (eight clauses closed; skip/take/sort/distinct openly unenforced)
- Fix stale Reference Implementation pointer: `types/check.go` → `types/check_expr.go:1252` after the recent types split
- Document existing T037/T044 obligations and the group-key shape special cases

Doc-only. No behaviour change. Tracking: #21396.

## Test plan
- [x] `mep-0014.md` renders