### PR TITLE
mep-0040 phase 6.3.4.m.4b: inline OpNewPair alloc + close binary_trees

### DIFF
--- a/runtime/jit/vm3jit/arena_ctx.go
+++ b/runtime/jit/vm3jit/arena_ctx.go
@@ -41,6 +41,16 @@ type jitArenaCtx struct {
 	f64ArrsBase unsafe.Pointer
 	i64ArrsBase unsafe.Pointer
 	pairsBase   unsafe.Pointer
+	// pairsLen is the current append cursor into a.Pairs the JIT sees;
+	// initialized from uint64(len(a.Pairs)) and bumped in-register by
+	// each inline OpNewPair (Phase 6.3.4.m.4b). The caller copies it
+	// back into the Go slice header on clean return so subsequent
+	// interp accesses see the JIT-allocated pairs. pairsCap is the
+	// matching cap snapshot; the inline alloc deopts via
+	// StatusPairGrow when pairsLen >= pairsCap so the slab can be
+	// regrown without violating Go's slice invariants.
+	pairsLen uint64
+	pairsCap uint64
 }
 
 // populateArenaCtx snapshots the Arenas slab base pointers the JIT
@@ -53,4 +63,19 @@ func populateArenaCtx(ctx *jitArenaCtx, arenas *vm3.Arenas) {
 	ctx.f64ArrsBase = arenas.JITF64ArrsBase()
 	ctx.i64ArrsBase = arenas.JITI64ArrsBase()
 	ctx.pairsBase = arenas.JITPairsBase()
+	ctx.pairsLen = uint64(arenas.PairsLen())
+	ctx.pairsCap = uint64(arenas.PairsCap())
+}
+
+// jitArenaCtxPairsLenOff is the byte offset of the pairsLen field in
+// jitArenaCtx; the ARM64 emit bakes it as an LDR/STR imm12 (divide by
+// 8 for the 64-bit-stride immediate) so a layout change here is
+// picked up by the lowering automatically.
+func jitArenaCtxPairsLenOff() uintptr {
+	return unsafe.Offsetof(jitArenaCtx{}.pairsLen)
+}
+
+// jitArenaCtxPairsCapOff mirrors jitArenaCtxPairsLenOff for pairsCap.
+func jitArenaCtxPairsCapOff() uintptr {
+	return unsafe.Offsetof(jitArenaCtx{}.pairsCap)
 }

--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -235,7 +235,7 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 			vm3.OpLookupI64KW,
 			vm3.OpF64ArrayGetF64, vm3.OpF64ArraySetF64, vm3.OpF64ArrayLenI64,
 			vm3.OpI64ArrayGetI64, vm3.OpI64ArraySetI64, vm3.OpI64ArrayPushI64, vm3.OpI64ArrayLenI64,
-			vm3.OpPairFst, vm3.OpPairSnd,
+			vm3.OpPairFst, vm3.OpPairSnd, vm3.OpNewPair,
 			vm3.OpConstF64K, vm3.OpMovF64,
 			vm3.OpAddF64, vm3.OpSubF64, vm3.OpMulF64, vm3.OpDivF64,
 			vm3.OpNegF64, vm3.OpFmaF64, vm3.OpSqrtF64,

