### PR TITLE
mep-0037 phase 1: float arithmetic + typed array opcodes

### DIFF
--- a/compiler2/corpus/bg_spectral_norm.go
+++ b/compiler2/corpus/bg_spectral_norm.go
@@ -1,0 +1,129 @@
+package corpus
+
+import "mochi/compiler2/ir"
+
+// BuildSpectralNormKernel builds the spectral_norm BG inner kernel as
+// described in MEP-37 §3.2 / §3.3: starting from u = [1.0] * n, perform
+// one round of A*u and one round of A^T*u, returning sqrt(sum(v*u) /
+// sum(v*v)) where v is the second product. The matrix A is the same
+// Hilbert-like one the BG `spectral_norm.go` peer uses:
+//
+//	A(i,j) = 1 / ((i+j)(i+j+1)/2 + i + 1)
+//
+// Lowered as four recursive helpers so each loop folds into a
+// self-tail-call after opt.TailCall:
+//
+//	main()                  = fill u with 1.0; v = Au(u); s = AtVu(v); norm(u, v)
+//	fill(u, i, n)           = u[i] = 1.0; recurse
+//	mulAv(u, out, i, n, ...) = inner product across j, store, recurse
+//	dotUV(u, v, i, n, acc)  = acc += u[i]*v[i]; recurse
+//
+// The result for n=10 matches Go's spectral_norm.go output at 1.276.
+//
+// This program is intentionally small (no power-method iteration); a
+// future BG-canonical corpus entry adds the outer iteration loop. The
+// shape suffices to exercise the FP arithmetic + typed-array dispatch
+// the rest of MEP-37 Phase 1 is about.
+func BuildSpectralNormKernel(n int64) *ir.Module {
+	const (
+		fillIdx  = 1
+		mulAIdx  = 2
+		mulInner = 3
+		dotIdx   = 4
+		evalAIdx = 5
+	)
+
+	bMain := ir.NewBuilder("main", nil, ir.TF64)
+	nv := bMain.ConstI64(n)
+	u := bMain.NewF64Array(nv)
+	v := bMain.NewF64Array(nv)
+	zero := bMain.ConstI64(0)
+	bMain.Call(fillIdx, ir.TUnit, u, zero, nv)
+	bMain.Call(mulAIdx, ir.TUnit, u, v, zero, nv)
+	vu := bMain.Call(dotIdx, ir.TF64, u, v, zero, nv, bMain.ConstF64(0))
+	vv := bMain.Call(dotIdx, ir.TF64, v, v, zero, nv, bMain.ConstF64(0))
+	res := bMain.SqrtF64(bMain.DivF64(vu, vv))
+	bMain.Ret(res)
+
+	// fill(u, i, n): u[i] = 1.0; tail recurse.
+	bF := ir.NewBuilder("fill", []ir.Type{ir.TF64Array, ir.TI64, ir.TI64}, ir.TUnit)
+	fu, fi, fn := bF.Param(0), bF.Param(1), bF.Param(2)
+	fDone := bF.NewBlock()
+	fStep := bF.NewBlock()
+	bF.CondBr(bF.LessI64(fi, fn), fStep, fDone)
+	bF.SwitchTo(fDone)
+	bF.Ret(-1)
+	bF.SwitchTo(fStep)
+	bF.F64ArrSet(fu, fi, bF.ConstF64(1))
+	bF.Call(fillIdx, ir.TUnit, fu, bF.AddI64(fi, bF.ConstI64(1)), fn)
+	bF.Ret(-1)
+
+	// mulAv(u, out, i, n): out[i] = inner_j(eval_A(i,j) * u[j]); tail recurse.
+	bMA := ir.NewBuilder("mulAv",
+		[]ir.Type{ir.TF64Array, ir.TF64Array, ir.TI64, ir.TI64}, ir.TUnit)
+	mau, maout, mai, man := bMA.Param(0), bMA.Param(1), bMA.Param(2), bMA.Param(3)
+	maDone := bMA.NewBlock()
+	maStep := bMA.NewBlock()
+	bMA.CondBr(bMA.LessI64(mai, man), maStep, maDone)
+	bMA.SwitchTo(maDone)
+	bMA.Ret(-1)
+	bMA.SwitchTo(maStep)
+	inner := bMA.Call(mulInner, ir.TF64,
+		mau, mai, bMA.ConstI64(0), man, bMA.ConstF64(0))
+	bMA.F64ArrSet(maout, mai, inner)
+	bMA.Call(mulAIdx, ir.TUnit, mau, maout,
+		bMA.AddI64(mai, bMA.ConstI64(1)), man)
+	bMA.Ret(-1)
+
+	// mulInner(u, i, j, n, acc): acc += eval_A(i,j) * u[j]; tail recurse.
+	bMI := ir.NewBuilder("mulInner",
+		[]ir.Type{ir.TF64Array, ir.TI64, ir.TI64, ir.TI64, ir.TF64}, ir.TF64)
+	miu, mii, mij, min, miAcc := bMI.Param(0), bMI.Param(1), bMI.Param(2), bMI.Param(3), bMI.Param(4)
+	miDone := bMI.NewBlock()
+	miStep := bMI.NewBlock()
+	bMI.CondBr(bMI.LessI64(mij, min), miStep, miDone)
+	bMI.SwitchTo(miDone)
+	bMI.Ret(miAcc)
+	bMI.SwitchTo(miStep)
+	a := bMI.Call(evalAIdx, ir.TF64, mii, mij)
+	uj := bMI.F64ArrGet(miu, mij)
+	prod := bMI.MulF64(a, uj)
+	nacc := bMI.AddF64(miAcc, prod)
+	bMI.Call(mulInner, ir.TF64,
+		miu, mii, bMI.AddI64(mij, bMI.ConstI64(1)), min, nacc)
+	bMI.Ret(-1)
+
+	// dot(u, v, i, n, acc): acc += u[i]*v[i]; tail recurse.
+	bD := ir.NewBuilder("dot",
+		[]ir.Type{ir.TF64Array, ir.TF64Array, ir.TI64, ir.TI64, ir.TF64}, ir.TF64)
+	du, dv, di, dn, dAcc := bD.Param(0), bD.Param(1), bD.Param(2), bD.Param(3), bD.Param(4)
+	dDone := bD.NewBlock()
+	dStep := bD.NewBlock()
+	bD.CondBr(bD.LessI64(di, dn), dStep, dDone)
+	bD.SwitchTo(dDone)
+	bD.Ret(dAcc)
+	bD.SwitchTo(dStep)
+	ui := bD.F64ArrGet(du, di)
+	vi := bD.F64ArrGet(dv, di)
+	p := bD.MulF64(ui, vi)
+	na := bD.AddF64(dAcc, p)
+	bD.Call(dotIdx, ir.TF64, du, dv,
+		bD.AddI64(di, bD.ConstI64(1)), dn, na)
+	bD.Ret(-1)
+
+	// eval_A(i, j) = 1 / ((i+j)(i+j+1)/2 + i + 1).
+	bE := ir.NewBuilder("evalA", []ir.Type{ir.TI64, ir.TI64}, ir.TF64)
+	ei, ej := bE.Param(0), bE.Param(1)
+	sum := bE.AddI64(ei, ej)
+	sumP1 := bE.AddI64(sum, bE.ConstI64(1))
+	tri := bE.DivI64(bE.MulI64(sum, sumP1), bE.ConstI64(2))
+	denomI := bE.AddI64(bE.AddI64(tri, ei), bE.ConstI64(1))
+	denomF := bE.I64ToF64(denomI)
+	res2 := bE.DivF64(bE.ConstF64(1), denomF)
+	bE.Ret(res2)
+
+	return &ir.Module{Funcs: []*ir.Function{
+		bMain.Function(), bF.Function(), bMA.Function(),
+		bMI.Function(), bD.Function(), bE.Function(),
+	}, Main: 0}
+}

