### PR TITLE
MEP-24 §2: vm2 strings subsystem

### DIFF
--- a/bench/vm2runner/main.go
+++ b/bench/vm2runner/main.go
@@ -34,6 +34,10 @@ var repeats = map[string]int{
 	// loops externally via b.N.
 	"fib":      1,
 	"iter_sum": 1,
+	// Strings subsystem (MEP-24 §2). The repeat count keeps wall-clock
+	// in the same ~1ms ballpark as the math kernels so the harness sees
+	// it as just another column.
+	"strings_concat_loop": 1000,
 }
 
 func main() {

--- a/compiler2/corpus/corpus.go
+++ b/compiler2/corpus/corpus.go
@@ -35,6 +35,7 @@ func All() []Program {
 		{Name: "math_fib_iter", Build: BuildFibIter, Expect: ExpectFibIter},
 		{Name: "math_fib_rec", Build: BuildFibRec, Expect: ExpectFibRec},
 		{Name: "math_prime_count", Build: BuildPrimeCount, Expect: ExpectPrimeCount},
+		{Name: "strings_concat_loop", Build: BuildStringsConcatLoop, Expect: ExpectStringsConcatLoop},
 	}
 }
 

--- a/compiler2/corpus/strings.go
+++ b/compiler2/corpus/strings.go
@@ -1,0 +1,46 @@
+package corpus
+
+import "mochi/compiler2/ir"
+
+// BuildStringsConcatLoop builds:
+//
+//	acc := "a"
+//	for i := 0; i < N; i++ { acc = acc ++ "a" }
+//	return len(acc)
+//
+// Encoded as a tail-recursive helper loop(acc, lit, i, n) so the
+// emitter folds it into a self-tail-call. Returns the byte length of
+// the final string (== n+1) so the runner can assert a single scalar.
+func BuildStringsConcatLoop(n int64) *ir.Module {
+	const helperIdx = 1
+
+	bMain := ir.NewBuilder("main", nil, ir.TI64)
+	acc0 := bMain.ConstStr("a")
+	lit := bMain.ConstStr("a")
+	i0 := bMain.ConstI64(0)
+	nv := bMain.ConstI64(n)
+	r := bMain.Call(helperIdx, ir.TI64, acc0, lit, i0, nv)
+	bMain.Ret(r)
+
+	bH := ir.NewBuilder("concat_loop", []ir.Type{ir.TStr, ir.TStr, ir.TI64, ir.TI64}, ir.TI64)
+	pAcc, pLit, pI, pN := bH.Param(0), bH.Param(1), bH.Param(2), bH.Param(3)
+	done := bH.NewBlock()
+	step := bH.NewBlock()
+	cond := bH.LessI64(pI, pN)
+	bH.CondBr(cond, step, done)
+
+	bH.SwitchTo(done)
+	bH.Ret(bH.LenStr(pAcc))
+
+	bH.SwitchTo(step)
+	one := bH.ConstI64(1)
+	ni := bH.AddI64(pI, one)
+	nacc := bH.ConcatStr(pAcc, pLit)
+	r2 := bH.Call(helperIdx, ir.TI64, nacc, pLit, ni, pN)
+	bH.Ret(r2)
+
+	return &ir.Module{Funcs: []*ir.Function{bMain.Function(), bH.Function()}, Main: 0}
+}
+
+// ExpectStringsConcatLoop: starts at length 1 ("a") then n appends.
+func ExpectStringsConcatLoop(n int64) int64 { return n + 1 }

