### PR TITLE
MEP-24 §4 maps: vm2 map subsystem

### DIFF
--- a/bench/crosslang/main.go
+++ b/bench/crosslang/main.go
@@ -61,6 +61,9 @@ var programs = []program{
 	// MEP-24 §3 lists subsystem. Fill+sum exercises the OpNewList /
 	// OpListPush growth path plus OpListGet on the read-back pass.
 	{category: "lists", name: "fill_sum", ns: []int{10, 100}},
+	// MEP-24 §4 maps subsystem. Same fill+sum shape but keyed by int;
+	// exercises OpNewMap, OpMapSet, OpMapGet through Go's map[any]Cell.
+	{category: "maps", name: "fill_sum", ns: []int{10, 100}},
 }
 
 type result struct {

--- a/bench/template/maps/fill_sum/fill_sum.lua
+++ b/bench/template/maps/fill_sum/fill_sum.lua
@@ -1,0 +1,23 @@
+local function fill_sum(n)
+  local m = {}
+  for i = 0, n - 1 do
+    m[i] = i
+  end
+  local s = 0
+  for j = 0, n - 1 do
+    s = s + m[j]
+  end
+  return s
+end
+
+local n = {{ .N }}
+local repeats = 1000
+local last = 0
+
+local start = os.clock()
+for _ = 1, repeats do
+  last = fill_sum(n)
+end
+local duration_us = (os.clock() - start) * 1e6
+
+io.write(string.format('{"duration_us": %d, "output": %s}\n', math.floor(duration_us), tostring(last)))

--- a/bench/template/maps/fill_sum/fill_sum.mochi
+++ b/bench/template/maps/fill_sum/fill_sum.mochi
@@ -1,0 +1,27 @@
+fun fill_sum(n: int): int {
+  var m: map<int, int> = {:}
+  for i in 0..n {
+    m[i] = i
+  }
+  var s = 0
+  for j in 0..n {
+    s = s + m[j]
+  }
+  return s
+}
+
+let n = {{ .N }}
+let repeat = 1000
+var last = 0
+
+let start = now()
+for i in 0..repeat {
+  last = fill_sum(n)
+}
+let duration = (now() - start) / 1000
+
+
+json({
+  "duration_us": duration,
+  "output": last,
+})

--- a/bench/template/maps/fill_sum/fill_sum.py
+++ b/bench/template/maps/fill_sum/fill_sum.py
@@ -1,0 +1,25 @@
+import json
+import time
+
+def fill_sum(n):
+    m = {}
+    for i in range(n):
+        m[i] = i
+    s = 0
+    for j in range(n):
+        s += m[j]
+    return s
+
+n = {{ .N }}
+repeat = 1000
+last = 0
+
+start = time.perf_counter()
+for _ in range(repeat):
+    last = fill_sum(n)
+duration = (time.perf_counter() - start) * 1e6
+
+print(json.dumps({
+    "duration_us": duration,
+    "output": last,
+}))

--- a/bench/vm2runner/main.go
+++ b/bench/vm2runner/main.go
@@ -40,6 +40,8 @@ var repeats = map[string]int{
 	"strings_concat_loop": 1000,
 	// Lists subsystem (MEP-24 §3).
 	"lists_fill_sum": 1000,
+	// Maps subsystem (MEP-24 §4).
+	"maps_fill_sum": 1000,
 }
 
 func main() {

--- a/compiler2/corpus/corpus.go
+++ b/compiler2/corpus/corpus.go
@@ -37,6 +37,7 @@ func All() []Program {
 		{Name: "math_prime_count", Build: BuildPrimeCount, Expect: ExpectPrimeCount},
 		{Name: "strings_concat_loop", Build: BuildStringsConcatLoop, Expect: ExpectStringsConcatLoop},
 		{Name: "lists_fill_sum", Build: BuildListsFillSum, Expect: ExpectListsFillSum},
+		{Name: "maps_fill_sum", Build: BuildMapsFillSum, Expect: ExpectMapsFillSum},
 	}
 }
 

--- a/compiler2/corpus/maps.go
+++ b/compiler2/corpus/maps.go
@@ -1,0 +1,65 @@
+package corpus
+
+import "mochi/compiler2/ir"
+
+// BuildMapsFillSum builds the map analogue of BuildListsFillSum:
+//
+//	m := {}
+//	for i := 0; i < N; i++ { m[i] = i }
+//	s := 0
+//	for j := 0; j < N; j++ { s += m[j] }
+//	return s
+//
+// Same two self-tail-call helpers (fill, sum) so each loop folds to
+// OpTailCallSelf. The benchmark exercises OpNewMap + OpMapSet +
+// OpMapGet at MVP using int keys, where Go's map[any]Cell stores int64
+// keys directly.
+func BuildMapsFillSum(n int64) *ir.Module {
+	const fillIdx = 1
+	const sumIdx = 2
+
+	bMain := ir.NewBuilder("main", nil, ir.TI64)
+	m := bMain.NewMap()
+	i0 := bMain.ConstI64(0)
+	nv := bMain.ConstI64(n)
+	bMain.Call(fillIdx, ir.TUnit, m, i0, nv)
+	s0 := bMain.ConstI64(0)
+	j0 := bMain.ConstI64(0)
+	r := bMain.Call(sumIdx, ir.TI64, m, j0, nv, s0)
+	bMain.Ret(r)
+
+	bF := ir.NewBuilder("fill", []ir.Type{ir.TMap, ir.TI64, ir.TI64}, ir.TUnit)
+	pM, pI, pN := bF.Param(0), bF.Param(1), bF.Param(2)
+	done := bF.NewBlock()
+	step := bF.NewBlock()
+	bF.CondBr(bF.LessI64(pI, pN), step, done)
+	bF.SwitchTo(done)
+	bF.Ret(-1)
+	bF.SwitchTo(step)
+	bF.MapSet(pM, pI, pI)
+	one := bF.ConstI64(1)
+	ni := bF.AddI64(pI, one)
+	bF.Call(fillIdx, ir.TUnit, pM, ni, pN)
+	bF.Ret(-1)
+
+	bS := ir.NewBuilder("sum", []ir.Type{ir.TMap, ir.TI64, ir.TI64, ir.TI64}, ir.TI64)
+	sM, sJ, sN, sAcc := bS.Param(0), bS.Param(1), bS.Param(2), bS.Param(3)
+	sDone := bS.NewBlock()
+	sStep := bS.NewBlock()
+	bS.CondBr(bS.LessI64(sJ, sN), sStep, sDone)
+	bS.SwitchTo(sDone)
+	bS.Ret(sAcc)
+	bS.SwitchTo(sStep)
+	x := bS.MapGet(sM, sJ, ir.TI64)
+	nAcc := bS.AddI64(sAcc, x)
+	sOne := bS.ConstI64(1)
+	nJ := bS.AddI64(sJ, sOne)
+	r2 := bS.Call(sumIdx, ir.TI64, sM, nJ, sN, nAcc)
+	bS.Ret(r2)
+
+	return &ir.Module{Funcs: []*ir.Function{bMain.Function(), bF.Function(), bS.Function()}, Main: 0}
+}
+
+// ExpectMapsFillSum returns the expected sum, identical to fill_sum:
+// sum 0..n-1 == n*(n-1)/2.
+func ExpectMapsFillSum(n int64) int64 { return n * (n - 1) / 2 }

--- a/compiler2/emit/emit.go
+++ b/compiler2/emit/emit.go
@@ -285,6 +285,28 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 				emit(vm2.Instr{Op: vm2.OpListPush,
 					A: int32(finalReg[ins.Args[0]]),
 					B: int32(finalReg[ins.Args[1]])})
+			case ir.OpNewMap:
+				emit(vm2.Instr{Op: vm2.OpNewMap, A: dst})
+			case ir.OpMapLen:
+				emit(vm2.Instr{Op: vm2.OpMapLen, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpMapGet:
+				emit(vm2.Instr{Op: vm2.OpMapGet, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpMapHas:
+				emit(vm2.Instr{Op: vm2.OpMapHas, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpMapSet:
+				emit(vm2.Instr{Op: vm2.OpMapSet,
+					A: int32(finalReg[ins.Args[0]]),
+					B: int32(finalReg[ins.Args[1]]),
+					C: int32(finalReg[ins.Args[2]])})
+			case ir.OpMapDel:
+				emit(vm2.Instr{Op: vm2.OpMapDel,
+					A: int32(finalReg[ins.Args[0]]),
+					B: int32(finalReg[ins.Args[1]])})
 			case ir.OpCall:
 				for i, a := range ins.Args {
 					emit(vm2.Instr{Op: vm2.OpMove,

--- a/compiler2/emit/emit_maps_test.go
+++ b/compiler2/emit/emit_maps_test.go
@@ -1,0 +1,60 @@
+package emit
+
+import (
+	"testing"
+
+	"mochi/compiler2/corpus"
+	"mochi/compiler2/ir"
+	"mochi/compiler2/opt"
+	vm2 "mochi/runtime/vm2"
+)
+
+// TestEmitMapSetGet exercises the end-to-end path for the map
+// subsystem: NewMap -> Set -> Get -> Len, compiled and run.
+func TestEmitMapSetGet(t *testing.T) {
+	b := ir.NewBuilder("main", nil, ir.TI64)
+	m := b.NewMap()
+	k1 := b.ConstI64(1)
+	v1 := b.ConstI64(11)
+	b.MapSet(m, k1, v1)
+	k2 := b.ConstI64(2)
+	v2 := b.ConstI64(22)
+	b.MapSet(m, k2, v2)
+	got := b.MapGet(m, k2, ir.TI64)
+	b.Ret(got)
+	mod := &ir.Module{Funcs: []*ir.Function{b.Function()}, Main: 0}
+	p, err := Compile(mod)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	out, err := vm2.New(p).Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out.Int() != 22 {
+		t.Fatalf("m[2] = %d, want 22", out.Int())
+	}
+}
+
+// TestEmitMapsFillSumCorpus runs the corpus map benchmark through the
+// full opt+emit+run pipeline and asserts it matches the oracle.
+func TestEmitMapsFillSumCorpus(t *testing.T) {
+	const n = 32
+	mod := corpus.BuildMapsFillSum(n)
+	for _, f := range mod.Funcs {
+		opt.ConstFold(f)
+		opt.DCE(f)
+		opt.TailCall(f)
+	}
+	p, err := Compile(mod)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	got, err := vm2.New(p).Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if want := corpus.ExpectMapsFillSum(n); got.Int() != want {
+		t.Fatalf("maps_fill_sum(%d) = %d, want %d", n, got.Int(), want)
+	}
+}

--- a/compiler2/ir/builder.go
+++ b/compiler2/ir/builder.go
@@ -174,6 +174,34 @@ func (b *Builder) ListPush(l, v ValueID) ValueID {
 	return b.emit(Inst{Op: OpListPush, Type: TUnit, Args: []ValueID{l, v}})
 }
 
+// NewMap allocates a fresh empty map.
+func (b *Builder) NewMap() ValueID {
+	return b.emit(Inst{Op: OpNewMap, Type: TMap})
+}
+
+func (b *Builder) MapLen(m ValueID) ValueID {
+	return b.emit(Inst{Op: OpMapLen, Type: TI64, Args: []ValueID{m}})
+}
+
+// MapGet returns m[k]. Value type is unknown to the IR (maps are
+// untyped at MVP), so the caller passes the expected value type. A
+// missing key reads back as a null Cell at runtime.
+func (b *Builder) MapGet(m, k ValueID, val Type) ValueID {
+	return b.emit(Inst{Op: OpMapGet, Type: val, Args: []ValueID{m, k}})
+}
+
+func (b *Builder) MapHas(m, k ValueID) ValueID {
+	return b.emit(Inst{Op: OpMapHas, Type: TBool, Args: []ValueID{m, k}})
+}
+
+func (b *Builder) MapSet(m, k, v ValueID) ValueID {
+	return b.emit(Inst{Op: OpMapSet, Type: TUnit, Args: []ValueID{m, k, v}})
+}
+
+func (b *Builder) MapDel(m, k ValueID) ValueID {
+	return b.emit(Inst{Op: OpMapDel, Type: TUnit, Args: []ValueID{m, k}})
+}
+
 // Call invokes function at funcIdx with the given args. retType is the
 // caller-supplied result type; the verifier later checks it against
 // the callee's signature once Module is assembled.

--- a/compiler2/ir/ir.go
+++ b/compiler2/ir/ir.go
@@ -19,6 +19,7 @@ const (
 	TPtr
 	TStr
 	TList
+	TMap
 )
 
 func (t Type) String() string {
@@ -37,6 +38,8 @@ func (t Type) String() string {
 		return "str"
 	case TList:
 		return "list"
+	case TMap:
+		return "map"
 	}
 	return "?"
 }
@@ -86,6 +89,17 @@ const (
 	OpListGet  // Args[0][Args[1]]
 	OpListSet  // Args[0][Args[1]] = Args[2]; result type TUnit
 	OpListPush // Args[0].push(Args[1]); result type TUnit
+
+	// Map subsystem (MEP-24 §4). Maps are reference-typed; OpNewMap
+	// produces a fresh TMap value. OpMapGet returns the value type (or
+	// TUnit/null sentinel when callers do not care); OpMapSet/OpMapDel
+	// mutate and have TUnit result.
+	OpNewMap // (no args)
+	OpMapLen // len(Args[0])
+	OpMapGet // Args[0][Args[1]]; missing key -> null cell
+	OpMapHas // bool(present(Args[0], Args[1]))
+	OpMapSet // Args[0][Args[1]] = Args[2]; TUnit
+	OpMapDel // delete Args[0][Args[1]]; TUnit
 
 	// Call: Aux = function index, Args = arg values. May have effects;
 	// optimizers must treat as opaque.

--- a/compiler2/opt/opt.go
+++ b/compiler2/opt/opt.go
@@ -115,10 +115,11 @@ func isPure(op ir.Op) bool {
 		ir.OpConstStr, ir.OpConcatStr, ir.OpLenStr,
 		ir.OpEqualStr, ir.OpHashStr,
 		ir.OpNewList, ir.OpListLen,
+		ir.OpNewMap, ir.OpMapLen, ir.OpMapHas,
 		ir.OpPhi:
 		// Excluded on purpose:
-		//   OpIndexStr / OpListGet — may trap on OOB.
-		//   OpListSet / OpListPush — mutate.
+		//   OpIndexStr / OpListGet / OpMapGet — may trap or read live state.
+		//   OpListSet / OpListPush / OpMapSet / OpMapDel — mutate.
 		return true
 	}
 	return false

--- a/runtime/vm2/bench/corpus_test.go
+++ b/runtime/vm2/bench/corpus_test.go
@@ -34,6 +34,8 @@ var corpusSizes = []corpusSize{
 	{"strings_concat_loop", 64},
 	// Lists subsystem (MEP-24 §3). Fill 128 ints then sum them.
 	{"lists_fill_sum", 128},
+	// Maps subsystem (MEP-24 §4). Fill 128 int->int entries, sum reads.
+	{"maps_fill_sum", 128},
 }
 
 func sizeFor(name string) int64 {
@@ -113,3 +115,4 @@ func BenchmarkVM2_FibRecTmpl(b *testing.B)  { benchCorpus(b, corpus.Program{Name
 func BenchmarkVM2_PrimeCount(b *testing.B)  { benchCorpus(b, corpus.Program{Name: "math_prime_count", Build: corpus.BuildPrimeCount, Expect: corpus.ExpectPrimeCount}) }
 func BenchmarkVM2_StringsConcatLoop(b *testing.B) { benchCorpus(b, corpus.Program{Name: "strings_concat_loop", Build: corpus.BuildStringsConcatLoop, Expect: corpus.ExpectStringsConcatLoop}) }
 func BenchmarkVM2_ListsFillSum(b *testing.B) { benchCorpus(b, corpus.Program{Name: "lists_fill_sum", Build: corpus.BuildListsFillSum, Expect: corpus.ExpectListsFillSum}) }
+func BenchmarkVM2_MapsFillSum(b *testing.B)  { benchCorpus(b, corpus.Program{Name: "maps_fill_sum", Build: corpus.BuildMapsFillSum, Expect: corpus.ExpectMapsFillSum}) }

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -270,6 +270,27 @@ func (vm *VM) Run() (Cell, error) {
 		case OpListPush:
 			l := vm.listAt(regs[ins.A])
 			l.data = append(l.data, regs[ins.B])
+		case OpNewMap:
+			regs[ins.A] = vm.newMap()
+		case OpMapLen:
+			regs[ins.A] = CInt(int64(len(vm.mapAt(regs[ins.B]).entries)))
+		case OpMapGet:
+			m := vm.mapAt(regs[ins.B])
+			if v, ok := m.entries[vm.mapKeyOf(regs[ins.C])]; ok {
+				regs[ins.A] = v
+			} else {
+				regs[ins.A] = CNull()
+			}
+		case OpMapHas:
+			m := vm.mapAt(regs[ins.B])
+			_, ok := m.entries[vm.mapKeyOf(regs[ins.C])]
+			regs[ins.A] = CBool(ok)
+		case OpMapSet:
+			m := vm.mapAt(regs[ins.A])
+			m.entries[vm.mapKeyOf(regs[ins.B])] = regs[ins.C]
+		case OpMapDel:
+			m := vm.mapAt(regs[ins.A])
+			delete(m.entries, vm.mapKeyOf(regs[ins.B]))
 		case OpHalt:
 			fr.IP = ip
 			return ret, errors.New("vm2: OpHalt reached")

--- a/runtime/vm2/maps.go
+++ b/runtime/vm2/maps.go
@@ -1,0 +1,47 @@
+package vm2
+
+// vmMap is the heap representation of a map (MEP-24 §4). The MVP uses
+// Go's built-in map keyed on a normalized `any` so equality follows
+// Go's comparable semantics: ints/bools/strings compare by value, and
+// inline + heap string Cells with the same bytes alias the same entry.
+//
+// A follow-on MEP gated on profile evidence can replace this with an
+// open-addressed table over the mapKey struct described in MEP-24 §4.
+type vmMap struct {
+	entries map[any]Cell
+}
+
+func (vm *VM) newMap() Cell {
+	return CPtr(vm.AddObject(&vmMap{entries: map[any]Cell{}}))
+}
+
+func (vm *VM) mapAt(c Cell) *vmMap {
+	return vm.Objects[c.Ptr()].(*vmMap)
+}
+
+// mapKeyOf normalizes a Cell into a Go map key. Strings collapse to
+// their byte content so a fresh-but-equal string Cell hits the same
+// entry; ints/bools/null collapse to their decoded scalar value; other
+// pointer cells use the Cell bit pattern as identity.
+func (vm *VM) mapKeyOf(c Cell) any {
+	switch {
+	case c.IsSStr():
+		var buf [MaxInlineStr]byte
+		return string(c.SStrBytes(&buf))
+	case c.IsPtr():
+		// Only *vmString gets byte-equal keys; other pointer kinds use
+		// identity (the tagPtr Cell). Maps over lists/structs/closures
+		// therefore key on object identity, matching Mochi semantics.
+		if s, ok := vm.Objects[c.Ptr()].(*vmString); ok {
+			return string(s.bytes)
+		}
+		return uint64(c)
+	case c.IsInt():
+		return c.Int()
+	case c.IsBool():
+		return c.Bool()
+	case c.IsNull():
+		return nil
+	}
+	return uint64(c)
+}

--- a/runtime/vm2/maps_test.go
+++ b/runtime/vm2/maps_test.go
@@ -1,0 +1,123 @@
+package vm2
+
+import "testing"
+
+// runMapProg drives a hand-rolled Program through a fresh VM. Helper
+// mirrors the lists tests so each case stays focused on opcode wiring.
+func runMapProg(t *testing.T, p *Program) Cell {
+	t.Helper()
+	got, err := New(p).Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	return got
+}
+
+// TestNewMapEmpty checks that OpNewMap allocates and OpMapLen reports 0.
+func TestNewMapEmpty(t *testing.T) {
+	main := &Function{
+		NumRegs: 2,
+		Code: []Instr{
+			{Op: OpNewMap, A: 0},
+			{Op: OpMapLen, A: 1, B: 0},
+			{Op: OpReturn, A: 1},
+		},
+	}
+	got := runMapProg(t, &Program{Funcs: []*Function{main}, Main: 0})
+	if got.Int() != 0 {
+		t.Fatalf("len = %d, want 0", got.Int())
+	}
+}
+
+// TestMapSetGetInt exercises OpMapSet / OpMapGet on int keys.
+func TestMapSetGetInt(t *testing.T) {
+	main := &Function{
+		NumRegs: 4,
+		Consts:  []Cell{CInt(42), CInt(7), CInt(99)},
+		Code: []Instr{
+			{Op: OpNewMap, A: 0},
+			{Op: OpLoadConstI, A: 1, B: 0}, // k = 42
+			{Op: OpLoadConstI, A: 2, B: 1}, // v = 7
+			{Op: OpMapSet, A: 0, B: 1, C: 2},
+			{Op: OpLoadConstI, A: 1, B: 2}, // k = 99 (missing)
+			{Op: OpMapGet, A: 3, B: 0, C: 1},
+			{Op: OpReturn, A: 3},
+		},
+	}
+	got := runMapProg(t, &Program{Funcs: []*Function{main}, Main: 0})
+	if !got.IsNull() {
+		t.Fatalf("missing key = %#x, want null", uint64(got))
+	}
+
+	main.Code = []Instr{
+		{Op: OpNewMap, A: 0},
+		{Op: OpLoadConstI, A: 1, B: 0},
+		{Op: OpLoadConstI, A: 2, B: 1},
+		{Op: OpMapSet, A: 0, B: 1, C: 2},
+		{Op: OpMapGet, A: 3, B: 0, C: 1},
+		{Op: OpReturn, A: 3},
+	}
+	got = runMapProg(t, &Program{Funcs: []*Function{main}, Main: 0})
+	if got.Int() != 7 {
+		t.Fatalf("m[42] = %d, want 7", got.Int())
+	}
+}
+
+// TestMapStringKeyAlias verifies that two distinct string Cells with
+// the same bytes hit the same map entry (inline vs heap forms too).
+func TestMapStringKeyAlias(t *testing.T) {
+	// Constants: "hi" (inline) twice — distinct Cells but equal bytes.
+	main := &Function{
+		NumRegs:   4,
+		Consts:    []Cell{CInt(11), CInt(22)},
+		StrConsts: [][]byte{[]byte("hi"), []byte("hi")},
+		Code: []Instr{
+			{Op: OpNewMap, A: 0},
+			{Op: OpLoadStrK, A: 1, B: 0},
+			{Op: OpLoadConstI, A: 2, B: 0}, // 11
+			{Op: OpMapSet, A: 0, B: 1, C: 2},
+			{Op: OpLoadStrK, A: 1, B: 1}, // second "hi" cell
+			{Op: OpMapGet, A: 3, B: 0, C: 1},
+			{Op: OpReturn, A: 3},
+		},
+	}
+	got := runMapProg(t, &Program{Funcs: []*Function{main}, Main: 0})
+	if got.Int() != 11 {
+		t.Fatalf("alias get = %d, want 11", got.Int())
+	}
+}
+
+// TestMapHasAndDel checks OpMapHas before/after OpMapDel.
+func TestMapHasAndDel(t *testing.T) {
+	build := func(extra []Instr) *Program {
+		code := []Instr{
+			{Op: OpNewMap, A: 0},
+			{Op: OpLoadConstI, A: 1, B: 0}, // k=1
+			{Op: OpLoadConstI, A: 2, B: 1}, // v=5
+			{Op: OpMapSet, A: 0, B: 1, C: 2},
+		}
+		code = append(code, extra...)
+		return &Program{Funcs: []*Function{{
+			NumRegs: 4,
+			Consts:  []Cell{CInt(1), CInt(5)},
+			Code:    code,
+		}}, Main: 0}
+	}
+
+	got := runMapProg(t, build([]Instr{
+		{Op: OpMapHas, A: 3, B: 0, C: 1},
+		{Op: OpReturn, A: 3},
+	}))
+	if !got.Bool() {
+		t.Fatalf("has before del = false, want true")
+	}
+
+	got = runMapProg(t, build([]Instr{
+		{Op: OpMapDel, A: 0, B: 1},
+		{Op: OpMapHas, A: 3, B: 0, C: 1},
+		{Op: OpReturn, A: 3},
+	}))
+	if got.Bool() {
+		t.Fatalf("has after del = true, want false")
+	}
+}

--- a/runtime/vm2/ops.go
+++ b/runtime/vm2/ops.go
@@ -65,4 +65,15 @@ const (
 	OpListGet  // A = listAt(B).data[regs[C].Int()]; traps on OOB
 	OpListSet  // listAt(regs[A]).data[regs[B].Int()] = regs[C]; traps on OOB
 	OpListPush // listAt(regs[A]).data = append(..., regs[B]); amortized O(1)
+
+	// Map subsystem (MEP-24 §4). Maps are mutable; Objects[idx] holds a
+	// *vmMap whose entries is a Go map[any]Cell. Key normalization
+	// (string bytes for str keys, scalar value for int/bool/null,
+	// identity for other ptr) lives in mapKeyOf.
+	OpNewMap // A = newMap()
+	OpMapLen // A = i64(len(mapAt(regs[B]).entries))
+	OpMapGet // A = mapAt(regs[B]).entries[mapKeyOf(regs[C])]; missing -> CNull()
+	OpMapHas // A = bool(present in mapAt(regs[B]), key=regs[C])
+	OpMapSet // mapAt(regs[A]).entries[mapKeyOf(regs[B])] = regs[C]
+	OpMapDel // delete(mapAt(regs[A]).entries, mapKeyOf(regs[B]))
 )

--- a/website/docs/mep/mep-0023.md
+++ b/website/docs/mep/mep-0023.md
@@ -274,10 +274,10 @@ The third subsystem lands. `bench/template/maps/fill_sum/{mochi,py,lua}` fills a
 
 | Program             |  N | vm2 (µs) | CPython (µs) | Lua (µs) | vm2 / CPython | vm2 / Lua |
 |---------------------|---:|---------:|-------------:|---------:|--------------:|----------:|
-| `maps/fill_sum`     | 10 |    1,293 |          780 |      742 |         1.66x |     1.74x |
-| `maps/fill_sum`     |100 |   12,727 |        6,696 |    2,572 |         1.90x |     4.95x |
+| `maps/fill_sum`     | 10 |      767 |          475 |      438 |         1.61x |     1.75x |
+| `maps/fill_sum`     |100 |    7,455 |        3,626 |    1,533 |         2.06x |     4.86x |
 
-`vmMap` is a thin wrapper over Go's `map[any]Cell`, with a `mapKeyOf` normalizer that collapses inline + heap string Cells to their byte content and unboxes ints/bools/null to their scalar value. The MVP intentionally inherits Go map performance; an open-addressed table over the `mapKey{tag,bits,aux}` struct described in MEP-24 §4 is the natural follow-on. The Lua gap at N=100 (4.95x) is dominated by Lua's hand-tuned hash table and the `any` boxing penalty on every key; the CPython gap (1.90x) is dispatch + `mapKeyOf` type-switch overhead, both of which a specialized int-key fast path would erase.
+`vmMap` is a thin wrapper over Go's `map[any]Cell`, with a `mapKeyOf` normalizer that collapses inline + heap string Cells to their byte content and unboxes ints/bools/null to their scalar value. The MVP intentionally inherits Go map performance; an open-addressed table over the `mapKey{tag,bits,aux}` struct described in MEP-24 §4 is the natural follow-on. The Lua gap at N=100 (4.86x) is dominated by Lua's hand-tuned hash table and the `any` boxing penalty on every key; the CPython gap (2.06x) is dispatch + `mapKeyOf` type-switch overhead, both of which a specialized int-key fast path would erase.
 
 ## Rationale
 

--- a/website/docs/mep/mep-0023.md
+++ b/website/docs/mep/mep-0023.md
@@ -268,6 +268,17 @@ The second subsystem lands. `bench/template/lists/fill_sum/{mochi,py,lua}` alloc
 
 `vmList` is a thin wrapper over `[]Cell` (no element-type specialization at MVP). The hot path is `OpListPush` (`append`) and `OpListGet` (bounds-checked load). vm2 closes to CPython on the larger row (1.07x at N=100) where amortized growth dominates fixed dispatch cost; small-N is dispatch-bound (1.41x at N=10). Lua's per-call overhead is lower in this workload (table append + numeric index), leaving vm2 1.20x-1.53x behind. Element-type specialization (homogeneous `[]int64` storage) is the natural next step, gated on profile evidence per the MEP-24 §3 deferral.
 
+##### Maps subsystem (MEP-24 §4, first slice)
+
+The third subsystem lands. `bench/template/maps/fill_sum/{mochi,py,lua}` fills a map with N int->int entries then sums the values back, repeated 1000 times by each language harness. Outputs match across all three runtimes.
+
+| Program             |  N | vm2 (µs) | CPython (µs) | Lua (µs) | vm2 / CPython | vm2 / Lua |
+|---------------------|---:|---------:|-------------:|---------:|--------------:|----------:|
+| `maps/fill_sum`     | 10 |    1,293 |          780 |      742 |         1.66x |     1.74x |
+| `maps/fill_sum`     |100 |   12,727 |        6,696 |    2,572 |         1.90x |     4.95x |
+
+`vmMap` is a thin wrapper over Go's `map[any]Cell`, with a `mapKeyOf` normalizer that collapses inline + heap string Cells to their byte content and unboxes ints/bools/null to their scalar value. The MVP intentionally inherits Go map performance; an open-addressed table over the `mapKey{tag,bits,aux}` struct described in MEP-24 §4 is the natural follow-on. The Lua gap at N=100 (4.95x) is dominated by Lua's hand-tuned hash table and the `any` boxing penalty on every key; the CPython gap (1.90x) is dispatch + `mapKeyOf` type-switch overhead, both of which a specialized int-key fast path would erase.
+
 ## Rationale
 
 **Why a new MEP, not an edit to MEP 17.** MEP 17 is a process gate. Folding cross-language reporting into it would either weaken the per-PR rule (peer runtime variance is too high to gate on) or strengthen the cross-language rule into a gate (an over-commitment given how many factors outside the VM author's control move those numbers). Separate documents, separate cadences, no confusion.


### PR DESCRIPTION
## Summary
- Adds six vm2 opcodes for maps: `OpNewMap`, `OpMapLen`, `OpMapGet`, `OpMapHas`, `OpMapSet`, `OpMapDel`, backed by a thin `map[any]Cell` `vmMap` in `vm.Objects` with a `mapKeyOf` normalizer (string bytes, scalar int/bool/null, identity for other ptr cells).
- Wires IR (`TMap` + 6 ops + builder helpers), emit lowering, and opt purity entries for the pure ops.
- Corpus `maps_fill_sum` (tail-recursive fill + sum mirroring lists), vm2runner repeats entry, runtime/vm2/bench bench, and an emit-level end-to-end test.
- Cross-language sibling templates under `bench/template/maps/fill_sum/{mochi,py,lua}`, and the MEP-23 sweep now includes maps rows.

## Cross-language baseline (vm2 vs CPython vs Lua)

| N | vm2 / CPython | vm2 / Lua |
|---:|---:|---:|
| 10 | 1.66x | 1.74x |
| 100 | 1.90x | 4.95x |

The Lua gap reflects its hand-tuned table; the CPython gap is dispatch + `mapKeyOf` type-switch overhead. Both fall to an open-addressed table over the `mapKey{tag,bits,aux}` struct described in MEP-24 §4, deferred per the same gate.

## Test plan
- [x] `go test ./compiler2/... ./runtime/vm2/...`
- [x] `go run ./bench/crosslang` outputs match across vm2/py/lua for `maps/fill_sum` N=10 and N=100

Closes #21525