### PR TITLE
mep-0021: replace VM Conformance spec with Type-Directed Bytecode

### DIFF
--- a/website/docs/mep/mep-0000.md
+++ b/website/docs/mep/mep-0000.md
@@ -76,7 +76,7 @@ The current series covers the soundness initiative for v0.11.0. Numbering follow
 | [18](/docs/mep/mep-0018)| Bytecode Dispatch in a Go-Hosted VM    | Draft         | Standards Track |
 | [19](/docs/mep/mep-0019)| Adaptive Specialization and Inline Caches | Draft      | Standards Track |
 | [20](/docs/mep/mep-0020)| Value Representation and Allocation Discipline | Draft | Standards Track |
-| [21](/docs/mep/mep-0021)| VM Conformance and Differential Testing | Draft        | Standards Track |
+| [21](/docs/mep/mep-0021)| Type-Directed Bytecode and Compiler/VM Co-Design | Draft | Standards Track |
 | [22](/docs/mep/mep-0022)| Baseline JIT via Copy-and-Patch        | Deferred      | Informational   |
 | [23](/docs/mep/mep-0023)| Cross-language Baseline Benchmarks     | Draft         | Process         |
 

--- a/website/docs/mep/mep-0021.md
+++ b/website/docs/mep/mep-0021.md
@@ -1,157 +1,191 @@
 ---
 mep: 21
-title: VM Conformance and Differential Testing
+title: Type-Directed Bytecode and Compiler/VM Co-Design
 author: Mochi core
 status: Draft
 type: Standards Track
 created: 2026-05-16
 sidebar_position: 21
-sidebar_label: MEP 21. VM Conformance
-description: Beyond golden files, fuzz the bytecode compiler, differential-test interpreter against constant folding, and prove laws via property tests so MEP-18 through MEP-22 cannot regress correctness.
+sidebar_label: MEP 21. Type-Directed Bytecode
+description: Mochi is statically typed. The compiler should emit type-specialized opcodes directly from the type checker's output, so the VM only quickens what is genuinely polymorphic and the bench corpus pays no IC tax on hot paths whose types were known at compile time.
 ---
 
-# MEP 21. VM Conformance and Differential Testing
+# MEP 21. Type-Directed Bytecode and Compiler/VM Co-Design
 
-| Field    | Value                                  |
-|----------|----------------------------------------|
-| MEP      | 21                                     |
-| Title    | VM Conformance and Differential Testing |
-| Author   | Mochi core                             |
-| Status   | Draft                                  |
-| Type     | Standards Track                        |
-| Created  | 2026-05-16                             |
+| Field    | Value                                          |
+|----------|------------------------------------------------|
+| MEP      | 21                                             |
+| Title    | Type-Directed Bytecode and Compiler/VM Co-Design |
+| Author   | Mochi core                                     |
+| Status   | Draft                                          |
+| Type     | Standards Track                                |
+| Created  | 2026-05-16                                     |
 
 ## Abstract
 
-MEPs 18 through 22 propose changes to dispatch, specialization, value representation, and (eventually) code generation. Each change is a chance to introduce a correctness regression that the existing golden suite misses because the regression only fires on inputs nobody wrote a fixture for. This MEP adds three correctness layers that close the gap without requiring a fixture for every bug: differential execution between the interpreter and the constant folder, property-based testing for laws the VM must obey, and Go's native `testing.F` fuzzer for the bytecode compiler.
+The vm2 bring-up (MEP-20) lands a 24-byte `Value`, pooled frames, a polymorphic call inline cache (MEP-19), and a quickening byte (MEP-18 Phase C). All four assume the runtime does not know the types ahead of time, so it must observe, specialize, and be ready to deopt. Mochi's type checker actually does know those types in almost every interesting case. This MEP closes the gap. The compiler emits typed opcodes (`OpAddInt`, `OpLessInt`, `OpIndex_List`, `OpCallStatic`) directly when its type information is exact, and the VM's tag-checking + quickening + IC machinery becomes a fallback for the residual polymorphic surface (interface dispatch, `any`, dataset queries with `dynamic` columns).
 
