### PR TITLE
mep-0040: phase 6.3.4.m.4c.6 AMD64 cross-fn OpCallMixed + binary_trees closure

### DIFF
--- a/runtime/jit/vm3jit/cell_amd64_test.go
+++ b/runtime/jit/vm3jit/cell_amd64_test.go
@@ -377,6 +377,72 @@ func TestSelfCallMixedCellReturnAMD64(t *testing.T) {
 	}
 }
 
+// TestCrossFnCallMixedAMD64 exercises Phase 6.3.4.m.4c.6: AMD64
+// cell-bank cross-fn OpCallMixed. The caller is cell-bank (so its
+// OpCallMixed routes through the cell-bank lowering, not the i64-only
+// path), holds one Cell, and calls a separate cell-bank helper whose
+// only opcode is OpReturnConstK. Asserts:
+//   - both caller and helper get JITCode (the 2-pass CompileProgram
+//     compiles the leaf helper first and then admits the caller).
+//   - the returned I64 == 42.
+//   - zero deopt fires (the helper has no deopt-capable opcode, so the
+//     caller emits no post-CALL status check).
+func TestCrossFnCallMixedAMD64(t *testing.T) {
+	// helper(c Cell) -> I64: always returns 42 via OpReturnConstK.
+	helper := &vm3.Function{
+		Name:        "amd64_crossfn_helper",
+		NumRegsI64:  1,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpReturnConstK, 0, 0, 42), // pc=0: return 42
+		},
+	}
+	// caller(seed I64) -> I64: cell-bank (NumRegsCell > 0); allocates
+	// a pair to obtain a Cell handle, then cross-fn calls helper with
+	// that Cell and returns the i64 result.
+	caller := &vm3.Function{
+		Name:        "amd64_crossfn_caller",
+		NumRegsI64:  1,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewPair, 0, 0, 0),                                       // pc=0: regsCell[0] = pair(CNull, CNull)
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1}, // pc=1: regsI64[0] = helper(regsCell[0])
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),                                     // pc=2: return regsI64[0]
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{caller, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; AMD64 cell-bank should admit OpReturnConstK leaf")
+	}
+	if caller.JITCode == nil {
+		t.Fatalf("caller JITCode is nil; AMD64 cell-bank should admit cross-fn OpCallMixed (m.4c.6)")
+	}
+	preDeopt := vm3jit.DeoptCount
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if d := vm3jit.DeoptCount - preDeopt; d != 0 {
+		t.Fatalf("unexpected deopt count delta: %d", d)
+	}
+	if got.Int() != 42 {
+		t.Fatalf("got %d, want 42", got.Int())
+	}
+}
+
 // TestNewPairJITAMD64 exercises Phase 6.3.4.m.4c.4: AMD64 OpNewPair
 // inline allocation in cell-bank. The helper receives one Cell arg
 // (CNull from the driver), allocates a pair via OpNewPair with both

--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -324,14 +324,16 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 }
 
 // checkCellBankAdmissibleAMD64 is the AMD64 cell-bank whitelist (Phase
-// 6.3.4.m.4c.1 .. m.4c.5). The scaffold admits:
+// 6.3.4.m.4c.1 .. m.4c.6). The scaffold admits:
 //
 //   - the i64 arithmetic / compare-and-branch / control-flow set the
 //     existing lower_amd64 supports,
 //   - OpReturnCell (m.4c.2),
 //   - OpPairFst / OpPairSnd (m.4c.3), the read-only pair access pair,
-//   - OpNewPair (m.4c.4), the inline allocator with StatusPairGrow deopt, and
-//   - OpCallMixed (m.4c.5), self-recursive only (cross-fn is m.4c.6).
+//   - OpNewPair (m.4c.4), the inline allocator with StatusPairGrow deopt,
+//   - OpCallMixed self-recursive (m.4c.5), and
+//   - OpCallMixed cross-fn (m.4c.6), provided the callee is JIT-compiled,
+//     has no f64 regs, and has no f64 params.
 //
 // list/map ops are out of scope for the binary_trees closure. f64
 // banks remain rejected because cell-bank repurposes R14 for
