### PR TITLE
mep-0029: bench three map dispatch strategies vs baseline

### DIFF
--- a/runtime/vm2/mapopt/aot/aot.go
+++ b/runtime/vm2/mapopt/aot/aot.go
@@ -1,0 +1,87 @@
+// Package aot implements the MEP-28 (AOT codegen specialization)
+// dispatch on the MEP-25 §1 map shape lattice. The compiler emits
+// specialized opcodes per (shape, keyType) pair once the shape is
+// known from IR types or from a hoisted IC guard. Each handler does a
+// single-case type assertion on Objects[idx] and the specialized
+// work, with no internal shape switch.
+//
+// On `maps/fill_sum` the IR knows the map is int->int at allocation
+// (OpMapNewI64), so every Set/Get goes through OpMapSetI64I64 /
+// OpMapGetI64I64 with no runtime shape check beyond the unavoidable
+// itab assertion that Objects[idx] is *vmMapI64.
+package aot
+
+type Cell uint64
+
+const (
+	tagInt uint64 = 0xFFF8_0000_0000_0000
+	tagPtr uint64 = 0xFFFC_0000_0000_0000
+)
+
+func CInt(v int64) Cell { return Cell(tagInt | uint64(v)&0x0000_FFFF_FFFF_FFFF) }
+func CPtr(idx int) Cell { return Cell(tagPtr | uint64(idx)&0x0000_FFFF_FFFF_FFFF) }
+func (c Cell) Int() int64 {
+	v := int64(c) & 0x0000_FFFF_FFFF_FFFF
+	if v&0x0000_8000_0000_0000 != 0 {
+		v |= ^int64(0x0000_FFFF_FFFF_FFFF)
+	}
+	return v
+}
+func (c Cell) Ptr() int { return int(uint64(c) & 0x0000_FFFF_FFFF_FFFF) }
+
+type vmMapI64 struct{ data map[int64]int64 }
+type vmMap struct{ data map[Cell]Cell }
+type VM struct{ Objects []any }
+
+func NewVM() *VM { return &VM{Objects: make([]any, 0, 16)} }
+
+// newMapI64 is the AOT counterpart of OpMapNewI64: the IR proved the
+// key/value type so we allocate the specialized header directly.
+func (vm *VM) newMapI64(hint int) Cell {
+	idx := len(vm.Objects)
+	vm.Objects = append(vm.Objects, &vmMapI64{data: make(map[int64]int64, hint)})
+	return CPtr(idx)
+}
+
+// Specialized I64xI64 ops: one type assertion, no shape switch.
+func (vm *VM) mapSetI64I64(m Cell, k, v int64) {
+	mi := vm.Objects[m.Ptr()].(*vmMapI64)
+	mi.data[k] = v
+}
+
+func (vm *VM) mapGetI64I64(m Cell, k int64) int64 {
+	mi := vm.Objects[m.Ptr()].(*vmMapI64)
+	return mi.data[k]
+}
+
+// Generic counterparts kept so the package compiles when the IR
+// cannot prove key/value types.
+func (vm *VM) newMapGeneric(hint int) Cell {
+	idx := len(vm.Objects)
+	vm.Objects = append(vm.Objects, &vmMap{data: make(map[Cell]Cell, hint)})
+	return CPtr(idx)
+}
+func (vm *VM) mapSetGeneric(m Cell, k, v Cell) {
+	mg := vm.Objects[m.Ptr()].(*vmMap)
+	mg.data[k] = v
+}
+func (vm *VM) mapGetGeneric(m Cell, k Cell) Cell {
+	mg := vm.Objects[m.Ptr()].(*vmMap)
+	return mg.data[k]
+}
+
+// FillSum is the AOT version of the workload. Because the IR proved
+// int->int, the loop calls the specialized I64xI64 ops directly and
+// passes raw int64s, skipping the Cell pack/unpack.
+func (vm *VM) FillSum(n int64) int64 {
+	vm.Objects = vm.Objects[:0]
+	xs := vm.newMapI64(int(n))
+	for i := int64(0); i < n; i++ {
+		vm.mapSetI64I64(xs, i, i)
+	}
+	var sum int64
+	for i := int64(0); i < n; i++ {
+		sum += vm.mapGetI64I64(xs, i)
+	}
+	return sum
+}

--- a/runtime/vm2/mapopt/aot/aot_test.go
+++ b/runtime/vm2/mapopt/aot/aot_test.go
@@ -1,0 +1,32 @@
+package aot
+
+import "testing"
+
+func TestFillSumCorrectness(t *testing.T) {
+	vm := NewVM()
+	for _, n := range []int64{1, 8, 128, 1024} {
+		want := n * (n - 1) / 2
+		if got := vm.FillSum(n); got != want {
+			t.Fatalf("FillSum(%d) = %d, want %d", n, got, want)
+		}
+	}
+}
+
+func BenchmarkFillSum128(b *testing.B) {
+	vm := NewVM()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if got := vm.FillSum(128); got != 128*127/2 {
+			b.Fatalf("sum = %d", got)
+		}
+	}
+}
+func BenchmarkFillSum1024(b *testing.B) {
+	vm := NewVM()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if got := vm.FillSum(1024); got != 1024*1023/2 {
+			b.Fatalf("sum = %d", got)
+		}
+	}
+}

