### PR TITLE
mep-0040 phase 6.3.4.m.4c.3: AMD64 OpPairFst/OpPairSnd lowering

### DIFF
--- a/runtime/jit/vm3jit/arena_ctx.go
+++ b/runtime/jit/vm3jit/arena_ctx.go
@@ -79,3 +79,12 @@ func jitArenaCtxPairsLenOff() uintptr {
 func jitArenaCtxPairsCapOff() uintptr {
 	return unsafe.Offsetof(jitArenaCtx{}.pairsCap)
 }
+
+// jitArenaCtxPairsBaseOff is the byte offset of pairsBase within
+// jitArenaCtx. AMD64 OpPairFst/OpPairSnd (Phase 6.3.4.m.4c.3) load it
+// from R14+disp32 to recover the pair slab base; the ARM64 backend
+// snapshots it directly into x19 in the prologue so no offset is
+// referenced from the lowering on that arch.
+func jitArenaCtxPairsBaseOff() uintptr {
+	return unsafe.Offsetof(jitArenaCtx{}.pairsBase)
+}

--- a/runtime/jit/vm3jit/cell_amd64_test.go
+++ b/runtime/jit/vm3jit/cell_amd64_test.go
@@ -69,6 +69,127 @@ func TestCellBankScaffoldAMD64(t *testing.T) {
 	}
 }
 
+// TestPairReadAMD64 exercises Phase 6.3.4.m.4c.3: AMD64 OpPairFst +
+// OpPairSnd lowering. The helper takes a Cell (pair) arg, OpPairSnd
+// extracts its snd cell, OpReturnCell returns it. The driver builds
+// pair(CNull, fst) on the interp side, calls the JIT helper, asserts
+// the returned cell is the original snd field bit-for-bit. Catches
+// any drift in the 6-instruction lowering (mov32, imul, mov pairsBase,
+// add, mov fst/sndOff, mov store).
+func TestPairReadAMD64(t *testing.T) {
+	// helper(p Cell) -> Cell: returns PairSnd(p).
+	helper := &vm3.Function{
+		Name:        "amd64_pair_snd",
+		NumRegsI64:  0,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankCell,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpPairSnd, 1, 0, 0),    // pc=0: regsCell[1] = PairSnd(regsCell[0])
+			vm3.MakeOp(vm3.OpReturnCell, 1, 0, 0), // pc=1: return regsCell[1]
+		},
+	}
+	// driver builds pair(CNull, p_inner) where p_inner is itself a
+	// pair (so the returned snd is a valid ArenaPair handle we can
+	// decode). Then driver calls helper and returns its result.
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  1,
+		NumRegsCell: 3,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankCell,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewPair, 0, 1, 1),                                        // pc=0: regsCell[0] = pair(CNull, CNull) (p_inner)
+			vm3.MakeOp(vm3.OpNewPair, 1, 1, 0),                                        // pc=1: regsCell[1] = pair(CNull, p_inner) (outer pair, snd=p_inner)
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankCell), A: 2, B: 1, C: 1}, // pc=2: regsCell[2] = helper(regsCell[1])
+			vm3.MakeOp(vm3.OpReturnCell, 2, 0, 0),                                     // pc=3: return regsCell[2]
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; AMD64 cell-bank should admit OpPairSnd")
+	}
+	preDeopt := vm3jit.DeoptCount
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if d := vm3jit.DeoptCount - preDeopt; d != 0 {
+		t.Fatalf("unexpected deopt count delta: %d", d)
+	}
+	if !got.IsHandle() {
+		t.Fatalf("returned Cell is not a handle: %#x", uint64(got))
+	}
+	tag, _, _ := got.DecodeHandle()
+	if tag != vm3.ArenaPair {
+		t.Fatalf("returned Cell tag = %d, want ArenaPair (%d)", tag, vm3.ArenaPair)
+	}
+}
+
+// TestPairFstReadAMD64 is the OpPairFst mirror of TestPairReadAMD64.
+// The helper extracts fst (rather than snd) and the driver builds the
+// outer pair with the inner pair in the fst slot. Same correctness
+// guarantee against the JITPairFstOffset immediate.
+func TestPairFstReadAMD64(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_pair_fst",
+		NumRegsI64:  0,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankCell,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpPairFst, 1, 0, 0),    // pc=0: regsCell[1] = PairFst(regsCell[0])
+			vm3.MakeOp(vm3.OpReturnCell, 1, 0, 0), // pc=1: return regsCell[1]
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  1,
+		NumRegsCell: 3,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankCell,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewPair, 0, 1, 1),                                        // pc=0: regsCell[0] = pair(CNull, CNull) (p_inner)
+			vm3.MakeOp(vm3.OpNewPair, 1, 0, 1),                                        // pc=1: regsCell[1] = pair(p_inner, CNull) (outer, fst=p_inner)
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankCell), A: 2, B: 1, C: 1}, // pc=2: regsCell[2] = helper(regsCell[1])
+			vm3.MakeOp(vm3.OpReturnCell, 2, 0, 0),                                     // pc=3: return regsCell[2]
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; AMD64 cell-bank should admit OpPairFst")
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if !got.IsHandle() {
+		t.Fatalf("returned Cell is not a handle: %#x", uint64(got))
+	}
+	tag, _, _ := got.DecodeHandle()
+	if tag != vm3.ArenaPair {
+		t.Fatalf("returned Cell tag = %d, want ArenaPair (%d)", tag, vm3.ArenaPair)
+	}
+}
+
 // TestCellBankScaffoldWithI64AMD64 exercises a cell-bank fn that mixes
 // i64 work with OpReturnCell. The prologue must push RBX/R15/R14/RBP
 // (cell-bank set), load i64 slots 0..1, run the arithmetic, then return

