### PR TITLE
mep-0039 §6.11: disable hard-coded BG kernel super-ops

### DIFF
--- a/compiler2/corpus/bg_k_nucleotide_scaled.go
+++ b/compiler2/corpus/bg_k_nucleotide_scaled.go
@@ -6,65 +6,153 @@ import "mochi/compiler2/ir"
 // kernel. The canonical BG k_nucleotide program reads the fasta
 // output (a DNA byte stream) and counts k-length substrings into a
 // hash map, reporting counts for k=1, k=2, and a handful of specific
-// k=3..18 mers ("GGT", "GGTA", ...). The cross-lang harness reduces
-// that to the load-bearing inner kernel: an LCG random stream (same
-// parameters as fasta §6.6) drives a HOMO_SAPIENS cumprob lookup
-// that returns a 2-bit code (0/1/2/3 for a/c/g/t); the kernel
-// maintains 1-mer and 2-mer counts indexed in [0, 20), then folds
-// the counts into a deterministic i64 hash so the cross-lang
-// harness compares a single integer across every peer.
+// k=3..18 mers ("GGT", "GGTA", ...). Iteration 1 of the cross-lang
+// harness reduces that to the load-bearing inner kernel: an LCG
+// random stream (same parameters as fasta §6.6) drives a HOMO_SAPIENS
+// cumprob lookup that returns a 2-bit code (0/1/2/3 for a/c/g/t);
+// the kernel maintains 1-mer and 2-mer counts in a single int-keyed
+// map, then folds the counts into a deterministic i64 hash so the
+// cross-lang harness compares a single integer across every peer.
 //
-// Slot layout in the counts array (iteration 2):
+// Key layout in the map:
 //
-//	idx  0..3   = 1-mer counts indexed by code
-//	idx  4..19  = 2-mer counts indexed by `4 + prev*4 + cur`
+//	keys  0..3   = 1-mer counts indexed by code
+//	keys  4..19  = 2-mer counts indexed by `4 + prev*4 + cur`
 //
-// Iteration 2 (MEP-39 §6.7) collapses the entire per-iter dispatch
-// chain (LCG + cumprob lookup + two MapGet/Set pairs) into a single
-// super-op OpKNucleotideRun, and swaps the rolling map for a 20-slot
-// TI64Array. Both changes are spec-named: §6.7 mechanism 3 (bounded
-// i64 array) eliminates the map probe cost, and the bulk super-op
-// drops the per-iter dispatch count from ~12 to 1, which is the
-// shape iter 7 used to bring reverse_complement under gate.
+// Iteration 1 ignores k=3..18 (the canonical specific-mer table);
+// MEP-39 §6.7 names the iteration 2 mechanism that extends the map
+// to k=3 and folds the byte→code conversion through the canonical
+// 97/99/103/116 byte alphabet (lookup currently returns the code
+// directly to keep iteration 1 focused on the map-increment cost,
+// which is the load-bearing measurement for this kernel).
 //
-// Rolling i64 hash (over indices 0..19):
+// LCG (matches fasta):
 //
-//	h = (h * 1009 + counts[idx]) % 2147483647
+//	seed = (seed * 3877 + 29573) % 139968    // canonical BG params
+//	prob = float64(seed) / 139968.0
 //
-// Two IR functions:
+// HOMO_SAPIENS cumprob → 2-bit code:
 //
-//	main()                    = allocate counts, KNucleotideRun(counts,n), call summ
-//	summ(arr, key, acc, end)  = TI64 tail-rec; walks 0..end, rolls hash
+//	prob < 0.3029549426680  → 0 ('a')
+//	prob < 0.5009432431601  → 1 ('c')
+//	prob < 0.6984905497992  → 2 ('g')
+//	otherwise               → 3 ('t')
+//
+// Rolling i64 hash (over keys 0..19):
+//
+//	h = (h * 1009 + count[key]) % 2147483647
+//
+// Four IR functions:
+//
+//	main()                    = bootstrap iter 0 inline, call loop, call summ
+//	loop(seed, m, prev, i, n) = TUnit tail-rec; one LCG step + 1-mer inc + 2-mer inc
+//	summ(m, key, acc, end)    = TI64 tail-rec; walks 0..end, rolls hash
+//	lookup(prob) -> TI64      = 4-way FP cascade returning 0..3
+//
+// The map increments are inlined inside `loop` (no helper call) to
+// keep the per-iter dispatch count tight: each iter dispatches one
+// MapGet + one AddI64 + one MapSet per k, plus the LCG and the
+// lookup call. With CNull().Int() == 0, the missing-key path for
+// integer values is "first inc reads 0, writes 1" without any
+// MapHas guard — no pre-init pass needed.
 func BuildKNucleotide(n int64) *ir.Module {
-	const summIdx = 1
+	const (
+		loopIdx   = 1
+		summIdx   = 2
+		lookupIdx = 3
+	)
 
-	// main(): allocate a 20-slot i64 counts array, drive the entire
-	// k_nucleotide kernel via one super-op, then fold into a hash.
+	// main(): bootstrap iter 0 inline (one LCG step + one 1-mer inc),
+	// then drive the rest of the iterations via `loop`, then summarise.
 	bMain := ir.NewBuilder("main", nil, ir.TI64)
-	counts := bMain.NewI64Array(bMain.ConstI64(20))
-	bMain.KNucleotideRun(counts, bMain.ConstI64(n))
-	h := bMain.Call(summIdx, ir.TI64, counts, bMain.ConstI64(0), bMain.ConstI64(0), bMain.ConstI64(20))
+	m := bMain.NewMap()
+	// LCG step 0: s0 = (42*3877 + 29573) % 139968
+	seed0 := bMain.ConstI64(42)
+	mul0 := bMain.MulI64(seed0, bMain.ConstI64(3877))
+	add0 := bMain.AddI64(mul0, bMain.ConstI64(29573))
+	s0 := bMain.ModI64(add0, bMain.ConstI64(139968))
+	prob0 := bMain.DivF64(bMain.I64ToF64(s0), bMain.ConstF64(139968.0))
+	code0 := bMain.Call(lookupIdx, ir.TI64, prob0)
+	// m[code0] += 1   (missing key reads as 0)
+	v0 := bMain.MapGet(m, code0, ir.TI64)
+	bMain.MapSet(m, code0, bMain.AddI64(v0, bMain.ConstI64(1)))
+	// drive remaining N-1 iters via loop, starting at i=1, prev=code0
+	bMain.Call(loopIdx, ir.TUnit, s0, m, code0, bMain.ConstI64(1), bMain.ConstI64(n))
+	// summarise: walk 0..20, fold counts into rolling i64 hash
+	h := bMain.Call(summIdx, ir.TI64, m, bMain.ConstI64(0), bMain.ConstI64(0), bMain.ConstI64(20))
 	bMain.Ret(h)
 
-	// summ(arr, key, acc, end) -> TI64 tail-rec. Walks key..end and
-	// folds arr[k] into acc via `(acc*1009 + c) % 2147483647`.
+	// loop(seed, m, prev, i, n) -> TUnit tail-rec.
+	bL := ir.NewBuilder("loop",
+		[]ir.Type{ir.TI64, ir.TMap, ir.TI64, ir.TI64, ir.TI64}, ir.TUnit)
+	pSeed, pM, pPrev, pI, pN := bL.Param(0), bL.Param(1), bL.Param(2), bL.Param(3), bL.Param(4)
+	lDone := bL.NewBlock()
+	lStep := bL.NewBlock()
+	bL.CondBr(bL.LessI64(pI, pN), lStep, lDone)
+	bL.SwitchTo(lDone)
+	bL.Ret(-1)
+	bL.SwitchTo(lStep)
+	// LCG step
+	mul := bL.MulI64(pSeed, bL.ConstI64(3877))
+	add := bL.AddI64(mul, bL.ConstI64(29573))
+	newSeed := bL.ModI64(add, bL.ConstI64(139968))
+	// prob + lookup
+	prob := bL.DivF64(bL.I64ToF64(newSeed), bL.ConstF64(139968.0))
+	code := bL.Call(lookupIdx, ir.TI64, prob)
+	// 1-mer increment: m[code] += 1
+	v1 := bL.MapGet(pM, code, ir.TI64)
+	bL.MapSet(pM, code, bL.AddI64(v1, bL.ConstI64(1)))
+	// 2-mer increment: m[4 + prev*4 + code] += 1
+	key2 := bL.AddI64(bL.ConstI64(4), bL.AddI64(bL.MulI64(pPrev, bL.ConstI64(4)), code))
+	v2 := bL.MapGet(pM, key2, ir.TI64)
+	bL.MapSet(pM, key2, bL.AddI64(v2, bL.ConstI64(1)))
+	// recurse with code becoming the new prev
+	ni := bL.AddI64(pI, bL.ConstI64(1))
+	bL.Call(loopIdx, ir.TUnit, newSeed, pM, code, ni, pN)
+	bL.Ret(-1)
+
+	// summ(m, key, acc, end) -> TI64 tail-rec. Walks key..end and
+	// folds m[k] into acc via `(acc*1009 + c) % 2147483647`.
 	bS := ir.NewBuilder("summ",
-		[]ir.Type{ir.TI64Array, ir.TI64, ir.TI64, ir.TI64}, ir.TI64)
-	sArr, sK, sAcc, sEnd := bS.Param(0), bS.Param(1), bS.Param(2), bS.Param(3)
+		[]ir.Type{ir.TMap, ir.TI64, ir.TI64, ir.TI64}, ir.TI64)
+	sM, sK, sAcc, sEnd := bS.Param(0), bS.Param(1), bS.Param(2), bS.Param(3)
 	sDone := bS.NewBlock()
 	sStep := bS.NewBlock()
 	bS.CondBr(bS.LessI64(sK, sEnd), sStep, sDone)
 	bS.SwitchTo(sDone)
 	bS.Ret(sAcc)
 	bS.SwitchTo(sStep)
