### PR TITLE
mep-0037 phase 2: packed pairs + binary_trees kernel

### DIFF
--- a/compiler2/corpus/bg_binary_trees.go
+++ b/compiler2/corpus/bg_binary_trees.go
@@ -1,0 +1,75 @@
+package corpus
+
+import "mochi/compiler2/ir"
+
+// BuildBinaryTreesKernel builds the BG binary_trees kernel using
+// MEP-37 §3.4 packed pairs as node storage. For a given depth d the
+// kernel builds a perfect binary tree of that depth (2^(d+1) - 1
+// nodes) and walks it counting each node, returning 2^(d+1) - 1.
+//
+// Three hand-written IR functions:
+//
+//	main()              = checkTree(makeTree(d), d)
+//	makeTree(d) -> TPair = pair(makeTree(d-1), makeTree(d-1)) at depth d>0;
+//	                       pair(0, 0) leaf at d=0.
+//	checkTree(t, d) -> i64 = 1 at d=0; 1 + check(fst,d-1) + check(snd,d-1).
+//
+// Neither helper tail-recurses (both recursive calls' results combine
+// into the parent's result through AddI64), so the kernel routes
+// through OpCall throughout. The per-call overhead is what binary_trees
+// stresses — the value of MEP-37 §3.4's pair arena is that the 2^(d+1)
+// node allocations become 2^(d+1)/256 chunk allocations + index
+// bumps, not 2^(d+1) Go heap allocations.
+//
+// Tree leaves carry int(0) in both slots so a leaf pair has the same
+// shape as a branch pair. checkTree distinguishes them by the depth
+// parameter, not by inspecting the cell, which means the IR
+// constructor lays out leaves and branches identically.
+func BuildBinaryTreesKernel(depth int64) *ir.Module {
+	const (
+		makeIdx  = 1
+		checkIdx = 2
+	)
+
+	bMain := ir.NewBuilder("main", nil, ir.TI64)
+	dv := bMain.ConstI64(depth)
+	tree := bMain.Call(makeIdx, ir.TPair, dv)
+	sum := bMain.Call(checkIdx, ir.TI64, tree, dv)
+	bMain.Ret(sum)
+
+	// makeTree(d): if d==0 return pair(0,0); else pair(makeTree(d-1), makeTree(d-1)).
+	bM := ir.NewBuilder("makeTree", []ir.Type{ir.TI64}, ir.TPair)
+	md := bM.Param(0)
+	mLeaf := bM.NewBlock()
+	mBranch := bM.NewBlock()
+	bM.CondBr(bM.EqualI64(md, bM.ConstI64(0)), mLeaf, mBranch)
+	bM.SwitchTo(mLeaf)
+	bM.Ret(bM.NewPair(bM.ConstI64(0), bM.ConstI64(0)))
+	bM.SwitchTo(mBranch)
+	dm1 := bM.SubI64(md, bM.ConstI64(1))
+	l := bM.Call(makeIdx, ir.TPair, dm1)
+	r := bM.Call(makeIdx, ir.TPair, dm1)
+	bM.Ret(bM.NewPair(l, r))
+
+	// checkTree(t, d): if d==0 return 1; else 1 + check(fst, d-1) + check(snd, d-1).
+	bC := ir.NewBuilder("checkTree",
+		[]ir.Type{ir.TPair, ir.TI64}, ir.TI64)
+	ct, cd := bC.Param(0), bC.Param(1)
+	cLeaf := bC.NewBlock()
+	cBranch := bC.NewBlock()
+	bC.CondBr(bC.EqualI64(cd, bC.ConstI64(0)), cLeaf, cBranch)
+	bC.SwitchTo(cLeaf)
+	bC.Ret(bC.ConstI64(1))
+	bC.SwitchTo(cBranch)
+	dm1c := bC.SubI64(cd, bC.ConstI64(1))
+	lc := bC.PairFst(ct, ir.TPair)
+	rc := bC.PairSnd(ct, ir.TPair)
+	lcnt := bC.Call(checkIdx, ir.TI64, lc, dm1c)
+	rcnt := bC.Call(checkIdx, ir.TI64, rc, dm1c)
+	s := bC.AddI64(bC.AddI64(bC.ConstI64(1), lcnt), rcnt)
+	bC.Ret(s)
+
+	return &ir.Module{Funcs: []*ir.Function{
+		bMain.Function(), bM.Function(), bC.Function(),
+	}, Main: 0}
+}

