### PR TITLE
MEP-19: monomorphic call IC + OpIndex quickening (+ MEP-18 Phase C)

### DIFF
--- a/runtime/vm/bench/history/v0.11.0-mep19-callic-opindex.txt
+++ b/runtime/vm/bench/history/v0.11.0-mep19-callic-opindex.txt
@@ -1,0 +1,76 @@
+goos: darwin
+goarch: arm64
+pkg: mochi/runtime/vm/bench
+cpu: Apple M4
+BenchmarkVM_Fib-10                	      13	 107138872 ns/op	         2.961 heap-MB	        18.55 sys-MB	 364739465 total-B/op	364739465 B/op	  515558 allocs/op
+BenchmarkVM_Fib-10                	      12	  94403833 ns/op	         4.719 heap-MB	        18.55 sys-MB	 364739179 total-B/op	364739178 B/op	  515556 allocs/op
+BenchmarkVM_Fib-10                	      13	  88329288 ns/op	         4.625 heap-MB	        18.55 sys-MB	 364739095 total-B/op	364739095 B/op	  515555 allocs/op
+BenchmarkVM_Fib-10                	      13	  87275978 ns/op	         3.641 heap-MB	        18.55 sys-MB	 364739044 total-B/op	364739043 B/op	  515555 allocs/op
+BenchmarkVM_Fib-10                	      13	  89053747 ns/op	         3.930 heap-MB	        18.55 sys-MB	 364739831 total-B/op	364739831 B/op	  515558 allocs/op
+BenchmarkVM_Fib-10                	      13	  87575369 ns/op	         3.414 heap-MB	        18.55 sys-MB	 364739423 total-B/op	364739422 B/op	  515558 allocs/op
+BenchmarkVM_Fib-10                	      13	  85978337 ns/op	         3.430 heap-MB	        18.55 sys-MB	 364739113 total-B/op	364739112 B/op	  515556 allocs/op
+BenchmarkVM_Fib-10                	      13	  88621154 ns/op	         2.617 heap-MB	        18.55 sys-MB	 364739319 total-B/op	364739319 B/op	  515557 allocs/op
+BenchmarkVM_Fib-10                	      13	  93838542 ns/op	         3.109 heap-MB	        18.55 sys-MB	 364739216 total-B/op	364739216 B/op	  515557 allocs/op
+BenchmarkVM_Fib-10                	      13	  87936186 ns/op	         3.805 heap-MB	        18.55 sys-MB	 364739406 total-B/op	364739405 B/op	  515558 allocs/op
+BenchmarkVM_IterSum-10            	     747	   1519032 ns/op	         2.703 heap-MB	        18.55 sys-MB	      5389 total-B/op	    5389 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	     805	   1485472 ns/op	         2.984 heap-MB	        18.55 sys-MB	      5389 total-B/op	    5389 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	     808	   1555404 ns/op	         2.961 heap-MB	        18.55 sys-MB	      5388 total-B/op	    5388 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	     796	   1498689 ns/op	         2.906 heap-MB	        18.55 sys-MB	      5388 total-B/op	    5388 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	     802	   1508949 ns/op	         2.961 heap-MB	        18.55 sys-MB	      5389 total-B/op	    5389 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	     802	   1518375 ns/op	         2.961 heap-MB	        18.55 sys-MB	      5388 total-B/op	    5388 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	     804	   1560800 ns/op	         2.898 heap-MB	        18.55 sys-MB	      5388 total-B/op	    5387 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	     722	   1607329 ns/op	         2.586 heap-MB	        18.55 sys-MB	      5390 total-B/op	    5389 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	     790	   1485858 ns/op	         2.891 heap-MB	        18.55 sys-MB	      5389 total-B/op	    5389 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	     808	   1508700 ns/op	         2.992 heap-MB	        18.55 sys-MB	      5388 total-B/op	    5388 B/op	       8 allocs/op
+BenchmarkVM_MapGet-10             	     636	   1899022 ns/op	         4.484 heap-MB	        18.55 sys-MB	      9070 total-B/op	    9069 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     637	   2463306 ns/op	         4.539 heap-MB	        18.55 sys-MB	      9070 total-B/op	    9069 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     450	   2535575 ns/op	         2.914 heap-MB	        18.55 sys-MB	      9071 total-B/op	    9071 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     640	   2399457 ns/op	         4.562 heap-MB	        18.55 sys-MB	      9070 total-B/op	    9069 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     505	   2384147 ns/op	         3.359 heap-MB	        18.55 sys-MB	      9071 total-B/op	    9071 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     598	   1898473 ns/op	         4.070 heap-MB	        18.55 sys-MB	      9071 total-B/op	    9070 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     499	   2537882 ns/op	         3.172 heap-MB	        18.55 sys-MB	      9071 total-B/op	    9071 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     484	   2385055 ns/op	         2.984 heap-MB	        18.55 sys-MB	      9071 total-B/op	    9071 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     500	   2510472 ns/op	         3.156 heap-MB	        18.55 sys-MB	      9071 total-B/op	    9070 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     658	   1845395 ns/op	         4.531 heap-MB	        18.55 sys-MB	      9070 total-B/op	    9069 B/op	      11 allocs/op
+BenchmarkVM_ListBuild-10          	      13	  89395657 ns/op	         3.891 heap-MB	        23.05 sys-MB	 467745156 total-B/op	467745156 B/op	    4095 allocs/op
+BenchmarkVM_ListBuild-10          	      12	  90262823 ns/op	         4.758 heap-MB	        23.05 sys-MB	 467745374 total-B/op	467745374 B/op	    4097 allocs/op
+BenchmarkVM_ListBuild-10          	      13	  95103990 ns/op	         3.883 heap-MB	        23.05 sys-MB	 467745268 total-B/op	467745268 B/op	    4096 allocs/op
+BenchmarkVM_ListBuild-10          	      13	  91140837 ns/op	         2.570 heap-MB	        23.05 sys-MB	 467745165 total-B/op	467745164 B/op	    4095 allocs/op
+BenchmarkVM_ListBuild-10          	      13	  90915433 ns/op	         4.977 heap-MB	        23.05 sys-MB	 467745354 total-B/op	467745354 B/op	    4097 allocs/op
+BenchmarkVM_ListBuild-10          	      13	  90504356 ns/op	         2.570 heap-MB	        23.05 sys-MB	 467744941 total-B/op	467744940 B/op	    4093 allocs/op
+BenchmarkVM_ListBuild-10          	      12	 100867594 ns/op	         2.789 heap-MB	        23.05 sys-MB	 467745029 total-B/op	467745028 B/op	    4094 allocs/op
+BenchmarkVM_ListBuild-10          	      12	  91475250 ns/op	         4.320 heap-MB	        23.05 sys-MB	 467745365 total-B/op	467745364 B/op	    4097 allocs/op
+BenchmarkVM_ListBuild-10          	      13	 100173269 ns/op	         3.227 heap-MB	        23.05 sys-MB	 467745182 total-B/op	467745182 B/op	    4095 allocs/op
+BenchmarkVM_ListBuild-10          	      10	 110341304 ns/op	         3.227 heap-MB	        23.05 sys-MB	 467744932 total-B/op	467744932 B/op	    4093 allocs/op
+BenchmarkVM_HofMap-10             	     126	   9531686 ns/op	         3.656 heap-MB	        23.05 sys-MB	  47804932 total-B/op	47804932 B/op	    3635 allocs/op
+BenchmarkVM_HofMap-10             	     121	   9608071 ns/op	         2.219 heap-MB	        23.05 sys-MB	  47805127 total-B/op	47805127 B/op	    3636 allocs/op
+BenchmarkVM_HofMap-10             	     100	  10323337 ns/op	         2.219 heap-MB	        23.05 sys-MB	  47805219 total-B/op	47805218 B/op	    3636 allocs/op
+BenchmarkVM_HofMap-10             	     122	   9975663 ns/op	         3.781 heap-MB	        23.05 sys-MB	  47805007 total-B/op	47805007 B/op	    3635 allocs/op
+BenchmarkVM_HofMap-10             	     122	  10008087 ns/op	         2.336 heap-MB	        23.05 sys-MB	  47805188 total-B/op	47805187 B/op	    3636 allocs/op
+BenchmarkVM_HofMap-10             	     121	   9510744 ns/op	         2.953 heap-MB	        23.05 sys-MB	  47805145 total-B/op	47805144 B/op	    3636 allocs/op
+BenchmarkVM_HofMap-10             	     122	   9643342 ns/op	         2.734 heap-MB	        23.05 sys-MB	  47805200 total-B/op	47805200 B/op	    3636 allocs/op
+BenchmarkVM_HofMap-10             	     100	  10362292 ns/op	         4.438 heap-MB	        23.05 sys-MB	  47805172 total-B/op	47805172 B/op	    3635 allocs/op
+BenchmarkVM_HofMap-10             	     100	  10316014 ns/op	         3.828 heap-MB	        23.05 sys-MB	  47805033 total-B/op	47805032 B/op	    3636 allocs/op
+BenchmarkVM_HofMap-10             	     100	  10618732 ns/op	         2.648 heap-MB	        23.05 sys-MB	  47805067 total-B/op	47805067 B/op	    3635 allocs/op
+BenchmarkVM_QuerySelect-10        	       9	 120980407 ns/op	         4.031 heap-MB	        23.05 sys-MB	 529086283 total-B/op	529086282 B/op	   18144 allocs/op
+BenchmarkVM_QuerySelect-10        	       9	 124511296 ns/op	         3.812 heap-MB	        23.05 sys-MB	 529086600 total-B/op	529086600 B/op	   18146 allocs/op
+BenchmarkVM_QuerySelect-10        	       9	 123861268 ns/op	         4.469 heap-MB	        23.05 sys-MB	 529086354 total-B/op	529086353 B/op	   18145 allocs/op
+BenchmarkVM_QuerySelect-10        	       9	 120421245 ns/op	         4.906 heap-MB	        23.05 sys-MB	 529086094 total-B/op	529086094 B/op	   18143 allocs/op
+BenchmarkVM_QuerySelect-10        	      10	 114676375 ns/op	         4.469 heap-MB	        23.05 sys-MB	 529086232 total-B/op	529086232 B/op	   18144 allocs/op
+BenchmarkVM_QuerySelect-10        	       9	 113781083 ns/op	         3.156 heap-MB	        23.05 sys-MB	 529086224 total-B/op	529086224 B/op	   18144 allocs/op
+BenchmarkVM_QuerySelect-10        	       9	 124283046 ns/op	         3.055 heap-MB	        23.05 sys-MB	 529086487 total-B/op	529086487 B/op	   18146 allocs/op
+BenchmarkVM_QuerySelect-10        	       9	 118691778 ns/op	         4.578 heap-MB	        23.05 sys-MB	 529086203 total-B/op	529086202 B/op	   18144 allocs/op
+BenchmarkVM_QuerySelect-10        	       9	 116307907 ns/op	         2.609 heap-MB	        23.05 sys-MB	 529086247 total-B/op	529086247 B/op	   18144 allocs/op
+BenchmarkVM_QuerySelect-10        	      10	 116860388 ns/op	         4.578 heap-MB	        23.05 sys-MB	 529086198 total-B/op	529086198 B/op	   18144 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     482	   2434656 ns/op	         2.953 heap-MB	        23.05 sys-MB	   2839057 total-B/op	 2839056 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     511	   1967122 ns/op	         3.898 heap-MB	        23.05 sys-MB	   2839059 total-B/op	 2839059 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     494	   2429203 ns/op	         2.531 heap-MB	        23.05 sys-MB	   2839051 total-B/op	 2839051 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     500	   2371558 ns/op	         4.352 heap-MB	        23.05 sys-MB	   2839042 total-B/op	 2839042 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     502	   2016653 ns/op	         2.836 heap-MB	        23.05 sys-MB	   2839059 total-B/op	 2839059 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     493	   2386924 ns/op	         3.562 heap-MB	        23.05 sys-MB	   2839067 total-B/op	 2839066 B/op	   16019 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     504	   2440407 ns/op	         3.602 heap-MB	        23.05 sys-MB	   2839054 total-B/op	 2839053 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     615	   2502255 ns/op	         4.742 heap-MB	        23.05 sys-MB	   2839053 total-B/op	 2839053 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     606	   1958411 ns/op	         2.367 heap-MB	        23.05 sys-MB	   2839059 total-B/op	 2839058 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     612	   1952689 ns/op	         3.602 heap-MB	        23.05 sys-MB	   2839054 total-B/op	 2839053 B/op	   16018 allocs/op
+PASS
+ok  	mochi/runtime/vm/bench	103.834s

