### PR TITLE
mep-0040 phase 6.3.4.j.5.b: JIT lower F64Array ops (ARM64)

### DIFF
--- a/runtime/jit/vm3jit/arena_ctx.go
+++ b/runtime/jit/vm3jit/arena_ctx.go
@@ -36,8 +36,9 @@ const MaxCellRegs = maxCellRegs
 // grow-aware sub-phase will add a deopt-on-grow guard mirroring
 // 6.2d.2.c's StatusListGrow.
 type jitArenaCtx struct {
-	listsBase unsafe.Pointer
-	mapsBase  unsafe.Pointer
+	listsBase   unsafe.Pointer
+	mapsBase    unsafe.Pointer
+	f64ArrsBase unsafe.Pointer
 }
 
 // populateArenaCtx snapshots the Arenas slab base pointers the JIT
@@ -47,4 +48,5 @@ type jitArenaCtx struct {
 func populateArenaCtx(ctx *jitArenaCtx, arenas *vm3.Arenas) {
 	ctx.listsBase = arenas.JITListsBase()
 	ctx.mapsBase = arenas.JITMapsBase()
+	ctx.f64ArrsBase = arenas.JITF64ArrsBase()
 }

--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -232,6 +232,7 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 			vm3.OpListGetI64, vm3.OpListPushI64, vm3.OpListSetI64,
 			vm3.OpListGetF64, vm3.OpListSetF64,
 			vm3.OpMapSetI64I64, vm3.OpMapGetI64I64,
+			vm3.OpF64ArrayGetF64, vm3.OpF64ArraySetF64, vm3.OpF64ArrayLenI64,
 			vm3.OpConstF64K, vm3.OpMovF64,
 			vm3.OpAddF64, vm3.OpSubF64, vm3.OpMulF64, vm3.OpDivF64,
 			vm3.OpNegF64, vm3.OpFmaF64, vm3.OpSqrtF64,
@@ -268,6 +269,19 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 				continue
 			}
 			return fmt.Errorf("%w: %s pc %d Cell-bank fn uses inline OpNewMap (only pre-alloc at pc=0 is admitted)",
+				ErrNotImplemented, fn.Name, i)
+		case vm3.OpNewF64Array:
+			// Phase 6.3.4.j.5.b: admit at i < K where K is the contiguous
+			// OpNewF64Array prefix length the JIT lifted into jitCall.
+			// The lowerer emits zero words for each pre-allocated PC; the
+			// prologue's LDR x_cell, [x3, #A*8] picks up the seeded
+			// handle. Inline OpNewF64Array outside the prefix routes back
+			// to the interpreter (it would need an inline arena-alloc
+			// kernel that we have not lowered yet).
+			if k := int(preAllocF64ArrPrefix(fn)); k > 0 && i < k {
+				continue
+			}
+			return fmt.Errorf("%w: %s pc %d Cell-bank fn uses inline OpNewF64Array (only pre-alloc prefix is admitted)",
 				ErrNotImplemented, fn.Name, i)
 		case vm3.OpTailCallMixed:
 			if opts.SelfIdx < 0 || int(uint16(op.C)) != opts.SelfIdx || op.B != 0 {

--- a/runtime/jit/vm3jit/f64arr_arm64_test.go
+++ b/runtime/jit/vm3jit/f64arr_arm64_test.go
@@ -1,0 +1,139 @@
+//go:build darwin && arm64
+
+package vm3jit_test
+
+import (
+	"math"
+	"testing"
+
+	"mochi/runtime/jit/vm3jit"
+	"mochi/runtime/vm3"
+)
+
+// TestF64ArrayJITGetSet exercises the Phase 6.3.4.j.5.b ARM64 lowering
+// for OpNewF64Array (pre-alloc skip), OpF64ArraySetF64, OpF64ArrayGetF64,
+// and OpF64ArrayLenI64. The kernel pre-allocates a 5-slot typed array,
+// writes 5 representative f64 values (including +Inf/-Inf to lock in the
+// raw-bits round trip), reads them back, sums via OpAddF64, and returns
+// the sum. The shape mirrors vm3.TestF64ArrayGetSet so the JIT path is
+// bit-for-bit comparable to the interpreter.
+func TestF64ArrayJITGetSet(t *testing.T) {
+	cs := []vm3.Cell{
+		vm3.CFloat(1.5),
+		vm3.CFloat(-2.25),
+		vm3.CFloat(0.0),
+		vm3.CFloat(math.Inf(1)),
+		vm3.CFloat(math.Inf(-1)),
+	}
+	wantSum := 1.5 + -2.25 + 0.0 + math.Inf(1) + math.Inf(-1) // NaN
+
+	fn := &vm3.Function{
+		Name:        "f64arr_jit_round_trip",
+		NumRegsI64:  1,
+		NumRegsF64:  2,
+		NumRegsCell: 1,
+		ResultBank:  vm3.BankF64,
+		Consts:      cs,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewF64Array, 0, 0, 5),
+			vm3.MakeOp(vm3.OpConstF64K, 0, 0, 0),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 0),
+			vm3.MakeOp(vm3.OpF64ArraySetF64, 0, 0, 0),
+			vm3.MakeOp(vm3.OpConstF64K, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 1),
+			vm3.MakeOp(vm3.OpF64ArraySetF64, 0, 0, 0),
+			vm3.MakeOp(vm3.OpConstF64K, 0, 0, 2),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 2),
+			vm3.MakeOp(vm3.OpF64ArraySetF64, 0, 0, 0),
+			vm3.MakeOp(vm3.OpConstF64K, 0, 0, 3),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 3),
+			vm3.MakeOp(vm3.OpF64ArraySetF64, 0, 0, 0),
+			vm3.MakeOp(vm3.OpConstF64K, 0, 0, 4),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 4),
+			vm3.MakeOp(vm3.OpF64ArraySetF64, 0, 0, 0),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 0),
+			vm3.MakeOp(vm3.OpF64ArrayGetF64, 0, 0, 0),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 1),
+			vm3.MakeOp(vm3.OpF64ArrayGetF64, 1, 0, 0),
+			vm3.MakeOp(vm3.OpAddF64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 2),
+			vm3.MakeOp(vm3.OpF64ArrayGetF64, 1, 0, 0),
+			vm3.MakeOp(vm3.OpAddF64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 3),
+			vm3.MakeOp(vm3.OpF64ArrayGetF64, 1, 0, 0),
+			vm3.MakeOp(vm3.OpAddF64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 4),
+			vm3.MakeOp(vm3.OpF64ArrayGetF64, 1, 0, 0),
+			vm3.MakeOp(vm3.OpAddF64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpReturnF64, 0, 0, 0),
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{fn}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if fn.JITCode == nil {
+		t.Fatalf("f64arr_jit_round_trip did not compile (JITCode is nil); "+
+			"NumRegsCell=%d, JITPreAllocF64ArrPrefix=%d", fn.NumRegsCell, fn.JITPreAllocF64ArrPrefix)
+	}
+	if fn.JITPreAllocF64ArrPrefix != 1 {
+		t.Fatalf("JITPreAllocF64ArrPrefix: got %d want 1", fn.JITPreAllocF64ArrPrefix)
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.Run(fn)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	gotF := got.Float()
+	if math.IsNaN(wantSum) {
+		if !math.IsNaN(gotF) {
+			t.Fatalf("want NaN, got %g", gotF)
+		}
+	} else if gotF != wantSum {
+		t.Fatalf("sum mismatch: got %g want %g", gotF, wantSum)
+	}
+}
+
+// TestF64ArrayJITLen exercises the Phase 6.3.4.j.5.b ARM64 lowering for
+// OpF64ArrayLenI64. The kernel pre-allocates a typed array sized via op.C
+// and immediately returns its length so the JIT path covers the cold
+// 5-inst form (UXTW + MOV stride + MUL + ADD + LDR Wd).
+func TestF64ArrayJITLen(t *testing.T) {
+	const want = 7
+	fn := &vm3.Function{
+		Name:        "f64arr_jit_len",
+		NumRegsI64:  1,
+		NumRegsCell: 1,
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewF64Array, 0, 0, want),
+			vm3.MakeOp(vm3.OpF64ArrayLenI64, 0, 0, 0),
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{fn}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if fn.JITCode == nil {
+		t.Fatalf("f64arr_jit_len did not compile (JITCode is nil)")
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.Run(fn)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got.Int() != int64(want) {
+		t.Fatalf("len: got %d want %d", got.Int(), want)
+	}
+}

--- a/runtime/jit/vm3jit/init.go
+++ b/runtime/jit/vm3jit/init.go
@@ -210,6 +210,21 @@ func jitCall(vm *vm3.VM, fn *vm3.Function, argsI64 []int64, argsF64 []float64, a
 			jf.regsCell[op.A] = vm.Arenas().AllocMap(int(op.C))
 		}
 	}
