### PR TITLE
mep-0016: drop var narrowing across impure calls (N5)

### DIFF
--- a/tests/types/errors/option_narrow_call_var.err
+++ b/tests/types/errors/option_narrow_call_var.err
@@ -1,0 +1,8 @@
+1. error[T020]: operator `+` cannot be used on types option[int] and int
+  --> tests/types/errors/option_narrow_call_var.mochi:10:18
+
+ 10 |   let b: int = x + 1
+    |                  ^
+
+help:
+  Choose an operator that supports these operand types.

--- a/tests/types/errors/option_narrow_call_var.mochi
+++ b/tests/types/errors/option_narrow_call_var.mochi
@@ -1,0 +1,13 @@
+// MEP-16 N5: an impure call inside a narrowed scope drops narrowing
+// for every `var` binding from the call site onward. The second
+// `x + 1` sees `x : int?` again and is rejected by R4 (T020).
+fun touch() { print("touched") }
+
+var x: int? = 5
+if x != none {
+  let a: int = x + 1
+  touch()
+  let b: int = x + 1
+  expect a == 6
+  expect b == 6
+}

--- a/tests/types/valid/option_narrow_call_let.golden
+++ b/tests/types/valid/option_narrow_call_let.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/option_narrow_call_let.mochi
+++ b/tests/types/valid/option_narrow_call_let.mochi
@@ -1,0 +1,13 @@
+// MEP-16 N5: an impure call inside a narrowed scope does not drop
+// narrowing for `let` bindings, because the target cannot be reassigned.
+// `x` remains `int` after `touch()` runs.
+fun touch() { print("touched") }
+
+let x: int? = 5
+if x != none {
+  let a: int = x + 1
+  touch()
+  let b: int = x + 1
+  expect a == 6
+  expect b == 6
+}

--- a/types/check.go
+++ b/types/check.go
@@ -1132,6 +1132,13 @@ func checkIfStmt(stmt *parser.IfStmt, env *Env, expectedReturn Type, inLoop bool
 		if err := checkStmt(s, child, expectedReturn, inLoop); err != nil {
 			return err
 		}
+		// MEP-16 N5: after a statement whose evaluation could call a
+		// non-pure function, drop every `var` narrowing visible from
+		// child. `let` bindings keep narrowing because the target
+		// cannot be reassigned.
+		if statementHasImpureCall(s, child) {
+			dropMutableNarrowings(child)
+		}
 	}
 	if stmt.ElseIf != nil {
 		return checkIfStmt(stmt.ElseIf, narrowedEnv(env, falsy), expectedReturn, inLoop)
@@ -1140,6 +1147,9 @@ func checkIfStmt(stmt *parser.IfStmt, env *Env, expectedReturn Type, inLoop bool
 	for _, s := range stmt.Else {
 		if err := checkStmt(s, elseChild, expectedReturn, inLoop); err != nil {
 			return err
+		}
+		if statementHasImpureCall(s, elseChild) {
+			dropMutableNarrowings(elseChild)
 		}
 	}
 	return nil

--- a/types/narrow.go
+++ b/types/narrow.go
@@ -221,3 +221,37 @@ func closureBoundaryEnv(env *Env) *Env {
 	}
 	return out
 }
+
+// dropMutableNarrowings drops every flow-narrowed shadow of a mutable
+// (`var`) binding visible from env by overlaying the binding's declared
+// type onto env. It implements MEP-16 N5: a call to a non-pure function
+// inside a narrowed scope cannot reason about which `var` was mutated,
+// so each `var` loses narrowing from the call site onward. Immutable
+// (`let`) bindings keep narrowing because the target cannot be
+// reassigned.
+func dropMutableNarrowings(env *Env) {
+	if env == nil {
+		return
+	}
+	seen := map[string]bool{}
+	for e := env; e != nil; e = e.parent {
+		for name := range e.narrowed {
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			mut, _ := env.isMutable(name)
+			if !mut {
+				continue
+			}
+			if _, local := env.types[name]; local {
+				continue
+			}
+			declared, err := env.DeclaredVarType(name)
+			if err != nil {
+				continue
+			}
+			env.SetVar(name, declared, true)
+		}
+	}
+}

--- a/types/pure.go
+++ b/types/pure.go
@@ -212,3 +212,65 @@ func firstImpurePrimary(p *parser.Primary, env *Env) (string, lexer.Position, bo
 	}
 	return "", lexer.Position{}, false
 }
+
+// statementHasImpureCall reports whether s contains any call to a
+// non-pure function in its directly evaluated expressions. It powers
+// MEP-16 N5 narrowing invalidation: after a statement whose evaluation
+// could call an impure function, every `var` binding loses narrowing.
+// Nested control-flow bodies (if / while / for) are not inspected here;
+// their own narrowed envs handle invalidation locally, and the
+// conservative drop on the cond / source expression is enough to cover
+// the outer scope.
+func statementHasImpureCall(s *parser.Statement, env *Env) bool {
+	if s == nil {
+		return false
+	}
+	switch {
+	case s.Let != nil:
+		return exprHasImpureCall(s.Let.Value, env)
+	case s.Var != nil:
+		return exprHasImpureCall(s.Var.Value, env)
+	case s.Assign != nil:
+		if exprHasImpureCall(s.Assign.Value, env) {
+			return true
+		}
+		for _, idx := range s.Assign.Index {
+			if exprHasImpureCall(idx.Start, env) || exprHasImpureCall(idx.End, env) {
+				return true
+			}
+		}
+		return false
+	case s.Return != nil:
+		return exprHasImpureCall(s.Return.Value, env)
+	case s.Expr != nil:
+		return exprHasImpureCall(s.Expr.Expr, env)
+	case s.If != nil:
+		return exprHasImpureCall(s.If.Cond, env)
+	case s.While != nil:
+		return exprHasImpureCall(s.While.Cond, env)
+	case s.For != nil:
+		if exprHasImpureCall(s.For.Source, env) {
+			return true
+		}
+		return exprHasImpureCall(s.For.RangeEnd, env)
+	case s.Update != nil:
+		if s.Update.Where != nil && exprHasImpureCall(s.Update.Where, env) {
+			return true
+		}
+		for _, it := range s.Update.Set.Items {
+			if exprHasImpureCall(it.Value, env) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
+func exprHasImpureCall(e *parser.Expr, env *Env) bool {
+	if e == nil {
+		return false
+	}
+	_, _, ok := firstImpureCall(e, env)
+	return ok
+}


### PR DESCRIPTION
Closes #21440.

## Summary
- An impure call inside `if x != none { ... }` now drops the narrowed shadow for every visible `var` binding from the call site onward, so a second `x + 1` after the call is correctly rejected.
- `let` bindings keep narrowing, matching the spec (the target can't be reassigned, so the callee can't widen them).
- The drop reuses `firstImpureCall` via a new statement-level walker; only directly evaluated expressions are scanned (nested `if`/`while`/`for` bodies handle invalidation inside their own narrowed envs).

## Test plan
- [x] `go test ./types/...`
- [x] New valid fixture: `tests/types/valid/option_narrow_call_let.mochi` (`let` binding survives an impure call).
- [x] New error fixture: `tests/types/errors/option_narrow_call_var.mochi` (`var` binding loses narrowing after `print(...)` and the second `x + 1` fails T020).