### PR TITLE
mep-0040 phase 6.2c: vm3 interp -> JIT call boundary

### DIFF
--- a/runtime/jit/vm3jit/bench_init_test.go
+++ b/runtime/jit/vm3jit/bench_init_test.go
@@ -1,0 +1,86 @@
+package vm3jit_test
+
+import (
+	"testing"
+
+	"mochi/compiler3/corpus"
+	"mochi/runtime/jit/vm3jit"
+	"mochi/runtime/vm3"
+)
+
+// buildSumLoopWrapper assembles a 2-function program: outer main(n)
+// returns sum_loop(n), where sum_loop is the standard corpus kernel.
+// Used by the Phase 6.2c interp -> JIT boundary benches.
+func buildSumLoopWrapper() *vm3.Program {
+	inner := corpus.SumLoop.Build(0).Funcs[0]
+	inner.Name = "sum_loop"
+	main := &vm3.Function{
+		Name:       "main_calls_sum_loop",
+		NumRegsI64: 2,
+		ParamBanks: []vm3.Bank{vm3.BankI64},
+		ResultBank: vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpCallI64, 1, 0, 1),
+			vm3.MakeOp(vm3.OpReturnI64, 1, 0, 0),
+		},
+	}
+	return &vm3.Program{Funcs: []*vm3.Function{main, inner}, Entry: 0}
+}
+
+// vm3jitInterpJITSink defeats dead-store elimination on the
+// interp+JIT bench loops.
+var vm3jitInterpJITSink int64
+
+// BenchmarkInterpToJITSumLoop measures the end-to-end cost of an
+// interpreted outer dispatching one OpCallI64 into a JIT'd inner
+// (sum_loop) per b.N iteration. The inner runs entirely in native
+// code; the outer pays one frame-allocation hop in jitCall plus the
+// trampoline crossing. Compared against BenchmarkInterpToJITSumLoopAllInterp
+// this isolates the JIT-boundary win on small-to-medium N.
+func BenchmarkInterpToJITSumLoop(b *testing.B) {
+	prog := buildSumLoopWrapper()
+	cf, err := vm3jit.CompileAndCache(prog, 1)
+	if err != nil {
+		b.Skipf("CompileAndCache: %v (no JIT backend)", err)
+	}
+	defer cf.Free()
+	main := prog.Funcs[0]
+	vm := vm3.NewWithProgram(prog)
+	const n = int64(1000)
+	var s int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := vm.RunWithArgs(main, []int64{n + int64(i&1)})
+		if err != nil {
+			b.Fatalf("RunWithArgs: %v", err)
+		}
+		s += got.Int()
+	}
+	vm3jitInterpJITSink = s
+}
+
+// BenchmarkInterpToJITSumLoopAllInterp is the same shape but with
+// the JIT disabled. The 2-function dispatch (interp main calls interp
+// sum_loop) is the baseline that BenchmarkInterpToJITSumLoop must
+// beat.
+func BenchmarkInterpToJITSumLoopAllInterp(b *testing.B) {
+	prog := buildSumLoopWrapper()
+	// Do NOT call CompileAndCache: inner.JITCode stays nil so vm3
+	// stays in the interp path. JITCompiled is set to true on the
+	// caller side so subsequent calls treat the fn as 'tried and
+	// declined'; we leave it false here to keep the lookup behavior
+	// identical to a fresh Program.
+	main := prog.Funcs[0]
+	vm := vm3.NewWithProgram(prog)
+	const n = int64(1000)
+	var s int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := vm.RunWithArgs(main, []int64{n + int64(i&1)})
+		if err != nil {
+			b.Fatalf("RunWithArgs: %v", err)
+		}
+		s += got.Int()
+	}
+	vm3jitInterpJITSink = s
+}

