### PR TITLE
mep-0038 phase 4: leaf-function inline opt pass

### DIFF
--- a/compiler2/emit/emit.go
+++ b/compiler2/emit/emit.go
@@ -213,6 +213,60 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 		return len(code) - 1
 	}
 
+	// MEP-38 §3.3 leaf-inline phi resolution: lower each ir.OpPhi at the
+	// head of a block to OpMove instructions emitted at the end of each
+	// predecessor, immediately before the predecessor's terminator. The
+	// leaf inliner only produces phis whose predecessors terminate in
+	// OpBr (a single successor), so every move scheduled here lives on a
+	// non-critical edge; the assumption is enforced via a runtime check
+	// the first time a phi with a non-OpBr predecessor would be lowered.
+	phiMovesByPred := make(map[ir.BlockID][]pmove)
+	hasPhi := false
+	for _, blk := range f.Blocks {
+		for _, vid := range blk.Insts {
+			ins := f.Values[vid]
+			if ins.Op != ir.OpPhi {
+				continue
+			}
+			hasPhi = true
+			if finalReg[vid] < 0 {
+				continue
+			}
+			dstReg := int32(finalReg[vid])
+			for i, predID := range ins.AuxBlocks {
+				srcVid := ins.Args[i]
+				if finalReg[srcVid] < 0 {
+					continue
+				}
+				srcReg := int32(finalReg[srcVid])
+				phiMovesByPred[predID] = append(phiMovesByPred[predID],
+					pmove{dst: dstReg, src: srcReg})
+			}
+		}
+	}
+	// Critical-edge check: if any phi-target block has a predecessor that
+	// terminates in OpCondBr (two successors), the moves can't be safely
+	// hoisted ahead of the branch without edge splitting. Reject loudly
+	// so the caller knows to split critical edges before emit.
+	if hasPhi {
+		for _, blk := range f.Blocks {
+			if len(phiMovesByPred[blk.ID]) == 0 {
+				continue
+			}
+			term := f.Values[blk.Insts[len(blk.Insts)-1]]
+			if term.Op != ir.OpBr {
+				return nil, fmt.Errorf("emit %s: phi predecessor block %d terminates in %d, only OpBr predecessors are supported (split critical edges first)", f.Name, blk.ID, term.Op)
+			}
+		}
+	}
+	flushPhiMoves := func(predID ir.BlockID) {
+		moves := phiMovesByPred[predID]
+		if len(moves) == 0 {
+			return
+		}
+		emitParallelMoves(moves, int32(callBase), emit)
+	}
+
 	for bi := range f.Blocks {
 		blockPC[bi] = int32(len(code))
 		blk := f.Blocks[bi]
@@ -543,6 +597,7 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 					emit(vm2.Instr{Op: vm2.OpReturn, A: 0})
 				}
 			case ir.OpBr:
+				flushPhiMoves(blk.ID)
 				idx := emit(vm2.Instr{Op: vm2.OpJump})
 				pending = append(pending, pendingJump{insIdx: idx, target: ins.AuxBlocks[0], field: 'A'})
 			case ir.OpCondBr:
@@ -598,7 +653,10 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 			case ir.OpInvalid:
 				// DCE'd
 			case ir.OpPhi:
-				return nil, fmt.Errorf("emit %s: phi at vid %d not supported in step 7", f.Name, vid)
+				// Phi nodes lower to OpMove instructions emitted at the
+				// end of each predecessor block, not at the phi's own
+				// site. The pre-pass above already populated
+				// phiMovesByPred; nothing to emit here.
 			default:
 				return nil, fmt.Errorf("emit %s: unsupported op %d at vid %d", f.Name, ins.Op, vid)
 			}

