### PR TITLE
MEP-24 §2 strings: add CPython + Lua cross-language baseline

### DIFF
--- a/bench/crosslang/main.go
+++ b/bench/crosslang/main.go
@@ -25,8 +25,18 @@ import (
 )
 
 type program struct {
-	name string // bench/template/math/<name> subdir
-	ns   []int  // sizes to run
+	category string // bench/template/<category>/<name> subdir; "" defaults to "math"
+	name     string // bench/template/<category>/<name> subdir
+	ns       []int  // sizes to run
+}
+
+// cat returns the effective category, defaulting math entries to "math"
+// so existing rows do not need to be edited when new categories land.
+func (p program) cat() string {
+	if p.category == "" {
+		return "math"
+	}
+	return p.category
 }
 
 // Per-program sizes. fact_rec and mul_loop cap at sizes whose result
@@ -38,12 +48,16 @@ type program struct {
 // ranking of vm2 vs CPython vs Lua. The remaining sizes already span
 // 10x–100x dynamic range, which is plenty for a comparison sweep.
 var programs = []program{
-	{"fact_rec", []int{10, 13}},
-	{"fib_iter", []int{10, 20}},
-	{"fib_rec", []int{15, 20}},
-	{"mul_loop", []int{10, 13}},
-	{"prime_count", []int{50, 100}},
-	{"sum_loop", []int{1000, 10000}},
+	{name: "fact_rec", ns: []int{10, 13}},
+	{name: "fib_iter", ns: []int{10, 20}},
+	{name: "fib_rec", ns: []int{15, 20}},
+	{name: "mul_loop", ns: []int{10, 13}},
+	{name: "prime_count", ns: []int{50, 100}},
+	{name: "sum_loop", ns: []int{1000, 10000}},
+	// MEP-24 §2 strings subsystem. Concat loop exercises the
+	// allocating string-concat path: N appends per inner call,
+	// repeated `repeats` times by each language harness.
+	{category: "strings", name: "concat_loop", ns: []int{10, 30}},
 }
 
 type result struct {
@@ -84,9 +98,9 @@ func main() {
 	var results []result
 	for _, p := range programs {
 		for _, n := range p.ns {
-			results = append(results, runVM2(vm2Bin, p.name, n))
-			results = append(results, runNative(repoRoot, tmp, p.name, n, "py", "python3"))
-			results = append(results, runNative(repoRoot, tmp, p.name, n, "lua", "lua"))
+			results = append(results, runVM2(vm2Bin, p.cat(), p.name, n))
+			results = append(results, runNative(repoRoot, tmp, p.cat(), p.name, n, "py", "python3"))
+			results = append(results, runNative(repoRoot, tmp, p.cat(), p.name, n, "lua", "lua"))
 		}
 	}
 
@@ -124,29 +138,29 @@ func main() {
 	}
 }
 
-func runVM2(bin, prog string, n int) result {
-	progName := "math_" + prog
+func runVM2(bin, cat, prog string, n int) result {
+	progName := cat + "_" + prog
 	cmd := exec.Command(bin, "-program", progName, "-n", fmt.Sprintf("%d", n))
-	return runCmd(prog, n, "vm2", cmd)
+	return runCmd(cat, prog, n, "vm2", cmd)
 }
 
-func runNative(repoRoot, tmp, prog string, n int, suffix, interpreter string) result {
-	srcPath := filepath.Join(repoRoot, "bench", "template", "math", prog, prog+"."+suffix)
+func runNative(repoRoot, tmp, cat, prog string, n int, suffix, interpreter string) result {
+	srcPath := filepath.Join(repoRoot, "bench", "template", cat, prog, prog+"."+suffix)
 	src, err := os.ReadFile(srcPath)
 	if err != nil {
-		return result{Program: prog, N: n, Lang: suffix, Err: err.Error()}
+		return result{Program: cat + "/" + prog, N: n, Lang: suffix, Err: err.Error()}
 	}
 	rendered := strings.ReplaceAll(string(src), "{{ .N }}", fmt.Sprintf("%d", n))
-	out := filepath.Join(tmp, fmt.Sprintf("%s_%d.%s", prog, n, suffix))
+	out := filepath.Join(tmp, fmt.Sprintf("%s_%s_%d.%s", cat, prog, n, suffix))
 	if err := os.WriteFile(out, []byte(rendered), 0644); err != nil {
-		return result{Program: prog, N: n, Lang: suffix, Err: err.Error()}
+		return result{Program: cat + "/" + prog, N: n, Lang: suffix, Err: err.Error()}
 	}
 	cmd := exec.Command(interpreter, out)
-	return runCmd(prog, n, suffix, cmd)
+	return runCmd(cat, prog, n, suffix, cmd)
 }
 
-func runCmd(prog string, n int, lang string, cmd *exec.Cmd) result {
-	r := result{Program: prog, N: n, Lang: lang}
+func runCmd(cat, prog string, n int, lang string, cmd *exec.Cmd) result {
+	r := result{Program: cat + "/" + prog, N: n, Lang: lang}
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/bench/template/strings/concat_loop/concat_loop.lua
+++ b/bench/template/strings/concat_loop/concat_loop.lua
@@ -1,0 +1,19 @@
+local function concat_loop(n)
+  local acc = "a"
+  for _ = 1, n do
+    acc = acc .. "a"
+  end
+  return #acc
+end
+
+local n = {{ .N }}
+local repeats = 1000
+local last = 0
+
+local start = os.clock()
+for _ = 1, repeats do
+  last = concat_loop(n)
+end
+local duration_us = (os.clock() - start) * 1e6
+
+io.write(string.format('{"duration_us": %d, "output": %s}\n', math.floor(duration_us), tostring(last)))

--- a/bench/template/strings/concat_loop/concat_loop.mochi
+++ b/bench/template/strings/concat_loop/concat_loop.mochi
@@ -1,0 +1,23 @@
+fun concat_loop(n: int): int {
+  var acc = "a"
+  for i in 0..n {
+    acc = acc + "a"
+  }
+  return len(acc)
+}
+
+let n = {{ .N }}
+let repeat = 1000
+var last = 0
+
+let start = now()
+for i in 0..repeat {
+  last = concat_loop(n)
+}
+let duration = (now() - start) / 1000
+
+
+json({
+  "duration_us": duration,
+  "output": last,
+})

--- a/bench/template/strings/concat_loop/concat_loop.py
+++ b/bench/template/strings/concat_loop/concat_loop.py
@@ -1,0 +1,22 @@
+import json
+import time
+
+def concat_loop(n):
+    acc = "a"
+    for _ in range(n):
+        acc = acc + "a"
+    return len(acc)
+
+n = {{ .N }}
+repeat = 1000
+last = 0
+
+start = time.perf_counter()
+for _ in range(repeat):
+    last = concat_loop(n)
+duration = (time.perf_counter() - start) * 1e6
+
+print(json.dumps({
+    "duration_us": duration,
+    "output": last,
+}))

--- a/website/docs/mep/mep-0023.md
+++ b/website/docs/mep/mep-0023.md
@@ -235,6 +235,17 @@ Landed in this round:
 
 Headline movement vs the floor: vm2 vs Lua is now **1.07x – 1.96x** across the slice (geomean ~1.6x). `fib_iter` is at **Lua parity** (1.07x – 1.15x). The recursive programs that round 2 left at ~3x Lua dropped to **1.55x – 1.79x** because the frame-pool round trip is gone. vs CPython, vm2 is **1.6x – 2.9x faster** on every program in the slice without exception.
 
+##### Strings subsystem (MEP-24 §2, first slice)
+
+The first non-integer subsystem lands. `bench/template/strings/concat_loop/{mochi,py,lua}` exercises `acc = acc + "a"` repeated N times in a loop, repeated 1000 times by each language harness. Outputs (final byte length) match across all three runtimes.
+
+| Program             |  N | vm2 (µs) | CPython (µs) | Lua (µs) | vm2 / CPython | vm2 / Lua |
+|---------------------|---:|---------:|-------------:|---------:|--------------:|----------:|
+| `strings/concat_loop` | 10 |      624 |          542 |      441 |         1.15x |     1.41x |
+| `strings/concat_loop` | 30 |    1,807 |        1,121 |    1,625 |         1.61x |     1.11x |
+
+vm2 is within **1.11x – 1.41x of Lua** and **1.15x – 1.61x of CPython** on the first cut. The widening at N=30 vs CPython is expected: CPython's `s = s + small` path hits the in-place resize fast-path on `str` when the reference count is 1; vm2 currently always allocates a fresh `*vmString`. A small-string inline tag (`tagSStr`) and concat reuse-when-unique are obvious next moves, deferred to a follow-on bench round so the first subsystem PR stays scope-pure.
+
 ## Rationale
 
 **Why a new MEP, not an edit to MEP 17.** MEP 17 is a process gate. Folding cross-language reporting into it would either weaken the per-PR rule (peer runtime variance is too high to gate on) or strengthen the cross-language rule into a gate (an over-commitment given how many factors outside the VM author's control move those numbers). Separate documents, separate cadences, no confusion.


### PR DESCRIPTION
Adds CPython and Lua siblings of `bench/template/strings/concat_loop` and teaches the cross-language harness (`bench/crosslang/main.go`) to handle non-`math` categories. Then re-runs the MEP-23 sweep and appends a "Strings subsystem" subsection to MEP-23.

The numbers show vm2 lags both CPython (1.61x at N=30) and Lua (1.41x at N=10) on the allocating concat path. Optimization work tracked separately; this PR is just the baseline so the gap is measured rather than guessed.

Stacked behind #21518 (merged).

Closes #21519.