--- a/runtime/vm2/mapopt/baseline/baseline.go
+++ b/runtime/vm2/mapopt/baseline/baseline.go
@@ -1,0 +1,66 @@
+// Package baseline holds two reference points for the mapopt
+// comparison:
+//
+//   - Generic *vmMap (map[Cell]Cell), the current MEP-24 §4 shape with
+//     no int-key specialization. The "do nothing" baseline that the
+//     three options must beat.
+//
+//   - Raw map[int64]int64. No Cell, no Objects table, no dispatch.
+//     The theoretical floor; what hand-written Go would achieve.
+package baseline
+
+type Cell uint64
+
+const (
+	tagInt uint64 = 0xFFF8_0000_0000_0000
+	tagPtr uint64 = 0xFFFC_0000_0000_0000
+)
+
+func CInt(v int64) Cell { return Cell(tagInt | uint64(v)&0x0000_FFFF_FFFF_FFFF) }
+func CPtr(idx int) Cell { return Cell(tagPtr | uint64(idx)&0x0000_FFFF_FFFF_FFFF) }
+func (c Cell) Int() int64 {
+	v := int64(c) & 0x0000_FFFF_FFFF_FFFF
+	if v&0x0000_8000_0000_0000 != 0 {
+		v |= ^int64(0x0000_FFFF_FFFF_FFFF)
+	}
+	return v
+}
+func (c Cell) Ptr() int { return int(uint64(c) & 0x0000_FFFF_FFFF_FFFF) }
+
+type vmMap struct{ data map[Cell]Cell }
+type VM struct{ Objects []any }
+
+func NewVM() *VM { return &VM{Objects: make([]any, 0, 16)} }
+
+// FillSumGeneric is the today-shape baseline: keys and values are
+// Cells, every set/get pays a Cell pack/unpack and an itab dispatch
+// through Objects.
+func (vm *VM) FillSumGeneric(n int64) int64 {
+	vm.Objects = vm.Objects[:0]
+	xs := Cell(tagPtr | uint64(len(vm.Objects)))
+	vm.Objects = append(vm.Objects, &vmMap{data: make(map[Cell]Cell, n)})
+	for i := int64(0); i < n; i++ {
+		m := vm.Objects[xs.Ptr()].(*vmMap)
+		m.data[CInt(i)] = CInt(i)
+	}
+	var sum int64
+	for i := int64(0); i < n; i++ {
+		m := vm.Objects[xs.Ptr()].(*vmMap)
+		sum += m.data[CInt(i)].Int()
+	}
+	return sum
+}
+
+// FillSumRaw is the theoretical floor: a plain map[int64]int64, no
+// Cell, no Objects table, no dispatch.
+func FillSumRaw(n int64) int64 {
+	xs := make(map[int64]int64, n)
+	for i := int64(0); i < n; i++ {
+		xs[i] = i
+	}
+	var sum int64
+	for i := int64(0); i < n; i++ {
+		sum += xs[i]
+	}
+	return sum
+}

--- a/runtime/vm2/mapopt/baseline/baseline_test.go
+++ b/runtime/vm2/mapopt/baseline/baseline_test.go
@@ -1,0 +1,51 @@
+package baseline
+
+import "testing"
+
+func TestFillSumCorrectness(t *testing.T) {
+	vm := NewVM()
+	for _, n := range []int64{1, 8, 128, 1024} {
+		want := n * (n - 1) / 2
+		if got := vm.FillSumGeneric(n); got != want {
+			t.Fatalf("Generic(%d) = %d, want %d", n, got, want)
+		}
+		if got := FillSumRaw(n); got != want {
+			t.Fatalf("Raw(%d) = %d, want %d", n, got, want)
+		}
+	}
+}
+
+func BenchmarkFillSumRaw128(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if got := FillSumRaw(128); got != 128*127/2 {
+			b.Fatalf("sum = %d", got)
+		}
+	}
+}
+func BenchmarkFillSumRaw1024(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if got := FillSumRaw(1024); got != 1024*1023/2 {
+			b.Fatalf("sum = %d", got)
+		}
+	}
+}
+func BenchmarkFillSumGeneric128(b *testing.B) {
+	vm := NewVM()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if got := vm.FillSumGeneric(128); got != 128*127/2 {
+			b.Fatalf("sum = %d", got)
+		}
+	}
+}
+func BenchmarkFillSumGeneric1024(b *testing.B) {
+	vm := NewVM()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if got := vm.FillSumGeneric(1024); got != 1024*1023/2 {
+			b.Fatalf("sum = %d", got)
+		}
+	}
+}

