### PR TITLE
mep-0040 phase 6.0: vm3jit AArch64 baseline puts sum_loop at Go parity

### DIFF
--- a/runtime/jit/vm3jit/arch.go
+++ b/runtime/jit/vm3jit/arch.go
@@ -1,0 +1,12 @@
+package vm3jit
+
+// Arch identifies a JIT backend target. vm3jit Phase 6.0 only supports
+// ArchARM64; the value space is shared with vm2jit so future code that
+// routes both JITs can use the same constants.
+type Arch int8
+
+const (
+	ArchUnsupported Arch = -1
+	ArchARM64       Arch = 0
+	ArchAMD64       Arch = 1
+)

--- a/runtime/jit/vm3jit/arch_arm64.go
+++ b/runtime/jit/vm3jit/arch_arm64.go
@@ -1,0 +1,5 @@
+//go:build arm64
+
+package vm3jit
+
+const hostArch Arch = ArchARM64

--- a/runtime/jit/vm3jit/arch_other.go
+++ b/runtime/jit/vm3jit/arch_other.go
@@ -1,0 +1,5 @@
+//go:build !arm64
+
+package vm3jit
+
+const hostArch Arch = ArchUnsupported

--- a/runtime/jit/vm3jit/bench_darwin_arm64_test.go
+++ b/runtime/jit/vm3jit/bench_darwin_arm64_test.go
@@ -1,0 +1,88 @@
+//go:build darwin && arm64
+
+package vm3jit_test
+
+import (
+	"testing"
+	"unsafe"
+
+	"mochi/compiler3/corpus"
+	"mochi/runtime/jit/vm2jit/trampoline"
+	"mochi/runtime/jit/vm3jit"
+	"mochi/runtime/vm3"
+)
+
+// goSumLoopBench is a //go:noinline copy of the same kernel the
+// "fair" Go baseline uses. Re-declared here so the bench in this
+// package does not need to import the compiler3/corpus tests file.
+//
+//go:noinline
+func goSumLoopBench(n int64) int64 {
+	var s int64
+	for i := int64(0); i < n; i++ {
+		s += i
+	}
+	return s
+}
+
+// vm3jitSink defeats dead-store elimination across the bench loops.
+var vm3jitSink int64
+
+// BenchmarkSumLoopJIT measures the JIT'd sum_loop at the same N
+// the fair-Go bench uses (10001). Compare its ns/op against
+// BenchmarkSumLoopGoFair to compute the vm3jit / Go ratio. Phase 6.0
+// gate: this ratio must be < 2x on the n=10001 case.
+func BenchmarkSumLoopJIT(b *testing.B) {
+	prog := corpus.SumLoop.Build(0)
+	fn := prog.Funcs[prog.Entry]
+	cf, err := vm3jit.Compile(fn)
+	if err != nil {
+		b.Fatalf("Compile: %v", err)
+	}
+	defer cf.Free()
+	entry := cf.Entry()
+
+	const n = int64(10001)
+	var regs [vm3jit.MaxI64Regs]int64
+	var s int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		regs[0] = n + int64(i&1)
+		s += int64(trampoline.Call(entry, unsafe.Pointer(&regs[0])))
+	}
+	vm3jitSink = s
+}
+
+// BenchmarkSumLoopGoFair is the apples-to-apples Go baseline that
+// BenchmarkSumLoopJIT compares against. Same N, same parity-perturbed
+// input, same package-global sink. Mirrors the shape of
+// compiler3/corpus.BenchmarkGoKernelsFair/sum_loop_n10001.
+func BenchmarkSumLoopGoFair(b *testing.B) {
+	const n = int64(10001)
+	var s int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s += goSumLoopBench(n + int64(i&1))
+	}
+	vm3jitSink = s
+}
+
+// BenchmarkSumLoopInterp measures the vm3 interpreter on the same
+// kernel and N so we can quote "interpreter vs JIT" and "JIT vs Go"
+// in the same units.
+func BenchmarkSumLoopInterp(b *testing.B) {
+	prog := corpus.SumLoop.Build(0)
+	fn := prog.Funcs[prog.Entry]
+	vm := vm3.NewWithProgram(prog)
+	const n = int64(10001)
+	var s int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := vm.RunWithArgs(fn, []int64{n + int64(i&1)})
+		if err != nil {
+			b.Fatalf("RunWithArgs: %v", err)
+		}
+		s += got.Int()
+	}
+	vm3jitSink = s
+}

