### PR TITLE
mep-0037 phase 1d: fannkuch_redux kernel corpus + bench

### DIFF
--- a/compiler2/corpus/bg_fannkuch_redux.go
+++ b/compiler2/corpus/bg_fannkuch_redux.go
@@ -1,0 +1,83 @@
+package corpus
+
+import "mochi/compiler2/ir"
+
+// BuildFannkuchReduxKernel builds the fannkuch_redux BG inner kernel as
+// described in MEP-37 §3.3 (boxed []Cell vs flat int array). It counts
+// the number of "flips" needed to bring 1 to the head of a 7-element
+// permutation, where a flip reverses the prefix whose length is the
+// current head value. Mirrors the inner loop of the BG canonical
+// fannkuch_redux except the outer permutation generator is replaced by
+// a fixed starting permutation [4,2,1,5,7,3,6] so the kernel has a
+// single deterministic return value (9 flips) for cross-language
+// verification.
+//
+// Three hand-written IR functions:
+//
+//	main()                = initialise perm[0..7) = {4,2,1,5,7,3,6}; return countFlips(perm, 0)
+//	countFlips(perm, c)   = if perm[0]==1 return c; reverse(perm, 0, perm[0]-1); recurse with c+1
+//	reverse(perm, lo, hi) = if lo>=hi return; swap perm[lo] and perm[hi]; recurse (lo+1, hi-1)
+//
+// countFlips is the only helper whose recursive call participates in
+// the caller's result, so it uses the canonical `r = Call; Ret r`
+// shape; reverse returns TUnit and uses Ret(-1).
+//
+// All loops tail-recurse and fold through opt.TailCall →
+// OpTailCallSelf. Storage is a single TI64Array of length 7 reused
+// across the whole call chain.
+func BuildFannkuchReduxKernel() *ir.Module {
+	const (
+		flipIdx = 1
+		revIdx  = 2
+	)
+
+	bMain := ir.NewBuilder("main", nil, ir.TI64)
+	n := bMain.ConstI64(7)
+	perm := bMain.NewI64Array(n)
+	for i, v := range []int64{4, 2, 1, 5, 7, 3, 6} {
+		bMain.I64ArrSet(perm, bMain.ConstI64(int64(i)), bMain.ConstI64(v))
+	}
+	count := bMain.Call(flipIdx, ir.TI64, perm, bMain.ConstI64(0))
+	bMain.Ret(count)
+
+	// countFlips(perm, count): if perm[0]==1 return count;
+	//   reverse(perm, 0, perm[0]-1); recurse with count+1.
+	bF := ir.NewBuilder("countFlips",
+		[]ir.Type{ir.TI64Array, ir.TI64}, ir.TI64)
+	fPerm, fCount := bF.Param(0), bF.Param(1)
+	fHead := bF.I64ArrGet(fPerm, bF.ConstI64(0))
+	fDone := bF.NewBlock()
+	fLoop := bF.NewBlock()
+	bF.CondBr(bF.EqualI64(fHead, bF.ConstI64(1)), fDone, fLoop)
+	bF.SwitchTo(fDone)
+	bF.Ret(fCount)
+	bF.SwitchTo(fLoop)
+	bF.Call(revIdx, ir.TUnit, fPerm, bF.ConstI64(0),
+		bF.SubI64(fHead, bF.ConstI64(1)))
+	rec := bF.Call(flipIdx, ir.TI64, fPerm,
+		bF.AddI64(fCount, bF.ConstI64(1)))
+	bF.Ret(rec)
+
+	// reverse(perm, lo, hi): swap perm[lo] and perm[hi], recurse with (lo+1, hi-1).
+	bR := ir.NewBuilder("reverse",
+		[]ir.Type{ir.TI64Array, ir.TI64, ir.TI64}, ir.TUnit)
+	rPerm, rLo, rHi := bR.Param(0), bR.Param(1), bR.Param(2)
+	rDone := bR.NewBlock()
+	rStep := bR.NewBlock()
+	bR.CondBr(bR.LessI64(rLo, rHi), rStep, rDone)
+	bR.SwitchTo(rDone)
+	bR.Ret(-1)
+	bR.SwitchTo(rStep)
+	a := bR.I64ArrGet(rPerm, rLo)
+	b := bR.I64ArrGet(rPerm, rHi)
+	bR.I64ArrSet(rPerm, rLo, b)
+	bR.I64ArrSet(rPerm, rHi, a)
+	bR.Call(revIdx, ir.TUnit, rPerm,
+		bR.AddI64(rLo, bR.ConstI64(1)),
+		bR.SubI64(rHi, bR.ConstI64(1)))
+	bR.Ret(-1)
+
+	return &ir.Module{Funcs: []*ir.Function{
+		bMain.Function(), bF.Function(), bR.Function(),
+	}, Main: 0}
+}

