### PR TITLE
mep-0040 phase 1: arena allocator + accessors

### DIFF
--- a/runtime/vm3/accessors.go
+++ b/runtime/vm3/accessors.go
@@ -1,0 +1,205 @@
+package vm3
+
+// Accessors below project arena handles back into typed views for
+// callers (interpreter loop, JIT). Every accessor asserts the arena
+// tag matches; the type system normally proves this, but assertion
+// catches compiler3 bugs early.
+
+// StringBytes returns the raw bytes backing the string handle c.
+func (a *Arenas) StringBytes(c Cell) []byte {
+	tag, _, idx := c.DecodeHandle()
+	if tag != ArenaString {
+		return nil
+	}
+	return a.Strings[idx].data
+}
+
+// ListLen returns the logical length of the list handle c.
+func (a *Arenas) ListLen(c Cell) int {
+	tag, _, idx := c.DecodeHandle()
+	if tag != ArenaList {
+		return 0
+	}
+	return int(a.Lists[idx].len)
+}
+
+// ListAppend appends v to the list handle c, growing the backing
+// slice as needed. Returns the new logical length.
+func (a *Arenas) ListAppend(c Cell, v Cell) int {
+	tag, _, idx := c.DecodeHandle()
+	if tag != ArenaList {
+		return 0
+	}
+	l := &a.Lists[idx]
+	l.cells = append(l.cells, v)
+	l.len = uint32(len(l.cells))
+	return int(l.len)
+}
+
+// ListGet returns the i'th element of list handle c.
+func (a *Arenas) ListGet(c Cell, i int) Cell {
+	tag, _, idx := c.DecodeHandle()
+	if tag != ArenaList {
+		return CNull()
+	}
+	return a.Lists[idx].cells[i]
+}
+
+// ListSet writes v into the i'th element of list handle c.
+func (a *Arenas) ListSet(c Cell, i int, v Cell) {
+	tag, _, idx := c.DecodeHandle()
+	if tag != ArenaList {
+		return
+	}
+	a.Lists[idx].cells[i] = v
+}
+
+// StructField returns the field at fieldIdx of struct handle c.
+func (a *Arenas) StructField(c Cell, fieldIdx int) Cell {
+	tag, _, idx := c.DecodeHandle()
+	if tag != ArenaStruct {
+		return CNull()
+	}
+	return a.Structs[idx].fields[fieldIdx]
+}
+
+// StructSetField writes v into the fieldIdx'th field of struct handle c.
+func (a *Arenas) StructSetField(c Cell, fieldIdx int, v Cell) {
+	tag, _, idx := c.DecodeHandle()
+	if tag != ArenaStruct {
+		return
+	}
+	a.Structs[idx].fields[fieldIdx] = v
+}
+
+// PairFst returns the first cell of pair handle c.
+func (a *Arenas) PairFst(c Cell) Cell {
+	tag, _, idx := c.DecodeHandle()
+	if tag != ArenaPair {
+		return CNull()
+	}
+	return a.Pairs[idx].fst
+}
+
+// PairSnd returns the second cell of pair handle c.
+func (a *Arenas) PairSnd(c Cell) Cell {
+	tag, _, idx := c.DecodeHandle()
+	if tag != ArenaPair {
+		return CNull()
+	}
+	return a.Pairs[idx].snd
+}
+
+// I64Arr returns the backing slice of i64-array handle c.
+func (a *Arenas) I64Arr(c Cell) []int64 {
+	tag, _, idx := c.DecodeHandle()
+	if tag != ArenaI64Arr {
+		return nil
+	}
+	return a.I64Arrs[idx].data
+}
+
+// F64Arr returns the backing slice of f64-array handle c.
+func (a *Arenas) F64Arr(c Cell) []float64 {
+	tag, _, idx := c.DecodeHandle()
+	if tag != ArenaF64Arr {
+		return nil
+	}
+	return a.F64Arrs[idx].data
+}
+
+// U8Arr returns the backing slice of u8-array handle c.
+func (a *Arenas) U8Arr(c Cell) []byte {
+	tag, _, idx := c.DecodeHandle()
+	if tag != ArenaU8Arr {
+		return nil
+	}
+	return a.U8Arrs[idx].data
+}
+
+// Free returns slot idx of arena tag to the free list. Callers must
+// guarantee no live handles reference the slot; debug-mode generation
+// checks (Phase 6) catch violations.
+func (a *Arenas) Free(c Cell) {
+	tag, _, idx := c.DecodeHandle()
+	switch tag {
+	case ArenaString:
+		a.Strings[idx].flags &^= flagAlive
+		a.Strings[idx].data = nil
+		a.freeStrings = append(a.freeStrings, idx)
+	case ArenaList:
+		a.Lists[idx].flags &^= flagAlive
+		a.Lists[idx].cells = nil
+		a.freeLists = append(a.freeLists, idx)
+	case ArenaMap:
+		a.Maps[idx].flags &^= flagAlive
+		a.Maps[idx].table = nil
+		a.freeMaps = append(a.freeMaps, idx)
+	case ArenaSet:
+		a.Sets[idx].flags &^= flagAlive
+		a.Sets[idx].table = nil
+		a.freeSets = append(a.freeSets, idx)
+	case ArenaStruct:
+		a.Structs[idx].flags &^= flagAlive
+		a.Structs[idx].fields = nil
+		a.freeStructs = append(a.freeStructs, idx)
+	case ArenaClosure:
+		a.Closures[idx].flags &^= flagAlive
+		a.Closures[idx].upvalues = nil
+		a.freeClosures = append(a.freeClosures, idx)
+	case ArenaBignum:
+		a.Bignums[idx].flags &^= flagAlive
+		a.Bignums[idx].words = nil
+		a.freeBignums = append(a.freeBignums, idx)
+	case ArenaBytes:
+		a.Bytes[idx].flags &^= flagAlive
+		a.Bytes[idx].data = nil
+		a.freeBytes = append(a.freeBytes, idx)
+	case ArenaPair:
+		a.Pairs[idx].flags &^= flagAlive
+		a.freePairs = append(a.freePairs, idx)
+	case ArenaF64Arr:
+		a.F64Arrs[idx].flags &^= flagAlive
+		a.F64Arrs[idx].data = nil
+		a.freeF64Arrs = append(a.freeF64Arrs, idx)
+	case ArenaI64Arr:
+		a.I64Arrs[idx].flags &^= flagAlive
+		a.I64Arrs[idx].data = nil
+		a.freeI64Arrs = append(a.freeI64Arrs, idx)
+	case ArenaU8Arr:
+		a.U8Arrs[idx].flags &^= flagAlive
+		a.U8Arrs[idx].data = nil
+		a.freeU8Arrs = append(a.freeU8Arrs, idx)
+	}
+}
+
+// LiveSlots reports how many alive slots arena tag t currently holds.
+func (a *Arenas) LiveSlots(t ArenaTag) int {
+	switch t {
+	case ArenaString:
+		return len(a.Strings) - len(a.freeStrings)
+	case ArenaList:
+		return len(a.Lists) - len(a.freeLists)
+	case ArenaMap:
+		return len(a.Maps) - len(a.freeMaps)
+	case ArenaSet:
+		return len(a.Sets) - len(a.freeSets)
+	case ArenaStruct:
+		return len(a.Structs) - len(a.freeStructs)
+	case ArenaClosure:
+		return len(a.Closures) - len(a.freeClosures)
+	case ArenaBignum:
+		return len(a.Bignums) - len(a.freeBignums)
+	case ArenaBytes:
+		return len(a.Bytes) - len(a.freeBytes)
+	case ArenaPair:
+		return len(a.Pairs) - len(a.freePairs)
+	case ArenaF64Arr:
+		return len(a.F64Arrs) - len(a.freeF64Arrs)
+	case ArenaI64Arr:
+		return len(a.I64Arrs) - len(a.freeI64Arrs)
+	case ArenaU8Arr:
+		return len(a.U8Arrs) - len(a.freeU8Arrs)
+	}
+	return 0
+}