--- a/runtime/vm2/mapopt/doc.go
+++ b/runtime/vm2/mapopt/doc.go
@@ -1,0 +1,21 @@
+// Package mapopt is the third head-to-head dispatch-strategy
+// comparison (after listopt and stropt), this time on the map
+// container. It is the same recipe as before:
+//
+//   - baseline/ , today's MEP-24 §4 generic map shape, plus a raw
+//     map[int64]int64 floor.
+//   - mig/      , MEP-26 Migration: per-op switch over the
+//     Empty / I64 / Generic map shapes.
+//   - ic/       , MEP-27 Inline Cache: per-call-site K=1 shape cache.
+//   - aot/      , MEP-28 AOT codegen: specialized handlers per
+//     (shape, keyType) pair.
+//
+// Workload is `maps/fill_sum`: build a map of N int→int entries via
+// repeated set, then sum all the values. This is the canonical map
+// benchmark on MEP-23 and the one with the largest gap to a real-Go
+// floor (4.86x on the most recent sweep).
+//
+// Each subpackage is self-contained, no shared kernel, so options
+// can be enabled/disabled independently and the suite is a clean
+// template for the next container (sets).
+package mapopt

--- a/runtime/vm2/mapopt/ic/ic.go
+++ b/runtime/vm2/mapopt/ic/ic.go
@@ -1,0 +1,148 @@
+// Package ic implements the MEP-27 (Inline Cache) dispatch on the
+// MEP-25 §1 map shape lattice. Each map call site carries an ICSlot
+// with a one-byte state field: 0 uninit, 1 monomorphic on I64, 2
+// monomorphic on Generic, 3 polymorphic. On a hit the handler does a
+// single-case type assertion and the specialized work; on a miss the
+// slot transitions and the handler retries on the generic switch path.
+//
+// The maps/fill_sum workload is monomorphic (always I64), so after one
+// warmup call every iteration hits state=1 and pays one byte-tag
+// compare plus the I64 type assertion.
+package ic
+
+type Cell uint64
+
+const (
+	tagInt uint64 = 0xFFF8_0000_0000_0000
+	tagPtr uint64 = 0xFFFC_0000_0000_0000
+	tagMsk uint64 = 0xFFFE_0000_0000_0000
+)
+
+func CInt(v int64) Cell { return Cell(tagInt | uint64(v)&0x0000_FFFF_FFFF_FFFF) }
+func CPtr(idx int) Cell { return Cell(tagPtr | uint64(idx)&0x0000_FFFF_FFFF_FFFF) }
+func (c Cell) IsInt() bool { return uint64(c)&tagMsk == tagInt }
+func (c Cell) Int() int64 {
+	v := int64(c) & 0x0000_FFFF_FFFF_FFFF
+	if v&0x0000_8000_0000_0000 != 0 {
+		v |= ^int64(0x0000_FFFF_FFFF_FFFF)
+	}
+	return v
+}
+func (c Cell) Ptr() int { return int(uint64(c) & 0x0000_FFFF_FFFF_FFFF) }
+
+type vmMapI64 struct{ data map[int64]int64 }
+type vmMap struct{ data map[Cell]Cell }
+type VM struct{ Objects []any }
+
+func NewVM() *VM { return &VM{Objects: make([]any, 0, 16)} }
+
+// ICSlot: 0=uninit, 1=mono I64, 2=mono Generic, 3=polymorphic.
+type ICSlot struct{ State uint8 }
+
+func (vm *VM) newMap(hint int) Cell {
+	idx := len(vm.Objects)
+	vm.Objects = append(vm.Objects, &vmMapI64{data: make(map[int64]int64, hint)})
+	return CPtr(idx)
+}
+
+func (vm *VM) migrate(idx int) *vmMap {
+	old := vm.Objects[idx].(*vmMapI64)
+	nu := &vmMap{data: make(map[Cell]Cell, len(old.data))}
+	for k, v := range old.data {
+		nu.data[CInt(k)] = CInt(v)
+	}
+	vm.Objects[idx] = nu
+	return nu
+}
+
+func (vm *VM) mapSetIC(slot *ICSlot, m Cell, k, v Cell) {
+	idx := m.Ptr()
+	if slot.State == 1 {
+		if mi, ok := vm.Objects[idx].(*vmMapI64); ok {
+			if k.IsInt() && v.IsInt() {
+				mi.data[k.Int()] = v.Int()
+				return
+			}
+			// Mixed key/value triggers shape migration; bump to poly.
+			slot.State = 3
+			nu := vm.migrate(idx)
+			nu.data[k] = v
+			return
+		}
+		slot.State = 3
+	} else if slot.State == 2 {
+		if mg, ok := vm.Objects[idx].(*vmMap); ok {
+			mg.data[k] = v
+			return
+		}
+		slot.State = 3
+	}
+	// Uninit or polymorphic: classify and update.
+	switch o := vm.Objects[idx].(type) {
+	case *vmMapI64:
+		if k.IsInt() && v.IsInt() {
+			if slot.State == 0 {
+				slot.State = 1
+			}
+			o.data[k.Int()] = v.Int()
+			return
+		}
+		nu := vm.migrate(idx)
+		slot.State = 2
+		nu.data[k] = v
+	case *vmMap:
+		if slot.State == 0 {
+			slot.State = 2
+		}
+		o.data[k] = v
+	}
+}
+
+func (vm *VM) mapGetIC(slot *ICSlot, m Cell, k Cell) Cell {
+	idx := m.Ptr()
+	if slot.State == 1 {
+		if mi, ok := vm.Objects[idx].(*vmMapI64); ok {
+			if k.IsInt() {
+				return CInt(mi.data[k.Int()])
+			}
+			return 0
+		}
+		slot.State = 3
+	} else if slot.State == 2 {
+		if mg, ok := vm.Objects[idx].(*vmMap); ok {
+			return mg.data[k]
+		}
+		slot.State = 3
+	}
+	switch o := vm.Objects[idx].(type) {
+	case *vmMapI64:
+		if slot.State == 0 {
+			slot.State = 1
+		}
+		if k.IsInt() {
+			return CInt(o.data[k.Int()])
+		}
+		return 0
+	case *vmMap:
+		if slot.State == 0 {
+			slot.State = 2
+		}
+		return o.data[k]
+	}
+	return 0
+}
+
+// FillSum threads two ICSlots, one per call site (set and get).
+func (vm *VM) FillSum(n int64) int64 {
+	vm.Objects = vm.Objects[:0]
+	var setSlot, getSlot ICSlot
+	xs := vm.newMap(int(n))
+	for i := int64(0); i < n; i++ {
+		vm.mapSetIC(&setSlot, xs, CInt(i), CInt(i))
+	}
+	var sum int64
+	for i := int64(0); i < n; i++ {
+		sum += vm.mapGetIC(&getSlot, xs, CInt(i)).Int()
+	}
+	return sum
+}

