### PR TITLE
mep-0037 phase 3: reverse_complement kernel corpus + bench

### DIFF
--- a/compiler2/corpus/bg_reverse_complement.go
+++ b/compiler2/corpus/bg_reverse_complement.go
@@ -1,0 +1,151 @@
+package corpus
+
+import "mochi/compiler2/ir"
+
+// BuildReverseComplementKernel builds the reverse_complement BG inner
+// kernel (MEP-37 §3.4). The full canonical program reads FASTA from
+// stdin, complements each DNA base (A↔T, C↔G, a↔t, c↔g), and writes the
+// reversed-complement stream to stdout in 60-char lines. The kernel
+// here keeps the arithmetic core (per-byte complement and an in-place
+// reverse) on a fixed 1024-byte buffer of generated input, then sums
+// the output bytes so the whole program reduces to a single i64 the
+// test can compare against a Go reference.
+//
+// Six hand-written IR functions:
+//
+//	main()                       = fillInput; rcLoop; sumBytes; return sum
+//	fillInput(in, i, n)          = tail-rec, sets in[i] = baseFor(i%4)
+//	baseFor(k) -> i64            = "ACGT"[k] dispatch (k in 0..3)
+//	rcLoop(in, out, i, n)        = tail-rec, sets out[n-1-i] = complement(in[i])
+//	complement(c) -> i64         = A<->T, C<->G dispatch on the input byte
+//	sumBytes(arr, i, n, acc)     = tail-rec accumulator
+//
+// All loops tail-recurse and fold through opt.TailCall →
+// OpTailCallSelf. The two U8Array allocations (input + output) are the
+// only heap touches; everything else stays in registers.
+func BuildReverseComplementKernel() *ir.Module {
+	const (
+		fillIdx = 1
+		baseIdx = 2
+		rcIdx   = 3
+		compIdx = 4
+		sumIdx  = 5
+	)
+
+	bMain := ir.NewBuilder("main", nil, ir.TI64)
+	n := bMain.ConstI64(1024)
+	in := bMain.NewU8Array(n)
+	out := bMain.NewU8Array(n)
+	bMain.Call(fillIdx, ir.TUnit, in, bMain.ConstI64(0), n)
+	bMain.Call(rcIdx, ir.TUnit, in, out, bMain.ConstI64(0), n)
+	sum := bMain.Call(sumIdx, ir.TI64, out, bMain.ConstI64(0), n, bMain.ConstI64(0))
+	bMain.Ret(sum)
+
+	// fillInput(in, i, n): in[i] = baseFor(i%4); recurse with i+1 until i>=n.
+	bF := ir.NewBuilder("fillInput",
+		[]ir.Type{ir.TU8Array, ir.TI64, ir.TI64}, ir.TUnit)
+	fIn, fI, fN := bF.Param(0), bF.Param(1), bF.Param(2)
+	fDone := bF.NewBlock()
+	fStep := bF.NewBlock()
+	bF.CondBr(bF.LessI64(fI, fN), fStep, fDone)
+	bF.SwitchTo(fDone)
+	bF.Ret(-1)
+	bF.SwitchTo(fStep)
+	mod4 := bF.ModI64(fI, bF.ConstI64(4))
+	v := bF.Call(baseIdx, ir.TI64, mod4)
+	bF.U8ArrSet(fIn, fI, v)
+	bF.Call(fillIdx, ir.TUnit, fIn,
+		bF.AddI64(fI, bF.ConstI64(1)), fN)
+	bF.Ret(-1)
+
+	// baseFor(k) -> i64: 0='A'(65), 1='C'(67), 2='G'(71), 3='T'(84).
+	bB := ir.NewBuilder("baseFor", []ir.Type{ir.TI64}, ir.TI64)
+	bK := bB.Param(0)
+	bbA := bB.NewBlock()
+	bbChk1 := bB.NewBlock()
+	bbC := bB.NewBlock()
+	bbChk2 := bB.NewBlock()
+	bbG := bB.NewBlock()
+	bbT := bB.NewBlock()
+	bB.CondBr(bB.EqualI64(bK, bB.ConstI64(0)), bbA, bbChk1)
+	bB.SwitchTo(bbA)
+	bB.Ret(bB.ConstI64(65))
+	bB.SwitchTo(bbChk1)
+	bB.CondBr(bB.EqualI64(bK, bB.ConstI64(1)), bbC, bbChk2)
+	bB.SwitchTo(bbC)
+	bB.Ret(bB.ConstI64(67))
+	bB.SwitchTo(bbChk2)
+	bB.CondBr(bB.EqualI64(bK, bB.ConstI64(2)), bbG, bbT)
+	bB.SwitchTo(bbG)
+	bB.Ret(bB.ConstI64(71))
+	bB.SwitchTo(bbT)
+	bB.Ret(bB.ConstI64(84))
+
+	// rcLoop(in, out, i, n): out[n-1-i] = complement(in[i]); recurse with i+1.
+	bR := ir.NewBuilder("rcLoop",
+		[]ir.Type{ir.TU8Array, ir.TU8Array, ir.TI64, ir.TI64}, ir.TUnit)
+	rIn, rOut, rI, rN := bR.Param(0), bR.Param(1), bR.Param(2), bR.Param(3)
+	rDone := bR.NewBlock()
+	rStep := bR.NewBlock()
+	bR.CondBr(bR.LessI64(rI, rN), rStep, rDone)
+	bR.SwitchTo(rDone)
+	bR.Ret(-1)
+	bR.SwitchTo(rStep)
+	srcByte := bR.U8ArrGet(rIn, rI)
+	comp := bR.Call(compIdx, ir.TI64, srcByte)
+	dstIdx := bR.SubI64(bR.SubI64(rN, bR.ConstI64(1)), rI)
+	bR.U8ArrSet(rOut, dstIdx, comp)
+	bR.Call(rcIdx, ir.TUnit, rIn, rOut,
+		bR.AddI64(rI, bR.ConstI64(1)), rN)
+	bR.Ret(-1)
+
+	// complement(c) -> i64: A(65)↔T(84), C(67)↔G(71). Other bytes pass through.
+	bC := ir.NewBuilder("complement", []ir.Type{ir.TI64}, ir.TI64)
+	cC := bC.Param(0)
+	cIsA := bC.NewBlock()
+	cChkT := bC.NewBlock()
+	cIsT := bC.NewBlock()
+	cChkC := bC.NewBlock()
+	cIsC := bC.NewBlock()
+	cChkG := bC.NewBlock()
+	cIsG := bC.NewBlock()
+	cElse := bC.NewBlock()
+	bC.CondBr(bC.EqualI64(cC, bC.ConstI64(65)), cIsA, cChkT)
+	bC.SwitchTo(cIsA)
+	bC.Ret(bC.ConstI64(84))
+	bC.SwitchTo(cChkT)
+	bC.CondBr(bC.EqualI64(cC, bC.ConstI64(84)), cIsT, cChkC)
+	bC.SwitchTo(cIsT)
+	bC.Ret(bC.ConstI64(65))
+	bC.SwitchTo(cChkC)
+	bC.CondBr(bC.EqualI64(cC, bC.ConstI64(67)), cIsC, cChkG)
+	bC.SwitchTo(cIsC)
+	bC.Ret(bC.ConstI64(71))
+	bC.SwitchTo(cChkG)
+	bC.CondBr(bC.EqualI64(cC, bC.ConstI64(71)), cIsG, cElse)
+	bC.SwitchTo(cIsG)
+	bC.Ret(bC.ConstI64(67))
+	bC.SwitchTo(cElse)
+	bC.Ret(cC)
+
+	// sumBytes(arr, i, n, acc): tail-rec accumulator.
+	bS := ir.NewBuilder("sumBytes",
+		[]ir.Type{ir.TU8Array, ir.TI64, ir.TI64, ir.TI64}, ir.TI64)
+	sArr, sI, sN, sAcc := bS.Param(0), bS.Param(1), bS.Param(2), bS.Param(3)
+	sDone := bS.NewBlock()
+	sStep := bS.NewBlock()
+	bS.CondBr(bS.LessI64(sI, sN), sStep, sDone)
+	bS.SwitchTo(sDone)
+	bS.Ret(sAcc)
+	bS.SwitchTo(sStep)
+	cell := bS.U8ArrGet(sArr, sI)
+	rec := bS.Call(sumIdx, ir.TI64, sArr,
+		bS.AddI64(sI, bS.ConstI64(1)), sN,
+		bS.AddI64(sAcc, cell))
+	bS.Ret(rec)
+
+	return &ir.Module{Funcs: []*ir.Function{
+		bMain.Function(), bF.Function(), bB.Function(),
+		bR.Function(), bC.Function(), bS.Function(),
+	}, Main: 0}
+}

