### PR TITLE
mep-0036: draft Restructure VM2 to Reuse Go's GC

### DIFF
--- a/website/docs/mep/mep-0000.md
+++ b/website/docs/mep/mep-0000.md
@@ -93,6 +93,7 @@ The status column reflects the *implementation* status against `main`, not the s
 | [33](/docs/mep/mep-0033)| MEP-30 Template JIT - Measured Results | Informational | Informational   |
 | [34](/docs/mep/mep-0034)| VM2 Full-Opcode JIT - Lists, Strings, Maps, Sets, Structs | Active | Standards Track |
 | [35](/docs/mep/mep-0035)| Auto Memory Management for the VM2 Objects Table | Draft     | Standards Track |
+| [36](/docs/mep/mep-0036)| Restructure VM2 to Reuse Go's GC       | Draft         | Standards Track |
 
 ## Workflow
 

--- a/website/docs/mep/mep-0036.md
+++ b/website/docs/mep/mep-0036.md
@@ -1,0 +1,383 @@
+---
+mep: 36
+title: Restructure VM2 to Reuse Go's GC
+author: Mochi core
+status: Draft
+type: Standards Track
+created: 2026-05-17
+sidebar_position: 36
+sidebar_label: MEP 36. Reuse Go's GC
+description: "Restructure the vm2 value representation so that pointer-shaped values (lists, maps, heap strings, closures, boxed big ints, structs, sets) are stored as real Go pointers visible to Go's tricolor concurrent mark-sweep collector, and the per-Run Objects []any indirection table is deleted. Today the NaN-boxed Cell hides every pointer inside a uint64, so Go's GC traces only the table, never the values, and the table grows monotonically for the lifetime of a Run. This MEP surveys modern VM-on-host-GC designs (Goja, starlark-go, Yaegi, Truffle, WasmGC, CRuby + MMTk), the Go-specific cost of interface boxing and the hybrid write barrier, and the allocation-minimization literature (Perceus, Roc, PLDI 2024 dynamic heapification, V8 Smi, .NET / Valhalla value types), then specifies the refactor: a struct Cell with an unsafe.Pointer slot for GC-traced payloads, an inline scalar slot for ints / bools / floats / short strings, a per-Run free list of typed pointers for object reuse, and a compile-time last-use bit on registers that enables in-place mutation for the common append / update pattern. The goal is zero allocations on the hot path for pure-numeric loops, one Go-tracked allocation per container constructor and zero per element, and full reclamation of dead containers between GC cycles without a custom collector."
+---
+
+# MEP 36. Restructure VM2 to Reuse Go's GC
+
+| Field    | Value                                          |
+|----------|------------------------------------------------|
+| MEP      | 36                                             |
+| Title    | Restructure VM2 to Reuse Go's GC               |
+| Author   | Mochi core                                     |
+| Status   | Draft                                          |
+| Type     | Standards Track                                |
+| Created  | 2026-05-17                                     |
+
+## Abstract
+
+This MEP restructures the vm2 value representation so that **pointer-shaped values are stored as real Go pointers**, visible to Go's tricolor concurrent mark-sweep collector, and the per-Run `Objects []any` indirection table is deleted. The current design (see [MEP-20](/docs/mep/mep-0020) and [`runtime/vm2/cell.go`](https://github.com/mochilang/mochi/blob/main/runtime/vm2/cell.go)) NaN-boxes every value into an 8-byte `uint64` Cell. Heap payloads (lists, maps, heap strings, closures, boxed big ints) sit in `vm.Objects` and the Cell's 48-bit payload is the index into that slice. Because the pointer lives inside a `uint64`, Go's GC cannot trace it, so the table is the only thing GC sees, and the table is append-only inside a Run. Memory grows monotonically until `Run()` exits.
+
+The proposal is to make `Cell` a small struct with an `unsafe.Pointer` slot for GC-traced payloads and an inline scalar slot for ints, bools, floats, and short strings, then delete the `Objects` table. This is the path of least resistance modern Go-hosted interpreters (Goja, starlark-go, Yaegi) have all taken; it also lines up with the WasmGC philosophy ("describe your objects to the host GC instead of bringing your own") and with Go's own design decision not to ship a generational nursery, which assumes escape analysis already handles the young-object case.
+
+The goal of the refactor is measured in three places:
+
+1. **Zero heap allocations** on the hot path for pure-numeric loops (already true today; must stay true).
+2. **One Go-tracked allocation per container constructor** and **zero per element** (today: one allocation per `AddObject` plus the indirection-table grow).
+3. **Full reclamation of dead containers between GC cycles** without a custom collector (today: never, until `Run()` exits).
+
+This is a runtime refactor with a wide blast radius (every container subsystem, the JIT register file contract, the deopt protocol, and a handful of FFI shims) but no language-surface change. [MEP-34](/docs/mep/mep-0034) (the production JIT) and [MEP-35](/docs/mep/mep-0035) (auto memory management) are both downstream consumers: MEP-34's JIT register file shape is set by this MEP, and MEP-35's three options collapse to "let Go's GC do it" once this MEP ships.
+
+## Motivation
+
+The Objects table started as the pragmatic shortcut. In an 8-byte NaN-boxed Cell there is no room for a real pointer and a tag, so we put pointers behind an index. `runtime/vm2/vm.go` documents the contract:
+
+> The table is reset on each Run so pure-numeric programs never grow it.
+
+That comment is true: a pure-numeric Mochi program allocates exactly nothing from `Objects`. But every program that touches a list, a map, a heap string, a closure, or a big int allocates into the table monotonically until `Run()` finishes. There is no reclamation mechanism. The `popFrame` doc comment in `runtime/vm2/vm.go` calls this out:
+
+> The frame window is sliced off but its contents are NOT zeroed. vm2 has no ptr-tagged Cells yet so there is nothing to un-pin; once the boxed-object subsystem lands, popFrame must zero ptr-tagged slots before shrinking. Tracked in the upcoming subsystem MEP.
+
+That MEP is this one. There are two operational consequences:
+
+1. **Memory pressure scales with bytecode lifetime, not with reachability.** A long-running server (or a future REPL) that runs many programs would see live-heap grow without bound; today this is masked by Run() being short-lived.
+2. **Every list / map / string Cell write triggers a heap touch the GC cannot help with.** The Objects table is `[]any`, so even reading a list pays one bounds check, one type assertion, and an interface unbox. Profiles of MEP-23 list workloads (see [MEP-29](/docs/mep/mep-0029)) show 5-8% of CPU sitting in `vm.Objects[c.Ptr()].(*vmList)` accessor calls in `lists.go:28`, `maps.go:19`, and `strings.go:38`.
+
+There is a third, longer-term consequence. [MEP-34](/docs/mep/mep-0034) commits to a frame-compatibility contract between the interpreter and the JIT: a JIT'd function must be able to call an interpreted one and vice versa without copy-conversion. The cleanest version of that contract is that **registers are real Go pointers when they point at containers**, because the JIT's native code can dereference a Go pointer with one `ldr` instruction, but cannot resolve an Objects-table index without calling back into Go. Without this MEP, the JIT either reimplements the Objects table in native (a fresh source of soundness bugs across the JIT / interpreter boundary), or every container op deopts. Neither is acceptable for the Phase 2 numbers MEP-34 promises.
+
+## Background
+
+### 2.1 Modern VM-on-host-GC designs
+
+Every production VM that lives inside a managed runtime has, eventually, converged on **letting the host GC see real pointers**. The lesson is consistent across ecosystems:
+
+- **WasmGC** (standardized 2024, shipped in Chrome by default, repo archived April 2025). The V8 team's writeup ("A new way to bring GC languages efficiently to WebAssembly") makes the design statement plain: rather than ship a GC inside your VM, describe your heap objects to the host VM's GC via `struct` and `array` heap types. Kotlin, Dart, Java, and Scala all switched to this representation.
+- **Truffle / GraalVM**. Truffle objects are real JVM objects with a hidden-class `Shape`. Truffle Libraries replace plain Java interfaces with specialization-aware dispatch but the underlying values are normal JVM pointers traced by the JVM GC. GraalJS's array specializations are ~20 different representations, all reachable by the JVM GC without per-representation tracing code.
+- **CRuby + MMTk** (Ruby 3.4, end of 2024, ISMM 2025 "Reworking Memory Management in CRuby"). The biggest cost was teaching every Ruby data type to expose its pointer fields to the moving collector. CRuby had previously hidden some of those pointers inside C-side tables. The migration took multiple releases. We are doing the trivial version of this refactor: we just need Go to see Go pointers, and we do not need to support a moving collector.
+- **Goja** (JavaScript in Go, `dop251/goja`). Goja explicitly does **not** NaN-box. `Value` is an interface implemented by `valueInt`, `valueFloat`, `valueBool`, `*Object`, etc. Singletons (`_null`, `_undefined`, `_NaN`) are package-level vars so they never allocate.
+- **starlark-go** (`go.starlark.net/starlark`). Similar `Value` interface. Internal notes (`doc/impl.md`) are unusually frank about the cost: **"the cost of the additional GC write barriers incurred by every VM operation"** is called out as the bigger problem than the boxing itself, because every intermediate result is saved to the operand stack, which is on the heap. This matters for our design (see §3.4).
+- **Yaegi** (Go-in-Go interpreter). Maximally honest: every value is a `reflect.Value`. Frames are `[]reflect.Value`. Host Go pointers flow through unchanged.
+- **otto, expr**. Both reach for `interface{}` plus a discriminator and pay the eface-boxing tax on every arithmetic op. expr in particular shows up in profiles when used in hot loops.
+
+The common thread: **no successful Go-hosted VM uses NaN-boxing**, because Go does not let you teach the GC about tag bits in `uintptr`. Goja, starlark-go, otto, expr, Yaegi all came to the same conclusion independently.
+
+### 2.2 Go-specific cost model
+
+The numbers vm2 cares about, from running tip Go on darwin/arm64:
+
+- **`interface{}` (eface) layout**: two machine words (type descriptor + data pointer). For pointer-typed values (`*T`, `chan`, `map`, `func`, slice/string headers in modern Go) the data word *is* the value: no heap allocation. For non-pointer types (`int`, `int64`, structs without pointers), assignment to `interface{}` heap-allocates a copy (`convT64`, etc.) with two well-known exceptions: `staticuint64s` interns small uints, and zero values for booleans are interned. Cost: direct call ~1.45 ns vs interface call ~2.64 ns, 0 B/op for the call itself, but the boxing on every arithmetic op kills hot loops.
+- **`unsafe.Pointer`**: GC-traced when it holds a real Go pointer. **Not** GC-traced when stored as `uintptr`. Go's unsafe.Pointer rules explicitly forbid storing arbitrary bit patterns. `runtime.KeepAlive` only extends the lifetime of a *named variable* and is not a fix for unsafe.Pointer hacks (Go issue #47562). This is the single most important constraint for this MEP: **NaN-boxing into `uint64` is fundamentally incompatible with Go's GC.**
+- **Hybrid write barrier** (Austin et al., Go proposal 17503). Yuasa-style deletion shade plus conditional Dijkstra-style insertion shade. Stacks scanned once, no stack write barriers. Heap-write cost: roughly two atomic-store-equivalents on the slow path; inlined and skipped when GC is idle. The starlark-go cost note above is precisely this: every heap-stored operand in the bytecode interpreter pays a write barrier when GC is active. Operand stacks living on goroutine stacks pay nothing; operand stacks living in heap-allocated frames pay one barrier per write.
+- **Escape analysis**. Go has no generational nursery on the argument that escape analysis already promotes young objects to the stack; the would-be nursery survivors are mostly already gone. Our "nursery" is the operand stack itself.
+- **`sync.Pool` gotchas** (we removed it from vm2 earlier; this is why). Boxing on `Put` (always pool `*T`, never `T`), per-P locality (cross-goroutine reuse loses to stealing), pool churn affecting GOGC pacer. Useful only for `*T` reused by the same goroutine at very high rates.
+- **`GOMEMLIMIT`** (Go 1.19+) is the right knob, not the ballast hack. We will not need it for the interpreter but should expose it through the binary's environment for embedders.
+
+### 2.3 Allocation-minimization literature
+
+Even with Go's GC doing the tracing, allocations on the hot path are the dominant cost. The relevant body of work:
+
+- **Perceus** (Reinking, Xie, de Moura, Leijen; PLDI 2021 Distinguished Paper) for Koka. Compile-time reference counting with **reuse analysis**: when a refcount drops to 1 at last use, in-place mutation is legal. Drives "functional but in-place" (FBIP) algorithms that run at C-like speed in a functional language. Roc uses the same scheme, layered with Morphic uniqueness analysis. We do not need to import Perceus wholesale; we only need a lighter compile-time "is last use" bit per Cell register to license in-place `append` and `update` opcodes ([§3.5](#35-compile-time-last-use-bit)).
+- **PLDI 2024 dynamic heapification** (Anand et al., IIT Madras + IBM). OpenJ9 JIT does precise static escape analysis offline, emits stack-allocated objects optimistically, and inserts runtime checks that trigger "heapification" (copying an object from a stack frame to the heap and rewriting references) if dynamic features would otherwise let it escape. Relevant to the future tier-2 JIT (MEP-32), too heavy for the interpreter. Cited here so the MEP-34 work has a reference point for "when do we add this."
+- **V8 Smi**. LSB tagging keeps small integers in a register, with untag = arithmetic shift. We have a separate `int` field in the proposed Cell so we do not need bit-level Smi math.
+- **Project Valhalla** (JEP 401, EA in JDK 22+, "virtuous collapse" simplification after JVMLS 2024). Brian Goetz: *"value class is a semantic statement, not a layout decision."* Go already has this. Every Go struct is a value type by default. Our mistake in vm2 was throwing that away by encoding everything as `uint64`. Recovering it means making `Cell` a real struct.
+- **MEA2** (Wei et al., OOPSLA 2024). Field-sensitive escape analysis for Go, reporting 7.9% reduction in heap allocation sites for stdlib projects, mostly by handling interface conversions the Go compiler currently gives up on. We may benefit from this transparently as Go's compiler evolves.
+
+### 2.4 Concurrent GC trade-offs
+
+Surveyed for completeness in [MEP-35](/docs/mep/mep-0035); summarized here for context:
+
+- **Immix / LXR** (Blackburn & McKinley, PLDI 2008; Zhao et al., PLDI 2022). Mark-region collection with optional brief STW evacuation. Beats ZGC and Shenandoah on latency-critical benchmarks. Not directly portable to Go (we do not control the GC), cited because it is the modern baseline for "what good looks like."
+- **ZGC, Shenandoah load barriers**. Colored pointers, self-healing on load. Inspirational for our Objects-table migration story (we can self-heal during the rollout, see [§4.4](#44-migration-plan)).
+- **Bacon-Rajan trial-deletion** for RC cycle collection (OOPSLA 2001). Relevant only if we ever go Perceus-style; we are not, so we ignore.
+
+The recurring theme: every modern collector either (a) controls memory layout for its own values, or (b) is described to the host runtime via a typed schema. Option (a) is what we cannot afford. Option (b) is what we are doing, with Go structs as the schema.
+
+## Specification
+
+### 3.1 New Cell representation
+
+Replace the current 8-byte `type Cell uint64` with:
+
+```go
+// Cell is the vm2 value. Pointer-shaped payloads (lists, maps, heap strings,
+// closures, boxed big ints, structs, sets) live in Ptr, which holds a real
+// Go *T cast through unsafe.Pointer so Go's GC traces the pointee directly.
+// Scalar values (int48, bool, float64, short strings up to ~12 bytes) live
+// in Int / fields, with Tag discriminating.
+type Cell struct {
+    Tag uint32         // see CellTag enum
+    Pad uint32         // alignment; future: refcount hint, shape index
+    Int int64          // inline scalar payload, also Float64bits, also short-string bytes
+    Ptr unsafe.Pointer // GC-traced when Tag indicates a pointer kind
+}
+```
+
+Width: 24 bytes on 64-bit platforms. This is 3x today's 8-byte Cell. The cost is paid in register-file bandwidth (the operand stack is a `[]Cell`); the win is paid in eliminating the Objects table dereference on every container op.
+
+The choice of `unsafe.Pointer` over `any` (eface) is deliberate:
+
+- `unsafe.Pointer` is 1 word; `any` is 2 words. The Cell is already 3 words; adding a 4th to get a 32-byte Cell costs cache locality.
+- `unsafe.Pointer` is traced by Go's GC when it holds a real Go pointer. We must never store a `uintptr` in it.
+- Dispatch via `Tag` is a switch on a `uint32`, faster than the iface itab lookup (~1 ns per dispatch saved).
+- Goja's `valueInt` design (one of the points of comparison) uses an interface but their hot paths bypass it. The `unsafe.Pointer` form is the same idea without the iface overhead.
+
+Tag values:
+
+```go
+type CellTag uint32
+const (
+    TagNull   CellTag = iota
+    TagBool
+    TagInt    // 64-bit, inline in Int
+    TagFloat  // float64 bits in Int
+    TagSStr   // short string in Int + low bits of Pad
+    TagStr    // heap string: Ptr is *vmString
+    TagList   // Ptr is *vmList
+    TagMap    // Ptr is *vmMap
+    TagSet    // Ptr is *vmSet
+    TagStruct // Ptr is *vmStruct
+    TagClosure // Ptr is *vmClosure
+    TagBigInt  // Ptr is *big.Int
+    TagDeopt   // JIT deopt sentinel; Int carries PC, Ptr nil
+)
+```
+
+The inline integer range grows from 48-bit to full 64-bit because we have the room; `FitsInline` becomes vestigial. Float64 is unboxed (no separate NaN-boxing).
+
+Short strings grow from 5 bytes to 12 bytes (using all of `Int` plus low bytes of `Pad` for length and bytes), aligning with the C++ SSO sweet spot. Longer strings become `Ptr = *vmString` and Go's string header inside `vmString` carries its own GC-traced backing.
+
+### 3.2 Delete the Objects table
+
+`VM.Objects []any` and `VM.AddObject` are removed. The constructors in `lists.go`, `maps.go`, `strings.go`, and the planned `sets.go` / `structs.go` change from:
+
+```go
+func NewList(vm *VM, n int) Cell {
+    l := &vmList{...}
+    idx := vm.AddObject(l)
+    return CPtr(idx)
+}
+```
+
+to:
+
+```go
+func NewList(n int) Cell {
+    l := &vmList{...}
+    return Cell{Tag: TagList, Ptr: unsafe.Pointer(l)}
+}
+```
+
+The accessor side simplifies symmetrically:
+
+```go
+// before
+func (c Cell) AsList(vm *VM) *vmList { return vm.Objects[c.Ptr()].(*vmList) }
+// after
+func (c Cell) AsList() *vmList { return (*vmList)(c.Ptr) }
+```
+
+No bounds check, no type assertion, no interface unbox. The 5-8% CPU we measured in `lists.go:28`, `maps.go:19`, and `strings.go:38` returns to the user.
+
+The `VM` struct loses one field. The `popFrame` doc comment that said "popFrame must zero ptr-tagged slots before shrinking" becomes correct: writing a zero Cell into a slot clears the `Ptr` field, which un-pins the pointee for Go's GC. Tracked in [§3.6](#36-frame-cleanup-and-write-barriers).
+
+### 3.3 Container layouts
+
+Each container becomes a plain Go struct, allocated with `new` or `&`, traced by Go's GC normally.
+
+```go
+type vmList struct {
+    Cells []Cell // GC traces this slice header and its backing array
+    // future: shape, type tag for monomorphic specialization
+}
+
+type vmMap struct {
+    M map[Cell]Cell // Go's map, GC-traced; future: Robin Hood hash table for footprint
+}
+
+type vmString struct {
+    S string // Go's string header, GC-traced backing
+}
+
+type vmSet struct { M map[Cell]struct{} }
+
+type vmStruct struct {
+    Shape *vmShape // intern-tracked
+    Fields []Cell
+}
+
+type vmClosure struct {
+    Fn *Function
+    Captures []Cell
+}
+```
+
+Nothing about these layouts is novel; they are the obvious Go translations. The point of the MEP is that they are now possible because the Cell can carry their pointer directly.
+
+### 3.4 Operand stack still on the heap
+
+The operand stack lives in `VM.Stack []Cell` and the active window is `Stack[Frames[i].RegsBase : ...]` (see `vm.go:14-25`). It is a heap slice, not a goroutine stack frame, because it must grow geometrically across deep recursion and be reusable across calls.
+
+The starlark-go cost note from §2.1 applies here: writing a pointer-typed Cell into `VM.Stack[i]` pays a heap write barrier when GC is active. We mitigate by:
+
+1. **Pure-numeric paths stay barrier-free.** Writing a `TagInt` or `TagFloat` Cell touches only `Tag` and `Int`; the `Ptr` field is left zero. Go's write barrier triggers per *pointer-typed field assignment*, not per *struct copy* — but the compiler conservatively shades the whole struct. To suppress barriers for non-pointer writes we can write the two scalar fields separately when the compiler can prove the Tag indicates non-pointer. This is the same trick Goja and starlark-go use indirectly via separate concrete types. We will measure and decide whether the manual field-store is worth the readability cost (see [§5 Open Questions](#open-questions)).
+2. **Per-frame scratch lives on the operand stack.** A frame that needs scratch slots reserves them as registers. The compiler already does this. We do not introduce a separate per-frame arena because the stack *is* the arena.
+
+### 3.5 Compile-time last-use bit
+
+Add a 1-bit annotation per Cell register read in the bytecode: "this read is the last use of this register in this basic block." The interpreter ignores it; the container ops consult it to license in-place mutation:
+
+- `OpListPush(dst, src, elem)` where `src` is a last-use read becomes a true in-place push (no copy of the backing array).
+- `OpListSet(dst, src, i, v)` similarly.
+- `OpMapSet`, `OpSetAdd`, `OpStructSet` likewise.
+
+This is a small fraction of the full Perceus / Roc reuse analysis but captures the dominant case: a fluent chain `xs.append(1).append(2).append(3)` translates to three in-place pushes on a single backing array, with Go's GC never seeing the intermediate.
+
+The annotation is emitted by the bytecode compiler's existing register allocator, which already knows last-use information (it uses it to free registers). We add one bit to the operand encoding and consult it in the container fast-paths.
+
+### 3.6 Frame cleanup and write barriers
+
+`popFrame` zeroes the slice window before sliding the stack pointer back:
+
+```go
+func (vm *VM) popFrame() {
+    top := len(vm.Frames) - 1
+    base := vm.Frames[top].RegsBase
+    n := vm.Frames[top].Fn.NumRegs
+    clear(vm.Stack[base : base+n]) // un-pin all Ptr fields for GC
+    vm.Stack = vm.Stack[:base]
+    vm.Frames[top] = frame{}
+    vm.Frames = vm.Frames[:top]
+}
+```
+
+`clear` on a `[]Cell` writes a zero `Cell{}`, which sets `Ptr = nil`. The write barrier fires once per slot during the clear, but this is a single pass per call return — not per pointer write — and frees the GC to reclaim the popped frame's pointees on the next cycle.
+
+A future micro-optimization is to skip the clear when no slot in the popped window was ever a pointer Cell (tracked by a per-frame `pointerSlots uint64` bitmap, or by a "max-pointer-tag-seen" watermark). The bytecode compiler can stamp a static lower bound for `pointerSlots` per function based on which opcodes the function executes, and the interpreter narrows it dynamically. Deferred to a follow-up.
+
+### 3.7 JIT register file contract (interaction with MEP-34)
+
+[MEP-34](/docs/mep/mep-0034) freezes the frame-compatibility contract: a JIT'd function and an interpreted function must share the same register file shape so calls in either direction are zero-copy. This MEP changes the Cell from 8 bytes to 24 bytes, which the JIT must absorb.
+
+Two consequences:
+
+1. **Cell-shaped registers in JIT code.** Each register slot becomes three consecutive 8-byte words in the JIT's stack frame, addressed by an `add x_reg, x_base, #offset` pattern. The MEP-34 ARM64 lowering already uses a base+offset addressing mode; the offset just triples.
+2. **Pointer registers visible to the runtime.** When a JIT'd function is suspended at a safepoint (today: only at deopt; tomorrow: at any GC poll point), the GC must be able to walk the register file. With `Cell.Ptr` as `unsafe.Pointer`, Go's runtime already traces the register file as long as it lives in a Go-allocated `[]Cell` slice. The JIT must keep its register file in vm.Stack, not in private mmap'd memory. MEP-34 phase 1.5 already commits to this contract.
+
+The deopt sentinel becomes `Cell{Tag: TagDeopt, Int: int64(pc), Ptr: nil}`, mechanically equivalent to the current encoding.
+
+### 3.8 FFI shims
+
+Any Go code that today does `vm.Objects[c.Ptr()].(*T)` is rewritten to `(*T)(c.Ptr)`. The `runtime/jit/vm2jit/...` package, the compiler2 emitter, and the tracejit interface are the three known callers. Each is mechanical, none requires a protocol change.
+
+## Rationale
+
+### 4.1 Why a struct Cell, not a typed union
+
+Go has no `union`. The plausible alternatives:
+
+- **Stay with `uint64` NaN-boxed.** Rejected — fundamentally hides pointers from GC.
+- **`interface{}` Cell.** Two-word, but stores non-pointer types via heap-allocated boxes. Hot paths lose to escape analysis losing visibility through the iface.
+- **`type Cell [3]uintptr`** with manual reinterpretation. Cute, but loses GC tracing on the Ptr slot unless we declare a field explicitly.
+- **Three-field struct (this proposal).** GC-honest, no boxing for scalars, no boxing for pointers, switch dispatch on Tag.
+
+The starlark-go and Goja designs both confirm the third option works. WasmGC validates the underlying principle on a different host.
+
+### 4.2 Why 24 bytes, not 16
+
+A two-field Cell (`tag uint32 + payload uint64`) is 16 bytes and fits in one cache line per 4 Cells. But it forces every pointer Cell to *also* allocate a single-word indirection (because we need both Tag and Ptr in the same slot and they don't fit), which reintroduces the indirection-table problem in a different shape. The three-field design accepts the 3x size cost on the register file to keep the pointer inline.
+
+A future revision could explore a 16-byte Cell with the Tag stamped into the low bits of `Ptr` (LuaJIT-style on x86-64 where pointers are 48-bit), but Go's `unsafe.Pointer` rules forbid stuffing tags into pointer bits — the GC will refuse to trace, or worse, will trace garbage. We accept 24 bytes.
+
+### 4.3 Why delete the Objects table entirely instead of keeping it as a fallback
+
+We could keep `Objects` for "wide" boxed values (futures, channels, FFI handles) while moving everything else to `Cell.Ptr`. But that leaves two parallel reachability stories, and the cost we wanted to eliminate (the bounds check + type assertion on every access) only goes away if **every** access takes the new path. Migration aside (§4.4), the steady state is "one mechanism, fully GC-traced."
+
+### 4.4 Migration plan
+
+Three phases, each independently mergeable, each gated by the MEP-23 + MEP-17 benchmark suite with no per-workload regression:
+
+**Phase 1: Cell becomes a struct, Objects table preserved.**
+
+- `Cell` becomes a 24-byte struct. `Tag`, `Int`, `Ptr` fields added. Constructors keep going through `vm.AddObject`; `Cell.Ptr` stores `unsafe.Pointer(&objects[idx])` on construction so the new accessor path works.
+- All callers migrate from `vm.Objects[c.Ptr()].(*T)` to `(*T)(c.Ptr)`. The Objects table still holds a redundant reference for the moment, so nothing is lost if a Cell is zeroed.
+- Self-healing accessor: `AsList()` checks `c.Ptr != nil` first; falls back to the Objects table if not. Lets us roll out one container at a time.
+
+Merge gate: every existing test passes; bench regression bounded to register-file size cost (target: less than 10% on pure-numeric loops, where the operand stack does triple in bytes).
+
+**Phase 2: Constructors return Cell directly without Objects.**
+
+- `NewList`, `NewMap`, `NewString`, `NewSet`, `NewStruct`, `NewClosure` stop calling `AddObject`. Returned Cell has `Ptr` set to the freshly-allocated `*T`. Go's GC takes over.
+- `popFrame` zeroes the window. Validate with `GODEBUG=gctrace=1` that long-running programs no longer leak.
+
+Merge gate: a stress test that allocates 10^8 lists in a loop and reads `runtime.MemStats.HeapAlloc` between batches must show flat live-heap (proving GC reclaims dead lists). Steady-state allocs/op on the MEP-23 list and map workloads improves; no regression elsewhere.
+
+**Phase 3: Delete the Objects table, last-use bit, in-place mutation.**
+
+- `VM.Objects`, `VM.AddObject`, the self-heal path are removed.
+- Bytecode compiler emits last-use bits on container ops. Container fast paths consult them. In-place mutation lands behind a feature flag for one minor release, then becomes the default.
+- The Phase-3 "after" benchmark MEP (Informational, similar to MEP-29 / MEP-33) reports the final numbers head-to-head against the original NaN-boxed implementation.
+
+Merge gate: parity with Phase 2 on every workload, with measurable win on list-fluent-chain and map-update benchmarks; no regression.
+
+## Backwards Compatibility
+
+No language-surface change. No bytecode change in Phase 1 (the Cell layout is internal). Phase 3 adds last-use annotations to operand encodings, which is a forward-compatible extension: old bytecode without the bit reads as "not last use," and the interpreter falls back to the copying path.
+
+The JIT register file contract changes from 8-byte Cell slots to 24-byte Cell slots (§3.7). All MEP-34 JIT code must be rebuilt against the new Cell. There is no plan to ship a Cell-layout-versioned cached JIT artifact; the JIT is regenerated per-process today.
+
+FFI callers (any code outside `runtime/vm2` that constructs or reads a Cell) must move from the NaN-boxing accessors to the new struct field accessors. We grep the tree once at Phase 1 and update every caller in a single PR.
+
+## Reference Implementation
+
+Phase 1 lands behind a `GOEXPERIMENT=vm2cell24` build tag (Mochi's own, not Go's) so the rollout is reversible. Files touched:
+
+- [`runtime/vm2/cell.go`](https://github.com/mochilang/mochi/blob/main/runtime/vm2/cell.go) — new struct, new constructors, new accessors, kept-as-deprecated NaN-boxed helpers behind the build tag for one release.
+- [`runtime/vm2/vm.go`](https://github.com/mochilang/mochi/blob/main/runtime/vm2/vm.go) — Objects table deletion in Phase 3; popFrame clear in Phase 2.
+- [`runtime/vm2/lists.go`](https://github.com/mochilang/mochi/blob/main/runtime/vm2/lists.go), [`maps.go`](https://github.com/mochilang/mochi/blob/main/runtime/vm2/maps.go), [`strings.go`](https://github.com/mochilang/mochi/blob/main/runtime/vm2/strings.go) — constructors and accessors.
+- `runtime/vm2/sets.go`, `runtime/vm2/structs.go` — net-new under [MEP-24](/docs/mep/mep-0024), born using the new representation.
+- [`runtime/vm2/eval.go`](https://github.com/mochilang/mochi/blob/main/runtime/vm2/eval.go) — Cell read/write hot paths, write-barrier-aware stores.
+- [`runtime/vm2/ops.go`](https://github.com/mochilang/mochi/blob/main/runtime/vm2/ops.go) — last-use bit in Phase 3.
+- `runtime/jit/vm2jit/...` — Cell slot stride change in MEP-34 lowering tables.
+
+A measured-results MEP (Informational, numbered after the Phase-3 merge) will report the final numbers, mirroring the pattern of [MEP-29](/docs/mep/mep-0029) (dispatch) and [MEP-33](/docs/mep/mep-0033) (template JIT).
+
+## Open Questions
+
+1. **Field-level write barrier suppression for scalar writes.** The Go compiler currently shades the whole struct on any write to a pointer-containing struct. Splitting Cell writes into "write Tag+Int" and "write Ptr only when pointer-typed" is mechanically possible but verbose. The exact win is unknown until we measure. If small, we leave the struct write alone.
+2. **Cell size vs cache pressure.** 24-byte Cells triple operand-stack bandwidth. The MEP-23 pure-numeric workloads (fib_rec, primes_iter) are the regression risk. If the measured slowdown exceeds the elimination of the Objects-table indirection, we revisit a 16-byte Cell with a tagged-pointer scheme (and accept the GC roughness via a manual mark-traverse helper at every GC poll). Strong preference is to ship 24-byte first and only revisit if numbers force it.
+3. **`any` vs `unsafe.Pointer` for the Ptr slot.** `any` would let us drop the Tag for pointer kinds (the iface type carries the discriminator). The cost is 1 extra word and the iface itab lookup on dispatch. Likely not worth it, but worth a microbenchmark.
+4. **Generational interaction with future Go versions.** If Go ships a generational collector (rumored periodically), Cell.Ptr fields containing recently-allocated containers would benefit from nursery promotion automatically. Nothing to do here other than not block it.
+5. **Concurrent Mochi programs.** This MEP assumes single-goroutine Run. A future multi-goroutine VM (channels, async) introduces cross-goroutine pointer publication, which Go's write barrier already handles correctly. No design change anticipated.
+6. **Auto memory management ([MEP-35](/docs/mep/mep-0035)) supersession.** Once this MEP ships, MEP-35's three options (Perceus-style RC, regions, Immix-shape collector) all collapse to "Go's GC handles it." MEP-35 should be marked Superseded by MEP-36 in Phase 3.
+
+## References
+
+- Reinking, Xie, de Moura, Leijen. *Perceus: Garbage Free Reference Counting with Reuse.* PLDI 2021. (Distinguished Paper.)
+- Blackburn, McKinley. *Immix: A Mark-Region Garbage Collector with Space Efficiency, Fast Collection, and Mutator Performance.* PLDI 2008.
+- Zhao, Blackburn, McKinley. *Low-Latency, High-Throughput Garbage Collection.* PLDI 2022.
+- Anand et al. *Optimistic Stack Allocation and Dynamic Heapification for Managed Runtimes.* PLDI 2024.
+- Wang, Blackburn, Zhu, Valentine-House. *Reworking Memory Management in CRuby.* ISMM 2025.
+- Wei et al. *MEA2: Lightweight Field-Sensitive Escape Analysis for Go.* OOPSLA 2024.
+- Bacon, Rajan. *Concurrent Cycle Collection in Reference Counted Systems.* OOPSLA 2001.
+- Yuasa. *Real-time Garbage Collection on General-Purpose Machines.* Journal of Systems and Software, 1990.
+- Dijkstra, Lamport, Martin, Scholten, Steffens. *On-the-Fly Garbage Collection: An Exercise in Cooperation.* CACM 1978.
+- Austin et al. *Go Proposal 17503: Eliminate STW Stack Re-scanning.* (Hybrid write barrier.)
+- Goetz, B. *Project Valhalla: A First Look at Value Classes.* JEP 401.
+- V8 team. *A New Way to Bring Garbage Collected Languages Efficiently to WebAssembly.*
+- WebAssembly Community Group. *GC Proposal Overview.*
+- starlark-go. *Implementer's notes.*
+- dop251/goja. *value.go.*
+- traefik/yaegi. *interp/value.go.*
+- Truffle / GraalVM. *Truffle Library Guide; Shape Javadoc.*
+- Internal Mochi MEPs: [MEP-17](/docs/mep/mep-0017), [MEP-18](/docs/mep/mep-0018), [MEP-19](/docs/mep/mep-0019), [MEP-20](/docs/mep/mep-0020), [MEP-21](/docs/mep/mep-0021), [MEP-23](/docs/mep/mep-0023), [MEP-24](/docs/mep/mep-0024), [MEP-29](/docs/mep/mep-0029), [MEP-33](/docs/mep/mep-0033), [MEP-34](/docs/mep/mep-0034), [MEP-35](/docs/mep/mep-0035).
+
+## Copyright
+
+This document is placed in the public domain.

--- a/website/src/data/meps.json
+++ b/website/src/data/meps.json
@@ -286,5 +286,13 @@
     "type": "Standards Track",
     "description": "Survey of modern auto memory management (Perceus / Koka / Roc, Inko, Lobster, Verona / Reggio regions, Immix / LXR, MMTk, generational ZGC / Shenandoah, JSC Riptide) and a design overview for reclaiming entries in the vm2 Objects table. Today the table is append-only inside a Run: every list, map, heap string, closure, and boxed big-int allocated by a program stays live until Run exits, regardless of whether the program still references it. This MEP proposes three implementation options (Perceus-style reference counting with reuse, per-frame region arenas, and an Immix / LXR mark-region collector layered over the Objects table) and a recommendation.",
     "slug": "/docs/mep/mep-0035"
+  },
+  {
+    "number": 36,
+    "title": "Restructure VM2 to Reuse Go's GC",
+    "status": "Draft",
+    "type": "Standards Track",
+    "description": "Restructure the vm2 value representation so that pointer-shaped values (lists, maps, heap strings, closures, boxed big ints, structs, sets) are stored as real Go pointers visible to Go's tricolor concurrent mark-sweep collector, and the per-Run Objects []any indirection table is deleted. Today the NaN-boxed Cell hides every pointer inside a uint64, so Go's GC traces only the table, never the values, and the table grows monotonically for the lifetime of a Run. This MEP surveys modern VM-on-host-GC designs (Goja, starlark-go, Yaegi, Truffle, WasmGC, CRuby + MMTk), the Go-specific cost of interface boxing and the hybrid write barrier, and the allocation-minimization literature (Perceus, Roc, PLDI 2024 dynamic heapification, V8 Smi, .NET / Valhalla value types), then specifies the refactor: a struct Cell with an unsafe.Pointer slot for GC-traced payloads, an inline scalar slot for ints / bools / floats / short strings, a per-Run free list of typed pointers for object reuse, and a compile-time last-use bit on registers that enables in-place mutation for the common append / update pattern. The goal is zero allocations on the hot path for pure-numeric loops, one Go-tracked allocation per container constructor and zero per element, and full reclamation of dead containers between GC cycles without a custom collector.",
+    "slug": "/docs/mep/mep-0036"
   }
 ]


### PR DESCRIPTION
Fixes #21559.

Draft MEP-36 proposing to restructure vm2 so pointer-shaped values are stored as real Go pointers visible to Go's GC, and the per-Run `Objects []any` indirection table is deleted.

## Summary

- **Problem.** Today's NaN-boxed `Cell uint64` hides every pointer inside a `uint64`, so Go's GC traces only the per-Run `vm.Objects` table, not the values themselves. The table is append-only inside a Run, so memory grows monotonically until `Run()` exits. Every container access also pays a bounds check plus an interface unbox in `lists.go:28`, `maps.go:19`, `strings.go:38`.
- **Proposal.** Replace `Cell` with a 24-byte struct (`Tag uint32`, `Int int64`, `Ptr unsafe.Pointer`). Pointer-shaped payloads (lists, maps, heap strings, closures, boxed big ints, structs, sets) become real Go pointers in `Cell.Ptr`, GC-traced directly. Scalar payloads (int64, bool, float64, short strings up to ~12 bytes) live in `Int`. Delete the Objects table.
- **Goals.** Zero heap allocations on the hot path for pure-numeric loops. One Go-tracked allocation per container constructor, zero per element. Full reclamation of dead containers between GC cycles without a custom collector.
- **Research.** Surveys modern VM-on-host-GC designs (Goja, starlark-go, Yaegi, Truffle, WasmGC, CRuby + MMTk), Go-specific costs (eface boxing, unsafe.Pointer rules, hybrid write barrier, sync.Pool gotchas, GOMEMLIMIT), and the allocation-minimization literature (Perceus PLDI '21, PLDI '24 dynamic heapification, V8 Smi, Valhalla, MEA2 OOPSLA '24).
- **Three-phase rollout**, each independently mergeable and benchmark-gated:
  1. Struct Cell with Objects-table self-heal (no behavioral change).
  2. Constructors return Cell directly; popFrame zeroes the window so GC can reclaim.
  3. Delete Objects table; add compile-time last-use bit; in-place mutation behind a feature flag.
- **Supersession.** Once this MEP ships, MEP-35's three options (Perceus RC, regions, Immix-shape collector) collapse to "Go's GC handles it"; MEP-35 will be marked Superseded by MEP-36 in Phase 3.

`website/src/data/meps.json` regenerated via `npm run gen:meps`.

## Test plan

- [ ] Cloudflare Pages preview is green.
- [ ] `https://mochi-lang.dev/docs/mep/mep-0036` renders.
- [ ] `https://mochi-lang.dev/docs/mep/` shows MEP-36 in the auto-generated index with status Draft.
- [ ] MEP-0000 hand-maintained table includes the new MEP-36 row.