### PR TITLE
mep-0040 phase 6.3.4.l.3: port reverse_complement + admit OpLookupI64KW (closure-pending)

### DIFF
--- a/compiler3/corpus/corpus.go
+++ b/compiler3/corpus/corpus.go
@@ -32,5 +32,6 @@ func All() []*Program {
 		N_body,
 		SpectralNorm,
 		FannkuchRedux,
+		ReverseComplement,
 	}
 }

--- a/compiler3/corpus/reverse_complement.go
+++ b/compiler3/corpus/reverse_complement.go
@@ -1,0 +1,153 @@
+package corpus
+
+import (
+	"mochi/runtime/vm3"
+)
+
+// ExpectReverseComplement mirrors the cross-lang reverse_complement
+// template: fill an n-entry buffer with the repeating ACGT pattern,
+// reverse-complement into a second buffer (A<->T, C<->G), then return
+// the sum of the output byte values as int64. For n a multiple of 4
+// the result is (n/4) * 287 because the complemented byte set per
+// 4-cycle is {T, G, C, A} = {84, 71, 67, 65}, summing to 287.
+func ExpectReverseComplement(n int64) int64 {
+	if n <= 0 {
+		return 0
+	}
+	in := make([]int64, n)
+	out := make([]int64, n)
+	bases := [4]int64{'A', 'C', 'G', 'T'}
+	for i := int64(0); i < n; i++ {
+		in[i] = bases[i%4]
+	}
+	for i := int64(0); i < n; i++ {
+		c := in[i]
+		var cc int64
+		switch c {
+		case 'A':
+			cc = 'T'
+		case 'C':
+			cc = 'G'
+		case 'G':
+			cc = 'C'
+		case 'T':
+			cc = 'A'
+		default:
+			cc = c
+		}
+		out[n-1-i] = cc
+	}
+	var sum int64
+	for i := int64(0); i < n; i++ {
+		sum += out[i]
+	}
+	return sum
+}
+
+// ReverseComplement: BG `reverse_complement` cross-lang shape port. The
+// template fills `in` with `bases[i%4]` for `bases = "ACGT"`, then
+// builds `out[n-1-i] = complement(in[i])` (A<->T, C<->G), then returns
+// `sum(out[i])` as int64. We mirror that exactly so the JIT path is
+// exercised end-to-end across three sequential phases (fill, revcomp,
+// sum). The Go template peer lives at bench/template/bg/reverse_complement.
+//
+// Single vm3 function with three sequential loops over two cell-bank
+// lists:
+//
+//  1. fill loop (pc 5..11): in.push(bases[i%4]) and out.push(0) for
+//     i in [0, n). Combining both pushes per iteration keeps the loop
+//     count at n rather than 2n; the second push grows `out` to len n
+//     so the revcomp loop can use OpListSetI64 by index.
+//  2. revcomp loop (pc 14..20): for i in [0, n), val = in[i],
+//     val = complement[val], out[dst_idx] = val with dst_idx = n-1-i
+//     maintained by a parallel decrement (saves an OpSubI64 per iter).
+//  3. sum loop (pc 22..26): sum += out[i] for i in [0, n).
+//
+// Two i64 lookup tables baked at Build time live in Function.I64Tables:
+//
+//	I64Tables[0] = bases    (4 entries: 'A'=65, 'C'=67, 'G'=71, 'T'=84)
+//	I64Tables[1] = complement (256 entries: complement[c] = ACGT-comp(c),
+//	              identity for other byte values)
+//
+// Both are unchecked OpLookupI64KW reads. Table 0's index `i%4` is
+// produced by OpModI64K(2, 1, 4) so it lives in [0, 4). Table 1's
+// index is `in[i]` which is one of {65, 67, 71, 84} by construction,
+// always in [0, 256). The 256-entry table is 2KB (fits in one L1 line
+// group) and avoids a 4-way OpCmpEqI64KBr cascade per element.
+//
+// Storage shape: two `OpNewList` with capHint = int16(n) so the JIT
+// cell-bank path can keep the slab pinned in x19 without a grow-deopt
+// (Phase 6.2d.2.b step 2.F regrow-and-retry covers the > 32767 case
+// at interp speed). For n bench sizes (1000, 10000) capHint is exact.
+//
+// Banks: NumRegsI64=6 (0:n, 1:i, 2:val, 3:dst_idx, 4:sum, 5:zero),
+// NumRegsCell=2 (0:in, 1:out).
+//
+// PC map (28 ops):
+//
+//	 0       NewList in (capHint=n)
+//	 1       NewList out (capHint=n)
+//	 2..4    zero=0; sum=0; i=0
+//	 5..11   fill loop: in.push(bases[i%4]); out.push(0)
+//	12..13   i=0; dst_idx = n-1
+//	14..20   revcomp loop: out[dst_idx--] = complement(in[i++])
+//	21..26   i=0; sum loop: sum += out[i]
+//	27       ReturnI64 sum
+var ReverseComplement = &Program{
+	Name: "reverse_complement",
+	Build: func(n int64) *vm3.Program {
+		capHint := int16(0)
+		if n > 0 && n <= 0x7FFF {
+			capHint = int16(n)
+		}
+		bases := []int64{'A', 'C', 'G', 'T'}
+		complement := make([]int64, 256)
+		for i := range complement {
+			complement[i] = int64(i)
+		}
+		complement['A'] = 'T'
+		complement['T'] = 'A'
+		complement['C'] = 'G'
+		complement['G'] = 'C'
+		fn := &vm3.Function{
+			Name:        "reverse_complement",
+			NumRegsI64:  6,
+			NumRegsF64:  0,
+			NumRegsCell: 2,
+			ParamBanks:  []vm3.Bank{vm3.BankI64},
+			ResultBank:  vm3.BankI64,
+			I64Tables:   [][]int64{bases, complement},
+			Code: []vm3.Op{
+				vm3.MakeOp(vm3.OpNewList, 0, 0, capHint),  // pc=0: in = NewList
+				vm3.MakeOp(vm3.OpNewList, 1, 0, capHint),  // pc=1: out = NewList
+				vm3.MakeOp(vm3.OpConstI64K, 5, 0, 0),      // pc=2: zero = 0
+				vm3.MakeOp(vm3.OpConstI64K, 4, 0, 0),      // pc=3: sum = 0
+				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 0),      // pc=4: i = 0
+				vm3.MakeOp(vm3.OpCmpGeI64Br, 1, 0, 12),    // pc=5: if i>=n -> after_fill
+				vm3.MakeOp(vm3.OpModI64K, 2, 1, 4),        // pc=6: val = i % 4
+				vm3.MakeOp(vm3.OpLookupI64KW, 2, 2, 0),    // pc=7: val = bases[val]
+				vm3.MakeOp(vm3.OpListPushI64, 0, 2, 0),    // pc=8: in.push(val)
+				vm3.MakeOp(vm3.OpListPushI64, 1, 5, 0),    // pc=9: out.push(0)
+				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 1),        // pc=10: i++
+				vm3.MakeOp(vm3.OpJump, 0, 0, 5),           // pc=11: -> fill_loop
+				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 0),      // pc=12: i = 0
+				vm3.MakeOp(vm3.OpAddI64K, 3, 0, -1),       // pc=13: dst_idx = n - 1
+				vm3.MakeOp(vm3.OpCmpGeI64Br, 1, 0, 21),    // pc=14: if i>=n -> after_rev
+				vm3.MakeOp(vm3.OpListGetI64, 2, 0, 1),     // pc=15: val = in[i]
+				vm3.MakeOp(vm3.OpLookupI64KW, 2, 2, 1),    // pc=16: val = complement[val]
+				vm3.MakeOp(vm3.OpListSetI64, 1, 2, 3),     // pc=17: out[dst_idx] = val
+				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 1),        // pc=18: i++
+				vm3.MakeOp(vm3.OpAddI64K, 3, 3, -1),       // pc=19: dst_idx--
+				vm3.MakeOp(vm3.OpJump, 0, 0, 14),          // pc=20: -> rev_loop
+				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 0),      // pc=21: i = 0
+				vm3.MakeOp(vm3.OpCmpGeI64Br, 1, 0, 27),    // pc=22: if i>=n -> end
+				vm3.MakeOp(vm3.OpListGetI64, 2, 1, 1),     // pc=23: val = out[i]
+				vm3.MakeOp(vm3.OpAddI64, 4, 4, 2),         // pc=24: sum += val
+				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 1),        // pc=25: i++
+				vm3.MakeOp(vm3.OpJump, 0, 0, 22),          // pc=26: -> sum_loop
+				vm3.MakeOp(vm3.OpReturnI64, 4, 0, 0),      // pc=27: return sum
+			},
+		}
+		return &vm3.Program{Funcs: []*vm3.Function{fn}, Entry: 0}
+	},
+}

