### PR TITLE
vm2 corpus port: int64-feasible benchmarks + cross-language harness wiring

### DIFF
--- a/bench/runner.go
+++ b/bench/runner.go
@@ -69,6 +69,17 @@ const keepTempFiles = false
 func Benchmarks(tempDir, mochiBin string) []Bench {
 	var benches []Bench
 
+	// Pre-build the compiler2/vm2 subprocess runner once into tempDir.
+	// Each math benchmark below registers a `mochi_vm2` template that
+	// invokes this binary with -program/-n flags rather than rendering
+	// a Mochi source file. This gives the rusage measurement a clean
+	// peak RSS reading for the vm2 process alone (no toolchain noise).
+	vm2Bin := filepath.Join(tempDir, "vm2runner")
+	if err := exec.Command("go", "build", "-o", vm2Bin, "./bench/vm2runner").Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "vm2runner build failed: %v\n", err)
+		vm2Bin = ""
+	}
+
 	_ = fs.WalkDir(templatesFS, "template", func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
 			return nil
@@ -95,6 +106,9 @@ func Benchmarks(tempDir, mochiBin string) []Bench {
 		templates := []Template{
 			{Lang: "mochi_vm", Path: path, Suffix: suffix, Command: []string{"go", "run"}},
 			{Lang: "mochi_go", Path: path, Suffix: suffix, Command: []string{"go", "run"}},
+		}
+		if vm2Bin != "" {
+			templates = append(templates, Template{Lang: "mochi_vm2", Path: path, Suffix: ".vm2", Command: []string{vm2Bin}})
 		}
 		if os.Getenv("MOCHI_SKIP_C") != "1" && name != "matrix_mul" {
 			templates = append(templates, Template{Lang: "mochi_c", Path: path, Suffix: suffix, Command: nil})
@@ -141,6 +155,22 @@ func generateBenchmarks(tempDir, category, name string, cfg Range, templates []T
 		}
 
 		for _, t := range templates {
+			// mochi_vm2 does not render a Mochi source file: it
+			// invokes the pre-built vm2runner with -program/-n flags
+			// pointing at compiler2/corpus, which holds the same
+			// program shapes as the .mochi templates.
+			if t.Lang == "mochi_vm2" {
+				progName := fmt.Sprintf("%s_%s", category, name)
+				benches = append(benches, Bench{
+					Name: fmt.Sprintf("%s.%s.%d.%s", category, name, n, t.Lang),
+					Command: append(append([]string(nil), t.Command...),
+						"-program", progName,
+						"-n", fmt.Sprintf("%d", n),
+					),
+				})
+				continue
+			}
+
 			actualSuffix := t.Suffix
 
 			fileName := fmt.Sprintf("%s_%s_%d%s", category, name, n, actualSuffix)
@@ -386,6 +416,8 @@ func report(results []Result) {
 			switch langName {
 			case "mochi_vm":
 				langName = "Mochi (VM)"
+			case "mochi_vm2":
+				langName = "Mochi (vm2)"
 			case "mochi_go":
 				langName = "Mochi (Go)"
 			case "mochi_c":
@@ -692,6 +724,8 @@ func exportMarkdown(results []Result) error {
 			switch langName {
 			case "mochi_vm":
 				langName = "Mochi (VM)"
+			case "mochi_vm2":
+				langName = "Mochi (vm2)"
 			case "mochi_go":
 				langName = "Mochi (Go)"
 			case "mochi_c":

--- a/bench/vm2runner/main.go
+++ b/bench/vm2runner/main.go
@@ -1,0 +1,100 @@
+// vm2runner is the bench/runner.go subprocess entry for the compiler2
+// + runtime/vm2 stack. It mirrors what every other language baseline
+// does: take a parameterized program identifier + N, run it the
+// canonical "repeat" count, and print {"duration_us": X, "output": Y}.
+//
+// The runner reuses the IR builders in compiler2/corpus so the program
+// shape is byte-identical to what runtime/vm2/bench/corpus_test.go
+// runs. That means a regression in either harness shows up in both.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"mochi/compiler2/corpus"
+	"mochi/compiler2/emit"
+	"mochi/compiler2/opt"
+	vm2 "mochi/runtime/vm2"
+)
+
+// repeats records the per-template repeat count baked into each
+// .mochi benchmark template. Keep these in sync with bench/template/.
+var repeats = map[string]int{
+	"math_fact_rec":    1000,
+	"math_fib_iter":    1000,
+	"math_fib_rec":     1,
+	"math_mul_loop":    1000,
+	"math_prime_count": 100,
+	"math_sum_loop":    1000,
+	// MEP-17 in-process corpus runs once per invocation; the harness
+	// loops externally via b.N.
+	"fib":      1,
+	"iter_sum": 1,
+}
+
+func main() {
+	prog := flag.String("program", "", "corpus program name (e.g. math_fact_rec)")
+	n := flag.Int64("n", 0, "size parameter")
+	flag.Parse()
+
+	if *prog == "" {
+		die("vm2runner: -program is required")
+	}
+	repeat, ok := repeats[*prog]
+	if !ok {
+		die("vm2runner: unknown program %q", *prog)
+	}
+
+	var builder func(int64) *corpus.Program
+	for _, p := range corpus.All() {
+		if p.Name == *prog {
+			pp := p
+			builder = func(int64) *corpus.Program { return &pp }
+			break
+		}
+	}
+	if builder == nil {
+		die("vm2runner: program %q not in corpus.All()", *prog)
+	}
+	p := builder(*n)
+
+	// Compile once outside the timed region: this matches every other
+	// language harness, which times only the inner repeat loop.
+	m := p.Build(*n)
+	for _, f := range m.Funcs {
+		opt.ConstFold(f)
+		opt.DCE(f)
+		opt.TailCall(f)
+	}
+	program, err := emit.Compile(m)
+	if err != nil {
+		die("vm2runner: emit %s: %v", *prog, err)
+	}
+
+	var last int64
+	start := time.Now()
+	for i := 0; i < repeat; i++ {
+		got, err := vm2.New(program).Run()
+		if err != nil {
+			die("vm2runner: run %s: %v", *prog, err)
+		}
+		last = got.Int()
+	}
+	durUs := float64(time.Since(start).Microseconds())
+
+	if err := json.NewEncoder(os.Stdout).Encode(map[string]any{
+		"duration_us": durUs,
+		"output":      last,
+	}); err != nil {
+		die("vm2runner: encode: %v", err)
+	}
+}
+
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/compiler2/corpus/corpus.go
+++ b/compiler2/corpus/corpus.go
@@ -1,0 +1,398 @@
+// Package corpus exposes the MEP-17 / MEP-23 benchmark suite expressed
+// directly in compiler2 IR. Each builder returns an ir.Module whose
+// Main entry computes the same i64 result the original .mochi program
+// would print, parametrized by N where applicable.
+//
+// Loops are expressed as tail-recursive helpers (no SSA phi) so the
+// modules round-trip through emit without needing phi lowering. The
+// opt.TailCall pass is expected to rewrite the recursive call sites
+// before emission so deep iterations do not grow the frame stack.
+//
+// Coverage is the int64-feasible subset of the corpus. Programs that
+// depend on strings, lists, maps, structs, closures, or query
+// iteration are deferred until those subsystems land in vm2.
+package corpus
+
+import "mochi/compiler2/ir"
+
+// Program is one corpus entry: a builder that produces an ir.Module
+// for a given N, plus an oracle that computes the same result in
+// plain Go so tests can assert equivalence without a second VM.
+type Program struct {
+	Name   string
+	Build  func(n int64) *ir.Module
+	Expect func(n int64) int64
+}
+
+// All returns the corpus in a stable order.
+func All() []Program {
+	return []Program{
+		{Name: "fib", Build: BuildFibRec, Expect: ExpectFibRec},
+		{Name: "iter_sum", Build: BuildIterSum, Expect: ExpectIterSum},
+		{Name: "math_sum_loop", Build: BuildSumLoop, Expect: ExpectSumLoop},
+		{Name: "math_mul_loop", Build: BuildMulLoop, Expect: ExpectMulLoop},
+		{Name: "math_fact_rec", Build: BuildFactRec, Expect: ExpectFactRec},
+		{Name: "math_fib_iter", Build: BuildFibIter, Expect: ExpectFibIter},
+		{Name: "math_fib_rec", Build: BuildFibRec, Expect: ExpectFibRec},
+		{Name: "math_prime_count", Build: BuildPrimeCount, Expect: ExpectPrimeCount},
+	}
+}
+
+// ---------- fib_rec (also runtime/vm/bench fib) ----------
+
+// BuildFibRec builds the naive doubly-recursive fibonacci:
+//
+//	fib(n) = if n <= 1 then n else fib(n-1) + fib(n-2)
+//	main() = fib(N)
+func BuildFibRec(n int64) *ir.Module {
+	const fibIdx = 1
+
+	bMain := ir.NewBuilder("main", nil, ir.TI64)
+	nv := bMain.ConstI64(n)
+	r := bMain.Call(fibIdx, ir.TI64, nv)
+	bMain.Ret(r)
+
+	bFib := ir.NewBuilder("fib", []ir.Type{ir.TI64}, ir.TI64)
+	pN := bFib.Param(0)
+	thenB := bFib.NewBlock()
+	elseB := bFib.NewBlock()
+	one := bFib.ConstI64(1)
+	cond := bFib.LessEqI64(pN, one)
+	bFib.CondBr(cond, thenB, elseB)
+
+	bFib.SwitchTo(thenB)
+	bFib.Ret(pN)
+
+	bFib.SwitchTo(elseB)
+	nm1 := bFib.SubI64(pN, one)
+	two := bFib.ConstI64(2)
+	nm2 := bFib.SubI64(pN, two)
+	a := bFib.Call(fibIdx, ir.TI64, nm1)
+	b := bFib.Call(fibIdx, ir.TI64, nm2)
+	s := bFib.AddI64(a, b)
+	bFib.Ret(s)
+
+	return &ir.Module{Funcs: []*ir.Function{bMain.Function(), bFib.Function()}, Main: 0}
+}
+
+// ExpectFibRec computes fib(n) by the same recurrence.
+func ExpectFibRec(n int64) int64 {
+	a, b := int64(0), int64(1)
+	for i := int64(0); i < n; i++ {
+		a, b = b, a+b
+	}
+	return a
+}
+
+// ---------- iter_sum ----------
+
+// BuildIterSum builds `for i in 1..N { total += i }` returning total.
+// Loop encoded as tail-recursive helper(i, total, n).
+func BuildIterSum(n int64) *ir.Module {
+	const helperIdx = 1
+
+	bMain := ir.NewBuilder("main", nil, ir.TI64)
+	one := bMain.ConstI64(1)
+	zero := bMain.ConstI64(0)
+	nv := bMain.ConstI64(n)
+	r := bMain.Call(helperIdx, ir.TI64, one, zero, nv)
+	bMain.Ret(r)
+
+	bH := ir.NewBuilder("iter_sum_loop", []ir.Type{ir.TI64, ir.TI64, ir.TI64}, ir.TI64)
+	pI, pT, pN := bH.Param(0), bH.Param(1), bH.Param(2)
+	done := bH.NewBlock()
+	step := bH.NewBlock()
+	cond := bH.LessI64(pI, pN)
+	bH.CondBr(cond, step, done)
+
+	bH.SwitchTo(done)
+	bH.Ret(pT)
+
+	bH.SwitchTo(step)
+	c1 := bH.ConstI64(1)
+	ni := bH.AddI64(pI, c1)
+	nt := bH.AddI64(pT, pI)
+	r2 := bH.Call(helperIdx, ir.TI64, ni, nt, pN)
+	bH.Ret(r2)
+
+	return &ir.Module{Funcs: []*ir.Function{bMain.Function(), bH.Function()}, Main: 0}
+}
+
+// ExpectIterSum: sum of [1, n).
+func ExpectIterSum(n int64) int64 { return (n - 1) * n / 2 }
+
+// ---------- math/sum_loop ----------
+
+// BuildSumLoop = iter_sum but the original benchmark wraps the loop in
+// a function called `sum_loop` and invokes it from main. Shape matches
+// the .mochi template: sum_loop(N).
+func BuildSumLoop(n int64) *ir.Module { return BuildIterSum(n) }
+
+// ExpectSumLoop matches ExpectIterSum.
+func ExpectSumLoop(n int64) int64 { return ExpectIterSum(n) }
+
+// ---------- math/mul_loop ----------
+
+// BuildMulLoop builds `for i in 1..N { result *= i }` returning result
+// (initial 1). Equivalent to (N-1)!.
+func BuildMulLoop(n int64) *ir.Module {
+	const helperIdx = 1
+
+	bMain := ir.NewBuilder("main", nil, ir.TI64)
+	one := bMain.ConstI64(1)
+	one2 := bMain.ConstI64(1)
+	nv := bMain.ConstI64(n)
+	r := bMain.Call(helperIdx, ir.TI64, one, one2, nv)
+	bMain.Ret(r)
+
+	bH := ir.NewBuilder("mul_loop", []ir.Type{ir.TI64, ir.TI64, ir.TI64}, ir.TI64)
+	pI, pR, pN := bH.Param(0), bH.Param(1), bH.Param(2)
+	done := bH.NewBlock()
+	step := bH.NewBlock()
+	cond := bH.LessI64(pI, pN)
+	bH.CondBr(cond, step, done)
+
+	bH.SwitchTo(done)
+	bH.Ret(pR)
+
+	bH.SwitchTo(step)
+	c1 := bH.ConstI64(1)
+	ni := bH.AddI64(pI, c1)
+	nr := bH.MulI64(pR, pI)
+	r2 := bH.Call(helperIdx, ir.TI64, ni, nr, pN)
+	bH.Ret(r2)
+
+	return &ir.Module{Funcs: []*ir.Function{bMain.Function(), bH.Function()}, Main: 0}
+}
+
+// ExpectMulLoop = product of [1, n) = (n-1)!.
+func ExpectMulLoop(n int64) int64 {
+	r := int64(1)
+	for i := int64(1); i < n; i++ {
+		r *= i
+	}
+	return r
+}
+
+// ---------- math/fact_rec ----------
+
+// BuildFactRec is the textbook recursive factorial, NOT tail-recursive,
+// to match the original benchmark's frame-growth profile.
+//
+//	fact(n) = if n == 0 then 1 else n * fact(n-1)
+func BuildFactRec(n int64) *ir.Module {
+	const factIdx = 1
+
+	bMain := ir.NewBuilder("main", nil, ir.TI64)
+	nv := bMain.ConstI64(n)
+	r := bMain.Call(factIdx, ir.TI64, nv)
+	bMain.Ret(r)
+
+	bF := ir.NewBuilder("fact_rec", []ir.Type{ir.TI64}, ir.TI64)
+	pN := bF.Param(0)
+	zero := bF.ConstI64(0)
+	cond := bF.EqualI64(pN, zero)
+	thenB := bF.NewBlock()
+	elseB := bF.NewBlock()
+	bF.CondBr(cond, thenB, elseB)
+
+	bF.SwitchTo(thenB)
+	one := bF.ConstI64(1)
+	bF.Ret(one)
+
+	bF.SwitchTo(elseB)
+	one2 := bF.ConstI64(1)
+	nm1 := bF.SubI64(pN, one2)
+	sub := bF.Call(factIdx, ir.TI64, nm1)
+	r2 := bF.MulI64(pN, sub)
+	bF.Ret(r2)
+
+	return &ir.Module{Funcs: []*ir.Function{bMain.Function(), bF.Function()}, Main: 0}
+}
+
+// ExpectFactRec computes n!.
+func ExpectFactRec(n int64) int64 {
+	r := int64(1)
+	for i := int64(2); i <= n; i++ {
+		r *= i
+	}
+	return r
+}
+
+// ---------- math/fib_iter ----------
+
+// BuildFibIter is the iterative fibonacci `(a, b) -> (b, a+b)` repeated
+// N times, returning a. Loop encoded as tail-recursive helper.
+//
+//	helper(i, a, b, n) = if i >= n then a else helper(i+1, b, a+b, n)
+func BuildFibIter(n int64) *ir.Module {
+	const helperIdx = 1
+
+	bMain := ir.NewBuilder("main", nil, ir.TI64)
+	zero := bMain.ConstI64(0)
+	a0 := bMain.ConstI64(0)
+	b0 := bMain.ConstI64(1)
+	nv := bMain.ConstI64(n)
+	r := bMain.Call(helperIdx, ir.TI64, zero, a0, b0, nv)
+	bMain.Ret(r)
+
+	bH := ir.NewBuilder("fib_iter_loop", []ir.Type{ir.TI64, ir.TI64, ir.TI64, ir.TI64}, ir.TI64)
+	pI, pA, pB, pN := bH.Param(0), bH.Param(1), bH.Param(2), bH.Param(3)
+	done := bH.NewBlock()
+	step := bH.NewBlock()
+	cond := bH.LessI64(pI, pN)
+	bH.CondBr(cond, step, done)
+
+	bH.SwitchTo(done)
+	bH.Ret(pA)
+
+	bH.SwitchTo(step)
+	one := bH.ConstI64(1)
+	ni := bH.AddI64(pI, one)
+	nab := bH.AddI64(pA, pB)
+	r2 := bH.Call(helperIdx, ir.TI64, ni, pB, nab, pN)
+	bH.Ret(r2)
+
+	return &ir.Module{Funcs: []*ir.Function{bMain.Function(), bH.Function()}, Main: 0}
+}
+
+// ExpectFibIter matches BuildFibRec's value semantics.
+func ExpectFibIter(n int64) int64 { return ExpectFibRec(n) }
+
+// ---------- math/prime_count ----------
+
+// BuildPrimeCount counts primes in [2, N). Encoded as four functions:
+//
+//	is_prime(n)            = if n < 2 then false else is_prime_loop(n, 2)
+//	is_prime_loop(n, i)    = if i >= n-1 then true
+//	                         else if n%i == 0 then false
+//	                         else is_prime_loop(n, i+1)
+//	count_loop(n, i, acc)  = if i >= n then acc
+//	                         else if is_prime(i)
+//	                              then count_loop(n, i+1, acc+1)
+//	                              else count_loop(n, i+1, acc)
+//	main()                 = count_loop(N, 2, 0)
+func BuildPrimeCount(n int64) *ir.Module {
+	const (
+		mainIdx        = 0
+		isPrimeIdx     = 1
+		isPrimeLoopIdx = 2
+		countLoopIdx   = 3
+	)
+	_ = mainIdx
+
+	// main
+	bMain := ir.NewBuilder("main", nil, ir.TI64)
+	nv := bMain.ConstI64(n)
+	i0 := bMain.ConstI64(2)
+	acc0 := bMain.ConstI64(0)
+	r := bMain.Call(countLoopIdx, ir.TI64, nv, i0, acc0)
+	bMain.Ret(r)
+
+	// is_prime(n): returns 1 if prime, 0 otherwise (as i64 for shape simplicity).
+	bIP := ir.NewBuilder("is_prime", []ir.Type{ir.TI64}, ir.TI64)
+	pN := bIP.Param(0)
+	two := bIP.ConstI64(2)
+	cond := bIP.LessI64(pN, two)
+	tooSmall := bIP.NewBlock()
+	bigEnough := bIP.NewBlock()
+	bIP.CondBr(cond, tooSmall, bigEnough)
+
+	bIP.SwitchTo(tooSmall)
+	zero := bIP.ConstI64(0)
+	bIP.Ret(zero)
+
+	bIP.SwitchTo(bigEnough)
+	twoStart := bIP.ConstI64(2)
+	r2 := bIP.Call(isPrimeLoopIdx, ir.TI64, pN, twoStart)
+	bIP.Ret(r2)
+
+	// is_prime_loop(n, i)
+	bL := ir.NewBuilder("is_prime_loop", []ir.Type{ir.TI64, ir.TI64}, ir.TI64)
+	lN, lI := bL.Param(0), bL.Param(1)
+	one := bL.ConstI64(1)
+	limit := bL.SubI64(lN, one)
+	cExit := bL.LessI64(lI, limit) // true while i < n-1
+	doneB := bL.NewBlock()
+	moreB := bL.NewBlock()
+	bL.CondBr(cExit, moreB, doneB)
+
+	bL.SwitchTo(doneB)
+	primeYes := bL.ConstI64(1)
+	bL.Ret(primeYes)
+
+	bL.SwitchTo(moreB)
+	rem := bL.ModI64(lN, lI)
+	zeroL := bL.ConstI64(0)
+	divides := bL.EqualI64(rem, zeroL)
+	notPrime := bL.NewBlock()
+	keepGoing := bL.NewBlock()
+	bL.CondBr(divides, notPrime, keepGoing)
+
+	bL.SwitchTo(notPrime)
+	zeroR := bL.ConstI64(0)
+	bL.Ret(zeroR)
+
+	bL.SwitchTo(keepGoing)
+	oneInc := bL.ConstI64(1)
+	ni := bL.AddI64(lI, oneInc)
+	r3 := bL.Call(isPrimeLoopIdx, ir.TI64, lN, ni)
+	bL.Ret(r3)
+
+	// count_loop(n, i, acc)
+	bC := ir.NewBuilder("count_loop", []ir.Type{ir.TI64, ir.TI64, ir.TI64}, ir.TI64)
+	cN, cI, cAcc := bC.Param(0), bC.Param(1), bC.Param(2)
+	cCond := bC.LessI64(cI, cN)
+	cDone := bC.NewBlock()
+	cStep := bC.NewBlock()
+	bC.CondBr(cCond, cStep, cDone)
+
+	bC.SwitchTo(cDone)
+	bC.Ret(cAcc)
+
+	bC.SwitchTo(cStep)
+	isP := bC.Call(isPrimeIdx, ir.TI64, cI)
+	oneIs := bC.ConstI64(1)
+	isPrime := bC.EqualI64(isP, oneIs)
+	primeBranch := bC.NewBlock()
+	nonPrimeBranch := bC.NewBlock()
+	bC.CondBr(isPrime, primeBranch, nonPrimeBranch)
+
+	bC.SwitchTo(primeBranch)
+	oneA := bC.ConstI64(1)
+	ni2 := bC.AddI64(cI, oneA)
+	nacc := bC.AddI64(cAcc, oneA)
+	r4 := bC.Call(countLoopIdx, ir.TI64, cN, ni2, nacc)
+	bC.Ret(r4)
+
+	bC.SwitchTo(nonPrimeBranch)
+	oneB := bC.ConstI64(1)
+	ni3 := bC.AddI64(cI, oneB)
+	r5 := bC.Call(countLoopIdx, ir.TI64, cN, ni3, cAcc)
+	bC.Ret(r5)
+
+	return &ir.Module{Funcs: []*ir.Function{
+		bMain.Function(),
+		bIP.Function(),
+		bL.Function(),
+		bC.Function(),
+	}, Main: 0}
+}
+
+// ExpectPrimeCount counts primes in [2, n).
+func ExpectPrimeCount(n int64) int64 {
+	count := int64(0)
+	for k := int64(2); k < n; k++ {
+		prime := true
+		for i := int64(2); i < k-1; i++ {
+			if k%i == 0 {
+				prime = false
+				break
+			}
+		}
+		if k >= 2 && prime {
+			count++
+		}
+	}
+	return count
+}

--- a/compiler2/emit/emit.go
+++ b/compiler2/emit/emit.go
@@ -117,6 +117,14 @@ func compileFunction(f *ir.Function, ra regalloc.Result) (*vm2.Function, error) 
 				emit(vm2.Instr{Op: vm2.OpMulI64, A: dst,
 					B: int32(finalReg[ins.Args[0]]),
 					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpDivI64:
+				emit(vm2.Instr{Op: vm2.OpDivI64, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpModI64:
+				emit(vm2.Instr{Op: vm2.OpModI64, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
 			case ir.OpLessI64:
 				emit(vm2.Instr{Op: vm2.OpLessI64, A: dst,
 					B: int32(finalReg[ins.Args[0]]),

--- a/compiler2/ir/builder.go
+++ b/compiler2/ir/builder.go
@@ -91,6 +91,14 @@ func (b *Builder) MulI64(x, y ValueID) ValueID {
 	return b.emit(Inst{Op: OpMulI64, Type: TI64, Args: []ValueID{x, y}})
 }
 
+func (b *Builder) DivI64(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpDivI64, Type: TI64, Args: []ValueID{x, y}})
+}
+
+func (b *Builder) ModI64(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpModI64, Type: TI64, Args: []ValueID{x, y}})
+}
+
 func (b *Builder) LessI64(x, y ValueID) ValueID {
 	return b.emit(Inst{Op: OpLessI64, Type: TBool, Args: []ValueID{x, y}})
 }

--- a/compiler2/ir/ir.go
+++ b/compiler2/ir/ir.go
@@ -55,6 +55,8 @@ const (
 	OpAddI64
 	OpSubI64
 	OpMulI64
+	OpDivI64
+	OpModI64
 	OpLessI64
 	OpLessEqI64
 	OpEqualI64

--- a/runtime/vm2/bench/corpus_test.go
+++ b/runtime/vm2/bench/corpus_test.go
@@ -1,0 +1,107 @@
+package bench
+
+import (
+	"runtime"
+	"testing"
+
+	"mochi/compiler2/corpus"
+	"mochi/compiler2/emit"
+	"mochi/compiler2/opt"
+	vm2 "mochi/runtime/vm2"
+)
+
+// corpusSize is the per-program N used by both correctness tests and
+// benchmarks. The values mirror the smallest size in bench/template
+// (math sizes 10/20/30) and the runtime/vm/bench defaults, picking a
+// size that exercises the program without making the suite slow.
+type corpusSize struct {
+	name string
+	n    int64
+}
+
+var corpusSizes = []corpusSize{
+	{"fib", 25},               // matches runtime/vm/bench fib.mochi (fib(25))
+	{"iter_sum", 10000},       // matches runtime/vm/bench iter_sum.mochi
+	{"math_sum_loop", 10001},  // 1..10000 = same as iter_sum oracle
+	{"math_mul_loop", 16},     // 15! = 1307674368000, fits in 48-bit Cell payload
+	{"math_fact_rec", 12},     // 12! = 479001600
+	{"math_fib_iter", 30},     // matches template size 30
+	{"math_fib_rec", 25},      // fib(25) = 75025
+	{"math_prime_count", 100}, // primes in [2, 100)
+}
+
+func sizeFor(name string) int64 {
+	for _, s := range corpusSizes {
+		if s.name == name {
+			return s.n
+		}
+	}
+	panic("vm2/bench: no size for " + name)
+}
+
+func compileCorpus(t testing.TB, p corpus.Program, n int64) *vm2.Program {
+	t.Helper()
+	m := p.Build(n)
+	for _, f := range m.Funcs {
+		opt.ConstFold(f)
+		opt.DCE(f)
+		opt.TailCall(f)
+	}
+	prog, err := emit.Compile(m)
+	if err != nil {
+		t.Fatalf("%s: compile: %v", p.Name, err)
+	}
+	return prog
+}
+
+// TestCorpusMatchesOracle runs every corpus program once on vm2 and
+// asserts the result matches the Go oracle in compiler2/corpus.
+func TestCorpusMatchesOracle(t *testing.T) {
+	for _, p := range corpus.All() {
+		p := p
+		t.Run(p.Name, func(t *testing.T) {
+			n := sizeFor(p.Name)
+			prog := compileCorpus(t, p, n)
+			got, err := vm2.New(prog).Run()
+			if err != nil {
+				t.Fatalf("run: %v", err)
+			}
+			want := p.Expect(n)
+			if got.Int() != want {
+				t.Fatalf("%s(%d) = %d, want %d", p.Name, n, got.Int(), want)
+			}
+		})
+	}
+}
+
+func benchCorpus(b *testing.B, p corpus.Program) {
+	n := sizeFor(p.Name)
+	prog := compileCorpus(b, p, n)
+	b.ReportAllocs()
+
+	var startMem, endMem runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&startMem)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := vm2.New(prog).Run(); err != nil {
+			b.Fatalf("run: %v", err)
+		}
+	}
+	b.StopTimer()
+
+	runtime.ReadMemStats(&endMem)
+	b.ReportMetric(float64(endMem.HeapInuse)/1024/1024, "heap-MB")
+	b.ReportMetric(float64(endMem.Sys)/1024/1024, "sys-MB")
+	b.ReportMetric(float64(endMem.TotalAlloc-startMem.TotalAlloc)/float64(b.N), "total-B/op")
+}
+
+func BenchmarkVM2_Fib(b *testing.B)         { benchCorpus(b, corpus.Program{Name: "fib", Build: corpus.BuildFibRec, Expect: corpus.ExpectFibRec}) }
+func BenchmarkVM2_IterSum(b *testing.B)     { benchCorpus(b, corpus.Program{Name: "iter_sum", Build: corpus.BuildIterSum, Expect: corpus.ExpectIterSum}) }
+func BenchmarkVM2_SumLoop(b *testing.B)     { benchCorpus(b, corpus.Program{Name: "math_sum_loop", Build: corpus.BuildSumLoop, Expect: corpus.ExpectSumLoop}) }
+func BenchmarkVM2_MulLoop(b *testing.B)     { benchCorpus(b, corpus.Program{Name: "math_mul_loop", Build: corpus.BuildMulLoop, Expect: corpus.ExpectMulLoop}) }
+func BenchmarkVM2_FactRec(b *testing.B)     { benchCorpus(b, corpus.Program{Name: "math_fact_rec", Build: corpus.BuildFactRec, Expect: corpus.ExpectFactRec}) }
+func BenchmarkVM2_FibIter(b *testing.B)     { benchCorpus(b, corpus.Program{Name: "math_fib_iter", Build: corpus.BuildFibIter, Expect: corpus.ExpectFibIter}) }
+func BenchmarkVM2_FibRecTmpl(b *testing.B)  { benchCorpus(b, corpus.Program{Name: "math_fib_rec", Build: corpus.BuildFibRec, Expect: corpus.ExpectFibRec}) }
+func BenchmarkVM2_PrimeCount(b *testing.B)  { benchCorpus(b, corpus.Program{Name: "math_prime_count", Build: corpus.BuildPrimeCount, Expect: corpus.ExpectPrimeCount}) }

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -25,6 +25,18 @@ func (vm *VM) Run() (Cell, error) {
 			fr.Regs[ins.A] = CInt(fr.Regs[ins.B].Int() - fr.Regs[ins.C].Int())
 		case OpMulI64:
 			fr.Regs[ins.A] = CInt(fr.Regs[ins.B].Int() * fr.Regs[ins.C].Int())
+		case OpDivI64:
+			d := fr.Regs[ins.C].Int()
+			if d == 0 {
+				return ret, errors.New("vm2: division by zero")
+			}
+			fr.Regs[ins.A] = CInt(fr.Regs[ins.B].Int() / d)
+		case OpModI64:
+			d := fr.Regs[ins.C].Int()
+			if d == 0 {
+				return ret, errors.New("vm2: mod by zero")
+			}
+			fr.Regs[ins.A] = CInt(fr.Regs[ins.B].Int() % d)
 		case OpLessI64:
 			fr.Regs[ins.A] = CBool(fr.Regs[ins.B].Int() < fr.Regs[ins.C].Int())
 		case OpLessEqI64:

--- a/runtime/vm2/ops.go
+++ b/runtime/vm2/ops.go
@@ -12,6 +12,8 @@ const (
 	OpAddI64                // A = B + C (signed 48-bit; overflow is implementation-defined)
 	OpSubI64                // A = B - C
 	OpMulI64                // A = B * C
+	OpDivI64                // A = B / C (truncated; division by zero traps)
+	OpModI64                // A = B % C (truncated, sign of dividend; mod by zero traps)
 	OpLessI64               // A = B < C  (bool)
 	OpLessEqI64             // A = B <= C (bool)
 	OpEqualI64              // A = B == C (bool)


### PR DESCRIPTION
Closes #21507. Part of #21496.

Brings the int64-feasible subset of the MEP-17 / MEP-23 corpus onto compiler2 + vm2, and registers a `mochi_vm2` lang in `bench/runner.go` so the harness compares vm2 alongside Python, TypeScript, Go, and C.

## Programs ported (8)

`fib`, `iter_sum`, `math/sum_loop`, `math/mul_loop`, `math/fact_rec`, `math/fib_iter`, `math/fib_rec`, `math/prime_count`. Each is expressed in compiler2 IR as tail-recursive helpers (no SSA phi), then run through ConstFold + DCE + TailCall before emit.

## Programs deferred

`string_cat`, `map_get`, `list_build`, `struct_field`, `hof_map`, `closure_dispatch`, `query_select`, `json_emit`, `matrix_mul`, and the 8 `join/*` templates. All depend on string / list / map / struct / closure runtime that vm2 does not yet have.

## Changes

- `runtime/vm2`: add `OpDivI64` / `OpModI64` (mod required by prime_count; div ships alongside; div-by-zero traps)
- `compiler2/ir` + `compiler2/emit`: matching builders + lowering for div/mod
- `compiler2/corpus`: new package, one Build/Expect pair per program; oracles let tests assert equivalence without a second VM
- `runtime/vm2/bench/corpus_test.go`: `TestCorpusMatchesOracle` exercises every program; `BenchmarkVM2_*` reports per-program time + heap-MB / sys-MB / B/op
- `bench/vm2runner`: subprocess CLI; takes `-program / -n`, runs the canonical repeat count, prints `{duration_us, output}` JSON like every other language baseline
- `bench/runner.go`: registers `mochi_vm2` template lang and pre-builds the vm2runner binary once into tempDir for clean rusage readings

## Results on Apple M4

`go test -tags=slow -bench=. -benchmem ./runtime/vm2/bench/`

| Program           | vm2          | runtime/vm   | speedup |
|---|---:|---:|---:|
| fib(25)           | ~13.7 ms/op  | ~104 ms/op   | 7.6x    |
| iter_sum(10000)   | ~232 us/op   | ~2400 us/op  | 10.3x   |

vm2 allocations: 0 allocs/op on both (sync.Pool frame + register slabs). runtime/vm fib(25): 515k allocs/op, 364 MB/op.

Cross-language head-to-head (vm2 vs Python / TS / Go / C) becomes available via `go run -tags=slow ./cmd/mochi-bench` once this lands. That comparison is the next focus per directive.

## Test plan

- [x] `go build ./...`
- [x] `go test ./runtime/vm2/bench/ -run TestCorpus` (all 8 programs pass)
- [x] `go test -tags=slow -bench=^BenchmarkVM2_ -benchmem ./runtime/vm2/bench/` (numbers above)
- [x] `go run ./bench/vm2runner -program math_sum_loop -n 10` returns valid JSON
- [ ] Full `go run -tags=slow ./cmd/mochi-bench` cross-language sweep (requires python3, deno, c compiler on CI host)