### PR TITLE
mep-0015 stage 2b: ! effect annotation surface + T064/T065

### DIFF
--- a/parser/ast.go
+++ b/parser/ast.go
@@ -209,6 +209,7 @@ type FunStmt struct {
 	TypeParams []string       `json:"type_params,omitempty" parser:"[ '<' @Ident { ',' @Ident } '>' ]"`
 	Params     []*Param       `json:"params,omitempty" parser:"'(' [ @@ { ',' @@ } ] ')'"`
 	Return     *TypeRef       `json:"return,omitempty" parser:"[ ':' @@ ]"`
+	Effects    []string       `json:"effects,omitempty" parser:"[ '!' @Ident { ',' @Ident } ]"`
 	Body       []*Statement   `json:"body,omitempty" parser:"'{' @@* '}'"`
 }
 
@@ -547,6 +548,7 @@ type FunExpr struct {
 	TypeParams []string       `json:"type_params,omitempty" parser:"'fun' [ '<' @Ident { ',' @Ident } '>' ]"`
 	Params     []*Param       `json:"params,omitempty" parser:"'(' [ @@ { ',' @@ } ] ')'"`
 	Return     *TypeRef       `json:"return,omitempty" parser:"[ ':' @@ ]"`
+	Effects    []string       `json:"effects,omitempty" parser:"[ '!' @Ident { ',' @Ident } ]"`
 	BlockBody  []*Statement   `json:"blockbody,omitempty" parser:"[ '{' @@* '}' ]"`
 	ExprBody   *Expr          `json:"exprbody,omitempty" parser:"[ '=>' @@ ]"`
 }

