### PR TITLE
vm2 step 3: dispatch core + fib bench (14.5x vs runtime/vm)

### DIFF
--- a/runtime/vm2/bench/fib_test.go
+++ b/runtime/vm2/bench/fib_test.go
@@ -1,0 +1,105 @@
+package bench
+
+import (
+	"testing"
+
+	vm2 "mochi/runtime/vm2"
+)
+
+// buildFibProgram builds a vm2 Program for:
+//
+//	func fib(n) {
+//	    if n < 2 { return n }
+//	    return fib(n-1) + fib(n-2)
+//	}
+//	main() = fib(N)
+func buildFibProgram(n int64) *vm2.Program {
+	const fibIdx = 1
+
+	// fib: NumParams=1 (r0=n), NumRegs=8
+	// r0: n
+	// r1: scratch (const / less result)
+	// r2: arg for fib(n-1)
+	// r3: result of fib(n-1)
+	// r4: arg for fib(n-2)
+	// r5: result of fib(n-2)
+	// r6: sum
+	fib := &vm2.Function{
+		Name:      "fib",
+		NumParams: 1,
+		NumRegs:   8,
+		Consts:    []vm2.Cell{vm2.CInt(2), vm2.CInt(1)},
+		Code: []vm2.Instr{
+			{Op: vm2.OpLoadConstI, A: 1, B: 0},               // r1 = 2
+			{Op: vm2.OpLessI64, A: 1, B: 0, C: 1},            // r1 = n < 2
+			{Op: vm2.OpJumpIfFalse, A: 1, B: 4},              // if !(n<2) goto 4
+			{Op: vm2.OpReturn, A: 0},                         // return n
+			{Op: vm2.OpLoadConstI, A: 1, B: 1},               // r1 = 1
+			{Op: vm2.OpSubI64, A: 2, B: 0, C: 1},             // r2 = n - 1
+			{Op: vm2.OpCall, A: 3, B: fibIdx, C: 2, D: 1},    // r3 = fib(r2)
+			{Op: vm2.OpLoadConstI, A: 1, B: 0},               // r1 = 2
+			{Op: vm2.OpSubI64, A: 4, B: 0, C: 1},             // r4 = n - 2
+			{Op: vm2.OpCall, A: 5, B: fibIdx, C: 4, D: 1},    // r5 = fib(r4)
+			{Op: vm2.OpAddI64, A: 6, B: 3, C: 5},             // r6 = r3 + r5
+			{Op: vm2.OpReturn, A: 6},                         // return r6
+		},
+	}
+
+	main := &vm2.Function{
+		Name:      "main",
+		NumParams: 0,
+		NumRegs:   4,
+		Consts:    []vm2.Cell{vm2.CInt(n)},
+		Code: []vm2.Instr{
+			{Op: vm2.OpLoadConstI, A: 0, B: 0},            // r0 = n
+			{Op: vm2.OpCall, A: 1, B: fibIdx, C: 0, D: 1}, // r1 = fib(r0)
+			{Op: vm2.OpReturn, A: 1},                      // return r1
+		},
+	}
+
+	return &vm2.Program{Funcs: []*vm2.Function{main, fib}, Main: 0}
+}
+
+func fibGold(n int64) int64 {
+	if n < 2 {
+		return n
+	}
+	return fibGold(n-1) + fibGold(n-2)
+}
+
+func TestFib10(t *testing.T) {
+	p := buildFibProgram(10)
+	v := vm2.New(p)
+	got, err := v.Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !got.IsInt() {
+		t.Fatalf("result not int: %#v", got)
+	}
+	if got.Int() != fibGold(10) {
+		t.Fatalf("fib(10) = %d, want %d", got.Int(), fibGold(10))
+	}
+}
+
+func TestFib20(t *testing.T) {
+	p := buildFibProgram(20)
+	v := vm2.New(p)
+	got, err := v.Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got.Int() != fibGold(20) {
+		t.Fatalf("fib(20) = %d, want %d", got.Int(), fibGold(20))
+	}
+}
+
+func BenchmarkFib25(b *testing.B) {
+	p := buildFibProgram(25)
+	v := vm2.New(p)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = v.Run()
+	}
+}

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -1,0 +1,92 @@
+package vm2
+
+import "errors"
+
+// Run executes Program.Main and returns the final Cell. Objects is
+// reset before dispatch; callers that pre-populate it (e.g. tests
+// loading boxed wide ints) must do so after Run starts via a hook in
+// a later step.
+func (vm *VM) Run() (Cell, error) {
+	vm.Objects = vm.Objects[:0]
+	main := vm.Program.Funcs[vm.Program.Main]
+	fr := vm.acquireFrame(main)
+	var ret Cell
+	for {
+		ins := &fr.Fn.Code[fr.IP]
+		fr.IP++
+		switch ins.Op {
+		case OpLoadConstI:
+			fr.Regs[ins.A] = fr.Fn.Consts[ins.B]
+		case OpMove:
+			fr.Regs[ins.A] = fr.Regs[ins.B]
+		case OpAddI64:
+			fr.Regs[ins.A] = CInt(fr.Regs[ins.B].Int() + fr.Regs[ins.C].Int())
+		case OpSubI64:
+			fr.Regs[ins.A] = CInt(fr.Regs[ins.B].Int() - fr.Regs[ins.C].Int())
+		case OpMulI64:
+			fr.Regs[ins.A] = CInt(fr.Regs[ins.B].Int() * fr.Regs[ins.C].Int())
+		case OpLessI64:
+			fr.Regs[ins.A] = CBool(fr.Regs[ins.B].Int() < fr.Regs[ins.C].Int())
+		case OpLessEqI64:
+			fr.Regs[ins.A] = CBool(fr.Regs[ins.B].Int() <= fr.Regs[ins.C].Int())
+		case OpEqualI64:
+			fr.Regs[ins.A] = CBool(fr.Regs[ins.B].Int() == fr.Regs[ins.C].Int())
+		case OpJump:
+			fr.IP = int(ins.A)
+		case OpJumpIfFalse:
+			if !fr.Regs[ins.A].Bool() {
+				fr.IP = int(ins.B)
+			}
+		case OpCall:
+			callee := vm.Program.Funcs[ins.B]
+			newFr := vm.acquireFrame(callee)
+			n := int(ins.D)
+			copy(newFr.Regs[:n], fr.Regs[ins.C:int(ins.C)+n])
+			newFr.RetReg = ins.A
+			newFr.Parent = fr
+			fr = newFr
+		case OpTailCall:
+			callee := vm.Program.Funcs[ins.A]
+			n := int(ins.C)
+			// Snapshot args before overwriting any register that
+			// might alias the destination slots.
+			var buf [16]Cell
+			var args []Cell
+			if n <= len(buf) {
+				args = buf[:n]
+			} else {
+				args = make([]Cell, n)
+			}
+			copy(args, fr.Regs[ins.B:int(ins.B)+n])
+			if callee == fr.Fn {
+				// Same function: reuse frame in place.
+				copy(fr.Regs[:n], args)
+				fr.IP = 0
+			} else {
+				// Different function: swap frame contents.
+				parent := fr.Parent
+				retReg := fr.RetReg
+				vm.releaseFrame(fr)
+				newFr := vm.acquireFrame(callee)
+				copy(newFr.Regs[:n], args)
+				newFr.RetReg = retReg
+				newFr.Parent = parent
+				fr = newFr
+			}
+		case OpReturn:
+			ret = fr.Regs[ins.A]
+			retReg := fr.RetReg
+			parent := fr.Parent
+			vm.releaseFrame(fr)
+			if parent == nil {
+				return ret, nil
+			}
+			parent.Regs[retReg] = ret
+			fr = parent
+		case OpHalt:
+			return ret, errors.New("vm2: OpHalt reached")
+		default:
+			return ret, errors.New("vm2: unknown opcode")
+		}
+	}
+}

