### PR TITLE
mep-0040: mark Phase 3.4 LANDED with measured numbers

### DIFF
--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -953,17 +953,30 @@ vm3 is ~3.3x faster than vm2 and uses ~8x less memory. The allocation count drop
 
 Splitmix64 with `|1` was chosen over the alternative "tombstone-with-zero-hash" scheme because the kernel never deletes; the `|1` trick is one extra `or` per insert and avoids any tombstone state machine. For mixed-type or delete-heavy maps a tombstone-based scheme will land in a later sub-phase.
 
-#### Phase 3.4: Memory hygiene Layer A (frame-scoped arena marks)
+#### Phase 3.4: Memory hygiene Layer A (frame-scoped arena marks): **LANDED**
 
 Phase 3.3 measurements made it concrete that subsequent sub-phases must not ship before memory is bounded per call. Phase 3.4 inserts Layer A from §6.7 ahead of any further opcode work.
 
-**Deliverables**:
-- Frame record gains 12 `uint32` mark fields (one per arena tag); `pushFrame` snapshots `len(arenas.X)` into each on entry.
-- `Return*` opcode bodies check the return value: if unboxed (`IsHandle` false), truncate every slab to `fr.markX`. If a handle whose `idx < fr.markX`, truncate everything *except* its tag's slab.
-- Memory-growth test extended: 1000 reused-VM `maps_fill_sum(128)` invocations now finish with `TotalSlots(ArenaMap) <= O(1)` (one slot reused per call, not 1000 fresh).
-- Spec §6.7 and §9.2 made concrete with the shipped truncation code.
+**Shipped**:
+- `Frame` carries `marks [12]uint32` and `freeMarks [12]uint32`, one slot per `ArenaTag`. `pushFrame` calls `arenas.snapshotMarks` to capture `len(arenas.X)` and `len(arenas.freeX)` for every tag.
+- `OpReturnI64`, `OpReturnF64`, `OpReturnConstK` call `arenas.truncateToMarks` before slicing the register stacks back. Each slab is sliced to its mark; the dropped slot records have their backing-slice fields (`data`, `cells`, `table`, etc.) zeroed so Go's GC can reclaim them; free-list entries whose index is at or above the slab mark are filtered out (only entries appended after `freeMark` are scanned).
+- `OpReturnCell` is deliberately not wired into Layer A; handle returns are Layer B's territory (Phase 3.5).
+- Test coverage: `runtime/vm3/memgrowth_test.go` (TestLayerATruncatesUnboxedReturn, TestLayerABoundsReusedVM) and `compiler3/corpus/corpus_test.go` (TestLayerABoundsCorpusReuse).
 
-**Gate**: maps_fill_sum_n128 bench across 1000 reused-VM iterations stays under 1 MB HeapInUse delta (down from ~6 MB pre-Phase 3.4). All Phase 3 corpus kernels remain bit-identical to vm2 oracle.
+**Measured (M4)**:
+
+| bench (n=128, 1000 reused-VM iters) | pre-3.4 ns/op | post-3.4 ns/op | speedup | post-3.4 TotalSlots after run |
+|--|--|--|--|--|
+| `maps_fill_sum_n128` | 13 000 | 4 853 | 2.7x | 0 |
+| `lists_fill_sum_n128` | ~4 200 | 3 451 | 1.2x | 0 |
+
+Memory growth across 1000 reused-VM invocations:
+- Pre-3.4: `arenas.Maps` grew to 1000 slots, Go `HeapInUse` climbed from 608 KB to ~6.6 MB.
+- Post-3.4: `arenas.Maps` stays at 0 across all 1000 invocations, `HeapInUse` flat.
+
+The interpreter speedup is a side effect of Layer A: pre-3.4 every reused-VM iteration grew `arenas.Maps`, triggering Go's `append` doubling and a fresh `mapEntry` table on each grow. Post-3.4 the slab returns to length 0 after every call, so the second and subsequent iterations re-use the previous backing array without resizing. Scalar kernels (`fib_iter`, `sum_loop`, `mul_loop`, `fact_rec`, `fib_rec`, `prime_count`) allocate nothing per frame, so they see the snapshot cost (one cache-line of stores) but the truncate is a 12-way no-op; no measurable regression.
+
+**Gate**: maps_fill_sum_n128 bench across 1000 reused-VM iterations stays under 1 MB HeapInUse delta (down from ~6 MB pre-Phase 3.4). All Phase 3 corpus kernels remain bit-identical to vm2 oracle. Gate met.
 
 **Exit**: any unboxed-return kernel keeps memory flat across calls. Layer B picks up handle-returning frames in Phase 3.5.
 


### PR DESCRIPTION
Spec-only update. Records Phase 3.4 as LANDED and pins the post-3.4 numbers.

## Summary

- Phase 3.4 heading: LANDED.
- New \"Shipped\" subsection: the actual deliverables (Frame.marks + freeMarks, snapshotMarks, truncateToMarks, the three Return* paths wired in, tests).
- New \"Measured (M4)\" table: maps_fill_sum_n128 13 000 -> 4 853 ns/op, lists_fill_sum_n128 4 200 -> 3 451 ns/op, post-3.4 TotalSlots after 1000 reused-VM iterations = 0.
- HeapInUse stays flat across 1000 reused-VM invocations (was climbing to ~6.6 MB pre-3.4).

Implementation already landed in #21696. This PR is the spec catch-up.

## Test plan
- [x] No em-dashes.
- [x] No bare angle brackets outside backticks.
- [x] Website docusaurus build will run on merge.