### PR TITLE
mep-0040 phase 3.2: list opcodes + lists_fill_sum kernel

### DIFF
--- a/compiler3/corpus/corpus.go
+++ b/compiler3/corpus/corpus.go
@@ -23,5 +23,6 @@ func All() []*Program {
 		FibRec,
 		PrimeCount,
 		StringsConcatLoop,
+		ListsFillSum,
 	}
 }

--- a/compiler3/corpus/corpus_test.go
+++ b/compiler3/corpus/corpus_test.go
@@ -24,6 +24,7 @@ func TestMathKernelsMatchVm2(t *testing.T) {
 		{"fib_rec", FibRec, []int64{0, 1, 2, 5, 10, 15, 20}, c2corpus.ExpectFibRec},
 		{"prime_count", PrimeCount, []int64{0, 2, 10, 50, 100}, c2corpus.ExpectPrimeCount},
 		{"strings_concat_loop", StringsConcatLoop, []int64{0, 1, 2, 5, 10, 50}, c2corpus.ExpectStringsConcatLoop},
+		{"lists_fill_sum", ListsFillSum, []int64{0, 1, 2, 10, 100, 128}, c2corpus.ExpectListsFillSum},
 	}
 	for _, tc := range cases {
 		for _, n := range tc.ns {
@@ -57,6 +58,7 @@ func BenchmarkMathKernels(b *testing.B) {
 		{"fib_rec_n25", FibRec, 25},
 		{"prime_count_n100", PrimeCount, 100},
 		{"strings_concat_loop_n64", StringsConcatLoop, 64},
+		{"lists_fill_sum_n128", ListsFillSum, 128},
 	}
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {
@@ -97,6 +99,7 @@ func BenchmarkGoKernels(b *testing.B) {
 		{"fib_rec_n25", c2corpus.ExpectFibRec, 25},
 		{"prime_count_n100", c2corpus.ExpectPrimeCount, 100},
 		{"strings_concat_loop_n64", c2corpus.ExpectStringsConcatLoop, 64},
+		{"lists_fill_sum_n128", c2corpus.ExpectListsFillSum, 128},
 	}
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {

--- a/compiler3/corpus/lists_fill_sum.go
+++ b/compiler3/corpus/lists_fill_sum.go
@@ -1,0 +1,90 @@
+package corpus
+
+import "mochi/runtime/vm3"
+
+// ListsFillSum: fill a list with [0..n) then sum it.
+//
+//	fun main(n) {
+//	  xs := []
+//	  fill(xs, 0, n)
+//	  return sum(xs, 0, n, 0)
+//	}
+//	fun fill(xs, i, n) {     // returns unit
+//	  if i >= n return
+//	  xs.push(i)
+//	  return fill(xs, i+1, n)
+//	}
+//	fun sum(xs, j, n, acc) {
+//	  if j >= n return acc
+//	  return sum(xs, j+1, n, acc + xs[j])
+//	}
+//
+// Two tail-recursive helpers exercise the list opcodes (NewList,
+// ListPushI64, ListGetI64). The helpers also use the mixed-bank call
+// ABI (Cell + I64 params) added in Phase 3.1.
+//
+// Function 0 ("main"): single I64 param n.
+//
+//	NumRegsI64 = 4, NumRegsCell = 2.
+//	regsI64[0]  = n input (also final result)
+//	regsCell[0] = xs (call arg position 0)
+//
+// Function 1 ("fill"): ParamBanks=[Cell, I64, I64]. NumRegsI64 = 3,
+// NumRegsCell = 1. regsCell[0]=xs, regsI64[1]=i, regsI64[2]=n.
+//
+// Function 2 ("sum"): ParamBanks=[Cell, I64, I64, I64]. NumRegsI64 = 4,
+// NumRegsCell = 1. regsCell[0]=xs, regsI64[1]=j, regsI64[2]=n,
+// regsI64[3]=acc. regsI64[0] is scratch for ListGetI64 destination.
+var ListsFillSum = &Program{
+	Name: "lists_fill_sum",
+	Build: func(_ int64) *vm3.Program {
+		main := &vm3.Function{
+			Name:        "main",
+			NumRegsI64:  4,
+			NumRegsCell: 2,
+			ParamBanks:  []vm3.Bank{vm3.BankI64},
+			ResultBank:  vm3.BankI64,
+			Code: []vm3.Op{
+				vm3.MakeOp(vm3.OpNewList, 0, 0, 0),
+				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 0),
+				vm3.MakeOp(vm3.OpMovI64, 2, 0, 0),
+				{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 3, B: 0, C: 1},
+				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 0),
+				vm3.MakeOp(vm3.OpMovI64, 2, 0, 0),
+				vm3.MakeOp(vm3.OpConstI64K, 3, 0, 0),
+				{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 2},
+				vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),
+			},
+		}
+		fill := &vm3.Function{
+			Name:        "fill",
+			NumRegsI64:  3,
+			NumRegsCell: 1,
+			ParamBanks:  []vm3.Bank{vm3.BankCell, vm3.BankI64, vm3.BankI64},
+			ResultBank:  vm3.BankI64,
+			Code: []vm3.Op{
+				vm3.MakeOp(vm3.OpCmpGeI64Br, 1, 2, 4),
+				vm3.MakeOp(vm3.OpListPushI64, 0, 1, 0),
+				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 1),
+				vm3.MakeOp(vm3.OpTailCallMixed, 0, 0, 1),
+				vm3.MakeOp(vm3.OpReturnConstK, 0, 0, 0),
+			},
+		}
+		sum := &vm3.Function{
+			Name:        "sum",
+			NumRegsI64:  4,
+			NumRegsCell: 1,
+			ParamBanks:  []vm3.Bank{vm3.BankCell, vm3.BankI64, vm3.BankI64, vm3.BankI64},
+			ResultBank:  vm3.BankI64,
+			Code: []vm3.Op{
+				vm3.MakeOp(vm3.OpCmpGeI64Br, 1, 2, 5),
+				vm3.MakeOp(vm3.OpListGetI64, 0, 0, 1),
+				vm3.MakeOp(vm3.OpAddI64, 3, 3, 0),
+				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 1),
+				vm3.MakeOp(vm3.OpTailCallMixed, 0, 0, 2),
+				vm3.MakeOp(vm3.OpReturnI64, 3, 0, 0),
+			},
+		}
+		return &vm3.Program{Funcs: []*vm3.Function{main, fill, sum}, Entry: 0}
+	},
+}

