### PR TITLE
mep-0040 phase 6.3.4.f.3: fix map-kernel wordCount for real JIT admission

### DIFF
--- a/runtime/jit/vm3jit/lower_arm64.go
+++ b/runtime/jit/vm3jit/lower_arm64.go
@@ -1510,7 +1510,7 @@ func wordCountARM64Body(fn *vm3.Function, op vm3.Op, opts Options, spillSets []u
 		if mapKernelOperandClobber(op) {
 			return 0, fmt.Errorf("%w: opcode %d (MapSetI64I64 key/val in slots 4..6 collides with kernel scratch)", ErrNotImplemented, op.Code)
 		}
-		return mapSetI64I64WordsARM64 + mapScratchSpillWordsARM64(fn), nil
+		return mapSetI64I64WordsARM64 + 2*mapScratchSpillWordsARM64(fn), nil
 
 	case vm3.OpMapGetI64I64:
 		// Phase 6.2d.2.d step 4 mirror of OpMapSetI64I64: inline open-
@@ -1524,7 +1524,7 @@ func wordCountARM64Body(fn *vm3.Function, op vm3.Op, opts Options, spillSets []u
 		if mapKernelOperandClobber(op) {
 			return 0, fmt.Errorf("%w: opcode %d (MapGetI64I64 dst/key in slots 4..6 collides with kernel scratch)", ErrNotImplemented, op.Code)
 		}
-		return mapGetI64I64WordsARM64 + mapScratchSpillWordsARM64(fn), nil
+		return mapGetI64I64WordsARM64 + 2*mapScratchSpillWordsARM64(fn), nil
 
 	case vm3.OpTailCallMixed:
 		// Self-tail-call with arg-base 0 lowers to a single backward B
@@ -2902,7 +2902,11 @@ const mapGetI64I64WordsARM64 = 36
 // and x13/x14/x15 carry no live data the kernel needs to preserve).
 // Three STRs at entry, three matching LDRs at exit; this helper returns
 // the entry-half count so the body's internal labels can shift by +N
-// while the buffer is sized with `mapXWordsARM64 + 2*spillW`.
+// while the buffer is sized with `mapXWordsARM64 + 2*spillW`. Phase
+// 6.3.4.f.3: wordCountARM64Body must also predict `mapXWordsARM64 +
+// 2*spillW` (the buffer cap) rather than `mapXWordsARM64 + spillW`;
+// otherwise the verifier rejects every map kernel emit when
+// NumRegsI64 > 4, silently preventing JIT admission.
 func mapScratchSpillWordsARM64(fn *vm3.Function) int {
 	if fn.NumRegsI64 > 4 {
 		return 3

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -1921,6 +1921,27 @@ The first cut of `mapScratchSpillWordsARM64` returned `6` (interpreting "Three S
 
 These are generic vm3jit improvements that benefit every map-heavy Cell-bank kernel; tracked separately so this PR stays scoped to admission + the correctness fix.
 
+#### Phase 6.3.4.f.3: map kernel wordCount fix (real JIT admission) (2026-05-19 23:36 GMT+7)
+
+Follow-up to 6.3.4.f.2 closing a second `mapScratchSpillWordsARM64` accounting bug that f.2 introduced but did not detect. With the bug present, `CompileAndCache` rejected every `OpMapGetI64I64` / `OpMapSetI64I64` site whose function had `NumRegsI64 > 4`, so the f.2 admission claim was false: `k_nucleotide`'s `fn.JITCode` stayed `nil`, the bench fell back to the interpreter through `vm.RunWithArgs`, and the published "JIT ratio 3.49x" was actually an interp ratio.
+
+**The bug.** `wordCountARM64Body` for `OpMapSetI64I64` / `OpMapGetI64I64` returned `mapXWordsARM64 + mapScratchSpillWordsARM64(fn)` (body + entry-prologue word count), but `emitInstrARM64Body` produces `mapXWordsARM64 + 2*spillW` (body + entry spill + exit restore). The verifier (`pc 19 op=56: emitted 42 words, predicted 39`) rejected the buffer, returned `ErrNotImplemented`, and silently aborted JIT compile. Every other CompileProgram call site treated the resulting `cf == nil` as "not admissible, fall back to interp" with no surfaced error.
+
+**Fix.** Two lines in `lower_arm64.go`: change the wordCount return values for `OpMapSetI64I64` and `OpMapGetI64I64` from `mapXWordsARM64 + mapScratchSpillWordsARM64(fn)` to `mapXWordsARM64 + 2*mapScratchSpillWordsARM64(fn)`. The helper's docstring is amended to spell out that `wordCount` must match the emit buffer-cap formula `mapXWordsARM64 + 2*spillW`.
+
+**Detection.** A direct `CompileProgram(KNucleotide.Build(0))` + `cf != nil` check is now in `/tmp/test_compile_err.go` (kept out of tree as a one-shot diagnostic). The bench harness `BenchmarkCorpusJITRunner/k_nucleotide_n100000` switches from the interp `vm.RunWithArgs` path to the JIT trampoline path when admission succeeds, and the ns/op delta is the gate: pre-fix 6.6 ms (interp), post-fix 0.9 ms (JIT).
+
+**Measured macOS post-fix (Apple M4, vm3+JIT trampoline, 0 deopts):**
+
+| Size | Go (ns/op) | vm3 JIT (ns/op) | JIT ratio vs Go |
+|------|-----------:|----------------:|----------------:|
+| n=10000  |   178,004 |    54,612 | **0.31x** (3.3x faster than Go) |
+| n=100000 | 1,889,989 |   922,615 | **0.49x** (2.0x faster than Go) |
+
+**Why the JIT beats Go.** The inline map kernel is straight-line ARM64: splitmix64 hash (14 µops, no call) + open-addressed probe (5 µops common case) + 8-byte store (1 µop), all with `x20` pinned to the slab base. Go's `runtime.mapaccess1_fast64` and `runtime.mapassign_fast64` each do a function-call entry + bucket walk through pointer-traced memory; for the steady-state hit-or-empty case the call overhead alone is comparable to the entire inline kernel body. The k_nucleotide kernel issues two MapSets and one MapGet per LCG iteration with all keys in a 20-entry dense range, so the inline kernel runs ~3-4x more map ops per nanosecond than Go's runtime, and the residual interp dispatch (4 ops in the LCG body) doesn't move the needle.
+
+**Status.** All 14 correctness sweeps (`n in {0,1,2,...,11,100,1000}`) match `compiler2/corpus.ExpectKNucleotide` bit-identically with the JIT trampoline live. 0 deopts across 100 runs of `n=100000`. `go test ./runtime/jit/vm3jit/` and `./compiler3/...` green. The three follow-up ideas in 6.3.4.f.2's epilogue (`MUL`+`ROR` hash, table-ptr/mask hoist, no-collision fast path) are deferred: the fix alone places k_nucleotide at 0.31-0.49x of Go, comfortably inside the 2x gate, and those changes would benefit other map-heavy kernels but are not on the BG closure critical path.
+
 #### Phase 6.3.4.h.2: AMD64 lowering of OpFmaF64 + OpSqrtF64 (2026-05-19 18:17 GMT+7)
 
 Catch-up for the AMD64 backend so both f64 super-ops are platform-portable, mirroring the ARM64 `FMADD`/`FSQRT` lowerings already in place. Until this lands, `mandelbrot_jit_test.go` (build-tag-free) would skip JIT admission on linux/amd64 and `sqrt_sum_jit_test.go` had to be gated to `darwin && arm64`. Both gates drop.


### PR DESCRIPTION
Closes #21788.

## Summary
- Phase 6.3.4.f.2 (#21787) shipped a wordCount bug that silently prevented k_nucleotide JIT admission; the bench fell back to the interpreter so the "3.49x JIT ratio" was actually an interp ratio.
- `wordCountARM64Body` for `OpMapSetI64I64` / `OpMapGetI64I64` predicted `mapXWordsARM64 + spillW` but emit produces `mapXWordsARM64 + 2*spillW` (body + entry spill + exit restore). Fix is two lines: switch to `2*spillW`.
- With the fix applied, k_nucleotide actually compiles and lands at 0.31-0.49x of Go on Apple M4 (vs. f.2's claimed 3.49x). Comfortably inside the 2x-of-Go BG closure gate.

## Measured (Apple M4, vm3+JIT trampoline, 0 deopts)
| Size | Go (ns/op) | vm3 JIT (ns/op) | Ratio |
| --- | ---: | ---: | ---: |
| n=10000 | 178,004 | 54,612 | **0.31x** (3.3x faster than Go) |
| n=100000 | 1,889,989 | 922,615 | **0.49x** (2.0x faster than Go) |

## Test plan
- [x] `go test ./runtime/jit/vm3jit/` green
- [x] `go test ./runtime/vm3/ ./compiler3/...` green
- [x] Correctness sweep `n in {0,1,...,11,100,1000}` matches `compiler2/corpus.ExpectKNucleotide` bit-identically with JIT trampoline live
- [x] `CompileAndCache` on `KNucleotide.Build(0)` now returns `cf != nil` (was `nil` on f.2)
- [x] MEP-40 spec updated with §Phase 6.3.4.f.3 measured table + scope notes