### PR TITLE
mep-0015: stage 3a widen T044 to name effect labels

### DIFF
--- a/tests/types/errors/impure_in_where_rejected.err
+++ b/tests/types/errors/impure_in_where_rejected.err
@@ -1,8 +1,8 @@
-1. error[T044]: impure call to `print` is not allowed in `where` predicate
+1. error[T044]: call to `print` produces effect(s) io, not allowed in `where` predicate
   --> tests/types/errors/impure_in_where_rejected.mochi:2:33
 
   2 | let result = from x in xs where print(x) == print(x) select x
     |                                 ^
 
 help:
-  Only pure functions may be called inside `where` and `having` predicates.
+  Only pure functions may be called inside `where` and `having` predicates. Refactor the predicate to read pre-computed values, or move the effectful call outside the query.

--- a/types/check_expr.go
+++ b/types/check_expr.go
@@ -1557,8 +1557,8 @@ func checkQueryExpr(q *parser.QueryExpr, env *Env, expected Type) (Type, error) 
 		if _, ok := wt.(AnyType); !ok && !unify(wt, BoolType{}, nil) {
 			return nil, errWhereBoolean(q.Where.Pos)
 		}
-		if name, pos, ok := firstImpureCall(q.Where, child); ok {
-			return nil, errImpurePredicate(pos, name, "where")
+		if name, pos, effects, ok := firstImpureCall(q.Where, child); ok {
+			return nil, errImpurePredicate(pos, name, "where", effects)
 		}
 	}
 
@@ -1626,8 +1626,8 @@ func checkQueryExpr(q *parser.QueryExpr, env *Env, expected Type) (Type, error) 
 			if _, ok := ht.(AnyType); !ok && !unify(ht, BoolType{}, nil) {
 				return nil, errHavingBoolean(q.Group.Having.Pos)
 			}
-			if name, pos, ok := firstImpureCall(q.Group.Having, armEnv); ok {
-				return nil, errImpurePredicate(pos, name, "having")
+			if name, pos, effects, ok := firstImpureCall(q.Group.Having, armEnv); ok {
+				return nil, errImpurePredicate(pos, name, "having", effects)
 			}
 		}
 	}