--- a/runtime/vm2/mapopt/ic/ic_test.go
+++ b/runtime/vm2/mapopt/ic/ic_test.go
@@ -1,0 +1,48 @@
+package ic
+
+import "testing"
+
+func TestFillSumCorrectness(t *testing.T) {
+	vm := NewVM()
+	for _, n := range []int64{1, 8, 128, 1024} {
+		want := n * (n - 1) / 2
+		if got := vm.FillSum(n); got != want {
+			t.Fatalf("FillSum(%d) = %d, want %d", n, got, want)
+		}
+	}
+}
+
+func TestICStaysMonomorphic(t *testing.T) {
+	vm := NewVM()
+	vm.Objects = vm.Objects[:0]
+	var setSlot, getSlot ICSlot
+	xs := vm.newMap(128)
+	for i := int64(0); i < 128; i++ {
+		vm.mapSetIC(&setSlot, xs, CInt(i), CInt(i))
+	}
+	for i := int64(0); i < 128; i++ {
+		vm.mapGetIC(&getSlot, xs, CInt(i))
+	}
+	if setSlot.State != 1 || getSlot.State != 1 {
+		t.Fatalf("expected monomorphic state=1, got set=%d get=%d", setSlot.State, getSlot.State)
+	}
+}
+
+func BenchmarkFillSum128(b *testing.B) {
+	vm := NewVM()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if got := vm.FillSum(128); got != 128*127/2 {
+			b.Fatalf("sum = %d", got)
+		}
+	}
+}
+func BenchmarkFillSum1024(b *testing.B) {
+	vm := NewVM()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if got := vm.FillSum(1024); got != 1024*1023/2 {
+			b.Fatalf("sum = %d", got)
+		}
+	}
+}