-These layers are independent of any of the perf MEPs; they harden the VM regardless of which optimization lands next. They also enable future MEPs (notably the copy-and-patch baseline JIT in MEP-22) to be tested against an oracle: the interpreter is the reference, the JIT is the candidate, and a differential harness compares outputs over a corpus.
+The result is a VM whose hot path on a statically typed program runs typed opcodes from instruction zero, without the tag-check + tryQuicken + deopt path that an observation-driven design pays on every site. That is the design Lua/LuaJIT, HotSpot, CoreCLR, Dart AOT, Crystal, and Julia all converge on for the same reason: when the front end knows, the back end should not have to learn.
 
 ## Motivation
 
-The Mochi conformance suite today is two things: golden files (`tests/vm/valid/*.mochi` + `.out` pairs) and the Rosetta task corpus (`tests/rosetta/x/Mochi/`). Both are *example-based*: a fixture passes if its output matches the recorded `.out`. This catches the bugs someone wrote a fixture for. It misses the rest.
+vm2 today, on `fib(25)`, runs the first iteration of every arithmetic op as `OpAdd`/`OpSub`/`OpLess`. Each call into the body pays:
 
-The patterns this MEP closes are well-known:
+1. a tag check on both operands,
+2. an overflow check,
+3. a `tryQuicken` write into the instruction word.
 
-1. **Optimizer-introduced divergence.** A constant-folding pass that mis-evaluates `1e308 * 10` produces `+Inf` while the runtime evaluates `+Inf` correctly. The golden test passes if `1e308 * 10` is never in a fixture. The differential harness catches it because it asks: "is the folded answer equal to the unfolded answer for every expression in the corpus?"
-2. **Quickened opcode bugs.** MEP-19 introduces `OpAdd_II`. If the deopt path is wrong on overflow, the bug shows up only on overflowing inputs, which goldens may not exercise. A property test on `OpAdd` (associative-modulo-overflow, commutative) catches it.
-3. **Bytecode compiler crashes.** A malformed input that the parser accepts but the compiler panics on. The Go fuzzer can find these in minutes given a seed corpus.
+Iteration two onward dispatches via the `Quick` byte to `OpAdd_II` etc., so the steady-state cost is one tag check + one overflow check + the arithmetic. The tag check exists only because the dispatcher does not trust the operand types. In Mochi `n - 1` where `n: int`, the type checker has *already* proved both operands are `int`. The compiler is throwing that proof away.
 
-Each layer below corresponds to one of these.
+Three concrete consequences:
+
+- **Cold-start tax.** Short programs (test fixtures, one-shot scripts, REPL evals) never reach the steady state. They pay the slow generic op for every site.
+- **Deopt risk on never-polymorphic sites.** If `OpAdd_II` ever sees a float (e.g. a const-folded `1.0` slips through), it deopts to `OpAdd` permanently after `siteMaxMisses`. A type-directed emitter would have used `OpAddFloat` from the start and the question would not arise.
+- **IC pressure on monomorphic calls.** `OpCallV` runs the polymorphic IC even when the call target is a statically resolved top-level function. A direct `OpCall` is one indirect jump; the IC path is a slot scan + capture-copy.
+
+Modern statically typed VMs do not pay these costs. The relevant prior art:
+
+- **JVM (since 1995).** Separate `iadd`, `ladd`, `fadd`, `dadd` opcodes; the verifier proves operand types statically. C1/C2 never speculate on numeric types because they were never in doubt.
+- **CLR / CIL.** Typed locals + typed `add.ovf.i4` / `add.r8` etc. RyuJIT inherits perfect type info from the verifier.
+- **LuaJIT.** Dynamically typed source, but the trace recorder commits to types at trace head and the resulting machine code is type-monomorphic; deopt is the *exception* path, not the steady-state path. The Mochi compiler can skip the recorder entirely because the front end is the type oracle.
+- **Dart AOT.** Kernel IR carries types end-to-end; `dart compile aot-snapshot` lowers to type-specialized calls with no profile data.
+- **Crystal, Julia, Roc.** All compile from a type-stable source to monomorphized IR; type-stability warnings exist precisely because the back end can only specialize what the front end nails down.
+- **WebAssembly.** Typed by construction; `i32.add` is not the same opcode as `f64.add`. The recently proposed GC and JS-string-builtins proposals continue to push *more* type information into the instruction set, not less.
+- **PEP 659 (CPython).** The opposite end of the spectrum: zero static types, full observation. Mochi has the inputs CPython does not; copying CPython's design wholesale leaves perf on the table.
+
+The unifying principle: **specialization wants type information; type information is cheapest at the point in the pipeline where it was just proved.** In Mochi that point is the end of `types/check.go`. By the time bytecode emission runs, the proof is one struct field away.
 
 ## Specification
 
