### PR TITLE
mep-0016: narrow option bindings through `&&` / `||` (N2)

### DIFF
--- a/tests/types/valid/option_narrow_logical_and.golden
+++ b/tests/types/valid/option_narrow_logical_and.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/option_narrow_logical_and.mochi
+++ b/tests/types/valid/option_narrow_logical_and.mochi
@@ -1,0 +1,6 @@
+// MEP-16 N2: the RHS of `&&` sees the narrowing implied by the LHS
+// being truthy. After `p != none`, the binding p is typed as int in
+// the conjunction's right operand, so `p + 1` type-checks.
+let p: int? = 7
+let ok = p != none && p + 1 > 0
+expect ok == true

--- a/tests/types/valid/option_narrow_logical_chain.golden
+++ b/tests/types/valid/option_narrow_logical_chain.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/option_narrow_logical_chain.mochi
+++ b/tests/types/valid/option_narrow_logical_chain.mochi
@@ -1,0 +1,7 @@
+// MEP-16 N2: chained `&&` accumulates narrowings left-to-right. With
+// p and q both option-typed, after `p != none && q != none` both
+// bindings are narrowed for the final conjunct.
+let p: int? = 1
+let q: int? = 2
+let combined = p != none && q != none && p + q > 0
+expect combined == true

--- a/tests/types/valid/option_narrow_logical_or.golden
+++ b/tests/types/valid/option_narrow_logical_or.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/option_narrow_logical_or.mochi
+++ b/tests/types/valid/option_narrow_logical_or.mochi
@@ -1,0 +1,6 @@
+// MEP-16 N2: the RHS of `||` sees the falsy-side narrowing of the
+// LHS. After `p == none` is rejected, p is typed as int in the second
+// operand so `p > 0` type-checks.
+let p: int? = 3
+let safe = p == none || p > 0
+expect safe == true