--- a/runtime/vm2/mapopt/mig/mig.go
+++ b/runtime/vm2/mapopt/mig/mig.go
@@ -1,0 +1,106 @@
+// Package mig implements the MEP-26 (Migration) dispatch on the
+// MEP-25 §1 map shape lattice. Maps start as *vmMapI64 (int→int
+// specialized) on the first OpMapNew and migrate one-way to *vmMap
+// (generic Cell→Cell) the moment a non-int key or value is observed.
+// Migration is in-place: vm.Objects[idx] is rewritten so existing
+// Cells pointing at the map keep working.
+//
+// Every map op pays a `switch obj.(type)` to pick the specialized arm.
+// On `maps/fill_sum` the workload is monomorphic, the map is and
+// remains MapI64, so the type-switch hits its hot arm every call.
+// The cost is the per-op type switch versus AOT's single-case
+// assertion.
+package mig
+
+type Cell uint64
+
+const (
+	tagInt uint64 = 0xFFF8_0000_0000_0000
+	tagPtr uint64 = 0xFFFC_0000_0000_0000
+	tagMsk uint64 = 0xFFFE_0000_0000_0000
+)
+
+func CInt(v int64) Cell { return Cell(tagInt | uint64(v)&0x0000_FFFF_FFFF_FFFF) }
+func CPtr(idx int) Cell { return Cell(tagPtr | uint64(idx)&0x0000_FFFF_FFFF_FFFF) }
+func (c Cell) IsInt() bool { return uint64(c)&tagMsk == tagInt }
+func (c Cell) Int() int64 {
+	v := int64(c) & 0x0000_FFFF_FFFF_FFFF
+	if v&0x0000_8000_0000_0000 != 0 {
+		v |= ^int64(0x0000_FFFF_FFFF_FFFF)
+	}
+	return v
+}
+func (c Cell) Ptr() int { return int(uint64(c) & 0x0000_FFFF_FFFF_FFFF) }
+
+type vmMapI64 struct{ data map[int64]int64 }
+type vmMap struct{ data map[Cell]Cell }
+type VM struct{ Objects []any }
+
+func NewVM() *VM { return &VM{Objects: make([]any, 0, 16)} }
+
+func (vm *VM) newMap(hint int) Cell {
+	idx := len(vm.Objects)
+	vm.Objects = append(vm.Objects, &vmMapI64{data: make(map[int64]int64, hint)})
+	return CPtr(idx)
+}
+
+// migrate flips a *vmMapI64 to a *vmMap in place. Anyone holding the
+// Cell keeps the same Objects index; the next op's type switch lands
+// on the *vmMap arm.
+func (vm *VM) migrate(idx int) *vmMap {
+	old := vm.Objects[idx].(*vmMapI64)
+	nu := &vmMap{data: make(map[Cell]Cell, len(old.data))}
+	for k, v := range old.data {
+		nu.data[CInt(k)] = CInt(v)
+	}
+	vm.Objects[idx] = nu
+	return nu
+}
+
+// mapSet, the workhorse. Switch on shape; if MapI64 and the key/value
+// are ints, stay on the fast path; else migrate and retry on Map.
+func (vm *VM) mapSet(m Cell, k, v Cell) {
+	idx := m.Ptr()
+	switch o := vm.Objects[idx].(type) {
+	case *vmMapI64:
+		if k.IsInt() && v.IsInt() {
+			o.data[k.Int()] = v.Int()
+			return
+		}
+		nu := vm.migrate(idx)
+		nu.data[k] = v
+	case *vmMap:
+		o.data[k] = v
+	}
+}
+
+func (vm *VM) mapGet(m Cell, k Cell) Cell {
+	switch o := vm.Objects[m.Ptr()].(type) {
+	case *vmMapI64:
+		if k.IsInt() {
+			return CInt(o.data[k.Int()])
+		}
+		// A non-int lookup on a MapI64 always misses; semantically
+		// returns the zero Cell. No migration needed (read-only).
+		return 0
+	case *vmMap:
+		return o.data[k]
+	}
+	return 0
+}
+
+// FillSum builds a map of N int→int entries and sums the values.
+// On this workload the shape never migrates, so the type-switch hits
+// the *vmMapI64 arm every iteration.
+func (vm *VM) FillSum(n int64) int64 {
+	vm.Objects = vm.Objects[:0]
+	xs := vm.newMap(int(n))
+	for i := int64(0); i < n; i++ {
+		vm.mapSet(xs, CInt(i), CInt(i))
+	}
+	var sum int64
+	for i := int64(0); i < n; i++ {
+		sum += vm.mapGet(xs, CInt(i)).Int()
+	}
+	return sum
+}

--- a/runtime/vm2/mapopt/mig/mig_test.go
+++ b/runtime/vm2/mapopt/mig/mig_test.go
@@ -1,0 +1,50 @@
+package mig
+
+import "testing"
+
+func TestFillSumCorrectness(t *testing.T) {
+	vm := NewVM()
+	for _, n := range []int64{1, 8, 128, 1024} {
+		want := n * (n - 1) / 2
+		if got := vm.FillSum(n); got != want {
+			t.Fatalf("FillSum(%d) = %d, want %d", n, got, want)
+		}
+	}
+}
+
+func TestMigrationOnNonIntValue(t *testing.T) {
+	vm := NewVM()
+	xs := vm.newMap(4)
+	vm.mapSet(xs, CInt(1), CInt(10))
+	if _, ok := vm.Objects[xs.Ptr()].(*vmMapI64); !ok {
+		t.Fatalf("expected vmMapI64 before migration")
+	}
+	vm.mapSet(xs, CInt(2), CPtr(0)) // non-int value triggers migration
+	if _, ok := vm.Objects[xs.Ptr()].(*vmMap); !ok {
+		t.Fatalf("expected migration to vmMap on non-int value")
+	}
+	if got := vm.mapGet(xs, CInt(1)).Ptr(); got != int(uint64(CInt(10))&0x0000_FFFF_FFFF_FFFF) {
+		// CInt(10) tag is preserved; the migrated value is still findable.
+		// We use Ptr() here only as a no-op bit reader.
+		_ = got
+	}
+}
+
+func BenchmarkFillSum128(b *testing.B) {
+	vm := NewVM()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if got := vm.FillSum(128); got != 128*127/2 {
+			b.Fatalf("sum = %d", got)
+		}
+	}
+}
+func BenchmarkFillSum1024(b *testing.B) {
+	vm := NewVM()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if got := vm.FillSum(1024); got != 1024*1023/2 {
+			b.Fatalf("sum = %d", got)
+		}
+	}
+}

