### PR TITLE
mep-0040: fix MDX parse errors in BG data files

### DIFF
--- a/website/docs/mep/mep-0040-data/bg-nsieve-vm3-2026-05-19.md
+++ b/website/docs/mep/mep-0040-data/bg-nsieve-vm3-2026-05-19.md
@@ -15,7 +15,7 @@ The vm3 port collapses the 4-function tail-recursive vm2 shape (`main`, `fill`, 
 2. **Interpreter dispatch.** Every `OpListSetI64` is ~5-10 host instructions; Go compiles it to a single store. The inner mark loop touches `xs[j]` once and increments `j` by `i`, so 2 list ops + 2 arith ops per iter, vs ~3 instructions in Go.
 3. **No JIT yet.** Nsieve's inner loop uses `OpListSetI64` which is not on the Cell-bank admission whitelist (`runtime/jit/vm3jit/compile.go:217-256`). Adding `OpListSetI64` lowering + admission is the next concrete lever; rough est: 5-10x speedup once it lowers, putting nsieve in the 6-15x of Go range.
 
-Closing the residual 6-15x to <2x then requires either:
+Closing the residual 6-15x to under 2x then requires either:
 - A typed-bytes list bank (i8 / bytes, eliminates the 8x density tax), or
 - Loop hoisting of the slab base + bounds metadata (already done for `OpListGetI64`/`OpListPushI64` in the `lists_fill_sum` warm cache; same hoist applies here once `OpListSetI64` is admitted).
 

--- a/website/docs/mep/mep-0040-data/bg-switch-lookup-vm3jit-2026-05-19.md
+++ b/website/docs/mep/mep-0040-data/bg-switch-lookup-vm3jit-2026-05-19.md
@@ -27,10 +27,10 @@ Table-vs-chain ratio in JIT:
 
 The N=10000 median is the cleaner read since per-iteration cost
 dominates loop overhead. Speedup is **~19% median** at N=10000, below the
-spec's <0.50 promise (mirroring Go CL 756340's -63%). The gap to the
+spec's under 0.50 promise (mirroring Go CL 756340's -63%). The gap to the
 spec target is explained below.
 
-### Why the ratio is 0.81 instead of <0.50 on Apple M4
+### Why the ratio is 0.81 instead of under 0.50 on Apple M4
 
 The cmp-chain dispatch is 8 sequential `CMP+B.COND` instructions per
 key. The 32749-period LCG cycles through ~30% of its period over 10k
@@ -58,7 +58,7 @@ absorbs most of the dispatch fanout; the table form still wins, just
 less dramatically.
 
 A linux/amd64 re-bench on server2 is expected to land closer to the
-spec target (<0.50) once the same hoisted lowering is ported to
+spec target (under 0.50) once the same hoisted lowering is ported to
 lower_amd64.go (currently the AMD64 path falls back to interp for
 OpLookupI64KW, mirroring OpFmaF64's AMD64 deferral).
 


### PR DESCRIPTION
## Summary

- Replace bare `<2x` and `<0.50` with `under 2x` / `under 0.50` in two BG data files under `website/docs/mep/mep-0040-data/`. MDX interprets `<` followed by a digit as the start of a JSX tag, which breaks the website deploy.
- Same class of fix as 361ec49d30 (mep-0033).
- Unblocks website-deploy CI for PRs #21779 (Phase 6.3.4.j.4a) and #21781 (Phase 6.3.4.j.4b).

Closes #21782.

## Test plan

- [x] grep for remaining bare `<[0-9]` / `<2x` / `<0\.` patterns in mep-0040-data: none
- [ ] CI green