### PR TITLE
mep-0005: close P6 (partial reads consistent)

### DIFF
--- a/website/docs/mep/mep-0005.md
+++ b/website/docs/mep/mep-0005.md
@@ -360,7 +360,7 @@ The following are concrete code-level defects against the rules above. Each is t
 
 **5. Match arms widen to `any` on disagreement.** The check rejects heterogeneous arms; the inferrer widens. Fixed in [#21267](https://github.com/mochilang/mochi/pull/21267).
 
-**6. `MapType` indexing producing `Option[V]` is inconsistent with other partial reads.** Struct field reads of an unknown name return `any`; query `select` of an unknown column does the same. The new rule is that partial reads return `Option`. Fix: rewrite the three loose paths.
+**6. `MapType` indexing producing `Option[V]` is inconsistent with other partial reads.** Struct field reads of an unknown name return `any`; query `select` of an unknown column does the same. The new rule is that partial reads return `Option`. **Status: closed.** All three paths are consistent now: struct field of unknown name raises T026 (a hard error, stronger than the proposed Option), map index of an absent key returns `Option[V]` via MEP-16 N1/N3, and a query `select x["k"]` propagates the option through the projection, yielding `list<Option<V>>` at the let-binding (verified with `let ys: list<int> = from x in xs select x["c"]` raising T008 because `[option[int]]` does not flow into `[int]`).
 
 **7. `nil` is a value of every type.** Several runtime entry points return Go `nil` for "missing", surfaced as `AnyType{}` to the user. The fix is to wrap them in `Option`/`Result` constructors at the runtime boundary; the inference rules above already forbid `nil`.
 


### PR DESCRIPTION
## Summary
- Audit MEP-5 §Problem 6 against current code
- Mark P6 closed: all three partial-read paths now consistent

## Why
- struct field unknown name → T026 hard error
- map index unknown key → `Option[V]` (MEP-16 N1/N3)
- query select wrapping a map index → `list<Option<V>>` propagated

Refs #21466, #21258