--- a/runtime/vm3/op.go
+++ b/runtime/vm3/op.go
@@ -95,11 +95,16 @@ const (
 	// and retBank are preserved.
 	OpTailCallMixed
 
+	// Lists (Phase 3.2).
+	OpNewList     // regsCell[A] = arenas.AllocList(elemType=0, capHint=0)
+	OpListLenI64  // regsI64[A] = arenas.ListLen(regsCell[B])
+	OpListPushI64 // arenas list at regsCell[A] gets CInt(regsI64[B])
+	OpListGetI64  // regsI64[A] = arenas.ListGet(regsCell[B], regsI64[uint16(C)]).Int()
+	OpListSetI64  // arenas list at regsCell[A] at regsI64[uint16(C)] = CInt(regsI64[B])
+
 	// Phase 3.2+ placeholders. Bodies land in their own sub-phases.
-	OpListGetI64
 	OpListGetF64
 	OpListGetCell
-	OpListSetI64
 	OpListSetF64
 	OpListSetCell
 )

--- a/runtime/vm3/vm.go
+++ b/runtime/vm3/vm.go
@@ -496,6 +496,30 @@ func (vm *VM) run() (Cell, error) {
 			fr.pc = pc
 			return EncodeDeopt(int(uint16(op.C))), nil
 
+		case OpNewList:
+			regsCell[op.A] = arenas.AllocList(0, 0)
+			pc++
+		case OpListLenI64:
+			regsI64[op.A] = int64(arenas.ListLen(regsCell[op.B]))
+			pc++
+		case OpListPushI64:
+			lst := regsCell[op.A]
+			_, _, idx := lst.DecodeHandle()
+			l := &arenas.Lists[idx]
+			l.cells = append(l.cells, CInt(regsI64[op.B]))
+			l.len = uint32(len(l.cells))
+			pc++
+		case OpListGetI64:
+			lst := regsCell[op.B]
+			_, _, idx := lst.DecodeHandle()
+			regsI64[op.A] = arenas.Lists[idx].cells[regsI64[uint16(op.C)]].Int()
+			pc++
+		case OpListSetI64:
+			lst := regsCell[op.A]
+			_, _, idx := lst.DecodeHandle()
+			arenas.Lists[idx].cells[regsI64[uint16(op.C)]] = CInt(regsI64[op.B])
+			pc++
+
 		case OpConstStrKW:
 			regsCell[op.A] = consts[uint16(op.C)]
 			pc++

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -740,6 +740,22 @@ vm3 is 1.87x slower than vm2 on this kernel: the inner loop pays one fresh arena
 
 **Mixed-bank call ABI rationale**: An alternative was per-bank arg bases (caller emits `OpSetArgBank` ops then `OpCall`). That requires more dispatches per call. The chosen "single common base" encoding fits in one Op with no setup ops, at the cost of sparse slot use in banks that don't match a param's bank. For the strings kernel this wastes 2 Cell slots and 2 I64 slots per concat_loop frame, a negligible footprint.
 
+#### Phase 3.2: Lists (boxed Cell): **LANDED**
+
+**Deliverables** (shipped):
+- Five list opcodes in `runtime/vm3/op.go`: `OpNewList` (allocate empty list slot via `Arenas.AllocList(0, 0)`), `OpListLenI64` (length into i64 reg), `OpListPushI64` (append `CInt(regsI64[B])`; uses Go reslice-append so amortized O(1)), `OpListGetI64` (load element, decode `.Int()` into i64 reg), `OpListSetI64` (overwrite element with `CInt(...)`).
+- Inline handle decode in the push/get/set hot paths: bypasses the `Arenas.ListGet` accessor's gen check (Phase 6 will reintroduce the check inside the `OpCheckList` slow path).
+- `compiler3/corpus/lists_fill_sum.go`: three-function mixed-bank program (main + tail-recursive `fill(xs, i, n)` + tail-recursive `sum(xs, j, n, acc)`). Exercises `OpNewList`, both `OpCallMixed` invocations with `[Cell, I64, I64]` and `[Cell, I64, I64, I64]` param banks, `OpTailCallMixed` self-recursion, `OpListPushI64`, `OpListGetI64`, `OpReturnConstK` (unit return from `fill`). Validated bit-identical to `c2corpus.ExpectListsFillSum` on N ∈ &#123;0, 1, 2, 10, 100, 128&#125;.
+
+**Measured (Apple M4, darwin/arm64)**: `lists_fill_sum_n128`.
+
+| VM        | ns/op  | B/op   | allocs/op | vs vm2 |
+| --------- | -----: | -----: | --------: | -----: |
+| vm3       |  5 600 |  2 255 |         8 |  0.32x |
+| vm2       | 17 300 | 80 280 |        13 |  1.00x |
+
+vm3 is ~3.1x faster than vm2 and uses ~36x less memory on this kernel. The wins come from (a) the typed `regsI64` bank avoiding per-element boxing of the loop induction variable, (b) `OpTailCallMixed`'s self-tail-call fast path (canonical layout means zero arg copy on the hot loop edge), and (c) the arena's reslice-append list growth amortizing allocations down to 8 vs vm2's 13. Note the list itself is still boxed Cell (one `CInt` Cell per element); a future i64-typed list (Phase 4 boundary) would cut the 2 255 B/op further by storing raw i64 in an `arenaI64Arr` slot.
+
 ### Phase 4: Typed register banks (weeks 10-12)
 
 **Deliverables**:


### PR DESCRIPTION
Phase 3.2 of MEP-40. Lands the five list opcodes used by the boxed-Cell list kernel and ports `lists_fill_sum` to compiler3.

## Summary

- five list opcodes in `runtime/vm3/op.go`: `OpNewList`, `OpListLenI64`, `OpListPushI64`, `OpListGetI64`, `OpListSetI64`
- inline handle decode on the push/get/set hot paths (the gen check will be reintroduced inside an `OpCheckList` slow path in Phase 6)
- list elements are boxed Cells (`CInt(v)` for i64); a typed i64 list (arenaI64Arr) is left to Phase 4
- `compiler3/corpus/lists_fill_sum.go`: three-function mixed-bank program covering `OpCallMixed` with `[Cell, I64, I64]` and `[Cell, I64, I64, I64]` param banks, `OpTailCallMixed` self-recursion, and the new list ops. Bit-identical to `c2corpus.ExpectListsFillSum` on N in {0, 1, 2, 10, 100, 128}
- MEP-40 spec §10 gains a Phase 3.2 sub-section with the measured table and design notes

## Measured (Apple M4, darwin/arm64, `lists_fill_sum_n128`)

| VM  | ns/op  | B/op   | allocs/op | vs vm2 |
| --- | -----: | -----: | --------: | -----: |
| vm3 |  5 600 |  2 255 |         8 |  0.32x |
| vm2 | 17 300 | 80 280 |        13 |  1.00x |

vm3 is ~3.1x faster than vm2 and uses ~36x less memory. Wins come from `regsI64` keeping `i` and `j` unboxed, `OpTailCallMixed`'s self-tail-call fast path (zero arg copy on the canonical recursion edge), and reslice-append list growth amortising allocations.

## Test plan

- [x] `go test ./runtime/vm3/... ./compiler3/... -count=1`
- [x] `go test ./compiler3/corpus/... -bench BenchmarkMathKernels/lists_fill_sum_n128 -benchmem`
- [x] `go test ./runtime/vm2/bench/... -bench BenchmarkVM2_ListsFillSum -benchmem` for vm2 baseline

Tracks #21686.

PR: #21687