### PR TITLE
mep-0015: stage 3c reserve T066 for pure positions

### DIFF
--- a/types/effects_test.go
+++ b/types/effects_test.go
@@ -4,6 +4,8 @@ import (
 	"mochi/parser"
 	"mochi/types"
 	"testing"
+
+	"github.com/alecthomas/participle/v2/lexer"
 )
 
 func TestEffectSet_Basics(t *testing.T) {
@@ -222,6 +224,28 @@ func TestFunExpr_EffectsExceedDeclared(t *testing.T) {
 		}
 	}
 	t.Fatalf("expected T065 in %v", errs)
+}
+
+// TestT066_ReservedForPurePositions pins the message contract for the
+// diagnostic MEP-15 reserves for `const` declarations and struct field
+// defaults. No surface emits T066 today, so the test renders the
+// template directly to lock in code, message, and help text.
+func TestT066_ReservedForPurePositions(t *testing.T) {
+	tpl, ok := types.Errors["T066"]
+	if !ok {
+		t.Fatalf("T066 missing from Errors map")
+	}
+	if tpl.Code != "T066" {
+		t.Fatalf("Code=%q want T066", tpl.Code)
+	}
+	d := tpl.New(lexer.Position{}, types.NewEffectSet(types.EffectIO).String(), "`const` initializer")
+	const wantMsg = "expression produces effect(s) io, not allowed in `const` initializer"
+	if d.Msg != wantMsg {
+		t.Fatalf("Msg=%q want %q", d.Msg, wantMsg)
+	}
+	if !contains(d.Help, "pure expression") {
+		t.Fatalf("Help missing `pure expression` hint: %q", d.Help)
+	}
 }
 
 func contains(s, sub string) bool {

--- a/types/errors.go
+++ b/types/errors.go
@@ -84,6 +84,7 @@ var Errors = map[string]diagnostic.Template{
 	"T063": {Code: "T063", Message: "safe-index `?[ ]` requires the wrapped type to be a list or map, got %s", Help: "Only `list<T>` and `map<K, V>` support indexed access after `?[`."},
 	"T064": {Code: "T064", Message: "unknown effect label `%s`", Help: "Effect annotations may only mention the closed label set: io, fs, net, time, meta."},
 	"T065": {Code: "T065", Message: "function `%s` declares effects %s but its body produces %s", Help: "Either add the missing label(s) to the `!` annotation, or remove the call that produces the extra effect."},
+	"T066": {Code: "T066", Message: "expression produces effect(s) %s, not allowed in %s", Help: "This position requires a pure expression. Replace the effectful call with a pre-computed value, or hoist the call out so only its result reaches this position."},
 }
 
 // --- Wrapper Functions ---
@@ -305,6 +306,14 @@ func errUnknownEffectLabel(pos lexer.Position, label string) error {
 
 func errEffectsExceedDeclared(pos lexer.Position, name string, declared, inferred EffectSet) error {
 	return Errors["T065"].New(pos, name, declared.String(), inferred.String())
+}
+
+// errEffectInPurePosition is reserved for the pure positions MEP-15
+// promises will gain a gate once `const` declarations and struct field
+// defaults land. No call site emits it today; the constructor exists so
+// the diagnostic message contract is pinned by tests.
+func errEffectInPurePosition(pos lexer.Position, context string, effects EffectSet) error {
+	return Errors["T066"].New(pos, effects.String(), context)
 }
 
 func errLenOperand(pos lexer.Position, typ Type) error {

--- a/website/docs/mep/mep-0015.md
+++ b/website/docs/mep/mep-0015.md
@@ -66,7 +66,7 @@ The upside is that every future enforcement point gets to ask the question it ac
 | Effect propagation through higher-order generics                  | **open** |
 | Surface annotation `fun foo(): T ! io, fs { ... }`                | **open** |
 | Diagnostic T065 (declared effect exceeded)                        | **open** |
-| Diagnostic T066 (effect not allowed in context)                   | **open** |
+| Diagnostic T066 (effect not allowed in context)                   | closed (reserved, no firing site until `const` lands) |
 | Effect inference for closures and intent methods                  | **open** |
 | User-defined effect labels                                        | by design (deferred) |
 | Algebraic effect handlers (`try` / `with` / `resume`)             | by design (deferred) |
@@ -258,7 +258,7 @@ Two new error codes plus a generalized one:
 
 - **T044** (existing): "impure call to `%s` is not allowed in `%s` predicate". Now reads the effect set instead of the binary flag; help text mentions which labels are present.
 - **T065** (new): "declared effect set `! %s` does not cover inferred effects `%s`". Fires when a function body uses an effect not listed in its `!` annotation. Help text names the missing label and the call site that contributed it.
-- **T066** (new): "effect %s is not allowed in this context". Fires in pure positions (compile-time eval, type-level args) once those land. Stage 1 does not raise T066; the code is reserved.
+- **T066** (new, reserved): "expression produces effect(s) %s, not allowed in %s". The diagnostic template, constructor (`errEffectInPurePosition`), and message contract are pinned by tests as of Stage 3c. No surface emits it yet; `const` declarations and struct field defaults will be the first call sites when they land.
 
 The error messages name labels with the same lowercase identifiers users wrote, never internal indices or codes.
 
@@ -350,7 +350,9 @@ The work lands in three stages, each a separate PR with fixture pinning:
 
 5. **Stage 3b (shipped): FunExpr annotation diagnostics.** Anonymous function expressions (`fun(x) ! io => print(x)`) now run the same T064 / T065 validation as named functions. `parseDeclaredEffects` is split so both `FunStmt` and `FunExpr` share the label parser. A new `inferFunExprEffects` walks both `BlockBody` and `ExprBody` symmetrically. The closure's `FuncType.Effects` is stamped with the declared set when present, or with the inferred set when omitted, so callers see the same upper-bound contract regardless of whether the function is named or anonymous.
 
-6. **Stage 4 (deferred):** decide on user-defined effects and handlers. Likely paired with the exception MEP or the async MEP. Out of scope here; the design is intentionally extensible.
+6. **Stage 3c (shipped): reserve T066.** The pure-position diagnostic template is registered in `types/errors.go`, the `errEffectInPurePosition(pos, context, effects)` helper is in place, and a unit test pins the rendered message and help text. No surface emits T066 yet; the helper will be wired up when `const` declarations and struct field defaults land. This stage exists so the diagnostic code, message wording, and constructor signature are settled before the consuming features go through review.
+
+7. **Stage 4 (deferred):** decide on user-defined effects and handlers. Likely paired with the exception MEP or the async MEP. Out of scope here; the design is intentionally extensible.
 
 The stages can ship months apart. Stage 1 is the only one that touches the type checker. Stage 2 is parser + a single subset check. Stage 3 is diagnostic polish. Stage 4 is a separate MEP.
 
@@ -366,7 +368,7 @@ Pointers to where each piece lives once the stages ship.
 - `types/check.go` if-statement narrowing loop (MEP-16 N5 hook): reads `Effects.IsEmpty()`.
 - `runtime/vm/vm.go` constant-folding gate: reads `Effects.IsEmpty()`.
 - `parser/ast.go` `FunStmt.Effects`: `[]string` populated by stage 2 parser. Empty at stage 1.
-- `types/errors.go`: T044 help text gains label list; T065 added.
+- `types/errors.go`: T044 help text gains label list; T065 added; T066 reserved with `errEffectInPurePosition` constructor.
 
 ## Open questions
 


### PR DESCRIPTION
Closes #21454.

Stage 3c of MEP-15. Registers diagnostic **T066** ("effect not allowed in this context") so the message contract is locked in before the consuming surfaces (`const` declarations, struct field defaults) land.

## What ships
- `types/errors.go`: `T066` template + `errEffectInPurePosition(pos, context, effects)` constructor.
- `types/effects_test.go`: `TestT066_ReservedForPurePositions` renders the template and asserts the message text, so wording is pinned even though no production code emits it yet.
- `website/docs/mep/mep-0015.md`: status table flips T066 from open to closed (reserved); migration staging gains Stage 3c entry; diagnostics section spells out the no-firing-site state.

## What does not ship
- No firing site. `const` and struct field defaults do not exist yet; T066 will be wired into them when those features land.
- No fixture, no parser change.

## Test plan
- [x] `go test ./types/ -run TestT066_ReservedForPurePositions` passes.
- [x] Full `go test ./types/` green.
- [x] `go vet ./types/` and `go build ./...` clean.