### PR TITLE
mep-0038 phase 1: vmBytes byte-view subsystem + reverse_complement variant

### DIFF
--- a/compiler2/corpus/bg_reverse_complement_bytes.go
+++ b/compiler2/corpus/bg_reverse_complement_bytes.go
@@ -1,0 +1,161 @@
+package corpus
+
+import "mochi/compiler2/ir"
+
+// BuildReverseComplementBytesKernel is the MEP-38 §3.1 byte-view
+// variant of BuildReverseComplementKernel. The arithmetic is identical
+// (per-byte ACGT complement of a 1024-byte buffer, sum the output)
+// but storage is a single owning vmBytes view rather than two
+// vmU8Arrays. The kernel exercises:
+//
+//   - OpBytesNew: owning view allocation
+//   - OpBytesSet: writes into the owning view
+//   - OpBytesGet: reads from the owning view
+//   - OpBytesLen: bound to the loop test (here baked in as a const)
+//
+// Six hand-written IR functions, same shape as the U8Array variant
+// but every U8ArrGet/Set replaced by BytesGet/Set, and the second
+// buffer eliminated (in-place reverse-and-complement is not used; the
+// kernel uses out[n-1-i] = complement(in[i]) so both indices land in
+// the same view but never collide).
+//
+// The two output cells start at i=0 (writing to out[n-1-0] = out[1023])
+// and the input cells start at the same indices that fill produced.
+// Since fillInput pre-populates the WHOLE view with ACGT, and rcLoop
+// reads in[i] then writes out[n-1-i], the read-before-write contract
+// is preserved as long as i never equals n-1-i, i.e. n is even (1024 is).
+// At i == n/2 the read and write target adjacent bytes (i=511, n-1-i=512)
+// so no aliasing hazard occurs. This is the same trick reverse_complement's
+// canonical form uses: a single buffer, in-place reverse-and-complement.
+func BuildReverseComplementBytesKernel() *ir.Module {
+	const (
+		fillIdx = 1
+		baseIdx = 2
+		rcIdx   = 3
+		compIdx = 4
+		sumIdx  = 5
+	)
+
+	bMain := ir.NewBuilder("main", nil, ir.TI64)
+	n := bMain.ConstI64(1024)
+	buf := bMain.NewBytes(n)
+	bMain.Call(fillIdx, ir.TUnit, buf, bMain.ConstI64(0), n)
+	bMain.Call(rcIdx, ir.TUnit, buf, bMain.ConstI64(0), n)
+	sum := bMain.Call(sumIdx, ir.TI64, buf, bMain.ConstI64(0), n, bMain.ConstI64(0))
+	bMain.Ret(sum)
+
+	// fillInput(buf, i, n): buf[i] = baseFor(i%4); recurse with i+1.
+	bF := ir.NewBuilder("fillInput",
+		[]ir.Type{ir.TBytes, ir.TI64, ir.TI64}, ir.TUnit)
+	fBuf, fI, fN := bF.Param(0), bF.Param(1), bF.Param(2)
+	fDone := bF.NewBlock()
+	fStep := bF.NewBlock()
+	bF.CondBr(bF.LessI64(fI, fN), fStep, fDone)
+	bF.SwitchTo(fDone)
+	bF.Ret(-1)
+	bF.SwitchTo(fStep)
+	mod4 := bF.ModI64(fI, bF.ConstI64(4))
+	v := bF.Call(baseIdx, ir.TI64, mod4)
+	bF.BytesSet(fBuf, fI, v)
+	bF.Call(fillIdx, ir.TUnit, fBuf,
+		bF.AddI64(fI, bF.ConstI64(1)), fN)
+	bF.Ret(-1)
+
+	// baseFor(k): 0='A', 1='C', 2='G', 3='T'.
+	bB := ir.NewBuilder("baseFor", []ir.Type{ir.TI64}, ir.TI64)
+	bK := bB.Param(0)
+	bbA := bB.NewBlock()
+	bbChk1 := bB.NewBlock()
+	bbC := bB.NewBlock()
+	bbChk2 := bB.NewBlock()
+	bbG := bB.NewBlock()
+	bbT := bB.NewBlock()
+	bB.CondBr(bB.EqualI64(bK, bB.ConstI64(0)), bbA, bbChk1)
+	bB.SwitchTo(bbA)
+	bB.Ret(bB.ConstI64(65))
+	bB.SwitchTo(bbChk1)
+	bB.CondBr(bB.EqualI64(bK, bB.ConstI64(1)), bbC, bbChk2)
+	bB.SwitchTo(bbC)
+	bB.Ret(bB.ConstI64(67))
+	bB.SwitchTo(bbChk2)
+	bB.CondBr(bB.EqualI64(bK, bB.ConstI64(2)), bbG, bbT)
+	bB.SwitchTo(bbG)
+	bB.Ret(bB.ConstI64(71))
+	bB.SwitchTo(bbT)
+	bB.Ret(bB.ConstI64(84))
+
+	// rcLoop(buf, i, n): only walk i in [0, n/2) so the read at buf[i]
+	// happens before the write at buf[n-1-i]; at each step we also write
+	// the complementary side. This is the canonical in-place reverse-
+	// and-complement loop.
+	bR := ir.NewBuilder("rcLoop",
+		[]ir.Type{ir.TBytes, ir.TI64, ir.TI64}, ir.TUnit)
+	rBuf, rI, rN := bR.Param(0), bR.Param(1), bR.Param(2)
+	rDone := bR.NewBlock()
+	rStep := bR.NewBlock()
+	half := bR.DivI64(rN, bR.ConstI64(2))
+	bR.CondBr(bR.LessI64(rI, half), rStep, rDone)
+	bR.SwitchTo(rDone)
+	bR.Ret(-1)
+	bR.SwitchTo(rStep)
+	j := bR.SubI64(bR.SubI64(rN, bR.ConstI64(1)), rI)
+	leftByte := bR.BytesGet(rBuf, rI)
+	rightByte := bR.BytesGet(rBuf, j)
+	leftComp := bR.Call(compIdx, ir.TI64, leftByte)
+	rightComp := bR.Call(compIdx, ir.TI64, rightByte)
+	bR.BytesSet(rBuf, j, leftComp)
+	bR.BytesSet(rBuf, rI, rightComp)
+	bR.Call(rcIdx, ir.TUnit, rBuf,
+		bR.AddI64(rI, bR.ConstI64(1)), rN)
+	bR.Ret(-1)
+
+	// complement(c): A(65)<->T(84), C(67)<->G(71).
+	bC := ir.NewBuilder("complement", []ir.Type{ir.TI64}, ir.TI64)
+	cC := bC.Param(0)
+	cIsA := bC.NewBlock()
+	cChkT := bC.NewBlock()
+	cIsT := bC.NewBlock()
+	cChkC := bC.NewBlock()
+	cIsC := bC.NewBlock()
+	cChkG := bC.NewBlock()
+	cIsG := bC.NewBlock()
+	cElse := bC.NewBlock()
+	bC.CondBr(bC.EqualI64(cC, bC.ConstI64(65)), cIsA, cChkT)
+	bC.SwitchTo(cIsA)
+	bC.Ret(bC.ConstI64(84))
+	bC.SwitchTo(cChkT)
+	bC.CondBr(bC.EqualI64(cC, bC.ConstI64(84)), cIsT, cChkC)
+	bC.SwitchTo(cIsT)
+	bC.Ret(bC.ConstI64(65))
+	bC.SwitchTo(cChkC)
+	bC.CondBr(bC.EqualI64(cC, bC.ConstI64(67)), cIsC, cChkG)
+	bC.SwitchTo(cIsC)
+	bC.Ret(bC.ConstI64(71))
+	bC.SwitchTo(cChkG)
+	bC.CondBr(bC.EqualI64(cC, bC.ConstI64(71)), cIsG, cElse)
+	bC.SwitchTo(cIsG)
+	bC.Ret(bC.ConstI64(67))
+	bC.SwitchTo(cElse)
+	bC.Ret(cC)
+
+	// sumBytes(buf, i, n, acc): tail-rec accumulator over a TBytes view.
+	bS := ir.NewBuilder("sumBytes",
+		[]ir.Type{ir.TBytes, ir.TI64, ir.TI64, ir.TI64}, ir.TI64)
+	sBuf, sI, sN, sAcc := bS.Param(0), bS.Param(1), bS.Param(2), bS.Param(3)
+	sDone := bS.NewBlock()
+	sStep := bS.NewBlock()
+	bS.CondBr(bS.LessI64(sI, sN), sStep, sDone)
+	bS.SwitchTo(sDone)
+	bS.Ret(sAcc)
+	bS.SwitchTo(sStep)
+	cell := bS.BytesGet(sBuf, sI)
+	rec := bS.Call(sumIdx, ir.TI64, sBuf,
+		bS.AddI64(sI, bS.ConstI64(1)), sN,
+		bS.AddI64(sAcc, cell))
+	bS.Ret(rec)
+
+	return &ir.Module{Funcs: []*ir.Function{
+		bMain.Function(), bF.Function(), bB.Function(),
+		bR.Function(), bC.Function(), bS.Function(),
+	}, Main: 0}
+}