+	// Phase 6.3.4.j.5.b: OpNewF64Array pre-alloc. fn.JITPreAllocF64ArrPrefix
+	// > 0 means the JIT skipped a contiguous K-op run of OpNewF64Array at
+	// PC=0; allocate K typed arrays here so the prologue's LDR x_cell picks
+	// up the pre-seeded handles. The Go-side allocations are bounded by
+	// the per-call arena snapshot so RestoreUnboxedReturn reclaims them
+	// on clean return.
+	if k := int(fn.JITPreAllocF64ArrPrefix); k > 0 {
+		arenas := vm.Arenas()
+		for i := 0; i < k; i++ {
+			op := fn.Code[i]
+			if int(op.A) < MaxCellRegs {
+				jf.regsCell[op.A] = arenas.AllocF64Arr(int(uint16(op.C)))
+			}
+		}
+	}
 	// Lay out params per ParamBanks position-indexed convention: argsX[k]
 	// is meaningful iff fn.ParamBanks[k] == BankX. For i64-only callees
 	// argsCell/argsF64 are nil and we use the fast path: copy argsI64
@@ -326,11 +341,13 @@ func CompileAndCache(prog *vm3.Program, idx uint32) (*CompiledFunc, error) {
 	fn.JITPreAllocList = canPreAllocList(fn)
 	fn.JITPreAllocListPrefix = preAllocListPrefix(fn)
 	fn.JITPreAllocMap = canPreAllocMap(fn)
+	fn.JITPreAllocF64ArrPrefix = preAllocF64ArrPrefix(fn)
 	cf, err := CompileInProgram(prog, idx)
 	if err != nil {
 		fn.JITPreAllocList = false
 		fn.JITPreAllocListPrefix = 0
 		fn.JITPreAllocMap = false
+		fn.JITPreAllocF64ArrPrefix = 0
 		return nil, err
 	}
 	fn.JITCode = cf.Entry()
@@ -458,6 +475,51 @@ func canPreAllocMap(fn *vm3.Function) bool {
 		}
 	}
 	return true