--- a/runtime/jit/vm3jit/cache.go
+++ b/runtime/jit/vm3jit/cache.go
@@ -1,0 +1,28 @@
+package vm3jit
+
+import (
+	"encoding/binary"
+	"unsafe"
+)
+
+// pageAlloc reserves an OS page large enough for nBytes of native
+// code. The page is RW but not yet executable.
+func pageAlloc(nBytes int) ([]byte, error) {
+	return pageAllocOS(nBytes)
+}
+
+// pageWrite copies words into page and flips it to RX. words is a
+// little-endian-packed AArch64 instruction stream.
+func pageWrite(page []byte, words []uint32) error {
+	buf := make([]byte, len(words)*4)
+	for i, w := range words {
+		binary.LittleEndian.PutUint32(buf[i*4:], w)
+	}
+	return pageMakeExecOS(page, buf)
+}
+
+// pageFree releases a page from pageAlloc.
+func pageFree(page []byte) error { return pageFreeOS(page) }
+
+// pageEntry returns the entry address for the trampoline.
+func pageEntry(page []byte) unsafe.Pointer { return unsafe.Pointer(&page[0]) }

--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -1,0 +1,87 @@
+package vm3jit
+
+import (
+	"errors"
+	"fmt"
+	"unsafe"
+
+	"mochi/runtime/vm3"
+)
+
+// ErrUnsupported is returned by Compile on architectures that have no
+// vm3jit backend.
+var ErrUnsupported = errors.New("vm3jit: no backend for this architecture")
+
+// ErrNotImplemented is returned by Compile when fn uses an opcode,
+// register count, or bank shape outside the current backend's scope.
+// Callers fall back to the vm3 interpreter.
+var ErrNotImplemented = errors.New("vm3jit: not implemented")
+
+// maxI64Regs is the Phase 6.0 cap on simultaneously live i64
+// registers. x9..x15 are AArch64 caller-saved temps; the function
+// body owns all seven without a prologue/epilogue frame save. Phase
+// 6.1 lifts the cap by pushing callee-saved x19..x28 (mirroring
+// vm2jit MEP-39 §6.14 Phase B).
+const maxI64Regs = 7
+
+// CompiledFunc is a handle to a vm3jit-compiled function. It owns the
+// executable page and must be freed via Free when the function is
+// unloaded.
+type CompiledFunc struct {
+	fn   *vm3.Function
+	code []byte
+}
+
+// CodeLen returns the size of the JIT'd code in bytes.
+func (c *CompiledFunc) CodeLen() int { return len(c.code) }
+
+// Entry returns the executable entry pointer to be passed as the
+// first argument of trampoline.Call.
+func (c *CompiledFunc) Entry() unsafe.Pointer { return pageEntry(c.code) }
+
+// MaxI64Regs is the cap on simultaneously-live i64 registers Phase
+// 6.0 supports. Exported so tests and callers can size their reg
+// scratch buffers correctly.
+const MaxI64Regs = maxI64Regs
+
+// Free releases the executable page.
+func (c *CompiledFunc) Free() error {
+	if c.code == nil {
+		return nil
+	}
+	err := pageFree(c.code)
+	c.code = nil
+	return err
+}
+
+// Compile lowers fn to native code for the host architecture and
+// returns the handle. Phase 6.0 only accepts i64-only functions whose
+// opcode set is covered by lower_arm64. Anything else returns
+// ErrNotImplemented so callers can fall back to the interpreter
+// cleanly.
+func Compile(fn *vm3.Function) (*CompiledFunc, error) {
+	if hostArch != ArchARM64 {
+		return nil, ErrUnsupported
+	}
+	if fn.NumRegsF64 != 0 || fn.NumRegsCell != 0 {
+		return nil, fmt.Errorf("%w: %s has non-i64 bank usage (F64=%d Cell=%d)",
+			ErrNotImplemented, fn.Name, fn.NumRegsF64, fn.NumRegsCell)
+	}
+	if fn.NumRegsI64 > maxI64Regs {
+		return nil, fmt.Errorf("%w: %s uses %d i64 regs (max %d in 6.0)",
+			ErrNotImplemented, fn.Name, fn.NumRegsI64, maxI64Regs)
+	}
+	words, err := lowerARM64(fn)
+	if err != nil {
+		return nil, err
+	}
+	page, err := pageAlloc(len(words) * 4)
+	if err != nil {
+		return nil, err
+	}
+	if err := pageWrite(page, words); err != nil {
+		_ = pageFree(page)
+		return nil, err
+	}
+	return &CompiledFunc{fn: fn, code: page}, nil
+}

