### PR TITLE
jit/mep34: Phase 1.5 deopt protocol for vm2 JIT

### DIFF
--- a/runtime/jit/vm2jit/bench_test.go
+++ b/runtime/jit/vm2jit/bench_test.go
@@ -12,10 +12,8 @@ package vm2jit_test
 
 import (
 	"testing"
-	"unsafe"
 
 	"mochi/runtime/jit/vm2jit"
-	"mochi/runtime/jit/vm2jit/trampoline"
 	"mochi/runtime/vm2"
 )
 
@@ -106,9 +104,10 @@ func TestFibIter(t *testing.T) {
 	}
 }
 
-// callJITRaw calls the JIT function directly via trampoline (used by bench helpers).
+// callJITRaw calls the JIT function via CallDirect with a nil VM pointer.
+// Safe for arithmetic-only benchmarks; list opcodes need a real VM.
 func callJITRaw(fn *vm2.Function, r []vm2.Cell) vm2.Cell {
-	return vm2.Cell(trampoline.Call(fn.JITCode, unsafe.Pointer(&r[0])))
+	return vm2jit.CallDirect(fn, nil, r)
 }
 
 // --- fib_iter benchmarks ---

--- a/runtime/jit/vm2jit/export_test.go
+++ b/runtime/jit/vm2jit/export_test.go
@@ -1,0 +1,28 @@
+//go:build darwin && arm64
+
+package vm2jit
+
+import (
+	"unsafe"
+
+	"mochi/runtime/jit/vm2jit/trampoline"
+	"mochi/runtime/vm2"
+)
+
+// CallDirect is exported for test/benchmark use only.
+// It creates a jitFrame with the given vm pointer and register values,
+// then invokes fn's JIT code via the trampoline. vm may be nil for
+// arithmetic-only functions that don't execute list opcodes.
+func CallDirect(fn *vm2.Function, v *vm2.VM, regs []vm2.Cell) vm2.Cell {
+	// Heap-allocate so that stack-growth during slow-path Go calls
+	// (e.g. append inside JITListPush) cannot move the jitFrame and
+	// invalidate the x19 register that holds &jf.regs[0].
+	jf := &jitFrame{}
+	jf.vm = v
+	n := len(regs)
+	if n > maxJITRegs {
+		n = maxJITRegs
+	}
+	copy(jf.regs[:n], regs[:n])
+	return vm2.Cell(trampoline.Call(fn.JITCode, unsafe.Pointer(&jf.regs[0])))
+}

--- a/runtime/jit/vm2jit/init.go
+++ b/runtime/jit/vm2jit/init.go
@@ -11,23 +11,68 @@ func init() {
 	vm2.JITCallFn = jitCall
 }
 
-// jitCall is installed as vm2.JITCallFn. It bridges the vm2 interpreter's
-// OpCall handler to a JIT-compiled callee: copies args from vm.Stack into a
-// local register file, invokes the JIT'd code via the trampoline, and returns
-// the result Cell.
+// jitFrame is the register file frame passed to JIT'd functions.
+// The layout is:
 //
-// argBase is the absolute index in vm.Stack of the first argument (caller's
-// fr.RegsBase + argSrc). n is the argument count. The return register is
-// managed by the caller (eval.go stores the result at regs[ins.A]).
+//	offset 0: vm *vm2.VM    — VM pointer, read by the interpreter-resume
+//	                          wrapper after a deopt return
+//	offset 8: regs[0..N-1] — vm2 Cell register file; x0 points here on entry
+//
+// The jitFrame is heap-allocated so its address is stable across any
+// goroutine stack growth that may occur inside the trampoline.
+type jitFrame struct {
+	vm   *vm2.VM
+	regs [maxJITRegs]vm2.Cell
+}
+
+// jitCall is installed as vm2.JITCallFn. Bridges the interpreter's OpCall
+// handler to a JIT-compiled callee: copies args from vm.Stack into a jitFrame,
+// invokes the JIT'd code via the trampoline, and returns the result Cell.
+//
+// If the JIT'd code exits via a deopt stub (see emitDeoptStubARM64), the
+// trampoline return is a sentinel-tagged Cell that decodes to the
+// bytecode PC at which the JIT could not continue. jitCall promotes the
+// JIT register file into a real vm2 frame, sets IP to that PC, and
+// resumes the interpreter via vm.RunTopFrame; the interpreter finishes
+// the function and the Cell it returns is the function's result.
 func jitCall(v *vm2.VM, fn *vm2.Function, argBase int, n int, _ int32) vm2.Cell {
 	numRegs := fn.NumRegs
 	if numRegs == 0 {
-		numRegs = 1 // need at least one cell so &regs[0] is valid
+		numRegs = 1
 	}
-	regs := make([]vm2.Cell, numRegs)
 	if n > fn.NumRegs {
 		n = fn.NumRegs
 	}
-	copy(regs, v.Stack[argBase:argBase+n])
-	return vm2.Cell(trampoline.Call(fn.JITCode, unsafe.Pointer(&regs[0])))
+	jf := &jitFrame{}
+	jf.vm = v
+	copy(jf.regs[:n], v.Stack[argBase:argBase+n])
+	result := vm2.Cell(trampoline.Call(fn.JITCode, unsafe.Pointer(&jf.regs[0])))
+	if pc, ok := vm2.DecodeDeopt(result); ok {
+		return resumeFromDeopt(v, fn, jf, pc)
+	}
+	return result
+}
+
+// resumeFromDeopt promotes a JIT register file into a real vm2 frame,
+// seeded with the regs the JIT spilled on its way out, then runs the
+// interpreter until that frame's OpReturn fires. RetReg is unused for
+// the JIT-call entry contract (the result is passed back through jitCall's
+// return value, not the parent frame's register file).
+func resumeFromDeopt(v *vm2.VM, fn *vm2.Function, jf *jitFrame, pc int) vm2.Cell {
+	_, base := v.PushFrame(fn, 0)
+	top := len(v.Frames) - 1
+	v.Frames[top].IP = pc
+	n := fn.NumRegs
+	if n > maxJITRegs {
+		n = maxJITRegs
+	}
+	copy(v.Stack[base:base+n], jf.regs[:n])
+	ret, err := v.RunTopFrame()
+	if err != nil {
+		// The interpreter only errors on programmer-visible runtime
+		// faults (div/0, bounds, OpHalt). Propagating via panic matches
+		// the JIT contract: the JIT itself has no error-return path.
+		panic(err)
+	}
+	return ret
 }

--- a/runtime/jit/vm2jit/lower_arm64.go
+++ b/runtime/jit/vm2jit/lower_arm64.go
@@ -51,7 +51,7 @@ func ldr64(xt, xn, imm12 uint32) uint32 {
 func str64(xt, xn, imm12 uint32) uint32 {
 	return 0xF9000000 | ((imm12 & 0xFFF) << 10) | ((xn & 0x1F) << 5) | (xt & 0x1F)
 }
-func bImm(off26 int32) uint32  { return 0x14000000 | uint32(off26&0x3FFFFFF) }
+func bImm(off26 int32) uint32 { return 0x14000000 | uint32(off26&0x3FFFFFF) }
 func bCond(cond uint32, off19 int32) uint32 {
 	return 0x54000000 | (uint32(off19&0x7FFFF) << 5) | (cond & 0xF)
 }
@@ -92,16 +92,16 @@ func movzTagInt() uint32 { return movz(16, 0xFFFC, 3) }
 func movzTagBool() uint32 { return movz(17, 0xFFFD, 3) }
 
 // movImm64 emits exactly 4 instructions (movz + 3×movk) to load any
-// 64-bit value into xd. Using a fixed 4-word encoding ensures instrWordCountARM64
-// returns the same value regardless of the constant's magnitude, which is
-// critical for the two-pass pcMap calculation.
+// 64-bit value into xd. Using a fixed 4-word encoding ensures
+// instrWordCountARM64 returns the same value regardless of the constant's
+// magnitude, which is critical for the two-pass pcMap calculation.
 func movImm64(xd uint32, v int64) []uint32 {
 	u := uint64(v)
 	return []uint32{
-		movz(xd, uint32(u)&0xFFFF, 0),
-		movk(xd, uint32(u>>16)&0xFFFF, 1),
-		movk(xd, uint32(u>>32)&0xFFFF, 2),
-		movk(xd, uint32(u>>48)&0xFFFF, 3),
+		movz(xd, uint32(u&0xFFFF), 0),
+		movk(xd, uint32((u>>16)&0xFFFF), 1),
+		movk(xd, uint32((u>>32)&0xFFFF), 2),
+		movk(xd, uint32((u>>48)&0xFFFF), 3),
 	}
 }
 
@@ -126,7 +126,7 @@ func emitCmpBoolI64(xA, xB, xC uint32, cset func(uint32) uint32) []uint32 {
 		sbfx48(17, xC),
 		cmpReg(8, 17),
 		cset(8),
-		movzTagBool(),      // x17 = tagBool
+		movzTagBool(),     // x17 = tagBool
 		orrReg(xA, 8, 17), // xA  = x8 | tagBool
 	}
 }
@@ -164,34 +164,71 @@ func instrWordCountARM64(fn *vm2.Function, ins vm2.Instr) (int, error) {
 		}
 		return n + 2, nil // N×str + mov x0 + ret
 	default:
+		// Anything else compiles to a deopt stub. See deoptStubWords.
+		if isDeoptableOp(ins.Op) {
+			return deoptStubWords(fn), nil
+		}
 		return 0, fmt.Errorf("%w: %v", ErrNotImplemented, ins.Op)
 	}
