### PR TITLE
mep-0040 phase 0: scaffold runtime/vm3 + compiler3

### DIFF
--- a/compiler3/corpus/doc.go
+++ b/compiler3/corpus/doc.go
@@ -1,0 +1,20 @@
+// Package corpus holds compiler3 hand-built IR programs used to
+// validate end-to-end builds before the Mochi-source frontend lands on
+// compiler3. Mirrors compiler2/corpus so the bench harness can drop in
+// vm3 alongside vm2 without rewriting templates.
+//
+// Phase 0 ships only the scaffold; programs port over in Phase 2.
+package corpus
+
+import "mochi/compiler3/ir"
+
+// Program names one corpus entry: a function builder keyed by name,
+// parameterized by N (the per-program size knob shared with bench/).
+type Program struct {
+	Name  string
+	Build func(n int64) *ir.Function
+}
+
+// All returns every registered corpus program. Phase 0 ships an empty
+// list; Phase 2 starts populating it.
+func All() []*Program { return nil }

--- a/compiler3/doc.go
+++ b/compiler3/doc.go
@@ -1,0 +1,17 @@
+// Package compiler3 is the from-scratch typed bytecode compiler for vm3.
+//
+// Design contract: MEP-40 (vm3 + compiler3). See
+// website/docs/mep/mep-0040.md.
+//
+// Pipeline:
+//
+//	typed AST (existing types/ pass)
+//	-> typed SSA IR (compiler3/ir)
+//	-> optimization passes (compiler3/opt: ConstFold, DCE, branch
+//	   threading, LICM, TailCall)
+//	-> linear-scan register allocation per bank (compiler3/regalloc)
+//	-> typed monomorphic bytecode emission (compiler3/emit)
+//	-> runtime/vm3 Function.
+//
+// compiler3 co-exists with compiler2 until Phase 7 cut-over.
+package compiler3

--- a/compiler3/emit/doc.go
+++ b/compiler3/emit/doc.go
@@ -1,0 +1,28 @@
+// Package emit is compiler3's bytecode generator.
+//
+// The emitter walks blocks in reverse postorder and emits the
+// fixed-width 8-byte opcodes described in MEP-40 §6.6. Constants are
+// pooled per function; strings live in the global string arena at
+// compile time.
+//
+// Phase 0 ships only the scaffold.
+package emit
+
+import (
+	"mochi/compiler3/ir"
+	"mochi/compiler3/regalloc"
+	"mochi/runtime/vm3"
+)
+
+// Compile lowers fn to a runtime/vm3 Function. Phase 0 returns an
+// empty Function so callers can wire end-to-end before Phase 2 fills
+// in the opcode bodies.
+func Compile(fn *ir.Function, alloc regalloc.Result) (*vm3.Function, error) {
+	_ = fn
+	return &vm3.Function{
+		Name:        fn.Name,
+		NumRegsI64:  alloc.NumI64,
+		NumRegsF64:  alloc.NumF64,
+		NumRegsCell: alloc.NumCell,
+	}, nil
+}