-	c := bS.I64ArrGet(sArr, sK)
+	c := bS.MapGet(sM, sK, ir.TI64)
 	newAcc := bS.ModI64(bS.AddI64(bS.MulI64(sAcc, bS.ConstI64(1009)), c), bS.ConstI64(2147483647))
 	nk := bS.AddI64(sK, bS.ConstI64(1))
-	rec := bS.Call(summIdx, ir.TI64, sArr, nk, newAcc, sEnd)
+	rec := bS.Call(summIdx, ir.TI64, sM, nk, newAcc, sEnd)
 	bS.Ret(rec)
 
+	// lookup(prob TF64) -> TI64 in {0,1,2,3}.
+	bLU := ir.NewBuilder("lookup", []ir.Type{ir.TF64}, ir.TI64)
+	pP := bLU.Param(0)
+	luA := bLU.NewBlock() // return 0 ('a')
+	luChkC := bLU.NewBlock()
+	luC := bLU.NewBlock() // return 1 ('c')
+	luChkG := bLU.NewBlock()
+	luG := bLU.NewBlock() // return 2 ('g')
+	luT := bLU.NewBlock() // return 3 ('t')
+	bLU.CondBr(bLU.LessF64(pP, bLU.ConstF64(0.3029549426680)), luA, luChkC)
+	bLU.SwitchTo(luA)
+	bLU.Ret(bLU.ConstI64(0))
+	bLU.SwitchTo(luChkC)
+	bLU.CondBr(bLU.LessF64(pP, bLU.ConstF64(0.5009432431601)), luC, luChkG)
+	bLU.SwitchTo(luC)
+	bLU.Ret(bLU.ConstI64(1))
+	bLU.SwitchTo(luChkG)
+	bLU.CondBr(bLU.LessF64(pP, bLU.ConstF64(0.6984905497992)), luG, luT)
+	bLU.SwitchTo(luG)
+	bLU.Ret(bLU.ConstI64(2))
+	bLU.SwitchTo(luT)
+	bLU.Ret(bLU.ConstI64(3))
+
 	return &ir.Module{Funcs: []*ir.Function{
-		bMain.Function(), bS.Function(),
+		bMain.Function(), bL.Function(), bS.Function(), bLU.Function(),
 	}, Main: 0}
 }
 

--- a/compiler2/corpus/bg_mandelbrot.go
+++ b/compiler2/corpus/bg_mandelbrot.go
@@ -3,9 +3,7 @@ package corpus
 import "mochi/compiler2/ir"
 
 // BuildMandelbrotKernel builds the mandelbrot BG kernel as described in
-// MEP-37 §3.2 (FMA in the iteration) / §3.3 (U8 bitmap output), updated
-// for MEP-39 §6.2 iter 2 to dispatch the entire per-pixel iteration
-// through a single OpMandelbrotKernel super-op.
+// MEP-37 §3.2 (FMA in the iteration) / §3.3 (U8 bitmap output).
 //
 // For each pixel (row, col) of a w x h grid, the kernel maps it to the
 // complex plane (cx, cy) in [-2, 1] x [-1, 1] and iterates
@@ -17,27 +15,116 @@ import "mochi/compiler2/ir"
 // returns the sum of all escape counts so a Go peer can verify the
 // kernel bit-for-bit.
 //
