### PR TITLE
mep-0039 §6.12: diagnostic probe for JIT coverage gap on FP-heavy BG programs

### DIFF
--- a/runtime/jit/vm2jit/coverage_probe_test.go
+++ b/runtime/jit/vm2jit/coverage_probe_test.go
@@ -1,0 +1,47 @@
+//go:build numregs_probe
+
+// Diagnostic probe: print NumRegs and JIT compile status for every
+// function in the FP-heavy BG corpora. Captured in MEP-39 §6.12.
+//
+// Run with:
+//
+//	go test -tags numregs_probe -run TestJITCoverageProbe -v ./runtime/jit/vm2jit/
+
+package vm2jit
+
+import (
+	"fmt"
+	"testing"
+
+	"mochi/compiler2/corpus"
+	"mochi/compiler2/emit"
+	"mochi/compiler2/ir"
+)
+
+func TestJITCoverageProbe(t *testing.T) {
+	cases := []struct {
+		name string
+		mod  *ir.Module
+	}{
+		{"mandelbrot", corpus.BuildMandelbrotKernel(200, 200, 50)},
+		{"spectral_norm", corpus.BuildSpectralNorm(100)},
+		{"n_body", corpus.BuildNBodyKernel()},
+	}
+	for _, c := range cases {
+		prog, err := emit.Compile(c.mod)
+		if err != nil {
+			fmt.Printf("%s: emit err: %v\n", c.name, err)
+			continue
+		}
+		for i, fn := range prog.Funcs {
+			_, jitErr := Compile(fn)
+			tag := "JIT-OK"
+			if jitErr != nil {
+				tag = fmt.Sprintf("JIT-skip(%v)", jitErr)
+			}
+			fmt.Printf("%-13s fn[%d] %-22s NumRegs=%2d  %s\n",
+				c.name, i, fn.Name, fn.NumRegs, tag)
+		}
+		fmt.Println()
+	}
+}

--- a/website/docs/mep/mep-0039.md
+++ b/website/docs/mep/mep-0039.md
@@ -2791,6 +2791,145 @@ consumer, not the only possible one. If the surrounding programs
 never materialise, this op may also become a candidate for the
 §6.11 lesson.
 