+}
+
+// preAllocF64ArrPrefix returns K such that fn.Code[0..K-1] is a
+// contiguous run of OpNewF64Array ops the JIT can lift into jitCall
+// (Phase 6.3.4.j.5.b). Each op must write a distinct cell reg within
+// the cell-bank window, and no subsequent op may overwrite any of
+// those cells via OpNewList / OpNewMap / OpNewF64Array. Returns 0 when
+// the prefix is empty or when the safety guard fails.
+func preAllocF64ArrPrefix(fn *vm3.Function) uint16 {
+	if len(fn.Code) == 0 || fn.Code[0].Code != vm3.OpNewF64Array {
+		return 0
+	}
+	cellCap := int(fn.NumRegsCell)
+	if cellCap > MaxCellRegs {
+		cellCap = MaxCellRegs
+	}
+	seen := make(map[uint16]bool)
+	k := 0
+	for i := 0; i < len(fn.Code); i++ {
+		op := fn.Code[i]
+		if op.Code != vm3.OpNewF64Array {
+			break
+		}
+		if int(op.A) >= cellCap {
+			break
+		}
+		if seen[op.A] {
+			break
+		}
+		seen[op.A] = true
+		k = i + 1
+	}
+	if k == 0 {
+		return 0
+	}
+	for i := k; i < len(fn.Code); i++ {
+		op := fn.Code[i]
+		if op.Code != vm3.OpNewList && op.Code != vm3.OpNewMap && op.Code != vm3.OpNewF64Array {
+			continue
+		}
+		if seen[op.A] {
+			return 0
+		}
+	}
+	return uint16(k)
 }
 
 // CompileProgram is the convenience entry point that walks every

--- a/runtime/jit/vm3jit/lower_arm64.go
+++ b/runtime/jit/vm3jit/lower_arm64.go
@@ -359,33 +359,54 @@ const (
 	slabKindNone slabKind = iota
 	slabKindList
 	slabKindMap
+	slabKindF64Arr
 )
 
 // slabKindARM64 classifies fn by which slab its inline body references.
-// Returns slabKindNone when fn references neither slab or both (mixed
+// Returns slabKindNone when fn references multiple slabs or none (mixed
 // kernels are rejected by checkCellBankAdmissible separately so they
