### PR TITLE
MEP-39 §6.6: fasta iteration 4 (mul/mod K-form fusion)

### DIFF
--- a/compiler2/emit/emit.go
+++ b/compiler2/emit/emit.go
@@ -211,6 +211,62 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 		suppress[rhs] = true
 		subK[ir.ValueID(vid)] = subKInfo{k: k, src: ins.Args[0]}
 	}
+	// mulK mirrors addK: multiply is commutative so either operand can
+	// be the immediate. Hot for LCG / hash chains in MEP-39 §6.6 fasta
+	// (`seed * 3877` and `hash * 1009` both fold). The i32 immediate
+	// covers every multiplier the BG corpus uses.
+	type mulKInfo struct {
+		k           int64
+		nonConstArg ir.ValueID
+	}
+	mulK := make(map[ir.ValueID]mulKInfo)
+	for vid, ins := range f.Values {
+		if ins.Op != ir.OpMulI64 {
+			continue
+		}
+		a0, a1 := ins.Args[0], ins.Args[1]
+		try := func(constArg, otherArg ir.ValueID) bool {
+			c := f.Values[constArg]
+			if c.Op != ir.OpConstI64 || useCount[constArg] != 1 {
+				return false
+			}
+			k := c.Aux
+			if k < -(1<<31) || k > (1<<31)-1 {
+				return false
+			}
+			suppress[constArg] = true
+			mulK[ir.ValueID(vid)] = mulKInfo{k: k, nonConstArg: otherArg}
+			return true
+		}
+		if !try(a1, a0) {
+			try(a0, a1)
+		}
+	}
+	// modK mirrors subK (not commutative): only the rhs (divisor) can
+	// fold. Hot for LCG / hash chains in MEP-39 §6.6 fasta (% 139968
+	// and % 2147483647). emit-side fusion enforces non-zero immediate
+	// so the dispatch path skips the mod-by-zero check.
+	type modKInfo struct {
+		k   int64
+		src ir.ValueID
+	}
+	modK := make(map[ir.ValueID]modKInfo)
+	for vid, ins := range f.Values {
+		if ins.Op != ir.OpModI64 {
+			continue
+		}
+		rhs := ins.Args[1]
+		c := f.Values[rhs]
+		if c.Op != ir.OpConstI64 || useCount[rhs] != 1 {
+			continue
+		}
+		k := c.Aux
+		if k == 0 || k < -(1<<31) || k > (1<<31)-1 {
+			continue
+		}
+		suppress[rhs] = true
+		modK[ir.ValueID(vid)] = modKInfo{k: k, src: ins.Args[0]}
+	}
 	// fuseCmpConst marks a fused cmp+condbr whose const operand should be
 	// inlined into the K-form jump op (avoids the OpLoadConstI dispatch
 	// + register slot). Populated for OpEqualI64, OpLessI64, OpLessEqI64
@@ -530,6 +586,12 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 					B: int32(finalReg[ins.Args[0]]),
 					C: int32(finalReg[ins.Args[1]])})
 			case ir.OpMulI64:
+				if info, ok := mulK[vid]; ok {
+					emit(vm2.Instr{Op: vm2.OpMulI64K, A: dst,
+						B: int32(finalReg[info.nonConstArg]),
+						C: int32(info.k)})
+					break
+				}
 				emit(vm2.Instr{Op: vm2.OpMulI64, A: dst,
 					B: int32(finalReg[ins.Args[0]]),
 					C: int32(finalReg[ins.Args[1]])})
@@ -538,6 +600,12 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 					B: int32(finalReg[ins.Args[0]]),
 					C: int32(finalReg[ins.Args[1]])})
 			case ir.OpModI64:
+				if info, ok := modK[vid]; ok {
+					emit(vm2.Instr{Op: vm2.OpModI64K, A: dst,
+						B: int32(finalReg[info.src]),
+						C: int32(info.k)})
+					break
+				}
 				emit(vm2.Instr{Op: vm2.OpModI64, A: dst,
 					B: int32(finalReg[ins.Args[0]]),
 					C: int32(finalReg[ins.Args[1]])})

