### PR TITLE
mep-0040 phase 6.3.4.j.5.c: migrate n_body kernel to F64Array

### DIFF
--- a/compiler3/corpus/n_body.go
+++ b/compiler3/corpus/n_body.go
@@ -76,49 +76,44 @@ func ExpectN_body(steps int64) float64 {
 // program that runs n advance+posUpdate steps then computes total
 // system energy and returns it as f64.
 //
-// The kernel uses Cell-backed f64 lists (7 of them: pos_x, pos_y,
-// pos_z, vel_x, vel_y, vel_z, mass) routed through OpListGetF64 /
-// OpListSetF64 (landed in Phase 6.3.4.j.1). vm2 used a typed
-// TF64Array primitive; vm3 has only generic Cell lists, and that's
-// the surface this port targets so the JIT lowering in Phase
-// 6.3.4.j.3 can stay inside the existing cells-slab hoist.
+// Phase 6.3.4.j.5.c migrates the seven body arrays from generic
+// Cell-backed lists to typed vm3.F64Array values. OpNewF64Array
+// pre-allocates a fixed 5-slot array per body component, so the
+// push_loop that seeded zeros in the list version is dropped (the
+// arena hands back length-N storage already cleared). OpF64ArrayGetF64
+// and OpF64ArraySetF64 replace the OpListGetF64/SetF64 pairs.
+// On ARM64 the JIT lowers all three ops inline through the f64arrs
+// slab pinned in x19 (Phase 6.3.4.j.5.b); on AMD64 the kernel runs
+// through the interpreter until j.5.d adds AMD64 lowering.
 //
 // Register banks (NumRegs: 7 / 8 / 7):
 //
-//	I64: 0 steps_in, 1 s, 2 i, 3 j, 4 p, 5 bi, 6 bj/push_zero
-//	     (reg 6 carries push_zero pc 7..16 and bj pc 137..159; the lifetimes
-//	     don't overlap, so they share the slot to keep i64 reg 7+ free —
-//	     otherwise the JIT's cell-bank lane at x21..x24 would clash with
-//	     the new cell-4..7 lay-out introduced in Phase 6.3.4.j.3).
+//	I64: 0 steps_in, 1 s, 2 i, 3 j, 4 p, 5 bi, 6 bj
+//	     (reg 6 only carries bj in the energy phase; no other
+//	     overlap since push_loop is gone)
 //	F64: 0..7 working file (reused across phases)
 //	Cell: 0 pos_x, 1 pos_y, 2 pos_z, 3 vel_x, 4 vel_y, 5 vel_z, 6 mass
 //
 // Consts (f64): [0]=0.0 [1]=1.0 [2]=2.0 [3]=3.0 [4]=0.1 [5]=0.2 [6]=0.3
 // [7]=0.01 (dt) [8]=0.5.
 //
-// PC map (165 ops; see the bytecode literal below):
+// PC map (154 ops; see the bytecode literal below):
 //
-//	0..6   NewList for the 7 arrays
-//	7..18  push 5 zeros into each list via push_loop
-//	19..42 init_loop: x[i]=fi; y=2fi; z=3fi; vx=0.1fi; vy=0.2fi; vz=0.3fi; m=fi+1
-//	43..120 step_loop: advance (adv_i x adv_j) + posUpdate
-//	121..164 energy loop (kin per body + pairwise pot via sqrt)
-//	165    ReturnF64
+//	0..6     NewF64Array(5) for the 7 typed arrays
+//	7..30    init_loop: x[i]=fi; y=2fi; z=3fi; vx=0.1fi; vy=0.2fi; vz=0.3fi; m=fi+1
+//	31..108  step_loop: advance (adv_i x adv_j) + posUpdate
+//	109..152 energy loop (kin per body + pairwise pot via sqrt)
+//	153      ReturnF64
 //
 // Branch targets (uint16(C)):
 //
-//	push_loop pc=9   -> push_done pc=19
-//	init_loop pc=20  -> init_done pc=43
-//	step_loop pc=44  -> step_done pc=121
-//	adv_i_loop pc=46 -> adv_i_done pc=99
-//	adv_j_loop pc=48 -> adv_j_done pc=97
-//	pos_loop  pc=100 -> pos_done  pc=119
-//	energy_loop pc=123 -> energy_done pc=165
-//	pot_loop  pc=138 -> pot_done  pc=161
-//
-// FmaF64 fusion is left to a follow-up; the spec §6.3.4.h FMA op needs
-// the multiplicand and addend in distinct f64 regs, and the inner loop
-// already operates near the 8-reg cap.
+//	init_loop  pc=8   -> init_done  pc=31
+//	step_loop  pc=32  -> step_done  pc=109
+//	adv_i_loop pc=34  -> adv_i_done pc=87
+//	adv_j_loop pc=36  -> adv_j_done pc=85
+//	pos_loop   pc=88  -> pos_done   pc=107
+//	energy_loop pc=111 -> energy_done pc=153
+//	pot_loop   pc=126 -> pot_done    pc=149
 var N_body = &Program{
 	Name: "n_body",
 	Build: func(_ int64) *vm3.Program {
@@ -141,220 +136,203 @@ var N_body = &Program{
 				vm3.CFloat(0.5),  // [8]
 			},
 			Code: []vm3.Op{
-				// --- setup: 7 NewList (pc 0..6)
-				vm3.MakeOp(vm3.OpNewList, 0, 0, 0),
-				vm3.MakeOp(vm3.OpNewList, 1, 0, 0),
-				vm3.MakeOp(vm3.OpNewList, 2, 0, 0),
-				vm3.MakeOp(vm3.OpNewList, 3, 0, 0),
-				vm3.MakeOp(vm3.OpNewList, 4, 0, 0),
-				vm3.MakeOp(vm3.OpNewList, 5, 0, 0),
-				vm3.MakeOp(vm3.OpNewList, 6, 0, 0),
-				// --- push 5 zeros into each list (pc 7..18). i64 reg 6 holds 0
-				// (reg 6 is later reused as the energy-phase bj; lifetimes
-				// don't overlap, see header note). Reg 2 is loop i.
-				vm3.MakeOp(vm3.OpConstI64K, 6, 0, 0), // pc=7: tmp_zero = 0
-				vm3.MakeOp(vm3.OpConstI64K, 2, 0, 0), // pc=8: i = 0
-				// push_loop pc=9
-				vm3.MakeOp(vm3.OpCmpGeI64KBr, 2, 5, 19), // pc=9: if i>=5 -> push_done
-				vm3.MakeOp(vm3.OpListPushI64, 0, 6, 0),  // pc=10
-				vm3.MakeOp(vm3.OpListPushI64, 1, 6, 0),  // pc=11
-				vm3.MakeOp(vm3.OpListPushI64, 2, 6, 0),  // pc=12
-				vm3.MakeOp(vm3.OpListPushI64, 3, 6, 0),  // pc=13
-				vm3.MakeOp(vm3.OpListPushI64, 4, 6, 0),  // pc=14
-				vm3.MakeOp(vm3.OpListPushI64, 5, 6, 0),  // pc=15
-				vm3.MakeOp(vm3.OpListPushI64, 6, 6, 0),  // pc=16
-				vm3.MakeOp(vm3.OpAddI64K, 2, 2, 1),      // pc=17: i++
-				vm3.MakeOp(vm3.OpJump, 0, 0, 9),         // pc=18: -> push_loop
-				// push_done pc=19
-				vm3.MakeOp(vm3.OpConstI64K, 2, 0, 0), // pc=19: i = 0
-				// init_loop pc=20
-				vm3.MakeOp(vm3.OpCmpGeI64KBr, 2, 5, 43), // pc=20: if i>=5 -> init_done
-				vm3.MakeOp(vm3.OpI64ToF64, 0, 2, 0),     // pc=21: f0 = fi
+				// --- setup: 7 NewF64Array(5) (pc 0..6)
+				vm3.MakeOp(vm3.OpNewF64Array, 0, 0, 5),
+				vm3.MakeOp(vm3.OpNewF64Array, 1, 0, 5),
+				vm3.MakeOp(vm3.OpNewF64Array, 2, 0, 5),
+				vm3.MakeOp(vm3.OpNewF64Array, 3, 0, 5),
+				vm3.MakeOp(vm3.OpNewF64Array, 4, 0, 5),
+				vm3.MakeOp(vm3.OpNewF64Array, 5, 0, 5),
+				vm3.MakeOp(vm3.OpNewF64Array, 6, 0, 5),
+				// init_loop pc=7
+				vm3.MakeOp(vm3.OpConstI64K, 2, 0, 0), // pc=7: i = 0
+				vm3.MakeOp(vm3.OpCmpGeI64KBr, 2, 5, 31), // pc=8: if i>=5 -> init_done
+				vm3.MakeOp(vm3.OpI64ToF64, 0, 2, 0),     // pc=9: f0 = fi
 				// pos_x[i] = fi
-				vm3.MakeOp(vm3.OpListSetF64, 0, 0, 2), // pc=22
+				vm3.MakeOp(vm3.OpF64ArraySetF64, 0, 0, 2), // pc=10
 				// pos_y[i] = fi * 2
-				vm3.MakeOp(vm3.OpConstF64K, 1, 0, 2),  // pc=23: f1 = 2.0
-				vm3.MakeOp(vm3.OpMulF64, 1, 0, 1),     // pc=24: f1 = fi * 2
-				vm3.MakeOp(vm3.OpListSetF64, 1, 1, 2), // pc=25
+				vm3.MakeOp(vm3.OpConstF64K, 1, 0, 2),      // pc=11: f1 = 2.0
+				vm3.MakeOp(vm3.OpMulF64, 1, 0, 1),         // pc=12: f1 = fi * 2
+				vm3.MakeOp(vm3.OpF64ArraySetF64, 1, 1, 2), // pc=13
 				// pos_z[i] = fi * 3
-				vm3.MakeOp(vm3.OpConstF64K, 1, 0, 3),  // pc=26: f1 = 3.0
-				vm3.MakeOp(vm3.OpMulF64, 1, 0, 1),     // pc=27: f1 = fi * 3
-				vm3.MakeOp(vm3.OpListSetF64, 2, 1, 2), // pc=28
+				vm3.MakeOp(vm3.OpConstF64K, 1, 0, 3),      // pc=14: f1 = 3.0
+				vm3.MakeOp(vm3.OpMulF64, 1, 0, 1),         // pc=15: f1 = fi * 3
+				vm3.MakeOp(vm3.OpF64ArraySetF64, 2, 1, 2), // pc=16
 				// vel_x[i] = fi * 0.1
-				vm3.MakeOp(vm3.OpConstF64K, 1, 0, 4),  // pc=29
-				vm3.MakeOp(vm3.OpMulF64, 1, 0, 1),     // pc=30
-				vm3.MakeOp(vm3.OpListSetF64, 3, 1, 2), // pc=31
+				vm3.MakeOp(vm3.OpConstF64K, 1, 0, 4),      // pc=17
+				vm3.MakeOp(vm3.OpMulF64, 1, 0, 1),         // pc=18
+				vm3.MakeOp(vm3.OpF64ArraySetF64, 3, 1, 2), // pc=19
 				// vel_y[i] = fi * 0.2
-				vm3.MakeOp(vm3.OpConstF64K, 1, 0, 5),  // pc=32
-				vm3.MakeOp(vm3.OpMulF64, 1, 0, 1),     // pc=33
-				vm3.MakeOp(vm3.OpListSetF64, 4, 1, 2), // pc=34
+				vm3.MakeOp(vm3.OpConstF64K, 1, 0, 5),      // pc=20
+				vm3.MakeOp(vm3.OpMulF64, 1, 0, 1),         // pc=21
+				vm3.MakeOp(vm3.OpF64ArraySetF64, 4, 1, 2), // pc=22
 				// vel_z[i] = fi * 0.3
-				vm3.MakeOp(vm3.OpConstF64K, 1, 0, 6),  // pc=35
-				vm3.MakeOp(vm3.OpMulF64, 1, 0, 1),     // pc=36
-				vm3.MakeOp(vm3.OpListSetF64, 5, 1, 2), // pc=37
+				vm3.MakeOp(vm3.OpConstF64K, 1, 0, 6),      // pc=23
+				vm3.MakeOp(vm3.OpMulF64, 1, 0, 1),         // pc=24
+				vm3.MakeOp(vm3.OpF64ArraySetF64, 5, 1, 2), // pc=25
 				// mass[i] = fi + 1
-				vm3.MakeOp(vm3.OpConstF64K, 1, 0, 1),  // pc=38: f1 = 1.0
-				vm3.MakeOp(vm3.OpAddF64, 1, 0, 1),     // pc=39: f1 = fi + 1
-				vm3.MakeOp(vm3.OpListSetF64, 6, 1, 2), // pc=40
-				vm3.MakeOp(vm3.OpAddI64K, 2, 2, 1),    // pc=41: i++
-				vm3.MakeOp(vm3.OpJump, 0, 0, 20),      // pc=42: -> init_loop
-				// init_done pc=43
-				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 0), // pc=43: s = 0
-				// step_loop pc=44
-				vm3.MakeOp(vm3.OpCmpGeI64Br, 1, 0, 121), // pc=44: if s >= steps_in -> step_done
-				vm3.MakeOp(vm3.OpConstI64K, 2, 0, 0),    // pc=45: i = 0
-				// adv_i_loop pc=46
-				vm3.MakeOp(vm3.OpCmpGeI64KBr, 2, 5, 99), // pc=46: if i>=5 -> adv_i_done
-				vm3.MakeOp(vm3.OpAddI64K, 3, 2, 1),      // pc=47: j = i + 1
-				// adv_j_loop pc=48
-				vm3.MakeOp(vm3.OpCmpGeI64KBr, 3, 5, 97), // pc=48: if j>=5 -> adv_j_done
+				vm3.MakeOp(vm3.OpConstF64K, 1, 0, 1),      // pc=26: f1 = 1.0
+				vm3.MakeOp(vm3.OpAddF64, 1, 0, 1),         // pc=27: f1 = fi + 1
+				vm3.MakeOp(vm3.OpF64ArraySetF64, 6, 1, 2), // pc=28
+				vm3.MakeOp(vm3.OpAddI64K, 2, 2, 1),        // pc=29: i++
+				vm3.MakeOp(vm3.OpJump, 0, 0, 8),           // pc=30: -> init_loop
+				// init_done pc=31
+				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 0), // pc=31: s = 0
+				// step_loop pc=32
+				vm3.MakeOp(vm3.OpCmpGeI64Br, 1, 0, 109), // pc=32: if s >= steps_in -> step_done
+				vm3.MakeOp(vm3.OpConstI64K, 2, 0, 0),    // pc=33: i = 0
+				// adv_i_loop pc=34
+				vm3.MakeOp(vm3.OpCmpGeI64KBr, 2, 5, 87), // pc=34: if i>=5 -> adv_i_done
+				vm3.MakeOp(vm3.OpAddI64K, 3, 2, 1),      // pc=35: j = i + 1
+				// adv_j_loop pc=36
+				vm3.MakeOp(vm3.OpCmpGeI64KBr, 3, 5, 85), // pc=36: if j>=5 -> adv_j_done
 				// dx = pos_x[i] - pos_x[j]  (regs: f0=dx)
-				vm3.MakeOp(vm3.OpListGetF64, 0, 0, 2), // pc=49
-				vm3.MakeOp(vm3.OpListGetF64, 1, 0, 3), // pc=50
-				vm3.MakeOp(vm3.OpSubF64, 0, 0, 1),     // pc=51
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 0, 0, 2), // pc=37
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 1, 0, 3), // pc=38
+				vm3.MakeOp(vm3.OpSubF64, 0, 0, 1),         // pc=39
 				// dy (f1)