-// never reach codegen).
+// never reach codegen). Phase 6.3.4.j.5.b adds slabKindF64Arr for
+// typed-f64-array kernels: any OpF64Array{Get,Set,Len} use makes the
+// fn an f64arr kernel.
 func slabKindARM64(fn *vm3.Function) slabKind {
 	hasList := hasListGetI64(fn) || hasListPushI64(fn)
 	hasMap := hasMapOpI64(fn)
-	switch {
-	case hasList && !hasMap:
-		return slabKindList
-	case hasMap && !hasList:
-		return slabKindMap
-	default:
+	hasF64Arr := hasF64ArrayOp(fn)
+	n := 0
+	if hasList {
+		n++
+	}
+	if hasMap {
+		n++
+	}
+	if hasF64Arr {
+		n++
+	}
+	if n != 1 {
 		return slabKindNone
 	}
+	switch {
+	case hasList:
+		return slabKindList
+	case hasMap:
+		return slabKindMap
+	case hasF64Arr:
+		return slabKindF64Arr
+	}
+	return slabKindNone
 }
 
 // slabBaseOffARM64 returns the byte offset within jitArenaCtx of the
 // slab base pointer the prologue should load into x19. Mirrors the
-// field order in jitArenaCtx: listsBase at offset 0, mapsBase at 8.
-// Fns with no slab kind default to listsBase so the existing list-only
-// admit set keeps its prologue word count unchanged.
+// field order in jitArenaCtx: listsBase at offset 0, mapsBase at 8,
+// f64ArrsBase at 16. Fns with no slab kind default to listsBase so the
+// existing list-only admit set keeps its prologue word count unchanged.
 func slabBaseOffARM64(fn *vm3.Function) uint32 {
-	if slabKindARM64(fn) == slabKindMap {
+	switch slabKindARM64(fn) {
+	case slabKindMap:
 		return 8
+	case slabKindF64Arr:
+		return 16
 	}
 	return 0
 }
@@ -394,8 +415,11 @@ func slabBaseOffARM64(fn *vm3.Function) uint32 {
 // entries for fn's slab kind. Used by the slab-base hoist (UXTW + MOV
 // stride + MUL + ADD) and by per-op cold-form recompute paths.
 func slabStrideARM64(fn *vm3.Function) int64 {
-	if slabKindARM64(fn) == slabKindMap {
+	switch slabKindARM64(fn) {
+	case slabKindMap:
 		return int64(vm3.JITMapSlabStride())
+	case slabKindF64Arr:
+		return int64(vm3.JITF64ArrSlabStride())
 	}
 	return int64(vm3.JITListSlabStride())
 }
@@ -1570,6 +1594,44 @@ func wordCountARM64Body(fn *vm3.Function, op vm3.Op, opts Options, spillSets []u
 		}
 		return 0, fmt.Errorf("%w: opcode %d (inline NewMap unsupported)", ErrNotImplemented, op.Code)
 
+	case vm3.OpNewF64Array:
+		// Phase 6.3.4.j.5.b: when fn.JITPreAllocF64ArrPrefix > 0 the JIT
+		// skips the contiguous OpNewF64Array prefix; jitCall allocates K
+		// typed arrays and seeds jf.regsCell[A] before the trampoline.
+		if idx < int(fn.JITPreAllocF64ArrPrefix) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("%w: opcode %d (inline NewF64Array unsupported)", ErrNotImplemented, op.Code)
+
+	case vm3.OpF64ArrayGetF64:
+		// Inline typed-f64-array load. Cold form (6 inst):
+		//   UXTW x16, w_cell ; MOV x17, #stride ; MUL ; ADD x16, x19 ;
+		//   LDR x16, [x16, #DATA_OFFSET] ; LDR Dt, [x16, xIdx, LSL #3]
+		// vmF64Array.data is a slice header at #DATA_OFFSET; the first 8
+		// bytes are the data.ptr, so a single LDR after the slab-byte-
+		// address compute gives the backing array, and an indexed LDR
+		// reads the f64 value bit-for-bit (no tag round-trip).
+		stride := int64(vm3.JITF64ArrSlabStride())
+		return movImm64WordCount(stride) + 5, nil
+
+	case vm3.OpF64ArraySetF64:
+		// Inline typed-f64-array store. Same shape as Get but the final
+		// instruction is STR Dt instead of LDR Dt. Stores the IEEE 754
+		// bits directly into data[idx], skipping the Cell payload pack
+		// step that OpListSetI64 needs for NaN-boxed int48.
+		stride := int64(vm3.JITF64ArrSlabStride())
+		return movImm64WordCount(stride) + 5, nil
+
+	case vm3.OpF64ArrayLenI64:
+		// Inline typed-f64-array len. Reads the slab-side u32 len field
+		// (which is bumped in lockstep with len(data) by Push, so it
+		// matches int64(len(data)) bit-for-bit) and zero-extends to i64
+		// via the W-form LDR. Cold form (5 inst):
+		//   UXTW x16, w_cell ; MOV x17, #stride ; MUL ; ADD x16, x19 ;
+		//   LDR Wd, [x16, #LEN_OFFSET]
+		stride := int64(vm3.JITF64ArrSlabStride())
+		return movImm64WordCount(stride) + 4, nil
+
 	default:
 		return 0, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
 	}
@@ -1955,6 +2017,15 @@ func emitInstrARM64Body(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deopt
 			// Phase 6.3.4.f.2 skip: jitCall pre-allocated the map and
 			// wrote the handle to regsCell[A]; prologue loaded it into
 			// the pinned reg before this PC. Emit zero words.
+			return []uint32{}, nil
+		}
+		return nil, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
+
+	case vm3.OpNewF64Array:
+		// Phase 6.3.4.j.5.b skip: jitCall pre-allocated K typed f64
+		// arrays and seeded jf.regsCell[A] for each pc in the prefix;
+		// the prologue loaded the handles into pinned cell regs.
+		if idx < int(fn.JITPreAllocF64ArrPrefix) {
 			return []uint32{}, nil
 		}
 		return nil, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
@@ -2551,6 +2622,77 @@ func emitInstrARM64Body(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deopt
 		ws = append(ws, addReg(16, 16, 19))
 		ws = append(ws, ldr64(17, 16, cellsOff/8))
 		ws = append(ws, strDRegLsl3(dB, 17, xIdx))
+		return ws, nil
+
+	case vm3.OpF64ArrayGetF64:
+		// regsF64[A] = arenas.F64Arrs[handleIdx(regsCell[B])].data[regsI64[C]]
+		//
+		// Cold form (6 inst):
+		//   UXTW x16, w_cell                  ; idx = handle & 0xFFFFFFFF
+		//   MOV  x17, #SIZEOF_VMF64ARRAY      ; stride
+		//   MUL  x16, x16, x17                ; slab byte offset
+		//   ADD  x16, x16, x19                ; x19 = cached f64arrs base
+		//   LDR  x16, [x16, #DATA_OFFSET]     ; data.ptr (first 8 bytes of slice hdr)
+		//   LDR  Dt,  [x16, xIdx, LSL #3]     ; data[idxReg] (raw f64 bits)
+		dataOff := uint32(vm3.JITF64ArrDataOffset())
+		xIdx := r2x(fn, uint16(op.C))
+		xCell := r2cell(op.B)
+		dA := r2d(op.A)
+		stride := int64(vm3.JITF64ArrSlabStride())
+		ws := make([]uint32, 0, movImm64WordCount(stride)+5)
+		ws = append(ws, uxtwReg(16, xCell))
+		ws = append(ws, movImm64(17, stride)...)
+		ws = append(ws, mulReg(16, 16, 17))
+		ws = append(ws, addReg(16, 16, 19))
+		ws = append(ws, ldr64(16, 16, dataOff/8))
+		ws = append(ws, ldrDRegLsl3(dA, 16, xIdx))
+		return ws, nil
+
+	case vm3.OpF64ArraySetF64:
+		// arenas.F64Arrs[handleIdx(regsCell[A])].data[regsI64[C]] = regsF64[B]
+		//
+		// Cold form (6 inst):
+		//   UXTW x16, w_cell                  ; idx = handle & 0xFFFFFFFF
+		//   MOV  x17, #SIZEOF_VMF64ARRAY      ; stride
+		//   MUL  x16, x16, x17                ; slab byte offset
+		//   ADD  x16, x16, x19                ; x19 = cached f64arrs base
+		//   LDR  x17, [x16, #DATA_OFFSET]     ; data.ptr
+		//   STR  Dt,  [x17, xIdx, LSL #3]     ; data[idxReg] = raw f64 bits
+		dataOff := uint32(vm3.JITF64ArrDataOffset())
+		xIdx := r2x(fn, uint16(op.C))
+		xCell := r2cell(op.A)
+		dB := r2d(op.B)
+		stride := int64(vm3.JITF64ArrSlabStride())
+		ws := make([]uint32, 0, movImm64WordCount(stride)+5)
+		ws = append(ws, uxtwReg(16, xCell))
+		ws = append(ws, movImm64(17, stride)...)
+		ws = append(ws, mulReg(16, 16, 17))
+		ws = append(ws, addReg(16, 16, 19))
+		ws = append(ws, ldr64(17, 16, dataOff/8))
+		ws = append(ws, strDRegLsl3(dB, 17, xIdx))
+		return ws, nil
+
+	case vm3.OpF64ArrayLenI64:
+		// regsI64[A] = int64(arenas.F64Arrs[handleIdx(regsCell[B])].len)
+		//
+		// Cold form (5 inst). The slab's u32 .len is bumped in lockstep
+		// with len(data) by AllocF64Arr/Push, so reading it matches
+		// int64(len(data)) bit-for-bit. The W-form LDR zero-extends into
+		// the 64-bit dest reg for free.
+		//   UXTW x16, w_cell                  ; idx = handle & 0xFFFFFFFF
+		//   MOV  x17, #SIZEOF_VMF64ARRAY      ; stride
+		//   MUL  x16, x16, x17                ; slab byte offset
+		//   ADD  x16, x16, x19                ; x19 = cached f64arrs base
+		//   LDR  Wd,  [x16, #LEN_OFFSET/4]    ; zero-extends to Xd
+		lenOff := uint32(vm3.JITF64ArrLenOffset())
+		xCell := r2cell(op.B)
+		stride := int64(vm3.JITF64ArrSlabStride())
+		ws := make([]uint32, 0, movImm64WordCount(stride)+4)
+		ws = append(ws, uxtwReg(16, xCell))
+		ws = append(ws, movImm64(17, stride)...)
+		ws = append(ws, mulReg(16, 16, 17))
+		ws = append(ws, addReg(16, 16, 19))
+		ws = append(ws, ldrW(xA, 16, lenOff/4))
 		return ws, nil
 
 	default:

--- a/runtime/jit/vm3jit/lower_common.go
+++ b/runtime/jit/vm3jit/lower_common.go
@@ -92,6 +92,44 @@ func hasMapOpI64(fn *vm3.Function) bool {
 	return hasMapSetI64I64(fn) || hasMapGetI64I64(fn)
 }
 
+// hasF64ArrayGetF64 reports whether fn contains any OpF64ArrayGetF64.
+func hasF64ArrayGetF64(fn *vm3.Function) bool {
+	for _, op := range fn.Code {
+		if op.Code == vm3.OpF64ArrayGetF64 {
+			return true
+		}
+	}
+	return false
+}
+
+// hasF64ArraySetF64 reports whether fn contains any OpF64ArraySetF64.
+func hasF64ArraySetF64(fn *vm3.Function) bool {
+	for _, op := range fn.Code {
+		if op.Code == vm3.OpF64ArraySetF64 {
+			return true
+		}
+	}
+	return false
+}
+
+// hasF64ArrayLenI64 reports whether fn contains any OpF64ArrayLenI64.
+func hasF64ArrayLenI64(fn *vm3.Function) bool {
+	for _, op := range fn.Code {
+		if op.Code == vm3.OpF64ArrayLenI64 {
+			return true
+		}
+	}
+	return false
+}
+
+// hasF64ArrayOp reports whether fn touches the F64Arr slab via any of
+// the JIT-lowered typed-f64-array ops (Phase 6.3.4.j.5.b). Used by the
+// prologue to decide whether to load f64ArrsBase into the slab-base
+// pin (x19 on ARM64).
+func hasF64ArrayOp(fn *vm3.Function) bool {
+	return hasF64ArrayGetF64(fn) || hasF64ArraySetF64(fn) || hasF64ArrayLenI64(fn)
+}
+
 // popcount32 counts set bits in v. Used to size OpCallI64 spill loops
 // on every backend.
 func popcount32(v uint32) int {

--- a/runtime/vm3/frame.go
+++ b/runtime/vm3/frame.go
@@ -96,12 +96,20 @@ type Function struct {
 	// and seeds jf.regsCell[A]; the JIT lowerer emits zero words for
 	// pc=0 so the prologue's LDR x_cell, [x3, #A*8] picks up the
 	// pre-seeded handle.
-	JITCode               unsafe.Pointer
-	JITCompiled           bool
-	JITHasF64             bool
-	JITPreAllocList       bool
-	JITPreAllocListPrefix uint16
-	JITPreAllocMap        bool
+	// JITPreAllocF64ArrPrefix (Phase 6.3.4.j.5.b) mirrors
+	// JITPreAllocListPrefix for the OpNewF64Array prefix shape. n_body and
+	// peers allocate position/velocity/mass arrays as a contiguous K-op
+	// run at fn entry; jitCall pre-allocates them on the Go side against
+	// the per-call arena snapshot and seeds regsCell[op.A]. The JIT lowerer
+	// emits zero words for those PCs so the prologue's LDR x_cell,
+	// [x3, #A*8] picks up the pre-seeded handle.
+	JITCode                  unsafe.Pointer
+	JITCompiled              bool
+	JITHasF64                bool
+	JITPreAllocList          bool
+	JITPreAllocListPrefix    uint16
+	JITPreAllocMap           bool
+	JITPreAllocF64ArrPrefix  uint16
 }
 
 // Bank identifies one of the three typed register banks.

--- a/runtime/vm3/jit_layout.go
+++ b/runtime/vm3/jit_layout.go
@@ -88,3 +88,37 @@ func (a *Arenas) JITMapsBase() unsafe.Pointer {
 	}
 	return unsafe.Pointer(&a.Maps[0])
 }
+
+// JITF64ArrSlabStride returns the byte distance between consecutive
+// vmF64Array entries in Arenas.F64Arrs. vm3jit bakes this as an
+// immediate when lowering OpF64ArrayGetF64 / OpF64ArraySetF64 /
+// OpF64ArrayLenI64 (Phase 6.3.4.j.5.b).
+func JITF64ArrSlabStride() uintptr {
+	return unsafe.Sizeof(vmF64Array{})
+}
+
+// JITF64ArrDataOffset returns the byte offset of the data slice header
+// within vmF64Array. The slice header at this offset is laid out as
+// {ptr u64, len u64, cap u64} per Go's slice header convention; vm3jit
+// loads the first 8 bytes (data.ptr) for typed f64 access.
+func JITF64ArrDataOffset() uintptr {
+	return unsafe.Offsetof(vmF64Array{}.data)
+}
+
+// JITF64ArrLenOffset returns the byte offset of the len field within
+// vmF64Array. OpF64ArrayLenI64 reads it as a u32 sign-extended to i64
+// (the slab's len is bumped in lockstep with len(data) by Push, so
+// reading the slab-side u32 matches int64(len(data))).
+func JITF64ArrLenOffset() uintptr {
+	return unsafe.Offsetof(vmF64Array{}.len)
+}
+
+// JITF64ArrsBase returns an unsafe.Pointer to the first element of
+// arenas.F64Arrs, or nil if the slab is empty. Mirror of JITListsBase
+// for the typed f64-array slab.
+func (a *Arenas) JITF64ArrsBase() unsafe.Pointer {
+	if len(a.F64Arrs) == 0 {
+		return nil
+	}
+	return unsafe.Pointer(&a.F64Arrs[0])
+}

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2175,6 +2175,57 @@ IR mirrors the surface 1-for-1: `compiler3/ir.OpNewF64Array` produces `TypeF64Ar
 
 **Exit gate.** Phase 6.3.4.j.5.a is the typed-surface foundation. Closing n_body under 2x of Go is gated on j.5.b (JIT lowering of the 5 new ops) + j.5.c (n_body kernel migration from `OpListGetF64`/`SetF64` to the typed forms).
 
+#### Phase 6.3.4.j.5.b: JIT lower F64Array ops (ARM64) (2026-05-20 11:45 GMT+7)
+
+**Why a separate sub-phase.** j.5.a stood up the typed-arena interp surface but `vm3jit` still routes every `OpF64Array*` instance through the slow path. n_body cannot be migrated to the typed surface in j.5.c until the JIT can lower the new ops; landing the lowering against synthetic correctness tests (no kernel re-shape) keeps the JIT change auditable on its own.
+
+**Surface admitted on ARM64.**
+
+- `OpNewF64Array` admitted only as a contiguous prefix at `fn.Code[0..K-1]`. The lowerer emits zero words for every PC in the prefix; `jitCall` pre-allocates `K` typed arrays against the per-call arena snapshot and seeds `jf.regsCell[op.A]` so the prologue's `LDR x_cell, [x3, #A*8]` picks up the handles. Inline `OpNewF64Array` outside the prefix still falls back to the interpreter (n_body and peers allocate position/velocity/mass arrays as a contiguous run at fn entry, which the prefix shape already covers).
+- `OpF64ArrayGetF64`, `OpF64ArraySetF64`, `OpF64ArrayLenI64` admitted unconditionally inside the cell-bank whitelist (mirror of the `OpListGetF64`/`OpListSetF64` admit). `OpF64ArrayPushF64` deliberately stays in the interpreter for j.5.b: it grows the backing slice via Go's `append`, which can rebase `Arenas.F64Arrs`'s element-data pointers, and the j.5.b base-snapshot is grow-aware only via deopt (no inline path exists yet).
+- **Mixed-slab rejection.** `slabKindARM64` now classifies fns into one of `{slabKindList, slabKindMap, slabKindF64Arr, slabKindNone}`; any fn touching more than one slab is rejected so the pinned `x19` base register specializes cleanly to one of `listsBase` / `mapsBase` / `f64ArrsBase` (the same offset/stride mechanic the existing list and map paths use).
+
+**Instruction sequences (ARM64, cold form, no hoist).** Each access pays the slab byte-address compute once per op; the j.5.b cold form mirrors `OpListGetF64`'s 6-instruction shape but reads/writes `data.ptr` (the first 8 bytes of `vmF64Array.data`'s slice header) instead of `cells.ptr`, and skips the cells-bank tag round trip because the typed slab stores raw IEEE 754 bits:
+
+```
+; OpF64ArrayGetF64, 6 inst (cold):
+UXTW x16, w_cell                  ; idx = handle & 0xFFFFFFFF
+MOV  x17, #SIZEOF_VMF64ARRAY      ; stride (32 bytes)
+MUL  x16, x16, x17                ; slab byte offset
+ADD  x16, x16, x19                ; x19 = cached f64ArrsBase
+LDR  x16, [x16, #DATA_OFFSET]     ; data.ptr (slice header head)
+LDR  Dt,  [x16, xIdx, LSL #3]     ; data[idxReg], raw f64 bits
+
+; OpF64ArraySetF64, 6 inst (cold):
+UXTW x16, w_cell
+MOV  x17, #SIZEOF_VMF64ARRAY
+MUL  x16, x16, x17
+ADD  x16, x16, x19
+LDR  x17, [x16, #DATA_OFFSET]     ; data.ptr
+STR  Dt,  [x17, xIdx, LSL #3]     ; data[idxReg] = raw f64 bits
+
+; OpF64ArrayLenI64, 5 inst (cold):
+UXTW x16, w_cell
+MOV  x17, #SIZEOF_VMF64ARRAY
+MUL  x16, x16, x17
+ADD  x16, x16, x19
+LDR  Wd,  [x16, #LEN_OFFSET/4]    ; W-form auto-zero-extends to Xd
+```
+
+The cold form is 1 instruction shorter than `OpListGetF64`'s cold form on the value side (no `SBFX` payload sign-extend) for the i64 case, and is bit-for-bit identical to the f64 list path on the f64 side (both store raw IEEE 754 bits, so neither needs a payload pack/unpack step). A hot form that hoists `data.ptr` per-cell mirroring `cellsPtrHoistedAt` is deferred to j.5.b.1 if benches show it; the j.5.c migration is the primary win and lands first.
+
+**Layout helpers and frame plumbing.**
+
+- `vm3.JITF64ArrSlabStride()`, `vm3.JITF64ArrDataOffset()`, `vm3.JITF64ArrLenOffset()` mirror the `JITList*` helpers; vm3jit bakes them as immediates so a future tweak to `vmF64Array`'s field order is picked up without touching the JIT.
+- `Arenas.JITF64ArrsBase()` returns `&a.F64Arrs[0]` (or nil when empty); `jitArenaCtx` gains `f64ArrsBase unsafe.Pointer` at byte offset 16. `populateArenaCtx` snapshots it every JIT entry alongside `listsBase` and `mapsBase`. The prologue's `slabBaseOffARM64` returns `16` for `slabKindF64Arr` so x19 loads the typed-array base; `slabStrideARM64` returns 32 (current `sizeof(vmF64Array)`).
+- `Function.JITPreAllocF64ArrPrefix uint16` mirrors `JITPreAllocListPrefix`. `CompileAndCache` sets it via `preAllocF64ArrPrefix(fn)`; `jitCall` reads it before the trampoline and calls `Arenas.AllocF64Arr(int(uint16(op.C)))` for each PC in the prefix.
+
+**Tests.** `runtime/jit/vm3jit/f64arr_arm64_test.go::TestF64ArrayJITGetSet` round-trips `{1.5, -2.25, 0.0, +Inf, -Inf}` through `NewF64Array(5)` + `SetF64` + `GetF64` + `AddF64` and asserts NaN equality on the resulting Inf-Inf sum (parity with the interp-side `TestF64ArrayGetSet`). The assert on `fn.JITCode != nil` confirms admission; the assert on `JITPreAllocF64ArrPrefix == 1` confirms the prefix-skip path is the one taken. `TestF64ArrayJITLen` covers `OpF64ArrayLenI64`'s W-form LDR auto-zero-extend on a `NewF64Array(7)` fn.
+
+**Performance.** No corpus kernel uses the new ops yet (j.5.c migrates n_body), so the bench surface is unchanged in j.5.b in isolation. The new tests are correctness-only; the perf landing is paid down in j.5.c against the n_body BG closure target.
+
+**Exit gate.** ARM64 admission gate met (synthetic correctness via the two JIT tests above; no regressions across the existing vm3 + vm3jit suites). AMD64 lowering follows the same shape and lands with j.5.c (cell-bank backend is deferred there per j.5.a's plan); `slabKindAMD64` and the corresponding emitters extend mechanically once the j.5.c kernel migration shows the n_body shape benefits on ARM64. The j.5.c sub-phase closes n_body under 2x of Go end-to-end.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
## Summary

- Admit typed `OpF64Array{Get,Set,Len}F64` in the vm3jit ARM64 cell-bank backend and lift `OpNewF64Array` as a contiguous prefix (mirror of `JITPreAllocListPrefix`).
- Add the 6/6/5 inst cold-form lowering for Get/Set/Len. `OpF64ArrayPushF64` and inline `OpNewF64Array` outside the prefix stay in the interpreter so the JIT's `f64ArrsBase` snapshot remains stable across the call.
- Wire layout helpers (`vm3.JITF64ArrSlabStride / JITF64ArrDataOffset / JITF64ArrLenOffset / Arenas.JITF64ArrsBase`) and extend `jitArenaCtx` with `f64ArrsBase` at byte offset 16.

Tracks #21794. Companion to #21793 (j.5.a interp landing). Gates the n_body kernel migration in j.5.c.

## Test plan

- [x] `go test ./runtime/vm3/... ./runtime/jit/vm3jit/...` passes (new tests + existing suites).
- [x] New `TestF64ArrayJITGetSet` round-trips `{1.5, -2.25, 0.0, +Inf, -Inf}` through `NewF64Array(5)` + `SetF64` + `GetF64` + `AddF64` and asserts NaN equality on the Inf-Inf sum (parity with the interp-side `TestF64ArrayGetSet`).
- [x] New `TestF64ArrayJITLen` covers `OpF64ArrayLenI64`'s cold form.
- [x] Existing `TestNBodyJITCompiles` still passes (no admit regression on the list-based kernel; the typed surface lands separately in j.5.c).
- [x] `npm run build` from repo root renders the MEP-40 j.5.b section cleanly.