### PR TITLE
MEP-14: pin left/outer join cardinality fixtures

### DIFF
--- a/tests/types/valid/query_join_left_unmatched_null.golden
+++ b/tests/types/valid/query_join_left_unmatched_null.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/query_join_left_unmatched_null.mochi
+++ b/tests/types/valid/query_join_left_unmatched_null.mochi
@@ -1,0 +1,11 @@
+// Left join cardinality: every left row appears once.
+// Unmatched left rows get the right side as null (any) today; see MEP-14 and MEP-10 A2.
+// One match + one unmatched left row -> result has two rows.
+type Order { id: int, cid: int }
+type Cust  { id: int, name: string }
+let orders: list<Order> = [Order{id: 1, cid: 10}, Order{id: 2, cid: 99}]
+let custs:  list<Cust>  = [Cust{id: 10, name: "a"}]
+let joined = from o in orders
+             left join c in custs on o.cid == c.id
+             select {oid: o.id, c: c}
+expect count(joined) == 2

--- a/tests/types/valid/query_join_outer_both_sides.golden
+++ b/tests/types/valid/query_join_outer_both_sides.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/query_join_outer_both_sides.mochi
+++ b/tests/types/valid/query_join_outer_both_sides.mochi
@@ -1,0 +1,10 @@
+// Outer join cardinality: union of both sides' unmatched rows plus the inner intersection.
+// Two left rows, two right rows, one match, one unmatched on each side -> three rows total.
+type Order { id: int, cid: int }
+type Cust  { id: int, name: string }
+let orders: list<Order> = [Order{id: 1, cid: 10}, Order{id: 2, cid: 99}]
+let custs:  list<Cust>  = [Cust{id: 10, name: "a"}, Cust{id: 20, name: "b"}]
+let joined = from o in orders
+             outer join c in custs on o.cid == c.id
+             select {o: o, c: c}
+expect count(joined) == 3

--- a/website/docs/mep/mep-0014.md
+++ b/website/docs/mep/mep-0014.md
@@ -49,7 +49,7 @@ Queries are how a lot of real Mochi programs are written. The clause type rules 
 | `skip n` and `take n` require `n : int` (T055)                    | closed |
 | `sort by e` requires `e` of an ordered type                       | **open** |
 | `select distinct e` requires `e` of a hashable type (T057)        | closed |
-| Left-join right-side binding becomes `Option<T>` (MEP-10 A2)      | deferred (depends on MEP-10) |
+| Left-join right-side binding becomes `Option<T>`                  | deferred (needs option-unwrap discipline; see Rationale) |
 
 ## Specification
 
@@ -77,7 +77,7 @@ Required: `from` and `select`. Everything else is optional. The order is fixed b
 
 Additional `from y in ys` clauses behave like nested loops. The projection sees both `x` and `y` in scope. There is no implicit cross-join elision; the result enumerates the cartesian product unless joined.
 
-`join z in zs on cond` requires `zs : [U]` (T034) and `cond : bool` (T035). The join side modifier (`left`, `right`, `outer`) controls the cardinality of unmatched rows. A left join may produce `z = null` for unmatched outer rows; today this returns `any` because of [MEP 10](/docs/mep/mep-0010) A2.
+`join z in zs on cond` requires `zs : [U]` (T034) and `cond : bool` (T035). The join side modifier (`left`, `right`, `outer`) controls the cardinality of unmatched rows. A left join may produce `z = null` for unmatched outer rows. The unmatched binding is typed as `any` today; the eventual target is `Option<U>`, but that depends on option-unwrap discipline at access sites (see Rationale).
 
 `where pred` requires `pred : bool` (T033). Calls inside the predicate must be pure; impure calls raise T044.
 
@@ -112,7 +112,7 @@ Cardinality fixtures:
 - Left join with one unmatched left row: result has the matched row and one row with the right side `null`.
 - Outer join with disjoint sides: result has the union of rows.
 
