### PR TITLE
mep-0016: option-retype bindings after left/right/outer joins (R10)

### DIFF
--- a/tests/types/errors/option_join_left_unguarded.err
+++ b/tests/types/errors/option_join_left_unguarded.err
@@ -1,0 +1,8 @@
+1. error[T058]: dereference of optional `c` requires a none guard
+  --> tests/types/errors/option_join_left_unguarded.mochi:11:20
+
+ 11 |             select c.name
+    |                    ^
+
+help:
+  Narrow with `if c != none { ... }` first, or supply a fallback (`?? default`).

--- a/tests/types/errors/option_join_left_unguarded.mochi
+++ b/tests/types/errors/option_join_left_unguarded.mochi
@@ -1,0 +1,11 @@
+// MEP-16 R10: the right side of a `left join` is `Option<T>` after the
+// `on` clause. Unguarded field access in `select` raises T058.
+type Order { id: int, cid: int }
+type Cust  { id: int, name: string }
+
+let orders: list<Order> = [Order{id: 1, cid: 10}]
+let custs:  list<Cust>  = [Cust{id: 10, name: "a"}]
+
+let names = from o in orders
+            left join c in custs on o.cid == c.id
+            select c.name

--- a/tests/types/errors/option_join_outer_unguarded.err
+++ b/tests/types/errors/option_join_outer_unguarded.err
@@ -1,0 +1,8 @@
+1. error[T058]: dereference of optional `c` requires a none guard
+  --> tests/types/errors/option_join_outer_unguarded.mochi:12:21
+
+ 12 |              select c.name
+    |                     ^
+
+help:
+  Narrow with `if c != none { ... }` first, or supply a fallback (`?? default`).

--- a/tests/types/errors/option_join_outer_unguarded.mochi
+++ b/tests/types/errors/option_join_outer_unguarded.mochi
@@ -1,0 +1,12 @@
+// MEP-16 R10: `outer join` retypes BOTH sides to `Option<T>`. The on
+// clause sees them as plain `T`, but the select clause must narrow
+// before accessing fields.
+type Order { id: int, cid: int }
+type Cust  { id: int, name: string }
+
+let orders: list<Order> = [Order{id: 1, cid: 10}]
+let custs:  list<Cust>  = [Cust{id: 10, name: "a"}]
+
+let result = from o in orders
+             outer join c in custs on o.cid == c.id
+             select c.name

--- a/tests/types/errors/option_join_right_left_unguarded.err
+++ b/tests/types/errors/option_join_right_left_unguarded.err
@@ -1,0 +1,8 @@
+1. error[T058]: dereference of optional `o` requires a none guard
+  --> tests/types/errors/option_join_right_left_unguarded.mochi:12:21
+
+ 12 |              select o.id
+    |                     ^
+
+help:
+  Narrow with `if o != none { ... }` first, or supply a fallback (`?? default`).

--- a/tests/types/errors/option_join_right_left_unguarded.mochi
+++ b/tests/types/errors/option_join_right_left_unguarded.mochi
@@ -1,0 +1,12 @@
+// MEP-16 R10: after a `right join`, the left side becomes `Option<T>`
+// while the join's variable keeps its plain type. Accessing the now-
+// optional left binding without narrowing raises T058.
+type Order { id: int, cid: int }
+type Cust  { id: int, name: string }
+
+let orders: list<Order> = [Order{id: 1, cid: 10}]
+let custs:  list<Cust>  = [Cust{id: 10, name: "a"}]
+
+let result = from o in orders
+             right join c in custs on o.cid == c.id
+             select o.id

--- a/tests/types/valid/option_join_left_narrows.golden
+++ b/tests/types/valid/option_join_left_narrows.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/option_join_left_narrows.mochi
+++ b/tests/types/valid/option_join_left_narrows.mochi
@@ -1,0 +1,13 @@
+// MEP-16 R10: after a `left join`, the right side is `Option<T>`.
+// Narrowing recovers the wrapped struct so its fields can be read.
+type Order { id: int, cid: int }
+type Cust  { id: int, name: string }
+
+let orders: list<Order> = [Order{id: 1, cid: 10}, Order{id: 2, cid: 99}]
+let custs:  list<Cust>  = [Cust{id: 10, name: "a"}]
+
+let names = from o in orders
+            left join c in custs on o.cid == c.id
+            select (if c != none { c.name } else { "?" })
+
+expect count(names) == 2

--- a/types/check_expr.go
+++ b/types/check_expr.go
@@ -1403,6 +1403,11 @@ func checkQueryExpr(q *parser.QueryExpr, env *Env, expected Type) (Type, error) 
 	}
 	child := NewEnv(env)
 	child.SetVar(q.Var, elemT, true)