--- a/runtime/jit/vm3jit/init.go
+++ b/runtime/jit/vm3jit/init.go
@@ -1,0 +1,121 @@
+package vm3jit
+
+import (
+	"errors"
+	"unsafe"
+
+	"mochi/runtime/jit/vm2jit/trampoline"
+	"mochi/runtime/vm3"
+)
+
+func init() {
+	vm3.JITCallFn = jitCall
+}
+
+// jitFrame3 is the per-call scratch the vm3 interp -> JIT boundary
+// hands to the trampoline. Heap-allocated so the Go GC will not move it
+// during the native call; reset (not cleared) between calls within a
+// single OpCallI64 site since the JIT writes the slots it uses and
+// reads only its declared params. status is pre-zeroed.
+type jitFrame3 struct {
+	regsI64 [MaxI64Regs]int64
+	regsF64 [MaxF64Regs]float64
+	status  int64
+}
+
+// jitCall is installed as vm3.JITCallFn. It is called by the interp
+// dispatch loop at every OpCallI64 site whose callee has a non-nil
+// JITCode entry. The contract:
+//
+//   - argsI64 carries the callee's i64 parameters preloaded.
+//   - argsF64 is reserved for a later Phase 6.2c+ extension that wires
+//     f64 parameter passing; this implementation accepts only nil or
+//     an empty slice and ignores any value (the JIT's existing f64
+//     kernels read regsF64[0..7] from x2/r14 but parameters all live
+//     in regsI64 for the current corpus, so the slice stays nil).
+//   - On clean return the raw uint64 from the trampoline is passed
+//     back to the caller. For i64-returning fns the caller stores it
+//     as int64 directly; for f64-returning fns the caller decodes via
+//     math.Float64frombits.
+//   - On deopt (status != 0) the trampoline result is undefined and
+//     we return deopt=true so the interpreter restarts the callee
+//     from PC=0 under its normal pushFrame path. Since the JIT does
+//     not allocate from arenas (Phase 6.2c+), no rollback is needed.
+func jitCall(_ *vm3.VM, fn *vm3.Function, argsI64 []int64, _ []float64) (uint64, bool, error) {
+	if fn.JITCode == nil {
+		return 0, false, errors.New("vm3jit: jitCall on fn without JITCode")
+	}
+	jf := &jitFrame3{}
+	n := min(len(argsI64), MaxI64Regs)
+	copy(jf.regsI64[:n], argsI64[:n])
+
+	var bits uint64
+	if fn.JITHasF64 {
+		bits = trampoline.CallStatusFF(
+			fn.JITCode,
+			unsafe.Pointer(&jf.regsI64[0]),
+			unsafe.Pointer(&jf.status),
+			unsafe.Pointer(&jf.regsF64[0]))
+	} else {
+		bits = trampoline.CallStatus(
+			fn.JITCode,
+			unsafe.Pointer(&jf.regsI64[0]),
+			unsafe.Pointer(&jf.status))
+	}
+	if jf.status != 0 {
+		// Status-word deopt (StatusDivByZero etc.). Phase 6.2c keeps
+		// it simple: signal deopt and let the interpreter restart the
+		// callee from PC=0. A later sub-phase can recover JIT-spilled
+		// regs and resume at the exact deopt PC.
+		return 0, true, nil
+	}
+	return bits, false, nil
+}
+
+// CompileAndCache compiles prog.Funcs[idx] for the host architecture
+// and, on success, stores the entry pointer into the Function so vm3's
+// OpCallI64 dispatch can route through the JIT. The returned
+// CompiledFunc owns the executable page: the caller must keep it
+// alive (and call Free() to release it) for the Program's lifetime.
+//
+// On any compile failure (ErrUnsupported on host without a backend,
+// ErrNotImplemented for opcodes beyond Phase 6.2b coverage), the
+// function is left in its non-JIT'd state and the error is returned
+// for the caller to log. Callers that want a "compile what we can,
+// skip the rest" policy can ignore the error.
+//
+// The fn.JITCompiled flag is set unconditionally on attempt, so a
+// subsequent CompileAndCache call on the same Function is a no-op.
+// This keeps cold-start cost out of the OpCallI64 hot path.
+func CompileAndCache(prog *vm3.Program, idx uint32) (*CompiledFunc, error) {
+	if int(idx) >= len(prog.Funcs) {
+		return nil, errors.New("vm3jit: CompileAndCache idx out of range")
+	}
+	fn := prog.Funcs[idx]
+	if fn.JITCompiled {
+		return nil, nil
+	}
+	fn.JITCompiled = true
+	cf, err := CompileInProgram(prog, idx)
+	if err != nil {
+		return nil, err
+	}
+	fn.JITCode = cf.Entry()
+	fn.JITHasF64 = fn.NumRegsF64 > 0
+	return cf, nil
+}
+
+// CompileProgram is the convenience entry point that walks every
+// function in prog and tries to JIT-cache it. Unsupported functions
+// are skipped silently (consistent with MEP-39 §6.15 vm2runner
+// behavior). The returned slice holds the CompiledFunc handles in
+// declaration order; nil entries indicate functions the JIT could
+// not compile on this host.
+func CompileProgram(prog *vm3.Program) []*CompiledFunc {
+	out := make([]*CompiledFunc, len(prog.Funcs))
+	for i := range prog.Funcs {
+		cf, _ := CompileAndCache(prog, uint32(i))
+		out[i] = cf
+	}
+	return out
+}

