### PR TITLE
mep-0021 v2: first-principles compiler2 + vm2 redesign

### DIFF
--- a/website/docs/mep/mep-0000.md
+++ b/website/docs/mep/mep-0000.md
@@ -76,7 +76,7 @@ The current series covers the soundness initiative for v0.11.0. Numbering follow
 | [18](/docs/mep/mep-0018)| Bytecode Dispatch in a Go-Hosted VM    | Draft         | Standards Track |
 | [19](/docs/mep/mep-0019)| Adaptive Specialization and Inline Caches | Draft      | Standards Track |
 | [20](/docs/mep/mep-0020)| Value Representation and Allocation Discipline | Draft | Standards Track |
-| [21](/docs/mep/mep-0021)| Type-Directed Bytecode and Compiler/VM Co-Design | Draft | Standards Track |
+| [21](/docs/mep/mep-0021)| Compiler2 and VM2 Co-Design for Maximum Interpreter Throughput | Draft | Standards Track |
 | [22](/docs/mep/mep-0022)| Baseline JIT via Copy-and-Patch        | Deferred      | Informational   |
 | [23](/docs/mep/mep-0023)| Cross-language Baseline Benchmarks     | Draft         | Process         |
 

--- a/website/docs/mep/mep-0021.md
+++ b/website/docs/mep/mep-0021.md
@@ -1,191 +1,334 @@
 ---
 mep: 21
-title: Type-Directed Bytecode and Compiler/VM Co-Design
+title: Compiler2 and VM2 Co-Design for Maximum Interpreter Throughput
 author: Mochi core
 status: Draft
 type: Standards Track
 created: 2026-05-16
 sidebar_position: 21
-sidebar_label: MEP 21. Type-Directed Bytecode
-description: Mochi is statically typed. The compiler should emit type-specialized opcodes directly from the type checker's output, so the VM only quickens what is genuinely polymorphic and the bench corpus pays no IC tax on hot paths whose types were known at compile time.
+sidebar_label: MEP 21. Compiler2 / VM2 Co-Design
+description: A first-principles redesign of the Mochi compile-and-execute pipeline. Replace the observation-driven runtime with a typed SSA compiler (compiler2) that emits monomorphic bytecode into a redesigned vm2 with NaN-boxed 8-byte values, register allocation, tail calls, and bounds-check elision. No backward compatibility constraints. Target the absolute throughput ceiling of a Go-hosted interpreter on statically typed source.
 ---
 
-# MEP 21. Type-Directed Bytecode and Compiler/VM Co-Design
+# MEP 21. Compiler2 and VM2 Co-Design for Maximum Interpreter Throughput
 
-| Field    | Value                                          |
-|----------|------------------------------------------------|
-| MEP      | 21                                             |
-| Title    | Type-Directed Bytecode and Compiler/VM Co-Design |
-| Author   | Mochi core                                     |
-| Status   | Draft                                          |
-| Type     | Standards Track                                |
-| Created  | 2026-05-16                                     |
+| Field    | Value                                                  |
+|----------|--------------------------------------------------------|
+| MEP      | 21                                                     |
+| Title    | Compiler2 and VM2 Co-Design for Maximum Interpreter Throughput |
+| Author   | Mochi core                                             |
+| Status   | Draft                                                  |
+| Type     | Standards Track                                        |
+| Created  | 2026-05-16                                             |
+| Replaces | MEP-21 v1 (Type-Directed Bytecode), merged in #21491   |
 
 ## Abstract
 
