### PR TITLE
mep-0040 phase 6.3.4.m.4c.prereq: fix amd64 recursive JIT correctness

### DIFF
--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -572,9 +572,14 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		nArgs := fn.NumI64Params()
 		// Each spill store: mov xS, disp32(%rbx) = 7 bytes.
 		// Each arg store: mov xS, disp32(%rbx) = 7 bytes.
-		// add $N*8, %rbx (7); call rel32 (5); sub $N*8, %rbx (7); mov %rax, xA (3).
+		// lea N*8(%rbx), %rdi (7) — set RDI = callee window so the
+		//   recursive callee's `mov %rdi, %rbx` prologue step receives
+		//   a valid pointer rather than a stale slot-1 value.
+		// mov %r15, %rsi (3) — propagate status pointer so the callee
+		//   prologue's `mov %rsi, %r15` keeps R15 = *status.
+		// call rel32 (5); mov %rax, xA (3).
 		// Each spill reload: mov disp32(%rbx), xS = 7 bytes.
-		return 7*nSpill + 7*nArgs + 7 + 5 + 7 + 3 + 7*nSpill, nil
+		return 7*nSpill + 7*nArgs + 7 + 3 + 5 + 3 + 7*nSpill, nil
 	default:
 		return 0, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
 	}
@@ -834,15 +839,19 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 			src := r2xAMD64(op.B + uint16(k))
 			out = append(out, mov64StoreDisp32(src, xRBX, int32(nRegsI64+k)*8)...)
 		}
-		// Bump RBX to callee window.
-		out = append(out, add64RImm32(xRBX, int32(nRegsI64)*8)...)
+		// Re-establish the SysV first/second arg registers the prologue
+		// expects (RDI = regs base, RSI = status). The callee prologue
+		// runs `mov %rdi, %rbx` / `mov %rsi, %r15`, so leaving stale
+		// slot-1 / slot-0 values in RDI/RSI would clobber RBX with
+		// junk and segfault on the first pinned-slot load. Keep RBX
+		// unchanged here — the callee derives its own window from RDI.
+		out = append(out, lea64Disp32(xRDI, xRBX, int32(nRegsI64)*8)...)
+		out = append(out, mov64RR(xR15, xRSI)...)
 		// CALL rel32 to entry (byte 0).
 		entry := 0
 		callSite := pcMap[idx] + len(out) + 5
 		rel := int32(entry - callSite)
 		out = append(out, callRel32(rel)...)
-		// Restore RBX.
-		out = append(out, sub64RImm32(xRBX, int32(nRegsI64)*8)...)
 		// Move result into destination slot (RAX → xA).
 		out = append(out, mov64RR(xRAX, xA)...)
 		// Reload spilled slots.
