### PR TITLE
mep-0029: bench three set dispatch strategies vs baseline

### DIFF
--- a/runtime/vm2/setopt/aot/aot.go
+++ b/runtime/vm2/setopt/aot/aot.go
@@ -1,0 +1,69 @@
+// Package aot implements MEP-28 AOT specialization for the set
+// container. Specialized I64 handlers take raw int64 members directly,
+// skipping the Cell pack/unpack.
+package aot
+
+type Cell uint64
+
+const (
+	tagInt uint64 = 0xFFF8_0000_0000_0000
+	tagPtr uint64 = 0xFFFC_0000_0000_0000
+)
+
+func CInt(v int64) Cell { return Cell(tagInt | uint64(v)&0x0000_FFFF_FFFF_FFFF) }
+func CPtr(idx int) Cell { return Cell(tagPtr | uint64(idx)&0x0000_FFFF_FFFF_FFFF) }
+func (c Cell) Ptr() int { return int(uint64(c) & 0x0000_FFFF_FFFF_FFFF) }
+
+type vmSetI64 struct{ data map[int64]struct{} }
+type vmSet struct{ data map[Cell]struct{} }
+type VM struct{ Objects []any }
+
+func NewVM() *VM { return &VM{Objects: make([]any, 0, 16)} }
+
+func (vm *VM) newSetI64(hint int) Cell {
+	idx := len(vm.Objects)
+	vm.Objects = append(vm.Objects, &vmSetI64{data: make(map[int64]struct{}, hint)})
+	return CPtr(idx)
+}
+
+func (vm *VM) setAddI64(s Cell, k int64) {
+	si := vm.Objects[s.Ptr()].(*vmSetI64)
+	si.data[k] = struct{}{}
+}
+
+func (vm *VM) setHasI64(s Cell, k int64) bool {
+	si := vm.Objects[s.Ptr()].(*vmSetI64)
+	_, hit := si.data[k]
+	return hit
+}
+
+// Generic counterparts kept for shape-unknown sites.
+func (vm *VM) newSetGeneric(hint int) Cell {
+	idx := len(vm.Objects)
+	vm.Objects = append(vm.Objects, &vmSet{data: make(map[Cell]struct{}, hint)})
+	return CPtr(idx)
+}
+func (vm *VM) setAddGeneric(s Cell, k Cell) {
+	sg := vm.Objects[s.Ptr()].(*vmSet)
+	sg.data[k] = struct{}{}
+}
+func (vm *VM) setHasGeneric(s Cell, k Cell) bool {
+	sg := vm.Objects[s.Ptr()].(*vmSet)
+	_, hit := sg.data[k]
+	return hit
+}
+
+func (vm *VM) FillProbe(n int64) int64 {
+	vm.Objects = vm.Objects[:0]
+	xs := vm.newSetI64(int(n))
+	for i := int64(0); i < n; i++ {
+		vm.setAddI64(xs, i)
+	}
+	var hits int64
+	for i := int64(0); i < n; i++ {
+		if vm.setHasI64(xs, i) {
+			hits++
+		}
+	}
+	return hits
+}

--- a/runtime/vm2/setopt/aot/aot_test.go
+++ b/runtime/vm2/setopt/aot/aot_test.go
@@ -1,0 +1,31 @@
+package aot
+
+import "testing"
+
+func TestFillProbe(t *testing.T) {
+	vm := NewVM()
+	for _, n := range []int64{1, 8, 128, 1024} {
+		if got := vm.FillProbe(n); got != n {
+			t.Fatalf("FillProbe(%d) = %d, want %d", n, got, n)
+		}
+	}
+}
+
+func BenchmarkFillProbe128(b *testing.B) {
+	vm := NewVM()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if vm.FillProbe(128) != 128 {
+			b.Fatal()
+		}
+	}
+}
+func BenchmarkFillProbe1024(b *testing.B) {
+	vm := NewVM()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if vm.FillProbe(1024) != 1024 {
+			b.Fatal()
+		}
+	}
+}

