### PR TITLE
MEP-40 phase 6.3.4.m.4a: admit OpReturnCell + safe Cell-return JIT entry

### DIFF
--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -228,7 +228,7 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 			vm3.OpCmpEqI64KBr, vm3.OpCmpNeI64KBr,
 			vm3.OpCmpLtI64KBr, vm3.OpCmpLeI64KBr,
 			vm3.OpCmpGtI64KBr, vm3.OpCmpGeI64KBr,
-			vm3.OpJump, vm3.OpReturnI64, vm3.OpReturnConstK,
+			vm3.OpJump, vm3.OpReturnI64, vm3.OpReturnConstK, vm3.OpReturnCell,
 			vm3.OpListGetI64, vm3.OpListPushI64, vm3.OpListSetI64,
 			vm3.OpListGetF64, vm3.OpListSetF64,
 			vm3.OpMapSetI64I64, vm3.OpMapGetI64I64,

--- a/runtime/jit/vm3jit/init.go
+++ b/runtime/jit/vm3jit/init.go
@@ -321,10 +321,16 @@ func jitCall(vm *vm3.VM, fn *vm3.Function, argsI64 []int64, argsF64 []float64, a
 		// and reclaim as normal on its own Return.
 		return 0, true, nil
 	}
-	// Clean unboxed return: reclaim any arena slot allocated during the
-	// JIT'd call. Safe because admitted Cell-bank callees return
-	// unboxed scalars; no handle escapes the call.
-	vm.Arenas().RestoreUnboxedReturn(&marks)
+	// Clean return: reclaim arena slots allocated during the JIT'd call.
+	// Phase 6.3.4.m.4a: when the callee returns a Cell (ResultBank=Cell),
+	// use Layer B handle-aware copy-up so a returned local handle stays
+	// valid across the truncate. Otherwise the returned value is unboxed
+	// (i64/f64), and Layer A's plain truncate suffices.
+	if fn.ResultBank == vm3.BankCell {
+		bits = uint64(vm.Arenas().HandleCellReturn(vm3.Cell(bits), &marks))
+	} else {
+		vm.Arenas().RestoreUnboxedReturn(&marks)
+	}
 	return bits, false, nil
 }
 

--- a/runtime/jit/vm3jit/lower_arm64.go
+++ b/runtime/jit/vm3jit/lower_arm64.go
@@ -1440,6 +1440,13 @@ func wordCountARM64Body(fn *vm3.Function, op vm3.Op, opts Options, spillSets []u
 		// Bit-cast the f64 in d<A> to a uint64 in x0 so the trampoline
 		// return channel carries either bank uniformly.
 		return 2 + numCalleeSavedPairs(fn) + numLRPair(fn) + cellsLenFlushWords(fn), nil
+	case vm3.OpReturnCell:
+		// [flush] MOV x0, <pinned cell reg>; <pop callee-saved frame>; <pop x29:x30>; RET.
+		// The pinned Cell register holds the 64-bit Cell payload; the
+		// trampoline returns it bit-for-bit and jitCall surfaces it via
+		// regsCell[retReg] without going through RestoreUnboxedReturn
+		// (Phase 6.3.4.m.4a).
+		return 2 + numCalleeSavedPairs(fn) + numLRPair(fn) + cellsLenFlushWords(fn), nil
 
 	case vm3.OpConstF64K:
 		// MOV imm into x16 with the IEEE 754 bit-pattern, then
@@ -1914,6 +1921,19 @@ func emitInstrARM64Body(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deopt
 			ws = emitCellsLenFlushARM64(ws)
 		}
 		ws = append(ws, fmovXD(0, r2d(op.A)))
+		ws = emitFrameEpilogueARM64(ws, calleeSavedPairRegs(fn), numLRPair(fn))
+		ws = append(ws, ret())
+		return ws, nil
+
+	case vm3.OpReturnCell:
+		// MOV x0, <pinned cell reg> BEFORE the LDPs: the cell regs live
+		// in x25..x28 / x21..x24, which the epilogue restores. Move
+		// first, then run the standard epilogue. Phase 6.3.4.m.4a.
+		ws := make([]uint32, 0, 2+numCalleeSavedPairs(fn)+numLRPair(fn)+cellsLenFlushWords(fn))
+		if hoistsCellsLenARM64(fn) {
+			ws = emitCellsLenFlushARM64(ws)
+		}
+		ws = append(ws, movReg(0, r2cell(op.A)))
 		ws = emitFrameEpilogueARM64(ws, calleeSavedPairRegs(fn), numLRPair(fn))
 		ws = append(ws, ret())
 		return ws, nil

--- a/runtime/jit/vm3jit/pair_arm64_test.go
+++ b/runtime/jit/vm3jit/pair_arm64_test.go
@@ -168,6 +168,67 @@ func TestCheckTreeJITAdmission(t *testing.T) {
 	}
 }
 
