### PR TITLE
mep-0039 §6.5: reverse_complement cross-lang iteration 1

### DIFF
--- a/bench/crosslang/main.go
+++ b/bench/crosslang/main.go
@@ -92,6 +92,12 @@ var programs = []program{
 	// runs 10 iterations (5 pairs of AtAu) regardless of N. See
 	// bench/template/bg/spectral_norm/.
 	{category: "bg", name: "spectral_norm", ns: []int{100, 200}},
+	// MEP-39 §6.5: BG reverse_complement. N is the buffer length;
+	// the buffer is filled with the ACGT cycle, the entire range
+	// is reverse-complemented into a second buffer, and the peers
+	// integer-compare sum(out). When N is a multiple of 4, the
+	// expected output is (N/4) * 287. See bench/template/bg/reverse_complement/.
+	{category: "bg", name: "reverse_complement", ns: []int{4096, 16384}},
 }
 
 type result struct {

--- a/bench/template/bg/reverse_complement/reverse_complement.go.tmpl
+++ b/bench/template/bg/reverse_complement/reverse_complement.go.tmpl
@@ -1,0 +1,54 @@
+// Template peer for the bg/reverse_complement benchmark. Mirrors
+// the reverse_complement.mochi shape: fill an N-byte buffer with the
+// repeating "ACGT" pattern, reverse-complement into a second buffer
+// (A<->T, C<->G), then return sum(out) as int64 so the cross-lang
+// harness can integer-compare. When N is a multiple of 4 the result
+// is (N/4) * 287.
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+)
+
+func complement(c byte) byte {
+	switch c {
+	case 'A':
+		return 'T'
+	case 'T':
+		return 'A'
+	case 'C':
+		return 'G'
+	case 'G':
+		return 'C'
+	default:
+		return c
+	}
+}
+
+func main() {
+	const n = {{ .N }}
+	in := make([]byte, n)
+	out := make([]byte, n)
+	bases := [4]byte{'A', 'C', 'G', 'T'}
+
+	start := time.Now()
+	for i := 0; i < n; i++ {
+		in[i] = bases[i%4]
+	}
+	for i := 0; i < n; i++ {
+		out[n-1-i] = complement(in[i])
+	}
+	var sum int64
+	for i := 0; i < n; i++ {
+		sum += int64(out[i])
+	}
+	durUs := float64(time.Since(start).Microseconds())
+
+	_ = json.NewEncoder(os.Stdout).Encode(map[string]any{
+		"duration_us": durUs,
+		"output":      sum,
+	})
+}

--- a/bench/template/bg/reverse_complement/reverse_complement.lua
+++ b/bench/template/bg/reverse_complement/reverse_complement.lua
@@ -1,0 +1,36 @@
+-- MEP-39 reverse_complement Lua peer. Fill an N-byte buffer with the
+-- ACGT cycle, reverse-complement into a second buffer (A<->T, C<->G),
+-- and sum the output as int64 so the cross-lang harness can
+-- integer-compare. When N is a multiple of 4 the result is
+-- (N/4) * 287.
+
+local N = {{ .N }}
+
+local function complement(c)
+  if c == 65 then return 84
+  elseif c == 84 then return 65
+  elseif c == 67 then return 71
+  elseif c == 71 then return 67
+  else return c end
+end
+
+local bases = {65, 67, 71, 84}
+local in_buf = {}
+local out_buf = {}
+
+local start = os.clock()
+for i = 0, N - 1 do
+  in_buf[i + 1] = bases[(i % 4) + 1]
+end
+for i = 0, N - 1 do
+  out_buf[N - i] = complement(in_buf[i + 1])
+end
+
+local total = 0
+for i = 1, N do
+  total = total + out_buf[i]
+end
+
+local duration_us = (os.clock() - start) * 1e6
+
+io.write(string.format('{"duration_us": %d, "output": %d}\n', math.floor(duration_us), total))

