### PR TITLE
mep-0016: reject option vs non-option comparison (T059)

### DIFF
--- a/tests/types/errors/none_compared_with_int.err
+++ b/tests/types/errors/none_compared_with_int.err
@@ -1,0 +1,8 @@
+1. error[T059]: comparison with `none` requires an optional operand, got int
+  --> tests/types/errors/none_compared_with_int.mochi:4:13
+
+  4 | let bad = 5 == none
+    |             ^
+
+help:
+  `none` is the empty side of `Option<T>`; comparing it to a non-optional value can never be true. Either change the operand to `T?` or drop the comparison.

--- a/tests/types/errors/none_compared_with_int.mochi
+++ b/tests/types/errors/none_compared_with_int.mochi
@@ -1,0 +1,4 @@
+// MEP-16 T059: comparing `none` (or any option-typed value) against a
+// bare non-optional operand is rejected. The result can never be true
+// because the option's payload, when present, is wrapped in `Some`.
+let bad = 5 == none

--- a/tests/types/valid/option_compared_with_option.golden
+++ b/tests/types/valid/option_compared_with_option.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/option_compared_with_option.mochi
+++ b/tests/types/valid/option_compared_with_option.mochi
@@ -1,0 +1,8 @@
+// MEP-16 R3: comparing two option-typed values is well-typed. The
+// comparison happens at the option layer; T059 only fires when one
+// side is non-optional.
+let p: int? = 7
+let q: int? = none
+expect (p == none) == false
+expect (q == none) == true
+expect (p == q) == false

--- a/types/check_expr.go
+++ b/types/check_expr.go
@@ -143,6 +143,22 @@ func applyBinaryType(pos lexer.Position, op string, left, right Type) (Type, err
 		if isNumeric(left) && isNumeric(right) {
 			return BoolType{}, nil
 		}
+		// MEP-16 T059: comparing an option to a non-option is rejected
+		// only for equality. The result can never be true (an option's
+		// payload, when present, lives inside the `Some` wrapper, not
+		// at the same level as a bare value).
+		if op == "==" || op == "!=" {
+			if _, lOpt := left.(OptionType); lOpt {
+				if _, rOpt := right.(OptionType); !rOpt {
+					return nil, errNoneComparison(pos, right)
+				}
+			}
+			if _, rOpt := right.(OptionType); rOpt {
+				if _, lOpt := left.(OptionType); !lOpt {
+					return nil, errNoneComparison(pos, left)
+				}
+			}
+		}
 		return nil, errIncompatibleComparison(pos)
 	case "in":
 		switch rt := right.(type) {

--- a/types/errors.go
+++ b/types/errors.go
@@ -77,6 +77,7 @@ var Errors = map[string]diagnostic.Template{
 	"T056": {Code: "T056", Message: "`sort by` expression must be an ordered type, got %s", Help: "Ordered types are int, int64, bigint, bigrat, float, bool, and string. Project a scalar field of an ordered type, or compare with an explicit key."},
 	"T057": {Code: "T057", Message: "`select distinct` expression must be a hashable type, got %s", Help: "Distinct deduplicates by structural equality. Function values do not have a stable hash. Project a scalar or record of scalars."},
 	"T058": {Code: "T058", Message: "dereference of optional `%s` requires a none guard", Help: "Narrow with `if %s != none { ... }` first, or supply a fallback (`?? default`)."},
+	"T059": {Code: "T059", Message: "comparison with `none` requires an optional operand, got %s", Help: "`none` is the empty side of `Option<T>`; comparing it to a non-optional value can never be true. Either change the operand to `T?` or drop the comparison."},
 }
 
 // --- Wrapper Functions ---
@@ -227,6 +228,10 @@ func errOptionalDeref(pos lexer.Position, name string) error {
 	msg := fmt.Sprintf(tmpl.Message, name)
 	help := fmt.Sprintf(tmpl.Help, name)
 	return diagnostic.New(tmpl.Code, pos, msg, help)
+}
+
+func errNoneComparison(pos lexer.Position, other Type) error {
+	return Errors["T059"].New(pos, other)
 }
 
 func errFetchURLString(pos lexer.Position) error {


### PR DESCRIPTION
Implements MEP-16 R3 / T059. Tracks #21418.

## Summary
- Adds T059: comparing an option-typed value against a bare non-optional operand is rejected with a hint that points at the actual cause.
- `applyBinaryType` checks equality operators and emits T059 when exactly one side is `OptionType`.
- Two-option comparisons still type-check.

## Test plan
- [x] New error fixture `none_compared_with_int` covers the rejected form.
- [x] New valid fixture `option_compared_with_option` covers the accepted forms (\`x == none\`, \`p == q\`).
- [x] \`go test ./...\` clean.