+// TestReturnCellJIT exercises Phase 6.3.4.m.4a admission and ARM64
+// lowering of OpReturnCell. A JIT'd helper takes a Cell arg and echoes
+// it via OpReturnCell; an interp-side driver builds a pair, calls the
+// helper, and returns the helper's Cell result. The trampoline must
+// carry the Cell handle in x0 bit-for-bit, jitCall must skip the
+// unboxed-truncate path (handles point into the local arena range and
+// would be invalidated), and the returned Cell must crack to a valid
+// ArenaPair handle.
+func TestReturnCellJIT(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "echo_cell",
+		NumRegsI64:  0,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankCell,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpReturnCell, 0, 0, 0), // pc=0: return regsCell[0]
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  1,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankCell,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewPair, 0, 1, 1),                                        // pc=0: regsCell[0] = pair(CNull, CNull)
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankCell), A: 1, B: 0, C: 1}, // pc=1: regsCell[1] = helper(regsCell[0])
+			vm3.MakeOp(vm3.OpReturnCell, 1, 0, 0),                                     // pc=2: return regsCell[1]
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil (OpReturnCell should compile)")
+	}
+	preDeopt := vm3jit.DeoptCount
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if d := vm3jit.DeoptCount - preDeopt; d != 0 {
+		t.Fatalf("unexpected deopt count delta: %d", d)
+	}
+	if !got.IsHandle() {
+		t.Fatalf("returned Cell is not a handle: %#x", uint64(got))
+	}
+	tag, _, _ := got.DecodeHandle()
+	if tag != vm3.ArenaPair {
+		t.Fatalf("returned Cell tag = %d, want ArenaPair (%d)", tag, vm3.ArenaPair)
+	}
+}
+
 // TestBinaryTreesEndToEndWithJIT runs the full binary_trees kernel
 // through CompileProgram. After Phase 6.3.4.m.3 check_tree is admitted
 // (self-OpCallMixed + OpPairFst/Snd) and runs natively; make_tree and

--- a/runtime/vm3/memory.go
+++ b/runtime/vm3/memory.go
@@ -46,6 +46,18 @@ func (a *Arenas) RestoreUnboxedReturn(m *CallScopeMarks) {
 	a.truncateToMarks(&m.marks, &m.freeMarks)
 }
 
