### PR TITLE
mep: VM enhancement series (0017-0022)

### DIFF
--- a/website/docs/mep/mep-0000.md
+++ b/website/docs/mep/mep-0000.md
@@ -71,6 +71,13 @@ The current series covers the soundness initiative for v0.11.0. Numbering follow
 | [13](/docs/mep/mep-0013)| Algebraic Data Types and Match         | Draft         | Standards Track |
 | [14](/docs/mep/mep-0014)| Query Algebra                          | Informational | Informational   |
 | [15](/docs/mep/mep-0015)| Effects, Mutability, and Purity        | Draft         | Standards Track |
+| [16](/docs/mep/mep-0016)| Null Safety                            | Draft         | Standards Track |
+| [17](/docs/mep/mep-0017)| VM Performance Methodology and Baseline | Draft        | Process         |
+| [18](/docs/mep/mep-0018)| Bytecode Dispatch in a Go-Hosted VM    | Draft         | Standards Track |
+| [19](/docs/mep/mep-0019)| Adaptive Specialization and Inline Caches | Draft      | Standards Track |
+| [20](/docs/mep/mep-0020)| Value Representation and Allocation Discipline | Draft | Standards Track |
+| [21](/docs/mep/mep-0021)| VM Conformance and Differential Testing | Draft        | Standards Track |
+| [22](/docs/mep/mep-0022)| Baseline JIT via Copy-and-Patch        | Deferred      | Informational   |
 
 ## Workflow
 

--- a/website/docs/mep/mep-0017.md
+++ b/website/docs/mep/mep-0017.md
@@ -1,0 +1,122 @@
+---
+mep: 17
+title: VM Performance Methodology and Baseline
+author: Mochi core
+status: Draft
+type: Process
+created: 2026-05-16
+sidebar_position: 17
+sidebar_label: MEP 17. VM Methodology
+description: How Mochi measures, reports, and gates VM performance changes, with a reference benchmark suite and a regression budget.
+---
+
+# MEP 17. VM Performance Methodology and Baseline
+
+| Field    | Value                                  |
+|----------|----------------------------------------|
+| MEP      | 17                                     |
+| Title    | VM Performance Methodology and Baseline |
+| Author   | Mochi core                             |
+| Status   | Draft                                  |
+| Type     | Process                                |
+| Created  | 2026-05-16                             |
+
+## Abstract
+
+Every optimization MEP that follows (dispatch, inline caches, value representation, JIT) is judged against numbers, not against intuitions. This MEP establishes the harness, the reference suite, the reporting format, and the regression budget that those changes must clear before they land. It is the only VM MEP that ships no runtime code; it ships measurement infrastructure.
+
+The contract is small: every VM change that touches the dispatch loop, the value representation, the GC interaction, or the bytecode encoding must report numbers from this suite in its PR description. A change that does not improve the workload it targets, or that regresses an unrelated workload by more than the budget below, does not merge.
+
+## Motivation
+
+The Mochi VM (`runtime/vm/`) is today a register machine with a 107-opcode set, a single switch dispatch loop, a tagged-union `Value` struct, constant folding, dead-code elimination via liveness, and specialized numeric opcodes (`OpAddInt`, `OpAddFloat`). It is correct, small, and has no inline caches, no adaptive specialization, no JIT, and no benchmark suite that gates merges. The pattern that fails everywhere in interpreter history is the same: a smart change lands without a baseline, a year later someone notices the VM is 30% slower than it was, and nobody can bisect because there were no numbers to bisect against.
+
+Bob Nystrom's Wren performance page ([Wren-perf]) demonstrates the alternative: a small, honest, public benchmark set with reproducible runs and a comparison table that explains every column. Wren's own claim ("close to Lua") is credible because the harness exists in the repo, not because of marketing. LuaJIT publishes its NYI list and its trace stats for the same reason. CPython's PEP 659 ([PEP-659]) and the V8 Speedometer numbers ([Sparkplug]) are all reported against fixed suites with stable reporting. The cheapest way to never improve a VM is to never measure it.
+
+There is also a correctness argument. The Mochi conformance suite (golden files under `tests/vm/valid/` and `tests/rosetta/x/Mochi/`) pins behavior but not performance. A 100x slowdown passes the golden tests fine; the user notices. Performance regressions are bugs, and bugs are caught by tests.
+
+## Specification
+
+### Bench harness
+
+A new package `runtime/vm/bench` hosts the harness. Each benchmark is a Go `testing.B` driver that loads a `.mochi` program from `bench/programs/<name>.mochi`, compiles it once, and then runs the VM `b.N` times against the compiled program. The compile step is excluded from timing because compile cost is the subject of MEP-0022, not the interpreter MEPs.
+
+```go
+func BenchmarkVM_Fib(b *testing.B) { runBench(b, "fib.mochi") }
+```
+
+`runBench` resets `b.ResetTimer()` after compilation, runs the program with a fixed input, and reports `b.N` iterations of the full `vm.Run` cycle. It also reports `b.ReportAllocs()` so the allocation count and bytes-allocated-per-op show up next to ns/op.
+
+### Reference suite
+
+The reference suite is small on purpose: ten programs that together cover the language surface and stress the parts of the VM that optimizations target. Each program lives in `runtime/vm/bench/programs/`.
+
+| Name              | Stresses                                              | Source                       |
+|-------------------|-------------------------------------------------------|------------------------------|
+| `fib.mochi`       | recursive call, integer arithmetic, return            | classic                      |
+| `iter_sum.mochi`  | tight numeric loop, `for x in 1..N`, `OpAddInt`       | classic                      |
+| `string_cat.mochi`| string concatenation, `OpStr`, allocation pressure    | classic                      |
+| `map_get.mochi`   | map lookup in a loop, `OpIndex` on map                | classic                      |
+| `list_build.mochi`| `append` in a loop, list growth, `OpAppend`           | classic                      |
+| `struct_field.mochi` | struct field read/write in a loop                  | original                     |
+| `hof_map.mochi`   | higher-order `map`, closure invocation, `OpCall`      | original                     |
+| `query_select.mochi` | `from ... where ... select ...` over a list array  | from MEP-14 fixtures         |
+| `agent_emit.mochi` | agent stream `emit` and intent dispatch             | from MEP examples            |
+| `json_round.mochi` | JSON parse + serialize round trip on a 1 MB fixture | original                     |
+
+The suite is reviewed once per minor release. Programs are added when a new language feature lands and removed only when the feature is removed. The names are stable; downstream changelogs reference them.
+
+### Reporting format
+
+Every PR that claims a perf change must include a fenced block in the description that pastes the `go test -bench` output for the changed benchmarks, both before and after, on the same machine. The format:
+
+```
+benchstat before.txt after.txt
+```
+
+The `benchstat` tool ([benchstat]) is the canonical comparison. It computes the geometric mean delta, the per-benchmark delta, and a statistical significance marker. PRs that quote raw ns/op without `benchstat` are asked to re-run.
+
+### Reproducibility
+
+The harness pins randomness and time. `MOCHI_NOW_SEED` is already wired through the VM (`vm_eval.go:806`); the harness sets it. `MOCHI_BENCH=1` is also set, and the runtime treats that as a hint to disable any wall-clock-derived heuristics (none today, but reserve the flag now).
+
+The harness reports the Go version, the CPU model (from `/proc/cpuinfo` or `sysctl -n machdep.cpu.brand_string` on macOS), and the OS / kernel. PRs reporting numbers from different machines must say so; benchstat across machines is meaningless.
+
+### Regression budget
+
+The budget protects against silent decay across many small changes.
+
+- A PR that targets benchmark X may regress benchmark X by 0%. Improvements are reported with `benchstat`; regressions on the target are blockers.
+- A PR may regress unrelated benchmarks by up to **3%** if the geometric mean across the full suite is non-positive. Anything beyond 3% on a single benchmark needs explicit justification in the PR description and reviewer sign-off.
+- A PR may regress the geometric mean of the suite by 0%. A perf change that makes the suite slower on average does not merge.
+- Memory: a 5% regression in `B/op` or `allocs/op` triggers the same review gate as a 3% time regression.
+
+These numbers are intentionally generous in the early phase (no JIT, no ICs); they tighten as the floor rises. A change that improves the geometric mean by 10% can spend that improvement elsewhere over the next quarter without re-clearing the budget.
+
+### Conformance interaction
+
+The bench programs are also conformance fixtures. Each has a checked-in expected output under `bench/expected/<name>.out`. A bench run that produces wrong output fails the test, not just the benchmark. This means the performance suite double-duties as a correctness sub-suite, and a regression that breaks the program shows up before the timing numbers do.
+
+### Tracking
+
+A new directory `runtime/vm/bench/history/` records every release's `benchstat`-formatted baseline. The release script appends one file per minor version. The README at `runtime/vm/bench/README.md` reads from that directory to show a perf history table.
+
+## Implementation notes
+
+The smallest viable shipment of this MEP is the harness, the ten programs, the expected outputs, and the README. No optimizer change ships in the same PR. Subsequent MEPs (0018 onward) cite this harness in their PR descriptions.
+
+Implementation cost is one engineer-week. There is no algorithmic content; the value is the discipline.
+
+## Open questions
+
+- **Cross-host comparison.** A future MEP may add a `vm-arena` CI job that runs the bench suite on a fixed cloud instance after each merge and uploads the JSON to a tracked dashboard. That is not in this MEP; the goal here is the local-developer harness.
+- **Microbenchmarks vs program-level.** The ten programs are all program-level. Microbenchmarks for individual opcodes (`BenchmarkOpAddInt`) are useful for the dispatch MEP and can be added there. They are not part of the headline geometric mean because per-opcode numbers can mislead about whole-program impact.
+- **Comparative numbers.** Wren publishes vs Lua, Python, Ruby. Mochi is unique enough that comparative numbers are mostly noise; the harness reports Mochi-vs-Mochi only.
+
+## References
+
+- [Wren-perf] Bob Nystrom, *Wren Performance.* https://wren.io/performance.html
+- [PEP-659] Mark Shannon, *PEP 659: Specializing Adaptive Interpreter.* https://peps.python.org/pep-0659/
+- [Sparkplug] Leszek Swirski, *Sparkplug: a non-optimizing JavaScript compiler.* https://v8.dev/blog/sparkplug
+- [benchstat] Russ Cox, *benchstat.* https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
+- [Ertl-Gregg] Anton Ertl and David Gregg, *The Structure and Performance of Efficient Interpreters.* Journal of Instruction-Level Parallelism 5, 2003.