+### 6.12 Diagnostic: JIT is silently off for FP-heavy BG programs
+
+**Status (2026-05-18).** Diagnostic finding that motivates the next
+several MEP-39 iterations. No code-path change in this section: it
+captures a measurement and the staged plan it implies. Implementation
+follows in §6.13 onward.
+
+**Method.** `runtime/jit/vm2jit/coverage_probe_test.go` (build tag
+`numregs_probe`) walks every `vm2.Function` in the FP-heavy BG corpora
+(`bg_mandelbrot.go`, `bg_spectral_norm_scaled.go`, `bg_n_body.go`),
+prints each function's `NumRegs`, and calls `vm2jit.Compile` to record
+whether the JIT accepts or rejects it. Run with:
+
+```
+go test -tags numregs_probe -run TestJITCoverageProbe -v \
+    ./runtime/jit/vm2jit/
+```
+
+**Result.** Every hot function in the three FP-heavy programs exceeds
+`maxJITRegs = 7` and is silently skipped by the JIT:
+
+| Program | Function | NumRegs | JIT |
+|---|---|---:|---|
+| mandelbrot | main | 12 | skip |
+| mandelbrot | rowLoop | 18 | skip |
+| mandelbrot | colLoop | 24 | skip |
+| mandelbrot | **iterate** | **23** | **skip** |
+| mandelbrot | sumU8 | 14 | skip |
+| spectral_norm | main | 13 | skip |
+| spectral_norm | fill | 11 | skip |
+| spectral_norm | mulAv | 16 | skip |
+| spectral_norm | mulAInner | 18 | skip |
+| spectral_norm | mulAtv | 16 | skip |
+| spectral_norm | mulAtInner | 18 | skip |
+| spectral_norm | **dot** | **18** | **skip** |
+| spectral_norm | iterLoop | 20 | skip |
+| spectral_norm | evalA | 6 | **OK** |
+| n_body | main | 19 | skip |
+| n_body | init | 27 | skip |
+| n_body | advance | 30 | skip |
+| n_body | **inner** | **38** | **skip** |
+| n_body | posUpdate | 27 | skip |
+| n_body | energy | 31 | skip |
+| n_body | subEnergy | 26 | skip |
+
+Of 21 functions across the three programs, exactly one
+(`spectral_norm.evalA`, the table lookup for the synthetic
+`A(i,j) = 1/((i+j)(i+j+1)/2+i+1)` entries) is small enough to JIT.
+Every per-iteration inner kernel is rejected.
+
+**Why the limit exists.** `runtime/jit/vm2jit/compile.go` caps
+`maxJITRegs` at 7. The arm64 backend maps vm2 register `r` to AArch64
+GPR `x(9+r)`, so r0-r6 → x9-x15. AAPCS64 partitions GPRs as:
+
+- `x0`-`x7`: argument and result registers (x0 is the regs pointer
+  on JIT entry; the others would alias the trampoline's call ABI),
+- `x8`: indirect result location (reserved by AAPCS64),
+- `x9`-`x15`: 7 caller-saved temporaries (the vm2 register file),
+- `x16`, `x17`: IP0, IP1 (used by the JIT as scratch in deopt-stub
+  encoding, list-len fast path, and float-comparison glue),
+- `x18`: platform register, reserved on Darwin,
+- `x19`-`x28`: 10 callee-saved registers (need save/restore at
+  function entry and exit if used),
+- `x29`-`x30`: frame pointer and link register.
+
+The current backend reaches the AArch64 caller-saved capacity. Going
+beyond 7 requires either (a) using callee-saved registers with a
+save/restore prologue, or (b) spilling to a stack frame. Both are
+real work and warrant their own iterations.
+
+**Why this is the bottleneck, not unlowered opcodes.** §6.11 ended
+by speculating that f64 ALU JIT lowering plus typed-array load/store
+were the next levers. Both are already in `lower_arm64.go`:
+`OpAddF64`, `OpSubF64`, `OpMulF64`, `OpDivF64`, `OpNegF64`,
+`OpAbsF64`, `OpSqrtF64`, `OpLessF64`, `OpLessEqF64`, `OpEqualF64`,
+`OpFmaF64`, `OpI64ToF64`, `OpF64ToI64`. The typed-array family
+(`OpF64ArrGet/Set/Len` and friends) is in the deopt list, but adding
+its lowering only helps if the surrounding function actually JITs. As
+the probe shows, none of them do. Closing the JIT-register gap is the
+prerequisite for any further FP lowering work to register on the
+benchmark.
+
+**Why NumRegs is so large.** `compiler2/regalloc/regalloc.go` is a
+linear-scan allocator (Poletto and Sarkar, 1999) that extends each
+live interval to its last read. It works well for straight-line code
+and has tighter scope notes about acyclic CFGs and back-edges. For
+the BG corpora it inflates `NumRegs` for three reasons:
+
+1. **Tail-recursive parameters.** Mandelbrot's `iterate` and every
+   spectral_norm inner loop end with a self-`Call` that re-passes
+   most parameters. Each parameter is live from function entry to the
+   call site at the bottom of the loop body, holding one register per
+   pass-through parameter even though the parameter is never mutated.
+2. **Branch-side dead values.** `iterate` has an `iI < iMi` check
+   that jumps to `iMax` (returns `iMi`) or `iCont` (computes the
+   step). The allocator linearises blocks in `entry, iMax, iCont,
+   iEsc, iLoop` order. A value defined in `entry` and used in `iEsc`
+   (six blocks later) lives across `iMax`, `iCont`, and any
+   intermediate definition, so its register is locked even when the
+   actual path through `iMax` never reads it. CFG-aware liveness
+   would prune these.
+3. **Intermediate SSA values per FMA family.** Each `MulF64`,
+   `SubF64`, `AddF64`, `FmaF64` produces a fresh SSA value with its
+   own interval. Coalescing consecutive single-use values into one
+   register would cut the allocator's high-water mark significantly
+   without changing the IR.
+
+**Staged plan.**
+
+- **Phase A (§6.13, next).** Reclaim caller-saved capacity. Move
+  scratch uses of `x16`/`x17` (currently consumed by movzTagInt,
+  list-len fast path, float-compare glue) onto `x8` plus a single
+  dedicated scratch slot. Then map r7, r8 onto `x16`, `x17`. Bumps
+  `maxJITRegs` from 7 to 9. Modest: unlocks no BG hot function on its
+  own but is a pure win for any 8-9 register function and is a
+  zero-stack-frame prologue change.
+- **Phase B (§6.14).** Use callee-saved x19-x28 with a STP/LDP
+  prologue/epilogue. Bumps `maxJITRegs` to 19. Unlocks
+  `spectral_norm.fill (11)`, `spectral_norm.main (13)`,
+  `mandelbrot.main (12)`, `mandelbrot.sumU8 (14)`,
+  `spectral_norm.mulAv (16)`, `spectral_norm.mulAtv (16)`,
+  `spectral_norm.dot (18)`, `mandelbrot.rowLoop (18)`,
+  `spectral_norm.mulAInner (18)`, `spectral_norm.mulAtInner (18)`. At
+  this point spectral_norm should JIT end-to-end (assuming typed-
+  array Get/Set are also lowered).
+- **Phase C (§6.15).** Spill-to-stack for the remaining 20-38-reg
+  functions. Reserves a stack frame and emits LDR/STR for vm2
+  registers beyond the GPR window. Unlocks mandelbrot.iterate (23),
+  mandelbrot.colLoop (24), spectral_norm.iterLoop (20), and every
+  n_body function (19-38).
+- **Phase D (§6.16, optional).** Compiler-side regalloc improvements
+  that cut `NumRegs` at source: CFG-aware live-range pruning
+  (eliminates branch-side false liveness) and last-use coalescing
+  (folds consecutive single-use values). If Phase D lands first, the
+  GPR window in Phase B may already be enough and Phase C becomes
+  unnecessary. The phases are independent.
+
+The next iteration writes Phase A.
+
 ### 6.x (template for future iterations)
 
 Each new program lands in 6.x with the same theory / mechanism /


### PR DESCRIPTION
## Summary

- Lands a build-tagged diagnostic test (`runtime/jit/vm2jit/coverage_probe_test.go`, tag `numregs_probe`) that prints NumRegs and JIT compile status for every function in the FP-heavy BG corpora.
- Adds MEP-39 §6.12 with the finding: every hot function in mandelbrot/spectral_norm/n_body exceeds maxJITRegs=7 and is silently rejected by vm2jit, so the 20-50x slowdowns vs Go come from the JIT being entirely off for these programs.
- Spec captures the AArch64 ABI constraint (x9-x15 = 7 caller-saved temporaries), the three SSA-level reasons NumRegs inflates (tail-recursive parameters, branch-side dead values, intermediate FMA values), and a four-phase plan.

No code-path change to compile or runtime. Phase A starts in the next iteration.

## Tracking

Issue: #21665

## Test plan

- [x] `go test -tags numregs_probe -run TestJITCoverageProbe -v ./runtime/jit/vm2jit/` runs and prints the table in §6.12
- [x] `go build ./...` clean
- [x] local docusaurus build passes (the §6.12 content is MDX-safe)