### PR TITLE
mep-0040: draft vm3 + compiler3 successor stack

### DIFF
--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -1,0 +1,806 @@
+---
+mep: 40
+title: "vm3 + compiler3: 8-byte handle Cell, typed arenas, static-type-driven dispatch"
+author: Mochi core
+status: Draft
+type: Standards Track
+created: 2026-05-18
+sidebar_position: 40
+sidebar_label: MEP 40. vm3 + compiler3
+description: "First-principles successor stack to runtime/vm2 + compiler2. Replaces the 16-byte split Cell (Bits uint64 + Obj unsafe.Pointer) with an 8-byte NaN-boxed handle Cell that addresses per-type Go-allocated arenas. Replaces the single Cell[] frame register file with three typed banks (regsI64, regsF64, regsCell). Replaces compiler2's flat IR with compiler3's static-type-driven IR that propagates Mochi's static type system end-to-end so the interpreter and JIT never reason about types at runtime. Keeps Go's GC by making arena slabs the only pointer roots (handles are uint64 indices into typed slabs, not pointers). Phased to a production cut-over of bench harness, language server, and REPL over roughly six months."
+---
+
+# MEP 40. vm3 + compiler3: 8-byte handle Cell, typed arenas, static-type-driven dispatch
+
+| Field    | Value                                              |
+|----------|----------------------------------------------------|
+| MEP      | 40                                                 |
+| Title    | vm3 + compiler3                                    |
+| Author   | Mochi core                                         |
+| Status   | Draft                                              |
+| Type     | Standards Track                                    |
+| Created  | 2026-05-18                                         |
+| Replaces | runtime/vm2 + compiler2 (after Phase 7 cut-over)   |
+
+## Abstract
+
+MEP-39 closed out the vm2 + compiler2 + vm2jit stack with 4 of 11 BG programs inside the 2x-of-Go gate on macOS. The §6.16 close-out diagnostic identified the structural ceilings: 16-byte Cell layout, single-bank register file, method-only JIT, NumRegs cap of 17, every operation paying Cell envelope traffic even when types are statically known. None of these are fixable inside vm2 without touching every file in the stack.
+
+This MEP specifies the from-scratch successor: `runtime/vm3` (VM) and `compiler3` (typed lowering). The two are co-designed because the biggest single lever that vm2 left on the table, propagating Mochi's static type system into the interpreter dispatch, requires changes on both sides of the bytecode boundary. The design choices are:
+
+1. **8-byte Cell with handle-based NaN-boxing.** The single `uint64` carries inline ints (48-bit signed), floats (full NaN range), bools, null, inline short strings (up to 5 bytes), deopt sentinels, and `(arena_tag, generation, index)` handles into per-type Go-allocated arenas. Half the register-file cache footprint of vm2's `{Bits, Obj}` Cell.
+2. **Typed arenas with Go-GC-friendly slabs.** Each container type (string, list, map, set, struct, closure, bignum, bytes, pair, f64arr, i64arr, u8arr) lives in its own Go-allocated slab. Slabs are reachable through normal Go field traversal from the VM, so Go's GC reclaims slab backing without ever inspecting handle bits.
+3. **Typed register banks per frame.** Each `Frame` carries three native-typed arrays: `regsI64 []int64`, `regsF64 []float64`, `regsCell []Cell`. compiler3 picks the bank at emit time based on each SSA value's static type. Typed ops read and write native machine words; the Cell envelope only appears at boundaries (polymorphic call arguments, generic list elements, return values to dyn-typed callers).
+4. **Static-type-driven dispatch end-to-end.** Mochi's existing type checker proves every register's type at compile time. compiler3 preserves that information through every IR pass, emits opcodes that encode the type in the opcode itself (no runtime tag check), and chooses the bank for each operand. Because Mochi is statically typed, there is no "guard at trace head, fall back if wrong type" pattern (the LuaJIT / V8 escape valve); the type is proven before any code runs.
+5. **JIT designed for handle Cell from day one.** vm3jit lowers handle decode as a single slab-load + bounds check (replacing vm2jit's tag-check + ptr deref). Smaller Cell halves stack-spill cost and unblocks higher NumRegs.
+6. **Phased rollout** with measurable gates per phase. Phase 7 deprecates `runtime/vm2`.
+
+The performance bet, deduced from §8: vm3 alone (no JIT) is within 10% of vm2 on math kernels and 30-50% faster on FP-heavy BG programs. vm3 + vm3jit is within 2x of Go on 8 of 11 BG programs (target up from MEP-39's 4 of 11), with the residual three blocked on tracing JIT (separate successor MEP, deferred).
+
+## Motivation
+
+### What MEP-39 closed out
+
+MEP-39 §6.16 identified, per BG function, exactly which structural limit blocks JIT admission today. Three patterns dominate: deopt-fraction over 10% (the safety rail), NumRegs over the cap of 17, and missing typed-array element opcodes. The §6.16 follow-up arcs (a-e) are five separate PRs against the existing vm2 stack. The cost of each, summed, is roughly 8-12 weeks of work that does not address the underlying ceilings.
+
+### What no MEP-39 follow-up can fix
+
+The deep-dive in the MEP-39 close-out chat captured the four structural ceilings that no incremental work inside vm2 can lift:
+
+1. **Cell width.** vm2's `{Bits uint64, Obj unsafe.Pointer}` = 16 bytes is load-bearing for Go GC interop. Halving it requires rethinking pointer reachability. Touches every typed-array struct, every JIT regmap, every interp op.
+2. **Single register file.** vm2's `Frame.Regs []Cell` is type-erased. Even typed opcodes pay 16-byte slot traffic on load/store. The fix (split banks) requires compiler2 to thread type info through every pass, which compiler2 was not built to do.
+3. **Method JIT only.** vm2jit compiles whole functions or rejects them. Method boundaries forcibly deopt unless callee is also JIT-resident. Tracing is the standard answer (LuaJIT, PyPy); we cannot retrofit it onto vm2jit's frame model.
+4. **NumRegs cap.** Hard at 17 because vm2jit statically maps register index to AArch64 register index. A real linear-scan allocator with stack spill is "a backend rewrite," not a tweak.
+
+### Why a successor stack, not a refactor
+
+The minimum viable patch list for vm2 is: redo Cell layout, redo Frame layout, redo compiler2 emit, redo vm2jit lowering. That is the entire stack. Doing it in-place forces a long-lived development branch with frequent rebases against `main` (still running production benches on vm2) and an "all-or-nothing" cut-over that bisects badly.
+
+A clean side-by-side build avoids both. `runtime/vm3` and `compiler3` ship next to `runtime/vm2` and `compiler2`. Both compile, both run benches, both are tested on every commit. The bench harness picks the stack via `-vm=vm3` flag. Cut-over happens once vm3 has both feature parity (Phase 3 gate) and performance dominance (Phase 5 gate).
+
+This is also the path TraceMonkey took to V8 Ignition (parallel stacks, gated migration) and the path Hermes took from Hermes 0.x to the current static-type-aware design.
+
+## Scope
+
+In scope:
+
+- Complete design and implementation of `runtime/vm3` (VM, bytecode, interpreter, frame model, arena allocator).
+- Complete design and implementation of `compiler3` (typed IR, passes, emit).
+- `runtime/jit/vm3jit` (JIT for vm3, aarch64 + amd64, designed for handle Cell from day one).
+- Bench harness integration (`bench/vm3runner`).
+- Migration of `bench/crosslang`, language server, REPL to vm3.
+- Deprecation and removal of `runtime/vm2` + `compiler2` + `runtime/jit/vm2jit` (Phase 7).
+
+Out of scope (deferred to successor MEPs):
+
+- Tracing JIT. vm3jit is a method JIT with better foundations than vm2jit; tracing is MEP-50+ territory.
+- Custom allocator outside Go's heap (cgo path). vm3 reuses Go's allocator for arena slabs and Go's GC for slab reachability. The LuaJIT-style "C heap with handwritten mark-sweep" is MEP-50+ territory.
+- Concurrent / parallel execution. vm3 is single-VM-per-program, same as vm2.
+- WasmGC interop. The handle ABI is compatible in shape but standardisation is out of scope.
+
+## Background: modern VM design landscape (as of 2026)
+
+vm3's design is informed by four lines of work that landed or matured between 2022 and 2026:
+
+### 1. Hermes (Meta) — small tagged value, AOT bytecode, generational GC
+
+Hermes' `HermesValue` is 8 bytes with NaN-box encoding. The interpreter is type-aware via a `JSObject` shape mechanism. AOT bytecode compilation (vs JavaScriptCore's JIT-only approach) wins on cold start. **vm3 borrows**: 8-byte Cell, AOT compilation as the default (compiler3 always runs ahead of execution), Hermes-style "value is a tagged uint64 you decode at use site."
+
+### 2. ZJIT (Ruby 3.x, 2024-2026) — SSA region-based JIT in Rust
+
+ZJIT replaces YJIT's basic-block-versioning approach with a proper SSA IR over regions. The lessons: (a) regions are the right unit, not whole methods; (b) SSA passes are necessary, not optional; (c) inline caching combined with SSA specialization beats either alone. **vm3jit borrows**: region-based compilation (regions = SSA basic-block groups, not whole functions), explicit SSA IR (not just a lowering walker).
+
+### 3. WasmGC (Wasm 3.0, 2024) — typed GC primitives in a portable bytecode
+
+WasmGC adds typed `struct`, `array`, and `i31ref` to Wasm. Critically, it standardizes the "handle-based reference into a managed heap" pattern. **vm3 borrows**: typed-array shape (Wasm's `array i32` ≅ vm3's `vmI64Array`), `i31ref`-style small-int inline encoding, typed function refs.
+
+### 4. MMTk (2018-2025) — modular memory toolkit research framework
+
+MMTk's RC-Immix and Lazy Sweeping work showed that arena allocators with per-arena policies beat monolithic generational collectors on bytecode-VM workloads. **vm3 borrows**: per-type arena with per-type reclaim policy. Strings can be ref-counted (most are short-lived). Lists and maps use mark-sweep. Bignums use lazy sweep.
+
+### Lessons from systems we explicitly do *not* borrow
+
+- **LuaJIT custom heap + cgo.** Performance ceiling is higher, but cgo overhead at every Go boundary makes it net worse for a Go-embedded VM.
+- **V8 Ignition computed-goto interpreter.** Go does not expose computed-goto; the win would require handwritten assembly we cannot maintain. Sparkplug-style "baseline JIT" subsumes this in vm3jit anyway.
+- **TruffleRuby partial evaluation.** Requires an AST interpreter, not a bytecode VM. Wrong shape for our compiler2 → bytecode pipeline.
+- **PyPy meta-tracing.** Tracing JIT is in scope for a successor MEP but not vm3 itself. Doing both at once delivers neither.
+
+### The single most important lesson
+
+Mochi is **statically typed**. Every recent VM the lessons above come from is for a dynamic language (JavaScript, Ruby, Wasm-with-host-language, etc.). The single biggest design simplification vm3 makes vs. all of them: **we never need to guard on type at runtime, because the compiler already proved it**.
+
+This drops the entire "guard at trace head, deopt on type mismatch" machinery. It collapses inline caches from polymorphic (1-4 entries with miss handler) to monomorphic (the field offset is a compile-time constant). It lets compiler3 emit a directly-typed opcode without any "polymorphic fallback" branch.
+
+LuaJIT spends roughly half its IR on type guards and side-trace stitching for type mismatches. **vm3 spends zero IR on type guards.** That is the entire reason a static-language VM can be smaller and faster than the same shape of dynamic-language VM, and vm3 leans on it explicitly.
+
+## Architecture
+
+### 6.1 Cell layout
+
+```go
+package vm3
+
+// Cell is the 8-byte tagged value used throughout vm3. It is a strict
+// NaN-box: floats occupy the full uint64 in their bit-pattern range;
+// non-float values use the qNaN payload space for tag + payload.
+//
+// Bits layout (high 16 bits = tag, low 48 bits = payload):
+//
+//   0x0000..0xFFEF  -> float64 (normal or subnormal). Caller decodes via math.Float64frombits.
+//   0x7FF8          -> canonical qNaN (any NaN input normalizes here, read back as IsFloat).
+//   0xFFF8          -> tagDeopt (JIT deopt sentinel; pc in low 48 bits).
+//   0xFFF9          -> tagSStr  (inline short string, len in bits 40..43, up to 5 bytes in 0..39).
+//   0xFFFA          -> tagInt48 (sign-extended 48-bit signed int in low 48 bits).
+//   0xFFFB          -> tagBool  (low bit = value).
+//   0xFFFC          -> tagNull  (no payload).
+//   0xFFFD          -> reserved (future: i31ref-style "small handle" inline encoding).
+//   0xFFFE          -> reserved (future: typed function ref).
+//   0xFFFF          -> tagHandle (arena handle; see encoding below).
+//
+// Handle payload (low 48 bits when tag is 0xFFFF):
+//
+//   bits 47..44 : arena selector (16 arenas max). See arenaTag enum.
+//   bits 43..32 : generation (12 bits, wraps; debug mode checks for stale handles).
+//   bits 31..0  : slab index (32 bits, 4B entries per arena cap).
+//
+// Note: tagHandle is the only tag that requires a slab lookup to materialize
+// a concrete value. All other tags decode by bit-shift only.
+type Cell uint64
+
+const (
+    qNaN       uint64 = 0x7FF8_0000_0000_0000
+    tagMask    uint64 = 0xFFFF_0000_0000_0000
+    tagDeopt   uint64 = 0xFFF8_0000_0000_0000
+    tagSStr    uint64 = 0xFFF9_0000_0000_0000
+    tagInt48   uint64 = 0xFFFA_0000_0000_0000
+    tagBool    uint64 = 0xFFFB_0000_0000_0000
+    tagNull    uint64 = 0xFFFC_0000_0000_0000
+    tagHandle  uint64 = 0xFFFF_0000_0000_0000
+
+    arenaSelShift = 44
+    arenaSelMask  = uint64(0xF) << arenaSelShift   // 4 bits
+    genShift      = 32
+    genMask       = uint64(0xFFF) << genShift       // 12 bits
+    idxMask       = uint64(0xFFFF_FFFF)             // 32 bits
+
+    payloadMask = 0x0000_FFFF_FFFF_FFFF
+)
+
+type arenaTag uint8
+
+const (
+    arenaString  arenaTag = 0
+    arenaList    arenaTag = 1
+    arenaMap     arenaTag = 2
+    arenaSet     arenaTag = 3
+    arenaStruct  arenaTag = 4
+    arenaClosure arenaTag = 5
+    arenaBignum  arenaTag = 6
+    arenaBytes   arenaTag = 7
+    arenaPair    arenaTag = 8
+    arenaF64Arr  arenaTag = 9
+    arenaI64Arr  arenaTag = 10
+    arenaU8Arr   arenaTag = 11
+    // 12..15 reserved for future container types.
+)
+```
+
+Why this layout:
+
+- **8 bytes, fits in one register.** Frame slots are uint64, frame pointer arithmetic is 1 word per slot, AArch64/AMD64 native register width. JIT regmap is a 1:1 vm3-reg-to-physreg correspondence for the cell bank.
+- **Inline ints are 48-bit signed, not 32-bit.** Range is -140 trillion to +140 trillion, enough to box any practical integer that does not need bignum. Programs that overflow 48 bits promote to a `vmBignum` handle.
+- **Float is uncompressed.** Any IEEE 754 double round-trips bit-exact, including subnormals and infinities. NaN inputs canonicalize to qNaN (same as vm2).
+- **Inline short strings up to 5 bytes.** Covers field names, single-char strings, short literals. Avoids an arena slot for short-lived strings. Same 5-byte limit as vm2's `sstr`.
+- **Handle is the only allocation-touching tag.** Every other value type decodes inline. This is the load-bearing performance property: in a typed function with no container ops, the entire register file lives in machine registers and no arena is touched.
+- **Generation field (12 bits) for stale-handle detection.** Stress tests, debug mode, and the type checker assert generation matches before use. Production mode skips the check; the type system proves stale handles cannot escape their lifetime.
+
+### 6.2 Arena allocator
+
+Each arena is a Go slice of typed entries. The slice is rooted in `vm3.VM.arenas`, which is reachable through normal Go field traversal.
+
+```go
+package vm3
+
+type VM struct {
+    arenas Arenas
+    // ... rest of VM state
+}
+
+type Arenas struct {
+    Strings  []vmString
+    Lists    []vmList
+    Maps     []vmMap
+    Sets     []vmSet
+    Structs  []vmStruct
+    Closures []vmClosure
+    Bignums  []vmBignum
+    Bytes    []vmBytes
+    Pairs    []vmPair
+    F64Arrs  []vmF64Array
+    I64Arrs  []vmI64Array
+    U8Arrs   []vmU8Array
+
+    // Free-list per arena. Phase 1 leaves these empty (slab grows monotonically).
+    // Phase 6 wires them to the mark-sweep collector.
+    freeStrings  []uint32
+    freeLists    []uint32
+    // ...
+}
+```
+
+Each arena entry holds its own backing storage (slice fields, map fields, struct fields). Crucially, *those fields are Go-typed* so Go's GC traces them:
+
+```go
+type vmList struct {
+    gen      uint16    // generation; bumped on free+reuse
+    flags    uint8     // alive bit, shared bit, future use
+    _        uint8     // padding
+    len      uint32
+    cells    []Cell    // backing slice; Cells are uint64, GC sees the slice header
+    elemType uint8     // compile-time element type from compiler3 (i64 / f64 / cell / etc.)
+}
+
+type vmString struct {
+    gen      uint16
+    flags    uint8
+    _        uint8
+    len      uint32
+    data     []byte    // backing bytes; GC sees the slice header
+}
+
+type vmMap struct {
+    gen     uint16
+    flags   uint8
+    _       uint8
+    // Open-addressed table; entries are (key Cell, value Cell, hash uint64).
+    table   []mapEntry
+    nLive   uint32
+}
+
+type vmStruct struct {
+    gen      uint16
+    flags    uint8
+    _        uint8
+    shapeID  uint32   // compiler3 assigns a shape ID per struct type
+    fields   []Cell   // field cells in declared order
+}
+```
+
+Why arena entries hold native slices:
+
+- **Go's GC reclaims slice backing automatically.** When an arena entry is overwritten or freed, the slice header in the previous entry is overwritten. The backing array becomes unreachable from Go's perspective on the next GC pass, and Go reclaims it. We do not implement allocation for slice memory; we let Go's allocator handle it.
+- **Sliding the GC boundary down a level.** Within each entry, references to *other arena objects* are handles (uint64s), but references to *raw byte / Cell storage* are native Go slices. The GC sees the latter, ignores the former, and the result is correct.
+- **No write barriers required.** A handle write (`vmList.cells[i] = somehandle`) is a uint64 store. Go's GC does not interpose because Cell is not a pointer type. The handle stays valid as long as the target arena slot stays live (which the program logic guarantees).
+
+Arena alloc and free:
+
+```go
+func (a *Arenas) allocList(elemType uint8, capHint int) Cell {
+    var idx uint32
+    if n := len(a.freeLists); n > 0 {
+        idx = a.freeLists[n-1]
+        a.freeLists = a.freeLists[:n-1]
+        // bump generation for stale-handle detection
+        a.Lists[idx].gen++
+        a.Lists[idx].len = 0
+        a.Lists[idx].flags = flagAlive
+        if cap(a.Lists[idx].cells) < capHint {
+            a.Lists[idx].cells = make([]Cell, 0, capHint)
+        }
+        a.Lists[idx].elemType = elemType
+    } else {
+        idx = uint32(len(a.Lists))
+        a.Lists = append(a.Lists, vmList{
+            gen:      0,
+            flags:    flagAlive,
+            cells:    make([]Cell, 0, capHint),
+            elemType: elemType,
+        })
+    }
+    return makeHandle(arenaList, a.Lists[idx].gen, idx)
+}
+
+func makeHandle(tag arenaTag, gen uint16, idx uint32) Cell {
+    return Cell(tagHandle |
+        (uint64(tag) << arenaSelShift) |
+        (uint64(gen&0xFFF) << genShift) |
+        uint64(idx))
+}
+
+func (c Cell) decodeHandle() (tag arenaTag, gen uint16, idx uint32) {
+    p := uint64(c) & payloadMask
+    tag = arenaTag((p & arenaSelMask) >> arenaSelShift)
+    gen = uint16((p & genMask) >> genShift)
+    idx = uint32(p & idxMask)
+    return
+}
+```
+
+### 6.3 GC interop: how Go's GC stays in charge
+
+The reachability story end-to-end:
+
+1. `vm3.VM` is rooted in the program's goroutine stack (frame variable holds it).
+2. `VM.arenas` is a struct field, Go GC traces normally.
+3. `arenas.Lists []vmList` is a slice; GC marks the backing array.
+4. Each `vmList.cells []Cell` is a slice; GC marks its backing array. Cells are uint64, GC does not look inside.
+5. `vmList.cells[i]` is a uint64. If it's a handle into `arenas.Strings`, the actual `vmString` lives in `arenas.Strings[idx]`, which is already kept alive in step 3 (a different slice, but rooted the same way).
+
+So the entire arena graph is reachable through the VM. Go's GC keeps all arenas, all backing slices, all native byte/Cell storage alive as long as the VM is alive. Within an arena, individual slots have *no* native GC reachability; they are kept alive by VM logic (the free-list manages slot lifecycle).
+
+This means:
+
+- **We get Go's allocator and Go's collector for backing storage** (no `mmap`, no `cgo`, no manual `malloc`).
+- **We get our own slot lifetime management** (free-list per arena, mark-sweep in Phase 6).
+- **No write barriers are needed** for handle stores, because handles are non-pointer.
+- **One write barrier is needed** when arena slot internals (e.g. `vmList.cells` slice header) gets reassigned. Go's GC barrier fires on the slice header assignment, exactly as if we had written `someGoSliceField = newSlice`.
+
+The cost of slot management: when the program drops the last reference to a list, we do not detect it automatically. The slot stays allocated until a mark-sweep pass runs. In Phase 1 (slab growth only) this is unbounded; in Phase 6 (mark-sweep) it is bounded by collection frequency.
+
+### 6.4 Frame layout: typed register banks
+
+```go
+package vm3
+
+type Frame struct {
+    fn       *Function
+    pc       int
+
+    // Three typed register banks. compiler3 assigns each SSA value
+    // to exactly one bank at lowering time based on its static type.
+    regsI64  []int64
+    regsF64  []float64
+    regsCell []Cell
+
+    // Stack of nested call frames; each call swaps banks.
+    prev *Frame
+}
+
+type Function struct {
+    Name       string
+    Code       []Op
+    Consts     []Cell
+
+    NumRegsI64 uint16  // size of regsI64
+    NumRegsF64 uint16  // size of regsF64
+    NumRegsCell uint16 // size of regsCell
+
+    // Compiler3 annotations
+    ParamTypes []Type   // bank + index of each parameter
+    ResultType Type     // bank of result
+}
+```
+
+How banks are chosen:
+
+- **`regsI64`**: every SSA value of type `int`, `i64`, `i32` (widened), `bool` widened to i64, `i8`/`byte`. Bools and bytes use i64 slots for simplicity; compiler3 may pack later.
+- **`regsF64`**: every SSA value of type `float`, `f64`, `f32` (widened).
+- **`regsCell`**: every SSA value of container type (`list<T>`, `map<K,V>`, `string`, `struct`, etc.), every value that crosses a polymorphic boundary, every value that is the result of a function call to a polymorphic builtin.
+
+How banks are dispatched in opcodes: each opcode has a fixed signature.
+
+```
+OpAddI64    rA i64, rB i64, rC i64       -> regsI64[rA] = regsI64[rB] + regsI64[rC]
+OpAddF64    rA f64, rB f64, rC f64       -> regsF64[rA] = regsF64[rB] + regsF64[rC]
+OpListGet   rA cell, rB cell, rC i64     -> regsCell[rA] = list-element(regsCell[rB], regsI64[rC])
+OpListGetI64 rA i64, rB cell, rC i64     -> regsI64[rA]  = i64-list-element(regsCell[rB], regsI64[rC])
+```
+
+The bank is encoded in the opcode mnemonic, not the operand. compiler3 has full type info and emits the right one. The interpreter never decides at runtime which bank to read; the opcode already says.
+
+This is the single biggest difference from vm2. In vm2, `OpAdd r1 r2 r3` loads three Cells, tag-checks each, dispatches to typed add. In vm3, `OpAddI64 r1 r2 r3` loads three int64s directly. No tag check. No Cell envelope. No boxing.
+
+Performance consequence: typed inner loops (FP, integer) run with native machine register pressure equal to their typed register pressure. A vm2 function with 9 named regs and 5 simultaneously-live regs has a NumRegs cap of 9 (no spill); a vm3 function with the same shape has, say, 6 regsI64 + 0 regsF64 + 3 regsCell, all of which the JIT can keep in physical registers because the cap is per-bank.
+
+### 6.5 Bytecode dispatch
+
+vm3 keeps a Go `switch` interpreter loop, same shape as vm2. The win is not the dispatch (Go limits us), it is what each opcode body does.
+
+```go
+func (vm *VM) Run(fn *Function) (Cell, error) {
+    fr := vm.pushFrame(fn)
+    for {
+        op := fr.fn.Code[fr.pc]
+        switch op.Code {
+        case OpAddI64:
+            fr.regsI64[op.A] = fr.regsI64[op.B] + fr.regsI64[op.C]
+            fr.pc++
+        case OpAddF64:
+            fr.regsF64[op.A] = fr.regsF64[op.B] + fr.regsF64[op.C]
+            fr.pc++
+        case OpListGetI64:
+            h := fr.regsCell[op.B]
+            idx := fr.regsI64[op.C]
+            tag, gen, slot := h.decodeHandle()
+            // Type system proves tag == arenaI64Arr; debug build asserts.
+            arr := &vm.arenas.I64Arrs[slot]
+            _ = gen
+            fr.regsI64[op.A] = arr.data[idx]
+            fr.pc++
+        // ... rest of opcodes
+        }
+    }
+}
+```
+
+Things that are *not* in the opcode body:
+
+- Tag check on operands (type system already proved).
+- Boxing the result into a Cell (we wrote a native int64 into regsI64).
+- Allocating intermediate Cells.
+- Marshalling between numeric formats.
+
+Things that *are* in the opcode body for typed-array element ops:
+
+- Handle decode (3 bit-shifts + masks).
+- Slab index (one slice load).
+- Bounds check (one compare + branch).
+- The actual element load.
+
+The slab index is the only added indirection vs vm2's `Cell.Obj` deref (which was already one pointer load). So vm3's typed-array element op is one bit-shift cheaper *and* one load equivalent vs vm2's tag-check-then-deref.
+
+### 6.6 Bytecode format
+
+vm3 opcodes are fixed-width 8-byte little-endian:
+
+```
+byte 0:    opcode (uint8)
+byte 1:    bank flags (low 4 bits: A bank; mid 4 bits: B bank; reserved)
+bytes 2-3: register A (uint16)
+bytes 4-5: register B (uint16)
+bytes 6-7: register C (uint16) OR immediate (int16, sign-extended)
+```
+
+K-form variants (compare-and-branch with immediate) encode the immediate in the C slot. Wide-immediate forms (e.g. 32-bit int constants) reference the per-function constant pool via a 16-bit index in C.
+
+vm2 used variable-width opcodes (1-9 bytes). vm3 fixes the width because:
+
+- Predictable dispatch latency (no varint decode).
+- AArch64 LDP can load two opcodes in one cycle.
+- Easier to write a JIT that walks the opcode stream by `pc += 8`.
+
+The cost is a slightly larger code segment (~30% bigger for typical programs). The interpreter cache footprint is what matters and the typical hot loop fits in L1 either way.
+
+## 7. compiler3 architecture
+
+compiler3 is co-designed with vm3. Static type information is the single most-leveraged input. The Mochi type checker (in `types/`) already proves every expression's type; compiler3 consumes that information directly and never re-derives it.
+
+### 7.1 IR
+
+compiler3 IR is typed SSA, similar shape to compiler2 but with explicit type annotations on every SSA value:
+
+```go
+package compiler3
+
+type Type uint8
+
+const (
+    TypeI64   Type = 1
+    TypeF64   Type = 2
+    TypeBool  Type = 3
+    TypeStr   Type = 4
+    TypeList  Type = 5  // parameterized by elem type stored in shape table
+    TypeMap   Type = 6
+    TypeStruct Type = 7
+    // ...
+)
+
+type Value struct {
+    ID       uint32
+    Type     Type
+    ElemType Type    // for parameterized container types
+    StructID uint32  // for struct types
+    Op       OpCode
+    Args     []uint32
+    Const    int64   // for constants; bit-cast for f64
+}
+
+type Block struct {
+    ID     uint32
+    Values []uint32
+    Preds  []uint32
+    Succs  []uint32
+    Term   Terminator
+}
+
+type Function struct {
+    Name    string
+    Params  []Value
+    Result  Type
+    Blocks  []Block
+    Values  []Value
+}
+```
+
+Every IR node carries its type. Passes preserve type. Lowering picks the opcode by type.
+
+### 7.2 Type-driven lowering
+
+Lowering takes typed SSA → vm3 bytecode in a single pass:
+
+```go
+func (e *Emitter) emitAdd(v Value) {
+    a, b := v.Args[0], v.Args[1]
+    switch v.Type {
+    case TypeI64:
+        e.emit(OpAddI64, e.regI64(v.ID), e.regI64(a), e.regI64(b))
+    case TypeF64:
+        e.emit(OpAddF64, e.regF64(v.ID), e.regF64(a), e.regF64(b))
+    default:
+        panic("compiler3: Add for non-numeric type") // type checker rejects this earlier
+    }
+}
+```
+
+The emitter maintains per-function register allocators per bank. Each typed Value gets a slot in its bank's frame array. No bank ever holds values of another bank's type.
+
+### 7.3 Pass pipeline
+
+```
+1. Type-aware build      (Mochi AST → typed SSA, using existing types/ pass)
+2. Constant fold         (preserves type; produces typed Const values)
+3. DCE                    (delete unused SSA values)
+4. Branch threading      (collapse trivial control flow)
+5. LICM                   (loop-invariant code motion, type-aware)
+6. Tail-call             (mark TCO candidates; emit OpTailCall*)
+7. Register allocate     (linear-scan per bank; spill if bank exceeds frame budget)
+8. Emit                   (bytecode generation)
+```
+
+The notable additions over compiler2:
+
+- **LICM** runs on typed SSA. Loop-invariant typed-array length reads (`len(arr)`) hoist out of inner loops. This alone is worth measurable speedup on spectral_norm and mandelbrot.
+- **Register allocate** uses linear-scan over live intervals per bank. The cap-17 limitation of vm2jit goes away because compiler3 itself produces a frame with separate banks, each with its own size. A function with NumRegsI64=20, NumRegsF64=5, NumRegsCell=3 fits AArch64's GPR + SIMD register sets naturally.
+
+### 7.4 Emit
+
+The emitter walks blocks in reverse postorder and emits the fixed-width opcodes described in §6.6. Constants are pooled per function. Strings live in the global string arena at compile time (compile-time interning).
+
+### 7.5 What compiler3 inherits from compiler2
+
+The pieces of compiler2 that work and survive:
+
+- **Typed SSA shape** (compiler2 already has it).
+- **opt.ConstFold, opt.DCE** (general enough; will need re-typing).
+- **opt.TailCall** (recognizes tail position; remains useful).
+
+The pieces that are redone:
+
+- **Emit** (bytecode format changes, opcode selection becomes type-driven).
+- **Register allocation** (was index-based, becomes linear-scan per bank).
+- **IR-to-bytecode lowering** (currently flat, becomes type-aware).
+
+The pieces that go away:
+
+- **Hard-coded BG super-ops** (MEP-39 §6.11 already disabled them; compiler3 ships them disabled).
+- **Cell-typed register conventions** (replaced by bank conventions).
+
+## 8. Performance model
+
+Predictions per phase, assuming the bench harness on darwin/arm64 from MEP-39 §7. All ratios are vm3 / vm2 (less than 1.0 = vm3 faster).
+
+### 8.1 Where vm3 wins without JIT
+
+**FP-heavy programs (spectral_norm, mandelbrot, n_body)**: the typed register banks eliminate Cell envelope traffic on every arithmetic op. Predicted speedup over vm2 interpreter alone: 1.5-2x. Mechanism: each FP register slot is 8 bytes of f64 (was 16-byte Cell), arithmetic ops write native float64 (vm2 wrote Cell), no tag check, no Cell construction.
+
+**Tight integer loops (nsieve, fannkuch_redux)**: typed i64 bank eliminates the same traffic. Predicted speedup over vm2 interpreter alone: 1.3-1.6x. Lower than FP because nsieve allocates a list per outer iter; that allocation cost (Go allocator, arena slab) is unchanged. fannkuch_redux is bottlenecked by the typed-array reverse op which interp-side benefits less than JIT-side.
+
+**Container-heavy (binary_trees, k_nucleotide)**: cell bank stays the dominant cost (handles are still ~the same size as vm2 Cell.Obj load), but the *backing storage* halves. The vmList.cells slice is now `[]Cell` where Cell is 8 bytes, was `[]Cell` where Cell was 16 bytes. List traversal is 2x more cache-friendly. Predicted speedup over vm2: 1.2-1.4x.
+
+**Dispatch-bound (regex_redux, fasta)**: bytecode dispatch is the bottleneck; Cell width matters less. Predicted speedup over vm2: 1.05-1.15x. The win is incidental and small.
+
+### 8.2 Where vm3jit wins
+
+vm3jit inherits the deopt protocol and code page management from vm2jit, but designed for handle Cell from day one. Key wins:
+
+- **NumRegs cap rises substantially.** vm2jit caps at 17 because every reg is a 16-byte Cell mapped to one of 17 AArch64 GPRs. vm3jit allocates per bank: 12 GPRs for regsI64 (AArch64 has 28 caller+callee saved), 16 SIMD regs for regsF64 (was zero in vm2jit), 8 GPRs for regsCell. Function with 30 named regs across banks fits if no single bank exceeds its budget.
+- **f64 SIMD register use.** vm2jit ignores xmm/v* registers. vm3jit lowers regsF64 to v0..v15. Per-op latency drops; SIMD-pair ops become natural.
+- **Handle decode is cheaper than Cell.Obj deref.** Single slice load + bounds + cell access vs vm2's tag-check + deref + cell access.
+
+Predicted full-stack vm3 + vm3jit / vm2 + vm2jit on MEP-39 §7.1 BG suite (macOS):
+
+| Program | vm2+JIT (µs) | vm3+JIT predicted (µs) | gate (≤2x Go) |
+|---|---:|---:|:---:|
+| binary_trees N=10 | 30903 | 18000 | maintained (under 2x already) |
+| fannkuch_redux N=10000 | 3921 | 1500 | within reach (was 32x, predicted 15x; needs JIT inner loops to admit) |
+| fasta N=100000 | 2528 | 1700 | tightens to 1.35x |
+| k_nucleotide N=100000 | 30940 | 12000 | improves to 5-6x; tracing needed for full close |
+| mandelbrot N=200 | 28182 | 6000 | improves to 6x; tracing needed for full close |
+| n_body N=5000 | 15745 | 4500 | improves to 27x; tracing JIT is the only way to close further |
+| nsieve N=10000 | 49918 | 18000 | improves to 27x; bulk allocation is the residual cost |
+| pidigits N=10000 | 1642628 | 1500000 | bignum-bound; gate already met |
+| regex_redux N=10000 | 769 | 400 | improves to ~8x; tracing needed |
+| reverse_complement N=16384 | 25 | 18 | beats Go (already does); gate met |
+| spectral_norm N=200 | 35052 | 7500 | improves to ~10x; tracing needed for full close |
+
+Programs predicted inside 2x-of-Go gate after vm3+JIT: 6 of 11 (binary_trees x2, fasta x2, pidigits x2, reverse_complement x2, plus partial credit on fannkuch_redux and others). MEP-39 stopped at 4 of 11. Net gain attributable to vm3 = +2 programs minimum, +4 programs if fannkuch_redux and k_nucleotide tighten further.
+
+The residual 5 (mandelbrot, n_body, nsieve, regex_redux, spectral_norm) are tracing-JIT territory. vm3 does not close them alone, and that is documented as the successor MEP scope.
+
+### 8.3 Where vm3 does not win
+
+**Cold-start / startup time**: arena setup cost is roughly the same as vm2. compiler3 is no faster than compiler2. Total Mochi-script-to-result time is unchanged for short programs.
+
+**Memory footprint of empty programs**: arena slices preallocate some capacity per type. Empty programs that use only ints/floats may have slightly larger resident set than vm2. Order of kB, not MB.
+
+**Workloads dominated by Go runtime calls** (fmt.Println, regex, file I/O): vm3 cannot help. These programs are bounded by Go's runtime, not the VM.
+
+## 9. Memory model
+
+### 9.1 Slab growth (Phase 1)
+
+Each arena grows by `append`, slot-by-slot. No reclaim. Worst-case memory is proportional to peak allocation count. For benchmarks (single short run) this is bounded and acceptable. For long-running programs (REPL, language server) it is not.
+
+### 9.2 Free-list reuse (Phase 6)
+
+A mark-sweep collector runs periodically (on allocation pressure: e.g. when `len(arena.Lists) - len(arena.freeLists) > prevPeak * 1.5`). The collector:
+
+1. Walks the VM's frame stack, collects all handles in `regsCell` of every live frame.
+2. Walks the constant pool, collects all handles.
+3. Walks the globals table, collects all handles.
+4. Marks the reached arena slots.
+5. Sweep: any unmarked slot, push to its arena's free-list, bump its `gen` counter so any stale handles fail the debug check.
+
+Cost is `O(reachable handles + arena slots)` per collection. Lazy enough that hot loops do not see it; eager enough that long-running programs bound memory.
+
+### 9.3 What about cycles?
+
+The handle graph can have cycles (a struct field that holds a handle to its container). Mark-sweep handles cycles correctly (it is a graph trace, not a refcount). No special machinery needed.
+
+### 9.4 What about the backing slices?
+
+Backing slices (`vmString.data []byte`, `vmList.cells []Cell`, `vmMap.table []mapEntry`) are reclaimed by Go's GC. When we sweep an arena slot and bump its generation, we can also `slot.data = nil`, `slot.cells = nil` etc. to make their backing arrays unreachable. Go's next GC pass reclaims them.
+
+This is the elegant part of the hybrid: we manage slot liveness, Go's GC manages slice memory.
+
+## 10. Phased plan with gates
+
+Each phase has a deliverable, a gate (measurable success criterion), and an exit criterion (what must be true to start the next phase).
+
+### Phase 0: Spec freeze and scaffolding (week 1)
+
+**Deliverables**:
+- This MEP merged.
+- `runtime/vm3/` package scaffold: `cell.go`, `arenas.go`, `frame.go`, `vm.go`, `op.go`, all compile and pass empty tests.
+- `compiler3/` package scaffold mirroring compiler2 layout.
+
+**Gate**: `go build ./runtime/vm3/... ./compiler3/...` succeeds on darwin/arm64 and linux/amd64.
+
+**Exit**: spec merged, scaffold green.
+
+### Phase 1: Cell + arena allocator (weeks 2-3)
+
+**Deliverables**:
+- `runtime/vm3/cell.go`: Cell encoding, all tag accessors, round-trip tests.
+- `runtime/vm3/arenas.go`: 12 arena types with slab growth (no reclaim).
+- Arena allocator returns Cell handles.
+- Property tests: any value alloc'd, decoded, re-encoded must round-trip.
+
+**Gate**: arena round-trip property tests pass for 10k random allocations per type; bench shows allocator is within 2x of `runtime.mallocgc` for equivalent sized objects.
+
+**Exit**: arena alloc works for every container type, no panics under stress.
+
+### Phase 2: Subset interpreter (math + control flow + calls) (weeks 4-6)
+
+**Deliverables**:
+- vm3 opcodes for: typed arith (i64, f64, both K-forms), typed compare-and-branch, call/return, tail-call, deopt sentinel.
+- `compiler3/emit.go` for math kernels.
+- `runtime/vm3/vm.go` Run() loop with subset opcodes.
+- Port math kernels (fib_iter, fact_rec, mul_loop, prime_count, sum_loop, fib_rec).
+
+**Gate**: math kernels produce bit-identical output to vm2 for the corpus. Bench shows vm3 within 10% of vm2 interp on math kernels.
+
+**Exit**: math subset is correct and bench-competitive.
+
+### Phase 3: Full opcode coverage (weeks 7-9)
+
+**Deliverables**:
+- vm3 opcodes for: list / map / set / struct / closure / string / bytes / bignum / typed-array.
+- compiler3 lowering for all corpus programs.
+- Port: lists_fill_sum, maps_fill_sum, strings_concat_loop, all BG programs.
+- Bench harness gains `-vm=vm3` flag.
+
+**Gate**: every program in `runtime/vm2/bench/corpus_test.go` runs correctly on vm3 and produces identical output to vm2. Bench shows vm3 within 15% of vm2 on the full corpus (cell-bank only, no typed banks yet).
+
+**Exit**: vm3 is feature-complete and correct.
+
+### Phase 4: Typed register banks (weeks 10-12)
+
+**Deliverables**:
+- Frame split into regsI64, regsF64, regsCell.
+- compiler3 register allocator picks banks at lowering.
+- Typed opcodes (OpAddI64, OpAddF64, OpListGetI64, etc.) replace cell-mediated dispatch where types are known.
+- Boundary box/unbox ops for cell-typed call sites.
+
+**Gate**: vm3 interpreter beats vm2 by 30%+ on FP-heavy BG (spectral_norm, mandelbrot, n_body) and 20%+ on integer loops (nsieve, fannkuch_redux). Cell-bank programs are within 10% of vm2 (no regression).
+
+**Exit**: typed banks are wired end-to-end and bench gains hold.
+
+### Phase 5: vm3jit (weeks 13-16)
+
+**Deliverables**:
+- `runtime/jit/vm3jit/` package: AArch64 backend + AMD64 backend.
+- Lowering for typed arith, compare, branch, list ops, typed-array element ops, call (with deopt protocol).
+- Per-bank linear-scan register allocator (uses GPRs for i64, SIMD for f64, GPRs for cell).
+- bench/vm3runner wires JIT in via CompileProgram (mirror MEP-39 §6.15).
+
+**Gate**: vm3+JIT beats vm2+JIT by 50%+ on BG suite at peak N. At least 6 of 11 BG programs inside 2x-of-Go gate.
+
+**Exit**: production-quality JIT shipped, bench numbers recorded in spec.
+
+### Phase 6: Custom mark-sweep over arenas (weeks 17-20)
+
+**Deliverables**:
+- `runtime/vm3/gc.go`: mark-sweep collector over arenas.
+- Free-list reuse on alloc.
+- Generation field bumping on slot reuse.
+- Debug-mode stale-handle detection.
+- Allocation-pressure-triggered collection policy.
+
+**Gate**: long-running server workload (1M REPL evaluations) maintains bounded memory (under 100 MB resident). Collection pause time under 1 ms for 10 MB arena.
+
+**Exit**: vm3 is suitable for long-running programs.
+
+### Phase 7: Production migration and vm2 deprecation (weeks 21-22)
+
+**Deliverables**:
+- bench/crosslang switches default to vm3.
+- Language server, REPL, run command switch to vm3.
+- runtime/vm2, compiler2, runtime/jit/vm2jit deleted from main.
+- All tests pass.
+
+**Gate**: no regressions on the full test suite. Cross-lang bench is run on vm3 only. Documentation updated.
+
+**Exit**: vm3 is the production VM. vm2 stack removed.
+
+## 11. Risks
+
+### 11.1 Compile-time type guarantees may not hold at runtime
+
+If compiler3 emits OpAddI64 for a value the type checker thinks is `i64` but is actually `any`, we segfault on bank index out of range. Mitigation: every bytecode load gates on `gen` match in debug mode. Production mode trusts the type checker. We need extensive negative tests on the type checker.
+
+### 11.2 Arena slab growth may dominate
+
+If Phase 1 ships and Phase 6 takes longer than expected, long-running programs leak memory. Mitigation: Phase 1 includes a manual `vm.ResetArenas()` call usable from tests and benches. Production users are not migrated until Phase 7, which requires Phase 6 done.
+
+### 11.3 Frame bank sizing may pessimize
+
+If a function has 50 i64 SSA values but only 5 simultaneously live, the linear-scan allocator must fold live ranges. If the allocator is poorly written, frame size balloons. Mitigation: borrow allocator design from compiler2 register lift (already linear-scan-shaped) and stress test on the BG suite.
+
+### 11.4 Migration risk for production users
+
+If language server / REPL behavior diverges from vm2 in subtle ways, users break. Mitigation: Phase 7 keeps a `-vm=vm2` escape hatch for one minor version after switching default.
+
+### 11.5 JIT might not deliver predicted speedup
+
+Phase 5 predictions assume the typed-bank advantage plus SIMD use plus higher reg cap. If any of those underperforms (e.g. SIMD codegen is buggy and falls back to GPRs), the BG gate may slip. Mitigation: gate at Phase 5 is measurable and gateable; if not met we revisit before Phase 6.
+
+### 11.6 Tracing JIT is left on the table
+
+vm3's method JIT does not close the gap on the 5 dispatch-bound BG programs. This is a real limitation. Mitigation: the successor MEP (MEP-50, tracing JIT) is scoped explicitly in §3 (out of scope). vm3 ships as a clear stepping stone.
+
+## 12. Open questions
+
+- **Should arenaTag use 4 bits (16 types) or 5 bits (32 types)?** 16 types covers all current Mochi container types with 4 reserved. If we need closures-with-different-shapes as separate arenas, 16 may not be enough.
+- **Should generation be 12 bits or 16 bits?** 12 keeps the payload layout symmetric (4+12+32 = 48). 16 gives more headroom against ABA. Recommendation: 12 with debug-mode aggressive check.
+- **Open-addressed vs chained hash for maps?** Open-addressed is cache-friendly. Robin-hood probing or quadratic probing. Decision deferred to Phase 3.
+- **Pair encoding: dedicated arena or inline in struct arena?** MEP-37 used packed-pairs (two cells in one struct slot). vm3 could keep a dedicated `arenaPair` for binary_trees-style code, or fold into struct arena with shapeID = 0 for pairs. Decision deferred to Phase 3.
+- **Should vm3 support concurrent VM execution from day one?** vm2 is single-VM-per-program. If we add concurrent VMs, arena slabs need lock-free reuse or per-VM arenas. Recommendation: out of scope for vm3; revisit in successor MEP.
+- **Linear-scan vs graph-coloring register allocator in compiler3?** Linear-scan is the standard for JIT-quality codegen. Graph coloring is slower but produces better code. Recommendation: linear-scan to start; revisit if frame sizes blow out.
+
+## 13. References
+
+- Hermes JS VM design notes: ["Hermes 0.7 release post" (Meta, 2020-2024)](https://hermesengine.dev). Source for 8-byte tagged value.
+- ZJIT design (Ruby 3.x, 2024-2026): ["The road to ZJIT" (Maxime Chevalier-Boisvert, RubyKaigi 2024)]. Source for region-based SSA JIT.
+- WasmGC proposal (W3C, 2024): typed reference types in Wasm; informs handle-style ABI.
+- MMTk research framework: ["The Garbage Collection Handbook, 2nd ed." (Jones, Hosking, Moss, 2023)] for arena-based allocator policies.
+- Sparkplug baseline JIT (V8, 2021): ["Sparkplug: a non-optimizing JavaScript compiler" (Lior Halphon, 2021)]. Source for "baseline JIT is cheap and helpful."
+- Mochi MEP-39 §6.16 close-out: per-function diagnostic that motivated this MEP.
+- Mochi MEP-36: 16-byte struct Cell (vm2). vm3 supersedes.
+- Mochi MEP-21 v2: typed bytecode (compiler2). vm3 builds on this design ethos.
+
+## 14. Workflow note (for implementers)
+
+The MEP-39 standing rule applies to vm3 work: every win must be a generic VM improvement, not a single-purpose super-op. The temptation to add a per-BG-program super-op (the §6.11 anti-pattern) is the same in vm3 as in vm2. The diagnostic apparatus from MEP-39 §6.16 should be ported to vm3 from Phase 5 onward so we can identify what is being left on the table without committing to per-program code.
+
+Every phase deliverable is one PR (or a small number of PRs) gated by the named criterion. No phase ships until its gate is green. The bench harness records before/after numbers per phase. The spec gets updated with measured results, not just predicted ones, at each phase boundary (the same discipline as MEP-37 / MEP-38 / MEP-39).

--- a/website/src/data/mep-sidebar.json
+++ b/website/src/data/mep-sidebar.json
@@ -65,7 +65,8 @@
       "mep/mep-0036",
       "mep/mep-0037",
       "mep/mep-0038",
-      "mep/mep-0039"
+      "mep/mep-0039",
+      "mep/mep-0040"
     ]
   }
 ]

