### PR TITLE
mep-0016: add safe ?. and ?[ ] postfix operators (Stage 2)

### DIFF
--- a/ast/convert.go
+++ b/ast/convert.go
@@ -511,6 +511,10 @@ func FromPostfixExpr(p *parser.PostfixExpr) *Node {
 			n = &Node{Kind: "cast", Pos: cast.Pos, Children: []*Node{n, FromTypeRef(cast.Type)}}
 		} else if field := op.Field; field != nil {
 			n = &Node{Kind: "selector", Value: field.Name, Pos: field.Pos, Children: []*Node{n}}
+		} else if sf := op.SafeField; sf != nil {
+			n = &Node{Kind: "safe_selector", Value: sf.Name, Pos: sf.Pos, Children: []*Node{n}}
+		} else if si := op.SafeIndex; si != nil {
+			n = &Node{Kind: "safe_index", Pos: si.Pos, Children: []*Node{n, FromExpr(si.Start)}}
 		}
 	}
 	return n

--- a/ast/printer.go
+++ b/ast/printer.go
@@ -289,6 +289,10 @@ func exprString(n *Node) string {
 			return fmt.Sprintf("%v", n.Value)
 		}
 		return exprString(n.Children[0]) + "." + n.Value.(string)
+	case "safe_selector":
+		return exprString(n.Children[0]) + "?." + n.Value.(string)
+	case "safe_index":
+		return fmt.Sprintf("%s?[%s]", exprString(n.Children[0]), exprString(n.Children[1]))
 	case "call":
 		start := 0
 		var callee string

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -354,11 +354,30 @@ type PostfixExpr struct {
 }
 
 type PostfixOp struct {
+	Pos         lexer.Position `json:"pos,omitempty" parser:""`
+	Call        *CallOp        `json:"call,omitempty" parser:"@@"`
+	SafeField   *SafeFieldOp   `json:"safe_field,omitempty" parser:"| @@"`
+	SafeIndex   *SafeIndexOp   `json:"safe_index,omitempty" parser:"| @@"`
+	Index       *IndexOp       `json:"index,omitempty" parser:"| @@"`
+	Field       *FieldOp       `json:"field,omitempty" parser:"| @@"`
+	Cast        *CastOp        `json:"cast,omitempty" parser:"| @@"`
+}
+
+// SafeFieldOp models the MEP-16 `?.` postfix selector. `a?.f` reads as
+// "if a holds a value, take field f, otherwise none". The type checker
+// requires the receiver to be option-typed and lifts the field type
+// back into `Option`.
+type SafeFieldOp struct {
+	Pos  lexer.Position `json:"pos,omitempty" parser:""`
+	Name string         `json:"name,omitempty" parser:"'?' '.' @Ident"`
+}
+
+// SafeIndexOp models the MEP-16 `?[ ]` postfix index. `a?[k]` reads as
+// "if a holds a value, look up k, otherwise none". The receiver must
+// be `list<T>?` or `map<K, V>?`; the element type is option-wrapped.
+type SafeIndexOp struct {
 	Pos   lexer.Position `json:"pos,omitempty" parser:""`
-	Call  *CallOp        `json:"call,omitempty" parser:"@@"`
-	Index *IndexOp       `json:"index,omitempty" parser:"| @@"`
-	Field *FieldOp       `json:"field,omitempty" parser:"| @@"`
-	Cast  *CastOp        `json:"cast,omitempty" parser:"| @@"`
+	Start *Expr          `json:"start,omitempty" parser:"'?' '[' @@ ']'"`
 }
 
 type FieldOp struct {

--- a/parser/invariants.go
+++ b/parser/invariants.go
@@ -287,9 +287,9 @@ func assertPostfixOp(op *PostfixOp) error {
 	if op == nil {
 		return invariant(lexer.Position{}, "postfix op is nil")
 	}
-	arms := [...]bool{op.Call != nil, op.Index != nil, op.Field != nil, op.Cast != nil}
+	arms := [...]bool{op.Call != nil, op.Index != nil, op.Field != nil, op.Cast != nil, op.SafeField != nil, op.SafeIndex != nil}
 	if n := countTrue(arms[:]); n != 1 {
-		return invariant(op.Pos, fmt.Sprintf("postfix op has %d arms set, expected exactly 1 of {call, index, field, cast}", n))
+		return invariant(op.Pos, fmt.Sprintf("postfix op has %d arms set, expected exactly 1 of {call, index, field, cast, safe_field, safe_index}", n))
 	}
 	switch {
 	case op.Call != nil:

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1262,6 +1262,20 @@ func (fc *funcCompiler) compilePostfix(p *parser.PostfixExpr) int {
 			dst := fc.newReg()
 			fc.emit(op.Cast.Pos, Instr{Op: OpCast, A: dst, B: r, C: idx})
 			r = dst
+		} else if sf := op.SafeField; sf != nil {
+			// MEP-16 R5: lower `a?.f` to OpIndex with the field name as
+			// key. OpIndex already short-circuits on a null receiver.
+			key := fc.constReg(op.Pos, Value{Tag: ValueStr, Str: sf.Name})
+			dst := fc.newReg()
+			fc.emit(op.Pos, Instr{Op: OpIndex, A: dst, B: r, C: key})
+			r = dst
+		} else if si := op.SafeIndex; si != nil {
+			// MEP-16 R6: lower `a?[k]` to OpIndex. OpIndex returns null
+			// when the source is null, which preserves the option layer.
+			idx := fc.compileExpr(si.Start)
+			dst := fc.newReg()
+			fc.emit(op.Pos, Instr{Op: OpIndex, A: dst, B: r, C: idx})
+			r = dst
 		}
 	}
 	return r
@@ -3076,6 +3090,8 @@ func (fc *funcCompiler) evalConstPostfix(p *parser.PostfixExpr) (Value, bool) {
 			}
 			v = FromAny(cv)
 		case op.Call != nil || op.Index != nil || op.Field != nil:
+			return Value{}, false
+		case op.SafeField != nil || op.SafeIndex != nil:
 			return Value{}, false
 		}
 	}