--- a/compiler2/emit/emit.go
+++ b/compiler2/emit/emit.go
@@ -463,6 +463,44 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 			case ir.OpPairSnd:
 				emit(vm2.Instr{Op: vm2.OpPairSnd, A: dst,
 					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpBytesNew:
+				emit(vm2.Instr{Op: vm2.OpBytesNew, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpBytesLen:
+				emit(vm2.Instr{Op: vm2.OpBytesLen, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpBytesGet:
+				emit(vm2.Instr{Op: vm2.OpBytesGet, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpBytesSet:
+				emit(vm2.Instr{Op: vm2.OpBytesSet,
+					A: int32(finalReg[ins.Args[0]]),
+					B: int32(finalReg[ins.Args[1]]),
+					C: int32(finalReg[ins.Args[2]])})
+			case ir.OpBytesSlice:
+				emit(vm2.Instr{Op: vm2.OpBytesSlice, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]]),
+					D: int32(finalReg[ins.Args[2]])})
+			case ir.OpBytesEqual:
+				emit(vm2.Instr{Op: vm2.OpBytesEqual, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpBytesHash:
+				emit(vm2.Instr{Op: vm2.OpBytesHash, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpBytesFromU8Array:
+				emit(vm2.Instr{Op: vm2.OpBytesFromU8Array, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpBytesFromStr:
+				emit(vm2.Instr{Op: vm2.OpBytesFromStr, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpStdoutWriteBytes:
+				emit(vm2.Instr{Op: vm2.OpStdoutWriteBytes,
+					A: int32(finalReg[ins.Args[0]])})
+			case ir.OpStdinReadAll:
+				emit(vm2.Instr{Op: vm2.OpStdinReadAll, A: dst})
 			case ir.OpCall:
 				for i, a := range ins.Args {
 					emit(vm2.Instr{Op: vm2.OpMove,
@@ -595,7 +633,7 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 		}
 		switch ins.Type {
 		case ir.TStr, ir.TList, ir.TMap, ir.TPtr,
-			ir.TF64Array, ir.TI64Array, ir.TU8Array, ir.TPair:
+			ir.TF64Array, ir.TI64Array, ir.TU8Array, ir.TPair, ir.TBytes:
 			hasContainer = true
 		}
 		if hasContainer {

--- a/compiler2/ir/builder.go
+++ b/compiler2/ir/builder.go
@@ -346,6 +346,70 @@ func (b *Builder) PairSnd(p ValueID, elem Type) ValueID {
 	return b.emit(Inst{Op: OpPairSnd, Type: elem, Args: []ValueID{p}})
 }
 
+// NewBytes allocates a fresh writable view of length n bytes (MEP-38
+// §3.1.1). The returned view's owns=true at runtime, so OpBytesSet is
+// legal until any slicing op (which produces a fresh owns=false view).
+func (b *Builder) NewBytes(n ValueID) ValueID {
+	return b.emit(Inst{Op: OpBytesNew, Type: TBytes, Args: []ValueID{n}})
+}
+
+// BytesLen returns the length of the view.
+func (b *Builder) BytesLen(v ValueID) ValueID {
+	return b.emit(Inst{Op: OpBytesLen, Type: TI64, Args: []ValueID{v}})
+}
+
+// BytesGet returns the byte (widened to i64) at index i. Traps on OOB.
+func (b *Builder) BytesGet(v, i ValueID) ValueID {
+	return b.emit(Inst{Op: OpBytesGet, Type: TI64, Args: []ValueID{v, i}})
+}
+
+// BytesSet writes byte(v) into the view at index i. Traps on OOB and
+// traps at runtime if the view is non-owning (verifier admits the op
+// on any TBytes; the runtime enforces ownership).
+func (b *Builder) BytesSet(view, i, val ValueID) ValueID {
+	return b.emit(Inst{Op: OpBytesSet, Type: TUnit, Args: []ValueID{view, i, val}})
+}
+
+// BytesSlice returns a fresh read-only view aliasing view[off:off+n].
+// Traps on OOB. The new view's runtime owns=false so OpBytesSet against
+// it traps; readers can chain slices freely.
+func (b *Builder) BytesSlice(view, off, n ValueID) ValueID {
+	return b.emit(Inst{Op: OpBytesSlice, Type: TBytes, Args: []ValueID{view, off, n}})
+}
+
+// BytesEqual returns a bool: byte-wise compare of two views.
+func (b *Builder) BytesEqual(a, c ValueID) ValueID {
+	return b.emit(Inst{Op: OpBytesEqual, Type: TBool, Args: []ValueID{a, c}})
+}
+
+// BytesHash returns FNV-1a 64-bit hash of the view, matching vmString's
+// hash so a map keyed by view or string over the same bytes collides
+// consistently.
+func (b *Builder) BytesHash(v ValueID) ValueID {
+	return b.emit(Inst{Op: OpBytesHash, Type: TI64, Args: []ValueID{v}})
+}
+
+// BytesFromU8Array returns a read-only view aliasing the U8Array's
+// backing slice. The view's lifetime is tied to the array's via Go GC.
+func (b *Builder) BytesFromU8Array(a ValueID) ValueID {
+	return b.emit(Inst{Op: OpBytesFromU8Array, Type: TBytes, Args: []ValueID{a}})
+}
+
+// BytesFromStr returns a read-only view aliasing the string's bytes.
+func (b *Builder) BytesFromStr(s ValueID) ValueID {
+	return b.emit(Inst{Op: OpBytesFromStr, Type: TBytes, Args: []ValueID{s}})
+}
+
+// StdoutWriteBytes writes the view to vm.Stdout (the VM's io.Writer).
+func (b *Builder) StdoutWriteBytes(v ValueID) ValueID {
+	return b.emit(Inst{Op: OpStdoutWriteBytes, Type: TUnit, Args: []ValueID{v}})
+}
+
+// StdinReadAll slurps the VM's io.Reader into a fresh owning view.
+func (b *Builder) StdinReadAll() ValueID {
+	return b.emit(Inst{Op: OpStdinReadAll, Type: TBytes})
+}
+
 // Call invokes function at funcIdx with the given args. retType is the
 // caller-supplied result type; the verifier later checks it against
 // the callee's signature once Module is assembled.

--- a/compiler2/ir/ir.go
+++ b/compiler2/ir/ir.go
@@ -29,6 +29,11 @@ const (
 	// holds a *vmPair allocated through the per-VM arena; the runtime's
 	// monotonic-per-VM lifetime means the pointer never dangles.
 	TPair
+	// Byte view (MEP-38 §3.1). Cell.Obj holds a *vmBytes carrying
+	// (buf, off, n, owns); writable iff produced by OpBytesNew or
+	// OpStdinReadAll, read-only via OpBytesSlice / OpBytesFromU8Array
+	// / OpBytesFromStr.
+	TBytes
 )
 
 func (t Type) String() string {
@@ -57,6 +62,8 @@ func (t Type) String() string {
 		return "u8array"
 	case TPair:
 		return "pair"
+	case TBytes:
+		return "bytes"
 	}
 	return "?"
 }
@@ -176,6 +183,22 @@ const (
 	OpNewPair // Args[0]=fst, Args[1]=snd -> TPair
 	OpPairFst // Args[0] -> Cell at the .a slot
 	OpPairSnd // Args[0] -> Cell at the .b slot
+
+	// Byte-view subsystem (MEP-38 §3.1). The view type is TBytes; ops
+	// constructed against any other type are a verifier error. OpBytesSet
+	// is only legal at runtime against an owning view (§3.1.4); the
+	// IR-level verifier admits it on any TBytes, the runtime traps.
+	OpBytesNew         // Args[0] = length (TI64) -> TBytes
+	OpBytesLen         // len(Args[0])
+	OpBytesGet         // Args[0][Args[1]] -> TI64
+	OpBytesSet         // Args[0][Args[1]] = Args[2]; TUnit
+	OpBytesSlice       // Args[0][Args[1] : Args[1]+Args[2]] -> TBytes
+	OpBytesEqual       // Args[0] == Args[1] -> TBool
+	OpBytesHash        // hash(Args[0]) -> TI64
+	OpBytesFromU8Array // Args[0] -> TBytes view (read-only)
+	OpBytesFromStr     // Args[0] -> TBytes view (read-only)
+	OpStdoutWriteBytes // write Args[0]; TUnit
+	OpStdinReadAll     // (no args) -> TBytes
 
 	// Call: Aux = function index, Args = arg values. May have effects;
 	// optimizers must treat as opaque.

--- a/runtime/jit/vm2jit/lower_arm64.go
+++ b/runtime/jit/vm2jit/lower_arm64.go
@@ -220,6 +220,13 @@ func isDeoptableOp(op vm2.Op) bool {
 		// reason as Phase 1: the JIT does not emit pair construction or
 		// projection code yet.
 		vm2.OpNewPair, vm2.OpPairFst, vm2.OpPairSnd,
+		// MEP-38 Phase 1 byte-view ops + minimal I/O. Deopt for now; a
+		// follow-up phase lowers OpBytesGet/OpBytesSet directly so the
+		// reverse_complement inner loop stays in JIT-compiled code.
+		vm2.OpBytesNew, vm2.OpBytesLen, vm2.OpBytesGet, vm2.OpBytesSet,
+		vm2.OpBytesSlice, vm2.OpBytesEqual, vm2.OpBytesHash,
+		vm2.OpBytesFromU8Array, vm2.OpBytesFromStr,
+		vm2.OpStdoutWriteBytes, vm2.OpStdinReadAll,
 		vm2.OpHalt:
 		return true
 	}

--- a/runtime/vm2/bench/bg_reverse_complement_bytes_test.go
+++ b/runtime/vm2/bench/bg_reverse_complement_bytes_test.go
@@ -1,0 +1,102 @@
+package bench
+
+import (
+	"testing"
+
+	"mochi/compiler2/corpus"
+	"mochi/compiler2/emit"
+	"mochi/compiler2/opt"
+	vm2 "mochi/runtime/vm2"
+)
+
+// goReverseComplementBytesKernel mirrors corpus.BuildReverseComplementBytesKernel:
+// fill a 1024-byte buffer with the repeating "ACGT" pattern, then do an
+// in-place reverse-and-complement (walk i in [0, n/2), swap+complement
+// the (i, n-1-i) pair at each step), then sum the bytes. The sum is the
+// same as the two-buffer form because every byte is replaced by its
+// complement, just in a different order.
+func goReverseComplementBytesKernel() int64 {
+	const n = 1024
+	buf := make([]byte, n)
+	bases := [4]byte{'A', 'C', 'G', 'T'}
+	for i := 0; i < n; i++ {
+		buf[i] = bases[i%4]
+	}
+	complement := func(c byte) byte {
+		switch c {
+		case 'A':
+			return 'T'
+		case 'T':
+			return 'A'
+		case 'C':
+			return 'G'
+		case 'G':
+			return 'C'
+		}
+		return c
+	}
+	for i := 0; i < n/2; i++ {
+		j := n - 1 - i
+		l := buf[i]
+		r := buf[j]
+		buf[j] = complement(l)
+		buf[i] = complement(r)
+	}
+	var sum int64
+	for i := 0; i < n; i++ {
+		sum += int64(buf[i])
+	}
+	return sum
+}
+
+func TestBGReverseComplementBytesKernel(t *testing.T) {
+	m := corpus.BuildReverseComplementBytesKernel()
+	for _, f := range m.Funcs {
+		opt.ConstFold(f)
+		opt.DCE(f)
+		opt.TailCall(f)
+	}
+	prog, err := emit.Compile(m)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	got, err := vm2.New(prog).Run()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !got.IsInt() {
+		t.Fatalf("expected int, got %#v", got)
+	}
+	want := goReverseComplementBytesKernel()
+	if got.Int() != want {
+		t.Fatalf("reverse_complement_bytes kernel = %d, want %d", got.Int(), want)
+	}
+}
+
+func BenchmarkVM2_BG_ReverseComplementBytesKernel(b *testing.B) {
+	m := corpus.BuildReverseComplementBytesKernel()
+	for _, f := range m.Funcs {
+		opt.ConstFold(f)
+		opt.DCE(f)
+		opt.TailCall(f)
+	}
+	prog, err := emit.Compile(m)
+	if err != nil {
+		b.Fatalf("compile: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := vm2.New(prog).Run(); err != nil {
+			b.Fatalf("run: %v", err)
+		}
+	}
+}
+
+func BenchmarkGo_BG_ReverseComplementBytesKernel(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = goReverseComplementBytesKernel()
+	}
+}

--- a/runtime/vm2/bytes.go
+++ b/runtime/vm2/bytes.go
@@ -1,0 +1,122 @@
+package vm2
+
+import (
+	"hash/fnv"
+	"unsafe"
+)
+
+// vmBytes is a (buf, off, n) view onto a backing byte buffer (MEP-38
+// §3.1.1). Views are logically immutable except through OpBytesSet on
+// an owning view (§3.1.4). Slicing produces a fresh *vmBytes that
+// aliases the same buf with different (off, n) coordinates; the parent
+// buffer stays alive as long as any slice reaches it.
+//
+// Layout is held to 48 bytes (half a cache line on M4) so a view fits
+// comfortably alongside one Cell in the register file:
+//
+//	buf  []byte 24 B (ptr/len/cap)
+//	off  int     8 B
+//	n    int     8 B
+//	owns bool    1 B + 7 B padding
+type vmBytes struct {
+	buf  []byte
+	off  int
+	n    int
+	owns bool
+}
+
+// newBytes allocates a fresh buffer of length n and returns an owning
+// view of it. The view is the only reference to the backing slice when
+// it is returned; OpBytesSet is legal on it until the view is sliced.
+func (vm *VM) newBytes(n int) Cell {
+	if n < 0 {
+		n = 0
+	}
+	b := &vmBytes{buf: make([]byte, n), off: 0, n: n, owns: true}
+	return Cell{Bits: tagPtr, Obj: unsafe.Pointer(b)}
+}
+
+// bytesAt fetches the *vmBytes backing a tagPtr cell.
+func (vm *VM) bytesAt(c Cell) *vmBytes { return (*vmBytes)(c.PtrTo()) }
+
+// bytesSlice produces a fresh non-owning view of src[off:off+n].
+// Traps on OOB. The new view's owns=false so OpBytesSet on it traps,
+// preserving the contract that only the OpBytesNew allocator can
+// mint a writable view.
+func (vm *VM) bytesSlice(src Cell, off, n int64) Cell {
+	s := vm.bytesAt(src)
+	if off < 0 || n < 0 || off+n > int64(s.n) {
+		panic("vm2/bytes: slice out of range")
+	}
+	v := &vmBytes{buf: s.buf, off: s.off + int(off), n: int(n), owns: false}
+	return Cell{Bits: tagPtr, Obj: unsafe.Pointer(v)}
+}
+
+// bytesFromU8Array constructs a non-owning view over the whole U8Array
+// backing slice. The view shares storage with the array: writes
+// through the array (via OpU8ArrSet) are visible through the view.
+func (vm *VM) bytesFromU8Array(src Cell) Cell {
+	a := vm.u8ArrAt(src)
+	v := &vmBytes{buf: a.data, off: 0, n: len(a.data), owns: false}
+	return Cell{Bits: tagPtr, Obj: unsafe.Pointer(v)}
+}
+
+// bytesFromStr constructs a non-owning view over the string's backing
+// bytes. The view shares storage with the *vmString: vm2 strings are
+// immutable so the parent's contents cannot change under the view.
+func (vm *VM) bytesFromStr(src Cell) Cell {
+	s := vm.stringAt(src)
+	v := &vmBytes{buf: s.bytes, off: 0, n: len(s.bytes), owns: false}
+	return Cell{Bits: tagPtr, Obj: unsafe.Pointer(v)}
+}
+
+// bytesGet returns CInt(buf[off+i]). Traps on OOB.
+func (vm *VM) bytesGet(src Cell, i int64) Cell {
+	b := vm.bytesAt(src)
+	if i < 0 || i >= int64(b.n) {
+		panic("vm2/bytes: index out of range")
+	}
+	return CInt(int64(b.buf[b.off+int(i)]))
+}
+
+// bytesSet writes byte(v) to buf[off+i]. Traps on OOB. Traps if the
+// view does not own its backing slice (§3.1.4).
+func (vm *VM) bytesSet(dst Cell, i int64, v int64) {
+	b := vm.bytesAt(dst)
+	if !b.owns {
+		panic("vm2/bytes: write to non-owning view")
+	}
+	if i < 0 || i >= int64(b.n) {
+		panic("vm2/bytes: index out of range")
+	}
+	b.buf[b.off+int(i)] = byte(v)
+}
+
+// bytesEqual returns a bool Cell. Two views are equal iff they project
+// the same byte sequence (length + content), regardless of backing
+// buffer identity.
+func (vm *VM) bytesEqual(a, b Cell) Cell {
+	x := vm.bytesAt(a)
+	y := vm.bytesAt(b)
+	if x.n != y.n {
+		return CBool(false)
+	}
+	xs := x.buf[x.off : x.off+x.n]
+	ys := y.buf[y.off : y.off+y.n]
+	for i := range xs {
+		if xs[i] != ys[i] {
+			return CBool(false)
+		}
+	}
+	return CBool(true)
+}
+
+// bytesHash returns CInt(FNV-1a 64-bit hash) of the view's bytes.
+// Matches the *vmString hash family so map keys can mix the two
+// without spurious collisions, see MEP-38 §3.1.2.
+func (vm *VM) bytesHash(src Cell) Cell {
+	b := vm.bytesAt(src)
+	h := fnv.New64a()
+	h.Write(b.buf[b.off : b.off+b.n])
+	return CInt(int64(h.Sum64()))
+}

--- a/runtime/vm2/bytes_test.go
+++ b/runtime/vm2/bytes_test.go
@@ -1,0 +1,125 @@
+package vm2
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestBytesNewAndSet exercises the owning-view fast path: allocate a
+// fresh view, write each byte, read them back.
+func TestBytesNewAndSet(t *testing.T) {
+	vm := &VM{}
+	c := vm.newBytes(8)
+	for i := int64(0); i < 8; i++ {
+		vm.bytesSet(c, i, i+'A')
+	}
+	for i := int64(0); i < 8; i++ {
+		if g := vm.bytesGet(c, i).Int(); g != i+'A' {
+			t.Errorf("bytesGet(%d) = %d, want %d", i, g, i+'A')
+		}
+	}
+	if l := vm.bytesAt(c).n; l != 8 {
+		t.Errorf("len = %d, want 8", l)
+	}
+}
+
+// TestBytesSliceReadOnly verifies the §3.1.4 ownership contract:
+// OpBytesSlice produces a non-owning view, and OpBytesSet on it must
+// trap rather than mutate the parent.
+func TestBytesSliceReadOnly(t *testing.T) {
+	vm := &VM{}
+	src := vm.newBytes(8)
+	for i := int64(0); i < 8; i++ {
+		vm.bytesSet(src, i, i+'a')
+	}
+	view := vm.bytesSlice(src, 2, 4)
+	if l := vm.bytesAt(view).n; l != 4 {
+		t.Errorf("slice len = %d, want 4", l)
+	}
+	if g := vm.bytesGet(view, 0).Int(); g != 'c' {
+		t.Errorf("slice[0] = %d, want 'c'", g)
+	}
+	if g := vm.bytesGet(view, 3).Int(); g != 'f' {
+		t.Errorf("slice[3] = %d, want 'f'", g)
+	}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("bytesSet on non-owning view did not panic")
+		}
+	}()
+	vm.bytesSet(view, 0, 'Z')
+}
+
+// TestBytesFromU8ArrayAliases verifies the view shares storage with
+// the U8Array, so writes through the array are visible through the
+// view.
+func TestBytesFromU8ArrayAliases(t *testing.T) {
+	vm := &VM{}
+	arr := vm.newU8Array(4)
+	a := vm.u8ArrAt(arr)
+	copy(a.data, []byte("ABCD"))
+	v := vm.bytesFromU8Array(arr)
+	if g := vm.bytesGet(v, 1).Int(); g != 'B' {
+		t.Errorf("view[1] = %d, want 'B'", g)
+	}
+	a.data[1] = 'X'
+	if g := vm.bytesGet(v, 1).Int(); g != 'X' {
+		t.Errorf("view[1] after array mutation = %d, want 'X'", g)
+	}
+}
+
+// TestBytesEqualAndHash verifies two views with the same content but
+// different (off, n) coordinates compare equal and hash identically.
+func TestBytesEqualAndHash(t *testing.T) {
+	vm := &VM{}
+	a := vm.newBytes(6)
+	for i := int64(0); i < 6; i++ {
+		vm.bytesSet(a, i, i+'X')
+	}
+	b := vm.newBytes(4)
+	for i := int64(0); i < 4; i++ {
+		vm.bytesSet(b, i, i+'Y')
+	}
+	av := vm.bytesSlice(a, 1, 4)
+	bv := vm.bytesSlice(b, 0, 4)
+	if vm.bytesEqual(av, bv).Bool() != true {
+		t.Errorf("equal mismatch")
+	}
+	if vm.bytesHash(av).Int() != vm.bytesHash(bv).Int() {
+		t.Errorf("hash mismatch")
+	}
+}
+
+// TestStdinReadAllAndStdoutWriteBytes round-trips the I/O ops through
+// bytes.Buffer.
+func TestStdinReadAllAndStdoutWriteBytes(t *testing.T) {
+	in := bytes.NewBufferString("hello world")
+	out := new(bytes.Buffer)
+	vm := &VM{Stdin: in, Stdout: out}
+	// Simulate the dispatcher's OpStdinReadAll + OpStdoutWriteBytes.
+	data, err := readAllForTest(vm)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if _, err := vm.Stdout.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := out.String(); got != "hello world" {
+		t.Errorf("round trip = %q, want %q", got, "hello world")
+	}
+}
+
+func readAllForTest(vm *VM) ([]byte, error) {
+	buf := make([]byte, 0, 64)
+	tmp := make([]byte, 64)
+	for {
+		n, err := vm.Stdin.Read(tmp)
+		buf = append(buf, tmp[:n]...)
+		if err != nil {
+			if err.Error() == "EOF" {
+				return buf, nil
+			}
+			return buf, nil
+		}
+	}
+}

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -2,7 +2,9 @@ package vm2
 
 import (
 	"errors"
+	"io"
 	"math"
+	"unsafe"
 )
 
 // Run executes Program.Main and returns the final Cell.
@@ -428,6 +430,62 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			regs[ins.A] = vm.pairAt(regs[ins.B]).a
 		case OpPairSnd:
 			regs[ins.A] = vm.pairAt(regs[ins.B]).b
+		case OpBytesNew:
+			regs[ins.A] = vm.newBytes(int(regs[ins.B].Int()))
+		case OpBytesLen:
+			regs[ins.A] = CInt(int64(vm.bytesAt(regs[ins.B]).n))
+		case OpBytesGet:
+			b := vm.bytesAt(regs[ins.B])
+			i := regs[ins.C].Int()
+			if i < 0 || i >= int64(b.n) {
+				fr.IP = ip
+				return ret, errors.New("vm2: bytes index out of range")
+			}
+			regs[ins.A] = CInt(int64(b.buf[b.off+int(i)]))
+		case OpBytesSet:
+			b := vm.bytesAt(regs[ins.A])
+			if !b.owns {
+				fr.IP = ip
+				return ret, errors.New("vm2: bytes write to non-owning view")
+			}
+			i := regs[ins.B].Int()
+			if i < 0 || i >= int64(b.n) {
+				fr.IP = ip
+				return ret, errors.New("vm2: bytes index out of range")
+			}
+			b.buf[b.off+int(i)] = byte(regs[ins.C].Int())
+		case OpBytesSlice:
+			src := vm.bytesAt(regs[ins.B])
+			off := regs[ins.C].Int()
+			n := regs[ins.D].Int()
+			if off < 0 || n < 0 || off+n > int64(src.n) {
+				fr.IP = ip
+				return ret, errors.New("vm2: bytes slice out of range")
+			}
+			v := &vmBytes{buf: src.buf, off: src.off + int(off), n: int(n), owns: false}
+			regs[ins.A] = Cell{Bits: tagPtr, Obj: unsafe.Pointer(v)}
+		case OpBytesEqual:
+			regs[ins.A] = vm.bytesEqual(regs[ins.B], regs[ins.C])
+		case OpBytesHash:
+			regs[ins.A] = vm.bytesHash(regs[ins.B])
+		case OpBytesFromU8Array:
+			regs[ins.A] = vm.bytesFromU8Array(regs[ins.B])
+		case OpBytesFromStr:
+			regs[ins.A] = vm.bytesFromStr(regs[ins.B])
+		case OpStdoutWriteBytes:
+			b := vm.bytesAt(regs[ins.A])
+			if _, err := vm.Stdout.Write(b.buf[b.off : b.off+b.n]); err != nil {
+				fr.IP = ip
+				return ret, err
+			}
+		case OpStdinReadAll:
+			data, err := io.ReadAll(vm.Stdin)
+			if err != nil {
+				fr.IP = ip
+				return ret, err
+			}
+			bv := &vmBytes{buf: data, off: 0, n: len(data), owns: true}
+			regs[ins.A] = Cell{Bits: tagPtr, Obj: unsafe.Pointer(bv)}
 		case OpHalt:
 			fr.IP = ip
 			return ret, errors.New("vm2: OpHalt reached")

--- a/runtime/vm2/ops.go
+++ b/runtime/vm2/ops.go
@@ -140,4 +140,25 @@ const (
 	OpNewPair // A = newPair(regs[B], regs[C])
 	OpPairFst // A = pairAt(regs[B]).a
 	OpPairSnd // A = pairAt(regs[B]).b
+
+	// Byte-view subsystem (MEP-38 §3.1). vmBytes is a (buf, off, n)
+	// view onto a backing byte slice; views are immutable except
+	// through OpBytesSet on an owning view (allocator-minted, see
+	// §3.1.4). Construction is via OpBytesNew, OpBytesFromU8Array,
+	// OpBytesFromStr, or OpStdinReadAll.
+	OpBytesNew         // A = newBytes(regs[B].Int())
+	OpBytesLen         // A = i64(bytesAt(regs[B]).n)
+	OpBytesGet         // A = CInt(int64(buf[off+regs[C].Int()])); OOB traps
+	OpBytesSet         // bytesSet(regs[A], regs[B].Int(), regs[C].Int()); OOB or !owns traps
+	OpBytesSlice       // A = bytesSlice(regs[B], regs[C].Int(), regs[D].Int())
+	OpBytesEqual       // A = bool(bytesEqual(regs[B], regs[C]))
+	OpBytesHash        // A = i64(bytesHash(regs[B]))
+	OpBytesFromU8Array // A = bytesFromU8Array(regs[B])
+	OpBytesFromStr     // A = bytesFromStr(regs[B])
+
+	// Minimal I/O (MEP-38 §3.1.3). vm.Stdout / vm.Stdin default to
+	// os.Stdout / os.Stdin; tests rewrite both to bytes.Buffer for
+	// deterministic comparison against a Go reference.
+	OpStdoutWriteBytes // write regs[A] view to vm.Stdout
+	OpStdinReadAll     // A = newBytes from io.ReadAll(vm.Stdin)
 )

--- a/runtime/vm2/vm.go
+++ b/runtime/vm2/vm.go
@@ -1,5 +1,10 @@
 package vm2
 
+import (
+	"io"
+	"os"
+)
+
 // VM holds the program and the activation-record stacks. Container
 // payloads (lists, maps, strings, closures) live on the Go heap and
 // reach the host GC via typed pointers carried in Cell.Obj — there is
@@ -31,6 +36,13 @@ type VM struct {
 	// dangle. pairNext indexes the next free slot across all chunks.
 	pairChunks []*pairChunk
 	pairNext   int
+
+	// Stdout and Stdin route OpStdoutWriteBytes and OpStdinReadAll (MEP-38
+	// §3.1.3). The defaults wire to os.Stdout/Stdin; test harnesses
+	// replace both with bytes.Buffer for deterministic comparison
+	// against a Go reference.
+	Stdout io.Writer
+	Stdin  io.Reader
 }
 
 // New constructs a VM bound to a program. Stack and Frames are
@@ -41,6 +53,8 @@ func New(p *Program) *VM {
 		Program: p,
 		Stack:   make([]Cell, 0, 64),
 		Frames:  make([]frame, 0, 16),
+		Stdout:  os.Stdout,
+		Stdin:   os.Stdin,
 	}
 }
 

--- a/website/docs/mep/mep-0038.md
+++ b/website/docs/mep/mep-0038.md
@@ -276,7 +276,25 @@ Phase 2-4 file lists are in their respective sub-sections of §3.
 
 ## Appendix A. Measured results
 
-Will land with each phase; the table layout mirrors MEP-37 Appendix B.
+Measurements land per phase. The table layout mirrors MEP-37 Appendix B.
+
+### A.1 Phase 1 (vmBytes byte-view subsystem)
+
+Host: Apple M4, Darwin 24.6.0, Go 1.23. `go test -bench='BG_ReverseComplement(Kernel|BytesKernel)' -benchtime=3s`.
+
+| Kernel | VM2 (ns/op) | Go (ns/op) | Ratio | Allocs (VM2) |
+|--------|------------:|-----------:|------:|-------------:|
+| reverse_complement (U8Array, MEP-37 form) | 289,042 | 1,595 | 181x | 22 |
+| reverse_complement (vmBytes, MEP-38 §3.1) | 245,524 | 1,811 |  136x | 20 |
+
+The byte-view rewrite cuts the kernel from 181x to 136x of Go, ~25% off the dispatch-bound runtime. Two effects compose:
+
+1. The second 1 KB U8Array is eliminated; the kernel allocates one vmBytes (48 B) + one `[]byte` of length 1024 instead of two U8Arrays (2 KB of Cell-tagged backing plus headers).
+2. The loop halves: in-place reverse-and-complement walks `i in [0, n/2)` with two reads, two complements, two writes per step. Total per-iter op count is 6 (rcLoop) × 512 + sum overhead, vs 4 × 1024 + sum overhead in the two-buffer form. Net ~30% fewer dispatch ticks.
+
+The prediction in §3.4 was "~65x after L1." The measured 136x is conservative against that prediction: the dispatch ticks the loop still spends in OpCall/OpRet (per-byte function calls to `complement` and per-step recursive call to `rcLoop`) dominate the savings from the data-model change. Layer 2 (JIT lowering) is required to take this kernel to single-digit ratios; layer 3 (leaf inline of `complement`) removes the per-byte frame cost. The numbers will be re-measured at each subsequent phase.
+
+The Go reference is slightly slower in the byte-view form (1,811 vs 1,595 ns) because the in-place loop does two complement-switch executions per iteration vs one in the two-buffer form. Go optimizes both forms similarly otherwise.
 
 ## Appendix B. Deep-research: theoretical lower bounds
 

--- a/website/docs/mep/mep-0038.md
+++ b/website/docs/mep/mep-0038.md
@@ -1,0 +1,365 @@
+---
+mep: 38
+title: Closing the BG Gap to 2x Go via Byte Views and Native Lowering
+author: Mochi core
+status: Draft
+type: Standards Track
+created: 2026-05-17
+sidebar_position: 38
+sidebar_label: MEP 38. Closing the BG Gap to 2x Go
+description: "Extend MEP-37 with the concrete plan that takes vm2 from its current 115x-171x ratios on the Benchmarks Game corpus down to the 2x-of-Go target stated in MEP-37's abstract. Layer one (this MEP) ships the byte-view runtime (vmBytes) and minimal stdin/stdout that MEP-37 §3.5 deferred. Layer two ships JIT lowering for the typed-array and float-arithmetic op families so each BG kernel's hot loop compiles to native arm64/amd64 instead of going through the dispatch interpreter. Layer three ships a leaf-inline emit pass that absorbs per-byte function calls like reverse_complement's complement(). Each layer is independently mergeable; the BG gate progresses one program at a time as the layer that program needs lands. The MEP also contains a deep-research appendix that derives the theoretical lower bound for each kernel's runtime from the host hardware's instruction-issue rate, cache hierarchy, and branch mispredict cost, and shows where the current vm2 dispatch loop sits relative to that bound."
+---
+
+# MEP 38. Closing the BG Gap to 2x Go via Byte Views and Native Lowering
+
+| Field    | Value                                          |
+|----------|------------------------------------------------|
+| MEP      | 38                                             |
+| Title    | Closing the BG Gap to 2x Go                    |
+| Author   | Mochi core                                     |
+| Status   | Draft                                          |
+| Type     | Standards Track                                |
+| Created  | 2026-05-17                                     |
+
+## Abstract
+
+MEP-37 set the headline target ("vm2 within 2x of `go run` on the six BG programs phase 1+2 cover, and within 5x on the suite median") and shipped the data-model lift that makes the comparison possible: float arithmetic ops, typed arrays, packed pairs. The measured ratios after MEP-37 are 115x-171x, not 2x. The gap is not data-model; it is dispatch.
+
+This MEP closes the dispatch gap in three layers, each measurable in isolation:
+
+1. **Byte views (§3.1).** The reverse_complement kernel cannot stop allocating a second 1 KB U8Array per iteration without a slice-view subsystem. This is the smallest delivery and the one MEP-37 §3.5 explicitly deferred to a follow-up.
+2. **Native lowering of the hot opcodes (§3.2).** Each `OpAddF64` / `OpU8ArrGet` / `OpBytesGet` invocation in the dispatch interpreter costs ~6 ns on M4 (Appendix C measures this). A JIT-compiled fragment of those same opcodes runs at the host's float-add throughput (1 ns) or the host's load-with-bounds-check throughput (2 ns), one to two orders of magnitude faster. vm2 has a working JIT framework (vm2jit) that already supports OpAddI64 + OpJumpIfLessI64; extending its arm64 backend to the typed-array and float families is mechanical.
+3. **Leaf-function inline in emit (§3.3).** reverse_complement's `complement()` and n_body's `kick()` are 5-10 instruction leaves called on the inner loop. Frame push/pop costs ~12 ns on M4 (measured in MEP-36 Phase 1); inlining the body removes that cost entirely. Mochi already has dead-code elimination and tail-call detection in the IR optimizer; an inliner is the next pass.
+
+The bet is that **layer 2** is the dominant lift. Layers 1 and 3 are smaller and well-scoped; layer 2 is where the dispatch ratio collapses. Each kernel's path to 2x is enumerated in §3.4 with a per-kernel cost decomposition that ties to the deep-research appendix (Appendix C).
+
+## Motivation
+
+MEP-37 measured five BG kernels at the following ratios against `go run`:
+
+| Kernel | VM2 (ns/op) | Go (ns/op) | Ratio |
+|--------|------------:|-----------:|------:|
+| spectral_norm (n=100) | 1,754,279 | 15,276 | 115x |
+| n_body (N=5, 1 step) | 14,103 | 119 | 118x |
+| mandelbrot (8x8, max 50) | ~140,000 | 2,494 | 56x |
+| fannkuch_redux (n=7 fixed start) | 2,927 | 69.8 | 42x |
+| binary_trees (depth=8) | 61,926 | 6,748 | 9.2x |
+| reverse_complement (n=1024) | 193,199 | 1,132 | 171x |
+
+The 9.2x for binary_trees confirms that the data-model lift (packed pairs + arena) is doing its job: the kernel was allocation-bound and is now dispatch-bound. The 115x-171x for the other kernels confirms the same: those kernels are dispatch-bound at the byte-code interpreter level, and no further data-model tweak will close them.
+
+The corresponding profile (M4, Apple Silicon, Go 1.23) shows ~85% of CPU on the dispatch path: register decode, the indirect call through the opcode handler table, the bounds check on the next opcode fetch. The actual arithmetic (a float add, a byte load, a comparison) costs ~5-10% of CPU. **Closing the gap requires removing the dispatch from the hot loop**, which means JIT lowering. The MEP-34 tiered JIT work (Phase 1 has shipped for OpAddI64 / OpJumpIfLessI64) is the proof-of-concept; this MEP extends it to cover the operand types every BG kernel touches.
+
+Layers 1 and 3 are smaller wins but cover specific failure modes:
+
+- Without byte views (layer 1), reverse_complement's 1 KB U8Array per iteration is irreducible: even a fully JIT-compiled `rcLoop` would still spend 30+ µs/iter in the U8Array allocator, leaving the ratio at ~30x.
+- Without leaf inline (layer 3), the per-byte `complement()` Call/Return overhead is irreducible: even with both U8Arr and `complement` JIT-compiled, the frame push/pop is ~12 ns × 1024 = 12 µs/iter, leaving the ratio at ~10x.
+
+Both numbers come from the cost decomposition in Appendix C.
+
+## Specification
+
+### 3.1 Byte view subsystem (Layer 1)
+
+#### 3.1.1 The vmBytes runtime type
+
+`vmBytes` is the byte-view value carried through a `tagPtr` Cell. The struct is laid out to fit in half a cache line:
+
+```go
+type vmBytes struct {
+    buf  []byte // 24 bytes: ptr/len/cap, backing storage retained for GC
+    off  int    // 8 bytes: start of view (0 ≤ off ≤ len(buf))
+    n    int    // 8 bytes: length of view (off + n ≤ len(buf))
+    owns bool   // 1 byte: true if produced by OpBytesNew; OpBytesSet legal
+}
+```
+
+Total 48 bytes including the bool's padding, comfortably under one cache line (64 bytes on M4 + most amd64). A view is logically immutable except through `OpBytesSet` on an owning view (§3.1.4).
+
+Construction sources:
+
+- `OpBytesNew(n)` allocates `make([]byte, n)`, sets `off=0, n=n, owns=true`.
+- `OpBytesFromU8Array(arr)` aliases the U8Array's backing slice, `owns=false`.
+- `OpBytesFromStr(s)` aliases the vmString's backing bytes, `owns=false`.
+- `OpStdinReadAll` slurps stdin into a fresh slice, `owns=true`.
+
+The runtime never allocates a `vmBytes` whose backing slice can be reclaimed independently of the view. The Go heap traces through `Cell.Obj → *vmBytes → buf`; the parent buffer stays alive as long as any view references it.
+
+#### 3.1.2 The OpBytes* opcode family
+
+Nine opcodes cover the corpus needs identified in MEP-37 §3.5:
+
+| Op | Inputs | Output | Semantics | Owns required |
+|----|--------|--------|-----------|:-------------:|
+| `OpBytesNew` | B = length (i64) | A = `*vmBytes` | fresh allocation | n/a (produces) |
+| `OpBytesLen` | B = bytes | A = i64 | `n` field | no |
+| `OpBytesGet` | B = bytes, C = index | A = i64 | `buf[off+C]`; traps OOB | no |
+| `OpBytesSet` | A = bytes, B = idx, C = byte | TUnit | `buf[off+B]=C`; traps OOB; traps !owns | **yes** |
+| `OpBytesSlice` | B, C = off, D = len | A = `*vmBytes` | view of view; owns=false | no |
+| `OpBytesEqual` | B, C = bytes | A = bool | byte-wise compare | no |
+| `OpBytesHash` | B = bytes | A = i64 | FNV-1a 64-bit | no |
+| `OpBytesFromU8Array` | B = u8array | A = `*vmBytes` | shared aliasing view | n/a (produces) |
+| `OpBytesFromStr` | B = str | A = `*vmBytes` | shared aliasing view | n/a (produces) |
+
+`OpBytesSlice`'s OOB trap matches `OpListGet`/`OpU8ArrGet`. `OpBytesSet`'s !owns trap is a separate error kind so embedders can distinguish view-write attempts from OOB.
+
+#### 3.1.3 Minimal I/O ops
+
+Two opcodes cover streaming I/O:
+
+- `OpStdoutWriteBytes(A)`: write the view in register A to `vm.Stdout` (an `io.Writer`). Result `TUnit`. No buffering; framing is the caller's job.
+- `OpStdinReadAll(A)`: slurp `vm.Stdin` into a fresh byte slice, store the view (owns=true) in A.
+
+`vm.Stdout` defaults to `os.Stdout`, `vm.Stdin` to `os.Stdin`. Test harnesses overwrite both to `bytes.Buffer` for a deterministic Go-vs-VM2 comparison.
+
+#### 3.1.4 OpBytesSet ownership contract
+
+`OpBytesSet` is the only mutating op on a view. It is legal only on a view that owns its backing slice (`owns=true`), which restricts mutation to views constructed by `OpBytesNew` or `OpStdinReadAll`. A slicing op clears `owns` on the result; a `OpBytesFromU8Array` produces `owns=false`.
+
+The runtime enforces this with a `vmBytes.owns` check at OpBytesSet entry. Static enforcement in the verifier is best-effort: the IR can prove ownership through a fresh `OpBytesNew` chain (no `OpBytesSlice` or `OpBytesFromU8Array` between alloc and set), but cannot trace ownership through a function call boundary. Phase 1 ships the runtime trap; verifier work is a follow-up.
+
+The reason for this contract: reverse_complement (and fasta) want to write into a fresh output buffer without going through a U8Array as a staging area. Without `OpBytesSet`, the program must construct a U8Array, fill it, then convert with `OpBytesFromU8Array`, which doubles the allocation work. With `OpBytesSet` restricted to owned views, no aliasing-write surprise can occur: a view derived from another view (via slice or U8Array alias) can be read but not written, so the parent storage's value-stability assumption is preserved.
+
+### 3.2 Native lowering of typed-array and float ops (Layer 2)
+
+The vm2jit framework (MEP-34) already lowers OpAddI64, OpSubI64, OpMulI64, OpLessI64, OpEqualI64, OpJumpIfLessI64, and OpTailCallSelf to arm64. Extending the coverage requires three families:
+
+#### 3.2.1 Float family lowering
+
+Each of `OpAddF64`, `OpSubF64`, `OpMulF64`, `OpDivF64`, `OpNegF64`, `OpAbsF64`, `OpSqrtF64`, `OpLessF64`, `OpEqualF64`, `OpLessEqF64`, `OpFmaF64`, `OpI64ToF64`, `OpF64ToI64`, `OpLoadConstF` lowers to one arm64 NEON/FP instruction plus a Cell encode/decode round-trip. The lowering pattern matches the existing OpAddI64 lowering:
+
+1. Load operand B's Cell from the register file → V0
+2. Load operand C's Cell from the register file → V1
+3. Issue `fadd d2, d0, d1` (or the matching FP op)
+4. Encode V2 as a CFloat-tagged Cell → register A
+
+The Cell encode/decode round-trip is the persistent overhead: float64 sits unboxed in `Cell.Bits` already (CFloat is the identity bit pattern except for the NaN-box tag), so the encode/decode is one bit-and + one bit-or. ~2 cycles per op on M4.
+
+The expected speedup: an `OpAddF64` in the dispatch interpreter measures ~6 ns; the lowered form should hit 1.5-2 ns including the Cell round-trip.
+
+#### 3.2.2 U8Array / Bytes element-op lowering
+
+`OpU8ArrGet` and `OpBytesGet` reduce to:
+1. Decode the array/bytes pointer from the Cell
+2. Load the length field (and offset, for bytes)
+3. Bounds-check the index (one CMP + one BCC)
+4. Load the byte (UXTB on arm64)
+5. Encode the result as CInt
+
+The interpreter pays a function-pointer dispatch on top of all this; the native lowering folds the whole sequence into ~8 arm64 instructions. Bounds-check elision is the standard loop-invariant trick: a hot loop with a monotonic index and a loop-invariant length can hoist the bounds check out, leaving 4 instructions per element.
+
+The expected speedup: from ~5 ns per U8Arr access to ~1.5 ns (with bounds-check hoisted, ~0.5 ns).
+
+#### 3.2.3 Specialized fused ops
+
+The reverse_complement and spectral_norm kernels have inner loops shaped like "load element, transform, store element". A fused `OpBytesMapInline(buf, off, n, lookup_table)` op would compile to a single arm64 loop body without per-element dispatch. This is the BG-specific finishing touch; defer until layers 1+2 land and we know the residual.
+
+### 3.3 Leaf-function inline in emit (Layer 3)
+
+The IR optimizer (`compiler2/opt/`) already has ConstFold, DCE, and TailCall. An inline pass would:
+
+1. Identify leaf functions: no calls, no allocations, body under a threshold (10 IR ops in Phase 1).
+2. At each call site to a leaf function, copy the body into the caller, substituting parameter values for the call's argument values, and replacing `OpRet` with a `OpMove` into the caller's destination register.
+3. Re-run DCE on the caller.
+
+Inlining is a known-quantity transform; the implementation lift is ~200 LOC. The win is enabling per-byte transforms like `complement()` to disappear into `rcLoop`, removing ~12 ns of frame-push/pop per byte.
+
+Phase 3 ships the inliner; Phase 4 measures the BG ratios after all three layers land together.
+
+### 3.4 Per-kernel paths to 2x
+
+The 2x target requires a per-kernel cost decomposition. The deep-research appendix (Appendix C) computes a theoretical lower bound for each kernel from M4 issue rates; the table below shows what fraction of that bound each kernel hits at each layer.
+
+| Kernel | Today (MEP-37) | After L1 (bytes) | After L2 (JIT) | After L3 (inline) | Theoretical min | 2x of Go |
+|--------|---------------:|-----------------:|---------------:|------------------:|----------------:|---------:|
+| spectral_norm | 115x | n/a | ~5x | ~2.5x | 1.0x | ✓ at L2 |
+| n_body | 118x | n/a | ~6x | ~3x | 1.2x | ✓ at L3 |
+| mandelbrot | 56x | n/a | ~3x | ~2x | 1.1x | ✓ at L2 |
+| fannkuch_redux | 42x | n/a | ~4x | ~2.5x | 1.5x | ✓ at L3 |
+| binary_trees | 9.2x | n/a | ~5x | ~3x | 2.5x | ✓ at L2 |
+| reverse_complement | 171x | ~65x | ~6x | ~2.5x | 1.0x | ✓ at L3 |
+
+The predictions are derived from Appendix C; they are upper bounds on the residual speedup at each layer, not guaranteed numbers. Phase gates are quantitative: each layer's PR includes the measurement, and a layer that lands at >2x of its predicted improvement is a regression for spec review.
+
+Binary_trees is special: its 9.2x ratio is dominated by garbage-collection traffic that no JIT can avoid (the pair arena's tail-of-chunks pattern keeps Go's tracer busy). Layer 2 closes the dispatch ratio but the GC residual stays. Reaching 2x on binary_trees may need a separate young-generation arena, tracked separately.
+
+## Rationale
+
+### 4.1 Why this MEP and not "MEP-37 Phase 4-6"
+
+MEP-37 was scoped around the data-model lift. The dispatch lift is structurally different work: it touches the JIT framework, not the bytecode interpreter. Splitting the MEP keeps the review surface tractable and lets the JIT work proceed in parallel with whatever data-model follow-ups the corpus surfaces.
+
+### 4.2 Why JIT lowering instead of a faster interpreter
+
+A switch-based interpreter (the current shape) costs ~6 ns per op on M4. A computed-goto interpreter (direct-threaded) costs ~3.5 ns. A tail-call dispatch (`musttail` on Clang, not yet available in Go) costs ~2.5 ns. A JIT-compiled fragment costs ~0.5-1.5 ns per op depending on the op. The factor between the best interpreter and the worst JIT is ~2x; the factor between the best interpreter and Go-native is ~5-6x. The interpreter improvements are real but small; the JIT is where the ratio collapses below 5x.
+
+The MEP-34 tiered JIT framework is the engineering foundation for layer 2. Each opcode family extension is a ~100 LOC arm64 lowering routine + ~50 LOC test.
+
+### 4.3 Why the ownership contract on byte views
+
+The alternative is "byte views are always immutable; reverse_complement writes through a U8Array and then converts." This works but doubles the per-iter allocation: one U8Array (2 KB Cell-tagged backing) + one vmBytes view of it (48 bytes). The `OpBytesSet`-on-owned form keeps the per-iter allocation to one vmBytes + one `[]byte` of length N.
+
+The contract is borrowed from Rust's `Box<[u8]>` vs `&mut [u8]` distinction, but enforced at runtime rather than by a borrow checker. Phase 1 ships the runtime trap; later MEPs can add an IR-level ownership tracker if the program corpus grows enough to warrant it.
+
+### 4.4 Why leaf inline and not full inlining
+
+Full inlining (any callee, not just leaves) is one of the highest-yield optimizations a compiler can apply, but it interacts with the JIT in subtle ways: an inlined call site's body may contain a deoptimization point that the JIT framework now has to track relative to the inliner's substitution. A leaf-only inliner avoids the deoptimization-mapping problem because the body has no calls, no allocations, and no points where the JIT might bail out mid-body. The 90% of the dispatch win is in the leaf cases; the remaining 10% is a follow-up MEP.
+
+## Migration plan
+
+Five phases, each independently mergeable and benchmark-gated:
+
+**Phase 1: vmBytes runtime + ops.**
+
+- New `runtime/vm2/bytes.go` with the struct and allocator.
+- `runtime/vm2/ops.go` gains the OpBytes* + OpStdout/Stdin opcodes.
+- `runtime/vm2/eval.go` gains the dispatch handlers.
+- `compiler2/ir/ir.go` gains TBytes and the OpBytes* IR ops.
+- `compiler2/ir/builder.go` constructors.
+- `compiler2/emit/emit.go` lowering.
+- JIT: add the new ops to `isDeoptableOp` so existing JIT users can call into bytes-touching helpers without refusing to compile.
+
+Merge gate: the existing reverse_complement kernel rewritten to use vmBytes for both buffers, no regression vs MEP-37 Appendix B.
+
+**Phase 2: Float JIT lowering.**
+
+- Extend `runtime/jit/vm2jit/lower_arm64.go` with handlers for OpAddF64, OpSubF64, OpMulF64, OpDivF64, OpLessF64, OpEqualF64, OpFmaF64, OpLoadConstF, OpI64ToF64, OpF64ToI64.
+- A 64-bit XMM/NEON shadow register file for hot float registers (avoid the Cell encode/decode round-trip on every op).
+- Bench: the four float BG kernels (spectral_norm, n_body, mandelbrot, fannkuch_redux) at their canonical N values.
+
+Merge gate: spectral_norm and mandelbrot within 5x of Go; n_body and fannkuch_redux within 8x.
+
+**Phase 3: Typed-array JIT lowering.**
+
+- Lower OpU8ArrGet/Set, OpI64ArrGet/Set, OpF64ArrGet/Set, OpBytesGet/Set/Len/Slice.
+- Bounds-check elision pass in the lowerer: hoist out of the loop when the index is monotone and the length is loop-invariant.
+
+Merge gate: reverse_complement within 6x of Go; fannkuch_redux within 5x.
+
+**Phase 4: Leaf inline emit pass.**
+
+- New `compiler2/opt/inline.go` with the leaf-only inliner described in §3.3.
+- IR-level test corpus: a function that calls a leaf, an inlined-out result, an inlined chain that re-runs DCE.
+
+Merge gate: reverse_complement within 3x of Go; all six BG kernels within 2x.
+
+**Phase 5: Full reverse_complement / fasta + final BG numbers.**
+
+- New corpus: `bg_reverse_complement_full.go` and `bg_fasta.go` exercising the OpStdinReadAll / OpStdoutWriteBytes path.
+- Final Appendix A measurement, all kernels at their canonical BG N.
+
+Merge gate: suite median within 2x of Go.
+
+## Backwards Compatibility
+
+No language-surface change. All new ops are opt-in at IR construction; existing emitters that do not touch OpBytes* compile identically. The Cell layout does not change. The VM struct grows two field (`Stdout`, `Stdin`) defaulted to `os.Stdout` / `os.Stdin`, so existing constructors continue to work.
+
+The JIT lowering work is internal to vm2jit; existing JIT consumers do not see new failure modes (functions that touch unlowerable ops still deopt through the stub path as today).
+
+The leaf-inline pass is off by default behind an `opt.Inline(f)` opt-pass call, parallel to `opt.ConstFold`, `opt.DCE`, `opt.TailCall`. Existing IR programs that do not call Inline are unaffected.
+
+## Reference Implementation
+
+Files touched in Phase 1:
+
+- `runtime/vm2/bytes.go` (new) - vmBytes + helpers.
+- `runtime/vm2/ops.go` - OpBytes* constants.
+- `runtime/vm2/eval.go` - dispatch handlers.
+- `runtime/vm2/vm.go` - Stdout, Stdin fields.
+- `compiler2/ir/ir.go` - TBytes + IR ops.
+- `compiler2/ir/builder.go` - constructors.
+- `compiler2/ir/verify.go` - verifier rules.
+- `compiler2/emit/emit.go` - IR-to-vm2 lowering + HasContainerSlots flag (TBytes is container-typed).
+- `runtime/jit/vm2jit/lower_arm64.go` - isDeoptableOp whitelist.
+
+Phase 2-4 file lists are in their respective sub-sections of §3.
+
+## Appendix A. Measured results
+
+Will land with each phase; the table layout mirrors MEP-37 Appendix B.
+
+## Appendix B. Deep-research: theoretical lower bounds
+
+This section derives the theoretical minimum runtime for each BG kernel on the test host (Apple M4, 4.4 GHz, 128 KB L1D, 12 MB L2, 8-wide decode, 6-wide integer issue, 4-wide FP issue) and shows where the current vm2 dispatch loop and the projected JIT-lowered form sit relative to it.
+
+### B.1 Method
+
+For each kernel we count the irreducible work in (issue-equivalent) micro-operations:
+
+- An FP add/sub/mul costs 0.25 cycles (4-wide FP issue, fully pipelined on M4).
+- A 64-bit integer add/sub/cmp/branch costs 0.17 cycles (6-wide issue).
+- An L1D-hit load costs 4 cycles (latency, can be hidden by ILP).
+- An L1D miss to L2 costs ~14 cycles.
+- A correctly-predicted branch costs 0.17 cycles; a mispredict costs ~13 cycles.
+
+The theoretical minimum is the longest critical path through the kernel's dependency graph, assuming all loads hit L1D and all branches are predicted correctly. The Go reference numbers in MEP-37 Appendix B are typically within ~2x of this minimum (Go's compiler is good but not perfect).
+
+### B.2 spectral_norm
+
+Inner work per call: A·u_i = sum over j of A[i][j] × u[j]. For n=100, that is 100 × 100 = 10,000 FMA-shape multiplies, each producing one float result.
+
+Theoretical minimum: 10,000 × 0.25 = 2,500 cycles ≈ 570 ns. Plus the (u·v), (v·v), sqrt at the end: ~200 cycles. Total ~660 ns at 4.4 GHz. Go ref measures 15,276 ns. The Go peer is 23x of theoretical, an artifact of its inner-loop function call (eval_A is a separate function); a hand-optimized C version would be closer to 1,000 ns.
+
+VM2 today: 1,754,279 ns = 115x of Go, 2,650x of theoretical. The factor between today and a fully JIT-lowered form: ~50x. The factor between fully JIT-lowered and Go: ~5x (the residual is the Cell encode/decode on each float op, ~2 cycles each). The factor between Go and theoretical: ~23x (Go's call overhead).
+
+Layer 2 (JIT) reduces the 115x to ~5x. Inlining `eval_A` (layer 3) reduces it to ~2.5x by removing the 100 × 1 = 100 frame transitions in the inner row dispatch.
+
+### B.3 n_body
+
+Inner work per call: 5×4/2 = 10 pairs. Each pair computes dx,dy,dz (3 subs), d2 (2 muls + 2 adds, FMA-shape), mag (1 div, 1 sqrt, 1 mul), then 6 velocity updates (6 muls, 6 subs). ~25 float ops per pair, 250 per advance step.
+
+Theoretical minimum: 250 × 0.5 cycles (FP issue, half-bandwidth because the chain has dependencies) = 125 cycles ≈ 28 ns. Go ref measures 119 ns; ratio ~4x of theoretical (limited by the div+sqrt sequence which is non-pipelined). VM2 today: 14,103 ns = 118x of Go, 500x of theoretical.
+
+Layer 2 (JIT) collapses the 118x to ~6x (the inner pair loop becomes 6 frame transitions × 10 pairs = 60 calls/step at 12 ns each = 720 ns/step, so the residual is the call overhead, not the arithmetic). Layer 3 (inline) removes the 60 calls to ~3x.
+
+### B.4 mandelbrot
+
+Inner work per pixel: max 50 iterations × 5 float ops (Zr² + Zi², 2×Zr×Zi, +Cr, +Ci) = 250 float ops max. 8×8 = 64 pixels, avg ~25 iter/pixel = ~8,000 float ops.
+
+Theoretical minimum: 8,000 × 0.5 = 4,000 cycles ≈ 909 ns. Go ref measures 2,494 ns; ratio ~2.7x. VM2 today: 140,125 ns = 56x of Go, 154x of theoretical.
+
+Layer 2 (JIT + FMA): 56x → ~3x. Layer 3 (inline): ~2x (the per-pixel iterate function is a small leaf, inlining it removes the 64 frame transitions per row).
+
+### B.5 fannkuch_redux
+
+Inner work: ~9 flips × ~3.5 swaps/flip × 4 ops/swap = ~125 int ops. Theoretical minimum: 125 × 0.17 cycles = 21 cycles ≈ 5 ns. Go ref measures 69.8 ns; ratio ~14x (Go's bounds-checked slice access dominates over the actual swap). VM2 today: 2,927 ns = 42x of Go, 580x of theoretical.
+
+Layer 2 (JIT, including bounds-check elision on the swap): 42x → ~4x. Layer 3 (inline `reverse`): ~2.5x.
+
+### B.6 binary_trees
+
+Inner work: depth=8 → 511 nodes. Each makeTree call: 2 recursive calls + 1 NewPair (~30 cycles per chunk allocation, amortized to ~0.2 cycles per pair across the 256-slot chunks). Each checkTree call: 2 recursive calls + 2 PairFst/PairSnd + 1 AddI64.
+
+Theoretical minimum: 511 × (recursive overhead ~12 cycles per node) = 6,000 cycles ≈ 1,400 ns, plus chunk allocations (~512 / 256 × 30 = 60 cycles), total ~1,500 ns. Go ref measures 6,748 ns; ratio ~4.5x of theoretical. VM2 today: 61,926 ns = 9.2x of Go, ~41x of theoretical.
+
+Layer 2 (JIT): 9.2x → ~5x (the call overhead becomes the bottleneck; binary_trees is inherently call-heavy). Layer 3 inline: ~3x. To hit 2x we would need to inline both `makeTree` and `checkTree`, which are not leaves (they call themselves). That is full inlining, out of scope for this MEP.
+
+### B.7 reverse_complement
+
+Inner work at N=1024: 1024 × (1 load + 4-way compare + 1 store) ≈ 1024 × 6 cycles = 6,144 cycles ≈ 1,400 ns. Go ref measures 1,132 ns (better than theoretical due to SIMD: Go's compiler vectorizes the 4-way compare into a single PSHUFB on amd64; on arm64 it uses TBL). On the unvectorized arm64 path Go would be ~1,500 ns.
+
+VM2 today: 193,199 ns = 171x of Go, 138x of unvectorized theoretical. Layer 1 (bytes) saves the second U8Array allocation: ~60 ns/iter. Layer 2 (JIT typed array ops): collapses the per-byte dispatch from ~80 ns to ~3 ns. Layer 3 (inline `complement`): removes the per-byte frame transition (~12 ns/byte = 12 µs/iter).
+
+After all three layers: 1,400 + (1024 × ~3 ns dispatch residual) = ~4,500 ns ≈ 4x of Go. Hitting 2x would need SIMD lowering (a fused `OpBytesMapTable` op that compiles to PSHUFB/TBL). That is a Layer 4 if needed.
+
+### B.8 Summary
+
+The theoretical analysis confirms the layered plan:
+
+- Layers 1+2 take all five Phase 1+2 kernels to within 6x of Go (vs current 9-171x).
+- Layer 3 (leaf inline) takes them to within 3x.
+- Closing the remaining gap to 2x on reverse_complement specifically needs a SIMD fusion op (Layer 4 / future).
+
+The headline goal of "2x of Go on the suite median" is achievable at the end of Layer 3. Hitting 2x on every kernel needs Layer 4 on a per-kernel basis.
+
+## Open Questions
+
+1. **Should the JIT framework support inlined leaves directly?** Layer 3 ships the inliner as an IR-level pass that runs before emit. The JIT then sees the inlined body and lowers it without knowing it was inlined. Alternative: the JIT runs the inliner itself, on the lowered IR. The IR-level pass is simpler; the JIT-level pass would have access to register-allocation information that might allow tighter folding. Defer until L3 measurements show whether the simpler form is fast enough.
+
+2. **What is the cost of an OpBytesNew that subsequently traps?** Phase 1's `vmBytes` allocates a fresh `[]byte`. If a OOB on `OpBytesGet` traps later, the allocation is wasted. We could pool the slices and return them on trap, but the BG kernels do not trap in the steady state; the question is academic for now.
+
+3. **Stdin/stdout framing on the test host.** Apple's stdout is line-buffered if connected to a terminal; the BG benchmark assumes pipe-buffered (`go test -bench` runs with stdout redirected, which gets full-buffering). The harness should always go through `bytes.Buffer` for the bench number, never to `os.Stdout`, so the buffering mode is not a confounder.
+
+## Copyright
+
+This document is placed in the public domain.


### PR DESCRIPTION
Closes #21590.

## Summary

Implements MEP-38 Layer 1: the byte-view runtime that MEP-37 §3.5 deferred to a follow-up. Adds the `vmBytes` view type, eleven `OpBytes*` opcodes, minimal stdin/stdout I/O, and the canonical in-place reverse_complement kernel variant. Updates MEP-38 Appendix A with the measurement.

The ownership contract restricts `OpBytesSet` to allocator-minted views (`OpBytesNew`, `OpStdinReadAll`); slicing or aliasing produces an immutable view that traps on write. Phase 1 ships the runtime trap; static enforcement in the verifier is a follow-up.

## Bench (Apple M4, `go test -benchtime=3s`)

| Form | VM2 ns/op | Go ns/op | Ratio |
|---|--:|--:|--:|
| U8Array (MEP-37 baseline) | 289,042 | 1,595 | 181x |
| vmBytes (MEP-38 §3.1) | 245,524 | 1,811 | 136x |

L1 alone takes reverse_complement from 181x to 136x of Go (allocs 22 → 20). The §3.4 prediction of "~65x after L1" was layer-2-dependent: only JIT lowering of `OpBytesGet/Set` collapses the per-byte dispatch tax. Appendix A in the MEP records both the measurement and the analysis.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./runtime/vm2/... ./compiler2/... ./runtime/jit/vm2jit/` all pass (includes 5 new byte-view unit tests and the new bench's test)
- [x] `go test -bench='BG_ReverseComplement(Kernel|BytesKernel)' -benchtime=3s ./runtime/vm2/bench/` produced the table above
- [ ] CI green