### PR TITLE
MEP-40 phase 6.3.4.m.4c.1+m.4c.2: AMD64 cell-bank scaffold + OpReturnCell

### DIFF
--- a/runtime/jit/vm3jit/cell_amd64_test.go
+++ b/runtime/jit/vm3jit/cell_amd64_test.go
@@ -1,0 +1,125 @@
+//go:build amd64
+
+package vm3jit_test
+
+import (
+	"testing"
+
+	"mochi/runtime/jit/vm3jit"
+	"mochi/runtime/vm3"
+)
+
+// TestCellBankScaffoldAMD64 exercises Phase 6.3.4.m.4c.1 + m.4c.2: the
+// AMD64 cell-bank prologue (push RBP+R14, load regsCell base from RCX,
+// load *jitArenaCtx from R8) and OpReturnCell lowering (mov disp32(%rbp),
+// %rax + epilogue). A JIT-admissible helper takes one Cell arg and
+// returns it via OpReturnCell. The interp-side driver builds a pair (its
+// OpNewPair routes through the interp), calls the JIT'd helper, and
+// asserts the returned Cell still decodes to a valid ArenaPair handle.
+func TestCellBankScaffoldAMD64(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_echo_cell",
+		NumRegsI64:  0,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankCell,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpReturnCell, 0, 0, 0), // pc=0: return regsCell[0]
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  1,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankCell,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewPair, 0, 1, 1),                                        // pc=0: regsCell[0] = pair(CNull, CNull)
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankCell), A: 1, B: 0, C: 1}, // pc=1: regsCell[1] = helper(regsCell[0])
+			vm3.MakeOp(vm3.OpReturnCell, 1, 0, 0),                                     // pc=2: return regsCell[1]
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; AMD64 cell-bank scaffold should admit OpReturnCell")
+	}
+	preDeopt := vm3jit.DeoptCount
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if d := vm3jit.DeoptCount - preDeopt; d != 0 {
+		t.Fatalf("unexpected deopt count delta: %d", d)
+	}
+	if !got.IsHandle() {
+		t.Fatalf("returned Cell is not a handle: %#x", uint64(got))
+	}
+	tag, _, _ := got.DecodeHandle()
+	if tag != vm3.ArenaPair {
+		t.Fatalf("returned Cell tag = %d, want ArenaPair (%d)", tag, vm3.ArenaPair)
+	}
+}
+
+// TestCellBankScaffoldWithI64AMD64 exercises a cell-bank fn that mixes
+// i64 work with OpReturnCell. The prologue must push RBX/R15/R14/RBP
+// (cell-bank set), load i64 slots 0..1, run the arithmetic, then return
+// the cell handle through RAX. Catches any prologue byte-count drift
+// between byteCountAMD64 and emitInstrAMD64.
+func TestCellBankScaffoldWithI64AMD64(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_cell_with_i64",
+		NumRegsI64:  2,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell, vm3.BankI64},
+		ResultBank:  vm3.BankCell,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpAddI64K, 0, 1, 99),   // pc=0: regsI64[0] = regsI64[1] + 99 (dead-store, exercises i64 path)
+			vm3.MakeOp(vm3.OpReturnCell, 0, 0, 0), // pc=1: return regsCell[0]
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankCell,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewPair, 0, 1, 1),                                        // pc=0: regsCell[0] = pair
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankCell), A: 1, B: 0, C: 1}, // pc=1: regsCell[1] = helper(cell, d)
+			vm3.MakeOp(vm3.OpReturnCell, 1, 0, 0),                                     // pc=2: return regsCell[1]
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; AMD64 cell-bank scaffold should admit i64+cell helper")
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{7})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if !got.IsHandle() {
+		t.Fatalf("returned Cell is not a handle: %#x", uint64(got))
+	}
+	tag, _, _ := got.DecodeHandle()
+	if tag != vm3.ArenaPair {
+		t.Fatalf("returned Cell tag = %d, want ArenaPair (%d)", tag, vm3.ArenaPair)
+	}
+}

--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -204,16 +204,21 @@ const maxI64RegsCellARM64 = 11
 // fns on ARM64 (Phase 6.2d.2.a step 2). The whitelist is intentionally
 // narrow: only the opcodes the sum kernel actually uses are admitted,
 // so unrelated Cell-bank fns (fill, map workloads, ...) keep falling
