### PR TITLE
mep-0040: phase 6.3.4.m.4c.5 AMD64 self-recursive OpCallMixed

### DIFF
--- a/runtime/jit/vm3jit/cell_amd64_test.go
+++ b/runtime/jit/vm3jit/cell_amd64_test.go
@@ -245,6 +245,138 @@ func TestCellBankScaffoldWithI64AMD64(t *testing.T) {
 	}
 }
 
+// TestSelfCallMixedI64ReturnAMD64 exercises Phase 6.3.4.m.4c.5: AMD64
+// self-recursive OpCallMixed with a Cell+I64 mixed param shape and an
+// I64 result, mirroring binary_trees' check_tree. The helper walks a
+// 1-deep pair recursively: at d>0 it follows PairFst, recurses with
+// d-1, then adds 1; at d==0 it returns 1. The driver builds a 2-level
+// pair so a single recursion bottoms out and returns 2 (leaf + parent
+// counted by the +1). Asserts admission, zero-deopt, correct return.
+func TestSelfCallMixedI64ReturnAMD64(t *testing.T) {
+	// helper(t Cell, d i64) -> i64.
+	// Cell-bank fn with ParamBanks=[Cell, I64], ResultBank=I64.
+	helper := &vm3.Function{
+		Name:        "amd64_self_cm_i64_ret",
+		NumRegsI64:  4,
+		NumRegsCell: 3,
+		ParamBanks:  []vm3.Bank{vm3.BankCell, vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpCmpGtI64KBr, 1, 0, 2),                                   // pc=0: if d > 0 -> 2
+			vm3.MakeOp(vm3.OpReturnConstK, 0, 0, 1),                                  // pc=1: leaf -> 1
+			vm3.MakeOp(vm3.OpSubI64K, 3, 1, 1),                                       // pc=2: d_minus_1 = d-1
+			vm3.MakeOp(vm3.OpPairFst, 2, 0, 0),                                       // pc=3: regsCell[2] = PairFst(t)
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 2, B: 2, C: 1}, // pc=4: regsI64[2] = helper(regsCell[2], regsI64[3])
+			vm3.MakeOp(vm3.OpAddI64K, 2, 2, 1),                                       // pc=5: regsI64[2]++
+			vm3.MakeOp(vm3.OpReturnI64, 2, 0, 0),                                     // pc=6: return regsI64[2]
+		},
+	}
+	// driver builds pair(inner, CNull) where inner is pair(CNull,CNull),
+	// then calls helper(pair, 1) -> should return 2 (one recursion step
+	// + a leaf returning 1).
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  3,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewPair, 0, 1, 1),                                       // pc=0: regsCell[0] = pair(CNull, CNull) (inner)
+			vm3.MakeOp(vm3.OpNewPair, 1, 0, 1),                                       // pc=1: regsCell[1] = pair(inner, CNull)
+			vm3.MakeOp(vm3.OpConstI64K, 2, 0, 1),                                     // pc=2: regsI64[2] = 1 (depth)
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 1, C: 1}, // pc=3: regsI64[0] = helper(regsCell[1], regsI64[2])
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),                                     // pc=4: return regsI64[0]
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; AMD64 cell-bank should admit self OpCallMixed (m.4c.5)")
+	}
+	preDeopt := vm3jit.DeoptCount
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if d := vm3jit.DeoptCount - preDeopt; d != 0 {
+		t.Fatalf("unexpected deopt count delta: %d", d)
+	}
+	if int64(got) != 2 {
+		t.Fatalf("got %d, want 2", int64(got))
+	}
+}
+
+// TestSelfCallMixedCellReturnAMD64 exercises Phase 6.3.4.m.4c.5: AMD64
+// self-recursive OpCallMixed with an I64-only param shape and a Cell
+// result, mirroring binary_trees' make_tree. The helper, at d>0,
+// recursively calls itself with d-1 to populate fst and snd, then
+// allocates a pair; at d==0, it allocates a leaf pair. Asserts admission,
+// zero-deopt (pairsCap accommodates the tree), and that the returned
+// cell decodes to a valid ArenaPair handle.
+func TestSelfCallMixedCellReturnAMD64(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_self_cm_cell_ret",
+		NumRegsI64:  2,
+		NumRegsCell: 3,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankCell,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpCmpGtI64KBr, 0, 0, 3),                                    // pc=0: if d > 0 -> 3
+			vm3.MakeOp(vm3.OpNewPair, 2, 0, 0),                                        // pc=1: leaf pair(CNull, CNull)
+			vm3.MakeOp(vm3.OpReturnCell, 2, 0, 0),                                     // pc=2: return leaf
+			vm3.MakeOp(vm3.OpSubI64K, 1, 0, 1),                                        // pc=3: arg = d-1
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankCell), A: 0, B: 1, C: 1}, // pc=4: regsCell[0] = helper(d-1)
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankCell), A: 1, B: 1, C: 1}, // pc=5: regsCell[1] = helper(d-1)
+			vm3.MakeOp(vm3.OpNewPair, 2, 0, 1),                                        // pc=6: pair(fst, snd)
+			vm3.MakeOp(vm3.OpReturnCell, 2, 0, 0),                                     // pc=7: return pair
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankCell,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 2),                                      // pc=0: regsI64[1] = 2 (depth)
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankCell), A: 0, B: 1, C: 1}, // pc=1: regsCell[0] = helper(2)
+			vm3.MakeOp(vm3.OpReturnCell, 0, 0, 0),                                     // pc=2: return
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; AMD64 cell-bank should admit self OpCallMixed with Cell result (m.4c.5)")
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if !got.IsHandle() {
+		t.Fatalf("returned Cell is not a handle: %#x", uint64(got))
+	}
+	tag, _, _ := got.DecodeHandle()
+	if tag != vm3.ArenaPair {
+		t.Fatalf("returned Cell tag = %d, want ArenaPair (%d)", tag, vm3.ArenaPair)
+	}
+}
+
 // TestNewPairJITAMD64 exercises Phase 6.3.4.m.4c.4: AMD64 OpNewPair
 // inline allocation in cell-bank. The helper receives one Cell arg
 // (CNull from the driver), allocates a pair via OpNewPair with both

