### PR TITLE
mep-0040 phase 6.1b: vm3jit i64 reg cap 7 → 17 via x19..x28 callee-saves

### DIFF
--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -17,12 +17,11 @@ var ErrUnsupported = errors.New("vm3jit: no backend for this architecture")
 // Callers fall back to the vm3 interpreter.
 var ErrNotImplemented = errors.New("vm3jit: not implemented")
 
-// maxI64Regs is the Phase 6.0 cap on simultaneously live i64
-// registers. x9..x15 are AArch64 caller-saved temps; the function
-// body owns all seven without a prologue/epilogue frame save. Phase
-// 6.1 lifts the cap by pushing callee-saved x19..x28 (mirroring
-// vm2jit MEP-39 §6.14 Phase B).
-const maxI64Regs = 7
+// maxI64Regs is the cap on simultaneously live i64 registers in the
+// JIT. Slots 0..6 land in x9..x15 (caller-saved, free); slots 7..16
+// land in x19..x28 (callee-saved, requires STP/LDP pairs in the
+// prologue/epilogue). Mirrors vm2jit MEP-39 §6.14 Phase B.
+const maxI64Regs = 17
 
 // CompiledFunc is a handle to a vm3jit-compiled function. It owns the
 // executable page and must be freed via Free when the function is

--- a/runtime/jit/vm3jit/lower_arm64.go
+++ b/runtime/jit/vm3jit/lower_arm64.go
@@ -8,14 +8,16 @@ import (
 	"mochi/runtime/vm3"
 )
 
-// Register pinning for Phase 6.0:
+// Register pinning:
 //
-//	regsI64[r] -> x(9 + r)  for r in [0, maxI64Regs)
+//	regsI64[r] -> x(9 + r)        for r in [0, 7)   (caller-saved)
+//	regsI64[r] -> x(19 + r - 7)   for r in [7, 17)  (callee-saved)
 //
 // x9..x15 are AArch64 caller-saved temporaries; the JIT can clobber
-// them freely without a callee-saved frame. x0 carries the regsI64
-// base pointer (set by the trampoline). x16/x17 are intra-procedure
-// scratches available to any encoder.
+// them freely. x19..x28 are callee-saved; functions that touch any of
+// those slots push them as STP/LDP pairs in the prologue/epilogue.
+// x0 carries the regsI64 base pointer (set by the trampoline).
+// x16/x17 are intra-procedure scratches available to any encoder.
 //
 // vm3 i64 registers are stored as raw int64 (no NaN-box, no tag). A
 // single LDR/STR moves a value between the regsI64 stack window and