--- a/bench/template/bg/reverse_complement/reverse_complement.mochi
+++ b/bench/template/bg/reverse_complement/reverse_complement.mochi
@@ -1,0 +1,41 @@
+// MEP-39 reverse_complement Mochi reference. Fill an N-byte buffer
+// with the repeating ACGT cycle, reverse-complement into a second
+// buffer (A<->T, C<->G), and print sum(out). The vm2 path actually
+// runs `compiler2/corpus/bg_reverse_complement_scaled.go` (the IR
+// builder); this file is the source-level reference documenting the
+// arithmetic the cross-lang peers replicate. When N is a multiple
+// of 4 the result is (N/4) * 287.
+
+let N = 4096
+
+fun complement(c: int): int {
+  if c == 65 { return 84 }
+  if c == 84 { return 65 }
+  if c == 67 { return 71 }
+  if c == 71 { return 67 }
+  return c
+}
+
+var in_buf: [int] = []
+var out_buf: [int] = []
+for _ in 0..N {
+  in_buf = in_buf + [0]
+  out_buf = out_buf + [0]
+}
+
+let bases: [int] = [65, 67, 71, 84]
+
+for i in 0..N {
+  in_buf[i] = bases[i % 4]
+}
+
+for i in 0..N {
+  out_buf[N - 1 - i] = complement(in_buf[i])
+}
+
+var total = 0
+for i in 0..N {
+  total = total + out_buf[i]
+}
+
+print(total)

--- a/bench/template/bg/reverse_complement/reverse_complement.py
+++ b/bench/template/bg/reverse_complement/reverse_complement.py
@@ -1,0 +1,38 @@
+import json
+import time
+
+
+COMPL = {
+    ord('A'): ord('T'),
+    ord('T'): ord('A'),
+    ord('C'): ord('G'),
+    ord('G'): ord('C'),
+}
+
+
+def complement(c):
+    return COMPL.get(c, c)
+
+
+N = {{ .N }}
+
+bases = (ord('A'), ord('C'), ord('G'), ord('T'))
+in_buf = bytearray(N)
+out_buf = bytearray(N)
+
+start = time.perf_counter()
+for i in range(N):
+    in_buf[i] = bases[i % 4]
+for i in range(N):
+    out_buf[N - 1 - i] = complement(in_buf[i])
+
+total = 0
+for i in range(N):
+    total += out_buf[i]
+
+duration_us = (time.perf_counter() - start) * 1e6
+
+print(json.dumps({
+    "duration_us": duration_us,
+    "output": total,
+}))