--- a/types/errors.go
+++ b/types/errors.go
@@ -62,7 +62,7 @@ var Errors = map[string]diagnostic.Template{
 	"T042": {Code: "T042", Message: "`having` condition must be boolean", Help: "Ensure the condition evaluates to true or false."},
 	"T039": {Code: "T039", Message: "function %s expects %d arguments, got %d", Help: "Pass exactly %d arguments to `%s`."},
 	"T040": {Code: "T040", Message: "`if` condition must be boolean", Help: "Ensure the condition evaluates to true or false."},
-	"T044": {Code: "T044", Message: "impure call to `%s` is not allowed in `%s` predicate", Help: "Only pure functions may be called inside `where` and `having` predicates."},
+	"T044": {Code: "T044", Message: "call to `%s` produces effect(s) %s, not allowed in `%s` predicate", Help: "Only pure functions may be called inside `where` and `having` predicates. Refactor the predicate to read pre-computed values, or move the effectful call outside the query."},
 	"T045": {Code: "T045", Message: "`%s` outside of loop", Help: "Move `%s` inside a `for` or `while` loop body."},
 	"T046": {Code: "T046", Message: "invalid cast: `%s` as `%s` is not allowed", Help: "Only numeric-tower, union-to-variant, map-to-struct, and any-related casts are allowed. Use a parsing function (e.g. `parseIntStr`) for string conversions."},
 	"T050": {Code: "T050", Message: "non-exhaustive match on union `%s`: missing variant(s) %s", Help: "Add an arm for each missing variant or use a wildcard `_` arm to cover the remainder."},
@@ -295,8 +295,8 @@ func errHavingBoolean(pos lexer.Position) error {
 	return Errors["T042"].New(pos)
 }
 
-func errImpurePredicate(pos lexer.Position, name, predicate string) error {
-	return Errors["T044"].New(pos, name, predicate)
+func errImpurePredicate(pos lexer.Position, name, predicate string, effects EffectSet) error {
+	return Errors["T044"].New(pos, name, effects.String(), predicate)
 }
 
 func errUnknownEffectLabel(pos lexer.Position, label string) error {

--- a/types/pure.go
+++ b/types/pure.go
@@ -156,26 +156,26 @@ func isPureFunction(fn *parser.FunStmt, env *Env) bool {
 	return true
 }
 
-// firstImpureCall walks e and returns the name and position of the first
-// call to a function whose Pure flag is false. Returns found=false if all
-// calls in the expression are to pure functions.
-func firstImpureCall(e *parser.Expr, env *Env) (name string, pos lexer.Position, found bool) {
+// firstImpureCall walks e and returns the name, position, and effect
+// set of the first call whose callee carries a non-empty effect set.
+// Returns found=false if every reachable call is pure.
+func firstImpureCall(e *parser.Expr, env *Env) (name string, pos lexer.Position, effects EffectSet, found bool) {
 	if e == nil {
 		return
 	}
 	return firstImpureUnary(e.Binary.Left, env)
 }
 
-func firstImpureUnary(u *parser.Unary, env *Env) (string, lexer.Position, bool) {
-	if n, p, ok := firstImpurePostfix(u.Value, env); ok {
-		return n, p, true
+func firstImpureUnary(u *parser.Unary, env *Env) (string, lexer.Position, EffectSet, bool) {
+	if n, p, eff, ok := firstImpurePostfix(u.Value, env); ok {
+		return n, p, eff, true
 	}
-	return "", lexer.Position{}, false
+	return "", lexer.Position{}, EmptyEffects, false
 }
 
-func firstImpurePostfix(p *parser.PostfixExpr, env *Env) (string, lexer.Position, bool) {
-	if n, pos, ok := firstImpurePrimary(p.Target, env); ok {
-		return n, pos, true
+func firstImpurePostfix(p *parser.PostfixExpr, env *Env) (string, lexer.Position, EffectSet, bool) {
+	if n, pos, eff, ok := firstImpurePrimary(p.Target, env); ok {
+		return n, pos, eff, true
 	}
 	for _, op := range p.Ops {
 		if op.Call != nil {
@@ -184,33 +184,33 @@ func firstImpurePostfix(p *parser.PostfixExpr, env *Env) (string, lexer.Position
 				t, err := env.GetVar(name)
 				if err == nil {
 					if ft, ok := t.(FuncType); ok && !ft.Pure() {
-						return name, p.Target.Pos, true
+						return name, p.Target.Pos, ft.Effects, true
 					}
 				}
 			}
 		}
 	}
-	return "", lexer.Position{}, false
+	return "", lexer.Position{}, EmptyEffects, false
 }
 
-func firstImpurePrimary(p *parser.Primary, env *Env) (string, lexer.Position, bool) {
+func firstImpurePrimary(p *parser.Primary, env *Env) (string, lexer.Position, EffectSet, bool) {
 	if p.Call != nil {
 		t, err := env.GetVar(p.Call.Func)
 		if err == nil {
 			if ft, ok := t.(FuncType); ok && !ft.Pure() {
-				return p.Call.Func, p.Pos, true
+				return p.Call.Func, p.Pos, ft.Effects, true
 			}
 		}
 		for _, arg := range p.Call.Args {
-			if n, pos, ok := firstImpureCall(arg, env); ok {
-				return n, pos, true
+			if n, pos, eff, ok := firstImpureCall(arg, env); ok {
+				return n, pos, eff, true
 			}
 		}
 	}
 	if p.Group != nil {
 		return firstImpureCall(p.Group, env)
 	}
-	return "", lexer.Position{}, false
+	return "", lexer.Position{}, EmptyEffects, false
 }
 
 // statementHasImpureCall reports whether s contains any call to a
@@ -271,6 +271,6 @@ func exprHasImpureCall(e *parser.Expr, env *Env) bool {
 	if e == nil {
 		return false
 	}
-	_, _, ok := firstImpureCall(e, env)
+	_, _, _, ok := firstImpureCall(e, env)
 	return ok
 }


### PR DESCRIPTION
Tracks #21448.

## Summary

- Widen `T044` so it names the offending effect labels: `call to \`print\` produces effect(s) io, not allowed in \`where\` predicate`
- Help text now suggests pre-computing or hoisting the effectful call outside the query
- `firstImpureCall` and helpers return the callee's `EffectSet` along with name + position

## Test plan

- [x] `go test ./types/` (including `TestTypeChecker_Errors/impure_in_where_rejected`)
- [x] `go build ./...`