### PR TITLE
mep-0039 §6.10: hotfix MDX parse error (bare less-than-equals to 16)

### DIFF
--- a/website/docs/mep/mep-0039.md
+++ b/website/docs/mep/mep-0039.md
@@ -2454,7 +2454,7 @@ this change alone. `binary_trees` N=10 (2.57x) is the remaining
 target for iteration 5: the residual cost is in the
 `outer(d, i, iters, acc)` driver, which still dispatches one
 `OpCallSelfA4` per `iters` tick. Per-node math: 21 ns/node at
-D=10 today, needs <= 16 ns/node for the gate, a ~4 ns/node cut.
+D=10 today, needs at most 16 ns/node for the gate, a ~4 ns/node cut.
 Candidates being scoped: fuse `OpSubI64K + OpCallSelfA1` into
 `OpCallSelfA1Sub1` (one dispatch saved per non-leaf in
 `make_tree`/`check_tree`), and a return-after-call fused op for


### PR DESCRIPTION
## Summary

Hotfix follow-up to #21662. The previous PR's Build & deploy check failed at line 2457 with an MDX parse error: MDX treats less-than followed by equals as the start of a JSX tag. Tests passed and auto-merge fired before this hotfix landed, so main is currently broken for docs deploy.

The fix matches the project pattern (361ec49d30): rephrase the comparison in prose.

## Test plan

- [x] local docusaurus build succeeds