--- a/runtime/jit/vm3jit/cell_amd64_test.go
+++ b/runtime/jit/vm3jit/cell_amd64_test.go
@@ -309,8 +309,8 @@ func TestSelfCallMixedI64ReturnAMD64(t *testing.T) {
 	if d := vm3jit.DeoptCount - preDeopt; d != 0 {
 		t.Fatalf("unexpected deopt count delta: %d", d)
 	}
-	if int64(got) != 2 {
-		t.Fatalf("got %d, want 2", int64(got))
+	if got.Int() != 2 {
+		t.Fatalf("got %d, want 2", got.Int())
 	}
 }
 

--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -324,18 +324,18 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 }
 
 // checkCellBankAdmissibleAMD64 is the AMD64 cell-bank whitelist (Phase
-// 6.3.4.m.4c.1 .. m.4c.4). The scaffold admits:
+// 6.3.4.m.4c.1 .. m.4c.5). The scaffold admits:
 //
 //   - the i64 arithmetic / compare-and-branch / control-flow set the
 //     existing lower_amd64 supports,
 //   - OpReturnCell (m.4c.2),
-//   - OpPairFst / OpPairSnd (m.4c.3), the read-only pair access pair, and
-//   - OpNewPair (m.4c.4), the inline allocator with StatusPairGrow deopt.
+//   - OpPairFst / OpPairSnd (m.4c.3), the read-only pair access pair,
+//   - OpNewPair (m.4c.4), the inline allocator with StatusPairGrow deopt, and
+//   - OpCallMixed (m.4c.5), self-recursive only (cross-fn is m.4c.6).
 //
