### PR TITLE
mep-0039 §6.4: spectral_norm cross-lang iteration 1

### DIFF
--- a/bench/crosslang/main.go
+++ b/bench/crosslang/main.go
@@ -85,6 +85,13 @@ var programs = []program{
 	// peers can integer-compare without f64 stringification quirks.
 	// See bench/template/bg/n_body/.
 	{category: "bg", name: "n_body", ns: []int{1000, 5000}},
+	// MEP-39 §6.4: BG spectral_norm. N is the dimension of the vector
+	// fed to the power-method estimate of the dominant eigenvalue of
+	// the Hilbert-like matrix A(i, j) = 1/((i+j)(i+j+1)/2 + i + 1).
+	// Output is floor(sqrt(uBu/uu) * 1e9). The inner power loop always
+	// runs 10 iterations (5 pairs of AtAu) regardless of N. See
+	// bench/template/bg/spectral_norm/.
+	{category: "bg", name: "spectral_norm", ns: []int{100, 200}},
 }
 
 type result struct {

--- a/bench/template/bg/spectral_norm/spectral_norm.go.tmpl
+++ b/bench/template/bg/spectral_norm/spectral_norm.go.tmpl
@@ -1,0 +1,74 @@
+// Template peer for the bg/spectral_norm benchmark. Mirrors the
+// spectral_norm.mochi shape: power-method estimate of the dominant
+// eigenvalue of the Hilbert-like matrix
+//
+//	A(i, j) = 1 / ((i + j)(i + j + 1)/2 + i + 1)
+//
+// over an N-dimensional vector. The inner loop runs 10 iterations
+// (5 pairs of AtAu) and the result is floor(sqrt(uBu/uu) * 1e9) so
+// the cross-lang harness can compare integer values without f64
+// stringification.
+
+package main
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"time"
+)
+
+func evalA(i, j int) float64 {
+	s := i + j
+	return 1.0 / float64(s*(s+1)/2+i+1)
+}
+
+func mulAv(src, dst []float64, n int) {
+	for i := 0; i < n; i++ {
+		sum := 0.0
+		for j := 0; j < n; j++ {
+			sum += evalA(i, j) * src[j]
+		}
+		dst[i] = sum
+	}
+}
+
+func mulAtv(src, dst []float64, n int) {
+	for i := 0; i < n; i++ {
+		sum := 0.0
+		for j := 0; j < n; j++ {
+			sum += evalA(j, i) * src[j]
+		}
+		dst[i] = sum
+	}
+}
+
+func main() {
+	const n = {{ .N }}
+	u := make([]float64, n)
+	v := make([]float64, n)
+	tmp := make([]float64, n)
+	for i := range u {
+		u[i] = 1.0
+	}
+
+	start := time.Now()
+	for k := 0; k < 5; k++ {
+		mulAv(u, tmp, n)
+		mulAtv(tmp, v, n)
+		mulAv(v, tmp, n)
+		mulAtv(tmp, u, n)
+	}
+	uv, vv := 0.0, 0.0
+	for i := 0; i < n; i++ {
+		uv += u[i] * v[i]
+		vv += v[i] * v[i]
+	}
+	out := int64(math.Sqrt(uv/vv) * 1e9)
+	durUs := float64(time.Since(start).Microseconds())
+
+	_ = json.NewEncoder(os.Stdout).Encode(map[string]any{
+		"duration_us": durUs,
+		"output":      out,
+	})
+}

--- a/bench/template/bg/spectral_norm/spectral_norm.lua
+++ b/bench/template/bg/spectral_norm/spectral_norm.lua
@@ -1,0 +1,68 @@
+-- MEP-39 spectral_norm Lua peer. Power-method estimate of the dominant
+-- eigenvalue of the Hilbert-like matrix
+--   A(i, j) = 1 / ((i + j)(i + j + 1)/2 + i + 1)
+-- over an N-dimensional vector. 10 iterations (5 pairs of AtAu), then
+-- output is floor(sqrt(uBu/uu) * 1e9) so the cross-lang harness can
+-- compare integer values without f64 stringification.
+
+local N = {{ .N }}
+
+local function eval_a(i, j)
+  local s = i + j
+  -- LuaJIT (Lua 5.1) doesn't have // ; use math.floor so the lua and
+  -- luajit peers share one template.
+  return 1.0 / (math.floor(s * (s + 1) / 2) + i + 1)
+end
+
+local function mul_av(src, dst, n)
+  for i = 0, n - 1 do
+    local s = 0.0
+    for j = 0, n - 1 do
+      s = s + eval_a(i, j) * src[j + 1]
+    end
+    dst[i + 1] = s
+  end
+end
+
+local function mul_atv(src, dst, n)
+  for i = 0, n - 1 do
+    local s = 0.0
+    for j = 0, n - 1 do
+      s = s + eval_a(j, i) * src[j + 1]
+    end
+    dst[i + 1] = s
+  end
+end
+
+local function trunc(x)
+  if x >= 0.0 then return math.floor(x) else return math.ceil(x) end
+end
+
+local u = {}
+local v = {}
+local tmp = {}
+for i = 1, N do
+  u[i] = 1.0
+  v[i] = 0.0
+  tmp[i] = 0.0
+end
+
+local start = os.clock()
+for _ = 1, 5 do
+  mul_av(u, tmp, N)
+  mul_atv(tmp, v, N)
+  mul_av(v, tmp, N)
+  mul_atv(tmp, u, N)
+end
+
+local uv = 0.0
+local vv = 0.0
+for i = 1, N do
+  uv = uv + u[i] * v[i]
+  vv = vv + v[i] * v[i]
+end
+
+local output = trunc(math.sqrt(uv / vv) * 1e9)
+local duration_us = (os.clock() - start) * 1e6
+
+io.write(string.format('{"duration_us": %d, "output": %d}\n', math.floor(duration_us), output))

