### PR TITLE
mep-0040 phase 6.3.4.l.2: port fannkuch_redux to compiler3 + JIT closure

### DIFF
--- a/compiler3/corpus/corpus.go
+++ b/compiler3/corpus/corpus.go
@@ -31,5 +31,6 @@ func All() []*Program {
 		KNucleotide,
 		N_body,
 		SpectralNorm,
+		FannkuchRedux,
 	}
 }

--- a/compiler3/corpus/fannkuch_redux.go
+++ b/compiler3/corpus/fannkuch_redux.go
@@ -1,0 +1,135 @@
+package corpus
+
+import (
+	"mochi/runtime/vm3"
+)
+
+// ExpectFannkuchRedux is the Go oracle that mirrors the FannkuchRedux
+// kernel bit-for-bit. It runs n trials of init+countFlips on a fixed
+// 7-element permutation `perm[i] = ((i+k) % 7) + 1` and returns the
+// sum of per-trial flip counts. Matches the cross-lang
+// `fannkuch_redux.go.tmpl` template peer used by the BG suite.
+func ExpectFannkuchRedux(n int64) int64 {
+	var perm [7]int64
+	var total int64
+	for k := int64(0); k < n; k++ {
+		for i := int64(0); i < 7; i++ {
+			perm[i] = ((i+k)%7 + 1)
+		}
+		var flips int64
+		head := perm[0]
+		for head != 1 {
+			lo, hi := int64(0), head-1
+			for lo < hi {
+				perm[lo], perm[hi] = perm[hi], perm[lo]
+				lo++
+				hi--
+			}
+			head = perm[0]
+			flips++
+		}
+		total += flips
+	}
+	return total
+}
+
+// FannkuchRedux: BG `fannkuch_redux` cross-lang shape port. The
+// canonical BG kernel generates every permutation of length n and
+// finds the max flip count; the cross-lang template (and so this port)
+// simplifies to a fixed 7-element permutation rotated by trial index k
+// and accumulates the per-trial flip totals. n is the outer trial
+// count.
+//
+// Single vm3 function with three nested loops:
+//
+//  1. outer trial loop k in [0, n)
+//  2. init loop seeding `perm[i] = ((i+k) % 7) + 1` for i in [0, 7)
+//  3. countFlips inner loop: while head != 1, reverse perm[0..head-1]
+//     and increment flips
+//
+// Storage is a single generic list of length 7 (`OpNewList` followed
+// by 7 `OpListPushI64`s of 0 to grow it to len 7). After the prefix
+// the kernel uses only `OpListGetI64`/`OpListSetI64` so the JIT
+// classifies the slab as `slabKindList`, matching nsieve's admit path.
+//
+// Register banks (NumRegsI64=10, NumRegsCell=1):
+//
+//	I64: 0 n_in, 1 k, 2 total, 3 i_or_lo, 4 hi, 5 head, 6 flips,
+//	     7 tmp_a, 8 zero_idx (const 0 for perm[0] reads + push payload),
+//	     9 swap_b
+//	Cell: 0 perm
+//
+// PC map (40 ops):
+//
+//	 0       NewList
+//	 1..2    zero_idx = 0; total = 0
+//	 3..9    push 7 zeros (perm.len -> 7)
+//	10..11   k = 0; outer_loop
+//	12..19   init loop (seed perm with rotation)
+//	20..21   flips = 0; head = perm[0]
+//	22..35   flip_loop -> reverse_loop -> reload head, flips++
+//	36..38   total += flips; k++; jump to outer_loop
+//	39       ReturnI64 total
+//
+// Branch targets (uint16(C)):
+//
+//	outer_loop pc=11 -> END        pc=39
+//	init_loop  pc=13 -> INIT_END   pc=20
+//	flip_loop  pc=22 -> FLIP_END   pc=36
+//	rev_loop   pc=25 -> REV_END    pc=33
+var FannkuchRedux = &Program{
+	Name: "fannkuch_redux",
+	Build: func(_ int64) *vm3.Program {
+		fn := &vm3.Function{
+			Name:        "fannkuch_redux",
+			NumRegsI64:  10,
+			NumRegsF64:  0,
+			NumRegsCell: 1,
+			ParamBanks:  []vm3.Bank{vm3.BankI64},
+			ResultBank:  vm3.BankI64,
+			Code: []vm3.Op{
+				vm3.MakeOp(vm3.OpNewList, 0, 0, 0),     // pc=0: perm = NewList
+				vm3.MakeOp(vm3.OpConstI64K, 8, 0, 0),   // pc=1: zero_idx = 0
+				vm3.MakeOp(vm3.OpConstI64K, 2, 0, 0),   // pc=2: total = 0
+				vm3.MakeOp(vm3.OpListPushI64, 0, 8, 0), // pc=3..9: push 7 zeros
+				vm3.MakeOp(vm3.OpListPushI64, 0, 8, 0),
+				vm3.MakeOp(vm3.OpListPushI64, 0, 8, 0),
+				vm3.MakeOp(vm3.OpListPushI64, 0, 8, 0),
+				vm3.MakeOp(vm3.OpListPushI64, 0, 8, 0),
+				vm3.MakeOp(vm3.OpListPushI64, 0, 8, 0),
+				vm3.MakeOp(vm3.OpListPushI64, 0, 8, 0),
+				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 0),    // pc=10: k = 0
+				vm3.MakeOp(vm3.OpCmpGeI64Br, 1, 0, 39),  // pc=11: if k>=n -> END
+				vm3.MakeOp(vm3.OpConstI64K, 3, 0, 0),    // pc=12: i = 0
+				vm3.MakeOp(vm3.OpCmpGeI64KBr, 3, 7, 20), // pc=13: if i>=7 -> INIT_END
+				vm3.MakeOp(vm3.OpAddI64, 7, 3, 1),       // pc=14: tmp = i + k
+				vm3.MakeOp(vm3.OpModI64K, 7, 7, 7),      // pc=15: tmp %= 7
+				vm3.MakeOp(vm3.OpAddI64K, 7, 7, 1),      // pc=16: tmp += 1
+				vm3.MakeOp(vm3.OpListSetI64, 0, 7, 3),   // pc=17: perm[i] = tmp
+				vm3.MakeOp(vm3.OpAddI64K, 3, 3, 1),      // pc=18: i++
+				vm3.MakeOp(vm3.OpJump, 0, 0, 13),        // pc=19 -> init_loop
+				vm3.MakeOp(vm3.OpConstI64K, 6, 0, 0),    // pc=20: flips = 0
+				vm3.MakeOp(vm3.OpListGetI64, 5, 0, 8),   // pc=21: head = perm[0]
+				vm3.MakeOp(vm3.OpCmpEqI64KBr, 5, 1, 36), // pc=22: if head==1 -> FLIP_END
+				vm3.MakeOp(vm3.OpConstI64K, 3, 0, 0),    // pc=23: lo = 0
+				vm3.MakeOp(vm3.OpAddI64K, 4, 5, -1),     // pc=24: hi = head - 1
+				vm3.MakeOp(vm3.OpCmpGeI64Br, 3, 4, 33),  // pc=25: if lo>=hi -> REV_END
+				vm3.MakeOp(vm3.OpListGetI64, 7, 0, 3),   // pc=26: a = perm[lo]
+				vm3.MakeOp(vm3.OpListGetI64, 9, 0, 4),   // pc=27: b = perm[hi]
+				vm3.MakeOp(vm3.OpListSetI64, 0, 9, 3),   // pc=28: perm[lo] = b
+				vm3.MakeOp(vm3.OpListSetI64, 0, 7, 4),   // pc=29: perm[hi] = a
+				vm3.MakeOp(vm3.OpAddI64K, 3, 3, 1),      // pc=30: lo++
+				vm3.MakeOp(vm3.OpAddI64K, 4, 4, -1),     // pc=31: hi--
+				vm3.MakeOp(vm3.OpJump, 0, 0, 25),        // pc=32 -> rev_loop
+				vm3.MakeOp(vm3.OpListGetI64, 5, 0, 8),   // pc=33: head = perm[0]
+				vm3.MakeOp(vm3.OpAddI64K, 6, 6, 1),      // pc=34: flips++
+				vm3.MakeOp(vm3.OpJump, 0, 0, 22),        // pc=35 -> flip_loop
+				vm3.MakeOp(vm3.OpAddI64, 2, 2, 6),       // pc=36: total += flips
+				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 1),      // pc=37: k++
+				vm3.MakeOp(vm3.OpJump, 0, 0, 11),        // pc=38 -> outer_loop
+				vm3.MakeOp(vm3.OpReturnI64, 2, 0, 0),    // pc=39: return total
+			},
+		}
+		return &vm3.Program{Funcs: []*vm3.Function{fn}, Entry: 0}
+	},
+}

