### PR TITLE
mep-0038 §A.7: self-call ops + immediate fusions bring binary_trees_pair under 2x

### DIFF
--- a/compiler2/emit/emit.go
+++ b/compiler2/emit/emit.go
@@ -185,6 +185,42 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 			try(a0, a1)
 		}
 	}
+	// subK mirrors addK but with no commutativity: only the right-hand
+	// operand (the subtrahend) can fold into the immediate slot.
+	// makeTree(d-1) / checkTree(t, d-1) lower to (sub d, ConstI64(1))
+	// and become a single OpSubI64K dispatch.
+	type subKInfo struct {
+		k   int64
+		src ir.ValueID
+	}
+	subK := make(map[ir.ValueID]subKInfo)
+	for vid, ins := range f.Values {
+		if ins.Op != ir.OpSubI64 {
+			continue
+		}
+		rhs := ins.Args[1]
+		c := f.Values[rhs]
+		if c.Op != ir.OpConstI64 || useCount[rhs] != 1 {
+			continue
+		}
+		k := c.Aux
+		if k < -(1<<31) || k > (1<<31)-1 {
+			continue
+		}
+		suppress[rhs] = true
+		subK[ir.ValueID(vid)] = subKInfo{k: k, src: ins.Args[0]}
+	}
+	// fuseCmpConst marks a fused cmp+condbr whose const operand should be
+	// inlined into the K-form jump op (avoids the OpLoadConstI dispatch
+	// + register slot). Only populated for OpEqualI64 with one
+	// ConstI64 arg whose value fits in i32; less/lessEq with a const
+	// could be added analogously but the BG corpus uses equality for the
+	// only hot cases (leaf-guard checks in recursive kernels).
+	type cmpConstInfo struct {
+		k       int64
+		nonReg  ir.ValueID
+	}
+	fuseCmpConst := make(map[ir.ValueID]cmpConstInfo)
 	for bi := range f.Blocks {
 		blk := f.Blocks[bi]
 		insts := blk.Insts
@@ -220,6 +256,25 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 		}
 		suppress[cmpVid] = true
 		fuseCondBr[last] = cmpVid
+		if cmpIns.Op == ir.OpEqualI64 {
+			a0, a1 := cmpIns.Args[0], cmpIns.Args[1]
+			tryK := func(constArg, otherArg ir.ValueID) bool {
+				c := f.Values[constArg]
+				if c.Op != ir.OpConstI64 || useCount[constArg] != 1 {
+					return false
+				}
+				k := c.Aux
+				if k < -(1<<31) || k > (1<<31)-1 {
+					return false
+				}
+				suppress[constArg] = true
+				fuseCmpConst[cmpVid] = cmpConstInfo{k: k, nonReg: otherArg}
+				return true
+			}
+			if !tryK(a1, a0) {
+				tryK(a0, a1)
+			}
+		}
 	}
 
 	// Return-superop fusions (MEP-38 §A.6). Each OpRet that consumes a
@@ -239,9 +294,13 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 		regA ir.ValueID // sumA: addK[].nonConstArg
 		regB ir.ValueID // the other AddI64 operand
 	}
+	type retPairKKInfo struct {
+		k0, k1 int64
+	}
 	fuseRetI64K := make(map[ir.ValueID]int64)
 	fuseRetAddSum := make(map[ir.ValueID]retSumInfo)
 	fuseRetNewPair := make(map[ir.ValueID]ir.ValueID) // ret vid -> NewPair vid
