### PR TITLE
MEP-19: OpSetIndex quickening (List + Map)

### DIFF
--- a/runtime/vm/bench/history/v0.11.0-mep19-setindex-quicken.txt
+++ b/runtime/vm/bench/history/v0.11.0-mep19-setindex-quicken.txt
@@ -1,0 +1,76 @@
+goos: darwin
+goarch: arm64
+pkg: mochi/runtime/vm/bench
+cpu: Apple M4
+BenchmarkVM_Fib-10                	      16	  63001211 ns/op	         2.617 heap-MB	        18.28 sys-MB	 364739817 total-B/op	364739817 B/op	  515557 allocs/op
+BenchmarkVM_Fib-10                	      19	  62074178 ns/op	         4.492 heap-MB	        18.28 sys-MB	 364738915 total-B/op	364738915 B/op	  515554 allocs/op
+BenchmarkVM_Fib-10                	      19	  62100522 ns/op	         4.266 heap-MB	        18.28 sys-MB	 364738974 total-B/op	364738974 B/op	  515554 allocs/op
+BenchmarkVM_Fib-10                	      20	  62815498 ns/op	         3.367 heap-MB	        18.28 sys-MB	 364738858 total-B/op	364738858 B/op	  515553 allocs/op
+BenchmarkVM_Fib-10                	      19	  58623379 ns/op	         4.672 heap-MB	        18.28 sys-MB	 364738927 total-B/op	364738927 B/op	  515554 allocs/op
+BenchmarkVM_Fib-10                	      20	  58705677 ns/op	         3.719 heap-MB	        18.28 sys-MB	 364738981 total-B/op	364738980 B/op	  515554 allocs/op
+BenchmarkVM_Fib-10                	      19	  62239754 ns/op	         5.148 heap-MB	        18.28 sys-MB	 364738933 total-B/op	364738933 B/op	  515554 allocs/op
+BenchmarkVM_Fib-10                	      20	  63430975 ns/op	         2.914 heap-MB	        18.28 sys-MB	 364739119 total-B/op	364739118 B/op	  515555 allocs/op
+BenchmarkVM_Fib-10                	      19	  62501007 ns/op	         4.234 heap-MB	        18.28 sys-MB	 364738974 total-B/op	364738974 B/op	  515554 allocs/op
+BenchmarkVM_Fib-10                	      19	  61887680 ns/op	         4.812 heap-MB	        18.28 sys-MB	 364738909 total-B/op	364738909 B/op	  515554 allocs/op
+BenchmarkVM_IterSum-10            	    1520	    792669 ns/op	         3.383 heap-MB	        18.28 sys-MB	      5387 total-B/op	    5387 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	    1502	    796259 ns/op	         3.297 heap-MB	        18.28 sys-MB	      5388 total-B/op	    5387 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	    1518	    793385 ns/op	         3.344 heap-MB	        18.28 sys-MB	      5387 total-B/op	    5387 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	    1510	    793332 ns/op	         3.250 heap-MB	        18.28 sys-MB	      5387 total-B/op	    5387 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	    1512	    791879 ns/op	         3.203 heap-MB	        18.28 sys-MB	      5387 total-B/op	    5387 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	    1514	    797014 ns/op	         3.328 heap-MB	        18.28 sys-MB	      5387 total-B/op	    5387 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	    1520	    791972 ns/op	         3.250 heap-MB	        18.28 sys-MB	      5387 total-B/op	    5387 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	     716	   1636691 ns/op	         2.492 heap-MB	        18.28 sys-MB	      5389 total-B/op	    5388 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	    1500	    793018 ns/op	         3.172 heap-MB	        18.28 sys-MB	      5388 total-B/op	    5387 B/op	       8 allocs/op
+BenchmarkVM_IterSum-10            	    1512	    800299 ns/op	         3.289 heap-MB	        18.28 sys-MB	      5388 total-B/op	    5387 B/op	       8 allocs/op
+BenchmarkVM_MapGet-10             	     864	   1390628 ns/op	         3.281 heap-MB	        18.28 sys-MB	      9070 total-B/op	    9070 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     460	   2664377 ns/op	         2.883 heap-MB	        18.28 sys-MB	      9072 total-B/op	    9072 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     850	   2593155 ns/op	         3.117 heap-MB	        18.28 sys-MB	      9070 total-B/op	    9070 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     866	   1384154 ns/op	         3.234 heap-MB	        18.28 sys-MB	      9071 total-B/op	    9070 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     866	   2620975 ns/op	         3.305 heap-MB	        18.28 sys-MB	      9071 total-B/op	    9071 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     847	   1408156 ns/op	         3.086 heap-MB	        18.28 sys-MB	      9071 total-B/op	    9070 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     861	   1398337 ns/op	         3.242 heap-MB	        18.28 sys-MB	      9071 total-B/op	    9070 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     867	   1387573 ns/op	         3.211 heap-MB	        18.28 sys-MB	      9070 total-B/op	    9069 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     848	   1409184 ns/op	         3.094 heap-MB	        18.28 sys-MB	      9070 total-B/op	    9070 B/op	      11 allocs/op
+BenchmarkVM_MapGet-10             	     850	   1400582 ns/op	         3.062 heap-MB	        18.28 sys-MB	      9071 total-B/op	    9070 B/op	      11 allocs/op
+BenchmarkVM_ListBuild-10          	      18	  65761190 ns/op	         3.703 heap-MB	        18.55 sys-MB	 467745225 total-B/op	467745224 B/op	    4095 allocs/op
+BenchmarkVM_ListBuild-10          	      18	  63810942 ns/op	         3.484 heap-MB	        18.55 sys-MB	 467745078 total-B/op	467745077 B/op	    4094 allocs/op
+BenchmarkVM_ListBuild-10          	      19	  64958002 ns/op	         3.047 heap-MB	        18.55 sys-MB	 467745056 total-B/op	467745056 B/op	    4094 allocs/op
+BenchmarkVM_ListBuild-10          	      18	  67062340 ns/op	         3.703 heap-MB	        18.55 sys-MB	 467745084 total-B/op	467745084 B/op	    4094 allocs/op
+BenchmarkVM_ListBuild-10          	      19	  66239890 ns/op	         4.141 heap-MB	        18.55 sys-MB	 467745304 total-B/op	467745304 B/op	    4096 allocs/op
+BenchmarkVM_ListBuild-10          	      18	  65214995 ns/op	         3.266 heap-MB	        18.55 sys-MB	 467745308 total-B/op	467745308 B/op	    4096 allocs/op
+BenchmarkVM_ListBuild-10          	      18	  66641451 ns/op	         3.266 heap-MB	        22.62 sys-MB	 467745420 total-B/op	467745420 B/op	    4097 allocs/op
+BenchmarkVM_ListBuild-10          	      16	  64341997 ns/op	         3.922 heap-MB	        22.62 sys-MB	 467745450 total-B/op	467745450 B/op	    4098 allocs/op
+BenchmarkVM_ListBuild-10          	      18	  67264514 ns/op	         4.359 heap-MB	        22.62 sys-MB	 467745283 total-B/op	467745283 B/op	    4096 allocs/op
+BenchmarkVM_ListBuild-10          	      18	  65231356 ns/op	         3.484 heap-MB	        22.62 sys-MB	 467745271 total-B/op	467745270 B/op	    4096 allocs/op
+BenchmarkVM_HofMap-10             	     199	   5927546 ns/op	         2.711 heap-MB	        22.62 sys-MB	  47804729 total-B/op	47804729 B/op	    3634 allocs/op
+BenchmarkVM_HofMap-10             	     200	   6084010 ns/op	         4.086 heap-MB	        22.62 sys-MB	  47804855 total-B/op	47804854 B/op	    3635 allocs/op
+BenchmarkVM_HofMap-10             	     198	   5972499 ns/op	         3.156 heap-MB	        22.62 sys-MB	  47804975 total-B/op	47804975 B/op	    3636 allocs/op
+BenchmarkVM_HofMap-10             	     201	   6056489 ns/op	         4.523 heap-MB	        22.62 sys-MB	  47804983 total-B/op	47804982 B/op	    3636 allocs/op
+BenchmarkVM_HofMap-10             	     198	   6580391 ns/op	         3.938 heap-MB	        22.62 sys-MB	  47804881 total-B/op	47804881 B/op	    3635 allocs/op
+BenchmarkVM_HofMap-10             	     100	  11522499 ns/op	         3.148 heap-MB	        22.62 sys-MB	  47805072 total-B/op	47805072 B/op	    3636 allocs/op
+BenchmarkVM_HofMap-10             	     196	   6029827 ns/op	         4.531 heap-MB	        22.62 sys-MB	  47805104 total-B/op	47805103 B/op	    3637 allocs/op
+BenchmarkVM_HofMap-10             	     200	   6232974 ns/op	         3.148 heap-MB	        22.62 sys-MB	  47805166 total-B/op	47805165 B/op	    3637 allocs/op
+BenchmarkVM_HofMap-10             	     198	   6103534 ns/op	         3.922 heap-MB	        22.62 sys-MB	  47805106 total-B/op	47805106 B/op	    3637 allocs/op
+BenchmarkVM_HofMap-10             	     195	   6121477 ns/op	         4.469 heap-MB	        22.62 sys-MB	  47804983 total-B/op	47804982 B/op	    3636 allocs/op
+BenchmarkVM_QuerySelect-10        	      14	  77284357 ns/op	         4.281 heap-MB	        22.62 sys-MB	 529086119 total-B/op	529086118 B/op	   18143 allocs/op
+BenchmarkVM_QuerySelect-10        	      14	  74538488 ns/op	         3.406 heap-MB	        22.87 sys-MB	 529086422 total-B/op	529086421 B/op	   18146 allocs/op
+BenchmarkVM_QuerySelect-10        	      15	  75789000 ns/op	         4.719 heap-MB	        22.87 sys-MB	 529086348 total-B/op	529086347 B/op	   18145 allocs/op
+BenchmarkVM_QuerySelect-10        	      15	  73772739 ns/op	         4.062 heap-MB	        22.87 sys-MB	 529086316 total-B/op	529086316 B/op	   18144 allocs/op
+BenchmarkVM_QuerySelect-10        	      15	  72987258 ns/op	         3.961 heap-MB	        22.87 sys-MB	 529086491 total-B/op	529086491 B/op	   18146 allocs/op
+BenchmarkVM_QuerySelect-10        	      15	  76477606 ns/op	         3.953 heap-MB	        22.87 sys-MB	 529086025 total-B/op	529086024 B/op	   18142 allocs/op
+BenchmarkVM_QuerySelect-10        	      15	  75648272 ns/op	         2.977 heap-MB	        22.87 sys-MB	 529086388 total-B/op	529086388 B/op	   18145 allocs/op
+BenchmarkVM_QuerySelect-10        	      15	  73681547 ns/op	         4.609 heap-MB	        22.87 sys-MB	 529086196 total-B/op	529086196 B/op	   18144 allocs/op
+BenchmarkVM_QuerySelect-10        	      15	  74576508 ns/op	         3.078 heap-MB	        22.87 sys-MB	 529086384 total-B/op	529086384 B/op	   18145 allocs/op
+BenchmarkVM_QuerySelect-10        	      16	  76126125 ns/op	         3.953 heap-MB	        22.87 sys-MB	 529086378 total-B/op	529086378 B/op	   18145 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     619	   1958780 ns/op	         3.938 heap-MB	        22.87 sys-MB	   2839036 total-B/op	 2839035 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     924	   1308766 ns/op	         4.781 heap-MB	        22.87 sys-MB	   2839049 total-B/op	 2839048 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     612	   1933811 ns/op	         2.914 heap-MB	        22.87 sys-MB	   2839050 total-B/op	 2839049 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     925	   1319782 ns/op	         2.656 heap-MB	        22.87 sys-MB	   2839050 total-B/op	 2839050 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     920	   1943676 ns/op	         4.688 heap-MB	        22.87 sys-MB	   2839028 total-B/op	 2839027 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     619	   1937300 ns/op	         4.086 heap-MB	        22.87 sys-MB	   2839039 total-B/op	 2839038 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     621	   1947038 ns/op	         4.930 heap-MB	        22.87 sys-MB	   2839037 total-B/op	 2839037 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     619	   1938297 ns/op	         2.719 heap-MB	        22.87 sys-MB	   2839051 total-B/op	 2839051 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     920	   2024914 ns/op	         2.727 heap-MB	        22.87 sys-MB	   2839036 total-B/op	 2839035 B/op	   16018 allocs/op
+BenchmarkVM_ClosureDispatch-10    	     566	   1955324 ns/op	         2.805 heap-MB	        22.87 sys-MB	   2839034 total-B/op	 2839034 B/op	   16018 allocs/op
+PASS
+ok  	mochi/runtime/vm/bench	102.974s