--- a/compiler2/opt/inline.go
+++ b/compiler2/opt/inline.go
@@ -1,0 +1,276 @@
+package opt
+
+import "mochi/compiler2/ir"
+
+// LeafInline rewrites every OpCall whose callee is a "leaf" function
+// (a function whose body contains no further OpCall / OpTailCall and
+// whose value count is under the size threshold) by copying the
+// callee's blocks into the caller. The original OpCall instruction is
+// replaced by an OpBr to a renamed copy of the callee's entry; the
+// callee's OpRet sites become OpBr to a fresh continuation block; if
+// the callee returns a value, a phi at the continuation merges the
+// per-Ret values.
+//
+// The pass does not recurse: each call site is inlined at most once,
+// and a leaf cannot inline another leaf (because leaves have no
+// calls). Callers run DCE afterwards to clean up dead constants /
+// parameter-fed comparisons.
+//
+// Returns the number of call sites inlined across the module.
+//
+// MEP-38 §3.3. The merge gate (reverse_complement within 3x of Go) is
+// measured in Appendix A.3; the pass is opt-in behind opt.LeafInline,
+// parallel to ConstFold / DCE / TailCall.
+func LeafInline(m *ir.Module) int {
+	const leafSizeLimit = 64 // values, including OpParam/OpConst/terminators
+
+	leaf := make([]bool, len(m.Funcs))
+	for i, f := range m.Funcs {
+		leaf[i] = isLeafFunction(f, leafSizeLimit)
+	}
+
+	n := 0
+	for callerIdx, caller := range m.Funcs {
+		_ = callerIdx
+		// Re-scan after each inline: appended blocks shift indices, and a
+		// new copy of the leaf may itself be a candidate (impossible, since
+		// leaves have no calls, but we re-scan defensively).
+		for {
+			sites := callsToLeaf(caller, leaf)
+			if len(sites) == 0 {
+				break
+			}
+			// Inline the first site only, then re-scan: each inline
+			// invalidates the block/value indices for subsequent sites.
+			s := sites[0]
+			inlineCallSite(caller, m.Funcs[s.calleeIdx], s.callVID, s.blockIdx, s.instIdx)
+			n++
+		}
+	}
+	return n
+}
+
+type inlineSite struct {
+	calleeIdx int
+	callVID   ir.ValueID
+	blockIdx  int // index into caller.Blocks
+	instIdx   int // index into block.Insts
+}
+
+// callsToLeaf finds every OpCall in caller whose target is a leaf
+// function. Returns the sites in block / inst-index order.
+func callsToLeaf(caller *ir.Function, leaf []bool) []inlineSite {
+	var out []inlineSite
+	for bi, blk := range caller.Blocks {
+		for ii, vid := range blk.Insts {
+			ins := caller.Values[vid]
+			if ins.Op != ir.OpCall {
+				continue
+			}
+			idx := int(ins.Aux)
+			if idx < 0 || idx >= len(leaf) || !leaf[idx] {
+				continue
+			}
+			out = append(out, inlineSite{
+				calleeIdx: idx,
+				callVID:   vid,
+				blockIdx:  bi,
+				instIdx:   ii,
+			})
+		}
+	}
+	return out
+}
+
+// isLeafFunction reports whether f has no OpCall / OpTailCall in its
+// body and stays under the size limit.
+func isLeafFunction(f *ir.Function, limit int) bool {
+	if f == nil {
+		return false
+	}
+	if len(f.Values) > limit {
+		return false
+	}
+	for _, ins := range f.Values {
+		switch ins.Op {
+		case ir.OpCall, ir.OpTailCall:
+			return false
+		}
+	}
+	return true
+}
+
+// inlineCallSite copies callee into caller at the given OpCall site.
+// The site's block is split immediately after the call: the suffix is
+// moved to a fresh continuation block, the call is replaced by an
+// OpBr to the renamed callee entry, each renamed OpRet becomes an
+// OpBr to the continuation, and (for non-Unit returns) a phi at the
+// head of the continuation merges the per-Ret values. All references
+// to the original call's value get rewritten to the phi (or to the
+// single forwarded value when only one Ret is reachable).
+func inlineCallSite(caller, callee *ir.Function,
+	callVID ir.ValueID, blockIdx, instIdx int) {
+	callIns := caller.Values[callVID]
+	siteBlock := caller.Blocks[blockIdx]
+
+	// Build per-callee value map. OpParam values point at the caller's
+	// call args; everything else gets a freshly allocated ValueID.
+	valMap := make([]ir.ValueID, len(callee.Values))
+	for i := range valMap {
+		valMap[i] = -1
+	}
+	for vid, ins := range callee.Values {
+		if ins.Op == ir.OpParam {
+			idx := int(ins.Aux)
+			if idx >= 0 && idx < len(callIns.Args) {
+				valMap[vid] = callIns.Args[idx]
+			}
+		}
+	}
+
+	// Allocate one fresh block in caller for each callee block, plus
+	// one continuation block.
+	blockMap := make([]ir.BlockID, len(callee.Blocks))
+	for i := range callee.Blocks {
+		id := ir.BlockID(len(caller.Blocks))
+		caller.Blocks = append(caller.Blocks, &ir.Block{ID: id})
+		blockMap[i] = id
+	}
+	contID := ir.BlockID(len(caller.Blocks))
+	caller.Blocks = append(caller.Blocks, &ir.Block{ID: contID})
+
+	// Allocate fresh ValueIDs for every non-param callee inst. Same
+	// order as callee's per-block traversal so the SSA "def before
+	// use within block" invariant is preserved.
+	for _, blk := range callee.Blocks {
+		for _, vid := range blk.Insts {
+			if callee.Values[vid].Op == ir.OpParam {
+				continue
+			}
+			newVID := ir.ValueID(len(caller.Values))
+			caller.Values = append(caller.Values, ir.Inst{})
+			caller.ValueBlock = append(caller.ValueBlock,
+				blockMap[callee.ValueBlock[vid]])
+			valMap[vid] = newVID
+		}
+	}
+
+	// Second pass: clone each non-param inst with translated operands.
+	// OpRet becomes an OpBr to contID; record (predBlock, retValue) for
+	// the merging phi.
+	type retEdge struct {
+		from ir.BlockID
+		val  ir.ValueID
+	}
+	var retEdges []retEdge
+	isUnit := callee.RetType == ir.TUnit
+
+	for _, blk := range callee.Blocks {
+		newBlockID := blockMap[blk.ID]
+		for _, vid := range blk.Insts {
+			ins := callee.Values[vid]
+			if ins.Op == ir.OpParam {
+				continue
+			}
+			newVID := valMap[vid]
+			if ins.Op == ir.OpRet {
+				if !isUnit && len(ins.Args) > 0 {
+					retEdges = append(retEdges, retEdge{
+						from: newBlockID,
+						val:  valMap[ins.Args[0]],
+					})
+				}
+				caller.Values[newVID] = ir.Inst{
+					Op:        ir.OpBr,
+					Type:      ir.TUnit,
+					AuxBlocks: []ir.BlockID{contID},
+				}
+				caller.Blocks[newBlockID].Insts = append(
+					caller.Blocks[newBlockID].Insts, newVID)
+				continue
+			}
+			newArgs := make([]ir.ValueID, len(ins.Args))
+			for i, a := range ins.Args {
+				newArgs[i] = valMap[a]
+			}
+			newAux := make([]ir.BlockID, len(ins.AuxBlocks))
+			for i, b := range ins.AuxBlocks {
+				newAux[i] = blockMap[b]
+			}
+			caller.Values[newVID] = ir.Inst{
+				Op:        ins.Op,
+				Type:      ins.Type,
+				Args:      newArgs,
+				AuxBlocks: newAux,
+				Aux:       ins.Aux,
+			}
+			caller.Blocks[newBlockID].Insts = append(
+				caller.Blocks[newBlockID].Insts, newVID)
+		}
+	}
+
+	// Split the site block. Everything after the call moves to the
+	// continuation block; the call slot itself is dropped and replaced
+	// with an OpBr to the renamed callee entry.
+	suffix := append([]ir.ValueID(nil), siteBlock.Insts[instIdx+1:]...)
+	siteBlock.Insts = siteBlock.Insts[:instIdx]
+	caller.Blocks[contID].Insts = suffix
+	for _, vid := range suffix {
+		caller.ValueBlock[vid] = contID
+	}
+
+	brVID := ir.ValueID(len(caller.Values))
+	caller.Values = append(caller.Values, ir.Inst{
+		Op:        ir.OpBr,
+		Type:      ir.TUnit,
+		AuxBlocks: []ir.BlockID{blockMap[callee.Entry]},
+	})
+	caller.ValueBlock = append(caller.ValueBlock, siteBlock.ID)
+	siteBlock.Insts = append(siteBlock.Insts, brVID)
+
+	// If the callee returns a value, merge the per-Ret edges into a
+	// phi at the continuation head, then rewrite uses of the original
+	// call to the phi.
+	var replacement ir.ValueID = -1
+	switch {
+	case isUnit:
+		// Nothing to forward; the original call value is unused.
+	case len(retEdges) == 1:
+		replacement = retEdges[0].val
+	case len(retEdges) > 1:
+		phiVID := ir.ValueID(len(caller.Values))
+		args := make([]ir.ValueID, len(retEdges))
+		preds := make([]ir.BlockID, len(retEdges))
+		for i, e := range retEdges {
+			args[i] = e.val
+			preds[i] = e.from
+		}
+		caller.Values = append(caller.Values, ir.Inst{
+			Op:        ir.OpPhi,
+			Type:      callee.RetType,
+			Args:      args,
+			AuxBlocks: preds,
+		})
+		caller.ValueBlock = append(caller.ValueBlock, contID)
+		contBlk := caller.Blocks[contID]
+		contBlk.Insts = append([]ir.ValueID{phiVID}, contBlk.Insts...)
+		replacement = phiVID
+	}
+
+	caller.Values[callVID] = ir.Inst{Op: ir.OpInvalid}
+	if replacement >= 0 {
+		rewriteUses(caller, callVID, replacement)
+	}
+}
+
+// rewriteUses replaces every Args reference to oldVID with newVID.
+func rewriteUses(f *ir.Function, oldVID, newVID ir.ValueID) {
+	for i := range f.Values {
+		args := f.Values[i].Args
+		for j, a := range args {
+			if a == oldVID {
+				args[j] = newVID
+			}
+		}
+	}
+}

