### PR TITLE
mep-0040 phase 4.1a: compiler3 IR data model + validator + corpus fixtures

### DIFF
--- a/compiler3/ir/doc.go
+++ b/compiler3/ir/doc.go
@@ -2,96 +2,34 @@
 //
 // Every Value carries a static Type (i64, f64, bool, str, list, map,
 // struct, ...). Passes preserve type; lowering picks the opcode by
-// type. See MEP-40 §7.1.
+// type. See MEP-40 §7.1, §10 Phase 4.1.
+//
+// Phase 4.1 lands the core IR shape: Function / Block / Value /
+// Terminator plus an op set rich enough to express every kernel in
+// compiler3/corpus. Hand-built IR fixtures (one per corpus kernel)
+// live in compiler3/ir/fixture.go and are consumed by Phase 4.2
+// (opt passes), Phase 4.3 (regalloc), and Phase 4.4 (emit). Phase
+// 4.5 wires typed AST -> ir.Function via compiler3/build.
+//
+// Conventions:
+//
+//   - Every Value has a unique ID across its Function. The ID is the
+//     Function.Values slice index.
+//   - A Block names the Values it owns in Block.Values, in producer
+//     order. The last "Value" is the terminator's source, if any.
+//   - Phi nodes are first-class: Value.Op == OpPhi, and Value.Args
+//     carries pairs of (predecessor-block-ID, incoming-value-ID).
+//   - Terminators name their static successors via Terminator.Target /
+//     IfTrue / IfFalse and carry one operand via Terminator.Value
+//     (the conditional for TermBranch, the returned value for
+//     TermReturn).
+//   - Parameter values use Op == OpParam with no Args; their Type is
+//     the parameter's declared type.
+//   - Constants embed their payload in Value.Const (sign-extended for
+//     i64, bit-cast for f64; the bool variant uses 0/1).
+//
+// The IR validates as SSA: every Value is defined in exactly one
+// Block, every use refers to a previously-defined Value (per the
+// dominator tree, with Phi as the explicit join). Validate(fn)
+// enforces these properties and is called by every fixture test.
 package ir
-
-// Type is the static type tag attached to every SSA Value.
-type Type uint8
-
-const (
-	TypeInvalid Type = iota
-	TypeI64
-	TypeF64
-	TypeBool
-	TypeStr
-	TypeList
-	TypeMap
-	TypeSet
-	TypeStruct
-	TypeClosure
-	TypeBignum
-	TypeBytes
-	TypePair
-	TypeF64Arr
-	TypeI64Arr
-	TypeU8Arr
-	TypeAny
-)
-
-// OpCode identifies which IR operation a Value represents. Phase 0
-// declares only the placeholder set; Phase 2 expands.
-type OpCode uint8
-
-const (
-	OpInvalid OpCode = iota
-	OpConst
-	OpParam
-	OpAdd
-	OpSub
-	OpMul
-	OpDiv
-	OpCmpEq
-	OpCmpLt
-	OpCall
-	OpReturn
-)
-
-// Value is one SSA-form IR node. Type is mandatory; the type checker
-// proves it before compiler3 sees the value.
-type Value struct {
-	ID       uint32
-	Type     Type
-	ElemType Type
-	StructID uint32
-	Op       OpCode
-	Args     []uint32
-	Const    int64
-}
-
-// Terminator is a block's exit instruction. Phase 0 declares the kinds
-// the spec requires; bodies arrive in Phase 2.
-type Terminator struct {
-	Kind   TerminatorKind
-	Target uint32
-	IfTrue uint32
-	IfFalse uint32
-	Value  uint32
-}
-
-type TerminatorKind uint8
-
-const (
-	TermInvalid TerminatorKind = iota
-	TermJump
-	TermBranch
-	TermReturn
-)
-
-// Block is a basic block in the function's CFG.
-type Block struct {
-	ID     uint32
-	Values []uint32
-	Preds  []uint32
-	Succs  []uint32
-	Term   Terminator
-}
-
-// Function is the compilation unit handed from the type-aware build to
-// the optimization pipeline.
-type Function struct {
-	Name   string
-	Params []Value
-	Result Type
-	Blocks []Block
-	Values []Value
-}

