### PR TITLE
mep-0040: Phase 4.0 fair vm3-vs-Go bench harness

### DIFF
--- a/compiler3/corpus/go_kernels_fair_test.go
+++ b/compiler3/corpus/go_kernels_fair_test.go
@@ -1,0 +1,197 @@
+package corpus
+
+import (
+	"testing"
+
+	vm3 "mochi/runtime/vm3"
+)
+
+// BenchmarkGoKernelsFair is the shape-faithful Go baseline for
+// MEP-40's "vm3 vs Go" ratio. The original BenchmarkGoKernels routes
+// through compiler2/corpus.Expect* helpers, several of which are
+// closed-form (e.g. ExpectIterSum is (n-1)*n/2, ExpectListsFillSum is
+// n*(n-1)/2, ExpectStringsConcatLoop is n+1) and so compare a vm3 O(n)
+// loop to a Go O(1) constant. The ratio under that harness is
+// meaningless.
+//
+// The kernels here mirror the vm3 corpus shape one-for-one:
+//
+//   - sum_loop: explicit i++ loop accumulating into s.
+//   - mul_loop: explicit i++ loop multiplying into r.
+//   - fact_rec: true recursion via goFactRec.
+//   - fib_iter: explicit (a, b) := (b, a+b) loop.
+//   - fib_rec: true recursion via goFibRec.
+//   - prime_count: nested loop with modulo per (k, i) pair.
+//   - strings_concat_loop: real string ++ loop building length-n string.
+//   - lists_fill_sum: real []int64 append loop then a sum loop.
+//   - maps_fill_sum: real map[int64]int64 fill loop then a sum lookup loop.
+//
+// Each Go kernel is //go:noinline so the bench loop can't fold its
+// body. fairSink is package-global so dead-store elimination can't
+// hoist the result out of the loop. The input is perturbed by b.N's
+// parity so the optimizer can't memoize on a single constant input.
+func BenchmarkGoKernelsFair(b *testing.B) {
+	cases := []struct {
+		name string
+		fn   func(int64) int64
+		n    int64
+	}{
+		{"fib_iter_n30", goFibIter, 30},
+		{"sum_loop_n10001", goSumLoop, 10001},
+		{"mul_loop_n16", goMulLoop, 16},
+		{"fact_rec_n12", goFactRec, 12},
+		{"fib_rec_n25", goFibRec, 25},
+		{"prime_count_n100", goPrimeCount, 100},
+		{"strings_concat_loop_n64", goStringsConcatLoop, 64},
+		{"lists_fill_sum_n128", goListsFillSum, 128},
+		{"maps_fill_sum_n128", goMapsFillSum, 128},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			n := tc.n
+			fn := tc.fn
+			var s int64
+			for i := 0; i < b.N; i++ {
+				s += fn(n + int64(i&1))
+			}
+			fairSink = s
+		})
+	}
+}
+
+// fairSink defeats dead-store elimination across the Fair bench loop.
+var fairSink int64
+
+//go:noinline
+func goFibIter(n int64) int64 {
+	a, b := int64(0), int64(1)
+	for i := int64(0); i < n; i++ {
+		a, b = b, a+b
+	}
+	return a
+}
+
+//go:noinline
+func goSumLoop(n int64) int64 {
+	var s int64
+	for i := int64(0); i < n; i++ {
+		s += i
+	}
+	return s
+}
+
+//go:noinline
+func goMulLoop(n int64) int64 {
+	r := int64(1)
+	for i := int64(1); i < n; i++ {
+		r *= i
+	}
+	return r
+}
+
+//go:noinline
+func goFactRec(n int64) int64 {
+	if n <= 1 {
+		return 1
+	}
+	return n * goFactRec(n-1)
+}
+
+//go:noinline
+func goFibRec(n int64) int64 {
+	if n < 2 {
+		return n
+	}
+	return goFibRec(n-1) + goFibRec(n-2)
+}
+
+//go:noinline
+func goPrimeCount(n int64) int64 {
+	count := int64(0)
+	for k := int64(2); k < n; k++ {
+		prime := true
+		for i := int64(2); i < k-1; i++ {
+			if k%i == 0 {
+				prime = false
+				break
+			}
+		}
+		if prime {
+			count++
+		}
+	}
+	return count
+}
+
+//go:noinline
+func goStringsConcatLoop(n int64) int64 {
+	s := "a"
+	for i := int64(0); i < n; i++ {
+		s = s + "a"
+	}
+	return int64(len(s))
+}
+
+//go:noinline
+func goListsFillSum(n int64) int64 {
+	xs := make([]int64, 0, n)
+	for i := int64(0); i < n; i++ {
+		xs = append(xs, i)
+	}
+	var s int64
+	for _, v := range xs {
+		s += v
+	}
+	return s
+}
+
+//go:noinline
+func goMapsFillSum(n int64) int64 {
+	m := make(map[int64]int64, n)
+	for i := int64(0); i < n; i++ {
+		m[i] = i
+	}
+	var s int64
+	for j := int64(0); j < n; j++ {
+		s += m[j]
+	}
+	return s
+}
+
+// TestGoFairMatchesVm3 asserts every shape-faithful Go kernel returns
+// the same result as the vm3 corpus for the same N. Without this
+// check the bench numbers would not be apples-to-apples even if the
+// shape were honest.
+func TestGoFairMatchesVm3(t *testing.T) {
+	cases := []struct {
+		name string
+		prog *Program
+		fn   func(int64) int64
+		ns   []int64
+	}{
+		{"fib_iter", FibIter, goFibIter, []int64{0, 1, 2, 5, 10, 20, 30}},
+		{"sum_loop", SumLoop, goSumLoop, []int64{0, 1, 2, 100, 10001}},
+		{"mul_loop", MulLoop, goMulLoop, []int64{1, 2, 5, 16}},
+		{"fact_rec", FactRec, goFactRec, []int64{0, 1, 2, 5, 12}},
+		{"fib_rec", FibRec, goFibRec, []int64{0, 1, 2, 10, 25}},
+		{"prime_count", PrimeCount, goPrimeCount, []int64{0, 2, 10, 50, 100}},
+		{"strings_concat_loop", StringsConcatLoop, goStringsConcatLoop, []int64{0, 1, 5, 64}},
+		{"lists_fill_sum", ListsFillSum, goListsFillSum, []int64{0, 1, 10, 128}},
+		{"maps_fill_sum", MapsFillSum, goMapsFillSum, []int64{0, 1, 10, 128}},
+	}
+	for _, tc := range cases {
+		for _, n := range tc.ns {
+			prog := tc.prog.Build(n)
+			vm := vm3.NewWithProgram(prog)
+			got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{n})
+			if err != nil {
+				t.Errorf("%s(%d) vm3: %v", tc.name, n, err)
+				continue
+			}
+			want := tc.fn(n)
+			if got.Int() != want {
+				t.Errorf("%s(%d): vm3=%d go=%d", tc.name, n, got.Int(), want)
+			}
+		}
+	}
+}

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -864,6 +864,38 @@ Quick observation on `maps_fill_sum(n=128)` reusing one `vm3.VM` across 1000 inv
 
 Each invocation `AllocMap`s once and never `Free`s. Without Phase 6 the slot count grows monotonically and `HeapInUse` climbs ~6 KB per call (the map backing table after 5 doublings to cap=256 plus per-slot overhead). Calling `Reset` between invocations brings totals back to zero. Tests in `runtime/vm3/memgrowth_test.go` lock in this behavior; the same helpers will gate Phase 6 acceptance once the collector lands.
 
