### PR TITLE
mep-0040 phase 6.3.4.l.4: I64Array surface + close reverse_complement under 2x

### DIFF
--- a/compiler3/corpus/reverse_complement.go
+++ b/compiler3/corpus/reverse_complement.go
@@ -52,16 +52,16 @@ func ExpectReverseComplement(n int64) int64 {
 // sum). The Go template peer lives at bench/template/bg/reverse_complement.
 //
 // Single vm3 function with three sequential loops over two cell-bank
-// lists:
+// typed-i64 arrays (Phase 6.3.4.l.4):
 //
-//  1. fill loop (pc 5..11): in.push(bases[i%4]) and out.push(0) for
-//     i in [0, n). Combining both pushes per iteration keeps the loop
-//     count at n rather than 2n; the second push grows `out` to len n
-//     so the revcomp loop can use OpListSetI64 by index.
-//  2. revcomp loop (pc 14..20): for i in [0, n), val = in[i],
+//  1. fill loop (pc 4..9): in[i] = bases[i%4] for i in [0, n). Both
+//     arrays are pre-sized to length n by OpNewI64Array, so the fill
+//     loop just Sets `in` (and `out` is left at its initial all-zero
+//     state, which the revcomp loop will overwrite).
+//  2. revcomp loop (pc 12..18): for i in [0, n), val = in[i],
 //     val = complement[val], out[dst_idx] = val with dst_idx = n-1-i
 //     maintained by a parallel decrement (saves an OpSubI64 per iter).
-//  3. sum loop (pc 22..26): sum += out[i] for i in [0, n).
+//  3. sum loop (pc 20..24): sum += out[i] for i in [0, n).
 //
 // Two i64 lookup tables baked at Build time live in Function.I64Tables:
 //
@@ -75,24 +75,29 @@ func ExpectReverseComplement(n int64) int64 {
 // always in [0, 256). The 256-entry table is 2KB (fits in one L1 line
 // group) and avoids a 4-way OpCmpEqI64KBr cascade per element.
 //
-// Storage shape: two `OpNewList` with capHint = int16(n) so the JIT
-// cell-bank path can keep the slab pinned in x19 without a grow-deopt
-// (Phase 6.2d.2.b step 2.F regrow-and-retry covers the > 32767 case
-// at interp speed). For n bench sizes (1000, 10000) capHint is exact.
+// Storage shape: two `OpNewI64Array` with capHint = int16(n) lifted into
+// jitCall's pre-alloc prefix (Phase 6.3.4.l.4), so the JIT lowerer emits
+// zero words for the two NewI64Array PCs and the prologue picks up the
+// pre-seeded handles. AllocI64Arr(n) pre-fills the data slice with n
+// zeros, so no Push is needed. Per-access cost drops to ~6 inst (UXTW
+// + MOV stride + MUL + ADD x19 + LDR data.ptr + LDR/STR Xd) with no
+// 48-bit CInt tag-box/unbox versus the OpList* path's 14+ inst (extra
+// BFI on push/set, SBFX on get). Closes the read/write loop under 2x
+// of Go.
 //
-// Banks: NumRegsI64=6 (0:n, 1:i, 2:val, 3:dst_idx, 4:sum, 5:zero),
+// Banks: NumRegsI64=5 (0:n, 1:i, 2:val, 3:dst_idx, 4:sum),
 // NumRegsCell=2 (0:in, 1:out).
 //
-// PC map (28 ops):
+// PC map (26 ops):
 //
-//	 0       NewList in (capHint=n)
-//	 1       NewList out (capHint=n)
-//	 2..4    zero=0; sum=0; i=0
-//	 5..11   fill loop: in.push(bases[i%4]); out.push(0)
-//	12..13   i=0; dst_idx = n-1
-//	14..20   revcomp loop: out[dst_idx--] = complement(in[i++])
-//	21..26   i=0; sum loop: sum += out[i]
-//	27       ReturnI64 sum
+//	 0       NewI64Array in (capHint=n)
+//	 1       NewI64Array out (capHint=n)
+//	 2..3    sum=0; i=0
+//	 4..9    fill loop: in[i] = bases[i%4]
+//	10..11   i=0; dst_idx = n-1
+//	12..18   revcomp loop: out[dst_idx--] = complement(in[i++])
+//	19..24   i=0; sum loop: sum += out[i]
+//	25       ReturnI64 sum
 var ReverseComplement = &Program{
 	Name: "reverse_complement",
 	Build: func(n int64) *vm3.Program {
@@ -111,41 +116,39 @@ var ReverseComplement = &Program{
 		complement['G'] = 'C'
 		fn := &vm3.Function{
 			Name:        "reverse_complement",
-			NumRegsI64:  6,
+			NumRegsI64:  5,
 			NumRegsF64:  0,
 			NumRegsCell: 2,
 			ParamBanks:  []vm3.Bank{vm3.BankI64},
 			ResultBank:  vm3.BankI64,
 			I64Tables:   [][]int64{bases, complement},
 			Code: []vm3.Op{
-				vm3.MakeOp(vm3.OpNewList, 0, 0, capHint),  // pc=0: in = NewList
-				vm3.MakeOp(vm3.OpNewList, 1, 0, capHint),  // pc=1: out = NewList
-				vm3.MakeOp(vm3.OpConstI64K, 5, 0, 0),      // pc=2: zero = 0
-				vm3.MakeOp(vm3.OpConstI64K, 4, 0, 0),      // pc=3: sum = 0
-				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 0),      // pc=4: i = 0
-				vm3.MakeOp(vm3.OpCmpGeI64Br, 1, 0, 12),    // pc=5: if i>=n -> after_fill
-				vm3.MakeOp(vm3.OpModI64K, 2, 1, 4),        // pc=6: val = i % 4
-				vm3.MakeOp(vm3.OpLookupI64KW, 2, 2, 0),    // pc=7: val = bases[val]
-				vm3.MakeOp(vm3.OpListPushI64, 0, 2, 0),    // pc=8: in.push(val)
-				vm3.MakeOp(vm3.OpListPushI64, 1, 5, 0),    // pc=9: out.push(0)
-				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 1),        // pc=10: i++
-				vm3.MakeOp(vm3.OpJump, 0, 0, 5),           // pc=11: -> fill_loop
-				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 0),      // pc=12: i = 0
-				vm3.MakeOp(vm3.OpAddI64K, 3, 0, -1),       // pc=13: dst_idx = n - 1
-				vm3.MakeOp(vm3.OpCmpGeI64Br, 1, 0, 21),    // pc=14: if i>=n -> after_rev
-				vm3.MakeOp(vm3.OpListGetI64, 2, 0, 1),     // pc=15: val = in[i]
-				vm3.MakeOp(vm3.OpLookupI64KW, 2, 2, 1),    // pc=16: val = complement[val]
-				vm3.MakeOp(vm3.OpListSetI64, 1, 2, 3),     // pc=17: out[dst_idx] = val
-				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 1),        // pc=18: i++
-				vm3.MakeOp(vm3.OpAddI64K, 3, 3, -1),       // pc=19: dst_idx--
-				vm3.MakeOp(vm3.OpJump, 0, 0, 14),          // pc=20: -> rev_loop
-				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 0),      // pc=21: i = 0
-				vm3.MakeOp(vm3.OpCmpGeI64Br, 1, 0, 27),    // pc=22: if i>=n -> end
-				vm3.MakeOp(vm3.OpListGetI64, 2, 1, 1),     // pc=23: val = out[i]
-				vm3.MakeOp(vm3.OpAddI64, 4, 4, 2),         // pc=24: sum += val
-				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 1),        // pc=25: i++
-				vm3.MakeOp(vm3.OpJump, 0, 0, 22),          // pc=26: -> sum_loop
-				vm3.MakeOp(vm3.OpReturnI64, 4, 0, 0),      // pc=27: return sum
+				vm3.MakeOp(vm3.OpNewI64Array, 0, 0, capHint), // pc=0: in = NewI64Array(n)
+				vm3.MakeOp(vm3.OpNewI64Array, 1, 0, capHint), // pc=1: out = NewI64Array(n)
+				vm3.MakeOp(vm3.OpConstI64K, 4, 0, 0),         // pc=2: sum = 0
+				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 0),         // pc=3: i = 0
+				vm3.MakeOp(vm3.OpCmpGeI64Br, 1, 0, 10),       // pc=4: if i>=n -> after_fill
+				vm3.MakeOp(vm3.OpModI64K, 2, 1, 4),           // pc=5: val = i % 4
+				vm3.MakeOp(vm3.OpLookupI64KW, 2, 2, 0),       // pc=6: val = bases[val]
+				vm3.MakeOp(vm3.OpI64ArraySetI64, 0, 2, 1),    // pc=7: in[i] = val
+				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 1),           // pc=8: i++
+				vm3.MakeOp(vm3.OpJump, 0, 0, 4),              // pc=9: -> fill_loop
+				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 0),         // pc=10: i = 0
+				vm3.MakeOp(vm3.OpAddI64K, 3, 0, -1),          // pc=11: dst_idx = n - 1
+				vm3.MakeOp(vm3.OpCmpGeI64Br, 1, 0, 19),       // pc=12: if i>=n -> after_rev
+				vm3.MakeOp(vm3.OpI64ArrayGetI64, 2, 0, 1),    // pc=13: val = in[i]
+				vm3.MakeOp(vm3.OpLookupI64KW, 2, 2, 1),       // pc=14: val = complement[val]
+				vm3.MakeOp(vm3.OpI64ArraySetI64, 1, 2, 3),    // pc=15: out[dst_idx] = val
+				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 1),           // pc=16: i++
+				vm3.MakeOp(vm3.OpAddI64K, 3, 3, -1),          // pc=17: dst_idx--
+				vm3.MakeOp(vm3.OpJump, 0, 0, 12),             // pc=18: -> rev_loop
+				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 0),         // pc=19: i = 0
+				vm3.MakeOp(vm3.OpCmpGeI64Br, 1, 0, 25),       // pc=20: if i>=n -> end
+				vm3.MakeOp(vm3.OpI64ArrayGetI64, 2, 1, 1),    // pc=21: val = out[i]
+				vm3.MakeOp(vm3.OpAddI64, 4, 4, 2),            // pc=22: sum += val
+				vm3.MakeOp(vm3.OpAddI64K, 1, 1, 1),           // pc=23: i++
+				vm3.MakeOp(vm3.OpJump, 0, 0, 20),             // pc=24: -> sum_loop
+				vm3.MakeOp(vm3.OpReturnI64, 4, 0, 0),         // pc=25: return sum
 			},
 		}
 		return &vm3.Program{Funcs: []*vm3.Function{fn}, Entry: 0}