--- a/runtime/vm2/setopt/baseline/baseline.go
+++ b/runtime/vm2/setopt/baseline/baseline.go
@@ -1,0 +1,52 @@
+// Package baseline holds two reference points for the setopt
+// comparison: today's generic map[Cell]struct{} shape plus a raw
+// map[int64]struct{} floor.
+package baseline
+
+type Cell uint64
+
+const (
+	tagInt uint64 = 0xFFF8_0000_0000_0000
+	tagPtr uint64 = 0xFFFC_0000_0000_0000
+)
+
+func CInt(v int64) Cell { return Cell(tagInt | uint64(v)&0x0000_FFFF_FFFF_FFFF) }
+func CPtr(idx int) Cell { return Cell(tagPtr | uint64(idx)&0x0000_FFFF_FFFF_FFFF) }
+func (c Cell) Ptr() int { return int(uint64(c) & 0x0000_FFFF_FFFF_FFFF) }
+
+type vmSet struct{ data map[Cell]struct{} }
+type VM struct{ Objects []any }
+
+func NewVM() *VM { return &VM{Objects: make([]any, 0, 16)} }
+
+func (vm *VM) FillProbeGeneric(n int64) int64 {
+	vm.Objects = vm.Objects[:0]
+	xs := Cell(tagPtr | uint64(len(vm.Objects)))
+	vm.Objects = append(vm.Objects, &vmSet{data: make(map[Cell]struct{}, n)})
+	for i := int64(0); i < n; i++ {
+		s := vm.Objects[xs.Ptr()].(*vmSet)
+		s.data[CInt(i)] = struct{}{}
+	}
+	var hits int64
+	for i := int64(0); i < n; i++ {
+		s := vm.Objects[xs.Ptr()].(*vmSet)
+		if _, ok := s.data[CInt(i)]; ok {
+			hits++
+		}
+	}
+	return hits
+}
+
+func FillProbeRaw(n int64) int64 {
+	xs := make(map[int64]struct{}, n)
+	for i := int64(0); i < n; i++ {
+		xs[i] = struct{}{}
+	}
+	var hits int64
+	for i := int64(0); i < n; i++ {
+		if _, ok := xs[i]; ok {
+			hits++
+		}
+	}
+	return hits
+}

--- a/runtime/vm2/setopt/baseline/baseline_test.go
+++ b/runtime/vm2/setopt/baseline/baseline_test.go
@@ -1,0 +1,50 @@
+package baseline
+
+import "testing"
+
+func TestFillProbe(t *testing.T) {
+	vm := NewVM()
+	for _, n := range []int64{1, 8, 128, 1024} {
+		if got := vm.FillProbeGeneric(n); got != n {
+			t.Fatalf("Generic(%d) = %d, want %d", n, got, n)
+		}
+		if got := FillProbeRaw(n); got != n {
+			t.Fatalf("Raw(%d) = %d, want %d", n, got, n)
+		}
+	}
+}
+
+func BenchmarkRaw128(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if FillProbeRaw(128) != 128 {
+			b.Fatal()
+		}
+	}
+}
+func BenchmarkRaw1024(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if FillProbeRaw(1024) != 1024 {
+			b.Fatal()
+		}
+	}
+}
+func BenchmarkGeneric128(b *testing.B) {
+	vm := NewVM()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if vm.FillProbeGeneric(128) != 128 {
+			b.Fatal()
+		}
+	}
+}
+func BenchmarkGeneric1024(b *testing.B) {
+	vm := NewVM()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if vm.FillProbeGeneric(1024) != 1024 {
+			b.Fatal()
+		}
+	}
+}

--- a/runtime/vm2/setopt/doc.go
+++ b/runtime/vm2/setopt/doc.go
@@ -1,0 +1,16 @@
+// Package setopt is the fourth head-to-head dispatch-strategy
+// comparison (after listopt, stropt, mapopt). Same recipe:
+//
+//   - baseline/  , today's MEP-24 §4 generic set shape (map[Cell]struct{})
+//     plus a raw map[int64]struct{} floor.
+//   - mig/       , MEP-26 Migration over SetI64 / Generic shapes.
+//   - ic/        , MEP-27 K=1 IC slot per call site.
+//   - aot/       , MEP-28 specialized I64 handlers.
+//
+// Workload is sets/fill_probe: insert N ints, then probe N members
+// and count hits. This is the canonical set benchmark on MEP-23.
+//
+// Prediction (from the maps result): sets should pattern-match maps,
+// since the underlying Go op is map-class. Baseline likely wins;
+// AOT in the noise; IC and Migration regress.
+package setopt

