### PR TITLE
mep-0040 phase 6.3.4.j.5.a: typed F64Array opcodes + interp

### DIFF
--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -138,6 +138,15 @@ const (
 	OpMapSetI64I64
 	OpMapGetI64I64
 
+	// Typed f64 array ops (Phase 6.3.4.j.5 vm3 surface). Flat
+	// vmF64Array backing skips the 16-byte Cell payload (8 bytes
+	// per element) used by OpListGetF64/SetF64.
+	OpNewF64Array
+	OpF64ArrayLenI64
+	OpF64ArrayPushF64
+	OpF64ArrayGetF64
+	OpF64ArraySetF64
+
 	// Calls. Args[0..] are the argument values; the callee is named by
 	// Value.Const (function index in the Function's owning Program).
 	OpCall
@@ -236,6 +245,16 @@ func (o OpCode) String() string {
 		return "map.set.i64.i64"
 	case OpMapGetI64I64:
 		return "map.get.i64.i64"
+	case OpNewF64Array:
+		return "newf64array"
+	case OpF64ArrayLenI64:
+		return "f64arr.len.i64"
+	case OpF64ArrayPushF64:
+		return "f64arr.push.f64"
+	case OpF64ArrayGetF64:
+		return "f64arr.get.f64"
+	case OpF64ArraySetF64:
+		return "f64arr.set.f64"
 	case OpCall:
 		return "call"
 	case OpTailCall:

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -195,6 +195,16 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeUnit, [3]Type{TypeMap, TypeI64, TypeI64}}
 	case OpMapGetI64I64:
 		return opSig{TypeI64, [3]Type{TypeMap, TypeI64}}
+	case OpNewF64Array:
+		return opSig{TypeF64Arr, [3]Type{}}
+	case OpF64ArrayLenI64:
+		return opSig{TypeI64, [3]Type{TypeF64Arr}}
+	case OpF64ArrayPushF64:
+		return opSig{TypeUnit, [3]Type{TypeF64Arr, TypeF64}}
+	case OpF64ArrayGetF64:
+		return opSig{TypeF64, [3]Type{TypeF64Arr, TypeI64}}
+	case OpF64ArraySetF64:
+		return opSig{TypeUnit, [3]Type{TypeF64Arr, TypeI64, TypeF64}}
 	}
 	// OpParam, OpConst, OpPhi, OpCall, OpTailCall: the validator
 	// can't pre-compute their signature without more context, so we

