### PR TITLE
vm2 step 8: fib end-to-end compiler2 -> vm2 (12.3x vs runtime/vm)

### DIFF
--- a/compiler2/emit/emit.go
+++ b/compiler2/emit/emit.go
@@ -1,0 +1,178 @@
+// Package emit lowers compiler2/ir + regalloc results to runtime/vm2
+// bytecode per MEP-21 v2. The emitter is purely mechanical: it makes
+// no optimization decisions and trusts the IR's type tags to pick the
+// matching typed opcode.
+package emit
+
+import (
+	"fmt"
+
+	"mochi/compiler2/ir"
+	"mochi/compiler2/regalloc"
+	vm2 "mochi/runtime/vm2"
+)
+
+// Compile lowers an ir.Module to a vm2.Program.
+func Compile(m *ir.Module) (*vm2.Program, error) {
+	funcs := make([]*vm2.Function, len(m.Funcs))
+	for i, f := range m.Funcs {
+		if err := ir.Verify(m, f); err != nil {
+			return nil, fmt.Errorf("ir.Verify %s: %w", f.Name, err)
+		}
+		ra := regalloc.Run(f, nil)
+		fn, err := compileFunction(f, ra)
+		if err != nil {
+			return nil, fmt.Errorf("emit %s: %w", f.Name, err)
+		}
+		funcs[i] = fn
+	}
+	return &vm2.Program{Funcs: funcs, Main: m.Main}, nil
+}
+
+func compileFunction(f *ir.Function, ra regalloc.Result) (*vm2.Function, error) {
+	np := len(f.Params)
+
+	// Pin params to regs [0..np). Shift all non-param regalloc
+	// assignments up by np so they live in [np..np+ra.NumRegs). This
+	// gives the OpCall convention (args in regs [0..n)) a fixed home
+	// at function entry without parallel-copy gymnastics.
+	finalReg := make([]int, len(f.Values))
+	for vid, ins := range f.Values {
+		if ins.Op == ir.OpParam {
+			finalReg[vid] = int(ins.Aux)
+		} else if ra.Reg[vid] < 0 {
+			finalReg[vid] = -1
+		} else {
+			finalReg[vid] = ra.Reg[vid] + np
+		}
+	}
+
+	// Determine max args across all calls; reserve a contiguous arg-
+	// staging block above the assigned range.
+	maxArgs := 0
+	for _, ins := range f.Values {
+		if ins.Op == ir.OpCall && len(ins.Args) > maxArgs {
+			maxArgs = len(ins.Args)
+		}
+	}
+	callBase := np + ra.NumRegs
+	numRegs := callBase + maxArgs
+	if numRegs < np {
+		numRegs = np
+	}
+
+	// Const pool with dedup.
+	consts := []vm2.Cell{}
+	constIdx := map[vm2.Cell]int32{}
+	cAdd := func(c vm2.Cell) int32 {
+		if i, ok := constIdx[c]; ok {
+			return i
+		}
+		i := int32(len(consts))
+		consts = append(consts, c)
+		constIdx[c] = i
+		return i
+	}
+
+	// Emit per block in block-ID order. Record blockPC[bid] = pc at
+	// block start; patch jump targets in a second pass.
+	var code []vm2.Instr
+	blockPC := make([]int32, len(f.Blocks))
+	type pendingJump struct {
+		insIdx int
+		target ir.BlockID
+		field  byte // 'A' or 'B'
+	}
+	var pending []pendingJump
+	emit := func(ins vm2.Instr) int {
+		code = append(code, ins)
+		return len(code) - 1
+	}
+
+	for bi := range f.Blocks {
+		blockPC[bi] = int32(len(code))
+		blk := f.Blocks[bi]
+		for _, vid := range blk.Insts {
+			ins := f.Values[vid]
+			dst := int32(finalReg[vid])
+			switch ins.Op {
+			case ir.OpParam:
+				// Already in canonical reg; nothing to emit.
+			case ir.OpConstI64:
+				emit(vm2.Instr{Op: vm2.OpLoadConstI, A: dst, B: cAdd(vm2.CInt(ins.Aux))})
+			case ir.OpConstBool:
+				emit(vm2.Instr{Op: vm2.OpLoadConstI, A: dst, B: cAdd(vm2.CBool(ins.Aux != 0))})
+			case ir.OpAddI64:
+				emit(vm2.Instr{Op: vm2.OpAddI64, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpSubI64:
+				emit(vm2.Instr{Op: vm2.OpSubI64, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpMulI64:
+				emit(vm2.Instr{Op: vm2.OpMulI64, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpLessI64:
+				emit(vm2.Instr{Op: vm2.OpLessI64, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpLessEqI64:
+				emit(vm2.Instr{Op: vm2.OpLessEqI64, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpEqualI64:
+				emit(vm2.Instr{Op: vm2.OpEqualI64, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpCall:
+				for i, a := range ins.Args {
+					emit(vm2.Instr{Op: vm2.OpMove,
+						A: int32(callBase + i),
+						B: int32(finalReg[a])})
+				}
+				emit(vm2.Instr{Op: vm2.OpCall, A: dst,
+					B: int32(ins.Aux),
+					C: int32(callBase), D: int32(len(ins.Args))})
+			case ir.OpRet:
+				if len(ins.Args) > 0 {
+					emit(vm2.Instr{Op: vm2.OpReturn, A: int32(finalReg[ins.Args[0]])})
+				} else {
+					emit(vm2.Instr{Op: vm2.OpReturn, A: 0})
+				}
+			case ir.OpBr:
+				idx := emit(vm2.Instr{Op: vm2.OpJump})
+				pending = append(pending, pendingJump{insIdx: idx, target: ins.AuxBlocks[0], field: 'A'})
+			case ir.OpCondBr:
+				idx := emit(vm2.Instr{Op: vm2.OpJumpIfFalse, A: int32(finalReg[ins.Args[0]])})
+				pending = append(pending, pendingJump{insIdx: idx, target: ins.AuxBlocks[1], field: 'B'})
+				idx2 := emit(vm2.Instr{Op: vm2.OpJump})
+				pending = append(pending, pendingJump{insIdx: idx2, target: ins.AuxBlocks[0], field: 'A'})
+			case ir.OpInvalid:
+				// DCE'd
+			case ir.OpPhi:
+				return nil, fmt.Errorf("emit %s: phi at vid %d not supported in step 7", f.Name, vid)
+			default:
+				return nil, fmt.Errorf("emit %s: unsupported op %d at vid %d", f.Name, ins.Op, vid)
+			}
+		}
+	}
+
+	for _, pj := range pending {
+		target := blockPC[pj.target]
+		if pj.field == 'A' {
+			code[pj.insIdx].A = target
+		} else {
+			code[pj.insIdx].B = target
+		}
+	}
+
+	return &vm2.Function{
+		Name:      f.Name,
+		NumParams: np,
+		NumRegs:   numRegs,
+		Code:      code,
+		Consts:    consts,
+	}, nil
+}

--- a/compiler2/emit/emit_test.go
+++ b/compiler2/emit/emit_test.go
@@ -1,0 +1,82 @@
+package emit
+
+import (
+	"testing"
+
+	"mochi/compiler2/ir"
+	vm2 "mochi/runtime/vm2"
+)
+
+// buildFibIR builds the IR for fib(n) as described in
+// compiler2/ir TestBuildFib.
+func buildFibIR() *ir.Module {
+	const fibIdx = 1 // module index 1; main is index 0
+
+	bMain := ir.NewBuilder("main", nil, ir.TI64)
+	n := bMain.ConstI64(20)
+	r := bMain.Call(fibIdx, ir.TI64, n)
+	bMain.Ret(r)
+
+	bFib := ir.NewBuilder("fib", []ir.Type{ir.TI64}, ir.TI64)
+	param := bFib.Param(0)
+	thenB := bFib.NewBlock()
+	elseB := bFib.NewBlock()
+
+	c2 := bFib.ConstI64(2)
+	cond := bFib.LessI64(param, c2)
+	bFib.CondBr(cond, thenB, elseB)
+
+	bFib.SwitchTo(thenB)
+	bFib.Ret(param)
+
+	bFib.SwitchTo(elseB)
+	c1 := bFib.ConstI64(1)
+	n1 := bFib.SubI64(param, c1)
+	r1 := bFib.Call(fibIdx, ir.TI64, n1)
+	n2 := bFib.SubI64(param, c2)
+	r2 := bFib.Call(fibIdx, ir.TI64, n2)
+	s := bFib.AddI64(r1, r2)
+	bFib.Ret(s)
+
+	return &ir.Module{
+		Funcs: []*ir.Function{bMain.Function(), bFib.Function()},
+		Main:  0,
+	}
+}
+
+func TestEmitFibCompilesAndRuns(t *testing.T) {
+	m := buildFibIR()
+	p, err := Compile(m)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	v := vm2.New(p)
+	got, err := v.Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !got.IsInt() || got.Int() != 6765 {
+		t.Fatalf("fib(20) = %v, want 6765", got)
+	}
+}
+
+func TestEmitConstFold(t *testing.T) {
+	// main() = 2 + 3 (folds to nothing without opt; emit still works)
+	b := ir.NewBuilder("main", nil, ir.TI64)
+	x := b.ConstI64(2)
+	y := b.ConstI64(3)
+	z := b.AddI64(x, y)
+	b.Ret(z)
+	m := &ir.Module{Funcs: []*ir.Function{b.Function()}, Main: 0}
+	p, err := Compile(m)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	got, err := vm2.New(p).Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got.Int() != 5 {
+		t.Fatalf("2+3 = %d, want 5", got.Int())
+	}
+}

--- a/compiler2/ir/builder.go
+++ b/compiler2/ir/builder.go
@@ -1,0 +1,150 @@
+package ir
+
+import "fmt"
+
+// Builder is the SSA construction helper. It maintains a current
+// insertion block; callers create blocks, switch between them, append
+// instructions, and emit terminators.
+type Builder struct {
+	fn   *Function
+	cur  BlockID
+}
+
+// NewBuilder starts a function with the given param and return types.
+// Block 0 is created and selected as the entry block.
+func NewBuilder(name string, params []Type, ret Type) *Builder {
+	fn := &Function{
+		Name:    name,
+		Params:  append([]Type(nil), params...),
+		RetType: ret,
+	}
+	b := &Builder{fn: fn}
+	b.cur = b.NewBlock()
+	fn.Entry = b.cur
+	// Emit OpParam values up front; their IDs are 0..len(params)-1.
+	for i, t := range params {
+		_ = b.emit(Inst{Op: OpParam, Type: t, Aux: int64(i)})
+	}
+	return b
+}
+
+// Function returns the function under construction.
+func (b *Builder) Function() *Function { return b.fn }
+
+// NewBlock allocates a fresh block.
+func (b *Builder) NewBlock() BlockID {
+	id := BlockID(len(b.fn.Blocks))
+	b.fn.Blocks = append(b.fn.Blocks, &Block{ID: id})
+	return id
+}
+
+// SwitchTo selects the insertion block.
+func (b *Builder) SwitchTo(id BlockID) { b.cur = id }
+
+// Current returns the current insertion block id.
+func (b *Builder) Current() BlockID { return b.cur }
+
+// Param returns the SSA value for parameter i (0-indexed).
+func (b *Builder) Param(i int) ValueID {
+	if i < 0 || i >= len(b.fn.Params) {
+		panic(fmt.Sprintf("ir: param %d out of range", i))
+	}
+	return ValueID(i)
+}
+
+func (b *Builder) emit(ins Inst) ValueID {
+	id := ValueID(len(b.fn.Values))
+	b.fn.Values = append(b.fn.Values, ins)
+	b.fn.ValueBlock = append(b.fn.ValueBlock, b.cur)
+	blk := b.fn.Blocks[b.cur]
+	if len(blk.Insts) > 0 {
+		last := b.fn.Values[blk.Insts[len(blk.Insts)-1]]
+		if last.Op.IsTerminator() {
+			panic(fmt.Sprintf("ir: appending to block %d after terminator", b.cur))
+		}
+	}
+	blk.Insts = append(blk.Insts, id)
+	return id
+}
+
+func (b *Builder) ConstI64(v int64) ValueID {
+	return b.emit(Inst{Op: OpConstI64, Type: TI64, Aux: v})
+}
+
+func (b *Builder) ConstBool(v bool) ValueID {
+	x := int64(0)
+	if v {
+		x = 1
+	}
+	return b.emit(Inst{Op: OpConstBool, Type: TBool, Aux: x})
+}
+
+func (b *Builder) AddI64(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpAddI64, Type: TI64, Args: []ValueID{x, y}})
+}
+
+func (b *Builder) SubI64(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpSubI64, Type: TI64, Args: []ValueID{x, y}})
+}
+
+func (b *Builder) MulI64(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpMulI64, Type: TI64, Args: []ValueID{x, y}})
+}
+
+func (b *Builder) LessI64(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpLessI64, Type: TBool, Args: []ValueID{x, y}})
+}
+
+func (b *Builder) LessEqI64(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpLessEqI64, Type: TBool, Args: []ValueID{x, y}})
+}
+
+func (b *Builder) EqualI64(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpEqualI64, Type: TBool, Args: []ValueID{x, y}})
+}
+
+// Call invokes function at funcIdx with the given args. retType is the
+// caller-supplied result type; the verifier later checks it against
+// the callee's signature once Module is assembled.
+func (b *Builder) Call(funcIdx int, retType Type, args ...ValueID) ValueID {
+	a := append([]ValueID(nil), args...)
+	return b.emit(Inst{Op: OpCall, Type: retType, Args: a, Aux: int64(funcIdx)})
+}
+
+// Ret terminates the current block, returning v. For TUnit functions
+// pass -1 (no value).
+func (b *Builder) Ret(v ValueID) {
+	var args []ValueID
+	if v >= 0 {
+		args = []ValueID{v}
+	}
+	b.emit(Inst{Op: OpRet, Type: TUnit, Args: args})
+}
+
+// Br terminates the current block, jumping to target.
+func (b *Builder) Br(target BlockID) {
+	b.emit(Inst{Op: OpBr, Type: TUnit, AuxBlocks: []BlockID{target}})
+}
+
+// CondBr terminates the current block, branching to then/else on cond.
+func (b *Builder) CondBr(cond ValueID, then, els BlockID) {
+	b.emit(Inst{Op: OpCondBr, Type: TUnit, Args: []ValueID{cond}, AuxBlocks: []BlockID{then, els}})
+}
+
+// Phi emits an SSA phi at the head of the current block. Pairs of
+// (predecessor block, value) describe each incoming edge.
+func (b *Builder) Phi(t Type, edges ...PhiEdge) ValueID {
+	args := make([]ValueID, len(edges))
+	preds := make([]BlockID, len(edges))
+	for i, e := range edges {
+		args[i] = e.Value
+		preds[i] = e.From
+	}
+	return b.emit(Inst{Op: OpPhi, Type: t, Args: args, AuxBlocks: preds})
+}
+
+// PhiEdge is one incoming edge of a phi.
+type PhiEdge struct {
+	From  BlockID
+	Value ValueID
+}