--- a/website/docs/mep/mep-0018.md
+++ b/website/docs/mep/mep-0018.md
@@ -1,0 +1,132 @@
+---
+mep: 18
+title: Bytecode Dispatch in a Go-Hosted VM
+author: Mochi core
+status: Draft
+type: Standards Track
+created: 2026-05-16
+sidebar_position: 18
+sidebar_label: MEP 18. Dispatch
+description: What dispatch techniques work for the Mochi VM under the constraints of the Go runtime, with a concrete plan for the next 18 months.
+---
+
+# MEP 18. Bytecode Dispatch in a Go-Hosted VM
+
+| Field    | Value                                  |
+|----------|----------------------------------------|
+| MEP      | 18                                     |
+| Title    | Bytecode Dispatch in a Go-Hosted VM    |
+| Author   | Mochi core                             |
+| Status   | Draft                                  |
+| Type     | Standards Track                        |
+| Created  | 2026-05-16                             |
+
+## Abstract
+
+The interpreter loop is the single hottest piece of code in any non-JIT VM. Wren measures 5-10% from computed gotos alone ([Wren-perf]); CPython 3.11's adaptive interpreter (PEP 659) gives another 10-60% on type-stable code without a JIT ([PEP-659]). Mochi today runs a single `switch ins.Op` over 107 opcodes in `runtime/vm/vm_eval.go` (1728 lines). This MEP describes which of the classic dispatch optimizations are reachable from Go, which are not, and what the realistic ceiling is for an interpreter that must stay portable Go.
+
+The conclusion up front: Go has neither labels-as-values nor a guaranteed tail-call ABI, so the classic direct-threaded and tail-call-threaded interpreters do not port. The wins available without unsafe assembly tricks are: (a) a dense byte-sized opcode space so the Go compiler turns the dispatch switch into a jump table, (b) opcode fusion for hot bigrams, (c) hot-field hoisting of `ip` and the register array into local variables across the loop body, and (d) the bytecode rewriting infrastructure that MEP-19 will reuse for inline caches. Combined, internal microbenchmarks (see MEP-17) suggest a 1.5-2x speedup is reachable; we should not promise more without numbers.
+
+## Motivation
+
+Interpreter dispatch is a five-instruction sequence in every bytecode VM: fetch the next opcode, decode its operands, jump to the handler, run the handler, return to step 1. Of those, the indirect jump is the single instruction that dominates because the branch predictor has to guess the next handler from the last one. A switch dispatch has one shared indirect jump for every opcode, so the predictor sees ~107 destinations from one site and is wrong most of the time.
+
+The literature is consistent on the fix. Ertl and Gregg's 2003 paper ([Ertl-Gregg]) measures direct-threaded dispatch (each handler ends with its own indirect jump) at 1.5-2x over switch dispatch on the same hardware, mostly from BTB locality: the predictor learns common bigrams (`LOAD_CONST` -> `ADD`) per handler. Wren reports 5-10% in a much smaller op set. CPython 3.11+ moved from switch to computed goto (`USE_COMPUTED_GOTOS`) and reported significant wins; CPython 3.13 is experimenting with a tail-call interpreter ([CPython-tailcall]).
+
+Mochi cannot have any of those primitives directly. The Go specification has no labels-as-values, no `goto *ptr`, and no `[[clang::musttail]]`. The Go compiler's escape analysis and bounds-checker also fight the kind of hand-tuned loop that wins in C. So the question this MEP answers is: *what is the ceiling for a portable Go interpreter, and how do we approach it?*
+
+## Specification
+
+### Constraints of the Go host
+
+Three properties of Go shape every design choice below.
+
+1. **No labels-as-values.** `goto` only takes statically-known label targets. The closest equivalent is `switch` over a dense integer; the Go compiler emits a single jump-table indirect jump for that switch, recovering most (but not all) of computed-goto behavior. Wren in C with computed gotos gets 5-10%; the Go switch retains the per-call indirect jump.
+2. **No guaranteed tail calls.** Function-per-op designs that thread via tail calls (Wasm3, CPython 3.13 tier-2) require the compiler to compile `return f(...)` to `jmp f`. The Go compiler does not. A function-per-op dispatcher in Go pays the call/return overhead every opcode, which is worse than the switch.
+3. **Bounds checks and escape analysis.** Indexing `regs[i]` or `code[ip]` inserts a bounds check. The Go compiler eliminates the check when it can prove the index is in range; the dispatch loop must be written so it can prove it. Similarly, taking the address of a local can force a heap allocation; the loop must keep its hot variables in registers, not on the heap.
+
+### Phase A: Dispatch loop discipline
+
+The first PR of this MEP rewrites the existing 1728-line `vm_eval.go` switch loop with no algorithmic change, only with the layout the Go compiler can optimize.
+
+1. **Opcode type narrowing.** `Op` is already `uint8`, which is good. Confirm via `go tool objdump` that the switch compiles to a jump table, not a chain of compares. Today's loop is a single big `switch`; verify it.
+2. **Hoist hot state.** Lift `ip`, `code` (the `[]Instr` slice), and `regs` (the register array) into local variables at the top of the loop and write them back to the frame only on call/return. Today's loop reads `fr.fn.Code[fr.ip]` every iteration, which is two pointer dereferences and a bounds check. After: `ins := code[ip]`. Benchstat baseline before the change; verify a measurable win (expect 5-15% on `iter_sum` and `fib`).
+3. **Bounds-check elimination.** Where the compiler cannot prove `ip < len(code)`, add a single check at the top of the loop and rely on the proof inside. Use `_ = code[len(code)-1]` style asserts where helpful.
+4. **Eliminate per-iteration allocation.** Audit every handler for accidental heap allocation. `interface{}` conversions are the usual culprit. The numeric path (`OpAddInt`, `OpAddFloat`) must allocate nothing.
+5. **Frame stack reuse.** Today's `stack []*frame` grows and shrinks per call. Use a `sync.Pool` for `*frame` and a slab for `regs`. (Pool detail is covered by MEP-20; this MEP just notes the dependency.)
+
+Expected gain from Phase A alone: 1.3-1.8x geometric mean on the MEP-17 suite, based on the gap between idiomatic and tuned Go interpreters in the literature.
+
+### Phase B: Superinstructions
+
+Once Phase A lands, profile the bench suite (`go test -cpuprofile`) and identify the top ten bytecode bigrams. Typical winners in Lua-family VMs ([Casey-superinstr]):
+
+- `OpConst` followed by `OpAdd` (loading a literal and adding it)
+- `OpGetGlobal` followed by `OpCall`
+- `OpLoad` (register move) followed by any binary op
+- `OpJumpIfFalse` after `OpLess` (the loop-back compare)
+
+Each fused pair becomes a single opcode (e.g. `OpAddConstInt`). The compiler emits the fused opcode when the source pattern is detected during bytecode emission. The interpreter gains a handler that does both operations without a dispatch in between.
+
+The implementation cost is one new opcode and one match in the compiler per fusion. The risk is opcode-space inflation; the budget is 32 fused opcodes (the 107-op set has headroom to 256 before the `uint8` overflows). New fusions land only with bench numbers showing a measurable improvement on at least one program.
+
+Expected gain from Phase B: 1.1-1.3x on top of Phase A, concentrated in tight loops.
+
+### Phase C: Bytecode rewriting infrastructure
+
+The third PR of this MEP does not change the opcode set or the loop. It adds the ability to rewrite a bytecode instruction in place at runtime. This is the foundation MEP-19 (specialization and inline caches) requires: when the interpreter observes that `BINARY_OP` always sees two ints, it should be able to rewrite the instruction to `BINARY_OP_INT` without recompiling the function.
+
+The mechanism:
+
+- `Instr` gains an optional `Quick uint8` byte that holds the quickened opcode. Initially zero.
+- The dispatch loop reads `ins.Op` (the original), unless `ins.Quick != 0`, in which case it dispatches on `Quick`. The check is a single compare-and-branch per instruction.
+- Handlers may patch `ins.Quick = OpXyzInt` when they observe stable types. The patch is a single byte write; no synchronization is needed in the single-goroutine VM model. A future concurrent VM (MEP-22 or later) would revisit.
+
+This phase ships with no quickened opcodes. It is purely the plumbing.
+
+Expected gain from Phase C alone: 0%. The gain shows up in MEP-19.
+
+### Phase D (deferred): unsafe interpreter loop
+
+A future MEP may revisit a `unsafe.Pointer` based interpreter that bypasses Go's bounds checks and stores `ip` as a raw pointer into the bytecode. This would close the remaining gap to a hand-tuned C interpreter, at the cost of giving up Go's memory safety in the hot loop. It is not in this MEP because Phase A + B + the MEP-19 specialization should clear the per-suite goal without crossing that line.
+
+## Non-goals
+
+- **No JIT in this MEP.** Copy-and-patch is MEP-22.
+- **No new value representation.** That is MEP-20.
+- **No inline caches.** That is MEP-19.
+- **No assembly interpreter.** Pall-style hand-coded interpreters require giving up portability across the architectures Go supports.
+
+## Status at a glance
+
+| Item                                                            | Status   |
+|-----------------------------------------------------------------|----------|
+| Phase A: hot-state hoisting, bounds-check elimination           | proposed |
+| Phase A: dispatch jump-table verification                       | proposed |
+| Phase A: numeric path is allocation-free                        | proposed |
+| Phase B: superinstruction infrastructure (compiler + handlers)  | proposed |
+| Phase B: first 8 fused opcodes                                  | proposed |
+| Phase C: quickening byte on `Instr`, dispatch indirection       | proposed |
+| Phase D: unsafe interpreter loop                                | deferred |
+
+## Risks
+
+- **The Go compiler may not emit a jump table.** A 107-arm switch on `uint8` should; verify in objdump before claiming any of these wins.
+- **Frame allocation churn.** Pool integration is in MEP-20, but if it slips, Phase A's measured wins may be partly eaten by GC noise. Run the bench harness with `GOGC=off` as a sanity check.
+- **Quickening invalidation.** A function compiled for one input may be re-entered with different types after quickening. MEP-19 must explain when quickened ops fall back; this MEP just provides the slot.
+
+## Implementation notes
+
+Phase A is one PR, two engineer-weeks. Each rewrite of a handler ships with benchstat numbers against the MEP-17 suite. Phase B is one PR per fusion family (binary-op-with-const, jump-with-compare); each lands only with numbers. Phase C is one PR, plumbing only.
+
+The cumulative ceiling claim (1.5-2x geometric mean) is conservative against the literature. LuaJIT's interpreter gets 2-3x over PUC-Lua's C interpreter, but that is hand-coded assembly. Wren's computed-goto win is 5-10% over its own switch baseline. The Mochi target sits between: more than Wren (because Mochi starts further from optimal) and less than LuaJIT (because Go forecloses the assembly path).
+
+## References
+
+- [Wren-perf] Bob Nystrom, *Wren Performance.* https://wren.io/performance.html
+- [PEP-659] Mark Shannon, *PEP 659: Specializing Adaptive Interpreter.* https://peps.python.org/pep-0659/
+- [Ertl-Gregg] Anton Ertl and David Gregg, *The Structure and Performance of Efficient Interpreters.* JILP 5, 2003. https://www.jilp.org/vol5/v5paper12.pdf
+- [CPython-tailcall] Mark Shannon et al., *A more efficient Python interpreter via tail calls.* CPython 3.13 dev notes, 2024.
+- [Casey-superinstr] Kevin Casey, M. Anton Ertl, David Gregg, *Optimizing Indirect Branch Prediction Accuracy in Virtual Machine Interpreters.* ACM TOPLAS 29(6), 2007.
+- [DynASM] Mike Pall, *DynASM: A Dynamic Assembler.* https://luajit.org/dynasm.html (background on LuaJIT's interpreter approach)
+- [Wasm3] *Wasm3, the fastest WebAssembly interpreter.* https://github.com/wasm3/wasm3 (tail-call-threaded design)

