### PR TITLE
vm2 step 9a: tail-call optimization (enables constant-stack recursion)

### DIFF
--- a/compiler2/emit/emit.go
+++ b/compiler2/emit/emit.go
@@ -51,8 +51,11 @@ func compileFunction(f *ir.Function, ra regalloc.Result) (*vm2.Function, error) 
 	// staging block above the assigned range.
 	maxArgs := 0
 	for _, ins := range f.Values {
-		if ins.Op == ir.OpCall && len(ins.Args) > maxArgs {
-			maxArgs = len(ins.Args)
+		switch ins.Op {
+		case ir.OpCall, ir.OpTailCall:
+			if len(ins.Args) > maxArgs {
+				maxArgs = len(ins.Args)
+			}
 		}
 	}
 	callBase := np + ra.NumRegs
@@ -135,6 +138,15 @@ func compileFunction(f *ir.Function, ra regalloc.Result) (*vm2.Function, error) 
 				emit(vm2.Instr{Op: vm2.OpCall, A: dst,
 					B: int32(ins.Aux),
 					C: int32(callBase), D: int32(len(ins.Args))})
+			case ir.OpTailCall:
+				for i, a := range ins.Args {
+					emit(vm2.Instr{Op: vm2.OpMove,
+						A: int32(callBase + i),
+						B: int32(finalReg[a])})
+				}
+				emit(vm2.Instr{Op: vm2.OpTailCall,
+					A: int32(ins.Aux),
+					B: int32(callBase), C: int32(len(ins.Args))})
 			case ir.OpRet:
 				if len(ins.Args) > 0 {
 					emit(vm2.Instr{Op: vm2.OpReturn, A: int32(finalReg[ins.Args[0]])})

--- a/compiler2/ir/ir.go
+++ b/compiler2/ir/ir.go
@@ -64,9 +64,10 @@ const (
 	OpCall
 
 	// Terminators: must appear once and only at end of block.
-	OpRet    // Args[0] = value (or none for TUnit)
-	OpBr     // AuxBlocks[0] = target
-	OpCondBr // Args[0] = cond, AuxBlocks[0] = then, AuxBlocks[1] = else
+	OpRet      // Args[0] = value (or none for TUnit)
+	OpBr       // AuxBlocks[0] = target
+	OpCondBr   // Args[0] = cond, AuxBlocks[0] = then, AuxBlocks[1] = else
+	OpTailCall // tail call. Aux = function index, Args = arg values; transfers control without growing the frame stack.
 
 	// Phi: must appear at head of block. Args[i] pairs with AuxBlocks[i].
 	OpPhi
@@ -84,7 +85,7 @@ type Inst struct {
 // IsTerminator reports whether the op ends a block.
 func (op Op) IsTerminator() bool {
 	switch op {
-	case OpRet, OpBr, OpCondBr:
+	case OpRet, OpBr, OpCondBr, OpTailCall:
 		return true
 	}
 	return false

--- a/compiler2/opt/tail.go
+++ b/compiler2/opt/tail.go
@@ -1,0 +1,40 @@
+package opt
+
+import "mochi/compiler2/ir"
+
+// TailCall rewrites every block whose last two instructions are
+//
+//	r = Call fn(args)
+//	Ret r
+//
+// into a single OpTailCall, dropping the Ret. The call no longer
+// grows the frame stack at runtime: the vm2 OpTailCall handler reuses
+// or swaps the frame in place.
+//
+// Returns the number of call sites rewritten.
+func TailCall(f *ir.Function) int {
+	n := 0
+	for _, blk := range f.Blocks {
+		if len(blk.Insts) < 2 {
+			continue
+		}
+		retVID := blk.Insts[len(blk.Insts)-1]
+		callVID := blk.Insts[len(blk.Insts)-2]
+		ret := f.Values[retVID]
+		call := f.Values[callVID]
+		if ret.Op != ir.OpRet || call.Op != ir.OpCall {
+			continue
+		}
+		if len(ret.Args) != 1 || ret.Args[0] != callVID {
+			continue
+		}
+		// Rewrite: turn the call into a tail call (still a value
+		// node, but now a terminator). Drop the Ret.
+		f.Values[callVID].Op = ir.OpTailCall
+		// Invalidate the Ret slot.
+		f.Values[retVID] = ir.Inst{Op: ir.OpInvalid}
+		blk.Insts = blk.Insts[:len(blk.Insts)-1]
+		n++
+	}
+	return n
+}

--- a/compiler2/opt/tail_test.go
+++ b/compiler2/opt/tail_test.go
@@ -1,0 +1,105 @@
+package opt
+
+import (
+	"testing"
+
+	"mochi/compiler2/emit"
+	"mochi/compiler2/ir"
+	vm2 "mochi/runtime/vm2"
+)
+
+// buildSumTo builds:
+//
+//	sum(n, acc) = if n == 0 then acc else sum(n-1, acc+n)
+//	main()     = sum(N, 0)
+func buildSumTo(N int64) *ir.Module {
+	const sumIdx = 1
+
+	bMain := ir.NewBuilder("main", nil, ir.TI64)
+	n := bMain.ConstI64(N)
+	z := bMain.ConstI64(0)
+	r := bMain.Call(sumIdx, ir.TI64, n, z)
+	bMain.Ret(r)
+
+	bSum := ir.NewBuilder("sum", []ir.Type{ir.TI64, ir.TI64}, ir.TI64)
+	pN := bSum.Param(0)
+	pAcc := bSum.Param(1)
+	thenB := bSum.NewBlock()
+	elseB := bSum.NewBlock()
+
+	c0 := bSum.ConstI64(0)
+	cond := bSum.EqualI64(pN, c0)
+	bSum.CondBr(cond, thenB, elseB)
+
+	bSum.SwitchTo(thenB)
+	bSum.Ret(pAcc)
+
+	bSum.SwitchTo(elseB)
+	c1 := bSum.ConstI64(1)
+	nm1 := bSum.SubI64(pN, c1)
+	acc1 := bSum.AddI64(pAcc, pN)
+	r2 := bSum.Call(sumIdx, ir.TI64, nm1, acc1)
+	bSum.Ret(r2) // tail position
+
+	return &ir.Module{Funcs: []*ir.Function{bMain.Function(), bSum.Function()}, Main: 0}
+}
+
+func TestTailCallRewritesSumTo(t *testing.T) {
+	m := buildSumTo(10)
+	n := 0
+	for _, f := range m.Funcs {
+		n += TailCall(f)
+	}
+	// Two rewrites: main's call to sum, and sum.elseB's recursive call.
+	if n != 2 {
+		t.Fatalf("TailCall rewrote %d sites, want 2", n)
+	}
+	// The else block of sum should now end in OpTailCall.
+	sum := m.Funcs[1]
+	for _, blk := range sum.Blocks {
+		last := sum.Values[blk.Insts[len(blk.Insts)-1]]
+		if last.Op == ir.OpTailCall {
+			return
+		}
+	}
+	t.Fatal("no OpTailCall found after rewrite")
+}
+
+func TestTailCallSumToRunsCorrectly(t *testing.T) {
+	m := buildSumTo(100)
+	for _, f := range m.Funcs {
+		TailCall(f)
+	}
+	p, err := emit.Compile(m)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	got, err := vm2.New(p).Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	want := int64(100 * 101 / 2)
+	if got.Int() != want {
+		t.Fatalf("sum(100) = %d, want %d", got.Int(), want)
+	}
+}
+
+func TestTailCallEnablesDeepRecursion(t *testing.T) {
+	// 100_000 frames would blow without tail-call.
+	m := buildSumTo(100_000)
+	for _, f := range m.Funcs {
+		TailCall(f)
+	}
+	p, err := emit.Compile(m)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	got, err := vm2.New(p).Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	want := int64(100_000) * 100_001 / 2
+	if got.Int() != want {
+		t.Fatalf("sum(100000) = %d, want %d", got.Int(), want)
+	}
+}


### PR DESCRIPTION
Step 9 sub-task 1/3 of #21496 (tail / bce / inline).

opt.TailCall pass + IR OpTailCall + emit lowering. vm2 handler was
already in place from step 3. Also fixes a latent emit bug where
maxArgs missed OpTailCall.

## Test plan
- [x] TestTailCallRewritesSumTo: 2 sites rewritten (main + recursive call)
- [x] TestTailCallSumToRunsCorrectly: sum(100) = 5050
- [x] TestTailCallEnablesDeepRecursion: sum(100_000) returns correct answer without blowing the frame stack