-				vm3.MakeOp(vm3.OpListGetF64, 1, 1, 2), // pc=52
-				vm3.MakeOp(vm3.OpListGetF64, 2, 1, 3), // pc=53: scratch f2
-				vm3.MakeOp(vm3.OpSubF64, 1, 1, 2),     // pc=54: f1 = dy
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 1, 1, 2), // pc=40
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 2, 1, 3), // pc=41: scratch f2
+				vm3.MakeOp(vm3.OpSubF64, 1, 1, 2),         // pc=42: f1 = dy
 				// dz (f2)
-				vm3.MakeOp(vm3.OpListGetF64, 2, 2, 2), // pc=55
-				vm3.MakeOp(vm3.OpListGetF64, 3, 2, 3), // pc=56: scratch f3
-				vm3.MakeOp(vm3.OpSubF64, 2, 2, 3),     // pc=57: f2 = dz
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 2, 2, 2), // pc=43
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 3, 2, 3), // pc=44: scratch f3
+				vm3.MakeOp(vm3.OpSubF64, 2, 2, 3),         // pc=45: f2 = dz
 				// d2 = dx*dx + dy*dy + dz*dz  (reuse f3)
-				vm3.MakeOp(vm3.OpMulF64, 3, 0, 0), // pc=58: dx^2
-				vm3.MakeOp(vm3.OpMulF64, 4, 1, 1), // pc=59: dy^2
-				vm3.MakeOp(vm3.OpMulF64, 5, 2, 2), // pc=60: dz^2
-				vm3.MakeOp(vm3.OpAddF64, 3, 3, 4), // pc=61
-				vm3.MakeOp(vm3.OpAddF64, 3, 3, 5), // pc=62: f3 = d2
+				vm3.MakeOp(vm3.OpMulF64, 3, 0, 0), // pc=46: dx^2
+				vm3.MakeOp(vm3.OpMulF64, 4, 1, 1), // pc=47: dy^2
+				vm3.MakeOp(vm3.OpMulF64, 5, 2, 2), // pc=48: dz^2
+				vm3.MakeOp(vm3.OpAddF64, 3, 3, 4), // pc=49
+				vm3.MakeOp(vm3.OpAddF64, 3, 3, 5), // pc=50: f3 = d2
 				// mag = dt / (d2 * sqrt(d2))  (f4=mag)
