### PR TITLE
mep-0040 phase 6.1c: vm3jit reg-reg Div/Mod with status-word deopt

### DIFF
--- a/runtime/jit/vm2jit/trampoline/trampoline_darwin_arm64.go
+++ b/runtime/jit/vm2jit/trampoline/trampoline_darwin_arm64.go
@@ -10,3 +10,13 @@ import "unsafe"
 //
 // Implemented in trampoline_darwin_arm64.s; no CGo on the JIT hot path.
 func Call(entry unsafe.Pointer, regs unsafe.Pointer) uint64
+
+// CallStatus is the vm3jit variant of Call that also pins a status word
+// pointer in x1. The JIT writes a non-zero status code to *status on a
+// deopt path (divide-by-zero, future type-check failures, ...) before
+// returning. Caller must pre-zero *status; on return, a non-zero value
+// means the uint64 result is undefined and the caller should fall back
+// to the interpreter with the corresponding error. Implemented in the
+// same trampoline_darwin_arm64.s file (NOSPLIT so the Go stack cannot
+// grow under the JIT and invalidate &status).
+func CallStatus(entry unsafe.Pointer, regs unsafe.Pointer, status unsafe.Pointer) uint64

--- a/runtime/jit/vm2jit/trampoline/trampoline_darwin_arm64.s
+++ b/runtime/jit/vm2jit/trampoline/trampoline_darwin_arm64.s
@@ -13,3 +13,19 @@ TEXT ·Call(SB),NOSPLIT,$0-24
 	CALL	(R16)			// call JIT'd function; result in R0
 	MOVD	R0, ret+16(FP)
 	RET
+
+// func CallStatus(entry unsafe.Pointer, regs unsafe.Pointer, status unsafe.Pointer) uint64
+//
+// ABI0: entry at FP+0, regs at FP+8, status at FP+16, result at FP+24.
+// Sets R0 = regs and R1 = status. On a clean return the JIT leaves *status
+// untouched (caller pre-zeroes it). On a deopt path the JIT writes a non-zero
+// status code to *status before RET, and the caller treats R0 as undefined.
+// Used by vm3jit for divide-by-zero and other guard-checked paths so the raw
+// int64 result channel can carry the full i64 range with no sentinel collision.
+TEXT ·CallStatus(SB),NOSPLIT,$0-32
+	MOVD	entry+0(FP), R16	// R16 = JIT entry point
+	MOVD	regs+8(FP), R0		// R0 = *int64 register file (JIT arg x0)
+	MOVD	status+16(FP), R1	// R1 = *int64 status word (JIT arg x1)
+	CALL	(R16)
+	MOVD	R0, ret+24(FP)
+	RET

--- a/runtime/jit/vm2jit/trampoline/trampoline_stub.go
+++ b/runtime/jit/vm2jit/trampoline/trampoline_stub.go
@@ -8,3 +8,8 @@ import "unsafe"
 func Call(_ unsafe.Pointer, _ unsafe.Pointer) uint64 {
 	panic("trampoline: not yet implemented on this platform")
 }
+
+// CallStatus panics on platforms without a JIT backend.
+func CallStatus(_ unsafe.Pointer, _ unsafe.Pointer, _ unsafe.Pointer) uint64 {
+	panic("trampoline: not yet implemented on this platform")
+}

--- a/runtime/jit/vm3jit/bench_darwin_arm64_test.go
+++ b/runtime/jit/vm3jit/bench_darwin_arm64_test.go
@@ -202,3 +202,77 @@ func BenchmarkFibIterInterp(b *testing.B) {
 	}
 	vm3jitSink = s
 }