--- a/runtime/vm2/ops.go
+++ b/runtime/vm2/ops.go
@@ -1,0 +1,23 @@
+package vm2
+
+// Op is the vm2 opcode. The set is intentionally small for step 3;
+// subsequent steps add typed float/string/list/map families per the
+// MEP-21 v2 opcode table.
+type Op uint8
+
+const (
+	OpHalt        Op = iota // never reached; sentinel for verifier
+	OpLoadConstI            // A = Consts[B]
+	OpMove                  // A = B
+	OpAddI64                // A = B + C (signed 48-bit; overflow is implementation-defined)
+	OpSubI64                // A = B - C
+	OpMulI64                // A = B * C
+	OpLessI64               // A = B < C  (bool)
+	OpLessEqI64             // A = B <= C (bool)
+	OpEqualI64              // A = B == C (bool)
+	OpJump                  // IP = A
+	OpJumpIfFalse           // if !A then IP = B
+	OpCall                  // A = call Funcs[B], args [C..C+D); RetReg=A
+	OpTailCall              // tail-call Funcs[A] with args [B..B+C); reuses frame
+	OpReturn                // return A to caller's RetReg
+)

--- a/runtime/vm2/program.go
+++ b/runtime/vm2/program.go
@@ -1,0 +1,26 @@
+package vm2
+
+// Instr is a single bytecode instruction. Fixed 20 bytes (one cache
+// line holds three). Variable-length encoding is a later MEP-21 v2
+// item; the fixed form keeps step 3 minimal.
+type Instr struct {
+	Op      Op
+	_       [3]byte
+	A, B, C int32
+	D       int32
+}
+
+// Function is a compiled top-level function or method body.
+type Function struct {
+	Name      string
+	NumParams int
+	NumRegs   int
+	Code      []Instr
+	Consts    []Cell
+}
+
+// Program is the unit of execution. Main names the entry function.
+type Program struct {
+	Funcs []*Function
+	Main  int
+}

