### PR TITLE
website: refresh MEP-0000 index, add MEP-35, fix mobile drawer

### DIFF
--- a/website/docs/mep/mep-0000.md
+++ b/website/docs/mep/mep-0000.md
@@ -53,6 +53,8 @@ A MEP is the place where we explain what the language does, why it does it that 
 
 The current series covers the soundness initiative for v0.11.0. Numbering follows the PEP convention: four-digit padded MEP numbers, status and type recorded in each file's header.
 
+The status column reflects the *implementation* status against `main`, not the spec drafting status. A MEP that has shipped code in `runtime/vm2`, `compiler2/`, `runtime/jit/`, or `tests/types/` is marked Active; the prose may still be refined. The auto-generated index at `/docs/mep/` mirrors each file's frontmatter, so the source of truth for any single MEP is its own header.
+
 | MEP                     | Title                                  | Status        | Type            |
 |-------------------------|----------------------------------------|---------------|-----------------|
 | [0](/docs/mep/mep-0000) | Index of Mochi Enhancement Proposals   | Active        | Process         |
@@ -60,25 +62,37 @@ The current series covers the soundness initiative for v0.11.0. Numbering follow
 | [2](/docs/mep/mep-0002) | Grammar                                | Informational | Informational   |
 | [3](/docs/mep/mep-0003) | Abstract Syntax Tree                   | Informational | Informational   |
 | [4](/docs/mep/mep-0004) | Type System                            | Informational | Informational   |
-| [5](/docs/mep/mep-0005) | Type Inference                         | Informational | Informational   |
+| [5](/docs/mep/mep-0005) | Type Inference                         | Active        | Standards Track |
 | [6](/docs/mep/mep-0006) | Type Checker                           | Informational | Informational   |
 | [7](/docs/mep/mep-0007) | Soundness                              | Active        | Process         |
 | [8](/docs/mep/mep-0008) | Test Strategy                          | Active        | Process         |
 | [9](/docs/mep/mep-0009) | Fixture Catalogue                      | Informational | Informational   |
 | [10](/docs/mep/mep-0010)| Known Gaps and Weakness Review         | Informational | Informational   |
-| [11](/docs/mep/mep-0011)| Subtyping and Variance                 | Draft         | Standards Track |
-| [12](/docs/mep/mep-0012)| Parametric Polymorphism                | Draft         | Standards Track |
+| [11](/docs/mep/mep-0011)| Subtyping and Variance                 | Active        | Standards Track |
+| [12](/docs/mep/mep-0012)| Parametric Polymorphism                | Active        | Standards Track |
 | [13](/docs/mep/mep-0013)| Algebraic Data Types and Match         | Draft         | Standards Track |
 | [14](/docs/mep/mep-0014)| Query Algebra                          | Informational | Informational   |
 | [15](/docs/mep/mep-0015)| Effects, Mutability, and Purity        | Draft         | Standards Track |
 | [16](/docs/mep/mep-0016)| Null Safety                            | Draft         | Standards Track |
-| [17](/docs/mep/mep-0017)| VM Performance Methodology and Baseline | Draft        | Process         |
-| [18](/docs/mep/mep-0018)| Bytecode Dispatch in a Go-Hosted VM    | Draft         | Standards Track |
-| [19](/docs/mep/mep-0019)| Adaptive Specialization and Inline Caches | Draft      | Standards Track |
-| [20](/docs/mep/mep-0020)| Value Representation and Allocation Discipline | Draft | Standards Track |
-| [21](/docs/mep/mep-0021)| Compiler2 and VM2 Co-Design for Maximum Interpreter Throughput | Draft | Standards Track |
+| [17](/docs/mep/mep-0017)| VM Performance Methodology and Baseline | Active       | Process         |
+| [18](/docs/mep/mep-0018)| Bytecode Dispatch in a Go-Hosted VM    | Active        | Standards Track |
+| [19](/docs/mep/mep-0019)| Adaptive Specialization and Inline Caches | Active     | Standards Track |
+| [20](/docs/mep/mep-0020)| Value Representation and Allocation Discipline | Active | Standards Track |
+| [21](/docs/mep/mep-0021)| Compiler2 and VM2 Co-Design for Maximum Interpreter Throughput | Active | Standards Track |
 | [22](/docs/mep/mep-0022)| Baseline JIT via Copy-and-Patch        | Deferred      | Informational   |
-| [23](/docs/mep/mep-0023)| Cross-language Baseline Benchmarks     | Draft         | Process         |
+| [23](/docs/mep/mep-0023)| Cross-language Baseline Benchmarks     | Active        | Process         |
+| [24](/docs/mep/mep-0024)| VM2 Subsystem Design (Objects, Strings, Structs, Lists, Maps, Closures, GC, Errors) | Active | Standards Track |
+| [25](/docs/mep/mep-0025)| VM2 Data Model (Strings, Lists, Maps, Sets, Structs) | Active        | Standards Track |
+| [26](/docs/mep/mep-0026)| VM2 Data Model Option 1 - Monomorphic + One-Way Migration | Draft | Standards Track |
+| [27](/docs/mep/mep-0027)| VM2 Data Model Option 2 - Polymorphic + Inline Caches | Draft        | Standards Track |
+| [28](/docs/mep/mep-0028)| VM2 Data Model Option 3 - AOT Codegen Specialization | Draft         | Standards Track |
+| [29](/docs/mep/mep-0029)| VM2 Dispatch Strategy - Measured Results | Informational | Informational |
+| [30](/docs/mep/mep-0030)| VM2 JIT Option A - Template / Copy-and-Patch Baseline JIT | Active | Standards Track |
+| [31](/docs/mep/mep-0031)| VM2 JIT Option B - Tracing JIT over Typed Loops | Draft        | Standards Track |
+| [32](/docs/mep/mep-0032)| VM2 JIT Option C - Tiered Method JIT with Type Feedback | Draft  | Standards Track |
+| [33](/docs/mep/mep-0033)| MEP-30 Template JIT - Measured Results | Informational | Informational   |
+| [34](/docs/mep/mep-0034)| VM2 Full-Opcode JIT - Lists, Strings, Maps, Sets, Structs | Active | Standards Track |
+| [35](/docs/mep/mep-0035)| Auto Memory Management for the VM2 Objects Table | Draft     | Standards Track |
 
 ## Workflow
 

--- a/website/docs/mep/mep-0005.md
+++ b/website/docs/mep/mep-0005.md
@@ -2,7 +2,7 @@
 mep: 5
 title: Type Inference
 author: Mochi core
-status: Standards Track
+status: Active
 type: Standards Track
 created: 2026-05-08
 revised: 2026-05-11

--- a/website/docs/mep/mep-0017.md
+++ b/website/docs/mep/mep-0017.md
@@ -2,7 +2,7 @@
 mep: 17
 title: VM Performance Methodology and Baseline
 author: Mochi core
-status: Draft
+status: Active
 type: Process
 created: 2026-05-16
 sidebar_position: 17

--- a/website/docs/mep/mep-0018.md
+++ b/website/docs/mep/mep-0018.md
@@ -2,7 +2,7 @@
 mep: 18
 title: Bytecode Dispatch in a Go-Hosted VM
 author: Mochi core
-status: Draft
+status: Active
 type: Standards Track
 created: 2026-05-16
 sidebar_position: 18