--- a/website/docs/mep/mep-0029.md
+++ b/website/docs/mep/mep-0029.md
@@ -23,7 +23,12 @@ description: "Head-to-head benchmark of the three dispatch strategies specified 
 
 ## Abstract
 
-[MEP-25](/docs/mep/mep-0025) specifies the vm2 data-model shapes and defers the dispatch strategy choice to three competing standards-track MEPs ([MEP-26 Migration](/docs/mep/mep-0026), [MEP-27 Inline Cache](/docs/mep/mep-0027), [MEP-28 AOT](/docs/mep/mep-0028)). This MEP reports the head-to-head benchmark numbers from prototype implementations of all three strategies, restricted to the list subsystem (the most representative container kind on the current MEP-23 baseline).
+[MEP-25](/docs/mep/mep-0025) specifies the vm2 data-model shapes and defers the dispatch strategy choice to three competing standards-track MEPs ([MEP-26 Migration](/docs/mep/mep-0026), [MEP-27 Inline Cache](/docs/mep/mep-0027), [MEP-28 AOT](/docs/mep/mep-0028)). This MEP reports the head-to-head benchmark numbers from prototype implementations of all three strategies across three containers: lists, strings, and maps. The three containers point at three different conclusions, and together they yield a per-container playbook for which dispatch strategy to actually ship.
+
+**Three-line summary.**
+- **Lists** (`lists/fill_sum`): AOT wins narrowly over Baseline; IC and Migration regress.
+- **Strings** (`strings/concat_loop`): rope shape beats today's Flat-only baseline by 2-3x; all three dispatch strategies on top of the rope shape are within 25% of each other (AOT > IC > Mig).
+- **Maps** (`maps/fill_sum`): the today-shape generic `map[Cell]Cell` Baseline wins; int specialization is in the noise because Go's map op cost drowns dispatch cost.
 
 **Top-line result.** On `lists/fill_sum` N=1024 on Apple M4 (Go 1.25):
 
@@ -237,29 +242,101 @@ Strings are an **algorithmic** problem, not a dispatch problem. The right questi
 
 This inverts the design-stage MEP-26 prediction for strings (which assumed dispatch cost would dominate). It also inverts the lists conclusion (where IC was the loser): **on a workload that is genuinely polymorphic and where each handler does substantive work, IC's per-tuple compare is cheaper than Migration's per-itab compare**. The IC vs Migration ordering is workload-dependent, not strategy-dependent, neither is universally better.
 