-// back to the interpreter until their own sub-phases land. AMD64 has
-// no Cell-bank lowering yet, so any Cell usage is rejected there.
+// back to the interpreter until their own sub-phases land. AMD64 admits
+// the narrow scaffold opcode set (i64-only + OpReturnCell) starting in
+// Phase 6.3.4.m.4c.1/.2; pair ops, list/map ops, and OpCallMixed are
+// added in m.4c.3+.
 func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
-	if hostArch != ArchARM64 {
-		return fmt.Errorf("%w: %s has Cell bank usage (Cell=%d) — no AMD64 backend yet",
-			ErrNotImplemented, fn.Name, fn.NumRegsCell)
-	}
 	if int(fn.NumRegsCell) > maxCellRegs {
 		return fmt.Errorf("%w: %s uses %d Cell regs (max %d on this arch)",
 			ErrNotImplemented, fn.Name, fn.NumRegsCell, maxCellRegs)
+	}
+	if hostArch == ArchAMD64 {
+		return checkCellBankAdmissibleAMD64(fn, opts)
+	}
+	if hostArch != ArchARM64 {
+		return fmt.Errorf("%w: %s has Cell bank usage (Cell=%d) on unsupported arch",
+			ErrNotImplemented, fn.Name, fn.NumRegsCell)
 	}
 	for i, op := range fn.Code {
 		switch op.Code {
@@ -312,6 +317,50 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 			}
 		default:
 			return fmt.Errorf("%w: %s pc %d Cell-bank fn uses opcode %d outside the sum-shape whitelist",
+				ErrNotImplemented, fn.Name, i, op.Code)
+		}
+	}
+	return nil
+}
+
+// checkCellBankAdmissibleAMD64 is the AMD64 cell-bank whitelist (Phase
+// 6.3.4.m.4c.1 + m.4c.2). The initial scaffold admits only opcodes the
+// AMD64 backend has lowered:
+//
+//   - the i64 arithmetic / compare-and-branch / control-flow set the
+//     existing lower_amd64 supports, plus
+//   - OpReturnCell, lowered by m.4c.2 as mov disp32(%rbp), %rax + epilogue.
+//
+// Pair ops (OpPairFst/Snd, OpNewPair) land in m.4c.3 / m.4c.4;
+// OpCallMixed (self + cross-fn) lands in m.4c.5; list/map ops are out
+// of scope for the binary_trees closure (m.4c.6). f64 banks remain
+// rejected because cell-bank repurposes R14 for *jitArenaCtx and R14 is
+// the f64 base on AMD64.
+func checkCellBankAdmissibleAMD64(fn *vm3.Function, opts Options) error {
+	if fn.NumRegsF64 > 0 {
+		return fmt.Errorf("%w: %s has both Cell and f64 banks (AMD64 m.4c.1 admits Cell+I64 only; R14 shared)",
+			ErrNotImplemented, fn.Name)
+	}
+	for i, op := range fn.Code {
+		switch op.Code {
+		case vm3.OpConstI64K, vm3.OpConstI64KW, vm3.OpMovI64,
+			vm3.OpAddI64, vm3.OpSubI64, vm3.OpMulI64,
+			vm3.OpDivI64, vm3.OpModI64,
+			vm3.OpAddI64K, vm3.OpSubI64K, vm3.OpMulI64K,
+			vm3.OpDivI64K, vm3.OpModI64K,
+			vm3.OpNegI64,
+			vm3.OpCmpEqI64Br, vm3.OpCmpNeI64Br,
+			vm3.OpCmpLtI64Br, vm3.OpCmpLeI64Br,
+			vm3.OpCmpGtI64Br, vm3.OpCmpGeI64Br,
+			vm3.OpCmpEqI64KBr, vm3.OpCmpNeI64KBr,
+			vm3.OpCmpLtI64KBr, vm3.OpCmpLeI64KBr,
+			vm3.OpCmpGtI64KBr, vm3.OpCmpGeI64KBr,
+			vm3.OpJump,
+			vm3.OpReturnI64, vm3.OpReturnConstK, vm3.OpReturnCell,
+			vm3.OpLookupI64KW:
+			continue
+		default:
+			return fmt.Errorf("%w: %s pc %d Cell-bank fn uses opcode %d (AMD64 cell-bank scaffold m.4c.1+m.4c.2 only; m.4c.3 adds OpPairFst/Snd, m.4c.4 OpNewPair, m.4c.5 OpCallMixed)",
 				ErrNotImplemented, fn.Name, i, op.Code)
 		}
 	}
@@ -465,6 +514,13 @@ func archCaps(fn *vm3.Function) (int, int, bool) {
 		i64Cap := maxI64RegsAMD64
 		if fn.NumRegsF64 > 0 {
 			i64Cap = maxI64RegsAMD64 - 1 // steal R14 for regsF64 base
+		}
+		if fn.NumRegsCell > 0 {
+			// Phase 6.3.4.m.4c.1: cell-bank steals R14 (arenaCtx) and
+			// RBP (regsCell). R14 was the i64 slot-8 home, so the
+			// cap drops by one. RBP is normally reserved (not in
+			// r2xAMD64's range), so no further i64 reduction.
+			i64Cap = maxI64RegsAMD64 - 1
 		}
 		return i64Cap, maxF64RegsAMD64, true
 	default:

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -25,15 +25,26 @@ import (
 // Reserved (never holds a pinned slot):
 //
 //	RAX (0) - scratch, i64 return value, IDIV quotient
-//	RCX (1) - scratch (free for use within a single opcode lowering)
+//	RCX (1) - scratch / regsCell base on entry (moved to RBP in cell-bank prologue)
 //	RDX (2) - scratch, IDIV remainder, CQO sign-extension high half
 //	RBX (3) - regsI64 base pointer (set from RDI in prologue,
 //	          preserved by the SysV-style callee-save we do for RBX,
 //	          so it survives our internal CALL on self-recursion)
 //	RSP (4) - stack pointer
-//	RBP (5) - frame pointer (unused but kept reserved for callstack
-//	          tooling; never touched by the JIT)
+//	RBP (5) - frame pointer (unused for i64-only fns; cell-bank fns
+//	          (Phase 6.3.4.m.4c.1) repurpose it as regsCell base
+//	          loaded from RCX, with the original RBP pushed/popped in
+//	          the prologue/epilogue)
+//	R8  (8) - *jitArenaCtx on entry when cell-bank (moved to R14)
 //	R15(15) - *int64 status word pointer (set from RSI in prologue)
+//
+// Cell-bank fns additionally pin:
+//
+//	RBP (5)  - regsCell base pointer (loaded from RCX in prologue)
+//	R14 (14) - *jitArenaCtx (loaded from R8 in prologue)
+//
+// R14 is shared with the f64 base path, so the cell-bank prologue
+// rejects fn.NumRegsF64 > 0 to keep the pinning unambiguous.
 //
 // The trampoline calls us with the SysV ABI:
 //
@@ -104,11 +115,19 @@ func calleeSavedSlot(r uint16) bool { return r >= 6 && r < 9 }
 // it regardless of how it is used inside the JIT'd body.
 func usesR14ForF64(fn *vm3.Function) bool { return fn.NumRegsF64 > 0 }
 
-// numCalleeSavedPushesAMD64 returns the number of R12..R14 pushes the
+// isCellBankAMD64 reports whether fn carries the Cell register bank.
+// Phase 6.3.4.m.4c.1 cell-bank fns repurpose RBP as the regsCell base
+// and R14 as the *jitArenaCtx pointer, so the prologue pushes both and
+// the epilogue pops them. usesR14ForF64 and isCellBankAMD64 are mutually
+// exclusive: lowerAMD64 rejects the combination.
+func isCellBankAMD64(fn *vm3.Function) bool { return fn.NumRegsCell > 0 }
+
+// numCalleeSavedPushesAMD64 returns the number of R12..R14/RBP pushes the
 // prologue needs for fn, plus the always-present RBX and R15 pushes
 // (2). Used by both the prologue emitter and the byte-count predictor.
 // R14 is pushed when (a) i64 slot 8 lands in R14 OR (b) R14 holds the
-// regsF64 base for an f64-touching fn.
+// regsF64 base for an f64-touching fn OR (c) R14 holds *jitArenaCtx for
+// a cell-bank fn. RBP is pushed only for cell-bank fns (regsCell base).
 func numCalleeSavedPushesAMD64(fn *vm3.Function) int {
 	n := int(fn.NumRegsI64)
 	if n > maxI64RegsAMD64 {
@@ -122,8 +141,11 @@ func numCalleeSavedPushesAMD64(fn *vm3.Function) int {
 	if n > 7 {
 		count++
 	}
-	if n > 8 || usesR14ForF64(fn) {
+	if n > 8 || usesR14ForF64(fn) || isCellBankAMD64(fn) {
 		count++
+	}
+	if isCellBankAMD64(fn) {
+		count++ // RBP for regsCell base
 	}
 	return count
 }
@@ -205,6 +227,14 @@ func lowerAMD64(fn *vm3.Function, opts Options) ([]byte, error) {
 		return nil, fmt.Errorf("%w: %s has both f64 regs and OpCallI64 (Phase 6.2b leaves f64+self-recursion to a later sub-phase)",
 			ErrNotImplemented, fn.Name)
 	}
+	if isCellBankAMD64(fn) && fn.NumRegsF64 > 0 {
+		return nil, fmt.Errorf("%w: %s has both Cell and f64 banks (AMD64 cell-bank Phase 6.3.4.m.4c.1 admits Cell+I64 only; R14 is shared)",
+			ErrNotImplemented, fn.Name)
+	}
+	if isCellBankAMD64(fn) && int(fn.NumRegsI64) > 8 {
+		return nil, fmt.Errorf("%w: %s has Cell bank with NumRegsI64=%d (>8); R14 reserved for *jitArenaCtx",
+			ErrNotImplemented, fn.Name, fn.NumRegsI64)
+	}
 	prologueBytes := prologueLenAMD64(fn)
 	spillSets := computeCallSpillsAMD64(fn)
 
@@ -264,8 +294,11 @@ func prologueLenAMD64(fn *vm3.Function) int {
 	if n > 7 {
 		bytes += pushBytes(xR13)
 	}
-	if n > 8 || usesR14ForF64(fn) {
+	if n > 8 || usesR14ForF64(fn) || isCellBankAMD64(fn) {
 		bytes += pushBytes(xR14)
+	}
+	if isCellBankAMD64(fn) {
+		bytes += pushBytes(xRBP)
 	}
 	if alignFixupBytesAMD64(fn) != 0 {
 		bytes += 4 // sub $8, %rsp == REX.W 83 /5 ib (4 bytes)
@@ -275,6 +308,10 @@ func prologueLenAMD64(fn *vm3.Function) int {
 	// mov %rdx, %r14 (3 bytes) when R14 holds regsF64 base.
 	if usesR14ForF64(fn) {
 		bytes += 3
+	}
+	// Cell-bank: mov %rcx, %rbp (3) + mov %r8, %r14 (3).
+	if isCellBankAMD64(fn) {
+		bytes += 3 + 3
 	}
 	// Each pinned i64 slot load is mov disp32(%rbx), <reg> = 7 bytes.
 	bytes += 7 * n
@@ -319,8 +356,11 @@ func emitPrologueAMD64(buf []byte, fn *vm3.Function) []byte {
 	if n > 7 {
 		buf = append(buf, push64(xR13)...)
 	}
-	if n > 8 || usesR14ForF64(fn) {
+	if n > 8 || usesR14ForF64(fn) || isCellBankAMD64(fn) {
 		buf = append(buf, push64(xR14)...)
+	}
+	if isCellBankAMD64(fn) {
+		buf = append(buf, push64(xRBP)...)
 	}
 	if alignFixupBytesAMD64(fn) != 0 {
 		buf = append(buf, subRSPImm8(8)...)
@@ -329,6 +369,10 @@ func emitPrologueAMD64(buf []byte, fn *vm3.Function) []byte {
 	buf = append(buf, mov64RR(xRSI, xR15)...)
 	if usesR14ForF64(fn) {
 		buf = append(buf, mov64RR(xRDX, xR14)...)
+	}
+	if isCellBankAMD64(fn) {
+		buf = append(buf, mov64RR(xRCX, xRBP)...)
+		buf = append(buf, mov64RR(xR8, xR14)...)
 	}
 	for r := 0; r < n; r++ {
 		buf = append(buf, mov64LoadDisp32(r2xAMD64(uint16(r)), xRBX, int32(r*8))...)
@@ -348,7 +392,10 @@ func emitEpilogueAMD64(buf []byte, fn *vm3.Function) []byte {
 	if alignFixupBytesAMD64(fn) != 0 {
 		buf = append(buf, addRSPImm8(8)...)
 	}
-	if n > 8 || usesR14ForF64(fn) {
+	if isCellBankAMD64(fn) {
+		buf = append(buf, pop64(xRBP)...)
+	}
+	if n > 8 || usesR14ForF64(fn) || isCellBankAMD64(fn) {
 		buf = append(buf, pop64(xR14)...)
 	}
 	if n > 7 {
@@ -371,7 +418,10 @@ func epilogueBytesAMD64(fn *vm3.Function) int {
 	if alignFixupBytesAMD64(fn) != 0 {
 		bytes += 4 // add $8, %rsp
 	}
-	if n > 8 || usesR14ForF64(fn) {
+	if isCellBankAMD64(fn) {
+		bytes += popBytes(xRBP)
+	}
+	if n > 8 || usesR14ForF64(fn) || isCellBankAMD64(fn) {
 		bytes += popBytes(xR14)
 	}
 	if n > 7 {
@@ -498,6 +548,12 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 	case vm3.OpReturnF64:
 		// movq xmm<A>, %rax (5) + epilogue.
 		return 5 + epilogueBytesAMD64(fn), nil
+	case vm3.OpReturnCell:
+		// mov disp32(%rbp), %rax (7) + epilogue. RBP holds the regsCell
+		// base for cell-bank fns (Phase 6.3.4.m.4c.2); the cell handle
+		// in slot A is loaded into RAX so the trampoline returns it
+		// bit-for-bit through Go's uint64 result channel.
+		return 7 + epilogueBytesAMD64(fn), nil
 
 	case vm3.OpConstF64K:
 		idx := int(uint16(op.C))
@@ -733,6 +789,13 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		// movq %rax, %xmm<A>: bit-cast f64 to int64 in RAX, then run
 		// the epilogue (which preserves RAX through pops).
 		out := movqR64FromXMM(xRAX, int(op.A))
+		out = emitEpilogueAMD64(out, fn)
+		return out, nil
+	case vm3.OpReturnCell:
+		// Phase 6.3.4.m.4c.2: cell-bank return. Load regsCell[A] from
+		// RBP+disp32 into RAX, then run the epilogue. RBP is restored
+		// by the epilogue's pop sequence; RAX carries the handle through.
+		out := mov64LoadDisp32(xRAX, xRBP, int32(op.A)*8)
 		out = emitEpilogueAMD64(out, fn)
 		return out, nil
 

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2621,6 +2621,34 @@ A pre-existing AMD64 bug in the recursive JIT path (`TestCompileFactRecMatchesIn
 
 **Closure verdict.** m.4c.prereq closes the recursive-JIT correctness gap on linux/amd64. m.4c can now port the inline OpNewPair / OpPairFst / OpPairSnd / OpReturnCell lowering and bench binary_trees on server2 without a sigpanic stop-energy.
 
+#### Phase 6.3.4.m.4c.1 + m.4c.2: AMD64 cell-bank scaffold + OpReturnCell (2026-05-20 05:54 GMT+7)
+
+**Why this exists.** Phase 6.3.4.m.4c needs six sub-phases to port the binary_trees ARM64 cell-bank path to AMD64. The first two land the entry/exit scaffolding so the remaining sub-phases (m.4c.3 OpPairFst/Snd, m.4c.4 inline OpNewPair, m.4c.5 self-OpCallMixed, m.4c.6 admission gate + bench) can be measured one opcode at a time without re-paying ABI cost on each iteration.
+
+**Implementation (m.4c.1: cell-bank entry path).** Cell-bank fns now pin two extra registers across the AMD64 JIT body:
+- `RBP` ← `RCX` (regsCell base, used by `mov disp32(%rbp), %rax` for OpReturnCell and later by OpPairFst/Snd loads).
+- `R14` ← `R8` (*jitArenaCtx, holding pairsBase/pairsLen/pairsCap for inline OpNewPair in m.4c.4).
+
+Both pushed in the prologue and popped in the epilogue. `isCellBankAMD64(fn) = fn.NumRegsCell > 0` gates the new push/pop pairs in `numCalleeSavedPushesAMD64`, `prologueLenAMD64`, `emitPrologueAMD64`, `emitEpilogueAMD64`, and `epilogueBytesAMD64`. Mutual exclusions:
+- Cell-bank + f64 banks rejected: R14 is shared as the f64 base path. Pure cell-bank or cell-bank + i64 only.
+- Cell-bank with `NumRegsI64 > 8` rejected: R14 was the slot-8 home, now arena-pinned. `archCaps` drops the amd64 i64 cap to 8 when cell-bank present.
+
+**Implementation (m.4c.2: OpReturnCell).** `byteCountAMD64` and `emitInstrAMD64` add an OpReturnCell case: `mov disp32(%rbp), %rax` (7 bytes) loads regsCell[A] into the SysV return register, then the epilogue restores callee-saved state. The trampoline (`CallStatusM`) returns the cell handle bit-for-bit through Go's `uint64` result channel, matching the ARM64 m.4a path.
+
+**Admission.** `checkCellBankAdmissible` dispatches to a new `checkCellBankAdmissibleAMD64` with a narrow whitelist: existing i64 arithmetic / compare-and-branch / control-flow ops + OpReturnCell. Pair ops, list/map ops, and OpCallMixed remain rejected on amd64 until their own sub-phases ship.
+
+**Tests.** `runtime/jit/vm3jit/cell_amd64_test.go` (build tag `//go:build amd64`) adds two synthetic kernels:
+- `TestCellBankScaffoldAMD64`: helper(Cell)→Cell with single OpReturnCell. A driver builds `pair(CNull, CNull)` on the interp side, calls the JIT helper, asserts the returned Cell still decodes to `ArenaPair`. Catches any prologue byte-count drift.
+- `TestCellBankScaffoldWithI64AMD64`: helper(Cell, I64)→Cell with OpAddI64K + OpReturnCell. Exercises the i64 slot-load path inside a cell-bank prologue, surfacing any RBX/R15/R14/RBP push-order mismatch between `byteCountAMD64` and `emitInstrAMD64`.
+
+**Results.**
+- darwin/arm64: full `go test ./runtime/jit/vm3jit/` clean (no regressions on existing arm64 cell-bank, pair, recursive paths).
+- linux/amd64 (server2, EPYC, Go 1.26.0): both new tests pass; rest of vm3jit suite green (TestNsieveJITCompiles failure pre-dates this PR; tracked separately under the broader amd64 cell-bank entry-path parity that arrives with m.4c.6).
+
+**Composite gate effect.** No BG row flips yet, scaffolding only. binary_trees on linux/amd64 stays at the m.4b interp-routed baseline (3.80x / 4.63x) and will close when m.4c.6 admits the full cell-bank path. m.4c.3 (OpPairFst/Snd) is unblocked.
+
+**Closure verdict.** m.4c.1 + m.4c.2 land the AMD64 cell-bank entry path and OpReturnCell lowering. Helper kernels that return a cell handle without touching pair ops now JIT correctly on linux/amd64; the remaining four sub-phases (m.4c.3 .. m.4c.6) can iterate against this baseline.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
Closes #21824.

First two sub-phases of the m.4c AMD64 cell-bank port. After this lands, m.4c.3 (OpPairFst/Snd lowering) is unblocked.

## Summary
- AMD64 cell-bank prologue pins `RBP`=regsCell (from RCX) and `R14`=*jitArenaCtx (from R8); both pushed/popped in prologue/epilogue. Cell-bank + f64 rejected (R14 collision); cell-bank with `NumRegsI64 > 8` rejected (R14 stolen). `archCaps` drops the amd64 i64 cap to 8 when cell-bank present.
- `OpReturnCell` on amd64 lowers as `mov disp32(%rbp), %rax` + epilogue. Matches the ARM64 m.4a path so the trampoline returns the cell handle bit-for-bit via RAX.
- `checkCellBankAdmissible` dispatches to a new AMD64 whitelist that admits the existing i64 op set + `OpReturnCell`. Pair / list / map / `OpCallMixed` ops still reject on amd64 until their own sub-phases ship.
- Adds `runtime/jit/vm3jit/cell_amd64_test.go` (build tag `//go:build amd64`) with `TestCellBankScaffoldAMD64` (pure cell echo) and `TestCellBankScaffoldWithI64AMD64` (cell + i64). Both pass on linux/amd64 server2.
- MEP-40 spec updated with the m.4c.1+m.4c.2 closure entry timestamped 2026-05-20 05:54 GMT+7.

## Test plan
- [x] `go test ./runtime/jit/vm3jit/` clean on darwin/arm64 (no regression).
- [x] `GOOS=linux GOARCH=amd64 go build ./runtime/jit/vm3jit/...` clean.
- [x] `GOOS=linux GOARCH=amd64 go vet ./runtime/jit/vm3jit/...` clean.
- [x] `go test ./runtime/jit/vm3jit/ -run TestCellBank -v` on server2 (linux/amd64): both new tests PASS.
- [x] `go test ./runtime/jit/vm3jit/ -skip TestNsieveJITCompiles` on server2: PASS. The TestNsieveJITCompiles failure pre-dates this PR (verified by re-running against parent commit 796ea372b8); tracked under the broader amd64 cell-bank entry-path parity that arrives with m.4c.6.