### PR TITLE
mep-0038 phase 2: float JIT lowering on arm64

### DIFF
--- a/runtime/jit/vm2jit/bench_float_test.go
+++ b/runtime/jit/vm2jit/bench_float_test.go
@@ -1,0 +1,211 @@
+//go:build darwin && arm64
+
+package vm2jit_test
+
+// MEP-38 Phase 2 (§3.2.1) float microbenchmarks. Each per-op bench runs
+// a one-instruction-then-return function through the JIT (callJITRaw)
+// so the timing isolates the lowered op (plus the function prologue,
+// epilogue, and trampoline overhead, which are constant across cases).
+//
+// The hot-loop bench is the real test: a polynomial-evaluation loop
+// that does ~6 float ops per iteration. The interpreter baseline runs
+// the same shape through vm2.Run().
+
+import (
+	"testing"
+
+	"mochi/runtime/jit/vm2jit"
+	"mochi/runtime/vm2"
+)
+
+// --- per-op float microbenchmarks (JIT only) ---
+
+func BenchmarkJITOpAddF(b *testing.B) {
+	fn := &vm2.Function{Name: "op_addf", NumRegs: 2, Code: []vm2.Instr{
+		{Op: vm2.OpAddF64, A: 0, B: 0, C: 1}, {Op: vm2.OpReturn, A: 0},
+	}}
+	benchOp(b, fn, func(r []vm2.Cell) { r[0] = vm2.CFloat(1.5); r[1] = vm2.CFloat(2.5) })
+}
+
+func BenchmarkJITOpMulF(b *testing.B) {
+	fn := &vm2.Function{Name: "op_mulf", NumRegs: 2, Code: []vm2.Instr{
+		{Op: vm2.OpMulF64, A: 0, B: 0, C: 1}, {Op: vm2.OpReturn, A: 0},
+	}}
+	benchOp(b, fn, func(r []vm2.Cell) { r[0] = vm2.CFloat(1.5); r[1] = vm2.CFloat(2.5) })
+}
+
+func BenchmarkJITOpDivF(b *testing.B) {
+	fn := &vm2.Function{Name: "op_divf", NumRegs: 2, Code: []vm2.Instr{
+		{Op: vm2.OpDivF64, A: 0, B: 0, C: 1}, {Op: vm2.OpReturn, A: 0},
+	}}
+	benchOp(b, fn, func(r []vm2.Cell) { r[0] = vm2.CFloat(1.5); r[1] = vm2.CFloat(2.5) })
+}
+
+func BenchmarkJITOpSqrtF(b *testing.B) {
+	fn := &vm2.Function{Name: "op_sqrtf", NumRegs: 2, Code: []vm2.Instr{
+		{Op: vm2.OpSqrtF64, A: 1, B: 0}, {Op: vm2.OpReturn, A: 1},
+	}}
+	benchOp(b, fn, func(r []vm2.Cell) { r[0] = vm2.CFloat(2.0) })
+}
+
+func BenchmarkJITOpFmaF(b *testing.B) {
+	fn := &vm2.Function{Name: "op_fmaf", NumRegs: 4, Code: []vm2.Instr{
+		{Op: vm2.OpFmaF64, A: 3, B: 0, C: 1, D: 2}, {Op: vm2.OpReturn, A: 3},
+	}}
+	benchOp(b, fn, func(r []vm2.Cell) {
+		r[0] = vm2.CFloat(1.5)
+		r[1] = vm2.CFloat(2.5)
+		r[2] = vm2.CFloat(0.75)
+	})
+}
+
+// --- per-op interpreter baselines (for ratio reporting) ---
+
+// makeF64BinopInterpProg builds a single-op interpreter Program whose
+// main function loads two float constants, applies op, and returns.
+func makeF64BinopInterpProg(op vm2.Op, a, c float64) *vm2.Program {
+	fn := &vm2.Function{
+		Name: "interp_binop", NumRegs: 2,
+		Consts: []vm2.Cell{vm2.CFloat(a), vm2.CFloat(c)},
+		Code: []vm2.Instr{
+			{Op: vm2.OpLoadConstF, A: 0, B: 0},
+			{Op: vm2.OpLoadConstF, A: 1, B: 1},
+			{Op: op, A: 0, B: 0, C: 1},
+			{Op: vm2.OpReturn, A: 0},
+		},
+	}
+	return &vm2.Program{Funcs: []*vm2.Function{fn}, Main: 0}
+}
+
+func BenchmarkInterpOpAddF(b *testing.B) {
+	prog := makeF64BinopInterpProg(vm2.OpAddF64, 1.5, 2.5)
+	vm := vm2.New(prog)
+	b.ResetTimer()
+	for range b.N {
+		_, _ = vm.Run()
+	}
+}
+
+func BenchmarkInterpOpMulF(b *testing.B) {
+	prog := makeF64BinopInterpProg(vm2.OpMulF64, 1.5, 2.5)
+	vm := vm2.New(prog)
+	b.ResetTimer()
+	for range b.N {
+		_, _ = vm.Run()
+	}
+}
+
+// --- hot-loop float bench ---
+//
+// polyHotFn computes the polynomial sum_{i=0..n} (a*i + b)*(c*i + d) /
+// (e + f*i) over a loop of n iterations. The body is six float ops
+// (mul, add, mul, add, div, add) plus the loop counter. Sized so the
+// loop dominates the prologue/epilogue cost.
+//
+// Registers (within JIT 7-reg budget):
+//   r0 = n (loop bound, int)
+//   r1 = i (loop counter, int)
+//   r2 = acc (accumulator, float)
+//   r3 = i_f (i as float, recomputed each iter)
+//   r4 = tmp1
+//   r5 = tmp2
+//   r6 = scratch
+//
+// Loop body:
+//   i_f  = i64_to_f64(i)
+//   tmp1 = i_f * 0.5  + 1.0       (replace coefficients with consts)
+//   tmp2 = i_f * 0.25 + 2.0
+//   tmp1 = tmp1 * tmp2
+//   acc  = acc + tmp1
+//   i    = i + 1
+//   if i < n loop
+//
+// Six float ops + one int add + one branch per iteration.
+
+func polyHotFn() *vm2.Function {
+	half := vm2.CFloat(0.5)
+	one := vm2.CFloat(1.0)
+	quarter := vm2.CFloat(0.25)
+	two := vm2.CFloat(2.0)
+	return &vm2.Function{
+		Name: "poly_hot", NumRegs: 7,
+		Consts: []vm2.Cell{half, one, quarter, two},
+		Code: []vm2.Instr{
+			// 0-3: load the four constants into r3..r6 (initialized once at entry,
+			// but the JIT does not yet treat consts as hoistable (the loads
+			// are inside the loop, paying their cost each iteration).
+			{Op: vm2.OpI64ToF64, A: 3, B: 1},     // 0: i_f = i64_to_f64(i)
+			{Op: vm2.OpLoadConstF, A: 4, B: 0},   // 1: tmp1 = 0.5
+			{Op: vm2.OpMulF64, A: 4, B: 4, C: 3}, // 2: tmp1 = tmp1 * i_f
+			{Op: vm2.OpLoadConstF, A: 5, B: 1},   // 3: tmp2 = 1.0
+			{Op: vm2.OpAddF64, A: 4, B: 4, C: 5}, // 4: tmp1 = tmp1 + 1.0
+			{Op: vm2.OpLoadConstF, A: 5, B: 2},   // 5: tmp2 = 0.25
+			{Op: vm2.OpMulF64, A: 5, B: 5, C: 3}, // 6: tmp2 = tmp2 * i_f
+			{Op: vm2.OpLoadConstF, A: 6, B: 3},   // 7: scratch = 2.0
+			{Op: vm2.OpAddF64, A: 5, B: 5, C: 6}, // 8: tmp2 = tmp2 + 2.0
+			{Op: vm2.OpMulF64, A: 4, B: 4, C: 5}, // 9: tmp1 = tmp1 * tmp2
+			{Op: vm2.OpAddF64, A: 2, B: 2, C: 4}, // 10: acc = acc + tmp1
+			{Op: vm2.OpAddI64K, A: 1, B: 1, C: 1}, // 11: i = i + 1
+			{Op: vm2.OpJumpIfLessI64, A: 1, B: 0, C: 0}, // 12: if i<n goto 0
+			{Op: vm2.OpReturn, A: 2},                    // 13: return acc
+		},
+	}
+}
+
+func polyHotInterpProg(n int64) *vm2.Program {
+	fn := polyHotFn()
+	// Wrap with a prelude that initialises r0=n, r1=0, r2=0.0. Use a small
+	// trampoline function (Main=0) that loads the constants and falls through.
+	main := &vm2.Function{
+		Name: "poly_main", NumRegs: 7,
+		Consts: append([]vm2.Cell{vm2.CInt(n), vm2.CInt(0), vm2.CFloat(0)}, fn.Consts...),
+		Code: append([]vm2.Instr{
+			{Op: vm2.OpLoadConstI, A: 0, B: 0},
+			{Op: vm2.OpLoadConstI, A: 1, B: 1},
+			{Op: vm2.OpLoadConstF, A: 2, B: 2},
+		}, []vm2.Instr{
+			// Loop body, shifted by 3 instructions for the prelude.
+			{Op: vm2.OpI64ToF64, A: 3, B: 1},
+			{Op: vm2.OpLoadConstF, A: 4, B: 3},
+			{Op: vm2.OpMulF64, A: 4, B: 4, C: 3},
+			{Op: vm2.OpLoadConstF, A: 5, B: 4},
+			{Op: vm2.OpAddF64, A: 4, B: 4, C: 5},
+			{Op: vm2.OpLoadConstF, A: 5, B: 5},
+			{Op: vm2.OpMulF64, A: 5, B: 5, C: 3},
+			{Op: vm2.OpLoadConstF, A: 6, B: 6},
+			{Op: vm2.OpAddF64, A: 5, B: 5, C: 6},
+			{Op: vm2.OpMulF64, A: 4, B: 4, C: 5},
+			{Op: vm2.OpAddF64, A: 2, B: 2, C: 4},
+			{Op: vm2.OpAddI64K, A: 1, B: 1, C: 1},
+			{Op: vm2.OpJumpIfLessI64, A: 1, B: 0, C: 3},
+			{Op: vm2.OpReturn, A: 2},
+		}...),
+	}
+	return &vm2.Program{Funcs: []*vm2.Function{main}, Main: 0}
+}
+
+func BenchmarkJITPolyHot1k(b *testing.B) {
+	fn := polyHotFn()
+	cf, err := vm2jit.Compile(fn)
+	if err != nil {
+		b.Skipf("Compile: %v", err)
+	}
+	defer cf.Free()
+	r := regs(7)
+	b.ResetTimer()
+	for range b.N {
+		r[0] = vm2.CInt(1000)
+		r[1] = vm2.CInt(0)
+		r[2] = vm2.CFloat(0)
+		callJITRaw(fn, r)
+	}
+}
+
+func BenchmarkInterpPolyHot1k(b *testing.B) {
+	prog := polyHotInterpProg(1000)
+	vm := vm2.New(prog)
+	b.ResetTimer()
+	for range b.N {
+		_, _ = vm.Run()
+	}
+}

