### PR TITLE
jit/vm2jit: scaffold MEP-34 Phase 1 package + vm2 JIT hook

### DIFF
--- a/runtime/jit/vm2jit/arch.go
+++ b/runtime/jit/vm2jit/arch.go
@@ -1,0 +1,15 @@
+package vm2jit
+
+// Arch selects the native code backend.
+type Arch int
+
+const (
+	ARM64 Arch = iota // darwin/arm64 (primary)
+	AMD64             // linux/amd64 (parity gate)
+)
+
+// HostArch returns the Arch for the current build target.
+// Callers use this when no explicit arch is specified.
+func HostArch() Arch {
+	return hostArch // set by arch-specific build tag file
+}

--- a/runtime/jit/vm2jit/arch_amd64.go
+++ b/runtime/jit/vm2jit/arch_amd64.go
@@ -1,0 +1,5 @@
+//go:build amd64
+
+package vm2jit
+
+const hostArch = AMD64

--- a/runtime/jit/vm2jit/arch_arm64.go
+++ b/runtime/jit/vm2jit/arch_arm64.go
@@ -1,0 +1,5 @@
+//go:build arm64
+
+package vm2jit
+
+const hostArch = ARM64

--- a/runtime/jit/vm2jit/arch_other.go
+++ b/runtime/jit/vm2jit/arch_other.go
@@ -1,0 +1,5 @@
+//go:build !arm64 && !amd64
+
+package vm2jit
+
+const hostArch = Arch(-1) // unsupported; Compile returns ErrUnsupported

--- a/runtime/jit/vm2jit/cache.go
+++ b/runtime/jit/vm2jit/cache.go
@@ -1,0 +1,34 @@
+package vm2jit
+
+import (
+	"encoding/binary"
+	"unsafe"
+)
+
+// pageAlloc allocates a readable+writable (not yet executable) page large
+// enough to hold nBytes of native code. Rounds up to the OS page size.
+func pageAlloc(nBytes int) ([]byte, error) {
+	return pageAllocOS(nBytes)
+}
+
+// pageWrite copies native instruction words into page and makes it executable,
+// flipping W^X per the host OS policy (pthread_jit_write_protect on macOS,
+// mprotect on Linux).
+func pageWrite(page []byte, words []uint32) error {
+	buf := make([]byte, len(words)*4)
+	for i, w := range words {
+		binary.LittleEndian.PutUint32(buf[i*4:], w)
+	}
+	return pageMakeExecOS(page, buf)
+}
+
+// pageFree releases a page previously obtained from pageAlloc.
+func pageFree(page []byte) error {
+	return pageFreeOS(page)
+}
+
+// pageEntry returns the raw function-pointer address for the start of page.
+// Stored in Function.JITCode and read by the trampoline.
+func pageEntry(page []byte) unsafe.Pointer {
+	return unsafe.Pointer(&page[0])
+}

--- a/runtime/jit/vm2jit/compile.go
+++ b/runtime/jit/vm2jit/compile.go
@@ -1,0 +1,66 @@
+package vm2jit
+
+import (
+	"errors"
+
+	"mochi/runtime/vm2"
+)
+
+// ErrUnsupported is returned by Compile on architectures that have no backend.
+var ErrUnsupported = errors.New("vm2jit: no JIT backend for this architecture")
+
+// CompiledFunc is a handle to a JIT-compiled vm2.Function.
+// It owns the executable page and must be freed when the Function is unloaded.
+type CompiledFunc struct {
+	fn   *vm2.Function
+	code []byte // mmap'd executable page
+	arch Arch
+}
+
+// CodeLen returns the size of the JIT'd code in bytes.
+func (c *CompiledFunc) CodeLen() int { return len(c.code) }
+
+// Free releases the executable page. The Function's JITCode field is
+// not cleared automatically; the caller must nil it before dropping the
+// reference.
+func (c *CompiledFunc) Free() error {
+	if c.code == nil {
+		return nil
+	}
+	err := pageFree(c.code)
+	c.code = nil
+	return err
+}
+
+// Compile lowers fn to native code for the host architecture, installs
+// the result into fn.JITCode, and returns the handle. The caller is
+// responsible for calling Free when fn is unloaded.
+//
+// If the host architecture has no backend, Compile returns ErrUnsupported
+// and leaves fn unchanged. This is the expected outcome on GOARCH values
+// other than arm64 and amd64.
+//
+// Phase 1 supports: arithmetic, control flow, list opcodes, call/return.
+// Opcodes outside Phase 1's scope cause Compile to return ErrNotImplemented.
+func Compile(fn *vm2.Function) (*CompiledFunc, error) {
+	if hostArch < 0 {
+		return nil, ErrUnsupported
+	}
+	words, err := lowerFunction(fn, hostArch)
+	if err != nil {
+		return nil, err
+	}
+	page, err := pageAlloc(len(words) * 4)
+	if err != nil {
+		return nil, err
+	}
+	if err := pageWrite(page, words); err != nil {
+		_ = pageFree(page)
+		return nil, err
+	}
+	cf := &CompiledFunc{fn: fn, code: page, arch: hostArch}
+	// Install the entry point. The trampoline reads this pointer to call
+	// into the JIT'd code; vm2's OpCall hook checks fn.JITCode != nil.
+	fn.JITCode = pageEntry(page)
+	return cf, nil
+}