--- a/types/check_expr.go
+++ b/types/check_expr.go
@@ -28,6 +28,17 @@ func checkExprWithExpected(e *parser.Expr, env *Env, expected Type) (Type, error
 	return actual, nil
 }
 func checkBinaryExpr(b *parser.BinaryExpr, env *Env, expected Type) (Type, error) {
+	// MEP-16 N2: split the chain at the lowest-precedence boolean
+	// operator and recurse. The RHS of `&&` is checked with the LHS's
+	// truthy narrowing applied; the RHS of `||` is checked with the
+	// falsy narrowing. Precedence climbing handles every other op.
+	if idx := lastLogicalIndex(b, "||"); idx >= 0 {
+		return checkLogicalChain(b, idx, "||", env)
+	}
+	if idx := lastLogicalIndex(b, "&&"); idx >= 0 {
+		return checkLogicalChain(b, idx, "&&", env)
+	}
+
 	left, err := checkUnary(b.Left, env, expected)
 	if err != nil {
 		return nil, err
@@ -85,6 +96,34 @@ func checkBinaryExpr(b *parser.BinaryExpr, env *Env, expected Type) (Type, error
 		return nil, fmt.Errorf("unexpected state after binary type eval")
 	}
 	return operands[0], nil
+}
+
+// checkLogicalChain type-checks a binary expression whose chain
+// contains the logical operator op at position idx. The RHS sub-binary
+// is evaluated under the narrowing implied by the LHS being truthy
+// (for `&&`) or falsy (for `||`); the operator is then applied between
+// the two side types. Used by MEP-16 N2.
+func checkLogicalChain(b *parser.BinaryExpr, idx int, op string, env *Env) (Type, error) {
+	lhs, rhs := splitBinaryAt(b, idx)
+	lhsType, err := checkBinaryExpr(lhs, env, nil)
+	if err != nil {
+		return nil, err
+	}
+	truthy, falsy := optionNarrowingBinary(lhs, env)
+	var rhsEnv *Env
+	switch op {
+	case "&&":
+		rhsEnv = narrowedEnv(env, truthy)
+	case "||":
+		rhsEnv = narrowedEnv(env, falsy)
+	default:
+		rhsEnv = env
+	}
+	rhsType, err := checkBinaryExpr(rhs, rhsEnv, nil)
+	if err != nil {
+		return nil, err
+	}
+	return applyBinaryType(b.Right[idx].Pos, op, lhsType, rhsType)
 }
 
 func applyBinaryType(pos lexer.Position, op string, left, right Type) (Type, error) {

--- a/types/narrow.go
+++ b/types/narrow.go
@@ -2,26 +2,57 @@ package types
 
 import "mochi/parser"
 
-// optionNarrowing inspects a boolean expression for `x == none` or
-// `x != none` patterns and reports which option-typed bindings can be
-// tightened to their wrapped element type in the truthy and falsy
-// branches. It implements MEP-16 N1 (if-condition narrowing).
+// optionNarrowing inspects a boolean expression and reports which
+// option-typed bindings can be tightened to their wrapped element type
+// in the truthy and falsy branches. It implements MEP-16 N1 (if-cond
+// narrowing) and N2 (propagation through `&&` and `||`).
 //
 // The function does not mutate env; the caller applies the result by
 // constructing narrowed child envs through narrowedEnv.
 func optionNarrowing(e *parser.Expr, env *Env) (truthy, falsy map[string]Type) {
-	if e == nil || e.Binary == nil || len(e.Binary.Right) != 1 {
+	if e == nil {
 		return nil, nil
 	}
-	op := e.Binary.Right[0].Op
+	return optionNarrowingBinary(e.Binary, env)
+}
+
+// optionNarrowingBinary is the recursive worker that walks a binary
+// expression tree. It splits the chain at the lowest-precedence boolean
+// operator and combines the per-side narrowings using the truth-table
+// rules from MEP-16 §N2.
+func optionNarrowingBinary(b *parser.BinaryExpr, env *Env) (truthy, falsy map[string]Type) {
+	if b == nil {
+		return nil, nil
+	}
+	if idx := lastLogicalIndex(b, "||"); idx >= 0 {
+		lhs, rhs := splitBinaryAt(b, idx)
+		lt, lf := optionNarrowingBinary(lhs, env)
+		// MEP-16 N2: when `||` is false, both sides are false. The RHS
+		// is checked in the LHS falsy-narrowed env so chained patterns
+		// like `x == none || y == none` accumulate narrowings.
+		rt, rf := optionNarrowingBinary(rhs, narrowedEnv(env, lf))
+		_, _ = lt, rt
+		return nil, mergeNarrowings(lf, rf)
+	}
+	if idx := lastLogicalIndex(b, "&&"); idx >= 0 {
+		lhs, rhs := splitBinaryAt(b, idx)
+		lt, lf := optionNarrowingBinary(lhs, env)
+		rt, rf := optionNarrowingBinary(rhs, narrowedEnv(env, lt))
+		_, _ = lf, rf
+		return mergeNarrowings(lt, rt), nil
+	}
+	if len(b.Right) != 1 {
+		return nil, nil
+	}
+	op := b.Right[0].Op
 	if op != "==" && op != "!=" {
 		return nil, nil
 	}
 
-	leftName := identFromUnary(e.Binary.Left)
-	rightName := identFromUnary(e.Binary.Right[0].Right)
-	leftNone := isNoneLiteralUnary(e.Binary.Left)
-	rightNone := isNoneLiteralUnary(e.Binary.Right[0].Right)
+	leftName := identFromUnary(b.Left)
+	rightName := identFromUnary(b.Right[0].Right)
+	leftNone := isNoneLiteralUnary(b.Left)
+	rightNone := isNoneLiteralUnary(b.Right[0].Right)
 
 	var bind string
 	switch {
@@ -46,6 +77,47 @@ func optionNarrowing(e *parser.Expr, env *Env) (truthy, falsy map[string]Type) {
 		return inner, nil
 	}
 	return nil, inner
+}
+
+// lastLogicalIndex returns the index of the rightmost occurrence of op
+// in b.Right, or -1 when absent. Splitting at the rightmost match keeps
+// the chain left-associative.
+func lastLogicalIndex(b *parser.BinaryExpr, op string) int {
+	for i := len(b.Right) - 1; i >= 0; i-- {
+		if b.Right[i].Op == op {
+			return i
+		}
+	}
+	return -1
+}
+
+// splitBinaryAt slices b into the sub-binaries that flank the operator
+// at idx. The returned binaries share AST nodes with b; callers must
+// not mutate them.
+func splitBinaryAt(b *parser.BinaryExpr, idx int) (lhs, rhs *parser.BinaryExpr) {
+	lhs = &parser.BinaryExpr{Left: b.Left, Right: b.Right[:idx]}
+	rhs = &parser.BinaryExpr{Left: b.Right[idx].Right, Right: b.Right[idx+1:]}
+	return lhs, rhs
+}
+
+// mergeNarrowings unions two narrowing maps. When the same binding
+// appears on both sides the right map wins; in practice both sides
+// agree because they narrow Option<T> to the same T.
+func mergeNarrowings(a, b map[string]Type) map[string]Type {
+	if len(a) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return a
+	}
+	out := make(map[string]Type, len(a)+len(b))
+	for k, v := range a {
+		out[k] = v
+	}
+	for k, v := range b {
+		out[k] = v
+	}
+	return out
 }
 
 // identFromUnary returns the binding name if u is a bare identifier

--- a/website/docs/mep/mep-0016.md
+++ b/website/docs/mep/mep-0016.md
@@ -69,7 +69,7 @@ There is a second force. MEP-14 (Query Algebra) left a deferred item: the right 
 | Coalesce operator `??`                                            | **open** |
 | Flow narrowing on `if x == none { ... } else { ... }`             | **open** |
 | Flow narrowing on `if x != none { ... } else { ... }`             | **open** |
-| Flow narrowing on `x != none && ...` / `x == none \|\| ...`       | **open** |
+| Flow narrowing on `x != none && ...` / `x == none \|\| ...`       | closed |
 | `match x { none => ..., _ => /* x : T */ }` narrowing             | **open** |
 | `map<K, V>` index returns `V?`                                    | **open** |
 | `left join` right side becomes `Option<T>` (MEP-14)               | **open** |


### PR DESCRIPTION
## Summary
- Split binary expressions at the lowest-precedence boolean operator and re-check the RHS in an env where the LHS narrowing is applied (`&&` propagates truthy narrowing, `||` propagates falsy).
- Extend the narrowing engine to walk `&&`/`||` chains recursively and merge per-side narrowings per the MEP-16 §N2 truth table.
- Add three valid fixtures covering single `&&`, single `||`, and a multi-binding chain.
- Mark the §N2 entry in the MEP-16 status table as closed.

Closes #21420.

## Test plan
- [x] `go test ./types/...`
- [x] `go test ./...`
- [x] Verified the same expressions fail without N2 (option arithmetic and option comparison both rejected with T020 / T013).