--- a/tests/parser/valid/safe_postfix.golden
+++ b/tests/parser/valid/safe_postfix.golden
@@ -1,0 +1,16 @@
+(program
+  (let a
+    (safe_selector f (selector b))
+  )
+  (let c
+    (safe_selector h
+      (safe_selector g (selector d))
+    )
+  )
+  (let e
+    (safe_index (selector f) (int 0))
+  )
+  (let g
+    (safe_index (selector h) (selector k))
+  )
+)

--- a/tests/parser/valid/safe_postfix.mochi
+++ b/tests/parser/valid/safe_postfix.mochi
@@ -1,0 +1,4 @@
+let a = b?.f
+let c = d?.g?.h
+let e = f?[0]
+let g = h?[k]

--- a/tests/types/errors/safe_field_non_option.err
+++ b/tests/types/errors/safe_field_non_option.err
@@ -1,0 +1,8 @@
+1. error[T060]: safe-call `?.value` requires an option-typed receiver, got Box
+  --> tests/types/errors/safe_field_non_option.mochi:5:10
+
+  5 | let v = b?.value
+    |          ^
+
+help:
+  `a?.f` is only defined when `a : T?`. Drop the `?` for a plain field access, or change the receiver's type.

--- a/tests/types/errors/safe_field_non_option.mochi
+++ b/tests/types/errors/safe_field_non_option.mochi
@@ -1,0 +1,5 @@
+// MEP-16 R5: `?.` is only defined for option-typed receivers. Applying
+// it to a bare `T` is meaningless.
+type Box { value: int }
+let b: Box = Box { value: 1 }
+let v = b?.value

--- a/tests/types/errors/safe_index_non_option.err
+++ b/tests/types/errors/safe_index_non_option.err
@@ -1,0 +1,8 @@
+1. error[T062]: safe-index `?[ ]` requires an option-typed receiver, got [int]
+  --> tests/types/errors/safe_index_non_option.mochi:3:11
+
+  3 | let v = xs?[0]
+    |           ^
+
+help:
+  `a?[k]` is only defined when `a : list<T>?` or `a : map<K, V>?`. Drop the `?` for a plain index access.

--- a/tests/types/errors/safe_index_non_option.mochi
+++ b/tests/types/errors/safe_index_non_option.mochi
@@ -1,0 +1,3 @@
+// MEP-16 R6: `?[ ]` is only defined for option-typed receivers.
+let xs: list<int> = [1, 2, 3]
+let v = xs?[0]

