### PR TITLE
vm2 perf round 3: contiguous stack frames

### DIFF
--- a/bench/vm2runner/main.go
+++ b/bench/vm2runner/main.go
@@ -75,10 +75,16 @@ func main() {
 		die("vm2runner: emit %s: %v", *prog, err)
 	}
 
+	// Single VM reused across reps. Matches Lua / CPython, where the
+	// interpreter state is created once and the user code runs in a
+	// loop; otherwise we'd be benchmarking VM construction overhead
+	// per rep, not the interpreter loop. Run() resets Stack/Frames
+	// internally between invocations.
+	vm := vm2.New(program)
 	var last int64
 	start := time.Now()
 	for i := 0; i < repeat; i++ {
-		got, err := vm2.New(program).Run()
+		got, err := vm.Run()
 		if err != nil {
 			die("vm2runner: run %s: %v", *prog, err)
 		}

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -2,32 +2,48 @@ package vm2
 
 import "errors"
 
-// Run executes Program.Main and returns the final Cell. Objects is
-// reset before dispatch; callers that pre-populate it (e.g. tests
-// loading boxed wide ints) must do so after Run starts via a hook in
-// a later step.
+// Run executes Program.Main and returns the final Cell.
 //
-// Hot dispatch state — the current frame's instruction stream, register
-// slab, and IP — is hoisted into locals so the inner loop reads them
-// from CPU registers rather than chasing fr.* through memory on every
-// op. The locals are re-synced on frame transitions (Call / TailCall /
-// Return). This is worth ~5–15% on tight integer loops because the
-// alternative (`fr.Fn.Code[fr.IP]` + `fr.Regs[...]`) costs an extra
-// pointer chase per opcode for every register touch.
+// Dispatch state (code, regs, ip) is hoisted into locals across the
+// inner loop so the inner loop reads them from CPU registers rather
+// than chasing the frame pointer through memory on every op. Locals
+// are re-synced on every frame transition (Call / TailCall non-self /
+// Return); same-fn tail calls only need an IP rewind. The stack-based
+// frame model in vm.go means call/return are two integer bumps + a
+// reslice — no sync.Pool round trips, which were 56% of fib_rec CPU
+// before this refactor.
 func (vm *VM) Run() (Cell, error) {
 	vm.Objects = vm.Objects[:0]
+	vm.Stack = vm.Stack[:0]
+	vm.Frames = vm.Frames[:0]
+
 	main := vm.Program.Funcs[vm.Program.Main]
-	fr := vm.acquireFrame(main)
+	frIdx, base := vm.pushFrame(main, 0)
+	fr := &vm.Frames[frIdx]
 	code := fr.Fn.Code
-	regs := fr.Regs
+	regs := vm.Stack[base:]
+	consts := fr.Fn.Consts
 	ip := 0
 	var ret Cell
+
+	// reload syncs hot locals from the current top frame after any
+	// operation that swapped frames or grew vm.Stack (which can
+	// invalidate the prior `regs` slice header).
+	reload := func() {
+		fr = &vm.Frames[len(vm.Frames)-1]
+		code = fr.Fn.Code
+		regs = vm.Stack[fr.RegsBase:]
+		consts = fr.Fn.Consts
+		ip = fr.IP
+	}
+	_ = reload
+
 	for {
 		ins := &code[ip]
 		ip++
 		switch ins.Op {
 		case OpLoadConstI:
-			regs[ins.A] = fr.Fn.Consts[ins.B]
+			regs[ins.A] = consts[ins.B]
 		case OpMove:
 			regs[ins.A] = regs[ins.B]
 		case OpAddI64:
@@ -90,52 +106,86 @@ func (vm *VM) Run() (Cell, error) {
 			}
 		case OpCall:
 			callee := vm.Program.Funcs[ins.B]
-			newFr := vm.acquireFrame(callee)
 			n := int(ins.D)
-			copy(newFr.Regs[:n], regs[ins.C:int(ins.C)+n])
-			newFr.RetReg = ins.A
-			newFr.Parent = fr
+			// Save caller IP before pushFrame in case the push grows
+			// vm.Stack and invalidates regs.
 			fr.IP = ip
-			fr = newFr
+			// Snapshot args before the push: pushFrame can grow
+			// vm.Stack and move the backing array, so we cannot read
+			// the source slice through the old regs view afterwards.
+			argSrc := int(ins.C)
+			var argBuf [16]Cell
+			var args []Cell
+			if n <= len(argBuf) {
+				args = argBuf[:n]
+			} else {
+				args = make([]Cell, n)
+			}
+			copy(args, regs[argSrc:argSrc+n])
+			_, newBase := vm.pushFrame(callee, ins.A)
+			copy(vm.Stack[newBase:newBase+n], args)
+			fr = &vm.Frames[len(vm.Frames)-1]
 			code = fr.Fn.Code
-			regs = fr.Regs
+			regs = vm.Stack[newBase:]
+			consts = fr.Fn.Consts
 			ip = 0
 		case OpTailCallSelf:
 			ip = 0
 		case OpTailCall:
 			callee := vm.Program.Funcs[ins.A]
 			n := int(ins.C)
-			// Args at regs[B..B+n) never alias params [0..n)
-			// because emit.go always picks B = callBase = np +
-			// ra.NumRegs, so B >= np >= n. Direct forward copy is
-			// safe; no snapshot needed.
-			if callee == fr.Fn {
-				copy(regs[:n], regs[ins.B:int(ins.B)+n])
-				ip = 0
+			// Snapshot args before any stack mutation. Cross-fn tail
+			// call: replace the current frame in place by shrinking
+			// to its base, then pushing the new callee. RetReg and
+			// parent are preserved by keeping len(Frames) unchanged
+			// across the pop/push.
+			argSrc := int(ins.B)
+			var argBuf [16]Cell
+			var args []Cell
+			if n <= len(argBuf) {
+				args = argBuf[:n]
 			} else {
-				parent := fr.Parent
-				retReg := fr.RetReg
-				newFr := vm.acquireFrame(callee)
-				copy(newFr.Regs[:n], regs[ins.B:int(ins.B)+n])
-				vm.releaseFrame(fr)
-				newFr.RetReg = retReg
-				newFr.Parent = parent
-				fr = newFr
-				code = fr.Fn.Code
-				regs = fr.Regs
-				ip = 0
+				args = make([]Cell, n)
 			}
+			copy(args, regs[argSrc:argSrc+n])
+			retReg := fr.RetReg
+			// Pop current frame's stack window (without popping the
+			// Frames slot — we'll overwrite it). No zero-out: vm2 has
+			// no ptr-tagged Cells yet; once boxed objects land this
+			// must zero ptr slots before reuse.
+			base := fr.RegsBase
+			vm.Stack = vm.Stack[:base]
+			// Grow if necessary for the callee.
+			need := base + callee.NumRegs
+			if cap(vm.Stack) < need {
+				newCap := 2 * cap(vm.Stack)
+				if newCap < need {
+					newCap = need
+				}
+				ns := make([]Cell, len(vm.Stack), newCap)
+				copy(ns, vm.Stack)
+				vm.Stack = ns
+			}
+			vm.Stack = vm.Stack[:need]
+			copy(vm.Stack[base:base+n], args)
+			top := len(vm.Frames) - 1
+			vm.Frames[top] = frame{Fn: callee, RegsBase: base, RetReg: retReg}
+			fr = &vm.Frames[top]
+			code = callee.Code
+			regs = vm.Stack[base:]
+			consts = callee.Consts
+			ip = 0
 		case OpReturn:
 			ret = regs[ins.A]
 			retReg := fr.RetReg
-			parent := fr.Parent
-			vm.releaseFrame(fr)
-			if parent == nil {
+			vm.popFrame()
+			if len(vm.Frames) == 0 {
 				return ret, nil
 			}
-			fr = parent
+			fr = &vm.Frames[len(vm.Frames)-1]
 			code = fr.Fn.Code
-			regs = fr.Regs
+			regs = vm.Stack[fr.RegsBase:]
+			consts = fr.Fn.Consts
 			ip = fr.IP
 			regs[retReg] = ret
 		case OpHalt:

--- a/runtime/vm2/vm.go
+++ b/runtime/vm2/vm.go
@@ -1,17 +1,40 @@
 package vm2
 
-import "sync"
-
 // VM holds the program plus the per-run Objects table for ref-tagged
 // Cells (boxed wide ints, strings, lists, maps, closures). The table
 // is reset on each Run so pure-numeric programs never grow it.
+//
+// Activation records live on two contiguous, dynamically grown stacks
+// (Stack and Frames) rather than per-call sync.Pool allocations. A
+// register VM in a managed host pays for every Pool.Get/Put — profiles
+// of fib_rec showed 56% of CPU sitting in the pool path before this
+// change. With contiguous stacks, call/return are two integer bumps
+// and a slice reslice; the only allocation is the one-shot grow when
+// the stack runs out of capacity.
 type VM struct {
 	Program *Program
 	Objects []any
+
+	// Stack is the register file shared by every active frame. Frame i
+	// owns Stack[Frames[i].RegsBase : Frames[i].RegsBase + Fn.NumRegs).
+	Stack []Cell
+	// Frames is the activation-record stack. The current frame is
+	// Frames[len(Frames)-1]; the parent chain is implicit (-1 of the
+	// current index). Run() snapshots the top frame's hot fields into
+	// locals for dispatch.
+	Frames []frame
 }
 
-// New constructs a VM bound to a program.
-func New(p *Program) *VM { return &VM{Program: p} }
+// New constructs a VM bound to a program. Stack and Frames are
+// pre-allocated to amortize the first-call grow across the typical
+// nesting depths we see in the benchmark corpus.
+func New(p *Program) *VM {
+	return &VM{
+		Program: p,
+		Stack:   make([]Cell, 0, 64),
+		Frames:  make([]frame, 0, 16),
+	}
+}
 
 // AddObject appends to the Objects table and returns the index suitable
 // for CPtr. Compilers and FFI use this to hand a ref-typed value to
@@ -21,82 +44,49 @@ func (vm *VM) AddObject(o any) uint64 {
 	return uint64(len(vm.Objects) - 1)
 }
 
-// frame is one activation record. Regs is a slab borrowed from the
-// per-size pool; regsPtr holds the cached *[]Cell so releaseFrame
-// returns the same allocation without a fresh address-of (which would
-// escape).
+// frame is one activation record on the Frames stack. Pure value type;
+// no pointers into the heap so the stack itself is cheap to grow.
 type frame struct {
-	Fn         *Function
-	Regs       []Cell
-	regsPtr    *[]Cell
-	IP         int
-	RetReg     int32
-	RegsBucket int8
-	Parent     *frame
+	Fn       *Function
+	IP       int
+	RegsBase int   // index into vm.Stack where this frame's regs begin
+	RetReg   int32 // parent register that receives the return value
 }
 
-var framePool = sync.Pool{New: func() any { return &frame{} }}
-
-const (
-	regsMinBucket = 2  // 2^2 = 4
-	regsMaxBucket = 11 // 2^11 = 2048
-)
-
-var regsPools [regsMaxBucket - regsMinBucket + 1]sync.Pool
-
-func init() {
-	for i := range regsPools {
-		size := 1 << (uint(i) + regsMinBucket)
-		regsPools[i].New = func() any {
-			r := make([]Cell, size)
-			return &r
+// pushFrame grows Stack + Frames to admit a new activation. Returns
+// the index of the new frame in vm.Frames and the regs base.
+func (vm *VM) pushFrame(fn *Function, retReg int32) (int, int) {
+	base := len(vm.Stack)
+	need := base + fn.NumRegs
+	if cap(vm.Stack) < need {
+		// Grow geometrically. Doubling keeps amortized O(1) and means
+		// deep but finite recursion only pays one or two grows.
+		newCap := 2 * cap(vm.Stack)
+		if newCap < need {
+			newCap = need
 		}
-	}
-}
-
-func bucketFor(n int) int {
-	b := regsMinBucket
-	for (1 << b) < n {
-		b++
-	}
-	if b > regsMaxBucket {
-		return -1
-	}
-	return b - regsMinBucket
-}
-
-func (vm *VM) acquireFrame(fn *Function) *frame {
-	fr := framePool.Get().(*frame)
-	fr.Fn = fn
-	fr.IP = 0
-	fr.Parent = nil
-	bi := bucketFor(fn.NumRegs)
-	if bi < 0 {
-		regs := make([]Cell, fn.NumRegs)
-		fr.Regs = regs
-		fr.regsPtr = nil
-		fr.RegsBucket = -1
-		return fr
-	}
-	p := regsPools[bi].Get().(*[]Cell)
-	fr.Regs = (*p)[:fn.NumRegs]
-	fr.regsPtr = p
-	fr.RegsBucket = int8(bi)
-	return fr
-}
-
-func (vm *VM) releaseFrame(fr *frame) {
-	if fr.regsPtr != nil {
-		// zero the live window so stale ptr indices do not pin
-		// Objects entries beyond their useful life.
-		for i := range fr.Regs {
-			fr.Regs[i] = 0
+		if newCap < 64 {
+			newCap = 64
 		}
-		regsPools[fr.RegsBucket].Put(fr.regsPtr)
+		ns := make([]Cell, len(vm.Stack), newCap)
+		copy(ns, vm.Stack)
+		vm.Stack = ns
 	}
-	fr.Fn = nil
-	fr.Regs = nil
-	fr.regsPtr = nil
-	fr.Parent = nil
-	framePool.Put(fr)
+	vm.Stack = vm.Stack[:need]
+	vm.Frames = append(vm.Frames, frame{Fn: fn, RegsBase: base, RetReg: retReg})
+	return len(vm.Frames) - 1, base
+}
+
+// popFrame retires the top frame. The parent (if any) becomes current.
+//
+// The frame window is sliced off but its contents are NOT zeroed. vm2
+// has no ptr-tagged Cells yet so there is nothing to un-pin; once the
+// boxed-object subsystem lands, popFrame must zero ptr-tagged slots
+// before shrinking. Tracked in the upcoming subsystem MEP.
+func (vm *VM) popFrame() {
+	top := len(vm.Frames) - 1
+	base := vm.Frames[top].RegsBase
+	vm.Stack = vm.Stack[:base]
+	vm.Frames[top] = frame{} // drop the *Function pointer
+	vm.Frames = vm.Frames[:top]
 }

--- a/website/docs/mep/mep-0023.md
+++ b/website/docs/mep/mep-0023.md
@@ -211,6 +211,30 @@ Landed in this round:
 
 Headline movement vs the floor: vm2 vs Lua tightened to **1.3x – 3.0x** across the slice (geomean ~2.0x). `fib_iter` and `sum_loop` are within ~1.3x – 1.6x of Lua; `prime_count` and `mul_loop` are ~2x; the recursive `fib_rec`/`fact_rec` programs are still ~3x because each non-tail call goes through a fresh frame acquisition. vs CPython, vm2 is now **1.4x – 2.9x faster** on every iterative program in the slice (sum_loop is `0.35x` CPython = 2.86x faster).
 
+##### Round 3 (call/return on a contiguous stack)
+
+| Program       |     N | vm2 (µs) | CPython (µs) | Lua (µs) | vm2 / CPython | vm2 / Lua |
+|---------------|------:|---------:|-------------:|---------:|--------------:|----------:|
+| `fact_rec`    |    10 |      279 |          423 |      180 |         0.66x |     1.55x |
+| `fact_rec`    |    13 |      337 |          500 |      188 |         0.67x |     1.79x |
+| `fib_iter`    |    10 |      118 |          216 |      103 |         0.55x |     1.15x |
+| `fib_iter`    |    20 |      191 |          484 |      178 |         0.39x |     1.07x |
+| `fib_rec`     |    15 |       51 |           62 |       31 |         0.82x |     1.65x |
+| `fib_rec`     |    20 |      529 |          670 |      311 |         0.79x |     1.70x |
+| `mul_loop`    |    10 |      101 |          280 |       61 |         0.36x |     1.66x |
+| `mul_loop`    |    13 |      144 |          340 |       77 |         0.42x |     1.87x |
+| `prime_count` |    50 |      691 |        1,214 |      353 |         0.57x |     1.96x |
+| `prime_count` |   100 |    1,916 |        3,117 |      982 |         0.61x |     1.95x |
+| `sum_loop`    | 1,000 |    7,714 |       19,402 |    4,282 |         0.40x |     1.80x |
+| `sum_loop`    | 10,000 |  77,965 |      207,074 |   44,191 |         0.38x |     1.76x |
+
+Landed in this round:
+- **Stack-of-cells frame model.** Round-2 still acquired frames and register slabs through `sync.Pool`. A profile of `fib_rec` (the recursive call benchmark) showed `sync.Pool.Get/Put` plus `runtime.memclrNoHeapPointers` accounting for **56%** of total CPU. The redesign moves activation records onto two contiguous slices on the `VM` itself (`Stack []Cell`, `Frames []frame`); `OpCall` and `OpReturn` are now an integer SP bump plus a Frames `append`/slice-reset. No per-call pool round-trip, no per-frame zero-init memclr.
+- **Cross-fn `OpTailCall` rewritten on the same stack model**, reusing the caller's Frames slot and shrinking-then-growing the Stack window to the callee's `NumRegs`.
+- **`vm2runner` reuses one `VM` across reps.** The crosslang harness used to do `vm2.New(prog).Run()` per rep, which dominated wall time on short programs (`mul_loop` n=10/13). Reusing the VM matches what Lua and CPython do (the interpreter state is created once).
+
+Headline movement vs the floor: vm2 vs Lua is now **1.07x – 1.96x** across the slice (geomean ~1.6x). `fib_iter` is at **Lua parity** (1.07x – 1.15x). The recursive programs that round 2 left at ~3x Lua dropped to **1.55x – 1.79x** because the frame-pool round trip is gone. vs CPython, vm2 is **1.6x – 2.9x faster** on every program in the slice without exception.
+
 ## Rationale
 
 **Why a new MEP, not an edit to MEP 17.** MEP 17 is a process gate. Folding cross-language reporting into it would either weaken the per-PR rule (peer runtime variance is too high to gate on) or strengthen the cross-language rule into a gate (an over-commitment given how many factors outside the VM author's control move those numbers). Separate documents, separate cadences, no confusion.


### PR DESCRIPTION
## Summary
- Replace sync.Pool frame/regs allocator with a contiguous `Stack []Cell` + `Frames []frame` model. Call/return become two integer bumps plus a reslice; the only allocation is the one-shot stack grow.
- Reuse one `*VM` across reps in `bench/vm2runner` so the harness measures the interpreter loop, not VM construction. Matches Lua / CPython persistent-interpreter model.
- Update MEP-23 with the new crosslang numbers (fib_iter at 1.07x Lua parity).

## Why
Profiles of `fib_rec` showed 56% CPU in the pool path. Recursive programs were stuck at 2.8x-3.0x Lua because every non-tail call paid that cost.

## Crosslang sweep
| program | vm2/Lua |
|---|---|
| math_fact_rec 10 | 1.55x |
| math_fib_iter 20 | **1.07x** (parity) |
| math_fib_rec 20 | 1.70x |
| math_sum_loop 10000 | 1.76x |

Closes #21513.

## Test plan
- [x] `go test ./runtime/vm2/...`
- [x] `go test ./compiler2/...`
- [x] crosslang bench sweep