-The current `null` behaviour falls under [MEP 10](/docs/mep/mep-0010) A2 (null is `any`). Once options are wired, the right-side bindings in a left join become `Option<T>` and pattern matching is required to access them.
+Today the unmatched right-side binding is typed as `any`. The eventual target is `Option<T>`, but that change is gated on the option-unwrap work (see Rationale). [MEP 10](/docs/mep/mep-0010) A2 (null literal is `any`) is closed and is not the blocker here.
 
 ### Group plan and types
 
@@ -150,18 +150,14 @@ The group plan builder lives at `types/query_plan_builder.go` and emits a struct
 
 Existing (committed in `tests/types/`):
 
-- Valid: `query_basic_select`, `query_sort_take`, `query_select_struct_proj`, `query_distinct_int`, `query_distinct_struct_canonical`, `query_join_inner_cardinality`, `query_group_aggregate_int_sum`, `query_group_aggregate_avg_float`, `join_basic`, `join_multi`.
+- Valid: `query_basic_select`, `query_sort_take`, `query_select_struct_proj`, `query_distinct_int`, `query_distinct_struct_canonical`, `query_join_inner_cardinality`, `query_join_left_unmatched_null`, `query_join_outer_both_sides`, `query_group_aggregate_int_sum`, `query_group_aggregate_avg_float`, `join_basic`, `join_multi`.
 - Error: `query_source_not_list` (T032), `query_where_bool_required` (T033), `join_source_not_list` (T034), `join_on_not_bool` (T035), `count_invalid_type` (T037), `avg_non_numeric` (T038), `query_group_having_bool_required` (T042), `query_take_int_required` (T055), `query_skip_int_required` (T055), `query_distinct_non_hashable` (T057).
-
-Pinning gaps (closure plan):
-
-- Valid: `query_join_left_unmatched_null`, `query_join_outer_both_sides`.
 
 ## Rationale
 
 LINQ-shaped queries are familiar, simple to teach, and easy to translate to a relational plan. We keep the clause order fixed because that simplifies the parser and makes the plan obvious.
 
-The `null`-from-left-join hack is a known wart. Once [MEP 10](/docs/mep/mep-0010) A2 lands, the right-side bindings become `Option<T>` and pattern matching is required to access them. We accept the wart in the meantime because changing it requires the option work.
+The `null`-from-left-join hack is a known wart. The right-side bindings should be `Option<T>` so that pattern matching is required to access them. The blocker is not [MEP 10](/docs/mep/mep-0010) A2 (closed): it is the surrounding option-unwrap discipline. Today a `let x: T? = ...` does not auto-wrap a `T` value, and field access on an `Option<T>` does not auto-unwrap, so retyping the binding would break a large set of fixtures that read `c.name` directly off a left-joined `c`. We accept the wart until the unwrap rules are written; the cardinality fixtures here pin the result shape so the eventual change is a visible diff.
 
 ## Backwards Compatibility
 
@@ -178,7 +174,7 @@ Tightening sort and distinct to type-check at compile time is a breaking change 
 ## Open Questions
 
 - **Ordered trait.** Decide between an explicit interface for `min`, `max`, `sort` or a hard-coded list of orderable kinds.
-- **Right-side `null` in left join.** Tied to [MEP 10](/docs/mep/mep-0010) A2.
+- **Right-side `null` in left join.** Retyping to `Option<T>` waits on option-unwrap discipline (auto-wrap on assignment, auto-unwrap or pattern-match on access). [MEP 10](/docs/mep/mep-0010) A2 (null literal is `any`) is closed and is not the blocker.
 
 ## References
 


### PR DESCRIPTION
Closes part of #21410.

## Summary

- Add `tests/types/valid/query_join_left_unmatched_null.{mochi,golden}` and `query_join_outer_both_sides.{mochi,golden}` to pin the result row count for left and outer joins.
- Update `website/docs/mep/mep-0014.md`:
  - Move both fixtures from "Pinning gaps" into "Existing".
  - Rewrite the left-join wart so it points at the actual blocker (option-unwrap discipline) instead of MEP-10 A2, which is closed.
  - Tighten the matching Open Question and `join` clause description.

## Test plan

- [x] `go build ./...`
- [x] `go test ./types/ -run TestTypeChecker_Valid -count=1`