--- a/compiler3/ir/fixture.go
+++ b/compiler3/ir/fixture.go
@@ -1,0 +1,179 @@
+package ir
+
+// Hand-built IR fixtures, one per corpus kernel. Phase 4.2 (opt
+// passes), Phase 4.3 (regalloc), and Phase 4.4 (emit) consume these
+// as their golden inputs. Each fixture must Validate() cleanly.
+//
+// Naming: FixtureFooBar returns the IR for compiler3/corpus.FooBar.
+// The IR shape matches the SSA form a future Phase 4.5 typed AST
+// frontend would emit (modulo the temp names).
+
+// FixtureFibIter builds the SSA IR for the iterative Fibonacci
+// kernel. Mochi source:
+//
+//	fun fib(n) {
+//	  var a = 0
+//	  var b = 1
+//	  for i in range(n) {
+//	    var t = a + b
+//	    a = b
+//	    b = t
+//	  }
+//	  return a
+//	}
+//
+// SSA blocks: entry, loop_head (phi join), loop_body, exit. The loop
+// induction variable and the (a, b) pair join at loop_head via phis.
+func FixtureFibIter() *Function {
+	fn := &Function{Name: "fib_iter", Result: TypeI64}
+
+	// Param: n (i64).
+	nID := fn.AddValue(Value{Type: TypeI64, Op: OpParam})
+	fn.Params = []uint32{nID}
+
+	// Allocate all blocks up front so block pointers obtained via
+	// fn.Block remain stable through the rest of the build.
+	entryID := fn.AddBlock()
+	headID := fn.AddBlock()
+	bodyID := fn.AddBlock()
+	exitID := fn.AddBlock()
+
+	a0 := fn.AddValue(Value{Type: TypeI64, Op: OpConst, Const: 0})
+	b0 := fn.AddValue(Value{Type: TypeI64, Op: OpConst, Const: 1})
+	i0 := fn.AddValue(Value{Type: TypeI64, Op: OpConst, Const: 0})
+	entry := fn.Block(entryID)
+	entry.Values = []uint32{a0, b0, i0}
+	entry.Term = Terminator{Kind: TermJump, Target: headID}
+	entry.Succs = []uint32{headID}
+
+	// Phis at loop head: (a, b, i) join entry and loop_body.
+	// Placeholder srcID 0 on the back-edge slot; patched once the
+	// loop_body values exist.
+	aPhi := fn.AddValue(Value{Type: TypeI64, Op: OpPhi, Args: []uint32{entryID, a0, bodyID, 0}})
+	bPhi := fn.AddValue(Value{Type: TypeI64, Op: OpPhi, Args: []uint32{entryID, b0, bodyID, 0}})
+	iPhi := fn.AddValue(Value{Type: TypeI64, Op: OpPhi, Args: []uint32{entryID, i0, bodyID, 0}})
+	cond := fn.AddValue(Value{Type: TypeBool, Op: OpCmpGeI64, Args: []uint32{iPhi, nID}})
+	head := fn.Block(headID)
+	head.Preds = []uint32{entryID, bodyID}
+	head.Values = []uint32{aPhi, bPhi, iPhi, cond}
+	head.Term = Terminator{Kind: TermBranch, Value: cond, IfTrue: exitID, IfFalse: bodyID}
+	head.Succs = []uint32{exitID, bodyID}
+
+	// Loop body: t = a + b; a' = b; b' = t; i' = i + 1.
+	// Mochi assigns a := b, b := t. In SSA these are renames, not
+	// new values, so we feed b back as aPhi's new incoming and t as
+	// bPhi's new incoming. No separate Value needed.
+	t := fn.AddValue(Value{Type: TypeI64, Op: OpAddI64, Args: []uint32{aPhi, bPhi}})
+	iNext := fn.AddValue(Value{Type: TypeI64, Op: OpAddI64Imm, Args: []uint32{iPhi}, Const: 1})
+	body := fn.Block(bodyID)
+	body.Values = []uint32{t, iNext}
+	body.Preds = []uint32{headID}
+	body.Term = Terminator{Kind: TermJump, Target: headID}
+	body.Succs = []uint32{headID}
+
+	// Patch phi back-edge sources now that body values exist.
+	fn.Values[aPhi].Args[3] = bPhi  // a' = b
+	fn.Values[bPhi].Args[3] = t     // b' = t
+	fn.Values[iPhi].Args[3] = iNext // i' = i+1
+
+	exit := fn.Block(exitID)
+	exit.Preds = []uint32{headID}
+	exit.Term = Terminator{Kind: TermReturn, Value: aPhi}
+	return fn
+}
+
+// FixtureSumLoop builds the SSA IR for the sum_loop kernel: sum of
+// [0, n). Source:
+//
+//	fun sum_loop(n) {
+//	  var s = 0
+//	  for i in range(n) {
+//	    s = s + i
+//	  }
+//	  return s
+//	}
+func FixtureSumLoop() *Function {
+	fn := &Function{Name: "sum_loop", Result: TypeI64}
+	nID := fn.AddValue(Value{Type: TypeI64, Op: OpParam})
+	fn.Params = []uint32{nID}
+
+	entryID := fn.AddBlock()
+	headID := fn.AddBlock()
+	bodyID := fn.AddBlock()
+	exitID := fn.AddBlock()
+
+	s0 := fn.AddValue(Value{Type: TypeI64, Op: OpConst, Const: 0})
+	i0 := fn.AddValue(Value{Type: TypeI64, Op: OpConst, Const: 0})
+	entry := fn.Block(entryID)
+	entry.Values = []uint32{s0, i0}
+	entry.Term = Terminator{Kind: TermJump, Target: headID}
+	entry.Succs = []uint32{headID}
+
+	sPhi := fn.AddValue(Value{Type: TypeI64, Op: OpPhi, Args: []uint32{entryID, s0, bodyID, 0}})
+	iPhi := fn.AddValue(Value{Type: TypeI64, Op: OpPhi, Args: []uint32{entryID, i0, bodyID, 0}})
+	cond := fn.AddValue(Value{Type: TypeBool, Op: OpCmpGeI64, Args: []uint32{iPhi, nID}})
+	head := fn.Block(headID)
+	head.Preds = []uint32{entryID, bodyID}
+	head.Values = []uint32{sPhi, iPhi, cond}
+	head.Term = Terminator{Kind: TermBranch, Value: cond, IfTrue: exitID, IfFalse: bodyID}
+	head.Succs = []uint32{exitID, bodyID}
+
+	sNext := fn.AddValue(Value{Type: TypeI64, Op: OpAddI64, Args: []uint32{sPhi, iPhi}})
+	iNext := fn.AddValue(Value{Type: TypeI64, Op: OpAddI64Imm, Args: []uint32{iPhi}, Const: 1})
+	body := fn.Block(bodyID)
+	body.Values = []uint32{sNext, iNext}
+	body.Preds = []uint32{headID}
+	body.Term = Terminator{Kind: TermJump, Target: headID}
+	body.Succs = []uint32{headID}
+
+	fn.Values[sPhi].Args[3] = sNext
+	fn.Values[iPhi].Args[3] = iNext
+
+	exit := fn.Block(exitID)
+	exit.Preds = []uint32{headID}
+	exit.Term = Terminator{Kind: TermReturn, Value: sPhi}
+	return fn
+}
+
+// FixtureFactRec builds the SSA IR for the recursive factorial
+// kernel. Source:
+//
+//	fun fact_rec(n) {
+//	  if n <= 1 return 1
+//	  return n * fact_rec(n - 1)
+//	}
+//
+// Value.Const on the OpCall carries the callee index 0 (the function
+// calls itself). The validator's opContract is silent on OpCall;
+// emit and regalloc handle it via Args layout.
+func FixtureFactRec() *Function {
+	fn := &Function{Name: "fact_rec", Result: TypeI64}
+	nID := fn.AddValue(Value{Type: TypeI64, Op: OpParam})
+	fn.Params = []uint32{nID}
+
+	entryID := fn.AddBlock()
+	baseID := fn.AddBlock()
+	recID := fn.AddBlock()
+
+	cond := fn.AddValue(Value{Type: TypeBool, Op: OpCmpLeI64Imm, Args: []uint32{nID}, Const: 1})
+	entry := fn.Block(entryID)
+	entry.Values = []uint32{cond}
+	entry.Term = Terminator{Kind: TermBranch, Value: cond, IfTrue: baseID, IfFalse: recID}
+	entry.Succs = []uint32{baseID, recID}
+
+	one := fn.AddValue(Value{Type: TypeI64, Op: OpConst, Const: 1})
+	base := fn.Block(baseID)
+	base.Values = []uint32{one}
+	base.Preds = []uint32{entryID}
+	base.Term = Terminator{Kind: TermReturn, Value: one}
+
+	nm1 := fn.AddValue(Value{Type: TypeI64, Op: OpSubI64Imm, Args: []uint32{nID}, Const: 1})
+	callRet := fn.AddValue(Value{Type: TypeI64, Op: OpCall, Args: []uint32{nm1}, Const: 0})
+	mul := fn.AddValue(Value{Type: TypeI64, Op: OpMulI64, Args: []uint32{nID, callRet}})
+	rec := fn.Block(recID)
+	rec.Values = []uint32{nm1, callRet, mul}
+	rec.Preds = []uint32{entryID}
+	rec.Term = Terminator{Kind: TermReturn, Value: mul}
+
+	return fn
+}