-### Layer 1: differential execution (folder vs interpreter)
+### Principle
 
-The Mochi compiler does constant folding in `runtime/vm/constfold.go`. The interpreter evaluates the same expressions at runtime. They must agree.
+> A site whose operand types are exact at type-check time MUST be lowered to a typed opcode. Quickening, IC, and deopt MUST be reserved for sites whose types are genuinely unresolved (`any`, interface methods, `dynamic` query columns, FFI returns).
 
-A new test harness, `runtime/vm/diff/`, walks every expression in every program in the bench suite (MEP-17), the golden suite, and the Rosetta corpus. For each pure expression (no `! io`, no `! fs`, etc., per MEP-15 effect inference) it:
+"Exact" means: every operand has a concrete monotype after type checking and effect inference. Generic type variables count as exact at each instantiation site (the monomorphizer fixes them before emission). Union types do not count as exact; they emit the generic op with a quickening hint.
 
-1. Evaluates the expression at compile time via `constfold.Eval`.
-2. Compiles the expression to bytecode with folding disabled and evaluates at runtime via the interpreter.
-3. Asserts the two values are `equal`, where `equal` follows Mochi's structural equality.
+### Lowering pass
 
-A divergence is a P1 bug. The test fails the CI run.
-
-Pure expressions are the only ones in scope because impure expressions are non-deterministic by definition (`now()`, `fetch(...)`). MEP-15's `Effects.IsEmpty()` is the gate: if the expression is pure, the two evaluators must agree.
-
-This catches the entire class of "the optimizer rewrites this to a value the interpreter does not produce" bugs. It is a one-time investment with permanent value; every optimization MEP gets free oracle testing.
-
-### Layer 2: property-based testing
-
-A new package `runtime/vm/prop/` defines properties that the VM must obey across every input. Properties express *laws*, not examples. Implementation uses [gopter] or hand-written quickcheck-style generators (gopter is preferred for breadth).
-
-The starter law set:
-
-- **Arithmetic associativity over `int`:** `(a + b) + c == a + (b + c)` for all int `a, b, c`. Modulo overflow, which Mochi defines per MEP (TODO: cite the right MEP) as wrapping; the property is on the wrapped result.
-- **Arithmetic commutativity over `int` and `float`:** `a + b == b + a`. Caveat for float: NaN. The property excludes NaN inputs.
-- **Equality reflexivity:** `x == x` for every value not containing NaN.
-- **`len` of `append`:** `len(append(xs, y)) == len(xs) + 1`.
-- **Map round-trip:** `m[k] = v; m[k] == v` for any key `k` and value `v`.
-- **Option unwrap-after-guard:** for any `Option<T>`, if `o != none` then `o!` returns the wrapped value (MEP-16).
-- **Pure expression idempotency:** for any pure expression `e`, `e == e` evaluated twice.
-- **Effect-set monotonicity (MEP-15):** for any function `f`, `inferredEffects(f) ⊆ declaredEffects(f)` whenever a declaration is present.
-
-Each property runs a few thousand random inputs by default; CI runs more (configurable via `MOCHI_PROP_N`). A failed property prints the smallest counterexample (shrinking).
-
-Properties are not fixtures. They do not pin a specific output; they pin a relationship. This is the right tool for the optimizer-vs-interpreter agreement question and for any invariant the type system promises.
-
-### Layer 3: bytecode-compiler fuzzing
-
-Go's native `testing.F` runs fuzzers in CI ([Go-Fuzz]). A new file `runtime/vm/fuzz_test.go` defines:
+A new pass, `compiler/lower_typed.go`, runs between the type checker and the bytecode emitter. Input: typed AST. Output: typed AST annotated with `EmitHint` per expression node.
 
 ```go
-func FuzzCompile(f *testing.F) {
-    seedFromCorpus(f, "tests/vm/valid")
-    f.Fuzz(func(t *testing.T, src string) {
-        prog, err := parser.ParseString(src)
-        if err != nil {
-            return
-        }
-        defer func() { recover() }() // panics are the bugs we hunt
-        _, _ = vm.Compile(prog, nil)
-    })
+type EmitHint struct {
+    Op       vm2.Op   // typed opcode to emit; 0 = use generic
+    LhsTag   vm2.Tag  // proven static tag of left operand
+    RhsTag   vm2.Tag  // proven static tag of right operand
+    Resolved bool     // call target known statically (true => OpCall, not OpCallV)
+    FuncIdx  int      // resolved function index when Resolved
 }
 ```
 