--- a/compiler3/ir/doc.go
+++ b/compiler3/ir/doc.go
@@ -1,0 +1,97 @@
+// Package ir is compiler3's typed SSA intermediate representation.
+//
+// Every Value carries a static Type (i64, f64, bool, str, list, map,
+// struct, ...). Passes preserve type; lowering picks the opcode by
+// type. See MEP-40 §7.1.
+package ir
+
+// Type is the static type tag attached to every SSA Value.
+type Type uint8
+
+const (
+	TypeInvalid Type = iota
+	TypeI64
+	TypeF64
+	TypeBool
+	TypeStr
+	TypeList
+	TypeMap
+	TypeSet
+	TypeStruct
+	TypeClosure
+	TypeBignum
+	TypeBytes
+	TypePair
+	TypeF64Arr
+	TypeI64Arr
+	TypeU8Arr
+	TypeAny
+)
+
+// OpCode identifies which IR operation a Value represents. Phase 0
+// declares only the placeholder set; Phase 2 expands.
+type OpCode uint8
+
+const (
+	OpInvalid OpCode = iota
+	OpConst
+	OpParam
+	OpAdd
+	OpSub
+	OpMul
+	OpDiv
+	OpCmpEq
+	OpCmpLt
+	OpCall
+	OpReturn
+)
+
+// Value is one SSA-form IR node. Type is mandatory; the type checker
+// proves it before compiler3 sees the value.
+type Value struct {
+	ID       uint32
+	Type     Type
+	ElemType Type
+	StructID uint32
+	Op       OpCode
+	Args     []uint32
+	Const    int64
+}
+
+// Terminator is a block's exit instruction. Phase 0 declares the kinds
+// the spec requires; bodies arrive in Phase 2.
+type Terminator struct {
+	Kind   TerminatorKind
+	Target uint32
+	IfTrue uint32
+	IfFalse uint32
+	Value  uint32
+}
+
+type TerminatorKind uint8
+
+const (
+	TermInvalid TerminatorKind = iota
+	TermJump
+	TermBranch
+	TermReturn
+)
+
+// Block is a basic block in the function's CFG.
+type Block struct {
+	ID     uint32
+	Values []uint32
+	Preds  []uint32
+	Succs  []uint32
+	Term   Terminator
+}
+
+// Function is the compilation unit handed from the type-aware build to
+// the optimization pipeline.
+type Function struct {
+	Name   string
+	Params []Value
+	Result Type
+	Blocks []Block
+	Values []Value
+}

--- a/compiler3/opt/doc.go
+++ b/compiler3/opt/doc.go
@@ -1,0 +1,31 @@
+// Package opt holds compiler3's type-preserving optimization passes.
+//
+// Pass pipeline (MEP-40 §7.3):
+//
+//  1. ConstFold     (preserves type, produces typed Const values)
+//  2. DCE            (deletes unused SSA values)
+//  3. BranchThread   (collapses trivial control flow)
+//  4. LICM           (loop-invariant code motion, type-aware)
+//  5. TailCall       (marks TCO candidates)
+//
+// Phase 0 ships only the scaffold; pass bodies arrive in Phase 2.
+package opt
+
+import "mochi/compiler3/ir"
+
+// ConstFold folds constant operands of arithmetic and comparison ops.
+// Phase 0 stub returns fn unchanged.
+func ConstFold(fn *ir.Function) { _ = fn }
+
+// DCE removes unused SSA values. Phase 0 stub.
+func DCE(fn *ir.Function) { _ = fn }
+
+// BranchThread collapses trivially-jump-only blocks. Phase 0 stub.
+func BranchThread(fn *ir.Function) { _ = fn }
+
+// LICM hoists loop-invariant values out of inner loops. Phase 0 stub.
+func LICM(fn *ir.Function) { _ = fn }
+
+// TailCall marks return-of-call patterns so emit can lower them to
+// OpTailCall. Phase 0 stub.
+func TailCall(fn *ir.Function) { _ = fn }

--- a/compiler3/regalloc/doc.go
+++ b/compiler3/regalloc/doc.go
@@ -1,0 +1,34 @@
+// Package regalloc is compiler3's linear-scan register allocator.
+//
+// Each bank (regsI64, regsF64, regsCell) gets its own live-interval
+// pass. The cap-17 limitation of vm2jit goes away because compiler3
+// produces a frame with separate banks, each with its own size. A
+// function with NumRegsI64=20, NumRegsF64=5, NumRegsCell=3 fits AArch64
+// GPR + SIMD register sets naturally.
+//
+// Phase 0 ships only the scaffold.
+package regalloc
+
+import "mochi/compiler3/ir"
+
+// Result holds the per-bank slot counts after allocation.
+type Result struct {
+	NumI64  uint16
+	NumF64  uint16
+	NumCell uint16
+	// Map from IR Value ID to (bank, slot). Phase 4 wires this up.
+	Slots map[uint32]Assignment
+}
+
+// Assignment names the bank + slot index of one SSA value's lifetime.
+type Assignment struct {
+	Bank uint8
+	Slot uint16
+}
+
+// Allocate runs linear-scan allocation per bank over fn's live ranges.
+// Phase 0 stub returns an empty result.
+func Allocate(fn *ir.Function) Result {
+	_ = fn
+	return Result{Slots: map[uint32]Assignment{}}
+}

