### PR TITLE
MEP-14.3: reject non-int skip/take in queries

### DIFF
--- a/tests/types/errors/query_skip_int_required.err
+++ b/tests/types/errors/query_skip_int_required.err
@@ -1,0 +1,8 @@
+1. error[T055]: `skip` operand must be `int`, got float
+  --> tests/types/errors/query_skip_int_required.mochi:3:29
+
+  3 | let bad = from x in xs skip 1.5 select x
+    |                             ^
+
+help:
+  `skip` and `take` count rows; supply an integer expression.

--- a/tests/types/errors/query_skip_int_required.mochi
+++ b/tests/types/errors/query_skip_int_required.mochi
@@ -1,0 +1,3 @@
+// `skip` counts rows; the operand must be `int` (T055).
+let xs: list<int> = [1, 2, 3]
+let bad = from x in xs skip 1.5 select x

--- a/tests/types/errors/query_take_int_required.err
+++ b/tests/types/errors/query_take_int_required.err
@@ -1,0 +1,8 @@
+1. error[T055]: `take` operand must be `int`, got string
+  --> tests/types/errors/query_take_int_required.mochi:3:29
+
+  3 | let bad = from x in xs take "two" select x
+    |                             ^
+
+help:
+  `skip` and `take` count rows; supply an integer expression.

--- a/tests/types/errors/query_take_int_required.mochi
+++ b/tests/types/errors/query_take_int_required.mochi
@@ -1,0 +1,3 @@
+// `take` counts rows; the operand must be `int` (T055).
+let xs: list<int> = [1, 2, 3]
+let bad = from x in xs take "two" select x

--- a/types/check_expr.go
+++ b/types/check_expr.go
@@ -1340,6 +1340,25 @@ func checkQueryExpr(q *parser.QueryExpr, env *Env, expected Type) (Type, error) 
 		}
 	}
 
