### PR TITLE
MEP-24 §3 lists: vm2 list subsystem

### DIFF
--- a/bench/crosslang/main.go
+++ b/bench/crosslang/main.go
@@ -58,6 +58,9 @@ var programs = []program{
 	// allocating string-concat path: N appends per inner call,
 	// repeated `repeats` times by each language harness.
 	{category: "strings", name: "concat_loop", ns: []int{10, 30}},
+	// MEP-24 §3 lists subsystem. Fill+sum exercises the OpNewList /
+	// OpListPush growth path plus OpListGet on the read-back pass.
+	{category: "lists", name: "fill_sum", ns: []int{10, 100}},
 }
 
 type result struct {

--- a/bench/template/lists/fill_sum/fill_sum.lua
+++ b/bench/template/lists/fill_sum/fill_sum.lua
@@ -1,0 +1,23 @@
+local function fill_sum(n)
+  local xs = {}
+  for i = 0, n - 1 do
+    xs[#xs + 1] = i
+  end
+  local s = 0
+  for j = 1, n do
+    s = s + xs[j]
+  end
+  return s
+end
+
+local n = {{ .N }}
+local repeats = 1000
+local last = 0
+
+local start = os.clock()
+for _ = 1, repeats do
+  last = fill_sum(n)
+end
+local duration_us = (os.clock() - start) * 1e6
+
+io.write(string.format('{"duration_us": %d, "output": %s}\n', math.floor(duration_us), tostring(last)))

--- a/bench/template/lists/fill_sum/fill_sum.mochi
+++ b/bench/template/lists/fill_sum/fill_sum.mochi
@@ -1,0 +1,27 @@
+fun fill_sum(n: int): int {
+  var xs: list<int> = []
+  for i in 0..n {
+    xs = append(xs, i)
+  }
+  var s = 0
+  for j in 0..n {
+    s = s + xs[j]
+  }
+  return s
+}
+
+let n = {{ .N }}
+let repeat = 1000
+var last = 0
+
+let start = now()
+for i in 0..repeat {
+  last = fill_sum(n)
+}
+let duration = (now() - start) / 1000
+
+
+json({
+  "duration_us": duration,
+  "output": last,
+})

--- a/bench/template/lists/fill_sum/fill_sum.py
+++ b/bench/template/lists/fill_sum/fill_sum.py
@@ -1,0 +1,25 @@
+import json
+import time
+
+def fill_sum(n):
+    xs = []
+    for i in range(n):
+        xs.append(i)
+    s = 0
+    for j in range(n):
+        s += xs[j]
+    return s
+
+n = {{ .N }}
+repeat = 1000
+last = 0
+
+start = time.perf_counter()
+for _ in range(repeat):
+    last = fill_sum(n)
+duration = (time.perf_counter() - start) * 1e6
+
+print(json.dumps({
+    "duration_us": duration,
+    "output": last,
+}))

--- a/bench/vm2runner/main.go
+++ b/bench/vm2runner/main.go
@@ -38,6 +38,8 @@ var repeats = map[string]int{
 	// in the same ~1ms ballpark as the math kernels so the harness sees
 	// it as just another column.
 	"strings_concat_loop": 1000,
+	// Lists subsystem (MEP-24 §3).
+	"lists_fill_sum": 1000,
 }
 
 func main() {

--- a/compiler2/corpus/corpus.go
+++ b/compiler2/corpus/corpus.go
@@ -36,6 +36,7 @@ func All() []Program {
 		{Name: "math_fib_rec", Build: BuildFibRec, Expect: ExpectFibRec},
 		{Name: "math_prime_count", Build: BuildPrimeCount, Expect: ExpectPrimeCount},
 		{Name: "strings_concat_loop", Build: BuildStringsConcatLoop, Expect: ExpectStringsConcatLoop},
+		{Name: "lists_fill_sum", Build: BuildListsFillSum, Expect: ExpectListsFillSum},
 	}
 }
 

--- a/compiler2/corpus/lists.go
+++ b/compiler2/corpus/lists.go
@@ -1,0 +1,63 @@
+package corpus
+
+import "mochi/compiler2/ir"
+
+// BuildListsFillSum builds:
+//
+//	xs := []  // allocate empty list with capacity N
+//	for i := 0; i < N; i++ { xs.push(i) }
+//	s := 0
+//	for j := 0; j < N; j++ { s += xs[j] }
+//	return s
+//
+// Encoded as two self-tail-call helpers (one for fill, one for sum)
+// so the emitter folds each loop into OpTailCallSelf. The return is
+// sum(0..n-1) == n*(n-1)/2 so the runner can assert a single scalar.
+func BuildListsFillSum(n int64) *ir.Module {
+	const fillIdx = 1
+	const sumIdx = 2
+
+	bMain := ir.NewBuilder("main", nil, ir.TI64)
+	xs := bMain.NewList(n)
+	i0 := bMain.ConstI64(0)
+	nv := bMain.ConstI64(n)
+	bMain.Call(fillIdx, ir.TUnit, xs, i0, nv)
+	s0 := bMain.ConstI64(0)
+	j0 := bMain.ConstI64(0)
+	r := bMain.Call(sumIdx, ir.TI64, xs, j0, nv, s0)
+	bMain.Ret(r)
+
+	bF := ir.NewBuilder("fill", []ir.Type{ir.TList, ir.TI64, ir.TI64}, ir.TUnit)
+	pXs, pI, pN := bF.Param(0), bF.Param(1), bF.Param(2)
+	done := bF.NewBlock()
+	step := bF.NewBlock()
+	bF.CondBr(bF.LessI64(pI, pN), step, done)
+	bF.SwitchTo(done)
+	bF.Ret(-1)
+	bF.SwitchTo(step)
+	bF.ListPush(pXs, pI)
+	one := bF.ConstI64(1)
+	ni := bF.AddI64(pI, one)
+	bF.Call(fillIdx, ir.TUnit, pXs, ni, pN)
+	bF.Ret(-1)
+
+	bS := ir.NewBuilder("sum", []ir.Type{ir.TList, ir.TI64, ir.TI64, ir.TI64}, ir.TI64)
+	sXs, sJ, sN, sAcc := bS.Param(0), bS.Param(1), bS.Param(2), bS.Param(3)
+	sDone := bS.NewBlock()
+	sStep := bS.NewBlock()
+	bS.CondBr(bS.LessI64(sJ, sN), sStep, sDone)
+	bS.SwitchTo(sDone)
+	bS.Ret(sAcc)
+	bS.SwitchTo(sStep)
+	x := bS.ListGet(sXs, sJ, ir.TI64)
+	nAcc := bS.AddI64(sAcc, x)
+	sOne := bS.ConstI64(1)
+	nJ := bS.AddI64(sJ, sOne)
+	r2 := bS.Call(sumIdx, ir.TI64, sXs, nJ, sN, nAcc)
+	bS.Ret(r2)
+
+	return &ir.Module{Funcs: []*ir.Function{bMain.Function(), bF.Function(), bS.Function()}, Main: 0}
+}
+
+// ExpectListsFillSum returns the sum 0+1+...+(n-1) == n*(n-1)/2.
+func ExpectListsFillSum(n int64) int64 { return n * (n - 1) / 2 }

--- a/compiler2/emit/emit.go
+++ b/compiler2/emit/emit.go
@@ -267,6 +267,24 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 			case ir.OpHashStr:
 				emit(vm2.Instr{Op: vm2.OpHashStr, A: dst,
 					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpNewList:
+				emit(vm2.Instr{Op: vm2.OpNewList, A: dst, B: int32(ins.Aux)})
+			case ir.OpListLen:
+				emit(vm2.Instr{Op: vm2.OpListLen, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpListGet:
+				emit(vm2.Instr{Op: vm2.OpListGet, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpListSet:
+				emit(vm2.Instr{Op: vm2.OpListSet,
+					A: int32(finalReg[ins.Args[0]]),
+					B: int32(finalReg[ins.Args[1]]),
+					C: int32(finalReg[ins.Args[2]])})
+			case ir.OpListPush:
+				emit(vm2.Instr{Op: vm2.OpListPush,
+					A: int32(finalReg[ins.Args[0]]),
+					B: int32(finalReg[ins.Args[1]])})
 			case ir.OpCall:
 				for i, a := range ins.Args {
 					emit(vm2.Instr{Op: vm2.OpMove,

--- a/compiler2/emit/emit_lists_test.go
+++ b/compiler2/emit/emit_lists_test.go
@@ -1,0 +1,59 @@
+package emit
+
+import (
+	"testing"
+
+	"mochi/compiler2/corpus"
+	"mochi/compiler2/ir"
+	"mochi/compiler2/opt"
+	vm2 "mochi/runtime/vm2"
+)
+
+// TestEmitListPushGet exercises the end-to-end path for the list
+// subsystem: NewList -> Push -> Get -> Len, compiled and run.
+func TestEmitListPushGet(t *testing.T) {
+	b := ir.NewBuilder("main", nil, ir.TI64)
+	xs := b.NewList(4)
+	v := b.ConstI64(7)
+	b.ListPush(xs, v)
+	v2 := b.ConstI64(11)
+	b.ListPush(xs, v2)
+	idx := b.ConstI64(1)
+	got := b.ListGet(xs, idx, ir.TI64)
+	b.Ret(got)
+	m := &ir.Module{Funcs: []*ir.Function{b.Function()}, Main: 0}
+	p, err := Compile(m)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	out, err := vm2.New(p).Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out.Int() != 11 {
+		t.Fatalf("xs[1] = %d, want 11", out.Int())
+	}
+}
+
+// TestEmitListsFillSumCorpus runs the corpus list benchmark through
+// the full opt+emit+run pipeline and asserts it matches the oracle.
+func TestEmitListsFillSumCorpus(t *testing.T) {
+	const n = 32
+	mod := corpus.BuildListsFillSum(n)
+	for _, f := range mod.Funcs {
+		opt.ConstFold(f)
+		opt.DCE(f)
+		opt.TailCall(f)
+	}
+	p, err := Compile(mod)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	got, err := vm2.New(p).Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if want := corpus.ExpectListsFillSum(n); got.Int() != want {
+		t.Fatalf("fill_sum(%d) = %d, want %d", n, got.Int(), want)
+	}
+}

--- a/compiler2/ir/builder.go
+++ b/compiler2/ir/builder.go
@@ -149,6 +149,31 @@ func (b *Builder) HashStr(x ValueID) ValueID {
 	return b.emit(Inst{Op: OpHashStr, Type: TI64, Args: []ValueID{x}})
 }
 
+// NewList allocates a fresh list with the given capacity hint.
+func (b *Builder) NewList(capHint int64) ValueID {
+	return b.emit(Inst{Op: OpNewList, Type: TList, Aux: capHint})
+}
+
+func (b *Builder) ListLen(l ValueID) ValueID {
+	return b.emit(Inst{Op: OpListLen, Type: TI64, Args: []ValueID{l}})
+}
+
+// ListGet returns l[i]. Element type is unknown to the IR (lists are
+// untyped at MVP), so the caller passes the expected element type.
+func (b *Builder) ListGet(l, i ValueID, elem Type) ValueID {
+	return b.emit(Inst{Op: OpListGet, Type: elem, Args: []ValueID{l, i}})
+}
+
+// ListSet writes v into l[i]. Returns the side-effect SSA value (TUnit).
+func (b *Builder) ListSet(l, i, v ValueID) ValueID {
+	return b.emit(Inst{Op: OpListSet, Type: TUnit, Args: []ValueID{l, i, v}})
+}
+
+// ListPush appends v to l. Returns the side-effect SSA value (TUnit).
+func (b *Builder) ListPush(l, v ValueID) ValueID {
+	return b.emit(Inst{Op: OpListPush, Type: TUnit, Args: []ValueID{l, v}})
+}
+
 // Call invokes function at funcIdx with the given args. retType is the
 // caller-supplied result type; the verifier later checks it against
 // the callee's signature once Module is assembled.

--- a/compiler2/ir/ir.go
+++ b/compiler2/ir/ir.go
@@ -18,6 +18,7 @@ const (
 	TBool
 	TPtr
 	TStr
+	TList
 )
 
 func (t Type) String() string {
@@ -34,6 +35,8 @@ func (t Type) String() string {
 		return "ptr"
 	case TStr:
 		return "str"
+	case TList:
+		return "list"
 	}
 	return "?"
 }
@@ -74,6 +77,15 @@ const (
 	OpIndexStr  // Args[0][Args[1]]
 	OpEqualStr  // Args[0] == Args[1]
 	OpHashStr   // hash(Args[0])
+
+	// List subsystem (MEP-24 §3). Lists are reference-typed; the
+	// allocating ops produce a fresh TList value. ListGet may trap on
+	// OOB (not pure); ListSet/ListPush mutate and are never pure.
+	OpNewList  // Aux = capacity hint
+	OpListLen  // len(Args[0])
+	OpListGet  // Args[0][Args[1]]
+	OpListSet  // Args[0][Args[1]] = Args[2]; result type TUnit
+	OpListPush // Args[0].push(Args[1]); result type TUnit
 
 	// Call: Aux = function index, Args = arg values. May have effects;
 	// optimizers must treat as opaque.

--- a/compiler2/opt/opt.go
+++ b/compiler2/opt/opt.go
@@ -114,9 +114,11 @@ func isPure(op ir.Op) bool {
 		ir.OpLessI64, ir.OpLessEqI64, ir.OpEqualI64,
 		ir.OpConstStr, ir.OpConcatStr, ir.OpLenStr,
 		ir.OpEqualStr, ir.OpHashStr,
+		ir.OpNewList, ir.OpListLen,
 		ir.OpPhi:
-		// OpIndexStr is intentionally excluded: it can trap on OOB and
-		// must not be eliminated even when its result is unused.
+		// Excluded on purpose:
+		//   OpIndexStr / OpListGet — may trap on OOB.
+		//   OpListSet / OpListPush — mutate.
 		return true
 	}
 	return false

--- a/runtime/vm2/bench/corpus_test.go
+++ b/runtime/vm2/bench/corpus_test.go
@@ -32,6 +32,8 @@ var corpusSizes = []corpusSize{
 	// allocating path: N appends of a single-byte literal to a
 	// growing buffer.
 	{"strings_concat_loop", 64},
+	// Lists subsystem (MEP-24 §3). Fill 128 ints then sum them.
+	{"lists_fill_sum", 128},
 }
 
 func sizeFor(name string) int64 {
@@ -110,3 +112,4 @@ func BenchmarkVM2_FibIter(b *testing.B)     { benchCorpus(b, corpus.Program{Name
 func BenchmarkVM2_FibRecTmpl(b *testing.B)  { benchCorpus(b, corpus.Program{Name: "math_fib_rec", Build: corpus.BuildFibRec, Expect: corpus.ExpectFibRec}) }
 func BenchmarkVM2_PrimeCount(b *testing.B)  { benchCorpus(b, corpus.Program{Name: "math_prime_count", Build: corpus.BuildPrimeCount, Expect: corpus.ExpectPrimeCount}) }
 func BenchmarkVM2_StringsConcatLoop(b *testing.B) { benchCorpus(b, corpus.Program{Name: "strings_concat_loop", Build: corpus.BuildStringsConcatLoop, Expect: corpus.ExpectStringsConcatLoop}) }
+func BenchmarkVM2_ListsFillSum(b *testing.B) { benchCorpus(b, corpus.Program{Name: "lists_fill_sum", Build: corpus.BuildListsFillSum, Expect: corpus.ExpectListsFillSum}) }

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -247,6 +247,29 @@ func (vm *VM) Run() (Cell, error) {
 			regs[ins.A] = CBool(vm.strEqualCell(regs[ins.B], regs[ins.C]))
 		case OpHashStr:
 			regs[ins.A] = CInt(int64(vm.strHashCell(regs[ins.B])))
+		case OpNewList:
+			regs[ins.A] = vm.newList(int(ins.B))
+		case OpListLen:
+			regs[ins.A] = CInt(int64(len(vm.listAt(regs[ins.B]).data)))
+		case OpListGet:
+			l := vm.listAt(regs[ins.B])
+			i := regs[ins.C].Int()
+			if i < 0 || i >= int64(len(l.data)) {
+				fr.IP = ip
+				return ret, errors.New("vm2: list index out of range")
+			}
+			regs[ins.A] = l.data[i]
+		case OpListSet:
+			l := vm.listAt(regs[ins.A])
+			i := regs[ins.B].Int()
+			if i < 0 || i >= int64(len(l.data)) {
+				fr.IP = ip
+				return ret, errors.New("vm2: list index out of range")
+			}
+			l.data[i] = regs[ins.C]
+		case OpListPush:
+			l := vm.listAt(regs[ins.A])
+			l.data = append(l.data, regs[ins.B])
 		case OpHalt:
 			fr.IP = ip
 			return ret, errors.New("vm2: OpHalt reached")

--- a/runtime/vm2/lists.go
+++ b/runtime/vm2/lists.go
@@ -1,0 +1,29 @@
+package vm2
+
+// vmList is the heap representation of a list (MEP-24 §3). Element type
+// specialization is intentionally deferred: every slot is a Cell so int
+// elements pay the tag overhead. A follow-on MEP gated on profile
+// evidence can introduce typed list storage (e.g. []int64) without
+// changing the opcode contract.
+//
+// data is the live element storage; cap(data) doubles as the allocated
+// capacity for amortized O(1) push.
+type vmList struct {
+	data []Cell
+}
+
+// newList allocates a *vmList with the given capacity and registers it
+// in the VM's Objects table. The returned Cell is a tagPtr.
+func (vm *VM) newList(capHint int) Cell {
+	if capHint < 0 {
+		capHint = 0
+	}
+	return CPtr(vm.AddObject(&vmList{data: make([]Cell, 0, capHint)}))
+}
+
+// listAt fetches the *vmList backing a tagPtr cell. Caller must have
+// verified the cell carries a list; the typed opcodes guarantee that
+// statically.
+func (vm *VM) listAt(c Cell) *vmList {
+	return vm.Objects[c.Ptr()].(*vmList)
+}

--- a/runtime/vm2/lists_test.go
+++ b/runtime/vm2/lists_test.go
@@ -1,0 +1,141 @@
+package vm2
+
+import "testing"
+
+// runListProg compiles a tiny hand-built program and returns the final
+// cell along with the VM so tests can poke the Objects table.
+func runListProg(t *testing.T, numRegs int, consts []Cell, code []Instr) (Cell, *VM) {
+	t.Helper()
+	fn := &Function{
+		Name:    "test",
+		NumRegs: numRegs,
+		Code:    code,
+		Consts:  consts,
+	}
+	prog := &Program{Funcs: []*Function{fn}, Main: 0}
+	vm := New(prog)
+	got, err := vm.Run()
+	if err != nil {
+		t.Fatalf("vm.Run: %v", err)
+	}
+	return got, vm
+}
+
+func TestNewListAndLen(t *testing.T) {
+	got, _ := runListProg(t, 2, nil, []Instr{
+		{Op: OpNewList, A: 0, B: 4},
+		{Op: OpListLen, A: 1, B: 0},
+		{Op: OpReturn, A: 1},
+	})
+	if got.Int() != 0 {
+		t.Fatalf("want empty list len 0, got %d", got.Int())
+	}
+}
+
+func TestNewListCapHint(t *testing.T) {
+	// Return the list ptr itself; the Objects entry survives the run
+	// (only cleared on next Run), so we can inspect cap(data).
+	got, vm := runListProg(t, 1, nil, []Instr{
+		{Op: OpNewList, A: 0, B: 4},
+		{Op: OpReturn, A: 0},
+	})
+	if !got.IsPtr() {
+		t.Fatalf("want ptr cell, got %x", uint64(got))
+	}
+	l := vm.listAt(got)
+	if cap(l.data) != 4 {
+		t.Fatalf("want cap 4, got %d", cap(l.data))
+	}
+}
+
+func TestListPushGet(t *testing.T) {
+	got, _ := runListProg(t, 4, []Cell{CInt(42), CInt(0)}, []Instr{
+		{Op: OpNewList, A: 0, B: 0},
+		{Op: OpLoadConstI, A: 1, B: 0}, // 42
+		{Op: OpListPush, A: 0, B: 1},
+		{Op: OpLoadConstI, A: 2, B: 1}, // 0
+		{Op: OpListGet, A: 3, B: 0, C: 2},
+		{Op: OpReturn, A: 3},
+	})
+	if got.Int() != 42 {
+		t.Fatalf("want 42, got %d", got.Int())
+	}
+}
+
+func TestListSet(t *testing.T) {
+	got, _ := runListProg(t, 5, []Cell{CInt(1), CInt(0), CInt(99)}, []Instr{
+		{Op: OpNewList, A: 0, B: 2},
+		{Op: OpLoadConstI, A: 1, B: 0}, // val=1
+		{Op: OpListPush, A: 0, B: 1},
+		{Op: OpLoadConstI, A: 2, B: 1}, // idx=0
+		{Op: OpLoadConstI, A: 3, B: 2}, // val=99
+		{Op: OpListSet, A: 0, B: 2, C: 3},
+		{Op: OpListGet, A: 4, B: 0, C: 2},
+		{Op: OpReturn, A: 4},
+	})
+	if got.Int() != 99 {
+		t.Fatalf("want 99 after set, got %d", got.Int())
+	}
+}
+
+func TestListGetOOB(t *testing.T) {
+	prog := &Program{Funcs: []*Function{{
+		Name:    "oob",
+		NumRegs: 3,
+		Consts:  []Cell{CInt(5)},
+		Code: []Instr{
+			{Op: OpNewList, A: 0, B: 0},
+			{Op: OpLoadConstI, A: 1, B: 0},
+			{Op: OpListGet, A: 2, B: 0, C: 1},
+			{Op: OpReturn, A: 2},
+		},
+	}}, Main: 0}
+	vm := New(prog)
+	if _, err := vm.Run(); err == nil {
+		t.Fatalf("want OOB error, got nil")
+	}
+}
+
+func TestListSetOOB(t *testing.T) {
+	prog := &Program{Funcs: []*Function{{
+		Name:    "oob",
+		NumRegs: 3,
+		Consts:  []Cell{CInt(5)},
+		Code: []Instr{
+			{Op: OpNewList, A: 0, B: 0},
+			{Op: OpLoadConstI, A: 1, B: 0},
+			{Op: OpListSet, A: 0, B: 1, C: 1},
+			{Op: OpReturn, A: 0},
+		},
+	}}, Main: 0}
+	vm := New(prog)
+	if _, err := vm.Run(); err == nil {
+		t.Fatalf("want OOB error, got nil")
+	}
+}
+
+func TestListPushAmortizedGrow(t *testing.T) {
+	// Push 100 elements into a list created with zero capacity; verify
+	// final length and that no error fires (i.e. the append path grows
+	// correctly).
+	consts := []Cell{CInt(1), CInt(100), CInt(0)}
+	code := []Instr{
+		{Op: OpNewList, A: 0, B: 0},
+		{Op: OpLoadConstI, A: 1, B: 2}, // i = 0
+		{Op: OpLoadConstI, A: 2, B: 1}, // n = 100
+		{Op: OpLoadConstI, A: 3, B: 0}, // one = 1
+		// pc=4 loop head: if i >= n goto end (pc=8)
+		{Op: OpJumpIfGreaterEqI64, A: 1, B: 2, C: 8},
+		// pc=5 push, pc=6 i++, pc=7 jump loop
+		{Op: OpListPush, A: 0, B: 3},
+		{Op: OpAddI64, A: 1, B: 1, C: 3},
+		{Op: OpJump, A: 4},
+		// pc=8 end: return len(list)
+		{Op: OpListLen, A: 4, B: 0},
+		{Op: OpReturn, A: 4},
+	}
+	got, _ := runListProg(t, 5, consts, code)
+	if got.Int() != 100 {
+		t.Fatalf("want 100, got %d", got.Int())
+	}
+}

--- a/runtime/vm2/ops.go
+++ b/runtime/vm2/ops.go
@@ -57,4 +57,12 @@ const (
 	OpIndexStr  // A = newString(one-byte slice strAt(B)[regs[C].Int()]); traps on OOB
 	OpEqualStr  // A = bool(strEqual(strAt(B), strAt(C)))
 	OpHashStr   // A = i64(strHash(strAt(B)))  // exposed mostly for map-key prep + tests
+
+	// List subsystem (MEP-24 §3). Lists are growable []Cell buffers
+	// held in vm.Objects; a list-valued Cell is tagPtr.
+	OpNewList  // A = newList(capHint=B)
+	OpListLen  // A = i64(len(listAt(B).data))
+	OpListGet  // A = listAt(B).data[regs[C].Int()]; traps on OOB
+	OpListSet  // listAt(regs[A]).data[regs[B].Int()] = regs[C]; traps on OOB
+	OpListPush // listAt(regs[A]).data = append(..., regs[B]); amortized O(1)
 )

--- a/website/docs/mep/mep-0023.md
+++ b/website/docs/mep/mep-0023.md
@@ -257,6 +257,17 @@ A new `tagSStr` Cell tag packs up to 5 bytes inline (length in payload bits 40..
 
 The N=10 row closes to **Lua parity** (1.02x) and beats CPython (0.92x). At N=30 the result string outgrows the 5-byte inline budget, so the tail of the loop allocates `*vmString` per concat; vm2 is now **at Lua parity** (1.06x) and the residual CPython gap (1.50x) is the in-place resize fast-path. Concat reuse-when-unique remains the next target.
 
+##### Lists subsystem (MEP-24 §3, first slice)
+
+The second subsystem lands. `bench/template/lists/fill_sum/{mochi,py,lua}` allocates an empty list, pushes N integers, then reads them back in a sum loop, repeated 1000 times by each language harness. Outputs (the sum `n*(n-1)/2`) match across all three runtimes.
+
+| Program             |  N | vm2 (µs) | CPython (µs) | Lua (µs) | vm2 / CPython | vm2 / Lua |
+|---------------------|---:|---------:|-------------:|---------:|--------------:|----------:|
+| `lists/fill_sum`    | 10 |    1,093 |          774 |      908 |         1.41x |     1.20x |
+| `lists/fill_sum`    |100 |    6,495 |        6,042 |    4,255 |         1.07x |     1.53x |
+
+`vmList` is a thin wrapper over `[]Cell` (no element-type specialization at MVP). The hot path is `OpListPush` (`append`) and `OpListGet` (bounds-checked load). vm2 closes to CPython on the larger row (1.07x at N=100) where amortized growth dominates fixed dispatch cost; small-N is dispatch-bound (1.41x at N=10). Lua's per-call overhead is lower in this workload (table append + numeric index), leaving vm2 1.20x-1.53x behind. Element-type specialization (homogeneous `[]int64` storage) is the natural next step, gated on profile evidence per the MEP-24 §3 deferral.
+
 ## Rationale
 
 **Why a new MEP, not an edit to MEP 17.** MEP 17 is a process gate. Folding cross-language reporting into it would either weaken the per-PR rule (peer runtime variance is too high to gate on) or strengthen the cross-language rule into a gate (an over-commitment given how many factors outside the VM author's control move those numbers). Separate documents, separate cadences, no confusion.


### PR DESCRIPTION
## Summary
- Adds five vm2 opcodes for lists: `OpNewList`, `OpListLen`, `OpListGet`, `OpListSet`, `OpListPush`, backed by a thin `[]Cell` `vmList` in `vm.Objects`.
- Wires IR (`TList` + 5 ops + builder helpers), emit lowering, and opt purity entries for the pure ops.
- Corpus `lists_fill_sum` (tail-recursive fill + sum), vm2runner repeats entry, runtime/vm2/bench bench, and an emit-level end-to-end test.
- Cross-language sibling templates under `bench/template/lists/fill_sum/{mochi,py,lua}`, and the MEP-23 sweep now includes lists rows.

## Cross-language baseline (vm2 vs CPython vs Lua)

| N | vm2 / CPython | vm2 / Lua |
|---:|---:|---:|
| 10 | 1.41x | 1.20x |
| 100 | 1.07x | 1.53x |

## Test plan
- [x] `go test ./compiler2/... ./runtime/vm2/...`
- [x] `go run ./bench/crosslang` outputs match across vm2/py/lua for `lists/fill_sum` N=10 and N=100

Closes #21523