-The vm2 bring-up (MEP-20) lands a 24-byte `Value`, pooled frames, a polymorphic call inline cache (MEP-19), and a quickening byte (MEP-18 Phase C). All four assume the runtime does not know the types ahead of time, so it must observe, specialize, and be ready to deopt. Mochi's type checker actually does know those types in almost every interesting case. This MEP closes the gap. The compiler emits typed opcodes (`OpAddInt`, `OpLessInt`, `OpIndex_List`, `OpCallStatic`) directly when its type information is exact, and the VM's tag-checking + quickening + IC machinery becomes a fallback for the residual polymorphic surface (interface dispatch, `any`, dataset queries with `dynamic` columns).
+The first cut of MEP-21 (#21491) kept vm2's tagged 24-byte `Value`, kept the quickening byte, kept the polymorphic IC, and added a lowering pass that emitted typed opcodes when types were known. That was the right MEP for "respect the existing surface." This MEP is the *first-principles* version: no respect for the existing surface, no backward-compatibility constraints, the ultimate goal is the throughput ceiling of a Go-hosted register interpreter on statically typed source.
 
-The result is a VM whose hot path on a statically typed program runs typed opcodes from instruction zero, without the tag-check + tryQuicken + deopt path that an observation-driven design pays on every site. That is the design Lua/LuaJIT, HotSpot, CoreCLR, Dart AOT, Crystal, and Julia all converge on for the same reason: when the front end knows, the back end should not have to learn.
+Concretely:
+
+1. **A new front end, `compiler2/`,** parallel to the existing `vm.Compile`. Pipeline: typed AST, typed SSA IR, optimization passes, linear-scan register allocation, vm2 bytecode. Output is monomorphic by construction.
+2. **A redesigned vm2 register cell: 8 bytes, NaN-boxed,** packing int64 / float64 / pointer into a single word. The current 24-byte `{Tag, _pad, Num, Ref any}` layout is abandoned. Register copies become a single 64-bit move; the per-instruction memory traffic drops 3x.
+3. **No generic opcodes on the typed surface.** No `OpAdd`. No `Quick` byte for typed ops. Quickening and the polymorphic IC are retained only for the genuinely dynamic boundary (FFI, JSON-derived `any`, runtime-constructed closures).
+4. **First-class IR-level optimizations** the existing compiler does not do: tail-call recognition, bounds-check elision, closure-capture flattening, register coalescing, common subexpression elimination on typed values, dead store elimination.
+5. **A direct-call opcode whose target is patched at link time,** plus a fused capture-into-frame closure call. No IC scan on resolved sites.
+
+This is a multi-PR initiative, not a single landing. The MEP defines the target architecture; the rollout is staged.
 
 ## Motivation
 
-vm2 today, on `fib(25)`, runs the first iteration of every arithmetic op as `OpAdd`/`OpSub`/`OpLess`. Each call into the body pays:
+### What vm2 is leaving on the floor today
 
-1. a tag check on both operands,
-2. an overflow check,
-3. a `tryQuicken` write into the instruction word.
+The fib(25) numbers in MEP-20 (runtime/vm2 at 46.7 ms / 10 allocs vs runtime/vm at 203.9 ms / 515k allocs) are a 4.4x speedup with zero compiler help; vm2 still runs hand-written bytecode in the bench. The real production path will compile Mochi source, and the existing compiler is built around vm's tagged 100-byte Value. Specifically:
 
-Iteration two onward dispatches via the `Quick` byte to `OpAdd_II` etc., so the steady-state cost is one tag check + one overflow check + the arithmetic. The tag check exists only because the dispatcher does not trust the operand types. In Mochi `n - 1` where `n: int`, the type checker has *already* proved both operands are `int`. The compiler is throwing that proof away.
+- **Value width.** Every `fr.Regs[ins.A] = fr.Regs[ins.B]` copies 24 bytes (Tag + pad + Num + Ref interface header). For a typed int register the meaningful payload is 8. The other 16 are tag, padding, and an interface descriptor that is always nil for ints. Three quarters of the per-instruction memory traffic is dead weight.
+- **Tag dispatch.** Even `OpAdd_II` reads the tag of both operands. After MEP-21 v1 the compiler would emit `OpAdd_II` directly, but the dispatcher still pays a tag check inside the handler because the layout still carries the tag. With type-erased typed registers the check is unreachable code.
+- **Register allocation.** The current compiler assigns a fresh register for every SSA value. Fibonacci uses 10 registers; with allocation it needs 4. Smaller frames mean smaller slabs, fewer cache lines per call, and a higher hit rate in the bucketed pool.
+- **No tail-call op.** `fib(n-1) + fib(n-2)` is not tail-recursive, but `fact_acc(n-1, acc*n)` is. The current pipeline emits an `OpCall` even for tail positions; vm2 grows the frame stack to depth N. A real tail-call op would run constant-stack.
+- **No bounds-check elision.** `xs[i]` after `for i in 0..len(xs)` re-checks the bound on every iteration. The compiler has the type and the loop bound in front of it; the check is provably redundant.
+- **OpCallV on resolved targets.** Every closure call goes through the polymorphic IC even when the target is a known top-level function captured into the closure. The IC slot scan is pure overhead in that case.
+- **GC pointer pressure.** The `Ref any` field forces the GC to scan every register on every cycle. Typed int/float registers should be invisible to the GC; only the ref bank (or the boxed-pointer slots in a NaN-boxed layout) should be scanned.
 
-Three concrete consequences:
+Each item is independently fixable. Taken together they are a different VM.
 
-- **Cold-start tax.** Short programs (test fixtures, one-shot scripts, REPL evals) never reach the steady state. They pay the slow generic op for every site.
-- **Deopt risk on never-polymorphic sites.** If `OpAdd_II` ever sees a float (e.g. a const-folded `1.0` slips through), it deopts to `OpAdd` permanently after `siteMaxMisses`. A type-directed emitter would have used `OpAddFloat` from the start and the question would not arise.
-- **IC pressure on monomorphic calls.** `OpCallV` runs the polymorphic IC even when the call target is a statically resolved top-level function. A direct `OpCall` is one indirect jump; the IC path is a slot scan + capture-copy.
+### Why a new compiler
 
-Modern statically typed VMs do not pay these costs. The relevant prior art:
+The current `runtime/vm` compiler is structured as a direct AST walker that emits instructions as it visits expressions. It has no IR between AST and bytecode. Without an IR there is nowhere to run an optimization pass; constant folding is bolted on as a pre-pass over the AST, and that is the only optimization in the pipeline. Adding the items above (register allocation, tail-call detection, BCE) without an IR means smearing them across the emitter, which has already proved hard to maintain (see the two-branch post-process pattern in `types/check.go` that this codebase learned the hard way to keep in two places).
 
-- **JVM (since 1995).** Separate `iadd`, `ladd`, `fadd`, `dadd` opcodes; the verifier proves operand types statically. C1/C2 never speculate on numeric types because they were never in doubt.
-- **CLR / CIL.** Typed locals + typed `add.ovf.i4` / `add.r8` etc. RyuJIT inherits perfect type info from the verifier.
-- **LuaJIT.** Dynamically typed source, but the trace recorder commits to types at trace head and the resulting machine code is type-monomorphic; deopt is the *exception* path, not the steady-state path. The Mochi compiler can skip the recorder entirely because the front end is the type oracle.
-- **Dart AOT.** Kernel IR carries types end-to-end; `dart compile aot-snapshot` lowers to type-specialized calls with no profile data.
-- **Crystal, Julia, Roc.** All compile from a type-stable source to monomorphized IR; type-stability warnings exist precisely because the back end can only specialize what the front end nails down.
-- **WebAssembly.** Typed by construction; `i32.add` is not the same opcode as `f64.add`. The recently proposed GC and JS-string-builtins proposals continue to push *more* type information into the instruction set, not less.
-- **PEP 659 (CPython).** The opposite end of the spectrum: zero static types, full observation. Mochi has the inputs CPython does not; copying CPython's design wholesale leaves perf on the table.
+A new package `compiler2/` decouples the new pipeline from the old. `vm.Compile` keeps shipping as the production target until compiler2 reaches feature parity. Then it becomes the production target and `vm.Compile` enters maintenance mode. This is the same risk profile that vm vs vm2 has: two paths, the new one earns its way to default.
 
-The unifying principle: **specialization wants type information; type information is cheapest at the point in the pipeline where it was just proved.** In Mochi that point is the end of `types/check.go`. By the time bytecode emission runs, the proof is one struct field away.
+### Prior art for the target architecture
+
+The combination of (typed SSA IR, register allocation, monomorphic typed bytecode, tight value layout, Go-style switch dispatch) is the architecture of:
+
+- **LuaJIT interpreter mode** ([LuaJIT-Interp]). NaN-boxed 8-byte cells; computed-goto dispatch in C; the trace JIT consumes already-typed bytecode. Mochi cannot do computed goto in Go, but everything else transfers.
+- **JSC LLInt** ([JSC-LLInt]). Hand-written assembler for portability across dispatch styles; tight tagged cells; direct-call ops; ICs only on dynamic sites.
+- **V8 Ignition** ([V8-Ignition]). Register VM with on-stack frame, variable-length opcodes for size, separate opcode set for cold paths. The variable-length idea ports cleanly to Mochi.
+- **Wren / wren-cli** ([Wren]). Small register-based VM, tagged 8-byte values, written so the entire dispatch loop is a single Go-style switch the C compiler inlines. Mochi's vm2 in Go is structurally identical except for layout width.
+- **Dart Kernel + DBC (Dart Bytecode)** ([Dart-DBC]). Typed IR, register allocation, direct calls. Discontinued only because Dart shipped AOT instead, not because the design failed.
+- **Crystal** ([Crystal-IR]). Source is typed; the compiler runs monomorphization + constant folding + dead code elim before LLVM. The first half of that pipeline is what compiler2 needs.
+- **MLton / Whole-program SML** ([MLton]). Aggressive monomorphization; demonstrates that whole-program type info collapses interface dispatch to direct calls. Mochi is whole-program by default.
+
+The contrary design (small AST-walking compiler + observation-driven VM) is what CPython did before PEP-659 and what Ruby did before YJIT/ZJIT. Both projects have spent person-years climbing back. Mochi does not need to walk that path twice.
 
 ## Specification
 
 ### Principle
 
-> A site whose operand types are exact at type-check time MUST be lowered to a typed opcode. Quickening, IC, and deopt MUST be reserved for sites whose types are genuinely unresolved (`any`, interface methods, `dynamic` query columns, FFI returns).
+> The compiler MUST produce bytecode in which every operand's type is exact and every call's target is either resolved at compile time or is genuinely dynamic. The VM MUST contain no machinery for guessing what the compiler already knew.
 
-"Exact" means: every operand has a concrete monotype after type checking and effect inference. Generic type variables count as exact at each instantiation site (the monomorphizer fixes them before emission). Union types do not count as exact; they emit the generic op with a quickening hint.
+Corollaries the spec enforces:
 
-### Lowering pass
+- No generic typed-arithmetic opcode (`OpAdd`, `OpSub`, ...) on the typed surface. They exist only in the residual polymorphic-dispatch path.
+- No `Quick` byte field on typed instructions. The byte still exists for residual ops to allow MEP-19 quickening of dynamic-source operands.
+- No tag field on typed register reads. Cells are either NaN-boxed (one bank) or untagged (per-type banks).
+- No IC on `OpCall`. The IC exists only on `OpCallDynamic`, which is emitted only when the front end cannot resolve.
 
-A new pass, `compiler/lower_typed.go`, runs between the type checker and the bytecode emitter. Input: typed AST. Output: typed AST annotated with `EmitHint` per expression node.
+### Compiler2 pipeline
+
+```
+parser AST
+   │
+   ▼
+types/check  (existing; unchanged contract)
+   │  typed AST
+   ▼
+compiler2/ir/build       (AST → typed SSA IR)
+   │
+   ▼
+compiler2/opt/{const,dce,cse,bce,tail,inline_trivial,closure_flatten}
+   │  optimized IR
+   ▼
+compiler2/regalloc       (linear scan, type-aware)
+   │  IR + register map
+   ▼
+compiler2/emit           (IR → vm2 bytecode)
+   │  *vm2.Program
+   ▼
+runtime/vm2.Run
+```
+
+Each pass is a pure function on IR with a small interface. The emitter is the only piece that knows the vm2 wire format.
+
+### IR shape
+
+Typed SSA, single-assignment per virtual register, instructions in basic blocks, CFG explicit. Each value carries its monotype. Generics and method dispatch are monomorphized before this IR exists.
 
 ```go
-type EmitHint struct {
-    Op       vm2.Op   // typed opcode to emit; 0 = use generic
-    LhsTag   vm2.Tag  // proven static tag of left operand
-    RhsTag   vm2.Tag  // proven static tag of right operand
-    Resolved bool     // call target known statically (true => OpCall, not OpCallV)
-    FuncIdx  int      // resolved function index when Resolved
+type Value struct {
+    ID   ValueID
+    Op   IROp     // typed: AddI64, AddF64, LoadGlobal, ...
+    Type Type     // monotype after check
+    Args []ValueID
+    Loc  source.Loc
+}
+
+type Block struct {
+    ID    BlockID
+    Insts []ValueID
+    Term  Terminator // Jump, CondJump, Return, TailCall
+}
+
+type Func struct {
+    Name   string
+    Params []ValueID
+    Blocks []Block
 }
 ```
 
-The emitter consults the hint. When `Op != 0` it emits that op directly and skips the tag-check + `tryQuicken` epilogue. When `Op == 0` it emits the generic op and the runtime's observation path takes over.
+This is intentionally close to Go's own `cmd/compile/internal/ssa.Func` shape, not because we are building the Go compiler but because the API surface has been beaten on for a decade and the pattern composes well with optimization passes.
 
-### Required typed opcodes in vm2
+### Optimization passes (initial set)
 
-vm2 today has the typed variants needed for the bench corpus (`OpAdd_II`, `OpSub_II`, `OpMul_II`, `OpLess_II`, `OpIndex_List`) as *quickened* variants only (never emitted directly). This MEP promotes them to first-class compiler outputs and adds the remaining set:
+| Pass               | What it does                                                | Win on bench corpus |
+|--------------------|-------------------------------------------------------------|---------------------|
+| `const`            | Typed constant folding + algebraic identities               | replaces existing constfold |
+| `dce`              | Dead-store + dead-instruction elimination                   | shrinks codegen |
+| `cse`              | Common subexpression elimination on pure ops                | dedups index/load |
+| `bce`              | Bounds-check elision after a proven `i < len(xs)`           | tightens iter loops |
+| `tail`             | Tail-call detection: convert `return f(...)` to `OpTailCall`| constant-stack recursion |
+| `inline_trivial`   | Inline single-block leaf functions (getters, identity)      | cuts call overhead |
+| `closure_flatten`  | Convert captured vars to explicit array; emit `OpCallClosureStatic` when target is fixed | drops IC on resolved closures |
 
-| Static type | Required typed ops                                   |
-|-------------|------------------------------------------------------|
-| `int`       | Add_II, Sub_II, Mul_II, Div_II, Mod_II, Neg_I, Less_II, LessEq_II, Equal_II |
-| `float`     | Add_FF, Sub_FF, Mul_FF, Div_FF, Neg_F, Less_FF, LessEq_FF, Equal_FF |
-| `bool`      | And_BB, Or_BB, Not_B, Equal_BB                       |
-| `string`    | Concat_SS, Len_S, Less_SS, Equal_SS                  |
-| `[T]`       | Index_List, SetIndex_List, Len_L, Append_L           |
-| `{K:V}`     | Index_Map, SetIndex_Map, Len_M, Contains_M           |
-| call         | OpCall (resolved), OpCallV (closure / unresolved)   |
+The set is small on purpose. Each pass is a few hundred lines of Go and ships with property-based tests against the unoptimized output. (The conformance content from MEP-21 v1 returns here, scoped to "optimization passes must not change observable behavior.")
 
-The `_II`/`_FF`/etc. naming is deliberate: the suffix is the static operand tag pair, not a runtime observation. A reader (and a verifier) can prove well-formedness from the opcode name alone.
+### Linear-scan register allocation
 
-### Verifier (debug-only)
+Run after optimization. Compute live ranges over SSA values. Walk in instruction order; assign each live range a vm2 register, recycle freed registers. Spill to memory only if the live-set exceeds the frame's allotment (we expect this never to fire in the bench corpus; Mochi functions are small).
 
-A new pass, `runtime/vm2/verify.go`, walks the emitted bytecode and asserts: for every typed op, the reaching definitions of its operand registers carry the matching `Tag`. Violations are bugs in the lowering pass and panic in `-tags debug` builds; production builds skip the pass.
+Output: a `map[ValueID]int32` consumed by the emitter. The emitted bytecode references the assigned vm2 register, not the SSA value ID.
 
-This is the JVM bytecode verifier idea in miniature. It exists so the lowering pass is testable: a fuzz input that produces a malformed typed op is caught at compile time, not at the first deopt.
+Effect on vm2: `Function.NumRegs` becomes the *allocated* count, not the SSA-cardinality. The bucketed regs-pool (MEP-20) hits a smaller bucket more often; the cache line footprint of a frame drops.
 
-### Quickening becomes a fallback
+### VM2 cell redesign
 
-vm2's `tryQuicken` / `deoptQuicken` machinery does not go away. It services:
+Replace `vm2.Value` with an 8-byte NaN-boxed cell:
 
-- expressions whose static type is `any` or a union (e.g. heterogeneous JSON, `dynamic` query rows),
-- interface method calls (MEP-15 effect-polymorphic sites),
-- FFI return values (`! io` boundaries),
-- `OpCallV` where the callee value is a runtime-constructed closure with no statically known target.
+```go
+type Cell uint64  // NaN-boxed
+```
 
-For these, the current observation path is correct and useful. The change is that it no longer fires for cases the type checker already settled.
+Encoding (industry-standard NaN-boxing as in [LuaJIT-NaNBox], [JSC-NaNBox], [SpiderMonkey-NaNBox]):
 
-### Resolved calls
+- A finite or infinite IEEE 754 double maps to its native bit pattern.
+- A signalling NaN with the top 13 bits set to `0xFFFA..0xFFFE` is a tag prefix; the low 48 bits are the payload.
+- Payload kinds: `kInt32` (`0xFFFA...`), `kPtr` (`0xFFFE...`), `kBool` / `kNull` constants (`0xFFFB...`).
 
-The type checker already knows whether a call target is a top-level function, a method on a known struct, or a closure value. The lowering pass annotates the call node with `Resolved=true` + `FuncIdx` when the target is fixed; the emitter then chooses `OpCall` instead of `OpCallV`. This skips the IC slot scan + capture-copy entirely for the common case and leaves `OpCallV` for genuinely first-class function values.
+Tradeoffs:
 
-Closure captures whose count is statically known emit a fused `OpCallStatic` that writes captures + args directly into the callee's frame, skipping the IC lookup and the no-captures-vs-captures branch in `OpCallV`.
+- **Width:** 8 bytes vs current 24. Register banks become 3x denser; a 16-register frame is one cache line, not three.
+- **Int range:** 48 bits in the int-tag encoding, or `int32` via a tighter tag. Mochi's typed `int` is 64-bit; we use the *untagged* numeric cell for typed `i64` (every bit is the int) and the tagged encoding only for the residual `any` path.
+- **GC visibility:** the cell is `uint64`, not `interface{}`. The GC does not scan it. Pointers are reachable via a parallel ref table indexed by the cell's pointer payload.
 
-### Constant folding hand-off
+The simpler alternative (per-type banks: `Ints []int64`, `Floats []float64`, `Refs []unsafe.Pointer`) is rejected because it triples register-naming bookkeeping in the emitter and complicates closures. NaN-boxing is the proven choice for register-uniform VMs.
 
-`compiler/constfold.go` already folds typed numeric constants. With typed lowering, the fold output also carries an `EmitHint`: a folded `int` literal emits `OpConst` with `Val.Tag = TagInt`, which the verifier checks. Folded float constants emit `Val.Tag = TagFloat`, which prevents the `OpAdd_II` deopt-on-first-use bug described under Motivation.
+For typed numeric ops where the compiler has proved the operand is `i64`, the emitter MAY emit untagged-cell variants (`OpAddI64Raw`) that interpret the cell as a raw int64. These run with zero decode overhead. The verifier (see below) checks that raw ops only appear after a typed proof.
 
-### Effect-set integration (MEP-15)
+### Bytecode encoding
 
-The effect inference pass tags each function with an `Effects` set. Pure-int leaf functions (`fib`, `fact`, etc.) become candidates for an additional MEP-22 work item: **shape-specialized compilation**, where the function body is recompiled with parameter tags promoted to constants. This MEP does not require shape specialization; it only requires that the lowering pass not throw away the information the next MEP will need.
+Variable-length 8-bit-aligned, after V8 Ignition:
 
-## Status at a glance
+- Short form: 1-byte opcode + up to 3 1-byte register operands = 4 bytes total.
+- Long form: 1-byte opcode-prefix `Wide` + the underlying op with 16-bit register operands.
+- Extra-long: prefix `ExtraWide` + 32-bit operands. Rare; used by large generated code.
 
-| Item                                                            | Status   |
-|-----------------------------------------------------------------|----------|
-| `compiler/lower_typed.go`: emit hints per AST node              | proposed |
-| Typed-op coverage for `int`, `float`, `bool`, `string`          | proposed |
-| Typed-op coverage for `[T]` and `{K:V}`                         | proposed |
-| Resolved-call lowering (`OpCall` vs `OpCallV`)                  | proposed |
-| Verifier pass under `-tags debug`                               | proposed |
-| Folder output carries `EmitHint`                                | proposed |
-| MEP-17 bench corpus rerun: report ns/op delta from typed emit   | proposed |
-| Quickening retained as fallback for `any` / unions / FFI / closures | proposed |
-| Cold-start microbench: typed program, first iteration only      | proposed |
+Constants live in a per-function pool; `OpConst R, idx` indexes into it. Inline constants are restricted to short immediates that fit a byte.
 
-## Performance hypothesis
+Cache footprint matters: the dispatch loop reads the next opcode from a cache line shared with the previous one. Short form keeps a tight loop in one or two cache lines.
 
-Three claims this MEP commits to measuring on the MEP-17 corpus once vm2 is wired to the compiler:
+### Dispatch
 
-1. **Cold-iteration speedup ≥ 1.3x on typed numeric programs** (`fib`, `mandelbrot`, `nbody`). The cold iteration today runs `OpAdd` with tag-check + overflow + quicken-write; the typed emit runs `OpAdd_II` directly with overflow + add.
-2. **Steady-state speedup ≥ 5% on the same corpus.** The quicken byte saves the indirect; removing the indirect entirely saves the load + branch.
-3. **Zero deopts on the typed corpus.** The deopt counter is observable; a typed program should report `0` deopts across the entire corpus run. Any non-zero value is a lowering-pass bug.
+Go does not support computed goto. The empirically fastest portable Go interpreter dispatch is a giant `switch op` where each case body is small enough to inline and the loop body is the entire switch. Two specific patterns matter:
 
-The MEP merges only if all three hold. If (1) lands but (2) does not, the typed emit still wins on cold start and the spec stands; the conclusion would be that quickening was already doing the steady-state job, which is itself useful to learn.
+- `_ = code[len(code)-1]` at the top of the loop hints the bounds checker, so `code[ip]` inside the loop has its check removed.
+- A two-level dispatch (`switch op { ... }` with hot ops first) lets the branch predictor learn the typical sequence; Go's switch is currently a jump table for dense small-integer enums, which is what `Op` is.
+
+The MEP-18 Phase A jump-table validation work feeds directly into this; nothing new is needed at the dispatch level beyond hot-ordering.
+
+### Direct calls
+
+Two new ops:
+
+- `OpCall fn_idx, arg_base, ret_reg` where `fn_idx` is a constant in the function table. No IC, no scan; the frame is acquired, args memcpy'd, dispatch transferred.
+- `OpCallClosureStatic captures_idx, fn_idx, arg_base, ret_reg` for closures whose capture set is fixed at construction. Emitted when `closure_flatten` proves the target.
+
+`OpCallDynamic`, the dynamic path, retains the polymorphic IC from MEP-19. It is emitted only when the front end cannot prove the target.
+
+### Tail calls
+
+`OpTailCall fn_idx, arg_base`. When in a tail position the compiler emits this instead of `OpCall+OpReturn`. The VM rewinds the current frame's registers (memmove args into the param slots, reset IP to 0, leave the frame allocated), reuses the slab, and continues. No frame stack growth.
+
+This is the technique Lua, Scheme, and Erlang all use. It costs a single new op and turns `fact_acc`, mutual-recursion patterns, and self-referential agent loops into constant-stack programs.
+
+### Bounds-check elision
+
+For an indexed read inside a loop guarded by a proven bound, emit `OpIndexI64Unchecked`. The bce pass proves the bound; the verifier (debug build) checks the proof.
+
+This is the same optimization Go's own compiler does on `for i := range xs { use(xs[i]) }`. Mochi's pattern is identical and the optimization transfers.
+
+### Closure flattening
+
+The current closure layout stores captures as `[]Value`. With NaN-boxed cells the captures become `[]Cell`. More importantly, when the IR proves a closure's capture set is fixed and the call sites are known, the emitter inlines the captures into the callee's frame at call time and skips the closure object entirely. This is the same "closure inlining" Self and HotSpot do for monomorphic call sites.
+
+### Verifier (mandatory in debug)
+
+`runtime/vm2/verify.go` walks emitted bytecode and asserts:
+
+- Every typed op's operands carry the correct compiler-assigned type.
+- Every untagged-cell op (`OpAddI64Raw`) follows a proven typed source.
+- Every bounds-elided op follows a proven bound.
+- Every `OpCall` target index is in range of the function table.
+- Every basic block ends with a terminator; no fall-through past the last instruction.
+
+In production builds (`-tags release`) the verifier is stripped. CI runs every fixture under `-tags debug` so a lowering bug fails fast.
+
+### Generic / dynamic surface
+
+The polymorphic surface is small but non-empty:
+
+- `! io` boundaries (FFI returns) yield `any`.
+- JSON decode returns dynamic shapes.
+- `dataset` queries over schema-less rows.
+- First-class functions passed across module boundaries.
+
+These sites emit the generic ops (`OpAddBoxed`, `OpCallDynamic`, ...). The MEP-18/19 machinery (Quick byte, polymorphic IC) lives here and only here. The split is enforced by the verifier: a typed op next to a generic op without an explicit `OpBox`/`OpUnbox` is a compiler bug.
+
+## Rollout
+
+Each step is one PR with measurable numbers.
+
+1. **`compiler2/ir`: minimal SSA + AST→IR builder for arithmetic + control flow.** No optimizations yet. Goal: round-trip every program in the typed bench corpus through IR and back to the existing emitter. Validates the IR shape.
+2. **`compiler2/opt/const` + `dce`.** Replaces the existing constfold; numbers should be flat on the bench corpus, no codegen change yet.
+3. **`compiler2/regalloc`.** Standalone pass; emits to existing vm2 with reduced `NumRegs`. Measure frame-pool bucket-hit rate.
+4. **vm2 cell redesign to NaN-boxed 8-byte.** Largest single PR; in vm2 only, no compiler2 dependency. Runs the existing hand-coded benches against the new layout. Expected: per-op cycle count drops by the cache-line factor.
+5. **`compiler2/emit` and the new opcode set (typed mono ops, direct calls).** First PR that produces compiler2 bytecode end-to-end. Runs alongside vm-compile output via a feature flag.
+6. **`compiler2/opt/{tail,bce,cse,inline_trivial,closure_flatten}`.** One pass per PR, each with a corpus benchstat row.
+7. **Make compiler2 the default target.** Flip the flag once the corpus is at parity or better and the verifier reports zero issues.
+
+Each PR appends a row to a results table in MEP-20 (which is the canonical "the layout paid off" document) and a row in MEP-17's per-PR gate.
+
+## Performance hypothesis (falsifiable)
+
+| Claim                                                              | Target  |
+|--------------------------------------------------------------------|---------|
+| Cell layout redesign alone (#4)                                    | ≥ 1.5x on fib(25), ≥ 1.3x geomean on the corpus |
+| compiler2 typed emit alone (#5, no opts)                           | ≥ 1.2x geomean over MEP-21 v1 typed emit         |
+| Register allocation alone (#3)                                     | ≥ 10% reduction in regs-pool largest-bucket use  |
+| Tail-call op alone (#6 first sub-PR)                               | constant stack on `fact_acc(10^6)` (qualitative) |
+| BCE alone                                                          | ≥ 5% on `iter_sum` and `hof_map`                 |
+| Closure flattening alone                                           | drops `OpCallV` allocs to 0 on `closure_dispatch`|
+| End-to-end (all of compiler2 + cell redesign) on the bench corpus  | ≥ 2.5x geomean over today's vm2                  |
+| Total vs runtime/vm baseline (bench corpus geomean)                | ≥ 10x                                            |
+
+The MEP merges step-by-step; each row must hold for its corresponding PR. The end-to-end target is the gate for declaring compiler2 the default.
 
 ## Risks
 
-- **Lowering bugs are silent without the verifier.** A typed op emitted for a wrong-typed operand corrupts data instead of erroring. The `-tags debug` verifier exists to catch this; CI runs the bench corpus under it.
-- **Union types are easy to drop on the floor.** A `Value | None` operand is *not* `int`; emitting `OpAdd_II` for it would be wrong. The lowering pass must check for monotype strictly, and the verifier backs it up.
-- **Generic instantiation correctness.** Monomorphization must happen *before* lowering, otherwise the lowering sees type variables and falls back to the generic op (correct but slow). The pass order is non-negotiable: monomorphize, then lower, then emit.
-- **Bytecode size growth.** More opcodes mean a bigger dispatch table. vm2's switch is fine up to a few hundred ops; we are well under that. A jump table (MEP-18 Phase A item) handles the dispatch cost.
-- **vm vs vm2 divergence.** This MEP targets vm2 only. runtime/vm continues to ship the observation-only design until the compiler port lands. The diff is intentional: vm is the safety net while vm2 stabilizes.
+- **Two compilers cost maintenance.** vm.Compile and compiler2 cohabit until the flip. The cost is real; the mitigation is feature parity tests that run *both* on the corpus and diff outputs (oracle harness).
+- **NaN-boxing portability.** The encoding relies on platform doubles being IEEE 754, which all Go targets satisfy. WASM-as-host (future) is the same encoding.
+- **GC ref table for boxed pointers.** Storing pointers in a parallel table behind cell indices requires the table to be live as long as any cell that points into it. The frame holds a reference; the GC keeps the table.
+- **Register allocator complexity.** Linear scan is well-understood. The risk is interaction with closure flattening (the captures must be live across the call site). Solvable with a standard "live-out" set per block.
+- **Verifier debt.** A pass added without a verifier check is a future bug. The CI gate is the verifier on every typed-corpus program in `-tags debug`.
+- **Compile-time growth.** A multi-pass compiler is slower than a single AST walk. The expected hit is small (Mochi modules are small), but a budget (compile time per kloc) goes into MEP-17 so regressions are visible.
+- **Polymorphic surface drift.** If JSON / `any` usage grows, the residual generic surface grows with it. The verifier's split-line keeps the architectures distinct; the perf story degrades gracefully toward the MEP-19 IC numbers.
 
 ## Non-goals
 
-- **No full SSA / register allocator.** vm2 stays a stack-of-frames register VM. SSA-based optimization is MEP-22 territory.
-- **No type inference beyond what `types/check.go` already does.** This MEP consumes the existing type checker's output, it does not extend it.
-- **No removal of the quickening machinery.** Quickening earns its keep on the polymorphic residual; removing it would regress `any`/dynamic-query workloads.
-- **No JIT.** Typed opcodes are still interpreted. MEP-22 layers a baseline JIT on top.
-
-## Implementation notes
-
-Land in this order, one PR per item, so each step is independently measurable:
-
-1. **Verifier scaffold.** Empty for now; the contract is in place so subsequent PRs can assert against it.
-2. **Lowering pass: arithmetic + comparison on `int` and `float`.** Smallest typed surface, biggest hit on the math corpus. Measure (1) and (2) on `fib`, `nbody`.
-3. **Lowering pass: list/map index + length.** Cuts the bench-corpus query plans down to one indirect per access.
-4. **Resolved-call lowering.** Drops the IC out of every top-level call site; should show up as fewer allocs/op in `bench`.
-5. **String, bool, closure-capture-resolved.** Mop-up.
-6. **MEP-17 corpus rerun + MEP-20 doc append.** Numbers go into the MEP-20 "results" section so the layout-flip and the typed-emit gains are reported together.
-
-Each PR includes a row in the typed-op coverage table above and a row in MEP-20's benchstat results.
+- **No JIT.** That is MEP-22. Compiler2 produces interpreter bytecode; the JIT (if it lands) consumes that bytecode.
+- **No source-language change.** Mochi syntax and semantics are unchanged. The pipeline is internal.
+- **No removal of runtime/vm.** vm stays as the safety net; vm2 + compiler2 win on merit.
+- **No removal of the MEP-19 IC machinery.** It earns its keep on the dynamic surface.
+- **No SSA-level escape analysis.** Reserved for a follow-up MEP if it pays off; copy-and-patch baseline (MEP-22) recovers most of the same wins.
 
 ## References
 
-- [JVM-Spec] *The Java Virtual Machine Specification, Chapter 6 (Instruction Set).* https://docs.oracle.com/javase/specs/jvms/se21/html/jvms-6.html — separate opcodes per primitive type.
-- [ECMA-335] *Common Language Infrastructure (CLI) Partition III: CIL.* https://www.ecma-international.org/publications-and-standards/standards/ecma-335/ — typed locals, typed arithmetic, verifier.
-- [LuaJIT] Mike Pall, *The LuaJIT 2.0 Wiki.* http://wiki.luajit.org/Home — trace heads commit to types; the steady state is type-monomorphic.
-- [Dart-AOT] Vyacheslav Egorov et al., *Compiling Dart to native code.* https://mrale.ph/dartvm/ — Kernel IR carries types end-to-end into AOT snapshots.
-- [Julia] Jeff Bezanson et al., *Julia: A Fresh Approach to Numerical Computing.* SIAM Review 2017. Type-stable code is a precondition for monomorphization.
-- [Crystal] *Crystal Reference: Type inference.* https://crystal-lang.org/reference/syntax_and_semantics/type_inference.html — compile-time monomorphization based on inferred types.
-- [Wasm] *WebAssembly Specification 2.0, §3 (Instructions).* https://webassembly.github.io/spec/core/ — instruction set is typed by construction.
-- [PEP-659] Mark Shannon, *PEP 659: Specializing Adaptive Interpreter.* https://peps.python.org/pep-0659/ — the observation-only design Mochi is intentionally diverging from.
-- [Wuerthinger-Truffle] Thomas Wuerthinger et al., *One VM to Rule Them All.* Onward! 2013 — even in Truffle, the partial evaluator wants type info at the language layer first.
+### Pipeline architecture
+- [SSA-Briggs] Preston Briggs, *Register Allocation via Graph Coloring.* PhD thesis, Rice 1992.
+- [LinearScan] Massimiliano Poletto, Vivek Sarkar, *Linear Scan Register Allocation.* ACM TOPLAS 1999.
+- [Go-SSA] Keith Randall et al., *Go's SSA backend.* https://github.com/golang/go/blob/master/src/cmd/compile/internal/ssa/README.md
+- [Crystal-IR] Crystal language team, *Type inference and monomorphization in Crystal.* https://crystal-lang.org/reference/syntax_and_semantics/type_inference.html
+- [MLton] *MLton whole-program optimizing compiler.* http://mlton.org/Documentation
+- [Dart-DBC] Vyacheslav Egorov, *Dart bytecode interpreter.* https://mrale.ph/dartvm/
+
+### Value representation
+- [LuaJIT-NaNBox] Mike Pall, *LuaJIT 2.0 NaN-tagging notes.* http://lua-users.org/lists/lua-l/2009-11/msg00089.html
+- [JSC-NaNBox] WebKit team, *JavaScriptCore value representation.* https://webkit.org/blog/10308/
+- [SpiderMonkey-NaNBox] Mozilla, *SpiderMonkey jsval and NaN-boxing.* https://firefox-source-docs.mozilla.org/js/HackingTips.html
+
+### Interpreter dispatch
+- [LuaJIT-Interp] Mike Pall, *The LuaJIT interpreter architecture.* http://wiki.luajit.org/Numerical-Computing-Performance-Guide
+- [JSC-LLInt] WebKit team, *Introducing the LLInt.* https://webkit.org/blog/189/
+- [V8-Ignition] V8 team, *Firing up the Ignition interpreter.* https://v8.dev/blog/ignition-interpreter
+- [Wren] Bob Nystrom, *Wren VM.* https://wren.io/
+- [Ertl-Threaded] M. Anton Ertl, David Gregg, *The Structure and Performance of Efficient Interpreters.* JILP 2003.
+- [Brunthaler-Inline] Stefan Brunthaler, *Inline Caching Meets Quickening.* ECOOP 2010.
+
+### Tail calls and recursion
+- [Steele-RABBIT] Guy Steele, *RABBIT: A Compiler for Scheme.* MIT-AITR 1978 (the original tail-call argument).
+
+### Bounds-check elision
+- [Wuerthinger-BCE] Thomas Wuerthinger et al., *Array bounds check elimination for the Java HotSpot client compiler.* PPPJ 2007.
+
+### Prior MEP-21 v1
+- Mochi PR #21491, *MEP-21: replace VM Conformance spec with Type-Directed Bytecode.* https://github.com/mochilang/mochi/pull/21491


### PR DESCRIPTION
Refs #21494. Supersedes the v1 spec merged in #21491.

v1 lowered typed ops on top of vm2's existing 24-byte tagged Value and the existing AST-walking emitter. That respected the surface but left perf on the floor. v2 throws backward-compat out and writes the spec from scratch.

## What changes

- New `compiler2/` package with typed SSA IR, opt passes, linear-scan reg-alloc. The existing AST-walking compiler stays as the safety net.
- vm2 cell goes from 24-byte tagged to 8-byte NaN-boxed.
- Typed surface has no generic ops, no Quick byte, no IC. MEP-18 / MEP-19 machinery lives only on the residual dynamic surface (FFI, JSON `any`, runtime-built closures). Verifier enforces the split.
- New direct-call, tail-call, bounds-check-elided, untagged-cell-raw opcodes, all gated by verifier proofs.
- Variable-length bytecode after V8 Ignition.
- Falsifiable per-step perf hypothesis table with end-to-end gate >=2.5x over today's vm2 and >=10x over runtime/vm.

## What does not change

- Mochi source language syntax / semantics.
- `runtime/vm` (stays as safety net).
- The MEP-19 IC machinery (retained for the dynamic surface).

## Test plan
- [x] Markdown renders.
- [x] All cross-references intact.

Doc-only PR. Implementation lands in follow-up PRs per the rollout section.