### PR TITLE
mep-0040 phase 6.3.4.m.1: vm3 pair opcodes + binary_trees port

### DIFF
--- a/compiler3/corpus/binary_trees.go
+++ b/compiler3/corpus/binary_trees.go
@@ -1,0 +1,144 @@
+package corpus
+
+import "mochi/runtime/vm3"
+
+// ExpectBinaryTrees mirrors the BG `binary_trees` Go template: build
+// 2^depth depth-`depth` trees with two-element nodes, return the total
+// node count summed across all `iters` trees. Each depth-`d` tree has
+// 2^(d+1)-1 nodes by induction (2 children + self), so the result is
+// `iters * (2^(depth+1) - 1) = 2^depth * (2^(depth+1) - 1)`. For
+// depth=10 this is 1024 * 2047 = 2,096,128; for depth=12 it is
+// 4096 * 8191 = 33,550,336.
+func ExpectBinaryTrees(depth int64) int64 {
+	if depth <= 0 {
+		return 1
+	}
+	iters := int64(1)
+	for range depth {
+		iters *= 2
+	}
+	nodes := int64(1)
+	for range depth + 1 {
+		nodes *= 2
+	}
+	nodes--
+	return iters * nodes
+}
+
+// BinaryTrees: BG `binary_trees` cross-lang shape port. Three vm3
+// functions exercise the new Phase 6.3.4.m.1 pair-arena ops
+// (OpNewPair, OpPairFst, OpPairSnd) end-to-end:
+//
+//  1. make_tree(d) -> Cell: allocates 2^(d+1)-1 pairs recursively.
+//     Leaves are OpNewPair(reg, reg) for arbitrary `reg`; the slot
+//     contents are never read because check_tree terminates on d==0
+//     before touching the pair.
+//  2. check_tree(t, d) -> i64: walks the tree, returning 2^(d+1)-1 by
+//     reading PairFst/PairSnd at every non-leaf and recursing.
+//  3. main(depth) -> i64: 2^depth iterations of
+//     `total += check_tree(make_tree(depth), depth)`.
+//
+// Bank usage by callee:
+//
+//	make_tree:   ParamBanks=[I64], ResultBank=Cell.
+//	check_tree:  ParamBanks=[Cell, I64], ResultBank=I64.
+//	main:        ParamBanks=[I64], ResultBank=I64.
+//
+// Per-node cost: 2 pair reads + 2 cross-fn calls + 2 i64 adds on the
+// check side, 1 OpNewPair on the make side. Allocation pressure is one
+// vmPair slot per node (leaves included), matching the Go peer's one
+// slice header per node.
+var BinaryTrees = &Program{
+	Name: "binary_trees",
+	Build: func(depth int64) *vm3.Program {
+		// make_tree(d): allocate pair tree.
+		//   regsI64[0]  = d (param)
+		//   regsI64[1]  = d-1 (arg slot for recursive call)
+		//   regsCell[0] = fst child (return slot for first recursive call)
+		//   regsCell[1] = snd child (return slot for second recursive call)
+		//   regsCell[2] = pair result
+		makeTree := &vm3.Function{
+			Name:        "make_tree",
+			NumRegsI64:  2,
+			NumRegsCell: 3,
+			ParamBanks:  []vm3.Bank{vm3.BankI64},
+			ResultBank:  vm3.BankCell,
+			Code: []vm3.Op{
+				vm3.MakeOp(vm3.OpCmpGtI64KBr, 0, 0, 3),                                       // pc=0: if d > 0 -> 3
+				vm3.MakeOp(vm3.OpNewPair, 2, 0, 0),                                           // pc=1: leaf pair(reg0,reg0)
+				vm3.MakeOp(vm3.OpReturnCell, 2, 0, 0),                                        // pc=2: return leaf
+				vm3.MakeOp(vm3.OpSubI64K, 1, 0, 1),                                           // pc=3: arg = d-1
+				{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankCell), A: 0, B: 1, C: 1},    // pc=4: regsCell[0] = make_tree(d-1)
+				{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankCell), A: 1, B: 1, C: 1},    // pc=5: regsCell[1] = make_tree(d-1)
+				vm3.MakeOp(vm3.OpNewPair, 2, 0, 1),                                           // pc=6: pair(fst, snd)
+				vm3.MakeOp(vm3.OpReturnCell, 2, 0, 0),                                        // pc=7: return pair
+			},
+		}
+		// check_tree(t, d): walk tree, return node count.
+		// Callee sees regsCell[0]=t, regsI64[1]=d (ParamBanks=[Cell, I64]).
+		//   regsI64[1]  = d (param)
+		//   regsI64[2]  = sum (result)
+		//   regsI64[3]  = d-1 (arg1 for recursive call, B=2 -> regsI64[B+1])
+		//   regsI64[4]  = left count return
+		//   regsI64[5]  = right count return
+		//   regsCell[0] = t (param)
+		//   regsCell[2] = current child (arg0 for recursive call, regsCell[B])
+		checkTree := &vm3.Function{
+			Name:        "check_tree",
+			NumRegsI64:  6,
+			NumRegsCell: 3,
+			ParamBanks:  []vm3.Bank{vm3.BankCell, vm3.BankI64},
+			ResultBank:  vm3.BankI64,
+			Code: []vm3.Op{
+				vm3.MakeOp(vm3.OpCmpGtI64KBr, 1, 0, 2),                                       // pc=0: if d > 0 -> 2
+				vm3.MakeOp(vm3.OpReturnConstK, 0, 0, 1),                                      // pc=1: leaf returns 1
+				vm3.MakeOp(vm3.OpSubI64K, 3, 1, 1),                                           // pc=2: d_minus_1 = d-1
+				vm3.MakeOp(vm3.OpPairFst, 2, 0, 0),                                           // pc=3: regsCell[2] = PairFst(t)
+				{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 4, B: 2, C: 2},     // pc=4: left = check_tree(fst, d-1)
+				vm3.MakeOp(vm3.OpPairSnd, 2, 0, 0),                                           // pc=5: regsCell[2] = PairSnd(t)
+				{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 5, B: 2, C: 2},     // pc=6: right = check_tree(snd, d-1)
+				vm3.MakeOp(vm3.OpAddI64, 2, 4, 5),                                            // pc=7: sum = left + right
+				vm3.MakeOp(vm3.OpAddI64K, 2, 2, 1),                                           // pc=8: sum += 1
+				vm3.MakeOp(vm3.OpReturnI64, 2, 0, 0),                                         // pc=9: return sum
+			},
+		}
+		// main(depth) -> i64.
+		//   regsI64[0]  = depth (param)
+		//   regsI64[1]  = iters
+		//   regsI64[2]  = i (outer loop counter)
+		//   regsI64[3]  = total (accumulator)
+		//   regsI64[4]  = arg slot for make_tree (depth), B=4
+		//   regsI64[5]  = arg slot for check_tree's d (also reused as k during 2^depth pre-loop)
+		//   regsI64[6]  = check_tree return
+		//   regsCell[4] = tree (make_tree dst, check_tree arg0 at B=4)
+		// Pre-loop: iters = 2^depth.
+		// Main loop: total += check_tree(make_tree(depth), depth) repeated iters times.
+		main := &vm3.Function{
+			Name:        "binary_trees_main",
+			NumRegsI64:  7,
+			NumRegsCell: 5,
+			ParamBanks:  []vm3.Bank{vm3.BankI64},
+			ResultBank:  vm3.BankI64,
+			Code: []vm3.Op{
+				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 1),                                         // pc=0:  iters = 1
+				vm3.MakeOp(vm3.OpConstI64K, 5, 0, 0),                                         // pc=1:  k = 0
+				vm3.MakeOp(vm3.OpCmpGeI64Br, 5, 0, 6),                                        // pc=2:  if k >= depth -> 6
+				vm3.MakeOp(vm3.OpMulI64K, 1, 1, 2),                                           // pc=3:  iters *= 2
+				vm3.MakeOp(vm3.OpAddI64K, 5, 5, 1),                                           // pc=4:  k++
+				vm3.MakeOp(vm3.OpJump, 0, 0, 2),                                              // pc=5:  -> 2
+				vm3.MakeOp(vm3.OpConstI64K, 2, 0, 0),                                         // pc=6:  i = 0
+				vm3.MakeOp(vm3.OpConstI64K, 3, 0, 0),                                         // pc=7:  total = 0
+				vm3.MakeOp(vm3.OpCmpGeI64Br, 2, 1, 16),                                       // pc=8:  if i >= iters -> 16
+				vm3.MakeOp(vm3.OpMovI64, 4, 0, 0),                                            // pc=9:  regsI64[4] = depth
+				{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankCell), A: 4, B: 4, C: 1},    // pc=10: regsCell[4] = make_tree(depth)
+				vm3.MakeOp(vm3.OpMovI64, 5, 0, 0),                                            // pc=11: regsI64[5] = depth
+				{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 6, B: 4, C: 2},     // pc=12: regsI64[6] = check_tree(regsCell[4], regsI64[5])
+				vm3.MakeOp(vm3.OpAddI64, 3, 3, 6),                                            // pc=13: total += check_ret
+				vm3.MakeOp(vm3.OpAddI64K, 2, 2, 1),                                           // pc=14: i++
+				vm3.MakeOp(vm3.OpJump, 0, 0, 8),                                              // pc=15: -> 8
+				vm3.MakeOp(vm3.OpReturnI64, 3, 0, 0),                                         // pc=16: return total
+			},
+		}
+		return &vm3.Program{Funcs: []*vm3.Function{main, makeTree, checkTree}, Entry: 0}
+	},
+}