--- a/runtime/vm2/bench/bg_fannkuch_redux_test.go
+++ b/runtime/vm2/bench/bg_fannkuch_redux_test.go
@@ -1,0 +1,79 @@
+package bench
+
+import (
+	"testing"
+
+	"mochi/compiler2/corpus"
+	"mochi/compiler2/emit"
+	"mochi/compiler2/opt"
+	vm2 "mochi/runtime/vm2"
+)
+
+// goFannkuchReduxKernel mirrors corpus.BuildFannkuchReduxKernel: count
+// the flips needed to bring 1 to the head of [4,2,1,5,7,3,6], where
+// each flip reverses the prefix whose length is the current head
+// value. Expected: 9.
+func goFannkuchReduxKernel() int64 {
+	perm := []int64{4, 2, 1, 5, 7, 3, 6}
+	var count int64
+	for perm[0] != 1 {
+		k := perm[0]
+		for lo, hi := int64(0), k-1; lo < hi; lo, hi = lo+1, hi-1 {
+			perm[lo], perm[hi] = perm[hi], perm[lo]
+		}
+		count++
+	}
+	return count
+}
+
+func TestBGFannkuchReduxKernel(t *testing.T) {
+	m := corpus.BuildFannkuchReduxKernel()
+	for _, f := range m.Funcs {
+		opt.ConstFold(f)
+		opt.DCE(f)
+		opt.TailCall(f)
+	}
+	prog, err := emit.Compile(m)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	got, err := vm2.New(prog).Run()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !got.IsInt() {
+		t.Fatalf("expected int, got %#v", got)
+	}
+	want := goFannkuchReduxKernel()
+	if got.Int() != want {
+		t.Fatalf("fannkuch_redux kernel = %d, want %d", got.Int(), want)
+	}
+}
+
+func BenchmarkVM2_BG_FannkuchReduxKernel(b *testing.B) {
+	m := corpus.BuildFannkuchReduxKernel()
+	for _, f := range m.Funcs {
+		opt.ConstFold(f)
+		opt.DCE(f)
+		opt.TailCall(f)
+	}
+	prog, err := emit.Compile(m)
+	if err != nil {
+		b.Fatalf("compile: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := vm2.New(prog).Run(); err != nil {
+			b.Fatalf("run: %v", err)
+		}
+	}
+}
+
+func BenchmarkGo_BG_FannkuchReduxKernel(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = goFannkuchReduxKernel()
+	}
+}


### PR DESCRIPTION
Tracking: #21584
Follows: #21583 (Phase 1c — mandelbrot kernel)

This completes Phase 1's BG corpus: four FP-dominated kernels (spectral_norm, n_body, mandelbrot, fannkuch_redux) now run end-to-end through compiler2 → emit → vm2.

## Summary

- Add the fannkuch_redux flip-count kernel as 3 hand-written IR functions in \`compiler2/corpus/bg_fannkuch_redux.go\`. Fixed starting permutation \`[4,2,1,5,7,3,6]\` gives a deterministic return of 9 flips.
- Add Go reference + VM2/Go benchmarks in \`runtime/vm2/bench/bg_fannkuch_redux_test.go\`.

## Measured baseline (Apple M4)

| Benchmark | ns/op | B/op | allocs/op | vm2 / Go |
|-----------|------:|-----:|----------:|---------:|
| BenchmarkVM2_BG_FannkuchReduxKernel | 2,927 | 1,816 | 5 | 42x |
| BenchmarkGo_BG_FannkuchReduxKernel  | 69.83 | 0 | 0 | 1.0x |

Best ratio of the Phase 1 kernels. Integer-only work avoids float dispatch overhead; I64Array Get/Set is one tag check + one slice index.

## Test plan

- [x] \`go test ./runtime/vm2/bench/ -run TestBGFannkuchReduxKernel\` — flip count matches Go reference (9).
- [x] \`go test ./runtime/vm2/bench/ -bench BG_FannkuchReduxKernel -benchtime=2s\` — bench runs cleanly.
- [x] No JIT changes needed (Phase 1a added all required ops to \`isDeoptableOp\`).