### PR TITLE
mep-0039 §6.7: k_nucleotide cross-lang iteration 1

### DIFF
--- a/bench/crosslang/main.go
+++ b/bench/crosslang/main.go
@@ -104,6 +104,12 @@ var programs = []program{
 	// t); hash = (hash * 1009 + byte) % (2^31 - 1). Output is the
 	// final hash. See bench/template/bg/fasta/.
 	{category: "bg", name: "fasta", ns: []int{10000, 100000}},
+	// MEP-39 §6.7: BG k_nucleotide kernel. N is the LCG iteration
+	// count. Each iter pushes one base into 1-mer and 2-mer count
+	// tables (int-keyed map; keys 0..3 = 1-mers, 4..19 = 2-mers).
+	// Output is a rolling i64 hash over the 20 counts. See
+	// bench/template/bg/k_nucleotide/.
+	{category: "bg", name: "k_nucleotide", ns: []int{10000, 100000}},
 }
 
 type result struct {

--- a/bench/template/bg/k_nucleotide/k_nucleotide.go.tmpl
+++ b/bench/template/bg/k_nucleotide/k_nucleotide.go.tmpl
@@ -1,0 +1,53 @@
+// Template peer for the bg/k_nucleotide benchmark. Mirrors
+// k_nucleotide.mochi: an LCG random generator + HOMO_SAPIENS 4-entry
+// cumprob lookup returning 2-bit codes 0..3; int-keyed map holds
+// 1-mer (keys 0..3) and 2-mer (keys 4..19) counts; output is a
+// rolling i64 hash over the 20 counts so peers integer-compare a
+// single value. See MEP-39 §6.7.
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+)
+
+func lookup(prob float64) int64 {
+	if prob < 0.3029549426680 {
+		return 0
+	}
+	if prob < 0.5009432431601 {
+		return 1
+	}
+	if prob < 0.6984905497992 {
+		return 2
+	}
+	return 3
+}
+
+func main() {
+	const n = {{ .N }}
+	start := time.Now()
+	counts := make(map[int64]int64, 20)
+	seed := (int64(42)*3877 + 29573) % 139968
+	prev := lookup(float64(seed) / 139968.0)
+	counts[prev] = 1
+	for i := int64(1); i < n; i++ {
+		seed = (seed*3877 + 29573) % 139968
+		code := lookup(float64(seed) / 139968.0)
+		counts[code]++
+		counts[4+prev*4+code]++
+		prev = code
+	}
+	var h int64
+	for k := int64(0); k < 20; k++ {
+		h = (h*1009 + counts[k]) % 2147483647
+	}
+	durUs := float64(time.Since(start).Microseconds())
+
+	_ = json.NewEncoder(os.Stdout).Encode(map[string]any{
+		"duration_us": durUs,
+		"output":      h,
+	})
+}

--- a/bench/template/bg/k_nucleotide/k_nucleotide.lua
+++ b/bench/template/bg/k_nucleotide/k_nucleotide.lua
@@ -1,0 +1,36 @@
+-- MEP-39 k_nucleotide Lua peer. LCG random generator + HOMO_SAPIENS
+-- 4-entry cumprob lookup returning 2-bit codes 0..3; int-keyed table
+-- holds 1-mer (keys 0..3) and 2-mer (keys 4..19) counts; output is
+-- a rolling i64 hash over the 20 counts, integer-comparable across
+-- all peers.
+
+local N = {{ .N }}
+
+local function lookup(prob)
+  if prob < 0.3029549426680 then return 0
+  elseif prob < 0.5009432431601 then return 1
+  elseif prob < 0.6984905497992 then return 2
+  else return 3 end
+end
+
+local start = os.clock()
+local counts = {}
+local seed = (42 * 3877 + 29573) % 139968
+local prev = lookup(seed / 139968)
+counts[prev] = 1
+for _ = 1, N - 1 do
+  seed = (seed * 3877 + 29573) % 139968
+  local code = lookup(seed / 139968)
+  counts[code] = (counts[code] or 0) + 1
+  local key2 = 4 + prev * 4 + code
+  counts[key2] = (counts[key2] or 0) + 1
+  prev = code
+end
+
+local h = 0
+for k = 0, 19 do
+  h = (h * 1009 + (counts[k] or 0)) % 2147483647
+end
+
+local duration_us = (os.clock() - start) * 1e6
+io.write(string.format('{"duration_us": %d, "output": %d}\n', math.floor(duration_us), h))