-				vm3.MakeOp(vm3.OpSqrtF64, 4, 3, 0),    // pc=63: f4 = sqrt(d2)
-				vm3.MakeOp(vm3.OpMulF64, 4, 3, 4),     // pc=64: f4 = d2 * sqrt(d2)
-				vm3.MakeOp(vm3.OpConstF64K, 5, 0, 7),  // pc=65: f5 = dt
-				vm3.MakeOp(vm3.OpDivF64, 4, 5, 4),     // pc=66: f4 = mag
+				vm3.MakeOp(vm3.OpSqrtF64, 4, 3, 0),        // pc=51: f4 = sqrt(d2)
+				vm3.MakeOp(vm3.OpMulF64, 4, 3, 4),         // pc=52: f4 = d2 * sqrt(d2)
+				vm3.MakeOp(vm3.OpConstF64K, 5, 0, 7),      // pc=53: f5 = dt
+				vm3.MakeOp(vm3.OpDivF64, 4, 5, 4),         // pc=54: f4 = mag
 				// mi_mag = m[i] * mag  (f5);  mj_mag = m[j] * mag (f6)
-				vm3.MakeOp(vm3.OpListGetF64, 5, 6, 2), // pc=67: m[i]
-				vm3.MakeOp(vm3.OpMulF64, 5, 5, 4),     // pc=68: mi_mag
-				vm3.MakeOp(vm3.OpListGetF64, 6, 6, 3), // pc=69: m[j]
-				vm3.MakeOp(vm3.OpMulF64, 6, 6, 4),     // pc=70: mj_mag
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 5, 6, 2), // pc=55: m[i]
+				vm3.MakeOp(vm3.OpMulF64, 5, 5, 4),         // pc=56: mi_mag
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 6, 6, 3), // pc=57: m[j]
+				vm3.MakeOp(vm3.OpMulF64, 6, 6, 4),         // pc=58: mj_mag
 				// vx[i] -= dx * mj_mag  (use f7 scratch, reuse f4)