--- a/runtime/vm2/setopt/ic/ic.go
+++ b/runtime/vm2/setopt/ic/ic.go
@@ -1,0 +1,143 @@
+// Package ic implements MEP-27 Inline Cache for the set container.
+// K=1 IC slot per call site: state 0=uninit, 1=mono SetI64,
+// 2=mono Generic, 3=polymorphic.
+package ic
+
+type Cell uint64
+
+const (
+	tagInt uint64 = 0xFFF8_0000_0000_0000
+	tagPtr uint64 = 0xFFFC_0000_0000_0000
+	tagMsk uint64 = 0xFFFE_0000_0000_0000
+)
+
+func CInt(v int64) Cell    { return Cell(tagInt | uint64(v)&0x0000_FFFF_FFFF_FFFF) }
+func CPtr(idx int) Cell    { return Cell(tagPtr | uint64(idx)&0x0000_FFFF_FFFF_FFFF) }
+func (c Cell) IsInt() bool { return uint64(c)&tagMsk == tagInt }
+func (c Cell) Int() int64 {
+	v := int64(c) & 0x0000_FFFF_FFFF_FFFF
+	if v&0x0000_8000_0000_0000 != 0 {
+		v |= ^int64(0x0000_FFFF_FFFF_FFFF)
+	}
+	return v
+}
+func (c Cell) Ptr() int { return int(uint64(c) & 0x0000_FFFF_FFFF_FFFF) }
+
+type vmSetI64 struct{ data map[int64]struct{} }
+type vmSet struct{ data map[Cell]struct{} }
+type VM struct{ Objects []any }
+
+func NewVM() *VM { return &VM{Objects: make([]any, 0, 16)} }
+
+type ICSlot struct{ State uint8 }
+
+func (vm *VM) newSet(hint int) Cell {
+	idx := len(vm.Objects)
+	vm.Objects = append(vm.Objects, &vmSetI64{data: make(map[int64]struct{}, hint)})
+	return CPtr(idx)
+}
+
+func (vm *VM) migrate(idx int) *vmSet {
+	old := vm.Objects[idx].(*vmSetI64)
+	nu := &vmSet{data: make(map[Cell]struct{}, len(old.data))}
+	for k := range old.data {
+		nu.data[CInt(k)] = struct{}{}
+	}
+	vm.Objects[idx] = nu
+	return nu
+}
+
+func (vm *VM) setAddIC(slot *ICSlot, s Cell, k Cell) {
+	idx := s.Ptr()
+	if slot.State == 1 {
+		if si, ok := vm.Objects[idx].(*vmSetI64); ok {
+			if k.IsInt() {
+				si.data[k.Int()] = struct{}{}
+				return
+			}
+			slot.State = 3
+			nu := vm.migrate(idx)
+			nu.data[k] = struct{}{}
+			return
+		}
+		slot.State = 3
+	} else if slot.State == 2 {
+		if sg, ok := vm.Objects[idx].(*vmSet); ok {
+			sg.data[k] = struct{}{}
+			return
+		}
+		slot.State = 3
+	}
+	switch o := vm.Objects[idx].(type) {
+	case *vmSetI64:
+		if k.IsInt() {
+			if slot.State == 0 {
+				slot.State = 1
+			}
+			o.data[k.Int()] = struct{}{}
+			return
+		}
+		nu := vm.migrate(idx)
+		slot.State = 2
+		nu.data[k] = struct{}{}
+	case *vmSet:
+		if slot.State == 0 {
+			slot.State = 2
+		}
+		o.data[k] = struct{}{}
+	}
+}
+
+func (vm *VM) setHasIC(slot *ICSlot, s Cell, k Cell) bool {
+	idx := s.Ptr()
+	if slot.State == 1 {
+		if si, ok := vm.Objects[idx].(*vmSetI64); ok {
+			if k.IsInt() {
+				_, hit := si.data[k.Int()]
+				return hit
+			}
+			return false
+		}
+		slot.State = 3
+	} else if slot.State == 2 {
+		if sg, ok := vm.Objects[idx].(*vmSet); ok {
+			_, hit := sg.data[k]
+			return hit
+		}
+		slot.State = 3
+	}
+	switch o := vm.Objects[idx].(type) {
+	case *vmSetI64:
+		if slot.State == 0 {
+			slot.State = 1
+		}
+		if k.IsInt() {
+			_, hit := o.data[k.Int()]
+			return hit
+		}
+		return false
+	case *vmSet:
+		if slot.State == 0 {
+			slot.State = 2
+		}
+		_, hit := o.data[k]
+		return hit
+	}
+	return false
+}
+
+func (vm *VM) FillProbe(n int64) int64 {
+	vm.Objects = vm.Objects[:0]
+	var addSlot, hasSlot ICSlot
+	xs := vm.newSet(int(n))
+	for i := int64(0); i < n; i++ {
+		vm.setAddIC(&addSlot, xs, CInt(i))
+	}
+	var hits int64
+	for i := int64(0); i < n; i++ {
+		if vm.setHasIC(&hasSlot, xs, CInt(i)) {
+			hits++
+		}
+	}
+	return hits
+}