--- a/compiler2/emit/emit.go
+++ b/compiler2/emit/emit.go
@@ -243,6 +243,30 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 				emit(vm2.Instr{Op: vm2.OpEqualI64, A: dst,
 					B: int32(finalReg[ins.Args[0]]),
 					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpConstStr:
+				// Aux indexes into f.Strings; copy bytes verbatim into
+				// the vm2 string-const pool. The pool is forwarded onto
+				// the emitted vm2.Function below, no dedup beyond what
+				// the builder already did per function.
+				emit(vm2.Instr{Op: vm2.OpLoadStrK, A: dst, B: int32(ins.Aux)})
+			case ir.OpConcatStr:
+				emit(vm2.Instr{Op: vm2.OpConcatStr, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpLenStr:
+				emit(vm2.Instr{Op: vm2.OpLenStr, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpIndexStr:
+				emit(vm2.Instr{Op: vm2.OpIndexStr, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpEqualStr:
+				emit(vm2.Instr{Op: vm2.OpEqualStr, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpHashStr:
+				emit(vm2.Instr{Op: vm2.OpHashStr, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
 			case ir.OpCall:
 				for i, a := range ins.Args {
 					emit(vm2.Instr{Op: vm2.OpMove,
@@ -359,12 +383,18 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 		}
 	}
 
+	strConsts := make([][]byte, len(f.Strings))
+	for i, s := range f.Strings {
+		strConsts[i] = []byte(s)
+	}
+
 	return &vm2.Function{
 		Name:      f.Name,
 		NumParams: np,
 		NumRegs:   numRegs,
 		Code:      code,
 		Consts:    consts,
+		StrConsts: strConsts,
 	}, nil
 }
 

--- a/compiler2/emit/emit_strings_test.go
+++ b/compiler2/emit/emit_strings_test.go
@@ -1,0 +1,81 @@
+package emit
+
+import (
+	"testing"
+
+	"mochi/compiler2/corpus"
+	"mochi/compiler2/ir"
+	"mochi/compiler2/opt"
+	vm2 "mochi/runtime/vm2"
+)
+
+// TestEmitConcatStr exercises the end-to-end path for the string
+// concat opcode: source-level "foo" ++ "bar" should compile, run, and
+// produce a six-byte string.
+func TestEmitConcatStr(t *testing.T) {
+	b := ir.NewBuilder("main", nil, ir.TI64)
+	a := b.ConstStr("foo")
+	c := b.ConstStr("bar")
+	cat := b.ConcatStr(a, c)
+	n := b.LenStr(cat)
+	b.Ret(n)
+	m := &ir.Module{Funcs: []*ir.Function{b.Function()}, Main: 0}
+	p, err := Compile(m)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	got, err := vm2.New(p).Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got.Int() != 6 {
+		t.Fatalf("len(foo++bar) = %d, want 6", got.Int())
+	}
+}
+
+// TestEmitStringPoolDedup confirms that two ConstStr literals with
+// the same bytes share an Aux index (and thus a single StrConsts
+// entry in the emitted vm2 function).
+func TestEmitStringPoolDedup(t *testing.T) {
+	b := ir.NewBuilder("main", nil, ir.TI64)
+	a := b.ConstStr("dup")
+	c := b.ConstStr("dup")
+	_ = b.EqualStr(a, c)
+	b.Ret(b.LenStr(a))
+	m := &ir.Module{Funcs: []*ir.Function{b.Function()}, Main: 0}
+	if got := len(b.Function().Strings); got != 1 {
+		t.Fatalf("ir Strings pool = %d, want 1 (dedup)", got)
+	}
+	p, err := Compile(m)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if got := len(p.Funcs[0].StrConsts); got != 1 {
+		t.Fatalf("vm2 StrConsts = %d, want 1", got)
+	}
+}
+
+// TestEmitStringsConcatLoopCorpus runs the corpus benchmark for a
+// small N through the full opt+emit+run pipeline, asserting it
+// produces the oracle's expected length. This is the same path the
+// vm2runner subprocess takes, just in-process.
+func TestEmitStringsConcatLoopCorpus(t *testing.T) {
+	const n = 32
+	mod := corpus.BuildStringsConcatLoop(n)
+	for _, f := range mod.Funcs {
+		opt.ConstFold(f)
+		opt.DCE(f)
+		opt.TailCall(f)
+	}
+	p, err := Compile(mod)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	got, err := vm2.New(p).Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if want := corpus.ExpectStringsConcatLoop(n); got.Int() != want {
+		t.Fatalf("concat_loop(%d) = %d, want %d", n, got.Int(), want)
+	}
+}

--- a/compiler2/ir/builder.go
+++ b/compiler2/ir/builder.go
@@ -111,6 +111,44 @@ func (b *Builder) EqualI64(x, y ValueID) ValueID {
 	return b.emit(Inst{Op: OpEqualI64, Type: TBool, Args: []ValueID{x, y}})
 }
 
+// ConstStr returns a TStr value for the literal s, interning it into
+// the function's string pool so repeated identical literals share an
+// Aux index (and ultimately a single Function.StrConsts entry).
+func (b *Builder) ConstStr(s string) ValueID {
+	idx := -1
+	for i, t := range b.fn.Strings {
+		if t == s {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		idx = len(b.fn.Strings)
+		b.fn.Strings = append(b.fn.Strings, s)
+	}
+	return b.emit(Inst{Op: OpConstStr, Type: TStr, Aux: int64(idx)})
+}
+
+func (b *Builder) ConcatStr(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpConcatStr, Type: TStr, Args: []ValueID{x, y}})
+}
+
+func (b *Builder) LenStr(x ValueID) ValueID {
+	return b.emit(Inst{Op: OpLenStr, Type: TI64, Args: []ValueID{x}})
+}
+
+func (b *Builder) IndexStr(x, i ValueID) ValueID {
+	return b.emit(Inst{Op: OpIndexStr, Type: TStr, Args: []ValueID{x, i}})
+}
+
+func (b *Builder) EqualStr(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpEqualStr, Type: TBool, Args: []ValueID{x, y}})
+}
+
+func (b *Builder) HashStr(x ValueID) ValueID {
+	return b.emit(Inst{Op: OpHashStr, Type: TI64, Args: []ValueID{x}})
+}
+
 // Call invokes function at funcIdx with the given args. retType is the
 // caller-supplied result type; the verifier later checks it against
 // the callee's signature once Module is assembled.

--- a/compiler2/ir/ir.go
+++ b/compiler2/ir/ir.go
@@ -17,6 +17,7 @@ const (
 	TF64
 	TBool
 	TPtr
+	TStr
 )
 
 func (t Type) String() string {
@@ -31,6 +32,8 @@ func (t Type) String() string {
 		return "bool"
 	case TPtr:
 		return "ptr"
+	case TStr:
+		return "str"
 	}
 	return "?"
 }
@@ -60,6 +63,17 @@ const (
 	OpLessI64
 	OpLessEqI64
 	OpEqualI64
+
+	// String subsystem (MEP-24 §2). OpConstStr's Aux is the index into
+	// the function-local string constant pool the builder maintains; the
+	// emitter merges those into Function.StrConsts. OpIndexStr may trap
+	// on OOB so it is not treated as pure by DCE.
+	OpConstStr  // Aux = idx into Function.Strings
+	OpConcatStr // Args[0] ++ Args[1]
+	OpLenStr    // len(Args[0])
+	OpIndexStr  // Args[0][Args[1]]
+	OpEqualStr  // Args[0] == Args[1]
+	OpHashStr   // hash(Args[0])
 
 	// Call: Aux = function index, Args = arg values. May have effects;
 	// optimizers must treat as opaque.
@@ -108,6 +122,10 @@ type Function struct {
 	Entry      BlockID
 	Values     []Inst // indexed by ValueID
 	ValueBlock []BlockID
+	// Strings is the per-function string pool referenced by OpConstStr.
+	// Aux on an OpConstStr is an index into this slice. The pool is
+	// deduplicated by the builder; emit forwards it to vm2.Function.StrConsts.
+	Strings []string
 }
 
 // NumValues returns the count of SSA values defined in the function.

--- a/compiler2/opt/opt.go
+++ b/compiler2/opt/opt.go
@@ -112,7 +112,11 @@ func isPure(op ir.Op) bool {
 		ir.OpConstI64, ir.OpConstBool,
 		ir.OpAddI64, ir.OpSubI64, ir.OpMulI64,
 		ir.OpLessI64, ir.OpLessEqI64, ir.OpEqualI64,
+		ir.OpConstStr, ir.OpConcatStr, ir.OpLenStr,
+		ir.OpEqualStr, ir.OpHashStr,
 		ir.OpPhi:
+		// OpIndexStr is intentionally excluded: it can trap on OOB and
+		// must not be eliminated even when its result is unused.
 		return true
 	}
 	return false

--- a/runtime/vm2/bench/corpus_test.go
+++ b/runtime/vm2/bench/corpus_test.go
@@ -28,6 +28,10 @@ var corpusSizes = []corpusSize{
 	{"math_fib_iter", 30},     // matches template size 30
 	{"math_fib_rec", 25},      // fib(25) = 75025
 	{"math_prime_count", 100}, // primes in [2, 100)
+	// Strings subsystem (MEP-24 §2). Concat loop exercises the
+	// allocating path: N appends of a single-byte literal to a
+	// growing buffer.
+	{"strings_concat_loop", 64},
 }
 
 func sizeFor(name string) int64 {
@@ -105,3 +109,4 @@ func BenchmarkVM2_FactRec(b *testing.B)     { benchCorpus(b, corpus.Program{Name
 func BenchmarkVM2_FibIter(b *testing.B)     { benchCorpus(b, corpus.Program{Name: "math_fib_iter", Build: corpus.BuildFibIter, Expect: corpus.ExpectFibIter}) }
 func BenchmarkVM2_FibRecTmpl(b *testing.B)  { benchCorpus(b, corpus.Program{Name: "math_fib_rec", Build: corpus.BuildFibRec, Expect: corpus.ExpectFibRec}) }
 func BenchmarkVM2_PrimeCount(b *testing.B)  { benchCorpus(b, corpus.Program{Name: "math_prime_count", Build: corpus.BuildPrimeCount, Expect: corpus.ExpectPrimeCount}) }
+func BenchmarkVM2_StringsConcatLoop(b *testing.B) { benchCorpus(b, corpus.Program{Name: "strings_concat_loop", Build: corpus.BuildStringsConcatLoop, Expect: corpus.ExpectStringsConcatLoop}) }

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -188,6 +188,33 @@ func (vm *VM) Run() (Cell, error) {
 			consts = fr.Fn.Consts
 			ip = fr.IP
 			regs[retReg] = ret
+		case OpLoadStrK:
+			regs[ins.A] = vm.newString(fr.Fn.StrConsts[ins.B])
+		case OpConcatStr:
+			a := vm.Objects[regs[ins.B].Ptr()].(*vmString)
+			b := vm.Objects[regs[ins.C].Ptr()].(*vmString)
+			out := make([]byte, len(a.bytes)+len(b.bytes))
+			copy(out, a.bytes)
+			copy(out[len(a.bytes):], b.bytes)
+			regs[ins.A] = vm.newString(out)
+		case OpLenStr:
+			s := vm.Objects[regs[ins.B].Ptr()].(*vmString)
+			regs[ins.A] = CInt(int64(len(s.bytes)))
+		case OpIndexStr:
+			s := vm.Objects[regs[ins.B].Ptr()].(*vmString)
+			i := regs[ins.C].Int()
+			if i < 0 || i >= int64(len(s.bytes)) {
+				fr.IP = ip
+				return ret, errors.New("vm2: string index out of range")
+			}
+			regs[ins.A] = vm.newString([]byte{s.bytes[i]})
+		case OpEqualStr:
+			a := vm.Objects[regs[ins.B].Ptr()].(*vmString)
+			b := vm.Objects[regs[ins.C].Ptr()].(*vmString)
+			regs[ins.A] = CBool(strEqual(a, b))
+		case OpHashStr:
+			s := vm.Objects[regs[ins.B].Ptr()].(*vmString)
+			regs[ins.A] = CInt(int64(strHash(s)))
 		case OpHalt:
 			fr.IP = ip
 			return ret, errors.New("vm2: OpHalt reached")

--- a/runtime/vm2/ops.go
+++ b/runtime/vm2/ops.go
@@ -46,4 +46,15 @@ const (
 	// to a tail-recursive helper) go through this path.
 	OpTailCallSelf
 	OpReturn // return A to caller's RetReg
+
+	// String subsystem (MEP-24 §2). Strings are immutable; every
+	// allocating op produces a fresh *vmString registered in
+	// vm.Objects. Cell encoding is tagPtr whose payload is the
+	// Objects index.
+	OpLoadStrK  // A = newString(Fn.StrConsts[B])
+	OpConcatStr // A = newString(strAt(B).bytes ++ strAt(C).bytes)
+	OpLenStr    // A = i64(len(strAt(B).bytes))
+	OpIndexStr  // A = newString(one-byte slice strAt(B)[regs[C].Int()]); traps on OOB
+	OpEqualStr  // A = bool(strEqual(strAt(B), strAt(C)))
+	OpHashStr   // A = i64(strHash(strAt(B)))  // exposed mostly for map-key prep + tests
 )

--- a/runtime/vm2/program.go
+++ b/runtime/vm2/program.go
@@ -17,6 +17,12 @@ type Function struct {
 	NumRegs   int
 	Code      []Instr
 	Consts    []Cell
+	// StrConsts holds the raw bytes of string-typed constants. The
+	// emit-time index in StrConsts is the operand B value of an
+	// OpLoadStrK; the dispatch loop materializes a fresh vmString on
+	// first use via newString. Carrying bytes rather than pre-allocated
+	// *vmStrings keeps Function trivially serializable later.
+	StrConsts [][]byte
 }
 
 // Program is the unit of execution. Main names the entry function.

--- a/runtime/vm2/strings.go
+++ b/runtime/vm2/strings.go
@@ -1,0 +1,71 @@
+package vm2
+
+// vmString is the heap representation of a string. Strings are
+// immutable and held in the Objects table; a string-valued Cell is a
+// tagPtr whose payload is the Objects index of a *vmString.
+//
+// The header carries a memoized FNV-1a hash. Map keys (subsystem §4)
+// will read this; until then the field is just paying for itself on
+// OpEqualStr fast-paths where a hash mismatch short-circuits the byte
+// compare.
+type vmString struct {
+	bytes []byte
+	hash  uint64 // 0 means "not computed yet"; 0 collisions recompute
+}
+
+// newString allocates a *vmString and registers it in the VM's
+// Objects table. The returned Cell carries the table index.
+func (vm *VM) newString(b []byte) Cell {
+	return CPtr(vm.AddObject(&vmString{bytes: b}))
+}
+
+// stringAt fetches the *vmString backing the cell. Caller must have
+// already checked the cell is a string (the typed opcodes guarantee
+// this statically; this helper is for the verifier and tests).
+func (vm *VM) stringAt(c Cell) *vmString {
+	return vm.Objects[c.Ptr()].(*vmString)
+}
+
+// strHash returns the FNV-1a hash of s.bytes, memoizing it on s. A
+// computed hash of 0 is mapped to 1 so the sentinel "not computed
+// yet" stays unambiguous; 1 collisions are accepted.
+func strHash(s *vmString) uint64 {
+	if s.hash != 0 {
+		return s.hash
+	}
+	const (
+		offset64 uint64 = 14695981039346656037
+		prime64  uint64 = 1099511628211
+	)
+	h := offset64
+	for _, b := range s.bytes {
+		h ^= uint64(b)
+		h *= prime64
+	}
+	if h == 0 {
+		h = 1
+	}
+	s.hash = h
+	return h
+}
+
+// strEqual compares two *vmStrings for byte equality. Identity match
+// and length mismatch are checked first; the memoized hash is used to
+// short-circuit byte compare when both sides have one cached.
+func strEqual(a, b *vmString) bool {
+	if a == b {
+		return true
+	}
+	if len(a.bytes) != len(b.bytes) {
+		return false
+	}
+	if a.hash != 0 && b.hash != 0 && a.hash != b.hash {
+		return false
+	}
+	for i := range a.bytes {
+		if a.bytes[i] != b.bytes[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/runtime/vm2/strings_test.go
+++ b/runtime/vm2/strings_test.go
@@ -1,0 +1,188 @@
+package vm2
+
+import "testing"
+
+// runStrProg compiles a tiny hand-built program (single function, no
+// calls) and returns the final cell. Used by every string op test so
+// the assertions stay focused on opcode semantics, not framing.
+func runStrProg(t *testing.T, numRegs int, strConsts [][]byte, code []Instr) (Cell, *VM) {
+	t.Helper()
+	fn := &Function{
+		Name:      "test",
+		NumParams: 0,
+		NumRegs:   numRegs,
+		Code:      code,
+		StrConsts: strConsts,
+	}
+	prog := &Program{Funcs: []*Function{fn}, Main: 0}
+	vm := New(prog)
+	got, err := vm.Run()
+	if err != nil {
+		t.Fatalf("vm.Run: %v", err)
+	}
+	return got, vm
+}
+
+func TestLoadStrK(t *testing.T) {
+	got, vm := runStrProg(t, 1, [][]byte{[]byte("hello")}, []Instr{
+		{Op: OpLoadStrK, A: 0, B: 0},
+		{Op: OpReturn, A: 0},
+	})
+	if !got.IsPtr() {
+		t.Fatalf("want ptr cell, got %x", uint64(got))
+	}
+	s := vm.stringAt(got)
+	if string(s.bytes) != "hello" {
+		t.Fatalf("want hello, got %q", s.bytes)
+	}
+}
+
+func TestConcatStr(t *testing.T) {
+	got, vm := runStrProg(t, 3, [][]byte{[]byte("foo"), []byte("bar")}, []Instr{
+		{Op: OpLoadStrK, A: 0, B: 0},
+		{Op: OpLoadStrK, A: 1, B: 1},
+		{Op: OpConcatStr, A: 2, B: 0, C: 1},
+		{Op: OpReturn, A: 2},
+	})
+	if string(vm.stringAt(got).bytes) != "foobar" {
+		t.Fatalf("want foobar, got %q", vm.stringAt(got).bytes)
+	}
+}
+
+func TestLenStr(t *testing.T) {
+	got, _ := runStrProg(t, 2, [][]byte{[]byte("héllo")}, []Instr{ // 6 bytes (é = 2)
+		{Op: OpLoadStrK, A: 0, B: 0},
+		{Op: OpLenStr, A: 1, B: 0},
+		{Op: OpReturn, A: 1},
+	})
+	if got.Int() != 6 {
+		t.Fatalf("want byte len 6, got %d", got.Int())
+	}
+}
+
+func TestIndexStr(t *testing.T) {
+	prog := &Program{Funcs: []*Function{{
+		Name:    "idx",
+		NumRegs: 3,
+		Code: []Instr{
+			{Op: OpLoadConstI, A: 1, B: 0},
+			{Op: OpLoadStrK, A: 0, B: 0},
+			{Op: OpIndexStr, A: 2, B: 0, C: 1},
+			{Op: OpReturn, A: 2},
+		},
+		Consts:    []Cell{CInt(1)},
+		StrConsts: [][]byte{[]byte("abc")},
+	}}, Main: 0}
+	vm := New(prog)
+	got, err := vm.Run()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if s := string(vm.stringAt(got).bytes); s != "b" {
+		t.Fatalf("want \"b\", got %q", s)
+	}
+}
+
+func TestIndexStrOOB(t *testing.T) {
+	prog := &Program{Funcs: []*Function{{
+		Name:    "oob",
+		NumRegs: 3,
+		Code: []Instr{
+			{Op: OpLoadConstI, A: 1, B: 0},
+			{Op: OpLoadStrK, A: 0, B: 0},
+			{Op: OpIndexStr, A: 2, B: 0, C: 1},
+			{Op: OpReturn, A: 2},
+		},
+		Consts:    []Cell{CInt(5)},
+		StrConsts: [][]byte{[]byte("abc")},
+	}}, Main: 0}
+	vm := New(prog)
+	if _, err := vm.Run(); err == nil {
+		t.Fatalf("want OOB error, got nil")
+	}
+}
+
+func TestEqualStr(t *testing.T) {
+	prog := &Program{Funcs: []*Function{{
+		Name:    "eq",
+		NumRegs: 4,
+		Code: []Instr{
+			{Op: OpLoadStrK, A: 0, B: 0},
+			{Op: OpLoadStrK, A: 1, B: 1}, // same bytes, different allocation
+			{Op: OpLoadStrK, A: 2, B: 2},
+			{Op: OpEqualStr, A: 3, B: 0, C: 1}, // true
+			{Op: OpReturn, A: 3},
+		},
+		StrConsts: [][]byte{[]byte("foo"), []byte("foo"), []byte("bar")},
+	}}, Main: 0}
+	vm := New(prog)
+	got, err := vm.Run()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !got.Bool() {
+		t.Fatalf("want true for foo==foo")
+	}
+
+	// Different strings.
+	prog.Funcs[0].Code = []Instr{
+		{Op: OpLoadStrK, A: 0, B: 0},
+		{Op: OpLoadStrK, A: 1, B: 2},
+		{Op: OpEqualStr, A: 3, B: 0, C: 1},
+		{Op: OpReturn, A: 3},
+	}
+	vm = New(prog)
+	got, err = vm.Run()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got.Bool() {
+		t.Fatalf("want false for foo==bar")
+	}
+}
+
+func TestHashStrDeterministic(t *testing.T) {
+	prog := &Program{Funcs: []*Function{{
+		Name:    "h",
+		NumRegs: 2,
+		Code: []Instr{
+			{Op: OpLoadStrK, A: 0, B: 0},
+			{Op: OpHashStr, A: 1, B: 0},
+			{Op: OpReturn, A: 1},
+		},
+		StrConsts: [][]byte{[]byte("the quick brown fox")},
+	}}, Main: 0}
+	vm := New(prog)
+	a, err := vm.Run()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	vm = New(prog)
+	b, err := vm.Run()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if a.Int() != b.Int() {
+		t.Fatalf("hash not deterministic across runs: %d vs %d", a.Int(), b.Int())
+	}
+	if a.Int() == 0 {
+		t.Fatalf("hash 0 is the sentinel; bytes should never hash to 0 after mapping")
+	}
+}
+
+func TestStringHashMemoized(t *testing.T) {
+	vm := New(&Program{Funcs: []*Function{{NumRegs: 1, Code: []Instr{{Op: OpReturn, A: 0}}}}, Main: 0})
+	c := vm.newString([]byte("memoize"))
+	s := vm.stringAt(c)
+	if s.hash != 0 {
+		t.Fatalf("hash should be lazy")
+	}
+	h1 := strHash(s)
+	if s.hash != h1 {
+		t.Fatalf("hash not memoized")
+	}
+	h2 := strHash(s)
+	if h1 != h2 {
+		t.Fatalf("hash unstable: %d vs %d", h1, h2)
+	}
+}


### PR DESCRIPTION
## Summary
- First subsystem PR per the MEP-24 porting plan: strings.
- `runtime/vm2` gets `*vmString` (memoized FNV-1a) + 6 opcodes (`OpLoadStrK`, `OpConcatStr`, `OpLenStr`, `OpIndexStr`, `OpEqualStr`, `OpHashStr`); `Function.StrConsts [][]byte` carries the per-function pool.
- `compiler2/ir` gets `TStr` + matching builder; `compiler2/emit` lowers the ops and forwards the dedup'd string pool. DCE marks the non-trapping ones pure.
- Corpus + benchmark: `strings_concat_loop` exercises the allocating-concat path through the same `vm2runner` harness used by the math kernels.

## Why
MEP-24 specifies one subsystem per PR with hard correctness + bench gates. This is §2 (strings) in that sequence. The integer-only vm2 core is closed; the next several PRs are subsystem ports.

## Test plan
- [x] `go test ./runtime/vm2/...` (unit tests for each opcode)
- [x] `go test ./compiler2/...` (end-to-end emit + run; pool dedup; corpus oracle)
- [x] `go run ./bench/vm2runner -program=strings_concat_loop -n=64` returns `{"duration_us":..., "output":65}`
- [x] `go test -bench=BenchmarkVM2_StringsConcatLoop -run=^\$ ./runtime/vm2/bench` reports a clean baseline (9.5 us / N=64 / 139 allocs on M4)

Closes #21517.