+	if q.Skip != nil {
+		skipT, err := checkExpr(q.Skip, child)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := skipT.(AnyType); !ok && !unify(skipT, IntType{}, nil) {
+			return nil, errSkipTakeIntOperand(q.Skip.Pos, "skip", skipT)
+		}
+	}
+	if q.Take != nil {
+		takeT, err := checkExpr(q.Take, child)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := takeT.(AnyType); !ok && !unify(takeT, IntType{}, nil) {
+			return nil, errSkipTakeIntOperand(q.Take.Pos, "take", takeT)
+		}
+	}
+
 	var selT Type
 	if q.Group != nil {
 		var keyT Type

--- a/types/errors.go
+++ b/types/errors.go
@@ -73,6 +73,7 @@ var Errors = map[string]diagnostic.Template{
 	"T052": {Code: "T052", Message: "cannot alias `%s` (%s) into a binding of type %s", Help: "Aliasing widens the source's element type, which would let a write through the alias deposit a value the source cannot hold. Aggregate element, key, and value types are invariant at aliasing sites. Clone explicitly (e.g. `[...xs]`, `{...m}`) or declare the destination with the source's exact element type."},
 	"T053": {Code: "T053", Message: "struct literal `%s` is missing required field(s) %s", Help: "Provide a value for every declared field. Mochi structs do not have field defaults."},
 	"T054": {Code: "T054", Message: "redundant match arm: %s", Help: "Remove the arm or merge it with the earlier arm it duplicates. Mochi does not have pattern guards, so duplicate patterns can never both fire."},
+	"T055": {Code: "T055", Message: "`%s` operand must be `int`, got %s", Help: "`skip` and `take` count rows; supply an integer expression."},
 }
 
 // --- Wrapper Functions ---
@@ -314,6 +315,10 @@ func errStructMissingField(pos lexer.Position, structName string, missing []stri
 
 func errMatchArmRedundant(pos lexer.Position, reason string) error {
 	return Errors["T054"].New(pos, reason)
+}
+
+func errSkipTakeIntOperand(pos lexer.Position, clause string, got Type) error {
+	return Errors["T055"].New(pos, clause, got)
 }
 
 func errMatchNonExhaustive(pos lexer.Position, unionName string, missing []string) error {

--- a/website/docs/mep/mep-0014.md
+++ b/website/docs/mep/mep-0014.md
@@ -45,7 +45,7 @@ Queries are how a lot of real Mochi programs are written. The clause type rules 
 | Aggregate misuse: `count` on non list/group (T037)                | closed |
 | Aggregate `avg(...): float`, `sum(...): T`, `count(...): int`     | closed |
 | Result shape: `[U]` where `U = ExprType(select)`                  | closed |
-| `skip n` and `take n` require `n : int`                           | **open** |
+| `skip n` and `take n` require `n : int` (T055)                    | closed |
 | `sort by e` requires `e` of an ordered type                       | **open** |
 | `select distinct e` requires `e` of a hashable type               | **open** |
 | Left-join right-side binding becomes `Option<T>` (MEP-10 A2)      | deferred (depends on MEP-10) |
@@ -84,7 +84,7 @@ Additional `from y in ys` clauses behave like nested loops. The projection sees 
 
 `sort by expr`. The expression must be ordered. Today the checker accepts any expression and the runtime sorts using a generic comparator. Negation prefix (`-expr`) sorts descending. **Open**: reject unordered expressions (structs without a declared comparator, list element types unless we lift the order to lexicographic) once the "ordered" trait is decided.
 
-`skip n` and `take n` require `n : int`. **Open**: the checker accepts any expression today and the runtime coerces / errors.
+`skip n` and `take n` require `n : int` (T055). The checker rejects non-int operands at compile time. `any` is allowed through (consistent with MEP-10 A2 escape hatch).
 
 `select expr` returns `[U]` where `U = ExprType(expr)`. Inside `select` the iteration variables are in scope.
 
@@ -124,15 +124,14 @@ The current `null` behaviour falls under [MEP 10](/docs/mep/mep-0010) A2 (null i
 
 The group plan builder lives at `types/query_plan_builder.go` and emits a structured plan that the runtime consumes. The plan is also golden-tested under `tests/queryplan/`.
 
-### Distinct, sort, skip, take (open soundness)
+### Distinct and sort (open soundness)
 
-These clauses are accepted by the checker without a per-clause type rule. They are the largest soundness gap in the query algebra today:
+These clauses are accepted by the checker without a per-clause type rule:
 
 - `select distinct e` deduplicates by structural equality on `e`. The runtime canonicalises through a string form. The checker does not constrain `e` at all.
 - `sort by e` orders the result by `e` ascending. The expression should be of an ordered type, but the checker accepts any expression.
-- `skip n` and `take n` should require `n : int` (and `n >= 0`). Today the checker accepts any expression.
 
-The first cut targeted for closure is `skip`/`take` (well-defined, no trait machinery required). `sort by` and `distinct` need an ordered/hashable trait decision; they remain open in this MEP.
+Both need an ordered/hashable trait decision; they remain open in this MEP. `skip` and `take` are closed under T055.
 
 ### Soundness obligations (current)
 
@@ -146,19 +145,18 @@ The first cut targeted for closure is `skip`/`take` (well-defined, no trait mach
 
 - Reject `sort by` on unordered types.
 - Reject `select distinct` on non-hashable types.
-- Reject `take` and `skip` with non-int.
 
 ### Fixtures
 
 Existing (committed in `tests/types/`):
 
-- Valid: `query_basic_select`, `query_sort_take`, `join_basic`, `join_multi`.
-- Error: `query_source_not_list` (T032), `join_on_not_bool` (T035), `join_source_not_list` (T034), `count_invalid_type` (T037), `avg_non_numeric` (T038).
+- Valid: `query_basic_select`, `query_sort_take`, `query_select_struct_proj`, `query_distinct_int`, `query_join_inner_cardinality`, `join_basic`, `join_multi`.
+- Error: `query_source_not_list` (T032), `query_where_bool_required` (current: T008, target: T033), `join_source_not_list` (T034), `join_on_not_bool` (T035), `count_invalid_type` (T037), `avg_non_numeric` (T038), `query_group_having_bool_required` (current: T008, target: T042), `query_take_int_required` (T055), `query_skip_int_required` (T055).
 
 Pinning gaps (closure plan):
 
-- Valid: `query_select_struct_proj`, `query_distinct_int`, `query_distinct_struct_canonical`, `query_join_inner_cardinality`, `query_join_left_unmatched_null`, `query_join_outer_both_sides`, `query_group_aggregate_int_sum`, `query_group_aggregate_avg_float`.
-- Error: `query_where_bool_required` (T033), `query_group_having_bool_required` (T042), `query_take_int_required` (new code), `query_skip_int_required` (new code).
+- Valid: `query_distinct_struct_canonical`, `query_join_left_unmatched_null`, `query_join_outer_both_sides`, `query_group_aggregate_int_sum`, `query_group_aggregate_avg_float` (the last two block on a separate checker bug: grouped aggregate projection currently returns scalar rather than `[T]`).
+- Error: a follow-up collapses the dead T033/T042 branches into the expected-type path so the specific code fires instead of T008.
 
 ## Rationale
 
@@ -168,13 +166,13 @@ The `null`-from-left-join hack is a known wart. Once [MEP 10](/docs/mep/mep-0010
 
 ## Backwards Compatibility
 
-Tightening sort, distinct, and skip/take to type-check at compile time is a breaking change for programs that rely on the loose runtime semantics. We pin the current behaviour in fixtures before tightening, so the closure for each gap is visible as a diff against a known baseline.
+Tightening sort and distinct to type-check at compile time is a breaking change for programs that rely on the loose runtime semantics. We pin the current behaviour in fixtures before tightening, so the closure for each gap is visible as a diff against a known baseline. `skip`/`take` (T055) already shipped under that pattern.
 
 ## Reference Implementation
 
-- `types/check_expr.go:1252` — `checkQueryExpr`: source, from, join, where, group, having, and aggregate select; emits T032, T033, T034, T035, T037, T038, T041, T042, T044.
+- `types/check_expr.go:1252` — `checkQueryExpr`: source, from, join, where, skip, take, group, having, and aggregate select; emits T032, T033, T034, T035, T037, T038, T041, T042, T044, T055.
 - `types/query_plan_builder.go` — group plan construction.
-- `types/errors.go` — query-related diagnostic helpers (`errQuerySourceList`, `errWhereBoolean`, `errJoinSourceList`, `errJoinOnBoolean`, `errHavingBoolean`, `errSumOperand`, `errImpurePredicate`).
+- `types/errors.go` — query-related diagnostic helpers (`errQuerySourceList`, `errWhereBoolean`, `errJoinSourceList`, `errJoinOnBoolean`, `errHavingBoolean`, `errSumOperand`, `errImpurePredicate`, `errSkipTakeIntOperand`).
 - `tests/queryplan/` — golden tests for the plan.
 
 ## Open Questions


### PR DESCRIPTION
## Summary
- New diagnostic **T055**: \`\`\`skip\`\`\` and \`\`\`take\`\`\` operands must be \`\`\`int\`\`\` (was silently accepted and panicked at runtime)
- Two pinning fixtures: string \`\`\`take\`\`\` and float \`\`\`skip\`\`\`
- Doc: marks the row closed; collapses "Distinct, sort, skip, take (open)" to "Distinct and sort"

Tracking: #21400.

## Test plan
- [x] `go test ./types/ ./runtime/...`