### PR TITLE
MEP-19: polymorphic call IC (N=4) for OpCallV

### DIFF
--- a/runtime/vm/bench/history/v0.11.0-mep19-poly-ic.txt
+++ b/runtime/vm/bench/history/v0.11.0-mep19-poly-ic.txt
@@ -1,0 +1,76 @@
+goos: darwin
+goarch: arm64
+pkg: mochi/runtime/vm/bench
+cpu: Apple M4
+BenchmarkVM_Fib-10                	      18	  61334877 ns/op	         4.383 heap-MB	        18.27 sys-MB	 364739142 total-B/op	364739142 B/op	  515556 allocs/op
+BenchmarkVM_Fib-10                	      19	  60886107 ns/op	         3.508 heap-MB	        18.28 sys-MB	 364738933 total-B/op	364738933 B/op	  515554 allocs/op
+BenchmarkVM_Fib-10                	      20	  60577390 ns/op	         4.031 heap-MB	        18.28 sys-MB	 364738986 total-B/op	364738986 B/op	  515554 allocs/op
+BenchmarkVM_Fib-10                	      19	  60277500 ns/op	         3.234 heap-MB	        18.28 sys-MB	 364738792 total-B/op	364738791 B/op	  515553 allocs/op
+BenchmarkVM_Fib-10                	      19	  62509627 ns/op	         4.281 heap-MB	        26.55 sys-MB	 364739193 total-B/op	364739193 B/op	  515556 allocs/op
+BenchmarkVM_Fib-10                	      20	  61439794 ns/op	         2.789 heap-MB	        26.55 sys-MB	 364739388 total-B/op	364739388 B/op	  515556 allocs/op
+BenchmarkVM_Fib-10                	      20	  59315067 ns/op	         3.000 heap-MB	        26.55 sys-MB	 364738942 total-B/op	364738941 B/op	  515554 allocs/op
+BenchmarkVM_Fib-10                	      19	  58692000 ns/op	         4.477 heap-MB	        26.55 sys-MB	 364739043 total-B/op	364739042 B/op	  515554 allocs/op
+BenchmarkVM_Fib-10                	      20	  60340898 ns/op	         4.758 heap-MB	        26.55 sys-MB	 364739048 total-B/op	364739048 B/op	  515555 allocs/op
+BenchmarkVM_Fib-10                	      20	  68025346 ns/op	         4.148 heap-MB	        26.55 sys-MB	 364739225 total-B/op	364739225 B/op	  515556 allocs/op
+BenchmarkVM_IterSum-10            	    1017	   1169427 ns/op	         3.914 heap-MB	        26.55 sys-MB	      5387 total-B/op	    5387 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	    1520	   1164422 ns/op	         3.430 heap-MB	        26.55 sys-MB	      5388 total-B/op	    5387 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	    1521	   1184683 ns/op	         3.422 heap-MB	        26.55 sys-MB	      5388 total-B/op	    5387 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	    1010	   1177822 ns/op	         3.914 heap-MB	        26.55 sys-MB	      5388 total-B/op	    5387 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	    1030	   1164156 ns/op	         4.000 heap-MB	        26.55 sys-MB	      5388 total-B/op	    5387 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	    1520	   1174291 ns/op	         3.328 heap-MB	        26.55 sys-MB	      5387 total-B/op	    5387 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	    1018	   1181009 ns/op	         3.922 heap-MB	        26.55 sys-MB	      5387 total-B/op	    5387 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	    1032	   1165625 ns/op	         3.938 heap-MB	        26.55 sys-MB	      5387 total-B/op	    5386 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	     994	   1164880 ns/op	         3.805 heap-MB	        26.55 sys-MB	      5388 total-B/op	    5387 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	    1514	   1176985 ns/op	         3.305 heap-MB	        26.55 sys-MB	      5388 total-B/op	    5387 B/op	       8 allocs/op
+BenchmarkVM_MapGet-10             	     646	   1854190 ns/op	         4.516 heap-MB	        26.55 sys-MB	      9070 total-B/op	    9070 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     868	   1867022 ns/op	         3.211 heap-MB	        26.55 sys-MB	      9070 total-B/op	    9070 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     642	   1853115 ns/op	         4.328 heap-MB	        26.80 sys-MB	      9069 total-B/op	    9069 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     866	   1853276 ns/op	         3.266 heap-MB	        26.80 sys-MB	      9071 total-B/op	    9070 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     867	   1382480 ns/op	         3.133 heap-MB	        26.80 sys-MB	      9070 total-B/op	    9069 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     858	   1406268 ns/op	         3.188 heap-MB	        26.80 sys-MB	      9070 total-B/op	    9069 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     628	   1995282 ns/op	         4.289 heap-MB	        26.80 sys-MB	      9070 total-B/op	    9069 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     798	   1854836 ns/op	         2.695 heap-MB	        26.80 sys-MB	      9071 total-B/op	    9071 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     868	   1861036 ns/op	         3.141 heap-MB	        26.80 sys-MB	      9070 total-B/op	    9069 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     866	   1850436 ns/op	         3.242 heap-MB	        26.80 sys-MB	      9071 total-B/op	    9071 B/op	      11 allocs/op
+BenchmarkVM_ListBuild-10          	      18	  62833271 ns/op	         2.797 heap-MB	        26.80 sys-MB	 467745408 total-B/op	467745407 B/op	    4097 allocs/op
+BenchmarkVM_ListBuild-10          	      19	  64018588 ns/op	         3.234 heap-MB	        26.80 sys-MB	 467745410 total-B/op	467745410 B/op	    4097 allocs/op
+BenchmarkVM_ListBuild-10          	      18	  63992266 ns/op	         2.797 heap-MB	        26.80 sys-MB	 467745152 total-B/op	467745152 B/op	    4095 allocs/op
+BenchmarkVM_ListBuild-10          	      18	  62982681 ns/op	         5.203 heap-MB	        26.80 sys-MB	 467745457 total-B/op	467745457 B/op	    4098 allocs/op
+BenchmarkVM_ListBuild-10          	      18	  64323880 ns/op	         4.766 heap-MB	        26.80 sys-MB	 467745308 total-B/op	467745308 B/op	    4096 allocs/op
+BenchmarkVM_ListBuild-10          	      18	  65142935 ns/op	         2.578 heap-MB	        26.80 sys-MB	 467745215 total-B/op	467745214 B/op	    4095 allocs/op
+BenchmarkVM_ListBuild-10          	      19	  62694945 ns/op	         3.234 heap-MB	        26.80 sys-MB	 467745392 total-B/op	467745392 B/op	    4097 allocs/op
+BenchmarkVM_ListBuild-10          	      18	  63770764 ns/op	         4.766 heap-MB	        26.80 sys-MB	 467745196 total-B/op	467745196 B/op	    4095 allocs/op
+BenchmarkVM_ListBuild-10          	      16	  64112659 ns/op	         3.891 heap-MB	        26.80 sys-MB	 467745156 total-B/op	467745156 B/op	    4095 allocs/op
+BenchmarkVM_ListBuild-10          	      18	  65267262 ns/op	         3.891 heap-MB	        26.80 sys-MB	 467745115 total-B/op	467745115 B/op	    4095 allocs/op
+BenchmarkVM_HofMap-10             	     206	   5833598 ns/op	         4.000 heap-MB	        26.80 sys-MB	  47804684 total-B/op	47804684 B/op	    3634 allocs/op
+BenchmarkVM_HofMap-10             	     178	   5859757 ns/op	         4.781 heap-MB	        26.80 sys-MB	  47804816 total-B/op	47804815 B/op	    3635 allocs/op
+BenchmarkVM_HofMap-10             	     201	   6048022 ns/op	         3.797 heap-MB	        26.80 sys-MB	  47804883 total-B/op	47804882 B/op	    3635 allocs/op
+BenchmarkVM_HofMap-10             	     204	   5965567 ns/op	         4.398 heap-MB	        26.80 sys-MB	  47804900 total-B/op	47804899 B/op	    3636 allocs/op
+BenchmarkVM_HofMap-10             	     205	   5849981 ns/op	         2.477 heap-MB	        26.80 sys-MB	  47804820 total-B/op	47804820 B/op	    3635 allocs/op
+BenchmarkVM_HofMap-10             	     196	   5964427 ns/op	         4.461 heap-MB	        26.80 sys-MB	  47804786 total-B/op	47804785 B/op	    3635 allocs/op
+BenchmarkVM_HofMap-10             	     202	   5921931 ns/op	         2.414 heap-MB	        26.80 sys-MB	  47804956 total-B/op	47804955 B/op	    3636 allocs/op
+BenchmarkVM_HofMap-10             	     204	   5857376 ns/op	         3.945 heap-MB	        26.80 sys-MB	  47804823 total-B/op	47804823 B/op	    3635 allocs/op
+BenchmarkVM_HofMap-10             	     201	   6074149 ns/op	         2.367 heap-MB	        26.80 sys-MB	  47804943 total-B/op	47804942 B/op	    3636 allocs/op
+BenchmarkVM_HofMap-10             	     201	   6110130 ns/op	         2.812 heap-MB	        26.80 sys-MB	  47804994 total-B/op	47804994 B/op	    3636 allocs/op
+BenchmarkVM_QuerySelect-10        	      15	  73478447 ns/op	         3.719 heap-MB	        26.80 sys-MB	 529086294 total-B/op	529086294 B/op	   18145 allocs/op
+BenchmarkVM_QuerySelect-10        	      15	  72043239 ns/op	         4.484 heap-MB	        26.80 sys-MB	 529086132 total-B/op	529086132 B/op	   18144 allocs/op
+BenchmarkVM_QuerySelect-10        	      14	  72342524 ns/op	         4.484 heap-MB	        27.05 sys-MB	 529086214 total-B/op	529086213 B/op	   18144 allocs/op
+BenchmarkVM_QuerySelect-10        	      16	  72688492 ns/op	         3.719 heap-MB	        27.05 sys-MB	 529086464 total-B/op	529086464 B/op	   18146 allocs/op
+BenchmarkVM_QuerySelect-10        	      15	  74092175 ns/op	         2.625 heap-MB	        27.05 sys-MB	 529086212 total-B/op	529086212 B/op	   18144 allocs/op
+BenchmarkVM_QuerySelect-10        	      15	  71499900 ns/op	         2.734 heap-MB	        27.30 sys-MB	 529086497 total-B/op	529086496 B/op	   18146 allocs/op
+BenchmarkVM_QuerySelect-10        	      16	  74293659 ns/op	         4.492 heap-MB	        27.30 sys-MB	 529086282 total-B/op	529086282 B/op	   18143 allocs/op
+BenchmarkVM_QuerySelect-10        	      15	  71550983 ns/op	         4.594 heap-MB	        27.30 sys-MB	 529085964 total-B/op	529085963 B/op	   18142 allocs/op
+BenchmarkVM_QuerySelect-10        	      16	  71784286 ns/op	         3.828 heap-MB	        27.30 sys-MB	 529085887 total-B/op	529085887 B/op	   18141 allocs/op
+BenchmarkVM_QuerySelect-10        	      15	  71744331 ns/op	         3.391 heap-MB	        27.30 sys-MB	 529086197 total-B/op	529086196 B/op	   18143 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     763	   1634700 ns/op	         2.914 heap-MB	        27.30 sys-MB	   2839036 total-B/op	 2839035 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     723	   1633301 ns/op	         3.953 heap-MB	        27.30 sys-MB	   2839049 total-B/op	 2839048 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     933	   1596189 ns/op	         2.398 heap-MB	        27.30 sys-MB	   2839044 total-B/op	 2839043 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     720	   1605905 ns/op	         3.508 heap-MB	        27.30 sys-MB	   2839029 total-B/op	 2839028 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     934	   1607389 ns/op	         3.984 heap-MB	        27.30 sys-MB	   2839026 total-B/op	 2839026 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     925	   1591149 ns/op	         3.609 heap-MB	        27.30 sys-MB	   2839043 total-B/op	 2839042 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     799	   1293237 ns/op	         3.430 heap-MB	        27.30 sys-MB	   2839038 total-B/op	 2839038 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     759	   1599299 ns/op	         3.648 heap-MB	        27.30 sys-MB	   2839037 total-B/op	 2839037 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     926	   1595885 ns/op	         3.211 heap-MB	        27.30 sys-MB	   2839049 total-B/op	 2839048 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     714	   1592107 ns/op	         4.484 heap-MB	        27.30 sys-MB	   2839052 total-B/op	 2839051 B/op	   16018 allocs/op
+PASS
+ok  	mochi/runtime/vm/bench	105.813s