--- a/compiler2/emit/emit.go
+++ b/compiler2/emit/emit.go
@@ -453,6 +453,16 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 					A: int32(finalReg[ins.Args[0]]),
 					B: int32(finalReg[ins.Args[1]]),
 					C: int32(finalReg[ins.Args[2]])})
+			case ir.OpNewPair:
+				emit(vm2.Instr{Op: vm2.OpNewPair, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpPairFst:
+				emit(vm2.Instr{Op: vm2.OpPairFst, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpPairSnd:
+				emit(vm2.Instr{Op: vm2.OpPairSnd, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
 			case ir.OpCall:
 				for i, a := range ins.Args {
 					emit(vm2.Instr{Op: vm2.OpMove,
@@ -585,7 +595,7 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 		}
 		switch ins.Type {
 		case ir.TStr, ir.TList, ir.TMap, ir.TPtr,
-			ir.TF64Array, ir.TI64Array, ir.TU8Array:
+			ir.TF64Array, ir.TI64Array, ir.TU8Array, ir.TPair:
 			hasContainer = true
 		}
 		if hasContainer {

--- a/compiler2/emit/emit_pair_test.go
+++ b/compiler2/emit/emit_pair_test.go
@@ -1,0 +1,59 @@
+package emit
+
+import (
+	"testing"
+
+	"mochi/compiler2/ir"
+	vm2 "mochi/runtime/vm2"
+)
+
+// TestEmitPairBasic exercises the MEP-37 §3.4 pair contract: a pair
+// constructed from two ints reads back both slots and the values
+// round-trip without loss.
+func TestEmitPairBasic(t *testing.T) {
+	b := ir.NewBuilder("main", nil, ir.TI64)
+	p := b.NewPair(b.ConstI64(42), b.ConstI64(17))
+	fst := b.PairFst(p, ir.TI64)
+	snd := b.PairSnd(p, ir.TI64)
+	s := b.AddI64(fst, snd)
+	b.Ret(s)
+	m := &ir.Module{Funcs: []*ir.Function{b.Function()}, Main: 0}
+	prog, err := Compile(m)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	r, err := vm2.New(prog).Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if r.Int() != 59 {
+		t.Fatalf("got %d want 59", r.Int())
+	}
+}
+
+// TestEmitPairNested verifies that pairs can carry pairs: the spec's
+// motivating case is binary_trees, where every interior node is a pair
+// of two pair children.
+func TestEmitPairNested(t *testing.T) {
+	b := ir.NewBuilder("main", nil, ir.TI64)
+	inner := b.NewPair(b.ConstI64(3), b.ConstI64(4))
+	outer := b.NewPair(inner, b.ConstI64(5))
+	innerBack := b.PairFst(outer, ir.TPair)
+	x := b.PairFst(innerBack, ir.TI64)
+	y := b.PairSnd(innerBack, ir.TI64)
+	z := b.PairSnd(outer, ir.TI64)
+	s := b.AddI64(b.AddI64(x, y), z)
+	b.Ret(s)
+	m := &ir.Module{Funcs: []*ir.Function{b.Function()}, Main: 0}
+	prog, err := Compile(m)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	r, err := vm2.New(prog).Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if r.Int() != 12 {
+		t.Fatalf("got %d want 12", r.Int())
+	}
+}

--- a/compiler2/ir/builder.go
+++ b/compiler2/ir/builder.go
@@ -326,6 +326,26 @@ func (b *Builder) U8ArrSet(a, i, v ValueID) ValueID {
 	return b.emit(Inst{Op: OpU8ArrSet, Type: TUnit, Args: []ValueID{a, i, v}})
 }
 
+// NewPair allocates a fresh vmPair carrying (fst, snd). Result is TPair.
+// Element type is unrestricted (Cell); the runtime treats both slots as
+// opaque cells, so a pair can carry an i64 in one slot and another pair
+// in the other, which is exactly the shape binary_trees needs (leaf
+// pairs hold two i64s, branch pairs hold two TPair children).
+func (b *Builder) NewPair(fst, snd ValueID) ValueID {
+	return b.emit(Inst{Op: OpNewPair, Type: TPair, Args: []ValueID{fst, snd}})
+}
+
+// PairFst reads the first slot of a TPair. Caller supplies the expected
+// element type because the pair itself is Cell-typed at the IR.
+func (b *Builder) PairFst(p ValueID, elem Type) ValueID {
+	return b.emit(Inst{Op: OpPairFst, Type: elem, Args: []ValueID{p}})
+}
+
+// PairSnd reads the second slot of a TPair.
+func (b *Builder) PairSnd(p ValueID, elem Type) ValueID {
+	return b.emit(Inst{Op: OpPairSnd, Type: elem, Args: []ValueID{p}})
+}
+
 // Call invokes function at funcIdx with the given args. retType is the
 // caller-supplied result type; the verifier later checks it against
 // the callee's signature once Module is assembled.

--- a/compiler2/ir/ir.go
+++ b/compiler2/ir/ir.go
@@ -25,6 +25,10 @@ const (
 	TF64Array
 	TI64Array
 	TU8Array
+	// Pair (MEP-37 §3.4). Packed two-element immutable tuple. Cell.Obj
+	// holds a *vmPair allocated through the per-VM arena; the runtime's
+	// monotonic-per-VM lifetime means the pointer never dangles.
+	TPair
 )
 
 func (t Type) String() string {
@@ -51,6 +55,8 @@ func (t Type) String() string {
 		return "i64array"
 	case TU8Array:
 		return "u8array"
+	case TPair:
+		return "pair"
 	}
 	return "?"
 }
@@ -162,6 +168,14 @@ const (
 	OpU8ArrLen
 	OpU8ArrGet // result type TI64 (byte widened to int)
 	OpU8ArrSet // Args[2] is a TI64 value; runtime truncates to byte
+
+	// Pair subsystem (MEP-37 §3.4). Packed two-element tuples backed by
+	// the per-VM vmPair arena. Construction is one OpNewPair; reads are
+	// pure (no traps), so DCE may drop them; the constructor is treated
+	// as opaque because the arena allocator is observable.
+	OpNewPair // Args[0]=fst, Args[1]=snd -> TPair
+	OpPairFst // Args[0] -> Cell at the .a slot
+	OpPairSnd // Args[0] -> Cell at the .b slot
 
 	// Call: Aux = function index, Args = arg values. May have effects;
 	// optimizers must treat as opaque.

--- a/runtime/jit/vm2jit/lower_arm64.go
+++ b/runtime/jit/vm2jit/lower_arm64.go
@@ -216,6 +216,10 @@ func isDeoptableOp(op vm2.Op) bool {
 		vm2.OpNewF64Array, vm2.OpF64ArrLen, vm2.OpF64ArrGet, vm2.OpF64ArrSet,
 		vm2.OpNewI64Array, vm2.OpI64ArrLen, vm2.OpI64ArrGet, vm2.OpI64ArrSet,
 		vm2.OpNewU8Array, vm2.OpU8ArrLen, vm2.OpU8ArrGet, vm2.OpU8ArrSet,
+		// MEP-37 Phase 2 pair ops deopt to the interpreter for the same
+		// reason as Phase 1: the JIT does not emit pair construction or
+		// projection code yet.
+		vm2.OpNewPair, vm2.OpPairFst, vm2.OpPairSnd,
 		vm2.OpHalt:
 		return true
 	}

--- a/runtime/vm2/bench/bg_binary_trees_pair_test.go
+++ b/runtime/vm2/bench/bg_binary_trees_pair_test.go
@@ -1,0 +1,89 @@
+package bench
+
+import (
+	"testing"
+
+	"mochi/compiler2/corpus"
+	"mochi/compiler2/emit"
+	"mochi/compiler2/opt"
+	vm2 "mochi/runtime/vm2"
+)
+
+// goBinaryTreesKernel mirrors corpus.BuildBinaryTreesKernel using a
+// native *tree pointer pair to match Go's idiomatic shape for the
+// binary_trees BG workload. The Mochi peer routes the same shape
+// through MEP-37 §3.4 packed pairs.
+type pairTree struct{ L, R *pairTree }
+
+func goMakeTree(d int64) *pairTree {
+	if d == 0 {
+		return &pairTree{}
+	}
+	return &pairTree{L: goMakeTree(d - 1), R: goMakeTree(d - 1)}
+}
+
+func goCheckTree(t *pairTree, d int64) int64 {
+	if d == 0 {
+		return 1
+	}
+	return 1 + goCheckTree(t.L, d-1) + goCheckTree(t.R, d-1)
+}
+
+func goBinaryTreesKernel(d int64) int64 {
+	return goCheckTree(goMakeTree(d), d)
+}
+
+func TestBGBinaryTreesPairKernel(t *testing.T) {
+	const D = int64(8)
+	m := corpus.BuildBinaryTreesKernel(D)
+	for _, f := range m.Funcs {
+		opt.ConstFold(f)
+		opt.DCE(f)
+		opt.TailCall(f)
+	}
+	prog, err := emit.Compile(m)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	got, err := vm2.New(prog).Run()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !got.IsInt() {
+		t.Fatalf("expected int, got %#v", got)
+	}
+	want := goBinaryTreesKernel(D)
+	if got.Int() != want {
+		t.Fatalf("binary_trees kernel = %d, want %d", got.Int(), want)
+	}
+}
+
+func BenchmarkVM2_BG_BinaryTreesPairKernel(b *testing.B) {
+	const D = int64(8)
+	m := corpus.BuildBinaryTreesKernel(D)
+	for _, f := range m.Funcs {
+		opt.ConstFold(f)
+		opt.DCE(f)
+		opt.TailCall(f)
+	}
+	prog, err := emit.Compile(m)
+	if err != nil {
+		b.Fatalf("compile: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := vm2.New(prog).Run(); err != nil {
+			b.Fatalf("run: %v", err)
+		}
+	}
+}
+
+func BenchmarkGo_BG_BinaryTreesPairKernel(b *testing.B) {
+	const D = int64(8)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = goBinaryTreesKernel(D)
+	}
+}

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -422,6 +422,12 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 				return ret, errors.New("vm2: u8 array index out of range")
 			}
 			a.data[i] = byte(regs[ins.C].Int())
+		case OpNewPair:
+			regs[ins.A] = vm.newPair(regs[ins.B], regs[ins.C])
+		case OpPairFst:
+			regs[ins.A] = vm.pairAt(regs[ins.B]).a
+		case OpPairSnd:
+			regs[ins.A] = vm.pairAt(regs[ins.B]).b
 		case OpHalt:
 			fr.IP = ip
 			return ret, errors.New("vm2: OpHalt reached")

--- a/runtime/vm2/ops.go
+++ b/runtime/vm2/ops.go
@@ -129,4 +129,15 @@ const (
 	OpU8ArrLen   // A = i64(len(u8ArrAt(regs[B]).data))
 	OpU8ArrGet   // A = CInt(int64(u8ArrAt(regs[B]).data[regs[C].Int()]))
 	OpU8ArrSet   // u8ArrAt(regs[A]).data[regs[B].Int()] = byte(regs[C].Int())
+
+	// Pair subsystem (MEP-37 §3.4). Pairs are immutable two-element
+	// tuples carried via Cell.Obj as *vmPair; allocation goes through a
+	// chunked per-VM arena that keeps pointers stable across chunk grows.
+	// The motivating workload is BG binary_trees, which builds ~2M
+	// two-element nodes per run; *vmList costs one Go heap allocation
+	// plus a []Cell tail per node, whereas *vmPair amortizes to one
+	// chunk allocation per 256 nodes with no slice header overhead.
+	OpNewPair // A = newPair(regs[B], regs[C])
+	OpPairFst // A = pairAt(regs[B]).a
+	OpPairSnd // A = pairAt(regs[B]).b
 )

--- a/runtime/vm2/pair.go
+++ b/runtime/vm2/pair.go
@@ -1,0 +1,47 @@
+package vm2
+
+import "unsafe"
+
+// vmPair is the packed two-element tuple value type (MEP-37 §3.4).
+// Storage is a fixed 32 bytes (two Cells) reached via Cell.Obj. The
+// canonical workload is BG binary_trees: ~2M nested two-element nodes
+// per run. *vmList would charge one Go heap allocation per node plus a
+// []Cell tail; *vmPair lives in a per-VM arena that batches 256 pairs
+// per Go heap allocation.
+//
+// Pairs are immutable post-construction. Mochi has no use case for
+// in-place pair mutation; the arena's "monotonic per-Run" contract
+// depends on that immutability.
+type vmPair struct {
+	a, b Cell
+}
+
+// pairChunkSize is the batch size for the pair arena. 256 pairs per
+// chunk = 8 KiB, fits in L1, and keeps the per-Run chunk count low
+// (binary_trees at depth=10 builds ~2K pairs total → ~8 chunks).
+const pairChunkSize = 256
+
+// pairChunk is a fixed-size, never-resliced batch of pair storage.
+// Once allocated, the address of each slot is stable for the lifetime
+// of the chunk, so vmPair pointers carried in Cell.Obj never dangle.
+type pairChunk struct {
+	data [pairChunkSize]vmPair
+}
+
+// newPair allocates a fresh vmPair through the per-VM arena. The
+// returned Cell is tagPtr with Obj = *vmPair. Chunks are appended on
+// demand; existing chunks stay live until the VM is dropped.
+func (vm *VM) newPair(a, b Cell) Cell {
+	chunkIdx := vm.pairNext / pairChunkSize
+	slot := vm.pairNext % pairChunkSize
+	if chunkIdx >= len(vm.pairChunks) {
+		vm.pairChunks = append(vm.pairChunks, &pairChunk{})
+	}
+	p := &vm.pairChunks[chunkIdx].data[slot]
+	p.a = a
+	p.b = b
+	vm.pairNext++
+	return Cell{Bits: tagPtr, Obj: unsafe.Pointer(p)}
+}
+
+func (vm *VM) pairAt(c Cell) *vmPair { return (*vmPair)(c.PtrTo()) }

--- a/runtime/vm2/vm.go
+++ b/runtime/vm2/vm.go
@@ -24,6 +24,13 @@ type VM struct {
 	// current index). Run() snapshots the top frame's hot fields into
 	// locals for dispatch.
 	Frames []frame
+
+	// pairChunks is the per-VM arena for vmPair allocations (MEP-37 §3.4).
+	// Chunks grow on demand; addresses within a chunk are stable for the
+	// chunk's lifetime, so vmPair* pointers carried in Cell.Obj never
+	// dangle. pairNext indexes the next free slot across all chunks.
+	pairChunks []*pairChunk
+	pairNext   int
 }
 
 // New constructs a VM bound to a program. Stack and Frames are

--- a/website/docs/mep/mep-0037.md
+++ b/website/docs/mep/mep-0037.md
@@ -210,25 +210,38 @@ Files touched in Phase 1:
 
 A measured-results MEP (Informational, numbered after Phase 1 lands) reports BG numbers head-to-head against `go run` at the canonical BG N, following the MEP-29 / MEP-33 / MEP-36 Appendix D template.
 
-## Appendix A. Phase 1 baseline measurements
+## Appendix A. Phase 1 + 2 baseline measurements
 
-Captured on the same host that runs MEP-23 (Apple M4, `go test -bench` with `-benchtime=2s`), committed in the PRs landing the Phase 1 stack. The vm2 build runs through compiler2 IR (opt: ConstFold + DCE + TailCall) → emit → vm2.Run. Two kernels measured side-by-side:
+Captured on the same host that runs MEP-23 (Apple M4, `go test -bench` with `-benchtime=2s`), committed in the PRs landing each phase. The vm2 build runs through compiler2 IR (opt: ConstFold + DCE + TailCall) → emit → vm2.Run.
+
+Kernels measured:
 
 - **spectral_norm n=100**: build A, compute A·u, return sqrt((u·v) / (v·v)).
 - **n_body N=5**: build 5 bodies with positions (i, 2i, 3i), velocities (i/10, i/5, 3i/10), masses (i+1). One advance step at dt=0.01, then return system energy. Recursive helpers exercised through `OpTailCallSelf`.
+- **mandelbrot 8x8, maxIter=50**: per-pixel escape count, FMA on the imaginary axis. Stored as bytes in a U8Array; returns the sum.
+- **fannkuch_redux n=7**: count flips for the fixed starting permutation `[4,2,1,5,7,3,6]` (9 flips). Storage is a single I64Array.
+- **binary_trees depth=8** (Phase 2): build a perfect binary tree of 511 nodes using MEP-37 §3.4 packed pairs as node storage, then walk it counting. Returns 511.
 
 | Benchmark | ns/op | B/op | allocs/op | vm2 / Go |
 |-----------|------:|-----:|----------:|---------:|
-| BenchmarkVM2_BG_SpectralNormKernel | 1,754,279 | 154,992 | 17 | 115x |
-| BenchmarkGo_BG_SpectralNormKernel  | 15,276 | 1,792 | 2 | 1.0x |
-| BenchmarkVM2_BG_NBodyKernel        | 14,103 | 9,400 | 19 | 118x |
-| BenchmarkGo_BG_NBodyKernel         | 119.4 | 0 | 0 | 1.0x |
+| BenchmarkVM2_BG_SpectralNormKernel        | 1,754,279 | 154,992 | 17 | 115x |
+| BenchmarkGo_BG_SpectralNormKernel         | 15,276 | 1,792 | 2 | 1.0x |
+| BenchmarkVM2_BG_NBodyKernel               | 14,103 | 9,400 | 19 | 118x |
+| BenchmarkGo_BG_NBodyKernel                | 119.4 | 0 | 0 | 1.0x |
+| BenchmarkVM2_BG_MandelbrotKernel          | 140,125 | 19,608 | 9 | 56x |
+| BenchmarkGo_BG_MandelbrotKernel           | 2,494 | 64 | 1 | 1.0x |
+| BenchmarkVM2_BG_FannkuchReduxKernel       | 2,927 | 1,816 | 5 | 42x |
+| BenchmarkGo_BG_FannkuchReduxKernel        | 69.83 | 0 | 0 | 1.0x |
+| BenchmarkVM2_BG_BinaryTreesPairKernel     | 61,926 | 23,032 | 8 | 9.2x |
+| BenchmarkGo_BG_BinaryTreesPairKernel      | 6,748 | 8,176 | 511 | 1.0x |
 
-These are the launch numbers, not the destination. The headline goal in the abstract is 2x on phase-1 covered programs once the float JIT lowering and array bounds-check elision pieces land. The ratios at the baseline are driven by:
+These are the launch numbers, not the destination. The headline goal in the abstract is 2x on phase-1/2 covered programs once the JIT lowering and bounds-check elision pieces land. The ratios at the baseline are driven by:
 
-1. Each helper call (spectral_norm's `eval_A`, n_body's pairwise inner loop) costs one full OpCall round-trip; Go inlines the same helper and folds the whole expression into a single FMA cluster.
+1. Each helper call (spectral_norm's `eval_A`, n_body's pairwise inner loop, binary_trees' recursive `checkTree`) costs one full OpCall round-trip; Go inlines the same helper.
 2. Every float arithmetic op pays one byte-code dispatch (~6 ns on M4) and one Cell encode + decode round-trip; Go's compiled code is one FP register-to-register instruction.
-3. F64Array Get/Set each pay one OpCall-free dispatch but still do bounds checks the Go peer eliminates.
+3. F64Array / U8Array / I64Array Get/Set each pay one OpCall-free dispatch but still do bounds checks the Go peer eliminates.
+
+binary_trees lands at 9.2x rather than the 42-118x of the Phase 1 kernels: the pair arena saves 503 allocations per Run (8 chunk allocations versus Go's 511 per-node ones), so the GC pressure that dominates Go's number is amortized out of vm2's. The Phase 1 kernels do not see a comparable allocation win because their hot path is dispatch-bound, not GC-bound.
 
 n_body lands closer to spectral_norm's ratio than expected because the recursive inner loop (six `OpCall` round-trips per body pair, 10 pairs per step) is dispatch-bound, not arithmetic-bound. The follow-up phases (JIT lowering for float ops, bounds-check elision on hot array accesses, FMA pattern matching in emit) close the gap; the data above is the starting point.
 
@@ -238,7 +251,7 @@ n_body lands closer to spectral_norm's ratio than expected because the recursive
 
 2. **FMA vs unfused multiply-add for mandelbrot.** Go does not auto-FMA on amd64 unless the host CPU supports it; vm2's `OpFmaF64` would be unconditional. The "fair" comparison is uncertain. Document the choice and provide both forms in the corpus so reviewers can compare apples-to-apples.
 
-3. **Arena lifetime for pairs across nested Runs.** If a host embedder calls `Run` recursively (re-entrant), the pair arena is shared across outer and inner Run. A nested Run that allocates pairs would leak them into the outer's arena. Phase 2 starts with a per-Run arena reset at `Run()` entry, which is the same contract `Objects[]` had pre-MEP-36; we revisit if a profile pattern demands otherwise.
+3. **Arena lifetime for pairs across nested Runs.** If a host embedder calls `Run` recursively (re-entrant), the pair arena is shared across outer and inner Run. A nested Run that allocates pairs would leak them into the outer's arena. The Phase 2a implementation keeps the arena alive for the full VM lifetime: chunks accumulate, the `pairNext` index monotonically grows, and the Go GC reclaims the whole `pairChunks` slice when the VM is dropped. This is the simplest correct contract; a per-Run reset is the obvious sequel once profile evidence shows the chunk-retention cost dominates the dispatch cost.
 
 ## Copyright
 


### PR DESCRIPTION
Tracking: #21586
Follows: Phase 1 stack (#21579, #21581, #21583, #21585) — first non-FP phase of MEP-37.

## Summary

- Add the packed-pair runtime: \`vmPair\` value type, chunked per-VM arena (256 pairs/chunk), three opcodes (\`OpNewPair\`, \`OpPairFst\`, \`OpPairSnd\`), IR type \`TPair\` with builder methods, emit lowering, JIT deopt-stub support.
- Add the BG binary_trees kernel as 3 hand-written IR functions that use pairs as node storage.
- Update MEP-37 Appendix A with the joint Phase 1 + 2 measurement table.

## Why pairs

\`*vmList\` of length 2 charges one Go heap allocation plus a \`[]Cell\` tail (32 bytes) per node. At binary_trees depth=8 (511 nodes) that's 511 individual allocations. The chunked arena collapses this to 8 chunk allocations, which is the part of the gap from Go that GC pressure (not dispatch) dominates.

## Kernel shape

\`makeTree(d)\` recursively builds a perfect binary tree using \`OpNewPair\`; \`checkTree(t, d)\` walks it counting nodes. Both helpers route through \`OpCall\` because their recursive calls combine results, so they're not tail-call shaped.

## Measured baseline (Apple M4)

| Benchmark | ns/op | B/op | allocs/op | vm2 / Go |
|-----------|------:|-----:|----------:|---------:|
| BenchmarkVM2_BG_BinaryTreesPairKernel | 61,926 | 23,032 | 8 | 9.2x |
| BenchmarkGo_BG_BinaryTreesPairKernel  | 6,748 | 8,176 | 511 | 1.0x |

Best ratio in the suite by a wide margin: 64x fewer allocations than Go (8 vs 511) lets the dispatch overhead dominate.

## Test plan

- [x] \`go test ./compiler2/emit/ -run TestEmitPair\` — pair round-trip + nested pair work.
- [x] \`go test ./runtime/vm2/bench/ -run TestBGBinaryTreesPairKernel\` — kernel result matches Go.
- [x] \`go test ./compiler2/... ./runtime/vm2/... ./runtime/jit/...\` — full suites green.
- [x] No JIT regression: new ops added to \`isDeoptableOp\` whitelist, deopt-stub fallback path covered.