### PR TITLE
mep-0039 §5: fill post-implementation baseline (10/10 BG)

### DIFF
--- a/website/docs/mep/mep-0039.md
+++ b/website/docs/mep/mep-0039.md
@@ -230,20 +230,54 @@ This is the same pattern MEP-38 used for its four target programs; MEP-39 extend
 
 ## 5. Post-implementation baseline
 
-To be filled after §4.1-§4.2 land. Empty rows below name the programs that will appear and the size grid each will be benched at.
+All ten BG programs are now wired into `bench/crosslang`. Measured
+2026-05-18 on macOS arm64 (M-series), median of 5 invocations,
+`go run ./bench/crosslang -repeat 5`. Iteration-1 numbers per
+program; the §6.x subsections track per-program iterations.
 
-| Program             | N (small) | N (medium) | vm2 (µs) | CPython (µs) | Lua (µs) | Go (µs) | vm2 / Go |
-|---------------------|----------:|-----------:|---------:|-------------:|---------:|--------:|---------:|
-| `bg/binary_trees`   |         8 |         10 |        — |            — |        — |       — |        — |
-| `bg/fannkuch_redux` |         7 |          9 |        — |            — |        — |       — |        — |
-| `bg/fasta`          |      1000 |      10000 |        — |            — |        — |       — |        — |
-| `bg/k_nucleotide`   |      1000 |      10000 |        — |            — |        — |       — |        — |
-| `bg/mandelbrot`     |        64 |        200 |        — |            — |        — |       — |        — |
-| `bg/n_body`         |       100 |       1000 |        — |            — |        — |       — |        — |
-| `bg/pidigits`       |        50 |        200 |        — |            — |        — |       — |        — |
-| `bg/regex_redux`    |      1000 |      10000 |        — |            — |        — |       — |        — |
-| `bg/reverse_complement` |   1024 |     65536 |        — |            — |        — |       — |        — |
-| `bg/spectral_norm`  |        50 |        100 |        — |            — |        — |       — |        — |
+| Program | N (small) | N (medium) | vm2 (µs) small / medium | Go (µs) small / medium | vm2 / Go small | vm2 / Go medium | Gate |
+|---|---:|---:|---:|---:|---:|---:|:---:|
+| `bg/binary_trees`      |     8 |     10 |     19427 /    326335 |      2376 /     35184 |   8.18x |   9.28x | ✗ |
+| `bg/fannkuch_redux`    |  1000 |  10000 |       749 /      7356 |        21 /       183 |  35.67x |  40.20x | ✗ |
+| `bg/fasta`             | 10000 | 100000 |      1342 /     11903 |       228 /      2256 |   5.89x |   5.28x | ✗ |
+| `bg/k_nucleotide`      | 10000 | 100000 |      7146 /     67778 |       381 /      3982 |  18.76x |  17.02x | ✗ |
+| `bg/mandelbrot`        |   100 |    200 |     13912 /     60494 |       478 /      1854 |  29.10x |  32.63x | ✗ |
+| `bg/n_body`            |  1000 |   5000 |      4789 /     32141 |        65 /       463 |  73.68x |  69.42x | ✗ |
+| `bg/pidigits`          |  1000 |  10000 |     36186 /   4042829 |     31001 /   2521885 |   1.17x |   1.60x | ✓ |
+| `bg/regex_redux`       |  1000 |  10000 |        94 /       785 |         9 /        58 |  10.44x |  13.53x | ✗ |
+| `bg/reverse_complement`|  4096 |  16384 |      1077 /      7457 |        13 /        49 |  82.85x | 152.18x | ✗ |
+| `bg/spectral_norm`     |   100 |    200 |     22167 /     78443 |       264 /      1196 |  83.97x |  65.59x | ✗ |
+
+Of the ten BG programs, only `bg/pidigits` clears the 2x-of-Go gate
+at iteration 1; this is the structural win MEP-39 §6.8 already
+explained (per-iter cost dominated by `math/big`, so dispatch tax
+amortises). The nine remaining programs are dispatch-bound at
+iteration 1 and need either fused ops (cheap, kernel-specific) or
+trace JIT lowering (expensive, generic) to land. Each gets a §6.x
+sub-section that drafts a mechanism plan, predicts the
+post-iteration-2 ratio, and records the measured delta once
+implemented.
+
+The relative ranking against CPython, PyPy, Lua, and LuaJIT is
+preserved in the full markdown export at this size grid:
+
+| Program | N | CPython (µs) small / medium | PyPy (µs) small / medium | Lua (µs) small / medium | LuaJIT (µs) small / medium |
+|---|---:|---:|---:|---:|---:|
+| `bg/binary_trees`      |  8 / 10 |    23868 / 345825 |    18077 /  62251 |   29979 / 387026 |     8975 / 117767 |
+| `bg/fannkuch_redux`    | 1000 / 10000 |   1492 /  14806 |     6488 /   8887 |     400 /   4585 |      298 /    651 |
+| `bg/fasta`             | 10000 / 100000 |  5121 /  51300 |     8243 /   9438 |     685 /   7757 |      487 /   3153 |
+| `bg/k_nucleotide`      | 10000 / 100000 |  5694 /  60748 |    10897 /  15785 |     941 /  10821 |      482 /   3798 |
+| `bg/mandelbrot`        | 100 / 200 |       30490 / 128329 |     7279 /  12946 |   10794 /  42418 |     1032 /   3830 |
+| `bg/n_body`            | 1000 / 5000 |     17819 /  87393 |    19231 /  20816 |    2639 /  12830 |      580 /   1114 |
+| `bg/pidigits`          | 1000 / 10000 |   76039 / 10157388 |  40945 / 4894657 |       — /      — |        — /      — |
+| `bg/regex_redux`       | 1000 / 10000 |     319 /   2740 |      558 /   1444 |      72 /    596 |      106 /    217 |
+| `bg/reverse_complement`| 4096 / 16384 |    1697 /   7190 |     3492 /   3939 |     411 /   1585 |      279 /    682 |
+| `bg/spectral_norm`     | 100 / 200 |       33783 / 132408 |    9601 /  11735 |   18608 /  72740 |      901 /   2493 |
+
+Outputs are bit-identical across every (vm2, peer) pair where a
+peer is wired (`✓` in the match column of the harness output).
+Lua and LuaJIT are intentionally skipped for `bg/pidigits` because
+neither has native arbitrary-precision integers; see MEP-39 §6.8.
 
 ## 6. Per-program iteration log
 


### PR DESCRIPTION
## Summary
- Replace the empty §5 placeholder table with iteration-1 numbers for all ten BG programs
- Only `bg/pidigits` clears the 2x-of-Go gate at iteration 1; the other nine need §6.x mechanism work

Measured 2026-05-18 on macOS arm64 (M-series), median of 5 invocations via `go run ./bench/crosslang -repeat 5`. Output is bit-identical across vm2 and every wired peer (Lua/LuaJIT skipped for pidigits per §6.8). The §5 table now drives the optimization sequencing in §6: reverse_complement (152x), spectral_norm (84x), n_body (74x), fannkuch_redux (40x), mandelbrot (33x), k_nucleotide (19x), regex_redux (14x), binary_trees (9x), fasta (6x) are all dispatch-bound; iteration 2 will pick the highest-leverage mechanism per program.

Tracking: #21629

## Test plan
- [x] §5 table renders cleanly (no MDX hazards; grepped `<[0-9]` over the whole file)
- [ ] CI deploy passes