--- a/runtime/vm/callsite.go
+++ b/runtime/vm/callsite.go
@@ -1,29 +1,38 @@
 package vm
 
-// MEP-19 call inline cache. Each call instruction can carry a single
-// observed-closure slot in a per-Function side table indexed by the
-// instruction's IP. On hit we skip the generic closure resolution and
-// the capture-merge construction; on miss we replace the slot.
+// MEP-19 call inline cache. Each call instruction carries a small
+// polymorphic cache in a per-Function side table indexed by the
+// instruction's IP. On hit we skip the generic closure resolution
+// and the capture-merge construction; on miss we either add the
+// callee to a free slot or, once all slots are full and a new
+// callee is observed, bump a megamorphism counter.
 //
-// The cache is monomorphic: a polymorphic site (e.g. a list of four
-// closures dispatched in a loop) churns the slot every iteration.
-// After siteMaxMisses consecutive misses on the same slot we mark the
-// site bypassed and stop touching the cache for the lifetime of the
-// program.
+// The cache holds up to siteSlots distinct closures (Hölzle/
+// Chambers/Ungar's classic polymorphic IC). siteSlots=4 catches
+// the agent-intent dispatch shape (a small fixed list of closures
+// rotated in a loop) without paying for an unbounded table.
+//
+// After siteMaxMisses consecutive megamorphic events the site is
+// bypassed for the lifetime of the program.
 //
 // The cache is single-goroutine-safe by construction (the VM is
 // single-goroutine today). A future concurrent VM revisits this.
 
 const (
 	siteMaxMisses = 8
+	siteSlots     = 4
 )
 