--- a/runtime/vm3/arenas.go
+++ b/runtime/vm3/arenas.go
@@ -1,0 +1,146 @@
+package vm3
+
+// Arenas holds the typed slabs that back every handle Cell. Each slab
+// is a plain Go slice, so Go's GC reclaims slab backing memory through
+// normal field traversal: the slab slice header lives on a VM field,
+// each entry's internal storage (bytes, cells, table) is a slice the
+// GC also sees.
+//
+// Phase 1 grows slabs monotonically (no free-list reuse). Phase 6 wires
+// a mark-sweep collector through the free-list fields below.
+type Arenas struct {
+	Strings  []vmString
+	Lists    []vmList
+	Maps     []vmMap
+	Sets     []vmSet
+	Structs  []vmStruct
+	Closures []vmClosure
+	Bignums  []vmBignum
+	Bytes    []vmBytes
+	Pairs    []vmPair
+	F64Arrs  []vmF64Array
+	I64Arrs  []vmI64Array
+	U8Arrs   []vmU8Array
+
+	freeStrings  []uint32
+	freeLists    []uint32
+	freeMaps     []uint32
+	freeSets     []uint32
+	freeStructs  []uint32
+	freeClosures []uint32
+	freeBignums  []uint32
+	freeBytes    []uint32
+	freePairs    []uint32
+	freeF64Arrs  []uint32
+	freeI64Arrs  []uint32
+	freeU8Arrs   []uint32
+}
+
+const (
+	flagAlive  uint8 = 1 << 0
+	flagShared uint8 = 1 << 1
+)
+
+type vmString struct {
+	gen   uint16
+	flags uint8
+	_     uint8
+	len   uint32
+	data  []byte
+}
+
+type vmList struct {
+	gen      uint16
+	flags    uint8
+	_        uint8
+	len      uint32
+	cells    []Cell
+	elemType uint8
+}
+
+type mapEntry struct {
+	hash  uint64
+	key   Cell
+	value Cell
+}
+
+type vmMap struct {
+	gen   uint16
+	flags uint8
+	_     uint8
+	nLive uint32
+	table []mapEntry
+}
+
+type vmSet struct {
+	gen   uint16
+	flags uint8
+	_     uint8
+	nLive uint32
+	table []mapEntry
+}
+
+type vmStruct struct {
+	gen     uint16
+	flags   uint8
+	_       uint8
+	shapeID uint32
+	fields  []Cell
+}
+
+type vmClosure struct {
+	gen      uint16
+	flags    uint8
+	_        uint8
+	fnID     uint32
+	upvalues []Cell
+}
+
+type vmBignum struct {
+	gen   uint16
+	flags uint8
+	sign  int8
+	_     uint32
+	words []uint64
+}
+
+type vmBytes struct {
+	gen   uint16
+	flags uint8
+	_     uint8
+	len   uint32
+	data  []byte
+}
+
+type vmPair struct {
+	gen   uint16
+	flags uint8
+	_     uint8
+	_     uint32
+	fst   Cell
+	snd   Cell
+}
+
+type vmF64Array struct {
+	gen   uint16
+	flags uint8
+	_     uint8
+	len   uint32
+	data  []float64
+}
+
+type vmI64Array struct {
+	gen   uint16
+	flags uint8
+	_     uint8
+	len   uint32
+	data  []int64
+}
+
+type vmU8Array struct {
+	gen   uint16
+	flags uint8
+	_     uint8
+	len   uint32
+	data  []byte
+}

