### PR TITLE
mep-0040 phase 6.3.4.m.2: JIT lower OpPairFst/OpPairSnd (ARM64) + admission

### DIFF
--- a/runtime/jit/vm3jit/arena_ctx.go
+++ b/runtime/jit/vm3jit/arena_ctx.go
@@ -40,6 +40,7 @@ type jitArenaCtx struct {
 	mapsBase    unsafe.Pointer
 	f64ArrsBase unsafe.Pointer
 	i64ArrsBase unsafe.Pointer
+	pairsBase   unsafe.Pointer
 }
 
 // populateArenaCtx snapshots the Arenas slab base pointers the JIT
@@ -51,4 +52,5 @@ func populateArenaCtx(ctx *jitArenaCtx, arenas *vm3.Arenas) {
 	ctx.mapsBase = arenas.JITMapsBase()
 	ctx.f64ArrsBase = arenas.JITF64ArrsBase()
 	ctx.i64ArrsBase = arenas.JITI64ArrsBase()
+	ctx.pairsBase = arenas.JITPairsBase()
 }

--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -235,6 +235,7 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 			vm3.OpLookupI64KW,
 			vm3.OpF64ArrayGetF64, vm3.OpF64ArraySetF64, vm3.OpF64ArrayLenI64,
 			vm3.OpI64ArrayGetI64, vm3.OpI64ArraySetI64, vm3.OpI64ArrayPushI64, vm3.OpI64ArrayLenI64,
+			vm3.OpPairFst, vm3.OpPairSnd,
 			vm3.OpConstF64K, vm3.OpMovF64,
 			vm3.OpAddF64, vm3.OpSubF64, vm3.OpMulF64, vm3.OpDivF64,
 			vm3.OpNegF64, vm3.OpFmaF64, vm3.OpSqrtF64,

--- a/runtime/jit/vm3jit/lower_arm64.go
+++ b/runtime/jit/vm3jit/lower_arm64.go
@@ -361,6 +361,7 @@ const (
 	slabKindMap
 	slabKindF64Arr
 	slabKindI64Arr
+	slabKindPair
 )
 
 // slabKindARM64 classifies fn by which slab its inline body references.
