### PR TITLE
vm2/compiler2 step 1: package scaffolds

### DIFF
--- a/compiler2/doc.go
+++ b/compiler2/doc.go
@@ -1,0 +1,13 @@
+// Package compiler2 is the from-scratch typed bytecode compiler for vm2.
+//
+// Design contract: MEP-21 v2 (Type-Directed Bytecode and Compiler/VM
+// Co-Design). See website/docs/mep/mep-0021.md.
+//
+// Pipeline: typed AST -> typed SSA IR (compiler2/ir) -> optimization
+// passes (compiler2/opt) -> linear-scan register allocation
+// (compiler2/regalloc) -> typed monomorphic bytecode emission
+// (compiler2/emit) -> runtime/vm2 Program.
+//
+// The existing compiler/ package continues to target runtime/vm; the two
+// pipelines coexist while compiler2 + vm2 are brought up to parity.
+package compiler2

--- a/runtime/vm2/doc.go
+++ b/runtime/vm2/doc.go
@@ -1,0 +1,11 @@
+// Package vm2 is the from-scratch redesign of the Mochi bytecode VM.
+//
+// Design contract: MEP-21 v2 (Type-Directed Bytecode and Compiler/VM
+// Co-Design) and MEP-20 (Value Representation and Allocation Discipline).
+// See website/docs/mep/mep-0021.md.
+//
+// vm2 is built around an 8-byte NaN-boxed Cell, typed monomorphic
+// opcodes emitted directly by compiler2, no Quick-byte rewriting and no
+// inline caches on the typed surface. The runtime/vm package continues
+// to ship as the observation-driven safety net.
+package vm2


### PR DESCRIPTION
Step 1/10 of the MEP-21 v2 from-scratch rollout (#21496).

Empty doc.go files for runtime/vm2 and compiler2 anchoring the contract to MEP-21 v2. No runtime change.

## Test plan
- [x] go build ./runtime/vm2/ ./compiler2/
- [x] go vet ./runtime/vm2/ ./compiler2/