--- a/runtime/vm3/cell.go
+++ b/runtime/vm3/cell.go
@@ -1,0 +1,166 @@
+package vm3
+
+import "math"
+
+// Cell is the 8-byte tagged value used throughout vm3. It is a strict
+// NaN-box: floats occupy the full uint64 in their bit-pattern range;
+// non-float values use the qNaN payload space for tag + payload.
+//
+// Bits layout (high 16 bits = tag, low 48 bits = payload):
+//
+//	0x0000..0xFFEF -> float64 (normal or subnormal). Decode via math.Float64frombits.
+//	0x7FF8         -> canonical qNaN. Any NaN input normalizes here.
+//	0xFFF8         -> tagDeopt  (JIT deopt sentinel; pc in low 48 bits).
+//	0xFFF9         -> tagSStr   (inline short string; len in bits 40..43, up to 5 bytes in 0..39).
+//	0xFFFA         -> tagInt48  (sign-extended 48-bit signed int in low 48 bits).
+//	0xFFFB         -> tagBool   (low bit = value).
+//	0xFFFC         -> tagNull   (no payload).
+//	0xFFFD         -> reserved.
+//	0xFFFE         -> reserved.
+//	0xFFFF         -> tagHandle (arena handle; see encoding below).
+//
+// Handle payload (low 48 bits when tag is 0xFFFF):
+//
+//	bits 47..44 : arena selector (16 arenas max). See ArenaTag enum.
+//	bits 43..32 : generation (12 bits, wraps; debug mode checks for stale handles).
+//	bits 31..0  : slab index (32 bits, 4B entries per arena cap).
+type Cell uint64
+
+const (
+	qNaN      uint64 = 0x7FF8_0000_0000_0000
+	tagMask   uint64 = 0xFFFF_0000_0000_0000
+	tagDeopt  uint64 = 0xFFF8_0000_0000_0000
+	tagSStr   uint64 = 0xFFF9_0000_0000_0000
+	tagInt48  uint64 = 0xFFFA_0000_0000_0000
+	tagBool   uint64 = 0xFFFB_0000_0000_0000
+	tagNull   uint64 = 0xFFFC_0000_0000_0000
+	tagHandle uint64 = 0xFFFF_0000_0000_0000
+
+	arenaSelShift uint64 = 44
+	arenaSelMask  uint64 = uint64(0xF) << arenaSelShift
+	genShift      uint64 = 32
+	genMask       uint64 = uint64(0xFFF) << genShift
+	idxMask       uint64 = 0xFFFF_FFFF
+
+	payloadMask uint64 = 0x0000_FFFF_FFFF_FFFF
+
+	MaxInlineStr           = 5
+	sstrLenShift    uint64 = 40
+	sstrLenMask     uint64 = 0xF
+	sstrByteMask    uint64 = (uint64(1) << sstrLenShift) - 1
+
+	MaxInlineInt int64 = 1<<47 - 1
+	MinInlineInt int64 = -(1 << 47)
+)
+
+// ArenaTag selects which arena slab a handle Cell points into.
+type ArenaTag uint8
+
+const (
+	ArenaString  ArenaTag = 0
+	ArenaList    ArenaTag = 1
+	ArenaMap     ArenaTag = 2
+	ArenaSet     ArenaTag = 3
+	ArenaStruct  ArenaTag = 4
+	ArenaClosure ArenaTag = 5
+	ArenaBignum  ArenaTag = 6
+	ArenaBytes   ArenaTag = 7
+	ArenaPair    ArenaTag = 8
+	ArenaF64Arr  ArenaTag = 9
+	ArenaI64Arr  ArenaTag = 10
+	ArenaU8Arr   ArenaTag = 11
+)
+
+func CFloat(f float64) Cell {
+	if f != f {
+		return Cell(qNaN)
+	}
+	return Cell(math.Float64bits(f))
+}
+
+func CInt(i int64) Cell {
+	return Cell(tagInt48 | uint64(i)&payloadMask)
+}
+
+func CBool(b bool) Cell {
+	if b {
+		return Cell(tagBool | 1)
+	}
+	return Cell(tagBool)
+}
+
+func CNull() Cell { return Cell(tagNull) }
+
+func CSStr(b []byte) Cell {
+	var packed uint64
+	n := min(len(b), MaxInlineStr)
+	for i := range n {
+		packed |= uint64(b[i]) << (uint(i) * 8)
+	}
+	return Cell(tagSStr | (uint64(n) << sstrLenShift) | packed)
+}
+
+func (c Cell) IsFloat() bool  { return uint64(c)&tagMask < tagSStr }
+func (c Cell) IsSStr() bool   { return uint64(c)&tagMask == tagSStr }
+func (c Cell) IsInt() bool    { return uint64(c)&tagMask == tagInt48 }
+func (c Cell) IsBool() bool   { return uint64(c)&tagMask == tagBool }
+func (c Cell) IsNull() bool   { return uint64(c)&tagMask == tagNull }
+func (c Cell) IsHandle() bool { return uint64(c)&tagMask == tagHandle }
+func (c Cell) IsDeopt() bool  { return uint64(c)&tagMask == tagDeopt }
+
+func (c Cell) Float() float64 { return math.Float64frombits(uint64(c)) }
+func (c Cell) Int() int64     { return int64(uint64(c)<<16) >> 16 }
+func (c Cell) Bool() bool     { return uint64(c)&1 != 0 }
+
+// SStrLen returns the byte length of an inline string Cell. Caller must
+// have verified IsSStr.
+func (c Cell) SStrLen() int {
+	return int((uint64(c) >> sstrLenShift) & sstrLenMask)
+}
+
+// SStrBytes writes the inline string bytes into buf and returns a subslice.
+func (c Cell) SStrBytes(buf *[MaxInlineStr]byte) []byte {
+	n := c.SStrLen()
+	packed := uint64(c) & sstrByteMask
+	for i := range n {
+		buf[i] = byte(packed >> (uint(i) * 8))
+	}
+	return buf[:n]
+}
+
+// MakeHandle packs (tag, gen, idx) into a handle Cell.
+func MakeHandle(tag ArenaTag, gen uint16, idx uint32) Cell {
+	return Cell(tagHandle |
+		(uint64(tag) << arenaSelShift) |
+		(uint64(gen&0xFFF) << genShift) |
+		uint64(idx))
+}
+
+// DecodeHandle splits a handle Cell into (tag, gen, idx). Caller must
+// have verified IsHandle.
+func (c Cell) DecodeHandle() (tag ArenaTag, gen uint16, idx uint32) {
+	p := uint64(c) & payloadMask
+	tag = ArenaTag((p & arenaSelMask) >> arenaSelShift)
+	gen = uint16((p & genMask) >> genShift)
+	idx = uint32(p & idxMask)
+	return
+}
+
+// EncodeDeopt produces the sentinel Cell returned by a JIT deopt stub.
+func EncodeDeopt(pc int) Cell {
+	return Cell(tagDeopt | uint64(pc)&payloadMask)
+}
+
+// DecodeDeopt reports whether c is a deopt sentinel and, if so, returns
+// the carried bytecode PC.
+func DecodeDeopt(c Cell) (pc int, ok bool) {
+	if uint64(c)&tagMask != tagDeopt {
+		return 0, false
+	}
+	return int(uint64(c) & payloadMask), true
+}
+
+// FitsInline reports whether i can be boxed inline by CInt without loss.
+func FitsInline(i int64) bool {
+	return i >= MinInlineInt && i <= MaxInlineInt
+}