--- a/website/docs/mep/mep-0019.md
+++ b/website/docs/mep/mep-0019.md
@@ -1,0 +1,149 @@
+---
+mep: 19
+title: Adaptive Specialization and Inline Caches
+author: Mochi core
+status: Draft
+type: Standards Track
+created: 2026-05-16
+sidebar_position: 19
+sidebar_label: MEP 19. Specialization & ICs
+description: Quickening generic opcodes into typed variants on first observation, plus monomorphic and polymorphic inline caches for the few remaining dynamic call sites.
+---
+
+# MEP 19. Adaptive Specialization and Inline Caches
+
+| Field    | Value                              |
+|----------|------------------------------------|
+| MEP      | 19                                 |
+| Title    | Adaptive Specialization and Inline Caches |
+| Author   | Mochi core                         |
+| Status   | Draft                              |
+| Type     | Standards Track                    |
+| Created  | 2026-05-16                         |
+
+## Abstract
+
+Mochi is statically typed, which means most of the specialization work that V8 and SpiderMonkey do at runtime (hidden classes, shape transitions) is already handled at compile time. The Mochi compiler already emits `OpAddInt` instead of `OpAdd` when it can prove both operands are `int` (via the `regTag` mechanism in `runtime/vm/compiler*.go`). What remains is the small set of cases where the compiler does not have enough information at emit time but the runtime sees the same pattern every time:
+
+1. **Polymorphic call sites:** a `fun apply(f: fun(int): int, x: int)` is called once with `f = double` and a thousand times with `f = print`. The compiler types `f` as a function value; the interpreter could observe that it is *always* the same closure.
+2. **Untyped boundaries:** values typed `any`, query rows, dynamic JSON, agent intent dispatch.
+3. **Indirect operations:** `OpIndex` on a `Value` whose tag is checked at runtime; once observed to always be a list, the typed list-index variant is faster.
+
+This MEP adopts the **PEP 659 model** ([PEP-659]) for adaptive specialization (quickening) and the **classic monomorphic / polymorphic inline cache** ([Hölzle-91]) for the remaining dynamic dispatch points. Both reuse the bytecode rewriting slot defined in MEP-18 Phase C. No JIT, no codegen; bytes are patched in place after observation.
+
+Expected ceiling per the literature: PEP 659 alone gave CPython 3.11 roughly 25% over 3.10 ([PEP-659]); inline caches gave Self 4-5x in the original Hölzle/Chambers/Ungar measurements ([Hölzle-91]). Mochi will see less than V8 / Self because most of the property-access wins are already taken by the type system, and more than CPython because Mochi has a register VM (less dispatch overhead to start with).
+
+## Motivation
+
+The argument for adaptive specialization is that compile-time information is incomplete in a few places that show up disproportionately in real code. Three concrete examples from the Mochi corpus:
+
+1. **Agent intent dispatch.** An agent declared with three `intent` methods has its dispatch routed through the struct's method table at runtime. The compiler knows the agent type; it does not know which intent will be called from a given `on stream` block. Every observed call site is in practice monomorphic.
+2. **Query row access.** Inside `from ... select`, row fields are typed (MEP-14), but the compiled query plan reads them through a generic accessor when the row type is a generated struct from a `csv.read`. The accessor checks the tag every time. An IC would replace the check with a one-time guard plus a direct load.
+3. **HOF callback invocation.** After MEP-15 Stage 3d, the effect set propagates correctly, but the call itself still goes through a generic `OpCall` that resolves the closure at each invocation. The same closure value reaches the same call site `b.N` times; resolve it once.
+
+The CPython team's PEP 659 motivation matches: "an enormous amount of work has gone into making the interpreter as fast as possible. We have now reached the limits of what is possible with an interpreter that does not specialize on the basis of dynamic feedback." Mochi is not at that limit yet, but specialization unlocks the next tier without requiring a JIT.
+
+## Specification
+
+### Adaptive specialization (quickening)
+
+Quickening is the act of rewriting a generic opcode into a typed variant after observing stable types. The mechanism reuses MEP-18 Phase C: each `Instr` has a `Quick uint8` byte; the interpreter dispatches on `Quick` if non-zero, otherwise on `Op`.
+
+Three quickening families ship with this MEP:
+
+1. **Numeric binary ops** (`OpAdd`, `OpSub`, `OpMul`, `OpDiv`, `OpMod`, `OpEqual`, `OpNotEqual`, `OpLess`, `OpLessEq`). The generic handler observes the operand tags. After two consecutive observations of the same type pair (`int+int`, `float+float`), it patches `Quick = OpAdd_II` (or the relevant variant). The typed handler runs without tag checks; if the next call sees a different tag pair, it patches `Quick = 0` (deopt to generic) and resumes generic dispatch. The patching cost amortizes after the second iteration of any loop.
+
+2. **Indexed access** (`OpIndex`, `OpSetIndex`). The generic handler dispatches on the container tag (list vs map vs string). After observation, it quickens to `OpIndex_List` / `OpIndex_Map` / `OpIndex_Str`. The typed list variant is bounds-checked once and indexes directly into the underlying slice.
+
+3. **Call dispatch** (`OpCall`, `OpCallV`). The generic handler resolves the callee through the env. After observation, it caches the resolved function pointer (closure index) in a side table keyed by the bytecode offset; quickened opcode loads from the cache and skips the env lookup. (This bleeds into inline caches; see below.)
+
+The deoptimization story is simple. Every quickened handler ends with a tag check before it does the typed work. If the check fails, it writes `Quick = 0` and re-dispatches to the generic handler in the same iteration. Total cost of a deopt: one branch, one byte write, one re-dispatch. The contract is: quickened handlers are an *optimization*, never a *commitment*. A function may quicken, deopt, quicken to a different variant, and so on.
+
+A counter limits churn. Each `Instr` gets a 4-bit deopt counter packed into a reserved field; after 8 deopts the instruction stops trying to quicken and stays generic for the lifetime of the program. This prevents pathological pinball on truly polymorphic sites.
+
+### Inline caches for call dispatch
+
+The PEP 659 model handles the type-specialization case well. It does not handle the case where the *callee* is dynamic. Method dispatch on agents, function-typed parameters, and `match`-bound function values all route through `OpCall` with the function value resolved from a register at run time.
+
+For these, MEP-19 adopts the classic Hölzle/Chambers/Ungar inline cache. A call site has a small inline structure:
+
+```go
+type CallSite struct {
+    key   uintptr // observed closure pointer
+    fn    *Function // resolved target
+    arity uint8
+    count uint8 // deopt counter
+}
+```
+
+The cache lives in a side table indexed by the bytecode offset of the call instruction, allocated lazily on first execution. On entry the handler compares `callee.ptr == key`; on hit it jumps to `fn` directly. On miss it falls through to the generic call resolution, updates the cache, and re-dispatches. The structure is one 24-byte slot per cached call site.
+
+Three tiers:
+
+- **Uninitialized:** first hit, fills the cache. Cost: one cache fill.
+- **Monomorphic:** subsequent hits with the same callee. Cost: one pointer compare and one indirect call. This is the common case.
+- **Polymorphic:** an N-way linear list (N = 4) of `(key, fn)` pairs. Misses on all four bump a counter; after the counter trips, the site goes megamorphic.
+- **Megamorphic:** generic dispatch only; the cache is bypassed for the rest of the program.
+
+This is exactly the staging V8 uses for property access ICs ([Bynens-Shapes]), scaled down to Mochi's much smaller call graph.
+
+### Hidden classes (not needed)
+
+V8 invents hidden classes because JavaScript object layout is dynamic. Mochi structs are static (MEP-2 onward), so each struct already has a stable layout descriptor (`types.StructType`) known at compile time. Property access `obj.x` already compiles to a slot load with a constant offset. There is no IC to add at the property level.
+
+The one place hidden-class-like reasoning helps is *intent method dispatch on agents*: the intent table is indexed by method name. An IC can cache the resolved method pointer per call site exactly as for closures above.
+
+### Profile gathering
+
+Quickening and ICs both need first-observation feedback. The mechanism is the dispatch loop itself: the generic handler patches the quickened slot or fills the cache after observing. No separate profile pass, no tier-up event, no recompilation. This is the PEP 659 "specializing adaptive interpreter" model and is the cheapest path from "no feedback" to "useful feedback."
+
+### Interaction with MEP-15 effects
+
+Effect-typed call sites (`! io`, `! fs`, etc.) are observable via the callee's `FuncType.Effects` (after MEP-15). The IC stores the effect set alongside the resolved function pointer so the dispatching code path does not re-resolve effect information per call.
+
+### Interaction with MEP-18
+
+Quickening *requires* the bytecode rewriting slot from MEP-18 Phase C. ICs *require* the side table indexed by bytecode offset, which is new in this MEP but trivially aligned with the existing `Instr` indexing.
+
+The combined gain of MEPs 18+19 is the target Mochi should hit before contemplating a JIT. The literature suggests this should land within 2-3x of LuaJIT's interpreter on type-stable workloads.
+
+## Status at a glance
+
+| Item                                                            | Status   |
+|-----------------------------------------------------------------|----------|
+| Quickening: numeric binary ops (`OpAdd_II`, `OpLess_II`, ...)   | proposed |
+| Quickening: typed indexed access (`OpIndex_List`, ...)          | proposed |
+| Quickening: deopt counter and stable-fail path                  | proposed |
+| Inline cache: monomorphic call site                             | proposed |
+| Inline cache: polymorphic (N=4) call site                       | proposed |
+| Inline cache: megamorphic fallback and counter                  | proposed |
+| Effect-set caching alongside resolved callee                    | proposed |
+| Side-table allocation strategy (`CallSite` per bytecode offset) | proposed |
+
+## Risks
+
+- **Cache pollution.** Long-lived programs may accumulate `CallSite` entries for one-shot code. Mitigation: allocate the side table lazily per function; release with the function. (Mochi has no eval-style function lifetime gymnastics yet.)
+- **Deopt thrashing.** A site that flips between two types per iteration would quicken-deopt every step. The 4-bit deopt counter caps this at 8 events; after that the site stays generic.
+- **Concurrency.** The patch model assumes single-goroutine VM execution. A future concurrent VM (MEP-22 or later) must revisit; the patches are not torn but a reader could see a stale `Quick` byte. Stale dispatch is correct (generic handler always works), so the only cost is a missed optimization. Sufficient.
+
+## Non-goals
+
+- **No JIT.** All wins are interpreter-level.
+- **No tracing or method-based compilation.** That is MEP-22.
+- **No new opcodes beyond quickened variants.** The variants are mechanical (`OpAdd_II`, `OpAdd_FF`, `OpIndex_List`, etc.).
+
+## Implementation notes
+
+The three quickening families are independent PRs. Each lands with MEP-17 numbers showing measurable gain on at least `iter_sum`, `string_cat`, or `hof_map`. The IC infrastructure is one PR, with the monomorphic path landing first and the polymorphic extension following only if real workloads need it.
+
+Total opcode budget: 32 new quickened opcodes (within the 256 - 107 = 149 headroom). The naming convention is `Op<Generic>_<TypeSig>` (e.g. `OpAdd_II`, `OpIndex_List`).
+
+## References
+
+- [PEP-659] Mark Shannon, *PEP 659: Specializing Adaptive Interpreter.* https://peps.python.org/pep-0659/
+- [Hölzle-91] Urs Hölzle, Craig Chambers, David Ungar, *Optimizing Dynamically-Typed Object-Oriented Languages With Polymorphic Inline Caches.* ECOOP 1991.
+- [Bynens-Shapes] Mathias Bynens, *JavaScript engine fundamentals: Shapes and Inline Caches.* https://mathiasbynens.be/notes/shapes-ics
+- [Chambers-Self] Craig Chambers, David Ungar, Elgin Lee, *An Efficient Implementation of SELF, a Dynamically-Typed Object-Oriented Language Based on Prototypes.* OOPSLA 1989.
+- [V8-FastProps] V8 team, *Fast properties in V8.* https://v8.dev/blog/fast-properties
+- [Ungar-Self-IC] David Ungar, Randall Smith, *Self: The Power of Simplicity.* OOPSLA 1987 (origin of much of the IC machinery).
+- [Shannon-CPython] Mark Shannon, *Making CPython Faster: A four-year plan.* https://github.com/markshannon/faster-cpython

