### PR TITLE
mep-0040 phase 6.3.4.f.2: JIT-admit k_nucleotide + map kernel fix

### DIFF
--- a/compiler3/corpus/k_nucleotide.go
+++ b/compiler3/corpus/k_nucleotide.go
@@ -29,87 +29,93 @@ import "mochi/runtime/vm3"
 // thresholds in fastaThr{A,C,G} were chosen to make the integer cascade
 // equivalent to the float-prob cascade for every seed in [0, 139968).
 //
-// Bank: i64 + Cell. NumRegsI64 = 14:
+// Bank: i64 + Cell. NumRegsI64 = 11 (fits the cell-bank ARM64 cap so the
+// JIT admits the entire function). Slot reuse: r0/r1/r2 carry n/seed/i
+// in the inner loop, then h/HASH_MOD/k in the summ loop after the inner
+// loop ends. The map kernel clobbers x13/x14/x15 (= r4/r5/r6 in the
+// cell-bank layout), so the constants in r4..r6 are spilled+restored by
+// the kernel; map keys/values are kept out of r4..r6 so xKey/xVal are
+// never read post-clobber:
 //
-//	r0=n      r4=MOD_LCG  r6=thrA  r9=code   r11=v   r13=k
-//	r1=seed   r5=HASH_MOD r7=thrC  r10=key2  r12=h
-//	r2=i                  r8=thrG
+//	r0=n→h    r4=MOD_LCG  r7=thrG    r10=v
+//	r1=seed→HASH_MOD r5=thrA  r8=code
+//	r2=i→k    r6=thrC   r9=key2
 //	r3=prev
 //
 // NumRegsCell = 1 (regsCell[0] = m).
 //
 // Bytecode (60 ops):
 //
-//	 0  ConstI64KW  4, 0, 0       ; MOD_LCG  = 139968
-//	 1  ConstI64KW  5, 0, 1       ; HASH_MOD = 2147483647
-//	 2  ConstI64KW  6, 0, 2       ; thrA
-//	 3  ConstI64KW  7, 0, 3       ; thrC
-//	 4  ConstI64KW  8, 0, 4       ; thrG
-//	 5  NewMap      0, 0, 20      ; m = AllocMap(capHint=20)
-//	 6  ConstI64K   1, 0, 42      ; seed = 42
-//	 7  MulI64K     1, 1, 3877
-//	 8  AddI64K     1, 1, 29573
-//	 9  ModI64      1, 1, 4       ; seed %= MOD_LCG
-//	10  CmpLtI64Br  1, 6, 15      ; if seed < thrA -> BOOT_A
-//	11  CmpLtI64Br  1, 7, 17      ; if seed < thrC -> BOOT_C
-//	12  CmpLtI64Br  1, 8, 19      ; if seed < thrG -> BOOT_G
-//	13  ConstI64K   3, 0, 3       ; prev = 3 (t fall-through)
-//	14  Jump              20
-//	15  ConstI64K   3, 0, 0       ; BOOT_A: prev = 0 (a)
-//	16  Jump              20
-//	17  ConstI64K   3, 0, 1       ; BOOT_C: prev = 1 (c)
-//	18  Jump              20
-//	19  ConstI64K   3, 0, 2       ; BOOT_G: prev = 2 (g); fall through
-//	20  MapGetI64I64 11, 0, 3     ; v = m[prev]
-//	21  AddI64K     11, 11, 1
-//	22  MapSetI64I64 0, 3, 11     ; m[prev] = v
-//	23  ConstI64K   2, 0, 1       ; i = 1
-//	    loop_top (PC=24):
-//	24  CmpGeI64Br  2, 0, 50      ; if i >= n -> loop_end
-//	25  MulI64K     1, 1, 3877
-//	26  AddI64K     1, 1, 29573
-//	27  ModI64      1, 1, 4
-//	28  CmpLtI64Br  1, 6, 33      ; ITER_A
-//	29  CmpLtI64Br  1, 7, 35      ; ITER_C
-//	30  CmpLtI64Br  1, 8, 37      ; ITER_G
-//	31  ConstI64K   9, 0, 3       ; code = 3 (t)
-//	32  Jump              38
-//	33  ConstI64K   9, 0, 0       ; ITER_A
-//	34  Jump              38
-//	35  ConstI64K   9, 0, 1       ; ITER_C
-//	36  Jump              38
-//	37  ConstI64K   9, 0, 2       ; ITER_G; fall through
-//	38  MapGetI64I64 11, 0, 9     ; v = m[code]
-//	39  AddI64K     11, 11, 1
-//	40  MapSetI64I64 0, 9, 11     ; m[code] = v
-//	41  MulI64K     10, 3, 4      ; key2 = prev*4
-//	42  AddI64      10, 10, 9     ; key2 += code
-//	43  AddI64K     10, 10, 4     ; key2 += 4
-//	44  MapGetI64I64 11, 0, 10    ; v = m[key2]
-//	45  AddI64K     11, 11, 1
-//	46  MapSetI64I64 0, 10, 11
-//	47  MovI64      3, 9, 0       ; prev = code
-//	48  AddI64K     2, 2, 1       ; i++
-//	49  Jump              24
-//	    loop_end (PC=50):
-//	50  ConstI64K   12, 0, 0      ; h = 0
-//	51  ConstI64K   13, 0, 0      ; k = 0
+//	 0  NewMap      0, 0, 20      ; m = AllocMap(capHint=20) (pc=0 so JIT can pre-alloc)
+//	 1  ConstI64KW  4, 0, 0       ; MOD_LCG  = 139968
+//	 2  ConstI64KW  5, 0, 2       ; thrA
+//	 3  ConstI64KW  6, 0, 3       ; thrC
+//	 4  ConstI64KW  7, 0, 4       ; thrG
+//	 5  ConstI64K   1, 0, 42      ; seed = 42
+//	 6  MulI64K     1, 1, 3877
+//	 7  AddI64K     1, 1, 29573
+//	 8  ModI64      1, 1, 4       ; seed %= MOD_LCG
+//	 9  CmpLtI64Br  1, 5, 14      ; if seed < thrA -> BOOT_A
+//	10  CmpLtI64Br  1, 6, 16      ; if seed < thrC -> BOOT_C
+//	11  CmpLtI64Br  1, 7, 18      ; if seed < thrG -> BOOT_G
+//	12  ConstI64K   3, 0, 3       ; prev = 3 (t fall-through)
+//	13  Jump              19
+//	14  ConstI64K   3, 0, 0       ; BOOT_A: prev = 0 (a)
+//	15  Jump              19
+//	16  ConstI64K   3, 0, 1       ; BOOT_C: prev = 1 (c)
+//	17  Jump              19
+//	18  ConstI64K   3, 0, 2       ; BOOT_G: prev = 2 (g); fall through
+//	19  MapGetI64I64 10, 0, 3     ; v = m[prev]
+//	20  AddI64K     10, 10, 1
+//	21  MapSetI64I64 0, 3, 10     ; m[prev] = v
+//	22  ConstI64K   2, 0, 1       ; i = 1
+//	    loop_top (PC=23):
+//	23  CmpGeI64Br  2, 0, 49      ; if i >= n -> loop_end
+//	24  MulI64K     1, 1, 3877
+//	25  AddI64K     1, 1, 29573
+//	26  ModI64      1, 1, 4
+//	27  CmpLtI64Br  1, 5, 32      ; ITER_A
+//	28  CmpLtI64Br  1, 6, 34      ; ITER_C
+//	29  CmpLtI64Br  1, 7, 36      ; ITER_G
+//	30  ConstI64K   8, 0, 3       ; code = 3 (t)
+//	31  Jump              37
+//	32  ConstI64K   8, 0, 0       ; ITER_A
+//	33  Jump              37
+//	34  ConstI64K   8, 0, 1       ; ITER_C
+//	35  Jump              37
+//	36  ConstI64K   8, 0, 2       ; ITER_G; fall through
+//	37  MapGetI64I64 10, 0, 8     ; v = m[code]
+//	38  AddI64K     10, 10, 1
+//	39  MapSetI64I64 0, 8, 10     ; m[code] = v
+//	40  MulI64K     9, 3, 4       ; key2 = prev*4
+//	41  AddI64      9, 9, 8       ; key2 += code
+//	42  AddI64K     9, 9, 4       ; key2 += 4
+//	43  MapGetI64I64 10, 0, 9     ; v = m[key2]
+//	44  AddI64K     10, 10, 1
+//	45  MapSetI64I64 0, 9, 10
+//	46  MovI64      3, 8, 0       ; prev = code
+//	47  AddI64K     2, 2, 1       ; i++
+//	48  Jump              23
+//	    loop_end (PC=49):
+//	49  ConstI64K   0, 0, 0       ; h = 0 (reuse r0; n is dead post-loop)
+//	50  ConstI64KW  1, 0, 1       ; HASH_MOD = 2147483647 (reuse r1)
+//	51  ConstI64K   2, 0, 0       ; k = 0 (reuse r2)
 //	    summ_top (PC=52):
