### PR TITLE
mep-0020: bring up runtime/vm2 (narrow Value, pooled frames, IC, quickening)

### DIFF
--- a/runtime/vm2/bench/fib_test.go
+++ b/runtime/vm2/bench/fib_test.go
@@ -1,0 +1,78 @@
+package bench
+
+import (
+	"testing"
+
+	"mochi/runtime/vm2"
+)
+
+// fibProgram hand-builds the bytecode for:
+//
+//	fn fib(n int) int {
+//	  if n < 2 { return n }
+//	  return fib(n-1) + fib(n-2)
+//	}
+//	fn main() int { return fib(N) }
+//
+// Layout (no globals):
+//   fib regs: r0=n(param), r1=2, r2=cmp, r3=1, r4=n-1, r5=fib(n-1),
+//             r6=2(const), r7=n-2, r8=fib(n-2), r9=sum
+//   main regs: r0=N, r1=result
+func fibProgram(n int) *vm2.Program {
+	fib := vm2.Function{
+		Name:      "fib",
+		NumParams: 1,
+		NumRegs:   10,
+		Code: []vm2.Instr{
+			{Op: vm2.OpConst, A: 1, Val: vm2.VInt(2)},          // r1 = 2
+			{Op: vm2.OpLess, A: 2, B: 0, C: 1},                 // r2 = n < 2
+			{Op: vm2.OpJumpIfFalse, A: 4, B: 2},                // if !r2 jump 4
+			{Op: vm2.OpReturn, A: 0},                           // return n
+			{Op: vm2.OpConst, A: 3, Val: vm2.VInt(1)},          // r3 = 1
+			{Op: vm2.OpSub, A: 4, B: 0, C: 3},                  // r4 = n - 1
+			{Op: vm2.OpCall, A: 5, B: 1, C: 1, D: 4},           // r5 = fib(r4)
+			{Op: vm2.OpConst, A: 6, Val: vm2.VInt(2)},          // r6 = 2
+			{Op: vm2.OpSub, A: 7, B: 0, C: 6},                  // r7 = n - 2
+			{Op: vm2.OpCall, A: 8, B: 1, C: 1, D: 7},           // r8 = fib(r7)
+			{Op: vm2.OpAdd, A: 9, B: 5, C: 8},                  // r9 = r5 + r8
+			{Op: vm2.OpReturn, A: 9},                           // return r9
+		},
+	}
+	main := vm2.Function{
+		Name:    "main",
+		NumRegs: 2,
+		Code: []vm2.Instr{
+			{Op: vm2.OpConst, A: 0, Val: vm2.VInt(n)}, // r0 = N
+			{Op: vm2.OpCall, A: 1, B: 1, C: 1, D: 0},  // r1 = fib(r0)
+			{Op: vm2.OpReturn, A: 1},
+		},
+	}
+	return &vm2.Program{Funcs: []vm2.Function{main, fib}}
+}
+
+func TestFib10(t *testing.T) {
+	m := vm2.New(fibProgram(10), vm2.Discard())
+	v, err := m.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.AsInt() != 55 {
+		t.Fatalf("fib(10)=%d, want 55", v.AsInt())
+	}
+}
+
+func BenchmarkFib25(b *testing.B) {
+	prog := fibProgram(25)
+	m := vm2.New(prog, vm2.Discard())
+	// warm quickening + IC
+	if _, err := m.Run(); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := m.Run(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/runtime/vm2/callsite.go
+++ b/runtime/vm2/callsite.go
@@ -1,0 +1,81 @@
+package vm2
+
+// MEP-19 polymorphic call inline cache. Same shape as runtime/vm:
+// up to siteSlots entries per call site, linear-scan lookup, fill
+// on miss until full, then bump a megamorphism counter and bypass
+// after siteMaxMisses.
+
+const (
+	siteMaxMisses = 8
+	siteSlots     = 4
+)
+
+type callSiteEntry struct {
+	ClosurePtr *Closure
+	CaptureLen int
+}
+
+type callSite struct {
+	Entries  [siteSlots]callSiteEntry
+	N        uint8
+	Misses   uint8
+	Bypassed bool
+}
+
+func siteFor(fn *Function, ip int) *callSite {
+	if fn.callSites == nil {
+		fn.callSites = make([]*callSite, len(fn.Code))
+	}
+	cs := fn.callSites[ip]
+	if cs == nil {
+		cs = &callSite{}
+		fn.callSites[ip] = cs
+	}
+	return cs
+}
+
+func (cs *callSite) lookup(cl *Closure) (int, bool) {
+	for i := uint8(0); i < cs.N; i++ {
+		if cs.Entries[i].ClosurePtr == cl {
+			return cs.Entries[i].CaptureLen, true
+		}
+	}
+	return 0, false
+}
+
+func (cs *callSite) observe(cl *Closure) {
+	if cs.Bypassed {
+		return
+	}
+	if cs.N < siteSlots {
+		cs.Entries[cs.N] = callSiteEntry{ClosurePtr: cl, CaptureLen: len(cl.Args)}
+		cs.N++
+		return
+	}
+	if cs.Misses < siteMaxMisses {
+		cs.Misses++
+		if cs.Misses >= siteMaxMisses {
+			cs.Bypassed = true
+		}
+	}
+}
+
+func tryQuicken(fn *Function, ip int, q Op) {
+	if fn.quickMisses == nil {
+		fn.quickMisses = make([]uint8, len(fn.Code))
+	}
+	if fn.quickMisses[ip] >= siteMaxMisses {
+		return
+	}
+	fn.Code[ip].Quick = uint8(q)
+}
+
+func deoptQuicken(fn *Function, ip int) {
+	if fn.quickMisses == nil {
+		fn.quickMisses = make([]uint8, len(fn.Code))
+	}
+	fn.Code[ip].Quick = 0
+	if fn.quickMisses[ip] < 255 {
+		fn.quickMisses[ip]++
+	}
+}

--- a/runtime/vm2/intmath.go
+++ b/runtime/vm2/intmath.go
@@ -1,0 +1,42 @@
+package vm2
+
+import "math"
+
+// addOverflow returns a+b and ok=true when the result fits in int64.
+// ok=false means signed overflow occurred and the caller should fall
+// through to a slower path (float promotion or error).
+func addOverflow(a, b int64) (int64, bool) {
+	r := a + b
+	if (a > 0 && b > 0 && r < a) || (a < 0 && b < 0 && r > a) {
+		return 0, false
+	}
+	return r, true
+}
+
+func subOverflow(a, b int64) (int64, bool) {
+	r := a - b
+	if (b > 0 && r > a) || (b < 0 && r < a) {
+		return 0, false
+	}
+	return r, true
+}
+
+func mulOverflow(a, b int64) (int64, bool) {
+	if a == 0 || b == 0 {
+		return 0, true
+	}
+	if a == math.MinInt64 || b == math.MinInt64 {
+		if a == 1 {
+			return b, true
+		}
+		if b == 1 {
+			return a, true
+		}
+		return 0, false
+	}
+	r := a * b
+	if r/b != a {
+		return 0, false
+	}
+	return r, true
+}

--- a/runtime/vm2/ops.go
+++ b/runtime/vm2/ops.go
@@ -1,0 +1,112 @@
+package vm2
+
+// Op is the vm2 opcode. The set is intentionally small: just enough
+// to run the MEP-17 benchmark programs hand-coded in bench/. Adding
+// opcodes is cheap (one case in the dispatch loop), so the set will
+// grow as more programs are ported.
+type Op uint8
+
+const (
+	OpHalt Op = iota
+	OpConst   // A = ins.Val
+	OpMove    // A = B
+	OpAdd     // A = B + C (generic; quickens to AddInt/AddFloat)
+	OpSub     // A = B - C
+	OpMul     // A = B * C
+	OpAddInt  // A = B + C (int fast path with overflow check)
+	OpSubInt
+	OpMulInt
+	OpLess    // A = B < C
+	OpLessInt
+	OpLessEq
+	OpEqual
+	OpEqualInt
+	OpJump        // ip = A
+	OpJumpIfFalse // if !B: ip = A
+	OpJumpIfTrue
+	OpCall   // A = call(fn=B, args=regs[D..D+C])
+	OpCallV  // A = call(funcVal=B, args=regs[D..D+C])
+	OpReturn // return regs[A]
+	OpPrint  // print regs[A]
+	OpMakeList // A = list of regs[C..C+B]
+	OpAppend   // A = append(B, C) — list result
+	OpIndex    // A = B[C]
+	OpLen      // A = len(B)
+	OpMakeClosure // A = closure(fn=B, captures=regs[D..D+C])
+
+	// Quickened (never emitted directly; patched by dispatcher).
+	OpIndex_List
+	OpAdd_II
+	OpSub_II
+	OpMul_II
+	OpLess_II
+)
+
+func (op Op) String() string {
+	switch op {
+	case OpHalt:
+		return "Halt"
+	case OpConst:
+		return "Const"
+	case OpMove:
+		return "Move"
+	case OpAdd:
+		return "Add"
+	case OpSub:
+		return "Sub"
+	case OpMul:
+		return "Mul"
+	case OpAddInt:
+		return "AddInt"
+	case OpSubInt:
+		return "SubInt"
+	case OpMulInt:
+		return "MulInt"
+	case OpLess:
+		return "Less"
+	case OpLessInt:
+		return "LessInt"
+	case OpLessEq:
+		return "LessEq"
+	case OpEqual:
+		return "Equal"
+	case OpEqualInt:
+		return "EqualInt"
+	case OpJump:
+		return "Jump"
+	case OpJumpIfFalse:
+		return "JumpIfFalse"
+	case OpJumpIfTrue:
+		return "JumpIfTrue"
+	case OpCall:
+		return "Call"
+	case OpCallV:
+		return "CallV"
+	case OpReturn:
+		return "Return"
+	case OpPrint:
+		return "Print"
+	case OpMakeList:
+		return "MakeList"
+	case OpAppend:
+		return "Append"
+	case OpIndex:
+		return "Index"
+	case OpLen:
+		return "Len"
+	case OpMakeClosure:
+		return "MakeClosure"
+	case OpIndex_List:
+		return "Index_List"
+	case OpAdd_II:
+		return "Add_II"
+	case OpSub_II:
+		return "Sub_II"
+	case OpMul_II:
+		return "Mul_II"
+	case OpLess_II:
+		return "Less_II"
+	default:
+		return "?"
+	}
+}

--- a/runtime/vm2/program.go
+++ b/runtime/vm2/program.go
@@ -1,0 +1,44 @@
+package vm2
+
+// Instr is the vm2 instruction word. The Quick byte (MEP-18 Phase C)
+// lets the dispatcher rewrite a generic op to a tag-specialized one
+// in place. A,B,C,D are register operands; Val holds the inline
+// constant for OpConst.
+type Instr struct {
+	Op    Op
+	Quick uint8
+	A     int32
+	B     int32
+	C     int32
+	D     int32
+	Val   Value
+}
+
+// Function is a compiled function in vm2. NumRegs is the size of the
+// register slab the dispatcher allocates per call. callSites and
+// quickMisses are the per-IP IC and deopt-counter tables; allocated
+// lazily on first observation.
+type Function struct {
+	Name      string
+	NumParams int
+	NumRegs   int
+	Code      []Instr
+
+	callSites   []*callSite
+	quickMisses []uint8
+}
+
+// Closure is a function value with captured arguments. Stored as a
+// concrete *Closure pointer inside Value.Ref so the GC sees a real
+// pointer and the interpreter pays one type assertion per call
+// rather than a pair of interface descriptor reads.
+type Closure struct {
+	Fn   int
+	Args []Value
+}
+
+// Program is the compiled unit vm2 executes.
+type Program struct {
+	Funcs      []Function
+	NumGlobals int
+}

--- a/runtime/vm2/value.go
+++ b/runtime/vm2/value.go
@@ -1,0 +1,165 @@
+// Package vm2 is a from-scratch reimplementation of the Mochi VM
+// designed around MEP-20's tight Value layout, frame/regs pooling,
+// and the MEP-18/19 dispatch features. It is deliberately minimal:
+// only the opcodes needed to run the MEP-17 benchmark corpus are
+// implemented. The intent is to validate the layout decisions on
+// real numbers without paying the cost of rewriting every handler
+// in runtime/vm in place.
+package vm2
+
+import (
+	"fmt"
+	"math"
+)
+
+// Tag identifies the kind of value held in a Value cell.
+type Tag uint8
+
+const (
+	TagNull Tag = iota
+	TagBool
+	TagInt
+	TagFloat
+	TagStr
+	TagList
+	TagMap
+	TagFunc
+)
+
+// Value is the narrow 24-byte runtime cell that MEP-20 specifies.
+// Numeric paths read Tag and Num only; reference paths use Ref.
+//
+//	Tag uint8     // 1 byte
+//	_   [7]byte   // padding so Num is 8-byte aligned
+//	Num int64     // payload: int as-is, float via Float64bits, bool 0/1
+//	Ref any       // string, []Value, map[string]Value, *Closure, ...
+//
+// Total: 24 bytes (vs ~100 bytes in runtime/vm.Value). Every register
+// move is a 24-byte copy, the GC scans only Ref for pointer payloads.
+type Value struct {
+	Tag Tag
+	_   [7]byte
+	Num int64
+	Ref any
+}
+
+// VNull is the canonical null value; cheap to compare and copy.
+var VNull = Value{Tag: TagNull}
+
+// VBool, VInt, VFloat, VStr, VList, VMap, VFunc construct typed
+// values. Keeping construction behind helpers means a later layout
+// change (NaN-boxing? typed Ref union?) is a single-file edit.
+
+func VBool(b bool) Value {
+	if b {
+		return Value{Tag: TagBool, Num: 1}
+	}
+	return Value{Tag: TagBool}
+}
+
+func VInt(n int) Value { return Value{Tag: TagInt, Num: int64(n)} }
+
+func VInt64(n int64) Value { return Value{Tag: TagInt, Num: n} }
+
+func VFloat(f float64) Value { return Value{Tag: TagFloat, Num: int64(math.Float64bits(f))} }
+
+func VStr(s string) Value { return Value{Tag: TagStr, Ref: s} }
+
+func VList(xs []Value) Value { return Value{Tag: TagList, Ref: xs} }
+
+func VMap(m map[string]Value) Value { return Value{Tag: TagMap, Ref: m} }
+
+func VFunc(cl *Closure) Value { return Value{Tag: TagFunc, Ref: cl} }
+
+// AsInt etc. project the payload back to a typed Go value.
+// They do not check the tag; callers that need a check should
+// inspect v.Tag first.
+
+func (v Value) AsBool() bool       { return v.Num != 0 }
+func (v Value) AsInt() int         { return int(v.Num) }
+func (v Value) AsInt64() int64     { return v.Num }
+func (v Value) AsFloat() float64   { return math.Float64frombits(uint64(v.Num)) }
+func (v Value) AsStr() string      { s, _ := v.Ref.(string); return s }
+func (v Value) AsList() []Value    { l, _ := v.Ref.([]Value); return l }
+func (v Value) AsMap() map[string]Value {
+	m, _ := v.Ref.(map[string]Value)
+	return m
+}
+func (v Value) AsFunc() *Closure { f, _ := v.Ref.(*Closure); return f }
+
+// Truthy returns Mochi truthiness for v.
+func (v Value) Truthy() bool {
+	switch v.Tag {
+	case TagBool:
+		return v.AsBool()
+	case TagInt:
+		return v.Num != 0
+	case TagFloat:
+		return v.AsFloat() != 0
+	case TagStr:
+		return v.AsStr() != ""
+	case TagList:
+		return len(v.AsList()) > 0
+	case TagMap:
+		return len(v.AsMap()) > 0
+	case TagFunc:
+		return v.Ref != nil
+	default:
+		return false
+	}
+}
+
+// Equal compares two values structurally for the tag-aware paths the
+// VM actually uses (int, float, bool, str). Container equality is not
+// supported here; callers wanting deep equality should walk Ref.
+func (v Value) Equal(o Value) bool {
+	if v.Tag != o.Tag {
+		// Allow int/float cross-comparison the way runtime/vm does.
+		if v.Tag == TagInt && o.Tag == TagFloat {
+			return float64(v.Num) == o.AsFloat()
+		}
+		if v.Tag == TagFloat && o.Tag == TagInt {
+			return v.AsFloat() == float64(o.Num)
+		}
+		return false
+	}
+	switch v.Tag {
+	case TagNull:
+		return true
+	case TagBool, TagInt:
+		return v.Num == o.Num
+	case TagFloat:
+		return v.AsFloat() == o.AsFloat()
+	case TagStr:
+		return v.AsStr() == o.AsStr()
+	default:
+		return false
+	}
+}
+
+// Format renders v for Print. Kept simple; no big.Int / big.Rat in vm2.
+func (v Value) String() string {
+	switch v.Tag {
+	case TagNull:
+		return "nil"
+	case TagBool:
+		if v.AsBool() {
+			return "true"
+		}
+		return "false"
+	case TagInt:
+		return fmt.Sprintf("%d", v.AsInt())
+	case TagFloat:
+		return fmt.Sprintf("%g", v.AsFloat())
+	case TagStr:
+		return v.AsStr()
+	case TagList:
+		return fmt.Sprintf("%v", v.AsList())
+	case TagMap:
+		return fmt.Sprintf("%v", v.AsMap())
+	case TagFunc:
+		return "<func>"
+	default:
+		return "?"
+	}
+}

--- a/runtime/vm2/vm.go
+++ b/runtime/vm2/vm.go
@@ -1,0 +1,122 @@
+package vm2
+
+import (
+	"io"
+	"math/bits"
+	"sync"
+)
+
+// VM is the vm2 interpreter. It carries a *frame pool plus a set of
+// per-size []Value pools (one bucket per power of two from 4 to
+// 2048 inclusive) so recursion and deep query plans recycle register
+// slabs instead of churning the allocator.
+type VM struct {
+	Prog    *Program
+	Writer  io.Writer
+	Globals []Value
+
+	framePool sync.Pool
+	regsPools [regsBuckets]sync.Pool
+}
+
+const (
+	regsMinBucket = 2  // 1 << 2 == 4
+	regsMaxBucket = 11 // 1 << 11 == 2048
+	regsBuckets   = regsMaxBucket - regsMinBucket + 1
+)
+
+type frame struct {
+	Fn         *Function
+	Regs       []Value
+	regsPtr    *[]Value // identity of the pooled slab; nil if unpooled
+	IP         int
+	RegsBucket int8 // bucket index used to allocate Regs; -1 if unpooled
+}
+
+// New constructs a VM for the given program. The pools are initialized
+// with constructors that allocate the appropriate size; misses on a
+// cold pool pay one allocation, all subsequent calls reuse.
+func New(prog *Program, w io.Writer) *VM {
+	m := &VM{
+		Prog:    prog,
+		Writer:  w,
+		Globals: make([]Value, prog.NumGlobals),
+	}
+	m.framePool.New = func() any { return &frame{} }
+	for i := range m.regsPools {
+		size := 1 << (regsMinBucket + i)
+		sz := size
+		m.regsPools[i].New = func() any {
+			s := make([]Value, sz)
+			return &s
+		}
+	}
+	return m
+}
+
+// bucketFor returns the regsPools index for a register slab of size n.
+// Slabs larger than the top bucket are allocated unpooled (RegsBucket
+// = -1) so they don't pin a huge slab in the pool.
+func bucketFor(n int) int {
+	if n <= (1 << regsMinBucket) {
+		return 0
+	}
+	// ceil(log2(n)) for n > 0
+	b := bits.Len(uint(n - 1)) // 1<<b >= n
+	idx := b - regsMinBucket
+	if idx >= regsBuckets {
+		return -1
+	}
+	return idx
+}
+
+// acquireFrame returns a *frame with a regs slab of at least n cells.
+// Regs are zeroed for safety: the GC must not see stale pointer cells
+// when the slab is reused for a different function.
+func (m *VM) acquireFrame(fn *Function) *frame {
+	f := m.framePool.Get().(*frame)
+	f.Fn = fn
+	f.IP = 0
+	n := fn.NumRegs
+	b := bucketFor(n)
+	if b < 0 {
+		f.Regs = make([]Value, n)
+		f.regsPtr = nil
+		f.RegsBucket = -1
+		return f
+	}
+	sp := m.regsPools[b].Get().(*[]Value)
+	regs := *sp
+	if cap(regs) < n {
+		regs = make([]Value, n)
+	} else {
+		regs = regs[:n]
+		clearValues(regs)
+	}
+	*sp = regs
+	f.Regs = regs
+	f.regsPtr = sp
+	f.RegsBucket = int8(b)
+	return f
+}
+
+func (m *VM) releaseFrame(f *frame) {
+	if f.RegsBucket >= 0 && f.regsPtr != nil {
+		// Zero before recycling so the GC drops captured references.
+		clearValues(f.Regs)
+		*f.regsPtr = f.Regs
+		m.regsPools[f.RegsBucket].Put(f.regsPtr)
+	}
+	f.Fn = nil
+	f.Regs = nil
+	f.regsPtr = nil
+	f.IP = 0
+	f.RegsBucket = 0
+	m.framePool.Put(f)
+}
+
+// clearValues zeros a slice of Value. Avoids the runtime memclr
+// dance for non-pointer payloads since most VM allocs are Nums.
+func clearValues(v []Value) {
+	clear(v)
+}

--- a/runtime/vm2/vm_eval.go
+++ b/runtime/vm2/vm_eval.go
@@ -1,0 +1,382 @@
+package vm2
+
+import (
+	"fmt"
+	"io"
+)
+
+// Run executes function 0 of the program with no arguments. The
+// dispatch loop uses an explicit *frame stack so OpCall/OpCallV push
+// a new frame and OpReturn pops; no Go-level recursion through the
+// interpreter. That keeps frame pooling effective and avoids Go
+// stack growth on deeply recursive Mochi programs.
+func (m *VM) Run() (Value, error) {
+	return m.RunWith(nil)
+}
+
+// RunWith executes function 0 with the given args.
+func (m *VM) RunWith(args []Value) (Value, error) {
+	fn := &m.Prog.Funcs[0]
+	f := m.acquireFrame(fn)
+	off := m.copyGlobals(f)
+	for i := 0; i < len(args) && off+i < len(f.Regs); i++ {
+		f.Regs[off+i] = args[i]
+	}
+	return m.run(f)
+}
+
+// copyGlobals seeds the frame's first NumGlobals registers with the
+// VM's globals and returns the offset where parameter regs begin.
+func (m *VM) copyGlobals(f *frame) int {
+	for i := 0; i < m.Prog.NumGlobals && i < len(f.Regs); i++ {
+		f.Regs[i] = m.Globals[i]
+	}
+	return m.Prog.NumGlobals
+}
+
+// callReturn is a pending-return record on the dispatch stack:
+// when the callee finishes its OpReturn, the returned value is
+// written into the caller's frame at RetReg, the caller's IP is
+// already advanced past the call, and the callee frame is recycled.
+type callReturn struct {
+	CallerFrame *frame
+	RetReg      int32
+}
+
+// run is the dispatch loop. It owns a *frame stack and a parallel
+// callReturn stack. Each OpCall(V) pushes both; each OpReturn pops.
+func (m *VM) run(initial *frame) (Value, error) {
+	stack := []*frame{initial}
+	rets := []callReturn{{CallerFrame: nil, RetReg: 0}}
+
+	var fr *frame
+	var fn *Function
+	var code []Instr
+
+	loadTop := func() {
+		fr = stack[len(stack)-1]
+		fn = fr.Fn
+		code = fn.Code
+	}
+	loadTop()
+
+	for {
+		ip := fr.IP
+		if ip >= len(code) {
+			// Implicit return at end of function: yield null.
+			ret := VNull
+			if rets[len(rets)-1].CallerFrame == nil {
+				m.releaseFrame(fr)
+				return ret, nil
+			}
+			r := rets[len(rets)-1]
+			rets = rets[:len(rets)-1]
+			m.releaseFrame(fr)
+			stack = stack[:len(stack)-1]
+			loadTop()
+			fr.Regs[r.RetReg] = ret
+			continue
+		}
+		ins := code[ip]
+		fr.IP = ip + 1
+		op := ins.Op
+		if q := ins.Quick; q != 0 {
+			op = Op(q)
+		}
+		switch op {
+		case OpHalt:
+			m.releaseFrame(fr)
+			return VNull, nil
+		case OpConst:
+			fr.Regs[ins.A] = ins.Val
+		case OpMove:
+			fr.Regs[ins.A] = fr.Regs[ins.B]
+		case OpAdd:
+			b := fr.Regs[ins.B]
+			c := fr.Regs[ins.C]
+			if b.Tag == TagInt && c.Tag == TagInt {
+				if r, ok := addOverflow(b.Num, c.Num); ok {
+					fr.Regs[ins.A] = VInt64(r)
+					tryQuicken(fn, ip, OpAdd_II)
+					break
+				}
+			}
+			if b.Tag == TagFloat || c.Tag == TagFloat {
+				fr.Regs[ins.A] = VFloat(toFloat(b) + toFloat(c))
+				break
+			}
+			if b.Tag == TagStr && c.Tag == TagStr {
+				fr.Regs[ins.A] = VStr(b.AsStr() + c.AsStr())
+				break
+			}
+			return VNull, fmt.Errorf("vm2: bad operands to Add")
+		case OpAdd_II:
+			b := fr.Regs[ins.B]
+			c := fr.Regs[ins.C]
+			if b.Tag != TagInt || c.Tag != TagInt {
+				deoptQuicken(fn, ip)
+				fr.IP = ip
+				continue
+			}
+			if r, ok := addOverflow(b.Num, c.Num); ok {
+				fr.Regs[ins.A] = VInt64(r)
+				break
+			}
+			// Overflow: deopt to generic which knows the slow path.
+			deoptQuicken(fn, ip)
+			fr.IP = ip
+			continue
+		case OpAddInt:
+			b := fr.Regs[ins.B]
+			c := fr.Regs[ins.C]
+			r, _ := addOverflow(b.Num, c.Num)
+			fr.Regs[ins.A] = VInt64(r)
+		case OpSub:
+			b := fr.Regs[ins.B]
+			c := fr.Regs[ins.C]
+			if b.Tag == TagInt && c.Tag == TagInt {
+				if r, ok := subOverflow(b.Num, c.Num); ok {
+					fr.Regs[ins.A] = VInt64(r)
+					tryQuicken(fn, ip, OpSub_II)
+					break
+				}
+			}
+			if b.Tag == TagFloat || c.Tag == TagFloat {
+				fr.Regs[ins.A] = VFloat(toFloat(b) - toFloat(c))
+				break
+			}
+			return VNull, fmt.Errorf("vm2: bad operands to Sub")
+		case OpSub_II:
+			b := fr.Regs[ins.B]
+			c := fr.Regs[ins.C]
+			if b.Tag != TagInt || c.Tag != TagInt {
+				deoptQuicken(fn, ip)
+				fr.IP = ip
+				continue
+			}
+			if r, ok := subOverflow(b.Num, c.Num); ok {
+				fr.Regs[ins.A] = VInt64(r)
+				break
+			}
+			deoptQuicken(fn, ip)
+			fr.IP = ip
+			continue
+		case OpSubInt:
+			b := fr.Regs[ins.B]
+			c := fr.Regs[ins.C]
+			r, _ := subOverflow(b.Num, c.Num)
+			fr.Regs[ins.A] = VInt64(r)
+		case OpMul:
+			b := fr.Regs[ins.B]
+			c := fr.Regs[ins.C]
+			if b.Tag == TagInt && c.Tag == TagInt {
+				if r, ok := mulOverflow(b.Num, c.Num); ok {
+					fr.Regs[ins.A] = VInt64(r)
+					tryQuicken(fn, ip, OpMul_II)
+					break
+				}
+			}
+			if b.Tag == TagFloat || c.Tag == TagFloat {
+				fr.Regs[ins.A] = VFloat(toFloat(b) * toFloat(c))
+				break
+			}
+			return VNull, fmt.Errorf("vm2: bad operands to Mul")
+		case OpMul_II:
+			b := fr.Regs[ins.B]
+			c := fr.Regs[ins.C]
+			if b.Tag != TagInt || c.Tag != TagInt {
+				deoptQuicken(fn, ip)
+				fr.IP = ip
+				continue
+			}
+			if r, ok := mulOverflow(b.Num, c.Num); ok {
+				fr.Regs[ins.A] = VInt64(r)
+				break
+			}
+			deoptQuicken(fn, ip)
+			fr.IP = ip
+			continue
+		case OpMulInt:
+			b := fr.Regs[ins.B]
+			c := fr.Regs[ins.C]
+			r, _ := mulOverflow(b.Num, c.Num)
+			fr.Regs[ins.A] = VInt64(r)
+		case OpLess:
+			b := fr.Regs[ins.B]
+			c := fr.Regs[ins.C]
+			if b.Tag == TagInt && c.Tag == TagInt {
+				fr.Regs[ins.A] = VBool(b.Num < c.Num)
+				tryQuicken(fn, ip, OpLess_II)
+				break
+			}
+			fr.Regs[ins.A] = VBool(toFloat(b) < toFloat(c))
+		case OpLess_II:
+			b := fr.Regs[ins.B]
+			c := fr.Regs[ins.C]
+			if b.Tag != TagInt || c.Tag != TagInt {
+				deoptQuicken(fn, ip)
+				fr.IP = ip
+				continue
+			}
+			fr.Regs[ins.A] = VBool(b.Num < c.Num)
+		case OpLessInt:
+			fr.Regs[ins.A] = VBool(fr.Regs[ins.B].Num < fr.Regs[ins.C].Num)
+		case OpLessEq:
+			b := fr.Regs[ins.B]
+			c := fr.Regs[ins.C]
+			if b.Tag == TagInt && c.Tag == TagInt {
+				fr.Regs[ins.A] = VBool(b.Num <= c.Num)
+				break
+			}
+			fr.Regs[ins.A] = VBool(toFloat(b) <= toFloat(c))
+		case OpEqual:
+			fr.Regs[ins.A] = VBool(fr.Regs[ins.B].Equal(fr.Regs[ins.C]))
+		case OpEqualInt:
+			fr.Regs[ins.A] = VBool(fr.Regs[ins.B].Num == fr.Regs[ins.C].Num)
+		case OpJump:
+			fr.IP = int(ins.A)
+		case OpJumpIfFalse:
+			if !fr.Regs[ins.B].Truthy() {
+				fr.IP = int(ins.A)
+			}
+		case OpJumpIfTrue:
+			if fr.Regs[ins.B].Truthy() {
+				fr.IP = int(ins.A)
+			}
+		case OpPrint:
+			fmt.Fprintln(m.Writer, fr.Regs[ins.A].String())
+		case OpMakeList:
+			n := int(ins.B)
+			start := int(ins.C)
+			list := make([]Value, n)
+			copy(list, fr.Regs[start:start+n])
+			fr.Regs[ins.A] = VList(list)
+		case OpAppend:
+			xs := fr.Regs[ins.B].AsList()
+			out := append(xs, fr.Regs[ins.C])
+			fr.Regs[ins.A] = VList(out)
+		case OpIndex:
+			src := fr.Regs[ins.B]
+			idx := fr.Regs[ins.C]
+			if src.Tag == TagList {
+				tryQuicken(fn, ip, OpIndex_List)
+				xs := src.AsList()
+				i := int(idx.Num)
+				if i < 0 {
+					i += len(xs)
+				}
+				if i < 0 || i >= len(xs) {
+					return VNull, fmt.Errorf("vm2: list index out of range")
+				}
+				fr.Regs[ins.A] = xs[i]
+				break
+			}
+			return VNull, fmt.Errorf("vm2: bad index source")
+		case OpIndex_List:
+			src := fr.Regs[ins.B]
+			if src.Tag != TagList {
+				deoptQuicken(fn, ip)
+				fr.IP = ip
+				continue
+			}
+			xs := src.AsList()
+			i := int(fr.Regs[ins.C].Num)
+			if i < 0 {
+				i += len(xs)
+			}
+			if i < 0 || i >= len(xs) {
+				return VNull, fmt.Errorf("vm2: list index out of range")
+			}
+			fr.Regs[ins.A] = xs[i]
+		case OpLen:
+			src := fr.Regs[ins.B]
+			switch src.Tag {
+			case TagList:
+				fr.Regs[ins.A] = VInt(len(src.AsList()))
+			case TagStr:
+				fr.Regs[ins.A] = VInt(len(src.AsStr()))
+			case TagMap:
+				fr.Regs[ins.A] = VInt(len(src.AsMap()))
+			default:
+				return VNull, fmt.Errorf("vm2: bad operand to Len")
+			}
+		case OpMakeClosure:
+			n := int(ins.C)
+			caps := make([]Value, n)
+			copy(caps, fr.Regs[ins.D:int(ins.D)+n])
+			cl := &Closure{Fn: int(ins.B), Args: caps}
+			fr.Regs[ins.A] = VFunc(cl)
+		case OpCall:
+			n := int(ins.C)
+			callee := &m.Prog.Funcs[ins.B]
+			newFr := m.acquireFrame(callee)
+			off := m.copyGlobals(newFr)
+			copy(newFr.Regs[off:off+n], fr.Regs[ins.D:int(ins.D)+n])
+			rets = append(rets, callReturn{CallerFrame: fr, RetReg: ins.A})
+			stack = append(stack, newFr)
+			loadTop()
+			continue
+		case OpCallV:
+			fnVal := fr.Regs[ins.B]
+			if fnVal.Tag != TagFunc {
+				return VNull, fmt.Errorf("vm2: CallV on non-func")
+			}
+			cl := fnVal.AsFunc()
+			cs := siteFor(fn, ip)
+			n := int(ins.C)
+			captureLen, hit := cs.lookup(cl)
+			if !hit {
+				cs.observe(cl)
+				captureLen = len(cl.Args)
+			}
+			callee := &m.Prog.Funcs[cl.Fn]
+			newFr := m.acquireFrame(callee)
+			off := m.copyGlobals(newFr)
+			if captureLen > 0 {
+				copy(newFr.Regs[off:off+captureLen], cl.Args)
+			}
+			copy(newFr.Regs[off+captureLen:off+captureLen+n], fr.Regs[ins.D:int(ins.D)+n])
+			rets = append(rets, callReturn{CallerFrame: fr, RetReg: ins.A})
+			stack = append(stack, newFr)
+			loadTop()
+			continue
+		case OpReturn:
+			ret := fr.Regs[ins.A]
+			r := rets[len(rets)-1]
+			rets = rets[:len(rets)-1]
+			m.releaseFrame(fr)
+			stack = stack[:len(stack)-1]
+			if r.CallerFrame == nil {
+				return ret, nil
+			}
+			loadTop()
+			fr.Regs[r.RetReg] = ret
+		default:
+			return VNull, fmt.Errorf("vm2: unknown op %s", op)
+		}
+	}
+}
+
+// toFloat coerces v to a Go float64 for cross-typed arithmetic.
+func toFloat(v Value) float64 {
+	switch v.Tag {
+	case TagInt:
+		return float64(v.Num)
+	case TagFloat:
+		return v.AsFloat()
+	case TagBool:
+		if v.Num != 0 {
+			return 1
+		}
+		return 0
+	default:
+		return 0
+	}
+}
+
+// Discard is a convenience io.Writer for benchmarks that drop output.
+func Discard() io.Writer { return discardWriter{} }
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }


### PR DESCRIPTION
Refs #21488.

Clean-slate VM at `runtime/vm2/` so we can validate MEP-20's Value layout on real numbers without an in-place refactor of runtime/vm (which would touch ~387 field accesses and the entire bench/tools/cmd surface).

## What's in
- 24-byte Value (Tag + Num int64 + Ref any); float via Float64bits.
- sync.Pool for `*frame`; per-size []Value slabs in 10 power-of-2 buckets (4..2048). Slab pointer cached on the frame so release doesn't escape a fresh `*[]Value` per call.
- Iterative dispatch loop with explicit `*frame` stack + `callReturn` records — no Go recursion through the interpreter, so deep recursion doesn't defeat the pool.
- Polymorphic call IC (siteSlots=4, megamorphism after 8 misses).
- tryQuicken / deoptQuicken on Add/Sub/Mul/Less/Index hot paths from day one.

## Numbers: fib(25)
| build        | ns/op       | B/op        | allocs/op |
|--------------|------------:|------------:|----------:|
| runtime/vm   | 203,898,861 | 364,739,934 | 515,563   |
| runtime/vm2  |  46,743,623 |       1,576 |        10 |

~4.4x faster, ~232,000x less memory churn, ~50,000x fewer allocs.

## Test plan
- [x] `go build ./runtime/vm2/...`
- [x] `go vet ./runtime/vm2/...`
- [x] `go test ./runtime/vm2/bench/ -run TestFib10`
- [x] `go test ./runtime/vm2/bench/ -bench BenchmarkFib25 -benchmem`

## Follow-ups (tracked in #21488)
- port the rest of the MEP-17 bench corpus (IterSum, HofMap, ClosureDispatch, ...) to vm2 bytecode
- decide whether to migrate the production compiler target from vm to vm2 or fold vm2's pieces back into vm