### PR TITLE
mep-0039 §5.1: add Linux x86_64 baseline (server2)

### DIFF
--- a/website/docs/mep/mep-0039.md
+++ b/website/docs/mep/mep-0039.md
@@ -279,6 +279,46 @@ peer is wired (`✓` in the match column of the harness output).
 Lua and LuaJIT are intentionally skipped for `bg/pidigits` because
 neither has native arbitrary-precision integers; see MEP-39 §6.8.
 
+### 5.1 Linux baseline (server2, Ubuntu x86_64)
+
+The standing directive requires the 2x gate on **both** macOS arm64
+and Linux x86_64. Linux ratios are uniformly worse than macOS on this
+workload: the host Go is faster (Linux ld.so + amd64 codegen amortises
+the LCG/window/branch chain into ~4 issued ops per iter), while vm2's
+Go-native dispatch loop costs roughly the same wall-clock per op on
+both hosts. Net effect: a 7-10x macOS ratio reads as 25-30x on Linux
+for the same kernel.
+
+Measured 2026-05-18, server2 (Ubuntu x86_64), median of 11 invocations.
+Iteration-1 numbers (binary_trees iteration 2 lands separately and is
+re-bench'd on Linux in §6.10).
+
+| Program | N (small) | N (medium) | vm2 (µs) small / medium | Go (µs) small / medium | vm2 / Go small | vm2 / Go medium | Gate |
+|---|---:|---:|---:|---:|---:|---:|:---:|
+| `bg/binary_trees`      |     8 |     10 |     59440 /   1577236 |      7519 /    293404 |    7.91x |    5.38x | ✗ |
+| `bg/fannkuch_redux`    |  1000 |  10000 |      1678 /     18375 |        25 /       252 |   67.12x |   72.92x | ✗ |
+| `bg/fasta`             | 10000 | 100000 |      1239 /     12621 |       185 /      1885 |    6.70x |    6.70x | ✗ |
+| `bg/k_nucleotide`      | 10000 | 100000 |     94485 /    896478 |       554 /      5208 |  170.55x |  172.13x | ✗ |
+| `bg/mandelbrot`        |   100 |    200 |     88078 /    289281 |       688 /      2465 |  128.02x |  117.36x | ✗ |
+| `bg/n_body`            |  1000 |   5000 |     12538 /    201732 |       117 /       680 |  107.16x |  296.66x | ✗ |
+| `bg/pidigits`          |  1000 |  10000 |    490847 /  69500905 |    581382 /  62789827 |    0.84x |    1.11x | ✓ |
+| `bg/regex_redux`       |  1000 |  10000 |       173 /      1564 |         5 /        58 |   34.60x |   26.97x | ✗ |
+| `bg/reverse_complement`|  4096 |  16384 |      5027 /     97657 |        13 /        57 |  386.69x | 1713.28x | ✗ |
+| `bg/spectral_norm`     |   100 |    200 |    104399 /    414106 |       451 /      1971 |  231.48x |  210.10x | ✗ |
+
+`bg/pidigits` is again the only program inside the gate, and at N=1000
+vm2 is faster than Go by 16% (the Linux `math/big` allocator is slower
+than mochi's bignum arena at small scales). At N=10000 the ratio
+narrows to 1.11x as the Go side catches up. Every other program is
+outside the gate, with reverse_complement, n_body, and spectral_norm
+the most exposed at three orders of magnitude. The gap distribution
+matches the macOS data: kernels whose hot path is i64 ALU + tail-call
+(fannkuch, mandelbrot, spectral_norm, n_body) are dispatch-bound and
+the kernels that allocate per iter (binary_trees, k_nucleotide,
+reverse_complement) compound dispatch cost with arena traffic. The
+remediation path is identical on both hosts; the iteration log in §6
+tracks the per-program work.
+
 ## 6. Per-program iteration log
 
 Each program outside the 2x-of-Go gate gets a subsection structured as


### PR DESCRIPTION
## Summary
- Records the 2026-05-18 crosslang run on server2 (Ubuntu x86_64, median of 11) as MEP-39 §5.1.
- pidigits is the only program inside the 2x-vs-Go gate on Linux (0.84x at N=1000, 1.11x at N=10000).
- Reverse_complement at 1713x, n_body at 297x, and spectral_norm at 231x are the most exposed.
- Linux ratios are uniformly worse than macOS arm64 because the host Go is faster on these kernels while vm2 Go-native dispatch cost is host-neutral.

Closes #21641

## Test plan
- [x] Cross-lang bench captured on server2 (Ubuntu x86_64).
- [x] `npm run build` from website/ succeeds (MDX compiles).