--- a/runtime/jit/vm2jit/lower_arm64.go
+++ b/runtime/jit/vm2jit/lower_arm64.go
@@ -97,6 +97,104 @@ func lsrImm(xd, xn, shift uint32) uint32 {
 	return 0xD340FC00 | ((shift & 0x3F) << 16) | ((xn & 0x1F) << 5) | (xd & 0x1F)
 }
 
+// --- AArch64 NEON / FP encoders (MEP-38 §3.2.1 float JIT lowering) ---
+//
+// Float Cells store the float64 bits directly in Cell.Bits (the
+// IsFloat predicate is `Bits & 0xFFFF0000_00000000 < 0x7FFB0000_00000000`,
+// matched by every normal/subnormal double plus the canonical qNaN
+// 0x7FF8). The JIT moves bits between GPR (xN) and FPR (dN) via FMOV,
+// performs the FP arithmetic in dN, and stores back. No tag bits are
+// applied; the bit pattern *is* the Cell. NaN bit patterns are not
+// canonicalized by the JIT (matches Go's native FP behavior and is
+// consistent with vm2's runtime which only canonicalizes at CFloat
+// construction; arithmetic on already-tagged cells preserves bits).
+
+// faddD, fsubD, fmulD, fdivD: FP data-processing (2 source), ftype=01 (double).
+// Encoding: 0 00 11110 01 1 Rm op2 10 Rn Rd, op2 in {0010,0011,0000,0001}.
+func faddD(dd, dn, dm uint32) uint32 {
+	return 0x1E602800 | ((dm & 0x1F) << 16) | ((dn & 0x1F) << 5) | (dd & 0x1F)
+}
+func fsubD(dd, dn, dm uint32) uint32 {
+	return 0x1E603800 | ((dm & 0x1F) << 16) | ((dn & 0x1F) << 5) | (dd & 0x1F)
+}
+func fmulD(dd, dn, dm uint32) uint32 {
+	return 0x1E600800 | ((dm & 0x1F) << 16) | ((dn & 0x1F) << 5) | (dd & 0x1F)
+}
+func fdivD(dd, dn, dm uint32) uint32 {
+	return 0x1E601800 | ((dm & 0x1F) << 16) | ((dn & 0x1F) << 5) | (dd & 0x1F)
+}
+
+// fabsD, fnegD, fsqrtD: FP data-processing (1 source), ftype=01 (double).
+// Encoding: 0 00 11110 01 1 opc 10000 Rn Rd, opc in {000001, 000010, 000011}.
+func fabsD(dd, dn uint32) uint32  { return 0x1E60C000 | ((dn & 0x1F) << 5) | (dd & 0x1F) }
+func fnegD(dd, dn uint32) uint32  { return 0x1E614000 | ((dn & 0x1F) << 5) | (dd & 0x1F) }
+func fsqrtD(dd, dn uint32) uint32 { return 0x1E61C000 | ((dn & 0x1F) << 5) | (dd & 0x1F) }
+
+// fcmpD: FCMP Dn, Dm, ftype=01. Sets PSTATE.NZCV; no Rd field.
+func fcmpD(dn, dm uint32) uint32 {
+	return 0x1E602000 | ((dm & 0x1F) << 16) | ((dn & 0x1F) << 5)
+}
+
+// fmovDX: FMOV Xd, Dn (bit-pattern copy double → 64-bit GPR, no convert).
+// fmovXD: FMOV Dd, Xn (bit-pattern copy 64-bit GPR → double, no convert).
+// sf=1, ftype=01, rmode=00, opcode=110 (DtoX) / 111 (XtoD).
+func fmovDX(xd, dn uint32) uint32 { return 0x9E660000 | ((dn & 0x1F) << 5) | (xd & 0x1F) }
+func fmovXD(dd, xn uint32) uint32 { return 0x9E670000 | ((xn & 0x1F) << 5) | (dd & 0x1F) }
+
+// scvtfD: SCVTF Dd, Xn, signed 64-bit int to double.
+// fcvtzsD: FCVTZS Xd, Dn, double to signed 64-bit int (round toward zero).
+func scvtfD(dd, xn uint32) uint32  { return 0x9E620000 | ((xn & 0x1F) << 5) | (dd & 0x1F) }
+func fcvtzsD(xd, dn uint32) uint32 { return 0x9E780000 | ((dn & 0x1F) << 5) | (xd & 0x1F) }
+
+// fmaddD: FMADD Dd, Dn, Dm, Da → Dd = Da + Dn*Dm. ftype=01, o2=0, o0=0.
+// Maps OpFmaF64(A = B*C + D) with Dd=A, Dn=B, Dm=C, Da=D.
+func fmaddD(dd, dn, dm, da uint32) uint32 {
+	return 0x1F400000 | ((dm & 0x1F) << 16) | ((da & 0x1F) << 10) | ((dn & 0x1F) << 5) | (dd & 0x1F)
+}
+
+// csetMI / csetLS: CSET aliases for ordered float comparisons.
+// CSET Xd, MI  = CSINC Xd, XZR, XZR, NOT(MI)=PL.  cond field 0x5.
+// CSET Xd, LS  = CSINC Xd, XZR, XZR, NOT(LS)=HI.  cond field 0x8.
+// MI is true after FCMP iff Vn < Vm and ordered (NaN sets V=1, clears N).
+// LS is true after FCMP iff Vn <= Vm and ordered (NaN sets C=1, Z=0; LS = !C || Z, so unordered → false).
+func csetMI(xd uint32) uint32 { return 0x9A9F07E0 | (0x5 << 12) | (xd & 0x1F) }
+func csetLS(xd uint32) uint32 { return 0x9A9F07E0 | (0x8 << 12) | (xd & 0x1F) }
+
+// --- FP emit helpers ---
+
+// emitBinopF64 emits the 4-instruction sequence for a binary FP op:
+// fmov d0, xB; fmov d1, xC; fop d2, d0, d1; fmov xA, d2.
+func emitBinopF64(xA, xB, xC uint32, op func(dd, dn, dm uint32) uint32) []uint32 {
+	return []uint32{
+		fmovXD(0, xB), // d0 = bits(B)
+		fmovXD(1, xC), // d1 = bits(C)
+		op(2, 0, 1),   // d2 = op(d0, d1)
+		fmovDX(xA, 2), // xA = bits(d2)
+	}
+}
+
+// emitUnopF64 emits: fmov d0, xB; fop d1, d0; fmov xA, d1.
+func emitUnopF64(xA, xB uint32, op func(dd, dn uint32) uint32) []uint32 {
+	return []uint32{
+		fmovXD(0, xB),
+		op(1, 0),
+		fmovDX(xA, 1),
+	}
+}
+
+// emitCmpBoolF64 emits the 6-instruction sequence for a float comparison
+// producing a bool Cell: fmov + fmov + fcmp + cset + movzTagBool + orr.
+func emitCmpBoolF64(xA, xB, xC uint32, cset func(uint32) uint32) []uint32 {
+	return []uint32{
+		fmovXD(0, xB),
+		fmovXD(1, xC),
+		fcmpD(0, 1),
+		cset(8),
+		movzTagBool(),     // x17 = tagBool
+		orrReg(xA, 8, 17), // xA  = x8 | tagBool
+	}
+}
+
 // movzTagInt emits MOVZ x16, #0xFFFC, LSL#48, loading tagInt into x16.
 func movzTagInt() uint32 { return movz(16, 0xFFFC, 3) }
 
