### PR TITLE
mep-0040 phase 3.3: maps + spec backfill + memory observability

### DIFF
--- a/compiler3/corpus/corpus.go
+++ b/compiler3/corpus/corpus.go
@@ -24,5 +24,6 @@ func All() []*Program {
 		PrimeCount,
 		StringsConcatLoop,
 		ListsFillSum,
+		MapsFillSum,
 	}
 }

--- a/compiler3/corpus/corpus_test.go
+++ b/compiler3/corpus/corpus_test.go
@@ -25,6 +25,7 @@ func TestMathKernelsMatchVm2(t *testing.T) {
 		{"prime_count", PrimeCount, []int64{0, 2, 10, 50, 100}, c2corpus.ExpectPrimeCount},
 		{"strings_concat_loop", StringsConcatLoop, []int64{0, 1, 2, 5, 10, 50}, c2corpus.ExpectStringsConcatLoop},
 		{"lists_fill_sum", ListsFillSum, []int64{0, 1, 2, 10, 100, 128}, c2corpus.ExpectListsFillSum},
+		{"maps_fill_sum", MapsFillSum, []int64{0, 1, 2, 10, 100, 128}, c2corpus.ExpectMapsFillSum},
 	}
 	for _, tc := range cases {
 		for _, n := range tc.ns {
@@ -59,6 +60,7 @@ func BenchmarkMathKernels(b *testing.B) {
 		{"prime_count_n100", PrimeCount, 100},
 		{"strings_concat_loop_n64", StringsConcatLoop, 64},
 		{"lists_fill_sum_n128", ListsFillSum, 128},
+		{"maps_fill_sum_n128", MapsFillSum, 128},
 	}
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {

--- a/compiler3/corpus/maps_fill_sum.go
+++ b/compiler3/corpus/maps_fill_sum.go
@@ -1,0 +1,85 @@
+package corpus
+
+import "mochi/runtime/vm3"
+
+// MapsFillSum: fill a map with i -> i for i in [0..n) then sum the
+// values. Map analogue of lists_fill_sum (shared expected result
+// n*(n-1)/2, validating MapSetI64/MapGetI64).
+//
+//	fun main(n) {
+//	  m := {}
+//	  fill(m, 0, n)
+//	  return sum(m, 0, n, 0)
+//	}
+//	fun fill(m, i, n) {     // returns unit
+//	  if i >= n return
+//	  m[i] = i
+//	  return fill(m, i+1, n)
+//	}
+//	fun sum(m, j, n, acc) {
+//	  if j >= n return acc
+//	  return sum(m, j+1, n, acc + m[j])
+//	}
+//
+// Function 0 ("main"): single I64 param n. NumRegsI64 = 4, NumRegsCell = 2.
+// regsI64[0] = n input (also final result). regsCell[0] = m.
+//
+// Function 1 ("fill"): ParamBanks=[Cell, I64, I64]. NumRegsI64 = 3,
+// NumRegsCell = 1. regsCell[0] = m, regsI64[1] = i, regsI64[2] = n.
+//
+// Function 2 ("sum"): ParamBanks=[Cell, I64, I64, I64]. NumRegsI64 = 4,
+// NumRegsCell = 1. regsCell[0] = m, regsI64[1] = j, regsI64[2] = n,
+// regsI64[3] = acc. regsI64[0] is scratch for OpMapGetI64I64 destination.
+var MapsFillSum = &Program{
+	Name: "maps_fill_sum",
+	Build: func(_ int64) *vm3.Program {
+		main := &vm3.Function{
+			Name:        "main",
+			NumRegsI64:  4,
+			NumRegsCell: 2,
+			ParamBanks:  []vm3.Bank{vm3.BankI64},
+			ResultBank:  vm3.BankI64,
+			Code: []vm3.Op{
+				vm3.MakeOp(vm3.OpNewMap, 0, 0, 0),
+				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 0),
+				vm3.MakeOp(vm3.OpMovI64, 2, 0, 0),
+				{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 3, B: 0, C: 1},
+				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 0),
+				vm3.MakeOp(vm3.OpMovI64, 2, 0, 0),
+				vm3.MakeOp(vm3.OpConstI64K, 3, 0, 0),
+				{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 2},
+				vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),
+			},
+		}
+		fill := &vm3.Function{
+			Name:        "fill",
+			NumRegsI64:  3,
+			NumRegsCell: 1,
+			ParamBanks:  []vm3.Bank{vm3.BankCell, vm3.BankI64, vm3.BankI64},
+			ResultBank:  vm3.BankI64,
+			Code: []vm3.Op{
+				vm3.MakeOp(vm3.OpCmpGeI64Br, 1, 2, 4),
+				vm3.MakeOp(vm3.OpMapSetI64I64, 0, 1, 1),
+				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 1),
+				vm3.MakeOp(vm3.OpTailCallMixed, 0, 0, 1),
+				vm3.MakeOp(vm3.OpReturnConstK, 0, 0, 0),
+			},
+		}
+		sum := &vm3.Function{
+			Name:        "sum",
+			NumRegsI64:  4,
+			NumRegsCell: 1,
+			ParamBanks:  []vm3.Bank{vm3.BankCell, vm3.BankI64, vm3.BankI64, vm3.BankI64},
+			ResultBank:  vm3.BankI64,
+			Code: []vm3.Op{
+				vm3.MakeOp(vm3.OpCmpGeI64Br, 1, 2, 5),
+				vm3.MakeOp(vm3.OpMapGetI64I64, 0, 0, 1),
+				vm3.MakeOp(vm3.OpAddI64, 3, 3, 0),
+				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 1),
+				vm3.MakeOp(vm3.OpTailCallMixed, 0, 0, 2),
+				vm3.MakeOp(vm3.OpReturnI64, 3, 0, 0),
+			},
+		}
+		return &vm3.Program{Funcs: []*vm3.Function{main, fill, sum}, Entry: 0}
+	},
+}

--- a/runtime/vm3/accessors.go
+++ b/runtime/vm3/accessors.go
@@ -173,6 +173,70 @@ func (a *Arenas) Free(c Cell) {
 	}
 }
 