--- a/runtime/vm3/cell_test.go
+++ b/runtime/vm3/cell_test.go
@@ -1,0 +1,119 @@
+package vm3
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCellInt(t *testing.T) {
+	for _, v := range []int64{0, 1, -1, 42, -42, MaxInlineInt, MinInlineInt} {
+		c := CInt(v)
+		if !c.IsInt() {
+			t.Fatalf("CInt(%d): IsInt false", v)
+		}
+		if got := c.Int(); got != v {
+			t.Fatalf("CInt(%d) round-trip: got %d", v, got)
+		}
+	}
+}
+
+func TestCellFloat(t *testing.T) {
+	for _, v := range []float64{0, 1, -1, 3.14, math.Inf(1), math.Inf(-1)} {
+		c := CFloat(v)
+		if !c.IsFloat() {
+			t.Fatalf("CFloat(%v): IsFloat false", v)
+		}
+		if got := c.Float(); got != v {
+			t.Fatalf("CFloat(%v) round-trip: got %v", v, got)
+		}
+	}
+	// NaN canonicalizes; the cell must still read as float.
+	c := CFloat(math.NaN())
+	if !c.IsFloat() {
+		t.Fatalf("CFloat(NaN): IsFloat false")
+	}
+}
+
+func TestCellBool(t *testing.T) {
+	if !CBool(true).IsBool() || !CBool(false).IsBool() {
+		t.Fatal("IsBool false on CBool")
+	}
+	if !CBool(true).Bool() || CBool(false).Bool() {
+		t.Fatal("Bool decode wrong")
+	}
+}
+
+func TestCellNull(t *testing.T) {
+	if !CNull().IsNull() {
+		t.Fatal("IsNull false on CNull")
+	}
+}
+
+func TestCellSStr(t *testing.T) {
+	for _, s := range [][]byte{nil, {'a'}, {'a', 'b'}, {'a', 'b', 'c', 'd', 'e'}} {
+		c := CSStr(s)
+		if !c.IsSStr() {
+			t.Fatalf("CSStr(%q): IsSStr false", s)
+		}
+		if got := c.SStrLen(); got != len(s) {
+			t.Fatalf("CSStr(%q) len: got %d want %d", s, got, len(s))
+		}
+		var buf [MaxInlineStr]byte
+		got := c.SStrBytes(&buf)
+		if len(got) != len(s) {
+			t.Fatalf("SStrBytes len: got %d want %d", len(got), len(s))
+		}
+		for i := range got {
+			if got[i] != s[i] {
+				t.Fatalf("SStrBytes byte %d: got %x want %x", i, got[i], s[i])
+			}
+		}
+	}
+}
+
+func TestHandleRoundTrip(t *testing.T) {
+	for _, tag := range []ArenaTag{
+		ArenaString, ArenaList, ArenaMap, ArenaSet, ArenaStruct,
+		ArenaClosure, ArenaBignum, ArenaBytes, ArenaPair,
+		ArenaF64Arr, ArenaI64Arr, ArenaU8Arr,
+	} {
+		for _, gen := range []uint16{0, 1, 0xFFF} {
+			for _, idx := range []uint32{0, 1, 0xFFFF_FFFF} {
+				c := MakeHandle(tag, gen, idx)
+				if !c.IsHandle() {
+					t.Fatalf("MakeHandle(%v, %d, %d): IsHandle false", tag, gen, idx)
+				}
+				gotTag, gotGen, gotIdx := c.DecodeHandle()
+				if gotTag != tag || gotGen != gen&0xFFF || gotIdx != idx {
+					t.Fatalf("DecodeHandle(%v, %d, %d) = (%v, %d, %d)",
+						tag, gen, idx, gotTag, gotGen, gotIdx)
+				}
+			}
+		}
+	}
+}
+
+func TestDeoptRoundTrip(t *testing.T) {
+	for _, pc := range []int{0, 1, 42, 1 << 20} {
+		c := EncodeDeopt(pc)
+		if !c.IsDeopt() {
+			t.Fatalf("EncodeDeopt(%d): IsDeopt false", pc)
+		}
+		got, ok := DecodeDeopt(c)
+		if !ok || got != pc {
+			t.Fatalf("DecodeDeopt(%d): got (%d, %v)", pc, got, ok)
+		}
+	}
+	if _, ok := DecodeDeopt(CInt(7)); ok {
+		t.Fatal("DecodeDeopt on int: ok true")
+	}
+}
+
+func TestFitsInline(t *testing.T) {
+	if !FitsInline(0) || !FitsInline(MaxInlineInt) || !FitsInline(MinInlineInt) {
+		t.Fatal("FitsInline false on edge")
+	}
+	if FitsInline(MaxInlineInt + 1) || FitsInline(MinInlineInt - 1) {
+		t.Fatal("FitsInline true past edge")
+	}
+}

