### PR TITLE
mep-0039 §6.10: binary_trees iter 2 (pair-arena encoding)

### DIFF
--- a/compiler2/corpus/binary_trees.go
+++ b/compiler2/corpus/binary_trees.go
@@ -3,28 +3,28 @@ package corpus
 import "mochi/compiler2/ir"
 
 // BuildBinaryTrees builds the Computer Language Benchmarks Game
-// `binary-trees` kernel: build 2^N short-lived trees of depth N and sum
-// their node counts. Each tree allocation grows and is then unreferenced,
-// so the program is dominated by container-construction throughput and
-// the runtime's ability to reclaim dead structures. This is the headline
-// benchmark for [MEP 36]'s container-GC contract.
+// `binary-trees` kernel: build 2^N short-lived trees of depth N and
+// sum their node counts. Each tree allocation grows and is then
+// unreferenced, so the program is dominated by container-construction
+// throughput and the runtime's ability to reclaim dead structures.
 //
-// vm2's IR has no struct support yet, so trees are encoded as nested
-// lists: a leaf is the empty list `[]`, and an internal node is a
-// 2-element list `[left, right]`. Both leaves and internal nodes flow
-// through the same OpListGet / OpListLen path. This is faithful to the
-// BG specification (each subtree is its own allocation) and exercises
-// the exact code path MEP 36 cares about: many small list allocations
-// dying as their referring frame returns.
+// MEP-39 §6.10 iteration 2 switched the per-node storage from nested
+// 2-element lists (`OpNewList(2)` + 2 × `OpListPush`) to MEP-37 §3.4
+// packed pairs (one `OpNewPair`). Per node that's 1 dispatch instead of
+// 3, and the pair arena bumps a cursor in a 256-slot chunk so a depth-N
+// tree allocates 2^(N+1)/256 chunks instead of 2^(N+1) individual Go
+// list+slice pairs. The leaf-vs-branch test moves to a depth-based
+// shape (pairs are indistinguishable structurally), matching the
+// canonical BG reference (which uses `if depth == 0` not `if len == 0`).
 //
 // The number of outer iterations is constant-folded at build time
 // because N is known when the IR is constructed; we precompute
 // `iters = 1 << N` rather than emitting a separate power-of-two helper.
 //
 //	main()                     = outer(N, 0, iters, 0)
-//	make_tree(depth)           = if depth==0 then [] else [make_tree(d-1), make_tree(d-1)]
-//	check_tree(t)              = if len(t)==0 then 1 else 1 + check_tree(t[0]) + check_tree(t[1])
-//	outer(d, i, iters, acc)    = if i>=iters then acc else recurse(d, i+1, iters, acc + check_tree(make_tree(d)))
+//	make_tree(d)               = if d==0 then pair(0,0) else pair(make_tree(d-1), make_tree(d-1))
+//	check_tree(t, d)           = if d==0 then 1 else 1 + check_tree(fst, d-1) + check_tree(snd, d-1)
+//	outer(d, i, iters, acc)    = if i>=iters then acc else outer(d, i+1, iters, acc + check_tree(make_tree(d), d))
 //
 // The outer loop is the only tail-recursive helper; check_tree's two
 // recursive calls are deliberately non-tail to keep the canonical BG