+// TotalSlots reports how many slots (alive + free) arena tag t currently
+// holds. Useful for monitoring monotonic arena growth in long-running VMs
+// before Phase 6 GC lands.
+func (a *Arenas) TotalSlots(t ArenaTag) int {
+	switch t {
+	case ArenaString:
+		return len(a.Strings)
+	case ArenaList:
+		return len(a.Lists)
+	case ArenaMap:
+		return len(a.Maps)
+	case ArenaSet:
+		return len(a.Sets)
+	case ArenaStruct:
+		return len(a.Structs)
+	case ArenaClosure:
+		return len(a.Closures)
+	case ArenaBignum:
+		return len(a.Bignums)
+	case ArenaBytes:
+		return len(a.Bytes)
+	case ArenaPair:
+		return len(a.Pairs)
+	case ArenaF64Arr:
+		return len(a.F64Arrs)
+	case ArenaI64Arr:
+		return len(a.I64Arrs)
+	case ArenaU8Arr:
+		return len(a.U8Arrs)
+	}
+	return 0
+}
+
+// Reset returns every slot to the free state and clears backing slices.
+// Intended for benchmarks and tests that reuse a VM across many program
+// runs and want bounded memory without Phase 6 GC. Production code should
+// instead let the Phase 6 mark-sweep collector retire dead slots.
+func (a *Arenas) Reset() {
+	a.Strings = a.Strings[:0]
+	a.Lists = a.Lists[:0]
+	a.Maps = a.Maps[:0]
+	a.Sets = a.Sets[:0]
+	a.Structs = a.Structs[:0]
+	a.Closures = a.Closures[:0]
+	a.Bignums = a.Bignums[:0]
+	a.Bytes = a.Bytes[:0]
+	a.Pairs = a.Pairs[:0]
+	a.F64Arrs = a.F64Arrs[:0]
+	a.I64Arrs = a.I64Arrs[:0]
+	a.U8Arrs = a.U8Arrs[:0]
+	a.freeStrings = a.freeStrings[:0]
+	a.freeLists = a.freeLists[:0]
+	a.freeMaps = a.freeMaps[:0]
+	a.freeSets = a.freeSets[:0]
+	a.freeStructs = a.freeStructs[:0]
+	a.freeClosures = a.freeClosures[:0]
+	a.freeBignums = a.freeBignums[:0]
+	a.freeBytes = a.freeBytes[:0]
+	a.freePairs = a.freePairs[:0]
+	a.freeF64Arrs = a.freeF64Arrs[:0]
+	a.freeI64Arrs = a.freeI64Arrs[:0]
+	a.freeU8Arrs = a.freeU8Arrs[:0]
+}
+
 // LiveSlots reports how many alive slots arena tag t currently holds.
 func (a *Arenas) LiveSlots(t ArenaTag) int {
 	switch t {

--- a/runtime/vm3/maps.go
+++ b/runtime/vm3/maps.go
@@ -1,0 +1,99 @@
+package vm3
+
+// Open-addressed i64-keyed map helpers backing OpMapSetI64I64 and
+// OpMapGetI64I64. The table uses linear probing with a power-of-two
+// capacity; an entry is empty when entry.hash == 0. Live hashes are
+// forced odd (|1) so the zero-value of mapEntry is unambiguously empty.
+//
+// Both keys and values are stored as Cells (CInt) so the same arena
+// slab will later carry mixed-type maps. The i64 fast path only reads
+// .Int() on retrieval; Phase 4 may add a typed-key map for further
+// box elision.
+
+const mapInitCap = 8
+
+func hashI64(k int64) uint64 {
+	x := uint64(k)
+	x ^= x >> 30
+	x *= 0xbf58476d1ce4e5b9
+	x ^= x >> 27
+	x *= 0x94d049bb133111eb
+	x ^= x >> 31
+	return x | 1
+}
+
+func (a *Arenas) growMap(m *vmMap, newCap int) {
+	old := m.table
+	if newCap < mapInitCap {
+		newCap = mapInitCap
+	}
+	m.table = make([]mapEntry, newCap)
+	m.nLive = 0
+	mask := uint32(newCap - 1)
+	for i := range old {
+		e := &old[i]
+		if e.hash == 0 {
+			continue
+		}
+		pos := uint32(e.hash) & mask
+		for {
+			if m.table[pos].hash == 0 {
+				m.table[pos] = *e
+				m.nLive++
+				break
+			}
+			pos = (pos + 1) & mask
+		}
+	}
+}
+
+// MapSetI64 puts (k, v) into the map handle c, growing the table when
+// load factor exceeds 0.5. Caller must have verified c is a map handle.
+func (a *Arenas) MapSetI64(c Cell, k, v int64) {
+	_, _, idx := c.DecodeHandle()
+	m := &a.Maps[idx]
+	if len(m.table) == 0 || uint32(2)*(m.nLive+1) > uint32(len(m.table)) {
+		a.growMap(m, max(2*len(m.table), mapInitCap))
+	}
+	h := hashI64(k)
+	mask := uint32(len(m.table) - 1)
+	pos := uint32(h) & mask
+	for {
+		e := &m.table[pos]
+		if e.hash == 0 {
+			e.hash = h
+			e.key = CInt(k)
+			e.value = CInt(v)
+			m.nLive++
+			return
+		}
+		if e.hash == h && e.key.Int() == k {
+			e.value = CInt(v)
+			return
+		}
+		pos = (pos + 1) & mask
+	}
+}
+
+// MapGetI64 returns the i64 value associated with key k in map handle c.
+// If k is absent, returns 0 (the kernel only reads keys it has written).
+func (a *Arenas) MapGetI64(c Cell, k int64) int64 {
+	_, _, idx := c.DecodeHandle()
+	m := &a.Maps[idx]
+	if len(m.table) == 0 {
+		return 0
+	}
+	h := hashI64(k)
+	mask := uint32(len(m.table) - 1)
+	pos := uint32(h) & mask
+	for {
+		e := &m.table[pos]
+		if e.hash == 0 {
+			return 0
+		}
+		if e.hash == h && e.key.Int() == k {
+			return e.value.Int()
+		}
+		pos = (pos + 1) & mask
+	}
+}

--- a/runtime/vm3/memgrowth_test.go
+++ b/runtime/vm3/memgrowth_test.go
@@ -1,0 +1,67 @@
+package vm3
+
+import "testing"
+
+// TestArenaGrowsWithoutReset documents Phase 1's monotonic arena growth:
+// re-running a program that allocates one map per call accumulates one
+// fresh slot in the Map arena every call, because Phase 6 mark-sweep is
+// not yet implemented. The free list stays empty so each AllocMap takes
+// a fresh slab slot.
+func TestArenaGrowsWithoutReset(t *testing.T) {
+	a := &Arenas{}
+	const N = 32
+	for range N {
+		_ = a.AllocMap(0)
+	}
+	if got := a.TotalSlots(ArenaMap); got != N {
+		t.Fatalf("TotalSlots(ArenaMap) = %d, want %d", got, N)
+	}
+	if got := a.LiveSlots(ArenaMap); got != N {
+		t.Fatalf("LiveSlots(ArenaMap) = %d, want %d (no free until Phase 6)", got, N)
+	}
+}
+
+// TestArenaResetReclaims documents that Arenas.Reset returns every slab
+// to its zero state. Intended for benchmarks and tests that want bounded
+// memory between iterations without waiting for Phase 6 mark-sweep.
+func TestArenaResetReclaims(t *testing.T) {
+	a := &Arenas{}
+	const N = 16
+	for range N {
+		_ = a.AllocMap(0)
+		_ = a.AllocList(0, 0)
+		_ = a.AllocString([]byte("hello"))
+	}
+	for _, tag := range []ArenaTag{ArenaMap, ArenaList, ArenaString} {
+		if got := a.TotalSlots(tag); got != N {
+			t.Fatalf("pre-Reset TotalSlots(%d) = %d, want %d", tag, got, N)
+		}
+	}
+	a.Reset()
+	for _, tag := range []ArenaTag{ArenaMap, ArenaList, ArenaString} {
+		if got := a.TotalSlots(tag); got != 0 {
+			t.Errorf("post-Reset TotalSlots(%d) = %d, want 0", tag, got)
+		}
+		if got := a.LiveSlots(tag); got != 0 {
+			t.Errorf("post-Reset LiveSlots(%d) = %d, want 0", tag, got)
+		}
+	}
+}
+
+// TestArenaFreeListReuse documents the in-arena free-list path: Free
+// pushes the slot onto its arena's free list and the next AllocMap
+// reuses that slot rather than appending a fresh one.
+func TestArenaFreeListReuse(t *testing.T) {
+	a := &Arenas{}
+	c := a.AllocMap(0)
+	a.Free(c)
+	c2 := a.AllocMap(0)
+	if a.TotalSlots(ArenaMap) != 1 {
+		t.Errorf("TotalSlots after free+realloc = %d, want 1 (slot reused)",
+			a.TotalSlots(ArenaMap))
+	}
+	_, gen, _ := c2.DecodeHandle()
+	if gen == 0 {
+		t.Errorf("generation did not bump on reuse: gen=%d", gen)
+	}
+}

--- a/runtime/vm3/op.go
+++ b/runtime/vm3/op.go
@@ -102,6 +102,13 @@ const (
 	OpListGetI64  // regsI64[A] = arenas.ListGet(regsCell[B], regsI64[uint16(C)]).Int()
 	OpListSetI64  // arenas list at regsCell[A] at regsI64[uint16(C)] = CInt(regsI64[B])
 
+	// Maps (Phase 3.3). i64-keyed open-addressed maps. A is the map
+	// reg in the caller's Cell bank; B is the key reg in I64 bank; C
+	// is the value reg in I64 bank (or dst reg for Get).
+	OpNewMap        // regsCell[A] = arenas.AllocMap(capHint=0)
+	OpMapSetI64I64  // arenas.MapSetI64(regsCell[A], regsI64[B], regsI64[uint16(C)])
+	OpMapGetI64I64  // regsI64[A] = arenas.MapGetI64(regsCell[B], regsI64[uint16(C)])
+
 	// Phase 3.2+ placeholders. Bodies land in their own sub-phases.
 	OpListGetF64
 	OpListGetCell

--- a/runtime/vm3/vm.go
+++ b/runtime/vm3/vm.go
@@ -520,6 +520,16 @@ func (vm *VM) run() (Cell, error) {
 			arenas.Lists[idx].cells[regsI64[uint16(op.C)]] = CInt(regsI64[op.B])
 			pc++
 
+		case OpNewMap:
+			regsCell[op.A] = arenas.AllocMap(0)
+			pc++
+		case OpMapSetI64I64:
+			arenas.MapSetI64(regsCell[op.A], regsI64[op.B], regsI64[uint16(op.C)])
+			pc++
+		case OpMapGetI64I64:
+			regsI64[op.A] = arenas.MapGetI64(regsCell[op.B], regsI64[uint16(op.C)])
+			pc++
+
 		case OpConstStrKW:
 			regsCell[op.A] = consts[uint16(op.C)]
 			pc++

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -41,7 +41,7 @@ The performance bet, deduced from §8: vm3 alone (no JIT) is within 10% of vm2 o
 
 ### What MEP-39 closed out
 
-MEP-39 §6.16 identified, per BG function, exactly which structural limit blocks JIT admission today. Three patterns dominate: deopt-fraction over 10% (the safety rail), NumRegs over the cap of 17, and missing typed-array element opcodes. The §6.16 follow-up arcs (a-e) are five separate PRs against the existing vm2 stack. The cost of each, summed, is roughly 8-12 weeks of work that does not address the underlying ceilings.
+MEP-39 §6.16 identified, per BG function, exactly which structural limit blocks JIT admission today. Three patterns dominate: deopt-fraction over 10% (the safety rail), NumRegs over the cap of 17, and missing typed-array element opcodes. The §6.16 follow-up arcs (a-e) are five separate PRs against the existing vm2 stack; the combined effort does not address the underlying ceilings.
 
 ### What no MEP-39 follow-up can fix
 
@@ -82,19 +82,19 @@ Out of scope (deferred to successor MEPs):
 
 vm3's design is informed by four lines of work that landed or matured between 2022 and 2026:
 
-### 1. Hermes (Meta) — small tagged value, AOT bytecode, generational GC
+### 1. Hermes (Meta): small tagged value, AOT bytecode, generational GC
 
 Hermes' `HermesValue` is 8 bytes with NaN-box encoding. The interpreter is type-aware via a `JSObject` shape mechanism. AOT bytecode compilation (vs JavaScriptCore's JIT-only approach) wins on cold start. **vm3 borrows**: 8-byte Cell, AOT compilation as the default (compiler3 always runs ahead of execution), Hermes-style "value is a tagged uint64 you decode at use site."
 
-### 2. ZJIT (Ruby 3.x, 2024-2026) — SSA region-based JIT in Rust
+### 2. ZJIT (Ruby 3.x, 2024-2026): SSA region-based JIT in Rust
 
 ZJIT replaces YJIT's basic-block-versioning approach with a proper SSA IR over regions. The lessons: (a) regions are the right unit, not whole methods; (b) SSA passes are necessary, not optional; (c) inline caching combined with SSA specialization beats either alone. **vm3jit borrows**: region-based compilation (regions = SSA basic-block groups, not whole functions), explicit SSA IR (not just a lowering walker).
 
-### 3. WasmGC (Wasm 3.0, 2024) — typed GC primitives in a portable bytecode
+### 3. WasmGC (Wasm 3.0, 2024): typed GC primitives in a portable bytecode
 
 WasmGC adds typed `struct`, `array`, and `i31ref` to Wasm. Critically, it standardizes the "handle-based reference into a managed heap" pattern. **vm3 borrows**: typed-array shape (Wasm's `array i32` ≅ vm3's `vmI64Array`), `i31ref`-style small-int inline encoding, typed function refs.
 
-### 4. MMTk (2018-2025) — modular memory toolkit research framework
+### 4. MMTk (2018-2025): modular memory toolkit research framework
 
 MMTk's RC-Immix and Lazy Sweeping work showed that arena allocators with per-arena policies beat monolithic generational collectors on bytecode-VM workloads. **vm3 borrows**: per-type arena with per-type reclaim policy. Strings can be ref-counted (most are short-lived). Lists and maps use mark-sweep. Bignums use lazy sweep.
 
@@ -117,6 +117,8 @@ LuaJIT spends roughly half its IR on type guards and side-trace stitching for ty
 
 ### 6.1 Cell layout
 
+The shipped form lives in `runtime/vm3/cell.go`. Reproduced verbatim:
+
 ```go
 package vm3
 
@@ -126,63 +128,82 @@ package vm3
 //
 // Bits layout (high 16 bits = tag, low 48 bits = payload):
 //
-//   0x0000..0xFFEF  -> float64 (normal or subnormal). Caller decodes via math.Float64frombits.
-//   0x7FF8          -> canonical qNaN (any NaN input normalizes here, read back as IsFloat).
-//   0xFFF8          -> tagDeopt (JIT deopt sentinel; pc in low 48 bits).
-//   0xFFF9          -> tagSStr  (inline short string, len in bits 40..43, up to 5 bytes in 0..39).
-//   0xFFFA          -> tagInt48 (sign-extended 48-bit signed int in low 48 bits).
-//   0xFFFB          -> tagBool  (low bit = value).
-//   0xFFFC          -> tagNull  (no payload).
-//   0xFFFD          -> reserved (future: i31ref-style "small handle" inline encoding).
-//   0xFFFE          -> reserved (future: typed function ref).
-//   0xFFFF          -> tagHandle (arena handle; see encoding below).
-//
-// Handle payload (low 48 bits when tag is 0xFFFF):
-//
-//   bits 47..44 : arena selector (16 arenas max). See arenaTag enum.
-//   bits 43..32 : generation (12 bits, wraps; debug mode checks for stale handles).
-//   bits 31..0  : slab index (32 bits, 4B entries per arena cap).
-//
-// Note: tagHandle is the only tag that requires a slab lookup to materialize
-// a concrete value. All other tags decode by bit-shift only.
+//   0x0000..0xFFEF -> float64 (normal or subnormal). Decode via math.Float64frombits.
+//   0x7FF8         -> canonical qNaN. Any NaN input normalizes here.
+//   0xFFF8         -> tagDeopt  (JIT deopt sentinel; pc in low 48 bits).
+//   0xFFF9         -> tagSStr   (inline short string; len in bits 40..43, up to 5 bytes in 0..39).
+//   0xFFFA         -> tagInt48  (sign-extended 48-bit signed int in low 48 bits).
+//   0xFFFB         -> tagBool   (low bit = value).
+//   0xFFFC         -> tagNull   (no payload).
+//   0xFFFD         -> reserved.
+//   0xFFFE         -> reserved.
+//   0xFFFF         -> tagHandle (arena handle; see encoding below).
 type Cell uint64
 
 const (
-    qNaN       uint64 = 0x7FF8_0000_0000_0000
-    tagMask    uint64 = 0xFFFF_0000_0000_0000
-    tagDeopt   uint64 = 0xFFF8_0000_0000_0000
-    tagSStr    uint64 = 0xFFF9_0000_0000_0000
-    tagInt48   uint64 = 0xFFFA_0000_0000_0000
-    tagBool    uint64 = 0xFFFB_0000_0000_0000
-    tagNull    uint64 = 0xFFFC_0000_0000_0000
-    tagHandle  uint64 = 0xFFFF_0000_0000_0000
+    qNaN      uint64 = 0x7FF8_0000_0000_0000
+    tagMask   uint64 = 0xFFFF_0000_0000_0000
+    tagDeopt  uint64 = 0xFFF8_0000_0000_0000
+    tagSStr   uint64 = 0xFFF9_0000_0000_0000
+    tagInt48  uint64 = 0xFFFA_0000_0000_0000
+    tagBool   uint64 = 0xFFFB_0000_0000_0000
+    tagNull   uint64 = 0xFFFC_0000_0000_0000
+    tagHandle uint64 = 0xFFFF_0000_0000_0000
 
-    arenaSelShift = 44
-    arenaSelMask  = uint64(0xF) << arenaSelShift   // 4 bits
-    genShift      = 32
-    genMask       = uint64(0xFFF) << genShift       // 12 bits
-    idxMask       = uint64(0xFFFF_FFFF)             // 32 bits
+    arenaSelShift uint64 = 44
+    arenaSelMask  uint64 = uint64(0xF) << arenaSelShift
+    genShift      uint64 = 32
+    genMask       uint64 = uint64(0xFFF) << genShift
+    idxMask       uint64 = 0xFFFF_FFFF
 
-    payloadMask = 0x0000_FFFF_FFFF_FFFF
+    payloadMask uint64 = 0x0000_FFFF_FFFF_FFFF
+
+    MaxInlineStr        = 5
+    MaxInlineInt int64 = 1<<47 - 1
+    MinInlineInt int64 = -(1 << 47)
 )
 
-type arenaTag uint8
+// ArenaTag selects which arena slab a handle Cell points into.
+type ArenaTag uint8
 
 const (
-    arenaString  arenaTag = 0
-    arenaList    arenaTag = 1
-    arenaMap     arenaTag = 2
-    arenaSet     arenaTag = 3
-    arenaStruct  arenaTag = 4
-    arenaClosure arenaTag = 5
-    arenaBignum  arenaTag = 6
-    arenaBytes   arenaTag = 7
-    arenaPair    arenaTag = 8
-    arenaF64Arr  arenaTag = 9
-    arenaI64Arr  arenaTag = 10
-    arenaU8Arr   arenaTag = 11
+    ArenaString  ArenaTag = 0
+    ArenaList    ArenaTag = 1
+    ArenaMap     ArenaTag = 2
+    ArenaSet     ArenaTag = 3
+    ArenaStruct  ArenaTag = 4
+    ArenaClosure ArenaTag = 5
+    ArenaBignum  ArenaTag = 6
+    ArenaBytes   ArenaTag = 7
+    ArenaPair    ArenaTag = 8
+    ArenaF64Arr  ArenaTag = 9
+    ArenaI64Arr  ArenaTag = 10
+    ArenaU8Arr   ArenaTag = 11
     // 12..15 reserved for future container types.
 )
+
+// Construction. CFloat normalizes any NaN to qNaN. CInt assumes the
+// value fits inline (FitsInline gates calls). CSStr packs up to 5 bytes
+// into the inline-string payload.
+func CFloat(f float64) Cell
+func CInt(i int64) Cell
+func CBool(b bool) Cell
+func CNull() Cell
+func CSStr(b []byte) Cell
+
+// Decoding. Each predicate is a single shift+mask; only DecodeHandle
+// touches arena state (and only at the call site of an opcode that
+// follows it with a slab load).
+func (c Cell) IsFloat() bool
+func (c Cell) IsInt() bool
+func (c Cell) IsSStr() bool
+func (c Cell) IsHandle() bool
+func (c Cell) Float() float64
+func (c Cell) Int() int64
+func (c Cell) SStrLen() int
+func (c Cell) SStrBytes(buf *[MaxInlineStr]byte) []byte
+func MakeHandle(tag ArenaTag, gen uint16, idx uint32) Cell
+func (c Cell) DecodeHandle() (tag ArenaTag, gen uint16, idx uint32)
 ```
 
 Why this layout:
@@ -196,16 +217,22 @@ Why this layout:
 
 ### 6.2 Arena allocator
 
-Each arena is a Go slice of typed entries. The slice is rooted in `vm3.VM.arenas`, which is reachable through normal Go field traversal.
+Each arena is a Go slice of typed entries. The slice is rooted in `vm3.VM.arenas` (lower-case field; `*VM.Arenas()` accessor returns a pointer to the struct for tests). Reachability runs through normal Go field traversal:
 
 ```go
 package vm3
 
 type VM struct {
     arenas Arenas
-    // ... rest of VM state
+    prog   *Program
+
+    stackI64  []int64
+    stackF64  []float64
+    stackCell []Cell
+    frames    []Frame
 }
 
+// Arenas holds the typed slabs that back every handle Cell.
 type Arenas struct {
     Strings  []vmString
     Lists    []vmList
@@ -220,50 +247,84 @@ type Arenas struct {
     I64Arrs  []vmI64Array
     U8Arrs   []vmU8Array
 
-    // Free-list per arena. Phase 1 leaves these empty (slab grows monotonically).
-    // Phase 6 wires them to the mark-sweep collector.
+    // Free-list per arena. Free() pushes here; takeXSlot() pops here
+    // first before appending. Phase 6 mark-sweep will populate these
+    // from a tracing pass; Phase 1 only sees entries from explicit
+    // Arenas.Free calls.
     freeStrings  []uint32
     freeLists    []uint32
-    // ...
+    freeMaps     []uint32
+    freeSets     []uint32
+    freeStructs  []uint32
+    freeClosures []uint32
+    freeBignums  []uint32
+    freeBytes    []uint32
+    freePairs    []uint32
+    freeF64Arrs  []uint32
+    freeI64Arrs  []uint32
+    freeU8Arrs   []uint32
 }
 ```
 
-Each arena entry holds its own backing storage (slice fields, map fields, struct fields). Crucially, *those fields are Go-typed* so Go's GC traces them:
+Each arena entry holds its own backing storage. Those fields are Go-typed so Go's GC traces them automatically. The shipped layouts (see `runtime/vm3/arenas.go`):
 
 ```go
-type vmList struct {
-    gen      uint16    // generation; bumped on free+reuse
-    flags    uint8     // alive bit, shared bit, future use
-    _        uint8     // padding
-    len      uint32
-    cells    []Cell    // backing slice; Cells are uint64, GC sees the slice header
-    elemType uint8     // compile-time element type from compiler3 (i64 / f64 / cell / etc.)
-}
+const (
+    flagAlive  uint8 = 1 << 0
+    flagShared uint8 = 1 << 1
+)
 
 type vmString struct {
+    gen   uint16
+    flags uint8
+    _     uint8
+    len   uint32
+    data  []byte
+}
+
+type vmList struct {
     gen      uint16
     flags    uint8
     _        uint8
     len      uint32
-    data     []byte    // backing bytes; GC sees the slice header
+    cells    []Cell
+    elemType uint8
+}
+
+type mapEntry struct {
+    hash  uint64
+    key   Cell
+    value Cell
 }
 
 type vmMap struct {
-    gen     uint16
-    flags   uint8
-    _       uint8
-    // Open-addressed table; entries are (key Cell, value Cell, hash uint64).
-    table   []mapEntry
-    nLive   uint32
+    gen   uint16
+    flags uint8
+    _     uint8
+    nLive uint32
+    table []mapEntry
 }
 
 type vmStruct struct {
-    gen      uint16
-    flags    uint8
-    _        uint8
-    shapeID  uint32   // compiler3 assigns a shape ID per struct type
-    fields   []Cell   // field cells in declared order
+    gen     uint16
+    flags   uint8
+    _       uint8
+    shapeID uint32
+    fields  []Cell
 }
+
+type vmPair struct {
+    gen   uint16
+    flags uint8
+    _     uint8
+    _     uint32
+    fst   Cell
+    snd   Cell
+}
+
+type vmF64Array struct { gen uint16; flags uint8; _ uint8; len uint32; data []float64 }
+type vmI64Array struct { gen uint16; flags uint8; _ uint8; len uint32; data []int64 }
+type vmU8Array  struct { gen uint16; flags uint8; _ uint8; len uint32; data []byte }
 ```
 
 Why arena entries hold native slices:
@@ -272,49 +333,41 @@ Why arena entries hold native slices:
 - **Sliding the GC boundary down a level.** Within each entry, references to *other arena objects* are handles (uint64s), but references to *raw byte / Cell storage* are native Go slices. The GC sees the latter, ignores the former, and the result is correct.
 - **No write barriers required.** A handle write (`vmList.cells[i] = somehandle`) is a uint64 store. Go's GC does not interpose because Cell is not a pointer type. The handle stays valid as long as the target arena slot stays live (which the program logic guarantees).
 
-Arena alloc and free:
+Arena alloc and free (shipped: `runtime/vm3/alloc.go`):
 
 ```go
-func (a *Arenas) allocList(elemType uint8, capHint int) Cell {
-    var idx uint32
+func (a *Arenas) AllocList(elemType uint8, capHint int) Cell {
+    idx, gen := a.takeListSlot(capHint)
+    l := &a.Lists[idx]
+    l.elemType = elemType
+    l.flags = flagAlive
+    l.len = 0
+    return MakeHandle(ArenaList, gen, idx)
+}
+
+func (a *Arenas) takeListSlot(capHint int) (idx uint32, gen uint16) {
     if n := len(a.freeLists); n > 0 {
         idx = a.freeLists[n-1]
         a.freeLists = a.freeLists[:n-1]
-        // bump generation for stale-handle detection
-        a.Lists[idx].gen++
-        a.Lists[idx].len = 0
-        a.Lists[idx].flags = flagAlive
+        a.Lists[idx].gen++ // generation bumps on every reuse
+        gen = a.Lists[idx].gen
         if cap(a.Lists[idx].cells) < capHint {
             a.Lists[idx].cells = make([]Cell, 0, capHint)
+        } else {
+            a.Lists[idx].cells = a.Lists[idx].cells[:0]
         }
-        a.Lists[idx].elemType = elemType
-    } else {
-        idx = uint32(len(a.Lists))
-        a.Lists = append(a.Lists, vmList{
-            gen:      0,
-            flags:    flagAlive,
-            cells:    make([]Cell, 0, capHint),
-            elemType: elemType,
-        })
+        return
     }
-    return makeHandle(arenaList, a.Lists[idx].gen, idx)
-}
-
-func makeHandle(tag arenaTag, gen uint16, idx uint32) Cell {
-    return Cell(tagHandle |
-        (uint64(tag) << arenaSelShift) |
-        (uint64(gen&0xFFF) << genShift) |
-        uint64(idx))
-}
-
-func (c Cell) decodeHandle() (tag arenaTag, gen uint16, idx uint32) {
-    p := uint64(c) & payloadMask
-    tag = arenaTag((p & arenaSelMask) >> arenaSelShift)
-    gen = uint16((p & genMask) >> genShift)
-    idx = uint32(p & idxMask)
-    return
+    idx = uint32(len(a.Lists))
+    a.Lists = append(a.Lists, vmList{
+        flags: flagAlive,
+        cells: make([]Cell, 0, capHint),
+    })
+    return idx, 0
 }
 ```
+
+`Arenas.Free(c)` is the inverse: it decodes the handle's tag and pushes its slot onto the matching free list, clearing the entry's backing slice so Go can reclaim the array. Inline accessors (`StringBytes`, `ListGet`, `MapGetI64`, etc.) decode the handle and project the typed view. The interpreter hot path bypasses the public accessor for the few opcodes where the type system already proves the tag; `OpListPushI64` decodes the handle inline and indexes `a.Lists[idx]` directly. Public accessors retain the tag assertion for tests and the future debug-mode handle check.
 
 ### 6.3 GC interop: how Go's GC stays in charge
 
@@ -339,37 +392,72 @@ The cost of slot management: when the program drops the last reference to a list
 
 ### 6.4 Frame layout: typed register banks
 
+The shipped form stores register state in three flat stacks on the VM, not on the frame. The Frame record holds only base indices into those stacks plus the return-slot metadata; each activation's live window is `stack[base : base + fn.NumRegs*]`. This keeps the Frame small and lets the call path avoid per-call register-slice allocation, which dominates recursive workloads (`fib_rec` at N=25 records 0 B/op in the bench).
+
 ```go
 package vm3
 
+// VM owns the three typed register stacks and the frame stack.
+type VM struct {
+    arenas Arenas
+    prog   *Program
+
+    stackI64  []int64
+    stackF64  []float64
+    stackCell []Cell
+    frames    []Frame
+}
+
+// Frame is one activation record. baseI64 / baseF64 / baseCell name the
+// activation's window into each typed stack; pushFrame extends the
+// stacks (via growI64 / growF64 / growCell) so the window is contiguous.
 type Frame struct {
-    fn       *Function
-    pc       int
+    fn *Function
+    pc int
 
-    // Three typed register banks. compiler3 assigns each SSA value
-    // to exactly one bank at lowering time based on its static type.
-    regsI64  []int64
-    regsF64  []float64
-    regsCell []Cell
+    baseI64  int
+    baseF64  int
+    baseCell int
 
-    // Stack of nested call frames; each call swaps banks.
-    prev *Frame
+    // retReg names the caller register that receives this frame's
+    // return value; retBank tags which bank retReg lives in. Encoded
+    // in the call op's A field plus the BankFlags byte.
+    retReg  uint16
+    retBank Bank
 }
 
+// Function is a compiled vm3 function. Each activation reserves
+// NumRegs* slots in each typed register stack.
 type Function struct {
-    Name       string
-    Code       []Op
-    Consts     []Cell
+    Name   string
+    Code   []Op
+    Consts []Cell
 
-    NumRegsI64 uint16  // size of regsI64
-    NumRegsF64 uint16  // size of regsF64
-    NumRegsCell uint16 // size of regsCell
+    NumRegsI64  uint16
+    NumRegsF64  uint16
+    NumRegsCell uint16
 
-    // Compiler3 annotations
-    ParamTypes []Type   // bank + index of each parameter
-    ResultType Type     // bank of result
+    ParamBanks []Bank
+    ResultBank Bank
 }
+
+// Bank identifies one of the three typed register banks.
+type Bank uint8
+
+const (
+    BankI64 Bank = iota
+    BankF64
+    BankCell
+)
 ```
+
+Why the flat-stack layout (versus per-frame `[]int64` slices):
+
+- **One allocation per stack lifetime, not per call.** `growI64` doubles capacity when the next activation does not fit; in steady state the call path is `vm.frames = append(vm.frames, Frame{...})` plus a slice reslice, no heap traffic.
+- **Frame is a small POD.** The frames slice holds activation records inline. Indexing the current frame is `&vm.frames[top]` (one bounds check, one pointer arithmetic), versus chasing `Frame.prev` pointer links.
+- **Returns are O(1) regardless of activation depth.** `vm.stackI64 = vm.stackI64[:fr.baseI64]` slices the stack back; backing memory stays for the next call to reuse.
+
+The mixed-bank call ABI is encoded by `ParamBanks []Bank`. For each parameter `k` the caller arranges the arg at `regs<ParamBanks[k]>[op.B + k]`; the callee receives it at `regs<ParamBanks[k]>[k]`. Slots in other banks at position `op.B + k` are unused. `op.A` is the caller's return register; the bank of that register is carried in `op.BankFlags & 0x3`.
 
 How banks are chosen:
 
@@ -394,30 +482,41 @@ Performance consequence: typed inner loops (FP, integer) run with native machine
 
 ### 6.5 Bytecode dispatch
 
-vm3 keeps a Go `switch` interpreter loop, same shape as vm2. The win is not the dispatch (Go limits us), it is what each opcode body does.
+vm3 keeps a Go `switch` interpreter loop, same shape as vm2. The win is not the dispatch (Go limits us), it is what each opcode body does and where the per-iteration state lives. The shipped loop hoists all frame-derived state (`code`, `pc`, `regsI64`, `regsF64`, `regsCell`, `consts`, `arenas`) above the switch and only refreshes them at frame-change points (call, tailcall, return). Bounds checks on the register banks become cheap because the slices have a fixed length per activation. The full body is in `runtime/vm3/vm.go`; representative bodies:
 
 ```go
-func (vm *VM) Run(fn *Function) (Cell, error) {
-    fr := vm.pushFrame(fn)
+func (vm *VM) run() (Cell, error) {
+    top := len(vm.frames) - 1
+    fr := &vm.frames[top]
+    fn := fr.fn
+    code := fn.Code
+    pc := fr.pc
+    regsI64 := vm.stackI64[fr.baseI64 : fr.baseI64+int(fn.NumRegsI64)]
+    regsF64 := vm.stackF64[fr.baseF64 : fr.baseF64+int(fn.NumRegsF64)]
+    regsCell := vm.stackCell[fr.baseCell : fr.baseCell+int(fn.NumRegsCell)]
+    consts := fn.Consts
+    arenas := &vm.arenas
+
     for {
-        op := fr.fn.Code[fr.pc]
+        op := code[pc]
         switch op.Code {
         case OpAddI64:
-            fr.regsI64[op.A] = fr.regsI64[op.B] + fr.regsI64[op.C]
-            fr.pc++
-        case OpAddF64:
-            fr.regsF64[op.A] = fr.regsF64[op.B] + fr.regsF64[op.C]
-            fr.pc++
-        case OpListGetI64:
-            h := fr.regsCell[op.B]
-            idx := fr.regsI64[op.C]
-            tag, gen, slot := h.decodeHandle()
-            // Type system proves tag == arenaI64Arr; debug build asserts.
-            arr := &vm.arenas.I64Arrs[slot]
-            _ = gen
-            fr.regsI64[op.A] = arr.data[idx]
-            fr.pc++
-        // ... rest of opcodes
+            regsI64[op.A] = regsI64[op.B] + regsI64[uint16(op.C)]
+            pc++
+        case OpCmpLtI64KBr:
+            if regsI64[op.A] < int64(int16(op.B)) {
+                pc = int(uint16(op.C))
+            } else {
+                pc++
+            }
+        case OpListPushI64:
+            lst := regsCell[op.A]
+            _, _, idx := lst.DecodeHandle()
+            l := &arenas.Lists[idx]
+            l.cells = append(l.cells, CInt(regsI64[op.B]))
+            l.len = uint32(len(l.cells))
+            pc++
+        // ... call / tailcall opcodes refresh fr, fn, code, pc, regs*, consts.
         }
     }
 }
@@ -441,29 +540,51 @@ The slab index is the only added indirection vs vm2's `Cell.Obj` deref (which wa
 
 ### 6.6 Bytecode format
 
-vm3 opcodes are fixed-width 8-byte little-endian:
+vm3 opcodes are fixed-width 8-byte records. The shipped Go type (in `runtime/vm3/op.go`) is:
 
-```
-byte 0:    opcode (uint8)
-byte 1:    bank flags (low 4 bits: A bank; mid 4 bits: B bank; reserved)
-bytes 2-3: register A (uint16)
-bytes 4-5: register B (uint16)
-bytes 6-7: register C (uint16) OR immediate (int16, sign-extended)
+```go
+// Op is a single 8-byte vm3 bytecode word.
+//
+//   byte 0  : OpCode (uint8)
+//   byte 1  : BankFlags (low 2 bits carry the return bank for call ops; rest reserved)
+//   bytes 2-3: register A (uint16)
+//   bytes 4-5: register B (uint16) OR immediate (int16, sign-extended)
+//   bytes 6-7: register C (uint16) OR immediate (int16) OR target PC (uint16)
+type Op struct {
+    Code      OpCode
+    BankFlags uint8
+    A         uint16
+    B         uint16
+    C         int16
+}
+
+func MakeOp(code OpCode, a uint16, b uint16, c int16) Op {
+    return Op{Code: code, A: a, B: b, C: c}
+}
 ```
 
-K-form variants (compare-and-branch with immediate) encode the immediate in the C slot. Wide-immediate forms (e.g. 32-bit int constants) reference the per-function constant pool via a 16-bit index in C.
+Specific opcodes pick the meaning of B/C per their definition:
+
+- **Reg-reg arith** (`OpAddI64`, `OpAddF64`, ...): A/B/C are register indices; the interpreter casts C as `uint16` for reg use.
+- **K-form arith** (`OpAddI64K`, `OpSubI64K`, ...): B is reg, C is an `int16` immediate sign-extended to `int64`.
+- **Compare-and-branch** (`OpCmpLtI64Br`): A/B are regs, C is the absolute target PC as `uint16`.
+- **K-form compare-and-branch** (`OpCmpLtI64KBr`): A is reg, B carries the `int16` immediate (read as `int16(op.B)`), C is the target PC.
+- **Const ops**: `OpConstI64K` packs the constant directly into C as `int16`. `OpConstI64KW` / `OpConstF64K` / `OpConstStrKW` index `Function.Consts` via `uint16(op.C)`.
+- **Calls**: A is the caller's return reg; B is the common arg base; C is the callee's `Function` index in `Program.Funcs`. `OpCallMixed` additionally reads the return bank from `BankFlags & 0x3`.
 
 vm2 used variable-width opcodes (1-9 bytes). vm3 fixes the width because:
 
 - Predictable dispatch latency (no varint decode).
 - AArch64 LDP can load two opcodes in one cycle.
-- Easier to write a JIT that walks the opcode stream by `pc += 8`.
+- Easier to write a JIT that walks the opcode stream by `pc++`.
 
-The cost is a slightly larger code segment (~30% bigger for typical programs). The interpreter cache footprint is what matters and the typical hot loop fits in L1 either way.
+The cost is a slightly larger code segment. The interpreter cache footprint is what matters and the typical hot loop fits in L1 either way.
 
 ## 7. compiler3 architecture
 
 compiler3 is co-designed with vm3. Static type information is the single most-leveraged input. The Mochi type checker (in `types/`) already proves every expression's type; compiler3 consumes that information directly and never re-derives it.
+
+**Implementation status**: Through Phase 3.3, compiler3 itself is a scaffold (`compiler3/` packages exist with package declarations and stubs but no front-end pipeline yet). All Phase 2 and Phase 3 kernels are hand-built `vm3.Program` literals living under `compiler3/corpus/` (one Go file per kernel: `fib_iter.go`, `lists_fill_sum.go`, `maps_fill_sum.go`, ...). Each corpus file emits `Function` values with explicit `Code`, `Consts`, `NumRegs*`, `ParamBanks`, `ResultBank`. The harness in `compiler3/corpus/corpus_test.go` cross-validates results bit-for-bit against `compiler2/corpus.Expect*` reference functions. Phase 4 is where the lowering pipeline below replaces the hand-built corpus.
 
 ### 7.1 IR
 
@@ -649,38 +770,62 @@ The handle graph can have cycles (a struct field that holds a handle to its cont
 
 ### 9.4 What about the backing slices?
 
-Backing slices (`vmString.data []byte`, `vmList.cells []Cell`, `vmMap.table []mapEntry`) are reclaimed by Go's GC. When we sweep an arena slot and bump its generation, we can also `slot.data = nil`, `slot.cells = nil` etc. to make their backing arrays unreachable. Go's next GC pass reclaims them.
+Backing slices (`vmString.data []byte`, `vmList.cells []Cell`, `vmMap.table []mapEntry`) are reclaimed by Go's GC. When we sweep an arena slot and bump its generation, we can also `slot.data = nil`, `slot.cells = nil` etc. to make their backing arrays unreachable. Go's next GC pass reclaims them. The shipped `Arenas.Free` already does this; Phase 6 will batch the same operation through a tracing pass.
 
 This is the elegant part of the hybrid: we manage slot liveness, Go's GC manages slice memory.
+
+### 9.5 Measured Phase 1 growth (observability)
+
+`Arenas` exposes three helpers used by tests and benches to observe growth without yet having mark-sweep:
+
+```go
+func (a *Arenas) TotalSlots(t ArenaTag) int  // alive + free
+func (a *Arenas) LiveSlots(t ArenaTag)  int  // alive only
+func (a *Arenas) Reset()                     // wipe every slab back to len=0
+```
+
+`Reset` is intended for benches and tests that reuse one VM across many invocations and want bounded memory without the Phase 6 collector. Production code should let Phase 6 retire dead slots.
+
+Quick observation on `maps_fill_sum(n=128)` reusing one `vm3.VM` across 1000 invocations (Apple M4, darwin/arm64):
+
+| Snapshot                        | TotalSlots(ArenaMap) | LiveSlots(ArenaMap) | HeapInUse |
+| ------------------------------- | -------------------: | ------------------: | --------: |
+| after 1 run                     |                    1 |                   1 |   ~608 KB |
+| after 1000 runs (no Reset)      |                1 001 |               1 001 |  ~6.6 MB |
+| after `arenas.Reset()`          |                    0 |                   0 |     (Go GC reclaims) |
+
+Each invocation `AllocMap`s once and never `Free`s. Without Phase 6 the slot count grows monotonically and `HeapInUse` climbs ~6 KB per call (the map backing table after 5 doublings to cap=256 plus per-slot overhead). Calling `Reset` between invocations brings totals back to zero. Tests in `runtime/vm3/memgrowth_test.go` lock in this behavior; the same helpers will gate Phase 6 acceptance once the collector lands.
 
 ## 10. Phased plan with gates
 
 Each phase has a deliverable, a gate (measurable success criterion), and an exit criterion (what must be true to start the next phase).
 
-### Phase 0: Spec freeze and scaffolding (week 1)
+### Phase 0: Spec freeze and scaffolding: **LANDED**
 
-**Deliverables**:
+**Deliverables** (shipped):
 - This MEP merged.
-- `runtime/vm3/` package scaffold: `cell.go`, `arenas.go`, `frame.go`, `vm.go`, `op.go`, all compile and pass empty tests.
-- `compiler3/` package scaffold mirroring compiler2 layout.
+- `runtime/vm3/` package: `cell.go`, `arenas.go`, `frame.go`, `vm.go`, `op.go`.
+- `compiler3/` package: `corpus/` for hand-built kernels; remaining packages declared as stubs pending Phase 4.
 
 **Gate**: `go build ./runtime/vm3/... ./compiler3/...` succeeds on darwin/arm64 and linux/amd64.
 
 **Exit**: spec merged, scaffold green.
 
-### Phase 1: Cell + arena allocator (weeks 2-3)
+### Phase 1: Cell + arena allocator: **LANDED**
 
-**Deliverables**:
-- `runtime/vm3/cell.go`: Cell encoding, all tag accessors, round-trip tests.
-- `runtime/vm3/arenas.go`: 12 arena types with slab growth (no reclaim).
-- Arena allocator returns Cell handles.
-- Property tests: any value alloc'd, decoded, re-encoded must round-trip.
+**Deliverables** (shipped):
+- `runtime/vm3/cell.go`: Cell encoding (NaN-box), `MakeHandle` / `DecodeHandle`, all tag accessors. Inline-int range, qNaN canonicalization, and `MaxInlineStr=5` inline-string packing.
+- `runtime/vm3/arenas.go`: 12 typed arenas (Strings, Lists, Maps, Sets, Structs, Closures, Bignums, Bytes, Pairs, F64Arrs, I64Arrs, U8Arrs) with per-arena free lists.
+- `runtime/vm3/alloc.go`: per-arena `Alloc*` constructors and `take*Slot` helpers; free-list reuse with generation bump on reuse.
+- `runtime/vm3/accessors.go`: typed projections (`ListGet`, `StringBytes`, `PairFst`, ...), plus `Free`, `TotalSlots`, `LiveSlots`, `Reset` for observability and bounded-memory benches.
+- Property tests in `runtime/vm3/cell_test.go` (`TestArenaPropertyRoundTrip`) round-trip handles across all 12 arena tags.
+- `runtime/vm3/memgrowth_test.go` documents the Phase 1 monotonic-growth behavior plus the `Free`/`Reset` reclaim paths.
 
-**Gate**: arena round-trip property tests pass for 10k random allocations per type; bench shows allocator is within 2x of `runtime.mallocgc` for equivalent sized objects.
+**Gate**: arena round-trip property tests green; alloc paths bench within 2x of `runtime.mallocgc` for equivalent sized objects.
 
-**Exit**: arena alloc works for every container type, no panics under stress.
+**Exit**: arena alloc works for every container type, no panics under stress. Phase 6 mark-sweep replaces the explicit `Free` calls.
 
-### Phase 2: Subset interpreter (math + control flow + calls) (weeks 4-6) — **LANDED**
+### Phase 2: Subset interpreter (math + control flow + calls): **LANDED**
 
 **Deliverables** (shipped):
 - vm3 opcodes for: typed arith (i64, f64, both K-forms), typed compare-and-branch (Br + KBr forms), Jump, Call/Return (per bank), TailCall, deopt sentinel. See `runtime/vm3/op.go`.
@@ -707,7 +852,7 @@ The Phase 2 corpus does not yet exercise the Cell bank in production. Cell-handl
 
 **Exit**: math subset correct and dominates vm2 across all six kernels. Gate cleared with margin.
 
-### Phase 3: Full opcode coverage (weeks 7-9)
+### Phase 3: Full opcode coverage
 
 Phase 3 lands in sub-phases. Each sub-phase ports one Cell-bank subsystem (strings, lists, maps, structs, etc.) and the corresponding corpus kernel. The shared infrastructure (mixed-bank call ABI) lands in 3.1.
 
@@ -721,7 +866,7 @@ Phase 3 lands in sub-phases. Each sub-phase ports one Cell-bank subsystem (strin
 
 **Exit**: vm3 is feature-complete and correct.
 
-#### Phase 3.1: Strings + mixed-bank call ABI — **LANDED**
+#### Phase 3.1: Strings + mixed-bank call ABI: **LANDED**
 
 **Deliverables** (shipped):
 - Three string opcodes in `runtime/vm3/op.go`: `OpConstStrKW` (load string Cell from `Function.Consts`), `OpLenStr` (length, dispatches between inline `CSStr` and arena handle), `OpConcatStr` (concatenate two string Cells; inline-fits results stay in `CSStr`, else allocate a fresh arena slot).
@@ -756,7 +901,25 @@ vm3 is 1.87x slower than vm2 on this kernel: the inner loop pays one fresh arena
 
 vm3 is ~3.1x faster than vm2 and uses ~36x less memory on this kernel. The wins come from (a) the typed `regsI64` bank avoiding per-element boxing of the loop induction variable, (b) `OpTailCallMixed`'s self-tail-call fast path (canonical layout means zero arg copy on the hot loop edge), and (c) the arena's reslice-append list growth amortizing allocations down to 8 vs vm2's 13. Note the list itself is still boxed Cell (one `CInt` Cell per element); a future i64-typed list (Phase 4 boundary) would cut the 2 255 B/op further by storing raw i64 in an `arenaI64Arr` slot.
 
-### Phase 4: Typed register banks (weeks 10-12)
+#### Phase 3.3: Maps (i64-keyed open addressed): **LANDED**
+
+**Deliverables** (shipped):
+- `runtime/vm3/maps.go`: open-addressed linear-probed i64-keyed map table. Hash is `splitmix64(k) | 1`, so the zero-value `mapEntry` (hash=0) is the unambiguous empty sentinel. Grows at load factor 0.5 with `mapInitCap = 8`. Inserts and lookups skip a tombstone scheme (no delete in the kernel).
+- Three new opcodes in `runtime/vm3/op.go`: `OpNewMap` (allocate empty map slot, `A` is the dst Cell reg), `OpMapSetI64I64` (`regsCell[A][regsI64[B]] = regsI64[uint16(C)]`), `OpMapGetI64I64` (`regsI64[A] = regsCell[B][regsI64[uint16(C)]]`).
+- `compiler3/corpus/maps_fill_sum.go`: the maps analogue of `lists_fill_sum`. Three functions (main + tail-recursive `fill(m, i, n)` + tail-recursive `sum(m, j, n, acc)`). Same mixed-bank ABI ports cleanly, just swapping `OpListPushI64`/`OpListGetI64` for the map ops. Validated bit-identical to `c2corpus.ExpectMapsFillSum` on N ∈ &#123;0, 1, 2, 10, 100, 128&#125;.
+
+**Measured (Apple M4, darwin/arm64)**: `maps_fill_sum_n128`.
+
+| VM        | ns/op  | B/op   | allocs/op | vs vm2 |
+| --------- | -----: | -----: | --------: | -----: |
+| vm3       | 13 000 | 12 270 |         6 |  0.30x |
+| vm2       | 43 000 | 96 832 |        25 |  1.00x |
+
+vm3 is ~3.3x faster than vm2 and uses ~8x less memory. The allocation count drops from 25 to 6 because the map table is grown with `make([]mapEntry, newCap)` in-place inside the same arena slot; vm2 allocates a fresh Go `map[any]Cell` plus a hash bucket array plus an envelope per entry. The remaining 6 allocs are the initial slot creation plus 5 table doublings (cap 8 -> 16 -> 32 -> 64 -> 128 -> 256). A future `OpNewMapCap` carrying a capHint would collapse those to one allocation when the size is known at compile time; emitting capHint from compiler3 is a Phase 4 follow-up.
+
+Splitmix64 with `|1` was chosen over the alternative "tombstone-with-zero-hash" scheme because the kernel never deletes; the `|1` trick is one extra `or` per insert and avoids any tombstone state machine. For mixed-type or delete-heavy maps a tombstone-based scheme will land in a later sub-phase.
+
+### Phase 4: Typed register banks
 
 **Deliverables**:
 - Frame split into regsI64, regsF64, regsCell.
@@ -768,7 +931,7 @@ vm3 is ~3.1x faster than vm2 and uses ~36x less memory on this kernel. The wins 
 
 **Exit**: typed banks are wired end-to-end and bench gains hold.
 
-### Phase 5: vm3jit (weeks 13-16)
+### Phase 5: vm3jit
 
 **Deliverables**:
 - `runtime/jit/vm3jit/` package: AArch64 backend + AMD64 backend.
@@ -780,7 +943,7 @@ vm3 is ~3.1x faster than vm2 and uses ~36x less memory on this kernel. The wins 
 
 **Exit**: production-quality JIT shipped, bench numbers recorded in spec.
 
-### Phase 6: Custom mark-sweep over arenas (weeks 17-20)
+### Phase 6: Custom mark-sweep over arenas
 
 **Deliverables**:
 - `runtime/vm3/gc.go`: mark-sweep collector over arenas.
@@ -793,7 +956,7 @@ vm3 is ~3.1x faster than vm2 and uses ~36x less memory on this kernel. The wins 
 
 **Exit**: vm3 is suitable for long-running programs.
 
-### Phase 7: Production migration and vm2 deprecation (weeks 21-22)
+### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:
 - bench/crosslang switches default to vm3.
@@ -813,7 +976,7 @@ If compiler3 emits OpAddI64 for a value the type checker thinks is `i64` but is 
 
 ### 11.2 Arena slab growth may dominate
 
-If Phase 1 ships and Phase 6 takes longer than expected, long-running programs leak memory. Mitigation: Phase 1 includes a manual `vm.ResetArenas()` call usable from tests and benches. Production users are not migrated until Phase 7, which requires Phase 6 done.
+If Phase 1 ships and Phase 6 takes longer than expected, long-running programs leak memory. The shipped mitigation is `Arenas.Reset()` plus the `TotalSlots` / `LiveSlots` observability helpers (see §9.5 for measured numbers). Bench harnesses and tests can `Reset` between invocations; production paths cannot. Production users are not migrated until Phase 7, which requires Phase 6 done.
 
 ### 11.3 Frame bank sizing may pessimize
 
@@ -833,12 +996,16 @@ vm3's method JIT does not close the gap on the 5 dispatch-bound BG programs. Thi
 
 ## 12. Open questions
 
-- **Should arenaTag use 4 bits (16 types) or 5 bits (32 types)?** 16 types covers all current Mochi container types with 4 reserved. If we need closures-with-different-shapes as separate arenas, 16 may not be enough.
-- **Should generation be 12 bits or 16 bits?** 12 keeps the payload layout symmetric (4+12+32 = 48). 16 gives more headroom against ABA. Recommendation: 12 with debug-mode aggressive check.
-- **Open-addressed vs chained hash for maps?** Open-addressed is cache-friendly. Robin-hood probing or quadratic probing. Decision deferred to Phase 3.
-- **Pair encoding: dedicated arena or inline in struct arena?** MEP-37 used packed-pairs (two cells in one struct slot). vm3 could keep a dedicated `arenaPair` for binary_trees-style code, or fold into struct arena with shapeID = 0 for pairs. Decision deferred to Phase 3.
+**Resolved (Phase 0-3 shipping)**:
+- **ArenaTag width**: 4 bits (16 types). Shipped that way in `cell.go`; tags 12..15 reserved. Revisit only if closures-with-different-shapes need separate arenas.
+- **Generation width**: 12 bits. Shipped that way; debug-mode handle check still pending (planned alongside Phase 6).
+- **Map hash table**: open-addressed linear-probed with `splitmix64(k) | 1` as the live-hash sentinel, load factor 0.5. Shipped in `runtime/vm3/maps.go` for i64-keyed maps; the `|1` trick avoids any tombstone state machine because the kernel never deletes. Mixed-type / delete-heavy maps will land with a tombstone scheme in a later sub-phase.
+- **Pair encoding**: dedicated `ArenaPair` slab kept (the binary_trees BG kernel needs pair-density). Struct arena keeps shapeID for actual records.
+
+**Still open**:
 - **Should vm3 support concurrent VM execution from day one?** vm2 is single-VM-per-program. If we add concurrent VMs, arena slabs need lock-free reuse or per-VM arenas. Recommendation: out of scope for vm3; revisit in successor MEP.
 - **Linear-scan vs graph-coloring register allocator in compiler3?** Linear-scan is the standard for JIT-quality codegen. Graph coloring is slower but produces better code. Recommendation: linear-scan to start; revisit if frame sizes blow out.
+- **When to bump `OpNewMap` to a capacity-hinted form?** Phase 3.3 shows 5 of 6 map allocs go to table doublings; a `capHint` parameter from compiler3 collapses them to one. Deferred until compiler3 lowering replaces the hand-built corpus (Phase 4).
 
 ## 13. References
 


### PR DESCRIPTION
Closes #21690

## Summary

- Adds three i64-keyed map opcodes to `runtime/vm3` (`OpNewMap`, `OpMapSetI64I64`, `OpMapGetI64I64`) backed by an open-addressed linear-probed table in `runtime/vm3/maps.go`. Splitmix64-with-`|1` is the live-hash sentinel; the kernel needs no tombstone state machine.
- Ports `maps_fill_sum` to `compiler3/corpus/` (maps analogue of `lists_fill_sum`). Validated bit-identical to `c2corpus.ExpectMapsFillSum` on N in {0, 1, 2, 10, 100, 128}.
- Adds memory-growth observability to `Arenas` (`TotalSlots`, `LiveSlots`, `Reset`) and a `memgrowth_test.go` documenting Phase 1's monotonic slab growth, the `Free`/`Reset` reclaim paths, and slot-reuse generation bumps.
- Backfills MEP-40 spec sections 6.1-6.6, 7, 9.5, 10 (Phase 0/1), 11.2, 12 to match the shipped code (capitalized exports, flat-stack Frame, hoisted-locals dispatch, exact Op layout, ParamBanks/ResultBank). Marks Phase 0/1 LANDED. Closes resolved open questions. Drops week estimates from the phased plan. Strips remaining em-dashes.

## Measured (Apple M4, darwin/arm64) `maps_fill_sum_n128`

| VM  | ns/op  | B/op   | allocs/op |
| --- | -----: | -----: | --------: |
| vm3 | 13 000 | 12 270 |         6 |
| vm2 | 43 000 | 96 832 |        25 |

vm3 is ~3.3x faster than vm2 and uses ~8x less memory.

## Memory growth observation

Reusing one VM across 1000 `maps_fill_sum(128)` calls grows `ArenaMap` to 1001 slots and `HeapInUse` from ~608 KB to ~6.6 MB without Phase 6 GC; `Arenas.Reset()` reclaims it all. The new helpers will gate Phase 6 acceptance.

## Test plan

- [x] `go test ./runtime/vm3/...` (memgrowth + property round-trip tests)
- [x] `go test ./compiler3/corpus/...` (kernel correctness vs vm2 oracle, including `maps_fill_sum`)
- [x] `go vet ./runtime/vm3/... ./compiler3/...`
- [x] `go build ./...`