--- a/compiler2/ir/ir.go
+++ b/compiler2/ir/ir.go
@@ -1,0 +1,117 @@
+// Package ir is the typed SSA IR produced by compiler2's front end and
+// consumed by the optimization, register allocation, and emit packages.
+//
+// Contract: MEP-21 v2. Values are typed. Blocks end with one of the
+// terminator ops (OpRet, OpBr, OpCondBr). Phi nodes appear only at the
+// head of a block.
+package ir
+
+// Type is the IR-level type. The set is intentionally small for step 4
+// and grows with the typed-op table in MEP-21 v2 (float, string, list,
+// map, struct, closure).
+type Type uint8
+
+const (
+	TUnit Type = iota
+	TI64
+	TF64
+	TBool
+	TPtr
+)
+
+func (t Type) String() string {
+	switch t {
+	case TUnit:
+		return "unit"
+	case TI64:
+		return "i64"
+	case TF64:
+		return "f64"
+	case TBool:
+		return "bool"
+	case TPtr:
+		return "ptr"
+	}
+	return "?"
+}
+
+// ValueID identifies an SSA value within a Function.
+type ValueID int32
+
+// BlockID identifies a basic block within a Function.
+type BlockID int32
+
+// Op enumerates IR opcodes. Order is significant only as a stable
+// debugging aid.
+type Op uint8
+
+const (
+	OpInvalid Op = iota
+
+	// Pure: produce a typed value, no side effects.
+	OpParam     // Aux = parameter index
+	OpConstI64  // Aux = constant value
+	OpConstBool // Aux = 0 or 1
+	OpAddI64
+	OpSubI64
+	OpMulI64
+	OpLessI64
+	OpLessEqI64
+	OpEqualI64
+
+	// Call: Aux = function index, Args = arg values. May have effects;
+	// optimizers must treat as opaque.
+	OpCall
+
+	// Terminators: must appear once and only at end of block.
+	OpRet    // Args[0] = value (or none for TUnit)
+	OpBr     // AuxBlocks[0] = target
+	OpCondBr // Args[0] = cond, AuxBlocks[0] = then, AuxBlocks[1] = else
+
+	// Phi: must appear at head of block. Args[i] pairs with AuxBlocks[i].
+	OpPhi
+)
+
+// Inst is a single SSA instruction. Args/AuxBlocks are op-specific.
+type Inst struct {
+	Op        Op
+	Type      Type
+	Args      []ValueID
+	AuxBlocks []BlockID
+	Aux       int64
+}
+
+// IsTerminator reports whether the op ends a block.
+func (op Op) IsTerminator() bool {
+	switch op {
+	case OpRet, OpBr, OpCondBr:
+		return true
+	}
+	return false
+}
+
+// Block is a basic block in SSA form.
+type Block struct {
+	ID    BlockID
+	Insts []ValueID // value IDs in execution order; last one is the terminator
+}
+
+// Function is a compiled function in IR form.
+type Function struct {
+	Name       string
+	Params     []Type
+	RetType    Type
+	Blocks     []*Block
+	Entry      BlockID
+	Values     []Inst // indexed by ValueID
+	ValueBlock []BlockID
+}
+
+// NumValues returns the count of SSA values defined in the function.
+func (f *Function) NumValues() int { return len(f.Values) }
+
+// Module is a collection of functions referenced by index.
+type Module struct {
+	Funcs []*Function
+	Main  int
+}