--- a/compiler3/corpus/fannkuch_redux_test.go
+++ b/compiler3/corpus/fannkuch_redux_test.go
@@ -1,0 +1,73 @@
+package corpus
+
+import (
+	"testing"
+
+	vm3 "mochi/runtime/vm3"
+)
+
+// TestFannkuchReduxMatchesOracle runs the vm3 fannkuch_redux kernel
+// for a range of trial counts and asserts the result matches
+// ExpectFannkuchRedux. Both implementations process the trials in the
+// same order; the result is an integer flip-count sum so the test
+// asserts strict equality.
+func TestFannkuchReduxMatchesOracle(t *testing.T) {
+	for _, n := range []int64{0, 1, 2, 5, 7, 14, 100, 1000} {
+		prog := FannkuchRedux.Build(n)
+		vm := vm3.NewWithProgram(prog)
+		got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{n})
+		if err != nil {
+			t.Fatalf("fannkuch_redux(%d): %v", n, err)
+		}
+		want := ExpectFannkuchRedux(n)
+		if got.Int() != want {
+			t.Errorf("fannkuch_redux(%d) = %d, want %d", n, got.Int(), want)
+		}
+	}
+}
+
+// BenchmarkFannkuchReduxInterp measures interp-only throughput on the
+// two BG cross-lang sizes (1000 and 10000 trials).
+func BenchmarkFannkuchReduxInterp(b *testing.B) {
+	for _, tc := range []struct {
+		name string
+		n    int64
+	}{
+		{"fannkuch_redux_n1000", 1000},
+		{"fannkuch_redux_n10000", 10000},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			prog := FannkuchRedux.Build(tc.n)
+			vm := vm3.NewWithProgram(prog)
+			fn := prog.Funcs[prog.Entry]
+			args := []int64{tc.n}
+			b.ResetTimer()
+			for range b.N {
+				_, _ = vm.RunWithArgs(fn, args)
+			}
+		})
+	}
+}
+
+var fannkuchGoSink int64
+
+// BenchmarkFannkuchReduxGo is the matching native-Go reference so the
+// vm3-vs-Go ratio is a single bench command away.
+func BenchmarkFannkuchReduxGo(b *testing.B) {
+	for _, tc := range []struct {
+		name string
+		n    int64
+	}{
+		{"fannkuch_redux_n1000", 1000},
+		{"fannkuch_redux_n10000", 10000},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			n := tc.n
+			var s int64
+			for i := 0; i < b.N; i++ {
+				s += ExpectFannkuchRedux(n + int64(i&1))
+			}
+			fannkuchGoSink = s
+		})
+	}
+}

