### PR TITLE
mep-0040 phase 6.3.4.j prep: OpSqrtF64 (ARM64 FSQRT)

### DIFF
--- a/compiler3/corpus/f64_sqrt_sum.go
+++ b/compiler3/corpus/f64_sqrt_sum.go
@@ -1,0 +1,55 @@
+package corpus
+
+import "mochi/runtime/vm3"
+
+// F64SqrtSum: s = sqrt(1) + sqrt(2) + ... + sqrt(n). Drives the loop
+// with an i64 counter and accumulates in f64, exercising OpSqrtF64
+// alongside the existing i64 cmp/br/AddK + f64 add shape.
+//
+//	fun sqrt_sum(n) {
+//	  var s = 0.0
+//	  var i = 1
+//	  while i <= n {
+//	    s = s + sqrt(f64(i))
+//	    i = i + 1
+//	  }
+//	  return s
+//	}
+//
+// Bank: i64 + f64. NumRegsI64 = 2 (n, i); NumRegsF64 = 2 (s, x).
+// OpConstI64K uses op.C as a literal i64 immediate (no Consts lookup).
+//
+//	0  ConstF64K  A=0, C=0          ; s = Consts[0] = 0.0
+//	1  ConstI64K  A=1, C=1          ; i = 1 (immediate)
+//	2  CmpGtI64Br A=1, B=0, C=8     ; if i > n jump to 8
+//	3  I64ToF64   A=1, B=1          ; x = f64(i)
+//	4  SqrtF64    A=1, B=1          ; x = sqrt(x)
+//	5  AddF64     A=0, B=0, C=1     ; s = s + x
+//	6  AddI64K    A=1, B=1, C=1     ; i = i + 1
+//	7  Jump              C=2        ; back to test
+//	8  ReturnF64  A=0
+var F64SqrtSum = &Program{
+	Name: "f64_sqrt_sum",
+	Build: func(_ int64) *vm3.Program {
+		fn := &vm3.Function{
+			Name:       "f64_sqrt_sum",
+			NumRegsI64: 2,
+			NumRegsF64: 2,
+			ParamBanks: []vm3.Bank{vm3.BankI64},
+			ResultBank: vm3.BankF64,
+			Consts:     []vm3.Cell{vm3.CFloat(0.0)},
+			Code: []vm3.Op{
+				vm3.MakeOp(vm3.OpConstF64K, 0, 0, 0),
+				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 1),
+				vm3.MakeOp(vm3.OpCmpGtI64Br, 1, 0, 8),
+				vm3.MakeOp(vm3.OpI64ToF64, 1, 1, 0),
+				vm3.MakeOp(vm3.OpSqrtF64, 1, 1, 0),
+				vm3.MakeOp(vm3.OpAddF64, 0, 0, 1),
+				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 1),
+				vm3.MakeOp(vm3.OpJump, 0, 0, 2),
+				vm3.MakeOp(vm3.OpReturnF64, 0, 0, 0),
+			},
+		}
+		return &vm3.Program{Funcs: []*vm3.Function{fn}, Entry: 0}
+	},
+}

--- a/runtime/jit/vm3jit/lower_arm64.go
+++ b/runtime/jit/vm3jit/lower_arm64.go
@@ -1128,6 +1128,8 @@ func wordCountARM64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		return 1, nil
 	case vm3.OpFmaF64:
 		return 1, nil
+	case vm3.OpSqrtF64:
+		return 1, nil
 
 	case vm3.OpCmpEqF64Br, vm3.OpCmpNeF64Br,
 		vm3.OpCmpLtF64Br, vm3.OpCmpLeF64Br,
@@ -1447,6 +1449,8 @@ func emitInstrARM64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		mul2 := uint16(op.C) & 0xFF
 		addend := (uint16(op.C) >> 8) & 0xFF
 		return []uint32{fmaddD(r2d(op.A), r2d(op.B), r2d(mul2), r2d(addend))}, nil
+	case vm3.OpSqrtF64:
+		return []uint32{fsqrtD(r2d(op.A), r2d(op.B))}, nil
 
 	case vm3.OpCmpEqF64Br, vm3.OpCmpNeF64Br,
 		vm3.OpCmpLtF64Br, vm3.OpCmpLeF64Br,