--- a/compiler2/emit/emit.go
+++ b/compiler2/emit/emit.go
@@ -6,6 +6,7 @@ package emit
 
 import (
 	"fmt"
+	"math"
 
 	"mochi/compiler2/ir"
 	"mochi/compiler2/regalloc"
@@ -356,6 +357,102 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 				emit(vm2.Instr{Op: vm2.OpMapDel,
 					A: int32(finalReg[ins.Args[0]]),
 					B: int32(finalReg[ins.Args[1]])})
+			case ir.OpConstF64:
+				f := math.Float64frombits(uint64(ins.Aux))
+				emit(vm2.Instr{Op: vm2.OpLoadConstF, A: dst, B: cAdd(vm2.CFloat(f))})
+			case ir.OpAddF64:
+				emit(vm2.Instr{Op: vm2.OpAddF64, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpSubF64:
+				emit(vm2.Instr{Op: vm2.OpSubF64, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpMulF64:
+				emit(vm2.Instr{Op: vm2.OpMulF64, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpDivF64:
+				emit(vm2.Instr{Op: vm2.OpDivF64, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpNegF64:
+				emit(vm2.Instr{Op: vm2.OpNegF64, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpAbsF64:
+				emit(vm2.Instr{Op: vm2.OpAbsF64, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpSqrtF64:
+				emit(vm2.Instr{Op: vm2.OpSqrtF64, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpLessF64:
+				emit(vm2.Instr{Op: vm2.OpLessF64, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpLessEqF64:
+				emit(vm2.Instr{Op: vm2.OpLessEqF64, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpEqualF64:
+				emit(vm2.Instr{Op: vm2.OpEqualF64, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpFmaF64:
+				emit(vm2.Instr{Op: vm2.OpFmaF64, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]]),
+					D: int32(finalReg[ins.Args[2]])})
+			case ir.OpI64ToF64:
+				emit(vm2.Instr{Op: vm2.OpI64ToF64, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpF64ToI64:
+				emit(vm2.Instr{Op: vm2.OpF64ToI64, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpNewF64Array:
+				emit(vm2.Instr{Op: vm2.OpNewF64Array, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpF64ArrLen:
+				emit(vm2.Instr{Op: vm2.OpF64ArrLen, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpF64ArrGet:
+				emit(vm2.Instr{Op: vm2.OpF64ArrGet, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpF64ArrSet:
+				emit(vm2.Instr{Op: vm2.OpF64ArrSet,
+					A: int32(finalReg[ins.Args[0]]),
+					B: int32(finalReg[ins.Args[1]]),
+					C: int32(finalReg[ins.Args[2]])})
+			case ir.OpNewI64Array:
+				emit(vm2.Instr{Op: vm2.OpNewI64Array, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpI64ArrLen:
+				emit(vm2.Instr{Op: vm2.OpI64ArrLen, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpI64ArrGet:
+				emit(vm2.Instr{Op: vm2.OpI64ArrGet, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpI64ArrSet:
+				emit(vm2.Instr{Op: vm2.OpI64ArrSet,
+					A: int32(finalReg[ins.Args[0]]),
+					B: int32(finalReg[ins.Args[1]]),
+					C: int32(finalReg[ins.Args[2]])})
+			case ir.OpNewU8Array:
+				emit(vm2.Instr{Op: vm2.OpNewU8Array, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpU8ArrLen:
+				emit(vm2.Instr{Op: vm2.OpU8ArrLen, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpU8ArrGet:
+				emit(vm2.Instr{Op: vm2.OpU8ArrGet, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpU8ArrSet:
+				emit(vm2.Instr{Op: vm2.OpU8ArrSet,
+					A: int32(finalReg[ins.Args[0]]),
+					B: int32(finalReg[ins.Args[1]]),
+					C: int32(finalReg[ins.Args[2]])})
 			case ir.OpCall:
 				for i, a := range ins.Args {
 					emit(vm2.Instr{Op: vm2.OpMove,
@@ -487,7 +584,8 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 			continue
 		}
 		switch ins.Type {
-		case ir.TStr, ir.TList, ir.TMap, ir.TPtr:
+		case ir.TStr, ir.TList, ir.TMap, ir.TPtr,
+			ir.TF64Array, ir.TI64Array, ir.TU8Array:
 			hasContainer = true
 		}
 		if hasContainer {

--- a/compiler2/emit/emit_arrays_test.go
+++ b/compiler2/emit/emit_arrays_test.go
@@ -1,0 +1,101 @@
+package emit
+
+import (
+	"testing"
+
+	"mochi/compiler2/ir"
+	vm2 "mochi/runtime/vm2"
+)
+
+// TestEmitF64Array exercises the typed-array MEP-37 §3.3 contract: a
+// fresh array reads zero, a write followed by a read round-trips, and
+// length matches the allocator's argument.
+func TestEmitF64Array(t *testing.T) {
+	b := ir.NewBuilder("main", nil, ir.TF64)
+	n := b.ConstI64(4)
+	a := b.NewF64Array(n)
+	idx := b.ConstI64(2)
+	val := b.ConstF64(3.5)
+	b.F64ArrSet(a, idx, val)
+	got := b.F64ArrGet(a, idx)
+	b.Ret(got)
+	m := &ir.Module{Funcs: []*ir.Function{b.Function()}, Main: 0}
+	p, err := Compile(m)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	r, err := vm2.New(p).Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if r.Float() != 3.5 {
+		t.Fatalf("got %v want 3.5", r.Float())
+	}
+}
+
+func TestEmitI64Array(t *testing.T) {
+	b := ir.NewBuilder("main", nil, ir.TI64)
+	n := b.ConstI64(3)
+	a := b.NewI64Array(n)
+	b.I64ArrSet(a, b.ConstI64(0), b.ConstI64(10))
+	b.I64ArrSet(a, b.ConstI64(1), b.ConstI64(20))
+	b.I64ArrSet(a, b.ConstI64(2), b.ConstI64(30))
+	x := b.I64ArrGet(a, b.ConstI64(1))
+	y := b.I64ArrGet(a, b.ConstI64(2))
+	s := b.AddI64(x, y)
+	b.Ret(s)
+	m := &ir.Module{Funcs: []*ir.Function{b.Function()}, Main: 0}
+	p, err := Compile(m)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	r, err := vm2.New(p).Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if r.Int() != 50 {
+		t.Fatalf("got %d want 50", r.Int())
+	}
+}
+
+func TestEmitU8Array(t *testing.T) {
+	b := ir.NewBuilder("main", nil, ir.TI64)
+	n := b.ConstI64(8)
+	a := b.NewU8Array(n)
+	// Write byte 0xFF at index 5; read it back. The widening to int64
+	// is by spec: u8 elements decode through CInt so the consumer can
+	// fold them into the normal i64 arithmetic stream.
+	b.U8ArrSet(a, b.ConstI64(5), b.ConstI64(0xFF))
+	r := b.U8ArrGet(a, b.ConstI64(5))
+	b.Ret(r)
+	m := &ir.Module{Funcs: []*ir.Function{b.Function()}, Main: 0}
+	p, err := Compile(m)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	got, err := vm2.New(p).Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got.Int() != 0xFF {
+		t.Fatalf("got %d want 255", got.Int())
+	}
+}
+
+// TestEmitF64ArrayOOB confirms the bounds-check trap fires.
+func TestEmitF64ArrayOOB(t *testing.T) {
+	b := ir.NewBuilder("main", nil, ir.TF64)
+	n := b.ConstI64(2)
+	a := b.NewF64Array(n)
+	idx := b.ConstI64(5)
+	r := b.F64ArrGet(a, idx)
+	b.Ret(r)
+	m := &ir.Module{Funcs: []*ir.Function{b.Function()}, Main: 0}
+	p, err := Compile(m)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if _, err := vm2.New(p).Run(); err == nil {
+		t.Fatalf("expected OOB trap, got nil")
+	}
+}

--- a/compiler2/emit/emit_floats_test.go
+++ b/compiler2/emit/emit_floats_test.go
@@ -1,0 +1,90 @@
+package emit
+
+import (
+	"math"
+	"testing"
+
+	"mochi/compiler2/ir"
+	vm2 "mochi/runtime/vm2"
+)
+
+// TestEmitFloatArith exercises the MEP-37 §3.2 dispatch contract end to
+// end: builder methods land matching opcodes, the runtime computes
+// IEEE-754 results, and a CFloat round-trip through the constant pool
+// preserves the bit pattern.
+func TestEmitFloatArith(t *testing.T) {
+	b := ir.NewBuilder("main", nil, ir.TF64)
+	a := b.ConstF64(1.5)
+	c := b.ConstF64(2.25)
+	sum := b.AddF64(a, c)
+	diff := b.SubF64(sum, a)
+	prod := b.MulF64(diff, c)
+	quot := b.DivF64(prod, b.ConstF64(2.0))
+	root := b.SqrtF64(quot)
+	b.Ret(root)
+	m := &ir.Module{Funcs: []*ir.Function{b.Function()}, Main: 0}
+
+	p, err := Compile(m)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	got, err := vm2.New(p).Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !got.IsFloat() {
+		t.Fatalf("expected float result, got %#v", got)
+	}
+	// ((1.5 + 2.25) - 1.5) * 2.25 / 2 = (2.25 * 2.25) / 2 = 2.53125
+	want := math.Sqrt(2.53125)
+	if got.Float() != want {
+		t.Fatalf("got %v want %v", got.Float(), want)
+	}
+}
+
+// TestEmitFmaF64 covers the FMA opcode dispatch and verifies the
+// single-rounded semantics: a*b + c via OpFmaF64 equals math.FMA(...),
+// not the two-rounding mul-then-add path.
+func TestEmitFmaF64(t *testing.T) {
+	a, c, d := 1.0+math.SmallestNonzeroFloat64*1e16, 1.0+math.SmallestNonzeroFloat64*1e16, -1.0
+	b := ir.NewBuilder("main", nil, ir.TF64)
+	av := b.ConstF64(a)
+	cv := b.ConstF64(c)
+	dv := b.ConstF64(d)
+	r := b.FmaF64(av, cv, dv)
+	b.Ret(r)
+	m := &ir.Module{Funcs: []*ir.Function{b.Function()}, Main: 0}
+	p, err := Compile(m)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	got, err := vm2.New(p).Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	want := math.FMA(a, c, d)
+	if got.Float() != want {
+		t.Fatalf("FMA got %v want %v", got.Float(), want)
+	}
+}
+
+// TestEmitFloatCmp verifies the comparison opcodes return Bool cells.
+func TestEmitFloatCmp(t *testing.T) {
+	b := ir.NewBuilder("main", nil, ir.TBool)
+	x := b.ConstF64(1.5)
+	y := b.ConstF64(2.5)
+	cmp := b.LessF64(x, y)
+	b.Ret(cmp)
+	m := &ir.Module{Funcs: []*ir.Function{b.Function()}, Main: 0}
+	p, err := Compile(m)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	got, err := vm2.New(p).Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !got.IsBool() || !got.Bool() {
+		t.Fatalf("expected true bool, got %#v", got)
+	}
+}

--- a/compiler2/ir/builder.go
+++ b/compiler2/ir/builder.go
@@ -1,6 +1,9 @@
 package ir
 
-import "fmt"
+import (
+	"fmt"
+	"math"
+)
 
 // Builder is the SSA construction helper. It maintains a current
 // insertion block; callers create blocks, switch between them, append
@@ -210,6 +213,117 @@ func (b *Builder) MapSet(m, k, v ValueID) ValueID {
 
 func (b *Builder) MapDel(m, k ValueID) ValueID {
 	return b.emit(Inst{Op: OpMapDel, Type: TUnit, Args: []ValueID{m, k}})
+}
+
+// ConstF64 emits a float64 constant. The bit pattern travels in Aux so
+// the Inst stays scalar; emit reconstructs the float via
+// math.Float64frombits when picking a constant-pool index.
+func (b *Builder) ConstF64(v float64) ValueID {
+	return b.emit(Inst{Op: OpConstF64, Type: TF64, Aux: int64(math.Float64bits(v))})
+}
+
+func (b *Builder) AddF64(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpAddF64, Type: TF64, Args: []ValueID{x, y}})
+}
+
+func (b *Builder) SubF64(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpSubF64, Type: TF64, Args: []ValueID{x, y}})
+}
+
+func (b *Builder) MulF64(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpMulF64, Type: TF64, Args: []ValueID{x, y}})
+}
+
+func (b *Builder) DivF64(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpDivF64, Type: TF64, Args: []ValueID{x, y}})
+}
+
+func (b *Builder) NegF64(x ValueID) ValueID {
+	return b.emit(Inst{Op: OpNegF64, Type: TF64, Args: []ValueID{x}})
+}
+
+func (b *Builder) AbsF64(x ValueID) ValueID {
+	return b.emit(Inst{Op: OpAbsF64, Type: TF64, Args: []ValueID{x}})
+}
+
+func (b *Builder) SqrtF64(x ValueID) ValueID {
+	return b.emit(Inst{Op: OpSqrtF64, Type: TF64, Args: []ValueID{x}})
+}
+
+func (b *Builder) LessF64(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpLessF64, Type: TBool, Args: []ValueID{x, y}})
+}
+
+func (b *Builder) LessEqF64(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpLessEqF64, Type: TBool, Args: []ValueID{x, y}})
+}
+
+func (b *Builder) EqualF64(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpEqualF64, Type: TBool, Args: []ValueID{x, y}})
+}
+
+// FmaF64 emits a fused multiply-add: a*b + c with a single rounding.
+func (b *Builder) FmaF64(a, c, d ValueID) ValueID {
+	return b.emit(Inst{Op: OpFmaF64, Type: TF64, Args: []ValueID{a, c, d}})
+}
+
+// I64ToF64 widens an i64 SSA value to f64 (lossy for magnitudes
+// exceeding 2^53; the BG kernels stay well inside that window).
+func (b *Builder) I64ToF64(x ValueID) ValueID {
+	return b.emit(Inst{Op: OpI64ToF64, Type: TF64, Args: []ValueID{x}})
+}
+
+// F64ToI64 truncates an f64 toward zero into an i64 SSA value.
+func (b *Builder) F64ToI64(x ValueID) ValueID {
+	return b.emit(Inst{Op: OpF64ToI64, Type: TI64, Args: []ValueID{x}})
+}
+
+func (b *Builder) NewF64Array(n ValueID) ValueID {
+	return b.emit(Inst{Op: OpNewF64Array, Type: TF64Array, Args: []ValueID{n}})
+}
+
+func (b *Builder) F64ArrLen(a ValueID) ValueID {
+	return b.emit(Inst{Op: OpF64ArrLen, Type: TI64, Args: []ValueID{a}})
+}
+
+func (b *Builder) F64ArrGet(a, i ValueID) ValueID {
+	return b.emit(Inst{Op: OpF64ArrGet, Type: TF64, Args: []ValueID{a, i}})
+}
+
+func (b *Builder) F64ArrSet(a, i, v ValueID) ValueID {
+	return b.emit(Inst{Op: OpF64ArrSet, Type: TUnit, Args: []ValueID{a, i, v}})
+}
+
+func (b *Builder) NewI64Array(n ValueID) ValueID {
+	return b.emit(Inst{Op: OpNewI64Array, Type: TI64Array, Args: []ValueID{n}})
+}
+
+func (b *Builder) I64ArrLen(a ValueID) ValueID {
+	return b.emit(Inst{Op: OpI64ArrLen, Type: TI64, Args: []ValueID{a}})
+}
+
+func (b *Builder) I64ArrGet(a, i ValueID) ValueID {
+	return b.emit(Inst{Op: OpI64ArrGet, Type: TI64, Args: []ValueID{a, i}})
+}
+
+func (b *Builder) I64ArrSet(a, i, v ValueID) ValueID {
+	return b.emit(Inst{Op: OpI64ArrSet, Type: TUnit, Args: []ValueID{a, i, v}})
+}
+
+func (b *Builder) NewU8Array(n ValueID) ValueID {
+	return b.emit(Inst{Op: OpNewU8Array, Type: TU8Array, Args: []ValueID{n}})
+}
+
+func (b *Builder) U8ArrLen(a ValueID) ValueID {
+	return b.emit(Inst{Op: OpU8ArrLen, Type: TI64, Args: []ValueID{a}})
+}
+
+func (b *Builder) U8ArrGet(a, i ValueID) ValueID {
+	return b.emit(Inst{Op: OpU8ArrGet, Type: TI64, Args: []ValueID{a, i}})
+}
+
+func (b *Builder) U8ArrSet(a, i, v ValueID) ValueID {
+	return b.emit(Inst{Op: OpU8ArrSet, Type: TUnit, Args: []ValueID{a, i, v}})
 }
 
 // Call invokes function at funcIdx with the given args. retType is the

--- a/compiler2/ir/ir.go
+++ b/compiler2/ir/ir.go
@@ -20,6 +20,11 @@ const (
 	TStr
 	TList
 	TMap
+	// Typed array kinds (MEP-37 §3.3). Each is a separate IR type so
+	// the verifier can pick the matching element-typed Get/Set op.
+	TF64Array
+	TI64Array
+	TU8Array
 )
 
 func (t Type) String() string {
@@ -40,6 +45,12 @@ func (t Type) String() string {
 		return "list"
 	case TMap:
 		return "map"
+	case TF64Array:
+		return "f64array"
+	case TI64Array:
+		return "i64array"
+	case TU8Array:
+		return "u8array"
 	}
 	return "?"
 }
@@ -109,6 +120,48 @@ const (
 	OpMapHas // bool(present(Args[0], Args[1]))
 	OpMapSet // Args[0][Args[1]] = Args[2]; TUnit
 	OpMapDel // delete Args[0][Args[1]]; TUnit
+
+	// Float arithmetic subsystem (MEP-37 §3.2). OpConstF64 carries the
+	// float bit-pattern in Aux (read back via math.Float64frombits in
+	// emit so the constant pool stores a single CFloat cell).
+	OpConstF64
+	OpAddF64
+	OpSubF64
+	OpMulF64
+	OpDivF64
+	OpNegF64
+	OpAbsF64
+	OpSqrtF64
+	OpLessF64
+	OpLessEqF64
+	OpEqualF64
+	// OpFmaF64 computes Args[0]*Args[1] + Args[2] with a single rounding
+	// (math.FMA in the runtime). Lowered by emit when a mul has exactly
+	// one use and that use is the matching add; the builder also exposes
+	// a direct constructor for IR producers that already know the
+	// pattern (Mandelbrot's iteration).
+	OpFmaF64
+	// Numeric conversions; see vm2/ops.go for the truncation contract.
+	OpI64ToF64
+	OpF64ToI64
+
+	// Typed array subsystem (MEP-37 §3.3). The allocator opcode takes a
+	// length argument; element ops take an array and an int index. The
+	// verifier checks that Get/Set are dispatched against the matching
+	// array kind so a TF64Array.Set with an i64 value is a build-time
+	// error.
+	OpNewF64Array // Args[0] = length
+	OpF64ArrLen   // len(Args[0])
+	OpF64ArrGet   // Args[0][Args[1]] -> TF64
+	OpF64ArrSet   // Args[0][Args[1]] = Args[2]; TUnit
+	OpNewI64Array
+	OpI64ArrLen
+	OpI64ArrGet
+	OpI64ArrSet
+	OpNewU8Array
+	OpU8ArrLen
+	OpU8ArrGet // result type TI64 (byte widened to int)
+	OpU8ArrSet // Args[2] is a TI64 value; runtime truncates to byte
 
 	// Call: Aux = function index, Args = arg values. May have effects;
 	// optimizers must treat as opaque.

--- a/runtime/jit/vm2jit/lower_arm64.go
+++ b/runtime/jit/vm2jit/lower_arm64.go
@@ -201,9 +201,21 @@ func isDeoptableOp(op vm2.Op) bool {
 	switch op {
 	case vm2.OpLoadStrK, vm2.OpConcatStr, vm2.OpLenStr, vm2.OpIndexStr,
 		vm2.OpEqualStr, vm2.OpHashStr,
-		vm2.OpNewList, vm2.OpListGet, vm2.OpListSet, vm2.OpListPush,
+		vm2.OpNewList, vm2.OpListGet, vm2.OpListSet, vm2.OpListPush, vm2.OpListAppend,
 		vm2.OpNewMap, vm2.OpMapLen, vm2.OpMapGet, vm2.OpMapHas, vm2.OpMapSet, vm2.OpMapDel,
 		vm2.OpCall, vm2.OpTailCall, vm2.OpTailCallSelf,
+		// MEP-37 Phase 1 ops deopt to the interpreter: the JIT does not
+		// emit float arithmetic or typed-array code yet; once n_body or
+		// mandelbrot benchmarks justify it, the lower_arm64 emitter
+		// gains direct float lowering and these move to the supported
+		// set.
+		vm2.OpLoadConstF, vm2.OpAddF64, vm2.OpSubF64, vm2.OpMulF64,
+		vm2.OpDivF64, vm2.OpNegF64, vm2.OpAbsF64, vm2.OpSqrtF64,
+		vm2.OpLessF64, vm2.OpLessEqF64, vm2.OpEqualF64, vm2.OpFmaF64,
+		vm2.OpI64ToF64, vm2.OpF64ToI64,
+		vm2.OpNewF64Array, vm2.OpF64ArrLen, vm2.OpF64ArrGet, vm2.OpF64ArrSet,
+		vm2.OpNewI64Array, vm2.OpI64ArrLen, vm2.OpI64ArrGet, vm2.OpI64ArrSet,
+		vm2.OpNewU8Array, vm2.OpU8ArrLen, vm2.OpU8ArrGet, vm2.OpU8ArrSet,
 		vm2.OpHalt:
 		return true
 	}

--- a/runtime/vm2/arrays.go
+++ b/runtime/vm2/arrays.go
@@ -1,0 +1,55 @@
+package vm2
+
+import "unsafe"
+
+// vmF64Array is the heap representation of a `[]float64`-typed array
+// (MEP-37 §3.3). Storage is a flat Go slice so the inner loop reads
+// 8 bytes per element instead of the 16 bytes a Cell takes; for the BG
+// FP workloads (n_body, spectral_norm, mandelbrot) this halves the
+// working set and removes the Cell decode on every load.
+type vmF64Array struct {
+	data []float64
+}
+
+// vmI64Array mirrors vmF64Array for int64-typed arrays. Used by
+// fannkuch_redux (which is dominated by `[]int8` permutation work; we
+// widen to int64 because vm2 has no narrower scalar type today but
+// keep storage homogeneous so the cache hit pattern stays flat).
+type vmI64Array struct {
+	data []int64
+}
+
+// vmU8Array mirrors the above for byte arrays. Used by the byte-array
+// BG workloads (fasta, reverse_complement, k_nucleotide) and by the
+// mandelbrot output bitmap.
+type vmU8Array struct {
+	data []byte
+}
+
+func (vm *VM) newF64Array(n int) Cell {
+	if n < 0 {
+		n = 0
+	}
+	a := &vmF64Array{data: make([]float64, n)}
+	return Cell{Bits: tagPtr, Obj: unsafe.Pointer(a)}
+}
+
+func (vm *VM) newI64Array(n int) Cell {
+	if n < 0 {
+		n = 0
+	}
+	a := &vmI64Array{data: make([]int64, n)}
+	return Cell{Bits: tagPtr, Obj: unsafe.Pointer(a)}
+}
+
+func (vm *VM) newU8Array(n int) Cell {
+	if n < 0 {
+		n = 0
+	}
+	a := &vmU8Array{data: make([]byte, n)}
+	return Cell{Bits: tagPtr, Obj: unsafe.Pointer(a)}
+}
+
+func (vm *VM) f64ArrAt(c Cell) *vmF64Array { return (*vmF64Array)(c.PtrTo()) }
+func (vm *VM) i64ArrAt(c Cell) *vmI64Array { return (*vmI64Array)(c.PtrTo()) }
+func (vm *VM) u8ArrAt(c Cell) *vmU8Array   { return (*vmU8Array)(c.PtrTo()) }

--- a/runtime/vm2/bench/bg_spectral_norm_test.go
+++ b/runtime/vm2/bench/bg_spectral_norm_test.go
@@ -1,0 +1,102 @@
+package bench
+
+import (
+	"math"
+	"testing"
+
+	"mochi/compiler2/corpus"
+	"mochi/compiler2/emit"
+	"mochi/compiler2/opt"
+	vm2 "mochi/runtime/vm2"
+)
+
+// goSpectralNormKernel mirrors the IR built by corpus.BuildSpectralNormKernel.
+// It is the source of truth the vm2 result is compared against.
+func goSpectralNormKernel(n int64) float64 {
+	evalA := func(i, j int64) float64 {
+		denom := (i+j)*(i+j+1)/2 + i + 1
+		return 1.0 / float64(denom)
+	}
+	u := make([]float64, n)
+	v := make([]float64, n)
+	for i := range u {
+		u[i] = 1
+	}
+	for i := int64(0); i < n; i++ {
+		var s float64
+		for j := int64(0); j < n; j++ {
+			s += evalA(i, j) * u[j]
+		}
+		v[i] = s
+	}
+	var vu, vv float64
+	for i := int64(0); i < n; i++ {
+		vu += u[i] * v[i]
+		vv += v[i] * v[i]
+	}
+	return math.Sqrt(vu / vv)
+}
+
+// TestBGSpectralNormKernel compiles and runs the spectral_norm BG inner
+// kernel and verifies the float result matches the Go oracle to within
+// 1e-12. This is the smoke test that the MEP-37 Phase 1 stack (float
+// arithmetic, typed-arrays, int↔float conversion) all line up end to
+// end through the IR, opt passes, emit, and runtime.
+func TestBGSpectralNormKernel(t *testing.T) {
+	const n int64 = 10
+	m := corpus.BuildSpectralNormKernel(n)
+	for _, f := range m.Funcs {
+		opt.ConstFold(f)
+		opt.DCE(f)
+		opt.TailCall(f)
+	}
+	prog, err := emit.Compile(m)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	got, err := vm2.New(prog).Run()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !got.IsFloat() {
+		t.Fatalf("expected float, got %#v", got)
+	}
+	want := goSpectralNormKernel(n)
+	if d := math.Abs(got.Float() - want); d > 1e-12 {
+		t.Fatalf("spectral_norm(%d) = %v, want %v (delta %v)", n, got.Float(), want, d)
+	}
+}
+
+func BenchmarkVM2_BG_SpectralNormKernel(b *testing.B) {
+	const n int64 = 100
+	m := corpus.BuildSpectralNormKernel(n)
+	for _, f := range m.Funcs {
+		opt.ConstFold(f)
+		opt.DCE(f)
+		opt.TailCall(f)
+	}
+	prog, err := emit.Compile(m)
+	if err != nil {
+		b.Fatalf("compile: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := vm2.New(prog).Run(); err != nil {
+			b.Fatalf("run: %v", err)
+		}
+	}
+}
+
+// BenchmarkGo_BG_SpectralNormKernel is the Go peer for the vm2 spectral
+// norm kernel benchmark. The ratio between this and BenchmarkVM2_*
+// quantifies the MEP-37 §3.2/§3.3 dispatch overhead and feeds the
+// MEP-37 Appendix A measurements.
+func BenchmarkGo_BG_SpectralNormKernel(b *testing.B) {
+	const n int64 = 100
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = goSpectralNormKernel(n)
+	}
+}

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -1,6 +1,9 @@
 package vm2
 
-import "errors"
+import (
+	"errors"
+	"math"
+)
 
 // Run executes Program.Main and returns the final Cell.
 //
@@ -331,6 +334,94 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 		case OpMapDel:
 			m := vm.mapAt(regs[ins.A])
 			delete(m.entries, vm.mapKeyOf(regs[ins.B]))
+		case OpLoadConstF:
+			regs[ins.A] = consts[ins.B]
+		case OpAddF64:
+			regs[ins.A] = CFloat(regs[ins.B].Float() + regs[ins.C].Float())
+		case OpSubF64:
+			regs[ins.A] = CFloat(regs[ins.B].Float() - regs[ins.C].Float())
+		case OpMulF64:
+			regs[ins.A] = CFloat(regs[ins.B].Float() * regs[ins.C].Float())
+		case OpDivF64:
+			regs[ins.A] = CFloat(regs[ins.B].Float() / regs[ins.C].Float())
+		case OpNegF64:
+			regs[ins.A] = CFloat(-regs[ins.B].Float())
+		case OpAbsF64:
+			regs[ins.A] = CFloat(math.Abs(regs[ins.B].Float()))
+		case OpSqrtF64:
+			regs[ins.A] = CFloat(math.Sqrt(regs[ins.B].Float()))
+		case OpLessF64:
+			regs[ins.A] = CBool(regs[ins.B].Float() < regs[ins.C].Float())
+		case OpLessEqF64:
+			regs[ins.A] = CBool(regs[ins.B].Float() <= regs[ins.C].Float())
+		case OpEqualF64:
+			regs[ins.A] = CBool(regs[ins.B].Float() == regs[ins.C].Float())
+		case OpFmaF64:
+			regs[ins.A] = CFloat(math.FMA(regs[ins.B].Float(), regs[ins.C].Float(), regs[ins.D].Float()))
+		case OpI64ToF64:
+			regs[ins.A] = CFloat(float64(regs[ins.B].Int()))
+		case OpF64ToI64:
+			regs[ins.A] = CInt(int64(regs[ins.B].Float()))
+		case OpNewF64Array:
+			regs[ins.A] = vm.newF64Array(int(regs[ins.B].Int()))
+		case OpF64ArrLen:
+			regs[ins.A] = CInt(int64(len(vm.f64ArrAt(regs[ins.B]).data)))
+		case OpF64ArrGet:
+			a := vm.f64ArrAt(regs[ins.B])
+			i := regs[ins.C].Int()
+			if i < 0 || i >= int64(len(a.data)) {
+				fr.IP = ip
+				return ret, errors.New("vm2: f64 array index out of range")
+			}
+			regs[ins.A] = CFloat(a.data[i])
+		case OpF64ArrSet:
+			a := vm.f64ArrAt(regs[ins.A])
+			i := regs[ins.B].Int()
+			if i < 0 || i >= int64(len(a.data)) {
+				fr.IP = ip
+				return ret, errors.New("vm2: f64 array index out of range")
+			}
+			a.data[i] = regs[ins.C].Float()
+		case OpNewI64Array:
+			regs[ins.A] = vm.newI64Array(int(regs[ins.B].Int()))
+		case OpI64ArrLen:
+			regs[ins.A] = CInt(int64(len(vm.i64ArrAt(regs[ins.B]).data)))
+		case OpI64ArrGet:
+			a := vm.i64ArrAt(regs[ins.B])
+			i := regs[ins.C].Int()
+			if i < 0 || i >= int64(len(a.data)) {
+				fr.IP = ip
+				return ret, errors.New("vm2: i64 array index out of range")
+			}
+			regs[ins.A] = CInt(a.data[i])
+		case OpI64ArrSet:
+			a := vm.i64ArrAt(regs[ins.A])
+			i := regs[ins.B].Int()
+			if i < 0 || i >= int64(len(a.data)) {
+				fr.IP = ip
+				return ret, errors.New("vm2: i64 array index out of range")
+			}
+			a.data[i] = regs[ins.C].Int()
+		case OpNewU8Array:
+			regs[ins.A] = vm.newU8Array(int(regs[ins.B].Int()))
+		case OpU8ArrLen:
+			regs[ins.A] = CInt(int64(len(vm.u8ArrAt(regs[ins.B]).data)))
+		case OpU8ArrGet:
+			a := vm.u8ArrAt(regs[ins.B])
+			i := regs[ins.C].Int()
+			if i < 0 || i >= int64(len(a.data)) {
+				fr.IP = ip
+				return ret, errors.New("vm2: u8 array index out of range")
+			}
+			regs[ins.A] = CInt(int64(a.data[i]))
+		case OpU8ArrSet:
+			a := vm.u8ArrAt(regs[ins.A])
+			i := regs[ins.B].Int()
+			if i < 0 || i >= int64(len(a.data)) {
+				fr.IP = ip
+				return ret, errors.New("vm2: u8 array index out of range")
+			}
+			a.data[i] = byte(regs[ins.C].Int())
 		case OpHalt:
 			fr.IP = ip
 			return ret, errors.New("vm2: OpHalt reached")

--- a/runtime/vm2/ops.go
+++ b/runtime/vm2/ops.go
@@ -82,4 +82,51 @@ const (
 	OpMapHas // A = bool(present in mapAt(regs[B]), key=regs[C])
 	OpMapSet // mapAt(regs[A]).entries[mapKeyOf(regs[B])] = regs[C]
 	OpMapDel // delete(mapAt(regs[A]).entries, mapKeyOf(regs[B]))
+
+	// Float arithmetic subsystem (MEP-37 §3.2). Operands and result are
+	// float64 Cells decoded via Cell.Float / encoded via CFloat. None of
+	// these trap: divide-by-zero produces ±Inf or NaN per IEEE-754, and
+	// the dispatch handler stays branch-free.
+	OpLoadConstF // A = Consts[B] (float64 const, cell already produced by CFloat)
+	OpAddF64     // A = B + C
+	OpSubF64     // A = B - C
+	OpMulF64     // A = B * C
+	OpDivF64     // A = B / C
+	OpNegF64     // A = -B
+	OpAbsF64     // A = math.Abs(B)
+	OpSqrtF64    // A = math.Sqrt(B)
+	OpLessF64    // A = B < C  (bool)
+	OpLessEqF64  // A = B <= C (bool)
+	OpEqualF64   // A = B == C (bool) — IEEE equality, NaN compares unequal
+	// Fused multiply-add. A = (B * C) + D. emit picks this over
+	// OpMulF64+OpAddF64 when the multiply has exactly one use and that
+	// use is the add (MEP-37 §3.2). The runtime uses math.FMA so the
+	// rounding is single-rounded, matching Go's `math.FMA`.
+	OpFmaF64
+	// Numeric conversions. The BG kernels mix int loop counters with
+	// float arithmetic (matrix index → coefficient, body count → step),
+	// so the i64↔f64 round-trip lives next to the float opcodes rather
+	// than in a separate conversion family.
+	OpI64ToF64 // A = float64(regs[B].Int())
+	OpF64ToI64 // A = int64(regs[B].Float())  (truncation toward zero)
+
+	// Typed array subsystem (MEP-37 §3.3). Element type is fixed at
+	// allocation; storage is a flat Go slice carried through Cell.Obj.
+	// Get/Set ops trap on OOB. Length operand is taken as a register
+	// holding an int Cell so dynamic sizing works without immediate
+	// staging.
+	OpNewF64Array // A = newF64Array(regs[B].Int())
+	OpF64ArrLen   // A = i64(len(f64ArrAt(regs[B]).data))
+	OpF64ArrGet   // A = CFloat(f64ArrAt(regs[B]).data[regs[C].Int()])
+	OpF64ArrSet   // f64ArrAt(regs[A]).data[regs[B].Int()] = regs[C].Float()
+
+	OpNewI64Array // A = newI64Array(regs[B].Int())
+	OpI64ArrLen   // A = i64(len(i64ArrAt(regs[B]).data))
+	OpI64ArrGet   // A = CInt(i64ArrAt(regs[B]).data[regs[C].Int()])
+	OpI64ArrSet   // i64ArrAt(regs[A]).data[regs[B].Int()] = regs[C].Int()
+
+	OpNewU8Array // A = newU8Array(regs[B].Int())
+	OpU8ArrLen   // A = i64(len(u8ArrAt(regs[B]).data))
+	OpU8ArrGet   // A = CInt(int64(u8ArrAt(regs[B]).data[regs[C].Int()]))
+	OpU8ArrSet   // u8ArrAt(regs[A]).data[regs[B].Int()] = byte(regs[C].Int())
 )

--- a/website/docs/mep/mep-0037.md
+++ b/website/docs/mep/mep-0037.md
@@ -1,0 +1,240 @@
+---
+mep: 37
+title: Benchmarks Game Parity with Go
+author: Mochi core
+status: Active
+type: Standards Track
+created: 2026-05-17
+sidebar_position: 37
+sidebar_label: MEP 37. Benchmarks Game Parity
+description: "Define the full Computer Language Benchmarks Game corpus as a long-running performance target for vm2, audit each program's data and control-flow shape against the current runtime, and specify the data-model and VM enhancements required to reach within 2x of `go run` on each. The catalog covers the ten canonical BG benchmarks (binary_trees, fannkuch_redux, fasta, k_nucleotide, mandelbrot, n_body, pidigits, regex_redux, reverse_complement, spectral_norm). The gap analysis identifies four bottlenecks vm2 must close to reach Go parity: missing float arithmetic opcodes (every numeric BG kernel besides binary_trees / fannkuch is double-dominated), boxed Cell storage for homogeneous arrays (each element pays 16 bytes plus indirection where Go uses 8 bytes inline), per-node heap allocation for tree-shaped data, and absence of byte-string slicing without copy. The plan lands in four phases, each independently mergeable and benchmark-gated, with the headline goal being end-to-end BG numbers within 2x of Go on the workloads phase 1+2 cover and a credible path on the remaining four."
+---
+
+# MEP 37. Benchmarks Game Parity with Go
+
+| Field    | Value                                          |
+|----------|------------------------------------------------|
+| MEP      | 37                                             |
+| Title    | Benchmarks Game Parity with Go                 |
+| Author   | Mochi core                                     |
+| Status   | Active (Phase 1 landing)                       |
+| Type     | Standards Track                                |
+| Created  | 2026-05-17                                     |
+
+## Abstract
+
+vm2 today is within ~2x of Lua on the two Benchmarks Game (BG) programs in the cross-language corpus ([MEP-36 Appendix D.2](/docs/mep/mep-0036#d2-bg-suite-phase-2--phase-3-delta): `bg/binary_trees` n=10 at 0.95x of Lua, `bg/nsieve` at 4.6x). Against `go run` it is between 7x and 70x slower depending on the workload. That ratio is not a single missing optimization: it is a stack of representation and dispatch gaps that compound. This MEP enumerates the gaps, ties each gap to the BG programs that surface it, and proposes the smallest concrete set of changes that closes the dominant ones.
+
+The bet is that **four data-model changes** (typed arrays for `float64`/`int64`/`uint8`, packed two-element tuples, byte-slice views, byte-allocator arena) plus **two opcode families** (float arithmetic; specialized typed-array load/store) account for the majority of the gap on six of the ten BG programs. The other four (pidigits, regex_redux, fasta, k_nucleotide) need subsystems that are out of scope for a single MEP and are routed to follow-ups.
+
+The goal stated in headline terms: **vm2 within 2x of `go run` on the six BG programs phase 1+2 cover, and within 5x on the suite median**, on the same host that runs MEP-23.
+
+## Motivation
+
+The MEP-23 cross-language baseline currently ships two BG programs. Both were added opportunistically: `bg/binary_trees` because it surfaces the popFrame GC contract that drove MEP-36, `bg/nsieve` because it was the smallest sieve we could agree on. The remaining eight canonical BG programs are not in the corpus, so vm2 has no measured signal on the workloads the rest of the BG world uses to compare runtimes.
+
+This is a problem for three reasons:
+
+1. **No data on FP-dominated workloads.** Four canonical BG programs (mandelbrot, n_body, spectral_norm, pidigits) spend nearly all their time in floating-point arithmetic. vm2 has the `TF64` IR type and `CFloat`/`Float()` Cell helpers, but **no float arithmetic opcodes**: no `OpAddF64`, `OpMulF64`, etc. Any Mochi program with double-typed math falls back to whatever the host language gives the front-end. We cannot measure the gap because we cannot run the program.
+
+2. **No data on byte-array workloads.** Three canonical BG programs (nsieve, fasta, reverse_complement) operate over byte arrays. vm2 stores everything as `[]Cell` (16 bytes per element, with an `unsafe.Pointer` slot that is nil for scalars). A 10,000-entry sieve takes 160 KB of L1/L2 in vm2 versus 10 KB in Go, so the cache miss rate on the inner loop is structurally higher even before dispatch overhead.
+
+3. **No story on the tree workloads.** binary_trees builds and tears down ~2 million two-element nodes per run. Each node is a `*vmList` with a `[]Cell` of length two: one Go heap allocation, one 32-byte tail, GC traces the lot. Go uses inline two-element slice literals plus generational young-gen reclamation. The factor between the two on this workload is largely allocation cost.
+
+Closing 1+2+3 is what this MEP is about. The remaining BG programs (regex_redux, k_nucleotide, fasta, reverse_complement, pidigits) need subsystem work that does not fit a single MEP and is enumerated below as future scope.
+
+## Specification
+
+### 3.1 The full BG catalog
+
+This MEP commits Mochi to maintaining a peer implementation of all ten canonical BG programs once the dependent subsystems land. The catalog below pairs each program with its dominant data structure and the subset of vm2 enhancements it depends on. The "lands in" column tracks the rollout phase.
+
+| Program | Dominant work | Dominant data | Gap from Go | Lands in |
+|---------|---------------|---------------|-------------|----------|
+| binary_trees | recursive allocate + traverse | mutable tree, 2-element nodes | per-node heap traffic | Phase 2 |
+| fannkuch_redux | array reversal + permutation | `[]int8` of length 12 | boxed `[]Cell` storage | Phase 1 |
+| fasta | RNG + table lookup | `[]uint8` output buffer | byte-array, stdout framing | Phase 3 |
+| k_nucleotide | hash table + substring | `[]byte` input + `map[string]int` | byte-slice views, large stdin | Phase 3 |
+| mandelbrot | dense FP inner loop | `[][]uint8` bitmap | FP arithmetic, byte-array | Phase 1 |
+| n_body | 5-body Verlet integrator | `[]float64` x/y/z/vx/vy/vz | FP arithmetic, float arrays | Phase 1 |
+| pidigits | spigot algorithm | big integers | big-int subsystem | Future MEP |
+| regex_redux | regex pattern matching | DNA byte string | regex engine | Future MEP |
+| reverse_complement | per-byte transform | large byte buffer | byte-array, large I/O | Phase 3 |
+| spectral_norm | matrix-vector multiply | `[]float64` u / v | FP arithmetic, float arrays | Phase 1 |
+
+Phase 1 covers the four FP-dominated programs (mandelbrot, n_body, spectral_norm, fannkuch_redux). Phase 2 covers binary_trees with packed tuples. Phase 3 covers the byte/IO programs. Phases 4+ cover the regex and big-int subsystems and are explicit non-goals here.
+
+### 3.2 Gap analysis: float arithmetic
+
+n_body's inner loop:
+```
+dx = b.x - p.x;  dy = b.y - p.y;  dz = b.z - p.z
+d2 = dx*dx + dy*dy + dz*dz
+mag = dt / (d2 * sqrt(d2))
+p.vx -= dx * b.m * mag
+```
+
+Every operation is `float64 op float64`. Today vm2 dispatches each through Cell-tagged paths or falls back to `OpAddI64` (which decodes the Bits as int — wrong). The fix is direct:
+
+- New opcodes: `OpAddF64`, `OpSubF64`, `OpMulF64`, `OpDivF64`, `OpNegF64`, `OpAbsF64`, `OpSqrtF64`, `OpLessF64`, `OpEqualF64`, `OpLessEqF64`. Each is a 3-byte handler reading two `Float()` operands and writing one via `CFloat`. The IR has `TF64`; the IR builder grows matching constructors.
+- A typed-immediate companion `OpLoadConstF` for float constants (the const pool can hold a float `Cell` directly since `CFloat` already maps `float64` into the Bits field).
+- A fused FMA opcode `OpFmaF64(d, a, b, c)` computing `d = a*b + c`. Mandelbrot's iteration is FMA-shaped; the saving is one dispatch per iteration in the inner loop.
+
+No structural runtime change. The handlers are mechanical and the work to land them is `len(ops)`.
+
+### 3.3 Gap analysis: typed arrays
+
+`vm2.vmList` stores `[]Cell`. For a `[]float64` workload this is wasteful:
+
+- 16 bytes per element vs 8 bytes for a `[]float64`. spectral_norm at n=5500 is 88 KB vs 44 KB. Both fit in L2 today but at n=20000 (the BG canonical N) the difference is 320 KB vs 160 KB and we cross L2.
+- Two loads per element: one to fetch the Cell, one to read `Bits` and decode via `Float()`. A `[]float64` is one load.
+- Cell's `Obj` field is nil for floats but the GC scans it anyway. For a tight FP loop this is wasted bandwidth.
+
+Resolution: typed array primitives.
+
+- `*vmF64Array` wraps `[]float64`. New constructor `OpNewF64Array(dst, len)`. Access via `OpF64ArrGet(dst, arr, idx)` and `OpF64ArrSet(arr, idx, val)`. The Cell wrapping this still tagPtrs through `Cell.Obj`, so GC visibility is identical to `*vmList`.
+- `*vmI64Array` mirrors the above for int64.
+- `*vmU8Array` mirrors the above for uint8 (the sieves and the mandelbrot bitmap).
+- IR types: `TF64Array`, `TI64Array`, `TU8Array`. The IR builder grows matching constructors.
+
+The Cell tag space accommodates this because the `Obj` field is the only discriminator we use for container types; the new array kinds are just additional `*T` shapes carried in `Obj`.
+
+### 3.4 Gap analysis: tree-shaped data
+
+binary_trees walks ~2M nested two-element nodes. Each `*vmList` is one Go heap allocation plus a `[]Cell` tail (32 bytes for cap=2). Go writes `&Tree{makeTree(d-1), makeTree(d-1)}` which is one allocation and a 16-byte body (two `Tree` pointers). The factor is roughly 2-3x just on allocation cost, on top of the dispatch overhead.
+
+Resolution: a packed two-element tuple Cell.
+
+- `vmPair` is a `{a, b Cell}` value type allocated in a dedicated arena. The arena is a slice of `vmPair` per VM; allocation is an index bump. Reclamation happens at popFrame / Run boundary (we own the arena, so we can clear it cheaply).
+- New ops: `OpNewPair(dst, a, b)`, `OpPairFst(dst, p)`, `OpPairSnd(dst, p)`. No `OpPairSet`: the corpus has no use case and the arena assumption is monotonic-per-Run.
+- IR type: `TPair`. Verifier checks the operand types of `OpPairFst`/`Snd` produce the right result type.
+
+The packed-pair representation is the BG-specific lift; binary_trees benefits, and future "small fixed struct" workloads do too. A larger tuple (3, 4, ... up to N) is a follow-up; for binary_trees specifically 2 is sufficient.
+
+### 3.5 Gap analysis: byte strings and I/O
+
+Three programs need byte-string ops vm2 does not have today:
+
+- **Byte slicing without copy.** k_nucleotide hashes substrings of a 5 MB DNA input. Copying the substring each time costs O(N×k) bytes. Resolution: `*vmBytes` carries a `(buf []byte, off, len int)` view; new ops `OpBytesSlice(dst, src, off, len)` and `OpBytesEqual` operate on the view. The view holds a back-reference to `buf` so GC keeps the parent alive.
+- **Stdin/stdout streaming.** fasta and reverse_complement write hundreds of KB to stdout. Today the only string op is `OpConcatStr` which allocates a new buffer per concat. Resolution: `OpStdoutWriteBytes(src)` that writes a byte buffer to the host stdout without intermediate allocation.
+- **Large stdin read.** k_nucleotide reads the whole stdin once. New op `OpStdinReadAll(dst)` produces a `*vmBytes`.
+
+These are catalogued but not in Phase 3's hard scope; the data-model pieces (byte view + arena) are. Phase 3 ships the data model and a minimal I/O API; the BG-specific glue lands separately.
+
+### 3.6 Out of scope
+
+- **Big-int subsystem (pidigits).** Mochi has no first-class big integer today. The standard approach is to wrap `math/big` and pay the function-call cost; pidigits is not bottlenecked on this once that's done. Tracked as a future MEP.
+- **Regex engine (regex_redux).** Mochi has no regex primitive. RE2 (Go's `regexp` package) is the obvious vendor; the work is mostly API surface, not engine. Tracked as a future MEP.
+
+## Rationale
+
+### 4.1 Why Go as the target
+
+The Benchmarks Game's standard pairwise comparisons use C as the floor. We use Go because:
+
+- vm2 is hosted in Go. The host language sets the ceiling for the runtime: a vm2 that beats Go on a workload would be hard to explain ("we beat the language that runs us"). 2x is a credible and self-consistent target.
+- Cross-compile peers in the existing MEP-23 harness already run Go for every Mochi program; the comparison is free in tooling.
+- Lua 5.x and CPython are the other obvious targets, but the goal here is to push vm2 past them (already true for binary_trees), so they are not the bar.
+
+### 4.2 Why typed arrays instead of polymorphic list specialization
+
+A polymorphic list specialization (start with `[]Cell`, switch to `[]float64` when every element happens to be a float) is what V8 and SpiderMonkey do. The implementation cost is much higher than typed-from-creation arrays, because every `OpListSet` has to check the homogeneity invariant and pay the deopt path when it breaks. The BG programs do not need polymorphism: the user knows at construction time that the array is `float64`. Typed-from-creation matches the language semantics and gets the cache-locality win with no dispatch cost.
+
+The follow-on "polymorphic list with type adaptation" is interesting for non-BG workloads and is left to a separate MEP if profile evidence demands it.
+
+### 4.3 Why packed pairs and not packed N-tuples
+
+Two reasons:
+
+- binary_trees is the canonical 2-tuple workload. Going to N>2 introduces alignment and size-classing problems for the arena (a `vmPair` is exactly 32 bytes; a `vmTuple3` is 48 and so on, none of which are L1-cache-line-aligned without padding). Solving size classes is its own MEP.
+- All current MEP-24 container plans treat structs as their own pointer-backed type. Packed pairs sit alongside that, not in place of it.
+
+If a future BG-like workload demonstrates that 3+ element packed tuples are load-bearing, we generalize then, with the size-class problem solved separately.
+
+### 4.4 Why an arena for pairs and not Go heap
+
+Per-node `&vmPair{...}` allocations would inherit the same factor we are trying to close. An arena (`[]vmPair`, indexed by handle) is one allocation amortized over N pair constructions; the dispatch cost is one bounds check plus one struct write per allocation. The trade-off is that pair memory cannot be reclaimed before Run() ends, the same trade vm2's original Objects table made and that MEP-36 reversed for containers. The reason to accept it here is that BG workloads have monotonic allocation profiles (tree construction is a build-then-tear-down, and the tear-down happens at Run boundary), so the trade is sound for this corpus.
+
+A future MEP that lifts the arena to a full nursery+old-gen split is the obvious sequel; for now the arena suffices.
+
+## Migration plan
+
+Four phases, each independently mergeable, each gated by the BG corpus subset it adds.
+
+**Phase 1: Float arithmetic + typed arrays.** **(landing in this MEP's PR)**
+
+- New vm2 ops: `OpAddF64`, `OpSubF64`, `OpMulF64`, `OpDivF64`, `OpNegF64`, `OpAbsF64`, `OpSqrtF64`, `OpLessF64`, `OpEqualF64`, `OpLessEqF64`, `OpLoadConstF`, `OpFmaF64`.
+- New vm2 container types: `*vmF64Array`, `*vmI64Array`, `*vmU8Array`. New ops: `OpNewF64Array`, `OpF64ArrLen`, `OpF64ArrGet`, `OpF64ArrSet` (and mirrors for I64/U8).
+- New IR ops + builder methods, verified end-to-end with emit + run tests.
+- Corpus programs: `bg/spectral_norm`, `bg/n_body`, `bg/mandelbrot`, `bg/fannkuch_redux`. Each ships a `.go.tmpl` peer and a `.lua` / `.py` peer (lua/py optional for first cut, gated on what the BG canonical sources have).
+
+Merge gate: each new program produces correct output at the canonical BG N and at a smaller N (for fast CI). Phase 1 vm2 within 5x of Go on the four programs at their CI N.
+
+**Phase 2: Packed pairs + arena.**
+
+- New vm2 type `vmPair`, per-VM arena, ops `OpNewPair`, `OpPairFst`, `OpPairSnd`.
+- New IR type `TPair`, builder method.
+- Corpus program: rewrite `bg/binary_trees` to use packed pairs. Keep the existing nested-list form as a separate program for the historical comparison.
+
+Merge gate: binary_trees within 2x of Go at depth 10, no regression on the rest of the suite, RSS within +1 MB.
+
+**Phase 3: Byte strings + minimal I/O.**
+
+- New vm2 type `*vmBytes` (view of `(buf, off, len)`), ops `OpBytesNew`, `OpBytesLen`, `OpBytesAt`, `OpBytesSlice`, `OpBytesEqual`.
+- New ops `OpStdoutWriteBytes`, `OpStdinReadAll`.
+- Corpus programs: `bg/reverse_complement`, partial `bg/fasta` (RNG part is straightforward, the table-encoding part rides on byte-view).
+
+Merge gate: reverse_complement within 3x of Go (Go is extremely good at this workload because it short-circuits to `bufio`; 3x is a reasonable bar).
+
+**Phase 4+: Big int and regex (separate MEPs).** Out of scope here, called out so the catalog is honest about the remaining gap.
+
+## Backwards Compatibility
+
+No language-surface change. All new ops are opt-in at IR construction; existing emitters that don't touch the new builders compile identically. The Cell layout does not change (Phase 1's typed arrays carry their pointer in `Obj` exactly like `*vmList` does today).
+
+The JIT register-file contract from MEP-34 is unaffected: typed-array container Cells are tagPtr with an `Obj` pointer, the same shape the JIT already handles for lists and maps. New scalar ops (`OpAddF64` etc.) have the same operand shape as their integer cousins; the JIT trace recognizer learns the new opcodes one by one as benchmarks warrant.
+
+## Reference Implementation
+
+Files touched in Phase 1:
+
+- [`runtime/vm2/ops.go`](https://github.com/mochilang/mochi/blob/main/runtime/vm2/ops.go) — new float and typed-array opcodes.
+- [`runtime/vm2/eval.go`](https://github.com/mochilang/mochi/blob/main/runtime/vm2/eval.go) — dispatch handlers.
+- `runtime/vm2/arrays.go` — new file housing `vmF64Array`, `vmI64Array`, `vmU8Array` and their accessors.
+- [`compiler2/ir/ir.go`](https://github.com/mochilang/mochi/blob/main/compiler2/ir/ir.go) — new IR ops and types.
+- [`compiler2/ir/builder.go`](https://github.com/mochilang/mochi/blob/main/compiler2/ir/builder.go) — matching builder methods.
+- [`compiler2/emit/emit.go`](https://github.com/mochilang/mochi/blob/main/compiler2/emit/emit.go) — lowering for the new IR ops.
+- `compiler2/corpus/bg_spectral_norm.go`, `bg_n_body.go`, `bg_mandelbrot.go`, `bg_fannkuch_redux.go` — hand-written IR corpus programs.
+- `bench/template/bg/spectral_norm/`, `bg/n_body/`, `bg/mandelbrot/`, `bg/fannkuch_redux/` — peer templates (Go / Lua / Python where available).
+- [`runtime/vm2/bench/corpus_test.go`](https://github.com/mochilang/mochi/blob/main/runtime/vm2/bench/corpus_test.go) — register the new programs at their CI N.
+
+A measured-results MEP (Informational, numbered after Phase 1 lands) reports BG numbers head-to-head against `go run` at the canonical BG N, following the MEP-29 / MEP-33 / MEP-36 Appendix D template.
+
+## Appendix A. Phase 1 baseline measurements
+
+Captured on the same host that runs MEP-23 (Apple M4, `go test -bench` with `-benchtime=2s`), committed in PR landing the Phase 1 stack. The kernel is the spectral_norm inner loop (build A, compute A*u, then sqrt((u·v) / (v·v))) at n=100. The vm2 build runs through compiler2 IR → opt (ConstFold + DCE + TailCall) → emit → vm2.Run.
+
+| Benchmark | ns/op | B/op | allocs/op | vm2 / Go |
+|-----------|------:|-----:|----------:|---------:|
+| BenchmarkVM2_BG_SpectralNormKernel | 2,053,934 | 154,994 | 17 | 268x |
+| BenchmarkGo_BG_SpectralNormKernel  | 7,649 | 1,792 | 2 | 1.0x |
+
+This is the launch number, not the destination. The headline goal in the abstract is 2x on phase-1 covered programs once the float JIT lowering and array bounds-check elision pieces land. The 268x ratio at the baseline is driven by:
+
+1. Each `eval_A(i, j)` call costs one full OpCall round-trip plus six int and two float ops to compute the denominator. Go inlines `evalA` and folds the whole expression into a single FMA cluster.
+2. Every float arithmetic op pays one byte-code dispatch (~6 ns on M4) and one Cell encode + decode round-trip; Go's compiled code is one FP register-to-register instruction.
+3. F64Array Get/Set each pay one OpCall-free dispatch but still do bounds checks the Go peer eliminates.
+
+The follow-up phases (JIT lowering for float ops, bounds-check elision on hot array accesses) close the gap; the data above is the starting point.
+
+## Open Questions
+
+1. **Inline float Cell vs `Obj`-carried float64 array Cells when N=1.** A single float result fits in `CFloat`'s NaN-box; a `*vmF64Array` of length 1 pays a heap allocation for nothing. We may want a fast-path `OpF64ArrGet` that returns `CFloat` directly (no boxed temporary). Phase 1 picks the naive form; profile evidence decides whether the fast-path is worth adding.
+
+2. **FMA vs unfused multiply-add for mandelbrot.** Go does not auto-FMA on amd64 unless the host CPU supports it; vm2's `OpFmaF64` would be unconditional. The "fair" comparison is uncertain. Document the choice and provide both forms in the corpus so reviewers can compare apples-to-apples.
+
+3. **Arena lifetime for pairs across nested Runs.** If a host embedder calls `Run` recursively (re-entrant), the pair arena is shared across outer and inner Run. A nested Run that allocates pairs would leak them into the outer's arena. Phase 2 starts with a per-Run arena reset at `Run()` entry, which is the same contract `Objects[]` had pre-MEP-36; we revisit if a profile pattern demands otherwise.
+
+## Copyright
+
+This document is placed in the public domain.


### PR DESCRIPTION
## Summary

- New MEP-37 covers full Benchmarks Game parity with Go; Phase 1 lands the float and typed-array primitives the four FP-dominated BG programs (spectral_norm, n_body, mandelbrot, fannkuch_redux) depend on.
- 12 float opcodes (add/sub/mul/div/neg/abs/sqrt/cmp/fma/load-const), two i64<->f64 conversions, and three typed-array families (F64/I64/U8) with new/len/get/set ops. IR ops + builder methods + emit lowering grow alongside.
- spectral_norm inner kernel corpus program exercises the full pipeline; baseline measurement (Apple M4) lands as Appendix A: vm2 268x slower than Go, the launch number the rest of the MEP closes.

Tracks #21578.

## Test plan
- [x] go test ./compiler2/... ./runtime/vm2/... ./runtime/jit/...
- [x] go test -bench BG_SpectralNorm -benchtime=2s ./runtime/vm2/bench/