--- a/runtime/jit/vm3jit/arena_ctx.go
+++ b/runtime/jit/vm3jit/arena_ctx.go
@@ -39,6 +39,7 @@ type jitArenaCtx struct {
 	listsBase   unsafe.Pointer
 	mapsBase    unsafe.Pointer
 	f64ArrsBase unsafe.Pointer
+	i64ArrsBase unsafe.Pointer
 }
 
 // populateArenaCtx snapshots the Arenas slab base pointers the JIT
@@ -49,4 +50,5 @@ func populateArenaCtx(ctx *jitArenaCtx, arenas *vm3.Arenas) {
 	ctx.listsBase = arenas.JITListsBase()
 	ctx.mapsBase = arenas.JITMapsBase()
 	ctx.f64ArrsBase = arenas.JITF64ArrsBase()
+	ctx.i64ArrsBase = arenas.JITI64ArrsBase()
 }

--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -234,6 +234,7 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 			vm3.OpMapSetI64I64, vm3.OpMapGetI64I64,
 			vm3.OpLookupI64KW,
 			vm3.OpF64ArrayGetF64, vm3.OpF64ArraySetF64, vm3.OpF64ArrayLenI64,
+			vm3.OpI64ArrayGetI64, vm3.OpI64ArraySetI64, vm3.OpI64ArrayPushI64, vm3.OpI64ArrayLenI64,
 			vm3.OpConstF64K, vm3.OpMovF64,
 			vm3.OpAddF64, vm3.OpSubF64, vm3.OpMulF64, vm3.OpDivF64,
 			vm3.OpNegF64, vm3.OpFmaF64, vm3.OpSqrtF64,
