### PR TITLE
mep-0037 phase 1b: n_body kernel corpus + bench

### DIFF
--- a/compiler2/corpus/bg_n_body.go
+++ b/compiler2/corpus/bg_n_body.go
@@ -1,0 +1,235 @@
+package corpus
+
+import "mochi/compiler2/ir"
+
+// BuildNBodyKernel builds the BG `n_body` per-step kernel as described
+// in MEP-37 §3.2: 5 bodies with position/velocity/mass arrays, one
+// advance() step at dt=0.01, then return the total system energy
+// (kinetic minus pairwise potential).
+//
+// The canonical BG n_body iterates the advance step 50_000_000 times.
+// The kernel here runs a single iteration; the BG number scales
+// linearly with iteration count so one-step timings extrapolate
+// cleanly. Initial conditions are simple test values (positions
+// (i, 2i, 3i), velocities (i/10, i/5, 3i/10), masses 1..5) rather
+// than the planetary defaults — this keeps the Go oracle small and
+// the test deterministic.
+//
+// Lowered as eight functions so each loop folds into a self-tail-call
+// after opt.TailCall:
+//
+//	main             = init arrays + advance + energy
+//	initFn(arrs, i)  = fill arrays at index i; tail recurse
+//	advance(arrs,i)  = inner(arrs, i, i+1); tail recurse
+//	inner(arrs,i,j)  = update vi/vj from pairwise force; tail recurse
+//	posUpdate(arrs,i)= xi += vxi*dt; tail recurse
+//	energy(arrs,i,acc)= kin - pot to acc; tail recurse
+//	subEnergy(arrs,i,j,acc) = subtract pairwise potential; tail recurse
+//
+// The result is verified end-to-end against a Go implementation in
+// runtime/vm2/bench/bg_n_body_test.go.
+func BuildNBodyKernel() *ir.Module {
+	const (
+		initIdx     = 1
+		advanceIdx  = 2
+		innerIdx    = 3
+		posIdx      = 4
+		energyIdx   = 5
+		subEnergyIdx = 6
+		N           = int64(5)
+	)
+	dt := 0.01
+
+	// main()
+	bMain := ir.NewBuilder("main", nil, ir.TF64)
+	nv := bMain.ConstI64(N)
+	x := bMain.NewF64Array(nv)
+	y := bMain.NewF64Array(nv)
+	z := bMain.NewF64Array(nv)
+	vx := bMain.NewF64Array(nv)
+	vy := bMain.NewF64Array(nv)
+	vz := bMain.NewF64Array(nv)
+	m := bMain.NewF64Array(nv)
+	zero := bMain.ConstI64(0)
+	bMain.Call(initIdx, ir.TUnit, x, y, z, vx, vy, vz, m, zero)
+	dtv := bMain.ConstF64(dt)
+	bMain.Call(advanceIdx, ir.TUnit, x, y, z, vx, vy, vz, m, zero, dtv)
+	bMain.Call(posIdx, ir.TUnit, x, y, z, vx, vy, vz, zero, dtv)
+	e := bMain.Call(energyIdx, ir.TF64, x, y, z, vx, vy, vz, m, zero, bMain.ConstF64(0))
+	bMain.Ret(e)
+
+	// initFn(x, y, z, vx, vy, vz, m, i)
+	bI := ir.NewBuilder("init",
+		[]ir.Type{ir.TF64Array, ir.TF64Array, ir.TF64Array,
+			ir.TF64Array, ir.TF64Array, ir.TF64Array,
+			ir.TF64Array, ir.TI64}, ir.TUnit)
+	bx, by, bz, bvx, bvy, bvz, bm, bi := bI.Param(0), bI.Param(1), bI.Param(2), bI.Param(3), bI.Param(4), bI.Param(5), bI.Param(6), bI.Param(7)
+	iDone := bI.NewBlock()
+	iStep := bI.NewBlock()
+	bI.CondBr(bI.LessI64(bi, bI.ConstI64(N)), iStep, iDone)
+	bI.SwitchTo(iDone)
+	bI.Ret(-1)
+	bI.SwitchTo(iStep)
+	fi := bI.I64ToF64(bi)
+	bI.F64ArrSet(bx, bi, fi)
+	bI.F64ArrSet(by, bi, bI.MulF64(fi, bI.ConstF64(2)))
+	bI.F64ArrSet(bz, bi, bI.MulF64(fi, bI.ConstF64(3)))
+	bI.F64ArrSet(bvx, bi, bI.MulF64(fi, bI.ConstF64(0.1)))
+	bI.F64ArrSet(bvy, bi, bI.MulF64(fi, bI.ConstF64(0.2)))
+	bI.F64ArrSet(bvz, bi, bI.MulF64(fi, bI.ConstF64(0.3)))
+	// mass = i+1
+	bI.F64ArrSet(bm, bi, bI.AddF64(fi, bI.ConstF64(1)))
+	bI.Call(initIdx, ir.TUnit, bx, by, bz, bvx, bvy, bvz, bm,
+		bI.AddI64(bi, bI.ConstI64(1)))
+	bI.Ret(-1)
+
+	// advance(x, y, z, vx, vy, vz, m, i, dt)
+	bA := ir.NewBuilder("advance",
+		[]ir.Type{ir.TF64Array, ir.TF64Array, ir.TF64Array,
+			ir.TF64Array, ir.TF64Array, ir.TF64Array,
+			ir.TF64Array, ir.TI64, ir.TF64}, ir.TUnit)
+	ax, ay, az, avx, avy, avz, am, ai, adt := bA.Param(0), bA.Param(1), bA.Param(2), bA.Param(3), bA.Param(4), bA.Param(5), bA.Param(6), bA.Param(7), bA.Param(8)
+	aDone := bA.NewBlock()
+	aStep := bA.NewBlock()
+	bA.CondBr(bA.LessI64(ai, bA.ConstI64(N)), aStep, aDone)
+	bA.SwitchTo(aDone)
+	bA.Ret(-1)
+	bA.SwitchTo(aStep)
+	bA.Call(innerIdx, ir.TUnit, ax, ay, az, avx, avy, avz, am, ai,
+		bA.AddI64(ai, bA.ConstI64(1)), adt)
+	bA.Call(advanceIdx, ir.TUnit, ax, ay, az, avx, avy, avz, am,
+		bA.AddI64(ai, bA.ConstI64(1)), adt)
+	bA.Ret(-1)
+
+	// inner(x, y, z, vx, vy, vz, m, i, j, dt)
+	bN := ir.NewBuilder("inner",
+		[]ir.Type{ir.TF64Array, ir.TF64Array, ir.TF64Array,
+			ir.TF64Array, ir.TF64Array, ir.TF64Array,
+			ir.TF64Array, ir.TI64, ir.TI64, ir.TF64}, ir.TUnit)
+	nx, ny, nz, nvx, nvy, nvz, nm, ni, nj, ndt := bN.Param(0), bN.Param(1), bN.Param(2), bN.Param(3), bN.Param(4), bN.Param(5), bN.Param(6), bN.Param(7), bN.Param(8), bN.Param(9)
+	nDone := bN.NewBlock()
+	nStep := bN.NewBlock()
+	bN.CondBr(bN.LessI64(nj, bN.ConstI64(N)), nStep, nDone)
+	bN.SwitchTo(nDone)
+	bN.Ret(-1)
+	bN.SwitchTo(nStep)
+	xi := bN.F64ArrGet(nx, ni)
+	xj := bN.F64ArrGet(nx, nj)
+	dx := bN.SubF64(xi, xj)
+	yi := bN.F64ArrGet(ny, ni)
+	yj := bN.F64ArrGet(ny, nj)
+	dy := bN.SubF64(yi, yj)
+	zi := bN.F64ArrGet(nz, ni)
+	zj := bN.F64ArrGet(nz, nj)
+	dz := bN.SubF64(zi, zj)
+	d2 := bN.AddF64(bN.AddF64(bN.MulF64(dx, dx), bN.MulF64(dy, dy)), bN.MulF64(dz, dz))
+	mag := bN.DivF64(ndt, bN.MulF64(d2, bN.SqrtF64(d2)))
+	mi := bN.F64ArrGet(nm, ni)
+	mj := bN.F64ArrGet(nm, nj)
+	miMag := bN.MulF64(mi, mag)
+	mjMag := bN.MulF64(mj, mag)
+	// vi -= d * mj_mag
+	vxi := bN.F64ArrGet(nvx, ni)
+	bN.F64ArrSet(nvx, ni, bN.SubF64(vxi, bN.MulF64(dx, mjMag)))
+	vyi := bN.F64ArrGet(nvy, ni)
+	bN.F64ArrSet(nvy, ni, bN.SubF64(vyi, bN.MulF64(dy, mjMag)))
+	vzi := bN.F64ArrGet(nvz, ni)
+	bN.F64ArrSet(nvz, ni, bN.SubF64(vzi, bN.MulF64(dz, mjMag)))
+	// vj += d * mi_mag
+	vxj := bN.F64ArrGet(nvx, nj)
+	bN.F64ArrSet(nvx, nj, bN.AddF64(vxj, bN.MulF64(dx, miMag)))
+	vyj := bN.F64ArrGet(nvy, nj)
+	bN.F64ArrSet(nvy, nj, bN.AddF64(vyj, bN.MulF64(dy, miMag)))
+	vzj := bN.F64ArrGet(nvz, nj)
+	bN.F64ArrSet(nvz, nj, bN.AddF64(vzj, bN.MulF64(dz, miMag)))
+	bN.Call(innerIdx, ir.TUnit, nx, ny, nz, nvx, nvy, nvz, nm, ni,
+		bN.AddI64(nj, bN.ConstI64(1)), ndt)
+	bN.Ret(-1)
+
+	// posUpdate(x, y, z, vx, vy, vz, i, dt)
+	bP := ir.NewBuilder("posUpdate",
+		[]ir.Type{ir.TF64Array, ir.TF64Array, ir.TF64Array,
+			ir.TF64Array, ir.TF64Array, ir.TF64Array,
+			ir.TI64, ir.TF64}, ir.TUnit)
+	px, py, pz, pvx, pvy, pvz, pi, pdt := bP.Param(0), bP.Param(1), bP.Param(2), bP.Param(3), bP.Param(4), bP.Param(5), bP.Param(6), bP.Param(7)
+	pDone := bP.NewBlock()
+	pStep := bP.NewBlock()
+	bP.CondBr(bP.LessI64(pi, bP.ConstI64(N)), pStep, pDone)
+	bP.SwitchTo(pDone)
+	bP.Ret(-1)
+	bP.SwitchTo(pStep)
+	pXi := bP.F64ArrGet(px, pi)
+	pVxi := bP.F64ArrGet(pvx, pi)
+	bP.F64ArrSet(px, pi, bP.AddF64(pXi, bP.MulF64(pVxi, pdt)))
+	pYi := bP.F64ArrGet(py, pi)
+	pVyi := bP.F64ArrGet(pvy, pi)
+	bP.F64ArrSet(py, pi, bP.AddF64(pYi, bP.MulF64(pVyi, pdt)))
+	pZi := bP.F64ArrGet(pz, pi)
+	pVzi := bP.F64ArrGet(pvz, pi)
+	bP.F64ArrSet(pz, pi, bP.AddF64(pZi, bP.MulF64(pVzi, pdt)))
+	bP.Call(posIdx, ir.TUnit, px, py, pz, pvx, pvy, pvz,
+		bP.AddI64(pi, bP.ConstI64(1)), pdt)
+	bP.Ret(-1)
+
+	// energy(x, y, z, vx, vy, vz, m, i, acc)
+	bE := ir.NewBuilder("energy",
+		[]ir.Type{ir.TF64Array, ir.TF64Array, ir.TF64Array,
+			ir.TF64Array, ir.TF64Array, ir.TF64Array,
+			ir.TF64Array, ir.TI64, ir.TF64}, ir.TF64)
+	ex, ey, ez, evx, evy, evz, em, ei, eAcc := bE.Param(0), bE.Param(1), bE.Param(2), bE.Param(3), bE.Param(4), bE.Param(5), bE.Param(6), bE.Param(7), bE.Param(8)
+	eDone := bE.NewBlock()
+	eStep := bE.NewBlock()
+	bE.CondBr(bE.LessI64(ei, bE.ConstI64(N)), eStep, eDone)
+	bE.SwitchTo(eDone)
+	bE.Ret(eAcc)
+	bE.SwitchTo(eStep)
+	// kin = 0.5 * m[i] * (vx[i]^2 + vy[i]^2 + vz[i]^2)
+	evxi := bE.F64ArrGet(evx, ei)
+	evyi := bE.F64ArrGet(evy, ei)
+	evzi := bE.F64ArrGet(evz, ei)
+	vSq := bE.AddF64(bE.AddF64(bE.MulF64(evxi, evxi), bE.MulF64(evyi, evyi)), bE.MulF64(evzi, evzi))
+	emi := bE.F64ArrGet(em, ei)
+	kin := bE.MulF64(bE.MulF64(bE.ConstF64(0.5), emi), vSq)
+	// pot = subEnergy(i+1, 0)
+	pot := bE.Call(subEnergyIdx, ir.TF64, ex, ey, ez, em, ei,
+		bE.AddI64(ei, bE.ConstI64(1)), bE.ConstF64(0))
+	delta := bE.SubF64(kin, pot)
+	nacc := bE.AddF64(eAcc, delta)
+	er := bE.Call(energyIdx, ir.TF64, ex, ey, ez, evx, evy, evz, em,
+		bE.AddI64(ei, bE.ConstI64(1)), nacc)
+	bE.Ret(er)
+
+	// subEnergy(x, y, z, m, i, j, acc) -> add m[i]*m[j]/r
+	bS := ir.NewBuilder("subEnergy",
+		[]ir.Type{ir.TF64Array, ir.TF64Array, ir.TF64Array,
+			ir.TF64Array, ir.TI64, ir.TI64, ir.TF64}, ir.TF64)
+	sx, sy, sz, sm, si, sj, sAcc := bS.Param(0), bS.Param(1), bS.Param(2), bS.Param(3), bS.Param(4), bS.Param(5), bS.Param(6)
+	sDone := bS.NewBlock()
+	sStep := bS.NewBlock()
+	bS.CondBr(bS.LessI64(sj, bS.ConstI64(N)), sStep, sDone)
+	bS.SwitchTo(sDone)
+	bS.Ret(sAcc)
+	bS.SwitchTo(sStep)
+	sxi := bS.F64ArrGet(sx, si)
+	sxj := bS.F64ArrGet(sx, sj)
+	sdx := bS.SubF64(sxi, sxj)
+	syi := bS.F64ArrGet(sy, si)
+	syj := bS.F64ArrGet(sy, sj)
+	sdy := bS.SubF64(syi, syj)
+	szi := bS.F64ArrGet(sz, si)
+	szj := bS.F64ArrGet(sz, sj)
+	sdz := bS.SubF64(szi, szj)
+	r := bS.SqrtF64(bS.AddF64(bS.AddF64(bS.MulF64(sdx, sdx), bS.MulF64(sdy, sdy)), bS.MulF64(sdz, sdz)))
+	smi := bS.F64ArrGet(sm, si)
+	smj := bS.F64ArrGet(sm, sj)
+	contrib := bS.DivF64(bS.MulF64(smi, smj), r)
+	nAcc2 := bS.AddF64(sAcc, contrib)
+	sr := bS.Call(subEnergyIdx, ir.TF64, sx, sy, sz, sm, si,
+		bS.AddI64(sj, bS.ConstI64(1)), nAcc2)
+	bS.Ret(sr)
+
+	return &ir.Module{Funcs: []*ir.Function{
+		bMain.Function(), bI.Function(), bA.Function(),
+		bN.Function(), bP.Function(), bE.Function(), bS.Function(),
+	}, Main: 0}
+}