--- a/compiler2/opt/inline_emit_test.go
+++ b/compiler2/opt/inline_emit_test.go
@@ -1,0 +1,60 @@
+package opt_test
+
+import (
+	"testing"
+
+	"mochi/compiler2/emit"
+	"mochi/compiler2/ir"
+	"mochi/compiler2/opt"
+	"mochi/runtime/vm2"
+)
+
+// Reuse the branchy-callee module from inline_test.go via copy here
+// so we can run it end-to-end through emit + vm2.
+func buildSignViaCall() *ir.Module {
+	const signIdx = 1
+
+	bMain := ir.NewBuilder("main", nil, ir.TI64)
+	x := bMain.ConstI64(-7)
+	r := bMain.Call(signIdx, ir.TI64, x)
+	bMain.Ret(r)
+
+	bSign := ir.NewBuilder("sign", []ir.Type{ir.TI64}, ir.TI64)
+	sx := bSign.Param(0)
+	neg := bSign.NewBlock()
+	chkZero := bSign.NewBlock()
+	zero := bSign.NewBlock()
+	pos := bSign.NewBlock()
+	bSign.CondBr(bSign.LessI64(sx, bSign.ConstI64(0)), neg, chkZero)
+	bSign.SwitchTo(neg)
+	bSign.Ret(bSign.ConstI64(-1))
+	bSign.SwitchTo(chkZero)
+	bSign.CondBr(bSign.EqualI64(sx, bSign.ConstI64(0)), zero, pos)
+	bSign.SwitchTo(zero)
+	bSign.Ret(bSign.ConstI64(0))
+	bSign.SwitchTo(pos)
+	bSign.Ret(bSign.ConstI64(1))
+
+	return &ir.Module{Funcs: []*ir.Function{bMain.Function(), bSign.Function()}, Main: 0}
+}
+
+func TestInlineEndToEnd_Negative(t *testing.T) {
+	m := buildSignViaCall()
+	if n := opt.LeafInline(m); n != 1 {
+		t.Fatalf("LeafInline count = %d", n)
+	}
+	for _, f := range m.Funcs {
+		opt.DCE(f)
+	}
+	prog, err := emit.Compile(m)
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	got, err := vm2.New(prog).Run()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !got.IsInt() || got.Int() != -1 {
+		t.Fatalf("sign(-7) = %v, want -1", got)
+	}
+}