--- a/compiler3/corpus/reverse_complement_test.go
+++ b/compiler3/corpus/reverse_complement_test.go
@@ -1,0 +1,74 @@
+package corpus
+
+import (
+	"testing"
+
+	vm3 "mochi/runtime/vm3"
+)
+
+// TestReverseComplementMatchesOracle runs the vm3 reverse_complement
+// kernel for a range of buffer sizes and asserts the result matches
+// ExpectReverseComplement. Both implementations sum out[] as int64 so
+// the test asserts strict equality. For n divisible by 4 the sum is
+// (n/4) * 287 by construction; non-multiple-of-4 sizes are covered by
+// the oracle.
+func TestReverseComplementMatchesOracle(t *testing.T) {
+	for _, n := range []int64{0, 1, 2, 4, 7, 16, 100, 1000, 8000} {
+		prog := ReverseComplement.Build(n)
+		vm := vm3.NewWithProgram(prog)
+		got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{n})
+		if err != nil {
+			t.Fatalf("reverse_complement(%d): %v", n, err)
+		}
+		want := ExpectReverseComplement(n)
+		if got.Int() != want {
+			t.Errorf("reverse_complement(%d) = %d, want %d", n, got.Int(), want)
+		}
+	}
+}
+
+// BenchmarkReverseComplementInterp measures interp-only throughput on
+// the two BG cross-lang sizes.
+func BenchmarkReverseComplementInterp(b *testing.B) {
+	for _, tc := range []struct {
+		name string
+		n    int64
+	}{
+		{"reverse_complement_n1000", 1000},
+		{"reverse_complement_n10000", 10000},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			prog := ReverseComplement.Build(tc.n)
+			vm := vm3.NewWithProgram(prog)
+			fn := prog.Funcs[prog.Entry]
+			args := []int64{tc.n}
+			b.ResetTimer()
+			for range b.N {
+				_, _ = vm.RunWithArgs(fn, args)
+			}
+		})
+	}
+}
+
+var reverseComplementGoSink int64
+
+// BenchmarkReverseComplementGo is the matching native-Go reference so
+// the vm3-vs-Go ratio is a single bench command away.
+func BenchmarkReverseComplementGo(b *testing.B) {
+	for _, tc := range []struct {
+		name string
+		n    int64
+	}{
+		{"reverse_complement_n1000", 1000},
+		{"reverse_complement_n10000", 10000},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			n := tc.n
+			var s int64
+			for i := 0; i < b.N; i++ {
+				s += ExpectReverseComplement(n + int64(i&1))
+			}
+			reverseComplementGoSink = s
+		})
+	}
+}