--- a/compiler3/corpus/binary_trees_test.go
+++ b/compiler3/corpus/binary_trees_test.go
@@ -1,0 +1,105 @@
+package corpus
+
+import (
+	"testing"
+
+	vm3 "mochi/runtime/vm3"
+)
+
+// TestBinaryTreesMatchesOracle runs the vm3 binary_trees kernel through
+// the interpreter and asserts strict equality against
+// ExpectBinaryTrees. The depth sweep covers the leaf case (0), small
+// depths (1..4), and one mid-size depth (8) so the recursive pair
+// arena alloc / PairFst / PairSnd path is exercised end-to-end without
+// triggering the slow BG bench sizes (depth=10/12 are saved for the
+// bench harness).
+func TestBinaryTreesMatchesOracle(t *testing.T) {
+	for _, depth := range []int64{0, 1, 2, 3, 4, 5, 8} {
+		prog := BinaryTrees.Build(depth)
+		vm := vm3.NewWithProgram(prog)
+		got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{depth})
+		if err != nil {
+			t.Fatalf("binary_trees(%d): %v", depth, err)
+		}
+		want := ExpectBinaryTrees(depth)
+		if got.Int() != want {
+			t.Errorf("binary_trees(%d) = %d, want %d", depth, got.Int(), want)
+		}
+	}
+}
+
+// BenchmarkBinaryTreesInterp measures interp-only throughput on the
+// two BG cross-lang sizes.
+func BenchmarkBinaryTreesInterp(b *testing.B) {
+	for _, tc := range []struct {
+		name  string
+		depth int64
+	}{
+		{"binary_trees_n10", 10},
+		{"binary_trees_n12", 12},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			prog := BinaryTrees.Build(tc.depth)
+			vm := vm3.NewWithProgram(prog)
+			fn := prog.Funcs[prog.Entry]
+			args := []int64{tc.depth}
+			b.ResetTimer()
+			for range b.N {
+				_, _ = vm.RunWithArgs(fn, args)
+			}
+		})
+	}
+}
+
+type goTree []goTree
+
+func goMakeTree(d int64) goTree {
+	if d == 0 {
+		return goTree{}
+	}
+	return goTree{goMakeTree(d - 1), goMakeTree(d - 1)}
+}
+
+func goCheckTree(t goTree) int64 {
+	if len(t) == 0 {
+		return 1
+	}
+	return 1 + goCheckTree(t[0]) + goCheckTree(t[1])
+}
+
+func goBinaryTrees(depth int64) int64 {
+	iters := int64(1)
+	for range depth {
+		iters *= 2
+	}
+	var total int64
+	for range iters {
+		total += goCheckTree(goMakeTree(depth))
+	}
+	return total
+}
+
+var binaryTreesGoSink int64
+
+// BenchmarkBinaryTreesGo is the matching native-Go reference (mirrors
+// bench/template/bg/binary_trees/binary_trees.go.tmpl: actually
+// allocates and walks the nested-2-slice tree) so the vm3-vs-Go ratio
+// is fair.
+func BenchmarkBinaryTreesGo(b *testing.B) {
+	for _, tc := range []struct {
+		name  string
+		depth int64
+	}{
+		{"binary_trees_n10", 10},
+		{"binary_trees_n12", 12},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			d := tc.depth
+			var s int64
+			for i := 0; i < b.N; i++ {
+				s += goBinaryTrees(d + int64(i&1))
+			}
+			binaryTreesGoSink = s
+		})
+	}
+}