--- a/runtime/jit/vm3jit/doc.go
+++ b/runtime/jit/vm3jit/doc.go
@@ -1,0 +1,31 @@
+// Package vm3jit is the MEP-40 Phase 6 baseline JIT for the vm3
+// interpreter.
+//
+// Strategy mirrors vm2jit (MEP-34) but adapted for vm3's three typed
+// register banks: i64 values live in a contiguous int64 stack, f64 in
+// a float64 stack, Cells in a Cell stack. vm3jit pins active i64
+// registers into AArch64 GPRs at function entry and operates entirely
+// on raw 64-bit integers in the body, with no NaN-boxing or tag
+// arithmetic. This is the central simplification over vm2jit and the
+// reason a 2x-of-Go gate is reachable on arithmetic kernels.
+//
+// # Phase 6.0 scope (this iteration)
+//
+//   - AArch64 (Darwin) only.
+//   - i64-only kernels (NumRegsF64 == 0, NumRegsCell == 0).
+//   - Up to 7 i64 registers (x9..x15, caller-saved temps, no prologue
+//     frame save needed).
+//   - Six opcodes: OpConstI64K, OpAddI64, OpAddI64K, OpCmpGeI64Br,
+//     OpJump, OpReturnI64. Anything outside that set returns
+//     ErrNotImplemented and the caller falls back to the interpreter.
+//
+// The 6.0 cut targets one corpus kernel end-to-end (sum_loop). Once
+// it shows under 2x of Go, 6.1 extends the opcode and register set to
+// the rest of the arithmetic kernels.
+//
+// # Trampoline
+//
+// vm3jit reuses runtime/jit/vm2jit/trampoline as-is: the trampoline
+// ABI ("entry pointer + one pointer argument, result in x0") is
+// generic and contains no vm2-specific assumptions.
+package vm3jit

