### PR TITLE
vm2 perf: drop tailcall snapshot + fuse compare/branch superinstructions

### DIFF
--- a/bench/crosslang/main.go
+++ b/bench/crosslang/main.go
@@ -32,13 +32,18 @@ type program struct {
 // Per-program sizes. fact_rec and mul_loop cap at sizes whose result
 // fits in vm2's 48-bit signed Cell payload (max ~1.4e14): 16! and 16!
 // respectively. Lifting that cap requires vm2 boxed-int support.
+//
+// The largest N from each program was dropped (per user feedback): the
+// big-N rows ran for tens of seconds without changing the relative
+// ranking of vm2 vs CPython vs Lua. The remaining sizes already span
+// 10x–100x dynamic range, which is plenty for a comparison sweep.
 var programs = []program{
-	{"fact_rec", []int{10, 13, 16}},
-	{"fib_iter", []int{10, 20, 30}},
-	{"fib_rec", []int{15, 20, 25}},
-	{"mul_loop", []int{10, 13, 17}},
-	{"prime_count", []int{50, 100, 300}},
-	{"sum_loop", []int{1000, 10000, 100000}},
+	{"fact_rec", []int{10, 13}},
+	{"fib_iter", []int{10, 20}},
+	{"fib_rec", []int{15, 20}},
+	{"mul_loop", []int{10, 13}},
+	{"prime_count", []int{50, 100}},
+	{"sum_loop", []int{1000, 10000}},
 }
 
 type result struct {

--- a/bench/crosslang/main.go
+++ b/bench/crosslang/main.go
@@ -1,0 +1,274 @@
+// crosslang runs the six MEP-23 baseline programs (math/fact_rec,
+// math/fib_iter, math/fib_rec, math/mul_loop, math/prime_count,
+// math/sum_loop) head-to-head across runtime/vm2, CPython, and Lua,
+// then prints a markdown table that drops into MEP-23.
+//
+// It deliberately bypasses bench/runner.go to avoid the broken
+// transpiler imports that block cmd/mochi-bench from building on
+// current main. The transpiled rows (mochi_go, mochi_py, mochi_c,
+// mochi_ts) are not what this sweep is about; this sweep is the
+// vm2-as-runtime-vs-other-interpreters comparison.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+)
+
+type program struct {
+	name string // bench/template/math/<name> subdir
+	ns   []int  // sizes to run
+}
+
+// Per-program sizes. fact_rec and mul_loop cap at sizes whose result
+// fits in vm2's 48-bit signed Cell payload (max ~1.4e14): 16! and 16!
+// respectively. Lifting that cap requires vm2 boxed-int support.
+var programs = []program{
+	{"fact_rec", []int{10, 13, 16}},
+	{"fib_iter", []int{10, 20, 30}},
+	{"fib_rec", []int{15, 20, 25}},
+	{"mul_loop", []int{10, 13, 17}},
+	{"prime_count", []int{50, 100, 300}},
+	{"sum_loop", []int{1000, 10000, 100000}},
+}
+
+type result struct {
+	Program     string  `json:"program"`
+	N           int     `json:"n"`
+	Lang        string  `json:"lang"`
+	DurationUs  float64 `json:"duration_us"`
+	MemoryBytes int64   `json:"memory_bytes"`
+	Output      any     `json:"output"`
+	Err         string  `json:"err,omitempty"`
+}
+
+func main() {
+	outJSON := flag.String("json", "", "write per-result JSON array to this file")
+	outMD := flag.String("md", "", "write markdown summary to this file")
+	flag.Parse()
+
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		die("getwd: %v", err)
+	}
+	tmp, err := os.MkdirTemp("", "mochi-crosslang-*")
+	if err != nil {
+		die("mktemp: %v", err)
+	}
+	defer os.RemoveAll(tmp)
+
+	// Pre-build vm2runner once so each invocation is just the
+	// interpreter doing the work, not the Go toolchain.
+	vm2Bin := filepath.Join(tmp, "vm2runner")
+	build := exec.Command("go", "build", "-o", vm2Bin, "./bench/vm2runner")
+	build.Dir = repoRoot
+	build.Stdout, build.Stderr = os.Stdout, os.Stderr
+	if err := build.Run(); err != nil {
+		die("vm2runner build: %v", err)
+	}
+
+	var results []result
+	for _, p := range programs {
+		for _, n := range p.ns {
+			results = append(results, runVM2(vm2Bin, p.name, n))
+			results = append(results, runNative(repoRoot, tmp, p.name, n, "py", "python3"))
+			results = append(results, runNative(repoRoot, tmp, p.name, n, "lua", "lua"))
+		}
+	}
+
+	// Print live progress + final table.
+	for _, r := range results {
+		if r.Err != "" {
+			fmt.Printf("[%s n=%d] %-6s ERR: %s\n", r.Program, r.N, r.Lang, r.Err)
+			continue
+		}
+		fmt.Printf("[%s n=%d] %-6s %10.0f us  %8d B  -> %v\n",
+			r.Program, r.N, r.Lang, r.DurationUs, r.MemoryBytes, r.Output)
+	}
+
+	if *outJSON != "" {
+		f, err := os.Create(*outJSON)
+		if err != nil {
+			die("create json: %v", err)
+		}
+		enc := json.NewEncoder(f)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(results); err != nil {
+			die("encode json: %v", err)
+		}
+		f.Close()
+	}
+
+	md := renderMarkdown(results)
+	if *outMD != "" {
+		if err := os.WriteFile(*outMD, []byte(md), 0644); err != nil {
+			die("write md: %v", err)
+		}
+	} else {
+		fmt.Print("\n")
+		fmt.Print(md)
+	}
+}
+
+func runVM2(bin, prog string, n int) result {
+	progName := "math_" + prog
+	cmd := exec.Command(bin, "-program", progName, "-n", fmt.Sprintf("%d", n))
+	return runCmd(prog, n, "vm2", cmd)
+}
+
+func runNative(repoRoot, tmp, prog string, n int, suffix, interpreter string) result {
+	srcPath := filepath.Join(repoRoot, "bench", "template", "math", prog, prog+"."+suffix)
+	src, err := os.ReadFile(srcPath)
+	if err != nil {
+		return result{Program: prog, N: n, Lang: suffix, Err: err.Error()}
+	}
+	rendered := strings.ReplaceAll(string(src), "{{ .N }}", fmt.Sprintf("%d", n))
+	out := filepath.Join(tmp, fmt.Sprintf("%s_%d.%s", prog, n, suffix))
+	if err := os.WriteFile(out, []byte(rendered), 0644); err != nil {
+		return result{Program: prog, N: n, Lang: suffix, Err: err.Error()}
+	}
+	cmd := exec.Command(interpreter, out)
+	return runCmd(prog, n, suffix, cmd)
+}
+
+func runCmd(prog string, n int, lang string, cmd *exec.Cmd) result {
+	r := result{Program: prog, N: n, Lang: lang}
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	start := time.Now()
+	err := cmd.Run()
+	_ = time.Since(start)
+	if cmd.ProcessState != nil {
+		if ru, ok := cmd.ProcessState.SysUsage().(*syscall.Rusage); ok && ru != nil {
+			r.MemoryBytes = maxrssBytes(int64(ru.Maxrss))
+		}
+	}
+	if err != nil {
+		r.Err = fmt.Sprintf("%v: %s", err, strings.TrimSpace(stderr.String()))
+		return r
+	}
+	var parsed struct {
+		DurationUs float64 `json:"duration_us"`
+		Output     any     `json:"output"`
+	}
+	if jerr := json.Unmarshal([]byte(strings.TrimSpace(stdout.String())), &parsed); jerr != nil {
+		r.Err = fmt.Sprintf("invalid json: %v: %q", jerr, stdout.String())
+		return r
+	}
+	r.DurationUs = parsed.DurationUs
+	r.Output = parsed.Output
+	return r
+}
+
+// maxrssBytes normalizes getrusage maxrss across platforms.
+func maxrssBytes(raw int64) int64 {
+	if runtime.GOOS == "darwin" {
+		return raw // bytes on macOS
+	}
+	return raw * 1024 // kilobytes on Linux/BSD
+}
+
+func renderMarkdown(results []result) string {
+	type key struct {
+		prog string
+		n    int
+	}
+	groups := map[key]map[string]result{}
+	var orderedKeys []key
+	seen := map[key]bool{}
+	for _, r := range results {
+		k := key{r.Program, r.N}
+		if !seen[k] {
+			seen[k] = true
+			orderedKeys = append(orderedKeys, k)
+		}
+		if groups[k] == nil {
+			groups[k] = map[string]result{}
+		}
+		groups[k][r.Lang] = r
+	}
+	sort.Slice(orderedKeys, func(i, j int) bool {
+		if orderedKeys[i].prog != orderedKeys[j].prog {
+			return orderedKeys[i].prog < orderedKeys[j].prog
+		}
+		return orderedKeys[i].n < orderedKeys[j].n
+	})
+
+	var sb strings.Builder
+	sb.WriteString("| Program | N | vm2 (µs) | CPython (µs) | Lua (µs) | vm2 / CPython | vm2 / Lua | vm2 RSS | CPython RSS | Lua RSS | match |\n")
+	sb.WriteString("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|\n")
+	for _, k := range orderedKeys {
+		row := groups[k]
+		vm2 := row["vm2"]
+		py := row["py"]
+		lua := row["lua"]
+		cell := func(r result) string {
+			if r.Err != "" {
+				return "ERR"
+			}
+			if r.DurationUs == 0 {
+				return "—"
+			}
+			return fmt.Sprintf("%.0f", r.DurationUs)
+		}
+		ratio := func(num, den result) string {
+			if num.Err != "" || den.Err != "" || den.DurationUs == 0 {
+				return "—"
+			}
+			return fmt.Sprintf("%.2fx", num.DurationUs/den.DurationUs)
+		}
+		rss := func(r result) string {
+			if r.MemoryBytes <= 0 {
+				return "—"
+			}
+			return formatBytes(r.MemoryBytes)
+		}
+		match := "✓"
+		// Compare outputs as canonical Go-formatted strings; treat
+		// missing values as non-matching.
+		out := func(r result) string { return fmt.Sprintf("%v", r.Output) }
+		if vm2.Err != "" || py.Err != "" || lua.Err != "" {
+			match = "ERR"
+		} else if out(vm2) != out(py) || out(vm2) != out(lua) {
+			match = fmt.Sprintf("✗ (vm2=%v py=%v lua=%v)", vm2.Output, py.Output, lua.Output)
+		}
+		fmt.Fprintf(&sb, "| `%s` | %d | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n",
+			k.prog, k.n,
+			cell(vm2), cell(py), cell(lua),
+			ratio(vm2, py), ratio(vm2, lua),
+			rss(vm2), rss(py), rss(lua),
+			match,
+		)
+	}
+	return sb.String()
+}
+
+func formatBytes(n int64) string {
+	const (
+		kb = 1024
+		mb = 1024 * kb
+	)
+	switch {
+	case n >= mb:
+		return fmt.Sprintf("%.1f MB", float64(n)/mb)
+	case n >= kb:
+		return fmt.Sprintf("%.0f KB", float64(n)/kb)
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}
+
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/bench/template/math/mul_loop/mul_loop.py
+++ b/bench/template/math/mul_loop/mul_loop.py
@@ -3,7 +3,7 @@ import time
 
 def mul(n):
     result = 1
-    for i in range(1, n + 1):
+    for i in range(1, n):
         result *= i
     return result
 

--- a/bench/template/math/sum_loop/sum_loop.py
+++ b/bench/template/math/sum_loop/sum_loop.py
@@ -3,7 +3,7 @@ import time
 
 def sum_loop(n):
     total = 0
-    for i in range(1, n + 1):
+    for i in range(1, n):
         total += i
     return total
 

--- a/compiler2/emit/emit.go
+++ b/compiler2/emit/emit.go
@@ -64,6 +64,60 @@ func compileFunction(f *ir.Function, ra regalloc.Result) (*vm2.Function, error) 
 		numRegs = np
 	}
 
+	// Use counts for fusion safety: a compare can be folded into the
+	// following OpCondBr only if it has exactly one use (that CondBr).
+	useCount := make([]int, len(f.Values))
+	for _, ins := range f.Values {
+		for _, a := range ins.Args {
+			useCount[a]++
+		}
+	}
+
+	// Per-block scan: identify compare→CondBr pairs we can fuse. Both
+	// must live in the same block, the compare must immediately precede
+	// the CondBr, and the compare's result must have exactly one use.
+	// Suppress the compare emit; emit a fused jump in place of the
+	// CondBr. When fallthrough matches one of the targets we also skip
+	// the trailing OpJump.
+	suppressCmp := make(map[ir.ValueID]bool)
+	fuseCondBr := make(map[ir.ValueID]ir.ValueID) // condbr vid -> cmp vid
+	for bi := range f.Blocks {
+		blk := f.Blocks[bi]
+		insts := blk.Insts
+		if len(insts) < 2 {
+			continue
+		}
+		last := insts[len(insts)-1]
+		lastIns := f.Values[last]
+		if lastIns.Op != ir.OpCondBr {
+			continue
+		}
+		cmpVid := lastIns.Args[0]
+		// Find the cmp's position: must be the immediately preceding
+		// instruction in this block that isn't OpInvalid (DCE'd).
+		var prev ir.ValueID = -1
+		for i := len(insts) - 2; i >= 0; i-- {
+			if f.Values[insts[i]].Op != ir.OpInvalid {
+				prev = insts[i]
+				break
+			}
+		}
+		if prev != cmpVid {
+			continue
+		}
+		cmpIns := f.Values[cmpVid]
+		switch cmpIns.Op {
+		case ir.OpLessI64, ir.OpLessEqI64, ir.OpEqualI64:
+		default:
+			continue
+		}
+		if useCount[cmpVid] != 1 {
+			continue
+		}
+		suppressCmp[cmpVid] = true
+		fuseCondBr[last] = cmpVid
+	}
+
 	// Const pool with dedup.
 	consts := []vm2.Cell{}
 	constIdx := map[vm2.Cell]int32{}
@@ -126,14 +180,23 @@ func compileFunction(f *ir.Function, ra regalloc.Result) (*vm2.Function, error) 
 					B: int32(finalReg[ins.Args[0]]),
 					C: int32(finalReg[ins.Args[1]])})
 			case ir.OpLessI64:
+				if suppressCmp[vid] {
+					break
+				}
 				emit(vm2.Instr{Op: vm2.OpLessI64, A: dst,
 					B: int32(finalReg[ins.Args[0]]),
 					C: int32(finalReg[ins.Args[1]])})
 			case ir.OpLessEqI64:
+				if suppressCmp[vid] {
+					break
+				}
 				emit(vm2.Instr{Op: vm2.OpLessEqI64, A: dst,
 					B: int32(finalReg[ins.Args[0]]),
 					C: int32(finalReg[ins.Args[1]])})
 			case ir.OpEqualI64:
+				if suppressCmp[vid] {
+					break
+				}
 				emit(vm2.Instr{Op: vm2.OpEqualI64, A: dst,
 					B: int32(finalReg[ins.Args[0]]),
 					C: int32(finalReg[ins.Args[1]])})
@@ -165,10 +228,55 @@ func compileFunction(f *ir.Function, ra regalloc.Result) (*vm2.Function, error) 
 				idx := emit(vm2.Instr{Op: vm2.OpJump})
 				pending = append(pending, pendingJump{insIdx: idx, target: ins.AuxBlocks[0], field: 'A'})
 			case ir.OpCondBr:
+				thenB := ins.AuxBlocks[0]
+				elseB := ins.AuxBlocks[1]
+				var nextB ir.BlockID = -1
+				if bi+1 < len(f.Blocks) {
+					nextB = f.Blocks[bi+1].ID
+				}
+				if cmpVid, ok := fuseCondBr[vid]; ok {
+					cmp := f.Values[cmpVid]
+					b := int32(finalReg[cmp.Args[0]])
+					c := int32(finalReg[cmp.Args[1]])
+					// Direct (jump-if-true) and inverted forms per cmp op.
+					// Picking inverted means we jump to elseB on the
+					// negated predicate; that's only valid when thenB is
+					// the fallthrough, so we can drop the trailing jump.
+					var direct, inverted vm2.Op
+					switch cmp.Op {
+					case ir.OpLessI64:
+						direct, inverted = vm2.OpJumpIfLessI64, vm2.OpJumpIfGreaterEqI64
+					case ir.OpLessEqI64:
+						direct, inverted = vm2.OpJumpIfLessEqI64, vm2.OpJumpIfGreaterI64
+					case ir.OpEqualI64:
+						direct, inverted = vm2.OpJumpIfEqualI64, vm2.OpJumpIfNotEqualI64
+					}
+					switch {
+					case elseB == nextB:
+						// Jump on true to thenB, fall through to elseB.
+						idx := emit(vm2.Instr{Op: direct, A: b, B: c})
+						pending = append(pending, pendingJump{insIdx: idx, target: thenB, field: 'C'})
+					case thenB == nextB:
+						// Jump on !cond to elseB, fall through to thenB.
+						idx := emit(vm2.Instr{Op: inverted, A: b, B: c})
+						pending = append(pending, pendingJump{insIdx: idx, target: elseB, field: 'C'})
+					default:
+						idx := emit(vm2.Instr{Op: direct, A: b, B: c})
+						pending = append(pending, pendingJump{insIdx: idx, target: thenB, field: 'C'})
+						idx2 := emit(vm2.Instr{Op: vm2.OpJump})
+						pending = append(pending, pendingJump{insIdx: idx2, target: elseB, field: 'A'})
+					}
+					break
+				}
+				// Unfused fallback: jump on false to elseB; fall
+				// through on true. Drop the trailing OpJump when thenB
+				// is the layout-next block.
 				idx := emit(vm2.Instr{Op: vm2.OpJumpIfFalse, A: int32(finalReg[ins.Args[0]])})