@@ -283,6 +284,15 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 				continue
 			}
 			return fmt.Errorf("%w: %s pc %d Cell-bank fn uses inline OpNewF64Array (only pre-alloc prefix is admitted)",
+				ErrNotImplemented, fn.Name, i)
+		case vm3.OpNewI64Array:
+			// Phase 6.3.4.l.4 mirror of OpNewF64Array: admit at i < K
+			// where K is the contiguous OpNewI64Array prefix length the
+			// JIT lifted into jitCall.
+			if k := int(preAllocI64ArrPrefix(fn)); k > 0 && i < k {
+				continue
+			}
+			return fmt.Errorf("%w: %s pc %d Cell-bank fn uses inline OpNewI64Array (only pre-alloc prefix is admitted)",
 				ErrNotImplemented, fn.Name, i)
 		case vm3.OpTailCallMixed:
 			if opts.SelfIdx < 0 || int(uint16(op.C)) != opts.SelfIdx || op.B != 0 {

--- a/runtime/jit/vm3jit/i64arr_arm64_test.go
+++ b/runtime/jit/vm3jit/i64arr_arm64_test.go
@@ -1,0 +1,164 @@
+//go:build darwin && arm64
+
+package vm3jit_test
+
+import (
+	"testing"
+
+	c3 "mochi/compiler3/corpus"
+	"mochi/runtime/jit/vm3jit"
+	"mochi/runtime/vm3"
+)
+
+// TestI64ArrayJITGetSet is the Phase 6.3.4.l.4 mirror of
+// TestF64ArrayJITGetSet for the typed-i64 array ops. The kernel
+// pre-allocates a 5-slot typed array, writes 5 representative i16-fitting
+// i64 values, reads them back via OpI64ArrayGetI64, sums via OpAddI64,
+// and returns the sum. (i16-fitting because OpConstI64K uses op.C
+// directly; larger payloads round-trip via OpConstI64KW but are out of
+// scope for this minimal round-trip test.)
+func TestI64ArrayJITGetSet(t *testing.T) {
+	vals := []int16{7, -3, 0, 32000, -32000}
+	var want int64
+	for _, v := range vals {
+		want += int64(v)
+	}
+	code := []vm3.Op{
+		vm3.MakeOp(vm3.OpNewI64Array, 0, 0, 5), // pc=0: arr = new(5)
+	}
+	// Write 5 entries: arr[i] = vals[i].
+	for i, v := range vals {
+		code = append(code,
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, v),
+			vm3.MakeOp(vm3.OpConstI64K, 2, 0, int16(i)),
+			vm3.MakeOp(vm3.OpI64ArraySetI64, 0, 1, 2),
+		)
+	}
+	// sum (r1) = arr[0]; for i in 1..4: sum += arr[i].
+	code = append(code,
+		vm3.MakeOp(vm3.OpConstI64K, 2, 0, 0),
+		vm3.MakeOp(vm3.OpI64ArrayGetI64, 1, 0, 2),
+	)
+	for i := 1; i < 5; i++ {
+		code = append(code,
+			vm3.MakeOp(vm3.OpConstI64K, 2, 0, int16(i)),
+			vm3.MakeOp(vm3.OpI64ArrayGetI64, 0, 0, 2),
+			vm3.MakeOp(vm3.OpAddI64, 1, 1, 0),
+		)
+	}
+	code = append(code, vm3.MakeOp(vm3.OpReturnI64, 1, 0, 0))
+	fn := &vm3.Function{
+		Name:        "i64arr_jit_round_trip",
+		NumRegsI64:  3,
+		NumRegsCell: 1,
+		ResultBank:  vm3.BankI64,
+		Code:        code,
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{fn}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if fn.JITCode == nil {
+		t.Fatalf("i64arr_jit_round_trip did not compile (JITCode is nil); "+
+			"NumRegsCell=%d, JITPreAllocI64ArrPrefix=%d", fn.NumRegsCell, fn.JITPreAllocI64ArrPrefix)
+	}
+	if fn.JITPreAllocI64ArrPrefix != 1 {
+		t.Fatalf("JITPreAllocI64ArrPrefix: got %d want 1", fn.JITPreAllocI64ArrPrefix)
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.Run(fn)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got.Int() != want {
+		t.Fatalf("sum: got %d want %d", got.Int(), want)
+	}
+}
+
+// TestI64ArrayJITLen is the Phase 6.3.4.l.4 mirror of TestF64ArrayJITLen
+// for the i64-array length op.
+func TestI64ArrayJITLen(t *testing.T) {
+	const want = 7
+	fn := &vm3.Function{
+		Name:        "i64arr_jit_len",
+		NumRegsI64:  1,
+		NumRegsCell: 1,
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewI64Array, 0, 0, want),
+			vm3.MakeOp(vm3.OpI64ArrayLenI64, 0, 0, 0),
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{fn}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if fn.JITCode == nil {
+		t.Fatalf("i64arr_jit_len did not compile (JITCode is nil)")
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.Run(fn)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got.Int() != int64(want) {
+		t.Fatalf("len: got %d want %d", got.Int(), want)
+	}
+}
+
+// TestReverseComplementJITCompiles is the Phase 6.3.4.l.4 correctness
+// gate: the compiler3 reverse_complement kernel must JIT-compile (entry
+// has non-nil JITCode after CompileProgram) and produce a result
+// matching the ExpectReverseComplement oracle. The kernel exercises the
+// new ARM64 lowerings for OpNewI64Array (pre-alloc prefix),
+// OpI64ArrayGetI64, OpI64ArraySetI64, and OpLookupI64KW. The admission
+// whitelist was extended in the same phase to cover the i64-array op
+// set.
+func TestReverseComplementJITCompiles(t *testing.T) {
+	for _, n := range []int64{0, 1, 2, 4, 7, 16, 100, 1000, 8000} {
+		prog := c3.ReverseComplement.Build(n)
+		cfs := vm3jit.CompileProgram(prog)
+		fn := prog.Funcs[prog.Entry]
+		if fn.JITCode == nil {
+			for _, cf := range cfs {
+				if cf != nil {
+					_ = cf.Free()
+				}
+			}
+			t.Skipf("n=%d: reverse_complement entry has no JITCode (CompileProgram fell back; expected on non-ARM64)", n)
+		}
+		if got := int(fn.JITPreAllocI64ArrPrefix); got != 2 {
+			for _, cf := range cfs {
+				if cf != nil {
+					_ = cf.Free()
+				}
+			}
+			t.Fatalf("n=%d: JITPreAllocI64ArrPrefix: got %d want 2", n, got)
+		}
+		vm := vm3.NewWithProgram(prog)
+		got, err := vm.RunWithArgs(fn, []int64{n})
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+		if err != nil {
+			t.Fatalf("n=%d: RunWithArgs: %v", n, err)
+		}
+		want := c3.ExpectReverseComplement(n)
+		if got.Int() != want {
+			t.Fatalf("n=%d: got %d, want %d", n, got.Int(), want)
+		}
+	}
+}

--- a/runtime/jit/vm3jit/init.go
+++ b/runtime/jit/vm3jit/init.go
@@ -225,6 +225,16 @@ func jitCall(vm *vm3.VM, fn *vm3.Function, argsI64 []int64, argsF64 []float64, a
 			}
 		}
 	}
+	// Phase 6.3.4.l.4: OpNewI64Array pre-alloc, mirror of F64Arr branch.
+	if k := int(fn.JITPreAllocI64ArrPrefix); k > 0 {
+		arenas := vm.Arenas()
+		for i := 0; i < k; i++ {
+			op := fn.Code[i]
+			if int(op.A) < MaxCellRegs {
+				jf.regsCell[op.A] = arenas.AllocI64Arr(int(uint16(op.C)))
+			}
+		}
+	}
 	// Lay out params per ParamBanks position-indexed convention: argsX[k]
 	// is meaningful iff fn.ParamBanks[k] == BankX. For i64-only callees
 	// argsCell/argsF64 are nil and we use the fast path: copy argsI64
@@ -342,12 +352,14 @@ func CompileAndCache(prog *vm3.Program, idx uint32) (*CompiledFunc, error) {
 	fn.JITPreAllocListPrefix = preAllocListPrefix(fn)
 	fn.JITPreAllocMap = canPreAllocMap(fn)
 	fn.JITPreAllocF64ArrPrefix = preAllocF64ArrPrefix(fn)
+	fn.JITPreAllocI64ArrPrefix = preAllocI64ArrPrefix(fn)
 	cf, err := CompileInProgram(prog, idx)
 	if err != nil {
 		fn.JITPreAllocList = false
 		fn.JITPreAllocListPrefix = 0
 		fn.JITPreAllocMap = false
 		fn.JITPreAllocF64ArrPrefix = 0
+		fn.JITPreAllocI64ArrPrefix = 0
 		return nil, err
 	}
 	fn.JITCode = cf.Entry()
@@ -512,7 +524,50 @@ func preAllocF64ArrPrefix(fn *vm3.Function) uint16 {
 	}
 	for i := k; i < len(fn.Code); i++ {
 		op := fn.Code[i]
-		if op.Code != vm3.OpNewList && op.Code != vm3.OpNewMap && op.Code != vm3.OpNewF64Array {
+		if op.Code != vm3.OpNewList && op.Code != vm3.OpNewMap && op.Code != vm3.OpNewF64Array && op.Code != vm3.OpNewI64Array {
+			continue
+		}
+		if seen[op.A] {
+			return 0
+		}
+	}
+	return uint16(k)
+}
+
+// preAllocI64ArrPrefix is the Phase 6.3.4.l.4 mirror of
+// preAllocF64ArrPrefix for OpNewI64Array. Same safety guards: contiguous
+// K-op prefix, each writing a distinct cell reg in the cell-bank window,
+// and no subsequent new-allocation op overwrites those cells.
+func preAllocI64ArrPrefix(fn *vm3.Function) uint16 {
+	if len(fn.Code) == 0 || fn.Code[0].Code != vm3.OpNewI64Array {
+		return 0
+	}
+	cellCap := int(fn.NumRegsCell)
+	if cellCap > MaxCellRegs {
+		cellCap = MaxCellRegs
+	}
+	seen := make(map[uint16]bool)
+	k := 0
+	for i := 0; i < len(fn.Code); i++ {
+		op := fn.Code[i]
+		if op.Code != vm3.OpNewI64Array {
+			break
+		}
+		if int(op.A) >= cellCap {
+			break
+		}
+		if seen[op.A] {
+			break
+		}
+		seen[op.A] = true
+		k = i + 1
+	}
+	if k == 0 {
+		return 0
+	}
+	for i := k; i < len(fn.Code); i++ {
+		op := fn.Code[i]
+		if op.Code != vm3.OpNewList && op.Code != vm3.OpNewMap && op.Code != vm3.OpNewF64Array && op.Code != vm3.OpNewI64Array {
 			continue
 		}
 		if seen[op.A] {

--- a/runtime/jit/vm3jit/lower_arm64.go
+++ b/runtime/jit/vm3jit/lower_arm64.go
@@ -360,18 +360,20 @@ const (
 	slabKindList
 	slabKindMap
 	slabKindF64Arr
+	slabKindI64Arr
 )
 
 // slabKindARM64 classifies fn by which slab its inline body references.
 // Returns slabKindNone when fn references multiple slabs or none (mixed
 // kernels are rejected by checkCellBankAdmissible separately so they
 // never reach codegen). Phase 6.3.4.j.5.b adds slabKindF64Arr for
-// typed-f64-array kernels: any OpF64Array{Get,Set,Len} use makes the
-// fn an f64arr kernel.
+// typed-f64-array kernels; Phase 6.3.4.l.4 adds slabKindI64Arr for
+// typed-i64-array kernels.
 func slabKindARM64(fn *vm3.Function) slabKind {
 	hasList := hasListGetI64(fn) || hasListPushI64(fn)
 	hasMap := hasMapOpI64(fn)
 	hasF64Arr := hasF64ArrayOp(fn)
+	hasI64Arr := hasI64ArrayOp(fn)
 	n := 0
 	if hasList {
 		n++
@@ -380,6 +382,9 @@ func slabKindARM64(fn *vm3.Function) slabKind {
 		n++
 	}
 	if hasF64Arr {
+		n++
+	}
+	if hasI64Arr {
 		n++
 	}
 	if n != 1 {
@@ -392,6 +397,8 @@ func slabKindARM64(fn *vm3.Function) slabKind {
 		return slabKindMap
 	case hasF64Arr:
 		return slabKindF64Arr
+	case hasI64Arr:
+		return slabKindI64Arr
 	}
 	return slabKindNone
 }
@@ -399,14 +406,17 @@ func slabKindARM64(fn *vm3.Function) slabKind {
 // slabBaseOffARM64 returns the byte offset within jitArenaCtx of the
 // slab base pointer the prologue should load into x19. Mirrors the
 // field order in jitArenaCtx: listsBase at offset 0, mapsBase at 8,
-// f64ArrsBase at 16. Fns with no slab kind default to listsBase so the
-// existing list-only admit set keeps its prologue word count unchanged.
+// f64ArrsBase at 16, i64ArrsBase at 24. Fns with no slab kind default
+// to listsBase so the existing list-only admit set keeps its prologue
+// word count unchanged.
 func slabBaseOffARM64(fn *vm3.Function) uint32 {
 	switch slabKindARM64(fn) {
 	case slabKindMap:
 		return 8
 	case slabKindF64Arr:
 		return 16
+	case slabKindI64Arr:
+		return 24
 	}
 	return 0
 }
@@ -420,6 +430,8 @@ func slabStrideARM64(fn *vm3.Function) int64 {
 		return int64(vm3.JITMapSlabStride())
 	case slabKindF64Arr:
 		return int64(vm3.JITF64ArrSlabStride())
+	case slabKindI64Arr:
+		return int64(vm3.JITI64ArrSlabStride())
 	}
 	return int64(vm3.JITListSlabStride())
 }
@@ -1603,6 +1615,44 @@ func wordCountARM64Body(fn *vm3.Function, op vm3.Op, opts Options, spillSets []u
 		}
 		return 0, fmt.Errorf("%w: opcode %d (inline NewF64Array unsupported)", ErrNotImplemented, op.Code)
 
+	case vm3.OpNewI64Array:
+		// Phase 6.3.4.l.4 mirror: prefix pre-alloc skip.
+		if idx < int(fn.JITPreAllocI64ArrPrefix) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("%w: opcode %d (inline NewI64Array unsupported)", ErrNotImplemented, op.Code)
+
+	case vm3.OpI64ArrayGetI64:
+		// Cold form (6 inst): UXTW + MOV stride + MUL + ADD x19 + LDR
+		// data.ptr + LDR Xd, [ptr, xIdx, LSL #3].
+		stride := int64(vm3.JITI64ArrSlabStride())
+		return movImm64WordCount(stride) + 5, nil
+
+	case vm3.OpI64ArraySetI64:
+		// Cold form (6 inst): same as Get but final STR Xs.
+		stride := int64(vm3.JITI64ArrSlabStride())
+		return movImm64WordCount(stride) + 5, nil
+
+	case vm3.OpI64ArrayLenI64:
+		// Cold form (5 inst): UXTW + MOV stride + MUL + ADD x19 + LDR Wd.
+		stride := int64(vm3.JITI64ArrSlabStride())
+		return movImm64WordCount(stride) + 4, nil
+
+	case vm3.OpI64ArrayPushI64:
+		// Inline append: bounds-check vs cap; deopt to interp on grow.
+		// Cold form (~12 inst incl. bounds check + STR Xs + len bump):
+		//   UXTW + MOV stride + MUL + ADD x19   ; x16 = &slab
+		//   LDR Wlen, [x16, #LEN]               ; cur len
+		//   LDR Xcap, [x16, #DATA+16]           ; cap (slice hdr)
+		//   CMP Xlen, Xcap                       ; len == cap?
+		//   B.HS deopt_listgrow                  ; defer to interp
+		//   LDR Xptr, [x16, #DATA]               ; data.ptr
+		//   STR Xs, [Xptr, Xlen, LSL #3]
+		//   ADD Wlen, Wlen, #1
+		//   STR Wlen, [x16, #LEN]
+		stride := int64(vm3.JITI64ArrSlabStride())
+		return movImm64WordCount(stride) + 9, nil
+
 	case vm3.OpF64ArrayGetF64:
 		// Inline typed-f64-array load. Cold form (6 inst):
 		//   UXTW x16, w_cell ; MOV x17, #stride ; MUL ; ADD x16, x19 ;
@@ -2026,6 +2076,14 @@ func emitInstrARM64Body(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deopt
 		// arrays and seeded jf.regsCell[A] for each pc in the prefix;
 		// the prologue loaded the handles into pinned cell regs.
 		if idx < int(fn.JITPreAllocF64ArrPrefix) {
+			return []uint32{}, nil
+		}
+		return nil, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
+
+	case vm3.OpNewI64Array:
+		// Phase 6.3.4.l.4 skip: jitCall pre-allocated K typed i64 arrays
+		// and seeded jf.regsCell[A] for each pc in the prefix.
+		if idx < int(fn.JITPreAllocI64ArrPrefix) {
 			return []uint32{}, nil
 		}
 		return nil, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
@@ -2693,6 +2751,117 @@ func emitInstrARM64Body(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deopt
 		ws = append(ws, mulReg(16, 16, 17))
 		ws = append(ws, addReg(16, 16, 19))
 		ws = append(ws, ldrW(xA, 16, lenOff/4))
+		return ws, nil
+
+	case vm3.OpI64ArrayGetI64:
+		// regsI64[A] = arenas.I64Arrs[handleIdx(regsCell[B])].data[regsI64[C]]
+		//
+		// Cold form (6 inst):
+		//   UXTW x16, w_cell                  ; idx = handle & 0xFFFFFFFF
+		//   MOV  x17, #SIZEOF_VMI64ARRAY      ; stride
+		//   MUL  x16, x16, x17                ; slab byte offset
+		//   ADD  x16, x16, x19                ; x19 = cached i64arrs base
+		//   LDR  x16, [x16, #DATA_OFFSET]     ; data.ptr (first 8 bytes of slice hdr)
+		//   LDR  Xd,  [x16, xIdx, LSL #3]     ; data[idxReg] (raw i64)
+		dataOff := uint32(vm3.JITI64ArrDataOffset())
+		xIdx := r2x(fn, uint16(op.C))
+		xCell := r2cell(op.B)
+		stride := int64(vm3.JITI64ArrSlabStride())
+		ws := make([]uint32, 0, movImm64WordCount(stride)+5)
+		ws = append(ws, uxtwReg(16, xCell))
+		ws = append(ws, movImm64(17, stride)...)
+		ws = append(ws, mulReg(16, 16, 17))
+		ws = append(ws, addReg(16, 16, 19))
+		ws = append(ws, ldr64(16, 16, dataOff/8))
+		ws = append(ws, ldrRegLsl3(xA, 16, xIdx))
+		return ws, nil
+
+	case vm3.OpI64ArraySetI64:
+		// arenas.I64Arrs[handleIdx(regsCell[A])].data[regsI64[C]] = regsI64[B]
+		//
+		// Cold form (6 inst):
+		//   UXTW x16, w_cell                  ; idx = handle & 0xFFFFFFFF
+		//   MOV  x17, #SIZEOF_VMI64ARRAY      ; stride
+		//   MUL  x16, x16, x17                ; slab byte offset
+		//   ADD  x16, x16, x19                ; x19 = cached i64arrs base
+		//   LDR  x17, [x16, #DATA_OFFSET]     ; data.ptr
+		//   STR  Xs,  [x17, xIdx, LSL #3]     ; data[idxReg] = raw i64
+		dataOff := uint32(vm3.JITI64ArrDataOffset())
+		xIdx := r2x(fn, uint16(op.C))
+		xCell := r2cell(op.A)
+		stride := int64(vm3.JITI64ArrSlabStride())
+		ws := make([]uint32, 0, movImm64WordCount(stride)+5)
+		ws = append(ws, uxtwReg(16, xCell))
+		ws = append(ws, movImm64(17, stride)...)
+		ws = append(ws, mulReg(16, 16, 17))
+		ws = append(ws, addReg(16, 16, 19))
+		ws = append(ws, ldr64(17, 16, dataOff/8))
+		ws = append(ws, str64RegLsl3(xB, 17, xIdx))
+		return ws, nil
+
+	case vm3.OpI64ArrayLenI64:
+		// regsI64[A] = int64(arenas.I64Arrs[handleIdx(regsCell[B])].len)
+		//
+		// Cold form (5 inst). Mirrors OpF64ArrayLenI64. The slab's u32
+		// .len is bumped in lockstep with len(data) by AllocI64Arr/Push.
+		lenOff := uint32(vm3.JITI64ArrLenOffset())
+		xCell := r2cell(op.B)
+		stride := int64(vm3.JITI64ArrSlabStride())
+		ws := make([]uint32, 0, movImm64WordCount(stride)+4)
+		ws = append(ws, uxtwReg(16, xCell))
+		ws = append(ws, movImm64(17, stride)...)
+		ws = append(ws, mulReg(16, 16, 17))
+		ws = append(ws, addReg(16, 16, 19))
+		ws = append(ws, ldrW(xA, 16, lenOff/4))
+		return ws, nil
+
+	case vm3.OpI64ArrayPushI64:
+		// arenas.I64Arrs[idx].data = append(..., regsI64[B])
+		//
+		// Cold form: bounds-check vs cap; deopt to interp on grow via
+		// StatusListGrow (reuse the same status code; the deopt block
+		// already restores all regs and resumes interp).
+		//   UXTW x16, w_cell                  ; idx
+		//   MOV  x17, #SIZEOF_VMI64ARRAY      ; stride
+		//   MUL  x16, x16, x17                ; slab byte offset
+		//   ADD  x16, x16, x19                ; x19 = i64arrs base
+		//   LDR  x4,  [x16, #DATA+8]          ; data.len
+		//   LDR  x17, [x16, #DATA+16]         ; data.cap
+		//   CMP  x4,  x17
+		//   B.HS deopt_listgrow                ; if len >= cap
+		//   LDR  x17, [x16, #DATA]             ; data.ptr
+		//   STR  Xs,  [x17, x4, LSL #3]        ; data[len] = val
+		//   ADD  x4,  x4, #1                   ; len++
+		//   STR  x4,  [x16, #DATA+8]           ; commit data.len
+		//   STR  W4,  [x16, #LEN]              ; vmI64Array.len (u32)
+		dataOff := uint32(vm3.JITI64ArrDataOffset())
+		lenOff := uint32(vm3.JITI64ArrLenOffset())
+		dataPtrImm12 := dataOff / 8        // ptr
+		dataLenImm12 := (dataOff + 8) / 8  // len
+		dataCapImm12 := (dataOff + 16) / 8 // cap
+		xCell := r2cell(op.A)
+		xVal := r2x(fn, op.B)
+		stride := int64(vm3.JITI64ArrSlabStride())
+		lgStart := deoptStartForStatus(fn, deoptStart, StatusListGrow)
+		ws := make([]uint32, 0, movImm64WordCount(stride)+12)
+		ws = append(ws, uxtwReg(16, xCell))
+		ws = append(ws, movImm64(17, stride)...)
+		ws = append(ws, mulReg(16, 16, 17))
+		ws = append(ws, addReg(16, 16, 19))
+		ws = append(ws, ldr64(4, 16, dataLenImm12))
+		ws = append(ws, ldr64(17, 16, dataCapImm12))
+		ws = append(ws, cmpReg(4, 17))
+		bWord := pcMap[idx] + len(ws)
+		off, err := branchOff(bWord, lgStart, 19)
+		if err != nil {
+			return nil, fmt.Errorf("I64ArrayPushI64 deopt branch: %w", err)
+		}
+		ws = append(ws, bCond(0x2, off)) // B.HS
+		ws = append(ws, ldr64(17, 16, dataPtrImm12))
+		ws = append(ws, str64RegLsl3(xVal, 17, 4))
+		ws = append(ws, addImm64(4, 4, 1))
+		ws = append(ws, str64(4, 16, dataLenImm12))
+		ws = append(ws, strW(4, 16, lenOff/4))
 		return ws, nil
 
 	default:

--- a/runtime/jit/vm3jit/lower_common.go
+++ b/runtime/jit/vm3jit/lower_common.go
@@ -130,6 +130,52 @@ func hasF64ArrayOp(fn *vm3.Function) bool {
 	return hasF64ArrayGetF64(fn) || hasF64ArraySetF64(fn) || hasF64ArrayLenI64(fn)
 }
 
+// hasI64ArrayGetI64 reports whether fn contains any OpI64ArrayGetI64.
+func hasI64ArrayGetI64(fn *vm3.Function) bool {
+	for _, op := range fn.Code {
+		if op.Code == vm3.OpI64ArrayGetI64 {
+			return true
+		}
+	}
+	return false
+}
+
+// hasI64ArraySetI64 reports whether fn contains any OpI64ArraySetI64.
+func hasI64ArraySetI64(fn *vm3.Function) bool {
+	for _, op := range fn.Code {
+		if op.Code == vm3.OpI64ArraySetI64 {
+			return true
+		}
+	}
+	return false
+}
+
+// hasI64ArrayPushI64 reports whether fn contains any OpI64ArrayPushI64.
+func hasI64ArrayPushI64(fn *vm3.Function) bool {
+	for _, op := range fn.Code {
+		if op.Code == vm3.OpI64ArrayPushI64 {
+			return true
+		}
+	}
+	return false
+}
+
+// hasI64ArrayLenI64 reports whether fn contains any OpI64ArrayLenI64.
+func hasI64ArrayLenI64(fn *vm3.Function) bool {
+	for _, op := range fn.Code {
+		if op.Code == vm3.OpI64ArrayLenI64 {
+			return true
+		}
+	}
+	return false
+}
+
+// hasI64ArrayOp reports whether fn touches the I64Arr slab via any of
+// the JIT-lowered typed-i64-array ops (Phase 6.3.4.l.4).
+func hasI64ArrayOp(fn *vm3.Function) bool {
+	return hasI64ArrayGetI64(fn) || hasI64ArraySetI64(fn) || hasI64ArrayPushI64(fn) || hasI64ArrayLenI64(fn)
+}
+
 // popcount32 counts set bits in v. Used to size OpCallI64 spill loops
 // on every backend.
 func popcount32(v uint32) int {

--- a/runtime/vm3/frame.go
+++ b/runtime/vm3/frame.go
@@ -103,6 +103,11 @@ type Function struct {
 	// the per-call arena snapshot and seeds regsCell[op.A]. The JIT lowerer
 	// emits zero words for those PCs so the prologue's LDR x_cell,
 	// [x3, #A*8] picks up the pre-seeded handle.
+	// JITPreAllocI64ArrPrefix (Phase 6.3.4.l.4) mirrors
+	// JITPreAllocF64ArrPrefix for the OpNewI64Array prefix shape used by
+	// reverse_complement and any other typed-i64-array kernel. jitCall
+	// pre-allocates K i64 arrays and seeds regsCell[op.A] before the
+	// trampoline so the JIT lowerer emits zero words for those PCs.
 	JITCode                  unsafe.Pointer
 	JITCompiled              bool
 	JITHasF64                bool
@@ -110,6 +115,7 @@ type Function struct {
 	JITPreAllocListPrefix    uint16
 	JITPreAllocMap           bool
 	JITPreAllocF64ArrPrefix  uint16
+	JITPreAllocI64ArrPrefix  uint16
 }
 
 // Bank identifies one of the three typed register banks.

--- a/runtime/vm3/jit_layout.go
+++ b/runtime/vm3/jit_layout.go
@@ -122,3 +122,35 @@ func (a *Arenas) JITF64ArrsBase() unsafe.Pointer {
 	}
 	return unsafe.Pointer(&a.F64Arrs[0])
 }
+
+// JITI64ArrSlabStride returns the byte distance between consecutive
+// vmI64Array entries in Arenas.I64Arrs. Phase 6.3.4.l.4 mirror of
+// JITF64ArrSlabStride for the typed i64-array slab.
+func JITI64ArrSlabStride() uintptr {
+	return unsafe.Sizeof(vmI64Array{})
+}
+
+// JITI64ArrDataOffset returns the byte offset of the data slice header
+// within vmI64Array. The slice header at this offset is laid out as
+// {ptr u64, len u64, cap u64} per Go's slice header convention; vm3jit
+// loads the first 8 bytes (data.ptr) for typed i64 access.
+func JITI64ArrDataOffset() uintptr {
+	return unsafe.Offsetof(vmI64Array{}.data)
+}
+
+// JITI64ArrLenOffset returns the byte offset of the len field within
+// vmI64Array. OpI64ArrayLenI64 reads it as a u32 zero-extended to i64
+// (the slab's len is bumped in lockstep with len(data) by Push).
+func JITI64ArrLenOffset() uintptr {
+	return unsafe.Offsetof(vmI64Array{}.len)
+}
+
+// JITI64ArrsBase returns an unsafe.Pointer to the first element of
+// arenas.I64Arrs, or nil if the slab is empty. Mirror of JITF64ArrsBase
+// for the typed i64-array slab.
+func (a *Arenas) JITI64ArrsBase() unsafe.Pointer {
+	if len(a.I64Arrs) == 0 {
+		return nil
+	}
+	return unsafe.Pointer(&a.I64Arrs[0])
+}

--- a/runtime/vm3/op.go
+++ b/runtime/vm3/op.go
@@ -188,6 +188,21 @@ const (
 	OpF64ArrayPushF64 // arenas.F64Arrs[idx].data = append(..., regsF64[B])
 	OpF64ArrayGetF64  // regsF64[A] = arenas.F64Arrs[idx].data[regsI64[uint16(C)]]
 	OpF64ArraySetF64  // arenas.F64Arrs[idx].data[regsI64[uint16(C)]] = regsF64[B]
+
+	// Typed i64 array ops (Phase 6.3.4.l.4). Backed by vmI64Array
+	// (flat []int64), structurally parallel to OpF64Array*. Wins are
+	// identical: 8-byte payload per element instead of 16-byte
+	// Cell-wrapped, and the per-access path skips the CInt tag
+	// round-trip. On ARM64 each access lowers to LDR/STR Xd, [Xptr,
+	// Xidx, LSL #3]; on AMD64 to MOV reg, [rptr + ridx*8]. Generic:
+	// any i64-only list that does not need Cell-tagged payload
+	// qualifies (reverse_complement's in/out byte buffers,
+	// fannkuch_redux's perm, k_nucleotide's count arrays).
+	OpNewI64Array     // regsCell[A] = arenas.AllocI64Arr(int(uint16(C)))
+	OpI64ArrayLenI64  // regsI64[A] = int64(len(arenas.I64Arrs[idx].data))
+	OpI64ArrayPushI64 // arenas.I64Arrs[idx].data = append(..., regsI64[B])
+	OpI64ArrayGetI64  // regsI64[A] = arenas.I64Arrs[idx].data[regsI64[uint16(C)]]
+	OpI64ArraySetI64  // arenas.I64Arrs[idx].data[regsI64[uint16(C)]] = regsI64[B]
 )
 
 // Op is a single 8-byte vm3 bytecode word. Layout:

--- a/runtime/vm3/vm.go
+++ b/runtime/vm3/vm.go
@@ -822,6 +822,32 @@ func (vm *VM) run() (Cell, error) {
 			arenas.F64Arrs[idx].data[regsI64[uint16(op.C)]] = regsF64[op.B]
 			pc++
 
+		case OpNewI64Array:
+			regsCell[op.A] = arenas.AllocI64Arr(int(uint16(op.C)))
+			pc++
+		case OpI64ArrayLenI64:
+			arr := regsCell[op.B]
+			_, _, idx := arr.DecodeHandle()
+			regsI64[op.A] = int64(len(arenas.I64Arrs[idx].data))
+			pc++
+		case OpI64ArrayPushI64:
+			arr := regsCell[op.A]
+			_, _, idx := arr.DecodeHandle()
+			a := &arenas.I64Arrs[idx]
+			a.data = append(a.data, regsI64[op.B])
+			a.len = uint32(len(a.data))
+			pc++
+		case OpI64ArrayGetI64:
+			arr := regsCell[op.B]
+			_, _, idx := arr.DecodeHandle()
+			regsI64[op.A] = arenas.I64Arrs[idx].data[regsI64[uint16(op.C)]]
+			pc++
+		case OpI64ArraySetI64:
+			arr := regsCell[op.A]
+			_, _, idx := arr.DecodeHandle()
+			arenas.I64Arrs[idx].data[regsI64[uint16(op.C)]] = regsI64[op.B]
+			pc++
+
 		case OpNewMap:
 			regsCell[op.A] = arenas.AllocMap(int(uint16(op.C)))
 			pc++

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2366,6 +2366,45 @@ Closure verdict: **port admitted, closure-pending.** The kernel is JIT-compiled 
 
 **Exit gate.** `reverse_complement` is now ported and JIT-admitted on macOS arm64; closure under 2x is deferred to Phase 6.3.4.l.4 (I64Array surface). Composite BG-suite progress on macOS arm64 with both l.2 and l.3 landed: 7/11 programs closed under 2x of Go, 8/11 ported with one (reverse_complement) closure-pending. Remaining unported: binary_trees (needs vm3 pair arena), pidigits_scaled (needs bignum), regex_redux_scaled (needs regex+strings).
 
+#### Phase 6.3.4.l.4: I64Array surface + close reverse_complement under 2x of Go (2026-05-20 01:50 GMT+7)
+
+**What landed.** A full typed-i64 array surface parallel to j.5's F64Array, plus the kernel migration that puts reverse_complement under 2x of Go on macOS arm64.
+
+1. **vm3 surface.** Five new opcodes (`OpNewI64Array`, `OpI64ArrayLenI64`, `OpI64ArrayPushI64`, `OpI64ArrayGetI64`, `OpI64ArraySetI64`) with `vmI64Array` arena type and an `AllocI64Arr(n)` helper that returns a length-`n` zero-filled `[]int64` slab (mirrors `AllocF64Arr`; differs from `AllocList` which is empty + `capHint` capacity). The interp tags are bank-checked the same way the F64Array path is.
+2. **JIT layout helpers.** `vm3.JITI64ArrDataOffset()` / `JITI64ArrSlabStride()` (and matching len/cap offsets) so both backends can encode raw slab access without poking into the Go struct directly. A new `JITPreAllocI64ArrPrefix uint16` field on `Function` mirrors `JITPreAllocListPrefix` / `JITPreAllocF64ArrPrefix`.
+3. **Arena context.** `jitArenaCtx` gains an `i64ArrsBase` field at offset 24 (after `listsBase=0`, `mapsBase=8`, `f64ArrsBase=16`), and `init.go`'s `jitCall` walks the contiguous `OpNewI64Array` pc=0..K-1 prefix to pre-allocate handles into `regsCell[A]` before jumping to JIT.
+4. **ARM64 lowering** (`lower_arm64.go`). New `slabKindI64Arr=4` enum, `slabBaseOff=24`, `slabStride=sizeof(vmI64Array)`. Emit code for the 5 ops:
+    - `OpNewI64Array`: returns `[]uint32{}` when `idx < int(fn.JITPreAllocI64ArrPrefix)`; otherwise `ErrNotImplemented` so the function falls back to interp.
+    - `OpI64ArrayGetI64` / `SetI64`: 6-inst cold form `UXTW + MOV stride + MUL + ADD x19 + LDR data.ptr + LDR/STR Xd[Xidx,LSL #3]` against the I64Arr slab base in the arena.
+    - `OpI64ArrayLenI64`: 5-inst cold form, `LDR W` from the in-place `lenOff` field.
+    - `OpI64ArrayPushI64`: bounds-check len vs cap, deopt with `StatusListGrow` on overflow, write at `data.ptr + len*8`, increment len. Reuses the same status code as list-grow so the existing regrow-and-retry path covers it.
+5. **Admission**. The 4 access ops are added to the cell-bank ARM64 whitelist; `OpNewI64Array` admits only at pc < `preAllocI64ArrPrefix(fn)`. AMD64 needs no work this phase because the AMD64 backend still rejects all cell-bank fns at the function level (`compile.go:210-212`).
+6. **Kernel migration.** `compiler3/corpus/reverse_complement.go` switched from `OpList*` to `OpI64Array*`, drops the Push-then-Set pattern (would have written past index `[0, n)` because `AllocI64Arr(n)` is already length-`n`), and uses direct `OpI64ArraySetI64` into the pre-sized buffers. `NumRegsI64` drops 6 → 5 (no `zero` register needed); op count drops 28 → 26.
+
+**Measured (Apple M4, darwin/arm64, `go test -bench`, 2s, ns/op, 3 runs).** Lower is better.
+
+| Bench                                  | Interp (l.3) | JIT (l.3)  | JIT (l.4)  |  Go    | JIT vs Go |
+| -------------------------------------- | -----------: | ---------: | ---------: | -----: | --------: |
+| `reverse_complement_n1000`             |       50,628 |     29,229 |      2,189 |  2,099 |     1.04x |
+| `reverse_complement_n10000`            |      506,175 |    280,782 |     20,242 | 17,110 |     1.18x |
+
+**Closure verdict: closed under 2x of Go at both sizes.** The l.4 JIT path is 13.4x faster than the l.3 JIT path at n=1000 and 13.9x faster at n=10000 because the per-access cost drops from a 14-inst cell-bank list path (BFI on push/set, SBFX on get) to a 6-inst typed-i64 path (UXTW + MUL stride + ADD base + LDR data.ptr + LDR/STR data). At n=10000 the 1.18x ratio is dominated by JIT call overhead + arena ctx setup divided across more iterations; at n=1000 the call overhead is the same constant which is why the smaller size sits closer to parity.
+
+**Correctness.** Three new tests in `runtime/jit/vm3jit/i64arr_arm64_test.go`:
+
+- `TestI64ArrayJITGetSet`: 5-slot round-trip with mixed i16-fitting values; checks `JITCode != nil`, `JITPreAllocI64ArrPrefix == 1`, sum matches.
+- `TestI64ArrayJITLen`: pre-alloc + `OpI64ArrayLenI64` round-trip.
+- `TestReverseComplementJITCompiles`: full kernel through `CompileProgram` for `n ∈ {0, 1, 2, 4, 7, 16, 100, 1000, 8000}`; checks `JITPreAllocI64ArrPrefix == 2` and asserts strict equality against `ExpectReverseComplement`. All sizes pass.
+
+`TestReverseComplementMatchesOracle` (in `compiler3/corpus`) still passes after the migration: the kernel result is identical because the user-visible semantics (Set into a pre-sized buffer) match the previous Push-into-empty semantics for the indices `[0, n)`.
+
+**Deferred to follow-ups.**
+
+- AMD64 lowering: the kernel runs through the interpreter on amd64 hosts until cell-bank lowering lands there (paired with j.5.d).
+- Linux server2 re-bench: paired with the amd64 closure so a single platform sweep records both arm64 and amd64.
+
+**Exit gate.** `reverse_complement` closes under 2x of Go on macOS arm64 at both n=1000 (1.04x) and n=10000 (1.18x). Composite BG-suite progress on macOS arm64 with l.4 landed: **8/11 programs closed under 2x of Go, 8/11 ported.** Remaining unported: binary_trees (needs vm3 pair arena), pidigits_scaled (needs bignum), regex_redux_scaled (needs regex+strings).
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
## Summary

- Phase 6.3.4.l.4 of MEP-40: add typed-i64 array opcode surface parallel to j.5's F64Array (5 new ops + ARM64 lowering + admission + arena slab + pre-alloc prefix), migrate `reverse_complement` to use it, and close the kernel under 2x of Go.
- Closes #21804.

## Measured (Apple M4, darwin/arm64, ns/op, 2s benchtime, 3 runs averaged)

| Bench                      | JIT l.3 | JIT l.4 |  Go    | l.4 vs Go |
| -------------------------- | ------: | ------: | -----: | --------: |
| reverse_complement_n1000   |  29,229 |   2,189 |  2,099 |     1.04x |
| reverse_complement_n10000  | 280,782 |  20,242 | 17,110 |     1.18x |

13.4x speedup at n=1000 and 13.9x at n=10000 vs the l.3 JIT path, driven by the typed-i64 6-inst access cold form replacing the 14-inst Cell-wrapped list path.

Composite BG-suite progress on macOS arm64: **8/11 programs closed under 2x of Go, 8/11 ported.** Remaining unported: binary_trees, pidigits_scaled, regex_redux_scaled.

## Test plan

- [x] `go test ./runtime/jit/vm3jit/ -run 'TestI64Array|TestReverseComplementJIT' -v` - new tests pass
- [x] `go test ./runtime/jit/vm3jit/ ./compiler3/corpus/ ./runtime/vm3/` - full regression sweep clean
- [x] `go test ./compiler3/corpus/ -bench 'BenchmarkReverseComplementGo' -benchtime 2s -count 3` - Go baseline
- [x] `go test ./runtime/jit/vm3jit/ -bench 'BenchmarkCorpusJITRunner/reverse_complement' -benchtime 2s -count 3` - JIT bench
- [ ] AMD64 paired closure (deferred; function-level cell-bank reject still in place on amd64)
- [ ] Linux server2 re-bench (paired with amd64)