--- a/runtime/jit/vm3jit/lower_arm64.go
+++ b/runtime/jit/vm3jit/lower_arm64.go
@@ -1,0 +1,273 @@
+//go:build arm64
+
+package vm3jit
+
+import (
+	"fmt"
+
+	"mochi/runtime/vm3"
+)
+
+// Register pinning for Phase 6.0:
+//
+//	regsI64[r] -> x(9 + r)  for r in [0, maxI64Regs)
+//
+// x9..x15 are AArch64 caller-saved temporaries; the JIT can clobber
+// them freely without a callee-saved frame. x0 carries the regsI64
+// base pointer (set by the trampoline). x16/x17 are intra-procedure
+// scratches available to any encoder.
+//
+// vm3 i64 registers are stored as raw int64 (no NaN-box, no tag). A
+// single LDR/STR moves a value between the regsI64 stack window and
+// its pinned host register; arithmetic runs directly on the host
+// register with no tag arithmetic. This is the key simplification
+// over vm2jit and the reason a small instruction count per opcode is
+// achievable for arithmetic kernels.
+func r2x(r uint16) uint32 { return uint32(r) + 9 }
+
+// lowerARM64 returns the AArch64 instruction-word stream for fn. Two
+// passes: pass 1 computes pcMap[i] = word index where the lowering of
+// bytecode i starts; pass 2 emits real instructions, resolving branch
+// destinations through pcMap.
+func lowerARM64(fn *vm3.Function) ([]uint32, error) {
+	prologueWords := int(fn.NumRegsI64)
+
+	pcMap := make([]int, len(fn.Code)+1)
+	pcMap[0] = prologueWords
+	for i, op := range fn.Code {
+		n, err := wordCountARM64(op)
+		if err != nil {
+			return nil, fmt.Errorf("vm3jit/%s: pc %d: %w", fn.Name, i, err)
+		}
+		pcMap[i+1] = pcMap[i] + n
+	}
+
+	total := pcMap[len(fn.Code)]
+	ws := make([]uint32, 0, total)
+
+	for r := uint32(0); r < uint32(fn.NumRegsI64); r++ {
+		ws = append(ws, ldr64(r+9, 0, r))
+	}
+
+	for i, op := range fn.Code {
+		emit, err := emitInstrARM64(fn, op, i, pcMap)
+		if err != nil {
+			return nil, fmt.Errorf("vm3jit/%s: pc %d op=%d: %w", fn.Name, i, op.Code, err)
+		}
+		if got, want := len(emit), pcMap[i+1]-pcMap[i]; got != want {
+			return nil, fmt.Errorf("vm3jit/%s: pc %d op=%d: emitted %d words, predicted %d",
+				fn.Name, i, op.Code, got, want)
+		}
+		ws = append(ws, emit...)
+	}
+	if len(ws) != total {
+		return nil, fmt.Errorf("vm3jit/%s: final stream %d words, predicted %d",
+			fn.Name, len(ws), total)
+	}
+	return ws, nil
+}
+
+// wordCountARM64 returns the exact number of 32-bit words emitInstrARM64
+// will produce for op. Used by pass 1 to lay out pcMap.
+func wordCountARM64(op vm3.Op) (int, error) {
+	switch op.Code {
+	case vm3.OpConstI64K:
+		// movImm64 emits 1..4 movz/movk words depending on the sign-extended
+		// 16-bit constant. For C in [0, 65535] one movz; for negative values
+		// a movn or up to 4 movz/movk pairs.
+		return movImm64WordCount(int64(op.C)), nil
+	case vm3.OpAddI64:
+		return 1, nil
+	case vm3.OpAddI64K:
+		// Always lower as: MOV imm into x16; ADD xd, xn, x16. Total cost
+		// is movImm64 words + 1 ADD. Const range -32768..32767 (int16).
+		return movImm64WordCount(int64(op.C)) + 1, nil
+	case vm3.OpCmpGeI64Br:
+		return 2, nil
+	case vm3.OpJump:
+		return 1, nil
+	case vm3.OpReturnI64:
+		// MOV x0, xA; RET.
+		return 2, nil
+	default:
+		return 0, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
+	}
+}
+
+// emitInstrARM64 emits the AArch64 instructions for op at bytecode
+// index idx. pcMap[i] is the word offset where instruction i's
+// lowering begins (and pcMap[len(Code)] is the word offset of the
+// fall-through past the last instruction).
+func emitInstrARM64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int) ([]uint32, error) {
+	xA := r2x(op.A)
+	xB := r2x(op.B)
+
+	switch op.Code {
+	case vm3.OpConstI64K:
+		return movImm64(xA, int64(op.C)), nil
+
+	case vm3.OpAddI64:
+		// op.C is int16 storage but holds a uint16 register index.
+		xC := r2x(uint16(op.C))
+		return []uint32{addReg(xA, xB, xC)}, nil
+
+	case vm3.OpAddI64K:
+		ws := movImm64(16, int64(op.C))
+		ws = append(ws, addReg(xA, xB, 16))
+		return ws, nil
+
+	case vm3.OpCmpGeI64Br:
+		dstWord := pcMap[int(uint16(op.C))]
+		// CMP at pcMap[idx]; B.GE at pcMap[idx]+1.
+		srcWord := pcMap[idx] + 1
+		off, err := branchOff(srcWord, dstWord, 19)
+		if err != nil {
+			return nil, err
+		}
+		return []uint32{cmpReg(xA, xB), bCond(0xA /*GE*/, off)}, nil
+
+	case vm3.OpJump:
+		dstWord := pcMap[int(uint16(op.C))]
+		srcWord := pcMap[idx]
+		off, err := branchOff(srcWord, dstWord, 26)
+		if err != nil {
+			return nil, err
+		}
+		return []uint32{bImm(off)}, nil
+
+	case vm3.OpReturnI64:
+		return []uint32{movReg(0, xA), ret()}, nil
+
+	default:
+		_ = fn
+		return nil, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
+	}
+}
+
+// branchOff computes the signed instruction-word displacement from
+// srcWord (the word that contains the branch) to dstWord, and checks
+// that it fits in the given bit-width.
+func branchOff(srcWord, dstWord, bits int) (int32, error) {
+	diff := dstWord - srcWord
+	lim := 1 << (bits - 1)
+	if diff >= lim || diff < -lim {
+		return 0, fmt.Errorf("branch offset %d out of %d-bit range", diff, bits)
+	}
+	return int32(diff), nil
+}
+
+// --- AArch64 instruction encoders ---
+//
+// Mechanically these mirror vm2jit's encoders; vm3jit uses only the
+// subset needed for i64 arithmetic + control flow (no NaN-box dance,
+// no float, no list/map fast paths).
+
+func movz(xd, imm16, hw uint32) uint32 {
+	return 0xD2800000 | (hw << 21) | ((imm16 & 0xFFFF) << 5) | (xd & 0x1F)
+}
+
+func movk(xd, imm16, hw uint32) uint32 {
+	return 0xF2800000 | (hw << 21) | ((imm16 & 0xFFFF) << 5) | (xd & 0x1F)
+}
+
+func movn(xd, imm16, hw uint32) uint32 {
+	return 0x92800000 | (hw << 21) | ((imm16 & 0xFFFF) << 5) | (xd & 0x1F)
+}
+
+func addReg(xd, xn, xm uint32) uint32 {
+	return 0x8B000000 | ((xm & 0x1F) << 16) | ((xn & 0x1F) << 5) | (xd & 0x1F)
+}
+
+func cmpReg(xn, xm uint32) uint32 {
+	return 0xEB00001F | ((xm & 0x1F) << 16) | ((xn & 0x1F) << 5)
+}
+
+func movReg(xd, xm uint32) uint32 {
+	return 0xAA0003E0 | ((xm & 0x1F) << 16) | (xd & 0x1F)
+}
+
+func ldr64(xt, xn, imm12 uint32) uint32 {
+	return 0xF9400000 | ((imm12 & 0xFFF) << 10) | ((xn & 0x1F) << 5) | (xt & 0x1F)
+}
+
+func bImm(off26 int32) uint32 {
+	return 0x14000000 | uint32(off26&0x3FFFFFF)
+}
+
+func bCond(cond uint32, off19 int32) uint32 {
+	return 0x54000000 | (uint32(off19&0x7FFFF) << 5) | (cond & 0xF)
+}
+
+func ret() uint32 { return 0xD65F03C0 }
+
+// movImm64 emits the shortest movz/movn/movk sequence that loads v
+// into xd. Negative values prefer movn (one-instruction load for
+// -65536..-1 etc.); positive values use movz then movk for each
+// non-zero 16-bit lane. Result length is movImm64WordCount(v).
+func movImm64(xd uint32, v int64) []uint32 {
+	if v == 0 {
+		return []uint32{movz(xd, 0, 0)}
+	}
+	if v > 0 && v <= 0xFFFF {
+		return []uint32{movz(xd, uint32(v), 0)}
+	}
+	if v < 0 && v >= -0x10000 {
+		return []uint32{movn(xd, uint32(^v), 0)}
+	}
+	// General 4-lane build: emit movz for the first non-zero lane,
+	// then movk for every subsequent non-zero lane.
+	lanes := [4]uint32{
+		uint32(v) & 0xFFFF,
+		uint32(v>>16) & 0xFFFF,
+		uint32(v>>32) & 0xFFFF,
+		uint32(v>>48) & 0xFFFF,
+	}
+	ws := make([]uint32, 0, 4)
+	first := -1
+	for i, l := range lanes {
+		if l != 0 {
+			first = i
+			break
+		}
+	}
+	if first < 0 {
+		return []uint32{movz(xd, 0, 0)}
+	}
+	ws = append(ws, movz(xd, lanes[first], uint32(first)))
+	for i := first + 1; i < 4; i++ {
+		if lanes[i] != 0 {
+			ws = append(ws, movk(xd, lanes[i], uint32(i)))
+		}
+	}
+	return ws
+}
+
+// movImm64WordCount predicts the length of movImm64(xd, v) without
+// allocating. Must agree with movImm64 byte-for-byte.
+func movImm64WordCount(v int64) int {
+	if v == 0 {
+		return 1
+	}
+	if v > 0 && v <= 0xFFFF {
+		return 1
+	}
+	if v < 0 && v >= -0x10000 {
+		return 1
+	}
+	lanes := [4]uint32{
+		uint32(v) & 0xFFFF,
+		uint32(v>>16) & 0xFFFF,
+		uint32(v>>32) & 0xFFFF,
+		uint32(v>>48) & 0xFFFF,
+	}
+	n := 0
+	for _, l := range lanes {
+		if l != 0 {
+			n++
+		}
+	}
+	if n == 0 {
+		return 1
+	}
+	return n
+}

