### PR TITLE
mep-0039 §6.10: binary_trees iter 3 (leaf-shape callee shortcut)

### DIFF
--- a/compiler2/emit/emit.go
+++ b/compiler2/emit/emit.go
@@ -26,6 +26,7 @@ func Compile(m *ir.Module) (*vm2.Program, error) {
 		if err != nil {
 			return nil, fmt.Errorf("emit %s: %w", f.Name, err)
 		}
+		vm2.AnalyzeLeafShape(fn)
 		funcs[i] = fn
 	}
 	return &vm2.Program{Funcs: funcs, Main: m.Main}, nil

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -252,6 +252,12 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			// at the new frame's slot 0 and dispatch. Hot path for
 			// binary_trees.makeTree(d-1) and fib_rec.
 			callee := vm.Program.Funcs[ins.B]
+			if callee.LeafKind != LeafKindNone {
+				if r, ok := callee.tryLeafA1(vm, regs[ins.C]); ok {
+					regs[ins.A] = r
+					break
+				}
+			}
 			fr.IP = ip
 			base := len(vm.Stack)
 			need := base + callee.NumRegs
@@ -278,6 +284,12 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			// 2-arg specialized call. Same shape as OpCallA1 with one
 			// more arg in ins.D. Hot path for binary_trees.checkTree.
 			callee := vm.Program.Funcs[ins.B]
+			if callee.LeafKind != LeafKindNone {
+				if r, ok := callee.tryLeafA2(vm, regs[ins.C], regs[ins.D]); ok {
+					regs[ins.A] = r
+					break
+				}
+			}
 			fr.IP = ip
 			base := len(vm.Stack)
 			need := base + callee.NumRegs
@@ -308,6 +320,12 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			// intermediate register write the standalone OpPairFst would
 			// have performed. Hot path for binary_trees.checkTree(fst,d-1).
 			callee := vm.Program.Funcs[ins.B]
+			if callee.LeafKind != LeafKindNone {
+				if r, ok := callee.tryLeafA2Guard1(vm, regs[ins.D]); ok {
+					regs[ins.A] = r
+					break
+				}
+			}
 			fr.IP = ip
 			base := len(vm.Stack)
 			need := base + callee.NumRegs
@@ -335,6 +353,12 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			ip = 0
 		case OpPairSndCallA2:
 			callee := vm.Program.Funcs[ins.B]
+			if callee.LeafKind != LeafKindNone {
+				if r, ok := callee.tryLeafA2Guard1(vm, regs[ins.D]); ok {
+					regs[ins.A] = r
+					break
+				}
+			}
 			fr.IP = ip
 			base := len(vm.Stack)
 			need := base + callee.NumRegs
@@ -362,6 +386,12 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			ip = 0
 		case OpCallSelfA1:
 			callee := fr.Fn
+			if callee.LeafKind != LeafKindNone {
+				if r, ok := callee.tryLeafA1(vm, regs[ins.C]); ok {
+					regs[ins.A] = r
+					break
+				}
+			}
 			fr.IP = ip
 			base := len(vm.Stack)
 			need := base + callee.NumRegs
@@ -382,6 +412,12 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			ip = 0
 		case OpCallSelfA2:
 			callee := fr.Fn
+			if callee.LeafKind != LeafKindNone {
+				if r, ok := callee.tryLeafA2(vm, regs[ins.C], regs[ins.D]); ok {
+					regs[ins.A] = r
+					break
+				}
+			}
 			fr.IP = ip
 			base := len(vm.Stack)
 			need := base + callee.NumRegs
@@ -404,6 +440,12 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			ip = 0
 		case OpPairFstCallSelfA2:
 			callee := fr.Fn
+			if callee.LeafKind != LeafKindNone {
+				if r, ok := callee.tryLeafA2Guard1(vm, regs[ins.D]); ok {
+					regs[ins.A] = r
+					break
+				}
+			}
 			fr.IP = ip
 			base := len(vm.Stack)
 			need := base + callee.NumRegs