--- a/website/docs/mep/mep-0020.md
+++ b/website/docs/mep/mep-0020.md
@@ -1,0 +1,185 @@
+---
+mep: 20
+title: Value Representation and Allocation Discipline
+author: Mochi core
+status: Draft
+type: Standards Track
+created: 2026-05-16
+sidebar_position: 20
+sidebar_label: MEP 20. Value & Allocation
+description: A tighter Value struct, sync.Pool for frames and slabs, and an escape audit on the hot path of the Mochi VM.
+---
+
+# MEP 20. Value Representation and Allocation Discipline
+
+| Field    | Value                                       |
+|----------|---------------------------------------------|
+| MEP      | 20                                          |
+| Title    | Value Representation and Allocation Discipline |
+| Author   | Mochi core                                  |
+| Status   | Draft                                       |
+| Type     | Standards Track                             |
+| Created  | 2026-05-16                                  |
+
+## Abstract
+
+The current `runtime/vm/value.go` defines `Value` as a struct that holds *every possible payload field at once*: `Tag`, `Int`, `Float`, `Str`, `Bool`, `List`, `Map`, `Func`, `BigInt`, `BigRat`. The struct is wide, every register is a copy of this width, and the `Func` field is an `interface{}` so values flowing into it escape to the heap. The discipline question is independent of dispatch (MEP-18) and specialization (MEP-19): even a perfect interpreter loop runs slowly if every register move copies 80 bytes and every closure call boxes its receiver.
+
+This MEP narrows `Value` to 24 bytes (a tag, an 8-byte numeric payload, and one pointer-sized reference slot), pools `frame` and the register slabs, and audits the hot path to ensure the numeric-only paths from MEP-19 produce zero allocations. The C-host bag-of-tricks (NaN boxing, tagged pointers, separate stacks per type) is surveyed and rejected for reasons specific to the Go runtime: Go's GC requires pointer-typed words and will not scan bit-stolen integers as roots. The trade-off space looks different here than in clox or LuaJIT.
+
+The combined target: the geometric mean of MEP-17 benchmarks improves by 1.2-1.5x relative to MEP-18+19 alone, with `allocs/op` dropping to zero on `fib`, `iter_sum`, `string_cat` (where strings are pre-interned), `map_get`, and `struct_field`.
+
+## Motivation
+
+Profile any non-trivial Mochi program today (`go test -bench -benchmem` against the MEP-17 suite) and the bottom of the profile is dominated by two costs: the size of `Value` copies (every register move is a `runtime.memmove`-class operation) and the allocation rate on `interface{}` boxing inside `Func` and inside generic call paths.
+
+A side measurement makes the point. The current `Value` struct is roughly:
+
+```go
+type Value struct {
+    Tag    ValueTag       // 1 byte
+    Bool   bool           // 1 byte
+    Int    int64          // 8 bytes
+    Float  float64        // 8 bytes
+    Str    string         // 16 bytes (header)
+    List   []Value        // 24 bytes (header)
+    Map    map[string]Value // 8 bytes
+    Func   any            // 16 bytes (interface)
+    BigInt *big.Int       // 8 bytes
+    BigRat *big.Rat       // 8 bytes
+}
+```
+
+With padding the total is roughly 96 bytes. A function with 16 registers allocates 1.5 KB of register file per frame. A 1000-deep recursion is 1.5 MB of register state. The numeric path in `OpAdd_II` (MEP-19) does `regs[a] = Value{Tag: ValueInt, Int: regs[b].Int + regs[c].Int}` which writes 96 bytes per opcode, half of which are unused.
+
+The fix is mechanical: collapse the payload into a single 8-byte slot and use a separate slot for the reference type. This is what nearly every Go-hosted VM in production does (Tengo, Starlark-Go, Risor, Yaegi). It is also what Crafting Interpreters does in its second-half optimizations once the tagged-union version is bottlenecked ([CI-Optimization]).
+
+## Specification
+
+### New `Value` layout
+
+```go
+type Value struct {
+    Tag uint8       // 0..15 used today; uint8 leaves room
+    _   [7]byte     // padding so num is 8-byte aligned
+    Num uint64      // int / float (via math.Float64bits) / bool / smaller refs as index
+    Ref any         // string, list, map, func, BigInt, BigRat — only set for reference tags
+}
+```
+
+Total: 24 bytes. Numeric paths read only `Tag` and `Num`. Reference paths read all three.
+
+Encoding by tag:
+
+- `ValueNull`: all zero.
+- `ValueBool`: `Num = 0 | 1`.
+- `ValueInt`: `Num = uint64(intValue)`. Use signed/unsigned reinterpret on read.
+- `ValueFloat`: `Num = math.Float64bits(f)`.
+- `ValueStr`: `Ref = string`. (String headers are 16 bytes; storing them in `Ref` via `any` boxes the header but not the string body.)
+- `ValueList`: `Ref = []Value`.
+- `ValueMap`: `Ref = map[string]Value` or the future map-of-Values type.
+- `ValueFunc`: `Ref = *Closure` (concrete type, not interface; see below).
+- `ValueBigInt`: `Ref = *big.Int`.
+- `ValueBigRat`: `Ref = *big.Rat`.
+
+The `Ref any` slot is unavoidable because Go's GC needs to scan the reference when it is live; `unsafe.Pointer` would defeat scanning, and `uintptr` is a non-pointer to the GC and unsafe to keep across a collection. Boxing the *header* (16 bytes for `string`, 24 bytes for `[]Value`) into `any` is a small constant cost, accepted as the price of staying GC-friendly.
+
+### Why not NaN boxing in Go
+
+NaN boxing packs the entire value into a single 64-bit double. It is the right answer in C/C++/Rust where you control GC and pointer scanning. In Go, the issue is that the GC scans only words typed as pointers. A `uint64` that happens to hold a pointer in its low 48 bits is invisible to the collector: the pointer is a root that the GC will not follow, so the pointed-to object may be collected while live, and the pointer may be torn at a copying-GC moment.
+
+There is a workaround (parallel root tables) but the bookkeeping cost is roughly equal to the savings from the tighter layout. Tengo, Starlark-Go, and the Go port of Lox all reach the same conclusion: discriminated struct, no bit-stealing.
+
+The remaining numeric-density win NaN boxing offers (single 64-bit register for the whole value) is not realizable in Go anyway because the calling convention passes structs piecewise. So even if NaN-boxed `Value` were possible, the Go compiler would not pass it in a single register.
+
+### Frame and register pooling
+
+`frame` and the register slab `regs []Value` are allocated per call today. Recursion and deep query plans churn the allocator. The fix is a per-VM `sync.Pool` for `*frame` and a per-size pool for `[]Value` (powers of two: 4, 8, 16, 32, 64, 128, 256, 512).
+
+```go
+type VM struct {
+    framePool sync.Pool             // *frame
+    regsPools [10]sync.Pool         // []Value by capacity bucket
+    // ...
+}
+```
+
+On call entry: pop a `*frame` from the pool, pop a `[]Value` of the appropriate bucket, attach to the frame. On return: zero the registers (via `runtime/internal/memclr` or a plain loop), push back to the pools. Zeroing is required so the GC does not see stale pointers; modern Go has `clear()` in the standard library since 1.21 for this exact use case.
+
+The pool design is well-trodden in Go networking (`bytes.Buffer` pools, HTTP request pools). The pitfall in VM use is that pooled slices can be retained longer than expected if the user keeps a closure reference; the rule is that the VM never hands out pool-backed slices to user code, only to internal frame state.
+
+### Numeric path allocation audit
+
+The combined MEP-18 Phase A + MEP-19 quickening + MEP-20 layout target is: zero allocations per iteration of `iter_sum` and `fib`. This is a testable property; add `-benchmem` to the bench harness from MEP-17 and assert `allocs/op == 0` for those two benchmarks in CI.
+
+The audit walks every handler in the quickened numeric path:
+
+- `OpAdd_II`: reads two `Value{Tag, Num}`, writes one. No allocation.
+- `OpLess_II`: reads two, writes one bool `Value`. No allocation.
+- `OpJumpIfFalse`: reads one, branches. No allocation.
+- Loop back: no allocation.
+
+If any of these allocate, the test fails. The `any`-typed `Ref` field on the result `Value` is set to `nil` for numeric results and Go knows not to escape; the test pins the contract.
+
+### Reference path: closure boxing
+
+Today `OpMakeClosure` allocates an `interface{}` holding `*closure`. Concretizing `Ref` to `*Closure` (a defined type, not `any`) for the `ValueFunc` case removes the interface box. The other reference tags (string, list, map, BigInt, BigRat) all keep `any` because they hold heterogeneous concrete types; the boxing cost there is per-reference, not per-arithmetic-op, and the gain is small.
+
+A future MEP may introduce a typed reference union (`type RefValue { Str string; List []Value; ... }`) to remove the last `any` cost. That requires touching every reference handler and is left for a follow-up.
+
+### Interaction with MEP-15 effects, MEP-16 null safety
+
+`Option<T>` (MEP-16) reuses the existing `ValueNull` tag for the `None` case. No new tag is needed. The size of `Value` is unchanged by MEP-16.
+
+Effect labels (MEP-15) live on `FuncType`, not on `Value`. The new layout does not affect effects.
+
+### Benchmarks gating the change
+
+This MEP lands in three PRs, each with MEP-17 numbers:
+
+1. **Value layout flip.** Just the struct rewrite plus the call-site updates. Expected: 1.1-1.3x on the geometric mean, mostly from smaller `memmove` per register move.
+2. **Frame and register pooling.** Expected: 1.05-1.15x and a measurable drop in `allocs/op` on recursive benchmarks.
+3. **`*Closure` concretization.** Expected: 1.02-1.05x but most visible on `hof_map`.
+
+A regression on any benchmark beyond MEP-17's 3% budget blocks the PR.
+
+## Status at a glance
+
+| Item                                                            | Status   |
+|-----------------------------------------------------------------|----------|
+| `Value` struct narrowed to `Tag + Num + Ref` (24 bytes)         | proposed |
+| Numeric path proven allocation-free on `iter_sum` and `fib`     | proposed |
+| Frame pool (`sync.Pool[*frame]`)                                | proposed |
+| Register slab pool (10 size buckets, powers of two)             | proposed |
+| `Ref` concretized to `*Closure` for `ValueFunc`                 | proposed |
+| Other reference tags remain `any` (small per-ref cost accepted) | proposed |
+| NaN boxing                                                      | rejected |
+| Tagged pointers / unsafe payload                                | rejected |
+
+## Risks
+
+- **Slice retention from pools.** If a user-visible closure captures a pooled slice, recycling it back to the pool produces aliasing. Mitigation: never hand pool-backed memory to user code. Audit closure capture paths.
+- **Race in the pools.** `sync.Pool` is safe; the per-bucket `regsPools` is an array of `sync.Pool`s, also safe. No new concurrency story.
+- **GC pressure shift.** Pool reuse trades allocator load for retention; if the working set grows the pool keeps slabs alive across GC cycles. Mitigation: cap each pool's per-P slab count via a custom wrapper if `pprof` shows pool growth.
+
+## Non-goals
+
+- **No NaN boxing.** Permanently rejected for Mochi for the reasons above.
+- **No custom GC.** Go's GC is sufficient; the audit is about minimizing allocation, not replacing the collector.
+- **No new opcodes.** Layout change only.
+
+## Implementation notes
+
+Sequencing matters: the layout flip (PR 1) is a big mechanical change and conflicts with most other VM PRs. Land it first; other work rebases. The pooling PR (PR 2) is small and lands second. The `*Closure` PR (PR 3) is contingent on PR 1.
+
+Total engineering cost: three engineer-weeks, dominated by the mechanical updates to handler call sites and tests.
+
+## References
+
+- [CI-Optimization] Bob Nystrom, *Crafting Interpreters: Optimization.* https://craftinginterpreters.com/optimization.html
+- [Wren-perf] Bob Nystrom, *Wren Performance.* https://wren.io/performance.html (NaN boxing rationale)
+- [Go-Pool] Go standard library, *sync.Pool.* https://pkg.go.dev/sync#Pool
+- [Go-Clear] Go 1.21 release notes, *clear builtin.* https://go.dev/doc/go1.21
+- [Tengo] *Tengo: A fast script language for Go.* https://github.com/d5/tengo (a Go-hosted VM that uses a discriminated Value struct)
+- [Starlark-Go] Bazel team, *Starlark in Go.* https://github.com/google/starlark-go
+- [Risor] *Risor: A fast and flexible scripting language for Go.* https://github.com/risor-io/risor