--- a/bench/template/bg/k_nucleotide/k_nucleotide.mochi
+++ b/bench/template/bg/k_nucleotide/k_nucleotide.mochi
@@ -1,0 +1,43 @@
+// MEP-39 k_nucleotide Mochi reference. LCG random generator paired
+// with a HOMO_SAPIENS 4-entry cumprob lookup that returns the 2-bit
+// code (0/1/2/3 for a/c/g/t). The kernel maintains 1-mer and 2-mer
+// counts in a single int-keyed map (keys 0..3 = 1-mers,
+// 4..19 = 2-mers indexed by `4 + prev*4 + cur`) and folds the 20
+// counts into a rolling i64 hash so the cross-lang harness compares
+// a single integer across every peer. The vm2 path runs
+// `compiler2/corpus/bg_k_nucleotide_scaled.go` (the IR builder);
+// this file is the source-level reference documenting the
+// arithmetic the cross-lang peers replicate.
+
+let N = 10000
+
+fun lookup(prob: float): int {
+  if prob < 0.3029549426680 { return 0 }
+  if prob < 0.5009432431601 { return 1 }
+  if prob < 0.6984905497992 { return 2 }
+  return 3
+}
+
+var counts: map<int, int> = {}
+var seed = (42 * 3877 + 29573) % 139968
+var prev = lookup(float(seed) / 139968.0)
+counts[prev] = 1
+
+for i in 1..N {
+  seed = (seed * 3877 + 29573) % 139968
+  let prob = float(seed) / 139968.0
+  let code = lookup(prob)
+  let c1 = counts[code]
+  counts[code] = c1 + 1
+  let key2 = 4 + prev * 4 + code
+  let c2 = counts[key2]
+  counts[key2] = c2 + 1
+  prev = code
+}
+
+var h = 0
+for k in 0..20 {
+  let c = counts[k]
+  h = (h * 1009 + c) % 2147483647
+}
+print(h)

--- a/bench/template/bg/k_nucleotide/k_nucleotide.py
+++ b/bench/template/bg/k_nucleotide/k_nucleotide.py
@@ -1,0 +1,39 @@
+import json
+import time
+
+
+def lookup(prob):
+    if prob < 0.3029549426680:
+        return 0
+    if prob < 0.5009432431601:
+        return 1
+    if prob < 0.6984905497992:
+        return 2
+    return 3
+
+
+N = {{ .N }}
+
+start = time.perf_counter()
+counts = {}
+seed = (42 * 3877 + 29573) % 139968
+prev = lookup(seed / 139968.0)
+counts[prev] = 1
+for i in range(1, N):
+    seed = (seed * 3877 + 29573) % 139968
+    code = lookup(seed / 139968.0)
+    counts[code] = counts.get(code, 0) + 1
+    key2 = 4 + prev * 4 + code
+    counts[key2] = counts.get(key2, 0) + 1
+    prev = code
+
+h = 0
+for k in range(20):
+    h = (h * 1009 + counts.get(k, 0)) % 2147483647
+
+duration_us = (time.perf_counter() - start) * 1e6
+
+print(json.dumps({
+    "duration_us": duration_us,
+    "output": h,
+}))