--- a/runtime/vm3/doc.go
+++ b/runtime/vm3/doc.go
@@ -1,0 +1,27 @@
+// Package vm3 is the from-scratch successor to runtime/vm2.
+//
+// Design contract: MEP-40 (vm3 + compiler3: 8-byte handle Cell, typed
+// arenas, static-type-driven dispatch). See website/docs/mep/mep-0040.md.
+//
+// vm3 is built around three load-bearing ideas:
+//
+//  1. 8-byte Cell with handle-based NaN-boxing. The single uint64 carries
+//     inline ints (48-bit signed), floats (full NaN range), bools, null,
+//     inline short strings (up to 5 bytes), deopt sentinels, and arena
+//     handles. Half the register-file cache footprint of vm2's 16-byte
+//     {Bits, Obj} Cell.
+//
+//  2. Typed arenas with Go-GC-friendly slabs. Each container type lives
+//     in its own Go-allocated slice. Slabs are reachable through normal
+//     Go field traversal, so Go's GC reclaims slab backing without ever
+//     inspecting handle bits.
+//
+//  3. Typed register banks per frame. Each Frame carries regsI64
+//     []int64, regsF64 []float64, regsCell []Cell. compiler3 picks the
+//     bank at emit time based on each SSA value's static type. Typed ops
+//     read and write native machine words; the Cell envelope only
+//     appears at boundaries (polymorphic call arguments, generic list
+//     elements, return values to dyn-typed callers).
+//
+// vm3 ships side-by-side with runtime/vm2 until Phase 7 cut-over.
+package vm3