--- a/website/docs/mep/mep-0021.md
+++ b/website/docs/mep/mep-0021.md
@@ -1,0 +1,157 @@
+---
+mep: 21
+title: VM Conformance and Differential Testing
+author: Mochi core
+status: Draft
+type: Standards Track
+created: 2026-05-16
+sidebar_position: 21
+sidebar_label: MEP 21. VM Conformance
+description: Beyond golden files, fuzz the bytecode compiler, differential-test interpreter against constant folding, and prove laws via property tests so MEP-18 through MEP-22 cannot regress correctness.
+---
+
+# MEP 21. VM Conformance and Differential Testing
+
+| Field    | Value                                  |
+|----------|----------------------------------------|
+| MEP      | 21                                     |
+| Title    | VM Conformance and Differential Testing |
+| Author   | Mochi core                             |
+| Status   | Draft                                  |
+| Type     | Standards Track                        |
+| Created  | 2026-05-16                             |
+
+## Abstract
+
+MEPs 18 through 22 propose changes to dispatch, specialization, value representation, and (eventually) code generation. Each change is a chance to introduce a correctness regression that the existing golden suite misses because the regression only fires on inputs nobody wrote a fixture for. This MEP adds three correctness layers that close the gap without requiring a fixture for every bug: differential execution between the interpreter and the constant folder, property-based testing for laws the VM must obey, and Go's native `testing.F` fuzzer for the bytecode compiler.
+
+These layers are independent of any of the perf MEPs; they harden the VM regardless of which optimization lands next. They also enable future MEPs (notably the copy-and-patch baseline JIT in MEP-22) to be tested against an oracle: the interpreter is the reference, the JIT is the candidate, and a differential harness compares outputs over a corpus.
+
+## Motivation
+
+The Mochi conformance suite today is two things: golden files (`tests/vm/valid/*.mochi` + `.out` pairs) and the Rosetta task corpus (`tests/rosetta/x/Mochi/`). Both are *example-based*: a fixture passes if its output matches the recorded `.out`. This catches the bugs someone wrote a fixture for. It misses the rest.
+
+The patterns this MEP closes are well-known:
+
+1. **Optimizer-introduced divergence.** A constant-folding pass that mis-evaluates `1e308 * 10` produces `+Inf` while the runtime evaluates `+Inf` correctly. The golden test passes if `1e308 * 10` is never in a fixture. The differential harness catches it because it asks: "is the folded answer equal to the unfolded answer for every expression in the corpus?"
+2. **Quickened opcode bugs.** MEP-19 introduces `OpAdd_II`. If the deopt path is wrong on overflow, the bug shows up only on overflowing inputs, which goldens may not exercise. A property test on `OpAdd` (associative-modulo-overflow, commutative) catches it.
+3. **Bytecode compiler crashes.** A malformed input that the parser accepts but the compiler panics on. The Go fuzzer can find these in minutes given a seed corpus.
+
+Each layer below corresponds to one of these.
+
+## Specification
+
+### Layer 1: differential execution (folder vs interpreter)
+
+The Mochi compiler does constant folding in `runtime/vm/constfold.go`. The interpreter evaluates the same expressions at runtime. They must agree.
+
+A new test harness, `runtime/vm/diff/`, walks every expression in every program in the bench suite (MEP-17), the golden suite, and the Rosetta corpus. For each pure expression (no `! io`, no `! fs`, etc., per MEP-15 effect inference) it:
+
+1. Evaluates the expression at compile time via `constfold.Eval`.
+2. Compiles the expression to bytecode with folding disabled and evaluates at runtime via the interpreter.
+3. Asserts the two values are `equal`, where `equal` follows Mochi's structural equality.
+
+A divergence is a P1 bug. The test fails the CI run.
+
+Pure expressions are the only ones in scope because impure expressions are non-deterministic by definition (`now()`, `fetch(...)`). MEP-15's `Effects.IsEmpty()` is the gate: if the expression is pure, the two evaluators must agree.
+
+This catches the entire class of "the optimizer rewrites this to a value the interpreter does not produce" bugs. It is a one-time investment with permanent value; every optimization MEP gets free oracle testing.
+
+### Layer 2: property-based testing
+
+A new package `runtime/vm/prop/` defines properties that the VM must obey across every input. Properties express *laws*, not examples. Implementation uses [gopter] or hand-written quickcheck-style generators (gopter is preferred for breadth).
+
+The starter law set:
+
+- **Arithmetic associativity over `int`:** `(a + b) + c == a + (b + c)` for all int `a, b, c`. Modulo overflow, which Mochi defines per MEP (TODO: cite the right MEP) as wrapping; the property is on the wrapped result.
+- **Arithmetic commutativity over `int` and `float`:** `a + b == b + a`. Caveat for float: NaN. The property excludes NaN inputs.
+- **Equality reflexivity:** `x == x` for every value not containing NaN.
+- **`len` of `append`:** `len(append(xs, y)) == len(xs) + 1`.
+- **Map round-trip:** `m[k] = v; m[k] == v` for any key `k` and value `v`.
+- **Option unwrap-after-guard:** for any `Option<T>`, if `o != none` then `o!` returns the wrapped value (MEP-16).
+- **Pure expression idempotency:** for any pure expression `e`, `e == e` evaluated twice.
+- **Effect-set monotonicity (MEP-15):** for any function `f`, `inferredEffects(f) ⊆ declaredEffects(f)` whenever a declaration is present.
+
+Each property runs a few thousand random inputs by default; CI runs more (configurable via `MOCHI_PROP_N`). A failed property prints the smallest counterexample (shrinking).
+
+Properties are not fixtures. They do not pin a specific output; they pin a relationship. This is the right tool for the optimizer-vs-interpreter agreement question and for any invariant the type system promises.
+
+### Layer 3: bytecode-compiler fuzzing
+
+Go's native `testing.F` runs fuzzers in CI ([Go-Fuzz]). A new file `runtime/vm/fuzz_test.go` defines:
+
+```go
+func FuzzCompile(f *testing.F) {
+    seedFromCorpus(f, "tests/vm/valid")
+    f.Fuzz(func(t *testing.T, src string) {
+        prog, err := parser.ParseString(src)
+        if err != nil {
+            return
+        }
+        defer func() { recover() }() // panics are the bugs we hunt
+        _, _ = vm.Compile(prog, nil)
+    })
+}
+```
+
+The seed corpus is the existing golden inputs (paths walked at fuzz init). The fuzzer mutates them. Any panic in `vm.Compile` is a bug; the fuzzer minimizes and reports.
+
+A second fuzzer, `FuzzRun`, takes the compiled program and runs it under a CPU/memory budget. The harness uses `runtime.SetFinalizer` and a hard wall-clock cap (5s) to detect non-termination. Any panic, infinite loop, or memory blowup is a bug.
+
+CI runs the fuzzers for a fixed time budget per PR (default 60s each). Nightly runs extend to 30 minutes. Found crashers are checked into `runtime/vm/fuzz_corpus/` so they become permanent regression tests.
+
+### Layer 4: oracle harness for MEP-22
+
+The copy-and-patch JIT in MEP-22 will need a differential harness against the interpreter. This MEP defines that harness ahead of time so MEP-22 ships behind it.
+
+The shape: for every program in the test corpus, run under the interpreter and under the JIT, compare outputs. Any divergence is a P1 bug. The interpreter is canonical.
+
+The harness is gated by a build tag (`-tags jit`) and is a no-op until MEP-22 ships. Its skeleton lands in this MEP so MEP-22 has nothing to design about correctness, only to implement.
+
+### Coverage measurement
+
+A new CI step runs `go test -cover ./runtime/vm/...` and reports the line coverage delta per PR. The goal is not a number to chase; it is to make uncovered handlers visible. A new opcode that lands without a test prints as uncovered and is rejected at review.
+
+## Status at a glance
+
+| Item                                                            | Status   |
+|-----------------------------------------------------------------|----------|
+| Differential exec: folder vs interpreter on pure expressions    | proposed |
+| Property suite: arithmetic, equality, len, map, option laws     | proposed |
+| Property suite: shrinkable counterexamples                      | proposed |
+| Fuzzer: `FuzzCompile` over parser corpus                        | proposed |
+| Fuzzer: `FuzzRun` with wall-clock and memory budget             | proposed |
+| Crasher corpus checked in under `runtime/vm/fuzz_corpus/`       | proposed |
+| Coverage delta reported in CI                                   | proposed |
+| Oracle harness skeleton for MEP-22                              | proposed |
+
+## Risks
+
+- **Flaky properties on float arithmetic.** Floating-point laws fail in edge cases (NaN, signed zero, denormals). The property generators must exclude these inputs explicitly; failures here are usually generator bugs, not VM bugs.
+- **Fuzzer noise.** Fuzzers find parser-acceptable-but-semantically-rejected inputs. The fuzzer counts a panic as a bug; it does *not* count a type error as a bug. The harness handles type errors as expected.
+- **CI time.** A 60s fuzz budget per PR is cheap. A 30-minute nightly run is fine. If the property suite grows beyond ~5 minutes total, split into nightly.
+- **False oracles.** The differential harness assumes the interpreter is correct. A bug in the interpreter that the folder also has would be invisible. The property suite catches the cases the folder cannot.
+
+## Non-goals
+
+- **No formal verification.** No proof of VM correctness against a denotational semantics. The combination of differential testing, properties, and fuzzing is enough to catch regressions; full verification is decades of work and not on the table.
+- **No metamorphic testing.** A future MEP may add metamorphic relations (e.g. "adding `var _ = 1` to any program should not change its output") but the three layers here are sufficient for the perf MEPs that motivate this work.
+
+## Implementation notes
+
+Layer 1 (differential exec) is the highest-value, lowest-cost item: a few hundred lines of Go that catch the entire optimizer-divergence class. Land it first.
+
+Layer 2 (properties) is the largest open-ended investment. Start with the eight laws above; add more as bugs are found. The discipline is that every fixed VM bug ships with the property that would have caught it.
+
+Layer 3 (fuzzing) is one PR; the seed corpus is what makes it effective. The corpus is the union of `tests/vm/valid/`, `tests/rosetta/x/Mochi/`, and the bench suite from MEP-17. Re-seed nightly from the latest corpus.
+
+Layer 4 (JIT oracle skeleton) is plumbing only; the real value materializes when MEP-22 ships.
+
+## References
+
+- [Go-Fuzz] *Tutorial: Getting started with fuzzing in Go.* https://go.dev/doc/tutorial/fuzz
+- [gopter] *gopter, a property-based testing library for Go.* https://github.com/leanovate/gopter
+- [Claessen-QC] Koen Claessen, John Hughes, *QuickCheck: A Lightweight Tool for Random Testing of Haskell Programs.* ICFP 2000.
+- [Csmith] Xuejun Yang et al., *Finding and Understanding Bugs in C Compilers.* PLDI 2011 (differential testing as bug-finding method).
+- [Yarpgen] *Yarpgen: a random C/C++ program generator.* https://github.com/intel/yarpgen
+- [PEP-659] Mark Shannon, *PEP 659.* https://peps.python.org/pep-0659/ (the deopt model and why it must be testable)