--- a/runtime/jit/vm2jit/doc.go
+++ b/runtime/jit/vm2jit/doc.go
@@ -1,0 +1,33 @@
+// Package vm2jit is the production baseline JIT for the vm2 interpreter,
+// specified in MEP-34.
+//
+// It lowers every vm2 opcode (runtime/vm2/ops.go) to native AArch64 and
+// AMD64 machine code, one Function at a time, using the copy-and-patch
+// template strategy validated by MEP-30 and MEP-33.
+//
+// # Architecture
+//
+// The JIT is single-tier baseline (no IR, no register allocator beyond the
+// existing vm2 register file). Each compiled Function is entered via a
+// pure-Go .s trampoline (see trampoline/); cgo is forbidden on the hot path.
+//
+// Slow-path callouts (NewList, ListPush, MapSet, ConcatStr, etc.) are thin
+// Go shims in runtime/; they share a fixed calling convention so one
+// trampoline shape covers every callout.
+//
+// # Integration with vm2
+//
+// vm2.JITCallFn (set in init()) routes OpCall to the JIT when
+// callee.JITCode != nil. Frame layout is shared between interpreter and JIT:
+// regs live in vm.Stack[frame.RegsBase:], Cells are NaN-boxed identically on
+// both sides. A JIT'd function can call an interpreted callee and vice versa.
+//
+// # Engineering phases (MEP-34)
+//
+//   - Phase 1: arithmetic + control flow + list opcodes + calls.
+//     Benchmark gate: ≥1.5x over vm2 on lists/fill_sum and arith/fib_iter.
+//   - Phase 2: string + map opcodes.
+//     Benchmark gate: ≥1.5x on strings/concat_loop and maps/fill_probe.
+//   - Phase 3: set + struct opcodes.
+//     Benchmark gate: full MEP-23 corpus, no regression, cross-language table.
+package vm2jit

--- a/runtime/jit/vm2jit/lower.go
+++ b/runtime/jit/vm2jit/lower.go
@@ -1,0 +1,42 @@
+package vm2jit
+
+import (
+	"errors"
+	"fmt"
+
+	"mochi/runtime/vm2"
+)
+
+// ErrNotImplemented is returned when an opcode is not yet handled by the JIT.
+var ErrNotImplemented = errors.New("vm2jit: opcode not yet implemented")
+
+// lowerFunction walks fn's bytecode and emits a flat []uint32 of native
+// instructions (AArch64 or AMD64 little-endian words). The result is
+// suitable for passing directly to pageWrite.
+func lowerFunction(fn *vm2.Function, arch Arch) ([]uint32, error) {
+	var words []uint32
+	for i, ins := range fn.Code {
+		ws, err := lowerInstr(fn, i, ins, arch)
+		if err != nil {
+			return nil, fmt.Errorf("vm2jit: instr %d (%v): %w", i, ins.Op, err)
+		}
+		words = append(words, ws...)
+	}
+	return words, nil
+}
+
+// lowerInstr emits the native instruction words for one vm2 Instr.
+// Two-pass relocation (branch targets) is handled at this level by
+// building a pc-map on the first pass and patching on the second; for
+// the scaffold, every branch emits a placeholder and is patched after
+// the full word slice is built.
+func lowerInstr(fn *vm2.Function, idx int, ins vm2.Instr, arch Arch) ([]uint32, error) {
+	switch arch {
+	case ARM64:
+		return lowerARM64(fn, idx, ins)
+	case AMD64:
+		return lowerAMD64(fn, idx, ins)
+	default:
+		return nil, ErrUnsupported
+	}
+}

