### PR TITLE
MEP-14.2: pin query obligations not yet covered

### DIFF
--- a/tests/types/errors/query_group_having_bool_required.err
+++ b/tests/types/errors/query_group_having_bool_required.err
@@ -1,0 +1,8 @@
+1. error[T008]: type mismatch: expected bool, got group
+  --> tests/types/errors/query_group_having_bool_required.mochi:8:18
+
+  8 |           having g
+    |                  ^
+
+help:
+  Change the value to match the expected type.

--- a/tests/types/errors/query_group_having_bool_required.mochi
+++ b/tests/types/errors/query_group_having_bool_required.mochi
@@ -1,0 +1,9 @@
+// `having` predicate inside `group by` must be `bool`. MEP-14 lists this
+// as T042 but today `checkExprWithExpected` short-circuits with T008
+// first. The fixture pins the actual diagnostic until the T042 path is
+// reached.
+let xs: list<int> = [1, 2, 3]
+let bad = from x in xs
+          group by x % 2 into g
+          having g
+          select g

--- a/tests/types/errors/query_where_bool_required.err
+++ b/tests/types/errors/query_where_bool_required.err
@@ -1,0 +1,8 @@
+1. error[T008]: type mismatch: expected bool, got int
+  --> tests/types/errors/query_where_bool_required.mochi:5:30
+
+  5 | let bad = from x in xs where x select x
+    |                              ^
+
+help:
+  Change the value to match the expected type.

--- a/tests/types/errors/query_where_bool_required.mochi
+++ b/tests/types/errors/query_where_bool_required.mochi
@@ -1,0 +1,5 @@
+// Query `where` predicate must be `bool`. MEP-14 lists this as T033 but
+// today `checkExprWithExpected` short-circuits with T008 first. The
+// fixture pins the actual diagnostic until the T033 path is reached.
+let xs: list<int> = [1, 2, 3]
+let bad = from x in xs where x select x

--- a/tests/types/valid/query_distinct_int.golden
+++ b/tests/types/valid/query_distinct_int.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/query_distinct_int.mochi
+++ b/tests/types/valid/query_distinct_int.mochi
@@ -1,0 +1,6 @@
+// `select distinct` deduplicates the projection. Today the checker
+// imposes no hashable constraint on the element type; int is the
+// trivially safe case.
+let xs: list<int> = [1, 2, 1, 3, 2, 3]
+let uniq: list<int> = from x in xs select distinct x
+expect count(uniq) == 3

--- a/tests/types/valid/query_join_inner_cardinality.golden
+++ b/tests/types/valid/query_join_inner_cardinality.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/query_join_inner_cardinality.mochi
+++ b/tests/types/valid/query_join_inner_cardinality.mochi
@@ -1,0 +1,10 @@
+// Inner join cardinality: result rows = intersection of matches.
+// Two left rows, two right rows, both match: result has two rows.
+type Order { id: int, cid: int }
+type Cust  { id: int, name: string }
+let orders: list<Order> = [Order{id: 1, cid: 10}, Order{id: 2, cid: 20}]
+let custs:  list<Cust>  = [Cust{id: 10, name: "a"}, Cust{id: 20, name: "b"}]
+let joined = from o in orders
+             join c in custs on o.cid == c.id
+             select {oid: o.id, name: c.name}
+expect count(joined) == 2

--- a/tests/types/valid/query_select_struct_proj.golden
+++ b/tests/types/valid/query_select_struct_proj.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/query_select_struct_proj.mochi
+++ b/tests/types/valid/query_select_struct_proj.mochi
@@ -1,0 +1,10 @@
+// Query projection into a struct: the result is `[Pair]` where Pair is
+// the anonymous struct shape (MEP-14, MEP-5 P2).
+type Pair { x: int, y: int }
+let xs: list<int> = [1, 2, 3]
+let ys: list<int> = [10, 20, 30]
+let pairs: list<Pair> = from a in xs
+                        from b in ys
+                        where a + b == 13
+                        select Pair{x: a, y: b}
+expect count(pairs) == 3


### PR DESCRIPTION
## Summary
- Five new fixtures (three valid, two error) pinning current behaviour of `checkQueryExpr` paths that the suite did not exercise
- Surfaces a real gap: non-bool `where`/`having` predicates raise **T008**, not the T033/T042 codes MEP-14 lists. Fixture comments flag the gap.

Tracking: #21398.

## Test plan
- [x] `go test ./types/`