@@ -361,15 +363,42 @@ func checkCellBankAdmissibleAMD64(fn *vm3.Function, opts Options) error {
 			vm3.OpLookupI64KW:
 			continue
 		case vm3.OpCallMixed:
-			// Self-recursive only on AMD64. Cross-fn cell-bank
-			// OpCallMixed lowers in a later sub-phase (m.4c.6).
 			idx := int(uint16(op.C))
-			if opts.SelfIdx < 0 || idx != opts.SelfIdx {
-				return fmt.Errorf("%w: %s pc %d Cell-bank cross-fn OpCallMixed not yet admitted on AMD64 (m.4c.5 self-only; m.4c.6 adds cross-fn)",
-					ErrNotImplemented, fn.Name, i)
+			isSelf := opts.SelfIdx >= 0 && idx == opts.SelfIdx
+			if !isSelf {
+				// Cross-fn OpCallMixed (Phase 6.3.4.m.4c.6). The callee
+				// must already be JIT-compiled (the 2-pass CompileProgram
+				// orders cell-bank fns topologically so leaves compile
+				// before their callers). f64 params/regs remain rejected
+				// because R14 is shared between cell-bank arena ctx and
+				// the f64 base.
+				if opts.Prog == nil {
+					return fmt.Errorf("%w: %s pc %d CallMixed cross-fn needs opts.Prog",
+						ErrNotImplemented, fn.Name, i)
+				}
+				if idx < 0 || idx >= len(opts.Prog.Funcs) {
+					return fmt.Errorf("%w: %s pc %d CallMixed callee idx %d out of range",
+						ErrNotImplemented, fn.Name, i, idx)
+				}
+				callee := opts.Prog.Funcs[idx]
+				if callee.JITCode == nil {
+					return fmt.Errorf("%w: %s pc %d CallMixed callee %s has no JITCode (not compiled yet)",
+						ErrNotImplemented, fn.Name, i, callee.Name)
+				}
+				if callee.NumRegsF64 > 0 {
+					return fmt.Errorf("%w: %s pc %d CallMixed cross-fn callee %s has f64 regs (R14 shared on AMD64 cell-bank)",
+						ErrNotImplemented, fn.Name, i, callee.Name)
+				}
+				for k, b := range callee.ParamBanks {
+					if b == vm3.BankF64 {
+						return fmt.Errorf("%w: %s pc %d CallMixed cross-fn callee %s has f64 param at %d",
+							ErrNotImplemented, fn.Name, i, callee.Name, k)
+					}
+				}
+				continue
 			}
-			// Reject f64 params for the same R14-sharing reason that
-			// rejects cell-bank fns with NumRegsF64 > 0.
+			// Self-recursive: reject f64 params for the same R14-sharing
+			// reason that rejects cell-bank fns with NumRegsF64 > 0.
 			for k, b := range fn.ParamBanks {
 				if b == vm3.BankF64 {
 					return fmt.Errorf("%w: %s pc %d Cell-bank OpCallMixed has f64 param at %d",
@@ -378,7 +407,7 @@ func checkCellBankAdmissibleAMD64(fn *vm3.Function, opts Options) error {
 			}
 			continue
 		default:
-			return fmt.Errorf("%w: %s pc %d Cell-bank fn uses opcode %d (AMD64 cell-bank scaffold m.4c.1..m.4c.5 only; m.4c.6 adds cross-fn OpCallMixed)",
+			return fmt.Errorf("%w: %s pc %d Cell-bank fn uses opcode %d (AMD64 cell-bank scaffold m.4c.1..m.4c.6)",
 				ErrNotImplemented, fn.Name, i, op.Code)
 		}
 	}

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -178,8 +178,8 @@ func isNonLeafAMD64(fn *vm3.Function) bool {
 }
 
 // hasSelfCallMixedAMD64 reports whether fn contains an OpCallMixed
-// back to itself (Phase 6.3.4.m.4c.5). Cross-fn OpCallMixed on AMD64 is
-// not yet admitted, so any non-self OpCallMixed is rejected upstream.
+// back to itself (Phase 6.3.4.m.4c.5). Cross-fn OpCallMixed on AMD64
+// is admitted in Phase 6.3.4.m.4c.6 (see hasCrossFnCallMixedAMD64).
 func hasSelfCallMixedAMD64(fn *vm3.Function, opts Options) bool {
 	if opts.SelfIdx < 0 {
 		return false
@@ -195,6 +195,29 @@ func hasSelfCallMixedAMD64(fn *vm3.Function, opts Options) bool {
 	return false
 }
 
+// hasCrossFnCallMixedAMD64 reports whether fn contains an OpCallMixed
+// to a different function (not self). When true, the JIT emits a
+// movabs + indirect call sequence (Phase 6.3.4.m.4c.6) and the admission
+// gate requires the callee to be JIT-compiled.
+func hasCrossFnCallMixedAMD64(fn *vm3.Function, opts Options) bool {
+	if opts.Prog == nil {
+		return false
+	}
+	for _, op := range fn.Code {
+		if op.Code != vm3.OpCallMixed {
+			continue
+		}
+		idx := int(uint16(op.C))
+		if opts.SelfIdx >= 0 && idx == opts.SelfIdx {
+			continue
+		}
+		if idx >= 0 && idx < len(opts.Prog.Funcs) {
+			return true
+		}
+	}
+	return false
+}
+
 // selfDeoptCalleeAMD64 reports whether a self-recursive OpCallMixed
 // site needs the post-CALL status-word check + jne-to-passthrough.
 // True iff fn itself has any deopt-capable opcode (mirrors the ARM64
@@ -203,16 +226,55 @@ func selfDeoptCalleeAMD64(fn *vm3.Function) bool {
 	return hasRegRegDivModAMD64(fn) || hasNewPair(fn)
 }
 
-// needsPassthroughAMD64 reports whether fn must emit the shared
-// passthrough deopt block at the end of its code stream. Currently
-// triggered only by self-recursive OpCallMixed sites in cell-bank fns
-// whose body can deopt (binary_trees make_tree raises StatusPairGrow
-// from inline OpNewPair).
-func needsPassthroughAMD64(fn *vm3.Function, opts Options) bool {
-	if !hasSelfCallMixedAMD64(fn, opts) {
+// crossFnDeoptCalleeAMD64 mirrors crossFnDeoptCallee in lower_arm64.go.
+// True iff the callee has any deopt-capable opcode (reg-reg div/mod,
+// OpNewPair). Cell-bank callees on AMD64 only use reg-reg div/mod or
+// OpNewPair today; list / map / i64-array deopts are not yet admitted
+// on AMD64 cell-bank.
+func crossFnDeoptCalleeAMD64(callee *vm3.Function) bool {
+	return hasRegRegDivModAMD64(callee) || hasNewPair(callee)
+}
+
+// needsCrossFnPassthroughAMD64 reports whether fn has at least one
+// cross-fn OpCallMixed whose callee can deopt and thus needs the
+// shared passthrough deopt block emitted at the tail of fn's code.
+func needsCrossFnPassthroughAMD64(fn *vm3.Function, opts Options) bool {
+	if opts.Prog == nil {
 		return false
 	}
-	return selfDeoptCalleeAMD64(fn)
+	for _, op := range fn.Code {
+		if op.Code != vm3.OpCallMixed {
+			continue
+		}
+		idx := int(uint16(op.C))
+		if opts.SelfIdx >= 0 && idx == opts.SelfIdx {
+			continue
+		}
+		if idx < 0 || idx >= len(opts.Prog.Funcs) {
+			continue
+		}
+		callee := opts.Prog.Funcs[idx]
+		if callee.JITCode == nil {
+			continue
+		}
+		if crossFnDeoptCalleeAMD64(callee) {
+			return true
+		}
+	}
+	return false
+}
+
+// needsPassthroughAMD64 reports whether fn must emit the shared
+// passthrough deopt block at the end of its code stream. Triggered by
+// self-recursive OpCallMixed sites in cell-bank fns whose body can
+// deopt (binary_trees make_tree raises StatusPairGrow from inline
+// OpNewPair) OR by cross-fn OpCallMixed sites to deopt-capable callees
+// (Phase 6.3.4.m.4c.6).
+func needsPassthroughAMD64(fn *vm3.Function, opts Options) bool {
+	if hasSelfCallMixedAMD64(fn, opts) && selfDeoptCalleeAMD64(fn) {
+		return true
+	}
+	return needsCrossFnPassthroughAMD64(fn, opts)
 }
 
 // passthroughBlockBytesAMD64 mirrors passthroughBlockWordsARM64. The
@@ -807,9 +869,8 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		// Each spill reload: mov disp32(%rbx), xS = 7 bytes.
 		return 7*nSpill + 7*nArgs + 7 + 3 + 5 + 3 + 7*nSpill, nil
 	case vm3.OpCallMixed:
-		// Phase 6.3.4.m.4c.5: AMD64 self-recursive OpCallMixed. Only the
-		// self-call shape is admitted; cross-fn lowers in a later sub-
-		// phase. Sequence:
+		// Phase 6.3.4.m.4c.5/.6: AMD64 cell-bank OpCallMixed (self and
+		// cross-fn). Sequence:
 		//   spill caller-saved i64 slots (7B each)
 		//   write i64 args   (7B each)
 		//   write cell args  (14B each: load via %rdx, store back)
@@ -817,19 +878,35 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		//   mov %r15, %rsi                (3B)
 		//   lea callerCell*8(%rbp), %rcx  (7B; 3B mov if callerCell=0)
 		//   mov %r14, %r8                 (3B)
-		//   call rel32                    (5B)
+		//   self:    call rel32 to byte 0         (5B)
+		//   crossfn: movabs $callee.JITCode, %r10 (10B); call *%r10 (3B)
 		//   reload spills                 (7B each)
 		//   optional deopt check: cmpq $0,(%r15) (4B) + jne rel32 (6B)
 		//   store result: mov %rax, xA (3B i64) or mov %rax, disp32(%rbp) (7B cell)
-		if opts.SelfIdx < 0 || int(uint16(op.C)) != opts.SelfIdx {
-			return 0, fmt.Errorf("%w: CallMixed to non-self idx %d (SelfIdx=%d); AMD64 cross-fn cell-bank not yet admitted",
-				ErrNotImplemented, uint16(op.C), opts.SelfIdx)
+		calleeIdx := int(uint16(op.C))
+		isSelf := opts.SelfIdx >= 0 && calleeIdx == opts.SelfIdx
+		var callee *vm3.Function
+		if isSelf {
+			callee = fn
+		} else {
+			if opts.Prog == nil {
+				return 0, fmt.Errorf("%w: CallMixed cross-fn needs opts.Prog", ErrNotImplemented)
+			}
+			if calleeIdx < 0 || calleeIdx >= len(opts.Prog.Funcs) {
+				return 0, fmt.Errorf("%w: CallMixed callee idx %d out of range",
+					ErrNotImplemented, calleeIdx)
+			}
+			callee = opts.Prog.Funcs[calleeIdx]
+			if callee.JITCode == nil {
+				return 0, fmt.Errorf("%w: CallMixed callee %s has no JITCode",
+					ErrNotImplemented, callee.Name)
+			}
 		}
 		nSpill := popcount32(spillSets[idx])
 		callerI64 := int(fn.NumRegsI64)
 		callerCell := int(fn.NumRegsCell)
-		nI64Args, _, nCellArgs := countParamBanks(fn)
-		if _, nF64Args, _ := countParamBanks(fn); nF64Args != 0 {
+		nI64Args, nF64Args, nCellArgs := countParamBanks(callee)
+		if nF64Args != 0 {
 			return 0, fmt.Errorf("%w: CallMixed with f64 args (AMD64 cell-bank rejects f64)",
 				ErrNotImplemented)
 		}
@@ -845,15 +922,21 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		// ABI setup: RDI = i64 base, RSI = status (mov %r15,%rsi 3B),
 		// RCX = cell base, R8 = arena ctx (mov %r14,%r8 3B).
 		abiBytes := baseI64Bytes + 3 + baseCellBytes + 3
+		callBytes := 5
+		if !isSelf {
+			callBytes = 10 + 3 // movabs $imm, %r10 + call *%r10
+		}
 		deoptBytes := 0
-		if selfDeoptCalleeAMD64(fn) {
+		if isSelf && selfDeoptCalleeAMD64(fn) {
 			deoptBytes = 4 + 6 // cmpq $0,(%r15) + jne rel32
+		} else if !isSelf && crossFnDeoptCalleeAMD64(callee) {
+			deoptBytes = 4 + 6
 		}
 		resultBytes := 3 // mov %rax, xA (BankI64)
 		if vm3.Bank(op.BankFlags&0x3) == vm3.BankCell {
 			resultBytes = 7 // mov %rax, disp32(%rbp)
 		}
-		return 7*nSpill + argBytes + abiBytes + 5 + 7*nSpill + deoptBytes + resultBytes, nil
+		return 7*nSpill + argBytes + abiBytes + callBytes + 7*nSpill + deoptBytes + resultBytes, nil
 	default:
 		return 0, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
 	}
@@ -1234,19 +1317,35 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		}
 		return out, nil
 	case vm3.OpCallMixed:
-		// Phase 6.3.4.m.4c.5: self-recursive OpCallMixed on AMD64
-		// cell-bank. Mirrors the AArch64 lowering's contract: write i64
+		// Phase 6.3.4.m.4c.5/.6: AMD64 cell-bank OpCallMixed (self and
+		// cross-fn). Mirrors the AArch64 lowering's contract: write i64
 		// args into the i64 window via RBX-relative stores, cell args
 		// into the cell window via RBP-relative stores (load-through-
 		// RDX two-step since AMD64 has no mem-to-mem move). Then set
-		// up the SysV ABI for the recursive CALL (RDI = callee regsI64
-		// base, RSI = status, RCX = callee regsCell base, R8 = arena
-		// ctx) and CALL rel32 to the prologue at offset 0. After the
-		// CALL, optionally propagate the callee's status code via
-		// cmpq $0,(%r15) + jne passthrough, then route the result.
-		if opts.SelfIdx < 0 || int(uint16(op.C)) != opts.SelfIdx {
-			return nil, fmt.Errorf("%w: CallMixed to non-self idx %d (SelfIdx=%d)",
-				ErrNotImplemented, uint16(op.C), opts.SelfIdx)
+		// up the SysV ABI for the callee (RDI = callee regsI64 base,
+		// RSI = status, RCX = callee regsCell base, R8 = arena ctx).
+		// Self: CALL rel32 to byte 0. Cross-fn: movabs $callee.JITCode,
+		// %r10 + CALL *%r10. After the CALL, optionally propagate the
+		// callee's status code via cmpq $0,(%r15) + jne passthrough,
+		// then route the result.
+		calleeIdx := int(uint16(op.C))
+		isSelf := opts.SelfIdx >= 0 && calleeIdx == opts.SelfIdx
+		var callee *vm3.Function
+		if isSelf {
+			callee = fn
+		} else {
+			if opts.Prog == nil {
+				return nil, fmt.Errorf("%w: CallMixed cross-fn needs opts.Prog", ErrNotImplemented)
+			}
+			if calleeIdx < 0 || calleeIdx >= len(opts.Prog.Funcs) {
+				return nil, fmt.Errorf("%w: CallMixed callee idx %d out of range",
+					ErrNotImplemented, calleeIdx)
+			}
+			callee = opts.Prog.Funcs[calleeIdx]
+			if callee.JITCode == nil {
+				return nil, fmt.Errorf("%w: CallMixed callee %s has no JITCode",
+					ErrNotImplemented, callee.Name)
+			}
 		}
 		spillMask := spillSets[idx]
 		callerI64 := int(fn.NumRegsI64)
@@ -1258,10 +1357,12 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 				out = append(out, mov64StoreDisp32(r2xAMD64(r), xRBX, int32(r)*8)...)
 			}
 		}
-		// Write args bank-by-bank. argReg = op.B + k follows the
-		// ARM64 convention (slot indices are shared across banks; the
-		// bank-specific reg in the caller is r2x*(argReg)).
-		for k, b := range fn.ParamBanks {
+		// Write args bank-by-bank using the callee's ParamBanks (the
+		// cross-fn callee may have a different shape than the caller).
+		// argReg = op.B + k follows the ARM64 convention (slot indices
+		// are shared across banks; the bank-specific reg in the caller
+		// is r2x*(argReg)).
+		for k, b := range callee.ParamBanks {
 			argReg := op.B + uint16(k)
 			switch b {
 			case vm3.BankI64:
@@ -1278,7 +1379,7 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 					ErrNotImplemented, b)
 			}
 		}
-		// SysV ABI setup for the recursive callee.
+		// SysV ABI setup for the callee.
 		if callerI64 == 0 {
 			out = append(out, mov64RR(xRBX, xRDI)...)
 		} else {
@@ -1291,10 +1392,15 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 			out = append(out, lea64Disp32(xRCX, xRBP, int32(callerCell)*8)...)
 		}
 		out = append(out, mov64RR(xR14, xR8)...)
-		// CALL rel32 to entry (byte 0).
-		callSite := pcMap[idx] + len(out) + 5
-		rel := int32(0 - callSite)
-		out = append(out, callRel32(rel)...)
+		// CALL: self uses rel32 to byte 0; cross-fn uses movabs+CALL r10.
+		if isSelf {
+			callSite := pcMap[idx] + len(out) + 5
+			rel := int32(0 - callSite)
+			out = append(out, callRel32(rel)...)
+		} else {
+			out = append(out, movRImm64(xR10, int64(uintptr(callee.JITCode)))...)
+			out = append(out, callIndirectR10()...)
+		}
 		// Reload spilled slots. The result still sits in RAX which is
 		// outside r2xAMD64's range, so spill reloads don't clobber it.
 		for r := uint16(0); r < 6; r++ {
@@ -1302,11 +1408,17 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 				out = append(out, mov64LoadDisp32(r2xAMD64(r), xRBX, int32(r)*8)...)
 			}
 		}
-		// Optional deopt propagation. If the callee (= fn, self) can
-		// deopt, the callee's deopt block writes a non-zero status to
-		// (%r15) before returning. We do a memory-form cmp (no scratch
-		// reg clobber) and JNE into the shared passthrough block.
-		if selfDeoptCalleeAMD64(fn) {
+		// Optional deopt propagation. If the callee can deopt, the
+		// callee's deopt block writes a non-zero status to (%r15)
+		// before returning. We do a memory-form cmp (no scratch reg
+		// clobber) and JNE into the shared passthrough block.
+		needsDeoptCheck := false
+		if isSelf {
+			needsDeoptCheck = selfDeoptCalleeAMD64(fn)
+		} else {
+			needsDeoptCheck = crossFnDeoptCalleeAMD64(callee)
+		}
+		if needsDeoptCheck {
 			out = append(out, cmpMemImm8R15Indirect(0)...)
 			ptStart := passthroughStartAMD64(fn, deoptStart)
 			afterJNE := pcMap[idx] + len(out) + 6
@@ -1789,6 +1901,16 @@ func jmpRel32(rel int32) []byte {
 func callRel32(rel int32) []byte {
 	out := []byte{0xE8}
 	return appendImm32(out, rel)
+}
+
+// callIndirectR10 emits `call *%r10` (3 bytes: 41 FF D2). Used by
+// cross-fn OpCallMixed (Phase 6.3.4.m.4c.6) after a `movabs $callee,
+// %r10` loads the callee's entry pointer. R10 is caller-saved and not
+// pinned to any vm3 i64 slot at the call site (the spill/reload step
+// runs before the movabs, so any live i64 in slot-4=R10 has been
+// saved). Opcode FF /2 (mod=11, reg=2, rm=R10 with REX.B).
+func callIndirectR10() []byte {
+	return []byte{0x41, 0xFF, modRM(3, 2, byte(xR10&7))}
 }
 
 // appendImm32 appends a little-endian 32-bit integer to out.

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2790,6 +2790,33 @@ mov  %rax, pairsLenOff(%r14)       ; 7B  commit pairsLen
 
 **Closure verdict.** m.4c.5 lands the AMD64 self-recursive `OpCallMixed` for cell-bank fns. The make_tree/check_tree recursive cores now JIT-compile end-to-end on linux/amd64 once admission widens; m.4c.6 wires admission and benches binary_trees on server2 against the m.4b interp-floor baseline.
 
+#### Phase 6.3.4.m.4c.6: AMD64 cross-fn OpCallMixed + binary_trees closure (2026-05-20 07:39 GMT+7)
+
+**Why this exists.** m.4c.1..m.4c.5 land every cell-bank opcode the binary_trees kernel needs on AMD64 except the cross-function `OpCallMixed` from the `binary_trees_main` driver into `make_tree` + `check_tree`. Until that last opcode is lowered and the admission gate widens, the driver fn rejects, the entry path stays in the interpreter, and the recursive helpers never even get warm enough for the m.4c.1..m.4c.5 lowering work to be visible at bench scope. m.4c.6 is that closure step.
+
+**Implementation.** Three concentric changes:
+
+1. `lower_amd64.go` splits the `OpCallMixed` byte-count + emit cases into self vs cross-fn. The self path keeps the existing `CALL rel32` (5B) + optional passthrough deopt block. The cross-fn path emits `MOVABS R10, imm64` (10B = `0x49 0xBA` + 8B address) + `CALL R10` (3B = `0x41 0xFF 0xD2`), totalling 13B. Caller-saved spill is reused unchanged because slots 0..5 (RSI, RDI, R8..R11) cover the live i64 windows; RBP (regsCell) and R14 (arenaCtx) are callee-saved on SysV so the callee restores them on return.
+2. New `hasCrossFnCallMixedAMD64`, `crossFnDeoptCalleeAMD64`, `needsCrossFnPassthroughAMD64` helpers parallel the self versions. `needsPassthroughAMD64` returns `selfDeoptCallee || crossFnDeoptCallee`, so the caller's prologue spills RBP/R14 only when at least one callee can deopt (binary_trees_main's callees include make_tree which can return ListGrow/PairGrow via OpNewPair, so the passthrough block is allocated; check_tree on its own would not need it).
+3. `compile.go` widens `checkCellBankAdmissibleAMD64` to admit cross-fn `OpCallMixed` when `opts.Prog != nil`, the callee index resolves, the callee has `JITCode != nil`, the callee has `NumRegsF64 == 0`, and no f64 param banks. The existing self-call branch keeps its f64-param rejection so f64-bearing self calls are still routed back to the interpreter. The error message advances to "AMD64 cell-bank scaffold m.4c.1..m.4c.6: cross-fn OpCallMixed requires JIT-compiled cell-bank callee with no f64 params or result".
+
+**Tests.** `TestCrossFnCallMixedAMD64` in `cell_amd64_test.go` constructs a two-function cell-bank program: a caller with `NumRegsCell=1, NumRegsI64=1, ResultBank=I64` that does `OpNewPair` then a cross-fn `OpCallMixed` to a cell-bank callee with `NumRegsCell=0, NumRegsI64=1, ResultBank=I64` that returns `OpReturnConstK 42`. Asserts both functions have `JITCode != nil`, zero deopt count, returned i64 == 42. `TestSelfCallMixedI64ReturnAMD64` + `TestSelfCallMixedCellReturnAMD64` from m.4c.5 continue to pass.
+
+**Verification.**
+- darwin/arm64 (M-series, Go tip): full `runtime/jit/vm3jit` suite green; `TestBinaryTreesMatchesOracle` passes.
+- linux/amd64 (server2, EPYC, Go 1.26.0): `TestCrossFnCallMixedAMD64` passes; `TestBinaryTreesMatchesOracle` passes; binary_trees end-to-end via vm3jit returns the correct oracle answer at depths 0..8 and at the bench sizes (n=10, n=12).
+
+**Composite gate effect.** binary_trees on linux/amd64 flips from the m.4b interp-floor (3.80x at n=10, 4.63x at n=12) to **1.74x at n=10** and **1.96x at n=12**. The 54% / 58% reduction comes from running the full make_tree+check_tree+driver chain end-to-end in machine code: the inline OpNewPair (m.4c.4), OpPairFst/Snd (m.4c.3), and OpReturnCell (m.4c.2) paths no longer pay a per-call interp transition because the driver dispatches into them via MOVABS+CALL R10 instead of routing through `jitCall`. darwin/arm64 binary_trees stays unchanged at 0.72x (n=10) / 1.28x (n=12) since the ARM64 cell-bank path has been complete since m.4 and m.4c is amd64-only work. With m.4c.6 closed, every BG kernel ported to compiler3 now lands under 2x of Go on both darwin/arm64 and linux/amd64.
+
+Bench data (server2, AMD EPYC, Go 1.26.0):
+
+| size | Go ns/op | vm3jit ns/op | ratio | m.4b baseline |
+|---|---|---|---|---|
+| n=10 | 805,621,454 | 1,404,312,112 | 1.74x | 3.80x |
+| n=12 | 5,805,752,478 | 11,385,452,195 | 1.96x | 4.63x |
+
+**Closure verdict.** m.4c.6 closes the Phase 6.3.4.m.4c sub-tree. The AMD64 backend now lowers the full cell-bank surface that binary_trees touches (entry path, OpReturnCell, OpPairFst/Snd, OpNewPair with PairGrow deopt, self + cross-fn OpCallMixed) and the admission gate routes all three binary_trees functions through JIT on linux/amd64. The remaining open amd64 work moves to the broader cell-bank parity for the list/map BG kernels (n_body, reverse_complement, nsieve, fasta, k_nucleotide, mandelbrot, spectral_norm, fannkuch_redux) which is tracked separately from m.4c.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
Closes #21832.

Final sub-phase of the AMD64 cell-bank port for binary_trees. Lowers cross-function `OpCallMixed` on AMD64 (MOVABS R10 + CALL R10), widens the admission gate, and benches binary_trees on server2 to verify the program now lands inside 2x of Go on linux/amd64.

## Summary

- `lower_amd64.go`: split OpCallMixed byte count + emit into self vs cross-fn paths.
  - Self path keeps 5B CALL rel32 + optional passthrough deopt.
  - Cross-fn path emits 10B MOVABS R10, imm64 + 3B CALL R10 = 13B.
  - New `hasCrossFnCallMixedAMD64`, `crossFnDeoptCalleeAMD64`, `needsCrossFnPassthroughAMD64` helpers. `needsPassthroughAMD64` returns `selfDeopt || crossFnDeopt`, so the prologue spills RBP/R14 only when a callee can actually deopt.
- `compile.go`: widen `checkCellBankAdmissibleAMD64` to admit cross-fn `OpCallMixed` when `opts.Prog != nil`, callee idx resolves, callee has `JITCode != nil`, callee has `NumRegsF64 == 0`, no f64 param banks.
- `cell_amd64_test.go`: `TestCrossFnCallMixedAMD64` covers a two-fn cell-bank program (caller does OpNewPair + cross-fn OpCallMixed; callee returns I64=42).
- `website/docs/mep/mep-0040.md`: §6.3.4.m.4c.6 section with implementation walkthrough, admission rule, tests, verification, bench table, closure verdict.

## Bench (server2, AMD EPYC, Go 1.26.0)

| size | Go ns/op | vm3jit ns/op | ratio | m.4b baseline |
|---|---|---|---|---|
| n=10 | 805,621,454 | 1,404,312,112 | 1.74x | 3.80x |
| n=12 | 5,805,752,478 | 11,385,452,195 | 1.96x | 4.63x |

54% / 58% reduction from the m.4b interp-floor. binary_trees is now under 2x of Go on both darwin/arm64 and linux/amd64.

## Test plan

- [x] `go test ./runtime/jit/vm3jit/...` on darwin/arm64 (green)
- [x] `GOOS=linux GOARCH=amd64 go build ./...` (clean)
- [x] `go test -run TestCrossFnCallMixedAMD64 ./runtime/jit/vm3jit/` on server2 (pass)
- [x] `go test -run TestBinaryTreesMatchesOracle ./compiler3/corpus/` on server2 (pass)
- [x] `go test -bench BinaryTrees -benchtime=2s` on server2 (1.74x / 1.96x)
- [x] `npm run build` in website/ (MDX clean)