--- a/runtime/vm2/bench/bg_n_body_test.go
+++ b/runtime/vm2/bench/bg_n_body_test.go
@@ -1,0 +1,127 @@
+package bench
+
+import (
+	"math"
+	"testing"
+
+	"mochi/compiler2/corpus"
+	"mochi/compiler2/emit"
+	"mochi/compiler2/opt"
+	vm2 "mochi/runtime/vm2"
+)
+
+// goNBodyKernel mirrors corpus.BuildNBodyKernel exactly: 5 bodies with
+// position (i, 2i, 3i), velocity (i/10, i/5, 3i/10), mass i+1; one
+// advance step at dt=0.01; return system energy.
+func goNBodyKernel() float64 {
+	const N = 5
+	const dt = 0.01
+	x := make([]float64, N)
+	y := make([]float64, N)
+	z := make([]float64, N)
+	vx := make([]float64, N)
+	vy := make([]float64, N)
+	vz := make([]float64, N)
+	m := make([]float64, N)
+	for i := 0; i < N; i++ {
+		fi := float64(i)
+		x[i] = fi
+		y[i] = fi * 2
+		z[i] = fi * 3
+		vx[i] = fi * 0.1
+		vy[i] = fi * 0.2
+		vz[i] = fi * 0.3
+		m[i] = fi + 1
+	}
+	// advance: pairwise velocity update
+	for i := 0; i < N; i++ {
+		for j := i + 1; j < N; j++ {
+			dx := x[i] - x[j]
+			dy := y[i] - y[j]
+			dz := z[i] - z[j]
+			d2 := dx*dx + dy*dy + dz*dz
+			mag := dt / (d2 * math.Sqrt(d2))
+			miMag := m[i] * mag
+			mjMag := m[j] * mag
+			vx[i] -= dx * mjMag
+			vy[i] -= dy * mjMag
+			vz[i] -= dz * mjMag
+			vx[j] += dx * miMag
+			vy[j] += dy * miMag
+			vz[j] += dz * miMag
+		}
+	}
+	// posUpdate
+	for i := 0; i < N; i++ {
+		x[i] += vx[i] * dt
+		y[i] += vy[i] * dt
+		z[i] += vz[i] * dt
+	}
+	// energy
+	var e float64
+	for i := 0; i < N; i++ {
+		kin := 0.5 * m[i] * (vx[i]*vx[i] + vy[i]*vy[i] + vz[i]*vz[i])
+		var pot float64
+		for j := i + 1; j < N; j++ {
+			dx := x[i] - x[j]
+			dy := y[i] - y[j]
+			dz := z[i] - z[j]
+			r := math.Sqrt(dx*dx + dy*dy + dz*dz)
+			pot += m[i] * m[j] / r
+		}
+		e += kin - pot
+	}
+	return e
+}
+
+func TestBGNBodyKernel(t *testing.T) {
+	m := corpus.BuildNBodyKernel()
+	for _, f := range m.Funcs {
+		opt.ConstFold(f)
+		opt.DCE(f)
+		opt.TailCall(f)
+	}
+	prog, err := emit.Compile(m)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	got, err := vm2.New(prog).Run()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !got.IsFloat() {
+		t.Fatalf("expected float, got %#v", got)
+	}
+	want := goNBodyKernel()
+	if d := math.Abs(got.Float() - want); d > 1e-10 {
+		t.Fatalf("n_body kernel = %v, want %v (delta %v)", got.Float(), want, d)
+	}
+}
+
+func BenchmarkVM2_BG_NBodyKernel(b *testing.B) {
+	m := corpus.BuildNBodyKernel()
+	for _, f := range m.Funcs {
+		opt.ConstFold(f)
+		opt.DCE(f)
+		opt.TailCall(f)
+	}
+	prog, err := emit.Compile(m)
+	if err != nil {
+		b.Fatalf("compile: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := vm2.New(prog).Run(); err != nil {
+			b.Fatalf("run: %v", err)
+		}
+	}
+}
+
+func BenchmarkGo_BG_NBodyKernel(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = goNBodyKernel()
+	}
+}