--- a/runtime/vm2/setopt/ic/ic_test.go
+++ b/runtime/vm2/setopt/ic/ic_test.go
@@ -1,0 +1,47 @@
+package ic
+
+import "testing"
+
+func TestFillProbe(t *testing.T) {
+	vm := NewVM()
+	for _, n := range []int64{1, 8, 128, 1024} {
+		if got := vm.FillProbe(n); got != n {
+			t.Fatalf("FillProbe(%d) = %d, want %d", n, got, n)
+		}
+	}
+}
+
+func TestICStaysMonomorphic(t *testing.T) {
+	vm := NewVM()
+	vm.Objects = vm.Objects[:0]
+	var addSlot, hasSlot ICSlot
+	xs := vm.newSet(128)
+	for i := int64(0); i < 128; i++ {
+		vm.setAddIC(&addSlot, xs, CInt(i))
+	}
+	for i := int64(0); i < 128; i++ {
+		vm.setHasIC(&hasSlot, xs, CInt(i))
+	}
+	if addSlot.State != 1 || hasSlot.State != 1 {
+		t.Fatalf("expected state=1, got add=%d has=%d", addSlot.State, hasSlot.State)
+	}
+}
+
+func BenchmarkFillProbe128(b *testing.B) {
+	vm := NewVM()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if vm.FillProbe(128) != 128 {
+			b.Fatal()
+		}
+	}
+}
+func BenchmarkFillProbe1024(b *testing.B) {
+	vm := NewVM()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if vm.FillProbe(1024) != 1024 {
+			b.Fatal()
+		}
+	}
+}