--- a/runtime/jit/vm2jit/lower_arm64.go
+++ b/runtime/jit/vm2jit/lower_arm64.go
@@ -330,10 +330,12 @@ func isDeoptableOp(op vm2.Op) bool {
 		// natively (they are just register-immediate arithmetic and
 		// compares), but Phase 1 keeps them as deopt stubs so the new
 		// emitter paths land without a JIT change. MEP-39 §6.6 iteration 3
-		// adds the Less/LessEq/Greater/GreaterEq K-forms to the family.
+		// adds the Less/LessEq/Greater/GreaterEq K-forms to the family;
+		// iteration 4 adds the Mul/Mod K-forms.
 		vm2.OpSubI64K, vm2.OpJumpIfEqualI64K, vm2.OpJumpIfNotEqualI64K,
 		vm2.OpJumpIfLessI64K, vm2.OpJumpIfLessEqI64K,
 		vm2.OpJumpIfGreaterI64K, vm2.OpJumpIfGreaterEqI64K,
+		vm2.OpMulI64K, vm2.OpModI64K,
 		// MEP-38 Phase 2 (§3.2.1) lowers OpLoadConstF, OpAddF64, OpSubF64,
 		// OpMulF64, OpDivF64, OpNegF64, OpAbsF64, OpSqrtF64, OpLessF64,
 		// OpLessEqF64, OpEqualF64, OpFmaF64, OpI64ToF64, OpF64ToI64 to

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -96,6 +96,8 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			regs[ins.A] = CInt(regs[ins.B].Int() - int64(ins.C))
 		case OpSubI64:
 			regs[ins.A] = CInt(regs[ins.B].Int() - regs[ins.C].Int())
+		case OpMulI64K:
+			regs[ins.A] = CInt(regs[ins.B].Int() * int64(ins.C))
 		case OpMulI64:
 			regs[ins.A] = CInt(regs[ins.B].Int() * regs[ins.C].Int())
 		case OpDivI64:
@@ -105,6 +107,9 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 				return ret, errors.New("vm2: division by zero")
 			}
 			regs[ins.A] = CInt(regs[ins.B].Int() / d)