@@ -368,12 +369,14 @@ const (
 // kernels are rejected by checkCellBankAdmissible separately so they
 // never reach codegen). Phase 6.3.4.j.5.b adds slabKindF64Arr for
 // typed-f64-array kernels; Phase 6.3.4.l.4 adds slabKindI64Arr for
-// typed-i64-array kernels.
+// typed-i64-array kernels; Phase 6.3.4.m.2 adds slabKindPair for
+// pair-arena kernels.
 func slabKindARM64(fn *vm3.Function) slabKind {
 	hasList := hasListGetI64(fn) || hasListPushI64(fn)
 	hasMap := hasMapOpI64(fn)
 	hasF64Arr := hasF64ArrayOp(fn)
 	hasI64Arr := hasI64ArrayOp(fn)
+	hasPair := hasPairOp(fn)
 	n := 0
 	if hasList {
 		n++
@@ -385,6 +388,9 @@ func slabKindARM64(fn *vm3.Function) slabKind {
 		n++
 	}
 	if hasI64Arr {
+		n++
+	}
+	if hasPair {
 		n++
 	}
 	if n != 1 {
@@ -399,6 +405,8 @@ func slabKindARM64(fn *vm3.Function) slabKind {
 		return slabKindF64Arr
 	case hasI64Arr:
 		return slabKindI64Arr
+	case hasPair:
+		return slabKindPair
 	}
 	return slabKindNone
 }
@@ -406,9 +414,9 @@ func slabKindARM64(fn *vm3.Function) slabKind {
 // slabBaseOffARM64 returns the byte offset within jitArenaCtx of the
 // slab base pointer the prologue should load into x19. Mirrors the
 // field order in jitArenaCtx: listsBase at offset 0, mapsBase at 8,
-// f64ArrsBase at 16, i64ArrsBase at 24. Fns with no slab kind default
-// to listsBase so the existing list-only admit set keeps its prologue
-// word count unchanged.
+// f64ArrsBase at 16, i64ArrsBase at 24, pairsBase at 32. Fns with no
+// slab kind default to listsBase so the existing list-only admit set
+// keeps its prologue word count unchanged.
 func slabBaseOffARM64(fn *vm3.Function) uint32 {
 	switch slabKindARM64(fn) {
 	case slabKindMap:
@@ -417,6 +425,8 @@ func slabBaseOffARM64(fn *vm3.Function) uint32 {
 		return 16
 	case slabKindI64Arr:
 		return 24
+	case slabKindPair:
+		return 32
 	}
 	return 0
 }
@@ -432,6 +442,8 @@ func slabStrideARM64(fn *vm3.Function) int64 {
 		return int64(vm3.JITF64ArrSlabStride())
 	case slabKindI64Arr:
 		return int64(vm3.JITI64ArrSlabStride())
+	case slabKindPair:
+		return int64(vm3.JITPairSlabStride())
 	}
 	return int64(vm3.JITListSlabStride())
 }
@@ -1682,6 +1694,13 @@ func wordCountARM64Body(fn *vm3.Function, op vm3.Op, opts Options, spillSets []u
 		stride := int64(vm3.JITF64ArrSlabStride())
 		return movImm64WordCount(stride) + 4, nil
 
+	case vm3.OpPairFst, vm3.OpPairSnd:
+		// Cold form (5 inst): UXTW + MOV stride + MUL + ADD x19 + LDR.
+		// The destination Cell reg is loaded directly via the indexed
+		// LDR from (slab byte addr + fstOff or sndOff). Phase 6.3.4.m.2.
+		stride := int64(vm3.JITPairSlabStride())
+		return movImm64WordCount(stride) + 4, nil
+
 	default:
 		return 0, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
 	}
@@ -2813,6 +2832,45 @@ func emitInstrARM64Body(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deopt
 		ws = append(ws, mulReg(16, 16, 17))
 		ws = append(ws, addReg(16, 16, 19))
 		ws = append(ws, ldrW(xA, 16, lenOff/4))
+		return ws, nil
+
+	case vm3.OpPairFst:
+		// regsCell[A] = arenas.Pairs[handleIdx(regsCell[B])].fst
+		//
+		// Cold form (5 inst). Phase 6.3.4.m.2 read-only pair access.
+		// The Cell payload masks down to a 32-bit slab index; the
+		// indexed LDR pulls the fst Cell straight into the pinned A reg.
+		//   UXTW x16, w_cellB                 ; idx = handle & 0xFFFFFFFF
+		//   MOV  x17, #SIZEOF_VMPAIR          ; stride (24)
+		//   MUL  x16, x16, x17                ; slab byte offset
+		//   ADD  x16, x16, x19                ; x19 = cached pairs base
+		//   LDR  xCellA, [x16, #FST_OFFSET]   ; fst (Cell u64)
+		fstOff := uint32(vm3.JITPairFstOffset())
+		xCellB := r2cell(op.B)
+		xCellA := r2cell(op.A)
+		stride := int64(vm3.JITPairSlabStride())
+		ws := make([]uint32, 0, movImm64WordCount(stride)+4)
+		ws = append(ws, uxtwReg(16, xCellB))
+		ws = append(ws, movImm64(17, stride)...)
+		ws = append(ws, mulReg(16, 16, 17))
+		ws = append(ws, addReg(16, 16, 19))
+		ws = append(ws, ldr64(xCellA, 16, fstOff/8))
+		return ws, nil
+
+	case vm3.OpPairSnd:
+		// regsCell[A] = arenas.Pairs[handleIdx(regsCell[B])].snd
+		//
+		// Cold form (5 inst). Mirror of OpPairFst with offset 16.
+		sndOff := uint32(vm3.JITPairSndOffset())
+		xCellB := r2cell(op.B)
+		xCellA := r2cell(op.A)
+		stride := int64(vm3.JITPairSlabStride())
+		ws := make([]uint32, 0, movImm64WordCount(stride)+4)
+		ws = append(ws, uxtwReg(16, xCellB))
+		ws = append(ws, movImm64(17, stride)...)
+		ws = append(ws, mulReg(16, 16, 17))
+		ws = append(ws, addReg(16, 16, 19))
+		ws = append(ws, ldr64(xCellA, 16, sndOff/8))
 		return ws, nil
 
 	case vm3.OpI64ArrayPushI64:

--- a/runtime/jit/vm3jit/lower_common.go
+++ b/runtime/jit/vm3jit/lower_common.go
@@ -176,6 +176,33 @@ func hasI64ArrayOp(fn *vm3.Function) bool {
 	return hasI64ArrayGetI64(fn) || hasI64ArraySetI64(fn) || hasI64ArrayPushI64(fn) || hasI64ArrayLenI64(fn)
 }
 
+// hasPairFst reports whether fn contains any OpPairFst.
+func hasPairFst(fn *vm3.Function) bool {
+	for _, op := range fn.Code {
+		if op.Code == vm3.OpPairFst {
+			return true
+		}
+	}
+	return false
+}
+
+// hasPairSnd reports whether fn contains any OpPairSnd.
+func hasPairSnd(fn *vm3.Function) bool {
+	for _, op := range fn.Code {
+		if op.Code == vm3.OpPairSnd {
+			return true
+		}
+	}
+	return false
+}
+
+// hasPairOp reports whether fn touches the Pair slab via any of the
+// JIT-lowered pair-arena ops (Phase 6.3.4.m.2). Used by the prologue
+// to decide whether to load pairsBase into the slab-base pin.
+func hasPairOp(fn *vm3.Function) bool {
+	return hasPairFst(fn) || hasPairSnd(fn)
+}
+
 // popcount32 counts set bits in v. Used to size OpCallI64 spill loops
 // on every backend.
 func popcount32(v uint32) int {

--- a/runtime/jit/vm3jit/pair_arm64_test.go
+++ b/runtime/jit/vm3jit/pair_arm64_test.go
@@ -1,0 +1,100 @@
+//go:build darwin && arm64
+
+package vm3jit_test
+
+import (
+	"testing"
+
+	c3 "mochi/compiler3/corpus"
+	"mochi/runtime/jit/vm3jit"
+	"mochi/runtime/vm3"
+)
+
+// TestPairJITRead exercises the Phase 6.3.4.m.2 ARM64 lowering for
+// OpPairFst / OpPairSnd in isolation. The synthetic program builds a
+// pair on the interp side (driver runs interp because OpNewPair has no
+// JIT lowering yet), then calls a JIT-compiled helper that does
+// OpPairFst + OpPairSnd reads against the pair slab. The helper
+// returns a constant (the reads' results are dead, but the LDR
+// instructions are emitted and must not fault). End-to-end run asserts
+// the helper returns the expected constant and no deopt fires.
+func TestPairJITRead(t *testing.T) {
+	// Helper (Cell-bank, JIT-admissible). Takes a Cell, reads its fst +
+	// snd, returns a constant via OpReturnConstK.
+	helper := &vm3.Function{
+		Name:        "pair_read_helper",
+		NumRegsI64:  0,
+		NumRegsCell: 3,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpPairFst, 1, 0, 0),     // pc=0: regsCell[1] = PairFst(regsCell[0])
+			vm3.MakeOp(vm3.OpPairSnd, 2, 0, 0),     // pc=1: regsCell[2] = PairSnd(regsCell[0])
+			vm3.MakeOp(vm3.OpReturnConstK, 0, 0, 42), // pc=2: return 42
+		},
+	}
+	// Driver (interp). Builds pair(CNull, CNull), calls helper, returns
+	// helper's result. Uses OpNewPair which has no JIT lowering, so the
+	// driver itself is not admitted; it routes through the interp.
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewPair, 0, 1, 1),                                       // pc=0: regsCell[0] = pair(CNull, CNull)
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 1, B: 0, C: 1}, // pc=1: regsI64[1] = helper(regsCell[0])
+			vm3.MakeOp(vm3.OpReturnI64, 1, 0, 0),                                     // pc=2: return regsI64[1]
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil (OpPairFst/Snd should compile)")
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if got.Int() != 42 {
+		t.Fatalf("got %d, want 42", got.Int())
+	}
+}
+
+// TestBinaryTreesEndToEndWithJIT runs the full binary_trees kernel
+// through CompileProgram. None of binary_trees's three functions are
+// JIT-admissible at this phase (make_tree allocates inline, check_tree
+// self-recurses via OpCallMixed which is not yet lowered, main calls
+// both), so all three route through the interp. The test asserts the
+// program still returns the oracle value after CompileProgram, ensuring
+// the Phase 6.3.4.m.2 changes to admission whitelist + slab kind
+// dispatch don't regress binary_trees.
+func TestBinaryTreesEndToEndWithJIT(t *testing.T) {
+	for _, depth := range []int64{0, 1, 2, 3, 4, 5, 8} {
+		prog := c3.BinaryTrees.Build(depth)
+		cfs := vm3jit.CompileProgram(prog)
+		vm := vm3.NewWithProgram(prog)
+		got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{depth})
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+		if err != nil {
+			t.Fatalf("depth=%d: RunWithArgs: %v", depth, err)
+		}
+		want := c3.ExpectBinaryTrees(depth)
+		if got.Int() != want {
+			t.Fatalf("depth=%d: got %d, want %d", depth, got.Int(), want)
+		}
+	}
+}

--- a/runtime/vm3/jit_layout.go
+++ b/runtime/vm3/jit_layout.go
@@ -154,3 +154,34 @@ func (a *Arenas) JITI64ArrsBase() unsafe.Pointer {
 	}
 	return unsafe.Pointer(&a.I64Arrs[0])
 }