--- a/tests/types/valid/option_safe_postfix.golden
+++ b/tests/types/valid/option_safe_postfix.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/option_safe_postfix.mochi
+++ b/tests/types/valid/option_safe_postfix.mochi
@@ -1,0 +1,15 @@
+// MEP-16 R5/R6: `?.` and `?[ ]` lift the field/element type back into
+// `Option`. The receiver must be option-typed.
+type Person { name: string, age: int }
+let p: Person? = Person { name: "ada", age: 30 }
+let n: string? = p?.name
+
+let xs: list<int>? = [1, 2, 3]
+let head: int? = xs?[0]
+
+let ys: list<int>? = none
+let miss: int? = ys?[0]
+
+expect n != none
+expect head != none
+expect miss == none

--- a/types/check_expr.go
+++ b/types/check_expr.go
@@ -405,10 +405,102 @@ func checkPostfix(p *parser.PostfixExpr, env *Env, expected Type) (Type, error) 
 				return nil, errInvalidCast(op.Pos, typ, target)
 			}
 			typ = target
+		} else if sf := op.SafeField; sf != nil {
+			// MEP-16 R5: `a?.f` requires `a : T?` and lifts `T.f : U`
+			// back into `U?`. If the receiver is already `U?` from an
+			// earlier `?.` step, the rule chains.
+			opt, ok := typ.(OptionType)
+			if !ok {
+				if _, isAny := typ.(AnyType); isAny {
+					typ = OptionType{Elem: AnyType{}}
+					continue
+				}
+				return nil, errSafeFieldNonOption(op.Pos, sf.Name, typ)
+			}
+			fieldT, err := safeFieldType(op.Pos, opt.Elem, sf.Name)
+			if err != nil {
+				return nil, err
+			}
+			typ = OptionType{Elem: fieldT}
+		} else if si := op.SafeIndex; si != nil {
+			// MEP-16 R6: `a?[k]` requires `a : list<T>?` or
+			// `a : map<K, V>?` and lifts the element type back into
+			// option form.
+			opt, ok := typ.(OptionType)
+			if !ok {
+				if _, isAny := typ.(AnyType); isAny {
+					if _, err := checkExpr(si.Start, env); err != nil {
+						return nil, err
+					}
+					typ = OptionType{Elem: AnyType{}}
+					continue
+				}
+				return nil, errSafeIndexNonOption(op.Pos, typ)
+			}
+			elemT, err := safeIndexType(op.Pos, opt.Elem, si.Start, env)
+			if err != nil {
+				return nil, err
+			}
+			typ = OptionType{Elem: elemT}
 		}
 	}
 
 	return typ, nil