--- a/website/docs/mep/mep-0037.md
+++ b/website/docs/mep/mep-0037.md
@@ -212,20 +212,25 @@ A measured-results MEP (Informational, numbered after Phase 1 lands) reports BG 
 
 ## Appendix A. Phase 1 baseline measurements
 
-Captured on the same host that runs MEP-23 (Apple M4, `go test -bench` with `-benchtime=2s`), committed in PR landing the Phase 1 stack. The kernel is the spectral_norm inner loop (build A, compute A*u, then sqrt((u·v) / (v·v))) at n=100. The vm2 build runs through compiler2 IR → opt (ConstFold + DCE + TailCall) → emit → vm2.Run.
+Captured on the same host that runs MEP-23 (Apple M4, `go test -bench` with `-benchtime=2s`), committed in the PRs landing the Phase 1 stack. The vm2 build runs through compiler2 IR (opt: ConstFold + DCE + TailCall) → emit → vm2.Run. Two kernels measured side-by-side:
+
+- **spectral_norm n=100**: build A, compute A·u, return sqrt((u·v) / (v·v)).
+- **n_body N=5**: build 5 bodies with positions (i, 2i, 3i), velocities (i/10, i/5, 3i/10), masses (i+1). One advance step at dt=0.01, then return system energy. Recursive helpers exercised through `OpTailCallSelf`.
 
 | Benchmark | ns/op | B/op | allocs/op | vm2 / Go |
 |-----------|------:|-----:|----------:|---------:|
