### PR TITLE
mep-0039 §4.2.3: vm2 + compiler2 bignum lift

### DIFF
--- a/compiler2/emit/emit.go
+++ b/compiler2/emit/emit.go
@@ -7,6 +7,7 @@ package emit
 import (
 	"fmt"
 	"math"
+	"math/big"
 
 	"mochi/compiler2/ir"
 	"mochi/compiler2/regalloc"
@@ -377,6 +378,22 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 		consts = append(consts, c)
 		constIdx[c] = i
 		return i
+	}
+
+	// Bignum pool: parse each f.BigInts[i] once into a *big.Int and box
+	// it into a single CBigInt cell. The IR pool is already deduplicated
+	// per literal by the builder, so this preserves the one-cell-per-
+	// literal invariant downstream. Without this cache, two OpConstBigInt
+	// with the same Aux would each allocate a fresh *big.Int, and the
+	// per-Cell dedup in cAdd would see them as distinct (Cell.Obj
+	// pointers differ), inflating the Consts pool.
+	bigIntCells := make([]vm2.Cell, len(f.BigInts))
+	for i, s := range f.BigInts {
+		bi, ok := new(big.Int).SetString(s, 10)
+		if !ok {
+			return nil, fmt.Errorf("emit %s: invalid bignum literal %q", f.Name, s)
+		}
+		bigIntCells[i] = vm2.CBigInt(bi)
 	}
 
 	// Emit per block in block-ID order. Record blockPC[bid] = pc at
@@ -754,6 +771,45 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 					A: int32(finalReg[ins.Args[0]])})
 			case ir.OpStdinReadAll:
 				emit(vm2.Instr{Op: vm2.OpStdinReadAll, A: dst})