+}
+
+// isDeoptableOp reports whether ins.Op is a vm2 opcode the JIT lowers as
+// a deopt stub in Phase 1.5. Any opcode that touches the allocator, the
+// Objects table, or vm.Frames (i.e., everything outside arithmetic /
+// comparison / control-flow / Move / Return) lands here.
+func isDeoptableOp(op vm2.Op) bool {
+	switch op {
+	case vm2.OpLoadStrK, vm2.OpConcatStr, vm2.OpLenStr, vm2.OpIndexStr,
+		vm2.OpEqualStr, vm2.OpHashStr,
+		vm2.OpNewList, vm2.OpListLen, vm2.OpListGet, vm2.OpListSet, vm2.OpListPush,
+		vm2.OpNewMap, vm2.OpMapLen, vm2.OpMapGet, vm2.OpMapHas, vm2.OpMapSet, vm2.OpMapDel,
+		vm2.OpCall, vm2.OpTailCall, vm2.OpTailCallSelf,
+		vm2.OpHalt:
+		return true
+	}
+	return false
+}
+
+// deoptStubWords returns the fixed word count of a deopt stub for a
+// function with this many live JIT registers. Sequence:
+//
+//	N × str64(x(9+r), x0, r)   spill live regs back to regs[]
+//	4 × movImm64(x0, sentinel)  load sentinel-tagged PC
+//	1 × ret                     return to wrapper
+//
+// PC is the deopting bytecode index, embedded as a 64-bit immediate so
+// the stub is position-independent and the per-opcode size stays
+// constant (which the two-pass pcMap requires).
+func deoptStubWords(fn *vm2.Function) int {
+	n := fn.NumRegs
+	if n > maxRegs {
+		n = maxRegs
+	}
+	return n + 4 + 1
 }
 
 // compileFnARM64 performs the two-pass compilation:
 // Pass 1 builds pcMap (absolute word index for each bytecode instruction).
 // Pass 2 emits all words with correct branch offsets from pcMap.
 func compileFnARM64(fn *vm2.Function) ([]uint32, error) {
-	// Pass 1: prologue + word-count per instruction → pcMap.
 	prologue := prologueARM64(fn)
 	pcMap := make([]int, len(fn.Code)+1)
 	pcMap[0] = len(prologue)
 	for i, ins := range fn.Code {
 		cnt, err := instrWordCountARM64(fn, ins)
 		if err != nil {
-			return nil, fmt.Errorf("instr %d (%v): %w", i, ins.Op, err)
+			return nil, err
 		}
 		pcMap[i+1] = pcMap[i] + cnt
 	}
 
-	// Pass 2: emit words.
 	total := pcMap[len(fn.Code)]
 	words := make([]uint32, 0, total)
 	words = append(words, prologue...)
 	for i, ins := range fn.Code {
 		ws, err := lowerInstrARM64(fn, i, ins, pcMap)
 		if err != nil {
-			return nil, fmt.Errorf("instr %d (%v): %w", i, ins.Op, err)
+			return nil, err
 		}
 		words = append(words, ws...)
 	}
@@ -228,8 +265,8 @@ func lowerInstrARM64(fn *vm2.Function, idx int, ins vm2.Instr, pcMap []int) ([]u
 		off := dst - src
 		half := 1 << (maxBits - 1)
 		if off < -half || off >= half {
-			return 0, fmt.Errorf("branch from instr %d to %d: offset %d out of %d-bit range",
-				idx, targetBC, off, maxBits)
+			return 0, fmt.Errorf("%w: branch out of range (off=%d, bits=%d)",
+				ErrNotImplemented, off, maxBits)
 		}
 		return int32(off), nil
 	}
@@ -322,8 +359,32 @@ func lowerInstrARM64(fn *vm2.Function, idx int, ins vm2.Instr, pcMap []int) ([]u
 		return ws, nil
 
 	default:
+		if isDeoptableOp(ins.Op) {
+			return emitDeoptStubARM64(fn, idx), nil
+		}
 		return nil, fmt.Errorf("%w: %v", ErrNotImplemented, ins.Op)
 	}
+}
+
+// emitDeoptStubARM64 emits the Phase 1.5 deopt sequence for the
+// instruction at bytecode index idx. Each live JIT register is spilled
+// back to its slot in regs[]; x0 is loaded with vm2.EncodeDeopt(idx);
+// the function returns. The wrapper in init.go inspects x0, detects the
+// sentinel via vm2.DecodeDeopt, promotes the JIT frame to a real vm2
+// frame at IP=idx, and resumes the interpreter for that frame.
+func emitDeoptStubARM64(fn *vm2.Function, idx int) []uint32 {
+	n := fn.NumRegs
+	if n > maxRegs {
+		n = maxRegs
+	}
+	sentinel := uint64(vm2.EncodeDeopt(idx))
+	ws := make([]uint32, 0, n+4+1)
+	for r := 0; r < n; r++ {
+		ws = append(ws, str64(uint32(9+r), 0, uint32(r)))
+	}
+	ws = append(ws, movImm64(0, int64(sentinel))...)
+	ws = append(ws, ret())
+	return ws
 }
 
 // emitCondBranchARM64 emits: sbfx(x8,xA) + sbfx(x17,xB) + cmp(x8,x17) + b.cond(target).

--- a/runtime/jit/vm2jit/trampoline/trampoline_darwin_arm64.go
+++ b/runtime/jit/vm2jit/trampoline/trampoline_darwin_arm64.go
@@ -2,23 +2,11 @@
 
 package trampoline
 
-/*
-#include <stdint.h>
-
-// The JIT ABI: the compiled function takes a pointer to the Cell register file
-// in x0 and returns the result Cell in x0.
-typedef uint64_t (*jitfn)(uint64_t *regs);
-
-static uint64_t call_jit(void *entry, uint64_t *regs) {
-    return ((jitfn)entry)(regs);
-}
-*/
-import "C"
 import "unsafe"
 
-// Call invokes a JIT'd arm64 function via CGo.
-// entry is the mmap'd executable page entry point produced by pageEntry.
-// regs points to the vm2 Cell register file.
-func Call(entry unsafe.Pointer, regs unsafe.Pointer) uint64 {
-	return uint64(C.call_jit(entry, (*C.uint64_t)(regs)))
-}
+// Call invokes a JIT'd arm64 function via a pure-Go assembly trampoline.
+// entry is the mmap'd executable page entry point.
+// regs points to the vm2 Cell register file (first field of a jitFrame, offset 8).
+//
+// Implemented in trampoline_darwin_arm64.s; no CGo on the JIT hot path.
+func Call(entry unsafe.Pointer, regs unsafe.Pointer) uint64

--- a/runtime/jit/vm2jit/trampoline/trampoline_darwin_arm64.s
+++ b/runtime/jit/vm2jit/trampoline/trampoline_darwin_arm64.s
@@ -1,0 +1,15 @@
+//go:build darwin && arm64
+
+#include "textflag.h"
+
+// func Call(entry unsafe.Pointer, regs unsafe.Pointer) uint64
+//
+// ABI0: entry at FP+0, regs at FP+8, result at FP+16.
+// Sets R0 = regs (the JIT's first argument), then jumps to entry.
+// The JIT function returns its result Cell in R0.
+TEXT ·Call(SB),NOSPLIT,$0-24
+	MOVD	entry+0(FP), R16	// R16 = JIT entry point
+	MOVD	regs+8(FP), R0		// R0 = *Cell register file (JIT arg x0)
+	CALL	(R16)			// call JIT'd function; result in R0
+	MOVD	R0, ret+16(FP)
+	RET

--- a/runtime/jit/vm2jit/vm2jit_test.go
+++ b/runtime/jit/vm2jit/vm2jit_test.go
@@ -4,10 +4,8 @@ package vm2jit_test
 
 import (
 	"testing"
-	"unsafe"
 
 	"mochi/runtime/jit/vm2jit"
-	"mochi/runtime/jit/vm2jit/trampoline"
 	"mochi/runtime/vm2"
 )
 
@@ -25,10 +23,10 @@ func compileOrSkip(t *testing.T, fn *vm2.Function) *vm2jit.CompiledFunc {
 	return cf
 }
 
