### PR TITLE
mep-0015: stage 3b FunExpr annotation diagnostics

### DIFF
--- a/types/check_expr.go
+++ b/types/check_expr.go
@@ -1102,7 +1102,22 @@ func checkFunExpr(f *parser.FunExpr, env *Env, expected Type, pos lexer.Position
 		}
 	}
 
-	return FuncType{Params: paramTypes, Return: declaredRet}, nil
+	// MEP-15 Stage 3b: validate the optional `! eff, ...` annotation on
+	// the closure. T064 fires for unknown labels; T065 fires when the
+	// inferred body effects escape the declared upper bound.
+	effects := inferFunExprEffects(f, child)
+	if len(f.Effects) > 0 {
+		declaredEff, labelErrs := parseFunExprEffects(f)
+		for _, le := range labelErrs {
+			env.RecordDiagnostic(le)
+		}
+		if !effects.IsSubset(declaredEff) {
+			env.RecordDiagnostic(errEffectsExceedDeclared(pos, "<fun>", declaredEff, effects))
+		}
+		effects = declaredEff
+	}
+
+	return FuncType{Params: paramTypes, Return: declaredRet, Effects: effects}, nil
 }
 
 // bareIdentName returns the source identifier if e is a single

--- a/types/effects_infer.go
+++ b/types/effects_infer.go
@@ -1,18 +1,32 @@
 package types
 
