### PR TITLE
mep-0016: apply N1 narrowing in if-statements

### DIFF
--- a/tests/types/valid/option_narrow_if_stmt.golden
+++ b/tests/types/valid/option_narrow_if_stmt.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/option_narrow_if_stmt.mochi
+++ b/tests/types/valid/option_narrow_if_stmt.mochi
@@ -1,0 +1,8 @@
+// MEP-16 N1 (if-statement form): `if x != none { ... }` narrows x to
+// T in the then-block, mirroring the if-expression case.
+let p: int? = 9
+var sum: int = 0
+if p != none {
+  sum = p + 1
+}
+expect sum == 10

--- a/tests/types/valid/option_narrow_if_stmt_else.golden
+++ b/tests/types/valid/option_narrow_if_stmt_else.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/option_narrow_if_stmt_else.mochi
+++ b/tests/types/valid/option_narrow_if_stmt_else.mochi
@@ -1,0 +1,10 @@
+// MEP-16 N1 (if-statement form): the else-block of `if x == none`
+// sees x narrowed to T.
+let p: int? = 4
+var doubled: int = 0
+if p == none {
+  doubled = 0
+} else {
+  doubled = p * 2
+}
+expect doubled == 8

--- a/types/check.go
+++ b/types/check.go
@@ -1115,16 +1115,20 @@ func checkIfStmt(stmt *parser.IfStmt, env *Env, expectedReturn Type, inLoop bool
 	if !unify(condT, BoolType{}, nil) {
 		return errIfCondBoolean(stmt.Cond.Pos)
 	}
-	child := NewEnv(env)
+	// MEP-16 N1: same narrowing the if-expression path applies. The
+	// then-block sees the truthy narrowing and the else-block sees the
+	// falsy narrowing of bare option-typed bindings compared to `none`.
+	truthy, falsy := optionNarrowing(stmt.Cond, env)
+	child := NewEnv(narrowedEnv(env, truthy))
 	for _, s := range stmt.Then {
 		if err := checkStmt(s, child, expectedReturn, inLoop); err != nil {
 			return err
 		}
 	}
 	if stmt.ElseIf != nil {
-		return checkIfStmt(stmt.ElseIf, env, expectedReturn, inLoop)
+		return checkIfStmt(stmt.ElseIf, narrowedEnv(env, falsy), expectedReturn, inLoop)
 	}
-	elseChild := NewEnv(env)
+	elseChild := NewEnv(narrowedEnv(env, falsy))
 	for _, s := range stmt.Else {
 		if err := checkStmt(s, elseChild, expectedReturn, inLoop); err != nil {
 			return err


### PR DESCRIPTION
## Summary
- Plumb `optionNarrowing` into `checkIfStmt` so the then-block sees the truthy narrowing and the else-block (or chained `else if`) sees the falsy narrowing, symmetric to `checkIfExpr`.
- Add valid fixtures covering `if p != none { ... }` and `if p == none { ... } else { ... }` at statement level.
- Mark the two §N1 entries in the MEP-16 status table as closed.

Closes #21424.

## Test plan
- [x] `go test ./types/...`
- [x] `go test ./...`