### PR TITLE
mep-0039 §6.14: Phase B full STP/LDP frame (cap=17) + profitability gate

### DIFF
--- a/runtime/jit/vm2jit/compile.go
+++ b/runtime/jit/vm2jit/compile.go
@@ -46,10 +46,21 @@ func (c *CompiledFunc) Free() error {
 // maxJITRegs is the maximum number of vm2 registers supported by any JIT
 // backend. Functions with more registers must be interpreted.
 //
-// MEP-39 §6.13 (Phase B-lite) bumps the limit from 7 to 9 by adding two
-// callee-saved slots (x19, x20 on AArch64) behind an STP/LDP frame.
-// Phase B-full will push the remaining x21..x28 in 80-byte STP pairs.
-const maxJITRegs = 9
+// MEP-39 §6.14 (Phase B full) takes the limit from 9 to 17 by pushing
+// all five AArch64 callee-saved GPR pairs (x19..x28) in the prologue.
+// The cap lift exposes a follow-up regression: outer-loop functions
+// that newly JIT but still deopt on every OpCall to non-JIT'd inner
+// loops can pay more in prologue + deopt-resume than they save. The
+// regression is recorded in §6.14 and addressed by gating with
+// jitProfitable (this file) until iter 14 lowers OpCall as a JIT-side
+// fast path.
+const maxJITRegs = 17
+
+// ErrUnprofitable is returned by Compile when fn is structurally
+// unprofitable to JIT under the current backend (see jitProfitable).
+// It is wrapped in ErrNotImplemented so existing callers that only
+// distinguish "JIT'd vs interp" continue to work.
+var ErrUnprofitable = fmt.Errorf("%w: deopt fraction too high", ErrNotImplemented)
 
 func Compile(fn *vm2.Function) (*CompiledFunc, error) {
 	if hostArch < 0 {
@@ -58,6 +69,20 @@ func Compile(fn *vm2.Function) (*CompiledFunc, error) {
 	if fn.NumRegs > maxJITRegs {
 		return nil, fmt.Errorf("%w: %s uses %d registers (max %d)",
 			ErrNotImplemented, fn.Name, fn.NumRegs, maxJITRegs)
+	}
+	if !jitProfitable(fn) {
+		return nil, fmt.Errorf("%w: %s", ErrUnprofitable, fn.Name)
+	}
+	return compileNoGate(fn)
+}
+
+// compileNoGate lowers fn unconditionally (skipping the cap and
+// profitability gate Compile applies). The deopt-stub tests use this
+// via export_test.go to exercise machinery that the public gate would
+// reject as unprofitable.
+func compileNoGate(fn *vm2.Function) (*CompiledFunc, error) {
+	if hostArch < 0 {
+		return nil, ErrUnsupported
 	}
 	words, err := lowerFunction(fn, hostArch)
 	if err != nil {
@@ -72,8 +97,6 @@ func Compile(fn *vm2.Function) (*CompiledFunc, error) {
 		return nil, err
 	}
 	cf := &CompiledFunc{fn: fn, code: page, arch: hostArch}
-	// Install the entry point. The trampoline reads this pointer to call
-	// into the JIT'd code; vm2's OpCall hook checks fn.JITCode != nil.
 	fn.JITCode = pageEntry(page)
 	return cf, nil
 }

--- a/runtime/jit/vm2jit/export_test.go
+++ b/runtime/jit/vm2jit/export_test.go
@@ -9,6 +9,15 @@ import (
 	"mochi/runtime/vm2"
 )
 
+// CompileForceForTest lowers fn unconditionally, skipping the
+// profitability and cap gates the public Compile applies. Tests use
+// this to exercise the deopt stub machinery on small synthetic
+// functions that the gate would reject. Production callers must use
+// Compile.
+func CompileForceForTest(fn *vm2.Function) (*CompiledFunc, error) {
+	return compileNoGate(fn)
+}
+
 // CallDirect is exported for test/benchmark use only.
 // It creates a jitFrame with the given vm pointer and register values,
 // then invokes fn's JIT code via the trampoline. vm may be nil for

--- a/runtime/jit/vm2jit/lower_arm64.go
+++ b/runtime/jit/vm2jit/lower_arm64.go
@@ -10,37 +10,91 @@ import (
 
 // AArch64 GPR mapping: vm2 register r[i] -> host x register.
 //
-//	r[0..6] -> x9..x15  (caller-saved temps; no save/restore needed)
-//	r[7]    -> x19      (callee-saved; requires STP/LDP frame)
-//	r[8]    -> x20      (callee-saved; requires STP/LDP frame)
+//	r[0..6]  -> x9..x15  (caller-saved temps; no save/restore needed)
+//	r[7..16] -> x19..x28 (callee-saved; pushed as 1..5 STP/LDP pairs)
 //
-// MEP-39 §6.13 (Phase B-lite) introduces the x19/x20 slots so the JIT
-// can cover functions whose linear-scan allocator chose 8 or 9 live
-// registers. When fn.NumRegs > 7, the prologue pushes STP x19, x20,
-// [SP, #-16]! and every exit path (OpReturn, deopt stub) restores via
-// LDP x19, x20, [SP], #16 so the stack stays balanced. x0 (the regs
-// pointer) is caller-saved and is preserved through the body since no
-// arithmetic opcode touches it.
+// MEP-39 §6.14 (Phase B) generalises §6.13's single-pair frame to all
+// five AArch64 callee-saved GPR pairs. The prologue pushes
+// numCalleeSavedPairs(fn) STP frames (pre-index, 16-byte each); every
+// exit path (OpReturn, deopt stub) pops them in reverse order via LDP
+// post-index. x0 (the regs pointer) is caller-saved and survives the
+// body since no arithmetic opcode touches it. x18 is Darwin-reserved
+// and is never used.
 func r2x(r int32) uint32 {
-	switch r {
-	case 7:
-		return 19
-	case 8:
-		return 20
-	default:
+	if r < 7 {
 		return uint32(r) + 9
 	}
+	return uint32(r) + 12 // r7->x19, r8->x20, ..., r16->x28
 }
 
-// usesCalleeSaved reports whether fn needs the STP/LDP x19/x20 frame.
-// True iff the function actually uses r7 or r8 (NumRegs > 7, clamped
-// at maxRegs).
-func usesCalleeSaved(fn *vm2.Function) bool {
+// numCalleeSavedPairs returns the number of x19..x28 STP/LDP pairs the
+// frame for fn must push. Each pair covers two register slots; an
+// 8-register function still pushes the first pair (x19/x20) even
+// though x20 is unused, because pre-index STP is a 16-byte
+// alignment-preserving 1-instruction op and partial pairs would waste
+// alignment without saving anything.
+func numCalleeSavedPairs(fn *vm2.Function) int {
 	n := fn.NumRegs
 	if n > maxRegs {
 		n = maxRegs
 	}
-	return n > 7
+	if n <= 7 {
+		return 0
+	}
+	return (n - 7 + 1) / 2
+}
+
+// jitProfitable is a static profitability gate for Phase B functions.
+// The current backend deopts at the first non-lowered opcode and never
+// re-enters JIT for that invocation, so any deoptable op on the hot
+// path means the JIT pays prologue + spill + LDP + sentinel + a
+// Go-side resumeFromDeopt for zero saved work.
+//
+// MEP-39 §6.14 records the concrete regression that motivated this
+// gate: bumping the register cap from 9 to 17 newly admits outer
+// "controller" functions (e.g. spectral_norm.main, mandelbrot.main)
+// whose bodies are dominated by OpCall into still-non-JIT inner
+// kernels. Without the gate the deopt-on-call thrash made the BG-vs-Go
+// ratio strictly worse on a focused crosslang run.
+//
+// The gate only kicks in for functions that need the §6.14 frame
+// extension (NumRegs > 9). Functions that already fit under §6.13's
+// single-pair frame keep the pre-Phase-B policy: any JIT'd code is
+// kept, on the empirical evidence that the §6.13 baseline was a win
+// at 1/21 BG coverage. This avoids regressing the existing baseline
+// just because the deopt-fraction heuristic happens to be pessimistic
+// on a small fn.
+//
+// Heuristic: among newly-admitted functions, if the body has any
+// deoptable op AND non-deopt ops are fewer than
+// profitabilityNonDeoptRatio per deopt, refuse to JIT. The ratio is
+// conservative (10:1) so inner loops with one entry-time deopt (e.g.
+// NewU8Array followed by a long arithmetic body) still JIT, but the
+// "alloc + N Calls + Return" controller shape is rejected.
+//
+// Once iter 14 lowers OpCall as a JIT-side fast path so JIT'd-to-JIT'd
+// calls do not deopt, this gate relaxes (likely to NumRegs > maxRegs
+// only, i.e. effectively off).
+const profitabilityNonDeoptRatio = 10
+
+func jitProfitable(fn *vm2.Function) bool {
+	// Functions that fit under §6.13's single-pair frame use the
+	// pre-Phase-B policy (no gate). Only the newly-admitted §6.14
+	// functions need profitability scrutiny.
+	if fn.NumRegs <= 9 {
+		return true
+	}
+	deopt := 0
+	for _, ins := range fn.Code {
+		if isDeoptableOp(ins.Op) {
+			deopt++
+		}
+	}
+	if deopt == 0 {
+		return true
+	}
+	nonDeopt := len(fn.Code) - deopt
+	return nonDeopt >= profitabilityNonDeoptRatio*deopt
 }
 
 // --- AArch64 instruction encoders ---
@@ -340,13 +394,9 @@ func instrWordCountARM64(fn *vm2.Function, ins vm2.Instr) (int, error) {
 		if n > maxRegs {
 			n = maxRegs
 		}
-		// N×str + mov x0 + ret, plus LDP x19,x20 when the function uses
-		// the callee-saved frame (NumRegs > 7, MEP-39 §6.13).
-		w := n + 2
-		if usesCalleeSaved(fn) {
-			w++
-		}
-		return w, nil
+		// N×str + mov x0 + numPairs×LDP + ret. The LDPs unwind the
+		// callee-saved frame established by the prologue. MEP-39 §6.14.
+		return n + 2 + numCalleeSavedPairs(fn), nil
 	case vm2.OpListLen:
 		return listLenWords(fn), nil
 	default:
@@ -426,10 +476,10 @@ func isDeoptableOp(op vm2.Op) bool {
 // deoptStubWords returns the fixed word count of a deopt stub for a
 // function with this many live JIT registers. Sequence:
 //
-//	N × str64(x_r, x0, r)         spill live regs back to regs[]
-//	(opt) LDP x19, x20, [SP], #16 restore callee-saved frame
-//	4 × movImm64(x0, sentinel)    load sentinel-tagged PC
-//	1 × ret                       return to wrapper
+//	N × str64(x_r, x0, r)               spill live regs back to regs[]
+//	numPairs × LDP x{2k+19}, x{2k+20}   restore callee-saved frame
+//	4 × movImm64(x0, sentinel)          load sentinel-tagged PC
+//	1 × ret                             return to wrapper
 //
 // PC is the deopting bytecode index, embedded as a 64-bit immediate so
 // the stub is position-independent and the per-opcode size stays
@@ -439,11 +489,7 @@ func deoptStubWords(fn *vm2.Function) int {
 	if n > maxRegs {
 		n = maxRegs
 	}
-	w := n + 4 + 1
-	if usesCalleeSaved(fn) {
-		w++
-	}
-	return w
+	return n + numCalleeSavedPairs(fn) + 4 + 1
 }
 
 // compileFnARM64 performs the two-pass compilation:
@@ -474,31 +520,40 @@ func compileFnARM64(fn *vm2.Function) ([]uint32, error) {
 	return words, nil
 }
 
-// prologueARM64 emits the function entry sequence. When the function
-// uses the callee-saved register frame (NumRegs > 7) the prologue first
-// pushes x19/x20 via STP, then it loads each live vm2 register from the
-// regs pointer in x0 into its host x register (via r2x).
+// prologueARM64 emits the function entry sequence. The prologue first
+// pushes numCalleeSavedPairs(fn) STP/LDP pairs of x19..x28 (each as a
+// pre-index `stp x{2k+19}, x{2k+20}, [sp, #-16]!`), then loads each
+// live vm2 register from the regs pointer in x0 into its host x
+// register (via r2x). SP stays 16-byte aligned because each STP is a
+// 16-byte push (AAPCS64).
 func prologueARM64(fn *vm2.Function) []uint32 {
 	n := fn.NumRegs
 	if n > maxRegs {
 		n = maxRegs
 	}
-	saveFrame := usesCalleeSaved(fn)
-	cap := n
-	if saveFrame {
-		cap++
-	}
-	ws := make([]uint32, 0, cap)
-	if saveFrame {
-		// stp x19, x20, [sp, #-16]!  — push the two callee-saved regs.
-		// SP stays 16-byte aligned (AAPCS64).
-		ws = append(ws, stpPreIdx64(19, 20, 31, -16))
+	pairs := numCalleeSavedPairs(fn)
+	ws := make([]uint32, 0, n+pairs)
+	for k := 0; k < pairs; k++ {
+		// Push pair k = (x_{2k+19}, x_{2k+20}). Pre-index writeback
+		// drops SP by 16 each time. Reverse order in the epilogue.
+		ws = append(ws, stpPreIdx64(uint32(2*k+19), uint32(2*k+20), 31, -16))
 	}
 	for r := 0; r < n; r++ {
 		// Cell is 16 bytes (Bits at offset 0, Obj at offset 8). The
 		// ldr64 imm12 is scaled by 8, so r*2 yields byte offset r*16,
 		// loading regs[r].Bits into r2x(r).
 		ws = append(ws, ldr64(r2x(int32(r)), 0, uint32(r)*2))
+	}
+	return ws
+}
+
+// emitCalleeSavedEpilogueARM64 appends numPairs `ldp x{2k+19},
+// x{2k+20}, [sp], #16` instructions to ws in REVERSE order of the
+// prologue's pushes, so each LDP pops the topmost STP frame and SP
+// returns to its entry value.
+func emitCalleeSavedEpilogueARM64(ws []uint32, pairs int) []uint32 {
+	for k := pairs - 1; k >= 0; k-- {
+		ws = append(ws, ldpPostIdx64(uint32(2*k+19), uint32(2*k+20), 31, 16))
 	}
 	return ws
 }
@@ -654,19 +709,17 @@ func lowerInstrARM64(fn *vm2.Function, idx int, ins vm2.Instr, pcMap []int) ([]u
 		if n > maxRegs {
 			n = maxRegs
 		}
-		ws := make([]uint32, 0, n+3)
+		pairs := numCalleeSavedPairs(fn)
+		ws := make([]uint32, 0, n+pairs+2)
 		for r := 0; r < n; r++ {
 			// 16-byte Cell stride: imm12 scaled by 8, so r*2 = byte
 			// offset r*16. Stores r2x(r) into regs[r].Bits.
 			ws = append(ws, str64(r2x(int32(r)), 0, uint32(r)*2))
 		}
 		// Move the result register to x0 BEFORE restoring callee-saved.
-		// If r2x(ins.A) is x19 or x20, LDP would clobber the result.
+		// If r2x(ins.A) is one of x19..x28, the LDPs would clobber it.
 		ws = append(ws, movReg(0, r2x(int32(ins.A))))
-		if usesCalleeSaved(fn) {
-			// ldp x19, x20, [sp], #16 — restore callee-saved frame.
-			ws = append(ws, ldpPostIdx64(19, 20, 31, 16))
-		}
+		ws = emitCalleeSavedEpilogueARM64(ws, pairs)
 		ws = append(ws, ret())
 		return ws, nil
 
@@ -684,29 +737,27 @@ func lowerInstrARM64(fn *vm2.Function, idx int, ins vm2.Instr, pcMap []int) ([]u
 // emitDeoptStubARM64 emits the Phase 1.5 deopt sequence for the
 // instruction at bytecode index idx. Each live JIT register is spilled
 // back to its slot in regs[]; if the function uses the callee-saved
-// frame (MEP-39 §6.13) the stub also pops it; x0 is loaded with
-// vm2.EncodeDeopt(idx); the function returns. The wrapper in init.go
-// inspects x0, detects the sentinel via vm2.DecodeDeopt, promotes the
-// JIT frame to a real vm2 frame at IP=idx, and resumes the interpreter
-// for that frame.
+// frame (MEP-39 §6.14) the stub also pops every pair in reverse order;
+// x0 is loaded with vm2.EncodeDeopt(idx); the function returns. The
+// wrapper in init.go inspects x0, detects the sentinel via
+// vm2.DecodeDeopt, promotes the JIT frame to a real vm2 frame at
+// IP=idx, and resumes the interpreter for that frame.
 func emitDeoptStubARM64(fn *vm2.Function, idx int) []uint32 {
 	n := fn.NumRegs
 	if n > maxRegs {
 		n = maxRegs
 	}
+	pairs := numCalleeSavedPairs(fn)
 	sentinel := vm2.EncodeDeopt(idx).Bits
-	ws := make([]uint32, 0, n+4+2)
+	ws := make([]uint32, 0, n+pairs+4+1)
 	for r := 0; r < n; r++ {
 		// 16-byte Cell stride: imm12*8 = byte offset, so r*2 spills
 		// r2x(r) back to regs[r].Bits.
 		ws = append(ws, str64(r2x(int32(r)), 0, uint32(r)*2))
 	}
-	if usesCalleeSaved(fn) {
-		// ldp x19, x20, [sp], #16 — must come AFTER the spills so the
-		// JIT-side x19/x20 values reach regs[] before the caller's
-		// originals are restored.
-		ws = append(ws, ldpPostIdx64(19, 20, 31, 16))
-	}
+	// Restore callee-saved pairs AFTER spills so the JIT-side values
+	// reach regs[] before the caller's originals are restored.
+	ws = emitCalleeSavedEpilogueARM64(ws, pairs)
 	ws = append(ws, movImm64(0, int64(sentinel))...)
 	ws = append(ws, ret())
 	return ws
@@ -794,9 +845,10 @@ func emitCondBranchARM64(xA, xB uint32, targetBC int, cond uint32,
 }
 
 // maxRegs is the maximum number of vm2 registers the JIT can handle:
-// x9-x15 (caller-saved temps, 7 slots) plus x19, x20 (callee-saved,
-// pushed by the STP/LDP frame in prologueARM64). MEP-39 §6.13.
-const maxRegs = 9
+// x9-x15 (caller-saved temps, 7 slots) plus x19-x28 (callee-saved,
+// pushed as up to five STP/LDP pairs by prologueARM64). MEP-39 §6.14.
+// x18 is Darwin-platform-reserved and is never used.
+const maxRegs = 17
 
 // lowerFnARM64 is the full-function entry point called by lower.go on arm64.
 func lowerFnARM64(fn *vm2.Function) ([]uint32, error) {

--- a/runtime/jit/vm2jit/lower_stub.go
+++ b/runtime/jit/vm2jit/lower_stub.go
@@ -7,3 +7,8 @@ import "mochi/runtime/vm2"
 func lowerFnARM64(_ *vm2.Function) ([]uint32, error) {
 	return nil, ErrUnsupported
 }
+
+// jitProfitable is the !arm64 stub. The arm64 backend has the deopt
+// machinery that this gate guards against; on other archs there is
+// no real JIT to be unprofitable, so the answer is trivially true.
+func jitProfitable(_ *vm2.Function) bool { return true }

--- a/runtime/jit/vm2jit/vm2jit_test.go
+++ b/runtime/jit/vm2jit/vm2jit_test.go
@@ -500,6 +500,76 @@ func TestCalleeSavedAddR7R8(t *testing.T) {
 	}
 }
 
+// TestCalleeSavedReturnR16 exercises the maximum-cap path (NumRegs=17,
+// r16 -> x28). This validates the fifth STP/LDP pair (x27, x28) and
+// confirms r2x's high boundary maps correctly.
+func TestCalleeSavedReturnR16(t *testing.T) {
+	fn := &vm2.Function{
+		Name:    "ret_r16",
+		NumRegs: 17,
+		Code:    []vm2.Instr{{Op: vm2.OpReturn, A: 16}},
+	}
+	compileOrSkip(t, fn)
+	want := vm2.CInt(0xDEADBEEF)
+	r := make([]vm2.Cell, 17)
+	for i := range r {
+		r[i] = vm2.CInt(int64(i))
+	}
+	r[16] = want
+	got := callJIT(fn, r)
+	if got != want {
+		t.Fatalf("r16: got %016x, want %016x", got.Bits, want.Bits)
+	}
+}
+
+// TestCalleeSavedAddR9R16 spans the second and fifth STP/LDP pairs
+// (x21 and x28). Catches mapping bugs where the prologue or epilogue
+// emits pairs in the wrong order or with swapped register operands.
+func TestCalleeSavedAddR9R16(t *testing.T) {
+	fn := &vm2.Function{
+		Name:    "add_r9_r16",
+		NumRegs: 17,
+		Code: []vm2.Instr{
+			{Op: vm2.OpAddI64, A: 0, B: 9, C: 16},
+			{Op: vm2.OpReturn, A: 0},
+		},
+	}
+	compileOrSkip(t, fn)
+	r := make([]vm2.Cell, 17)
+	r[9] = vm2.CInt(100)
+	r[16] = vm2.CInt(23)
+	got := callJIT(fn, r)
+	if got.Int() != 123 {
+		t.Fatalf("add_r9_r16: got %d, want 123", got.Int())
+	}
+}
+
+// TestCalleeSavedRoundTripEverySlot fills every slot r0..r16 with a
+// distinct value, returns each in turn, and verifies the JIT routes
+// the correct host register through the spill/result/LDP sequence.
+// Catches off-by-one bugs in r2x or the epilogue ordering that only
+// show up at specific register indices.
+func TestCalleeSavedRoundTripEverySlot(t *testing.T) {
+	const N = 17
+	r := make([]vm2.Cell, N)
+	for i := range r {
+		r[i] = vm2.CInt(int64(0x1000 + i))
+	}
+	for slot := range N {
+		fn := &vm2.Function{
+			Name:    "ret_slot",
+			NumRegs: N,
+			Code:    []vm2.Instr{{Op: vm2.OpReturn, A: int32(slot)}},
+		}
+		compileOrSkip(t, fn)
+		got := callJIT(fn, r)
+		want := r[slot]
+		if got != want {
+			t.Fatalf("slot %d: got %016x, want %016x", slot, got.Bits, want.Bits)
+		}
+	}
+}
+
 // TestCalleeSavedDeoptStub exercises the deopt path when the function
 // uses the callee-saved frame. The deopt stub must spill r7 from x19
 // (and r8 from x20 when present) before LDP restores the caller's
@@ -519,7 +589,10 @@ func TestCalleeSavedDeoptStub(t *testing.T) {
 			{Op: vm2.OpReturn, A: 7},
 		},
 	}
-	cf, err := vm2jit.Compile(fn)
+	// Use CompileForceForTest: jitProfitable rejects this synthetic fn
+	// (1 deoptable op, 1 non-deopt), but the deopt stub is exactly the
+	// machinery we want to test.
+	cf, err := vm2jit.CompileForceForTest(fn)
 	if err != nil {
 		t.Skipf("Compile: %v", err)
 	}
@@ -739,7 +812,9 @@ func TestJITDeoptResume(t *testing.T) {
 			{Op: vm2.OpReturn, A: 1},              // return r1
 		},
 	}
-	cf, err := vm2jit.Compile(callee)
+	// Force-compile: jitProfitable rejects this 3:1 non-deopt:deopt ratio,
+	// but the test specifically exercises the deopt-resume path.
+	cf, err := vm2jit.CompileForceForTest(callee)
 	if err != nil {
 		t.Skipf("Compile: %v", err)
 	}

--- a/website/docs/mep/mep-0039.md
+++ b/website/docs/mep/mep-0039.md
@@ -3013,6 +3013,153 @@ The next iteration extends the prologue to the second STP/LDP pair
 (x21, x22) so functions up to NumRegs=11 can JIT, then bench
 spectral_norm to see whether `fill` JITing alone bends the curve.
 
+### 6.14 Iter 13: Phase B full, x19..x28 frame with profitability gate
+
+**Theory.** §6.13 landed the first callee-saved pair (x19, x20) and
+bumped the JIT register cap from 7 to 9. AAPCS64 has five callee-saved
+GPR pairs in total: (x19, x20), (x21, x22), (x23, x24), (x25, x26),
+(x27, x28). Generalising §6.13 from one pair to five is a single
+parametric change to the prologue and epilogue: emit
+`numCalleeSavedPairs(fn)` STP frames at entry, one LDP per pair (in
+reverse order) at every exit. That raises the cap to 17 registers
+(seven caller-saved x9..x15 plus ten callee-saved x19..x28; x18 stays
+Darwin-reserved). The coverage probe shows the theoretical reach: at
+cap=17, seven BG hot functions newly fit the JIT (mandelbrot.main,
+mandelbrot.sumU8; spectral_norm.main, spectral_norm.fill,
+spectral_norm.mulAv, spectral_norm.mulAtv; plus spectral_norm.evalA
+already at cap=9), taking probe coverage from 1/21 to 7/21.
+
+A focused crosslang bench (vm2 vs Go, repeat=9) on the cap=17 build
+without any gating regressed both programs: spectral_norm/100 moved
+from 32x to 60x vs Go, mandelbrot/100 from 18x to 21x. The cause is
+deopt-on-call thrash. Every newly-admitted outer function makes
+OpCall into inner kernels that are still over the 17-register cap
+(`mulAInner`, `mulAtInner`, `dot`, `iterLoop`, `iterate` all 18..23
+regs). OpCall is in `isDeoptableOp`, so the JIT'd caller deopts at
+the first call, spills its register file via the per-op stub, pops
+the five LDP pairs, and Go-side `resumeFromDeopt` re-enters the
+interpreter at the deopt PC. The interpreter then runs the rest of
+the function in interpreter mode. Net: prologue plus spill plus five
+LDP plus four movz + ret plus a Go-side frame push, versus the
+interpreter's straight dispatch. The JIT pays setup for zero work.
+
+The fix is structural: until OpCall has a JIT-side fast path that
+keeps control in JIT land when both caller and callee have `JITCode`,
+admitting outer-controller functions is a net loss. A profitability
+gate now refuses to JIT such functions until iter 14 lands the OpCall
+fast path. The gate is bounded: it only applies to functions newly
+admitted by Phase B (`NumRegs > 9`), so the §6.13 baseline (the one
+JIT'd BG function, `spectral_norm.evalA` at 6 regs) is preserved
+unchanged.
+
+**Mechanism.**
+
+- `r2x(r)` becomes arithmetic on the slot index: `r < 7` maps to
+  `x(r + 9)` (x9..x15), `r >= 7` maps to `x(r + 12)` (x19..x28).
+- `numCalleeSavedPairs(fn)` returns `(min(NumRegs, maxRegs) - 7 + 1) / 2`
+  for `NumRegs > 7`, else 0. An 8-register function pushes one pair
+  (x19, x20) even though x20 is unused, because partial pairs waste
+  stack alignment without saving work.
+- `prologueARM64` loops `for k := 0; k < pairs; k++` and emits
+  `stp x{2k+19}, x{2k+20}, [sp, #-16]!`. Pre-index writeback drops SP
+  by 16 each time, preserving AAPCS64 alignment.
+- `emitCalleeSavedEpilogueARM64` emits LDPs in reverse order
+  (`for k := pairs-1; k >= 0; k--`), one
+  `ldp x{2k+19}, x{2k+20}, [sp], #16` per pair. Reversal matters: SP
+  unwinds in the opposite order from the push sequence.
+- `OpReturn` moves the result to x0 _before_ the epilogue runs, so a
+  result that lives in x19..x28 is not clobbered by the matching LDP.
+- The deopt stub follows the same shape: spill live regs to
+  `regs[..]` via `str64`, then run the reverse-order LDPs, then load
+  the sentinel-tagged PC into x0 and ret. `deoptStubWords` accounts
+  for `NumRegs + numPairs + 4 + 1` so the two-pass pcMap remains
+  deterministic.
+- `instrWordCountARM64` for `OpReturn` reads `numCalleeSavedPairs`
+  directly, dropping the boolean `usesCalleeSaved` helper.
+- `jitProfitable(fn)` in `lower_arm64.go` returns true unconditionally
+  for `NumRegs <= 9` (preserving §6.13 policy), and otherwise gates
+  on the ratio of non-deoptable to deoptable opcodes in `fn.Code`. If
+  the body has any deoptable op and non-deopt ops are fewer than 10
+  per deopt, refuse. Outer-controller bodies of shape "alloc; N
+  Call; Return" fail the 10:1 ratio; inner loops with one entry-time
+  deopt followed by a long arithmetic body still pass.
+- `Compile` calls `jitProfitable` after the NumRegs cap check and
+  returns the new `ErrUnprofitable` (which wraps `ErrNotImplemented`,
+  so existing callers continue to treat the result as "interpret").
+  A test-only `CompileForceForTest` is exported via `export_test.go`
+  for the deopt-stub unit tests that must exercise machinery the
+  gate would reject as unprofitable.
+
+**Implementation.**
+
+```
+runtime/jit/vm2jit/lower_arm64.go
+  - r2x: arithmetic mapping (r<7 -> x(r+9), else x(r+12))
+  - numCalleeSavedPairs(fn) replaces usesCalleeSaved
+  - emitCalleeSavedEpilogueARM64(ws, pairs) reverse-order LDPs
+  - prologueARM64: forward-order STPs by pair count
+  - OpReturn: movReg(0, result) before epilogue, then ret
+  - emitDeoptStubARM64: spill + reverse-order LDPs + sentinel + ret
+  - jitProfitable(fn): NumRegs<=9 returns true; else 10:1 non-deopt:deopt
+  - maxRegs: 9 -> 17
+runtime/jit/vm2jit/lower_stub.go
+  - jitProfitable stub for non-arm64 builds (returns true)
+runtime/jit/vm2jit/compile.go
+  - maxJITRegs: 9 -> 17
+  - ErrUnprofitable wraps ErrNotImplemented
+  - Compile applies jitProfitable after the cap check
+  - compileNoGate factors the post-gate path
+runtime/jit/vm2jit/export_test.go
+  - CompileForceForTest exposes compileNoGate for deopt-machinery tests
+runtime/jit/vm2jit/vm2jit_test.go
+  - TestCalleeSavedReturnR16: NumRegs=17, return r16 (x28) round-trip
+  - TestCalleeSavedAddR9R16: arithmetic across 2nd and 5th pairs
+  - TestCalleeSavedRoundTripEverySlot: every slot 0..16 returns its
+    own value, catches r2x / epilogue ordering bugs at every index
+  - TestCalleeSavedDeoptStub, TestJITDeoptResume: switched to
+    CompileForceForTest because their synthetic bodies fail the 10:1
+    profitability ratio that the public Compile applies
+```
+
+**Bench note.** Iter 13 lands the scaffolding for cap=17 but the
+profitability gate restores the §6.13 admission set, so coverage
+remains 1/21 (`spectral_norm.evalA` only). A focused vm2 vs Go run
+on macOS/arm64 (repeat=9, this branch vs `dc90008e10` §6.13 baseline,
+same shell, same Go version):
+
+| Program | N | vm2 (µs) §6.13 | vm2 (µs) iter13 | Delta |
+|---|---:|---:|---:|---:|
+| `bg/mandelbrot` | 100 | 7049 | 7151 | +1.4% |
+| `bg/mandelbrot` | 200 | 28090 | 28058 | -0.1% |
+| `bg/spectral_norm` | 100 | 8479 | 8465 | -0.2% |
+| `bg/spectral_norm` | 200 | 33578 | 34073 | +1.5% |
+
+All deltas are within run-to-run noise. The vm2/Go ratio swings
+observed across runs are Go-side variance (the Go binaries finish in
+under 1ms and the measurement is dominated by process startup cost).
+No regression vs §6.13; the iter 13 machinery is live but currently
+unused at runtime because the gate rejects every cap > 9 candidate.
+
+**Why land it now anyway.** The 5-pair frame, the parametric `r2x`,
+and the reverse-order epilogue are unit-tested at every register
+slot (TestCalleeSavedRoundTripEverySlot iterates 0..16). When iter 14
+lowers OpCall as a JIT-to-JIT fast path that keeps control in JIT
+land for `callee.JITCode != nil`, the gate's 10:1 ratio relaxes and
+the seven Phase-B candidates can be admitted in one change without
+re-touching the prologue/epilogue. Splitting the scaffolding from
+the policy keeps each PR small enough to review and bisect.
+
+**Next.** Iter 14 lowers `OpCall` (and the relevant `OpCallA*` /
+`OpTailCallSelfA*` variants) as a JIT-side fast path. When the callee
+has `JITCode != nil` the JIT emits a register-shuffle + indirect call
+sequence and continues in JIT land on return; only `JITCode == nil`
+callees deopt. The expected effect is that
+`spectral_norm.main / fill / mulAv / mulAtv`,
+`mandelbrot.main / sumU8`, and `spectral_norm.evalA`'s caller chain
+all become JIT-resident, which (combined with the existing fast
+paths for typed array ops) is the first iteration that can flip a
+BG program below the 2x-vs-Go gate from the JIT side.
+
 ### 6.x (template for future iterations)
 
 Each new program lands in 6.x with the same theory / mechanism /


### PR DESCRIPTION
## Summary

- Extends §6.13's single callee-saved pair (x19, x20) to all five AArch64 pairs (x19..x28), raising maxJITRegs from 9 to 17. Parametric in numCalleeSavedPairs(fn) so the prologue/epilogue handle any pair count cleanly.
- Adds jitProfitable(fn) as a static admission gate: rejects functions where NumRegs > 9 _and_ non-deopt ops are fewer than 10 per deopt op. §6.13's cap-9 admission policy is preserved verbatim, so the existing 1/21 BG coverage baseline (spectral_norm.evalA) is unchanged.
- Writes §6.14 to mep-0039.md with theory, mechanism, implementation, and bench-delta vs the §6.13 baseline. Iter 14 will lower OpCall as a JIT-to-JIT fast path so the seven Phase-B candidates can be admitted in one change.

## Why land it now

A focused crosslang run on unfiltered cap=17 (no gate) regressed both spectral_norm and mandelbrot vs §6.13. Root cause is the deopt-on-call thrash: newly-admitted outer functions deopt on every OpCall to inner kernels still over the 17-register cap, paying prologue + 5 LDP + sentinel + resumeFromDeopt for zero saved work.

The gate fully neutralizes that regression (vm2 absolute deltas <= 1.5% vs §6.13 across mandelbrot/spectral_norm at N=100 and N=200). The 5-pair STP/LDP machinery is exercised by TestCalleeSavedReturnR16 / AddR9R16 / RoundTripEverySlot so iter 14 inherits a tested frame.

Closes #21669

## Test plan

- [x] go test ./runtime/jit/vm2jit/ (all unit tests pass)
- [x] go test -tags numregs_probe -run TestJITCoverageProbe (coverage at 1/21, matches §6.13 baseline)
- [x] focused crosslang vm2 vs Go on bg/mandelbrot, bg/spectral_norm at N=100 and N=200, repeat=9 (no regression vs §6.13)
- [ ] Linux re-bench on server2 once auto-merged