### PR TITLE
website: extend mepSidebar with MEPs 30 through 36

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -122,6 +122,29 @@ const sidebars = {
         'mep/mep-0029',
       ],
     },
+    {
+      label: 'JIT',
+      type: 'category',
+      className: 'sidebar-heading',
+      collapsed: false,
+      items: [
+        'mep/mep-0030',
+        'mep/mep-0031',
+        'mep/mep-0032',
+        'mep/mep-0033',
+        'mep/mep-0034',
+      ],
+    },
+    {
+      label: 'Memory',
+      type: 'category',
+      className: 'sidebar-heading',
+      collapsed: false,
+      items: [
+        'mep/mep-0035',
+        'mep/mep-0036',
+      ],
+    },
   ],
 };
 


### PR DESCRIPTION
Fixes #21561.

The MEP sidebar on https://mochi-lang.dev/docs/mep stops at MEP-29 because `sidebars.js` `mepSidebar` is hand-maintained and was never extended past the original "VM & Runtime" group. MEPs 30-36 ship as files and appear on the auto-generated `/docs/mep` index but were missing from the left nav.

## Summary

- Add a "JIT" group for MEPs 30-34 (Template JIT, Tracing JIT, Tiered Method JIT, MEP-30 Measured Results, Full-Opcode JIT).
- Add a "Memory" group for MEPs 35-36 (Auto Memory Management, Restructure VM2 to Reuse Go's GC).

## Test plan

- [ ] Cloudflare Pages preview is green.
- [ ] `https://mochi-lang.dev/docs/mep` left sidebar shows the two new groups expanded and MEPs 30 through 36 are clickable.
- [ ] Navigating to `https://mochi-lang.dev/docs/mep/mep-0036` still works.

## Follow-up

The hand-maintained sidebar is the recurring source of this drift. Worth considering auto-generating `mepSidebar` from `src/data/meps.json` so adding a MEP only needs one place to be touched. Tracking in #21561.