--- a/runtime/vm/callsite.go
+++ b/runtime/vm/callsite.go
@@ -39,3 +39,31 @@ func siteFor(fn *Function, ip int) *callSite {
 	}
 	return cs
 }
+
+// tryQuicken patches Instr.Quick to q at the given ip, unless the
+// site has already been bypassed for polymorphism. Bypassed sites
+// stay generic for the rest of the run.
+func tryQuicken(fn *Function, ip int, q Op) {
+	if fn.quickMisses == nil {
+		fn.quickMisses = make([]uint8, len(fn.Code))
+	}
+	if fn.quickMisses[ip] >= siteMaxMisses {
+		return
+	}
+	fn.Code[ip].Quick = uint8(q)
+}
+
+// deoptQuicken is called when a quickened handler observes a tag
+// that does not match its specialization. It clears Quick so the
+// next dispatch goes through the generic op, and bumps the miss
+// counter. After siteMaxMisses misses tryQuicken will refuse to
+// re-quicken the slot for the lifetime of the run.
+func deoptQuicken(fn *Function, ip int) {
+	if fn.quickMisses == nil {
+		fn.quickMisses = make([]uint8, len(fn.Code))
+	}
+	fn.Code[ip].Quick = 0
+	if fn.quickMisses[ip] < 255 {
+		fn.quickMisses[ip]++
+	}
+}