-The seed corpus is the existing golden inputs (paths walked at fuzz init). The fuzzer mutates them. Any panic in `vm.Compile` is a bug; the fuzzer minimizes and reports.
+The emitter consults the hint. When `Op != 0` it emits that op directly and skips the tag-check + `tryQuicken` epilogue. When `Op == 0` it emits the generic op and the runtime's observation path takes over.
 
-A second fuzzer, `FuzzRun`, takes the compiled program and runs it under a CPU/memory budget. The harness uses `runtime.SetFinalizer` and a hard wall-clock cap (5s) to detect non-termination. Any panic, infinite loop, or memory blowup is a bug.
+### Required typed opcodes in vm2
 
-CI runs the fuzzers for a fixed time budget per PR (default 60s each). Nightly runs extend to 30 minutes. Found crashers are checked into `runtime/vm/fuzz_corpus/` so they become permanent regression tests.
+vm2 today has the typed variants needed for the bench corpus (`OpAdd_II`, `OpSub_II`, `OpMul_II`, `OpLess_II`, `OpIndex_List`) as *quickened* variants only (never emitted directly). This MEP promotes them to first-class compiler outputs and adds the remaining set:
 
-### Layer 4: oracle harness for MEP-22
+| Static type | Required typed ops                                   |
+|-------------|------------------------------------------------------|
+| `int`       | Add_II, Sub_II, Mul_II, Div_II, Mod_II, Neg_I, Less_II, LessEq_II, Equal_II |
+| `float`     | Add_FF, Sub_FF, Mul_FF, Div_FF, Neg_F, Less_FF, LessEq_FF, Equal_FF |
+| `bool`      | And_BB, Or_BB, Not_B, Equal_BB                       |
+| `string`    | Concat_SS, Len_S, Less_SS, Equal_SS                  |
+| `[T]`       | Index_List, SetIndex_List, Len_L, Append_L           |
+| `{K:V}`     | Index_Map, SetIndex_Map, Len_M, Contains_M           |
+| call         | OpCall (resolved), OpCallV (closure / unresolved)   |
 
-The copy-and-patch JIT in MEP-22 will need a differential harness against the interpreter. This MEP defines that harness ahead of time so MEP-22 ships behind it.
+The `_II`/`_FF`/etc. naming is deliberate: the suffix is the static operand tag pair, not a runtime observation. A reader (and a verifier) can prove well-formedness from the opcode name alone.
 
-The shape: for every program in the test corpus, run under the interpreter and under the JIT, compare outputs. Any divergence is a P1 bug. The interpreter is canonical.
+### Verifier (debug-only)
 
-The harness is gated by a build tag (`-tags jit`) and is a no-op until MEP-22 ships. Its skeleton lands in this MEP so MEP-22 has nothing to design about correctness, only to implement.
+A new pass, `runtime/vm2/verify.go`, walks the emitted bytecode and asserts: for every typed op, the reaching definitions of its operand registers carry the matching `Tag`. Violations are bugs in the lowering pass and panic in `-tags debug` builds; production builds skip the pass.
 
-### Coverage measurement
+This is the JVM bytecode verifier idea in miniature. It exists so the lowering pass is testable: a fuzz input that produces a malformed typed op is caught at compile time, not at the first deopt.
 
