### PR TITLE
mep-0016: retype first(list<T>) to T? (Stage 4 first slice)

### DIFF
--- a/tests/types/errors/option_first_unwrapped.err
+++ b/tests/types/errors/option_first_unwrapped.err
@@ -1,0 +1,8 @@
+1. error[T008]: type mismatch: expected int, got option[int]
+  --> tests/types/errors/option_first_unwrapped.mochi:4:17
+
+  4 | let head: int = first(xs)
+    |                 ^
+
+help:
+  Change the value to match the expected type.

--- a/tests/types/errors/option_first_unwrapped.mochi
+++ b/tests/types/errors/option_first_unwrapped.mochi
@@ -1,0 +1,4 @@
+// MEP-16 Stage 4: `first(xs)` is `T?`, not `T`. Binding it to a `T`
+// slot without a fallback raises T008.
+let xs: list<int> = [1, 2, 3]
+let head: int = first(xs)

--- a/tests/types/valid/generic_builtins.mochi
+++ b/tests/types/valid/generic_builtins.mochi
@@ -1,8 +1,10 @@
 // MEP-12.4: first / distinct / keys / values / push / append are
 // generic. The instantiated return type matches the inferred element /
 // key / value type, so no `as T` cast is needed at the consumer.
+// MEP-16 Stage 4: `first` now returns `T?` so the caller supplies a
+// fallback with `??` or narrows through the option binding.
 let xs: list<int> = [3, 1, 4, 1, 5, 9]
-let head: int = first(xs)
+let head: int = first(xs) ?? 0
 let uniq: list<int> = distinct(xs)
 expect head == 3
 expect len(uniq) == 5

--- a/tests/types/valid/option_first_narrows.golden
+++ b/tests/types/valid/option_first_narrows.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/option_first_narrows.mochi
+++ b/tests/types/valid/option_first_narrows.mochi
@@ -1,0 +1,17 @@
+// MEP-16 Stage 4: `first` returns `T?` so the empty case no longer
+// panics at runtime. Callers either supply a fallback with `??` or
+// narrow through the option binding.
+let xs: list<int> = [10, 20, 30]
+let ys: list<int> = []
+
+let head: int = first(xs) ?? -1
+expect head == 10
+
+let missing: int = first(ys) ?? -1
+expect missing == -1
+
+let opt: int? = first(xs)
+if opt != none {
+  let doubled: int = opt * 2
+  expect doubled == 20
+}

--- a/types/check.go
+++ b/types/check.go
@@ -40,13 +40,14 @@ func Check(prog *parser.Program, env *Env) []error {
 		Variadic:   ListType{Elem: concatT},
 		TypeParams: []string{"T"},
 	}, false)
-	// first<T>(xs: list<T>): T - MEP-12.4. Generic so the result of
-	// first(list<int>) is int rather than any, and the user no longer
-	// needs an `as T` cast at the consumer site.
+	// first<T>(xs: list<T>): T? - MEP-12.4 generic, MEP-16 Stage 4.
+	// Under MEP-16 the empty list returns `none` instead of panicking,
+	// so the static signature must say `T?`. Callers handle empties
+	// with `first(xs) ?? default` or by narrowing through the binding.
 	firstT := &TypeVar{Name: "T"}
 	env.SetVar("first", FuncType{
 		Params:     []Type{ListType{Elem: firstT}},
-		Return:     firstT,
+		Return:     OptionType{Elem: firstT},
 		Pure:       true,
 		TypeParams: []string{"T"},
 	}, false)

--- a/types/infer.go
+++ b/types/infer.go
@@ -447,7 +447,7 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 			if len(p.Call.Args) == 1 {
 				t := ExprType(p.Call.Args[0], env)
 				if lt, ok := t.(ListType); ok {
-					return lt.Elem
+					return OptionType{Elem: lt.Elem}
 				}
 			}
 			return AnyType{}


### PR DESCRIPTION
## Summary
- `first<T>(xs: list<T>) : T?` is set in both the env registration (`types/check.go`) and the inferrer (`types/infer.go`). The runtime already returns `none` for an empty list, so this just stops the static type from lying.
- Rewrites `tests/types/valid/generic_builtins.mochi` so the empty case is handled with `?? 0`.
- New fixtures: `option_first_narrows` (valid - narrow/coalesce paths) and `option_first_unwrapped` (error - T008 when binding `T?` to a `T` slot).
- `last` / `find` / standalone `get` are not addressed here because none of them are wired today; that's a follow-up that also touches the runtime ops.

Closes #21436

## Test plan
- [x] `go test ./types/...`
- [x] `go test ./...`
- [x] `go run ./cmd/mochi run` on `tests/types/valid/option_first_narrows.mochi` (silent exit = all expects passed)