### PR TITLE
mep-0016: narrow option bindings in if-conditions, emit T058

### DIFF
--- a/tests/types/errors/option_deref_unguarded.err
+++ b/tests/types/errors/option_deref_unguarded.err
@@ -1,0 +1,8 @@
+1. error[T058]: dereference of optional `p` requires a none guard
+  --> tests/types/errors/option_deref_unguarded.mochi:6:13
+
+  6 | let label = p.name
+    |             ^
+
+help:
+  Narrow with `if p != null { ... }` first, or supply a fallback (`?? default`).

--- a/tests/types/errors/option_deref_unguarded.mochi
+++ b/tests/types/errors/option_deref_unguarded.mochi
@@ -1,0 +1,6 @@
+// MEP-16 T058: a field access on an Option<T> binding without a none
+// guard is rejected. The fix is `if p != null { p.name }` or a `??`
+// fallback.
+type Person { name: string }
+let p: Person? = null
+let label = p.name

--- a/tests/types/valid/option_narrow_else_branch.golden
+++ b/tests/types/valid/option_narrow_else_branch.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/option_narrow_else_branch.mochi
+++ b/tests/types/valid/option_narrow_else_branch.mochi
@@ -1,0 +1,5 @@
+// MEP-16 N1 (else form): `if x == null { ... } else { ... }` narrows
+// x from Option<T> to T inside the else-branch.
+let p: int? = null
+let total = if p == null { 0 } else { p + 1 }
+expect total == 0

--- a/tests/types/valid/option_narrow_if_not_null.golden
+++ b/tests/types/valid/option_narrow_if_not_null.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/option_narrow_if_not_null.mochi
+++ b/tests/types/valid/option_narrow_if_not_null.mochi
@@ -1,0 +1,6 @@
+// MEP-16 N1: `if x != null { ... }` narrows x from Option<T> to T
+// inside the then-branch. The static path: p has declared type int?,
+// the then-branch sees p : int and the arithmetic type-checks.
+let p: int? = null
+let total = if p != null { p + 1 } else { 0 }
+expect total == 0

--- a/types/check_expr.go
+++ b/types/check_expr.go
@@ -360,6 +360,14 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 				prefix = prefix + "." + field
 				continue
 			}
