### PR TITLE
mep-0040 phase 3.4: Layer A frame-scoped arena marks

### DIFF
--- a/compiler3/corpus/corpus_test.go
+++ b/compiler3/corpus/corpus_test.go
@@ -80,6 +80,46 @@ func BenchmarkMathKernels(b *testing.B) {
 // no observable effect and hoist the call out of the loop body.
 var goSink int64
 
+// TestLayerABoundsCorpusReuse asserts that re-running every corpus
+// kernel against the same VM keeps arena memory flat. Layer A (§6.7,
+// Phase 3.4) truncates per-call allocations on unboxed Return, so
+// reused-VM kernels should end with the same TotalSlots they started
+// with regardless of N or invocation count.
+//
+// This is the bench-correctness gate: until Layer A held, every
+// long-running bench drifted because arenas accumulated state across
+// b.N iterations.
+func TestLayerABoundsCorpusReuse(t *testing.T) {
+	cases := []struct {
+		name string
+		prog *Program
+		n    int64
+	}{
+		{"lists_fill_sum_n128", ListsFillSum, 128},
+		{"maps_fill_sum_n128", MapsFillSum, 128},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prog := tc.prog.Build(tc.n)
+			vm := vm3.NewWithProgram(prog)
+			fn := prog.Funcs[prog.Entry]
+			args := []int64{tc.n}
+			const N = 1000
+			for range N {
+				if _, err := vm.RunWithArgs(fn, args); err != nil {
+					t.Fatalf("RunWithArgs error: %v", err)
+				}
+			}
+			a := vm.Arenas()
+			for _, tag := range []vm3.ArenaTag{vm3.ArenaMap, vm3.ArenaList} {
+				if got := a.TotalSlots(tag); got != 0 {
+					t.Errorf("TotalSlots(tag=%d) after %d reused-VM runs = %d, want 0", tag, N, got)
+				}
+			}
+		})
+	}
+}
+
 // BenchmarkGoKernels runs the compiler2 Expect* reference functions
 // directly. Pairing this with BenchmarkMathKernels gives a "vm3 vs
 // native Go" ratio per kernel, the headline MEP-40 perf metric.

--- a/runtime/vm3/frame.go
+++ b/runtime/vm3/frame.go
@@ -6,6 +6,12 @@ package vm3
 // indices keeps the Frame record small and lets the call path avoid
 // per-call register-slice allocation, which dominates recursive
 // workloads.
+//
+// marks / freeMarks snapshot every arena slab's len() and free-list
+// len() at pushFrame. On an unboxed Return* the interpreter calls
+// arenas.truncateToMarks to slice each slab back to its mark and drop
+// any free-list entries pointing above the mark. This is Layer A of
+// the §6.7 memory plan: per-call region reclamation, no trace.
 type Frame struct {
 	fn *Function
 	pc int
@@ -19,7 +25,14 @@ type Frame struct {
 	retReg uint16
 	// retBank tags which bank retReg lives in.
 	retBank Bank
+
+	marks     [numArenaTags]uint32
+	freeMarks [numArenaTags]uint32
 }
+
+// numArenaTags is one past the last ArenaTag enumerator. Sized to fit
+// every tag so a Frame can hold one mark per arena without indirection.
+const numArenaTags = 12
 
 // Function is a compiled vm3 function. Each activation reserves
 // NumRegs* slots in each typed register stack.

--- a/runtime/vm3/memgrowth_test.go
+++ b/runtime/vm3/memgrowth_test.go
@@ -65,3 +65,62 @@ func TestArenaFreeListReuse(t *testing.T) {
 		t.Errorf("generation did not bump on reuse: gen=%d", gen)
 	}
 }