-import "mochi/parser"
+import (
+	"mochi/parser"
+
+	"github.com/alecthomas/participle/v2/lexer"
+)
 
 // parseDeclaredEffects converts the raw label list on FunStmt.Effects
 // into a typed EffectSet. Each unknown label produces a T064
 // diagnostic but the parse keeps going so the caller sees every bad
 // label in one pass.
 func parseDeclaredEffects(fn *parser.FunStmt) (EffectSet, []error) {
+	return parseEffectLabels(fn.Pos, fn.Effects)
+}
+
+// parseFunExprEffects mirrors parseDeclaredEffects for anonymous
+// function expressions. MEP-15 Stage 3b extends T064 to FunExpr.
+func parseFunExprEffects(f *parser.FunExpr) (EffectSet, []error) {
+	return parseEffectLabels(f.Pos, f.Effects)
+}
+
+func parseEffectLabels(pos lexer.Position, labels []string) (EffectSet, []error) {
 	var set EffectSet
 	var errs []error
-	for _, name := range fn.Effects {
+	for _, name := range labels {
 		label, ok := ParseEffectLabel(name)
 		if !ok {
-			errs = append(errs, errUnknownEffectLabel(fn.Pos, name))
+			errs = append(errs, errUnknownEffectLabel(pos, name))
 			continue
 		}
 		set = set.Add(label)
@@ -34,19 +48,43 @@ func inferFunctionEffects(fn *parser.FunStmt, env *Env) EffectSet {
 	if fn == nil {
 		return EmptyEffects
 	}
+	child := funBodyEnv(env, fn.Params)
+	var effs EffectSet
+	for _, stmt := range fn.Body {
+		effs = effs.Union(stmtEffects(stmt, child))
+	}
+	return effs
+}
+
+// inferFunExprEffects walks the body of an anonymous function and
+// returns the union of effect labels reachable from it. ExprBody and
+// BlockBody are handled symmetrically so `fun(x) => print(x)` and the
+// equivalent block produce the same set.
+func inferFunExprEffects(f *parser.FunExpr, env *Env) EffectSet {
+	if f == nil {
+		return EmptyEffects
+	}
+	child := funBodyEnv(env, f.Params)
+	var effs EffectSet
+	if f.ExprBody != nil {
+		effs = effs.Union(exprEffects(f.ExprBody, child))
+	}
+	for _, stmt := range f.BlockBody {
+		effs = effs.Union(stmtEffects(stmt, child))
+	}
+	return effs
+}
+
+func funBodyEnv(env *Env, params []*parser.Param) *Env {
 	child := NewEnv(env)
-	for _, p := range fn.Params {
+	for _, p := range params {
 		if p.Type != nil {
 			child.SetVar(p.Name, resolveTypeRef(p.Type, env), false)
 		} else {
 			child.SetVar(p.Name, AnyType{}, false)
 		}
 	}
-	var effs EffectSet
-	for _, stmt := range fn.Body {
-		effs = effs.Union(stmtEffects(stmt, child))
-	}
-	return effs
+	return child
 }
 
 // stmtEffects returns the effects produced by evaluating s in env. The

--- a/types/effects_test.go
+++ b/types/effects_test.go
@@ -144,6 +144,86 @@ func TestDeclaredEffects_UnknownLabel(t *testing.T) {
 	}
 }
 
+// TestFunExpr_DeclaredEffects exercises MEP-15 Stage 3b: a closure
+// (anonymous function expression) accepts the same `! eff, ...`
+// annotation as a top-level FunStmt, and the declared set propagates
+// to the FuncType produced by the let binding.
+func TestFunExpr_DeclaredEffects(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want types.EffectSet
+	}{
+		{"block body io", "let f = fun(name: string) ! io { print(name) }", types.NewEffectSet(types.EffectIO)},
+		{"expr body time", "let stamp = fun(): int64 ! time => now()", types.NewEffectSet(types.EffectTime)},
+		{"declared wider than body", "let noop = fun(name: string) ! io, fs { print(name) }", types.NewEffectSet(types.EffectIO, types.EffectFS)},
+		{"no annotation infers pure", "let id = fun(x: int): int => x", types.EmptyEffects},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prog, err := parser.ParseString(tc.src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("Check: %v", errs)
+			}
+			target := tc.src[4:]
+			target = target[:indexOf(target, " ")]
+			ty, err := env.GetVar(target)
+			if err != nil {
+				t.Fatalf("GetVar(%q): %v", target, err)
+			}
+			ft, ok := ty.(types.FuncType)
+			if !ok {
+				t.Fatalf("expected FuncType, got %T", ty)
+			}
+			if ft.Effects != tc.want {
+				t.Fatalf("Effects=%s want %s", ft.Effects.String(), tc.want.String())
+			}
+		})
+	}
+}
+
+// TestFunExpr_UnknownEffectLabel exercises T064 on FunExpr: an unknown
+// label in the `!` annotation of an anonymous function must surface a
+// diagnostic.
+func TestFunExpr_UnknownEffectLabel(t *testing.T) {
+	src := "let f = fun(x: int): int ! quantum => x"
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	env := types.NewEnv(nil)
+	errs := types.Check(prog, env)
+	for _, e := range errs {
+		if contains(e.Error(), "T064") {
+			return
+		}
+	}
+	t.Fatalf("expected T064 in %v", errs)
+}
+
+// TestFunExpr_EffectsExceedDeclared exercises T065 on FunExpr: when
+// the inferred body effects escape the declared upper bound, type
+// check must reject the closure.
+func TestFunExpr_EffectsExceedDeclared(t *testing.T) {
+	src := "let stamp = fun(): int64 ! io => now()"
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	env := types.NewEnv(nil)
+	errs := types.Check(prog, env)
+	for _, e := range errs {
+		if contains(e.Error(), "T065") {
+			return
+		}
+	}
+	t.Fatalf("expected T065 in %v", errs)
+}
+
 func contains(s, sub string) bool {
 	return len(s) >= len(sub) && indexOf(s, sub) >= 0
 }

--- a/website/docs/mep/mep-0015.md
+++ b/website/docs/mep/mep-0015.md
@@ -33,7 +33,7 @@ Mochi adopts a small labeled effect system. Each function value carries a finite
 
 The system is intentionally not a row-typed effect calculus. There is no `<e>` row variable in surface syntax, no algebraic effects, and no handlers. Higher-order functions like `map` and `fold` propagate their callback's effect set to the call site through a hidden row variable that the elaborator threads but the printed type never shows. This matches Swift's `rethrows` discipline and Unison's "abilities" surface, and avoids the row-variable-everywhere noise that Koka users live with.
 