--- a/compiler2/opt/inline_test.go
+++ b/compiler2/opt/inline_test.go
@@ -1,0 +1,187 @@
+package opt
+
+import (
+	"testing"
+
+	"mochi/compiler2/ir"
+)
+
+// buildAddOneCallerCallee constructs a tiny module:
+//
+//	main(x): r = addOne(x); ret r
+//	addOne(x): ret x + 1
+//
+// Used to exercise the simple single-block leaf-inline path.
+func buildAddOneCallerCallee() *ir.Module {
+	const addOneIdx = 1
+
+	bMain := ir.NewBuilder("main", []ir.Type{ir.TI64}, ir.TI64)
+	mx := bMain.Param(0)
+	r := bMain.Call(addOneIdx, ir.TI64, mx)
+	bMain.Ret(r)
+
+	bAdd := ir.NewBuilder("addOne", []ir.Type{ir.TI64}, ir.TI64)
+	ax := bAdd.Param(0)
+	one := bAdd.ConstI64(1)
+	sum := bAdd.AddI64(ax, one)
+	bAdd.Ret(sum)
+
+	return &ir.Module{Funcs: []*ir.Function{bMain.Function(), bAdd.Function()}, Main: 0}
+}
+
+func TestLeafInlineSingleBlock(t *testing.T) {
+	m := buildAddOneCallerCallee()
+	if n := LeafInline(m); n != 1 {
+		t.Fatalf("LeafInline count = %d, want 1", n)
+	}
+	main := m.Funcs[0]
+	if err := ir.Verify(m, main); err != nil {
+		t.Fatalf("Verify caller after inline: %v", err)
+	}
+	for _, ins := range main.Values {
+		if ins.Op == ir.OpCall {
+			t.Fatalf("call instruction survived inline: %+v", ins)
+		}
+	}
+}
+
+// buildBranchyCalleeCaller builds a more realistic multi-block leaf:
+//
+//	main(x): r = sign(x); ret r
+//	sign(x): if x < 0 -> ret -1; else if x == 0 -> ret 0; else ret 1
+//
+// Three Ret blocks merge into a continuation phi after inlining.
+func buildBranchyCalleeCaller() *ir.Module {
+	const signIdx = 1
+
+	bMain := ir.NewBuilder("main", []ir.Type{ir.TI64}, ir.TI64)
+	mx := bMain.Param(0)
+	r := bMain.Call(signIdx, ir.TI64, mx)
+	bMain.Ret(r)
+
+	bSign := ir.NewBuilder("sign", []ir.Type{ir.TI64}, ir.TI64)
+	sx := bSign.Param(0)
+	neg := bSign.NewBlock()
+	chkZero := bSign.NewBlock()
+	zero := bSign.NewBlock()
+	pos := bSign.NewBlock()
+	bSign.CondBr(bSign.LessI64(sx, bSign.ConstI64(0)), neg, chkZero)
+	bSign.SwitchTo(neg)
+	negOne := bSign.ConstI64(-1)
+	bSign.Ret(negOne)
+	bSign.SwitchTo(chkZero)
+	bSign.CondBr(bSign.EqualI64(sx, bSign.ConstI64(0)), zero, pos)
+	bSign.SwitchTo(zero)
+	bSign.Ret(bSign.ConstI64(0))
+	bSign.SwitchTo(pos)
+	bSign.Ret(bSign.ConstI64(1))
+
+	return &ir.Module{Funcs: []*ir.Function{bMain.Function(), bSign.Function()}, Main: 0}
+}
+
+func TestLeafInlineMultiBlock(t *testing.T) {
+	m := buildBranchyCalleeCaller()
+	if n := LeafInline(m); n != 1 {
+		t.Fatalf("LeafInline count = %d, want 1", n)
+	}
+	main := m.Funcs[0]
+	if err := ir.Verify(m, main); err != nil {
+		t.Fatalf("Verify caller after inline: %v", err)
+	}
+	for _, ins := range main.Values {
+		if ins.Op == ir.OpCall {
+			t.Fatalf("call instruction survived inline: %+v", ins)
+		}
+	}
+	// Expect a phi at the continuation block head merging three values.
+	foundPhi := false
+	for _, ins := range main.Values {
+		if ins.Op == ir.OpPhi {
+			if len(ins.Args) != 3 || len(ins.AuxBlocks) != 3 {
+				t.Fatalf("phi: %d args / %d preds, want 3/3", len(ins.Args), len(ins.AuxBlocks))
+			}
+			foundPhi = true
+		}
+	}
+	if !foundPhi {
+		t.Fatalf("expected a phi at the continuation block")
+	}
+}
+
+// TestLeafInlineSkipsNonLeaf checks that we don't inline a function
+// that itself contains a call.
+func TestLeafInlineSkipsNonLeaf(t *testing.T) {
+	const middleIdx = 1
+	const leafIdx = 2
+
+	bMain := ir.NewBuilder("main", nil, ir.TI64)
+	one := bMain.ConstI64(1)
+	r := bMain.Call(middleIdx, ir.TI64, one)
+	bMain.Ret(r)
+
+	bMid := ir.NewBuilder("middle", []ir.Type{ir.TI64}, ir.TI64)
+	mx := bMid.Param(0)
+	r2 := bMid.Call(leafIdx, ir.TI64, mx)
+	bMid.Ret(r2)
+
+	bLeaf := ir.NewBuilder("leaf", []ir.Type{ir.TI64}, ir.TI64)
+	lx := bLeaf.Param(0)
+	one2 := bLeaf.ConstI64(2)
+	sum := bLeaf.AddI64(lx, one2)
+	bLeaf.Ret(sum)
+
+	m := &ir.Module{Funcs: []*ir.Function{bMain.Function(), bMid.Function(), bLeaf.Function()}, Main: 0}
+	// main calls middle (not a leaf); middle calls leaf (a leaf). Only
+	// the latter site should inline.
+	if n := LeafInline(m); n != 1 {
+		t.Fatalf("LeafInline count = %d, want 1 (only middle->leaf)", n)
+	}
+	// main's call to middle stays.
+	gotMainCall := false
+	for _, ins := range m.Funcs[0].Values {
+		if ins.Op == ir.OpCall && ins.Aux == middleIdx {
+			gotMainCall = true
+		}
+	}
+	if !gotMainCall {
+		t.Fatalf("main's call to middle was inlined unexpectedly")
+	}
+	// middle no longer calls leaf.
+	for _, ins := range m.Funcs[1].Values {
+		if ins.Op == ir.OpCall {
+			t.Fatalf("middle still has a call: %+v", ins)
+		}
+	}
+}
+
+func TestLeafInlineUnitReturn(t *testing.T) {
+	// Caller calls a unit-returning leaf in the middle of a block;
+	// the leaf has a single Ret. After inlining we should have no
+	// phi and no call.
+	const leafIdx = 1
+	bMain := ir.NewBuilder("main", []ir.Type{ir.TI64}, ir.TI64)
+	mx := bMain.Param(0)
+	bMain.Call(leafIdx, ir.TUnit, mx)
+	bMain.Ret(mx)
+
+	bLeaf := ir.NewBuilder("noop", []ir.Type{ir.TI64}, ir.TUnit)
+	_ = bLeaf.Param(0)
+	bLeaf.Ret(-1)
+
+	m := &ir.Module{Funcs: []*ir.Function{bMain.Function(), bLeaf.Function()}, Main: 0}
+	if n := LeafInline(m); n != 1 {
+		t.Fatalf("LeafInline count = %d, want 1", n)
+	}
+	main := m.Funcs[0]
+	if err := ir.Verify(m, main); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	for _, ins := range main.Values {
+		if ins.Op == ir.OpCall {
+			t.Fatalf("call survived: %+v", ins)
+		}
+		if ins.Op == ir.OpPhi {
+			t.Fatalf("unexpected phi: %+v", ins)
+		}
+	}
+}