--- a/runtime/vm3/f64_array_test.go
+++ b/runtime/vm3/f64_array_test.go
@@ -1,0 +1,123 @@
+package vm3
+
+import (
+	"math"
+	"testing"
+)
+
+// TestF64ArrayGetSet verifies OpNewF64Array + OpF64ArrayGetF64 +
+// OpF64ArraySetF64 + OpF64ArrayLenI64 round-trip a representative
+// f64 value through a typed flat-f64 array. Mirrors TestListF64GetSet
+// but exercises the typed-arena path that backs n_body's position /
+// velocity / mass arrays without the Cell payload round-trip.
+func TestF64ArrayGetSet(t *testing.T) {
+	cs := []Cell{
+		CFloat(1.5),
+		CFloat(-2.25),
+		CFloat(0.0),
+		CFloat(math.Inf(1)),
+		CFloat(math.Inf(-1)),
+	}
+	wantSum := 1.5 + -2.25 + 0.0 + math.Inf(1) + math.Inf(-1) // NaN
+
+	fn := &Function{
+		Name:        "f64arr_round_trip",
+		NumRegsI64:  1,
+		NumRegsF64:  2,
+		NumRegsCell: 1,
+		ResultBank:  BankF64,
+		Consts:      cs,
+		Code: []Op{
+			// arr = NewF64Array(5) (pre-allocates 5 zero slots)
+			MakeOp(OpNewF64Array, 0, 0, 5),
+			// arr[0] = 1.5
+			MakeOp(OpConstF64K, 0, 0, 0),
+			MakeOp(OpConstI64K, 0, 0, 0),
+			MakeOp(OpF64ArraySetF64, 0, 0, 0),
+			// arr[1] = -2.25
+			MakeOp(OpConstF64K, 0, 0, 1),
+			MakeOp(OpConstI64K, 0, 0, 1),
+			MakeOp(OpF64ArraySetF64, 0, 0, 0),
+			// arr[2] = 0.0
+			MakeOp(OpConstF64K, 0, 0, 2),
+			MakeOp(OpConstI64K, 0, 0, 2),
+			MakeOp(OpF64ArraySetF64, 0, 0, 0),
+			// arr[3] = +Inf
+			MakeOp(OpConstF64K, 0, 0, 3),
+			MakeOp(OpConstI64K, 0, 0, 3),
+			MakeOp(OpF64ArraySetF64, 0, 0, 0),
+			// arr[4] = -Inf
+			MakeOp(OpConstF64K, 0, 0, 4),
+			MakeOp(OpConstI64K, 0, 0, 4),
+			MakeOp(OpF64ArraySetF64, 0, 0, 0),
+			// acc = arr[0]
+			MakeOp(OpConstI64K, 0, 0, 0),
+			MakeOp(OpF64ArrayGetF64, 0, 0, 0),
+			// acc += arr[1]
+			MakeOp(OpConstI64K, 0, 0, 1),
+			MakeOp(OpF64ArrayGetF64, 1, 0, 0),
+			MakeOp(OpAddF64, 0, 0, 1),
+			// acc += arr[2]
+			MakeOp(OpConstI64K, 0, 0, 2),
+			MakeOp(OpF64ArrayGetF64, 1, 0, 0),
+			MakeOp(OpAddF64, 0, 0, 1),
+			// acc += arr[3]
+			MakeOp(OpConstI64K, 0, 0, 3),
+			MakeOp(OpF64ArrayGetF64, 1, 0, 0),
+			MakeOp(OpAddF64, 0, 0, 1),
+			// acc += arr[4]
+			MakeOp(OpConstI64K, 0, 0, 4),
+			MakeOp(OpF64ArrayGetF64, 1, 0, 0),
+			MakeOp(OpAddF64, 0, 0, 1),
+			MakeOp(OpReturnF64, 0, 0, 0),
+		},
+	}
+	prog := &Program{Funcs: []*Function{fn}, Entry: 0}
+	vm := NewWithProgram(prog)
+	got, err := vm.Run(fn)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	gotF := got.Float()
+	if math.IsNaN(wantSum) {
+		if !math.IsNaN(gotF) {
+			t.Fatalf("want NaN, got %g", gotF)
+		}
+	} else if gotF != wantSum {
+		t.Fatalf("sum mismatch: got %g want %g", gotF, wantSum)
+	}
+}
+
+// TestF64ArrayPushLen verifies OpF64ArrayPushF64 grows the backing
+// slice and OpF64ArrayLenI64 returns int64(len(data)). NewF64Array(0)
+// starts at length 0 so Push is observable.
+func TestF64ArrayPushLen(t *testing.T) {
+	fn := &Function{
+		Name:        "f64arr_push_len",
+		NumRegsI64:  1,
+		NumRegsF64:  1,
+		NumRegsCell: 1,
+		ResultBank:  BankI64,
+		Consts:      []Cell{CFloat(3.14), CFloat(2.71), CFloat(1.41)},
+		Code: []Op{
+			MakeOp(OpNewF64Array, 0, 0, 0),
+			MakeOp(OpConstF64K, 0, 0, 0),
+			MakeOp(OpF64ArrayPushF64, 0, 0, 0),
+			MakeOp(OpConstF64K, 0, 0, 1),
+			MakeOp(OpF64ArrayPushF64, 0, 0, 0),
+			MakeOp(OpConstF64K, 0, 0, 2),
+			MakeOp(OpF64ArrayPushF64, 0, 0, 0),
+			MakeOp(OpF64ArrayLenI64, 0, 0, 0),
+			MakeOp(OpReturnI64, 0, 0, 0),
+		},
+	}
+	prog := &Program{Funcs: []*Function{fn}, Entry: 0}
+	vm := NewWithProgram(prog)
+	got, err := vm.Run(fn)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got.Int() != 3 {
+		t.Fatalf("len: got %d want 3", got.Int())
+	}
+}

