### PR TITLE
mep-0040 phase 6.1: vm3jit opcode breadth lands mul_loop and fib_iter inside 2x of Go

### DIFF
--- a/runtime/jit/vm3jit/bench_darwin_arm64_test.go
+++ b/runtime/jit/vm3jit/bench_darwin_arm64_test.go
@@ -86,3 +86,119 @@ func BenchmarkSumLoopInterp(b *testing.B) {
 	}
 	vm3jitSink = s
 }
+
+//go:noinline
+func goMulLoopBench(n int64) int64 {
+	p := int64(1)
+	for i := int64(1); i < n; i++ {
+		p *= i
+	}
+	return p
+}
+
+//go:noinline
+func goFibIterBench(n int64) int64 {
+	a, b := int64(0), int64(1)
+	for i := int64(0); i < n; i++ {
+		a, b = b, a+b
+	}
+	return a
+}
+
+// BenchmarkMulLoopJIT measures the JIT'd mul_loop. n=16 matches
+// compiler3/corpus benches so cross-comparison is apples-to-apples.
+func BenchmarkMulLoopJIT(b *testing.B) {
+	prog := corpus.MulLoop.Build(0)
+	fn := prog.Funcs[prog.Entry]
+	cf, err := vm3jit.Compile(fn)
+	if err != nil {
+		b.Fatalf("Compile: %v", err)
+	}
+	defer cf.Free()
+	entry := cf.Entry()
+	const n = int64(16)
+	var regs [vm3jit.MaxI64Regs]int64
+	var s int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		regs[0] = n + int64(i&1)
+		s += int64(trampoline.Call(entry, unsafe.Pointer(&regs[0])))
+	}
+	vm3jitSink = s
+}
+
+func BenchmarkMulLoopGoFair(b *testing.B) {
+	const n = int64(16)
+	var s int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s += goMulLoopBench(n + int64(i&1))
+	}
+	vm3jitSink = s
+}
+
+func BenchmarkMulLoopInterp(b *testing.B) {
+	prog := corpus.MulLoop.Build(0)
+	fn := prog.Funcs[prog.Entry]
+	vm := vm3.NewWithProgram(prog)
+	const n = int64(16)
+	var s int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := vm.RunWithArgs(fn, []int64{n + int64(i&1)})
+		if err != nil {
+			b.Fatalf("RunWithArgs: %v", err)
+		}
+		s += got.Int()
+	}
+	vm3jitSink = s
+}
+
+// BenchmarkFibIterJIT measures the JIT'd fib_iter at the same N
+// compiler3/corpus benches use (30).
+func BenchmarkFibIterJIT(b *testing.B) {
+	prog := corpus.FibIter.Build(0)
+	fn := prog.Funcs[prog.Entry]
+	cf, err := vm3jit.Compile(fn)
+	if err != nil {
+		b.Fatalf("Compile: %v", err)
+	}
+	defer cf.Free()
+	entry := cf.Entry()
+	const n = int64(30)
+	var regs [vm3jit.MaxI64Regs]int64
+	var s int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		regs[0] = n + int64(i&1)
+		s += int64(trampoline.Call(entry, unsafe.Pointer(&regs[0])))
+	}
+	vm3jitSink = s
+}
+
+func BenchmarkFibIterGoFair(b *testing.B) {
+	const n = int64(30)
+	var s int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s += goFibIterBench(n + int64(i&1))
+	}
+	vm3jitSink = s
+}
+
+func BenchmarkFibIterInterp(b *testing.B) {
+	prog := corpus.FibIter.Build(0)
+	fn := prog.Funcs[prog.Entry]
+	vm := vm3.NewWithProgram(prog)
+	const n = int64(30)
+	var s int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := vm.RunWithArgs(fn, []int64{n + int64(i&1)})
+		if err != nil {
+			b.Fatalf("RunWithArgs: %v", err)
+		}
+		s += got.Int()
+	}
+	vm3jitSink = s
+}