+
+//go:noinline
+func goPrimeCountBench(n int64) int64 {
+	count := int64(0)
+	for i := int64(2); i < n; i++ {
+		isPrime := int64(1)
+		for j := int64(2); j*j <= i; j++ {
+			if i%j == 0 {
+				isPrime = 0
+				break
+			}
+		}
+		if isPrime != 0 {
+			count++
+		}
+	}
+	return count
+}
+
+// BenchmarkPrimeCountJIT measures the JIT'd prime_count at N=1000.
+// The kernel exercises reg-reg OpMulI64 and OpModI64 plus the CBZ
+// /0 guard (which never trips on the happy path, since j starts at 2
+// and increments by 1). Phase 6.1c gate: this ratio must clear the
+// 2x-of-Go bar.
+func BenchmarkPrimeCountJIT(b *testing.B) {
+	prog := corpus.PrimeCount.Build(0)
+	fn := prog.Funcs[prog.Entry]
+	cf, err := vm3jit.Compile(fn)
+	if err != nil {
+		b.Fatalf("Compile: %v", err)
+	}
+	defer cf.Free()
+	entry := cf.Entry()
+	const n = int64(1000)
+	var regs [vm3jit.MaxI64Regs]int64
+	var status int64
+	var s int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		regs[0] = n + int64(i&1)
+		s += int64(trampoline.CallStatus(entry, unsafe.Pointer(&regs[0]), unsafe.Pointer(&status)))
+		if status != 0 {
+			b.Fatalf("unexpected deopt: status=%d", status)
+		}
+	}
+	vm3jitSink = s
+}
+
+func BenchmarkPrimeCountGoFair(b *testing.B) {
+	const n = int64(1000)
+	var s int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s += goPrimeCountBench(n + int64(i&1))
+	}
+	vm3jitSink = s
+}
+
+func BenchmarkPrimeCountInterp(b *testing.B) {
+	prog := corpus.PrimeCount.Build(0)
+	fn := prog.Funcs[prog.Entry]
+	vm := vm3.NewWithProgram(prog)
+	const n = int64(1000)
+	var s int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := vm.RunWithArgs(fn, []int64{n + int64(i&1)})
+		if err != nil {
+			b.Fatalf("RunWithArgs: %v", err)
+		}
+		s += got.Int()
+	}
+	vm3jitSink = s
+}

