### PR TITLE
mep-0030/0031/0032: three competing JIT strategy specs for vm2

### DIFF
--- a/website/docs/mep/mep-0030.md
+++ b/website/docs/mep/mep-0030.md
@@ -1,0 +1,226 @@
+---
+mep: 30
+title: VM2 JIT Option A - Template / Copy-and-Patch Baseline JIT
+author: Mochi core
+status: Draft
+type: Standards Track
+created: 2026-05-17
+sidebar_position: 30
+sidebar_label: MEP 30. JIT Option A (Template)
+description: "First of three competing JIT strategy specs for vm2. Each opcode handler is pre-compiled once into a position-independent native snippet, stored as a byte slice keyed by (opcode, shape-tuple), then concatenated and patched into an mmap'd executable buffer at function load. No IR, no register allocator, no inliner. The result is a non-optimizing baseline JIT in the lineage of V8 Sparkplug, JSC's Baseline JIT, and CPython 3.13's copy-and-patch JIT. This MEP specifies the snippet harvesting pipeline, the patcher ABI, the interpreter-compatible frame layout that makes OSR trivial, the deopt-free guard model, the distribution story (single Go binary, no cgo), and predicts a 2-4x speedup over the vm2 interpreter on fill_sum-class workloads."
+---
+
+# MEP 30. VM2 JIT Option A - Template / Copy-and-Patch Baseline JIT
+
+| Field    | Value                                                          |
+|----------|----------------------------------------------------------------|
+| MEP      | 30                                                             |
+| Title    | VM2 JIT Option A - Template / Copy-and-Patch Baseline JIT      |
+| Author   | Mochi core                                                     |
+| Status   | Draft                                                          |
+| Type     | Standards Track                                                |
+| Created  | 2026-05-17                                                     |
+
+## Abstract
+
+This MEP specifies the **template / copy-and-patch baseline JIT** for vm2: the lowest-complexity tier in the JIT taxonomy, in the lineage of V8 Sparkplug (2021), JavaScriptCore's Baseline JIT, and CPython 3.13's copy-and-patch JIT (PEP 744). The vm2 compiler emits its existing bytecode; on the first call past a hotness threshold, a JIT pass walks the bytecode and concatenates one pre-compiled native snippet per (opcode, shape-tuple), patches in immediates and branch targets, then `mmap`s the result as executable. The interpreter frame layout is preserved bit-for-bit, so on-stack replacement (OSR) is a function-pointer swap and bailout is a `JMP` back into the interpreter.
+
+This is **Option A of three**. MEP-31 specifies the tracing JIT alternative; MEP-32 specifies the tiered method JIT with type feedback. All three share the same vm2 bytecode, the same `Cell` ABI, and the same MEP-25 data-model shapes; only the compilation strategy differs.
+
+## Motivation
+
+The vm2 interpreter, after the MEP-17 through MEP-29 work, is within ~4x of native Go on `fill_sum`-class loops and within ~5x of LuaJIT on the broader corpus. The remaining gap is dominated by **dispatch overhead and Cell boxing on the hot path**, not by missing optimizations. A baseline JIT that erases the opcode dispatch and inlines the per-shape handler bodies will close the bulk of that gap with no IR, no register allocator, and no speculative type system.
+
+The design constraint for Mochi is sharper than for V8 or CPython: **Mochi must continue to distribute as a single static Go binary, with no cgo and no external toolchain on the user's machine**. This rules out LLVM-at-runtime (CPython's offline approach is fine, but their runtime is C; ours is Go) and rules out invoking the Go compiler as a subprocess. The only emission backend that satisfies the constraint is direct machine-code patching, for which `github.com/twitchyliquid64/golang-asm` (the Go compiler's own assembler, repackaged) is the proven Go-native path.
+
+The historical evidence is consistent: every serious JIT engine started with a baseline tier of roughly this shape, and every one of them banked a 3-5x win at engineering costs measured in engineer-quarters, not engineer-years:
+
+- **V8 Sparkplug** (2021): no IR, "switch in a for loop", compiles in ~10 us per function, 5-15% on real workloads and +45% on JetStream over the Ignition interpreter.
+- **JSC Baseline JIT**: the second tier above the LLInt interpreter; ~2x over LLInt at a fraction of DFG's complexity.
+- **CPython 3.13 copy-and-patch JIT**: ~0% in 3.13 (parity with the tier-2 interpreter, by design), single-digit gains in 3.14, ~12% on macOS arm64 in 3.15 alphas. The peak ceiling is modest precisely because it is the *baseline* tier; the engineering cost is modest for the same reason.
+
+Mochi's relative gain should be larger than CPython's because vm2's interpreter is less aggressively optimized than CPython's tier-2 specializer, and the per-opcode handler bodies in vm2 are already short and shape-typed thanks to MEP-19 (quickening) and MEP-29's measured-AOT work.
+
+## Specification
+
+### Overview
+
+The JIT is a build-time + run-time pipeline:
+
+1. **Build time**: a code generator produces one Go source function per (opcode, shape-tuple) handler. The Go compiler emits each as a regular function. A harvesting tool walks the resulting object file, extracts the function body bytes, records relocation sites (immediates, branch targets, helper-function addresses), and writes the result into a `templates_<arch>.go` table compiled into the Mochi binary.
+2. **Run time**: when a function's call count crosses `JITThreshold` (default 1000), the JIT walks its bytecode once, looks up each instruction's template, appends the body bytes to a per-function `[]byte` buffer, fills in the recorded relocation slots from the instruction's immediates and from the JIT's own jump-target map, then `mmap`s the buffer with `PROT_EXEC` and stores the entry pointer in the function's `JITCode` field.
+3. **Dispatch**: the interpreter's main loop checks `frame.fn.JITCode != nil` on function entry and on back-edges; if set, it jumps into the JIT code via a CGO-free trampoline.
+
+### Snippet ABI
+
+Every snippet is compiled under one fixed calling convention so the patcher can splice them safely:
+
+| Register / Slot      | Role                                                          |
+|----------------------|---------------------------------------------------------------|
+| `R_VM` (arm64 x19, amd64 r14)   | `*vm2.VM`                                          |
+| `R_FP`               | Pointer to the current frame's register file (`*Cell`)        |
+| `R_PC`               | Current PC; only meaningful at instruction boundaries         |
+| `R_OBJECTS`          | Cached `vm.Objects` slice header                              |
+| `R_TMP0..R_TMP3`     | Caller-saved scratch                                          |
+
+Each snippet expects its operand register indexes already encoded as immediate slots within the body. The patcher fills those slots at copy time. Snippets never spill, never allocate Go stack frames, and never call into Go-managed code on the hot path; the only off-snippet calls are to a small set of pre-resolved C-ABI helpers (alloc, GC barrier, deopt return) whose addresses are patched into snippet bodies at JIT time.
+
+### Templates table
+
+`templates_<arch>.go` is generated by `cmd/mochi-jit-gen` at build time and looks like:
+
+```go
+// AUTOGENERATED by cmd/mochi-jit-gen. Do not edit.
+package jit
+
+var templatesARM64 = map[opShape]template{
+    {Op: vm.OpListGetI64, Shape: shapeListI64Int}: {
+        Body:  []byte{0xfd, 0x7b, 0xbf, 0xa9, /* ... */ },
+        Slots: []slot{{Off: 12, Kind: slotImmReg, Field: "Dst"}, ...},
+    },
+    // ... one entry per (opcode, shape-tuple)
+}
+```
+
+Slot kinds:
+
+- `slotImmReg`: write a small integer (register index) into the immediate field of an `add`/`ldr` instruction.
+- `slotImmI64`: write a 64-bit constant into a pair of `movz/movk` instructions.
+- `slotBranch`: write a relative offset to another snippet within the same function.
+- `slotHelper`: write the absolute address of one of the pre-registered runtime helpers (resolved at JIT init).
+
+The number of templates is bounded by `len(opcodes) * len(shape-tuples)`. With ~80 opcodes and an average of ~4 shape tuples per dispatchable opcode, the table is ~320 entries. At an average snippet size of 64 bytes, the templates table compiles into ~20 KB of `.rodata`. This is small enough to embed in every Mochi binary regardless of whether the JIT is enabled at runtime.
+
+### Frame compatibility (free OSR, free bailout)
+
+The single most consequential design choice in Sparkplug was making JIT frames bit-compatible with interpreter frames so that OSR was a function-pointer swap. Mochi adopts the same rule:
+
+- The JIT does not allocate its own register file. It reads and writes the same `frame.Registers []Cell` slab the interpreter uses.
+- The JIT does not invent its own PC encoding. It maintains a `PC -> NativeOffset` table so the interpreter can resume at any instruction boundary.
+- The JIT never holds a Mochi value in an arch register across an instruction boundary. Between snippets, all live state is in `frame.Registers`, exactly as in the interpreter.
+
+This means:
+
+- **OSR**: a back-edge in the interpreter checks `JITCode != nil`; if set, it loads the corresponding `NativeOffset`, sets `R_FP` from the interpreter's frame pointer, and jumps. No frame rewriting.
+- **Bailout** (e.g. shape changed under the JIT, or a helper signals deopt): the snippet writes the current PC into `R_PC` and returns to the trampoline, which falls through into the interpreter loop. No state reconstruction.
+
+The cost of this rule is that the JIT cannot keep a value pinned in a register across opcodes (no cross-opcode register allocation). The benefit is the elimination of deopt as a category of engineering problem. This is the same tradeoff Sparkplug took explicitly. Mochi takes it for the same reason: a baseline tier is the wrong place to pay for a regalloc.
+
+### Hot-path example
+
+`OpListGetI64 dst, list, idx` (Mochi int-specialized list get, post-MEP-19 quickening) compiles, on arm64, to roughly:
+
+```
+ldr   x0, [R_FP, #idx_off]        ; idx (Cell)
+and   x0, x0, #0x0000FFFFFFFFFFFF ; unbox int
+ldr   x1, [R_FP, #list_off]       ; list (Cell)
+and   x1, x1, #0x0000FFFFFFFFFFFF ; unbox ptr
+ldr   x2, [R_OBJECTS, x1, lsl #3] ; *vmListI64
+ldr   x2, [x2, #data_off]         ; backing slice header
+ldr   x0, [x2, x0, lsl #3]        ; load int64 element
+mov   x3, #tagInt_hi
+movk  x3, #tagInt_lo, lsl #48
+orr   x0, x0, x3                  ; rebox int
+str   x0, [R_FP, #dst_off]        ; write result
+```
+
+Eleven instructions, no branches, no calls. The interpreter's equivalent path is ~30 Go statements plus a switch arm, an interface-type assertion, and a Cell pack/unpack helper call. The expected speedup on `fill_sum`-class loops is the ratio of these two paths, modulo Go's inlining of the interpreter loop and the bench harness; benchmarks should land in the 2-4x range.
+
+### Hotness threshold and warmup
+
+A function's `CallCount` increments on entry and `BackEdgeCount` on each backward branch. JIT is triggered when either exceeds `JITThreshold` (default: 1000 for `CallCount`, 10000 for `BackEdgeCount`). Both thresholds are tunable via `MOCHI_JIT_THRESHOLD` and can be set to 1 for testing.
+
+Compilation is synchronous on the calling goroutine. The expected compile time, measured against Sparkplug's ~10 us/function, is a few microseconds per Mochi function; this is well below the threshold at which a background-compilation thread would pay for its complexity.
+
+### Memory and code-cache management
+
+JIT code is allocated from a per-process pool of 64 KiB executable pages allocated via `syscall.Mmap(PROT_EXEC|PROT_READ)`. Pages are append-only within a process; there is no eviction or recompilation. A future MEP may add code-cache GC if real Mochi programs prove to need it.
+
+### Distribution and build constraints
+
+The JIT subsystem lives under `runtime/vm2/jit/`. It is compiled into every Mochi binary but gated by a runtime flag `MOCHI_JIT=1`. The default in 0.x releases is **off**; the default in 1.0 will flip to **on**. Two `GOOS`/`GOARCH` pairs are supported in tier 1: `darwin/arm64` and `linux/amd64`. Other pairs fall back to the interpreter with no source-level changes.
+
+No cgo. No external toolchain. The Mochi binary remains a single static Go file.
+
+## Cost model
+
+Per-opcode steady-state cost, in machine cycles on Apple M4:
+
+| Path                                 | Cycles |
+|--------------------------------------|--------|
+| vm2 interpreter (post-MEP-19)        | 8-12   |
+| vm2 + AOT specialization (MEP-29)    | 6-9    |
+| **vm2 + Option A JIT (this MEP)**    | **2-4** |
+| Theoretical floor (Go native)        | 1-2    |
+
+On `fill_sum` N=1024, this translates to a predicted ~2.5x over the current interpreter and ~2x over the MEP-29 AOT prototype.
+
+## Engineering scope
+
+| Component                                | Lines of Go | Engineer-weeks |
+|------------------------------------------|-------------|----------------|
+| `cmd/mochi-jit-gen` (template harvester) | 800         | 3              |
+| `runtime/vm2/jit/templates_arm64.go`     | generated   | -              |
+| `runtime/vm2/jit/patcher.go`             | 600         | 4              |
+| `runtime/vm2/jit/trampoline_arm64.s`     | 80          | 1              |
+| `runtime/vm2/jit/codecache.go`           | 200         | 1              |
+| Interpreter integration (OSR hooks)      | 150         | 2              |
+| Conformance tests + fuzzers              | 400         | 3              |
+| **Total**                                | **~2200**   | **~14 weeks**  |
+
+Roughly **one engineer-quarter to prototype, two to harden**. Consistent with Sparkplug's reported timeline and CPython 3.13's "small team" framing.
+
+## JIT integration with the rest of vm2
+
+- **MEP-19 quickening**: each quickened opcode (e.g. `OpListGetI64`) is a separate template entry. The JIT consumes whatever shape the interpreter already saw.
+- **MEP-25 shapes**: the JIT does not perform speculation. If a shape changes after JIT compilation, the snippet's shape guard fails and execution falls back to the interpreter via the bailout path.
+- **MEP-27 inline caches**: ICs are read by the JIT as immediate hints when picking templates, but the JIT emits no IC of its own; it embeds the specialized handler directly.
+- **MEP-28 AOT specialization**: orthogonal. MEP-28 specializes the interpreter loop; this MEP replaces the interpreter loop for hot functions.
+
+## Risks
+
+1. **Go runtime safety on JIT code**. JIT code must respect the goroutine preemption protocol, must not appear as a stack frame the GC tries to walk, and must not block stack growth. Mitigation: route all calls back into Go through the trampoline, never let the JIT execute across a back-edge without checking for `g.preempt`.
+2. **Snippet ABI drift between Go versions**. The Go compiler's choice of callee-saved registers and stack frame shape can change. Mitigation: pin the Go toolchain version per Mochi release; verify the templates table at JIT init by re-running a small known-result snippet.
+3. **Architecture coverage**. arm64 + amd64 covers ~95% of Mochi's measured installs but excludes Windows-arm64 and Linux-arm64 (notable for CI runners). Mitigation: explicit fallback to the interpreter on unsupported pairs; track adoption in `MEP-29` style measured-results MEPs.
+4. **Code-cache pressure on long-running processes**. There is no eviction in v1. Mitigation: document the per-process cap; add eviction in a follow-on MEP if measurements warrant.
+
+## Alternatives considered
+
+- **LLVM via cgo**: highest peak performance, but breaks single-binary distribution and adds 50-100 MB of build dependencies. Rejected for the baseline tier; viable as an optional `mochi-jit-llvm` tag in a future MEP.
+- **`go build -buildmode=plugin`**: works only on linux/darwin, requires the Go toolchain at the user's machine, and adds whole-second compile latency. Rejected.
+- **Emit WASM, run via wazero**: viable, gives ~10x over interpreter per wazero's own numbers, but inherits Wasm's calling convention overhead on every host callback. A reasonable Option D worth a follow-on MEP; rejected here because the goal is to share frame layout with the interpreter.
+- **Cranelift via cgo**: 10x faster codegen than LLVM but requires a Rust toolchain plus cgo. Rejected.
+
+## Comparison matrix
+
+| Dimension                       | Option A (this MEP) | Option B (MEP-31, tracing) | Option C (MEP-32, tiered) |
+|---------------------------------|---------------------|----------------------------|---------------------------|
+| Predicted speedup on `fill_sum` | 2-4x                | 5-15x                      | 4-8x                      |
+| Engineering scope (KLOC)        | ~2.2                | ~12                        | ~25                       |
+| Engineer-months to prototype    | ~3                  | ~12                        | ~18                       |
+| Deopt complexity                | None                | Medium                     | High                      |
+| OSR complexity                  | None (free)         | Medium                     | High                      |
+| Single static binary preserved  | Yes                 | Yes (with golang-asm)      | Yes (tier 1)              |
+| Reuses MEP-27 IC infrastructure | Read-only           | Yes                        | Yes (heavily)             |
+| Performance ceiling             | Modest              | High                       | High                      |
+
+## Predicted MEP-23 numbers
+
+On the MEP-23 cross-language `lists/fill_sum` bench, N=1024 on Apple M4 (Go 1.25), current measured ~3805 ns/op for vm2; predicted with Option A: ~1500-1900 ns/op, closing ~70% of the gap to the Go-native floor at 935 ns/op. On `strings/concat_loop` (rope-shape baseline from MEP-29), the JIT's win is smaller (~1.3x) because the hot path is already dominated by allocation, not dispatch.
+
+## Open questions
+
+- **Per-shape vs per-shape-tuple templates**. Templates for binary opcodes (e.g. `OpListConcat`) explode quadratically in shape count. Cap the explosion by deferring shape-tuples beyond a threshold to the interpreter? Or factor them via a runtime shape-merging table inside the snippet?
+- **AArch64 PAC interaction**. Apple Silicon enforces pointer authentication on return addresses. The trampoline must sign/authenticate its own return path; the JIT body is leaf and unaffected. Verify on real hardware before merging.
+- **Whether to ship the JIT off by default in 1.0**. Sparkplug shipped on by default; CPython 3.13's JIT shipped off. Mochi should pick once tier 1 lands and `MEP-29-equivalent` measurements are in hand.
+
+## Related work
+
+- [V8 Sparkplug post (Verwaest, 2021)](https://v8.dev/blog/sparkplug)
+- [PEP 744 - JIT Compilation](https://peps.python.org/pep-0744/)
+- [Copy-and-Patch Compilation (Xu & Kjolstad, PLDI 2021)](https://dl.acm.org/doi/10.1145/3485513)
+- [JSC Baseline JIT internals (Zon8)](https://zon8.re/posts/jsc-internals-part2-the-llint-and-baseline-jit/)
+- [golang-asm](https://github.com/twitchyliquid64/golang-asm)
+- [Runtime code generation in Go (mathetake)](https://mathetake.github.io/posts/runtime-code-generation-in-go-part-1/)
+- [MEP-25](/docs/mep/mep-0025), [MEP-27](/docs/mep/mep-0027), [MEP-28](/docs/mep/mep-0028), [MEP-29](/docs/mep/mep-0029): the data model and dispatch-strategy MEPs whose work this JIT consumes.
+- [MEP-31](/docs/mep/mep-0031), [MEP-32](/docs/mep/mep-0032): the two competing JIT strategies.

--- a/website/docs/mep/mep-0031.md
+++ b/website/docs/mep/mep-0031.md
@@ -1,0 +1,232 @@
+---
+mep: 31
+title: VM2 JIT Option B - Tracing JIT over Typed Loops
+author: Mochi core
+status: Draft
+type: Standards Track
+created: 2026-05-17
+sidebar_position: 31
+sidebar_label: MEP 31. JIT Option B (Tracing)
+description: "Second of three competing JIT strategy specs for vm2. The interpreter counts iterations of every back-edge; when a counter trips, the runtime begins recording a linear trace of typed Cell operations starting from that back-edge. The trace is closed when control returns to the same back-edge, optimized in straight-line form (constant folding, allocation removal, guard hoisting), and compiled to native via golang-asm. Subsequent iterations execute the compiled trace; any guard failure side-exits back to the interpreter. Lineage traces to LuaJIT (single-level, hand-coded) and PyPy (meta-tracing, RPython-generated). This MEP specifies the trace recorder, the trace-IR with explicit guards, the guard-keyed side-exit table, the trace tree shape, and predicts a 5-15x speedup on numeric loops at a 4-6x larger engineering scope than MEP-30."
+---
+
+# MEP 31. VM2 JIT Option B - Tracing JIT over Typed Loops
+
+| Field    | Value                                                |
+|----------|------------------------------------------------------|
+| MEP      | 31                                                   |
+| Title    | VM2 JIT Option B - Tracing JIT over Typed Loops      |
+| Author   | Mochi core                                           |
+| Status   | Draft                                                |
+| Type     | Standards Track                                      |
+| Created  | 2026-05-17                                           |
+
+## Abstract
+
+This MEP specifies the **tracing JIT** for vm2: a per-loop compilation strategy that records the actual instructions executed on a hot back-edge, optimizes the recorded trace as straight-line code with explicit guards, and compiles it to native. The compiled trace runs subsequent iterations directly; any deviation (a guard fails) exits to the interpreter. The lineage runs through LuaJIT 2 (Pall, 2010-) for the hand-coded single-level form, PyPy / RPython for the meta-tracing form, and SpiderMonkey TraceMonkey (2008) as the cautionary tale.
+
+This is **Option B of three**. MEP-30 specifies the template / copy-and-patch baseline JIT; MEP-32 specifies the tiered method JIT. All three share the same vm2 bytecode, `Cell` ABI, and MEP-25 shapes; only the compilation strategy differs.
+
+## Motivation
+
+Tracing JITs are uniquely good at one specific shape of program: **a hot loop whose dynamic behavior is far simpler than its static text**. The interpreter walks branchy generic code; the trace records only what actually happened on the path through. The compiler then optimizes a linear sequence with no merge points, where escape analysis, constant folding, and guard hoisting become local rewrites instead of dataflow analyses. The published evidence:
+
+- **LuaJIT** routinely matches or beats C on numeric loops and stays within 2-4x on most idiomatic Lua, on a codebase of ~30 KLOC of C plus DynASM.
+- **PyPy** is typically 4-7x faster than CPython on numeric workloads and competitive on broader Python despite the dynamism overhead.
+- **Bolz & Tratt (2013)** found that adding meta-tracing to an interpreter typically required ~2 KLOC of optimization code on top of the recorder, because trace optimizations are local.
+
+The cost is well documented too:
+
+- **TraceMonkey** was removed from SpiderMonkey because it lost on branchy code, and the warmup pathology (cold traces, megamorphic dispatch, trace abort cycles) was hard to diagnose.
+- **PyPy** maintains a small expert team and a substantial set of trace-debugging tools because the failure modes are non-local.
+
+For Mochi specifically, the workload mix matters. MEP-23's crosslang corpus is dominated by `fill_sum`, `concat_loop`, `fib`, and similar loop-heavy benchmarks; these are exactly the shape tracing JITs were built for. A tracing JIT would deliver a 5-15x win on this subset. The risk is what happens off this subset: code with deeply nested polymorphic dispatch, exceptions, or generators.
+
+This MEP exists to **specify the tracing alternative precisely enough that it can be measured against the baseline (MEP-30) and the tiered (MEP-32) options**. A follow-on Informational MEP (analogous to MEP-29) will pick the winner from measured numbers.
+
+## Specification
+
+### Overview
+
+The JIT consists of five components:
+
+1. **Hotness profiler**: per-back-edge counters in the interpreter.
+2. **Recorder**: records a typed-Cell trace from the moment a back-edge counter trips until control returns to the same back-edge, an inner trace exits, or a record budget is exceeded.
+3. **Trace IR + optimizer**: a small SSA IR with explicit `Guard` operations; passes are constant folding, guard hoisting, allocation removal, and dead store elimination.
+4. **Backend**: emits native code per trace via `golang-asm` (same backend as MEP-30, different IR upstream).
+5. **Side-exit table**: per-guard map from native PC to (interpreter PC, register snapshot) so the deopt path can resume.
+
+### Hotness profiling
+
+A `BackEdgeCount` is added to the existing function metadata, indexed by source PC (back-edge target). The interpreter increments on each backward branch; when a counter crosses `TraceThreshold` (default 50), recording begins on the next entry.
+
+`TraceThreshold` is deliberately low compared to MEP-30's 1000 because tracing has higher warmup cost per attempt; we want to amortize recording over many iterations but not over a million.
+
+### Trace recording
+
+The recorder is a separate execution mode of the interpreter, not a separate VM. On each opcode dispatch, in addition to the normal handler, the recorder appends an IR node:
+
+```go
+type TraceOp struct {
+    Op       vm.OpCode
+    Args     [3]TraceRef     // SSA references to prior IR nodes or guard outputs
+    Imm      int64           // immediate from bytecode
+    Guards   []Guard         // type guards attached to this op
+    PC       int             // originating interpreter PC for deopt
+}
+```
+
+Type guards are inserted **at every shape-dependent operation**:
+
+- `OpListGet` records as `OpListGetTraced` with a `Guard{kind: ShapeIs, expect: ListI64}`. If the list is later not `ListI64` the guard fails.
+- `OpAdd` records as `OpAddI64` or `OpAddF64` per the observed types, each with a numeric tag guard.
+
+Recording terminates on any of:
+
+- **Loop close**: control reaches the same back-edge that started the trace. The trace is closed and queued for optimization.
+- **Inner side-exit**: control reaches a guard that was recorded as a trace exit (trace tree split).
+- **Record budget exceeded**: trace length > 1024 IR nodes, indicating non-loop code or runaway recursion. Trace is discarded, back-edge marked "blacklisted" for `BlacklistDuration` (default 100 entries) before retry.
+- **Hard abort**: any non-traceable opcode (allocation that must call into Go-managed code with a stack-growth check, GC barrier, exception throw). Trace discarded; back-edge counter decremented but not blacklisted.
+
+### Trace IR and optimizations
+
+The IR is SSA with one block (the trace itself). Operations are typed: integer add, float add, Cell box, Cell unbox, list-data-load (specialized to ListI64), and so on.
+
+Optimization passes, in order:
+
+1. **Constant folding**: standard SSA constant propagation. Removes the bulk of address arithmetic produced by the recorder.
+2. **Guard hoisting**: move loop-invariant guards out of the loop body, into the trace's prologue. This is the largest single win and the reason tracing JITs are fast: a typed inner loop pays guard cost once on entry, not per iteration.
+3. **Allocation removal**: any `vmList`, `vmString`, or `vmStruct` allocated inside the trace and not escaping (no store to a heap location, no return) is scalar-replaced. Its fields live in SSA values. PyPy reports this as the dominant optimization for Python performance and the analog should hold for Mochi.
+4. **Dead store elimination**: stores to `frame.Registers[i]` whose value is overwritten before the next side-exit or trace end can be dropped, since side-exits restore from the snapshot table, not from the live frame.
+5. **Common subexpression elimination**: standard.
+
+The optimizer is intentionally local and intentionally small: trace IR is straight-line by construction, so each pass is a single forward sweep.
+
+### Trace shape: linear, then trees, then meta-traces
+
+Three trace shapes are specified in order of complexity. v1 ships only `Linear`.
+
+- **Linear (v1)**: each trace is a single loop closed by a back-edge. A side-exit drops to interpreter.
+- **Tree (v2)**: a side-exit that itself becomes hot is recorded as a child trace and patched into the parent's guard, forming a trace tree. Sharply reduces interpreter time in code with biased branches.
+- **Meta-traces (deferred)**: only relevant if Mochi grows a second front-end interpreter. Not in scope.
+
+### Backend
+
+Code generation reuses the MEP-30 `golang-asm` backend, but the input is a trace-SSA function rather than per-opcode templates. The backend performs a single linear-scan register allocation over the trace's SSA values, mapping live values to architecture registers and spilling to `frame.Registers` only at side-exits.
+
+This is the key performance differentiator over MEP-30: a trace can keep an int64 accumulator in `x0` across many iterations, never touching memory, because there are no opcode boundaries that need a memory-consistent state.
+
+### Side-exit table
+
+Each guard in the compiled trace stores:
+
+```go
+type SideExit struct {
+    NativePC    uint32              // offset within the trace
+    InterpPC    uint32              // PC to resume at
+    Snapshot    []SnapshotEntry     // SSA value -> frame register / immediate
+    ExitCount   uint32              // for tree formation
+}
+```
+
+On guard failure the trace jumps to a trampoline that walks `Snapshot`, writes each captured SSA value back into `frame.Registers`, then returns control to the interpreter at `InterpPC`. This is the deopt path. Unlike MEP-32's deopt, it is local to the trace and never has to reconstruct state from an arbitrary point in an optimized method.
+
+### Blacklisting and trace stability
+
+If the same back-edge produces more than `MaxAbortsPerSite` (default 3) aborted traces in a row, the back-edge is **permanently blacklisted** for the process lifetime. This is the TraceMonkey lesson: trace abort cycles, where the recorder keeps trying and failing, are the worst possible interpreter state and worse than not tracing at all. Hard-blacklisting after a small retry count bounds the damage.
+
+### Memory and concurrency
+
+Compiled traces share the MEP-30 executable code cache (per-process append-only mmap'd pages). Side-exit tables live in regular Go heap memory and are kept alive by a back-pointer from each `Function` to its trace set.
+
+Mochi's per-goroutine VM model means each goroutine has its own profiling counters and may trigger independent tracing; the recorded trace is shared across goroutines once compiled, since the resulting native code is pure (no goroutine-local state beyond `R_VM`).
+
+## Cost model
+
+Per-iteration steady-state cost on a `fill_sum`-style loop, Apple M4:
+
+| Path                                                  | Cycles per loop iter |
+|-------------------------------------------------------|----------------------|
+| vm2 interpreter (post-MEP-19)                         | ~25                  |
+| vm2 + Option A baseline JIT (MEP-30)                  | ~10                  |
+| **vm2 + Option B tracing JIT (this MEP)**             | **~3**               |
+| Theoretical floor (Go native, `for i := 0; i < n;` summing `[]int64`) | ~1 |
+
+The expected end-to-end speedup over the interpreter on numeric loops is **5-15x**. On branchy or polymorphic code that aborts traces, the cost falls back to the interpreter plus a small profiling tax.
+
+## Engineering scope
+
+| Component                                  | Lines of Go | Engineer-weeks |
+|--------------------------------------------|-------------|----------------|
+| Back-edge profiler hooks                   | 100         | 1              |
+| Trace recorder                             | 1500        | 6              |
+| Trace IR + SSA infra                       | 1200        | 5              |
+| Optimization passes (5)                    | 1500        | 8              |
+| Linear-scan register allocator             | 800         | 4              |
+| `golang-asm` backend (trace lowering)      | 1200        | 6              |
+| Side-exit table + deopt trampoline         | 600         | 4              |
+| Trace tree formation (v2)                  | 1000        | 6              |
+| Blacklisting + recorder budget             | 200         | 1              |
+| Conformance tests + trace-shape fuzzers    | 1500        | 8              |
+| Trace-debug tooling (mandatory, not nice-to-have) | 1500 | 8              |
+| **Total**                                  | **~11000**  | **~57 weeks**  |
+
+Roughly **one engineer-year to prototype, plus another year to harden and ship trace trees**. Consistent with the published timelines for LuaJIT 2 (one architect, multi-year) and PyPy (small team, multi-year, with the trace-debug tooling cost dominating once correctness regressions show up in the wild).
+
+## JIT integration with the rest of vm2
+
+- **MEP-19 quickening**: the trace recorder works at the quickened-opcode level, so the IR is already type-narrow before recording starts.
+- **MEP-25 shapes**: shape transitions on a hot loop's container trigger side-exit, which is the correct behavior; the next entry retries the trace under the new shape.
+- **MEP-27 inline caches**: the recorder reads ICs as type predictions but always emits its own guard, so trace correctness does not depend on IC freshness.
+- **MEP-30 baseline JIT**: complementary. Baseline JIT compiles whole functions cheaply; tracing JIT compiles hot inner loops expensively. A coexistence design is possible (baseline JIT serves as the fallback path on trace side-exit), but v1 ships tracing-only and reuses the interpreter as the side-exit target.
+
+## Risks
+
+1. **Trace abort pathology**. The single biggest source of failure for tracing JITs in the field. Mitigation: hard blacklisting after 3 aborts; comprehensive trace-debug logging (`MOCHI_JIT_TRACE_DEBUG=1`); measured corpus tests in CI that fail if any expected-traceable loop aborts.
+2. **Code with mixed types in the loop body**. Each type change is a guard; many guards make the trace fat. Mitigation: cap trace length at 1024 IR nodes; bail out and let the interpreter handle the loop if the type histogram is too wide.
+3. **Allocation in the loop**. Allocations that escape cannot be removed and become a serialization point in the trace. Mitigation: rely on Mochi's existing escape analysis at compile time; emit a hint to the trace recorder so it can pre-emptively abort traces with known-escaping allocations.
+4. **Trace-debug tooling cost**. PyPy's experience: trace-debug tooling ends up the same order of magnitude as the optimizer itself. We have explicitly budgeted ~8 engineer-weeks for it above. Underestimating this is the single largest risk to the project schedule.
+5. **Interaction with Go's GC**. Trace code holds raw `*Cell` pointers into `frame.Registers`. The frame must be GC-pinned for the duration of trace execution. Mitigation: trace prologue takes a `runtime.KeepAlive` analog; trace epilogue releases. Detailed protocol specified in `runtime/vm2/jit/trace_gc.go` design doc (deferred).
+
+## Alternatives considered
+
+- **Pure method JIT (MEP-32 only)**: gives up the tracing JIT's structural advantage of seeing only the path taken. For numeric loops this is a 2-3x performance gap, per the LuaJIT-vs-V8 comparison on numeric benchmarks.
+- **Meta-tracing in RPython style**: requires Mochi to be implemented in RPython, which it is not. The Go ecosystem has no equivalent meta-tracing toolkit. Rejected as out-of-scope.
+- **Tracing without trace trees**: the v1 design, deliberately. Trade some peak performance for a simpler initial implementation.
+
+## Comparison matrix
+
+| Dimension                       | Option A (MEP-30, template) | Option B (this MEP) | Option C (MEP-32, tiered) |
+|---------------------------------|-----------------------------|---------------------|---------------------------|
+| Predicted speedup on `fill_sum` | 2-4x                        | 5-15x               | 4-8x                      |
+| Engineering scope (KLOC)        | ~2.2                        | ~11                 | ~25                       |
+| Engineer-months to prototype    | ~3                          | ~12                 | ~18                       |
+| Deopt complexity                | None                        | Medium (local)      | High (cross-method)       |
+| OSR complexity                  | None (free)                 | N/A (back-edge native) | High                   |
+| Single static binary preserved  | Yes                         | Yes                 | Yes (tier 1)              |
+| Reuses MEP-27 IC infrastructure | Read-only                   | Yes                 | Yes                       |
+| Performance ceiling             | Modest                      | High                | High                      |
+| Failure mode on bad workload    | None (= interpreter)        | Abort + blacklist   | Tier-2 deopt cascades     |
+
+## Predicted MEP-23 numbers
+
+On the MEP-23 cross-language `lists/fill_sum` bench, N=1024, current vm2 ~3805 ns/op; predicted with Option B: **~600-900 ns/op**, reaching parity with Go native and roughly 1.5x faster than LuaJIT on the same workload (LuaJIT pays a small Lua-table overhead vm2 does not). On `concat_loop` the win is modest (~2x) because the loop body is dominated by allocation, which tracing can only partially eliminate. On `fib` (recursive, no loop) the trace recorder cannot help; predict a small regression from the recorder's per-call overhead, mitigated by hot-recursion-as-loop detection (a v2 feature, deferred).
+
+## Open questions
+
+- **Function inlining inside a trace**. Tracing JITs naturally inline because they record the called function's body inline. This is mostly good but can blow the trace length budget. Bound by an `InlineDepth` parameter? Per-function annotation?
+- **Tracing across goroutine boundaries**. A `go func()` inside a trace must abort. But blocking on a channel might or might not be worth tracing depending on contention. Defer.
+- **Whether to share the executable code cache with MEP-30**. Both fragment the cache differently. Recommendation: share with eviction policy that prefers retaining trace code.
+- **Pause-for-recording cost**. Recording roughly halves interpreter throughput while active. If a back-edge trips at the start of a long loop, recording cost is amortized; if at the end, it is pure waste. Mitigate via `MinIterationsBeforeRecord`?
+
+## Related work
+
+- [The LuaJIT Wiki - Bytecode and IR](http://wiki.luajit.org/Bytecode-2.0)
+- [Mike Pall, LuaJIT and tracing (LWN, 2010)](https://lwn.net/Articles/378164/)
+- [Bolz et al., Tracing the Meta-Level (ICOOOLPS 2009)](https://dl.acm.org/doi/10.1145/1565824.1565827)
+- [Bolz & Tratt, The Impact of Meta-Tracing on VM Design and Implementation (2013)](https://tratt.net/laurie/research/pubs/papers/bolz_tratt__the_impact_of_metatracing_on_vm_design_and_implementation.pdf)
+- [Bolz-Tereick, Musings on Tracing in PyPy (2025)](https://pypy.org/posts/2025/01/musings-tracing.html)
+- [Gal et al., Trace-based Just-in-Time Type Specialization for Dynamic Languages (PLDI 2009)](https://dl.acm.org/doi/10.1145/1543135.1542528) (TraceMonkey)
+- [Why TraceMonkey was removed (Bug 858032)](https://bugzilla.mozilla.org/show_bug.cgi?id=858032)
+- [MEP-25](/docs/mep/mep-0025), [MEP-27](/docs/mep/mep-0027): data model and IC infrastructure consumed.
+- [MEP-30](/docs/mep/mep-0030), [MEP-32](/docs/mep/mep-0032): the two competing JIT strategies.

--- a/website/docs/mep/mep-0032.md
+++ b/website/docs/mep/mep-0032.md
@@ -1,0 +1,266 @@
+---
+mep: 32
+title: VM2 JIT Option C - Tiered Method JIT with Type Feedback
+author: Mochi core
+status: Draft
+type: Standards Track
+created: 2026-05-17
+sidebar_position: 32
+sidebar_label: MEP 32. JIT Option C (Tiered)
+description: "Third of three competing JIT strategy specs for vm2. Two compilation tiers stacked on the interpreter: tier 1 is the MEP-30 copy-and-patch baseline JIT; tier 2 is a typed-SSA optimizing method JIT that consumes type feedback from MEP-27 inline caches, performs profile-guided inlining and escape analysis, and emits native code with linear-scan register allocation. Bidirectional on-stack replacement (OSR) moves frames between interpreter, tier 1, and tier 2 mid-execution; speculative tier-2 code deopts back to tier 1 on guard failure. Lineage traces to HotSpot C1/C2, JSC's four-tier strategy (LLInt, Baseline, DFG, FTL), and V8's Ignition / Sparkplug / Maglev / Turbofan pipeline. This MEP specifies tier transitions, the optimizing IR, the deopt protocol, the inlining heuristic, and predicts a 4-8x speedup with the broadest workload coverage of the three options."
+---
+
+# MEP 32. VM2 JIT Option C - Tiered Method JIT with Type Feedback
+
+| Field    | Value                                                          |
+|----------|----------------------------------------------------------------|
+| MEP      | 32                                                             |
+| Title    | VM2 JIT Option C - Tiered Method JIT with Type Feedback        |
+| Author   | Mochi core                                                     |
+| Status   | Draft                                                          |
+| Type     | Standards Track                                                |
+| Created  | 2026-05-17                                                     |
+
+## Abstract
+
+This MEP specifies the **tiered method JIT** for vm2: a two-tier compilation pipeline stacked on the existing interpreter, where tier 1 is the MEP-30 baseline JIT and tier 2 is a typed-SSA optimizing method compiler that consumes type feedback from MEP-27 inline caches. The optimizing tier performs profile-guided inlining, escape analysis, scalar replacement, and linear-scan register allocation, then emits native code via `golang-asm`. Frames move bidirectionally across tiers via on-stack replacement; tier-2 code may speculatively assume a stable IC and deopt back to tier 1 (or the interpreter) on guard failure.
+
+The architecture is **the same one every serious production engine converges on**: HotSpot's C1 / C2 (since 1999), JSC's four-tier LLInt / Baseline / DFG / FTL pipeline, V8's Ignition / Sparkplug / Maglev / Turbofan pipeline. The lesson Google taught with Maglev (2023) is that **a mid-tier optimizing JIT between a baseline tier and a peak-optimizing tier is the right shape**; this MEP specifies exactly that shape for Mochi.
+
+This is **Option C of three**. MEP-30 specifies the baseline tier in isolation; MEP-31 specifies the tracing alternative. MEP-32 builds on top of MEP-30 (tier 1 = MEP-30 verbatim) and adds tier 2.
+
+## Motivation
+
+The MEP-30 baseline JIT closes the dispatch-cost gap but cannot eliminate boxing, cannot inline across call sites, and cannot exploit loop-invariant structure. A method JIT that does these three things adds another 2-3x on top of the baseline tier, which is the same ratio HotSpot's C2 adds over C1 and JSC's DFG adds over Baseline.
+
+The published evidence for tiered designs is unusually consistent across engines:
+
+- **HotSpot** (1999-present): two-tier C1 (~5x over interpreter) + C2 (~2x over C1) has been the dominant Java performance architecture for 25 years. The brief C2-only experiment in early HotSpot was abandoned because warmup cost dominated short-running programs.
+- **JSC's four-tier strategy**: LLInt -> Baseline (~2x) -> DFG (~2-3x) -> FTL (~1.1x). Each tier costs 4-6x the compile time of the one below.
+- **V8's Maglev (2023)** was added specifically to fill the gap between Sparkplug (no IR) and Turbofan (deeply optimizing): "good enough code, fast enough". The lesson: even a team Google's size needed an *intermediate* tier; jumping straight from a baseline to a peak optimizer leaves too much performance on the table during warmup.
+
+For Mochi, the case for a tier 2 is:
+
+- The MEP-30 baseline JIT will land at ~2-4x over the interpreter. The remaining gap to LuaJIT and to Go-native is ~3x and is dominated by boxing and call overhead, both of which are tier-2 problems.
+- The IC infrastructure from MEP-27 already collects the type feedback a tier 2 needs. Building a tier 2 without that feedback (i.e. without first doing MEP-27) would not work; building one **with** that feedback is mostly a matter of consuming what is already there.
+- A tier 2 also unlocks ergonomic features: inlining means Mochi-language abstractions (small helper functions, getters) become free at runtime, which raises the ceiling on idiomatic Mochi performance.
+
+The case against:
+
+- Tier 2 is **substantially more engineering than tiers 0 (interpreter) and 1 (baseline) combined**. JSC's DFG is several KLOC; Maglev shipped as a multi-engineer multi-year project even at Google.
+- Speculative deopt is the most subtle correctness hazard in any optimizing JIT.
+
+This MEP exists to specify the tier-2 design precisely enough that the team can decide, after MEP-30 is shipped and measured, whether to fund the tier-2 work. **It is the natural Phase 2** for the JIT effort.
+
+## Specification
+
+### Tier topology
+
+```
+                       +-----------------+
+                       |   Interpreter   | (tier 0, today)
+                       +-------+---------+
+                               |
+                  call hot / back-edge hot
+                               v
+                       +-----------------+
+                       | Tier 1 baseline | (MEP-30, copy-and-patch)
+                       +-------+---------+
+                               |
+                  same function called >= TieringThreshold,
+                  IC slot has been monomorphic for >= ICStableCount
+                               v
+                       +-----------------+
+                       | Tier 2 optimizing| (this MEP)
+                       +-----------------+
+```
+
+Frames transition both ways: a tier-2 deopt sends the frame back to tier 1 (or the interpreter if tier 1 is not present for that function); an OSR back-edge in tier 1 sends the frame forward to tier 2. The interpreter remains the source of truth for semantics; tiers 1 and 2 are observably-equivalent optimizations.
+
+### Tier 1: by reference
+
+Tier 1 is **MEP-30 verbatim**. This MEP introduces no changes to tier 1; it consumes its frame layout, code cache, and trampoline ABI.
+
+### Tier 2: optimizing method JIT
+
+Tier 2 takes a function's vm2 bytecode plus its IC slot table as input and emits native code. The pipeline:
+
+1. **IR construction**: walk bytecode, build typed SSA. Type each SSA value from the local IC slot, narrowing where possible.
+2. **Inlining**: replace `OpCall` with the callee's IR when the callee is small enough and the IC at that site is monomorphic. Recursive; bounded by `MaxInlineDepth` and `MaxInlineSize`.
+3. **Type propagation**: forward dataflow over the inlined IR; collapse `Box(Unbox(x))` and `Unbox(Box(x))` pairs revealed by inlining.
+4. **Guard insertion**: for every speculation (monomorphic shape, monomorphic callee, non-overflowing int op), insert an explicit `Guard` node. Failure semantics are specified below.
+5. **Escape analysis**: standard reachability analysis on SSA. Any allocation not stored to a heap location nor returned is scalar-replaced.
+6. **Loop-invariant code motion**: standard.
+7. **Common subexpression elimination + constant folding**: standard.
+8. **Linear-scan register allocator**: a small linear-scan pass over the SSA values. Live ranges are computed per basic block.
+9. **Backend**: emit native code via `golang-asm`, sharing the executable code cache with tier 1.
+
+### Tier 2 IR
+
+The IR is conventional typed SSA, modeled on Cranelift's CLIF and JSC's DFG IR:
+
+```
+%0:i64 = LoadReg %frame, #r0
+%1:listptr = LoadObject %vm, %0
+        Guard %1, ShapeIs(ListI64)
+%2:i64 = LoadReg %frame, #r1
+%3:i64 = ListGetI64 %1, %2
+        Guard %3, NoOverflow                 ; meaningless for get; example for AddI64
+StoreReg %frame, #r2, %3
+```
+
+Types are restricted to a small set: `i64`, `f64`, `bool`, `listptr<ListI64|Generic>`, `strptr<Inline|Flat|Rope>`, `setptr`, `mapptr`, `structptr<shape-id>`, and the catch-all `Cell`. Promotion from `Cell` to a narrower type costs an unbox plus a tag guard.
+
+### Speculation and deopt
+
+A `Guard` node carries the speculation kind, the SSA value being checked, and a **deopt descriptor**: the bytecode PC to resume at and the live-variable map at that PC. On guard failure the tier-2 code jumps to a per-guard stub that:
+
+1. Walks the deopt descriptor and writes each tier-2 SSA value back into the frame's register file as the interpreter expects it.
+2. Sets `frame.PC` to the resume PC.
+3. Jumps to tier 1 if present, else to the interpreter.
+
+Deopt is the **single largest correctness hazard** in this MEP. The protocol is constrained as follows to bound the hazard:
+
+- Deopt descriptors are computed at IR-build time, before any optimization. Optimizations may rewrite IR but must preserve the descriptor's reachability and the mapping from PC to live-variable set.
+- Inlining replicates the deopt descriptors of the inlined callee, adjusted for the new call chain. The descriptor records the full inlined call stack so the interpreter can resume with the right frame stack.
+- A failed deopt (interpreter and tier 2 disagree on observable behavior after the deopt) is a process-fatal bug. There is no soft recovery. The fuzzers in `runtime/vm2/jit/conformance/` exist to find every such bug pre-merge.
+
+The same protocol Google adopted for Maglev. The cost is high; the alternative (non-speculative tier 2) is a worthless tier 2.
+
+### Tiering policy
+
+Tier transitions are governed by simple counters and thresholds, the same shape every production engine uses:
+
+| Counter / Trigger           | Threshold | Default | Tunable via                |
+|-----------------------------|-----------|---------|----------------------------|
+| Function call count -> tier 1 | `JITThreshold`       | 1000    | `MOCHI_JIT_THRESHOLD`     |
+| Function call count -> tier 2 | `OptThreshold`       | 10000   | `MOCHI_OPT_THRESHOLD`     |
+| Back-edge OSR -> tier 1       | `BackEdgeThreshold`  | 10000   | `MOCHI_BACKEDGE_THRESHOLD`|
+| IC stability -> permits tier 2 | `ICStableCount`     | 100     | `MOCHI_IC_STABLE`         |
+| Deopts before disabling tier 2 | `MaxDeoptsPerFn`    | 10      | `MOCHI_MAX_DEOPTS`        |
+
+A function that deopts more than `MaxDeoptsPerFn` times has its tier-2 code discarded and is **denylisted from tier 2** for the process lifetime; subsequent calls run in tier 1. This mirrors V8's "never-optimize" flag and bounds the cost of pathological speculation cycles.
+
+### Compilation off the main goroutine
+
+Tier-2 compilation is performed on a dedicated background goroutine pool (`runtime.NumCPU() / 4`, minimum 1). The triggering call runs in tier 1 while compilation proceeds; the tier-2 code is installed atomically when ready, and subsequent calls pick it up via the `JITCode` pointer.
+
+This is the V8 / HotSpot / JSC pattern. Synchronous tier-2 compilation is not specified because tier-2 compile times in published engines range from milliseconds to hundreds of milliseconds per function and would block whatever goroutine triggered them. Mochi cannot afford that.
+
+### Code-cache management
+
+Tier 2 shares the executable code-cache pool with tier 1, but with two added rules:
+
+- **Per-function size cap**: a single tier-2 compilation may not exceed 64 KiB. Functions whose IR exceeds this are denylisted from tier 2 (very rare in practice; bounds the cache fragmentation risk).
+- **Eviction policy**: when the code cache exceeds `MaxCacheSize` (default 64 MiB), the least-recently-executed tier-2 code is evicted and the corresponding function falls back to tier 1. Tier-1 code is never evicted (it is cheaper to keep than to recompile).
+
+### Interaction with MEP-27 inline caches
+
+Tier 2 reads the IC slots both at compile time (as type predictions) and consumes IC stability counts as a tiering signal (a function whose ICs are still churning is a bad tier-2 candidate). Tier 2 does **not** emit ICs of its own; speculation is baked in as guards.
+
+A change to an IC slot from monomorphic to polymorphic at runtime can invalidate tier-2 code. Two recovery options:
+
+- **Active invalidation**: walk the JIT'd function list, mark any function whose IR depended on the changed IC as `Stale`, force-deopt all running frames of that function on the next safepoint. Correct, expensive.
+- **Passive invalidation (v1)**: do nothing; rely on the per-frame guard to fail naturally when the polymorphic case is hit. Simpler, slightly less optimal (some tier-2 frames keep running with stale assumptions until they hit the changed code path).
+
+v1 ships passive invalidation. v2 may add active invalidation if measurements warrant.
+
+## Cost model
+
+Per-call steady-state cost on a typical Mochi function (10-20 vm2 ops, one IC, one call), Apple M4:
+
+| Path                                                  | Cycles per call |
+|-------------------------------------------------------|-----------------|
+| vm2 interpreter (post-MEP-19)                         | ~250            |
+| Tier 1 baseline JIT (MEP-30)                          | ~80             |
+| **Tier 2 optimizing JIT (this MEP)**                  | **~30**         |
+| Theoretical floor (Go inline)                         | ~15             |
+
+Tier 2's win over tier 1 is dominated by inlining and unboxing, not by the optimizer. A function with no inlining opportunities sees only a ~1.3x tier-2 win; a function with substantial inlining can see ~3x.
+
+## Engineering scope
+
+Beyond the MEP-30 baseline tier:
+
+| Component                                  | Lines of Go | Engineer-weeks |
+|--------------------------------------------|-------------|----------------|
+| Typed SSA IR + builder                     | 2500        | 8              |
+| Type propagation + constant folding        | 1200        | 5              |
+| Inliner                                    | 1500        | 6              |
+| Escape analysis + scalar replacement       | 1800        | 8              |
+| LICM + CSE + DCE                           | 1500        | 5              |
+| Linear-scan register allocator             | 1200        | 6              |
+| `golang-asm` backend (SSA lowering)        | 2000        | 8              |
+| Guard / deopt protocol + stubs             | 1500        | 8              |
+| Tiering policy + counters                  | 400         | 2              |
+| Background compilation pool                | 400         | 2              |
+| Code-cache eviction                        | 500         | 3              |
+| IC invalidation hooks                      | 300         | 2              |
+| Conformance + deopt fuzzers (mandatory)    | 3000        | 12             |
+| Tier-2-debug tooling                       | 1500        | 6              |
+| **Tier 2 total (incremental over MEP-30)** | **~19300**  | **~81 weeks**  |
+
+Combined with MEP-30, **roughly 1.5 engineer-years to prototype and another year to harden**. Consistent with the smaller end of published method-JIT timelines (Maglev took longer with a larger team).
+
+## JIT integration with the rest of vm2
+
+- **MEP-19 quickening**: tier-2 IR consumes quickened opcodes directly; no separate path.
+- **MEP-25 shapes**: shape transitions deopt tier-2 frames whose guards assumed the prior shape.
+- **MEP-27 inline caches**: read at compile time as type predictions; consulted at tiering time as stability signal.
+- **MEP-28 AOT specialization**: tier 2 subsumes MEP-28 for hot code (it specializes more aggressively); MEP-28 remains the right strategy for cold code.
+- **MEP-30 baseline JIT**: tier 1 of this MEP. Hard prerequisite.
+
+## Risks
+
+1. **Deopt correctness**. The single largest failure mode. Mitigation: extensive conformance fuzzing in CI (mandatory before merge); deopt path is the only path tier 2 takes on any guard failure, exercised by every test that touches polymorphic code.
+2. **Engineering scope**. ~1.5 engineer-years is a substantial commitment for the Mochi team. Mitigation: gate the tier-2 work explicitly on measured tier-1 ceiling (a future Informational MEP, analogous to MEP-29, comparing measured tier-1 numbers to the LuaJIT floor).
+3. **Inlining-driven code bloat**. The cache eviction policy bounds it, but pathological cases (deeply recursive inlining of a small leaf function across many call sites) can dominate cache usage. Mitigation: per-call-site inlining budget; per-function code cap.
+4. **Background compilation worker starvation under load**. With one compile pool and N application goroutines, hot functions may take seconds to install tier-2 code under high load. Mitigation: prioritize compile jobs by accumulated tier-1 execution time; expose pool size via env var.
+5. **Maglev's lesson on warmup**. Even with two tiers, V8's Maglev exists because Sparkplug -> Turbofan was too slow a transition. If tier-1 -> tier-2 in Mochi proves similarly slow, the design admits a third tier; until then, accept the trade.
+
+## Alternatives considered
+
+- **Single-tier method JIT (skip tier 1)**: rejected. Every production engine that tried this regressed on short-running programs and reverted to a tiered design.
+- **Single-tier optimizing JIT triggered from interpreter (no baseline)**: HotSpot tried this. Warmup is unacceptable. Rejected.
+- **Adopt a third-party JIT framework (LLVM ORC, Cranelift)**: viable for tier 2, breaks single-binary distribution. Worth a follow-on MEP as an optional `mochi-jit-llvm` build tag, not the default.
+- **Skip tier 2 entirely, do only MEP-30**: leaves ~2-3x on the table. Acceptable if the team chooses to invest the saved engineering elsewhere (e.g. on language features). The right answer depends on whether Mochi positions itself on the "fast scripting" vs "production-grade VM" axis. This MEP specifies the design; the decision to fund it is separate.
+
+## Comparison matrix
+
+| Dimension                       | Option A (MEP-30) | Option B (MEP-31) | Option C (this MEP) |
+|---------------------------------|-------------------|-------------------|---------------------|
+| Predicted speedup on `fill_sum` | 2-4x              | 5-15x             | 4-8x                |
+| Workload coverage               | Universal         | Loop-heavy        | Universal           |
+| Engineering scope (KLOC)        | ~2.2              | ~11               | ~25 (incl. MEP-30)  |
+| Engineer-months to prototype    | ~3                | ~12               | ~18                 |
+| Deopt complexity                | None              | Medium (local)    | High (cross-method) |
+| OSR complexity                  | None (free)       | N/A               | High                |
+| Single static binary preserved  | Yes               | Yes               | Yes                 |
+| Reuses MEP-27 IC infrastructure | Read-only         | Yes               | Yes (heavily)       |
+| Performance ceiling             | Modest            | High on loops     | High broadly        |
+| Lineage                         | Sparkplug, CPython 3.13 | LuaJIT, PyPy | HotSpot, JSC, V8    |
+
+## Predicted MEP-23 numbers
+
+On the MEP-23 cross-language `lists/fill_sum` bench, N=1024 on Apple M4, current vm2 ~3805 ns/op; predicted with the full tier-1 + tier-2 stack: **~800-1100 ns/op**, reaching parity with Go-native on this monomorphic loop. On `concat_loop` with rope-shape allocations, **~1500-2000 ns/op**, a 4-5x win over the current strings baseline. On `fib` (recursive, branchy), **~1.5-2x** speedup from tier-2 inlining of the recursive call, which neither MEP-30 nor MEP-31 can match.
+
+## Open questions
+
+- **Whether to share IR with `compiler2`**. The Mochi compiler2 work (MEP-17 area) introduced a typed SSA IR for compile-time optimizations. A unified IR across compile-time and tier 2 would reduce maintenance cost but raise coupling. Likely yes, with a small adapter; specified in a follow-on MEP.
+- **Speculative call inlining policy**. Inlining a monomorphic callee is uncontroversial; inlining the most-common-of-two polymorphic callee with a guard is the V8 Maglev choice and is worth measuring on Mochi's corpus before committing.
+- **Tier-2 compile latency target**. Maglev targets ~1 ms/function; Turbofan targets ~100 ms. Where Mochi tier-2 should land depends on the typical Mochi function size and how often programs cross the optimization threshold. Suggest 10 ms p99 as a draft target.
+- **Whether tier 2 should be off by default in 1.0**. Tier 1 should ship on by default once stable (per MEP-30). Tier 2's deopt-bug risk argues for a longer opt-in period. Decide post-measurement.
+
+## Related work
+
+- [Java HotSpot VM Performance Enhancements (Oracle, 2014)](https://docs.oracle.com/en/java/javase/14/vm/java-hotspot-virtual-machine-performance-enhancements.html)
+- [JavaScriptCore Deep Dive (WebKit Docs)](https://docs.webkit.org/Deep%20Dive/JSC/JavaScriptCore.html)
+- [Maglev: V8's Fastest Optimizing JIT (Verwaest, 2023)](https://v8.dev/blog/maglev)
+- [Sparkplug: a non-optimizing JavaScript compiler (Verwaest, 2021)](https://v8.dev/blog/sparkplug)
+- [Speculation in JavaScriptCore (Pizlo, 2020)](https://webkit.org/blog/10308/speculation-in-javascriptcore/)
+- [Introducing the WebKit FTL JIT (Pizlo, 2014)](https://webkit.org/blog/3362/introducing-the-webkit-ftl-jit/)
+- [Oracle Drops GraalVM JIT Compiler from JDK (InfoQ, 2024)](https://www.infoq.com/news/2024/12/oracle-jdk-graalvm-jit-compiler/)
+- [Cranelift Codegen Primer (Bouvier)](https://bouvier.cc/cranelift-codegen-primer/)
+- [MEP-25](/docs/mep/mep-0025), [MEP-27](/docs/mep/mep-0027), [MEP-28](/docs/mep/mep-0028), [MEP-29](/docs/mep/mep-0029): data model, IC infrastructure, AOT specialization, measured results.
+- [MEP-30](/docs/mep/mep-0030): the baseline tier this MEP builds on.
+- [MEP-31](/docs/mep/mep-0031): the tracing JIT alternative.

--- a/website/src/data/meps.json
+++ b/website/src/data/meps.json
@@ -238,5 +238,29 @@
     "type": "Informational",
     "description": "Head-to-head benchmark of the three dispatch strategies specified in MEP-26 (Migration), MEP-27 (Inline Cache) and MEP-28 (AOT codegen) on canonical workloads for two containers, lists (fill_sum) and strings (concat_loop). Sibling prototype packages under runtime/vm2/listopt/ and runtime/vm2/stropt/ implement each strategy in isolation. Lists, AOT wins narrowly, IC regresses substantially. Strings, all three rope-aware strategies trounce the today-shape baseline because the algorithmic O(N²) to O(N) win swamps the dispatch cost. The two containers point at opposite engineering choices, and the result inverts the design-stage MEP predictions in both cases.",
     "slug": "/docs/mep/mep-0029"
+  },
+  {
+    "number": 30,
+    "title": "VM2 JIT Option A - Template / Copy-and-Patch Baseline JIT",
+    "status": "Draft",
+    "type": "Standards Track",
+    "description": "First of three competing JIT strategy specs for vm2. Each opcode handler is pre-compiled once into a position-independent native snippet, stored as a byte slice keyed by (opcode, shape-tuple), then concatenated and patched into an mmap'd executable buffer at function load. No IR, no register allocator, no inliner. The result is a non-optimizing baseline JIT in the lineage of V8 Sparkplug, JSC's Baseline JIT, and CPython 3.13's copy-and-patch JIT. This MEP specifies the snippet harvesting pipeline, the patcher ABI, the interpreter-compatible frame layout that makes OSR trivial, the deopt-free guard model, the distribution story (single Go binary, no cgo), and predicts a 2-4x speedup over the vm2 interpreter on fill_sum-class workloads.",
+    "slug": "/docs/mep/mep-0030"
+  },
+  {
+    "number": 31,
+    "title": "VM2 JIT Option B - Tracing JIT over Typed Loops",
+    "status": "Draft",
+    "type": "Standards Track",
+    "description": "Second of three competing JIT strategy specs for vm2. The interpreter counts iterations of every back-edge; when a counter trips, the runtime begins recording a linear trace of typed Cell operations starting from that back-edge. The trace is closed when control returns to the same back-edge, optimized in straight-line form (constant folding, allocation removal, guard hoisting), and compiled to native via golang-asm. Subsequent iterations execute the compiled trace; any guard failure side-exits back to the interpreter. Lineage traces to LuaJIT (single-level, hand-coded) and PyPy (meta-tracing, RPython-generated). This MEP specifies the trace recorder, the trace-IR with explicit guards, the guard-keyed side-exit table, the trace tree shape, and predicts a 5-15x speedup on numeric loops at a 4-6x larger engineering scope than MEP-30.",
+    "slug": "/docs/mep/mep-0031"
+  },
+  {
+    "number": 32,
+    "title": "VM2 JIT Option C - Tiered Method JIT with Type Feedback",
+    "status": "Draft",
+    "type": "Standards Track",
+    "description": "Third of three competing JIT strategy specs for vm2. Two compilation tiers stacked on the interpreter: tier 1 is the MEP-30 copy-and-patch baseline JIT; tier 2 is a typed-SSA optimizing method JIT that consumes type feedback from MEP-27 inline caches, performs profile-guided inlining and escape analysis, and emits native code with linear-scan register allocation. Bidirectional on-stack replacement (OSR) moves frames between interpreter, tier 1, and tier 2 mid-execution; speculative tier-2 code deopts back to tier 1 on guard failure. Lineage traces to HotSpot C1/C2, JSC's four-tier strategy (LLInt, Baseline, DFG, FTL), and V8's Ignition / Sparkplug / Maglev / Turbofan pipeline. This MEP specifies tier transitions, the optimizing IR, the deopt protocol, the inlining heuristic, and predicts a 4-8x speedup with the broadest workload coverage of the three options.",
+    "slug": "/docs/mep/mep-0032"
   }
 ]


### PR DESCRIPTION
## Summary
- Three standards-track MEPs (30, 31, 32) covering the JIT design space for vm2, modeled on the MEP-26/27/28 trio for the data model.
- All three preserve Mochi's single-static-binary distribution by targeting `golang-asm` as the emission backend (no cgo, no external toolchain).
- A follow-on Informational MEP (MEP-29 style) will pick the winner from measured prototype numbers.

## The three options

| MEP | Strategy | Lineage | Scope | Predicted `fill_sum` speedup |
|---|---|---|---|---|
| 30 | Template / copy-and-patch baseline | Sparkplug, CPython 3.13 | ~2.2 KLOC, ~3 eng-mo | 2-4x |
| 31 | Tracing JIT over typed loops | LuaJIT, PyPy | ~11 KLOC, ~12 eng-mo | 5-15x (numeric loops) |
| 32 | Tiered method JIT with type feedback | HotSpot, JSC, V8 | ~25 KLOC (incl. 30), ~18 eng-mo | 4-8x broadly |

Each MEP specifies frame ABI, dispatch flow, deopt protocol (where applicable), cost model, engineering scope breakdown, risks, alternatives, and predicted MEP-23 numbers. The same comparison matrix appears at the end of each so a reader entering at any point can pick.

## Editorial recommendation (in MEP-30's section, summarized)

MEP-30 is the right first move regardless of which long-term direction Mochi picks: every production engine started with a baseline tier of roughly this shape, the engineering risk is bounded (no deopt, no IR, no regalloc), and MEP-32 explicitly reuses MEP-30 as its tier 1. The choice between MEP-31 and MEP-32 as Phase 2 depends on workload mix; the corpus comparison should run on a measured MEP-30 prototype first.

Closes #21537.

## Test plan
- [x] Website prebuild regenerates `meps.json` from frontmatter
- [x] `npm run build` succeeds, all 33 MEPs render
- [x] No em-dashes in titles or bodies
- [x] Internal cross-links (MEP-25/27/28/29/30/31/32) resolve