-A new CI step runs `go test -cover ./runtime/vm/...` and reports the line coverage delta per PR. The goal is not a number to chase; it is to make uncovered handlers visible. A new opcode that lands without a test prints as uncovered and is rejected at review.
+### Quickening becomes a fallback
+
+vm2's `tryQuicken` / `deoptQuicken` machinery does not go away. It services:
+
+- expressions whose static type is `any` or a union (e.g. heterogeneous JSON, `dynamic` query rows),
+- interface method calls (MEP-15 effect-polymorphic sites),
+- FFI return values (`! io` boundaries),
+- `OpCallV` where the callee value is a runtime-constructed closure with no statically known target.
+
+For these, the current observation path is correct and useful. The change is that it no longer fires for cases the type checker already settled.
+
+### Resolved calls
+
+The type checker already knows whether a call target is a top-level function, a method on a known struct, or a closure value. The lowering pass annotates the call node with `Resolved=true` + `FuncIdx` when the target is fixed; the emitter then chooses `OpCall` instead of `OpCallV`. This skips the IC slot scan + capture-copy entirely for the common case and leaves `OpCallV` for genuinely first-class function values.
+
+Closure captures whose count is statically known emit a fused `OpCallStatic` that writes captures + args directly into the callee's frame, skipping the IC lookup and the no-captures-vs-captures branch in `OpCallV`.
+
+### Constant folding hand-off
+
+`compiler/constfold.go` already folds typed numeric constants. With typed lowering, the fold output also carries an `EmitHint`: a folded `int` literal emits `OpConst` with `Val.Tag = TagInt`, which the verifier checks. Folded float constants emit `Val.Tag = TagFloat`, which prevents the `OpAdd_II` deopt-on-first-use bug described under Motivation.
+
+### Effect-set integration (MEP-15)
+
+The effect inference pass tags each function with an `Effects` set. Pure-int leaf functions (`fib`, `fact`, etc.) become candidates for an additional MEP-22 work item: **shape-specialized compilation**, where the function body is recompiled with parameter tags promoted to constants. This MEP does not require shape specialization; it only requires that the lowering pass not throw away the information the next MEP will need.
 
 ## Status at a glance
 
 | Item                                                            | Status   |
 |-----------------------------------------------------------------|----------|
-| Differential exec: folder vs interpreter on pure expressions    | proposed |
-| Property suite: arithmetic, equality, len, map, option laws     | proposed |
-| Property suite: shrinkable counterexamples                      | proposed |
-| Fuzzer: `FuzzCompile` over parser corpus                        | proposed |
-| Fuzzer: `FuzzRun` with wall-clock and memory budget             | proposed |
-| Crasher corpus checked in under `runtime/vm/fuzz_corpus/`       | proposed |
-| Coverage delta reported in CI                                   | proposed |
-| Oracle harness skeleton for MEP-22                              | proposed |
+| `compiler/lower_typed.go`: emit hints per AST node              | proposed |
+| Typed-op coverage for `int`, `float`, `bool`, `string`          | proposed |
+| Typed-op coverage for `[T]` and `{K:V}`                         | proposed |
+| Resolved-call lowering (`OpCall` vs `OpCallV`)                  | proposed |
+| Verifier pass under `-tags debug`                               | proposed |
+| Folder output carries `EmitHint`                                | proposed |
+| MEP-17 bench corpus rerun: report ns/op delta from typed emit   | proposed |
+| Quickening retained as fallback for `any` / unions / FFI / closures | proposed |
+| Cold-start microbench: typed program, first iteration only      | proposed |
+
+## Performance hypothesis
+
+Three claims this MEP commits to measuring on the MEP-17 corpus once vm2 is wired to the compiler:
+
+1. **Cold-iteration speedup ≥ 1.3x on typed numeric programs** (`fib`, `mandelbrot`, `nbody`). The cold iteration today runs `OpAdd` with tag-check + overflow + quicken-write; the typed emit runs `OpAdd_II` directly with overflow + add.
+2. **Steady-state speedup ≥ 5% on the same corpus.** The quicken byte saves the indirect; removing the indirect entirely saves the load + branch.
+3. **Zero deopts on the typed corpus.** The deopt counter is observable; a typed program should report `0` deopts across the entire corpus run. Any non-zero value is a lowering-pass bug.
+
+The MEP merges only if all three hold. If (1) lands but (2) does not, the typed emit still wins on cold start and the spec stands; the conclusion would be that quickening was already doing the steady-state job, which is itself useful to learn.
 
 ## Risks
 