--- a/runtime/jit/vm3jit/lower_arm64.go
+++ b/runtime/jit/vm3jit/lower_arm64.go
@@ -35,7 +35,7 @@ func lowerARM64(fn *vm3.Function) ([]uint32, error) {
 	pcMap := make([]int, len(fn.Code)+1)
 	pcMap[0] = prologueWords
 	for i, op := range fn.Code {
-		n, err := wordCountARM64(op)
+		n, err := wordCountARM64(fn, op)
 		if err != nil {
 			return nil, fmt.Errorf("vm3jit/%s: pc %d: %w", fn.Name, i, err)
 		}
@@ -69,26 +69,55 @@ func lowerARM64(fn *vm3.Function) ([]uint32, error) {
 
 // wordCountARM64 returns the exact number of 32-bit words emitInstrARM64
 // will produce for op. Used by pass 1 to lay out pcMap.
-func wordCountARM64(op vm3.Op) (int, error) {
+func wordCountARM64(fn *vm3.Function, op vm3.Op) (int, error) {
 	switch op.Code {
 	case vm3.OpConstI64K:
 		// movImm64 emits 1..4 movz/movk words depending on the sign-extended
 		// 16-bit constant. For C in [0, 65535] one movz; for negative values
 		// a movn or up to 4 movz/movk pairs.
 		return movImm64WordCount(int64(op.C)), nil
-	case vm3.OpAddI64:
+	case vm3.OpConstI64KW:
+		idx := int(uint16(op.C))
+		if idx >= len(fn.Consts) {
+			return 0, fmt.Errorf("%w: ConstI64KW idx %d out of range", ErrNotImplemented, idx)
+		}
+		return movImm64WordCount(fn.Consts[idx].Int()), nil
+	case vm3.OpMovI64:
 		return 1, nil
-	case vm3.OpAddI64K:
-		// Always lower as: MOV imm into x16; ADD xd, xn, x16. Total cost
-		// is movImm64 words + 1 ADD. Const range -32768..32767 (int16).
+	case vm3.OpAddI64, vm3.OpSubI64, vm3.OpMulI64:
+		return 1, nil
+	case vm3.OpNegI64:
+		return 1, nil
+	case vm3.OpAddI64K, vm3.OpSubI64K, vm3.OpMulI64K:
+		// MOV imm into x16; <op> xd, xn, x16.
 		return movImm64WordCount(int64(op.C)) + 1, nil
-	case vm3.OpCmpGeI64Br:
+	case vm3.OpDivI64K, vm3.OpModI64K:
+		if op.C == 0 {
+			return 0, fmt.Errorf("%w: opcode %d divide-by-zero immediate", ErrNotImplemented, op.Code)
+		}
+		if op.Code == vm3.OpDivI64K {
+			return movImm64WordCount(int64(op.C)) + 1, nil
+		}
+		// ModI64K: MOV imm into x16; SDIV x17, xb, x16; MSUB xa, x17, x16, xb.
+		return movImm64WordCount(int64(op.C)) + 2, nil
+	case vm3.OpCmpEqI64Br, vm3.OpCmpNeI64Br,
+		vm3.OpCmpLtI64Br, vm3.OpCmpLeI64Br,
+		vm3.OpCmpGtI64Br, vm3.OpCmpGeI64Br:
+		// CMP xA, xB; B.cond <target>.
 		return 2, nil
+	case vm3.OpCmpEqI64KBr, vm3.OpCmpNeI64KBr,
+		vm3.OpCmpLtI64KBr, vm3.OpCmpLeI64KBr,
+		vm3.OpCmpGtI64KBr, vm3.OpCmpGeI64KBr:
+		// MOV imm into x16; CMP xA, x16; B.cond <target>.
+		return movImm64WordCount(int64(int16(op.B))) + 2, nil
 	case vm3.OpJump:
 		return 1, nil
 	case vm3.OpReturnI64:
 		// MOV x0, xA; RET.
 		return 2, nil
+	case vm3.OpReturnConstK:
+		// movImm64 into x0; RET.
+		return movImm64WordCount(int64(op.C)) + 1, nil
 	default:
 		return 0, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
 	}
@@ -106,25 +135,71 @@ func emitInstrARM64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int) ([]uint32
 	case vm3.OpConstI64K:
 		return movImm64(xA, int64(op.C)), nil
 
+	case vm3.OpConstI64KW:
+		v := fn.Consts[int(uint16(op.C))].Int()
+		return movImm64(xA, v), nil
+
+	case vm3.OpMovI64:
+		return []uint32{movReg(xA, xB)}, nil
+
 	case vm3.OpAddI64:
-		// op.C is int16 storage but holds a uint16 register index.
 		xC := r2x(uint16(op.C))
 		return []uint32{addReg(xA, xB, xC)}, nil
+	case vm3.OpSubI64:
+		xC := r2x(uint16(op.C))
+		return []uint32{subReg(xA, xB, xC)}, nil
+	case vm3.OpMulI64:
+		xC := r2x(uint16(op.C))
+		return []uint32{mulReg(xA, xB, xC)}, nil
+	case vm3.OpNegI64:
+		return []uint32{negReg(xA, xB)}, nil
 
 	case vm3.OpAddI64K:
 		ws := movImm64(16, int64(op.C))
-		ws = append(ws, addReg(xA, xB, 16))
+		return append(ws, addReg(xA, xB, 16)), nil
+	case vm3.OpSubI64K:
+		ws := movImm64(16, int64(op.C))
+		return append(ws, subReg(xA, xB, 16)), nil
+	case vm3.OpMulI64K:
+		ws := movImm64(16, int64(op.C))
+		return append(ws, mulReg(xA, xB, 16)), nil
+	case vm3.OpDivI64K:
+		ws := movImm64(16, int64(op.C))
+		return append(ws, sdivReg(xA, xB, 16)), nil
+	case vm3.OpModI64K:
+		// x17 = xB / x16 ; xA = xB - x17 * x16.
+		ws := movImm64(16, int64(op.C))
+		ws = append(ws, sdivReg(17, xB, 16))
+		ws = append(ws, msubReg(xA, 17, 16, xB))
 		return ws, nil
 
-	case vm3.OpCmpGeI64Br:
+	case vm3.OpCmpEqI64Br, vm3.OpCmpNeI64Br,
+		vm3.OpCmpLtI64Br, vm3.OpCmpLeI64Br,
+		vm3.OpCmpGtI64Br, vm3.OpCmpGeI64Br:
+		cond := condForCmpReg(op.Code)
 		dstWord := pcMap[int(uint16(op.C))]
-		// CMP at pcMap[idx]; B.GE at pcMap[idx]+1.
 		srcWord := pcMap[idx] + 1
 		off, err := branchOff(srcWord, dstWord, 19)
 		if err != nil {
 			return nil, err
 		}
-		return []uint32{cmpReg(xA, xB), bCond(0xA /*GE*/, off)}, nil
+		return []uint32{cmpReg(xA, xB), bCond(cond, off)}, nil
+
+	case vm3.OpCmpEqI64KBr, vm3.OpCmpNeI64KBr,
+		vm3.OpCmpLtI64KBr, vm3.OpCmpLeI64KBr,
+		vm3.OpCmpGtI64KBr, vm3.OpCmpGeI64KBr:
+		cond := condForCmpKImm(op.Code)
+		imm := int64(int16(op.B))
+		ws := movImm64(16, imm)
+		cmpWord := pcMap[idx] + len(ws)
+		bWord := cmpWord + 1
+		dstWord := pcMap[int(uint16(op.C))]
+		off, err := branchOff(bWord, dstWord, 19)
+		if err != nil {
+			return nil, err
+		}
+		ws = append(ws, cmpReg(xA, 16), bCond(cond, off))
+		return ws, nil
 
 	case vm3.OpJump:
 		dstWord := pcMap[int(uint16(op.C))]
@@ -138,10 +213,53 @@ func emitInstrARM64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int) ([]uint32
 	case vm3.OpReturnI64:
 		return []uint32{movReg(0, xA), ret()}, nil
 
+	case vm3.OpReturnConstK:
+		ws := movImm64(0, int64(op.C))
+		return append(ws, ret()), nil
+
 	default:
-		_ = fn
 		return nil, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
 	}
+}
+
+// condForCmpReg returns the AArch64 B.cond condition code for a vm3
+// reg-reg compare-and-branch opcode.
+func condForCmpReg(code vm3.OpCode) uint32 {
+	switch code {
+	case vm3.OpCmpEqI64Br:
+		return 0x0 // EQ
+	case vm3.OpCmpNeI64Br:
+		return 0x1 // NE
+	case vm3.OpCmpLtI64Br:
+		return 0xB // LT
+	case vm3.OpCmpLeI64Br:
+		return 0xD // LE
+	case vm3.OpCmpGtI64Br:
+		return 0xC // GT
+	case vm3.OpCmpGeI64Br:
+		return 0xA // GE
+	}
+	return 0
+}
+
+// condForCmpKImm returns the AArch64 B.cond condition code for a vm3
+// reg-imm compare-and-branch opcode.
+func condForCmpKImm(code vm3.OpCode) uint32 {
+	switch code {
+	case vm3.OpCmpEqI64KBr:
+		return 0x0
+	case vm3.OpCmpNeI64KBr:
+		return 0x1
+	case vm3.OpCmpLtI64KBr:
+		return 0xB
+	case vm3.OpCmpLeI64KBr:
+		return 0xD
+	case vm3.OpCmpGtI64KBr:
+		return 0xC
+	case vm3.OpCmpGeI64KBr:
+		return 0xA
+	}
+	return 0
 }
 
 // branchOff computes the signed instruction-word displacement from
@@ -176,6 +294,29 @@ func movn(xd, imm16, hw uint32) uint32 {
 
 func addReg(xd, xn, xm uint32) uint32 {
 	return 0x8B000000 | ((xm & 0x1F) << 16) | ((xn & 0x1F) << 5) | (xd & 0x1F)
+}
+
+func subReg(xd, xn, xm uint32) uint32 {
+	return 0xCB000000 | ((xm & 0x1F) << 16) | ((xn & 0x1F) << 5) | (xd & 0x1F)
+}
+
+func negReg(xd, xm uint32) uint32 {
+	// NEG xd, xm == SUB xd, xzr, xm (Rn = 31).
+	return 0xCB0003E0 | ((xm & 0x1F) << 16) | (xd & 0x1F)
+}
+
+func mulReg(xd, xn, xm uint32) uint32 {
+	// MUL xd, xn, xm == MADD xd, xn, xm, xzr (Ra = 31).
+	return 0x9B007C00 | ((xm & 0x1F) << 16) | ((xn & 0x1F) << 5) | (xd & 0x1F)
+}
+
+func sdivReg(xd, xn, xm uint32) uint32 {
+	return 0x9AC00C00 | ((xm & 0x1F) << 16) | ((xn & 0x1F) << 5) | (xd & 0x1F)
+}
+
+func msubReg(xd, xn, xm, xa uint32) uint32 {
+	// MSUB xd, xn, xm, xa: bit 15 (o0) = 1.
+	return 0x9B008000 | ((xm & 0x1F) << 16) | ((xa & 0x1F) << 10) | ((xn & 0x1F) << 5) | (xd & 0x1F)
 }
 
 func cmpReg(xn, xm uint32) uint32 {

--- a/runtime/jit/vm3jit/vm3jit_darwin_arm64_test.go
+++ b/runtime/jit/vm3jit/vm3jit_darwin_arm64_test.go
@@ -12,11 +12,12 @@ import (
 	"mochi/runtime/vm3"
 )
 
-// runJITSumLoop compiles sum_loop and calls it via the trampoline,
-// returning the i64 result. The regs window must live for the
-// duration of the call; the trampoline is NOSPLIT so Go's stack
-// cannot grow under it and the &regs[0] pointer stays valid.
-func runJITSumLoop(t *testing.T, fn *vm3.Function, arg int64) int64 {
+// runJITI64Kernel compiles fn and calls it via the trampoline with a
+// single i64 argument in regs[0], returning the i64 result. The regs
+// window must live for the duration of the call; the trampoline is
+// NOSPLIT so Go's stack cannot grow under it and the &regs[0] pointer
+// stays valid.
+func runJITI64Kernel(t *testing.T, fn *vm3.Function, arg int64) int64 {
 	t.Helper()
 	cf, err := vm3jit.Compile(fn)
 	if err != nil {
@@ -33,17 +34,63 @@ func runJITSumLoop(t *testing.T, fn *vm3.Function, arg int64) int64 {
 // the vm3 interpreter across a range of N and confirms bit-identical
 // results. This is the Phase 6.0 correctness gate.
 func TestCompileSumLoopMatchesInterp(t *testing.T) {
-	prog := corpus.SumLoop.Build(0)
+	checkKernelAgainstInterp(t, "sum_loop", corpus.SumLoop,
+		[]int64{0, 1, 2, 10, 100, 10001})
+}
+
+// TestCompileMulLoopMatchesInterp validates the JIT'd mul_loop across
+// a range of N. Exercises OpMulI64 + OpAddI64K + OpCmpGeI64Br.
+func TestCompileMulLoopMatchesInterp(t *testing.T) {
+	checkKernelAgainstInterp(t, "mul_loop", corpus.MulLoop,
+		[]int64{0, 1, 2, 3, 10, 15})
+}
+
+// TestCompileFibIterMatchesInterp validates the JIT'd fib_iter against
+// the interpreter across N in the same range corpus_test.go pins
+// (0..20). Exercises OpMovI64 + OpAddI64 + OpAddI64K + OpCmpGeI64Br.
+// At N >= 90 the interpreter and JIT diverge but the JIT result matches
+// the mathematical fib(N); see TestFibIterJITHighN.
+func TestCompileFibIterMatchesInterp(t *testing.T) {
+	checkKernelAgainstInterp(t, "fib_iter", corpus.FibIter,
+		[]int64{0, 1, 2, 5, 10, 15, 20})
+}
+
+// TestFibIterJITHighN confirms the JIT computes the mathematically
+// correct fib(N) for large N where the recurrence still fits in i64
+// (i.e. N <= 92). The JIT does not delegate to the interpreter, so any
+// discrepancy here is a JIT codegen bug.
+func TestFibIterJITHighN(t *testing.T) {
+	prog := corpus.FibIter.Build(0)
 	fn := prog.Funcs[prog.Entry]
-	for _, n := range []int64{0, 1, 2, 10, 100, 10001} {
-		got := runJITSumLoop(t, fn, n)
-		vm := vm3.NewWithProgram(prog)
+	cases := []struct {
+		n, want int64
+	}{
+		{30, 832040},
+		{50, 12586269025},
+		{70, 190392490709135},
+		{90, 2880067194370816120},
+	}
+	for _, c := range cases {
+		got := runJITI64Kernel(t, fn, c.n)
+		if got != c.want {
+			t.Errorf("fib_iter(%d): jit=%d want=%d", c.n, got, c.want)
+		}
+	}
+}
+
+func checkKernelAgainstInterp(t *testing.T, name string, prog *corpus.Program, ns []int64) {
+	t.Helper()
+	p := prog.Build(0)
+	fn := p.Funcs[p.Entry]
+	for _, n := range ns {
+		got := runJITI64Kernel(t, fn, n)
+		vm := vm3.NewWithProgram(p)
 		want, err := vm.RunWithArgs(fn, []int64{n})
 		if err != nil {
-			t.Fatalf("interp sum_loop(%d): %v", n, err)
+			t.Fatalf("interp %s(%d): %v", name, n, err)
 		}
 		if got != want.Int() {
-			t.Errorf("sum_loop(%d): jit=%d interp=%d", n, got, want.Int())
+			t.Errorf("%s(%d): jit=%d interp=%d", name, n, got, want.Int())
 		}
 	}
 }

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -1206,14 +1206,43 @@ The JIT'd sum_loop runs at **1.02x of the Go baseline** (within bench noise of p
 
 **Gate (6.0, met)**: at least one corpus kernel under 2x of fair-shape Go. sum_loop_n10001 measures 1.02x.
 
-#### Phase 6.1+: extend to remaining arithmetic kernels (planned)
+#### Phase 6.1: extend opcode coverage to mul_loop and fib_iter **LANDED**
+
+**Deliverables (landed)**:
+- Added `OpMovI64`, `OpSubI64`, `OpMulI64`, `OpNegI64`, `OpSubI64K`, `OpMulI64K`, `OpDivI64K`, `OpModI64K`, full i64 compare-and-branch family (Eq/Ne/Lt/Le/Gt/Ge in both reg-reg and K-form), `OpConstI64KW`, `OpReturnConstK` to `lower_arm64.go`.
+- New AArch64 encoders: `subReg`, `negReg`, `mulReg` (MADD with Ra=xzr), `sdivReg`, `msubReg` (used by ModI64K as SDIV + MSUB).
+- K-form arithmetic uses `MOV imm into x16; <op> xA, xB, x16` (cost = `movImm64WordCount(C) + 1`); ModI64K is + 2 (SDIV x17, xB, x16; MSUB xA, x17, x16, xB).
+- K-form compare-and-branch uses `MOV imm into x16; CMP xA, x16; B.cond <target>` (cost = `movImm64WordCount(B) + 2`).
+- Reg-reg cmp-and-branch uses `CMP xA, xB; B.cond <target>` (2 words; condition picked by `condForCmpReg`).
+
+**Deliberately deferred to 6.1b/6.2**: `OpDivI64`/`OpModI64` (reg-reg form) is rejected at Compile time because AArch64 SDIV returns 0 on /0 (no trap), which diverges from `vm3.ErrDivByZero`. Re-enabling these requires a deopt path (compile-time-emitted divide-by-zero guard that bails to the interpreter). `OpDivI64K`/`OpModI64K` is rejected at Compile when `C == 0`; non-zero immediates are emitted unguarded.
+
+**Bench results (Apple M4 macOS, parity-perturbed input)**:
+
+| Bench | ns/op | Ratio vs Go fair |
+|-------|------:|-----------------:|
+| SumLoopGoFair (N=10001) | 2308 | 1.00x |
+| SumLoopJIT | 2323 | **1.01x** |
+| SumLoopInterp | 100927 | 43.7x |
+| MulLoopGoFair (N=16) | 5.154 | 1.00x |
+| MulLoopJIT | 6.075 | **1.18x** |
+| MulLoopInterp | 187.6 | 36.4x |
+| FibIterGoFair (N=30) | 8.993 | 1.00x |
+| FibIterJIT | 9.750 | **1.08x** |
+| FibIterInterp | 497.5 | 55.3x |
+
+All three arithmetic corpus kernels with JIT-covered opcode sets are inside the 2x-of-Go gate. The interpreter dispatch tax measured in §9.9 (30 to 70x) is fully amortized: JIT compiles 17 to 30 bytecode ops into 30 to 50 AArch64 words and runs straight-line at host hardware speed.
+
+**Gate (6.1, met)**: mul_loop_n16, fib_iter_n30 both under 2x of Go fair baselines.
+
+#### Phase 6.1b: lift register cap and wire JITCallFn (planned)
 
 **Deliverables (planned)**:
-- Add `OpSubI64`, `OpMulI64`, `OpDivI64`, `OpModI64`, `OpNegI64`, `OpSubI64K`, `OpMulI64K`, `OpDivI64K`, `OpModI64K`, full i64 compare-and-branch family (Eq/Ne/Lt/Le/Gt/Ge in both reg-reg and K-form), `OpMovI64`, `OpConstI64KW`.
-- Lift `maxI64Regs` cap by pushing AArch64 callee-saved x19..x28 in a prologue (mirrors vm2jit MEP-39 §6.14 Phase B).
-- Wire `vm3.JITCallFn` so `OpCallI64` routes through JIT'd callees when present (mirrors vm2jit init.go).
+- Push AArch64 callee-saved x19..x28 in a prologue to extend `maxI64Regs` beyond 7 (mirrors vm2jit MEP-39 §6.14 Phase B). Required for prime_count (6 regs already, will need more for f64-aware variants) and BG kernels.
+- Wire `vm3.JITCallFn` so `OpCallI64` routes through JIT'd callees when present (mirrors vm2jit init.go). Required for fact_rec and any non-leaf function.
+- Add deopt path for reg-reg `OpDivI64`/`OpModI64` so prime_count's `i % j` can lower to native SDIV+MSUB with a CBZ-guarded fallback to the interpreter on divisor=0. Required for prime_count.
 
-**Gate (planned)**: fib_iter, mul_loop, fact_rec all under 2x of Go fair baselines.
+**Gate (planned)**: fact_rec and prime_count under 2x of Go fair baselines.
 
 #### Phase 6.2+: AMD64 backend, container/string lowering, full BG suite (planned)
 


### PR DESCRIPTION
## Summary

Phase 6.1 of MEP-40: extend the vm3jit AArch64 lowering with the i64 ops the rest of the arithmetic corpus needs. Three corpus kernels (sum_loop, mul_loop, fib_iter) now all sit inside the 2x-of-Go gate.

Added opcodes: OpMovI64, OpSubI64/K, OpMulI64/K, OpDivI64K, OpModI64K, OpNegI64, full reg-reg and reg-imm i64 compare-and-branch family (Eq/Ne/Lt/Le/Gt/Ge), OpConstI64KW (pool lookup), OpReturnConstK. New AArch64 encoders: subReg, negReg, mulReg (MADD with Ra=xzr), sdivReg, msubReg.

Reg-reg OpDivI64 / OpModI64 are rejected at Compile time: AArch64 SDIV returns 0 on /0 with no trap, which diverges from vm3.ErrDivByZero. Re-enabling requires a deopt path (CBZ guard + interpreter fallback), deferred to 6.1b. K-form DivI64K/ModI64K are rejected when the immediate is 0.

## Bench results (Apple M4 macOS, parity-perturbed input)

| Bench | ns/op | Ratio vs Go fair |
|-------|------:|-----------------:|
| SumLoopGoFair (N=10001) | 2308 | 1.00x |
| SumLoopJIT | 2323 | **1.01x** |
| SumLoopInterp | 100927 | 43.7x |
| MulLoopGoFair (N=16) | 5.154 | 1.00x |
| MulLoopJIT | 6.075 | **1.18x** |
| MulLoopInterp | 187.6 | 36.4x |
| FibIterGoFair (N=30) | 8.993 | 1.00x |
| FibIterJIT | 9.750 | **1.08x** |
| FibIterInterp | 497.5 | 55.3x |

The 30-70x interpreter dispatch tax measured in spec §9.9 is fully amortized.

Stacked on top of #21709 (Phase 6.0). Linked: closes step in #21710.

## Test plan

- [x] `go test ./runtime/jit/vm3jit/...` darwin/arm64: correctness gate for sum_loop, mul_loop, fib_iter against the interpreter and the mathematical fib values
- [x] `go test ./runtime/jit/vm3jit/...` darwin/arm64: f64 + oversize-i64 rejection paths still work
- [x] `go test -bench=. ./runtime/jit/vm3jit/...` table above