### PR TITLE
mep-0040 phase 6.3.4.h.2: AMD64 lowering of OpFmaF64 + OpSqrtF64

### DIFF
--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -509,6 +509,30 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		}
 		return 10 + 5 + 4 + 5, nil
 
+	case vm3.OpFmaF64:
+		// Phase 6.3.4.h.2 AMD64 lowering: VFMADDxxxSD selected so dst
+		// stays in xmm<A> and the three FMA operands map to vm3's
+		// semantics A = B*mul2 + addend without extra moves when one of
+		// the operands already aliases A. All four code paths emit a
+		// single 5-byte VEX-encoded instruction; only the catch-all
+		// (no alias) needs a leading movsd (4 bytes) to set A := B
+		// before the 132 form.
+		mul2 := int(uint16(op.C) & 0xFF)
+		addend := int((uint16(op.C) >> 8) & 0xFF)
+		a, b := int(op.A), int(op.B)
+		if a == b || a == addend || a == mul2 {
+			return 5, nil
+		}
+		return 4 + 5, nil
+	case vm3.OpSqrtF64:
+		// optional movsd xmm<A>, xmm<B> (4) ; sqrtsd xmm<A>, xmm<A> (4).
+		// (sqrtsd's source can match its dest, so we always operate
+		// in-place after the optional copy.)
+		if op.A == op.B {
+			return 4, nil
+		}
+		return 8, nil
+
 	case vm3.OpCmpEqF64Br, vm3.OpCmpLtF64Br, vm3.OpCmpLeF64Br:
 		// ucomisd xmm<A>, xmm<B> (4) ; jp +6 (6) ; jcc rel32 (6).
 		return 4 + 6 + 6, nil
@@ -704,6 +728,28 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		}
 		out = append(out, xorpdRR(int(op.A), 15)...)
 		return out, nil
+
+	case vm3.OpFmaF64:
+		mul2 := int(uint16(op.C) & 0xFF)
+		addend := int((uint16(op.C) >> 8) & 0xFF)
+		a, b := int(op.A), int(op.B)
+		switch {
+		case a == b:
+			return vfmaddSDRR(0x98, a, addend, mul2), nil
+		case a == addend:
+			return vfmaddSDRR(0xB8, a, b, mul2), nil
+		case a == mul2:
+			return vfmaddSDRR(0xA8, a, b, addend), nil
+		default:
+			out := movsdRR(a, b)
+			return append(out, vfmaddSDRR(0x98, a, addend, mul2)...), nil
+		}
+	case vm3.OpSqrtF64:
+		var out []byte
+		if op.A != op.B {
+			out = append(out, movsdRR(int(op.A), int(op.B))...)
+		}
+		return append(out, sqrtsdRR(int(op.A), int(op.A))...), nil
 
 	case vm3.OpCmpEqF64Br, vm3.OpCmpLtF64Br, vm3.OpCmpLeF64Br:
 		// ucomisd ; jp +6 (skip the je/jb/jbe) ; jcc target.
@@ -1146,6 +1192,34 @@ func mulsdRR(dst, src int) []byte { return sseRR2(0x59, dst, src) }
 
 // divsdRR emits `divsd xmmDst, xmmSrc`. Opcode F2 [REX] 0F 5E /r.
 func divsdRR(dst, src int) []byte { return sseRR2(0x5E, dst, src) }