--- a/runtime/vm3/op.go
+++ b/runtime/vm3/op.go
@@ -170,6 +170,24 @@ const (
 	// SQRTSD xmmA, xmmB. Prereq for n_body's inner-loop distance
 	// computation (sqrt(dx*dx + dy*dy + dz*dz)).
 	OpSqrtF64
+
+	// Typed f64 array ops (Phase 6.3.4.j.5). Backed by vmF64Array
+	// (flat []float64), so each element is 8 bytes instead of the
+	// 16-byte Cell payload an OpList* uses. Two structural wins:
+	// (a) half the cache footprint per element (5 bodies x 7 arrays
+	// = 280 bytes in F64Array vs 560 bytes in Cell-Lists, fits in
+	// a single L1 line vs two), and (b) the per-access path skips
+	// the CFloat tag round-trip (no shift-and-mask on read, no
+	// tag re-emit on write). On ARM64 the JIT lowering collapses
+	// to a single LDR/STR Dt, [Xptr, Xidx, LSL #3] per access
+	// instead of the j.4a-hoisted Cell-list 2-instruction form
+	// (LDR Xcell + extract f64 bits). Generic: any f64-only list
+	// that does not need a Cell-tagged payload qualifies.
+	OpNewF64Array     // regsCell[A] = arenas.AllocF64Arr(int(uint16(C)))
+	OpF64ArrayLenI64  // regsI64[A] = int64(len(arenas.F64Arrs[idx].data))
+	OpF64ArrayPushF64 // arenas.F64Arrs[idx].data = append(..., regsF64[B])
+	OpF64ArrayGetF64  // regsF64[A] = arenas.F64Arrs[idx].data[regsI64[uint16(C)]]
+	OpF64ArraySetF64  // arenas.F64Arrs[idx].data[regsI64[uint16(C)]] = regsF64[B]
 )
 
 // Op is a single 8-byte vm3 bytecode word. Layout:

--- a/runtime/vm3/vm.go
+++ b/runtime/vm3/vm.go
@@ -796,6 +796,32 @@ func (vm *VM) run() (Cell, error) {
 			arenas.Lists[idx].cells[regsI64[uint16(op.C)]] = CFloat(regsF64[op.B])
 			pc++
 
+		case OpNewF64Array:
+			regsCell[op.A] = arenas.AllocF64Arr(int(uint16(op.C)))
+			pc++
+		case OpF64ArrayLenI64:
+			arr := regsCell[op.B]
+			_, _, idx := arr.DecodeHandle()
+			regsI64[op.A] = int64(len(arenas.F64Arrs[idx].data))
+			pc++
+		case OpF64ArrayPushF64:
+			arr := regsCell[op.A]
+			_, _, idx := arr.DecodeHandle()
+			a := &arenas.F64Arrs[idx]
+			a.data = append(a.data, regsF64[op.B])
+			a.len = uint32(len(a.data))
+			pc++
+		case OpF64ArrayGetF64:
+			arr := regsCell[op.B]
+			_, _, idx := arr.DecodeHandle()
+			regsF64[op.A] = arenas.F64Arrs[idx].data[regsI64[uint16(op.C)]]
+			pc++
+		case OpF64ArraySetF64:
+			arr := regsCell[op.A]
+			_, _, idx := arr.DecodeHandle()
+			arenas.F64Arrs[idx].data[regsI64[uint16(op.C)]] = regsF64[op.B]
+			pc++
+
 		case OpNewMap:
 			regsCell[op.A] = arenas.AllocMap(int(uint16(op.C)))
 			pc++

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2149,6 +2149,32 @@ The headline win is modest (~1%) on n_body because after j.4a the bottleneck shi
 
 **Status.** Generic JIT peephole, no opcode change, no kernel-side change. ARM64 only in j.4b; AMD64 catch-up rolls into j.5. Correctness verified via existing `TestNBodyJITCompiles` (1e-10 tolerance covers FMA's single-rounding ULP delta vs the Go oracle's two-rounding chain). No regressions on lists_fill_sum, maps_fill_sum, nsieve, fasta, mandelbrot, k_nucleotide benches.
 
+#### Phase 6.3.4.j.5.a: typed F64Array opcodes + interp (2026-05-20 09:00 GMT+7)
+
+**Why a separate sub-phase.** Per §6.3.4.j.4b's gap-descent note (and §10's Phase 6.3.4 closure table line for `n_body`), the residual ~30-40x gap on `n_body` after j.4a + j.4b is dominated by the Cell-payload tax on `OpListGetF64` / `OpListSetF64`: each access loads a 16-byte `Cell` (8-byte tag word + 8-byte payload) just to extract the float bits, then on stores re-emits the `CFloat` tag. The vm3 arena layer already has a flat `vmF64Array{data []float64}` slab (`runtime/vm3/arenas.go::vmF64Array`, `ArenaF64Arr = 9`, allocator `Arenas.AllocF64Arr`, swept by `Arenas.sweepF64Arr`); it was scaffolded with Phase 1 but never wired to a vm3 opcode. Landing the typed surface as its own sub-phase keeps j.5.b (JIT lowering) and j.5.c (n_body kernel migration) on the same well-understood interp baseline that every prior BG closure followed (j.1 → j.2 → j.3 shape).
+
+**Structural rationale.**
+
+- **8 bytes/element vs 16-byte `Cell` payload.** `vmF64Array.data` is a flat `[]float64`; per-element footprint is exactly the IEEE 754 double. `vmList.cells` carries 16-byte `Cell` slots (tag word + payload). For n_body's 5-body x 7-array hot working set, the difference is 5x7x8 = 280 bytes (typed) vs 5x7x16 = 560 bytes (Cell). The typed form fits in a single 64-byte L1 line per array (5 doubles = 40 bytes); the Cell form straddles two cache lines per array. On Apple M4 (128-byte L1 line, but the same prefetch granularity applies) this is one L1 hit vs two on each pair-iter sweep.
+- **No tag round-trip on read/write.** `OpListGetF64`'s eval body extracts `cells[idx].Float()` (shift + mask + bit-cast through `math.Float64frombits`); `OpListSetF64`'s eval body re-emits `CFloat(regsF64[B])` (bit-cast + tag OR). On the typed surface, get is `data[idx]` and set is `data[idx] = v` (direct f64 load/store, no shift-and-mask). Per-access work drops from ~5 instructions of bit manipulation to a single LDR/STR.
+- **JIT lowering becomes one instruction per access.** Once j.5.b lands, the ARM64 emit for `OpF64ArrayGetF64`/`OpF64ArraySetF64` is a single `LDR Dt, [Xptr, Xidx, LSL #3]` or `STR Dt, [Xptr, Xidx, LSL #3]` (versus j.4a's 2-instruction `LDR Xcell + extract f64 bits` form). AMD64 lowering is similarly one `MOVSD xmmA, [rPtr + rIdx*8]` or `MOVSD [rPtr + rIdx*8], xmmA`. This is the limit of what any JIT can produce on the access path; from here, the kernel-level bottleneck shifts to `FSQRT`/`FDIV` latency (the two remaining serialized ops in adv_j_loop, both fundamental to the gravity computation), not the load/store engine.
+
+**Opcode surface.** Five ops parallel to the `OpList*F64` family but typed on `vmF64Array`:
+
+- `OpNewF64Array A,_,C`: `regsCell[A] = arenas.AllocF64Arr(int(uint16(C)))`. The C field carries the initial length (not capacity, so subsequent `OpF64ArrayGetF64`/`SetF64` calls index pre-zeroed elements without intermediate `Push`); use `C=0` if the kernel `Push`es elements on a known-length-zero path.
+- `OpF64ArrayLenI64 A,B,_`: `regsI64[A] = int64(len(arenas.F64Arrs[idx].data))` where `idx = regsCell[B].DecodeHandle().idx`.
+- `OpF64ArrayPushF64 A,B,_`: `arenas.F64Arrs[idx].data = append(..., regsF64[B])`; the arena's `len` counter is bumped in lockstep with the slice growth so subsequent `OpF64ArrayLenI64` sees the new length.
+- `OpF64ArrayGetF64 A,B,C`: `regsF64[A] = arenas.F64Arrs[idx].data[regsI64[uint16(C)]]` where `idx = regsCell[B].DecodeHandle().idx`.
+- `OpF64ArraySetF64 A,B,C`: `arenas.F64Arrs[idx].data[regsI64[uint16(C)]] = regsF64[B]` where `idx = regsCell[A].DecodeHandle().idx`.
+
+IR mirrors the surface 1-for-1: `compiler3/ir.OpNewF64Array` produces `TypeF64Arr`, `Op*LenI64` consumes `TypeF64Arr` and produces `TypeI64`, `Op*Push/Set/GetF64` consume `(TypeF64Arr, ...)` and produce `TypeUnit` (writes) or `TypeF64` (reads). The validator's `opContract` table (`compiler3/ir/validate.go`) holds the new sigs so an ill-formed IR is caught before regalloc.
+
+**Tests.** `runtime/vm3/f64_array_test.go::TestF64ArrayGetSet` round-trips a representative set `{1.5, -2.25, 0.0, +Inf, -Inf}` through `NewF64Array(5)` + `Set` + `Get` + `Sum`, asserting NaN equality on the (Inf - Inf) sum to confirm IEEE 754 semantics survive both the typed-arena read path and the f64 register bank. `TestF64ArrayPushLen` confirms `Push` grows the backing slice and `LenI64` returns `int64(len(data))`.
+
+**Performance.** Pure interp landing; no JIT impact and no n_body kernel migration. The j.5.b JIT lowering and j.5.c kernel migration land separately so the perf delta is attributable. On j.5.a alone, n_body's bench is unchanged (it still uses `OpListGetF64`/`OpListSetF64` end-to-end).
+
+**Exit gate.** Phase 6.3.4.j.5.a is the typed-surface foundation. Closing n_body under 2x of Go is gated on j.5.b (JIT lowering of the 5 new ops) + j.5.c (n_body kernel migration from `OpListGetF64`/`SetF64` to the typed forms).
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
Tracks #21792.

## Summary

Wires the previously-scaffolded `vmF64Array` arena (`ArenaF64Arr=9`, flat `[]float64`, 8 bytes/element) to a vm3 op surface, mirrored in `compiler3/ir`. Five ops parallel the existing `OpListGetF64`/`OpListSetF64` family:

| op | semantics |
|---|---|
| `OpNewF64Array A,_,C` | `regsCell[A] = arenas.AllocF64Arr(int(uint16(C)))` |
| `OpF64ArrayLenI64 A,B,_` | `regsI64[A] = len(arenas.F64Arrs[idx].data)` |
| `OpF64ArrayPushF64 A,B,_` | `arenas.F64Arrs[idx].data = append(..., regsF64[B])` |
| `OpF64ArrayGetF64 A,B,C` | `regsF64[A] = arenas.F64Arrs[idx].data[regsI64[uint16(C)]]` |
| `OpF64ArraySetF64 A,B,C` | `arenas.F64Arrs[idx].data[regsI64[uint16(C)]] = regsF64[B]` |

`idx = regsCell[*].DecodeHandle().idx` per op semantics.

## Why

Per MEP-40 §6.3.4.j.4b's gap-descent note, the residual ~30-40x gap on n_body after j.4a (cells.ptr hoist) + j.4b (FMA fusion) is dominated by the Cell-payload tax on `OpListGetF64`/`OpListSetF64`:

- Get loads a 16-byte Cell (tag + payload), shifts/masks, then bit-casts to f64.
- Set re-emits `CFloat` (bit-cast + tag OR).

On the typed surface, get is `data[idx]` and set is `data[idx] = v` (a single LDR/STR after j.5.b lowering). Per-access work drops from ~5 instructions of bit manipulation to one. For n_body's 5-body x 7-array working set, the cache footprint also halves (280 bytes flat vs 560 bytes Cell).

This PR is interp-only. No JIT impact and no n_body kernel migration:

- j.5.b (followup): ARM64 + AMD64 JIT lowering of the 5 new ops.
- j.5.c (followup): refactor `compiler3/corpus/n_body.go` to use the typed surface, bench, close under 2x of Go.

## Changes

- `runtime/vm3/op.go`: 5 new OpCodes + docstrings.
- `runtime/vm3/vm.go`: 5 new interp eval cases.
- `compiler3/ir/types.go`: mirror OpCodes + String() entries.
- `compiler3/ir/validate.go`: opContract sigs.
- `runtime/vm3/f64_array_test.go`: round-trip tests.
- `website/docs/mep/mep-0040.md`: Phase 6.3.4.j.5.a section.

## Test plan

- [x] `go test ./runtime/vm3/ -run TestF64Array` passes
- [x] `go build ./runtime/vm3/... ./compiler3/... ./runtime/jit/...` clean
- [x] `go test ./runtime/vm3/... ./compiler3/...` no regressions
- [ ] (j.5.b followup) JIT lowering + admit on n_body kernel
- [ ] (j.5.c followup) n_body kernel migration + bench close