### PR TITLE
mep-0040 phase 6.3.4.m.4c plan: amd64 cell-bank parity sub-phases

### DIFF
--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2621,6 +2621,40 @@ A pre-existing AMD64 bug in the recursive JIT path (`TestCompileFactRecMatchesIn
 
 **Closure verdict.** m.4c.prereq closes the recursive-JIT correctness gap on linux/amd64. m.4c can now port the inline OpNewPair / OpPairFst / OpPairSnd / OpReturnCell lowering and bench binary_trees on server2 without a sigpanic stop-energy.
 
+#### Phase 6.3.4.m.4c: AMD64 cell-bank parity plan (2026-05-20 05:27 GMT+7)
+
+**Why this exists.** Closing binary_trees on linux/amd64 (the only BG program still strictly over 2x of Go on the AMD64 platform) requires porting the arm64 cell-bank lowering surface to AMD64. ARM64 ships full coverage; AMD64 currently has **zero** cell-bank scaffold (`lower_amd64.go` rejects every cell-bank opcode with `ErrNotImplemented`). This section scopes the port and breaks it into named sub-phases so each can ship as a self-contained PR.
+
+**AMD64 register pressure analysis.** SysV callee-saved GPRs are `{RBX, RBP, R12, R13, R14, R15}`. Existing pins are RBX = regsI64 base and R15 = status ptr. The i64 backend already claims R12/R13/R14 conditionally for i64 slots 6/7/8 (NumRegsI64 > 6/7/8 respectively). That leaves **RBP free for cell-bank** plus a single conditional reg out of `{R12, R13, R14}` depending on NumRegsI64.
+
+Worst case from the binary_trees corpus: `binary_trees_main` has `NumRegsI64=7` (claims R12) and `NumRegsCell=5`. ARM64 pins 5 Cell regs in callee-saved x21..x28; AMD64 cannot match that without spilling i64 lanes. **Decision:** unlike arm64, AMD64 cell-bank lowering will **not pin Cell regs**. Cell-bank ops address Cell slots via `mov [rbp + idx*8], r` / `mov r, [rbp + idx*8]` with RBP pinned to the regsCell base. This is per-op slower than arm64's pinned-Cell-reg pattern, but it (a) scales to any NumRegsCell without callee-saved budget gymnastics, (b) avoids prologue/epilogue invariant changes for i64-only fns, and (c) keeps the AMD64 backend small while still meeting the 2x-of-Go gate (the cell-bank fns are dispatch-bound, not register-allocation-bound).
+
+**Pinned regs after m.4c:**
+- `RBX` = regsI64 base (existing).
+- `R15` = status ptr (existing).
+- `RBP` = regsCell base, loaded from RCX in the prologue (new; cell-bank fns only).
+- `R14` = `*jitArenaCtx`, loaded from R8 in the prologue (new; cell-bank fns only). Conflicts with i64-slot-8; cell-bank fns are capped at `NumRegsI64 <= 8` (binary_trees fits well inside).
+
+**Trampoline ABI.** `trampoline.CallStatusM` already passes all five pointers (DI/SI/DX/CX/R8 on SysV). The Go side at `init.go:136-142` is unchanged.
+
+**Sub-phases.**
+
+1. **m.4c.1 — Cell-bank entry path scaffold.** Extend `emitPrologueAMD64` / `emitEpilogueAMD64` / `prologueLenAMD64` to push RBP and R14 when `fn.NumRegsCell > 0`, copy RCX into RBP and R8 into R14, and respect the new `NumRegsI64 <= 8` cap. No new opcode emit; this lands the infrastructure so subsequent phases stack on a stable scaffold. **Task #210.**
+
+2. **m.4c.2 — `OpReturnCell` + per-status deopt blocks.** Implement `OpReturnCell` (`mov [rbp + A*8], %rax`, then epilogue) and extend `deoptBlockBytesAMD64` / `emitDeoptBlockAMD64` to emit one block per **distinct** status code the function uses (StatusDivByZero, StatusListGrow, StatusMapGrow, StatusPairGrow). Add a per-status `deoptStartForStatusAMD64` mirroring the arm64 helper. Mirror `TestReturnCellJIT` from `pair_arm64_test.go`. **Task #211.**
+
+3. **m.4c.3 — `OpPairFst` + `OpPairSnd`.** Read-only pair access. Load Cell handle from `[rbp + B*8]`, mask to 32-bit slab idx via `mov %eax, %eax` (zero-extension), compute slab byte offset (`imul $stride, %r..., %rcx; add r14-arenaCtx-pairsBase, %rcx`), load the fst/snd Cell from `[rcx + fstOff]`, store to `[rbp + A*8]`. Mirror `TestPairOpsJIT`. **Task #212.**
+
+4. **m.4c.4 — `OpNewPair` with StatusPairGrow deopt.** Load `pairsLen` and `pairsCap` from arenaCtx through R14, branch to the StatusPairGrow deopt block if `pairsLen >= pairsCap`, otherwise compute slab byte offset, write the 32-bit gen/flags header (`movl $0x10000, (%rcx)`), write fst/snd Cells from `[rbp+B*8]`/`[rbp+C*8]`, build the handle Cell (`idx | ArenaPair<<44 | 0xFFFF<<48`) and store to `[rbp+A*8]`, then bump pairsLen and write back through R14. Mirror the arm64 16-instruction sequence at lines 2996-3057 in `lower_arm64.go`. **Task #213.**
+
+5. **m.4c.5 — Self-recursive `OpCallMixed`.** Spill live caller-saved i64 + cell slots to their windows, advance RBX by `NumRegsI64*8` and RBP by `NumRegsCell*8`, propagate RSI = status and reload RDI/RCX from the bumped bases via `lea`, `CALL rel32` to byte 0 of the same page, reload spills, copy RAX into the return slot for BankI64 results or `[rbp + A*8]` for BankCell results. Handle the cross-fn deopt passthrough block (mirror arm64's `callMixedWordsARM64`). **Task #214.**
+
+6. **m.4c.6 — Admission + bench.** Drop the amd64 cell-bank rejection in `checkCellBankAdmissible`. Re-bench `binary_trees` on server2 vs the m.4b interp-floor baseline (3.80x at n=10, 4.63x at n=12). Update the composite-gate table. **Task #215.**
+
+**Closure target.** binary_trees on linux/amd64 inside 2x of Go (mirrors m.4b's macOS arm64 result: 0.79x at n=10, 1.34x at n=12). Reaching that on AMD64 may require an additional sub-phase (m.4c.7) if RBP-relative Cell access pessimizes the inner loops enough to push n=12 over 2x; the bench-then-react pattern from prior m phases applies.
+
+**Out of scope for m.4c.** AMD64 cell-bank lowering for the typed-array (F64Array/I64Array), list, and map kernels is tracked separately (it gates n_body / reverse_complement / nsieve closures on linux/amd64). Those programs are already over 2x of Go on AMD64 because the cell-bank entry path is arm64-only; the same scaffold m.4c.1 lands will be the foundation for that work.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
Stacks on #21821 (m.4c.prereq). Once that merges this PR's diff against main will reduce to the single scoping commit.

Scopes the work needed to close binary_trees on linux/amd64 by porting the arm64 cell-bank lowering surface to AMD64. ARM64 ships full coverage; AMD64 currently has zero cell-bank scaffold (`lower_amd64.go` rejects every cell-bank opcode with `ErrNotImplemented`).

## Summary

Six sub-phases each shippable as a self-contained PR:

- **m.4c.1** Cell-bank entry path scaffold (RBP = regsCell base, R14 = arenaCtx ptr)
- **m.4c.2** OpReturnCell + per-status deopt blocks
- **m.4c.3** OpPairFst + OpPairSnd
- **m.4c.4** OpNewPair with StatusPairGrow deopt
- **m.4c.5** Self-recursive OpCallMixed (Cell arg + Cell/I64 return)
- **m.4c.6** Cell-bank admission gate + bench binary_trees on server2

## Key decision

AMD64 will not pin Cell regs. ARM64 pins 8 Cell regs in callee-saved x21..x28; AMD64 only has 4 free callee-saved GPRs after RBX/R15 are pinned, and binary_trees_main needs `NumRegsCell=5` alongside `NumRegsI64=7`. Cell slots live in memory at `[rbp + idx*8]` with RBP pinned to the regsCell base. Per-op slower than arm64 but scales to any NumRegsCell and keeps the AMD64 backend small.

## Test plan

- [x] Spec section lints
- [ ] m.4c.1..6 PRs ship per their own gates
- [ ] Final composite gate: binary_trees inside 2x of Go on linux/amd64

Cross-link: opens #21822 (this PR's tracking issue).