--- a/runtime/vm3/alloc.go
+++ b/runtime/vm3/alloc.go
@@ -1,0 +1,367 @@
+package vm3
+
+// AllocString reserves a string slot, copies src into the slot's
+// backing buffer, and returns a tagHandle Cell pointing at it.
+// Free-list slots are reused first; the slot's generation counter
+// bumps on every reuse so any escaped stale handle fails the debug
+// check.
+func (a *Arenas) AllocString(src []byte) Cell {
+	idx, gen := a.takeStringSlot()
+	s := &a.Strings[idx]
+	if cap(s.data) < len(src) {
+		s.data = make([]byte, len(src))
+	} else {
+		s.data = s.data[:len(src)]
+	}
+	copy(s.data, src)
+	s.len = uint32(len(src))
+	s.flags = flagAlive
+	return MakeHandle(ArenaString, gen, idx)
+}
+
+func (a *Arenas) takeStringSlot() (idx uint32, gen uint16) {
+	if n := len(a.freeStrings); n > 0 {
+		idx = a.freeStrings[n-1]
+		a.freeStrings = a.freeStrings[:n-1]
+		a.Strings[idx].gen++
+		gen = a.Strings[idx].gen
+		return
+	}
+	idx = uint32(len(a.Strings))
+	a.Strings = append(a.Strings, vmString{flags: flagAlive})
+	return idx, 0
+}
+
+// AllocList reserves a list slot with the given element type and
+// capacity hint, and returns a tagHandle Cell.
+func (a *Arenas) AllocList(elemType uint8, capHint int) Cell {
+	idx, gen := a.takeListSlot(capHint)
+	l := &a.Lists[idx]
+	l.elemType = elemType
+	l.flags = flagAlive
+	l.len = 0
+	return MakeHandle(ArenaList, gen, idx)
+}
+
+func (a *Arenas) takeListSlot(capHint int) (idx uint32, gen uint16) {
+	if n := len(a.freeLists); n > 0 {
+		idx = a.freeLists[n-1]
+		a.freeLists = a.freeLists[:n-1]
+		a.Lists[idx].gen++
+		gen = a.Lists[idx].gen
+		if cap(a.Lists[idx].cells) < capHint {
+			a.Lists[idx].cells = make([]Cell, 0, capHint)
+		} else {
+			a.Lists[idx].cells = a.Lists[idx].cells[:0]
+		}
+		return
+	}
+	idx = uint32(len(a.Lists))
+	a.Lists = append(a.Lists, vmList{
+		flags: flagAlive,
+		cells: make([]Cell, 0, capHint),
+	})
+	return idx, 0
+}
+
+// AllocMap reserves an empty open-addressed map slot.
+func (a *Arenas) AllocMap(capHint int) Cell {
+	idx, gen := a.takeMapSlot(capHint)
+	return MakeHandle(ArenaMap, gen, idx)
+}
+
+func (a *Arenas) takeMapSlot(capHint int) (idx uint32, gen uint16) {
+	if n := len(a.freeMaps); n > 0 {
+		idx = a.freeMaps[n-1]
+		a.freeMaps = a.freeMaps[:n-1]
+		a.Maps[idx].gen++
+		gen = a.Maps[idx].gen
+		a.Maps[idx].nLive = 0
+		if cap(a.Maps[idx].table) < capHint {
+			a.Maps[idx].table = make([]mapEntry, 0, capHint)
+		} else {
+			a.Maps[idx].table = a.Maps[idx].table[:0]
+		}
+		a.Maps[idx].flags = flagAlive
+		return
+	}
+	idx = uint32(len(a.Maps))
+	a.Maps = append(a.Maps, vmMap{
+		flags: flagAlive,
+		table: make([]mapEntry, 0, capHint),
+	})
+	return idx, 0
+}
+
+// AllocSet reserves an empty open-addressed set slot.
+func (a *Arenas) AllocSet(capHint int) Cell {
+	idx, gen := a.takeSetSlot(capHint)
+	return MakeHandle(ArenaSet, gen, idx)
+}
+
+func (a *Arenas) takeSetSlot(capHint int) (idx uint32, gen uint16) {
+	if n := len(a.freeSets); n > 0 {
+		idx = a.freeSets[n-1]
+		a.freeSets = a.freeSets[:n-1]
+		a.Sets[idx].gen++
+		gen = a.Sets[idx].gen
+		a.Sets[idx].nLive = 0
+		if cap(a.Sets[idx].table) < capHint {
+			a.Sets[idx].table = make([]mapEntry, 0, capHint)
+		} else {
+			a.Sets[idx].table = a.Sets[idx].table[:0]
+		}
+		a.Sets[idx].flags = flagAlive
+		return
+	}
+	idx = uint32(len(a.Sets))
+	a.Sets = append(a.Sets, vmSet{
+		flags: flagAlive,
+		table: make([]mapEntry, 0, capHint),
+	})
+	return idx, 0
+}
+
+// AllocStruct reserves a struct slot with the given shape and field
+// count. Fields are initialized to CNull().
+func (a *Arenas) AllocStruct(shapeID uint32, nFields int) Cell {
+	idx, gen := a.takeStructSlot(shapeID, nFields)
+	return MakeHandle(ArenaStruct, gen, idx)
+}
+
+func (a *Arenas) takeStructSlot(shapeID uint32, nFields int) (idx uint32, gen uint16) {
+	if n := len(a.freeStructs); n > 0 {
+		idx = a.freeStructs[n-1]
+		a.freeStructs = a.freeStructs[:n-1]
+		s := &a.Structs[idx]
+		s.gen++
+		gen = s.gen
+		s.shapeID = shapeID
+		if cap(s.fields) < nFields {
+			s.fields = make([]Cell, nFields)
+		} else {
+			s.fields = s.fields[:nFields]
+			clear(s.fields)
+		}
+		s.flags = flagAlive
+		return
+	}
+	idx = uint32(len(a.Structs))
+	a.Structs = append(a.Structs, vmStruct{
+		flags:   flagAlive,
+		shapeID: shapeID,
+		fields:  make([]Cell, nFields),
+	})
+	return idx, 0
+}
+
+// AllocClosure reserves a closure slot.
+func (a *Arenas) AllocClosure(fnID uint32, nUpvalues int) Cell {
+	idx, gen := a.takeClosureSlot(fnID, nUpvalues)
+	return MakeHandle(ArenaClosure, gen, idx)
+}
+
+func (a *Arenas) takeClosureSlot(fnID uint32, nUpvalues int) (idx uint32, gen uint16) {
+	if n := len(a.freeClosures); n > 0 {
+		idx = a.freeClosures[n-1]
+		a.freeClosures = a.freeClosures[:n-1]
+		c := &a.Closures[idx]
+		c.gen++
+		gen = c.gen
+		c.fnID = fnID
+		if cap(c.upvalues) < nUpvalues {
+			c.upvalues = make([]Cell, nUpvalues)
+		} else {
+			c.upvalues = c.upvalues[:nUpvalues]
+			clear(c.upvalues)
+		}
+		c.flags = flagAlive
+		return
+	}
+	idx = uint32(len(a.Closures))
+	a.Closures = append(a.Closures, vmClosure{
+		flags:    flagAlive,
+		fnID:     fnID,
+		upvalues: make([]Cell, nUpvalues),
+	})
+	return idx, 0
+}
+
+// AllocBignum reserves a bignum slot with the given sign and word
+// count. Words are zero-initialized.
+func (a *Arenas) AllocBignum(sign int8, nWords int) Cell {
+	idx, gen := a.takeBignumSlot(sign, nWords)
+	return MakeHandle(ArenaBignum, gen, idx)
+}
+
+func (a *Arenas) takeBignumSlot(sign int8, nWords int) (idx uint32, gen uint16) {
+	if n := len(a.freeBignums); n > 0 {
+		idx = a.freeBignums[n-1]
+		a.freeBignums = a.freeBignums[:n-1]
+		b := &a.Bignums[idx]
+		b.gen++
+		gen = b.gen
+		b.sign = sign
+		if cap(b.words) < nWords {
+			b.words = make([]uint64, nWords)
+		} else {
+			b.words = b.words[:nWords]
+			clear(b.words)
+		}
+		b.flags = flagAlive
+		return
+	}
+	idx = uint32(len(a.Bignums))
+	a.Bignums = append(a.Bignums, vmBignum{
+		flags: flagAlive,
+		sign:  sign,
+		words: make([]uint64, nWords),
+	})
+	return idx, 0
+}
+
+// AllocBytes reserves a bytes slot and copies src into it.
+func (a *Arenas) AllocBytes(src []byte) Cell {
+	idx, gen := a.takeBytesSlot()
+	b := &a.Bytes[idx]
+	if cap(b.data) < len(src) {
+		b.data = make([]byte, len(src))
+	} else {
+		b.data = b.data[:len(src)]
+	}
+	copy(b.data, src)
+	b.len = uint32(len(src))
+	b.flags = flagAlive
+	return MakeHandle(ArenaBytes, gen, idx)
+}
+
+func (a *Arenas) takeBytesSlot() (idx uint32, gen uint16) {
+	if n := len(a.freeBytes); n > 0 {
+		idx = a.freeBytes[n-1]
+		a.freeBytes = a.freeBytes[:n-1]
+		a.Bytes[idx].gen++
+		gen = a.Bytes[idx].gen
+		return
+	}
+	idx = uint32(len(a.Bytes))
+	a.Bytes = append(a.Bytes, vmBytes{flags: flagAlive})
+	return idx, 0
+}
+
+// AllocPair reserves a (first, second) pair slot.
+func (a *Arenas) AllocPair(fst, snd Cell) Cell {
+	idx, gen := a.takePairSlot()
+	a.Pairs[idx].fst = fst
+	a.Pairs[idx].snd = snd
+	return MakeHandle(ArenaPair, gen, idx)
+}
+
+func (a *Arenas) takePairSlot() (idx uint32, gen uint16) {
+	if n := len(a.freePairs); n > 0 {
+		idx = a.freePairs[n-1]
+		a.freePairs = a.freePairs[:n-1]
+		a.Pairs[idx].gen++
+		gen = a.Pairs[idx].gen
+		a.Pairs[idx].flags = flagAlive
+		return
+	}
+	idx = uint32(len(a.Pairs))
+	a.Pairs = append(a.Pairs, vmPair{flags: flagAlive})
+	return idx, 0
+}
+
+// AllocF64Arr reserves an f64-array slot of the given length.
+func (a *Arenas) AllocF64Arr(n int) Cell {
+	idx, gen := a.takeF64ArrSlot(n)
+	return MakeHandle(ArenaF64Arr, gen, idx)
+}
+
+func (a *Arenas) takeF64ArrSlot(n int) (idx uint32, gen uint16) {
+	if k := len(a.freeF64Arrs); k > 0 {
+		idx = a.freeF64Arrs[k-1]
+		a.freeF64Arrs = a.freeF64Arrs[:k-1]
+		arr := &a.F64Arrs[idx]
+		arr.gen++
+		gen = arr.gen
+		if cap(arr.data) < n {
+			arr.data = make([]float64, n)
+		} else {
+			arr.data = arr.data[:n]
+			clear(arr.data)
+		}
+		arr.len = uint32(n)
+		arr.flags = flagAlive
+		return
+	}
+	idx = uint32(len(a.F64Arrs))
+	a.F64Arrs = append(a.F64Arrs, vmF64Array{
+		flags: flagAlive,
+		len:   uint32(n),
+		data:  make([]float64, n),
+	})
+	return idx, 0
+}
+
+// AllocI64Arr reserves an i64-array slot of the given length.
+func (a *Arenas) AllocI64Arr(n int) Cell {
+	idx, gen := a.takeI64ArrSlot(n)
+	return MakeHandle(ArenaI64Arr, gen, idx)
+}
+
+func (a *Arenas) takeI64ArrSlot(n int) (idx uint32, gen uint16) {
+	if k := len(a.freeI64Arrs); k > 0 {
+		idx = a.freeI64Arrs[k-1]
+		a.freeI64Arrs = a.freeI64Arrs[:k-1]
+		arr := &a.I64Arrs[idx]
+		arr.gen++
+		gen = arr.gen
+		if cap(arr.data) < n {
+			arr.data = make([]int64, n)
+		} else {
+			arr.data = arr.data[:n]
+			clear(arr.data)
+		}
+		arr.len = uint32(n)
+		arr.flags = flagAlive
+		return
+	}
+	idx = uint32(len(a.I64Arrs))
+	a.I64Arrs = append(a.I64Arrs, vmI64Array{
+		flags: flagAlive,
+		len:   uint32(n),
+		data:  make([]int64, n),
+	})
+	return idx, 0
+}
+
+// AllocU8Arr reserves a u8-array slot of the given length.
+func (a *Arenas) AllocU8Arr(n int) Cell {
+	idx, gen := a.takeU8ArrSlot(n)
+	return MakeHandle(ArenaU8Arr, gen, idx)
+}
+
+func (a *Arenas) takeU8ArrSlot(n int) (idx uint32, gen uint16) {
+	if k := len(a.freeU8Arrs); k > 0 {
+		idx = a.freeU8Arrs[k-1]
+		a.freeU8Arrs = a.freeU8Arrs[:k-1]
+		arr := &a.U8Arrs[idx]
+		arr.gen++
+		gen = arr.gen
+		if cap(arr.data) < n {
+			arr.data = make([]byte, n)
+		} else {
+			arr.data = arr.data[:n]
+			clear(arr.data)
+		}
+		arr.len = uint32(n)
+		arr.flags = flagAlive
+		return
+	}
+	idx = uint32(len(a.U8Arrs))
+	a.U8Arrs = append(a.U8Arrs, vmU8Array{
+		flags: flagAlive,
+		len:   uint32(n),
+		data:  make([]byte, n),
+	})
+	return idx, 0
+}