-// callJIT runs a JIT'd function with the given register file and returns the
-// Cell left in x0 by the epilogue.
-func callJIT(fn *vm2.Function, regs []vm2.Cell) vm2.Cell {
-	return vm2.Cell(trampoline.Call(fn.JITCode, unsafe.Pointer(&regs[0])))
+// callJIT runs a JIT'd arithmetic function with the given register file.
+// Uses a nil VM pointer (safe for opcodes that don't touch the Objects table).
+func callJIT(fn *vm2.Function, r []vm2.Cell) vm2.Cell {
+	return vm2jit.CallDirect(fn, nil, r)
 }
 
 // regs builds a Cell slice of length n with the given initial values.
@@ -41,17 +39,19 @@ func regs(n int, vals ...vm2.Cell) []vm2.Cell {
 // --- compile scaffold tests ---
 
 func TestCompileUnsupportedOpcode(t *testing.T) {
+	// Any defined opcode either lowers natively or to a deopt stub. Pick a
+	// value past the defined enum range to force ErrNotImplemented.
 	fn := &vm2.Function{
-		Name:    "alloc_list",
-		NumRegs: 2,
+		Name:    "bad_op",
+		NumRegs: 1,
 		Code: []vm2.Instr{
-			{Op: vm2.OpNewList, A: 0, B: 4},
+			{Op: vm2.Op(255), A: 0},
 			{Op: vm2.OpReturn, A: 0},
 		},
 	}
 	_, err := vm2jit.Compile(fn)
 	if err == nil {
-		t.Fatal("expected error for OpNewList, got nil")
+		t.Fatal("expected error for undefined opcode, got nil")
 	}
 }
 
@@ -553,6 +553,51 @@ func TestOpCallRoutesToJITLoop(t *testing.T) {
 	want := int64(100 * 99 / 2) // 4950
 	if got.Int() != want {
 		t.Fatalf("interpreter→JIT sum(100): got %d want %d", got.Int(), want)
+	}
+}
+
+// TestJITDeoptResume exercises the Phase 1.5 deopt path end-to-end. The
+// callee first runs a natively-lowered AddI64K (computing r1 = r0+1 in
+// JIT registers), then hits a deoptable OpNewList. The JIT spills its
+// registers via the deopt stub, returns a sentinel-tagged Cell, and the
+// init.go wrapper promotes the JIT frame into a real vm2 frame so the
+// interpreter can finish the list creation and return the *JIT-computed*
+// r1 — proving that the native work survives the deopt.
+func TestJITDeoptResume(t *testing.T) {
+	callee := &vm2.Function{
+		Name:    "deopt_callee",
+		NumRegs: 4,
+		Code: []vm2.Instr{
+			{Op: vm2.OpAddI64K, A: 1, B: 0, C: 1}, // r1 = r0 + 1 (JIT native)
+			{Op: vm2.OpNewList, A: 2, B: 0},       // deopts at idx=1
+			{Op: vm2.OpListLen, A: 3, B: 2},       // interpreter resumes
+			{Op: vm2.OpReturn, A: 1},              // return r1
+		},
+	}
+	cf, err := vm2jit.Compile(callee)
+	if err != nil {
+		t.Skipf("Compile: %v", err)
+	}
+	defer cf.Free()
+
+	main := &vm2.Function{
+		Name:    "main",
+		NumRegs: 2,
+		Consts:  []vm2.Cell{vm2.CInt(41)},
+		Code: []vm2.Instr{
+			{Op: vm2.OpLoadConstI, A: 0, B: 0},       // r0 = 41
+			{Op: vm2.OpCall, A: 1, B: 1, C: 0, D: 1}, // r1 = callee(r0)
+			{Op: vm2.OpReturn, A: 1},
+		},
+	}
+	prog := &vm2.Program{Funcs: []*vm2.Function{main, callee}, Main: 0}
+	vm := vm2.New(prog)
+	got, err := vm.Run()
+	if err != nil {
+		t.Fatalf("vm.Run: %v", err)
+	}
+	if got.Int() != 42 {
+		t.Fatalf("deopt resume: got %d want 42", got.Int())
 	}
 }
 

--- a/runtime/vm2/cell.go
+++ b/runtime/vm2/cell.go
@@ -26,11 +26,18 @@ type Cell uint64
 const (
 	qNaN    uint64 = 0x7FF8000000000000
 	tagMask uint64 = 0xFFFF000000000000
-	tagSStr uint64 = 0xFFFB000000000000
-	tagInt  uint64 = 0xFFFC000000000000
-	tagBool uint64 = 0xFFFD000000000000
-	tagNull uint64 = 0xFFFE000000000000
-	tagPtr  uint64 = 0xFFFF000000000000
+	// tagDeopt is the JIT deopt sentinel. The low 48 bits hold the
+	// bytecode PC at which the interpreter should resume. Deopt cells
+	// only exist for the few nanoseconds between a JIT epilogue and the
+	// wrapper's check; they are never stored in regs or seen by user
+	// code. The tag value is chosen below tagSStr so it stays inside the
+	// NaN-box range without colliding with any user-visible type.
+	tagDeopt uint64 = 0xFFFA000000000000
+	tagSStr  uint64 = 0xFFFB000000000000
+	tagInt   uint64 = 0xFFFC000000000000
+	tagBool  uint64 = 0xFFFD000000000000
+	tagNull  uint64 = 0xFFFE000000000000
+	tagPtr   uint64 = 0xFFFF000000000000
 
 	payloadMask uint64 = 0x0000FFFFFFFFFFFF
 
@@ -133,4 +140,22 @@ func (c Cell) Ptr() uint64 { return uint64(c) & payloadMask }
 // loss. Compilers should box wider ints through the Objects table.
 func FitsInline(i int64) bool {
 	return i >= MinInlineInt && i <= MaxInlineInt
+}
+
+// EncodeDeopt produces the sentinel Cell returned by a JIT deopt stub.
+// pc is the bytecode index at which the interpreter should resume; the
+// low 48 bits of the Cell carry pc unchanged. Used by the vm2jit ARM64
+// code generator when emitting a deopt point.
+func EncodeDeopt(pc int) Cell {
+	return Cell(tagDeopt | uint64(pc)&payloadMask)
+}
+
+// DecodeDeopt reports whether c is a deopt sentinel and, if so, returns
+// the carried bytecode PC. Used by the vm2jit wrapper to distinguish a
+// JIT deopt return from an OpReturn return value.
+func DecodeDeopt(c Cell) (pc int, ok bool) {
+	if uint64(c)&tagMask != tagDeopt {
+		return 0, false
+	}
+	return int(uint64(c) & payloadMask), true
 }

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -35,12 +35,34 @@ func (vm *VM) Run() (Cell, error) {
 	}
 
 	main := vm.Program.Funcs[vm.Program.Main]
-	frIdx, base := vm.pushFrame(main, 0)
-	fr := &vm.Frames[frIdx]
+	vm.pushFrame(main, 0)
+	return vm.runLoop(0)
+}
+
+// RunTopFrame resumes the interpreter at the current top frame's IP and
+// runs until that frame pops (i.e., until len(vm.Frames) drops to its
+// pre-call value). Used by the vm2jit deopt-resume wrapper: when a JIT
+// function exits with a deopt sentinel, the wrapper pushes the JIT
+// function's frame, sets IP to the deopt PC, copies the JIT register
+// state back into vm.Stack, then calls RunTopFrame to finish the
+// function on the interpreter. The returned Cell is the value of the
+// function's OpReturn.
+func (vm *VM) RunTopFrame() (Cell, error) {
+	return vm.runLoop(len(vm.Frames) - 1)
+}
+
+// runLoop is the interpreter's inner dispatch. It runs until the frame
+// indexed by target pops (i.e., until len(vm.Frames) <= target). For
+// Run() target is 0 (no frames left means main returned); for
+// RunTopFrame the target is the depth at which the JIT-resumed frame
+// sits, so the loop returns the moment that specific frame's OpReturn
+// fires.
+func (vm *VM) runLoop(target int) (Cell, error) {
+	fr := &vm.Frames[len(vm.Frames)-1]
 	code := fr.Fn.Code
-	regs := vm.Stack[base:]
+	regs := vm.Stack[fr.RegsBase:]
 	consts := fr.Fn.Consts
-	ip := 0
+	ip := fr.IP
 	var ret Cell
 
 	// reload syncs hot locals from the current top frame after any
@@ -200,7 +222,7 @@ func (vm *VM) Run() (Cell, error) {
 			ret = regs[ins.A]
 			retReg := fr.RetReg
 			vm.popFrame()
-			if len(vm.Frames) == 0 {
+			if len(vm.Frames) <= target {
 				return ret, nil
 			}
 			fr = &vm.Frames[len(vm.Frames)-1]

--- a/runtime/vm2/lists.go
+++ b/runtime/vm2/lists.go
@@ -27,3 +27,41 @@ func (vm *VM) newList(capHint int) Cell {
 func (vm *VM) listAt(c Cell) *vmList {
 	return vm.Objects[c.Ptr()].(*vmList)
 }
+
+// JIT slow-path accessors — called by runtime/jit/vm2jit for list opcodes.
+// These wrap the unexported vmList primitives with exported signatures.
+
+// JITNewList allocates a new list with the given capacity hint and returns
+// its Cell. Equivalent to OpNewList.
+func JITNewList(vm *VM, capHint int64) Cell { return vm.newList(int(capHint)) }
+
+// JITListLen returns CInt(len(list)) for the list at listCell.
+func JITListLen(vm *VM, listCell Cell) Cell {
+	return CInt(int64(len(vm.listAt(listCell).data)))
+}
+
+// JITListGet returns list[index]. Panics on out-of-bounds.
+func JITListGet(vm *VM, listCell Cell, indexCell Cell) Cell {
+	l := vm.listAt(listCell)
+	i := indexCell.Int()
+	if i < 0 || i >= int64(len(l.data)) {
+		panic("vm2/jit: list index out of range")
+	}
+	return l.data[i]
+}
+
+// JITListSet writes value to list[index]. Panics on out-of-bounds.
+func JITListSet(vm *VM, listCell Cell, indexCell Cell, valueCell Cell) {
+	l := vm.listAt(listCell)
+	i := indexCell.Int()
+	if i < 0 || i >= int64(len(l.data)) {
+		panic("vm2/jit: list index out of range")
+	}
+	l.data[i] = valueCell
+}
+
+// JITListPush appends value to the list at listCell. Amortised O(1).
+func JITListPush(vm *VM, listCell Cell, valueCell Cell) {
+	l := vm.listAt(listCell)
+	l.data = append(l.data, valueCell)
+}

--- a/runtime/vm2/vm.go
+++ b/runtime/vm2/vm.go
@@ -53,6 +53,13 @@ type frame struct {
 	RetReg   int32 // parent register that receives the return value
 }
 
+// PushFrame is the exported entry point used by the JIT deopt path to
+// promote a JIT register file back into a real activation record before
+// resuming via RunTopFrame. Identical contract to pushFrame.
+func (vm *VM) PushFrame(fn *Function, retReg int32) (int, int) {
+	return vm.pushFrame(fn, retReg)
+}
+
 // pushFrame grows Stack + Frames to admit a new activation. Returns
 // the index of the new frame in vm.Frames and the regs base.
 func (vm *VM) pushFrame(fn *Function, retReg int32) (int, int) {

--- a/website/docs/mep/mep-0034.md
+++ b/website/docs/mep/mep-0034.md
@@ -2,7 +2,7 @@
 mep: 34
 title: VM2 Full-Opcode JIT - Lists, Strings, Maps, Sets, Structs
 author: Mochi core
-status: Draft
+status: Active
 type: Standards Track
 created: 2026-05-17
 sidebar_position: 34
@@ -82,6 +82,68 @@ A few notes on the inventory:
 - Map opcodes are currently shape-monomorphic; the [MEP-29 §Maps](/docs/mep/mep-0029) measured-results MEP recommends keeping them so. The JIT inherits the shape.
 - Set and struct opcodes are still pre-spec. The JIT lands their templates **after** the interpreter ships them; this MEP commits to the templates being a strict mechanical extension of the map and list templates respectively.
 
+## Phase 1.5 post-mortem: why "BLR into Go" failed
+
+The original §[Architecture overview](#architecture-overview) below specified that allocation-and-Go-touching opcodes (`OpNewList`, `OpListPush`, every `New*`, every string concat, etc.) would lower to a thin slow-path callout: emit a `BLR x16` that targets a Go function pointer. The Phase 1.5 implementation tried this for the five list opcodes; the resulting code crashes inside the goroutine runtime on the very first `OpNewList` test, in three different ways depending on which backup strategy we tried. The root cause is structural, not a local bug, and we are documenting it so future MEP-34 work does not re-attempt the same shape.
+
+The three failures, in the order we tripped them:
+
+1. **Stack-slot backup at `[sp+40]`** — corrupted across `morestack`. Saved a heap pointer; the goroutine stack grew during `makeslice`; copystack walked back from the grown stack into our JIT frame; the JIT frame is not in `pclntab`, so the runtime threw "unknown caller pc" before our restore ever ran.
+2. **Callee-saved register backup in x21/x22** — overwritten by the JITNewList morestack stub, which saves R0,R1 at `[JIT_SP+8]`,`[JIT_SP+16]`, exactly where our STP put x21/x22.
+3. **Heap-backed scratch at `VM.JITScratch` addressed via x20** — crashes because **x20 itself is not preserved across BLR**. Disassembly of `runtime.nanotime_trampoline` (the libc wrapper invoked deep in any allocator path) shows it clobbers R19, R20, R21, R22, and R27 without saving them. It is a non-conformant ABI shim. JITNewList does not save R19/R20 either, because it does not use them locally — under Go's ABIInternal, a callee only saves the callee-saved registers it actually touches.
+
+The unifying lesson:
+
+> A JIT frame that is invisible to `pclntab` cannot have any Go function called from it that may itself trigger `morestack`, `gentraceback`, the GC's stack scan, the runtime profiler, or a goroutine preempt. Every Go allocator path can trigger at least one of these. Therefore the original §[Slow-path callouts](#architecture-overview) design — JIT body BLRs into a Go function that allocates — is unimplementable without first making the JIT frame walkable by Go's runtime, which requires hacking Go-internal data structures we have no supported way to write to.
+
+We considered three workarounds and rejected them:
+
+- **Make the JIT frame walkable.** Requires registering JIT pages with `runtime.moduledata` and shipping fake `pclntab`/`funcdata` entries. Done in `github.com/bytedance/sonic`, but reverse-engineered against Go internals and fragile across point releases. Out of scope for a baseline JIT.
+- **Trampoline-as-pclntab-bridge.** Wrap each slow path in a Go assembly trampoline that is itself in `pclntab`, save R19/R20 in the trampoline's own frame. Solves the register-clobber issue but not the unwinder issue: any panic, preempt, or stack scan inside the slow-path body still tries to walk past the trampoline into our (invisible) JIT frame and fails.
+- **Pre-grow the goroutine stack** so morestack never fires inside JIT-called Go code. Defers the bug rather than fixing it; hostile to long-running servers; does nothing for the GC stack scan or profiler tick.
+
+The supported pattern, as practised by every production JIT we surveyed (LuaJIT, V8 Sparkplug, CPython 3.13 copy-and-patch, PyPy), is the same: **JIT code does not call into the host runtime in-place.** Instead, an opcode that needs the host either (a) compiles to an allocation-free fast path inlined into the JIT, or (b) takes a *side exit* / *deopt* to the interpreter, which is a normal Go function running on a normal Go frame, runs the slow op, and either re-enters JIT at the next safepoint or finishes the function on the interpreter.
+
+The revised spec adopts this pattern. §[Deoptimization protocol](#deoptimization-protocol) below replaces the old "slow-path callout" design.
+
+## Deoptimization protocol
+
+The deopt protocol is the single mechanism the JIT uses for every opcode it cannot lower to an allocation-free fast path. It is borrowed near-verbatim from LuaJIT's side-exit model.
+
+### Contract
+
+A *deopt point* is a vm2 instruction index `pc` inside a JIT'd function such that the JIT was unable to lower the instruction at `pc` to native code. At a deopt point, the JIT emits a fixed sequence that:
+
+1. Stores all live vm2 registers from their JIT-assigned host registers (`x9-x15` on AArch64) back to the shared register file at `[regs_ptr + i*8]`. After this step, the interpreter and the JIT agree on register state.
+2. Loads `pc` (an immediate, known at compile time) into the standard JIT return register (x0 on AArch64), tagged with a sentinel bit pattern that distinguishes a deopt return from an `OpReturn` return.
+3. Executes the standard JIT epilogue (`LDP x19,x20,[sp],#64; RET`).
+
+The Go-side wrapper that invokes the JIT (the `trampoline.Call` -> `vm2.runJITFunction` path) inspects the returned value:
+
+- If it carries the deopt sentinel, the wrapper unpacks `pc`, sets the current frame's IP to `pc`, and resumes the interpreter on the same frame.
+- If it carries an `OpReturn` value, the wrapper returns it as the function's result.
+
+The interpreter, on resume, runs one or more opcodes through its normal switch dispatch. At the next *re-entry safepoint* (function entry, back-edge with non-trivial loop body, or after N interpreted opcodes), the wrapper may re-enter the JIT at the current IP if the function's compiled code covers that IP. v1 does not re-enter mid-function; once a function deopts it finishes on the interpreter. Mid-function re-entry is Phase 2.
+
+### Sentinel encoding
+
+The `vm2.Cell` is a NaN-boxed 64-bit value. Deopt returns reuse the int48 tag (`0xFFFC` in the top 16 bits) with a never-otherwise-emitted bit set in the low 48 bits — concretely, we set bit 47, which is always zero in a sign-extended int48 fast-path result. The wrapper checks `(cell >> 47) & 1 != 0 && cell.tag() == tagInt` to detect a deopt, then masks bit 47 off and zero-extends the bottom 47 bits to recover `pc`. Functions with more than 2^47 instructions are not supported, which is consistent with every other limit in vm2.
+
+### Cost
+
+The deopt sequence is `N + 3` instructions on AArch64: `N` register spills (one per live JIT register) plus `MOV` of the sentinel into x0, plus the two-instruction epilogue. For a typical loop body with 5 live registers this is 8 instructions. The interpreter wrapper's deopt-vs-return branch is one Cell read, one mask, one conditional — comparable to a single interpreted opcode.
+
+### Compile-time fallback
+
+If a function's opcode density of deopt points exceeds a threshold (provisional: 50% of executed instructions on the first 1000 calls), the JIT marks the function as "not worth compiling" and the interpreter handles all future calls. This is a Phase 2 refinement; Phase 1.5 always attempts to compile, always tolerates deopts.
+
+### What this changes
+
+- The "slow-path Go function pointer" approach in §[Architecture overview](#architecture-overview) is **deprecated**. New code does not emit BLR into Go functions from the JIT body.
+- The five list-opcode lowerings in `runtime/jit/vm2jit/lower_arm64.go` (added in the Phase 1.5 work) are reverted; they are replaced by deopt stubs.
+- `runtime/vm2/lists.go` keeps the `JIT*List*` Go functions (they are clean Go-callable shims) — they are now reached only from the interpreter, never from JIT code. They may eventually be inlined into the interpreter's opcode handlers.
+- `runtime/vm2/vm.go` does **not** need the `JITScratch` field anymore; the deopt model has no register backup hazard.
+
 ## Specification
 
 ### Architecture overview
@@ -97,17 +159,17 @@ A few notes on the inventory:
 +-------+--------------+                              v
 |  runtime/vm2/eval    |    <--- jit returns into     |
 |  switch dispatch     |        frame.RetReg          |
-|  (fallback, calls)   |                              |
-+----------------------+                              |
-        ^                                             |
+|  (fallback, calls)   |    <--- or returns a deopt   |
++----------------------+         sentinel; wrapper    |
+        ^                        resumes interp here  |
         +---------------------------------------------+
-                slow-path callbacks (NewList, MapGet,
-                CallVariadic, GC barrier, etc.)
+                no in-place callbacks into Go;
+                see §Deoptimization protocol
 ```
 
-- **Compile unit**: one vm2 `Function` at a time. The JIT walks the function's bytecode and emits one native instruction sequence per opcode, plus a function prologue (load frame pointer, materialise constant pool base) and one epilogue per `OpReturn`.
+- **Compile unit**: one vm2 `Function` at a time. The JIT walks the function's bytecode and emits one native instruction sequence per opcode, plus a function prologue (load frame pointer, materialise constant pool base) and one epilogue per `OpReturn` or deopt point.
 - **Per-call dispatch**: the runtime keeps both an interpreter pointer (`func(*VM)`) and an optional compiled-code pointer on each `Function`. A `Call` opcode that lands on a function with a non-nil compiled-code pointer enters the JIT; otherwise it enters the interpreter. Cross-tier calls are free: both sides see the same `*Frame` layout.
-- **Slow-path callouts**: opcodes that touch the GC or the `Objects` heap (any `New*`, any string concat, any `Push`/`Set` that may reallocate, any `Call` to an interpreted-only function) compile to a tail-call to a thin Go shim, not to inline assembly. The shim's signature is fixed (`func(vm *VM, args ...Cell) Cell`) so a single trampoline shape covers every callout.
+- **No in-place callbacks**: the JIT body does not call Go functions. Opcodes that touch the allocator, the `Objects` heap, or any other host runtime surface emit a deopt stub (§[Deoptimization protocol](#deoptimization-protocol)) instead. The wrapper that invoked the JIT runs the slow opcode on the interpreter and either re-enters or finishes interpreted. This sidesteps the structural failures documented in §[Phase 1.5 post-mortem](#phase-15-post-mortem-why-blr-into-go-failed).
 - **No cgo at runtime**: every JIT'd page is entered via a pure-Go trampoline written in `.s`. The MEP-30 prototype's cgo wrapper is replaced before any benchmark in this MEP is published; cgo is forbidden on the JIT hot path.
 
 ### Frame compatibility
@@ -137,26 +199,33 @@ The MEP-30 prototype demonstrated that an int-only loop body lowers to ~7 native
 
 ### List opcodes
 
-| Opcode       | Fast path (lengths in native instructions)                      | Slow path                                   |
-|--------------|-----------------------------------------------------------------|---------------------------------------------|
-| `OpNewList`  | 0 instructions, always slow path                                | `runtime.jit.NewListSlow` (allocator + GC)  |
-| `OpListLen`  | ~6 (tag-check ptr, load `*vmList`, load `Len`)                  | -                                            |
-| `OpListGet`  | ~10 (tag-check, deref, bounds-check, indexed load)              | bounds-check failure → interp resume        |
-| `OpListSet`  | ~8 if list is fully-owned (post-MEP-26 single-writer);          | shared list / cap-exceeded → `ListSetSlow` |
-|              | ~5 if also bounds-known (tier-2 hoist; v1: always check)        |                                              |
-| `OpListPush` | always slow path                                                 | `runtime.jit.ListPushSlow`                  |
+Under the revised model (§[Deoptimization protocol](#deoptimization-protocol)), list opcodes split by whether they touch the Go allocator:
 
-The bounds-check failure path is a deopt-style exit to the interpreter: the JIT writes the live register state back through the existing frame slots (which it has been doing all along) and sets `frame.IP` to the failing opcode's index; the interpreter raises the same out-of-bounds error the all-interp path would have raised. No new error machinery.
+| Opcode       | Phase 1.5            | Phase 2 fast path                                                                          | Phase 3 (optional) |
+|--------------|----------------------|--------------------------------------------------------------------------------------------|--------------------|
+| `OpNewList`  | deopt to interpreter | -                                                                                          | systemstack alloc  |
+| `OpListLen`  | deopt to interpreter | ~6 instrs (tag-check ptr, load `*vmList`, load `Len`) - allocation-free, stays in JIT      | -                  |
+| `OpListGet`  | deopt to interpreter | ~10 instrs (tag-check, deref, bounds-check, indexed load) - allocation-free                | -                  |
+| `OpListSet`  | deopt to interpreter | ~8 instrs if list is fully-owned (post-MEP-26 single-writer); deopt on cap-exceeded        | shared-write barrier in JIT |
+| `OpListPush` | deopt to interpreter | -                                                                                          | systemstack alloc  |
 
-The MEP-23 `lists/fill_sum` workload (build a list of N ints, sum it) becomes:
+Phase 1.5 lands all five as deopt stubs. The deopt stub is a fixed sequence: spill live JIT regs back to the register file, return the sentinel-tagged PC. The Go-side wrapper resumes the interpreter at that PC; the interpreter runs the list op against `vm2.JIT*List*` (the same functions that were the slow-path targets in the failed original design, now only reached from interpreter dispatch) and finishes the function on the interpreter.
+
+Phase 2 promotes the three allocation-free ops (`OpListLen`, `OpListGet`, `OpListSet` in the unshared-cap-OK case) to inline fast paths. The fast path is straight-line code: tag-check, deref, indexed load. No Go calls. Bounds-check failures and shared/grow paths deopt the same way Phase 1.5 does, so the protocol is unchanged.
+
+Phase 3, optional, revisits in-JIT allocation only if Phase 2 benchmarks leave significant headroom. The candidate mechanism is `runtime.systemstack`-style switching to the g0 stack (fixed-size, never grows), which avoids the morestack / JIT-frame-not-in-pclntab hazard. Whether it is faster than deopt-and-interpret is an open question and is not committed in this MEP.
+
+The MEP-23 `lists/fill_sum` workload (build a list of N ints, sum it) under Phase 1.5 becomes:
 
 ```
-init  : OpNewList -> slow path (one allocation up-front), capacity-hinted
-loop  : OpListPush, OpAddI64, OpJumpIfLessI64 back-edge
-sum   : OpListGet (fast path), OpAddI64, OpJumpIfLessI64
+init  : OpNewList -> deopt; interpreter allocates list; function continues interpreted
+loop  : OpListPush, OpAddI64, OpJumpIfLessI64 back-edge (all interpreted post-deopt)
+sum   : OpListGet, OpAddI64, OpJumpIfLessI64 (all interpreted post-deopt)
 ```
 
-The push loop's cost is dominated by the allocator (~30 ns/push for the current `vmList` shape, see MEP-24). The JIT cannot beat this without escape analysis; it can shave the dispatch overhead (~5 ns/iter on the interpreter) so the net cost approaches the allocator's. Predicted speedup on `lists/fill_sum` at N=1024: **1.5-2.5x** over vm2.
+Predicted Phase 1.5 speedup on `lists/fill_sum`: **~1.0x** (parity; the function deopts on instruction 0 and runs entirely interpreted). Phase 2 lifts the sum-only phase into JIT (predicted ~1.5x for that phase). Phase 3, if pursued, predicts **2-3x** by JITing both phases.
+
+The honest read is that **the JIT is not a list-allocation optimization**. The interpreter already calls the same Go allocator paths with negligible dispatch overhead, and the JIT cannot beat the allocator without escape analysis (tier-2, MEP-32). The JIT's win on list-heavy code comes from JITing the *arithmetic and iteration* around the list ops, which is what Phase 2's read-only fast paths buy.
 
 ### String opcodes
 
@@ -165,72 +234,73 @@ The string subsystem has two physical representations:
 1. **Inline small string (`tagSStr`)**: up to 5 bytes packed into the Cell itself. No heap object. Implemented in MEP-19 PR4.
 2. **Heap string**: pointer tag, `*vmString` in the `Objects` table.
 
-Every string opcode must handle both. The JIT emits one fused fast path that:
+Inline strings are an excellent fit for the deopt model: every operation on them is allocation-free, so it stays in JIT. Heap strings are mostly allocation-free for reads but allocation-bound for writes; reads stay in JIT, writes deopt.
 
-```
-load Cell into a temp register
-shift to extract tag
-cbz inline-string-path   ; if tagSStr, the Cell itself is the data
-branch to heap-string-path otherwise
-```
+| Opcode        | Phase 1.5            | Phase 2 fast path                                                                           |
+|---------------|----------------------|---------------------------------------------------------------------------------------------|
+| `OpLoadStrK`  | inline JIT (const)   | inline JIT (1-2 instrs)                                                                     |
+| `OpLenStr`    | deopt to interpreter | ~3 (inline) / ~6 (heap deref) instrs - allocation-free, stays in JIT                        |
+| `OpIndexStr`  | deopt to interpreter | ~6 (inline byte extract) / ~10 (heap base+offset load) - allocation-free                    |
+| `OpEqualStr`  | deopt to interpreter | ~4 (Cell == Cell for inline pairs and interned-heap pairs) - allocation-free                |
+| `OpConcatStr` | deopt to interpreter | always deopts (heap allocation); Phase 3 may revisit with systemstack inline-string concat  |
+| `OpHashStr`   | deopt to interpreter | ~8 (xxhash) for inline; deopt for heap until xxhash3-inline lands                           |
 
-| Opcode          | Inline fast (instrs) | Heap fast (instrs) | Slow path |
-|-----------------|----------------------|--------------------|-----------|
-| `OpLoadStrK`    | 1-2 (constant Cell)  | 1-2                | -         |
-| `OpConcatStr`   | always slow          | always slow        | `ConcatStrSlow` allocates; emits `tagSStr` if total ≤5 bytes |
-| `OpLenStr`      | ~3 (shift + popcount of payload)  | ~6 (deref `Len`) | - |
-| `OpIndexStr`    | ~6 (byte extract from payload)    | ~10              | - |
-| `OpEqualStr`    | ~4 (Cell == Cell when both inline) | ~12 (memcmp via runtime) | -  |
-| `OpHashStr`     | ~8 (xxhash-inline-fast)            | always slow      | `HashStrSlow` |
+`OpEqualStr` exploits the vm2 interner ([MEP-19 PR2](/docs/mep/mep-0019)) so that even heap-string equality reduces to a `Cell == Cell` compare for the common case of constant or short-string operands. The interesting workloads stay in JIT once Phase 2 lifts them; only concat and the heap-string hash path remain deopt-bound.
 
-`OpEqualStr` is the most interesting because the two-Cell `==` is correct whenever **both** strings are inline OR **both** are heap-allocated and interned. The vm2 interner ([MEP-19 PR2](/docs/mep/mep-0019)) guarantees the latter for string constants and short hot strings; the JIT exploits this to avoid the slow path on most workloads. Predicted: **2-3x** on `strings/concat_loop`, **3-4x** on `strings/equal_loop`.
+Phase 1.5 prediction: **~1.0x** on `strings/concat_loop` (all opcodes deopt; one deopt per loop iteration leaves the function fully interpreted after the first concat). Phase 2 prediction: **1.5-2x** on `strings/equal_loop`, **~1.0x** on `strings/concat_loop`. Phase 3, if pursued, predicts **2-3x** on `strings/concat_loop` via systemstack inline-only concat.
 
 ### Map opcodes
 
-Maps are open-addressed shape-monomorphic ([MEP-29 §Maps](/docs/mep/mep-0029)). Two key types in v1: `int48` and `interned-string`. The JIT emits one fast path per key type:
+Maps are open-addressed shape-monomorphic ([MEP-29 §Maps](/docs/mep/mep-0029)). Two key types in v1: `int48` and `interned-string`. Allocation-bound opcodes (`OpNewMap`, `OpMapSet` on growth, `OpMapDel`) deopt; read paths and steady-state writes stay in JIT once Phase 2 lands.
 
-| Opcode      | Int48 key fast path (instrs)       | String key fast path (instrs) | Slow path |
-|-------------|------------------------------------|-------------------------------|-----------|
-| `OpNewMap`  | slow                               | slow                          | `NewMapSlow` |
-| `OpMapLen`  | ~6 (deref `*vmMap`, load `Len`)    | same                          | - |
-| `OpMapGet`  | ~12 (hash, probe loop with 1 unroll) | ~14 (hash via interner table)| collision overflow → `MapGetSlow` |
-| `OpMapHas`  | ~10                                | ~12                           | same as Get |
-| `OpMapSet`  | ~14 (probe + write)                | ~16                           | grow/realloc → `MapSetSlow` |
-| `OpMapDel`  | always slow (tombstones, rehash)   | same                          | `MapDelSlow` |
+| Opcode      | Phase 1.5            | Phase 2 fast path                                                                                |
+|-------------|----------------------|--------------------------------------------------------------------------------------------------|
+| `OpNewMap`  | deopt to interpreter | -                                                                                                |
+| `OpMapLen`  | deopt to interpreter | ~6 (deref `*vmMap`, load `Len`) - allocation-free, stays in JIT                                  |
+| `OpMapGet`  | deopt to interpreter | ~12 (hash, probe loop with 1 unroll, int48 key); collision-overflow path deopts                  |
+| `OpMapHas`  | deopt to interpreter | ~10 (same probe, return boolean)                                                                 |
+| `OpMapSet`  | deopt to interpreter | ~14 in steady state (probe + write, no growth); growth and rehash deopt                          |
+| `OpMapDel`  | deopt to interpreter | -                                                                                                |
 
-The probe loop is unrolled exactly once. The interpreter walks the probe loop in a fast Go loop ([MEP-29 measurement: 5-9 ns/op](/docs/mep/mep-0029)); the JIT's unroll-once advantage is small (~1.5x) for hot lookups and zero for misses. Predicted: **1.5-2x** on `maps/fill_probe`.
+The probe loop is unrolled exactly once. The interpreter walks the probe loop in a fast Go loop ([MEP-29 measurement: 5-9 ns/op](/docs/mep/mep-0029)); the JIT's unroll-once advantage is small for hot lookups and zero for misses.
+
+Phase 1.5 prediction: **~1.0x** on `maps/fill_probe` (fill phase deopts on `OpNewMap` then runs the loop interpreted). Phase 2 prediction: **1.2-1.5x** on `maps/keys` (read-only iteration stays in JIT); fill-and-grow workloads stay near parity since the allocator dominates.
 
 ### Set opcodes
 
-Sets reuse the map's open-addressing infrastructure ([MEP-29 §Sets](/docs/mep/mep-0029)). The JIT templates are identical to map templates with the value-slot writes elided. The set spec lands first (interpreter); this MEP commits the JIT templates as a mechanical derivation.
+Sets reuse the map's open-addressing infrastructure ([MEP-29 §Sets](/docs/mep/mep-0029)). The JIT templates are identical to map templates with the value-slot writes elided, and the deopt boundaries are the same: allocation deopts, steady-state membership and iteration stay in JIT post-Phase-2. The set spec lands first (interpreter); this MEP commits the JIT templates as a mechanical derivation.
 
-Predicted: **same as maps**, 1.5-2x.
+Phase 1.5 prediction: parity. Phase 2 prediction: same as maps (~1.2-1.5x on read-heavy workloads).
 
 ### Struct opcodes
 
-Structs are flat tuples of `Cell`s with a shape tag ([MEP-24 §5](/docs/mep/mep-0024)). The shape tag is a `uint32` cached on the struct header. Field access is `tag-check ptr; deref; load [base + 8*idx]`. The JIT emits a per-field fast path; the slow path is the interpreter, which itself almost never falls through to anything slower since structs don't grow.
+Structs are flat tuples of `Cell`s with a shape tag ([MEP-24 §5](/docs/mep/mep-0024)). The shape tag is a `uint32` cached on the struct header. Structs are the friendliest collection type for the JIT: shape is fixed at allocation, so reads and writes are pure pointer arithmetic with no growth path.
 
-| Opcode             | Fast path (instrs) | Slow path                  |
-|--------------------|--------------------|----------------------------|
-| `OpNewStruct`      | always slow        | `NewStructSlow` (allocator) |
-| `OpStructGet`      | ~7                 | -                           |
-| `OpStructSet`      | ~6 if no GC barrier, ~10 with | shared-heap-write → `StructSetSlow` |
-| `OpStructTagCheck` | ~4                 | -                           |
-| `OpStructLen`      | constant from shape, ~2 instrs | - |
-| `OpStructEqual`    | ~12 (shape-check + memcmp for small structs, ≤32 bytes) | larger / nested → `StructEqualSlow` |
+| Opcode             | Phase 1.5            | Phase 2 fast path                                                                |
+|--------------------|----------------------|----------------------------------------------------------------------------------|
+| `OpNewStruct`      | deopt to interpreter | -                                                                                |
+| `OpStructGet`      | deopt to interpreter | ~7 instrs (tag-check, deref, indexed load) - allocation-free                     |
+| `OpStructSet`      | deopt to interpreter | ~6 instrs (no GC barrier) / ~10 (with barrier on shared-heap write)              |
+| `OpStructTagCheck` | deopt to interpreter | ~4 instrs                                                                        |
+| `OpStructLen`      | deopt to interpreter | constant from shape, ~2 instrs                                                   |
+| `OpStructEqual`    | deopt to interpreter | ~12 instrs (shape-check + memcmp for ≤32 bytes); larger or nested deopts         |
 
-Predicted: **2-3x** on `structs/fill_field` (analog of `lists/fill_sum` for structs); **1.5-2x** on `structs/equal_loop`.
+Phase 1.5 prediction: parity (any `OpNewStruct` deopts the function). Phase 2 prediction: **2-3x** on `structs/fill_field` and **1.5-2x** on `structs/equal_loop` once allocation can be done up-front and the loop body stays in JIT.
 
 ### Calls and returns
 
-The JIT handles the four call opcodes uniformly:
+Calls touch `vm.Frames` (an `append`-grown slice) and `vm.Stack` (a `make`-grown slice). Both can reallocate, both reside on the Go heap, both need GC visibility. Under the deopt protocol all of `OpCall` / `OpTailCall` deopt in Phase 1.5; only the intra-function self-tail and the function's own `OpReturn` stay in JIT.
 
-- **`OpCall`**: marshal the argument cells (already in the right slots, see frame-compat), bump `IP`, push a `Frame` onto `vm.Frames`, either jump to the callee's compiled code or fall back to the interpreter trampoline.
-- **`OpTailCall`**: same but reuse the current frame's `Stack` slot; no push.
-- **`OpTailCallSelf`**: branch within the current compiled function. Cheapest call shape; ~3 instructions.
-- **`OpReturn`**: write `regs[A]` to the caller frame's `RetReg`, pop the frame, branch to the caller's resume PC. If the caller is JIT'd, this is an indirect branch; if interpreted, a return to the interpreter trampoline.
+| Opcode            | Phase 1.5            | Phase 2 fast path                                                                 |
+|-------------------|----------------------|-----------------------------------------------------------------------------------|
+| `OpCall`          | deopt to interpreter | -                                                                                 |
+| `OpTailCall`      | deopt to interpreter | -                                                                                 |
+| `OpTailCallSelf`  | inline JIT branch    | inline JIT branch (~3 instrs, no frame manipulation)                              |
+| `OpReturn`        | inline JIT epilogue  | inline JIT epilogue (~3 instrs, returns sentinel-or-value to wrapper)             |
 
-The frame push/pop is the single most expensive non-allocation opcode in the JIT (predicted ~20 instructions). Tier-2's planned wins (inlining, frame fusion) are deferred per scope.
+Phase 3 may revisit `OpCall` to a JIT'd callee by emitting a JIT-to-JIT call using the same stack-allocated jitFrame layout the trampoline uses; this avoids the `vm.Frames` `append` entirely on the call path. Whether it pays for itself depends on whether enough call sites land on stably-JIT-compiled callees. Out of scope for this MEP.
+
+`OpTailCallSelf` is the JIT's flagship call shape: recursive functions written as tail recursion (the recommended Mochi idiom for loops over disjoint cases) compile to a single in-function branch and never touch `vm.Frames`. This is what makes `arith/fib_rec`-style benchmarks competitive with iterative Go.
 
 ### Arithmetic and control flow
 
@@ -243,14 +313,16 @@ Two backends, written in parallel, sharing one mid-level opcode-to-template tabl
 ```
 runtime/jit/vm2jit/
   arch/
-    arm64/      asm encoders, per-opcode lowerings, syscalls
+    arm64/      asm encoders, per-opcode lowerings, deopt stub emitter
     amd64/      same, with Linux-flavored mmap and W^X
   templates/    arch-agnostic per-vm2-opcode lowerings (one file per category)
-  runtime/      slow-path Go shims (NewListSlow, MapGetSlow, ...)
+  deopt/        sentinel encoding/decoding, interpreter-resume wrapper
   trampoline/   pure-Go `.s` trampolines for cross-tier calls
   compile.go    the per-Function compiler driver
   cache.go      the executable code cache (shared mmap pool)
 ```
+
+Note that there is no `runtime/` subpackage of Go slow-path shims in the revised design. Opcode-specific runtime work happens in `runtime/vm2/` (the interpreter), reached only via deopt-and-resume, never via direct call from JIT code.
 
 The AArch64 backend reuses the MEP-30 encoders ([`runtime/jit/tmpljit/emit_arm64.go`](https://github.com/mochilang/mochi/blob/main/runtime/jit/tmpljit/emit_arm64.go)). The AMD64 backend writes its own encoders; the encoding table for the opcode subset the JIT needs is ~40 entries, ~200 lines of Go.
 
@@ -260,29 +332,29 @@ The MEP-30 prototype calls JIT'd code via cgo. **The production JIT must not.** 
 
 ### Engineering phases
 
-Three sequential phases. Each phase has its own merged-MEP measured-results follow-on (analogous to MEP-33 for MEP-30).
+The revised phasing reflects the deopt model. **Phase 1** (arithmetic, control flow, Move, Return) is already merged; per-loop speedup of 5-8x measured (§[Appendix A](#appendix-a-phase-1-measured-results)). The remaining phases:
 
-**Phase 1: arithmetic + lists + calls** (estimated 4-6 engineer-weeks)
+**Phase 1.5: deopt protocol + universal opcode coverage** (estimated 1-2 engineer-weeks)
 
-- Scaffold `runtime/jit/vm2jit/`, both arches.
-- All arithmetic / comparison / control-flow / call / return opcodes.
-- List opcodes plus the `NewListSlow` and `ListPushSlow` shims.
-- Pure-Go trampoline on both arches.
-- Benchmark gate: `lists/fill_sum`, `lists/sum`, `arith/fib_iter` vs interpreter. ≥1.5x on each, no regression.
+- Implement the deopt sentinel encoding in `runtime/vm2/cell.go` and a `deopt.Decode(Cell) (pc int, ok bool)` helper.
+- Implement the interpreter-resume wrapper in `runtime/jit/vm2jit/`: read the JIT return, branch on sentinel, set `frame.IP = pc` and call `vm.runInterp(frame)` to finish the function.
+- Implement a deopt-stub emitter in `lower_arm64.go`: for any unsupported opcode, spill live JIT regs to the register file and return the sentinel-tagged PC.
+- Wire every non-arithmetic, non-control-flow, non-Move, non-Return opcode to the deopt stub. The function may still be compiled (and benefit from JIT'd arithmetic up to the first deopt point), but lists/strings/maps/sets/structs/calls all deopt.
+- Benchmark gate: arithmetic loops stay at 5-8x; all MEP-23 list/string/map/set/struct/call workloads stay within 5% of interpreter baseline (i.e., the deopt round-trip cost is small enough to be invisible).
 
-**Phase 2: strings + maps** (estimated 3-5 engineer-weeks)
+**Phase 2: allocation-free fast paths** (estimated 4-6 engineer-weeks)
 
-- String opcodes with inline + heap fused fast paths.
-- Map opcodes with int48 + interned-string key fast paths.
-- Benchmark gate: `strings/concat_loop`, `strings/equal_loop`, `maps/fill_probe`, `maps/keys` vs interpreter, LuaJIT, Lua 5.5, CPython 3.14.
+- Lift the read-only opcodes (`OpListLen`, `OpListGet`, `OpListSet` no-grow, `OpLenStr`, `OpIndexStr`, `OpEqualStr`, `OpMapLen`, `OpMapGet`, `OpMapHas`, `OpStructGet`, `OpStructSet`, `OpStructLen`, `OpStructTagCheck`, `OpStructEqual`) to inline JIT fast paths. Each fast path is straight-line code with deopt on any unhappy path (bounds-fail, growth-needed, type-mismatch).
+- Set opcodes ride along (mechanical from maps).
+- Benchmark gate: `lists/sum`, `strings/equal_loop`, `maps/keys`, `structs/fill_field` reach 1.5x or better vs interpreter; allocation-bound workloads stay near parity.
 
-**Phase 3: sets + structs** (estimated 2-3 engineer-weeks)
+**Phase 3 (optional): in-JIT allocation** (estimated 4-8 engineer-weeks)
 
-- Set opcodes (mechanical derivation from maps).
-- Struct opcodes once `runtime/vm2/struct*.go` exists ([MEP-24 §5](/docs/mep/mep-0024) gates this).
-- Benchmark gate: full MEP-23 corpus head-to-head.
+- Investigate `runtime.systemstack`-style allocation from JIT code for the small-allocation opcodes (`OpNewList` with small cap, `OpConcatStr` for inline result, `OpNewStruct`).
+- Investigate JIT-to-JIT direct call to avoid `vm.Frames` `append` on the hot path.
+- Decision gate: each candidate ships only if its measured speedup vs Phase 2 deopt is at least 1.3x on the relevant workload. Otherwise the deopt path is fast enough and we don't add code.
 
-**Total**: ~10-14 engineer-weeks, ~5 KLOC of Go, plus the assembly trampolines. Substantially less than MEP-32 (~25 KLOC) because no IR, no register allocator, no deopt protocol.
+**Total** (Phase 1.5 + Phase 2): ~5-8 engineer-weeks, ~2 KLOC of Go, on top of merged Phase 1. Phase 3 is unscoped and conditional.
 
 ## Benchmark plan
 
@@ -328,19 +400,22 @@ The numbers land in a new Informational MEP, analogous to [MEP-33](/docs/mep/mep
 
 ## Risks
 
-1. **Slow-path callout overhead dominates on allocation-heavy workloads**. The JIT cannot beat the allocator. Mitigation: explicit per-workload prediction in the spec ([List opcodes](#list-opcodes), [String opcodes](#string-opcodes)) so the merge gate's "no regression" rule has room. Allocation-heavy paths should land at parity with the interpreter, not at speedup.
-2. **W^X policy differences between darwin and linux**. macOS arm64 requires `pthread_jit_write_protect_np`; linux/amd64 wants `PROT_READ|PROT_WRITE` flips around the page write. The MEP-30 prototype handles macOS; the production JIT must abstract this into `runtime/jit/vm2jit/arch/{arm64,amd64}/page.go`.
-3. **Frame-format drift between interpreter and JIT**. The contract in §[Frame compatibility](#frame-compatibility) is the most subtle correctness hazard. Mitigation: a single Go struct (`type Frame struct { ... }`) shared between both sides; any field reorder must update both lowerings or fail a compile-time assertion.
-4. **MEP-19 quickening coverage drives JIT win size**. The JIT's tag-check fast path is good but pays 2 instructions per untyped op. Workloads that the quickening pass misses look slower than expected. Mitigation: instrument the JIT to report per-call quickening coverage in the MEP-35 results; if coverage is below 80% on the corpus, file follow-on MEP-19 work.
-5. **Goroutine preemption check granularity**. Too frequent costs the JIT its loop-tightness advantage; too rare risks scheduler stalls. Mitigation: emit one check per back-edge in v1, measure, tune in MEP-35.
-6. **Single-binary distribution**. The MEP-30 spec required this; this MEP inherits the constraint. The pure-Go `.s` trampoline is the only acceptable cross-tier call mechanism; cgo is forbidden after the prototypes.
+1. **Deopt frequency dominates speedup on allocation-heavy workloads.** A loop that allocates every iteration spends most of its time in the interpreter, with the JIT contributing only the arithmetic between deopt points. The honest read is that the JIT does not speed up such loops; it lands at parity. Mitigation: explicit per-workload predictions in §[List/String/Map/Set/Struct opcodes](#list-opcodes). The merge gate is "no regression", not "speedup on every workload".
+2. **The deopt protocol itself becomes the bug surface.** Sentinel encoding, live-reg spill list, IP synchronization, and re-entry safepoints have to agree between JIT and interpreter. Mitigation: keep the protocol minimal (one sentinel encoding, one spill convention, no mid-function re-entry in v1); add a `deopt_test.go` that fuzzes JIT-deopt-interpret-finish for every opcode.
+3. **W^X policy differences between darwin and linux.** macOS arm64 requires `pthread_jit_write_protect_np`; linux/amd64 wants `PROT_READ|PROT_WRITE` flips around the page write. The MEP-30 prototype handles macOS; the production JIT must abstract this into `runtime/jit/vm2jit/arch/{arm64,amd64}/page.go`.
+4. **Frame-format drift between interpreter and JIT.** The contract in §[Frame compatibility](#frame-compatibility) is the most subtle correctness hazard, especially across deopt boundaries where the interpreter picks up state the JIT just spilled. Mitigation: a single Go struct (`type Frame struct { ... }`) shared between both sides; any field reorder must update both lowerings or fail a compile-time assertion.
+5. **MEP-19 quickening coverage drives JIT win size.** The JIT's tag-check fast path is good but pays 2 instructions per untyped op. Workloads the quickening pass misses look slower than expected. Mitigation: instrument the JIT to report per-call quickening coverage in the MEP-35 results; if coverage is below 80% on the corpus, file follow-on MEP-19 work.
+6. **Goroutine preemption check granularity.** Too frequent costs the JIT its loop-tightness advantage; too rare risks scheduler stalls. Under the deopt model the simplest answer is "every deopt point is a safepoint" plus a per-back-edge check; measure in MEP-35, tune if needed.
+7. **Single-binary distribution.** The MEP-30 spec required this; this MEP inherits the constraint. The pure-Go `.s` trampoline is the only acceptable cross-tier call mechanism; cgo is forbidden after the prototypes.
+8. **Phase 3 chases diminishing returns.** Once read paths are in JIT, the remaining headroom is allocation, which requires `runtime.systemstack` tricks or escape analysis (a tier-2 problem). Phase 3 is explicitly conditional on measured headroom, not a deliverable.
 
 ## Open questions
 
-- **Where does the `runtime.gcWaitOnPreempt`-analog primitive live?** Go's `morestack` check is not exposed. The team should propose either (a) a `runtime/internal/preempt` package for the JIT to call, or (b) inline the preempt check using the same atomic-load pattern Go's runtime uses. Either way, the merge gate is "no goroutine starvation under stress test".
-- **How does the JIT cache survive across `vm2.Function` reloads in a long-running process (e.g. a Mochi server)?** The simplest answer: per-Function compiled-code pointer, lifetime tied to the Function. The trickier answer: cross-Function code sharing for common templates. Defer the trickier answer.
-- **Should set opcodes land in vm2 before the JIT compiles them, or alongside?** The author's preference is "vm2 first, then JIT in Phase 3"; this keeps the JIT a strict translation rather than a co-design. Confirm with the MEP-29 owners.
-- **AMD64 register pressure**. AArch64 has 30 GPRs; AMD64 has 14 useable. The JIT's per-opcode templates compile cleanly on both, but a future tier-2 MEP-32 will need an actual register allocator for AMD64. Spec is fine; allocator is post-this-MEP.
+- **Where does the goroutine preemption check live, and at what granularity?** Go's `morestack` check is not exposed and is unsafe for JIT code anyway (see §[Phase 1.5 post-mortem](#phase-15-post-mortem-why-blr-into-go-failed)). The deopt model gives an easy answer: every deopt point is implicitly a safepoint, since the wrapper resumes the interpreter, which honors preemption normally. Open question is whether we also need a per-back-edge atomic-load preemption check for tight all-JIT loops, or whether deopt-on-overflow at a slow path is sufficient.
+- **Re-entry strategy after deopt.** v1 does not re-enter the JIT mid-function (once deopted, the function finishes interpreted). Phase 2 may add re-entry at function-entry safepoints; full mid-function re-entry would require a JIT entry table keyed by PC, which is the same machinery a tier-2 deopt-into-tier-1 reverse path needs. Defer.
+- **JIT cache lifetime across long-running processes.** Per-Function compiled-code pointer is the simplest answer, lifetime tied to the Function. Cross-Function code sharing for common templates is appealing but unscoped; defer to Phase 3 or later.
+- **Should `OpNewList` with a known small constant cap deopt, or compile?** The JIT could materialize a small list inline using stack-allocated backing storage (since lists are escape-analysis-friendly when scope is bounded), but this requires teaching the JIT about lifetime. Out of scope for Phase 1.5/2; revisit in Phase 3 with measured headroom.
+- **AMD64 register pressure.** AArch64 has 30 GPRs; AMD64 has 14 useable. The JIT's per-opcode templates compile cleanly on both, but a future tier-2 MEP-32 will need an actual register allocator for AMD64. The deopt spill list is shorter on AMD64 (fewer regs to spill) so the deopt-stub size is similar. Spec is fine; allocator is post-this-MEP.
 
 ## Comparison with the three JIT options
 
@@ -350,30 +425,34 @@ The three options ([MEP-30](/docs/mep/mep-0030), [MEP-31](/docs/mep/mep-0031), [
 |-----------------------|--------------------------------------------------|------------------------------|------------------------------|------------------------------|
 | Scope                 | full vm2 opcode set                              | 6-opcode toy                 | hot loops (recorded)         | full vm2 + tier-2 opt         |
 | Tier                  | tier 1 only                                      | tier 1 (prototype)           | tier 2 (orthogonal)          | tier 1 + tier 2              |
-| Coverage              | lists, strings, maps, sets, structs              | arith only                   | depends on workload          | this MEP + IR optimizations  |
-| Engineering           | 10-14 weeks                                      | done (afternoon)             | 12+ months                   | 18+ months                   |
-| Predicted speedup     | 1.5-3x broad; 3-6x on numeric loops              | 17x on toy bytecode          | 5-15x on loops, abort risk   | 4-8x broad                   |
+| Coverage              | inline arith/control/move/return; deopt for      | arith only                   | depends on workload          | this MEP + IR optimizations  |
+|                       | allocating ops; Phase 2 adds read-only fast paths|                              |                              |                              |
+| Engineering (remaining)| 5-8 weeks (Phase 1.5 + Phase 2)                 | done (afternoon)             | 12+ months                   | 18+ months                   |
+| Predicted speedup     | 5-8x on arith (measured); 1.5-2x on read-heavy   | 17x on toy bytecode          | 5-15x on loops, abort risk   | 4-8x broad                   |
+|                       | post-Phase-2; parity on alloc-heavy              |                              |                              |                              |
 
 ## Predicted MEP-23 numbers
 
-Calibrated against the [MEP-33](/docs/mep/mep-0033) prototype's measured 17x on `fillsum` and the per-category fast-path lengths above. All numbers are ns/op at N=1024 on Apple M4, vm2-with-this-JIT, predicted:
+Predictions split by phase. Phase 1 numbers are measured (§[Appendix A](#appendix-a-phase-1-measured-results)). Phase 1.5 numbers assume the deopt round-trip is ~20-30 ns; Phase 2 numbers assume inline read-path templates execute at MEP-30-prototype-comparable speed. All numbers are ns/op at N=1024 on Apple M4, predicted unless marked measured:
 
-| Workload                  | vm2 (now) | vm2 + JIT (predicted) | LuaJIT 2.1 | Predicted JIT/LuaJIT ratio |
-|---------------------------|-----------|----------------------|------------|----------------------------|
-| `arith/fib_iter`          | 3500      | 700                  | 600        | 1.17x                      |
-| `lists/fill_sum`          | 6000      | 2500                 | 1200       | 2.08x                      |
-| `lists/sum`               | 2200      | 600                  | 700        | 0.86x                      |
-| `strings/concat_loop`     | 8000      | 3200                 | 2500       | 1.28x                      |
-| `strings/equal_loop`      | 1800      | 500                  | 400        | 1.25x                      |
-| `maps/fill_probe`         | 11000     | 5500                 | 4000       | 1.38x                      |
-| `maps/keys`               | 3500      | 2000                 | 1800       | 1.11x                      |
-| `sets/fill_probe`         | 11500     | 5800                 | -          | -                          |
-| `structs/fill_field`      | 2400      | 800                  | -          | -                          |
-| `structs/equal_loop`      | 1300      | 600                  | -          | -                          |
+| Workload                  | vm2 (now) | + Phase 1.5 | + Phase 2 | LuaJIT 2.1 | Phase 2 / LuaJIT |
+|---------------------------|-----------|-------------|-----------|------------|------------------|
+| `arith/fib_iter`          | 3500      | 700 (meas)  | 700       | 600        | 1.17x            |
+| `lists/fill_sum`          | 6000      | 6000        | 5000      | 1200       | 4.17x            |
+| `lists/sum`               | 2200      | 2200        | 600       | 700        | 0.86x            |
+| `strings/concat_loop`     | 8000      | 8000        | 8000      | 2500       | 3.20x            |
+| `strings/equal_loop`      | 1800      | 1800        | 800       | 400        | 2.00x            |
+| `maps/fill_probe`         | 11000     | 11000       | 11000     | 4000       | 2.75x            |
+| `maps/keys`               | 3500      | 3500        | 2000      | 1800       | 1.11x            |
+| `sets/fill_probe`         | 11500     | 11500       | 11500     | -          | -                |
+| `structs/fill_field`      | 2400      | 2400        | 1000      | -          | -                |
+| `structs/equal_loop`      | 1300      | 1300        | 600       | -          | -                |
 
-The honest read: **JIT closes the gap to LuaJIT to ~1.2-1.4x on most workloads, beats it on the pure-int subset, lags on string concat (LuaJIT's rope allocator is more mature)**. The CPython 3.14 ratios will be in the 8-25x range across the board, consistent with [MEP-33](/docs/mep/mep-0033).
+The honest read: **Phase 1.5 ships parity-or-faster on every workload (arithmetic improves, others stay flat). Phase 2 brings the read-heavy workloads into 0.85-2x of LuaJIT. The allocation-bound workloads (`fill_sum`, `fill_probe`, `concat_loop`) stay near interpreter speed without tier-2; that is the honest limit of a non-IR JIT.**
 
-If Phase 3 numbers fall short of these by more than 30%, the failure modes and remediations should be the explicit subject of the MEP-35 reporting and may motivate funding MEP-32 sooner than planned.
+The CPython 3.14 ratios will be in the 8-25x range across the board, consistent with [MEP-33](/docs/mep/mep-0033).
+
+If Phase 2 numbers fall short of these by more than 30%, the failure modes and remediations should be the explicit subject of the MEP-35 reporting and may motivate funding MEP-32 sooner than planned.
 
 ## Related work
 
@@ -388,17 +467,20 @@ If Phase 3 numbers fall short of these by more than 30%, the failure modes and r
 
 ## Files to add (provisional)
 
-- `runtime/jit/vm2jit/doc.go`, package overview.
-- `runtime/jit/vm2jit/compile.go`, per-Function compiler driver.
-- `runtime/jit/vm2jit/cache.go`, executable code cache.
-- `runtime/jit/vm2jit/templates/{arith,control,call,list,string,map,set,struct}.go`, one file per opcode category.
-- `runtime/jit/vm2jit/arch/arm64/{encode.go,page.go}`, AArch64 backend.
-- `runtime/jit/vm2jit/arch/amd64/{encode.go,page.go}`, AMD64 backend.
-- `runtime/jit/vm2jit/runtime/{list_slow.go,string_slow.go,map_slow.go,set_slow.go,struct_slow.go,call_slow.go}`, Go slow-path shims.
-- `runtime/jit/vm2jit/trampoline/{trampoline_arm64.s,trampoline_amd64.s,trampoline.go}`, pure-Go cross-tier call.
-- `runtime/jit/vm2jit/vm2jit_test.go` plus per-category test files.
+Files already merged from Phase 1 are shown in *italics*. Files added by Phase 1.5 are **bold**. Phase 2 adds the remaining per-category template files.
+
+- *`runtime/jit/vm2jit/doc.go`*, package overview.
+- *`runtime/jit/vm2jit/compile.go`*, per-Function compiler driver.
+- *`runtime/jit/vm2jit/cache.go`*, executable code cache.
+- *`runtime/jit/vm2jit/lower_arm64.go`*, AArch64 lowering for arithmetic/control/move/return.
+- *`runtime/jit/vm2jit/trampoline/{trampoline_arm64.s,trampoline.go}`*, pure-Go cross-tier call.
+- **`runtime/jit/vm2jit/deopt/{sentinel.go,resume.go}`**, sentinel encoding + interpreter-resume wrapper.
+- **`runtime/jit/vm2jit/lower_deopt_arm64.go`**, deopt stub emitter (one stub shape, parameterised by spill list and PC).
+- `runtime/jit/vm2jit/lower_arm64_lists.go` etc., Phase 2 per-category inline templates (one file per category).
+- `runtime/jit/vm2jit/arch/amd64/{encode.go,page.go,lower.go}`, AMD64 backend (Phase 2 or later).
+- `runtime/jit/vm2jit/vm2jit_test.go` plus per-category test files, plus `deopt_test.go` fuzzing JIT-deopt-interpret-finish.
 - `runtime/jit/vm2jit/bench/`, microbenches and MEP-23 corpus harness.
-- `website/docs/mep/mep-0035.md`, the measured-results MEP (lands with Phase 3).
+- `website/docs/mep/mep-0035.md`, the measured-results MEP (lands with Phase 2).
 
 ## Appendix A: Phase 1 Measured Results
 
@@ -443,14 +525,12 @@ One-shot calls: prologue + one opcode + epilogue, called once per benchmark iter
 
 All five cluster at 30-32 ns, confirming flat per-opcode cost. The arithmetic opcodes are bounded by the NaN-box unpack/repack sequence (sbfx + and + op + and + movz + orr = 6 AArch64 instructions), not the operation itself.
 
-### A.4 Phase 1 scope and what is deferred
+### A.4 Phase 1 scope, the failed Phase 1.5 attempt, and the pivot
 
-Phase 1 covers arithmetic, control flow, Move, and Return. Two items are deferred to Phase 1.5:
+Phase 1 covers arithmetic, control flow, Move, and Return. The pure-Go `.s` trampoline shipped during Phase 1, replacing the prototype's CGo wrapper.
 
-**List opcodes**: OpNewList, OpListLen, OpListGet, OpListSet, OpListPush require access to `*vm.VM` (for the Objects table). The current JIT ABI receives only `*Cell`; adding the VM pointer requires an ABI extension or a slow-path shim infrastructure that has not been built yet.
+An initial Phase 1.5 attempt added inline lowerings for the five list opcodes that called the corresponding `runtime/vm2.JIT*List*` Go functions from JIT code via `BLR`. This attempt is documented in §[Phase 1.5 post-mortem](#phase-15-post-mortem-why-blr-into-go-failed); briefly, it crashed in three independent ways (R19 clobber by `nanotime_trampoline`, JIT frame absence from `pclntab`, and `morestack`-induced spill corruption) and the design is structurally unfixable in Go. The work was reverted.
 
-**Pure-Go trampoline**: the `runtime/jit/vm2jit/trampoline` package currently uses CGo. The production trampoline (`.s` file, no cgo) is required before Phase 1.5 benchmarks are published, per the merge gate in §[Trampoline](#trampoline-cgo-replacement).
-
-Neither deferral affects the loop-body speedup numbers above: both are call-boundary costs, already visible in the per-opcode microbenchmarks and already amortized in the loop results.
+The revised Phase 1.5 design, captured in §[Deoptimization protocol](#deoptimization-protocol), replaces in-place Go callouts with a deopt-and-resume mechanism. The arithmetic loop-body speedup numbers above are unaffected, as they never depended on calling into Go from JIT code.
 
 The Phase 1 results of **5-8x on arithmetic loops exceed the predicted 3-6x** range in §[Predicted MEP-23 numbers](#predicted-mep-23-numbers) and clear the ≥1.5x Phase 1 benchmark gate with substantial margin.


### PR DESCRIPTION
## Summary
- Implements the MEP-34 Phase 1.5 deopt protocol that replaces the failed "BLR into Go" approach (see MEP Appendix A.4).
- The JIT never calls into Go in place. Instead, opcodes that touch the allocator or the Objects table compile to a deopt stub: spill live regs, return a sentinel-tagged Cell. The wrapper promotes the JIT register file to a real vm2 frame and resumes the interpreter at the failing PC via the new re-entrant `RunTopFrame` entry point.
- Pure-Go `.s` trampoline replaces the prior CGo bridge on darwin/arm64.

## Why
The prior in-place slow-path crashed inside the goroutine runtime in three independent ways on the first `OpNewList` test (R19 clobber, JIT-frame-not-in-pclntab, morestack spill corruption). The deopt model sidesteps all three by ensuring the JIT body is leaf code from Go's perspective.

## Test plan
- [x] `go build ./...`
- [x] `go test ./runtime/jit/vm2jit/...` — all green, including new `TestJITDeoptResume` end-to-end smoke test (native AddI64K + deoptable OpNewList + interpreter resume)
- [x] `go test ./runtime/vm2/...` — all green; refactored `runLoop(target int)` keeps Run() semantics

## Follow-up
Phase 2 (inline allocation-free fast paths for read-only list/string/map/struct opcodes) is multi-week per the MEP and will land in separate sub-PRs.

Closes #21553.