### PR TITLE
mep-0015: stage 3d HOF callback effect propagation

### DIFF
--- a/types/effects_infer.go
+++ b/types/effects_infer.go
@@ -182,7 +182,7 @@ func postfixEffects(p *parser.PostfixExpr, env *Env) EffectSet {
 	for _, op := range p.Ops {
 		if op.Call != nil {
 			for _, a := range op.Call.Args {
-				eff = eff.Union(exprEffects(a, env))
+				eff = eff.Union(exprEffects(a, env)).Union(callableEffects(a, env))
 			}
 			if p.Target != nil && p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 {
 				if t, err := env.GetVar(p.Target.Selector.Root); err == nil {
@@ -212,7 +212,7 @@ func primaryEffects(p *parser.Primary, env *Env) EffectSet {
 			}
 		}
 		for _, a := range p.Call.Args {
-			eff = eff.Union(exprEffects(a, env))
+			eff = eff.Union(exprEffects(a, env)).Union(callableEffects(a, env))
 		}
 		return eff
 	case p.Group != nil:
@@ -223,6 +223,49 @@ func primaryEffects(p *parser.Primary, env *Env) EffectSet {
 		return NewEffectSet(EffectFS)
 	case p.Save != nil:
 		return NewEffectSet(EffectFS)
+	}
+	return EmptyEffects
+}
+
+// callableEffects returns the effect set that would be incurred by
+// *calling* the value produced by e, as opposed to merely evaluating
+// it. Constructing a closure is pure; calling it may not be.
+//
+// The function recognises two "bare callable" forms:
+//   - a FunExpr literal with no surrounding operators → infer its body effects
+//   - a plain identifier (Selector with no field tail) of function type
+//     → return the FuncType.Effects already recorded in env
+//
+// Any other expression shape returns EmptyEffects. This is a deliberate
+// conservative choice: we only propagate effects we can see statically.
+// Indirect dispatch through complex expressions is left to the call site
+// that actually invokes the stored value.
+func callableEffects(e *parser.Expr, env *Env) EffectSet {
+	if e == nil || e.Binary == nil {
+		return EmptyEffects
+	}
+	// Only the "bare" case: no binary ops, no unary ops, no postfix ops.
+	b := e.Binary
+	if len(b.Right) > 0 {
+		return EmptyEffects
+	}
+	u := b.Left
+	if u == nil || len(u.Ops) > 0 || u.Value == nil || len(u.Value.Ops) > 0 {
+		return EmptyEffects
+	}
+	p := u.Value.Target
+	if p == nil {
+		return EmptyEffects
+	}
+	switch {
+	case p.FunExpr != nil:
+		return inferFunExprEffects(p.FunExpr, env)
+	case p.Selector != nil && len(p.Selector.Tail) == 0:
+		if t, err := env.GetVar(p.Selector.Root); err == nil {
+			if ft, ok := t.(FuncType); ok {
+				return ft.Effects
+			}
+		}
 	}
 	return EmptyEffects
 }

--- a/types/effects_test.go
+++ b/types/effects_test.go
@@ -248,6 +248,53 @@ func TestT066_ReservedForPurePositions(t *testing.T) {
 	}
 }
 
+// TestHOFCallbackEffects verifies MEP-15 E5: a call to a HOF that
+// receives a function-typed argument inherits the argument's effects at
+// the call site. Three scenarios:
+//   - literal FunExpr with !io body → call site inherits io
+//   - named function with !io effects → call site inherits io
+//   - literal FunExpr with pure body → call site stays pure
+func TestHOFCallbackEffects(t *testing.T) {
+	const src = `
+fun do_print(x: int): int { print(x); return x }
+fun apply(f: fun(int): int, x: int): int { return f(x) }
+fun hof_literal_io(): int   { return apply(fun(x: int): int { print(x); return x }, 5) }
+fun hof_named_io(): int     { return apply(do_print, 5) }
+fun hof_literal_pure(): int { return apply(fun(x: int): int { return x * 2 }, 5) }
+`
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("Check: %v", errs)
+	}
+	cases := []struct {
+		fn   string
+		want types.EffectSet
+	}{
+		{"hof_literal_io", types.NewEffectSet(types.EffectIO)},
+		{"hof_named_io", types.NewEffectSet(types.EffectIO)},
+		{"hof_literal_pure", types.EmptyEffects},
+	}
+	for _, tc := range cases {
+		t.Run(tc.fn, func(t *testing.T) {
+			v, err := env.GetVar(tc.fn)
+			if err != nil {
+				t.Fatalf("GetVar(%q): %v", tc.fn, err)
+			}
+			ft, ok := v.(types.FuncType)
+			if !ok {
+				t.Fatalf("expected FuncType for %q, got %T", tc.fn, v)
+			}
+			if ft.Effects != tc.want {
+				t.Fatalf("%s: got %s, want %s", tc.fn, ft.Effects, tc.want)
+			}
+		})
+	}
+}
+
 func contains(s, sub string) bool {
 	return len(s) >= len(sub) && indexOf(s, sub) >= 0
 }

--- a/website/docs/mep/mep-0015.md
+++ b/website/docs/mep/mep-0015.md
@@ -58,16 +58,16 @@ The upside is that every future enforcement point gets to ask the question it ac
 | T044 in `where` and `having` predicates                           | closed |
 | Compile-time constant folding gated on Pure                       | closed |
 | MEP-16 N5 narrowing drop on non-pure call                         | closed |
-| `Effects EffectSet` field on `FuncType`                           | **open** |
-| Closed label set: `io`, `fs`, `net`, `time`, `meta`               | **open** |
-| Builtin effect annotations                                        | **open** |
-| Effect inference (union of callees, plus statement-level effects) | **open** |
-| `Pure()` method as compatibility shim                             | **open** |
-| Effect propagation through higher-order generics                  | **open** |
-| Surface annotation `fun foo(): T ! io, fs { ... }`                | **open** |
-| Diagnostic T065 (declared effect exceeded)                        | **open** |
+| `Effects EffectSet` field on `FuncType`                           | closed (Stage 1) |
+| Closed label set: `io`, `fs`, `net`, `time`, `meta`               | closed (Stage 1) |
+| Builtin effect annotations                                        | closed (Stage 1) |
+| Effect inference (union of callees, plus statement-level effects) | closed (Stage 2a) |
+| `Pure()` method as compatibility shim                             | closed (Stage 1) |
+| Effect propagation through higher-order generics                  | closed (Stage 3d) |
+| Surface annotation `fun foo(): T ! io, fs { ... }`                | closed (Stage 2b) |
+| Diagnostic T065 (declared effect exceeded)                        | closed (Stage 2b) |
 | Diagnostic T066 (effect not allowed in context)                   | closed (reserved, no firing site until `const` lands) |
-| Effect inference for closures and intent methods                  | **open** |
+| Effect inference for closures and intent methods                  | closed (Stage 3b) |
 | User-defined effect labels                                        | by design (deferred) |
 | Algebraic effect handlers (`try` / `with` / `resume`)             | by design (deferred) |
 
@@ -352,7 +352,9 @@ The work lands in three stages, each a separate PR with fixture pinning:
 
 6. **Stage 3c (shipped): reserve T066.** The pure-position diagnostic template is registered in `types/errors.go`, the `errEffectInPurePosition(pos, context, effects)` helper is in place, and a unit test pins the rendered message and help text. No surface emits T066 yet; the helper will be wired up when `const` declarations and struct field defaults land. This stage exists so the diagnostic code, message wording, and constructor signature are settled before the consuming features go through review.
 
-7. **Stage 4 (deferred):** decide on user-defined effects and handlers. Likely paired with the exception MEP or the async MEP. Out of scope here; the design is intentionally extensible.
+7. **Stage 3d (shipped): HOF callback effect propagation.** A new `callableEffects(e, env)` helper in `types/effects_infer.go` detects the two "bare callable" argument forms — a FunExpr literal and a simple identifier of function type — and returns the effects that calling that value would incur. Both `primaryEffects` (direct calls `f(args)`) and `postfixEffects` (postfix / method calls) union in `callableEffects` for each argument. This means `apply(fun(x:int):int{ print(x); x }, 5)` and `apply(do_print, 5)` are both correctly typed as `!io` at the call site, regardless of `apply`'s own declared effects. The approximation is conservative: if an argument could be a function value, its effects flow to the call site. No false negatives; occasional false positives for HOFs that store rather than call their argument are accepted as the sound over-approximation.
+
+8. **Stage 4 (deferred):** decide on user-defined effects and handlers. Likely paired with the exception MEP or the async MEP. Out of scope here; the design is intentionally extensible.
 
 The stages can ship months apart. Stage 1 is the only one that touches the type checker. Stage 2 is parser + a single subset check. Stage 3 is diagnostic polish. Stage 4 is a separate MEP.
 
@@ -369,6 +371,7 @@ Pointers to where each piece lives once the stages ship.
 - `runtime/vm/vm.go` constant-folding gate: reads `Effects.IsEmpty()`.
 - `parser/ast.go` `FunStmt.Effects`: `[]string` populated by stage 2 parser. Empty at stage 1.
 - `types/errors.go`: T044 help text gains label list; T065 added; T066 reserved with `errEffectInPurePosition` constructor.
+- `types/effects_infer.go` `callableEffects`: detects bare-callable arguments (FunExpr literal or identifier of function type) and returns the effects incurred by calling them; wired into `primaryEffects` and `postfixEffects` arg loops (Stage 3d).
 
 ## Open questions
 


### PR DESCRIPTION
Closes #21456.

Stage 3d of MEP-15 — the last non-deferred open item.

## Problem

MEP-15 E5 says a HOF call site should inherit the effects of its function-typed arguments when those arguments are called. Before this PR, `apply(fun(x:int):int{ print(x); x }, 5)` was incorrectly typed as pure: `exprEffects` for a FunExpr argument returns `{}` (closure construction is pure), so the `io` effect in the callback body never reached the enclosing call.

## Fix

New `callableEffects(e, env)` in `types/effects_infer.go`:
- Detects "bare callable" arguments: a FunExpr literal, or a plain identifier of function type.
- Returns the effects that *calling* that value would incur (vs. just constructing it).

Wired into both `primaryEffects` (`f(args)` direct calls) and `postfixEffects` (`obj.method(args)` / postfix calls) — for each argument, union in both `exprEffects` (evaluation cost) and `callableEffects` (call cost).

## Approximation note

The propagation is conservative: any function-typed argument is treated as-if-called, even for HOFs that only store their argument. This is a sound over-approximation (no false negatives; occasional false positives for store-only HOFs). The MEP's hidden row variable is implemented without requiring row types in the surface or the stored `FuncType`.

## Also

Syncs the MEP-15 status-at-a-glance table: all Stages 1–3d rows are now marked closed, with the stage number attached.

## Test plan
- [x] `TestHOFCallbackEffects`: three sub-cases (FunExpr literal `!io`, named function `!io`, pure FunExpr literal)
- [x] Full `go test ./...` green