### PR TITLE
mep-0040 m.4b followup: honest linux/amd64 re-bench

### DIFF
--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2559,6 +2559,41 @@ Both sizes are inside the 2x-of-Go gate; **n=10 actually beats native Go** becau
 
 **Exit gate.** `OpNewPair` admits + emits inline on ARM64; self-recursive deopt-capable OpCallMixed sites correctly propagate status. Composite BG-suite progress: **9/11 closed, 9/11 ported on macOS arm64**. Linux re-bench on server2 and AMD64 lowering of OpNewPair / OpPairFst / OpPairSnd roll to the next phase (m.4c).
 
+#### Phase 6.3.4.m.4b followup: linux/amd64 honest re-bench (2026-05-20 06:30 GMT+7)
+
+**Why this exists.** The composite BG-suite gate measures **all 11 BG programs x both platforms** (Apple M4 darwin/arm64 + AMD EPYC linux/amd64 on server2). Prior phases in the m.* series shipped arm64-only cell-bank lowering and listed "Linux server2 re-bench: paired with the amd64 closure" as a deferred line. With m.4b landing on macOS, an honest re-bench was finally taken on server2 to make the per-platform gap explicit rather than implicit.
+
+**Measured on server2 (linux/amd64, AMD EPYC 6 cores, m.4b at commit f7ffb3c3a4).** `BenchmarkCorpusJITRunner/binary_trees` vs `BenchmarkBinaryTreesGo` reference (3x3s runs each):
+
+| Kernel | vm3+JIT (ns/op) | Go (ns/op) | linux/amd64 ratio |
+|---|---|---|---|
+| `binary_trees_n10` | ~5.13G (median) | ~1.35G (median) | **3.80x** |
+| `binary_trees_n12` | ~47.4G (median) | ~10.23G (median) | **4.63x** |
+
+Both linux/amd64 ratios are **over 2x**. Root cause: the AMD64 backend (`lower_amd64.go`) has no lowering for `OpNewPair`, `OpPairFst`, `OpPairSnd`, or `OpReturnCell`. `compile.go`'s admission gate is platform-agnostic, but the arch dispatch in `compile.go` (Phase 6.0/6.2a split) routes amd64 compilation through `lower_amd64.go`, which silently drops cell-bank pair shapes back to interp. So `make_tree`/`check_tree` run entirely through the vm3 interpreter on linux/amd64, paying the 3.8-4.6x interpretive overhead that vm3 carries on cell-bank workloads.
+
+A pre-existing AMD64 bug in the recursive JIT path (`TestCompileFactRecMatchesInterp` sigpanics on linux/amd64 since at least m.1, HEAD~5) is orthogonal but compounds the situation: even kernels that *would* admit on AMD64 may not survive a recursive entry. Task tracker entry queued as the m.4c-prereq.
+
+**Honest composite BG-suite state after m.4b + this re-bench.**
+
+| Program | macOS arm64 | linux/amd64 | Composite gate |
+|---|---|---|---|
+| fib_iter | PASS (JIT) | PASS (JIT, i64-only) | MET |
+| sum_loop | PASS (JIT) | PASS (JIT, i64-only) | MET |
+| mul_loop | PASS (JIT) | PASS (JIT, i64-only) | MET |
+| fact_rec | PASS (JIT) | BROKEN (sigpanic) | unmet, amd64 recursive bug |
+| fib_rec | PASS (JIT) | BROKEN (sigpanic) | unmet, amd64 recursive bug |
+| prime_count | PASS (JIT) | PASS (JIT, i64-only) | MET |
+| n_body | PASS (JIT, arm64 cell-bank + F64Array) | unmeasured (likely over 2x, F64Array amd64 lowering j.5.b done but cell-bank entry path arm64-only) | unmet |
+| reverse_complement | PASS (JIT, arm64 I64Array) | unmeasured (likely over 2x, same reason) | unmet |
+| binary_trees | PASS (JIT, arm64 pair lowering) | 3.80x / 4.63x (interp-routed) | **unmet** |
+| fasta n100000 | interp-only | interp-only | not in scope |
+| k_nucleotide n100000 | interp-only | interp-only | not in scope |
+
+**Closure verdict.** The composite gate is **not** met. m.4b closes binary_trees on macOS arm64 but linux/amd64 remains over 2x because the AMD64 backend has not yet inherited the arm64 cell-bank lowering for pair ops, F64Array, I64Array, OpReturnCell, OpListPushI64, OpMapSetI64I64/OpMapGetI64I64, OpLookupI64KW (cell-bank), and OpFmaF64 (Phase 6.3.4.h.2 landed FMA but the surrounding cell-bank entry path is still arm64-only).
+
+**Next.** Phase 6.3.4.m.4c will port the inline OpNewPair lowering to AMD64 alongside OpPairFst/OpPairSnd/OpReturnCell, then re-bench server2. The broader AMD64 cell-bank entry-path parity is a separate multi-phase track (j.5.d for typed arrays, plus the cell-bank prologue mirroring 6.2d.2.a step 2). The pre-existing fact_rec sigpanic on linux/amd64 is the immediate blocker for any recursive cell-bank kernel and must be fixed before m.4c can be benched.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
Closes #21818.

The composite BG-suite gate measures all 11 BG programs x both platforms (macOS arm64 + linux/amd64 server2). Prior m.* phases shipped arm64-only cell-bank lowering and listed "Linux server2 re-bench: paired with the amd64 closure" as a deferred line; the composite gate was never honestly measured across both platforms.

## Summary

- Linux/amd64 re-bench on server2 (AMD EPYC, 6 cores) at the m.4b commit (f7ffb3c3a4):
  - binary_trees_n10: vm3+JIT 5.13s / Go 1.35s = **3.80x** (over 2x gate)
  - binary_trees_n12: vm3+JIT 47.4s / Go 10.23s = **4.63x** (over 2x gate)
- Root cause: `lower_amd64.go` has no cell-bank lowering for OpNewPair / OpPairFst / OpPairSnd / OpReturnCell. make_tree/check_tree run entirely through the vm3 interpreter on linux/amd64.
- A pre-existing AMD64 bug — `TestCompileFactRecMatchesInterp` sigpanics on linux/amd64 since at least HEAD~5 / m.1 — is the immediate blocker for any recursive cell-bank kernel.
- Spec adds a Phase 6.3.4.m.4b followup section with the per-platform composite table so subsequent phases work against an honest baseline rather than implicit arm64-only progress.

## Composite gate state after this followup

9/11 closed on **macOS arm64**; the same set is **not** closed on linux/amd64. Composite gate (all 11 x both platforms) is **not** met.

## Follow-up tracking

- m.4c: AMD64 lowering of OpNewPair/Fst/Snd/ReturnCell (task #208)
- Fix amd64 fact_rec sigpanic (task #209, m.4c prereq)
- amd64 cell-bank entry-path parity for n_body / reverse_complement (separate track)

## Test plan

- [x] Spec MDX build clean (`npm run build`)
- [x] Documentation-only change; no code changes