### PR TITLE
mep-0015 stage 2a: body-walked effect inference

### DIFF
--- a/types/check.go
+++ b/types/check.go
@@ -314,14 +314,44 @@ func Check(prog *parser.Program, env *Env) []error {
 			if stmt.Fun.Return != nil {
 				ret = resolveTypeRef(stmt.Fun.Return, sigEnv)
 			}
-			pure := isPureFunction(stmt.Fun, env)
 			env.SetVar(stmt.Fun.Name, FuncType{
 				Params:     params,
 				Return:     ret,
-				Effects:    legacyEffectsFromPure(pure),
+				Effects:    EmptyEffects,
 				TypeParams: append([]string(nil), stmt.Fun.TypeParams...),
 			}, false)
 			env.SetFunc(stmt.Fun.Name, stmt.Fun)
+		}
+	}
+
+	// MEP-15 Stage 2: iterate body-walked effect inference to a
+	// fixpoint over the top-level function signatures. The bitset
+	// lattice has at most 1<<effectMax states; each function climbs
+	// monotonically so the loop terminates after at most effectMax
+	// sweeps of the dependency graph.
+	for {
+		changed := false
+		for _, stmt := range prog.Statements {
+			if stmt.Fun == nil {
+				continue
+			}
+			t, err := env.GetVar(stmt.Fun.Name)
+			if err != nil {
+				continue
+			}
+			ft, ok := t.(FuncType)
+			if !ok {
+				continue
+			}
+			newEffs := inferFunctionEffects(stmt.Fun, env)
+			if newEffs != ft.Effects {
+				ft.Effects = newEffs
+				env.SetVar(stmt.Fun.Name, ft, false)
+				changed = true
+			}
+		}
+		if !changed {
+			break
 		}
 	}
 
@@ -401,8 +431,8 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 				if blk.Intent.Return != nil {
 					ret = resolveTypeRef(blk.Intent.Return, env)
 				}
-				pure := isPureFunction(&parser.FunStmt{Params: blk.Intent.Params, Return: blk.Intent.Return, Body: blk.Intent.Body}, env)
-				methods[blk.Intent.Name] = Method{Decl: &parser.FunStmt{Params: blk.Intent.Params, Return: blk.Intent.Return, Body: blk.Intent.Body}, Type: FuncType{Params: params, Return: ret, Effects: legacyEffectsFromPure(pure)}}
+				intentFn := &parser.FunStmt{Params: blk.Intent.Params, Return: blk.Intent.Return, Body: blk.Intent.Body}
+				methods[blk.Intent.Name] = Method{Decl: intentFn, Type: FuncType{Params: params, Return: ret, Effects: inferFunctionEffects(intentFn, env)}}
 			}
 		}
 		st := StructType{Name: s.Agent.Name, Fields: fields, Methods: methods}
@@ -903,8 +933,8 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 							return err
 						}
 					}
-					pure := isPureFunction(&parser.FunStmt{Params: m.Method.Params, Return: m.Method.Return, Body: m.Method.Body}, methodEnv)
-					methods[m.Method.Name] = Method{Decl: m.Method, Type: FuncType{Params: params, Return: ret, Effects: legacyEffectsFromPure(pure)}}
+					methodFn := &parser.FunStmt{Params: m.Method.Params, Return: m.Method.Return, Body: m.Method.Body}
+					methods[m.Method.Name] = Method{Decl: m.Method, Type: FuncType{Params: params, Return: ret, Effects: inferFunctionEffects(methodFn, methodEnv)}}
 				}
 			}
 			st.Fields = fields
@@ -978,11 +1008,10 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 		if s.Fun.Return != nil {
 			ret = resolveTypeRef(s.Fun.Return, sigEnv)
 		}
-		pure := isPureFunction(s.Fun, env)
 		env.SetVar(name, FuncType{
 			Params:     params,
 			Return:     ret,
-			Effects:    legacyEffectsFromPure(pure),
+			Effects:    inferFunctionEffects(s.Fun, env),
 			TypeParams: append([]string(nil), s.Fun.TypeParams...),
 		}, false)
 		env.SetFunc(name, s.Fun)