-- **Flaky properties on float arithmetic.** Floating-point laws fail in edge cases (NaN, signed zero, denormals). The property generators must exclude these inputs explicitly; failures here are usually generator bugs, not VM bugs.
-- **Fuzzer noise.** Fuzzers find parser-acceptable-but-semantically-rejected inputs. The fuzzer counts a panic as a bug; it does *not* count a type error as a bug. The harness handles type errors as expected.
-- **CI time.** A 60s fuzz budget per PR is cheap. A 30-minute nightly run is fine. If the property suite grows beyond ~5 minutes total, split into nightly.
-- **False oracles.** The differential harness assumes the interpreter is correct. A bug in the interpreter that the folder also has would be invisible. The property suite catches the cases the folder cannot.
+- **Lowering bugs are silent without the verifier.** A typed op emitted for a wrong-typed operand corrupts data instead of erroring. The `-tags debug` verifier exists to catch this; CI runs the bench corpus under it.
+- **Union types are easy to drop on the floor.** A `Value | None` operand is *not* `int`; emitting `OpAdd_II` for it would be wrong. The lowering pass must check for monotype strictly, and the verifier backs it up.
+- **Generic instantiation correctness.** Monomorphization must happen *before* lowering, otherwise the lowering sees type variables and falls back to the generic op (correct but slow). The pass order is non-negotiable: monomorphize, then lower, then emit.
+- **Bytecode size growth.** More opcodes mean a bigger dispatch table. vm2's switch is fine up to a few hundred ops; we are well under that. A jump table (MEP-18 Phase A item) handles the dispatch cost.
+- **vm vs vm2 divergence.** This MEP targets vm2 only. runtime/vm continues to ship the observation-only design until the compiler port lands. The diff is intentional: vm is the safety net while vm2 stabilizes.
 
 ## Non-goals
 
-- **No formal verification.** No proof of VM correctness against a denotational semantics. The combination of differential testing, properties, and fuzzing is enough to catch regressions; full verification is decades of work and not on the table.
-- **No metamorphic testing.** A future MEP may add metamorphic relations (e.g. "adding `var _ = 1` to any program should not change its output") but the three layers here are sufficient for the perf MEPs that motivate this work.
+- **No full SSA / register allocator.** vm2 stays a stack-of-frames register VM. SSA-based optimization is MEP-22 territory.
+- **No type inference beyond what `types/check.go` already does.** This MEP consumes the existing type checker's output, it does not extend it.
+- **No removal of the quickening machinery.** Quickening earns its keep on the polymorphic residual; removing it would regress `any`/dynamic-query workloads.
+- **No JIT.** Typed opcodes are still interpreted. MEP-22 layers a baseline JIT on top.
 
 ## Implementation notes
 
-Layer 1 (differential exec) is the highest-value, lowest-cost item: a few hundred lines of Go that catch the entire optimizer-divergence class. Land it first.
+Land in this order, one PR per item, so each step is independently measurable:
 
-Layer 2 (properties) is the largest open-ended investment. Start with the eight laws above; add more as bugs are found. The discipline is that every fixed VM bug ships with the property that would have caught it.
+1. **Verifier scaffold.** Empty for now; the contract is in place so subsequent PRs can assert against it.
+2. **Lowering pass: arithmetic + comparison on `int` and `float`.** Smallest typed surface, biggest hit on the math corpus. Measure (1) and (2) on `fib`, `nbody`.
+3. **Lowering pass: list/map index + length.** Cuts the bench-corpus query plans down to one indirect per access.
+4. **Resolved-call lowering.** Drops the IC out of every top-level call site; should show up as fewer allocs/op in `bench`.
+5. **String, bool, closure-capture-resolved.** Mop-up.
+6. **MEP-17 corpus rerun + MEP-20 doc append.** Numbers go into the MEP-20 "results" section so the layout-flip and the typed-emit gains are reported together.
 
-Layer 3 (fuzzing) is one PR; the seed corpus is what makes it effective. The corpus is the union of `tests/vm/valid/`, `tests/rosetta/x/Mochi/`, and the bench suite from MEP-17. Re-seed nightly from the latest corpus.
-
-Layer 4 (JIT oracle skeleton) is plumbing only; the real value materializes when MEP-22 ships.
+Each PR includes a row in the typed-op coverage table above and a row in MEP-20's benchstat results.
 
 ## References
 