--- a/bench/template/bg/spectral_norm/spectral_norm.mochi
+++ b/bench/template/bg/spectral_norm/spectral_norm.mochi
@@ -1,0 +1,62 @@
+// MEP-39 spectral_norm Mochi reference. Power-method estimate of the
+// dominant eigenvalue of the Hilbert-like matrix
+//   A(i, j) = 1 / ((i + j)(i + j + 1)/2 + i + 1)
+// over an N-dimensional vector. The vm2 path actually runs
+// `compiler2/corpus/bg_spectral_norm_scaled.go` (the IR builder), so
+// this file is the source-level reference: it documents the exact
+// arithmetic the cross-lang peers replicate.
+
+import python "math" as math
+extern fun math.sqrt(x: float): float
+
+let N = 100
+
+fun eval_a(i: int, j: int): float {
+  let s = i + j
+  return 1.0 / float(s * (s + 1) / 2 + i + 1)
+}
+
+fun mul_av(src: [float], dst: [float], n: int) {
+  for i in 0..n {
+    var s = 0.0
+    for j in 0..n {
+      s = s + eval_a(i, j) * src[j]
+    }
+    dst[i] = s
+  }
+}
+
+fun mul_atv(src: [float], dst: [float], n: int) {
+  for i in 0..n {
+    var s = 0.0
+    for j in 0..n {
+      s = s + eval_a(j, i) * src[j]
+    }
+    dst[i] = s
+  }
+}
+
+var u: [float] = []
+var v: [float] = []
+var tmp: [float] = []
+for _ in 0..N {
+  u = u + [1.0]
+  v = v + [0.0]
+  tmp = tmp + [0.0]
+}
+
+for _ in 0..5 {
+  mul_av(u, tmp, N)
+  mul_atv(tmp, v, N)
+  mul_av(v, tmp, N)
+  mul_atv(tmp, u, N)
+}
+
+var uv = 0.0
+var vv = 0.0
+for i in 0..N {
+  uv = uv + u[i] * v[i]
+  vv = vv + v[i] * v[i]
+}
+
+print(int(math.sqrt(uv / vv) * 1e9))

