### PR TITLE
mep-0034: spec full-opcode vm2 JIT for lists, strings, maps, sets, structs

### DIFF
--- a/website/docs/mep/mep-0034.md
+++ b/website/docs/mep/mep-0034.md
@@ -1,0 +1,401 @@
+---
+mep: 34
+title: VM2 Full-Opcode JIT - Lists, Strings, Maps, Sets, Structs
+author: Mochi core
+status: Draft
+type: Standards Track
+created: 2026-05-17
+sidebar_position: 34
+sidebar_label: MEP 34. Full vm2-opcode JIT
+description: "Production-track spec for the next JIT after the MEP-30 prototype. Extends MEP-30's template / copy-and-patch design from the 6-opcode tmpljit toy to the full vm2 opcode set, with first-class native support for the five container subsystems (lists, strings, maps, sets, structs). Specifies per-opcode codegen templates, the frame-compatibility contract that lets the JIT and the vm2 interpreter share a Cell-shaped register file across calls, the Cell NaN-boxing fast paths and slow-path runtime callbacks, the cross-architecture backend split (darwin/arm64 + linux/amd64 from day one), and the benchmark plan that gates merge: head-to-head against the vm2 interpreter, LuaJIT, Lua 5.5, and CPython 3.14 on the MEP-23 corpus and on each container's hot ops. Predicts 3-6x over vm2 on list / arithmetic loops, 1.5-3x on string and map workloads, and parity with LuaJIT on numeric loops by Phase 3."
+---
+
+# MEP 34. VM2 Full-Opcode JIT - Lists, Strings, Maps, Sets, Structs
+
+| Field    | Value                                                              |
+|----------|--------------------------------------------------------------------|
+| MEP      | 34                                                                 |
+| Title    | VM2 Full-Opcode JIT - Lists, Strings, Maps, Sets, Structs          |
+| Author   | Mochi core                                                         |
+| Status   | Draft                                                              |
+| Type     | Standards Track                                                    |
+| Created  | 2026-05-17                                                         |
+
+## Abstract
+
+This MEP specifies the **production JIT** for vm2: a template / copy-and-patch baseline JIT, in the lineage of V8 Sparkplug and CPython 3.13, that lowers **every** vm2 opcode (current count: 41, plus the planned set and struct families) to native AArch64 and AMD64 code. Where the MEP-30 prototype proved the dispatch architecture on a 6-opcode toy bytecode (see [MEP-33](/docs/mep/mep-0033)), this MEP scopes the work of carrying the same approach across the full Mochi container surface: `Cell` arithmetic, lists, strings, maps, sets, structs, calls, control flow.
+
+The JIT is **single-tier baseline** by design. Tier-2 optimization (MEP-32) is deferred until the baseline ships and the measured-result MEP for this work lands. Tracing (MEP-31) is deferred per [MEP-33 §Recommendations](/docs/mep/mep-0033#recommendations).
+
+The benchmark plan is the gate: merge is contingent on (1) JIT correctness across the existing `runtime/vm2/...` test corpus, (2) measurable speedup over the vm2 interpreter on every [MEP-23](/docs/mep/mep-0023) workload, with no per-workload regression, and (3) head-to-head numbers against LuaJIT 2.1, Lua 5.5, and CPython 3.14 on the same corpus.
+
+## Motivation
+
+The [MEP-33](/docs/mep/mep-0033) prototype demonstrated that on a 6-opcode arithmetic bytecode, a template JIT delivers 17x over the matching switch interpreter, matches LuaJIT, and rivals hand-written Go. The result is encouraging but narrow:
+
+- The toy bytecode has no boxing, no allocation, no shape dispatch. Every real Mochi workload has all three.
+- The MEP-23 corpus is dominated by list, string, map, and set workloads. A JIT that does not handle those is not a JIT for Mochi.
+- vm2's `Cell` is NaN-boxed (LuaJIT/JSC style, see `runtime/vm2/cell.go:24-49`). Fast paths must inline the tag-check pattern; slow paths must call back into Go for `Objects` table operations.
+
+The spec exists to bound the work between "MEP-30 prototype validated" and "JIT shipped". Without it, the implementation drifts toward unbounded ambition (tier-2 optimizations, deopt protocols, tracing) before the baseline tier exists. With it, the path is **mechanical**: enumerate opcodes, write templates, integrate with the interpreter's frame format, measure.
+
+## Scope
+
+In scope:
+
+- A baseline JIT (no IR, no register allocator beyond the existing vm2 register file) for every opcode currently in `runtime/vm2/ops.go` plus the planned set opcodes ([MEP-29 §Sets](/docs/mep/mep-0029)) and struct opcodes ([MEP-24 §5](/docs/mep/mep-0024)).
+- Two architectures from day one: darwin/arm64 (primary) and linux/amd64 (parity gate).
+- The frame-compatibility contract that lets the JIT and the interpreter share the same `Cell`-shaped register file, so a JIT'd function can call an interpreted one and vice versa without copy-conversion.
+- The per-Cell tag-check fast paths and the slow-path runtime callbacks for the four container subsystems.
+- The benchmark plan and the gates that govern merge.
+
+Out of scope (deferred to follow-on MEPs):
+
+- Tier-2 optimizing JIT ([MEP-32](/docs/mep/mep-0032), funded after this MEP ships).
+- Tracing JIT ([MEP-31](/docs/mep/mep-0031), funded only if Phase-2 numbers warrant).
+- Inline caches in the JIT itself: the interpreter's [MEP-19](/docs/mep/mep-0019) and [MEP-27](/docs/mep/mep-0027) ICs are read by the JIT as type hints, but the JIT does not learn or update IC state in v1.
+- Allocation-removal, escape analysis, profile-guided inlining: all tier-2 features.
+- Speculative deopt: there is no tier-2 to deopt to.
+- Garbage collection coordination beyond the [MEP-20](/docs/mep/mep-0020) frame layout already preserved by the interpreter.
+
+## Background: vm2 opcode surface
+
+From `runtime/vm2/ops.go` and the planned MEP-24/MEP-29 additions, the JIT must cover roughly **60 opcodes** across nine categories. Counts below are current + planned in parentheses.
+
+| Category               | Opcodes (current + planned) | Canonical examples |
+|------------------------|-----------------------------|--------------------|
+| Misc / control         | 2                           | `OpHalt`, `OpMove` |
+| Arithmetic (I64)       | 8                           | `OpAddI64`, `OpAddI64K`, `OpSubI64`, `OpMulI64`, `OpDivI64`, `OpModI64`, `OpLessI64`, `OpEqualI64` |
+| Control flow           | 8                           | `OpJump`, `OpJumpIfFalse`, `OpJumpIfLessI64`, `OpJumpIfLessEqI64`, `OpJumpIfGreaterI64`, `OpJumpIfGreaterEqI64`, `OpJumpIfEqualI64`, `OpJumpIfNotEqualI64` |
+| Closure / call         | 4                           | `OpCall`, `OpTailCall`, `OpTailCallSelf`, `OpReturn` |
+| Constants              | 1                           | `OpLoadConstI` |
+| String                 | 6                           | `OpLoadStrK`, `OpConcatStr`, `OpLenStr`, `OpIndexStr`, `OpEqualStr`, `OpHashStr` |
+| List                   | 5                           | `OpNewList`, `OpListLen`, `OpListGet`, `OpListSet`, `OpListPush` |
+| Map                    | 6                           | `OpNewMap`, `OpMapLen`, `OpMapGet`, `OpMapHas`, `OpMapSet`, `OpMapDel` |
+| Set (planned, MEP-29)  | 0 (+6)                      | `OpNewSet`, `OpSetAdd`, `OpSetHas`, `OpSetDel`, `OpSetLen`, `OpSetIter` |
+| Struct (planned, MEP-24) | 0 (+6)                    | `OpNewStruct`, `OpStructGet`, `OpStructSet`, `OpStructTagCheck`, `OpStructLen`, `OpStructEqual` |
+| **Total**              | **40 + ~12 = ~52**          | |
+
+A few notes on the inventory:
+
+- The string opcodes already include both small-string-inline (the `tagSStr` work, [MEP-19 PR4](/docs/mep/mep-0019)) and pointer-tagged paths. The JIT must support both branches in a single fused fast-path. See §[String opcodes](#string-opcodes).
+- Map opcodes are currently shape-monomorphic; the [MEP-29 §Maps](/docs/mep/mep-0029) measured-results MEP recommends keeping them so. The JIT inherits the shape.
+- Set and struct opcodes are still pre-spec. The JIT lands their templates **after** the interpreter ships them; this MEP commits to the templates being a strict mechanical extension of the map and list templates respectively.
+
+## Specification
+
+### Architecture overview
+
+```
++----------------------+    JIT compile     +-------------------+
+|   vm2 bytecode for   | -----------------> | Native code page  |
+|   a Function         |   (per-function)   | (mmap'd MAP_JIT)  |
++----------------------+                    +---------+---------+
+        ^                                             |
+        |    interpret unchanged                      | call via
+        |                                             | runtime trampoline
++-------+--------------+                              v
+|  runtime/vm2/eval    |    <--- jit returns into     |
+|  switch dispatch     |        frame.RetReg          |
+|  (fallback, calls)   |                              |
++----------------------+                              |
+        ^                                             |
+        +---------------------------------------------+
+                slow-path callbacks (NewList, MapGet,
+                CallVariadic, GC barrier, etc.)
+```
+
+- **Compile unit**: one vm2 `Function` at a time. The JIT walks the function's bytecode and emits one native instruction sequence per opcode, plus a function prologue (load frame pointer, materialise constant pool base) and one epilogue per `OpReturn`.
+- **Per-call dispatch**: the runtime keeps both an interpreter pointer (`func(*VM)`) and an optional compiled-code pointer on each `Function`. A `Call` opcode that lands on a function with a non-nil compiled-code pointer enters the JIT; otherwise it enters the interpreter. Cross-tier calls are free: both sides see the same `*Frame` layout.
+- **Slow-path callouts**: opcodes that touch the GC or the `Objects` heap (any `New*`, any string concat, any `Push`/`Set` that may reallocate, any `Call` to an interpreted-only function) compile to a tail-call to a thin Go shim, not to inline assembly. The shim's signature is fixed (`func(vm *VM, args ...Cell) Cell`) so a single trampoline shape covers every callout.
+- **No cgo at runtime**: every JIT'd page is entered via a pure-Go trampoline written in `.s`. The MEP-30 prototype's cgo wrapper is replaced before any benchmark in this MEP is published; cgo is forbidden on the JIT hot path.
+
+### Frame compatibility
+
+The single largest correctness obligation. The contract:
+
+1. **Register file layout is identical between interpreter and JIT**. `Frame.RegsBase` points at the start of `NumRegs` `Cell`-sized slots in the shared `Stack`. The JIT compiles to native code that addresses `[frame_ptr + RegsBase*8 + reg*8]` for every register read, and writes back to the same slot on every register write. There is no shadow register file.
+2. **Frame metadata fields are read-only to the JIT** except for `Frame.IP` and `Frame.RetReg`. The JIT increments `Frame.IP` only at safepoints (back-edges, calls, allocations); within a straight-line opcode sequence the IP is undefined.
+3. **Safepoints are deterministic**. The JIT inserts a one-instruction goroutine-preemption check at every back-edge and at every slow-path callout. The check polls `runtime.gcWaitOnPreempt` analog (the precise primitive is TBD; see Open Questions).
+4. **`Cell` reads are tag-aware**. The JIT does not assume `regs[i]` is a particular type unless the bytecode came from an MEP-19-quickened typed opcode (`OpAddI64` etc). For untyped opcodes the JIT emits the tag-check fast path inline.
+
+The contract means a JIT'd function can `OpCall` an interpreted callee, the interpreter can `OpCall` a JIT'd callee, and `runtime.Stack(t)` panics traverse both stacks indistinguishably.
+
+### Cell fast paths
+
+Every typed opcode (`OpAddI64`, `OpListGet`, `OpMapGet`, ...) decomposes into:
+
+```
+tag-check (1-2 instructions, branch on mismatch to slow path)
+type-specific work (1-4 instructions)
+write back to register (1 instruction)
+```
+
+The tag-check exploits the NaN-boxing layout in `runtime/vm2/cell.go`. For int48, the check is a single `ubfx` (AArch64) or `shr+cmp` (AMD64) against `0xFFFC`; the int48 payload is then extracted by sign-extending the bottom 48 bits. For pointer tags (`0xFFFF`), the payload is the `Objects` table index, and the slot fetch is a base+scaled-index load.
+
+The MEP-30 prototype demonstrated that an int-only loop body lowers to ~7 native instructions per iteration (post-MEP-32 peephole), with no tag check. The full vm2 JIT pays a per-untyped-op tag check, expected at ~2 extra instructions and one well-predicted branch per op. MEP-19's quickening removes the tag check for fully-typed code paths; this is why MEP-19 is on the critical path for the JIT to shine.
+
+### List opcodes
+
+| Opcode       | Fast path (lengths in native instructions)                      | Slow path                                   |
+|--------------|-----------------------------------------------------------------|---------------------------------------------|
+| `OpNewList`  | 0 instructions, always slow path                                | `runtime.jit.NewListSlow` (allocator + GC)  |
+| `OpListLen`  | ~6 (tag-check ptr, load `*vmList`, load `Len`)                  | -                                            |
+| `OpListGet`  | ~10 (tag-check, deref, bounds-check, indexed load)              | bounds-check failure → interp resume        |
+| `OpListSet`  | ~8 if list is fully-owned (post-MEP-26 single-writer);          | shared list / cap-exceeded → `ListSetSlow` |
+|              | ~5 if also bounds-known (tier-2 hoist; v1: always check)        |                                              |
+| `OpListPush` | always slow path                                                 | `runtime.jit.ListPushSlow`                  |
+
+The bounds-check failure path is a deopt-style exit to the interpreter: the JIT writes the live register state back through the existing frame slots (which it has been doing all along) and sets `frame.IP` to the failing opcode's index; the interpreter raises the same out-of-bounds error the all-interp path would have raised. No new error machinery.
+
+The MEP-23 `lists/fill_sum` workload (build a list of N ints, sum it) becomes:
+
+```
+init  : OpNewList -> slow path (one allocation up-front), capacity-hinted
+loop  : OpListPush, OpAddI64, OpJumpIfLessI64 back-edge
+sum   : OpListGet (fast path), OpAddI64, OpJumpIfLessI64
+```
+
+The push loop's cost is dominated by the allocator (~30 ns/push for the current `vmList` shape, see MEP-24). The JIT cannot beat this without escape analysis; it can shave the dispatch overhead (~5 ns/iter on the interpreter) so the net cost approaches the allocator's. Predicted speedup on `lists/fill_sum` at N=1024: **1.5-2.5x** over vm2.
+
+### String opcodes
+
+The string subsystem has two physical representations:
+
+1. **Inline small string (`tagSStr`)**: up to 5 bytes packed into the Cell itself. No heap object. Implemented in MEP-19 PR4.
+2. **Heap string**: pointer tag, `*vmString` in the `Objects` table.
+
+Every string opcode must handle both. The JIT emits one fused fast path that:
+
+```
+load Cell into a temp register
+shift to extract tag
+cbz inline-string-path   ; if tagSStr, the Cell itself is the data
+branch to heap-string-path otherwise
+```
+
+| Opcode          | Inline fast (instrs) | Heap fast (instrs) | Slow path |
+|-----------------|----------------------|--------------------|-----------|
+| `OpLoadStrK`    | 1-2 (constant Cell)  | 1-2                | -         |
+| `OpConcatStr`   | always slow          | always slow        | `ConcatStrSlow` allocates; emits `tagSStr` if total ≤5 bytes |
+| `OpLenStr`      | ~3 (shift + popcount of payload)  | ~6 (deref `Len`) | - |
+| `OpIndexStr`    | ~6 (byte extract from payload)    | ~10              | - |
+| `OpEqualStr`    | ~4 (Cell == Cell when both inline) | ~12 (memcmp via runtime) | -  |
+| `OpHashStr`     | ~8 (xxhash-inline-fast)            | always slow      | `HashStrSlow` |
+
+`OpEqualStr` is the most interesting because the two-Cell `==` is correct whenever **both** strings are inline OR **both** are heap-allocated and interned. The vm2 interner ([MEP-19 PR2](/docs/mep/mep-0019)) guarantees the latter for string constants and short hot strings; the JIT exploits this to avoid the slow path on most workloads. Predicted: **2-3x** on `strings/concat_loop`, **3-4x** on `strings/equal_loop`.
+
+### Map opcodes
+
+Maps are open-addressed shape-monomorphic ([MEP-29 §Maps](/docs/mep/mep-0029)). Two key types in v1: `int48` and `interned-string`. The JIT emits one fast path per key type:
+
+| Opcode      | Int48 key fast path (instrs)       | String key fast path (instrs) | Slow path |
+|-------------|------------------------------------|-------------------------------|-----------|
+| `OpNewMap`  | slow                               | slow                          | `NewMapSlow` |
+| `OpMapLen`  | ~6 (deref `*vmMap`, load `Len`)    | same                          | - |
+| `OpMapGet`  | ~12 (hash, probe loop with 1 unroll) | ~14 (hash via interner table)| collision overflow → `MapGetSlow` |
+| `OpMapHas`  | ~10                                | ~12                           | same as Get |
+| `OpMapSet`  | ~14 (probe + write)                | ~16                           | grow/realloc → `MapSetSlow` |
+| `OpMapDel`  | always slow (tombstones, rehash)   | same                          | `MapDelSlow` |
+
+The probe loop is unrolled exactly once. The interpreter walks the probe loop in a fast Go loop ([MEP-29 measurement: 5-9 ns/op](/docs/mep/mep-0029)); the JIT's unroll-once advantage is small (~1.5x) for hot lookups and zero for misses. Predicted: **1.5-2x** on `maps/fill_probe`.
+
+### Set opcodes
+
+Sets reuse the map's open-addressing infrastructure ([MEP-29 §Sets](/docs/mep/mep-0029)). The JIT templates are identical to map templates with the value-slot writes elided. The set spec lands first (interpreter); this MEP commits the JIT templates as a mechanical derivation.
+
+Predicted: **same as maps**, 1.5-2x.
+
+### Struct opcodes
+
+Structs are flat tuples of `Cell`s with a shape tag ([MEP-24 §5](/docs/mep/mep-0024)). The shape tag is a `uint32` cached on the struct header. Field access is `tag-check ptr; deref; load [base + 8*idx]`. The JIT emits a per-field fast path; the slow path is the interpreter, which itself almost never falls through to anything slower since structs don't grow.
+
+| Opcode             | Fast path (instrs) | Slow path                  |
+|--------------------|--------------------|----------------------------|
+| `OpNewStruct`      | always slow        | `NewStructSlow` (allocator) |
+| `OpStructGet`      | ~7                 | -                           |
+| `OpStructSet`      | ~6 if no GC barrier, ~10 with | shared-heap-write → `StructSetSlow` |
+| `OpStructTagCheck` | ~4                 | -                           |
+| `OpStructLen`      | constant from shape, ~2 instrs | - |
+| `OpStructEqual`    | ~12 (shape-check + memcmp for small structs, ≤32 bytes) | larger / nested → `StructEqualSlow` |
+
+Predicted: **2-3x** on `structs/fill_field` (analog of `lists/fill_sum` for structs); **1.5-2x** on `structs/equal_loop`.
+
+### Calls and returns
+
+The JIT handles the four call opcodes uniformly:
+
+- **`OpCall`**: marshal the argument cells (already in the right slots, see frame-compat), bump `IP`, push a `Frame` onto `vm.Frames`, either jump to the callee's compiled code or fall back to the interpreter trampoline.
+- **`OpTailCall`**: same but reuse the current frame's `Stack` slot; no push.
+- **`OpTailCallSelf`**: branch within the current compiled function. Cheapest call shape; ~3 instructions.
+- **`OpReturn`**: write `regs[A]` to the caller frame's `RetReg`, pop the frame, branch to the caller's resume PC. If the caller is JIT'd, this is an indirect branch; if interpreted, a return to the interpreter trampoline.
+
+The frame push/pop is the single most expensive non-allocation opcode in the JIT (predicted ~20 instructions). Tier-2's planned wins (inlining, frame fusion) are deferred per scope.
+
+### Arithmetic and control flow
+
+These are the MEP-30 prototype's home territory. Templates are short (1-4 instructions each) and the only new wrinkle is the comparison-and-branch fusion: `OpJumpIfLessI64` is a single `cmp; b.lt` on AArch64 and `cmp; jl` on AMD64. The MEP-30 prototype emitted `cmp; csinc; cbnz` (three instructions) because it had no fused branch opcode; vm2 already has the fused opcodes, so the JIT is strictly simpler here than the prototype was.
+
+### Backend split: AArch64 + AMD64
+
+Two backends, written in parallel, sharing one mid-level opcode-to-template table that takes an `(arch, opcode) -> template` shape:
+
+```
+runtime/jit/vm2jit/
+  arch/
+    arm64/      asm encoders, per-opcode lowerings, syscalls
+    amd64/      same, with Linux-flavored mmap and W^X
+  templates/    arch-agnostic per-vm2-opcode lowerings (one file per category)
+  runtime/      slow-path Go shims (NewListSlow, MapGetSlow, ...)
+  trampoline/   pure-Go `.s` trampolines for cross-tier calls
+  compile.go    the per-Function compiler driver
+  cache.go      the executable code cache (shared mmap pool)
+```
+
+The AArch64 backend reuses the MEP-30 encoders ([`runtime/jit/tmpljit/emit_arm64.go`](https://github.com/mochilang/mochi/blob/main/runtime/jit/tmpljit/emit_arm64.go)). The AMD64 backend writes its own encoders; the encoding table for the opcode subset the JIT needs is ~40 entries, ~200 lines of Go.
+
+### Trampoline (cgo replacement)
+
+The MEP-30 prototype calls JIT'd code via cgo. **The production JIT must not.** The MEP-30 spec ([§6.2](/docs/mep/mep-0030#)) specifies a pure-Go `.s` trampoline. This MEP commits the trampoline as a hard merge gate: no benchmark in §[Benchmark plan](#benchmark-plan) is published with cgo. The trampoline shape is the standard "call assembly with a fixed-prototype function pointer" pattern; see Go's own `runtime/asm_arm64.s` for the precedent.
+
+### Engineering phases
+
+Three sequential phases. Each phase has its own merged-MEP measured-results follow-on (analogous to MEP-33 for MEP-30).
+
+**Phase 1: arithmetic + lists + calls** (estimated 4-6 engineer-weeks)
+
+- Scaffold `runtime/jit/vm2jit/`, both arches.
+- All arithmetic / comparison / control-flow / call / return opcodes.
+- List opcodes plus the `NewListSlow` and `ListPushSlow` shims.
+- Pure-Go trampoline on both arches.
+- Benchmark gate: `lists/fill_sum`, `lists/sum`, `arith/fib_iter` vs interpreter. ≥1.5x on each, no regression.
+
+**Phase 2: strings + maps** (estimated 3-5 engineer-weeks)
+
+- String opcodes with inline + heap fused fast paths.
+- Map opcodes with int48 + interned-string key fast paths.
+- Benchmark gate: `strings/concat_loop`, `strings/equal_loop`, `maps/fill_probe`, `maps/keys` vs interpreter, LuaJIT, Lua 5.5, CPython 3.14.
+
+**Phase 3: sets + structs** (estimated 2-3 engineer-weeks)
+
+- Set opcodes (mechanical derivation from maps).
+- Struct opcodes once `runtime/vm2/struct*.go` exists ([MEP-24 §5](/docs/mep/mep-0024) gates this).
+- Benchmark gate: full MEP-23 corpus head-to-head.
+
+**Total**: ~10-14 engineer-weeks, ~5 KLOC of Go, plus the assembly trampolines. Substantially less than MEP-32 (~25 KLOC) because no IR, no register allocator, no deopt protocol.
+
+## Benchmark plan
+
+Three benchmark groups, all run on the same hardware in the same session, all reported with five-sample medians and benchstat-style variance:
+
+### Group A: vm2 interpreter head-to-head
+
+For every MEP-23 workload, three numbers:
+
+1. vm2 interpreter (current main).
+2. vm2 + this JIT.
+3. The ratio.
+
+**Merge gate**: ratio < 1.0 on every workload, with at least 1.5x on the loop-dominated subset (`fill_sum`, `concat_loop`, `fill_probe`, `fib_iter`).
+
+### Group B: cross-language
+
+For each Group A workload that has a published port:
+
+| Language       | Implementation                              |
+|----------------|---------------------------------------------|
+| Mochi          | vm2 interpreter + this JIT                  |
+| Lua            | Stock Lua 5.5 (loadable binary on macOS)    |
+| LuaJIT         | LuaJIT 2.1 (master)                         |
+| Python         | CPython 3.14 (default tier-2 interpreter)   |
+| Go (reference) | Hand-translated, for the theoretical floor  |
+
+**Reportable**: the ratio table, the workload-level analysis, the threats-to-validity section. Not gated on any specific ratio; ship the numbers.
+
+### Group C: per-opcode microbenchmarks
+
+For every category in §[Background](#background-vm2-opcode-surface), one microbench per opcode hot path. Reports ns/op for:
+
+1. The interpreter handler.
+2. The JIT'd fast path.
+3. The JIT'd slow path.
+
+**Used internally only**, not in the public results MEP. The role is to flag regressions during development (the per-opcode fast path should not regress between phases) and to give the tier-2 MEP its baseline numbers.
+
+### Reporting MEP
+
+The numbers land in a new Informational MEP, analogous to [MEP-33](/docs/mep/mep-0033). Provisional number: **MEP-35. Full vm2-opcode JIT - Measured Results**. The MEP-35 draft is written alongside Phase 3 and merged simultaneously with the JIT flip-default change in vm2.
+
+## Risks
+
+1. **Slow-path callout overhead dominates on allocation-heavy workloads**. The JIT cannot beat the allocator. Mitigation: explicit per-workload prediction in the spec ([List opcodes](#list-opcodes), [String opcodes](#string-opcodes)) so the merge gate's "no regression" rule has room. Allocation-heavy paths should land at parity with the interpreter, not at speedup.
+2. **W^X policy differences between darwin and linux**. macOS arm64 requires `pthread_jit_write_protect_np`; linux/amd64 wants `PROT_READ|PROT_WRITE` flips around the page write. The MEP-30 prototype handles macOS; the production JIT must abstract this into `runtime/jit/vm2jit/arch/{arm64,amd64}/page.go`.
+3. **Frame-format drift between interpreter and JIT**. The contract in §[Frame compatibility](#frame-compatibility) is the most subtle correctness hazard. Mitigation: a single Go struct (`type Frame struct { ... }`) shared between both sides; any field reorder must update both lowerings or fail a compile-time assertion.
+4. **MEP-19 quickening coverage drives JIT win size**. The JIT's tag-check fast path is good but pays 2 instructions per untyped op. Workloads that the quickening pass misses look slower than expected. Mitigation: instrument the JIT to report per-call quickening coverage in the MEP-35 results; if coverage is below 80% on the corpus, file follow-on MEP-19 work.
+5. **Goroutine preemption check granularity**. Too frequent costs the JIT its loop-tightness advantage; too rare risks scheduler stalls. Mitigation: emit one check per back-edge in v1, measure, tune in MEP-35.
+6. **Single-binary distribution**. The MEP-30 spec required this; this MEP inherits the constraint. The pure-Go `.s` trampoline is the only acceptable cross-tier call mechanism; cgo is forbidden after the prototypes.
+
+## Open questions
+
+- **Where does the `runtime.gcWaitOnPreempt`-analog primitive live?** Go's `morestack` check is not exposed. The team should propose either (a) a `runtime/internal/preempt` package for the JIT to call, or (b) inline the preempt check using the same atomic-load pattern Go's runtime uses. Either way, the merge gate is "no goroutine starvation under stress test".
+- **How does the JIT cache survive across `vm2.Function` reloads in a long-running process (e.g. a Mochi server)?** The simplest answer: per-Function compiled-code pointer, lifetime tied to the Function. The trickier answer: cross-Function code sharing for common templates. Defer the trickier answer.
+- **Should set opcodes land in vm2 before the JIT compiles them, or alongside?** The author's preference is "vm2 first, then JIT in Phase 3"; this keeps the JIT a strict translation rather than a co-design. Confirm with the MEP-29 owners.
+- **AMD64 register pressure**. AArch64 has 30 GPRs; AMD64 has 14 useable. The JIT's per-opcode templates compile cleanly on both, but a future tier-2 MEP-32 will need an actual register allocator for AMD64. Spec is fine; allocator is post-this-MEP.
+
+## Comparison with the three JIT options
+
+The three options ([MEP-30](/docs/mep/mep-0030), [MEP-31](/docs/mep/mep-0031), [MEP-32](/docs/mep/mep-0032)) are about **strategy**: template vs tracing vs tiered. This MEP is about **coverage**: how the chosen strategy (template, per MEP-30 + MEP-33) is carried across the full vm2 opcode surface.
+
+| Aspect                | This MEP (MEP-34)                                | MEP-30                       | MEP-31                       | MEP-32                       |
+|-----------------------|--------------------------------------------------|------------------------------|------------------------------|------------------------------|
+| Scope                 | full vm2 opcode set                              | 6-opcode toy                 | hot loops (recorded)         | full vm2 + tier-2 opt         |
+| Tier                  | tier 1 only                                      | tier 1 (prototype)           | tier 2 (orthogonal)          | tier 1 + tier 2              |
+| Coverage              | lists, strings, maps, sets, structs              | arith only                   | depends on workload          | this MEP + IR optimizations  |
+| Engineering           | 10-14 weeks                                      | done (afternoon)             | 12+ months                   | 18+ months                   |
+| Predicted speedup     | 1.5-3x broad; 3-6x on numeric loops              | 17x on toy bytecode          | 5-15x on loops, abort risk   | 4-8x broad                   |
+
+## Predicted MEP-23 numbers
+
+Calibrated against the [MEP-33](/docs/mep/mep-0033) prototype's measured 17x on `fillsum` and the per-category fast-path lengths above. All numbers are ns/op at N=1024 on Apple M4, vm2-with-this-JIT, predicted:
+
+| Workload                  | vm2 (now) | vm2 + JIT (predicted) | LuaJIT 2.1 | Predicted JIT/LuaJIT ratio |
+|---------------------------|-----------|----------------------|------------|----------------------------|
+| `arith/fib_iter`          | 3500      | 700                  | 600        | 1.17x                      |
+| `lists/fill_sum`          | 6000      | 2500                 | 1200       | 2.08x                      |
+| `lists/sum`               | 2200      | 600                  | 700        | 0.86x                      |
+| `strings/concat_loop`     | 8000      | 3200                 | 2500       | 1.28x                      |
+| `strings/equal_loop`      | 1800      | 500                  | 400        | 1.25x                      |
+| `maps/fill_probe`         | 11000     | 5500                 | 4000       | 1.38x                      |
+| `maps/keys`               | 3500      | 2000                 | 1800       | 1.11x                      |
+| `sets/fill_probe`         | 11500     | 5800                 | -          | -                          |
+| `structs/fill_field`      | 2400      | 800                  | -          | -                          |
+| `structs/equal_loop`      | 1300      | 600                  | -          | -                          |
+
+The honest read: **JIT closes the gap to LuaJIT to ~1.2-1.4x on most workloads, beats it on the pure-int subset, lags on string concat (LuaJIT's rope allocator is more mature)**. The CPython 3.14 ratios will be in the 8-25x range across the board, consistent with [MEP-33](/docs/mep/mep-0033).
+
+If Phase 3 numbers fall short of these by more than 30%, the failure modes and remediations should be the explicit subject of the MEP-35 reporting and may motivate funding MEP-32 sooner than planned.
+
+## Related work
+
+- [MEP-23](/docs/mep/mep-0023), the cross-language benchmark methodology this MEP's gates use.
+- [MEP-24](/docs/mep/mep-0024), the vm2 subsystem spec defining the list/string/map/set/struct shapes the JIT must handle.
+- [MEP-19](/docs/mep/mep-0019), [MEP-27](/docs/mep/mep-0027), the IC infrastructure whose type feedback the JIT reads but does not write.
+- [MEP-29](/docs/mep/mep-0029), the dispatch-strategy measured results that motivate keeping vm2 monomorphic, which this JIT inherits.
+- [MEP-30](/docs/mep/mep-0030), the template / copy-and-patch baseline JIT strategy this MEP carries to full opcode coverage.
+- [MEP-31](/docs/mep/mep-0031), the tracing JIT alternative; remains deferred.
+- [MEP-32](/docs/mep/mep-0032), the tier-2 optimizing JIT; funded after this MEP ships and MEP-35 lands.
+- [MEP-33](/docs/mep/mep-0033), the MEP-30 prototype's measured results that calibrate this MEP's predictions.
+
+## Files to add (provisional)
+
+- `runtime/jit/vm2jit/doc.go`, package overview.
+- `runtime/jit/vm2jit/compile.go`, per-Function compiler driver.
+- `runtime/jit/vm2jit/cache.go`, executable code cache.
+- `runtime/jit/vm2jit/templates/{arith,control,call,list,string,map,set,struct}.go`, one file per opcode category.
+- `runtime/jit/vm2jit/arch/arm64/{encode.go,page.go}`, AArch64 backend.
+- `runtime/jit/vm2jit/arch/amd64/{encode.go,page.go}`, AMD64 backend.
+- `runtime/jit/vm2jit/runtime/{list_slow.go,string_slow.go,map_slow.go,set_slow.go,struct_slow.go,call_slow.go}`, Go slow-path shims.
+- `runtime/jit/vm2jit/trampoline/{trampoline_arm64.s,trampoline_amd64.s,trampoline.go}`, pure-Go cross-tier call.
+- `runtime/jit/vm2jit/vm2jit_test.go` plus per-category test files.
+- `runtime/jit/vm2jit/bench/`, microbenches and MEP-23 corpus harness.
+- `website/docs/mep/mep-0035.md`, the measured-results MEP (lands with Phase 3).

--- a/website/src/data/meps.json
+++ b/website/src/data/meps.json
@@ -270,5 +270,13 @@
     "type": "Informational",
     "description": "First measured-results report for the MEP-30 template / copy-and-patch baseline JIT. A reference prototype lives under runtime/jit/tmpljit and implements a 6-opcode register VM plus a copy-and-patch JIT that lowers each opcode to a fixed AArch64 instruction sequence and stitches them into an mmap'd executable page. On a canonical fillsum workload at N=1024 on Apple M4, the JIT runs at 418 ns/op vs 7177 ns/op for the same-shape interpreter, a 17.2x speedup, beating LuaJIT (532 ns/op) and matching hand-written Go (499 ns/op) within 17%. At N=10000 the JIT edges out Go native (3883 vs 5025 ns/op) because the JIT loop carries no Go preemption check. CPython 3.14 lands at 23899 ns/op, ~57x slower than the JIT. Results validate the MEP-30 design and recommend proceeding to a full vm2-opcode prototype.",
     "slug": "/docs/mep/mep-0033"
+  },
+  {
+    "number": 34,
+    "title": "VM2 Full-Opcode JIT - Lists, Strings, Maps, Sets, Structs",
+    "status": "Draft",
+    "type": "Standards Track",
+    "description": "Production-track spec for the next JIT after the MEP-30 prototype. Extends MEP-30's template / copy-and-patch design from the 6-opcode tmpljit toy to the full vm2 opcode set, with first-class native support for the five container subsystems (lists, strings, maps, sets, structs). Specifies per-opcode codegen templates, the frame-compatibility contract that lets the JIT and the vm2 interpreter share a Cell-shaped register file across calls, the Cell NaN-boxing fast paths and slow-path runtime callbacks, the cross-architecture backend split (darwin/arm64 + linux/amd64 from day one), and the benchmark plan that gates merge: head-to-head against the vm2 interpreter, LuaJIT, Lua 5.5, and CPython 3.14 on the MEP-23 corpus and on each container's hot ops. Predicts 3-6x over vm2 on list / arithmetic loops, 1.5-3x on string and map workloads, and parity with LuaJIT on numeric loops by Phase 3.",
+    "slug": "/docs/mep/mep-0034"
   }
 ]


### PR DESCRIPTION
Adds [MEP-34](https://github.com/mochilang/mochi/blob/mep/jit-vm2-opcodes/website/docs/mep/mep-0034.md) as Standards Track Draft.

Scope: full ~52-opcode vm2 JIT covering container opcodes (lists, strings, maps, sets, structs), with per-container codegen templates, slow-path callouts to runtime helpers, frame-compat contract with the interpreter, dual-arch backends (arm64 + amd64), three engineering phases, and three benchmark groups (A: vm2 head-to-head; B: cross-language vs Lua/LuaJIT/CPython/Go; C: per-opcode microbenches) with explicit merge gates.

Builds on MEPs 30 (template JIT), 31 (tracing prototype), 32 (tiered prototype), 33 (benchmark methodology).

Tracks #21543.

## Test plan
- [x] Spec renders correctly on Docusaurus build
- [x] meps.json regenerated (35 entries)
- [ ] Follow-up PRs implement Phase 1/2/3 per spec gates