### PR TITLE
mep-0039 §6.15 hotfix: fence Go snippet so MDX stops parsing { as JSX

### DIFF
--- a/website/docs/mep/mep-0039.md
+++ b/website/docs/mep/mep-0039.md
@@ -3200,25 +3200,27 @@ reclaims the pages. The pass runs outside the timed region in
 
 - `runtime/jit/vm2jit/compile.go` adds:
 
-      func CompileProgram(p *vm2.Program) (handles []*CompiledFunc, compiled, total int) {
-          if p == nil {
-              return nil, 0, 0
-          }
-          total = len(p.Funcs)
-          handles = make([]*CompiledFunc, 0, total)
-          for _, fn := range p.Funcs {
-              if fn == nil {
-                  continue
-              }
-              cf, err := Compile(fn)
-              if err != nil {
-                  continue
-              }
-              handles = append(handles, cf)
-              compiled++
-          }
-          return handles, compiled, total
-      }
+```go
+func CompileProgram(p *vm2.Program) (handles []*CompiledFunc, compiled, total int) {
+    if p == nil {
+        return nil, 0, 0
+    }
+    total = len(p.Funcs)
+    handles = make([]*CompiledFunc, 0, total)
+    for _, fn := range p.Funcs {
+        if fn == nil {
+            continue
+        }
+        cf, err := Compile(fn)
+        if err != nil {
+            continue
+        }
+        handles = append(handles, cf)
+        compiled++
+    }
+    return handles, compiled, total
+}
+```
 
 - `bench/vm2runner/main.go` imports `mochi/runtime/jit/vm2jit` and
   inserts `vm2jit.CompileProgram(program)` between `emit.Compile`


### PR DESCRIPTION
## Summary
- §6.15 landed with a 4-space-indented Go snippet that contains `{` and `}`. MDX's expression extension reads those as JSX and the docusaurus build fails with `Could not parse expression with acorn` at line 3204.
- Switch to a fenced ```go block, which MDX leaves alone.

Tracks the deploy failure on the merge commit for #21672.

## Test plan
- [x] Visual diff: only the code-fence wrapper changes, the Go source inside is byte-identical.