### PR TITLE
MEP-39 §6.6: fasta iteration 3 (i64 cmp+branch K-form fusion)

### DIFF
--- a/compiler2/emit/emit.go
+++ b/compiler2/emit/emit.go
@@ -213,13 +213,18 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 	}
 	// fuseCmpConst marks a fused cmp+condbr whose const operand should be
 	// inlined into the K-form jump op (avoids the OpLoadConstI dispatch
-	// + register slot). Only populated for OpEqualI64 with one
-	// ConstI64 arg whose value fits in i32; less/lessEq with a const
-	// could be added analogously but the BG corpus uses equality for the
-	// only hot cases (leaf-guard checks in recursive kernels).
+	// + register slot). Populated for OpEqualI64, OpLessI64, OpLessEqI64
+	// with one ConstI64 arg whose value fits in i32. The constSide field
+	// tells the emit site which side held the constant: 1 for rhs (the
+	// commutative-friendly case for Equal, and the natural case for the
+	// Less/LessEq forms), 0 for lhs (only valid for Equal, where the
+	// emit site swaps to the symmetric K-form). MEP-39 §6.6 fasta
+	// iteration 3 motivates Less/LessEq: the inlined cumprob cascade
+	// compares the LCG output against three i64 thresholds per iter.
 	type cmpConstInfo struct {
-		k       int64
-		nonReg  ir.ValueID
+		k         int64
+		nonReg    ir.ValueID
+		constSide uint8 // 0 = lhs is const, 1 = rhs is const
 	}
 	fuseCmpConst := make(map[ir.ValueID]cmpConstInfo)
 	for bi := range f.Blocks {
@@ -257,9 +262,12 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 		}
 		suppress[cmpVid] = true
 		fuseCondBr[last] = cmpVid