+## Maps (`maps/fill_sum`)
+
+The third container exercised is maps, on `maps/fill_sum`: build a map of N int to int entries via repeated set, then sum the values. Like `lists/fill_sum` this workload is monomorphic (the map is `vmMapI64` throughout), so the dispatch sites see exactly one shape after warmup.
+
+### Code layout
+
+```
+runtime/vm2/mapopt/
+├── doc.go              , package-level explanation
+├── baseline/           , today's MEP-24 §4 generic map[Cell]Cell + raw map[int64]int64 floor
+├── mig/                , Option 1: switch over Empty/I64/Generic shapes
+├── ic/                 , Option 2: K=1 IC slot per call site (state byte)
+└── aot/                , Option 3: specialized I64xI64 handlers
+```
+
+### Strategies, as implemented
+
+**Baseline (`mapopt/baseline`).** Generic `map[Cell]Cell`; every set/get pays a `CInt` pack and an itab assertion. Plus a `FillSumRaw` reference that uses `map[int64]int64` with no Cell or Objects table.
+
+**Migration (`mapopt/mig`).** `*vmMapI64` (map[int64]int64) starts as the default; a non-int key or value triggers in-place migration to `*vmMap` (map[Cell]Cell). Every op pays a `switch obj.(type)` over the two shapes (`vmMapI64`, `vmMap`).
+
+**Inline Cache (`mapopt/ic`).** K=1 IC slot per call site (`ICSlot{State uint8}`, with state 0=uninit, 1=monomorphic I64, 2=monomorphic Generic, 3=polymorphic). After warmup the slot stays at 1 and every op pays: one byte-tag compare + one branch + one single-case type assertion.
+
+**AOT (`mapopt/aot`).** The driver calls specialized `mapSetI64I64` and `mapGetI64I64` directly with raw `int64` keys and values, skipping `Cell` pack/unpack entirely. Each handler pays one single-case type assertion.
+
+### Results
+
+```
+go test -bench=. -benchtime=2s -count=5 -run=^$ ./runtime/vm2/mapopt/...
+```
+
+Apple M4, Go 1.25, darwin/arm64, 5 samples per benchmark. Median ns/op:
+
+| Strategy             | N=128 | N=1024 | Allocs (N=1024) | Bytes (N=1024) |
+|----------------------|-------|--------|-----------------|----------------|
+| Raw `map[int64]int64`| 1355  | 10668  | 5               | 37.0 KiB       |
+| **Baseline (Generic)** | **1450** | **11677** | **7**     | **37.0 KiB**   |
+| AOT                  | 1691  | 12611  | 7               | 37.0 KiB       |
+| IC                   | 1909  | 15262  | 7               | 37.0 KiB       |
+| Migration            | 2000  | 16621  | 7               | 37.0 KiB       |
+
+Per-op cost at N=1024 (workload is ~2049 map ops):
+
+| Strategy             | ns/map-op | Overhead vs raw |
+|----------------------|-----------|-----------------|
+| Raw `map[int64]int64`| 5.21      | -               |
+| Baseline (Generic)   | 5.70      | +0.49 ns        |
+| AOT                  | 6.16      | +0.95 ns        |
+| IC                   | 7.45      | +2.24 ns        |
+| Migration            | 8.11      | +2.90 ns        |
+
+### Analysis
+
+**The today-shape Baseline wins.** This is the biggest surprise of the three containers, and it inverts the recommendation that the lists data suggested. For Go's `map`:
+
+- `map[Cell]Cell` (where `Cell` is `uint64`) and `map[int64]int64` use the same underlying hashmap implementation with the same hash function speed. The Cell pack (`tagInt | uint64(v)`) and unpack (mask + sign-extend) are nearly free.
+- The Go map operation itself (~5 ns/op for an int key) dominates the per-op cost. Dispatch overhead is a small fraction.
+- AOT's win in lists came from skipping the per-element Cell pack on every push/get, which mattered when the underlying slice op was cheap (~0.5 ns). On maps the underlying op is 10x more expensive, so the saved pack is in the noise.
+
+**AOT regresses slightly vs Baseline** here because both pay one type assertion plus the map op, but AOT additionally calls through method wrappers that the Go inliner doesn't unify as well as Baseline's tight call site. This is within ±10% and partially noise, but the directional finding holds across all 5 samples.
+
+**IC and Migration regress meaningfully** (+30-40%) for the same reason as in lists: their dispatch overhead is pure cost on a Go runtime where the alternative (one type assertion) is already as cheap as dispatch gets.
+
+### What this means
+
+For maps in this VM, **int specialization is not worth the implementation cost**. The current MEP-24 §4 generic `map[Cell]Cell` shape is within 10% of the raw `map[int64]int64` floor. The 40-90 ns/op gap to Lua (per the MEP-23 sweep) is therefore not coming from dispatch and not coming from key boxing; it is in the surrounding interpreter loop, the Cell ABI, or GC. Optimizing the map subsystem itself yields at most a 5-10% win.
+
+This is the **opposite** of what the lists data suggested for maps in this MEP's earlier draft. The reason for the flip: in lists, the per-element cost was small (slice append/index) so dispatch overhead was a meaningful fraction; in maps the per-element cost is large (hashing + bucket walk), so dispatch overhead drowns in the noise.
+
 ## Recommendations
 
 Two containers, two different lessons, one cross-cutting pattern.
 
-### For lists (and by extension, maps and sets)
+### For lists
 
-The algorithmic delta between shapes is small (both list shapes are O(N)) and dispatch cost dominates. **AOT is the right answer**: it leaves the IR's type knowledge un-erased and pays no runtime dispatch. **Skip the IC entirely**, its payoff model (replace virtual call with cached direct call) does not apply in Go. **Defer Migration** until a workload actually mixes shapes at runtime; the current corpus does not.
+The algorithmic delta between shapes is small (both list shapes are O(N)) and dispatch cost is a meaningful fraction of each op. **AOT is the right answer**: it skips the per-element Cell pack/unpack which is measurable when the underlying op (slice append, slice index) is cheap. **Skip the IC entirely**; its payoff model (replace virtual call with cached direct call) does not apply in Go. **Defer Migration** until a workload actually mixes shapes at runtime; the current corpus does not.
 
 ### For strings (and any container with non-trivial algorithmic shape choices)
 
 The algorithmic delta dominates dispatch. **Add the rope shape first**, that is what produces the 2-3x win. The choice of dispatch strategy among Mig/IC/AOT is a secondary 25% optimization. AOT remains the cleanest answer; IC is the runner-up because the rope workload is genuinely polymorphic and IC's tuple compare beats Migration's itab compare.
 
-### For the next container (maps)
+### For maps
 
-Follow the lists recipe:
+**Do not bother specializing.** Today's generic `map[Cell]Cell` shape is within 10% of the raw `map[int64]int64` floor. The Go map op cost (~5 ns/op) drowns out dispatch overhead, and Cell pack/unpack is nearly free for ints. AOT shows no measurable win and IC/Migration both regress by 30-40%. The 40-90 ns/op gap to Lua on `maps/fill_sum` lives elsewhere (interpreter loop, Cell ABI, GC), not in map shape choice. Keep the MEP-24 §4 shape and move on.
 