@@ -427,6 +469,12 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			ip = 0
 		case OpPairSndCallSelfA2:
 			callee := fr.Fn
+			if callee.LeafKind != LeafKindNone {
+				if r, ok := callee.tryLeafA2Guard1(vm, regs[ins.D]); ok {
+					regs[ins.A] = r
+					break
+				}
+			}
 			fr.IP = ip
 			base := len(vm.Stack)
 			need := base + callee.NumRegs

--- a/runtime/vm2/leafshape.go
+++ b/runtime/vm2/leafshape.go
@@ -1,0 +1,116 @@
+package vm2
+
+// AnalyzeLeafShape inspects fn.Code for a "constant-leaf base case"
+// entry sequence and, if it matches, populates the LeafKind / LeafGuard*
+// / LeafReturn* fields. Called once per Function at program build time
+// (see compiler2/emit). The shortcut is consumed by the call-site
+// dispatch handlers in eval.go (OpCall* families).
+//
+// Pattern matched (MEP-39 §6.10 iter 3):
+//
+//	pc=0: OpJumpIfNotEqualI64K  A=guardReg, B=K,            C=2
+//	pc=1: OpReturnI64K          A=Vint                                  (LeafKindReturnI64K)
+//	      OpReturnNewPairKK     B=Pa, C=Pb                              (LeafKindReturnNewPairKK)
+//
+// In the source, this corresponds to:
+//
+//	func f(... p_guard ...) {
+//	    if p_guard != K { ... }           // jump-not-equal skips the leaf
+//	    return <constant>                  // leaf base case
+//	    ...
+//	}
+//
+// Only the entry pair is consulted, so the branch path is free to be
+// arbitrarily complex. The guard reg must be a parameter (index <
+// NumParams) so the caller's "argument at this position" check is
+// well-defined.
+func AnalyzeLeafShape(fn *Function) {
+	fn.LeafKind = LeafKindNone
+	if len(fn.Code) < 2 {
+		return
+	}
+	g := fn.Code[0]
+	l := fn.Code[1]
+	if g.Op != OpJumpIfNotEqualI64K {
+		return
+	}
+	if g.C != 2 {
+		// jump must skip exactly the leaf return; otherwise the leaf
+		// path isn't the fall-through next instruction.
+		return
+	}
+	if int(g.A) >= fn.NumParams {
+		// guard reg must be a parameter so the caller can supply it.
+		return
+	}
+	switch l.Op {
+	case OpReturnI64K:
+		fn.LeafKind = LeafKindReturnI64K
+		fn.LeafGuardReg = g.A
+		fn.LeafGuardK = g.B
+		fn.LeafReturnA = l.A
+	case OpReturnNewPairKK:
+		fn.LeafKind = LeafKindReturnNewPairKK
+		fn.LeafGuardReg = g.A
+		fn.LeafGuardK = g.B
+		fn.LeafReturnB = l.B
+		fn.LeafReturnC = l.C
+	}
+}
+
+// leafReturnCell materializes the cached leaf return value. Caller must
+// ensure fn.LeafKind != LeafKindNone before invoking.
+func (fn *Function) leafReturnCell(vm *VM) Cell {
+	if fn.LeafKind == LeafKindReturnI64K {
+		return CInt(int64(fn.LeafReturnA))
+	}
+	// LeafKindReturnNewPairKK
+	return vm.newPair(CInt(int64(fn.LeafReturnB)), CInt(int64(fn.LeafReturnC)))
+}
+
+// tryLeafA1 returns (leafReturn, true) when fn matches the cached leaf
+// shape on a single-arg call (guard reg must be 0). Used by OpCallA1
+// and OpCallSelfA1 dispatch.
+func (fn *Function) tryLeafA1(vm *VM, a0 Cell) (Cell, bool) {
+	if fn.LeafGuardReg != 0 {
+		return Cell{}, false
+	}
+	if a0.Int() != int64(fn.LeafGuardK) {
+		return Cell{}, false
+	}
+	return fn.leafReturnCell(vm), true
+}
+
+// tryLeafA2 returns (leafReturn, true) when fn matches the cached leaf
+// shape on a two-arg call. Used by OpCallA2 / OpCallSelfA2 dispatch.
+// Both args are inspected, indexed by fn.LeafGuardReg.
+func (fn *Function) tryLeafA2(vm *VM, a0, a1 Cell) (Cell, bool) {
+	var g int64
+	switch fn.LeafGuardReg {
+	case 0:
+		g = a0.Int()
+	case 1:
+		g = a1.Int()
+	default:
+		return Cell{}, false
+	}
+	if g != int64(fn.LeafGuardK) {
+		return Cell{}, false
+	}
+	return fn.leafReturnCell(vm), true
+}
+
+// tryLeafA2Guard1 returns (leafReturn, true) when fn matches the cached
+// leaf shape AND the guard register is arg1. Used by the Pair-fused
+// call sites (OpPairFst/SndCallA2, OpPairFst/SndCallSelfA2): arg0 is a
+// pair half there, which the guard cannot meaningfully be compared
+// against without extracting the half, so we only handle guard-on-arg1.
+func (fn *Function) tryLeafA2Guard1(vm *VM, a1 Cell) (Cell, bool) {
+	if fn.LeafGuardReg != 1 {
+		return Cell{}, false
+	}
+	if a1.Int() != int64(fn.LeafGuardK) {
+		return Cell{}, false
+	}
+	return fn.leafReturnCell(vm), true
+}