+
+// TestLayerATruncatesUnboxedReturn asserts that running a program which
+// allocates a map and returns an unboxed i64 leaves the map slab empty:
+// Layer A's frame mark drops every slot allocated above the caller's
+// high-water mark on Return*.
+func TestLayerATruncatesUnboxedReturn(t *testing.T) {
+	// Single-function program: alloc a map into regsCell[0], do nothing
+	// with it, return constant 0 (unboxed via OpReturnConstK).
+	main := &Function{
+		Name:        "allocAndDrop",
+		NumRegsI64:  1,
+		NumRegsCell: 1,
+		ResultBank:  BankI64,
+		Code: []Op{
+			MakeOp(OpNewMap, 0, 0, 0),
+			MakeOp(OpReturnConstK, 0, 0, 0),
+		},
+	}
+	prog := &Program{Funcs: []*Function{main}, Entry: 0}
+	vm := NewWithProgram(prog)
+	if _, err := vm.Run(main); err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if got := vm.Arenas().TotalSlots(ArenaMap); got != 0 {
+		t.Errorf("TotalSlots(ArenaMap) after unboxed return = %d, want 0 (Layer A truncate)", got)
+	}
+}
+
+// TestLayerABoundsReusedVM asserts that re-running an allocating
+// program against the same VM keeps arena memory flat: Layer A drops
+// each call's allocations on return, so 1000 invocations end with the
+// same TotalSlots as one invocation.
+func TestLayerABoundsReusedVM(t *testing.T) {
+	main := &Function{
+		Name:        "allocAndDrop",
+		NumRegsI64:  1,
+		NumRegsCell: 2,
+		ResultBank:  BankI64,
+		Code: []Op{
+			MakeOp(OpNewMap, 0, 0, 0),
+			MakeOp(OpNewList, 1, 0, 0),
+			MakeOp(OpReturnConstK, 0, 0, 0),
+		},
+	}
+	prog := &Program{Funcs: []*Function{main}, Entry: 0}
+	vm := NewWithProgram(prog)
+	const N = 1000
+	for range N {
+		if _, err := vm.Run(main); err != nil {
+			t.Fatalf("Run error: %v", err)
+		}
+	}
+	if got := vm.Arenas().TotalSlots(ArenaMap); got != 0 {
+		t.Errorf("TotalSlots(ArenaMap) after %d reused-VM runs = %d, want 0", N, got)
+	}
+	if got := vm.Arenas().TotalSlots(ArenaList); got != 0 {
+		t.Errorf("TotalSlots(ArenaList) after %d reused-VM runs = %d, want 0", N, got)
+	}
+}