@@ -23,14 +25,36 @@ import (
 // register with no tag arithmetic. This is the key simplification
 // over vm2jit and the reason a small instruction count per opcode is
 // achievable for arithmetic kernels.
-func r2x(r uint16) uint32 { return uint32(r) + 9 }
+func r2x(r uint16) uint32 {
+	if r < 7 {
+		return uint32(r) + 9
+	}
+	return uint32(r) - 7 + 19
+}
+
+// numCalleeSavedPairs returns the number of x19..x28 STP/LDP pairs the
+// frame for fn must push. Each pair covers two register slots. The
+// final pair is pushed even if only one of its two regs is live, since
+// AArch64 STP is a single 16-byte op and partial pairs would waste
+// alignment without saving anything.
+func numCalleeSavedPairs(fn *vm3.Function) int {
+	n := int(fn.NumRegsI64)
+	if n > maxI64Regs {
+		n = maxI64Regs
+	}
+	if n <= 7 {
+		return 0
+	}
+	return (n - 7 + 1) / 2
+}
 
 // lowerARM64 returns the AArch64 instruction-word stream for fn. Two
 // passes: pass 1 computes pcMap[i] = word index where the lowering of
 // bytecode i starts; pass 2 emits real instructions, resolving branch
 // destinations through pcMap.
 func lowerARM64(fn *vm3.Function) ([]uint32, error) {
-	prologueWords := int(fn.NumRegsI64)
+	pairs := numCalleeSavedPairs(fn)
+	prologueWords := pairs + int(fn.NumRegsI64)
 
 	pcMap := make([]int, len(fn.Code)+1)
 	pcMap[0] = prologueWords
@@ -45,8 +69,13 @@ func lowerARM64(fn *vm3.Function) ([]uint32, error) {
 	total := pcMap[len(fn.Code)]
 	ws := make([]uint32, 0, total)
 
+	// Prologue: push callee-saved pairs, then load each live reg from
+	// [x0, #r*8] into its pinned host register.
+	for k := 0; k < pairs; k++ {
+		ws = append(ws, stpPreIdx64(uint32(2*k+19), uint32(2*k+20), 31, -16))
+	}
 	for r := uint32(0); r < uint32(fn.NumRegsI64); r++ {
-		ws = append(ws, ldr64(r+9, 0, r))
+		ws = append(ws, ldr64(r2x(uint16(r)), 0, r))
 	}
 
 	for i, op := range fn.Code {
@@ -65,6 +94,16 @@ func lowerARM64(fn *vm3.Function) ([]uint32, error) {
 			fn.Name, len(ws), total)
 	}
 	return ws, nil
+}
+
+// emitCalleeSavedEpilogueARM64 appends pairs LDP instructions to ws in
+// REVERSE order of the prologue's pushes so each pop matches the
+// topmost STP frame and SP returns to its entry value.
+func emitCalleeSavedEpilogueARM64(ws []uint32, pairs int) []uint32 {
+	for k := pairs - 1; k >= 0; k-- {
+		ws = append(ws, ldpPostIdx64(uint32(2*k+19), uint32(2*k+20), 31, 16))
+	}
+	return ws
 }
 
 // wordCountARM64 returns the exact number of 32-bit words emitInstrARM64
@@ -113,11 +152,11 @@ func wordCountARM64(fn *vm3.Function, op vm3.Op) (int, error) {
 	case vm3.OpJump:
 		return 1, nil
 	case vm3.OpReturnI64:
-		// MOV x0, xA; RET.
-		return 2, nil
+		// MOV x0, xA; <pop callee-saved frame>; RET.
+		return 2 + numCalleeSavedPairs(fn), nil
 	case vm3.OpReturnConstK:
-		// movImm64 into x0; RET.
-		return movImm64WordCount(int64(op.C)) + 1, nil
+		// movImm64 into x0; <pop callee-saved frame>; RET.
+		return movImm64WordCount(int64(op.C)) + numCalleeSavedPairs(fn) + 1, nil
 	default:
 		return 0, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
 	}
@@ -211,11 +250,18 @@ func emitInstrARM64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int) ([]uint32
 		return []uint32{bImm(off)}, nil
 
 	case vm3.OpReturnI64:
-		return []uint32{movReg(0, xA), ret()}, nil
+		// MOV x0, xA BEFORE the LDPs: if xA is one of x19..x28 the
+		// epilogue would clobber it.
+		ws := []uint32{movReg(0, xA)}
+		ws = emitCalleeSavedEpilogueARM64(ws, numCalleeSavedPairs(fn))
+		ws = append(ws, ret())
+		return ws, nil
 
 	case vm3.OpReturnConstK:
 		ws := movImm64(0, int64(op.C))
-		return append(ws, ret()), nil
+		ws = emitCalleeSavedEpilogueARM64(ws, numCalleeSavedPairs(fn))
+		ws = append(ws, ret())
+		return ws, nil
 
 	default:
 		return nil, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
@@ -340,6 +386,23 @@ func bCond(cond uint32, off19 int32) uint32 {
 }
 
 func ret() uint32 { return 0xD65F03C0 }
+
+// stpPreIdx64 encodes STP Xt1, Xt2, [Xn, #imm]! (64-bit pre-index,
+// writeback). imm is a 7-bit signed multiple of 8 bytes, so the
+// instruction-level immediate is imm/8. Used to push callee-saved
+// pairs in 16-byte chunks (imm = -16).
+func stpPreIdx64(xt1, xt2, xn uint32, imm int32) uint32 {
+	imm7 := uint32(imm/8) & 0x7F
+	return 0xA9800000 | (imm7 << 15) | ((xt2 & 0x1F) << 10) | ((xn & 0x1F) << 5) | (xt1 & 0x1F)
+}
+
+// ldpPostIdx64 encodes LDP Xt1, Xt2, [Xn], #imm (64-bit post-index,
+// writeback). imm is a 7-bit signed multiple of 8. Used to pop the
+// callee-saved pairs in 16-byte chunks (imm = +16).
+func ldpPostIdx64(xt1, xt2, xn uint32, imm int32) uint32 {
+	imm7 := uint32(imm/8) & 0x7F
+	return 0xA8C00000 | (imm7 << 15) | ((xt2 & 0x1F) << 10) | ((xn & 0x1F) << 5) | (xt1 & 0x1F)
+}
 
 // movImm64 emits the shortest movz/movn/movk sequence that loads v
 // into xd. Negative values prefer movn (one-instruction load for

--- a/runtime/jit/vm3jit/vm3jit_darwin_arm64_test.go
+++ b/runtime/jit/vm3jit/vm3jit_darwin_arm64_test.go
@@ -95,6 +95,43 @@ func checkKernelAgainstInterp(t *testing.T, name string, prog *corpus.Program, n
 	}
 }
 
+// TestWideI64Frame exercises the callee-saved prologue/epilogue by
+// compiling a function with NumRegsI64 in the [8, 17] range. Each
+// register gets assigned a distinct value, then a chain of moves and
+// adds proves all slots are reachable and survive the function-entry
+// load + the final epilogue's LDP pops.
+func TestWideI64Frame(t *testing.T) {
+	// fn(x) := x + 1 + 2 + ... + 11 + 12 = x + 78.
+	//   regs[0] = x (param)
+	//   regs[1..12] = constants 1..12
+	//   regs[0] = regs[0] + regs[k] for k in 1..12
+	//   return regs[0]
+	const N = 13 // 1 param + 12 consts; all need distinct host regs
+	code := []vm3.Op{}
+	for k := uint16(1); k <= 12; k++ {
+		code = append(code, vm3.MakeOp(vm3.OpConstI64K, k, 0, int16(k)))
+	}
+	for k := uint16(1); k <= 12; k++ {
+		code = append(code, vm3.MakeOp(vm3.OpAddI64, 0, 0, int16(k)))
+	}
+	code = append(code, vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0))
+
+	fn := &vm3.Function{
+		Name:       "wide_chain",
+		NumRegsI64: N,
+		ParamBanks: []vm3.Bank{vm3.BankI64},
+		ResultBank: vm3.BankI64,
+		Code:       code,
+	}
+	for _, x := range []int64{0, 1, 100, -5} {
+		got := runJITI64Kernel(t, fn, x)
+		want := x + 78
+		if got != want {
+			t.Errorf("wide_chain(%d) = %d want %d", x, got, want)
+		}
+	}
+}
+
 // TestRejectF64 confirms a function with f64 banks is rejected by the
 // 6.0 gate (so callers fall back to the interpreter cleanly).
 func TestRejectF64(t *testing.T) {

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -1235,14 +1235,29 @@ All three arithmetic corpus kernels with JIT-covered opcode sets are inside the 
 
 **Gate (6.1, met)**: mul_loop_n16, fib_iter_n30 both under 2x of Go fair baselines.
 
-#### Phase 6.1b: lift register cap and wire JITCallFn (planned)
+#### Phase 6.1b: lift maxI64Regs cap from 7 to 17 **LANDED**
+
+**Deliverables (landed)**:
+- New AArch64 encoders `stpPreIdx64` and `ldpPostIdx64` for the callee-saved push/pop pairs.
+- `numCalleeSavedPairs(fn)` computes the number of 16-byte STP frames the prologue must push, given fn.NumRegsI64. Functions with NumRegsI64 <= 7 push 0 pairs (no overhead change, preserves 6.0 / 6.1 bench parity); functions with 8..17 regs push 1..5 pairs covering x19..x28.
+- `r2x(r)` now maps r in [0, 7) to x(9+r) (caller-saved temps) and r in [7, 17) to x(19 + r - 7) (callee-saved).
+- `lowerARM64` prologue emits `STP x_{2k+19}, x_{2k+20}, [sp, #-16]!` for each callee-saved pair, then the existing `LDR x_{r2x(r)}, [x0, #r*8]` loop for each live i64 reg.
+- `OpReturnI64` and `OpReturnConstK` now emit `MOV x0, result; LDP* pairs; RET`. MOV runs before the LDPs because xA may be one of x19..x28 and the LDPs would clobber it.
+- `maxI64Regs` bumped from 7 to 17 in `compile.go`. `TestRejectTooManyI64` and `TestWideI64Frame` exercise both the new boundary and the callee-saved encoders.
+
+**Bench impact**: none on existing kernels. sum_loop / mul_loop / fib_iter all use NumRegsI64 <= 5, so they push 0 callee-saved pairs and the prologue is unchanged. Bench numbers from Phase 6.1 reproduce within noise.
+
+**Why this matters even without a kernel impact**: it is the load-bearing piece for the BG suite. Once 6.1c lands `vm3.JITCallFn`, the cap lift is what lets prime_count (6 regs today, 8-10 once f64-aware) and the BG kernels (mandelbrot.main with 11 regs, spectral_norm.main with 14) compile at all. MEP-39 §6.14 measured this same lift on vm2 and concluded "no kernel becomes faster from the lift alone, but the lift removes a hard wall that 5 of 11 BG programs were sitting against".
+
+#### Phase 6.1c: wire JITCallFn + deopt protocol for reg-reg Div/Mod (planned)
 
 **Deliverables (planned)**:
-- Push AArch64 callee-saved x19..x28 in a prologue to extend `maxI64Regs` beyond 7 (mirrors vm2jit MEP-39 §6.14 Phase B). Required for prime_count (6 regs already, will need more for f64-aware variants) and BG kernels.
-- Wire `vm3.JITCallFn` so `OpCallI64` routes through JIT'd callees when present (mirrors vm2jit init.go). Required for fact_rec and any non-leaf function.
-- Add deopt path for reg-reg `OpDivI64`/`OpModI64` so prime_count's `i % j` can lower to native SDIV+MSUB with a CBZ-guarded fallback to the interpreter on divisor=0. Required for prime_count.
+- Add `vm3.JITCallFn` callback (mirrors vm2.JITCallFn) and a `vm3.Function.JITCode` field. OpCallI64 routes to the JIT when present.
+- Refine the AArch64 trampoline to accept a second arg (status word pointer); deopt sets `*status = 1` and returns; caller falls back to interpreter.
+- Add reg-reg `OpDivI64`/`OpModI64` lowering: `CBZ xC, deopt; SDIV ...; MSUB ...`.
+- Bench fact_rec, fib_rec, prime_count against Go fair baselines.
 
-**Gate (planned)**: fact_rec and prime_count under 2x of Go fair baselines.
+**Gate (planned)**: fact_rec, fib_rec, prime_count under 2x of Go fair baselines.
 
 #### Phase 6.2+: AMD64 backend, container/string lowering, full BG suite (planned)
 


### PR DESCRIPTION
Closes #21712. Sub-step of MEP-40 Phase 6 (parent #21646).

Phase 6.1 closed the opcode-coverage gap on the three baseline corpus kernels (sum_loop, mul_loop, fib_iter). The next batch of kernels needs more than 7 simultaneously-live i64 registers, so the JIT was rejecting them at Compile time. This PR lifts the cap from 7 to 17 by adding a second register class.

## Mechanism

`r2x(r uint16) uint32` now maps:

- r in 0..6  → x9..x15  (caller-saved; nothing to save/restore)
- r in 7..16 → x19..x28 (callee-saved; must be preserved across the trampoline call)

For functions with `NumRegsI64 > 7`, the prologue pre-indexes `STP x19,x20, [sp,#-16]!` (then x21/x22, x23/x24, ...). Every return path post-indexes `LDP` pairs in reverse order. `OpReturnI64` / `OpReturnConstK` emit the result MOV *before* the LDPs, because the source register itself may be in x19..x28 and would otherwise be clobbered by the pop.

`numCalleeSavedPairs(fn) = ((min(NumRegsI64, 17) - 7) + 1) / 2` (0 when n <= 7). The +1 round-up handles odd counts by parking a dead x29 next to the last live save register, which keeps the SP 16-byte aligned without separate special-casing.

New encoders:

- `stpPreIdx64(xt1, xt2, xn, imm)`  -> 0xA9800000 | (imm/8)<<15 | xt2<<10 | xn<<5 | xt1
- `ldpPostIdx64(xt1, xt2, xn, imm)` -> 0xA8C00000 | (imm/8)<<15 | xt2<<10 | xn<<5 | xt1

Word-count pass is updated to account for the prologue/epilogue STP/LDP pairs so the two-pass pcMap stays exact.

## Bench impact

None on the three existing corpus kernels (sum_loop NumRegsI64=3, mul_loop=4, fib_iter=5; all stay in caller-saves, no STP/LDP emitted). This PR is foundation: it removes a hard wall the next batch of kernels are sitting against. The new kernel work (matmul, prime_count, fact_rec, BG-suite) lands in Phase 6.1c+.

## Test

- `TestWideI64Frame` builds a 13-reg function (3 STP pairs) summing 1..12 onto the input and verifies four input values; this exercises the prologue, every callee-save slot, and the LDP-after-MOV ordering on return.
- Existing TestCompileSumLoop / MulLoop / FibIter remain green (no codegen change for fn.NumRegsI64 <= 7).

## Out of scope

- JITCallFn + refined trampoline with status word (Phase 6.1c)
- Reg-reg OpDivI64 / OpModI64 with CBZ-guarded /0 deopt (Phase 6.1c)
- AMD64 backend (Phase 6.2)

Spec updated in `website/docs/mep/mep-0040.md` (Phase 6.1b LANDED + Phase 6.1c planned).