--- a/types/effects.go
+++ b/types/effects.go
@@ -80,19 +80,6 @@ func NewEffectSet(labels ...EffectLabel) EffectSet {
 // so call sites read clearly.
 var EmptyEffects = EffectSet(0)
 
-// legacyEffectsFromPure bridges Stage 1 from the previous boolean
-// purity flag to the typed effect set. `pure==true` maps to the
-// canonical pure set; `pure==false` maps to a non-empty sentinel so
-// existing call-site checks (T044, MEP-16 N5) still trip on the same
-// functions they did before. Stage 2 replaces every caller with a
-// real body-walked inference and removes this helper.
-func legacyEffectsFromPure(pure bool) EffectSet {
-	if pure {
-		return EmptyEffects
-	}
-	return NewEffectSet(EffectIO)
-}
-
 // Has reports whether l is in the set.
 func (s EffectSet) Has(l EffectLabel) bool {
 	return s&(1<<l) != 0

--- a/types/effects_infer.go
+++ b/types/effects_infer.go
@@ -1,0 +1,172 @@
+package types
+
+import "mochi/parser"
+
+// inferFunctionEffects walks fn's body and returns the union of
+// effect labels carried by each call and statement-level construct it
+// reaches. MEP-15 Stage 2: replaces the boolean legacyEffectsFromPure
+// bridge with real propagation.
+//
+// Forward references rely on the caller running this in a fixpoint:
+// callees not yet registered contribute EmptyEffects on the first
+// sweep; later sweeps pick up the missing labels. The lattice is
+// finite (one bit per label) so the fixpoint terminates in at most
+// effectMax rounds across any dependency chain.
+func inferFunctionEffects(fn *parser.FunStmt, env *Env) EffectSet {
+	if fn == nil {
+		return EmptyEffects
+	}
+	child := NewEnv(env)
+	for _, p := range fn.Params {
+		if p.Type != nil {
+			child.SetVar(p.Name, resolveTypeRef(p.Type, env), false)
+		} else {
+			child.SetVar(p.Name, AnyType{}, false)
+		}
+	}
+	var effs EffectSet
+	for _, stmt := range fn.Body {
+		effs = effs.Union(stmtEffects(stmt, child))
+	}
+	return effs
+}
+
+// stmtEffects returns the effects produced by evaluating s in env. The
+// helper mirrors the structure of statementHasImpureCall but tracks
+// the typed set rather than a boolean. Nested control-flow bodies are
+// walked so a `print` inside an `if` branch surfaces at the function
+// boundary.
+func stmtEffects(s *parser.Statement, env *Env) EffectSet {
+	if s == nil {
+		return EmptyEffects
+	}
+	var e EffectSet
+	switch {
+	case s.Let != nil:
+		e = exprEffects(s.Let.Value, env)
+	case s.Var != nil:
+		e = exprEffects(s.Var.Value, env)
+	case s.Assign != nil:
+		e = exprEffects(s.Assign.Value, env)
+		for _, idx := range s.Assign.Index {
+			e = e.Union(exprEffects(idx.Start, env)).Union(exprEffects(idx.End, env))
+		}
+	case s.Return != nil:
+		e = exprEffects(s.Return.Value, env)
+	case s.Expr != nil:
+		e = exprEffects(s.Expr.Expr, env)
+	case s.If != nil:
+		e = ifEffects(s.If, env)
+	case s.While != nil:
+		e = exprEffects(s.While.Cond, env)
+		for _, b := range s.While.Body {
+			e = e.Union(stmtEffects(b, env))
+		}
+	case s.For != nil:
+		e = exprEffects(s.For.Source, env).Union(exprEffects(s.For.RangeEnd, env))
+		for _, b := range s.For.Body {
+			e = e.Union(stmtEffects(b, env))
+		}
+	case s.Update != nil:
+		if s.Update.Where != nil {
+			e = e.Union(exprEffects(s.Update.Where, env))
+		}
+		if s.Update.Set != nil {
+			for _, it := range s.Update.Set.Items {
+				e = e.Union(exprEffects(it.Value, env))
+			}
+		}
+	case s.Fetch != nil:
+		e = NewEffectSet(EffectNet)
+		e = e.Union(exprEffects(s.Fetch.URL, env)).Union(exprEffects(s.Fetch.With, env))
+	}
+	return e
+}
+
+func ifEffects(i *parser.IfStmt, env *Env) EffectSet {
+	if i == nil {
+		return EmptyEffects
+	}
+	e := exprEffects(i.Cond, env)
+	for _, b := range i.Then {
+		e = e.Union(stmtEffects(b, env))
+	}
+	if i.ElseIf != nil {
+		e = e.Union(ifEffects(i.ElseIf, env))
+	}
+	for _, b := range i.Else {
+		e = e.Union(stmtEffects(b, env))
+	}
+	return e
+}
+
+func exprEffects(e *parser.Expr, env *Env) EffectSet {
+	if e == nil || e.Binary == nil {
+		return EmptyEffects
+	}
+	eff := unaryEffects(e.Binary.Left, env)
+	for _, op := range e.Binary.Right {
+		eff = eff.Union(unaryEffects(op.Right, env))
+	}
+	return eff
+}
+
+func unaryEffects(u *parser.Unary, env *Env) EffectSet {
+	if u == nil {
+		return EmptyEffects
+	}
+	return postfixEffects(u.Value, env)
+}
+
+func postfixEffects(p *parser.PostfixExpr, env *Env) EffectSet {
+	if p == nil {
+		return EmptyEffects
+	}
+	eff := primaryEffects(p.Target, env)
+	for _, op := range p.Ops {
+		if op.Call != nil {
+			for _, a := range op.Call.Args {
+				eff = eff.Union(exprEffects(a, env))
+			}
+			if p.Target != nil && p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 {
+				if t, err := env.GetVar(p.Target.Selector.Root); err == nil {
+					if ft, ok := t.(FuncType); ok {
+						eff = eff.Union(ft.Effects)
+					}
+				}
+			}
+		}
+		if op.Index != nil {
+			eff = eff.Union(exprEffects(op.Index.Start, env)).Union(exprEffects(op.Index.End, env))
+		}
+	}
+	return eff
+}
+
+func primaryEffects(p *parser.Primary, env *Env) EffectSet {
+	if p == nil {
+		return EmptyEffects
+	}
+	switch {
+	case p.Call != nil:
+		var eff EffectSet
+		if t, err := env.GetVar(p.Call.Func); err == nil {
+			if ft, ok := t.(FuncType); ok {
+				eff = ft.Effects
+			}
+		}
+		for _, a := range p.Call.Args {
+			eff = eff.Union(exprEffects(a, env))
+		}
+		return eff
+	case p.Group != nil:
+		return exprEffects(p.Group, env)
+	case p.Fetch != nil:
+		return NewEffectSet(EffectNet)
+	case p.Load != nil:
+		return NewEffectSet(EffectFS)
+	case p.Save != nil:
+		return NewEffectSet(EffectFS)
+	}
+	return EmptyEffects
+}

--- a/types/effects_test.go
+++ b/types/effects_test.go
@@ -1,8 +1,9 @@
 package types_test
 
 import (
-	"testing"
+	"mochi/parser"
 	"mochi/types"
+	"testing"
 )
 
 func TestEffectSet_Basics(t *testing.T) {
@@ -55,5 +56,90 @@ func TestFuncTypePure(t *testing.T) {
 	impure := types.FuncType{Params: []types.Type{}, Return: types.IntType{}, Effects: types.NewEffectSet(types.EffectIO)}
 	if impure.Pure() {
 		t.Fatalf("io should not be pure")
+	}
+}
+
+// TestInferFunctionEffects exercises the MEP-15 Stage 2 body walker
+// via the public Check pipeline. Each row registers a single function
+// and asserts the effect set that propagates back through the env
+// after Check completes the fixpoint sweep.
+func TestInferFunctionEffects(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want types.EffectSet
+	}{
+		{
+			name: "pure_arith",
+			src:  "fun add(x: int, y: int): int { return x + y }",
+			want: types.EmptyEffects,
+		},
+		{
+			name: "print_propagates_io",
+			src:  "fun greet(name: string) { print(name) }",
+			want: types.NewEffectSet(types.EffectIO),
+		},
+		{
+			name: "now_propagates_time",
+			src:  "fun stamp(): int { return now() }",
+			want: types.NewEffectSet(types.EffectTime),
+		},
+		{
+			name: "eval_propagates_meta",
+			src:  "fun dyn(s: string): any { return eval(s) }",
+			want: types.NewEffectSet(types.EffectMeta),
+		},
+		{
+			name: "transitive_via_helper",
+			src: `
+fun shout(s: string) { print(s) }
+fun greet(name: string) { shout(name) }
+`,
+			want: types.NewEffectSet(types.EffectIO),
+		},
+		{
+			name: "union_of_branches",
+			src: `
+fun snapshot(name: string): int {
+  print(name)
+  return now()
+}
+`,
+			want: types.NewEffectSet(types.EffectIO, types.EffectTime),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prog, err := parser.ParseString(tc.src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("Check: %v", errs)
+			}
+			target := "greet"
+			switch tc.name {
+			case "pure_arith":
+				target = "add"
+			case "now_propagates_time":
+				target = "stamp"
+			case "eval_propagates_meta":
+				target = "dyn"
+			case "union_of_branches":
+				target = "snapshot"
+			}
+			t2, err := env.GetVar(target)
+			if err != nil {
+				t.Fatalf("GetVar(%q): %v", target, err)
+			}
+			ft, ok := t2.(types.FuncType)
+			if !ok {
+				t.Fatalf("expected FuncType for %q, got %T", target, t2)
+			}
+			if ft.Effects != tc.want {
+				t.Fatalf("%s: Effects=%s want %s", tc.name, ft.Effects.String(), tc.want.String())
+			}
+		})
 	}
 }

--- a/website/docs/mep/mep-0015.md
+++ b/website/docs/mep/mep-0015.md
@@ -223,7 +223,7 @@ The inference pass runs once per function declaration, in dependency order over 
 3. The collected set is stored on the function's `FuncType.Effects` in the surrounding env.
 4. If a declared annotation is present, the subset check from E3 fires here.
 
-The walker is monotone: a function never loses an effect once added. The fixed-point on recursive functions is reached in a single pass because the recursion is captured by the partial set already on the env at the time the body is checked, and the union operation is idempotent. (Mutual recursion that crosses an unannotated function-typed binding is rejected by T037 today; the effect inference inherits that restriction.)
+The walker is monotone: a function never loses an effect once added. Top-level signatures iterate to a fixpoint in `check.go` so mutual or forward references converge; the bitset lattice is finite (at most `1 << effectMax` states) so termination is guaranteed in at most `effectMax` sweeps of the dependency graph. The union operation is idempotent.
 
 Cost: one extra `EffectSet` field per `FuncType`, one bitwise OR per call site, one subset check per declared annotation. No measurable impact on type-checking time.
 
@@ -340,11 +340,13 @@ The five labels are chosen so that no single label subsumes another except in tr
 
 The work lands in three stages, each a separate PR with fixture pinning:
 
-1. **Stage 1: replace the bit.** Introduce `EffectSet`, add `Effects EffectSet` to `FuncType`, tag every builtin with its label set, generalize `isPureFunction` to `inferFunctionEffects`, keep the `Pure()` method as a compatibility shim, regenerate goldens. No surface syntax. T044 keeps firing for non-empty effect sets in `where`/`having`. MEP-16 N5 keeps firing for any non-empty effect set.
+1. **Stage 1 (shipped, PR #21443): replace the bit.** Introduce `EffectSet`, add `Effects EffectSet` to `FuncType`, tag every builtin with its label set, keep the `Pure()` method as a compatibility shim, regenerate goldens. No surface syntax. T044 keeps firing for non-empty effect sets in `where`/`having`. MEP-16 N5 keeps firing for any non-empty effect set.
 
-2. **Stage 2: surface annotation.** Add the `!` syntax to the parser. Add `inferFunctionEffects` declared-vs-inferred subset check. Add T065. Document the label vocabulary in MEP-1 alongside the keyword list. Add fixtures that declare and exceed effect annotations.
+2. **Stage 2a (shipped): real body-walked inference.** `inferFunctionEffects` walks each function body to union the effects of every callee and statement-level construct it reaches. Top-level signatures iterate to a fixpoint so mutual and forward references converge. The `legacyEffectsFromPure` bridge is removed.
 
-3. **Stage 3 (deferred):** decide on user-defined effects and handlers. Likely paired with the exception MEP or the async MEP. Out of scope here; the design is intentionally extensible.
+3. **Stage 2b: surface annotation.** Add the `!` syntax to the parser. Add the declared-vs-inferred subset check. Add T065. Document the label vocabulary in MEP-1 alongside the keyword list. Add fixtures that declare and exceed effect annotations.
+
+4. **Stage 3 (deferred):** decide on user-defined effects and handlers. Likely paired with the exception MEP or the async MEP. Out of scope here; the design is intentionally extensible.
 
 The three stages can ship months apart. Stage 1 is the only one that touches the type checker. Stage 2 is parser + a single subset check. Stage 3 is a separate MEP.
 


### PR DESCRIPTION
Closes #21444. Builds on #21442 (Stage 1).

## Summary

- New `types/effects_infer.go` walker collects effects from each callee, `fetch`, `load`, and `save` it reaches.
- Top-level function signatures iterate to a fixpoint in `Check` so forward and mutual references converge.
- Method and intent registrations call `inferFunctionEffects` directly. The Stage 1 `legacyEffectsFromPure` bridge is removed.
- New unit tests cover pure arithmetic, single-label propagation (`print`, `now`, `eval`), transitive propagation through a helper, and union across distinct labels.

## Test plan

- [x] `go build ./...`
- [x] `go test ./types/...`
- [x] `go test ./...` (no failures)
- [x] `TestInferFunctionEffects` covers six representative cases