--- a/runtime/jit/vm3jit/init_test.go
+++ b/runtime/jit/vm3jit/init_test.go
@@ -1,0 +1,104 @@
+package vm3jit_test
+
+import (
+	"testing"
+
+	"mochi/runtime/jit/vm3jit"
+	"mochi/runtime/vm3"
+)
+
+// buildInterpJITProgram constructs a 2-function vm3 Program where
+//
+//	main(n) returns inner(n)
+//	inner(n) returns n*3 + 7
+//
+// The point is to exercise vm3's OpCallI64 dispatch routing through
+// the JIT trampoline when inner.JITCode is set. main itself stays
+// interpreted (no JITCode), so the test isolates the interp -> JIT
+// call boundary added in Phase 6.2c.
+func buildInterpJITProgram() *vm3.Program {
+	inner := &vm3.Function{
+		Name:       "inner",
+		NumRegsI64: 2,
+		ParamBanks: []vm3.Bank{vm3.BankI64},
+		ResultBank: vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpMulI64K, 0, 0, 3),
+			vm3.MakeOp(vm3.OpAddI64K, 0, 0, 7),
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),
+		},
+	}
+	main := &vm3.Function{
+		Name:       "main",
+		NumRegsI64: 2,
+		ParamBanks: []vm3.Bank{vm3.BankI64},
+		ResultBank: vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpCallI64, 1, 0, 1),
+			vm3.MakeOp(vm3.OpReturnI64, 1, 0, 0),
+		},
+	}
+	return &vm3.Program{Funcs: []*vm3.Function{main, inner}, Entry: 0}
+}
+
+// TestInterpToJITCallBoundary exercises the Phase 6.2c hook:
+// vm3.JITCallFn is registered by vm3jit's init; CompileAndCache(prog,
+// 1) populates inner.JITCode; then vm.RunWithArgs runs main which
+// OpCallI64's into inner. The interp dispatch sees JITCode != nil and
+// routes through the trampoline. We validate by checking the result
+// matches the interp-only baseline and by asserting JITCode is set.
+func TestInterpToJITCallBoundary(t *testing.T) {
+	prog := buildInterpJITProgram()
+	inner := prog.Funcs[1]
+	main := prog.Funcs[0]
+
+	cf, err := vm3jit.CompileAndCache(prog, 1)
+	if err != nil {
+		// Skip on hosts without a JIT backend (e.g. windows, linux/arm64).
+		t.Skipf("CompileAndCache: %v (no JIT backend on this host)", err)
+	}
+	defer cf.Free()
+	if inner.JITCode == nil {
+		t.Fatalf("CompileAndCache succeeded but inner.JITCode is nil")
+	}
+	if main.JITCode != nil {
+		t.Fatalf("main.JITCode unexpectedly set; only inner should be JIT'd")
+	}
+
+	vm := vm3.NewWithProgram(prog)
+	for _, n := range []int64{0, 1, 2, 10, 100} {
+		got, err := vm.RunWithArgs(main, []int64{n})
+		if err != nil {
+			t.Fatalf("RunWithArgs n=%d: %v", n, err)
+		}
+		want := n*3 + 7
+		if got.Int() != want {
+			t.Fatalf("interp+JIT n=%d: got %d want %d", n, got.Int(), want)
+		}
+	}
+}
+
+// TestInterpToJITCallBoundaryDeoptFalls exercises the deopt branch of
+// the OpCallI64 hook. If the JIT trampoline reports status != 0 we
+// return deopt=true and the interpreter restarts the callee under
+// pushFrame. Phase 6.2c uses this on any reg-reg Div/Mod by-zero; we
+// cannot trivially trigger that from a 2-function corpus, so the test
+// here only validates that the deopt code path compiles and does not
+// regress the happy path. A real div-by-zero deopt test lives in the
+// vm3jit_*_test.go arch files.
+func TestInterpToJITCallBoundaryDeoptFalls(t *testing.T) {
+	prog := buildInterpJITProgram()
+	cf, err := vm3jit.CompileAndCache(prog, 1)
+	if err != nil {
+		t.Skipf("CompileAndCache: %v", err)
+	}
+	defer cf.Free()
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[0], []int64{42})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if got.Int() != 42*3+7 {
+		t.Fatalf("got %d want %d", got.Int(), 42*3+7)
+	}
+}