+### 9.9 Measured vm3 interpreter vs Go (corpus, Phase 4.0 baseline)
+
+The headline MEP-40 metric is "vm3 within 2x of Go". An honest baseline needs Go reference kernels that match the vm3 corpus's shape, not closed-form shortcuts (e.g. `(n-1)*n/2` for `sum_loop`, `n+1` for `strings_concat_loop`, `n*(n-1)/2` for `lists_fill_sum`). The original `BenchmarkGoKernels` in `compiler3/corpus/corpus_test.go` ran through `compiler2/corpus.Expect*` helpers, several of which are O(1) closed forms, so the ratio was meaningless.
+
+`compiler3/corpus/go_kernels_fair_test.go` (`BenchmarkGoKernelsFair`) ships shape-faithful Go kernels: real i++ loops for `sum_loop` / `mul_loop` / `fib_iter`, true recursion for `fact_rec` / `fib_rec`, nested loops with modulo for `prime_count`, real `s = s + "a"` string growth for `strings_concat_loop`, real `append`+sum for `lists_fill_sum`, real `map[int64]int64` fill+lookup for `maps_fill_sum`. Every Go kernel is `//go:noinline` and writes through a package-global sink so the compiler can't fold the loop body away. A correctness gate (`TestGoFairMatchesVm3`) checks every Go output matches the vm3 output across multiple N.
+
+Measured (Apple M4, darwin/arm64, `-benchtime=2s`):
+
+| Kernel                   |  vm3 ns/op |  Go ns/op | Ratio | Notes |
+| ------------------------ | ---------: | --------: | ----: | ----- |
+| `fib_iter_n30`           |        649 |      9.37 | 69.3x | 6 ops/iter × 30 iters = ~180 dispatches; Go SCEV+unroll dominates |
+| `sum_loop_n10001`        |    102 585 |     2 540 | 40.4x | 10001 trivial adds; Go vectorizes |
+| `mul_loop_n16`           |        186 |      5.81 | 32.0x | 16 muls; Go unrolls |
+| `fact_rec_n12`           |        389 |     10.33 | 37.7x | recursion both sides; Go inlines through depth 12 |
+| `fib_rec_n25`            |  8 211 930 |   222 672 | 36.9x | true exponential recursion; both sides do real work |
+| `prime_count_n100`       |      5 526 |     574.1 |  9.6x | nested loops + modulo per (k,i); larger per-op work narrows the gap |
+| `strings_concat_loop_n64`|      1 711 |     1 088 |  1.57x | already inside 2x; allocator + concat are the real work, dispatch is small share |
+| `lists_fill_sum_n128`    |      3 447 |       147 | 23.4x | Go SCEV-folds the second loop after seeing append pattern |
+| `maps_fill_sum_n128`     |      4 973 |     2 425 |  2.05x | nearly 2x; real hash work on both sides dwarfs dispatch |
+
+**Interpretation**:
+
+The two kernels already inside or at 2x (`strings_concat_loop` 1.57x, `maps_fill_sum` 2.05x) share one property: each iteration does enough real work (string allocation, hash lookup) that the per-op dispatch cost is a small share of the total. Dispatch is approximately 3.5 ns/op on M4, which is normal interpreter speed (about 5 cycles per case in Go's compiled jump table).
+
+The kernels at 30-70x (`fib_iter`, `sum_loop`, `mul_loop`, `fact_rec`, `fib_rec`) are arithmetic-pure: Go's compiler unrolls, vectorizes, and folds them down to a handful of instructions per iteration, while vm3 still pays the per-op dispatch cost. Closing this gap with an interpreter alone is not feasible: at 3.5 ns/op dispatch, even a hypothetical "1 op per loop iteration" lowering of `fib_iter` would still be ~105 ns vs Go's ~9 ns. The remaining gap is the fundamental interpretation tax. (Generic VM improvements such as smarter regalloc that drops the two `MovI64`s in `fib_iter`'s loop body can move the kernel from 6 ops/iter to 4, which closes the ratio from 69x to ~46x; useful, not transformative.)
+
+**This is why Phase 6 (vm3jit) is on the critical path to the 2x gate.** §11.5 and §11.6 already acknowledge it; this section pins the numerical baseline that Phase 6 inherits. The 2x gate is realistic for ~6 of the 11 BG programs once JIT lowers the hot loops; the rest (deep recursion, deeply dispatch-bound code) are the "left on the table" set noted in §11.6.
+
+**Implications for the phase order**:
+
+Phase 4 (compiler3 lowering) and Phase 6 (vm3jit) are independent prerequisites for the 2x gate, but their order is fungible. Compiler3 is required to compile real Mochi sources (the BG suite) to vm3 bytecode; without it vm3 can only run the hand-built corpus. JIT is required to bring arithmetic-pure kernels inside 2x. The current spec ordering keeps Phase 4 before Phase 6 because (a) the BG suite is needed to validate JIT lowerings and (b) compiler3 emits OpFree at SSA last-use (Layer C from §6.7), which the JIT consumes too.
+
 ## 10. Phased plan with gates
 
 Each phase has a deliverable, a gate (measurable success criterion), and an exit criterion (what must be true to start the next phase).
@@ -1040,16 +1072,83 @@ The interpreter speedup is a side effect of Layer A: pre-3.4 every reused-VM ite
 
 ### Phase 4: Typed register banks + compiler3 lowering + Layer C
 
-**Deliverables**:
-- Frame split into regsI64, regsF64, regsCell (largely done; this phase finalizes any remaining cell-mediated paths).
+Phase 4 lands in sub-phases. Each sub-phase ships one piece of the compiler3 pipeline (IR, opt passes, regalloc, emit, Layer C) end-to-end against the existing corpus, then admits more programs from the BG suite once the pipeline is stable.
+
+**Whole-phase deliverables**:
+- Frame split into regsI64, regsF64, regsCell (largely done in Phase 2 / 3.1; sub-phase 4.5 finishes any cell-mediated residue).
 - compiler3 lowering pipeline (`compiler3/ir`, `compiler3/opt`, `compiler3/regalloc`, `compiler3/emit`) replaces the hand-built corpus.
 - compiler3 emits `OpFree A` at SSA last-use for handles statically known to be intra-function (Layer C from §6.7).
 - Typed opcodes (OpAddI64, OpAddF64, OpListGetI64, etc.) replace cell-mediated dispatch where types are known.
 - Boundary box/unbox ops for cell-typed call sites.
 
-**Gate**: vm3 interpreter beats vm2 by 30%+ on FP-heavy BG (spectral_norm, mandelbrot, n_body) and 20%+ on integer loops (nsieve, fannkuch_redux). Cell-bank programs within 10% of vm2 (no regression). Memory budget for long-running programs under 100 MB even before Phase 5 mark-sweep lands.
+**Whole-phase gate**: vm3 interpreter beats vm2 by 30%+ on FP-heavy BG (spectral_norm, mandelbrot, n_body) and 20%+ on integer loops (nsieve, fannkuch_redux). Cell-bank programs within 10% of vm2 (no regression). Memory budget for long-running programs under 100 MB even before Phase 5 mark-sweep lands.
 
-**Exit**: typed banks wired end-to-end, compiler3 lowering replaces hand-built corpus, Layer C trims residual single-function allocations.
+**Whole-phase exit**: typed banks wired end-to-end, compiler3 lowering replaces hand-built corpus, Layer C trims residual single-function allocations.
+
+#### Phase 4.0: Fair vm3-vs-Go bench harness (PREREQUISITE)
+
+The original `BenchmarkGoKernels` ran vm3 against `compiler2/corpus.Expect*` helpers, several of which are O(1) closed forms (`(n-1)*n/2`, `n+1`, `n*(n-1)/2`). The resulting ratio compared a vm3 O(n) loop to a Go O(1) formula, so the number was not a baseline for any of the later phases.
+
+**Shipped**:
+- `compiler3/corpus/go_kernels_fair_test.go`: `BenchmarkGoKernelsFair` with nine `//go:noinline` shape-faithful Go kernels (`goSumLoop`, `goMulLoop`, `goFactRec`, `goFibIter`, `goFibRec`, `goPrimeCount`, `goStringsConcatLoop`, `goListsFillSum`, `goMapsFillSum`), each writing through `fairSink`.
+- `TestGoFairMatchesVm3` correctness gate: every Go kernel output matches the vm3 corpus output across multiple N (`{0, 1, 2, 5, 10, 20, 30}` for `fib_iter`, similar ranges per kernel).
+
+**Result** (measured): see §9.9. Two kernels already inside the 2x gate (`strings_concat_loop_n64` 1.57x, `maps_fill_sum_n128` 2.05x); arithmetic-pure kernels at 30-70x, which is the irreducible interpreter dispatch tax and motivates Phase 6 (vm3jit).
+
+**Exit**: the bench-harness assumption used by every later sub-phase is now honest. The original `BenchmarkGoKernels` is kept as a regression marker (its numbers don't match Phase 6's gate but mirror the vm2-era pattern).
+
+#### Phase 4.1: compiler3 IR + typed AST → SSA frontend
+
+**Deliverables**:
+- `compiler3/ir`: complete `Function`/`Block`/`Value`/`Terminator` data; expand `OpCode` enum to cover every operation produced by the current corpus shape (math, cmp, branch, jump, call, return, list/map/string ops).
+- `compiler3/build` (new sub-package): typed AST -> `ir.Function`. Starts with the math kernels (no containers) and grows by sub-phase. Reuses `types/` from compiler2 so this is a lowering pass, not a re-typecheck.
+- Round-trip test: every existing corpus kernel can be expressed as Mochi source, lowered to `ir.Function`, and run through Phase 4.4 emit to produce identical bytecode to the hand-built version.
+
+**Gate**: every `compiler3/corpus` program has a Mochi-source equivalent; `compile_then_run` produces bit-identical outputs to the hand-built corpus on the existing N ranges.
+
+#### Phase 4.2: opt passes (ConstFold, DCE, BranchThread, LICM, TailCall)
+
+**Deliverables**:
+- `compiler3/opt`: real bodies for the five pass stubs declared in `opt/doc.go`. Each pass is type-preserving; passes compose in the order declared in §7.3.
+- `TailCall` is the load-bearing pass for the corpus: it marks return-of-self-call patterns so emit can lower them to `OpTailCallI64` / `OpTailCallMixed`. The hand-built corpus uses these directly; the lowered version must too, or recursion eats the stack.
+
+**Gate**: same correctness gate as 4.1, plus the lowered bytecode for `fib_iter`, `fact_rec`, `fib_rec` is within 10% of the hand-built op count.
+
+#### Phase 4.3: linear-scan register allocator per bank
+
+**Deliverables**:
+- `compiler3/regalloc.Allocate`: linear-scan live-interval pass per bank (i64, f64, cell). Each bank gets independent slot indices.
+- Slot reuse: an i64 value whose live range ends before another's starts shares the same `regsI64` slot. Frame size = max simultaneously live slots per bank.
+- Spill is not implemented in 4.3 (no kernel in the corpus exceeds 16 simultaneously live values per bank). Phase 6 may revisit if BG suite needs it.
+
+**Gate**: every corpus kernel allocates with `NumRegsI64 + NumRegsF64 + NumRegsCell <= ` the hand-built corpus's totals (frame stays within the hand-tuned envelope).
+
+#### Phase 4.4: emit (SSA → vm3 bytecode)
+
+**Deliverables**:
+- `compiler3/emit.Compile`: walk blocks in reverse postorder, emit Op per IR value, patch jump targets in a second pass.
+- Constant pool: numeric constants under 16 bits go to the `int16 C` immediate (`OpConstI64K`); wider constants are pooled in `Function.Consts` and addressed via `OpConstI64KW` index.
+- Mixed-bank call-site lowering: when callee has `ParamBanks=[Cell, I64, ...]`, emit copies the args into the unified arg-base layout that `OpCallMixed` expects.
+
+**Gate**: the lowered bytecode for every corpus kernel produces bit-identical results to the hand-built version on the existing N ranges. Bench shows lowered code within 5% of the hand-built code (no regression from the compiler).
+
+#### Phase 4.5: Layer C OpFree at SSA last-use
+
+**Deliverables**:
+- New opcode `OpFree A` in `runtime/vm3/op.go`: invokes `arenas.Free(regsCell[A])` and clears the slot.
+- `compiler3/emit`: when a Cell-typed SSA value has its last use within the function (no escape via return, no embed into a returned container), emit `OpFree` after the use.
+- Escape analysis is the simple version: any `OpReturnCell` whose source is an SSA value taints that value; any container `Op*Set*` whose target Cell is itself tainted taints the source. Untainted Cell values get `OpFree`.
+
+**Gate**: a synthetic kernel that allocates 1000 maps inside a single function and uses each one once stays at `TotalSlots(ArenaMap) == 1` across the whole function (Phase 5 mark-sweep at function exit is not needed). On the existing corpus, Layer C reduces peak arena occupancy by at least 30% on kernels with intra-function transient containers.
+
+#### Phase 4.6: admit BG suite (drives compiler3 to feature parity)
+
+**Deliverables**:
+- Mochi sources from `compiler2/corpus`'s BG programs (or `bench/crosslang`) compile through the Phase 4.1-4.5 pipeline.
+- Programs that hit a missing feature land back-pressure as either (a) a new IR op in 4.1, (b) a new lowering rule in 4.4, or (c) a new vm3 opcode (rare; flagged as Phase 3.7 follow-up).
+- Each admitted program records vm3 vs Go vs vm2 numbers.
+
+**Gate**: at least 6 of 11 BG programs compile and run on vm3 with correct output. Numbers recorded; absolute 2x-of-Go is not gated here (Phase 6 owns that).
 
 ### Phase 5: Mark-sweep GC over arenas (was Phase 6): **LANDED (v1, manual trigger)**
 


### PR DESCRIPTION
Fixes #21704.

## Summary
- Adds `compiler3/corpus/go_kernels_fair_test.go` with nine `//go:noinline` shape-faithful Go reference kernels and `TestGoFairMatchesVm3` correctness gate.
- Records measured baseline in MEP-40 §9.9 (Apple M4, darwin/arm64): two kernels already inside or at 2x (strings_concat_loop 1.57x, maps_fill_sum 2.05x); arithmetic-pure kernels at 30-70x.
- Refines Phase 4 in §10 into six sub-phases (4.0 bench harness, 4.1 IR + AST, 4.2 opt passes, 4.3 regalloc, 4.4 emit, 4.5 Layer C OpFree, 4.6 BG admission) so the 2x-of-Go critical path is explicit.

## Why
The original `BenchmarkGoKernels` ran vm3 against `compiler2/corpus.Expect*` helpers, several of which are closed-form (`(n-1)*n/2`, `n+1`, `n*(n-1)/2`). The "vm3 vs Go" ratios under that harness compare a vm3 O(n) loop to a Go O(1) formula, which is not a baseline for any later phase. Phase 4 cannot be planned on top of a meaningless number.

## Test plan
- [x] `go test ./compiler3/corpus/... ./runtime/vm3/...` passes.
- [x] `TestGoFairMatchesVm3` matches vm3 output for every kernel across multiple N.
- [x] `BenchmarkGoKernelsFair` produces the table in §9.9.
- [x] Docusaurus build of `website/` parses MDX cleanly.