--- a/runtime/vm2/setopt/mig/mig.go
+++ b/runtime/vm2/setopt/mig/mig.go
@@ -1,0 +1,95 @@
+// Package mig implements MEP-26 Migration for the set container.
+// Sets start as *vmSetI64 (map[int64]struct{}) and migrate one-way to
+// *vmSet (map[Cell]struct{}) the moment a non-int member is added.
+// Every op pays a type switch over the two shapes.
+package mig
+
+type Cell uint64
+
+const (
+	tagInt uint64 = 0xFFF8_0000_0000_0000
+	tagPtr uint64 = 0xFFFC_0000_0000_0000
+	tagMsk uint64 = 0xFFFE_0000_0000_0000
+)
+
+func CInt(v int64) Cell    { return Cell(tagInt | uint64(v)&0x0000_FFFF_FFFF_FFFF) }
+func CPtr(idx int) Cell    { return Cell(tagPtr | uint64(idx)&0x0000_FFFF_FFFF_FFFF) }
+func (c Cell) IsInt() bool { return uint64(c)&tagMsk == tagInt }
+func (c Cell) Int() int64 {
+	v := int64(c) & 0x0000_FFFF_FFFF_FFFF
+	if v&0x0000_8000_0000_0000 != 0 {
+		v |= ^int64(0x0000_FFFF_FFFF_FFFF)
+	}
+	return v
+}
+func (c Cell) Ptr() int { return int(uint64(c) & 0x0000_FFFF_FFFF_FFFF) }
+
+type vmSetI64 struct{ data map[int64]struct{} }
+type vmSet struct{ data map[Cell]struct{} }
+type VM struct{ Objects []any }
+
+func NewVM() *VM { return &VM{Objects: make([]any, 0, 16)} }
+
+func (vm *VM) newSet(hint int) Cell {
+	idx := len(vm.Objects)
+	vm.Objects = append(vm.Objects, &vmSetI64{data: make(map[int64]struct{}, hint)})
+	return CPtr(idx)
+}
+
+func (vm *VM) migrate(idx int) *vmSet {
+	old := vm.Objects[idx].(*vmSetI64)
+	nu := &vmSet{data: make(map[Cell]struct{}, len(old.data))}
+	for k := range old.data {
+		nu.data[CInt(k)] = struct{}{}
+	}
+	vm.Objects[idx] = nu
+	return nu
+}
+
+func (vm *VM) setAdd(s Cell, k Cell) {
+	idx := s.Ptr()
+	switch o := vm.Objects[idx].(type) {
+	case *vmSetI64:
+		if k.IsInt() {
+			o.data[k.Int()] = struct{}{}
+			return
+		}
+		nu := vm.migrate(idx)
+		nu.data[k] = struct{}{}
+	case *vmSet:
+		o.data[k] = struct{}{}
+	}
+}
+
+func (vm *VM) setHas(s Cell, k Cell) bool {
+	switch o := vm.Objects[s.Ptr()].(type) {
+	case *vmSetI64:
+		if k.IsInt() {
+			_, ok := o.data[k.Int()]
+			return ok
+		}
+		return false
+	case *vmSet:
+		_, ok := o.data[k]
+		return ok
+	}
+	return false
+}
+
+// FillProbe inserts N ints then probes the same N members and counts
+// hits. The shape stays SetI64 throughout, so the type switch hits
+// its hot arm every call.
+func (vm *VM) FillProbe(n int64) int64 {
+	vm.Objects = vm.Objects[:0]
+	xs := vm.newSet(int(n))
+	for i := int64(0); i < n; i++ {
+		vm.setAdd(xs, CInt(i))
+	}
+	var hits int64
+	for i := int64(0); i < n; i++ {
+		if vm.setHas(xs, CInt(i)) {
+			hits++
+		}
+	}
+	return hits
+}

--- a/runtime/vm2/setopt/mig/mig_test.go
+++ b/runtime/vm2/setopt/mig/mig_test.go
@@ -1,0 +1,44 @@
+package mig
+
+import "testing"
+
+func TestFillProbe(t *testing.T) {
+	vm := NewVM()
+	for _, n := range []int64{1, 8, 128, 1024} {
+		if got := vm.FillProbe(n); got != n {
+			t.Fatalf("FillProbe(%d) = %d, want %d", n, got, n)
+		}
+	}
+}
+
+func TestMigration(t *testing.T) {
+	vm := NewVM()
+	xs := vm.newSet(4)
+	vm.setAdd(xs, CInt(1))
+	if _, ok := vm.Objects[xs.Ptr()].(*vmSetI64); !ok {
+		t.Fatal("expected vmSetI64")
+	}
+	vm.setAdd(xs, CPtr(0))
+	if _, ok := vm.Objects[xs.Ptr()].(*vmSet); !ok {
+		t.Fatal("expected migration to vmSet")
+	}
+}
+
+func BenchmarkFillProbe128(b *testing.B) {
+	vm := NewVM()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if vm.FillProbe(128) != 128 {
+			b.Fatal()
+		}
+	}
+}
+func BenchmarkFillProbe1024(b *testing.B) {
+	vm := NewVM()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if vm.FillProbe(1024) != 1024 {
+			b.Fatal()
+		}
+	}
+}

--- a/website/docs/mep/mep-0029.md
+++ b/website/docs/mep/mep-0029.md
@@ -311,9 +311,70 @@ For maps in this VM, **int specialization is not worth the implementation cost**
 
 This is the **opposite** of what the lists data suggested for maps in this MEP's earlier draft. The reason for the flip: in lists, the per-element cost was small (slice append/index) so dispatch overhead was a meaningful fraction; in maps the per-element cost is large (hashing + bucket walk), so dispatch overhead drowns in the noise.
 