--- a/parser/effects_parse_test.go
+++ b/parser/effects_parse_test.go
@@ -1,0 +1,61 @@
+package parser_test
+
+import (
+	"reflect"
+	"testing"
+
+	"mochi/parser"
+)
+
+func TestParse_FunStmtEffectAnnotation(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{"no annotation", "fun add(x: int, y: int): int { return x + y }", nil},
+		{"single label", "fun greet(name: string) ! io { print(name) }", []string{"io"}},
+		{"multi label", "fun snapshot(): int ! io, time { print(1); return now() }", []string{"io", "time"}},
+		{"all labels", "fun any() ! io, fs, net, time, meta { }", []string{"io", "fs", "net", "time", "meta"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prog, err := parser.ParseString(tc.src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if len(prog.Statements) == 0 || prog.Statements[0].Fun == nil {
+				t.Fatalf("expected a FunStmt at top, got %+v", prog.Statements)
+			}
+			got := prog.Statements[0].Fun.Effects
+			if tc.want == nil {
+				if len(got) != 0 {
+					t.Fatalf("expected no effects, got %v", got)
+				}
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("Effects=%v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParse_FunExprEffectAnnotation(t *testing.T) {
+	src := "let f = fun(x: int): int ! io => x"
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	let := prog.Statements[0].Let
+	if let == nil || let.Value == nil {
+		t.Fatalf("expected let, got %+v", prog.Statements[0])
+	}
+	p := let.Value.Binary.Left.Value.Target
+	if p == nil || p.FunExpr == nil {
+		t.Fatalf("expected FunExpr, got %+v", p)
+	}
+	if got, want := p.FunExpr.Effects, []string{"io"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("FunExpr.Effects=%v want %v", got, want)
+	}
+}

--- a/tests/parser/errors/missing_paren.err
+++ b/tests/parser/errors/missing_paren.err
@@ -1,4 +1,4 @@
-error[P052]: tests/parser/errors/missing_paren.mochi:1:23: unexpected token ":" (expected ")" (":" TypeRef)? "{" Statement* "}")
+error[P052]: tests/parser/errors/missing_paren.mochi:1:23: unexpected token ":" (expected ")" (":" TypeRef)? ("!" <ident> ("," <ident>)*)? "{" Statement* "}")
   --> tests/parser/errors/missing_paren.mochi:1:23
 
   1 | fun add(a: int, b: int: int {

--- a/tests/types/errors/effects_declared_exceeds_inferred.err
+++ b/tests/types/errors/effects_declared_exceeds_inferred.err
@@ -1,0 +1,8 @@
+1. error[T065]: function `stamp` declares effects io but its body produces time
+  --> tests/types/errors/effects_declared_exceeds_inferred.mochi:5:1
+
+  5 | fun stamp(): int ! io {
+    | ^
+
+help:
+  Either add the missing label(s) to the `!` annotation, or remove the call that produces the extra effect.

--- a/tests/types/errors/effects_declared_exceeds_inferred.mochi
+++ b/tests/types/errors/effects_declared_exceeds_inferred.mochi
@@ -1,0 +1,7 @@
+// MEP-15 stage 2b T065: the body produces `time` (via now()) but the
+// declaration only promises `io`. The annotation is the public
+// contract, so the call to now() must either be removed or the
+// annotation must add `time`.
+fun stamp(): int ! io {
+  return now()
+}

--- a/tests/types/errors/effects_unknown_label.err
+++ b/tests/types/errors/effects_unknown_label.err
@@ -1,0 +1,8 @@
+1. error[T064]: unknown effect label `quantum`
+  --> tests/types/errors/effects_unknown_label.mochi:3:1
+
+  3 | fun broken() ! quantum {
+    | ^
+
+help:
+  Effect annotations may only mention the closed label set: io, fs, net, time, meta.

--- a/tests/types/errors/effects_unknown_label.mochi
+++ b/tests/types/errors/effects_unknown_label.mochi
@@ -1,0 +1,4 @@
+// MEP-15 stage 2b T064: unknown labels in an effect annotation are
+// rejected up front. The closed vocabulary is io, fs, net, time, meta.
+fun broken() ! quantum {
+}

--- a/tests/types/valid/effects_annotation_accepted.golden
+++ b/tests/types/valid/effects_annotation_accepted.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/effects_annotation_accepted.mochi
+++ b/tests/types/valid/effects_annotation_accepted.mochi
@@ -1,0 +1,10 @@
+// MEP-15 stage 2b: an annotation may be wider than the inferred set,
+// since it is an upper bound on observable effects.
+fun maybe_chatter(name: string) ! io, time {
+  print(name)
+}
+
+fun snapshot(): int ! io, time {
+  print(1)
+  return now()
+}

--- a/types/check.go
+++ b/types/check.go
@@ -292,7 +292,10 @@ func Check(prog *parser.Program, env *Env) []error {
 	}
 
 	// First pass: gather all function declarations so methods defined in types
-	// can reference them regardless of order in the source file.
+	// can reference them regardless of order in the source file. MEP-15 Stage
+	// 2b: a non-empty Effects annotation on FunStmt seeds the signature with
+	// the declared upper bound; T064 fires here for unknown labels.
+	declared := map[string]EffectSet{}
 	for _, stmt := range prog.Statements {
 		if stmt.Fun != nil {
 			sigEnv := env
@@ -314,10 +317,17 @@ func Check(prog *parser.Program, env *Env) []error {
 			if stmt.Fun.Return != nil {
 				ret = resolveTypeRef(stmt.Fun.Return, sigEnv)
 			}
+			seed := EmptyEffects
+			if len(stmt.Fun.Effects) > 0 {
+				d, labelErrs := parseDeclaredEffects(stmt.Fun)
+				errs = append(errs, labelErrs...)
+				declared[stmt.Fun.Name] = d
+				seed = d
+			}
 			env.SetVar(stmt.Fun.Name, FuncType{
 				Params:     params,
 				Return:     ret,
-				Effects:    EmptyEffects,
+				Effects:    seed,
 				TypeParams: append([]string(nil), stmt.Fun.TypeParams...),
 			}, false)
 			env.SetFunc(stmt.Fun.Name, stmt.Fun)
@@ -328,11 +338,17 @@ func Check(prog *parser.Program, env *Env) []error {
 	// fixpoint over the top-level function signatures. The bitset
 	// lattice has at most 1<<effectMax states; each function climbs
 	// monotonically so the loop terminates after at most effectMax
-	// sweeps of the dependency graph.
+	// sweeps of the dependency graph. Annotated functions are pinned
+	// to their declared set so callers see the published contract;
+	// inference still runs against the same env to populate the
+	// downstream check below.
 	for {
 		changed := false
 		for _, stmt := range prog.Statements {
 			if stmt.Fun == nil {
+				continue
+			}
+			if _, pinned := declared[stmt.Fun.Name]; pinned {
 				continue
 			}
 			t, err := env.GetVar(stmt.Fun.Name)
@@ -352,6 +368,23 @@ func Check(prog *parser.Program, env *Env) []error {
 		}
 		if !changed {
 			break
+		}
+	}
+
+	// MEP-15 Stage 2b: T065 declared-exceeds-inferred. For each
+	// annotated function, re-run the walker against the finalized env
+	// and reject any inferred label that escapes the declared set.
+	for _, stmt := range prog.Statements {
+		if stmt.Fun == nil {
+			continue
+		}
+		d, ok := declared[stmt.Fun.Name]
+		if !ok {
+			continue
+		}
+		inferred := inferFunctionEffects(stmt.Fun, env)
+		if !inferred.IsSubset(d) {
+			errs = append(errs, errEffectsExceedDeclared(stmt.Fun.Pos, stmt.Fun.Name, d, inferred))
 		}
 	}
 
@@ -1008,10 +1041,20 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type, inLoop bool) 
 		if s.Fun.Return != nil {
 			ret = resolveTypeRef(s.Fun.Return, sigEnv)
 		}
+		// Top-level FunStmts already had their FuncType registered by
+		// the Check pre-pass, where T064 and T065 diagnostics fired.
+		// Nested FunStmts run the inference walker here and inherit
+		// the declared set (if any) silently; their effects propagate
+		// to outer callers through the next inference pass.
+		effects := inferFunctionEffects(s.Fun, env)
+		if len(s.Fun.Effects) > 0 {
+			declared, _ := parseDeclaredEffects(s.Fun)
+			effects = declared
+		}
 		env.SetVar(name, FuncType{
 			Params:     params,
 			Return:     ret,
-			Effects:    inferFunctionEffects(s.Fun, env),
+			Effects:    effects,
 			TypeParams: append([]string(nil), s.Fun.TypeParams...),
 		}, false)
 		env.SetFunc(name, s.Fun)

--- a/types/effects_infer.go
+++ b/types/effects_infer.go
@@ -2,6 +2,24 @@ package types
 
 import "mochi/parser"
 
+// parseDeclaredEffects converts the raw label list on FunStmt.Effects
+// into a typed EffectSet. Each unknown label produces a T064
+// diagnostic but the parse keeps going so the caller sees every bad
+// label in one pass.
+func parseDeclaredEffects(fn *parser.FunStmt) (EffectSet, []error) {
+	var set EffectSet
+	var errs []error
+	for _, name := range fn.Effects {
+		label, ok := ParseEffectLabel(name)
+		if !ok {
+			errs = append(errs, errUnknownEffectLabel(fn.Pos, name))
+			continue
+		}
+		set = set.Add(label)
+	}
+	return set, errs
+}
+
 // inferFunctionEffects walks fn's body and returns the union of
 // effect labels carried by each call and statement-level construct it
 // reaches. MEP-15 Stage 2: replaces the boolean legacyEffectsFromPure

--- a/types/effects_test.go
+++ b/types/effects_test.go
@@ -59,6 +59,104 @@ func TestFuncTypePure(t *testing.T) {
 	}
 }
 
+// TestDeclaredEffects_Accepted exercises MEP-15 Stage 2b: a function
+// that annotates an effect set the body actually produces should
+// type-check cleanly, and the declared set should appear on the
+// FuncType so callers see the published contract.
+func TestDeclaredEffects_Accepted(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		fn   string
+		want types.EffectSet
+	}{
+		{"exact match", "fun greet(name: string) ! io { print(name) }", "greet", types.NewEffectSet(types.EffectIO)},
+		{"wider than body", "fun maybe_print(name: string) ! io, time { }", "maybe_print", types.NewEffectSet(types.EffectIO, types.EffectTime)},
+		{"declared without body effects", "fun reserve() ! fs { }", "reserve", types.NewEffectSet(types.EffectFS)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prog, err := parser.ParseString(tc.src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("Check: %v", errs)
+			}
+			ty, err := env.GetVar(tc.fn)
+			if err != nil {
+				t.Fatalf("GetVar: %v", err)
+			}
+			ft := ty.(types.FuncType)
+			if ft.Effects != tc.want {
+				t.Fatalf("Effects=%s want %s", ft.Effects, tc.want)
+			}
+		})
+	}
+}
+
+// TestDeclaredEffects_Rejected exercises T065: when the inferred set
+// exceeds the declared annotation, type-check must fail.
+func TestDeclaredEffects_Rejected(t *testing.T) {
+	src := "fun stamp(): int ! io { return now() }"
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	env := types.NewEnv(nil)
+	errs := types.Check(prog, env)
+	if len(errs) == 0 {
+		t.Fatalf("expected T065 diagnostic, got none")
+	}
+	found := false
+	for _, e := range errs {
+		if msg := e.Error(); contains(msg, "T065") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected T065 in %v", errs)
+	}
+}
+
+// TestDeclaredEffects_UnknownLabel exercises T064: an unknown label
+// in the annotation must surface a diagnostic rather than silently
+// expand the closed vocabulary.
+func TestDeclaredEffects_UnknownLabel(t *testing.T) {
+	src := "fun broken() ! quantum { }"
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	env := types.NewEnv(nil)
+	errs := types.Check(prog, env)
+	found := false
+	for _, e := range errs {
+		if contains(e.Error(), "T064") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected T064 in %v", errs)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && indexOf(s, sub) >= 0
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
 // TestInferFunctionEffects exercises the MEP-15 Stage 2 body walker
 // via the public Check pipeline. Each row registers a single function
 // and asserts the effect set that propagates back through the env

--- a/types/errors.go
+++ b/types/errors.go
@@ -82,6 +82,8 @@ var Errors = map[string]diagnostic.Template{
 	"T061": {Code: "T061", Message: "safe-call `?.%s` requires the wrapped type to be a struct, got %s", Help: "The element side of the option must expose a field named `%s`."},
 	"T062": {Code: "T062", Message: "safe-index `?[ ]` requires an option-typed receiver, got %s", Help: "`a?[k]` is only defined when `a : list<T>?` or `a : map<K, V>?`. Drop the `?` for a plain index access."},
 	"T063": {Code: "T063", Message: "safe-index `?[ ]` requires the wrapped type to be a list or map, got %s", Help: "Only `list<T>` and `map<K, V>` support indexed access after `?[`."},
+	"T064": {Code: "T064", Message: "unknown effect label `%s`", Help: "Effect annotations may only mention the closed label set: io, fs, net, time, meta."},
+	"T065": {Code: "T065", Message: "function `%s` declares effects %s but its body produces %s", Help: "Either add the missing label(s) to the `!` annotation, or remove the call that produces the extra effect."},
 }
 
 // --- Wrapper Functions ---
@@ -295,6 +297,14 @@ func errHavingBoolean(pos lexer.Position) error {
 
 func errImpurePredicate(pos lexer.Position, name, predicate string) error {
 	return Errors["T044"].New(pos, name, predicate)
+}
+
+func errUnknownEffectLabel(pos lexer.Position, label string) error {
+	return Errors["T064"].New(pos, label)
+}
+
+func errEffectsExceedDeclared(pos lexer.Position, name string, declared, inferred EffectSet) error {
+	return Errors["T065"].New(pos, name, declared.String(), inferred.String())
 }
 
 func errLenOperand(pos lexer.Position, typ Type) error {

--- a/website/docs/mep/mep-0015.md
+++ b/website/docs/mep/mep-0015.md
@@ -344,7 +344,7 @@ The work lands in three stages, each a separate PR with fixture pinning:
 
 2. **Stage 2a (shipped): real body-walked inference.** `inferFunctionEffects` walks each function body to union the effects of every callee and statement-level construct it reaches. Top-level signatures iterate to a fixpoint so mutual and forward references converge. The `legacyEffectsFromPure` bridge is removed.
 
-3. **Stage 2b: surface annotation.** Add the `!` syntax to the parser. Add the declared-vs-inferred subset check. Add T065. Document the label vocabulary in MEP-1 alongside the keyword list. Add fixtures that declare and exceed effect annotations.
+3. **Stage 2b (shipped): surface annotation.** Add the `!` syntax to `FunStmt` and `FunExpr` in the parser. The annotation is parsed as a list of label idents, then converted to an `EffectSet` in `types/check.go`. The declared set is treated as the published upper bound: callers see the declared value on `FuncType.Effects`, and the body walker's inferred set must be a subset (else T065). Unknown labels surface T064. Fixtures: `tests/types/valid/effects_annotation_accepted.mochi`, `tests/types/errors/effects_declared_exceeds_inferred.mochi`, `tests/types/errors/effects_unknown_label.mochi`.
 
 4. **Stage 3 (deferred):** decide on user-defined effects and handlers. Likely paired with the exception MEP or the async MEP. Out of scope here; the design is intentionally extensible.
 


### PR DESCRIPTION
Closes #21446. Builds on #21442 (Stage 1) and #21444 (Stage 2a).

## Summary

- New `Effects []string` field on `FunStmt` and `FunExpr` parses the optional `! io, fs, ...` annotation between the return type and the body.
- Declared annotation is parsed to `EffectSet` and pinned on `FuncType.Effects` so callers see the published contract.
- T064 fires for unknown labels (closed vocabulary: io, fs, net, time, meta).
- T065 fires when the inferred set escapes the declared set.
- Goldens cover one passing case (annotation wider than body) and two failing cases.

## Test plan

- [x] `go build ./...`
- [x] `go test ./types/...` (TestDeclaredEffects_Accepted, _Rejected, _UnknownLabel pass)
- [x] `go test ./parser/...` (TestParse_FunStmtEffectAnnotation, TestParse_FunExprEffectAnnotation pass)
- [x] `go test ./...` (no failures)