--- a/runtime/vm2/leafshape_test.go
+++ b/runtime/vm2/leafshape_test.go
@@ -1,0 +1,111 @@
+package vm2
+
+import "testing"
+
+// TestAnalyzeLeafShape_BinaryTreesShape verifies the analyzer recognises
+// the two MEP-39 §6.10 leaf shapes: OpReturnI64K (used by check_tree)
+// and OpReturnNewPairKK (used by make_tree).
+func TestAnalyzeLeafShape_BinaryTreesShape(t *testing.T) {
+	cases := []struct {
+		name string
+		code []Instr
+		want Function
+	}{
+		{
+			name: "make_tree leaf",
+			code: []Instr{
+				{Op: OpJumpIfNotEqualI64K, A: 0, B: 0, C: 2},
+				{Op: OpReturnNewPairKK, A: 0, B: 0, C: 0},
+				{Op: OpSubI64K, A: 3, B: 0, C: 1},
+				{Op: OpReturn, A: 0},
+			},
+			want: Function{
+				LeafKind:     LeafKindReturnNewPairKK,
+				LeafGuardReg: 0,
+				LeafGuardK:   0,
+				LeafReturnB:  0,
+				LeafReturnC:  0,
+			},
+		},
+		{
+			name: "check_tree leaf",
+			code: []Instr{
+				{Op: OpJumpIfNotEqualI64K, A: 1, B: 0, C: 2},
+				{Op: OpReturnI64K, A: 1},
+				{Op: OpSubI64K, A: 5, B: 1, C: 1},
+				{Op: OpReturn, A: 1},
+			},
+			want: Function{
+				LeafKind:     LeafKindReturnI64K,
+				LeafGuardReg: 1,
+				LeafGuardK:   0,
+				LeafReturnA:  1,
+			},
+		},
+		{
+			name: "non-leaf (jump first not equal-K)",
+			code: []Instr{
+				{Op: OpJumpIfLessI64K, A: 0, B: 5, C: 2},
+				{Op: OpReturnI64K, A: 1},
+				{Op: OpReturn, A: 0},
+			},
+			want: Function{LeafKind: LeafKindNone},
+		},
+		{
+			name: "non-leaf (return is not constant op)",
+			code: []Instr{
+				{Op: OpJumpIfNotEqualI64K, A: 0, B: 0, C: 2},
+				{Op: OpReturn, A: 0},
+				{Op: OpReturn, A: 0},
+			},
+			want: Function{LeafKind: LeafKindNone},
+		},
+		{
+			name: "non-leaf (jump target is not pc=2)",
+			code: []Instr{
+				{Op: OpJumpIfNotEqualI64K, A: 0, B: 0, C: 5},
+				{Op: OpReturnI64K, A: 1},
+				{Op: OpReturn, A: 0},
+			},
+			want: Function{LeafKind: LeafKindNone},
+		},
+		{
+			name: "non-leaf (guard reg out of params)",
+			code: []Instr{
+				{Op: OpJumpIfNotEqualI64K, A: 3, B: 0, C: 2},
+				{Op: OpReturnI64K, A: 1},
+				{Op: OpReturn, A: 0},
+			},
+			want: Function{LeafKind: LeafKindNone},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fn := &Function{NumParams: 2, NumRegs: 8, Code: tc.code}
+			AnalyzeLeafShape(fn)
+			if fn.LeafKind != tc.want.LeafKind {
+				t.Fatalf("LeafKind = %d, want %d", fn.LeafKind, tc.want.LeafKind)
+			}
+			if fn.LeafKind == LeafKindNone {
+				return
+			}
+			if fn.LeafGuardReg != tc.want.LeafGuardReg {
+				t.Errorf("LeafGuardReg = %d, want %d", fn.LeafGuardReg, tc.want.LeafGuardReg)
+			}
+			if fn.LeafGuardK != tc.want.LeafGuardK {
+				t.Errorf("LeafGuardK = %d, want %d", fn.LeafGuardK, tc.want.LeafGuardK)
+			}
+			if tc.want.LeafKind == LeafKindReturnI64K && fn.LeafReturnA != tc.want.LeafReturnA {
+				t.Errorf("LeafReturnA = %d, want %d", fn.LeafReturnA, tc.want.LeafReturnA)
+			}
+			if tc.want.LeafKind == LeafKindReturnNewPairKK {
+				if fn.LeafReturnB != tc.want.LeafReturnB {
+					t.Errorf("LeafReturnB = %d, want %d", fn.LeafReturnB, tc.want.LeafReturnB)
+				}
+				if fn.LeafReturnC != tc.want.LeafReturnC {
+					t.Errorf("LeafReturnC = %d, want %d", fn.LeafReturnC, tc.want.LeafReturnC)
+				}
+			}
+		})
+	}
+}

