### PR TITLE
mep-0016: narrow option scrutinee in `match` arms (N3)

### DIFF
--- a/tests/types/valid/option_narrow_match_chained.golden
+++ b/tests/types/valid/option_narrow_match_chained.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/option_narrow_match_chained.mochi
+++ b/tests/types/valid/option_narrow_match_chained.mochi
@@ -1,0 +1,8 @@
+// MEP-16 N3: narrowing applies to the whole arm body, so multiple
+// uses of the scrutinee inside the wildcard arm all see T.
+let p: int? = 4
+let result: int = match p {
+  none => -1
+  _ => p * p + p
+}
+expect result == 20

--- a/tests/types/valid/option_narrow_match_wildcard.golden
+++ b/tests/types/valid/option_narrow_match_wildcard.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/option_narrow_match_wildcard.mochi
+++ b/tests/types/valid/option_narrow_match_wildcard.mochi
@@ -1,0 +1,9 @@
+// MEP-16 N3: when the scrutinee of a `match` is a bare option-typed
+// binding, the wildcard arm sees the binding narrowed to T because
+// the `none` arm matched and short-circuited everything else.
+let p: int? = 5
+let label: int = match p {
+  none => 0
+  _ => p + 1
+}
+expect label == 6

--- a/types/check_expr.go
+++ b/types/check_expr.go
@@ -1221,6 +1221,12 @@ func checkMatchExpr(m *parser.MatchExpr, env *Env, expected Type) (Type, error) 
 	if err != nil {
 		return nil, err
 	}
+	// MEP-16 N3: when the scrutinee is a bare option-typed binding, the
+	// arm whose pattern is `none` keeps the binding's option type; every
+	// other arm proves the value is non-none, so the binding narrows to
+	// the wrapped element. The narrowing is applied per arm below.
+	scrutineeName := bareIdentName(m.Target)
+	scrutineeElem, scrutineeIsOption := optionElem(targetType)
 	var resultType Type
 	// MEP-10 A4: track variant coverage when the scrutinee is a union.
 	// A wildcard `_` (or an identifier binding that does not name a
@@ -1296,6 +1302,15 @@ func checkMatchExpr(m *parser.MatchExpr, env *Env, expected Type) (Type, error) 
 			}
 		} else {
 			hasCatchAll = true
+		}
+		// MEP-16 N3: apply scrutinee narrowing. The `none` literal arm
+		// leaves the binding option-typed; any other pattern narrows it
+		// to the wrapped element since `none` would have matched the
+		// none arm and short-circuited.
+		if scrutineeIsOption && scrutineeName != "" {
+			if !isNoneLiteralExpr(c.Pattern) {
+				caseEnv = narrowedEnv(caseEnv, map[string]Type{scrutineeName: scrutineeElem})
+			}
 		}
 		if c.Result == nil {
 			for _, st := range c.Block {

--- a/types/narrow.go
+++ b/types/narrow.go
@@ -138,6 +138,25 @@ func identFromUnary(u *parser.Unary) string {
 	return sel.Root
 }
 
+// isNoneLiteralExpr reports whether e is the bare `none` literal. It
+// drives MEP-16 N3 match-arm narrowing: a `none` pattern leaves the
+// scrutinee option-typed, while every other arm narrows it to T.
+func isNoneLiteralExpr(e *parser.Expr) bool {
+	if e == nil || e.Binary == nil || len(e.Binary.Right) != 0 {
+		return false
+	}
+	return isNoneLiteralUnary(e.Binary.Left)
+}
+
+// optionElem unwraps an OptionType to its element. The second return
+// reports whether t was an option in the first place.
+func optionElem(t Type) (Type, bool) {
+	if opt, ok := t.(OptionType); ok {
+		return opt.Elem, true
+	}
+	return nil, false
+}
+
 // isNoneLiteralUnary reports whether u is the bare `none` literal.
 func isNoneLiteralUnary(u *parser.Unary) bool {
 	if u == nil || len(u.Ops) != 0 || u.Value == nil {

--- a/website/docs/mep/mep-0016.md
+++ b/website/docs/mep/mep-0016.md
@@ -70,7 +70,7 @@ There is a second force. MEP-14 (Query Algebra) left a deferred item: the right 
 | Flow narrowing on `if x == none { ... } else { ... }`             | **open** |
 | Flow narrowing on `if x != none { ... } else { ... }`             | **open** |
 | Flow narrowing on `x != none && ...` / `x == none \|\| ...`       | closed |
-| `match x { none => ..., _ => /* x : T */ }` narrowing             | **open** |
+| `match x { none => ..., _ => /* x : T */ }` narrowing             | closed |
 | `map<K, V>` index returns `V?`                                    | **open** |
 | `left join` right side becomes `Option<T>` (MEP-14)               | **open** |
 | `right join` left side becomes `Option<T>` (MEP-14)               | **open** |


### PR DESCRIPTION
## Summary
- Detect when the scrutinee of a `match` is a bare option-typed binding and narrow it in every arm whose pattern is not the bare `none` literal.
- Add `isNoneLiteralExpr` and `optionElem` helpers in `types/narrow.go`.
- Add valid fixtures: wildcard arm narrowing, and a multi-use arm body that requires the narrowing.
- Mark the §N3 entry in the MEP-16 status table as closed.

The none-arm path still rejects unguarded deref (verified locally with `match p { none => p + 1, _ => p }` returning T020), so the narrowing only fires where it should.

Closes #21422.

## Test plan
- [x] `go test ./types/...`
- [x] `go test ./...`