--- a/runtime/jit/vm3jit/lower_stub.go
+++ b/runtime/jit/vm3jit/lower_stub.go
@@ -1,0 +1,7 @@
+//go:build !arm64
+
+package vm3jit
+
+import "mochi/runtime/vm3"
+
+func lowerARM64(*vm3.Function) ([]uint32, error) { return nil, ErrUnsupported }

--- a/runtime/jit/vm3jit/page_darwin_arm64.go
+++ b/runtime/jit/vm3jit/page_darwin_arm64.go
@@ -1,0 +1,46 @@
+//go:build darwin && arm64
+
+package vm3jit
+
+/*
+#include <stdint.h>
+#include <pthread.h>
+#include <libkern/OSCacheControl.h>
+
+static void jwp(int enable) { pthread_jit_write_protect_np(enable); }
+static void icache(void *p, size_t n) { sys_icache_invalidate(p, n); }
+*/
+import "C"
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+const osPageSize = 16384
+const mapJIT = 0x0800
+
+func pageRound(n int) int { return (n + osPageSize - 1) &^ (osPageSize - 1) }
+
+func pageAllocOS(nBytes int) ([]byte, error) {
+	p, err := syscall.Mmap(-1, 0, pageRound(nBytes),
+		syscall.PROT_READ|syscall.PROT_WRITE,
+		syscall.MAP_ANON|syscall.MAP_PRIVATE|mapJIT)
+	if err != nil {
+		return nil, fmt.Errorf("vm3jit/page: mmap: %w", err)
+	}
+	return p, nil
+}
+
+func pageMakeExecOS(page, src []byte) error {
+	C.jwp(0)
+	copy(page, src)
+	C.jwp(1)
+	C.icache(unsafe.Pointer(&page[0]), C.size_t(len(src)))
+	if err := syscall.Mprotect(page, syscall.PROT_READ|syscall.PROT_EXEC); err != nil {
+		return fmt.Errorf("vm3jit/page: mprotect: %w", err)
+	}
+	return nil
+}
+
+func pageFreeOS(page []byte) error { return syscall.Munmap(page) }