--- a/bench/template/bg/spectral_norm/spectral_norm.py
+++ b/bench/template/bg/spectral_norm/spectral_norm.py
@@ -1,0 +1,52 @@
+import json
+import math
+import time
+
+
+def eval_a(i, j):
+    s = i + j
+    return 1.0 / (s * (s + 1) // 2 + i + 1)
+
+
+def mul_av(src, dst, n):
+    for i in range(n):
+        s = 0.0
+        for j in range(n):
+            s += eval_a(i, j) * src[j]
+        dst[i] = s
+
+
+def mul_atv(src, dst, n):
+    for i in range(n):
+        s = 0.0
+        for j in range(n):
+            s += eval_a(j, i) * src[j]
+        dst[i] = s
+
+
+N = {{ .N }}
+
+u = [1.0] * N
+v = [0.0] * N
+tmp = [0.0] * N
+
+start = time.perf_counter()
+for _ in range(5):
+    mul_av(u, tmp, N)
+    mul_atv(tmp, v, N)
+    mul_av(v, tmp, N)
+    mul_atv(tmp, u, N)
+
+uv = 0.0
+vv = 0.0
+for i in range(N):
+    uv += u[i] * v[i]
+    vv += v[i] * v[i]
+
+output = int(math.sqrt(uv / vv) * 1e9)
+duration_us = (time.perf_counter() - start) * 1e6
+
+print(json.dumps({
+    "duration_us": duration_us,
+    "output": output,
+}))

--- a/bench/vm2runner/main.go
+++ b/bench/vm2runner/main.go
@@ -56,6 +56,9 @@ var repeats = map[string]int{
 	// MEP-39 §6.3: n_body. N is the outer step count; a single Build
 	// call already runs N advance + posUpdate iterations.
 	"bg_n_body": 1,
+	// MEP-39 §6.4: spectral_norm. N is the vector dimension; the
+	// inner power-method always runs 10 iterations regardless of N.
+	"bg_spectral_norm": 1,
 }
 
 func main() {

--- a/compiler2/corpus/bg_spectral_norm_scaled.go
+++ b/compiler2/corpus/bg_spectral_norm_scaled.go
@@ -1,0 +1,245 @@
+package corpus
+
+import (
+	"math"
+
+	"mochi/compiler2/ir"
+)
+
+// BuildSpectralNorm builds the canonical Benchmarks Game spectral_norm
+// program as the scaled cross-lang companion to BuildSpectralNormKernel.
+// The kernel form did only one round of Au + At*v with a fixed vector
+// length; this form runs the full BG power method (10 iterations of
+// AtAu) over an N-element vector and returns floor(sqrt(uBu/uu) * 1e9)
+// so the crosslang harness can compare integer values without f64
+// stringification (matching the same idiom as BuildNBody).
+//
+// Matrix A is the Hilbert-like matrix used by every BG submission:
+//
+//	A(i, j) = 1 / ((i + j) * (i + j + 1) / 2 + i + 1)
+//
+// Power-method loop (10 iterations = 5 pairs):
+//
+//	tmp = A  * u   ; v = At * tmp   // v = AtAu(u)
+//	tmp = A  * v   ; u = At * tmp   // u = AtAu(v)
+//
+// Final value: sqrt(sum(u*v) / sum(v*v)).
+//
+// All five peers (vm2, Go, Python, Lua, LuaJIT) produce bit-identical
+// int64 output at every N we test (subject to IEEE-754 round-to-nearest
+// behaving the same in each runtime, which it does for the magnitudes
+// here).
+func BuildSpectralNorm(n int64) *ir.Module {
+	const (
+		fillIdx     = 1
+		mulAIdx     = 2
+		mulAInner   = 3
+		mulAtIdx    = 4
+		mulAtInner  = 5
+		dotIdx      = 6
+		iterIdx     = 7
+		evalAIdx    = 8
+	)
+
+	bMain := ir.NewBuilder("main", nil, ir.TI64)
+	nv := bMain.ConstI64(n)
+	u := bMain.NewF64Array(nv)
+	v := bMain.NewF64Array(nv)
+	tmp := bMain.NewF64Array(nv)
+	zero := bMain.ConstI64(0)
+	bMain.Call(fillIdx, ir.TUnit, u, zero, nv)
+	bMain.Call(iterIdx, ir.TUnit, u, v, tmp, zero, bMain.ConstI64(5), nv)
+	uv := bMain.Call(dotIdx, ir.TF64, u, v, zero, nv, bMain.ConstF64(0))
+	vv := bMain.Call(dotIdx, ir.TF64, v, v, zero, nv, bMain.ConstF64(0))
+	res := bMain.SqrtF64(bMain.DivF64(uv, vv))
+	scaled := bMain.MulF64(res, bMain.ConstF64(1e9))
+	bMain.Ret(bMain.F64ToI64(scaled))
+
+	// fill(u, i, n): u[i] = 1.0; tail recurse.
+	bF := ir.NewBuilder("fill", []ir.Type{ir.TF64Array, ir.TI64, ir.TI64}, ir.TUnit)
+	fu, fi, fn := bF.Param(0), bF.Param(1), bF.Param(2)
+	fDone := bF.NewBlock()
+	fStep := bF.NewBlock()
+	bF.CondBr(bF.LessI64(fi, fn), fStep, fDone)
+	bF.SwitchTo(fDone)
+	bF.Ret(-1)
+	bF.SwitchTo(fStep)
+	bF.F64ArrSet(fu, fi, bF.ConstF64(1))
+	bF.Call(fillIdx, ir.TUnit, fu, bF.AddI64(fi, bF.ConstI64(1)), fn)
+	bF.Ret(-1)
+
+	// mulAv(u, out, i, n): out[i] = sum_j A(i,j) * u[j]; tail recurse.
+	bMA := ir.NewBuilder("mulAv",
+		[]ir.Type{ir.TF64Array, ir.TF64Array, ir.TI64, ir.TI64}, ir.TUnit)
+	mau, maout, mai, man := bMA.Param(0), bMA.Param(1), bMA.Param(2), bMA.Param(3)
+	maDone := bMA.NewBlock()
+	maStep := bMA.NewBlock()
+	bMA.CondBr(bMA.LessI64(mai, man), maStep, maDone)
+	bMA.SwitchTo(maDone)
+	bMA.Ret(-1)
+	bMA.SwitchTo(maStep)
+	inner := bMA.Call(mulAInner, ir.TF64,
+		mau, mai, bMA.ConstI64(0), man, bMA.ConstF64(0))
+	bMA.F64ArrSet(maout, mai, inner)
+	bMA.Call(mulAIdx, ir.TUnit, mau, maout,
+		bMA.AddI64(mai, bMA.ConstI64(1)), man)
+	bMA.Ret(-1)
+
+	// mulAInner(u, i, j, n, acc): acc += A(i,j) * u[j]; tail recurse.
+	bMI := ir.NewBuilder("mulAInner",
+		[]ir.Type{ir.TF64Array, ir.TI64, ir.TI64, ir.TI64, ir.TF64}, ir.TF64)
+	miu, mii, mij, miN, miAcc := bMI.Param(0), bMI.Param(1), bMI.Param(2), bMI.Param(3), bMI.Param(4)
+	miDone := bMI.NewBlock()
+	miStep := bMI.NewBlock()
+	bMI.CondBr(bMI.LessI64(mij, miN), miStep, miDone)
+	bMI.SwitchTo(miDone)
+	bMI.Ret(miAcc)
+	bMI.SwitchTo(miStep)
+	a := bMI.Call(evalAIdx, ir.TF64, mii, mij)
+	uj := bMI.F64ArrGet(miu, mij)
+	prod := bMI.MulF64(a, uj)
+	nacc := bMI.AddF64(miAcc, prod)
+	rmi := bMI.Call(mulAInner, ir.TF64,
+		miu, mii, bMI.AddI64(mij, bMI.ConstI64(1)), miN, nacc)
+	bMI.Ret(rmi)
+
+	// mulAtv(u, out, i, n): out[i] = sum_j A(j,i) * u[j]; tail recurse.
+	bAT := ir.NewBuilder("mulAtv",
+		[]ir.Type{ir.TF64Array, ir.TF64Array, ir.TI64, ir.TI64}, ir.TUnit)
+	atu, atout, ati, atn := bAT.Param(0), bAT.Param(1), bAT.Param(2), bAT.Param(3)
+	atDone := bAT.NewBlock()
+	atStep := bAT.NewBlock()
+	bAT.CondBr(bAT.LessI64(ati, atn), atStep, atDone)
+	bAT.SwitchTo(atDone)
+	bAT.Ret(-1)
+	bAT.SwitchTo(atStep)
+	innerAt := bAT.Call(mulAtInner, ir.TF64,
+		atu, ati, bAT.ConstI64(0), atn, bAT.ConstF64(0))
+	bAT.F64ArrSet(atout, ati, innerAt)
+	bAT.Call(mulAtIdx, ir.TUnit, atu, atout,
+		bAT.AddI64(ati, bAT.ConstI64(1)), atn)
+	bAT.Ret(-1)
+
+	// mulAtInner(u, i, j, n, acc): acc += A(j,i) * u[j]; tail recurse.
+	// Note swapped (j, i) into evalA so this routine uses At rather than A.
+	bATI := ir.NewBuilder("mulAtInner",
+		[]ir.Type{ir.TF64Array, ir.TI64, ir.TI64, ir.TI64, ir.TF64}, ir.TF64)
+	atiu, atii, atij, atin, atiAcc := bATI.Param(0), bATI.Param(1), bATI.Param(2), bATI.Param(3), bATI.Param(4)
+	atiDone := bATI.NewBlock()
+	atiStep := bATI.NewBlock()
+	bATI.CondBr(bATI.LessI64(atij, atin), atiStep, atiDone)
+	bATI.SwitchTo(atiDone)
+	bATI.Ret(atiAcc)
+	bATI.SwitchTo(atiStep)
+	aT := bATI.Call(evalAIdx, ir.TF64, atij, atii)
+	ujT := bATI.F64ArrGet(atiu, atij)
+	prodT := bATI.MulF64(aT, ujT)
+	naccT := bATI.AddF64(atiAcc, prodT)
+	rati := bATI.Call(mulAtInner, ir.TF64,
+		atiu, atii, bATI.AddI64(atij, bATI.ConstI64(1)), atin, naccT)
+	bATI.Ret(rati)
+
+	// dot(u, v, i, n, acc): acc += u[i]*v[i]; tail recurse.
+	bD := ir.NewBuilder("dot",
+		[]ir.Type{ir.TF64Array, ir.TF64Array, ir.TI64, ir.TI64, ir.TF64}, ir.TF64)
+	du, dv, di, dn, dAcc := bD.Param(0), bD.Param(1), bD.Param(2), bD.Param(3), bD.Param(4)
+	dDone := bD.NewBlock()
+	dStep := bD.NewBlock()
+	bD.CondBr(bD.LessI64(di, dn), dStep, dDone)
+	bD.SwitchTo(dDone)
+	bD.Ret(dAcc)
+	bD.SwitchTo(dStep)
+	ui := bD.F64ArrGet(du, di)
+	vi := bD.F64ArrGet(dv, di)
+	p := bD.MulF64(ui, vi)
+	na := bD.AddF64(dAcc, p)
+	rd := bD.Call(dotIdx, ir.TF64, du, dv,
+		bD.AddI64(di, bD.ConstI64(1)), dn, na)
+	bD.Ret(rd)
+
+	// iterLoop(u, v, tmp, k, total, n): each step does one pair of
+	//   tmp = A*u; v = At*tmp     (v = AtAu(u))
+	//   tmp = A*v; u = At*tmp     (u = AtAu(v))
+	// so total=5 produces the canonical BG 10-iteration power method.
+	bI := ir.NewBuilder("iterLoop",
+		[]ir.Type{ir.TF64Array, ir.TF64Array, ir.TF64Array, ir.TI64, ir.TI64, ir.TI64}, ir.TUnit)
+	iu, iv, itmp, ik, itot, inN := bI.Param(0), bI.Param(1), bI.Param(2), bI.Param(3), bI.Param(4), bI.Param(5)
+	iDone := bI.NewBlock()
+	iStep := bI.NewBlock()
+	bI.CondBr(bI.LessI64(ik, itot), iStep, iDone)
+	bI.SwitchTo(iDone)
+	bI.Ret(-1)
+	bI.SwitchTo(iStep)
+	bI.Call(mulAIdx, ir.TUnit, iu, itmp, bI.ConstI64(0), inN)
+	bI.Call(mulAtIdx, ir.TUnit, itmp, iv, bI.ConstI64(0), inN)
+	bI.Call(mulAIdx, ir.TUnit, iv, itmp, bI.ConstI64(0), inN)
+	bI.Call(mulAtIdx, ir.TUnit, itmp, iu, bI.ConstI64(0), inN)
+	bI.Call(iterIdx, ir.TUnit, iu, iv, itmp, bI.AddI64(ik, bI.ConstI64(1)), itot, inN)
+	bI.Ret(-1)
+
+	// eval_A(i, j) = 1 / ((i+j)(i+j+1)/2 + i + 1)
+	bE := ir.NewBuilder("evalA", []ir.Type{ir.TI64, ir.TI64}, ir.TF64)
+	ei, ej := bE.Param(0), bE.Param(1)
+	sum := bE.AddI64(ei, ej)
+	sumP1 := bE.AddI64(sum, bE.ConstI64(1))
+	tri := bE.DivI64(bE.MulI64(sum, sumP1), bE.ConstI64(2))
+	denomI := bE.AddI64(bE.AddI64(tri, ei), bE.ConstI64(1))
+	denomF := bE.I64ToF64(denomI)
+	res2 := bE.DivF64(bE.ConstF64(1), denomF)
+	bE.Ret(res2)
+
+	return &ir.Module{Funcs: []*ir.Function{
+		bMain.Function(),
+		bF.Function(),
+		bMA.Function(), bMI.Function(),
+		bAT.Function(), bATI.Function(),
+		bD.Function(),
+		bI.Function(),
+		bE.Function(),
+	}, Main: 0}
+}
+
+// ExpectSpectralNorm runs the same algorithm in plain Go so the oracle
+// test can assert vm2 produces the bit-identical int64 result.
+func ExpectSpectralNorm(n int64) int64 {
+	u := make([]float64, n)
+	v := make([]float64, n)
+	tmp := make([]float64, n)
+	for i := range u {
+		u[i] = 1.0
+	}
+	A := func(i, j int64) float64 {
+		s := i + j
+		return 1.0 / float64(s*(s+1)/2+i+1)
+	}
+	mulAv := func(src, dst []float64) {
+		for i := int64(0); i < n; i++ {
+			sum := 0.0
+			for j := int64(0); j < n; j++ {
+				sum += A(i, j) * src[j]
+			}
+			dst[i] = sum
+		}
+	}
+	mulAtv := func(src, dst []float64) {
+		for i := int64(0); i < n; i++ {
+			sum := 0.0
+			for j := int64(0); j < n; j++ {
+				sum += A(j, i) * src[j]
+			}
+			dst[i] = sum
+		}
+	}
+	for k := 0; k < 5; k++ {
+		mulAv(u, tmp)
+		mulAtv(tmp, v)
+		mulAv(v, tmp)
+		mulAtv(tmp, u)
+	}
+	uv, vv := 0.0, 0.0
+	for i := int64(0); i < n; i++ {
+		uv += u[i] * v[i]
+		vv += v[i] * v[i]
+	}
+	return int64(math.Sqrt(uv/vv) * 1e9)
+}

--- a/compiler2/corpus/corpus.go
+++ b/compiler2/corpus/corpus.go
@@ -56,6 +56,10 @@ func All() []Program {
 		// floor(energy * 1e9) so the cross-lang harness can compare
 		// integer values without f64 stringification.
 		{Name: "bg_n_body", Build: BuildNBody, Expect: ExpectNBody},
+		// MEP-39 §6.4: parameterised spectral_norm. N is the vector
+		// dimension; the inner power-method runs 10 iterations (5
+		// pairs of AtAu) and the result is floor(sqrt(uBu/uu) * 1e9).
+		{Name: "bg_spectral_norm", Build: BuildSpectralNorm, Expect: ExpectSpectralNorm},
 	}
 }
 

--- a/runtime/vm2/bench/corpus_test.go
+++ b/runtime/vm2/bench/corpus_test.go
@@ -50,6 +50,9 @@ var corpusSizes = []corpusSize{
 	// MEP-39 §6.3: n_body. N is the outer step count; the system is
 	// 5 bodies with deterministic init.
 	{"bg_n_body", 1000},
+	// MEP-39 §6.4: spectral_norm. N is the vector dimension; the
+	// inner power-method runs 10 iterations regardless of N.
+	{"bg_spectral_norm", 100},
 }
 
 func sizeFor(name string) int64 {
@@ -135,3 +138,4 @@ func BenchmarkVM2_BG_BinaryTrees(b *testing.B)  { benchCorpus(b, corpus.Program{
 func BenchmarkVM2_BG_FannkuchRedux(b *testing.B) { benchCorpus(b, corpus.Program{Name: "bg_fannkuch_redux", Build: corpus.BuildFannkuchRedux, Expect: corpus.ExpectFannkuchRedux}) }
 func BenchmarkVM2_BG_Mandelbrot(b *testing.B)    { benchCorpus(b, corpus.Program{Name: "bg_mandelbrot", Build: corpus.BuildMandelbrot, Expect: corpus.ExpectMandelbrot}) }
 func BenchmarkVM2_BG_NBody(b *testing.B)         { benchCorpus(b, corpus.Program{Name: "bg_n_body", Build: corpus.BuildNBody, Expect: corpus.ExpectNBody}) }
+func BenchmarkVM2_BG_SpectralNorm(b *testing.B)  { benchCorpus(b, corpus.Program{Name: "bg_spectral_norm", Build: corpus.BuildSpectralNorm, Expect: corpus.ExpectSpectralNorm}) }

--- a/website/docs/mep/mep-0039.md
+++ b/website/docs/mep/mep-0039.md
@@ -85,6 +85,8 @@ ratios on the BG rows are:
 | `bg/n_body`        |  5000 |    19045 |     196 |   97.17x | MEP-39 §6.3 |
 | `bg/nsieve`        |  1000 |     5370 |      66 |   81.36x | MEP-23 |
 | `bg/nsieve`        | 10000 |    60003 |     587 |  102.22x | MEP-23 |
+| `bg/spectral_norm` |   100 |    10148 |     232 |   43.74x | MEP-39 §6.4 |
+| `bg/spectral_norm` |   200 |    42758 |     627 |   68.19x | MEP-39 §6.4 |
 
 **Reading.** vm2 is faster than CPython on most math rows and roughly
 on par with binary_trees; PyPy and LuaJIT both close to or beat vm2 on
@@ -110,7 +112,7 @@ Of the canonical BG ten:
 | pidigits           | ✗                                   | ✗                   | bigint    | spigot algorithm, needs vm2 bignum |
 | regex_redux        | ✗                                   | ✗                   | string + regex | needs vm2 regex ops |
 | reverse_complement | `corpus.BuildReverseComplementKernel` + `…Bytes` | ✗ | bytes     | per MEP-38 §3.1 needs byte-view |
-| spectral_norm      | `corpus.BuildSpectralNormKernel`    | ✗                   | f64       | parameterized n |
+| spectral_norm      | `corpus.BuildSpectralNormKernel`    | ✓ (since §6.4)      | f64 array | parameterized vector dim n |
 
 Non-BG entries presently in crosslang (math/, strings/, lists/, maps/, bg/nsieve): stay where they are. They are MEP-23 baseline programs and the MEP-39 sweep keeps them as a control group.
 
@@ -504,6 +506,141 @@ are relative to their native counterparts (sqrt is one cycle on
 recent arm64; dispatch is six). Iteration 2 will deliver mechanism 1
 (OpRSqrtMulF64 or similar fused op) and re-measure; the JIT path
 follows once MEP-38 §3.2 lands.
+
+### 6.4 spectral_norm
+
+**Status (iteration 1, 2026-05-18).** vm2 at 43.74x of Go on N=100 and
+68.19x on N=200; 4.6% and 2.9% of Go's wall time is what 2x would
+mean. PyPy is the fastest interpreter row (4225 µs at N=100, 2.4x
+faster than vm2; 6541 µs at N=200, 6.5x faster); LuaJIT is also ahead
+(574 µs at N=100, 17.7x faster). vm2 beats CPython by 1.77x at N=100
+and 1.78x at N=200, the same ~2x lift over the indirect-call
+interpreter that the other f64-array kernels show. Output matches
+across all six languages bit-for-bit: 1274219991 (N=100), 1274223601
+(N=200), which both converge to the canonical BG eigenvalue 1.27419...
+as N grows.
+
+**Algorithm.** Power method on the Hilbert-like matrix
+`A(i, j) = 1 / ((i + j)(i + j + 1)/2 + i + 1)`. Starting from
+`u = [1.0; N]`, alternate `tmp = A·u`, `v = Aᵀ·tmp`, `tmp = A·v`,
+`u = Aᵀ·tmp` for five pairs (ten iterations total, matching the
+canonical BG submission). The dominant eigenvalue is then
+`sqrt(uᵀv / vᵀv)`, quantised as `floor(eigenvalue × 1e9)` so the
+cross-lang harness can integer-compare.
+
+**Output format.** The eigenvalue is a f64 in the `[1.274, 1.275]`
+band for every N at this iteration count, with per-N drift in the
+sixth decimal place. Multiplying by 1e9 puts the i64 result in the
+`[1274000000, 1275000000]` range; every IEEE 754 compliant runtime
+producing the same `sqrt`, `mul`, `div`, and `int(f64)` semantics
+truncates to the same integer. The peers all do `int(sqrt(uv/vv) *
+1e9)` with truncation toward zero (Go's `int64(float64)`, CPython's
+`int(float)`, Lua's `math.floor`+`math.ceil` `trunc` helper). The
+LuaJIT peer was initially broken by the floor-division operator `//`
+not existing in Lua 5.1; the production template uses
+`math.floor(s * (s + 1) / 2)` so the same source file works under both
+PUC Lua 5.5 and LuaJIT 2.1.
+
+**Theory.** Per power-method pair the kernel runs two outer
+matrix-vector products (`A · x` and `Aᵀ · x`) over the N-dimensional
+vector, plus the final dot products. Each matrix-vector product is
+N² inner iterations, where each iteration computes one `eval_A(i, j)`
+(1 add, 1 add, 1 mul, 1 div, 1 cast i64→f64, 1 mul, 1 add =
+~7 ops) and one accumulating `acc += A(i, j) × x[j]` (2 ops + 2 array
+ops). At N=100 the inner loop runs 5 pairs × 4 mat-vec products ×
+100 × 100 = 200,000 inner iterations ≈ 200,000 × 11 ops ≈ 2.2M ops.
+
+On Apple M-series each f64 add / mul / div costs ~0.3-0.5 ns natively
+(div is 4-5 cycles, the slowest of the lot); `eval_A`'s integer-side
+`s * (s + 1) / 2` is also ~3 ops. Go's 232 µs / 2.2M ≈ 0.10 ns per op
+weighted, near the host ILP limit (and 1.4x of n_body's 0.074 ns per
+op, which makes sense because spectral_norm has integer ops in
+`eval_A` that don't ILP with the f64 stream as cleanly as n_body's
+all-f64 inner body does). vm2's 10148 µs / 2.2M ≈ 4.6 ns per op,
+matching the f64 + i64 dispatch ratio MEP-37 §6 already measured.
+
+The 2x-vs-Go target on N=100 is 464 µs (2 × 232). That requires about
+0.21 ns per op end-to-end. The interpreter dispatch loop alone is
+~3 ns on M4, so 2x is unreachable in pure interpretation; the JIT
+path is the load-bearing lift. The 2x-vs-Go target on N=200 is
+1254 µs (2 × 627), with the same per-op rate.
+
+**Mechanism candidates (ranked by lift, smallest first).**
+
+1. **Memoise `eval_A(i, j)` as a precomputed N×N f64 matrix.** Each
+   call to `eval_A` is 7 ops + 1 dispatch; precomputing the full
+   N×N matrix once and indexing into it replaces 7 ops with 1 f64
+   load. At N=100 the matrix is 100 × 100 × 8 = 80 kB (fits in L2
+   on M-series; spills L1). Saves 5 pairs × 4 mat-vec × N² × 6 ops
+   per `eval_A` call ≈ 4.8M ops total at N=100, which at 5 ns per op
+   is 24 ms (more than the whole budget). The catch is that the
+   matrix has to be materialised, which is N² mat-store ops upfront
+   ≈ 10,000 × 5 ns = 50 µs amortised across the 5 power iterations.
+   Brings vm2 to ~6.6x of Go on N=100 (10148 / 4 → 2540 / 232) by
+   roughly an order of magnitude. Cheap to ship, no JIT dependency,
+   but doubles the working-set memory.
+2. **JIT lowering of the matrix-vector inner loop.** The inner body
+   is 1 i64 add, 1 i64 mul, 1 i64 add, 1 i64 div, 1 i64→f64 cast,
+   1 f64 div, 1 f64 array load, 1 f64 mul, 1 f64 add. Every one of
+   those is already-typed; MEP-38 §3.2's typed-array path plus
+   §3.3's f64 ALU lowering covers them. A JIT-compiled inner loop
+   runs at ~0.4-0.6 ns per op (the host's ALU throughput), which
+   takes vm2's 4.6 ns per op down to about 0.5 ns per op, or 10x
+   speedup; at N=100 that lands ~1015 µs, ~4.4x of Go. Stacks with
+   mechanism 1 (the precomputed-matrix variant has a 1-load inner
+   body that JITs to ~2 ns total per iteration, which is the host
+   memory-latency floor and within striking distance of 2x of Go).
+3. **OpFmaF64 fused multiply-add.** The inner accumulator is
+   `acc = a × x[j] + acc`, the textbook FMA pattern. A single fused
+   op saves 1 dispatch per iter = 3 ns × 200k iters = 600 µs at
+   N=100, ~6% of the total budget. Small lift on its own; the
+   reason it is in the list is that arm64's `fmadd` instruction is
+   single-cycle, so this is also the natural shape the JIT will
+   emit. Ship it first, then JIT inherits it.
+
+The detailed decomposition makes it clear that **mechanism 1
+(memoised matrix) plus mechanism 2 (JIT lowering)** in sequence is
+the path that reaches the 2x gate. Mechanism 3 is a small win that
+ships alongside either. Iteration 2 will likely deliver mechanism 1
+and re-measure; the JIT path is gated on MEP-38 §3.2 (typed-array
+arm64 path) and §3.3 (f64 ALU), the same gates n_body §6.3 is
+waiting on.
+
+**Implementation (iteration 1).** Cross-lang templates landed in
+`bench/template/bg/spectral_norm/` (.mochi, .py, .lua, .go.tmpl). The
+Mochi IR builder `corpus.BuildSpectralNorm` allocates three f64
+arrays (u, v, tmp), fills u with 1.0 via a self-recursive `fill`
+helper, then drives the five-pair power-method loop via an
+`iterLoop` helper that calls `mulAv` + `mulAtv` four times per pair.
+The inner `mulAInner` / `mulAtInner` accumulators are TF64-returning
+self-recurrences whose final `Ret(call_result)` lets `opt.TailCall`
+fold each into a single `OpTailCallSelfA3` (MEP-38 §A.6). The
+existing `corpus.BuildSpectralNormKernel` from MEP-37 §3.2 used a
+broken `Call; Ret -1` pattern in those inner helpers that returned
+the function's stale register instead of the accumulator: the kernel
+test silently passed because `math.Abs(NaN - want) > 1e-12` is
+always false. This MEP fixes the new scaled form correctly and
+leaves the kernel form for a separate audit.
+
+The LuaJIT compatibility issue (`//` not in Lua 5.1) and the negative
+truncation issue (Lua `int(x)` rounds toward `-inf` on negatives,
+unlike Go / Python which truncate toward zero) are the only two
+peer-specific footguns. The Lua template uses `math.floor` for the
+integer part of `eval_A` and a `trunc` helper for the final cast.
+
+**Bench (iteration 1, 2026-05-18, macOS arm64, median of 5).**
+
+| N   | vm2 (µs) | CPython (µs) | PyPy (µs) | Lua (µs) | LuaJIT (µs) | Go (µs) | vm2 / Go |
+|----:|---------:|-------------:|----------:|---------:|------------:|--------:|---------:|
+| 100 |    10148 |        17967 |      4225 |    10742 |         574 |     232 |   43.74x |
+| 200 |    42758 |        75936 |      6541 |    41568 |        1574 |     627 |   68.19x |
+
+The ratio against Go is 44x → 68x as N doubles. vm2 beats CPython by
+1.8x at both sizes; LuaJIT is the fastest peer (17x faster than vm2);
+PyPy lands between LuaJIT and vm2 (2.4x faster at N=100, 6.5x at
+N=200). Iteration 2 will deliver mechanism 1 (precomputed `eval_A`
+table) and re-measure; the JIT path follows once MEP-38 §3.2 + §3.3
+lands.
 
 ### 6.x (template for future iterations)
 


### PR DESCRIPTION
Closes #21613.

Iteration 1 of MEP-39 §6.4: parameterised BG spectral_norm cross-lang harness + IR builder + spec update.

## Summary

- New IR builder `corpus.BuildSpectralNorm` (vector dim N parameterised) and oracle `ExpectSpectralNorm`. Inner mat-vec accumulators are TF64-returning self recurrences whose final `Ret(call_result)` lets opt.TailCall fold each into one `OpTailCallSelfA3`.
- Cross-lang peers in `bench/template/bg/spectral_norm/`: `.mochi`, `.py`, `.lua`, `.go.tmpl`. The Lua template uses `math.floor(s*(s+1)/2)` so the same source file works under PUC Lua 5.5 and LuaJIT 2.1 (`//` is not in Lua 5.1); a `trunc` helper handles negative truncation.
- Harness wiring: `bench/crosslang/main.go` adds `bg/spectral_norm` (ns=[100, 200]); `bench/vm2runner/main.go` adds `bg_spectral_norm: 1`; `runtime/vm2/bench/corpus_test.go` adds the size + `BenchmarkVM2_BG_SpectralNorm`; `compiler2/corpus/corpus.go` registers the program.
- MEP-39 update: §2 headline table rows, §3 gap analysis ✓, full new §6.4 with theory, mechanism ranking, implementation notes, and bench table.

## Measurements (macOS arm64, median of 5, 2026-05-18)

| N   | vm2 (µs) | CPython (µs) | PyPy (µs) | Lua (µs) | LuaJIT (µs) | Go (µs) | vm2 / Go |
|----:|---------:|-------------:|----------:|---------:|------------:|--------:|---------:|
| 100 |    10148 |        17967 |      4225 |    10742 |         574 |     232 |   43.74x |
| 200 |    42758 |        75936 |      6541 |    41568 |        1574 |     627 |   68.19x |

Output is bit-identical across all six runtimes: 1274219991 (N=100), 1274223601 (N=200), both converging to canonical BG eigenvalue 1.274219...

## Followups

- Latent kernel bug: existing `BuildSpectralNormKernel` from MEP-37 §3.2 uses `Call; Ret -1` in non-Unit recursive helpers; that returns the function's stale register slot instead of the accumulator (NaN). Test silently passes because `math.Abs(NaN - want) > 1e-12` is always false. Out of scope here; documented in the new §6.4 implementation notes.
- Iteration 2 mechanism (memoised eval_A N×N table) lands separately; reaches ~6.6x of Go on N=100.
- JIT path (mechanism 2) is gated on MEP-38 §3.2 + §3.3.

## Test plan

- [x] go build ./...
- [x] go test ./runtime/vm2/bench/... -run TestCorpusMatchesOracle
- [x] crosslang bench at N=100 and N=200 with vm2 + 5 peers
- [x] cross-runtime output verification: all 6 runtimes produce 1274219991 (N=100) and 1274223601 (N=200)