--- a/runtime/vm2/vm.go
+++ b/runtime/vm2/vm.go
@@ -1,0 +1,102 @@
+package vm2
+
+import "sync"
+
+// VM holds the program plus the per-run Objects table for ref-tagged
+// Cells (boxed wide ints, strings, lists, maps, closures). The table
+// is reset on each Run so pure-numeric programs never grow it.
+type VM struct {
+	Program *Program
+	Objects []any
+}
+
+// New constructs a VM bound to a program.
+func New(p *Program) *VM { return &VM{Program: p} }
+
+// AddObject appends to the Objects table and returns the index suitable
+// for CPtr. Compilers and FFI use this to hand a ref-typed value to
+// running code.
+func (vm *VM) AddObject(o any) uint64 {
+	vm.Objects = append(vm.Objects, o)
+	return uint64(len(vm.Objects) - 1)
+}
+
+// frame is one activation record. Regs is a slab borrowed from the
+// per-size pool; regsPtr holds the cached *[]Cell so releaseFrame
+// returns the same allocation without a fresh address-of (which would
+// escape).
+type frame struct {
+	Fn         *Function
+	Regs       []Cell
+	regsPtr    *[]Cell
+	IP         int
+	RetReg     int32
+	RegsBucket int8
+	Parent     *frame
+}
+
+var framePool = sync.Pool{New: func() any { return &frame{} }}
+
+const (
+	regsMinBucket = 2  // 2^2 = 4
+	regsMaxBucket = 11 // 2^11 = 2048
+)
+
+var regsPools [regsMaxBucket - regsMinBucket + 1]sync.Pool
+
+func init() {
+	for i := range regsPools {
+		size := 1 << (uint(i) + regsMinBucket)
+		regsPools[i].New = func() any {
+			r := make([]Cell, size)
+			return &r
+		}
+	}
+}
+
+func bucketFor(n int) int {
+	b := regsMinBucket
+	for (1 << b) < n {
+		b++
+	}
+	if b > regsMaxBucket {
+		return -1
+	}
+	return b - regsMinBucket
+}
+
+func (vm *VM) acquireFrame(fn *Function) *frame {
+	fr := framePool.Get().(*frame)
+	fr.Fn = fn
+	fr.IP = 0
+	fr.Parent = nil
+	bi := bucketFor(fn.NumRegs)
+	if bi < 0 {
+		regs := make([]Cell, fn.NumRegs)
+		fr.Regs = regs
+		fr.regsPtr = nil
+		fr.RegsBucket = -1
+		return fr
+	}
+	p := regsPools[bi].Get().(*[]Cell)
+	fr.Regs = (*p)[:fn.NumRegs]
+	fr.regsPtr = p
+	fr.RegsBucket = int8(bi)
+	return fr
+}
+
+func (vm *VM) releaseFrame(fr *frame) {
+	if fr.regsPtr != nil {
+		// zero the live window so stale ptr indices do not pin
+		// Objects entries beyond their useful life.
+		for i := range fr.Regs {
+			fr.Regs[i] = 0
+		}
+		regsPools[fr.RegsBucket].Put(fr.regsPtr)
+	}
+	fr.Fn = nil
+	fr.Regs = nil
+	fr.regsPtr = nil
+	fr.Parent = nil
+	framePool.Put(fr)
+}


### PR DESCRIPTION
Step 3/10 of #21496. Stacks on #21498 (step 2) and #21497 (step 1).

Minimal interpreter loop with the opcode set needed for hand-coded fib:
LoadConstI, Move, AddI64/SubI64/MulI64, LessI64/LessEqI64/EqualI64,
Jump/JumpIfFalse, Call, TailCall, Return.

Frame and register-slab pools follow MEP-20 with the cached \`*[]Cell\`
trick: regsPtr lives on the frame struct so releaseFrame does not take
the address of a local (which would escape and reintroduce allocs).

TailCall handles both same-function (frame reuse) and cross-function
(frame swap) paths so step 9's tail-call pass has a landing site.

## Benchstat (M4, fib(25))

| pipeline          | ns/op       | B/op          | allocs/op |
|-------------------|-------------|---------------|-----------|
| runtime/vm        | 203,898,861 | 364,739,934   | 515,563   |
| **vm2 (this PR)** | **14,060,401** | **43**        | **0**     |

That is **14.5x** on time, and the MEP-21 v2 hypothesis table called
for >=10x. The 24-byte-Value prior-session vm2 came in at 46.7 ms/op;
the 8-byte Cell + lean dispatch is 3.3x on top of that.

## Test plan
- [x] go test ./runtime/vm2/... -timeout 30s (TestFib10, TestFib20 pass)
- [x] go test ./runtime/vm2/bench/ -bench BenchmarkFib25 -benchmem