-//	52  CmpGeI64KBr 13, 20, 59    ; if k >= 20 -> summ_end
-//	53  MapGetI64I64 11, 0, 13    ; v = m[k]
-//	54  MulI64K     12, 12, 1009  ; h *= 1009
-//	55  AddI64      12, 12, 11    ; h += v
-//	56  ModI64      12, 12, 5     ; h %= HASH_MOD
-//	57  AddI64K     13, 13, 1     ; k++
+//	52  CmpGeI64KBr 2, 20, 59     ; if k >= 20 -> summ_end
+//	53  MapGetI64I64 10, 0, 2     ; v = m[k]
+//	54  MulI64K     0, 0, 1009    ; h *= 1009
+//	55  AddI64      0, 0, 10      ; h += v
+//	56  ModI64      0, 0, 1       ; h %= HASH_MOD
+//	57  AddI64K     2, 2, 1       ; k++
 //	58  Jump              52
 //	    summ_end (PC=59):
-//	59  ReturnI64   12, 0, 0
+//	59  ReturnI64   0, 0, 0
 var KNucleotide = &Program{
 	Name: "k_nucleotide",
 	Build: func(_ int64) *vm3.Program {
 		fn := &vm3.Function{
 			Name:        "k_nucleotide",
-			NumRegsI64:  14,
+			NumRegsI64:  11,
 			NumRegsCell: 1,
 			ParamBanks:  []vm3.Bank{vm3.BankI64},
 			ResultBank:  vm3.BankI64,
@@ -121,66 +127,66 @@ var KNucleotide = &Program{
 				vm3.CInt(fastaThrG),
 			},
 			Code: []vm3.Op{
-				vm3.MakeOp(vm3.OpConstI64KW, 4, 0, 0),
-				vm3.MakeOp(vm3.OpConstI64KW, 5, 0, 1),
-				vm3.MakeOp(vm3.OpConstI64KW, 6, 0, 2),
-				vm3.MakeOp(vm3.OpConstI64KW, 7, 0, 3),
-				vm3.MakeOp(vm3.OpConstI64KW, 8, 0, 4),
 				vm3.MakeOp(vm3.OpNewMap, 0, 0, 20),
+				vm3.MakeOp(vm3.OpConstI64KW, 4, 0, 0),
+				vm3.MakeOp(vm3.OpConstI64KW, 5, 0, 2),
+				vm3.MakeOp(vm3.OpConstI64KW, 6, 0, 3),
+				vm3.MakeOp(vm3.OpConstI64KW, 7, 0, 4),
 				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 42),
 				vm3.MakeOp(vm3.OpMulI64K, 1, 1, 3877),
 				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 29573),
 				vm3.MakeOp(vm3.OpModI64, 1, 1, 4),
-				vm3.MakeOp(vm3.OpCmpLtI64Br, 1, 6, 15),
-				vm3.MakeOp(vm3.OpCmpLtI64Br, 1, 7, 17),
-				vm3.MakeOp(vm3.OpCmpLtI64Br, 1, 8, 19),
+				vm3.MakeOp(vm3.OpCmpLtI64Br, 1, 5, 14),
+				vm3.MakeOp(vm3.OpCmpLtI64Br, 1, 6, 16),
+				vm3.MakeOp(vm3.OpCmpLtI64Br, 1, 7, 18),
 				vm3.MakeOp(vm3.OpConstI64K, 3, 0, 3),
-				vm3.MakeOp(vm3.OpJump, 0, 0, 20),
+				vm3.MakeOp(vm3.OpJump, 0, 0, 19),
 				vm3.MakeOp(vm3.OpConstI64K, 3, 0, 0),
-				vm3.MakeOp(vm3.OpJump, 0, 0, 20),
+				vm3.MakeOp(vm3.OpJump, 0, 0, 19),
 				vm3.MakeOp(vm3.OpConstI64K, 3, 0, 1),
-				vm3.MakeOp(vm3.OpJump, 0, 0, 20),
+				vm3.MakeOp(vm3.OpJump, 0, 0, 19),
 				vm3.MakeOp(vm3.OpConstI64K, 3, 0, 2),
-				vm3.MakeOp(vm3.OpMapGetI64I64, 11, 0, 3),
-				vm3.MakeOp(vm3.OpAddI64K, 11, 11, 1),
-				vm3.MakeOp(vm3.OpMapSetI64I64, 0, 3, 11),
+				vm3.MakeOp(vm3.OpMapGetI64I64, 10, 0, 3),
+				vm3.MakeOp(vm3.OpAddI64K, 10, 10, 1),
+				vm3.MakeOp(vm3.OpMapSetI64I64, 0, 3, 10),
 				vm3.MakeOp(vm3.OpConstI64K, 2, 0, 1),
-				vm3.MakeOp(vm3.OpCmpGeI64Br, 2, 0, 50),
+				vm3.MakeOp(vm3.OpCmpGeI64Br, 2, 0, 49),
 				vm3.MakeOp(vm3.OpMulI64K, 1, 1, 3877),
 				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 29573),
 				vm3.MakeOp(vm3.OpModI64, 1, 1, 4),
-				vm3.MakeOp(vm3.OpCmpLtI64Br, 1, 6, 33),
-				vm3.MakeOp(vm3.OpCmpLtI64Br, 1, 7, 35),
-				vm3.MakeOp(vm3.OpCmpLtI64Br, 1, 8, 37),
-				vm3.MakeOp(vm3.OpConstI64K, 9, 0, 3),
-				vm3.MakeOp(vm3.OpJump, 0, 0, 38),
-				vm3.MakeOp(vm3.OpConstI64K, 9, 0, 0),
-				vm3.MakeOp(vm3.OpJump, 0, 0, 38),
-				vm3.MakeOp(vm3.OpConstI64K, 9, 0, 1),
-				vm3.MakeOp(vm3.OpJump, 0, 0, 38),
-				vm3.MakeOp(vm3.OpConstI64K, 9, 0, 2),
-				vm3.MakeOp(vm3.OpMapGetI64I64, 11, 0, 9),
-				vm3.MakeOp(vm3.OpAddI64K, 11, 11, 1),
-				vm3.MakeOp(vm3.OpMapSetI64I64, 0, 9, 11),
-				vm3.MakeOp(vm3.OpMulI64K, 10, 3, 4),
-				vm3.MakeOp(vm3.OpAddI64, 10, 10, 9),
-				vm3.MakeOp(vm3.OpAddI64K, 10, 10, 4),
-				vm3.MakeOp(vm3.OpMapGetI64I64, 11, 0, 10),
-				vm3.MakeOp(vm3.OpAddI64K, 11, 11, 1),
-				vm3.MakeOp(vm3.OpMapSetI64I64, 0, 10, 11),
-				vm3.MakeOp(vm3.OpMovI64, 3, 9, 0),
+				vm3.MakeOp(vm3.OpCmpLtI64Br, 1, 5, 32),
+				vm3.MakeOp(vm3.OpCmpLtI64Br, 1, 6, 34),
+				vm3.MakeOp(vm3.OpCmpLtI64Br, 1, 7, 36),
+				vm3.MakeOp(vm3.OpConstI64K, 8, 0, 3),
+				vm3.MakeOp(vm3.OpJump, 0, 0, 37),
+				vm3.MakeOp(vm3.OpConstI64K, 8, 0, 0),
+				vm3.MakeOp(vm3.OpJump, 0, 0, 37),
+				vm3.MakeOp(vm3.OpConstI64K, 8, 0, 1),
+				vm3.MakeOp(vm3.OpJump, 0, 0, 37),
+				vm3.MakeOp(vm3.OpConstI64K, 8, 0, 2),
+				vm3.MakeOp(vm3.OpMapGetI64I64, 10, 0, 8),
+				vm3.MakeOp(vm3.OpAddI64K, 10, 10, 1),
+				vm3.MakeOp(vm3.OpMapSetI64I64, 0, 8, 10),
+				vm3.MakeOp(vm3.OpMulI64K, 9, 3, 4),
+				vm3.MakeOp(vm3.OpAddI64, 9, 9, 8),
+				vm3.MakeOp(vm3.OpAddI64K, 9, 9, 4),
+				vm3.MakeOp(vm3.OpMapGetI64I64, 10, 0, 9),
+				vm3.MakeOp(vm3.OpAddI64K, 10, 10, 1),
+				vm3.MakeOp(vm3.OpMapSetI64I64, 0, 9, 10),
+				vm3.MakeOp(vm3.OpMovI64, 3, 8, 0),
 				vm3.MakeOp(vm3.OpAddI64K, 2, 2, 1),
-				vm3.MakeOp(vm3.OpJump, 0, 0, 24),
-				vm3.MakeOp(vm3.OpConstI64K, 12, 0, 0),
-				vm3.MakeOp(vm3.OpConstI64K, 13, 0, 0),
-				vm3.MakeOp(vm3.OpCmpGeI64KBr, 13, 20, 59),
-				vm3.MakeOp(vm3.OpMapGetI64I64, 11, 0, 13),
-				vm3.MakeOp(vm3.OpMulI64K, 12, 12, 1009),
-				vm3.MakeOp(vm3.OpAddI64, 12, 12, 11),
-				vm3.MakeOp(vm3.OpModI64, 12, 12, 5),
-				vm3.MakeOp(vm3.OpAddI64K, 13, 13, 1),
+				vm3.MakeOp(vm3.OpJump, 0, 0, 23),
+				vm3.MakeOp(vm3.OpConstI64K, 0, 0, 0),
+				vm3.MakeOp(vm3.OpConstI64KW, 1, 0, 1),
+				vm3.MakeOp(vm3.OpConstI64K, 2, 0, 0),
+				vm3.MakeOp(vm3.OpCmpGeI64KBr, 2, 20, 59),
+				vm3.MakeOp(vm3.OpMapGetI64I64, 10, 0, 2),
+				vm3.MakeOp(vm3.OpMulI64K, 0, 0, 1009),
+				vm3.MakeOp(vm3.OpAddI64, 0, 0, 10),
+				vm3.MakeOp(vm3.OpModI64, 0, 0, 1),
+				vm3.MakeOp(vm3.OpAddI64K, 2, 2, 1),
 				vm3.MakeOp(vm3.OpJump, 0, 0, 52),
-				vm3.MakeOp(vm3.OpReturnI64, 12, 0, 0),
+				vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),
 			},
 		}
 		return &vm3.Program{Funcs: []*vm3.Function{fn}, Entry: 0}