--- a/website/docs/mep/mep-0022.md
+++ b/website/docs/mep/mep-0022.md
@@ -1,0 +1,126 @@
+---
+mep: 22
+title: Baseline JIT via Copy-and-Patch (Deferred)
+author: Mochi core
+status: Deferred
+type: Informational
+created: 2026-05-16
+sidebar_position: 22
+sidebar_label: MEP 22. Copy-and-Patch JIT
+description: A non-optimizing baseline JIT built on copy-and-patch compilation, planned as the long-term tier above the interpreter once MEP-18 through MEP-21 are exhausted.
+---
+
+# MEP 22. Baseline JIT via Copy-and-Patch (Deferred)
+
+| Field    | Value                                  |
+|----------|----------------------------------------|
+| MEP      | 22                                     |
+| Title    | Baseline JIT via Copy-and-Patch        |
+| Author   | Mochi core                             |
+| Status   | Deferred                               |
+| Type     | Informational                          |
+| Created  | 2026-05-16                             |
+
+## Abstract
+
+This MEP describes Mochi's planned baseline JIT and explicitly defers its implementation. The point of writing it now is to make the design space visible to readers of MEPs 17 through 21, so they can see *why* the interpreter MEPs are sufficient for the next 18-24 months and *which* JIT technology Mochi will adopt when it becomes worth the engineering cost.
+
+The chosen technology is **copy-and-patch compilation** (Xu and Kjolstad, OOPSLA 2021, [Copy-Patch]), the same approach the experimental CPython 3.13+ JIT uses ([PEP-744]). Copy-and-patch generates code by `memcpy`-ing pre-compiled "stencils" into a code buffer and patching the immediates. There is no register allocator, no instruction selector, and no optimizer at runtime; all of that work happens at build time when the stencils are produced by LLVM. The runtime is a few hundred lines of Go.
+
+This is a *baseline* tier. The interpreter remains the cold tier (MEPs 18 to 20). A function tiers up to the JIT after a hot threshold; the JIT generates code that performs the same operations the interpreter would. It does not specialize, inline, or eliminate guards. That work is reserved for a hypothetical optimizing tier (a separate, future MEP), which is not currently planned.
+
+## Motivation
+
+Three questions decide whether to add a JIT:
+
+1. *Has the interpreter been pushed to its limit?* If not, a JIT is premature; interpreter wins are cheaper per unit speedup. Mochi has not approached this limit. MEPs 18 (dispatch), 19 (specialization + ICs), and 20 (value layout) are projected to give cumulative 2-4x speedups before a JIT is necessary.
+2. *Are workloads long-running enough to amortize compile cost?* Mochi targets scripting, agent loops, and AI tools. Some workloads are short-lived (CLI invocations); some are long-lived (agent reactors, query servers). For the long-lived case, a JIT is justified eventually. For the short-lived case, compile latency dominates and a JIT must keep compile cost low.
+3. *Can the team afford the maintenance cost?* Optimizing JITs (TurboFan, Maglev, LuaJIT) are multi-person-year investments. Baseline JITs (Sparkplug, JSC LLInt, copy-and-patch) are weeks-to-months. Mochi can plan for the second class but not the first.
+
+Copy-and-patch hits all three constraints: it is cheaper to build than a register allocator, its compile cost is bounded by `memcpy` speed (Xu and Kjolstad report 1-2 GB/s on commodity hardware), and it gives meaningful speedups (2-5x over an interpreter at near-zero startup cost). The CPython team chose it for the same combination of reasons ([PEP-744]).
+
+The alternative paths considered and rejected for Mochi:
+
+- **Trace-based JIT (LuaJIT).** Highest ceiling, multi-year build, requires deopt/OSR infrastructure and a custom backend. Rejected because the ceiling is unreachable given engineering capacity, and the interpreter MEPs already capture most of the value.
+- **Method-based optimizing JIT (V8 TurboFan).** Higher ceiling than baseline, much more complex than copy-and-patch. Rejected for the same reason.
+- **Sparkplug-style single-pass codegen.** Comparable speedup to copy-and-patch but requires writing an assembler for each target ISA. Copy-and-patch sidesteps this by reusing LLVM at build time.
+- **Truffle / partial evaluation.** Requires a Graal-equivalent in Go, which does not exist.
+
+## Specification (sketch)
+
+The specification is intentionally a sketch. A real proposal will write the details after MEPs 18-21 land and the bench harness shows where the interpreter ceiling is.
+
+### Build-time stencil generation
+
+For each `Op` in the bytecode set, a hand-written C function implements the opcode's behavior. The C is compiled by LLVM with specific calling conventions and PIC settings. A custom build script extracts each function's object code into a *stencil* of bytes plus a relocation table. Stencils are checked into `runtime/vm/jit/stencils/<arch>/`. The build script runs once per release; the runtime never invokes LLVM.
+
+The stencil set is large but mechanical: roughly one stencil per opcode per type-specialization variant. For Mochi's 107 + ~32 quickened opcodes, that is ~150 stencils per architecture (x86_64, arm64). Stencil compile time at the LLVM step is in minutes; the artifacts are byte arrays in the repo.
+
+### Runtime code generation
+
+When a function tiers up:
+
+1. Allocate an executable page via `syscall.Mmap` with `PROT_EXEC` (or `VirtualAlloc` with `PAGE_EXECUTE_READWRITE` on Windows).
+2. For each instruction in the function, `memcpy` the matching stencil into the page.
+3. Apply relocations: patch immediates (register offsets, constants, branch targets) into the copied stencil.
+4. Mark the page executable and read-only via `mprotect(PROT_READ|PROT_EXEC)` (W^X discipline).
+5. Update the function's entry slot to point at the generated code instead of the interpreter trampoline.
+
+Code generation cost is O(instruction count) `memcpy`s plus the patches. On a 1000-instruction function it is well under a millisecond. The trade-off is that the generated code is roughly interpreter-equivalent: no register allocation, each opcode is its own self-contained block with stack-passed operands.
+
+### Tier-up heuristic
+
+Functions tier up after their entry counter exceeds a threshold (initial proposal: 10,000 calls). The counter lives on the `Function` struct and increments on entry. When it crosses the threshold, the VM enqueues the function for JIT compilation; subsequent calls run the JITted code.
+
+The counter and tier-up logic interact with MEP-19 quickening: quickened bytecode produces better stencils (`OpAdd_II` is a tighter stencil than `OpAdd`). The JIT consumes the quickened bytecode after the function has warmed up in the interpreter. This is the same staging V8 uses (Ignition warmup feeds Sparkplug).
+
+### Deoptimization
+
+Copy-and-patch JIT code can deoptimize back to the interpreter at any instruction boundary because the stack frame layout is identical to the interpreter frame. (This is the Sparkplug trick: keep frames compatible, no on-stack replacement gymnastics.) When a quickened type-check fails inside generated code, control returns to the interpreter at the same `ip`, which re-quickens or stays generic. Mochi inherits this design choice directly from Sparkplug ([V8-Sparkplug]).
+
+### Oracle harness
+
+MEP-21 Layer 4 provides the differential harness that compares JIT output to interpreter output across the test corpus. Any divergence is a P1 bug. This is the *only* correctness mechanism the JIT relies on; there is no separate JIT test suite, only the interpreter suite run twice (once cold, once after tier-up).
+
+### Cross-platform notes
+
+- **x86_64 Linux/macOS:** straightforward `mmap`+`mprotect` flow.
+- **arm64 macOS:** Apple Silicon requires `MAP_JIT` and per-thread `pthread_jit_write_protect_np` calls. The flow is well-documented in the JSC and v8 source.
+- **Windows:** `VirtualAlloc` with `PAGE_EXECUTE_READWRITE` then `VirtualProtect` to drop write. CFG / hardware-enforced stack protection may need carve-outs.
+- **Other Go targets:** The JIT ships disabled by default; the interpreter remains the only required path. Adding a target is one architecture's worth of stencils.
+
+### Build-tag gate
+
+The JIT is gated behind `-tags jit`. Default builds use the interpreter only. This means the JIT cannot break a default build, and a user can opt in if they have a long-running workload that benefits.
+
+## Why this is deferred
+
+The interpreter MEPs (18, 19, 20) are projected to deliver:
+
+- MEP-18 (dispatch): 1.5-2x geometric mean on the bench suite.
+- MEP-19 (specialization + ICs): another 1.5-2x on type-stable code.
+- MEP-20 (value layout): another 1.2-1.5x, mostly from reduced allocation.
+
+Compounded, that is 2.7x to 6x without leaving the interpreter. Real-world dynamic-language interpreters in this performance class (CPython 3.13, Wren, the LuaJIT interpreter) are within a small constant factor of a baseline JIT for typical workloads.
+
+The decision to start the JIT is data-driven: once the bench suite from MEP-17 shows interpreter improvements plateauing at less than 5% per MEP, and at least one production Mochi workload has measurable headroom against the interpreter ceiling, this MEP gets revisited and promoted from Deferred to Draft.
+
+## Open questions for the future draft
+
+- **Stencil generator's place in the build.** Is it a Go `go:generate` step or a separate make target? Which LLVM version is pinned? How are stencils versioned against opcode-set changes?
+- **Code-cache eviction.** The current design assumes JIT code lives as long as the function. Long-running agent processes that load many functions may need an LRU eviction policy on the code cache.
+- **Interaction with future concurrency.** A goroutine-parallel VM (not currently planned) would need per-goroutine entry counters and JIT-state-aware tier-up.
+- **Comparative numbers.** Once a prototype exists, what is the speedup over MEP-18+19+20? If less than 1.5x, the JIT is not worth shipping. If more than 3x, it justifies a follow-up optimizing tier.
+- **Safety story for `unsafe.Pointer` and W^X.** Go is a memory-safe language; a JIT that writes executable pages is by definition outside that safety boundary. The code cache must be the only place where Mochi gives that up, and the boundary must be documented.
+
+## References
+
+- [Copy-Patch] Haoran Xu, Fredrik Kjolstad, *Copy-and-Patch Compilation: A fast compilation algorithm for high-level languages and bytecode.* OOPSLA 2021. https://arxiv.org/abs/2011.13127
+- [PEP-744] Brandt Bucher, *PEP 744: JIT Compilation.* https://peps.python.org/pep-0744/
+- [V8-Sparkplug] Leszek Swirski, *Sparkplug: a non-optimizing JavaScript compiler.* https://v8.dev/blog/sparkplug
+- [V8-Maglev] V8 team, *Maglev: V8's Fastest Optimizing JIT.* https://v8.dev/blog/maglev
+- [JSC-LLInt] WebKit team, *Introducing the LLInt: the WebKit JavaScriptCore Low-Level Interpreter.* https://webkit.org/blog/189/
+- [YJIT] Maxime Chevalier-Boisvert et al., *YJIT: A Basic Block Versioning JIT Compiler for Ruby.* MPLR 2023.
+- [Deegen] Haoran Xu et al., *Deegen: A high-performance language-VM generator from a declarative spec.* PLDI 2024.
+- [Truffle] Thomas Würthinger et al., *One VM to rule them all.* Onward! 2013.
+- [Hölzle-Deopt] Urs Hölzle, Craig Chambers, David Ungar, *Debugging Optimized Code with Dynamic Deoptimization.* PLDI 1992 (deopt foundations).

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -101,6 +101,20 @@ const sidebars = {
         'mep/mep-0016',
       ],
     },
