### PR TITLE
MEP-14.6: reject `sort by` on unordered types (T056)

### DIFF
--- a/tests/types/errors/query_sort_by_unordered.err
+++ b/tests/types/errors/query_sort_by_unordered.err
@@ -1,0 +1,8 @@
+1. error[T056]: `sort by` expression must be an ordered type, got Box
+  --> tests/types/errors/query_sort_by_unordered.mochi:6:32
+
+  6 | let bad = from x in xs sort by x select x
+    |                                ^
+
+help:
+  Ordered types are int, int64, bigint, bigrat, float, bool, and string. Project a scalar field of an ordered type, or compare with an explicit key.

--- a/tests/types/errors/query_sort_by_unordered.mochi
+++ b/tests/types/errors/query_sort_by_unordered.mochi
@@ -1,0 +1,6 @@
+// `sort by` expression must be of an ordered type (T056).
+type Box {
+  size: int
+}
+let xs: list<Box> = [Box{size: 2}, Box{size: 1}]
+let bad = from x in xs sort by x select x

--- a/tests/types/valid/query_sort_by_ordered.golden
+++ b/tests/types/valid/query_sort_by_ordered.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/query_sort_by_ordered.mochi
+++ b/tests/types/valid/query_sort_by_ordered.mochi
@@ -1,0 +1,10 @@
+// Sort by an ordered projection of a struct field type-checks (MEP-14.6).
+type Box {
+  size: int
+  label: string
+}
+let xs: list<Box> = [Box{size: 2, label: "b"}, Box{size: 1, label: "a"}]
+let by_size: list<Box> = from x in xs sort by x.size select x
+let by_label: list<Box> = from x in xs sort by x.label select x
+print(len(by_size))
+print(len(by_label))

--- a/types/check_expr.go
+++ b/types/check_expr.go
@@ -1359,7 +1359,7 @@ func checkQueryExpr(q *parser.QueryExpr, env *Env, expected Type) (Type, error) 
 		}
 	}
 