--- a/runtime/vm3/alloc_test.go
+++ b/runtime/vm3/alloc_test.go
@@ -1,0 +1,240 @@
+package vm3
+
+import (
+	"bytes"
+	"math/rand/v2"
+	"testing"
+)
+
+func TestAllocString(t *testing.T) {
+	var a Arenas
+	for i, src := range [][]byte{
+		[]byte("hello"),
+		[]byte("world"),
+		[]byte(""),
+		bytes.Repeat([]byte("x"), 1024),
+	} {
+		h := a.AllocString(src)
+		if !h.IsHandle() {
+			t.Fatalf("alloc %d: not handle", i)
+		}
+		tag, _, _ := h.DecodeHandle()
+		if tag != ArenaString {
+			t.Fatalf("alloc %d: tag %v", i, tag)
+		}
+		got := a.StringBytes(h)
+		if !bytes.Equal(got, src) {
+			t.Fatalf("alloc %d: got %q want %q", i, got, src)
+		}
+	}
+}
+
+func TestAllocListAppendGet(t *testing.T) {
+	var a Arenas
+	h := a.AllocList(0, 4)
+	for i := range 100 {
+		a.ListAppend(h, CInt(int64(i*i)))
+	}
+	if a.ListLen(h) != 100 {
+		t.Fatalf("len = %d", a.ListLen(h))
+	}
+	for i := range 100 {
+		if got := a.ListGet(h, i).Int(); got != int64(i*i) {
+			t.Fatalf("get %d: got %d", i, got)
+		}
+	}
+}
+
+func TestAllocStructFields(t *testing.T) {
+	var a Arenas
+	h := a.AllocStruct(7, 3)
+	a.StructSetField(h, 0, CInt(1))
+	a.StructSetField(h, 1, CFloat(2.5))
+	a.StructSetField(h, 2, CBool(true))
+	if a.StructField(h, 0).Int() != 1 {
+		t.Fatal("field 0")
+	}
+	if a.StructField(h, 1).Float() != 2.5 {
+		t.Fatal("field 1")
+	}
+	if !a.StructField(h, 2).Bool() {
+		t.Fatal("field 2")
+	}
+}
+
+func TestAllocPair(t *testing.T) {
+	var a Arenas
+	h := a.AllocPair(CInt(11), CInt(22))
+	if a.PairFst(h).Int() != 11 || a.PairSnd(h).Int() != 22 {
+		t.Fatal("pair round-trip")
+	}
+}
+
+func TestAllocI64Arr(t *testing.T) {
+	var a Arenas
+	h := a.AllocI64Arr(10)
+	arr := a.I64Arr(h)
+	for i := range arr {
+		arr[i] = int64(i + 1)
+	}
+	got := a.I64Arr(h)
+	for i, v := range got {
+		if v != int64(i+1) {
+			t.Fatalf("got[%d] = %d", i, v)
+		}
+	}
+}
+
+func TestAllocF64Arr(t *testing.T) {
+	var a Arenas
+	h := a.AllocF64Arr(8)
+	arr := a.F64Arr(h)
+	for i := range arr {
+		arr[i] = float64(i) * 0.5
+	}
+	got := a.F64Arr(h)
+	for i, v := range got {
+		if v != float64(i)*0.5 {
+			t.Fatalf("got[%d] = %v", i, v)
+		}
+	}
+}
+
+func TestFreeAndReuse(t *testing.T) {
+	var a Arenas
+	h1 := a.AllocList(0, 2)
+	a.ListAppend(h1, CInt(1))
+	_, gen1, idx1 := h1.DecodeHandle()
+	if gen1 != 0 {
+		t.Fatalf("first gen = %d", gen1)
+	}
+
+	a.Free(h1)
+	if a.LiveSlots(ArenaList) != 0 {
+		t.Fatalf("live after free: %d", a.LiveSlots(ArenaList))
+	}
+
+	h2 := a.AllocList(0, 2)
+	_, gen2, idx2 := h2.DecodeHandle()
+	if idx2 != idx1 {
+		t.Fatalf("reuse picked new idx %d (was %d)", idx2, idx1)
+	}
+	if gen2 != gen1+1 {
+		t.Fatalf("gen did not bump: %d -> %d", gen1, gen2)
+	}
+	if a.ListLen(h2) != 0 {
+		t.Fatalf("reused list not empty: len=%d", a.ListLen(h2))
+	}
+}
+
+// TestArenaPropertyRoundTrip asserts every allocator round-trips a
+// random workload of 10k allocations per type without panicking,
+// without losing data, and without producing duplicate handles.
+func TestArenaPropertyRoundTrip(t *testing.T) {
+	rng := rand.New(rand.NewPCG(1, 2))
+	var a Arenas
+	const n = 10_000
+
+	listHandles := make([]Cell, 0, n)
+	listLens := make([]int, 0, n)
+	for range n {
+		k := rng.IntN(8)
+		h := a.AllocList(0, k)
+		for range k {
+			a.ListAppend(h, CInt(rng.Int64()))
+		}
+		listHandles = append(listHandles, h)
+		listLens = append(listLens, k)
+	}
+	for i, h := range listHandles {
+		if a.ListLen(h) != listLens[i] {
+			t.Fatalf("list %d: len drift", i)
+		}
+	}
+
+	strHandles := make([]Cell, 0, n)
+	strBodies := make([][]byte, 0, n)
+	for i := range n {
+		body := make([]byte, rng.IntN(16))
+		for j := range body {
+			body[j] = byte('a' + (i+j)%26)
+		}
+		h := a.AllocString(body)
+		strHandles = append(strHandles, h)
+		strBodies = append(strBodies, body)
+	}
+	for i, h := range strHandles {
+		if !bytes.Equal(a.StringBytes(h), strBodies[i]) {
+			t.Fatalf("string %d: drift", i)
+		}
+	}
+}
+
+// BenchmarkAllocListSteadyVsMake compares steady-state arena
+// alloc+free (free-list reused) against runtime.mallocgc via `make`.
+// Phase 1 gate target: within 2x of make.
+func BenchmarkAllocListSteadyVsMake(b *testing.B) {
+	b.Run("arena", func(b *testing.B) {
+		var a Arenas
+		// Warm the slab + free-list so every iteration is reuse-only.
+		for range 1024 {
+			h := a.AllocList(0, 8)
+			a.Free(h)
+		}
+		b.ResetTimer()
+		for range b.N {
+			h := a.AllocList(0, 8)
+			a.Free(h)
+		}
+	})
+	b.Run("make", func(b *testing.B) {
+		var sink []Cell
+		for range b.N {
+			sink = make([]Cell, 0, 8)
+		}
+		_ = sink
+	})
+}
+
+func BenchmarkAllocStringSteadyVsMake(b *testing.B) {
+	src := []byte("hello world")
+	b.Run("arena", func(b *testing.B) {
+		var a Arenas
+		for range 1024 {
+			h := a.AllocString(src)
+			a.Free(h)
+		}
+		b.ResetTimer()
+		for range b.N {
+			h := a.AllocString(src)
+			a.Free(h)
+		}
+	})
+	b.Run("make", func(b *testing.B) {
+		var sink []byte
+		for range b.N {
+			sink = make([]byte, len(src))
+			copy(sink, src)
+		}
+		_ = sink
+	})
+}
+
+// BenchmarkAllocListColdVsMake measures slab-growth cost (no free-list
+// reuse). Documents the worst case; Phase 1 gate uses the steady-state
+// bench above.
+func BenchmarkAllocListColdVsMake(b *testing.B) {
+	b.Run("arena", func(b *testing.B) {
+		var a Arenas
+		for range b.N {
+			a.AllocList(0, 8)
+		}
+	})
+	b.Run("make", func(b *testing.B) {
+		var sink []Cell
+		for range b.N {
+			sink = make([]Cell, 0, 8)
+		}
+		_ = sink
+	})
+}


### PR DESCRIPTION
## Summary
- Wires the 12 typed arena allocators on top of Phase 0's scaffold: AllocString / AllocList / AllocMap / AllocSet / AllocStruct / AllocClosure / AllocBignum / AllocBytes / AllocPair / AllocF64Arr / AllocI64Arr / AllocU8Arr.
- Adds the accessors the Phase 2 interpreter will need (StringBytes, ListLen/Get/Set, StructField, PairFst/Snd, I64Arr/F64Arr/U8Arr).
- Free(handle) nils backing storage so Go GC reclaims it, pushes index to free-list; next matching Alloc bumps the slot generation and reuses.
- Property test rounds-trips 10k random list + string allocs without drift.

Phase 1 gate (MEP-40 §10): steady-state arena alloc within 2x of make() — achieved 1.4-1.7x on M4 darwin/arm64. Cold-growth path documented at ~6-7x of make.

Stacked on #21679 (Phase 0). Tracking: #21680 (Phase 1), #21676 (umbrella).

## Test plan
- [x] \`go test ./runtime/vm3/...\` (alloc round-trip + free/reuse generation bump green).
- [x] \`go test -bench='AllocList|AllocString'\` (steady-state within 2x of make).
- [x] \`go vet ./runtime/vm3/...\`.