### PR TITLE
website: auto-generated MEP index page

### DIFF
--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -38,7 +38,7 @@ The [Mochi Manual](/docs/manual/) documents the language in depth.
 
 ## Design proposals
 
-- [Mochi Enhancement Proposals (MEPs)](/docs/mep/mep-0000). Design documents for the language, the type system, and the toolchain.
+- [Mochi Enhancement Proposals (MEPs)](/docs/mep). Auto-generated catalogue of every design document for the language, the type system, and the toolchain.
 
 ## More
 

--- a/website/docs/mep/index.mdx
+++ b/website/docs/mep/index.mdx
@@ -1,0 +1,92 @@
+---
+title: Mochi Enhancement Proposals
+slug: /mep
+sidebar_position: 0
+sidebar_label: Index
+description: Auto-generated list of every Mochi Enhancement Proposal (MEP), grouped by type and sorted by number.
+---
+
+import meps from '@site/src/data/meps.json';
+
+# Mochi Enhancement Proposals
+
+A MEP is a design document for the Mochi language, type system, and toolchain. The full process is described in [MEP 0](/docs/mep/mep-0000). The list below is generated from the frontmatter of every `mep-NNNN.md` file in the docs tree, so new proposals appear here automatically once `npm run gen:meps` (or any `npm start` / `npm run build`) regenerates the manifest.
+
+export const statusColor = (s) => {
+  const v = (s || '').toLowerCase();
+  if (v === 'final' || v === 'accepted') return '#1f883d';
+  if (v === 'active') return '#0969da';
+  if (v === 'draft') return '#9a6700';
+  if (v === 'rejected' || v === 'withdrawn') return '#cf222e';
+  return '#6e7781';
+};
+
+export const StatusPill = ({ children }) => (
+  <span
+    style={{
+      display: 'inline-block',
+      padding: '0.1rem 0.5rem',
+      borderRadius: '999px',
+      fontSize: '0.75rem',
+      fontWeight: 600,
+      color: '#fff',
+      background: statusColor(children),
+      verticalAlign: 'middle',
+    }}
+  >
+    {children}
+  </span>
+);
+
+export const MEPGroup = ({ heading, entries }) => (
+  <>
+    <h2>{heading}</h2>
+    <table>
+      <thead>
+        <tr>
+          <th style={{ width: '4rem' }}>MEP</th>
+          <th>Title</th>
+          <th style={{ width: '6rem' }}>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {entries.map((e) => (
+          <tr key={e.number}>
+            <td><code>{String(e.number).padStart(4, '0')}</code></td>
+            <td>
+              <a href={e.slug}><strong>{e.title}</strong></a>
+              {e.description ? <div style={{ fontSize: '0.85rem', opacity: 0.75 }}>{e.description}</div> : null}
+            </td>
+            <td><StatusPill>{e.status || 'Unknown'}</StatusPill></td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </>
+);
+
+export const groupOrder = ['Process', 'Informational', 'Standards Track'];
+
+export const grouped = (() => {
+  const byType = new Map();
+  for (const e of meps) {
+    const key = e.type || 'Other';
+    if (!byType.has(key)) byType.set(key, []);
+    byType.get(key).push(e);
+  }
+  const ordered = [];
+  for (const k of groupOrder) {
+    if (byType.has(k)) {
+      ordered.push([k, byType.get(k)]);
+      byType.delete(k);
+    }
+  }
+  for (const [k, v] of byType) ordered.push([k, v]);
+  return ordered;
+})();
+
+<MEPGroup heading="All MEPs" entries={meps} />
+
+{grouped.map(([type, entries]) => (
+  <MEPGroup key={type} heading={type} entries={entries} />
+))}

--- a/website/package.json
+++ b/website/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
+    "gen:meps": "node scripts/gen-meps.js",
+    "prestart": "node scripts/gen-meps.js",
+    "prebuild": "node scripts/gen-meps.js",
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",

--- a/website/scripts/gen-meps.js
+++ b/website/scripts/gen-meps.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// Reads every website/docs/mep/mep-NNNN.md, extracts the YAML
+// frontmatter, and writes website/src/data/meps.json. The MEP index
+// page imports the JSON so any new MEP-NNNN.md file appears in the
+// listing the next time `npm run gen:meps` (or `prebuild` / `prestart`)
+// runs.
+
+const fs = require('fs');
+const path = require('path');
+const matter = require('gray-matter');
+
+const root = path.resolve(__dirname, '..');
+const mepDir = path.join(root, 'docs', 'mep');
+const outFile = path.join(root, 'src', 'data', 'meps.json');
+
+const entries = [];
+for (const name of fs.readdirSync(mepDir)) {
+  const m = name.match(/^mep-(\d{4})\.md$/);
+  if (!m) continue;
+  const src = fs.readFileSync(path.join(mepDir, name), 'utf8');
+  const fm = matter(src).data;
+  if (typeof fm.mep !== 'number') {
+    throw new Error(`${name}: missing numeric \`mep\` frontmatter field`);
+  }
+  entries.push({
+    number: fm.mep,
+    title: String(fm.title || ''),
+    status: String(fm.status || ''),
+    type: String(fm.type || ''),
+    description: String(fm.description || ''),
+    slug: `/docs/mep/mep-${m[1]}`,
+  });
+}
+
+entries.sort((a, b) => a.number - b.number);
+
+fs.mkdirSync(path.dirname(outFile), { recursive: true });
+fs.writeFileSync(outFile, JSON.stringify(entries, null, 2) + '\n');
+
+console.log(`wrote ${entries.length} MEP entries to ${path.relative(root, outFile)}`);

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -59,6 +59,7 @@ const sidebars = {
   ],
 
   mepSidebar: [
+    'mep/index',
     'mep/mep-0000',
     {
       label: 'Foundations',
@@ -97,6 +98,7 @@ const sidebars = {
         'mep/mep-0013',
         'mep/mep-0014',
         'mep/mep-0015',
+        'mep/mep-0016',
       ],
     },
   ],

--- a/website/src/data/meps.json
+++ b/website/src/data/meps.json
@@ -1,0 +1,138 @@
+[
+  {
+    "number": 0,
+    "title": "Index of Mochi Enhancement Proposals",
+    "status": "Active",
+    "type": "Process",
+    "description": "Index of Mochi Enhancement Proposals.",
+    "slug": "/docs/mep/mep-0000"
+  },
+  {
+    "number": 1,
+    "title": "Lexer",
+    "status": "Informational",
+    "type": "Informational",
+    "description": "Mochi's token classes, reserved words, lexical errors, and conformance corpus, specified end-to-end with no corner cases.",
+    "slug": "/docs/mep/mep-0001"
+  },
+  {
+    "number": 2,
+    "title": "Grammar",
+    "status": "Informational",
+    "type": "Informational",
+    "description": "Mochi's PEG grammar in full, with the design principles and conformance obligations that fix the language.",
+    "slug": "/docs/mep/mep-0002"
+  },
+  {
+    "number": 3,
+    "title": "Abstract Syntax Tree",
+    "status": "Informational",
+    "type": "Informational",
+    "description": "Mochi's AST as a closed family of tagged unions, the encoding that makes parse output unambiguous, and the soundness invariants every consumer can rely on.",
+    "slug": "/docs/mep/mep-0003"
+  },
+  {
+    "number": 4,
+    "title": "Type System",
+    "status": "Informational",
+    "type": "Informational",
+    "description": "The kinds, the comparisons, the numeric tower, and the places where Mochi's type system does not yet do what it claims.",
+    "slug": "/docs/mep/mep-0004"
+  },
+  {
+    "number": 5,
+    "title": "Type Inference",
+    "status": "Standards Track",
+    "type": "Standards Track",
+    "description": "Strict static algebraic type inference. Principal types, no implicit any, no null.",
+    "slug": "/docs/mep/mep-0005"
+  },
+  {
+    "number": 6,
+    "title": "Type Checker",
+    "status": "Informational",
+    "type": "Informational",
+    "description": "Entry point, builtin environment, statement walk, and the diagnostic catalogue.",
+    "slug": "/docs/mep/mep-0006"
+  },
+  {
+    "number": 7,
+    "title": "Soundness",
+    "status": "Active",
+    "type": "Process",
+    "description": "Progress, preservation, and the test obligations that prove them.",
+    "slug": "/docs/mep/mep-0007"
+  },
+  {
+    "number": 8,
+    "title": "Test Strategy",
+    "status": "Active",
+    "type": "Process",
+    "description": "The five test layers, the golden harness, and the TAPL chapter mapping.",
+    "slug": "/docs/mep/mep-0008"
+  },
+  {
+    "number": 9,
+    "title": "Fixture Catalogue",
+    "status": "Informational",
+    "type": "Informational",
+    "description": "Inventory of parser and type fixtures with a property coverage matrix.",
+    "slug": "/docs/mep/mep-0009"
+  },
+  {
+    "number": 10,
+    "title": "Known Gaps and Weakness Review",
+    "status": "Informational",
+    "type": "Informational",
+    "description": "Catalogue of soundness gaps, surprising behavior, and tracked follow-ups.",
+    "slug": "/docs/mep/mep-0010"
+  },
+  {
+    "number": 11,
+    "title": "Subtyping and Variance",
+    "status": "Active",
+    "type": "Standards Track",
+    "description": "A separate subtype predicate, the variance lattice, and the closure of any.",
+    "slug": "/docs/mep/mep-0011"
+  },
+  {
+    "number": 12,
+    "title": "Parametric Polymorphism",
+    "status": "Active",
+    "type": "Standards Track",
+    "description": "System-F-lite call-site inference, fresh type variables, and the end of any-builtins.",
+    "slug": "/docs/mep/mep-0012"
+  },
+  {
+    "number": 13,
+    "title": "Algebraic Data Types and Match",
+    "status": "Draft",
+    "type": "Standards Track",
+    "description": "Struct and union typing rules, match exhaustiveness, irredundancy, and recursive types.",
+    "slug": "/docs/mep/mep-0013"
+  },
+  {
+    "number": 14,
+    "title": "Query Algebra",
+    "status": "Informational",
+    "type": "Informational",
+    "description": "LINQ-shaped query expressions, clause-by-clause type rules, and aggregate semantics.",
+    "slug": "/docs/mep/mep-0014"
+  },
+  {
+    "number": 15,
+    "title": "Effects",
+    "status": "Draft",
+    "type": "Standards Track",
+    "description": "A labeled effect system over function types. Pure by default, inferred from the body, annotatable at module boundaries, enforced where purity matters.",
+    "slug": "/docs/mep/mep-0015"
+  },
+  {
+    "number": 16,
+    "title": "Null Safety",
+    "status": "Draft",
+    "type": "Standards Track",
+    "description": "Total option discipline with no force unwrap, flow narrowing, safe-call and coalesce operators, and a no-panic guarantee.",
+    "slug": "/docs/mep/mep-0016"
+  }
+]


### PR DESCRIPTION
Tracks #21452.

## Summary

- New `/docs/mep` index auto-generated from every `mep-NNNN.md` frontmatter
- `prestart` / `prebuild` hooks regenerate `src/data/meps.json` so the catalogue cannot drift
- Sidebar gains the previously missing `mep-0016` and pins the new index page at the top

## Test plan

- [x] `npm run build` (prebuild script writes 17 MEP entries, build succeeds)
- [x] `build/docs/mep.html` exists (previously 404) and references all 17 MEPs