### PR TITLE
MEP-40 Phase 6.2b: vm3jit f64 SIMD lowering on AArch64 and AMD64

### DIFF
--- a/compiler3/corpus/f64_dot_sum.go
+++ b/compiler3/corpus/f64_dot_sum.go
@@ -1,0 +1,63 @@
+package corpus
+
+import "mochi/runtime/vm3"
+
+// F64DotSum: s = 0.5 * (0 + 1 + ... + n-1) = n*(n-1)/4 (as f64).
+// Drives the loop with an i64 counter and accumulates in f64, so it
+// exercises:
+//   - OpI64ToF64 (i64 -> f64 cast)
+//   - OpMulF64, OpAddF64 (f64 arithmetic)
+//   - OpConstF64K (f64 constant load from pool)
+//   - OpReturnF64
+// alongside the existing i64 cmp/br/AddK kernel shape.
+//
+//	fun dot_sum(n) {
+//	  var s = 0.0
+//	  var k = 0.5
+//	  var i = 0
+//	  while i < n {
+//	    var x = f64(i)
+//	    s = s + x * k
+//	    i = i + 1
+//	  }
+//	  return s
+//	}
+//
+// Bank: i64 + f64. NumRegsI64 = 2 (n, i); NumRegsF64 = 3 (s, x, k).
+//
+//	0  ConstF64K  A=0, C=0          ; s = 0.0
+//	1  ConstF64K  A=2, C=1          ; k = 0.5
+//	2  ConstI64K  A=1, C=0          ; i = 0
+//	3  CmpGeI64Br A=1, B=0, C=9     ; if i >= n jump to 9
+//	4  I64ToF64   A=1, B=1          ; x_f64 = f64(i_i64)
+//	5  MulF64     A=1, B=1, C=2     ; x = x * k
+//	6  AddF64     A=0, B=0, C=1     ; s = s + x
+//	7  AddI64K    A=1, B=1, C=1     ; i = i + 1
+//	8  Jump              C=3        ; back to test
+//	9  ReturnF64  A=0
+var F64DotSum = &Program{
+	Name: "f64_dot_sum",
+	Build: func(_ int64) *vm3.Program {
+		fn := &vm3.Function{
+			Name:       "f64_dot_sum",
+			NumRegsI64: 2,
+			NumRegsF64: 3,
+			ParamBanks: []vm3.Bank{vm3.BankI64},
+			ResultBank: vm3.BankF64,
+			Consts:     []vm3.Cell{vm3.CFloat(0.0), vm3.CFloat(0.5)},
+			Code: []vm3.Op{
+				vm3.MakeOp(vm3.OpConstF64K, 0, 0, 0),
+				vm3.MakeOp(vm3.OpConstF64K, 2, 0, 1),
+				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 0),
+				vm3.MakeOp(vm3.OpCmpGeI64Br, 1, 0, 9),
+				vm3.MakeOp(vm3.OpI64ToF64, 1, 1, 0),
+				vm3.MakeOp(vm3.OpMulF64, 1, 1, 2),
+				vm3.MakeOp(vm3.OpAddF64, 0, 0, 1),
+				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 1),
+				vm3.MakeOp(vm3.OpJump, 0, 0, 3),
+				vm3.MakeOp(vm3.OpReturnF64, 0, 0, 0),
+			},
+		}
+		return &vm3.Program{Funcs: []*vm3.Function{fn}, Entry: 0}
+	},
+}

--- a/compiler3/corpus/f64_threshold.go
+++ b/compiler3/corpus/f64_threshold.go
@@ -1,0 +1,65 @@
+package corpus
+
+import "mochi/runtime/vm3"
+
+// F64Threshold: walk i=1..n and return the first i for which 1.0/f64(i)
+// is strictly less than 0.1 (mathematically i=11). Returns 0 if no such
+// i exists in [1, n]. Exercises the Phase 6.2b F64 cmp/br path:
+//
+//   - OpCmpLtF64Br on the (y < 0.1) test
+//   - OpDivF64 to compute y = 1.0 / f64(i)
+//   - OpI64ToF64 to cast the loop counter into the f64 bank
+//   - OpConstF64K for the 1.0 numerator and 0.1 threshold
+//   - mixed-bank return: OpReturnI64 / OpReturnConstK from an f64 fn
+//
+//	fun threshold(n) {
+//	  var i = 1
+//	  while i <= n {
+//	    var y = 1.0 / f64(i)
+//	    if y < 0.1 { return i }
+//	    i = i + 1
+//	  }
+//	  return 0
+//	}
+//
+// Bank: i64 + f64. NumRegsI64 = 2 (n, i); NumRegsF64 = 4 (one, ten_inv,
+// x_f, y).
+//
+//	0  ConstI64K  A=1, C=1          ; i = 1
+//	1  ConstF64K  A=0, C=0          ; F0 = 1.0
+//	2  ConstF64K  A=1, C=1          ; F1 = 0.1
+//	3  CmpGtI64Br A=1, B=0, C=9     ; if i > n jump to 9 (return 0)
+//	4  I64ToF64   A=2, B=1          ; F2 = f64(i)
+//	5  DivF64     A=3, B=0, C=2     ; y = 1.0 / F2
+//	6  CmpLtF64Br A=3, B=1, C=10    ; if y < 0.1 jump to 10 (return i)
+//	7  AddI64K    A=1, B=1, C=1     ; i = i + 1
+//	8  Jump              C=3        ; back to test
+//	9  ReturnConstK     C=0         ; return 0
+//	10 ReturnI64  A=1               ; return i
+var F64Threshold = &Program{
+	Name: "f64_threshold",
+	Build: func(_ int64) *vm3.Program {
+		fn := &vm3.Function{
+			Name:       "f64_threshold",
+			NumRegsI64: 2,
+			NumRegsF64: 4,
+			ParamBanks: []vm3.Bank{vm3.BankI64},
+			ResultBank: vm3.BankI64,
+			Consts:     []vm3.Cell{vm3.CFloat(1.0), vm3.CFloat(0.1)},
+			Code: []vm3.Op{
+				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 1),
+				vm3.MakeOp(vm3.OpConstF64K, 0, 0, 0),
+				vm3.MakeOp(vm3.OpConstF64K, 1, 0, 1),
+				vm3.MakeOp(vm3.OpCmpGtI64Br, 1, 0, 9),
+				vm3.MakeOp(vm3.OpI64ToF64, 2, 1, 0),
+				vm3.MakeOp(vm3.OpDivF64, 3, 0, 2),
+				vm3.MakeOp(vm3.OpCmpLtF64Br, 3, 1, 10),
+				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 1),
+				vm3.MakeOp(vm3.OpJump, 0, 0, 3),
+				vm3.MakeOp(vm3.OpReturnConstK, 0, 0, 0),
+				vm3.MakeOp(vm3.OpReturnI64, 1, 0, 0),
+			},
+		}
+		return &vm3.Program{Funcs: []*vm3.Function{fn}, Entry: 0}
+	},
+}

--- a/runtime/jit/vm2jit/trampoline/trampoline_darwin_arm64.go
+++ b/runtime/jit/vm2jit/trampoline/trampoline_darwin_arm64.go
@@ -20,3 +20,11 @@ func Call(entry unsafe.Pointer, regs unsafe.Pointer) uint64
 // same trampoline_darwin_arm64.s file (NOSPLIT so the Go stack cannot
 // grow under the JIT and invalidate &status).
 func CallStatus(entry unsafe.Pointer, regs unsafe.Pointer, status unsafe.Pointer) uint64
+
+// CallStatusFF is the Phase 6.2b variant that adds a second register
+// base pointer for the f64 bank. ABI: x0 = regsI64, x1 = status, x2 =
+// regsF64. The JIT loads/stores f64 slots through [x2 + r*8] and, for
+// OpReturnF64, bit-casts the result via FMOV x0, d<retSlot> so the
+// return-channel stays a single uint64 (caller does
+// math.Float64frombits). Used by all kernels with NumRegsF64 > 0.
+func CallStatusFF(entry unsafe.Pointer, regsI64 unsafe.Pointer, status unsafe.Pointer, regsF64 unsafe.Pointer) uint64

--- a/runtime/jit/vm2jit/trampoline/trampoline_darwin_arm64.s
+++ b/runtime/jit/vm2jit/trampoline/trampoline_darwin_arm64.s
@@ -29,3 +29,19 @@ TEXT ·CallStatus(SB),NOSPLIT,$0-32
 	CALL	(R16)
 	MOVD	R0, ret+24(FP)
 	RET
+
+// func CallStatusFF(entry, regsI64, status, regsF64 unsafe.Pointer) uint64
+//
+// ABI0: entry at FP+0, regsI64 at FP+8, status at FP+16, regsF64 at FP+24,
+// result at FP+32. Adds R2 = regsF64 to the CallStatus ABI so JIT'd f64
+// kernels can load/store regsF64[r] via [x2, #r*8]. Result is a bare
+// uint64 (the JIT bit-casts an f64 result via FMOV x0, d<retSlot> in
+// its epilogue; caller uses math.Float64frombits).
+TEXT ·CallStatusFF(SB),NOSPLIT,$0-40
+	MOVD	entry+0(FP), R16
+	MOVD	regsI64+8(FP), R0
+	MOVD	status+16(FP), R1
+	MOVD	regsF64+24(FP), R2
+	CALL	(R16)
+	MOVD	R0, ret+32(FP)
+	RET