--- a/compiler3/corpus/corpus.go
+++ b/compiler3/corpus/corpus.go
@@ -33,5 +33,6 @@ func All() []*Program {
 		SpectralNorm,
 		FannkuchRedux,
 		ReverseComplement,
+		BinaryTrees,
 	}
 }

--- a/runtime/jit/vm3jit/bench_corpus_jit_test.go
+++ b/runtime/jit/vm3jit/bench_corpus_jit_test.go
@@ -66,6 +66,8 @@ func BenchmarkCorpusJITRunner(b *testing.B) {
 		{"fannkuch_redux_n10000", corpus.FannkuchRedux, 10000},
 		{"reverse_complement_n1000", corpus.ReverseComplement, 1000},
 		{"reverse_complement_n10000", corpus.ReverseComplement, 10000},
+		{"binary_trees_n10", corpus.BinaryTrees, 10},
+		{"binary_trees_n12", corpus.BinaryTrees, 12},
 	}
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {

--- a/runtime/vm3/op.go
+++ b/runtime/vm3/op.go
@@ -203,6 +203,16 @@ const (
 	OpI64ArrayPushI64 // arenas.I64Arrs[idx].data = append(..., regsI64[B])
 	OpI64ArrayGetI64  // regsI64[A] = arenas.I64Arrs[idx].data[regsI64[uint16(C)]]
 	OpI64ArraySetI64  // arenas.I64Arrs[idx].data[regsI64[uint16(C)]] = regsI64[B]
+
+	// Pair (Phase 6.3.4.m.1). The vmPair arena was provisioned by Phase
+	// 3.6 and is the storage shape for binary_trees: every interior tree
+	// node is an immutable 2-Cell pair. Leaves carry whatever happens to
+	// be in the two slots; the canonical kernel reaches them only after
+	// a depth check, never via PairFst/PairSnd. The opcode trio mirrors
+	// AllocPair/PairFst/PairSnd in accessors.go.
+	OpNewPair // regsCell[A] = arenas.AllocPair(regsCell[B], regsCell[uint16(C)])
+	OpPairFst // regsCell[A] = arenas.PairFst(regsCell[B])
+	OpPairSnd // regsCell[A] = arenas.PairSnd(regsCell[B])
 )
 
 // Op is a single 8-byte vm3 bytecode word. Layout:

--- a/runtime/vm3/vm.go
+++ b/runtime/vm3/vm.go
@@ -848,6 +848,16 @@ func (vm *VM) run() (Cell, error) {
 			arenas.I64Arrs[idx].data[regsI64[uint16(op.C)]] = regsI64[op.B]
 			pc++
 
+		case OpNewPair:
+			regsCell[op.A] = arenas.AllocPair(regsCell[op.B], regsCell[uint16(op.C)])
+			pc++
+		case OpPairFst:
+			regsCell[op.A] = arenas.PairFst(regsCell[op.B])
+			pc++
+		case OpPairSnd:
+			regsCell[op.A] = arenas.PairSnd(regsCell[op.B])
+			pc++
+
 		case OpNewMap:
 			regsCell[op.A] = arenas.AllocMap(int(uint16(op.C)))
 			pc++

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2405,6 +2405,35 @@ Closure verdict: **port admitted, closure-pending.** The kernel is JIT-compiled 
 
 **Exit gate.** `reverse_complement` closes under 2x of Go on macOS arm64 at both n=1000 (1.04x) and n=10000 (1.18x). Composite BG-suite progress on macOS arm64 with l.4 landed: **8/11 programs closed under 2x of Go, 8/11 ported.** Remaining unported: binary_trees (needs vm3 pair arena), pidigits_scaled (needs bignum), regex_redux_scaled (needs regex+strings).
 
+#### Phase 6.3.4.m.1: vm3 pair opcodes + binary_trees port + interp baseline (2026-05-20 02:06 GMT+7)
+
+**What landed.** The first half of the binary_trees closure: a minimal pair-arena surface in vm3 plus the compiler3 corpus port and a fair Go reference. JIT closure for `binary_trees` is deferred to Phase 6.3.4.m.2; this phase ships the interp-only baseline so the composite BG-suite gate has a measurable starting point and the JIT lowering work in m.2 has a stable in-tree kernel to admit.
+
+1. **vm3 surface.** Three new opcodes in `runtime/vm3/op.go`: `OpNewPair`, `OpPairFst`, `OpPairSnd`. The `vmPair` arena was provisioned in Phase 3.6 (`AllocPair` / `PairFst` / `PairSnd` already live in `accessors.go`, GC traversal already wired at `gc.go:144`), so this phase only needs the opcode entry points. The three interp cases in `runtime/vm3/vm.go` are one-line dispatches into the existing accessors: `regsCell[A] = arenas.AllocPair(regsCell[B], regsCell[uint16(C)])` and the symmetric `PairFst` / `PairSnd` reads. No bank-flag bits are consumed; the operand layout follows the standard A/B/C `Op` shape.
+2. **Corpus port.** `compiler3/corpus/binary_trees.go` defines the BG `binary_trees` kernel as three vm3 functions mirroring the cross-lang template:
+    - `make_tree(d) -> Cell`: 8 ops, `ParamBanks=[I64]`, `ResultBank=Cell`, `NumRegsI64=2`, `NumRegsCell=3`. Allocates 2^(d+1)-1 pairs recursively; leaves are `OpNewPair(reg, reg)` with arbitrary slot contents (never read because `check_tree` terminates on `d==0` before touching the pair).
+    - `check_tree(t, d) -> i64`: 10 ops, `ParamBanks=[Cell, I64]`, `ResultBank=I64`, `NumRegsI64=6`, `NumRegsCell=3`. Walks the tree returning 2^(d+1)-1 by reading `PairFst` / `PairSnd` at every non-leaf and recursing.
+    - `binary_trees_main(depth) -> i64`: 17 ops, `ParamBanks=[I64]`, `ResultBank=I64`, `NumRegsI64=7`, `NumRegsCell=5`. 2^depth iterations of `total += check_tree(make_tree(depth), depth)`. The 2^depth pre-loop uses one `OpMulI64K` (k=2) per bit instead of `OpShlI64K` to avoid adding new opcodes for this kernel.
+3. **Oracle.** `ExpectBinaryTrees(depth)` uses the closed form `iters * (2^(depth+1) - 1) = 2^depth * (2^(depth+1) - 1)` (depth=10: 1024×2047 = 2,096,128; depth=12: 4096×8191 = 33,550,336). `TestBinaryTreesMatchesOracle` covers `depth ∈ {0, 1, 2, 3, 4, 5, 8}`, sweeping the leaf case, small depths, and one mid-size depth so the recursive pair arena alloc / PairFst / PairSnd path is exercised end-to-end without the slow BG bench sizes.
+4. **Fair Go peer.** `BenchmarkBinaryTreesGo` uses a `goTree []goTree` nested-slice tree with `goMakeTree` / `goCheckTree` that actually allocates and walks the structure, mirroring `bench/template/bg/binary_trees/binary_trees.go.tmpl`. An earlier draft used the closed-form `ExpectBinaryTrees` directly, which would have been an O(1) math eval and made the vm3-vs-Go ratio meaningless.
+5. **Bench harness wiring.** `runtime/jit/vm3jit/bench_corpus_jit_test.go` registers `binary_trees_n10` and `binary_trees_n12` alongside the rest of the corpus. With no JIT lowering for the pair ops yet, `vm3jit.CompileProgram` silently skips both `make_tree` and `check_tree` and the bench routes through the interp default case via `vm.RunWithArgs`.
+6. **Registry.** `compiler3/corpus/corpus.go` exports `BinaryTrees` from `All()` so harnesses iterating the corpus pick up the new kernel without explicit listing.
+
+**Measured (Apple M4, darwin/arm64, `go test -bench`, 2s, ns/op, 3 runs).** Lower is better.
+
+| Bench                          | Interp     |    Go     | Interp vs Go |
+| ------------------------------ | ---------: | --------: | -----------: |
+| `binary_trees_n10`             |  148.5 ms  |  43.2 ms  |        3.43x |
+| `binary_trees_n12`             |   2756 ms  |   723 ms  |        3.82x |
+
+Per-node cost: 2 pair reads + 2 cross-fn calls + 2 i64 adds on the check side, 1 `OpNewPair` on the make side. Allocation pressure is one `vmPair` slot per node (2^(d+1)-1 per tree), matching the Go peer's one slice header per node.
+
+**Closure verdict: port-only at this phase; closure under 2x of Go deferred to Phase 6.3.4.m.2.** The 3.4-3.8x gap is dominated by dispatch overhead on the small bodies (`check_tree` is 10 ops, half of which are calls), and arena `AllocPair` / `PairFst` / `PairSnd` walk through the same handle-decode path as every other Cell op. JIT closure in m.2 needs (a) ARM64 cold-form lowering for `OpPairFst` / `OpPairSnd` (UXTW + MUL stride + ADD pairsBase + LDR at `fstOff` / `sndOff`), (b) a `pairsBase` slot in `jitArenaCtx` at offset 32, (c) admission of `check_tree` once pair reads compile, and (d) either inline bump-pointer `OpNewPair` lowering or a pre-allocated pair-pool prefix so `make_tree` is admissible. Phase 6.3.4.l.4's F64Array / I64Array prefix trick does not directly apply because `make_tree` allocates inside a loop, not in a pc=0..K-1 contiguous prefix.
+
+**Correctness.** `TestBinaryTreesMatchesOracle` passes for `depth ∈ {0, 1, 2, 3, 4, 5, 8}`. Full regression sweep clean across `compiler3/corpus`, `runtime/vm3`, and `runtime/jit/vm3jit`. No existing test regressed; pair ops are additive.
+
+**Exit gate.** `binary_trees` is ported to compiler3, oracle-verified, and wired into the JIT bench harness with an interp-only baseline of 3.43x (n=10) and 3.82x (n=12) of Go. Composite BG-suite progress on macOS arm64 with m.1 landed: **8/11 programs closed under 2x of Go, 9/11 ported** (binary_trees ported but closure-pending). Remaining unported: pidigits_scaled (needs bignum), regex_redux_scaled (needs regex+strings). Closure for binary_trees lands in Phase 6.3.4.m.2.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
Tracks #21806.

## Summary

- Add `OpNewPair` / `OpPairFst` / `OpPairSnd` to vm3 (interp only). The `vmPair` arena and the `AllocPair` / `PairFst` / `PairSnd` accessors already landed in Phase 3.6; this PR just adds the opcode entry points.
- Port the BG `binary_trees` kernel into `compiler3/corpus` as 3 vm3 functions: `make_tree` (Cell-result, recursive pair builder), `check_tree` (I64-result, walks via `PairFst` / `PairSnd`), and `binary_trees_main` (2^depth outer driver).
- Oracle test covers `depth in {0, 1, 2, 3, 4, 5, 8}`; closed form is `iters * (2^(depth+1) - 1)`. Bench harness wired for `binary_trees_n10` and `binary_trees_n12` (both fall through to interp until Phase 6.3.4.m.2 lands JIT lowering for pair ops).

## Measured

Apple M4, darwin/arm64, `go test -bench`, 2s, 3 runs, ns/op:

| Bench               |  Interp  |   Go    | Interp vs Go |
| ------------------- | -------: | ------: | -----------: |
| binary_trees_n10    |  148.5ms |  43.2ms |        3.43x |
| binary_trees_n12    |   2756ms |   723ms |        3.82x |

Closure to under 2x of Go is deferred to Phase 6.3.4.m.2 (JIT lower `OpPairFst` / `OpPairSnd` on ARM64, decide on `OpNewPair` admission for `make_tree`).

## Composite BG-suite progress

8/11 programs closed under 2x of Go on macOS arm64, 9/11 ported (binary_trees ported, closure-pending). Remaining unported: pidigits_scaled (needs bignum), regex_redux_scaled (needs regex+strings).

## Test plan

- [x] `go test -run TestBinaryTreesMatchesOracle ./compiler3/corpus/` passes
- [x] `go test ./compiler3/corpus/ ./runtime/vm3/ ./runtime/jit/vm3jit/` clean
- [x] `go test -bench BenchmarkBinaryTrees ./compiler3/corpus/` runs and matches expected counts
- [x] `go test -bench BenchmarkCorpusJITRunner/binary_trees ./runtime/jit/vm3jit/` runs (falls back to interp)
- [x] MEP-40 spec updated with Phase 6.3.4.m.1 section