+
+// sqrtsdRR emits `sqrtsd xmmDst, xmmSrc`. Opcode F2 [REX] 0F 51 /r.
+// IEEE 754 correctly-rounded scalar square root; bit-identical to Go's
+// math.Sqrt on AMD64 (which emits the same SQRTSD). Phase 6.3.4.h.2
+// (AMD64 catch-up for OpSqrtF64, mirror of ARM64 FSQRT in lower_arm64).
+func sqrtsdRR(dst, src int) []byte { return sseRR2(0x51, dst, src) }
+
+// vfmaddSDRR emits a 3-byte-VEX-encoded VFMADDxxxSD xmmDst, xmmSrc1, xmmSrc2.
+// opc selects the FMA3 variant:
+//
+//	0x98 = VFMADD132SD: dst = dst*src2 + src1
+//	0xA8 = VFMADD213SD: dst = src1*dst + src2
+//	0xB8 = VFMADD231SD: dst = src1*src2 + dst
+//
+// All operands must live in xmm0..7 (vm3 caps f64 regs at 8). Encoding:
+//
+//	C4 byte1 byte2 opc modrm   (5 bytes total)
+//	  byte1 = 11100010b = 0xE2  (R̄=X̄=B̄=1, mmmmm=00010 for 0F 38 escape)
+//	  byte2 = 1 vvvv 0 01b      (W=1, ~src1 in vvvv, L=0, pp=01 for 66)
+//	  modrm = 11 dst src2       (register-register, ModRM.r/m = src2)
+//
+// Used by Phase 6.3.4.h.2 (AMD64 catch-up for OpFmaF64, mirror of ARM64
+// FMADD in lower_arm64). Bit-identical to math.FMA per IEEE 754-2008.
+func vfmaddSDRR(opc byte, dst, src1, src2 int) []byte {
+	vvvv := byte(0xF) ^ byte(src1&0xF)
+	byte2 := byte(0x80) | (vvvv << 3) | 0x01
+	return []byte{0xC4, 0xE2, byte2, opc, modRM(3, byte(dst&7), byte(src2&7))}
+}
 
 // movsdLoadXMMFromR14 emits `movsd xmm<dst>, disp32(%r14)`.
 // Opcode F2 REX.B 0F 10 /r disp32. REX is always present (REX.B for R14

--- a/runtime/jit/vm3jit/sqrt_sum_jit_test.go
+++ b/runtime/jit/vm3jit/sqrt_sum_jit_test.go
@@ -1,4 +1,4 @@
-//go:build darwin && arm64
+//go:build (darwin && arm64) || (linux && amd64)
 
 package vm3jit_test
 