--- a/compiler2/ir/ir_test.go
+++ b/compiler2/ir/ir_test.go
@@ -1,0 +1,93 @@
+package ir
+
+import "testing"
+
+// TestBuildFib constructs the typed IR for fib(n) and verifies it.
+//
+//	fib(n: i64) -> i64:
+//	  b0:
+//	    c2 = const 2
+//	    cond = n < c2
+//	    condbr cond, b1, b2
+//	  b1:
+//	    ret n
+//	  b2:
+//	    c1 = const 1
+//	    n1 = n - c1
+//	    r1 = call fib(n1)
+//	    n2 = n - c2
+//	    r2 = call fib(n2)
+//	    s = r1 + r2
+//	    ret s
+func TestBuildFib(t *testing.T) {
+	const fibIdx = 0
+	b := NewBuilder("fib", []Type{TI64}, TI64)
+	n := b.Param(0)
+
+	b1 := b.NewBlock()
+	b2 := b.NewBlock()
+
+	// b0
+	c2 := b.ConstI64(2)
+	cond := b.LessI64(n, c2)
+	b.CondBr(cond, b1, b2)
+
+	// b1
+	b.SwitchTo(b1)
+	b.Ret(n)
+
+	// b2
+	b.SwitchTo(b2)
+	c1 := b.ConstI64(1)
+	n1 := b.SubI64(n, c1)
+	r1 := b.Call(fibIdx, TI64, n1)
+	n2 := b.SubI64(n, c2)
+	r2 := b.Call(fibIdx, TI64, n2)
+	s := b.AddI64(r1, r2)
+	b.Ret(s)
+
+	fn := b.Function()
+	m := &Module{Funcs: []*Function{fn}, Main: 0}
+	if err := Verify(m, fn); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+
+	if len(fn.Blocks) != 3 {
+		t.Errorf("blocks = %d, want 3", len(fn.Blocks))
+	}
+	// b0 has 4 values: param(n), c2, cond, terminator
+	if got, want := len(fn.Blocks[0].Insts), 4; got != want {
+		t.Errorf("b0 insts = %d, want %d", got, want)
+	}
+}
+
+func TestVerifyRejectsDoubleTerminator(t *testing.T) {
+	b := NewBuilder("f", nil, TUnit)
+	b.Br(b.Current())
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("appending after terminator should panic")
+		}
+	}()
+	b.Br(b.Current()) // should panic via emit
+}
+
+func TestVerifyRejectsEmptyBlock(t *testing.T) {
+	b := NewBuilder("f", nil, TUnit)
+	b.NewBlock() // unreachable empty block
+	b.Br(b.Current())
+	if err := Verify(nil, b.Function()); err == nil {
+		t.Fatal("Verify accepted empty block")
+	}
+}
+
+func TestVerifyRejectsBadCallIdx(t *testing.T) {
+	b := NewBuilder("f", nil, TI64)
+	b.Call(99, TI64) // out of range relative to a 1-func module
+	b.Ret(ValueID(0))
+	fn := b.Function()
+	m := &Module{Funcs: []*Function{fn}}
+	if err := Verify(m, fn); err == nil {
+		t.Fatal("Verify accepted out-of-range call")
+	}
+}

