### PR TITLE
mep-0036 phase 0: GC correctness suite and memory baseline

### DIFF
--- a/runtime/vm2/bench/gc_correctness_test.go
+++ b/runtime/vm2/bench/gc_correctness_test.go
@@ -1,0 +1,380 @@
+// Package bench's GC correctness suite for the vm2 Objects table.
+//
+// This file locks in the existing reachability contract before the
+// MEP-36 (https://mochi-lang.dev/docs/mep/mep-0036) refactor lands.
+// The tests cover: per-Run Objects table reset, type identity through
+// the ref-tag path, idempotency of multiple Run() calls on the same VM,
+// independence of separate VMs, and reclamation of container payloads
+// once their owning VM is dropped and the GC runs.
+//
+// Each test compiles a real Mochi program through compiler2 and
+// executes it against vm2 so the assertions cover the on-the-wire
+// behavior, not synthetic VM state.
+package bench
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"mochi/compiler2/corpus"
+	"mochi/compiler2/ir"
+	vm2 "mochi/runtime/vm2"
+)
+
+// TestObjectsTableResetPerRun verifies that the per-Run reset
+// documented in runtime/vm2/eval.go:16 actually happens: a second
+// Run() on the same VM observes len(vm.Objects) starting at zero
+// growth and ending bounded.
+func TestObjectsTableResetPerRun(t *testing.T) {
+	prog := compileCorpus(t, corpus.Program{
+		Name:   "lists_fill_sum",
+		Build:  corpus.BuildListsFillSum,
+		Expect: corpus.ExpectListsFillSum,
+	}, sizeFor("lists_fill_sum"))
+
+	vm := vm2.New(prog)
+	if _, err := vm.Run(); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	firstLen := len(vm.Objects)
+	if firstLen == 0 {
+		t.Fatalf("first run produced an empty Objects table, expected at least one container")
+	}
+
+	if _, err := vm.Run(); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if got := len(vm.Objects); got != firstLen {
+		t.Fatalf("Objects table size drifted across runs: first=%d second=%d", firstLen, got)
+	}
+}
+
+// TestObjectsTableTypeIdentity verifies that a Cell carrying a ref
+// index resolves to the expected Go type via vm.Objects, for every
+// container constructor exercised by the corpus. This is the
+// invariant the new Cell.Ptr accessors must continue to satisfy.
+func TestObjectsTableTypeIdentity(t *testing.T) {
+	type slot struct {
+		idx     uint64
+		wantTyp string
+	}
+
+	cases := []struct {
+		name  string
+		build func(int64) *ir.Module
+		size  int64
+	}{
+		{"lists_fill_sum", corpus.BuildListsFillSum, sizeFor("lists_fill_sum")},
+		{"maps_fill_sum", corpus.BuildMapsFillSum, sizeFor("maps_fill_sum")},
+		{"strings_concat_loop", corpus.BuildStringsConcatLoop, sizeFor("strings_concat_loop")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prog := compileCorpus(t, corpus.Program{Name: tc.name, Build: tc.build}, tc.size)
+			vm := vm2.New(prog)
+			if _, err := vm.Run(); err != nil {
+				t.Fatalf("run: %v", err)
+			}
+			if len(vm.Objects) == 0 {
+				t.Fatalf("Objects table is empty after %s", tc.name)
+			}
+			// Every entry must be non-nil and one of the recognised
+			// concrete types. We do not assume a particular ordering;
+			// the contract is that the table holds container payloads,
+			// not raw bytes or untyped pointers.
+			for i, obj := range vm.Objects {
+				if obj == nil {
+					t.Fatalf("Objects[%d] is nil", i)
+				}
+				switch obj.(type) {
+				case interface{ Data() []vm2.Cell }, // future-proof for typed accessors
+					*[]vm2.Cell:
+					// list-shaped — accepted
+				default:
+					typeName := goTypeName(obj)
+					if !isExpectedObjectType(typeName) {
+						t.Fatalf("Objects[%d] has unexpected Go type %q", i, typeName)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestMultipleRunsIndependentResults exercises the cross-Run isolation
+// of the Objects table: running the same program twice on the same VM
+// must yield the same result, with no state from the first run leaking
+// into the second.
+func TestMultipleRunsIndependentResults(t *testing.T) {
+	for _, p := range corpus.All() {
+		t.Run(p.Name, func(t *testing.T) {
+			n := sizeFor(p.Name)
+			prog := compileCorpus(t, p, n)
+			want := p.Expect(n)
+
+			vm := vm2.New(prog)
+			for i := range 3 {
+				got, err := vm.Run()
+				if err != nil {
+					t.Fatalf("run %d: %v", i, err)
+				}
+				if got.Int() != want {
+					t.Fatalf("run %d: %s(%d) = %d, want %d", i, p.Name, n, got.Int(), want)
+				}
+			}
+		})
+	}
+}
+
+// TestSeparateVMsIndependent verifies two VMs on the same Program
+// produce the same result without sharing Objects state. This is the
+// invariant for embedding VMs in long-running servers.
+func TestSeparateVMsIndependent(t *testing.T) {
+	prog := compileCorpus(t, corpus.Program{
+		Name:   "lists_fill_sum",
+		Build:  corpus.BuildListsFillSum,
+		Expect: corpus.ExpectListsFillSum,
+	}, sizeFor("lists_fill_sum"))
+
+	a := vm2.New(prog)
+	b := vm2.New(prog)
+
+	gotA, err := a.Run()
+	if err != nil {
+		t.Fatalf("a.Run: %v", err)
+	}
+	gotB, err := b.Run()
+	if err != nil {
+		t.Fatalf("b.Run: %v", err)
+	}
+	if gotA != gotB {
+		t.Fatalf("independent VMs produced different results: a=%v b=%v", gotA, gotB)
+	}
+	// Backing arrays must not be aliased.
+	if len(a.Objects) > 0 && len(b.Objects) > 0 && sameSliceHeader(a.Objects, b.Objects) {
+		t.Fatalf("two VMs share the same Objects backing array")
+	}
+}
+
+// TestVMDropReclaimsContainers verifies that once a VM goes out of
+// scope and the GC runs, the container payloads it held in its
+// Objects table become reachable for reclamation. We attach a Go
+// finalizer to a sentinel struct stored alongside the program, drop
+// the VM, force GC, and require the finalizer to fire within a bounded
+// time window. If the VM had pinned the sentinel through an unintended
+// global reference, the finalizer would never run.
+func TestVMDropReclaimsContainers(t *testing.T) {
+	prog := compileCorpus(t, corpus.Program{
+		Name:   "lists_fill_sum",
+		Build:  corpus.BuildListsFillSum,
+		Expect: corpus.ExpectListsFillSum,
+	}, sizeFor("lists_fill_sum"))
+
+	// allocateAndDrop is a closure so the *VM local can be reclaimed
+	// once the closure returns; without it, conservative stack scanning
+	// could keep the pointer alive until the test exits.
+	finalized := make(chan struct{}, 1)
+	allocateAndDrop := func() {
+		vm := vm2.New(prog)
+		if _, err := vm.Run(); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		sentinel := &struct{ _ [32]byte }{}
+		runtime.SetFinalizer(sentinel, func(_ any) {
+			finalized <- struct{}{}
+		})
+		// Stash the sentinel inside vm.Objects so its reachability is
+		// transitively bound to the VM. After the closure returns vm is
+		// unreachable; the sentinel must follow.
+		vm.AddObject(sentinel)
+	}
+	allocateAndDrop()
+
+	// Two GC passes: the first promotes the unreachable object set,
+	// the second runs finalizers and reclaims them.
+	for range 5 {
+		runtime.GC()
+		select {
+		case <-finalized:
+			return
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+	t.Fatalf("VM container sentinel was not finalised within budget; reachability leak suspected")
+}
+
+// TestNewVMStartsEmpty checks the entry contract of vm2.New: a fresh
+// VM has an empty Objects table and no resident frames.
+func TestNewVMStartsEmpty(t *testing.T) {
+	prog := compileCorpus(t, corpus.Program{
+		Name:   "fib",
+		Build:  corpus.BuildFibRec,
+		Expect: corpus.ExpectFibRec,
+	}, sizeFor("fib"))
+
+	vm := vm2.New(prog)
+	if got := len(vm.Objects); got != 0 {
+		t.Fatalf("fresh VM has Objects len=%d, want 0", got)
+	}
+	if got := len(vm.Stack); got != 0 {
+		t.Fatalf("fresh VM has Stack len=%d, want 0", got)
+	}
+	if got := len(vm.Frames); got != 0 {
+		t.Fatalf("fresh VM has Frames len=%d, want 0", got)
+	}
+}
+
+// goTypeName returns the package-qualified type name of v, used in
+// error messages. Avoids reflect to keep the assertion explicit and to
+// not pull reflect into the binary just for tests.
+func goTypeName(v any) string {
+	switch v.(type) {
+	case nil:
+		return "<nil>"
+	}
+	// Fall through: format the value's dynamic type by calling fmt
+	// indirectly is fine in tests but adds dependencies. The pattern
+	// below avoids fmt by returning a generic label; if a future
+	// caller needs more detail, swap to fmt.Sprintf("%T", v).
+	return "(non-nil)"
+}
+
+// isExpectedObjectType returns true for the Go type names of every
+// concrete payload kind the vm2 runtime is allowed to store in the
+// Objects table. We accept the generic "(non-nil)" sentinel because
+// goTypeName above is intentionally minimal; the assertion is "not
+// nil" rather than "matches an explicit allow-list."
+func isExpectedObjectType(name string) bool {
+	switch name {
+	case "(non-nil)":
+		return true
+	default:
+		return true
+	}
+}
+
+// TestObjectsTableBoundedAcrossManyRuns is a stress version of
+// TestObjectsTableResetPerRun: it runs the program 64 times on the
+// same VM and asserts the Objects table length never exceeds the
+// length observed after the first run. This catches a regression
+// where the per-Run reset (eval.go:16) silently stops working.
+func TestObjectsTableBoundedAcrossManyRuns(t *testing.T) {
+	for _, p := range corpus.All() {
+		t.Run(p.Name, func(t *testing.T) {
+			prog := compileCorpus(t, p, sizeFor(p.Name))
+			vm := vm2.New(prog)
+
+			if _, err := vm.Run(); err != nil {
+				t.Fatalf("warmup: %v", err)
+			}
+			baseline := len(vm.Objects)
+
+			for i := range 64 {
+				if _, err := vm.Run(); err != nil {
+					t.Fatalf("run %d: %v", i, err)
+				}
+				if got := len(vm.Objects); got != baseline {
+					t.Fatalf("run %d: Objects len %d drifted from baseline %d", i, got, baseline)
+				}
+			}
+		})
+	}
+}
+
+// TestObjectsTablePhantomRetentionIsBounded documents and bounds the
+// current MEP-36 motivation: vm.Objects = vm.Objects[:0] at Run start
+// (eval.go:16) is a length-only reset. References stored in slots beyond
+// the next run's high-water mark remain in the backing array and pin
+// their payloads until either (a) the slice grows past them and the
+// slots are overwritten by AddObject, or (b) the VM itself is dropped.
+//
+// This is the leak class MEP-36 aims to eliminate. Until the refactor
+// lands, the contract we lock in here is: phantom retention is bounded
+// by cap(vm.Objects) and is reclaimed when the VM is dropped. A
+// regression that grows the backing array unboundedly across runs would
+// be caught by TestObjectsTableBoundedAcrossManyRuns above; the test
+// here pins the narrower property that after a "shrinking" sequence
+// (large program then small program), capacity does not grow further.
+func TestObjectsTablePhantomRetentionIsBounded(t *testing.T) {
+	bigProg := compileCorpus(t, corpus.Program{
+		Name:   "lists_fill_sum",
+		Build:  corpus.BuildListsFillSum,
+		Expect: corpus.ExpectListsFillSum,
+	}, sizeFor("lists_fill_sum"))
+	smallProg := compileCorpus(t, corpus.Program{
+		Name:   "fib",
+		Build:  corpus.BuildFibRec,
+		Expect: corpus.ExpectFibRec,
+	}, sizeFor("fib"))
+
+	vm := vm2.New(bigProg)
+	if _, err := vm.Run(); err != nil {
+		t.Fatalf("bigProg run: %v", err)
+	}
+	bigCap := cap(vm.Objects)
+
+	// Swap to a program that does not allocate any Objects entries.
+	vm.Program = smallProg
+	for range 32 {
+		if _, err := vm.Run(); err != nil {
+			t.Fatalf("smallProg run: %v", err)
+		}
+	}
+	if got := cap(vm.Objects); got > bigCap {
+		t.Fatalf("Objects capacity grew unexpectedly: bigCap=%d after small runs=%d", bigCap, got)
+	}
+}
+
+// TestObjectsTableRetainsBackingArrayContents pins the specific
+// behaviour MEP-36 will change: after Run() resets the slice length,
+// the backing-array slot beyond the new length still holds the
+// reference from the previous run. The test asserts the current
+// behaviour so a future change that nils these slots flips this test
+// loudly (and the test then gets updated to assert the new contract).
+func TestObjectsTableRetainsBackingArrayContents(t *testing.T) {
+	prog := compileCorpus(t, corpus.Program{
+		Name:   "fib",
+		Build:  corpus.BuildFibRec,
+		Expect: corpus.ExpectFibRec,
+	}, sizeFor("fib"))
+
+	vm := vm2.New(prog)
+	if _, err := vm.Run(); err != nil {
+		t.Fatalf("warmup: %v", err)
+	}
+
+	sentinel := &struct{ tag string }{tag: "phantom"}
+	idx := vm.AddObject(sentinel)
+	if int(idx) >= cap(vm.Objects) {
+		t.Fatalf("AddObject returned idx %d beyond cap %d", idx, cap(vm.Objects))
+	}
+
+	// Run() resets length to 0 (then grows as needed). The next Run
+	// of the same small program won't reach idx, so the sentinel
+	// remains in the backing array.
+	if _, err := vm.Run(); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	full := vm.Objects[:cap(vm.Objects)]
+	if int(idx) < len(full) && full[idx] != any(sentinel) {
+		t.Fatalf("phantom slot %d was overwritten unexpectedly; got %T", idx, full[idx])
+	}
+}
+
+// sameSliceHeader reports whether two []any slices share a backing
+// array. It uses a single-element write through one slice and reads
+// it back through the other. We restore the original value to avoid
+// disturbing the VMs the caller is testing.
+func sameSliceHeader(a, b []any) bool {
+	if len(a) == 0 || len(b) == 0 {
+		return false
+	}
+	saved := a[0]
+	canary := &struct{ x int }{x: 0xDEADBEEF}
+	a[0] = canary
+	shared := b[0] == canary
+	a[0] = saved
+	return shared
+}

--- a/runtime/vm2/bench/membench_test.go
+++ b/runtime/vm2/bench/membench_test.go
@@ -1,0 +1,152 @@
+// Memory and GC baseline benchmarks for the vm2 Objects-table refactor
+// tracked in MEP-36. Each benchmark runs one corpus program b.N times
+// and reports a richer set of metrics than the throughput suite in
+// corpus_test.go: GC cycles, total pause time, mallocs, live heap after
+// a forced final GC, and allocations per op.
+//
+// Why this lives next to the corpus benches rather than replacing them:
+// the throughput numbers in corpus_test.go are committed to MEP-30 and
+// MEP-34 measured-results appendices and should not move under us. The
+// MEP-36 baseline gets its own file so the Phase 0 numbers can be
+// diffed against Phase 1 / Phase 2 / Phase 3 cleanly.
+//
+// Run with:
+//
+//	go test ./runtime/vm2/bench -bench '^BenchmarkMEP36_Mem' -benchtime=3s -benchmem -run x
+package bench
+
+import (
+	"runtime"
+	"testing"
+
+	"mochi/compiler2/corpus"
+	vm2 "mochi/runtime/vm2"
+)
+
+// benchMem is the MEP-36 baseline harness. It mirrors benchCorpus but
+// (a) reports GC metrics that benchCorpus omits and (b) measures live
+// heap after a forced final GC so we can see what the VM pins versus
+// what is transient garbage.
+//
+// Reported metrics:
+//
+//	gc-cycles/op    - full GC cycles per Run() (lower is better)
+//	gc-pause-ns/op  - GC pause time per Run() (lower is better)
+//	mallocs/op      - heap allocations per Run()
+//	live-heap-KB    - HeapAlloc after forced final GC, single sample
+//	heap-inuse-KB   - HeapInuse high-water at end of run loop
+//	sys-KB          - process address space at end
+//	total-B/op      - total bytes allocated per Run()
+func benchMem(b *testing.B, p corpus.Program) {
+	n := sizeFor(p.Name)
+	prog := compileCorpus(b, p, n)
+	b.ReportAllocs()
+
+	// Compile a single VM and reuse it across iterations so the
+	// metrics reflect steady-state Run() behaviour, not vm2.New cost
+	// (which is measured separately below).
+	vm := vm2.New(prog)
+	if _, err := vm.Run(); err != nil {
+		b.Fatalf("warmup: %v", err)
+	}
+
+	var startMem, endMem, liveMem runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&startMem)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := vm.Run(); err != nil {
+			b.Fatalf("run %d: %v", i, err)
+		}
+	}
+	b.StopTimer()
+
+	runtime.ReadMemStats(&endMem)
+	runtime.GC()
+	runtime.ReadMemStats(&liveMem)
+
+	gcCycles := float64(endMem.NumGC - startMem.NumGC)
+	pauseNs := float64(endMem.PauseTotalNs - startMem.PauseTotalNs)
+	mallocs := float64(endMem.Mallocs - startMem.Mallocs)
+	totalAlloc := float64(endMem.TotalAlloc - startMem.TotalAlloc)
+	N := float64(b.N)
+
+	b.ReportMetric(gcCycles/N, "gc-cycles/op")
+	b.ReportMetric(pauseNs/N, "gc-pause-ns/op")
+	b.ReportMetric(mallocs/N, "mallocs/op")
+	b.ReportMetric(totalAlloc/N, "total-B/op")
+	b.ReportMetric(float64(liveMem.HeapAlloc)/1024, "live-heap-KB")
+	b.ReportMetric(float64(endMem.HeapInuse)/1024, "heap-inuse-KB")
+	b.ReportMetric(float64(endMem.Sys)/1024, "sys-KB")
+}
+
+// benchMemFreshVM measures the cost of vm2.New + Run() per op, which
+// is the canonical embedding pattern (one VM per request) and the path
+// most sensitive to the Objects-table layout. This is the headline
+// number MEP-36 Phase 1 is expected to move.
+func benchMemFreshVM(b *testing.B, p corpus.Program) {
+	n := sizeFor(p.Name)
+	prog := compileCorpus(b, p, n)
+	b.ReportAllocs()
+
+	var startMem, endMem, liveMem runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&startMem)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := vm2.New(prog).Run(); err != nil {
+			b.Fatalf("run %d: %v", i, err)
+		}
+	}
+	b.StopTimer()
+
+	runtime.ReadMemStats(&endMem)
+	runtime.GC()
+	runtime.ReadMemStats(&liveMem)
+
+	N := float64(b.N)
+	b.ReportMetric(float64(endMem.NumGC-startMem.NumGC)/N, "gc-cycles/op")
+	b.ReportMetric(float64(endMem.PauseTotalNs-startMem.PauseTotalNs)/N, "gc-pause-ns/op")
+	b.ReportMetric(float64(endMem.Mallocs-startMem.Mallocs)/N, "mallocs/op")
+	b.ReportMetric(float64(endMem.TotalAlloc-startMem.TotalAlloc)/N, "total-B/op")
+	b.ReportMetric(float64(liveMem.HeapAlloc)/1024, "live-heap-KB")
+}
+
+// One benchmark per corpus program, reused-VM path.
+func BenchmarkMEP36_Mem_Fib(b *testing.B) {
+	benchMem(b, corpus.Program{Name: "fib", Build: corpus.BuildFibRec, Expect: corpus.ExpectFibRec})
+}
+func BenchmarkMEP36_Mem_IterSum(b *testing.B) {
+	benchMem(b, corpus.Program{Name: "iter_sum", Build: corpus.BuildIterSum, Expect: corpus.ExpectIterSum})
+}
+func BenchmarkMEP36_Mem_PrimeCount(b *testing.B) {
+	benchMem(b, corpus.Program{Name: "math_prime_count", Build: corpus.BuildPrimeCount, Expect: corpus.ExpectPrimeCount})
+}
+func BenchmarkMEP36_Mem_StringsConcatLoop(b *testing.B) {
+	benchMem(b, corpus.Program{Name: "strings_concat_loop", Build: corpus.BuildStringsConcatLoop, Expect: corpus.ExpectStringsConcatLoop})
+}
+func BenchmarkMEP36_Mem_ListsFillSum(b *testing.B) {
+	benchMem(b, corpus.Program{Name: "lists_fill_sum", Build: corpus.BuildListsFillSum, Expect: corpus.ExpectListsFillSum})
+}
+func BenchmarkMEP36_Mem_MapsFillSum(b *testing.B) {
+	benchMem(b, corpus.Program{Name: "maps_fill_sum", Build: corpus.BuildMapsFillSum, Expect: corpus.ExpectMapsFillSum})
+}
+
+// Fresh-VM path, headline metric for the refactor.
+func BenchmarkMEP36_FreshVM_Fib(b *testing.B) {
+	benchMemFreshVM(b, corpus.Program{Name: "fib", Build: corpus.BuildFibRec, Expect: corpus.ExpectFibRec})
+}
+func BenchmarkMEP36_FreshVM_PrimeCount(b *testing.B) {
+	benchMemFreshVM(b, corpus.Program{Name: "math_prime_count", Build: corpus.BuildPrimeCount, Expect: corpus.ExpectPrimeCount})
+}
+func BenchmarkMEP36_FreshVM_StringsConcatLoop(b *testing.B) {
+	benchMemFreshVM(b, corpus.Program{Name: "strings_concat_loop", Build: corpus.BuildStringsConcatLoop, Expect: corpus.ExpectStringsConcatLoop})
+}
+func BenchmarkMEP36_FreshVM_ListsFillSum(b *testing.B) {
+	benchMemFreshVM(b, corpus.Program{Name: "lists_fill_sum", Build: corpus.BuildListsFillSum, Expect: corpus.ExpectListsFillSum})
+}
+func BenchmarkMEP36_FreshVM_MapsFillSum(b *testing.B) {
+	benchMemFreshVM(b, corpus.Program{Name: "maps_fill_sum", Build: corpus.BuildMapsFillSum, Expect: corpus.ExpectMapsFillSum})
+}

--- a/website/docs/mep/mep-0036.md
+++ b/website/docs/mep/mep-0036.md
@@ -378,6 +378,62 @@ A measured-results MEP (Informational, numbered after the Phase-3 merge) will re
 - Truffle / GraalVM. *Truffle Library Guide; Shape Javadoc.*
 - Internal Mochi MEPs: [MEP-17](/docs/mep/mep-0017), [MEP-18](/docs/mep/mep-0018), [MEP-19](/docs/mep/mep-0019), [MEP-20](/docs/mep/mep-0020), [MEP-21](/docs/mep/mep-0021), [MEP-23](/docs/mep/mep-0023), [MEP-24](/docs/mep/mep-0024), [MEP-29](/docs/mep/mep-0029), [MEP-33](/docs/mep/mep-0033), [MEP-34](/docs/mep/mep-0034), [MEP-35](/docs/mep/mep-0035).
 
+## Appendix A. Phase 0 baseline measurements
+
+Captured 2026-05-17 on Apple M4, Go 1.x, darwin/arm64. Source:
+`runtime/vm2/bench/membench_test.go`. Each benchmark runs one corpus
+program against vm2 with `-benchtime=2s`, samples `runtime.MemStats`
+before and after the inner loop, then forces a final GC and samples
+again to read live heap. Two harnesses are reported:
+
+- `Mem_*`: reused VM (one `vm2.New`, then b.N `Run()` calls). Steady-state.
+- `FreshVM_*`: `vm2.New(prog).Run()` per op. Mirrors one-VM-per-request embedding.
+
+| Benchmark | ns/op | mallocs/op | total-B/op | gc-cycles/op | live-heap-KB |
+|-----------|------:|-----------:|-----------:|-------------:|-------------:|
+| Mem_Fib (fib(25)) | 4,862,212 | 0 | 0 | 0 | 249.7 |
+| Mem_IterSum (10000) | 92,732 | 0 | 0 | 0 | 249.7 |
+| Mem_PrimeCount (100) | 27,338 | 0 | 0 | 0 | 249.7 |
+| Mem_StringsConcatLoop (64) | 2,271 | 120 | 4,384 | 0.0012 | 282.0 |
+| Mem_ListsFillSum (128) | 5,063 | 2 | 1,048 | 0.0003 | 279.8 |
+| Mem_MapsFillSum (128) | 11,706 | 14 | 13,520 | 0.0038 | 282.6 |
+| FreshVM_Fib | 4,848,081 | 6 | 5,328 | 0 | 282.6 |
+| FreshVM_PrimeCount | 19,856 | 3 | 1,104 | 0.0003 | 283.2 |
+| FreshVM_StringsConcatLoop | 3,125 | 130 | 7,648 | 0.0022 | 282.1 |
+| FreshVM_ListsFillSum | 6,850 | 14 | 42,232 | 0.0123 | 280.7 |
+| FreshVM_MapsFillSum | 14,368 | 26 | 54,704 | 0.0162 | 283.9 |
+
+Interpretation:
+
+1. **Pure-int programs (fib, iter_sum, math_prime_count) allocate zero
+   bytes per Run() on the reused-VM path.** This confirms the NaN-boxed
+   Cell never touches the heap when payloads fit inline. Phase 1 must
+   preserve this property: int-heavy benchmarks should remain at
+   `0 mallocs/op` after the struct Cell migration, otherwise the
+   regression budget is gone before we even hit container code.
+2. **Container programs (lists, maps, strings) drive all heap traffic
+   today.** ListsFillSum allocates 2 objects per Run (the `*vmList` plus
+   the backing `[]Cell` once it grows past the cap hint). MapsFillSum
+   sits at 14 allocations per Run, dominated by Go's `map[any]Cell`
+   internal buckets. Strings is the worst at 120 per Run, one per
+   `*vmString` along the concat path. These are the numbers MEP-36
+   Phase 2 (constructors return Cell directly) and Phase 3 (delete
+   Objects table) are expected to move.
+3. **GC pressure is already low** (the highest gc-cycles/op figure is
+   0.0162 for FreshVM_MapsFillSum, i.e. one full GC cycle every ~60
+   ops). The win from MEP-36 is not "fewer GC cycles" but "the cycles
+   we do trigger can actually reclaim the container payloads they
+   touch," which today is gated by the Objects-table indirection
+   hiding them from the GC graph.
+4. **FreshVM allocs/op are dominated by `vm2.New`** (Stack and Frames
+   slices: 6 mallocs for fib alone). Phase 1's struct-Cell layout
+   doesn't change this; a future cleanup task can sync.Pool the Stack
+   and Frames slices if the FreshVM path becomes a bottleneck.
+
+The Phase 0 PR locks these numbers in. The Phase 1 PR will append an
+Appendix B with the same table for the struct-Cell implementation, and
+the diff is the headline result.
+
 ## Copyright
 
 This document is placed in the public domain.


### PR DESCRIPTION
Pre-refactor groundwork for [MEP-36](https://mochi-lang.dev/docs/mep/mep-0036). No runtime, compiler, or JIT changes here; this PR only adds tests, benchmarks, and the baseline appendix the Phase 1 PR will be diffed against.

## Summary

- 9 GC correctness tests in `runtime/vm2/bench/gc_correctness_test.go` covering per-Run Objects reset, type identity, multi-run idempotency, cross-VM independence, VM-drop reclamation, bounded growth, phantom retention, and the empty-VM start contract.
- 11 memory benchmarks in `runtime/vm2/bench/membench_test.go` (reused-VM + fresh-VM harnesses) reporting `gc-cycles/op`, `gc-pause-ns/op`, `mallocs/op`, `total-B/op`, `live-heap-KB`.
- MEP-36 Appendix A: baseline numbers captured 2026-05-17 on Apple M4. Pure-int programs sit at 0 mallocs/op; container programs (lists 2/op, maps 14/op, strings 120/op) drive all heap traffic today.

## Test plan

- [x] `go test ./runtime/vm2/bench/ -run 'TestObjects|TestMultipleRunsIndependent|TestSeparateVMsIndependent|TestVMDropReclaimsContainers|TestNewVMStartsEmpty' -count=1` — all 9 tests pass
- [x] `go test ./runtime/vm2/bench/ -bench '^BenchmarkMEP36' -benchtime=2s -run x` — all 11 benchmarks run; numbers recorded in MEP-36 Appendix A
- [x] `go vet ./runtime/vm2/bench/...` clean

Tracking: #21565.