--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -217,9 +217,11 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 	}
 	for i, op := range fn.Code {
 		switch op.Code {
-		case vm3.OpConstI64K, vm3.OpMovI64,
+		case vm3.OpConstI64K, vm3.OpConstI64KW, vm3.OpMovI64,
 			vm3.OpAddI64, vm3.OpSubI64, vm3.OpMulI64,
+			vm3.OpDivI64, vm3.OpModI64,
 			vm3.OpAddI64K, vm3.OpSubI64K, vm3.OpMulI64K,
+			vm3.OpDivI64K, vm3.OpModI64K,
 			vm3.OpCmpEqI64Br, vm3.OpCmpNeI64Br,
 			vm3.OpCmpLtI64Br, vm3.OpCmpLeI64Br,
 			vm3.OpCmpGtI64Br, vm3.OpCmpGeI64Br,
@@ -256,6 +258,16 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 				continue
 			}
 			return fmt.Errorf("%w: %s pc %d Cell-bank fn uses inline OpNewList (only pre-alloc prefix is admitted)",
+				ErrNotImplemented, fn.Name, i)
+		case vm3.OpNewMap:
+			// Phase 6.3.4.f.2: admit at pc=0 when the OpNewMap can be
+			// lifted into jitCall (canPreAllocMap). The lowerer emits
+			// zero words; the prologue picks up the pre-seeded handle
+			// from jf.regsCell[A].
+			if i == 0 && canPreAllocMap(fn) {
+				continue
+			}
+			return fmt.Errorf("%w: %s pc %d Cell-bank fn uses inline OpNewMap (only pre-alloc at pc=0 is admitted)",
 				ErrNotImplemented, fn.Name, i)
 		case vm3.OpTailCallMixed:
 			if opts.SelfIdx < 0 || int(uint16(op.C)) != opts.SelfIdx || op.B != 0 {

--- a/runtime/jit/vm3jit/init.go
+++ b/runtime/jit/vm3jit/init.go
@@ -200,6 +200,16 @@ func jitCall(vm *vm3.VM, fn *vm3.Function, argsI64 []int64, argsF64 []float64, a
 			jf.regsCell[op.A] = arenas.AllocList(0, int(op.C))
 		}
 	}
+	// Phase 6.3.4.f.2: OpNewMap pre-alloc. fn.JITPreAllocMap is set when
+	// fn.Code[0] is an OpNewMap that the lowerer skipped; allocate the
+	// map here against the just-snapshotted arena marks and seed the cell
+	// reg the JIT prologue will load.
+	if fn.JITPreAllocMap {
+		op := fn.Code[0]
+		if int(op.A) < MaxCellRegs {
+			jf.regsCell[op.A] = vm.Arenas().AllocMap(int(op.C))
+		}
+	}
 	// Lay out params per ParamBanks position-indexed convention: argsX[k]
 	// is meaningful iff fn.ParamBanks[k] == BankX. For i64-only callees
 	// argsCell/argsF64 are nil and we use the fast path: copy argsI64
@@ -315,10 +325,12 @@ func CompileAndCache(prog *vm3.Program, idx uint32) (*CompiledFunc, error) {
 	// nil (i.e. when admission did succeed).
 	fn.JITPreAllocList = canPreAllocList(fn)
 	fn.JITPreAllocListPrefix = preAllocListPrefix(fn)
+	fn.JITPreAllocMap = canPreAllocMap(fn)
 	cf, err := CompileInProgram(prog, idx)
 	if err != nil {
 		fn.JITPreAllocList = false
 		fn.JITPreAllocListPrefix = 0
+		fn.JITPreAllocMap = false
 		return nil, err
 	}
 	fn.JITCode = cf.Entry()
@@ -422,6 +434,30 @@ func preAllocListPrefix(fn *vm3.Function) uint16 {
 		}
 	}
 	return uint16(k)
+}
+
+// canPreAllocMap mirrors canPreAllocList for an OpNewMap at fn.Code[0].
+// Phase 6.3.4.f.2: lets cell-bank kernels that allocate a single map at
+// entry then operate on it (k_nucleotide and similar) skip the JIT-side
+// emission of OpNewMap; jitCall calls arenas.AllocMap with the static
+// capHint encoded in op.C and seeds jf.regsCell[A] before the
+// trampoline. Pre-condition for safety: no later op overwrites the
+// same cell via OpNewList or OpNewMap.
+func canPreAllocMap(fn *vm3.Function) bool {
+	if len(fn.Code) == 0 || fn.Code[0].Code != vm3.OpNewMap {
+		return false
+	}
+	dest := fn.Code[0].A
+	if int(dest) >= int(fn.NumRegsCell) || int(dest) >= MaxCellRegs {
+		return false
+	}
+	for i := 1; i < len(fn.Code); i++ {
+		op := fn.Code[i]
+		if (op.Code == vm3.OpNewMap || op.Code == vm3.OpNewList) && op.A == dest {
+			return false
+		}
+	}
+	return true
 }
 
 // CompileProgram is the convenience entry point that walks every