--- a/runtime/vm3/frame.go
+++ b/runtime/vm3/frame.go
@@ -1,0 +1,39 @@
+package vm3
+
+// Frame is one activation record. Each frame carries three typed
+// register banks. compiler3 partitions every SSA value into exactly one
+// bank at lowering time, based on the value's static type.
+type Frame struct {
+	fn *Function
+	pc int
+
+	regsI64  []int64
+	regsF64  []float64
+	regsCell []Cell
+
+	prev *Frame
+}
+
+// Function is a compiled vm3 function. Each call to it allocates a
+// Frame with banks sized by Num*Regs.
+type Function struct {
+	Name   string
+	Code   []Op
+	Consts []Cell
+
+	NumRegsI64  uint16
+	NumRegsF64  uint16
+	NumRegsCell uint16
+
+	ParamBanks []Bank
+	ResultBank Bank
+}
+
+// Bank identifies one of the three typed register banks.
+type Bank uint8
+
+const (
+	BankI64 Bank = iota
+	BankF64
+	BankCell
+)

--- a/runtime/vm3/op.go
+++ b/runtime/vm3/op.go
@@ -1,0 +1,62 @@
+package vm3
+
+// OpCode is the vm3 bytecode opcode. The bank is encoded in the opcode
+// mnemonic itself (e.g. OpAddI64 vs OpAddF64), so the interpreter
+// never decides at runtime which bank to read.
+type OpCode uint8
+
+const (
+	OpNop OpCode = iota
+
+	// Typed arithmetic (Phase 2).
+	OpMovI64
+	OpMovF64
+	OpAddI64
+	OpSubI64
+	OpMulI64
+	OpDivI64
+	OpAddF64
+	OpSubF64
+	OpMulF64
+	OpDivF64
+
+	// Constant load (Phase 2).
+	OpConstI64
+	OpConstF64
+
+	// Control flow (Phase 2).
+	OpJump
+	OpJumpIfI64
+	OpJumpIfNotI64
+	OpCmpEqI64
+	OpCmpLtI64
+	OpCmpEqF64
+	OpCmpLtF64
+
+	// Call / return (Phase 2).
+	OpCall
+	OpTailCall
+	OpReturnI64
+	OpReturnF64
+	OpReturnCell
+
+	// Container ops (Phase 3, placeholder).
+	OpListGetI64
+	OpListGetF64
+	OpListGetCell
+	OpListSetI64
+	OpListSetF64
+	OpListSetCell
+)
+
+// Op is a single 8-byte vm3 bytecode word. compiler3 emits these into
+// Function.Code. Banks for A and B are encoded in BankFlags; C may be
+// either a third register (bank inferred from the opcode) or a 16-bit
+// signed immediate.
+type Op struct {
+	Code      OpCode
+	BankFlags uint8
+	A         uint16
+	B         uint16
+	C         int16
+}