--- a/runtime/vm2/bench/bg_reverse_complement_test.go
+++ b/runtime/vm2/bench/bg_reverse_complement_test.go
@@ -1,0 +1,98 @@
+package bench
+
+import (
+	"testing"
+
+	"mochi/compiler2/corpus"
+	"mochi/compiler2/emit"
+	"mochi/compiler2/opt"
+	vm2 "mochi/runtime/vm2"
+)
+
+// goReverseComplementKernel mirrors corpus.BuildReverseComplementKernel:
+// fill a 1024-byte buffer with the repeating "ACGT" pattern, reverse
+// and complement into a second buffer (A↔T, C↔G), then sum the output
+// bytes. The arithmetic boils down to (256 * (84+71+67+65)) so the
+// test has a deterministic expected value.
+func goReverseComplementKernel() int64 {
+	const n = 1024
+	in := make([]byte, n)
+	bases := [4]byte{'A', 'C', 'G', 'T'}
+	for i := 0; i < n; i++ {
+		in[i] = bases[i%4]
+	}
+	out := make([]byte, n)
+	for i := 0; i < n; i++ {
+		var c byte
+		switch in[i] {
+		case 'A':
+			c = 'T'
+		case 'T':
+			c = 'A'
+		case 'C':
+			c = 'G'
+		case 'G':
+			c = 'C'
+		default:
+			c = in[i]
+		}
+		out[n-1-i] = c
+	}
+	var sum int64
+	for i := 0; i < n; i++ {
+		sum += int64(out[i])
+	}
+	return sum
+}
+
+func TestBGReverseComplementKernel(t *testing.T) {
+	m := corpus.BuildReverseComplementKernel()
+	for _, f := range m.Funcs {
+		opt.ConstFold(f)
+		opt.DCE(f)
+		opt.TailCall(f)
+	}
+	prog, err := emit.Compile(m)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	got, err := vm2.New(prog).Run()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !got.IsInt() {
+		t.Fatalf("expected int, got %#v", got)
+	}
+	want := goReverseComplementKernel()
+	if got.Int() != want {
+		t.Fatalf("reverse_complement kernel = %d, want %d", got.Int(), want)
+	}
+}
+
+func BenchmarkVM2_BG_ReverseComplementKernel(b *testing.B) {
+	m := corpus.BuildReverseComplementKernel()
+	for _, f := range m.Funcs {
+		opt.ConstFold(f)
+		opt.DCE(f)
+		opt.TailCall(f)
+	}
+	prog, err := emit.Compile(m)
+	if err != nil {
+		b.Fatalf("compile: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := vm2.New(prog).Run(); err != nil {
+			b.Fatalf("run: %v", err)
+		}
+	}
+}
+
+func BenchmarkGo_BG_ReverseComplementKernel(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = goReverseComplementKernel()
+	}
+}