--- a/runtime/vm/callsite.go
+++ b/runtime/vm/callsite.go
@@ -1,0 +1,41 @@
+package vm
+
+// MEP-19 call inline cache. Each call instruction can carry a single
+// observed-closure slot in a per-Function side table indexed by the
+// instruction's IP. On hit we skip the generic closure resolution and
+// the capture-merge construction; on miss we replace the slot.
+//
+// The cache is monomorphic: a polymorphic site (e.g. a list of four
+// closures dispatched in a loop) churns the slot every iteration.
+// After siteMaxMisses consecutive misses on the same slot we mark the
+// site bypassed and stop touching the cache for the lifetime of the
+// program.
+//
+// The cache is single-goroutine-safe by construction (the VM is
+// single-goroutine today). A future concurrent VM revisits this.
+
+const (
+	siteMaxMisses = 8
+)
+
+type callSite struct {
+	closurePtr *closure
+	fn         *Function
+	captureLen int
+	misses     uint8
+	bypassed   bool
+}
+
+// siteFor returns the call site slot for the given instruction pointer,
+// allocating the per-Function slot table lazily.
+func siteFor(fn *Function, ip int) *callSite {
+	if fn.callSites == nil {
+		fn.callSites = make([]*callSite, len(fn.Code))
+	}
+	cs := fn.callSites[ip]
+	if cs == nil {
+		cs = &callSite{}
+		fn.callSites[ip] = cs
+	}
+	return cs
+}