--- a/website/docs/mep/mep-0019.md
+++ b/website/docs/mep/mep-0019.md
@@ -2,7 +2,7 @@
 mep: 19
 title: Adaptive Specialization and Inline Caches
 author: Mochi core
-status: Draft
+status: Active
 type: Standards Track
 created: 2026-05-16
 sidebar_position: 19

--- a/website/docs/mep/mep-0020.md
+++ b/website/docs/mep/mep-0020.md
@@ -2,7 +2,7 @@
 mep: 20
 title: Value Representation and Allocation Discipline
 author: Mochi core
-status: Draft
+status: Active
 type: Standards Track
 created: 2026-05-16
 sidebar_position: 20

--- a/website/docs/mep/mep-0021.md
+++ b/website/docs/mep/mep-0021.md
@@ -2,7 +2,7 @@
 mep: 21
 title: Compiler2 and VM2 Co-Design for Maximum Interpreter Throughput
 author: Mochi core
-status: Draft
+status: Active
 type: Standards Track
 created: 2026-05-16
 sidebar_position: 21

--- a/website/docs/mep/mep-0023.md
+++ b/website/docs/mep/mep-0023.md
@@ -2,7 +2,7 @@
 mep: 23
 title: Cross-language Baseline Benchmarks
 author: Mochi core
-status: Draft
+status: Active
 type: Process
 created: 2026-05-16
 sidebar_position: 23

--- a/website/docs/mep/mep-0024.md
+++ b/website/docs/mep/mep-0024.md
@@ -2,7 +2,7 @@
 mep: 24
 title: VM2 Subsystem Design (Objects, Strings, Structs, Lists, Maps, Closures, GC, Errors)
 author: Mochi core
-status: Draft
+status: Active
 type: Standards Track
 created: 2026-05-16
 sidebar_position: 24

--- a/website/docs/mep/mep-0025.md
+++ b/website/docs/mep/mep-0025.md
@@ -2,7 +2,7 @@
 mep: 25
 title: VM2 Data Model (Strings, Lists, Maps, Sets, Structs)
 author: Mochi core
-status: Draft
+status: Active
 type: Standards Track
 created: 2026-05-16
 sidebar_position: 25

--- a/website/docs/mep/mep-0030.md
+++ b/website/docs/mep/mep-0030.md
@@ -2,7 +2,7 @@
 mep: 30
 title: VM2 JIT Option A - Template / Copy-and-Patch Baseline JIT
 author: Mochi core
-status: Draft
+status: Active
 type: Standards Track
 created: 2026-05-17
 sidebar_position: 30

--- a/website/docs/mep/mep-0034.md
+++ b/website/docs/mep/mep-0034.md
@@ -17,7 +17,7 @@ description: "Production-track spec for the next JIT after the MEP-30 prototype.
 | MEP      | 34                                                                 |
 | Title    | VM2 Full-Opcode JIT - Lists, Strings, Maps, Sets, Structs          |
 | Author   | Mochi core                                                         |
-| Status   | Draft                                                              |
+| Status   | Active                                                             |
 | Type     | Standards Track                                                    |
 | Created  | 2026-05-17                                                         |
 