--- a/runtime/vm3/frame.go
+++ b/runtime/vm3/frame.go
@@ -1,5 +1,7 @@
 package vm3
 
+import "unsafe"
+
 // Frame is one activation record. Each frame holds a base index into
 // each of the VM's three typed register stacks; the live window for
 // this activation is stack[base : base + fn.NumRegs*]. Storing only
@@ -47,6 +49,19 @@ type Function struct {
 
 	ParamBanks []Bank
 	ResultBank Bank
+
+	// JIT slots. Populated by runtime/jit/vm3jit.CompileAndCache when
+	// the function lowers cleanly on the host arch; vm3 reads them in
+	// OpCallI64 dispatch and routes through JITCallFn when JITCode is
+	// non-nil. JITCompiled is the sticky negative-cache flag: once a
+	// compile attempt has run, we do not retry on every call. The
+	// CompiledFunc that owns the mmap'd page (and keeps JITCode valid)
+	// is held by the caller of CompileAndCache, typically a
+	// vm3runner-style harness or a test. JITHasF64 selects the
+	// 4-argument trampoline (CallStatusFF) for f64-touching kernels.
+	JITCode     unsafe.Pointer
+	JITCompiled bool
+	JITHasF64   bool
 }
 
 // Bank identifies one of the three typed register banks.

--- a/runtime/vm3/program.go
+++ b/runtime/vm3/program.go
@@ -7,3 +7,17 @@ type Program struct {
 	Funcs []*Function
 	Entry uint32
 }
+
+// JITCallFn is installed by runtime/jit/vm3jit on package init when the
+// host architecture has a JIT backend (currently darwin/arm64 and
+// linux/amd64). vm3 treats the JIT as opaque: OpCallI64 sites route
+// through JITCallFn whenever the callee carries a non-nil JITCode entry
+// pointer in its Function record.
+//
+// argsI64 holds the NumI64Params() preloaded slots. argsF64 is reserved
+// for a future Phase 6.2c+ slice that wires f64 parameter passing; it
+// is currently always nil on this path. The return is the raw uint64
+// from the JIT trampoline; for i64-returning fns the caller reads it
+// as int64 directly. deopt=true means the JIT bailed and the caller
+// must restart this callee through the interpreter.
+var JITCallFn func(vm *VM, fn *Function, argsI64 []int64, argsF64 []float64) (resultBits uint64, deopt bool, err error)

--- a/runtime/vm3/vm.go
+++ b/runtime/vm3/vm.go
@@ -360,6 +360,23 @@ func (vm *VM) run() (Cell, error) {
 				args = make([]int64, n)
 			}
 			copy(args, regsI64[op.B:op.B+uint16(n)])
+			// Phase 6.2c: if the callee has been JIT'd, route through
+			// the trampoline instead of pushing an interpreter frame.
+			// The JIT's recursive self-calls live on the JIT's own
+			// stack and do not touch vm.frames. On deopt we fall
+			// through to the interpreter path so the function restarts
+			// from PC=0 under the interpreter.
+			if callee.JITCode != nil && JITCallFn != nil {
+				bits, deopt, err := JITCallFn(vm, callee, args, nil)
+				if err != nil {
+					return Cell(0), err
+				}
+				if !deopt {
+					regsI64[op.A] = int64(bits)
+					pc++
+					continue
+				}
+			}
 			// Stash caller state so we resume one past the call site.
 			fr.pc = pc + 1
 			vm.pushFrame(callee, op.A, BankI64)

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -1416,11 +1416,41 @@ Both numbers also clear the cross-stack target: vm3+JIT vs Go on f64 kernels is 
 
 **Gate (6.2b, met)**: `go build` and `go vet` clean on both `darwin/arm64` and `linux/amd64`. The two f64 corpus kernels pass JIT-vs-interp on darwin/arm64; the linux/amd64 test binary compiles clean and the same kernel structure runs through cross-arch CI on server2. Both f64 corpus kernels are inside 2x of fair Go on the local Darwin arm64 run (0.79x and 1.08x).
 
