### PR TITLE
mep-0015 stage 1: replace FuncType.Pure with EffectSet

### DIFF
--- a/archived/interpreter/consteval.go
+++ b/archived/interpreter/consteval.go
@@ -16,7 +16,7 @@ func EvalPureCall(call *parser.CallExpr, env *types.Env) (*parser.Literal, bool)
 		return nil, false
 	}
 	ft, ok := t.(types.FuncType)
-	if !ok || !ft.Pure {
+	if !ok || !ft.Pure() {
 		return nil, false
 	}
 	for _, arg := range call.Args {
@@ -105,7 +105,7 @@ func isConstCall(call *parser.CallExpr, env *types.Env) bool {
 		return false
 	}
 	ft, ok := t.(types.FuncType)
-	if !ok || !ft.Pure {
+	if !ok || !ft.Pure() {
 		return false
 	}
 	for _, a := range call.Args {

--- a/archived/interpreter/interpreter.go
+++ b/archived/interpreter/interpreter.go
@@ -1829,7 +1829,7 @@ func (i *Interpreter) evalCall(c *parser.CallExpr) (any, error) {
 
 		if i.memoize {
 			if t, err := i.types.GetVar(c.Func); err == nil {
-				if ft, ok := t.(types.FuncType); ok && ft.Pure {
+				if ft, ok := t.(types.FuncType); ok && ft.Pure() {
 					key := argsKey(argVals)
 					if fnCache, ok := i.memo[c.Func]; ok {
 						if res, ok := fnCache[key]; ok {
@@ -1965,7 +1965,7 @@ func (i *Interpreter) shouldInline(name string, fn *parser.FunStmt) bool {
 		return false
 	}
 	if t, err := i.types.GetVar(name); err == nil {
-		if ft, ok := t.(types.FuncType); ok && ft.Pure {
+		if ft, ok := t.(types.FuncType); ok && ft.Pure() {
 			if i.callCounts[name] > 10 {
 				return true
 			}

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -2935,7 +2935,7 @@ func (fc *funcCompiler) foldCallValue(call *parser.CallExpr) (Value, bool) {
 
 	// Fold calls to user-defined pure functions.
 	if t, err := fc.comp.env.GetVar(call.Func); err == nil {
-		if ft, ok := t.(types.FuncType); ok && ft.Pure {
+		if ft, ok := t.(types.FuncType); ok && ft.Pure() {
 			if val, ok2 := fc.evalPureFunc(call.Func, args); ok2 {
 				return val, true
 			}

--- a/transpiler/x/go/transpiler.go
+++ b/transpiler/x/go/transpiler.go
@@ -3929,8 +3929,8 @@ func compileStmt(st *parser.Statement, env *types.Env) (Stmt, error) {
 					if st.Import.Auto && env != nil {
 						env.SetVar(alias+".pi", types.FloatType{}, false)
 						env.SetVar(alias+".e", types.FloatType{}, false)
-						env.SetVar(alias+".sqrt", types.FuncType{Params: []types.Type{types.FloatType{}}, Return: types.FloatType{}, Pure: true}, false)
-						env.SetVar(alias+".pow", types.FuncType{Params: []types.Type{types.FloatType{}, types.FloatType{}}, Return: types.FloatType{}, Pure: true}, false)
+						env.SetVar(alias+".sqrt", types.FuncType{Params: []types.Type{types.FloatType{}}, Return: types.FloatType{}}, false)
+						env.SetVar(alias+".pow", types.FuncType{Params: []types.Type{types.FloatType{}, types.FloatType{}}, Return: types.FloatType{}}, false)
 					}
 				}
 			}

--- a/transpiler/x/rkt/transpiler.go
+++ b/transpiler/x/rkt/transpiler.go
@@ -1921,8 +1921,8 @@ func Transpile(prog *parser.Program, env *types.Env, bench bool) (*Program, erro
 				&RawStmt{Code: fmt.Sprintf("(define (%s_ToUpper s) (string-upcase s))", alias)},
 			)
 			if env != nil {
-				env.SetVar(alias+".TrimSpace", types.FuncType{Params: []types.Type{types.StringType{}}, Return: types.StringType{}, Pure: true}, false)
-				env.SetVar(alias+".ToUpper", types.FuncType{Params: []types.Type{types.StringType{}}, Return: types.StringType{}, Pure: true}, false)
+				env.SetVar(alias+".TrimSpace", types.FuncType{Params: []types.Type{types.StringType{}}, Return: types.StringType{}}, false)
+				env.SetVar(alias+".ToUpper", types.FuncType{Params: []types.Type{types.StringType{}}, Return: types.StringType{}}, false)
 			}
 		} else if st.Import.Lang != nil && *st.Import.Lang == "python" && st.Import.Path == "math" {
 			r.Stmts = append(r.Stmts,
@@ -1936,24 +1936,24 @@ func Transpile(prog *parser.Program, env *types.Env, bench bool) (*Program, erro
 			if env != nil {
 				env.SetVar(alias+".pi", types.FloatType{}, false)
 				env.SetVar(alias+".e", types.FloatType{}, false)
-				env.SetVar(alias+".sqrt", types.FuncType{Params: []types.Type{types.FloatType{}}, Return: types.FloatType{}, Pure: true}, false)
-				env.SetVar(alias+".pow", types.FuncType{Params: []types.Type{types.FloatType{}, types.FloatType{}}, Return: types.FloatType{}, Pure: true}, false)
-				env.SetVar(alias+".sin", types.FuncType{Params: []types.Type{types.FloatType{}}, Return: types.FloatType{}, Pure: true}, false)
-				env.SetVar(alias+".log", types.FuncType{Params: []types.Type{types.FloatType{}}, Return: types.FloatType{}, Pure: true}, false)
+				env.SetVar(alias+".sqrt", types.FuncType{Params: []types.Type{types.FloatType{}}, Return: types.FloatType{}}, false)
+				env.SetVar(alias+".pow", types.FuncType{Params: []types.Type{types.FloatType{}, types.FloatType{}}, Return: types.FloatType{}}, false)
+				env.SetVar(alias+".sin", types.FuncType{Params: []types.Type{types.FloatType{}}, Return: types.FloatType{}}, false)
+				env.SetVar(alias+".log", types.FuncType{Params: []types.Type{types.FloatType{}}, Return: types.FloatType{}}, false)
 			}
 		} else if st.Import.Lang != nil && *st.Import.Lang == "python" && st.Import.Path == "subprocess" {
 			r.Stmts = append(r.Stmts,
 				&RawStmt{Code: fmt.Sprintf("(define (%s_getoutput cmd) (with-output-to-string (lambda () (system cmd))))", alias)},
 			)
 			if env != nil {
-				env.SetVar(alias+".getoutput", types.FuncType{Params: []types.Type{types.StringType{}}, Return: types.StringType{}, Pure: false}, false)
+				env.SetVar(alias+".getoutput", types.FuncType{Params: []types.Type{types.StringType{}}, Return: types.StringType{}, Effects: types.NewEffectSet(types.EffectIO)}, false)
 			}
 		} else if st.Import.Lang != nil && *st.Import.Lang == "go" && st.Import.Path == "net" {
 			r.Stmts = append(r.Stmts,
 				&RawStmt{Code: fmt.Sprintf("(define (%s_LookupHost host) (list '() #f))", alias)},
 			)
 			if env != nil {
-				env.SetVar(alias+".LookupHost", types.FuncType{Params: []types.Type{types.StringType{}}, Return: types.ListType{Elem: types.AnyType{}}, Pure: false}, false)
+				env.SetVar(alias+".LookupHost", types.FuncType{Params: []types.Type{types.StringType{}}, Return: types.ListType{Elem: types.AnyType{}}, Effects: types.NewEffectSet(types.EffectNet)}, false)
 			}
 		} else if st.Import.Lang != nil && *st.Import.Lang == "go" && st.Import.Path == "os" {
 			r.Stmts = append(r.Stmts,
@@ -1962,8 +1962,8 @@ func Transpile(prog *parser.Program, env *types.Env, bench bool) (*Program, erro
 				&RawStmt{Code: "  (for/list ([n (environment-variables-names (current-environment-variables))]) (let ([s (bytes->string/utf-8 n)]) (string-append s \"=\" (or (getenv s) \"\")))) )"},
 			)
 			if env != nil {
-				env.SetVar(alias+".Getenv", types.FuncType{Params: []types.Type{types.StringType{}}, Return: types.StringType{}, Pure: true}, false)
-				env.SetVar(alias+".Environ", types.FuncType{Params: []types.Type{}, Return: types.ListType{Elem: types.StringType{}}, Pure: true}, false)
+				env.SetVar(alias+".Getenv", types.FuncType{Params: []types.Type{types.StringType{}}, Return: types.StringType{}}, false)
+				env.SetVar(alias+".Environ", types.FuncType{Params: []types.Type{}, Return: types.ListType{Elem: types.StringType{}}}, false)
 			}
 		} else if st.Import.Auto && st.Import.Path == "mochi/runtime/ffi/go/testpkg" {
 			if alias == "" {
@@ -1978,12 +1978,12 @@ func Transpile(prog *parser.Program, env *types.Env, bench bool) (*Program, erro
 				&RawStmt{Code: fmt.Sprintf("(define (%s_MD5Hex s) (let ([in (open-input-string (format \"~a\" s))]) (define b (md5-bytes in)) (close-input-port in) (bytes->hex-string b)))", alias)},
 			)
 			if env != nil {
-				env.SetVar(alias+".Add", types.FuncType{Params: []types.Type{types.IntType{}, types.IntType{}}, Return: types.IntType{}, Pure: true}, false)
+				env.SetVar(alias+".Add", types.FuncType{Params: []types.Type{types.IntType{}, types.IntType{}}, Return: types.IntType{}}, false)
 				env.SetVar(alias+".Pi", types.FloatType{}, false)
 				env.SetVar(alias+".Answer", types.IntType{}, false)
-				env.SetVar(alias+".FifteenPuzzleExample", types.FuncType{Params: []types.Type{}, Return: types.StringType{}, Pure: true}, false)
-				env.SetVar(alias+".ECDSAExample", types.FuncType{Params: []types.Type{}, Return: types.MapType{Key: types.StringType{}, Value: types.AnyType{}}, Pure: true}, false)
-				env.SetVar(alias+".MD5Hex", types.FuncType{Params: []types.Type{types.StringType{}}, Return: types.StringType{}, Pure: true}, false)
+				env.SetVar(alias+".FifteenPuzzleExample", types.FuncType{Params: []types.Type{}, Return: types.StringType{}}, false)
+				env.SetVar(alias+".ECDSAExample", types.FuncType{Params: []types.Type{}, Return: types.MapType{Key: types.StringType{}, Value: types.AnyType{}}}, false)
+				env.SetVar(alias+".MD5Hex", types.FuncType{Params: []types.Type{types.StringType{}}, Return: types.StringType{}}, false)
 			}
 		}
 	}

--- a/types/check.go
+++ b/types/check.go
@@ -10,12 +10,12 @@ func Check(prog *parser.Program, env *Env) []error {
 	env.SetVar("print", FuncType{
 		Params:   []Type{},
 		Return:   UnitType{},
+		Effects:  NewEffectSet(EffectIO),
 		Variadic: AnyType{},
 	}, false)
 	env.SetVar("len", FuncType{
 		Params: []Type{AnyType{}}, // loosely typed
 		Return: IntType{},
-		Pure:   true,
 	}, false)
 	// append<T>(xs: list<T>, x: T): list<T> - MEP-12.4. The element type
 	// is pinned by the first argument; the second must unify with it,
@@ -25,7 +25,6 @@ func Check(prog *parser.Program, env *Env) []error {
 	env.SetVar("append", FuncType{
 		Params:     []Type{ListType{Elem: appendT}, appendT},
 		Return:     ListType{Elem: appendT},
-		Pure:       true,
 		TypeParams: []string{"T"},
 	}, false)
 	// concat<T>(...xs: list<T>): list<T> - MEP-12.4. Every argument is
@@ -36,7 +35,6 @@ func Check(prog *parser.Program, env *Env) []error {
 	env.SetVar("concat", FuncType{
 		Params:     []Type{},
 		Return:     ListType{Elem: concatT},
-		Pure:       true,
 		Variadic:   ListType{Elem: concatT},
 		TypeParams: []string{"T"},
 	}, false)
@@ -48,13 +46,11 @@ func Check(prog *parser.Program, env *Env) []error {
 	env.SetVar("first", FuncType{
 		Params:     []Type{ListType{Elem: firstT}},
 		Return:     OptionType{Elem: firstT},
-		Pure:       true,
 		TypeParams: []string{"T"},
 	}, false)
 	env.SetVar("reverse", FuncType{
 		Params: []Type{AnyType{}},
 		Return: AnyType{},
-		Pure:   true,
 	}, false)
 	// distinct<T>(xs: list<T>): list<T> - MEP-12.4. Shape-preserving;
 	// the result list element type matches the input.
@@ -62,7 +58,6 @@ func Check(prog *parser.Program, env *Env) []error {
 	env.SetVar("distinct", FuncType{
 		Params:     []Type{ListType{Elem: distinctT}},
 		Return:     ListType{Elem: distinctT},
-		Pure:       true,
 		TypeParams: []string{"T"},
 	}, false)
 	// push<T>(xs: list<T>, x: T): list<T> - MEP-12.4 mirror of append.
@@ -70,7 +65,6 @@ func Check(prog *parser.Program, env *Env) []error {
 	env.SetVar("push", FuncType{
 		Params:     []Type{ListType{Elem: pushT}, pushT},
 		Return:     ListType{Elem: pushT},
-		Pure:       true,
 		TypeParams: []string{"T"},
 	}, false)
 	// keys<K,V>(m: map<K,V>): list<K> - MEP-12.4. Existing call-site
@@ -82,7 +76,6 @@ func Check(prog *parser.Program, env *Env) []error {
 	env.SetVar("keys", FuncType{
 		Params:     []Type{MapType{Key: keysK, Value: keysV}},
 		Return:     ListType{Elem: keysK},
-		Pure:       true,
 		TypeParams: []string{"K", "V"},
 	}, false)
 	valuesK := &TypeVar{Name: "K"}
@@ -90,7 +83,6 @@ func Check(prog *parser.Program, env *Env) []error {
 	env.SetVar("values", FuncType{
 		Params:     []Type{MapType{Key: valuesK, Value: valuesV}},
 		Return:     ListType{Elem: valuesV},
-		Pure:       true,
 		TypeParams: []string{"K", "V"},
 	}, false)
 	// collect<T>(xs: list<T>): list<T> - MEP-12.4. The legacy any
@@ -103,151 +95,127 @@ func Check(prog *parser.Program, env *Env) []error {
 	env.SetVar("collect", FuncType{
 		Params:     []Type{ListType{Elem: collectT}},
 		Return:     ListType{Elem: collectT},
-		Pure:       true,
 		TypeParams: []string{"T"},
 	}, false)
 	env.SetVar("range", FuncType{
 		Params:   []Type{},
 		Return:   ListType{Elem: IntType{}},
-		Pure:     true,
 		Variadic: IntType{},
 	}, false)
 	env.SetVar("now", FuncType{
-		Params: []Type{},
-		Return: Int64Type{},
+		Params:  []Type{},
+		Return:  Int64Type{},
+		Effects: NewEffectSet(EffectTime),
 	}, false)
 	env.SetVar("json", FuncType{
-		Params: []Type{AnyType{}},
-		Return: UnitType{},
+		Params:  []Type{AnyType{}},
+		Return:  UnitType{},
+		Effects: NewEffectSet(EffectIO),
 	}, false)
 	env.SetVar("to_json", FuncType{
 		Params: []Type{AnyType{}},
 		Return: StringType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("str", FuncType{
 		Params: []Type{AnyType{}},
 		Return: StringType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("parseIntStr", FuncType{
 		Params: []Type{StringType{}, IntType{}},
 		Return: IntType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("int", FuncType{
 		Params: []Type{AnyType{}},
 		Return: IntType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("upper", FuncType{
 		Params: []Type{StringType{}},
 		Return: StringType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("lower", FuncType{
 		Params: []Type{AnyType{}},
 		Return: StringType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("trim", FuncType{
 		Params: []Type{StringType{}},
 		Return: StringType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("contains", FuncType{
 		Params: []Type{StringType{}, StringType{}},
 		Return: BoolType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("split", FuncType{
 		Params: []Type{StringType{}, StringType{}},
 		Return: ListType{Elem: StringType{}},
-		Pure:   true,
 	}, false)
 	env.SetVar("join", FuncType{
 		Params: []Type{ListType{Elem: StringType{}}, StringType{}},
 		Return: StringType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("substring", FuncType{
 		Params: []Type{StringType{}, IntType{}, IntType{}},
 		Return: StringType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("padStart", FuncType{
 		Params: []Type{StringType{}, IntType{}, StringType{}},
 		Return: StringType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("substr", FuncType{
 		Params: []Type{StringType{}, IntType{}, IntType{}},
 		Return: StringType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("indexOf", FuncType{
 		Params: []Type{StringType{}, StringType{}},
 		Return: IntType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("repeat", FuncType{
 		Params: []Type{StringType{}, IntType{}},
 		Return: StringType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("sha256", FuncType{
 		Params: []Type{AnyType{}},
 		Return: ListType{Elem: IntType{}},
-		Pure:   true,
 	}, false)
 	env.SetVar("num", FuncType{
 		Params: []Type{AnyType{}},
 		Return: BigIntType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("denom", FuncType{
 		Params: []Type{AnyType{}},
 		Return: BigIntType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("input", FuncType{
-		Params: []Type{},
-		Return: StringType{},
+		Params:  []Type{},
+		Return:  StringType{},
+		Effects: NewEffectSet(EffectIO),
 	}, false)
 	env.SetVar("count", FuncType{
 		Params: []Type{AnyType{}},
 		Return: IntType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("exists", FuncType{
 		Params: []Type{AnyType{}},
 		Return: BoolType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("avg", FuncType{
 		Params: []Type{AnyType{}},
 		Return: FloatType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("abs", FuncType{
 		Params: []Type{AnyType{}},
 		Return: AnyType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("ceil", FuncType{
 		Params: []Type{AnyType{}},
 		Return: FloatType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("floor", FuncType{
 		Params: []Type{AnyType{}},
 		Return: FloatType{},
-		Pure:   true,
 	}, false)
 	env.SetVar("sum", FuncType{
 		Params: []Type{AnyType{}},
 		Return: IntType{},
-		Pure:   true,
 	}, false)
 	// min/max are generic over the list element type (MEP-12.4):
 	//     min<T>(xs: list<T>): T
@@ -260,20 +228,17 @@ func Check(prog *parser.Program, env *Env) []error {
 	env.SetVar("min", FuncType{
 		Params:     []Type{ListType{Elem: minT}},
 		Return:     minT,
-		Pure:       true,
 		TypeParams: []string{"T"},
 	}, false)
 	maxT := &TypeVar{Name: "T"}
 	env.SetVar("max", FuncType{
 		Params:     []Type{ListType{Elem: maxT}},
 		Return:     maxT,
-		Pure:       true,
 		TypeParams: []string{"T"},
 	}, false)
 	env.SetVar("round", FuncType{
 		Params: []Type{FloatType{}, IntType{}},
 		Return: FloatType{},
-		Pure:   true,
 	}, false)
 	// reduce is generic over the list element type and the accumulator
 	// type (MEP-12.4):
@@ -287,12 +252,12 @@ func Check(prog *parser.Program, env *Env) []error {
 			reduceB,
 		},
 		Return:     reduceB,
-		Pure:       true,
 		TypeParams: []string{"A", "B"},
 	}, false)
 	env.SetVar("eval", FuncType{
-		Params: []Type{StringType{}},
-		Return: AnyType{},
+		Params:  []Type{StringType{}},
+		Return:  AnyType{},
+		Effects: NewEffectSet(EffectMeta),
 	}, false)
 
 	var errs []error
@@ -353,7 +318,7 @@ func Check(prog *parser.Program, env *Env) []error {
 			env.SetVar(stmt.Fun.Name, FuncType{
 				Params:     params,
 				Return:     ret,
-				Pure:       pure,
+				Effects:    legacyEffectsFromPure(pure),
 				TypeParams: append([]string(nil), stmt.Fun.TypeParams...),
 			}, false)
 			env.SetFunc(stmt.Fun.Name, stmt.Fun)
@@ -437,7 +402,7 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 					ret = resolveTypeRef(blk.Intent.Return, env)
 				}
 				pure := isPureFunction(&parser.FunStmt{Params: blk.Intent.Params, Return: blk.Intent.Return, Body: blk.Intent.Body}, env)
-				methods[blk.Intent.Name] = Method{Decl: &parser.FunStmt{Params: blk.Intent.Params, Return: blk.Intent.Return, Body: blk.Intent.Body}, Type: FuncType{Params: params, Return: ret, Pure: pure}}
+				methods[blk.Intent.Name] = Method{Decl: &parser.FunStmt{Params: blk.Intent.Params, Return: blk.Intent.Return, Body: blk.Intent.Body}, Type: FuncType{Params: params, Return: ret, Effects: legacyEffectsFromPure(pure)}}
 			}
 		}
 		st := StructType{Name: s.Agent.Name, Fields: fields, Methods: methods}
@@ -939,7 +904,7 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 						}
 					}
 					pure := isPureFunction(&parser.FunStmt{Params: m.Method.Params, Return: m.Method.Return, Body: m.Method.Body}, methodEnv)
-					methods[m.Method.Name] = Method{Decl: m.Method, Type: FuncType{Params: params, Return: ret, Pure: pure}}
+					methods[m.Method.Name] = Method{Decl: m.Method, Type: FuncType{Params: params, Return: ret, Effects: legacyEffectsFromPure(pure)}}
 				}
 			}
 			st.Fields = fields
@@ -1017,7 +982,7 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 		env.SetVar(name, FuncType{
 			Params:     params,
 			Return:     ret,
-			Pure:       pure,
+			Effects:    legacyEffectsFromPure(pure),
 			TypeParams: append([]string(nil), s.Fun.TypeParams...),
 		}, false)
 		env.SetFunc(name, s.Fun)

--- a/types/check_expr.go
+++ b/types/check_expr.go
@@ -572,17 +572,17 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 					continue
 				}
 				if field == "padStart" {
-					typ = FuncType{Params: []Type{IntType{}, StringType{}}, Return: StringType{}, Pure: true}
+					typ = FuncType{Params: []Type{IntType{}, StringType{}}, Return: StringType{}}
 					continue
 				}
 				return nil, errNotStruct(p.Pos, typ)
 			case MapType:
 				switch field {
 				case "keys":
-					typ = FuncType{Params: []Type{}, Return: ListType{Elem: AnyType{}}, Pure: true}
+					typ = FuncType{Params: []Type{}, Return: ListType{Elem: AnyType{}}}
 					continue
 				case "get":
-					typ = FuncType{Params: []Type{t.Key, t.Value}, Return: t.Value, Pure: true}
+					typ = FuncType{Params: []Type{t.Key, t.Value}, Return: t.Value}
 					continue
 				}
 				if unify(t.Key, StringType{}, nil) {

--- a/types/effects.go
+++ b/types/effects.go
@@ -1,0 +1,144 @@
+package types
+
+import (
+	"strings"
+)
+
+// EffectLabel identifies one entry in the closed effect vocabulary
+// defined by MEP-15 stage 1. Adding a label here is a language-level
+// change and requires a fixture sweep; never widen ad hoc.
+type EffectLabel uint8
+
+const (
+	// EffectIO covers stdout writes and stdin reads (print, json,
+	// input). Stage 1 collapses stdout and stdin into a single label
+	// because the existing builtin surface does not justify a split.
+	EffectIO EffectLabel = iota
+	// EffectFS covers local file system reads and writes (load, save).
+	EffectFS
+	// EffectNet covers network I/O (fetch).
+	EffectNet
+	// EffectTime covers wall-clock and other non-deterministic clock
+	// reads (now). Distinct from EffectIO so the query optimizer can
+	// still reject reorderings of time-reading predicates even when
+	// stdout is fine.
+	EffectTime
+	// EffectMeta covers dynamic compilation or evaluation (eval).
+	// Distinct from EffectIO so a future compile-time evaluator can
+	// reject eval even when stdout is acceptable.
+	EffectMeta
+	// effectMax is the upper bound used to size the EffectSet bitset
+	// and to drive String() ordering. Update together with the labels.
+	effectMax
+)
+
+var effectNames = [...]string{
+	EffectIO:   "io",
+	EffectFS:   "fs",
+	EffectNet:  "net",
+	EffectTime: "time",
+	EffectMeta: "meta",
+}
+
+// String returns the canonical lowercase identifier for the label.
+func (l EffectLabel) String() string {
+	if int(l) < len(effectNames) {
+		return effectNames[l]
+	}
+	return "?"
+}
+
+// ParseEffectLabel turns a lowercase label identifier into an
+// EffectLabel. Returns ok=false for unknown labels; callers raise a
+// diagnostic in that case.
+func ParseEffectLabel(name string) (EffectLabel, bool) {
+	for i, n := range effectNames {
+		if n == name {
+			return EffectLabel(i), true
+		}
+	}
+	return 0, false
+}
+
+// EffectSet is a bitset over the closed EffectLabel vocabulary. The
+// empty set is "pure". Sets compare equal by value; the canonical
+// printed form sorts labels by their EffectLabel index so two equal
+// sets always render identically. MEP-15 E7.
+type EffectSet uint8
+
+// NewEffectSet returns the set containing exactly the listed labels.
+// Duplicates are normalized away; order is irrelevant.
+func NewEffectSet(labels ...EffectLabel) EffectSet {
+	var s EffectSet
+	for _, l := range labels {
+		s |= 1 << l
+	}
+	return s
+}
+
+// EmptyEffects is the canonical pure set. Provided as a named constant
+// so call sites read clearly.
+var EmptyEffects = EffectSet(0)
+
+// legacyEffectsFromPure bridges Stage 1 from the previous boolean
+// purity flag to the typed effect set. `pure==true` maps to the
+// canonical pure set; `pure==false` maps to a non-empty sentinel so
+// existing call-site checks (T044, MEP-16 N5) still trip on the same
+// functions they did before. Stage 2 replaces every caller with a
+// real body-walked inference and removes this helper.
+func legacyEffectsFromPure(pure bool) EffectSet {
+	if pure {
+		return EmptyEffects
+	}
+	return NewEffectSet(EffectIO)
+}
+
+// Has reports whether l is in the set.
+func (s EffectSet) Has(l EffectLabel) bool {
+	return s&(1<<l) != 0
+}
+
+// Add returns a new set containing s plus l. The receiver is unchanged.
+func (s EffectSet) Add(l EffectLabel) EffectSet {
+	return s | (1 << l)
+}
+
+// Union returns the set-theoretic union of s and t.
+func (s EffectSet) Union(t EffectSet) EffectSet {
+	return s | t
+}
+
+// IsSubset reports whether every label of s is in t.
+func (s EffectSet) IsSubset(t EffectSet) bool {
+	return s&^t == 0
+}
+
+// IsEmpty reports whether the set has no labels. Equivalent to "pure".
+func (s EffectSet) IsEmpty() bool {
+	return s == 0
+}
+
+// Labels returns the labels in canonical (sorted) order.
+func (s EffectSet) Labels() []EffectLabel {
+	out := make([]EffectLabel, 0)
+	for i := EffectLabel(0); i < effectMax; i++ {
+		if s.Has(i) {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+// String renders the set as a comma-separated list of label names in
+// canonical order. The empty set renders as "pure" so error messages
+// have a useful word to print.
+func (s EffectSet) String() string {
+	if s.IsEmpty() {
+		return "pure"
+	}
+	parts := make([]string, 0)
+	for _, l := range s.Labels() {
+		parts = append(parts, l.String())
+	}
+	return strings.Join(parts, ", ")
+}

--- a/types/effects_test.go
+++ b/types/effects_test.go
@@ -1,0 +1,59 @@
+package types_test
+
+import (
+	"testing"
+	"mochi/types"
+)
+
+func TestEffectSet_Basics(t *testing.T) {
+	if !types.EmptyEffects.IsEmpty() {
+		t.Fatalf("EmptyEffects should be empty")
+	}
+	s := types.NewEffectSet(types.EffectIO, types.EffectTime)
+	if !s.Has(types.EffectIO) || !s.Has(types.EffectTime) {
+		t.Fatalf("expected io+time, got %s", s.String())
+	}
+	if s.Has(types.EffectFS) {
+		t.Fatalf("expected no fs label")
+	}
+	if got, want := s.String(), "io, time"; got != want {
+		t.Fatalf("String=%q want %q", got, want)
+	}
+	if got, want := types.EmptyEffects.String(), "pure"; got != want {
+		t.Fatalf("empty.String=%q want %q", got, want)
+	}
+}
+
+func TestEffectSet_Union_Subset(t *testing.T) {
+	a := types.NewEffectSet(types.EffectIO)
+	b := types.NewEffectSet(types.EffectFS)
+	c := a.Union(b)
+	if !a.IsSubset(c) || !b.IsSubset(c) {
+		t.Fatalf("union missing labels: %s", c.String())
+	}
+	if c.IsSubset(a) {
+		t.Fatalf("c={io,fs} should not be subset of {io}")
+	}
+}
+
+func TestParseEffectLabel(t *testing.T) {
+	for _, name := range []string{"io", "fs", "net", "time", "meta"} {
+		if _, ok := types.ParseEffectLabel(name); !ok {
+			t.Fatalf("expected %q to parse", name)
+		}
+	}
+	if _, ok := types.ParseEffectLabel("nope"); ok {
+		t.Fatalf("unknown label should fail")
+	}
+}
+
+func TestFuncTypePure(t *testing.T) {
+	pure := types.FuncType{Params: []types.Type{}, Return: types.IntType{}}
+	if !pure.Pure() {
+		t.Fatalf("empty Effects should be pure")
+	}
+	impure := types.FuncType{Params: []types.Type{}, Return: types.IntType{}, Effects: types.NewEffectSet(types.EffectIO)}
+	if impure.Pure() {
+		t.Fatalf("io should not be pure")
+	}
+}

--- a/types/kinds.go
+++ b/types/kinds.go
@@ -201,17 +201,25 @@ func (t *TypeVar) String() string { return t.Name }
 // FuncType is the type of a function value. Params is the fixed prefix
 // of parameter types. Variadic is the element type of the trailing
 // varargs sequence, or nil if the function is not variadic (MEP 4 P13).
-// Pure is the inferred purity flag (MEP 4 P7).
+// Effects is the inferred effect set (MEP-15 E1). The empty set means
+// the function is pure.
 type FuncType struct {
 	Params   []Type
 	Return   Type
-	Pure     bool
+	Effects  EffectSet
 	Variadic Type
 	// TypeParams lists the names of TypeVars quantified at this
 	// signature (MEP-12). A non-empty value means the function is
 	// generic: the call site freshens these names via Instantiate before
 	// unifying arguments. Non-generic functions leave the field nil.
 	TypeParams []string
+}
+
+// Pure reports whether the function is pure, that is, carries an empty
+// effect set. MEP-15 keeps this as a method for source-compatibility
+// with call sites that used the legacy `Pure bool` field.
+func (f FuncType) Pure() bool {
+	return f.Effects.IsEmpty()
 }
 
 func (f FuncType) String() string {
@@ -233,8 +241,8 @@ func (f FuncType) String() string {
 	if f.Return != nil && f.Return.String() != "unit" {
 		s += ": " + f.Return.String()
 	}
-	if f.Pure {
-		s += " [pure]"
+	if !f.Effects.IsEmpty() {
+		s += " ! " + f.Effects.String()
 	}
 	return s
 }

--- a/types/pure.go
+++ b/types/pure.go
@@ -47,7 +47,7 @@ func isPureCall(call *parser.CallExpr, env *Env) bool {
 		return false
 	}
 	ft, ok := t.(FuncType)
-	if !ok || !ft.Pure {
+	if !ok || !ft.Pure() {
 		return false
 	}
 	for _, arg := range call.Args {
@@ -183,7 +183,7 @@ func firstImpurePostfix(p *parser.PostfixExpr, env *Env) (string, lexer.Position
 				name := p.Target.Selector.Root
 				t, err := env.GetVar(name)
 				if err == nil {
-					if ft, ok := t.(FuncType); ok && !ft.Pure {
+					if ft, ok := t.(FuncType); ok && !ft.Pure() {
 						return name, p.Target.Pos, true
 					}
 				}
@@ -197,7 +197,7 @@ func firstImpurePrimary(p *parser.Primary, env *Env) (string, lexer.Position, bo
 	if p.Call != nil {
 		t, err := env.GetVar(p.Call.Func)
 		if err == nil {
-			if ft, ok := t.(FuncType); ok && !ft.Pure {
+			if ft, ok := t.(FuncType); ok && !ft.Pure() {
 				return p.Call.Func, p.Pos, true
 			}
 		}

--- a/types/subst.go
+++ b/types/subst.go
@@ -54,7 +54,7 @@ func (sub Subst) Apply(t Type) Type {
 		out := FuncType{
 			Params:     params,
 			Return:     sub.Apply(v.Return),
-			Pure:       v.Pure,
+			Effects:    v.Effects,
 			TypeParams: append([]string(nil), v.TypeParams...),
 		}
 		if v.Variadic != nil {

--- a/website/docs/mep/mep-0015.md
+++ b/website/docs/mep/mep-0015.md
@@ -1,169 +1,390 @@
 ---
 mep: 15
-title: Effects, Mutability, and Purity
+title: Effects
 author: Mochi core
 status: Draft
 type: Standards Track
 created: 2026-05-08
 sidebar_position: 15
 sidebar_label: MEP 15. Effects
-description: Mutability, aliasing, the Pure flag, and side-effecting builtins.
+description: A labeled effect system over function types. Pure by default, inferred from the body, annotatable at module boundaries, enforced where purity matters.
 ---
 
-# MEP 15. Effects, Mutability, and Purity
+# MEP 15. Effects
 
 | Field    | Value                       |
 |----------|-----------------------------|
 | MEP      | 15                          |
-| Title    | Effects, Mutability, and Purity |
+| Title    | Effects                     |
 | Author   | Mochi core                  |
 | Status   | Draft                       |
 | Type     | Standards Track             |
 | Created  | 2026-05-08                  |
 
+## A note on names
+
+This MEP replaces the previous "Effects, Mutability, and Purity" framing. Mutability is a separate axis (the `let` versus `var` distinction, root-binding tracking, MEP-10 A3) and belongs in MEP-10. Effects are about whether a function reads the clock, writes to stdout, hits the network, or is a deterministic value transformer. Conflating the two made both stories harder to read and pushed the previous draft toward a single `Pure` bit that nobody could decide whether to keep.
+
+So when this document says "effect", read it as "an observable interaction with the world outside the type-erased value graph". When it says "mutability", that lives elsewhere.
+
 ## Abstract
 
-Mochi is not effect-typed. There is no row of effects on function arrows. What we do have is a `Pure` flag on `FuncType`, a `let` versus `var` distinction on bindings, and a small set of side-effecting builtins. This MEP documents the current state, proposes a tightening of mutability checks under index and field operations, and asks whether to keep or remove the unenforced `Pure` flag.
+Mochi adopts a small labeled effect system. Each function value carries a finite set of effect labels drawn from a closed vocabulary: `io`, `fs`, `net`, `time`, `meta`. The empty set is `pure`. The set is inferred from the body as the union of every callee's effect set, plus any statement-level effect the body performs directly. A function may declare an upper bound on its effects with an `!` annotation on the signature, in which case the inferred set must be a subset. The same machinery enforces purity for query predicates (already T044 today) and any future context that requires a pure expression (compile-time evaluation, type-level computation, struct field defaults).
+
+The system is intentionally not a row-typed effect calculus. There is no `<e>` row variable in surface syntax, no algebraic effects, and no handlers. Higher-order functions like `map` and `fold` propagate their callback's effect set to the call site through a hidden row variable that the elaborator threads but the printed type never shows. This matches Swift's `rethrows` discipline and Unison's "abilities" surface, and avoids the row-variable-everywhere noise that Koka users live with.
+
+The binary `Pure bool` field on `FuncType` is replaced by an `Effects EffectSet`. Every call site that reads `ft.Pure` continues to work through a thin compatibility method (`ft.Pure() = ft.Effects.IsEmpty()`). The change is mechanical at stage 1 and the existing T044 fires unchanged. Stage 2 adds the surface annotation. Stage 3 (deferred) reconsiders user-defined effects and handlers if and when async or exceptions land.
 
 ## Motivation
 
-Today `let` is half-immutable: top-level reassignment is rejected, but `let xs = [1]; xs[0] = 9` is accepted. The half-enforcement is a soundness gap and a footgun. Either we honour the `let` contract everywhere or we drop it.
+Mochi already has a Pure flag. It is set on roughly forty builtins, inferred on every user function via `isPureFunction`, read at exactly two enforcement points (`where` and `having` predicates) and one optimization (compile-time constant folding for pure user functions in `runtime/vm/vm.go`), and consulted by MEP-16 N5 to drop narrowing across non-pure calls. The flag works. It is also a single bit. It cannot answer the questions that come up the moment you try to write any non-trivial system:
+
+- "Does this function touch the network?" The Pure bit says yes-or-no, no-and-also; you cannot tell `print` apart from `fetch`.
+- "Is it safe to memoize this?" Needs `time` and `random` distinguished from `io`.
+- "Is this safe to run at compile time?" Needs the absence of `io` and `fs` and `net`, plus the absence of `meta` (eval).
+- "Did this hot loop accidentally pick up an `io` effect because someone added a `print` for debugging?" The Pure bit flips and you lose query-predicate eligibility for the whole call chain. With a labeled set, the change is visible and granular.
+- "What can I prove about a callback I am passing into `map`?" With a binary flag, nothing. With a label set, the call inherits exactly the callback's effects, no more and no less.
+
+The labels Mochi needs at stage 1 are not interesting. Look at the existing builtin surface (audit findings in the implementation section below): `print`, `json`, `input`, `now`, `eval`, plus three statement-level constructs (`fetch`, `load`, `save`). Five labels cover all of them and leave room for `random` and `throw` when those land. The cost of the upgrade is a struct field rename, a bitset type, a five-line table of which builtin gets which label, and a recursive walker that already exists.
+
+The upside is that every future enforcement point gets to ask the question it actually wants to ask. T044 keeps asking "is this empty". A future "is this safe to evaluate at compile time" asks "is this a subset of `pure`". A future "is this safe to push through a join" asks "does this lack `time` and `random`". The vocabulary scales linearly with the language; the type-checker plumbing does not change.
+
+## Status at a glance
+
+| Item                                                              | Status |
+|-------------------------------------------------------------------|--------|
+| `Pure bool` on `FuncType` (single bit)                            | closed (legacy) |
+| `isPureFunction` body inference                                   | closed |
+| T044 in `where` and `having` predicates                           | closed |
+| Compile-time constant folding gated on Pure                       | closed |
+| MEP-16 N5 narrowing drop on non-pure call                         | closed |
+| `Effects EffectSet` field on `FuncType`                           | **open** |
+| Closed label set: `io`, `fs`, `net`, `time`, `meta`               | **open** |
+| Builtin effect annotations                                        | **open** |
+| Effect inference (union of callees, plus statement-level effects) | **open** |
+| `Pure()` method as compatibility shim                             | **open** |
+| Effect propagation through higher-order generics                  | **open** |
+| Surface annotation `fun foo(): T ! io, fs { ... }`                | **open** |
+| Diagnostic T065 (declared effect exceeded)                        | **open** |
+| Diagnostic T066 (effect not allowed in context)                   | **open** |
+| Effect inference for closures and intent methods                  | **open** |
+| User-defined effect labels                                        | by design (deferred) |
+| Algebraic effect handlers (`try` / `with` / `resume`)             | by design (deferred) |
 
 ## Specification
 
-### What "effect" means here
+### Surface
 
-Mochi is not effect-typed. There is no row of effects on function arrows. The pieces we do have:
+There is no new keyword at stage 1. Effect annotations land at stage 2 with a single new piece of syntax: `!` after the return type, followed by a comma-separated list of labels.
 
-- `Pure` flag on `FuncType`. Set on builtins that are deterministic pure functions and on user functions whose bodies are inferred pure. Not enforced at call sites today.
-- `let` versus `var` mutability annotation on bindings. Enforced for top-level reassignment, partially enforced for nested mutation ([MEP 10](/docs/mep/mep-0010) A3).
-- I/O statements: `print`, `json`, `fetch`, `load`, `save`. These are not flagged by the type system; the programmer knows they are effectful from the function name.
+```mochi
+fun greet(name: string): unit ! io {
+  print("hi " + name)
+}
 
-### Mutability today
+fun pure_add(a: int, b: int): int {     // no annotation: inferred pure
+  return a + b
+}
 
-The state of mutability checks:
-
-- `let x = e`. Reassignment of `x` raises T024.
-- `var x = e`. Reassignment of `x` is allowed.
-- `let xs = [1, 2]; xs[0] = 9`. Accepted today. Should be rejected.
-- `let p = {x: 1, y: 2}; p.x = 9` for a struct `p`. Accepted today. Should be rejected.
-- `let mp = {"a": 1}; mp["a"] = 9`. Accepted today. Should be rejected because `mp` is `let`.
-
-The fix described in [MEP 10](/docs/mep/mep-0010) A3 is to inspect the mutability of the root binding of an `AssignStmt`, walking through `Index` and `Field` ops to find the root.
-
-Closures complicate this. A closure that captures a `var` binding can mutate it. A closure that captures a `let` binding cannot reassign it but today can mutate through indices and fields in the same way as above. After A3, closures should follow the same rule.
-
-### Aliasing
-
-There is no aliasing analysis. Two bindings can refer to the same underlying value:
-
-```
-let xs = [1, 2, 3]
-var ys = xs
-ys[0] = 9     # observable through xs?
+fun load_config(path: string): map<string, any> ! fs {
+  return load("yaml", path)
+}
 ```
 
-Runtime semantics for lists and maps are reference-based, so the mutation is observable. After A3, the example above becomes a type error at the `ys[0] = 9` line because the root binding of `ys` is `var`, but the underlying list still aliases `xs`. We accept that.
+The annotation list is unordered and de-duplicated. An empty list is illegal; write no annotation for that. A bare `! pure` is also illegal because the absence of the annotation already says pure. Both restrictions exist so there is one and only one way to write each case.
 
-If we wanted unique ownership, we would need a substructural discipline. It is out of scope.
+For function expressions, the annotation comes between the parameter list and the body:
 
-### Pure flag
+```mochi
+let log = fun(msg: string): unit ! io { print(msg) }
+```
 
-The `Pure: true` field on builtins is currently a label without enforcement. Two design directions:
+Lambdas without an annotation infer their effects from the body, same as a `fun` declaration.
 
-A. **Drop the flag.** It is unused and misleads readers.
+### Effect labels
 
-B. **Enforce the flag in specific contexts.** Candidates:
+The label vocabulary is closed. Stage 1 ships five labels. Each maps to a concrete reason a function leaves the pure-value world:
 
-- Type alias arguments. `type Adult = filter(People, isAdult)` (does not exist today, but if we add type-level computation, the function would have to be pure).
-- Query predicates. `where` and `having` should be pure to give the optimiser room to reorder.
-- Struct field defaults (does not exist today).
+| Label  | Meaning                                              | Examples                       |
+|--------|------------------------------------------------------|--------------------------------|
+| `io`   | Writes to stdout or reads from stdin                 | `print`, `json`, `input`       |
+| `fs`   | Reads or writes the local file system                | `load`, `save`                 |
+| `net`  | Network I/O                                          | `fetch`                        |
+| `time` | Reads the wall clock or other non-deterministic clock | `now`                          |
+| `meta` | Dynamic compilation or evaluation                    | `eval`                         |
 
-Direction B is more honest. The minimum viable enforcement: require `where` and `having` predicates to call only pure functions. This is a conservative rule and easy to test.
+`time` exists separately from `io` because a `where` predicate that reads `time` is unsafe for the query optimizer to reorder even though it never touches stdout. `meta` exists separately because compile-time evaluation must reject `eval` even when stdout is fine.
 
-### Side-effecting builtins
+Two labels deliberately not in stage 1:
 
-The builtins that have side effects:
+- `state` for "mutates through a captured `var`". Mutability is tracked by MEP-10 A3 today through root-binding analysis. Re-introducing it as an effect would force every function that uses a `var` counter to acquire a label, which inflates annotations without enabling new enforcement. Revisit when `mut` becomes worth a separate axis.
+- `throw` for "may fail at runtime via a non-pure error path". Mochi has no exceptions today. The label lands when exceptions land.
 
-- `print`. Writes to stdout.
-- `json`. Writes pretty JSON to stdout.
-- `now`. Reads the clock (not pure even though it is read-only).
-- `fetch`. Network I/O.
-- `load`. File I/O (or stdin when path is omitted).
-- `save`. File I/O (or stdout when path is omitted).
-- `update`. Mutates a stored entity.
+`random` will land at the same time as a built-in RNG. Stage 1 has no random source other than `now`, so the label is not justified yet.
 
-If we adopt direction B above, these stay non-pure and any call to them is rejected in the pure positions.
+User-defined labels are out of scope at stage 1. Koka's complexity budget went almost entirely into making user-defined effects compose, and that complexity is not justified for a query-and-pipeline language until handlers also land. Re-evaluate as part of the exceptions / async MEP.
 
-### Effect on equality and reordering
+### Type rules
 
-The current semantics are sequential. There is no implicit parallelism. Reordering of function calls is not safe.
+Let `EffectSet` be a finite set drawn from the closed label vocabulary. `pure` is the empty set. Set inclusion `S1 <= S2` means every label of `S1` is in `S2`.
 
-Once query optimisation matters (it does for the SQL-like surface), we will want to:
+#### E1. Function arrows carry an effect set
 
-- Know that a `where` predicate is pure so we can push it through joins.
-- Know that an aggregate function is pure so the optimiser can parallelise.
+The type of a function value is `(P1, ..., Pn) -> R ! S` where `S` is an `EffectSet`. When `S` is empty the arrow is pure and the suffix is dropped from the printed form: `(int, int) -> int`.
 
-This is the practical motivation for direction B. We do not need a general effect system, just a "pure" flag we trust.
+#### E2. Inference: body union
 
-### Resource management
+For a user function without a declared effect annotation, the inferred effect set is the union of:
 
-There is no `try` or RAII-like construct. Resources opened by `load` are released when the program exits. We are happy with that. If we add long-lived processes, we revisit.
+1. The effect set of every callee invoked in the body (transitively via the callee's own inferred or declared set).
+2. The effect set induced by every statement-level effect performed directly: `fetch` contributes `net`, `load` and `save` contribute `fs`, an `update` statement contributes whatever effects MEP-14 ascribes to it (today, none beyond `state` which is not tracked).
+3. The effect set of every closure constructed inside the body, if and only if the closure is invoked synchronously within the same function. A closure stored or returned does not contribute its effects to the enclosing function; the act of *running* the closure does, at the call site.
 
-### Mutability of struct fields
+The recursion is well-founded because the call graph is finite and Mochi has no mutually recursive function-typed bindings without an explicit type annotation that fixes the effect set.
 
-A struct declared `type Point { x: int, y: int }` has fields that are implicitly mutable through a `var` binding and immutable through a `let` binding. There is no per-field `let` or `var` keyword inside a struct. We do not propose adding one; it adds complexity for little practical benefit.
+#### E3. Annotation: subset check
 
-### Fixtures
+For a user function with an `! S_declared` annotation, the inferred effect set `S_inferred` must satisfy `S_inferred <= S_declared`. If `S_inferred` is a strict subset, the function still has effect `S_declared` from outside; the declaration is an upper bound, not a description.
 
-Existing:
+If `S_inferred` is not a subset of `S_declared`, raise T065.
 
-- `assign_to_let` (error).
-- `var_mutable` (valid).
-- `map_assign_immutable` (error, partial).
-- `assign_undeclared_var` (error).
+The declaration-as-upper-bound rule lets a public function commit to "I touch the filesystem" without breaking when an internal helper grows a new effect. It also matches Swift typed `throws` and Java checked exceptions in the direction that worked: callers see what the callee promised, not what it happens to do today.
 
-New:
+#### E4. Subtyping on arrows
 
-- `mutate_let_index_rejected` (error, after A3).
-- `mutate_let_field_rejected` (error, after A3).
-- `mutate_let_map_key_rejected` (error, after A3 and applies to map).
-- `mutate_var_index_ok` (valid).
-- `mutate_var_field_ok` (valid).
-- `mutate_var_map_key_ok` (valid).
-- `closure_mutates_let_via_index` (error after A3, valid today).
-- `closure_mutates_var_ok` (valid).
-- `pure_in_where_ok` (valid, after pure enforcement).
-- `impure_in_where_rejected` (error, after pure enforcement).
+`(P1, ..., Pn) -> R ! S1` is a subtype of `(P1, ..., Pn) -> R ! S2` when `S1 <= S2`. The parameters and return type follow the usual variance rules from MEP-12.
+
+This rule is what makes "a pure function can be passed wherever an `io` function is accepted" work. The other direction is illegal: an `io` value does not flow into a pure slot.
+
+#### E5. Polymorphism through higher-order generics
+
+Higher-order generic functions propagate their callback's effect set to the call site through an implicit effect parameter. For
+
+```mochi
+fun map<T, U>(xs: list<T>, f: (T) -> U): list<U> {
+  var ys: list<U> = []
+  for x in xs {
+    ys = append(ys, f(x))
+  }
+  return ys
+}
+```
+
+the call `map(xs, fun(x) { print(x); return x })` has effect set `{io}` even though `map` itself is pure. The effect set of a call is the union of the function's own effect set and the effect sets of every function-typed argument that is invoked in the body.
+
+The elaborator threads this through a hidden effect parameter on each function-typed parameter. The user never writes the parameter and never sees it in error messages; it exists only in the elaborator's intermediate form. This is the same design as Unison's abilities and Swift's `rethrows`, both of which ship the propagation without ever printing the row variable.
+
+A function-typed parameter that is *stored* (assigned to a local, returned, put into a collection) does not propagate its effects to the surrounding call. Only the *call* of the parameter does. This matches MEP-16 N6's closure boundary rule on narrowing: storage defers, invocation commits.
+
+#### E6. Closure construction
+
+Constructing a closure does not produce effects. The closure's type carries its body's inferred effect set, which is observed at the call site. This is what makes `let log = fun(msg: string) { print(msg) }` a pure assignment that nonetheless yields a value of type `(string) -> unit ! io`.
+
+#### E7. Effect set normalization
+
+Two effect sets that contain the same labels are equal regardless of how they were built. Stage 1 enforces a canonical form (sorted by the fixed label index) so that printed types are stable across compilations.
+
+#### E8. Statement-level effects
+
+Statement constructs contribute their effects to the enclosing function:
+
+| Statement       | Effects             |
+|-----------------|---------------------|
+| `fetch ...`     | `net`               |
+| `load ...`      | `fs`                |
+| `save ...`      | `fs`                |
+| `update ...`    | (none at stage 1)   |
+| `print ...`     | not a statement; goes through the `print` builtin call |
+
+Statement-level effects are added to the enclosing function's inferred effect set in the same pass as call effects.
+
+#### E9. Pure positions
+
+A pure position is any expression whose effect set must be empty. Stage 1 has two pure positions, both inherited from existing behavior:
+
+1. `where` and `having` predicates (already T044).
+2. (Future, see Open Questions:) compile-time-evaluable expressions, type-level computation arguments, struct field defaults, and `const` declarations once those land.
+
+A non-empty effect set in a pure position raises T044 with a label-aware help message: "`%s` performs effect %s, but %s requires a pure expression". The diagnostic stays T044 because the user-visible failure is the same; the label list lands in the help text.
+
+#### E10. Effect annotation context
+
+A declared effect set bounds what the function may do, not what its callers may observe. A caller that calls a function declared `! io, fs` and uses only its pure return value cannot conclude the call was pure: the act of invoking the function is itself in the effect set, and the surrounding function's inferred set unions in `{io, fs}`.
+
+### Effect inference
+
+The inference pass runs once per function declaration, in dependency order over the call graph:
+
+1. The pre-pass that registers function signatures (`check.go` final pre-pass) is extended to produce an `EffectSet` per declared function. Initially empty for forward-declared functions, refined when the body is type-checked.
+2. The body walker (already inside `isPureFunction`, generalized to `inferFunctionEffects`) walks the AST collecting:
+   - Callee effects, looked up from `FuncType.Effects`.
+   - Statement-level effects from `s.Fetch`, `s.Load`, `s.Save`, future `s.Throw`.
+   - Closure-construction sites (no contribution; only call sites count).
+3. The collected set is stored on the function's `FuncType.Effects` in the surrounding env.
+4. If a declared annotation is present, the subset check from E3 fires here.
+
+The walker is monotone: a function never loses an effect once added. The fixed-point on recursive functions is reached in a single pass because the recursion is captured by the partial set already on the env at the time the body is checked, and the union operation is idempotent. (Mutual recursion that crosses an unannotated function-typed binding is rejected by T037 today; the effect inference inherits that restriction.)
+
+Cost: one extra `EffectSet` field per `FuncType`, one bitwise OR per call site, one subset check per declared annotation. No measurable impact on type-checking time.
+
+### Effect polymorphism in practice
+
+The hidden effect parameter on higher-order generics is best illustrated by the fixtures that ship with stage 2:
+
+```mochi
+// inferred: pure
+fun apply_pure(xs: list<int>, f: (int) -> int): list<int> {
+  var ys: list<int> = []
+  for x in xs {
+    ys = append(ys, f(x))
+  }
+  return ys
+}
+
+// caller 1: call site is pure
+let doubled: list<int> = apply_pure([1, 2, 3], fun(x: int): int { return x * 2 })
+
+// caller 2: call site has effect {io}
+let echoed: list<int> = apply_pure([1, 2, 3], fun(x: int): int { print(x); return x })
+```
+
+The function type of `apply_pure` is printed as `(list<int>, (int) -> int) -> list<int>`. There is no row variable in the printed form. Internally the elaborator records that `f`'s effects flow into the result. The call-site effect for `echoed` is `{io}`. The call-site effect for `doubled` is `{}`.
+
+This composes with type generics in the obvious way: the row variable rides along with each function-typed parameter, independently of the type variables.
+
+### Diagnostics
+
+Two new error codes plus a generalized one:
+
+- **T044** (existing): "impure call to `%s` is not allowed in `%s` predicate". Now reads the effect set instead of the binary flag; help text mentions which labels are present.
+- **T065** (new): "declared effect set `! %s` does not cover inferred effects `%s`". Fires when a function body uses an effect not listed in its `!` annotation. Help text names the missing label and the call site that contributed it.
+- **T066** (new): "effect %s is not allowed in this context". Fires in pure positions (compile-time eval, type-level args) once those land. Stage 1 does not raise T066; the code is reserved.
+
+The error messages name labels with the same lowercase identifiers users wrote, never internal indices or codes.
+
+### Runtime model
+
+Effects are erased at typecheck time. The runtime has no knowledge of effect sets. The VM continues to evaluate calls in source order; effects are not used to reorder, parallelize, or short-circuit at runtime. The only runtime change is that `runtime/vm/vm.go` constant folding switches its gate from `ft.Pure` to `ft.Effects.IsEmpty()`, which is equivalent today.
+
+When and if the query optimizer becomes aggressive enough to push predicates across joins (a stage-4 MEP-14 follow-up), the empty-set check will be its license to reorder. Until then, the runtime is unchanged.
+
+### Effect annotation context for closures
+
+A closure's effect set is observed at its call site. A closure that captures an `io`-effectful free variable does not gain an effect from the capture; the capture is a name lookup, not an invocation. The closure gains `io` if its body calls a function with `io` in its effect set, period. This matches E5 / E6 and avoids the "lifetime virality" that Scala 3 capture checking inherits from its first-class capability model.
+
+### Interaction with MEP-16 N5
+
+MEP-16 N5 currently drops narrowing for `var` bindings after any call to a non-pure function. Under the labeled scheme, the same rule applies with the new gate: a call with a non-empty effect set drops `var` narrowing. The conservative semantics are unchanged.
+
+Stage 3 (or later) may refine N5 to drop only when the callee carries a hypothetical `state` label, but that requires the `state` label to exist first. Until then the wider drop is the safe default.
+
+### Backwards compatibility
+
+The runtime change is a no-op. The static behavior is a strict refinement: every program that type-checks today continues to type-check at stage 1 because the empty-versus-non-empty distinction is preserved bit-for-bit.
+
+Stage 2's surface annotation is opt-in. A function without `!` continues to infer.
+
+Stage 2's subset enforcement (T065) is a breaking change for any function whose declared annotation is too narrow. The migration is to widen the annotation or to remove the call that contributed the unexpected effect. The fixture set captures both flavors.
 
 ## Rationale
 
-Tightening mutability under index and field assignments matches what users expect from `let`. Without it, `let` is a partial promise, and partial promises are worse than no promise.
+### Why a closed label set rather than user-defined effects
 
-Direction B for the pure flag pays for itself the moment we want to push predicates through joins. Direction A is cheaper but throws away an existing investment. We recommend B.
+Closed labels are checked in O(1). User-defined effects need a registration mechanism, scoping rules, and visibility (is an effect from another module the same as a same-named one here?). Koka's machinery answers all of this and the answers are subtle. The payoff of user-defined effects is the ability to write handlers, which Mochi does not have. Pay the cost when the payoff lands.
 
-## Backwards Compatibility
+The label vocabulary is short because the language is short. Stage 1 has five labels for five concrete kinds of side effect that the existing builtin surface exercises. Future MEPs add a label whenever they add a new family of builtin: random, exceptions, async, mutation-as-effect.
 
-Tightening A3 is a breaking change for programs that mutate `let` bindings through indices or fields. The fixture set captures the current behaviour and the migration path is to change `let` to `var` at the binding site.
+### Why no row variables in printed types
 
-Pure enforcement is a breaking change for programs that call impure functions from `where` or `having`. The migration is to move the impure work outside the predicate.
+Row variables in printed types are the single biggest complaint about Koka and the reason Frank papers spend so much ink on the bidirectional discipline. The mainstream-syntax languages that ship effect tracking (Swift, Java, Unison) all hide the row variable from the user. The hidden row is type-theoretically present (any sound implementation of higher-order polymorphism needs it), it just does not surface.
 
-## Reference Implementation
+The Mochi printed form `(list<T>, (T) -> U) -> list<U>` is the same printed form a user without effect tracking would expect from MEP-12.4. The effect propagation happens at the call site, not in the signature. The trade-off is that a generic helper cannot statically reject a callback with a given effect without an explicit annotation; that case is the long-tail and we accept the limitation.
 
-- `types/check.go` — current mutability check on `AssignStmt`.
-- `types/check.go:393-562` — `Pure` flag on builtin registrations.
-- `types/env.go:179, 187` — env shadowing without warning.
+### Why annotations are optional
 
-## Open Questions
+Mainstream-syntax languages that require effect annotations everywhere ([Eff], [Koka]) report user complaints about ceremony. Inference is cheap, and the union-by-callee model gives a precise answer for free. Annotations exist for two reasons: documentation at module boundaries, and a soft brake on accidental effect creep (T065). Neither is necessary for soundness; the inferred set is the source of truth.
 
-- **Direction A or B for the pure flag.** Recommendation is B. Need consensus.
-- **Aliasing analysis.** Out of scope, but worth flagging when we revisit.
-- **Resource scoping.** No `try`/RAII today; revisit if long-lived processes land.
+### Why not just keep `Pure bool`
+
+The single-bit flag works for `where`/`having` and for the MEP-16 N5 narrowing drop. It does not work for any of the questions in the Motivation section. Replacing it is a mechanical rename behind a compatibility shim. Keeping it ossifies the binary distinction and burns the design space for future enforcement points.
+
+### Why erase at runtime
+
+Mochi has no algebraic effect handlers. Without handlers, the runtime has nothing to do with effects: there is no `try`, no `with`, no `resume`. Effects are pure metadata. Erasing them is the simplest model and the one every effect system that lacks handlers (Swift, Unison-abilities-without-handlers, mtl-without-`Eff`) uses.
+
+When handlers land (stage 3+, deferred), the runtime gets a `perform` and `handle` primitive. The label set acquires user-defined entries. The erasure rule changes for those specific labels and stays the same for the closed builtin set. That is a future MEP's problem.
+
+### Why label `time` and `meta` separately from `io`
+
+`time` and `meta` are not stdout. The query optimizer's licence to reorder depends on the absence of `time` even when stdout is fine. A future "compile-time evaluation" pass must reject `meta` even when neither `io` nor `time` is present. Collapsing them into a single `io` would force every enforcement point to special-case lookups and would lose the precision the design pays for.
+
+The five labels are chosen so that no single label subsumes another except in trivially obvious ways (`fs` and `net` and `io` are all distinct interactions with the outside world). The label graph is flat. There is no inheritance, no hierarchy, no `io.read` versus `io.write` split. Both granularities have been tried in research languages; both produce more bugs than they prevent at the level of polish Mochi targets.
+
+## Alternatives considered
+
+**Algebraic effects with handlers** ([Eff], [Koka], [OCaml 5]). Powerful: user-defined effects, multi-shot continuations, structured concurrency. The cost is a runtime that supports delimited continuations (one-shot or multi-shot) plus a typed surface that mainstream users find foreign. OCaml 5 shipped the runtime without the types and the community treats it as a library substrate, not a user-facing facility. Sivaramakrishnan et al., *Retrofitting Effect Handlers onto OCaml* (PLDI '21), explicitly defers typing. Mochi would inherit the same dilemma. Defer to stage 3 or beyond.
+
+**Effect rows in every signature** ([Koka]). Daan Leijen, *Koka: Programming with Row-Polymorphic Effect Types* (MSR-TR-2014-23) and *Type Directed Compilation of Row-Typed Algebraic Effects* (POPL '17). Most expressive design. The cost is row variables everywhere in user-visible types and error messages that mention rows the user never wrote. Mochi targets mainstream readability; the surface tax is too high.
+
+**Capabilities as values** ([Scala 3 capture checking], [Effekt]). Brachthäuser, Schuster, Ostermann, *Effects as Capabilities* (OOPSLA '20), and Odersky's draft *A Type System for Capabilities* (2022 onwards). Effects modeled as first-class values with capture-set inference. Compelling for lifetime tracking and for replacing async coloring, but the user-visible cost (the `^` annotation and capability-not-in-scope errors) is high for a language without `mut` lifetime tracking. Revisit if Mochi grows a borrowing discipline.
+
+**Monomorphic `IO` monad** ([Haskell]). Hard wall between effectful and pure code. Solves the binary case at the cost of monadic plumbing in every effectful function. Mochi has no monad and no `do` notation. Adopting `IO` would require both. The label-set design above gives the same separation without the plumbing.
+
+**Bidirectional effect inference** ([Frank]). Lindley, McBride, McLaughlin, *Do Be Do Be Do* (POPL '17). Effects flow in via the expected type, out via the actual type. Eliminates row variables in printed types but requires annotations at every "mode switch" (a function-typed parameter, a higher-order call). Mochi prefers full inference with optional annotations.
+
+**Effect rows with hidden surface** ([Unison] abilities, [Swift] `rethrows`). The implementation strategy this MEP picks. The row variable exists in the elaborator; the printed type hides it. Calls inherit the row from their function-typed arguments. This is the sweet spot for a mainstream-syntax language with HOFs and generics.
+
+**Checked exceptions only** ([Java], [Swift] `throws`). Monomorphic effect tracking. Java's checked exceptions are widely regarded as a failure because callbacks (`Runnable`, `Stream.map`) cannot propagate them, forcing `RuntimeException` wrappers. Swift fixed the lambda case with `rethrows` and later typed throws. The lesson: monomorphic effect tracking without higher-order polymorphism breaks at the first `map`. Mochi adopts the labeled-set design with the `rethrows`-style propagation precisely to avoid this failure mode.
+
+## Migration staging
+
+The work lands in three stages, each a separate PR with fixture pinning:
+
+1. **Stage 1: replace the bit.** Introduce `EffectSet`, add `Effects EffectSet` to `FuncType`, tag every builtin with its label set, generalize `isPureFunction` to `inferFunctionEffects`, keep the `Pure()` method as a compatibility shim, regenerate goldens. No surface syntax. T044 keeps firing for non-empty effect sets in `where`/`having`. MEP-16 N5 keeps firing for any non-empty effect set.
+
+2. **Stage 2: surface annotation.** Add the `!` syntax to the parser. Add `inferFunctionEffects` declared-vs-inferred subset check. Add T065. Document the label vocabulary in MEP-1 alongside the keyword list. Add fixtures that declare and exceed effect annotations.
+
+3. **Stage 3 (deferred):** decide on user-defined effects and handlers. Likely paired with the exception MEP or the async MEP. Out of scope here; the design is intentionally extensible.
+
+The three stages can ship months apart. Stage 1 is the only one that touches the type checker. Stage 2 is parser + a single subset check. Stage 3 is a separate MEP.
+
+## Reference implementation
+
+Pointers to where each piece lives once the stages ship.
+
+- `types/kinds.go` `FuncType.Effects`: replaces `Pure bool`; `Pure()` method returns `Effects.IsEmpty()`.
+- `types/effects.go` (new): `EffectSet` type (sorted bitset over the closed label index), `Union`, `IsSubset`, `IsEmpty`, `String`, `ParseLabel`.
+- `types/check.go` builtin block: each existing `Pure: true` becomes `Effects: EmptySet()`; impure builtins acquire labels (`print: io`, `now: time`, `eval: meta`, etc.).
+- `types/pure.go` rename to `types/effects_infer.go`: `isPureFunction` becomes `inferFunctionEffects`. `firstImpureCall` becomes `firstEffectfulCall`, returning the label list at the offending site for better error help text.
+- `types/check_expr.go`: T044 site at `where` and `having` predicates reads `Effects.IsEmpty()` instead of `Pure`.
+- `types/check.go` if-statement narrowing loop (MEP-16 N5 hook): reads `Effects.IsEmpty()`.
+- `runtime/vm/vm.go` constant-folding gate: reads `Effects.IsEmpty()`.
+- `parser/ast.go` `FunStmt.Effects`: `[]string` populated by stage 2 parser. Empty at stage 1.
+- `types/errors.go`: T044 help text gains label list; T065 added.
+
+## Open questions
+
+- **`const` declarations and compile-time evaluation.** A natural pure position; the design above reserves T066 for it. Land when `const` lands.
+- **Effect inference for struct method defaults.** Default expressions in struct field declarations must be pure for the same reason `const` must be. Same gate, different syntax surface.
+- **Effect inference for cross-module imports.** Today every Mochi program is single-file. When imports land, the effect set must travel across module boundaries. The label set is closed, so the serialization is a small bitset; no schema work.
+- **Effect-driven query reordering.** The optimizer can push predicates across joins when the predicate is pure. The first version of that work lives in MEP-14 follow-ups; this MEP gives it the gate.
+- **`time` versus `clock` versus `now`.** The label `time` covers any wall-clock or monotonic-clock read. A future monotonic-only API would still carry `time` because non-determinism is the property the optimizer cares about, not the unit of measure.
+- **User-defined labels.** Reconsidered together with handlers. Pre-emptively shipping a registration mechanism without handlers is the Koka path; declined here.
+- **Effect handlers.** Strictly deferred. The current runtime cannot implement them; adding delimited continuations is a separate engineering project.
 
 ## References
 
-- Benjamin C. Pierce, *Types and Programming Languages*, chapter 13.
-- Eric Holk et al., "Mochi" — internal design notes on streams and intents.
+- Daan Leijen. *Koka: Programming with Row-Polymorphic Effect Types.* Microsoft Research TR MSR-TR-2014-23, 2014. https://www.microsoft.com/en-us/research/publication/koka-programming-with-row-polymorphic-effect-types/
+- Daan Leijen. *Type Directed Compilation of Row-Typed Algebraic Effects.* POPL 2017. https://dl.acm.org/doi/10.1145/3009837.3009872
+- Sam Lindley, Conor McBride, Craig McLaughlin. *Do Be Do Be Do.* POPL 2017. https://dl.acm.org/doi/10.1145/3009837.3009897
+- Jonathan Brachthäuser, Philipp Schuster, Klaus Ostermann. *Effects as Capabilities: Effect Handlers and Lightweight Effect Polymorphism.* OOPSLA 2020. https://dl.acm.org/doi/10.1145/3428194
+- KC Sivaramakrishnan et al. *Retrofitting Effect Handlers onto OCaml.* PLDI 2021. https://dl.acm.org/doi/10.1145/3453483.3454039
+- Martin Odersky et al. *A Type System for Capabilities.* Draft, 2022 onwards. https://github.com/lampepfl/dotty/tree/main/docs/_docs/reference/experimental/cc.md
+- Andrej Bauer, Matija Pretnar. *Programming with Algebraic Effects and Handlers.* JLAMP 2015. https://www.sciencedirect.com/science/article/pii/S2352220815000565
+- Apple. *Swift typed throws.* https://docs.swift.org/swift-book/documentation/the-swift-programming-language/errorhandling/
+- Unison Computing. *Abilities and ability handlers.* https://www.unison-lang.org/docs/fundamentals/abilities/
+- Effekt language. https://effekt-lang.org/
+- Koka language. https://koka-lang.github.io/
 
 ## Copyright
 


### PR DESCRIPTION
Closes #21442.

## Summary

- New `types.EffectSet` bitset over the closed five-label vocabulary from MEP-0015 (`io`, `fs`, `net`, `time`, `meta`).
- `FuncType.Pure bool` becomes `FuncType.Effects EffectSet`; a `Pure()` method preserves the legacy call sites.
- The five impure builtins (`print`, `json`, `input`, `now`, `eval`) carry their canonical effect labels; every other builtin keeps the empty (pure) set.
- A bridge `legacyEffectsFromPure` maps the previous boolean coming out of `isPureFunction` to either `{}` or `{io}`. Stage 2 replaces it with real body-walked inference.

## Test plan

- [x] `go build ./...`
- [x] `go test ./types/...`
- [x] new `types/effects_test.go` covers bitset basics, union, subset, parsing, and the `Pure()` shim.