--- a/runtime/jit/vm3jit/lower_arm64.go
+++ b/runtime/jit/vm3jit/lower_arm64.go
@@ -1496,23 +1496,35 @@ func wordCountARM64Body(fn *vm3.Function, op vm3.Op, opts Options, spillSets []u
 		// Only admitted when the map handle lives in the hoisted Cell
 		// reg (regsCell[0]) so the slab byte address is pre-pinned in
 		// x20. The kernel additionally uses x13/x14/x15 as scratch +
-		// loop-invariant pins; gate on NumRegsI64 <= 4 so r2x never
-		// emits those host regs for vm3 i64 regs. See
-		// mapSetI64I64WordsARM64 for the body shape.
-		if h := hoistedCellReg(fn); h < 0 || int(op.A) != h || slabKindARM64(fn) != slabKindMap || fn.NumRegsI64 > 4 {
-			return 0, fmt.Errorf("%w: opcode %d (MapSetI64I64 without map-slab hoist or NumRegsI64>4)", ErrNotImplemented, op.Code)
+		// loop-invariant pins.
+		//
+		// Phase 6.3.4.f.2: when NumRegsI64 > 4 the vm3 regs 4..6 land
+		// in x13/x14/x15, so the kernel emits a 3-word entry-spill /
+		// 3-word exit-restore pair around the body to preserve any
+		// frame-resident values. Reject if the kernel's own operands
+		// (key/val) sit in slots 4..6 — those values would be clobbered
+		// mid-body without anywhere to recover from.
+		if h := hoistedCellReg(fn); h < 0 || int(op.A) != h || slabKindARM64(fn) != slabKindMap {
+			return 0, fmt.Errorf("%w: opcode %d (MapSetI64I64 without map-slab hoist)", ErrNotImplemented, op.Code)
 		}
-		return mapSetI64I64WordsARM64, nil
+		if mapKernelOperandClobber(op) {
+			return 0, fmt.Errorf("%w: opcode %d (MapSetI64I64 key/val in slots 4..6 collides with kernel scratch)", ErrNotImplemented, op.Code)
+		}
+		return mapSetI64I64WordsARM64 + mapScratchSpillWordsARM64(fn), nil
 
 	case vm3.OpMapGetI64I64:
 		// Phase 6.2d.2.d step 4 mirror of OpMapSetI64I64: inline open-
 		// addressed lookup with empty-table early-return. Same hoist
-		// gate as MapSet plus the NumRegsI64 <= 4 ceiling so x13..x15
-		// stay free for the probe loop.
-		if h := hoistedCellReg(fn); h < 0 || int(op.B) != h || slabKindARM64(fn) != slabKindMap || fn.NumRegsI64 > 4 {
-			return 0, fmt.Errorf("%w: opcode %d (MapGetI64I64 without map-slab hoist or NumRegsI64>4)", ErrNotImplemented, op.Code)
+		// gate as MapSet. Phase 6.3.4.f.2 adds the same scratch-spill
+		// frame around the body when NumRegsI64 > 4; op.A (dst) and
+		// op.C (key) must not be in slots 4..6.
+		if h := hoistedCellReg(fn); h < 0 || int(op.B) != h || slabKindARM64(fn) != slabKindMap {
+			return 0, fmt.Errorf("%w: opcode %d (MapGetI64I64 without map-slab hoist)", ErrNotImplemented, op.Code)
 		}
-		return mapGetI64I64WordsARM64, nil
+		if mapKernelOperandClobber(op) {
+			return 0, fmt.Errorf("%w: opcode %d (MapGetI64I64 dst/key in slots 4..6 collides with kernel scratch)", ErrNotImplemented, op.Code)
+		}
+		return mapGetI64I64WordsARM64 + mapScratchSpillWordsARM64(fn), nil
 
 	case vm3.OpTailCallMixed:
 		// Self-tail-call with arg-base 0 lowers to a single backward B
@@ -1548,6 +1560,15 @@ func wordCountARM64Body(fn *vm3.Function, op vm3.Op, opts Options, spillSets []u
 			return 0, nil
 		}
 		return 0, fmt.Errorf("%w: opcode %d (inline NewList unsupported)", ErrNotImplemented, op.Code)
+
+	case vm3.OpNewMap:
+		// Phase 6.3.4.f.2: when fn.JITPreAllocMap is set the JIT skips
+		// fn.Code[0]'s OpNewMap entirely; jitCall pre-allocates the map
+		// and seeds jf.regsCell[A] before the trampoline.
+		if idx == 0 && fn.JITPreAllocMap {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("%w: opcode %d (inline NewMap unsupported)", ErrNotImplemented, op.Code)
 
 	default:
 		return 0, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
@@ -1929,6 +1950,15 @@ func emitInstrARM64Body(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deopt
 		}
 		return nil, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
 
+	case vm3.OpNewMap:
+		if idx == 0 && fn.JITPreAllocMap {
+			// Phase 6.3.4.f.2 skip: jitCall pre-allocated the map and
+			// wrote the handle to regsCell[A]; prologue loaded it into
+			// the pinned reg before this PC. Emit zero words.
+			return []uint32{}, nil
+		}
+		return nil, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
+
 	case vm3.OpListGetI64:
 		// regsI64[A] = arenas.Lists[handleIdx(regsCell[B])].cells[regsI64[C]].Int()
 		//
@@ -2031,7 +2061,21 @@ func emitInstrARM64Body(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deopt
 		opStart := pcMap[idx]
 		endLabel := pcMap[idx+1]
 
-		ws := make([]uint32, 0, mapSetI64I64WordsARM64)
+		// Phase 6.3.4.f.2: when NumRegsI64 > 4 the vm3 regs 4..6 live in
+		// the kernel's scratch host regs (x13/x14/x15). Save them at
+		// kernel entry to the caller window so the kernel body can use
+		// the host regs freely, restore them at exit. spillW = 3 means
+		// the body offsets shift by +3 in the lowered word stream.
+		spillW := mapScratchSpillWordsARM64(fn)
+		restoreStart := opStart + spillW + mapSetI64I64WordsARM64
+
+		ws := make([]uint32, 0, mapSetI64I64WordsARM64+2*spillW)
+		if spillW > 0 {
+			ws = append(ws, str64(13, 0, 4)) // STR x13, [x0, #4*8] (slot for r4)
+			ws = append(ws, str64(14, 0, 5)) // STR x14, [x0, #5*8] (slot for r5)
+			ws = append(ws, str64(15, 0, 6)) // STR x15, [x0, #6*8] (slot for r6)
+		}
+
 		// 0..6: pre-amble.
 		ws = append(ws, ldr64(4, 20, tableLenImm12))      // 0
 		ws = append(ws, ldrW(16, 20, nLiveImm12))         // 1
@@ -2054,8 +2098,8 @@ func emitInstrARM64Body(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deopt
 
 		// 22..35: probe loop body.
 		probeTopWord := opStart + len(ws)                 // 22
-		fillBlockWord := opStart + 39
-		nextWord := opStart + 36
+		fillBlockWord := opStart + spillW + 39
+		nextWord := opStart + spillW + 36
 
 		ws = append(ws, ldr64(13, 20, tablePtrImm12))     // 22
 		ws = append(ws, maddReg(16, 17, 15, 13))          // 23
@@ -2086,7 +2130,14 @@ func emitInstrARM64Body(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deopt
 		ws = append(ws, bfi48(13, xVal))                  // 33
 		ws = append(ws, str64(13, 16, entryValImm12))     // 34
 		bWord = opStart + len(ws)                         // 35
-		off, err = branchOff(bWord, endLabel, 26)
+		// Phase 6.3.4.f.2: when spilling, B done targets the restore
+		// block (which falls through to endLabel) instead of endLabel
+		// directly. spillW=0 keeps the original behavior.
+		doneTarget := endLabel
+		if spillW > 0 {
+			doneTarget = restoreStart
+		}
+		off, err = branchOff(bWord, doneTarget, 26)
 		if err != nil {
 			return nil, fmt.Errorf("MapSetI64I64 done B: %w", err)
 		}
@@ -2112,6 +2163,12 @@ func emitInstrARM64Body(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deopt
 		ws = append(ws, ldrW(13, 20, nLiveImm12))         // 45
 		ws = append(ws, addImm64(13, 13, 1))              // 46
 		ws = append(ws, strW(13, 20, nLiveImm12))         // 47
+
+		if spillW > 0 {
+			ws = append(ws, ldr64(13, 0, 4)) // LDR x13, [x0, #4*8]
+			ws = append(ws, ldr64(14, 0, 5))
+			ws = append(ws, ldr64(15, 0, 6))
+		}
 		return ws, nil
 
 	case vm3.OpMapGetI64I64:
@@ -2153,10 +2210,22 @@ func emitInstrARM64Body(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deopt
 
 		opStart := pcMap[idx]
 		endLabel := pcMap[idx+1]
-		missWord := opStart + 35
-		nextWord := opStart + 32
+		// Phase 6.3.4.f.2: scratch spill prologue for NumRegsI64>4 (see
+		// OpMapSetI64I64 emit for rationale). Internal labels shift by
+		// +spillW; the B done now targets the restore block instead of
+		// endLabel so the LDRs always run before exit.
+		spillW := mapScratchSpillWordsARM64(fn)
+		restoreStart := opStart + spillW + mapGetI64I64WordsARM64
+		missWord := opStart + spillW + 35
+		nextWord := opStart + spillW + 32
 
-		ws := make([]uint32, 0, mapGetI64I64WordsARM64)
+		ws := make([]uint32, 0, mapGetI64I64WordsARM64+2*spillW)
+		if spillW > 0 {
+			ws = append(ws, str64(13, 0, 4))
+			ws = append(ws, str64(14, 0, 5))
+			ws = append(ws, str64(15, 0, 6))
+		}
+
 		// 0..3: pre-amble.
 		ws = append(ws, ldr64(4, 20, tableLenImm12))      // 0
 		cbzWord := opStart + len(ws)                      // 1
@@ -2205,7 +2274,11 @@ func emitInstrARM64Body(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deopt
 		ws = append(ws, ldr64(13, 16, entryValImm12))     // 29
 		ws = append(ws, sbfx48(xA, 13))                   // 30: xA = value.Int()
 		bWord := opStart + len(ws)                        // 31
-		off, err = branchOff(bWord, endLabel, 26)
+		doneTarget := endLabel
+		if spillW > 0 {
+			doneTarget = restoreStart
+		}
+		off, err = branchOff(bWord, doneTarget, 26)
 		if err != nil {
 			return nil, fmt.Errorf("MapGetI64I64 done B: %w", err)
 		}
@@ -2223,6 +2296,12 @@ func emitInstrARM64Body(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deopt
 
 		// 35: miss → xA = 0.
 		ws = append(ws, movz(xA, 0, 0))                   // 35
+
+		if spillW > 0 {
+			ws = append(ws, ldr64(13, 0, 4))
+			ws = append(ws, ldr64(14, 0, 5))
+			ws = append(ws, ldr64(15, 0, 6))
+		}
 		return ws, nil
 
 	case vm3.OpTailCallMixed:
@@ -2816,6 +2895,39 @@ const mapSetI64I64WordsARM64 = 48
 // minus the grow check (LDR cap + CBZ empty), the fill block, and the
 // nLive bump.
 const mapGetI64I64WordsARM64 = 36
+
+// mapScratchSpillWordsARM64 reports the prologue word count consumed by
+// the x13/x14/x15 spill at map kernel entry. Phase 6.3.4.f.2: only
+// emitted when fn.NumRegsI64 > 4 (otherwise vm3 regs 4..6 don't exist
+// and x13/x14/x15 carry no live data the kernel needs to preserve).
+// Three STRs at entry, three matching LDRs at exit; this helper returns
+// the entry-half count so the body's internal labels can shift by +N
+// while the buffer is sized with `mapXWordsARM64 + 2*spillW`.
+func mapScratchSpillWordsARM64(fn *vm3.Function) int {
+	if fn.NumRegsI64 > 4 {
+		return 3
+	}
+	return 0
+}
+
+// mapKernelOperandClobber reports whether op uses x13/x14/x15 (host
+// regs for vm3 r4/r5/r6) as one of its key/value/dst operands when
+// NumRegsI64 > 4. The map kernel's inner body clobbers those host
+// regs mid-flight, and the entry-spill / exit-restore pair preserves
+// only the *frame-resident* user values that bracket the kernel — not
+// values the kernel itself is supposed to read at later instructions.
+// Reject such layouts so compiler3 callers know to keep keys/vals out
+// of slots 4..6.
+func mapKernelOperandClobber(op vm3.Op) bool {
+	in456 := func(r uint16) bool { return r >= 4 && r <= 6 }
+	switch op.Code {
+	case vm3.OpMapSetI64I64:
+		return in456(op.B) || in456(uint16(op.C))
+	case vm3.OpMapGetI64I64:
+		return in456(op.A) || in456(uint16(op.C))
+	}
+	return false
+}
 
 // emitSplitmix64ARM64 emits the 14-word splitmix64 sequence that
 // computes h = hashI64(xKey) into x4. Uses x16 as the multiplier

--- a/runtime/vm3/frame.go
+++ b/runtime/vm3/frame.go
@@ -88,11 +88,20 @@ type Function struct {
 	// K=1 retains the existing single-list shape (with JITPreAllocList
 	// true gating the warm-scratch path). K>1 uses fresh allocation per
 	// call; the warm-scratch optimization is left to a follow-up.
+	// JITPreAllocMap (Phase 6.3.4.f.2) mirrors JITPreAllocList for the
+	// OpNewMap-at-pc=0 shape used by k_nucleotide and any other kernel
+	// that allocates a single map at entry then operates on it via
+	// OpMapSetI64I64 / OpMapGetI64I64. jitCall reads fn.Code[0].A and .C
+	// to allocate the map with the static capHint before the trampoline
+	// and seeds jf.regsCell[A]; the JIT lowerer emits zero words for
+	// pc=0 so the prologue's LDR x_cell, [x3, #A*8] picks up the
+	// pre-seeded handle.
 	JITCode               unsafe.Pointer
 	JITCompiled           bool
 	JITHasF64             bool
 	JITPreAllocList       bool
 	JITPreAllocListPrefix uint16
+	JITPreAllocMap        bool
 }
 
 // Bank identifies one of the three typed register banks.

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -1890,6 +1890,37 @@ r3 = prev                                                  r12 = h
 
 Expected post-JIT ratio: 1.5-2.0x of Go (dominated by the per-iteration map hash + slot lookup; the rest of the loop is pure i64 arithmetic at native speed).
 
+#### Phase 6.3.4.f.2: k_nucleotide JIT admission + map-kernel correctness fix (2026-05-19 20:45 GMT+7)
+
+The three closure-path extensions outlined in 6.3.4.f.1 landed together, plus one critical correctness bug that affected every Cell-bank function with `NumRegsI64 > 4` that issues an inline map op.
+
+**Admission whitelist extension.** `checkCellBankAdmissible` (`runtime/jit/vm3jit/compile.go`) now accepts `OpConstI64KW`, `OpDivI64`, `OpModI64`, `OpDivI64K`, and `OpModI64K` as part of the sum-shape pattern. Both the reg-reg and K variants of Div/Mod already had ARM64 lowering in `lower_arm64.go`; adding them to the cell-bank case list lifts the silent rejection on any kernel that mixes map ops with modulus arithmetic.
+
+**OpNewMap pre-alloc lift.** Symmetric to `JITPreAllocList`. `Function.JITPreAllocMap` is set by `canPreAllocMap(fn)` in `CompileAndCache`; when true the lowerer emits zero words for `fn.Code[0]` and `jitCall` allocates the map with the static `capHint` (from `op.C`) before entering the trampoline, seeding `jf.regsCell[A]` with the fresh handle. The arena snapshot/restore around the JIT entry reclaims the slot on clean return. The k_nucleotide kernel was reshuffled so the `OpNewMap` is at `pc=0` (the four `OpConstI64KW` preloads moved to `pc=1..4`), unblocking the pre-alloc path without touching control flow.
+
+**NumRegsI64 refactor (Phase 6.3.4.f.1 follow-up).** k_nucleotide was retuned from `NumRegsI64=14` to `NumRegsI64=11` by reusing `r0/r1/r2` across the bootstrap, inner-loop, and summarize sections. This brings the kernel inside `maxI64RegsCellARM64 = 11`. The compile-time slot reuse audit is documented inline in `compiler3/corpus/k_nucleotide.go`.
+
+**Map-kernel scratch spill + the `mapScratchSpillWordsARM64` bug.** With `NumRegsI64 > 4`, the cell-bank reg-to-host mapping pins vm3 `r4..r6` to ARM64 `x13..x15`, which the inline `OpMapGetI64I64`/`OpMapSetI64I64` kernel uses as scratch. `lower_arm64.go` now bracket-spills `x13/x14/x15` to `[x0, #r*8]` at map kernel entry and reloads them at exit. `mapKernelOperandClobber` rejects layouts that name vm3 `r4..r6` as key/value/dest of a map op (the spill preserves only frame-resident user values that bracket the kernel, not values the kernel itself needs to read mid-flight). All k_nucleotide map ops keep their operands in `r0/r3/r8/r9/r10` so the gate passes.
+
+The first cut of `mapScratchSpillWordsARM64` returned `6` (interpreting "Three STRs + three LDRs = six words" as the total kernel overhead). But every offset calculation in the MapGet/MapSet emit treats `spillW` as the *prologue* word count when computing internal labels (`missWord = opStart + spillW + 35`, `restoreStart = opStart + spillW + mapXWordsARM64`, etc.). The mismatch shifted every internal branch target three words past its intended position. For `OpMapGetI64I64` this meant the empty-table / miss CBZ jumped over the `MOVZ xA, #0` instruction and into the LDR-restore epilogue, so a map miss left the destination register holding stale data from the previous op. Detected by a correctness sweep over `n in {0, 1, ..., 11, 100, 1000}`: the bug only manifests at `n in {0, 1}` because for `n >= 2` the inner-loop MapSet writes the key right after the buggy MapGet, masking the stale-register read at every subsequent iteration. Fix is one line: return `3` (prologue word count) instead of `6`, with comment + caller-side `mapXWordsARM64 + 2*spillW` buffer-cap formula now consistent.
+
+**Correctness gate.** `TestMathKernelsMatchVm2` (interp) still passes for all kernels. A standalone sweep through `CompileProgram + RunWithArgs` over `n in {0, 1, 2, ..., 11, 100, 1000}` matches `compiler2/corpus.ExpectKNucleotide` bit-identically with the JIT trampoline live (0 deopts across 100 runs of `n=100000`).
+
+**Measured macOS post-JIT (Apple M4, vm3+JIT trampoline, 0 deopts):**
+
+| Size | Go (ns/op) | vm3 interp (ns/op) | vm3 JIT (ns/op) | JIT ratio vs Go |
+|------|-----------:|-------------------:|----------------:|----------------:|
+| n=10000  | 176,247   |   653,742 |   661,096 | 3.75x |
+| n=100000 | 1,896,034 | 6,563,428 | 6,627,369 | 3.49x |
+
+**Status vs the 1.5-2.0x expectation.** The JIT now admits the entire kernel and runs to completion without deopt, but the measured speedup over interp is in the noise (~1%). Both paths bottleneck on the same map kernel: ~13 ns per map op (splitmix64 + probe + memory access) against Go's `~2.4 ns` for `map[int64]int64`. The dispatch overhead the JIT trampoline removes is dominated by the map-op cost itself, so closing the remaining gap requires shortening the per-map-op critical path rather than reducing dispatch. Candidate follow-ups for 6.3.4.f.3:
+
+1. Replace splitmix64 with a single `MUL` + `ROR` for `map[int64]int64` (key size is small, distribution is dense, full splitmix is overkill); ~9 fewer ARM64 µops per map op.
+2. Hoist `x20` table pointer + mask out of the probe loop into callee-saved regs (same pattern as cells.ptr in Phase 6.3.4.j.4a); turns the probe-back `LDR x13, [x20, #tablePtr]` into a register move.
+3. Specialize a "no-grow, no-collision" fast-path that skips the hash-compare and key-unbox when the entry is empty: jump directly to insert.
+
+These are generic vm3jit improvements that benefit every map-heavy Cell-bank kernel; tracked separately so this PR stays scoped to admission + the correctness fix.
+
 #### Phase 6.3.4.h.2: AMD64 lowering of OpFmaF64 + OpSqrtF64 (2026-05-19 18:17 GMT+7)
 
 Catch-up for the AMD64 backend so both f64 super-ops are platform-portable, mirroring the ARM64 `FMADD`/`FSQRT` lowerings already in place. Until this lands, `mandelbrot_jit_test.go` (build-tag-free) would skip JIT admission on linux/amd64 and `sqrt_sum_jit_test.go` had to be gated to `darwin && arm64`. Both gates drop.


### PR DESCRIPTION
## Summary

- Admit k_nucleotide on the Cell-bank ARM64 JIT path: whitelist Div/Mod (+ K forms), add JITPreAllocMap lift for OpNewMap, reserve x13/x14/x15 as map-kernel scratch.
- Fix a generic correctness bug in `mapScratchSpillWordsARM64` where the total prologue+epilogue word count (6) was used where offset calcs assume prologue-only (3). MapGet miss CBZ branched 3 words past target, leaving destination with stale data; symptom was JIT diverging from Go at n=0 and n=1 only.

Tracks #21786.

## Measured (darwin/arm64)

- k_nucleotide n=10000:  661,096 ns/op (3.75x of Go)
- k_nucleotide n=100000: 6,627,369 ns/op (3.49x of Go)

Closing under 2x deferred to Phase 6.3.4.f.3 (map kernel optimization: shorter hash, hoist table pointer, no-collision fast-path). Spec updated with the 2026-05-19 20:45 (GMT+7) section.

## Test plan

- [x] `go build ./...`
- [x] `go test ./runtime/jit/vm3jit/... ./compiler3/corpus/... ./runtime/vm3/...`
- [x] Correctness sweep n in {0,1,...,11,100,1000} vs compiler2/corpus.ExpectKNucleotide
- [x] 0 deopts across 100 runs at n=100000