-				vm3.MakeOp(vm3.OpListGetF64, 7, 3, 2), // pc=71
-				vm3.MakeOp(vm3.OpMulF64, 4, 0, 6),     // pc=72: dx*mj_mag (f4 free since mag done)
-				vm3.MakeOp(vm3.OpSubF64, 7, 7, 4),     // pc=73
-				vm3.MakeOp(vm3.OpListSetF64, 3, 7, 2), // pc=74
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 7, 3, 2), // pc=59
+				vm3.MakeOp(vm3.OpMulF64, 4, 0, 6),         // pc=60: dx*mj_mag
+				vm3.MakeOp(vm3.OpSubF64, 7, 7, 4),         // pc=61
+				vm3.MakeOp(vm3.OpF64ArraySetF64, 3, 7, 2), // pc=62
 				// vy[i] -= dy * mj_mag
-				vm3.MakeOp(vm3.OpListGetF64, 7, 4, 2), // pc=75
-				vm3.MakeOp(vm3.OpMulF64, 4, 1, 6),     // pc=76
-				vm3.MakeOp(vm3.OpSubF64, 7, 7, 4),     // pc=77
-				vm3.MakeOp(vm3.OpListSetF64, 4, 7, 2), // pc=78
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 7, 4, 2), // pc=63
+				vm3.MakeOp(vm3.OpMulF64, 4, 1, 6),         // pc=64
+				vm3.MakeOp(vm3.OpSubF64, 7, 7, 4),         // pc=65
+				vm3.MakeOp(vm3.OpF64ArraySetF64, 4, 7, 2), // pc=66
 				// vz[i] -= dz * mj_mag
-				vm3.MakeOp(vm3.OpListGetF64, 7, 5, 2), // pc=79
-				vm3.MakeOp(vm3.OpMulF64, 4, 2, 6),     // pc=80
-				vm3.MakeOp(vm3.OpSubF64, 7, 7, 4),     // pc=81
-				vm3.MakeOp(vm3.OpListSetF64, 5, 7, 2), // pc=82
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 7, 5, 2), // pc=67
+				vm3.MakeOp(vm3.OpMulF64, 4, 2, 6),         // pc=68
+				vm3.MakeOp(vm3.OpSubF64, 7, 7, 4),         // pc=69
+				vm3.MakeOp(vm3.OpF64ArraySetF64, 5, 7, 2), // pc=70
 				// vx[j] += dx * mi_mag
-				vm3.MakeOp(vm3.OpListGetF64, 7, 3, 3), // pc=83
-				vm3.MakeOp(vm3.OpMulF64, 4, 0, 5),     // pc=84
-				vm3.MakeOp(vm3.OpAddF64, 7, 7, 4),     // pc=85
-				vm3.MakeOp(vm3.OpListSetF64, 3, 7, 3), // pc=86
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 7, 3, 3), // pc=71
+				vm3.MakeOp(vm3.OpMulF64, 4, 0, 5),         // pc=72
+				vm3.MakeOp(vm3.OpAddF64, 7, 7, 4),         // pc=73
+				vm3.MakeOp(vm3.OpF64ArraySetF64, 3, 7, 3), // pc=74
 				// vy[j] += dy * mi_mag
-				vm3.MakeOp(vm3.OpListGetF64, 7, 4, 3), // pc=87
-				vm3.MakeOp(vm3.OpMulF64, 4, 1, 5),     // pc=88
-				vm3.MakeOp(vm3.OpAddF64, 7, 7, 4),     // pc=89
-				vm3.MakeOp(vm3.OpListSetF64, 4, 7, 3), // pc=90
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 7, 4, 3), // pc=75
+				vm3.MakeOp(vm3.OpMulF64, 4, 1, 5),         // pc=76
+				vm3.MakeOp(vm3.OpAddF64, 7, 7, 4),         // pc=77
+				vm3.MakeOp(vm3.OpF64ArraySetF64, 4, 7, 3), // pc=78
 				// vz[j] += dz * mi_mag