--- a/runtime/jit/vm3jit/bench_corpus_jit_test.go
+++ b/runtime/jit/vm3jit/bench_corpus_jit_test.go
@@ -64,6 +64,8 @@ func BenchmarkCorpusJITRunner(b *testing.B) {
 		{"spectral_norm_n1000", corpus.SpectralNorm, 1000},
 		{"fannkuch_redux_n1000", corpus.FannkuchRedux, 1000},
 		{"fannkuch_redux_n10000", corpus.FannkuchRedux, 10000},
+		{"reverse_complement_n1000", corpus.ReverseComplement, 1000},
+		{"reverse_complement_n10000", corpus.ReverseComplement, 10000},
 	}
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {

--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -232,6 +232,7 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 			vm3.OpListGetI64, vm3.OpListPushI64, vm3.OpListSetI64,
 			vm3.OpListGetF64, vm3.OpListSetF64,
 			vm3.OpMapSetI64I64, vm3.OpMapGetI64I64,
+			vm3.OpLookupI64KW,
 			vm3.OpF64ArrayGetF64, vm3.OpF64ArraySetF64, vm3.OpF64ArrayLenI64,
 			vm3.OpConstF64K, vm3.OpMovF64,
 			vm3.OpAddF64, vm3.OpSubF64, vm3.OpMulF64, vm3.OpDivF64,

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2331,6 +2331,41 @@ Closure verdict: both sizes land under the 2x of Go gate on macOS arm64 (1.07x a
 
 **Exit gate.** `fannkuch_redux` now closes under 2x of Go on macOS arm64 (1.07x at n=1000, 1.35x at n=10000). Composite BG-suite progress on macOS arm64: 7/11 programs closed (fasta, k_nucleotide, mandelbrot, nsieve, n_body, spectral_norm, fannkuch_redux). Remaining unported: binary_trees, pidigits_scaled, regex_redux_scaled, reverse_complement.
 
+#### Phase 6.3.4.l.3: port reverse_complement to compiler3 + admit OpLookupI64KW in cell-bank (2026-05-20 01:22 GMT+7)
+
+**Why this sub-phase.** Continuing the BG composite-gate walk, `reverse_complement` is the next unported kernel (the remaining ones either need bignum, regex, or a new arena kind). The cross-lang template fills an n-entry buffer with the repeating ACGT pattern, reverse-complements into a second buffer (A<->T, C<->G), then sums the output as int64. This sub-phase lands two things: (a) the kernel port itself, single-fn with three sequential loops over two cell-bank lists, and (b) admission of `OpLookupI64KW` in the cell-bank whitelist so the kernel's bases-and-complement lookup tables run as native LDR's instead of a 4-way OpCmp cascade. The JIT ARM64 lowering of `OpLookupI64KW` already exists (Phase 6.4.b); the only missing piece was the cell-bank admit check.
+
+**Kernel shape** (`compiler3/corpus/reverse_complement.go`).
+
+A single vm3 function with three sequential loops over two cell-bank lists:
+
+1. **fill loop** (pc 5..11): `in.push(bases[i%4])` and `out.push(0)` for `i ∈ [0, n)`. Combining both pushes per iteration keeps the loop count at n rather than 2n; the second push grows `out` to len n so the revcomp loop can use `OpListSetI64` by index.
+2. **revcomp loop** (pc 14..20): `out[dst_idx] = complement[in[i]]` with `dst_idx = n-1-i` maintained by a parallel decrement (saves an `OpSubI64` per iteration).
+3. **sum loop** (pc 22..26): `sum += out[i]` for `i ∈ [0, n)`.
+
+Total 28 ops. `NumRegsI64=6`, `NumRegsCell=2` (both `in` and `out`). Both `OpNewList` sit at pc 0..1 with `capHint=int16(n)` so `preAllocListPrefix` returns 2 and both lists are lifted into the per-call arena snapshot. The inner loops use only `OpListGetI64`/`OpListSetI64`/`OpListPushI64`, so `slabKindARM64` classifies the kernel as `slabKindList` (matching nsieve and fannkuch_redux). Two i64 lookup tables live in `Function.I64Tables`: `Tables[0]` is the 4-entry bases table; `Tables[1]` is a 256-entry complement table (identity for non-ACGT bytes, so the kernel stays correct under any byte payload).
+
+**Generic enabler.** `checkCellBankAdmissible` previously rejected `OpLookupI64KW` since the whitelist only covered the lists_fill_sum / nsieve / n_body shapes. Cell-bank fns get `tableHoistCapARM64 = 0` (their x19..x28 layout is fully committed to slab/arena pins), so every site emits the cold pair (`movImm64` + `LDR Xd, [x16, Xidx, LSL #3]`). That is still 5..7x faster than a 4-way OpCmp cascade per element, and zero extra prologue cost since there is nothing to hoist. Any future cell-bank kernel that wants a compile-time lookup table now admits without further admit-list work.
+
+**Measured (Apple M4, darwin/arm64, `go test -bench`, 2s, ns/op).** Lower is better.
+
+| Bench                                  | Interp     | JIT (l.3)  |  Go    | JIT vs Go |
+| -------------------------------------- | ---------: | ---------: | -----: | --------: |
+| `reverse_complement_n1000`             |     50,628 |     29,229 |  2,236 |    13.07x |
+| `reverse_complement_n10000`            |    506,175 |    280,782 | 17,144 |    16.38x |
+
+Closure verdict: **port admitted, closure-pending.** The kernel is JIT-compiled (`fn.JITCode != nil`, `JITPreAllocListPrefix=2`) and runs at ~1.7x of interp, but does not reach the 2x of Go gate. Per-op cost on the cell-bank list path is ~7 ns vs Go's ~0.5 ns for the equivalent `[]int64` access; the 14x per-op gap explains the 13..16x ratio. Each cell-bank list access is a Cell-wrapped 16-byte load/store while Go's `[]int64` is a flat 8-byte load/store; closing the gap needs a typed `OpI64Array{Get,Set,Push}` surface (parallel to j.5's `OpF64Array{Get,Set,Push}`). Other cell-bank kernels in the suite (fannkuch_redux at 1.07x, nsieve at <2x) close because their inner loops are compute-bound rather than list-op-bound; reverse_complement's inner loops are 100% list ops which is exactly the shape that gets the F64Array-style treatment.
+
+**Correctness.** `TestReverseComplementMatchesOracle` runs `n ∈ {0, 1, 2, 4, 7, 16, 100, 1000, 8000}` and asserts strict equality against `ExpectReverseComplement` (which mirrors the cross-lang `reverse_complement.go.tmpl` Go template peer, using `int64` storage to match vm3's Cell-wrapped lists). All sizes pass.
+
+**Deferred to follow-ups.**
+
+- **Phase 6.3.4.l.4: I64Array surface for closure.** Add `OpNewI64Array` / `OpI64ArrayLenI64` / `OpI64ArrayPushI64` / `OpI64ArrayGetI64` / `OpI64ArraySetI64` (mirror j.5.a) with arena type `vmI64Array`, ARM64 + AMD64 lowering (mirror j.5.b), and migrate `reverse_complement` (and optionally `fannkuch_redux`) to use it (mirror j.5.c). Projected closure: under 2x of Go at both n=1000 and n=10000, by the same logic that brought n_body and spectral_norm under 2x via F64Array.
+- AMD64 lowering: the kernel runs through the interpreter on amd64 hosts until the cell-bank backend lands there (paired with j.5.d).
+- Linux server2 re-bench: paired with the amd64 closure so a single platform sweep records both arm64 and amd64.
+
+**Exit gate.** `reverse_complement` is now ported and JIT-admitted on macOS arm64; closure under 2x is deferred to Phase 6.3.4.l.4 (I64Array surface). Composite BG-suite progress on macOS arm64 with both l.2 and l.3 landed: 7/11 programs closed under 2x of Go, 8/11 ported with one (reverse_complement) closure-pending. Remaining unported: binary_trees (needs vm3 pair arena), pidigits_scaled (needs bignum), regex_redux_scaled (needs regex+strings).
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
Resolves #21802 (port + admit; closure deferred to l.4).

## Summary

- Adds compiler3/corpus.ReverseComplement: 28-op 3-loop fill/revcomp/sum shape over 2 cell-bank lists driven by 2 I64Tables (4-entry bases, 256-entry complement) via OpLookupI64KW.
- Admits OpLookupI64KW in checkCellBankAdmissible's whitelist so cell-bank kernels with compile-time lookup tables JIT-compile (previously i64-only fns admitted this op).
- Wires reverse_complement_n1000 / _n10000 into BenchmarkCorpusJITRunner.

## Measured (macOS arm64)

| Bench | JIT ns/op | Go ns/op | Ratio |
|-|-|-|-|
| reverse_complement_n1000 | 29,229 | 2,236 | 13.07x |
| reverse_complement_n10000 | 280,782 | 17,144 | 16.38x |

Closure-pending: cell-bank list per-element cost (~7 ns through Cell wrappers vs ~0.5 ns for native []int64) caps this kernel ~14x of Go. Phase 6.3.4.l.4 adds an OpI64Array typed surface (parallel to the F64Array surface from j.5.a/b/c) to close under 2x.

## Spec

MEP-40 updated with phase 6.3.4.l.3 section dated 2026-05-20 01:22 GMT+7. Measured table + closure-pending verdict + l.4 scope all documented.

## Test plan

- [x] TestReverseComplementMatchesOracle passes for n in {0,1,2,4,7,16,100,1000,8000}
- [x] go test ./compiler3/corpus/ ./runtime/vm3/ ./runtime/jit/vm3jit/ all green
- [x] BenchmarkCorpusJITRunner picks up both new entries; JIT path executes (JITCode != nil)
- [x] No new em-dashes in spec (count stable at 23)