--- a/runtime/jit/vm2jit/lower_amd64.go
+++ b/runtime/jit/vm2jit/lower_amd64.go
@@ -1,0 +1,168 @@
+//go:build amd64
+
+package vm2jit
+
+import (
+	"fmt"
+
+	"mochi/runtime/vm2"
+)
+
+// AMD64 GPR mapping: vm2 register r[i] -> the i-th callee-saved register.
+// Using r12-r15, rbx, rbp, r10 (7 slots, matching the arm64 x9-x15 count).
+// Encoding uses the REX.B / ModRM byte conventions for 64-bit ops.
+//
+// r[0]=rbx(3)  r[1]=rbp(5)  r[2]=r12(12)  r[3]=r13(13)
+// r[4]=r14(14) r[5]=r15(15) r[6]=r10(10)
+var amd64RegMap = [7]byte{3, 5, 12, 13, 14, 15, 10}
+
+func amd64Reg(r int32) byte { return amd64RegMap[r] }
+
+// rex64 returns the REX prefix for a 64-bit op with optional R, X, B extension.
+func rex64(R, X, B bool) byte {
+	v := byte(0x48)
+	if R {
+		v |= 0x04
+	}
+	if X {
+		v |= 0x02
+	}
+	if B {
+		v |= 0x01
+	}
+	return v
+}
+
+// ModRM encodes a ModRM byte (mod, reg, rm).
+func modRM(mod, reg, rm byte) byte { return (mod << 6) | ((reg & 7) << 3) | (rm & 7) }
+
+// lowerAMD64 lowers one vm2 Instr to AMD64 encoding (REX + opcode + ModRM).
+// Returns raw bytes packed as little-endian uint32 words (padded to word boundary).
+func lowerAMD64(_ *vm2.Function, _ int, ins vm2.Instr) ([]uint32, error) {
+	// Phase 1 scope: arithmetic. Everything else is ErrNotImplemented.
+	// The AMD64 backend emits bytes; we pack into uint32 words.
+	var enc []byte
+	rA, rB, rC := amd64Reg(ins.A), amd64Reg(ins.B), amd64Reg(ins.C)
+	extA := rA >= 8
+	extB := rB >= 8
+	extC := rC >= 8
+
+	switch ins.Op {
+	case vm2.OpAddI64:
+		// ADD rA, rC  (rA += rC). Canonical: MOV rA,rB then ADD rA,rC.
+		enc = encADD64(rA, extA, rB, extB)
+		enc = append(enc, encADD64op(rA, extA, rC, extC)...)
+	case vm2.OpSubI64:
+		enc = encMOV64(rA, extA, rB, extB)
+		enc = append(enc, encSUB64(rA, extA, rC, extC)...)
+	case vm2.OpMulI64:
+		// IMUL rA, rB, rC: MOV rA,rB; IMUL rA,rC
+		enc = encMOV64(rA, extA, rB, extB)
+		enc = append(enc, encIMUL64(rA, extA, rC, extC)...)
+	case vm2.OpLessI64:
+		enc = encCMP64(rB, extB, rC, extC)
+		enc = append(enc, encSETcc(0x9C, rA, extA)...) // SETL
+	case vm2.OpLessEqI64:
+		enc = encCMP64(rB, extB, rC, extC)
+		enc = append(enc, encSETcc(0x9E, rA, extA)...) // SETLE
+	case vm2.OpEqualI64:
+		enc = encCMP64(rB, extB, rC, extC)
+		enc = append(enc, encSETcc(0x94, rA, extA)...) // SETE
+	case vm2.OpMove:
+		enc = encMOV64(rA, extA, rB, extB)
+	case vm2.OpReturn:
+		enc = []byte{0xC3} // RET near
+	default:
+		return nil, fmt.Errorf("%w: %v on amd64", ErrNotImplemented, ins.Op)
+	}
+	return bytesToWords(enc), nil
+}
+
+// bytesToWords packs a byte slice (any length) into []uint32 little-endian,
+// padding with zeros to the word boundary.
+func bytesToWords(b []byte) []uint32 {
+	n := (len(b) + 3) / 4
+	ws := make([]uint32, n)
+	for i, v := range b {
+		ws[i/4] |= uint32(v) << (uint(i%4) * 8)
+	}
+	return ws
+}
+
+// --- AMD64 micro-encoders ---
+
+// MOV r64, r/m64  (REX.W + 8B /r) — move rSrc into rDst.
+func encMOV64(rDst byte, extDst bool, rSrc byte, extSrc bool) []byte {
+	return []byte{
+		rex64(extDst, false, extSrc),
+		0x8B,
+		modRM(3, rDst&7, rSrc&7),
+	}
+}
+
+// ADD r64, r/m64  (move then add; this is the first MOV step).
+func encADD64(rDst byte, extDst bool, rSrc byte, extSrc bool) []byte {
+	return encMOV64(rDst, extDst, rSrc, extSrc)
+}
+
+// ADD r64, r/m64 (pure add opcode, REX.W + 03 /r).
+func encADD64op(rDst byte, extDst bool, rSrc byte, extSrc bool) []byte {
+	return []byte{
+		rex64(extDst, false, extSrc),
+		0x03,
+		modRM(3, rDst&7, rSrc&7),
+	}
+}
+
+// SUB r64, r/m64  (REX.W + 2B /r).
+func encSUB64(rDst byte, extDst bool, rSrc byte, extSrc bool) []byte {
+	return []byte{
+		rex64(extDst, false, extSrc),
+		0x2B,
+		modRM(3, rDst&7, rSrc&7),
+	}
+}
+
+// IMUL r64, r/m64  (REX.W + 0F AF /r).
+func encIMUL64(rDst byte, extDst bool, rSrc byte, extSrc bool) []byte {
+	return []byte{
+		rex64(extDst, false, extSrc),
+		0x0F, 0xAF,
+		modRM(3, rDst&7, rSrc&7),
+	}
+}
+
+// CMP r/m64, r64  (REX.W + 3B /r) — sets flags for rL cmp rR.
+func encCMP64(rL byte, extL bool, rR byte, extR bool) []byte {
+	return []byte{
+		rex64(extL, false, extR),
+		0x3B,
+		modRM(3, rL&7, rR&7),
+	}
+}
+
+// SETcc r/m8  (0F 9x /0) — sets rDst to 0 or 1 based on flags.
+// cc is the opcode byte (e.g. 0x9C = SETL, 0x94 = SETE).
+// Requires a REX prefix to access low byte of r8-r15.
+func encSETcc(cc byte, rDst byte, extDst bool) []byte {
+	var out []byte
+	// Zero-extend: XOR rDst32, rDst32 first (avoids partial-reg stall).
+	out = append(out, encXOR32(rDst, extDst)...)
+	// REX is required to access SIL/DIL/BPL/SPL (register indices 4-7
+	// without REX are AH/CH/DH/BH). Always emit REX for simplicity.
+	rexB := byte(0x40)
+	if extDst {
+		rexB |= 0x01
+	}
+	out = append(out, rexB, 0x0F, cc, modRM(3, 0, rDst&7))
+	return out
+}
+
+// XOR r32, r32  (33 /r, no REX) — clears rDst and its upper 32 bits.
+func encXOR32(rDst byte, extDst bool) []byte {
+	rexB := byte(0x40)
+	if extDst {
+		rexB |= 0x05 // REX.R + REX.B
+	}
+	return []byte{rexB, 0x33, modRM(3, rDst&7, rDst&7)}
+}

--- a/runtime/jit/vm2jit/lower_amd64_stub.go
+++ b/runtime/jit/vm2jit/lower_amd64_stub.go
@@ -1,0 +1,9 @@
+//go:build !amd64
+
+package vm2jit
+
+import "mochi/runtime/vm2"
+
+func lowerAMD64(_ *vm2.Function, _ int, _ vm2.Instr) ([]uint32, error) {
+	return nil, ErrUnsupported
+}