-| BenchmarkVM2_BG_SpectralNormKernel | 2,053,934 | 154,994 | 17 | 268x |
-| BenchmarkGo_BG_SpectralNormKernel  | 7,649 | 1,792 | 2 | 1.0x |
+| BenchmarkVM2_BG_SpectralNormKernel | 1,754,279 | 154,992 | 17 | 115x |
+| BenchmarkGo_BG_SpectralNormKernel  | 15,276 | 1,792 | 2 | 1.0x |
+| BenchmarkVM2_BG_NBodyKernel        | 14,103 | 9,400 | 19 | 118x |
+| BenchmarkGo_BG_NBodyKernel         | 119.4 | 0 | 0 | 1.0x |
 
-This is the launch number, not the destination. The headline goal in the abstract is 2x on phase-1 covered programs once the float JIT lowering and array bounds-check elision pieces land. The 268x ratio at the baseline is driven by:
+These are the launch numbers, not the destination. The headline goal in the abstract is 2x on phase-1 covered programs once the float JIT lowering and array bounds-check elision pieces land. The ratios at the baseline are driven by:
 
-1. Each `eval_A(i, j)` call costs one full OpCall round-trip plus six int and two float ops to compute the denominator. Go inlines `evalA` and folds the whole expression into a single FMA cluster.
+1. Each helper call (spectral_norm's `eval_A`, n_body's pairwise inner loop) costs one full OpCall round-trip; Go inlines the same helper and folds the whole expression into a single FMA cluster.
 2. Every float arithmetic op pays one byte-code dispatch (~6 ns on M4) and one Cell encode + decode round-trip; Go's compiled code is one FP register-to-register instruction.
 3. F64Array Get/Set each pay one OpCall-free dispatch but still do bounds checks the Go peer eliminates.
 