+		case OpModI64K:
+			// emit-side fusion guarantees the immediate is non-zero
+			regs[ins.A] = CInt(regs[ins.B].Int() % int64(ins.C))
 		case OpModI64:
 			d := regs[ins.C].Int()
 			if d == 0 {

--- a/runtime/vm2/ops.go
+++ b/runtime/vm2/ops.go
@@ -21,10 +21,24 @@ const (
 	// (binary_trees.makeTree(d-1) / checkTree(t, d-1) where the constant
 	// 1 is loaded and immediately subtracted from the depth parameter).
 	OpSubI64K
-	OpSubI64                // A = B - C
-	OpMulI64                // A = B * C
-	OpDivI64                // A = B / C (truncated; division by zero traps)
-	OpModI64                // A = B % C (truncated, sign of dividend; mod by zero traps)
+	OpSubI64 // A = B - C
+	// A = B * sign-extend(C). Same fusion shape as OpAddI64K but for
+	// multiply-by-immediate. Hot for LCG/hash chains in the BG suite
+	// (MEP-39 §6.6 fasta iteration 4: `seed = (seed * 3877 + 29573) %
+	// 139968` and `hash = (hash * 1009 + byte) % 2147483647` both fold
+	// their multiplier here). The multiplicand is treated as signed
+	// 64-bit so wrap-around matches OpMulI64.
+	OpMulI64K
+	OpMulI64 // A = B * C
+	OpDivI64 // A = B / C (truncated; division by zero traps)
+	// A = B % sign-extend(C). Same fusion shape as OpAddI64K but for
+	// mod-by-immediate. Hot for LCG/hash chains in the BG suite
+	// (MEP-39 §6.6 fasta iteration 4: the LCG modulus 139968 and the
+	// hash modulus 2147483647 both fit in i32). Mod-by-zero traps
+	// (the i32 immediate cannot be 0 because emit-side fusion only
+	// fires for non-zero ConstI64 inputs).
+	OpModI64K
+	OpModI64 // A = B % C (truncated, sign of dividend; mod by zero traps)
 	OpLessI64               // A = B < C  (bool)
 	OpLessEqI64             // A = B <= C (bool)
 	OpEqualI64              // A = B == C (bool)

--- a/website/docs/mep/mep-0039.md
+++ b/website/docs/mep/mep-0039.md
@@ -860,12 +860,14 @@ MEP-38 §3.2 lands.
 
 ### 6.6 fasta
 
-**Status (iteration 3, 2026-05-18).** vm2 at 3.11x of Go on N=10000
-and 3.07x on N=100000 after iteration 3 (i64 compare+branch K-form
-fusion on the cumprob cascade); iteration 2 sat at 3.78x / 3.47x and
-iteration 1 at 4.35x / 4.94x. Still outside the 2x gate but moved
-1.6x closer cumulatively; mechanism 1 (fused affine-mod for LCG/hash
-chains) is the iteration-4 target. fasta remains the closest
+**Status (iteration 4, 2026-05-18).** vm2 at ~2.95x of Go on
+N=100000 after iteration 4 (mul/mod K-form fusion on the LCG and
+hash chains); iteration 3 sat at 3.07x, iteration 2 at 3.47x, and
+iteration 1 at 4.94x. Cumulative speedup is 1.67x from baseline.
+The 2x gate is still ~1.5x away; iteration 5 will combine the three
+remaining levers (return-value caching of the leaf tail call,
+typed-i64 register file for the hot regs, and final JIT lowering of
+the inner loop) to close the rest. fasta remains the closest
 BG row to the 2x gate that MEP-39 has shipped so far (every other
 BG kernel sits at 5x to 152x of Go); the kernel is workload-shape-
 flattering to vm2 because the inner step is i64-arithmetic dominated
@@ -1098,6 +1100,59 @@ measured delta is 582 µs after subtracting the Go-side noise. The
 ratio against Go improves from 3.47x to 3.07x at N=100000.
 Output remains bit-identical: 1072663717 at N=10000 and 1362045038
 at N=100000.
+
+**Implementation (iteration 4, 2026-05-18).** Mechanism 1 ships as
+two separate K-form opcodes rather than a single fused
+`OpAffineModI64K`: `OpMulI64K` (`A = B * sign-extend(C)`) and
+`OpModI64K` (`A = B % sign-extend(C)`). Both follow the same
+fusion shape as the existing `OpAddI64K` / `OpSubI64K`: the
+emit-side pre-pass walks `f.Values` for `OpMulI64` / `OpModI64`
+whose constant operand is a single-use `OpConstI64` fitting in
+i32, marks the const for suppression, and emits the K-form at the
+multiply / mod site. Multiply is commutative so either operand
+can fold; mod only folds the divisor (the rhs), with an explicit
+non-zero check so the K-form dispatch path can skip the runtime
+mod-by-zero trap.
+
+Two narrow opcodes beat one wide fused `OpAffineModI64K` for two
+reasons. First, they re-use the existing `Instr` layout (one i32
+immediate in `C`, one source register in `B`, one dest register in
+`A`); a fused affine-mod would need three constants and would have
+to indirect through a side table since `Instr` has only four i32
+slots. Second, they generalise beyond fasta: any LCG-style or
+hash-style loop (and many simple counters) folds its constants
+without per-kernel emit logic. The fasta cumprob cascade still
+benefits from both ops in concert: the LCG step
+`seed = (seed * 3877 + 29573) % 139968` lowers to
+`OpMulI64K` + `OpAddI64K` + `OpModI64K` (3 dispatches, down from
+5), and each leaf's hash step
+`hash = (hash * 1009 + byte) % 2147483647` lowers identically (3
+dispatches down from 5). Total per-iter dispatch drops from ~10
+(iter 3) to ~6.
+
+Both ops are added to `isDeoptableOp` in
+`runtime/jit/vm2jit/lower_arm64.go` so traces hitting them deopt
+to the interpreter (same Phase 1 treatment as the other K-forms);
+native JIT lowering is straightforward register-immediate arm64
+emit and is deferred to MEP-38 Phase 2.
+
+**Bench (iteration 4, 2026-05-18, macOS arm64, crosslang
+head-to-head against main, median of 50 over 3 alternating rounds
+to bracket system noise).**
+
+| N      | vm2 iter3 (µs) | vm2 iter4 (µs) | speedup | Go (µs) | vm2 / Go iter3 | vm2 / Go iter4 |
+|-------:|---------------:|---------------:|--------:|--------:|---------------:|---------------:|
+| 100000 |          10737 |           7642 |    1.41 |    2606 |          4.12x |          2.95x |
+
+System load was elevated during this measurement (Go absolute
+time roughly doubled vs iteration 3's session, from ~1.2 ms to
+~2.6 ms), so the absolute µs numbers do not match the iter 3
+table; the ratio against Go is the honest comparator. Iter 4
+drops the ratio from 4.12x to 2.95x in the same session, a 1.4x
+relative improvement that matches the theoretical lift (four
+dispatches saved per iter at ~3-4 ns each is ~12-16 ns/iter, or
+~28% of the iter 3 per-iter cost). Output remains bit-identical:
+1072663717 at N=10000 and 1362045038 at N=100000.
 
 ### 6.7 k_nucleotide
 


### PR DESCRIPTION
## Summary

- Adds `OpMulI64K` and `OpModI64K` (per-iter LCG / hash chain dispatch from ~10 to ~6 on fasta)
- Generalises emit-side K-form fusion: any single-use `OpConstI64` operand of `OpMulI64` / `OpModI64` whose value fits in i32 folds into the K-form
- Drops fasta crosslang ratio from 4.12x to 2.95x of Go at N=100000 (head-to-head same-session, 1.41x speedup, 28% closer to 2x gate)
- Cumulative iter 1 -> iter 4: 4.94x -> 2.95x of Go, 1.67x total speedup

Refs #21635

## Test plan

- [x] `go test ./...` full suite passes
- [x] Bytecode dump confirms LCG and hash chains both lower to 3 ops each (`OpMulI64K` + `OpAddI64K` + `OpModI64K`), down from 5
- [x] Crosslang output bit-identical: 1072663717 at N=10000, 1362045038 at N=100000
- [x] Crosslang head-to-head over 3 alternating rounds confirms 1.41x median speedup vs main