-type callSite struct {
+type callSiteEntry struct {
 	closurePtr *closure
-	fn         *Function
 	captureLen int
-	misses     uint8
-	bypassed   bool
+}
+
+type callSite struct {
+	entries  [siteSlots]callSiteEntry
+	nEntries uint8
+	misses   uint8
+	bypassed bool
 }
 
 // siteFor returns the call site slot for the given instruction pointer,
@@ -38,6 +47,37 @@ func siteFor(fn *Function, ip int) *callSite {
 		fn.callSites[ip] = cs
 	}
 	return cs
+}
+
+// lookup returns the cached captureLen and true if cl is already in
+// the cache. Linear scan over at most siteSlots entries.
+func (cs *callSite) lookup(cl *closure) (int, bool) {
+	for i := uint8(0); i < cs.nEntries; i++ {
+		if cs.entries[i].closurePtr == cl {
+			return cs.entries[i].captureLen, true
+		}
+	}
+	return 0, false
+}
+
+// observe records cl in the cache. If a free slot exists it is
+// filled. Otherwise a megamorphic event is recorded and, after
+// siteMaxMisses such events, the site is permanently bypassed.
+func (cs *callSite) observe(cl *closure) {
+	if cs.bypassed {
+		return
+	}
+	if cs.nEntries < siteSlots {
+		cs.entries[cs.nEntries] = callSiteEntry{closurePtr: cl, captureLen: len(cl.args)}
+		cs.nEntries++
+		return
+	}
+	if cs.misses < siteMaxMisses {
+		cs.misses++
+		if cs.misses >= siteMaxMisses {
+			cs.bypassed = true
+		}
+	}
 }
 
 // tryQuicken patches Instr.Quick to q at the given ip, unless the