-// OpCallMixed (self + cross-fn) lands in m.4c.5; list/map ops are out
-// of scope for the binary_trees closure (m.4c.6). f64 banks remain
-// rejected because cell-bank repurposes R14 for *jitArenaCtx and R14
-// is the f64 base on AMD64.
+// list/map ops are out of scope for the binary_trees closure. f64
+// banks remain rejected because cell-bank repurposes R14 for
+// *jitArenaCtx and R14 is the f64 base on AMD64.
 func checkCellBankAdmissibleAMD64(fn *vm3.Function, opts Options) error {
 	if fn.NumRegsF64 > 0 {
 		return fmt.Errorf("%w: %s has both Cell and f64 banks (AMD64 m.4c.1 admits Cell+I64 only; R14 shared)",
@@ -360,8 +360,25 @@ func checkCellBankAdmissibleAMD64(fn *vm3.Function, opts Options) error {
 			vm3.OpPairFst, vm3.OpPairSnd, vm3.OpNewPair,
 			vm3.OpLookupI64KW:
 			continue
+		case vm3.OpCallMixed:
+			// Self-recursive only on AMD64. Cross-fn cell-bank
+			// OpCallMixed lowers in a later sub-phase (m.4c.6).
+			idx := int(uint16(op.C))
+			if opts.SelfIdx < 0 || idx != opts.SelfIdx {
+				return fmt.Errorf("%w: %s pc %d Cell-bank cross-fn OpCallMixed not yet admitted on AMD64 (m.4c.5 self-only; m.4c.6 adds cross-fn)",
+					ErrNotImplemented, fn.Name, i)
+			}
+			// Reject f64 params for the same R14-sharing reason that
+			// rejects cell-bank fns with NumRegsF64 > 0.
+			for k, b := range fn.ParamBanks {
+				if b == vm3.BankF64 {
+					return fmt.Errorf("%w: %s pc %d Cell-bank OpCallMixed has f64 param at %d",
+						ErrNotImplemented, fn.Name, i, k)
+				}
+			}
+			continue
 		default:
-			return fmt.Errorf("%w: %s pc %d Cell-bank fn uses opcode %d (AMD64 cell-bank scaffold m.4c.1..m.4c.4 only; m.4c.5 adds OpCallMixed)",
+			return fmt.Errorf("%w: %s pc %d Cell-bank fn uses opcode %d (AMD64 cell-bank scaffold m.4c.1..m.4c.5 only; m.4c.6 adds cross-fn OpCallMixed)",
 				ErrNotImplemented, fn.Name, i, op.Code)
 		}
 	}

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -164,14 +164,80 @@ func alignFixupBytesAMD64(fn *vm3.Function) int {
 	return 0
 }
 
-// isNonLeafAMD64 mirrors isNonLeaf for the AMD64 backend.
+// isNonLeafAMD64 mirrors isNonLeaf for the AMD64 backend. Phase
+// 6.3.4.m.4c.5 adds self-recursive OpCallMixed to the set of native
+// CALLs the AMD64 backend emits, so cell-bank fns with self-CallMixed
+// also need the SP-alignment fixup.
 func isNonLeafAMD64(fn *vm3.Function) bool {
 	for _, op := range fn.Code {
-		if op.Code == vm3.OpCallI64 {
+		if op.Code == vm3.OpCallI64 || op.Code == vm3.OpCallMixed {
 			return true
 		}
 	}
 	return false
+}
+
+// hasSelfCallMixedAMD64 reports whether fn contains an OpCallMixed
+// back to itself (Phase 6.3.4.m.4c.5). Cross-fn OpCallMixed on AMD64 is
+// not yet admitted, so any non-self OpCallMixed is rejected upstream.
+func hasSelfCallMixedAMD64(fn *vm3.Function, opts Options) bool {
+	if opts.SelfIdx < 0 {
+		return false
+	}
+	for _, op := range fn.Code {
+		if op.Code != vm3.OpCallMixed {
+			continue
+		}
+		if int(uint16(op.C)) == opts.SelfIdx {
+			return true
+		}
+	}
+	return false
+}
+
+// selfDeoptCalleeAMD64 reports whether a self-recursive OpCallMixed
+// site needs the post-CALL status-word check + jne-to-passthrough.
+// True iff fn itself has any deopt-capable opcode (mirrors the ARM64
+// crossFnDeoptCallee gate for self-recursion; the callee here is fn).
+func selfDeoptCalleeAMD64(fn *vm3.Function) bool {
+	return hasRegRegDivModAMD64(fn) || hasNewPair(fn)
+}
+
+// needsPassthroughAMD64 reports whether fn must emit the shared
+// passthrough deopt block at the end of its code stream. Currently
+// triggered only by self-recursive OpCallMixed sites in cell-bank fns
+// whose body can deopt (binary_trees make_tree raises StatusPairGrow
+// from inline OpNewPair).
+func needsPassthroughAMD64(fn *vm3.Function, opts Options) bool {
+	if !hasSelfCallMixedAMD64(fn, opts) {
+		return false
+	}
+	return selfDeoptCalleeAMD64(fn)
+}
+
+// passthroughBlockBytesAMD64 mirrors passthroughBlockWordsARM64. The
+// block is the bare epilogue (no `movq $status, (%r15)` write since
+// the callee already wrote the status before propagating).
+func passthroughBlockBytesAMD64(fn *vm3.Function, opts Options) int {
+	if !needsPassthroughAMD64(fn, opts) {
+		return 0
+	}
+	return epilogueBytesAMD64(fn)
+}
+
+// passthroughStartAMD64 returns the byte offset of the passthrough
+// deopt block, given the first per-status deopt block start. Lives
+// after the per-status blocks.
+func passthroughStartAMD64(fn *vm3.Function, deoptStart int) int {
+	return deoptStart + deoptBlockBytesAMD64(fn)
+}
+
+// emitPassthroughBlockAMD64 emits the shared passthrough deopt block:
+// just the epilogue (which restores the caller's regs and RETs with
+// RAX carrying whatever the inner deopt left in it). The status word
+// is left untouched so jitCall sees the callee's status code.
+func emitPassthroughBlockAMD64(fn *vm3.Function) []byte {
+	return emitEpilogueAMD64(nil, fn)
 }
 
 // hasRegRegDivModAMD64 mirrors hasRegRegDivMod.
@@ -207,12 +273,25 @@ func computeCallSpillsAMD64(fn *vm3.Function) []uint32 {
 		}
 	}
 	for i, op := range fn.Code {
-		if op.Code != vm3.OpCallI64 {
-			continue
+		switch op.Code {
+		case vm3.OpCallI64:
+			mask := uint32(0x3F) // caller-saved slots 0..5
+			dstBit := uint32(1) << op.A
+			spills[i] = (liveOut[i] &^ dstBit) & mask
+		case vm3.OpCallMixed:
+			// Phase 6.3.4.m.4c.5: self-recursive OpCallMixed spills the
+			// same caller-saved slot 0..5 set as OpCallI64. Excluded only
+			// when the result lands back in slot A and the bank is I64;
+			// for BankCell results the destination is a regsCell slot, so
+			// no i64 bit is reused, and all live caller-saved slots are
+			// spilled.
+			mask := uint32(0x3F)
+			live := liveOut[i] & mask
+			if vm3.Bank(op.BankFlags&0x3) == vm3.BankI64 {
+				live &^= uint32(1) << op.A
+			}
+			spills[i] = live
 		}
-		mask := uint32(0x3F) // caller-saved slots 0..5
-		dstBit := uint32(1) << op.A
-		spills[i] = (liveOut[i] &^ dstBit) & mask
 	}
 	return spills
 }
@@ -248,7 +327,8 @@ func lowerAMD64(fn *vm3.Function, opts Options) ([]byte, error) {
 		pcMap[i+1] = pcMap[i] + n
 	}
 	deoptStart := pcMap[len(fn.Code)]
-	total := deoptStart + deoptBlockBytesAMD64(fn)
+	passthroughBytes := passthroughBlockBytesAMD64(fn, opts)
+	total := deoptStart + deoptBlockBytesAMD64(fn) + passthroughBytes
 
 	buf := make([]byte, 0, total)
 	buf = emitPrologueAMD64(buf, fn)
@@ -269,6 +349,9 @@ func lowerAMD64(fn *vm3.Function, opts Options) ([]byte, error) {
 	}
 	for _, status := range deoptStatusesUsedAMD64(fn) {
 		buf = append(buf, emitDeoptBlockAMD64(fn, status)...)
+	}
+	if passthroughBytes > 0 {
+		buf = append(buf, emitPassthroughBlockAMD64(fn)...)
 	}
 	if len(buf) != total {
 		return nil, fmt.Errorf("vm3jit/%s: final stream %d bytes, predicted %d",
@@ -723,6 +806,54 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		// call rel32 (5); mov %rax, xA (3).
 		// Each spill reload: mov disp32(%rbx), xS = 7 bytes.
 		return 7*nSpill + 7*nArgs + 7 + 3 + 5 + 3 + 7*nSpill, nil
+	case vm3.OpCallMixed:
+		// Phase 6.3.4.m.4c.5: AMD64 self-recursive OpCallMixed. Only the
+		// self-call shape is admitted; cross-fn lowers in a later sub-
+		// phase. Sequence:
+		//   spill caller-saved i64 slots (7B each)
+		//   write i64 args   (7B each)
+		//   write cell args  (14B each: load via %rdx, store back)
+		//   lea callerI64*8(%rbx), %rdi   (7B; 3B mov if callerI64=0)
+		//   mov %r15, %rsi                (3B)
+		//   lea callerCell*8(%rbp), %rcx  (7B; 3B mov if callerCell=0)
+		//   mov %r14, %r8                 (3B)
+		//   call rel32                    (5B)
+		//   reload spills                 (7B each)
+		//   optional deopt check: cmpq $0,(%r15) (4B) + jne rel32 (6B)
+		//   store result: mov %rax, xA (3B i64) or mov %rax, disp32(%rbp) (7B cell)
+		if opts.SelfIdx < 0 || int(uint16(op.C)) != opts.SelfIdx {
+			return 0, fmt.Errorf("%w: CallMixed to non-self idx %d (SelfIdx=%d); AMD64 cross-fn cell-bank not yet admitted",
+				ErrNotImplemented, uint16(op.C), opts.SelfIdx)
+		}
+		nSpill := popcount32(spillSets[idx])
+		callerI64 := int(fn.NumRegsI64)
+		callerCell := int(fn.NumRegsCell)
+		nI64Args, _, nCellArgs := countParamBanks(fn)
+		if _, nF64Args, _ := countParamBanks(fn); nF64Args != 0 {
+			return 0, fmt.Errorf("%w: CallMixed with f64 args (AMD64 cell-bank rejects f64)",
+				ErrNotImplemented)
+		}
+		argBytes := 7*nI64Args + 14*nCellArgs
+		baseI64Bytes := 7
+		if callerI64 == 0 {
+			baseI64Bytes = 3
+		}
+		baseCellBytes := 7
+		if callerCell == 0 {
+			baseCellBytes = 3
+		}
+		// ABI setup: RDI = i64 base, RSI = status (mov %r15,%rsi 3B),
+		// RCX = cell base, R8 = arena ctx (mov %r14,%r8 3B).
+		abiBytes := baseI64Bytes + 3 + baseCellBytes + 3
+		deoptBytes := 0
+		if selfDeoptCalleeAMD64(fn) {
+			deoptBytes = 4 + 6 // cmpq $0,(%r15) + jne rel32
+		}
+		resultBytes := 3 // mov %rax, xA (BankI64)
+		if vm3.Bank(op.BankFlags&0x3) == vm3.BankCell {
+			resultBytes = 7 // mov %rax, disp32(%rbp)
+		}
+		return 7*nSpill + argBytes + abiBytes + 5 + 7*nSpill + deoptBytes + resultBytes, nil
 	default:
 		return 0, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
 	}
@@ -1102,6 +1233,97 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 			}
 		}
 		return out, nil
+	case vm3.OpCallMixed:
+		// Phase 6.3.4.m.4c.5: self-recursive OpCallMixed on AMD64
+		// cell-bank. Mirrors the AArch64 lowering's contract: write i64
+		// args into the i64 window via RBX-relative stores, cell args
+		// into the cell window via RBP-relative stores (load-through-
+		// RDX two-step since AMD64 has no mem-to-mem move). Then set
+		// up the SysV ABI for the recursive CALL (RDI = callee regsI64
+		// base, RSI = status, RCX = callee regsCell base, R8 = arena
+		// ctx) and CALL rel32 to the prologue at offset 0. After the
+		// CALL, optionally propagate the callee's status code via
+		// cmpq $0,(%r15) + jne passthrough, then route the result.
+		if opts.SelfIdx < 0 || int(uint16(op.C)) != opts.SelfIdx {
+			return nil, fmt.Errorf("%w: CallMixed to non-self idx %d (SelfIdx=%d)",
+				ErrNotImplemented, uint16(op.C), opts.SelfIdx)
+		}
+		spillMask := spillSets[idx]
+		callerI64 := int(fn.NumRegsI64)
+		callerCell := int(fn.NumRegsCell)
+		out := make([]byte, 0, 96)
+		// Spill live caller-saved i64 slots.
+		for r := uint16(0); r < 6; r++ {
+			if spillMask&(1<<r) != 0 {
+				out = append(out, mov64StoreDisp32(r2xAMD64(r), xRBX, int32(r)*8)...)
+			}
+		}
+		// Write args bank-by-bank. argReg = op.B + k follows the
+		// ARM64 convention (slot indices are shared across banks; the
+		// bank-specific reg in the caller is r2x*(argReg)).
+		for k, b := range fn.ParamBanks {
+			argReg := op.B + uint16(k)
+			switch b {
+			case vm3.BankI64:
+				src := r2xAMD64(argReg)
+				out = append(out, mov64StoreDisp32(src, xRBX, int32(callerI64+k)*8)...)
+			case vm3.BankCell:
+				// Cell args live at [%rbp + argReg*8]; load via RDX
+				// (caller-saved scratch) and store to the callee
+				// window at [%rbp + (callerCell+k)*8].
+				out = append(out, mov64LoadDisp32(xRDX, xRBP, int32(argReg)*8)...)
+				out = append(out, mov64StoreDisp32(xRDX, xRBP, int32(callerCell+k)*8)...)
+			default:
+				return nil, fmt.Errorf("%w: CallMixed param bank %d not supported on AMD64",
+					ErrNotImplemented, b)
+			}
+		}
+		// SysV ABI setup for the recursive callee.
+		if callerI64 == 0 {
+			out = append(out, mov64RR(xRBX, xRDI)...)
+		} else {
+			out = append(out, lea64Disp32(xRDI, xRBX, int32(callerI64)*8)...)
+		}
+		out = append(out, mov64RR(xR15, xRSI)...)
+		if callerCell == 0 {
+			out = append(out, mov64RR(xRBP, xRCX)...)
+		} else {
+			out = append(out, lea64Disp32(xRCX, xRBP, int32(callerCell)*8)...)
+		}
+		out = append(out, mov64RR(xR14, xR8)...)
+		// CALL rel32 to entry (byte 0).
+		callSite := pcMap[idx] + len(out) + 5
+		rel := int32(0 - callSite)
+		out = append(out, callRel32(rel)...)
+		// Reload spilled slots. The result still sits in RAX which is
+		// outside r2xAMD64's range, so spill reloads don't clobber it.
+		for r := uint16(0); r < 6; r++ {
+			if spillMask&(1<<r) != 0 {
+				out = append(out, mov64LoadDisp32(r2xAMD64(r), xRBX, int32(r)*8)...)
+			}
+		}
+		// Optional deopt propagation. If the callee (= fn, self) can
+		// deopt, the callee's deopt block writes a non-zero status to
+		// (%r15) before returning. We do a memory-form cmp (no scratch
+		// reg clobber) and JNE into the shared passthrough block.
+		if selfDeoptCalleeAMD64(fn) {
+			out = append(out, cmpMemImm8R15Indirect(0)...)
+			ptStart := passthroughStartAMD64(fn, deoptStart)
+			afterJNE := pcMap[idx] + len(out) + 6
+			out = append(out, jccRel32(ccNZ, int32(ptStart-afterJNE))...)
+		}
+		// Route the result. BankI64 → mov %rax, xA. BankCell → store
+		// %rax into regsCell[op.A] at [%rbp + op.A*8].
+		switch vm3.Bank(op.BankFlags & 0x3) {
+		case vm3.BankCell:
+			out = append(out, mov64StoreDisp32(xRAX, xRBP, int32(op.A)*8)...)
+		case vm3.BankI64:
+			out = append(out, mov64RR(xRAX, xA)...)
+		default:
+			return nil, fmt.Errorf("%w: CallMixed result bank %d not supported on AMD64",
+				ErrNotImplemented, op.BankFlags&0x3)
+		}
+		return out, nil
 	default:
 		return nil, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
 	}
@@ -1462,6 +1684,15 @@ func movMemImm32R15Indirect(imm int32) []byte {
 	out := []byte{0x49, 0xC7, modRM(0, 0, 7)}
 	out = appendImm32(out, imm)
 	return out
+}
+
+// cmpMemImm8R15Indirect emits `cmpq $imm8, (%r15)` (sign-extended).
+// Opcode REX.W|REX.B 83 /7 ModR/M(mod=00, reg=7, rm=111) imm8. Used by
+// self-recursive OpCallMixed (Phase 6.3.4.m.4c.5) to test the callee's
+// status word without clobbering RAX (which carries the call result).
+// 4 bytes total.
+func cmpMemImm8R15Indirect(imm int8) []byte {
+	return []byte{0x49, 0x83, modRM(0, 7, 7), byte(imm)}
 }
 
 // movRImm32SignExt emits `mov rDst, imm32` (sign-extended to 64-bit).

--- a/runtime/jit/vm3jit/lower_arm64.go
+++ b/runtime/jit/vm3jit/lower_arm64.go
@@ -956,23 +956,6 @@ func resolveCallMixedCallee(fn *vm3.Function, opts Options, op vm3.Op) (*vm3.Fun
 	return callee, false, err
 }
 
-// countParamBanks returns the per-bank arg counts for callee.ParamBanks.
-// Used by crossFnCallMixedWordsARM64 to size the BLR sequence's arg STR
-// runs.
-func countParamBanks(callee *vm3.Function) (nI64, nF64, nCell int) {
-	for _, b := range callee.ParamBanks {
-		switch b {
-		case vm3.BankI64:
-			nI64++
-		case vm3.BankF64:
-			nF64++
-		case vm3.BankCell:
-			nCell++
-		}
-	}
-	return
-}
-
 // crossFnCallMixedWordsARM64 returns the word count for the BLR
 // sequence at a cross-fn OpCallMixed site. The sequence is:
 //

--- a/runtime/jit/vm3jit/lower_common.go
+++ b/runtime/jit/vm3jit/lower_common.go
@@ -2,6 +2,23 @@ package vm3jit
 
 import "mochi/runtime/vm3"
 
+// countParamBanks returns the per-bank arg counts for callee.ParamBanks.
+// Used by OpCallMixed lowering on both ARM64 and AMD64 to size the
+// caller-side arg-store run.
+func countParamBanks(callee *vm3.Function) (nI64, nF64, nCell int) {
+	for _, b := range callee.ParamBanks {
+		switch b {
+		case vm3.BankI64:
+			nI64++
+		case vm3.BankF64:
+			nF64++
+		case vm3.BankCell:
+			nCell++
+		}
+	}
+	return
+}
+
 // Status codes the JIT writes through *(status word ptr) on a deopt
 // path. Caller checks this word after a trampoline.CallStatus return
 // and routes to the corresponding vm3 error if non-zero.

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2758,6 +2758,38 @@ mov  %rax, pairsLenOff(%r14)       ; 7B  commit pairsLen
 
 **Closure verdict.** m.4c.4 lands the inline pair allocator on AMD64 cell-bank fns. Together with m.4c.1..m.4c.3 this covers the entry path, return path, pair reads, and pair allocation; m.4c.5..m.4c.6 add self-recursion and the bench close to flip binary_trees inside 2x of Go on linux/amd64.
 
+#### Phase 6.3.4.m.4c.5: AMD64 self-recursive OpCallMixed (2026-05-20 07:19 GMT+7)
+
+**Why this exists.** With m.4c.1..m.4c.4 covering the AMD64 cell-bank entry path, return path, read-only pair access, and inline pair allocation, the remaining opcode the binary_trees inner loop needs before the m.4c.6 admission gate is the self-recursive `OpCallMixed`. The ARM64 backend has had self-OpCallMixed since m.3 (check_tree) and m.4 (make_tree); landing the AMD64 mirror lets `check_tree` and `make_tree` recurse without paying a per-call interp transition on linux/amd64.
+
+**Implementation.** `byteCountAMD64` and `emitInstrAMD64` add an `OpCallMixed` case gated on `op.C == opts.SelfIdx` (cross-fn OpCallMixed remains rejected by admission for now and is tracked under the broader m.4c.6 admission widening). The emit sequence mirrors the ARM64 m.3 layout but uses the SysV AMD64 ABI:
+
+1. **Spill live caller-saved i64 slots.** For each i64 register `r` in `0..5` that is in the live-out set at this op (the lowest 6 slot indices map to RSI, RDI, R8, R9, R10, R11 — all caller-saved), `mov r2xAMD64(r), [rbx + r*8]`. The dataflow walker (`computeCallSpillsAMD64`) excludes the return slot `A` when the result bank is I64 to avoid spilling-then-reloading the same slot the callee will overwrite.
+2. **Write args to callee windows.** For each `ParamBank[k]` of the (self-)callee:
+   - BankI64: `mov r2xAMD64(B+k), [rbx + (NumRegsI64+k)*8]`.
+   - BankCell: `mov [rbp + (B+k)*8], rdx; mov rdx, [rbp + (NumRegsCell+k)*8]` (cell-bank args are read from regsCell at slot `B+k` and written to the callee's slot just past the caller's window).
+3. **Set up SysV ABI for CallStatusM.** `lea rdi, [rbx + NumRegsI64*8]` (callee i64 base), `mov rsi, r15` (status pointer pinned across the call), `lea rcx, [rbp + NumRegsCell*8]` (callee cell base), `mov r8, r14` (arenaCtx).
+4. **Direct CALL rel32 to byte 0.** Encoded as `e8 rel32` with `rel = -(pcMap[idx] + emit_offset + 5)`. The fall-through after the CALL is the deopt-passthrough check (when the callee's status word is non-zero, jump to the per-status passthrough block).
+5. **Reload spills.** Mirror step 1's spill set with `mov [rbx + r*8], r2xAMD64(r)`.
+6. **Move the return value to the destination slot.** For BankI64: `mov rax, r2xAMD64(A)`. For BankCell: `mov rax, [rbp + A*8]`. The trampoline (`CallStatusM`) carries the return value through Go's `uint64` channel for both i64 and cell bits.
+
+**Admission.** `checkCellBankAdmissibleAMD64` extends its whitelist from `m.4c.1..m.4c.4` to add `OpCallMixed` only when `op.C == opts.SelfIdx`. Cross-fn `OpCallMixed` on amd64 cell-bank remains rejected and is folded into m.4c.6's admission widening together with the binary_trees outer driver. The error message advances to "AMD64 cell-bank scaffold m.4c.1..m.4c.5 only; m.4c.6 adds cross-fn OpCallMixed".
+
+**Liveness over OpCallMixed.** `defUseI64` already treats `OpCallMixed` as defining only `op.A` (when ResultBank == BankI64) and using up to 8 contiguous slots starting at `op.B`. The same set is used by `computeCallSpillsAMD64` to decide which of the lowest 6 i64 slots need spill/reload across the recursive CALL. Cell slots are pinned via RBP — they survive the CALL as memory, so no explicit spill is needed on the AMD64 cell-bank path.
+
+**Tests.**
+- `TestSelfCallMixedI64ReturnAMD64`: helper(t Cell, d i64) -> i64 that traverses a 2-level pair on each recursive step and returns `1 + (leaf=1) = 2` at depth=1. Asserts admission, zero-deopt, and the returned i64 unpacks to 2 via `Cell.Int()`.
+- `TestSelfCallMixedCellReturnAMD64`: make_tree-shape helper(d i64) -> Cell that recursively allocates a balanced pair tree at d=2 (3 inner nodes + 4 leaves). Asserts admission and that the returned Cell is a valid ArenaPair handle.
+- All m.4c.1..m.4c.4 tests continue to pass on linux/amd64; the m.4c.5 admission widening does not break the byte-count of any prior path.
+
+**Verification.**
+- darwin/arm64 (M-series, Go tip): full `runtime/jit/vm3jit` suite green.
+- linux/amd64 (server2, EPYC, Go 1.26.0): `TestSelfCallMixedI64ReturnAMD64` + `TestSelfCallMixedCellReturnAMD64` pass, plus all m.4c.1..m.4c.4 cell-bank tests. (Pre-existing `TestNsieveJITCompiles` failure on linux/amd64 is unchanged and remains tracked under the broader amd64 cell-bank entry-path parity for list/map kernels.)
+
+**Composite gate effect.** No BG row flips yet, opcode addition only. binary_trees on linux/amd64 stays at the m.4b interp-routed baseline (3.80x at n=10, 4.63x at n=12); m.4c.6 (drop the amd64 cell-bank rejection in `checkCellBankAdmissible` + cross-fn `OpCallMixed` for the binary_trees outer driver + bench on server2) is the closure step.
+
+**Closure verdict.** m.4c.5 lands the AMD64 self-recursive `OpCallMixed` for cell-bank fns. The make_tree/check_tree recursive cores now JIT-compile end-to-end on linux/amd64 once admission widens; m.4c.6 wires admission and benches binary_trees on server2 against the m.4b interp-floor baseline.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
## Summary
- Land AMD64 cell-bank lowering of self-recursive `OpCallMixed` (mirrors ARM64 m.3). Spill caller-saved i64 slots, write args via SysV ABI, `CALL rel32` to byte 0, reload, copy result.
- Admit self `OpCallMixed` in `checkCellBankAdmissibleAMD64` (only when `op.C == opts.SelfIdx`); cross-fn stays rejected until m.4c.6.
- Add `TestSelfCallMixedI64ReturnAMD64` and `TestSelfCallMixedCellReturnAMD64` covering both result banks with zero-deopt asserts.
- Spec append: §6.3.4.m.4c.5 with implementation walkthrough, admission rule, tests, and verification on darwin/arm64 + linux/amd64.

Closes #21830. Part of #208.

## Test plan
- [x] darwin/arm64: full `runtime/jit/vm3jit` suite green.
- [x] linux/amd64 (server2): `TestSelfCallMixedI64ReturnAMD64` + `TestSelfCallMixedCellReturnAMD64` pass; m.4c.1..m.4c.4 cell-bank tests still green; pre-existing `TestNsieveJITCompiles` failure is unchanged (tracked separately).