### PR TITLE
mep-0005: close P18 (builtins substantively parametric)

### DIFF
--- a/website/docs/mep/mep-0005.md
+++ b/website/docs/mep/mep-0005.md
@@ -384,7 +384,7 @@ The following are concrete code-level defects against the rules above. Each is t
 
 **17. Closure return type is inferred without parameter types.** A lambda without annotations is typed at `(any, …) → any`. The strict rule requires either annotations or an enclosing expected type. Fix: gate unannotated lambdas on bidirectional checking ([MEP 12](/docs/mep/mep-0012)).
 
-**18. Builtins still declare `any` parameters.** `len`, `first`, `push`, etc. Replace with `∀α. ...α...` schemes. Gated on [MEP 12](/docs/mep/mep-0012).
+**18. Builtins still declare `any` parameters.** The shape-preserving collection builtins were retyped to `∀α. ...α...` schemes in the MEP-12.4 batch: `first` ([#21315](https://github.com/mochilang/mochi/pull/21315)), `distinct`, `keys`, `values` ([#21315](https://github.com/mochilang/mochi/pull/21315)), `push`, `append` ([#21333](https://github.com/mochilang/mochi/pull/21333)), `min`, `max`, `collect`, `concat`, `reduce` (same batch). **Status: substantively closed.** The remaining loose signatures (`reverse`, `len`, `count`, `exists`, `sum`) are sound but not parametric; tightening them needs row polymorphism or numeric bounds (a future MEP-12 extension), and `reverse` keeps its `(any) → any` declaration on purpose so the list-or-string discriminator in `checkBuiltinCall` still applies. The call-site post-processor in `types/check_expr.go` pins the static return shape for `reverse`, `keys`, and `values` even when the declared type is loose.
 
 **19. The `ExprType` / `ExprTypeHint` split duplicates list/map hint logic.** Should be a single bidirectional pass. Fix: collapse the two entry points and route the hint through the recursion.
 


### PR DESCRIPTION
## Summary
- Mark MEP-5 §Problem 18 substantively closed
- Doc-only change: notes which builtins were retyped in MEP-12.4 and why reverse intentionally stays loose

## Why
P18 audit against current code shows first/distinct/keys/values/push/append/min/max/collect/concat/reduce are all parametric (`∀α. ...α...`) since #21315 and #21333. The remaining loose signatures (reverse, len, count, exists, sum) are sound but want row polymorphism or numeric bounds to fully tighten.

Refs #21460, #21258