### PR TITLE
vm2 step 2: NaN-boxed Cell

### DIFF
--- a/runtime/vm2/cell.go
+++ b/runtime/vm2/cell.go
@@ -1,0 +1,91 @@
+package vm2
+
+import "math"
+
+// Cell is the 8-byte tagged value used by vm2 throughout. It is
+// NaN-boxed in the style of LuaJIT / JavaScriptCore: a Cell is either a
+// raw IEEE 754 float64 (non-canonicalized NaNs are normalized on
+// construction), or one of four tagged forms whose high 16 bits live
+// inside the qNaN-with-sign-bit range so they cannot collide with a
+// real float bit pattern.
+//
+// Tag layout (high 16 bits):
+//
+//	0x0000..0xFFEF  -> float64 (normal or subnormal)
+//	0x7FF8          -> canonical qNaN, treated as float
+//	0xFFFC          -> int (low 48 bits, signed)
+//	0xFFFD          -> bool (low bit)
+//	0xFFFE          -> null
+//	0xFFFF          -> ptr index into VM.Objects (low 48 bits, unsigned)
+//
+// Int is 48-bit signed (range -2^47 .. 2^47-1). Wider ints are boxed
+// into the Objects table by the compiler; see CPtr.
+type Cell uint64
+
+const (
+	qNaN    uint64 = 0x7FF8000000000000
+	tagMask uint64 = 0xFFFF000000000000
+	tagInt  uint64 = 0xFFFC000000000000
+	tagBool uint64 = 0xFFFD000000000000
+	tagNull uint64 = 0xFFFE000000000000
+	tagPtr  uint64 = 0xFFFF000000000000
+
+	payloadMask uint64 = 0x0000FFFFFFFFFFFF
+
+	// MaxInlineInt and MinInlineInt are the inclusive bounds of an int
+	// that fits in a Cell without boxing into Objects.
+	MaxInlineInt int64 = 1<<47 - 1
+	MinInlineInt int64 = -(1 << 47)
+)
+
+// CFloat boxes a float64. NaN inputs are canonicalized so they read
+// back as IsFloat.
+func CFloat(f float64) Cell {
+	if f != f { // any NaN -> canonical qNaN
+		return Cell(qNaN)
+	}
+	return Cell(math.Float64bits(f))
+}
+
+// CInt boxes a 48-bit signed int. Callers that may overflow must check
+// FitsInline first; out-of-range values are silently truncated here.
+func CInt(i int64) Cell {
+	return Cell(tagInt | uint64(i)&payloadMask)
+}
+
+func CBool(b bool) Cell {
+	if b {
+		return Cell(tagBool | 1)
+	}
+	return Cell(tagBool)
+}
+
+func CNull() Cell { return Cell(tagNull) }
+
+// CPtr boxes a 48-bit unsigned index into the owning VM's Objects table.
+func CPtr(idx uint64) Cell {
+	return Cell(tagPtr | idx&payloadMask)
+}
+
+func (c Cell) IsFloat() bool { return uint64(c)&tagMask < tagInt }
+func (c Cell) IsInt() bool   { return uint64(c)&tagMask == tagInt }
+func (c Cell) IsBool() bool  { return uint64(c)&tagMask == tagBool }
+func (c Cell) IsNull() bool  { return uint64(c)&tagMask == tagNull }
+func (c Cell) IsPtr() bool   { return uint64(c)&tagMask == tagPtr }
+
+func (c Cell) Float() float64 { return math.Float64frombits(uint64(c)) }
+
+// Int decodes the 48-bit signed payload by sign-extending through a
+// left-then-arithmetic-right shift.
+func (c Cell) Int() int64 { return int64(c<<16) >> 16 }
+
+func (c Cell) Bool() bool { return uint64(c)&1 != 0 }
+
+// Ptr returns the 48-bit index into VM.Objects.
+func (c Cell) Ptr() uint64 { return uint64(c) & payloadMask }
+
+// FitsInline reports whether i can be boxed inline by CInt without
+// loss. Compilers should box wider ints through the Objects table.
+func FitsInline(i int64) bool {
+	return i >= MinInlineInt && i <= MaxInlineInt
+}