-The binary `Pure bool` field on `FuncType` is replaced by an `Effects EffectSet`. Every call site that reads `ft.Pure` continues to work through a thin compatibility method (`ft.Pure() = ft.Effects.IsEmpty()`). The change is mechanical at stage 1 and the existing T044 fires unchanged. Stage 2 adds the surface annotation. Stage 3 (deferred) reconsiders user-defined effects and handlers if and when async or exceptions land.
+The binary `Pure bool` field on `FuncType` is replaced by an `Effects EffectSet`. Every call site that reads `ft.Pure` continues to work through a thin compatibility method (`ft.Pure() = ft.Effects.IsEmpty()`). The change is mechanical at stage 1 and the existing T044 fires unchanged. Stage 2 adds the surface annotation. Stage 3 widens predicate diagnostics to name the offending effect labels and extends T064 / T065 to anonymous functions. Stage 4 (deferred) reconsiders user-defined effects and handlers if and when async or exceptions land.
 
 ## Motivation
 
@@ -276,7 +276,7 @@ A closure's effect set is observed at its call site. A closure that captures an 
 
 MEP-16 N5 currently drops narrowing for `var` bindings after any call to a non-pure function. Under the labeled scheme, the same rule applies with the new gate: a call with a non-empty effect set drops `var` narrowing. The conservative semantics are unchanged.
 
-Stage 3 (or later) may refine N5 to drop only when the callee carries a hypothetical `state` label, but that requires the `state` label to exist first. Until then the wider drop is the safe default.
+Stage 4 (or later) may refine N5 to drop only when the callee carries a hypothetical `state` label, but that requires the `state` label to exist first. Until then the wider drop is the safe default.
 
 ### Backwards compatibility
 
@@ -312,7 +312,7 @@ The single-bit flag works for `where`/`having` and for the MEP-16 N5 narrowing d
 
 Mochi has no algebraic effect handlers. Without handlers, the runtime has nothing to do with effects: there is no `try`, no `with`, no `resume`. Effects are pure metadata. Erasing them is the simplest model and the one every effect system that lacks handlers (Swift, Unison-abilities-without-handlers, mtl-without-`Eff`) uses.
 
-When handlers land (stage 3+, deferred), the runtime gets a `perform` and `handle` primitive. The label set acquires user-defined entries. The erasure rule changes for those specific labels and stays the same for the closed builtin set. That is a future MEP's problem.
+When handlers land (stage 4+, deferred), the runtime gets a `perform` and `handle` primitive. The label set acquires user-defined entries. The erasure rule changes for those specific labels and stays the same for the closed builtin set. That is a future MEP's problem.
 
 ### Why label `time` and `meta` separately from `io`
 
@@ -322,7 +322,7 @@ The five labels are chosen so that no single label subsumes another except in tr
 
 ## Alternatives considered
 
