### PR TITLE
mep-0005: close P14 (query select projection is principal)

### DIFF
--- a/website/docs/mep/mep-0005.md
+++ b/website/docs/mep/mep-0005.md
@@ -376,7 +376,7 @@ The following are concrete code-level defects against the rules above. Each is t
 
 **13. `for x in source` for unknown source falls back to `x : any`.** Per the rules above, an unknown source is T022. Fixed in [#21265](https://github.com/mochilang/mochi/pull/21265).
 
-**14. `select r` in a query falls through to general expression inference.** Under the new rule the projection's type must be principal, not `any`. Fix: extract a query-select rule and remove the fall-through.
+**14. `select r` in a query falls through to general expression inference.** Under the new rule the projection's type must be principal, not `any`. **Status: closed.** `checkQueryExpr` in `types/check_expr.go` already calls `checkExpr` proper on the select expression and returns `ListType{Elem: selT}` (or the scalar aggregate result), so the projection is principal by construction. The original loose-`any` concern came from generic builtins returning `any`; that was sealed by MEP-10 A1 (Assignable routing on call arguments) and MEP-12.4 (parametric TypeVar signatures on `first`, `distinct`, `keys`, `values`, `push`, `append`, `min`, `max`, etc.). See [bb4f1d2c87](https://github.com/mochilang/mochi/commit/bb4f1d2c87) for the MEP-10 B6 close, which is the same closure for this row. The only `any`-typed projections that remain are user-declared `: any` returns, which are opt-in.
 
 **15. Exhaustiveness is not enforced.** Tracked by [MEP 13](/docs/mep/mep-0013). Without it, `Option` consumption is unsafe. Required for this MEP to be sound.
 


### PR DESCRIPTION
## Summary
- Audit MEP-5 §Problem 14 against current code
- Mark P14 closed: `checkQueryExpr` already produces a principal projection type
- Cross-reference the MEP-10 B6 close (bb4f1d2c87) which sealed the same loose-any source

## Why
P14's original text predates MEP-10 A1 and MEP-12.4. After those landed:
- Query select calls `checkExpr` proper on the projection
- Generic builtin returns are parametric, not `any`
- Only user-declared `: any` returns produce any-typed projections

Probes pass: `from x in [1,2,3] select x + 1` types as `list<int>`; `from x in [1,2,3] select x.unknown` raises T027 cleanly.

Refs #21464, #21258