--- a/bench/vm2runner/main.go
+++ b/bench/vm2runner/main.go
@@ -65,6 +65,10 @@ var repeats = map[string]int{
 	// MEP-39 §6.6: fasta. N is the LCG iteration count; one LCG step
 	// + one cumprob lookup + one hash update per inner iter.
 	"bg_fasta": 1,
+	// MEP-39 §6.7: k_nucleotide. N is the LCG iteration count; one
+	// LCG step + 1-mer inc + 2-mer inc per inner iter, then a 20-key
+	// summarise pass at the end.
+	"bg_k_nucleotide": 1,
 }
 
 func main() {

--- a/compiler2/corpus/bg_k_nucleotide_scaled.go
+++ b/compiler2/corpus/bg_k_nucleotide_scaled.go
@@ -1,0 +1,193 @@
+package corpus
+
+import "mochi/compiler2/ir"
+
+// BuildKNucleotide is the MEP-39 §6.7 parameterised BG k_nucleotide
+// kernel. The canonical BG k_nucleotide program reads the fasta
+// output (a DNA byte stream) and counts k-length substrings into a
+// hash map, reporting counts for k=1, k=2, and a handful of specific
+// k=3..18 mers ("GGT", "GGTA", ...). Iteration 1 of the cross-lang
+// harness reduces that to the load-bearing inner kernel: an LCG
+// random stream (same parameters as fasta §6.6) drives a HOMO_SAPIENS
+// cumprob lookup that returns a 2-bit code (0/1/2/3 for a/c/g/t);
+// the kernel maintains 1-mer and 2-mer counts in a single int-keyed
+// map, then folds the counts into a deterministic i64 hash so the
+// cross-lang harness compares a single integer across every peer.
+//
+// Key layout in the map:
+//
+//	keys  0..3   = 1-mer counts indexed by code
+//	keys  4..19  = 2-mer counts indexed by `4 + prev*4 + cur`
+//
+// Iteration 1 ignores k=3..18 (the canonical specific-mer table);
+// MEP-39 §6.7 names the iteration 2 mechanism that extends the map
+// to k=3 and folds the byte→code conversion through the canonical
+// 97/99/103/116 byte alphabet (lookup currently returns the code
+// directly to keep iteration 1 focused on the map-increment cost,
+// which is the load-bearing measurement for this kernel).
+//
+// LCG (matches fasta):
+//
+//	seed = (seed * 3877 + 29573) % 139968    // canonical BG params
+//	prob = float64(seed) / 139968.0
+//
+// HOMO_SAPIENS cumprob → 2-bit code:
+//
+//	prob < 0.3029549426680  → 0 ('a')
+//	prob < 0.5009432431601  → 1 ('c')
+//	prob < 0.6984905497992  → 2 ('g')
+//	otherwise               → 3 ('t')
+//
+// Rolling i64 hash (over keys 0..19):
+//
+//	h = (h * 1009 + count[key]) % 2147483647
+//
+// Four IR functions:
+//
+//	main()                    = bootstrap iter 0 inline, call loop, call summ
+//	loop(seed, m, prev, i, n) = TUnit tail-rec; one LCG step + 1-mer inc + 2-mer inc
+//	summ(m, key, acc, end)    = TI64 tail-rec; walks 0..end, rolls hash
+//	lookup(prob) -> TI64      = 4-way FP cascade returning 0..3
+//
+// The map increments are inlined inside `loop` (no helper call) to
+// keep the per-iter dispatch count tight: each iter dispatches one
+// MapGet + one AddI64 + one MapSet per k, plus the LCG and the
+// lookup call. With CNull().Int() == 0, the missing-key path for
+// integer values is "first inc reads 0, writes 1" without any
+// MapHas guard — no pre-init pass needed.
+func BuildKNucleotide(n int64) *ir.Module {
+	const (
+		loopIdx   = 1
+		summIdx   = 2
+		lookupIdx = 3
+	)
+
+	// main(): bootstrap iter 0 inline (one LCG step + one 1-mer inc),
+	// then drive the rest of the iterations via `loop`, then summarise.
+	bMain := ir.NewBuilder("main", nil, ir.TI64)
+	m := bMain.NewMap()
+	// LCG step 0: s0 = (42*3877 + 29573) % 139968
+	seed0 := bMain.ConstI64(42)
+	mul0 := bMain.MulI64(seed0, bMain.ConstI64(3877))
+	add0 := bMain.AddI64(mul0, bMain.ConstI64(29573))
+	s0 := bMain.ModI64(add0, bMain.ConstI64(139968))
+	prob0 := bMain.DivF64(bMain.I64ToF64(s0), bMain.ConstF64(139968.0))
+	code0 := bMain.Call(lookupIdx, ir.TI64, prob0)
+	// m[code0] += 1   (missing key reads as 0)
+	v0 := bMain.MapGet(m, code0, ir.TI64)
+	bMain.MapSet(m, code0, bMain.AddI64(v0, bMain.ConstI64(1)))
+	// drive remaining N-1 iters via loop, starting at i=1, prev=code0
+	bMain.Call(loopIdx, ir.TUnit, s0, m, code0, bMain.ConstI64(1), bMain.ConstI64(n))
+	// summarise: walk 0..20, fold counts into rolling i64 hash
+	h := bMain.Call(summIdx, ir.TI64, m, bMain.ConstI64(0), bMain.ConstI64(0), bMain.ConstI64(20))
+	bMain.Ret(h)
+
+	// loop(seed, m, prev, i, n) -> TUnit tail-rec.
+	bL := ir.NewBuilder("loop",
+		[]ir.Type{ir.TI64, ir.TMap, ir.TI64, ir.TI64, ir.TI64}, ir.TUnit)
+	pSeed, pM, pPrev, pI, pN := bL.Param(0), bL.Param(1), bL.Param(2), bL.Param(3), bL.Param(4)
+	lDone := bL.NewBlock()
+	lStep := bL.NewBlock()
+	bL.CondBr(bL.LessI64(pI, pN), lStep, lDone)
+	bL.SwitchTo(lDone)
+	bL.Ret(-1)
+	bL.SwitchTo(lStep)
+	// LCG step
+	mul := bL.MulI64(pSeed, bL.ConstI64(3877))
+	add := bL.AddI64(mul, bL.ConstI64(29573))
+	newSeed := bL.ModI64(add, bL.ConstI64(139968))
+	// prob + lookup
+	prob := bL.DivF64(bL.I64ToF64(newSeed), bL.ConstF64(139968.0))
+	code := bL.Call(lookupIdx, ir.TI64, prob)
+	// 1-mer increment: m[code] += 1
+	v1 := bL.MapGet(pM, code, ir.TI64)
+	bL.MapSet(pM, code, bL.AddI64(v1, bL.ConstI64(1)))
+	// 2-mer increment: m[4 + prev*4 + code] += 1
+	key2 := bL.AddI64(bL.ConstI64(4), bL.AddI64(bL.MulI64(pPrev, bL.ConstI64(4)), code))
+	v2 := bL.MapGet(pM, key2, ir.TI64)
+	bL.MapSet(pM, key2, bL.AddI64(v2, bL.ConstI64(1)))
+	// recurse with code becoming the new prev
+	ni := bL.AddI64(pI, bL.ConstI64(1))
+	bL.Call(loopIdx, ir.TUnit, newSeed, pM, code, ni, pN)
+	bL.Ret(-1)
+
+	// summ(m, key, acc, end) -> TI64 tail-rec. Walks key..end and
+	// folds m[k] into acc via `(acc*1009 + c) % 2147483647`.
+	bS := ir.NewBuilder("summ",
+		[]ir.Type{ir.TMap, ir.TI64, ir.TI64, ir.TI64}, ir.TI64)
+	sM, sK, sAcc, sEnd := bS.Param(0), bS.Param(1), bS.Param(2), bS.Param(3)
+	sDone := bS.NewBlock()
+	sStep := bS.NewBlock()
+	bS.CondBr(bS.LessI64(sK, sEnd), sStep, sDone)
+	bS.SwitchTo(sDone)
+	bS.Ret(sAcc)
+	bS.SwitchTo(sStep)
+	c := bS.MapGet(sM, sK, ir.TI64)
+	newAcc := bS.ModI64(bS.AddI64(bS.MulI64(sAcc, bS.ConstI64(1009)), c), bS.ConstI64(2147483647))
+	nk := bS.AddI64(sK, bS.ConstI64(1))
+	rec := bS.Call(summIdx, ir.TI64, sM, nk, newAcc, sEnd)
+	bS.Ret(rec)
+
+	// lookup(prob TF64) -> TI64 in {0,1,2,3}.
+	bLU := ir.NewBuilder("lookup", []ir.Type{ir.TF64}, ir.TI64)
+	pP := bLU.Param(0)
+	luA := bLU.NewBlock() // return 0 ('a')
+	luChkC := bLU.NewBlock()
+	luC := bLU.NewBlock() // return 1 ('c')
+	luChkG := bLU.NewBlock()
+	luG := bLU.NewBlock() // return 2 ('g')
+	luT := bLU.NewBlock() // return 3 ('t')
+	bLU.CondBr(bLU.LessF64(pP, bLU.ConstF64(0.3029549426680)), luA, luChkC)
+	bLU.SwitchTo(luA)
+	bLU.Ret(bLU.ConstI64(0))
+	bLU.SwitchTo(luChkC)
+	bLU.CondBr(bLU.LessF64(pP, bLU.ConstF64(0.5009432431601)), luC, luChkG)
+	bLU.SwitchTo(luC)
+	bLU.Ret(bLU.ConstI64(1))
+	bLU.SwitchTo(luChkG)
+	bLU.CondBr(bLU.LessF64(pP, bLU.ConstF64(0.6984905497992)), luG, luT)
+	bLU.SwitchTo(luG)
+	bLU.Ret(bLU.ConstI64(2))
+	bLU.SwitchTo(luT)
+	bLU.Ret(bLU.ConstI64(3))
+
+	return &ir.Module{Funcs: []*ir.Function{
+		bMain.Function(), bL.Function(), bS.Function(), bLU.Function(),
+	}, Main: 0}
+}
+
+// ExpectKNucleotide runs the same algorithm in plain Go so the oracle
+// test can assert vm2 produces the bit-identical i64 hash.
+func ExpectKNucleotide(n int64) int64 {
+	counts := make(map[int64]int64, 20)
+	lookup := func(prob float64) int64 {
+		switch {
+		case prob < 0.3029549426680:
+			return 0
+		case prob < 0.5009432431601:
+			return 1
+		case prob < 0.6984905497992:
+			return 2
+		default:
+			return 3
+		}
+	}
+	// bootstrap iter 0
+	seed := (int64(42)*3877 + 29573) % 139968
+	prev := lookup(float64(seed) / 139968.0)
+	counts[prev]++
+	// iters 1..n-1
+	for i := int64(1); i < n; i++ {
+		seed = (seed*3877 + 29573) % 139968
+		code := lookup(float64(seed) / 139968.0)
+		counts[code]++
+		counts[4+prev*4+code]++
+		prev = code
+	}
+	// summarise
+	var h int64
+	for k := int64(0); k < 20; k++ {
+		h = (h*1009 + counts[k]) % 2147483647
+	}
+	return h
+}

--- a/compiler2/corpus/corpus.go
+++ b/compiler2/corpus/corpus.go
@@ -70,6 +70,11 @@ func All() []Program {
 		// a rolling i64 hash so the cross-lang harness compares a
 		// single i64 across every peer.
 		{Name: "bg_fasta", Build: BuildFasta, Expect: ExpectFasta},
+		// MEP-39 §6.7: parameterised k_nucleotide kernel. N is the
+		// LCG iteration count; an int-keyed map holds 1-mer and
+		// 2-mer counts, folded into a single i64 hash so the cross-
+		// lang harness compares a single i64 across every peer.
+		{Name: "bg_k_nucleotide", Build: BuildKNucleotide, Expect: ExpectKNucleotide},
 	}
 }
 