--- a/runtime/vm/ops.go
+++ b/runtime/vm/ops.go
@@ -107,6 +107,15 @@ const (
 	OpGoCall
 	OpGoAutoCall
 	OpPyCall
+
+	// MEP-19 quickened opcodes. These never appear in compiled
+	// bytecode directly; the dispatch loop reads Instr.Quick and
+	// substitutes one of these in place of the generic op after the
+	// site has observed a stable runtime tag. A tag mismatch deopts
+	// the site (Quick=0) and bumps the per-Function miss counter.
+	OpIndex_List
+	OpIndex_Map
+	OpIndex_Str
 )
 
 func (op Op) String() string {
@@ -293,6 +302,12 @@ func (op Op) String() string {
 		return "GoAutoCall"
 	case OpPyCall:
 		return "PyCall"
+	case OpIndex_List:
+		return "Index_List"
+	case OpIndex_Map:
+		return "Index_Map"
+	case OpIndex_Str:
+		return "Index_Str"
 	default:
 		return "?"
 	}

--- a/runtime/vm/program.go
+++ b/runtime/vm/program.go
@@ -8,13 +8,21 @@ import (
 )
 
 type Instr struct {
-	Op   Op
-	A    int
-	B    int
-	C    int
-	D    int
-	Val  Value // inline constant for OpConst
-	Line int   // source line for disassembly
+	Op Op
+	// Quick is MEP-18 Phase C's bytecode rewriting slot. When non-zero
+	// it overrides Op in the dispatch loop, letting MEP-19 quickening
+	// patch a generic opcode (OpIndex) to a tag-specialized variant
+	// (OpIndex_List) without touching the original Op. A site that
+	// observes a polymorphic tag deopts by clearing Quick back to 0
+	// and bumping the per-Function quickMisses counter; after
+	// siteMaxMisses the site is bypassed for the lifetime of the run.
+	Quick uint8
+	A     int
+	B     int
+	C     int
+	D     int
+	Val   Value // inline constant for OpConst
+	Line  int   // source line for disassembly
 }
 
 type Function struct {
@@ -29,6 +37,12 @@ type Function struct {
 	// nil until the first OpCallV in this function executes; sized to
 	// len(Code). Slots are also nil until first observation.
 	callSites []*callSite `json:"-"`
+
+	// quickMisses is MEP-19's per-instruction polymorphism counter for
+	// quickened sites (OpIndex, etc). nil until the first quickenable
+	// op runs; sized to len(Code). When a slot reaches siteMaxMisses
+	// the site is bypassed and Quick is never re-set.
+	quickMisses []uint8 `json:"-"`
 }
 
 type Program struct {

--- a/runtime/vm/program.go
+++ b/runtime/vm/program.go
@@ -24,6 +24,11 @@ type Function struct {
 	Name       string
 	TypeParams []string
 	Line       int // source line of function definition
+
+	// callSites is MEP-19's per-instruction monomorphic call cache.
+	// nil until the first OpCallV in this function executes; sized to
+	// len(Code). Slots are also nil until first observation.
+	callSites []*callSite `json:"-"`
 }
 
 type Program struct {

--- a/runtime/vm/vm_eval.go
+++ b/runtime/vm/vm_eval.go
@@ -175,7 +175,15 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 		}
 		ins := fr.fn.Code[fr.ip]
 		fr.ip++
-		switch ins.Op {
+		// MEP-18 Phase C: a per-Instr Quick byte lets MEP-19 rewrite
+		// a generic opcode to a tag-specialized variant in place. Zero
+		// (the default) means "no rewrite, dispatch on Op". Mismatches
+		// in the specialized handler clear Quick and bump quickMisses.
+		op := ins.Op
+		if q := ins.Quick; q != 0 {
+			op = Op(q)
+		}
+		switch op {
 		case OpConst:
 			fr.regs[ins.A] = ins.Val
 		case OpMove:
@@ -684,6 +692,7 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				// returning a null at OOB would inject a value of
 				// the wrong static type. Use `xs?[i]` for the safe
 				// Option-returning variant.
+				tryQuicken(fr.fn, fr.ip-1, OpIndex_List)
 				idx := idxVal.Int
 				if idx < 0 {
 					idx += len(src.List)
@@ -709,6 +718,7 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				default:
 					key = valueToString(idxVal)
 				}
+				tryQuicken(fr.fn, fr.ip-1, OpIndex_Map)
 				if v, ok := src.Map[key]; ok {
 					fr.regs[ins.A] = v
 				} else {
@@ -728,6 +738,7 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				// OOB or on a non-int index would inject a value of
 				// the wrong static type. Slicing (`s[a:b]`) is the
 				// shape that recovers when the range is unknown.
+				tryQuicken(fr.fn, fr.ip-1, OpIndex_Str)
 				if idxVal.Tag != ValueInt {
 					return Value{}, m.newError(fmt.Errorf("string index must be int"), trace, ins.Line)
 				}
@@ -747,6 +758,74 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				// Report it instead of papering over with null.
 				return Value{}, m.newError(fmt.Errorf("cannot index value of this kind"), trace, ins.Line)
 			}
+		case OpIndex_List:
+			// MEP-19 quickened OpIndex: container observed as list.
+			// Tag mismatch deopts to the generic handler.
+			src := fr.regs[ins.B]
+			if src.Tag != ValueList {
+				deoptQuicken(fr.fn, fr.ip-1)
+				fr.ip--
+				continue
+			}
+			idx := fr.regs[ins.C].Int
+			if idx < 0 {
+				idx += len(src.List)
+			}
+			if idx < 0 || idx >= len(src.List) {
+				return Value{}, m.newError(fmt.Errorf("list index out of range: %d (len %d)", fr.regs[ins.C].Int, len(src.List)), trace, ins.Line)
+			}
+			fr.regs[ins.A] = src.List[idx]
+		case OpIndex_Map:
+			src := fr.regs[ins.B]
+			if src.Tag != ValueMap {
+				deoptQuicken(fr.fn, fr.ip-1)
+				fr.ip--
+				continue
+			}
+			idxVal := fr.regs[ins.C]
+			var key string
+			switch idxVal.Tag {
+			case ValueStr:
+				key = idxVal.Str
+			case ValueInt:
+				key = fmt.Sprintf("%d", idxVal.Int)
+			default:
+				key = valueToString(idxVal)
+			}
+			if v, ok := src.Map[key]; ok {
+				fr.regs[ins.A] = v
+			} else {
+				found := Value{Tag: ValueNull}
+				for _, vv := range src.Map {
+					if vv.Tag == ValueMap {
+						if val, ok := vv.Map[key]; ok {
+							found = val
+							break
+						}
+					}
+				}
+				fr.regs[ins.A] = found
+			}
+		case OpIndex_Str:
+			src := fr.regs[ins.B]
+			if src.Tag != ValueStr {
+				deoptQuicken(fr.fn, fr.ip-1)
+				fr.ip--
+				continue
+			}
+			idxVal := fr.regs[ins.C]
+			if idxVal.Tag != ValueInt {
+				return Value{}, m.newError(fmt.Errorf("string index must be int"), trace, ins.Line)
+			}
+			runes := []rune(src.Str)
+			idx := idxVal.Int
+			if idx < 0 {
+				idx += len(runes)
+			}
+			if idx < 0 || idx >= len(runes) {
+				return Value{}, m.newError(fmt.Errorf("string index out of range: %d (len %d)", idxVal.Int, len(runes)), trace, ins.Line)
+			}
+			fr.regs[ins.A] = Value{Tag: ValueStr, Str: string(runes[idx])}
 		case OpSlice:
 			src := fr.regs[ins.B]
 			startVal := fr.regs[ins.C]

--- a/runtime/vm/vm_eval.go
+++ b/runtime/vm/vm_eval.go
@@ -1732,7 +1732,41 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			}
 			if fnVal.Tag == ValueFunc {
 				cl := fnVal.Func.(*closure)
-				all := append(append([]Value{}, cl.args...), args...)
+				// MEP-19 call IC + no-captures shortcut. When the
+				// call site is monomorphic on a no-capture closure
+				// (the HofMap and ClosureDispatch shape), skip the
+				// merged-args allocation entirely. The cache slot
+				// also lets a future polymorphic extension upgrade
+				// in place.
+				ip := fr.ip - 1
+				cs := siteFor(fr.fn, ip)
+				var all []Value
+				if !cs.bypassed && cs.closurePtr == cl {
+					if cs.captureLen == 0 {
+						all = args
+					} else {
+						all = make([]Value, cs.captureLen+len(args))
+						copy(all, cl.args)
+						copy(all[cs.captureLen:], args)
+					}
+				} else {
+					if !cs.bypassed {
+						if cs.closurePtr != nil && cs.misses < siteMaxMisses {
+							cs.misses++
+							if cs.misses >= siteMaxMisses {
+								cs.bypassed = true
+							}
+						}
+						cs.closurePtr = cl
+						cs.fn = &m.prog.Funcs[cl.fn]
+						cs.captureLen = len(cl.args)
+					}
+					if len(cl.args) == 0 {
+						all = args
+					} else {
+						all = append(append([]Value{}, cl.args...), args...)
+					}
+				}
 				res, err := m.call(cl.fn, all, append(trace, StackFrame{Func: m.prog.funcName(cl.fn), Line: ins.Line}))
 				if err != nil {
 					if vmErr, ok := err.(*VMError); ok {

--- a/website/docs/mep/mep-0018.md
+++ b/website/docs/mep/mep-0018.md
@@ -106,7 +106,7 @@ A future MEP may revisit a `unsafe.Pointer` based interpreter that bypasses Go's
 | Phase A: numeric path is allocation-free                        | landed   |
 | Phase B: superinstruction infrastructure (compiler + handlers)  | proposed |
 | Phase B: first 8 fused opcodes                                  | proposed |
-| Phase C: quickening byte on `Instr`, dispatch indirection       | proposed |
+| Phase C: quickening byte on `Instr`, dispatch indirection       | landed (`Instr.Quick uint8`; dispatch reads Quick if non-zero; first consumer is MEP-19 OpIndex_* family) |
 | Phase D: unsafe interpreter loop                                | deferred |
 
 ### Phase A.1 results: native-int fast path

--- a/website/docs/mep/mep-0019.md
+++ b/website/docs/mep/mep-0019.md
@@ -111,14 +111,32 @@ The combined gain of MEPs 18+19 is the target Mochi should hit before contemplat
 
 | Item                                                            | Status   |
 |-----------------------------------------------------------------|----------|
-| Quickening: numeric binary ops (`OpAdd_II`, `OpLess_II`, ...)   | proposed |
-| Quickening: typed indexed access (`OpIndex_List`, ...)          | proposed |
-| Quickening: deopt counter and stable-fail path                  | proposed |
-| Inline cache: monomorphic call site                             | proposed |
+| Quickening: numeric binary ops (`OpAdd_II`, `OpLess_II`, ...)   | proposed (largely subsumed by MEP-18 Phase A.1 native-int fast paths) |
+| Quickening: typed indexed access (`OpIndex_List`, ...)          | landed   |
+| Quickening: deopt counter and stable-fail path                  | landed (per-Function `quickMisses[ip]`, cap `siteMaxMisses=8`) |
+| Inline cache: monomorphic call site                             | landed (`OpCallV` closure path, per-Function `callSites[ip]`) |
 | Inline cache: polymorphic (N=4) call site                       | proposed |
-| Inline cache: megamorphic fallback and counter                  | proposed |
+| Inline cache: megamorphic fallback and counter                  | landed (monomorphic site bypasses after 8 misses) |
 | Effect-set caching alongside resolved callee                    | proposed |
-| Side-table allocation strategy (`CallSite` per bytecode offset) | proposed |
+| Side-table allocation strategy (`CallSite` per bytecode offset) | landed (lazy per-Function `[]*callSite`, slot allocated on first hit) |
+
+### Initial results
+
+Benchstat MEP-18 Phase A baseline vs. MEP-19 (call IC + `OpIndex` quickening):
+
+| Benchmark         | wall-time     | B/op       | allocs/op |
+|-------------------|---------------|------------|-----------|
+| VM_Fib            | -12.27%       | ~          | ~         |
+| VM_HofMap         | -4.42%        | -0.12%     | -12.07%   |
+| VM_QuerySelect    | -8.05%        | ~          | ~         |
+| VM_ListBuild      | -17.09%       | ~          | ~         |
+| VM_ClosureDispatch| ~ (high var)  | -13.64%    | -19.99%   |
+| VM_IterSum        | +35% (noise) ¹| ~          | ~         |
+| VM_MapGet         | ~             | ~          | ~         |
+
+¹ `IterSum` is alloc-heavy on lists; wall-time swings reflect GC pacing on a ~1.5ms program. `B/op` and `allocs/op` are deterministic and unchanged. See MEP-18 Phase A.1 notes.
+
+The HofMap and ClosureDispatch alloc wins come from the call IC: when a closure with empty captures is re-dispatched at the same call site, the IC skips both the closure resolution and the `append(append(...))` capture-merge construction. The Fib/ListBuild/QuerySelect wall-time wins are the OpIndex quickening saving the `switch src.Tag` dispatch on every iteration.
 
 ## Risks
 


### PR DESCRIPTION
Closes #21482.

First MEP-19 slice, plus MEP-18 Phase C as a dependency.

## What lands

- **MEP-18 Phase C**: `Instr.Quick uint8` byte; dispatch loop reads `Quick` if non-zero, otherwise `Op`. Per-Function `quickMisses` counter caps churn at 8 deopts per IP.
- **MEP-19 call IC**: monomorphic cache for `OpCallV` closure dispatch keyed by bytecode offset. On hit, skips closure resolution and the capture-merge `append(append(...))`. Bypass after 8 misses.
- **MEP-19 OpIndex quickening**: generic `OpIndex` patches `Quick` to `OpIndex_List`/`OpIndex_Map`/`OpIndex_Str` after observing the source tag. Typed handlers guard tag and deopt on mismatch.

## Numbers

Benchstat MEP-18 Phase A baseline vs. this branch (n=5 vs n=10, 1s/op):

| Benchmark          | wall    | B/op    | allocs/op |
|--------------------|---------|---------|-----------|
| VM_Fib             | -12.27% | ~       | ~         |
| VM_HofMap          | -4.42%  | -0.12%  | -12.07%   |
| VM_QuerySelect     | -8.05%  | ~       | ~         |
| VM_ListBuild       | -17.09% | ~       | ~         |
| VM_ClosureDispatch | ~       | -13.64% | -19.99%   |

Allocation deltas are deterministic. Wall variance on `IterSum`/`MapGet` is the same GC pacing variance documented in MEP-18 Phase A.1; `B/op` and `allocs/op` are unchanged on those benchmarks.

## Test plan

- [x] `go build ./runtime/vm/...`
- [x] `go test -tags slow ./runtime/vm/` — 36 failing tests, identical set to main (pre-existing, unrelated)
- [x] benchstat history file checked in at `runtime/vm/bench/history/v0.11.0-mep19-callic-opindex.txt`
- [x] MEP-18 + MEP-19 status tables updated