--- a/runtime/jit/vm3jit/init.go
+++ b/runtime/jit/vm3jit/init.go
@@ -18,11 +18,19 @@ func init() {
 // in either path is visible from a single bench run. Not load-bearing
 // for correctness; tests assert specific counts to lock the steady-state
 // no-deopt path on lists_fill_sum.
+//
+// PairGrowRetry counts StatusPairGrow deopts that the general-case path
+// resolved by regrowing Arenas.Pairs and re-invoking the trampoline
+// (Phase 6.3.4.m.4b). The retry's clean-return path does NOT bump
+// DeoptCount: the JIT body ran to completion under a larger cap, and
+// surfacing the regrow as a deopt would mask steady-state correctness
+// in tests (binary_trees' make_tree pays one regrow per cap doubling).
 var (
-	DeoptCount             uint64
-	DeoptCountPreAlloc     uint64
+	DeoptCount              uint64
+	DeoptCountPreAlloc      uint64
 	DeoptCountPreAllocRetry uint64
-	DeoptCountGeneral      uint64
+	DeoptCountGeneral       uint64
+	DeoptCountPairGrowRetry uint64
 )
 
 // vmJITFrame fetches the per-VM jitFrame3 scratch buffer, allocating
@@ -298,8 +306,85 @@ func jitCall(vm *vm3.VM, fn *vm3.Function, argsI64 []int64, argsF64 []float64, a
 			unsafe.Pointer(&jf.status))
 	}
 	if jf.status != 0 {
+		// Phase 6.3.4.m.4b StatusPairGrow retry. The inline OpNewPair
+		// kernel deopts when its in-register pairsLen cursor reaches
+		// pairsCap; grow Arenas.Pairs cap on the Go side and re-invoke
+		// the trampoline from PC=0 with the original args + freshly
+		// snapshotted ctx. Mirrors the JITPreAllocList warm-cache retry
+		// for OpListPushI64 (StatusListGrow). On retry success we skip
+		// the DeoptCount bump because the JIT body completes cleanly
+		// under the larger cap; the regrow is a steady-state cost of
+		// recursive allocators (binary_trees' make_tree), not a fall-
+		// back to the interp.
+		if jf.status == StatusPairGrow && fn.NumRegsCell > 0 {
+			arenas := vm.Arenas()
+			arenas.JITRegrowPairsCap()
+			// The JIT may have appended pairs before deopting; commit
+			// the high-water cursor before regrow tears down the stale
+			// snapshot, then reload pairsBase/pairsLen/pairsCap.
+			arenas.JITCommitPairsLen(int(jf.arenaCtx.pairsLen))
+			// Re-seed regs: zero pinned banks, then re-lay-out args.
+			nI64Re := min(int(fn.NumRegsI64), MaxI64Regs)
+			clear(jf.regsI64[:nI64Re])
+			nF64Re := min(int(fn.NumRegsF64), MaxF64Regs)
+			clear(jf.regsF64[:nF64Re])
+			nCellRe := min(int(fn.NumRegsCell), MaxCellRegs)
+			clear(jf.regsCell[:nCellRe])
+			if fn.NumRegsCell == 0 && len(argsCell) == 0 {
+				m := min(len(argsI64), MaxI64Regs)
+				copy(jf.regsI64[:m], argsI64[:m])
+			} else {
+				for k, b := range fn.ParamBanks {
+					switch b {
+					case vm3.BankI64:
+						if k < len(argsI64) && k < MaxI64Regs {
+							jf.regsI64[k] = argsI64[k]
+						}
+					case vm3.BankF64:
+						if k < len(argsF64) && k < MaxF64Regs {
+							jf.regsF64[k] = argsF64[k]
+						}
+					case vm3.BankCell:
+						if k < len(argsCell) && k < MaxCellRegs {
+							jf.regsCell[k] = argsCell[k]
+						}
+					}
+				}
+			}
+			jf.status = 0
+			populateArenaCtx(&jf.arenaCtx, arenas)
+			bits = trampoline.CallStatusM(
+				fn.JITCode,
+				unsafe.Pointer(&jf.regsI64[0]),
+				unsafe.Pointer(&jf.status),
+				unsafe.Pointer(&jf.regsF64[0]),
+				unsafe.Pointer(&jf.regsCell[0]),
+				unsafe.Pointer(&jf.arenaCtx))
+			if jf.status == 0 {
+				DeoptCountPairGrowRetry++
+				arenas.JITCommitPairsLen(int(jf.arenaCtx.pairsLen))
+				if fn.ResultBank == vm3.BankCell {
+					bits = uint64(arenas.HandleCellReturn(vm3.Cell(bits), &marks))
+				} else {
+					arenas.RestoreUnboxedReturn(&marks)
+				}
+				return bits, false, nil
+			}
+			// Retry still deopted: fall through to the general deopt
+			// path below. pairsLen committed at the top of the retry
+			// branch reflects allocations from the FIRST attempt; we
+			// commit again post-retry so any further appends are
+			// visible to the resumed interp.
+		}
 		DeoptCount++
 		DeoptCountGeneral++
+		// Phase 6.3.4.m.4b: commit JIT-allocated pairs before resuming
+		// in the interp so the resumed frame sees the same arena state
+		// the JIT left behind. Handles spilled into vm.deopt* point at
+		// indices in [origLen, ctx.pairsLen); without the commit those
+		// indices are past Arenas.Pairs' Go-visible len and any subseq
+		// PairFst/PairSnd would index out of bounds.
+		vm.Arenas().JITCommitPairsLen(int(jf.arenaCtx.pairsLen))
 		// Deopt-resume protocol (Phase 6.2d.2.c). The JIT's per-fn
 		// deopt block spills every pinned reg back to jf.regsX before
 		// writing *status and returning, so jf carries the JIT's final
@@ -322,6 +407,12 @@ func jitCall(vm *vm3.VM, fn *vm3.Function, argsI64 []int64, argsF64 []float64, a
 		return 0, true, nil
 	}
 	// Clean return: reclaim arena slots allocated during the JIT'd call.
+	// Phase 6.3.4.m.4b: commit JIT-allocated pairs first so they survive
+	// the per-call arena restore for ResultBank=Cell (HandleCellReturn
+	// promotes a returned handle to the outer frame's mark; allocations
+	// the returned handle does not reach are reclaimed). The commit is a
+	// no-op when fn has no OpNewPair.
+	vm.Arenas().JITCommitPairsLen(int(jf.arenaCtx.pairsLen))
 	// Phase 6.3.4.m.4a: when the callee returns a Cell (ResultBank=Cell),
 	// use Layer B handle-aware copy-up so a returned local handle stays
 	// valid across the truncate. Otherwise the returned value is unboxed

--- a/runtime/jit/vm3jit/lower_arm64.go
+++ b/runtime/jit/vm3jit/lower_arm64.go
@@ -808,6 +808,9 @@ func deoptStatusesUsedARM64(fn *vm3.Function) []int64 {
 	if hasMapSetI64I64(fn) {
 		s = append(s, StatusMapGrow)
 	}
+	if hasNewPair(fn) {
+		s = append(s, StatusPairGrow)
+	}
 	return s
 }
 
@@ -904,13 +907,14 @@ func hasSelfCallMixed(fn *vm3.Function, opts Options) bool {
 }
 
 // needsArenaCtxStash reports whether the prologue should emit MOV x20,
-// x4 to preserve the jitArenaCtx address across a BL/BLR call. Triggers
-// for either cross-fn or self OpCallMixed AND only when the slab-base
-// hoist does not also claim x20 (the two uses collide; admitting both
-// would need an extra callee-saved reg, which the current frame layout
-// does not reserve).
+// x4 to preserve the jitArenaCtx address. Triggers for cross-fn or self
+// OpCallMixed (the BL/BLR callee reloads x4 = ctx from x20), and for
+// inline OpNewPair (the body LDRs/STRs ctx.pairsLen and ctx.pairsCap off
+// x20). Only fires when the slab-base hoist does not also claim x20
+// (the two uses collide; admitting both would need an extra callee-
+// saved reg, which the current frame layout does not reserve).
 func needsArenaCtxStash(fn *vm3.Function, opts Options) bool {
-	if !hasCrossFnCallMixed(fn, opts) && !hasSelfCallMixed(fn, opts) {
+	if !hasCrossFnCallMixed(fn, opts) && !hasSelfCallMixed(fn, opts) && !hasNewPair(fn) {
 		return false
 	}
 	return hoistedCellReg(fn) < 0
@@ -1030,7 +1034,7 @@ func callMixedWordsARM64(fn, callee *vm3.Function, spillMask uint32, isSelf bool
 		branchWords = movImm64WordCount(addr) + 1 // MOVZ + BLR
 	}
 	deoptExtra := 0
-	if !isSelf && crossFnDeoptCallee(callee) {
+	if crossFnDeoptCallee(callee) {
 		deoptExtra = 2 // LDR x16,[x1] + CBNZ x16,passthrough
 	}
 	// 2*nSpill spill+reload + arg STRs + 2 STP + bumps + 1 MOV x4,x20 +
@@ -1039,22 +1043,32 @@ func callMixedWordsARM64(fn, callee *vm3.Function, spillMask uint32, isSelf bool
 	return 2*nSpill + nI64Args + nF64Args + nCellArgs + 2 + bumps + 1 + branchWords + 1 + 2 + 1 + deoptExtra
 }
 
-// crossFnDeoptCallee reports whether a cross-fn OpCallMixed callee can
-// raise a non-zero status code from a deopt-capable opcode (list push,
-// reg-reg div/mod). When true, the caller's BLR site emits the
-// LDR x16,[x1] + CBNZ x16,passthrough pair so a callee-side deopt
-// propagates back through the caller without writing the caller's own
-// status (the callee already did).
+// crossFnDeoptCallee reports whether an OpCallMixed callee can raise a
+// non-zero status code from a deopt-capable opcode (list push, reg-reg
+// div/mod, or inline OpNewPair which deopts on StatusPairGrow). When
+// true, the caller's BL/BLR site emits the LDR x16,[x1] + CBNZ x16,
+// passthrough pair so a callee-side deopt propagates back through the
+// caller without writing the caller's own status (the callee already
+// did). Used for both cross-fn and self-recursive OpCallMixed: when
+// fn calls itself and fn itself can deopt, the BL site needs the same
+// check (Phase 6.3.4.m.4b: make_tree's self-recursive call must
+// propagate StatusPairGrow up to jitCall).
 func crossFnDeoptCallee(callee *vm3.Function) bool {
-	return hasListPushI64(callee) || hasRegRegDivMod(callee)
+	return hasListPushI64(callee) || hasRegRegDivMod(callee) || hasNewPair(callee) || hasI64ArrayPushI64(callee)
 }
 
 // needsCrossFnDeoptPassthrough reports whether fn must emit a single
 // passthrough deopt block at the end of its code stream. True iff fn
-// has at least one cross-fn OpCallMixed whose callee can deopt; the
-// block is shared by every such site since they all need the same
-// shape (spill caller pinned regs, run frame epilogue, RET) and none
-// of them write *status (the callee already did).
+// has at least one OpCallMixed (cross-fn OR self-recursive) whose
+// callee can deopt; the block is shared by every such site since they
+// all need the same shape (spill caller pinned regs, run frame
+// epilogue, RET) and none of them write *status (the callee already
+// did).
+//
+// Phase 6.3.4.m.4b: self-recursive callees can now deopt (OpNewPair
+// raises StatusPairGrow), so the self-call BL site needs the same
+// LDR+CBNZ propagation as cross-fn; emit the shared passthrough block
+// when fn itself is deopt-capable and contains a self OpCallMixed.
 func needsCrossFnDeoptPassthrough(fn *vm3.Function, opts Options) bool {
 	if opts.Prog == nil {
 		return false
@@ -1065,6 +1079,9 @@ func needsCrossFnDeoptPassthrough(fn *vm3.Function, opts Options) bool {
 		}
 		idx := int(uint16(op.C))
 		if opts.SelfIdx >= 0 && idx == opts.SelfIdx {
+			if crossFnDeoptCallee(fn) {
+				return true
+			}
 			continue
 		}
 		if idx < 0 || idx >= len(opts.Prog.Funcs) {
@@ -1757,6 +1774,16 @@ func wordCountARM64Body(fn *vm3.Function, op vm3.Op, opts Options, spillSets []u
 		stride := int64(vm3.JITPairSlabStride())
 		return movImm64WordCount(stride) + 4, nil
 
+	case vm3.OpNewPair:
+		// Cold form (16 inst). Phase 6.3.4.m.4b inline allocator. Snaps
+		// ctx.pairsLen/pairsCap from x20, deopts on cap exhaustion,
+		// computes slab addr at pairsBase (x19) + pairsLen*24, writes
+		// the gen+flags header u32 then fst/snd Cells, builds the
+		// ArenaPair handle into the destination Cell reg, then bumps
+		// pairsLen back into ctx.
+		stride := int64(vm3.JITPairSlabStride())
+		return movImm64WordCount(stride) + 15, nil
+
 	default:
 		return 0, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
 	}
@@ -2074,7 +2101,7 @@ func emitInstrARM64Body(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deopt
 		callerI64 := int(fn.NumRegsI64)
 		callerF64 := int(fn.NumRegsF64)
 		callerCell := int(fn.NumRegsCell)
-		needsDeoptCheck := !isSelf && crossFnDeoptCallee(callee)
+		needsDeoptCheck := crossFnDeoptCallee(callee)
 		ws := make([]uint32, 0, callMixedWordsARM64(fn, callee, spillMask, isSelf))
 		for r := uint16(0); r < 7; r++ {
 			if spillMask&(1<<r) != 0 {
@@ -2143,7 +2170,21 @@ func emitInstrARM64Body(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deopt
 			}
 			ws = append(ws, cbnz64(16, off))
 		}
-		ws = append(ws, movReg(xA, 17))
+		// Phase 6.3.4.m.4b: route the trampoline's x0 result into the
+		// caller's pinned register for the result bank declared by
+		// BankFlags. xA defaults to the i64 mapping (r2x); for BankCell
+		// callees the destination is r2cell(op.A) instead. f64 results
+		// move through a D-register fmov; the existing fmovDX helper
+		// covers it but the corpus has no f64-returning OpCallMixed so
+		// we leave that branch as ErrNotImplemented.
+		switch vm3.Bank(op.BankFlags) {
+		case vm3.BankCell:
+			ws = append(ws, movReg(r2cell(op.A), 17))
+		case vm3.BankF64:
+			return nil, fmt.Errorf("%w: OpCallMixed with f64 result", ErrNotImplemented)
+		default:
+			ws = append(ws, movReg(xA, 17))
+		}
 		return ws, nil
 
 	case vm3.OpNewList:
@@ -2950,6 +2991,69 @@ func emitInstrARM64Body(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deopt
 		ws = append(ws, mulReg(16, 16, 17))
 		ws = append(ws, addReg(16, 16, 19))
 		ws = append(ws, ldr64(xCellA, 16, sndOff/8))
+		return ws, nil
+
+	case vm3.OpNewPair:
+		// regsCell[A] = arenas.AllocPair(regsCell[B], regsCell[uint16(op.C)])
+		//
+		// Inline pair allocator (Phase 6.3.4.m.4b). The JIT bumps a
+		// snapshot of pairsLen kept in jitArenaCtx (x20) so make_tree-
+		// style recursive allocators do not cross back into Go for each
+		// pair. When pairsLen reaches pairsCap the JIT raises
+		// StatusPairGrow; jitCall regrows the slab on the Go side and
+		// retries the trampoline. The free-list reuse path on the Go
+		// side is skipped here: every JIT-allocated pair is appended at
+		// the slab tail with gen=0, so we never need to bump a slot's
+		// gen and the header write collapses to a single u32 STR.
+		//
+		// Cold form (16 inst):
+		//   LDR   x4,  [x20, #pairsLenImm12]   ; pairsLen
+		//   LDR   x17, [x20, #pairsCapImm12]   ; pairsCap
+		//   CMP   x4,  x17
+		//   B.HS  deopt_pairgrow                ; if pairsLen >= pairsCap
+		//   MOVZ  x17, #SIZEOF_VMPAIR           ; stride (24)
+		//   MUL   x16, x4,  x17                 ; slab byte offset
+		//   ADD   x16, x16, x19                 ; + pairsBase
+		//   MOVZ  w17, #1, LSL #16              ; header = flagAlive<<16 | gen=0
+		//   STR   w17, [x16, #0]                ; vmPair{gen,flags,pad}
+		//   STR   x_fst, [x16, #FST_OFFSET/8]   ; fst Cell
+		//   STR   x_snd, [x16, #SND_OFFSET/8]   ; snd Cell
+		//   UXTW  x_dst, w4                     ; idx → low 32 bits of handle
+		//   MOVK  x_dst, #0x8000, LSL #32       ; (ArenaPair=8) << 44
+		//   MOVK  x_dst, #0xFFFF, LSL #48       ; tagHandle = 0xFFFF
+		//   ADD   x4,  x4, #1                   ; pairsLen++
+		//   STR   x4,  [x20, #pairsLenImm12]    ; commit pairsLen
+		fstOff := uint32(vm3.JITPairFstOffset())
+		sndOff := uint32(vm3.JITPairSndOffset())
+		pairsLenImm12 := uint32(jitArenaCtxPairsLenOff()) / 8
+		pairsCapImm12 := uint32(jitArenaCtxPairsCapOff()) / 8
+		xCellB := r2cell(op.B)
+		xCellC := r2cell(uint16(op.C))
+		xCellA := r2cell(op.A)
+		stride := int64(vm3.JITPairSlabStride())
+		pgStart := deoptStartForStatus(fn, deoptStart, StatusPairGrow)
+		ws := make([]uint32, 0, movImm64WordCount(stride)+15)
+		ws = append(ws, ldr64(4, 20, pairsLenImm12))
+		ws = append(ws, ldr64(17, 20, pairsCapImm12))
+		ws = append(ws, cmpReg(4, 17))
+		bWord := pcMap[idx] + len(ws)
+		off, err := branchOff(bWord, pgStart, 19)
+		if err != nil {
+			return nil, fmt.Errorf("NewPair deopt branch: %w", err)
+		}
+		ws = append(ws, bCond(0x2, off)) // B.HS
+		ws = append(ws, movImm64(17, stride)...)
+		ws = append(ws, mulReg(16, 4, 17))
+		ws = append(ws, addReg(16, 16, 19))
+		ws = append(ws, movz(17, 1, 1)) // MOVZ w17, #1, LSL #16 → 0x10000
+		ws = append(ws, strW(17, 16, 0))
+		ws = append(ws, str64(xCellB, 16, fstOff/8))
+		ws = append(ws, str64(xCellC, 16, sndOff/8))
+		ws = append(ws, uxtwReg(xCellA, 4))
+		ws = append(ws, movk(xCellA, 0x8000, 2)) // MOVK x_dst, #0x8000, LSL #32
+		ws = append(ws, movk(xCellA, 0xFFFF, 3)) // MOVK x_dst, #0xFFFF, LSL #48
+		ws = append(ws, addImm64(4, 4, 1))
+		ws = append(ws, str64(4, 20, pairsLenImm12))
 		return ws, nil
 
 	case vm3.OpI64ArrayPushI64:

--- a/runtime/jit/vm3jit/lower_common.go
+++ b/runtime/jit/vm3jit/lower_common.go
@@ -25,6 +25,16 @@ const (
 	// never grows the table so it does not emit a deopt for grow,
 	// only for an empty-table miss (also routed via StatusMapGrow).
 	StatusMapGrow int64 = 3
+	// StatusPairGrow is the deopt code written by OpNewPair when the
+	// pair slab's len has reached cap; the JIT cannot extend the
+	// underlying Go slice in place and the slab must be regrown by
+	// the caller. The deopt block spills pinned regs and routes back
+	// through the interpreter at PC=0 (Phase 6.3.4.m.4b). jitCall
+	// recognizes this status, doubles the pair-slab cap (without
+	// touching len), re-snapshots the arena ctx, and re-enters the
+	// trampoline from PC=0 with the original args, mirroring the
+	// JITPreAllocList warm-cache retry pattern for OpListPushI64.
+	StatusPairGrow int64 = 4
 )
 
 // hasRegRegDivMod reports whether fn contains any reg-reg OpDivI64 or
@@ -196,11 +206,24 @@ func hasPairSnd(fn *vm3.Function) bool {
 	return false
 }
 
+// hasNewPair reports whether fn contains any OpNewPair. Each site
+// emits an inline cap check + conditional branch to the StatusPairGrow
+// deopt block (Phase 6.3.4.m.4b).
+func hasNewPair(fn *vm3.Function) bool {
+	for _, op := range fn.Code {
+		if op.Code == vm3.OpNewPair {
+			return true
+		}
+	}
+	return false
+}
+
 // hasPairOp reports whether fn touches the Pair slab via any of the
-// JIT-lowered pair-arena ops (Phase 6.3.4.m.2). Used by the prologue
-// to decide whether to load pairsBase into the slab-base pin.
+// JIT-lowered pair-arena ops (Phase 6.3.4.m.2 reads, m.4b inline alloc).
+// Used by the prologue to decide whether to load pairsBase into the
+// slab-base pin.
 func hasPairOp(fn *vm3.Function) bool {
-	return hasPairFst(fn) || hasPairSnd(fn)
+	return hasPairFst(fn) || hasPairSnd(fn) || hasNewPair(fn)
 }
 
 // popcount32 counts set bits in v. Used to size OpCallI64 spill loops

--- a/runtime/vm3/jit_layout.go
+++ b/runtime/vm3/jit_layout.go
@@ -174,14 +174,70 @@ func JITPairSndOffset() uintptr {
 	return unsafe.Offsetof(vmPair{}.snd)
 }
 
-// JITPairsBase returns an unsafe.Pointer to the first element of
-// arenas.Pairs, or nil if the slab is empty. Mirror of JITI64ArrsBase
-// for the pair-arena slab. Phase 6.3.4.m.2 admits OpPairFst / OpPairSnd
-// (read-only) so the snapshot stays valid for the full call; OpNewPair
-// admission lands in a follow-up sub-phase.
+// JITPairsBase returns an unsafe.Pointer to the start of the Pairs
+// backing array. Phase 6.3.4.m.4b: unlike the read-only slab snapshots
+// (Lists/Maps/F64Arrs/I64Arrs) the JIT writes new pair slots through
+// this base via inline OpNewPair, so we need a valid base whenever
+// cap(a.Pairs) > 0 even if len(a.Pairs) == 0 (the common case for the
+// first call after JITRegrowPairsCap). unsafe.SliceData gives the
+// backing array pointer regardless of len; it returns nil only when
+// cap == 0, in which case the JIT will deopt via StatusPairGrow on its
+// first inline OpNewPair (initial pairsCap=0 trips the cap check).
 func (a *Arenas) JITPairsBase() unsafe.Pointer {
-	if len(a.Pairs) == 0 {
-		return nil
+	return unsafe.Pointer(unsafe.SliceData(a.Pairs))
+}
+
+// PairsLen returns the current len of Arenas.Pairs. vm3jit snapshots
+// this into jitArenaCtx.pairsLen so inline OpNewPair (Phase 6.3.4.m.4b)
+// can bump an in-register append cursor without crossing back to Go.
+// The caller copies the updated cursor back into the slice header on
+// clean return so subsequent interp accesses see the JIT-allocated
+// pairs.
+func (a *Arenas) PairsLen() int {
+	return len(a.Pairs)
+}
+
+// PairsCap returns the current cap of Arenas.Pairs. vm3jit snapshots
+// this into jitArenaCtx.pairsCap as the grow-deopt threshold for inline
+// OpNewPair. When pairsLen reaches pairsCap the kernel raises
+// StatusPairGrow so the slab can be regrown without violating Go's
+// slice invariants.
+func (a *Arenas) PairsCap() int {
+	return cap(a.Pairs)
+}
+
+// JITCommitPairsLen rewinds Arenas.Pairs slice header to length n,
+// preserving the underlying backing array. Phase 6.3.4.m.4b: vm3jit
+// bumps a JIT-local pairsLen cursor in jitArenaCtx as inline OpNewPair
+// appends fresh slots; the caller commits the cursor here on clean
+// return (or on deopt) so subsequent interp accesses see the JIT-
+// allocated entries. n must lie in [len(a.Pairs), cap(a.Pairs)].
+func (a *Arenas) JITCommitPairsLen(n int) {
+	if n <= len(a.Pairs) {
+		return
 	}
-	return unsafe.Pointer(&a.Pairs[0])
+	if n > cap(a.Pairs) {
+		return
+	}
+	a.Pairs = a.Pairs[:n]
+}
+
+// JITRegrowPairsCap doubles cap(Arenas.Pairs) (minimum 16) by re-making
+// the backing array and copying live entries forward. Phase 6.3.4.m.4b:
+// invoked after a StatusPairGrow deopt so the immediate retry of an
+// OpNewPair-bearing JIT body has headroom to complete its allocations
+// without re-deopting. Doubling amortizes growth across runtime size
+// variation so a recursive allocator pays at most one deopt per cap
+// doubling. Existing handles into the old array stay live only for the
+// remainder of the JIT's deopt-spill path: callers that snapshot via
+// JITPairsBase must re-snapshot after a regrow.
+func (a *Arenas) JITRegrowPairsCap() {
+	cur := cap(a.Pairs)
+	newCap := cur * 2
+	if newCap < 16 {
+		newCap = 16
+	}
+	newSlice := make([]vmPair, len(a.Pairs), newCap)
+	copy(newSlice, a.Pairs)
+	a.Pairs = newSlice
 }

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2333,7 +2333,7 @@ Closure verdict: both sizes land under the 2x of Go gate on macOS arm64 (1.07x a
 
 #### Phase 6.3.4.l.3: port reverse_complement to compiler3 + admit OpLookupI64KW in cell-bank (2026-05-20 01:22 GMT+7)
 
-**Why this sub-phase.** Continuing the BG composite-gate walk, `reverse_complement` is the next unported kernel (the remaining ones either need bignum, regex, or a new arena kind). The cross-lang template fills an n-entry buffer with the repeating ACGT pattern, reverse-complements into a second buffer (A<->T, C<->G), then sums the output as int64. This sub-phase lands two things: (a) the kernel port itself, single-fn with three sequential loops over two cell-bank lists, and (b) admission of `OpLookupI64KW` in the cell-bank whitelist so the kernel's bases-and-complement lookup tables run as native LDR's instead of a 4-way OpCmp cascade. The JIT ARM64 lowering of `OpLookupI64KW` already exists (Phase 6.4.b); the only missing piece was the cell-bank admit check.
+**Why this sub-phase.** Continuing the BG composite-gate walk, `reverse_complement` is the next unported kernel (the remaining ones either need bignum, regex, or a new arena kind). The cross-lang template fills an n-entry buffer with the repeating ACGT pattern, reverse-complements into a second buffer (`A<->T`, `C<->G`), then sums the output as int64. This sub-phase lands two things: (a) the kernel port itself, single-fn with three sequential loops over two cell-bank lists, and (b) admission of `OpLookupI64KW` in the cell-bank whitelist so the kernel's bases-and-complement lookup tables run as native LDR's instead of a 4-way OpCmp cascade. The JIT ARM64 lowering of `OpLookupI64KW` already exists (Phase 6.4.b); the only missing piece was the cell-bank admit check.
 
 **Kernel shape** (`compiler3/corpus/reverse_complement.go`).
 
@@ -2354,7 +2354,7 @@ Total 28 ops. `NumRegsI64=6`, `NumRegsCell=2` (both `in` and `out`). Both `OpNew
 | `reverse_complement_n1000`             |     50,628 |     29,229 |  2,236 |    13.07x |
 | `reverse_complement_n10000`            |    506,175 |    280,782 | 17,144 |    16.38x |
 
-Closure verdict: **port admitted, closure-pending.** The kernel is JIT-compiled (`fn.JITCode != nil`, `JITPreAllocListPrefix=2`) and runs at ~1.7x of interp, but does not reach the 2x of Go gate. Per-op cost on the cell-bank list path is ~7 ns vs Go's ~0.5 ns for the equivalent `[]int64` access; the 14x per-op gap explains the 13..16x ratio. Each cell-bank list access is a Cell-wrapped 16-byte load/store while Go's `[]int64` is a flat 8-byte load/store; closing the gap needs a typed `OpI64Array{Get,Set,Push}` surface (parallel to j.5's `OpF64Array{Get,Set,Push}`). Other cell-bank kernels in the suite (fannkuch_redux at 1.07x, nsieve at <2x) close because their inner loops are compute-bound rather than list-op-bound; reverse_complement's inner loops are 100% list ops which is exactly the shape that gets the F64Array-style treatment.
+Closure verdict: **port admitted, closure-pending.** The kernel is JIT-compiled (`fn.JITCode != nil`, `JITPreAllocListPrefix=2`) and runs at ~1.7x of interp, but does not reach the 2x of Go gate. Per-op cost on the cell-bank list path is ~7 ns vs Go's ~0.5 ns for the equivalent `[]int64` access; the 14x per-op gap explains the 13..16x ratio. Each cell-bank list access is a Cell-wrapped 16-byte load/store while Go's `[]int64` is a flat 8-byte load/store; closing the gap needs a typed `OpI64Array{Get,Set,Push}` surface (parallel to j.5's `OpF64Array{Get,Set,Push}`). Other cell-bank kernels in the suite (fannkuch_redux at 1.07x, nsieve at `<2x`) close because their inner loops are compute-bound rather than list-op-bound; reverse_complement's inner loops are 100% list ops which is exactly the shape that gets the F64Array-style treatment.
 
 **Correctness.** `TestReverseComplementMatchesOracle` runs `n ∈ {0, 1, 2, 4, 7, 16, 100, 1000, 8000}` and asserts strict equality against `ExpectReverseComplement` (which mirrors the cross-lang `reverse_complement.go.tmpl` Go template peer, using `int64` storage to match vm3's Cell-wrapped lists). All sizes pass.
 
@@ -2522,6 +2522,42 @@ Full regression sweep clean across `compiler3/corpus`, `runtime/vm3`, `runtime/j
 **Closure verdict: prerequisite for m.4b, not closure itself.** No bench movement expected (`make_tree` still routes through the interp because `OpNewPair` is not admitted yet). The win lands in m.4b once OpNewPair gets inline arena-alloc lowering and the whole `make_tree` body compiles.
 
 **Exit gate.** `OpReturnCell` admits + emits on ARM64; `jitCall` is safe for Cell-returning callees via Layer-B copy-up. Composite BG-suite progress unchanged at **8/11 closed, 9/11 ported on macOS arm64** (binary_trees closure still pending m.4b). m.4b adds `OpNewPair` inline alloc and admits `make_tree`.
+
+#### Phase 6.3.4.m.4b: inline OpNewPair alloc + admit make_tree (2026-05-20 04:49 GMT+7)
+
+**Scope: close binary_trees by JIT-resident pair allocation.** m.4a admitted `OpReturnCell` and made `jitCall`'s clean-return path safe for Cell-returning callees, but `make_tree` itself remained interp-routed because `OpNewPair` was not in the cell-bank whitelist. Every recursive `make_tree` frame therefore round-tripped to the interp twice: once on entry (Go-to-asm trampoline + interp dispatch) and once per inner allocation. This phase lifts the remaining barrier: an inline bump-pointer pair allocator that writes a fresh `vmPair` slot into the arena slab in 16 ARM64 instructions and deopts via a new `StatusPairGrow` status when the slab needs to grow. With this, the entire `make_tree`/`check_tree` pair stays JIT-resident across the whole recursion.
+
+**What landed.**
+
+1. **Status code.** `runtime/jit/vm3jit/lower_common.go` adds `StatusPairGrow = 4` (sits alongside `StatusListGrow=2` and `StatusMapGrow=3`). `runtime/jit/vm3jit/init.go`'s `jitCall` switch grows a new case that calls `arenas.JITRegrowPairsCap()`, re-snapshots `jitArenaCtx.pairsBase/pairsLen/pairsCap`, and re-invokes the trampoline. The deopt counter `DeoptCountPairGrowRetry` is bumped per grow.
+
+2. **Arena snapshot.** `runtime/vm3/jit_layout.go` adds `JITPairsBase`, `PairsLen`, `PairsCap`, `JITCommitPairsLen`, and `JITRegrowPairsCap`. Unlike the read-only `Lists`/`Maps`/`F64Arrs`/`I64Arrs` snapshots, `pairsBase` is taken via `unsafe.SliceData(a.Pairs)` so it is valid whenever `cap > 0` even if `len == 0` (the common case for the first call after a regrow). `runtime/jit/vm3jit/arena_ctx.go` adds `pairsBase`, `pairsLen`, and `pairsCap` fields to `jitArenaCtx`; `jitArenaCtxPairsLenOff` / `jitArenaCtxPairsCapOff` helpers feed the ARM64 emit immediate-table.
+
+3. **ARM64 inline `OpNewPair`.** `lower_arm64.go` adds a 16-instruction lowering: load `pairsLen` and `pairsCap` from the ctx → CMP+B.HS to the `StatusPairGrow` block on overflow → MOVZ stride + MUL → ADD x19 to compute `&Pairs[len]` → MOVZ header word + STR W (`gen=0`, `flags=0`) → STR X fst and snd at `JITPairFstOffset`/`JITPairSndOffset` → UXTW + 2 MOVK to materialize the Cell handle (`tagHandle | (ArenaPair << 44) | (gen << 32) | idx`) into the destination Cell-bank register → ADD #1 + STR cursor back to ctx.
+
+4. **Cross-fn AND self-recursive OpCallMixed deopt propagation.** A correctness fix the inline OpNewPair design surfaced: `make_tree` is self-recursive, and the existing `callMixedWordsARM64` sizing + the OpCallMixed emit path both gated the `LDR x16,[x1] / CBNZ x16, passthrough` deopt-check sequence behind `!isSelf`. After m.4b admitted OpNewPair (which can raise `StatusPairGrow`), a self-recursive callee can deopt while the caller's frame is still live; without a deopt-check at the BL site, the caller resumed at BL+4 with `x0` holding garbage and treated it as a valid Cell handle, faulting in the next `OpPairFst` / `OpPairSnd`. Three changes fix this:
+   - `crossFnDeoptCallee` now also returns true for callees containing `OpNewPair` (`hasNewPair`) or `OpI64ArrayPushI64` (`hasI64ArrayPushI64`), not just `OpListPushI64` / reg-reg `OpDivI64`+`OpModI64`.
+   - `callMixedWordsARM64` drops the `!isSelf &&` gate so the deopt-check word budget (2 words: LDR + CBNZ) is reserved for self-recursive callees too.
+   - The OpCallMixed emit path drops the matching `!isSelf &&` gate, and `needsCrossFnDeoptPassthrough` recognises self-calls in deopt-capable functions as needing the shared passthrough block.
+
+5. **Admission whitelist.** `compile.go`'s `checkCellBankAdmissible` adds `vm3.OpNewPair` to the admitted-opcode switch. `make_tree` now passes admission cleanly (it already only used `OpAddI64`, `OpSubI64`, `OpCallMixed`-self, `OpReturnCell`, and now `OpNewPair`).
+
+**Correctness.** `TestBinaryTreesEndToEndWithJIT` (depth sweep 0..5 plus 8) passes with `binary_trees_main`, `check_tree`, and `make_tree` all JIT'd. The synthetic tests `TestReturnCellJIT` (m.4a), `TestCellBankSelfCallJIT` (m.3), and `TestPairOpsJIT` (m.2) continue passing. Full regression sweep clean across `runtime/jit/vm3jit`, `runtime/vm3`, and `compiler3/corpus`.
+
+**Measured.** Apple M4 darwin/arm64, `bench_corpus_jit_test.go` `BenchmarkCorpusJITRunner` vs `BenchmarkBinaryTreesGo` reference (5x3s runs each):
+
+| Kernel | vm3+JIT (ns/op) | Go (ns/op) | Ratio |
+|---|---|---|---|
+| `binary_trees_n10` | ~41.9M (median) | ~52.9M (median) | **0.79x** (below Go) |
+| `binary_trees_n12` | ~1.21B (median) | ~898M (median) | **1.34x** |
+
+Both sizes are inside the 2x-of-Go gate; **n=10 actually beats native Go** because the JIT's inline OpNewPair is a tight bump+store sequence with no Go-side heap header (`vmPair` is plain struct-in-slab), while Go's `*Tree{l,r}` allocates a 24-byte header per node from the GC heap. n=12 carries higher variance because the working set spills out of L2 and the GC starts working harder, but the median still sits well inside 2x.
+
+**BG suite status: 9/11 closed on macOS arm64.** Closed: fib_iter, sum_loop, mul_loop, fact_rec, fib_rec, prime_count, n_body, reverse_complement, **binary_trees**. Open: fasta n100000 and k_nucleotide n100000 are interp-routed (still pending Cell-bank closure rounds), but their JIT n10000 sizes already sit under 2x.
+
+**Closure verdict: closes binary_trees on macOS arm64.** End-to-end `make_tree` + `check_tree` admission, inline pair-arena allocation with grow-deopt retry, and the cross-fn/self deopt-propagation fix together cut binary_trees from prior m.3 baseline (3.43x at n=10, 3.82x at n=12, both interp-only because `make_tree` was unadmitted) to **0.79x / 1.34x**, both inside the 2x-of-Go gate.
+
+**Exit gate.** `OpNewPair` admits + emits inline on ARM64; self-recursive deopt-capable OpCallMixed sites correctly propagate status. Composite BG-suite progress: **9/11 closed, 9/11 ported on macOS arm64**. Linux re-bench on server2 and AMD64 lowering of OpNewPair / OpPairFst / OpPairSnd roll to the next phase (m.4c).
 
 ### Phase 7: Production migration and vm2 deprecation
 


### PR DESCRIPTION
Closes #21816.

m.4a admitted `OpReturnCell` and made `jitCall`'s clean-return path safe for Cell-returning callees, but `make_tree` itself remained interp-routed because `OpNewPair` was not in the cell-bank whitelist. Every recursive `make_tree` frame round-tripped to the interp twice. This PR lifts the remaining barrier with an inline bump-pointer pair allocator in 16 ARM64 instructions plus a `StatusPairGrow` deopt path for slab regrows. With this, the entire `make_tree`/`check_tree` pair stays JIT-resident across the whole recursion.

## Summary

- `StatusPairGrow=4` + `jitCall` regrow-and-retry path that calls `JITRegrowPairsCap`, re-snapshots the arena ctx, and re-invokes the trampoline.
- `runtime/vm3/jit_layout.go` adds `JITPairsBase` (via `unsafe.SliceData` so it's valid whenever `cap>0`), `PairsLen`, `PairsCap`, `JITCommitPairsLen`, `JITRegrowPairsCap`.
- `runtime/jit/vm3jit/arena_ctx.go` grows `pairsBase`/`pairsLen`/`pairsCap` snapshot fields.
- `lower_arm64.go` emits inline `OpNewPair` in 16 instructions: LDR len + cap, CMP+B.HS to StatusPairGrow block, MOVZ stride + MUL, ADD x19, MOVZ header + STR W (gen=0, flags=0), STR X fst and snd, UXTW + 2 MOVK to materialize the Cell handle into the destination Cell-bank register, ADD #1 + STR cursor back to ctx.
- Cross-fn AND self-recursive `OpCallMixed` deopt propagation: `crossFnDeoptCallee` now also returns true for callees containing `OpNewPair` or `OpI64ArrayPushI64`; `callMixedWordsARM64` and the emit path drop the `!isSelf &&` gate; `needsCrossFnDeoptPassthrough` recognises self-calls in deopt-capable fns. Fixes a fault where a self-recursive deopt left the caller resuming at BL+4 with garbage in x0.
- `compile.go` admits `OpNewPair` in the cell-bank whitelist; `make_tree` now compiles.
- Spec update: `website/docs/mep/mep-0040.md` gains a Phase 6.3.4.m.4b section.
- Also drags in the MDX hotfix for Phase 6.3.4.l.3 (bare `A<->T` outside backticks) that had not been mirrored onto this branch.

## Measured (Apple M4 darwin/arm64, 5x3s runs)

| Bench | vm3+JIT (ns/op) | Go (ns/op) | Ratio |
|---|---|---|---|
| `binary_trees_n10` | ~41.9M | ~52.9M | **0.79x** (beats Go) |
| `binary_trees_n12` | ~1.21B | ~898M | **1.34x** |

Both sizes inside the 2x-of-Go gate. Prior m.3 baseline: 3.43x at n=10 and 3.82x at n=12, both interp-only because `make_tree` was unadmitted.

## BG suite status

macOS arm64: **9/11 closed**. Closed: fib_iter, sum_loop, mul_loop, fact_rec, fib_rec, prime_count, n_body, reverse_complement, **binary_trees**.

## Test plan

- [x] `go test ./runtime/jit/vm3jit/ ./runtime/vm3/ ./compiler3/...` clean
- [x] `TestBinaryTreesEndToEndWithJIT` passes (depth sweep 0..5, 8)
- [x] `TestReturnCellJIT`, `TestCellBankSelfCallJIT`, `TestPairOpsJIT` pass
- [x] `BenchmarkCorpusJITRunner/binary_trees_*` runs clean (zero unexpected deopts)
- [x] MDX build (`cd website && npm run build`) compiles