+    {
+      label: 'VM & Runtime',
+      type: 'category',
+      className: 'sidebar-heading',
+      collapsed: false,
+      items: [
+        'mep/mep-0017',
+        'mep/mep-0018',
+        'mep/mep-0019',
+        'mep/mep-0020',
+        'mep/mep-0021',
+        'mep/mep-0022',
+      ],
+    },
   ],
 };
 

--- a/website/src/data/meps.json
+++ b/website/src/data/meps.json
@@ -134,5 +134,53 @@
     "type": "Standards Track",
     "description": "Total option discipline with no force unwrap, flow narrowing, safe-call and coalesce operators, and a no-panic guarantee.",
     "slug": "/docs/mep/mep-0016"
+  },
+  {
+    "number": 17,
+    "title": "VM Performance Methodology and Baseline",
+    "status": "Draft",
+    "type": "Process",
+    "description": "How Mochi measures, reports, and gates VM performance changes, with a reference benchmark suite and a regression budget.",
+    "slug": "/docs/mep/mep-0017"
+  },
+  {
+    "number": 18,
+    "title": "Bytecode Dispatch in a Go-Hosted VM",
+    "status": "Draft",
+    "type": "Standards Track",
+    "description": "What dispatch techniques work for the Mochi VM under the constraints of the Go runtime, with a concrete plan for the next 18 months.",
+    "slug": "/docs/mep/mep-0018"
+  },
+  {
+    "number": 19,
+    "title": "Adaptive Specialization and Inline Caches",
+    "status": "Draft",
+    "type": "Standards Track",
+    "description": "Quickening generic opcodes into typed variants on first observation, plus monomorphic and polymorphic inline caches for the few remaining dynamic call sites.",
+    "slug": "/docs/mep/mep-0019"
+  },
+  {
+    "number": 20,
+    "title": "Value Representation and Allocation Discipline",
+    "status": "Draft",
+    "type": "Standards Track",
+    "description": "A tighter Value struct, sync.Pool for frames and slabs, and an escape audit on the hot path of the Mochi VM.",
+    "slug": "/docs/mep/mep-0020"
+  },
+  {
+    "number": 21,
+    "title": "VM Conformance and Differential Testing",
+    "status": "Draft",
+    "type": "Standards Track",
+    "description": "Beyond golden files, fuzz the bytecode compiler, differential-test interpreter against constant folding, and prove laws via property tests so MEP-18 through MEP-22 cannot regress correctness.",
+    "slug": "/docs/mep/mep-0021"
+  },
+  {
+    "number": 22,
+    "title": "Baseline JIT via Copy-and-Patch (Deferred)",
+    "status": "Deferred",
+    "type": "Informational",
+    "description": "A non-optimizing baseline JIT built on copy-and-patch compilation, planned as the long-term tier above the interpreter once MEP-18 through MEP-21 are exhausted.",
+    "slug": "/docs/mep/mep-0022"
   }
 ]