-**Algebraic effects with handlers** ([Eff], [Koka], [OCaml 5]). Powerful: user-defined effects, multi-shot continuations, structured concurrency. The cost is a runtime that supports delimited continuations (one-shot or multi-shot) plus a typed surface that mainstream users find foreign. OCaml 5 shipped the runtime without the types and the community treats it as a library substrate, not a user-facing facility. Sivaramakrishnan et al., *Retrofitting Effect Handlers onto OCaml* (PLDI '21), explicitly defers typing. Mochi would inherit the same dilemma. Defer to stage 3 or beyond.
+**Algebraic effects with handlers** ([Eff], [Koka], [OCaml 5]). Powerful: user-defined effects, multi-shot continuations, structured concurrency. The cost is a runtime that supports delimited continuations (one-shot or multi-shot) plus a typed surface that mainstream users find foreign. OCaml 5 shipped the runtime without the types and the community treats it as a library substrate, not a user-facing facility. Sivaramakrishnan et al., *Retrofitting Effect Handlers onto OCaml* (PLDI '21), explicitly defers typing. Mochi would inherit the same dilemma. Defer to stage 4 or beyond.
 
 **Effect rows in every signature** ([Koka]). Daan Leijen, *Koka: Programming with Row-Polymorphic Effect Types* (MSR-TR-2014-23) and *Type Directed Compilation of Row-Typed Algebraic Effects* (POPL '17). Most expressive design. The cost is row variables everywhere in user-visible types and error messages that mention rows the user never wrote. Mochi targets mainstream readability; the surface tax is too high.
 
@@ -346,9 +346,13 @@ The work lands in three stages, each a separate PR with fixture pinning:
 
 3. **Stage 2b (shipped): surface annotation.** Add the `!` syntax to `FunStmt` and `FunExpr` in the parser. The annotation is parsed as a list of label idents, then converted to an `EffectSet` in `types/check.go`. The declared set is treated as the published upper bound: callers see the declared value on `FuncType.Effects`, and the body walker's inferred set must be a subset (else T065). Unknown labels surface T064. Fixtures: `tests/types/valid/effects_annotation_accepted.mochi`, `tests/types/errors/effects_declared_exceeds_inferred.mochi`, `tests/types/errors/effects_unknown_label.mochi`.
 
-4. **Stage 3 (deferred):** decide on user-defined effects and handlers. Likely paired with the exception MEP or the async MEP. Out of scope here; the design is intentionally extensible.
+4. **Stage 3a (shipped, PR #21449): T044 names the effect labels.** The predicate diagnostic now reads `call to \`print\` produces effect(s) io, not allowed in \`where\` predicate` instead of the binary `impure call`. Help text suggests pre-computing the value or hoisting the call outside the query. `firstImpureCall` and helpers thread the callee's `EffectSet` through to `errImpurePredicate`.
 
-The three stages can ship months apart. Stage 1 is the only one that touches the type checker. Stage 2 is parser + a single subset check. Stage 3 is a separate MEP.
+5. **Stage 3b (shipped): FunExpr annotation diagnostics.** Anonymous function expressions (`fun(x) ! io => print(x)`) now run the same T064 / T065 validation as named functions. `parseDeclaredEffects` is split so both `FunStmt` and `FunExpr` share the label parser. A new `inferFunExprEffects` walks both `BlockBody` and `ExprBody` symmetrically. The closure's `FuncType.Effects` is stamped with the declared set when present, or with the inferred set when omitted, so callers see the same upper-bound contract regardless of whether the function is named or anonymous.
+
+6. **Stage 4 (deferred):** decide on user-defined effects and handlers. Likely paired with the exception MEP or the async MEP. Out of scope here; the design is intentionally extensible.
+
+The stages can ship months apart. Stage 1 is the only one that touches the type checker. Stage 2 is parser + a single subset check. Stage 3 is diagnostic polish. Stage 4 is a separate MEP.
 
 ## Reference implementation
 


### PR DESCRIPTION
Tracks #21450.

## Summary

- Anonymous function expressions now accept `! eff, ...` and surface T064 / T065 the same way named functions do
- `parseDeclaredEffects` split into a shared label parser used by FunStmt and FunExpr
- New `inferFunExprEffects` walks `BlockBody` and `ExprBody` symmetrically
- MEP-15 doc renumbers the deferred user-handlers piece to Stage 4 so active diagnostic polish fits under Stage 3

## Test plan

- [x] `go test ./types/` (new `TestFunExpr_DeclaredEffects`, `TestFunExpr_UnknownEffectLabel`, `TestFunExpr_EffectsExceedDeclared`)
- [x] `go build ./...`