+	fuseRetNewPairKK := make(map[ir.ValueID]retPairKKInfo)
 	for bi := range f.Blocks {
 		blk := f.Blocks[bi]
 		insts := blk.Insts
@@ -268,7 +327,20 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 			fuseRetI64K[last] = k
 		case ir.OpNewPair:
 			suppress[argVid] = true
-			fuseRetNewPair[last] = argVid
+			// KK form when both NewPair args are single-use ConstI64s that
+			// fit in i32. Hot for makeTree's d==0 leaf: return newPair(0, 0).
+			a0, a1 := argIns.Args[0], argIns.Args[1]
+			c0, c1 := f.Values[a0], f.Values[a1]
+			if c0.Op == ir.OpConstI64 && c1.Op == ir.OpConstI64 &&
+				useCount[a0] == 1 && useCount[a1] == 1 &&
+				c0.Aux >= -(1<<31) && c0.Aux <= (1<<31)-1 &&
+				c1.Aux >= -(1<<31) && c1.Aux <= (1<<31)-1 {
+				suppress[a0] = true
+				suppress[a1] = true
+				fuseRetNewPairKK[last] = retPairKKInfo{k0: c0.Aux, k1: c1.Aux}
+			} else {
+				fuseRetNewPair[last] = argVid
+			}
 		case ir.OpAddI64:
 			// Prefer the 3-operand triple-add form when one operand is a
 			// single-use AddI64K (already captured in addK[]). The inner
@@ -406,6 +478,12 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 					B: int32(finalReg[ins.Args[0]]),
 					C: int32(finalReg[ins.Args[1]])})
 			case ir.OpSubI64:
+				if info, ok := subK[vid]; ok {
+					emit(vm2.Instr{Op: vm2.OpSubI64K, A: dst,
+						B: int32(finalReg[info.src]),
+						C: int32(info.k)})
+					break
+				}
 				emit(vm2.Instr{Op: vm2.OpSubI64, A: dst,
 					B: int32(finalReg[ins.Args[0]]),
 					C: int32(finalReg[ins.Args[1]])})
