### PR TITLE
mep-0039 §6.13: bump maxJITRegs 7 to 9 via callee-saved x19/x20

### DIFF
--- a/runtime/jit/vm2jit/compile.go
+++ b/runtime/jit/vm2jit/compile.go
@@ -45,7 +45,11 @@ func (c *CompiledFunc) Free() error {
 // Opcodes outside Phase 1's scope cause Compile to return ErrNotImplemented.
 // maxJITRegs is the maximum number of vm2 registers supported by any JIT
 // backend. Functions with more registers must be interpreted.
-const maxJITRegs = 7
+//
+// MEP-39 §6.13 (Phase B-lite) bumps the limit from 7 to 9 by adding two
+// callee-saved slots (x19, x20 on AArch64) behind an STP/LDP frame.
+// Phase B-full will push the remaining x21..x28 in 80-byte STP pairs.
+const maxJITRegs = 9
 
 func Compile(fn *vm2.Function) (*CompiledFunc, error) {
 	if hostArch < 0 {

--- a/runtime/jit/vm2jit/lower_arm64.go
+++ b/runtime/jit/vm2jit/lower_arm64.go
@@ -8,12 +8,40 @@ import (
 	"mochi/runtime/vm2"
 )
 
-// AArch64 GPR mapping: vm2 register r[i] -> x(9+i), i.e. x9-x15 (7 slots).
-// These are temporary (caller-saved) in AAPCS64, so the JIT'd function
-// does not need to save/restore them. x0 (the regs pointer) is also
-// caller-saved and is preserved through the body since no arithmetic
-// opcode touches it.
-func r2x(r int32) uint32 { return uint32(r) + 9 }
+// AArch64 GPR mapping: vm2 register r[i] -> host x register.
+//
+//	r[0..6] -> x9..x15  (caller-saved temps; no save/restore needed)
+//	r[7]    -> x19      (callee-saved; requires STP/LDP frame)
+//	r[8]    -> x20      (callee-saved; requires STP/LDP frame)
+//
+// MEP-39 §6.13 (Phase B-lite) introduces the x19/x20 slots so the JIT
+// can cover functions whose linear-scan allocator chose 8 or 9 live
+// registers. When fn.NumRegs > 7, the prologue pushes STP x19, x20,
+// [SP, #-16]! and every exit path (OpReturn, deopt stub) restores via
+// LDP x19, x20, [SP], #16 so the stack stays balanced. x0 (the regs
+// pointer) is caller-saved and is preserved through the body since no
+// arithmetic opcode touches it.
+func r2x(r int32) uint32 {
+	switch r {
+	case 7:
+		return 19
+	case 8:
+		return 20
+	default:
+		return uint32(r) + 9
+	}
+}
+
+// usesCalleeSaved reports whether fn needs the STP/LDP x19/x20 frame.
+// True iff the function actually uses r7 or r8 (NumRegs > 7, clamped
+// at maxRegs).
+func usesCalleeSaved(fn *vm2.Function) bool {
+	n := fn.NumRegs
+	if n > maxRegs {
+		n = maxRegs
+	}
+	return n > 7
+}
 
 // --- AArch64 instruction encoders ---
 
@@ -56,6 +84,22 @@ func ldur64(xt, xn uint32, imm9 int32) uint32 {
 }
 func str64(xt, xn, imm12 uint32) uint32 {
 	return 0xF9000000 | ((imm12 & 0xFFF) << 10) | ((xn & 0x1F) << 5) | (xt & 0x1F)
+}
+
+// stpPreIdx64 emits STP Xt1, Xt2, [Xn, #imm]! (64-bit pre-index, writeback).
+// imm is the byte offset (signed, range -512..504, must be multiple of 8).
+// Base 0xA9800000: opc=10, V=0, L=0, pre-index with writeback.
+func stpPreIdx64(rt1, rt2, rn uint32, imm int32) uint32 {
+	imm7 := uint32(imm/8) & 0x7F
+	return 0xA9800000 | (imm7 << 15) | ((rt2 & 0x1F) << 10) | ((rn & 0x1F) << 5) | (rt1 & 0x1F)
+}
+
+// ldpPostIdx64 emits LDP Xt1, Xt2, [Xn], #imm (64-bit post-index, writeback).
+// imm is the byte offset applied after the load (signed, multiple of 8).
+// Base 0xA8C00000: opc=10, V=0, L=1, post-index with writeback.
+func ldpPostIdx64(rt1, rt2, rn uint32, imm int32) uint32 {
+	imm7 := uint32(imm/8) & 0x7F
+	return 0xA8C00000 | (imm7 << 15) | ((rt2 & 0x1F) << 10) | ((rn & 0x1F) << 5) | (rt1 & 0x1F)
 }
 func bImm(off26 int32) uint32 { return 0x14000000 | uint32(off26&0x3FFFFFF) }
 func bCond(cond uint32, off19 int32) uint32 {
@@ -296,7 +340,13 @@ func instrWordCountARM64(fn *vm2.Function, ins vm2.Instr) (int, error) {
 		if n > maxRegs {
 			n = maxRegs
 		}
-		return n + 2, nil // N×str + mov x0 + ret
+		// N×str + mov x0 + ret, plus LDP x19,x20 when the function uses
+		// the callee-saved frame (NumRegs > 7, MEP-39 §6.13).
+		w := n + 2
+		if usesCalleeSaved(fn) {
+			w++
+		}
+		return w, nil
 	case vm2.OpListLen:
 		return listLenWords(fn), nil
 	default:
@@ -376,9 +426,10 @@ func isDeoptableOp(op vm2.Op) bool {
 // deoptStubWords returns the fixed word count of a deopt stub for a
 // function with this many live JIT registers. Sequence:
 //
-//	N × str64(x(9+r), x0, r)   spill live regs back to regs[]
-//	4 × movImm64(x0, sentinel)  load sentinel-tagged PC
-//	1 × ret                     return to wrapper
+//	N × str64(x_r, x0, r)         spill live regs back to regs[]
+//	(opt) LDP x19, x20, [SP], #16 restore callee-saved frame
+//	4 × movImm64(x0, sentinel)    load sentinel-tagged PC
+//	1 × ret                       return to wrapper
 //
 // PC is the deopting bytecode index, embedded as a 64-bit immediate so
 // the stub is position-independent and the per-opcode size stays
@@ -388,7 +439,11 @@ func deoptStubWords(fn *vm2.Function) int {
 	if n > maxRegs {
 		n = maxRegs
 	}
-	return n + 4 + 1
+	w := n + 4 + 1
+	if usesCalleeSaved(fn) {
+		w++
+	}
+	return w
 }
 
 // compileFnARM64 performs the two-pass compilation:
@@ -419,19 +474,31 @@ func compileFnARM64(fn *vm2.Function) ([]uint32, error) {
 	return words, nil
 }
 
-// prologueARM64 emits the N ldr64 instructions that load vm2 registers
-// from the regs pointer in x0 into x9..x(9+N-1).
+// prologueARM64 emits the function entry sequence. When the function
+// uses the callee-saved register frame (NumRegs > 7) the prologue first
+// pushes x19/x20 via STP, then it loads each live vm2 register from the
+// regs pointer in x0 into its host x register (via r2x).
 func prologueARM64(fn *vm2.Function) []uint32 {
 	n := fn.NumRegs
 	if n > maxRegs {
 		n = maxRegs
 	}
-	ws := make([]uint32, n)
+	saveFrame := usesCalleeSaved(fn)
+	cap := n
+	if saveFrame {
+		cap++
+	}
+	ws := make([]uint32, 0, cap)
+	if saveFrame {
+		// stp x19, x20, [sp, #-16]!  — push the two callee-saved regs.
+		// SP stays 16-byte aligned (AAPCS64).
+		ws = append(ws, stpPreIdx64(19, 20, 31, -16))
+	}
 	for r := 0; r < n; r++ {
 		// Cell is 16 bytes (Bits at offset 0, Obj at offset 8). The
 		// ldr64 imm12 is scaled by 8, so r*2 yields byte offset r*16,
-		// loading regs[r].Bits into x(9+r).
-		ws[r] = ldr64(uint32(9+r), 0, uint32(r)*2)
+		// loading regs[r].Bits into r2x(r).
+		ws = append(ws, ldr64(r2x(int32(r)), 0, uint32(r)*2))
 	}
 	return ws
 }
@@ -587,13 +654,19 @@ func lowerInstrARM64(fn *vm2.Function, idx int, ins vm2.Instr, pcMap []int) ([]u
 		if n > maxRegs {
 			n = maxRegs
 		}
-		ws := make([]uint32, 0, n+2)
+		ws := make([]uint32, 0, n+3)
 		for r := 0; r < n; r++ {
 			// 16-byte Cell stride: imm12 scaled by 8, so r*2 = byte
-			// offset r*16. Stores x(9+r) into regs[r].Bits.
-			ws = append(ws, str64(uint32(9+r), 0, uint32(r)*2))
+			// offset r*16. Stores r2x(r) into regs[r].Bits.
+			ws = append(ws, str64(r2x(int32(r)), 0, uint32(r)*2))
 		}
-		ws = append(ws, movReg(0, uint32(9+int(ins.A)))) // x0 = result Cell
+		// Move the result register to x0 BEFORE restoring callee-saved.
+		// If r2x(ins.A) is x19 or x20, LDP would clobber the result.
+		ws = append(ws, movReg(0, r2x(int32(ins.A))))
+		if usesCalleeSaved(fn) {
+			// ldp x19, x20, [sp], #16 — restore callee-saved frame.
+			ws = append(ws, ldpPostIdx64(19, 20, 31, 16))
+		}
 		ws = append(ws, ret())
 		return ws, nil
 
@@ -610,21 +683,29 @@ func lowerInstrARM64(fn *vm2.Function, idx int, ins vm2.Instr, pcMap []int) ([]u
 
 // emitDeoptStubARM64 emits the Phase 1.5 deopt sequence for the
 // instruction at bytecode index idx. Each live JIT register is spilled
-// back to its slot in regs[]; x0 is loaded with vm2.EncodeDeopt(idx);
-// the function returns. The wrapper in init.go inspects x0, detects the
-// sentinel via vm2.DecodeDeopt, promotes the JIT frame to a real vm2
-// frame at IP=idx, and resumes the interpreter for that frame.
+// back to its slot in regs[]; if the function uses the callee-saved
+// frame (MEP-39 §6.13) the stub also pops it; x0 is loaded with
+// vm2.EncodeDeopt(idx); the function returns. The wrapper in init.go
+// inspects x0, detects the sentinel via vm2.DecodeDeopt, promotes the
+// JIT frame to a real vm2 frame at IP=idx, and resumes the interpreter
+// for that frame.
 func emitDeoptStubARM64(fn *vm2.Function, idx int) []uint32 {
 	n := fn.NumRegs
 	if n > maxRegs {
 		n = maxRegs
 	}
 	sentinel := vm2.EncodeDeopt(idx).Bits
-	ws := make([]uint32, 0, n+4+1)
+	ws := make([]uint32, 0, n+4+2)
 	for r := 0; r < n; r++ {
 		// 16-byte Cell stride: imm12*8 = byte offset, so r*2 spills
-		// x(9+r) back to regs[r].Bits.
-		ws = append(ws, str64(uint32(9+r), 0, uint32(r)*2))
+		// r2x(r) back to regs[r].Bits.
+		ws = append(ws, str64(r2x(int32(r)), 0, uint32(r)*2))
+	}
+	if usesCalleeSaved(fn) {
+		// ldp x19, x20, [sp], #16 — must come AFTER the spills so the
+		// JIT-side x19/x20 values reach regs[] before the caller's
+		// originals are restored.
+		ws = append(ws, ldpPostIdx64(19, 20, 31, 16))
 	}
 	ws = append(ws, movImm64(0, int64(sentinel))...)
 	ws = append(ws, ret())
@@ -712,8 +793,10 @@ func emitCondBranchARM64(xA, xB uint32, targetBC int, cond uint32,
 	}, nil
 }
 
-// maxRegs is the maximum number of vm2 registers the JIT can handle (x9-x15).
-const maxRegs = 7
+// maxRegs is the maximum number of vm2 registers the JIT can handle:
+// x9-x15 (caller-saved temps, 7 slots) plus x19, x20 (callee-saved,
+// pushed by the STP/LDP frame in prologueARM64). MEP-39 §6.13.
+const maxRegs = 9
 
 // lowerFnARM64 is the full-function entry point called by lower.go on arm64.
 func lowerFnARM64(fn *vm2.Function) ([]uint32, error) {

--- a/runtime/jit/vm2jit/vm2jit_test.go
+++ b/runtime/jit/vm2jit/vm2jit_test.go
@@ -436,6 +436,107 @@ func TestCountLoop(t *testing.T) {
 	}
 }
 
+// TestCalleeSavedReturnR7 exercises the MEP-39 §6.13 Phase B-lite path
+// (NumRegs=8): the prologue must STP x19/x20 onto the stack, the body
+// must read r7 from x19, and OpReturn must spill x19 into regs[7]
+// before LDP restores the caller's x19. Returning r7 specifically
+// catches the ordering bug where LDP runs before the result move.
+func TestCalleeSavedReturnR7(t *testing.T) {
+	fn := &vm2.Function{
+		Name:    "ret_r7",
+		NumRegs: 8,
+		Code:    []vm2.Instr{{Op: vm2.OpReturn, A: 7}},
+	}
+	compileOrSkip(t, fn)
+	want := vm2.CInt(0xABCDEF)
+	r := regs(8, vm2.CInt(0), vm2.CInt(0), vm2.CInt(0), vm2.CInt(0),
+		vm2.CInt(0), vm2.CInt(0), vm2.CInt(0), want)
+	got := callJIT(fn, r)
+	if got != want {
+		t.Fatalf("r7: got %016x, want %016x", got.Bits, want.Bits)
+	}
+}
+
+// TestCalleeSavedReturnR8 mirrors the above for r8 -> x20. This is the
+// second slot in the STP/LDP pair; if the pre-index offset or the Rt2
+// field is wrong, the JIT'd code will crash or return the wrong value.
+func TestCalleeSavedReturnR8(t *testing.T) {
+	fn := &vm2.Function{
+		Name:    "ret_r8",
+		NumRegs: 9,
+		Code:    []vm2.Instr{{Op: vm2.OpReturn, A: 8}},
+	}
+	compileOrSkip(t, fn)
+	want := vm2.CInt(-12345)
+	r := regs(9, vm2.CInt(0), vm2.CInt(0), vm2.CInt(0), vm2.CInt(0),
+		vm2.CInt(0), vm2.CInt(0), vm2.CInt(0), vm2.CInt(0), want)
+	got := callJIT(fn, r)
+	if got != want {
+		t.Fatalf("r8: got %016x, want %016x", got.Bits, want.Bits)
+	}
+}
+
+// TestCalleeSavedAddR7R8 exercises arithmetic on r7+r8 (both callee-
+// saved slots) and returns r0. The body unboxes from x19, x20, computes
+// in x8, masks/retags, and writes back to x9 (r0). Catches r2x mapping
+// errors that confuse caller-saved and callee-saved slots.
+func TestCalleeSavedAddR7R8(t *testing.T) {
+	fn := &vm2.Function{
+		Name:    "add_r7_r8",
+		NumRegs: 9,
+		Code: []vm2.Instr{
+			// r0 = r7 + r8
+			{Op: vm2.OpAddI64, A: 0, B: 7, C: 8},
+			{Op: vm2.OpReturn, A: 0},
+		},
+	}
+	compileOrSkip(t, fn)
+	r := regs(9, vm2.CInt(0), vm2.CInt(0), vm2.CInt(0), vm2.CInt(0),
+		vm2.CInt(0), vm2.CInt(0), vm2.CInt(0),
+		vm2.CInt(100), vm2.CInt(23))
+	got := callJIT(fn, r)
+	if got.Int() != 123 {
+		t.Fatalf("add_r7_r8: got %d, want 123", got.Int())
+	}
+}
+
+// TestCalleeSavedDeoptStub exercises the deopt path when the function
+// uses the callee-saved frame. The deopt stub must spill r7 from x19
+// (and r8 from x20 when present) before LDP restores the caller's
+// values, then load the sentinel into x0 and RET with a balanced
+// stack. CallDirect does not run resumeFromDeopt, so the sentinel
+// itself is the expected return; the test passes if the trampoline
+// returns cleanly without a crash.
+func TestCalleeSavedDeoptStub(t *testing.T) {
+	// r1 = bytesNew(r0)  — OpBytesNew is always a deopt. The deopt
+	// stub fires immediately; r7 must round-trip into regs[7] so the
+	// interpreter sees the correct state if it ever runs resume.
+	fn := &vm2.Function{
+		Name:    "deopt_r7",
+		NumRegs: 8,
+		Code: []vm2.Instr{
+			{Op: vm2.OpBytesNew, A: 1, B: 0},
+			{Op: vm2.OpReturn, A: 7},
+		},
+	}
+	cf, err := vm2jit.Compile(fn)
+	if err != nil {
+		t.Skipf("Compile: %v", err)
+	}
+	defer cf.Free()
+
+	got := vm2jit.CallDirect(fn, nil, []vm2.Cell{
+		vm2.CInt(0), {}, {}, {}, {}, {}, {}, vm2.CInt(7777),
+	})
+	pc, ok := vm2.DecodeDeopt(got)
+	if !ok {
+		t.Fatalf("expected deopt sentinel, got %016x", got.Bits)
+	}
+	if pc != 0 {
+		t.Fatalf("expected deopt at pc=0, got pc=%d", pc)
+	}
+}
+
 // TestNaNBoxingRoundtrip verifies that the JIT correctly round-trips extreme
 // int48 values through the NaN-boxing pack/unpack cycle.
 func TestNaNBoxingRoundtrip(t *testing.T) {

--- a/website/docs/mep/mep-0039.md
+++ b/website/docs/mep/mep-0039.md
@@ -2930,6 +2930,89 @@ the BG corpora it inflates `NumRegs` for three reasons:
 
 The next iteration writes Phase A.
 
+### 6.13 Iter 12: Phase B step 1, callee-saved x19/x20 frame
+
+**Theory.** The §6.12 staged plan listed Phase A (reclaim x16/x17 as JIT
+register slots) before Phase B (callee-saved x19..x28). On a closer
+read of `runtime/jit/vm2jit/lower_arm64.go`, x17 is not actually free:
+`OpModI64` needs three live scratches simultaneously (sbfx C into x17,
+sdivReg into x16, msubReg A from x8+x16+x17), and `OpAddI64K`/list-len
+fast paths each hold either x16 or x17 across multiple instructions.
+Reclaiming a second slot would mean spilling temporaries to memory or
+splitting `OpModI64` into a longer sequence, both of which cost more in
+the hot path than they buy. Phase A is therefore deferred indefinitely
+and the first step of Phase B lands first: take the first STP/LDP pair
+of callee-saved GPRs (x19, x20) and use them as additional JIT register
+slots for r7 and r8. This bumps `maxJITRegs` from 7 to 9 with a
+one-instruction prologue (STP, 16-byte stack push) and a
+one-instruction epilogue (LDP) on every exit path.
+
+**Mechanism.**
+
+- `r2x(r)` becomes a switch: r0..r6 -> x9..x15 (caller-saved, no save
+  needed), r7 -> x19, r8 -> x20 (callee-saved, must STP/LDP).
+- `usesCalleeSaved(fn)` reports true iff `fn.NumRegs > 7`. When true,
+  the prologue emits `stp x19, x20, [sp, #-16]!`; every `OpReturn` and
+  every deopt stub emits `ldp x19, x20, [sp], #16` so the stack is
+  rebalanced. The push/pop is unconditional when the function uses
+  r7 or r8 (we do not selectively save x19 vs x20 because the cost of
+  a single STP/LDP pair is the same as either alone).
+- AAPCS64 requires SP to stay 16-byte aligned; the 16-byte STP frame
+  preserves that. x18 is platform-reserved on Darwin and is therefore
+  not used by the JIT.
+- The deopt stub must spill x19/x20 to `regs[7]`/`regs[8]` _before_
+  LDP runs, so the JIT-side r7/r8 values reach the interpreter when
+  `resumeFromDeopt` copies `jf.regs[..]` back into the vm2 frame.
+  Likewise `OpReturn` must move the result register to x0 before LDP,
+  in case the result is r7 (x19) or r8 (x20) which LDP would clobber.
+- The two-pass pcMap accounting in `instrWordCountARM64` is updated:
+  `OpReturn` word count grows by 1 when `usesCalleeSaved` is true,
+  and `deoptStubWords` grows by 1 (the LDP word). Prologue length is
+  read directly from `prologueARM64(fn)`'s return slice so `pcMap[0]`
+  stays correct without a separate constant.
+
+**Implementation.**
+
+```
+runtime/jit/vm2jit/lower_arm64.go
+  - r2x: switch r {case 7: x19; case 8: x20; default: x(9+r)}
+  - usesCalleeSaved(fn): NumRegs (clamped) > 7
+  - stpPreIdx64, ldpPostIdx64: AArch64 STP/LDP encoders, imm7 scaled by 8
+  - prologueARM64: prepend STP when usesCalleeSaved
+  - OpReturn lowering: movReg(0, result) before optional LDP, then ret
+  - emitDeoptStubARM64: spill via r2x, optional LDP, movImm64 sentinel, ret
+  - maxRegs: 7 -> 9
+runtime/jit/vm2jit/compile.go
+  - maxJITRegs: 7 -> 9 (jitFrame regs array auto-resizes)
+runtime/jit/vm2jit/vm2jit_test.go
+  - TestCalleeSavedReturnR7 / R8: return r7 / r8 directly to exercise
+    the STP/LDP frame and the movReg-before-LDP ordering
+  - TestCalleeSavedAddR7R8: arithmetic on x19+x20 to verify the SBFX/
+    ADD/ORR sequence works for the new register slots
+  - TestCalleeSavedDeoptStub: OpBytesNew (always-deopt) with NumRegs=8
+    confirms the stub's LDP balances the stack so the trampoline RET
+    lands cleanly with the sentinel in x0
+```
+
+**Bench note.** Phase B step 1 lifts the JIT cap to 9 registers. The
+coverage probe in §6.12 shows the smallest BG hot function is
+`spectral_norm.fill` at NumRegs=11, so this iteration on its own does
+not flip any BG program into the JIT. It is scaffolding for the rest
+of Phase B (x21..x28, four more STP/LDP pairs) which will cover the
+11..19-register functions where the bulk of the FP-heavy BG hot code
+lives. The smallest BG functions that will JIT once the next pair
+(x21, x22, cap=11) lands are `spectral_norm.fill` (11) and
+`mandelbrot.main` (12); the pair after that (x23, x24, cap=13) adds
+`spectral_norm.main` (13) and `mandelbrot.sumU8` (14).
+
+The coverage probe still reports the same 1/21 JIT-OK ratio
+(`spectral_norm.evalA` only). All existing JIT tests pass. No
+crosslang benchmark moved because no new function entered the JIT.
+
+The next iteration extends the prologue to the second STP/LDP pair
+(x21, x22) so functions up to NumRegs=11 can JIT, then bench
+spectral_norm to see whether `fill` JITing alone bends the curve.
+
 ### 6.x (template for future iterations)
 
 Each new program lands in 6.x with the same theory / mechanism /


### PR DESCRIPTION
## Summary

- Iter 12 lands Phase B step 1 from the §6.12 staged plan: map r7, r8 onto AArch64 x19, x20 behind a one-instruction STP/LDP frame, bumping `maxJITRegs` from 7 to 9.
- Phase A (reclaim x16/x17) is deferred indefinitely; `OpModI64` needs x8+x16+x17 simultaneously, so reclaiming x17 would split mod into a slower sequence.
- Scaffolding for the rest of Phase B (x21..x28, four more STP/LDP pairs) which will cover the 11..19-register BG hot functions where the FP-heavy code lives. No BG program moves yet because the smallest BG hot function is `spectral_norm.fill` at NumRegs=11.

Linked tracking issue: see comment for cross-link.

## Test plan

- [x] `go test ./runtime/jit/vm2jit/...` (all green; old tests unchanged)
- [x] `go test -tags numregs_probe -run TestJITCoverageProbe -v ./runtime/jit/vm2jit/` (1/21 JIT-OK, unchanged; new cap reflected in skip messages)
- [x] New tests `TestCalleeSavedReturnR7 / R8 / AddR7R8 / DeoptStub` exercise the STP/LDP frame, the movReg-before-LDP ordering, and the deopt-stub LDP balance.
- [x] `go test ./runtime/vm2/... ./compiler2/...` (no regressions)
- [x] Spec section §6.13 added; no bare `<` (MDX) tokens outside backticks.