### PR TITLE
vm2 perf round 2: dispatch state hoist + OpTailCallSelf + OpAddI64K

### DIFF
--- a/compiler2/emit/emit.go
+++ b/compiler2/emit/emit.go
@@ -20,7 +20,7 @@ func Compile(m *ir.Module) (*vm2.Program, error) {
 			return nil, fmt.Errorf("ir.Verify %s: %w", f.Name, err)
 		}
 		ra := regalloc.Run(f, nil)
-		fn, err := compileFunction(f, ra)
+		fn, err := compileFunction(f, ra, i)
 		if err != nil {
 			return nil, fmt.Errorf("emit %s: %w", f.Name, err)
 		}
@@ -29,7 +29,7 @@ func Compile(m *ir.Module) (*vm2.Program, error) {
 	return &vm2.Program{Funcs: funcs, Main: m.Main}, nil
 }
 
-func compileFunction(f *ir.Function, ra regalloc.Result) (*vm2.Function, error) {
+func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Function, error) {
 	np := len(f.Params)
 
 	// Pin params to regs [0..np). Shift all non-param regalloc
@@ -79,8 +79,42 @@ func compileFunction(f *ir.Function, ra regalloc.Result) (*vm2.Function, error) 
 	// Suppress the compare emit; emit a fused jump in place of the
 	// CondBr. When fallthrough matches one of the targets we also skip
 	// the trailing OpJump.
-	suppressCmp := make(map[ir.ValueID]bool)
+	// suppress is the set of value IDs whose emit should be skipped
+	// because some later instruction fuses them in directly (compare
+	// folded into a branch, const folded into an add immediate, etc).
+	suppress := make(map[ir.ValueID]bool)
 	fuseCondBr := make(map[ir.ValueID]ir.ValueID) // condbr vid -> cmp vid
+	// addK records an OpAddI64 fused with a single-use ConstI64
+	// operand: the constant value k and the value ID of the non-const
+	// addend. Emit lowers these to OpAddI64K instead of two separate
+	// dispatches, which cuts ~14% off the hot loop step in iter_sum.
+	type addKInfo struct {
+		k           int64
+		nonConstArg ir.ValueID
+	}
+	addK := make(map[ir.ValueID]addKInfo)
+	for vid, ins := range f.Values {
+		if ins.Op != ir.OpAddI64 {
+			continue
+		}
+		a0, a1 := ins.Args[0], ins.Args[1]
+		try := func(constArg, otherArg ir.ValueID) bool {
+			c := f.Values[constArg]
+			if c.Op != ir.OpConstI64 || useCount[constArg] != 1 {
+				return false
+			}
+			k := c.Aux
+			if k < -(1<<31) || k > (1<<31)-1 {
+				return false
+			}
+			suppress[constArg] = true
+			addK[ir.ValueID(vid)] = addKInfo{k: k, nonConstArg: otherArg}
+			return true
+		}
+		if !try(a1, a0) {
+			try(a0, a1)
+		}
+	}
 	for bi := range f.Blocks {
 		blk := f.Blocks[bi]
 		insts := blk.Insts
@@ -114,7 +148,7 @@ func compileFunction(f *ir.Function, ra regalloc.Result) (*vm2.Function, error) 
 		if useCount[cmpVid] != 1 {
 			continue
 		}
-		suppressCmp[cmpVid] = true
+		suppress[cmpVid] = true
 		fuseCondBr[last] = cmpVid
 	}
 
@@ -156,10 +190,19 @@ func compileFunction(f *ir.Function, ra regalloc.Result) (*vm2.Function, error) 
 			case ir.OpParam:
 				// Already in canonical reg; nothing to emit.
 			case ir.OpConstI64:
+				if suppress[vid] {
+					break
+				}
 				emit(vm2.Instr{Op: vm2.OpLoadConstI, A: dst, B: cAdd(vm2.CInt(ins.Aux))})
 			case ir.OpConstBool:
 				emit(vm2.Instr{Op: vm2.OpLoadConstI, A: dst, B: cAdd(vm2.CBool(ins.Aux != 0))})
 			case ir.OpAddI64:
+				if info, ok := addK[vid]; ok {
+					emit(vm2.Instr{Op: vm2.OpAddI64K, A: dst,
+						B: int32(finalReg[info.nonConstArg]),
+						C: int32(info.k)})
+					break
+				}
 				emit(vm2.Instr{Op: vm2.OpAddI64, A: dst,
 					B: int32(finalReg[ins.Args[0]]),
 					C: int32(finalReg[ins.Args[1]])})
@@ -180,21 +223,21 @@ func compileFunction(f *ir.Function, ra regalloc.Result) (*vm2.Function, error) 
 					B: int32(finalReg[ins.Args[0]]),
 					C: int32(finalReg[ins.Args[1]])})
 			case ir.OpLessI64:
-				if suppressCmp[vid] {
+				if suppress[vid] {
 					break
 				}
 				emit(vm2.Instr{Op: vm2.OpLessI64, A: dst,
 					B: int32(finalReg[ins.Args[0]]),
 					C: int32(finalReg[ins.Args[1]])})
 			case ir.OpLessEqI64:
-				if suppressCmp[vid] {
+				if suppress[vid] {
 					break
 				}
 				emit(vm2.Instr{Op: vm2.OpLessEqI64, A: dst,
 					B: int32(finalReg[ins.Args[0]]),
 					C: int32(finalReg[ins.Args[1]])})
 			case ir.OpEqualI64:
-				if suppressCmp[vid] {
+				if suppress[vid] {
 					break
 				}
 				emit(vm2.Instr{Op: vm2.OpEqualI64, A: dst,
@@ -210,14 +253,31 @@ func compileFunction(f *ir.Function, ra regalloc.Result) (*vm2.Function, error) 
 					B: int32(ins.Aux),
 					C: int32(callBase), D: int32(len(ins.Args))})
 			case ir.OpTailCall:
-				for i, a := range ins.Args {
-					emit(vm2.Instr{Op: vm2.OpMove,
-						A: int32(callBase + i),
-						B: int32(finalReg[a])})
+				if int(ins.Aux) == selfIdx {
+					// Same-function tail call. Move args directly into
+					// the param slots [0..n) via a parallel-move
+					// schedule, then dispatch OpTailCallSelf which only
+					// rewinds IP. This kills the staging copy + the
+					// dispatch-side memmove that show up in profiles of
+					// loop-heavy programs (every `for` lowers to one of
+					// these). callBase is unused on this path and
+					// serves as the cycle-breaking temp register.
+					moves := make([]pmove, 0, len(ins.Args))
+					for i, a := range ins.Args {
+						moves = append(moves, pmove{dst: int32(i), src: int32(finalReg[a])})
+					}
+					emitParallelMoves(moves, int32(callBase), emit)
+					emit(vm2.Instr{Op: vm2.OpTailCallSelf})
+				} else {
+					for i, a := range ins.Args {
+						emit(vm2.Instr{Op: vm2.OpMove,
+							A: int32(callBase + i),
+							B: int32(finalReg[a])})
+					}
+					emit(vm2.Instr{Op: vm2.OpTailCall,
+						A: int32(ins.Aux),
+						B: int32(callBase), C: int32(len(ins.Args))})
 				}
-				emit(vm2.Instr{Op: vm2.OpTailCall,
-					A: int32(ins.Aux),
-					B: int32(callBase), C: int32(len(ins.Args))})
 			case ir.OpRet:
 				if len(ins.Args) > 0 {
 					emit(vm2.Instr{Op: vm2.OpReturn, A: int32(finalReg[ins.Args[0]])})
@@ -306,4 +366,57 @@ func compileFunction(f *ir.Function, ra regalloc.Result) (*vm2.Function, error) 
 		Code:      code,
 		Consts:    consts,
 	}, nil
+}
+
+// pmove is one entry in a parallel-move schedule: regs[dst] <- regs[src].
+type pmove struct{ dst, src int32 }
+
+// emitParallelMoves lowers a parallel-move set into a serial OpMove
+// sequence that preserves the all-at-once semantics. Trivial src==dst
+// pairs are dropped. The graph is emitted in reverse topological order
+// (a move whose dst is not anyone else's src is safe to emit). Cycles
+// are broken by spilling one src to tempReg and rewriting every
+// in-edge that read it. tempReg must be a register slot not otherwise
+// live across the move sequence.
+func emitParallelMoves(moves []pmove, tempReg int32, emit func(vm2.Instr) int) {
+	out := moves[:0]
+	for _, m := range moves {
+		if m.src != m.dst {
+			out = append(out, m)
+		}
+	}
+	moves = out
+	for len(moves) > 0 {
+		progressed := false
+		for i := 0; i < len(moves); i++ {
+			d := moves[i].dst
+			isSrc := false
+			for j := range moves {
+				if j != i && moves[j].src == d {
+					isSrc = true
+					break
+				}
+			}
+			if !isSrc {
+				emit(vm2.Instr{Op: vm2.OpMove, A: d, B: moves[i].src})
+				moves = append(moves[:i], moves[i+1:]...)
+				progressed = true
+				break
+			}
+		}
+		if progressed {
+			continue
+		}
+		// Only cycles remain. Spill the first move's src to tempReg and
+		// rewrite every consumer of that src so they read tempReg
+		// instead. After this, at least one move's dst is no longer
+		// referenced as a src and the loop makes progress.
+		spillSrc := moves[0].src
+		emit(vm2.Instr{Op: vm2.OpMove, A: tempReg, B: spillSrc})
+		for i := range moves {
+			if moves[i].src == spillSrc {
+				moves[i].src = tempReg
+			}
+		}
+	}
 }

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -6,117 +6,143 @@ import "errors"
 // reset before dispatch; callers that pre-populate it (e.g. tests
 // loading boxed wide ints) must do so after Run starts via a hook in
 // a later step.
+//
+// Hot dispatch state — the current frame's instruction stream, register
+// slab, and IP — is hoisted into locals so the inner loop reads them
+// from CPU registers rather than chasing fr.* through memory on every
+// op. The locals are re-synced on frame transitions (Call / TailCall /
+// Return). This is worth ~5–15% on tight integer loops because the
+// alternative (`fr.Fn.Code[fr.IP]` + `fr.Regs[...]`) costs an extra
+// pointer chase per opcode for every register touch.
 func (vm *VM) Run() (Cell, error) {
 	vm.Objects = vm.Objects[:0]
 	main := vm.Program.Funcs[vm.Program.Main]
 	fr := vm.acquireFrame(main)
+	code := fr.Fn.Code
+	regs := fr.Regs
+	ip := 0
 	var ret Cell
 	for {
-		ins := &fr.Fn.Code[fr.IP]
-		fr.IP++
+		ins := &code[ip]
+		ip++
 		switch ins.Op {
 		case OpLoadConstI:
-			fr.Regs[ins.A] = fr.Fn.Consts[ins.B]
+			regs[ins.A] = fr.Fn.Consts[ins.B]
 		case OpMove:
-			fr.Regs[ins.A] = fr.Regs[ins.B]
+			regs[ins.A] = regs[ins.B]
 		case OpAddI64:
-			fr.Regs[ins.A] = CInt(fr.Regs[ins.B].Int() + fr.Regs[ins.C].Int())
+			regs[ins.A] = CInt(regs[ins.B].Int() + regs[ins.C].Int())
+		case OpAddI64K:
+			regs[ins.A] = CInt(regs[ins.B].Int() + int64(ins.C))
 		case OpSubI64:
-			fr.Regs[ins.A] = CInt(fr.Regs[ins.B].Int() - fr.Regs[ins.C].Int())
+			regs[ins.A] = CInt(regs[ins.B].Int() - regs[ins.C].Int())
 		case OpMulI64:
-			fr.Regs[ins.A] = CInt(fr.Regs[ins.B].Int() * fr.Regs[ins.C].Int())
+			regs[ins.A] = CInt(regs[ins.B].Int() * regs[ins.C].Int())
 		case OpDivI64:
-			d := fr.Regs[ins.C].Int()
+			d := regs[ins.C].Int()
 			if d == 0 {
+				fr.IP = ip
 				return ret, errors.New("vm2: division by zero")
 			}
-			fr.Regs[ins.A] = CInt(fr.Regs[ins.B].Int() / d)
+			regs[ins.A] = CInt(regs[ins.B].Int() / d)
 		case OpModI64:
-			d := fr.Regs[ins.C].Int()
+			d := regs[ins.C].Int()
 			if d == 0 {
+				fr.IP = ip
 				return ret, errors.New("vm2: mod by zero")
 			}
-			fr.Regs[ins.A] = CInt(fr.Regs[ins.B].Int() % d)
+			regs[ins.A] = CInt(regs[ins.B].Int() % d)
 		case OpLessI64:
-			fr.Regs[ins.A] = CBool(fr.Regs[ins.B].Int() < fr.Regs[ins.C].Int())
+			regs[ins.A] = CBool(regs[ins.B].Int() < regs[ins.C].Int())
 		case OpLessEqI64:
-			fr.Regs[ins.A] = CBool(fr.Regs[ins.B].Int() <= fr.Regs[ins.C].Int())
+			regs[ins.A] = CBool(regs[ins.B].Int() <= regs[ins.C].Int())
 		case OpEqualI64:
-			fr.Regs[ins.A] = CBool(fr.Regs[ins.B].Int() == fr.Regs[ins.C].Int())
+			regs[ins.A] = CBool(regs[ins.B].Int() == regs[ins.C].Int())
 		case OpJump:
-			fr.IP = int(ins.A)
+			ip = int(ins.A)
 		case OpJumpIfFalse:
-			if !fr.Regs[ins.A].Bool() {
-				fr.IP = int(ins.B)
+			if !regs[ins.A].Bool() {
+				ip = int(ins.B)
 			}
 		case OpJumpIfLessI64:
-			if fr.Regs[ins.A].Int() < fr.Regs[ins.B].Int() {
-				fr.IP = int(ins.C)
+			if regs[ins.A].Int() < regs[ins.B].Int() {
+				ip = int(ins.C)
 			}
 		case OpJumpIfLessEqI64:
-			if fr.Regs[ins.A].Int() <= fr.Regs[ins.B].Int() {
-				fr.IP = int(ins.C)
+			if regs[ins.A].Int() <= regs[ins.B].Int() {
+				ip = int(ins.C)
 			}
 		case OpJumpIfGreaterI64:
-			if fr.Regs[ins.A].Int() > fr.Regs[ins.B].Int() {
-				fr.IP = int(ins.C)
+			if regs[ins.A].Int() > regs[ins.B].Int() {
+				ip = int(ins.C)
 			}
 		case OpJumpIfGreaterEqI64:
-			if fr.Regs[ins.A].Int() >= fr.Regs[ins.B].Int() {
-				fr.IP = int(ins.C)
+			if regs[ins.A].Int() >= regs[ins.B].Int() {
+				ip = int(ins.C)
 			}
 		case OpJumpIfEqualI64:
-			if fr.Regs[ins.A].Int() == fr.Regs[ins.B].Int() {
-				fr.IP = int(ins.C)
+			if regs[ins.A].Int() == regs[ins.B].Int() {
+				ip = int(ins.C)
 			}
 		case OpJumpIfNotEqualI64:
-			if fr.Regs[ins.A].Int() != fr.Regs[ins.B].Int() {
-				fr.IP = int(ins.C)
+			if regs[ins.A].Int() != regs[ins.B].Int() {
+				ip = int(ins.C)
 			}
 		case OpCall:
 			callee := vm.Program.Funcs[ins.B]
 			newFr := vm.acquireFrame(callee)
 			n := int(ins.D)
-			copy(newFr.Regs[:n], fr.Regs[ins.C:int(ins.C)+n])
+			copy(newFr.Regs[:n], regs[ins.C:int(ins.C)+n])
 			newFr.RetReg = ins.A
 			newFr.Parent = fr
+			fr.IP = ip
 			fr = newFr
+			code = fr.Fn.Code
+			regs = fr.Regs
+			ip = 0
+		case OpTailCallSelf:
+			ip = 0
 		case OpTailCall:
 			callee := vm.Program.Funcs[ins.A]
 			n := int(ins.C)
-			// Args at fr.Regs[B..B+n) never alias params [0..n)
+			// Args at regs[B..B+n) never alias params [0..n)
 			// because emit.go always picks B = callBase = np +
 			// ra.NumRegs, so B >= np >= n. Direct forward copy is
 			// safe; no snapshot needed.
 			if callee == fr.Fn {
-				copy(fr.Regs[:n], fr.Regs[ins.B:int(ins.B)+n])
-				fr.IP = 0
+				copy(regs[:n], regs[ins.B:int(ins.B)+n])
+				ip = 0
 			} else {
 				parent := fr.Parent
 				retReg := fr.RetReg
-				// Acquire the new frame before releasing the old
-				// one so the source and destination Regs are
-				// guaranteed-distinct slices; only then release.
 				newFr := vm.acquireFrame(callee)
-				copy(newFr.Regs[:n], fr.Regs[ins.B:int(ins.B)+n])
+				copy(newFr.Regs[:n], regs[ins.B:int(ins.B)+n])
 				vm.releaseFrame(fr)
 				newFr.RetReg = retReg
 				newFr.Parent = parent
 				fr = newFr
+				code = fr.Fn.Code
+				regs = fr.Regs
+				ip = 0
 			}
 		case OpReturn:
-			ret = fr.Regs[ins.A]
+			ret = regs[ins.A]
 			retReg := fr.RetReg
 			parent := fr.Parent
 			vm.releaseFrame(fr)
 			if parent == nil {
 				return ret, nil
 			}
-			parent.Regs[retReg] = ret
 			fr = parent
+			code = fr.Fn.Code
+			regs = fr.Regs
+			ip = fr.IP
+			regs[retReg] = ret
 		case OpHalt:
+			fr.IP = ip
 			return ret, errors.New("vm2: OpHalt reached")
 		default:
+			fr.IP = ip
 			return ret, errors.New("vm2: unknown opcode")
 		}
 	}

--- a/runtime/vm2/ops.go
+++ b/runtime/vm2/ops.go
@@ -10,6 +10,12 @@ const (
 	OpLoadConstI            // A = Consts[B]
 	OpMove                  // A = B
 	OpAddI64                // A = B + C (signed 48-bit; overflow is implementation-defined)
+	// A = B + sign-extend(C). Fuses an OpLoadConstI of a 32-bit-fitting
+	// integer immediately followed by an OpAddI64 that consumes it as
+	// its only use. Saves one dispatch + one const-pool load per loop
+	// step counter (e.g. `i = i + 1` lowers to one of these instead of
+	// load-const-then-add).
+	OpAddI64K
 	OpSubI64                // A = B - C
 	OpMulI64                // A = B * C
 	OpDivI64                // A = B / C (truncated; division by zero traps)
@@ -33,5 +39,11 @@ const (
 	OpJumpIfNotEqualI64  // if A != B then IP = C
 	OpCall                  // A = call Funcs[B], args [C..C+D); RetReg=A
 	OpTailCall              // tail-call Funcs[A] with args [B..B+C); reuses frame
-	OpReturn                // return A to caller's RetReg
+	// Same-function tail call. Params already live in regs[0..np) thanks
+	// to parallel moves the emitter inserted into the param slots, so
+	// the dispatch handler just rewinds IP. No frame swap, no memmove,
+	// no callee lookup. Hot self-recursion loops (every `for` lowered
+	// to a tail-recursive helper) go through this path.
+	OpTailCallSelf
+	OpReturn // return A to caller's RetReg
 )

--- a/website/docs/mep/mep-0023.md
+++ b/website/docs/mep/mep-0023.md
@@ -187,6 +187,30 @@ Landed in this delta:
 
 Headline movement vs the floor: vm2 vs Lua tightened from **3.0x – 5.1x** to **1.7x – 3.5x** (geomean ~2.8x). vs CPython, vm2 is now faster on every loop-heavy program in this slice and within ~1.5x on every recursive one.
 
+##### Round 2 (eval-loop and tail-call codegen)
+
+| Program       |     N | vm2 (µs) | CPython (µs) | Lua (µs) | vm2 / CPython | vm2 / Lua |
+|---------------|------:|---------:|-------------:|---------:|--------------:|----------:|
+| `fact_rec`    |    10 |      615 |          492 |      208 |         1.25x |     2.96x |
+| `fact_rec`    |    13 |      751 |          600 |      250 |         1.25x |     3.00x |
+| `fib_iter`    |    10 |      186 |          254 |      119 |         0.73x |     1.56x |
+| `fib_iter`    |    20 |      270 |          502 |      210 |         0.54x |     1.29x |
+| `fib_rec`     |    15 |      103 |           75 |       36 |         1.38x |     2.86x |
+| `fib_rec`     |    20 |    1,157 |          880 |      413 |         1.31x |     2.80x |
+| `mul_loop`    |    10 |      170 |          336 |       76 |         0.51x |     2.24x |
+| `mul_loop`    |    13 |      200 |          354 |       89 |         0.56x |     2.25x |
+| `prime_count` |    50 |      822 |        1,373 |      396 |         0.60x |     2.08x |
+| `prime_count` |   100 |    2,393 |        3,851 |    1,190 |         0.62x |     2.01x |
+| `sum_loop`    | 1,000 |    8,609 |       23,547 |    5,200 |         0.37x |     1.66x |
+| `sum_loop`    | 10,000 |  83,678 |      240,766 |   52,795 |         0.35x |     1.58x |
+
+Landed in this round:
+- **Hoist dispatch state into locals in `eval.go`.** `fr.Fn.Code`, `fr.Regs`, and `fr.IP` are kept in named locals (`code`, `regs`, `ip`) across the dispatch loop and only synced back to the frame on Call / TailCall / Return / error. Removes one pointer chase per register touch; ~20% across the suite.
+- **`OpTailCallSelf` + parallel-move codegen for same-fn tail calls.** Before: emit staged args into a scratch range above the regalloc window, then `OpTailCall` did a `runtime.memmove` of the args into `[0..n)`. Profiles showed that memmove was 15.6% of total CPU on `sum_loop` — every loop iteration was paying for a copy that included the *unchanged* loop bound. After: the emitter runs a parallel-move scheduler that emits direct `OpMove`s into the param slots (dropping `src==dst` entries and breaking cycles via the otherwise-unused `callBase` register), then dispatches the trivial `OpTailCallSelf` which only rewinds IP. Cross-fn tail calls keep the staging path. ~2x on `sum_loop`.
+- **`OpAddI64K` (add-immediate) superinstruction.** The emitter detects `AddI64` whose operand is a single-use `ConstI64` fitting `int32` and fuses both into one dispatch — the loop-counter step (`i = i + 1`) was the highest-volume `OpLoadConstI` consumer. ~15% on `sum_loop`.
+
+Headline movement vs the floor: vm2 vs Lua tightened to **1.3x – 3.0x** across the slice (geomean ~2.0x). `fib_iter` and `sum_loop` are within ~1.3x – 1.6x of Lua; `prime_count` and `mul_loop` are ~2x; the recursive `fib_rec`/`fact_rec` programs are still ~3x because each non-tail call goes through a fresh frame acquisition. vs CPython, vm2 is now **1.4x – 2.9x faster** on every iterative program in the slice (sum_loop is `0.35x` CPython = 2.86x faster).
+
 ## Rationale
 
 **Why a new MEP, not an edit to MEP 17.** MEP 17 is a process gate. Folding cross-language reporting into it would either weaken the per-PR rule (peer runtime variance is too high to gate on) or strengthen the cross-language rule into a gate (an over-commitment given how many factors outside the VM author's control move those numbers). Separate documents, separate cadences, no confusion.


### PR DESCRIPTION
Closes #21511. Continues the work from #21510.

## Summary
- Hoist dispatch state in `eval.go` (`code`, `regs`, `ip` as locals across the dispatch loop; sync back to frame only at Call / TailCall / Return / error). One pointer chase saved per register touch.
- Add `OpTailCallSelf` and a parallel-move scheduler in `emit.go` for same-fn tail calls. Eliminates the staging+memmove that profiles flagged as 15.6% of total CPU on `sum_loop`.
- Add `OpAddI64K` (add-immediate). emit fuses `AddI64` with a single-use `ConstI64` arg (int32-bounded) into one dispatch, killing the per-iteration `OpLoadConstI` for loop counters.
- MEP-23 gets a "Round 2" subsection recording the new table.

## Numbers (cross-language sweep, vs MEP-23 floor)
- vm2 vs Lua: `sum_loop` **5.0x -> 1.58x**, `fib_iter` **4.57x -> 1.29x**, `prime_count` **3.73x -> 2.01x**.
- vm2 vs CPython: **1.4x - 2.9x faster** on every iterative program (sum_loop now 0.35x CPython).

## Test plan
- [x] `go build ./...`
- [x] `go test -run TestCorpusMatchesOracle ./runtime/vm2/bench/...` (every corpus program matches its Go oracle)
- [x] `go test -bench . -benchtime=200ms ./runtime/vm2/bench/...` (per-iteration time down across the board)
- [x] `go run ./bench/crosslang` (output column matches across vm2/CPython/Lua for every row)