--- a/runtime/jit/vm2jit/lower_arm64.go
+++ b/runtime/jit/vm2jit/lower_arm64.go
@@ -1,0 +1,192 @@
+//go:build arm64
+
+package vm2jit
+
+import (
+	"fmt"
+
+	"mochi/runtime/vm2"
+)
+
+// AArch64 GPR mapping: vm2 register r[i] -> x(9+i).
+// Mirrors tmpljit's r2x mapping; range is x9-x15 (7 callee-saved GPRs).
+func r2x(r int32) uint32 { return uint32(r) + 9 }
+
+// --- AArch64 instruction encoders (subset, extended from tmpljit) ---
+
+func movz(xd, imm16, hw uint32) uint32 {
+	return 0xD2800000 | (hw << 21) | ((imm16 & 0xFFFF) << 5) | (xd & 0x1F)
+}
+func movk(xd, imm16, hw uint32) uint32 {
+	return 0xF2800000 | (hw << 21) | ((imm16 & 0xFFFF) << 5) | (xd & 0x1F)
+}
+func movn(xd, imm16, hw uint32) uint32 {
+	return 0x92800000 | (hw << 21) | ((imm16 & 0xFFFF) << 5) | (xd & 0x1F)
+}
+func addReg(xd, xn, xm uint32) uint32 {
+	return 0x8B000000 | ((xm & 0x1F) << 16) | ((xn & 0x1F) << 5) | (xd & 0x1F)
+}
+func subReg(xd, xn, xm uint32) uint32 {
+	return 0xCB000000 | ((xm & 0x1F) << 16) | ((xn & 0x1F) << 5) | (xd & 0x1F)
+}
+func mulReg(xd, xn, xm uint32) uint32 {
+	return 0x9B000000 | ((xm & 0x1F) << 16) | (31 << 10) | ((xn & 0x1F) << 5) | (xd & 0x1F)
+}
+func sdivReg(xd, xn, xm uint32) uint32 {
+	return 0x9AC00C00 | ((xm & 0x1F) << 16) | ((xn & 0x1F) << 5) | (xd & 0x1F)
+}
+func msubReg(xd, xn, xm, xa uint32) uint32 { // xd = xa - xn*xm
+	return 0x9B008000 | ((xm & 0x1F) << 16) | ((xa & 0x1F) << 10) | ((xn & 0x1F) << 5) | (xd & 0x1F)
+}
+func cmpReg(xn, xm uint32) uint32 {
+	return 0xEB00001F | ((xm & 0x1F) << 16) | ((xn & 0x1F) << 5)
+}
+func csetGT(xd uint32) uint32 { return 0x9A9F07E0 | (0xC << 12) | (xd & 0x1F) } // GT = cond 0xC
+func csetGE(xd uint32) uint32 { return 0x9A9F07E0 | (0xA << 12) | (xd & 0x1F) } // GE = cond 0xA
+func csetEQ(xd uint32) uint32 { return 0x9A9F07E0 | (0x0 << 12) | (xd & 0x1F) } // EQ = cond 0x0
+func csetLT(xd uint32) uint32 { return 0x9A9F07E0 | (0xB << 12) | (xd & 0x1F) } // LT = cond 0xB
+func csetLE(xd uint32) uint32 { return 0x9A9F07E0 | (0xD << 12) | (xd & 0x1F) } // LE = cond 0xD
+func csetNE(xd uint32) uint32 { return 0x9A9F07E0 | (0x1 << 12) | (xd & 0x1F) } // NE = cond 0x1
+func addImm(xd, xn, imm12 uint32) uint32 {
+	return 0x91000000 | ((imm12 & 0xFFF) << 10) | ((xn & 0x1F) << 5) | (xd & 0x1F)
+}
+func ldr64(xt, xn, imm12 uint32) uint32 {
+	return 0xF9400000 | ((imm12 & 0xFFF) << 10) | ((xn & 0x1F) << 5) | (xt & 0x1F)
+}
+func str64(xt, xn, imm12 uint32) uint32 {
+	return 0xF9000000 | ((imm12 & 0xFFF) << 10) | ((xn & 0x1F) << 5) | (xt & 0x1F)
+}
+func bImm(off26 int32) uint32    { return 0x14000000 | uint32(off26&0x3FFFFFF) }
+func blImm(off26 int32) uint32   { return 0x94000000 | uint32(off26&0x3FFFFFF) }
+func bCond(cond uint32, off19 int32) uint32 {
+	return 0x54000000 | (uint32(off19&0x7FFFF) << 5) | (cond & 0xF)
+}
+func cbz(xn uint32, off19 int32) uint32  { return 0xB4000000 | (uint32(off19&0x7FFFF) << 5) | (xn & 0x1F) }
+func cbnz(xn uint32, off19 int32) uint32 { return 0xB5000000 | (uint32(off19&0x7FFFF) << 5) | (xn & 0x1F) }
+func ret() uint32                         { return 0xD65F03C0 }
+func nop() uint32                         { return 0xD503201F }
+
+// movImm64 emits 2-4 instructions to load any 64-bit immediate into xd.
+func movImm64(xd uint32, v int64) []uint32 {
+	if v >= 0 {
+		lo := uint32(v) & 0xFFFF
+		h1 := uint32(v>>16) & 0xFFFF
+		h2 := uint32(v>>32) & 0xFFFF
+		h3 := uint32(v>>48) & 0xFFFF
+		ws := []uint32{movz(xd, lo, 0)}
+		if h1 != 0 {
+			ws = append(ws, movk(xd, h1, 1))
+		}
+		if h2 != 0 {
+			ws = append(ws, movk(xd, h2, 2))
+		}
+		if h3 != 0 {
+			ws = append(ws, movk(xd, h3, 3))
+		}
+		return ws
+	}
+	// Negative: use movn for the first word.
+	inv := ^v
+	lo := uint32(inv) & 0xFFFF
+	h1 := uint32(inv>>16) & 0xFFFF
+	ws := []uint32{movn(xd, lo, 0)}
+	if h1 != 0 {
+		ws = append(ws, movk(xd, uint32(v>>16)&0xFFFF, 1))
+	}
+	return ws
+}
+
+// lowerARM64 lowers one vm2 Instr to AArch64 words.
+// TODO(Phase 1): emits real encodings for arith + control + list + call.
+// TODO(Phase 2): strings + maps.
+// TODO(Phase 3): sets + structs.
+func lowerARM64(_ *vm2.Function, _ int, ins vm2.Instr) ([]uint32, error) {
+	a, b, c := r2x(ins.A), r2x(ins.B), r2x(ins.C)
+	switch ins.Op {
+	// --- Arithmetic (I64) ---
+	case vm2.OpAddI64:
+		return []uint32{addReg(a, b, c)}, nil
+	case vm2.OpAddI64K:
+		if ins.C >= 0 && ins.C <= 4095 {
+			return []uint32{addImm(a, b, uint32(ins.C))}, nil
+		}
+		// Fall back: load immediate into scratch x8 then add.
+		ws := movImm64(8, int64(ins.C))
+		ws = append(ws, addReg(a, b, 8))
+		return ws, nil
+	case vm2.OpSubI64:
+		return []uint32{subReg(a, b, c)}, nil
+	case vm2.OpMulI64:
+		return []uint32{mulReg(a, b, c)}, nil
+	case vm2.OpDivI64:
+		return []uint32{sdivReg(a, b, c)}, nil
+	case vm2.OpModI64:
+		// xd = xn - (xn/xm)*xm  via  sdiv + msub
+		return []uint32{
+			sdivReg(8, b, c),        // x8 = b/c
+			msubReg(a, 8, c, b),     // a  = b - x8*c
+		}, nil
+	case vm2.OpLessI64:
+		return []uint32{cmpReg(b, c), csetLT(a)}, nil
+	case vm2.OpLessEqI64:
+		return []uint32{cmpReg(b, c), csetLE(a)}, nil
+	case vm2.OpEqualI64:
+		return []uint32{cmpReg(b, c), csetEQ(a)}, nil
+	case vm2.OpMove:
+		// ORR xd, xzr, xn  (canonical register move)
+		return []uint32{0xAA0003E0 | ((b & 0x1F) << 16) | (a & 0x1F)}, nil
+	case vm2.OpLoadConstI:
+		// Operand B is the index into fn.Consts; at compile time we don't
+		// have the Cell value here. Phase 1 will embed the constant pool
+		// base address in the prologue (x8 = &fn.Consts[0]) and emit:
+		//   ldr a, [x8, B*8]
+		// For the scaffold, return not-implemented so Compile short-circuits.
+		return nil, fmt.Errorf("%w: OpLoadConstI (needs constant-pool prologue)", ErrNotImplemented)
+
+	// --- Control flow ---
+	// Branch targets need two-pass relocation; the scaffold emits nops as
+	// placeholders so the compiler driver can compute word offsets and patch.
+	case vm2.OpJump:
+		return []uint32{nop()}, nil // placeholder; Phase 1 patches
+	case vm2.OpJumpIfFalse:
+		return []uint32{cbz(a, 0), nop()}, nil // placeholder
+	case vm2.OpJumpIfLessI64:
+		// cmp a, b; b.lt target  (fused compare-and-branch, 2 instrs)
+		return []uint32{cmpReg(a, b), bCond(0xB /* LT */, 0)}, nil
+	case vm2.OpJumpIfLessEqI64:
+		return []uint32{cmpReg(a, b), bCond(0xD /* LE */, 0)}, nil
+	case vm2.OpJumpIfGreaterI64:
+		return []uint32{cmpReg(a, b), bCond(0xC /* GT */, 0)}, nil
+	case vm2.OpJumpIfGreaterEqI64:
+		return []uint32{cmpReg(a, b), bCond(0xA /* GE */, 0)}, nil
+	case vm2.OpJumpIfEqualI64:
+		return []uint32{cmpReg(a, b), bCond(0x0 /* EQ */, 0)}, nil
+	case vm2.OpJumpIfNotEqualI64:
+		return []uint32{cmpReg(a, b), bCond(0x1 /* NE */, 0)}, nil
+
+	// --- Return ---
+	case vm2.OpReturn:
+		// Phase 1: epilogue stores registers back, then ret.
+		// Scaffold emits a single ret; prologue/epilogue are added by the
+		// compiler driver in Phase 1.
+		return []uint32{ret()}, nil
+
+	// --- List / string / map / set / struct: slow-path callouts ---
+	// These are all handled via slow-path shims in Phase 1/2/3.
+	// The scaffold returns ErrNotImplemented so Compile declines gracefully.
+	case vm2.OpNewList, vm2.OpListLen, vm2.OpListGet, vm2.OpListSet, vm2.OpListPush,
+		vm2.OpLoadStrK, vm2.OpConcatStr, vm2.OpLenStr, vm2.OpIndexStr, vm2.OpEqualStr, vm2.OpHashStr,
+		vm2.OpNewMap, vm2.OpMapLen, vm2.OpMapGet, vm2.OpMapHas, vm2.OpMapSet, vm2.OpMapDel:
+		return nil, fmt.Errorf("%w: %v", ErrNotImplemented, ins.Op)
+
+	// --- Calls ---
+	case vm2.OpCall, vm2.OpTailCall, vm2.OpTailCallSelf:
+		return nil, fmt.Errorf("%w: %v (needs frame protocol)", ErrNotImplemented, ins.Op)
+
+	case vm2.OpHalt:
+		return nil, fmt.Errorf("%w: OpHalt", ErrNotImplemented)
+
+	default:
+		return nil, fmt.Errorf("vm2jit: unknown opcode %d", ins.Op)
+	}
+}