-#### Phase 6.2c+: container/string lowering, full BG suite (planned)
+#### Phase 6.2c: vm3 interp -> JIT call boundary integration **LANDED**
+
+**Goal**: wire the JIT into the vm3 interpreter so that real programs running through `vm.RunWithArgs` actually exercise the JIT'd code path. Before this phase the Phase 6.0..6.2b work was a parallel pipeline reachable only from tests/benches that called `vm3jit.Compile` and `trampoline.Call*` directly; the standing MEP-40 corpus benches measured the JIT in isolation but `vm.RunWithArgs` always ran the interpreter dispatch loop end-to-end.
+
+This phase mirrors MEP-39 §6.15 (`vm2.JITCallFn`) on the vm3 side, with the small extension of a dual-bank register file and the status-word trampoline picked up in 6.1c.
+
+**Landed scope**:
+- New package-level hook `vm3.JITCallFn func(vm, fn, argsI64, argsF64) (resultBits uint64, deopt bool, err error)` in `runtime/vm3/program.go`. The vm3 package keeps the JIT opaque: it only needs the entry pointer and a way to deliver args + receive results.
+- New fields on `vm3.Function`:
+  - `JITCode unsafe.Pointer`: native-code entry from a successful `CompileAndCache`.
+  - `JITCompiled bool`: sticky "compile already attempted" flag; keeps the cold-start cost off the OpCallI64 hot path.
+  - `JITHasF64 bool`: selects the 4-argument `CallStatusFF` trampoline when the JIT'd function uses any f64 register.
+- `OpCallI64` dispatch in `runtime/vm3/vm.go` checks `callee.JITCode != nil && JITCallFn != nil` and routes through the hook. On a clean return the result is stored in `regsI64[op.A]` and `pc` advances by one; on `deopt=true` the call falls through to the normal `pushFrame` path so the interpreter restarts the callee from `PC=0`. The deopt path covers the Phase 6.1c reg-reg Div/Mod status-word bail and any future status-word condition; since the JIT does not allocate from arenas in Phase 6.0..6.2b, no rollback of arena marks is needed.
+- New `runtime/jit/vm3jit/init.go` registers the hook in `init()`, defines a heap-allocated `jitFrame3{regsI64, regsF64, status}`, and implements `jitCall` (the function that copies args, dispatches `CallStatus` or `CallStatusFF`, and reads back the status word). The frame is heap-allocated so the Go GC will not move it under the NOSPLIT trampoline.
+- New helpers `vm3jit.CompileAndCache(prog, idx) (*CompiledFunc, error)` and `vm3jit.CompileProgram(prog) []*CompiledFunc`. Both populate `fn.JITCode` on success; the latter walks the entire `Program` and silently skips functions the JIT cannot handle on the current host (parity with `vm2runner.CompileProgram`).
+- Tests `TestInterpToJITCallBoundary` and `TestInterpToJITCallBoundaryDeoptFalls` in `runtime/jit/vm3jit/init_test.go` build a 2-function program `main(n) returns inner(n)`, JIT-compile only `inner`, then drive `vm.RunWithArgs(main, ...)` to confirm the dispatch path crosses the JIT boundary and the returned `Cell` decodes to the expected `int64`. Both tests are cross-arch (no build tag) so the wiring is exercised on darwin/arm64 and linux/amd64 without duplication. On hosts without a JIT backend `CompileAndCache` returns `ErrUnsupported` and the tests skip cleanly.
+
+**Measured bench** (Darwin arm64, M4, `-benchtime=200ms`, single run):
+
+| bench                                  | ns/op  | Notes |
+| -------------------------------------- | -----: | ----- |
+| `BenchmarkInterpToJITSumLoop`          |  319.5 | interp `main(n)` calls JIT'd `sum_loop(n)` at n=1000 |
+| `BenchmarkInterpToJITSumLoopAllInterp` | 10316  | interp `main(n)` calls interp `sum_loop(n)`; no JIT |
+
+The interp -> JIT boundary delivers a **32x end-to-end speedup** on the sum_loop kernel when reached through the interpreter dispatch loop. The remaining ~65 ns above the direct-JIT corpus bench (255 ns/op for sum_loop at n=1000) is the per-call cost of `jitFrame3` allocation, the args copy, and the trampoline crossing; it is small enough that the BG suite's outer-driver patterns (run a JIT'd kernel inside a hot loop) will see the JIT speedup directly.
+
+The all-interp baseline (10316 ns) reproduces §9.9's interpreter floor (sum_loop at n=1000 measured 10262 ns/op on the same machine in the Phase 4.0 baseline), confirming the 2-function wrapper adds no measurable interp-side overhead vs the 1-function corpus shape.
+
+**Gate (6.2c, met)**: `go build` and `go vet` clean on darwin/arm64 and linux/amd64. The new tests pass on darwin/arm64. The bench shows a >10x speedup of interp+JIT over all-interp at the same call boundary, which is the load-bearing assumption for the BG suite to inherit the JIT's per-kernel wins via Phase 6.2d's `CompileProgram` walk.
+
+#### Phase 6.2d+: container/string lowering, full BG suite (planned)
 
 **Deliverables (planned)**:
