### PR TITLE
mep-0039 §6.10: binary_trees iteration 6 (call+return fusion)

### DIFF
--- a/compiler2/emit/emit.go
+++ b/compiler2/emit/emit.go
@@ -1339,6 +1339,37 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 		}
 	}
 
+	// Peephole: fuse [SubK self-call] + [fused-return] when adjacent and
+	// the call's destination feeds the return op's right operand. The
+	// fused op short-circuits the leaf-shortcut hit path through one
+	// dispatch instead of two; on miss it falls through to the original
+	// return op which stays at code[i+1]. MEP-39 §6.10 iter 6.
+	for i := 0; i+1 < len(code); i++ {
+		call := code[i]
+		ret := code[i+1]
+		switch call.Op {
+		case vm2.OpCallSelfA1Sub1:
+			if ret.Op == vm2.OpReturnNewPair && ret.C == call.A {
+				code[i] = vm2.Instr{
+					Op: vm2.OpCallSelfA1Sub1RetNewPair,
+					A:  call.A,
+					B:  ret.B,
+					C:  call.C,
+				}
+			}
+		case vm2.OpPairSndCallSelfA2Sub1:
+			if ret.Op == vm2.OpReturnAddSum && ret.A == 1 && ret.C == call.A {
+				code[i] = vm2.Instr{
+					Op: vm2.OpPairSndCallSelfA2Sub1RetAddSum,
+					A:  call.A,
+					B:  ret.B,
+					C:  call.C,
+					D:  call.D,
+				}
+			}
+		}
+	}
+
 	return &vm2.Function{
 		Name:              f.Name,
 		NumParams:         np,

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -629,6 +629,107 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 			fr = &vm.Frames[len(vm.Frames)-1]
 			regs = vm.Stack[newBase:]
 			ip = int(callee.BranchEntryIP)
+		case OpCallSelfA1Sub1RetNewPair:
+			// Fused OpCallSelfA1Sub1 + OpReturnNewPair. The next
+			// instruction in the function is the standalone OpReturnNewPair
+			// that handles the miss path; the hit path pops the parent
+			// frame directly here, skipping that dispatch.
+			callee := fr.Fn
+			argv := regs[ins.C].Int() - 1
+			if lk := callee.LeafKind; lk != LeafKindNone && callee.LeafGuardReg == 0 && argv == int64(callee.LeafGuardK) {
+				var right Cell
+				if lk == LeafKindReturnI64K {
+					right = CInt(int64(callee.LeafReturnA))
+				} else {
+					right = vm.newPair(CInt(int64(callee.LeafReturnB)), CInt(int64(callee.LeafReturnC)))
+				}
+				ret = vm.newPair(regs[ins.B], right)
+				retReg := fr.RetReg
+				top := len(vm.Frames) - 1
+				poppedBase := fr.RegsBase
+				if fr.Fn.HasContainerSlots {
+					clear(vm.Stack[poppedBase:])
+				}
+				vm.Stack = vm.Stack[:poppedBase]
+				vm.Frames = vm.Frames[:top]
+				if top <= target {
+					return ret, nil
+				}
+				fr = &vm.Frames[top-1]
+				code = fr.Fn.Code
+				regs = vm.Stack[fr.RegsBase:]
+				consts = fr.Fn.Consts
+				ip = fr.IP
+				regs[retReg] = ret
+				break
+			}
+			fr.IP = ip
+			base := len(vm.Stack)
+			need := base + callee.NumRegs
+			if cap(vm.Stack) >= need {
+				vm.Stack = vm.Stack[:need]
+				vm.Stack[base] = CInt(argv)
+				vm.Frames = append(vm.Frames, frame{Fn: callee, RegsBase: base, RetReg: ins.A})
+				fr = &vm.Frames[len(vm.Frames)-1]
+				regs = vm.Stack[base:]
+				ip = int(callee.BranchEntryIP)
+				break
+			}
+			a0 := CInt(argv)
+			_, newBase := vm.pushFrame(callee, ins.A)
+			vm.Stack[newBase] = a0
+			fr = &vm.Frames[len(vm.Frames)-1]
+			regs = vm.Stack[newBase:]
+			ip = int(callee.BranchEntryIP)
+		case OpPairSndCallSelfA2Sub1RetAddSum:
+			// Fused OpPairSndCallSelfA2Sub1 + OpReturnAddSum K=1. Hit
+			// path pops parent frame directly with ret = 1 + lcnt + rcnt;
+			// miss path falls through to the standalone OpReturnAddSum
+			// that follows in the emitted code.
+			callee := fr.Fn
+			argv := regs[ins.D].Int() - 1
+			if lk := callee.LeafKind; lk != LeafKindNone && callee.LeafGuardReg == 1 && argv == int64(callee.LeafGuardK) && lk == LeafKindReturnI64K {
+				ret = CInt(1 + regs[ins.B].Int() + int64(callee.LeafReturnA))
+				retReg := fr.RetReg
+				top := len(vm.Frames) - 1
+				poppedBase := fr.RegsBase
+				if fr.Fn.HasContainerSlots {
+					clear(vm.Stack[poppedBase:])
+				}
+				vm.Stack = vm.Stack[:poppedBase]
+				vm.Frames = vm.Frames[:top]
+				if top <= target {
+					return ret, nil
+				}
+				fr = &vm.Frames[top-1]
+				code = fr.Fn.Code
+				regs = vm.Stack[fr.RegsBase:]
+				consts = fr.Fn.Consts
+				ip = fr.IP
+				regs[retReg] = ret
+				break
+			}
+			fr.IP = ip
+			base := len(vm.Stack)
+			need := base + callee.NumRegs
+			if cap(vm.Stack) >= need {
+				vm.Stack = vm.Stack[:need]
+				vm.Stack[base] = (*vmPair)(regs[ins.C].PtrTo()).b
+				vm.Stack[base+1] = CInt(argv)
+				vm.Frames = append(vm.Frames, frame{Fn: callee, RegsBase: base, RetReg: ins.A})
+				fr = &vm.Frames[len(vm.Frames)-1]
+				regs = vm.Stack[base:]
+				ip = int(callee.BranchEntryIP)
+				break
+			}
+			a0 := (*vmPair)(regs[ins.C].PtrTo()).b
+			a1 := CInt(argv)
+			_, newBase := vm.pushFrame(callee, ins.A)
+			vm.Stack[newBase] = a0
+			vm.Stack[newBase+1] = a1
+			fr = &vm.Frames[len(vm.Frames)-1]
+			regs = vm.Stack[newBase:]
+			ip = int(callee.BranchEntryIP)
 		case OpTailCallSelf:
 			ip = 0
 		case OpTailCallSelfA3:

--- a/runtime/vm2/ops.go
+++ b/runtime/vm2/ops.go
@@ -358,4 +358,22 @@ const (
 	OpCallSelfA1Sub1
 	OpPairFstCallSelfA2Sub1
 	OpPairSndCallSelfA2Sub1
+
+	// Call+Return fused ops (MEP-39 §6.10 iter 6). Each fuses a
+	// SubK+self-call op with the immediately following Return-superop.
+	// Emit fires when the LAST call before a fused-return op feeds that
+	// return op's operand: that call site can pop the parent frame
+	// directly on a leaf-shortcut hit (saving one OpReturn* dispatch)
+	// or fall through to the standalone Return-superop on a miss.
+	//
+	// OpCallSelfA1Sub1RetNewPair: fuse [OpCallSelfA1Sub1 right, src;
+	//   OpReturnNewPair B=left, C=right]. A=rightReg (miss-path slot),
+	//   B=leftReg (other newPair input), C=srcReg (arg0 = regs[C] - 1).
+	//
+	// OpPairSndCallSelfA2Sub1RetAddSum: fuse [OpPairSndCallSelfA2Sub1
+	//   right, pair, depth; OpReturnAddSum K=1, B=left, C=right].
+	//   A=rightReg (miss-path slot), B=leftReg (other addSum input),
+	//   C=pairReg, D=depthReg (arg1 = regs[D] - 1). K is fixed to 1.
+	OpCallSelfA1Sub1RetNewPair
+	OpPairSndCallSelfA2Sub1RetAddSum
 )

--- a/website/docs/mep/mep-0039.md
+++ b/website/docs/mep/mep-0039.md
@@ -2253,6 +2253,106 @@ candidate for iter 6 (fused tick body: `make_tree(d) +
 check_tree(_, d) + add + i+1` collapsed into a single arm, or a
 specialized driver that recognises the outer-loop shape).
 
+#### 6.10 iteration 6: call + return fusion
+
+**Theory.** Iter 5 fused the *prologue* of each recursion (SubK
+into the call, plus the leaf-shape callee's pc=0 guard re-test).
+What remained was the *epilogue*: every non-leaf recursion ends
+with `OpReturnNewPair` (inside `make_tree`) or `OpReturnAddSum`
+(inside `check_tree`), each of which is one dispatch that runs
+exactly once per recursion. Per binary-tree node the dispatch
+count is now:
+
+- 2 `OpCallSelfA1Sub1` (left + right `make_tree(d-1)`), each followed by
+  one `OpReturnNewPair`,
+- 2 `OpPairSndCallSelfA2Sub1` (left + right `check_tree(_, d-1)`), each
+  followed by one `OpReturnAddSum K=1`.
+
+When the recursive call's destination register is the same register
+the return op reads as its right-hand operand (i.e. the call result
+feeds the return directly), the call + return is a fusible pair:
+the leaf-shortcut hit path can build the return cell from the leaf
+constant and pop the parent frame in one step instead of two
+dispatches. Per non-leaf parent of a leaf, that fuses two dispatches
+into one. At D=10, the leaf-shortcut hits at d=1 (the only depth that
+matches the guard `d == 0`), so the saving is approximately one
+dispatch per d=1 parent × 2 calls (left+right) per parent × 2 funcs
+(make_tree + check_tree). For an N=10 outer-driver run, that is
+roughly 2 × 2^9 × 2 × 2 = 4096 dispatches per outer tick, ~4M
+dispatches per run at ~3-4 ns each: 12-16 ms shaved.
+
+**Mechanism.**
+
+```
+# iter 5 (per non-leaf make_tree(d) right-child call sequence):
+OpCallSelfA1Sub1   right, _, depth   # dispatch 1: leaf-shortcut hit
+                                     #   sets regs[right] = LeafReturnA
+OpReturnNewPair    _, left, right    # dispatch 2: pop frame, return
+                                     #   newPair(regs[left], regs[right])
+
+# iter 6:
+OpCallSelfA1Sub1RetNewPair right, left, depth  # dispatch 1, hit:
+                                               #   computes leafReturn,
+                                               #   builds newPair,
+                                               #   pops frame, returns.
+# (the standalone OpReturnNewPair stays at code[i+1] for the miss path:
+#  the call arm only pops on a hit; on miss it pushes the child frame
+#  and dispatch lands on the standalone OpReturnNewPair when the child
+#  returns.)
+```
+
+The same shape applies to `check_tree`: the d=1 call is the only
+one that triggers the leaf-shortcut, and its return immediately
+combines `1 + lcnt + rcnt` via `OpReturnAddSum`. The fused
+`OpPairSndCallSelfA2Sub1RetAddSum` runs that addition inline when
+the leaf-shortcut hits, then pops.
+
+**Implementation.**
+
+- `runtime/vm2/ops.go`: two new opcodes
+  (`OpCallSelfA1Sub1RetNewPair`, `OpPairSndCallSelfA2Sub1RetAddSum`).
+  Each carries the union of its constituent ops' operands.
+- `runtime/vm2/eval.go`: two new arms. The hit path computes the
+  leaf return inline (a CInt for `LeafKindReturnI64K`, or a
+  `vm.newPair(...)` for `LeafKindReturnNewPairKK`), wraps it as
+  required by the fused return (newPair or 1+sum), pops the parent
+  frame, and writes the result into the parent's return register.
+  The miss path pushes the child frame exactly the way the non-fused
+  Sub1 arm did, with `ip = int(callee.BranchEntryIP)`; when the
+  child returns it lands on the standalone return op that the
+  peephole left in place at `code[i+1]`.
+- `compiler2/emit/emit.go`: a peephole pass at the end of
+  `compileFunction` walks adjacent `(call, return)` pairs and
+  rewrites the call when (a) the call is one of the fusible Sub1
+  ops, (b) the return op matches (`OpReturnNewPair` for
+  `OpCallSelfA1Sub1`; `OpReturnAddSum` with `K == 1` for
+  `OpPairSndCallSelfA2Sub1`), and (c) the call's destination
+  register matches the return op's right-operand register
+  (`ret.C == call.A`). The standalone return op is left in place
+  to handle the miss path.
+
+**Bench (iteration 6, 2026-05-18, macOS arm64).**
+
+Single-shot crosslang harness, best of 21 reps:
+
+| Program | N | iter 5 vm2 / Go | iter 6 vm2 / Go | Gate |
+|---|---:|---:|---:|:---:|
+| `bg/binary_trees` |  8 | 1.88x | **1.83x** | ✓ inside |
+| `bg/binary_trees` | 10 | 2.10x | **1.87x** | ✓ crossed |
+
+N=10 crosses the 2.0x gate. The crosslang ratio drops 0.23x at
+N=10 (from 2.10x to 1.87x), well above the ~5-7% the dispatch
+math predicted because the fused op also keeps the cell flowing
+in registers (no store-to-`regs[right]` then load-on-newPair
+round-trip) and the parent frame's `regs[ins.A]` slot is never
+written on the hit path.
+
+After iter 6 the residual binary_trees cost is dominated by the
+pair allocator (`vm.newPair`, 11-13% of warm cycles) and the
+outer driver's per-tick `OpCallA1 + OpCallA2` sequence; both are
+inside the gate today, so further work is deferred until another
+program forces the issue.
+
 ### 6.x (template for future iterations)
 
 Each new program lands in 6.x with the same theory / mechanism /


### PR DESCRIPTION
## Summary

- fuse `OpCallSelfA1Sub1 + OpReturnNewPair` and `OpPairSndCallSelfA2Sub1 + OpReturnAddSum(K=1)` into two new single-dispatch arms so the leaf-shortcut hit path builds the return cell and pops the parent frame in one step.
- emit peephole rewrites the call when the call's destination feeds the return op's right operand; the standalone return op stays at `code[i+1]` to handle the miss path.
- `binary_trees` N=10 crosslang vs Go drops from 2.10x to 1.87x on macOS arm64, crossing the MEP-37 2x gate. N=8 stays inside at 1.83x.

Tracking: #21651

## Test plan

- [x] `go test ./runtime/vm2/... ./compiler2/...`
- [x] `go run ./bench/crosslang -programs bg/binary_trees -langs vm2,go -repeat 21` confirms N=8 1.83x and N=10 1.87x
- [ ] Linux re-bench on server2 (off-peak retry, tracked separately under #21651)