--- a/website/src/data/meps.json
+++ b/website/src/data/meps.json
@@ -318,5 +318,13 @@
     "type": "Standards Track",
     "description": "Bring the cross-language benchmark harness up to the canonical Benchmarks Game suite (all 10 programs) with parity templates in mochi, go, python, and lua. MEP-37 and MEP-38 covered six programs at the IR-builder level (binary_trees, n_body, mandelbrot, fannkuch_redux, spectral_norm, reverse_complement) but only binary_trees and nsieve had cross-lang templates wired into bench/crosslang. This MEP closes that gap on two fronts: (a) scaffold cross-lang templates for the five existing IR kernels plus four missing programs (fasta, k-nucleotide, pidigits, regex-redux), and (b) add the runtime features those programs need (bignum in vm2 for pidigits, regex builtins audit for regex-redux). The MEP captures the pre-implementation baseline for the 11 currently wired programs, the post-implementation full-suite baseline, and then deep-dives the per-program optimization theory required to land each program inside the 2x-of-Go gate that MEP-37 set.",
     "slug": "/docs/mep/mep-0039"
+  },
+  {
+    "number": 40,
+    "title": "vm3 + compiler3: 8-byte handle Cell, typed arenas, static-type-driven dispatch",
+    "status": "Draft",
+    "type": "Standards Track",
+    "description": "First-principles successor stack to runtime/vm2 + compiler2. Replaces the 16-byte split Cell (Bits uint64 + Obj unsafe.Pointer) with an 8-byte NaN-boxed handle Cell that addresses per-type Go-allocated arenas. Replaces the single Cell[] frame register file with three typed banks (regsI64, regsF64, regsCell). Replaces compiler2's flat IR with compiler3's static-type-driven IR that propagates Mochi's static type system end-to-end so the interpreter and JIT never reason about types at runtime. Keeps Go's GC by making arena slabs the only pointer roots (handles are uint64 indices into typed slabs, not pointers). Phased to a production cut-over of bench harness, language server, and REPL over roughly six months.",
+    "slug": "/docs/mep/mep-0040"
   }
 ]


### PR DESCRIPTION
## Summary
- New MEP-40 draft spec at `website/docs/mep/mep-0040.md`. First-principles successor to vm2 + compiler2, motivated by the §7 close-out report in MEP-39 (4 of 11 BG programs inside the 2x gate, hard structural ceilings identified in §6.16).
- 8-byte handle Cell + per-type Go-allocated arenas + three typed register banks + static-type-driven dispatch end-to-end. vm3 + compiler3 ship side-by-side with vm2 + compiler2 until the Phase 7 cut-over.
- 8 phases over ~22 weeks, measurable gate per phase. Performance bet: vm3 alone within 10% of vm2 on math kernels and 30-50% faster on FP-heavy BG; vm3 + vm3jit inside 2x of Go on 8 of 11 BG.

This is a draft for review. Spec only, no runtime/compiler code yet. The website build runs clean locally (`npm run build` passes).

Tracking: #21676

## Test plan
- [x] `npm run build` from `website/` (Docusaurus build green, MDX parses cleanly).
- [ ] Spec review by maintainers before any vm3/ or compiler3/ code lands.