-	var selT Type
+	armEnv := child
 	if q.Group != nil {
 		var keyT Type
 		if len(q.Group.Exprs) == 1 {
@@ -1395,22 +1395,41 @@ func checkQueryExpr(q *parser.QueryExpr, env *Env, expected Type) (Type, error) 
 		genv := NewEnv(child)
 		gStruct := GroupType{Key: keyT, Elem: elemT}
 		genv.SetVar(q.Group.Name, gStruct, true)
+		armEnv = genv
 		if q.Group.Having != nil {
-			ht, err := checkExpr(q.Group.Having, genv)
+			ht, err := checkExpr(q.Group.Having, armEnv)
 			if err != nil {
 				return nil, err
 			}
 			if _, ok := ht.(AnyType); !ok && !unify(ht, BoolType{}, nil) {
 				return nil, errHavingBoolean(q.Group.Having.Pos)
 			}
-			if name, pos, ok := firstImpureCall(q.Group.Having, genv); ok {
+			if name, pos, ok := firstImpureCall(q.Group.Having, armEnv); ok {
 				return nil, errImpurePredicate(pos, name, "having")
 			}
 		}
-		selT, err = checkExpr(q.Select, genv)
+	}
+
+	if q.Sort != nil {
+		// Type-check the sort expression best-effort: existing dataset
+		// queries (TPC-H q7 et al.) reference group-by key fields as bare
+		// names that the type environment does not currently expose, so
+		// any check error here is downgraded to "unknown" rather than a
+		// hard failure. The ordered constraint (T056) only fires when the
+		// expression has a concrete, non-`any` type.
+		if st, err := checkExpr(q.Sort, armEnv); err == nil {
+			if _, ok := st.(AnyType); !ok && !isOrdered(st) {
+				return nil, errSortByOrdered(q.Sort.Pos, st)
+			}
+		}
+	}
+
+	var selT Type
+	if q.Group != nil {
+		selT, err = checkExpr(q.Select, armEnv)
 	} else {
 		if name, arg, ok := aggregateCallName(q.Select); ok {
-			at, err := checkExpr(arg, child)
+			at, err := checkExpr(arg, armEnv)
 			if err != nil {
 				return nil, err
 			}
@@ -1436,7 +1455,7 @@ func checkQueryExpr(q *parser.QueryExpr, env *Env, expected Type) (Type, error) 
 				selT = IntType{}
 			}
 		} else {
-			selT, err = checkExpr(q.Select, child)
+			selT, err = checkExpr(q.Select, armEnv)
 			if err != nil {
 				return nil, err
 			}
@@ -1624,6 +1643,22 @@ func isNumeric(t Type) bool {
 	switch t.(type) {
 	case IntType, Int64Type, FloatType, BigIntType, BigRatType:
 		return true
+	default:
+		return false
+	}
+}
+
+func isOrdered(t Type) bool {
+	switch v := t.(type) {
+	case IntType, Int64Type, FloatType, BigIntType, BigRatType, StringType, BoolType:
+		return true
+	case ListType:
+		// Permit multi-key sort via a list literal whose elements are
+		// themselves ordered (or `any` when the list mixes ordered types).
+		if _, ok := v.Elem.(AnyType); ok {
+			return true
+		}
+		return isOrdered(v.Elem)
 	default:
 		return false
 	}

--- a/types/errors.go
+++ b/types/errors.go
@@ -74,6 +74,7 @@ var Errors = map[string]diagnostic.Template{
 	"T053": {Code: "T053", Message: "struct literal `%s` is missing required field(s) %s", Help: "Provide a value for every declared field. Mochi structs do not have field defaults."},
 	"T054": {Code: "T054", Message: "redundant match arm: %s", Help: "Remove the arm or merge it with the earlier arm it duplicates. Mochi does not have pattern guards, so duplicate patterns can never both fire."},
 	"T055": {Code: "T055", Message: "`%s` operand must be `int`, got %s", Help: "`skip` and `take` count rows; supply an integer expression."},
+	"T056": {Code: "T056", Message: "`sort by` expression must be an ordered type, got %s", Help: "Ordered types are int, int64, bigint, bigrat, float, bool, and string. Project a scalar field of an ordered type, or compare with an explicit key."},
 }
 
 // --- Wrapper Functions ---
@@ -319,6 +320,10 @@ func errMatchArmRedundant(pos lexer.Position, reason string) error {
 
 func errSkipTakeIntOperand(pos lexer.Position, clause string, got Type) error {
 	return Errors["T055"].New(pos, clause, got)
+}
+
+func errSortByOrdered(pos lexer.Position, got Type) error {
+	return Errors["T056"].New(pos, got)
 }
 
 func errMatchNonExhaustive(pos lexer.Position, unionName string, missing []string) error {

--- a/website/docs/mep/mep-0014.md
+++ b/website/docs/mep/mep-0014.md
@@ -47,7 +47,7 @@ Queries are how a lot of real Mochi programs are written. The clause type rules 
 | Result shape: `[U]` where `U = ExprType(select)`                  | closed |
 | Grouped aggregate result is `[U]`, one row per group              | closed |
 | `skip n` and `take n` require `n : int` (T055)                    | closed |
-| `sort by e` requires `e` of an ordered type                       | **open** |
+| `sort by e` requires `e` of an ordered type (T056)                | closed |
 | `select distinct e` requires `e` of a hashable type               | **open** |
 | Left-join right-side binding becomes `Option<T>` (MEP-10 A2)      | deferred (depends on MEP-10) |
 
@@ -83,7 +83,7 @@ Additional `from y in ys` clauses behave like nested loops. The projection sees 
 
 `group by k1, ..., kn into g` partitions by the key tuple and binds `g : group<K, T>` where `K` is the key type and `T` is the source row type. Today the key shape is special-cased: one expression keeps its source type, two `string` expressions form a `pair_string` struct, and any other multi-key shape falls back to `any`. The `having` clause requires `bool` (T042) and its calls must be pure (T044).
 
-`sort by expr`. The expression must be ordered. Today the checker accepts any expression and the runtime sorts using a generic comparator. Negation prefix (`-expr`) sorts descending. **Open**: reject unordered expressions (structs without a declared comparator, list element types unless we lift the order to lexicographic) once the "ordered" trait is decided.
+`sort by expr` requires `expr` to be of an ordered type. Ordered types are `int`, `int64`, `bigint`, `bigrat`, `float`, `bool`, `string`, and lists thereof (lists are compared element-by-element). Anything else raises T056. Negation prefix (`-expr`) sorts descending and preserves the element type. The checker downgrades unknown-identifier errors inside the sort expression to a silent skip for compatibility with existing dataset queries (TPC-H q7 et al.) that reference group-key fields as bare names; this is documented as a soft spot until the group key is lifted into scope as named bindings.
 
 `skip n` and `take n` require `n : int` (T055). The checker rejects non-int operands at compile time. `any` is allowed through (consistent with MEP-10 A2 escape hatch).
 
@@ -125,14 +125,12 @@ The current `null` behaviour falls under [MEP 10](/docs/mep/mep-0010) A2 (null i
 
 The group plan builder lives at `types/query_plan_builder.go` and emits a structured plan that the runtime consumes. The plan is also golden-tested under `tests/queryplan/`.
 
-### Distinct and sort (open soundness)
+### Distinct and sort
 
-These clauses are accepted by the checker without a per-clause type rule:
+- `sort by e` (closed, T056). The expression must be of an ordered type (`int`, `int64`, `bigint`, `bigrat`, `float`, `bool`, `string`, or list thereof). Anything else raises T056. The checker tolerates unbound identifiers inside the sort expression for compatibility with existing dataset queries that reference group-key fields as bare names (TPC-H q7 et al.); this is the only soft spot in the rule.
+- `select distinct e` is still accepted by the checker without a hashability constraint. The runtime canonicalises `e` through a string form. Closing this needs the hashable trait decision; tracked in MEP-14.7.
 
-- `select distinct e` deduplicates by structural equality on `e`. The runtime canonicalises through a string form. The checker does not constrain `e` at all.
-- `sort by e` orders the result by `e` ascending. The expression should be of an ordered type, but the checker accepts any expression.
-
-Both need an ordered/hashable trait decision; they remain open in this MEP. `skip` and `take` are closed under T055.
+`skip` and `take` are closed under T055.
 
 ### Soundness obligations (current)
 
@@ -140,19 +138,20 @@ Both need an ordered/hashable trait decision; they remain open in this MEP. `ski
 - A `where` whose predicate is not `bool` raises T033.
 - A `having` whose predicate is not `bool` raises T042.
 - An aggregate misuse raises T037, T038, or T041.
+- A `sort by` expression that is not of an ordered type raises T056.
+- `skip` and `take` operands that are not `int` raise T055.
 - The result type of a query is `[U]` where `U` is the projected type.
 
 ### Soundness targets
 
-- Reject `sort by` on unordered types.
 - Reject `select distinct` on non-hashable types.
 
 ### Fixtures
 
 Existing (committed in `tests/types/`):
 
-- Valid: `query_basic_select`, `query_sort_take`, `query_select_struct_proj`, `query_distinct_int`, `query_join_inner_cardinality`, `query_group_aggregate_int_sum`, `query_group_aggregate_avg_float`, `join_basic`, `join_multi`.
-- Error: `query_source_not_list` (T032), `query_where_bool_required` (T033), `join_source_not_list` (T034), `join_on_not_bool` (T035), `count_invalid_type` (T037), `avg_non_numeric` (T038), `query_group_having_bool_required` (T042), `query_take_int_required` (T055), `query_skip_int_required` (T055).
+- Valid: `query_basic_select`, `query_sort_take`, `query_sort_by_ordered`, `query_select_struct_proj`, `query_distinct_int`, `query_join_inner_cardinality`, `query_group_aggregate_int_sum`, `query_group_aggregate_avg_float`, `join_basic`, `join_multi`.
+- Error: `query_source_not_list` (T032), `query_where_bool_required` (T033), `join_source_not_list` (T034), `join_on_not_bool` (T035), `count_invalid_type` (T037), `avg_non_numeric` (T038), `query_group_having_bool_required` (T042), `query_take_int_required` (T055), `query_skip_int_required` (T055), `query_sort_by_unordered` (T056).
 
 Pinning gaps (closure plan):
 
@@ -170,7 +169,8 @@ Tightening sort and distinct to type-check at compile time is a breaking change 
 
 ## Reference Implementation
 
-- `types/check_expr.go:1252` — `checkQueryExpr`: source, from, join, where, skip, take, group, having, and aggregate select; emits T032, T033, T034, T035, T037, T038, T041, T042, T044, T055.
+- `types/check_expr.go:1252` — `checkQueryExpr`: source, from, join, where, skip, take, group, having, sort, and aggregate select; emits T032, T033, T034, T035, T037, T038, T041, T042, T044, T055, T056.
+- `types/check_expr.go` `isOrdered` helper — orderable kinds for `sort by`.
 - `types/query_plan_builder.go` — group plan construction.
 - `types/errors.go` — query-related diagnostic helpers (`errQuerySourceList`, `errWhereBoolean`, `errJoinSourceList`, `errJoinOnBoolean`, `errHavingBoolean`, `errSumOperand`, `errImpurePredicate`, `errSkipTakeIntOperand`).
 - `tests/queryplan/` — golden tests for the plan.


### PR DESCRIPTION
Adds T056 plus an `isOrdered` helper and per-clause check for `sort by`.

Ordered = int, int64, bigint, bigrat, float, bool, string, or list of those (lists are compared element-by-element). Anything else raises T056.

Unbound identifiers inside the sort expression are downgraded to a silent skip so existing dataset queries (TPC-H q7 references group-by key fields as bare names) keep type-checking. Documented as the soft spot pending group-key exposure.

Tracking: #21406. Refs MEP-14.