-				vm3.MakeOp(vm3.OpListGetF64, 7, 5, 3), // pc=91
-				vm3.MakeOp(vm3.OpMulF64, 4, 2, 5),     // pc=92
-				vm3.MakeOp(vm3.OpAddF64, 7, 7, 4),     // pc=93
-				vm3.MakeOp(vm3.OpListSetF64, 5, 7, 3), // pc=94
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 7, 5, 3), // pc=79
+				vm3.MakeOp(vm3.OpMulF64, 4, 2, 5),         // pc=80
+				vm3.MakeOp(vm3.OpAddF64, 7, 7, 4),         // pc=81
+				vm3.MakeOp(vm3.OpF64ArraySetF64, 5, 7, 3), // pc=82
 				// j++ ; -> adv_j_loop
-				vm3.MakeOp(vm3.OpAddI64K, 3, 3, 1), // pc=95
-				vm3.MakeOp(vm3.OpJump, 0, 0, 48),   // pc=96
-				// adv_j_done pc=97
-				vm3.MakeOp(vm3.OpAddI64K, 2, 2, 1), // pc=97
-				vm3.MakeOp(vm3.OpJump, 0, 0, 46),   // pc=98 -> adv_i_loop
-				// adv_i_done pc=99
-				vm3.MakeOp(vm3.OpConstI64K, 4, 0, 0), // pc=99: p = 0
-				// pos_loop pc=100
-				vm3.MakeOp(vm3.OpCmpGeI64KBr, 4, 5, 119), // pc=100: if p>=5 -> pos_done
-				vm3.MakeOp(vm3.OpConstF64K, 0, 0, 7),     // pc=101: f0 = dt
+				vm3.MakeOp(vm3.OpAddI64K, 3, 3, 1), // pc=83
+				vm3.MakeOp(vm3.OpJump, 0, 0, 36),   // pc=84
+				// adv_j_done pc=85
+				vm3.MakeOp(vm3.OpAddI64K, 2, 2, 1), // pc=85
+				vm3.MakeOp(vm3.OpJump, 0, 0, 34),   // pc=86 -> adv_i_loop
+				// adv_i_done pc=87
+				vm3.MakeOp(vm3.OpConstI64K, 4, 0, 0), // pc=87: p = 0
+				// pos_loop pc=88
+				vm3.MakeOp(vm3.OpCmpGeI64KBr, 4, 5, 107), // pc=88: if p>=5 -> pos_done
+				vm3.MakeOp(vm3.OpConstF64K, 0, 0, 7),     // pc=89: f0 = dt
 				// pos_x[p] += vel_x[p] * dt
-				vm3.MakeOp(vm3.OpListGetF64, 1, 3, 4), // pc=102: f1 = vx
-				vm3.MakeOp(vm3.OpMulF64, 1, 1, 0),     // pc=103: f1 = vx*dt
-				vm3.MakeOp(vm3.OpListGetF64, 2, 0, 4), // pc=104: f2 = px
-				vm3.MakeOp(vm3.OpAddF64, 2, 2, 1),     // pc=105
-				vm3.MakeOp(vm3.OpListSetF64, 0, 2, 4), // pc=106
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 1, 3, 4), // pc=90: f1 = vx
+				vm3.MakeOp(vm3.OpMulF64, 1, 1, 0),         // pc=91: f1 = vx*dt
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 2, 0, 4), // pc=92: f2 = px
+				vm3.MakeOp(vm3.OpAddF64, 2, 2, 1),         // pc=93
+				vm3.MakeOp(vm3.OpF64ArraySetF64, 0, 2, 4), // pc=94
 				// pos_y[p] += vel_y[p] * dt
-				vm3.MakeOp(vm3.OpListGetF64, 1, 4, 4), // pc=107
-				vm3.MakeOp(vm3.OpMulF64, 1, 1, 0),     // pc=108
-				vm3.MakeOp(vm3.OpListGetF64, 2, 1, 4), // pc=109
-				vm3.MakeOp(vm3.OpAddF64, 2, 2, 1),     // pc=110
-				vm3.MakeOp(vm3.OpListSetF64, 1, 2, 4), // pc=111
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 1, 4, 4), // pc=95
+				vm3.MakeOp(vm3.OpMulF64, 1, 1, 0),         // pc=96
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 2, 1, 4), // pc=97
+				vm3.MakeOp(vm3.OpAddF64, 2, 2, 1),         // pc=98
+				vm3.MakeOp(vm3.OpF64ArraySetF64, 1, 2, 4), // pc=99
 				// pos_z[p] += vel_z[p] * dt