-- [Go-Fuzz] *Tutorial: Getting started with fuzzing in Go.* https://go.dev/doc/tutorial/fuzz
-- [gopter] *gopter, a property-based testing library for Go.* https://github.com/leanovate/gopter
-- [Claessen-QC] Koen Claessen, John Hughes, *QuickCheck: A Lightweight Tool for Random Testing of Haskell Programs.* ICFP 2000.
-- [Csmith] Xuejun Yang et al., *Finding and Understanding Bugs in C Compilers.* PLDI 2011 (differential testing as bug-finding method).
-- [Yarpgen] *Yarpgen: a random C/C++ program generator.* https://github.com/intel/yarpgen
-- [PEP-659] Mark Shannon, *PEP 659.* https://peps.python.org/pep-0659/ (the deopt model and why it must be testable)
+- [JVM-Spec] *The Java Virtual Machine Specification, Chapter 6 (Instruction Set).* https://docs.oracle.com/javase/specs/jvms/se21/html/jvms-6.html — separate opcodes per primitive type.
+- [ECMA-335] *Common Language Infrastructure (CLI) Partition III: CIL.* https://www.ecma-international.org/publications-and-standards/standards/ecma-335/ — typed locals, typed arithmetic, verifier.
+- [LuaJIT] Mike Pall, *The LuaJIT 2.0 Wiki.* http://wiki.luajit.org/Home — trace heads commit to types; the steady state is type-monomorphic.
+- [Dart-AOT] Vyacheslav Egorov et al., *Compiling Dart to native code.* https://mrale.ph/dartvm/ — Kernel IR carries types end-to-end into AOT snapshots.
+- [Julia] Jeff Bezanson et al., *Julia: A Fresh Approach to Numerical Computing.* SIAM Review 2017. Type-stable code is a precondition for monomorphization.
+- [Crystal] *Crystal Reference: Type inference.* https://crystal-lang.org/reference/syntax_and_semantics/type_inference.html — compile-time monomorphization based on inferred types.
+- [Wasm] *WebAssembly Specification 2.0, §3 (Instructions).* https://webassembly.github.io/spec/core/ — instruction set is typed by construction.
+- [PEP-659] Mark Shannon, *PEP 659: Specializing Adaptive Interpreter.* https://peps.python.org/pep-0659/ — the observation-only design Mochi is intentionally diverging from.
+- [Wuerthinger-Truffle] Thomas Wuerthinger et al., *One VM to Rule Them All.* Onward! 2013 — even in Truffle, the partial evaluator wants type info at the language layer first.

--- a/website/docs/mep/mep-0022.md
+++ b/website/docs/mep/mep-0022.md
@@ -80,7 +80,7 @@ Copy-and-patch JIT code can deoptimize back to the interpreter at any instructio
 
 ### Oracle harness
 
-MEP-21 Layer 4 provides the differential harness that compares JIT output to interpreter output across the test corpus. Any divergence is a P1 bug. This is the *only* correctness mechanism the JIT relies on; there is no separate JIT test suite, only the interpreter suite run twice (once cold, once after tier-up).
+The JIT runs against a differential harness: every program in the test corpus is executed under the interpreter and under the JIT, and outputs must match. Any divergence is a P1 bug. This is the *only* correctness mechanism the JIT relies on; there is no separate JIT test suite, only the interpreter suite run twice (once cold, once after tier-up). The harness skeleton is gated by `-tags jit` and lands as part of this MEP, not as a prerequisite.
 
 ### Cross-platform notes
 


### PR DESCRIPTION
Refs #21490.

Replaces MEP-21 (VM Conformance and Differential Testing) with a new spec on type-directed bytecode emission and compiler/VM co-design.

## Why

The vm2 bring-up (MEP-20) ships polymorphic IC (MEP-19) + quickening (MEP-18 Phase C). Both are observation-driven: they assume the runtime does not know operand types. The Mochi type checker actually does. The compiler should emit typed opcodes (OpAdd_II, OpLess_II, OpIndex_List, OpCall vs OpCallV) directly when types are exact, and keep the observation/IC machinery only for the residual polymorphic surface.

## What changed

- `website/docs/mep/mep-0021.md` rewritten.
- `website/docs/mep/mep-0000.md` index row updated.
- `website/docs/mep/mep-0022.md` oracle-harness paragraph reworded so it no longer depends on a layer of old MEP-21.

The original conformance/property/fuzz content will return in a later MEP slot when we actually need it; the current live work is the perf chain.

## Test plan
- [x] Markdown renders (no template breakage).
- [x] All cross-refs to old MEP-21 reworked.