--- a/runtime/jit/vm3jit/bench_corpus_jit_test.go
+++ b/runtime/jit/vm3jit/bench_corpus_jit_test.go
@@ -62,6 +62,8 @@ func BenchmarkCorpusJITRunner(b *testing.B) {
 		{"n_body_n10000", corpus.N_body, 10000},
 		{"spectral_norm_n100", corpus.SpectralNorm, 100},
 		{"spectral_norm_n1000", corpus.SpectralNorm, 1000},
+		{"fannkuch_redux_n1000", corpus.FannkuchRedux, 1000},
+		{"fannkuch_redux_n10000", corpus.FannkuchRedux, 10000},
 	}
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2296,6 +2296,41 @@ Closure verdict: both sizes land at ~1.04x of Go on macOS arm64 (well under the 
 
 **Exit gate.** `spectral_norm` now closes under 2x of Go on macOS arm64 (1.04x at both n=100 and n=1000). Composite BG-suite progress on macOS arm64: 6/11 programs closed (fasta, k_nucleotide, mandelbrot, nsieve, n_body, spectral_norm). Remaining unported: binary_trees, fannkuch_redux, pidigits_scaled, regex_redux_scaled, reverse_complement.
 
+#### Phase 6.3.4.l.2: port fannkuch_redux to compiler3 + close under 2x of Go (2026-05-20 01:09 GMT+7)
+
+**Why this sub-phase.** With l.1 confirming the typed-slab JIT generalizes across F64Array kernels, the next composite-gate target is a small dispatch-bound BG kernel that exercises the generic `OpListGetI64`/`OpListSetI64` cell-bank path. `fannkuch_redux` is the cross-lang shape peer: a fixed 7-element permutation, N trial iterations of init+countFlips, sum of per-trial flip counts. The vm2 form is 83 source lines across 3 recursive helpers; compiler3 collapses that to a single function with three nested loops over one 7-element generic list. This is the j.5.b admit shape (slabKindList unique, no cross-fn `OpCallMixed`) so it inherits all the j-series cell-bank JIT work without new lowering.
+
+**Kernel shape** (`compiler3/corpus/fannkuch_redux.go`).
+
+A single vm3 function with three nested loops over a generic list:
+
+1. **outer trial loop** (pc 11..38): `for k = 0; k < n; k++`.
+2. **init loop** (pc 13..19): seed `perm[i] = ((i+k) % 7) + 1` for `i ∈ [0, 7)` using `OpAddI64` + `OpModI64K` + `OpAddI64K`.
+3. **flip loop** (pc 22..35) wrapping a **reverse loop** (pc 25..32): while `head != 1`, reverse `perm[0..head-1]` and increment flips; reload head from `perm[0]` after the reverse.
+
+The result is the sum of per-trial flip counts. Total 40 ops. Register footprint: `NumRegsI64=10`, `NumRegsCell=1`. Storage is one `OpNewList` followed by 7 `OpListPushI64`s of 0 to grow it to len 7; the trial body then uses only `OpListGetI64`/`OpListSetI64`, so `slabKindARM64` classifies the kernel as `slabKindList` (matching the nsieve/lists_fill_sum admit path).
+
+The compiler2 form used a typed `TI64Array` (`OpI64ArrayGet/Set`) and three recursive functions (`init`, `countFlips`, `main`). The compiler3 port collapses to single-fn nested loops so (a) there is no cross-fn cell-bank machinery, (b) the slab kind stays unique, and (c) vm3's lack of a typed I64Array surface costs only the per-load `cells.ptr` indirection that j.4a already pins outside the loop. A dedicated i64 register (`zero_idx`, reg 8) is initialized once to 0 and reused for every `perm[0]` read so the inner-loop `OpListGetI64` has its index already in a register without a per-iter `OpConstI64K`.
+
+**Measured (Apple M4, darwin/arm64, `go test -bench`, 2s, ns/op).** Lower is better.
+
+| Bench                                  | Interp     | JIT (l.2)  |  Go    | JIT vs Go |
+| -------------------------------------- | ---------: | ---------: | -----: | --------: |
+| `fannkuch_redux_n1000`                 |    312,349 |     11,326 | 10,613 |     1.07x |
+| `fannkuch_redux_n10000`                |  3,152,197 |    114,859 | 85,175 |     1.35x |
+
+Closure verdict: both sizes land under the 2x of Go gate on macOS arm64 (1.07x at n=1000, 1.35x at n=10000). Interp-to-JIT speedup is 27.6x at n=1000 and 27.4x at n=10000. The wider residual at n=10000 vs n=1000 is the inner reverse loop dominating (more flips per trial as the rotated head moves through 2..7); the per-load `cells.ptr` cost on the generic list path is the bulk of it. Closing the last 0.35x is not required for the composite gate; a typed `OpI64Array{Get,Set}` surface (parallel to j.5's `OpF64Array{Get,Set}`) would erase it, but it is deferred to a follow-up since this kernel already clears the gate.
+
+**Correctness.** `TestFannkuchReduxMatchesOracle` runs `n ∈ {0, 1, 2, 5, 7, 14, 100, 1000}` and asserts strict equality against `ExpectFannkuchRedux` (which mirrors the cross-lang `fannkuch_redux.go.tmpl` Go template peer used by the BG suite). All sizes pass.
+
+**Deferred to follow-ups.**
+
+- AMD64 lowering (l.2.d, paired with j.5.d): the kernel runs through the interpreter on amd64 hosts until the cell-bank backend lands there. The ARM64 admit path ports mechanically once `lower_amd64.go` learns `OpListGetI64`/`OpListSetI64`.
+- Typed I64Array surface: a parallel `OpI64Array{Get,Set}` opcode pair (mirroring j.5's F64 variants) would erase the per-load `cells.ptr` indirection on this kernel and any future i64-array BG kernel. Out of scope here.
+- Linux server2 re-bench: paired with the amd64 closure so a single platform sweep records both arm64 and amd64.
+
+**Exit gate.** `fannkuch_redux` now closes under 2x of Go on macOS arm64 (1.07x at n=1000, 1.35x at n=10000). Composite BG-suite progress on macOS arm64: 7/11 programs closed (fasta, k_nucleotide, mandelbrot, nsieve, n_body, spectral_norm, fannkuch_redux). Remaining unported: binary_trees, pidigits_scaled, regex_redux_scaled, reverse_complement.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
Tracks #21800.

Ports the cross-lang `fannkuch_redux` kernel to `compiler3/corpus` as a single vm3 function with three nested loops over a 7-element generic list. `slabKindARM64` classifies the fn as `slabKindList` so it inherits the j-series cell-bank JIT admit path without new lowering.

## Measured (Apple M4, darwin/arm64, 2s bench, ns/op)

| Bench | Interp | JIT | Go | JIT vs Go |
| --- | ---: | ---: | ---: | ---: |
| `fannkuch_redux_n1000` | 312,349 | 11,326 | 10,613 | 1.07x |
| `fannkuch_redux_n10000` | 3,152,197 | 114,859 | 85,175 | 1.35x |

Both sizes land under the 2x of Go composite-gate target. Interp-to-JIT speedup ~27.5x at both sizes.

## Composite gate progress

macOS arm64: 7/11 BG programs closed. Remaining unported: binary_trees (blocked on vm3 pair arena), pidigits_scaled, regex_redux_scaled, reverse_complement. amd64 + Linux server2 paired with j.5.d.

## Test plan

- [x] `go test -run TestFannkuchReduxMatchesOracle ./compiler3/corpus/` passes for `n ∈ {0,1,2,5,7,14,100,1000}` (strict equality vs `ExpectFannkuchRedux`)
- [x] `go test ./compiler3/corpus/ ./runtime/vm3/ ./runtime/jit/vm3jit/` green
- [x] `go vet ./compiler3/corpus/ ./runtime/jit/vm3jit/` clean
- [x] JIT bench captured under `BenchmarkCorpusJITRunner/fannkuch_redux_n{1000,10000}`