@@ -2584,6 +2588,12 @@ func fdivD(dd, dn, dm uint32) uint32 {
 // fnegD encodes FNEG Dd, Dn.
 func fnegD(dd, dn uint32) uint32 {
 	return 0x1E614000 | ((dn & 0x1F) << 5) | (dd & 0x1F)
+}
+
+// fsqrtD encodes FSQRT Dd, Dn (scalar double square root).
+// IEEE 754 correctly-rounded, bit-identical to Go's math.Sqrt on arm64.
+func fsqrtD(dd, dn uint32) uint32 {
+	return 0x1E61C000 | ((dn & 0x1F) << 5) | (dd & 0x1F)
 }
 
 // fmaddD encodes FMADD Dd, Dn, Dm, Da (scalar double, fused multiply-add).

--- a/runtime/jit/vm3jit/sqrt_sum_jit_test.go
+++ b/runtime/jit/vm3jit/sqrt_sum_jit_test.go
@@ -1,0 +1,35 @@
+//go:build darwin && arm64
+
+package vm3jit_test
+
+import (
+	"testing"
+
+	"mochi/compiler3/corpus"
+	"mochi/runtime/jit/vm3jit"
+	"mochi/runtime/vm3"
+)
+
+// TestCompileF64SqrtSumMatchesInterp validates the Phase 6.3.4.j prep
+// OpSqrtF64 lowering. F64SqrtSum is the f64 dual of F64DotSum: it
+// drives an i64 counter through OpSqrtF64 + OpAddF64 and confirms the
+// JIT'd FSQRT result is bit-identical to math.Sqrt across N in the
+// n_body inner-loop range.
+func TestCompileF64SqrtSumMatchesInterp(t *testing.T) {
+	prog := corpus.F64SqrtSum.Build(0)
+	fn := prog.Funcs[prog.Entry]
+	for _, n := range []int64{0, 1, 2, 10, 100, 1000} {
+		got, status := runJITF64Kernel(t, fn, n)
+		if status != vm3jit.StatusOK {
+			t.Fatalf("unexpected deopt n=%d status=%d", n, status)
+		}
+		vm := vm3.NewWithProgram(prog)
+		want, err := vm.RunWithArgs(fn, []int64{n})
+		if err != nil {
+			t.Fatalf("interp n=%d: %v", n, err)
+		}
+		if got != want.Float() {
+			t.Errorf("f64_sqrt_sum(%d): jit=%g interp=%g", n, got, want.Float())
+		}
+	}
+}

--- a/runtime/vm3/op.go
+++ b/runtime/vm3/op.go
@@ -155,6 +155,15 @@ const (
 	// OpCmpGeI64KBr + one OpLookupI64KW + the case-body return. See
 	// compiler3/corpus/switch_lookup.go for the bench shape.
 	OpLookupI64KW
+
+	// Scalar f64 square root (Phase 6.3.4.j prep). 2-source f64:
+	//   regsF64[A] = math.Sqrt(regsF64[B])
+	// IEEE 754 correctly-rounded, bit-identical to Go's math.Sqrt
+	// (which on arm64 is a single FSQRT). On ARM64 lowers to one
+	// FSQRT Dd, Dn (0x1E61C000 | (B<<5) | A). On AMD64 lowers to
+	// SQRTSD xmmA, xmmB. Prereq for n_body's inner-loop distance
+	// computation (sqrt(dx*dx + dy*dy + dz*dz)).
+	OpSqrtF64
 )
 
 // Op is a single 8-byte vm3 bytecode word. Layout:

--- a/runtime/vm3/vm.go
+++ b/runtime/vm3/vm.go
@@ -395,6 +395,9 @@ func (vm *VM) run() (Cell, error) {
 			addend := (uint16(op.C) >> 8) & 0xFF
 			regsF64[op.A] = math.FMA(regsF64[op.B], regsF64[mul2], regsF64[addend])
 			pc++
+		case OpSqrtF64:
+			regsF64[op.A] = math.Sqrt(regsF64[op.B])
+			pc++
 
 		case OpCmpEqI64Br:
 			if regsI64[op.A] == regsI64[op.B] {

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -1833,6 +1833,23 @@ The gap to Go's reported -62.65% is closed only by JIT lowering of `OpLookupI64K
 
 AMD64 lowering is the remaining Phase 6.4.b deliverable.
 
+#### Phase 6.3.4.j prep: OpSqrtF64 generic op + ARM64 lowering (2026-05-19)
+
+n_body's inner advance loop computes pairwise gravitational forces via `1 / sqrt(dx*dx + dy*dy + dz*dz)`. The scalar `sqrt` is the only piece not already covered by Phase 6.2b's f64 arithmetic (Add/Sub/Mul/Div/Neg) or Phase 6.3.4.h's `OpFmaF64`. Landing it as a generic op now (parallel to `OpFmaF64`) unblocks the n_body port without scope-mixing into Phase 6.3.4.j itself.
+
+`OpSqrtF64` semantics: `regsF64[A] = math.Sqrt(regsF64[B])`. IEEE 754 correctly-rounded; bit-identical to Go's `math.Sqrt` on arm64 (which already emits `FSQRT`). ARM64 lowering is one word:
+
+```go
+case vm3.OpSqrtF64:
+    return []uint32{fsqrtD(r2d(op.A), r2d(op.B))}, nil
+```
+
+`fsqrtD` encodes `0x1E61C000 | (Dn << 5) | Dd`. AMD64 routes through the interpreter for now (`SQRTSD xmmA, xmmB` is the trivial follow-up, tracked as part of Phase 6.4.c/h.2 AMD64 catch-up).
+
+**Synthetic correctness gate.** `compiler3/corpus.F64SqrtSum` is the f64 dual of `F64DotSum`: it drives an i64 counter through `OpSqrtF64` + `OpAddF64` to compute `sum(sqrt(i) for i in 1..n)`. `TestCompileF64SqrtSumMatchesInterp` (`runtime/jit/vm3jit/sqrt_sum_jit_test.go`) confirms the JIT'd `FSQRT` is bit-identical to the interpreter's `math.Sqrt` across N in {0, 1, 2, 10, 100, 1000}. The n_body port (Phase 6.3.4.j proper) becomes the closure gate once it lands.
+
+**Why a separate op vs an inline `math.Sqrt` call.** A reg-reg call into Go's `math.Sqrt` would route through the trampoline + cgo-style barrier and would defeat the f64-bank's whole point. `FSQRT` is a single host instruction on every modern ISA (ARM64 `FSQRT.D`, x86 `SQRTSD`, RISC-V `FSQRT.D`, PowerPC `fsqrt`); the bytecode-level op + 1-word JIT lowering composes naturally with the existing f64 arithmetic shape.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -1833,7 +1833,7 @@ The gap to Go's reported -62.65% is closed only by JIT lowering of `OpLookupI64K
 
 AMD64 lowering is the remaining Phase 6.4.b deliverable.
 
-#### Phase 6.3.4.j prep: OpSqrtF64 generic op + ARM64 lowering (2026-05-19)
+#### Phase 6.3.4.j prep: OpSqrtF64 generic op + ARM64 lowering (2026-05-19 17:37 GMT+7)
 
 n_body's inner advance loop computes pairwise gravitational forces via `1 / sqrt(dx*dx + dy*dy + dz*dz)`. The scalar `sqrt` is the only piece not already covered by Phase 6.2b's f64 arithmetic (Add/Sub/Mul/Div/Neg) or Phase 6.3.4.h's `OpFmaF64`. Landing it as a generic op now (parallel to `OpFmaF64`) unblocks the n_body port without scope-mixing into Phase 6.3.4.j itself.
 


### PR DESCRIPTION
Generic 2-source f64 square root op, prep for the n_body closure (Phase 6.3.4.j).

Tracking issue: #21764.

## Summary
- New op `OpSqrtF64` (`regsF64[A] = math.Sqrt(regsF64[B])`); IEEE 754 correctly-rounded, bit-identical to Go's `math.Sqrt` on arm64.
- ARM64 JIT lowering: one word, `FSQRT Dd, Dn` (`0x1E61C000 | (Dn<<5) | Dd`).
- AMD64 routes through interp; `SQRTSD` lowering folds into the AMD64 catch-up tracked alongside #169 (OpFmaF64 VFMADD132SD) and #170 (OpLookupI64KW).
- Synthetic kernel `compiler3/corpus.F64SqrtSum` (sum of `sqrt(i)` for i=1..n) + `TestCompileF64SqrtSumMatchesInterp` gate the interp/JIT bit-equality across N in {0, 1, 2, 10, 100, 1000}.
- Spec section in mep-0040.md uses the new `YYYY-MM-DD HH:MM (GMT+7)` timestamp convention per user feedback.

## Why a separate op vs an inline `math.Sqrt` call
Reg-reg call into `math.Sqrt` would route through the trampoline barrier and defeat the f64-bank. `FSQRT` is one host instruction on every modern ISA; the bytecode-level op composes naturally with existing f64 arithmetic.

## Follow-on
- Phase 6.3.4.j: port n_body to compiler3 + close under 2x of Go (needs `OpSqrtF64` + may need f64 array infrastructure).

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./compiler3/corpus/ ./runtime/vm3/ ./runtime/jit/vm3jit/` green
- [x] `TestCompileF64SqrtSumMatchesInterp` bit-identical at all N

Closes: parts of #21764