### PR TITLE
mep-0040: fix MDX parse error from bare `<=` in prose

### DIFF
--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -1239,13 +1239,13 @@ All three arithmetic corpus kernels with JIT-covered opcode sets are inside the 
 
 **Deliverables (landed)**:
 - New AArch64 encoders `stpPreIdx64` and `ldpPostIdx64` for the callee-saved push/pop pairs.
-- `numCalleeSavedPairs(fn)` computes the number of 16-byte STP frames the prologue must push, given fn.NumRegsI64. Functions with NumRegsI64 <= 7 push 0 pairs (no overhead change, preserves 6.0 / 6.1 bench parity); functions with 8..17 regs push 1..5 pairs covering x19..x28.
+- `numCalleeSavedPairs(fn)` computes the number of 16-byte STP frames the prologue must push, given fn.NumRegsI64. Functions with `NumRegsI64 <= 7` push 0 pairs (no overhead change, preserves 6.0 / 6.1 bench parity); functions with 8..17 regs push 1..5 pairs covering x19..x28.
 - `r2x(r)` now maps r in [0, 7) to x(9+r) (caller-saved temps) and r in [7, 17) to x(19 + r - 7) (callee-saved).
 - `lowerARM64` prologue emits `STP x_{2k+19}, x_{2k+20}, [sp, #-16]!` for each callee-saved pair, then the existing `LDR x_{r2x(r)}, [x0, #r*8]` loop for each live i64 reg.
 - `OpReturnI64` and `OpReturnConstK` now emit `MOV x0, result; LDP* pairs; RET`. MOV runs before the LDPs because xA may be one of x19..x28 and the LDPs would clobber it.
 - `maxI64Regs` bumped from 7 to 17 in `compile.go`. `TestRejectTooManyI64` and `TestWideI64Frame` exercise both the new boundary and the callee-saved encoders.
 
-**Bench impact**: none on existing kernels. sum_loop / mul_loop / fib_iter all use NumRegsI64 <= 5, so they push 0 callee-saved pairs and the prologue is unchanged. Bench numbers from Phase 6.1 reproduce within noise.
+**Bench impact**: none on existing kernels. sum_loop / mul_loop / fib_iter all use `NumRegsI64 <= 5`, so they push 0 callee-saved pairs and the prologue is unchanged. Bench numbers from Phase 6.1 reproduce within noise.
 
 **Why this matters even without a kernel impact**: it is the load-bearing piece for the BG suite. Once 6.1c lands `vm3.JITCallFn`, the cap lift is what lets prime_count (6 regs today, 8-10 once f64-aware) and the BG kernels (mandelbrot.main with 11 regs, spectral_norm.main with 14) compile at all. MEP-39 §6.14 measured this same lift on vm2 and concluded "no kernel becomes faster from the lift alone, but the lift removes a hard wall that 5 of 11 BG programs were sitting against".
 


### PR DESCRIPTION
Closes #21718.

## Summary
- Cloudflare Pages deploys on `main` have been failing since the Phase 6.1b LANDED section landed in MEP-40.
- MDX rejects two prose sentences containing `NumRegsI64 <= N`: micromark-extension-mdx-jsx parses the `<` as a JSX tag open, then chokes on the `=`.
- Wraps both occurrences in inline-code backticks so the parser ignores them.

## Test plan
- [x] `npm run build` succeeds locally on the website (previously failed at mep-0040.md:1242:143).
- [ ] Cloudflare Pages deploy turns green on merge.