### PR TITLE
MEP-14.5: grouped-aggregate select returns [T] not scalar

### DIFF
--- a/tests/types/valid/query_group_aggregate_avg_float.golden
+++ b/tests/types/valid/query_group_aggregate_avg_float.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/query_group_aggregate_avg_float.mochi
+++ b/tests/types/valid/query_group_aggregate_avg_float.mochi
@@ -1,0 +1,7 @@
+// `avg(g)` per group is `float`, so a grouped avg projection has type
+// `[float]` (MEP-14.5).
+let xs: list<int> = [1, 2, 3, 4, 5]
+let means: list<float> = from x in xs
+                         group by x % 2 into g
+                         select avg(g)
+expect count(means) == 2

--- a/tests/types/valid/query_group_aggregate_int_sum.golden
+++ b/tests/types/valid/query_group_aggregate_int_sum.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/query_group_aggregate_int_sum.mochi
+++ b/tests/types/valid/query_group_aggregate_int_sum.mochi
@@ -1,0 +1,7 @@
+// A grouped aggregate produces one row per group, so the result is a
+// list of sums, not a scalar (MEP-14.5).
+let xs: list<int> = [1, 2, 3, 4, 5]
+let totals: list<int> = from x in xs
+                        group by x % 2 into g
+                        select sum(g)
+expect count(totals) == 2

--- a/types/check_expr.go
+++ b/types/check_expr.go
@@ -1450,11 +1450,13 @@ func checkQueryExpr(q *parser.QueryExpr, env *Env, expected Type) (Type, error) 
 	if err != nil {
 		return nil, err
 	}
-	if _, _, ok := aggregateCallName(q.Select); ok {
-		if expected != nil && !unify(selT, expected, nil) {
-			return nil, errTypeMismatch(q.Pos, expected, selT)
+	if q.Group == nil {
+		if _, _, ok := aggregateCallName(q.Select); ok {
+			if expected != nil && !unify(selT, expected, nil) {
+				return nil, errTypeMismatch(q.Pos, expected, selT)
+			}
+			return selT, nil
 		}
-		return selT, nil
 	}
 	result := ListType{Elem: selT}
 	if expected != nil && !unify(result, expected, nil) {

--- a/website/docs/mep/mep-0014.md
+++ b/website/docs/mep/mep-0014.md
@@ -45,6 +45,7 @@ Queries are how a lot of real Mochi programs are written. The clause type rules 
 | Aggregate misuse: `count` on non list/group (T037)                | closed |
 | Aggregate `avg(...): float`, `sum(...): T`, `count(...): int`     | closed |
 | Result shape: `[U]` where `U = ExprType(select)`                  | closed |
+| Grouped aggregate result is `[U]`, one row per group              | closed |
 | `skip n` and `take n` require `n : int` (T055)                    | closed |
 | `sort by e` requires `e` of an ordered type                       | **open** |
 | `select distinct e` requires `e` of a hashable type               | **open** |
@@ -150,12 +151,12 @@ Both need an ordered/hashable trait decision; they remain open in this MEP. `ski
 
 Existing (committed in `tests/types/`):
 
-- Valid: `query_basic_select`, `query_sort_take`, `query_select_struct_proj`, `query_distinct_int`, `query_join_inner_cardinality`, `join_basic`, `join_multi`.
+- Valid: `query_basic_select`, `query_sort_take`, `query_select_struct_proj`, `query_distinct_int`, `query_join_inner_cardinality`, `query_group_aggregate_int_sum`, `query_group_aggregate_avg_float`, `join_basic`, `join_multi`.
 - Error: `query_source_not_list` (T032), `query_where_bool_required` (T033), `join_source_not_list` (T034), `join_on_not_bool` (T035), `count_invalid_type` (T037), `avg_non_numeric` (T038), `query_group_having_bool_required` (T042), `query_take_int_required` (T055), `query_skip_int_required` (T055).
 
 Pinning gaps (closure plan):
 
-- Valid: `query_distinct_struct_canonical`, `query_join_left_unmatched_null`, `query_join_outer_both_sides`, `query_group_aggregate_int_sum`, `query_group_aggregate_avg_float` (the last two block on a separate checker bug: grouped aggregate projection currently returns scalar rather than `[T]`).
+- Valid: `query_distinct_struct_canonical`, `query_join_left_unmatched_null`, `query_join_outer_both_sides`.
 
 ## Rationale
 


### PR DESCRIPTION
## Summary
- Type checker bug: \`\`\`from x in xs group by k into g select sum(g)\`\`\` runs at runtime as \`\`\`[T]\`\`\` (one row per group) but was typed as scalar \`\`\`T\`\`\`. Surfaced in MEP-14.2.
- Fix: gate the post-loop \`\`\`aggregateCallName\`\`\` scalar shortcut on \`\`\`q.Group == nil\`\`\`.
- Two pinning fixtures: int-sum and avg-float.

Tracking: #21404.

## Test plan
- [x] \`\`\`go test ./types/\`\`\`
- [x] \`\`\`go test ./...\`\`\` (no regressions)