### PR TITLE
MEP-14.7: reject `select distinct` on non-hashable types (T057)

### DIFF
--- a/tests/types/errors/query_distinct_non_hashable.err
+++ b/tests/types/errors/query_distinct_non_hashable.err
@@ -1,0 +1,8 @@
+1. error[T057]: `select distinct` expression must be a hashable type, got fun(int): int
+  --> tests/types/errors/query_distinct_non_hashable.mochi:4:40
+
+  4 | let bad = from x in xs select distinct double
+    |                                        ^
+
+help:
+  Distinct deduplicates by structural equality. Function values do not have a stable hash. Project a scalar or record of scalars.

--- a/tests/types/errors/query_distinct_non_hashable.mochi
+++ b/tests/types/errors/query_distinct_non_hashable.mochi
@@ -1,0 +1,4 @@
+// `select distinct` requires a hashable expression type (T057).
+let double = fun(x: int): int => x * 2
+let xs: list<int> = [1, 2, 3]
+let bad = from x in xs select distinct double

--- a/tests/types/valid/query_distinct_struct_canonical.golden
+++ b/tests/types/valid/query_distinct_struct_canonical.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/query_distinct_struct_canonical.mochi
+++ b/tests/types/valid/query_distinct_struct_canonical.mochi
@@ -1,0 +1,8 @@
+// `select distinct` over a struct value with hashable fields type-checks (MEP-14.7).
+type Row {
+  id: int
+  label: string
+}
+let rs: list<Row> = [Row{id: 1, label: "a"}, Row{id: 1, label: "a"}, Row{id: 2, label: "b"}]
+let uniq: list<Row> = from r in rs select distinct r
+print(len(uniq))

--- a/types/check_expr.go
+++ b/types/check_expr.go
@@ -1440,15 +1440,15 @@ func checkQueryExpr(q *parser.QueryExpr, env *Env, expected Type) (Type, error) 
 			if err != nil {
 				return nil, err
 			}