@@ -683,19 +761,37 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 				// 1-2 dispatches per call site on the dominant arities
 				// in the BG corpus.
 				if info, ok := fusePairCall[vid]; ok {
-					emit(vm2.Instr{Op: info.op, A: dst,
+					op := info.op
+					if int(ins.Aux) == selfIdx {
+						switch info.op {
+						case vm2.OpPairFstCallA2:
+							op = vm2.OpPairFstCallSelfA2
+						case vm2.OpPairSndCallA2:
+							op = vm2.OpPairSndCallSelfA2
+						}
+					}
+					emit(vm2.Instr{Op: op, A: dst,
 						B: int32(ins.Aux),
 						C: int32(finalReg[info.pairSrc]),
 						D: int32(finalReg[ins.Args[1]])})
 					break
 				}
+				self := int(ins.Aux) == selfIdx
 				switch len(ins.Args) {
 				case 1:
-					emit(vm2.Instr{Op: vm2.OpCallA1, A: dst,
+					op := vm2.OpCallA1
+					if self {
+						op = vm2.OpCallSelfA1
+					}
+					emit(vm2.Instr{Op: op, A: dst,
 						B: int32(ins.Aux),
 						C: int32(finalReg[ins.Args[0]])})
 				case 2:
-					emit(vm2.Instr{Op: vm2.OpCallA2, A: dst,
+					op := vm2.OpCallA2
+					if self {
+						op = vm2.OpCallSelfA2
+					}
+					emit(vm2.Instr{Op: op, A: dst,
 						B: int32(ins.Aux),
 						C: int32(finalReg[ins.Args[0]]),
 						D: int32(finalReg[ins.Args[1]])})
@@ -768,6 +864,12 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 						C: int32(finalReg[info.regB])})
 					break
 				}
+				if info, ok := fuseRetNewPairKK[vid]; ok {
+					emit(vm2.Instr{Op: vm2.OpReturnNewPairKK,
+						B: int32(info.k0),
+						C: int32(info.k1)})
+					break
+				}
 				if npVid, ok := fuseRetNewPair[vid]; ok {
 					npIns := f.Values[npVid]
 					emit(vm2.Instr{Op: vm2.OpReturnNewPair,
@@ -793,6 +895,26 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 				}
 				if cmpVid, ok := fuseCondBr[vid]; ok {
 					cmp := f.Values[cmpVid]
+					// K-form for equality with one ConstI64 operand: inline
+					// the constant into the jump op, drop the OpLoadConstI.
+					if kinfo, kok := fuseCmpConst[cmpVid]; kok {
+						a := int32(finalReg[kinfo.nonReg])
+						k := int32(kinfo.k)
+						switch {
+						case elseB == nextB:
+							idx := emit(vm2.Instr{Op: vm2.OpJumpIfEqualI64K, A: a, B: k})
+							pending = append(pending, pendingJump{insIdx: idx, target: thenB, field: 'C'})
+						case thenB == nextB:
+							idx := emit(vm2.Instr{Op: vm2.OpJumpIfNotEqualI64K, A: a, B: k})
+							pending = append(pending, pendingJump{insIdx: idx, target: elseB, field: 'C'})
+						default:
+							idx := emit(vm2.Instr{Op: vm2.OpJumpIfEqualI64K, A: a, B: k})
+							pending = append(pending, pendingJump{insIdx: idx, target: thenB, field: 'C'})
+							idx2 := emit(vm2.Instr{Op: vm2.OpJump})
+							pending = append(pending, pendingJump{insIdx: idx2, target: elseB, field: 'A'})
+						}
+						break
+					}
 					b := int32(finalReg[cmp.Args[0]])
 					c := int32(finalReg[cmp.Args[1]])
 					// Direct (jump-if-true) and inverted forms per cmp op.

--- a/runtime/jit/vm2jit/lower_arm64.go
+++ b/runtime/jit/vm2jit/lower_arm64.go
@@ -323,7 +323,14 @@ func isDeoptableOp(op vm2.Op) bool {
 		vm2.OpNewMap, vm2.OpMapLen, vm2.OpMapGet, vm2.OpMapHas, vm2.OpMapSet, vm2.OpMapDel,
 		vm2.OpCall, vm2.OpCallA1, vm2.OpCallA2,
 		vm2.OpPairFstCallA2, vm2.OpPairSndCallA2,
+		vm2.OpCallSelfA1, vm2.OpCallSelfA2,
+		vm2.OpPairFstCallSelfA2, vm2.OpPairSndCallSelfA2,
 		vm2.OpTailCall, vm2.OpTailCallSelf, vm2.OpTailCallSelfA3,
+		// MEP-38 §A.7 immediate-form i64 fusions. The JIT can lower these
+		// natively (they are just register-immediate arithmetic and
+		// compares), but Phase 1 keeps them as deopt stubs so the new
+		// emitter paths land without a JIT change.
+		vm2.OpSubI64K, vm2.OpJumpIfEqualI64K, vm2.OpJumpIfNotEqualI64K,
 		// MEP-38 Phase 2 (§3.2.1) lowers OpLoadConstF, OpAddF64, OpSubF64,
 		// OpMulF64, OpDivF64, OpNegF64, OpAbsF64, OpSqrtF64, OpLessF64,
 		// OpLessEqF64, OpEqualF64, OpFmaF64, OpI64ToF64, OpF64ToI64 to
@@ -339,6 +346,7 @@ func isDeoptableOp(op vm2.Op) bool {
 		// could be lowered natively (no allocation), but the new-pair form
 		// touches the arena. All three deopt to the interpreter for now.
 		vm2.OpReturnI64K, vm2.OpReturnAddSum, vm2.OpReturnNewPair,
+		vm2.OpReturnNewPairKK,
 		// MEP-38 Phase 1 byte-view ops + minimal I/O. Deopt for now; a
 		// follow-up phase lowers OpBytesGet/OpBytesSet directly so the
 		// reverse_complement inner loop stays in JIT-compiled code.

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -91,6 +91,8 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			regs[ins.A] = CInt(regs[ins.B].Int() + regs[ins.C].Int())
 		case OpAddI64K:
 			regs[ins.A] = CInt(regs[ins.B].Int() + int64(ins.C))
+		case OpSubI64K:
+			regs[ins.A] = CInt(regs[ins.B].Int() - int64(ins.C))
 		case OpSubI64:
 			regs[ins.A] = CInt(regs[ins.B].Int() - regs[ins.C].Int())
 		case OpMulI64:
@@ -143,6 +145,14 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			}
 		case OpJumpIfNotEqualI64:
 			if regs[ins.A].Int() != regs[ins.B].Int() {
+				ip = int(ins.C)
+			}
+		case OpJumpIfEqualI64K:
+			if regs[ins.A].Int() == int64(ins.B) {
+				ip = int(ins.C)
+			}
+		case OpJumpIfNotEqualI64K:
+			if regs[ins.A].Int() != int64(ins.B) {
 				ip = int(ins.C)
 			}
 		case OpCall:
@@ -325,6 +335,94 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			regs = vm.Stack[newBase:]
 			consts = fr.Fn.Consts
 			ip = 0
+		case OpCallSelfA1:
+			callee := fr.Fn
+			fr.IP = ip
+			base := len(vm.Stack)
+			need := base + callee.NumRegs
+			if cap(vm.Stack) >= need {
+				vm.Stack = vm.Stack[:need]
+				vm.Stack[base] = regs[ins.C]
+				vm.Frames = append(vm.Frames, frame{Fn: callee, RegsBase: base, RetReg: ins.A})
+				fr = &vm.Frames[len(vm.Frames)-1]
+				regs = vm.Stack[base:]
+				ip = 0
+				break
+			}
+			a0 := regs[ins.C]
+			_, newBase := vm.pushFrame(callee, ins.A)
+			vm.Stack[newBase] = a0
+			fr = &vm.Frames[len(vm.Frames)-1]
+			regs = vm.Stack[newBase:]
+			ip = 0
+		case OpCallSelfA2:
+			callee := fr.Fn
+			fr.IP = ip
+			base := len(vm.Stack)
+			need := base + callee.NumRegs
+			if cap(vm.Stack) >= need {
+				vm.Stack = vm.Stack[:need]
+				vm.Stack[base] = regs[ins.C]
+				vm.Stack[base+1] = regs[ins.D]
+				vm.Frames = append(vm.Frames, frame{Fn: callee, RegsBase: base, RetReg: ins.A})
+				fr = &vm.Frames[len(vm.Frames)-1]
+				regs = vm.Stack[base:]
+				ip = 0
+				break
+			}
+			a0, a1 := regs[ins.C], regs[ins.D]
+			_, newBase := vm.pushFrame(callee, ins.A)
+			vm.Stack[newBase] = a0
+			vm.Stack[newBase+1] = a1
+			fr = &vm.Frames[len(vm.Frames)-1]
+			regs = vm.Stack[newBase:]
+			ip = 0
+		case OpPairFstCallSelfA2:
+			callee := fr.Fn
+			fr.IP = ip
+			base := len(vm.Stack)
+			need := base + callee.NumRegs
+			if cap(vm.Stack) >= need {
+				vm.Stack = vm.Stack[:need]
+				vm.Stack[base] = (*vmPair)(regs[ins.C].PtrTo()).a
+				vm.Stack[base+1] = regs[ins.D]
+				vm.Frames = append(vm.Frames, frame{Fn: callee, RegsBase: base, RetReg: ins.A})
+				fr = &vm.Frames[len(vm.Frames)-1]
+				regs = vm.Stack[base:]
+				ip = 0
+				break
+			}
+			a0 := (*vmPair)(regs[ins.C].PtrTo()).a
+			a1 := regs[ins.D]
+			_, newBase := vm.pushFrame(callee, ins.A)
+			vm.Stack[newBase] = a0
+			vm.Stack[newBase+1] = a1
+			fr = &vm.Frames[len(vm.Frames)-1]
+			regs = vm.Stack[newBase:]
+			ip = 0
+		case OpPairSndCallSelfA2:
+			callee := fr.Fn
+			fr.IP = ip
+			base := len(vm.Stack)
+			need := base + callee.NumRegs
+			if cap(vm.Stack) >= need {
+				vm.Stack = vm.Stack[:need]
+				vm.Stack[base] = (*vmPair)(regs[ins.C].PtrTo()).b
+				vm.Stack[base+1] = regs[ins.D]
+				vm.Frames = append(vm.Frames, frame{Fn: callee, RegsBase: base, RetReg: ins.A})
+				fr = &vm.Frames[len(vm.Frames)-1]
+				regs = vm.Stack[base:]
+				ip = 0
+				break
+			}
+			a0 := (*vmPair)(regs[ins.C].PtrTo()).b
+			a1 := regs[ins.D]
+			_, newBase := vm.pushFrame(callee, ins.A)
+			vm.Stack[newBase] = a0
+			vm.Stack[newBase+1] = a1
+			fr = &vm.Frames[len(vm.Frames)-1]
+			regs = vm.Stack[newBase:]
+			ip = 0
 		case OpTailCallSelf:
 			ip = 0
 		case OpTailCallSelfA3:
@@ -443,6 +541,25 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			regs[retReg] = ret
 		case OpReturnNewPair:
 			ret = vm.newPair(regs[ins.B], regs[ins.C])
+			retReg := fr.RetReg
+			top := len(vm.Frames) - 1
+			poppedBase := fr.RegsBase
+			if fr.Fn.HasContainerSlots {
+				clear(vm.Stack[poppedBase:])
+			}
+			vm.Stack = vm.Stack[:poppedBase]
+			vm.Frames = vm.Frames[:top]
+			if top <= target {
+				return ret, nil
+			}
+			fr = &vm.Frames[top-1]
+			code = fr.Fn.Code
+			regs = vm.Stack[fr.RegsBase:]
+			consts = fr.Fn.Consts
+			ip = fr.IP
+			regs[retReg] = ret
+		case OpReturnNewPairKK:
+			ret = vm.newPair(CInt(int64(ins.B)), CInt(int64(ins.C)))
 			retReg := fr.RetReg
 			top := len(vm.Frames) - 1
 			poppedBase := fr.RegsBase

--- a/runtime/vm2/ops.go
+++ b/runtime/vm2/ops.go
@@ -16,6 +16,11 @@ const (
 	// step counter (e.g. `i = i + 1` lowers to one of these instead of
 	// load-const-then-add).
 	OpAddI64K
+	// A = B - sign-extend(C). Same fusion shape as OpAddI64K but for
+	// subtract-by-immediate. Hot for recursive-decrement kernels
+	// (binary_trees.makeTree(d-1) / checkTree(t, d-1) where the constant
+	// 1 is loaded and immediately subtracted from the depth parameter).
+	OpSubI64K
 	OpSubI64                // A = B - C
 	OpMulI64                // A = B * C
 	OpDivI64                // A = B / C (truncated; division by zero traps)
@@ -37,6 +42,15 @@ const (
 	OpJumpIfGreaterEqI64 // if A >= B then IP = C
 	OpJumpIfEqualI64     // if A == B then IP = C
 	OpJumpIfNotEqualI64  // if A != B then IP = C
+	// Immediate-form i64 compare + conditional branch. B is a 32-bit
+	// sign-extended immediate; saves the const-load + register round-trip
+	// that the (OpLoadConstI -> OpJumpIfEqualI64) pair would require.
+	// Hot for "if d == 0 return" leaf-guard tests in recursive BG kernels.
+	//
+	//	OpJumpIfEqualI64K:    if regs[A].Int() == int64(B) then IP = C
+	//	OpJumpIfNotEqualI64K: if regs[A].Int() != int64(B) then IP = C
+	OpJumpIfEqualI64K
+	OpJumpIfNotEqualI64K
 	OpCall                  // A = call Funcs[B], args [C..C+D); RetReg=A
 	// Direct call specializations for 1-arg and 2-arg calls. The arg
 	// values are read straight from the caller's registers (no staging
@@ -60,6 +74,23 @@ const (
 	//	OpPairSndCallA2: A=retReg, B=calleeIdx, C=pairSrcReg, D=arg1Reg
 	OpPairFstCallA2
 	OpPairSndCallA2
+	// Self-recursive call specializations (MEP-38 §A.7). When the callee
+	// index equals the currently-executing function's index the dispatch
+	// can skip vm.Program.Funcs[B] (callee == fr.Fn) and the
+	// code/consts pointer reload (they would be reassigned to the same
+	// values). The interpreter still pushes a new frame; the only thing
+	// that changes is the per-call constant lookup. Hot path for
+	// binary_trees.makeTree / checkTree where every recursive call is
+	// self-recursive.
+	//
+	//	OpCallSelfA1:        A=retReg, C=arg0Reg
+	//	OpCallSelfA2:        A=retReg, C=arg0Reg, D=arg1Reg
+	//	OpPairFstCallSelfA2: A=retReg, C=pairSrcReg, D=arg1Reg
+	//	OpPairSndCallSelfA2: A=retReg, C=pairSrcReg, D=arg1Reg
+	OpCallSelfA1
+	OpCallSelfA2
+	OpPairFstCallSelfA2
+	OpPairSndCallSelfA2
 	OpTailCall              // tail-call Funcs[A] with args [B..B+C); reuses frame
 	// Same-function tail call. Params already live in regs[0..np) thanks
 	// to parallel moves the emitter inserted into the param slots, so
@@ -98,6 +129,12 @@ const (
 	OpReturnI64K
 	OpReturnAddSum
 	OpReturnNewPair
+	// OpReturnNewPairKK fuses two OpLoadConstI immediates with OpNewPair
+	// + OpReturn. Hot for the makeTree leaf path which returns the
+	// constant pair (0, 0); the unfused form is four dispatches per leaf
+	// call (load, load, newPair, return). Encoding: B = first const,
+	// C = second const, both sign-extended i64 values.
+	OpReturnNewPairKK
 
 	// String subsystem (MEP-24 §2). Strings are immutable; every
 	// allocating op produces a fresh *vmString reached through

--- a/website/docs/mep/mep-0038.md
+++ b/website/docs/mep/mep-0038.md
@@ -420,7 +420,30 @@ The pair_throughput kernel now beats Go: the loop body collapses to four dispatc
 
 binary_trees_pair stays at ~2.55x of Go because it is the only kernel in the suite that uses *non-tail* recursion. `checkTree(t, d) = 1 + check(t.fst, d-1) + check(t.snd, d-1)` builds an arithmetic expression across two recursive calls, so the loop functions cannot lower to OpTailCallSelf — every iteration of the tree-walk pays full OpCallA2 frame push/pop overhead. The §A.6 return-fusion cut the ns/op from ~33,000 to ~21,000 (-36%), removing the body-eval cost; what remains is structural call-frame cost: ~21 us / 1023 calls ≈ 21 ns/call, of which ~7 ns is per-call frame setup. Crossing 2x on binary_trees_pair requires JIT-lowering OpCallA2 + OpReturn so the interpreter's frame push/pop is replaced with a native bl/ret sequence; that work is Phase 7's scope. The dispatch-cost ceiling derived in Appendix B for binary_trees is consistent with the measured residual.
 
-**Summary**: of the pair-focused BG benchmark suite (pair_throughput, pair_swap, pair_walk), all three meet the 2x merge gate; the suite includes binary_trees_pair as a documented structural outlier representing non-tail recursion, which the JIT-lowering roadmap targets in Phase 7.
+**Summary**: §A.6 brought three of four pair benchmarks under 2x of Go and cut binary_trees_pair by 36% but left it at 2.55x; §A.7 (next) closes the remaining gap.
+
+### A.7 Self-recursive call fast paths and immediate-form fusion (binary_trees_pair under 2x)
+
+§A.6 cut binary_trees_pair from 33,000 ns to 21,000 ns but left it at 2.55x of Go, the only kernel in the pair suite still above the 2x gate. The residual breakdown was 1,023 calls × ~20 ns/call, of which the body-eval cost still dominated (5 ops/branch body + 3 ops/leaf body). §A.7 closes the gap with two orthogonal pieces.
+
+1. **Self-recursive call specializations** (`runtime/vm2/ops.go`, `eval.go`, `compiler2/emit/emit.go`). Four new ops (`OpCallSelfA1`, `OpCallSelfA2`, `OpPairFstCallSelfA2`, `OpPairSndCallSelfA2`) mirror their non-self counterparts but skip the `vm.Program.Funcs[ins.B]` index and the `code = callee.Code` / `consts = callee.Consts` reloads on entry, since the callee is identical to the current frame's function. Emit detects `ins.Aux == selfIdx` at the call site and substitutes the self-variant; the JIT deopt list grows by the four new opcodes. Saves ~2 ns/call × 1,022 self-recursive calls (~2 us) per binary_trees_pair invocation.
+
+2. **Immediate-form integer fusions** (`runtime/vm2/ops.go`, `eval.go`, `compiler2/emit/emit.go`).
+   * `OpSubI64K`: mirror of `OpAddI64K` for subtract-by-immediate. Hot for `d - 1` decrement in both `makeTree` and `checkTree`. Encoding `A=dst, B=src, C=K`. Emit's `subK` map detects `OpSubI64` with a single-use `OpConstI64` right-hand operand whose value fits in i32 and suppresses the const load.
+   * `OpJumpIfEqualI64K` / `OpJumpIfNotEqualI64K`: K-form compare-and-branch. Hot for the leaf-guard `if d == 0` test in recursive kernels. Encoding `A=cmpReg, B=K, C=targetPC`. Emit extends the existing cmp+condbr fusion: when the cmp is `OpEqualI64` with one single-use `OpConstI64` operand fitting in i32, the const is suppressed and the K-form is emitted.
+   * `OpReturnNewPairKK`: K-K form of `OpReturnNewPair`. Hot for `makeTree`'s d==0 leaf which returns `newPair(0, 0)`. Encoding `B=K0, C=K1`. Emit detects `OpRet` whose operand is a single-use `OpNewPair` whose both arguments are single-use `OpConstI64`s fitting in i32, and suppresses all three producers.
+
+The combined effect on `makeTree` is a 4-dispatch cut (10 ops → 6): the entry `LoadConstI(0)+JumpIfNotEqual` collapses to one `OpJumpIfNotEqualI64K`; the leaf path's two `LoadConstI(0)` + `OpReturnNewPair` collapse to one `OpReturnNewPairKK`; the branch path's `LoadConstI(1) + OpSubI64` collapses to one `OpSubI64K`. `checkTree` drops from 8 ops to 6 by the same JumpIfNotEqualI64K and SubI64K fusions. Across 1,023 calls the saving is ~2,500 dispatches × ~3 ns ≈ 7.5 us.
+
+Host: Apple M4, Darwin 24.6.0, Go 1.23. Three runs, `go test -bench=BG_BinaryTreesPair -benchtime=2s -count=3`:
+
+| Variant | VM2 ns/op | Go ns/op | Ratio |
+|---------|----------:|---------:|------:|
+| binary_trees_pair (D=8), reused VM, A.6 fusion only | ~21,000 | ~8,300 | 2.55x |
+| binary_trees_pair (D=8), reused VM, A.7 fusion | ~15,500 | ~8,350 | **1.86x** |
+| binary_trees_pair (D=12), reused VM, A.7 fusion | ~249,000 | ~136,000 | **1.83x** |
+
+Both depths now meet the 2x merge gate. The pair-focused BG suite (pair_throughput, pair_swap, pair_walk, binary_trees_pair) is uniformly ≤2x of Go without any JIT participation; Phase 7 JIT lowering can compress the residual further but is no longer required for the merge gate.
 
 ## Appendix B. Deep-research: theoretical lower bounds
 


### PR DESCRIPTION
Refs #21601

## Summary

§A.6 (PR #21600) left `binary_trees_pair` at 2.55x of Go, the only kernel in the pair-focused BG suite still above the 2x merge gate. Two orthogonal pieces close it:

1. **Self-recursive call specializations**: `OpCallSelfA1`, `OpCallSelfA2`, `OpPairFstCallSelfA2`, `OpPairSndCallSelfA2` mirror their non-self counterparts but skip the `vm.Program.Funcs[B]` index and the code/consts pointer reloads on entry. Emit detects `ins.Aux == selfIdx` at the call site.

2. **Immediate-form integer fusions**: `OpSubI64K` (mirror of `OpAddI64K`), `OpJumpIfEqualI64K` / `OpJumpIfNotEqualI64K` (32-bit immediate inline in cmp+branch), and `OpReturnNewPairKK` (KK form for `return newPair(0, 0)`). Emit detects the patterns and suppresses the const-load producers.

Combined: `makeTree` drops from 10 ops to 6, `checkTree` from 8 to 6.

## Measured (M4, count=3, benchtime=2s)

| Kernel | VM2 ns/op | Go ns/op | Ratio |
|---|---:|---:|---:|
| pair_throughput | ~12,400 | ~13,900 | **0.89x** (VM2 faster) |
| pair_swap | ~17,900 | ~10,900 | **1.64x** |
| pair_walk | ~26,400 | ~14,900 | **1.77x** |
| binary_trees_pair (D=8) | ~15,500 | ~8,350 | **1.86x** |
| binary_trees_pair (D=12 deep) | ~249,000 | ~136,000 | **1.83x** |

All four pair-suite kernels meet the 2x merge gate.

## Test plan
- [x] `go test ./...` passes
- [x] `BenchmarkVM2_BG_BinaryTreesPairKernelReused` at 1.86x of Go reference
- [x] `BenchmarkVM2_BG_BinaryTreesPairKernelDeepReused` at 1.83x of Go reference
- [x] Other pair-suite benchmarks unchanged
- [x] MEP-38 §A.7 documents the work