--- a/runtime/jit/vm2jit/trampoline/trampoline_linux_amd64.go
+++ b/runtime/jit/vm2jit/trampoline/trampoline_linux_amd64.go
@@ -20,3 +20,13 @@ func Call(entry unsafe.Pointer, regs unsafe.Pointer) uint64
 // trampoline_linux_amd64.s (NOSPLIT so the Go stack cannot grow under
 // the JIT and invalidate &status).
 func CallStatus(entry unsafe.Pointer, regs unsafe.Pointer, status unsafe.Pointer) uint64
+
+// CallStatusFF is the Phase 6.2b variant that adds a second register
+// base pointer for the f64 bank. ABI: RDI = regsI64, RSI = status,
+// RDX = regsF64. The JIT moves RDX into a callee-saved GPR in its
+// prologue (R14 by convention) so f64 loads/stores can use
+// `movsd disp32(%r14), xmm` without flowing through scratch. Result
+// is a bare uint64; for an f64 return the JIT bit-casts via
+// `movq %xmm<retSlot>, %rax` in its epilogue (caller uses
+// math.Float64frombits).
+func CallStatusFF(entry unsafe.Pointer, regsI64 unsafe.Pointer, status unsafe.Pointer, regsF64 unsafe.Pointer) uint64

--- a/runtime/jit/vm2jit/trampoline/trampoline_linux_amd64.s
+++ b/runtime/jit/vm2jit/trampoline/trampoline_linux_amd64.s
@@ -30,3 +30,19 @@ TEXT ·CallStatus(SB),NOSPLIT,$0-32
 	CALL	AX
 	MOVQ	AX, ret+24(FP)
 	RET
+
+// func CallStatusFF(entry, regsI64, status, regsF64 unsafe.Pointer) uint64
+//
+// ABI0: entry at FP+0, regsI64 at FP+8, status at FP+16, regsF64 at FP+24,
+// result at FP+32. Adds DX = regsF64 to the CallStatus ABI. The JIT
+// loads/stores XMM slots via `movsd disp32(%r14), xmm` after copying DX
+// into R14 in its prologue. Result is a bare uint64 (the JIT bit-casts
+// an f64 result via `movq %xmm<retSlot>, %rax` in its epilogue).
+TEXT ·CallStatusFF(SB),NOSPLIT,$0-40
+	MOVQ	entry+0(FP), AX
+	MOVQ	regsI64+8(FP), DI
+	MOVQ	status+16(FP), SI
+	MOVQ	regsF64+24(FP), DX
+	CALL	AX
+	MOVQ	AX, ret+32(FP)
+	RET