+// HandleCellReturn is the Layer B analogue of RestoreUnboxedReturn for
+// the JIT entry path (Phase 6.3.4.m.4a). It mirrors what OpReturnCell
+// does on the interp side: if the returned Cell is unboxed or points
+// below the snapshot, truncate the arena range; if it points into the
+// local range, copy-up to the mark and truncate the rest; abort the
+// truncate when the slot transitively references other local handles
+// (Layer D mark-sweep will reclaim later). The returned Cell is the
+// possibly-rewritten handle the caller should hand back to the interp.
+func (a *Arenas) HandleCellReturn(ret Cell, m *CallScopeMarks) Cell {
+	return a.handleCellReturn(ret, &m.marks, &m.freeMarks)
+}
+
 // snapshotMarks records every slab and free-list length into the
 // caller-supplied arrays. Called from pushFrame.
 func (a *Arenas) snapshotMarks(marks, freeMarks *[numArenaTags]uint32) {

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2507,6 +2507,22 @@ Full regression sweep clean across `compiler3/corpus`, `runtime/vm3`, `runtime/j
 
 **Exit gate.** Cell-bank self-`OpCallMixed` admission lands with ARM64 lowering, synthetic + integration tests, and zero-deopt confirmation. Composite BG-suite progress unchanged at **8/11 closed, 9/11 ported on macOS arm64** (binary_trees still pending closure pending m.4). Closure of binary_trees rolls into m.4.
 
+#### Phase 6.3.4.m.4a: admit OpReturnCell + Cell-return safe JIT entry (2026-05-20 03:51 GMT+7)
+
+**Scope: foundation for `make_tree` admission.** m.4 needs `make_tree` (the work side of binary_trees that allocates pairs in a loop) to compile, but the function has two prerequisites the JIT currently lacks: `OpReturnCell` is not in the cell-bank whitelist, and `jitCall`'s clean-return path calls `Arenas.RestoreUnboxedReturn` which truncates the arenas back to the per-call snapshot. A Cell-returning callee may hand back a handle pointing into the just-allocated range, and a blind truncate would invalidate it. This phase lands both: admit `OpReturnCell`, emit its ARM64 lowering, and route Cell-returning callees through a Layer-B handle-aware copy-up so the returned handle stays live across the truncate. `OpNewPair` admission + inline alloc is deferred to m.4b; this phase ships only the return-value plumbing so m.4b drops in cleanly.
+
+**What landed.**
+
+1. **Whitelist.** `compile.go`'s `checkCellBankAdmissible` adds `vm3.OpReturnCell` to the admitted-opcode switch (it now sits alongside `OpReturnI64`, `OpReturnConstK`, and `OpReturnF64`).
+2. **ARM64 emit.** `lower_arm64.go` `emitInstrARM64Body`'s case for `OpReturnCell` mirrors `OpReturnI64`: optional `cells.len` flush hoist, `MOV x0, <pinned cell reg>` using `r2cell(op.A)` to map the cell slot (0..3 → x25..x28, 4..7 → x21..x24), the standard callee-saved frame epilogue (`emitFrameEpilogueARM64`), then `RET`. Word-count entry mirrors `OpReturnF64`'s budget (`2 + numCalleeSavedPairs + numLRPair + cellsLenFlushWords`).
+3. **Layer-B JIT-entry return.** `runtime/vm3/memory.go` grows an exported `Arenas.HandleCellReturn(ret Cell, m *CallScopeMarks) Cell` wrapper around the existing internal `handleCellReturn` Layer-B helper. `jitCall` in `init.go` checks `fn.ResultBank == vm3.BankCell` on the clean-return path: if true, it bit-casts `bits` to `Cell`, calls `HandleCellReturn` against the per-call marks, and casts the (possibly-rewritten) result back to `bits`; otherwise the existing `RestoreUnboxedReturn` path runs unchanged. This mirrors the interp's `OpReturnCell` discipline (`vm.go`:704 calls `arenas.handleCellReturn` for exactly the same reason) so JIT-entry semantics now match interp-entry semantics for Cell-returning callees.
+
+**Correctness.** `pair_arm64_test.go` ships `TestReturnCellJIT`: a 2-fn program where a 1-op JIT'd helper (`OpReturnCell, 0, 0, 0`) takes a `Cell` param and echoes it; the interp-side driver builds a pair via `OpNewPair`, calls the helper through `OpCallMixed` with `retBank=BankCell`, and returns the helper's Cell result. The test asserts `helper.JITCode != nil` (admission worked), `DeoptCount` delta is 0 (no bailout), the returned Cell `IsHandle()`, and its `DecodeHandle()` tag is `ArenaPair` (the round-trip kept the handle bit-pattern intact). Full regression sweep clean across `compiler3/corpus`, `runtime/vm3`, `runtime/jit/vm3jit`.
+
+**Closure verdict: prerequisite for m.4b, not closure itself.** No bench movement expected (`make_tree` still routes through the interp because `OpNewPair` is not admitted yet). The win lands in m.4b once OpNewPair gets inline arena-alloc lowering and the whole `make_tree` body compiles.
+
+**Exit gate.** `OpReturnCell` admits + emits on ARM64; `jitCall` is safe for Cell-returning callees via Layer-B copy-up. Composite BG-suite progress unchanged at **8/11 closed, 9/11 ported on macOS arm64** (binary_trees closure still pending m.4b). m.4b adds `OpNewPair` inline alloc and admits `make_tree`.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
## Summary

- Admit `OpReturnCell` in the cell-bank JIT whitelist; ARM64 emit mirrors `OpReturnI64` with `r2cell(op.A)` mapping to the pinned cell reg.
- Export `Arenas.HandleCellReturn` (Layer-B copy-up) and route `jitCall`'s clean-return path through it when `fn.ResultBank == BankCell` so a returned local-arena handle stays valid across the per-call snapshot truncate.
- Synthetic test `TestReturnCellJIT` covers the new path end-to-end (zero deopts, returned Cell cracks to `ArenaPair`).
- MEP-40 spec gets a Phase 6.3.4.m.4a section.

Foundation for m.4b (`OpNewPair` inline alloc + admit `make_tree`); no bench movement expected on its own.

Closes #21812.

## Test plan

- [x] `go test ./runtime/jit/vm3jit/... -count=1`
- [x] `go test ./runtime/vm3/... -count=1`
- [x] `go test ./compiler3/... -count=1`
- [x] `TestReturnCellJIT` passes with zero deopts