+## Sets (`sets/fill_probe`)
+
+The fourth container exercised is sets, on `sets/fill_probe`: insert N int members into a set, then probe the same N members and count hits. Like `lists/fill_sum` and `maps/fill_sum` this workload is monomorphic (the set stays `vmSetI64` throughout), so dispatch sites see one shape after warmup.
+
+### Code layout
+
+```
+runtime/vm2/setopt/
+├── doc.go              , package-level explanation
+├── baseline/           , today's MEP-24 §4-style generic map[Cell]struct{} + raw map[int64]struct{} floor
+├── mig/                , Option 1: switch over SetI64/Generic shapes
+├── ic/                 , Option 2: K=1 IC slot per call site (state byte)
+└── aot/                , Option 3: specialized I64 add/has handlers
+```
+
+### Strategies, as implemented
+
+**Baseline (`setopt/baseline`).** Generic `map[Cell]struct{}`; every add/has pays a `CInt` pack and one itab assertion. Plus a `FillProbeRaw` reference that uses `map[int64]struct{}` with no Cell or Objects table.
+
+**Migration (`setopt/mig`).** `*vmSetI64` (map[int64]struct{}) is the default; adding a non-int member migrates in-place to `*vmSet` (map[Cell]struct{}). Every op pays a `switch obj.(type)` over the two shapes.
+
+**Inline Cache (`setopt/ic`).** K=1 IC slot per call site (`ICSlot{State uint8}`, with state 0=uninit, 1=monomorphic I64, 2=monomorphic Generic, 3=polymorphic). After warmup the slot stays at 1 and every op pays: one byte-tag compare + one branch + one single-case type assertion.
+
+**AOT (`setopt/aot`).** The driver calls specialized `setAddI64` and `setHasI64` directly with raw `int64` members, skipping `Cell` pack entirely. Each handler pays one single-case type assertion.
+
+### Results
+
+```
+go test -bench=. -benchtime=2s -count=5 -run=^$ ./runtime/vm2/setopt/...
+```
+
+Apple M4, Go 1.25, darwin/arm64, 5 samples per benchmark. Median ns/op:
+
+| Strategy               | N=128 | N=1024 | Allocs (N=1024) | Bytes (N=1024) |
+|------------------------|-------|--------|-----------------|----------------|
+| Raw `map[int64]struct{}` | 1325 | 10780 | 5               | 36.1 KiB       |
+| **AOT**                | **1424** | **11373** | **7**     | **36.1 KiB**   |
+| **Baseline (Generic)** | **1429** | **11614** | **7**     | **36.1 KiB**   |
+| IC                     | 1626  | 13413  | 7               | 36.1 KiB       |
+| Migration              | 1549  | 13610  | 7               | 36.1 KiB       |
+
+Per-op cost at N=1024 (workload is 2048 set ops, N adds + N probes):
+
+| Strategy               | ns/set-op | Overhead vs raw |
+|------------------------|-----------|-----------------|
+| Raw `map[int64]struct{}` | 5.26    | -               |
+| AOT                    | 5.55      | +0.29 ns        |
+| Baseline (Generic)     | 5.67      | +0.41 ns        |
+| IC                     | 6.55      | +1.29 ns        |
+| Migration              | 6.65      | +1.39 ns        |
+
+### Analysis
+
+**Sets confirm the maps heuristic.** The forward prediction from the maps section ("if the underlying Go op already costs ~5 ns/op, dispatch strategy doesn't matter") lands. AOT and Baseline tie within noise, both within 8% of the raw floor. IC and Migration regress by ~18% for the usual reason: their dispatch overhead is pure cost on a Go runtime where the alternative (one single-case type assertion) is already as cheap as dispatch gets.
+
+**AOT shows a hair of a win this time** (~2% over Baseline), unlike maps where Baseline edged AOT. The reason is that the set workload's hot op (`map[int64]struct{}` insert/lookup) is a touch cheaper than `map[int64]int64` (no value byte to copy on insert, no value to load on lookup), so the saved Cell pack becomes a slightly larger fraction. The gap is too small to act on; treat sets and maps as the same regime.
+
+### What this means
+
+For sets in this VM, **int specialization is not worth the implementation cost**, same conclusion as maps. The current MEP-24 generic `map[Cell]struct{}` shape is within 8% of the raw `map[int64]struct{}` floor. Wherever the Lua gap on `sets/*` workloads comes from, it is not in the set shape choice. Keep the generic shape and move on.
+
 ## Recommendations
 
-Two containers, two different lessons, one cross-cutting pattern.
+Three containers, three different lessons, one cross-cutting pattern.
 
 ### For lists
 