--- a/runtime/vm2/cell_test.go
+++ b/runtime/vm2/cell_test.go
@@ -1,0 +1,108 @@
+package vm2
+
+import (
+	"math"
+	"testing"
+	"unsafe"
+)
+
+func TestCellSize(t *testing.T) {
+	if got := unsafe.Sizeof(Cell(0)); got != 8 {
+		t.Fatalf("Cell size = %d, want 8", got)
+	}
+}
+
+func TestCellInt(t *testing.T) {
+	for _, v := range []int64{0, 1, -1, 42, -42, MaxInlineInt, MinInlineInt, 1 << 30, -(1 << 30)} {
+		c := CInt(v)
+		if !c.IsInt() {
+			t.Fatalf("CInt(%d) not IsInt: %#x", v, uint64(c))
+		}
+		if c.IsFloat() || c.IsBool() || c.IsNull() || c.IsPtr() {
+			t.Fatalf("CInt(%d) tag collision: %#x", v, uint64(c))
+		}
+		if got := c.Int(); got != v {
+			t.Fatalf("CInt(%d).Int() = %d", v, got)
+		}
+	}
+}
+
+func TestCellFloat(t *testing.T) {
+	cases := []float64{0, 1, -1, 3.14, -3.14, math.Inf(1), math.Inf(-1), math.MaxFloat64, -math.MaxFloat64, math.SmallestNonzeroFloat64}
+	for _, v := range cases {
+		c := CFloat(v)
+		if !c.IsFloat() {
+			t.Fatalf("CFloat(%g) not IsFloat: %#x", v, uint64(c))
+		}
+		if c.IsInt() || c.IsBool() || c.IsNull() || c.IsPtr() {
+			t.Fatalf("CFloat(%g) tag collision: %#x", v, uint64(c))
+		}
+		if got := c.Float(); got != v {
+			t.Fatalf("CFloat(%g).Float() = %g", v, got)
+		}
+	}
+	nan := CFloat(math.NaN())
+	if !nan.IsFloat() {
+		t.Fatalf("NaN cell not IsFloat: %#x", uint64(nan))
+	}
+	if !math.IsNaN(nan.Float()) {
+		t.Fatalf("NaN cell decoded to non-NaN: %g", nan.Float())
+	}
+}
+
+func TestCellBool(t *testing.T) {
+	if !CBool(true).Bool() {
+		t.Fatal("CBool(true).Bool() == false")
+	}
+	if CBool(false).Bool() {
+		t.Fatal("CBool(false).Bool() == true")
+	}
+	if !CBool(true).IsBool() || !CBool(false).IsBool() {
+		t.Fatal("CBool not IsBool")
+	}
+	if CBool(true).IsInt() || CBool(false).IsFloat() {
+		t.Fatal("CBool tag collision")
+	}
+}
+
+func TestCellNull(t *testing.T) {
+	c := CNull()
+	if !c.IsNull() {
+		t.Fatal("CNull not IsNull")
+	}
+	if c.IsInt() || c.IsFloat() || c.IsBool() || c.IsPtr() {
+		t.Fatal("CNull tag collision")
+	}
+}
+
+func TestCellPtr(t *testing.T) {
+	for _, idx := range []uint64{0, 1, 42, payloadMask} {
+		c := CPtr(idx)
+		if !c.IsPtr() {
+			t.Fatalf("CPtr(%d) not IsPtr: %#x", idx, uint64(c))
+		}
+		if c.IsInt() || c.IsFloat() || c.IsBool() || c.IsNull() {
+			t.Fatalf("CPtr(%d) tag collision", idx)
+		}
+		if got := c.Ptr(); got != idx {
+			t.Fatalf("CPtr(%d).Ptr() = %d", idx, got)
+		}
+	}
+}
+
+func TestFitsInline(t *testing.T) {
+	cases := []struct {
+		v  int64
+		ok bool
+	}{
+		{0, true}, {1, true}, {-1, true},
+		{MaxInlineInt, true}, {MinInlineInt, true},
+		{MaxInlineInt + 1, false}, {MinInlineInt - 1, false},
+		{math.MaxInt64, false}, {math.MinInt64, false},
+	}
+	for _, c := range cases {
+		if got := FitsInline(c.v); got != c.ok {
+			t.Fatalf("FitsInline(%d) = %v, want %v", c.v, got, c.ok)
+		}
+	}
+}


### PR DESCRIPTION
Step 2/10 of #21496.

8-byte NaN-boxed Cell per [MEP-21 v2](/docs/mep/mep-0021). Tag scheme:
high 16 bits in {0xFFFC..0xFFFF} for int/bool/null/ptr; everything else
is a float64. Int payload is 48-bit signed; wider ints box through the
Objects table via CPtr (added in step 3).

## Test plan
- [x] go test ./runtime/vm2/ -v (7/7 pass)
- [x] unsafe.Sizeof(Cell) == 8
- [x] NaN canonicalization round-trips