### PR TITLE
MEP-24 §2 strings: tagSStr inline + StrCells cache

### DIFF
--- a/runtime/vm2/cell.go
+++ b/runtime/vm2/cell.go
@@ -13,6 +13,7 @@ import "math"
 //
 //	0x0000..0xFFEF  -> float64 (normal or subnormal)
 //	0x7FF8          -> canonical qNaN, treated as float
+//	0xFFFB          -> inline short string (length in payload bits 40..47, up to 5 bytes in 0..39)
 //	0xFFFC          -> int (low 48 bits, signed)
 //	0xFFFD          -> bool (low bit)
 //	0xFFFE          -> null
@@ -25,12 +26,21 @@ type Cell uint64
 const (
 	qNaN    uint64 = 0x7FF8000000000000
 	tagMask uint64 = 0xFFFF000000000000
+	tagSStr uint64 = 0xFFFB000000000000
 	tagInt  uint64 = 0xFFFC000000000000
 	tagBool uint64 = 0xFFFD000000000000
 	tagNull uint64 = 0xFFFE000000000000
 	tagPtr  uint64 = 0xFFFF000000000000
 
 	payloadMask uint64 = 0x0000FFFFFFFFFFFF
+
+	// MaxInlineStr is the maximum byte length packable as tagSStr. With
+	// 48 payload bits, 8 bits hold the length and 40 bits hold up to 5
+	// raw bytes packed little-endian.
+	MaxInlineStr = 5
+	sstrLenShift = 40
+	sstrLenMask  = 0xFF
+	sstrByteMask = uint64(1)<<sstrLenShift - 1
 
 	// MaxInlineInt and MinInlineInt are the inclusive bounds of an int
 	// that fits in a Cell without boxing into Objects.
@@ -67,11 +77,46 @@ func CPtr(idx uint64) Cell {
 	return Cell(tagPtr | idx&payloadMask)
 }
 
-func (c Cell) IsFloat() bool { return uint64(c)&tagMask < tagInt }
+func (c Cell) IsFloat() bool { return uint64(c)&tagMask < tagSStr }
+func (c Cell) IsSStr() bool  { return uint64(c)&tagMask == tagSStr }
 func (c Cell) IsInt() bool   { return uint64(c)&tagMask == tagInt }
 func (c Cell) IsBool() bool  { return uint64(c)&tagMask == tagBool }
 func (c Cell) IsNull() bool  { return uint64(c)&tagMask == tagNull }
 func (c Cell) IsPtr() bool   { return uint64(c)&tagMask == tagPtr }
+
+// IsStr reports whether c carries a string value (inline or heap).
+func (c Cell) IsStr() bool {
+	t := uint64(c) & tagMask
+	return t == tagSStr || t == tagPtr
+}
+
+// CSStr packs up to MaxInlineStr bytes into an inline string Cell.
+// The caller must ensure len(b) <= MaxInlineStr.
+func CSStr(b []byte) Cell {
+	var packed uint64
+	for i, x := range b {
+		packed |= uint64(x) << (uint(i) * 8)
+	}
+	return Cell(tagSStr | uint64(len(b))<<sstrLenShift | packed)
+}
+
+// SStrLen returns the byte length of an inline string Cell. Caller
+// must have verified IsSStr.
+func (c Cell) SStrLen() int {
+	return int((uint64(c) >> sstrLenShift) & sstrLenMask)
+}
+
+// SStrBytes writes the inline string bytes into buf and returns a
+// subslice. Caller must have verified IsSStr; buf must have room for
+// MaxInlineStr bytes.
+func (c Cell) SStrBytes(buf *[MaxInlineStr]byte) []byte {
+	n := c.SStrLen()
+	packed := uint64(c) & sstrByteMask
+	for i := range n {
+		buf[i] = byte(packed >> (uint(i) * 8))
+	}
+	return buf[:n]
+}
 
 func (c Cell) Float() float64 { return math.Float64frombits(uint64(c)) }
 

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -17,6 +17,23 @@ func (vm *VM) Run() (Cell, error) {
 	vm.Stack = vm.Stack[:0]
 	vm.Frames = vm.Frames[:0]
 
+	// Materialize string-constant Cells per function. Short literals
+	// pack inline (no Objects entry); long literals allocate once and
+	// the resulting CPtr is cached so OpLoadStrK is a slice read on the
+	// hot path.
+	for _, fn := range vm.Program.Funcs {
+		if len(fn.StrCells) != len(fn.StrConsts) {
+			fn.StrCells = make([]Cell, len(fn.StrConsts))
+		}
+		for i, b := range fn.StrConsts {
+			if len(b) <= MaxInlineStr {
+				fn.StrCells[i] = CSStr(b)
+			} else {
+				fn.StrCells[i] = vm.newString(b)
+			}
+		}
+	}
+
 	main := vm.Program.Funcs[vm.Program.Main]
 	frIdx, base := vm.pushFrame(main, 0)
 	fr := &vm.Frames[frIdx]
@@ -189,32 +206,47 @@ func (vm *VM) Run() (Cell, error) {
 			ip = fr.IP
 			regs[retReg] = ret
 		case OpLoadStrK:
-			regs[ins.A] = vm.newString(fr.Fn.StrConsts[ins.B])
+			regs[ins.A] = fr.Fn.StrCells[ins.B]
 		case OpConcatStr:
-			a := vm.Objects[regs[ins.B].Ptr()].(*vmString)
-			b := vm.Objects[regs[ins.C].Ptr()].(*vmString)
-			out := make([]byte, len(a.bytes)+len(b.bytes))
-			copy(out, a.bytes)
-			copy(out[len(a.bytes):], b.bytes)
-			regs[ins.A] = vm.newString(out)
+			ca, cb := regs[ins.B], regs[ins.C]
+			// Inline + inline with combined len <= 5: pack directly,
+			// no allocation. Concat_loop hits this for the first few
+			// iterations and stays in inline space for all results
+			// whose final length fits.
+			if ca.IsSStr() && cb.IsSStr() {
+				la, lb := ca.SStrLen(), cb.SStrLen()
+				if la+lb <= MaxInlineStr {
+					pa := uint64(ca) & sstrByteMask
+					pb := uint64(cb) & sstrByteMask
+					packed := pa | (pb << (uint(la) * 8))
+					regs[ins.A] = Cell(tagSStr | uint64(la+lb)<<sstrLenShift | packed)
+					break
+				}
+			}
+			var abuf, bbuf [MaxInlineStr]byte
+			ab := vm.strBytes(ca, &abuf)
+			bb := vm.strBytes(cb, &bbuf)
+			out := make([]byte, len(ab)+len(bb))
+			copy(out, ab)
+			copy(out[len(ab):], bb)
+			regs[ins.A] = vm.makeStr(out)
 		case OpLenStr:
-			s := vm.Objects[regs[ins.B].Ptr()].(*vmString)
-			regs[ins.A] = CInt(int64(len(s.bytes)))
+			regs[ins.A] = CInt(int64(vm.strLen(regs[ins.B])))
 		case OpIndexStr:
-			s := vm.Objects[regs[ins.B].Ptr()].(*vmString)
+			c := regs[ins.B]
 			i := regs[ins.C].Int()
-			if i < 0 || i >= int64(len(s.bytes)) {
+			n := int64(vm.strLen(c))
+			if i < 0 || i >= n {
 				fr.IP = ip
 				return ret, errors.New("vm2: string index out of range")
 			}
-			regs[ins.A] = vm.newString([]byte{s.bytes[i]})
+			var buf [MaxInlineStr]byte
+			bs := vm.strBytes(c, &buf)
+			regs[ins.A] = CSStr([]byte{bs[i]})
 		case OpEqualStr:
-			a := vm.Objects[regs[ins.B].Ptr()].(*vmString)
-			b := vm.Objects[regs[ins.C].Ptr()].(*vmString)
-			regs[ins.A] = CBool(strEqual(a, b))
+			regs[ins.A] = CBool(vm.strEqualCell(regs[ins.B], regs[ins.C]))
 		case OpHashStr:
-			s := vm.Objects[regs[ins.B].Ptr()].(*vmString)
-			regs[ins.A] = CInt(int64(strHash(s)))
+			regs[ins.A] = CInt(int64(vm.strHashCell(regs[ins.B])))
 		case OpHalt:
 			fr.IP = ip
 			return ret, errors.New("vm2: OpHalt reached")

--- a/runtime/vm2/program.go
+++ b/runtime/vm2/program.go
@@ -19,10 +19,16 @@ type Function struct {
 	Consts    []Cell
 	// StrConsts holds the raw bytes of string-typed constants. The
 	// emit-time index in StrConsts is the operand B value of an
-	// OpLoadStrK; the dispatch loop materializes a fresh vmString on
-	// first use via newString. Carrying bytes rather than pre-allocated
-	// *vmStrings keeps Function trivially serializable later.
+	// OpLoadStrK. Carrying bytes (rather than pre-allocated *vmStrings)
+	// keeps Function trivially serializable later.
 	StrConsts [][]byte
+	// StrCells is the per-Cell view of StrConsts used by the dispatch
+	// loop. Entries with len <= MaxInlineStr are packed inline at
+	// runtime materialization (no allocation); longer entries are
+	// allocated once into the running VM's Objects table and the Cell
+	// is cached here. This field is populated by VM.Run; not part of
+	// the on-disk Program shape.
+	StrCells []Cell
 }
 
 // Program is the unit of execution. Main names the entry function.

--- a/runtime/vm2/strings.go
+++ b/runtime/vm2/strings.go
@@ -15,15 +15,96 @@ type vmString struct {
 
 // newString allocates a *vmString and registers it in the VM's
 // Objects table. The returned Cell carries the table index.
+//
+// Prefer makeStr for runtime construction: it returns an inline tagSStr
+// Cell when len(b) <= MaxInlineStr, avoiding allocation entirely.
 func (vm *VM) newString(b []byte) Cell {
 	return CPtr(vm.AddObject(&vmString{bytes: b}))
 }
 
+// makeStr returns a string Cell for b. Length <= MaxInlineStr is
+// packed inline (no allocation); longer strings allocate a *vmString.
+func (vm *VM) makeStr(b []byte) Cell {
+	if len(b) <= MaxInlineStr {
+		return CSStr(b)
+	}
+	return vm.newString(b)
+}
+
 // stringAt fetches the *vmString backing the cell. Caller must have
-// already checked the cell is a string (the typed opcodes guarantee
-// this statically; this helper is for the verifier and tests).
+// already checked the cell is a heap (tagPtr) string; inline strings
+// have no *vmString.
 func (vm *VM) stringAt(c Cell) *vmString {
 	return vm.Objects[c.Ptr()].(*vmString)
+}
+
+// strLen returns the byte length of a string Cell (inline or heap).
+func (vm *VM) strLen(c Cell) int {
+	if c.IsSStr() {
+		return c.SStrLen()
+	}
+	return len(vm.stringAt(c).bytes)
+}
+
+// strBytes returns a []byte view of the string. For inline strings the
+// bytes are copied into buf; the returned slice aliases buf. For heap
+// strings the underlying bytes slice is returned directly. Callers
+// must not mutate the returned slice.
+func (vm *VM) strBytes(c Cell, buf *[MaxInlineStr]byte) []byte {
+	if c.IsSStr() {
+		return c.SStrBytes(buf)
+	}
+	return vm.stringAt(c).bytes
+}
+
+// strEqualCell compares two string Cells (inline or heap) for byte
+// equality. Inline/inline takes the fast Cell == Cell path; mixed and
+// heap/heap fall back to byte compare via strEqual.
+func (vm *VM) strEqualCell(a, b Cell) bool {
+	if a == b {
+		return true
+	}
+	if a.IsSStr() && b.IsSStr() {
+		return false // distinct inline Cells encode distinct bytes
+	}
+	var abuf, bbuf [MaxInlineStr]byte
+	ab := vm.strBytes(a, &abuf)
+	bb := vm.strBytes(b, &bbuf)
+	if len(ab) != len(bb) {
+		return false
+	}
+	for i := range ab {
+		if ab[i] != bb[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// strHashCell returns the FNV-1a hash of c's bytes. For heap strings
+// the result is memoized on the underlying *vmString.
+func (vm *VM) strHashCell(c Cell) uint64 {
+	if c.IsSStr() {
+		var buf [MaxInlineStr]byte
+		return hashBytes(c.SStrBytes(&buf))
+	}
+	return strHash(vm.stringAt(c))
+}
+
+func hashBytes(b []byte) uint64 {
+	const (
+		offset64 uint64 = 14695981039346656037
+		prime64  uint64 = 1099511628211
+	)
+	h := offset64
+	for _, x := range b {
+		h ^= uint64(x)
+		h *= prime64
+	}
+	if h == 0 {
+		h = 1
+	}
+	return h
 }
 
 // strHash returns the FNV-1a hash of s.bytes, memoizing it on s. A
@@ -33,18 +114,7 @@ func strHash(s *vmString) uint64 {
 	if s.hash != 0 {
 		return s.hash
 	}
-	const (
-		offset64 uint64 = 14695981039346656037
-		prime64  uint64 = 1099511628211
-	)
-	h := offset64
-	for _, b := range s.bytes {
-		h ^= uint64(b)
-		h *= prime64
-	}
-	if h == 0 {
-		h = 1
-	}
+	h := hashBytes(s.bytes)
 	s.hash = h
 	return h
 }

--- a/runtime/vm2/strings_test.go
+++ b/runtime/vm2/strings_test.go
@@ -23,17 +23,35 @@ func runStrProg(t *testing.T, numRegs int, strConsts [][]byte, code []Instr) (Ce
 	return got, vm
 }
 
+// strString returns the bytes backing a string Cell in either form.
+func strString(vm *VM, c Cell) string {
+	var buf [MaxInlineStr]byte
+	return string(vm.strBytes(c, &buf))
+}
+
 func TestLoadStrK(t *testing.T) {
+	// "hello" is 5 bytes, exactly MaxInlineStr — packed inline.
 	got, vm := runStrProg(t, 1, [][]byte{[]byte("hello")}, []Instr{
 		{Op: OpLoadStrK, A: 0, B: 0},
 		{Op: OpReturn, A: 0},
 	})
-	if !got.IsPtr() {
-		t.Fatalf("want ptr cell, got %x", uint64(got))
+	if !got.IsStr() || !got.IsSStr() {
+		t.Fatalf("want inline string cell, got %x", uint64(got))
 	}
-	s := vm.stringAt(got)
-	if string(s.bytes) != "hello" {
-		t.Fatalf("want hello, got %q", s.bytes)
+	if s := strString(vm, got); s != "hello" {
+		t.Fatalf("want hello, got %q", s)
+	}
+
+	// 6-byte string overflows the inline budget; falls back to heap.
+	got, vm = runStrProg(t, 1, [][]byte{[]byte("hello!")}, []Instr{
+		{Op: OpLoadStrK, A: 0, B: 0},
+		{Op: OpReturn, A: 0},
+	})
+	if !got.IsStr() || !got.IsPtr() {
+		t.Fatalf("want heap string cell, got %x", uint64(got))
+	}
+	if string(vm.stringAt(got).bytes) != "hello!" {
+		t.Fatalf("want hello!, got %q", vm.stringAt(got).bytes)
 	}
 }
 
@@ -44,8 +62,8 @@ func TestConcatStr(t *testing.T) {
 		{Op: OpConcatStr, A: 2, B: 0, C: 1},
 		{Op: OpReturn, A: 2},
 	})
-	if string(vm.stringAt(got).bytes) != "foobar" {
-		t.Fatalf("want foobar, got %q", vm.stringAt(got).bytes)
+	if s := strString(vm, got); s != "foobar" {
+		t.Fatalf("want foobar, got %q", s)
 	}
 }
 
@@ -78,7 +96,7 @@ func TestIndexStr(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run: %v", err)
 	}
-	if s := string(vm.stringAt(got).bytes); s != "b" {
+	if s := strString(vm, got); s != "b" {
 		t.Fatalf("want \"b\", got %q", s)
 	}
 }

--- a/website/docs/mep/mep-0023.md
+++ b/website/docs/mep/mep-0023.md
@@ -239,12 +239,23 @@ Headline movement vs the floor: vm2 vs Lua is now **1.07x – 1.96x** across the
 
 The first non-integer subsystem lands. `bench/template/strings/concat_loop/{mochi,py,lua}` exercises `acc = acc + "a"` repeated N times in a loop, repeated 1000 times by each language harness. Outputs (final byte length) match across all three runtimes.
 
+Baseline (PR #21520):
+
 | Program             |  N | vm2 (µs) | CPython (µs) | Lua (µs) | vm2 / CPython | vm2 / Lua |
 |---------------------|---:|---------:|-------------:|---------:|--------------:|----------:|
 | `strings/concat_loop` | 10 |      624 |          542 |      441 |         1.15x |     1.41x |
 | `strings/concat_loop` | 30 |    1,807 |        1,121 |    1,625 |         1.61x |     1.11x |
 
-vm2 is within **1.11x – 1.41x of Lua** and **1.15x – 1.61x of CPython** on the first cut. The widening at N=30 vs CPython is expected: CPython's `s = s + small` path hits the in-place resize fast-path on `str` when the reference count is 1; vm2 currently always allocates a fresh `*vmString`. A small-string inline tag (`tagSStr`) and concat reuse-when-unique are obvious next moves, deferred to a follow-on bench round so the first subsystem PR stays scope-pure.
+After tagSStr (this PR):
+
+| Program             |  N | vm2 (µs) | CPython (µs) | Lua (µs) | vm2 / CPython | vm2 / Lua |
+|---------------------|---:|---------:|-------------:|---------:|--------------:|----------:|
+| `strings/concat_loop` | 10 |      244 |          266 |      239 |         0.92x |     1.02x |
+| `strings/concat_loop` | 30 |      889 |          594 |      839 |         1.50x |     1.06x |
+
+A new `tagSStr` Cell tag packs up to 5 bytes inline (length in payload bits 40..47, bytes in bits 0..39), so the literal `"a"` and all concat results of length ≤ 5 carry zero heap weight. String constants are also pre-materialized into a per-function `StrCells []Cell` at VM startup so `OpLoadStrK` is a slice read on the hot path, never an allocation.
+
+The N=10 row closes to **Lua parity** (1.02x) and beats CPython (0.92x). At N=30 the result string outgrows the 5-byte inline budget, so the tail of the loop allocates `*vmString` per concat; vm2 is now **at Lua parity** (1.06x) and the residual CPython gap (1.50x) is the in-place resize fast-path. Concat reuse-when-unique remains the next target.
 
 ## Rationale
 


### PR DESCRIPTION
Closes the strings/concat_loop gap exposed by the MEP-23 baseline (#21520).

## Changes

- New `tagSStr` Cell tag (0xFFFB) packs strings of length ≤ 5 inline: length in payload bits 40..47, bytes in bits 0..39. Zero allocations, zero Objects entries.
- Per-function `StrCells []Cell` cache populated at `VM.Run` startup. Short literals pack inline; longer literals allocate once and the CPtr is cached. `OpLoadStrK` becomes a slice read on the hot path.
- All six string ops (LoadStrK, ConcatStr, LenStr, IndexStr, EqualStr, HashStr) handle both inline and heap forms. `OpConcatStr` packs the result inline when the combined length fits.

## Results

| N  | vm2 (before) | vm2 (after) | vs CPython | vs Lua |
|----|--------------|-------------|------------|--------|
| 10 | 624 µs       | 244 µs      | 1.15x → 0.92x | 1.41x → **1.02x** |
| 30 | 1807 µs      | 889 µs      | 1.61x → 1.50x | 1.11x → **1.06x** |

At N=10 vm2 reaches **Lua parity** and beats CPython. At N=30 the result outgrows the 5-byte inline budget so the loop tail still allocates per concat; remaining CPython gap is the in-place resize fast-path. Concat reuse-when-unique is the next target.

Closes #21521.