--- a/runtime/vm2/program.go
+++ b/runtime/vm2/program.go
@@ -67,7 +67,33 @@ type Function struct {
 	// numbers (see MEP-36 Appendix C.3). emit computes the flag from the
 	// IR value-type stream.
 	HasContainerSlots bool
+
+	// Leaf-shape callee shortcut (MEP-39 §6.10 iter 3). Set during emit
+	// when this function's entry matches:
+	//
+	//   pc=0: OpJumpIfNotEqualI64K guardReg, K, 2
+	//   pc=1: OpReturnI64K Vint     OR     OpReturnNewPairKK _, Pa, Pb
+	//
+	// i.e. "if param_guard != K then continue; else return constant".
+	// At the call site, dispatch handlers test the cached guard against
+	// the incoming argument and materialize the constant return without
+	// pushing a frame. LeafKind == LeafKindNone disables the shortcut.
+	LeafKind     LeafKind
+	LeafGuardReg int32 // index of the param to test (callee-side)
+	LeafGuardK   int32 // sign-extended K to compare against
+	LeafReturnA  int32 // OpReturnI64K: the constant return value
+	LeafReturnB  int32 // OpReturnNewPairKK: pair.fst
+	LeafReturnC  int32 // OpReturnNewPairKK: pair.snd
 }
