### PR TITLE
MEP-36 Phase 3: gate popFrame clear + delete Objects table

### DIFF
--- a/compiler2/emit/emit.go
+++ b/compiler2/emit/emit.go
@@ -428,13 +428,32 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 		strConsts[i] = []byte(s)
 	}
 
+	// MEP-36 Phase 3: a register window holds a container only if some
+	// IR value of container type (TStr/TList/TMap/TPtr) was assigned a
+	// real register. Pure int/bool functions get HasContainerSlots=false
+	// and popFrame elides the clear sweep.
+	hasContainer := false
+	for vid, ins := range f.Values {
+		if finalReg[vid] < 0 {
+			continue
+		}
+		switch ins.Type {
+		case ir.TStr, ir.TList, ir.TMap, ir.TPtr:
+			hasContainer = true
+		}
+		if hasContainer {
+			break
+		}
+	}
+
 	return &vm2.Function{
-		Name:      f.Name,
-		NumParams: np,
-		NumRegs:   numRegs,
-		Code:      code,
-		Consts:    consts,
-		StrConsts: strConsts,
+		Name:              f.Name,
+		NumParams:         np,
+		NumRegs:           numRegs,
+		Code:              code,
+		Consts:            consts,
+		StrConsts:         strConsts,
+		HasContainerSlots: hasContainer,
 	}, nil
 }
 

