### PR TITLE
mep-0040 phase 6.3.4.j.3: JIT-admit n_body on ARM64

### DIFF
--- a/compiler3/corpus/n_body.go
+++ b/compiler3/corpus/n_body.go
@@ -83,9 +83,13 @@ func ExpectN_body(steps int64) float64 {
 // the surface this port targets so the JIT lowering in Phase
 // 6.3.4.j.3 can stay inside the existing cells-slab hoist.
 //
-// Register banks (NumRegs: 9 / 8 / 7):
+// Register banks (NumRegs: 7 / 8 / 7):
 //
-//	I64: 0 steps_in, 1 s, 2 i, 3 j, 4 p, 5 bi, 6 bj, 7 push_zero, 8 unused
+//	I64: 0 steps_in, 1 s, 2 i, 3 j, 4 p, 5 bi, 6 bj/push_zero
+//	     (reg 6 carries push_zero pc 7..16 and bj pc 137..159; the lifetimes
+//	     don't overlap, so they share the slot to keep i64 reg 7+ free —
+//	     otherwise the JIT's cell-bank lane at x21..x24 would clash with
+//	     the new cell-4..7 lay-out introduced in Phase 6.3.4.j.3).
 //	F64: 0..7 working file (reused across phases)
 //	Cell: 0 pos_x, 1 pos_y, 2 pos_z, 3 vel_x, 4 vel_y, 5 vel_z, 6 mass
 //
@@ -120,7 +124,7 @@ var N_body = &Program{
 	Build: func(_ int64) *vm3.Program {
 		fn := &vm3.Function{
 			Name:        "n_body",
-			NumRegsI64:  9,
+			NumRegsI64:  7,
 			NumRegsF64:  8,
 			NumRegsCell: 7,
 			ParamBanks:  []vm3.Bank{vm3.BankI64},
@@ -145,18 +149,20 @@ var N_body = &Program{
 				vm3.MakeOp(vm3.OpNewList, 4, 0, 0),
 				vm3.MakeOp(vm3.OpNewList, 5, 0, 0),
 				vm3.MakeOp(vm3.OpNewList, 6, 0, 0),
-				// --- push 5 zeros into each list (pc 7..18). i64 reg 7 holds 0; reg 2 is loop i.
-				vm3.MakeOp(vm3.OpConstI64K, 7, 0, 0), // pc=7: tmp_zero = 0
+				// --- push 5 zeros into each list (pc 7..18). i64 reg 6 holds 0
+				// (reg 6 is later reused as the energy-phase bj; lifetimes
+				// don't overlap, see header note). Reg 2 is loop i.
+				vm3.MakeOp(vm3.OpConstI64K, 6, 0, 0), // pc=7: tmp_zero = 0
 				vm3.MakeOp(vm3.OpConstI64K, 2, 0, 0), // pc=8: i = 0
 				// push_loop pc=9
 				vm3.MakeOp(vm3.OpCmpGeI64KBr, 2, 5, 19), // pc=9: if i>=5 -> push_done
-				vm3.MakeOp(vm3.OpListPushI64, 0, 7, 0),  // pc=10
-				vm3.MakeOp(vm3.OpListPushI64, 1, 7, 0),  // pc=11
-				vm3.MakeOp(vm3.OpListPushI64, 2, 7, 0),  // pc=12
-				vm3.MakeOp(vm3.OpListPushI64, 3, 7, 0),  // pc=13
-				vm3.MakeOp(vm3.OpListPushI64, 4, 7, 0),  // pc=14
-				vm3.MakeOp(vm3.OpListPushI64, 5, 7, 0),  // pc=15
-				vm3.MakeOp(vm3.OpListPushI64, 6, 7, 0),  // pc=16
+				vm3.MakeOp(vm3.OpListPushI64, 0, 6, 0),  // pc=10
+				vm3.MakeOp(vm3.OpListPushI64, 1, 6, 0),  // pc=11
+				vm3.MakeOp(vm3.OpListPushI64, 2, 6, 0),  // pc=12
+				vm3.MakeOp(vm3.OpListPushI64, 3, 6, 0),  // pc=13
+				vm3.MakeOp(vm3.OpListPushI64, 4, 6, 0),  // pc=14
+				vm3.MakeOp(vm3.OpListPushI64, 5, 6, 0),  // pc=15
+				vm3.MakeOp(vm3.OpListPushI64, 6, 6, 0),  // pc=16
 				vm3.MakeOp(vm3.OpAddI64K, 2, 2, 1),      // pc=17: i++
 				vm3.MakeOp(vm3.OpJump, 0, 0, 9),         // pc=18: -> push_loop
 				// push_done pc=19

--- a/runtime/jit/vm3jit/arena_ctx.go
+++ b/runtime/jit/vm3jit/arena_ctx.go
@@ -7,11 +7,14 @@ import (
 )
 
 // maxCellRegs is the cap on simultaneously-live Cell registers in the
-// vm3jit backend. AArch64 pins Cell regs 0..3 in x25..x28; AMD64
-// Cell-bank lowering (Phase 6.2d.2.e) will mirror this on its own
-// callee-saved range. Bumping the cap requires growing jitFrame3 and
-// allocating more callee-saved pairs in the prologue.
-const maxCellRegs = 4
+// vm3jit backend. AArch64 pins Cell regs 0..3 in x25..x28 and Cell regs
+// 4..7 in x21..x24 (the latter overlaps the i64 callee-saved lane, so
+// fns with NumRegsCell > 4 must keep NumRegsI64 <= 7 — see archCaps and
+// the i64-cap gate in compile.go). AMD64 Cell-bank lowering (Phase
+// 6.2d.2.e) will mirror this on its own callee-saved range. Bumping the
+// cap further requires growing jitFrame3 and allocating more callee-
+// saved pairs in the prologue.
+const maxCellRegs = 8
 
 // MaxCellRegs is exported for tests and external callers that size
 // scratch buffers for the Cell bank.

--- a/runtime/jit/vm3jit/bench_corpus_jit_test.go
+++ b/runtime/jit/vm3jit/bench_corpus_jit_test.go
@@ -58,6 +58,8 @@ func BenchmarkCorpusJITRunner(b *testing.B) {
 		{"mandelbrot_n300", corpus.Mandelbrot, 300},
 		{"k_nucleotide_n10000", corpus.KNucleotide, 10000},
 		{"k_nucleotide_n100000", corpus.KNucleotide, 100000},
+		{"n_body_n100", corpus.N_body, 100},
+		{"n_body_n10000", corpus.N_body, 10000},
 	}
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {

--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -228,17 +228,34 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 			vm3.OpCmpGtI64KBr, vm3.OpCmpGeI64KBr,
 			vm3.OpJump, vm3.OpReturnI64, vm3.OpReturnConstK,
 			vm3.OpListGetI64, vm3.OpListPushI64, vm3.OpListSetI64,
-			vm3.OpMapSetI64I64, vm3.OpMapGetI64I64:
+			vm3.OpListGetF64, vm3.OpListSetF64,
+			vm3.OpMapSetI64I64, vm3.OpMapGetI64I64,
+			vm3.OpConstF64K, vm3.OpMovF64,
+			vm3.OpAddF64, vm3.OpSubF64, vm3.OpMulF64, vm3.OpDivF64,
+			vm3.OpNegF64, vm3.OpFmaF64, vm3.OpSqrtF64,
+			vm3.OpCmpEqF64Br, vm3.OpCmpNeF64Br,
+			vm3.OpCmpLtF64Br, vm3.OpCmpLeF64Br,
+			vm3.OpCmpGtF64Br, vm3.OpCmpGeF64Br,
+			vm3.OpI64ToF64, vm3.OpF64ToI64,
+			vm3.OpReturnF64:
 			continue
 		case vm3.OpNewList:
 			// Phase 6.2d.2.b step 2: admit at pc=0 when the lowerer can
 			// skip its emission (jitCall pre-allocates the list on the
 			// Go side). canPreAllocList further requires no other op in
 			// fn overwrites the cell.
+			//
+			// Phase 6.3.4.j.3 generalizes the skip to a contiguous prefix
+			// of K OpNewList ops at pc 0..K-1. Admit when the op falls
+			// inside the prefix (preAllocListPrefix returns K>0 and
+			// i<K).
 			if i == 0 && canPreAllocList(fn) {
 				continue
 			}
-			return fmt.Errorf("%w: %s pc %d Cell-bank fn uses inline OpNewList (only pc=0 with pre-alloc is admitted)",
+			if k := int(preAllocListPrefix(fn)); k > 0 && i < k {
+				continue
+			}
+			return fmt.Errorf("%w: %s pc %d Cell-bank fn uses inline OpNewList (only pre-alloc prefix is admitted)",
 				ErrNotImplemented, fn.Name, i)
 		case vm3.OpTailCallMixed:
 			if opts.SelfIdx < 0 || int(uint16(op.C)) != opts.SelfIdx || op.B != 0 {
@@ -352,6 +369,13 @@ func archCaps(fn *vm3.Function) (int, int, bool) {
 		i64Cap := maxI64Regs
 		if fn.NumRegsCell > 0 {
 			i64Cap = maxI64RegsCellARM64
+		}
+		// Phase 6.3.4.j.3: when NumRegsCell > 4 the lower-cell range
+		// (cells 4..7) overlaps the i64 callee-saved lane (x21..x24),
+		// so callers must keep i64 in the caller-saved bank (regs 0..6
+		// at x9..x15).
+		if fn.NumRegsCell > 4 {
+			i64Cap = 7
 		}
 		return i64Cap, maxF64RegsARM64, true
 	case ArchAMD64:

--- a/runtime/jit/vm3jit/init.go
+++ b/runtime/jit/vm3jit/init.go
@@ -187,6 +187,19 @@ func jitCall(vm *vm3.VM, fn *vm3.Function, argsI64 []int64, argsF64 []float64, a
 	// vm.deopt* handles stay valid for the interp's resume.
 	var marks vm3.CallScopeMarks
 	vm.Arenas().SnapshotForJITEntry(&marks)
+	// Phase 6.3.4.j.3 multi-list pre-alloc: fn.JITPreAllocListPrefix > 0
+	// means the JIT skipped the first K OpNewList ops; allocate them
+	// here against the just-snapshotted arena marks so the per-call
+	// restore reclaims them on clean return. The K=1 warm-scratch shape
+	// is handled by the JITPreAllocList branch above and never reaches
+	// this point.
+	if fn.JITPreAllocListPrefix > 0 {
+		arenas := vm.Arenas()
+		for i := 0; i < int(fn.JITPreAllocListPrefix); i++ {
+			op := fn.Code[i]
+			jf.regsCell[op.A] = arenas.AllocList(0, int(op.C))
+		}
+	}
 	// Lay out params per ParamBanks position-indexed convention: argsX[k]
 	// is meaningful iff fn.ParamBanks[k] == BankX. For i64-only callees
 	// argsCell/argsF64 are nil and we use the fast path: copy argsI64
@@ -301,9 +314,11 @@ func CompileAndCache(prog *vm3.Program, idx uint32) (*CompiledFunc, error) {
 	// it is read only by jitCall, which only fires when JITCode is non-
 	// nil (i.e. when admission did succeed).
 	fn.JITPreAllocList = canPreAllocList(fn)
+	fn.JITPreAllocListPrefix = preAllocListPrefix(fn)
 	cf, err := CompileInProgram(prog, idx)
 	if err != nil {
 		fn.JITPreAllocList = false
+		fn.JITPreAllocListPrefix = 0
 		return nil, err
 	}
 	fn.JITCode = cf.Entry()
@@ -334,6 +349,12 @@ func canPreAllocList(fn *vm3.Function) bool {
 	if int(dest) >= int(fn.NumRegsCell) || int(dest) >= MaxCellRegs {
 		return false
 	}
+	// Single-list warm-scratch shape: fn.Code[1] is not also an
+	// OpNewList. The K>1 prefix path takes over via
+	// JITPreAllocListPrefix when there is a contiguous run.
+	if len(fn.Code) > 1 && fn.Code[1].Code == vm3.OpNewList {
+		return false
+	}
 	for i := 1; i < len(fn.Code); i++ {
 		op := fn.Code[i]
 		if op.Code == vm3.OpNewList && op.A == dest {
@@ -344,6 +365,63 @@ func canPreAllocList(fn *vm3.Function) bool {
 		}
 	}
 	return true
+}
+
+// preAllocListPrefix returns the length K of the contiguous OpNewList
+// prefix at fn.Code[0..K-1] that can be lifted into jitCall. K satisfies
+// these invariants (Phase 6.3.4.j.3):
+//
+//   - Each op fn.Code[i] for i<K is an OpNewList writing to a distinct
+//     regsCell[A] with A < min(NumRegsCell, MaxCellRegs).
+//   - No subsequent op (i >= K) writes regsCell[A] via OpNewList or
+//     OpNewMap (would clobber the pre-seeded handle without the lowerer
+//     seeing the data flow).
+//
+// Returns 0 when the prefix is empty. The single-list warm-scratch
+// shape (K=1) is recognized by canPreAllocList separately; this helper
+// reports it as K=1 too, so K=0 strictly means "no pre-alloc". The
+// existing JITPreAllocList flag continues to gate the warm-scratch
+// path; JITPreAllocListPrefix gates the JIT-side skip and (for K>1)
+// the fresh-alloc multi-list path in jitCall.
+func preAllocListPrefix(fn *vm3.Function) uint16 {
+	if len(fn.Code) == 0 || fn.Code[0].Code != vm3.OpNewList {
+		return 0
+	}
+	cellCap := int(fn.NumRegsCell)
+	if cellCap > MaxCellRegs {
+		cellCap = MaxCellRegs
+	}
+	seen := make(map[uint16]bool)
+	k := 0
+	for i := 0; i < len(fn.Code); i++ {
+		op := fn.Code[i]
+		if op.Code != vm3.OpNewList {
+			break
+		}
+		if int(op.A) >= cellCap {
+			break
+		}
+		if seen[op.A] {
+			break
+		}
+		seen[op.A] = true
+		k = i + 1
+	}
+	if k == 0 {
+		return 0
+	}
+	// No subsequent op may overwrite any pre-seeded cell via
+	// OpNewList / OpNewMap.
+	for i := k; i < len(fn.Code); i++ {
+		op := fn.Code[i]
+		if op.Code != vm3.OpNewList && op.Code != vm3.OpNewMap {
+			continue
+		}
+		if seen[op.A] {
+			return 0
+		}
+	}
+	return uint16(k)
 }
 
 // CompileProgram is the convenience entry point that walks every

--- a/runtime/jit/vm3jit/lower_arm64.go
+++ b/runtime/jit/vm3jit/lower_arm64.go
@@ -56,8 +56,18 @@ func r2x(fn *vm3.Function, r uint16) uint32 {
 }
 
 // r2cell maps a vm3 Cell register slot to its pinned AArch64 callee-
-// saved register (x25..x28). Caller has pre-checked r < maxCellRegs.
-func r2cell(r uint16) uint32 { return uint32(r) + 25 }
+// saved register. Cells 0..3 sit in x25..x28 (unchanged); cells 4..7
+// sit in x21..x24 (Phase 6.3.4.j.3). Caller has pre-checked
+// r < maxCellRegs. When fn.NumRegsCell > 4 the admissibility check in
+// compile.go also forbids NumRegsI64 > 7 so the cell-4..7 lane and the
+// i64-7..10 callee-saved lane (which also lives at x21..x24) never
+// overlap.
+func r2cell(r uint16) uint32 {
+	if r < 4 {
+		return uint32(r) + 25
+	}
+	return uint32(r) + 17 // r=4→21, r=5→22, r=6→23, r=7→24
+}
 
 // r2d maps a vm3 f64 register slot to the AArch64 SIMD register
 // number (V0..V7 / D0..D7). Caller pre-checks r < maxF64RegsARM64.
@@ -166,6 +176,14 @@ func numCellCalleeSavedPairs(fn *vm3.Function) int {
 // STP x21:x22 (cells.cap + cells.ptr; cap unused for sum but pushed
 // alongside ptr), STP x25:x26 (cell reg 0). For fill (has Push) the
 // list grows with STP x23:x24 (cells.len + unused) before x25.
+//
+// Phase 6.3.4.j.3 extends cell-bank to NumRegsCell up to 8: cells 0..3
+// stay at x25..x28 (pairs k=0,1), cells 4..7 land at x21..x24 (pairs
+// k=2,3 → first regs 21, 23). The x21:x22 / x23:x24 pairs are
+// mutually exclusive with the slab-field hoist (hoist only applies at
+// NumRegsCell==1) and with the i64-callee-saved lane (the
+// admissibility check forbids NumRegsCell > 4 with NumRegsI64 > 7),
+// so the same pair never carries two banks simultaneously.
 func calleeSavedPairRegs(fn *vm3.Function) []uint32 {
 	pairs := make([]uint32, 0, numCalleeSavedPairs(fn))
 	if numCellScratchPairs(fn) > 0 {
@@ -188,7 +206,20 @@ func calleeSavedPairRegs(fn *vm3.Function) []uint32 {
 		}
 	}
 	for k := 0; k < numCellCalleeSavedPairs(fn); k++ {
-		pairs = append(pairs, 25+uint32(2*k))
+		// Cells 0..3 live in x25:x26 (k=0) and x27:x28 (k=1).
+		// Cells 4..7 live in x21:x22 (k=2) and x23:x24 (k=3).
+		var first uint32
+		switch k {
+		case 0:
+			first = 25
+		case 1:
+			first = 27
+		case 2:
+			first = 21
+		case 3:
+			first = 23
+		}
+		pairs = append(pairs, first)
 	}
 	hoistStart := tableHoistRegStartARM64(fn)
 	for k := 0; k < numTableHoistPairsARM64(fn); k++ {
@@ -1221,6 +1252,24 @@ func wordCountARM64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		stride := int64(vm3.JITListSlabStride())
 		return movImm64WordCount(stride) + 7, nil
 
+	case vm3.OpListGetF64:
+		// Inline f64-typed list load. CFloat stores raw IEEE 754 bits
+		// so there is no sign-extend step; the cold form mirrors the
+		// i64 cold form minus the SBFX. No hoist applies to n_body
+		// (NumRegsCell=7), so only the cold form lands in this phase:
+		//   UXTW x16, w_cell ; MOV x17, #stride ; MUL ; ADD x16, x19 ;
+		//   LDR x16, [x16, #CELLS_OFFSET] ; LDR Dt, [x16, xIdx, LSL #3]
+		stride := int64(vm3.JITListSlabStride())
+		return movImm64WordCount(stride) + 5, nil
+
+	case vm3.OpListSetF64:
+		// Inline f64-typed list store. CFloat is unbox-free so no
+		// MOVZ tag / BFI pack step is needed. Cold form:
+		//   UXTW x16, w_cell ; MOV x17, #stride ; MUL ; ADD x16, x19 ;
+		//   LDR x17, [x16, #CELLS_OFFSET] ; STR Dt, [x17, xIdx, LSL #3]
+		stride := int64(vm3.JITListSlabStride())
+		return movImm64WordCount(stride) + 5, nil
+
 	case vm3.OpMapSetI64I64:
 		// Phase 6.2d.2.d step 4: inline open-addressed map set with a
 		// load-factor 0.5 grow check that deopts via StatusMapGrow.
@@ -1268,9 +1317,14 @@ func wordCountARM64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		// skips fn.Code[0]'s OpNewList entirely; jitCall (Go side) writes
 		// the pre-allocated list handle into jf.regsCell[A] before the
 		// trampoline call, and the prologue's LDR x_cell, [x3, #A*8]
-		// picks it up into the pinned reg. Only the PC=0 instance is
-		// skipped; any later OpNewList is left for a future sub-phase.
+		// picks it up into the pinned reg.
+		//
+		// Phase 6.3.4.j.3 extends the skip to a K-op prefix of inline
+		// OpNewLists; jitCall pre-allocates K lists and seeds each cell.
 		if idx == 0 && fn.JITPreAllocList {
+			return 0, nil
+		}
+		if idx < int(fn.JITPreAllocListPrefix) {
 			return 0, nil
 		}
 		return 0, fmt.Errorf("%w: opcode %d (inline NewList unsupported)", ErrNotImplemented, op.Code)
@@ -1620,6 +1674,11 @@ func emitInstrARM64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 			// Skipped: jitCall pre-allocated the list and wrote the
 			// handle to regsCell[A]; the prologue loaded it into the
 			// pinned reg before this PC. Emit zero words.
+			return []uint32{}, nil
+		}
+		if idx < int(fn.JITPreAllocListPrefix) {
+			// Phase 6.3.4.j.3 multi-list prefix: same skip rationale,
+			// jitCall pre-seeded K cells before the trampoline.
 			return []uint32{}, nil
 		}
 		return nil, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
@@ -2105,6 +2164,58 @@ func emitInstrARM64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		ws = append(ws, str64RegLsl3(20, 17, xIdx))
 		return ws, nil
 
+	case vm3.OpListGetF64:
+		// regsF64[A] = arenas.Lists[handleIdx(regsCell[B])].cells[regsI64[C]].Float()
+		//
+		// Cold form (no hoist):
+		//   UXTW x16, w_cell                  ; idx = handle & 0xFFFFFFFF
+		//   MOV  x17, #SIZEOF_VMLIST           ; stride
+		//   MUL  x16, x16, x17                 ; slab byte offset
+		//   ADD  x16, x16, x19                 ; x19 = cached lists base
+		//   LDR  x16, [x16, #CELLS_OFFSET]     ; cells.ptr
+		//   LDR  Dt,  [x16, xIdx, LSL #3]      ; cells[idxReg] as raw f64 bits
+		//
+		// No SBFX: CFloat stores IEEE 754 bits directly, so the load
+		// produces the f64 payload bit-for-bit identical to the
+		// interp's .Float() decoder.
+		cellsOff := uint32(vm3.JITListCellsOffset())
+		xIdx := r2x(fn, uint16(op.C))
+		stride := int64(vm3.JITListSlabStride())
+		xCell := r2cell(op.B)
+		dA := r2d(op.A)
+		ws := make([]uint32, 0, movImm64WordCount(stride)+5)
+		ws = append(ws, uxtwReg(16, xCell))
+		ws = append(ws, movImm64(17, stride)...)
+		ws = append(ws, mulReg(16, 16, 17))
+		ws = append(ws, addReg(16, 16, 19))
+		ws = append(ws, ldr64(16, 16, cellsOff/8))
+		ws = append(ws, ldrDRegLsl3(dA, 16, xIdx))
+		return ws, nil
+
+	case vm3.OpListSetF64:
+		// arenas.Lists[handleIdx(regsCell[A])].cells[regsI64[C]] = CFloat(regsF64[B])
+		//
+		// Cold form (no hoist):
+		//   UXTW x16, w_cell                  ; idx = handle & 0xFFFFFFFF
+		//   MOV  x17, #SIZEOF_VMLIST           ; stride
+		//   MUL  x16, x16, x17                 ; slab byte offset
+		//   ADD  x16, x16, x19                 ; x19 = cached lists base
+		//   LDR  x17, [x16, #CELLS_OFFSET]     ; cells.ptr
+		//   STR  Dt,  [x17, xIdx, LSL #3]      ; cells[idxReg] = raw f64 bits
+		cellsOff := uint32(vm3.JITListCellsOffset())
+		xIdx := r2x(fn, uint16(op.C))
+		stride := int64(vm3.JITListSlabStride())
+		xCell := r2cell(op.A)
+		dB := r2d(op.B)
+		ws := make([]uint32, 0, movImm64WordCount(stride)+5)
+		ws = append(ws, uxtwReg(16, xCell))
+		ws = append(ws, movImm64(17, stride)...)
+		ws = append(ws, mulReg(16, 16, 17))
+		ws = append(ws, addReg(16, 16, 19))
+		ws = append(ws, ldr64(17, 16, cellsOff/8))
+		ws = append(ws, strDRegLsl3(dB, 17, xIdx))
+		return ws, nil
+
 	default:
 		return nil, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
 	}
@@ -2316,6 +2427,14 @@ func ldrRegLsl3(xt, xn, xm uint32) uint32 {
 	return 0xF8607800 | ((xm & 0x1F) << 16) | ((xn & 0x1F) << 5) | (xt & 0x1F)
 }
 
+// ldrDRegLsl3 encodes LDR Dt, [Xn, Xm, LSL #3]: load a 64-bit FP
+// register from base+idx*8. Identical to ldrRegLsl3 except V=1
+// (SIMD&FP variant). Used by OpListGetF64 to read cells[idxReg] as
+// raw f64 bits into a D-register.
+func ldrDRegLsl3(dt, xn, xm uint32) uint32 {
+	return 0xFC607800 | ((xm & 0x1F) << 16) | ((xn & 0x1F) << 5) | (dt & 0x1F)
+}
+
 // sbfx48 encodes SBFX Xd, Xn, #0, #48: sign-extend the low 48 bits of
 // Xn into Xd. Equivalent to SBFM Xd, Xn, #0, #47 (immr=0, imms=47,
 // sf=1, N=1). Used by OpListGetI64 to recover the signed Int48 payload
@@ -2337,6 +2456,14 @@ func bfi48(xd, xn uint32) uint32 {
 // OpListPushI64 to write cells[len] = boxedCell.
 func str64RegLsl3(xt, xn, xm uint32) uint32 {
 	return 0xF8207800 | ((xm & 0x1F) << 16) | ((xn & 0x1F) << 5) | (xt & 0x1F)
+}
+
+// strDRegLsl3 encodes STR Dt, [Xn, Xm, LSL #3]: store a 64-bit FP
+// register at base+idx*8. Used by OpListSetF64 to write a raw f64
+// payload into cells[idxReg]. The CFloat encoding stores the IEEE
+// 754 bits directly, so no NaN-box tag is added on the way in.
+func strDRegLsl3(dt, xn, xm uint32) uint32 {
+	return 0xFC207800 | ((xm & 0x1F) << 16) | ((xn & 0x1F) << 5) | (dt & 0x1F)
 }
 
 // strW encodes STR Wt, [Xn, #imm12*4] (unsigned-offset 32-bit). Used

--- a/runtime/jit/vm3jit/nbody_jit_test.go
+++ b/runtime/jit/vm3jit/nbody_jit_test.go
@@ -1,0 +1,49 @@
+package vm3jit_test
+
+import (
+	"math"
+	"testing"
+
+	c3 "mochi/compiler3/corpus"
+	"mochi/runtime/jit/vm3jit"
+	"mochi/runtime/vm3"
+)
+
+// TestNBodyJITCompiles is the Phase 6.3.4.j.3 correctness gate: the
+// compiler3 n_body kernel must JIT-compile (entry has non-nil JITCode
+// after CompileProgram) and produce a result within 1e-10 of the
+// ExpectN_body oracle. The kernel exercises the new ARM64 lowerings
+// for OpListGetF64 and OpListSetF64 on a Cell-bank fn that interleaves
+// 7 distinct list handles inside a triple-nested loop; the
+// admission whitelist was extended in the same phase to cover the
+// f64 op set the kernel needs (Add/Sub/Mul/Div/Sqrt/Const/I64ToF64
+// plus the new list f64 ops and OpReturnF64).
+//
+// On non-ARM64 hosts CompileProgram will fall back to the interpreter
+// for any Cell-bank fn, so this test is skipped there.
+func TestNBodyJITCompiles(t *testing.T) {
+	for _, steps := range []int64{0, 1, 2, 5, 10, 100} {
+		prog := c3.N_body.Build(steps)
+		cfs := vm3jit.CompileProgram(prog)
+		defer func() {
+			for _, cf := range cfs {
+				if cf != nil {
+					_ = cf.Free()
+				}
+			}
+		}()
+		fn := prog.Funcs[prog.Entry]
+		if fn.JITCode == nil {
+			t.Skipf("steps=%d: n_body entry has no JITCode (CompileProgram fell back; expected on non-ARM64)", steps)
+		}
+		vm := vm3.NewWithProgram(prog)
+		got, err := vm.RunWithArgs(fn, []int64{steps})
+		if err != nil {
+			t.Fatalf("steps=%d: RunWithArgs: %v", steps, err)
+		}
+		want := c3.ExpectN_body(steps)
+		if d := math.Abs(got.Float() - want); d > 1e-10 {
+			t.Fatalf("steps=%d: got %v, want %v (delta %v)", steps, got.Float(), want, d)
+		}
+	}
+}

--- a/runtime/vm3/frame.go
+++ b/runtime/vm3/frame.go
@@ -75,11 +75,24 @@ type Function struct {
 	// pre-allocates the list on the Go side before entering the
 	// trampoline so the JIT can drop the inline allocation. Used to
 	// admit `lists_fill_sum` main without growing the JIT into the
-	// arena slab fast path (Phase 6.2d.2.b step 2).
-	JITCode         unsafe.Pointer
-	JITCompiled     bool
-	JITHasF64       bool
-	JITPreAllocList bool
+	// arena slab fast path (Phase 6.2d.2.b step 2). This flag is the
+	// warm-scratch shape (single OpNewList at pc=0 reused across calls
+	// via vm.EnsureScratchList); multi-list kernels use
+	// JITPreAllocListPrefix instead.
+	//
+	// JITPreAllocListPrefix (Phase 6.3.4.j.3) generalizes the skip to a
+	// contiguous prefix of K OpNewList ops at pc 0..K-1, each writing a
+	// distinct cell reg, none of them overwritten by a later op. jitCall
+	// allocates K fresh lists and seeds the cell regs before the
+	// trampoline; the JIT lowerer emits zero words for those PCs.
+	// K=1 retains the existing single-list shape (with JITPreAllocList
+	// true gating the warm-scratch path). K>1 uses fresh allocation per
+	// call; the warm-scratch optimization is left to a follow-up.
+	JITCode               unsafe.Pointer
+	JITCompiled           bool
+	JITHasF64             bool
+	JITPreAllocList       bool
+	JITPreAllocListPrefix uint16
 }
 
 // Bank identifies one of the three typed register banks.

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -1966,6 +1966,37 @@ Per-op allocations stay flat at 28 (the seven `OpNewList` calls and the per-Run 
 
 **Exit gate.** Phase 6.3.4.j.2 is the interp+correctness landing. Closing n_body under 2x of Go is gated on Phase 6.3.4.j.3 (JIT lowering of `OpListGetF64` / `OpListSetF64`).
 
+#### Phase 6.3.4.j.3: n_body JIT admission (ARM64) (2026-05-19 19:14 GMT+7)
+
+**Shape.** Three concurrent admission changes let the JIT accept the n_body cell-bank kernel without scope-mixing into the j.4 perf-closure work:
+
+1. **Cell-reg cap bump to 8 with split lane (ARM64).** `maxCellRegs` rises from 4 to 8. Cells 0..3 keep the x25..x28 lane introduced in Phase 6.2d.2.b; cells 4..7 land at x21..x24 (`r2cell` in `runtime/jit/vm3jit/lower_arm64.go`). The x21..x24 pair is mutually exclusive with the existing i64-callee-saved lane (i64 regs 7..10) and with the cells.{cap,ptr,len} hoist (which only fires at `NumRegsCell == 1`). `archCaps` enforces the constraint: when `NumRegsCell > 4`, `i64Cap` is forced to 7. n_body's register layout (`NumRegsI64=7`, `NumRegsCell=7`) sits exactly on that boundary by reusing i64 reg 6 across the push-zero phase (pc 7..16) and the energy-phase `bj` (pc 137..159), whose lifetimes do not overlap.
+2. **`JITPreAllocListPrefix` (K>=1 fresh-alloc).** The existing single-list warm-scratch path (`JITPreAllocList`, K=1, slot reused via `vm.EnsureScratchList`) is left untouched for `lists_fill_sum` / `maps_fill_sum`. A new field `Function.JITPreAllocListPrefix` records the length of a leading contiguous `OpNewList` prefix where each op writes a distinct cell reg in [0, MaxCellRegs) and no later op clobbers any seeded slot. `init.go::preAllocListPrefix` walks `fn.Code[0..]` to compute K; `checkCellBankAdmissible` admits the K-prefix in the JIT body; `lower_arm64.go` emits zero words for `idx < K`; `jitCall`'s general path calls `arenas.AllocList(0, capHint)` K times after `SnapshotForJITEntry`, so the per-call mark-and-restore reclaims them on a clean return. n_body's seven leading `OpNewList` ops (pc 0..6, cells 0..6) admit cleanly under this rule.
+3. **`OpListGetF64` / `OpListSetF64` ARM64 lowering (cold form).** `CFloat` already stores the IEEE-754 bits directly (no NaN-box tag), so the lowered sequence is one shorter than the i64 form. Get: `UXTW; MOVZ stride; MUL; ADD x19; LDR cells.ptr; LDR Dt`. Set: same, ending in `STR Dt`. Two new helpers (`ldrDRegLsl3`, `strDRegLsl3`) encode the SIMD&FP `LDR/STR Dt, [Xn, Xm, LSL #3]` variant (`V=1` over the i64 form). No per-cell-reg `cells.ptr` hoist in this sub-phase, so every access pays the full 6-instruction sequence; that is the bulk of the perf gap below.
+
+**Correctness gate.** `TestNBodyJITCompiles` (`runtime/jit/vm3jit/nbody_jit_test.go`) drives `corpus.N_body.Build(steps)` through `CompileAndCache` + `vm.RunWithArgs` for `steps in {0, 1, 2, 5, 10, 100}` and asserts the f64 result is within `1e-10` of `ExpectN_body`. Pass: the JIT'd kernel returns bit-identical energy across all step counts, confirming the cell-4..7 lane, K-prefix pre-alloc, and f64 list lowering are correct end-to-end.
+
+**Measured (darwin/arm64, M4, `go test -bench`).** Three runs each, best of three; pure JIT path (`vm.RunWithArgs` -> `JITCallFn` -> trampoline) vs the matching `ExpectN_body` Go reference.
+
+| Size | vm3 JIT | vm3 interp (re-bench) | Go reference | JIT/Go | JIT/interp |
+| --- | --- | --- | --- | --- | --- |
+| `n_body_n100` | 350.5 us/op | 348.0 us/op | 5.66 us/op | 61.9x | 1.01x |
+| `n_body_n10000` | 28.37 ms/op | 31.89 ms/op | 0.591 ms/op | 48.0x | 0.89x |
+
+The JIT matches interp at N=100 and is 11% faster at N=10000. Both are admission-only numbers; the perf-closure work below is what brings the ratio inside 2x.
+
+**Why the gap is still 50-60x.** The lowering is the cold cell-bank form. Each `OpListGetF64` / `OpListSetF64` reloads `cells.ptr` from the slab header on every access (`UXTW; MOVZ; MUL; ADD; LDR cells.ptr; LDR/STR Dt`), and n_body's hot pair-loop does ~25 such accesses per `(i, j)` body pair across 7 cell regs. The interpreter pays a comparable per-access cost, which is why the JIT matches interp but does not yet beat it. The remaining work is mechanical loop-invariant motion plus FMA fusion of the `acc -= dim * mag` pattern that already exists in the kernel:
+
+- **`cells.ptr` hoist per pinned cell reg (Phase 6.3.4.j.4 a).** Pin `pos_x.cells.ptr`, `pos_y.cells.ptr`, ..., `mass.cells.ptr` into seven dedicated callee-saved x-regs (or reuse the x21..x28 lane that already pins the handles, swapping a single MOV for the entire prologue handle-to-ptr resolution). Each get/set then collapses from 6 instructions to 2 (`LDR Dt, [Xptr, xIdx, LSL #3]` / `STR Dt, ...`). Expected speedup: 3-5x on the inner pair loop. The slab fast path already does this for `NumRegsCell == 1` (`runtime/jit/vm3jit/lower_arm64.go::cellsSlabHoist`); generalizing it to the K-prefix lane is a straight extension once the prologue has spare callee-saved x-regs (cap is currently saturated by i64-7 + cells-4..7).
+- **`OpFmaF64` fusion in the gravity loop (Phase 6.3.4.j.4 b).** Six `acc -= dim * mj_mag` / `acc += dim * mi_mag` pairs at pc 71..94 each split across `OpListGet + OpMul + OpSub + OpListSet`. Folding the `OpSub`/`OpAdd` into a fused `vm3.OpFmaF64` plus a sign flip on the multiplier matches Phase 6.3.4.h.1's mandelbrot closure: AArch64 emits `FMSUB`/`FMADD` directly. Expected speedup: ~1.5x on the dependent f64 chain.
+- **AMD64 lowering (Phase 6.3.4.j.5).** `lower_amd64.go` does not yet have a cell-bank backend, so n_body is darwin/arm64 only. AMD64 lowering follows the j.4 perf closure so the cold form is not duplicated and discarded.
+
+**Generic, no super-op.** The three admission changes are all generic VM/JIT widenings: more cell regs, K-list pre-alloc, f64-typed list access. They benefit any future cell-bank kernel that opens >4 lists, leads with a list-prefix, or threads f64 through Cell-backed arrays (spectral_norm's `Au`/`Atu` vectors, any Mochi user code that does `let v: [float] = ...`). Nothing in the lowering is n_body-specific.
+
+**Tests + bench wiring.** `BenchmarkCorpusJITRunner` in `runtime/jit/vm3jit/bench_corpus_jit_test.go` gains `n_body_n100` and `n_body_n10000` cases; they exercise the `fn.NumRegsCell != 0` arm (cell-bank dispatch via `vm.RunWithArgs`). Full test suite (`./runtime/jit/vm3jit/...`, `./runtime/vm3/...`, `./compiler3/...`) remains green.
+
+**Status.** Admission gate met. Perf closure to under 2x of Go deferred to Phase 6.3.4.j.4 (cells.ptr hoist + FMA fusion) and Phase 6.3.4.j.5 (AMD64). The j.2 interp baseline (177.6 us / 17.61 ms) does not reproduce on this machine when re-measured under the same harness; the j.3 re-bench in the table above is the load-bearing number for the gap-descent plan.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
Tracks #21776.

Stacked on #21773 (j.1, base = main) -> #21775 (j.2, merged into j.1).

## Summary

- Cell-reg cap 4 -> 8 on ARM64 with a split lane (cells 0..3 at `x25..x28`, cells 4..7 at `x21..x24`); admissibility forces `i64Cap = 7` when `NumRegsCell > 4` so the i64-callee-saved lane never clashes.
- New `Function.JITPreAllocListPrefix` records a leading contiguous `OpNewList` prefix where each op writes a distinct cell reg in `[0, MaxCellRegs)` and no later op clobbers any seeded slot. `jitCall` pre-allocates K lists against the per-call snapshot mark; the JIT lowerer emits zero words for those PCs. K=1 warm-scratch (`lists_fill_sum`, `maps_fill_sum`) is left untouched.
- ARM64 cold-form lowering of `OpListGetF64` / `OpListSetF64` (6 instructions each; `CFloat` carries raw IEEE 754 bits so no SBFX is needed). Two new helpers (`ldrDRegLsl3`, `strDRegLsl3`) encode the SIMD&FP `LDR/STR Dt, [Xn, Xm, LSL #3]` variant.
- `corpus/n_body.go` trims `NumRegsI64` 9 -> 7 by reusing reg 6 across push-zero (pc 7..16) and energy-phase `bj` (pc 137..159) whose lifetimes do not overlap. Keeps the kernel within the cap constraint above.

## Correctness

`TestNBodyJITCompiles` drives the JIT'd kernel through steps in {0,1,2,5,10,100} and asserts results within 1e-10 of `ExpectN_body`. Full suite (`./runtime/jit/vm3jit/...`, `./runtime/vm3/...`, `./compiler3/...`) green.

## Measured (darwin/arm64 M4, best of 3)

| Size | JIT | Go | Ratio |
| --- | --- | --- | --- |
| `n_body_n100` | 350.5 us | 5.66 us | 61.9x |
| `n_body_n10000` | 28.37 ms | 0.591 ms | 48.0x |

JIT matches interp at N=100 and is 11% faster at N=10000. Admission only; perf closure to under 2x of Go is deferred to Phase 6.3.4.j.4 (per-cell `cells.ptr` hoist + `OpFmaF64` fusion of the gravity loop). AMD64 cell-bank backend follows in j.5.

## Test plan

- [x] `go test ./runtime/jit/vm3jit/... ./runtime/vm3/... ./compiler3/...`
- [x] `go test ./runtime/jit/vm3jit -run TestNBodyJITCompiles -count=1`
- [x] `go test ./runtime/jit/vm3jit -run='^\$' -bench='BenchmarkCorpusJITRunner/n_body' -benchtime=1s -count=3`
- [x] `go test ./compiler3/corpus -run='^\$' -bench='BenchmarkN_bodyGo' -benchtime=1s -count=3`