+			// MEP-16 R4 / T058: a field access on an Option<T> binding
+			// is rejected unless the binding has been narrowed (e.g.
+			// inside `if x != null { ... }`). The narrowed env shadows
+			// the binding with T, so the OptionType reaches here only
+			// when no guard is in scope.
+			if _, opt := typ.(OptionType); opt {
+				return nil, errOptionalDeref(p.Pos, prefix)
+			}
 			switch t := typ.(type) {
 			case StructType:
 				if ft, ok := t.FieldType(field); ok {
@@ -1112,19 +1120,27 @@ func checkIfExpr(ie *parser.IfExpr, env *Env, expected Type) (Type, error) {
 		return nil, errIfCondBoolean(ie.Cond.Pos)
 	}
 
-	thenT, err := checkExprWithExpected(ie.Then, env, expected)
+	// MEP-16 N1: tighten Option<T> bindings to T inside the branch
+	// that proves the value is present. `if x != null { ... }` narrows
+	// x in the then-branch; `if x == null { ... } else { ... }`
+	// narrows x in the else-branch.
+	truthy, falsy := optionNarrowing(ie.Cond, env)
+	thenEnv := narrowedEnv(env, truthy)
+	elseEnv := narrowedEnv(env, falsy)
+
+	thenT, err := checkExprWithExpected(ie.Then, thenEnv, expected)
 	if err != nil {
 		return nil, err
 	}
 
 	var elseT Type = AnyType{}
 	if ie.ElseIf != nil {
-		elseT, err = checkIfExpr(ie.ElseIf, env, thenT)
+		elseT, err = checkIfExpr(ie.ElseIf, elseEnv, thenT)
 		if err != nil {
 			return nil, err
 		}
 	} else if ie.Else != nil {
-		elseT, err = checkExprWithExpected(ie.Else, env, thenT)
+		elseT, err = checkExprWithExpected(ie.Else, elseEnv, thenT)
 		if err != nil {
 			return nil, err
 		}

--- a/types/errors.go
+++ b/types/errors.go
@@ -76,6 +76,7 @@ var Errors = map[string]diagnostic.Template{
 	"T055": {Code: "T055", Message: "`%s` operand must be `int`, got %s", Help: "`skip` and `take` count rows; supply an integer expression."},
 	"T056": {Code: "T056", Message: "`sort by` expression must be an ordered type, got %s", Help: "Ordered types are int, int64, bigint, bigrat, float, bool, and string. Project a scalar field of an ordered type, or compare with an explicit key."},
 	"T057": {Code: "T057", Message: "`select distinct` expression must be a hashable type, got %s", Help: "Distinct deduplicates by structural equality. Function values do not have a stable hash. Project a scalar or record of scalars."},
+	"T058": {Code: "T058", Message: "dereference of optional `%s` requires a none guard", Help: "Narrow with `if %s != null { ... }` first, or supply a fallback (`?? default`)."},
 }
 
 // --- Wrapper Functions ---
@@ -219,6 +220,13 @@ func errUnknownField(pos lexer.Position, field string, typ Type) error {
 
 func errNotStruct(pos lexer.Position, typ Type) error {
 	return Errors["T027"].New(pos, typ)
+}
+
+func errOptionalDeref(pos lexer.Position, name string) error {
+	tmpl := Errors["T058"]
+	msg := fmt.Sprintf(tmpl.Message, name)
+	help := fmt.Sprintf(tmpl.Help, name)
+	return diagnostic.New(tmpl.Code, pos, msg, help)
 }
 
 func errFetchURLString(pos lexer.Position) error {

--- a/types/narrow.go
+++ b/types/narrow.go
@@ -1,0 +1,96 @@
+package types
+
+import "mochi/parser"
+
+// optionNarrowing inspects a boolean expression for `x == null` or
+// `x != null` patterns and reports which option-typed bindings can be
+// tightened to their wrapped element type in the truthy and falsy
+// branches. It implements MEP-16 N1 (if-condition narrowing).
+//
+// The function does not mutate env; the caller applies the result by
+// constructing narrowed child envs through narrowedEnv.
+func optionNarrowing(e *parser.Expr, env *Env) (truthy, falsy map[string]Type) {
+	if e == nil || e.Binary == nil || len(e.Binary.Right) != 1 {
+		return nil, nil
+	}
+	op := e.Binary.Right[0].Op
+	if op != "==" && op != "!=" {
+		return nil, nil
+	}
+
+	leftName := identFromUnary(e.Binary.Left)
+	rightName := identFromUnary(e.Binary.Right[0].Right)
+	leftNull := isNullLiteralUnary(e.Binary.Left)
+	rightNull := isNullLiteralUnary(e.Binary.Right[0].Right)
+
+	var bind string
+	switch {
+	case leftName != "" && rightNull:
+		bind = leftName
+	case rightName != "" && leftNull:
+		bind = rightName
+	default:
+		return nil, nil
+	}
+
+	t, err := env.GetVar(bind)
+	if err != nil {
+		return nil, nil
+	}
+	opt, ok := t.(OptionType)
+	if !ok {
+		return nil, nil
+	}
+	inner := map[string]Type{bind: opt.Elem}
+	if op == "!=" {
+		return inner, nil
+	}
+	return nil, inner
+}
+
+// identFromUnary returns the binding name if u is a bare identifier
+// (no postfix ops, no selector tail). It returns "" for anything more
+// structured: stage 1 only narrows on simple names.
+func identFromUnary(u *parser.Unary) string {
+	if u == nil || len(u.Ops) != 0 || u.Value == nil {
+		return ""
+	}
+	px := u.Value
+	if len(px.Ops) != 0 || px.Target == nil {
+		return ""
+	}
+	sel := px.Target.Selector
+	if sel == nil || len(sel.Tail) != 0 {
+		return ""
+	}
+	return sel.Root
+}
+
+// isNullLiteralUnary reports whether u is the bare `null` literal.
+func isNullLiteralUnary(u *parser.Unary) bool {
+	if u == nil || len(u.Ops) != 0 || u.Value == nil {
+		return false
+	}
+	px := u.Value
+	if len(px.Ops) != 0 || px.Target == nil {
+		return false
+	}
+	lit := px.Target.Lit
+	return lit != nil && lit.Null
+}
+
+// narrowedEnv returns a child env where each (name, type) in narrowed
+// shadows the parent binding. The child preserves the parent's
+// mutability flag for the binding. When narrowed is empty the parent
+// env is returned unchanged so the common path stays allocation-free.
+func narrowedEnv(env *Env, narrowed map[string]Type) *Env {
+	if len(narrowed) == 0 {
+		return env
+	}
+	child := NewEnv(env)
+	for name, t := range narrowed {
+		mut, _ := env.isMutable(name)
+		child.SetVar(name, t, mut)
+	}
+	return child
+}


### PR DESCRIPTION
First slice of MEP-16 stage 1. Tracks #21414.

## Summary
- `if x != null { ... }` narrows x from `Option<T>` to T in the then-branch; the `==` form narrows in the else-branch.
- Field access on an option-typed binding without a guard now errors with T058 and a hint to add a guard or `??` fallback.

## Test plan
- [x] `go test ./types/` passes, covering the two new valid fixtures and the new T058 error fixture.
- [x] `go test ./...` clean.