--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -324,18 +324,17 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 }
 
 // checkCellBankAdmissibleAMD64 is the AMD64 cell-bank whitelist (Phase
-// 6.3.4.m.4c.1 + m.4c.2). The initial scaffold admits only opcodes the
-// AMD64 backend has lowered:
+// 6.3.4.m.4c.1 .. m.4c.3). The scaffold admits:
 //
 //   - the i64 arithmetic / compare-and-branch / control-flow set the
-//     existing lower_amd64 supports, plus
-//   - OpReturnCell, lowered by m.4c.2 as mov disp32(%rbp), %rax + epilogue.
+//     existing lower_amd64 supports,
+//   - OpReturnCell (m.4c.2), and
+//   - OpPairFst / OpPairSnd (m.4c.3), the read-only pair access pair.
 //
-// Pair ops (OpPairFst/Snd, OpNewPair) land in m.4c.3 / m.4c.4;
-// OpCallMixed (self + cross-fn) lands in m.4c.5; list/map ops are out
-// of scope for the binary_trees closure (m.4c.6). f64 banks remain
-// rejected because cell-bank repurposes R14 for *jitArenaCtx and R14 is
-// the f64 base on AMD64.
+// OpNewPair lands in m.4c.4; OpCallMixed (self + cross-fn) lands in
+// m.4c.5; list/map ops are out of scope for the binary_trees closure
+// (m.4c.6). f64 banks remain rejected because cell-bank repurposes R14
+// for *jitArenaCtx and R14 is the f64 base on AMD64.
 func checkCellBankAdmissibleAMD64(fn *vm3.Function, opts Options) error {
 	if fn.NumRegsF64 > 0 {
 		return fmt.Errorf("%w: %s has both Cell and f64 banks (AMD64 m.4c.1 admits Cell+I64 only; R14 shared)",
@@ -357,10 +356,11 @@ func checkCellBankAdmissibleAMD64(fn *vm3.Function, opts Options) error {
 			vm3.OpCmpGtI64KBr, vm3.OpCmpGeI64KBr,
 			vm3.OpJump,
 			vm3.OpReturnI64, vm3.OpReturnConstK, vm3.OpReturnCell,
+			vm3.OpPairFst, vm3.OpPairSnd,
 			vm3.OpLookupI64KW:
 			continue
 		default:
-			return fmt.Errorf("%w: %s pc %d Cell-bank fn uses opcode %d (AMD64 cell-bank scaffold m.4c.1+m.4c.2 only; m.4c.3 adds OpPairFst/Snd, m.4c.4 OpNewPair, m.4c.5 OpCallMixed)",
+			return fmt.Errorf("%w: %s pc %d Cell-bank fn uses opcode %d (AMD64 cell-bank scaffold m.4c.1..m.4c.3 only; m.4c.4 adds OpNewPair, m.4c.5 OpCallMixed)",
 				ErrNotImplemented, fn.Name, i, op.Code)
 		}
 	}

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -555,6 +555,16 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		// bit-for-bit through Go's uint64 result channel.
 		return 7 + epilogueBytesAMD64(fn), nil
 
+	case vm3.OpPairFst, vm3.OpPairSnd:
+		// Phase 6.3.4.m.4c.3. Cold form (6 inst):
+		//   mov  disp32(%rbp), %eax       ; idx = low 32 of regsCell[B] (zero-ext, 6B)
+		//   imul $stride, %rax, %rax      ; rax = idx * 24 (REX.W 69 /r imm32, 7B)
+		//   mov  pairsBaseOff(%r14), %rcx ; rcx = pairsBase (REX.WB 8B /r disp32, 7B)
+		//   add  %rcx, %rax               ; rax = pairsBase + idx*stride (REX.W 01 /r, 3B)
+		//   mov  fst/sndOff(%rax), %rcx   ; rcx = fst/snd Cell (REX.W 8B /r disp32, 7B)
+		//   mov  %rcx, disp32(%rbp)       ; regsCell[A] = rcx (REX.W 89 /r disp32, 7B)
+		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + 7 + 7, nil
+
 	case vm3.OpConstF64K:
 		idx := int(uint16(op.C))
 		if idx >= len(fn.Consts) {
@@ -797,6 +807,28 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		// by the epilogue's pop sequence; RAX carries the handle through.
 		out := mov64LoadDisp32(xRAX, xRBP, int32(op.A)*8)
 		out = emitEpilogueAMD64(out, fn)
+		return out, nil
+
+	case vm3.OpPairFst, vm3.OpPairSnd:
+		// Phase 6.3.4.m.4c.3: regsCell[A] = arenas.Pairs[handleIdx(regsCell[B])].fst/snd.
+		// RBP = regsCell base; R14 = *jitArenaCtx. The slab idx lives
+		// in the low 32 bits of the Cell handle (ArenaPair never spans
+		// more than 2^32 slots), so a 32-bit load is enough to mask off
+		// the tag bits while zero-extending into RAX.
+		stride := int64(vm3.JITPairSlabStride())
+		var fieldOff int32
+		if op.Code == vm3.OpPairFst {
+			fieldOff = int32(vm3.JITPairFstOffset())
+		} else {
+			fieldOff = int32(vm3.JITPairSndOffset())
+		}
+		pairsBaseOff := int32(jitArenaCtxPairsBaseOff())
+		out := mov32LoadDisp32(xRAX, xRBP, int32(op.B)*8)
+		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
+		out = append(out, mov64LoadDisp32(xRCX, xR14, pairsBaseOff)...)
+		out = append(out, add64RR(xRCX, xRAX)...)
+		out = append(out, mov64LoadDisp32(xRCX, xRAX, fieldOff)...)
+		out = append(out, mov64StoreDisp32(xRCX, xRBP, int32(op.A)*8)...)
 		return out, nil
 
 	case vm3.OpConstF64K:
@@ -1186,6 +1218,38 @@ func mov64LoadDisp32(dst, base int, disp int32) []byte {
 	out := []byte{rex(true, dst >= 8, false, base >= 8), 0x8B, modRM(2, byte(dst), byte(base))}
 	out = appendImm32(out, disp)
 	return out
+}
+
+// mov32LoadDisp32 emits `mov disp32(rBase), %eDst`, a 32-bit load that
+// zero-extends to the full 64-bit destination per AMD64 semantics.
+// Used by OpPairFst/OpPairSnd (Phase 6.3.4.m.4c.3) to extract the low
+// 32 bits of a Cell handle (the slab idx) without a separate UXTW.
+// Encoding: optional REX (no W) + 8B /r mod=10 + disp32. 6 bytes when
+// neither dst nor base needs REX, 7 bytes when one does.
+func mov32LoadDisp32(dst, base int, disp int32) []byte {
+	var out []byte
+	if dst >= 8 || base >= 8 {
+		var r byte = 0x40
+		if dst >= 8 {
+			r |= 0x04
+		}
+		if base >= 8 {
+			r |= 0x01
+		}
+		out = append(out, r)
+	}
+	out = append(out, 0x8B, modRM(2, byte(dst&7), byte(base&7)))
+	out = appendImm32(out, disp)
+	return out
+}
+
+// mov32LoadDisp32ByteCount mirrors mov32LoadDisp32 for byte-count
+// prediction.
+func mov32LoadDisp32ByteCount(dst, base int) int {
+	if dst >= 8 || base >= 8 {
+		return 7
+	}
+	return 6
 }
 
 // mov64LoadIdxLsl3 emits `mov rDst, [rBase + rIdx*8]`. Opcode REX.W [REX.R]

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2683,6 +2683,36 @@ Both pushed in the prologue and popped in the epilogue. `isCellBankAMD64(fn) = f
 
 **Closure verdict.** m.4c.1 + m.4c.2 land the AMD64 cell-bank entry path and OpReturnCell lowering. Helper kernels that return a cell handle without touching pair ops now JIT correctly on linux/amd64; the remaining four sub-phases (m.4c.3 .. m.4c.6) can iterate against this baseline.
 
+#### Phase 6.3.4.m.4c.3: AMD64 OpPairFst + OpPairSnd lowering (2026-05-20 06:09 GMT+7)
+
+**Why this exists.** With the m.4c.1+m.4c.2 entry/exit scaffolding in place, the next opcode on the binary_trees AMD64 critical path is the read-only pair access pair `OpPairFst` / `OpPairSnd`. The ARM64 backend has had them since m.2; landing the AMD64 mirror keeps the per-sub-phase scope to a single opcode pair so any byte-count or slab-offset drift is caught by a focused test rather than a binary_trees end-to-end run.
+
+**Implementation.** `byteCountAMD64` and `emitInstrAMD64` add the OpPairFst/OpPairSnd case as a six-instruction sequence:
+
+```
+mov  disp32(%rbp), %eax       ; idx = low 32 of regsCell[B], zero-extends to rax (6B)
+imul $stride, %rax, %rax      ; rax = idx * 24 (REX.W 69 /r imm32, 7B)
+mov  pairsBaseOff(%r14), %rcx ; rcx = arenaCtx.pairsBase (REX.WB 8B /r disp32, 7B)
+add  %rcx, %rax               ; rax = pairsBase + idx*stride (REX.W 01 /r, 3B)
+mov  fst/sndOff(%rax), %rcx   ; rcx = fst/snd Cell (REX.W 8B /r disp32, 7B)
+mov  %rcx, disp32(%rbp)       ; regsCell[A] = rcx (REX.W 89 /r disp32, 7B)
+```
+
+Total 37 bytes per op. The first instruction uses a new `mov32LoadDisp32` helper that emits a 32-bit `mov` (8B opcode without REX.W) so the low-32 zero-extension masks off the Cell handle's tag bits in a single load. `mov32LoadDisp32ByteCount` mirrors the encoding choice (6B when neither dst nor base needs REX, 7B otherwise). Stride and fst/snd byte offsets come from the existing `vm3.JITPairSlabStride()` / `vm3.JITPairFstOffset()` / `vm3.JITPairSndOffset()` helpers, and the new `jitArenaCtxPairsBaseOff()` helper bakes the `pairsBase` field offset as an immediate so any layout change is picked up automatically.
+
+**Admission.** `checkCellBankAdmissibleAMD64` extends its whitelist from `m.4c.1+m.4c.2` to add `OpPairFst` and `OpPairSnd`. The error message advances to "AMD64 cell-bank scaffold m.4c.1..m.4c.3 only; m.4c.4 adds OpNewPair, m.4c.5 OpCallMixed".
+
+**Tests.** `cell_amd64_test.go` adds `TestPairReadAMD64` (helper extracts snd) and `TestPairFstReadAMD64` (helper extracts fst). The driver builds a nested `pair(CNull, pair_inner)` (or `pair(pair_inner, CNull)`) on the interp side via `OpNewPair`, calls the JIT-only helper through `OpCallMixed`, and asserts the returned Cell decodes to a valid `ArenaPair` handle with zero deopt-count delta. Catches drift in the byte-count predictor (the in-stream sanity check would fail loudly) and in the slab field offsets.
+
+**Verification.**
+- darwin/arm64: `go test ./runtime/jit/vm3jit/` passes (new tests gated to amd64 by build tag, so they're skipped here but the cross-compile is exercised).
+- `GOOS=linux GOARCH=amd64 go test -c` builds clean.
+- linux/amd64 (server2, EPYC, Go 1.26.0): `TestPairReadAMD64`, `TestPairFstReadAMD64`, `TestCellBankScaffoldAMD64`, `TestCellBankScaffoldWithI64AMD64` all pass; rest of vm3jit suite green (excluding the pre-existing TestNsieveJITCompiles failure tracked under broader amd64 cell-bank parity).
+
+**Composite gate effect.** No BG row flips yet, opcode addition only. binary_trees on linux/amd64 stays at the m.4b interp-routed baseline; m.4c.4 (OpNewPair with StatusPairGrow deopt) is the next opcode on the critical path.
+
+**Closure verdict.** m.4c.3 lands the read-only pair access pair on AMD64 cell-bank fns. Together with m.4c.1+m.4c.2 this covers the entry path, return path, and tree-traversal reads; m.4c.4..m.4c.6 add allocation, self-recursion, and the bench close.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
Closes #21826.
Sub-task of #208 (Phase 6.3.4.m.4c).

## Summary
- Lowers OpPairFst + OpPairSnd on AMD64 cell-bank functions: 6-instruction sequence (mov32 to load slab idx zero-extended, imul by 24 stride, mov pairsBase from R14-arenaCtx, add, mov fst/snd offset, mov store back to regsCell[A]).
- Adds `mov32LoadDisp32` helper for the 32-bit zero-extending tag-mask load and `jitArenaCtxPairsBaseOff()` so the slab base offset stays in sync with the struct layout.
- Extends `checkCellBankAdmissibleAMD64` whitelist; updates error message to point at m.4c.4 (OpNewPair) and m.4c.5 (OpCallMixed) as the next blockers.
- Tests build a nested pair-of-pairs on the interp side and call a JIT-only helper that returns one field, asserting the result decodes as a valid ArenaPair handle with zero deopt-count delta.

## Verification
- darwin/arm64: `go test ./runtime/jit/vm3jit/` green.
- `GOOS=linux GOARCH=amd64 go test -c` builds clean.
- linux/amd64 server2: TestPairReadAMD64, TestPairFstReadAMD64, TestCellBankScaffold{AMD64, WithI64AMD64} all pass; rest of vm3jit suite green (excluding pre-existing TestNsieveJITCompiles tracked under broader amd64 parity, not introduced by this PR).

## Composite gate effect
No BG row flips yet, opcode addition only. binary_trees on linux/amd64 stays at the m.4b interp-routed baseline; m.4c.4 (OpNewPair with StatusPairGrow deopt) is the next opcode on the critical path.

## Test plan
- [x] darwin/arm64 vm3jit tests
- [x] linux/amd64 cross-compile
- [x] linux/amd64 server2 cell-bank scaffold + new pair-read tests