### PR TITLE
mep-0036: fix MDX parse error in spec (bare <1 MB)

### DIFF
--- a/website/docs/mep/mep-0036.md
+++ b/website/docs/mep/mep-0036.md
@@ -575,7 +575,7 @@ Summary:
   set in §3 was "≤ 15% on int-heavy crosslang"; we are at the edge of
   that budget and Phase 2 (which removes the Objects[] write on the
   container hot paths) needs to recover the gap.
-- **RSS moved by <1 MB on every benchmark.** The stack-cell doubling
+- **RSS moved by under 1 MB on every benchmark.** The stack-cell doubling
   is offset on the RSS side because the OS-page footprint is
   dominated by the Go runtime baseline (~4 MB), not by vm2's
   Stack/Frames. Container-heavy benchmarks (`lists/fill_sum n=100`,


### PR DESCRIPTION
## Summary

- Cloudflare Pages build of main fails because MDX sees `<1 MB` as a JSX tag start.
- Same pattern fixed in commit 361ec49d30 for mep-0033 (`<2%`).

Refs: #21569

## Test plan
- [x] Local `cd website && npm run build` succeeds with the change applied.