### PR TITLE
mep-0039 §6.10: binary_trees iter 5 (SubK+call fusion, branch-entry IP)

### DIFF
--- a/compiler2/emit/emit.go
+++ b/compiler2/emit/emit.go
@@ -212,6 +212,69 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 		suppress[rhs] = true
 		subK[ir.ValueID(vid)] = subKInfo{k: k, src: ins.Args[0]}
 	}
+	// SubK+Call fusion (MEP-39 §6.10 iter 5). When a SubI64K(_, 1) result
+	// is consumed only by self-recursive calls in fusable arg positions,
+	// each consumer call emits a Sub1 variant that re-derives `src - 1`
+	// inline, and the standalone SubI64K is suppressed. Hot path for
+	// binary_trees.make_tree (two consecutive calls share `d-1`) and
+	// check_tree (two pair-fused calls share `d-1`). Both call sites
+	// recompute the subtraction; doubling the subtract is cheaper than
+	// the dispatch it eliminates.
+	fuseCallSub1 := make(map[ir.ValueID]ir.ValueID) // call vid -> src reg vid
+	for subVid, info := range subK {
+		if info.k != 1 {
+			continue
+		}
+		// Find every use of subVid; each must be a self-recursive call
+		// that lands in either OpCallSelfA1 or a fusePairCall (PairFst /
+		// PairSnd) shape with the sub result as arg1.
+		uses := []ir.ValueID{}
+		ok := true
+		for vid, ins := range f.Values {
+			if pos[vid] < 0 || ir.ValueID(vid) == subVid {
+				continue
+			}
+			for argIdx, a := range ins.Args {
+				if a != subVid {
+					continue
+				}
+				if ins.Op != ir.OpCall || int(ins.Aux) != selfIdx {
+					ok = false
+					break
+				}
+				switch len(ins.Args) {
+				case 1:
+					if argIdx != 0 {
+						ok = false
+					}
+				case 2:
+					if argIdx != 1 {
+						ok = false
+						break
+					}
+					if _, hasFuse := fusePairCall[ir.ValueID(vid)]; !hasFuse {
+						ok = false
+					}
+				default:
+					ok = false
+				}
+				if !ok {
+					break
+				}
+				uses = append(uses, ir.ValueID(vid))
+			}
+			if !ok {
+				break
+			}
+		}
+		if !ok || len(uses) == 0 {
+			continue
+		}
+		suppress[subVid] = true
+		for _, callVid := range uses {
+			fuseCallSub1[callVid] = info.src
+		}
+	}
 	// mulK mirrors addK: multiply is commutative so either operand can
 	// be the immediate. Hot for LCG / hash chains in MEP-39 §6.6 fasta
 	// (`seed * 3877` and `hash * 1009` both fold). The i32 immediate
@@ -602,6 +665,9 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 					B: int32(finalReg[ins.Args[0]]),
 					C: int32(finalReg[ins.Args[1]])})
 			case ir.OpSubI64:
+				if suppress[vid] {
+					break
+				}
 				if info, ok := subK[vid]; ok {
 					emit(vm2.Instr{Op: vm2.OpSubI64K, A: dst,
 						B: int32(finalReg[info.src]),
@@ -944,6 +1010,30 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 				// dispatch handler read source registers directly. Cuts
 				// 1-2 dispatches per call site on the dominant arities
 				// in the BG corpus.
+				if subSrc, ok := fuseCallSub1[vid]; ok {
+					// MEP-39 §6.10 iter 5: the call's depth operand is a
+					// SubI64K(_, 1) that's been suppressed in favor of a
+					// Sub1-fused call variant. Re-derive `src - 1`
+					// inline at dispatch.
+					if info, hasFusePair := fusePairCall[vid]; hasFusePair {
+						var op vm2.Op
+						switch info.op {
+						case vm2.OpPairFstCallA2:
+							op = vm2.OpPairFstCallSelfA2Sub1
+						case vm2.OpPairSndCallA2:
+							op = vm2.OpPairSndCallSelfA2Sub1
+						}
+						emit(vm2.Instr{Op: op, A: dst,
+							B: int32(ins.Aux),
+							C: int32(finalReg[info.pairSrc]),
+							D: int32(finalReg[subSrc])})
+						break
+					}
+					emit(vm2.Instr{Op: vm2.OpCallSelfA1Sub1, A: dst,
+						B: int32(ins.Aux),
+						C: int32(finalReg[subSrc])})
+					break
+				}
 				if info, ok := fusePairCall[vid]; ok {
 					op := info.op
 					if int(ins.Aux) == selfIdx {

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -271,7 +271,7 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 				code = callee.Code
 				regs = vm.Stack[base:]
 				consts = callee.Consts
-				ip = 0
+				ip = int(callee.BranchEntryIP)
 				break
 			}
 			a0 := regs[ins.C]
@@ -281,7 +281,7 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			code = fr.Fn.Code
 			regs = vm.Stack[newBase:]
 			consts = fr.Fn.Consts
-			ip = 0
+			ip = int(callee.BranchEntryIP)
 		case OpCallA2:
 			// 2-arg specialized call. Same shape as OpCallA1 with one
 			// more arg in ins.D. Hot path for binary_trees.checkTree.
@@ -318,7 +318,7 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 				code = callee.Code
 				regs = vm.Stack[base:]
 				consts = callee.Consts
-				ip = 0
+				ip = int(callee.BranchEntryIP)
 				break
 			}
 			a0, a1 := regs[ins.C], regs[ins.D]
@@ -329,7 +329,7 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			code = fr.Fn.Code
 			regs = vm.Stack[newBase:]
 			consts = fr.Fn.Consts
-			ip = 0
+			ip = int(callee.BranchEntryIP)
 		case OpPairFstCallA2:
 			// Fused OpPairFst + OpCallA2. arg0 is the .a half of the pair
 			// in regs[ins.C]; arg1 is regs[ins.D]. Saves one dispatch + the
@@ -356,7 +356,7 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 				code = callee.Code
 				regs = vm.Stack[base:]
 				consts = callee.Consts
-				ip = 0
+				ip = int(callee.BranchEntryIP)
 				break
 			}
 			a0 := (*vmPair)(regs[ins.C].PtrTo()).a
@@ -368,7 +368,7 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			code = fr.Fn.Code
 			regs = vm.Stack[newBase:]
 			consts = fr.Fn.Consts
-			ip = 0
+			ip = int(callee.BranchEntryIP)
 		case OpPairSndCallA2:
 			callee := vm.Program.Funcs[ins.B]
 			if lk := callee.LeafKind; lk != LeafKindNone && callee.LeafGuardReg == 1 && regs[ins.D].Int() == int64(callee.LeafGuardK) {
@@ -391,7 +391,7 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 				code = callee.Code
 				regs = vm.Stack[base:]
 				consts = callee.Consts
-				ip = 0
+				ip = int(callee.BranchEntryIP)
 				break
 			}
 			a0 := (*vmPair)(regs[ins.C].PtrTo()).b
@@ -403,7 +403,7 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			code = fr.Fn.Code
 			regs = vm.Stack[newBase:]
 			consts = fr.Fn.Consts
-			ip = 0
+			ip = int(callee.BranchEntryIP)
 		case OpCallSelfA1:
 			callee := fr.Fn
 			if lk := callee.LeafKind; lk != LeafKindNone && callee.LeafGuardReg == 0 && regs[ins.C].Int() == int64(callee.LeafGuardK) {
@@ -423,7 +423,7 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 				vm.Frames = append(vm.Frames, frame{Fn: callee, RegsBase: base, RetReg: ins.A})
 				fr = &vm.Frames[len(vm.Frames)-1]
 				regs = vm.Stack[base:]
-				ip = 0
+				ip = int(callee.BranchEntryIP)
 				break
 			}
 			a0 := regs[ins.C]
@@ -431,7 +431,7 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			vm.Stack[newBase] = a0
 			fr = &vm.Frames[len(vm.Frames)-1]
 			regs = vm.Stack[newBase:]
-			ip = 0
+			ip = int(callee.BranchEntryIP)
 		case OpCallSelfA2:
 			callee := fr.Fn
 			if lk := callee.LeafKind; lk != LeafKindNone {
@@ -464,7 +464,7 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 				vm.Frames = append(vm.Frames, frame{Fn: callee, RegsBase: base, RetReg: ins.A})
 				fr = &vm.Frames[len(vm.Frames)-1]
 				regs = vm.Stack[base:]
-				ip = 0
+				ip = int(callee.BranchEntryIP)
 				break
 			}
 			a0, a1 := regs[ins.C], regs[ins.D]
@@ -473,7 +473,7 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			vm.Stack[newBase+1] = a1
 			fr = &vm.Frames[len(vm.Frames)-1]
 			regs = vm.Stack[newBase:]
-			ip = 0
+			ip = int(callee.BranchEntryIP)
 		case OpPairFstCallSelfA2:
 			callee := fr.Fn
 			if lk := callee.LeafKind; lk != LeafKindNone && callee.LeafGuardReg == 1 && regs[ins.D].Int() == int64(callee.LeafGuardK) {
@@ -494,7 +494,7 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 				vm.Frames = append(vm.Frames, frame{Fn: callee, RegsBase: base, RetReg: ins.A})
 				fr = &vm.Frames[len(vm.Frames)-1]
 				regs = vm.Stack[base:]
-				ip = 0
+				ip = int(callee.BranchEntryIP)
 				break
 			}
 			a0 := (*vmPair)(regs[ins.C].PtrTo()).a
@@ -504,7 +504,7 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			vm.Stack[newBase+1] = a1
 			fr = &vm.Frames[len(vm.Frames)-1]
 			regs = vm.Stack[newBase:]
-			ip = 0
+			ip = int(callee.BranchEntryIP)
 		case OpPairSndCallSelfA2:
 			callee := fr.Fn
 			if lk := callee.LeafKind; lk != LeafKindNone && callee.LeafGuardReg == 1 && regs[ins.D].Int() == int64(callee.LeafGuardK) {
@@ -525,7 +525,7 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 				vm.Frames = append(vm.Frames, frame{Fn: callee, RegsBase: base, RetReg: ins.A})
 				fr = &vm.Frames[len(vm.Frames)-1]
 				regs = vm.Stack[base:]
-				ip = 0
+				ip = int(callee.BranchEntryIP)
 				break
 			}
 			a0 := (*vmPair)(regs[ins.C].PtrTo()).b
@@ -535,7 +535,100 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			vm.Stack[newBase+1] = a1
 			fr = &vm.Frames[len(vm.Frames)-1]
 			regs = vm.Stack[newBase:]
-			ip = 0
+			ip = int(callee.BranchEntryIP)
+		case OpCallSelfA1Sub1:
+			callee := fr.Fn
+			argv := regs[ins.C].Int() - 1
+			if lk := callee.LeafKind; lk != LeafKindNone && callee.LeafGuardReg == 0 && argv == int64(callee.LeafGuardK) {
+				if lk == LeafKindReturnI64K {
+					regs[ins.A] = CInt(int64(callee.LeafReturnA))
+				} else {
+					regs[ins.A] = vm.newPair(CInt(int64(callee.LeafReturnB)), CInt(int64(callee.LeafReturnC)))
+				}
+				break
+			}
+			fr.IP = ip
+			base := len(vm.Stack)
+			need := base + callee.NumRegs
+			if cap(vm.Stack) >= need {
+				vm.Stack = vm.Stack[:need]
+				vm.Stack[base] = CInt(argv)
+				vm.Frames = append(vm.Frames, frame{Fn: callee, RegsBase: base, RetReg: ins.A})
+				fr = &vm.Frames[len(vm.Frames)-1]
+				regs = vm.Stack[base:]
+				ip = int(callee.BranchEntryIP)
+				break
+			}
+			a0 := CInt(argv)
+			_, newBase := vm.pushFrame(callee, ins.A)
+			vm.Stack[newBase] = a0
+			fr = &vm.Frames[len(vm.Frames)-1]
+			regs = vm.Stack[newBase:]
+			ip = int(callee.BranchEntryIP)
+		case OpPairFstCallSelfA2Sub1:
+			callee := fr.Fn
+			argv := regs[ins.D].Int() - 1
+			if lk := callee.LeafKind; lk != LeafKindNone && callee.LeafGuardReg == 1 && argv == int64(callee.LeafGuardK) {
+				if lk == LeafKindReturnI64K {
+					regs[ins.A] = CInt(int64(callee.LeafReturnA))
+				} else {
+					regs[ins.A] = vm.newPair(CInt(int64(callee.LeafReturnB)), CInt(int64(callee.LeafReturnC)))
+				}
+				break
+			}
+			fr.IP = ip
+			base := len(vm.Stack)
+			need := base + callee.NumRegs
+			if cap(vm.Stack) >= need {
+				vm.Stack = vm.Stack[:need]
+				vm.Stack[base] = (*vmPair)(regs[ins.C].PtrTo()).a
+				vm.Stack[base+1] = CInt(argv)
+				vm.Frames = append(vm.Frames, frame{Fn: callee, RegsBase: base, RetReg: ins.A})
+				fr = &vm.Frames[len(vm.Frames)-1]
+				regs = vm.Stack[base:]
+				ip = int(callee.BranchEntryIP)
+				break
+			}
+			a0 := (*vmPair)(regs[ins.C].PtrTo()).a
+			a1 := CInt(argv)
+			_, newBase := vm.pushFrame(callee, ins.A)
+			vm.Stack[newBase] = a0
+			vm.Stack[newBase+1] = a1
+			fr = &vm.Frames[len(vm.Frames)-1]
+			regs = vm.Stack[newBase:]
+			ip = int(callee.BranchEntryIP)
+		case OpPairSndCallSelfA2Sub1:
+			callee := fr.Fn
+			argv := regs[ins.D].Int() - 1
+			if lk := callee.LeafKind; lk != LeafKindNone && callee.LeafGuardReg == 1 && argv == int64(callee.LeafGuardK) {
+				if lk == LeafKindReturnI64K {
+					regs[ins.A] = CInt(int64(callee.LeafReturnA))
+				} else {
+					regs[ins.A] = vm.newPair(CInt(int64(callee.LeafReturnB)), CInt(int64(callee.LeafReturnC)))
+				}
+				break
+			}
+			fr.IP = ip
+			base := len(vm.Stack)
+			need := base + callee.NumRegs
+			if cap(vm.Stack) >= need {
+				vm.Stack = vm.Stack[:need]
+				vm.Stack[base] = (*vmPair)(regs[ins.C].PtrTo()).b
+				vm.Stack[base+1] = CInt(argv)
+				vm.Frames = append(vm.Frames, frame{Fn: callee, RegsBase: base, RetReg: ins.A})
+				fr = &vm.Frames[len(vm.Frames)-1]
+				regs = vm.Stack[base:]
+				ip = int(callee.BranchEntryIP)
+				break
+			}
+			a0 := (*vmPair)(regs[ins.C].PtrTo()).b
+			a1 := CInt(argv)
+			_, newBase := vm.pushFrame(callee, ins.A)
+			vm.Stack[newBase] = a0
+			vm.Stack[newBase+1] = a1
+			fr = &vm.Frames[len(vm.Frames)-1]
+			regs = vm.Stack[newBase:]
+			ip = int(callee.BranchEntryIP)
 		case OpTailCallSelf:
 			ip = 0
 		case OpTailCallSelfA3:

--- a/runtime/vm2/leafshape.go
+++ b/runtime/vm2/leafshape.go
@@ -55,7 +55,14 @@ func AnalyzeLeafShape(fn *Function) {
 		fn.LeafGuardK = g.B
 		fn.LeafReturnB = l.B
 		fn.LeafReturnC = l.C
+	default:
+		return
 	}
+	// Branch entry: a leaf-shape callee whose caller already performed
+	// the guard test inline (and chose the non-leaf path) can start the
+	// new frame at pc=2, skipping the redundant OpJumpIfNotEqualI64K
+	// guard dispatch. MEP-39 §6.10 iter 5.
+	fn.BranchEntryIP = 2
 }
 
 // The leaf shortcut is consumed inline in each of the eight call-site

--- a/runtime/vm2/ops.go
+++ b/runtime/vm2/ops.go
@@ -339,4 +339,23 @@ const (
 	OpI64ToBigInt  // A = CBigInt(new(big.Int).SetInt64(regs[B].Int()))
 	OpBigIntToI64  // A = CInt(bigIntAt(regs[B]).Int64()); low 64 bits if oversize
 	OpBigIntToStr  // A = newString(bigIntAt(regs[B]).Text(10))
+
+	// SubK-fused self-recursive calls (MEP-39 §6.10 iter 5).
+	//
+	// Each variant subtracts 1 from a parameter register inline before
+	// the call, instead of consuming a SubI64K op output. Emitted when
+	// the compiler proves every use of a SubI64K(reg, 1) is one of
+	// these call forms (the SubI64K is then DCE'd via suppress[]).
+	//
+	// Used by recursive descent kernels (binary_trees.make_tree /
+	// check_tree) where two consecutive calls share `d-1`: with the
+	// fusion both calls re-derive `d-1` from the source register, and
+	// the standalone SubI64K disappears.
+	//
+	//	OpCallSelfA1Sub1:        A=retReg, C=arg0SrcReg (arg0 = regs[C] - 1)
+	//	OpPairFstCallSelfA2Sub1: A=retReg, C=pairSrcReg, D=arg1SrcReg (arg1 = regs[D] - 1)
+	//	OpPairSndCallSelfA2Sub1: A=retReg, C=pairSrcReg, D=arg1SrcReg (arg1 = regs[D] - 1)
+	OpCallSelfA1Sub1
+	OpPairFstCallSelfA2Sub1
+	OpPairSndCallSelfA2Sub1
 )

--- a/runtime/vm2/program.go
+++ b/runtime/vm2/program.go
@@ -84,6 +84,15 @@ type Function struct {
 	LeafReturnA  int32 // OpReturnI64K: the constant return value
 	LeafReturnB  int32 // OpReturnNewPairKK: pair.fst
 	LeafReturnC  int32 // OpReturnNewPairKK: pair.snd
+
+	// BranchEntryIP is the ip to use when entering this function on the
+	// branch path. For leaf-shape callees the entry guard at pc=0 jumps
+	// to pc=2 when the arg fails the guard test; if the caller already
+	// performed the guard test inline (via the leaf shortcut) and saw a
+	// mismatch, the frame can start directly at pc=2 to skip the guard
+	// dispatch. MEP-39 §6.10 iter 5: set to 2 by AnalyzeLeafShape when
+	// the leaf-shape match succeeds, else 0 (default entry).
+	BranchEntryIP int32
 }
 
 // LeafKind classifies the cached leaf-return shape (see Function.LeafKind).

--- a/website/docs/mep/mep-0039.md
+++ b/website/docs/mep/mep-0039.md
@@ -2124,6 +2124,135 @@ no longer appear, and `runLoop` flat-time rose from 74% to 84.5%
 of warm cycles, with `vm.newPair` taking 11.8% (was 7.79%, larger
 as a share now that the helper layer is removed).
 
+#### 6.10 iteration 5: SubK + call fusion and branch-entry IP
+
+**Theory.** With iteration 4 the leaf-shape shortcut materialises
+the base-case return without paying frame-push cost, but the
+non-leaf branch of the recursion still pays the full sequence:
+`OpSubI64K dm1, d, 1` (decrement); `OpCallSelfA1` (or pair-fused
+2-arg variant); on entry the callee's pc=0 `OpJumpIfNotEqualI64K`
+re-tests the guard the caller already evaluated inline. For
+`binary_trees`, each non-leaf `make_tree(d)` / `check_tree(t, d)`
+invocation pays 1 dispatch on the decrement, 1 dispatch to enter
+the call, and 1 dispatch to re-skip the leaf guard, before
+reaching its first useful instruction. At N=10 those three
+dispatches multiply across ~2 × 2^N internal nodes per outer tick
+and ~2^N outer ticks: roughly 6 × 2^(2N) avoidable dispatches per
+run, or ~25M at N=10. At ~3-4 ns/dispatch that is ~75-100 ms of
+the iter 4 vm2 cost.
+
+Two fusions collapse the sequence:
+
+1.  **SubK + Call fusion** for self-recursive calls whose only
+    argument-feeding operation is `OpSubI64K(_, K=1)`. The emitter
+    suppresses the standalone `OpSubI64K` and emits a fused op
+    that reads the source register, subtracts 1, and dispatches
+    the call in one go:
+
+    - `OpCallSelfA1Sub1 retReg, _, srcReg` (1-arg self-call,
+      arg0 = `regs[srcReg] - 1`).
+    - `OpPairFstCallSelfA2Sub1 retReg, _, pairReg, srcReg` (pair-fst
+      fused, arg0 = `pair.a`, arg1 = `regs[srcReg] - 1`).
+    - `OpPairSndCallSelfA2Sub1 retReg, _, pairReg, srcReg` (pair-snd
+      fused, arg0 = `pair.b`, arg1 = `regs[srcReg] - 1`).
+
+    The emitter only fuses when `K == 1` (the only constant that
+    appears in `binary_trees` and the other tree-recursion BG
+    programs) and only when *every* use of the `SubI64K` value is
+    a fusible self-call. Mixed-use values fall back to the
+    standalone op.
+
+2.  **Branch-entry IP.** A leaf-shape callee whose entry is
+    `OpJumpIfNotEqualI64K guard, K, 2` / `OpReturn{I64K, NewPairKK}`
+    has a fixed branch target: pc=2. When the call-site inline
+    check has already established `arg != K` and pushed a frame
+    anyway (i.e. the non-leaf path), the callee's pc=0 guard is
+    redundant: it will evaluate to "not equal" and jump to pc=2,
+    one dispatch later. `AnalyzeLeafShape` now records this
+    target as `Function.BranchEntryIP = 2`, and every specialized
+    call arm (`OpCallA1`, `OpCallA2`, the four pair-fused arms,
+    the four self-call arms, and the three new Sub1-fused arms)
+    sets the new frame's ip to `int(callee.BranchEntryIP)` rather
+    than 0. Generic `OpCall` and all `OpTailCall*` arms still use
+    ip=0 (they may dispatch non-leaf-shape callees, or jump back
+    into the active frame whose pc=0 has not been pre-checked).
+
+The combination cuts three dispatches per non-leaf recursion
+(decrement + call-arm dispatch overhead + pc=0 guard) down to one
+fused dispatch for the call. The arg decrement happens inline
+inside the call arm at memory-load speed.
+
+**Mechanism.**
+
+```
+# iter 4 (per non-leaf check_tree call):
+OpSubI64K       dm1c, depth, 1   # dispatch 1: decrement
+OpPairFstCallSelfA2 lcnt, _, t, dm1c  # dispatch 2: call (frame push, ip=0)
+  ↓ inside callee, pc=0:
+OpJumpIfNotEqualI64K depth, 0, 2 # dispatch 3: re-test guard, jump to pc=2
+  ↓ pc=2: first real work
+
+# iter 5:
+OpPairFstCallSelfA2Sub1 lcnt, _, t, depth  # dispatch 1: fused
+  ↓ inside callee, ip starts at 2 (BranchEntryIP):
+  ↓ pc=2: first real work, immediately
+```
+
+**Implementation.**
+
+- `runtime/vm2/ops.go`: add three opcodes (`OpCallSelfA1Sub1`,
+  `OpPairFstCallSelfA2Sub1`, `OpPairSndCallSelfA2Sub1`). The new
+  opcodes carry the same operands as their non-Sub1 versions
+  except the decrement-source register replaces the arg slot.
+- `runtime/vm2/program.go`: add `Function.BranchEntryIP int32`.
+- `runtime/vm2/leafshape.go`: set `fn.BranchEntryIP = 2` whenever
+  the leaf-shape match succeeds. Non-matching functions retain
+  the default zero entry.
+- `runtime/vm2/eval.go`: implement the three new arms (each runs
+  the same inline leaf-check + frame-push sequence as its non-Sub1
+  cousin, computing `argv := regs[srcReg].Int() - 1` once); change
+  the post-frame-push `ip = 0` to `ip = int(callee.BranchEntryIP)`
+  in all eleven specialized call arms.
+- `compiler2/emit/emit.go`: add a post-pass that collects every
+  `OpSubI64` value with `K == 1` whose uses are all 1-arg
+  self-calls (`fuseCallSub1[callVid] = srcReg`) or pair-fused
+  2-arg self-calls where the SubK feeds the arg1 slot. The arm
+  rewriting happens in the existing `OpCall` switch arm: if the
+  vid is in `fuseCallSub1`, emit the appropriate Sub1 op and
+  suppress the standalone decrement.
+
+**Bench (iteration 5, 2026-05-18, macOS arm64).**
+
+Go-microbench head-to-head (`bg_binary_trees_pair_test.go`,
+Apple M4):
+
+| Bench (D) | iter 4 vm2 ns/op | iter 5 vm2 ns/op | go ns/op | iter 5 vm2 / go |
+|---|---:|---:|---:|---:|
+| D=8 (`Reused`)        |   8300 |   7596 |  6920 | **1.10x** ✓ |
+| D=12 (`DeepReused`)   | 131500 | 130764 | 109607 | **1.19x** ✓ |
+
+The microbench gains are modest because the warm Go baseline also
+allocates per node (its tree builder uses `&Tree{...}` per node);
+the vm2 pair arena already amortizes that. The kernel ratio is
+inside the gate, and the dispatch saving is what survives at the
+full-program level.
+
+Single-shot crosslang harness, best of 11 reps:
+
+| Program | N | iter 4 vm2 / Go | iter 5 vm2 / Go | Gate |
+|---|---:|---:|---:|:---:|
+| `bg/binary_trees` |  8 | 1.87x | **1.88x** | ✓ inside |
+| `bg/binary_trees` | 10 | 2.57x | **2.10x** | (close: 5% over) |
+
+`binary_trees` N=8 stays inside the gate. N=10 closes from 2.57x
+to 2.10x: the per-tick dispatch budget drops by the predicted ~30%
+of dispatch overhead, but the outer driver's four-arg tail call
+plus per-tick `OpCallA1 + OpCallA2` to `make_tree` / `check_tree`
+still dominate, so the residual margin (~5% over the gate) is a
+candidate for iter 6 (fused tick body: `make_tree(d) +
+check_tree(_, d) + add + i+1` collapsed into a single arm, or a
+specialized driver that recognises the outer-loop shape).
+
 ### 6.x (template for future iterations)
 
 Each new program lands in 6.x with the same theory / mechanism /


### PR DESCRIPTION
## Summary

- three new fused ops collapse `OpSubI64K(_, 1)` + self-recursive call into one dispatch: `OpCallSelfA1Sub1`, `OpPairFstCallSelfA2Sub1`, `OpPairSndCallSelfA2Sub1`
- `Function.BranchEntryIP` records the leaf-shape callee's pc=2 entry; specialized call arms set the new frame's ip to `BranchEntryIP` (skipping the redundant pc=0 guard) when the inline leaf check fell through
- spec updated in `website/docs/mep/mep-0039.md` §6.10 iter 5

binary_trees N=10 crosslang vs Go: 2.57x → 2.10x. N=8 stays inside gate at 1.88x.

Tracking: #21649

## Test plan
- [x] `go test ./runtime/vm2/... ./compiler2/...`
- [x] `go test -run x -bench '...PairKernel...' -benchtime=3s ./runtime/vm2/bench/`
- [x] `go run ./bench/crosslang -programs bg/binary_trees -langs vm2,go -repeat 11`
- [ ] Linux re-bench on server2