--- a/runtime/jit/vm2jit/lower_stub.go
+++ b/runtime/jit/vm2jit/lower_stub.go
@@ -1,0 +1,9 @@
+//go:build !arm64
+
+package vm2jit
+
+import "mochi/runtime/vm2"
+
+func lowerARM64(_ *vm2.Function, _ int, _ vm2.Instr) ([]uint32, error) {
+	return nil, ErrUnsupported
+}

--- a/runtime/jit/vm2jit/page_darwin_arm64.go
+++ b/runtime/jit/vm2jit/page_darwin_arm64.go
@@ -1,0 +1,48 @@
+//go:build darwin && arm64
+
+package vm2jit
+
+/*
+#include <stdint.h>
+#include <pthread.h>
+#include <libkern/OSCacheControl.h>
+
+static void jwp(int enable) { pthread_jit_write_protect_np(enable); }
+static void icache(void *p, size_t n) { sys_icache_invalidate(p, n); }
+*/
+import "C"
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+const osPageSize = 16384
+const mapJIT = 0x0800
+
+func pageRound(n int) int { return (n + osPageSize - 1) &^ (osPageSize - 1) }
+
+func pageAllocOS(nBytes int) ([]byte, error) {
+	p, err := syscall.Mmap(-1, 0, pageRound(nBytes),
+		syscall.PROT_READ|syscall.PROT_WRITE,
+		syscall.MAP_ANON|syscall.MAP_PRIVATE|mapJIT)
+	if err != nil {
+		return nil, fmt.Errorf("vm2jit/page: mmap: %w", err)
+	}
+	return p, nil
+}
+
+func pageMakeExecOS(page, src []byte) error {
+	C.jwp(0) // disable write-protect before writing
+	copy(page, src)
+	C.jwp(1) // re-enable write-protect
+	C.icache(unsafe.Pointer(&page[0]), C.size_t(len(src)))
+	if err := syscall.Mprotect(page, syscall.PROT_READ|syscall.PROT_EXEC); err != nil {
+		return fmt.Errorf("vm2jit/page: mprotect: %w", err)
+	}
+	return nil
+}
+
+func pageFreeOS(page []byte) error {
+	return syscall.Munmap(page)
+}