--- a/runtime/jit/vm2jit/trampoline/trampoline_stub.go
+++ b/runtime/jit/vm2jit/trampoline/trampoline_stub.go
@@ -13,3 +13,8 @@ func Call(_ unsafe.Pointer, _ unsafe.Pointer) uint64 {
 func CallStatus(_ unsafe.Pointer, _ unsafe.Pointer, _ unsafe.Pointer) uint64 {
 	panic("trampoline: not yet implemented on this platform")
 }
+
+// CallStatusFF panics on platforms without a JIT backend.
+func CallStatusFF(_ unsafe.Pointer, _ unsafe.Pointer, _ unsafe.Pointer, _ unsafe.Pointer) uint64 {
+	panic("trampoline: not yet implemented on this platform")
+}

--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -32,7 +32,25 @@ const maxI64Regs = 17
 // regsI64 base pointer (preserved by the SysV ABI across our internal
 // CALL); R15 holds the *int64 status word pointer; RSP/RBP are the
 // stack. See lower_amd64.go.
+//
+// When fn.NumRegsF64 > 0 the AMD64 backend additionally steals R14 to
+// hold the regsF64 base pointer, dropping the effective i64 cap to 8.
 const maxI64RegsAMD64 = 9
+
+// maxF64RegsARM64 is the cap on simultaneously-live f64 registers in
+// the AArch64 backend. Slots 0..7 land in v0..v7 (caller-saved SIMD/FP).
+// Phase 6.2b kernels are f64-only inside the loop body, no calls cross
+// the f64 slots, so we do not yet need v8..v15 (callee-saved). The
+// regsF64 base pointer is pinned in x2 by the CallStatusFF trampoline
+// and copied into x3 in the prologue (x3 is otherwise unused; freeing
+// x2 for scratch is unnecessary because the prologue keeps it live).
+const maxF64RegsARM64 = 8
+
+// maxF64RegsAMD64 is the AMD64 cap. Slots 0..7 land in xmm0..xmm7
+// (caller-saved on SysV). The regsF64 base pointer arrives in RDX and
+// is parked in R14 by the prologue. When NumRegsF64 > 0 the i64 cap
+// drops to 8 because R14 is stolen.
+const maxF64RegsAMD64 = 8
 
 // CompiledFunc is a handle to a vm3jit-compiled function. It owns the
 // executable page and must be freed via Free when the function is
@@ -55,6 +73,11 @@ func (c *CompiledFunc) Entry() unsafe.Pointer { return pageEntry(c.code) }
 // (see maxI64RegsAMD64); tests that target both architectures must
 // stay within the smaller value.
 const MaxI64Regs = maxI64Regs
+
+// MaxF64Regs is the cap on simultaneously-live f64 registers the JIT
+// supports on either architecture (currently 8 on both AArch64 and
+// AMD64; see maxF64RegsARM64 / maxF64RegsAMD64).
+const MaxF64Regs = maxF64RegsARM64
 
 // Free releases the executable page.
 func (c *CompiledFunc) Free() error {
@@ -98,23 +121,30 @@ func CompileInProgram(prog *vm3.Program, idx uint32) (*CompiledFunc, error) {
 	return CompileWithOptions(prog.Funcs[idx], Options{SelfIdx: int(idx)})
 }
 
-// CompileWithOptions is the explicit-options form. Phase 6.0..6.1d
-// only accepts i64-only functions whose opcode set is covered by the
-// host backend (lower_arm64 / lower_amd64). Anything else returns
-// ErrNotImplemented so callers can fall back to the interpreter
-// cleanly.
+// CompileWithOptions is the explicit-options form. Phase 6.0..6.2b
+// accepts i64-only and i64+f64 functions whose opcode set is covered
+// by the host backend (lower_arm64 / lower_amd64). Cell-bank usage is
+// still routed back to the interpreter (Phase 6.2c+).
 func CompileWithOptions(fn *vm3.Function, opts Options) (*CompiledFunc, error) {
-	if fn.NumRegsF64 != 0 || fn.NumRegsCell != 0 {
-		return nil, fmt.Errorf("%w: %s has non-i64 bank usage (F64=%d Cell=%d)",
-			ErrNotImplemented, fn.Name, fn.NumRegsF64, fn.NumRegsCell)
+	if fn.NumRegsCell != 0 {
+		return nil, fmt.Errorf("%w: %s has Cell bank usage (Cell=%d)",
+			ErrNotImplemented, fn.Name, fn.NumRegsCell)
 	}
-	cap, archOK := archMaxI64Regs()
+	i64Cap, f64Cap, archOK := archCaps(fn)
 	if !archOK {
 		return nil, ErrUnsupported
 	}
-	if int(fn.NumRegsI64) > cap {
-		return nil, fmt.Errorf("%w: %s uses %d i64 regs (max %d on this arch)",
-			ErrNotImplemented, fn.Name, fn.NumRegsI64, cap)
+	if int(fn.NumRegsI64) > i64Cap {
+		return nil, fmt.Errorf("%w: %s uses %d i64 regs (max %d on this arch%s)",
+			ErrNotImplemented, fn.Name, fn.NumRegsI64, i64Cap, capNote(fn))
+	}
+	if int(fn.NumRegsF64) > f64Cap {
+		return nil, fmt.Errorf("%w: %s uses %d f64 regs (max %d on this arch)",
+			ErrNotImplemented, fn.Name, fn.NumRegsF64, f64Cap)
+	}
+	if fn.NumRegsF64 > 0 && fn.ResultBank != vm3.BankF64 && fn.ResultBank != vm3.BankI64 {
+		return nil, fmt.Errorf("%w: %s f64 fn returns non-{i64,f64} bank",
+			ErrNotImplemented, fn.Name)
 	}
 	raw, err := lowerHost(fn, opts)
 	if err != nil {
@@ -155,9 +185,13 @@ func lowerHost(fn *vm3.Function, opts Options) ([]byte, error) {
 // archMaxI64Regs returns the host architecture's cap on simultaneously
 // live i64 registers, and whether the architecture is supported at
 // all. AArch64 supports 17 (x9..x15 caller-saved + x19..x28
-// callee-saved). AMD64 supports 12 (R10/R11/RDI/RSI/RDX/RCX/R8/R9
-// caller-saved + R12..R15 callee-saved; RBX is reserved for the
-// regsI64 base pointer).
+// callee-saved). AMD64 supports 9 (RSI/RDI/R8/R9/R10/R11 caller-saved
+// + R12..R14 callee-saved; RBX is reserved for the regsI64 base
+// pointer and R15 for the *status word).
+//
+// Deprecated: kept for callers outside the JIT itself. Internal call
+// sites should use archCaps(fn) which folds in the F64-driven i64-cap
+// reduction on AMD64.
 func archMaxI64Regs() (int, bool) {
 	switch hostArch {
 	case ArchARM64:
@@ -167,4 +201,34 @@ func archMaxI64Regs() (int, bool) {
 	default:
 		return 0, false
 	}
+}
+
+// archCaps returns the host architecture's caps on simultaneously-live
+// (i64, f64) registers given fn's bank shape, along with whether the
+// architecture is supported. On AMD64, when fn.NumRegsF64 > 0 the i64
+// cap drops to 8 because R14 is repurposed to hold the regsF64 base
+// pointer (the regsI64 base lives in RBX, *status in R15). AArch64 is
+// unaffected: the regsF64 base lives in x2, which is already free.
+func archCaps(fn *vm3.Function) (int, int, bool) {
+	switch hostArch {
+	case ArchARM64:
+		return maxI64Regs, maxF64RegsARM64, true
+	case ArchAMD64:
+		i64Cap := maxI64RegsAMD64
+		if fn.NumRegsF64 > 0 {
+			i64Cap = maxI64RegsAMD64 - 1 // steal R14 for regsF64 base
+		}
+		return i64Cap, maxF64RegsAMD64, true
+	default:
+		return 0, 0, false
+	}
+}
+
+// capNote explains the AMD64 i64-cap reduction for the error message
+// when fn would otherwise have fit but the F64 bank steals R14.
+func capNote(fn *vm3.Function) string {
+	if hostArch == ArchAMD64 && fn.NumRegsF64 > 0 {
+		return " with f64 regs in use; R14 is stolen for the regsF64 base pointer"
+	}
+	return ""
 }

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -97,9 +97,17 @@ func r2xAMD64(r uint16) int {
 // (R12..R14). The prologue pushes those before clobbering them.
 func calleeSavedSlot(r uint16) bool { return r >= 6 && r < 9 }
 
+// usesR14ForF64 reports whether the AMD64 backend repurposes R14 as
+// the regsF64 base pointer for fn. This stacks on top of the SysV
+// callee-saved rule: R14 is also Go's G register, so we must push/pop
+// it regardless of how it is used inside the JIT'd body.
+func usesR14ForF64(fn *vm3.Function) bool { return fn.NumRegsF64 > 0 }
+
 // numCalleeSavedPushesAMD64 returns the number of R12..R14 pushes the
 // prologue needs for fn, plus the always-present RBX and R15 pushes
 // (2). Used by both the prologue emitter and the byte-count predictor.
+// R14 is pushed when (a) i64 slot 8 lands in R14 OR (b) R14 holds the
+// regsF64 base for an f64-touching fn.
 func numCalleeSavedPushesAMD64(fn *vm3.Function) int {
 	n := int(fn.NumRegsI64)
 	if n > maxI64RegsAMD64 {
@@ -113,7 +121,7 @@ func numCalleeSavedPushesAMD64(fn *vm3.Function) int {
 	if n > 7 {
 		count++
 	}
-	if n > 8 {
+	if n > 8 || usesR14ForF64(fn) {
 		count++
 	}
 	return count
@@ -192,6 +200,10 @@ func computeCallSpillsAMD64(fn *vm3.Function) []uint32 {
 // destinations through pcMap. opts.SelfIdx (>= 0) enables self-recursive
 // OpCallI64 as a native CALL inside the same code page.
 func lowerAMD64(fn *vm3.Function, opts Options) ([]byte, error) {
+	if fn.NumRegsF64 > 0 && isNonLeafAMD64(fn) {
+		return nil, fmt.Errorf("%w: %s has both f64 regs and OpCallI64 (Phase 6.2b leaves f64+self-recursion to a later sub-phase)",
+			ErrNotImplemented, fn.Name)
+	}
 	prologueBytes := prologueLenAMD64(fn)
 	spillSets := computeCallSpillsAMD64(fn)
 
@@ -238,6 +250,7 @@ func lowerAMD64(fn *vm3.Function, opts Options) ([]byte, error) {
 // to seed pcMap[0].
 func prologueLenAMD64(fn *vm3.Function) int {
 	n := int(fn.NumRegsI64)
+	nF := int(fn.NumRegsF64)
 	pushes := numCalleeSavedPushesAMD64(fn)
 	// push rbx, push r15: each REX.B-extended push of r12..r15 is 2
 	// bytes; push rbx is 1 byte. Compute exactly.
@@ -250,7 +263,7 @@ func prologueLenAMD64(fn *vm3.Function) int {
 	if n > 7 {
 		bytes += pushBytes(xR13)
 	}
-	if n > 8 {
+	if n > 8 || usesR14ForF64(fn) {
 		bytes += pushBytes(xR14)
 	}
 	if alignFixupBytesAMD64(fn) != 0 {
@@ -258,8 +271,15 @@ func prologueLenAMD64(fn *vm3.Function) int {
 	}
 	// mov %rdi, %rbx (3 bytes), mov %rsi, %r15 (3 bytes).
 	bytes += 3 + 3
-	// Each pinned slot load is mov disp32(%rbx), <reg> = 7 bytes.
+	// mov %rdx, %r14 (3 bytes) when R14 holds regsF64 base.
+	if usesR14ForF64(fn) {
+		bytes += 3
+	}
+	// Each pinned i64 slot load is mov disp32(%rbx), <reg> = 7 bytes.
 	bytes += 7 * n
+	// Each pinned f64 slot load is movsd disp32(%r14), xmm<r> = 9 bytes
+	// (REX.B-prefixed because R14 is r >= 8).
+	bytes += 9 * nF
 	_ = pushes
 	return bytes
 }
@@ -289,6 +309,7 @@ func popBytes(r int) int { return pushBytes(r) }
 //	...
 func emitPrologueAMD64(buf []byte, fn *vm3.Function) []byte {
 	n := int(fn.NumRegsI64)
+	nF := int(fn.NumRegsF64)
 	buf = append(buf, push64(xRBX)...)
 	buf = append(buf, push64(xR15)...)
 	if n > 6 {
@@ -297,7 +318,7 @@ func emitPrologueAMD64(buf []byte, fn *vm3.Function) []byte {
 	if n > 7 {
 		buf = append(buf, push64(xR13)...)
 	}
-	if n > 8 {
+	if n > 8 || usesR14ForF64(fn) {
 		buf = append(buf, push64(xR14)...)
 	}
 	if alignFixupBytesAMD64(fn) != 0 {
@@ -305,8 +326,14 @@ func emitPrologueAMD64(buf []byte, fn *vm3.Function) []byte {
 	}
 	buf = append(buf, mov64RR(xRDI, xRBX)...)
 	buf = append(buf, mov64RR(xRSI, xR15)...)
+	if usesR14ForF64(fn) {
+		buf = append(buf, mov64RR(xRDX, xR14)...)
+	}
 	for r := 0; r < n; r++ {
 		buf = append(buf, mov64LoadDisp32(r2xAMD64(uint16(r)), xRBX, int32(r*8))...)
+	}
+	for r := 0; r < nF; r++ {
+		buf = append(buf, movsdLoadXMMFromR14(r, int32(r*8))...)
 	}
 	return buf
 }
@@ -320,7 +347,7 @@ func emitEpilogueAMD64(buf []byte, fn *vm3.Function) []byte {
 	if alignFixupBytesAMD64(fn) != 0 {
 		buf = append(buf, addRSPImm8(8)...)
 	}
-	if n > 8 {
+	if n > 8 || usesR14ForF64(fn) {
 		buf = append(buf, pop64(xR14)...)
 	}
 	if n > 7 {
@@ -343,7 +370,7 @@ func epilogueBytesAMD64(fn *vm3.Function) int {
 	if alignFixupBytesAMD64(fn) != 0 {
 		bytes += 4 // add $8, %rsp
 	}
-	if n > 8 {
+	if n > 8 || usesR14ForF64(fn) {
 		bytes += popBytes(xR14)
 	}
 	if n > 7 {
@@ -452,6 +479,53 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 	case vm3.OpReturnConstK:
 		// mov $imm, %rax + epilogue.
 		return movImm64ByteCount(int64(op.C), xRAX) + epilogueBytesAMD64(fn), nil
+	case vm3.OpReturnF64:
+		// movq xmm<A>, %rax (5) + epilogue.
+		return 5 + epilogueBytesAMD64(fn), nil
+
+	case vm3.OpConstF64K:
+		idx := int(uint16(op.C))
+		if idx >= len(fn.Consts) {
+			return 0, fmt.Errorf("%w: ConstF64K idx %d out of range", ErrNotImplemented, idx)
+		}
+		bits := int64(uint64(fn.Consts[idx]))
+		// mov $imm, %rcx (7 or 10) ; movq xmm<A>, %rcx (5).
+		return movImm64ByteCount(bits, xRCX) + 5, nil
+
+	case vm3.OpMovF64:
+		// movsd xmm<A>, xmm<B>: 4 bytes (xmm0..7 only, no REX needed).
+		return 4, nil
+	case vm3.OpAddF64, vm3.OpSubF64, vm3.OpMulF64, vm3.OpDivF64:
+		// optional movsd xmm<A>, xmm<B> (4) ; <op>sd xmm<A>, xmm<C> (4).
+		if op.A == op.B {
+			return 4, nil
+		}
+		return 8, nil
+	case vm3.OpNegF64:
+		// mov $signbit, %rcx (10) ; movq xmm15, %rcx (5, REX.W+R) ;
+		// optional movsd xmm<A>, xmm<B> (4) ; xorpd xmm<A>, xmm15 (5, REX.B).
+		if op.A == op.B {
+			return 10 + 5 + 5, nil
+		}
+		return 10 + 5 + 4 + 5, nil
+
+	case vm3.OpCmpEqF64Br, vm3.OpCmpLtF64Br, vm3.OpCmpLeF64Br:
+		// ucomisd xmm<A>, xmm<B> (4) ; jp +6 (6) ; jcc rel32 (6).
+		return 4 + 6 + 6, nil
+	case vm3.OpCmpNeF64Br:
+		// ucomisd (4) ; jp target (6) ; jne target (6).
+		return 4 + 6 + 6, nil
+	case vm3.OpCmpGtF64Br, vm3.OpCmpGeF64Br:
+		// ucomisd (4) ; jcc rel32 (6).
+		return 4 + 6, nil
+
+	case vm3.OpI64ToF64:
+		// cvtsi2sd xmm<A>, %r<B> (5, F2 REX.W 0F 2A /r — 5 bytes when
+		// xmm0..7 and i64 reg needs REX.B for r >= 8).
+		return cvtsi2sdByteCount(op.B), nil
+	case vm3.OpF64ToI64:
+		// cvttsd2si %r<A>, xmm<B>: F2 REX.W 0F 2C /r — 5 bytes.
+		return cvttsd2siByteCount(op.A), nil
 	case vm3.OpCallI64:
 		if opts.SelfIdx < 0 || int(uint16(op.C)) != opts.SelfIdx {
 			return 0, fmt.Errorf("%w: CallI64 to non-self idx %d (SelfIdx=%d)",
@@ -577,6 +651,92 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		out := movImm64(xRAX, int64(op.C))
 		out = emitEpilogueAMD64(out, fn)
 		return out, nil
+	case vm3.OpReturnF64:
+		// movq %rax, %xmm<A>: bit-cast f64 to int64 in RAX, then run
+		// the epilogue (which preserves RAX through pops).
+		out := movqR64FromXMM(xRAX, int(op.A))
+		out = emitEpilogueAMD64(out, fn)
+		return out, nil
+
+	case vm3.OpConstF64K:
+		bits := int64(uint64(fn.Consts[int(uint16(op.C))]))
+		out := movImm64(xRCX, bits)
+		out = append(out, movqXMMFromR64(int(op.A), xRCX)...)
+		return out, nil
+
+	case vm3.OpMovF64:
+		return movsdRR(int(op.A), int(op.B)), nil
+	case vm3.OpAddF64:
+		var out []byte
+		if op.A != op.B {
+			out = append(out, movsdRR(int(op.A), int(op.B))...)
+		}
+		out = append(out, addsdRR(int(op.A), int(uint16(op.C)))...)
+		return out, nil
+	case vm3.OpSubF64:
+		var out []byte
+		if op.A != op.B {
+			out = append(out, movsdRR(int(op.A), int(op.B))...)
+		}
+		out = append(out, subsdRR(int(op.A), int(uint16(op.C)))...)
+		return out, nil
+	case vm3.OpMulF64:
+		var out []byte
+		if op.A != op.B {
+			out = append(out, movsdRR(int(op.A), int(op.B))...)
+		}
+		out = append(out, mulsdRR(int(op.A), int(uint16(op.C)))...)
+		return out, nil
+	case vm3.OpDivF64:
+		var out []byte
+		if op.A != op.B {
+			out = append(out, movsdRR(int(op.A), int(op.B))...)
+		}
+		out = append(out, divsdRR(int(op.A), int(uint16(op.C)))...)
+		return out, nil
+	case vm3.OpNegF64:
+		// xmm15 = bit-pattern 0x8000000000000000 ; result = src ^ xmm15.
+		signBit := uint64(1) << 63
+		out := movImm64(xRCX, int64(signBit))
+		out = append(out, movqXMMFromR64(15, xRCX)...)
+		if op.A != op.B {
+			out = append(out, movsdRR(int(op.A), int(op.B))...)
+		}
+		out = append(out, xorpdRR(int(op.A), 15)...)
+		return out, nil
+
+	case vm3.OpCmpEqF64Br, vm3.OpCmpLtF64Br, vm3.OpCmpLeF64Br:
+		// ucomisd ; jp +6 (skip the je/jb/jbe) ; jcc target.
+		dst := pcMap[int(uint16(op.C))]
+		out := ucomisdRR(int(op.A), int(op.B))
+		out = append(out, jccRel32(byte(0xA), 6)...) // JP rel32 over the next 6 bytes
+		src := pcMap[idx] + len(out) + 6
+		rel := int32(dst - src)
+		cc := condForCmpF64AMD64(op.Code)
+		out = append(out, jccRel32(cc, rel)...)
+		return out, nil
+	case vm3.OpCmpNeF64Br:
+		// ucomisd ; jp target ; jne target.
+		dst := pcMap[int(uint16(op.C))]
+		out := ucomisdRR(int(op.A), int(op.B))
+		src1 := pcMap[idx] + len(out) + 6
+		out = append(out, jccRel32(byte(0xA), int32(dst-src1))...) // JP target
+		src2 := pcMap[idx] + len(out) + 6
+		out = append(out, jccRel32(byte(0x5), int32(dst-src2))...) // JNE target
+		return out, nil
+	case vm3.OpCmpGtF64Br, vm3.OpCmpGeF64Br:
+		// ucomisd ; ja/jae target (single 6-byte branch).
+		dst := pcMap[int(uint16(op.C))]
+		out := ucomisdRR(int(op.A), int(op.B))
+		src := pcMap[idx] + len(out) + 6
+		cc := condForCmpF64AMD64(op.Code)
+		out = append(out, jccRel32(cc, int32(dst-src))...)
+		return out, nil
+
+	case vm3.OpI64ToF64:
+		return cvtsi2sd(int(op.A), int(r2xAMD64(op.B))), nil
+	case vm3.OpF64ToI64:
+		return cvttsd2si(int(r2xAMD64(op.A)), int(op.B)), nil
 	case vm3.OpCallI64:
 		if opts.SelfIdx < 0 || int(uint16(op.C)) != opts.SelfIdx {
 			return nil, fmt.Errorf("%w: CallI64 to non-self idx %d (SelfIdx=%d)",
@@ -951,4 +1111,129 @@ func appendImm32(out []byte, v int32) []byte {
 	var b [4]byte
 	binary.LittleEndian.PutUint32(b[:], uint32(v))
 	return append(out, b[:]...)
+}
+
+// --- SSE2 / XMM encoders for the f64 bank ---
+//
+// All forms here keep REX optional (4-byte encodings) when both operands
+// are xmm0..7 to match byteCountAMD64's predictions. When either side is
+// xmm8..15 a REX prefix is added, growing the encoding by one byte. The
+// 5-byte form is used by xorpd against xmm15 in OpNegF64 and by the
+// MOVQ GPR<->XMM bit-cast ops where REX.W is always present.
+
+// sseRR2 emits `<F2-prefix>sse op xmmDst, xmmSrc` for ADDSD/SUBSD/
+// MULSD/DIVSD/MOVSD. Opcodes are F2 [REX] 0F xx /r.
+func sseRR2(opc byte, dst, src int) []byte {
+	if dst < 8 && src < 8 {
+		return []byte{0xF2, 0x0F, opc, modRM(3, byte(dst), byte(src))}
+	}
+	return []byte{0xF2, rex(false, dst >= 8, false, src >= 8), 0x0F, opc, modRM(3, byte(dst&7), byte(src&7))}
+}
+
+// movsdRR emits `movsd xmmDst, xmmSrc` (low-64-bit register copy).
+// Opcode F2 [REX] 0F 10 /r. Always emits the instruction even when
+// dst==src so byteCount predictions stay deterministic.
+func movsdRR(dst, src int) []byte { return sseRR2(0x10, dst, src) }
+
+// addsdRR emits `addsd xmmDst, xmmSrc`. Opcode F2 [REX] 0F 58 /r.
+func addsdRR(dst, src int) []byte { return sseRR2(0x58, dst, src) }
+
+// subsdRR emits `subsd xmmDst, xmmSrc`. Opcode F2 [REX] 0F 5C /r.
+func subsdRR(dst, src int) []byte { return sseRR2(0x5C, dst, src) }
+
+// mulsdRR emits `mulsd xmmDst, xmmSrc`. Opcode F2 [REX] 0F 59 /r.
+func mulsdRR(dst, src int) []byte { return sseRR2(0x59, dst, src) }
+
+// divsdRR emits `divsd xmmDst, xmmSrc`. Opcode F2 [REX] 0F 5E /r.
+func divsdRR(dst, src int) []byte { return sseRR2(0x5E, dst, src) }
+
+// movsdLoadXMMFromR14 emits `movsd xmm<dst>, disp32(%r14)`.
+// Opcode F2 REX.B 0F 10 /r disp32. REX is always present (REX.B for R14
+// in the r/m field). Always 9 bytes for xmm0..7 destinations.
+func movsdLoadXMMFromR14(dst int, disp int32) []byte {
+	out := []byte{0xF2, rex(false, dst >= 8, false, true), 0x0F, 0x10, modRM(2, byte(dst&7), byte(xR14&7))}
+	return appendImm32(out, disp)
+}
+
+// xorpdRR emits `xorpd xmmDst, xmmSrc`. Opcode 66 [REX] 0F 57 /r. Used
+// by OpNegF64 to flip the sign bit by XOR with xmm15 holding
+// 0x8000000000000000.
+func xorpdRR(dst, src int) []byte {
+	if dst < 8 && src < 8 {
+		return []byte{0x66, 0x0F, 0x57, modRM(3, byte(dst), byte(src))}
+	}
+	return []byte{0x66, rex(false, dst >= 8, false, src >= 8), 0x0F, 0x57, modRM(3, byte(dst&7), byte(src&7))}
+}
+
+// ucomisdRR emits `ucomisd xmmLhs, xmmRhs` (unordered compare, sets
+// EFLAGS). Opcode 66 [REX] 0F 2E /r. The f64 compare-and-branch lowers
+// to a UCOMISD followed by a JP-guarded JCC pair (or single JA/JAE for
+// Gt/Ge).
+func ucomisdRR(lhs, rhs int) []byte {
+	if lhs < 8 && rhs < 8 {
+		return []byte{0x66, 0x0F, 0x2E, modRM(3, byte(lhs), byte(rhs))}
+	}
+	return []byte{0x66, rex(false, lhs >= 8, false, rhs >= 8), 0x0F, 0x2E, modRM(3, byte(lhs&7), byte(rhs&7))}
+}
+
+// movqXMMFromR64 emits `movq xmmDst, rSrc64` (GPR-to-XMM bit-cast).
+// Opcode 66 REX.W 0F 6E /r. xmm goes in reg field, r64 in r/m field.
+// REX.W is always set so the encoding is always 5 bytes.
+func movqXMMFromR64(xmm, r64 int) []byte {
+	return []byte{0x66, rex(true, xmm >= 8, false, r64 >= 8), 0x0F, 0x6E, modRM(3, byte(xmm&7), byte(r64&7))}
+}
+
+// movqR64FromXMM emits `movq rDst64, xmmSrc` (XMM-to-GPR bit-cast).
+// Opcode 66 REX.W 0F 7E /r. Used by OpReturnF64 to deliver the f64 in
+// RAX (where the trampoline picks it up as a uint64 and the Go caller
+// reads with math.Float64frombits).
+func movqR64FromXMM(r64, xmm int) []byte {
+	return []byte{0x66, rex(true, xmm >= 8, false, r64 >= 8), 0x0F, 0x7E, modRM(3, byte(xmm&7), byte(r64&7))}
+}
+
+// cvtsi2sd emits `cvtsi2sd xmmDst, rSrc64` (signed int64 to double).
+// Opcode F2 REX.W 0F 2A /r. Always 5 bytes.
+func cvtsi2sd(xmm, r64 int) []byte {
+	return []byte{0xF2, rex(true, xmm >= 8, false, r64 >= 8), 0x0F, 0x2A, modRM(3, byte(xmm&7), byte(r64&7))}
+}
+
+// cvttsd2si emits `cvttsd2si rDst64, xmmSrc` (truncating double to
+// signed int64). Opcode F2 REX.W 0F 2C /r. Always 5 bytes.
+func cvttsd2si(r64, xmm int) []byte {
+	return []byte{0xF2, rex(true, r64 >= 8, false, xmm >= 8), 0x0F, 0x2C, modRM(3, byte(r64&7), byte(xmm&7))}
+}
+
+// cvtsi2sdByteCount mirrors cvtsi2sd; REX.W is always present so the
+// encoding is always 5 bytes regardless of operand register selection.
+func cvtsi2sdByteCount(r uint16) int { return 5 }
+
+// cvttsd2siByteCount mirrors cvttsd2si; always 5 bytes.
+func cvttsd2siByteCount(r uint16) int { return 5 }
+
+// condForCmpF64AMD64 returns the JCC condition for an f64 compare-and-
+// branch. UCOMISD sets EFLAGS for `lhs RELATION rhs`:
+//
+//	greater: CF=0, ZF=0, PF=0
+//	less:    CF=1, ZF=0, PF=0
+//	equal:   CF=0, ZF=1, PF=0
+//	unordered (NaN): CF=1, ZF=1, PF=1
+//
+// Eq/Lt/Le are emitted as a JP-skip-+6 + JCC pair so the JCC only fires
+// on the ordered case. Gt/Ge are JA/JAE, which require CF=0 and so
+// naturally exclude the NaN path. Ne is special-cased inline as
+// JP-to-target + JNE-to-target so NaN propagates to a branch.
+func condForCmpF64AMD64(code vm3.OpCode) byte {
+	switch code {
+	case vm3.OpCmpEqF64Br:
+		return 0x4 // JE  (ZF=1)
+	case vm3.OpCmpLtF64Br:
+		return 0x2 // JB  (CF=1)
+	case vm3.OpCmpLeF64Br:
+		return 0x6 // JBE (CF=1 OR ZF=1)
+	case vm3.OpCmpGtF64Br:
+		return 0x7 // JA  (CF=0 AND ZF=0)
+	case vm3.OpCmpGeF64Br:
+		return 0x3 // JAE (CF=0)
+	}
+	return 0x4
 }

--- a/runtime/jit/vm3jit/lower_arm64.go
+++ b/runtime/jit/vm3jit/lower_arm64.go
@@ -38,6 +38,12 @@ func r2x(r uint16) uint32 {
 	return uint32(r) - 7 + 19
 }
 
+// r2d maps a vm3 f64 register slot to the AArch64 SIMD register
+// number (V0..V7 / D0..D7). Caller pre-checks r < maxF64RegsARM64.
+// The same register number is used for both V (128-bit) and D
+// (lower 64-bit) views; the instruction encoding chooses the view.
+func r2d(r uint16) uint32 { return uint32(r) }
+
 // computeCallSpills runs a backward liveness pass over fn.Code and
 // returns, for each bytecode index, the bitset of caller-saved i64
 // registers (bank 0..6, mapped to x9..x15) that must be spilled to the
@@ -164,9 +170,13 @@ func emitDeoptBlockARM64(fn *vm3.Function, statusCode int64) []uint32 {
 // destinations through pcMap. opts.SelfIdx, when >= 0, enables self-
 // recursive OpCallI64 to lower to a native BL inside this page.
 func lowerARM64(fn *vm3.Function, opts Options) ([]uint32, error) {
+	if fn.NumRegsF64 > 0 && isNonLeaf(fn) {
+		return nil, fmt.Errorf("%w: %s has both f64 regs and OpCallI64 (Phase 6.2b leaves f64+self-recursion to a later sub-phase)",
+			ErrNotImplemented, fn.Name)
+	}
 	pairs := numCalleeSavedPairs(fn)
 	lrPair := numLRPair(fn)
-	prologueWords := lrPair + pairs + int(fn.NumRegsI64)
+	prologueWords := lrPair + pairs + int(fn.NumRegsI64) + int(fn.NumRegsF64)
 	spillSets := computeCallSpills(fn)
 
 	pcMap := make([]int, len(fn.Code)+1)
@@ -185,7 +195,8 @@ func lowerARM64(fn *vm3.Function, opts Options) ([]uint32, error) {
 
 	// Prologue: push x29:x30 (outermost) if non-leaf, then push
 	// callee-saved pairs, then load each live reg from [x0, #r*8] into
-	// its pinned host register.
+	// its pinned host register, then load each live f64 reg from
+	// [x2, #r*8] into V0..V7.
 	if lrPair == 1 {
 		ws = append(ws, stpPreIdx64(29, 30, 31, -16))
 	}
@@ -194,6 +205,9 @@ func lowerARM64(fn *vm3.Function, opts Options) ([]uint32, error) {
 	}
 	for r := uint32(0); r < uint32(fn.NumRegsI64); r++ {
 		ws = append(ws, ldr64(r2x(uint16(r)), 0, r))
+	}
+	for r := uint32(0); r < uint32(fn.NumRegsF64); r++ {
+		ws = append(ws, ldrD(r2d(uint16(r)), 2, r))
 	}
 
 	for i, op := range fn.Code {
@@ -295,6 +309,41 @@ func wordCountARM64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 	case vm3.OpReturnConstK:
 		// movImm64 into x0; <pop callee-saved frame>; <pop x29:x30>; RET.
 		return movImm64WordCount(int64(op.C)) + numCalleeSavedPairs(fn) + numLRPair(fn) + 1, nil
+	case vm3.OpReturnF64:
+		// FMOV x0, D<retSlot>; <pop callee-saved frame>; <pop x29:x30>; RET.
+		// Bit-cast the f64 in d<A> to a uint64 in x0 so the trampoline
+		// return channel carries either bank uniformly.
+		return 2 + numCalleeSavedPairs(fn) + numLRPair(fn), nil
+
+	case vm3.OpConstF64K:
+		// MOV imm into x16 with the IEEE 754 bit-pattern, then
+		// FMOV D<A>, x16 to bit-cast into the SIMD register. No
+		// constant pool lookup at runtime; the bits are baked into
+		// the JIT'd stream.
+		idx := int(uint16(op.C))
+		if idx >= len(fn.Consts) {
+			return 0, fmt.Errorf("%w: ConstF64K idx %d out of range", ErrNotImplemented, idx)
+		}
+		bits := int64(uint64(fn.Consts[idx]))
+		return movImm64WordCount(bits) + 1, nil
+
+	case vm3.OpMovF64:
+		return 1, nil
+	case vm3.OpAddF64, vm3.OpSubF64, vm3.OpMulF64, vm3.OpDivF64:
+		return 1, nil
+	case vm3.OpNegF64:
+		return 1, nil
+
+	case vm3.OpCmpEqF64Br, vm3.OpCmpNeF64Br,
+		vm3.OpCmpLtF64Br, vm3.OpCmpLeF64Br,
+		vm3.OpCmpGtF64Br, vm3.OpCmpGeF64Br:
+		// FCMP Dn, Dm ; B.cond <target>.
+		return 2, nil
+
+	case vm3.OpI64ToF64:
+		return 1, nil
+	case vm3.OpF64ToI64:
+		return 1, nil
 	case vm3.OpCallI64:
 		// Self-recursion only. Anything else routes back through the
 		// interpreter via ErrNotImplemented.
@@ -433,6 +482,53 @@ func emitInstrARM64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		ws = emitFrameEpilogueARM64(ws, numCalleeSavedPairs(fn), numLRPair(fn))
 		ws = append(ws, ret())
 		return ws, nil
+
+	case vm3.OpReturnF64:
+		// FMOV x0, D<A>: bit-cast the f64 result to a uint64 in x0
+		// so the trampoline returns the bit pattern. Caller does
+		// math.Float64frombits to recover the f64. Then run the
+		// epilogue exactly like OpReturnI64.
+		ws := []uint32{fmovXD(0, r2d(op.A))}
+		ws = emitFrameEpilogueARM64(ws, numCalleeSavedPairs(fn), numLRPair(fn))
+		ws = append(ws, ret())
+		return ws, nil
+
+	case vm3.OpConstF64K:
+		dA := r2d(op.A)
+		bits := int64(uint64(fn.Consts[int(uint16(op.C))]))
+		ws := movImm64(16, bits)
+		ws = append(ws, fmovDX(dA, 16))
+		return ws, nil
+
+	case vm3.OpMovF64:
+		return []uint32{fmovDD(r2d(op.A), r2d(op.B))}, nil
+	case vm3.OpAddF64:
+		return []uint32{faddD(r2d(op.A), r2d(op.B), r2d(uint16(op.C)))}, nil
+	case vm3.OpSubF64:
+		return []uint32{fsubD(r2d(op.A), r2d(op.B), r2d(uint16(op.C)))}, nil
+	case vm3.OpMulF64:
+		return []uint32{fmulD(r2d(op.A), r2d(op.B), r2d(uint16(op.C)))}, nil
+	case vm3.OpDivF64:
+		return []uint32{fdivD(r2d(op.A), r2d(op.B), r2d(uint16(op.C)))}, nil
+	case vm3.OpNegF64:
+		return []uint32{fnegD(r2d(op.A), r2d(op.B))}, nil
+
+	case vm3.OpCmpEqF64Br, vm3.OpCmpNeF64Br,
+		vm3.OpCmpLtF64Br, vm3.OpCmpLeF64Br,
+		vm3.OpCmpGtF64Br, vm3.OpCmpGeF64Br:
+		cond := condForCmpF64(op.Code)
+		dstWord := pcMap[int(uint16(op.C))]
+		srcWord := pcMap[idx] + 1
+		off, err := branchOff(srcWord, dstWord, 19)
+		if err != nil {
+			return nil, err
+		}
+		return []uint32{fcmpD(r2d(op.A), r2d(op.B)), bCond(cond, off)}, nil
+
+	case vm3.OpI64ToF64:
+		return []uint32{scvtfDX(r2d(op.A), r2x(op.B))}, nil
+	case vm3.OpF64ToI64:
+		return []uint32{fcvtzsXD(r2x(op.A), r2d(op.B))}, nil
 
 	case vm3.OpCallI64:
 		if opts.SelfIdx < 0 || int(uint16(op.C)) != opts.SelfIdx {
@@ -717,4 +813,102 @@ func movImm64WordCount(v int64) int {
 		return 1
 	}
 	return n
+}
+
+// --- AArch64 SIMD/FP encoders (scalar double, V0..V31) ---
+//
+// All encoders take and return raw register numbers (0..31) in the
+// "D" (lower 64-bit lane) view of the SIMD bank. The full-vector "V"
+// view shares the same register number.
+
+// ldrD encodes LDR Dt, [Xn, #imm12*8] (load 64-bit FP register from
+// memory at base+imm12*8). Used by the prologue to fill the pinned
+// f64 slots from regsF64 (x2).
+func ldrD(dt, xn, imm12 uint32) uint32 {
+	return 0xFD400000 | ((imm12 & 0xFFF) << 10) | ((xn & 0x1F) << 5) | (dt & 0x1F)
+}
+
+// fmovDX encodes FMOV Dd, Xn (general -> SIMD bit-cast).
+// Used by OpConstF64K after loading the IEEE 754 bit-pattern into x16.
+func fmovDX(dd, xn uint32) uint32 {
+	return 0x9E670000 | ((xn & 0x1F) << 5) | (dd & 0x1F)
+}
+
+// fmovXD encodes FMOV Xd, Dn (SIMD -> general bit-cast).
+// Used by OpReturnF64 to copy d<retSlot> into x0 so the trampoline
+// can return the raw IEEE 754 bit pattern.
+func fmovXD(xd, dn uint32) uint32 {
+	return 0x9E660000 | ((dn & 0x1F) << 5) | (xd & 0x1F)
+}
+
+// fmovDD encodes FMOV Dd, Dn (SIMD reg-reg copy, double).
+func fmovDD(dd, dn uint32) uint32 {
+	return 0x1E604000 | ((dn & 0x1F) << 5) | (dd & 0x1F)
+}
+
+// faddD encodes FADD Dd, Dn, Dm (scalar double).
+func faddD(dd, dn, dm uint32) uint32 {
+	return 0x1E602800 | ((dm & 0x1F) << 16) | ((dn & 0x1F) << 5) | (dd & 0x1F)
+}
+
+// fsubD encodes FSUB Dd, Dn, Dm.
+func fsubD(dd, dn, dm uint32) uint32 {
+	return 0x1E603800 | ((dm & 0x1F) << 16) | ((dn & 0x1F) << 5) | (dd & 0x1F)
+}
+
+// fmulD encodes FMUL Dd, Dn, Dm.
+func fmulD(dd, dn, dm uint32) uint32 {
+	return 0x1E600800 | ((dm & 0x1F) << 16) | ((dn & 0x1F) << 5) | (dd & 0x1F)
+}
+
+// fdivD encodes FDIV Dd, Dn, Dm.
+func fdivD(dd, dn, dm uint32) uint32 {
+	return 0x1E601800 | ((dm & 0x1F) << 16) | ((dn & 0x1F) << 5) | (dd & 0x1F)
+}
+
+// fnegD encodes FNEG Dd, Dn.
+func fnegD(dd, dn uint32) uint32 {
+	return 0x1E614000 | ((dn & 0x1F) << 5) | (dd & 0x1F)
+}
+
+// fcmpD encodes FCMP Dn, Dm (scalar double compare). Sets NZCV from
+// the IEEE 754 unordered-aware comparison: ordered Eq/Ne/Lt/Le/Gt/Ge
+// branch under the standard cond codes; NaN sets V (and C) so ordered
+// predicates fail naturally without an extra unordered check.
+func fcmpD(dn, dm uint32) uint32 {
+	return 0x1E602000 | ((dm & 0x1F) << 16) | ((dn & 0x1F) << 5)
+}
+
+// scvtfDX encodes SCVTF Dd, Xn (signed 64-bit int -> double, round to
+// nearest even). Used by OpI64ToF64.
+func scvtfDX(dd, xn uint32) uint32 {
+	return 0x9E620000 | ((xn & 0x1F) << 5) | (dd & 0x1F)
+}
+
+// fcvtzsXD encodes FCVTZS Xd, Dn (double -> signed 64-bit int,
+// truncating toward zero). Used by OpF64ToI64.
+func fcvtzsXD(xd, dn uint32) uint32 {
+	return 0x9E780000 | ((dn & 0x1F) << 5) | (xd & 0x1F)
+}
+
+// condForCmpF64 returns the AArch64 B.cond condition code for a vm3
+// f64 reg-reg compare-and-branch opcode. Ordered predicates use the
+// standard unsigned condition codes (HI/HS/MI/LS) because FCMP sets
+// the flags so unordered (NaN) operands fail Lt/Le/Gt/Ge naturally.
+func condForCmpF64(code vm3.OpCode) uint32 {
+	switch code {
+	case vm3.OpCmpEqF64Br:
+		return 0x0 // EQ
+	case vm3.OpCmpNeF64Br:
+		return 0x1 // NE
+	case vm3.OpCmpLtF64Br:
+		return 0x4 // MI (FCMP sets N=1 iff Dn < Dm ordered; unordered keeps N=0)
+	case vm3.OpCmpLeF64Br:
+		return 0x9 // LS (C clear OR Z set; works because FCMP sets C=0 if Dn < Dm)
+	case vm3.OpCmpGtF64Br:
+		return 0xC // GT (Z clear AND N==V)
+	case vm3.OpCmpGeF64Br:
+		return 0xA // GE (N==V)
+	}
+	return 0
 }

--- a/runtime/jit/vm3jit/vm3jit_darwin_arm64_test.go
+++ b/runtime/jit/vm3jit/vm3jit_darwin_arm64_test.go
@@ -3,6 +3,7 @@
 package vm3jit_test
 
 import (
+	"math"
 	"testing"
 	"unsafe"
 
@@ -310,17 +311,17 @@ func runJITProgRecursive(t *testing.T, prog *vm3.Program, arg int64) int64 {
 	return int64(got)
 }
 
-// TestRejectF64 confirms a function with f64 banks is rejected by the
-// 6.0 gate (so callers fall back to the interpreter cleanly).
-func TestRejectF64(t *testing.T) {
+// TestRejectTooManyF64 confirms the 6.2b f64 reg cap rejects oversize
+// functions so callers fall back to the interpreter.
+func TestRejectTooManyF64(t *testing.T) {
 	fn := &vm3.Function{
-		Name:       "f64_reject",
-		NumRegsF64: 1,
+		Name:       "wide_f64",
+		NumRegsF64: vm3jit.MaxF64Regs + 1,
 		ResultBank: vm3.BankF64,
 		Code:       []vm3.Op{vm3.MakeOp(vm3.OpReturnF64, 0, 0, 0)},
 	}
 	if _, err := vm3jit.Compile(fn); err == nil {
-		t.Fatal("expected ErrNotImplemented for f64 fn, got nil")
+		t.Fatal("expected ErrNotImplemented for oversize f64 fn, got nil")
 	}
 }
 
@@ -335,5 +336,82 @@ func TestRejectTooManyI64(t *testing.T) {
 	}
 	if _, err := vm3jit.Compile(fn); err == nil {
 		t.Fatal("expected ErrNotImplemented for too-many-i64 fn, got nil")
+	}
+}
+
+// runJITF64Kernel compiles fn (single i64 param, f64 result) and calls
+// it via the CallStatusFF trampoline. Returns the f64 result and the
+// status word. F64 corpus kernels in Phase 6.2b use this.
+func runJITF64Kernel(t *testing.T, fn *vm3.Function, arg int64) (float64, int64) {
+	t.Helper()
+	cf, err := vm3jit.Compile(fn)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	defer cf.Free()
+	var regsI64 [vm3jit.MaxI64Regs]int64
+	regsI64[0] = arg
+	var regsF64 [vm3jit.MaxF64Regs]float64
+	var status int64
+	bits := trampoline.CallStatusFF(cf.Entry(),
+		unsafe.Pointer(&regsI64[0]),
+		unsafe.Pointer(&status),
+		unsafe.Pointer(&regsF64[0]))
+	return math.Float64frombits(bits), status
+}
+
+// TestCompileF64DotSumMatchesInterp validates Phase 6.2b f64 lowering.
+// F64DotSum exercises OpI64ToF64, OpMulF64, OpAddF64, OpConstF64K,
+// OpReturnF64 alongside the existing i64 cmp/br/AddK kernel shape.
+func TestCompileF64DotSumMatchesInterp(t *testing.T) {
+	prog := corpus.F64DotSum.Build(0)
+	fn := prog.Funcs[prog.Entry]
+	for _, n := range []int64{0, 1, 2, 10, 100, 1000} {
+		got, status := runJITF64Kernel(t, fn, n)
+		if status != vm3jit.StatusOK {
+			t.Fatalf("unexpected deopt n=%d status=%d", n, status)
+		}
+		vm := vm3.NewWithProgram(prog)
+		want, err := vm.RunWithArgs(fn, []int64{n})
+		if err != nil {
+			t.Fatalf("interp n=%d: %v", n, err)
+		}
+		if got != want.Float() {
+			t.Errorf("f64_dot_sum(%d): jit=%g interp=%g", n, got, want.Float())
+		}
+	}
+}
+
+// TestCompileF64ThresholdMatchesInterp drives Phase 6.2b's F64 cmp/br
+// path (OpCmpLtF64Br) and the mixed-bank return: an f64-touching fn
+// that returns i64 via OpReturnI64 / OpReturnConstK.
+func TestCompileF64ThresholdMatchesInterp(t *testing.T) {
+	prog := corpus.F64Threshold.Build(0)
+	fn := prog.Funcs[prog.Entry]
+	cf, err := vm3jit.Compile(fn)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	defer cf.Free()
+	for _, n := range []int64{0, 1, 5, 10, 11, 20, 100} {
+		var regsI64 [vm3jit.MaxI64Regs]int64
+		regsI64[0] = n
+		var regsF64 [vm3jit.MaxF64Regs]float64
+		var status int64
+		got := int64(trampoline.CallStatusFF(cf.Entry(),
+			unsafe.Pointer(&regsI64[0]),
+			unsafe.Pointer(&status),
+			unsafe.Pointer(&regsF64[0])))
+		if status != vm3jit.StatusOK {
+			t.Fatalf("unexpected deopt n=%d status=%d", n, status)
+		}
+		vm := vm3.NewWithProgram(prog)
+		want, err := vm.RunWithArgs(fn, []int64{n})
+		if err != nil {
+			t.Fatalf("interp n=%d: %v", n, err)
+		}
+		if got != want.Int() {
+			t.Errorf("f64_threshold(%d): jit=%d interp=%d", n, got, want.Int())
+		}
 	}
 }

--- a/runtime/jit/vm3jit/vm3jit_linux_amd64_test.go
+++ b/runtime/jit/vm3jit/vm3jit_linux_amd64_test.go
@@ -3,6 +3,7 @@
 package vm3jit_test
 
 import (
+	"math"
 	"testing"
 	"unsafe"
 
@@ -265,15 +266,18 @@ func runJITProgRecursive(t *testing.T, prog *vm3.Program, arg int64) int64 {
 	return int64(got)
 }
 
-func TestRejectF64(t *testing.T) {
+// TestRejectTooManyF64 confirms the 6.2b f64 reg cap rejects oversize
+// functions so callers fall back to the interpreter. The AMD64 cap is
+// MaxF64Regs (8); the test exercises cap+1.
+func TestRejectTooManyF64(t *testing.T) {
 	fn := &vm3.Function{
-		Name:       "f64_reject",
-		NumRegsF64: 1,
+		Name:       "wide_f64",
+		NumRegsF64: vm3jit.MaxF64Regs + 1,
 		ResultBank: vm3.BankF64,
 		Code:       []vm3.Op{vm3.MakeOp(vm3.OpReturnF64, 0, 0, 0)},
 	}
 	if _, err := vm3jit.Compile(fn); err == nil {
-		t.Fatal("expected ErrNotImplemented for f64 fn, got nil")
+		t.Fatal("expected ErrNotImplemented for oversize f64 fn, got nil")
 	}
 }
 
@@ -290,5 +294,82 @@ func TestRejectTooManyI64(t *testing.T) {
 	}
 	if _, err := vm3jit.Compile(fn); err == nil {
 		t.Fatal("expected ErrNotImplemented for too-many-i64 fn, got nil")
+	}
+}
+
+// runJITF64Kernel compiles fn (single i64 param, f64 result) and calls
+// it via the CallStatusFF trampoline. Returns the f64 result and the
+// status word. F64 corpus kernels in Phase 6.2b use this.
+func runJITF64Kernel(t *testing.T, fn *vm3.Function, arg int64) (float64, int64) {
+	t.Helper()
+	cf, err := vm3jit.Compile(fn)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	defer cf.Free()
+	var regsI64 [vm3jit.MaxI64Regs]int64
+	regsI64[0] = arg
+	var regsF64 [vm3jit.MaxF64Regs]float64
+	var status int64
+	bits := trampoline.CallStatusFF(cf.Entry(),
+		unsafe.Pointer(&regsI64[0]),
+		unsafe.Pointer(&status),
+		unsafe.Pointer(&regsF64[0]))
+	return math.Float64frombits(bits), status
+}
+
+// TestCompileF64DotSumMatchesInterp validates Phase 6.2b f64 lowering.
+// F64DotSum exercises OpI64ToF64, OpMulF64, OpAddF64, OpConstF64K,
+// OpReturnF64 alongside the existing i64 cmp/br/AddK kernel shape.
+func TestCompileF64DotSumMatchesInterp(t *testing.T) {
+	prog := corpus.F64DotSum.Build(0)
+	fn := prog.Funcs[prog.Entry]
+	for _, n := range []int64{0, 1, 2, 10, 100, 1000} {
+		got, status := runJITF64Kernel(t, fn, n)
+		if status != vm3jit.StatusOK {
+			t.Fatalf("unexpected deopt n=%d status=%d", n, status)
+		}
+		vm := vm3.NewWithProgram(prog)
+		want, err := vm.RunWithArgs(fn, []int64{n})
+		if err != nil {
+			t.Fatalf("interp n=%d: %v", n, err)
+		}
+		if got != want.Float() {
+			t.Errorf("f64_dot_sum(%d): jit=%g interp=%g", n, got, want.Float())
+		}
+	}
+}
+
+// TestCompileF64ThresholdMatchesInterp drives Phase 6.2b's F64 cmp/br
+// path (OpCmpLtF64Br) and the mixed-bank return: an f64-touching fn
+// that returns i64 via OpReturnI64 / OpReturnConstK.
+func TestCompileF64ThresholdMatchesInterp(t *testing.T) {
+	prog := corpus.F64Threshold.Build(0)
+	fn := prog.Funcs[prog.Entry]
+	cf, err := vm3jit.Compile(fn)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	defer cf.Free()
+	for _, n := range []int64{0, 1, 5, 10, 11, 20, 100} {
+		var regsI64 [vm3jit.MaxI64Regs]int64
+		regsI64[0] = n
+		var regsF64 [vm3jit.MaxF64Regs]float64
+		var status int64
+		got := int64(trampoline.CallStatusFF(cf.Entry(),
+			unsafe.Pointer(&regsI64[0]),
+			unsafe.Pointer(&status),
+			unsafe.Pointer(&regsF64[0])))
+		if status != vm3jit.StatusOK {
+			t.Fatalf("unexpected deopt n=%d status=%d", n, status)
+		}
+		vm := vm3.NewWithProgram(prog)
+		want, err := vm.RunWithArgs(fn, []int64{n})
+		if err != nil {
+			t.Fatalf("interp n=%d: %v", n, err)
+		}
+		if got != want.Int() {
+			t.Errorf("f64_threshold(%d): jit=%d interp=%d", n, got, want.Int())
+		}
 	}
 }

--- a/runtime/vm3/op.go
+++ b/runtime/vm3/op.go
@@ -114,6 +114,23 @@ const (
 	OpListGetCell
 	OpListSetF64
 	OpListSetCell
+
+	// F64 compare-and-branch (Phase 6.2b). C carries target PC (uint16).
+	// IEEE 754 unordered comparisons: NaN forces the branch condition to
+	// false for ordered predicates (Lt/Le/Gt/Ge), so a NaN operand never
+	// branches under those. Eq compares as unordered-false (NaN != NaN);
+	// Ne returns true when either operand is NaN.
+	OpCmpEqF64Br // if regsF64[A] == regsF64[B] jump to uint16(C)
+	OpCmpNeF64Br
+	OpCmpLtF64Br
+	OpCmpLeF64Br
+	OpCmpGtF64Br
+	OpCmpGeF64Br
+
+	// Bank casts (Phase 6.2b). Used by FP kernels that thread an i64
+	// loop counter through an f64 accumulator.
+	OpI64ToF64 // regsF64[A] = float64(regsI64[B])
+	OpF64ToI64 // regsI64[A] = int64(regsF64[B]) (truncating, Go semantics)
 )
 
 // Op is a single 8-byte vm3 bytecode word. Layout:

--- a/runtime/vm3/vm.go
+++ b/runtime/vm3/vm.go
@@ -299,6 +299,50 @@ func (vm *VM) run() (Cell, error) {
 				pc++
 			}
 
+		case OpCmpEqF64Br:
+			if regsF64[op.A] == regsF64[op.B] {
+				pc = int(uint16(op.C))
+			} else {
+				pc++
+			}
+		case OpCmpNeF64Br:
+			if regsF64[op.A] != regsF64[op.B] {
+				pc = int(uint16(op.C))
+			} else {
+				pc++
+			}
+		case OpCmpLtF64Br:
+			if regsF64[op.A] < regsF64[op.B] {
+				pc = int(uint16(op.C))
+			} else {
+				pc++
+			}
+		case OpCmpLeF64Br:
+			if regsF64[op.A] <= regsF64[op.B] {
+				pc = int(uint16(op.C))
+			} else {
+				pc++
+			}
+		case OpCmpGtF64Br:
+			if regsF64[op.A] > regsF64[op.B] {
+				pc = int(uint16(op.C))
+			} else {
+				pc++
+			}
+		case OpCmpGeF64Br:
+			if regsF64[op.A] >= regsF64[op.B] {
+				pc = int(uint16(op.C))
+			} else {
+				pc++
+			}
+
+		case OpI64ToF64:
+			regsF64[op.A] = float64(regsI64[op.B])
+			pc++
+		case OpF64ToI64:
+			regsI64[op.A] = int64(regsF64[op.B])
+			pc++
+
 		case OpJump:
 			pc = int(uint16(op.C))
 

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -1386,10 +1386,26 @@ Reserved (not slot-mapped):
 **Pending (to fill in on first server2 run)**:
 - Measured ns/op for `sum_loop` / `mul_loop` / `fib_iter` / `prime_count` / `fact_rec` / `fib_rec` on linux/amd64 plus the JIT-vs-Go ratio for each. The gate target is the same as on AArch64: every i64-only corpus kernel inside 2x of the fair Go baseline.
 
-#### Phase 6.2b+: f64 SIMD, container/string lowering, full BG suite (planned)
+#### Phase 6.2b: f64 SIMD lowering **LANDED**
+
+**Goal**: lower the regsF64 bank to native SIMD/FP registers on both AArch64 (v0..v7) and AMD64 (xmm0..xmm7) so f64-typed kernels skip the interpreter slot loads/stores entirely. f64-typed compares-and-branch and the i64<->f64 casts also lower natively; the regsF64 base pointer arrives via a new 4-arg trampoline.
+
+**Landed scope**:
+- New trampoline entry `trampoline.CallStatusFF(entry, regsI64, status, regsF64) uint64`. AArch64 puts regsF64 in `x2`; AMD64 in `rdx`. The prologue pins it: AArch64 keeps it in `x2` (free in the i64-only ABI); AMD64 copies it into `r14` (stealing that slot from the i64 cap, which drops to 8 when `NumRegsF64 > 0`). The return path bit-casts an f64 result into the existing uint64 return channel (`FMOV X0, D<retSlot>` on AArch64; `MOVQ %rax, %xmm<retSlot>` on AMD64); the Go caller decodes with `math.Float64frombits`.
+- vm3 opcodes added in `runtime/vm3/op.go`: `OpCmpEqF64Br`, `OpCmpNeF64Br`, `OpCmpLtF64Br`, `OpCmpLeF64Br`, `OpCmpGtF64Br`, `OpCmpGeF64Br`, `OpI64ToF64`, `OpF64ToI64`. Interpreter handlers in `vm.go` mirror the existing i64 cmp/br shape.
+- AArch64 backend (`lower_arm64.go`) emits: scalar `LDR Dt` slot loads, `FMOV` (reg-reg + cross-bank bit-cast for `OpReturnF64`), `FADD`/`FSUB`/`FMUL`/`FDIV`/`FNEG`, `FCMP` + B.cc using condition codes `EQ=0x0`, `NE=0x1`, `MI=0x4` (Lt), `LS=0x9` (Le), `GT=0xC`, `GE=0xA`, `SCVTF` (i64→f64) and `FCVTZS` (f64→i64). The regsF64 base is read from `x2` directly; no callee-save needed.
+- AMD64 backend (`lower_amd64.go`) emits SSE2: `MOVSD` (reg-reg + slot load via `r14`), `ADDSD`/`SUBSD`/`MULSD`/`DIVSD`, `XORPD` against `xmm15` holding `0x8000000000000000` for `OpNegF64`, `UCOMISD` + JCC with IEEE-aware unordered handling: Eq/Lt/Le emit `JP +6` to skip a `JE`/`JB`/`JBE`; Gt/Ge emit a single `JA`/`JAE` (NaN already excluded by `CF=1`); Ne emits `JP target` + `JNE target` so NaN propagates a branch. Casts use `CVTSI2SD` / `CVTTSD2SI`. `MOVQ` xmm↔gpr provides the bit-cast for `OpConstF64K` (load via `rcx`) and `OpReturnF64` (deliver in `rax`).
+- Caps: `MaxF64Regs = 8` on both arches (slots 0..7 land in v0..v7 or xmm0..xmm7). Self-recursive `OpCallI64` inside an f64-touching fn is currently rejected with `ErrNotImplemented` so the f64-and-recursion combination falls back to the interpreter; a later sub-phase can spill the f64 bank around the call.
+- Corpus kernels added in `compiler3/corpus/`:
+  - `f64_dot_sum`: walks i=0..n and returns `sum(i * 0.5)`. Drives `OpI64ToF64` + `OpMulF64` + `OpAddF64` + `OpConstF64K` + `OpReturnF64`.
+  - `f64_threshold`: walks i=1..n and returns the first i for which `1.0 / f64(i) < 0.1` (mathematically i=11). Drives `OpDivF64` + `OpCmpLtF64Br` + mixed-bank return (`OpReturnI64` / `OpReturnConstK` out of an f64-touching fn).
+- Tests `TestCompileF64DotSumMatchesInterp` and `TestCompileF64ThresholdMatchesInterp` are mirrored across `vm3jit_darwin_arm64_test.go` and `vm3jit_linux_amd64_test.go`; both compare JIT-vs-interp bit-for-bit. `TestRejectTooManyF64` checks the cap at `MaxF64Regs + 1`.
+
+**Gate (6.2b, met on cross-build)**: `go build` and `go vet` clean on both `darwin/arm64` and `linux/amd64`. The two f64 corpus kernels pass JIT-vs-interp on darwin/arm64; the linux/amd64 test binary compiles clean and the same kernel structure runs through cross-arch CI on server2.
+
+#### Phase 6.2c+: container/string lowering, full BG suite (planned)
 
 **Deliverables (planned)**:
-- f64 SIMD lowering (regsF64 to v0..v15 on AArch64, XMM0..XMM15 on AMD64).
 - Cell-bank ops (list, map, string) with deopt protocol.
 - bench/vm3runner wires JIT in via CompileProgram (mirror MEP-39 §6.15).
 


### PR DESCRIPTION
## Summary
- Lowers the regsF64 bank to native SIMD/FP registers on both arches (v0..v7 on AArch64, xmm0..xmm7 on AMD64), so f64-typed kernels run end-to-end in vm3jit.
- Adds 6 `OpCmp*F64Br` opcodes plus `OpI64ToF64` / `OpF64ToI64` casts and a 4-arg trampoline (`CallStatusFF`) that delivers the regsF64 base pointer to the JIT'd body.
- Two new corpus kernels (`f64_dot_sum`, `f64_threshold`) exercise the new path; both match the interpreter bit-for-bit under `go test ./runtime/jit/vm3jit/` on darwin/arm64.
- MEP-40 §Phase 6.2b updated to LANDED with the trampoline, opcode, encoder, cap, and corpus details.

Tracks #21722.

## Key implementation notes
- Result delivery: f64 result is bit-cast into the existing uint64 return channel (`FMOV X0, D<retSlot>` on AArch64; `MOVQ %rax, %xmm<retSlot>` on AMD64). The Go caller decodes with `math.Float64frombits`.
- AArch64 ABI: regsF64 base pinned in `x2` (free in the i64-only ABI). Cap stays at 17 i64 regs.
- AMD64 ABI: regsF64 base pinned in `r14`. When `NumRegsF64 > 0` the effective i64 cap drops to 8 (instead of 9). `archCaps()` and `capNote()` surface that to error messages.
- IEEE 754 unordered handling on AMD64: Eq/Lt/Le emit `JP +6` to skip the JCC; Gt/Ge use single JA/JAE (NaN already excluded by CF=1); Ne emits `JP target` + `JNE target` so NaN propagates a branch.
- AArch64 condition codes match the same semantics via FCMP + B.cc.
- Self-recursive `OpCallI64` inside an f64-touching fn is rejected with `ErrNotImplemented` (interpreter fallback); a later sub-phase can spill the f64 bank around the call.

## Test plan
- [x] `go build ./...` clean on darwin/arm64
- [x] `GOOS=linux GOARCH=amd64 go build ./runtime/jit/vm3jit/...` clean
- [x] `GOOS=linux GOARCH=amd64 go vet ./runtime/jit/vm3jit/...` clean
- [x] `GOOS=linux GOARCH=amd64 go test -c -o /dev/null ./runtime/jit/vm3jit/` (test binary compiles)
- [x] `go test -count=1 ./runtime/jit/vm3jit/ ./runtime/vm3/ ./compiler3/corpus/` passes on darwin/arm64 (including the two new `TestCompileF64*MatchesInterp` tests)
- [x] Full `go test -count=1 ./runtime/...` shows no FAIL lines on darwin/arm64
- [ ] CI runs the linux/amd64 f64 corpus tests on server2