-			result := ListType{Elem: selT}
-			if expected != nil && !unify(result, expected, nil) {
-				return nil, errTypeMismatch(q.Pos, expected, result)
-			}
-			return result, nil
 		}
 	}
 	if err != nil {
 		return nil, err
+	}
+	if q.Distinct {
+		if !isHashable(selT) {
+			return nil, errDistinctHashable(q.Select.Pos, selT)
+		}
 	}
 	if q.Group == nil {
 		if _, _, ok := aggregateCallName(q.Select); ok {
@@ -1624,6 +1624,37 @@ func isNumeric(t Type) bool {
 	switch t.(type) {
 	case IntType, Int64Type, FloatType, BigIntType, BigRatType:
 		return true
+	default:
+		return false
+	}
+}
+
+func isHashable(t Type) bool {
+	switch v := t.(type) {
+	case IntType, Int64Type, FloatType, BigIntType, BigRatType, StringType, BoolType, UnitType, AnyType:
+		return true
+	case ListType:
+		return isHashable(v.Elem)
+	case MapType:
+		return isHashable(v.Key) && isHashable(v.Value)
+	case OptionType:
+		return isHashable(v.Elem)
+	case StructType:
+		for _, f := range v.Fields {
+			if !isHashable(f.Type) {
+				return false
+			}
+		}
+		return true
+	case UnionType:
+		for _, s := range v.Variants {
+			if !isHashable(s) {
+				return false
+			}
+		}
+		return true
+	case FuncType, GroupType:
+		return false
 	default:
 		return false
 	}

--- a/types/errors.go
+++ b/types/errors.go
@@ -74,6 +74,7 @@ var Errors = map[string]diagnostic.Template{
 	"T053": {Code: "T053", Message: "struct literal `%s` is missing required field(s) %s", Help: "Provide a value for every declared field. Mochi structs do not have field defaults."},
 	"T054": {Code: "T054", Message: "redundant match arm: %s", Help: "Remove the arm or merge it with the earlier arm it duplicates. Mochi does not have pattern guards, so duplicate patterns can never both fire."},
 	"T055": {Code: "T055", Message: "`%s` operand must be `int`, got %s", Help: "`skip` and `take` count rows; supply an integer expression."},
+	"T057": {Code: "T057", Message: "`select distinct` expression must be a hashable type, got %s", Help: "Distinct deduplicates by structural equality. Function values do not have a stable hash. Project a scalar or record of scalars."},
 }
 
 // --- Wrapper Functions ---
@@ -319,6 +320,10 @@ func errMatchArmRedundant(pos lexer.Position, reason string) error {
 
 func errSkipTakeIntOperand(pos lexer.Position, clause string, got Type) error {
 	return Errors["T055"].New(pos, clause, got)
+}
+
+func errDistinctHashable(pos lexer.Position, got Type) error {
+	return Errors["T057"].New(pos, got)
 }
 
 func errMatchNonExhaustive(pos lexer.Position, unionName string, missing []string) error {

--- a/website/docs/mep/mep-0014.md
+++ b/website/docs/mep/mep-0014.md
@@ -48,7 +48,7 @@ Queries are how a lot of real Mochi programs are written. The clause type rules 
 | Grouped aggregate result is `[U]`, one row per group              | closed |
 | `skip n` and `take n` require `n : int` (T055)                    | closed |
 | `sort by e` requires `e` of an ordered type                       | **open** |
-| `select distinct e` requires `e` of a hashable type               | **open** |
+| `select distinct e` requires `e` of a hashable type (T057)        | closed |
 | Left-join right-side binding becomes `Option<T>` (MEP-10 A2)      | deferred (depends on MEP-10) |
 
 ## Specification
@@ -89,7 +89,7 @@ Additional `from y in ys` clauses behave like nested loops. The projection sees 
 
 `select expr` returns `[U]` where `U = ExprType(expr)`. Inside `select` the iteration variables are in scope.
 
-`select distinct expr` is the same with deduplication. The element type must be hashable. Today the runtime falls back to a canonical string form. **Open**: constrain `select distinct` to types with a known canonical form once a hashable trait is decided.
+`select distinct expr` is the same with deduplication. The element type must be hashable (T057). Hashable types are the numerics, `bool`, `string`, `unit`, lists/maps/options/structs/unions of hashable types, and `any`. Function and group values are rejected. The runtime canonicalises through a string form.
 
 ### Aggregate operators
 
@@ -125,14 +125,12 @@ The current `null` behaviour falls under [MEP 10](/docs/mep/mep-0010) A2 (null i
 
 The group plan builder lives at `types/query_plan_builder.go` and emits a structured plan that the runtime consumes. The plan is also golden-tested under `tests/queryplan/`.
 
-### Distinct and sort (open soundness)
+### Distinct and sort
 
-These clauses are accepted by the checker without a per-clause type rule:
-
-- `select distinct e` deduplicates by structural equality on `e`. The runtime canonicalises through a string form. The checker does not constrain `e` at all.
+- `select distinct e` (closed, T057). Deduplicates by structural equality on `e`. The runtime canonicalises through a string form. The checker requires `e` to be of a hashable type: numerics, `bool`, `string`, `unit`, lists/maps/options/structs/unions of hashable elements, or `any`. Functions and group values are rejected.
 - `sort by e` orders the result by `e` ascending. The expression should be of an ordered type, but the checker accepts any expression.
 
-Both need an ordered/hashable trait decision; they remain open in this MEP. `skip` and `take` are closed under T055.
+`skip` and `take` are closed under T055.
 
 ### Soundness obligations (current)
 
@@ -140,23 +138,24 @@ Both need an ordered/hashable trait decision; they remain open in this MEP. `ski
 - A `where` whose predicate is not `bool` raises T033.
 - A `having` whose predicate is not `bool` raises T042.
 - An aggregate misuse raises T037, T038, or T041.
+- A `select distinct` expression that is not of a hashable type raises T057.
+- `skip` and `take` operands that are not `int` raise T055.
 - The result type of a query is `[U]` where `U` is the projected type.
 
 ### Soundness targets
 
 - Reject `sort by` on unordered types.
-- Reject `select distinct` on non-hashable types.
 
 ### Fixtures
 
 Existing (committed in `tests/types/`):
 
-- Valid: `query_basic_select`, `query_sort_take`, `query_select_struct_proj`, `query_distinct_int`, `query_join_inner_cardinality`, `query_group_aggregate_int_sum`, `query_group_aggregate_avg_float`, `join_basic`, `join_multi`.
-- Error: `query_source_not_list` (T032), `query_where_bool_required` (T033), `join_source_not_list` (T034), `join_on_not_bool` (T035), `count_invalid_type` (T037), `avg_non_numeric` (T038), `query_group_having_bool_required` (T042), `query_take_int_required` (T055), `query_skip_int_required` (T055).
+- Valid: `query_basic_select`, `query_sort_take`, `query_select_struct_proj`, `query_distinct_int`, `query_distinct_struct_canonical`, `query_join_inner_cardinality`, `query_group_aggregate_int_sum`, `query_group_aggregate_avg_float`, `join_basic`, `join_multi`.
+- Error: `query_source_not_list` (T032), `query_where_bool_required` (T033), `join_source_not_list` (T034), `join_on_not_bool` (T035), `count_invalid_type` (T037), `avg_non_numeric` (T038), `query_group_having_bool_required` (T042), `query_take_int_required` (T055), `query_skip_int_required` (T055), `query_distinct_non_hashable` (T057).
 
 Pinning gaps (closure plan):
 
-- Valid: `query_distinct_struct_canonical`, `query_join_left_unmatched_null`, `query_join_outer_both_sides`.
+- Valid: `query_join_left_unmatched_null`, `query_join_outer_both_sides`.
 
 ## Rationale
 
@@ -170,15 +169,15 @@ Tightening sort and distinct to type-check at compile time is a breaking change 
 
 ## Reference Implementation
 
-- `types/check_expr.go:1252` — `checkQueryExpr`: source, from, join, where, skip, take, group, having, and aggregate select; emits T032, T033, T034, T035, T037, T038, T041, T042, T044, T055.
+- `types/check_expr.go:1252` — `checkQueryExpr`: source, from, join, where, skip, take, group, having, and aggregate select; emits T032, T033, T034, T035, T037, T038, T041, T042, T044, T055, T057.
+- `types/check_expr.go` `isHashable` helper — hashable kinds for `select distinct`.
 - `types/query_plan_builder.go` — group plan construction.
-- `types/errors.go` — query-related diagnostic helpers (`errQuerySourceList`, `errWhereBoolean`, `errJoinSourceList`, `errJoinOnBoolean`, `errHavingBoolean`, `errSumOperand`, `errImpurePredicate`, `errSkipTakeIntOperand`).
+- `types/errors.go` — query-related diagnostic helpers (`errQuerySourceList`, `errWhereBoolean`, `errJoinSourceList`, `errJoinOnBoolean`, `errHavingBoolean`, `errSumOperand`, `errImpurePredicate`, `errSkipTakeIntOperand`, `errDistinctHashable`).
 - `tests/queryplan/` — golden tests for the plan.
 
 ## Open Questions
 
 - **Ordered trait.** Decide between an explicit interface for `min`, `max`, `sort` or a hard-coded list of orderable kinds.
-- **Hashable trait.** Same question for `distinct` and group keys.
 - **Right-side `null` in left join.** Tied to [MEP 10](/docs/mep/mep-0010) A2.
 
 ## References


### PR DESCRIPTION
Adds T057 plus an `isHashable` helper and a per-clause check for `select distinct`.

Hashable = numerics, `bool`, `string`, `unit`, `any`, plus lists/maps/options/structs/unions of hashable elements. Function and group values are rejected.

Tracking: #21408. Refs MEP-14.