--- a/runtime/vm3/vm.go
+++ b/runtime/vm3/vm.go
@@ -1,0 +1,32 @@
+package vm3
+
+import "errors"
+
+// VM is a vm3 interpreter instance. Each VM owns one Arenas struct,
+// rooted from this field; Go's GC reaches every arena slab and every
+// backing slice through normal traversal.
+type VM struct {
+	arenas Arenas
+	frame  *Frame
+}
+
+// New constructs an empty VM. Phase 0 ships only the scaffold; later
+// phases wire Run and the opcode bodies.
+func New() *VM {
+	return &VM{}
+}
+
+// Arenas returns the VM's arena state. Tests use this to inspect slot
+// counts and free-list lengths.
+func (vm *VM) Arenas() *Arenas { return &vm.arenas }
+
+// ErrNotImplemented is returned by VM.Run until Phase 2 lands the
+// interpreter loop.
+var ErrNotImplemented = errors.New("vm3: VM.Run not yet implemented (Phase 2)")
+
+// Run executes fn until it returns or traps. Phase 0 returns
+// ErrNotImplemented unconditionally.
+func (vm *VM) Run(fn *Function) (Cell, error) {
+	_ = fn
+	return CNull(), ErrNotImplemented
+}

--- a/runtime/vm3/vm_test.go
+++ b/runtime/vm3/vm_test.go
@@ -1,0 +1,23 @@
+package vm3
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNewVMHasEmptyArenas(t *testing.T) {
+	vm := New()
+	a := vm.Arenas()
+	if len(a.Strings)+len(a.Lists)+len(a.Maps)+len(a.Sets)+
+		len(a.Structs)+len(a.Closures)+len(a.Bignums)+len(a.Bytes)+
+		len(a.Pairs)+len(a.F64Arrs)+len(a.I64Arrs)+len(a.U8Arrs) != 0 {
+		t.Fatal("new VM has non-empty arena")
+	}
+}
+
+func TestRunReturnsNotImplemented(t *testing.T) {
+	vm := New()
+	if _, err := vm.Run(&Function{}); !errors.Is(err, ErrNotImplemented) {
+		t.Fatalf("Run: got %v want ErrNotImplemented", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Lays down the Phase 0 deliverable from MEP-40 §10: an empty side-by-side runtime/vm3 + compiler3 stack that compiles clean.
- runtime/vm3: cell (8-byte handle NaN-box with 12 arena tags), arenas (typed slabs), frame (regsI64 / regsF64 / regsCell), vm (Run stub returns ErrNotImplemented until Phase 2), op (opcode enum).
- compiler3: ir (typed SSA), opt (pass stubs: ConstFold / DCE / BranchThread / LICM / TailCall), regalloc (linear-scan per bank stub), emit (Compile stub), corpus (program registry).
- cell_test.go round-trips every tagged value type. Phase 0 gate met: \`go build\` green, \`go test ./runtime/vm3/...\` green.

Tracking: #21678 (Phase 0), #21676 (MEP-40 umbrella).

## Test plan
- [x] \`go build ./runtime/vm3/... ./compiler3/...\` on darwin/arm64.
- [x] \`go test ./runtime/vm3/...\` (cell + vm tests pass).
- [x] \`go vet ./runtime/vm3/... ./compiler3/...\`.