### PR DESCRIPTION
Closes #21458.

Draft six MEPs covering Mochi VM correctness and performance, designed as a coherent series so the relationships between methodology, dispatch, specialization, value representation, conformance, and JIT are visible in one read.

## The series

| MEP | Title | Type | Status |
|-----|-------|------|--------|
| 17 | VM Performance Methodology and Baseline | Process | Draft |
| 18 | Bytecode Dispatch in a Go-Hosted VM | Standards Track | Draft |
| 19 | Adaptive Specialization and Inline Caches | Standards Track | Draft |
| 20 | Value Representation and Allocation Discipline | Standards Track | Draft |
| 21 | VM Conformance and Differential Testing | Standards Track | Draft |
| 22 | Baseline JIT via Copy-and-Patch | Informational | Deferred |

## Design through-line

- **MEP-17** ships the bench harness, the ten-program reference suite, and the regression budget. Every subsequent MEP reports `benchstat` numbers against it.
- **MEPs 18-20** are interpreter improvements, sequenced so each unlocks the next. Dispatch (18) introduces the bytecode rewriting slot that specialization (19) needs. Value layout (20) makes the numeric paths from 19 allocation-free.
- **MEP-21** is correctness. Differential testing (folder vs interpreter), property tests, native fuzzers. Hardens the VM regardless of which perf MEP lands next; lays the oracle for MEP-22.
- **MEP-22** is the JIT, planted as a design stake and deferred until interpreter wins plateau. Copy-and-patch (Xu/Kjolstad OOPSLA 2021, also chosen by CPython 3.13+) is the chosen technology because of low engineering cost and near-zero compile latency in a Go host.

## Research grounding

Each MEP cites the work it builds on with concrete measured speedups from the literature. Sources include: Wren perf page, Crafting Interpreters (clox), LuaJIT 2 SSA-IR docs, V8 Sparkplug / Maglev / Hidden Classes posts, PEP 659, PEP 744, Hölzle/Chambers/Ungar 1991 (PIC), Ertl/Gregg 2003 (efficient interpreters), Copy-and-Patch (OOPSLA 2021), Deegen (PLDI 2024), YJIT (MPLR 2023), Truffle / Onward! 2013.

## What this PR does not do

- No runtime code changes. The Mochi VM continues to work exactly as it does today.
- No commitment to ship every MEP. The series is the *design space*; each implementation lands behind its own PR with `benchstat` numbers against MEP-17.

## Test plan
- [x] Sidebar updated with new "VM & Runtime" category
- [x] MEP-0000 catalog table extended with rows for 16-22 (also caught a missing row for 16)
- [x] `website/src/data/meps.json` regenerated via `node scripts/gen-meps.js` (23 entries total)
- [x] Frontmatter validated on all six files