### PR TITLE
mep-0040 phase 6.1d: vm3jit self-recursive OpCallI64 via native BL

### DIFF
--- a/runtime/jit/vm3jit/bench_darwin_arm64_test.go
+++ b/runtime/jit/vm3jit/bench_darwin_arm64_test.go
@@ -260,6 +260,129 @@ func BenchmarkPrimeCountGoFair(b *testing.B) {
 	vm3jitSink = s
 }
 
+//go:noinline
+func goFactRecBench(n int64) int64 {
+	if n <= 1 {
+		return 1
+	}
+	return n * goFactRecBench(n-1)
+}
+
+//go:noinline
+func goFibRecBench(n int64) int64 {
+	if n < 2 {
+		return n
+	}
+	return goFibRecBench(n-1) + goFibRecBench(n-2)
+}
+
+// BenchmarkFactRecJIT measures the JIT'd fact_rec with self-recursive
+// BL lowering. n=15 keeps the result inside i64 (15! = 1307674368000)
+// and gives a deep enough call stack to make the spill/reload sequence
+// visible in the timing.
+func BenchmarkFactRecJIT(b *testing.B) {
+	prog := corpus.FactRec.Build(0)
+	cf, err := vm3jit.CompileInProgram(prog, prog.Entry)
+	if err != nil {
+		b.Fatalf("CompileInProgram: %v", err)
+	}
+	defer cf.Free()
+	entry := cf.Entry()
+	regs := make([]int64, 8192)
+	const n = int64(15)
+	var status int64
+	var s int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		regs[0] = n + int64(i&1)
+		s += int64(trampoline.CallStatus(entry, unsafe.Pointer(&regs[0]), unsafe.Pointer(&status)))
+		if status != 0 {
+			b.Fatalf("unexpected deopt: status=%d", status)
+		}
+	}
+	vm3jitSink = s
+}
+
+func BenchmarkFactRecGoFair(b *testing.B) {
+	const n = int64(15)
+	var s int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s += goFactRecBench(n + int64(i&1))
+	}
+	vm3jitSink = s
+}
+
+func BenchmarkFactRecInterp(b *testing.B) {
+	prog := corpus.FactRec.Build(0)
+	fn := prog.Funcs[prog.Entry]
+	vm := vm3.NewWithProgram(prog)
+	const n = int64(15)
+	var s int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := vm.RunWithArgs(fn, []int64{n + int64(i&1)})
+		if err != nil {
+			b.Fatalf("RunWithArgs: %v", err)
+		}
+		s += got.Int()
+	}
+	vm3jitSink = s
+}
+
+// BenchmarkFibRecJIT measures the JIT'd fib_rec with two self-recursive
+// BL sites per activation. n=25 gives ~242k call activations (a real
+// recursion-bound kernel; the BL/spill/reload cost dominates).
+func BenchmarkFibRecJIT(b *testing.B) {
+	prog := corpus.FibRec.Build(0)
+	cf, err := vm3jit.CompileInProgram(prog, prog.Entry)
+	if err != nil {
+		b.Fatalf("CompileInProgram: %v", err)
+	}
+	defer cf.Free()
+	entry := cf.Entry()
+	regs := make([]int64, 8192)
+	const n = int64(25)
+	var status int64
+	var s int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		regs[0] = n + int64(i&1)
+		s += int64(trampoline.CallStatus(entry, unsafe.Pointer(&regs[0]), unsafe.Pointer(&status)))
+		if status != 0 {
+			b.Fatalf("unexpected deopt: status=%d", status)
+		}
+	}
+	vm3jitSink = s
+}
+
+func BenchmarkFibRecGoFair(b *testing.B) {
+	const n = int64(25)
+	var s int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s += goFibRecBench(n + int64(i&1))
+	}
+	vm3jitSink = s
+}
+
+func BenchmarkFibRecInterp(b *testing.B) {
+	prog := corpus.FibRec.Build(0)
+	fn := prog.Funcs[prog.Entry]
+	vm := vm3.NewWithProgram(prog)
+	const n = int64(25)
+	var s int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := vm.RunWithArgs(fn, []int64{n + int64(i&1)})
+		if err != nil {
+			b.Fatalf("RunWithArgs: %v", err)
+		}
+		s += got.Int()
+	}
+	vm3jitSink = s
+}
+
 func BenchmarkPrimeCountInterp(b *testing.B) {
 	prog := corpus.PrimeCount.Build(0)
 	fn := prog.Funcs[prog.Entry]

--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -53,12 +53,43 @@ func (c *CompiledFunc) Free() error {
 	return err
 }
 
+// Options tunes Compile's behavior. Zero value disables features that
+// need extra context from the caller.
+type Options struct {
+	// SelfIdx is fn's index in its containing Program. When set
+	// (>= 0), the JIT lowers self-recursive OpCallI64 (op.C ==
+	// SelfIdx) to a native BL inside the same code page. -1
+	// disables self-recursion: any OpCallI64 returns ErrNotImplemented
+	// and the caller falls back to the interpreter.
+	SelfIdx int
+}
+
+// DefaultOptions returns the conservative defaults for callers that
+// build a fn standalone (no Program context).
+func DefaultOptions() Options { return Options{SelfIdx: -1} }
+
 // Compile lowers fn to native code for the host architecture and
-// returns the handle. Phase 6.0 only accepts i64-only functions whose
-// opcode set is covered by lower_arm64. Anything else returns
-// ErrNotImplemented so callers can fall back to the interpreter
-// cleanly.
+// returns the handle. Equivalent to CompileWithOptions(fn,
+// DefaultOptions()).
 func Compile(fn *vm3.Function) (*CompiledFunc, error) {
+	return CompileWithOptions(fn, DefaultOptions())
+}
+
+// CompileInProgram is the convenience form for Programs: it looks up
+// fn = prog.Funcs[idx] and threads idx through as opts.SelfIdx so the
+// JIT can lower self-recursive OpCallI64.
+func CompileInProgram(prog *vm3.Program, idx uint32) (*CompiledFunc, error) {
+	if int(idx) >= len(prog.Funcs) {
+		return nil, fmt.Errorf("vm3jit: fn idx %d out of range (Funcs=%d)", idx, len(prog.Funcs))
+	}
+	return CompileWithOptions(prog.Funcs[idx], Options{SelfIdx: int(idx)})
+}
+
+// CompileWithOptions is the explicit-options form. Phase 6.0..6.1d
+// only accepts i64-only functions whose opcode set is covered by
+// lower_arm64. Anything else returns ErrNotImplemented so callers can
+// fall back to the interpreter cleanly.
+func CompileWithOptions(fn *vm3.Function, opts Options) (*CompiledFunc, error) {
 	if hostArch != ArchARM64 {
 		return nil, ErrUnsupported
 	}
@@ -70,7 +101,7 @@ func Compile(fn *vm3.Function) (*CompiledFunc, error) {
 		return nil, fmt.Errorf("%w: %s uses %d i64 regs (max %d in 6.0)",
 			ErrNotImplemented, fn.Name, fn.NumRegsI64, maxI64Regs)
 	}
-	words, err := lowerARM64(fn)
+	words, err := lowerARM64(fn, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/jit/vm3jit/lower_arm64.go
+++ b/runtime/jit/vm3jit/lower_arm64.go
@@ -45,6 +45,129 @@ func r2x(r uint16) uint32 {
 	return uint32(r) - 7 + 19
 }
 
+// popcount32 counts set bits in v. Used to size OpCallI64 spill loops.
+func popcount32(v uint32) int {
+	v = v - ((v >> 1) & 0x55555555)
+	v = (v & 0x33333333) + ((v >> 2) & 0x33333333)
+	v = (v + (v >> 4)) & 0x0F0F0F0F
+	return int((v * 0x01010101) >> 24)
+}
+
+// computeCallSpills runs a backward liveness pass over fn.Code and
+// returns, for each bytecode index, the bitset of caller-saved i64
+// registers (bank 0..6, mapped to x9..x15) that must be spilled to the
+// caller window across the call. For non-call opcodes the entry is 0.
+// Self-recursive OpCallI64 sites use this to skip spilling dead regs.
+func computeCallSpills(fn *vm3.Function) []uint32 {
+	n := len(fn.Code)
+	spills := make([]uint32, n)
+	liveIn := make([]uint32, n+1) // liveIn[n] = 0 (post-exit)
+	liveOut := make([]uint32, n)
+	for changed := true; changed; {
+		changed = false
+		for i := n - 1; i >= 0; i-- {
+			op := fn.Code[i]
+			out := liveSuccUnion(fn, i, liveIn)
+			d, u := defUseI64(fn, op)
+			in := u | (out &^ d)
+			if out != liveOut[i] || in != liveIn[i] {
+				liveOut[i] = out
+				liveIn[i] = in
+				changed = true
+			}
+		}
+	}
+	for i, op := range fn.Code {
+		if op.Code != vm3.OpCallI64 {
+			continue
+		}
+		mask := uint32(0x7F) // caller-saved (regs 0..6 → x9..x15)
+		dstBit := uint32(1) << op.A
+		spills[i] = (liveOut[i] &^ dstBit) & mask
+	}
+	return spills
+}
+
+// liveSuccUnion is the live-in union across the successors of pc i.
+// Branch opcodes have two successors (fall-through and op.C target);
+// Jump has one (op.C); Return* have none; everything else falls
+// through to i+1.
+func liveSuccUnion(fn *vm3.Function, i int, liveIn []uint32) uint32 {
+	op := fn.Code[i]
+	switch op.Code {
+	case vm3.OpReturnI64, vm3.OpReturnConstK, vm3.OpReturnF64:
+		return 0
+	case vm3.OpJump:
+		t := int(uint16(op.C))
+		if t < 0 || t > len(fn.Code) {
+			return 0
+		}
+		return liveIn[t]
+	case vm3.OpCmpEqI64Br, vm3.OpCmpNeI64Br,
+		vm3.OpCmpLtI64Br, vm3.OpCmpLeI64Br,
+		vm3.OpCmpGtI64Br, vm3.OpCmpGeI64Br,
+		vm3.OpCmpEqI64KBr, vm3.OpCmpNeI64KBr,
+		vm3.OpCmpLtI64KBr, vm3.OpCmpLeI64KBr,
+		vm3.OpCmpGtI64KBr, vm3.OpCmpGeI64KBr:
+		t := int(uint16(op.C))
+		if t < 0 || t > len(fn.Code) {
+			return liveIn[i+1]
+		}
+		return liveIn[i+1] | liveIn[t]
+	default:
+		if i+1 <= len(fn.Code) {
+			return liveIn[i+1]
+		}
+		return 0
+	}
+}
+
+// defUseI64 returns (defs, uses) bitmasks for op over fn's i64 register
+// bank. Bit r is set iff register r is defined/used. For OpCallI64 the
+// uses cover op.B..op.B+nArgs-1.
+func defUseI64(fn *vm3.Function, op vm3.Op) (uint32, uint32) {
+	a := uint32(1) << op.A
+	b := uint32(1) << op.B
+	c := uint32(1) << uint16(op.C)
+	switch op.Code {
+	case vm3.OpConstI64K, vm3.OpConstI64KW:
+		return a, 0
+	case vm3.OpMovI64:
+		return a, b
+	case vm3.OpAddI64, vm3.OpSubI64, vm3.OpMulI64,
+		vm3.OpDivI64, vm3.OpModI64:
+		return a, b | c
+	case vm3.OpNegI64:
+		return a, b
+	case vm3.OpAddI64K, vm3.OpSubI64K, vm3.OpMulI64K,
+		vm3.OpDivI64K, vm3.OpModI64K:
+		return a, b
+	case vm3.OpCmpEqI64Br, vm3.OpCmpNeI64Br,
+		vm3.OpCmpLtI64Br, vm3.OpCmpLeI64Br,
+		vm3.OpCmpGtI64Br, vm3.OpCmpGeI64Br:
+		return 0, a | b
+	case vm3.OpCmpEqI64KBr, vm3.OpCmpNeI64KBr,
+		vm3.OpCmpLtI64KBr, vm3.OpCmpLeI64KBr,
+		vm3.OpCmpGtI64KBr, vm3.OpCmpGeI64KBr:
+		return 0, a
+	case vm3.OpJump:
+		return 0, 0
+	case vm3.OpReturnI64:
+		return 0, a
+	case vm3.OpReturnConstK:
+		return 0, 0
+	case vm3.OpCallI64:
+		// Args are i64 regs op.B..op.B+nArgs-1.
+		var uses uint32
+		n := fn.NumI64Params()
+		for k := 0; k < n; k++ {
+			uses |= 1 << (op.B + uint16(k))
+		}
+		return a, uses
+	}
+	return 0, 0
+}
+
 // numCalleeSavedPairs returns the number of x19..x28 STP/LDP pairs the
 // frame for fn must push. Each pair covers two register slots. The
 // final pair is pushed even if only one of its two regs is live, since
@@ -73,6 +196,31 @@ func hasRegRegDivMod(fn *vm3.Function) bool {
 	return false
 }
 
+// isNonLeaf reports whether fn issues any native BL (currently only
+// self-recursive OpCallI64 is lowered to BL; everything else routes
+// through the interpreter and so does not need x30 saved). Non-leaf
+// fns must push x29:x30 as an extra outermost STP pair so the JIT'd
+// callee can use BL/RET without clobbering the caller's return
+// address.
+func isNonLeaf(fn *vm3.Function) bool {
+	for _, op := range fn.Code {
+		if op.Code == vm3.OpCallI64 {
+			return true
+		}
+	}
+	return false
+}
+
+// numLRPair returns 1 if fn needs the x29:x30 outermost STP/LDP pair,
+// 0 otherwise. The pair is independent of numCalleeSavedPairs and lives
+// in addition to those (x19..x28 register saves).
+func numLRPair(fn *vm3.Function) int {
+	if isNonLeaf(fn) {
+		return 1
+	}
+	return 0
+}
+
 // deoptBlockWordsARM64 returns the number of instruction words the
 // per-function shared deopt block occupies, or 0 if no opcode in fn can
 // take a deopt path. The block lives at the very end of the JIT stream;
@@ -88,7 +236,7 @@ func deoptBlockWordsARM64(fn *vm3.Function) int {
 	if !hasRegRegDivMod(fn) {
 		return 0
 	}
-	return 2 + numCalleeSavedPairs(fn) + 1
+	return 2 + numCalleeSavedPairs(fn) + numLRPair(fn) + 1
 }
 
 // emitDeoptBlockARM64 emits the shared deopt block for fn at the end
@@ -99,7 +247,7 @@ func deoptBlockWordsARM64(fn *vm3.Function) int {
 func emitDeoptBlockARM64(fn *vm3.Function, statusCode int64) []uint32 {
 	ws := movImm64(16, statusCode)
 	ws = append(ws, str64(16, 1, 0))
-	ws = emitCalleeSavedEpilogueARM64(ws, numCalleeSavedPairs(fn))
+	ws = emitFrameEpilogueARM64(ws, numCalleeSavedPairs(fn), numLRPair(fn))
 	ws = append(ws, ret())
 	return ws
 }
@@ -107,15 +255,18 @@ func emitDeoptBlockARM64(fn *vm3.Function, statusCode int64) []uint32 {
 // lowerARM64 returns the AArch64 instruction-word stream for fn. Two
 // passes: pass 1 computes pcMap[i] = word index where the lowering of
 // bytecode i starts; pass 2 emits real instructions, resolving branch
-// destinations through pcMap.
-func lowerARM64(fn *vm3.Function) ([]uint32, error) {
+// destinations through pcMap. opts.SelfIdx, when >= 0, enables self-
+// recursive OpCallI64 to lower to a native BL inside this page.
+func lowerARM64(fn *vm3.Function, opts Options) ([]uint32, error) {
 	pairs := numCalleeSavedPairs(fn)
-	prologueWords := pairs + int(fn.NumRegsI64)
+	lrPair := numLRPair(fn)
+	prologueWords := lrPair + pairs + int(fn.NumRegsI64)
+	spillSets := computeCallSpills(fn)
 
 	pcMap := make([]int, len(fn.Code)+1)
 	pcMap[0] = prologueWords
 	for i, op := range fn.Code {
-		n, err := wordCountARM64(fn, op)
+		n, err := wordCountARM64(fn, op, opts, spillSets, i)
 		if err != nil {
 			return nil, fmt.Errorf("vm3jit/%s: pc %d: %w", fn.Name, i, err)
 		}
@@ -126,8 +277,12 @@ func lowerARM64(fn *vm3.Function) ([]uint32, error) {
 	total := deoptStart + deoptBlockWordsARM64(fn)
 	ws := make([]uint32, 0, total)
 
-	// Prologue: push callee-saved pairs, then load each live reg from
-	// [x0, #r*8] into its pinned host register.
+	// Prologue: push x29:x30 (outermost) if non-leaf, then push
+	// callee-saved pairs, then load each live reg from [x0, #r*8] into
+	// its pinned host register.
+	if lrPair == 1 {
+		ws = append(ws, stpPreIdx64(29, 30, 31, -16))
+	}
 	for k := 0; k < pairs; k++ {
 		ws = append(ws, stpPreIdx64(uint32(2*k+19), uint32(2*k+20), 31, -16))
 	}
@@ -136,7 +291,7 @@ func lowerARM64(fn *vm3.Function) ([]uint32, error) {
 	}
 
 	for i, op := range fn.Code {
-		emit, err := emitInstrARM64(fn, op, i, pcMap, deoptStart)
+		emit, err := emitInstrARM64(fn, op, i, pcMap, deoptStart, opts, spillSets)
 		if err != nil {
 			return nil, fmt.Errorf("vm3jit/%s: pc %d op=%d: %w", fn.Name, i, op.Code, err)
 		}
@@ -160,19 +315,26 @@ func lowerARM64(fn *vm3.Function) ([]uint32, error) {
 	return ws, nil
 }
 
-// emitCalleeSavedEpilogueARM64 appends pairs LDP instructions to ws in
-// REVERSE order of the prologue's pushes so each pop matches the
-// topmost STP frame and SP returns to its entry value.
-func emitCalleeSavedEpilogueARM64(ws []uint32, pairs int) []uint32 {
+// emitFrameEpilogueARM64 appends LDP instructions to ws in REVERSE
+// order of the prologue's pushes so each pop matches the topmost STP
+// frame and SP returns to its entry value. pairs is the number of
+// x19..x28 STP pairs, lrPair is 1 if x29:x30 was pushed as the
+// outermost pair (non-leaf fns).
+func emitFrameEpilogueARM64(ws []uint32, pairs, lrPair int) []uint32 {
 	for k := pairs - 1; k >= 0; k-- {
 		ws = append(ws, ldpPostIdx64(uint32(2*k+19), uint32(2*k+20), 31, 16))
+	}
+	if lrPair == 1 {
+		ws = append(ws, ldpPostIdx64(29, 30, 31, 16))
 	}
 	return ws
 }
 
 // wordCountARM64 returns the exact number of 32-bit words emitInstrARM64
-// will produce for op. Used by pass 1 to lay out pcMap.
-func wordCountARM64(fn *vm3.Function, op vm3.Op) (int, error) {
+// will produce for op. Used by pass 1 to lay out pcMap. spillSets and
+// idx are only consulted for OpCallI64; for other opcodes the spill
+// set is irrelevant.
+func wordCountARM64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint32, idx int) (int, error) {
 	switch op.Code {
 	case vm3.OpConstI64K:
 		// movImm64 emits 1..4 movz/movk words depending on the sign-extended
@@ -222,11 +384,23 @@ func wordCountARM64(fn *vm3.Function, op vm3.Op) (int, error) {
 	case vm3.OpJump:
 		return 1, nil
 	case vm3.OpReturnI64:
-		// MOV x0, xA; <pop callee-saved frame>; RET.
-		return 2 + numCalleeSavedPairs(fn), nil
+		// MOV x0, xA; <pop callee-saved frame>; <pop x29:x30 if non-leaf>; RET.
+		return 2 + numCalleeSavedPairs(fn) + numLRPair(fn), nil
 	case vm3.OpReturnConstK:
-		// movImm64 into x0; <pop callee-saved frame>; RET.
-		return movImm64WordCount(int64(op.C)) + numCalleeSavedPairs(fn) + 1, nil
+		// movImm64 into x0; <pop callee-saved frame>; <pop x29:x30>; RET.
+		return movImm64WordCount(int64(op.C)) + numCalleeSavedPairs(fn) + numLRPair(fn) + 1, nil
+	case vm3.OpCallI64:
+		// Self-recursion only. Anything else routes back through the
+		// interpreter via ErrNotImplemented.
+		if opts.SelfIdx < 0 || int(uint16(op.C)) != opts.SelfIdx {
+			return 0, fmt.Errorf("%w: CallI64 to non-self idx %d (SelfIdx=%d)",
+				ErrNotImplemented, uint16(op.C), opts.SelfIdx)
+		}
+		nSpill := popcount32(spillSets[idx])
+		nArgs := fn.NumI64Params()
+		// nSpill STRs + nArgs STRs + STP x0 + ADD x0 + BL + MOV x16,x0 +
+		// LDP x0 + nSpill LDRs + MOV pinned[dst],x16.
+		return 2*nSpill + nArgs + 6, nil
 	default:
 		return 0, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
 	}
@@ -239,7 +413,7 @@ func wordCountARM64(fn *vm3.Function, op vm3.Op) (int, error) {
 // block start when one is emitted). deoptStart is supplied separately
 // so guard-checked opcodes (Div/Mod) can compute CBZ offsets without
 // re-deriving it.
-func emitInstrARM64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStart int) ([]uint32, error) {
+func emitInstrARM64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStart int, opts Options, spillSets []uint32) ([]uint32, error) {
 	xA := r2x(op.A)
 	xB := r2x(op.B)
 
@@ -344,14 +518,59 @@ func emitInstrARM64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		// MOV x0, xA BEFORE the LDPs: if xA is one of x19..x28 the
 		// epilogue would clobber it.
 		ws := []uint32{movReg(0, xA)}
-		ws = emitCalleeSavedEpilogueARM64(ws, numCalleeSavedPairs(fn))
+		ws = emitFrameEpilogueARM64(ws, numCalleeSavedPairs(fn), numLRPair(fn))
 		ws = append(ws, ret())
 		return ws, nil
 
 	case vm3.OpReturnConstK:
 		ws := movImm64(0, int64(op.C))
-		ws = emitCalleeSavedEpilogueARM64(ws, numCalleeSavedPairs(fn))
+		ws = emitFrameEpilogueARM64(ws, numCalleeSavedPairs(fn), numLRPair(fn))
 		ws = append(ws, ret())
+		return ws, nil
+
+	case vm3.OpCallI64:
+		if opts.SelfIdx < 0 || int(uint16(op.C)) != opts.SelfIdx {
+			return nil, fmt.Errorf("%w: CallI64 to non-self idx %d (SelfIdx=%d)",
+				ErrNotImplemented, uint16(op.C), opts.SelfIdx)
+		}
+		spillMask := spillSets[idx]
+		nSpill := popcount32(spillMask)
+		nArgs := fn.NumI64Params()
+		nRegsI64 := int(fn.NumRegsI64)
+		ws := make([]uint32, 0, 2*nSpill+nArgs+6)
+		// Spill only the caller-saved pinned regs that are live across
+		// this call, computed by backward liveness in computeCallSpills.
+		for r := uint16(0); r < 7; r++ {
+			if spillMask&(1<<r) != 0 {
+				ws = append(ws, str64(uint32(9+r), 0, uint32(r)))
+			}
+		}
+		// Write args into callee's window slots at offset NumRegsI64*8.
+		for k := 0; k < nArgs; k++ {
+			src := r2x(op.B + uint16(k))
+			ws = append(ws, str64(src, 0, uint32(nRegsI64+k)))
+		}
+		// Save caller's x0 (regs base), bump to callee window, BL.
+		ws = append(ws, stpPreIdx64(0, 31, 31, -16))
+		ws = append(ws, addImm64(0, 0, uint32(nRegsI64*8)))
+		entryWord := 0
+		callSiteWord := pcMap[idx] + len(ws)
+		off, err := branchOff(callSiteWord, entryWord, 26)
+		if err != nil {
+			return nil, fmt.Errorf("CallI64 BL: %w", err)
+		}
+		ws = append(ws, bl(off))
+		// Capture result into x16, restore caller's x0.
+		ws = append(ws, movReg(16, 0))
+		ws = append(ws, ldpPostIdx64(0, 31, 31, 16))
+		// Reload only the regs we spilled.
+		for r := uint16(0); r < 7; r++ {
+			if spillMask&(1<<r) != 0 {
+				ws = append(ws, ldr64(uint32(9+r), 0, uint32(r)))
+			}
+		}
+		// Move result into caller's pinned dst register.
+		ws = append(ws, movReg(xA, 16))
 		return ws, nil
 
 	default:
@@ -483,6 +702,20 @@ func cbz64(xt uint32, off19 int32) uint32 {
 
 func bImm(off26 int32) uint32 {
 	return 0x14000000 | uint32(off26&0x3FFFFFF)
+}
+
+// bl encodes BL <pc-rel>: same imm26 field as B, top opcode bit set so
+// the CPU writes x30 with the return address. Used by self-recursive
+// OpCallI64 to call back into the same JIT page.
+func bl(off26 int32) uint32 {
+	return 0x94000000 | uint32(off26&0x3FFFFFF)
+}
+
+// addImm64 encodes ADD Xd, Xn, #imm12 (64-bit, shift=0). Used by the
+// OpCallI64 lowering to bump x0 from caller's regs base to callee's
+// window (offset NumRegsI64*8 bytes).
+func addImm64(xd, xn, imm12 uint32) uint32 {
+	return 0x91000000 | ((imm12 & 0xFFF) << 10) | ((xn & 0x1F) << 5) | (xd & 0x1F)
 }
 
 func bCond(cond uint32, off19 int32) uint32 {

--- a/runtime/jit/vm3jit/lower_stub.go
+++ b/runtime/jit/vm3jit/lower_stub.go
@@ -4,4 +4,4 @@ package vm3jit
 
 import "mochi/runtime/vm3"
 
-func lowerARM64(*vm3.Function) ([]uint32, error) { return nil, ErrUnsupported }
+func lowerARM64(*vm3.Function, Options) ([]uint32, error) { return nil, ErrUnsupported }

--- a/runtime/jit/vm3jit/vm3jit_darwin_arm64_test.go
+++ b/runtime/jit/vm3jit/vm3jit_darwin_arm64_test.go
@@ -227,6 +227,89 @@ func TestCompilePrimeCountMatchesInterp(t *testing.T) {
 		[]int64{2, 10, 100, 1000})
 }
 
+// TestCompileFactRecMatchesInterp validates the JIT'd fact_rec against
+// the interpreter across a range of N. fact_rec exercises self-recursive
+// OpCallI64 (Phase 6.1d): the JIT lowers the call to a native BL inside
+// the same code page, with caller-saved spill/reload and a window bump
+// in x0.
+func TestCompileFactRecMatchesInterp(t *testing.T) {
+	prog := corpus.FactRec.Build(0)
+	for _, n := range []int64{0, 1, 2, 3, 5, 10, 12, 15} {
+		got := runJITProgRecursive(t, prog, n)
+		vm := vm3.NewWithProgram(prog)
+		want, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{n})
+		if err != nil {
+			t.Fatalf("interp fact_rec(%d): %v", n, err)
+		}
+		if got != want.Int() {
+			t.Errorf("fact_rec(%d): jit=%d interp=%d", n, got, want.Int())
+		}
+	}
+}
+
+// TestCompileFibRecMatchesInterp validates the JIT'd fib_rec across the
+// same N range that corpus_test.go pins. Two self-recursive call sites
+// per activation, so this exercises both the spill/reload symmetry and
+// the BL offset math at two distinct call-site PCs.
+func TestCompileFibRecMatchesInterp(t *testing.T) {
+	prog := corpus.FibRec.Build(0)
+	for _, n := range []int64{0, 1, 2, 5, 10, 15, 20} {
+		got := runJITProgRecursive(t, prog, n)
+		vm := vm3.NewWithProgram(prog)
+		want, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{n})
+		if err != nil {
+			t.Fatalf("interp fib_rec(%d): %v", n, err)
+		}
+		if got != want.Int() {
+			t.Errorf("fib_rec(%d): jit=%d interp=%d", n, got, want.Int())
+		}
+	}
+}
+
+// TestRejectNonSelfCallI64 confirms that an OpCallI64 whose callee idx
+// does not match the compile-time SelfIdx is rejected with
+// ErrNotImplemented so callers fall back to the interpreter. This is
+// the Phase 6.1d guard rail; full inter-function calls come later.
+func TestRejectNonSelfCallI64(t *testing.T) {
+	fn := &vm3.Function{
+		Name:       "bad_call",
+		NumRegsI64: 2,
+		ParamBanks: []vm3.Bank{vm3.BankI64},
+		ResultBank: vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpCallI64, 1, 0, 7),
+			vm3.MakeOp(vm3.OpReturnI64, 1, 0, 0),
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{fn}, Entry: 0}
+	if _, err := vm3jit.CompileInProgram(prog, 0); err == nil {
+		t.Fatal("expected ErrNotImplemented for non-self CallI64, got nil")
+	}
+}
+
+// runJITProgRecursive compiles fn = prog.Funcs[Entry] with the
+// Program-aware helper (so the JIT knows its own callee index for
+// self-recursion) and runs it on a large window buffer big enough to
+// hold the deepest recursion the corpus uses. The buffer is sized for
+// the largest test input (fib_rec(20) needs ~20 frames * 5 regs).
+func runJITProgRecursive(t *testing.T, prog *vm3.Program, arg int64) int64 {
+	t.Helper()
+	cf, err := vm3jit.CompileInProgram(prog, prog.Entry)
+	if err != nil {
+		t.Fatalf("CompileInProgram: %v", err)
+	}
+	defer cf.Free()
+	// 8192 slots is plenty for fact_rec(20) / fib_rec(20).
+	regs := make([]int64, 8192)
+	regs[0] = arg
+	var status int64
+	got := trampoline.CallStatus(cf.Entry(), unsafe.Pointer(&regs[0]), unsafe.Pointer(&status))
+	if status != vm3jit.StatusOK {
+		t.Fatalf("unexpected deopt: status=%d", status)
+	}
+	return int64(got)
+}
+
 // TestRejectF64 confirms a function with f64 banks is rejected by the
 // 6.0 gate (so callers fall back to the interpreter cleanly).
 func TestRejectF64(t *testing.T) {

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -1275,6 +1275,67 @@ All three arithmetic corpus kernels with JIT-covered opcode sets are inside the 
 - `vm3.JITCallFn` callback wiring and `vm3.Function.JITCode` field. Without these, recursive kernels (fact_rec, fib_rec) still fall back to the interpreter.
 - Additional deopt codes (type-check failures, i64 overflow checks). The ABI is in place; only `StatusDivByZero` is wired today.
 
+#### Phase 6.1d: self-recursive `OpCallI64` via native BL **LANDED**
+
+**Goal**: lower self-recursive `OpCallI64` to a native AArch64 `BL` inside the same JIT'd code page so the two recursive corpus kernels (`fact_rec`, `fib_rec`) run JIT'd end-to-end. Cross-function calls and arbitrary callees remain deferred to Phase 6.2.
+
+**API surface (`runtime/jit/vm3jit/compile.go`)**:
+- `Options{SelfIdx int}` plus `DefaultOptions()`. `SelfIdx = -1` (the default) keeps the conservative 6.0..6.1c behavior: any `OpCallI64` returns `ErrNotImplemented` and the caller falls back to the interpreter.
+- `Compile(fn)` stays back-compatible (it calls `CompileWithOptions(fn, DefaultOptions())`).
+- `CompileInProgram(prog, idx)` is the Program-aware helper that threads `idx` into `Options{SelfIdx: int(idx)}` so the JIT can recognize self-calls.
+- `CompileWithOptions(fn, opts)` is the explicit-options form for tests and embedders.
+
+**Frame mechanics**:
+- `isNonLeaf(fn)` flags functions that issue any `OpCallI64`. Non-leaf functions push an outermost `STP x29, x30, [sp, #-16]!` pair in the prologue and pop it at every return path (including the shared deopt block). Leaf functions skip the pair entirely, so 6.0/6.1/6.1c kernels see no prologue or epilogue overhead change.
+- `emitFrameEpilogueARM64(ws, pairs, lrPair)` (formerly `emitCalleeSavedEpilogueARM64`) pops `x19..x28` pairs in reverse order, then optionally pops `x29:x30`. Reused by `OpReturnI64`, `OpReturnConstK`, and the shared deopt block.
+
+**OpCallI64 lowering** (self-recursive only, gated by `op.C == opts.SelfIdx`):
+
+```text
+    ; 1. spill caller-saved pinned regs that are LIVE across this call
+    for r in spillSet:        STR x(9+r), [x0, #r*8]
+    ; 2. write args into callee window slots
+    for k in 0..nArgs-1:      STR x(r2x(op.B+k)), [x0, #(NumRegsI64+k)*8]
+    ; 3. save caller's regs base on the stack
+    STP x0, xzr, [sp, #-16]!
+    ; 4. bump x0 to callee window
+    ADD x0, x0, #NumRegsI64*8
+    ; 5. BL into the same JIT page at word 0
+    BL <entry>
+    ; 6. capture result, restore caller's x0
+    MOV x16, x0
+    LDP x0, xzr, [sp], #16
+    ; 7. reload only the regs we spilled
+    for r in spillSet:        LDR x(9+r), [x0, #r*8]
+    ; 8. land result into caller's pinned dst register
+    MOV x(r2x(op.A)), x16
+```
+
+The `x19..x28` (callee-saved) pinned regs are preserved across the BL by the callee's own STP/LDP, so the JIT never spills them at the caller. The `STP x0, xzr / LDP x0, xzr` pair saves the regs-base pointer in a 16-byte stack frame, paid once per call site regardless of register count.
+
+**Liveness-aware spill** (`computeCallSpills`): a backward dataflow pass over `fn.Code` computes the live-out bitset at every `OpCallI64` site. The spill mask is `(liveOut[i] &^ {op.A}) & 0x7F` (caller-saved bank, with the call's destination excluded since the call writes it). For `fact_rec(15)` this reduces the per-call spill from 3 STR + 3 LDR to 1 STR + 1 LDR (only `r0` is live across the call). For `fib_rec(25)` the two call sites spill `{r0}` and `{r2}` respectively, also one slot each. Spill-everything cost 28.4 ns/op for `fact_rec(15)` (2.28x of Go); spill-only-live drops that to 19.4 ns/op (1.56x of Go).
+
+**Window memory**: the trampoline's regs buffer must be large enough to hold the deepest recursion's stacked frames (`NumRegsI64 * max_depth` i64s). Tests allocate `make([]int64, 8192)`, which covers `fact_rec(20)` and `fib_rec(30)` comfortably. Embedders that compile a recursive function pre-size their regs buffer for the worst recursion depth they expect.
+
+**Out of scope (deferred to Phase 6.2)**:
+- Inter-function calls (different `op.C` index than `opts.SelfIdx`). Rejected with `ErrNotImplemented`; tests pin the rejection.
+- Indirect calls / `OpCallByName`.
+- Tail-call elimination for `OpTailCallI64` (vm3 has no TailCall opcode today; if added it lowers to `B` rather than `BL` and reuses the caller's frame).
+- f64 / Cell-bank call ABI; the same window-bump scheme will work but needs the bank-aware spill/reload.
+
+**Bench (Darwin arm64 M4, best-of-3, `-benchtime=2s`)**:
+
+| Kernel | vm3jit ns/op | Go ns/op | JIT/Go | Interp ns/op | Interp/Go |
+|---|---:|---:|---:|---:|---:|
+| sum_loop (n=10001)     | 2489   | 2691   | 0.93x | 237262   | 88.2x |
+| mul_loop (n=16)        | 7.99   | 5.71   | 1.40x | 188.2    | 33.0x |
+| fib_iter (n=30)        | 9.83   | 9.30   | 1.06x | 498.3    | 53.6x |
+| prime_count (n=1000)   | 2908   | 2680   | 1.09x | 99011    | 36.9x |
+| fact_rec (n=15)        | 19.33  | 12.38  | 1.56x | 499.5    | 40.3x |
+| fib_rec (n=25)         | 332417 | 210359 | 1.58x | 10570562 | 50.2x |
+
+**Gate (6.1d, met)**: `fact_rec` and `fib_rec` under 2x of Go fair baselines (1.56x and 1.58x respectively). All four pre-6.1d kernels reproduce within noise; the call-site liveness pass is a strict no-op for non-call opcodes, so loop kernels see no regression. The 2x-of-Go gate is now met on six of six i64-only corpus kernels; the remaining corpus kernels (`strings_concat_loop`, `lists_fill_sum`, `maps_fill_sum`) need Cell-bank lowering (Phase 6.2).
+
 #### Phase 6.2+: AMD64 backend, container/string lowering, full BG suite (planned)
 
 **Deliverables (planned)**:


### PR DESCRIPTION
## Summary
- Self-recursive `OpCallI64` lowers to a native AArch64 `BL` inside the same JIT'd code page (`fact_rec` and `fib_rec` run JIT'd end-to-end).
- Backward liveness pass (`computeCallSpills`) makes the per-call-site spill set minimal: 1 STR + 1 LDR per `fact_rec` call instead of 3 + 3.
- Non-leaf frame pushes an extra `x29:x30` pair; leaf kernels see zero overhead change.
- Six of six i64-only corpus kernels are now inside 2x of Go (Darwin arm64 M4, best-of-3).

## Bench (Darwin arm64 M4, best-of-3, `-benchtime=2s`)

| Kernel | vm3jit ns/op | Go ns/op | JIT/Go |
|---|---:|---:|---:|
| sum_loop (n=10001)     | 2489   | 2691   | 0.93x |
| mul_loop (n=16)        | 7.99   | 5.71   | 1.40x |
| fib_iter (n=30)        | 9.83   | 9.30   | 1.06x |
| prime_count (n=1000)   | 2908   | 2680   | 1.09x |
| fact_rec (n=15)        | 19.33  | 12.38  | **1.56x** |
| fib_rec (n=25)         | 332417 | 210359 | **1.58x** |

## Out of scope (Phase 6.2)
- Inter-function calls (different `op.C` than `opts.SelfIdx`).
- f64 / Cell-bank call ABI.

Closes #21716.

## Test plan
- [x] `go test ./runtime/jit/vm3jit/`
- [x] `go test -bench=. -benchtime=2s ./runtime/jit/vm3jit/` (six kernels all under 2x)
- [x] Pre-6.1d tests reproduce (loop kernels unaffected by the liveness pass)