### PR TITLE
mep-0016: invalidate option narrowing on reassign and closure entry (N4, N6)

### DIFF
--- a/tests/types/errors/option_narrow_closure_boundary.err
+++ b/tests/types/errors/option_narrow_closure_boundary.err
@@ -1,0 +1,8 @@
+1. error[T020]: operator `+` cannot be used on types option[int] and int
+  --> tests/types/errors/option_narrow_closure_boundary.mochi:6:33
+
+  6 |   let f = fun(): int { return x + 1 }
+    |                                 ^
+
+help:
+  Choose an operator that supports these operand types.

--- a/tests/types/errors/option_narrow_closure_boundary.mochi
+++ b/tests/types/errors/option_narrow_closure_boundary.mochi
@@ -1,0 +1,9 @@
+// MEP-16 N6: a closure body resets narrowing to the declared type.
+// `x` is `int?` inside the lambda even though the surrounding scope
+// narrowed it to `int`.
+var x: int? = 5
+if x != none {
+  let f = fun(): int { return x + 1 }
+  let r: int = f()
+  expect r == 6
+}

--- a/tests/types/errors/option_narrow_reassign.err
+++ b/tests/types/errors/option_narrow_reassign.err
@@ -1,0 +1,8 @@
+1. error[T020]: operator `+` cannot be used on types option[int] and int
+  --> tests/types/errors/option_narrow_reassign.mochi:10:18
+
+ 10 |   let b: int = x + 1
+    |                  ^
+
+help:
+  Choose an operator that supports these operand types.

--- a/tests/types/errors/option_narrow_reassign.mochi
+++ b/tests/types/errors/option_narrow_reassign.mochi
@@ -1,0 +1,13 @@
+// MEP-16 N4: reassignment inside a narrowed scope drops the narrowing
+// from the assignment site onward. The second `x + 1` sees `x : int?`
+// again and is rejected by R4 (T008).
+fun maybe(): int? { return none }
+
+var x: int? = 5
+if x != none {
+  let a: int = x + 1
+  x = maybe()
+  let b: int = x + 1
+  expect a == 6
+  expect b == 0
+}

--- a/tests/types/valid/option_narrow_reassign_keeps.golden
+++ b/tests/types/valid/option_narrow_reassign_keeps.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/option_narrow_reassign_keeps.mochi
+++ b/tests/types/valid/option_narrow_reassign_keeps.mochi
@@ -1,0 +1,10 @@
+// MEP-16 N4: when the reassignment RHS is a non-option `T`, the
+// narrowing stays valid because the binding is still proven non-`none`.
+var x: int? = 1
+if x != none {
+  let a: int = x + 10
+  x = 7
+  let b: int = x + 100
+  expect a == 11
+  expect b == 107
+}

--- a/types/check.go
+++ b/types/check.go
@@ -604,7 +604,11 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 		return nil
 
 	case s.Assign != nil:
-		lhsType, err := env.GetVar(s.Assign.Name)
+		// MEP-16 N4: when the LHS binding is narrowed (e.g., inside
+		// `if x != none { ... }`), the assignment must reference the
+		// declared type, not the narrowed shadow. Otherwise rebinding to
+		// the wider option type would be rejected.
+		lhsType, err := env.DeclaredVarType(s.Assign.Name)
 		if err != nil {
 			return errAssignUndeclared(s.Assign.Pos, s.Assign.Name)
 		}
@@ -730,7 +734,10 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 		if err != nil {
 			return err
 		}