-		if cmpIns.Op == ir.OpEqualI64 {
+		switch cmpIns.Op {
+		case ir.OpEqualI64:
+			// Equal is commutative; try rhs first so we keep the
+			// (otherReg, k) shape that OpJumpIfEqualI64K expects.
 			a0, a1 := cmpIns.Args[0], cmpIns.Args[1]
-			tryK := func(constArg, otherArg ir.ValueID) bool {
+			tryK := func(constArg, otherArg ir.ValueID, side uint8) bool {
 				c := f.Values[constArg]
 				if c.Op != ir.OpConstI64 || useCount[constArg] != 1 {
 					return false
@@ -269,12 +277,29 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 					return false
 				}
 				suppress[constArg] = true
-				fuseCmpConst[cmpVid] = cmpConstInfo{k: k, nonReg: otherArg}
+				fuseCmpConst[cmpVid] = cmpConstInfo{k: k, nonReg: otherArg, constSide: side}
 				return true
 			}
-			if !tryK(a1, a0) {
-				tryK(a0, a1)
+			if !tryK(a1, a0, 1) {
+				tryK(a0, a1, 0)
 			}
+		case ir.OpLessI64, ir.OpLessEqI64:
+			// Less/LessEq are not commutative; only fuse when the rhs is
+			// the constant. The lhs-constant case would need an inverted
+			// op (e.g. K < reg ≡ reg > K), which we could add later; the
+			// fasta cumprob cascade only generates rhs-const, so leave
+			// the symmetric form for follow-up.
+			rhs := cmpIns.Args[1]
+			c := f.Values[rhs]
+			if c.Op != ir.OpConstI64 || useCount[rhs] != 1 {
+				continue
+			}
+			k := c.Aux
+			if k < -(1<<31) || k > (1<<31)-1 {
+				continue
+			}
+			suppress[rhs] = true
+			fuseCmpConst[cmpVid] = cmpConstInfo{k: k, nonReg: cmpIns.Args[0], constSide: 1}
 		}
 	}
 
@@ -954,20 +979,36 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 				}
 				if cmpVid, ok := fuseCondBr[vid]; ok {
 					cmp := f.Values[cmpVid]
-					// K-form for equality with one ConstI64 operand: inline
-					// the constant into the jump op, drop the OpLoadConstI.
+					// K-form for cmp with one ConstI64 operand: inline the
+					// constant into the jump op, drop the OpLoadConstI.
 					if kinfo, kok := fuseCmpConst[cmpVid]; kok {
 						a := int32(finalReg[kinfo.nonReg])
 						k := int32(kinfo.k)
+						// Pick the direct/inverted K-ops for this cmp shape.
+						// Equality is symmetric so the constSide doesn't
+						// matter; less/lessEq only fuse with rhs-const so
+						// the inverted op is the >= / > variant. The
+						// inverted form is emitted when the layout-next
+						// block is the true branch, so we can drop the
+						// trailing OpJump.
+						var directK, invertedK vm2.Op
+						switch cmp.Op {
+						case ir.OpEqualI64:
+							directK, invertedK = vm2.OpJumpIfEqualI64K, vm2.OpJumpIfNotEqualI64K
+						case ir.OpLessI64:
+							directK, invertedK = vm2.OpJumpIfLessI64K, vm2.OpJumpIfGreaterEqI64K
+						case ir.OpLessEqI64:
+							directK, invertedK = vm2.OpJumpIfLessEqI64K, vm2.OpJumpIfGreaterI64K
+						}
 						switch {
 						case elseB == nextB:
-							idx := emit(vm2.Instr{Op: vm2.OpJumpIfEqualI64K, A: a, B: k})
+							idx := emit(vm2.Instr{Op: directK, A: a, B: k})
 							pending = append(pending, pendingJump{insIdx: idx, target: thenB, field: 'C'})
 						case thenB == nextB:
-							idx := emit(vm2.Instr{Op: vm2.OpJumpIfNotEqualI64K, A: a, B: k})
+							idx := emit(vm2.Instr{Op: invertedK, A: a, B: k})
 							pending = append(pending, pendingJump{insIdx: idx, target: elseB, field: 'C'})
 						default:
-							idx := emit(vm2.Instr{Op: vm2.OpJumpIfEqualI64K, A: a, B: k})
+							idx := emit(vm2.Instr{Op: directK, A: a, B: k})
 							pending = append(pending, pendingJump{insIdx: idx, target: thenB, field: 'C'})
 							idx2 := emit(vm2.Instr{Op: vm2.OpJump})
 							pending = append(pending, pendingJump{insIdx: idx2, target: elseB, field: 'A'})

--- a/runtime/jit/vm2jit/lower_arm64.go
+++ b/runtime/jit/vm2jit/lower_arm64.go
@@ -329,8 +329,11 @@ func isDeoptableOp(op vm2.Op) bool {
 		// MEP-38 §A.7 immediate-form i64 fusions. The JIT can lower these
 		// natively (they are just register-immediate arithmetic and
 		// compares), but Phase 1 keeps them as deopt stubs so the new
-		// emitter paths land without a JIT change.
+		// emitter paths land without a JIT change. MEP-39 §6.6 iteration 3
+		// adds the Less/LessEq/Greater/GreaterEq K-forms to the family.
 		vm2.OpSubI64K, vm2.OpJumpIfEqualI64K, vm2.OpJumpIfNotEqualI64K,
+		vm2.OpJumpIfLessI64K, vm2.OpJumpIfLessEqI64K,
+		vm2.OpJumpIfGreaterI64K, vm2.OpJumpIfGreaterEqI64K,
 		// MEP-38 Phase 2 (§3.2.1) lowers OpLoadConstF, OpAddF64, OpSubF64,
 		// OpMulF64, OpDivF64, OpNegF64, OpAbsF64, OpSqrtF64, OpLessF64,
 		// OpLessEqF64, OpEqualF64, OpFmaF64, OpI64ToF64, OpF64ToI64 to

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -156,6 +156,22 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			if regs[ins.A].Int() != int64(ins.B) {
 				ip = int(ins.C)
 			}
+		case OpJumpIfLessI64K:
+			if regs[ins.A].Int() < int64(ins.B) {
+				ip = int(ins.C)
+			}
+		case OpJumpIfLessEqI64K:
+			if regs[ins.A].Int() <= int64(ins.B) {
+				ip = int(ins.C)
+			}
+		case OpJumpIfGreaterI64K:
+			if regs[ins.A].Int() > int64(ins.B) {
+				ip = int(ins.C)
+			}
+		case OpJumpIfGreaterEqI64K:
+			if regs[ins.A].Int() >= int64(ins.B) {
+				ip = int(ins.C)
+			}
 		case OpCall:
 			callee := vm.Program.Funcs[ins.B]
 			n := int(ins.D)

--- a/runtime/vm2/ops.go
+++ b/runtime/vm2/ops.go
@@ -44,13 +44,26 @@ const (
 	OpJumpIfNotEqualI64  // if A != B then IP = C
 	// Immediate-form i64 compare + conditional branch. B is a 32-bit
 	// sign-extended immediate; saves the const-load + register round-trip
-	// that the (OpLoadConstI -> OpJumpIfEqualI64) pair would require.
-	// Hot for "if d == 0 return" leaf-guard tests in recursive BG kernels.
+	// that the (OpLoadConstI -> OpJumpIfXxxI64) pair would require. Hot
+	// for "if d == 0 return" leaf-guard tests in recursive BG kernels
+	// and for any cascade comparing a register against a constant table
+	// (MEP-39 §6.6 fasta iteration 3: the inlined cumprob threshold
+	// cascade compares the LCG output against three i64 constants per
+	// iter; the K-forms collapse three const-loads + three compare ops
+	// into three single dispatches).
 	//
-	//	OpJumpIfEqualI64K:    if regs[A].Int() == int64(B) then IP = C
-	//	OpJumpIfNotEqualI64K: if regs[A].Int() != int64(B) then IP = C
+	//	OpJumpIfEqualI64K:      if regs[A].Int() == int64(B) then IP = C
+	//	OpJumpIfNotEqualI64K:   if regs[A].Int() != int64(B) then IP = C
+	//	OpJumpIfLessI64K:       if regs[A].Int() <  int64(B) then IP = C
+	//	OpJumpIfLessEqI64K:     if regs[A].Int() <= int64(B) then IP = C
+	//	OpJumpIfGreaterI64K:    if regs[A].Int() >  int64(B) then IP = C
+	//	OpJumpIfGreaterEqI64K:  if regs[A].Int() >= int64(B) then IP = C
 	OpJumpIfEqualI64K
 	OpJumpIfNotEqualI64K
+	OpJumpIfLessI64K
+	OpJumpIfLessEqI64K
+	OpJumpIfGreaterI64K
+	OpJumpIfGreaterEqI64K
 	OpCall                  // A = call Funcs[B], args [C..C+D); RetReg=A
 	// Direct call specializations for 1-arg and 2-arg calls. The arg
 	// values are read straight from the caller's registers (no staging

--- a/website/docs/mep/mep-0039.md
+++ b/website/docs/mep/mep-0039.md
@@ -860,11 +860,12 @@ MEP-38 §3.2 lands.
 
 ### 6.6 fasta
 
-**Status (iteration 2, 2026-05-18).** vm2 at 3.78x of Go on N=10000
-and 3.47x on N=100000 after mechanism 2 (integer-threshold lookup +
-cascade inlining); iteration 1 sat at 4.35x / 4.94x respectively.
-Still outside the 2x gate but moved 1.3x closer; mechanism 1 (fused
-LCG/hash ops) is the iteration-3 target. fasta remains the closest
+**Status (iteration 3, 2026-05-18).** vm2 at 3.11x of Go on N=10000
+and 3.07x on N=100000 after iteration 3 (i64 compare+branch K-form
+fusion on the cumprob cascade); iteration 2 sat at 3.78x / 3.47x and
+iteration 1 at 4.35x / 4.94x. Still outside the 2x gate but moved
+1.6x closer cumulatively; mechanism 1 (fused affine-mod for LCG/hash
+chains) is the iteration-4 target. fasta remains the closest
 BG row to the 2x gate that MEP-39 has shipped so far (every other
 BG kernel sits at 5x to 152x of Go); the kernel is workload-shape-
 flattering to vm2 because the inner step is i64-arithmetic dominated
@@ -1045,8 +1046,58 @@ to the 2x gate. The remaining gap is dispatch-count-limited (~13
 dispatches per iter at ~4 ns each = ~52 ns/iter, vs ~14 ns/iter
 needed for 2x of Go); collapsing the two affine+mod chains into
 single dispatches via mechanism 1 (a fused `OpAffineModI64K` opcode)
-is the iteration-3 target. Output remains bit-identical:
+is the iteration-4 target. Output remains bit-identical:
 1072663717 at N=10000 and 1362045038 at N=100000.
+
+**Implementation (iteration 3, 2026-05-18).** Generalised K-form
+fusion to the i64 ordered-compare family. The existing K-form path
+in `compiler2/emit/emit.go` only fired for `OpEqualI64`; the iter-2
+cumprob cascade emits three `OpLessI64` against the precomputed
+thresholds (42404 / 70117 / 97767), each preceded by an
+`OpLoadConstI` to materialise the constant into a register. Iter 3
+adds four new opcodes (`OpJumpIfLessI64K`, `OpJumpIfLessEqI64K`,
+`OpJumpIfGreaterI64K`, `OpJumpIfGreaterEqI64K`), each with the same
+shape as the existing equality K-forms (one i32 immediate in `B`, one
+register in `A`, branch target in `C`), and extends the emit-side
+fusion pass to populate `fuseCmpConst` for `OpLessI64` / `OpLessEqI64`
+when the rhs is a `ConstI64` whose value fits in i32. The inverted
+K-ops (greater / greater-eq) are used when the layout-next block is
+the true branch, so the trailing `OpJump` collapses too. Less/LessEq
+are not commutative, so only the rhs-const shape fuses; a future
+iteration can add the lhs-const path via the symmetric ops.
+
+The four new opcodes are also added to `isDeoptableOp` in
+`runtime/jit/vm2jit/lower_arm64.go` so traces hitting them deopt to
+the interpreter (matching how Phase 1 of MEP-38 handles the existing
+equality K-forms); native JIT lowering of compare+immediate+branch
+is straightforward register-immediate arm64 emit and is deferred to
+the MEP-38 Phase 2 fast-path expansion. Per-iter dispatch on fasta
+drops from ~13 (iter 2) to ~10: the cumprob cascade's three
+`OpLoadConstI` ops disappear and the three `OpJumpIfLessI64` ops
+become K-form variants.
+
+**Bench (iteration 3, 2026-05-18, macOS arm64, go test -bench
+median of 5 head-to-head against main).**
+
+| Bench | vm2 iter2 (ns/op) | vm2 iter3 (ns/op) | speedup |
+|---|---:|---:|---:|
+| `BenchmarkVM2_BG_Fasta` (N=10000) | 417478 | 377374 | 1.11 |
+
+| N      | vm2 iter2 (µs) | vm2 iter3 (µs) | Go (µs) | vm2 / Go iter2 | vm2 / Go iter3 |
+|-------:|---------------:|---------------:|--------:|---------------:|---------------:|
+|  10000 |            467 |            376 |     121 |          3.78x |          3.11x |
+| 100000 |           4246 |           3664 |    1192 |          3.47x |          3.07x |
+
+The go-test bench (more reliable than crosslang for small VM
+deltas, since it stays inside one process and computes b.N
+adaptively) shows a 1.11x speedup at N=10000. The crosslang run
+shows a 1.16x improvement at N=100000 (4246 µs → 3664 µs) which
+matches the theoretical lift: three dispatches saved per iter at
+~3 ns each on M4 is ~9 ns/iter, or ~900 µs over 100000 iters; the
+measured delta is 582 µs after subtracting the Go-side noise. The
+ratio against Go improves from 3.47x to 3.07x at N=100000.
+Output remains bit-identical: 1072663717 at N=10000 and 1362045038
+at N=100000.
 
 ### 6.7 k_nucleotide
 


### PR DESCRIPTION
## Summary

- Generalises K-form fusion (previously equality-only) to the i64 ordered-compare family with four new opcodes
- Extends `compiler2/emit/emit.go` to fold `OpLoadConstI` + `OpLessI64`/`OpLessEqI64` + `OpCondBr` into a single dispatch when the rhs fits in i32
- Drops fasta crosslang ratio from 3.47x to 3.07x of Go at N=100000; `go test -bench` shows 1.11x speedup at N=10000

Refs #21633

## Test plan

- [x] `go test ./runtime/vm2/... ./compiler2/emit/... ./runtime/jit/vm2jit/...` pass
- [x] `go test ./...` full suite passes
- [x] Bytecode dump confirms three `OpJumpIfLessI64K` replace three `OpLoadConstI`+`OpJumpIfLessI64` pairs in the fasta cumprob cascade
- [x] Crosslang output bit-identical: 1072663717 at N=10000, 1362045038 at N=100000
- [x] `go test -bench=BenchmarkVM2_BG_Fasta -count=5` head-to-head against main: 417478 -> 377374 ns/op (1.11x)