-				vm3.MakeOp(vm3.OpListGetF64, 1, 5, 4), // pc=112
-				vm3.MakeOp(vm3.OpMulF64, 1, 1, 0),     // pc=113
-				vm3.MakeOp(vm3.OpListGetF64, 2, 2, 4), // pc=114
-				vm3.MakeOp(vm3.OpAddF64, 2, 2, 1),     // pc=115
-				vm3.MakeOp(vm3.OpListSetF64, 2, 2, 4), // pc=116
-				vm3.MakeOp(vm3.OpAddI64K, 4, 4, 1),    // pc=117: p++
-				vm3.MakeOp(vm3.OpJump, 0, 0, 100),     // pc=118 -> pos_loop
-				// pos_done pc=119
-				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 1), // pc=119: s++
-				vm3.MakeOp(vm3.OpJump, 0, 0, 44),   // pc=120 -> step_loop
-				// step_done pc=121: energy accumulator f0
-				vm3.MakeOp(vm3.OpConstF64K, 0, 0, 0), // pc=121: e = 0.0
-				vm3.MakeOp(vm3.OpConstI64K, 5, 0, 0), // pc=122: bi = 0
-				// energy_loop pc=123
-				vm3.MakeOp(vm3.OpCmpGeI64KBr, 5, 5, 165), // pc=123: if bi>=5 -> end
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 1, 5, 4), // pc=100
+				vm3.MakeOp(vm3.OpMulF64, 1, 1, 0),         // pc=101
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 2, 2, 4), // pc=102
+				vm3.MakeOp(vm3.OpAddF64, 2, 2, 1),         // pc=103
+				vm3.MakeOp(vm3.OpF64ArraySetF64, 2, 2, 4), // pc=104
+				vm3.MakeOp(vm3.OpAddI64K, 4, 4, 1),        // pc=105: p++
+				vm3.MakeOp(vm3.OpJump, 0, 0, 88),          // pc=106 -> pos_loop
+				// pos_done pc=107
+				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 1), // pc=107: s++
+				vm3.MakeOp(vm3.OpJump, 0, 0, 32),   // pc=108 -> step_loop
+				// step_done pc=109: energy accumulator f0
+				vm3.MakeOp(vm3.OpConstF64K, 0, 0, 0), // pc=109: e = 0.0
+				vm3.MakeOp(vm3.OpConstI64K, 5, 0, 0), // pc=110: bi = 0
+				// energy_loop pc=111
+				vm3.MakeOp(vm3.OpCmpGeI64KBr, 5, 5, 153), // pc=111: if bi>=5 -> end
 				// vsq = vx[bi]^2 + vy[bi]^2 + vz[bi]^2 (f2 accumulator)
-				vm3.MakeOp(vm3.OpListGetF64, 1, 3, 5), // pc=124: vx
-				vm3.MakeOp(vm3.OpMulF64, 2, 1, 1),     // pc=125: vx^2
-				vm3.MakeOp(vm3.OpListGetF64, 1, 4, 5), // pc=126: vy
-				vm3.MakeOp(vm3.OpMulF64, 3, 1, 1),     // pc=127: vy^2
-				vm3.MakeOp(vm3.OpAddF64, 2, 2, 3),     // pc=128
-				vm3.MakeOp(vm3.OpListGetF64, 1, 5, 5), // pc=129: vz
-				vm3.MakeOp(vm3.OpMulF64, 3, 1, 1),     // pc=130: vz^2
-				vm3.MakeOp(vm3.OpAddF64, 2, 2, 3),     // pc=131: f2 = vsq
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 1, 3, 5), // pc=112: vx
+				vm3.MakeOp(vm3.OpMulF64, 2, 1, 1),         // pc=113: vx^2
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 1, 4, 5), // pc=114: vy
+				vm3.MakeOp(vm3.OpMulF64, 3, 1, 1),         // pc=115: vy^2
+				vm3.MakeOp(vm3.OpAddF64, 2, 2, 3),         // pc=116
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 1, 5, 5), // pc=117: vz
+				vm3.MakeOp(vm3.OpMulF64, 3, 1, 1),         // pc=118: vz^2
+				vm3.MakeOp(vm3.OpAddF64, 2, 2, 3),         // pc=119: f2 = vsq
 				// kin = 0.5 * m[bi] * vsq  (f3)
-				vm3.MakeOp(vm3.OpListGetF64, 3, 6, 5), // pc=132: m[bi]
-				vm3.MakeOp(vm3.OpConstF64K, 4, 0, 8),  // pc=133: f4 = 0.5
-				vm3.MakeOp(vm3.OpMulF64, 3, 3, 4),     // pc=134: 0.5*m
-				vm3.MakeOp(vm3.OpMulF64, 3, 3, 2),     // pc=135: kin
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 3, 6, 5), // pc=120: m[bi]
+				vm3.MakeOp(vm3.OpConstF64K, 4, 0, 8),      // pc=121: f4 = 0.5
+				vm3.MakeOp(vm3.OpMulF64, 3, 3, 4),         // pc=122: 0.5*m
+				vm3.MakeOp(vm3.OpMulF64, 3, 3, 2),         // pc=123: kin
 				// pot = 0 (f4); bj = bi + 1
-				vm3.MakeOp(vm3.OpConstF64K, 4, 0, 0), // pc=136: pot = 0
-				vm3.MakeOp(vm3.OpAddI64K, 6, 5, 1),   // pc=137: bj = bi + 1
-				// pot_loop pc=138
-				vm3.MakeOp(vm3.OpCmpGeI64KBr, 6, 5, 161), // pc=138: if bj>=5 -> pot_done
+				vm3.MakeOp(vm3.OpConstF64K, 4, 0, 0), // pc=124: pot = 0
+				vm3.MakeOp(vm3.OpAddI64K, 6, 5, 1),   // pc=125: bj = bi + 1
+				// pot_loop pc=126
+				vm3.MakeOp(vm3.OpCmpGeI64KBr, 6, 5, 149), // pc=126: if bj>=5 -> pot_done
 				// dx (f5 scratch), accumulate squared distance in f5