+}
+
+// safeFieldType resolves a `?.f` step given the wrapped element type.
+// Mirrors the field-access cases from the bare Selector path but is
+// restricted to struct fields and `any` since `?.` only makes sense on
+// addressable named members.
+func safeFieldType(pos lexer.Position, elem Type, name string) (Type, error) {
+	switch t := elem.(type) {
+	case StructType:
+		if ft, ok := t.FieldType(name); ok {
+			return ft, nil
+		}
+		if m, ok := t.Methods[name]; ok {
+			return m.Type, nil
+		}
+		return nil, errUnknownField(pos, name, t)
+	case AnyType:
+		return AnyType{}, nil
+	case MapType:
+		if unify(t.Key, StringType{}, nil) {
+			return t.Value, nil
+		}
+	}
+	return nil, errSafeFieldNonStruct(pos, name, elem)
+}
+
+// safeIndexType resolves a `?[k]` step given the wrapped element type.
+// Supports list and map receivers; everything else is a type error.
+func safeIndexType(pos lexer.Position, elem Type, key *parser.Expr, env *Env) (Type, error) {
+	switch t := elem.(type) {
+	case ListType:
+		keyT, err := checkExpr(key, env)
+		if err != nil {
+			return nil, err
+		}
+		if !(unify(keyT, IntType{}, nil) || unify(keyT, Int64Type{}, nil)) {
+			return nil, errIndexNotInteger(pos)
+		}
+		return t.Elem, nil
+	case MapType:
+		keyT, err := checkExpr(key, env)
+		if err != nil {
+			return nil, err
+		}
+		if !unify(keyT, t.Key, nil) {
+			return nil, errIndexTypeMismatch(pos, t.Key, keyT)
+		}
+		return t.Value, nil
+	case AnyType:
+		if _, err := checkExpr(key, env); err != nil {
+			return nil, err
+		}
+		return AnyType{}, nil
+	}
+	return nil, errSafeIndexNonIndexable(pos, elem)
 }
 
 func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {

--- a/types/errors.go
+++ b/types/errors.go
@@ -78,6 +78,10 @@ var Errors = map[string]diagnostic.Template{
 	"T057": {Code: "T057", Message: "`select distinct` expression must be a hashable type, got %s", Help: "Distinct deduplicates by structural equality. Function values do not have a stable hash. Project a scalar or record of scalars."},
 	"T058": {Code: "T058", Message: "dereference of optional `%s` requires a none guard", Help: "Narrow with `if %s != none { ... }` first, or supply a fallback (`?? default`)."},
 	"T059": {Code: "T059", Message: "comparison with `none` requires an optional operand, got %s", Help: "`none` is the empty side of `Option<T>`; comparing it to a non-optional value can never be true. Either change the operand to `T?` or drop the comparison."},
+	"T060": {Code: "T060", Message: "safe-call `?.%s` requires an option-typed receiver, got %s", Help: "`a?.f` is only defined when `a : T?`. Drop the `?` for a plain field access, or change the receiver's type."},
+	"T061": {Code: "T061", Message: "safe-call `?.%s` requires the wrapped type to be a struct, got %s", Help: "The element side of the option must expose a field named `%s`."},
+	"T062": {Code: "T062", Message: "safe-index `?[ ]` requires an option-typed receiver, got %s", Help: "`a?[k]` is only defined when `a : list<T>?` or `a : map<K, V>?`. Drop the `?` for a plain index access."},
+	"T063": {Code: "T063", Message: "safe-index `?[ ]` requires the wrapped type to be a list or map, got %s", Help: "Only `list<T>` and `map<K, V>` support indexed access after `?[`."},
 }
 
 // --- Wrapper Functions ---
@@ -232,6 +236,25 @@ func errOptionalDeref(pos lexer.Position, name string) error {
 
 func errNoneComparison(pos lexer.Position, other Type) error {
 	return Errors["T059"].New(pos, other)
+}
+
+func errSafeFieldNonOption(pos lexer.Position, field string, typ Type) error {
+	return Errors["T060"].New(pos, field, typ)
+}
+
+func errSafeFieldNonStruct(pos lexer.Position, field string, typ Type) error {
+	tmpl := Errors["T061"]
+	msg := fmt.Sprintf(tmpl.Message, field, typ)
+	help := fmt.Sprintf(tmpl.Help, field)
+	return diagnostic.New(tmpl.Code, pos, msg, help)
+}
+
+func errSafeIndexNonOption(pos lexer.Position, typ Type) error {
+	return Errors["T062"].New(pos, typ)
+}
+
+func errSafeIndexNonIndexable(pos lexer.Position, typ Type) error {
+	return Errors["T063"].New(pos, typ)
 }
 
 func errFetchURLString(pos lexer.Position) error {

--- a/website/docs/mep/mep-0016.md
+++ b/website/docs/mep/mep-0016.md
@@ -64,8 +64,8 @@ There is a second force. MEP-14 (Query Algebra) left a deferred item: the right 
 | Unguarded field access on `T?` raises T058                        | **open** |
 | Unguarded index access on `T?` raises T058                        | **open** |
 | `==` / `!=` against `none` is `bool` for any `T?`                 | **open** |
-| Safe-call operator `?.`                                           | **open** |
-| Safe-index operator `?[ ]`                                        | **open** |
+| Safe-call operator `?.`                                           | closed |
+| Safe-index operator `?[ ]`                                        | closed |
 | Coalesce operator `??`                                            | closed |
 | Flow narrowing on `if x == none { ... } else { ... }`             | closed |
 | Flow narrowing on `if x != none { ... } else { ... }`             | closed |


### PR DESCRIPTION
## Summary
- Parser learns `SafeFieldOp` (`a?.f`) and `SafeIndexOp` (`a?[k]`) as new postfix arms; invariant counts them.
- Type checker enforces R5/R6: the receiver must be `T?`, the result is option-typed. Adds T060-T063 for the four reject cases (non-option receiver / non-struct or non-indexable wrapped type).
- VM lowers both to `OpIndex`, which already short-circuits on a null source, so no new opcode is needed.
- AST `safe_selector` / `safe_index` so a2mochi and lsp round-trips don't drop the operator.

Closes #21432

## Test plan
- [x] `go test ./parser/... ./types/... ./ast/...`
- [x] `go test ./...`
- [x] New fixtures: `tests/parser/valid/safe_postfix.*`, `tests/types/valid/option_safe_postfix.*`, `tests/types/errors/safe_field_non_option.*`, `tests/types/errors/safe_index_non_option.*`
- [x] `go run ./cmd/mochi run` on a hand-written program covering `Person?.name`, `list<int>?[0]`, and a `none` receiver