### PR TITLE
mep-0040 phase 6.3.4.f.1: port k_nucleotide to compiler3 + baseline

### DIFF
--- a/compiler3/corpus/corpus.go
+++ b/compiler3/corpus/corpus.go
@@ -28,5 +28,6 @@ func All() []*Program {
 		Nsieve,
 		Fasta,
 		Mandelbrot,
+		KNucleotide,
 	}
 }

--- a/compiler3/corpus/corpus_test.go
+++ b/compiler3/corpus/corpus_test.go
@@ -29,6 +29,7 @@ func TestMathKernelsMatchVm2(t *testing.T) {
 		{"nsieve", Nsieve, []int64{0, 1, 2, 10, 50, 100, 1000}, c2corpus.ExpectNsieve},
 		{"fasta", Fasta, []int64{0, 1, 2, 10, 100, 1000, 10000}, c2corpus.ExpectFasta},
 		{"mandelbrot", Mandelbrot, []int64{0, 1, 2, 5, 10, 50, 100}, c2corpus.ExpectMandelbrot},
+		{"k_nucleotide", KNucleotide, []int64{0, 1, 2, 10, 100, 1000}, c2corpus.ExpectKNucleotide},
 	}
 	for _, tc := range cases {
 		for _, n := range tc.ns {
@@ -70,6 +71,8 @@ func BenchmarkMathKernels(b *testing.B) {
 		{"fasta_n100000", Fasta, 100000},
 		{"mandelbrot_n100", Mandelbrot, 100},
 		{"mandelbrot_n300", Mandelbrot, 300},
+		{"k_nucleotide_n10000", KNucleotide, 10000},
+		{"k_nucleotide_n100000", KNucleotide, 100000},
 	}
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {
@@ -157,6 +160,8 @@ func BenchmarkGoKernels(b *testing.B) {
 		{"fasta_n100000", c2corpus.ExpectFasta, 100000},
 		{"mandelbrot_n100", c2corpus.ExpectMandelbrot, 100},
 		{"mandelbrot_n300", c2corpus.ExpectMandelbrot, 300},
+		{"k_nucleotide_n10000", c2corpus.ExpectKNucleotide, 10000},
+		{"k_nucleotide_n100000", c2corpus.ExpectKNucleotide, 100000},
 	}
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {

--- a/compiler3/corpus/k_nucleotide.go
+++ b/compiler3/corpus/k_nucleotide.go
@@ -1,0 +1,188 @@
+package corpus
+
+import "mochi/runtime/vm3"
+
+// KNucleotide: Phase 6.3.4.f single-function port of the BG k_nucleotide
+// kernel. Mirrors compiler2/corpus.BuildKNucleotide (4-fn loop/summ/lookup
+// shape) but collapses to one vm3 function with inline LCG, i64-threshold
+// cascade, and back-jump, so the hot loop carries no cross-fn call. This
+// is the same shape choice we made for fasta in Phase 6.3.4.d: drop the
+// per-iter dispatch + parameter shuffle and let the JIT see a flat
+// loop-body once the Cell-bank admission grows to cover this opcode mix.
+//
+// Algorithm:
+//
+//	seed = 42; prev = lookup_int(LCG(seed))
+//	m[prev] += 1                                 // bootstrap iter 0
+//	for i in 1..n {
+//	  seed = LCG(seed)                            // (seed*3877+29573)%139968
+//	  code = lookup_int(seed)                     // 4-way int-threshold
+//	  m[code] += 1                                // 1-mer count
+//	  m[4 + prev*4 + code] += 1                   // 2-mer count
+//	  prev = code
+//	}
+//	h = 0
+//	for k in 0..20 { h = (h*1009 + m[k]) % 2147483647 }
+//	return h
+//
+// Bit-identical to compiler2/corpus.ExpectKNucleotide because the i64
+// thresholds in fastaThr{A,C,G} were chosen to make the integer cascade
+// equivalent to the float-prob cascade for every seed in [0, 139968).
+//
+// Bank: i64 + Cell. NumRegsI64 = 14:
+//
+//	r0=n      r4=MOD_LCG  r6=thrA  r9=code   r11=v   r13=k
+//	r1=seed   r5=HASH_MOD r7=thrC  r10=key2  r12=h
+//	r2=i                  r8=thrG
+//	r3=prev
+//
+// NumRegsCell = 1 (regsCell[0] = m).
+//
+// Bytecode (60 ops):
+//
+//	 0  ConstI64KW  4, 0, 0       ; MOD_LCG  = 139968
+//	 1  ConstI64KW  5, 0, 1       ; HASH_MOD = 2147483647
+//	 2  ConstI64KW  6, 0, 2       ; thrA
+//	 3  ConstI64KW  7, 0, 3       ; thrC
+//	 4  ConstI64KW  8, 0, 4       ; thrG
+//	 5  NewMap      0, 0, 20      ; m = AllocMap(capHint=20)
+//	 6  ConstI64K   1, 0, 42      ; seed = 42
+//	 7  MulI64K     1, 1, 3877
+//	 8  AddI64K     1, 1, 29573
+//	 9  ModI64      1, 1, 4       ; seed %= MOD_LCG
+//	10  CmpLtI64Br  1, 6, 15      ; if seed < thrA -> BOOT_A
+//	11  CmpLtI64Br  1, 7, 17      ; if seed < thrC -> BOOT_C
+//	12  CmpLtI64Br  1, 8, 19      ; if seed < thrG -> BOOT_G
+//	13  ConstI64K   3, 0, 3       ; prev = 3 (t fall-through)
+//	14  Jump              20
+//	15  ConstI64K   3, 0, 0       ; BOOT_A: prev = 0 (a)
+//	16  Jump              20
+//	17  ConstI64K   3, 0, 1       ; BOOT_C: prev = 1 (c)
+//	18  Jump              20
+//	19  ConstI64K   3, 0, 2       ; BOOT_G: prev = 2 (g); fall through
+//	20  MapGetI64I64 11, 0, 3     ; v = m[prev]
+//	21  AddI64K     11, 11, 1
+//	22  MapSetI64I64 0, 3, 11     ; m[prev] = v
+//	23  ConstI64K   2, 0, 1       ; i = 1
+//	    loop_top (PC=24):
+//	24  CmpGeI64Br  2, 0, 50      ; if i >= n -> loop_end
+//	25  MulI64K     1, 1, 3877
+//	26  AddI64K     1, 1, 29573
+//	27  ModI64      1, 1, 4
+//	28  CmpLtI64Br  1, 6, 33      ; ITER_A
+//	29  CmpLtI64Br  1, 7, 35      ; ITER_C
+//	30  CmpLtI64Br  1, 8, 37      ; ITER_G
+//	31  ConstI64K   9, 0, 3       ; code = 3 (t)
+//	32  Jump              38
+//	33  ConstI64K   9, 0, 0       ; ITER_A
+//	34  Jump              38
+//	35  ConstI64K   9, 0, 1       ; ITER_C
+//	36  Jump              38
+//	37  ConstI64K   9, 0, 2       ; ITER_G; fall through
+//	38  MapGetI64I64 11, 0, 9     ; v = m[code]
+//	39  AddI64K     11, 11, 1
+//	40  MapSetI64I64 0, 9, 11     ; m[code] = v
+//	41  MulI64K     10, 3, 4      ; key2 = prev*4
+//	42  AddI64      10, 10, 9     ; key2 += code
+//	43  AddI64K     10, 10, 4     ; key2 += 4
+//	44  MapGetI64I64 11, 0, 10    ; v = m[key2]
+//	45  AddI64K     11, 11, 1
+//	46  MapSetI64I64 0, 10, 11
+//	47  MovI64      3, 9, 0       ; prev = code
+//	48  AddI64K     2, 2, 1       ; i++
+//	49  Jump              24
+//	    loop_end (PC=50):
+//	50  ConstI64K   12, 0, 0      ; h = 0
+//	51  ConstI64K   13, 0, 0      ; k = 0
+//	    summ_top (PC=52):
+//	52  CmpGeI64KBr 13, 20, 59    ; if k >= 20 -> summ_end
+//	53  MapGetI64I64 11, 0, 13    ; v = m[k]
+//	54  MulI64K     12, 12, 1009  ; h *= 1009
+//	55  AddI64      12, 12, 11    ; h += v
+//	56  ModI64      12, 12, 5     ; h %= HASH_MOD
+//	57  AddI64K     13, 13, 1     ; k++
+//	58  Jump              52
+//	    summ_end (PC=59):
+//	59  ReturnI64   12, 0, 0
+var KNucleotide = &Program{
+	Name: "k_nucleotide",
+	Build: func(_ int64) *vm3.Program {
+		fn := &vm3.Function{
+			Name:        "k_nucleotide",
+			NumRegsI64:  14,
+			NumRegsCell: 1,
+			ParamBanks:  []vm3.Bank{vm3.BankI64},
+			ResultBank:  vm3.BankI64,
+			Consts: []vm3.Cell{
+				vm3.CInt(139968),
+				vm3.CInt(2147483647),
+				vm3.CInt(fastaThrA),
+				vm3.CInt(fastaThrC),
+				vm3.CInt(fastaThrG),
+			},
+			Code: []vm3.Op{
+				vm3.MakeOp(vm3.OpConstI64KW, 4, 0, 0),
+				vm3.MakeOp(vm3.OpConstI64KW, 5, 0, 1),
+				vm3.MakeOp(vm3.OpConstI64KW, 6, 0, 2),
+				vm3.MakeOp(vm3.OpConstI64KW, 7, 0, 3),
+				vm3.MakeOp(vm3.OpConstI64KW, 8, 0, 4),
+				vm3.MakeOp(vm3.OpNewMap, 0, 0, 20),
+				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 42),
+				vm3.MakeOp(vm3.OpMulI64K, 1, 1, 3877),
+				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 29573),
+				vm3.MakeOp(vm3.OpModI64, 1, 1, 4),
+				vm3.MakeOp(vm3.OpCmpLtI64Br, 1, 6, 15),
+				vm3.MakeOp(vm3.OpCmpLtI64Br, 1, 7, 17),
+				vm3.MakeOp(vm3.OpCmpLtI64Br, 1, 8, 19),
+				vm3.MakeOp(vm3.OpConstI64K, 3, 0, 3),
+				vm3.MakeOp(vm3.OpJump, 0, 0, 20),
+				vm3.MakeOp(vm3.OpConstI64K, 3, 0, 0),
+				vm3.MakeOp(vm3.OpJump, 0, 0, 20),
+				vm3.MakeOp(vm3.OpConstI64K, 3, 0, 1),
+				vm3.MakeOp(vm3.OpJump, 0, 0, 20),
+				vm3.MakeOp(vm3.OpConstI64K, 3, 0, 2),
+				vm3.MakeOp(vm3.OpMapGetI64I64, 11, 0, 3),
+				vm3.MakeOp(vm3.OpAddI64K, 11, 11, 1),
+				vm3.MakeOp(vm3.OpMapSetI64I64, 0, 3, 11),
+				vm3.MakeOp(vm3.OpConstI64K, 2, 0, 1),
+				vm3.MakeOp(vm3.OpCmpGeI64Br, 2, 0, 50),
+				vm3.MakeOp(vm3.OpMulI64K, 1, 1, 3877),
+				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 29573),
+				vm3.MakeOp(vm3.OpModI64, 1, 1, 4),
+				vm3.MakeOp(vm3.OpCmpLtI64Br, 1, 6, 33),
+				vm3.MakeOp(vm3.OpCmpLtI64Br, 1, 7, 35),
+				vm3.MakeOp(vm3.OpCmpLtI64Br, 1, 8, 37),
+				vm3.MakeOp(vm3.OpConstI64K, 9, 0, 3),
+				vm3.MakeOp(vm3.OpJump, 0, 0, 38),
+				vm3.MakeOp(vm3.OpConstI64K, 9, 0, 0),
+				vm3.MakeOp(vm3.OpJump, 0, 0, 38),
+				vm3.MakeOp(vm3.OpConstI64K, 9, 0, 1),
+				vm3.MakeOp(vm3.OpJump, 0, 0, 38),
+				vm3.MakeOp(vm3.OpConstI64K, 9, 0, 2),
+				vm3.MakeOp(vm3.OpMapGetI64I64, 11, 0, 9),
+				vm3.MakeOp(vm3.OpAddI64K, 11, 11, 1),
+				vm3.MakeOp(vm3.OpMapSetI64I64, 0, 9, 11),
+				vm3.MakeOp(vm3.OpMulI64K, 10, 3, 4),
+				vm3.MakeOp(vm3.OpAddI64, 10, 10, 9),
+				vm3.MakeOp(vm3.OpAddI64K, 10, 10, 4),
+				vm3.MakeOp(vm3.OpMapGetI64I64, 11, 0, 10),
+				vm3.MakeOp(vm3.OpAddI64K, 11, 11, 1),
+				vm3.MakeOp(vm3.OpMapSetI64I64, 0, 10, 11),
+				vm3.MakeOp(vm3.OpMovI64, 3, 9, 0),
+				vm3.MakeOp(vm3.OpAddI64K, 2, 2, 1),
+				vm3.MakeOp(vm3.OpJump, 0, 0, 24),
+				vm3.MakeOp(vm3.OpConstI64K, 12, 0, 0),
+				vm3.MakeOp(vm3.OpConstI64K, 13, 0, 0),
+				vm3.MakeOp(vm3.OpCmpGeI64KBr, 13, 20, 59),
+				vm3.MakeOp(vm3.OpMapGetI64I64, 11, 0, 13),
+				vm3.MakeOp(vm3.OpMulI64K, 12, 12, 1009),
+				vm3.MakeOp(vm3.OpAddI64, 12, 12, 11),
+				vm3.MakeOp(vm3.OpModI64, 12, 12, 5),
+				vm3.MakeOp(vm3.OpAddI64K, 13, 13, 1),
+				vm3.MakeOp(vm3.OpJump, 0, 0, 52),
+				vm3.MakeOp(vm3.OpReturnI64, 12, 0, 0),
+			},
+		}
+		return &vm3.Program{Funcs: []*vm3.Function{fn}, Entry: 0}
+	},
+}

--- a/runtime/jit/vm3jit/bench_corpus_jit_test.go
+++ b/runtime/jit/vm3jit/bench_corpus_jit_test.go
@@ -56,6 +56,8 @@ func BenchmarkCorpusJITRunner(b *testing.B) {
 		{"fasta_n100000", corpus.Fasta, 100000},
 		{"mandelbrot_n100", corpus.Mandelbrot, 100},
 		{"mandelbrot_n300", corpus.Mandelbrot, 300},
+		{"k_nucleotide_n10000", corpus.KNucleotide, 10000},
+		{"k_nucleotide_n100000", corpus.KNucleotide, 100000},
 	}
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -1850,6 +1850,42 @@ case vm3.OpSqrtF64:
 
 **Why a separate op vs an inline `math.Sqrt` call.** A reg-reg call into Go's `math.Sqrt` would route through the trampoline + cgo-style barrier and would defeat the f64-bank's whole point. `FSQRT` is a single host instruction on every modern ISA (ARM64 `FSQRT.D`, x86 `SQRTSD`, RISC-V `FSQRT.D`, PowerPC `fsqrt`); the bytecode-level op + 1-word JIT lowering composes naturally with the existing f64 arithmetic shape.
 
+#### Phase 6.3.4.f.1: k_nucleotide corpus port + baseline (2026-05-19 18:30 GMT+7)
+
+k_nucleotide is the BG "hash-keyed counter" kernel: a 4-way LCG-driven nucleotide classifier (`a/c/g/t`) that increments per-key counters in a map (1-mer and 2-mer) across N iterations, then folds the first 20 counter slots with a multiplicative hash. Compiler2 modelled this as four functions (loop / lookup / inc / summ). Compiler3 collapses it to a single function with an inline integer-threshold cascade and inline map ops, mirroring the same shape choice we made for `fasta` in Phase 6.3.4.d.
+
+The i64-threshold trick reuses `fastaThrA, fastaThrC, fastaThrG` from `compiler3/corpus/fasta.go` (precomputed so the integer cascade `seed < thrX` is bit-identical to the float cascade `s/139968.0 < probX` for every `seed in [0, 139968)`). This eliminates the per-iteration f64 divide and lets the whole hot loop stay in the i64 bank.
+
+**Bank shape.** NumRegsI64 = 14, NumRegsCell = 1 (`regsCell[0] = m`). Layout:
+
+```
+r0 = n        r4 = MOD_LCG  (139968)        r6  = thrA     r9  = code
+r1 = seed     r5 = HASH_MOD (2147483647)    r7  = thrC     r10 = key2
+r2 = i                                      r8  = thrG     r11 = v
+r3 = prev                                                  r12 = h
+                                                           r13 = k
+```
+
+`OpConstI64KW` loads the wide thresholds + moduli from the Consts pool; the loop body is 26 ops (LCG, cascade -> code, `m[code] += 1`, `key2 = 4 + prev*4 + code`, `m[key2] += 1`, `prev = code`, `i++`, back-jump). The closing summarization is a 7-op loop over `m[0..19]`.
+
+**Correctness gate.** `TestMathKernelsMatchVm2` is extended with k_nucleotide cases for `n in {0, 1, 2, 10, 100, 1000}`; every value is bit-identical to `compiler2/corpus.ExpectKNucleotide`. The single-function shape preserves the exact LCG sequence + iteration order from the 4-fn vm2 reference, so the post-summarize hash matches exactly.
+
+**Measured macOS baseline (Apple M4, vm3 interp, no JIT admission):**
+
+| Size | Go (ns/op) | vm3 interp (ns/op) | Ratio vs Go |
+|------|-----------:|-------------------:|------------:|
+| n=10000  | 178,495   |   671,831 | 3.76x |
+| n=100000 | 1,923,983 | 6,669,710 | 3.47x |
+
+`BenchmarkCorpusJITRunner` returns numbers identical to `BenchmarkMathKernels`, confirming the JIT trampoline did not admit the kernel. The Cell-bank admission gate currently rejects on three counts: (1) `OpModI64` and `OpConstI64KW` are not in the whitelist, (2) `OpNewMap` has no pre-alloc analogue of `JITPreAllocList`, and (3) `NumRegsI64 = 14 > maxI64RegsCellARM64 = 11` plus the map-op gate's `NumRegsI64 <= 4` constraint (because vm3 `r4..r6` alias the map-kernel scratch registers `x13..x15`).
+
+**Closure path (Phase 6.3.4.f.2).** Three orthogonal JIT extensions are needed:
+1. Extend `checkCellBankAdmissible` whitelist to include `OpModI64` and `OpConstI64KW` (both are trivial single-instruction ARM64 lowerings: `SDIV+MSUB` and `MOVK` cascade respectively).
+2. Add `JITPreAllocMap` (the `OpNewMap` analogue of `JITPreAllocList`) so the JIT-admitted function receives a pre-warmed map cell in `regsCell[0]` and the `OpNewMap` op becomes a no-op at JIT entry.
+3. Relax the map-op `NumRegsI64 <= 4` gate by scanning ops to verify `r4..r6` are unused as live-across-call values, then emitting spill/reload for them around each map kernel. Optionally add generic wide-K ops (`OpModI64KW`, `OpCmpLtI64KWBr`) so the kernel fits in 10 i64 registers and avoids the spill/reload entirely.
+
+Expected post-JIT ratio: 1.5-2.0x of Go (dominated by the per-iteration map hash + slot lookup; the rest of the loop is pure i64 arithmetic at native speed).
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
Tracks #21766.

Phase 6.3.4.f.1 of MEP-40 BG closure: port k_nucleotide to `compiler3/corpus` as a single-function vm3 kernel (collapses compiler2's 4-fn loop/lookup/inc/summ shape via inline integer-threshold cascade + inline map ops, mirroring the Phase 6.3.4.d fasta port). Lands the correctness gate + measured baseline; JIT closure is tracked as Phase 6.3.4.f.2 in a follow-up.

## Summary

- Single-function vm3 kernel (60 ops): 5 `OpConstI64KW` wide constants, `OpNewMap(capHint=20)`, bootstrap LCG + 3-way cascade, hot loop (LCG -> cascade -> code, `m[code] += 1`, `key2 = 4 + prev*4 + code`, `m[key2] += 1`, `prev = code`, `i++`, back-jump), summarize loop over `m[0..19]` with `h = (h*1009 + v) % 2147483647`.
- i64-threshold trick reuses `fastaThrA / thrC / thrG` from `compiler3/corpus/fasta.go` so the integer cascade is bit-identical to the float cascade for every seed in `[0, 139968)`. Hot loop stays entirely in the i64 bank.
- Bit-identical to `compiler2/corpus.ExpectKNucleotide` for `n in {0, 1, 2, 10, 100, 1000}` via `TestMathKernelsMatchVm2`.
- Bench harness wires `k_nucleotide_n10000 + n100000` into `BenchmarkMathKernels`, `BenchmarkGoKernels`, and `BenchmarkCorpusJITRunner`.
- Spec section `Phase 6.3.4.f.1` records the bank layout, the measured baseline, and names the JIT extensions needed for Phase 6.3.4.f.2 closure.

## Measured macOS baseline (Apple M4, vm3 interp, no JIT admission)

| Size | Go (ns/op) | vm3 interp (ns/op) | Ratio vs Go |
|------|-----------:|-------------------:|------------:|
| n=10000  | 178,495   |   671,831 | 3.76x |
| n=100000 | 1,923,983 | 6,669,710 | 3.47x |

`BenchmarkCorpusJITRunner` numbers are identical to `BenchmarkMathKernels` — the Cell-bank admission gate currently rejects the kernel on three counts: `OpModI64` and `OpConstI64KW` are not in the whitelist, `OpNewMap` has no `JITPreAllocList` analogue, and `NumRegsI64 = 14` exceeds both `maxI64RegsCellARM64 = 11` and the map-op `<=4` constraint (because vm3 `r4..r6` alias the map-kernel scratch registers `x13..x15`).

## Closure plan (Phase 6.3.4.f.2, tracked separately)

1. Extend `checkCellBankAdmissible` whitelist with `OpModI64` (single-instruction `SDIV+MSUB`) and `OpConstI64KW` (3-word `MOVK` cascade).
2. Add `JITPreAllocMap` analogue of `JITPreAllocList` so `OpNewMap` becomes a no-op at JIT entry once the map cell is pre-warmed.
3. Relax the map-op `NumRegsI64 <= 4` gate via spill/reload around each map kernel (or by adding generic wide-K ops `OpModI64KW` + `OpCmpLtI64KWBr` so the kernel fits in 10 i64 registers and avoids the spill entirely).

Expected post-JIT ratio: 1.5-2.0x of Go.

## Test plan

- [x] `go test ./compiler3/corpus/... -run TestMathKernelsMatchVm2` passes
- [x] `go build ./...` clean
- [x] `go test -bench=BenchmarkGoKernels/k_nucleotide -benchtime=2s ./compiler3/corpus/...` produces baseline
- [x] `go test -bench=BenchmarkMathKernels/k_nucleotide -benchtime=2s ./compiler3/corpus/...` produces baseline
- [x] `go test -bench=BenchmarkCorpusJITRunner/k_nucleotide -benchtime=2s ./runtime/jit/vm3jit/...` produces identical-to-interp numbers (admission rejected as expected)