@@ -329,14 +390,13 @@ The algorithmic delta dominates dispatch. **Add the rope shape first**, that is 
 
 This is the **opposite** of the recommendation MEP-29 made before the maps data landed. The earlier recommendation extrapolated from the lists pattern (where AOT won by skipping pack/unpack). The extrapolation broke because the per-op cost in maps is 10x the per-op cost in lists; what was a meaningful fraction in lists is in the noise in maps.
 
-### For the next container (sets and structs)
+### For sets
 
-The maps result implies a heuristic: **if the underlying Go operation already costs ≥5 ns/op, dispatch strategy doesn't matter** (Baseline wins). Apply it forward:
+**Same answer as maps: do not bother specializing.** Today's generic `map[Cell]struct{}` shape is within 8% of the raw `map[int64]struct{}` floor; AOT shows a ~2% improvement that is not worth the implementation cost; IC/Migration both regress by ~18%. The maps heuristic ("if the underlying Go op already costs ~5 ns/op, dispatch strategy doesn't matter") transferred cleanly. Keep the MEP-24 set shape.
 
-- **Sets** (`maps/fill_sum` analogue): the underlying Go `map[K]struct{}` is the same cost as `map[K]V`, so the maps conclusion likely transfers. Implement the suite anyway to confirm.
-- **Structs**: per-field load/store in Go is sub-nanosecond. If structs end up as `[]Cell` indexed by slot, they will look like lists, and AOT-style slot-typed specialization should pay off. If structs end up as Go struct types via `any`, they will look like maps and not pay off.
+### For the next container (structs)
 
-Either way, build the three-package suite and let the numbers decide.
+Predict by per-op cost. **Per-field load/store in Go is sub-nanosecond** (slice index, struct field), much faster than a map op. If structs end up as `[]Cell` indexed by slot, they will look like lists, and AOT-style slot-typed specialization should pay off. If structs end up as Go struct types reached via `any`, they will look like maps and not pay off. Build the three-package suite and let the numbers decide.
 
 ## Caveats
 
@@ -365,6 +425,11 @@ Either way, build the three-package suite and let the numbers decide.
 - `runtime/vm2/mapopt/mig/mig.go` + test, MEP-26 map prototype (Empty/I64/Generic switch)
 - `runtime/vm2/mapopt/ic/ic.go` + test, MEP-27 map prototype (K=1 IC slot)
 - `runtime/vm2/mapopt/aot/aot.go` + test, MEP-28 map prototype (specialized I64xI64 handlers)
+- `runtime/vm2/setopt/doc.go`, sets package documentation
+- `runtime/vm2/setopt/baseline/baseline.go` + test, today's MEP-24-style generic set shape
+- `runtime/vm2/setopt/mig/mig.go` + test, MEP-26 set prototype (SetI64/Generic switch)
+- `runtime/vm2/setopt/ic/ic.go` + test, MEP-27 set prototype (K=1 IC slot)
+- `runtime/vm2/setopt/aot/aot.go` + test, MEP-28 set prototype (specialized I64 handlers)
 - `website/docs/mep/mep-0029.md`, this MEP
 
 ## Related work


### PR DESCRIPTION
## Summary
- Fourth container in the MEP-29 head-to-head: `sets/fill_probe` (insert N, then probe N).
- Adds `runtime/vm2/setopt/{baseline,mig,ic,aot}` mirroring the lists/strings/maps layout.
- Updates MEP-29 with a Sets section + recommendation; structs is now the only container left.

## Results

N=1024 medians (Apple M4, Go 1.25, 5 samples), ns/op:

| Strategy | N=128 | N=1024 |
|---|---|---|
| Raw `map[int64]struct{}` | 1325 | 10780 |
| **AOT** | **1424** | **11373** |
| **Baseline (Generic)** | **1429** | **11614** |
| IC | 1626 | 13413 |
| Migration | 1549 | 13610 |

AOT and Baseline tie within noise (both ~8% over raw floor); IC/Mig regress ~18%. Confirms the maps heuristic: when the underlying Go op is ~5 ns/op, dispatch strategy doesn't matter.

Closes #21535.

## Test plan
- [x] `go test ./runtime/vm2/setopt/...`
- [x] `go test -bench=. -benchtime=2s -count=5 -run=^$ ./runtime/vm2/setopt/...`
- [x] No em-dashes in new content