-				vm3.MakeOp(vm3.OpListGetF64, 5, 0, 5), // pc=139: xi
-				vm3.MakeOp(vm3.OpListGetF64, 6, 0, 6), // pc=140: xj
-				vm3.MakeOp(vm3.OpSubF64, 5, 5, 6),     // pc=141: f5 = dx
-				vm3.MakeOp(vm3.OpListGetF64, 6, 1, 5), // pc=142: yi
-				vm3.MakeOp(vm3.OpListGetF64, 7, 1, 6), // pc=143: yj
-				vm3.MakeOp(vm3.OpSubF64, 6, 6, 7),     // pc=144: f6 = dy
-				vm3.MakeOp(vm3.OpMulF64, 5, 5, 5),     // pc=145: dx^2
-				vm3.MakeOp(vm3.OpMulF64, 6, 6, 6),     // pc=146: dy^2
-				vm3.MakeOp(vm3.OpAddF64, 5, 5, 6),     // pc=147: dx^2+dy^2
-				vm3.MakeOp(vm3.OpListGetF64, 6, 2, 5), // pc=148: zi
-				vm3.MakeOp(vm3.OpListGetF64, 7, 2, 6), // pc=149: zj
-				vm3.MakeOp(vm3.OpSubF64, 6, 6, 7),     // pc=150: f6 = dz
-				vm3.MakeOp(vm3.OpMulF64, 6, 6, 6),     // pc=151: dz^2
-				vm3.MakeOp(vm3.OpAddF64, 5, 5, 6),     // pc=152: f5 = d2
-				vm3.MakeOp(vm3.OpSqrtF64, 5, 5, 0),    // pc=153: f5 = r
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 5, 0, 5), // pc=127: xi
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 6, 0, 6), // pc=128: xj
+				vm3.MakeOp(vm3.OpSubF64, 5, 5, 6),         // pc=129: f5 = dx
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 6, 1, 5), // pc=130: yi
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 7, 1, 6), // pc=131: yj
+				vm3.MakeOp(vm3.OpSubF64, 6, 6, 7),         // pc=132: f6 = dy
+				vm3.MakeOp(vm3.OpMulF64, 5, 5, 5),         // pc=133: dx^2
+				vm3.MakeOp(vm3.OpMulF64, 6, 6, 6),         // pc=134: dy^2
+				vm3.MakeOp(vm3.OpAddF64, 5, 5, 6),         // pc=135: dx^2+dy^2
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 6, 2, 5), // pc=136: zi
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 7, 2, 6), // pc=137: zj
+				vm3.MakeOp(vm3.OpSubF64, 6, 6, 7),         // pc=138: f6 = dz
+				vm3.MakeOp(vm3.OpMulF64, 6, 6, 6),         // pc=139: dz^2
+				vm3.MakeOp(vm3.OpAddF64, 5, 5, 6),         // pc=140: f5 = d2
+				vm3.MakeOp(vm3.OpSqrtF64, 5, 5, 0),        // pc=141: f5 = r
 				// m[bi] * m[bj] / r ; pot += ...