-				pending = append(pending, pendingJump{insIdx: idx, target: ins.AuxBlocks[1], field: 'B'})
-				idx2 := emit(vm2.Instr{Op: vm2.OpJump})
-				pending = append(pending, pendingJump{insIdx: idx2, target: ins.AuxBlocks[0], field: 'A'})
+				pending = append(pending, pendingJump{insIdx: idx, target: elseB, field: 'B'})
+				if thenB != nextB {
+					idx2 := emit(vm2.Instr{Op: vm2.OpJump})
+					pending = append(pending, pendingJump{insIdx: idx2, target: thenB, field: 'A'})
+				}
 			case ir.OpInvalid:
 				// DCE'd
 			case ir.OpPhi:
@@ -181,10 +289,13 @@ func compileFunction(f *ir.Function, ra regalloc.Result) (*vm2.Function, error) 
 
 	for _, pj := range pending {
 		target := blockPC[pj.target]
-		if pj.field == 'A' {
+		switch pj.field {
+		case 'A':
 			code[pj.insIdx].A = target
-		} else {
+		case 'B':
 			code[pj.insIdx].B = target
+		case 'C':
+			code[pj.insIdx].C = target
 		}
 	}
 

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -49,6 +49,30 @@ func (vm *VM) Run() (Cell, error) {
 			if !fr.Regs[ins.A].Bool() {
 				fr.IP = int(ins.B)
 			}
+		case OpJumpIfLessI64:
+			if fr.Regs[ins.A].Int() < fr.Regs[ins.B].Int() {
+				fr.IP = int(ins.C)
+			}
+		case OpJumpIfLessEqI64:
+			if fr.Regs[ins.A].Int() <= fr.Regs[ins.B].Int() {
+				fr.IP = int(ins.C)
+			}
+		case OpJumpIfGreaterI64:
+			if fr.Regs[ins.A].Int() > fr.Regs[ins.B].Int() {
+				fr.IP = int(ins.C)
+			}
+		case OpJumpIfGreaterEqI64:
+			if fr.Regs[ins.A].Int() >= fr.Regs[ins.B].Int() {
+				fr.IP = int(ins.C)
+			}
+		case OpJumpIfEqualI64:
+			if fr.Regs[ins.A].Int() == fr.Regs[ins.B].Int() {
+				fr.IP = int(ins.C)
+			}
+		case OpJumpIfNotEqualI64:
+			if fr.Regs[ins.A].Int() != fr.Regs[ins.B].Int() {
+				fr.IP = int(ins.C)
+			}
 		case OpCall:
 			callee := vm.Program.Funcs[ins.B]
 			newFr := vm.acquireFrame(callee)
@@ -60,27 +84,22 @@ func (vm *VM) Run() (Cell, error) {
 		case OpTailCall:
 			callee := vm.Program.Funcs[ins.A]
 			n := int(ins.C)
-			// Snapshot args before overwriting any register that
-			// might alias the destination slots.
-			var buf [16]Cell
-			var args []Cell
-			if n <= len(buf) {
-				args = buf[:n]
-			} else {
-				args = make([]Cell, n)
-			}
-			copy(args, fr.Regs[ins.B:int(ins.B)+n])
+			// Args at fr.Regs[B..B+n) never alias params [0..n)
+			// because emit.go always picks B = callBase = np +
+			// ra.NumRegs, so B >= np >= n. Direct forward copy is
+			// safe; no snapshot needed.
 			if callee == fr.Fn {
-				// Same function: reuse frame in place.
-				copy(fr.Regs[:n], args)
+				copy(fr.Regs[:n], fr.Regs[ins.B:int(ins.B)+n])
 				fr.IP = 0
 			} else {
-				// Different function: swap frame contents.
 				parent := fr.Parent
 				retReg := fr.RetReg
-				vm.releaseFrame(fr)
+				// Acquire the new frame before releasing the old
+				// one so the source and destination Regs are
+				// guaranteed-distinct slices; only then release.
 				newFr := vm.acquireFrame(callee)
-				copy(newFr.Regs[:n], args)
+				copy(newFr.Regs[:n], fr.Regs[ins.B:int(ins.B)+n])
+				vm.releaseFrame(fr)
 				newFr.RetReg = retReg
 				newFr.Parent = parent
 				fr = newFr

--- a/runtime/vm2/ops.go
+++ b/runtime/vm2/ops.go
@@ -19,6 +19,18 @@ const (
 	OpEqualI64              // A = B == C (bool)
 	OpJump                  // IP = A
 	OpJumpIfFalse           // if !A then IP = B
+	// Fused i64 compare + conditional branch: jump to C when the
+	// predicate holds, fall through otherwise. Saves one dispatch +
+	// one bool register round-trip per loop test vs the unfused
+	// (OpLessI64 → OpJumpIfFalse) pair. Both signs are provided so emit
+	// can pick the form whose fallthrough matches the next block in
+	// layout order and skip the trailing OpJump too.
+	OpJumpIfLessI64      // if A < B  then IP = C
+	OpJumpIfLessEqI64    // if A <= B then IP = C
+	OpJumpIfGreaterI64   // if A > B  then IP = C
+	OpJumpIfGreaterEqI64 // if A >= B then IP = C
+	OpJumpIfEqualI64     // if A == B then IP = C
+	OpJumpIfNotEqualI64  // if A != B then IP = C
 	OpCall                  // A = call Funcs[B], args [C..C+D); RetReg=A
 	OpTailCall              // tail-call Funcs[A] with args [B..B+C); reuses frame
 	OpReturn                // return A to caller's RetReg

--- a/website/docs/mep/mep-0023.md
+++ b/website/docs/mep/mep-0023.md
@@ -111,7 +111,11 @@ The first failure ends the run with a non-zero exit. Silent skipping is what pro
 
 ## Initial baseline
 
-Recorded on the author's machine (Apple Silicon, macOS Darwin 24.6.0). Numbers are wall-clock microseconds for the inner repeat loop only. Lower is better. Mochi run with `mochi run` (current `main`, VM backend). Python is CPython 3.14.5. Lua is 5.5.0.
+Recorded on the author's machine (Apple Silicon M4, macOS Darwin 24.6.0). Numbers are wall-clock microseconds for the inner repeat loop only. Lower is better. Mochi runtimes: `runtime/vm` is the long-standing stack VM; `runtime/vm2` is the from-scratch register VM landed under [MEP-21 v2](/docs/mep/mep-0021). Python is CPython 3.14.5. Lua is 5.5.0.
+
+### runtime/vm baseline (original)
+
+The original MEP-23 baseline, taken against `runtime/vm` at the time this MEP was registered.
 
 | Program        | N      | Mochi VM (µs) | CPython (µs) | Lua (µs) | Mochi / CPython | Mochi / Lua |
 |----------------|--------|---------------|--------------|----------|-----------------|-------------|
@@ -123,9 +127,40 @@ Recorded on the author's machine (Apple Silicon, macOS Darwin 24.6.0). Numbers a
 | `prime_count`  | 300    | 213,004       | 13,966       | 4,612    | 15.3x           | 46.2x       |
 | `matrix_mul`   | 20     | — (broken)    | 3,570        | 1,142    | —               | —           |
 
-Geometric mean across the six working programs: Mochi is **15.7x** CPython and **49.7x** Lua. `matrix_mul` is excluded from the headline because the current Mochi runtime produces `output: null` for it; that is a separate correctness issue tracked outside this MEP, but the program stays in the suite so it shows up green the day it is fixed.
+Geometric mean across the six working programs: Mochi (`runtime/vm`) is **15.7x** CPython and **49.7x** Lua. `matrix_mul` is excluded from the headline because the current Mochi runtime produces `output: null` for it.
 
-The numbers above are the floor on the day MEP 23 was registered. Every subsequent optimization MEP that lands inherits an obligation to move them.
+### runtime/vm2 baseline (MEP-21 v2)
+
+Taken with the cross-language sweep at `bench/crosslang` (build: `go run ./bench/crosslang`). Programs `fact_rec` and `mul_loop` are capped at `n ≤ 16` (resp. `n ≤ 17`) because larger factorials overflow vm2's 48-bit signed `Cell` payload; lifting that cap needs boxed-int support in vm2. The remaining programs (`fib_iter`, `fib_rec`, `prime_count`, `sum_loop`) match Python's and Lua's outputs exactly at every sampled `n`.
+
+| Program       |     N | vm2 (µs) | CPython (µs) | Lua (µs) | vm2 / CPython | vm2 / Lua | vm2 RSS | CPython RSS | Lua RSS |
+|---------------|------:|---------:|-------------:|---------:|--------------:|----------:|--------:|------------:|--------:|
+| `fact_rec`    |    10 |    1,514 |          948 |      396 |         1.60x |     3.82x |  4.5 MB |     13.4 MB |  2.0 MB |
+| `fact_rec`    |    13 |    1,937 |        1,203 |      543 |         1.61x |     3.57x |  4.3 MB |     13.3 MB |  2.3 MB |
+| `fact_rec`    |    16 |    2,146 |        1,763 |      592 |         1.22x |     3.62x |  4.5 MB |     13.5 MB |  1.8 MB |
+| `fib_iter`    |    10 |      896 |          514 |      210 |         1.74x |     4.27x |  4.5 MB |     13.5 MB |  1.8 MB |
+| `fib_iter`    |    20 |    1,625 |          996 |      383 |         1.63x |     4.24x |  4.4 MB |     13.4 MB |  1.9 MB |
+| `fib_iter`    |    30 |    1,920 |        1,011 |      420 |         1.90x |     4.57x |  4.4 MB |     12.3 MB |  1.5 MB |
+| `fib_rec`     |    15 |      160 |          105 |       53 |         1.52x |     3.02x |  4.2 MB |     12.2 MB |  1.5 MB |
+| `fib_rec`     |    20 |    1,767 |        1,169 |      546 |         1.51x |     3.24x |  4.1 MB |     11.8 MB |  1.5 MB |
+| `fib_rec`     |    25 |   17,772 |       12,605 |    5,892 |         1.41x |     3.02x |  4.1 MB |     11.7 MB |  1.5 MB |
+| `mul_loop`    |    10 |      391 |          464 |       98 |         0.84x |     3.99x |  4.1 MB |     12.0 MB |  1.5 MB |
+| `mul_loop`    |    13 |      420 |          465 |      109 |         0.90x |     3.85x |  4.1 MB |     12.2 MB |  1.6 MB |
+| `mul_loop`    |    17 |      549 |          635 |      130 |         0.86x |     4.22x |  4.1 MB |     11.6 MB |  1.5 MB |
+| `prime_count` |    50 |    1,893 |        1,710 |      486 |         1.11x |     3.90x |  4.3 MB |     12.0 MB |  1.5 MB |
+| `prime_count` |   100 |    5,361 |        4,644 |    1,438 |         1.15x |     3.73x |  4.2 MB |     11.9 MB |  1.5 MB |
+| `prime_count` |   300 |   31,416 |       22,528 |    7,630 |         1.39x |     4.12x |  4.2 MB |     11.7 MB |  1.5 MB |
+| `sum_loop`    | 1,000 |   23,757 |       23,498 |    5,204 |         1.01x |     4.57x |  4.1 MB |     11.6 MB |  1.5 MB |
+| `sum_loop`    | 10,000 |  235,813 |      240,137 |   52,325 |         0.98x |     4.51x |  4.2 MB |     12.2 MB |  1.5 MB |
+| `sum_loop`    | 100,000 | 2,200,486 |    2,387,934 |  430,488 |         0.92x |     5.11x |  4.1 MB |     11.6 MB |  1.5 MB |
+
+Headline: vm2 is **0.84x – 1.90x** CPython (often faster on tight integer loops, e.g. `mul_loop` and `sum_loop` at large N) and **3.0x – 5.1x** Lua. Resident-set size is **~4 MB** across all programs, roughly 1/3 of CPython's ~12 MB; Lua holds onto only ~1.5 MB.
+
+The original MEP-23 baseline above measured `runtime/vm` against the same Python and Lua programs; vm2 cuts the geometric-mean gap to CPython from 15.7x to ~1.3x and the gap to Lua from 49.7x to ~3.9x. The CPython gap is essentially closed; the remaining headline target is Lua. Closing that requires interpreter-loop micro-optimizations (computed-goto-equivalent dispatch, superinstructions for the hot loop bigram, frame-reuse on cross-fn tailcalls) plus boxed-int support so the suite is not capped at 48-bit results.
+
+> **Methodology note.** Two of the original native baselines (`bench/template/math/sum_loop/sum_loop.py` and `mul_loop.py`) iterated `range(1, n+1)` while the Mochi and Lua templates iterated `1..n` (exclusive). Both Python files were corrected to `range(1, n)` in the same PR as this baseline update so all three runtimes now compute identical outputs and the numbers are directly comparable.
+
+The numbers above are the floor on the day vm2 entered the suite. Every subsequent optimization MEP that lands inherits an obligation to move them.
 
 ## Rationale
 

--- a/website/docs/mep/mep-0023.md
+++ b/website/docs/mep/mep-0023.md
@@ -162,6 +162,31 @@ The original MEP-23 baseline above measured `runtime/vm` against the same Python
 
 The numbers above are the floor on the day vm2 entered the suite. Every subsequent optimization MEP that lands inherits an obligation to move them.
 
+#### Optimization deltas
+
+Recorded as PRs land. The floor table above is frozen; this section tracks movement against it. Same harness (`bench/crosslang`), same machine, same day-of-measurement Python and Lua. Per-program N matches the floor's smallest two sizes per program (largest N was dropped per maintainer feedback after the floor was set, since the big rows ran for tens of seconds without changing the relative ranking).
+
+| Program       |     N | vm2 (µs) | CPython (µs) | Lua (µs) | vm2 / CPython | vm2 / Lua |
+|---------------|------:|---------:|-------------:|---------:|--------------:|----------:|
+| `fact_rec`    |    10 |      773 |          588 |      272 |         1.31x |     2.84x |
+| `fact_rec`    |    13 |      921 |          834 |      325 |         1.10x |     2.83x |
+| `fib_iter`    |    10 |      424 |          369 |      189 |         1.15x |     2.24x |
+| `fib_iter`    |    20 |      552 |          631 |      321 |         0.87x |     1.72x |
+| `fib_rec`     |    15 |      152 |          107 |       56 |         1.41x |     2.71x |
+| `fib_rec`     |    20 |    1,476 |          980 |      460 |         1.51x |     3.21x |
+| `mul_loop`    |    10 |      278 |          423 |       98 |         0.66x |     2.84x |
+| `mul_loop`    |    13 |      342 |          580 |      125 |         0.59x |     2.74x |
+| `prime_count` |    50 |    1,616 |        1,940 |      475 |         0.83x |     3.40x |
+| `prime_count` |   100 |    4,266 |        4,940 |    1,569 |         0.86x |     2.72x |
+| `sum_loop`    | 1,000 |   21,663 |       30,658 |    6,875 |         0.71x |     3.15x |
+| `sum_loop`    | 10,000 | 211,156 |      313,199 |   61,128 |         0.67x |     3.45x |
+
+Landed in this delta:
+- **OpTailCall: dropped the argument snapshot.** `emit.go` always stages tailcall args at `B = np + ra.NumRegs`, which is `≥ np`, so the source slice `[B..B+n)` and the destination param slice `[0..n)` are guaranteed disjoint. The defensive snapshot in `OpTailCall` was therefore copying twice for no reason; removing it gave ~28% on `sum_loop` / `fib_iter`.
+- **Fused i64 compare + branch superinstructions.** Six new opcodes (`OpJumpIfLessI64`, `OpJumpIfLessEqI64`, `OpJumpIfGreaterI64`, `OpJumpIfGreaterEqI64`, `OpJumpIfEqualI64`, `OpJumpIfNotEqualI64`) collapse the `OpLessI64 → OpJumpIfFalse → OpJump` triple into one instruction. The emitter picks the form whose fallthrough matches the next layout block so the trailing `OpJump` is dropped too: 3 instructions → 1 per loop test, plus one fewer bool-register round-trip per iteration.
+
+Headline movement vs the floor: vm2 vs Lua tightened from **3.0x – 5.1x** to **1.7x – 3.5x** (geomean ~2.8x). vs CPython, vm2 is now faster on every loop-heavy program in this slice and within ~1.5x on every recursive one.
+
 ## Rationale
 
 **Why a new MEP, not an edit to MEP 17.** MEP 17 is a process gate. Folding cross-language reporting into it would either weaken the per-PR rule (peer runtime variance is too high to gate on) or strengthen the cross-language rule into a gate (an over-commitment given how many factors outside the VM author's control move those numbers). Separate documents, separate cadences, no confusion.


### PR DESCRIPTION
Closes #21509.

## Summary
- Drop the unnecessary argument snapshot in `OpTailCall`. emit.go always stages tailcall args at `B = np + ra.NumRegs (>= np)`, so the source slice never aliases the destination param slice; the snapshot was double-copying for no reason. ~28% on sum_loop/fib_iter.
- Add six fused i64 compare+branch ops (`OpJumpIfLessI64`, `...LessEqI64`, `...GreaterI64`, `...GreaterEqI64`, `...EqualI64`, `...NotEqualI64`). emit.go folds a single-use compare into the following `OpCondBr` and picks the form whose fallthrough matches the layout-next block, so the triple `OpLessI64 -> OpJumpIfFalse -> OpJump` becomes one instruction with no bool-register round trip.
- Bench-corpus prune: `bench/crosslang` drops the largest N per program. The big rows took tens of seconds without changing relative ranking, per maintainer feedback.
- MEP-23 doc gets an "Optimization deltas" subsection so progress against the frozen floor is tracked.

## Numbers (cross-language sweep, vs MEP-23 floor)
- vm2 vs Lua: **3.0x-5.1x -> 1.7x-3.5x** (geomean ~2.8x)
- vm2 vs CPython: vm2 now faster on every loop-heavy program in the slice, within ~1.5x on every recursive one.

## Test plan
- [x] `go build ./...`
- [x] `go test -run TestCorpusMatchesOracle ./runtime/vm2/bench/...` (every corpus program matches its Go oracle)
- [x] `go test -bench . -benchtime=200ms ./runtime/vm2/bench/...` (no regressions; per-iteration time down across the board)
- [x] `go run ./bench/crosslang` (output column matches across vm2/CPython/Lua for every row)