--- a/runtime/vm3/memory.go
+++ b/runtime/vm3/memory.go
@@ -1,0 +1,179 @@
+package vm3
+
+// Layer A of the §6.7 memory plan: per-frame arena marks.
+//
+// snapshotMarks captures len() of every arena slab and free-list into a
+// pair of mark arrays at pushFrame. truncateToMarks slices each slab
+// back to its mark on unboxed Return, and filters newly-pushed
+// free-list entries that point above the mark (dangling after the
+// slice). Slot records dropped by the truncation have their backing
+// slice fields zeroed first so Go's GC can reclaim them.
+//
+// The strategy is the Tofte-Talpin (ML Kit, 1997) region model
+// restricted to per-call regions. It catches the dominant allocation
+// pattern of math kernels and any function that returns an unboxed
+// value (i64 / f64 / SStr / bool / null). Functions that return a
+// handle into the local arena range are handled by Layer B (Phase 3.5).
+
+// snapshotMarks records every slab and free-list length into the
+// caller-supplied arrays. Called from pushFrame.
+func (a *Arenas) snapshotMarks(marks, freeMarks *[numArenaTags]uint32) {
+	marks[ArenaString] = uint32(len(a.Strings))
+	marks[ArenaList] = uint32(len(a.Lists))
+	marks[ArenaMap] = uint32(len(a.Maps))
+	marks[ArenaSet] = uint32(len(a.Sets))
+	marks[ArenaStruct] = uint32(len(a.Structs))
+	marks[ArenaClosure] = uint32(len(a.Closures))
+	marks[ArenaBignum] = uint32(len(a.Bignums))
+	marks[ArenaBytes] = uint32(len(a.Bytes))
+	marks[ArenaPair] = uint32(len(a.Pairs))
+	marks[ArenaF64Arr] = uint32(len(a.F64Arrs))
+	marks[ArenaI64Arr] = uint32(len(a.I64Arrs))
+	marks[ArenaU8Arr] = uint32(len(a.U8Arrs))
+
+	freeMarks[ArenaString] = uint32(len(a.freeStrings))
+	freeMarks[ArenaList] = uint32(len(a.freeLists))
+	freeMarks[ArenaMap] = uint32(len(a.freeMaps))
+	freeMarks[ArenaSet] = uint32(len(a.freeSets))
+	freeMarks[ArenaStruct] = uint32(len(a.freeStructs))
+	freeMarks[ArenaClosure] = uint32(len(a.freeClosures))
+	freeMarks[ArenaBignum] = uint32(len(a.freeBignums))
+	freeMarks[ArenaBytes] = uint32(len(a.freeBytes))
+	freeMarks[ArenaPair] = uint32(len(a.freePairs))
+	freeMarks[ArenaF64Arr] = uint32(len(a.freeF64Arrs))
+	freeMarks[ArenaI64Arr] = uint32(len(a.freeI64Arrs))
+	freeMarks[ArenaU8Arr] = uint32(len(a.freeU8Arrs))
+}
+
+// truncateToMarks slices every slab back to the mark recorded by
+// snapshotMarks and drops dangling free-list entries. Slot records
+// being discarded have their backing slice fields zeroed so Go's GC
+// can reclaim them. Caller must guarantee no live handle outside the
+// current frame points above any mark (this is the precondition Layer
+// A relies on, satisfied automatically by an unboxed Return).
+func (a *Arenas) truncateToMarks(marks, freeMarks *[numArenaTags]uint32) {
+	if m := marks[ArenaString]; uint32(len(a.Strings)) > m {
+		tail := a.Strings[m:]
+		for i := range tail {
+			tail[i].data = nil
+			tail[i].flags = 0
+		}
+		a.Strings = a.Strings[:m]
+		a.freeStrings = filterFreeList(a.freeStrings, freeMarks[ArenaString], m)
+	}
+	if m := marks[ArenaList]; uint32(len(a.Lists)) > m {
+		tail := a.Lists[m:]
+		for i := range tail {
+			tail[i].cells = nil
+			tail[i].flags = 0
+		}
+		a.Lists = a.Lists[:m]
+		a.freeLists = filterFreeList(a.freeLists, freeMarks[ArenaList], m)
+	}
+	if m := marks[ArenaMap]; uint32(len(a.Maps)) > m {
+		tail := a.Maps[m:]
+		for i := range tail {
+			tail[i].table = nil
+			tail[i].flags = 0
+		}
+		a.Maps = a.Maps[:m]
+		a.freeMaps = filterFreeList(a.freeMaps, freeMarks[ArenaMap], m)
+	}
+	if m := marks[ArenaSet]; uint32(len(a.Sets)) > m {
+		tail := a.Sets[m:]
+		for i := range tail {
+			tail[i].table = nil
+			tail[i].flags = 0
+		}
+		a.Sets = a.Sets[:m]
+		a.freeSets = filterFreeList(a.freeSets, freeMarks[ArenaSet], m)
+	}
+	if m := marks[ArenaStruct]; uint32(len(a.Structs)) > m {
+		tail := a.Structs[m:]
+		for i := range tail {
+			tail[i].fields = nil
+			tail[i].flags = 0
+		}
+		a.Structs = a.Structs[:m]
+		a.freeStructs = filterFreeList(a.freeStructs, freeMarks[ArenaStruct], m)
+	}
+	if m := marks[ArenaClosure]; uint32(len(a.Closures)) > m {
+		tail := a.Closures[m:]
+		for i := range tail {
+			tail[i].upvalues = nil
+			tail[i].flags = 0
+		}
+		a.Closures = a.Closures[:m]
+		a.freeClosures = filterFreeList(a.freeClosures, freeMarks[ArenaClosure], m)
+	}
+	if m := marks[ArenaBignum]; uint32(len(a.Bignums)) > m {
+		tail := a.Bignums[m:]
+		for i := range tail {
+			tail[i].words = nil
+			tail[i].flags = 0
+		}
+		a.Bignums = a.Bignums[:m]
+		a.freeBignums = filterFreeList(a.freeBignums, freeMarks[ArenaBignum], m)
+	}
+	if m := marks[ArenaBytes]; uint32(len(a.Bytes)) > m {
+		tail := a.Bytes[m:]
+		for i := range tail {
+			tail[i].data = nil
+			tail[i].flags = 0
+		}
+		a.Bytes = a.Bytes[:m]
+		a.freeBytes = filterFreeList(a.freeBytes, freeMarks[ArenaBytes], m)
+	}
+	if m := marks[ArenaPair]; uint32(len(a.Pairs)) > m {
+		tail := a.Pairs[m:]
+		for i := range tail {
+			tail[i].flags = 0
+		}
+		a.Pairs = a.Pairs[:m]
+		a.freePairs = filterFreeList(a.freePairs, freeMarks[ArenaPair], m)
+	}
+	if m := marks[ArenaF64Arr]; uint32(len(a.F64Arrs)) > m {
+		tail := a.F64Arrs[m:]
+		for i := range tail {
+			tail[i].data = nil
+			tail[i].flags = 0
+		}
+		a.F64Arrs = a.F64Arrs[:m]
+		a.freeF64Arrs = filterFreeList(a.freeF64Arrs, freeMarks[ArenaF64Arr], m)
+	}
+	if m := marks[ArenaI64Arr]; uint32(len(a.I64Arrs)) > m {
+		tail := a.I64Arrs[m:]
+		for i := range tail {
+			tail[i].data = nil
+			tail[i].flags = 0
+		}
+		a.I64Arrs = a.I64Arrs[:m]
+		a.freeI64Arrs = filterFreeList(a.freeI64Arrs, freeMarks[ArenaI64Arr], m)
+	}
+	if m := marks[ArenaU8Arr]; uint32(len(a.U8Arrs)) > m {
+		tail := a.U8Arrs[m:]
+		for i := range tail {
+			tail[i].data = nil
+			tail[i].flags = 0
+		}
+		a.U8Arrs = a.U8Arrs[:m]
+		a.freeU8Arrs = filterFreeList(a.freeU8Arrs, freeMarks[ArenaU8Arr], m)
+	}
+}
+
+// filterFreeList drops entries appended after freeMark whose value is
+// at or above slabMark (those slots no longer exist after truncation).
+// Entries below freeMark are left untouched because they were live
+// before pushFrame and still refer to slots below the mark.
+func filterFreeList(free []uint32, freeMark, slabMark uint32) []uint32 {
+	if uint32(len(free)) <= freeMark {
+		return free
+	}
+	kept := free[:freeMark]
+	for _, idx := range free[freeMark:] {
+		if idx < slabMark {
+			kept = append(kept, idx)
+		}
+	}
+	return kept
+}