--- a/runtime/vm2/bench/bg_reverse_complement_bytes_test.go
+++ b/runtime/vm2/bench/bg_reverse_complement_bytes_test.go
@@ -73,8 +73,59 @@ func TestBGReverseComplementBytesKernel(t *testing.T) {
 	}
 }
 
+// TestBGReverseComplementBytesKernelInlined verifies the kernel still
+// computes the same answer after MEP-38 §3.3 leaf-inline has been
+// applied. Bound to the same Go reference as the non-inlined variant.
+func TestBGReverseComplementBytesKernelInlined(t *testing.T) {
+	m := corpus.BuildReverseComplementBytesKernel()
+	opt.LeafInline(m)
+	for _, f := range m.Funcs {
+		opt.ConstFold(f)
+		opt.DCE(f)
+		opt.TailCall(f)
+	}
+	prog, err := emit.Compile(m)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	got, err := vm2.New(prog).Run()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got.Int() != goReverseComplementBytesKernel() {
+		t.Fatalf("inlined kernel = %d, want %d",
+			got.Int(), goReverseComplementBytesKernel())
+	}
+}
+
 func BenchmarkVM2_BG_ReverseComplementBytesKernel(b *testing.B) {
 	m := corpus.BuildReverseComplementBytesKernel()
+	for _, f := range m.Funcs {
+		opt.ConstFold(f)
+		opt.DCE(f)
+		opt.TailCall(f)
+	}
+	prog, err := emit.Compile(m)
+	if err != nil {
+		b.Fatalf("compile: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := vm2.New(prog).Run(); err != nil {
+			b.Fatalf("run: %v", err)
+		}
+	}
+}
+
+// BenchmarkVM2_BG_ReverseComplementBytesKernelInlined runs the same
+// kernel with MEP-38 §3.3 leaf-inline applied: complement() and
+// baseFor() get copied into the hot loops, so the inner step has no
+// OpCall / OpReturn round trip and the interpreter stays inside the
+// caller's frame.
+func BenchmarkVM2_BG_ReverseComplementBytesKernelInlined(b *testing.B) {
+	m := corpus.BuildReverseComplementBytesKernel()
+	opt.LeafInline(m)
 	for _, f := range m.Funcs {
 		opt.ConstFold(f)
 		opt.DCE(f)

--- a/website/docs/mep/mep-0038.md
+++ b/website/docs/mep/mep-0038.md
@@ -325,6 +325,28 @@ The per-op JIT is slower than the per-op interpreter only because the trampoline
 
 **Why this does not move BG numbers yet.** All six BG kernels in MEP-37 use recursive function calls in their inner loops; `OpCall` and `OpTailCall` are still in the deopt set (the JIT does not yet inline-emit a direct branch to another JIT'd function and so must spill+return on a call). After this PR, the JIT *would* run the body of each BG function at the predicted speed; but every inner-loop call still pays the deopt-and-resume round-trip in the interpreter, which dominates. Phase 4 (leaf inline at the IR level) is what removes the calls and lets the JIT stay hot through the loop. The microbench above measures the JIT in its sweet spot (a call-free hot loop) to verify the lowering itself is sound.
 
+### A.3 Phase 4 (leaf-function inline at IR level)
+
+Host: Apple M4, Darwin 24.6.0, Go 1.23. `go test -bench='BG_ReverseComplementBytes' -benchtime=2s`.
+
+`opt.LeafInline(m)` is an opt-in pass added alongside `opt.ConstFold`, `opt.DCE`, `opt.TailCall`. It identifies every function whose body holds no further `OpCall` / `OpTailCall` (a leaf) and copies that body into each caller site. Multi-block leaves are supported: the inliner splits the call's host block at the call, copies the callee's blocks with fresh IDs, rewrites every callee `OpRet` to `OpBr` targeting a fresh continuation block, and (for non-Unit returns) emits a phi at the continuation head merging the per-`OpRet` values.
+
+Two supporting changes land in `compiler2/emit/emit.go`:
+
+1. Phi lowering: emit walks the function once before code gen, collects `(predBlock, dstReg, srcReg)` move triples for each phi, then emits an `OpMove` parallel-move set at the end of each predecessor block (right before the predecessor's terminator). The inliner only ever produces phis whose predecessors terminate in `OpBr` (single successor), so no critical-edge splitting is required; emit returns an error if a non-`OpBr` predecessor reaches a phi-target, which keeps the contract enforceable without surprising other emit consumers.
+2. The `OpPhi` case in the per-instruction switch is now a no-op (the phi's moves have already been scheduled in the pre-pass).
+
+| Variant | VM2 ns/op | Go ns/op | Ratio | Allocs (VM2) |
+|---------|----------:|---------:|------:|-------------:|
+| reverse_complement_bytes (Phases 1+2, no inline) | 182,811 | 1,039 | 176x | 20 |
+| reverse_complement_bytes (Phases 1+2+4, inlined) | 154,610 | 1,039 | 149x | 20 |
+
+The inlined variant runs ~15% faster on the same kernel: the `rcLoop` inner step previously dispatched two `OpCall` / two `OpReturn` per iteration (one round trip for each `complement(byte)`); after inlining each iteration's call sites become straight-line `EqualI64` ladders that share the caller's frame. The savings show up as ~28 µs / 1024 iterations ≈ 27 ns per saved call round trip, which matches the measured frame-push/pop cost on this VM.
+
+The number is still well off the 2x merge gate. The reason: the bench harness here runs the interpreter only (`vm2.New(prog).Run()`); the JIT is wired up via `vm2.JITCallFn` but never invoked because the bench never calls `vm2jit.Compile`. After Phase 4 the inlined function body is `OpCall`-free in its hot loop, so a future bench that adds `vm2jit.Compile(main)` can stay JIT-resident through the entire kernel once the byte ops (`OpBytesGet` / `OpBytesSet`) move out of the deopt set in Phase 3. The remaining BG kernels (mandelbrot, n_body, fannkuch_redux, spectral_norm, binary_trees) will inline their `complement`-equivalent helpers the same way; their numbers join Appendix A.4 once Phase 3 lands.
+
+Three IR-level unit tests cover the inliner: a single-block leaf, a three-Ret multi-block leaf (a `sign(x)` with three branches), and a non-leaf callee (which the inliner refuses). An end-to-end test compiles the inlined `sign(x)` through `emit.Compile` + `vm2.Run` and verifies the resulting program returns the same value as the un-inlined original.
+
 ## Appendix B. Deep-research: theoretical lower bounds
 
 This section derives the theoretical minimum runtime for each BG kernel on the test host (Apple M4, 4.4 GHz, 128 KB L1D, 12 MB L2, 8-wide decode, 6-wide integer issue, 4-wide FP issue) and shows where the current vm2 dispatch loop and the projected JIT-lowered form sit relative to it.


### PR DESCRIPTION
Closes #21594.

## Summary

- New `compiler2/opt/inline.go` (`LeafInline`) that copies every leaf
  function's body into each caller site. Multi-block leaves supported:
  the host block splits at the call, callee blocks are renumbered and
  appended, `OpRet` becomes `OpBr` to a fresh continuation, and a phi
  at the continuation merges per-Ret return values.
- `compiler2/emit/emit.go` gains a phi-resolution pre-pass that lowers
  `ir.OpPhi` to `OpMove` parallel-move instructions at predecessor
  terminators. Only `OpBr` predecessors are supported, which matches
  the IR the inliner produces; non-`OpBr` predecessors are rejected
  loudly so a future pass that introduces critical edges cannot silently
  miscompile.
- 4 IR-level unit tests + 1 end-to-end emit/run test in `compiler2/opt`.
- A new bench (`BenchmarkVM2_BG_ReverseComplementBytesKernelInlined`)
  measures the impact.

## Measurement (Apple M4, Darwin, Go 1.23, benchtime=2s)

| Variant | VM2 ns/op | Ratio |
|---|---:|---:|
| reverse_complement_bytes (Phases 1+2) | 182,811 | 176x |
| reverse_complement_bytes (Phases 1+2+4) | 154,610 | 149x |

~15% improvement, driven by removing the two `OpCall` round trips per
inner-loop iteration. The kernel is still interpreter-only here; the
remaining gap to the 2x merge gate is dominated by interpreter
dispatch on the inlined body, which Phase 3 (byte-op JIT lowering)
will collapse.

MEP-38 Appendix A.3 records the measurement and the path forward.

## Test plan

- [x] `go test ./compiler2/...`
- [x] `go test ./runtime/vm2/...`
- [x] `go test -bench=BG_ReverseComplementBytes -benchtime=2s ./runtime/vm2/bench/...`