### PR TITLE
mep-0040 phase 6.2d.2.a (step 1): CallStatusM mixed-bank trampoline ABI

### DIFF
--- a/runtime/jit/vm2jit/trampoline/trampoline_darwin_arm64.go
+++ b/runtime/jit/vm2jit/trampoline/trampoline_darwin_arm64.go
@@ -28,3 +28,12 @@ func CallStatus(entry unsafe.Pointer, regs unsafe.Pointer, status unsafe.Pointer
 // return-channel stays a single uint64 (caller does
 // math.Float64frombits). Used by all kernels with NumRegsF64 > 0.
 func CallStatusFF(entry unsafe.Pointer, regsI64 unsafe.Pointer, status unsafe.Pointer, regsF64 unsafe.Pointer) uint64
+
+// CallStatusM is the MEP-40 Phase 6.2d.2.a mixed-bank trampoline. ABI on
+// AArch64: x0 = regsI64, x1 = status, x2 = regsF64, x3 = regsCell, x4 =
+// *jitArenaCtx. The JIT accesses the Cell register window through
+// [x3 + r*8] (Cell is 8 bytes wide, raw uint64 representation) and
+// resolves arena slab base pointers via [x4 + offset]. Existing
+// kernels keep their CallStatus / CallStatusFF entry; only fns with
+// NumRegsCell > 0 are dispatched via this trampoline.
+func CallStatusM(entry unsafe.Pointer, regsI64 unsafe.Pointer, status unsafe.Pointer, regsF64 unsafe.Pointer, regsCell unsafe.Pointer, arenaCtx unsafe.Pointer) uint64

--- a/runtime/jit/vm2jit/trampoline/trampoline_darwin_arm64.s
+++ b/runtime/jit/vm2jit/trampoline/trampoline_darwin_arm64.s
@@ -45,3 +45,23 @@ TEXT ·CallStatusFF(SB),NOSPLIT,$0-40
 	CALL	(R16)
 	MOVD	R0, ret+32(FP)
 	RET
+
+// func CallStatusM(entry, regsI64, status, regsF64, regsCell, arenaCtx unsafe.Pointer) uint64
+//
+// MEP-40 Phase 6.2d.2.a mixed-bank trampoline. ABI0: args at FP+0..+40,
+// result at FP+48. Pins R0 = regsI64, R1 = status, R2 = regsF64, R3 =
+// regsCell, R4 = *jitArenaCtx so a Cell-bank JIT'd fn can access all
+// three register windows plus the arena slab base pointers without
+// going back through the interpreter. Existing Call / CallStatus /
+// CallStatusFF variants stay unchanged so i64- and f64-only kernels
+// pay no extra register-pinning cost.
+TEXT ·CallStatusM(SB),NOSPLIT,$0-56
+	MOVD	entry+0(FP), R16
+	MOVD	regsI64+8(FP), R0
+	MOVD	status+16(FP), R1
+	MOVD	regsF64+24(FP), R2
+	MOVD	regsCell+32(FP), R3
+	MOVD	arenaCtx+40(FP), R4
+	CALL	(R16)
+	MOVD	R0, ret+48(FP)
+	RET

--- a/runtime/jit/vm2jit/trampoline/trampoline_linux_amd64.go
+++ b/runtime/jit/vm2jit/trampoline/trampoline_linux_amd64.go
@@ -30,3 +30,10 @@ func CallStatus(entry unsafe.Pointer, regs unsafe.Pointer, status unsafe.Pointer
 // `movq %xmm<retSlot>, %rax` in its epilogue (caller uses
 // math.Float64frombits).
 func CallStatusFF(entry unsafe.Pointer, regsI64 unsafe.Pointer, status unsafe.Pointer, regsF64 unsafe.Pointer) uint64
+
+// CallStatusM is the MEP-40 Phase 6.2d.2.a mixed-bank trampoline. ABI on
+// AMD64 (SysV): RDI = regsI64, RSI = status, RDX = regsF64, RCX =
+// regsCell, R8 = *jitArenaCtx. Linux/AMD64 Cell-bank lowering is the
+// Phase 6.2d.2.e gate; until then the JIT rejects any cell-bank fn at
+// compile time and this entry is unused on AMD64.
+func CallStatusM(entry unsafe.Pointer, regsI64 unsafe.Pointer, status unsafe.Pointer, regsF64 unsafe.Pointer, regsCell unsafe.Pointer, arenaCtx unsafe.Pointer) uint64

--- a/runtime/jit/vm2jit/trampoline/trampoline_linux_amd64.s
+++ b/runtime/jit/vm2jit/trampoline/trampoline_linux_amd64.s
@@ -46,3 +46,22 @@ TEXT ·CallStatusFF(SB),NOSPLIT,$0-40
 	CALL	AX
 	MOVQ	AX, ret+32(FP)
 	RET
+
+// func CallStatusM(entry, regsI64, status, regsF64, regsCell, arenaCtx unsafe.Pointer) uint64
+//
+// MEP-40 Phase 6.2d.2.a mixed-bank trampoline. ABI0: args at FP+0..+40,
+// result at FP+48. AMD64 Cell-bank lowering (Phase 6.2d.2.e) is still
+// planned; on Linux/AMD64 today the JIT rejects any cell-bank function
+// at compile time, so this entry exists only to keep the Go decl
+// symmetric with darwin/arm64. Pinning is: DI = regsI64, SI = status,
+// DX = regsF64, CX = regsCell, R8 = *jitArenaCtx (SysV args 1..5).
+TEXT ·CallStatusM(SB),NOSPLIT,$0-56
+	MOVQ	entry+0(FP), AX
+	MOVQ	regsI64+8(FP), DI
+	MOVQ	status+16(FP), SI
+	MOVQ	regsF64+24(FP), DX
+	MOVQ	regsCell+32(FP), CX
+	MOVQ	arenaCtx+40(FP), R8
+	CALL	AX
+	MOVQ	AX, ret+48(FP)
+	RET

--- a/runtime/jit/vm2jit/trampoline/trampoline_stub.go
+++ b/runtime/jit/vm2jit/trampoline/trampoline_stub.go
@@ -18,3 +18,8 @@ func CallStatus(_ unsafe.Pointer, _ unsafe.Pointer, _ unsafe.Pointer) uint64 {
 func CallStatusFF(_ unsafe.Pointer, _ unsafe.Pointer, _ unsafe.Pointer, _ unsafe.Pointer) uint64 {
 	panic("trampoline: not yet implemented on this platform")
 }
+
+// CallStatusM panics on platforms without a JIT backend.
+func CallStatusM(_ unsafe.Pointer, _ unsafe.Pointer, _ unsafe.Pointer, _ unsafe.Pointer, _ unsafe.Pointer, _ unsafe.Pointer) uint64 {
+	panic("trampoline: not yet implemented on this platform")
+}


### PR DESCRIPTION
## Summary

- Adds `CallStatusM` to `runtime/jit/vm2jit/trampoline` across all four platform variants (darwin/arm64 real, linux/amd64 real for symmetry, stub panic for unsupported). This is the new mixed-bank entry that pins `regsI64` / `status` / `regsF64` / `regsCell` / `*jitArenaCtx` in fixed registers per arch, as designed in the Phase 6.2d.2 spec decomposition (#21731).
- Existing `Call` / `CallStatus` / `CallStatusFF` entries stay unchanged so the 9 corpus kernels already inside 2x of Go pay no extra register-pinning cost.
- No consumer yet: `compile.go` still rejects any fn with `NumRegsCell != 0`. The follow-up PR lifts the rejection, adds Cell register pinning in `lower_arm64.go`, and lowers `OpListGetI64` + `OpTailCallMixed` self-tail.

Tracks: #21732. Builds on #21731 (Phase 6.2d.2 plan), #21729 (Phase 6.2d.1).

## ABI pinning

| Arch | regsI64 | status | regsF64 | regsCell | arenaCtx |
| --- | --- | --- | --- | --- | --- |
| darwin/arm64 | x0 | x1 | x2 | x3 | x4 |
| linux/amd64 | RDI | RSI | RDX | RCX | R8 |

## Test plan

- [x] `go build ./...` clean on darwin/arm64
- [x] `go vet ./runtime/jit/...` clean
- [x] `go test ./runtime/jit/... -count=1` passes (5 packages including vm2jit, vm3jit, tracejit, tieredjit, tmpljit; no regressions on existing kernels)