--- a/runtime/jit/vm2jit/vm2jit_test.go
+++ b/runtime/jit/vm2jit/vm2jit_test.go
@@ -559,7 +559,7 @@ func TestOpCallRoutesToJITLoop(t *testing.T) {
 // TestJITListLenFastPath exercises the Phase 2 OpListLen fast path. The
 // callee has a single OpListLen + OpReturn so the JIT must lower OpListLen
 // natively (no deopt for the body to fall through to). Test builds a real
-// list in vm.Objects, calls the JIT'd callee directly via CallDirect, and
+// list via JITNewList, calls the JIT'd callee directly via CallDirect, and
 // asserts the returned Cell carries the expected int48 length.
 func TestJITListLenFastPath(t *testing.T) {
 	callee := &vm2.Function{

--- a/runtime/vm2/bench/gc_correctness_test.go
+++ b/runtime/vm2/bench/gc_correctness_test.go
@@ -1,11 +1,12 @@
-// Package bench's GC correctness suite for the vm2 Objects table.
+// Package bench's GC correctness suite for the vm2 register file.
 //
-// This file locks in the existing reachability contract before the
-// MEP-36 (https://mochi-lang.dev/docs/mep/mep-0036) refactor lands.
-// The tests cover: per-Run Objects table reset, type identity through
-// the ref-tag path, idempotency of multiple Run() calls on the same VM,
-// independence of separate VMs, and reclamation of container payloads
-// once their owning VM is dropped and the GC runs.
+// This file pins the reachability contract for vm2's MEP-36 Phase 3
+// world: containers (lists, maps, strings) reach the host GC via
+// typed pointers carried in Cell.Obj, not via a side Objects[]
+// registry. The tests cover per-Run isolation, idempotency of
+// multiple Run() calls on the same VM, independence of separate VMs,
+// and reclamation of container payloads once their owning VM is
+// dropped and the GC runs.
 //
 // Each test compiles a real Mochi program through compiler2 and
 // executes it against vm2 so the assertions cover the on-the-wire
@@ -18,83 +19,12 @@ import (
 	"time"
 
 	"mochi/compiler2/corpus"
-	"mochi/compiler2/ir"
 	vm2 "mochi/runtime/vm2"
 )
 
-// TestObjectsTableStaysEmptyAfterRun pins the MEP-36 Phase 2 invariant:
-// container constructors (newList / newMap / newString) no longer
-// register in vm.Objects. The Objects table is retained for the
-// self-heal AddObject path (FFI, wide-int boxing) but the corpus
-// programs that previously populated it must now observe len(Objects)
-// == 0 after Run.
-//
-// Phase 3 will delete the field outright; this test exists to catch a
-// regression that re-routes container constructors through AddObject.
-func TestObjectsTableStaysEmptyAfterRun(t *testing.T) {
-	prog := compileCorpus(t, corpus.Program{
-		Name:   "lists_fill_sum",
-		Build:  corpus.BuildListsFillSum,
-		Expect: corpus.ExpectListsFillSum,
-	}, sizeFor("lists_fill_sum"))
-
-	vm := vm2.New(prog)
-	if _, err := vm.Run(); err != nil {
-		t.Fatalf("first run: %v", err)
-	}
-	if got := len(vm.Objects); got != 0 {
-		t.Fatalf("Phase 2 expects empty Objects table after Run; got len=%d", got)
-	}
-
-	if _, err := vm.Run(); err != nil {
-		t.Fatalf("second run: %v", err)
-	}
-	if got := len(vm.Objects); got != 0 {
-		t.Fatalf("Phase 2 expects empty Objects table across runs; got len=%d", got)
-	}
-}
-
-// TestPhase2TypedPointersTraceContainers verifies that the corpus
-// programs which used to register containers in Objects now thread
-// their typed pointers through Cell.Obj. We do not have a direct hook
-// into the running register file from the test, so we run the program
-// and assert the result matches the expected value — a proxy for the
-// pointer path working end-to-end. The complementary "no Objects
-// growth" assertion lives in TestObjectsTableStaysEmptyAfterRun.
-func TestPhase2TypedPointersTraceContainers(t *testing.T) {
-	cases := []struct {
-		name  string
-		build func(int64) *ir.Module
-		want  func(int64) int64
-		size  int64
-	}{
-		{"lists_fill_sum", corpus.BuildListsFillSum, corpus.ExpectListsFillSum, sizeFor("lists_fill_sum")},
-		{"maps_fill_sum", corpus.BuildMapsFillSum, corpus.ExpectMapsFillSum, sizeFor("maps_fill_sum")},
-		{"strings_concat_loop", corpus.BuildStringsConcatLoop, corpus.ExpectStringsConcatLoop, sizeFor("strings_concat_loop")},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			prog := compileCorpus(t, corpus.Program{Name: tc.name, Build: tc.build, Expect: tc.want}, tc.size)
-			vm := vm2.New(prog)
-			got, err := vm.Run()
-			if err != nil {
-				t.Fatalf("run: %v", err)
-			}
-			if want := tc.want(tc.size); got.Int() != want {
-				t.Fatalf("%s: got=%d want=%d", tc.name, got.Int(), want)
-			}
-			if len(vm.Objects) != 0 {
-				t.Fatalf("%s: container constructors leaked into Objects (len=%d)", tc.name, len(vm.Objects))
-			}
-		})
-	}
-}
-
-// TestMultipleRunsIndependentResults exercises the cross-Run isolation
-// of the Objects table: running the same program twice on the same VM
-// must yield the same result, with no state from the first run leaking
-// into the second.
+// TestMultipleRunsIndependentResults exercises cross-Run isolation:
+// running the same program twice on the same VM must yield the same
+// result, with no state from the first run leaking into the second.
 func TestMultipleRunsIndependentResults(t *testing.T) {
 	for _, p := range corpus.All() {
 		t.Run(p.Name, func(t *testing.T) {
@@ -117,8 +47,8 @@ func TestMultipleRunsIndependentResults(t *testing.T) {
 }
 
 // TestSeparateVMsIndependent verifies two VMs on the same Program
-// produce the same result without sharing Objects state. This is the
-// invariant for embedding VMs in long-running servers.
+// produce the same result. This is the invariant for embedding VMs in
+// long-running servers.
 func TestSeparateVMsIndependent(t *testing.T) {
 	prog := compileCorpus(t, corpus.Program{
 		Name:   "lists_fill_sum",
@@ -140,19 +70,14 @@ func TestSeparateVMsIndependent(t *testing.T) {
 	if gotA != gotB {
 		t.Fatalf("independent VMs produced different results: a=%v b=%v", gotA, gotB)
 	}
-	// Backing arrays must not be aliased.
-	if len(a.Objects) > 0 && len(b.Objects) > 0 && sameSliceHeader(a.Objects, b.Objects) {
-		t.Fatalf("two VMs share the same Objects backing array")
-	}
 }
 
 // TestVMDropReclaimsContainers verifies that once a VM goes out of
-// scope and the GC runs, the container payloads it held in its
-// Objects table become reachable for reclamation. We attach a Go
-// finalizer to a sentinel struct stored alongside the program, drop
-// the VM, force GC, and require the finalizer to fire within a bounded
-// time window. If the VM had pinned the sentinel through an unintended
-// global reference, the finalizer would never run.
+// scope and the GC runs, the entire VM is reclaimable — which
+// transitively reclaims every container payload it referenced through
+// its Stack. The finalizer is attached to the *VM itself; without
+// MEP-36 Phase 3's reachability fix (typed pointer in Cell.Obj only,
+// no side registry pinning), the finalizer would never run.
 func TestVMDropReclaimsContainers(t *testing.T) {
 	prog := compileCorpus(t, corpus.Program{
 		Name:   "lists_fill_sum",
@@ -160,28 +85,21 @@ func TestVMDropReclaimsContainers(t *testing.T) {
 		Expect: corpus.ExpectListsFillSum,
 	}, sizeFor("lists_fill_sum"))
 
-	// allocateAndDrop is a closure so the *VM local can be reclaimed
-	// once the closure returns; without it, conservative stack scanning
-	// could keep the pointer alive until the test exits.
 	finalized := make(chan struct{}, 1)
 	allocateAndDrop := func() {
 		vm := vm2.New(prog)
 		if _, err := vm.Run(); err != nil {
 			t.Fatalf("run: %v", err)
 		}
-		sentinel := &struct{ _ [32]byte }{}
-		runtime.SetFinalizer(sentinel, func(_ any) {
-			finalized <- struct{}{}
+		runtime.SetFinalizer(vm, func(_ *vm2.VM) {
+			select {
+			case finalized <- struct{}{}:
+			default:
+			}
 		})
-		// Stash the sentinel inside vm.Objects so its reachability is
-		// transitively bound to the VM. After the closure returns vm is
-		// unreachable; the sentinel must follow.
-		vm.AddObject(sentinel)
 	}
 	allocateAndDrop()
 
-	// Two GC passes: the first promotes the unreachable object set,
-	// the second runs finalizers and reclaims them.
 	for range 5 {
 		runtime.GC()
 		select {
@@ -190,11 +108,11 @@ func TestVMDropReclaimsContainers(t *testing.T) {
 		case <-time.After(20 * time.Millisecond):
 		}
 	}
-	t.Fatalf("VM container sentinel was not finalised within budget; reachability leak suspected")
+	t.Fatalf("VM was not finalised within budget; reachability leak suspected")
 }
 
 // TestNewVMStartsEmpty checks the entry contract of vm2.New: a fresh
-// VM has an empty Objects table and no resident frames.
+// VM has no resident frames or stack slots.
 func TestNewVMStartsEmpty(t *testing.T) {
 	prog := compileCorpus(t, corpus.Program{
 		Name:   "fib",
@@ -203,166 +121,10 @@ func TestNewVMStartsEmpty(t *testing.T) {
 	}, sizeFor("fib"))
 
 	vm := vm2.New(prog)
-	if got := len(vm.Objects); got != 0 {
-		t.Fatalf("fresh VM has Objects len=%d, want 0", got)
-	}
 	if got := len(vm.Stack); got != 0 {
 		t.Fatalf("fresh VM has Stack len=%d, want 0", got)
 	}
 	if got := len(vm.Frames); got != 0 {
 		t.Fatalf("fresh VM has Frames len=%d, want 0", got)
 	}
-}
-
-// goTypeName returns the package-qualified type name of v, used in
-// error messages. Avoids reflect to keep the assertion explicit and to
-// not pull reflect into the binary just for tests.
-func goTypeName(v any) string {
-	switch v.(type) {
-	case nil:
-		return "<nil>"
-	}
-	// Fall through: format the value's dynamic type by calling fmt
-	// indirectly is fine in tests but adds dependencies. The pattern
-	// below avoids fmt by returning a generic label; if a future
-	// caller needs more detail, swap to fmt.Sprintf("%T", v).
-	return "(non-nil)"
-}
-
-// isExpectedObjectType returns true for the Go type names of every
-// concrete payload kind the vm2 runtime is allowed to store in the
-// Objects table. We accept the generic "(non-nil)" sentinel because
-// goTypeName above is intentionally minimal; the assertion is "not
-// nil" rather than "matches an explicit allow-list."
-func isExpectedObjectType(name string) bool {
-	switch name {
-	case "(non-nil)":
-		return true
-	default:
-		return true
-	}
-}
-
-// TestObjectsTableBoundedAcrossManyRuns is a stress version of
-// TestObjectsTableResetPerRun: it runs the program 64 times on the
-// same VM and asserts the Objects table length never exceeds the
-// length observed after the first run. This catches a regression
-// where the per-Run reset (eval.go:16) silently stops working.
-func TestObjectsTableBoundedAcrossManyRuns(t *testing.T) {
-	for _, p := range corpus.All() {
-		t.Run(p.Name, func(t *testing.T) {
-			prog := compileCorpus(t, p, sizeFor(p.Name))
-			vm := vm2.New(prog)
-
-			if _, err := vm.Run(); err != nil {
-				t.Fatalf("warmup: %v", err)
-			}
-			baseline := len(vm.Objects)
-
-			for i := range 64 {
-				if _, err := vm.Run(); err != nil {
-					t.Fatalf("run %d: %v", i, err)
-				}
-				if got := len(vm.Objects); got != baseline {
-					t.Fatalf("run %d: Objects len %d drifted from baseline %d", i, got, baseline)
-				}
-			}
-		})
-	}
-}
-
-// TestObjectsTablePhantomRetentionIsBounded documents and bounds the
-// current MEP-36 motivation: vm.Objects = vm.Objects[:0] at Run start
-// (eval.go:16) is a length-only reset. References stored in slots beyond
-// the next run's high-water mark remain in the backing array and pin
-// their payloads until either (a) the slice grows past them and the
-// slots are overwritten by AddObject, or (b) the VM itself is dropped.
-//
-// This is the leak class MEP-36 aims to eliminate. Until the refactor
-// lands, the contract we lock in here is: phantom retention is bounded
-// by cap(vm.Objects) and is reclaimed when the VM is dropped. A
-// regression that grows the backing array unboundedly across runs would
-// be caught by TestObjectsTableBoundedAcrossManyRuns above; the test
-// here pins the narrower property that after a "shrinking" sequence
-// (large program then small program), capacity does not grow further.
-func TestObjectsTablePhantomRetentionIsBounded(t *testing.T) {
-	bigProg := compileCorpus(t, corpus.Program{
-		Name:   "lists_fill_sum",
-		Build:  corpus.BuildListsFillSum,
-		Expect: corpus.ExpectListsFillSum,
-	}, sizeFor("lists_fill_sum"))
-	smallProg := compileCorpus(t, corpus.Program{
-		Name:   "fib",
-		Build:  corpus.BuildFibRec,
-		Expect: corpus.ExpectFibRec,
-	}, sizeFor("fib"))
-
-	vm := vm2.New(bigProg)
-	if _, err := vm.Run(); err != nil {
-		t.Fatalf("bigProg run: %v", err)
-	}
-	bigCap := cap(vm.Objects)
-
-	// Swap to a program that does not allocate any Objects entries.
-	vm.Program = smallProg
-	for range 32 {
-		if _, err := vm.Run(); err != nil {
-			t.Fatalf("smallProg run: %v", err)
-		}
-	}
-	if got := cap(vm.Objects); got > bigCap {
-		t.Fatalf("Objects capacity grew unexpectedly: bigCap=%d after small runs=%d", bigCap, got)
-	}
-}
-
-// TestObjectsTableRetainsBackingArrayContents pins the specific
-// behaviour MEP-36 will change: after Run() resets the slice length,
-// the backing-array slot beyond the new length still holds the
-// reference from the previous run. The test asserts the current
-// behaviour so a future change that nils these slots flips this test
-// loudly (and the test then gets updated to assert the new contract).
-func TestObjectsTableRetainsBackingArrayContents(t *testing.T) {
-	prog := compileCorpus(t, corpus.Program{
-		Name:   "fib",
-		Build:  corpus.BuildFibRec,
-		Expect: corpus.ExpectFibRec,
-	}, sizeFor("fib"))
-
-	vm := vm2.New(prog)
-	if _, err := vm.Run(); err != nil {
-		t.Fatalf("warmup: %v", err)
-	}
-
-	sentinel := &struct{ tag string }{tag: "phantom"}
-	idx := vm.AddObject(sentinel)
-	if int(idx) >= cap(vm.Objects) {
-		t.Fatalf("AddObject returned idx %d beyond cap %d", idx, cap(vm.Objects))
-	}
-
-	// Run() resets length to 0 (then grows as needed). The next Run
-	// of the same small program won't reach idx, so the sentinel
-	// remains in the backing array.
-	if _, err := vm.Run(); err != nil {
-		t.Fatalf("second run: %v", err)
-	}
-	full := vm.Objects[:cap(vm.Objects)]
-	if int(idx) < len(full) && full[idx] != any(sentinel) {
-		t.Fatalf("phantom slot %d was overwritten unexpectedly; got %T", idx, full[idx])
-	}
-}
-
-// sameSliceHeader reports whether two []any slices share a backing
-// array. It uses a single-element write through one slice and reads
-// it back through the other. We restore the original value to avoid
-// disturbing the VMs the caller is testing.
-func sameSliceHeader(a, b []any) bool {
-	if len(a) == 0 || len(b) == 0 {
-		return false
-	}
-	saved := a[0]
-	canary := &struct{ x int }{x: 0xDEADBEEF}
-	a[0] = canary
-	shared := b[0] == canary
-	a[0] = saved
-	return shared
 }

--- a/runtime/vm2/bench/gc_phase2_test.go
+++ b/runtime/vm2/bench/gc_phase2_test.go
@@ -1,21 +1,20 @@
-// Phase 2 GC tests for MEP-36.
+// Phase 2/3 GC tests for MEP-36.
 //
-// These tests pin the memory-management properties that Phase 2 of
-// MEP-36 was designed to deliver:
+// These tests pin the memory-management properties that Phase 2 and
+// Phase 3 of MEP-36 jointly deliver:
 //
-//  1. Container constructors no longer populate vm.Objects: containers
-//     are reachable from the operand stack via Cell.Obj only.
-//  2. popFrame clear()s the popped window so a container that was the
-//     callee's last reference becomes reclaimable on the next GC.
+//  1. Container constructors do not populate a side Objects[] table:
+//     containers are reachable from the operand stack via Cell.Obj
+//     only. The field has been removed entirely in Phase 3; what the
+//     tests here actually prove is the live-heap reclamation contract
+//     that motivated the removal.
+//  2. popFrame clear()s the popped window when the frame held a
+//     container, so a container that was the callee's last reference
+//     becomes reclaimable on the next GC. Phase 3 skips the clear for
+//     int-only frames; the reclamation contract still holds.
 //  3. Repeated Run() calls do not grow live heap: dead containers from
 //     a previous Run are collected before the next steady-state sample.
-//  4. The Objects table no longer carries container payloads, so its
-//     length stays at 0 even on container-heavy workloads.
-//
-// These properties are the precondition for Phase 3 (delete the
-// Objects table outright); a regression that re-routes container
-// constructors through AddObject would be caught by point 4, a
-// regression that drops the popFrame clear would be caught by point 2.
+//  4. Dropping the VM lets the GC reclaim everything the VM held.
 package bench
 
 import (
@@ -28,13 +27,10 @@ import (
 
 // TestPhase2_PopFrameReclamation pins property (2): a container
 // allocated inside a callee frame becomes reclaimable once the callee
-// returns. We attach a Go finalizer to a list constructed by the
-// running program, drop the only Mochi-side reference by overwriting
-// the result register, force GC, and require the finalizer to fire.
-//
-// We exercise this indirectly by running a corpus program that builds
-// a list inside a function, returns its length, and discards the list;
-// then we drive enough GC cycles to flush the popped frame's slots.
+// returns. We exercise this indirectly by running a corpus program
+// that builds a list inside a function, returns its length, and
+// discards the list; then we drive enough GC cycles to flush the
+// popped frame's slots.
 func TestPhase2_PopFrameReclamation(t *testing.T) {
 	prog := compileCorpus(t, corpus.Program{
 		Name:   "lists_fill_sum",
@@ -76,32 +72,11 @@ func TestPhase2_PopFrameReclamation(t *testing.T) {
 	}
 }
 
-// TestPhase2_ObjectsTableEmptyAcrossWorkloads pins property (4): no
-// corpus program populates vm.Objects in Phase 2. This is the static
-// guarantee that lets us delete Objects in Phase 3.
-func TestPhase2_ObjectsTableEmptyAcrossWorkloads(t *testing.T) {
-	for _, p := range corpus.All() {
-		t.Run(p.Name, func(t *testing.T) {
-			prog := compileCorpus(t, p, sizeFor(p.Name))
-			vm := vm2.New(prog)
-			for i := range 8 {
-				if _, err := vm.Run(); err != nil {
-					t.Fatalf("run %d: %v", i, err)
-				}
-				if got := len(vm.Objects); got != 0 {
-					t.Fatalf("run %d: Objects table grew to %d, expected 0", i, got)
-				}
-			}
-		})
-	}
-}
-
-// TestPhase2_LiveHeapBoundedAcrossManyRuns is the stronger version of
-// the Phase 0 bounded-Objects test: Phase 2's reclamation guarantee
-// says live heap (not just the Objects table) stays flat. We run each
-// container-heavy program 128 times on a reused VM and assert HeapAlloc
-// after a forced GC stays within a small multiple of the first-run
-// reading.
+// TestPhase2_LiveHeapBoundedAcrossManyRuns is the steady-state form of
+// the reclamation contract: live heap (HeapAlloc) stays flat across
+// 128 runs of every container-heavy corpus program on a reused VM.
+// A regression that pins per-Run containers would scale linearly with
+// the iteration count.
 func TestPhase2_LiveHeapBoundedAcrossManyRuns(t *testing.T) {
 	cases := []struct {
 		name string
@@ -145,12 +120,12 @@ func TestPhase2_LiveHeapBoundedAcrossManyRuns(t *testing.T) {
 	}
 }
 
-// TestPhase2_FreshVMReclaimableAfterDrop pins property (2) on the
-// fresh-VM embedding pattern (one VM per request). After the closure
-// returns, the entire VM (including its Stack with all live Cells) must
-// be reclaimable. We use a sentinel registered via AddObject (the only
-// remaining Objects[] consumer in Phase 2) to prove the VM is fully
-// unreachable.
+// TestPhase2_FreshVMReclaimableAfterDrop pins the fresh-VM embedding
+// pattern (one VM per request): once the closure returns, the entire
+// VM (including its Stack with all live Cells) must be reclaimable.
+// We attach a finalizer to the *VM itself; without MEP-36's
+// reachability fix (containers reachable only through Cell.Obj on the
+// Stack, not pinned in a side registry), the finalizer would never run.
 func TestPhase2_FreshVMReclaimableAfterDrop(t *testing.T) {
 	prog := compileCorpus(t, corpus.Program{
 		Name:   "lists_fill_sum",
@@ -164,14 +139,12 @@ func TestPhase2_FreshVMReclaimableAfterDrop(t *testing.T) {
 		if _, err := vm.Run(); err != nil {
 			t.Fatalf("run: %v", err)
 		}
-		sentinel := &struct{ _ [128]byte }{}
-		runtime.SetFinalizer(sentinel, func(_ any) {
+		runtime.SetFinalizer(vm, func(_ *vm2.VM) {
 			select {
 			case finalized <- struct{}{}:
 			default:
 			}
 		})
-		vm.AddObject(sentinel)
 	}
 	allocateAndDrop()
 

--- a/runtime/vm2/cell.go
+++ b/runtime/vm2/cell.go
@@ -7,10 +7,8 @@ import (
 
 // Cell is the 16-byte tagged value used by vm2 throughout. It is the
 // MEP-36 Option X layout: the 8-byte NaN-boxed Bits field carries the
-// same tag/payload encoding the runtime used in its pre-refactor
-// uint64 form, and Ptr carries a Go-typed pointer for pointer-tagged
-// cells so the host GC can reach the pointee directly without going
-// through vm.Objects.
+// tag/payload encoding, and Obj carries a Go-typed pointer for
+// pointer-tagged cells so the host GC reaches the pointee directly.
 //
 // Bits layout (high 16 bits):
 //
@@ -21,12 +19,11 @@ import (
 //	0xFFFC          -> int (low 48 bits, signed)
 //	0xFFFD          -> bool (low bit)
 //	0xFFFE          -> null
-//	0xFFFF          -> ptr: low 48 bits are an Objects[] index for the
-//	                  self-heal fallback; Ptr field carries the typed
-//	                  Go pointer when it is populated.
+//	0xFFFF          -> ptr (typed Go pointer in Obj; bit 47 of payload
+//	                  is tagPtrStrFlag for *vmString vs other pointees).
 //
-// Int is 48-bit signed (range -2^47 .. 2^47-1). Wider ints are boxed
-// into the Objects table by the compiler; see CPtr.
+// Int is 48-bit signed (range -2^47 .. 2^47-1). Wider ints fall back
+// to float64 boxing.
 type Cell struct {
 	Bits uint64
 	// Obj carries the Go-typed pointer for pointer-tagged cells, set by
@@ -88,15 +85,6 @@ func CBool(b bool) Cell {
 
 func CNull() Cell { return Cell{Bits: tagNull} }
 
-// CPtr boxes a 48-bit unsigned index into the owning VM's Objects table.
-// The typed-pointer companion is filled in by the container constructors
-// (newList, newMap, newString) that have access to the actual *T at
-// construction time; CPtr alone leaves Ptr nil and callers fall through
-// the self-heal accessor path.
-func CPtr(idx uint64) Cell {
-	return Cell{Bits: tagPtr | idx&payloadMask}
-}
-
 func (c Cell) IsFloat() bool { return c.Bits&tagMask < tagSStr }
 func (c Cell) IsSStr() bool  { return c.Bits&tagMask == tagSStr }
 func (c Cell) IsInt() bool   { return c.Bits&tagMask == tagInt }
@@ -151,12 +139,10 @@ func (c Cell) Int() int64 { return int64(c.Bits<<16) >> 16 }
 
 func (c Cell) Bool() bool { return c.Bits&1 != 0 }
 
-// Ptr returns the 48-bit index into VM.Objects (the self-heal fallback path).
-func (c Cell) Ptr() uint64 { return c.Bits & payloadMask }
-
-// PtrTo returns the Go-typed pointer carried by this Cell, or nil if
-// the cell has no populated typed pointer yet. Callers cast through
-// unsafe.Pointer to the concrete type (e.g. (*vmList)(c.PtrTo())).
+// PtrTo returns the Go-typed pointer carried by this Cell. Callers
+// cast through unsafe.Pointer to the concrete type (e.g.
+// (*vmList)(c.PtrTo())). Tag dispatch (IsPtr / IsHeapStr) tells the
+// caller which concrete type to expect.
 func (c Cell) PtrTo() unsafe.Pointer { return c.Obj }
 
 // FitsInline reports whether i can be boxed inline by CInt without loss.

--- a/runtime/vm2/cell_test.go
+++ b/runtime/vm2/cell_test.go
@@ -75,21 +75,6 @@ func TestCellNull(t *testing.T) {
 	}
 }
 
-func TestCellPtr(t *testing.T) {
-	for _, idx := range []uint64{0, 1, 42, payloadMask} {
-		c := CPtr(idx)
-		if !c.IsPtr() {
-			t.Fatalf("CPtr(%d) not IsPtr: %#x", idx, c.Bits)
-		}
-		if c.IsInt() || c.IsFloat() || c.IsBool() || c.IsNull() {
-			t.Fatalf("CPtr(%d) tag collision", idx)
-		}
-		if got := c.Ptr(); got != idx {
-			t.Fatalf("CPtr(%d).Ptr() = %d", idx, got)
-		}
-	}
-}
-
 func TestFitsInline(t *testing.T) {
 	cases := []struct {
 		v  int64

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -13,14 +13,13 @@ import "errors"
 // reslice — no sync.Pool round trips, which were 56% of fib_rec CPU
 // before this refactor.
 func (vm *VM) Run() (Cell, error) {
-	vm.Objects = vm.Objects[:0]
 	vm.Stack = vm.Stack[:0]
 	vm.Frames = vm.Frames[:0]
 
 	// Materialize string-constant Cells per function. Short literals
-	// pack inline (no Objects entry); long literals allocate once and
-	// the resulting CPtr is cached so OpLoadStrK is a slice read on the
-	// hot path.
+	// pack inline; long literals allocate a *vmString once and the
+	// resulting Cell is cached so OpLoadStrK is a slice read on the hot
+	// path. The Go GC traces the pointee through Cell.Obj.
 	for _, fn := range vm.Program.Funcs {
 		if len(fn.StrCells) != len(fn.StrConsts) {
 			fn.StrCells = make([]Cell, len(fn.StrConsts))

--- a/runtime/vm2/lists.go
+++ b/runtime/vm2/lists.go
@@ -16,8 +16,7 @@ type vmList struct {
 
 // newList allocates a *vmList with the given capacity and returns a
 // tagPtr Cell whose Obj field carries the typed pointer so the host GC
-// can trace the pointee directly. Phase 2 of MEP-36: no longer
-// registers in vm.Objects.
+// can trace the pointee directly (MEP-36 Phase 2+).
 func (vm *VM) newList(capHint int) Cell {
 	if capHint < 0 {
 		capHint = 0
@@ -26,9 +25,7 @@ func (vm *VM) newList(capHint int) Cell {
 	return Cell{Bits: tagPtr, Obj: unsafe.Pointer(l)}
 }
 
-// listAt fetches the *vmList backing a tagPtr cell. Phase 2: the typed
-// pointer is the only reference path; newList no longer populates
-// vm.Objects.
+// listAt fetches the *vmList backing a tagPtr cell.
 func (vm *VM) listAt(c Cell) *vmList {
 	return (*vmList)(c.PtrTo())
 }

--- a/runtime/vm2/maps.go
+++ b/runtime/vm2/maps.go
@@ -20,9 +20,7 @@ func (vm *VM) newMap() Cell {
 	return Cell{Bits: tagPtr, Obj: unsafe.Pointer(m)}
 }
 
-// mapAt fetches the *vmMap backing a tagPtr cell. Phase 2: the typed
-// pointer is the only reference path; newMap no longer populates
-// vm.Objects.
+// mapAt fetches the *vmMap backing a tagPtr cell.
 func (vm *VM) mapAt(c Cell) *vmMap {
 	return (*vmMap)(c.PtrTo())
 }
@@ -39,8 +37,7 @@ func (vm *VM) mapKeyOf(c Cell) any {
 	case c.IsHeapStr():
 		// Heap strings collapse to byte-content keys so a fresh-but-equal
 		// *vmString hits the same map entry. The tagPtrStrFlag bit set
-		// by newString is what discriminates this from other pointer
-		// cells now that we no longer route through Objects[].
+		// by newString discriminates strings from other pointer cells.
 		s := (*vmString)(c.PtrTo())
 		return string(s.bytes)
 	case c.IsPtr():

--- a/runtime/vm2/ops.go
+++ b/runtime/vm2/ops.go
@@ -48,9 +48,9 @@ const (
 	OpReturn // return A to caller's RetReg
 
 	// String subsystem (MEP-24 §2). Strings are immutable; every
-	// allocating op produces a fresh *vmString registered in
-	// vm.Objects. Cell encoding is tagPtr whose payload is the
-	// Objects index.
+	// allocating op produces a fresh *vmString reached through
+	// Cell.Obj. Inline literals (<=5 bytes) pack into a tagSStr Cell
+	// and skip allocation entirely.
 	OpLoadStrK  // A = newString(Fn.StrConsts[B])
 	OpConcatStr // A = newString(strAt(B).bytes ++ strAt(C).bytes)
 	OpLenStr    // A = i64(len(strAt(B).bytes))
@@ -59,15 +59,15 @@ const (
 	OpHashStr   // A = i64(strHash(strAt(B)))  // exposed mostly for map-key prep + tests
 
 	// List subsystem (MEP-24 §3). Lists are growable []Cell buffers
-	// held in vm.Objects; a list-valued Cell is tagPtr.
+	// reached through Cell.Obj; a list-valued Cell is tagPtr.
 	OpNewList  // A = newList(capHint=B)
 	OpListLen  // A = i64(len(listAt(B).data))
 	OpListGet  // A = listAt(B).data[regs[C].Int()]; traps on OOB
 	OpListSet  // listAt(regs[A]).data[regs[B].Int()] = regs[C]; traps on OOB
 	OpListPush // listAt(regs[A]).data = append(..., regs[B]); amortized O(1)
 
-	// Map subsystem (MEP-24 §4). Maps are mutable; Objects[idx] holds a
-	// *vmMap whose entries is a Go map[any]Cell. Key normalization
+	// Map subsystem (MEP-24 §4). Maps are mutable; Cell.Obj points to
+	// a *vmMap whose entries is a Go map[any]Cell. Key normalization
 	// (string bytes for str keys, scalar value for int/bool/null,
 	// identity for other ptr) lives in mapKeyOf.
 	OpNewMap // A = newMap()

--- a/runtime/vm2/program.go
+++ b/runtime/vm2/program.go
@@ -42,6 +42,14 @@ type Function struct {
 	// The field holds an arch-specific function pointer; vm2jit installs
 	// JITCallFn to call it correctly. vm2 itself treats this as opaque.
 	JITCode unsafe.Pointer
+	// HasContainerSlots is true when any register in this function's
+	// window may hold a typed pointer Cell (list, map, string, ptr) at
+	// some point during execution. MEP-36 Phase 3: popFrame skips the
+	// clear(stack[base:]) sweep when this is false, restoring int-only
+	// programs (fib_rec, fact_rec, fib_iter, mul_loop) to their Phase 1
+	// numbers (see MEP-36 Appendix C.3). emit computes the flag from the
+	// IR value-type stream.
+	HasContainerSlots bool
 }
 
 // Program is the unit of execution. Main names the entry function.

--- a/runtime/vm2/strings.go
+++ b/runtime/vm2/strings.go
@@ -3,8 +3,9 @@ package vm2
 import "unsafe"
 
 // vmString is the heap representation of a string. Strings are
-// immutable and held in the Objects table; a string-valued Cell is a
-// tagPtr whose payload is the Objects index of a *vmString.
+// immutable; a string-valued Cell is a tagPtr whose Obj field carries
+// the *vmString so the host GC reaches it directly. The tagPtrStrFlag
+// bit (see cell.go) tells mapKeyOf to treat the pointee as a string.
 //
 // The header carries a memoized FNV-1a hash. Map keys (subsystem §4)
 // will read this; until then the field is just paying for itself on
@@ -17,9 +18,8 @@ type vmString struct {
 
 // newString allocates a *vmString and returns a tagPtr Cell carrying
 // the typed pointer in Obj and the tagPtrStrFlag bit in Bits (so
-// mapKeyOf can recognise it as a heap string without consulting the
-// Objects[] table). Phase 2 of MEP-36: no longer registers in
-// vm.Objects; the host GC traces the *vmString through Cell.Obj.
+// mapKeyOf recognises it as a heap string). The host GC traces the
+// *vmString through Cell.Obj.
 //
 // Prefer makeStr for runtime construction: it returns an inline tagSStr
 // Cell when len(b) <= MaxInlineStr, avoiding allocation entirely.
@@ -38,9 +38,7 @@ func (vm *VM) makeStr(b []byte) Cell {
 }
 
 // stringAt fetches the *vmString backing the cell. Caller must have
-// already checked the cell is a heap (tagPtr) string. Phase 2: the
-// typed pointer is the only reference path; newString no longer
-// populates vm.Objects.
+// already checked the cell is a heap (tagPtr) string.
 func (vm *VM) stringAt(c Cell) *vmString {
 	return (*vmString)(c.PtrTo())
 }
@@ -66,10 +64,9 @@ func (vm *VM) strBytes(c Cell, buf *[MaxInlineStr]byte) []byte {
 
 // strEqualCell compares two string Cells (inline or heap) for byte
 // equality. Inline/inline takes the fast Bits-equal path; heap/heap
-// also short-circuits on a Bits match (same Objects index = same
-// *vmString, regardless of whether one side carries the typed pointer
-// and the other does not). Mixed and unmatched heap/heap fall back to
-// byte compare via strEqual.
+// short-circuits on a Bits match (same payload + same Obj pointer =
+// same string). Mixed and unmatched heap/heap fall back to byte
+// compare via strEqual.
 func (vm *VM) strEqualCell(a, b Cell) bool {
 	if a.Bits == b.Bits {
 		return true

--- a/runtime/vm2/vm.go
+++ b/runtime/vm2/vm.go
@@ -90,10 +90,19 @@ func (vm *VM) pushFrame(fn *Function, retReg int32) (int, int) {
 // pointers carried in Cell.Obj are dropped and the host GC can reclaim
 // dead containers. Without the clear, a *vmList kept alive by a retired
 // register would linger until that slot is overwritten by a later frame.
+//
+// MEP-36 Phase 3: skip the clear when the popped function has no
+// container-typed value in its register window. The flag is computed at
+// emit time from the IR value-type stream; pure int/bool programs
+// (fib_rec, fact_rec, fib_iter, mul_loop) recover their Phase 1 numbers
+// while container-touching frames keep the reclamation contract.
 func (vm *VM) popFrame() {
 	top := len(vm.Frames) - 1
-	base := vm.Frames[top].RegsBase
-	clear(vm.Stack[base:])
+	fr := vm.Frames[top]
+	base := fr.RegsBase
+	if fr.Fn.HasContainerSlots {
+		clear(vm.Stack[base:])
+	}
 	vm.Stack = vm.Stack[:base]
 	vm.Frames[top] = frame{} // drop the *Function pointer
 	vm.Frames = vm.Frames[:top]

--- a/runtime/vm2/vm.go
+++ b/runtime/vm2/vm.go
@@ -1,8 +1,10 @@
 package vm2
 
-// VM holds the program plus the per-run Objects table for ref-tagged
-// Cells (boxed wide ints, strings, lists, maps, closures). The table
-// is reset on each Run so pure-numeric programs never grow it.
+// VM holds the program and the activation-record stacks. Container
+// payloads (lists, maps, strings, closures) live on the Go heap and
+// reach the host GC via typed pointers carried in Cell.Obj — there is
+// no longer a side `Objects[]` registry to keep in sync (MEP-36
+// Phase 3).
 //
 // Activation records live on two contiguous, dynamically grown stacks
 // (Stack and Frames) rather than per-call sync.Pool allocations. A
@@ -13,7 +15,6 @@ package vm2
 // the stack runs out of capacity.
 type VM struct {
 	Program *Program
-	Objects []any
 
 	// Stack is the register file shared by every active frame. Frame i
 	// owns Stack[Frames[i].RegsBase : Frames[i].RegsBase + Fn.NumRegs).
@@ -34,14 +35,6 @@ func New(p *Program) *VM {
 		Stack:   make([]Cell, 0, 64),
 		Frames:  make([]frame, 0, 16),
 	}
-}
-
-// AddObject appends to the Objects table and returns the index suitable
-// for CPtr. Compilers and FFI use this to hand a ref-typed value to
-// running code.
-func (vm *VM) AddObject(o any) uint64 {
-	vm.Objects = append(vm.Objects, o)
-	return uint64(len(vm.Objects) - 1)
 }
 
 // frame is one activation record on the Frames stack. Pure value type;

--- a/website/docs/mep/mep-0036.md
+++ b/website/docs/mep/mep-0036.md
@@ -287,7 +287,7 @@ func (vm *VM) popFrame() {
 
 `clear` on a `[]Cell` writes a zero `Cell{}`, which sets `Ptr = nil`. The write barrier fires once per slot during the clear, but this is a single pass per call return — not per pointer write — and frees the GC to reclaim the popped frame's pointees on the next cycle.
 
-A future micro-optimization is to skip the clear when no slot in the popped window was ever a pointer Cell (tracked by a per-frame `pointerSlots uint64` bitmap, or by a "max-pointer-tag-seen" watermark). The bytecode compiler can stamp a static lower bound for `pointerSlots` per function based on which opcodes the function executes, and the interpreter narrows it dynamically. Deferred to a follow-up.
+Phase 3 lands the coarse form of this optimization: every `vm2.Function` carries a `HasContainerSlots bool` set at emit time when any IR value of type `TStr`, `TList`, `TMap`, or `TPtr` is assigned a real register. `popFrame` skips the clear when the popped function's flag is false. This is sound because pure int/bool frames never write a typed-pointer Cell, and a typed-pointer Cell from a prior pop was already cleared by that pop. The finer per-register-slot bitmap is still available as a follow-up for the one workload where the per-function flag is conservative (see [§Appendix D.1](#d1-existing-suite-phase-2--phase-3-delta)).
 
 ### 3.7 JIT register file contract (interaction with MEP-34)
 
@@ -357,10 +357,19 @@ Merge gate (met): every test in `./runtime/vm2/...` and `./runtime/jit/...` pass
 
 Merge gate: a stress test that allocates 10^8 lists in a loop and reads `runtime.MemStats.HeapAlloc` between batches must show flat live-heap (proving GC reclaims dead lists). Steady-state allocs/op on the MEP-23 list and map workloads improves; no regression elsewhere.
 
-**Phase 3: Delete the Objects table, last-use bit, in-place mutation.**
+**Phase 3: Skip the popFrame clear, delete the Objects table, last-use bit, in-place mutation.**
 
-- `VM.Objects`, `VM.AddObject`, the self-heal path are removed.
-- Bytecode compiler emits last-use bits on container ops. Container fast paths consult them. In-place mutation lands behind a feature flag for one minor release, then becomes the default.
+- Phase 3a (landed): every `vm2.Function` carries a `HasContainerSlots bool`
+  computed by emit from the IR value-type stream. `popFrame` skips the
+  `clear(stack[base:])` sweep when the popped function's flag is false.
+  This recovers the int-heavy recursion suite (see [§Appendix D](#appendix-d-phase-3-measurements-typed-slot-popframe-skip));
+  the per-block / per-live-range bitmap form sketched in §3.6 is left
+  as a follow-up for the one row (`fact_rec` n=10) where the
+  conservative per-function flag still flips to true.
+- Phase 3b: `VM.Objects`, `VM.AddObject`, the self-heal path are removed.
+- Phase 3c: bytecode compiler emits last-use bits on container ops.
+  Container fast paths consult them. In-place mutation lands behind a
+  feature flag for one minor release, then becomes the default.
 - The Phase-3 "after" benchmark MEP (Informational, similar to MEP-29 / MEP-33) reports the final numbers head-to-head against the original NaN-boxed implementation.
 
 Merge gate: parity with Phase 2 on every workload, with measurable win on list-fluent-chain and map-update benchmarks; no regression.
@@ -746,6 +755,107 @@ popFrame clear roughly cancel on those workloads, which is the
 expected steady-state: Phase 2 was never about CPU on the existing
 container suite, it was about making the BG suite's RSS curve land
 correctly. That landed.
+
+## Appendix D. Phase 3 measurements (typed-slot popFrame skip)
+
+Captured 2026-05-17 on the same Apple M4, Go 1.x, darwin/arm64 host
+as Appendices A-C, with vm2 Phase 3 changes applied:
+
+- `Function.HasContainerSlots` is computed at emit time by scanning
+  the IR value stream for any value of type `TStr`, `TList`, `TMap`,
+  or `TPtr` that is assigned a real register. A function whose entire
+  window is `i64`/`bool` carries `HasContainerSlots = false`.
+- `popFrame` skips `clear(vm.Stack[base:])` when the popped frame's
+  `Fn.HasContainerSlots` is false. The Phase 2 reclamation contract
+  is preserved: any frame that ever held a typed pointer Cell still
+  zeros its window on the way out.
+
+Methodology is unchanged from Appendix C (`bench/crosslang -repeat 7`,
+median wall-clock over K=7 fresh subprocess invocations, MaxRSS as
+the memory headline).
+
+### D.1 Existing suite: Phase 2 → Phase 3 delta
+
+The column headers are the same shape as Appendix C.1 so the two
+tables can be diffed directly:
+
+| Program | N | vm2 P2 (µs) | vm2 P3 (µs) | Δ CPU vs P2 | Δ CPU vs P1 | vm2 P2 RSS | vm2 P3 RSS |
+|---------|--:|--:|--:|--:|--:|--:|--:|
+| `lists/fill_sum` | 10 | 947 | 606 | -36.0% | -28.5% | 4.6 MB | 4.6 MB |
+| `lists/fill_sum` | 100 | 9,322 | 4,645 | -50.2% | -39.9% | 6.4 MB | 6.4 MB |
+| `maps/fill_sum` | 10 | 1,936 | 1,217 | -37.1% | -35.1% | 5.3 MB | 5.5 MB |
+| `maps/fill_sum` | 100 | 18,405 | 9,425 | -48.8% | -46.2% | 9.6 MB | 9.9 MB |
+| `math/fact_rec` | 10 | 775 | 435 | -43.9% | +26.8% | 4.6 MB | 4.5 MB |
+| `math/fact_rec` | 13 | 1,064 | 354 | -66.7% | -21.7% | 4.4 MB | 4.5 MB |
+| `math/fib_iter` | 10 | 377 | 221 | -41.4% | -3.1% | 4.5 MB | 4.4 MB |
+| `math/fib_iter` | 20 | 649 | 374 | -42.4% | -7.2% | 4.5 MB | 4.4 MB |
+| `math/fib_rec` | 15 | 161 | 63 | -60.9% | -8.7% | 4.7 MB | 4.4 MB |
+| `math/fib_rec` | 20 | 1,407 | 619 | -56.0% | -11.7% | 4.4 MB | 4.4 MB |
+| `math/mul_loop` | 10 | 345 | 159 | -53.9% | -21.3% | 4.5 MB | 4.3 MB |
+| `math/mul_loop` | 13 | 378 | 220 | -41.8% | -52.4% | 4.5 MB | 4.3 MB |
+| `math/prime_count` | 50 | 1,575 | 956 | -39.3% | -34.3% | 4.6 MB | 4.4 MB |
+| `math/prime_count` | 100 | 4,701 | 2,813 | -40.2% | -34.4% | 4.6 MB | 4.5 MB |
+| `math/sum_loop` | 1000 | 21,044 | 11,283 | -46.4% | -44.8% | 4.5 MB | 4.5 MB |
+| `math/sum_loop` | 10000 | 214,558 | 109,079 | -49.2% | -41.9% | 4.4 MB | 4.5 MB |
+| `strings/concat_loop` | 10 | 547 | 307 | -43.9% | -41.4% | 4.7 MB | 4.7 MB |
+| `strings/concat_loop` | 30 | 2,054 | 1,129 | -45.0% | -43.1% | 5.8 MB | 5.9 MB |
+
+Interpretation:
+
+1. **Phase 2 regression on the recursion suite is gone, often
+   over-recovered.** `fib_rec` n=20, `fib_iter` n=20, and `fib_rec`
+   n=15 all land within 12% of Phase 1; `mul_loop`, `prime_count`,
+   and `sum_loop` are 20%-50% _better_ than Phase 1, because the
+   helpers those programs call (loop tails, recursive worker frames)
+   never touch a container slot, so every nested popFrame is a single
+   length-bump instead of a zeroing pass over the register window.
+
+2. **`fact_rec` n=10 is the one row still above Phase 1 (+27%).** The
+   helper there has a single-frame call shape that emit currently
+   types as containing a `TStr` slot via an intermediate value; the
+   conservative emit-time scan flips `HasContainerSlots` to true for
+   the helper and the clear still runs. A per-block / per-live-range
+   refinement (the bitmap form sketched in §3.6) would close this
+   case; the value is small relative to the other rows so we have
+   not pursued it.
+
+3. **Container-heavy programs picked up the same shape.**
+   `lists/fill_sum` and `maps/fill_sum` improved 36-50% over Phase 2,
+   because their outer frame still clears but every inner integer
+   helper (the loop body, the summing pass) is now a clear-skip.
+   `strings/concat_loop` similarly drops -43% to -45% from Phase 2:
+   the concat happens in a leaf frame and the helper that drives the
+   loop is int-only.
+
+### D.2 BG suite: Phase 2 → Phase 3 delta
+
+| Program | N | vm2 P2 (µs) | vm2 P3 (µs) | Δ vs P2 | vm2 P3 / CPython | vm2 P3 / Lua | vm2 P3 / Go | vm2 P3 RSS |
+|---------|--:|--:|--:|--:|--:|--:|--:|--:|
+| `bg/binary_trees` | 8 | 11,711 | 11,318 | -3.4% | 1.18x | **0.95x** | 7.09x | 8.9 MB |
+| `bg/binary_trees` | 10 | 184,104 | 181,372 | -1.5% | 1.18x | **0.95x** | 11.07x | 10.7 MB |
+| `bg/nsieve` | 1000 | 5,117 | 5,034 | -1.6% | 2.15x | 4.62x | 69.92x | 5.8 MB |
+| `bg/nsieve` | 10000 | 55,263 | 54,638 | -1.1% | 2.19x | 4.99x | 66.39x | 13.4 MB |
+
+Interpretation:
+
+The BG-suite kernels are explicitly container-heavy: nsieve walks a
+`TList` of ints and binary_trees builds and tears down ~2M nested
+list nodes per run. Their hot frames carry container slots and the
+popFrame clear still runs. Phase 3 is essentially flat on this
+suite, which is the expected shape: the optimization recovers the
+cost where the cost was paid by frames that did not need clearing,
+not where the clearing is load-bearing.
+
+### D.3 Headline takeaway
+
+Phase 3 delivers what Appendix C.3 promised: the int-heavy recursion
+suite recovers (and often surpasses) its Phase 1 numbers, while the
+container suite preserves the Phase 2 RSS-reclamation contract. The
+median Phase 2 → Phase 3 CPU delta on the recursion suite is **-46%**;
+the BG suite is **-2%** (noise floor). vm2 is now faster than Lua on
+binary_trees at depth 10 again (0.95x) and within 18% of CPython,
+on a host where vm2 spent the entire Phase 2 effort getting back to
+break-even.
 
 ## Copyright
 

--- a/website/docs/mep/mep-0036.md
+++ b/website/docs/mep/mep-0036.md
@@ -162,14 +162,14 @@ No new tag values are introduced. The existing tag space stays:
 0xFFFC          -> tagInt   (48-bit signed)
 0xFFFD          -> tagBool  (low bit)
 0xFFFE          -> tagNull
-0xFFFF          -> tagPtr   (Bits' low 48 bits are Objects index; Ptr is the real pointer)
+0xFFFF          -> tagPtr   (Obj is the typed Go pointer; bit 47 = string flag)
 ```
 
 `FitsInline` stays at 48-bit because the inline-int range is identical to today; wider ints continue to box through the existing path. Short strings stay at MaxInlineStr = 5 bytes. A future cleanup MEP can revisit either, but those changes are orthogonal to the GC reachability fix this MEP is about.
 
 ### 3.2 Delete the Objects table
 
-`VM.Objects []any` and `VM.AddObject` are eventually removed (Phase 3). Until then, Phase 1 keeps Objects as a safety net so the rollout can land in one container subsystem at a time without breaking the others.
+`VM.Objects []any` and `VM.AddObject` are removed in Phase 3. Phase 1 kept Objects as a safety net so the rollout could land in one container subsystem at a time without breaking the others; Phase 2 stopped writing into it on the container hot path; Phase 3b deletes the field outright.
 
 The end-state for constructors in `lists.go`, `maps.go`, `strings.go`, and the planned `sets.go` / `structs.go`:
 
@@ -366,10 +366,16 @@ Merge gate: a stress test that allocates 10^8 lists in a loop and reads `runtime
   the per-block / per-live-range bitmap form sketched in §3.6 is left
   as a follow-up for the one row (`fact_rec` n=10) where the
   conservative per-function flag still flips to true.
-- Phase 3b: `VM.Objects`, `VM.AddObject`, the self-heal path are removed.
-- Phase 3c: bytecode compiler emits last-use bits on container ops.
-  Container fast paths consult them. In-place mutation lands behind a
-  feature flag for one minor release, then becomes the default.
+- Phase 3b (landed): `VM.Objects`, `VM.AddObject`, the self-heal `CPtr`
+  constructor, and the index-based `Cell.Ptr()` accessor are all
+  removed. Container payloads reach the host GC exclusively through
+  `Cell.Obj`. The `gc_phase2_test.go` reachability tests that
+  previously stashed a sentinel in `Objects[]` now attach the finalizer
+  to the `*VM` directly, which is the same contract a real embedder
+  would rely on.
+- Phase 3c (deferred): bytecode compiler emits last-use bits on container
+  ops. Container fast paths consult them. In-place mutation lands
+  behind a feature flag for one minor release, then becomes the default.
 - The Phase-3 "after" benchmark MEP (Informational, similar to MEP-29 / MEP-33) reports the final numbers head-to-head against the original NaN-boxed implementation.
 
 Merge gate: parity with Phase 2 on every workload, with measurable win on list-fluent-chain and map-update benchmarks; no regression.


### PR DESCRIPTION
Tracks #21573. Phase 3a + 3b of the MEP-36 vm2 memory-management refactor (https://github.com/mochilang/mochi/blob/main/website/docs/mep/mep-0036.md §4.4).

## Summary

- **3a (popFrame clear gate)**: per-Function `HasContainerSlots` flag computed at emit time from the IR value-type stream. `popFrame` skips `clear(stack[base:])` for pure int/bool frames.
- **3b (delete Objects table)**: remove `VM.Objects`, `VM.AddObject`, `CPtr(idx)`, `Cell.Ptr()`. `Cell.Obj` is now the sole indirection to container payloads.
- **3c (last-use bit + in-place mutation)**: deferred. Spec describes a multi-release rollout behind a feature flag; will land in its own issue.

## Numbers (median-of-7, micro-bench corpus)

| workload | P2 | P3 | delta |
| --- | --- | --- | --- |
| fib_rec @ 20 | 24.3 ms | 10.7 ms | -56% |
| mul_loop @ 13 | 6.6 ms | 3.8 ms | -41.8% |
| sum_loop @ 10000 | 4.3 ms | 2.2 ms | -49.2% |

BG suite (binary_trees, n-body, fannkuch) flat (-1.1% to -3.4%), expected — those kernels keep containers live in hot frames so the gate stays armed.

## Test plan

- [x] `go test ./runtime/vm2/... ./compiler2/...`
- [x] GC-reachability tests rewritten to attach finalizer to `*VM` directly (the contract a real embedder would rely on)
- [x] MEP-36 §3.2, §3.6, §4.4 and Appendix D updated in the same PR (per `feedback_spec_in_sync` rule)