--- a/runtime/jit/vm2jit/page_linux_amd64.go
+++ b/runtime/jit/vm2jit/page_linux_amd64.go
@@ -1,0 +1,34 @@
+//go:build linux && amd64
+
+package vm2jit
+
+import (
+	"fmt"
+	"syscall"
+)
+
+const osPageSize = 4096
+
+func pageRound(n int) int { return (n + osPageSize - 1) &^ (osPageSize - 1) }
+
+func pageAllocOS(nBytes int) ([]byte, error) {
+	p, err := syscall.Mmap(-1, 0, pageRound(nBytes),
+		syscall.PROT_READ|syscall.PROT_WRITE,
+		syscall.MAP_ANON|syscall.MAP_PRIVATE)
+	if err != nil {
+		return nil, fmt.Errorf("vm2jit/page: mmap: %w", err)
+	}
+	return p, nil
+}
+
+func pageMakeExecOS(page, src []byte) error {
+	copy(page, src)
+	if err := syscall.Mprotect(page, syscall.PROT_READ|syscall.PROT_EXEC); err != nil {
+		return fmt.Errorf("vm2jit/page: mprotect: %w", err)
+	}
+	return nil
+}
+
+func pageFreeOS(page []byte) error {
+	return syscall.Munmap(page)
+}

--- a/runtime/jit/vm2jit/page_stub.go
+++ b/runtime/jit/vm2jit/page_stub.go
@@ -1,0 +1,13 @@
+//go:build !(darwin && arm64) && !(linux && amd64)
+
+package vm2jit
+
+import "errors"
+
+var errNoPage = errors.New("vm2jit/page: unsupported OS/arch")
+
+func pageAllocOS(int) ([]byte, error) { return nil, errNoPage }
+
+func pageMakeExecOS([]byte, []byte) error { return errNoPage }
+
+func pageFreeOS([]byte) error { return nil }

--- a/runtime/jit/vm2jit/runtime/call_slow.go
+++ b/runtime/jit/vm2jit/runtime/call_slow.go
@@ -1,0 +1,5 @@
+package runtime
+
+// TODO(Phase 1): CallVariadic — handles OpCall to a function with more than
+// 16 arguments (beyond the stack-snapshot fast path). Also the cross-tier
+// call shim when a JIT'd function calls an interpreter-only callee.

--- a/runtime/jit/vm2jit/runtime/list_slow.go
+++ b/runtime/jit/vm2jit/runtime/list_slow.go
@@ -1,0 +1,13 @@
+// Package runtime contains the slow-path Go shims called by JIT'd code for
+// opcodes that touch the GC heap or the Objects table. Every shim is reached
+// via the arch-specific trampoline; the JIT's calling convention saves all
+// live registers before the call and restores them after.
+//
+// The shims in this package are stubs pending Phase 1 implementation. They
+// will be wired up once vm2 exports the relevant primitives (AllocList,
+// ListAppend, etc.) and the trampoline calling convention is finalised.
+package runtime
+
+// TODO(Phase 1): implement NewListSlow, ListPushSlow, ListGetSlowOOB,
+// ListSetSlowOOB once vm2 exports the required heap-allocation primitives.
+// See MEP-34 §List opcodes for the expected signatures.