--- a/runtime/vm2/bench/corpus_test.go
+++ b/runtime/vm2/bench/corpus_test.go
@@ -59,6 +59,9 @@ var corpusSizes = []corpusSize{
 	// MEP-39 §6.6: fasta. N is the LCG iteration count; one inner
 	// step per iter (LCG + cumprob lookup + hash update).
 	{"bg_fasta", 10000},
+	// MEP-39 §6.7: k_nucleotide. N is the LCG iteration count; one
+	// LCG step + 1-mer inc + 2-mer inc per inner iter.
+	{"bg_k_nucleotide", 10000},
 }
 
 func sizeFor(name string) int64 {
@@ -147,3 +150,4 @@ func BenchmarkVM2_BG_NBody(b *testing.B)         { benchCorpus(b, corpus.Program
 func BenchmarkVM2_BG_SpectralNorm(b *testing.B)  { benchCorpus(b, corpus.Program{Name: "bg_spectral_norm", Build: corpus.BuildSpectralNorm, Expect: corpus.ExpectSpectralNorm}) }
 func BenchmarkVM2_BG_ReverseComplement(b *testing.B) { benchCorpus(b, corpus.Program{Name: "bg_reverse_complement", Build: corpus.BuildReverseComplement, Expect: corpus.ExpectReverseComplement}) }
 func BenchmarkVM2_BG_Fasta(b *testing.B)         { benchCorpus(b, corpus.Program{Name: "bg_fasta", Build: corpus.BuildFasta, Expect: corpus.ExpectFasta}) }
+func BenchmarkVM2_BG_KNucleotide(b *testing.B)   { benchCorpus(b, corpus.Program{Name: "bg_k_nucleotide", Build: corpus.BuildKNucleotide, Expect: corpus.ExpectKNucleotide}) }

--- a/website/docs/mep/mep-0039.md
+++ b/website/docs/mep/mep-0039.md
@@ -91,6 +91,8 @@ ratios on the BG rows are:
 | `bg/reverse_complement` | 16384 |  5818 |      49 |  118.73x | MEP-39 §6.5 |
 | `bg/fasta`         | 10000 |      614 |     141 |    4.35x | MEP-39 §6.6 |
 | `bg/fasta`         |100000 |     6724 |    1360 |    4.94x | MEP-39 §6.6 |
+| `bg/k_nucleotide`  | 10000 |     3325 |     200 |   16.62x | MEP-39 §6.7 |
+| `bg/k_nucleotide`  |100000 |    31087 |    1944 |   15.99x | MEP-39 §6.7 |
 
 **Reading.** vm2 is faster than CPython on most math rows and roughly
 on par with binary_trees; PyPy and LuaJIT both close to or beat vm2 on
@@ -110,7 +112,7 @@ Of the canonical BG ten:
 | binary_trees       | `corpus.BuildBinaryTreesKernel`     | ✓                   | list      | also has packed-pair variant |
 | fannkuch_redux     | `corpus.BuildFannkuchReduxKernel`   | ✗                   | i64 array | fixed n=7 in current IR; MEP needs parameterized |
 | fasta              | `corpus.BuildFasta`                 | ✓ (since §6.6)      | i64 + f64 | scaled LCG + HOMO_SAPIENS cumprob lookup; iteration 1 hashes bytes into a single i64 |
-| k_nucleotide       | ✗                                   | ✗                   | `map<str,i64>` | depends on fasta output |
+| k_nucleotide       | `corpus.BuildKNucleotide`           | ✓ (since §6.7)      | `map<int,int>` | scaled int-keyed 1-mer + 2-mer counts hashed into a single i64; canonical str keys + k=3..18 are iteration 2 |
 | mandelbrot         | `corpus.BuildMandelbrotKernel`      | ✓ (since §6.2)      | f64 + bool   | parameterized w,h,maxIter |
 | n_body             | `corpus.BuildNBodyKernel`           | ✓ (since §6.3)      | f64 array | fixed 5 bodies, parameterized step count |
 | pidigits           | ✗                                   | ✗                   | bigint    | spigot algorithm, needs vm2 bignum |
@@ -938,6 +940,180 @@ until either mechanism 1 (fused LCG/hash ops) or mechanism 3 (JIT
 inner loop) lands. Iteration 2 will deliver mechanism 1 and re-
 measure; the integer-threshold rewrite (mechanism 2) follows once
 the constant-fold detection lands in emit.
+
+### 6.7 k_nucleotide
+
+**Status (iteration 1, 2026-05-18).** vm2 at 16.62x of Go on N=10000
+and 15.99x on N=100000. The ratio stays nearly flat as N grows
+because the per-iter cost is dominated by map ops, which scale
+linearly on both sides (Go's `m[k]++` and vm2's `MapGet + AddI64 +
+MapSet` are both O(1) per access). Output is bit-identical across
+all six runtimes: 723253870 at N=10000 and 1936471392 at N=100000.
+
+vm2's interpreter rank inside the peer set lands it side-by-side
+with CPython. At N=10000 vm2 (3325 µs) is within 10% of CPython
+(3037 µs, 0.91x); at N=100000 the gap stays the same (31087 µs vs
+28849 µs, 0.93x). The empirical signal: vm2's generic map dispatch
+cost is in the same ballpark as CPython's `dict` hash + bucket walk
+once the inner loop is map-dominated. PyPy beats vm2 by ~4x at
+N=100000 (its tracing JIT specialises the int-keyed dict to a
+direct array probe); LuaJIT beats vm2 by ~18x (the trace path
+folds the table access into a register-resident hashed probe).
+
+**Algorithm.** N iterations of the same LCG used by fasta §6.6,
+producing a 2-bit code (0..3) per iter via the HOMO_SAPIENS cumprob
+lookup. Per iter:
+
+```
+seed = (seed * 3877 + 29573) % 139968       // LCG (same as fasta)
+prob = float64(seed) / 139968.0             // i64 → f64 → divide
+code = lookup(prob)                         // returns 0/1/2/3
+counts[code] += 1                           // 1-mer count
+counts[4 + prev*4 + code] += 1              // 2-mer count
+prev = code
+```
+
+The map is int-keyed: keys 0..3 hold the four 1-mer counts and keys
+4..19 hold the sixteen 2-mer counts indexed by `4 + prev*4 + cur`.
+After the loop a single 20-step rolling i64 hash folds the counts
+into one integer so peers can integer-compare the result.
+`vm2.MapGet` returns `CNull()` for missing keys; `CNull().Int()`
+returns 0, so the first increment of any key reads 0 and writes 1
+without an explicit pre-init pass.
+
+The canonical BG k_nucleotide program reads the fasta byte stream
+and counts k=1, k=2, and seven specific k=3..18 mers (`GGT`,
+`GGTA`, ...). Iteration 1 scopes the kernel to the load-bearing
+piece: the inner map-increment loop. Iteration 2 extends the map to
+k=3 (64 additional keys) and routes the byte→code conversion
+through the canonical 97/99/103/116 alphabet so the kernel reads
+the fasta byte stream byte-for-byte; iteration 3 specialises the
+map to a direct int→int probe (mechanism 2 below).
+
+**Output format.** Iteration 1 reduces the kernel to a single i64
+hash that depends on every (1-mer, 2-mer) count. Bit-identical hash
+across Go / Python / Lua / Mochi confirms the LCG, the FP→cumprob
+threshold comparisons, the map-key arithmetic, and the hash
+summarisation all match. The 16 2-mer counts roughly track the
+product of the four marginal probabilities (a≈0.30, c≈0.20, g≈0.20,
+t≈0.30), so for example `count[4 + 0*4 + 0]` (the 'aa' 2-mer) is
+approximately N × 0.30 × 0.30 ≈ 0.09 × N. At N=100000 the bulk of
+the variance in the i64 hash comes from these 16 numbers, which is
+why the hash is sensitive to even one-off LCG drift between peers.
+
+**Theory.** Per iter the inner loop does, in vm2 bytecode:
+
+- 3 ops for the LCG (Mul + Add + Mod on i64)
+- 2 ops for prob (I64ToF64 + DivF64)
+- 1 Call to lookup; lookup body averages ~3 dispatches (LessF64 +
+  CondBr down the cascade)
+- 6 ops for the 1-mer increment: MapGet + ConstI64(1) + AddI64 +
+  MapSet (4 hot dispatches; the constant 1 folds at compile time
+  but the MapGet/MapSet pair is the dominant cost)
+- 8 ops for the 2-mer increment: 3 ops for the key arith (Mul +
+  Add + Add with a constant base), plus MapGet + AddI64 + MapSet
+- 1 fused OpTailCallSelfA5 for the recurse
+
+Total: ~26 dispatches per iter, but only ~6 of them are map ops
+(the heavy ones). At N=100000, the measured 311 ns/iter
+decomposes roughly as: 80 ns of arithmetic + lookup, plus 230 ns
+of map work (4 map ops × ~55 ns each). Go's 19.4 ns/iter splits as
+~10 ns of arith + ~9 ns for the four map ops (Go's int-keyed map
+hash is a 64-bit fingerprint + bucket walk, ~2-3 ns per access on
+an L1-resident map). The ~220 ns/iter map-cost gap is the load-
+bearing optimisation target.
+
+The 2x-vs-Go target at N=100000 is 3.9 ms (2 × 1944 µs). That
+requires ~39 ns per iter. To close the gap from 311 ns to 39 ns
+per iter, both the per-map-op cost AND the dispatch count need to
+drop. Mechanism candidates below name the steps.
+
+**Mechanism candidates (ranked by lift, smallest first).**
+
+1. **OpMapIncI64K (fused MapGet + AddI64K + MapSet on int keys).**
+   The increment pattern `m[k] = m[k] + 1` is the textbook three-op
+   fusion target for an int-keyed map. The fused op takes one map,
+   one key, and one immediate delta (here +1) and walks the bucket
+   chain once. At ~25 ns per fused op vs ~55 ns for the three
+   separate ops, this cuts per-iter map cost from ~220 ns to ~100
+   ns. Brings vm2 to ~18 ms at N=100000 (9.2x of Go). Cheap to
+   ship: one new opcode + one dispatch arm; no JIT dependency.
+   Stacks with mechanism 2.
+2. **Typed int-int map (`map[int64]int64` instead of
+   `map[any]Cell`).** vm2's map stores `Cell` values keyed by an
+   `any`-typed hash key, which adds interface boxing on every
+   access (~30-40 ns per access in Go's `runtime.mapaccess`). A
+   typed `map[int64]int64` skips the interface table and runs at
+   Go's native int-map speed (~3 ns per access). Saves ~50 ns per
+   access × 4 accesses per iter = ~200 ns saved per iter. Combined
+   with mechanism 1 this brings per-iter cost to ~50 ns, i.e. ~5
+   ms at N=100000, which is ~2.6x of Go. Requires a type-tagged
+   map variant in `runtime/vm2/maps.go` plus emit-side dispatch
+   based on key/value typing (the existing `MapGet(m, k, TI64)`
+   call already carries the type hint, so emit can pick the typed
+   path when both key and value are i64). The work is constrained
+   but it changes a public-facing op signature, so it lives in a
+   followup MEP rather than this kernel's iteration log.
+3. **OpArrayInc + bounded i64 array.** When the key range is
+   compile-time bounded (the k_nucleotide map has 20 keys at
+   k=1+2, 84 keys at k=1+2+3), emit can replace the map with a
+   fixed-size i64 array. `counts[k] += 1` becomes a single
+   `ArrayInc` op walking a register-resident array. Per-access
+   cost drops to ~3 ns (Go can do this in ~1 ns). Brings vm2 to
+   ~2 ms at N=100000, well inside the 2x gate. The price is an
+   emit-time analysis that proves the key range is bounded, which
+   for k_nucleotide is straightforward (`k_max = 4^k_max`); for
+   general programs this is a separate kernel optimisation pass.
+
+The path to 2x-vs-Go on this row is mechanism 1 + mechanism 3
+combined: fused increments handle the small-key case cheaply, and
+the bounded-array specialisation handles the k_nucleotide-shape
+workload at host-cache speed. Mechanism 2 is a broader runtime
+investment that benefits every int-keyed map in the codebase, not
+just this kernel.
+
+**Implementation (iteration 1).** Cross-lang templates landed in
+`bench/template/bg/k_nucleotide/` (.mochi, .py, .lua, .go.tmpl).
+The Mochi IR builder `corpus.BuildKNucleotide(n)` has four IR
+functions: `main` (bootstraps iter 0 inline, drives the rest of
+the loop, then summarises), `loop(seed, m, prev, i, n)` (TUnit
+tail-recursive worker doing LCG + lookup + two map increments per
+iter), `summ(m, key, acc, end)` (TI64 tail-recursive 20-step hash
+rollup), and `lookup(prob)` (TI64 4-way FP cascade returning 0..3).
+The map increments are inlined inside `loop` (no helper call) so
+the per-iter dispatch count is tight; the first iter is bootstrapped
+inline in `main` so the loop body is uniform (no "first iter is
+different" branch).
+
+The Lua peer keeps the same shape: an if/elseif chain for
+`lookup`, `math.floor` for the µs cast on output, and
+`counts[k] or 0` for the missing-key idiom (Lua tables return
+`nil` on missing keys, which an `or 0` lifts to 0 for the
+arithmetic). Python uses `counts.get(k, 0)` for the same reason;
+Go uses zero-valued reads from the `int64` map (`counts[k]` on a
+missing key returns the zero value 0).
+
+**Bench (iteration 1, 2026-05-18, macOS arm64, median of 3).**
+
+| N      | vm2 (µs) | CPython (µs) | PyPy (µs) | Lua (µs) | LuaJIT (µs) | Go (µs) | vm2 / Go |
+|-------:|---------:|-------------:|----------:|---------:|------------:|--------:|---------:|
+|  10000 |     3325 |         3037 |      5116 |      497 |         246 |     200 |   16.62x |
+| 100000 |    31087 |        28849 |      7440 |     4910 |        1710 |    1944 |   15.99x |
+
+The ratio against Go is nearly flat (16.62x → 15.99x as N goes 10x)
+because both sides scale linearly with map ops per iter. vm2 lands
+side-by-side with CPython (within 10%) because both runtimes pay a
+~50 ns per-access cost on a generic boxed map; PyPy specialises
+the int dict via tracing JIT (~4x faster than vm2 at N=100000)
+and LuaJIT specialises the table access to a register-resident
+hashed probe (~18x faster than vm2). Lua interpreter sits between
+vm2 and the JITs (4910 µs vs vm2's 31087 µs, 6.3x faster), which
+betrays the cost of Lua's stack-machine dispatch loop being faster
+than vm2's register dispatch on this kernel.
+
+Iteration 2 will deliver mechanism 1 (OpMapIncI64K) and re-measure;
+the bounded-array specialisation (mechanism 3) follows once
+iteration 2 numbers confirm fused increments are not enough alone.
 
 ### 6.x (template for future iterations)
 


### PR DESCRIPTION
Tracks #21619.

Scaled BG k_nucleotide kernel: an LCG random generator (same as fasta §6.6) drives a HOMO_SAPIENS cumprob lookup returning 2-bit codes 0..3; an int-keyed map holds 1-mer counts (keys 0..3) and 2-mer counts (keys 4..19), folded into a rolling i64 hash so the cross-lang harness compares a single integer across every peer.

## Result (macOS arm64, 2026-05-18, median of 3)

| N      | vm2 (µs) | CPython (µs) | PyPy (µs) | Lua (µs) | LuaJIT (µs) | Go (µs) | vm2 / Go |
|-------:|---------:|-------------:|----------:|---------:|------------:|--------:|---------:|
|  10000 |     3325 |         3037 |      5116 |      497 |         246 |     200 |   16.62x |
| 100000 |    31087 |        28849 |      7440 |     4910 |        1710 |    1944 |   15.99x |

vm2 side-by-side with CPython (within 10%); both pay similar generic-map overhead. PyPy and LuaJIT specialise the int-keyed table and beat vm2 by 4x and 18x respectively. Output bit-identical across all six runtimes: 723253870 / 1936471392.

## Files

- `bench/template/bg/k_nucleotide/` (.mochi, .py, .lua, .go.tmpl)
- `compiler2/corpus/bg_k_nucleotide_scaled.go` (`BuildKNucleotide` + `ExpectKNucleotide`)
- `compiler2/corpus/corpus.go` (register `bg_k_nucleotide`)
- `bench/crosslang/main.go` (program entry, ns=[10000, 100000])
- `bench/vm2runner/main.go` (repeats=1)
- `runtime/vm2/bench/corpus_test.go` (size 10000 + `BenchmarkVM2_BG_KNucleotide`)
- `website/docs/mep/mep-0039.md` (§2 headline row, §3 mark, full §6.7)

Spec: MEP-39 §6.7 names mechanism candidates (OpMapIncI64K, typed int-int map, bounded i64 array); iteration 2 will deliver mechanism 1.

## Test plan

- [x] `go test ./runtime/vm2/bench/ -run TestCorpusMatchesOracle`
- [x] Cross-lang sweep: all 6 runtimes produce bit-identical hash at N=10000 and N=100000