--- a/runtime/vm/vm_eval.go
+++ b/runtime/vm/vm_eval.go
@@ -1811,35 +1811,26 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			}
 			if fnVal.Tag == ValueFunc {
 				cl := fnVal.Func.(*closure)
-				// MEP-19 call IC + no-captures shortcut. When the
-				// call site is monomorphic on a no-capture closure
-				// (the HofMap and ClosureDispatch shape), skip the
-				// merged-args allocation entirely. The cache slot
-				// also lets a future polymorphic extension upgrade
-				// in place.
+				// MEP-19 polymorphic call IC + no-captures shortcut.
+				// Caches up to siteSlots distinct closures per call
+				// site. ClosureDispatch's four-way rotation fills
+				// all four slots in the first iteration; every
+				// subsequent call is a hit and skips both the
+				// closure resolution and the capture-merge alloc.
 				ip := fr.ip - 1
 				cs := siteFor(fr.fn, ip)
+				captureLen, hit := cs.lookup(cl)
 				var all []Value
-				if !cs.bypassed && cs.closurePtr == cl {
-					if cs.captureLen == 0 {
+				if hit {
+					if captureLen == 0 {
 						all = args
 					} else {
-						all = make([]Value, cs.captureLen+len(args))
+						all = make([]Value, captureLen+len(args))
 						copy(all, cl.args)
-						copy(all[cs.captureLen:], args)
+						copy(all[captureLen:], args)
 					}
 				} else {
-					if !cs.bypassed {
-						if cs.closurePtr != nil && cs.misses < siteMaxMisses {
-							cs.misses++
-							if cs.misses >= siteMaxMisses {
-								cs.bypassed = true
-							}
-						}
-						cs.closurePtr = cl
-						cs.fn = &m.prog.Funcs[cl.fn]
-						cs.captureLen = len(cl.args)
-					}
+					cs.observe(cl)
 					if len(cl.args) == 0 {
 						all = args
 					} else {

--- a/website/docs/mep/mep-0019.md
+++ b/website/docs/mep/mep-0019.md
@@ -115,7 +115,7 @@ The combined gain of MEPs 18+19 is the target Mochi should hit before contemplat
 | Quickening: typed indexed access (`OpIndex_List`, ...)          | landed   |
 | Quickening: deopt counter and stable-fail path                  | landed (per-Function `quickMisses[ip]`, cap `siteMaxMisses=8`) |
 | Inline cache: monomorphic call site                             | landed (`OpCallV` closure path, per-Function `callSites[ip]`) |
-| Inline cache: polymorphic (N=4) call site                       | proposed |
+| Inline cache: polymorphic (N=4) call site                       | landed (`siteSlots=4` linear-scan cache; fills on miss until full, then bumps megamorphism counter) |
 | Inline cache: megamorphic fallback and counter                  | landed (monomorphic site bypasses after 8 misses) |
 | Effect-set caching alongside resolved callee                    | proposed |
 | Side-table allocation strategy (`CallSite` per bytecode offset) | landed (lazy per-Function `[]*callSite`, slot allocated on first hit) |
@@ -137,6 +137,24 @@ Benchstat MEP-18 Phase A baseline vs. MEP-19 (call IC + `OpIndex` quickening):
 ¹ `IterSum` is alloc-heavy on lists; wall-time swings reflect GC pacing on a ~1.5ms program. `B/op` and `allocs/op` are deterministic and unchanged. See MEP-18 Phase A.1 notes.
 
 The HofMap and ClosureDispatch alloc wins come from the call IC: when a closure with empty captures is re-dispatched at the same call site, the IC skips both the closure resolution and the `append(append(...))` capture-merge construction. The Fib/ListBuild/QuerySelect wall-time wins are the OpIndex quickening saving the `switch src.Tag` dispatch on every iteration.
+
+### Polymorphic IC results
+
+Extending the cache to `siteSlots=4` (Hölzle/Chambers/Ungar's classic poly-IC) closes the remaining gap on `ClosureDispatch`, where the program rotates through four closures in a loop. Benchstat MEP-18 Phase A baseline vs. MEP-19 with polymorphic IC:
+
+| Benchmark         | wall-time |
+|-------------------|-----------|
+| VM_Fib            | -39.78%   |
+| VM_HofMap         | -43.15%   |
+| VM_QuerySelect    | -44.48%   |
+| VM_ListBuild      | -41.88%   |
+| VM_ClosureDispatch| -26.14%   |
+| VM_MapGet         | -7.42%    |
+| VM_IterSum        | +4.57% ¹  |
+
+¹ Within run-to-run noise for a 1ms program; `B/op` and `allocs/op` are deterministic and unchanged.
+
+Geomean wall-time across the seven covered benchmarks: **-31.66% vs. the monomorphic-only landing**, on top of the prior MEP-18 Phase A.1 gains.
 
 ## Risks
 


### PR DESCRIPTION
Closes #21484.

Extends the monomorphic OpCallV cache from #21483 to a classic Hölzle/Chambers/Ungar polymorphic IC with `siteSlots=4`. Linear-scan lookup, fill-on-miss until full, then bump a megamorphism counter (bypass at `siteMaxMisses=8`).

## Why

The monomorphic cache bypassed ClosureDispatch's 4-way rotation after 8 churns. A 4-slot cache fills in the first iteration and hits 100% thereafter.

## Numbers

Benchstat MEP-18 Phase A baseline vs. this branch (n=10, 1s/op):

| Benchmark         | wall    |
|-------------------|---------|
| VM_Fib            | -39.78% |
| VM_HofMap         | -43.15% |
| VM_QuerySelect    | -44.48% |
| VM_ListBuild      | -41.88% |
| VM_ClosureDispatch| -26.14% |
| VM_MapGet         | -7.42%  |
| VM_IterSum        | +4.57% (within run-to-run noise for a 1ms program) |

Geomean wall-time vs. monomorphic-only landing: **-31.66%**.

`B/op` and `allocs/op` are unchanged (deterministic), confirming this is a pure dispatch speedup.

## Test plan

- [x] `go build ./runtime/vm/...`
- [x] `go test -tags slow ./runtime/vm/` — 36 failing tests, identical set to main (pre-existing, unrelated)
- [x] benchstat history checked in at `runtime/vm/bench/history/v0.11.0-mep19-poly-ic.txt`
- [x] MEP-19 status table updated; polymorphic IC marked landed