--- a/bench/vm2runner/main.go
+++ b/bench/vm2runner/main.go
@@ -59,6 +59,9 @@ var repeats = map[string]int{
 	// MEP-39 §6.4: spectral_norm. N is the vector dimension; the
 	// inner power-method always runs 10 iterations regardless of N.
 	"bg_spectral_norm": 1,
+	// MEP-39 §6.5: reverse_complement. N is the buffer length; one
+	// fill + one reverse-complement pass + one sum at that size.
+	"bg_reverse_complement": 1,
 }
 
 func main() {

--- a/compiler2/corpus/bg_reverse_complement_scaled.go
+++ b/compiler2/corpus/bg_reverse_complement_scaled.go
@@ -1,0 +1,193 @@
+package corpus
+
+import "mochi/compiler2/ir"
+
+// BuildReverseComplement is the scaled cross-lang companion to
+// BuildReverseComplementKernel. The kernel form uses a hard-coded
+// N=1024 buffer; this form takes N as a parameter so the cross-lang
+// harness can sweep buffer sizes.
+//
+// The arithmetic boils down to:
+//
+//	in := bytes[0..N), filled with the repeating "ACGT" pattern
+//	out[N-1-i] := complement(in[i]) for every i in [0, N)
+//	return sum(out)
+//
+// When N is a multiple of 4, the sum is deterministic and equals
+// (N/4) * (65+67+71+84) = (N/4) * 287; the cross-lang harness uses
+// this single i64 to integer-compare every peer.
+//
+// Six hand-written IR functions, identical in shape to the kernel
+// form:
+//
+//	main()                       = fillInput; rcLoop; sumBytes; return sum
+//	fillInput(in, i, n)          = tail-rec, in[i] = baseFor(i%4)
+//	baseFor(k) -> i64            = "ACGT"[k] dispatch (k in 0..3)
+//	rcLoop(in, out, i, n)        = tail-rec, out[n-1-i] = complement(in[i])
+//	complement(c) -> i64         = A<->T, C<->G dispatch on the input byte
+//	sumBytes(arr, i, n, acc)     = tail-rec accumulator
+//
+// All recursive loops are tail-call shaped. The accumulator
+// (sumBytes) uses Ret(call_result) so opt.TailCall folds it into a
+// single OpTailCallSelfA4; the other helpers return TUnit and use
+// Ret(-1) after the recursive call, the same idiom the kernel form
+// uses (and the same idiom every other scaled BG builder uses for
+// TUnit recursion).
+func BuildReverseComplement(n int64) *ir.Module {
+	const (
+		fillIdx = 1
+		baseIdx = 2
+		rcIdx   = 3
+		compIdx = 4
+		sumIdx  = 5
+	)
+
+	bMain := ir.NewBuilder("main", nil, ir.TI64)
+	nv := bMain.ConstI64(n)
+	in := bMain.NewU8Array(nv)
+	out := bMain.NewU8Array(nv)
+	bMain.Call(fillIdx, ir.TUnit, in, bMain.ConstI64(0), nv)
+	bMain.Call(rcIdx, ir.TUnit, in, out, bMain.ConstI64(0), nv)
+	sum := bMain.Call(sumIdx, ir.TI64, out, bMain.ConstI64(0), nv, bMain.ConstI64(0))
+	bMain.Ret(sum)
+
+	// fillInput(in, i, n): in[i] = baseFor(i%4); recurse with i+1 until i>=n.
+	bF := ir.NewBuilder("fillInput",
+		[]ir.Type{ir.TU8Array, ir.TI64, ir.TI64}, ir.TUnit)
+	fIn, fI, fN := bF.Param(0), bF.Param(1), bF.Param(2)
+	fDone := bF.NewBlock()
+	fStep := bF.NewBlock()
+	bF.CondBr(bF.LessI64(fI, fN), fStep, fDone)
+	bF.SwitchTo(fDone)
+	bF.Ret(-1)
+	bF.SwitchTo(fStep)
+	mod4 := bF.ModI64(fI, bF.ConstI64(4))
+	v := bF.Call(baseIdx, ir.TI64, mod4)
+	bF.U8ArrSet(fIn, fI, v)
+	bF.Call(fillIdx, ir.TUnit, fIn,
+		bF.AddI64(fI, bF.ConstI64(1)), fN)
+	bF.Ret(-1)
+
+	// baseFor(k) -> i64: 0='A'(65), 1='C'(67), 2='G'(71), 3='T'(84).
+	bB := ir.NewBuilder("baseFor", []ir.Type{ir.TI64}, ir.TI64)
+	bK := bB.Param(0)
+	bbA := bB.NewBlock()
+	bbChk1 := bB.NewBlock()
+	bbC := bB.NewBlock()
+	bbChk2 := bB.NewBlock()
+	bbG := bB.NewBlock()
+	bbT := bB.NewBlock()
+	bB.CondBr(bB.EqualI64(bK, bB.ConstI64(0)), bbA, bbChk1)
+	bB.SwitchTo(bbA)
+	bB.Ret(bB.ConstI64(65))
+	bB.SwitchTo(bbChk1)
+	bB.CondBr(bB.EqualI64(bK, bB.ConstI64(1)), bbC, bbChk2)
+	bB.SwitchTo(bbC)
+	bB.Ret(bB.ConstI64(67))
+	bB.SwitchTo(bbChk2)
+	bB.CondBr(bB.EqualI64(bK, bB.ConstI64(2)), bbG, bbT)
+	bB.SwitchTo(bbG)
+	bB.Ret(bB.ConstI64(71))
+	bB.SwitchTo(bbT)
+	bB.Ret(bB.ConstI64(84))
+
+	// rcLoop(in, out, i, n): out[n-1-i] = complement(in[i]); recurse with i+1.
+	bR := ir.NewBuilder("rcLoop",
+		[]ir.Type{ir.TU8Array, ir.TU8Array, ir.TI64, ir.TI64}, ir.TUnit)
+	rIn, rOut, rI, rN := bR.Param(0), bR.Param(1), bR.Param(2), bR.Param(3)
+	rDone := bR.NewBlock()
+	rStep := bR.NewBlock()
+	bR.CondBr(bR.LessI64(rI, rN), rStep, rDone)
+	bR.SwitchTo(rDone)
+	bR.Ret(-1)
+	bR.SwitchTo(rStep)
+	srcByte := bR.U8ArrGet(rIn, rI)
+	comp := bR.Call(compIdx, ir.TI64, srcByte)
+	dstIdx := bR.SubI64(bR.SubI64(rN, bR.ConstI64(1)), rI)
+	bR.U8ArrSet(rOut, dstIdx, comp)
+	bR.Call(rcIdx, ir.TUnit, rIn, rOut,
+		bR.AddI64(rI, bR.ConstI64(1)), rN)
+	bR.Ret(-1)
+
+	// complement(c) -> i64: A(65)<->T(84), C(67)<->G(71). Other bytes pass through.
+	bC := ir.NewBuilder("complement", []ir.Type{ir.TI64}, ir.TI64)
+	cC := bC.Param(0)
+	cIsA := bC.NewBlock()
+	cChkT := bC.NewBlock()
+	cIsT := bC.NewBlock()
+	cChkC := bC.NewBlock()
+	cIsC := bC.NewBlock()
+	cChkG := bC.NewBlock()
+	cIsG := bC.NewBlock()
+	cElse := bC.NewBlock()
+	bC.CondBr(bC.EqualI64(cC, bC.ConstI64(65)), cIsA, cChkT)
+	bC.SwitchTo(cIsA)
+	bC.Ret(bC.ConstI64(84))
+	bC.SwitchTo(cChkT)
+	bC.CondBr(bC.EqualI64(cC, bC.ConstI64(84)), cIsT, cChkC)
+	bC.SwitchTo(cIsT)
+	bC.Ret(bC.ConstI64(65))
+	bC.SwitchTo(cChkC)
+	bC.CondBr(bC.EqualI64(cC, bC.ConstI64(67)), cIsC, cChkG)
+	bC.SwitchTo(cIsC)
+	bC.Ret(bC.ConstI64(71))
+	bC.SwitchTo(cChkG)
+	bC.CondBr(bC.EqualI64(cC, bC.ConstI64(71)), cIsG, cElse)
+	bC.SwitchTo(cIsG)
+	bC.Ret(bC.ConstI64(67))
+	bC.SwitchTo(cElse)
+	bC.Ret(cC)
+
+	// sumBytes(arr, i, n, acc): tail-rec accumulator.
+	bS := ir.NewBuilder("sumBytes",
+		[]ir.Type{ir.TU8Array, ir.TI64, ir.TI64, ir.TI64}, ir.TI64)
+	sArr, sI, sN, sAcc := bS.Param(0), bS.Param(1), bS.Param(2), bS.Param(3)
+	sDone := bS.NewBlock()
+	sStep := bS.NewBlock()
+	bS.CondBr(bS.LessI64(sI, sN), sStep, sDone)
+	bS.SwitchTo(sDone)
+	bS.Ret(sAcc)
+	bS.SwitchTo(sStep)
+	cell := bS.U8ArrGet(sArr, sI)
+	rec := bS.Call(sumIdx, ir.TI64, sArr,
+		bS.AddI64(sI, bS.ConstI64(1)), sN,
+		bS.AddI64(sAcc, cell))
+	bS.Ret(rec)
+
+	return &ir.Module{Funcs: []*ir.Function{
+		bMain.Function(), bF.Function(), bB.Function(),
+		bR.Function(), bC.Function(), bS.Function(),
+	}, Main: 0}
+}
+
+// ExpectReverseComplement runs the same algorithm in plain Go so the
+// oracle test can assert vm2 produces the bit-identical int64 result.
+func ExpectReverseComplement(n int64) int64 {
+	in := make([]byte, n)
+	bases := [4]byte{'A', 'C', 'G', 'T'}
+	for i := int64(0); i < n; i++ {
+		in[i] = bases[i%4]
+	}
+	out := make([]byte, n)
+	for i := int64(0); i < n; i++ {
+		var c byte
+		switch in[i] {
+		case 'A':
+			c = 'T'
+		case 'T':
+			c = 'A'
+		case 'C':
+			c = 'G'
+		case 'G':
+			c = 'C'
+		default:
+			c = in[i]
+		}
+		out[n-1-i] = c
+	}
+	var sum int64
+	for i := int64(0); i < n; i++ {
+		sum += int64(out[i])
+	}
+	return sum
+}

--- a/compiler2/corpus/corpus.go
+++ b/compiler2/corpus/corpus.go
@@ -60,6 +60,11 @@ func All() []Program {
 		// dimension; the inner power-method runs 10 iterations (5
 		// pairs of AtAu) and the result is floor(sqrt(uBu/uu) * 1e9).
 		{Name: "bg_spectral_norm", Build: BuildSpectralNorm, Expect: ExpectSpectralNorm},
+		// MEP-39 §6.5: parameterised reverse_complement. N is the
+		// buffer length; fill with the ACGT cycle, reverse-complement
+		// into a second buffer, return sum(out) so peers can integer-
+		// compare. When N is a multiple of 4, sum = (N/4) * 287.
+		{Name: "bg_reverse_complement", Build: BuildReverseComplement, Expect: ExpectReverseComplement},
 	}
 }
 