@@ -50,68 +50,56 @@ func BuildBinaryTrees(n int64) *ir.Module {
 	r := bMain.Call(outerIdx, ir.TI64, depthV, zero, itersV, acc0)
 	bMain.Ret(r)
 
-	bM := ir.NewBuilder("make_tree", []ir.Type{ir.TI64}, ir.TList)
+	bM := ir.NewBuilder("make_tree", []ir.Type{ir.TI64}, ir.TPair)
 	pD := bM.Param(0)
 	leafB := bM.NewBlock()
 	nodeB := bM.NewBlock()
-	zeroM := bM.ConstI64(0)
-	isLeaf := bM.EqualI64(pD, zeroM)
-	bM.CondBr(isLeaf, leafB, nodeB)
+	bM.CondBr(bM.EqualI64(pD, bM.ConstI64(0)), leafB, nodeB)
 
 	bM.SwitchTo(leafB)
-	leaf := bM.NewList(0)
-	bM.Ret(leaf)
+	bM.Ret(bM.NewPair(bM.ConstI64(0), bM.ConstI64(0)))
 
 	bM.SwitchTo(nodeB)
-	one := bM.ConstI64(1)
-	dm1 := bM.SubI64(pD, one)
-	left := bM.Call(makeIdx, ir.TList, dm1)
-	right := bM.Call(makeIdx, ir.TList, dm1)
-	node := bM.NewList(2)
-	bM.ListPush(node, left)
-	bM.ListPush(node, right)
-	bM.Ret(node)
+	dm1 := bM.SubI64(pD, bM.ConstI64(1))
+	left := bM.Call(makeIdx, ir.TPair, dm1)
+	right := bM.Call(makeIdx, ir.TPair, dm1)
+	bM.Ret(bM.NewPair(left, right))
 
-	bC := ir.NewBuilder("check_tree", []ir.Type{ir.TList}, ir.TI64)
+	bC := ir.NewBuilder("check_tree", []ir.Type{ir.TPair, ir.TI64}, ir.TI64)
 	pT := bC.Param(0)
+	pCD := bC.Param(1)
 	cLeafB := bC.NewBlock()
 	cNodeB := bC.NewBlock()
-	lenT := bC.ListLen(pT)
-	zeroC := bC.ConstI64(0)
-	isEmpty := bC.EqualI64(lenT, zeroC)
-	bC.CondBr(isEmpty, cLeafB, cNodeB)
+	bC.CondBr(bC.EqualI64(pCD, bC.ConstI64(0)), cLeafB, cNodeB)
 
 	bC.SwitchTo(cLeafB)
-	oneC := bC.ConstI64(1)
-	bC.Ret(oneC)
+	bC.Ret(bC.ConstI64(1))
 
 	bC.SwitchTo(cNodeB)
-	idx0 := bC.ConstI64(0)
-	idx1 := bC.ConstI64(1)
-	leftT := bC.ListGet(pT, idx0, ir.TList)
-	rightT := bC.ListGet(pT, idx1, ir.TList)
-	lc := bC.Call(checkIdx, ir.TI64, leftT)
-	rc := bC.Call(checkIdx, ir.TI64, rightT)
-	sum := bC.AddI64(lc, rc)
-	oneN := bC.ConstI64(1)
-	rr := bC.AddI64(sum, oneN)
-	bC.Ret(rr)
+	dm1c := bC.SubI64(pCD, bC.ConstI64(1))
+	lc := bC.PairFst(pT, ir.TPair)
+	rc := bC.PairSnd(pT, ir.TPair)
+	lcnt := bC.Call(checkIdx, ir.TI64, lc, dm1c)
+	rcnt := bC.Call(checkIdx, ir.TI64, rc, dm1c)
+	sum := bC.AddI64(bC.AddI64(bC.ConstI64(1), lcnt), rcnt)
+	bC.Ret(sum)
 
 	bO := ir.NewBuilder("outer", []ir.Type{ir.TI64, ir.TI64, ir.TI64, ir.TI64}, ir.TI64)
 	oD, oI, oIters, oAcc := bO.Param(0), bO.Param(1), bO.Param(2), bO.Param(3)
 	oDone := bO.NewBlock()
 	oStep := bO.NewBlock()
 	bO.CondBr(bO.LessI64(oI, oIters), oStep, oDone)
+
 	bO.SwitchTo(oDone)
 	bO.Ret(oAcc)
+
 	bO.SwitchTo(oStep)
-	tree := bO.Call(makeIdx, ir.TList, oD)
-	cVal := bO.Call(checkIdx, ir.TI64, tree)
+	tree := bO.Call(makeIdx, ir.TPair, oD)
+	cVal := bO.Call(checkIdx, ir.TI64, tree, oD)
 	nAcc := bO.AddI64(oAcc, cVal)
-	oneO := bO.ConstI64(1)
-	ni := bO.AddI64(oI, oneO)
-	r2 := bO.Call(outerIdx, ir.TI64, oD, ni, oIters, nAcc)
-	bO.Ret(r2)
+	ni := bO.AddI64(oI, bO.ConstI64(1))
+	rRec := bO.Call(outerIdx, ir.TI64, oD, ni, oIters, nAcc)
+	bO.Ret(rRec)
 
 	return &ir.Module{Funcs: []*ir.Function{
 		bMain.Function(), bM.Function(), bC.Function(), bO.Function(),

--- a/website/docs/mep/mep-0039.md
+++ b/website/docs/mep/mep-0039.md
@@ -1672,6 +1672,129 @@ Iteration 2 will land the trace-JIT lowering and re-run this row.
 Predicted post-iteration-2 number: ~150 µs at N=10000 (1.9x of Go),
 inside the gate.
 
+### 6.10 binary_trees
+
+**Status (iteration 2, 2026-05-18).** vm2 at **3.11x** of Go on N=8 and
+**3.21x** on N=10 after switching the per-node storage from nested
+2-element lists to MEP-37 §3.4 packed pairs. Iteration 1 measured
+8.18x / 9.28x (see §5 baseline), so this iteration delivers a 2.6x-2.9x
+speedup. Allocations per `b.N` invocation drop from 196,100 to 525 (a
+374x reduction) because the pair arena bumps a cursor in 256-slot
+chunks instead of allocating one Go `[]Tree` header + one backing
+slice per node.
+
+**Theory.** The canonical BG workload at depth N builds `2^N` trees of
+depth N and walks each. A depth-N tree has `2^(N+1) - 1` nodes, so at
+N=8 the program performs `256 * 511 = 130,816` node creations + the
+same number of node walks. Per-node cost decomposes into:
+
+- **Node creation (build path).** Iteration 1 emitted
+  `OpNewList(2) + OpListPush(left) + OpListPush(right)` per branch
+  node: 3 dispatches and (in Go terms) 2 heap allocations (the list
+  header + the 2-slot backing slice). At ~7 ns per dispatch and ~30
+  ns per heap allocation plus GC pressure, a single branch creation
+  cost ~80-90 ns.
+- **Node walk (check path).** `OpListLen + OpListGet(0) + OpListGet(1)`
+  plus the two recursive `OpCall` ops: 5 dispatches per branch plus
+  the bounds-check tax inside `OpListGet`.
+- **Leaf detection.** Iteration 1 distinguished leaves from branches
+  by `OpListLen == 0`, which means each walk pays a length-load + a
+  compare + a branch even though the depth parameter would have given
+  the same answer for free.
+
+Native Go on the slice-of-Tree encoding (the bench/crosslang peer)
+runs the same shape but with Go's escape analysis + bump allocator
+amortising the alloc cost. At N=8, Go measured 2376 µs total ≈ 2.2 ns
+per scheduled op across the ~1.1M total ops in the kernel. vm2 measured
+19427 µs ≈ 18 ns per op, which is the iteration-1 dispatch ratio (~8x
+worst-case unfused).
+
+**Mechanism 1 (iteration 2): pair-arena encoding.** MEP-37 §3.4
+already provides a packed-pair runtime: each pair is two `Cell` slots
+inside a 256-slot Go-heap chunk, addressed by `(chunkIdx, slot)`.
+The arena bumps a per-chunk cursor and grows a new chunk every 256
+pair allocations. Existing fused ops mean check_tree gets a
+near-optimal dispatch shape automatically:
+
+- `OpNewPair(fst, snd)` collapses the 3-op
+  `NewList(2)+ListPush+ListPush` into one dispatch.
+- `OpReturnNewPair` and `OpReturnNewPairKK` fuse the pair construction
+  with the `Ret` terminator on `make_tree`'s leaf and branch paths,
+  saving one further dispatch per node returned.
+- `OpPairFstCallSelfA2` / `OpPairSndCallSelfA2` (MEP-38 §A.5) fuse the
+  pair-slot read with the recursive `check_tree` call: 2 dispatches
+  per branch instead of 4. The fasta `OpReturnAddSum` (MEP-38 §A.6) and
+  the `OpReturnI64K` superop on the leaf path are already wired and
+  fire here without any further change.
+- Leaves are detected by the depth parameter (`d == 0`), so the
+  `OpListLen + OpEqualI64K + OpJumpIfFalse` triplet of iteration 1
+  collapses to `OpJumpIfNotEqualI64K`.
+
+**Implementation (iteration 2).** A single file changed:
+`compiler2/corpus/binary_trees.go`. `BuildBinaryTrees` now builds the
+canonical BG outer-loop on top of the existing
+`BuildBinaryTreesKernel` shape (which has been pair-arena-encoded
+since MEP-37). The four-function IR module is
+
+```
+main()                       = outer(N, 0, 2^N, 0)
+make_tree(d) -> TPair        = if d==0 then pair(0,0) else pair(make_tree(d-1), make_tree(d-1))
+check_tree(t, d) -> i64      = if d==0 then 1 else 1 + check_tree(fst, d-1) + check_tree(snd, d-1)
+outer(d, i, iters, acc)      = if i>=iters then acc else outer(d, i+1, iters, acc + check_tree(make_tree(d), d))
+```
+
+Outer is the only tail-recursive helper (it folds into
+`OpTailCallSelfA4`); check_tree and make_tree stay as `OpCall` /
+`OpCallSelfA1` chains, which is the canonical BG recursion shape
+(the inliner could collapse a single arm, but the program's whole
+point is to recurse). The emitted dispatch shape for check_tree's
+branch path is
+
+```
+OpJumpIfNotEqualI64K (d, 0, branch_block)
+OpReturnI64K (1)                       ; leaf branch
+OpSubI64K (dm1 = d-1, K=1)             ; branch path
+OpPairFstCallSelfA2 (lcnt = check_tree(fst(t), dm1))
+OpPairSndCallSelfA2 (rcnt = check_tree(snd(t), dm1))
+OpReturnAddSum (return 1 + lcnt + rcnt)
+```
+
+Six dispatches per branch instead of the iteration-1 nine. make_tree
+mirrors with `OpReturnNewPairKK` on the leaf and
+`OpReturnNewPair` on the branch.
+
+`ExpectBinaryTrees` and the corpus oracle did not change: the same
+N gives the same `iters * (2*iters - 1)` total, because the abstract
+program (build 2^N trees of depth N, sum their node counts) is
+unchanged. The MEP-36 GC-stress shape (lists die per outer iter) is
+preserved at the chunk-arena level (each chunk fills up and is
+collected once its trees are walked), so the headline-GC contract
+still applies, just at chunk granularity.
+
+**Bench (iteration 2, 2026-05-18, macOS arm64, median of 5).**
+
+| Program | N | vm2 (µs) | Go (µs) | vm2 / Go | Match |
+|---|---:|---:|---:|---:|---|
+| `bg/binary_trees` |  8 |   6803 |  2184 | **3.11x** | ✓ |
+| `bg/binary_trees` | 10 | 118725 | 36983 | **3.21x** | ✓ |
+
+The `b.ReportAllocs` rows in `BenchmarkVM2_BG_BinaryTrees` confirm the
+structural win at N=8:
+- Iteration 1: 196100 allocs/op, 5.23 MB/op.
+- Iteration 2: 525 allocs/op, 4.85 MB/op.
+
+That is the MEP-37 §3.4 arena delivering its design promise: dispatch
+per node halved, Go-heap allocation count cut 374x. The remaining
+~3.1x gap to Go is the dispatch tax on the surviving ops. Per N=8
+invocation the kernel issues about 917k vm2 ops (256 trees × ~3574
+ops/tree from make_tree + check_tree + outer overhead); at 7-8 ns per
+dispatch for vm2 versus 2.2 ns per scheduled op in Go's native code,
+the cost ratio is exactly what we measure. The structural options to
+close the gap are (a) further op fusion (each saved dispatch is ~3-7
+ns × ~130k branches = ~400-900 µs, which alone is not enough to clear
+2x at N=8) or (b) trace JIT lowering. Iteration 3 will pick one
+mechanism and re-bench.
+
 ### 6.x (template for future iterations)
 
 Each new program lands in 6.x with the same theory / mechanism /


### PR DESCRIPTION
## Summary
- Switch `corpus.BuildBinaryTrees` from nested 2-element lists to MEP-37 §3.4 packed pairs (one `OpNewPair` per node instead of `NewList(2)+ListPush+ListPush`).
- Existing fused ops on the pair path (`OpReturnNewPair`, `OpReturnNewPairKK`, `OpPairFstCallSelfA2`, `OpPairSndCallSelfA2`, `OpReturnAddSum`, `OpReturnI64K`) all fire on the new IR shape automatically.
- Crosslang macOS arm64, repeat=5: N=8 vm2/Go = **3.11x** (was 8.18x), N=10 = **3.21x** (was 9.28x). Allocs per N=8 invocation drop from 196100 to 525 (374x).
- Output unchanged; same `iters * (2*iters - 1)` total.

Tracks #21639.

## Test plan
- [x] `go test ./compiler2/... ./runtime/vm2/...` passes (including `TestCorpusMatchesOracle/bg_binary_trees`).
- [x] `BenchmarkVM2_BG_BinaryTrees` shows 7.0 ms median (was 19.4 ms), 525 allocs/op (was 196100).
- [x] `go run ./bench/crosslang -repeat 5 -langs vm2,go` produces 3.11x at N=8 and 3.21x at N=10 with matching outputs.