-The follow-up phases (JIT lowering for float ops, bounds-check elision on hot array accesses) close the gap; the data above is the starting point.
+n_body lands closer to spectral_norm's ratio than expected because the recursive inner loop (six `OpCall` round-trips per body pair, 10 pairs per step) is dispatch-bound, not arithmetic-bound. The follow-up phases (JIT lowering for float ops, bounds-check elision on hot array accesses, FMA pattern matching in emit) close the gap; the data above is the starting point.
 
 ## Open Questions
 


### PR DESCRIPTION
Tracking: #21580
Follow-up to: #21579 (Phase 1a — float ops + typed arrays)

## Summary

- Add the n_body Verlet-integrator kernel to `compiler2/corpus` as 7 hand-written IR functions, exercising the float arithmetic + OpTailCallSelf path that landed in Phase 1a.
- Add a Go reference + VM2/Go benchmarks in `runtime/vm2/bench/bg_n_body_test.go`.
- Update MEP-37 Appendix A with a joint measurement table covering both Phase 1 kernels under identical conditions.

## Kernel shape

5 bodies, positions `(i, 2i, 3i)`, velocities `(i/10, i/5, 3i/10)`, masses `i+1`. One advance step at `dt=0.01`, return system energy. Inner pairwise helpers use the `r = Call; Ret r` shape so `opt.TailCall` folds them to `OpTailCallSelf`. F64Arrays carry per-axis state (x/y/z/vx/vy/vz/m) through every helper.

## Measured baseline (Apple M4)

| Benchmark | ns/op | B/op | allocs/op | vm2 / Go |
|-----------|------:|-----:|----------:|---------:|
| BenchmarkVM2_BG_NBodyKernel | 14,103 | 9,400 | 19 | 118x |
| BenchmarkGo_BG_NBodyKernel  | 119.4 | 0 | 0 | 1.0x |

In the same range as spectral_norm's 115x (joint table in the spec). Dispatch-bound (6 OpCall round-trips per body pair, 10 pairs per step), not arithmetic-bound, which clarifies what the follow-up JIT lowering needs to target.

## Test plan

- [x] `go test ./runtime/vm2/bench/ -run TestBGNBodyKernel` — verifies vm2 result matches `goNBodyKernel` within 1e-10.
- [x] `go test ./runtime/vm2/bench/ -run='^$' -bench='BG_(NBody|SpectralNorm)Kernel$' -benchtime=2s` — both kernels benchmarked together.
- [x] No JIT changes needed: Phase 1a already added the float + array ops to `isDeoptableOp` so any function using them deopts cleanly to interpreter.