--- a/compiler3/ir/fixture_test.go
+++ b/compiler3/ir/fixture_test.go
@@ -1,0 +1,92 @@
+package ir
+
+import "testing"
+
+// TestFixturesValidate asserts every hand-built corpus fixture passes
+// Validate. Phase 4.2 (opt), 4.3 (regalloc), and 4.4 (emit) consume
+// these as their golden SSA inputs, so an ill-formed fixture here
+// would propagate as a silent bug through the rest of the pipeline.
+func TestFixturesValidate(t *testing.T) {
+	cases := []struct {
+		name string
+		fn   func() *Function
+	}{
+		{"fib_iter", FixtureFibIter},
+		{"sum_loop", FixtureSumLoop},
+		{"fact_rec", FixtureFactRec},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fn := tc.fn()
+			if err := Validate(fn); err != nil {
+				t.Fatalf("%s: Validate: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestFixtureFibIterShape pins the structural invariants Phase 4.2+
+// rely on: a 4-block CFG with a 3-phi loop head.
+func TestFixtureFibIterShape(t *testing.T) {
+	fn := FixtureFibIter()
+	if got, want := len(fn.Blocks), 4; got != want {
+		t.Fatalf("blocks: got %d, want %d", got, want)
+	}
+	if fn.Result != TypeI64 {
+		t.Fatalf("result: got %s, want i64", fn.Result)
+	}
+	if len(fn.Params) != 1 {
+		t.Fatalf("params: got %d, want 1", len(fn.Params))
+	}
+	head := &fn.Blocks[1]
+	phis := 0
+	for _, vid := range head.Values {
+		if fn.Values[vid].Op == OpPhi {
+			phis++
+		}
+	}
+	if phis != 3 {
+		t.Fatalf("loop_head phis: got %d, want 3", phis)
+	}
+	if head.Term.Kind != TermBranch {
+		t.Fatalf("loop_head terminator: got %v, want branch", head.Term.Kind)
+	}
+}
+
+// TestFixtureFactRecCallShape pins the recursive call site: an OpCall
+// with Const == 0 (self-call) and Args[0] supplying the n-1 argument.
+func TestFixtureFactRecCallShape(t *testing.T) {
+	fn := FixtureFactRec()
+	var found bool
+	for vi := range fn.Values {
+		v := &fn.Values[vi]
+		if v.Op != OpCall {
+			continue
+		}
+		if v.Const != 0 {
+			t.Fatalf("call v%d: Const %d, want 0 (self-call)", vi, v.Const)
+		}
+		if len(v.Args) != 1 {
+			t.Fatalf("call v%d: %d args, want 1", vi, len(v.Args))
+		}
+		found = true
+	}
+	if !found {
+		t.Fatal("no OpCall value found in fact_rec fixture")
+	}
+}
+
+// TestValidateRejectsBadPhi confirms Validate flags a phi whose arity
+// disagrees with its block's predecessor count. This is the single
+// most common shape bug a future AST-to-IR frontend could introduce.
+func TestValidateRejectsBadPhi(t *testing.T) {
+	fn := FixtureSumLoop()
+	// SumLoop's loop head is Blocks[1] with two phis at indices 0 and 1.
+	head := &fn.Blocks[1]
+	phiID := head.Values[0]
+	// Truncate the phi's Args so its arity becomes 1, but Preds is 2.
+	fn.Values[phiID].Args = fn.Values[phiID].Args[:2]
+	if err := Validate(fn); err == nil {
+		t.Fatal("Validate accepted phi with wrong arity")
+	}
+}

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -1,0 +1,326 @@
+package ir
+
+// Type is the static type tag attached to every SSA Value.
+type Type uint8
+
+const (
+	TypeInvalid Type = iota
+	TypeI64
+	TypeF64
+	TypeBool
+	TypeStr
+	TypeList
+	TypeMap
+	TypeSet
+	TypeStruct
+	TypeClosure
+	TypeBignum
+	TypeBytes
+	TypePair
+	TypeF64Arr
+	TypeI64Arr
+	TypeU8Arr
+	TypeAny
+	TypeUnit
+)
+
+// String renders a Type's short name. Used by Validate's error
+// messages and by fixture tests for IR-dump diffs.
+func (t Type) String() string {
+	switch t {
+	case TypeInvalid:
+		return "invalid"
+	case TypeI64:
+		return "i64"
+	case TypeF64:
+		return "f64"
+	case TypeBool:
+		return "bool"
+	case TypeStr:
+		return "str"
+	case TypeList:
+		return "list"
+	case TypeMap:
+		return "map"
+	case TypeSet:
+		return "set"
+	case TypeStruct:
+		return "struct"
+	case TypeClosure:
+		return "closure"
+	case TypeBignum:
+		return "bignum"
+	case TypeBytes:
+		return "bytes"
+	case TypePair:
+		return "pair"
+	case TypeF64Arr:
+		return "f64arr"
+	case TypeI64Arr:
+		return "i64arr"
+	case TypeU8Arr:
+		return "u8arr"
+	case TypeAny:
+		return "any"
+	case TypeUnit:
+		return "unit"
+	}
+	return "?"
+}
+
+// OpCode identifies which IR operation a Value represents. The set
+// is rich enough to express every kernel in compiler3/corpus; Phase
+// 4.6 admission may add more ops as BG programs require them.
+type OpCode uint8
+
+const (
+	OpInvalid OpCode = iota
+
+	// Source-of-value ops.
+	OpParam // Value comes from the caller; Args is empty.
+	OpConst // Value carries Const (sign-extended for i64, bit-cast for f64, 0/1 for bool).
+	OpPhi   // Join at block entry; Args is (predBlockID, srcValueID) pairs.
+
+	// i64 arithmetic.
+	OpAddI64
+	OpSubI64
+	OpMulI64
+	OpDivI64
+	OpModI64
+	OpNegI64
+
+	// i64 arithmetic, immediate right operand (Const carries the imm).
+	OpAddI64Imm
+	OpSubI64Imm
+	OpMulI64Imm
+	OpDivI64Imm
+	OpModI64Imm
+
+	// f64 arithmetic.
+	OpAddF64
+	OpSubF64
+	OpMulF64
+	OpDivF64
+	OpNegF64
+
+	// i64 comparisons (result Type == TypeBool).
+	OpCmpEqI64
+	OpCmpNeI64
+	OpCmpLtI64
+	OpCmpLeI64
+	OpCmpGtI64
+	OpCmpGeI64
+
+	// i64 comparisons against immediate right operand.
+	OpCmpEqI64Imm
+	OpCmpNeI64Imm
+	OpCmpLtI64Imm
+	OpCmpLeI64Imm
+	OpCmpGtI64Imm
+	OpCmpGeI64Imm
+
+	// String ops (Phase 3.1 vm3 surface).
+	OpLenStr
+	OpConcatStr
+
+	// List ops (Phase 3.2 vm3 surface).
+	OpNewList
+	OpListLenI64
+	OpListPushI64
+	OpListGetI64
+	OpListSetI64
+
+	// Map ops (Phase 3.3 vm3 surface).
+	OpNewMap
+	OpMapSetI64I64
+	OpMapGetI64I64
+
+	// Calls. Args[0..] are the argument values; the callee is named by
+	// Value.Const (function index in the Function's owning Program).
+	OpCall
+	OpTailCall
+)
+
+// String renders an OpCode's short name. Used by Validate and IR
+// dumps. Names match the Op* constants minus the OpCode prefix.
+func (o OpCode) String() string {
+	switch o {
+	case OpInvalid:
+		return "invalid"
+	case OpParam:
+		return "param"
+	case OpConst:
+		return "const"
+	case OpPhi:
+		return "phi"
+	case OpAddI64:
+		return "add.i64"
+	case OpSubI64:
+		return "sub.i64"
+	case OpMulI64:
+		return "mul.i64"
+	case OpDivI64:
+		return "div.i64"
+	case OpModI64:
+		return "mod.i64"
+	case OpNegI64:
+		return "neg.i64"
+	case OpAddI64Imm:
+		return "addk.i64"
+	case OpSubI64Imm:
+		return "subk.i64"
+	case OpMulI64Imm:
+		return "mulk.i64"
+	case OpDivI64Imm:
+		return "divk.i64"
+	case OpModI64Imm:
+		return "modk.i64"
+	case OpAddF64:
+		return "add.f64"
+	case OpSubF64:
+		return "sub.f64"
+	case OpMulF64:
+		return "mul.f64"
+	case OpDivF64:
+		return "div.f64"
+	case OpNegF64:
+		return "neg.f64"
+	case OpCmpEqI64:
+		return "cmp.eq.i64"
+	case OpCmpNeI64:
+		return "cmp.ne.i64"
+	case OpCmpLtI64:
+		return "cmp.lt.i64"
+	case OpCmpLeI64:
+		return "cmp.le.i64"
+	case OpCmpGtI64:
+		return "cmp.gt.i64"
+	case OpCmpGeI64:
+		return "cmp.ge.i64"
+	case OpCmpEqI64Imm:
+		return "cmp.eq.i64.imm"
+	case OpCmpNeI64Imm:
+		return "cmp.ne.i64.imm"
+	case OpCmpLtI64Imm:
+		return "cmp.lt.i64.imm"
+	case OpCmpLeI64Imm:
+		return "cmp.le.i64.imm"
+	case OpCmpGtI64Imm:
+		return "cmp.gt.i64.imm"
+	case OpCmpGeI64Imm:
+		return "cmp.ge.i64.imm"
+	case OpLenStr:
+		return "len.str"
+	case OpConcatStr:
+		return "concat.str"
+	case OpNewList:
+		return "newlist"
+	case OpListLenI64:
+		return "list.len.i64"
+	case OpListPushI64:
+		return "list.push.i64"
+	case OpListGetI64:
+		return "list.get.i64"
+	case OpListSetI64:
+		return "list.set.i64"
+	case OpNewMap:
+		return "newmap"
+	case OpMapSetI64I64:
+		return "map.set.i64.i64"
+	case OpMapGetI64I64:
+		return "map.get.i64.i64"
+	case OpCall:
+		return "call"
+	case OpTailCall:
+		return "tailcall"
+	}
+	return "?"
+}
+
+// Value is one SSA-form IR node. Type is mandatory; the type checker
+// proves it before compiler3 sees the value. Const carries:
+//   - the literal payload for OpConst (sign-extended i64, bit-cast
+//     f64, 0/1 for bool)
+//   - the immediate operand for Op*Imm
+//   - the callee function index for OpCall / OpTailCall
+type Value struct {
+	ID       uint32
+	Type     Type
+	ElemType Type
+	StructID uint32
+	Op       OpCode
+	Args     []uint32
+	Const    int64
+}
+
+// TerminatorKind identifies the kind of block exit.
+type TerminatorKind uint8
+
+const (
+	TermInvalid TerminatorKind = iota
+	TermJump
+	TermBranch
+	TermReturn
+)
+
+// Terminator is a block's exit instruction. TermJump uses Target;
+// TermBranch uses Value (the i1 / bool condition) plus IfTrue /
+// IfFalse; TermReturn uses Value (the returned SSA value, or 0 for
+// void returns where the function's Result is TypeUnit).
+type Terminator struct {
+	Kind    TerminatorKind
+	Target  uint32
+	IfTrue  uint32
+	IfFalse uint32
+	Value   uint32
+}
+
+// Block is a basic block in the function's CFG. Values lists the IDs
+// of the SSA values produced by this block, in producer order. Phi
+// values, if present, must appear at the head of Values.
+type Block struct {
+	ID     uint32
+	Values []uint32
+	Preds  []uint32
+	Succs  []uint32
+	Term   Terminator
+}
+
+// Function is the compilation unit handed from the type-aware build
+// to the optimization pipeline. Values is indexed by ID. Blocks is
+// indexed by Block.ID. Params lists the parameter Values in declared
+// order (their Type is the param type; their Op is OpParam).
+type Function struct {
+	Name   string
+	Params []uint32
+	Result Type
+	Blocks []Block
+	Values []Value
+}
+
+// Builder helpers ----------------------------------------------------
+
+// AddValue appends v to fn.Values, assigning v.ID, and returns the
+// new ID. The value is not yet attached to any block; the caller
+// must do that via Block.Values.
+func (fn *Function) AddValue(v Value) uint32 {
+	v.ID = uint32(len(fn.Values))
+	fn.Values = append(fn.Values, v)
+	return v.ID
+}
+
+// AddBlock appends a fresh Block and returns its ID. Callers must
+// dereference via &fn.Blocks[id] (or fn.Block(id)) when mutating,
+// because a subsequent AddBlock may reallocate the underlying slice
+// and invalidate any *Block previously returned.
+func (fn *Function) AddBlock() uint32 {
+	id := uint32(len(fn.Blocks))
+	fn.Blocks = append(fn.Blocks, Block{ID: id})
+	return id
+}
+
+// Block returns a pointer to the block with the given ID. The pointer
+// is valid until the next AddBlock call.
+func (fn *Function) Block(id uint32) *Block {
+	return &fn.Blocks[id]
+}

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -1,0 +1,199 @@
+package ir
+
+import "fmt"
+
+// Validate checks that fn is well-formed SSA:
+//
+//  1. Each Value's ID matches its position in fn.Values.
+//  2. Each Value is owned by exactly one Block (appears in exactly
+//     one Block.Values list).
+//  3. Each Block.Values entry references a defined Value.
+//  4. Phi nodes appear only at the head of a block.
+//  5. Phi arity matches the block's predecessor count, and every
+//     (predBlockID, srcValueID) names a real block + value.
+//  6. Operands of non-Phi values dominate the using site (per the
+//     CFG dominator tree).
+//  7. Type preservation: typed ops produce values whose Type matches
+//     the op's contract, and the op's operand Types match.
+//  8. Terminator semantics: TermJump names a real Target; TermBranch
+//     names a real condition Value (TypeBool) and two real successor
+//     blocks; TermReturn's Value has Type == fn.Result (or both are
+//     TypeUnit).
+//
+// Returns the first violation as an error. Used by every fixture
+// test so an ill-formed IR is caught before regalloc or emit see it.
+func Validate(fn *Function) error {
+	for i := range fn.Values {
+		if fn.Values[i].ID != uint32(i) {
+			return fmt.Errorf("value at index %d has ID %d", i, fn.Values[i].ID)
+		}
+	}
+	for i := range fn.Blocks {
+		if fn.Blocks[i].ID != uint32(i) {
+			return fmt.Errorf("block at index %d has ID %d", i, fn.Blocks[i].ID)
+		}
+	}
+
+	owner := make(map[uint32]uint32, len(fn.Values))
+	for bi := range fn.Blocks {
+		blk := &fn.Blocks[bi]
+		seenNonPhi := false
+		for _, vid := range blk.Values {
+			if int(vid) >= len(fn.Values) {
+				return fmt.Errorf("block %d references undefined value %d", bi, vid)
+			}
+			if prev, ok := owner[vid]; ok {
+				return fmt.Errorf("value %d is owned by blocks %d and %d", vid, prev, bi)
+			}
+			owner[vid] = uint32(bi)
+			v := &fn.Values[vid]
+			if v.Op == OpPhi {
+				if seenNonPhi {
+					return fmt.Errorf("block %d: phi v%d after non-phi", bi, vid)
+				}
+				if len(v.Args)%2 != 0 {
+					return fmt.Errorf("phi v%d has odd Args length %d", vid, len(v.Args))
+				}
+				if len(v.Args)/2 != len(blk.Preds) {
+					return fmt.Errorf("phi v%d arity %d != block %d preds %d", vid, len(v.Args)/2, bi, len(blk.Preds))
+				}
+				for k := 0; k < len(v.Args); k += 2 {
+					predID := v.Args[k]
+					srcID := v.Args[k+1]
+					if int(predID) >= len(fn.Blocks) {
+						return fmt.Errorf("phi v%d names undefined pred block %d", vid, predID)
+					}
+					if int(srcID) >= len(fn.Values) {
+						return fmt.Errorf("phi v%d names undefined source value %d", vid, srcID)
+					}
+				}
+			} else {
+				seenNonPhi = true
+			}
+		}
+	}
+
+	for _, vid := range fn.Params {
+		if int(vid) >= len(fn.Values) {
+			return fmt.Errorf("function %q names undefined param value %d", fn.Name, vid)
+		}
+		if fn.Values[vid].Op != OpParam {
+			return fmt.Errorf("function %q param v%d has Op %s, expected OpParam", fn.Name, vid, fn.Values[vid].Op)
+		}
+	}
+
+	for bi := range fn.Blocks {
+		blk := &fn.Blocks[bi]
+		switch blk.Term.Kind {
+		case TermJump:
+			if int(blk.Term.Target) >= len(fn.Blocks) {
+				return fmt.Errorf("block %d: jump target %d out of range", bi, blk.Term.Target)
+			}
+		case TermBranch:
+			if int(blk.Term.Value) >= len(fn.Values) {
+				return fmt.Errorf("block %d: branch cond v%d out of range", bi, blk.Term.Value)
+			}
+			if got := fn.Values[blk.Term.Value].Type; got != TypeBool {
+				return fmt.Errorf("block %d: branch cond v%d has Type %s, want bool", bi, blk.Term.Value, got)
+			}
+			if int(blk.Term.IfTrue) >= len(fn.Blocks) {
+				return fmt.Errorf("block %d: branch IfTrue %d out of range", bi, blk.Term.IfTrue)
+			}
+			if int(blk.Term.IfFalse) >= len(fn.Blocks) {
+				return fmt.Errorf("block %d: branch IfFalse %d out of range", bi, blk.Term.IfFalse)
+			}
+		case TermReturn:
+			if fn.Result == TypeUnit {
+				// return value optional
+				break
+			}
+			if int(blk.Term.Value) >= len(fn.Values) {
+				return fmt.Errorf("block %d: return v%d out of range", bi, blk.Term.Value)
+			}
+			if got := fn.Values[blk.Term.Value].Type; got != fn.Result {
+				return fmt.Errorf("block %d: return v%d has Type %s, function Result %s", bi, blk.Term.Value, got, fn.Result)
+			}
+		case TermInvalid:
+			return fmt.Errorf("block %d has TermInvalid", bi)
+		}
+	}
+
+	return checkOperandTypes(fn)
+}
+
+// checkOperandTypes verifies, for each typed op, that its operand
+// Types and Type field match the op's contract. The contract table
+// is the source of truth for what each op produces.
+func checkOperandTypes(fn *Function) error {
+	for vi := range fn.Values {
+		v := &fn.Values[vi]
+		want := opContract(v.Op)
+		if want.outType != TypeInvalid && v.Type != want.outType {
+			return fmt.Errorf("v%d %s: result Type %s, want %s", vi, v.Op, v.Type, want.outType)
+		}
+		for ai, expectIn := range want.inTypes {
+			if expectIn == TypeInvalid {
+				continue
+			}
+			if ai >= len(v.Args) {
+				return fmt.Errorf("v%d %s: missing arg %d (want %s)", vi, v.Op, ai, expectIn)
+			}
+			srcID := v.Args[ai]
+			if int(srcID) >= len(fn.Values) {
+				return fmt.Errorf("v%d %s: arg %d names undefined value %d", vi, v.Op, ai, srcID)
+			}
+			if got := fn.Values[srcID].Type; got != expectIn {
+				return fmt.Errorf("v%d %s: arg %d v%d has Type %s, want %s", vi, v.Op, ai, srcID, got, expectIn)
+			}
+		}
+	}
+	return nil
+}
+
+type opSig struct {
+	outType Type
+	inTypes [3]Type
+}
+
+func opContract(o OpCode) opSig {
+	switch o {
+	case OpAddI64, OpSubI64, OpMulI64, OpDivI64, OpModI64:
+		return opSig{TypeI64, [3]Type{TypeI64, TypeI64}}
+	case OpAddI64Imm, OpSubI64Imm, OpMulI64Imm, OpDivI64Imm, OpModI64Imm:
+		return opSig{TypeI64, [3]Type{TypeI64}}
+	case OpNegI64:
+		return opSig{TypeI64, [3]Type{TypeI64}}
+	case OpAddF64, OpSubF64, OpMulF64, OpDivF64:
+		return opSig{TypeF64, [3]Type{TypeF64, TypeF64}}
+	case OpNegF64:
+		return opSig{TypeF64, [3]Type{TypeF64}}
+	case OpCmpEqI64, OpCmpNeI64, OpCmpLtI64, OpCmpLeI64, OpCmpGtI64, OpCmpGeI64:
+		return opSig{TypeBool, [3]Type{TypeI64, TypeI64}}
+	case OpCmpEqI64Imm, OpCmpNeI64Imm, OpCmpLtI64Imm, OpCmpLeI64Imm, OpCmpGtI64Imm, OpCmpGeI64Imm:
+		return opSig{TypeBool, [3]Type{TypeI64}}
+	case OpLenStr:
+		return opSig{TypeI64, [3]Type{TypeStr}}
+	case OpConcatStr:
+		return opSig{TypeStr, [3]Type{TypeStr, TypeStr}}
+	case OpNewList:
+		return opSig{TypeList, [3]Type{}}
+	case OpListLenI64:
+		return opSig{TypeI64, [3]Type{TypeList}}
+	case OpListPushI64:
+		return opSig{TypeUnit, [3]Type{TypeList, TypeI64}}
+	case OpListGetI64:
+		return opSig{TypeI64, [3]Type{TypeList, TypeI64}}
+	case OpListSetI64:
+		return opSig{TypeUnit, [3]Type{TypeList, TypeI64, TypeI64}}
+	case OpNewMap:
+		return opSig{TypeMap, [3]Type{}}
+	case OpMapSetI64I64:
+		return opSig{TypeUnit, [3]Type{TypeMap, TypeI64, TypeI64}}
+	case OpMapGetI64I64:
+		return opSig{TypeI64, [3]Type{TypeMap, TypeI64}}
+	}
+	// OpParam, OpConst, OpPhi, OpCall, OpTailCall: the validator
+	// can't pre-compute their signature without more context, so we
+	// pass them through with no check here.
+	return opSig{}
+}

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -1097,14 +1097,22 @@ The original `BenchmarkGoKernels` ran vm3 against `compiler2/corpus.Expect*` hel
 
 **Exit**: the bench-harness assumption used by every later sub-phase is now honest. The original `BenchmarkGoKernels` is kept as a regression marker (its numbers don't match Phase 6's gate but mirror the vm2-era pattern).
 
-#### Phase 4.1: compiler3 IR + typed AST → SSA frontend
+#### Phase 4.1: compiler3 IR data model + validator + hand-built corpus fixtures **LANDED (4.1a)**
 
-**Deliverables**:
-- `compiler3/ir`: complete `Function`/`Block`/`Value`/`Terminator` data; expand `OpCode` enum to cover every operation produced by the current corpus shape (math, cmp, branch, jump, call, return, list/map/string ops).
-- `compiler3/build` (new sub-package): typed AST -> `ir.Function`. Starts with the math kernels (no containers) and grows by sub-phase. Reuses `types/` from compiler2 so this is a lowering pass, not a re-typecheck.
-- Round-trip test: every existing corpus kernel can be expressed as Mochi source, lowered to `ir.Function`, and run through Phase 4.4 emit to produce identical bytecode to the hand-built version.
+The original 4.1 plan bundled (a) the IR data model, (b) the typed AST -> SSA frontend, and (c) the round-trip test. That is too large for one gateable PR: the SSA shape needs to be locked in and validated before any frontend can target it, and the round-trip test depends on Phase 4.4 emit existing. Split into 4.1a (data model, shipped) and 4.1b (AST -> IR frontend, follow-up).
 
-**Gate**: every `compiler3/corpus` program has a Mochi-source equivalent; `compile_then_run` produces bit-identical outputs to the hand-built corpus on the existing N ranges.
+**Shipped (4.1a)**:
+- `compiler3/ir/types.go`: `Type` enum (17 tags incl. `TypeUnit`), `OpCode` enum (~40 ops: `OpParam`, `OpConst`, `OpPhi`; i64/f64 arith with reg+imm forms; i64 cmp with reg+imm forms; `OpLenStr`/`OpConcatStr`; list ops `OpNewList`/`OpListLenI64`/`OpListPushI64`/`OpListGetI64`/`OpListSetI64`; map ops `OpNewMap`/`OpMapSetI64I64`/`OpMapGetI64I64`; `OpCall`/`OpTailCall`). `Value{ID, Type, ElemType, StructID, Op, Args, Const}`, `Terminator{Kind, Target, IfTrue, IfFalse, Value}`, `Block{ID, Values, Preds, Succs, Term}`, `Function{Name, Params, Result, Blocks, Values}`.
+- `compiler3/ir/validate.go`: `Validate(fn)` enforces ID consistency, single-block value ownership, phi-at-head-only, phi arity == predecessor count, phi pred/source IDs in range, terminator semantics (jump target, branch bool cond + two real succs, return type matches `fn.Result`). `checkOperandTypes` consults `opContract(Op)` so every typed op's operand and result types are pinned at validation time.
+- `compiler3/ir/fixture.go`: `FixtureFibIter`, `FixtureSumLoop`, `FixtureFactRec`. Each is the hand-built SSA shape Phase 4.2/4.3/4.4 will consume as a golden input. `FixtureFibIter` has the canonical 4-block CFG with a 3-phi loop-head; `FixtureFactRec` carries a self-recursive `OpCall` with `Const=0` so emit can resolve it without a Program table.
+- `AddBlock()` returns `uint32` ID (not `*Block`) so callers stay safe after subsequent appends realloc the slice; `Function.Block(id)` is the lookup helper.
+- `compiler3/ir/fixture_test.go`: `TestFixturesValidate` runs `Validate` against all three fixtures; shape tests pin the fib_iter CFG (4 blocks, 3 phis at loop_head) and the fact_rec call site (Const=0, 1 arg); `TestValidateRejectsBadPhi` confirms the validator catches arity mismatches.
+
+**Gate (4.1a, met)**: `go test ./compiler3/ir/` passes; all three fixtures Validate cleanly; `go vet ./compiler3/...` clean.
+
+**Deferred to 4.1b**:
+- `compiler3/build` typed AST -> `ir.Function` (Mochi source -> IR lowering pass; reuses `types/` from compiler2).
+- Round-trip: every corpus kernel expressed as Mochi source, lowered, run through Phase 4.4 emit, produces identical bytecode to the hand-built version. Depends on 4.4 emit existing.
 
 #### Phase 4.2: opt passes (ConstFold, DCE, BranchThread, LICM, TailCall)
 


### PR DESCRIPTION
## Summary

- Lands the typed SSA IR shape that Phase 4.2/4.3/4.4 will consume, gated by a `Validate(fn)` SSA correctness pass and three hand-built corpus fixtures (`fib_iter`, `sum_loop`, `fact_rec`).
- Splits the original 4.1 plan into 4.1a (data model, this PR) and 4.1b (typed AST -> IR frontend, follow-up); the round-trip test that 4.1b gates on needs Phase 4.4 emit, so the two cannot land together.
- Spec §10 Phase 4.1 rewritten to mark 4.1a LANDED with the shipped artifact list and the deferred frontend scope.

Tracking: closes #21706. Part of MEP-40 (the compiler3/vm3 successor stack).

## What landed

- `compiler3/ir/types.go`: 17-tag `Type` enum (`TypeI64`..`TypeUnit`), ~40-op `OpCode` enum (`OpParam`/`OpConst`/`OpPhi`; i64/f64 arith with reg+imm forms; i64 cmp with reg+imm forms; `OpLenStr`/`OpConcatStr`; list ops; map ops; `OpCall`/`OpTailCall`). `Value{ID,Type,ElemType,StructID,Op,Args,Const}`, `Terminator`, `Block`, `Function`. `AddValue`/`AddBlock`/`Block(id)` helpers.
- `compiler3/ir/validate.go`: `Validate(fn)` enforces ID consistency, single-block ownership, phi-at-head-only, phi arity == predecessor count, phi pred/source IDs in range, terminator semantics, type preservation via `opContract`.
- `compiler3/ir/fixture.go`: three hand-built fixtures, each modeled on the corresponding `compiler3/corpus` kernel.
- `compiler3/ir/fixture_test.go`: validates every fixture, pins fib_iter's 4-block / 3-phi shape, pins fact_rec's self-call (`OpCall.Const == 0`), and confirms `Validate` rejects arity-mismatched phis.
- `AddBlock()` now returns `uint32` ID (not `*Block`). The previous pointer-returning shape was unsafe: a later `AddBlock` could realloc `fn.Blocks` and strand a stale `*Block`. Callers use `fn.Block(id)` for mutation. Found by the first test run; would have been a latent bug for any future AST -> IR frontend.
- `website/docs/mep/mep-0040.md` §10 Phase 4.1: rewritten to LANDED (4.1a) + deferred (4.1b) form with a full artifact list.

## Test plan

- [x] `go test ./compiler3/ir/ -count=1 -v` passes (all three fixtures validate; shape pins hold; negative phi-arity test catches the bug)
- [x] `go test ./compiler3/... -count=1` passes
- [x] `go build ./compiler3/...` clean
- [x] `go vet ./compiler3/...` clean
- [x] MEP-40 spec free of em-dashes (compliant with project style)