+	// leftSide tracks the binding names contributed by the query's
+	// primary source and every prior `from` / `join`. MEP-16 R10 needs
+	// this list because a `right`/`outer` join retypes every left-side
+	// binding to `Option<T>` after the `on` clause executes.
+	leftSide := []string{q.Var}
 
 	for _, f := range q.Froms {
 		ft, err := checkExpr(f.Src, child)
@@ -1419,6 +1424,7 @@ func checkQueryExpr(q *parser.QueryExpr, env *Env, expected Type) (Type, error) 
 			return nil, errJoinSourceList(f.Pos)
 		}
 		child.SetVar(f.Var, fe, true)
+		leftSide = append(leftSide, f.Var)
 	}
 
 	for _, j := range q.Joins {
@@ -1443,6 +1449,12 @@ func checkQueryExpr(q *parser.QueryExpr, env *Env, expected Type) (Type, error) 
 		if !unify(onT, BoolType{}, nil) {
 			return nil, errJoinOnBoolean(j.On.Pos)
 		}
+		// MEP-16 R10: option-retype the bindings that may be unmatched
+		// after the join completes. The `on` clause above sees both
+		// sides as `T` because it runs on candidate pairs; subsequent
+		// `where`/`select` see the post-join types.
+		applyJoinSideRetype(child, j.Side, j.Var, leftSide)
+		leftSide = append(leftSide, j.Var)
 	}
 
 	if q.Where != nil {
@@ -1666,6 +1678,52 @@ func stringKey(e *parser.Expr) (string, bool) {
 		return *p.Target.Lit.Str, true
 	}
 	return "", false
+}
+
+// applyJoinSideRetype implements MEP-16 R10. After a join's `on`
+// clause runs, bindings on the side that may be unmatched become
+// `Option<T>`:
+//
+//   - `left  join r in xs on c`: r becomes `Option<T>`.
+//   - `right join r in xs on c`: every previously bound name becomes
+//     `Option<T>` while r keeps its `T` type.
+//   - `outer join r in xs on c`: both sides become `Option<T>`.
+//
+// A nil Side means an inner join, which preserves the input types.
+// Already-optional bindings stay as-is to keep the operation
+// idempotent for chained joins.
+func applyJoinSideRetype(env *Env, side *string, rightVar string, leftSide []string) {
+	if side == nil {
+		return
+	}
+	switch *side {
+	case "left":
+		wrapBindingOptional(env, rightVar)
+	case "right":
+		for _, name := range leftSide {
+			wrapBindingOptional(env, name)
+		}
+	case "outer":
+		for _, name := range leftSide {
+			wrapBindingOptional(env, name)
+		}
+		wrapBindingOptional(env, rightVar)
+	}
+}
+
+// wrapBindingOptional re-types `name` in env to `Option<T>` where T is
+// its current type. No-op if the binding is already optional or
+// missing.
+func wrapBindingOptional(env *Env, name string) {
+	t, err := env.GetVar(name)
+	if err != nil {
+		return
+	}
+	if _, ok := t.(OptionType); ok {
+		return
+	}
+	mut, _ := env.isMutable(name)
+	env.SetVar(name, OptionType{Elem: t}, mut)
 }
 
 func aggregateCallName(e *parser.Expr) (string, *parser.Expr, bool) {

--- a/website/docs/mep/mep-0016.md
+++ b/website/docs/mep/mep-0016.md
@@ -72,7 +72,7 @@ There is a second force. MEP-14 (Query Algebra) left a deferred item: the right 
 | Flow narrowing on `x != none && ...` / `x == none \|\| ...`       | closed |
 | `match x { none => ..., _ => /* x : T */ }` narrowing             | closed |
 | `map<K, V>` index returns `V?`                                    | **open** |
-| `left join` right side becomes `Option<T>` (MEP-14)               | **open** |
+| `left join` right side becomes `Option<T>` (MEP-14)               | closed |
 | `right join` left side becomes `Option<T>` (MEP-14)               | **open** |
 | `outer join` both sides become `Option<T>` (MEP-14)               | **open** |
 | **No** force-unwrap operator (`!!`, `?!`, etc.)                   | by design |


### PR DESCRIPTION
## Summary
- `checkQueryExpr` applies R10: after the join's `on` clause, the side that may be unmatched is re-typed to `Option<T>`. Left wraps the join variable, right wraps every prior binding, outer wraps both.
- Inner joins are unaffected. Already-optional bindings stay as-is so chained joins are idempotent.
- New fixtures: one valid (narrowing through the join binding to read fields) and three errors (left, right, outer unguarded access raising T058).

Closes #21434

## Test plan
- [x] `go test ./types/...`
- [x] `go test ./...`
- [x] Verified existing `tests/types/valid/{left_join,outer_join,query_join_*}.mochi` still pass (they only bind the joined value into a struct field, no unguarded dereference)