+
+// JITPairSlabStride returns the byte distance between consecutive
+// vmPair entries in Arenas.Pairs. Phase 6.3.4.m.2 mirror of
+// JITI64ArrSlabStride for the pair-arena slab.
+func JITPairSlabStride() uintptr {
+	return unsafe.Sizeof(vmPair{})
+}
+
+// JITPairFstOffset returns the byte offset of vmPair.fst within the
+// pair record. vm3jit bakes this immediate into OpPairFst lowering.
+func JITPairFstOffset() uintptr {
+	return unsafe.Offsetof(vmPair{}.fst)
+}
+
+// JITPairSndOffset returns the byte offset of vmPair.snd within the
+// pair record. vm3jit bakes this immediate into OpPairSnd lowering.
+func JITPairSndOffset() uintptr {
+	return unsafe.Offsetof(vmPair{}.snd)
+}
+
+// JITPairsBase returns an unsafe.Pointer to the first element of
+// arenas.Pairs, or nil if the slab is empty. Mirror of JITI64ArrsBase
+// for the pair-arena slab. Phase 6.3.4.m.2 admits OpPairFst / OpPairSnd
+// (read-only) so the snapshot stays valid for the full call; OpNewPair
+// admission lands in a follow-up sub-phase.
+func (a *Arenas) JITPairsBase() unsafe.Pointer {
+	if len(a.Pairs) == 0 {
+		return nil
+	}
+	return unsafe.Pointer(&a.Pairs[0])
+}

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2434,6 +2434,45 @@ Per-node cost: 2 pair reads + 2 cross-fn calls + 2 i64 adds on the check side, 1
 
 **Exit gate.** `binary_trees` is ported to compiler3, oracle-verified, and wired into the JIT bench harness with an interp-only baseline of 3.43x (n=10) and 3.82x (n=12) of Go. Composite BG-suite progress on macOS arm64 with m.1 landed: **8/11 programs closed under 2x of Go, 9/11 ported** (binary_trees ported but closure-pending). Remaining unported: pidigits_scaled (needs bignum), regex_redux_scaled (needs regex+strings). Closure for binary_trees lands in Phase 6.3.4.m.2.
 