--- a/runtime/vm/ops.go
+++ b/runtime/vm/ops.go
@@ -116,6 +116,8 @@ const (
 	OpIndex_List
 	OpIndex_Map
 	OpIndex_Str
+	OpSetIndex_List
+	OpSetIndex_Map
 )
 
 func (op Op) String() string {
@@ -308,6 +310,10 @@ func (op Op) String() string {
 		return "Index_Map"
 	case OpIndex_Str:
 		return "Index_Str"
+	case OpSetIndex_List:
+		return "SetIndex_List"
+	case OpSetIndex_Map:
+		return "SetIndex_Map"
 	default:
 		return "?"
 	}

--- a/runtime/vm/vm_eval.go
+++ b/runtime/vm/vm_eval.go
@@ -879,10 +879,15 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			val := fr.regs[ins.C]
 			switch dst.Tag {
 			case ValueNull:
+				// Autovivify path: do NOT quicken. A site that
+				// sometimes sees null (first write) and sometimes
+				// sees list (subsequent writes) would deopt on
+				// every first-write into a fresh variable.
 				dst.Tag = ValueList
 				dst.List = make([]Value, idxVal.Int+1)
 				dst.List[idxVal.Int] = val
 			case ValueList:
+				tryQuicken(fr.fn, fr.ip-1, OpSetIndex_List)
 				idx := idxVal.Int
 				if idx < 0 {
 					idx += len(dst.List)
@@ -906,6 +911,7 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				default:
 					key = valueToString(idxVal)
 				}
+				tryQuicken(fr.fn, fr.ip-1, OpSetIndex_Map)
 				if dst.Map == nil {
 					dst.Map = map[string]Value{}
 				}
@@ -913,6 +919,49 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			default:
 				return Value{}, m.newError(fmt.Errorf("invalid index target"), trace, ins.Line)
 			}
+		case OpSetIndex_List:
+			// MEP-19 quickened OpSetIndex: target observed as list.
+			// Tag mismatch (including the autovivify null path) deopts.
+			dst := &fr.regs[ins.A]
+			if dst.Tag != ValueList {
+				deoptQuicken(fr.fn, fr.ip-1)
+				fr.ip--
+				continue
+			}
+			idx := fr.regs[ins.B].Int
+			if idx < 0 {
+				idx += len(dst.List)
+			}
+			if idx < 0 {
+				return Value{}, m.newError(fmt.Errorf("index out of range"), trace, ins.Line)
+			}
+			if idx >= len(dst.List) {
+				newList := make([]Value, idx+1)
+				copy(newList, dst.List)
+				dst.List = newList
+			}
+			dst.List[idx] = fr.regs[ins.C]
+		case OpSetIndex_Map:
+			dst := &fr.regs[ins.A]
+			if dst.Tag != ValueMap {
+				deoptQuicken(fr.fn, fr.ip-1)
+				fr.ip--
+				continue
+			}
+			idxVal := fr.regs[ins.B]
+			var key string
+			switch idxVal.Tag {
+			case ValueStr:
+				key = idxVal.Str
+			case ValueInt:
+				key = fmt.Sprintf("%d", idxVal.Int)
+			default:
+				key = valueToString(idxVal)
+			}
+			if dst.Map == nil {
+				dst.Map = map[string]Value{}
+			}
+			dst.Map[key] = fr.regs[ins.C]
 		case OpMakeList:
 			n := ins.B
 			start := ins.C

--- a/website/docs/mep/mep-0019.md
+++ b/website/docs/mep/mep-0019.md
@@ -112,7 +112,7 @@ The combined gain of MEPs 18+19 is the target Mochi should hit before contemplat
 | Item                                                            | Status   |
 |-----------------------------------------------------------------|----------|
 | Quickening: numeric binary ops (`OpAdd_II`, `OpLess_II`, ...)   | proposed (largely subsumed by MEP-18 Phase A.1 native-int fast paths) |
-| Quickening: typed indexed access (`OpIndex_List`, ...)          | landed   |
+| Quickening: typed indexed access (`OpIndex_List`, `OpSetIndex_List`, ...) | landed (read and write paths; autovivify null-to-list path stays generic) |
 | Quickening: deopt counter and stable-fail path                  | landed (per-Function `quickMisses[ip]`, cap `siteMaxMisses=8`) |
 | Inline cache: monomorphic call site                             | landed (`OpCallV` closure path, per-Function `callSites[ip]`) |
 | Inline cache: polymorphic (N=4) call site                       | landed (`siteSlots=4` linear-scan cache; fills on miss until full, then bumps megamorphism counter) |


### PR DESCRIPTION
Closes #21486.

Symmetric to the OpIndex quickening landed in #21483. Generic `OpSetIndex` observes `dst.Tag` on the List and Map branches and patches `Quick` to `OpSetIndex_List` / `OpSetIndex_Map`. The autovivify null-to-list path stays generic (a fresh variable would deopt on the first write).

Typed handlers guard the tag and deopt via `deoptQuicken` on mismatch; `siteMaxMisses=8` bypasses permanently.

## Numbers

Wall-time deltas land in the noise envelope (~+/- 5%): the current bench corpus is dominated by reads and `append()` rather than direct index assignment. Lands for symmetry and surface coverage rather than perf wins. See benchstat at `runtime/vm/bench/history/v0.11.0-mep19-setindex-quicken.txt`.

## Test plan

- [x] `go build ./runtime/vm/...`
- [x] `go test -tags slow ./runtime/vm/` — 36 failing tests, identical set to main (pre-existing)
- [x] benchstat history checked in
- [x] MEP-19 status table updated