--- a/website/docs/mep/mep-0035.md
+++ b/website/docs/mep/mep-0035.md
@@ -1,0 +1,364 @@
+---
+mep: 35
+title: Auto Memory Management for the VM2 Objects Table
+author: Mochi core
+status: Draft
+type: Standards Track
+created: 2026-05-17
+sidebar_position: 35
+sidebar_label: MEP 35. Auto Memory Management
+description: "Survey of modern auto memory management (Perceus / Koka / Roc, Inko, Lobster, Verona / Reggio regions, Immix / LXR, MMTk, generational ZGC / Shenandoah, JSC Riptide) and a design overview for reclaiming entries in the vm2 Objects table. Today the table is append-only inside a Run: every list, map, heap string, closure, and boxed big-int allocated by a program stays live until Run exits, regardless of whether the program still references it. This MEP proposes three implementation options (Perceus-style reference counting with reuse, per-frame region arenas, and an Immix / LXR mark-region collector layered over the Objects table) and a recommendation."
+---
+
+# MEP 35. Auto Memory Management for the VM2 Objects Table
+
+| Field    | Value                                            |
+|----------|--------------------------------------------------|
+| MEP      | 35                                               |
+| Title    | Auto Memory Management for the VM2 Objects Table |
+| Author   | Mochi core                                       |
+| Status   | Draft                                            |
+| Type     | Standards Track                                  |
+| Created  | 2026-05-17                                       |
+
+## Abstract
+
+vm2 carries every reference-typed value through an indirection table: `VM.Objects []any` ([runtime/vm2/vm.go:14-26](https://github.com/mochilang/mochi/blob/main/runtime/vm2/vm.go)). A `Cell` with tag `tagPtr` is a 48-bit index into that slice ([runtime/vm2/cell.go:40,83-85,137](https://github.com/mochilang/mochi/blob/main/runtime/vm2/cell.go)). The table is **append-only** for the duration of a Run. There is no reclamation. There is no cycle detection. There is no escape analysis. `popFrame` explicitly defers the work to a future MEP:
+
+> The frame window is sliced off but its contents are NOT zeroed. vm2 has no ptr-tagged Cells yet so there is nothing to un-pin; once the boxed-object subsystem lands, popFrame must zero ptr-tagged slots before shrinking. Tracked in the upcoming subsystem MEP.
+>
+> [runtime/vm2/vm.go:87-99](https://github.com/mochilang/mochi/blob/main/runtime/vm2/vm.go)
+
+That MEP is this one.
+
+The choice is not whether to reclaim. Append-only allocation is a non-starter for any program that touches lists or maps inside a loop. The choice is **how**. This MEP surveys the design space the last five years have produced (Perceus reuse analysis in Koka and Roc, Inko's runtime single ownership, Lobster's compile-time RC elimination, Verona's Reggio region forest, LXR over Immix, MMTk, generational ZGC and Shenandoah, JSC's Riptide), pins down the constraints unique to a Go-hosted VM, and proposes three concrete implementation paths with their measured-or-projected trade-offs.
+
+The Phase 1 deliverable is option 1 (Perceus-style reference counting with compiler-driven RC elision and cycle collection at Run-exit), gated on the [MEP-23](/docs/mep/mep-0023) benchmark corpus and on `allocs/op` and `heap-bytes-retained-at-Run-exit` metrics introduced here.
+
+## Motivation
+
+### What "append-only" costs today
+
+Run this program in vm2:
+
+```mochi
+fun main() {
+  for i in 0..1_000_000 {
+    let xs = [i, i+1, i+2]
+    println(xs[0])
+  }
+}
+```
+
+The loop allocates one `*vmList` per iteration ([runtime/vm2/lists.go:16-28](https://github.com/mochilang/mochi/blob/main/runtime/vm2/lists.go)). Every one of those 1,000,000 lists stays pinned in `vm.Objects` until `Run` returns. Peak heap is `1_000_000 * sizeof(*vmList + backing array)`, even though only one list is reachable at a time from the program's perspective. The Go GC cannot help: every entry in `Objects []any` is a live root for Go.
+
+Three workloads in the [MEP-23](/docs/mep/mep-0023) corpus already trip this: `map_get` builds and discards 32 maps per iteration, `string_cat` accumulates an intern table that never shrinks, and `quicksort_recursive` allocates sublists that the parent overwrites but never frees. The `iter_sum` and `fib_rec` numbers in MEP-30 are clean **only because the numeric fast path never touches Objects**. The minute we benchmark anything container-shaped, the absence of reclamation becomes the dominant cost.
+
+### Why we cannot just lean on Go's GC
+
+The host language is Go and its GC is excellent for Go-shaped programs. It does not help here because the lifetime our users care about is shorter than the lifetime visible to Go: a `*vmList` is reachable through `vm.Objects[i]` as long as the program runs, even if the program will never read index `i` again. We have a precise dependency graph at the bytecode level (the JIT and the type system both know which Cells reference which Objects); Go does not. The job is to *publish* that reachability to a per-VM allocator that runs inside Go's GC but reclaims at vm2's granularity.
+
+### Why this is the right time
+
+Three things changed under us in the last twelve months that make the choice less open than it was when [MEP-20](/docs/mep/mep-0020) deferred this question:
+
+1. **Perceus is no longer research.** Roc ships it. Lean ships it. Koka ships it. The PLDI 2021 paper has been productized for four years and Roc 2024 numbers show Set/List benchmarks within 1.3-2x of C with no GC pauses ([Roc Functional](https://www.roc-lang.org/functional), [Perceus PLDI'21](https://www.microsoft.com/en-us/research/wp-content/uploads/2020/11/perceus-tr-v1.pdf)).
+2. **MMTk reached Ruby 3.4** in January 2025 ([Rails at Scale 2025-01-08](https://railsatscale.com/2025-01-08-new-for-ruby-3-4-modular-garbage-collectors-and-mmtk/)). The modular interface (`VMBinding`) is the first credible way for a small VM to consume a research-grade collector (Immix, LXR, SemiSpace, MarkSweep) without writing one. The cost is the Rust FFI; the benefit is that the GC algorithm becomes a swap-out.
+3. **Generational Shenandoah went production in JDK 25** ([Perf Parlor 2025-09-14](https://theperfparlor.com/2025/09/14/new-in-java25-generational-shenandoah-gc-is-no-longer-experimental/)) and Generational ZGC is the default in JDK 23+. The "pauseless concurrent GC pays back even at small heaps" hypothesis has now been re-checked at scale; the answer is *only above 8 GB*. At vm2's scale (interpreter heap rarely above 1 GB) the right primitive is per-allocation reclamation, not concurrent tracing.
+
+The conclusion that follows from those three is that **reference counting plus reuse analysis is the front-runner for a small register VM in 2026**, not tracing GC. This MEP commits to validating that hypothesis on the MEP-23 corpus before locking it in, hence three options rather than one.
+
+## Background: what we are borrowing from
+
+This section is the deep-research output, condensed. Each subsection ends with the one or two ideas we are taking from that line of work.
+
+### Perceus (Koka, Roc, Lean 4)
+
+Perceus is precise non-deferred reference counting with three compile-time passes that erase most of the runtime cost ([Reinking, Xie, de Moura, Leijen, PLDI 2021](https://www.microsoft.com/en-us/research/wp-content/uploads/2020/11/perceus-tr-v1.pdf)):
+
+- **Precise RC.** Drops are inserted by the compiler at the *exact* last-use point. There is no liveness extension to end-of-scope. Programs are "garbage free" in the sense that an object's refcount hits zero the instant it becomes unreachable.
+- **Reuse analysis.** If a function consumes a unique value of one shape and constructs a value of the same or smaller shape, the compiler rewrites the construction as an in-place mutation of the consumed cell. Koka's `map` over a unique list does zero allocation.
+- **Borrow inference.** Function parameters annotated as borrowed do not get a refcount bump on entry. Most local helpers in Roc compile to zero RC ops because borrow-inference handles the steady state.
+
+Roc's 2024 status: ~95% of RC ops elided by compile-time analysis in Lobster ([Lobster memory management](https://aardappel.github.io/lobster/memory_management.html)); Roc reports comparable elision rates and Set / List benchmarks within 1.3-2x of C ([Roc Functional](https://www.roc-lang.org/functional)). The known weakness is cycles: Roc resolves it by language design (no mutation, no cycles); Koka resolves it with a runtime cycle collector run on demand; Lobster reports cycles at exit ("cycle report") and asks the programmer to break them. Bacon and Rajan's concurrent cycle collector ([ECOOP 2001](https://pages.cs.wisc.edu/~cymen/misc/interests/Bacon01Concurrent.pdf)) is the underlying algorithm.
+
+**What we take:** the Perceus shape (drop at last-use, reuse-on-unique, borrow-on-parameter) is exactly what fits vm2: every container Cell already has a known type tag at JIT compile time ([MEP-34 §Cell tag-check fast paths](/docs/mep/mep-0034)), so the analysis has the information it needs without a whole-program closed-world assumption.
+
+### Inko: runtime single ownership
+
+Inko ([inko-lang.org/papers/ownership.pdf](https://inko-lang.org/papers/ownership.pdf)) gives each value one owner; aliases are runtime-checked borrows. A "unique value" cannot be aliased outside its box and can be sent across processes without copy. Where Rust enforces single ownership at compile time, Inko enforces it at runtime with one extra word per object holding a borrow count; on drop, if the borrow count is non-zero the program aborts.
+
+**What we take:** the *runtime* enforcement story is the right one for a dynamic register VM. The Rust-style "prove single ownership at compile time" story is incompatible with Mochi's reflection / `any` paths.
+
+### Lobster: compile-time RC elimination
+
+Lobster ([Wouter van Oortmerssen, 2019 talk](https://aardappel.github.io/lobster/memory_management.html)) interleaves ownership analysis with type checking. The ownership "kind" is a property of every AST node, not just of variables. Result: 95% of RC ops removed at compile time, cycles reported at exit. Influenced Nim's `--gc:arc`.
+
+**What we take:** the architecture decision that *ownership analysis lives inside the type checker, not as a separate pass*. For Mochi this means `types/check.go` and the soundness work in [MEP-7](/docs/mep/mep-0007) are the right home, not a new analyzer.
+
+### Verona / Reggio: region forest
+
+Verona ([OOPSLA 2023, Cheney et al.](https://arxiv.org/pdf/2309.02983)) organizes all objects into a forest of isolated regions. Each region has a memory-management strategy (trace, RC, arena) chosen per-region. A thread has one "window of mutability" at a time. Region isolation is enforced by a reference-capability type system; regions are reclaimed wholesale when their owning reference is dropped.
+
+**What we take:** the *per-allocation-site strategy* idea. A frame's local lists can live in an arena that dies with the frame; the program's global persistent map cannot. Verona's choice to make strategy a region property rather than a global one is the right abstraction.
+
+### Immix / LXR / MMTk
+
+Immix ([Blackburn & McKinley, PLDI 2008](https://www.steveblackburn.org/pubs/papers/immix-pldi-2008.pdf)) is a mark-region collector: 128-byte lines grouped into 32 KB blocks, allocate bump-pointer inside a block, reclaim at line granularity, opportunistically copy fragmented blocks. LXR ([Zhao, Blackburn, McKinley, PLDI 2022](https://www.steveblackburn.org/pubs/papers/lxr-pldi-2022.pdf)) layers reference counting over Immix: stop-the-world RC pauses (a few ms) reclaim 90%+ of memory without copying; occasional concurrent traces catch cycles. LXR beat ZGC and Shenandoah on the 2022 latency benchmarks while matching G1 throughput.
+
+MMTk ([mmtk.io](https://www.mmtk.io/), [Ruby 3.4 integration 2025-01](https://railsatscale.com/2025-01-08-new-for-ruby-3-4-modular-garbage-collectors-and-mmtk/)) packages Immix, LXR, SemiSpace, MarkSweep, and friends as a Rust library with a `VMBinding` trait. Bindings exist for OpenJDK, V8, Julia, Ruby.
+
+**What we take:** if the RC option underperforms, LXR is the fallback. MMTk gives us LXR (and SemiSpace, MarkSweep, Immix) without writing a collector. The cost is the Rust FFI boundary and a write-barrier on every ptr-tagged Cell store.
+
+### Generational ZGC, Shenandoah, JSC Riptide
+
+The big concurrent collectors ([Java 25 ZGC](https://andrewbaker.ninja/2025/12/03/deep-dive-pauseless-garbage-collection-in-java-25/), [WebKit Riptide](https://webkit.org/blog/12967/understanding-gc-in-jsc-from-scratch/)) are engineered for heaps in the 8 GB to multi-TB range. Their constant overhead (write barriers, colored pointers in ZGC, Brooks pointers in Shenandoah, conservative root scanning in JSC) is meaningful on small heaps. Riptide's "logical versioning" trick (bump a global version rather than physically clearing mark bits) is interesting and cheap; the rest of the bag of tricks is sized wrong for vm2.
+
+**What we take:** logical versioning for mark bits, in option 3. Nothing else.
+
+### Escape analysis: PLDI 2024 and OOPSLA 2024
+
+"Optimistic Stack Allocation and Dynamic Heapification" ([PLDI 2024](https://dl.acm.org/doi/full/10.1145/3656389)) and MEA2 ([OOPSLA 2024](https://2024.splashcon.org/details/splash-2024-oopsla/102/)) advance the state of the art on stack-promoting heap allocations in managed runtimes. The PLDI'24 idea: do a precise *static* escape analysis offline, JIT-compile with optimistic stack allocation, and have the JIT and interpreter perform *dynamic heapification* (copy the stack object to the heap and rewrite references) when an optimistic assumption is invalidated.
+
+**What we take:** the dynamic-heapification escape valve, in option 2 (regions). It is the answer to "what happens when an allocation outlives the frame we put it in".
+
+### Summary table
+
+| System | Mechanism | Cycle handling | Strength | Weakness |
+|--------|-----------|----------------|----------|----------|
+| Perceus / Koka / Roc | Precise RC + reuse + borrow | Cycle collector or by-design | Predictable, allocation-free hot paths | Atomic RC for shared, cycle cost |
+| Inko | RC + runtime borrow check | Single ownership rules out | Deterministic destructors, simple model | Aborts on borrow violation |
+| Lobster | RC + compile-time elision | Reported at exit | 95% RC ops gone, simple | Cycles leak silently |
+| Verona / Reggio | Per-region strategy | Per-region | Mixes arena + RC + trace | Type system complexity |
+| LXR / Immix | Mark-region + opportunistic copy | Concurrent trace | Throughput rivals G1, ms pauses | Write barrier, MMTk FFI |
+| ZGC / Shenandoah | Concurrent copy, colored / Brooks ptrs | Trace | Pauseless at TB heaps | Overweight at MB heaps |
+| JSC Riptide | Non-compacting concurrent mark | Trace | Conservative roots, logical versioning | Conservative roots are imprecise |
+
+## Constraints unique to vm2
+
+Before laying out options, the constraints that filter them:
+
+1. **Host is Go.** Anything we allocate lives in Go's heap. The Go GC must remain able to scan our objects; otherwise we get use-after-free at the next concurrent mark. This rules out `unsafe.Pointer`-based bit-stealing for object payloads. See [MEP-20 §"Why not NaN boxing in Go"](/docs/mep/mep-0020) for the analogous Cell argument.
+2. **Cells are 8 bytes and NaN-boxed.** A ptr-tagged Cell is a 48-bit table index, not a pointer ([runtime/vm2/cell.go:40](https://github.com/mochilang/mochi/blob/main/runtime/vm2/cell.go)). Adding a header word to every object is free for us (we already have an `any` slot per `Objects[i]`); adding a header bit to every *Cell* is not (the NaN-box is full).
+3. **The JIT and the interpreter share the frame format ([MEP-34](/docs/mep/mep-0034)).** Both must produce identical RC operations and identical write barriers, or a JIT'd function that calls an interpreted one (and vice versa) double-counts or skip-counts. The MEP-34 frame-compatibility contract extends to the memory subsystem.
+4. **Determinism is a feature.** Mochi's test corpus diffs program output. Anything non-deterministic (concurrent tracing with cooperation points scheduled by wall-clock) breaks reproducibility. Pauses must be deterministic and scheduled at well-known program points (back-edges, `OpReturn`, allocation overflow).
+5. **No assumption of closed-world.** Mochi has FFI (the `Objects` table holds opaque `any` payloads, some of which are Go-side resources). A whole-program escape analysis is not viable in v1. Per-function or per-call-site analysis is.
+
+## Three implementation options
+
+### Option 1: Perceus-style reference counting with compile-time RC elision and cycle collection at Run exit
+
+**Mechanism.** Add one `uint32` refcount per `Objects[i]` slot. Compile every `Move`, `Call`, container construct, and container drop opcode to emit `dup` (increment) and `drop` (decrement-and-maybe-free) operations on ptr-tagged Cells. Run two compiler passes inside `compiler2` ([MEP-21](/docs/mep/mep-0021)):
+
+- **Last-use insertion.** Place each `drop` at the last lexical use of a ptr-tagged value within a function. Implemented as a backward dataflow over the bytecode, identical in shape to Koka's pass.
+- **Reuse analysis.** When a function consumes a ptr-tagged value via `drop` and then constructs a new container of the same shape, rewrite the pair as an in-place reuse if the refcount is observed to be 1 at runtime. Cells of refcount 1 are "unique"; the JIT can inline this check as a one-instruction comparison ([Roc Set.insert idiom](https://www.roc-lang.org/functional)).
+- **Borrow inference.** Function parameters used read-only and not stored into long-lived state are marked `borrowed`. Borrowed parameters skip the entry `dup` and the exit `drop`.
+
+**Cycles.** Detected once, at `Run` exit, by sweeping `Objects` for entries with refcount > 0 that are unreachable from the registers. Bacon-Rajan ([ECOOP 2001](https://pages.cs.wisc.edu/~cymen/misc/interests/Bacon01Concurrent.pdf)) is the algorithm. A program with no cycles pays nothing. A program with cycles pays one full sweep per Run.
+
+**Allocator.** A small free-list per object class (`*vmList`, `*vmMap`, `*vmString`, `*Closure`, `*big.Int`) reuses freed slots in `Objects`. The slot index is stable across Run; freed slots are pushed onto a per-class freelist and reused by the next allocator call. Cells that hold the old index continue to compare equal but dereference to whatever now occupies the slot, which is the failure mode RC must rule out before slot reuse; the refcount-hit-zero check is exactly that proof.
+
+**Mochi mapping.**
+
+| vm2 concept | New RC concept |
+|-------------|---------------|
+| `Objects []any` | `Objects []objSlot` where `objSlot = {payload any; refcount uint32; next uint32}` |
+| `CPtr(idx)` cell construction | Compiler emits `dup` on the resulting Cell |
+| `OpReturn` | Compiler emits `drop` on every ptr-tagged register at last use |
+| `popFrame` | No change. RC drops happen at last-use, not at frame exit. |
+| `Run` exit | `runCycleCollect(vm)` then reset `Objects` |
+
+**Pros.** Allocation-free hot paths once reuse fires (Roc demonstrates this in practice). No GC pauses other than at Run exit. Deterministic. Co-evolves with [MEP-7](/docs/mep/mep-0007) (the type checker already knows ptr-tagged Cells). Aligns with the precedent set in [MEP-20](/docs/mep/mep-0020) of "Go-friendly value layout".
+
+**Cons.** Refcount operations on shared containers are atomic if Mochi grows concurrency. The atomic op cost is ~3-5 ns on modern x86, less on ARM; Biased Reference Counting ([PACT'18](https://iacoma.cs.uiuc.edu/iacoma-papers/pact18.pdf)) is the known mitigation if it becomes a bottleneck. Cycles in long-running programs leak until Run exit; programs that build cyclic graphs (graph algorithms, mutable cyclic data) regress.
+
+**Projected numbers** (extrapolating from Roc, Lobster, Koka on equivalent workloads):
+
+| Workload | vs append-only baseline | vs LuaJIT |
+|----------|-------------------------|-----------|
+| `iter_sum` (no refs) | 1.00x (unchanged, no ptr-tagged Cells) | parity |
+| `map_get` | 30x lower heap retained, 1.1-1.3x throughput | 1.3-1.8x slower (RC bump on each map insert) |
+| `quicksort` (in-place reuse fires) | 100x lower heap retained, 1.0x throughput | parity |
+| `string_cat` (interned) | 50x lower retained | 1.2-1.5x slower |
+
+### Option 2: Per-frame region arenas with dynamic heapification
+
+**Mechanism.** Each `pushFrame` opens a new region in a `[]Region` stack. Every allocation made from inside that frame's bytecode goes into the current region's bump allocator. `popFrame` discards the region in one operation: drop the bump allocator's slab, no per-object work.
+
+When the type system cannot prove a ptr-tagged value is frame-local (the value escapes via `OpReturn`, is stored into a parent register, is captured by a closure, or flows into the FFI), the compiler inserts a *heapification* opcode that copies the object out of the frame region into the parent's region or into a long-lived "global" region. This is the PLDI 2024 idea ([Anand et al.](https://dl.acm.org/doi/full/10.1145/3656389)), adapted: instead of stack-vs-heap, we have region-vs-region, and heapification rewrites the source Cell to point at the copy.
+
+The compiler's escape analysis is conservative: a value escapes unless the bytecode demonstrably does not let it. Cases that demonstrably do not let it (large fraction of the corpus, per MEA2's measurements on Go): list comprehensions over a local list, map literals consumed by a single call, intermediate strings in `string_cat`.
+
+**Mochi mapping.**
+
+| vm2 concept | New region concept |
+|-------------|--------------------|
+| `Objects []any` | `Objects []any` becomes one of many regions; one `*Region` per frame |
+| `pushFrame` | `vm.Regions = append(vm.Regions, NewRegion())` |
+| `popFrame` | `vm.Regions[top].free()` then `Regions = Regions[:top]` |
+| Container construct | Allocates in current frame's region |
+| Escaping value | Compiler emits `OpHeapify dst, src` that copies into parent region |
+
+**Pros.** O(1) reclamation per frame. No write barriers in the steady state. Aligns naturally with Mochi's frame structure ([MEP-34 §frame-compatibility](/docs/mep/mep-0034)). Cycles among objects in the same region are reclaimed for free.
+
+**Cons.** Escape analysis is the bottleneck. If most values escape (we have not measured), regions degrade to a slow heap. Long-lived values (the program's global state, the persistent map a user keeps growing) need their own region with one of the other two strategies layered on top, which means we end up implementing option 1 or 3 anyway, just on a smaller footprint. The Verona / Reggio paper makes precisely this argument ([Cheney et al., OOPSLA 2023 §3.2](https://arxiv.org/pdf/2309.02983)).
+
+**Projected numbers.**
+
+| Workload | vs append-only baseline | vs LuaJIT |
+|----------|-------------------------|-----------|
+| `iter_sum` | 1.00x | parity |
+| `map_get` | 100x lower retained if maps don't escape, 1.0x retained if they do | parity if non-escaping |
+| `quicksort` | 200x lower retained (frame-local sublists) | parity |
+| `long_running_repl` (global growing map) | regresses, need fallback strategy | regresses |
+
+### Option 3: Mark-region collector over the Objects table (Immix / LXR shape, no MMTk dependency)
+
+**Mechanism.** Replace `Objects []any` with a slab-allocated region heap: 32 KB blocks, 128 B lines, bump-pointer inside a block. Every block holds objects of the same class (`*vmList`, `*vmMap`, ...) to keep the Go GC's type information precise. A mark phase runs at allocation overflow (when no block of the requested class has a free line):
+
+1. Stop the mutator at the next safepoint (back-edge or `OpCall` / `OpReturn`).
+2. Scan the register file plus the `Objects` indirection (we still need indirection for slot stability under refcount-free reclamation; see below) for ptr-tagged Cells. The Cells *are* the precise root set; no conservative scan.
+3. Mark lines and blocks reachable. Use logical versioning ([JSC Riptide](https://webkit.org/blog/12967/understanding-gc-in-jsc-from-scratch/)) so mark bits do not need physical clearing between cycles.
+4. Reclaim free lines for allocation. Compact only fragmented blocks via the Immix opportunistic-copy path.
+
+LXR layers RC on top of this for incrementality. We would start without LXR and adopt it in a follow-on MEP if pause times exceed the budget.
+
+**Mochi mapping.**
+
+| vm2 concept | New collector concept |
+|-------------|----------------------|
+| `Objects []any` | Per-class block lists; ptr-tagged Cell still carries a 48-bit identity but resolved through a forwarding table |
+| `pushFrame` / `popFrame` | No change |
+| `OpCall` / back-edge | Safepoint check; collector runs if requested |
+| Container construct | Bump-alloc in current block; allocate new block on overflow |
+| `Run` exit | Discard all blocks |
+
+**Pros.** Throughput within the Immix / LXR range, which is to say competitive with G1 on Java benchmarks. Cycles handled. No compiler-side analysis required (no Perceus-style passes, no escape analysis). Simplifies the JIT contract: the JIT emits a write barrier on ptr-tagged stores, nothing else.
+
+**Cons.** A write barrier on every ptr-tagged Cell write. The barrier is one branch and one byte-store ([LXR §3.2](https://www.steveblackburn.org/pubs/papers/lxr-pldi-2022.pdf)) but it is not zero. Pause times are bounded but not zero: a Stop-The-World mark is in the millisecond range for heaps with a few hundred thousand live objects. The implementation effort is the largest of the three: we are writing a collector. We could lean on [MMTk](https://www.mmtk.io/) via cgo or a Rust subprocess; the cost is the FFI boundary and a build-system dependency on cargo and a Rust toolchain in CI.
+
+**Projected numbers.**
+
+| Workload | vs append-only baseline | vs LuaJIT |
+|----------|-------------------------|-----------|
+| `iter_sum` | 0.97x (write-barrier cost) | parity |
+| `map_get` | 50x lower retained, 1.0-1.1x throughput | 1.1-1.3x slower |
+| `quicksort` | 50x lower retained, 0.95x throughput | parity |
+| cycle-heavy graphs | reclaimed correctly | parity |
+
+## Comparison
+
+| Property | Option 1 (Perceus RC) | Option 2 (Regions) | Option 3 (Mark-region) |
+|----------|----------------------|-------------------|------------------------|
+| Compiler work | Last-use, reuse, borrow passes | Escape analysis + heapify opcode | Write-barrier emission only |
+| Runtime work | RC bump on dup / drop | None in steady state | Mark sweep at overflow |
+| Cycles | Bacon-Rajan at Run exit | Free per region | Free during mark |
+| Pause | None (RC) or one per Run (cycles) | None | ms-scale per mark |
+| Heap overhead | 4 bytes per Object | One slab per frame | Block headers + mark bitvectors |
+| Determinism | Full | Full | Pause time varies with heap |
+| FFI | Clean (RC visible to Go) | Clean | Clean if pure-Go, FFI if MMTk |
+| Failure mode | Cycles leak until Run exit | Escape analysis pessimism | Pause spikes under allocation pressure |
+| Lines of code (estimate) | 1500-2500 in compiler + runtime | 2000-3000 in compiler + runtime | 3000-5000 in runtime, or MMTk FFI |
+| Risk of regressing MEP-30 numeric path | None (no ptr-tag in `fib_rec`) | None | Small (write barrier dead-coded out) |
+
+## Recommendation
+
+**Option 1 is the proposed Phase 1.** Specifically:
+
+1. Land the slot freelist + refcount in `Objects` first, with the compiler emitting `dup` / `drop` at every ptr-tagged register move. This is the unoptimized RC baseline. Measure heap-retained on the MEP-23 corpus.
+2. Add last-use insertion. Measure RC op count and heap-retained.
+3. Add reuse analysis. Measure allocation rate on `quicksort` and `map_get`.
+4. Add borrow inference. Measure RC op count on closure-heavy workloads.
+5. Add Bacon-Rajan cycle collection. Measure on graph workloads.
+
+Each of the five steps lands as a separate PR with its own gate against the MEP-23 baseline. If any step regresses geo-mean throughput against the previous step, the work stops and we re-evaluate against option 3.
+
+Option 3 is the explicit fallback. If at step 3 or step 5 we cannot reach 0.9x of Roc-shape numbers on the container corpus, the recommendation pivots to MMTk via FFI. Option 2 is rejected as a primary path because the escape analysis dominates risk; we adopt regions only as an opportunistic optimization layered on whichever of options 1 or 3 wins.
+
+## Scope
+
+In scope for the Phase 1 deliverable (option 1):
+
+- The slotted Objects table with refcount + freelist (`runtime/vm2/vm.go`).
+- The compiler passes for last-use, reuse, and borrow inference (`compiler2/`).
+- The Bacon-Rajan cycle collector triggered at Run exit (`runtime/vm2/cycles.go`, new).
+- JIT integration: vm2jit ([MEP-34](/docs/mep/mep-0034)) must emit identical `dup` / `drop` operations to the interpreter at the matching opcodes.
+- Bench gates added to the [MEP-23](/docs/mep/mep-0023) corpus: `heap-bytes-retained-at-Run-exit`, `rc-ops-per-iteration`, `cycle-collector-time-at-Run-exit`.
+
+Out of scope (deferred):
+
+- Concurrent reference counting / atomic RC ops. Mochi is single-threaded today; revisit when [MEP-15](/docs/mep/mep-0015) lands.
+- Generational RC ([Blackburn & McKinley, "Ulterior RC"](https://www.cs.utexas.edu/~mckinley/papers/ulterior-pldi-2003.pdf)) or Biased RC. Land if the steady-state RC overhead exceeds 10% of runtime on the corpus.
+- Region allocator for frame-local values (option 2). Land if escape analysis turns out cheap to bolt onto the type checker.
+- Mark-region collector (option 3). Land if option 1 stalls at step 3 or step 5.
+
+## Backwards Compatibility
+
+The change is invisible to source-level Mochi programs. The bytecode changes (new `dup` / `drop` opcodes, new `OpRunCycleCollect`) are emitted by the compiler, not the user. The JIT and the interpreter must coordinate per [MEP-34](/docs/mep/mep-0034); a JIT'd function calling an interpreted one and vice versa must produce identical RC effects.
+
+The `Objects []any` slot encoding stays compatible: existing `CPtr` Cells still resolve to the same Go-level payload. The added refcount and freelist are an internal detail of `vm.Objects`.
+
+The only externally visible change is that `vm.Objects` is *not* a stable index across Runs. Test fixtures that compare `len(vm.Objects)` between Runs (none today) would break.
+
+## Reference Implementation
+
+The implementation lands across three trees:
+
+- `runtime/vm2/vm.go`: `Objects []any` becomes `Objects []objSlot`; `AddObject` consults the freelist; new `dup(idx)`, `drop(idx)` methods; `popFrame` runs no per-slot work (RC drops happen at the per-opcode level, not at frame retire).
+- `runtime/vm2/cycles.go` (new): Bacon-Rajan cycle collector.
+- `compiler2/rc/` (new): the last-use, reuse, borrow passes.
+- `runtime/jit/vm2jit/`: emit matching `dup` / `drop` in the ARM64 and AMD64 templates.
+
+Each PR lands behind a build tag (`vm2_rc`) until the gate passes; the append-only path remains the default until the measured-results MEP lands.
+
+## Open Questions
+
+1. **Atomic vs non-atomic RC.** Today Mochi has no concurrency; non-atomic is correct. When [MEP-15](/docs/mep/mep-0015) introduces effect-tracked concurrency, we will need a thread-local-or-shared bit per slot (Inko's model) or BRC (the 2018 Biased RC paper). Defer.
+2. **Stable slot identity.** If a slot is freed and reused, any Cell that still holds the old index has a stale reference. The RC invariant rules this out (refcount-zero is a precondition for freeing the slot), but the JIT must be audited for paths that read a Cell after a drop. Add a `dropped` debug flag in test builds.
+3. **Cycle-collector cost on Run exit.** If a program's cyclic-garbage rate is high, the exit cost dominates. We may want to schedule it more often than at Run exit (every N allocations, or at GC.AssistMark-style triggers). Defer until measured.
+4. **MMTk fallback ergonomics.** If option 3 becomes the path, the FFI boundary needs to coexist with `go test`. Bun's cgo+Rust experience ([Bun blog 2024-09](https://bun.com/blog/how-bun-supports-v8-apis-without-using-v8-part-1)) suggests this is workable but not free.
+5. **Slot indirection vs direct pointer.** Once RC is precise, the `Objects` indirection becomes optional; a ptr-tagged Cell could in principle carry a 48-bit Go pointer directly. Go's GC scanning rules block this today (Cells are `uint64`, not `*X`), but a parallel `Roots []*objSlot` array could expose the pointers. Defer.
+
+## References
+
+### Reference counting and reuse
+
+- Reinking, Xie, de Moura, Leijen. *Perceus: Garbage Free Reference Counting with Reuse.* PLDI 2021. [paper](https://www.microsoft.com/en-us/research/wp-content/uploads/2020/11/perceus-tr-v1.pdf), [ACM DL](https://dl.acm.org/doi/10.1145/3453483.3454032)
+- Bacon, Rajan. *Concurrent Cycle Collection in Reference Counted Systems.* ECOOP 2001. [paper](https://pages.cs.wisc.edu/~cymen/misc/interests/Bacon01Concurrent.pdf)
+- Choi, Lee. *Biased Reference Counting: Minimizing Atomic Operations in Garbage Collection.* PACT 2018. [paper](https://iacoma.cs.uiuc.edu/iacoma-papers/pact18.pdf)
+- Roc Programming Language. *Functional design page* ([roc-lang.org/functional](https://www.roc-lang.org/functional)).
+- van Oortmerssen. *Memory Management in Lobster.* [aardappel.github.io](https://aardappel.github.io/lobster/memory_management.html)
+- Inko Project. *Ownership You Can Count On: A Hybrid Approach to Safe Explicit Memory Management.* [inko-lang.org/papers/ownership.pdf](https://inko-lang.org/papers/ownership.pdf)
+
+### Regions
+
+- Cheney, Drossopoulou, et al. *Reference Capabilities for Flexible Memory Management* (Verona / Reggio). OOPSLA 2023. [arXiv:2309.02983](https://arxiv.org/pdf/2309.02983)
+- Wikipedia. *Region-based memory management.* [link](https://en.wikipedia.org/wiki/Region-based_memory_management)
+
+### Tracing and hybrid collectors
+
+- Blackburn, McKinley. *Immix: a Mark-Region Garbage Collector with Space Efficiency, Fast Collection, and Mutator Performance.* PLDI 2008. [paper](https://www.steveblackburn.org/pubs/papers/immix-pldi-2008.pdf)
+- Zhao, Blackburn, McKinley. *Low-Latency, High-Throughput Garbage Collection.* PLDI 2022 (LXR). [paper](https://www.steveblackburn.org/pubs/papers/lxr-pldi-2022.pdf)
+- Memory Management Toolkit. [mmtk.io](https://www.mmtk.io/), [Ruby 3.4 integration 2025-01](https://railsatscale.com/2025-01-08-new-for-ruby-3-4-modular-garbage-collectors-and-mmtk/)
+- WebKit. *Understanding Garbage Collection in JavaScriptCore From Scratch.* [webkit.org/blog/12967](https://webkit.org/blog/12967/understanding-gc-in-jsc-from-scratch/)
+- Norlinder, Österlund, Black-Schaffer, Wrigstad. *Mark-Scavenge: Waiting for Trash to Take Itself Out.* OOPSLA 2024.
+- *Generational Shenandoah, Java 25.* [The Perf Parlor 2025-09](https://theperfparlor.com/2025/09/14/new-in-java25-generational-shenandoah-gc-is-no-longer-experimental/)
+- *Pauseless Garbage Collection in Java 25: ZGC Deep Dive.* [andrewbaker.ninja 2025-12](https://andrewbaker.ninja/2025/12/03/deep-dive-pauseless-garbage-collection-in-java-25/)
+
+### Escape analysis
+
+- Anand, Adithya, Rustagi, Seth, Sundaresan, Maier, Nandivada, Thakur. *Optimistic Stack Allocation and Dynamic Heapification for Managed Runtimes.* PLDI 2024. [ACM](https://dl.acm.org/doi/full/10.1145/3656389)
+- *MEA2: a Lightweight Field-Sensitive Escape Analysis with Points-to Calculation for Go.* OOPSLA 2024. [splashcon.org](https://2024.splashcon.org/details/splash-2024-oopsla/102/)
+
+### Mochi context
+
+- [MEP-7. Soundness](/docs/mep/mep-0007)
+- [MEP-15. Effects, Mutability, and Purity](/docs/mep/mep-0015)
+- [MEP-20. Value Representation and Allocation Discipline](/docs/mep/mep-0020)
+- [MEP-21. Compiler2 and VM2 Co-Design](/docs/mep/mep-0021)
+- [MEP-23. Cross-language Baseline Benchmarks](/docs/mep/mep-0023)
+- [MEP-34. VM2 Full-Opcode JIT](/docs/mep/mep-0034)
+
+## Copyright
+
+This document is placed in the public domain.

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -246,10 +246,21 @@ h4:hover .hash-link {
    ========================================================================= */
 
 .navbar {
-  backdrop-filter: saturate(180%) blur(12px);
-  -webkit-backdrop-filter: saturate(180%) blur(12px);
   border-bottom: 1px solid var(--mochi-border);
   box-shadow: none;
+}
+
+/* Apply the translucent blur only on desktop. On mobile (≤ 996px,
+   the Docusaurus drawer breakpoint), `backdrop-filter` would make
+   `.navbar` a containing block for its `position: fixed` descendants,
+   which clips the slide-in drawer (`.navbar-sidebar`) to the navbar's
+   own height. Result: the hamburger toggle fires, the drawer opens,
+   but the user sees nothing because it has been compressed to ~60px. */
+@media (min-width: 997px) {
+  .navbar {
+    backdrop-filter: saturate(180%) blur(12px);
+    -webkit-backdrop-filter: saturate(180%) blur(12px);
+  }
 }
 
 .navbar__brand {

--- a/website/src/data/meps.json
+++ b/website/src/data/meps.json
@@ -42,7 +42,7 @@
   {
     "number": 5,
     "title": "Type Inference",
-    "status": "Standards Track",
+    "status": "Active",
     "type": "Standards Track",
     "description": "Strict static algebraic type inference. Principal types, no implicit any, no null.",
     "slug": "/docs/mep/mep-0005"
@@ -138,7 +138,7 @@
   {
     "number": 17,
     "title": "VM Performance Methodology and Baseline",
-    "status": "Draft",
+    "status": "Active",
     "type": "Process",
     "description": "How Mochi measures, reports, and gates VM performance changes, with a reference benchmark suite and a regression budget.",
     "slug": "/docs/mep/mep-0017"
@@ -146,7 +146,7 @@
   {
     "number": 18,
     "title": "Bytecode Dispatch in a Go-Hosted VM",
-    "status": "Draft",
+    "status": "Active",
     "type": "Standards Track",
     "description": "What dispatch techniques work for the Mochi VM under the constraints of the Go runtime, with a concrete plan for the next 18 months.",
     "slug": "/docs/mep/mep-0018"
@@ -154,7 +154,7 @@
   {
     "number": 19,
     "title": "Adaptive Specialization and Inline Caches",
-    "status": "Draft",
+    "status": "Active",
     "type": "Standards Track",
     "description": "Quickening generic opcodes into typed variants on first observation, plus monomorphic and polymorphic inline caches for the few remaining dynamic call sites.",
     "slug": "/docs/mep/mep-0019"
@@ -162,7 +162,7 @@
   {
     "number": 20,
     "title": "Value Representation and Allocation Discipline",
-    "status": "Draft",
+    "status": "Active",
     "type": "Standards Track",
     "description": "A tighter Value struct, sync.Pool for frames and slabs, and an escape audit on the hot path of the Mochi VM.",
     "slug": "/docs/mep/mep-0020"
@@ -170,7 +170,7 @@
   {
     "number": 21,
     "title": "Compiler2 and VM2 Co-Design for Maximum Interpreter Throughput",
-    "status": "Draft",
+    "status": "Active",
     "type": "Standards Track",
     "description": "A first-principles redesign of the Mochi compile-and-execute pipeline. Replace the observation-driven runtime with a typed SSA compiler (compiler2) that emits monomorphic bytecode into a redesigned vm2 with NaN-boxed 8-byte values, register allocation, tail calls, and bounds-check elision. No backward compatibility constraints. Target the absolute throughput ceiling of a Go-hosted interpreter on statically typed source.",
     "slug": "/docs/mep/mep-0021"
@@ -186,7 +186,7 @@
   {
     "number": 23,
     "title": "Cross-language Baseline Benchmarks",
-    "status": "Draft",
+    "status": "Active",
     "type": "Process",
     "description": "A periodic, hand-written cross-language benchmark suite that positions Mochi against Python and Lua on the same workloads, separate from the MEP-17 per-PR gate.",
     "slug": "/docs/mep/mep-0023"
@@ -194,7 +194,7 @@
   {
     "number": 24,
     "title": "VM2 Subsystem Design (Objects, Strings, Structs, Lists, Maps, Closures, GC, Errors)",
-    "status": "Draft",
+    "status": "Active",
     "type": "Standards Track",
     "description": "A consolidated subsystem design for vm2 that replaces the ad-hoc per-feature opcode growth of MEPs 18-21 with a single coherent plan for value representation, heap-allocated types, garbage collection, exception/Result handling, and the porting path to feature parity with the legacy VM. Co-designed with a comprehensive correctness + benchmark gate.",
     "slug": "/docs/mep/mep-0024"
@@ -202,7 +202,7 @@
   {
     "number": 25,
     "title": "VM2 Data Model (Strings, Lists, Maps, Sets, Structs)",
-    "status": "Draft",
+    "status": "Active",
     "type": "Standards Track",
     "description": "Algorithmically modern in-memory representations for vm2's five core container kinds, strings, lists, maps, sets, structs, replacing the MEP-24 MVP shapes with shapes that close the Lua gap on the cross-language baseline and stay competitive after a future JIT lands. Specifies SSO + rope strings, type-specialized lists, Swiss-style int-keyed maps, presence-only set storage, and slot-packed structs. Implementation strategy is selected from three competing approaches detailed in MEP-26, MEP-27, MEP-28.",
     "slug": "/docs/mep/mep-0025"
@@ -242,7 +242,7 @@
   {
     "number": 30,
     "title": "VM2 JIT Option A - Template / Copy-and-Patch Baseline JIT",
-    "status": "Draft",
+    "status": "Active",
     "type": "Standards Track",
     "description": "First of three competing JIT strategy specs for vm2. Each opcode handler is pre-compiled once into a position-independent native snippet, stored as a byte slice keyed by (opcode, shape-tuple), then concatenated and patched into an mmap'd executable buffer at function load. No IR, no register allocator, no inliner. The result is a non-optimizing baseline JIT in the lineage of V8 Sparkplug, JSC's Baseline JIT, and CPython 3.13's copy-and-patch JIT. This MEP specifies the snippet harvesting pipeline, the patcher ABI, the interpreter-compatible frame layout that makes OSR trivial, the deopt-free guard model, the distribution story (single Go binary, no cgo), and predicts a 2-4x speedup over the vm2 interpreter on fill_sum-class workloads.",
     "slug": "/docs/mep/mep-0030"
@@ -274,9 +274,17 @@
   {
     "number": 34,
     "title": "VM2 Full-Opcode JIT - Lists, Strings, Maps, Sets, Structs",
-    "status": "Draft",
+    "status": "Active",
     "type": "Standards Track",
     "description": "Production-track spec for the next JIT after the MEP-30 prototype. Extends MEP-30's template / copy-and-patch design from the 6-opcode tmpljit toy to the full vm2 opcode set, with first-class native support for the five container subsystems (lists, strings, maps, sets, structs). Specifies per-opcode codegen templates, the frame-compatibility contract that lets the JIT and the vm2 interpreter share a Cell-shaped register file across calls, the Cell NaN-boxing fast paths and slow-path runtime callbacks, the cross-architecture backend split (darwin/arm64 + linux/amd64 from day one), and the benchmark plan that gates merge: head-to-head against the vm2 interpreter, LuaJIT, Lua 5.5, and CPython 3.14 on the MEP-23 corpus and on each container's hot ops. Predicts 3-6x over vm2 on list / arithmetic loops, 1.5-3x on string and map workloads, and parity with LuaJIT on numeric loops by Phase 3.",
     "slug": "/docs/mep/mep-0034"
+  },
+  {
+    "number": 35,
+    "title": "Auto Memory Management for the VM2 Objects Table",
+    "status": "Draft",
+    "type": "Standards Track",
+    "description": "Survey of modern auto memory management (Perceus / Koka / Roc, Inko, Lobster, Verona / Reggio regions, Immix / LXR, MMTk, generational ZGC / Shenandoah, JSC Riptide) and a design overview for reclaiming entries in the vm2 Objects table. Today the table is append-only inside a Run: every list, map, heap string, closure, and boxed big-int allocated by a program stays live until Run exits, regardless of whether the program still references it. This MEP proposes three implementation options (Perceus-style reference counting with reuse, per-frame region arenas, and an Immix / LXR mark-region collector layered over the Objects table) and a recommendation.",
+    "slug": "/docs/mep/mep-0035"
   }
 ]


### PR DESCRIPTION
Fixes #21555.

Three changes bundled into one push so Cloudflare Pages does a single deploy to mochi-lang.dev.

## Summary

- **MEP-0000 index.** Add rows 24-35 (files existed but were missing from the table). Promote MEPs that have already shipped code (5, 11, 12, 17, 18, 19, 20, 21, 23, 24, 25, 30, 34) from Draft to Active. Add a preamble that says the status column tracks implementation status, not spec drafting status, so future edits stay honest. Also fix MEP-5 frontmatter (status was "Standards Track", which is a type value).
- **MEP-0035 draft.** "Auto Memory Management for the VM2 Objects Table". Surveys Perceus (PLDI '21), Inko, Lobster, Verona / Reggio regions (OOPSLA '23), Immix / LXR (PLDI '08, '22), MMTk (Ruby 3.4), generational ZGC / Shenandoah (Java 25), JSC Riptide. Proposes three options for reclaiming entries in the per-Run `vm2.VM.Objects` table (today append-only): Perceus-style RC with reuse plus Bacon-Rajan cycle collection, per-frame region arenas with PLDI '24 dynamic heapification, and an Immix / LXR mark-region collector. Recommends option 1.
- **Mobile hamburger fix.** The navbar carried `backdrop-filter` unconditionally, which makes it a containing block for its `position: fixed` descendants. The Docusaurus mobile drawer (`.navbar-sidebar`) is one of those descendants, so tapping the hamburger opened a drawer that had been clipped to the navbar's own ~60px height. Move the blur behind a `min-width: 997px` media query (Docusaurus' drawer breakpoint) so mobile gets a plain navbar and the drawer positions against the viewport.

`website/src/data/meps.json` regenerated via `npm run gen:meps`.

## Test plan

- [ ] Cloudflare Pages preview build is green.
- [ ] `https://mochi-lang.dev/docs/mep/` shows MEPs 0-35 with the new statuses.
- [ ] `https://mochi-lang.dev/docs/mep/mep-0035` renders.
- [ ] On a phone or DevTools mobile emulation (≤ 996px), the hamburger toggle opens a full-height drawer with the sidebar contents visible.
- [ ] On desktop (≥ 997px), the navbar still has the saturated blur background.