### PR TITLE
mep-0039: hotfix MDX deploy in §6.8

### DIFF
--- a/website/docs/mep/mep-0039.md
+++ b/website/docs/mep/mep-0039.md
@@ -1237,7 +1237,7 @@ mul, mul, sub, mul, add, mul, div, sub, fold-hash) and the consume
 branch dispatches ~14 ops (compare, two i64→bignum widens, four
 muls, add, div, narrow, then 4 i64 step ops). At ~10 ns per
 dispatch in the host this is ~140 ns per iter of dispatch overhead,
-vs the ~80 µs of `math/big` work per iter; dispatch is <0.2% of
+vs the ~80 µs of `math/big` work per iter; dispatch is under 0.2% of
 wall-clock.
 
 **Mechanism candidates (deferred, not needed to clear the 2x


### PR DESCRIPTION
## Summary
- Escape `<0.2%` to "under 0.2%" so MDX stops parsing it as a malformed JSX tag

Main's website deploy has been failing since #21624 merged because the §6.8 pidigits prose contained `<0.2%`. Tests passed but Cloudflare Pages build did not, and the deploy check isn't a required check so auto-merge went through.

Tracking: #21625

## Test plan
- [x] `mdx` parse will no longer choke (rendered fine locally)
- [ ] CI deploy passes