-- Cell-bank ops (list, map, string) with deopt protocol.
-- bench/vm3runner wires JIT in via CompileProgram (mirror MEP-39 §6.15).
+- Cell-bank ops (list, map, string) with deopt protocol. The interp -> JIT boundary from Phase 6.2c already lets a JIT'd inner be called from an interp outer; Cell-bank lowering extends the set of opcodes that compile cleanly so more inners qualify.
+- bench harness wires `CompileProgram` into the BG-suite driver and reports per-program JIT-vs-Go numbers.
 
 **Gate (planned)**: vm3+JIT beats vm2+JIT by 50%+ on BG suite at peak N. At least 6 of 11 BG programs inside 2x-of-Go.
 


### PR DESCRIPTION
Tracking issue: #21726

## Summary

Wires the JIT into the vm3 interpreter at the OpCallI64 boundary. Before this PR the JIT was a parallel pipeline reachable only from tests that called \`vm3jit.Compile\` + \`trampoline.Call*\` directly; \`vm.RunWithArgs\` always ran the interpreter dispatch loop end-to-end. Mirrors MEP-39 §6.15 (vm2.JITCallFn) on the vm3 side.

- New \`vm3.JITCallFn\` hook + \`vm3.Function.{JITCode,JITCompiled,JITHasF64}\`.
- \`OpCallI64\` dispatch routes through the hook when JITCode is set; on deopt falls through to pushFrame.
- \`vm3jit.CompileAndCache(prog, idx)\` + \`vm3jit.CompileProgram(prog)\` helpers in a new \`runtime/jit/vm3jit/init.go\`.
- Tests cross-arch (no build tag) with 2-function \`main(n) returns inner(n)\` program; on hosts without a JIT backend they skip cleanly.

## Measured (darwin/arm64, M4, -benchtime=200ms)

| bench                                | ns/op  |
| ------------------------------------ | -----: |
| BenchmarkInterpToJITSumLoop          |  319.5 |
| BenchmarkInterpToJITSumLoopAllInterp | 10316  |

**32x end-to-end speedup** at the OpCallI64 boundary on \`sum_loop(n=1000)\`.

## Test plan

- [x] \`go test ./runtime/jit/vm3jit/ ./runtime/vm3/\` passes on darwin/arm64
- [x] \`GOOS=linux GOARCH=amd64 go build ./runtime/jit/vm3jit/... ./runtime/vm3/...\` clean
- [x] \`GOOS=linux GOARCH=amd64 go vet ./runtime/jit/vm3jit/... ./runtime/vm3/...\` clean
- [x] New tests \`TestInterpToJITCallBoundary\` and \`TestInterpToJITCallBoundaryDeoptFalls\` pass
- [x] New benches \`BenchmarkInterpToJITSumLoop{,AllInterp}\` produce the 32x ratio above
- [x] MEP-40 spec backfilled with design + measured table
- [x] No em-dashes in MEP-40 prose