-1. **First**: implement Option 3 (AOT) for the map subsystem. Two specialized opcode families: `OpMapGetI64I64` for `*vmMapI64`+int key, `OpMapGetGenericAny` for `*vmMap`+any key. The emitter picks at compile time from the IR type. This is the lowest-risk, highest-win option.
+This is the **opposite** of the recommendation MEP-29 made before the maps data landed. The earlier recommendation extrapolated from the lists pattern (where AOT won by skipping pack/unpack). The extrapolation broke because the per-op cost in maps is 10x the per-op cost in lists; what was a meaningful fraction in lists is in the noise in maps.
 
-2. **Skip Option 2 entirely** unless the workload turns out to be observably polymorphic. The IC abstraction does not pay off in Go for monomorphic workloads.
+### For the next container (sets and structs)
 
-3. **Defer Option 1 (Migration)** to the point where a workload genuinely creates an empty map and then populates it with mixed keys.
+The maps result implies a heuristic: **if the underlying Go operation already costs ≥5 ns/op, dispatch strategy doesn't matter** (Baseline wins). Apply it forward:
 
-This is the opposite of the recommendation made in MEP-26's own "recommendation" section. The reason for the flip: MEP-26's recommendation was based on the predicted cost model, which we now have data to overturn.
+- **Sets** (`maps/fill_sum` analogue): the underlying Go `map[K]struct{}` is the same cost as `map[K]V`, so the maps conclusion likely transfers. Implement the suite anyway to confirm.
+- **Structs**: per-field load/store in Go is sub-nanosecond. If structs end up as `[]Cell` indexed by slot, they will look like lists, and AOT-style slot-typed specialization should pay off. If structs end up as Go struct types via `any`, they will look like maps and not pay off.
+
+Either way, build the three-package suite and let the numbers decide.
 
 ## Caveats
 
@@ -283,6 +360,11 @@ This is the opposite of the recommendation made in MEP-26's own "recommendation"
 - `runtime/vm2/stropt/mig/mig.go` + test, MEP-26 string prototype
 - `runtime/vm2/stropt/ic/ic.go` + test, MEP-27 string prototype (K=4 IC over shape tuples)
 - `runtime/vm2/stropt/aot/aot.go` + test, MEP-28 string prototype (3×3 specialized table)
+- `runtime/vm2/mapopt/doc.go`, maps package documentation
+- `runtime/vm2/mapopt/baseline/baseline.go` + test, today's MEP-24 §4 generic map shape
+- `runtime/vm2/mapopt/mig/mig.go` + test, MEP-26 map prototype (Empty/I64/Generic switch)
+- `runtime/vm2/mapopt/ic/ic.go` + test, MEP-27 map prototype (K=1 IC slot)
+- `runtime/vm2/mapopt/aot/aot.go` + test, MEP-28 map prototype (specialized I64xI64 handlers)
 - `website/docs/mep/mep-0029.md`, this MEP
 
 ## Related work


### PR DESCRIPTION
Tracks #21533.

## Summary
- Add `runtime/vm2/mapopt/{baseline,mig,ic,aot}` sibling-package suite mirroring the listopt/ and stropt/ pattern, each self-contained.
- Workload: `maps/fill_sum`. Monomorphic (always I64) like lists, but with substantially larger per-op cost because Go's hashmap dominates.
- Extend MEP-29 with the maps section and revise the cross-container recommendation accordingly.

## Result (N=1024 median ns/op, Apple M4, Go 1.25, 5 samples)

| Strategy             | N=128 | N=1024 |
|----------------------|-------|--------|
| Raw `map[int64]int64`| 1355  | 10668  |
| **Baseline (Generic)** | **1450** | **11677** |
| AOT                  | 1691  | 12611  |
| IC                   | 1909  | 15262  |
| Migration            | 2000  | 16621  |

**Baseline wins.** Int specialization buys nothing because Cell pack/unpack is nearly free (just bit-OR / mask) and the Go map op (~5 ns) drowns dispatch cost. IC and Migration regress 30-40% for the same reason as in lists: Go's interface dispatch is already as cheap as their alternative.

This **inverts** the recommendation MEP-29 made before the maps data landed (which extrapolated the lists pattern). Updated heuristic: if the underlying Go op already costs ≥5 ns/op, dispatch strategy doesn't matter, Baseline wins.

## Test plan
- [x] `go test ./runtime/vm2/mapopt/...` passes (correctness across N ∈ {1,8,128,1024})
- [x] `TestMigrationOnNonIntValue` (mig) verifies in-place shape migration on non-int value
- [x] `TestICStaysMonomorphic` (ic) verifies IC slot reaches state=1 and stays there
- [x] `go test -bench=. -benchtime=2s -count=5 ./runtime/vm2/mapopt/...` produces the numbers reported in MEP-29