--- a/runtime/jit/vm3jit/page_stub.go
+++ b/runtime/jit/vm3jit/page_stub.go
@@ -1,0 +1,11 @@
+//go:build !(darwin && arm64)
+
+package vm3jit
+
+import "errors"
+
+var errNoPageBackend = errors.New("vm3jit/page: no executable-page backend for this OS/arch")
+
+func pageAllocOS(int) ([]byte, error)         { return nil, errNoPageBackend }
+func pageMakeExecOS(page, src []byte) error   { return errNoPageBackend }
+func pageFreeOS([]byte) error                 { return errNoPageBackend }

--- a/runtime/jit/vm3jit/vm3jit_darwin_arm64_test.go
+++ b/runtime/jit/vm3jit/vm3jit_darwin_arm64_test.go
@@ -1,0 +1,77 @@
+//go:build darwin && arm64
+
+package vm3jit_test
+
+import (
+	"testing"
+	"unsafe"
+
+	"mochi/compiler3/corpus"
+	"mochi/runtime/jit/vm2jit/trampoline"
+	"mochi/runtime/jit/vm3jit"
+	"mochi/runtime/vm3"
+)
+
+// runJITSumLoop compiles sum_loop and calls it via the trampoline,
+// returning the i64 result. The regs window must live for the
+// duration of the call; the trampoline is NOSPLIT so Go's stack
+// cannot grow under it and the &regs[0] pointer stays valid.
+func runJITSumLoop(t *testing.T, fn *vm3.Function, arg int64) int64 {
+	t.Helper()
+	cf, err := vm3jit.Compile(fn)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	defer cf.Free()
+	var regs [vm3jit.MaxI64Regs]int64
+	regs[0] = arg
+	got := trampoline.Call(cf.Entry(), unsafe.Pointer(&regs[0]))
+	return int64(got)
+}
+
+// TestCompileSumLoopMatchesInterp runs the JIT'd sum_loop alongside
+// the vm3 interpreter across a range of N and confirms bit-identical
+// results. This is the Phase 6.0 correctness gate.
+func TestCompileSumLoopMatchesInterp(t *testing.T) {
+	prog := corpus.SumLoop.Build(0)
+	fn := prog.Funcs[prog.Entry]
+	for _, n := range []int64{0, 1, 2, 10, 100, 10001} {
+		got := runJITSumLoop(t, fn, n)
+		vm := vm3.NewWithProgram(prog)
+		want, err := vm.RunWithArgs(fn, []int64{n})
+		if err != nil {
+			t.Fatalf("interp sum_loop(%d): %v", n, err)
+		}
+		if got != want.Int() {
+			t.Errorf("sum_loop(%d): jit=%d interp=%d", n, got, want.Int())
+		}
+	}
+}
+
+// TestRejectF64 confirms a function with f64 banks is rejected by the
+// 6.0 gate (so callers fall back to the interpreter cleanly).
+func TestRejectF64(t *testing.T) {
+	fn := &vm3.Function{
+		Name:       "f64_reject",
+		NumRegsF64: 1,
+		ResultBank: vm3.BankF64,
+		Code:       []vm3.Op{vm3.MakeOp(vm3.OpReturnF64, 0, 0, 0)},
+	}
+	if _, err := vm3jit.Compile(fn); err == nil {
+		t.Fatal("expected ErrNotImplemented for f64 fn, got nil")
+	}
+}
+
+// TestRejectTooManyI64 confirms the 6.0 i64 reg cap rejects oversize
+// functions so callers fall back to the interpreter.
+func TestRejectTooManyI64(t *testing.T) {
+	fn := &vm3.Function{
+		Name:       "wide_i64",
+		NumRegsI64: vm3jit.MaxI64Regs + 1,
+		ResultBank: vm3.BankI64,
+		Code:       []vm3.Op{vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0)},
+	}
+	if _, err := vm3jit.Compile(fn); err == nil {
+		t.Fatal("expected ErrNotImplemented for too-many-i64 fn, got nil")
+	}
+}

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -1182,15 +1182,48 @@ Rationale for moving up from Phase 6 to Phase 5: with Layers A and B already shi
 
 ### Phase 6: vm3jit (was Phase 5)
 