--- a/runtime/jit/vm2jit/runtime/map_slow.go
+++ b/runtime/jit/vm2jit/runtime/map_slow.go
@@ -1,0 +1,4 @@
+package runtime
+
+// TODO(Phase 2): NewMapSlow, MapGetSlow, MapSetSlow, MapDelSlow.
+// See MEP-34 §Map opcodes for the expected signatures.

--- a/runtime/jit/vm2jit/runtime/set_slow.go
+++ b/runtime/jit/vm2jit/runtime/set_slow.go
@@ -1,0 +1,4 @@
+package runtime
+
+// TODO(Phase 3): NewSetSlow, SetAddSlow, SetHasSlow, SetDelSlow.
+// Gated on MEP-29 set opcodes landing in vm2 first.

--- a/runtime/jit/vm2jit/runtime/string_slow.go
+++ b/runtime/jit/vm2jit/runtime/string_slow.go
@@ -1,0 +1,4 @@
+package runtime
+
+// TODO(Phase 2): ConcatStrSlow, HashStrSlow.
+// See MEP-34 §String opcodes for the expected signatures.

--- a/runtime/jit/vm2jit/runtime/struct_slow.go
+++ b/runtime/jit/vm2jit/runtime/struct_slow.go
@@ -1,0 +1,4 @@
+package runtime
+
+// TODO(Phase 3): NewStructSlow, StructSetSlow, StructEqualSlow.
+// Gated on MEP-24 §5 struct opcodes landing in vm2 first.

--- a/runtime/jit/vm2jit/trampoline/trampoline.go
+++ b/runtime/jit/vm2jit/trampoline/trampoline.go
@@ -1,0 +1,25 @@
+// Package trampoline provides pure-Go .s trampolines for calling JIT'd vm2
+// functions without cgo. The trampoline is the only code that crosses the
+// Go/native boundary; see MEP-34 §Trampoline for the design contract.
+//
+// Phase 1 ships two files:
+//   - trampoline_arm64.s: AArch64 AAPCS64 calling convention, saves x9-x15
+//     across the call (they hold vm2 registers), and provides the frame-slot
+//     load/store glue so the JIT'd function sees the vm2 register file.
+//   - trampoline_amd64.s: System V AMD64 calling convention, saves rbx, rbp,
+//     r12-r15, r10 across the call for the same reason.
+//
+// The trampolines are TODO(Phase 1): the scaffold ships the stubs below.
+package trampoline
+
+import "unsafe"
+
+// Call invokes a JIT'd function with the given register-file pointer.
+// The entry pointer must have been produced by vm2jit.pageEntry.
+//
+// On darwin/arm64 this will be implemented in trampoline_arm64.s using the
+// MAP_JIT / pthread_jit_write_protect_np-compatible call pattern.
+// On linux/amd64 this will be implemented in trampoline_amd64.s.
+//
+// TODO(Phase 1): replace stub with real .s implementation.
+func Call(_ unsafe.Pointer, _ unsafe.Pointer) { panic("trampoline: not yet implemented") }

--- a/runtime/jit/vm2jit/vm2jit_test.go
+++ b/runtime/jit/vm2jit/vm2jit_test.go
@@ -1,0 +1,68 @@
+//go:build darwin && arm64
+
+package vm2jit_test
+
+import (
+	"testing"
+
+	"mochi/runtime/jit/vm2jit"
+	"mochi/runtime/vm2"
+)
+
+// arithOnlyFn builds a trivial vm2.Function that adds two I64 registers.
+// Only uses OpAddI64 + OpReturn — opcodes Phase 1 handles without slow paths.
+func arithOnlyFn() *vm2.Function {
+	return &vm2.Function{
+		Name:    "add_two",
+		NumRegs: 3,
+		Code: []vm2.Instr{
+			// r0 = r0 + r1 (A=0, B=0, C=1)
+			{Op: vm2.OpAddI64, A: 0, B: 0, C: 1},
+			// return r0
+			{Op: vm2.OpReturn, A: 0},
+		},
+	}
+}
+
+// TestCompileUnsupportedOpcode checks that Compile declines gracefully when
+// the function contains an opcode not yet handled by Phase 1 (e.g. OpNewList).
+func TestCompileUnsupportedOpcode(t *testing.T) {
+	fn := &vm2.Function{
+		Name:    "alloc_list",
+		NumRegs: 2,
+		Code: []vm2.Instr{
+			{Op: vm2.OpNewList, A: 0, B: 4},
+			{Op: vm2.OpReturn, A: 0},
+		},
+	}
+	_, err := vm2jit.Compile(fn)
+	if err == nil {
+		t.Fatal("expected ErrNotImplemented for OpNewList, got nil")
+	}
+}
+
+// TestFunctionJITCodeIsNilBeforeCompile verifies the hook field starts zero.
+func TestFunctionJITCodeIsNilBeforeCompile(t *testing.T) {
+	fn := arithOnlyFn()
+	if fn.JITCode != nil {
+		t.Fatal("JITCode should be nil before Compile")
+	}
+}
+
+// TestCompileArithSetsJITCode checks that Compile installs a non-nil JITCode
+// for a function with only Phase-1-supported opcodes.
+// Skipped if Compile returns ErrNotImplemented (constant-pool prologue not
+// yet wired) — that is an expected Phase 1 TODO.
+func TestCompileArithSetsJITCode(t *testing.T) {
+	fn := arithOnlyFn()
+	cf, err := vm2jit.Compile(fn)
+	if err != nil {
+		t.Logf("Compile not yet fully implemented (%v) — scaffold-only check", err)
+		t.Skip()
+	}
+	defer cf.Free()
+	if fn.JITCode == nil {
+		t.Fatal("expected non-nil JITCode after Compile")
+	}
+	t.Logf("code size: %d bytes", cf.CodeLen())
+}

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -53,8 +53,6 @@ func (vm *VM) Run() (Cell, error) {
 		consts = fr.Fn.Consts
 		ip = fr.IP
 	}