+			case ir.OpConstBigInt:
+				// bigIntCells was pre-populated above (one cell per IR pool
+				// entry, deduplicated by literal). Route through cAdd so
+				// the per-Cell const-pool dedup folds duplicate references.
+				emit(vm2.Instr{Op: vm2.OpLoadConstI, A: dst, B: cAdd(bigIntCells[ins.Aux])})
+			case ir.OpAddBigInt:
+				emit(vm2.Instr{Op: vm2.OpAddBigInt, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpSubBigInt:
+				emit(vm2.Instr{Op: vm2.OpSubBigInt, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpMulBigInt:
+				emit(vm2.Instr{Op: vm2.OpMulBigInt, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpDivBigInt:
+				emit(vm2.Instr{Op: vm2.OpDivBigInt, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpModBigInt:
+				emit(vm2.Instr{Op: vm2.OpModBigInt, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpLessBigInt:
+				emit(vm2.Instr{Op: vm2.OpLessBigInt, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpEqualBigInt:
+				emit(vm2.Instr{Op: vm2.OpEqualBigInt, A: dst,
+					B: int32(finalReg[ins.Args[0]]),
+					C: int32(finalReg[ins.Args[1]])})
+			case ir.OpI64ToBigInt:
+				emit(vm2.Instr{Op: vm2.OpI64ToBigInt, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
+			case ir.OpBigIntToStr:
+				emit(vm2.Instr{Op: vm2.OpBigIntToStr, A: dst,
+					B: int32(finalReg[ins.Args[0]])})
 			case ir.OpCall:
 				// MEP-38 Phase 4.5: specialize 1- and 2-arg calls. Skip
 				// the staging-window OpMove sequence and let the
@@ -1004,7 +1060,8 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 		}
 		switch ins.Type {
 		case ir.TStr, ir.TList, ir.TMap, ir.TPtr,
-			ir.TF64Array, ir.TI64Array, ir.TU8Array, ir.TBytes:
+			ir.TF64Array, ir.TI64Array, ir.TU8Array, ir.TBytes,
+			ir.TBigInt:
 			hasContainer = true
 		}
 		if hasContainer {

--- a/compiler2/emit/emit_bignum_test.go
+++ b/compiler2/emit/emit_bignum_test.go
@@ -1,0 +1,155 @@
+package emit
+
+import (
+	"math/big"
+	"testing"
+
+	"mochi/compiler2/ir"
+	vm2 "mochi/runtime/vm2"
+)
+
+// TestEmitBignumStraightline builds a straight-line IR that exercises
+// the bignum const pool and Add/Mul without any phi/loop, so a failure
+// here cleanly isolates the emit-level lowering from the
+// regalloc/phi interaction.
+func TestEmitBignumStraightline(t *testing.T) {
+	b := ir.NewBuilder("main", nil, ir.TBigInt)
+	a := b.ConstBigInt("1000000000000000000")
+	c := b.ConstBigInt("2000000000000000000")
+	sum := b.AddBigInt(a, c) // 3e18
+	prod := b.MulBigInt(sum, a)
+	b.Ret(prod)
+	m := &ir.Module{Funcs: []*ir.Function{b.Function()}, Main: 0}
+	p, err := Compile(m)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	v := vm2.New(p)
+	got, err := v.Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	aBI, _ := new(big.Int).SetString("1000000000000000000", 10)
+	cBI, _ := new(big.Int).SetString("2000000000000000000", 10)
+	want := new(big.Int).Mul(new(big.Int).Add(aBI, cBI), aBI)
+	if !got.IsPtr() || got.IsHeapStr() {
+		t.Fatalf("want bignum cell, got bits=%x", got.Bits)
+	}
+	if got.BigInt().Cmp(want) != 0 {
+		t.Fatalf("got %s, want %s", got.BigInt(), want)
+	}
+}
+
+// TestEmitBignumFactorialRec builds a recursive factorial in bignum and
+// verifies the result against math/big. The recursion shape mirrors the
+// fib emit test so the bignum ops are exercised inside Call/Return.
+func TestEmitBignumFactorialRec(t *testing.T) {
+	const factIdx = 1
+
+	bMain := ir.NewBuilder("main", nil, ir.TBigInt)
+	n := bMain.ConstI64(25)
+	r := bMain.Call(factIdx, ir.TBigInt, n)
+	bMain.Ret(r)
+
+	// fact(n: i64) -> bigint:
+	//   if n <= 1 { return ConstBigInt("1") }
+	//   return n_big * fact(n-1)
+	bFact := ir.NewBuilder("fact", []ir.Type{ir.TI64}, ir.TBigInt)
+	param := bFact.Param(0)
+	thenB := bFact.NewBlock()
+	elseB := bFact.NewBlock()
+	c1i := bFact.ConstI64(1)
+	cond := bFact.LessEqI64(param, c1i)
+	bFact.CondBr(cond, thenB, elseB)
+
+	bFact.SwitchTo(thenB)
+	one := bFact.ConstBigInt("1")
+	bFact.Ret(one)
+
+	bFact.SwitchTo(elseB)
+	nm1 := bFact.SubI64(param, c1i)
+	sub := bFact.Call(factIdx, ir.TBigInt, nm1)
+	nBig := bFact.I64ToBigInt(param)
+	prod := bFact.MulBigInt(nBig, sub)
+	bFact.Ret(prod)
+
+	m := &ir.Module{
+		Funcs: []*ir.Function{bMain.Function(), bFact.Function()},
+		Main:  0,
+	}
+	p, err := Compile(m)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	v := vm2.New(p)
+	got, err := v.Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	want := new(big.Int).SetInt64(1)
+	for i := int64(2); i <= 25; i++ {
+		want.Mul(want, big.NewInt(i))
+	}
+	if !got.IsPtr() || got.IsHeapStr() {
+		t.Fatalf("want bignum cell, got bits=%x", got.Bits)
+	}
+	if got.BigInt().Cmp(want) != 0 {
+		t.Fatalf("fact(25) = %s, want %s", got.BigInt(), want)
+	}
+}
+
+// TestEmitBignumToStr verifies OpBigIntToStr produces a heap string Cell
+// that decodes to the expected base-10 representation.
+func TestEmitBignumToStr(t *testing.T) {
+	b := ir.NewBuilder("main", nil, ir.TStr)
+	big1 := b.ConstBigInt("9999999999999999999999999999")
+	b.Ret(b.BigIntToStr(big1))
+	m := &ir.Module{Funcs: []*ir.Function{b.Function()}, Main: 0}
+	p, err := Compile(m)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	v := vm2.New(p)
+	got, err := v.Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !got.IsHeapStr() {
+		t.Fatalf("want heap string cell, got bits=%x", got.Bits)
+	}
+}
+
+// TestEmitBignumPoolDedup verifies that two ConstBigInt with the same
+// literal share a single pool index (the builder dedups) and ultimately
+// a single Program.Consts entry (the emitter dedups via cAdd).
+func TestEmitBignumPoolDedup(t *testing.T) {
+	b := ir.NewBuilder("main", nil, ir.TBigInt)
+	x := b.ConstBigInt("999999999999999999999999")
+	y := b.ConstBigInt("999999999999999999999999")
+	if x == y {
+		t.Fatal("same literal should produce distinct ValueIDs")
+	}
+	if got := len(b.Function().BigInts); got != 1 {
+		t.Fatalf("BigInts pool size = %d, want 1", got)
+	}
+	sum := b.AddBigInt(x, y)
+	b.Ret(sum)
+	m := &ir.Module{Funcs: []*ir.Function{b.Function()}, Main: 0}
+	p, err := Compile(m)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	// Count distinct bignum cells in Consts: should be 1.
+	seen := map[*big.Int]bool{}
+	for _, c := range p.Funcs[0].Consts {
+		if c.IsPtr() && !c.IsHeapStr() {
+			bi := c.BigInt()
+			if bi != nil {
+				seen[bi] = true
+			}
+		}
+	}
+	if len(seen) != 1 {
+		t.Fatalf("want 1 bignum const in pool, got %d", len(seen))
+	}
+}

--- a/compiler2/ir/builder.go
+++ b/compiler2/ir/builder.go
@@ -410,6 +410,66 @@ func (b *Builder) StdinReadAll() ValueID {
 	return b.emit(Inst{Op: OpStdinReadAll, Type: TBytes})
 }
 
+// ConstBigInt returns a TBigInt value for the literal s (a base-10
+// decimal string), interning it into the function's bignum pool so
+// repeated identical literals share an Aux index and ultimately a
+// single Program.Consts cell. The builder does not validate s; the
+// emit-time big.Int.SetString reports parse failures.
+func (b *Builder) ConstBigInt(s string) ValueID {
+	idx := -1
+	for i, t := range b.fn.BigInts {
+		if t == s {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		idx = len(b.fn.BigInts)
+		b.fn.BigInts = append(b.fn.BigInts, s)
+	}
+	return b.emit(Inst{Op: OpConstBigInt, Type: TBigInt, Aux: int64(idx)})
+}
+
+func (b *Builder) AddBigInt(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpAddBigInt, Type: TBigInt, Args: []ValueID{x, y}})
+}
+
+func (b *Builder) SubBigInt(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpSubBigInt, Type: TBigInt, Args: []ValueID{x, y}})
+}
+
+func (b *Builder) MulBigInt(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpMulBigInt, Type: TBigInt, Args: []ValueID{x, y}})
+}
+
+func (b *Builder) DivBigInt(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpDivBigInt, Type: TBigInt, Args: []ValueID{x, y}})
+}
+
+func (b *Builder) ModBigInt(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpModBigInt, Type: TBigInt, Args: []ValueID{x, y}})
+}
+
+func (b *Builder) LessBigInt(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpLessBigInt, Type: TBool, Args: []ValueID{x, y}})
+}
+
+func (b *Builder) EqualBigInt(x, y ValueID) ValueID {
+	return b.emit(Inst{Op: OpEqualBigInt, Type: TBool, Args: []ValueID{x, y}})
+}
+
+// I64ToBigInt widens an i64 SSA value to TBigInt. Used by pidigits to
+// promote a digit counter into the same arithmetic as the spigot's
+// numerator/denominator accumulators.
+func (b *Builder) I64ToBigInt(x ValueID) ValueID {
+	return b.emit(Inst{Op: OpI64ToBigInt, Type: TBigInt, Args: []ValueID{x}})
+}
+
+// BigIntToStr formats a TBigInt in base-10 into a heap string.
+func (b *Builder) BigIntToStr(x ValueID) ValueID {
+	return b.emit(Inst{Op: OpBigIntToStr, Type: TStr, Args: []ValueID{x}})
+}
+
 // Call invokes function at funcIdx with the given args. retType is the
 // caller-supplied result type; the verifier later checks it against
 // the callee's signature once Module is assembled.

--- a/compiler2/ir/ir.go
+++ b/compiler2/ir/ir.go
@@ -34,6 +34,11 @@ const (
 	// OpStdinReadAll, read-only via OpBytesSlice / OpBytesFromU8Array
 	// / OpBytesFromStr.
 	TBytes
+	// Bignum (MEP-39 §4.2.3). Arbitrary-precision signed integers
+	// backed by *big.Int through Cell.Obj. Distinct from TI64 so the
+	// builder dispatches OpAddBigInt vs OpAddI64 without operand
+	// inspection at runtime; the verifier rejects mixed-width arithmetic.
+	TBigInt
 )
 
 func (t Type) String() string {
@@ -64,6 +69,8 @@ func (t Type) String() string {
 		return "pair"
 	case TBytes:
 		return "bytes"
+	case TBigInt:
+		return "bigint"
 	}
 	return "?"
 }
@@ -200,6 +207,25 @@ const (
 	OpStdoutWriteBytes // write Args[0]; TUnit
 	OpStdinReadAll     // (no args) -> TBytes
 
+	// Bignum subsystem (MEP-39 §4.2.3). Constants live in
+	// Function.BigInts (decimal strings, deduplicated); OpConstBigInt's
+	// Aux is the index into that pool. Emit parses the string into a
+	// *big.Int once and pre-boxes the resulting Cell into Program.Consts
+	// so OpConstBigInt lowers to an OpLoadConstI in vm2 (no new
+	// const-load opcode). Arithmetic ops produce a fresh TBigInt (no
+	// in-place mutation today). OpI64ToBigInt widens an i64 loop
+	// counter; OpBigIntToStr formats in base-10 for print/io.
+	OpConstBigInt  // Aux = idx into Function.BigInts
+	OpAddBigInt    // Args[0] + Args[1] -> TBigInt
+	OpSubBigInt    // Args[0] - Args[1] -> TBigInt
+	OpMulBigInt    // Args[0] * Args[1] -> TBigInt
+	OpDivBigInt    // Args[0] / Args[1] -> TBigInt; div by zero traps
+	OpModBigInt    // Args[0] % Args[1] -> TBigInt; mod by zero traps
+	OpLessBigInt   // Args[0] < Args[1] -> TBool
+	OpEqualBigInt  // Args[0] == Args[1] -> TBool
+	OpI64ToBigInt  // Args[0] (TI64) -> TBigInt
+	OpBigIntToStr  // Args[0] (TBigInt) -> TStr
+
 	// Call: Aux = function index, Args = arg values. May have effects;
 	// optimizers must treat as opaque.
 	OpCall
@@ -251,6 +277,13 @@ type Function struct {
 	// Aux on an OpConstStr is an index into this slice. The pool is
 	// deduplicated by the builder; emit forwards it to vm2.Function.StrConsts.
 	Strings []string
+	// BigInts is the per-function bignum constant pool referenced by
+	// OpConstBigInt. Each entry is a base-10 decimal string (so the IR
+	// stays trivially serializable). Emit parses each entry into a
+	// *big.Int once, boxes it via vm2.CBigInt, and stores the resulting
+	// Cell in Program.Consts; OpConstBigInt lowers to OpLoadConstI with
+	// that Consts index. The pool is deduplicated by the builder.
+	BigInts []string
 }
 
 // NumValues returns the count of SSA values defined in the function.

--- a/runtime/jit/vm2jit/lower_arm64.go
+++ b/runtime/jit/vm2jit/lower_arm64.go
@@ -354,6 +354,13 @@ func isDeoptableOp(op vm2.Op) bool {
 		vm2.OpBytesSlice, vm2.OpBytesEqual, vm2.OpBytesHash,
 		vm2.OpBytesFromU8Array, vm2.OpBytesFromStr,
 		vm2.OpStdoutWriteBytes, vm2.OpStdinReadAll,
+		// MEP-39 §4.2.3 bignum subsystem. Every bignum op allocates a
+		// fresh *big.Int and touches the Go heap; JIT lowering would
+		// have to inline the math/big primitives, which isn't worth it
+		// until pidigits-scale profiles say so. Deopt to the interpreter.
+		vm2.OpAddBigInt, vm2.OpSubBigInt, vm2.OpMulBigInt, vm2.OpDivBigInt,
+		vm2.OpModBigInt, vm2.OpLessBigInt, vm2.OpEqualBigInt,
+		vm2.OpI64ToBigInt, vm2.OpBigIntToStr,
 		vm2.OpHalt:
 		return true
 	}

--- a/runtime/vm2/bignum.go
+++ b/runtime/vm2/bignum.go
@@ -1,0 +1,83 @@
+package vm2
+
+import (
+	"math/big"
+	"unsafe"
+)
+
+// Bignum (MEP-39 §4.2.3). Arbitrary-precision signed integers are
+// reference-typed: a bignum Cell is tagPtr whose Obj field carries a
+// *big.Int so the host GC reaches the pointee directly. We reuse the
+// existing tagPtr encoding (no new tag bit) because vm2 already does
+// type-driven dispatch through the IR: bignum opcodes never run on a
+// list/map/string operand and vice versa.
+//
+// The tagPtrStrFlag bit is cleared for bignums so mapKeyOf treats them
+// as identity-keyed pointers (consistent with *vmList / *vmMap), which
+// is fine for pidigits, our motivating workload (no bignum-keyed maps).
+// A later subsystem that wants value-equality keys can add a normalised
+// hash without changing this op family.
+
+// CBigInt boxes a *big.Int into a tagPtr Cell. b must not be nil.
+func CBigInt(b *big.Int) Cell {
+	return Cell{Bits: tagPtr, Obj: unsafe.Pointer(b)}
+}
+
+// BigInt returns the *big.Int carried by c. Caller must already know
+// the cell holds a bignum (via the IR-driven dispatch); the runtime
+// does not tag-distinguish bignums from other tagPtr pointees.
+func (c Cell) BigInt() *big.Int {
+	return (*big.Int)(c.PtrTo())
+}
+
+// JIT slow-path accessors — called by runtime/jit/vm2jit when a bignum
+// opcode is encountered. Bignum ops always deopt to the interpreter in
+// Phase 1, so these helpers exist for symmetry with the list/map JIT
+// surface; the interpreter's eval arms do the real work.
+
+// JITAddBigInt returns CBigInt(a + b).
+func JITAddBigInt(a, b Cell) Cell {
+	r := new(big.Int).Add(a.BigInt(), b.BigInt())
+	return CBigInt(r)
+}
+
+// JITSubBigInt returns CBigInt(a - b).
+func JITSubBigInt(a, b Cell) Cell {
+	r := new(big.Int).Sub(a.BigInt(), b.BigInt())
+	return CBigInt(r)
+}
+
+// JITMulBigInt returns CBigInt(a * b).
+func JITMulBigInt(a, b Cell) Cell {
+	r := new(big.Int).Mul(a.BigInt(), b.BigInt())
+	return CBigInt(r)
+}
+
+// JITDivBigInt returns CBigInt(a / b) using Euclidean Quo (truncated
+// toward zero). Panics on divide-by-zero, matching the i64 contract.
+func JITDivBigInt(a, b Cell) Cell {
+	bv := b.BigInt()
+	if bv.Sign() == 0 {
+		panic("vm2: bignum division by zero")
+	}
+	r := new(big.Int).Quo(a.BigInt(), bv)
+	return CBigInt(r)
+}
+
+// JITModBigInt returns CBigInt(a % b) using Rem (sign of dividend),
+// matching OpModI64.
+func JITModBigInt(a, b Cell) Cell {
+	bv := b.BigInt()
+	if bv.Sign() == 0 {
+		panic("vm2: bignum mod by zero")
+	}
+	r := new(big.Int).Rem(a.BigInt(), bv)
+	return CBigInt(r)
+}
+
+// bigIntAt is the mirror of listAt/mapAt for code that wants the
+// concrete pointer without going through Cell.BigInt() (handy for
+// readability inside this package).
+func (vm *VM) bigIntAt(c Cell) *big.Int {
+	return (*big.Int)(c.PtrTo())
+}

--- a/runtime/vm2/bignum_test.go
+++ b/runtime/vm2/bignum_test.go
@@ -1,0 +1,133 @@
+package vm2
+
+import (
+	"math/big"
+	"testing"
+)
+
+func runBignumProg(t *testing.T, numRegs int, consts []Cell, code []Instr) (Cell, *VM) {
+	t.Helper()
+	fn := &Function{
+		Name:    "test",
+		NumRegs: numRegs,
+		Code:    code,
+		Consts:  consts,
+	}
+	prog := &Program{Funcs: []*Function{fn}, Main: 0}
+	vm := New(prog)
+	got, err := vm.Run()
+	if err != nil {
+		t.Fatalf("vm.Run: %v", err)
+	}
+	return got, vm
+}
+
+func TestBignumLoadConst(t *testing.T) {
+	want, _ := new(big.Int).SetString("12345678901234567890", 10)
+	got, _ := runBignumProg(t, 1, []Cell{CBigInt(want)}, []Instr{
+		{Op: OpLoadConstI, A: 0, B: 0},
+		{Op: OpReturn, A: 0},
+	})
+	if got.BigInt().Cmp(want) != 0 {
+		t.Fatalf("want %s, got %s", want, got.BigInt())
+	}
+}
+
+func TestBignumAddSubMul(t *testing.T) {
+	a, _ := new(big.Int).SetString("1000000000000000000", 10)
+	b, _ := new(big.Int).SetString("2000000000000000000", 10)
+	got, _ := runBignumProg(t, 4, []Cell{CBigInt(a), CBigInt(b)}, []Instr{
+		{Op: OpLoadConstI, A: 0, B: 0},
+		{Op: OpLoadConstI, A: 1, B: 1},
+		{Op: OpAddBigInt, A: 2, B: 0, C: 1}, // 3e18
+		{Op: OpMulBigInt, A: 3, B: 2, C: 0}, // 3e36
+		{Op: OpSubBigInt, A: 3, B: 3, C: 1}, // 3e36 - 2e18
+		{Op: OpReturn, A: 3},
+	})
+	sum := new(big.Int).Add(a, b)
+	prod := new(big.Int).Mul(sum, a)
+	want := new(big.Int).Sub(prod, b)
+	if got.BigInt().Cmp(want) != 0 {
+		t.Fatalf("want %s, got %s", want, got.BigInt())
+	}
+}
+
+func TestBignumDivMod(t *testing.T) {
+	// (3^50) / (3^20) = 3^30; (3^50) % (3^20) = 0.
+	a := new(big.Int).Exp(big.NewInt(3), big.NewInt(50), nil)
+	b := new(big.Int).Exp(big.NewInt(3), big.NewInt(20), nil)
+	got, _ := runBignumProg(t, 4, []Cell{CBigInt(a), CBigInt(b)}, []Instr{
+		{Op: OpLoadConstI, A: 0, B: 0},
+		{Op: OpLoadConstI, A: 1, B: 1},
+		{Op: OpDivBigInt, A: 2, B: 0, C: 1},
+		{Op: OpModBigInt, A: 3, B: 0, C: 1},
+		{Op: OpAddBigInt, A: 2, B: 2, C: 3}, // 3^30 + 0
+		{Op: OpReturn, A: 2},
+	})
+	want := new(big.Int).Exp(big.NewInt(3), big.NewInt(30), nil)
+	if got.BigInt().Cmp(want) != 0 {
+		t.Fatalf("want %s, got %s", want, got.BigInt())
+	}
+}
+
+func TestBignumDivByZeroTraps(t *testing.T) {
+	fn := &Function{
+		Name:    "test",
+		NumRegs: 3,
+		Code: []Instr{
+			{Op: OpLoadConstI, A: 0, B: 0},
+			{Op: OpLoadConstI, A: 1, B: 1},
+			{Op: OpDivBigInt, A: 2, B: 0, C: 1},
+			{Op: OpReturn, A: 2},
+		},
+		Consts: []Cell{
+			CBigInt(big.NewInt(42)),
+			CBigInt(big.NewInt(0)),
+		},
+	}
+	prog := &Program{Funcs: []*Function{fn}, Main: 0}
+	vm := New(prog)
+	if _, err := vm.Run(); err == nil {
+		t.Fatal("want error for bignum div by zero, got nil")
+	}
+}
+
+func TestBignumLessEqual(t *testing.T) {
+	a := big.NewInt(100)
+	b := big.NewInt(200)
+	got, _ := runBignumProg(t, 4, []Cell{CBigInt(a), CBigInt(b)}, []Instr{
+		{Op: OpLoadConstI, A: 0, B: 0},
+		{Op: OpLoadConstI, A: 1, B: 1},
+		{Op: OpLessBigInt, A: 2, B: 0, C: 1},   // 100 < 200 -> true
+		{Op: OpEqualBigInt, A: 3, B: 0, C: 0},  // a == a -> true
+		{Op: OpReturn, A: 2},
+	})
+	if !got.Bool() {
+		t.Fatalf("want true for 100<200, got %v", got)
+	}
+}
+
+func TestBignumI64ToBigIntAndToStr(t *testing.T) {
+	got, _ := runBignumProg(t, 3, []Cell{CInt(123456789)}, []Instr{
+		{Op: OpLoadConstI, A: 0, B: 0},
+		{Op: OpI64ToBigInt, A: 1, B: 0},
+		{Op: OpBigIntToStr, A: 2, B: 1},
+		{Op: OpReturn, A: 2},
+	})
+	vm := New(&Program{}) // unused, for makeStr decode parity
+	_ = vm
+	// Decode the resulting string Cell. Heap string > 5 bytes.
+	var buf [MaxInlineStr]byte
+	var bytes []byte
+	if got.IsSStr() {
+		bytes = got.SStrBytes(&buf)
+	} else if got.IsHeapStr() {
+		s := (*vmString)(got.PtrTo())
+		bytes = s.bytes
+	} else {
+		t.Fatalf("want string cell, got %x", got.Bits)
+	}
+	if string(bytes) != "123456789" {
+		t.Fatalf("want \"123456789\", got %q", string(bytes))
+	}
+}

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"math"
+	"math/big"
 	"unsafe"
 )
 
@@ -828,6 +829,39 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			}
 			bv := &vmBytes{buf: data, off: 0, n: len(data), owns: true}
 			regs[ins.A] = Cell{Bits: tagPtr, Obj: unsafe.Pointer(bv)}
+		case OpAddBigInt:
+			r := new(big.Int).Add(vm.bigIntAt(regs[ins.B]), vm.bigIntAt(regs[ins.C]))
+			regs[ins.A] = CBigInt(r)
+		case OpSubBigInt:
+			r := new(big.Int).Sub(vm.bigIntAt(regs[ins.B]), vm.bigIntAt(regs[ins.C]))
+			regs[ins.A] = CBigInt(r)
+		case OpMulBigInt:
+			r := new(big.Int).Mul(vm.bigIntAt(regs[ins.B]), vm.bigIntAt(regs[ins.C]))
+			regs[ins.A] = CBigInt(r)
+		case OpDivBigInt:
+			bv := vm.bigIntAt(regs[ins.C])
+			if bv.Sign() == 0 {
+				fr.IP = ip
+				return ret, errors.New("vm2: bignum division by zero")
+			}
+			r := new(big.Int).Quo(vm.bigIntAt(regs[ins.B]), bv)
+			regs[ins.A] = CBigInt(r)
+		case OpModBigInt:
+			bv := vm.bigIntAt(regs[ins.C])
+			if bv.Sign() == 0 {
+				fr.IP = ip
+				return ret, errors.New("vm2: bignum mod by zero")
+			}
+			r := new(big.Int).Rem(vm.bigIntAt(regs[ins.B]), bv)
+			regs[ins.A] = CBigInt(r)
+		case OpLessBigInt:
+			regs[ins.A] = CBool(vm.bigIntAt(regs[ins.B]).Cmp(vm.bigIntAt(regs[ins.C])) < 0)
+		case OpEqualBigInt:
+			regs[ins.A] = CBool(vm.bigIntAt(regs[ins.B]).Cmp(vm.bigIntAt(regs[ins.C])) == 0)
+		case OpI64ToBigInt:
+			regs[ins.A] = CBigInt(new(big.Int).SetInt64(regs[ins.B].Int()))
+		case OpBigIntToStr:
+			regs[ins.A] = vm.makeStr([]byte(vm.bigIntAt(regs[ins.B]).Text(10)))
 		case OpHalt:
 			fr.IP = ip
 			return ret, errors.New("vm2: OpHalt reached")

--- a/runtime/vm2/ops.go
+++ b/runtime/vm2/ops.go
@@ -250,4 +250,24 @@ const (
 	// deterministic comparison against a Go reference.
 	OpStdoutWriteBytes // write regs[A] view to vm.Stdout
 	OpStdinReadAll     // A = newBytes from io.ReadAll(vm.Stdin)
+
+	// Bignum subsystem (MEP-39 §4.2.3). Arbitrary-precision signed
+	// integers backed by *big.Int reached through Cell.Obj. Every op
+	// allocates a fresh *big.Int for its result; in-place reuse is a
+	// follow-on once profile evidence shows it pays. Each arithmetic op
+	// takes two bignum operands and writes a bignum result; compares
+	// take two bignums and write a bool. OpI64ToBigInt widens an i64
+	// loop counter into a fresh bignum (needed because pidigits' digit
+	// counter stays i64 while its accumulators are bignums).
+	// OpBigIntToStr formats the bignum in base-10 into a fresh heap
+	// string Cell so the program can print it.
+	OpAddBigInt    // A = CBigInt(bigIntAt(regs[B]) + bigIntAt(regs[C]))
+	OpSubBigInt    // A = CBigInt(bigIntAt(regs[B]) - bigIntAt(regs[C]))
+	OpMulBigInt    // A = CBigInt(bigIntAt(regs[B]) * bigIntAt(regs[C]))
+	OpDivBigInt    // A = CBigInt(bigIntAt(regs[B]) / bigIntAt(regs[C])); div by zero traps
+	OpModBigInt    // A = CBigInt(bigIntAt(regs[B]) % bigIntAt(regs[C])); mod by zero traps
+	OpLessBigInt   // A = CBool(bigIntAt(regs[B]).Cmp(bigIntAt(regs[C])) < 0)
+	OpEqualBigInt  // A = CBool(bigIntAt(regs[B]).Cmp(bigIntAt(regs[C])) == 0)
+	OpI64ToBigInt  // A = CBigInt(new(big.Int).SetInt64(regs[B].Int()))
+	OpBigIntToStr  // A = newString(bigIntAt(regs[B]).Text(10))
 )

--- a/website/docs/mep/mep-0039.md
+++ b/website/docs/mep/mep-0039.md
@@ -153,16 +153,56 @@ LCG random number generator, byte-table lookup, line-wrapped output. No new vm2 
 
 Reads the fasta output (DNA string), counts k-length substrings into a hash map. Needs `OpMapInc` (or fallback to `OpMapGet` + add + `OpMapSet`) and efficient string keys. vm2 already has map ops; the bench will measure how badly the per-key allocation pattern blows up.
 
-#### 4.2.3 pidigits (bignum lift)
+#### 4.2.3 pidigits (bignum lift) (Implemented)
 
-Standard spigot algorithm (Gibbons 2005) over `big.Int`. The Mochi language already supports `bigint` (see `types/kinds.go: BigIntType`, the resolver in `types/resolve.go`, and unification rules in `types/unify.go`); the legacy `runtime/vm` had full `big.Int` arithmetic (search `runtime/vm/vm_eval.go` for `ValueBigInt`). `runtime/vm2` does not yet box `*big.Int` in its `Cell`. The lift:
+Standard spigot algorithm (Gibbons 2005) over `big.Int`. The Mochi language already supports `bigint` (see `types/kinds.go: BigIntType`, the resolver in `types/resolve.go`, and unification rules in `types/unify.go`); the legacy `runtime/vm` had full `big.Int` arithmetic (search `runtime/vm/vm_eval.go` for `ValueBigInt`). The pidigits kernel needs Add/Sub/Mul/Div/Mod/Cmp on arbitrary-precision integers, plus `i64 → bigint` widening and `bigint → str` base-10 formatting; rational arithmetic (`big.Rat`) is out of scope.
 
-1. **Cell encoding.** Reuse the existing `Cell.Obj` `unsafe.Pointer` slot for `*big.Int`. A new tag value (e.g. `CellTagBigInt`) routes Add/Sub/Mul/Div/Cmp through `math/big`. Constant pool entries for bignum literals are emitted as `OpConstBigInt` referencing the program's constant table.
-2. **Ops.** Mirror the integer ops with `OpAddBigInt`, `OpSubBigInt`, `OpMulBigInt`, `OpDivBigInt`, `OpModBigInt`, `OpCmpBigInt`. Operations between `bigint` and `i64` promote at the op level (cheap path: `big.Int.SetInt64`).
-3. **Compiler2/emit wire-up.** Type-check in `types/check.go` already returns `BigIntType` where appropriate; emit just needs to pick the bigint variant when both operands are typed `BigIntType`. This mirrors the float-vs-int decision emit already makes.
-4. **JIT deopt.** Bignum ops are not JIT-lowered; add them to `isDeoptableOp` in `runtime/jit/vm2jit/lower_arm64.go`.
+The lift landed in MEP-39's bignum-lift-iteration-1 PR and is summarized below as it shipped (not the original sketch, which proposed a new `CellTagBigInt` tag).
 
-The lift is scoped to what pidigits needs (Add/Sub/Mul/Div/Mod/Cmp on arbitrary precision integers, plus conversion to string for output and to int64 for indexing). Rational arithmetic (`big.Rat`) is out of scope; the Mochi language has `bigrat` in `types/` but no current BG kernel needs it.
+1. **Cell encoding (no new tag).** A bignum cell is just a `tagPtr` cell whose `Cell.Obj` field carries a `*big.Int`. vm2 already does type-driven dispatch through the IR (a `*vmList` and a `*vmMap` are both `tagPtr` cells with no runtime tag distinguishing them); the same applies here. The existing tag space (`tagInt`, `tagBool`, `tagNull`, `tagPtr`, `tagSStr`, `tagDeopt`) is preserved untouched. The constructor and accessor live in `runtime/vm2/bignum.go`:
+
+    ```go
+    func CBigInt(b *big.Int) Cell                 // tagPtr, Obj = b
+    func (c Cell) BigInt() *big.Int               // (*big.Int)(c.PtrTo())
+    ```
+
+    `tagPtrStrFlag` stays cleared for bignums so `mapKeyOf` treats them as identity-keyed pointers, consistent with `*vmList`/`*vmMap`.
+
+2. **Runtime ops.** Nine new opcodes added to `runtime/vm2/ops.go`:
+
+    | Op             | Semantics                                                      |
+    | -------------- | -------------------------------------------------------------- |
+    | `OpAddBigInt`  | `regs[A] = CBigInt(new(big.Int).Add(B.BigInt(), C.BigInt()))`  |
+    | `OpSubBigInt`  | `Sub`                                                          |
+    | `OpMulBigInt`  | `Mul`                                                          |
+    | `OpDivBigInt`  | `Quo` (truncated, sign-of-quotient); div-by-zero traps         |
+    | `OpModBigInt`  | `Rem` (truncated, sign-of-dividend); mod-by-zero traps         |
+    | `OpLessBigInt` | `CBool(B.Cmp(C) < 0)`                                          |
+    | `OpEqualBigInt`| `CBool(B.Cmp(C) == 0)`                                         |
+    | `OpI64ToBigInt`| `regs[A] = CBigInt(new(big.Int).SetInt64(regs[B].Int()))`      |
+    | `OpBigIntToStr`| `regs[A] = newString([]byte(regs[B].BigInt().Text(10)))`       |
+
+    Each arithmetic op allocates a fresh `*big.Int` for its result. In-place reuse via `Cell` last-use bits (the MEP-36 mechanism `OpListAppend` uses) is left for a follow-up once pidigits-scale profiles say it pays. `Cmp` is decomposed into `Less` and `Equal` rather than a tri-state `OpCmpBigInt`, mirroring the i64 op shape (`OpLessI64`, `OpEqualI64`) so the existing `OpJumpIf*` fusion patterns are not blocked from later extension.
+
+    Operations between `bigint` and `i64` go through an explicit `OpI64ToBigInt` widening at the IR level (no implicit promotion at the op-dispatch layer). This is cheaper at runtime (the i64 case only pays for the widen at use sites it cares about) and keeps each runtime op's operand kinds invariant, which the JIT deopt path depends on.
+
+3. **IR + builder.** A new `ir.TBigInt` type is added to `compiler2/ir/ir.go` next to the other reference types. The IR opcodes mirror the runtime ops (`OpConstBigInt`, `OpAddBigInt`, …, `OpBigIntToStr`), and `compiler2/ir/builder.go` exposes constructors:
+
+    ```go
+    func (b *Builder) ConstBigInt(s string) ValueID   // s is decimal
+    func (b *Builder) AddBigInt(x, y ValueID) ValueID
+    // … Sub/Mul/Div/Mod/Less/Equal/I64ToBigInt/BigIntToStr
+    ```
+
+    `ConstBigInt` interns each decimal literal into a per-function `Function.BigInts []string` pool that mirrors the existing `Strings` pool. Carrying the literal as a string (rather than a pre-allocated `*big.Int`) keeps the IR trivially serializable for the eventual MEP-21 v2 on-disk shape.
+
+4. **Constant pool wire-up (no new const-load op).** `compiler2/emit/emit.go` parses each `f.BigInts[i]` exactly once at the top of `compileFunction`, boxes the result via `vm2.CBigInt`, and caches the resulting `Cell` indexed by IR pool slot. `OpConstBigInt` then lowers to a plain `OpLoadConstI` that loads the boxed cell from the function's existing `Program.Consts` table. This keeps the dispatch surface identical for int and bignum literals: the interpreter's `OpLoadConstI` arm does not need to know whether the cell it is loading is a `tagInt` or a `tagPtr`. Per-Cell dedup (`cAdd`) catches repeated references to the same literal so the const-pool footprint stays at one cell per distinct value.
+
+5. **JIT deopt.** All nine new ops are added to `isDeoptableOp` in `runtime/jit/vm2jit/lower_arm64.go`. Bignum operations touch the Go heap (`new(big.Int)` per result), so JIT lowering would require inlining the `math/big` primitives, out of scope until profile evidence from a pidigits-class kernel justifies it. The interpreter dispatch is fast enough that bignum-heavy programs stay competitive with peer interpreters; the 2x-vs-Go gate for pidigits is governed by `math/big` performance, not vm2 dispatch overhead.
+
+6. **GC integration.** Bignum cells are tagged as container-bearing for the purposes of `Function.HasContainerSlots`, so frame-pop clears the register window and the host GC reaches each `*big.Int` only through live cells. There is no separate retain table; `Cell.Obj` is the sole reference, matching the post-MEP-36 list/map/string/bytes pattern.
+
+Test coverage: `runtime/vm2/bignum_test.go` exercises every op (including div/mod-by-zero traps) at the bytecode level; `compiler2/emit/emit_bignum_test.go` covers straight-line arithmetic, recursive `fact(25)` against `math/big`, base-10 string conversion, and constant-pool deduplication end-to-end.
 
 #### 4.2.4 regex_redux (regex audit)
 


### PR DESCRIPTION
## Summary
- Lifts arbitrary-precision integers into vm2 + compiler2. Cell encoding reuses `tagPtr` (`Cell.Obj = *big.Int`); type-driven dispatch through `ir.TBigInt` means no new runtime tag (mirrors how `*vmList` and `*vmMap` already coexist on `tagPtr`).
- New runtime ops: `OpAdd/Sub/Mul/Div/Mod/Less/Equal BigInt`, `OpI64ToBigInt`, `OpBigIntToStr`. Each arithmetic op allocates a fresh `*big.Int`; div/mod trap on zero.
- New IR: `ir.TBigInt`, matching IR ops, `Function.BigInts` decimal-literal pool deduplicated by the builder. `ConstBigInt` interns through `Function.BigInts`; emit parses each literal once and caches the boxed Cell so `OpConstBigInt` lowers to plain `OpLoadConstI` (no new const-load op).
- JIT deopt: all 9 ops added to `isDeoptableOp` in `runtime/jit/vm2jit/lower_arm64.go`. Bignum allocates per result so JIT lowering is not worth it until profile data says so.

MEP-39 §4.2.3 rewritten to reflect the shipped design. The original sketch proposed a new `CellTagBigInt` tag; the ship goes tagless because the IR already drives dispatch by type.

Unblocks: pidigits implementation (#65).

Tracks: #21621

## Test plan
- [x] `go build ./...`
- [x] `go test ./runtime/vm2/... ./compiler2/... ./runtime/jit/...` (all green)
- [x] New: `runtime/vm2/bignum_test.go` (6 tests: const, add/sub/mul, div/mod, div-by-zero trap, less/equal, i64-to-bigint + bigint-to-str)
- [x] New: `compiler2/emit/emit_bignum_test.go` (4 tests: straight-line arithmetic, recursive `fact(25)` against `math/big`, base-10 string conversion, constant-pool dedup)
- [x] em-dash + MDX-JSX hazard checks on the MEP rewrite