-**Deliverables**:
-- `runtime/jit/vm3jit/` package: AArch64 backend + AMD64 backend.
-- Lowering for typed arith, compare, branch, list ops, typed-array element ops, call (with deopt protocol).
-- Per-bank linear-scan register allocator (uses GPRs for i64, SIMD for f64, GPRs for cell).
+Phase 6 is the load-bearing piece for the 2x-of-Go gate. §9.9's Phase 4.0 baseline measured the vm3 interpreter at 30 to 70x slower than Go on arithmetic kernels; Phase 4.2 to 4.5 (opt passes, regalloc, emit, OpFree) cannot close that gap because the interpreter's dispatch overhead is irreducible. Phase 6 is split into 6.0 (MVP, one kernel through the trampoline, prove 2x reachable) and 6.1+ (extend coverage to the rest of the arithmetic kernels, then containers).
+
+#### Phase 6.0: AArch64 baseline JIT, one arithmetic kernel through trampoline **LANDED**
+
+**Shipped**:
+- `runtime/jit/vm3jit/`: doc, compile entry (Compile, CompiledFunc, Entry, Free), AArch64 lowerer (lower_arm64.go), darwin/arm64 page allocator (mmap with MAP_JIT + pthread_jit_write_protect + sys_icache_invalidate), non-arm64 stubs.
+- Register pinning: regsI64[r] is loaded into x(9+r) at function entry. x9..x15 are AArch64 caller-saved temps, so no callee-saved frame save is needed in 6.0. Cap is `maxI64Regs = 7`; functions above the cap return ErrNotImplemented.
+- Two-pass lowering: pass 1 builds pcMap (word offset per bytecode index), pass 2 emits instructions and resolves branch targets through pcMap.
+- Six opcodes: `OpConstI64K`, `OpAddI64`, `OpAddI64K`, `OpCmpGeI64Br`, `OpJump`, `OpReturnI64`. Anything else returns `ErrNotImplemented` so callers fall back cleanly to the interpreter.
+- Trampoline reuse: `runtime/jit/vm2jit/trampoline` is generic (set x0 = pointer arg, call entry, return uint64 in x0) and is imported unchanged. No cgo on the hot path; cgo only at install time for pthread_jit_write_protect / sys_icache_invalidate.
+- Tests: `TestCompileSumLoopMatchesInterp` confirms the JIT'd sum_loop produces bit-identical results to the interpreter on N in {0, 1, 2, 10, 100, 10001}. Negative tests confirm f64/Cell bank usage and oversize i64 reg counts are rejected.
+
+**Measured** (M4, darwin/arm64, `go test -bench=SumLoop -benchtime=3s -count=5`):
+
+| Bench | ns/op (median) | Ratio vs Go fair |
+|-------|---------------:|-----------------:|
+| `SumLoopGoFair`  (Go //go:noinline) | 2475 | 1.00x |
+| `SumLoopJIT`     (vm3jit)           | 2524 | **1.02x** |
+| `SumLoopInterp`  (vm3 interpreter)  | 100905 | 40.77x |
+
+The JIT'd sum_loop runs at **1.02x of the Go baseline** (within bench noise of parity), down from the interpreter's 40.77x. This is the first measured datapoint proving the 2x-of-Go gate is reachable end-to-end on a real arithmetic kernel via the vm3 + vm3jit stack. Phase 6.1+ extends the opcode and register set to the remaining arithmetic kernels (fib_iter, mul_loop, fact_rec, fib_rec, prime_count) and then to containers.
+
+**Gate (6.0, met)**: at least one corpus kernel under 2x of fair-shape Go. sum_loop_n10001 measures 1.02x.
+
+#### Phase 6.1+: extend to remaining arithmetic kernels (planned)
+
+**Deliverables (planned)**:
+- Add `OpSubI64`, `OpMulI64`, `OpDivI64`, `OpModI64`, `OpNegI64`, `OpSubI64K`, `OpMulI64K`, `OpDivI64K`, `OpModI64K`, full i64 compare-and-branch family (Eq/Ne/Lt/Le/Gt/Ge in both reg-reg and K-form), `OpMovI64`, `OpConstI64KW`.
+- Lift `maxI64Regs` cap by pushing AArch64 callee-saved x19..x28 in a prologue (mirrors vm2jit MEP-39 §6.14 Phase B).
+- Wire `vm3.JITCallFn` so `OpCallI64` routes through JIT'd callees when present (mirrors vm2jit init.go).
+
+**Gate (planned)**: fib_iter, mul_loop, fact_rec all under 2x of Go fair baselines.
+
+#### Phase 6.2+: AMD64 backend, container/string lowering, full BG suite (planned)
+
+**Deliverables (planned)**:
+- `lower_amd64.go` mirroring lower_arm64 for the same opcode set.
+- f64 SIMD lowering (regsF64 to v0..v15).
+- Cell-bank ops (list, map, string) with deopt protocol.
 - bench/vm3runner wires JIT in via CompileProgram (mirror MEP-39 §6.15).
 
-**Gate**: vm3+JIT beats vm2+JIT by 50%+ on BG suite at peak N. At least 6 of 11 BG programs inside 2x-of-Go gate.
-
-**Exit**: production-quality JIT shipped, bench numbers recorded in spec.
+**Gate (planned)**: vm3+JIT beats vm2+JIT by 50%+ on BG suite at peak N. At least 6 of 11 BG programs inside 2x-of-Go.
 
 ### Phase 7: Production migration and vm2 deprecation
 


### PR DESCRIPTION
## Summary

Phase 6.0 of MEP-40: minimum-viable vm3jit on AArch64 (Darwin). One arithmetic kernel (sum_loop) compiles through the JIT and runs at Go parity, closing the 40x interpreter dispatch gap measured in Phase 4.0.

Six opcodes lowered (OpConstI64K, OpAddI64, OpAddI64K, OpCmpGeI64Br, OpJump, OpReturnI64) through a two-pass lowering pipeline with pcMap-resolved branches. Pinned register allocator: regsI64[r] -> x(9+r), capped at 7 i64 regs for 6.0 to stay within caller-saved temporaries. f64 / Cell banks and oversize i64 reg counts are rejected with ErrNotImplemented so callers fall back to the interpreter cleanly.

Bench results on M-series macOS:

| Bench | ns/op (median) | Ratio vs Go fair |
|-------|---------------:|-----------------:|
| SumLoopGoFair | 2475 | 1.00x |
| SumLoopJIT | 2524 | **1.02x** |
| SumLoopInterp | 100905 | 40.77x |

This is the first MEP-40 measurement that hits the 2x-of-Go gate on an arithmetic kernel. The wins are generic (real codegen, real trampoline, real page allocation), not hardcoded super-ops.

Linked: closes step in #21708.

## Test plan

- [x] `go test ./runtime/jit/vm3jit/...` (darwin/arm64): correctness gate (sum_loop matches interpreter bit-for-bit across N in {0, 1, 2, 10, 100, 10001})
- [x] `go test ./runtime/jit/vm3jit/...` (darwin/arm64): f64 + oversize-i64 rejection paths
- [x] `go test ./...` non-darwin/arm64 build paths via stubs
- [x] `go test -bench=. ./runtime/jit/vm3jit/...` measured table above