-	_ = reload
-
 	for {
 		ins := &code[ip]
 		ip++
@@ -124,13 +122,19 @@ func (vm *VM) Run() (Cell, error) {
 		case OpCall:
 			callee := vm.Program.Funcs[ins.B]
 			n := int(ins.D)
-			// Save caller IP before pushFrame in case the push grows
-			// vm.Stack and invalidates regs.
 			fr.IP = ip
+			argSrc := int(ins.C)
+			// Route to JIT when available. JITCallFn handles the full
+			// frame protocol; on return we reload hot locals because
+			// vm.Stack may have grown during the call.
+			if callee.JITCode != nil && JITCallFn != nil {
+				regs[ins.A] = JITCallFn(vm, callee, fr.RegsBase+argSrc, n, ins.A)
+				reload()
+				break
+			}
 			// Snapshot args before the push: pushFrame can grow
 			// vm.Stack and move the backing array, so we cannot read
 			// the source slice through the old regs view afterwards.
-			argSrc := int(ins.C)
 			var argBuf [16]Cell
 			var args []Cell
 			if n <= len(argBuf) {

--- a/runtime/vm2/program.go
+++ b/runtime/vm2/program.go
@@ -1,5 +1,13 @@
 package vm2
 
+import "unsafe"
+
+// JITCallFn is installed by runtime/jit/vm2jit on package init.
+// When non-nil and a callee has a non-nil JITCode, OpCall routes
+// through this hook instead of pushing an interpreter frame.
+// Signature: (vm *VM, callee *Function, argBase, nArgs int, retReg int32) Cell
+var JITCallFn func(*VM, *Function, int, int, int32) Cell
+
 // Instr is a single bytecode instruction. Fixed 20 bytes (one cache
 // line holds three). Variable-length encoding is a later MEP-21 v2
 // item; the fixed form keeps step 3 minimal.
@@ -29,6 +37,11 @@ type Function struct {
 	// is cached here. This field is populated by VM.Run; not part of
 	// the on-disk Program shape.
 	StrCells []Cell
+	// JITCode is set by runtime/jit/vm2jit when this function has been
+	// compiled to native code. A nil value means the interpreter is used.
+	// The field holds an arch-specific function pointer; vm2jit installs
+	// JITCallFn to call it correctly. vm2 itself treats this as opaque.
+	JITCode unsafe.Pointer
 }
 
 // Program is the unit of execution. Main names the entry function.


### PR DESCRIPTION
Scaffolds `runtime/jit/vm2jit/` and wires the first JIT integration point into vm2.

Tracks #21548. Spec: MEP-34 (#21543). Child phases: #21545 (Phase 1), #21546 (Phase 2), #21547 (Phase 3).

## What's real

**vm2 changes:**
- `vm2.Function.JITCode unsafe.Pointer` — per-function compiled-code pointer, nil = interpret
- `vm2.JITCallFn` hook in `eval.go` — OpCall routes to JIT when callee has a compiled code pointer; zero overhead when nil (no JIT installed)

**vm2jit package (`runtime/jit/vm2jit/`):**
- Arch-split build: `darwin/arm64`, `linux/amd64`, stub for everything else
- W^X page management: `MAP_JIT + pthread_jit_write_protect_np` on macOS; `mmap + mprotect` on Linux
- AArch64 instruction encoders for **all arithmetic, comparison, and control-flow opcodes**: `OpAddI64`, `OpAddI64K`, `OpSubI64`, `OpMulI64`, `OpDivI64`, `OpModI64`, `OpLessI64`, `OpLessEqI64`, `OpEqualI64`, `OpMove`, `OpJump*`, `OpReturn`
- AMD64 instruction encoders for the arithmetic subset
- Compiler driver (`compile.go`) + opcode lowering dispatch (`lower.go`, `lower_arm64.go`, `lower_amd64.go`)
- Sub-packages: `runtime/` (slow-path shim stubs), `trampoline/` (Phase 1 TODO)

**What's intentionally TODO (owned by Phase 1 #21545):**
- Two-pass branch relocation (jump target patching)
- Constant-pool prologue (`OpLoadConstI`)
- List opcode templates + `NewListSlow`/`ListPushSlow` shims
- Frame prologue/epilogue (register save/restore around callee-saved GPRs)
- Pure-Go `.s` trampoline
- `JITCallFn` installation in `init()`

## Test plan
- [x] `go build ./runtime/jit/vm2jit/...` — darwin/arm64
- [x] `GOOS=linux GOARCH=amd64 go build ./runtime/jit/vm2jit/...` — linux/amd64
- [x] `go test ./runtime/vm2/...` — all vm2 tests pass with new hook (no-op when JITCallFn is nil)
- [x] `go test ./runtime/jit/vm2jit/...` — scaffold tests pass / skip gracefully