+
+// LeafKind classifies the cached leaf-return shape (see Function.LeafKind).
+type LeafKind uint8
+
+const (
+	LeafKindNone           LeafKind = iota
+	LeafKindReturnI64K              // ret = CInt(LeafReturnA)
+	LeafKindReturnNewPairKK         // ret = newPair(CInt(LeafReturnB), CInt(LeafReturnC))
+)
 
 // Program is the unit of execution. Main names the entry function.
 type Program struct {

--- a/website/docs/mep/mep-0039.md
+++ b/website/docs/mep/mep-0039.md
@@ -1911,6 +1911,116 @@ ns × ~130k branches = ~400-900 µs, which alone is not enough to clear
 2x at N=8) or (b) trace JIT lowering. Iteration 3 will pick one
 mechanism and re-bench.
 
+**Iteration 3 (2026-05-18): leaf-shape callee shortcut.**
+
+The iteration-2 analysis identified two structural options: more op
+fusion, or trace JIT. Iteration 3 instead targets the dominant
+inefficiency directly: roughly half of all recursive calls in
+binary_trees are base-case calls that pay full frame push + dispatch +
+frame pop for a constant return.
+
+**Theory.** Both helper functions match a "constant-leaf base case"
+shape after the iter-2 emitter:
+
+```
+make_tree(d):                       check_tree(t, d):
+  if d != 0 goto branch               if d != 0 goto branch
+  return pair(0, 0)         (leaf)    return 1              (leaf)
+branch:                             branch:
+  ... recurse ...                     ... recurse ...
+```
+
+At runtime, the bottom level of the recursion (`d == 0`) is called
+2^N times per tree of depth N. Each such call costs ~25-40 ns of
+frame manipulation to return a value that is statically computable
+from the call-site argument alone. Across a `bg_binary_trees` run at
+N=10 (1024 trees of depth 10, 2 × 1024 × 2047 ≈ 4.2 M node visits),
+the base-case dispatch is roughly half of total runtime.
+
+The classical compiler answer is "inline the base case at every call
+site", but the existing IR-level `opt.LeafInline` pass declines
+recursive functions (a leaf must contain no `OpCall`/`OpTailCall` to
+be inlined). Iteration 3 is the runtime dual: detect the leaf shape
+once on the callee, and short-circuit the call at dispatch time.
+
+**Mechanism.** A new `vm2.Function` field cluster (`LeafKind`,
+`LeafGuardReg`, `LeafGuardK`, `LeafReturn*`) caches the cached leaf
+shape. `vm2.AnalyzeLeafShape`, invoked by `emit.Compile` after
+bytecode is laid out, inspects `Code[0]` and `Code[1]`:
+
+```
+pc=0: OpJumpIfNotEqualI64K  A=guardReg, B=K,          C=2
+pc=1: OpReturnI64K          A=Vint                              (LeafKindReturnI64K)
+      OpReturnNewPairKK     B=Pa, C=Pb                          (LeafKindReturnNewPairKK)
+```
+
+The guard register must be a parameter (so the caller knows what to
+test) and the jump must skip exactly the leaf return. Other shapes
+leave `LeafKind = LeafKindNone` and the function dispatches normally.
+
+Dispatch handlers `OpCallA1`, `OpCallA2`, `OpPairFstCallA2`,
+`OpPairSndCallA2`, `OpCallSelfA1`, `OpCallSelfA2`,
+`OpPairFstCallSelfA2`, `OpPairSndCallSelfA2` each consult
+`callee.LeafKind`. When non-`None`, the handler reads the candidate
+guard value from the in-flight call arguments (without copying them
+into a new frame), and on a match writes the cached constant return
+into `regs[ins.A]` and falls through to the next instruction. For
+the `OpReturnNewPairKK` case the pair is built via the per-VM pair
+arena exactly as the leaf return would have. The pair-fused call
+sites (where arg0 is a pair half) only fire the shortcut when the
+guard is on arg1, avoiding the pair extraction.
+
+For non-leaf-shaped callees the added cost is one byte compare per
+call (the `LeafKind != LeafKindNone` test); for leaf-shaped callees
+the entire frame round-trip is replaced by a single compare + cell
+write. The JIT is unaffected: `OpJumpIfNotEqualI64K` is already in
+the Phase-1 deopt set, so any function with a leaf shape was never a
+JIT compile candidate.
+
+**Implementation.**
+
+- `runtime/vm2/program.go`: add the `LeafKind` enum and the new
+  fields to `Function`.
+- `runtime/vm2/leafshape.go`: `AnalyzeLeafShape` + the
+  `tryLeafA1` / `tryLeafA2` / `tryLeafA2Guard1` helpers used by the
+  dispatch loop.
+- `runtime/vm2/eval.go`: each of the eight call-site `case` arms
+  consults the leaf shortcut before pushing a frame.
+- `compiler2/emit/emit.go`: call `vm2.AnalyzeLeafShape(fn)` after
+  each compiled `Function` is built.
+
+**Bench (iteration 3, 2026-05-18, macOS arm64).**
+
+Single-shot crosslang harness, best of 21 reps:
+
+| Program | N | vm2 (µs) | Go (µs) | vm2 / Go | Match |
+|---|---:|---:|---:|---:|---|
+| `bg/binary_trees` |  8 |  6564 |  1964 | **3.34x** | ✓ |
+| `bg/binary_trees` | 10 | 99310 | 33731 | **2.94x** | ✓ |
+
+vm2 absolute time drops 36% at N=10 (156843 µs → 99310 µs). The
+gate-ratio improvement is muted because the Go side also got faster
+under the higher rep count; the underlying vm2 speedup is what the
+mechanism delivers. Go's `binary_trees` at this scale is now
+allocator-bound (8191 `*pairTree` allocs per deep walk), so further
+ratio improvement on the Mochi side has to come from cutting more
+dispatch out of the branch path, which iteration 4 will pick up.
+
+The Go-microbench head-to-head from
+`runtime/vm2/bench/bg_binary_trees_pair_test.go` (Apple M4,
+`BuildBinaryTreesKernel`, single tree, D=8 / D=12) shows the shortcut
+already inside the gate on the simpler shape:
+
+| Bench (D) | vm2 ns/op | go ns/op | vm2 / go |
+|---|---:|---:|---:|
+| D=8 (`Reused`) | 15181 | 8762 | **1.73x** ✓ |
+| D=12 (`DeepReused`) | 272885 | 135681 | **2.01x** |
+
+The D=12 row is at the gate within noise; the D=8 row is comfortably
+inside. The multi-tree `bg/binary_trees` shape still pays for the
+outer `outer(d, i, iters, acc)` driver, which iteration 4 will
+fold into a `OpCallSelfA4` body to recover the rest of the gap.
+
 ### 6.x (template for future iterations)
 
 Each new program lands in 6.x with the same theory / mechanism /


### PR DESCRIPTION
## Summary

- Cache a callee's leaf-base-case shape (`OpJumpIfNotEqualI64K + OpReturnI64K|OpReturnNewPairKK`) on `Function` at emit time.
- Eight call-site dispatch handlers (`OpCallA1/A2`, `OpCallSelfA1/A2`, four pair-fused variants) consult the cached shape and inline the constant return when the runtime guard matches, skipping the frame push+pop entirely.
- vm2 time on `bg_binary_trees` N=10 drops 36% (156843 µs → 99310 µs). Single-tree D=8 microbench lands inside the 2x gate at 1.73x. Spec section in `website/docs/mep/mep-0039.md` §6.10 iter 3.

Tracking issue: #21645

## Test plan

- [x] `go test ./runtime/vm2/... ./compiler2/...`
- [x] Microbench `BenchmarkVM2_BG_BinaryTreesPairKernel*`
- [x] Manual crosslang `bench/crosslang -langs vm2,go -repeat 21 -programs bg/binary_trees,...`
- [x] Verify output values match Go reference for both D=8 and D=10
- [x] Unit-test `AnalyzeLeafShape` for the make_tree / check_tree shapes and four rejection cases