--- a/runtime/vm2/bench/corpus_test.go
+++ b/runtime/vm2/bench/corpus_test.go
@@ -53,6 +53,9 @@ var corpusSizes = []corpusSize{
 	// MEP-39 §6.4: spectral_norm. N is the vector dimension; the
 	// inner power-method runs 10 iterations regardless of N.
 	{"bg_spectral_norm", 100},
+	// MEP-39 §6.5: reverse_complement. N is the buffer length; one
+	// fill + one reverse-complement pass + one sum at that size.
+	{"bg_reverse_complement", 4096},
 }
 
 func sizeFor(name string) int64 {
@@ -139,3 +142,4 @@ func BenchmarkVM2_BG_FannkuchRedux(b *testing.B) { benchCorpus(b, corpus.Program
 func BenchmarkVM2_BG_Mandelbrot(b *testing.B)    { benchCorpus(b, corpus.Program{Name: "bg_mandelbrot", Build: corpus.BuildMandelbrot, Expect: corpus.ExpectMandelbrot}) }
 func BenchmarkVM2_BG_NBody(b *testing.B)         { benchCorpus(b, corpus.Program{Name: "bg_n_body", Build: corpus.BuildNBody, Expect: corpus.ExpectNBody}) }
 func BenchmarkVM2_BG_SpectralNorm(b *testing.B)  { benchCorpus(b, corpus.Program{Name: "bg_spectral_norm", Build: corpus.BuildSpectralNorm, Expect: corpus.ExpectSpectralNorm}) }
+func BenchmarkVM2_BG_ReverseComplement(b *testing.B) { benchCorpus(b, corpus.Program{Name: "bg_reverse_complement", Build: corpus.BuildReverseComplement, Expect: corpus.ExpectReverseComplement}) }

--- a/website/docs/mep/mep-0039.md
+++ b/website/docs/mep/mep-0039.md
@@ -87,6 +87,8 @@ ratios on the BG rows are:
 | `bg/nsieve`        | 10000 |    60003 |     587 |  102.22x | MEP-23 |
 | `bg/spectral_norm` |   100 |    10148 |     232 |   43.74x | MEP-39 §6.4 |
 | `bg/spectral_norm` |   200 |    42758 |     627 |   68.19x | MEP-39 §6.4 |
+| `bg/reverse_complement` |  4096 |   586 |       8 |   73.25x | MEP-39 §6.5 |
+| `bg/reverse_complement` | 16384 |  5818 |      49 |  118.73x | MEP-39 §6.5 |
 
 **Reading.** vm2 is faster than CPython on most math rows and roughly
 on par with binary_trees; PyPy and LuaJIT both close to or beat vm2 on
@@ -111,7 +113,7 @@ Of the canonical BG ten:
 | n_body             | `corpus.BuildNBodyKernel`           | ✓ (since §6.3)      | f64 array | fixed 5 bodies, parameterized step count |
 | pidigits           | ✗                                   | ✗                   | bigint    | spigot algorithm, needs vm2 bignum |
 | regex_redux        | ✗                                   | ✗                   | string + regex | needs vm2 regex ops |
-| reverse_complement | `corpus.BuildReverseComplementKernel` + `…Bytes` | ✗ | bytes     | per MEP-38 §3.1 needs byte-view |
+| reverse_complement | `corpus.BuildReverseComplementKernel` + `…Bytes` + `BuildReverseComplement` | ✓ (since §6.5) | bytes     | scaled U8Array form; byte-view per MEP-38 §3.1 still pending |
 | spectral_norm      | `corpus.BuildSpectralNormKernel`    | ✓ (since §6.4)      | f64 array | parameterized vector dim n |
 
 Non-BG entries presently in crosslang (math/, strings/, lists/, maps/, bg/nsieve): stay where they are. They are MEP-23 baseline programs and the MEP-39 sweep keeps them as a control group.
@@ -641,6 +643,142 @@ PyPy lands between LuaJIT and vm2 (2.4x faster at N=100, 6.5x at
 N=200). Iteration 2 will deliver mechanism 1 (precomputed `eval_A`
 table) and re-measure; the JIT path follows once MEP-38 §3.2 + §3.3
 lands.
+
+### 6.5 reverse_complement
+
+**Status (iteration 1, 2026-05-18).** vm2 at 73.25x of Go on N=4096
+and 118.73x on N=16384. The smaller N is more flattering to vm2
+because Go's 8 µs hits scheduling noise (warm cache, no allocator
+cost amortised), so the ratio shrinks; the N=16384 row is the more
+honest baseline. Output is bit-identical across all six runtimes:
+293888 (N=4096) and 1175552 (N=16384), exactly `(N/4) * 287` as the
+algebra predicts.
+
+vm2's interpreter rank inside the peer set inverts as N grows.  At
+N=4096 vm2 (586 µs) beats every interpreter peer except Lua (231 µs)
+and LuaJIT (166 µs); even PyPy is slower (2109 µs, warmup-dominated
+at this size). At N=16384 vm2 (5818 µs) lands behind CPython (5481
+µs), Lua (1712 µs), PyPy (2139 µs), and LuaJIT (565 µs); CPython's
+bytearray loop is implemented in C and beats vm2's per-op dispatch
+once N is large enough that the dispatch cost compounds linearly.
+That crossover is the load-bearing observation for this kernel: the
+existing TUnit-recursive shape of `fillInput` / `rcLoop` walks one
+byte per dispatch, and the dispatch is exactly what specialisation
+removes.
+
+**Algorithm.** Fill an N-byte buffer `in` with the cycle
+`['A', 'C', 'G', 'T']`. Reverse-complement into a second buffer
+`out` via the table A↔T, C↔G. Sum `out` as i64; print that integer
+so the harness can compare without byte-array marshalling. The
+canonical BG program reads FASTA from stdin and writes the reversed
+60-char-line FASTA to stdout; this scaled form keeps the arithmetic
+(per-byte complement + reverse) and replaces the stdio plumbing with
+a deterministic summation so the cross-lang harness can integer-
+compare every peer.
+
+**Output format.** `sum(out)` is exactly `sum(in)` because each
+complement is a permutation of the same four bytes
+`{65, 67, 71, 84}` whose sum is 287; for N a multiple of 4, the
+result is `(N/4) * 287`. The reverse step is a pure permutation, so
+order doesn't matter to the sum either. We therefore have a
+closed-form expected value the oracle can check exactly without
+floating-point error: 1175552 at N=16384, 293888 at N=4096. Every
+peer hits these exact integers.
+
+**Theory.** Per byte the inner loop does one `U8ArrGet`, one call to
+`complement`, one `U8ArrSet`, one index arith (`n - 1 - i`), one
+loop var update + comparison + tail-recurse, and one indirect call
+return. That's roughly 6 dispatches per byte, plus 3 inside
+`complement` (the byte-equal dispatch chain). At 5 ns per dispatch
+the per-byte cost is ~45 ns ≈ 9 ns/byte on hot dispatch (with
+shared branch prediction across the predictable A/C/G/T cycle).
+Go's `for i := range buf { out[n-1-i] = complement(in[i]) }` is
+mostly a register loop with an inlined switch; modern Go's escape
+analysis keeps the bytearray on stack and emits one byte load +
+table lookup + one byte store per iter ≈ 3 ns total. Go's 49 µs at
+N=16384 lines up: 49 µs / 16384 ≈ 3.0 ns/byte. vm2's 5818 µs /
+16384 ≈ 355 ns/byte (filling, reverse, summing combined: 3 passes,
+so ~118 ns/byte/pass, consistent with the 6 dispatches per byte
+times the 5 ns vm2 dispatch latency MEP-37 §6 measured plus
+constant per-iter overhead).
+
+The 2x-vs-Go target at N=16384 is 98 µs (2 × 49). That requires
+~6 ns/byte end-to-end. The interpreter dispatch loop alone is ~3 ns
+on M4, leaving ~3 ns for the per-byte work, which is unreachable
+without specialised bulk ops or JIT.
+
+**Mechanism candidates (ranked by lift, smallest first).**
+
+1. **OpBytesFill (constant byte cycle) + OpBytesReverseComplement
+   (table-driven map) + OpBytesSum (bulk i64 reduction).** Each
+   replaces an N-iter dispatch chain with a single C-loop dispatch.
+   At N=16384 the three passes go from 3 × 16384 × 5 ns = 246 µs of
+   dispatch overhead down to 3 × 16 byte/iter SIMD = roughly 6 µs
+   (memory-bound on the read-modify-write streaming pass). Brings
+   vm2 within ~7 µs of Go before counting alloc cost. The dispatch
+   for the three ops is constant, so the speedup grows with N.
+   Cheap to ship: each op is a `for` loop over the byte view in
+   pure Go inside the vm2 dispatch table; no JIT dependency. Stacks
+   with mechanism 3.
+2. **JIT lowering of the byte loop.** Per-byte dispatch goes from
+   ~5 ns to ~0.4 ns (one indirect load + one table dispatch in
+   the JIT'd loop body, register-resident loop counter). At
+   N=16384 the loop takes ~7 µs, matching Go. Requires the
+   typed-array arm64 path (MEP-38 §3.2) plus a u8-load/store
+   lowering. Highest lift; longest critical path.
+3. **TBytes byte-view path.** The existing
+   `BuildReverseComplementBytesKernel` already uses a single
+   in-place buffer (`BytesGet` / `BytesSet`) — half the allocation
+   and one fewer scan because it walks `0..N/2` and pairs reads
+   and writes. Switching the scaled form to TBytes saves the
+   second N-byte alloc (16 KB at N=16384) and the `Sub` index
+   arith (since the walk is now `0..N/2`, both indices come from
+   the same loop counter). Small lift on the timing axis (~10%)
+   but it is the prerequisite for any future byte-string ABI work
+   the regex_redux row will need.
+
+The path to 2x-vs-Go on this row is mechanism 1 alone: 246 µs of
+dispatch overhead is the dominant cost; replacing it brings vm2 to
+~7 µs at N=16384, which is 0.14x of Go, well inside the gate. The
+JIT path is a follow-on optimisation that brings the per-byte cost
+down to host-cache speed.
+
+**Implementation (iteration 1).** Cross-lang templates landed in
+`bench/template/bg/reverse_complement/` (.mochi, .py, .lua,
+.go.tmpl). The Mochi IR builder `corpus.BuildReverseComplement(n)`
+mirrors the existing `BuildReverseComplementKernel` shape (six
+functions: `main`, `fillInput`, `baseFor`, `rcLoop`, `complement`,
+`sumBytes`) but takes N as a parameter so the cross-lang harness
+can sweep buffer lengths. `fillInput` and `rcLoop` are TUnit
+recursive helpers using `Call; Ret -1`; `sumBytes` returns TI64 via
+`Ret(call_result)` so opt.TailCall folds it to a single
+`OpTailCallSelfA4`.
+
+The Lua peer keeps the same shape as the other BG Lua templates: a
+plain table for the bytearrays, an if/elseif chain for
+`complement` (since Lua 5.1 / LuaJIT 2.1 have no switch), and
+`math.floor` for the µs cast on output to avoid LuaJIT's f64
+print noise. Python uses `bytearray` + a `dict` lookup for
+`complement` so the comparison stays in the C loop instead of
+crossing into pure-Python control flow.
+
+**Bench (iteration 1, 2026-05-18, macOS arm64, median of 5).**
+
+| N     | vm2 (µs) | CPython (µs) | PyPy (µs) | Lua (µs) | LuaJIT (µs) | Go (µs) | vm2 / Go |
+|------:|---------:|-------------:|----------:|---------:|------------:|--------:|---------:|
+|  4096 |      586 |         1008 |      2109 |      231 |         166 |       8 |   73.25x |
+| 16384 |     5818 |         5481 |      2139 |     1712 |         565 |      49 |  118.73x |
+
+The ratio against Go grows with N (73x → 119x as N quadruples)
+because the interpreter dispatch overhead is per-byte while Go's
+inner loop is near-constant-cost per byte. CPython catches up to
+vm2 between N=4096 and N=16384 because CPython's bytearray loop is
+implemented in C and beats vm2's per-op dispatch once N is large
+enough that the dispatch cost compounds linearly; this is the
+empirical signal that the OpBytesFill / OpBytesReverseComplement /
+OpBytesSum specialisation is the right next move. Iteration 2 will
+deliver mechanism 1 and re-measure; the JIT path follows once
+MEP-38 §3.2 lands.
 
 ### 6.x (template for future iterations)
 


### PR DESCRIPTION
Closes #21615.

Iteration 1 of MEP-39 §6.5: parameterised BG reverse_complement cross-lang harness + IR builder + spec update.

## Summary

- New IR builder `corpus.BuildReverseComplement(n)` (parameterised buffer length) and oracle `ExpectReverseComplement(n)`. The existing `BuildReverseComplementKernel` is fixed at N=1024; the scaled form takes N as a parameter so the cross-lang harness can sweep sizes. `sumBytes` uses `Ret(call_result)` so opt.TailCall folds it to `OpTailCallSelfA4`.
- Cross-lang peers in `bench/template/bg/reverse_complement/`: `.mochi`, `.py`, `.lua`, `.go.tmpl`. Python uses `bytearray` + dict for `complement` to keep the inner loop in C; Lua uses if/elseif chain (no switch in Lua 5.1 / LuaJIT 2.1) and `math.floor` for the µs print.
- Harness wiring: `bench/crosslang/main.go` adds `bg/reverse_complement` (ns=[4096, 16384]); `bench/vm2runner/main.go` adds `bg_reverse_complement: 1`; `runtime/vm2/bench/corpus_test.go` adds size + `BenchmarkVM2_BG_ReverseComplement`; `compiler2/corpus/corpus.go` registers the program.
- MEP-39 update: §2 headline rows, §3 gap analysis ✓ (since §6.5), full new §6.5 with theory, mechanism ranking, implementation notes, and bench table.

## Measurements (macOS arm64, median of 5, 2026-05-18)

| N     | vm2 (µs) | CPython (µs) | PyPy (µs) | Lua (µs) | LuaJIT (µs) | Go (µs) | vm2 / Go |
|------:|---------:|-------------:|----------:|---------:|------------:|--------:|---------:|
|  4096 |      586 |         1008 |      2109 |      231 |         166 |       8 |   73.25x |
| 16384 |     5818 |         5481 |      2139 |     1712 |         565 |      49 |  118.73x |

Output is bit-identical across all six runtimes: 293888 (N=4096) and 1175552 (N=16384), exactly `(N/4) * 287`.

## Theory finding

CPython catches up to vm2 at N=16384 because CPython's bytearray loop is C-implemented and beats vm2's per-op dispatch once N is large enough that the dispatch cost compounds linearly. This is the empirical signal that bulk byte ops (OpBytesFill / OpBytesReverseComplement / OpBytesSum) are the right next move; mechanism 1 in the §6.5 ranking brings vm2 to roughly 7µs at N=16384, well inside the 2x-of-Go gate (98µs). See MEP-39 §6.5 for the full ranking and per-byte cost decomposition.

## Test plan

- [x] go build ./...
- [x] go test ./runtime/vm2/bench/... -run TestCorpusMatchesOracle
- [x] crosslang bench at N=4096 and N=16384 with vm2 + 5 peers
- [x] cross-runtime output verification: all 6 runtimes produce 293888 (N=4096) and 1175552 (N=16384)