--- a/runtime/vm3/vm.go
+++ b/runtime/vm3/vm.go
@@ -82,6 +82,10 @@ func (vm *VM) pushFrame(fn *Function, retReg uint16, retBank Bank) {
 		retReg:   retReg,
 		retBank:  retBank,
 	})
+	// Layer A: snapshot arena lengths so an unboxed Return can drop
+	// every slot allocated in this activation.
+	fr := &vm.frames[len(vm.frames)-1]
+	vm.arenas.snapshotMarks(&fr.marks, &fr.freeMarks)
 }
 
 func growI64(s []int64, need int) []int64 {
@@ -383,6 +387,10 @@ func (vm *VM) run() (Cell, error) {
 			ret := regsI64[op.A]
 			retReg := fr.retReg
 			retBank := fr.retBank
+			// Layer A: unboxed return, so any handle allocated in this
+			// activation is dead. Truncate arenas back to the marks
+			// captured at pushFrame before clearing the cell window.
+			arenas.truncateToMarks(&fr.marks, &fr.freeMarks)
 			// Pop the current frame; stacks are sliced back to the
 			// caller's high-water mark. Don't bother clearing i64/f64
 			// (no GC implications); clear cell to release Go-heap refs
@@ -418,6 +426,7 @@ func (vm *VM) run() (Cell, error) {
 			ret := regsF64[op.A]
 			retReg := fr.retReg
 			retBank := fr.retBank
+			arenas.truncateToMarks(&fr.marks, &fr.freeMarks)
 			if fn.NumRegsCell > 0 {
 				clear(regsCell)
 			}
@@ -471,6 +480,7 @@ func (vm *VM) run() (Cell, error) {
 		case OpReturnConstK:
 			ret := int64(op.C)
 			retReg := fr.retReg
+			arenas.truncateToMarks(&fr.marks, &fr.freeMarks)
 			if fn.NumRegsCell > 0 {
 				clear(regsCell)
 			}


### PR DESCRIPTION
Re-landing of Phase 3.4 after #21694 reverted an accidental direct-to-main push of commit 254f2a267d. The diff is identical to that commit; only the path to main differs (now via PR, as intended).

## Summary

- 12 arena marks + 12 free-list marks captured on every pushFrame.
- OpReturnI64 / OpReturnF64 / OpReturnConstK call arenas.truncateToMarks before slicing the register stacks.
- Dropped slot records have their backing-slice fields zeroed so Go's GC can reclaim them. Free-list entries pointing above the mark are filtered out.
- OpReturnCell left for Layer B (Phase 3.5).

## Measured impact (M4)

- maps_fill_sum_n128 reused-VM bench: 13 000 -> 4 853 ns/op (2.7x faster)
- 1000 reused-VM invocations of maps_fill_sum or lists_fill_sum end with TotalSlots(ArenaMap)=0, TotalSlots(ArenaList)=0
- HeapInUse stays flat instead of climbing to ~6.6 MB across the same 1000 invocations
- No regression on scalar kernels (fib_iter, sum_loop, mul_loop, fact_rec, fib_rec, prime_count): they allocate nothing per frame, so snapshotMarks runs once per call but truncateToMarks is a 12-way no-op

## Test plan

- [x] go test ./runtime/vm3/... ./compiler3/... clean
- [x] go vet clean
- [x] TestLayerATruncatesUnboxedReturn: single-run alloc-and-drop ends with empty arenas
- [x] TestLayerABoundsReusedVM: 1000 runs keep TotalSlots(ArenaMap/List) at 0
- [x] TestLayerABoundsCorpusReuse: 1000 reused-VM runs of lists_fill_sum and maps_fill_sum stay memory-flat
- [x] Existing TestArenaGrowsWithoutReset, TestArenaResetReclaims, TestArenaFreeListReuse, TestMathKernelsMatchVm2 all still pass

Closes #21695.