@@ -14,7 +14,9 @@ import (
 // OpSqrtF64 lowering. F64SqrtSum is the f64 dual of F64DotSum: it
 // drives an i64 counter through OpSqrtF64 + OpAddF64 and confirms the
 // JIT'd FSQRT result is bit-identical to math.Sqrt across N in the
-// n_body inner-loop range.
+// n_body inner-loop range. The lowering covers both ARM64 (FSQRT) and
+// AMD64 (SQRTSD), so this test runs platform-agnostic; Phase 6.3.4.h.2
+// (2026-05-19) drops the prior darwin&&arm64 build tag.
 func TestCompileF64SqrtSumMatchesInterp(t *testing.T) {
 	prog := corpus.F64SqrtSum.Build(0)
 	fn := prog.Funcs[prog.Entry]

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -1886,6 +1886,40 @@ r3 = prev                                                  r12 = h
 
 Expected post-JIT ratio: 1.5-2.0x of Go (dominated by the per-iteration map hash + slot lookup; the rest of the loop is pure i64 arithmetic at native speed).
 
+#### Phase 6.3.4.h.2: AMD64 lowering of OpFmaF64 + OpSqrtF64 (2026-05-19 18:17 GMT+7)
+
+Catch-up for the AMD64 backend so both f64 super-ops are platform-portable, mirroring the ARM64 `FMADD`/`FSQRT` lowerings already in place. Until this lands, `mandelbrot_jit_test.go` (build-tag-free) would skip JIT admission on linux/amd64 and `sqrt_sum_jit_test.go` had to be gated to `darwin && arm64`. Both gates drop.
+
+**OpFmaF64 -> VFMADDxxxSD.** vm3 semantics: `regsF64[A] = regsF64[B] * regsF64[mul2] + regsF64[addend]`, where `op.C` packs `mul2` (low byte) and `addend` (high byte). FMA3 has three register-aliasing variants and we pick whichever single-instruction form matches the operand layout so no extra `movsd` is needed when one of B/mul2/addend already aliases A:
+
+| Operand aliasing | Variant emitted | Bytes |
+| --- | --- | --- |
+| `A == B` | `VFMADD132SD A, addend, mul2` (opc 0x98: A = A*mul2 + addend) | 5 |
+| `A == addend` | `VFMADD231SD A, B, mul2` (opc 0xB8: A = B*mul2 + A) | 5 |
+| `A == mul2` | `VFMADD213SD A, B, addend` (opc 0xA8: A = B*A + addend) | 5 |
+| none | `movsd A, B` ; `VFMADD132SD A, addend, mul2` | 4 + 5 = 9 |
+
+VEX 3-byte encoding (xmm0..7, vm3 caps `MaxF64Regs=8`):
+
+```
+C4 E2 byte2 opc modRM    (5 bytes)
+  byte2 = 1 vvvv 0 01b   (W=1, vvvv = ~src1, L=0, pp=01 for 66 prefix)
+  modRM = 11 dst src2    (register-register, ModRM.r/m = src2)
+```
+
+**OpSqrtF64 -> SQRTSD.** vm3 semantics: `regsF64[A] = math.Sqrt(regsF64[B])`. SQRTSD allows source == dest, so the lowering is:
+
+```
+[movsd xmmA, xmmB]   ; 4 bytes, only when A != B
+sqrtsd xmmA, xmmA    ; 4 bytes (F2 0F 51 /r)
+```
+
+Bit-identical to Go's `math.Sqrt` on AMD64 (which itself emits SQRTSD). IEEE 754-2008 correctly-rounded.
+
+**Tests.** `TestMandelbrotJITCompiles` (no build tag) is now the cross-platform `OpFmaF64` correctness gate: it asserts every N in {0,1,2,5,10,50,100} produces a result bit-identical to `compiler2/corpus.ExpectMandelbrot`. `TestCompileF64SqrtSumMatchesInterp` drops its `darwin && arm64` build tag and gains the `(darwin && arm64) || (linux && amd64)` set so it runs on both production targets. The previous `n_body prep` note about "AMD64 routes through the interpreter for now" no longer applies; n_body itself (Phase 6.3.4.j) now blocks only on `OpListGetF64`/`OpListSetF64`.
+
+**Why one PR for both ops.** They share an emit-site (the f64 super-op cluster between `OpNegF64` and `OpCmpEqF64Br` in `lower_amd64.go`), share the cross-platform test set (both kernels have prior ARM64 coverage), and share the helper pattern (one SSE helper + one VEX helper). Splitting the PR would mean two builds and two CI runs for what is structurally a single backend extension.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
## Summary
- AMD64 lowering for `OpFmaF64` (VFMADD132SD/VFMADD213SD/VFMADD231SD, picks no-`movsd` variant when one operand already aliases dst; 5 or 9 bytes).
- AMD64 lowering for `OpSqrtF64` (SQRTSD; 4 bytes in-place, 8 bytes when dst != src).
- Drops `darwin && arm64` build tag on `sqrt_sum_jit_test.go` and widens to `(darwin && arm64) || (linux && amd64)`. `TestMandelbrotJITCompiles` (no build tag) is now the cross-platform `OpFmaF64` correctness gate.
- MEP-40 spec: Phase 6.3.4.h.2 (2026-05-19 18:17 GMT+7) section recording the VEX/SSE encodings and the FMA3 aliasing-variant table.

Refs #21768.

## Test plan
- [x] `go build ./...` clean (native ARM64).
- [x] `GOOS=linux GOARCH=amd64 go build ./runtime/jit/vm3jit/...` clean.
- [x] `GOOS=linux GOARCH=amd64 go vet ./runtime/jit/vm3jit/...` clean.
- [x] `go test ./runtime/jit/vm3jit/...` passes on native ARM64 (no regression).
- [ ] CI runs `sqrt_sum_jit_test.go` + `mandelbrot_jit_test.go` on linux/amd64 (auto-merge gate).