-		if !unify(lhsType, rhsType, nil) {
+		// MEP-10 R1 also covers assignment: a non-option `int` flows
+		// into an `int?` slot via auto-wrap. The let-binding path
+		// already uses Assignable; mirror it here.
+		if !unify(lhsType, rhsType, nil) && !Assignable(rhsType, lhsType) {
 			return errCannotAssign(s.Assign.Pos, rhsType, s.Assign.Name, lhsType)
 		}
 		// MEP-10 B3d: when the LHS targets a slot reached through an

--- a/types/check_expr.go
+++ b/types/check_expr.go
@@ -972,7 +972,10 @@ func checkFunExpr(f *parser.FunExpr, env *Env, expected Type, pos lexer.Position
 		declaredRet = &TypeVar{Name: "R"}
 	}
 
-	child := NewEnv(env)
+	// MEP-16 N6: the closure may run after the outer scope mutates a
+	// narrowed binding. Strip any flow-narrowed shadows so the body
+	// reads outer bindings at their declared types.
+	child := NewEnv(closureBoundaryEnv(env))
 	for i, p := range f.Params {
 		child.SetVar(p.Name, paramTypes[i], true)
 	}

--- a/types/env.go
+++ b/types/env.go
@@ -28,6 +28,12 @@ type Env struct {
 	funcs   map[string]*parser.FunStmt   // function declarations
 	models  map[string]ModelSpec         // model aliases
 
+	// narrowed marks bindings whose entry in `types` is a flow-narrowed
+	// shadow rather than a fresh declaration. `declaredVarType` skips
+	// these so MEP-16 N4 can resolve an assignment's target against the
+	// original declared type rather than the tightened option element.
+	narrowed map[string]bool
+
 	// typeParams holds the active generic type parameters in this scope.
 	// resolveTypeRef consults this so that names like `T` and `K` inside
 	// a `fun foo<T, K>(...)` signature resolve to the same TypeVar
@@ -91,6 +97,7 @@ func NewEnv(parent *Env) *Env {
 		values:  make(map[string]any),
 		funcs:   make(map[string]*parser.FunStmt),
 		models:  make(map[string]ModelSpec),
+		narrowed: make(map[string]bool),
 		typeParams: make(map[string]*TypeVar),
 		output:  out,
 		input:   in,
@@ -254,6 +261,36 @@ func (e *Env) GetVar(name string) (Type, error) {
 		return e.parent.GetVar(name)
 	}
 	return nil, fmt.Errorf("undefined variable: %s", name)
+}
+
+// DeclaredVarType looks up the binding's declared type, skipping any
+// narrowed shadow installed by flow narrowing. Returns the original
+// type the binding was declared with (e.g., `int?` even when narrowed
+// to `int` in the current scope). Falls back to GetVar when no
+// declaration is found, which would be a bug elsewhere in the checker.
+func (e *Env) DeclaredVarType(name string) (Type, error) {
+	if t, ok := e.types[name]; ok && !e.narrowed[name] {
+		return t, nil
+	}
+	if e.parent != nil {
+		return e.parent.DeclaredVarType(name)
+	}
+	if t, ok := e.types[name]; ok {
+		return t, nil
+	}
+	return nil, fmt.Errorf("undefined variable: %s", name)
+}
+
+// IsNarrowed reports whether name's current binding in env or any parent
+// is a flow-narrowed shadow (true) rather than a plain declaration.
+func (e *Env) IsNarrowed(name string) bool {
+	if _, ok := e.types[name]; ok {
+		return e.narrowed[name]
+	}
+	if e.parent != nil {
+		return e.parent.IsNarrowed(name)
+	}
+	return false
 }
 
 func (e *Env) isMutable(name string) (bool, bool) {

--- a/types/narrow.go
+++ b/types/narrow.go
@@ -172,8 +172,10 @@ func isNoneLiteralUnary(u *parser.Unary) bool {
 
 // narrowedEnv returns a child env where each (name, type) in narrowed
 // shadows the parent binding. The child preserves the parent's
-// mutability flag for the binding. When narrowed is empty the parent
-// env is returned unchanged so the common path stays allocation-free.
+// mutability flag for the binding and marks the shadow so MEP-16 N4
+// can recover the declared type at assignment sites. When narrowed is
+// empty the parent env is returned unchanged so the common path stays
+// allocation-free.
 func narrowedEnv(env *Env, narrowed map[string]Type) *Env {
 	if len(narrowed) == 0 {
 		return env
@@ -182,6 +184,40 @@ func narrowedEnv(env *Env, narrowed map[string]Type) *Env {
 	for name, t := range narrowed {
 		mut, _ := env.isMutable(name)
 		child.SetVar(name, t, mut)
+		child.narrowed[name] = true
 	}
 	return child
+}
+
+// closureBoundaryEnv strips every flow-narrowed shadow visible from env
+// by overlaying the declared types of those bindings. Closures cannot
+// rely on outer narrowing because the body may run after the outer
+// scope has reassigned the binding; MEP-16 N6 resets to declared types
+// at the closure boundary.
+func closureBoundaryEnv(env *Env) *Env {
+	if env == nil {
+		return env
+	}
+	collected := map[string]Type{}
+	for e := env; e != nil; e = e.parent {
+		for name := range e.narrowed {
+			if _, seen := collected[name]; seen {
+				continue
+			}
+			declared, err := env.DeclaredVarType(name)
+			if err != nil {
+				continue
+			}
+			collected[name] = declared
+		}
+	}
+	if len(collected) == 0 {
+		return env
+	}
+	out := NewEnv(env)
+	for name, t := range collected {
+		mut, _ := env.isMutable(name)
+		out.SetVar(name, t, mut)
+	}
+	return out
 }


### PR DESCRIPTION
Closes #21430.

## Summary

- **N4 (reassignment)**: assignments inside a narrowed scope resolve the LHS via the declared type. Option-typed RHS drops the narrowing for the rest of the block; bare `T` RHS keeps it.
- **N6 (closure boundary)**: closure bodies read captured narrowed bindings at their declared option types.
- Plumbing: `Env.narrowed` map plus `DeclaredVarType` / `IsNarrowed` helpers; `narrowedEnv` marks shadows; assignment check falls back to `Assignable` so R1 auto-wrap applies on reassignment too.

N5 (call invalidation) is deferred to a follow-up because it depends on MEP-15 purity to avoid being disruptively conservative.

## Test plan

- [x] `go test ./types/`
- [x] `go test ./...`