-// Iteration 2 (MEP-39 §6.2) collapses what was a four-IR-function
-// recursive descent (rowLoop -> colLoop -> iterate, plus sumU8) into
-// one OpMandelbrotKernel dispatch. The escape-count summation stays
-// as a tail-recursive helper because that loop runs in O(w*h) and is
-// well inside the dispatch budget; only the per-pixel inner loop
-// (w*h*maxIter total iterations) is hot enough to merit a super-op.
+// The inner iteration is FMA-shaped on the imaginary axis: the spec
+// calls out zi_{n+1} = 2*zr*zi + cy as a one-rounding FMA, and the
+// builder emits OpFmaF64 directly for that step. The real axis stays as
+// the naive (zr*zr - zi*zi) + cx form because that pattern is a SUB+ADD
+// rather than a MUL+ADD; FMA-folding it would need an FMS opcode we
+// have not added yet.
+//
+// All loops are written as tail-recursive helpers so opt.TailCall folds
+// each into OpTailCallSelf. The recursive shape (Call; Ret r) is
+// preserved for any helper whose return value participates in the
+// caller's result; the same constraint we hit in n_body's energy
+// accumulator.
 func BuildMandelbrotKernel(w, h, maxIter int64) *ir.Module {
-	const sumIdx = 1
+	const (
+		rowIdx  = 1
+		colIdx  = 2
+		iterIdx = 3
+		sumIdx  = 4
+	)
 
-	// main: out = newU8Array(w*h); MandelbrotKernel(out, w, h, mi);
-	// return sumU8(out, 0, w*h, 0).
+	// main: out = newU8Array(w*h); rowLoop(out, 0, ...); return sum(out).
 	bMain := ir.NewBuilder("main", nil, ir.TI64)
 	wv := bMain.ConstI64(w)
 	hv := bMain.ConstI64(h)
 	miv := bMain.ConstI64(maxIter)
 	n := bMain.MulI64(wv, hv)
 	out := bMain.NewU8Array(n)
-	bMain.MandelbrotKernel(out, wv, hv, miv)
 	zero := bMain.ConstI64(0)
+	bMain.Call(rowIdx, ir.TUnit, out, zero, wv, hv, miv)
 	sum := bMain.Call(sumIdx, ir.TI64, out, zero, n, zero)
 	bMain.Ret(sum)
+
+	// rowLoop(out, row, w, h, mi): if row >= h return; colLoop; recurse row+1.
+	bR := ir.NewBuilder("rowLoop",
+		[]ir.Type{ir.TU8Array, ir.TI64, ir.TI64, ir.TI64, ir.TI64}, ir.TUnit)
+	rOut, rRow, rW, rH, rMi := bR.Param(0), bR.Param(1), bR.Param(2), bR.Param(3), bR.Param(4)
+	rDone := bR.NewBlock()
+	rStep := bR.NewBlock()
+	bR.CondBr(bR.LessI64(rRow, rH), rStep, rDone)
+	bR.SwitchTo(rDone)
+	bR.Ret(-1)
+	bR.SwitchTo(rStep)
+	bR.Call(colIdx, ir.TUnit, rOut, rRow, bR.ConstI64(0), rW, rH, rMi)
+	bR.Call(rowIdx, ir.TUnit, rOut,
+		bR.AddI64(rRow, bR.ConstI64(1)), rW, rH, rMi)
+	bR.Ret(-1)
+
+	// colLoop(out, row, col, w, h, mi):
+	//   if col >= w return
+	//   cx = col/w * 3.0 - 2.0
+	//   cy = row/h * 2.0 - 1.0
+	//   n  = iterate(0, 0, cx, cy, 0, mi)
+	//   out[row*w + col] = n
+	//   recurse col+1
+	bC := ir.NewBuilder("colLoop",
+		[]ir.Type{ir.TU8Array, ir.TI64, ir.TI64, ir.TI64, ir.TI64, ir.TI64}, ir.TUnit)
+	cOut, cRow, cCol, cW, cH, cMi := bC.Param(0), bC.Param(1), bC.Param(2), bC.Param(3), bC.Param(4), bC.Param(5)
+	cDone := bC.NewBlock()
+	cStep := bC.NewBlock()
+	bC.CondBr(bC.LessI64(cCol, cW), cStep, cDone)
+	bC.SwitchTo(cDone)
+	bC.Ret(-1)
+	bC.SwitchTo(cStep)
+	colF := bC.I64ToF64(cCol)
+	wF := bC.I64ToF64(cW)
+	cx := bC.SubF64(bC.MulF64(bC.DivF64(colF, wF), bC.ConstF64(3)),
+		bC.ConstF64(2))
+	rowF := bC.I64ToF64(cRow)
+	hF := bC.I64ToF64(cH)
+	cy := bC.SubF64(bC.MulF64(bC.DivF64(rowF, hF), bC.ConstF64(2)),
+		bC.ConstF64(1))
+	iters := bC.Call(iterIdx, ir.TI64,
+		bC.ConstF64(0), bC.ConstF64(0), cx, cy, bC.ConstI64(0), cMi)
+	idx := bC.AddI64(bC.MulI64(cRow, cW), cCol)
+	bC.U8ArrSet(cOut, idx, iters)
+	bC.Call(colIdx, ir.TUnit, cOut, cRow,
+		bC.AddI64(cCol, bC.ConstI64(1)), cW, cH, cMi)
+	bC.Ret(-1)
+
+	// iterate(zr, zi, cx, cy, i, mi):
+	//   if i >= mi return mi
+	//   r2 = zr*zr; i2 = zi*zi
+	//   if r2 + i2 > 4 return i
+	//   nzi = FMA(2*zr, zi, cy)
+	//   nzr = (r2 - i2) + cx
+	//   tail-call iterate(nzr, nzi, cx, cy, i+1, mi)
+	bI := ir.NewBuilder("iterate",
+		[]ir.Type{ir.TF64, ir.TF64, ir.TF64, ir.TF64, ir.TI64, ir.TI64}, ir.TI64)
+	iZr, iZi, iCx, iCy, iI, iMi := bI.Param(0), bI.Param(1), bI.Param(2), bI.Param(3), bI.Param(4), bI.Param(5)
+	iMax := bI.NewBlock()
+	iCont := bI.NewBlock()
+	bI.CondBr(bI.LessI64(iI, iMi), iCont, iMax)
+	bI.SwitchTo(iMax)
+	bI.Ret(iMi)
+	bI.SwitchTo(iCont)
+	r2 := bI.MulF64(iZr, iZr)
+	i2 := bI.MulF64(iZi, iZi)
+	mag := bI.AddF64(r2, i2)
+	iEsc := bI.NewBlock()
+	iLoop := bI.NewBlock()
+	bI.CondBr(bI.LessEqF64(mag, bI.ConstF64(4)), iLoop, iEsc)
+	bI.SwitchTo(iEsc)
+	bI.Ret(iI)
+	bI.SwitchTo(iLoop)
+	twoZr := bI.MulF64(bI.ConstF64(2), iZr)
+	nzi := bI.FmaF64(twoZr, iZi, iCy)
+	nzr := bI.AddF64(bI.SubF64(r2, i2), iCx)
+	rec := bI.Call(iterIdx, ir.TI64,
+		nzr, nzi, iCx, iCy, bI.AddI64(iI, bI.ConstI64(1)), iMi)
+	bI.Ret(rec)
 
 	// sumU8(out, i, n, acc): if i >= n return acc; acc += out[i]; recurse.
 	bS := ir.NewBuilder("sumU8",
@@ -56,6 +143,7 @@ func BuildMandelbrotKernel(w, h, maxIter int64) *ir.Module {
 	bS.Ret(sr)
 
 	return &ir.Module{Funcs: []*ir.Function{
-		bMain.Function(), bS.Function(),
+		bMain.Function(), bR.Function(), bC.Function(),
+		bI.Function(), bS.Function(),
 	}, Main: 0}
 }

--- a/compiler2/corpus/bg_spectral_norm_scaled.go
+++ b/compiler2/corpus/bg_spectral_norm_scaled.go
@@ -8,18 +8,17 @@ import (
 
 // BuildSpectralNorm builds the canonical Benchmarks Game spectral_norm
 // program as the scaled cross-lang companion to BuildSpectralNormKernel.
-// Iteration 2 (MEP-39 §6.4) collapses the entire computation into a
-// single OpSpectralNormKernel super-op: the per-element matrix-vector
-// dispatch chain that dominated iter 1 (~100 dispatches per (i, j)
-// pair across 10 mat-vec products at O(n^2) each) is replaced by one
-// dispatch that runs the whole power method natively in Go and
-// returns the final int64.
+// The kernel form did only one round of Au + At*v with a fixed vector
+// length; this form runs the full BG power method (10 iterations of
+// AtAu) over an N-element vector and returns floor(sqrt(uBu/uu) * 1e9)
+// so the crosslang harness can compare integer values without f64
+// stringification (matching the same idiom as BuildNBody).
 //
 // Matrix A is the Hilbert-like matrix used by every BG submission:
 //
 //	A(i, j) = 1 / ((i + j) * (i + j + 1) / 2 + i + 1)
 //
-// Power-method loop (10 iterations = 5 pairs of AtAu):
+// Power-method loop (10 iterations = 5 pairs):
 //
 //	tmp = A  * u   ; v = At * tmp   // v = AtAu(u)
 //	tmp = A  * v   ; u = At * tmp   // u = AtAu(v)
@@ -31,12 +30,173 @@ import (
 // behaving the same in each runtime, which it does for the magnitudes
 // here).
 func BuildSpectralNorm(n int64) *ir.Module {
+	const (
+		fillIdx     = 1
+		mulAIdx     = 2
+		mulAInner   = 3
+		mulAtIdx    = 4
+		mulAtInner  = 5
+		dotIdx      = 6
+		iterIdx     = 7
+		evalAIdx    = 8
+	)
+
 	bMain := ir.NewBuilder("main", nil, ir.TI64)
 	nv := bMain.ConstI64(n)
-	res := bMain.SpectralNormKernel(nv)
-	bMain.Ret(res)
+	u := bMain.NewF64Array(nv)
+	v := bMain.NewF64Array(nv)
+	tmp := bMain.NewF64Array(nv)
+	zero := bMain.ConstI64(0)
+	bMain.Call(fillIdx, ir.TUnit, u, zero, nv)
+	bMain.Call(iterIdx, ir.TUnit, u, v, tmp, zero, bMain.ConstI64(5), nv)
+	uv := bMain.Call(dotIdx, ir.TF64, u, v, zero, nv, bMain.ConstF64(0))
+	vv := bMain.Call(dotIdx, ir.TF64, v, v, zero, nv, bMain.ConstF64(0))
+	res := bMain.SqrtF64(bMain.DivF64(uv, vv))
+	scaled := bMain.MulF64(res, bMain.ConstF64(1e9))
+	bMain.Ret(bMain.F64ToI64(scaled))
 
-	return &ir.Module{Funcs: []*ir.Function{bMain.Function()}, Main: 0}
+	// fill(u, i, n): u[i] = 1.0; tail recurse.
+	bF := ir.NewBuilder("fill", []ir.Type{ir.TF64Array, ir.TI64, ir.TI64}, ir.TUnit)
+	fu, fi, fn := bF.Param(0), bF.Param(1), bF.Param(2)
+	fDone := bF.NewBlock()
+	fStep := bF.NewBlock()
+	bF.CondBr(bF.LessI64(fi, fn), fStep, fDone)
+	bF.SwitchTo(fDone)
+	bF.Ret(-1)
+	bF.SwitchTo(fStep)
+	bF.F64ArrSet(fu, fi, bF.ConstF64(1))
+	bF.Call(fillIdx, ir.TUnit, fu, bF.AddI64(fi, bF.ConstI64(1)), fn)
+	bF.Ret(-1)
+
+	// mulAv(u, out, i, n): out[i] = sum_j A(i,j) * u[j]; tail recurse.
+	bMA := ir.NewBuilder("mulAv",
+		[]ir.Type{ir.TF64Array, ir.TF64Array, ir.TI64, ir.TI64}, ir.TUnit)
+	mau, maout, mai, man := bMA.Param(0), bMA.Param(1), bMA.Param(2), bMA.Param(3)
+	maDone := bMA.NewBlock()
+	maStep := bMA.NewBlock()
+	bMA.CondBr(bMA.LessI64(mai, man), maStep, maDone)
+	bMA.SwitchTo(maDone)
+	bMA.Ret(-1)
+	bMA.SwitchTo(maStep)
+	inner := bMA.Call(mulAInner, ir.TF64,
+		mau, mai, bMA.ConstI64(0), man, bMA.ConstF64(0))
+	bMA.F64ArrSet(maout, mai, inner)
+	bMA.Call(mulAIdx, ir.TUnit, mau, maout,
+		bMA.AddI64(mai, bMA.ConstI64(1)), man)
+	bMA.Ret(-1)
+
+	// mulAInner(u, i, j, n, acc): acc += A(i,j) * u[j]; tail recurse.
+	bMI := ir.NewBuilder("mulAInner",
+		[]ir.Type{ir.TF64Array, ir.TI64, ir.TI64, ir.TI64, ir.TF64}, ir.TF64)
+	miu, mii, mij, miN, miAcc := bMI.Param(0), bMI.Param(1), bMI.Param(2), bMI.Param(3), bMI.Param(4)
+	miDone := bMI.NewBlock()
+	miStep := bMI.NewBlock()
+	bMI.CondBr(bMI.LessI64(mij, miN), miStep, miDone)
+	bMI.SwitchTo(miDone)
+	bMI.Ret(miAcc)
+	bMI.SwitchTo(miStep)
+	a := bMI.Call(evalAIdx, ir.TF64, mii, mij)
+	uj := bMI.F64ArrGet(miu, mij)
+	prod := bMI.MulF64(a, uj)
+	nacc := bMI.AddF64(miAcc, prod)
+	rmi := bMI.Call(mulAInner, ir.TF64,
+		miu, mii, bMI.AddI64(mij, bMI.ConstI64(1)), miN, nacc)
+	bMI.Ret(rmi)
+
+	// mulAtv(u, out, i, n): out[i] = sum_j A(j,i) * u[j]; tail recurse.
+	bAT := ir.NewBuilder("mulAtv",
+		[]ir.Type{ir.TF64Array, ir.TF64Array, ir.TI64, ir.TI64}, ir.TUnit)
+	atu, atout, ati, atn := bAT.Param(0), bAT.Param(1), bAT.Param(2), bAT.Param(3)
+	atDone := bAT.NewBlock()
+	atStep := bAT.NewBlock()
+	bAT.CondBr(bAT.LessI64(ati, atn), atStep, atDone)
+	bAT.SwitchTo(atDone)
+	bAT.Ret(-1)
+	bAT.SwitchTo(atStep)
+	innerAt := bAT.Call(mulAtInner, ir.TF64,
+		atu, ati, bAT.ConstI64(0), atn, bAT.ConstF64(0))
+	bAT.F64ArrSet(atout, ati, innerAt)
+	bAT.Call(mulAtIdx, ir.TUnit, atu, atout,
+		bAT.AddI64(ati, bAT.ConstI64(1)), atn)
+	bAT.Ret(-1)
+
+	// mulAtInner(u, i, j, n, acc): acc += A(j,i) * u[j]; tail recurse.
+	// Note swapped (j, i) into evalA so this routine uses At rather than A.
+	bATI := ir.NewBuilder("mulAtInner",
+		[]ir.Type{ir.TF64Array, ir.TI64, ir.TI64, ir.TI64, ir.TF64}, ir.TF64)
+	atiu, atii, atij, atin, atiAcc := bATI.Param(0), bATI.Param(1), bATI.Param(2), bATI.Param(3), bATI.Param(4)
+	atiDone := bATI.NewBlock()
+	atiStep := bATI.NewBlock()
+	bATI.CondBr(bATI.LessI64(atij, atin), atiStep, atiDone)
+	bATI.SwitchTo(atiDone)
+	bATI.Ret(atiAcc)
+	bATI.SwitchTo(atiStep)
+	aT := bATI.Call(evalAIdx, ir.TF64, atij, atii)
+	ujT := bATI.F64ArrGet(atiu, atij)
+	prodT := bATI.MulF64(aT, ujT)
+	naccT := bATI.AddF64(atiAcc, prodT)
+	rati := bATI.Call(mulAtInner, ir.TF64,
+		atiu, atii, bATI.AddI64(atij, bATI.ConstI64(1)), atin, naccT)
+	bATI.Ret(rati)
+
+	// dot(u, v, i, n, acc): acc += u[i]*v[i]; tail recurse.
+	bD := ir.NewBuilder("dot",
+		[]ir.Type{ir.TF64Array, ir.TF64Array, ir.TI64, ir.TI64, ir.TF64}, ir.TF64)
+	du, dv, di, dn, dAcc := bD.Param(0), bD.Param(1), bD.Param(2), bD.Param(3), bD.Param(4)
+	dDone := bD.NewBlock()
+	dStep := bD.NewBlock()
+	bD.CondBr(bD.LessI64(di, dn), dStep, dDone)
+	bD.SwitchTo(dDone)
+	bD.Ret(dAcc)
+	bD.SwitchTo(dStep)
+	ui := bD.F64ArrGet(du, di)
+	vi := bD.F64ArrGet(dv, di)
+	p := bD.MulF64(ui, vi)
+	na := bD.AddF64(dAcc, p)
+	rd := bD.Call(dotIdx, ir.TF64, du, dv,
+		bD.AddI64(di, bD.ConstI64(1)), dn, na)
+	bD.Ret(rd)
+
+	// iterLoop(u, v, tmp, k, total, n): each step does one pair of
+	//   tmp = A*u; v = At*tmp     (v = AtAu(u))
+	//   tmp = A*v; u = At*tmp     (u = AtAu(v))
+	// so total=5 produces the canonical BG 10-iteration power method.
+	bI := ir.NewBuilder("iterLoop",
+		[]ir.Type{ir.TF64Array, ir.TF64Array, ir.TF64Array, ir.TI64, ir.TI64, ir.TI64}, ir.TUnit)
+	iu, iv, itmp, ik, itot, inN := bI.Param(0), bI.Param(1), bI.Param(2), bI.Param(3), bI.Param(4), bI.Param(5)
+	iDone := bI.NewBlock()
+	iStep := bI.NewBlock()
+	bI.CondBr(bI.LessI64(ik, itot), iStep, iDone)
+	bI.SwitchTo(iDone)
+	bI.Ret(-1)
+	bI.SwitchTo(iStep)
+	bI.Call(mulAIdx, ir.TUnit, iu, itmp, bI.ConstI64(0), inN)
+	bI.Call(mulAtIdx, ir.TUnit, itmp, iv, bI.ConstI64(0), inN)
+	bI.Call(mulAIdx, ir.TUnit, iv, itmp, bI.ConstI64(0), inN)
+	bI.Call(mulAtIdx, ir.TUnit, itmp, iu, bI.ConstI64(0), inN)
+	bI.Call(iterIdx, ir.TUnit, iu, iv, itmp, bI.AddI64(ik, bI.ConstI64(1)), itot, inN)
+	bI.Ret(-1)
+
+	// eval_A(i, j) = 1 / ((i+j)(i+j+1)/2 + i + 1)
+	bE := ir.NewBuilder("evalA", []ir.Type{ir.TI64, ir.TI64}, ir.TF64)
+	ei, ej := bE.Param(0), bE.Param(1)
+	sum := bE.AddI64(ei, ej)
+	sumP1 := bE.AddI64(sum, bE.ConstI64(1))
+	tri := bE.DivI64(bE.MulI64(sum, sumP1), bE.ConstI64(2))
+	denomI := bE.AddI64(bE.AddI64(tri, ei), bE.ConstI64(1))
+	denomF := bE.I64ToF64(denomI)
+	res2 := bE.DivF64(bE.ConstF64(1), denomF)
+	bE.Ret(res2)
+
+	return &ir.Module{Funcs: []*ir.Function{
+		bMain.Function(),
+		bF.Function(),
+		bMA.Function(), bMI.Function(),
+		bAT.Function(), bATI.Function(),
+		bD.Function(),
+		bI.Function(),
+		bE.Function(),
+	}, Main: 0}
 }
 
 // ExpectSpectralNorm runs the same algorithm in plain Go so the oracle

--- a/compiler2/emit/emit.go
+++ b/compiler2/emit/emit.go
@@ -918,20 +918,25 @@ func compileFunction(f *ir.Function, ra regalloc.Result, selfIdx int) (*vm2.Func
 				emit(vm2.Instr{Op: vm2.OpU8SumI64, A: dst,
 					B: int32(finalReg[ins.Args[0]]),
 					C: int32(finalReg[ins.Args[1]])})
-			case ir.OpKNucleotideRun:
-				emit(vm2.Instr{Op: vm2.OpKNucleotideRun,
-					A: int32(finalReg[ins.Args[0]]),
-					B: int32(finalReg[ins.Args[1]])})
-			case ir.OpMandelbrotKernel:
-				emit(vm2.Instr{Op: vm2.OpMandelbrotKernel,
-					A: int32(finalReg[ins.Args[0]]),
-					B: int32(finalReg[ins.Args[1]]),
-					C: int32(finalReg[ins.Args[2]]),
-					D: int32(finalReg[ins.Args[3]])})
-			case ir.OpSpectralNormKernel:
-				emit(vm2.Instr{Op: vm2.OpSpectralNormKernel,
-					A: dst,
-					B: int32(finalReg[ins.Args[0]])})
+			// MEP-39 §6.11: emit cases for the hard-coded BG kernel
+			// super-ops are disabled. The builder methods that produced
+			// these IR ops are commented out in compiler2/ir/builder.go;
+			// the runtime dispatch arms trap. Kept here as a record:
+			//
+			// case ir.OpKNucleotideRun:
+			// 	emit(vm2.Instr{Op: vm2.OpKNucleotideRun,
+			// 		A: int32(finalReg[ins.Args[0]]),
+			// 		B: int32(finalReg[ins.Args[1]])})
+			// case ir.OpMandelbrotKernel:
+			// 	emit(vm2.Instr{Op: vm2.OpMandelbrotKernel,
+			// 		A: int32(finalReg[ins.Args[0]]),
+			// 		B: int32(finalReg[ins.Args[1]]),
+			// 		C: int32(finalReg[ins.Args[2]]),
+			// 		D: int32(finalReg[ins.Args[3]])})
+			// case ir.OpSpectralNormKernel:
+			// 	emit(vm2.Instr{Op: vm2.OpSpectralNormKernel,
+			// 		A: dst,
+			// 		B: int32(finalReg[ins.Args[0]])})
 			case ir.OpNewPair:
 				if suppress[vid] {
 					break

--- a/compiler2/ir/builder.go
+++ b/compiler2/ir/builder.go
@@ -346,33 +346,25 @@ func (b *Builder) U8SumI64(arr, n ValueID) ValueID {
 	return b.emit(Inst{Op: OpU8SumI64, Type: TI64, Args: []ValueID{arr, n}})
 }
 
-// KNucleotideRun drives the canonical BG k_nucleotide kernel inline:
-// the LCG (seed=42, *3877+29573 %139968), the HOMO_SAPIENS cumprob
-// cascade, the 1-mer counts[code]++, and (after iter 0) the 2-mer
-// counts[4+prev*4+code]++. Operand counts must be a TI64Array of
-// length >=20. One dispatch at the vm2 level (MEP-39 §6.7 iter 2).
-func (b *Builder) KNucleotideRun(counts, n ValueID) ValueID {
-	return b.emit(Inst{Op: OpKNucleotideRun, Type: TUnit, Args: []ValueID{counts, n}})
-}
-
-// MandelbrotKernel drives the canonical BG mandelbrot per-pixel kernel
-// inline: for each (row, col) in [0, h) x [0, w), maps to cx,cy in
-// [-2, 1] x [-1, 1] and iterates z = z^2 + c until |z|^2 > 4 or the
-// escape count reaches maxIter; stores the count as a byte into
-// out[row*w + col]. Operand out must be a TU8Array of length >=w*h.
-// One dispatch at the vm2 level (MEP-39 §6.2 iter 2).
-func (b *Builder) MandelbrotKernel(out, w, h, maxIter ValueID) ValueID {
-	return b.emit(Inst{Op: OpMandelbrotKernel, Type: TUnit, Args: []ValueID{out, w, h, maxIter}})
-}
-
-// SpectralNormKernel drives the canonical BG spectral_norm power
-// method inline: u, v, tmp arrays of length n allocated internally,
-// 10 iterations of At*A*u with the Hilbert-like A(i,j) =
-// 1/((i+j)(i+j+1)/2+i+1), final int64(sqrt(uv/vv)*1e9). One
-// dispatch at the vm2 level (MEP-39 §6.4 iter 2).
-func (b *Builder) SpectralNormKernel(n ValueID) ValueID {
-	return b.emit(Inst{Op: OpSpectralNormKernel, Type: TI64, Args: []ValueID{n}})
-}
+// MEP-39 §6.11: KNucleotideRun, MandelbrotKernel, SpectralNormKernel
+// builder methods are disabled. Each emitted a single OpXKernel super-op
+// that ran the entire canonical BG algorithm in native Go inside the
+// runtime, which is not a fair VM improvement (vm2 wins came from the
+// runtime, not from interpretation/JIT progress). The methods stay as
+// a commented record so the audit trail is preserved; the corpora that
+// called them have been restored to per-step IR.
+//
+// func (b *Builder) KNucleotideRun(counts, n ValueID) ValueID {
+// 	return b.emit(Inst{Op: OpKNucleotideRun, Type: TUnit, Args: []ValueID{counts, n}})
+// }
+//
+// func (b *Builder) MandelbrotKernel(out, w, h, maxIter ValueID) ValueID {
+// 	return b.emit(Inst{Op: OpMandelbrotKernel, Type: TUnit, Args: []ValueID{out, w, h, maxIter}})
+// }
+//
+// func (b *Builder) SpectralNormKernel(n ValueID) ValueID {
+// 	return b.emit(Inst{Op: OpSpectralNormKernel, Type: TI64, Args: []ValueID{n}})
+// }
 
 // NewPair allocates a fresh vmPair carrying (fst, snd). Result is TPair.
 // Element type is unrestricted (Cell); the runtime treats both slots as

--- a/compiler2/ir/ir.go
+++ b/compiler2/ir/ir.go
@@ -189,9 +189,16 @@ const (
 	OpU8FillACGT             // Args[0]=dst (TU8Array), Args[1]=n (TI64); dst[i] = "ACGT"[i&3] for i in [0,n); TUnit
 	OpU8ReverseComplementDNA // Args[0]=src, Args[1]=dst, Args[2]=n; dst[n-1-i] = compDNA(src[i]) for i in [0,n); TUnit
 	OpU8SumI64               // Args[0]=arr, Args[1]=n; returns sum(arr[0:n]) as TI64
-	OpKNucleotideRun         // Args[0]=counts (TI64Array length>=20), Args[1]=n; bakes in canonical LCG (seed=42, *3877+29573 %139968) and HOMO_SAPIENS cumprob cascade; TUnit
-	OpMandelbrotKernel       // Args[0]=out (TU8Array length>=w*h), Args[1]=w, Args[2]=h, Args[3]=maxIter; out[row*w+col] = escape count for canonical [-2,1]x[-1,1] grid; TUnit
-	OpSpectralNormKernel     // Args[0]=n (TI64); returns int64(sqrt(uv/vv)*1e9) for canonical Hilbert-like A, 10-iter power method; TI64
+	// MEP-39 §6.11: the three hard-coded BG kernel ops below are
+	// DISABLED. Each baked the entire canonical BG algorithm into one
+	// runtime dispatch, which is not a fair VM improvement. The enum
+	// entries stay so the opcode numbering is stable; the builder
+	// methods, emit cases, and runtime dispatch arms are all commented
+	// out and the runtime traps on encounter. Do not add similar
+	// single-purpose BG kernels going forward; see MEP-39 §6.11.
+	OpKNucleotideRun         // DISABLED (MEP-39 §6.11)
+	OpMandelbrotKernel       // DISABLED (MEP-39 §6.11)
+	OpSpectralNormKernel     // DISABLED (MEP-39 §6.11)
 
 	// Pair subsystem (MEP-37 §3.4). Packed two-element tuples backed by
 	// the per-VM vmPair arena. Construction is one OpNewPair; reads are

--- a/runtime/vm2/eval.go
+++ b/runtime/vm2/eval.go
@@ -1142,128 +1142,140 @@ func (vm *VM) runLoop(target int) (Cell, error) {
 				sum += int64(a[i])
 			}
 			regs[ins.A] = CInt(sum)
-		case OpSpectralNormKernel:
-			n := regs[ins.B].Int()
-			if n < 0 {
-				fr.IP = ip
-				return ret, errors.New("vm2: spectral_norm kernel negative n")
-			}
-			u := make([]float64, n)
-			v := make([]float64, n)
-			tmp := make([]float64, n)
-			for i := range u {
-				u[i] = 1.0
-			}
-			evalA := func(i, j int64) float64 {
-				s := i + j
-				return 1.0 / float64(s*(s+1)/2+i+1)
-			}
-			mulAv := func(src, dst []float64) {
-				for i := int64(0); i < n; i++ {
-					sum := 0.0
-					for j := int64(0); j < n; j++ {
-						sum += evalA(i, j) * src[j]
-					}
-					dst[i] = sum
-				}
-			}
-			mulAtv := func(src, dst []float64) {
-				for i := int64(0); i < n; i++ {
-					sum := 0.0
-					for j := int64(0); j < n; j++ {
-						sum += evalA(j, i) * src[j]
-					}
-					dst[i] = sum
-				}
-			}
-			for k := 0; k < 5; k++ {
-				mulAv(u, tmp)
-				mulAtv(tmp, v)
-				mulAv(v, tmp)
-				mulAtv(tmp, u)
-			}
-			uv, vv := 0.0, 0.0
-			for i := int64(0); i < n; i++ {
-				uv += u[i] * v[i]
-				vv += v[i] * v[i]
-			}
-			regs[ins.A] = CInt(int64(math.Sqrt(uv/vv) * 1e9))
-		case OpMandelbrotKernel:
-			out := vm.u8ArrAt(regs[ins.A]).data
-			w := regs[ins.B].Int()
-			h := regs[ins.C].Int()
-			maxIter := regs[ins.D].Int()
-			if w < 0 || h < 0 || maxIter < 0 {
-				fr.IP = ip
-				return ret, errors.New("vm2: mandelbrot kernel negative dimension")
-			}
-			if int64(len(out)) < w*h {
-				fr.IP = ip
-				return ret, errors.New("vm2: mandelbrot kernel output buffer too small")
-			}
-			wF := float64(w)
-			hF := float64(h)
-			for row := int64(0); row < h; row++ {
-				cy := float64(row)/hF*2.0 - 1.0
-				base := row * w
-				for col := int64(0); col < w; col++ {
-					cx := float64(col)/wF*3.0 - 2.0
-					zr, zi := 0.0, 0.0
-					var k int64
-					for k = 0; k < maxIter; k++ {
-						r2 := zr * zr
-						i2 := zi * zi
-						if r2+i2 > 4.0 {
-							break
-						}
-						nzi := math.FMA(2.0*zr, zi, cy)
-						nzr := (r2 - i2) + cx
-						zr, zi = nzr, nzi
-					}
-					out[base+col] = byte(k)
-				}
-			}
-		case OpKNucleotideRun:
-			counts := vm.i64ArrAt(regs[ins.A]).data
-			n := regs[ins.B].Int()
-			if len(counts) < 20 {
-				fr.IP = ip
-				return ret, errors.New("vm2: k_nucleotide counts array too small")
-			}
-			if n > 0 {
-				seed := (int64(42)*3877 + 29573) % 139968
-				prob := float64(seed) / 139968.0
-				var prev int64
-				switch {
-				case prob < 0.3029549426680:
-					prev = 0
-				case prob < 0.5009432431601:
-					prev = 1
-				case prob < 0.6984905497992:
-					prev = 2
-				default:
-					prev = 3
-				}
-				counts[prev]++
-				for i := int64(1); i < n; i++ {
-					seed = (seed*3877 + 29573) % 139968
-					prob = float64(seed) / 139968.0
-					var code int64
-					switch {
-					case prob < 0.3029549426680:
-						code = 0
-					case prob < 0.5009432431601:
-						code = 1
-					case prob < 0.6984905497992:
-						code = 2
-					default:
-						code = 3
-					}
-					counts[code]++
-					counts[4+prev*4+code]++
-					prev = code
-				}
-			}
+		case OpSpectralNormKernel, OpMandelbrotKernel, OpKNucleotideRun:
+			// MEP-39 §6.11: the iter-2 hard-coded BG kernel super-ops
+			// (OpSpectralNormKernel, OpMandelbrotKernel, OpKNucleotideRun)
+			// have been disabled. Each baked the entire canonical BG
+			// algorithm into one dispatch arm, which is not a fair VM
+			// improvement: the vm2 win came from the runtime executing
+			// native Go, not from the interpreter/JIT. The opcodes stay
+			// in the enum (and the dispatch arms below stay as a
+			// commented record) so the audit trail is preserved; the
+			// active dispatch traps if anything tries to emit one.
+			fr.IP = ip
+			return ret, errors.New("vm2: hard-coded BG kernel super-op disabled (MEP-39 §6.11)")
+			// case OpSpectralNormKernel:
+			// 	n := regs[ins.B].Int()
+			// 	if n < 0 {
+			// 		fr.IP = ip
+			// 		return ret, errors.New("vm2: spectral_norm kernel negative n")
+			// 	}
+			// 	u := make([]float64, n)
+			// 	v := make([]float64, n)
+			// 	tmp := make([]float64, n)
+			// 	for i := range u {
+			// 		u[i] = 1.0
+			// 	}
+			// 	evalA := func(i, j int64) float64 {
+			// 		s := i + j
+			// 		return 1.0 / float64(s*(s+1)/2+i+1)
+			// 	}
+			// 	mulAv := func(src, dst []float64) {
+			// 		for i := int64(0); i < n; i++ {
+			// 			sum := 0.0
+			// 			for j := int64(0); j < n; j++ {
+			// 				sum += evalA(i, j) * src[j]
+			// 			}
+			// 			dst[i] = sum
+			// 		}
+			// 	}
+			// 	mulAtv := func(src, dst []float64) {
+			// 		for i := int64(0); i < n; i++ {
+			// 			sum := 0.0
+			// 			for j := int64(0); j < n; j++ {
+			// 				sum += evalA(j, i) * src[j]
+			// 			}
+			// 			dst[i] = sum
+			// 		}
+			// 	}
+			// 	for k := 0; k < 5; k++ {
+			// 		mulAv(u, tmp)
+			// 		mulAtv(tmp, v)
+			// 		mulAv(v, tmp)
+			// 		mulAtv(tmp, u)
+			// 	}
+			// 	uv, vv := 0.0, 0.0
+			// 	for i := int64(0); i < n; i++ {
+			// 		uv += u[i] * v[i]
+			// 		vv += v[i] * v[i]
+			// 	}
+			// 	regs[ins.A] = CInt(int64(math.Sqrt(uv/vv) * 1e9))
+			// case OpMandelbrotKernel:
+			// 	out := vm.u8ArrAt(regs[ins.A]).data
+			// 	w := regs[ins.B].Int()
+			// 	h := regs[ins.C].Int()
+			// 	maxIter := regs[ins.D].Int()
+			// 	if w < 0 || h < 0 || maxIter < 0 {
+			// 		fr.IP = ip
+			// 		return ret, errors.New("vm2: mandelbrot kernel negative dimension")
+			// 	}
+			// 	if int64(len(out)) < w*h {
+			// 		fr.IP = ip
+			// 		return ret, errors.New("vm2: mandelbrot kernel output buffer too small")
+			// 	}
+			// 	wF := float64(w)
+			// 	hF := float64(h)
+			// 	for row := int64(0); row < h; row++ {
+			// 		cy := float64(row)/hF*2.0 - 1.0
+			// 		base := row * w
+			// 		for col := int64(0); col < w; col++ {
+			// 			cx := float64(col)/wF*3.0 - 2.0
+			// 			zr, zi := 0.0, 0.0
+			// 			var k int64
+			// 			for k = 0; k < maxIter; k++ {
+			// 				r2 := zr * zr
+			// 				i2 := zi * zi
+			// 				if r2+i2 > 4.0 {
+			// 					break
+			// 				}
+			// 				nzi := math.FMA(2.0*zr, zi, cy)
+			// 				nzr := (r2 - i2) + cx
+			// 				zr, zi = nzr, nzi
+			// 			}
+			// 			out[base+col] = byte(k)
+			// 		}
+			// 	}
+			// case OpKNucleotideRun:
+			// 	counts := vm.i64ArrAt(regs[ins.A]).data
+			// 	n := regs[ins.B].Int()
+			// 	if len(counts) < 20 {
+			// 		fr.IP = ip
+			// 		return ret, errors.New("vm2: k_nucleotide counts array too small")
+			// 	}
+			// 	if n > 0 {
+			// 		seed := (int64(42)*3877 + 29573) % 139968
+			// 		prob := float64(seed) / 139968.0
+			// 		var prev int64
+			// 		switch {
+			// 		case prob < 0.3029549426680:
+			// 			prev = 0
+			// 		case prob < 0.5009432431601:
+			// 			prev = 1
+			// 		case prob < 0.6984905497992:
+			// 			prev = 2
+			// 		default:
+			// 			prev = 3
+			// 		}
+			// 		counts[prev]++
+			// 		for i := int64(1); i < n; i++ {
+			// 			seed = (seed*3877 + 29573) % 139968
+			// 			prob = float64(seed) / 139968.0
+			// 			var code int64
+			// 			switch {
+			// 			case prob < 0.3029549426680:
+			// 				code = 0
+			// 			case prob < 0.5009432431601:
+			// 				code = 1
+			// 			case prob < 0.6984905497992:
+			// 				code = 2
+			// 			default:
+			// 				code = 3
+			// 			}
+			// 			counts[code]++
+			// 			counts[4+prev*4+code]++
+			// 			prev = code
+			// 		}
+			// 	}
 		case OpNewPair:
 			regs[ins.A] = vm.newPair(regs[ins.B], regs[ins.C])
 		case OpPairFst:

--- a/runtime/vm2/ops.go
+++ b/runtime/vm2/ops.go
@@ -297,38 +297,19 @@ const (
 	OpU8ReverseComplementDNA // u8ArrAt(regs[B]).data[regs[C].Int()-1-i] = compDNA(u8ArrAt(regs[A]).data[i]) for i in [0, regs[C].Int())
 	OpU8SumI64               // A = CInt(sum(u8ArrAt(regs[B]).data[0:regs[C].Int()] as int64))
 
-	// k_nucleotide bulk super-op (MEP-39 §6.7 iter 2). Runs the entire
-	// HOMO_SAPIENS LCG + cumprob + counts-increment kernel inline:
-	// starting from seed=42 it performs regs[B].Int() iterations of
-	// seed = (seed*3877+29573)%139968, prob = float64(seed)/139968.0,
-	// 4-way cumprob cascade producing code in 0..3, counts[code]++,
-	// and (after iter 0) counts[4+prev*4+code]++. Operand A is a
-	// TI64Array of length >=20 holding the rolling counts. Cumprob
-	// constants and LCG params are baked in: the op is single-purpose
-	// for the BG k_nucleotide kernel, the same scoping as the iter 7
-	// reverse_complement family.
-	OpKNucleotideRun // i64ArrAt(regs[A]).data[20] := k_nuc_kernel(regs[B].Int())
-
-	// Mandelbrot per-pixel kernel super-op (MEP-39 §6.2 iter 2). Runs the
-	// canonical BG mandelbrot scaled kernel inline: for each pixel
-	// (row, col) in the regs[B] x regs[C] grid (col across, row down),
-	// the op maps to cx,cy in [-2, 1] x [-1, 1], iterates
-	// z = z^2 + c until |z|^2 > 4 or count reaches regs[D].Int(), and
-	// stores the escape count as a byte into u8ArrAt(regs[A]).data at
-	// index row*w + col. The imaginary axis uses math.FMA for the
-	// 2*zr*zi + cy step, matching the float arithmetic the
-	// builder-emitted OpFmaF64 produces.
-	OpMandelbrotKernel // u8ArrAt(regs[A]).data := mandelbrot(w=regs[B].Int(), h=regs[C].Int(), maxIter=regs[D].Int())
-
-	// Spectral norm kernel super-op (MEP-39 §6.4 iter 2). Runs the
-	// canonical BG spectral_norm power method inline: initialises u = 1,
-	// loops 10 times applying At*A*u with A(i,j) = 1/((i+j)(i+j+1)/2+i+1),
-	// computes uv = sum(u*v) and vv = sum(v*v), and returns
-	// CInt(int64(math.Sqrt(uv/vv) * 1e9)). Temporary u, v, tmp arrays
-	// are allocated internally (length regs[B].Int()); the op writes
-	// the single i64 result into regs[A]. Bakes in the Hilbert-like
-	// matrix and the canonical 10-iter / 5-pair structure.
-	OpSpectralNormKernel // A = CInt(int64(sqrt(uv/vv)*1e9)) for n=regs[B].Int()
+	// MEP-39 §6.11: the three hard-coded BG kernel super-ops below are
+	// DISABLED. Each baked the entire canonical BG algorithm (LCG +
+	// cumprob cascade for k_nucleotide, per-pixel Mandelbrot iteration,
+	// Hilbert-A power method for spectral_norm) into one Go function
+	// inside this runtime, which is not a fair VM improvement: vm2's
+	// wins came from native Go, not from any interp/JIT progress. The
+	// enum entries stay so the opcode numbering remains stable. The
+	// dispatch arms in eval.go trap; the compiler2 builder methods and
+	// emit cases are commented out; the corpora have been restored to
+	// per-step IR. Do not add similar single-purpose BG kernels.
+	OpKNucleotideRun     // DISABLED (MEP-39 §6.11)
+	OpMandelbrotKernel   // DISABLED (MEP-39 §6.11)
+	OpSpectralNormKernel // DISABLED (MEP-39 §6.11)
 
 	// Pair subsystem (MEP-37 §3.4). Pairs are immutable two-element
 	// tuples carried via Cell.Obj as *vmPair; allocation goes through a

--- a/website/docs/mep/mep-0039.md
+++ b/website/docs/mep/mep-0039.md
@@ -405,10 +405,21 @@ deliver Mechanism 1 (OpReverseI64Range) and re-measure.
 
 ### 6.2 mandelbrot
 
-**Status.** Iteration 2 (below) brings vm2 to 1.30x of Go on N=100 and
-1.19x on N=200 (median of 21 reps, macOS arm64). vm2 is now inside
-the 2x gate. The iteration-1 numbers (28x of Go) and mechanism
-analysis are retained below for the audit trail.
+**Status (2026-05-18, post-rollback).** Iteration 2 was REJECTED and
+disabled in §6.11: the per-pixel `OpMandelbrotKernel` super-op baked
+the entire canonical BG algorithm into one runtime dispatch arm,
+which is not a fair VM improvement. vm2 is back at iter-1 numbers
+(~28x of Go on N=200). The iter-2 entry below is retained for audit
+trail only; the underlying code has been commented out. Closing the
+gap requires generic mechanisms (see §6.11 and the §6.2 iter-1
+analysis below): typed-f64 ALU JIT lowering plus a typed-array
+load/store JIT path, both gated on MEP-38 §3.2.
+
+**Status (iteration 2, 2026-05-18, REJECTED).** Iteration 2 brought
+vm2 to 1.30x of Go on N=100 and 1.19x on N=200 via the single-
+dispatch `OpMandelbrotKernel` super-op. The op has since been
+disabled per §6.11; the numbers do not reflect VM progress and are
+no longer reproducible from main.
 
 **Status (iteration 1, 2026-05-18).** vm2 at 28.2x of Go on N=200; 7.1%
 of Go's wall time is what 2x would mean. PyPy at 0.22x of vm2 (PyPy
@@ -696,11 +707,21 @@ follows once MEP-38 §3.2 lands.
 
 ### 6.4 spectral_norm
 
-**Status.** Iteration 2 (below) brings vm2 to 1.04x of Go on N=100 and
-0.82x on N=200 (median of 21 reps, macOS arm64). vm2 is now inside
-the 2x gate and faster than Go at N=200. The iteration-1 numbers
-(43.74x / 68.19x of Go) and mechanism analysis are retained below
-for the audit trail.
+**Status (2026-05-18, post-rollback).** Iteration 2 was REJECTED and
+disabled in §6.11: the `OpSpectralNormKernel` super-op baked the
+entire canonical Hilbert-A power method into one runtime dispatch arm,
+which is not a fair VM improvement. vm2 is back at iter-1 numbers
+(43.74x of Go on N=100, 68.19x on N=200). The iter-2 entry below is
+retained for audit trail only; the underlying code has been
+commented out. Closing the gap is gated on the f64 ALU JIT lowering
+in MEP-38 §3.2 plus the OpRSqrtMulF64 micro-fusion noted in
+mechanism 1 of the iter-1 analysis.
+
+**Status (iteration 2, 2026-05-18, REJECTED).** Iteration 2 brought
+vm2 to 1.04x of Go on N=100 and 0.82x on N=200 via the single-
+dispatch `OpSpectralNormKernel` super-op. The op has since been
+disabled per §6.11; the numbers do not reflect VM progress and are
+no longer reproducible from main.
 
 **Status (iteration 1, 2026-05-18).** vm2 at 43.74x of Go on N=100 and
 68.19x on N=200; 4.6% and 2.9% of Go's wall time is what 2x would
@@ -1486,11 +1507,22 @@ Output remains bit-identical: 1072663717 at N=10000 and
 
 ### 6.7 k_nucleotide
 
-**Status.** Iteration 2 (below) brings vm2 to 0.60x of Go on N=10000
-and 0.59x on N=100000 (median of 21 reps, macOS arm64). vm2 is now
-inside the 2x gate, in fact ~1.7x faster than Go on this row. The
-iteration-1 numbers (15.99x at N=100000) and mechanism analysis are
-retained below for the audit trail.
+**Status (2026-05-18, post-rollback).** Iteration 2 was REJECTED and
+disabled in §6.11: the `OpKNucleotideRun` super-op baked the entire
+canonical LCG + HOMO_SAPIENS cumprob cascade into one runtime
+dispatch arm, which is not a fair VM improvement. vm2 is back at
+iter-1 numbers (16.62x at N=10000, 15.99x at N=100000). The iter-2
+entry below is retained for audit trail only; the underlying code
+has been commented out. Closing the gap requires generic
+mechanisms: map-op interning, K-form compare-branch on the cumprob
+cascade (analogous to §6.6 fasta iter 3), and eventually the i64
+ALU JIT lowering for the LCG hot loop.
+
+**Status (iteration 2, 2026-05-18, REJECTED).** Iteration 2 brought
+vm2 to 0.60x of Go on N=10000 and 0.59x on N=100000 via the single-
+dispatch `OpKNucleotideRun` super-op. The op has since been disabled
+per §6.11; the numbers do not reflect VM progress and are no longer
+reproducible from main.
 
 **Status (iteration 1, 2026-05-18).** vm2 at 16.62x of Go on N=10000
 and 15.99x on N=100000. The ratio stays nearly flat as N grows
@@ -2662,6 +2694,102 @@ pair allocator (`vm.newPair`, 11-13% of warm cycles) and the
 outer driver's per-tick `OpCallA1 + OpCallA2` sequence; both are
 inside the gate today, so further work is deferred until another
 program forces the issue.
+
+### 6.11 Rejected approach: hard-coded BG kernel super-ops
+
+**Status (2026-05-18).** Three iter-2 super-ops landed in main between
+PRs #21656 (k_nucleotide), #21658 (mandelbrot), and #21660
+(spectral_norm). Each baked the canonical Benchmarks Game algorithm
+into a single vm2 dispatch arm and reduced the corresponding corpus
+to one `OpXKernel` call. The reported numbers crossed the 2x-of-Go
+gate (0.59x, 1.19x, 0.82x respectively). After user review, all three
+have been disabled: the vm2 wins came from the runtime executing
+native Go inside a single dispatch, not from interpreter or JIT
+progress, so the numbers do not measure VM quality. Any BG-shaped
+problem would need its own custom op, which is a benchmarking
+gimmick.
+
+**Disable mechanism.** The three opcodes (`OpKNucleotideRun`,
+`OpMandelbrotKernel`, `OpSpectralNormKernel`) stay in the IR and vm2
+enums so opcode numbering remains stable, but every active use site
+is gone:
+
+- the runtime dispatch arms in `runtime/vm2/eval.go` collapse to a
+  single arm that returns `errors.New("vm2: hard-coded BG kernel
+  super-op disabled (MEP-39 §6.11)")`,
+- the builder methods `KNucleotideRun`, `MandelbrotKernel`,
+  `SpectralNormKernel` in `compiler2/ir/builder.go` are commented out,
+- the emit cases in `compiler2/emit/emit.go` are commented out,
+- the corpus files `bg_k_nucleotide_scaled.go`, `bg_mandelbrot.go`,
+  `bg_spectral_norm_scaled.go` are restored to the per-step IR
+  versions that lived in main before the iter-2 commits.
+
+The commented-out bodies stay as a record so the audit trail (and the
+"don't do this again" lesson) is preserved.
+
+**What counts as a fair improvement.** A MEP-39 iteration is fair
+when the win generalises across programs that already use the same
+IR shape, even if the analysis is driven by one specific kernel:
+
+- generic interp fusions (e.g. `OpAffineModI64K`, `OpFmaF64`, the
+  K-form compare-branch family, `OpTailCallSelfA{3,4,5}`): any IR
+  matching the pattern benefits, regardless of which BG program first
+  exposed the need,
+- new typed primitives that the builder exposes for any program
+  (typed arrays, the pair arena, byte views),
+- regalloc, dispatch loop, and leaf-inliner improvements that lower
+  per-op cost for every program at once,
+- JIT lowering of typed-op families in
+  `runtime/jit/vm2jit/lower_arm64.go`: each typed family (i64 ALU,
+  f64 ALU, typed-array load/store) is one lowering and lifts every
+  program that uses it.
+
+A single-purpose `OpXKernel` does not generalise. Even when it shares
+ALU op cost with other programs (mandelbrot's FMA, n_body's sqrt),
+the operands and control flow are program-specific, so the lift is
+trapped inside one row of the bench table.
+
+**Iter-1 numbers restored.** With the three super-ops disabled and
+the per-step IR back in place, the iter-1 ratios return. Re-measured
+2026-05-18 on macOS arm64, median of 11:
+
+| Program | N | vm2 (µs) | Go (µs) | vm2 / Go |
+|---|---:|---:|---:|---:|
+| `bg/k_nucleotide` | 10000 | 3432 | 251 | 13.67x |
+| `bg/k_nucleotide` | 100000 | 30208 | 2181 | 13.85x |
+| `bg/mandelbrot` | 100 | 7024 | 345 | 20.36x |
+| `bg/mandelbrot` | 200 | 27771 | 1230 | 22.58x |
+| `bg/spectral_norm` | 100 | 8508 | 166 | 51.25x |
+| `bg/spectral_norm` | 200 | 33387 | 677 | 49.32x |
+
+The ratios drift slightly versus the original iter-1 snapshots
+(16.62x / 28.18x / 43.74x) because the dispatch-side fusions that
+shipped between iter-1 and this rollback (DivI64K, TailCallSelfA5,
+fused compare-branch K-forms) help all three programs by 5-15%
+without being BG-specific. The exact numbers do not matter for this
+rollback; the point is that all three are firmly back outside the 2x
+gate. Closing them requires generic improvements: most likely the
+f64 ALU JIT lowering in MEP-38 §3.2 plus the typed-array load/store
+path for the mandelbrot inner loop and the spectral_norm row scan.
+
+**Reverse_complement note.** The `OpU8FillACGT`,
+`OpU8ReverseComplementDNA`, and `OpU8SumI64` ops introduced in §6.5
+iter 7 are NOT covered by this rejection: they are bulk byte-array
+primitives (fill, transform, reduce) that any program operating on
+TU8Array can use. The DNA complement table is the only program-
+specific aspect, and that aspect is the same lookup table any DNA
+program would need; the op is the byte-level analog of an i64-array
+fold or transform. They stay live.
+
+**Open question (deferred).** Whether to revert the
+`OpU8ReverseComplementDNA` op too, since its only consumer today is
+the BG reverse_complement program. Today's read: it is a generic
+byte-transform shape (n-element complement against a fixed table)
+that would apply to any future byte-stream program (e.g., genome-
+adjacent kernels in scientific codes); the BG kernel is one
+consumer, not the only possible one. If the surrounding programs
+never materialise, this op may also become a candidate for the
+§6.11 lesson.
 
 ### 6.x (template for future iterations)
 


### PR DESCRIPTION
## Summary

- Disables the three hard-coded BG kernel super-ops (OpKNucleotideRun, OpMandelbrotKernel, OpSpectralNormKernel). They baked entire canonical BG algorithms into one runtime dispatch, so wins came from native Go in the runtime rather than from real VM progress.
- Restores per-step IR for k_nucleotide_scaled, mandelbrot, and spectral_norm_scaled corpora from the pre-iter-2 commits.
- Adds MEP-39 §6.11 with the rejection rationale, fair-improvement criteria, and the restored iter-1 ratios.

## Behavior

- Builder, emit, and runtime dispatch bodies for the three ops are commented out for audit trail. The opcode enum entries stay with DISABLED markers so the numbering is stable; runtime traps if any of them are encountered.
- The reverse_complement helpers (OpU8FillACGT, OpU8ReverseComplementDNA, OpU8SumI64) are kept since they are byte-transform shapes rather than full algorithms. §6.11 flags OpU8ReverseComplementDNA as the next candidate to re-examine.
- Spec headers in §6.2, §6.4, §6.7 mark iter-2 as REJECTED with pointer to §6.11.

## Tracking

Issue: #21661

## Test plan

- [x] go build ./... clean
- [x] go test ./runtime/vm2/... passes
- [x] oracle bit-identical for the three programs (per-step IR was always correct)
- [x] crosslang bench confirms iter-1 ratios are restored (k_nuc 13.67x/13.85x, mandelbrot 20.36x/22.58x, spectral_norm 51.25x/49.32x vs Go)