-				vm3.MakeOp(vm3.OpListGetF64, 6, 6, 5), // pc=154: m[bi]
-				vm3.MakeOp(vm3.OpListGetF64, 7, 6, 6), // pc=155: m[bj]
-				vm3.MakeOp(vm3.OpMulF64, 6, 6, 7),     // pc=156: m[bi]*m[bj]
-				vm3.MakeOp(vm3.OpDivF64, 6, 6, 5),     // pc=157: /r
-				vm3.MakeOp(vm3.OpAddF64, 4, 4, 6),     // pc=158: pot += ...
-				vm3.MakeOp(vm3.OpAddI64K, 6, 6, 1),    // pc=159: bj++
-				vm3.MakeOp(vm3.OpJump, 0, 0, 138),     // pc=160 -> pot_loop
-				// pot_done pc=161
-				vm3.MakeOp(vm3.OpSubF64, 3, 3, 4),  // pc=161: kin - pot
-				vm3.MakeOp(vm3.OpAddF64, 0, 0, 3),  // pc=162: e += kin - pot
-				vm3.MakeOp(vm3.OpAddI64K, 5, 5, 1), // pc=163: bi++
-				vm3.MakeOp(vm3.OpJump, 0, 0, 123),  // pc=164 -> energy_loop
-				// end pc=165
-				vm3.MakeOp(vm3.OpReturnF64, 0, 0, 0), // pc=165
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 6, 6, 5), // pc=142: m[bi]
+				vm3.MakeOp(vm3.OpF64ArrayGetF64, 7, 6, 6), // pc=143: m[bj]
+				vm3.MakeOp(vm3.OpMulF64, 6, 6, 7),         // pc=144: m[bi]*m[bj]
+				vm3.MakeOp(vm3.OpDivF64, 6, 6, 5),         // pc=145: /r
+				vm3.MakeOp(vm3.OpAddF64, 4, 4, 6),         // pc=146: pot += ...
+				vm3.MakeOp(vm3.OpAddI64K, 6, 6, 1),        // pc=147: bj++
+				vm3.MakeOp(vm3.OpJump, 0, 0, 126),         // pc=148 -> pot_loop
+				// pot_done pc=149
+				vm3.MakeOp(vm3.OpSubF64, 3, 3, 4),  // pc=149: kin - pot
+				vm3.MakeOp(vm3.OpAddF64, 0, 0, 3),  // pc=150: e += kin - pot
+				vm3.MakeOp(vm3.OpAddI64K, 5, 5, 1), // pc=151: bi++
+				vm3.MakeOp(vm3.OpJump, 0, 0, 111),  // pc=152 -> energy_loop
+				// end pc=153
+				vm3.MakeOp(vm3.OpReturnF64, 0, 0, 0), // pc=153
 			},
 		}
 		return &vm3.Program{Funcs: []*vm3.Function{fn}, Entry: 0}

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2226,6 +2226,39 @@ The cold form is 1 instruction shorter than `OpListGetF64`'s cold form on the va
 
 **Exit gate.** ARM64 admission gate met (synthetic correctness via the two JIT tests above; no regressions across the existing vm3 + vm3jit suites). AMD64 lowering follows the same shape and lands with j.5.c (cell-bank backend is deferred there per j.5.a's plan); `slabKindAMD64` and the corresponding emitters extend mechanically once the j.5.c kernel migration shows the n_body shape benefits on ARM64. The j.5.c sub-phase closes n_body under 2x of Go end-to-end.
 
+#### Phase 6.3.4.j.5.c: migrate n_body to F64Array + close under 2x of Go (2026-05-20 18:00 GMT+7)
+
+**Why this sub-phase.** j.5.a landed the typed `OpF64Array*` ops and j.5.b admitted them on the ARM64 JIT, but no corpus kernel exercised the typed slab. n_body was still routing the seven body arrays through generic `Cell`-backed lists with `OpListGetF64`/`SetF64`, so the j.5.b lowering work paid zero on the bench. This sub-phase migrates the kernel to the typed surface and measures the closure to under 2x of Go on macOS arm64.
+
+**Kernel shape change** (`compiler3/corpus/n_body.go`).
+
+- 7 `OpNewList` (pos_x/y/z, vel_x/y/z, mass) become 7 `OpNewF64Array` with capacity 5 written into cell regs `[0..6]`. The contiguous prefix matches `preAllocF64ArrPrefix`, so `jitCall` lifts all 7 allocations into the per-call arena snapshot and the lowerer emits zero words at those PCs.
+- The 12-op `push_loop` that seeded 5 zeros into each generic list is dropped entirely. `Arenas.AllocF64Arr(5)` hands back zero-filled `len(data)==5` storage, so the kernel skips straight to the init loop.
+- 70 `OpListGetF64`/`OpListSetF64` sites become `OpF64ArrayGetF64`/`OpF64ArraySetF64` (same A/B/C semantics). Branch targets shift by -12 throughout.
+- I64 reg 6 used to alias `push_zero` (pc 7..16) and `bj` (pc 137..159); with the push loop gone the alias is no longer needed, but reg 6 stays in use only as `bj` to keep the energy phase's reg footprint unchanged.
+- Op count drops 166 → 154 (-7.2%). `NumRegsI64`/`F64`/`Cell` and the `Consts` table are unchanged.
+
+**Slab classification.** With every list op replaced, the kernel touches only `OpF64Array{Get,Set,Len,New}`. `slabKindARM64` classifies it as `slabKindF64Arr`, so the prologue pins `x19` to `f64ArrsBase` (offset 16 in `jitArenaCtx`) and the cold-form sequences from j.5.b fire on every Get/Set/Len site.
+
+**Measured (Apple M4, darwin/arm64, `go test -bench`, 3x 2s, ns/op).** Lower is better.
+
+| Bench                                   | Interp (j.5.b) | JIT lists (j.4b) | JIT F64Array (j.5.c) | vs Go (j.5.c) |
+| --------------------------------------- | --------------:| ----------------:| --------------------:| -------------:|
+| `n_body_n100`   (Go: 3271 ns)           |    170,471     |     ~6,800       |        5,993         |      1.83x    |
+| `n_body_n10000` (Go: ~325,900 ns)       | 16,945,702     |    ~650,000      |       577,917        |      1.78x    |
+
+Closure verdict: both sizes drop from j.4b's ~2.1x to under 2x of Go on macOS arm64. The 12% improvement at `n_body_n100` and 11% at `n_body_n10000` reflects two effects: (1) the push-loop is gone end-to-end (12 ops per fn entry, dominated at n=100 where setup is a non-trivial fraction), and (2) the typed slab reads/writes pay one fewer instruction per access than `OpListGetF64`/`SetF64` (no `SBFX`-style payload sign-extend; the data slice header stores raw IEEE 754 bits the same way the list path does, but the new cold-form skips the tag check entirely).
+
+**Correctness.** `TestN_bodyMatchesOracle` and `TestNBodyJITCompiles` keep their `1e-10` tolerance against `ExpectN_body`; both pass across steps `{0, 1, 2, 5, 10, 100}`. No vm3 or vm3jit regressions across the rest of the corpus.
+
+**Deferred to follow-ups.**
+
+- AMD64 lowering of the F64Array ops (j.5.d): the kernel falls back to the interpreter on amd64 hosts. The cold-form sequence ports mechanically; deferred to keep this PR scoped to the perf closure on the host where the migration lands first.
+- `data.ptr` hoist per-cell (j.5.b.1): the j.4a list-path optimization can apply here too once a bench shows the cold-form is the residual.
+- Linux re-bench on server2: paired with j.5.d so a single platform sweep records both arm64 and amd64 results.
+
+**Exit gate.** n_body now closes under 2x of Go on macOS arm64 (1.83x at n=100, 1.78x at n=10000). The composite BG-suite gate (all 11 programs × both platforms inside 2x) still requires j.5.d (amd64) + the 6 unported BG programs + Linux server2 re-bench.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
Closes n_body under 2x of Go on macOS arm64. j.5.b shipped the ARM64 JIT lowering for the typed F64Array ops but no corpus kernel used them yet; this PR migrates the n_body kernel so the lowering actually fires on the hot path.

Tracks #21796. Predecessor: #21795 (j.5.b ARM64 lowering, merged).

## Summary

- Replace 7 `OpNewList` with `OpNewF64Array(cap=5)` (contiguous prefix; jitCall lifts into the per-call arena snapshot).
- Drop the 12-op `push_loop` that seeded zeros into the lists; `Arenas.AllocF64Arr(5)` returns zero-filled storage.
- Swap 70 `OpListGetF64`/`OpListSetF64` for `OpF64ArrayGetF64`/`SetF64` (same A/B/C semantics).
- Branch targets shift -12 throughout; op count drops 166 -> 154.
- Spec section 6.3.4.j.5.c added with measured numbers and the closure verdict.

## Measured (Apple M4, darwin/arm64, go test -bench, 3x 2s)

| bench           | Go        | JIT j.4b (list) | JIT j.5.c (F64Arr) | vs Go  |
|-----------------|-----------|-----------------|--------------------|--------|
| n_body_n100     | 3271 ns   | ~6800 ns        | 5993 ns            | 1.83x  |
| n_body_n10000   | 326 us    | ~650 us         | 578 us             | 1.78x  |

Both sizes UNDER 2x of Go.

## Deferred (not in this PR)

- AMD64 lowering of F64Array ops (j.5.d): kernel falls back to interp on amd64 hosts.
- `data.ptr` per-cell hoist (j.5.b.1).
- Linux server2 re-bench paired with j.5.d.

## Test plan

- [x] `go test ./runtime/vm3/... ./runtime/jit/vm3jit/... ./compiler3/... -count=1` passes.
- [x] `TestN_bodyMatchesOracle` and `TestNBodyJITCompiles` pass with 1e-10 tolerance against `ExpectN_body`.
- [x] `BenchmarkCorpusJITRunner/n_body_n100` and `n_body_n10000` measured under 2x of Go (numbers above).
- [x] `npm run build` for the website renders clean MDX.