+#### Phase 6.3.4.m.2: JIT lower OpPairFst / OpPairSnd (ARM64) (2026-05-20 02:21 GMT+7)
+
+**Scope: infrastructure for binary_trees closure, not closure itself.** Closing `binary_trees` end-to-end needs three independent pieces of JIT work: (a) ARM64 lowering for `OpPairFst` / `OpPairSnd`, (b) admission of `check_tree`'s self `OpCallMixed` (currently rejected at `compile.go:340` with "CallMixed to self not admitted; use OpTailCallMixed for self-tail", and tail-call form does not apply because `check_tree` consumes the recursive result via `OpAddI64`), (c) inline bump-pointer `OpNewPair` so `make_tree` is admissible. This phase ships only (a) plus the infrastructure shared by all three. Closure is split because each piece is independent and the pair-read lowering is the smallest atomic unit that pays its own keep (it would also be reused by any future `cons`-list kernel).
+
+**What landed.**
+
+1. **`pairsBase` in `jitArenaCtx`.** `runtime/jit/vm3jit/arena_ctx.go` grows a fifth slot at offset 32: `pairsBase unsafe.Pointer`. `populateArenaCtx` snapshots it from `arenas.JITPairsBase()`. The slab base is stable across the JIT call (pair arena grows but slot 0's address is pinned by the arena slab layout). The new field order is `listsBase=0, mapsBase=8, f64ArrsBase=16, i64ArrsBase=24, pairsBase=32`.
+2. **`vm3` JIT-layout helpers.** `runtime/vm3/jit_layout.go` exposes `JITPairSlabStride()` (= `unsafe.Sizeof(vmPair{})` = 24), `JITPairFstOffset()` (= 8), `JITPairSndOffset()` (= 16), and `(*Arenas).JITPairsBase()` (returns `&Arenas.Pairs[0]` or nil). These are the same shape as the existing `JITListSlabStride` / `JITMapSlabStride` helpers so the ARM64 emitter consumes them uniformly.
+3. **`slabKind` enum extension.** `runtime/jit/vm3jit/lower_arm64.go` grows a `slabKindPair` variant. `slabKindARM64(op)` returns it for `OpPairFst` / `OpPairSnd`. `slabBaseOffARM64(slabKindPair)` returns 32 (the `pairsBase` offset in `jitArenaCtx`). `slabStrideARM64(slabKindPair)` returns `JITPairSlabStride()`. `hasPairFst` / `hasPairSnd` / `hasPairOp` in `lower_common.go` mirror the existing per-op scanners so the prologue can choose the right base register.
+4. **Cold-form lowering.** Both ops emit the same 5-instruction sequence (`fstOff` for `OpPairFst`, `sndOff` for `OpPairSnd`):
+
+    ```text
+    UXTW  x16, w_cellB              ; zero-extend Cell handle low 32 (idx field)
+    MOV   x17, #24                  ; pair slab stride
+    MUL   x16, x16, x17             ; byte offset = idx * 24
+    ADD   x16, x16, x19             ; absolute slab pointer
+    LDR   xCellA, [x16, #fstOff/sndOff]
+    ```
+
+    `x19` is pre-loaded with `pairsBase` in the prologue (the dispatch picks `pairsBase` when the body references a pair op). The Cell handle's `idxMask = 0xFFFFFFFF` is the low 32 bits, so a single `UXTW` extracts the index without an `AND` immediate. `fstOff=8` and `sndOff=16` both fit in the 12-bit unsigned scaled-offset encoding of `LDR (immediate)` (the scale for 64-bit is 8, so we encode `fstOff/8=1`, `sndOff/8=2`). `opSizeARM64` returns `movImm64WordCount(24) + 4` instructions (= 5 in practice, since 24 fits in a single `MOV` immediate). No `gen` re-check is emitted; this matches the existing list / map / array cold forms where the type checker is trusted at JIT entry.
+
+5. **Admission whitelist.** `runtime/jit/vm3jit/compile.go`'s cell-bank admission gate (`checkCellBankAdmissible`) adds `OpPairFst, OpPairSnd` to the allow-list. `OpNewPair` is intentionally not added (m.4 will handle it).
+
+**Correctness.** `runtime/jit/vm3jit/pair_arm64_test.go` ships two tests:
+
+- `TestPairJITRead` is the focused unit test. A synthetic 2-fn program: an interp-only driver builds `pair(CNull, CNull)` via `OpNewPair` then cross-calls a JIT-admissible helper via `OpCallMixed` with the pair as its Cell argument; the helper does `OpPairFst regsCell[1] = fst(regsCell[0])`, `OpPairSnd regsCell[2] = snd(regsCell[0])`, `OpReturnConstK 42`. The test asserts (i) the helper compiled (`helper.JITCode != nil`, exercising admission), (ii) the program returns 42 (exercising no-fault execution of the LDR pair).
+- `TestBinaryTreesEndToEndWithJIT` is the regression test. It runs the full `binary_trees` kernel through `CompileProgram` for `depth ∈ {0, 1, 2, 3, 4, 5, 8}`. None of `make_tree` / `check_tree` / `binary_trees_main` is admitted at this phase (`make_tree` uses `OpNewPair` which has no JIT lowering, `check_tree` uses self `OpCallMixed`, `main` calls both via `OpCallMixed`), so all three route through the interp. The test asserts the oracle value still matches after `CompileProgram`, catching any regression introduced by the new admission / slab-kind dispatch path on programs whose JIT-compilation flow now visits the pair op cases.
+
+Full regression sweep clean across `compiler3/corpus`, `runtime/vm3`, `runtime/jit/vm3jit`.
+
+**Measured.** No bench impact at this phase: with no `binary_trees` function admitted, both `binary_trees_n10` and `binary_trees_n12` continue to route through the interp and the numbers are identical to m.1's `148.5 ms` / `2756 ms`. Per-op `OpPairFst` / `OpPairSnd` cost in isolation (synthetic JIT-admissible helper, M4 darwin/arm64) is the 5-instruction cold form, the same shape as the existing `OpListGetI64K` / `OpMapGetI64I64` reads.
+
+**Closure verdict: deferred to Phase 6.3.4.m.3 (self-CallMixed) + Phase 6.3.4.m.4 (OpNewPair inline alloc).** The pair-read lowering on its own does not move the bench needle because neither of the BG kernel's two hot functions is admissible without (b) and (c). The natural split:
+
+- **m.3**: lift the cell-bank self-CallMixed gate at `compile.go:340-343`. Self-recursion via PC-relative `BL` is already wired for `OpCallI64` (i64 self-recursion is admissible today); the cell-bank version needs the same prologue / epilogue spill discipline plus arg-base juggling for mixed-bank parameters. Once admitted, `check_tree` (which is now `OpPairFst` + `OpPairSnd` + 2 self-CallMixeds + adds + return) compiles. That alone should cut the BG ratio substantially even without `make_tree` admission.
+- **m.4**: inline bump-pointer `OpNewPair`. Phase 6.3.4.l.4's F64Array / I64Array prefix trick does not apply because `make_tree` allocates inside the recursive body, not in a pc=0..K-1 contiguous prefix. The cleanest design is a per-call pair-pool prefix sized by a compiler3 hint (worst case `2^(d+1)-1`), but that requires a new vm3-level concept; an interim path is a bounded bump-pointer that deopts to `arenas.AllocPair` when the pool is exhausted.
+
+**Exit gate.** `OpPairFst` / `OpPairSnd` JIT lowering lands with admission gate update + synthetic correctness + regression test. Composite BG-suite progress unchanged at **8/11 closed, 9/11 ported on macOS arm64** (binary_trees still pending closure). Closure of binary_trees rolls into m.3 + m.4.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
Tracks #21808.

## Summary

Phase 6.3.4.m.2 of MEP-40. Infrastructure step for closing `binary_trees`: cold-form ARM64 lowering for `OpPairFst` / `OpPairSnd` plus the admission gate, `jitArenaCtx` slot, and helpers they need. Binary_trees closure stays open; this lands the smallest atomic piece (pair reads) so m.3 (self-CallMixed) and m.4 (OpNewPair inline alloc) can build on top.

- `arena_ctx.go`: `pairsBase` slot in `jitArenaCtx` at offset 32.
- `jit_layout.go`: `JITPairSlabStride`, `JITPairFstOffset`, `JITPairSndOffset`, `(*Arenas).JITPairsBase`.
- `lower_arm64.go`: `slabKindPair` variant + 5-instruction cold form (UXTW + MOV stride + MUL + ADD base + LDR at fstOff/sndOff).
- `lower_common.go`: `hasPairFst` / `hasPairSnd` / `hasPairOp` scanners.
- `compile.go`: admit `OpPairFst` / `OpPairSnd` in `checkCellBankAdmissible`.
- `pair_arm64_test.go`: `TestPairJITRead` (synthetic 2-fn helper, exercises lowering) + `TestBinaryTreesEndToEndWithJIT` (regression: full kernel still produces oracle after `CompileProgram`).
- MEP-40 Phase 6.3.4.m.2 section dated 2026-05-20 02:21 GMT+7.

## What's not in this PR

- `OpNewPair` JIT lowering (m.4).
- Self-`OpCallMixed` admission for cell-bank fns (m.3).
- AMD64 mirror of the pair ops.

## Test plan

- [x] `go test -run "TestPairJITRead|TestBinaryTreesEndToEndWithJIT" ./runtime/jit/vm3jit/ -v -count=1` -> both PASS on darwin/arm64.
- [x] `go test ./compiler3/corpus/ ./runtime/vm3/ ./runtime/jit/vm3jit/ -count=1 -timeout 180s` -> all PASS, no regressions.
- [x] Bench numbers unchanged (no admissible func in this phase, interp baseline holds at 148.5ms n10 / 2756ms n12).