@@ -1187,6 +1196,16 @@ func pop64(r int) []byte {
 // subRSPImm8 emits `sub rsp, imm8` (4 bytes). Used for stack alignment.
 func subRSPImm8(imm int8) []byte {
 	return []byte{0x48, 0x83, modRM(3, 5, xRSP), byte(imm)}
+}
+
+// lea64Disp32 emits `lea rDst, [rBase + disp32]`. Opcode REX.W 8D /r
+// with mod=10 (disp32). Used at the self-recursive OpCallI64 site to
+// load RDI with the callee's regs-window base before the CALL so the
+// callee prologue's `mov %rdi, %rbx` lands on a valid pointer.
+func lea64Disp32(dst, base int, disp int32) []byte {
+	out := []byte{rex(true, dst >= 8, false, base >= 8), 0x8D, modRM(2, byte(dst), byte(base))}
+	out = appendImm32(out, disp)
+	return out
 }
 
 // addRSPImm8 emits `add rsp, imm8` (4 bytes).

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -421,15 +421,30 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		return movImm64ByteCount(fn.Consts[k].Int(), r2xAMD64(op.A)), nil
 	case vm3.OpMovI64:
 		return 3, nil // mov r64, r64
-	case vm3.OpAddI64, vm3.OpSubI64:
-		// mov xA, xB if xA != xB (3); add/sub xA, xC (3).
+	case vm3.OpAddI64:
+		// Two-operand AMD64 form: dest is also one source. Cases:
+		//   A == B : add xA, xC                              (3)
+		//   A == C : add xA, xB (commutative, skips the mov) (3)
+		//   else   : mov xB, xA; add xA, xC                  (6)
+		if op.A == op.B || op.A == uint16(op.C) {
+			return 3, nil
+		}
+		return 6, nil
+	case vm3.OpSubI64:
+		// Sub is not commutative, so A == C needs a different shape:
+		//   A == B : sub xA, xC               (3)
+		//   A == C : sub xA, xB; neg xA       (6)  — A = -(C - B) = B - C
+		//   else   : mov xB, xA; sub xA, xC   (6)
 		if op.A == op.B {
 			return 3, nil
 		}
 		return 6, nil
 	case vm3.OpMulI64:
-		// mov xA, xB if xA != xB (3); imul xA, xC (4).
-		if op.A == op.B {
+		// imul is commutative, mirror OpAddI64:
+		//   A == B : imul xA, xC                              (4)
+		//   A == C : imul xA, xB (skip mov via commutativity) (4)
+		//   else   : mov xB, xA; imul xA, xC                  (7)
+		if op.A == op.B || op.A == uint16(op.C) {
 			return 4, nil
 		}
 		return 7, nil
@@ -603,28 +618,49 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 	case vm3.OpMovI64:
 		return mov64RR(xB, xA), nil
 	case vm3.OpAddI64:
+		// Commutative; collapse A == C via commutativity to avoid
+		// `mov xB, xA` clobbering xC when A and C share a register.
 		xC := r2xAMD64(uint16(op.C))
 		var out []byte
-		if op.A != op.B {
+		switch {
+		case op.A == op.B:
+			out = append(out, add64RR(xC, xA)...)
+		case op.A == uint16(op.C):
+			out = append(out, add64RR(xB, xA)...)
+		default:
 			out = append(out, mov64RR(xB, xA)...)
+			out = append(out, add64RR(xC, xA)...)
 		}
-		out = append(out, add64RR(xC, xA)...)
 		return out, nil
 	case vm3.OpSubI64:
+		// Non-commutative; A == C uses sub+neg so we don't lose the
+		// original C value before the subtract: A = -(C - B) = B - C.
 		xC := r2xAMD64(uint16(op.C))
 		var out []byte
-		if op.A != op.B {
+		switch {
+		case op.A == op.B:
+			out = append(out, sub64RR(xC, xA)...)
+		case op.A == uint16(op.C):
+			out = append(out, sub64RR(xB, xA)...)
+			out = append(out, neg64R(xA)...)
+		default:
 			out = append(out, mov64RR(xB, xA)...)
+			out = append(out, sub64RR(xC, xA)...)
 		}
-		out = append(out, sub64RR(xC, xA)...)
 		return out, nil
 	case vm3.OpMulI64:
+		// imul is commutative; mirror OpAddI64.
 		xC := r2xAMD64(uint16(op.C))
 		var out []byte
-		if op.A != op.B {
+		switch {
+		case op.A == op.B:
+			out = append(out, imul64RR(xC, xA)...)
+		case op.A == uint16(op.C):
+			out = append(out, imul64RR(xB, xA)...)
+		default:
 			out = append(out, mov64RR(xB, xA)...)
+			out = append(out, imul64RR(xC, xA)...)
 		}
-		out = append(out, imul64RR(xC, xA)...)
 		return out, nil
 	case vm3.OpNegI64:
 		var out []byte

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2581,8 +2581,8 @@ A pre-existing AMD64 bug in the recursive JIT path (`TestCompileFactRecMatchesIn
 | fib_iter | PASS (JIT) | PASS (JIT, i64-only) | MET |
 | sum_loop | PASS (JIT) | PASS (JIT, i64-only) | MET |
 | mul_loop | PASS (JIT) | PASS (JIT, i64-only) | MET |
-| fact_rec | PASS (JIT) | BROKEN (sigpanic) | unmet, amd64 recursive bug |
-| fib_rec | PASS (JIT) | BROKEN (sigpanic) | unmet, amd64 recursive bug |
+| fact_rec | PASS (JIT) | PASS (JIT, i64-only) | MET (m.4c-prereq) |
+| fib_rec | PASS (JIT) | PASS (JIT, i64-only) | MET (m.4c-prereq) |
 | prime_count | PASS (JIT) | PASS (JIT, i64-only) | MET |
 | n_body | PASS (JIT, arm64 cell-bank + F64Array) | unmeasured (likely over 2x, F64Array amd64 lowering j.5.b done but cell-bank entry path arm64-only) | unmet |
 | reverse_complement | PASS (JIT, arm64 I64Array) | unmeasured (likely over 2x, same reason) | unmet |
@@ -2593,6 +2593,33 @@ A pre-existing AMD64 bug in the recursive JIT path (`TestCompileFactRecMatchesIn
 **Closure verdict.** The composite gate is **not** met. m.4b closes binary_trees on macOS arm64 but linux/amd64 remains over 2x because the AMD64 backend has not yet inherited the arm64 cell-bank lowering for pair ops, F64Array, I64Array, OpReturnCell, OpListPushI64, OpMapSetI64I64/OpMapGetI64I64, OpLookupI64KW (cell-bank), and OpFmaF64 (Phase 6.3.4.h.2 landed FMA but the surrounding cell-bank entry path is still arm64-only).
 
 **Next.** Phase 6.3.4.m.4c will port the inline OpNewPair lowering to AMD64 alongside OpPairFst/OpPairSnd/OpReturnCell, then re-bench server2. The broader AMD64 cell-bank entry-path parity is a separate multi-phase track (j.5.d for typed arrays, plus the cell-bank prologue mirroring 6.2d.2.a step 2). The pre-existing fact_rec sigpanic on linux/amd64 is the immediate blocker for any recursive cell-bank kernel and must be fixed before m.4c can be benched.
+
+#### Phase 6.3.4.m.4c.prereq: fix amd64 recursive JIT correctness (2026-05-20 05:27 GMT+7)
+
+**Why this exists.** The m.4b followup re-bench surfaced that `TestCompileFactRecMatchesInterp` and `TestCompileFibRecMatchesInterp` sigpanic on linux/amd64 (regression present since at least m.1, HEAD~5). Two independent bugs were diagnosed and fixed; without them no recursive kernel can survive AMD64 JIT entry, blocking the m.4c cell-bank lowering benches.
+
+**Bug #1: OpCallI64 self-call leaves RDI stale.** The AMD64 emit at the self-recursive `OpCallI64` site (`lower_amd64.go`) updated RBX to point at the callee's regs window (`lea (nRegsI64*8)(%rbx), %rbx`) before `CALL rel32`, but **did not update RDI**. The callee's prologue begins with `mov %rdi, %rbx`, which then clobbers the freshly-advanced RBX with the stale RDI value (slot 1's contents, e.g. 4 for `fact_rec(5)`). The very first pinned-slot load `mov 0(%rbx), %rsi` segfaulted at PC offset `0x0d` into the JIT page with "unknown caller pc". Reproduced by dumping the JIT page bytes and locating the faulting instruction.
+
+  - **Fix.** Set RDI to the callee window via `lea (nRegsI64*8)(%rbx), %rdi` and propagate RSI = status via `mov %r15, %rsi` immediately before the CALL. The callee's prologue (`mov %rdi, %rbx`, `mov %rsi, %r15`) now lands on the right pointers. Added `lea64Disp32` helper. OpCallI64 site byte budget changed from `22+7*(2*nSpill+nArgs)` to `18+7*(2*nSpill+nArgs)`.
+  - **Commit:** `17038744bd` (mep-0040 phase 6.3.4.m.4c.prereq: fix amd64 fact_rec recursive call).
+
+**Bug #2: AMD64 2-op aliasing corrupts Add/Sub/Mul when dst aliases the non-first source.** AMD64 reg-reg arithmetic is two-operand (`op rDst, rSrc` where rDst is also the first source). The naive lowering pattern emitted `mov rB -> rA; op rC, rA`. When `A == C` aliases the second source (e.g. `MulI64 A=2, B=0, C=2` for `result = n * result`), the `mov %rsi, %r8` step clobbered slot 2 with slot 0's value, then `imul %r8, %r8` squared it: fact_rec returned `n*n` instead of `n!`. ARM64 has 3-operand `MUL` so this bug is amd64-only.
+
+  - **Fix.** Case-split on aliasing for `OpAddI64`/`OpSubI64`/`OpMulI64`:
+    - `A == B`: emit `op rC, rA` directly (3/4 bytes).
+    - `A == C`: for commutative ops (Add, Mul) just swap: `op rB, rA`. For Sub use the `sub+neg` trick: `sub %rB, %rA; neg %rA` (yields `B - C` in 6 bytes).
+    - Otherwise: original `mov rB -> rA; op rC, rA` (7 bytes).
+  - **Commit:** `dce99dbce0` (mep-0040 phase 6.3.4.m.4c.prereq2: fix amd64 2-op aliasing on Add/Sub/Mul).
+
+**Verification (server2, linux/amd64).**
+
+- `go test ./runtime/jit/vm3jit -run 'TestCompileFactRecMatchesInterp|TestCompileFibRecMatchesInterp'` PASS.
+- Full `./runtime/jit/vm3jit` suite passes except pre-existing `TestNsieveJITCompiles` (expects Cell-bank entry path; not introduced by this fix, fails on `main` HEAD~5 too).
+- macOS arm64 vm3jit suite unaffected (ARM emit path untouched).
+
+**Composite gate effect.** Two rows flip from BROKEN to MET (fact_rec, fib_rec). binary_trees on linux/amd64 still depends on the m.4c cell-bank port; n_body / reverse_complement / nsieve still depend on broader amd64 cell-bank entry-path parity. Composite gate progress: **5/11 MET on both platforms** (fib_iter, sum_loop, mul_loop, fact_rec, fib_rec, prime_count) is now confirmed; the recursive amd64 path is no longer a blocker for the m.4c bench.
+
+**Closure verdict.** m.4c.prereq closes the recursive-JIT correctness gap on linux/amd64. m.4c can now port the inline OpNewPair / OpPairFst / OpPairSnd / OpReturnCell lowering and bench binary_trees on server2 without a sigpanic stop-energy.
 
 ### Phase 7: Production migration and vm2 deprecation
 


### PR DESCRIPTION
Fixes two amd64-only correctness bugs in `lower_amd64.go` that were blocking the linux/amd64 recursive-JIT path. Surfaced by the m.4b honest re-bench on server2 (#21819).

Cross-link: closes #21820.

## Summary

- **Bug 1:** `OpCallI64` self-call updated RBX before `CALL` but not RDI; callee prologue's `mov %rdi, %rbx` then clobbered the freshly-advanced base with stale RDI. Sigpanicked at JIT page offset 0x0d on `fact_rec(5)`.
- **Bug 2:** AMD64 2-op `op rDst, rSrc` form caused aliasing corruption in Add/Sub/Mul when A aliased C; `fact_rec(5)` returned `n*n` instead of `n!`.

## Fixes

- OpCallI64 emit now sets RDI = `lea (nRegsI64*8)(%rbx), %rdi` and propagates RSI = status (`mov %r15, %rsi`) before CALL. Drops the explicit RBX bump (callee prologue does it). Added `lea64Disp32` helper.
- Case-split aliasing in OpAddI64/OpSubI64/OpMulI64: commutativity for Add/Mul (`A == C` becomes `op rB, rA`), sub+neg trick for Sub (yields `B-C` in 6 bytes).

## Test plan

- [x] `go test ./runtime/jit/vm3jit/...` on darwin/arm64
- [x] `go test ./runtime/jit/vm3jit -run 'TestCompileFactRecMatchesInterp|TestCompileFibRecMatchesInterp'` on linux/amd64 (server2)
- [x] `go test ./runtime/jit/vm3jit/... -skip TestNsieveJITCompiles` on linux/amd64 (server2) — full suite green; nsieve failure is pre-existing on `main`
- [x] MEP-40 spec updated with the diagnosis + composite-gate row flips

## Composite gate effect

| Program | macOS arm64 | linux/amd64 (this PR) |
|---|---|---|
| fact_rec | PASS | PASS (was sigpanic) |
| fib_rec | PASS | PASS (was sigpanic) |

5/11 BG programs now confirmed MET on both platforms. binary_trees still depends on the m.4c cell-bank lowering port.