### PR TITLE
mep-0040 phase 6.3.4.f.3 followup: composite BG-suite gate state

### DIFF
--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -1942,6 +1942,24 @@ Follow-up to 6.3.4.f.2 closing a second `mapScratchSpillWordsARM64` accounting b
 
 **Status.** All 14 correctness sweeps (`n in {0,1,2,...,11,100,1000}`) match `compiler2/corpus.ExpectKNucleotide` bit-identically with the JIT trampoline live. 0 deopts across 100 runs of `n=100000`. `go test ./runtime/jit/vm3jit/` and `./compiler3/...` green. The three follow-up ideas in 6.3.4.f.2's epilogue (`MUL`+`ROR` hash, table-ptr/mask hoist, no-collision fast path) are deferred: the fix alone places k_nucleotide at 0.31-0.49x of Go, comfortably inside the 2x gate, and those changes would benefit other map-heavy kernels but are not on the BG closure critical path.
 
+**Composite BG-suite gate after f.3.** The 2x-of-Go gate covers 11 BG programs × 2 platforms (macOS Apple M4 + Linux server2). Honest state at this point:
+
+| Program | macOS ratio | macOS gate | Linux server2 | Notes |
+| --- | ---: | --- | --- | --- |
+| nsieve_n1000/n10000 | 1.64x / 1.73x | PASS | not measured | Phase 6.3.4.k.2 closed macOS |
+| fasta_n10000/n100000 | 1.17x / 1.01x | PASS | not measured | Phase 6.3.4.d closed macOS |
+| mandelbrot_n100/n300 | 0.75x / 0.76x | PASS | not measured | Phase 6.3.4.h closed macOS |
+| k_nucleotide_n10000/n100000 | 0.30x / 0.47x | PASS | not measured | **Phase 6.3.4.f.3 closed macOS** |
+| n_body_n100/n10000 | ~30x / ~30x | FAIL | not measured | Phase 6.3.4.j.4c LICM pending (task #179) |
+| binary_trees | n/a | not ported | not measured | scheduled for Phase 6.3.5+ |
+| fannkuch_redux | n/a | not ported | not measured | scheduled for Phase 6.3.5+ |
+| pidigits | n/a | not ported | not measured | scheduled for Phase 6.3.5+ |
+| regex_redux | n/a | not ported | not measured | scheduled for Phase 6.3.5+ |
+| reverse_complement | n/a | not ported | not measured | scheduled for Phase 6.3.5+ |
+| spectral_norm | n/a | not ported | not measured | scheduled for Phase 6.3.5+ |
+
+**Closure progress.** 4 of 11 BG programs PASS the macOS gate (nsieve, fasta, mandelbrot, k_nucleotide). 1 in flight (n_body, blocked on j.4c LICM). 6 unported (binary_trees, fannkuch_redux, pidigits, regex_redux, reverse_complement, spectral_norm) so they still run through `vm2` + `compiler2` in the cross-lang harness at their MEP-39 ratios (3.8x to 60x of Go). **Linux/server2 has not been re-benched on vm3 yet**; the second-platform half of the composite gate is tracked as task #85 and gates on a measurement run on the Linux host. f.3 advances the closure by one program; the full 11×2 matrix is not yet closed.
+
 #### Phase 6.3.4.h.2: AMD64 lowering of OpFmaF64 + OpSqrtF64 (2026-05-19 18:17 GMT+7)
 
 Catch-up for the AMD64 backend so both f64 super-ops are platform-portable, mirroring the ARM64 `FMADD`/`FSQRT` lowerings already in place. Until this lands, `mandelbrot_jit_test.go` (build-tag-free) would skip JIT admission on linux/amd64 and `sqrt_sum_jit_test.go` had to be gated to `darwin && arm64`. Both gates drop.


### PR DESCRIPTION
Follow-up to #21789 (closes #21790).

The map-kernel wordCount fix landed but the composite-gate state table got orphaned on the branch after auto-merge completed at the first commit. This PR is spec-only and lands that documentation so MEP-40 honestly reflects the 11x2 matrix.

## Summary
- Adds composite BG-suite gate state table to phase 6.3.4.f.3 entry
- States explicitly: composite gate not closed (4 PASS macOS, 1 FAIL n_body, 6 unported, Linux not measured)
- No code changes

## Test plan
- [x] Spec-only, no code touched
- [x] Cherry-picked from orphaned commit on prior branch (088fc5b730 = dc6def4f52 after rebase onto main)