@@ -173,6 +271,26 @@ func instrWordCountARM64(fn *vm2.Function, ins vm2.Instr) (int, error) {
 	case vm2.OpJumpIfLessI64, vm2.OpJumpIfLessEqI64, vm2.OpJumpIfGreaterI64,
 		vm2.OpJumpIfGreaterEqI64, vm2.OpJumpIfEqualI64, vm2.OpJumpIfNotEqualI64:
 		return 4, nil // sbfx + sbfx + cmp + b.cond
+
+	// --- MEP-38 §3.2.1 float lowering ---
+	case vm2.OpLoadConstF:
+		if int(ins.B) >= len(fn.Consts) {
+			return 0, fmt.Errorf("%w: float const index %d out of range", ErrNotImplemented, ins.B)
+		}
+		return 4, nil // movz + 3×movk (the float bits)
+	case vm2.OpAddF64, vm2.OpSubF64, vm2.OpMulF64, vm2.OpDivF64:
+		return 4, nil // fmov + fmov + fop + fmov
+	case vm2.OpNegF64, vm2.OpAbsF64, vm2.OpSqrtF64:
+		return 3, nil // fmov + fop + fmov
+	case vm2.OpLessF64, vm2.OpLessEqF64, vm2.OpEqualF64:
+		return 6, nil // fmov + fmov + fcmp + cset + movzTagBool + orr
+	case vm2.OpFmaF64:
+		return 5, nil // 3×fmov(in) + fmadd + fmov(out)
+	case vm2.OpI64ToF64:
+		return 3, nil // sbfx + scvtf + fmov
+	case vm2.OpF64ToI64:
+		return 5, nil // fmov + fcvtzs + andMask + movzTagInt + orr
+
 	case vm2.OpReturn:
 		n := fn.NumRegs
 		if n > maxRegs {
@@ -204,15 +322,10 @@ func isDeoptableOp(op vm2.Op) bool {
 		vm2.OpNewList, vm2.OpListGet, vm2.OpListSet, vm2.OpListPush, vm2.OpListAppend,
 		vm2.OpNewMap, vm2.OpMapLen, vm2.OpMapGet, vm2.OpMapHas, vm2.OpMapSet, vm2.OpMapDel,
 		vm2.OpCall, vm2.OpTailCall, vm2.OpTailCallSelf,
-		// MEP-37 Phase 1 ops deopt to the interpreter: the JIT does not
-		// emit float arithmetic or typed-array code yet; once n_body or
-		// mandelbrot benchmarks justify it, the lower_arm64 emitter
-		// gains direct float lowering and these move to the supported
-		// set.
-		vm2.OpLoadConstF, vm2.OpAddF64, vm2.OpSubF64, vm2.OpMulF64,
-		vm2.OpDivF64, vm2.OpNegF64, vm2.OpAbsF64, vm2.OpSqrtF64,
-		vm2.OpLessF64, vm2.OpLessEqF64, vm2.OpEqualF64, vm2.OpFmaF64,
-		vm2.OpI64ToF64, vm2.OpF64ToI64,
+		// MEP-38 Phase 2 (§3.2.1) lowers OpLoadConstF, OpAddF64, OpSubF64,
+		// OpMulF64, OpDivF64, OpNegF64, OpAbsF64, OpSqrtF64, OpLessF64,
+		// OpLessEqF64, OpEqualF64, OpFmaF64, OpI64ToF64, OpF64ToI64 to
+		// NEON FP arithmetic. They are no longer in the deopt set.
 		vm2.OpNewF64Array, vm2.OpF64ArrLen, vm2.OpF64ArrGet, vm2.OpF64ArrSet,
 		vm2.OpNewI64Array, vm2.OpI64ArrLen, vm2.OpI64ArrGet, vm2.OpI64ArrSet,
 		vm2.OpNewU8Array, vm2.OpU8ArrLen, vm2.OpU8ArrGet, vm2.OpU8ArrSet,
@@ -363,6 +476,56 @@ func lowerInstrARM64(fn *vm2.Function, idx int, ins vm2.Instr, pcMap []int) ([]u
 		return emitCmpBoolI64(xA, xB, xC, csetLE), nil
 	case vm2.OpEqualI64:
 		return emitCmpBoolI64(xA, xB, xC, csetEQ), nil
+
+	// --- MEP-38 §3.2.1 float lowering ---
+	case vm2.OpLoadConstF:
+		return movImm64(xA, int64(fn.Consts[ins.B].Bits)), nil
+	case vm2.OpAddF64:
+		return emitBinopF64(xA, xB, xC, faddD), nil
+	case vm2.OpSubF64:
+		return emitBinopF64(xA, xB, xC, fsubD), nil
+	case vm2.OpMulF64:
+		return emitBinopF64(xA, xB, xC, fmulD), nil
+	case vm2.OpDivF64:
+		return emitBinopF64(xA, xB, xC, fdivD), nil
+	case vm2.OpNegF64:
+		return emitUnopF64(xA, xB, fnegD), nil
+	case vm2.OpAbsF64:
+		return emitUnopF64(xA, xB, fabsD), nil
+	case vm2.OpSqrtF64:
+		return emitUnopF64(xA, xB, fsqrtD), nil
+	case vm2.OpLessF64:
+		return emitCmpBoolF64(xA, xB, xC, csetMI), nil
+	case vm2.OpLessEqF64:
+		return emitCmpBoolF64(xA, xB, xC, csetLS), nil
+	case vm2.OpEqualF64:
+		return emitCmpBoolF64(xA, xB, xC, csetEQ), nil
+	case vm2.OpFmaF64:
+		// A = B*C + D. FMADD Dd, Dn, Dm, Da = Da + Dn*Dm; map d0=B, d1=C, d2=D, d3=A.
+		xD := r2x(int32(ins.D))
+		return []uint32{
+			fmovXD(0, xB),
+			fmovXD(1, xC),
+			fmovXD(2, xD),
+			fmaddD(3, 0, 1, 2),
+			fmovDX(xA, 3),
+		}, nil
+	case vm2.OpI64ToF64:
+		// xB carries a tagInt Cell. Unbox to int64 (sbfx48), convert, store.
+		return []uint32{
+			sbfx48(8, xB),
+			scvtfD(0, 8),
+			fmovDX(xA, 0),
+		}, nil
+	case vm2.OpF64ToI64:
+		// xB carries float bits. Convert, mask, retag.
+		return []uint32{
+			fmovXD(0, xB),
+			fcvtzsD(8, 0),
+			andMask48(8, 8),
+			movzTagInt(),
+			orrReg(xA, 8, 16),
+		}, nil
 
 	case vm2.OpJump:
 		off, err := branchOff(0, int(ins.A), 26)

--- a/runtime/jit/vm2jit/vm2jit_float_test.go
+++ b/runtime/jit/vm2jit/vm2jit_float_test.go
@@ -1,0 +1,377 @@
+//go:build darwin && arm64
+
+package vm2jit_test
+
+import (
+	"math"
+	"testing"
+
+	"mochi/runtime/vm2"
+)
+
+// MEP-38 Phase 2 (§3.2.1): float JIT lowering correctness tests.
+// Each op gets a dedicated function that returns r0 after applying the
+// op once. The test compiles the function via vm2jit, runs it with
+// callJIT (nil VM, safe for arithmetic-only ops), and compares Cell
+// bits against the Go-native float operation.
+
+func cf(f float64) vm2.Cell { return vm2.CFloat(f) }
+
+func TestAddF64(t *testing.T) {
+	fn := &vm2.Function{
+		Name: "addf", NumRegs: 2,
+		Code: []vm2.Instr{
+			{Op: vm2.OpAddF64, A: 0, B: 0, C: 1},
+			{Op: vm2.OpReturn, A: 0},
+		},
+	}
+	compileOrSkip(t, fn)
+	for _, tc := range []struct{ a, b, want float64 }{
+		{1, 2, 3},
+		{-0.5, 0.5, 0},
+		{1e100, 1e100, 2e100},
+	} {
+		got := callJIT(fn, regs(2, cf(tc.a), cf(tc.b)))
+		if !got.IsFloat() {
+			t.Errorf("addf(%v,%v): tag mismatch, bits=%#x", tc.a, tc.b, got.Bits)
+			continue
+		}
+		if got.Float() != tc.want {
+			t.Errorf("addf(%v,%v)=%v want %v", tc.a, tc.b, got.Float(), tc.want)
+		}
+	}
+	// Verify bit-identical result for an IEEE-tricky case where 0.1+0.2 != 0.3.
+	// Use variables so Go doesn't constant-fold the right-hand side at
+	// arbitrary precision (which would mask the inexact-add).
+	a, b := 0.1, 0.2
+	got := callJIT(fn, regs(2, cf(a), cf(b)))
+	if got.Float() != a+b {
+		t.Errorf("addf(0.1,0.2)=%v want %v (Go-native)", got.Float(), a+b)
+	}
+}
+
+func TestSubF64(t *testing.T) {
+	fn := &vm2.Function{
+		Name: "subf", NumRegs: 2,
+		Code: []vm2.Instr{
+			{Op: vm2.OpSubF64, A: 0, B: 0, C: 1},
+			{Op: vm2.OpReturn, A: 0},
+		},
+	}
+	compileOrSkip(t, fn)
+	for _, tc := range []struct{ a, b, want float64 }{
+		{5, 3, 2},
+		{0, 1, -1},
+		{1.5, 0.5, 1.0},
+	} {
+		got := callJIT(fn, regs(2, cf(tc.a), cf(tc.b)))
+		if got.Float() != tc.want {
+			t.Errorf("subf(%v,%v)=%v want %v", tc.a, tc.b, got.Float(), tc.want)
+		}
+	}
+}
+
+func TestMulF64(t *testing.T) {
+	fn := &vm2.Function{
+		Name: "mulf", NumRegs: 2,
+		Code: []vm2.Instr{
+			{Op: vm2.OpMulF64, A: 0, B: 0, C: 1},
+			{Op: vm2.OpReturn, A: 0},
+		},
+	}
+	compileOrSkip(t, fn)
+	for _, tc := range []struct{ a, b, want float64 }{
+		{2, 3, 6},
+		{-2, 3, -6},
+		{0.5, 0.5, 0.25},
+	} {
+		got := callJIT(fn, regs(2, cf(tc.a), cf(tc.b)))
+		if got.Float() != tc.want {
+			t.Errorf("mulf(%v,%v)=%v want %v", tc.a, tc.b, got.Float(), tc.want)
+		}
+	}
+}
+
+func TestDivF64(t *testing.T) {
+	fn := &vm2.Function{
+		Name: "divf", NumRegs: 2,
+		Code: []vm2.Instr{
+			{Op: vm2.OpDivF64, A: 0, B: 0, C: 1},
+			{Op: vm2.OpReturn, A: 0},
+		},
+	}
+	compileOrSkip(t, fn)
+	for _, tc := range []struct{ a, b, want float64 }{
+		{6, 2, 3},
+		{1, 4, 0.25},
+		{-1, 4, -0.25},
+	} {
+		got := callJIT(fn, regs(2, cf(tc.a), cf(tc.b)))
+		if got.Float() != tc.want {
+			t.Errorf("divf(%v,%v)=%v want %v", tc.a, tc.b, got.Float(), tc.want)
+		}
+	}
+}
+
+func TestNegF64(t *testing.T) {
+	fn := &vm2.Function{
+		Name: "negf", NumRegs: 2,
+		Code: []vm2.Instr{
+			{Op: vm2.OpNegF64, A: 1, B: 0},
+			{Op: vm2.OpReturn, A: 1},
+		},
+	}
+	compileOrSkip(t, fn)
+	for _, v := range []float64{3.0, -2.5, 0, 1e100} {
+		got := callJIT(fn, regs(2, cf(v)))
+		if got.Float() != -v {
+			t.Errorf("negf(%v)=%v want %v", v, got.Float(), -v)
+		}
+	}
+}
+
+func TestAbsF64(t *testing.T) {
+	fn := &vm2.Function{
+		Name: "absf", NumRegs: 2,
+		Code: []vm2.Instr{
+			{Op: vm2.OpAbsF64, A: 1, B: 0},
+			{Op: vm2.OpReturn, A: 1},
+		},
+	}
+	compileOrSkip(t, fn)
+	for _, v := range []float64{3.0, -3.0, 0, math.Copysign(0, -1), 1e100, -1e100} {
+		got := callJIT(fn, regs(2, cf(v)))
+		if got.Float() != math.Abs(v) {
+			t.Errorf("absf(%v)=%v want %v", v, got.Float(), math.Abs(v))
+		}
+	}
+}
+
+func TestSqrtF64(t *testing.T) {
+	fn := &vm2.Function{
+		Name: "sqrtf", NumRegs: 2,
+		Code: []vm2.Instr{
+			{Op: vm2.OpSqrtF64, A: 1, B: 0},
+			{Op: vm2.OpReturn, A: 1},
+		},
+	}
+	compileOrSkip(t, fn)
+	for _, v := range []float64{0, 1, 4, 9, 2, 0.25, 1e10} {
+		got := callJIT(fn, regs(2, cf(v)))
+		if got.Float() != math.Sqrt(v) {
+			t.Errorf("sqrtf(%v)=%v want %v", v, got.Float(), math.Sqrt(v))
+		}
+	}
+}
+
+func TestLessF64(t *testing.T) {
+	fn := &vm2.Function{
+		Name: "lessf", NumRegs: 3,
+		Code: []vm2.Instr{
+			{Op: vm2.OpLessF64, A: 2, B: 0, C: 1},
+			{Op: vm2.OpReturn, A: 2},
+		},
+	}
+	compileOrSkip(t, fn)
+	nan := math.NaN()
+	for _, tc := range []struct {
+		a, b float64
+		want bool
+	}{
+		{1, 2, true},
+		{2, 1, false},
+		{1, 1, false},
+		{-1, 0, true},
+		{nan, 1, false},
+		{1, nan, false},
+		{nan, nan, false},
+	} {
+		got := callJIT(fn, regs(3, cf(tc.a), cf(tc.b)))
+		if !got.IsBool() {
+			t.Errorf("lessf(%v,%v): tag mismatch, bits=%#x", tc.a, tc.b, got.Bits)
+			continue
+		}
+		if got.Bool() != tc.want {
+			t.Errorf("lessf(%v,%v)=%v want %v", tc.a, tc.b, got.Bool(), tc.want)
+		}
+	}
+}
+
+func TestLessEqF64(t *testing.T) {
+	fn := &vm2.Function{
+		Name: "lessef", NumRegs: 3,
+		Code: []vm2.Instr{
+			{Op: vm2.OpLessEqF64, A: 2, B: 0, C: 1},
+			{Op: vm2.OpReturn, A: 2},
+		},
+	}
+	compileOrSkip(t, fn)
+	nan := math.NaN()
+	for _, tc := range []struct {
+		a, b float64
+		want bool
+	}{
+		{1, 2, true},
+		{2, 1, false},
+		{1, 1, true},
+		{nan, 1, false},
+		{1, nan, false},
+	} {
+		got := callJIT(fn, regs(3, cf(tc.a), cf(tc.b)))
+		if got.Bool() != tc.want {
+			t.Errorf("lessef(%v,%v)=%v want %v", tc.a, tc.b, got.Bool(), tc.want)
+		}
+	}
+}
+
+func TestEqualF64(t *testing.T) {
+	fn := &vm2.Function{
+		Name: "eqf", NumRegs: 3,
+		Code: []vm2.Instr{
+			{Op: vm2.OpEqualF64, A: 2, B: 0, C: 1},
+			{Op: vm2.OpReturn, A: 2},
+		},
+	}
+	compileOrSkip(t, fn)
+	nan := math.NaN()
+	for _, tc := range []struct {
+		a, b float64
+		want bool
+	}{
+		{1, 1, true},
+		{1, 2, false},
+		{0, math.Copysign(0, -1), true},
+		{nan, nan, false},
+		{nan, 1, false},
+	} {
+		got := callJIT(fn, regs(3, cf(tc.a), cf(tc.b)))
+		if got.Bool() != tc.want {
+			t.Errorf("eqf(%v,%v)=%v want %v", tc.a, tc.b, got.Bool(), tc.want)
+		}
+	}
+}
+
+func TestFmaF64(t *testing.T) {
+	fn := &vm2.Function{
+		Name: "fmaf", NumRegs: 4,
+		Code: []vm2.Instr{
+			{Op: vm2.OpFmaF64, A: 3, B: 0, C: 1, D: 2},
+			{Op: vm2.OpReturn, A: 3},
+		},
+	}
+	compileOrSkip(t, fn)
+	for _, tc := range []struct{ b, c, d, want float64 }{
+		{2, 3, 4, 10},                 // 2*3+4 = 10
+		{0.5, 0.5, 0.5, 0.75},         // 0.5*0.5+0.5 = 0.75
+		{-1, 2, 5, 3},                 // -1*2+5 = 3
+		{1, 1, 0, 1},
+	} {
+		got := callJIT(fn, regs(4, cf(tc.b), cf(tc.c), cf(tc.d)))
+		if got.Float() != tc.want {
+			t.Errorf("fmaf(%v,%v,%v)=%v want %v", tc.b, tc.c, tc.d, got.Float(), tc.want)
+		}
+	}
+}
+
+func TestI64ToF64(t *testing.T) {
+	fn := &vm2.Function{
+		Name: "i2f", NumRegs: 2,
+		Code: []vm2.Instr{
+			{Op: vm2.OpI64ToF64, A: 1, B: 0},
+			{Op: vm2.OpReturn, A: 1},
+		},
+	}
+	compileOrSkip(t, fn)
+	for _, v := range []int64{0, 1, -1, 42, -42, 1 << 30, -(1 << 30)} {
+		got := callJIT(fn, regs(2, vm2.CInt(v)))
+		if !got.IsFloat() {
+			t.Errorf("i2f(%v): tag mismatch, bits=%#x", v, got.Bits)
+			continue
+		}
+		if got.Float() != float64(v) {
+			t.Errorf("i2f(%v)=%v want %v", v, got.Float(), float64(v))
+		}
+	}
+}
+
+func TestF64ToI64(t *testing.T) {
+	fn := &vm2.Function{
+		Name: "f2i", NumRegs: 2,
+		Code: []vm2.Instr{
+			{Op: vm2.OpF64ToI64, A: 1, B: 0},
+			{Op: vm2.OpReturn, A: 1},
+		},
+	}
+	compileOrSkip(t, fn)
+	for _, tc := range []struct {
+		in   float64
+		want int64
+	}{
+		{0, 0},
+		{1.5, 1},
+		{-1.5, -1},
+		{42.9, 42},
+		{-42.9, -42},
+	} {
+		got := callJIT(fn, regs(2, cf(tc.in)))
+		if !got.IsInt() {
+			t.Errorf("f2i(%v): tag mismatch, bits=%#x", tc.in, got.Bits)
+			continue
+		}
+		if got.Int() != tc.want {
+			t.Errorf("f2i(%v)=%v want %v", tc.in, got.Int(), tc.want)
+		}
+	}
+}
+
+func TestLoadConstF(t *testing.T) {
+	want := 3.141592653589793
+	fn := &vm2.Function{
+		Name: "pi", NumRegs: 1,
+		Consts: []vm2.Cell{vm2.CFloat(want)},
+		Code: []vm2.Instr{
+			{Op: vm2.OpLoadConstF, A: 0, B: 0},
+			{Op: vm2.OpReturn, A: 0},
+		},
+	}
+	compileOrSkip(t, fn)
+	got := callJIT(fn, regs(1))
+	if !got.IsFloat() {
+		t.Fatalf("LoadConstF: tag mismatch, bits=%#x", got.Bits)
+	}
+	if got.Float() != want {
+		t.Fatalf("LoadConstF=%v want %v", got.Float(), want)
+	}
+}
+
+// TestFloatPipelineMandelLike exercises a small composed FP sequence
+// of the shape mandelbrot uses on its inner loop:
+//   tmp = zr*zr - zi*zi + cr
+// without the per-pixel branch. Verifies the JIT-emitted sequence
+// returns identical bits to the Go-native computation.
+func TestFloatPipelineMandelLike(t *testing.T) {
+	// r0 = zr, r1 = zi, r2 = cr; r3 = zr*zr; r4 = zi*zi; r3 = r3 - r4; r3 = r3 + cr.
+	fn := &vm2.Function{
+		Name: "mandel_step", NumRegs: 5,
+		Code: []vm2.Instr{
+			{Op: vm2.OpMulF64, A: 3, B: 0, C: 0},
+			{Op: vm2.OpMulF64, A: 4, B: 1, C: 1},
+			{Op: vm2.OpSubF64, A: 3, B: 3, C: 4},
+			{Op: vm2.OpAddF64, A: 3, B: 3, C: 2},
+			{Op: vm2.OpReturn, A: 3},
+		},
+	}
+	compileOrSkip(t, fn)
+	for _, tc := range []struct{ zr, zi, cr float64 }{
+		{0.5, 0.5, -0.7},
+		{1.0, 0, 0.25},
+		{-0.1, 0.1, -0.1},
+	} {
+		got := callJIT(fn, regs(5, cf(tc.zr), cf(tc.zi), cf(tc.cr)))
+		want := tc.zr*tc.zr - tc.zi*tc.zi + tc.cr
+		if got.Float() != want {
+			t.Errorf("mandel_step(%v,%v,%v)=%v want %v",
+				tc.zr, tc.zi, tc.cr, got.Float(), want)
+		}
+	}
+}

--- a/website/docs/mep/mep-0038.md
+++ b/website/docs/mep/mep-0038.md
@@ -296,6 +296,35 @@ The prediction in §3.4 was "~65x after L1." The measured 136x is conservative a
 
 The Go reference is slightly slower in the byte-view form (1,811 vs 1,595 ns) because the in-place loop does two complement-switch executions per iteration vs one in the two-buffer form. Go optimizes both forms similarly otherwise.
 
+### A.2 Phase 2 (float JIT lowering)
+
+Host: Apple M4, Darwin 24.6.0, Go 1.23. `go test -bench=... -benchtime=2s`.
+
+14 float opcodes lowered to arm64 NEON/FP: `OpLoadConstF`, `OpAddF64`, `OpSubF64`, `OpMulF64`, `OpDivF64`, `OpNegF64`, `OpAbsF64`, `OpSqrtF64`, `OpLessF64`, `OpLessEqF64`, `OpEqualF64`, `OpFmaF64`, `OpI64ToF64`, `OpF64ToI64`. 15 unit tests cover correctness including NaN-ordered semantics for the comparison ops (NaN compares false against everything).
+
+**Hot-loop microbench** (1,000-iteration polynomial loop, ~12 ops/iter: i64-to-f64 + 3 const-load + 4 mul + 3 add + 1 int inc + branch):
+
+| Engine | ns/op | Speedup |
+|--------|------:|--------:|
+| Interpreter | 26,729 | 1.0x |
+| JIT (this phase) | 3,291 | **8.1x** |
+
+This matches the §3.4 prediction (Layer 2 collapses the dispatch tax by ~6-8x) and the §B.7 cost analysis (a `OpAddF64` in the interpreter costs ~6 ns, in the JIT ~0.5-1 ns plus a fixed Cell encode/decode).
+
+**Per-op microbenches** (one float op + Return, called via the trampoline; bench dominated by trampoline overhead, so absolute numbers are not directly comparable to the hot-loop number above):
+
+| Op | JIT ns/op | Interp ns/op |
+|----|---------:|-------------:|
+| OpAddF64 | 33.6 | 20.4 |
+| OpMulF64 | 25.0 | 21.8 |
+| OpDivF64 | 25.8 | n/a |
+| OpSqrtF64 | 28.0 | n/a |
+| OpFmaF64 | 40.2 | n/a |
+
+The per-op JIT is slower than the per-op interpreter only because the trampoline call dwarfs the arithmetic; once the JIT amortizes the trampoline over many ops (the polynomial loop above) the dispatch saving dominates.
+
+**Why this does not move BG numbers yet.** All six BG kernels in MEP-37 use recursive function calls in their inner loops; `OpCall` and `OpTailCall` are still in the deopt set (the JIT does not yet inline-emit a direct branch to another JIT'd function and so must spill+return on a call). After this PR, the JIT *would* run the body of each BG function at the predicted speed; but every inner-loop call still pays the deopt-and-resume round-trip in the interpreter, which dominates. Phase 4 (leaf inline at the IR level) is what removes the calls and lets the JIT stay hot through the loop. The microbench above measures the JIT in its sweet spot (a call-free hot loop) to verify the lowering itself is sound.
+
 ## Appendix B. Deep-research: theoretical lower bounds
 
 This section derives the theoretical minimum runtime for each BG kernel on the test host (Apple M4, 4.4 GHz, 128 KB L1D, 12 MB L2, 8-wide decode, 6-wide integer issue, 4-wide FP issue) and shows where the current vm2 dispatch loop and the projected JIT-lowered form sit relative to it.


### PR DESCRIPTION
Closes #21592. Follows #21591 (Phase 1, now merged).

## Summary

Lowers 14 float opcodes from the dispatch interpreter to native arm64 NEON/FP arithmetic. Float Cells already carry float64 bits unboxed, so the lowering is a thin FMOV/FOP/FMOV shell over the FP instructions. Comparison ops use ordered-aware CSET conditions so NaN compares false consistently with Go.

The 14 lowered ops are removed from the deopt whitelist; functions that touch only float arithmetic, control flow, OpMove, and OpReturn now compile cleanly through vm2jit and run hot through the loop.

## Microbench (Apple M4, go test -benchtime=2s ./runtime/jit/vm2jit/)

Hot-loop, ~12 ops/iter, 1000 iterations:

| Engine | ns/op | Speedup |
|---|--:|--:|
| Interpreter | 26,729 | 1.0x |
| JIT (this phase) | 3,291 | 8.1x |

Matches the §3.4 / §B.7 predictions (Layer 2 collapses the dispatch tax by ~6-8x). Per-op micro-benches are trampoline-dominated and not directly comparable.

## Why this does not yet move BG kernel numbers

All six BG kernels in MEP-37 use recursive function calls in their inner loops. OpCall and OpTailCall remain in the deopt set (the JIT does not yet inline-emit a direct branch to another JIT'd function, so it must spill + return on every call). The microbench above measures the JIT in its sweet spot to verify the lowering itself is sound; closing the BG gap to 2x requires Phase 4 (leaf inline at the IR level) to remove the per-iteration calls.

## Test plan

- [x] go build ./... clean
- [x] go vet ./... clean
- [x] go test ./runtime/vm2/... ./compiler2/... ./runtime/jit/vm2jit/ all pass
- [x] 15 new float-op unit tests cover correctness (incl. NaN-ordered semantics, IEEE inexact add, mandelbrot-step pipeline)
- [x] go test -bench='JITPolyHot|InterpPolyHot' -benchtime=2s produced the 8.1x speedup above
- [ ] CI green