### PR TITLE
MEP-14.4: fire T033/T042 directly on non-bool where/having

### DIFF
--- a/tests/types/errors/query_group_having_bool_required.err
+++ b/tests/types/errors/query_group_having_bool_required.err
@@ -1,8 +1,8 @@
-1. error[T008]: type mismatch: expected bool, got group
-  --> tests/types/errors/query_group_having_bool_required.mochi:8:18
+1. error[T042]: `having` condition must be boolean
+  --> tests/types/errors/query_group_having_bool_required.mochi:5:18
 
-  8 |           having g
+  5 |           having g
     |                  ^
 
 help:
-  Change the value to match the expected type.
+  Ensure the condition evaluates to true or false.

--- a/tests/types/errors/query_group_having_bool_required.mochi
+++ b/tests/types/errors/query_group_having_bool_required.mochi
@@ -1,7 +1,4 @@
-// `having` predicate inside `group by` must be `bool`. MEP-14 lists this
-// as T042 but today `checkExprWithExpected` short-circuits with T008
-// first. The fixture pins the actual diagnostic until the T042 path is
-// reached.
+// `having` predicate inside `group by` must be `bool` (T042).
 let xs: list<int> = [1, 2, 3]
 let bad = from x in xs
           group by x % 2 into g

--- a/tests/types/errors/query_where_bool_required.err
+++ b/tests/types/errors/query_where_bool_required.err
@@ -1,8 +1,8 @@
-1. error[T008]: type mismatch: expected bool, got int
-  --> tests/types/errors/query_where_bool_required.mochi:5:30
+1. error[T033]: `where` condition must be boolean
+  --> tests/types/errors/query_where_bool_required.mochi:3:30
 
-  5 | let bad = from x in xs where x select x
+  3 | let bad = from x in xs where x select x
     |                              ^
 
 help:
-  Change the value to match the expected type.
+  Ensure the condition evaluates to true or false.

--- a/tests/types/errors/query_where_bool_required.mochi
+++ b/tests/types/errors/query_where_bool_required.mochi
@@ -1,5 +1,3 @@
-// Query `where` predicate must be `bool`. MEP-14 lists this as T033 but
-// today `checkExprWithExpected` short-circuits with T008 first. The
-// fixture pins the actual diagnostic until the T033 path is reached.
+// Query `where` predicate must be `bool` (T033).
 let xs: list<int> = [1, 2, 3]
 let bad = from x in xs where x select x

--- a/types/check_expr.go
+++ b/types/check_expr.go
@@ -1328,11 +1328,11 @@ func checkQueryExpr(q *parser.QueryExpr, env *Env, expected Type) (Type, error) 
 	}
 
 	if q.Where != nil {
-		wt, err := checkExprWithExpected(q.Where, child, BoolType{})
+		wt, err := checkExpr(q.Where, child)
 		if err != nil {
 			return nil, err
 		}
-		if !unify(wt, BoolType{}, nil) {
+		if _, ok := wt.(AnyType); !ok && !unify(wt, BoolType{}, nil) {
 			return nil, errWhereBoolean(q.Where.Pos)
 		}
 		if name, pos, ok := firstImpureCall(q.Where, child); ok {
@@ -1396,11 +1396,11 @@ func checkQueryExpr(q *parser.QueryExpr, env *Env, expected Type) (Type, error) 
 		gStruct := GroupType{Key: keyT, Elem: elemT}
 		genv.SetVar(q.Group.Name, gStruct, true)
 		if q.Group.Having != nil {
-			ht, err := checkExprWithExpected(q.Group.Having, genv, BoolType{})
+			ht, err := checkExpr(q.Group.Having, genv)
 			if err != nil {
 				return nil, err
 			}
-			if !unify(ht, BoolType{}, nil) {
+			if _, ok := ht.(AnyType); !ok && !unify(ht, BoolType{}, nil) {
 				return nil, errHavingBoolean(q.Group.Having.Pos)
 			}
 			if name, pos, ok := firstImpureCall(q.Group.Having, genv); ok {

--- a/website/docs/mep/mep-0014.md
+++ b/website/docs/mep/mep-0014.md
@@ -151,12 +151,11 @@ Both need an ordered/hashable trait decision; they remain open in this MEP. `ski
 Existing (committed in `tests/types/`):
 
 - Valid: `query_basic_select`, `query_sort_take`, `query_select_struct_proj`, `query_distinct_int`, `query_join_inner_cardinality`, `join_basic`, `join_multi`.
-- Error: `query_source_not_list` (T032), `query_where_bool_required` (current: T008, target: T033), `join_source_not_list` (T034), `join_on_not_bool` (T035), `count_invalid_type` (T037), `avg_non_numeric` (T038), `query_group_having_bool_required` (current: T008, target: T042), `query_take_int_required` (T055), `query_skip_int_required` (T055).
+- Error: `query_source_not_list` (T032), `query_where_bool_required` (T033), `join_source_not_list` (T034), `join_on_not_bool` (T035), `count_invalid_type` (T037), `avg_non_numeric` (T038), `query_group_having_bool_required` (T042), `query_take_int_required` (T055), `query_skip_int_required` (T055).
 
 Pinning gaps (closure plan):
 
 - Valid: `query_distinct_struct_canonical`, `query_join_left_unmatched_null`, `query_join_outer_both_sides`, `query_group_aggregate_int_sum`, `query_group_aggregate_avg_float` (the last two block on a separate checker bug: grouped aggregate projection currently returns scalar rather than `[T]`).
-- Error: a follow-up collapses the dead T033/T042 branches into the expected-type path so the specific code fires instead of T008.
 
 ## Rationale
 


### PR DESCRIPTION
## Summary
- Switch \`\`\`where\`\`\` / \`\`\`having\`\`\` checks from \`\`\`checkExprWithExpected(..., BoolType{})\`\`\` (raises generic T008) to plain \`\`\`checkExpr\`\`\` so the explicit T033 / T042 unify-then-error branch fires
- Refresh the MEP-14.2 pinning fixtures so goldens show the specific code

Tracking: #21402.

## Test plan
- [x] \`\`\`go test ./types/\`\`\`
- [x] \`\`\`go test ./...\`\`\` (no regressions)