--- a/website/docs/mep/mep-0037.md
+++ b/website/docs/mep/mep-0037.md
@@ -232,6 +232,19 @@ These are the launch numbers, not the destination. The headline goal in the abst
 
 n_body lands closer to spectral_norm's ratio than expected because the recursive inner loop (six `OpCall` round-trips per body pair, 10 pairs per step) is dispatch-bound, not arithmetic-bound. The follow-up phases (JIT lowering for float ops, bounds-check elision on hot array accesses, FMA pattern matching in emit) close the gap; the data above is the starting point.
 
+## Appendix B. Phase 3 baseline (reverse_complement kernel)
+
+Same host (Apple M4, `-benchtime=3s`). The kernel synthesizes 1024 bytes of `ACGT` repeating, reverses-and-complements into a second buffer (A↔T, C↔G via a 4-way conditional), then sums the output. Two `OpNewU8Array` allocations and a chain of `OpTailCallSelf` loops do the work; per-byte we pay one `Call`/`Return` into `baseFor` (fill) and one into `complement` (rcLoop), plus the `OpU8ArrGet` / `OpU8ArrSet` dispatches.
+
+| Benchmark | ns/op | B/op | allocs/op | vm2 / Go |
+|-----------|------:|-----:|----------:|---------:|
+| BenchmarkVM2_BG_ReverseComplementKernel | 193,199 | 648,816 | 22 | 171x |
+| BenchmarkGo_BG_ReverseComplementKernel  | 1,132 | 0 | 0 | 1.0x |
+
+The 171x gap is wider than the phase-1 float ratios for two reasons specific to byte work. First, `complement` is a per-byte function call in the IR (no inline expansion). Go's compiled peer keeps the same logic in a single `switch` that the SSA backend turns into a balanced branch tree without a frame transition. Second, the kernel allocates two 1024-byte `vmU8Array` Cells per Run; Go's reference allocates the equivalent `make([]byte, 1024)` once and the bench loop's allocator hits the bump-allocator fast path almost entirely.
+
+Both of those gaps are precisely what the Phase 3 follow-ups in §3.5 propose: a `vmBytes` view subsystem (slice-without-copy, plus `OpStdoutWriteBytes` for streaming output) and an emit-side fast path that inlines small leaf functions like `complement` into the calling frame. Those land in a subsequent MEP rather than this one; the data above is the measurement that motivates them.
+
 ## Open Questions
 
 1. **Inline float Cell vs `Obj`-carried float64 array Cells when N=1.** A single float result fits in `CFloat`'s NaN-box; a `*vmF64Array` of length 1 pays a heap allocation for nothing. We may want a fast-path `OpF64ArrGet` that returns `CFloat` directly (no boxed temporary). Phase 1 picks the naive form; profile evidence decides whether the fast-path is worth adding.


### PR DESCRIPTION
## Summary

- Adds `BuildReverseComplementKernel` (corpus) + matching Go reference and bench. 6 IR functions, two U8Array buffers, tail-rec loops, deterministic sum.
- Updates MEP-37 Appendix B with the baseline number: VM2 193,199 ns/op vs Go 1,132 ns/op = 171x on M4.
- The gap is wider than the float kernels because per-byte `complement` is a `Call`/`Return` round-trip; spec §3.5 attributes that to the absence of a vmBytes view + leaf-inline pass, both routed to a follow-up MEP.

Tracks #21588.

## Test plan

- [x] `go test ./runtime/vm2/bench/ -run TestBGReverseComplementKernel`
- [x] `go test ./compiler2/... ./runtime/vm2/...` (no regressions)
- [x] `go test ./runtime/jit/...` (no regressions; U8Arr ops were already in the deopt whitelist from phase 1)