--- a/runtime/jit/vm3jit/lower_arm64.go
+++ b/runtime/jit/vm3jit/lower_arm64.go
@@ -17,6 +17,11 @@ import (
 // them freely. x19..x28 are callee-saved; functions that touch any of
 // those slots push them as STP/LDP pairs in the prologue/epilogue.
 // x0 carries the regsI64 base pointer (set by the trampoline).
+// x1 carries the optional *int64 status word pointer (set by
+// trampoline.CallStatus). The JIT writes a non-zero status code via
+// [x1] on a deopt path (divide-by-zero etc.) before returning. Phase
+// 6.1c+ codegen assumes x1 is always live and never clobbers it; the
+// happy path leaves *status at its caller-pre-zeroed value.
 // x16/x17 are intra-procedure scratches available to any encoder.
 //
 // vm3 i64 registers are stored as raw int64 (no NaN-box, no tag). A
@@ -25,6 +30,14 @@ import (
 // register with no tag arithmetic. This is the key simplification
 // over vm2jit and the reason a small instruction count per opcode is
 // achievable for arithmetic kernels.
+
+// Status codes the JIT writes to *(x1) on a deopt path. Caller checks
+// this word after a CallStatus return and routes to the corresponding
+// vm3 error if non-zero.
+const (
+	StatusOK         int64 = 0
+	StatusDivByZero  int64 = 1
+)
 func r2x(r uint16) uint32 {
 	if r < 7 {
 		return uint32(r) + 9
@@ -48,6 +61,49 @@ func numCalleeSavedPairs(fn *vm3.Function) int {
 	return (n - 7 + 1) / 2
 }
 
+// hasRegRegDivMod reports whether fn contains any reg-reg OpDivI64 or
+// OpModI64 (the K-form variants reject /0 at Compile time and need no
+// runtime guard, so they do not contribute to the deopt block).
+func hasRegRegDivMod(fn *vm3.Function) bool {
+	for _, op := range fn.Code {
+		if op.Code == vm3.OpDivI64 || op.Code == vm3.OpModI64 {
+			return true
+		}
+	}
+	return false
+}
+
+// deoptBlockWordsARM64 returns the number of instruction words the
+// per-function shared deopt block occupies, or 0 if no opcode in fn can
+// take a deopt path. The block lives at the very end of the JIT stream;
+// every CBZ-guarded check branches to its start.
+//
+// Block layout (when emitted):
+//
+//	MOV  x16, #status_code
+//	STR  x16, [x1]                  ; write *status
+//	<pop callee-saved pairs>        ; numCalleeSavedPairs LDPs
+//	RET
+func deoptBlockWordsARM64(fn *vm3.Function) int {
+	if !hasRegRegDivMod(fn) {
+		return 0
+	}
+	return 2 + numCalleeSavedPairs(fn) + 1
+}
+
+// emitDeoptBlockARM64 emits the shared deopt block for fn at the end
+// of the instruction stream. statusCode is the int64 value the JIT
+// writes to *(x1) before unwinding. Callers compute the branch offset
+// from each guard site to this block via pcMap[len(fn.Code)] (the word
+// index where the block starts).
+func emitDeoptBlockARM64(fn *vm3.Function, statusCode int64) []uint32 {
+	ws := movImm64(16, statusCode)
+	ws = append(ws, str64(16, 1, 0))
+	ws = emitCalleeSavedEpilogueARM64(ws, numCalleeSavedPairs(fn))
+	ws = append(ws, ret())
+	return ws
+}
+
 // lowerARM64 returns the AArch64 instruction-word stream for fn. Two
 // passes: pass 1 computes pcMap[i] = word index where the lowering of
 // bytecode i starts; pass 2 emits real instructions, resolving branch
@@ -66,7 +122,8 @@ func lowerARM64(fn *vm3.Function) ([]uint32, error) {
 		pcMap[i+1] = pcMap[i] + n
 	}
 
-	total := pcMap[len(fn.Code)]
+	deoptStart := pcMap[len(fn.Code)]
+	total := deoptStart + deoptBlockWordsARM64(fn)
 	ws := make([]uint32, 0, total)
 
 	// Prologue: push callee-saved pairs, then load each live reg from
@@ -79,7 +136,7 @@ func lowerARM64(fn *vm3.Function) ([]uint32, error) {
 	}
 
 	for i, op := range fn.Code {
-		emit, err := emitInstrARM64(fn, op, i, pcMap)
+		emit, err := emitInstrARM64(fn, op, i, pcMap, deoptStart)
 		if err != nil {
 			return nil, fmt.Errorf("vm3jit/%s: pc %d op=%d: %w", fn.Name, i, op.Code, err)
 		}
@@ -88,6 +145,13 @@ func lowerARM64(fn *vm3.Function) ([]uint32, error) {
 				fn.Name, i, op.Code, got, want)
 		}
 		ws = append(ws, emit...)
+	}
+	if len(ws) != deoptStart {
+		return nil, fmt.Errorf("vm3jit/%s: code stream %d words, predicted %d",
+			fn.Name, len(ws), deoptStart)
+	}
+	if hasRegRegDivMod(fn) {
+		ws = append(ws, emitDeoptBlockARM64(fn, StatusDivByZero)...)
 	}
 	if len(ws) != total {
 		return nil, fmt.Errorf("vm3jit/%s: final stream %d words, predicted %d",
@@ -125,6 +189,12 @@ func wordCountARM64(fn *vm3.Function, op vm3.Op) (int, error) {
 		return 1, nil
 	case vm3.OpAddI64, vm3.OpSubI64, vm3.OpMulI64:
 		return 1, nil
+	case vm3.OpDivI64:
+		// CBZ xC, deopt ; SDIV xA, xB, xC.
+		return 2, nil
+	case vm3.OpModI64:
+		// CBZ xC, deopt ; SDIV x17, xB, xC ; MSUB xA, x17, xC, xB.
+		return 3, nil
 	case vm3.OpNegI64:
 		return 1, nil
 	case vm3.OpAddI64K, vm3.OpSubI64K, vm3.OpMulI64K:
@@ -165,8 +235,11 @@ func wordCountARM64(fn *vm3.Function, op vm3.Op) (int, error) {
 // emitInstrARM64 emits the AArch64 instructions for op at bytecode
 // index idx. pcMap[i] is the word offset where instruction i's
 // lowering begins (and pcMap[len(Code)] is the word offset of the
-// fall-through past the last instruction).
-func emitInstrARM64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int) ([]uint32, error) {
+// fall-through past the last instruction; that is also the deopt
+// block start when one is emitted). deoptStart is supplied separately
+// so guard-checked opcodes (Div/Mod) can compute CBZ offsets without
+// re-deriving it.
+func emitInstrARM64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStart int) ([]uint32, error) {
 	xA := r2x(op.A)
 	xB := r2x(op.B)
 
@@ -190,6 +263,24 @@ func emitInstrARM64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int) ([]uint32
 	case vm3.OpMulI64:
 		xC := r2x(uint16(op.C))
 		return []uint32{mulReg(xA, xB, xC)}, nil
+	case vm3.OpDivI64:
+		xC := r2x(uint16(op.C))
+		off, err := branchOff(pcMap[idx], deoptStart, 19)
+		if err != nil {
+			return nil, fmt.Errorf("DivI64 deopt branch: %w", err)
+		}
+		return []uint32{cbz64(xC, off), sdivReg(xA, xB, xC)}, nil
+	case vm3.OpModI64:
+		xC := r2x(uint16(op.C))
+		off, err := branchOff(pcMap[idx], deoptStart, 19)
+		if err != nil {
+			return nil, fmt.Errorf("ModI64 deopt branch: %w", err)
+		}
+		return []uint32{
+			cbz64(xC, off),
+			sdivReg(17, xB, xC),
+			msubReg(xA, 17, xC, xB),
+		}, nil
 	case vm3.OpNegI64:
 		return []uint32{negReg(xA, xB)}, nil
 
@@ -375,6 +466,19 @@ func movReg(xd, xm uint32) uint32 {
 
 func ldr64(xt, xn, imm12 uint32) uint32 {
 	return 0xF9400000 | ((imm12 & 0xFFF) << 10) | ((xn & 0x1F) << 5) | (xt & 0x1F)
+}
+
+// str64 encodes STR Xt, [Xn, #imm12*8] (unsigned-offset 64-bit). Used
+// by the deopt block to write the status code through *(x1).
+func str64(xt, xn, imm12 uint32) uint32 {
+	return 0xF9000000 | ((imm12 & 0xFFF) << 10) | ((xn & 0x1F) << 5) | (xt & 0x1F)
+}
+
+// cbz64 encodes CBZ Xt, <pc-rel> (64-bit, branch if Xt is zero).
+// off19 is a signed instruction-word offset; caller must pre-validate
+// that it fits in 19 bits via branchOff(_, _, 19).
+func cbz64(xt uint32, off19 int32) uint32 {
+	return 0xB4000000 | (uint32(off19&0x7FFFF) << 5) | (xt & 0x1F)
 }
 
 func bImm(off26 int32) uint32 {

--- a/runtime/jit/vm3jit/vm3jit_darwin_arm64_test.go
+++ b/runtime/jit/vm3jit/vm3jit_darwin_arm64_test.go
@@ -12,12 +12,26 @@ import (
 	"mochi/runtime/vm3"
 )
 
-// runJITI64Kernel compiles fn and calls it via the trampoline with a
-// single i64 argument in regs[0], returning the i64 result. The regs
-// window must live for the duration of the call; the trampoline is
-// NOSPLIT so Go's stack cannot grow under it and the &regs[0] pointer
-// stays valid.
+// runJITI64Kernel compiles fn and calls it via the status-word
+// trampoline with a single i64 argument in regs[0], returning the i64
+// result. The regs window and status word must live for the duration
+// of the call; the trampoline is NOSPLIT so Go's stack cannot grow
+// under it and the &regs[0] / &status pointers stay valid. On a
+// non-zero status the test fails (callers that expect a deopt path
+// should use runJITI64KernelStatus instead).
 func runJITI64Kernel(t *testing.T, fn *vm3.Function, arg int64) int64 {
+	t.Helper()
+	got, status := runJITI64KernelStatus(t, fn, arg)
+	if status != vm3jit.StatusOK {
+		t.Fatalf("unexpected deopt: status=%d", status)
+	}
+	return got
+}
+
+// runJITI64KernelStatus is the variant that surfaces the deopt status
+// to the caller. Tests for the divide-by-zero path use this to assert
+// status == StatusDivByZero.
+func runJITI64KernelStatus(t *testing.T, fn *vm3.Function, arg int64) (int64, int64) {
 	t.Helper()
 	cf, err := vm3jit.Compile(fn)
 	if err != nil {
@@ -26,8 +40,9 @@ func runJITI64Kernel(t *testing.T, fn *vm3.Function, arg int64) int64 {
 	defer cf.Free()
 	var regs [vm3jit.MaxI64Regs]int64
 	regs[0] = arg
-	got := trampoline.Call(cf.Entry(), unsafe.Pointer(&regs[0]))
-	return int64(got)
+	var status int64
+	got := trampoline.CallStatus(cf.Entry(), unsafe.Pointer(&regs[0]), unsafe.Pointer(&status))
+	return int64(got), status
 }
 
 // TestCompileSumLoopMatchesInterp runs the JIT'd sum_loop alongside
@@ -130,6 +145,86 @@ func TestWideI64Frame(t *testing.T) {
 			t.Errorf("wide_chain(%d) = %d want %d", x, got, want)
 		}
 	}
+}
+
+// TestCompileDivModI64 exercises reg-reg OpDivI64 and OpModI64 codegen
+// on a couple of canonical (B, C) pairs and checks results match Go's
+// signed div/mod semantics. The shared deopt block is laid out at the
+// end of the JIT stream but is never reached on the happy path.
+func TestCompileDivModI64(t *testing.T) {
+	cases := []struct {
+		op           vm3.OpCode
+		b, c         int64
+		want         int64
+	}{
+		{vm3.OpDivI64, 100, 7, 100 / 7},
+		{vm3.OpDivI64, -100, 7, -100 / 7},
+		{vm3.OpDivI64, 100, -7, 100 / -7},
+		{vm3.OpModI64, 100, 7, 100 % 7},
+		{vm3.OpModI64, -100, 7, -100 % 7},
+		{vm3.OpModI64, 100, -7, 100 % -7},
+	}
+	for _, c := range cases {
+		// fn(_) := { r1 = b ; r2 = c ; r0 = r1 OP r2 ; return r0 }
+		fn := &vm3.Function{
+			Name:       "div_mod",
+			NumRegsI64: 3,
+			ParamBanks: []vm3.Bank{vm3.BankI64},
+			ResultBank: vm3.BankI64,
+			Code: []vm3.Op{
+				vm3.MakeOp(vm3.OpConstI64KW, 1, 0, 0),
+				vm3.MakeOp(vm3.OpConstI64KW, 2, 0, 1),
+				vm3.MakeOp(c.op, 0, 1, 2),
+				vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),
+			},
+			Consts: []vm3.Cell{vm3.CInt(c.b), vm3.CInt(c.c)},
+		}
+		got := runJITI64Kernel(t, fn, 0)
+		if got != c.want {
+			t.Errorf("%d %v %d: jit=%d want=%d", c.b, c.op, c.c, got, c.want)
+		}
+	}
+}
+
+// TestDivByZeroDeopt confirms the CBZ guard on reg-reg OpDivI64 routes
+// to the shared deopt block, which writes StatusDivByZero through x1
+// before returning. The result value is undefined and the test
+// inspects only the status word.
+func TestDivByZeroDeopt(t *testing.T) {
+	// fn(x) := { r1 = 1 ; r0 = r1 / x }. Pass x=0 to trigger deopt.
+	fn := &vm3.Function{
+		Name:       "div_by_zero",
+		NumRegsI64: 2,
+		ParamBanks: []vm3.Bank{vm3.BankI64},
+		ResultBank: vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 1),
+			vm3.MakeOp(vm3.OpDivI64, 0, 1, 0),
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),
+		},
+	}
+	_, status := runJITI64KernelStatus(t, fn, 0)
+	if status != vm3jit.StatusDivByZero {
+		t.Fatalf("status: got %d want StatusDivByZero=%d", status, vm3jit.StatusDivByZero)
+	}
+	// Happy path on the same fn with non-zero divisor must clear.
+	got, status := runJITI64KernelStatus(t, fn, 7)
+	if status != vm3jit.StatusOK {
+		t.Fatalf("happy-path status: got %d want OK", status)
+	}
+	if got != 0 {
+		// signed: 1 / 7 = 0 (rounds toward zero).
+		t.Errorf("1/7: got %d want 0", got)
+	}
+}
+
+// TestCompilePrimeCountMatchesInterp runs the JIT'd prime_count
+// kernel (which uses reg-reg OpMulI64 + OpModI64) against the
+// interpreter across a small range of N. This is the first corpus
+// kernel that needs the /0 guard.
+func TestCompilePrimeCountMatchesInterp(t *testing.T) {
+	checkKernelAgainstInterp(t, "prime_count", corpus.PrimeCount,
+		[]int64{2, 10, 100, 1000})
 }
 
 // TestRejectF64 confirms a function with f64 banks is rejected by the

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -1249,15 +1249,31 @@ All three arithmetic corpus kernels with JIT-covered opcode sets are inside the 
 
 **Why this matters even without a kernel impact**: it is the load-bearing piece for the BG suite. Once 6.1c lands `vm3.JITCallFn`, the cap lift is what lets prime_count (6 regs today, 8-10 once f64-aware) and the BG kernels (mandelbrot.main with 11 regs, spectral_norm.main with 14) compile at all. MEP-39 §6.14 measured this same lift on vm2 and concluded "no kernel becomes faster from the lift alone, but the lift removes a hard wall that 5 of 11 BG programs were sitting against".
 
-#### Phase 6.1c: wire JITCallFn + deopt protocol for reg-reg Div/Mod (planned)
+#### Phase 6.1c: status-word trampoline + reg-reg Div/Mod deopt **LANDED**
 
-**Deliverables (planned)**:
-- Add `vm3.JITCallFn` callback (mirrors vm2.JITCallFn) and a `vm3.Function.JITCode` field. OpCallI64 routes to the JIT when present.
-- Refine the AArch64 trampoline to accept a second arg (status word pointer); deopt sets `*status = 1` and returns; caller falls back to interpreter.
-- Add reg-reg `OpDivI64`/`OpModI64` lowering: `CBZ xC, deopt; SDIV ...; MSUB ...`.
-- Bench fact_rec, fib_rec, prime_count against Go fair baselines.
+**Deliverables (landed)**:
+- New trampoline entry point `trampoline.CallStatus(entry, regs, status) uint64` that pins `x1 = *int64 status` alongside `x0 = regsI64 base`. NOSPLIT so the Go stack cannot grow under the JIT and the `&status` pointer stays valid for the duration of the native call. The original `trampoline.Call` is unchanged for vm2jit consumers.
+- Status-word ABI exposed as `vm3jit.StatusOK = 0` and `vm3jit.StatusDivByZero = 1`. The JIT writes the code through `[x1]` before unwinding; caller pre-zeros, then routes a non-zero post-call value to the matching vm3 error (`ErrDivByZero` for code 1). The raw int64 result channel keeps full i64 range with no sentinel collision (which a packed-Cell return would have suffered for `tagDeopt = 0xFFF8...` colliding with legal large negative i64 values).
+- New AArch64 encoders: `cbz64(xt, off19)` and `str64(xt, xn, imm12)`. CBZ uses a 19-bit signed word offset (±2^18 words), large enough to reach the per-fn deopt block at the end of every realistic JIT stream.
+- `deoptBlockWordsARM64(fn)` and `emitDeoptBlockARM64(fn, status)` lay out a shared per-fn deopt epilogue at the end of the instruction stream (only emitted when fn contains a guarded opcode). Block layout: `MOV x16, #status; STR x16, [x1]; <pop callee-saved pairs>; RET`. Every guard CBZ branches to its start; the happy path falls through with no extra cost.
+- Reg-reg `OpDivI64` (`CBZ xC, deopt; SDIV xA, xB, xC`) and `OpModI64` (`CBZ xC, deopt; SDIV x17, xB, xC; MSUB xA, x17, xC, xB`). The K-form variants (`OpDivI64K`, `OpModI64K`) still reject /0 at Compile time since their divisor is a static int16 immediate.
+- `TestCompileDivModI64` exercises 6 (B, C) pairs covering positive/negative signs for both opcodes; `TestDivByZeroDeopt` confirms the CBZ path writes `StatusDivByZero` and that the happy path still clears.
+- `TestCompilePrimeCountMatchesInterp` is the first corpus kernel that needs the /0 guard (the inner-loop `i % j` with j starting at 2 cannot actually trip the guard at runtime, but the codegen path still emits it for correctness).
 
-**Gate (planned)**: fact_rec, fib_rec, prime_count under 2x of Go fair baselines.
+**Measured bench** (Darwin arm64, M4, `-benchtime=2s -count=5`, best-of-5 ns/op):
+
+| kernel | JIT ns/op | Go-fair ns/op | JIT / Go | Interp ns/op | Interp / JIT |
+|---|--:|--:|--:|--:|--:|
+| sum_loop (n=10001) | 2570 | 2570 | 1.00x | 102942 | 40.1x |
+| mul_loop (n=16) | 6.27 | 5.43 | 1.16x | 199.5 | 31.8x |
+| fib_iter (n=30) | 10.10 | 9.74 | 1.04x | 509.6 | 50.5x |
+| prime_count (n=1000) | 3498 | 2727 | 1.28x | 100117 | 28.6x |
+
+**Gate (6.1c, met)**: prime_count under 2x of Go fair baseline (measured 1.16-1.28x across runs; well under the 2x bar). Existing 6.1 / 6.1b kernels reproduce within noise (no regression from the status-word ABI on the happy path; the deopt block only emits when `hasRegRegDivMod(fn)` is true).
+
+**Out of scope (deferred to Phase 6.1d)**:
+- `vm3.JITCallFn` callback wiring and `vm3.Function.JITCode` field. Without these, recursive kernels (fact_rec, fib_rec) still fall back to the interpreter.
+- Additional deopt codes (type-check failures, i64 overflow checks). The ABI is in place; only `StatusDivByZero` is wired today.
 
 #### Phase 6.2+: AMD64 backend, container/string lowering, full BG suite (planned)
 


### PR DESCRIPTION
Closes #21714. Sub-step of MEP-40 Phase 6 (parent #21646).

The first corpus kernel that needs runtime guards (prime_count, via reg-reg `OpDivI64`/`OpModI64`) is unblocked by this PR. Returning a sentinel through the int64 result channel would collide with legitimate large negative i64 values, so the deopt status lives on a separate side channel pinned through x1.

## Trampoline

- `trampoline.CallStatus(entry, regs, status) uint64` is new; same NOSPLIT shape as `Call`, sets x0 = regs and x1 = status, calls entry, returns x0. The Go stack cannot grow under the JIT, so `&status` stays valid.
- `trampoline.Call` is unchanged; vm2jit consumers keep using it.

## JIT codegen

- x1 is reserved as the `*int64` status pointer. The JIT never clobbers x1 on the happy path; only the deopt block writes through it.
- Status constants: `vm3jit.StatusOK = 0`, `vm3jit.StatusDivByZero = 1`.
- New encoders: `cbz64(xt, off19)`, `str64(xt, xn, imm12)`.
- `hasRegRegDivMod(fn)` and `deoptBlockWordsARM64(fn)` reserve a single shared deopt epilogue at the end of the JIT stream (only emitted when at least one guarded opcode is present). Layout: `MOV x16, #status; STR x16, [x1]; <pop callee-saved pairs>; RET`. Every guard CBZ branches to its start.
- Reg-reg `OpDivI64`: `CBZ xC, deopt; SDIV xA, xB, xC`.
- Reg-reg `OpModI64`: `CBZ xC, deopt; SDIV x17, xB, xC; MSUB xA, x17, xC, xB`.
- K-form `OpDivI64K`/`OpModI64K` still reject /0 at Compile time (divisor is a static int16 immediate).

## Tests

- `TestCompileDivModI64`: 6 (B, C) sign combinations for both opcodes.
- `TestDivByZeroDeopt`: /0 path writes `StatusDivByZero`; happy path on the same fn clears.
- `TestCompilePrimeCountMatchesInterp`: end-to-end vs vm3 interpreter at N in {2, 10, 100, 1000}.
- Existing 6.0/6.1/6.1b tests stay green; the deopt block emits only when `hasRegRegDivMod` is true, so kernels without Div/Mod see zero codegen change.

## Measured bench (Darwin arm64, M4, `-benchtime=2s -count=5`, best-of-5 ns/op)

| kernel | JIT | Go-fair | JIT / Go | Interp / JIT |
|---|--:|--:|--:|--:|
| sum_loop (n=10001) | 2570 | 2570 | 1.00x | 40.1x |
| mul_loop (n=16) | 6.27 | 5.43 | 1.16x | 31.8x |
| fib_iter (n=30) | 10.10 | 9.74 | 1.04x | 50.5x |
| prime_count (n=1000) | 3498 | 2727 | 1.28x | 28.6x |

prime_count clears the 2x-of-Go gate (4 of 4 i64 corpus kernels now inside 2x).

## Out of scope (Phase 6.1d)

- `vm3.JITCallFn` callback wiring + recursion (fact_rec, fib_rec).
- Additional deopt codes (type-check failures, i64 overflow). The ABI is in place; only `StatusDivByZero` is wired.

Spec updated in `website/docs/mep/mep-0040.md` (Phase 6.1c LANDED replaces planned; Phase 6.1d entry added).