### PR TITLE
mep-0040 phase 3.1: string opcodes + mixed-bank call ABI

### DIFF
--- a/compiler3/corpus/corpus.go
+++ b/compiler3/corpus/corpus.go
@@ -22,5 +22,6 @@ func All() []*Program {
 		FactRec,
 		FibRec,
 		PrimeCount,
+		StringsConcatLoop,
 	}
 }

--- a/compiler3/corpus/corpus_test.go
+++ b/compiler3/corpus/corpus_test.go
@@ -23,6 +23,7 @@ func TestMathKernelsMatchVm2(t *testing.T) {
 		{"fact_rec", FactRec, []int64{0, 1, 2, 3, 5, 10, 13}, c2corpus.ExpectFactRec},
 		{"fib_rec", FibRec, []int64{0, 1, 2, 5, 10, 15, 20}, c2corpus.ExpectFibRec},
 		{"prime_count", PrimeCount, []int64{0, 2, 10, 50, 100}, c2corpus.ExpectPrimeCount},
+		{"strings_concat_loop", StringsConcatLoop, []int64{0, 1, 2, 5, 10, 50}, c2corpus.ExpectStringsConcatLoop},
 	}
 	for _, tc := range cases {
 		for _, n := range tc.ns {
@@ -55,6 +56,7 @@ func BenchmarkMathKernels(b *testing.B) {
 		{"fact_rec_n12", FactRec, 12},
 		{"fib_rec_n25", FibRec, 25},
 		{"prime_count_n100", PrimeCount, 100},
+		{"strings_concat_loop_n64", StringsConcatLoop, 64},
 	}
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {
@@ -94,6 +96,7 @@ func BenchmarkGoKernels(b *testing.B) {
 		{"fact_rec_n12", c2corpus.ExpectFactRec, 12},
 		{"fib_rec_n25", c2corpus.ExpectFibRec, 25},
 		{"prime_count_n100", c2corpus.ExpectPrimeCount, 100},
+		{"strings_concat_loop_n64", c2corpus.ExpectStringsConcatLoop, 64},
 	}
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {

--- a/compiler3/corpus/strings_concat_loop.go
+++ b/compiler3/corpus/strings_concat_loop.go
@@ -1,0 +1,87 @@
+package corpus
+
+import "mochi/runtime/vm3"
+
+// StringsConcatLoop: concatenate "a" n times via tail-recursive helper.
+//
+//	fun main(n) {
+//	  return concat_loop("a", "a", 0, n)
+//	}
+//	fun concat_loop(acc, lit, i, n) {
+//	  if i >= n return len(acc)
+//	  return concat_loop(acc ++ lit, lit, i+1, n)
+//	}
+//
+// The helper takes 2 Cell + 2 I64 params, so it exercises the mixed-bank
+// call protocol added in Phase 3.1. The caller arranges per-bank args at
+// regs<bank>[op.B + k] where k is the param position; positions in banks
+// that don't match the param's bank are unused.
+//
+// Function 0 ("main"): single I64 param n at regsI64[0].
+//
+//	NumRegsI64 = 6, NumRegsCell = 4.
+//	regsI64[0]   = n (input, also reused for result)
+//	regsCell[2]  = "a" (acc, param 0 at arg-base 2)
+//	regsCell[3]  = "a" (lit, param 1)
+//	regsI64[4]   = 0   (i, param 2)
+//	regsI64[5]   = n   (param 3, copied from regsI64[0])
+//
+//	0  OpConstStrKW   A=2 C=0           ; acc = "a"
+//	1  OpConstStrKW   A=3 C=0           ; lit = "a"
+//	2  OpConstI64K    A=4 C=0           ; i = 0
+//	3  OpMovI64       A=5 B=0           ; n copy
+//	4  OpCallMixed    A=0 B=2 C=1 BF=I64; regsI64[0] = concat_loop(...)
+//	5  OpReturnI64    A=0
+//
+// Function 1 ("concat_loop"): ParamBanks=[Cell, Cell, I64, I64].
+//
+//	NumRegsI64 = 4, NumRegsCell = 2.
+//	regsCell[0] = acc, regsCell[1] = lit (params 0,1)
+//	regsI64[2]  = i,   regsI64[3]  = n   (params 2,3)
+//	regsI64[0]  = result scratch
+//
+//	0  OpCmpGeI64Br   A=2 B=3 C=4       ; if i >= n jump to 4 (done)
+//	1  OpAddI64K      A=2 B=2 C=1       ; i = i + 1
+//	2  OpConcatStr    A=0 B=0 C=1       ; acc = acc ++ lit
+//	3  OpTailCallMixed A=0 B=0 C=1      ; tail call self
+//	4  OpLenStr       A=0 B=0           ; result = len(acc)
+//	5  OpReturnI64    A=0
+var StringsConcatLoop = &Program{
+	Name: "strings_concat_loop",
+	Build: func(_ int64) *vm3.Program {
+		// Inline "a" as a short-string Cell (CSStr, fits in 5-byte slot).
+		strA := vm3.CSStr([]byte{'a'})
+		main := &vm3.Function{
+			Name:        "main",
+			NumRegsI64:  6,
+			NumRegsCell: 4,
+			ParamBanks:  []vm3.Bank{vm3.BankI64},
+			ResultBank:  vm3.BankI64,
+			Consts:      []vm3.Cell{strA},
+			Code: []vm3.Op{
+				vm3.MakeOp(vm3.OpConstStrKW, 2, 0, 0),
+				vm3.MakeOp(vm3.OpConstStrKW, 3, 0, 0),
+				vm3.MakeOp(vm3.OpConstI64K, 4, 0, 0),
+				vm3.MakeOp(vm3.OpMovI64, 5, 0, 0),
+				{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 2, C: 1},
+				vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),
+			},
+		}
+		helper := &vm3.Function{
+			Name:        "concat_loop",
+			NumRegsI64:  4,
+			NumRegsCell: 2,
+			ParamBanks:  []vm3.Bank{vm3.BankCell, vm3.BankCell, vm3.BankI64, vm3.BankI64},
+			ResultBank:  vm3.BankI64,
+			Code: []vm3.Op{
+				vm3.MakeOp(vm3.OpCmpGeI64Br, 2, 3, 4),
+				vm3.MakeOp(vm3.OpAddI64K, 2, 2, 1),
+				vm3.MakeOp(vm3.OpConcatStr, 0, 0, 1),
+				vm3.MakeOp(vm3.OpTailCallMixed, 0, 0, 1),
+				vm3.MakeOp(vm3.OpLenStr, 0, 0, 0),
+				vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),
+			},
+		}
+		return &vm3.Program{Funcs: []*vm3.Function{main, helper}, Entry: 0}
+	},
+}

--- a/runtime/vm3/alloc.go
+++ b/runtime/vm3/alloc.go
@@ -32,6 +32,24 @@ func (a *Arenas) takeStringSlot() (idx uint32, gen uint16) {
 	return idx, 0
 }
 
+// AllocStringConcat reserves a string slot whose contents are left++right.
+// Saves the intermediate []byte allocation that AllocString would need.
+func (a *Arenas) AllocStringConcat(left, right []byte) Cell {
+	idx, gen := a.takeStringSlot()
+	s := &a.Strings[idx]
+	nlen := len(left) + len(right)
+	if cap(s.data) < nlen {
+		s.data = make([]byte, nlen)
+	} else {
+		s.data = s.data[:nlen]
+	}
+	copy(s.data, left)
+	copy(s.data[len(left):], right)
+	s.len = uint32(nlen)
+	s.flags = flagAlive
+	return MakeHandle(ArenaString, gen, idx)
+}
+
 // AllocList reserves a list slot with the given element type and
 // capacity hint, and returns a tagHandle Cell.
 func (a *Arenas) AllocList(elemType uint8, capHint int) Cell {

--- a/runtime/vm3/op.go
+++ b/runtime/vm3/op.go
@@ -78,7 +78,24 @@ const (
 	// JIT uses this to bail back to the interpreter at exact PC.
 	OpDeopt
 
-	// Phase 3 (placeholder; bodies arrive when Phase 3 lands).
+	// Strings (Phase 3.1).
+	OpConstStrKW // regsCell[A] = Function.Consts[uint16(C)] (a Cell-tagged string)
+	OpLenStr     // regsI64[A] = len(string at regsCell[B])
+	OpConcatStr  // regsCell[A] = regsCell[B] ++ regsCell[uint16(C)]
+
+	// Mixed-bank calls (Phase 3.1). Args live at regs<bank>[B + k] in
+	// the caller for each param k whose bank is given by callee
+	// ParamBanks[k]. Callee receives them at regs<bank>[k]. Slots in
+	// banks other than ParamBanks[k] at position B+k are unused. A
+	// names the caller's return slot in retBank (BankFlags low 2 bits).
+	// C carries callee Function index.
+	OpCallMixed
+	// OpTailCallMixed: like OpCallMixed but reuses the current frame.
+	// No retReg / retBank fields are read; the existing frame's retReg
+	// and retBank are preserved.
+	OpTailCallMixed
+
+	// Phase 3.2+ placeholders. Bodies land in their own sub-phases.
 	OpListGetI64
 	OpListGetF64
 	OpListGetCell

--- a/runtime/vm3/vm.go
+++ b/runtime/vm3/vm.go
@@ -129,6 +129,7 @@ func (vm *VM) run() (Cell, error) {
 	regsF64 := vm.stackF64[fr.baseF64 : fr.baseF64+int(fn.NumRegsF64)]
 	regsCell := vm.stackCell[fr.baseCell : fr.baseCell+int(fn.NumRegsCell)]
 	consts := fn.Consts
+	arenas := &vm.arenas
 
 	for {
 		op := code[pc]
@@ -494,6 +495,138 @@ func (vm *VM) run() (Cell, error) {
 		case OpDeopt:
 			fr.pc = pc
 			return EncodeDeopt(int(uint16(op.C))), nil
+
+		case OpConstStrKW:
+			regsCell[op.A] = consts[uint16(op.C)]
+			pc++
+		case OpLenStr:
+			c := regsCell[op.B]
+			if c.IsSStr() {
+				regsI64[op.A] = int64(c.SStrLen())
+			} else {
+				regsI64[op.A] = int64(len(arenas.StringBytes(c)))
+			}
+			pc++
+		case OpConcatStr:
+			lhs := regsCell[op.B]
+			rhs := regsCell[uint16(op.C)]
+			var lbuf, rbuf [MaxInlineStr]byte
+			var lb, rb []byte
+			if lhs.IsSStr() {
+				lb = lhs.SStrBytes(&lbuf)
+			} else {
+				lb = arenas.StringBytes(lhs)
+			}
+			if rhs.IsSStr() {
+				rb = rhs.SStrBytes(&rbuf)
+			} else {
+				rb = arenas.StringBytes(rhs)
+			}
+			nlen := len(lb) + len(rb)
+			if nlen <= MaxInlineStr {
+				var merged [MaxInlineStr]byte
+				copy(merged[:], lb)
+				copy(merged[len(lb):], rb)
+				regsCell[op.A] = CSStr(merged[:nlen])
+			} else {
+				regsCell[op.A] = arenas.AllocStringConcat(lb, rb)
+			}
+			pc++
+
+		case OpCallMixed:
+			callee := vm.prog.Funcs[uint16(op.C)]
+			pbs := callee.ParamBanks
+			// Snapshot args before pushFrame (which may regrow slabs).
+			var argI64 [8]int64
+			var argF64 [8]float64
+			var argCell [8]Cell
+			argBase := op.B
+			for k, b := range pbs {
+				idx := argBase + uint16(k)
+				switch b {
+				case BankI64:
+					argI64[k] = regsI64[idx]
+				case BankF64:
+					argF64[k] = regsF64[idx]
+				case BankCell:
+					argCell[k] = regsCell[idx]
+				}
+			}
+			fr.pc = pc + 1
+			retBank := Bank(op.BankFlags & 0x3)
+			vm.pushFrame(callee, op.A, retBank)
+			top++
+			fr = &vm.frames[top]
+			fn = callee
+			code = fn.Code
+			pc = 0
+			regsI64 = vm.stackI64[fr.baseI64 : fr.baseI64+int(fn.NumRegsI64)]
+			regsF64 = vm.stackF64[fr.baseF64 : fr.baseF64+int(fn.NumRegsF64)]
+			regsCell = vm.stackCell[fr.baseCell : fr.baseCell+int(fn.NumRegsCell)]
+			consts = fn.Consts
+			for k, b := range pbs {
+				switch b {
+				case BankI64:
+					regsI64[k] = argI64[k]
+				case BankF64:
+					regsF64[k] = argF64[k]
+				case BankCell:
+					regsCell[k] = argCell[k]
+				}
+			}
+
+		case OpTailCallMixed:
+			callee := vm.prog.Funcs[uint16(op.C)]
+			// Self-tail-call with arg-base 0: args already live in the
+			// canonical regs<bank>[k] positions matching ParamBanks[k].
+			// No copies / clears needed; just rewind PC.
+			if callee == fn && op.B == 0 {
+				pc = 0
+				continue
+			}
+			pbs := callee.ParamBanks
+			var argI64 [8]int64
+			var argF64 [8]float64
+			var argCell [8]Cell
+			argBase := op.B
+			for k, b := range pbs {
+				idx := argBase + uint16(k)
+				switch b {
+				case BankI64:
+					argI64[k] = regsI64[idx]
+				case BankF64:
+					argF64[k] = regsF64[idx]
+				case BankCell:
+					argCell[k] = regsCell[idx]
+				}
+			}
+			fr.fn = callee
+			fn = callee
+			code = fn.Code
+			pc = 0
+			endI := fr.baseI64 + int(callee.NumRegsI64)
+			vm.stackI64 = growI64(vm.stackI64, endI)
+			regsI64 = vm.stackI64[fr.baseI64:endI]
+			clear(regsI64)
+			endF := fr.baseF64 + int(callee.NumRegsF64)
+			vm.stackF64 = growF64(vm.stackF64, endF)
+			regsF64 = vm.stackF64[fr.baseF64:endF]
+			clear(regsF64)
+			endC := fr.baseCell + int(callee.NumRegsCell)
+			vm.stackCell = growCell(vm.stackCell, endC)
+			regsCell = vm.stackCell[fr.baseCell:endC]
+			clear(regsCell)
+			consts = fn.Consts
+			for k, b := range pbs {
+				switch b {
+				case BankI64:
+					regsI64[k] = argI64[k]
+				case BankF64:
+					regsF64[k] = argF64[k]
+				case BankCell:
+					regsCell[k] = argCell[k]
+				}
+			}
 
 		default:
 			fr.pc = pc

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -709,7 +709,9 @@ The Phase 2 corpus does not yet exercise the Cell bank in production. Cell-handl
 
 ### Phase 3: Full opcode coverage (weeks 7-9)
 
-**Deliverables**:
+Phase 3 lands in sub-phases. Each sub-phase ports one Cell-bank subsystem (strings, lists, maps, structs, etc.) and the corresponding corpus kernel. The shared infrastructure (mixed-bank call ABI) lands in 3.1.
+
+**Deliverables (whole phase)**:
 - vm3 opcodes for: list / map / set / struct / closure / string / bytes / bignum / typed-array.
 - compiler3 lowering for all corpus programs.
 - Port: lists_fill_sum, maps_fill_sum, strings_concat_loop, all BG programs.
@@ -718,6 +720,25 @@ The Phase 2 corpus does not yet exercise the Cell bank in production. Cell-handl
 **Gate**: every program in `runtime/vm2/bench/corpus_test.go` runs correctly on vm3 and produces identical output to vm2. Bench shows vm3 within 15% of vm2 on the full corpus (cell-bank only, no typed banks yet).
 
 **Exit**: vm3 is feature-complete and correct.
+
+#### Phase 3.1: Strings + mixed-bank call ABI — **LANDED**
+
+**Deliverables** (shipped):
+- Three string opcodes in `runtime/vm3/op.go`: `OpConstStrKW` (load string Cell from `Function.Consts`), `OpLenStr` (length, dispatches between inline `CSStr` and arena handle), `OpConcatStr` (concatenate two string Cells; inline-fits results stay in `CSStr`, else allocate a fresh arena slot).
+- Two mixed-bank call opcodes: `OpCallMixed` and `OpTailCallMixed`. Both encode a single common arg base `op.B`: for each param `k` with bank `B`, the caller arranges the arg at `regs<B>[op.B + k]` and the callee receives it at `regs<B>[k]`. Slots in banks other than `ParamBanks[k]` at position `op.B + k` are unused. `OpCallMixed` carries the return bank in the op's `BankFlags` byte (low 2 bits). `OpTailCallMixed` has a self-tail-call fast path that no-ops the arg copy when `callee == fn && op.B == 0` (the canonical layout, common for self-recursive loops).
+- `Arenas.AllocStringConcat(left, right)` (`runtime/vm3/alloc.go`): reserves a string slot and writes `left ++ right` directly into the backing buffer, saving the intermediate slice allocation that `AllocString(make(merged))` would do.
+- `compiler3/corpus/strings_concat_loop.go`: tail-recursive helper that exercises every Phase 3.1 op. Validated bit-identical to `c2corpus.ExpectStringsConcatLoop` on N ∈ {0, 1, 2, 5, 10, 50}.
+
+**Measured (Apple M4, darwin/arm64)**: `strings_concat_loop_n64`.
+
+| VM        | ns/op | B/op   | allocs/op | vs vm2 |
+| --------- | ----: | -----: | --------: | -----: |
+| vm3       | 4 293 | 12 910 |        60 |  1.87x |
+| vm2       | 2 421 |  6 176 |       123 |  1.00x |
+
+vm3 is 1.87x slower than vm2 on this kernel: the inner loop pays one fresh arena slot per `OpConcatStr` (no slot reuse without Phase 6 GC), and each new slot's backing `[]byte` is `make`'d from scratch since slots aren't pooled. Note vm3 already cuts the allocation *count* in half (60 vs 123) by skipping the intermediate `merged` slice; the remaining gap is byte volume, dominated by re-`make`'d backing buffers as the string grows. Phase 6 (mark-sweep over arenas) will retire freed slots back to the free list; combined with capacity-doubling growth that closes the gap. The string opcodes themselves are correct.
+
+**Mixed-bank call ABI rationale**: An alternative was per-bank arg bases (caller emits `OpSetArgBank` ops then `OpCall`). That requires more dispatches per call. The chosen "single common base" encoding fits in one Op with no setup ops, at the cost of sparse slot use in banks that don't match a param's bank. For the strings kernel this wastes 2 Cell slots and 2 I64 slots per concat_loop frame, a negligible footprint.
 
 ### Phase 4: Typed register banks (weeks 10-12)
 


### PR DESCRIPTION
Phase 3.1 of MEP-40 sub-phase ladder. Adds string opcodes and the mixed-bank call ABI. Stacked on #21683.

## Summary
- 3 new string opcodes: `OpConstStrKW`, `OpLenStr`, `OpConcatStr`
- 2 new call opcodes: `OpCallMixed`, `OpTailCallMixed` (return bank in BankFlags low 2 bits; self-tail-call fast path when argBase=0)
- `Arenas.AllocStringConcat(left, right)` skips the intermediate merged-slice alloc
- `compiler3/corpus/strings_concat_loop.go` ports the compiler2 kernel and validates against `c2corpus.ExpectStringsConcatLoop`
- MEP-40 §10 Phase 3 split into sub-phases; 3.1 marked LANDED

## Bench
Apple M4, darwin/arm64, strings_concat_loop_n64:
- vm3: 4 293 ns/op, 12 910 B/op, 60 allocs/op
- vm2: 2 421 ns/op,  6 176 B/op, 123 allocs/op

vm3 is 1.87x slower since each OpConcatStr allocates a fresh arena slot (no reuse without Phase 6 GC). Already halves alloc count vs vm2; byte-volume gap closes when Phase 6 lands.

## Test plan
- [x] go test ./runtime/vm3/... ./compiler3/...
- [x] go vet ./runtime/vm3/... ./compiler3/...
- [x] strings_concat_loop matches ExpectStringsConcatLoop for N ∈ {0,1,2,5,10,50}
- [x] math kernels (Phase 2) still pass

Tracks #21684.