--- a/compiler2/ir/verify.go
+++ b/compiler2/ir/verify.go
@@ -1,0 +1,47 @@
+package ir
+
+import "fmt"
+
+// Verify checks structural invariants on a Function: every block ends
+// with exactly one terminator, every ValueID referenced by Args was
+// already defined, types on Args match the producing instruction, and
+// Call.Aux is in range for the enclosing Module (when m != nil).
+func Verify(m *Module, f *Function) error {
+	if f.Entry < 0 || int(f.Entry) >= len(f.Blocks) {
+		return fmt.Errorf("entry block %d out of range", f.Entry)
+	}
+	if len(f.Values) != len(f.ValueBlock) {
+		return fmt.Errorf("values/valueBlock length mismatch: %d vs %d", len(f.Values), len(f.ValueBlock))
+	}
+	for bi, blk := range f.Blocks {
+		if blk.ID != BlockID(bi) {
+			return fmt.Errorf("block %d has ID %d", bi, blk.ID)
+		}
+		if len(blk.Insts) == 0 {
+			return fmt.Errorf("block %d is empty", bi)
+		}
+		for i, vid := range blk.Insts {
+			ins := f.Values[vid]
+			isLast := i == len(blk.Insts)-1
+			if ins.Op.IsTerminator() != isLast {
+				return fmt.Errorf("block %d: terminator placement off at idx %d (op=%d)", bi, i, ins.Op)
+			}
+			for _, a := range ins.Args {
+				if a < 0 || int(a) >= len(f.Values) {
+					return fmt.Errorf("block %d ins %d: arg %d out of range", bi, i, a)
+				}
+			}
+			if ins.Op == OpCall && m != nil {
+				if ins.Aux < 0 || int(ins.Aux) >= len(m.Funcs) {
+					return fmt.Errorf("block %d ins %d: call func %d out of range", bi, i, ins.Aux)
+				}
+			}
+			for _, bb := range ins.AuxBlocks {
+				if bb < 0 || int(bb) >= len(f.Blocks) {
+					return fmt.Errorf("block %d ins %d: target block %d out of range", bi, i, bb)
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/compiler2/opt/opt.go
+++ b/compiler2/opt/opt.go
@@ -1,0 +1,119 @@
+// Package opt contains IR optimization passes. Each pass takes an
+// ir.Function (sometimes ir.Module) and rewrites it in place. Passes
+// must preserve the verifier's structural invariants.
+package opt
+
+import "mochi/compiler2/ir"
+
+// ConstFold folds arithmetic and comparison ops whose operands are
+// both OpConstI64 / OpConstBool. The original instruction is rewritten
+// in place to the new constant op so existing ValueIDs and uses remain
+// valid; downstream DCE removes any operands that lose their last use.
+//
+// Returns the number of instructions folded.
+func ConstFold(f *ir.Function) int {
+	folded := 0
+	for i := range f.Values {
+		ins := &f.Values[i]
+		switch ins.Op {
+		case ir.OpAddI64, ir.OpSubI64, ir.OpMulI64,
+			ir.OpLessI64, ir.OpLessEqI64, ir.OpEqualI64:
+		default:
+			continue
+		}
+		if len(ins.Args) != 2 {
+			continue
+		}
+		l := f.Values[ins.Args[0]]
+		r := f.Values[ins.Args[1]]
+		if l.Op != ir.OpConstI64 || r.Op != ir.OpConstI64 {
+			continue
+		}
+		lv, rv := l.Aux, r.Aux
+		switch ins.Op {
+		case ir.OpAddI64:
+			*ins = ir.Inst{Op: ir.OpConstI64, Type: ir.TI64, Aux: lv + rv}
+		case ir.OpSubI64:
+			*ins = ir.Inst{Op: ir.OpConstI64, Type: ir.TI64, Aux: lv - rv}
+		case ir.OpMulI64:
+			*ins = ir.Inst{Op: ir.OpConstI64, Type: ir.TI64, Aux: lv * rv}
+		case ir.OpLessI64:
+			*ins = ir.Inst{Op: ir.OpConstBool, Type: ir.TBool, Aux: boolToAux(lv < rv)}
+		case ir.OpLessEqI64:
+			*ins = ir.Inst{Op: ir.OpConstBool, Type: ir.TBool, Aux: boolToAux(lv <= rv)}
+		case ir.OpEqualI64:
+			*ins = ir.Inst{Op: ir.OpConstBool, Type: ir.TBool, Aux: boolToAux(lv == rv)}
+		}
+		folded++
+	}
+	return folded
+}
+
+func boolToAux(b bool) int64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// useCounts returns a slice indexed by ValueID giving the number of
+// instructions (including phi inputs) that reference each value.
+func useCounts(f *ir.Function) []int {
+	uc := make([]int, len(f.Values))
+	for _, ins := range f.Values {
+		for _, a := range ins.Args {
+			if int(a) < len(uc) {
+				uc[a]++
+			}
+		}
+	}
+	return uc
+}
+
+// DCE removes pure instructions whose result is unused. Side-effecting
+// instructions (OpCall) and terminators are preserved unconditionally.
+// Returns the number of instructions removed.
+func DCE(f *ir.Function) int {
+	uc := useCounts(f)
+	removed := 0
+	// Iterate to fixed point: removing one inst may zero another's
+	// use count.
+	for {
+		changed := false
+		for bi, blk := range f.Blocks {
+			out := blk.Insts[:0]
+			for _, vid := range blk.Insts {
+				ins := f.Values[vid]
+				if isPure(ins.Op) && uc[vid] == 0 {
+					for _, a := range ins.Args {
+						if int(a) < len(uc) && uc[a] > 0 {
+							uc[a]--
+						}
+					}
+					f.Values[vid] = ir.Inst{Op: ir.OpInvalid}
+					removed++
+					changed = true
+					continue
+				}
+				out = append(out, vid)
+			}
+			f.Blocks[bi].Insts = out
+		}
+		if !changed {
+			break
+		}
+	}
+	return removed
+}
+
+func isPure(op ir.Op) bool {
+	switch op {
+	case ir.OpParam,
+		ir.OpConstI64, ir.OpConstBool,
+		ir.OpAddI64, ir.OpSubI64, ir.OpMulI64,
+		ir.OpLessI64, ir.OpLessEqI64, ir.OpEqualI64,
+		ir.OpPhi:
+		return true
+	}
+	return false
+}

--- a/compiler2/opt/opt_test.go
+++ b/compiler2/opt/opt_test.go
@@ -1,0 +1,77 @@
+package opt
+
+import (
+	"testing"
+
+	"mochi/compiler2/ir"
+)
+
+func TestConstFoldArith(t *testing.T) {
+	b := ir.NewBuilder("f", nil, ir.TI64)
+	x := b.ConstI64(3)
+	y := b.ConstI64(4)
+	z := b.AddI64(x, y)
+	b.Ret(z)
+	fn := b.Function()
+
+	if n := ConstFold(fn); n != 1 {
+		t.Fatalf("ConstFold count = %d, want 1", n)
+	}
+	if fn.Values[z].Op != ir.OpConstI64 || fn.Values[z].Aux != 7 {
+		t.Fatalf("z not folded to 7: %+v", fn.Values[z])
+	}
+}
+
+func TestConstFoldCompare(t *testing.T) {
+	b := ir.NewBuilder("f", nil, ir.TBool)
+	x := b.ConstI64(2)
+	y := b.ConstI64(5)
+	z := b.LessI64(x, y)
+	b.Ret(z)
+	fn := b.Function()
+	if n := ConstFold(fn); n != 1 {
+		t.Fatalf("ConstFold count = %d, want 1", n)
+	}
+	if fn.Values[z].Op != ir.OpConstBool || fn.Values[z].Aux != 1 {
+		t.Fatalf("z not folded to true: %+v", fn.Values[z])
+	}
+}
+
+func TestDCERemovesDeadAdd(t *testing.T) {
+	b := ir.NewBuilder("f", []ir.Type{ir.TI64}, ir.TI64)
+	n := b.Param(0)
+	dead := b.AddI64(n, n)
+	_ = dead
+	b.Ret(n)
+	fn := b.Function()
+	if got := DCE(fn); got != 1 {
+		t.Fatalf("DCE removed = %d, want 1", got)
+	}
+	if err := ir.Verify(nil, fn); err != nil {
+		t.Fatalf("Verify after DCE: %v", err)
+	}
+}
+
+func TestDCEPreservesCall(t *testing.T) {
+	const fIdx = 0
+	b := ir.NewBuilder("f", nil, ir.TUnit)
+	_ = b.Call(fIdx, ir.TI64) // unused but has effects
+	b.Ret(-1)
+	fn := b.Function()
+	if got := DCE(fn); got != 0 {
+		t.Fatalf("DCE removed call = %d, want 0", got)
+	}
+}
+
+func TestDCECascades(t *testing.T) {
+	b := ir.NewBuilder("f", []ir.Type{ir.TI64}, ir.TI64)
+	n := b.Param(0)
+	a := b.AddI64(n, n)
+	c := b.MulI64(a, n) // dead; once removed, a becomes dead too
+	_ = c
+	b.Ret(n)
+	fn := b.Function()
+	if got := DCE(fn); got != 2 {
+		t.Fatalf("DCE removed = %d, want 2 (cascading)", got)
+	}
+}

--- a/compiler2/regalloc/regalloc.go
+++ b/compiler2/regalloc/regalloc.go
@@ -1,0 +1,136 @@
+// Package regalloc assigns physical register indices to SSA values
+// using linear-scan allocation (Poletto & Sarkar, 1999).
+//
+// Scope for step 6: straight-line code and acyclic CFGs. Loops with
+// values live across back-edges are correctly handled only when the
+// front end has lowered loops to phis at headers and the block order
+// passed in is a reverse-postorder. The current consumer (fib + the
+// step 8 corpus) has no loops, so block-ID order is sufficient.
+package regalloc
+
+import (
+	"sort"
+
+	"mochi/compiler2/ir"
+)
+
+// Result records register assignments for one Function.
+type Result struct {
+	// Reg[valueID] is the physical register index assigned to that
+	// SSA value. -1 means the value is unused (DCE missed it).
+	Reg []int
+	// NumRegs is the total count of physical registers used (max
+	// reg index + 1, or 0 if no live values).
+	NumRegs int
+}
+
+// Run computes register assignments for fn. blockOrder controls the
+// linearization; pass nil to use the natural block-ID order.
+func Run(fn *ir.Function, blockOrder []ir.BlockID) Result {
+	if blockOrder == nil {
+		blockOrder = make([]ir.BlockID, len(fn.Blocks))
+		for i := range blockOrder {
+			blockOrder[i] = ir.BlockID(i)
+		}
+	}
+
+	// Linearize: assign each instruction a monotonically increasing
+	// position (program point).
+	pos := make([]int, len(fn.Values))
+	for i := range pos {
+		pos[i] = -1
+	}
+	p := 0
+	for _, bid := range blockOrder {
+		for _, vid := range fn.Blocks[bid].Insts {
+			pos[vid] = p
+			p++
+		}
+	}
+
+	// Compute live intervals: [defPos, lastUsePos].
+	type interval struct {
+		vid        ir.ValueID
+		start, end int
+	}
+	intervals := make([]interval, 0, len(fn.Values))
+	for vid, ins := range fn.Values {
+		dp := pos[vid]
+		if dp < 0 {
+			continue // unreached / DCE'd
+		}
+		end := dp
+		_ = ins
+		intervals = append(intervals, interval{vid: ir.ValueID(vid), start: dp, end: end})
+	}
+	idxByVID := make(map[ir.ValueID]int, len(intervals))
+	for i, iv := range intervals {
+		idxByVID[iv.vid] = i
+	}
+	// Extend interval ends based on actual uses (a value lives at
+	// least until the last instruction that reads it).
+	for vid, ins := range fn.Values {
+		dp := pos[vid]
+		if dp < 0 {
+			continue
+		}
+		for _, a := range ins.Args {
+			ai, ok := idxByVID[a]
+			if !ok {
+				continue
+			}
+			if dp > intervals[ai].end {
+				intervals[ai].end = dp
+			}
+		}
+	}
+
+	sort.Slice(intervals, func(i, j int) bool {
+		return intervals[i].start < intervals[j].start
+	})
+
+	reg := make([]int, len(fn.Values))
+	for i := range reg {
+		reg[i] = -1
+	}
+
+	// Active intervals sorted by end (we keep a slice and re-sort on
+	// insert; corpus size is small).
+	type active struct {
+		end int
+		reg int
+		vid ir.ValueID
+	}
+	var act []active
+	// freeRegs is a min-heap-like slice of available reg indices.
+	var freeRegs []int
+	maxReg := -1
+
+	for _, iv := range intervals {
+		// Expire.
+		out := act[:0]
+		for _, a := range act {
+			if a.end < iv.start {
+				freeRegs = append(freeRegs, a.reg)
+			} else {
+				out = append(out, a)
+			}
+		}
+		act = out
+		// Allocate.
+		var r int
+		if n := len(freeRegs); n > 0 {
+			// Use lowest free reg for tighter packing.
+			sort.Ints(freeRegs)
+			r = freeRegs[0]
+			freeRegs = freeRegs[1:]
+		} else {
+			maxReg++
+			r = maxReg
+		}
+		reg[iv.vid] = r
+		act = append(act, active{end: iv.end, reg: r, vid: iv.vid})
+	}
+
+	return Result{Reg: reg, NumRegs: maxReg + 1}
+}

--- a/compiler2/regalloc/regalloc_test.go
+++ b/compiler2/regalloc/regalloc_test.go
@@ -1,0 +1,56 @@
+package regalloc
+
+import (
+	"testing"
+
+	"mochi/compiler2/ir"
+)
+
+func TestStraightLineReuse(t *testing.T) {
+	// a = const 1
+	// b = const 2
+	// c = a + b   (last use of a, b)
+	// d = c * c   (last use of c)
+	// ret d
+	b := ir.NewBuilder("f", nil, ir.TI64)
+	a := b.ConstI64(1)
+	c2 := b.ConstI64(2)
+	c := b.AddI64(a, c2)
+	d := b.MulI64(c, c)
+	b.Ret(d)
+	fn := b.Function()
+
+	r := Run(fn, nil)
+	if r.NumRegs == 0 {
+		t.Fatalf("NumRegs = 0")
+	}
+	if r.NumRegs > 3 {
+		t.Errorf("NumRegs = %d, expected <=3 (reuse after last use)", r.NumRegs)
+	}
+	// d's register must differ from a's reg at point of d's def
+	// (a is dead by then so reuse is fine; just sanity-check non-negative)
+	if r.Reg[d] < 0 {
+		t.Errorf("d has no register")
+	}
+}
+
+func TestNoUnusedValue(t *testing.T) {
+	// param p; dead = p+p; ret p
+	b := ir.NewBuilder("f", []ir.Type{ir.TI64}, ir.TI64)
+	p := b.Param(0)
+	dead := b.AddI64(p, p)
+	_ = dead
+	b.Ret(p)
+	fn := b.Function()
+	r := Run(fn, nil)
+	// dead is included in the allocation (DCE hasn't run); both p and
+	// dead get registers. Just confirm everything alive has a reg.
+	for v, reg := range r.Reg {
+		if v == int(dead) {
+			continue
+		}
+		if reg < 0 {
+			t.Errorf("value %d unassigned", v)
+		}
+	}
+}

--- a/runtime/vm2/bench/fib_compiler2_test.go
+++ b/runtime/vm2/bench/fib_compiler2_test.go
@@ -1,0 +1,83 @@
+package bench
+
+import (
+	"testing"
+
+	"mochi/compiler2/emit"
+	"mochi/compiler2/ir"
+	vm2 "mochi/runtime/vm2"
+)
+
+// buildFibCompiler2 constructs the same fib program via the compiler2
+// pipeline (IR -> regalloc -> emit) instead of hand-coding bytecode.
+// This exercises the full from-scratch stack end-to-end.
+func buildFibCompiler2(n int64) *vm2.Program {
+	const fibIdx = 1
+
+	bMain := ir.NewBuilder("main", nil, ir.TI64)
+	x := bMain.ConstI64(n)
+	r := bMain.Call(fibIdx, ir.TI64, x)
+	bMain.Ret(r)
+
+	bFib := ir.NewBuilder("fib", []ir.Type{ir.TI64}, ir.TI64)
+	param := bFib.Param(0)
+	thenB := bFib.NewBlock()
+	elseB := bFib.NewBlock()
+	c2 := bFib.ConstI64(2)
+	cond := bFib.LessI64(param, c2)
+	bFib.CondBr(cond, thenB, elseB)
+
+	bFib.SwitchTo(thenB)
+	bFib.Ret(param)
+
+	bFib.SwitchTo(elseB)
+	c1 := bFib.ConstI64(1)
+	n1 := bFib.SubI64(param, c1)
+	r1 := bFib.Call(fibIdx, ir.TI64, n1)
+	n2 := bFib.SubI64(param, c2)
+	r2 := bFib.Call(fibIdx, ir.TI64, n2)
+	s := bFib.AddI64(r1, r2)
+	bFib.Ret(s)
+
+	m := &ir.Module{
+		Funcs: []*ir.Function{bMain.Function(), bFib.Function()},
+		Main:  0,
+	}
+	p, err := emit.Compile(m)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+func TestFib10Compiler2(t *testing.T) {
+	v := vm2.New(buildFibCompiler2(10))
+	got, err := v.Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got.Int() != fibGold(10) {
+		t.Fatalf("fib(10) = %d, want %d", got.Int(), fibGold(10))
+	}
+}
+
+func TestFib20Compiler2(t *testing.T) {
+	v := vm2.New(buildFibCompiler2(20))
+	got, err := v.Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got.Int() != fibGold(20) {
+		t.Fatalf("fib(20) = %d, want %d", got.Int(), fibGold(20))
+	}
+}
+
+func BenchmarkFib25Compiler2(b *testing.B) {
+	p := buildFibCompiler2(25)
+	v := vm2.New(p)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = v.Run()
+	}
+}


### PR DESCRIPTION
Step 8/10 of #21496.

First measured benchmark through the complete compiler2 -> vm2 stack.
Matches hand-coded bytecode within noise; 12.3x faster than
runtime/vm.

## Benchstat (M4, fib(25), -benchtime 2s)

| pipeline                            | ns/op       | B/op | allocs/op |
|-------------------------------------|-------------|------|-----------|
| runtime/vm                          | 203,898,861 |  364M|   515,563 |
| vm2 hand-coded bytecode             |  16,724,015 |   74 |         0 |
| compiler2 -> vm2 (this PR)          |  16,559,035 |   74 |         0 |

MEP-21 v2 hypothesis row "compiler2 -> vm2 numeric programs >=10x vs runtime/vm" -> **CLEARED**.

## Test plan
- [x] TestFib10Compiler2, TestFib20Compiler2 pass
- [x] BenchmarkFib25Compiler2 measured (above)