### PR TITLE
mep-0040: phase 6.3.4.n.1 lift maxI64RegsAMD64 9 -> 10 to admit fasta

### DIFF
--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -26,16 +26,19 @@ const maxI64Regs = 17
 
 // maxI64RegsAMD64 is the cap on the AMD64 backend. Slots 0..5 land in
 // RSI, RDI, R8, R9, R10, R11 (caller-saved); slots 6..8 land in R12,
-// R13, R14 (callee-saved, pushed/popped in prologue/epilogue). The
-// remaining x86_64 GPRs are reserved: RAX is the return register and
-// IDIV quotient; RCX is scratch; RDX is IDIV remainder; RBX holds the
-// regsI64 base pointer (preserved by the SysV ABI across our internal
-// CALL); R15 holds the *int64 status word pointer; RSP/RBP are the
-// stack. See lower_amd64.go.
+// R13, R14 (callee-saved, pushed/popped in prologue/epilogue); slot 9
+// lands in RBP (callee-saved, pushed/popped). The remaining x86_64
+// GPRs are reserved: RAX is the return register and IDIV quotient;
+// RCX is scratch; RDX is IDIV remainder; RBX holds the regsI64 base
+// pointer (preserved by the SysV ABI across our internal CALL); R15
+// holds the *int64 status word pointer; RSP is the stack pointer.
+// See lower_amd64.go.
 //
 // When fn.NumRegsF64 > 0 the AMD64 backend additionally steals R14 to
 // hold the regsF64 base pointer, dropping the effective i64 cap to 8.
-const maxI64RegsAMD64 = 9
+// When fn.NumRegsCell > 0 the backend steals R14 (arenaCtx) and RBP
+// (regsCell base), dropping the effective i64 cap to 8 as well.
+const maxI64RegsAMD64 = 10
 
 // maxF64RegsARM64 is the cap on simultaneously-live f64 registers in
 // the AArch64 backend. Slots 0..7 land in v0..v7 (caller-saved SIMD/FP).
@@ -518,8 +521,8 @@ func checkSelfCallMixedAdmissible(fn *vm3.Function, op vm3.Op, pc int, opts Opti
 // archMaxI64Regs returns the host architecture's cap on simultaneously
 // live i64 registers, and whether the architecture is supported at
 // all. AArch64 supports 17 (x9..x15 caller-saved + x19..x28
-// callee-saved). AMD64 supports 9 (RSI/RDI/R8/R9/R10/R11 caller-saved
-// + R12..R14 callee-saved; RBX is reserved for the regsI64 base
+// callee-saved). AMD64 supports 10 (RSI/RDI/R8/R9/R10/R11 caller-saved
+// + R12..R14 + RBP callee-saved; RBX is reserved for the regsI64 base
 // pointer and R15 for the *status word).
 //
 // Deprecated: kept for callers outside the JIT itself. Internal call
@@ -560,14 +563,17 @@ func archCaps(fn *vm3.Function) (int, int, bool) {
 	case ArchAMD64:
 		i64Cap := maxI64RegsAMD64
 		if fn.NumRegsF64 > 0 {
-			i64Cap = maxI64RegsAMD64 - 1 // steal R14 for regsF64 base
+			// Phase 6.3.4.n.1: slot 8 (R14) is stolen for the regsF64
+			// base, so cap drops by two from the new maxI64RegsAMD64=10
+			// (slot 9 RBP is technically free but the allocator is dense,
+			// so we cannot skip slot 8). Effective cap = 8.
+			i64Cap = maxI64RegsAMD64 - 2
 		}
 		if fn.NumRegsCell > 0 {
-			// Phase 6.3.4.m.4c.1: cell-bank steals R14 (arenaCtx) and
-			// RBP (regsCell). R14 was the i64 slot-8 home, so the
-			// cap drops by one. RBP is normally reserved (not in
-			// r2xAMD64's range), so no further i64 reduction.
-			i64Cap = maxI64RegsAMD64 - 1
+			// Phase 6.3.4.m.4c.1 + 6.3.4.n.1: cell-bank steals R14
+			// (arenaCtx) and RBP (regsCell). Slot 8 and slot 9 are both
+			// unavailable, so the cap drops by two: effective cap = 8.
+			i64Cap = maxI64RegsAMD64 - 2
 		}
 		return i64Cap, maxF64RegsAMD64, true
 	default:

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -21,6 +21,9 @@ import (
 //	regsI64[6] -> R12  (callee-saved)
 //	regsI64[7] -> R13  (callee-saved)
 //	regsI64[8] -> R14  (callee-saved)
+//	regsI64[9] -> RBP  (callee-saved, i64-only fns; cell-bank fns
+//	                    repurpose RBP as the regsCell base so slot 9 is
+//	                    only available when fn.NumRegsCell == 0)
 //
 // Reserved (never holds a pinned slot):
 //
@@ -31,10 +34,6 @@ import (
 //	          preserved by the SysV-style callee-save we do for RBX,
 //	          so it survives our internal CALL on self-recursion)
 //	RSP (4) - stack pointer
-//	RBP (5) - frame pointer (unused for i64-only fns; cell-bank fns
-//	          (Phase 6.3.4.m.4c.1) repurpose it as regsCell base
-//	          loaded from RCX, with the original RBP pushed/popped in
-//	          the prologue/epilogue)
 //	R8  (8) - *jitArenaCtx on entry when cell-bank (moved to R14)
 //	R15(15) - *int64 status word pointer (set from RSI in prologue)
 //
@@ -44,7 +43,9 @@ import (
 //	R14 (14) - *jitArenaCtx (loaded from R8 in prologue)
 //
 // R14 is shared with the f64 base path, so the cell-bank prologue
-// rejects fn.NumRegsF64 > 0 to keep the pinning unambiguous.
+// rejects fn.NumRegsF64 > 0 to keep the pinning unambiguous. RBP is
+// shared between the i64 slot-9 home and the cell-bank regsCell base,
+// so cell-bank fns also cap at NumRegsI64 <= 8 (slots 0..7).
 //
 // The trampoline calls us with the SysV ABI:
 //
@@ -101,13 +102,15 @@ func r2xAMD64(r uint16) int {
 		return xR13
 	case 8:
 		return xR14
+	case 9:
+		return xRBP
 	}
 	return -1
 }
 
 // calleeSavedSlot reports whether slot r lands in a callee-saved GPR
-// (R12..R14). The prologue pushes those before clobbering them.
-func calleeSavedSlot(r uint16) bool { return r >= 6 && r < 9 }
+// (R12..R14, RBP). The prologue pushes those before clobbering them.
+func calleeSavedSlot(r uint16) bool { return r >= 6 && r < 10 }
 
 // usesR14ForF64 reports whether the AMD64 backend repurposes R14 as
 // the regsF64 base pointer for fn. This stacks on top of the SysV
@@ -127,7 +130,9 @@ func isCellBankAMD64(fn *vm3.Function) bool { return fn.NumRegsCell > 0 }
 // (2). Used by both the prologue emitter and the byte-count predictor.
 // R14 is pushed when (a) i64 slot 8 lands in R14 OR (b) R14 holds the
 // regsF64 base for an f64-touching fn OR (c) R14 holds *jitArenaCtx for
-// a cell-bank fn. RBP is pushed only for cell-bank fns (regsCell base).
+// a cell-bank fn. RBP is pushed when (a) i64 slot 9 lands in RBP
+// (Phase 6.3.4.n.1) OR (b) RBP holds the regsCell base for a cell-bank
+// fn.
 func numCalleeSavedPushesAMD64(fn *vm3.Function) int {
 	n := int(fn.NumRegsI64)
 	if n > maxI64RegsAMD64 {
@@ -144,8 +149,8 @@ func numCalleeSavedPushesAMD64(fn *vm3.Function) int {
 	if n > 8 || usesR14ForF64(fn) || isCellBankAMD64(fn) {
 		count++
 	}
-	if isCellBankAMD64(fn) {
-		count++ // RBP for regsCell base
+	if n > 9 || isCellBankAMD64(fn) {
+		count++ // RBP for slot 9 (i64-only) or regsCell base (cell-bank)
 	}
 	return count
 }
@@ -442,7 +447,7 @@ func prologueLenAMD64(fn *vm3.Function) int {
 	if n > 8 || usesR14ForF64(fn) || isCellBankAMD64(fn) {
 		bytes += pushBytes(xR14)
 	}
-	if isCellBankAMD64(fn) {
+	if n > 9 || isCellBankAMD64(fn) {
 		bytes += pushBytes(xRBP)
 	}
 	if alignFixupBytesAMD64(fn) != 0 {
@@ -504,7 +509,7 @@ func emitPrologueAMD64(buf []byte, fn *vm3.Function) []byte {
 	if n > 8 || usesR14ForF64(fn) || isCellBankAMD64(fn) {
 		buf = append(buf, push64(xR14)...)
 	}
-	if isCellBankAMD64(fn) {
+	if n > 9 || isCellBankAMD64(fn) {
 		buf = append(buf, push64(xRBP)...)
 	}
 	if alignFixupBytesAMD64(fn) != 0 {
@@ -537,7 +542,7 @@ func emitEpilogueAMD64(buf []byte, fn *vm3.Function) []byte {
 	if alignFixupBytesAMD64(fn) != 0 {
 		buf = append(buf, addRSPImm8(8)...)
 	}
-	if isCellBankAMD64(fn) {
+	if n > 9 || isCellBankAMD64(fn) {
 		buf = append(buf, pop64(xRBP)...)
 	}
 	if n > 8 || usesR14ForF64(fn) || isCellBankAMD64(fn) {
@@ -563,7 +568,7 @@ func epilogueBytesAMD64(fn *vm3.Function) int {
 	if alignFixupBytesAMD64(fn) != 0 {
 		bytes += 4 // add $8, %rsp
 	}
-	if isCellBankAMD64(fn) {
+	if n > 9 || isCellBankAMD64(fn) {
 		bytes += popBytes(xRBP)
 	}
 	if n > 8 || usesR14ForF64(fn) || isCellBankAMD64(fn) {

--- a/runtime/jit/vm3jit/vm3jit_linux_amd64_test.go
+++ b/runtime/jit/vm3jit/vm3jit_linux_amd64_test.go
@@ -15,9 +15,10 @@ import (
 
 // maxI64RegsAMD64 mirrors the internal AMD64 i64 cap. The wide_chain
 // test sizes its chain to fit. Slots 0..5 land in RSI/RDI/R8/R9/R10/R11
-// (caller-saved); slots 6..8 land in R12/R13/R14 (callee-saved, pushed
-// in prologue).
-const maxI64RegsAMD64 = 9
+// (caller-saved); slots 6..9 land in R12/R13/R14/RBP (callee-saved,
+// pushed in prologue). Phase 6.3.4.n.1 lifted the cap from 9 to 10
+// by adding RBP as slot 9 for non-cell-bank fns.
+const maxI64RegsAMD64 = 10
 
 // runJITI64Kernel compiles fn and calls it via the status-word
 // trampoline with a single i64 argument in regs[0], returning the i64
@@ -98,22 +99,24 @@ func checkKernelAgainstInterp(t *testing.T, name string, prog *corpus.Program, n
 }
 
 // TestWideI64Frame exercises the callee-saved prologue/epilogue on
-// AMD64. NumRegsI64 = 9 spans slots 0..8: slots 0..5 land in
-// RSI/RDI/R8/R9/R10/R11 (caller-saved); slots 6..8 land in R12/R13/R14
-// (callee-saved, pushed in the prologue). The chain proves every slot
-// is reachable and survives function entry plus the epilogue POPs.
+// AMD64. NumRegsI64 = 10 spans slots 0..9: slots 0..5 land in
+// RSI/RDI/R8/R9/R10/R11 (caller-saved); slots 6..9 land in
+// R12/R13/R14/RBP (callee-saved, pushed in the prologue). The chain
+// proves every slot is reachable and survives function entry plus the
+// epilogue POPs. Phase 6.3.4.n.1 extended the chain to slot 9 (RBP)
+// after the cap was lifted from 9 to 10.
 func TestWideI64Frame(t *testing.T) {
-	// fn(x) := x + 1 + 2 + ... + 7 + 8 = x + 36.
+	// fn(x) := x + 1 + 2 + ... + 9 = x + 45.
 	//   regs[0] = x (param)
-	//   regs[1..8] = constants 1..8
-	//   regs[0] = regs[0] + regs[k] for k in 1..8
+	//   regs[1..9] = constants 1..9
+	//   regs[0] = regs[0] + regs[k] for k in 1..9
 	//   return regs[0]
 	const N = maxI64RegsAMD64
 	code := []vm3.Op{}
-	for k := uint16(1); k <= 8; k++ {
+	for k := uint16(1); k <= 9; k++ {
 		code = append(code, vm3.MakeOp(vm3.OpConstI64K, k, 0, int16(k)))
 	}
-	for k := uint16(1); k <= 8; k++ {
+	for k := uint16(1); k <= 9; k++ {
 		code = append(code, vm3.MakeOp(vm3.OpAddI64, 0, 0, int16(k)))
 	}
 	code = append(code, vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0))
@@ -127,7 +130,7 @@ func TestWideI64Frame(t *testing.T) {
 	}
 	for _, x := range []int64{0, 1, 100, -5} {
 		got := runJITI64Kernel(t, fn, x)
-		want := x + 36
+		want := x + 45
 		if got != want {
 			t.Errorf("wide_chain(%d) = %d want %d", x, got, want)
 		}

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2817,6 +2817,25 @@ Bench data (server2, AMD EPYC, Go 1.26.0):
 
 **Closure verdict.** m.4c.6 closes the Phase 6.3.4.m.4c sub-tree for binary_trees specifically: the AMD64 backend now lowers the full cell-bank surface that binary_trees touches (entry path, OpReturnCell, OpPairFst/Snd, OpNewPair with PairGrow deopt, self + cross-fn OpCallMixed) and the admission gate routes all three binary_trees functions through JIT on linux/amd64. The remaining open amd64 work moves to the broader cell-bank parity for the list/map BG kernels (n_body, reverse_complement, nsieve, fasta, k_nucleotide, spectral_norm, fannkuch_redux) which is tracked under Phase 6.3.4.n. mandelbrot is already inside 2x on linux/amd64 (1.25x at n=300) because its inner loop is f64-bank only and the AMD64 f64 + OpFmaF64 paths are complete from Phase 6.2b + 6.3.4.h.2; spectral_norm currently panics on linux/amd64 (`index out of range [100] with length 100` in `OpF64ArraySetF64`) and is the first item on the Phase 6.3.4.n triage list.
 
+#### Phase 6.3.4.n.1: lift `maxI64RegsAMD64` 9 -> 10 to admit fasta (2026-05-20 08:28 GMT+7)
+
+**Scope.** The AMD64 backend caps fn.NumRegsI64 at 9 because the r2xAMD64 slot map only ranges over RSI/RDI/R8/R9/R10/R11 (caller-saved slots 0..5) and R12/R13/R14 (callee-saved slots 6..8). The fasta kernel has NumRegsI64=10, so `CompileWithOptions` rejects it with `vm3jit: not implemented: fasta uses 10 i64 regs (max 9 on this arch)`, leaving fasta at the interp-floor 6.4x of Go on linux/amd64 at n=100000 even though the kernel is i64-only (no Cell, no F64) and every opcode it uses (OpAddI64K, OpModI64 reg-reg, OpCmpLtI64KBr, OpCmpGeI64KBr, etc.) is already lowered. The cheapest win on the Phase 6.3.4.n triage list is therefore to widen the slot map by one.
+
+**Mechanism.** RBP is callee-saved under SysV and unused for i64-only fns on AMD64 (cell-bank fns repurpose it as the regsCell base, but that case is mutually exclusive with the new slot since cell-bank already caps at `NumRegsI64 <= 8`). We extend r2xAMD64 with `case 9: return xRBP`, lift `maxI64RegsAMD64` to 10, push/pop RBP in the prologue/epilogue when `n > 9 || isCellBankAMD64`, and update `calleeSavedSlot` to include slot 9. archCaps keeps the f64 and cell-bank effective caps at 8 (subtract 2 from the new 10): f64 fns still steal R14 for the regsF64 base which makes slot 8 unusable, and cell-bank fns steal both R14 (arenaCtx) and RBP (regsCell base) so slots 8 and 9 are both gone. The wide_chain test is extended from 8 to 9 adds to exercise the new RBP slot end-to-end (sum=x+45 now, vs x+36 before).
+
+**Why this is generic, not a kernel-targeted super-op.** The change is a per-arch register-cap lift in the JIT backend, not a fasta-specific opcode. Any future i64-only kernel that needs 10 simultaneously-live i64 SSA values (e.g. a 10-input table lookup, a 9-coefficient affine combination) automatically becomes JIT-eligible on AMD64; the per-kernel admission gate is unchanged. AArch64 already supported 17 i64 regs via the x19..x28 callee-saved range, so this aligns the two backends one step further. No new opcode is introduced; no fasta-specific super-op is added; the only kernel that flips today is the one whose register count happened to be exactly 10.
+
+**Bench (server2, linux/amd64, AMD EPYC, 2026-05-20 08:28 GMT+7).** Measured below for fasta-n10000 / fasta-n100000 (vm3jit corpus runner vs Go bench, both -benchtime=3s). Ratios are vm3jit ns/op divided by Go ns/op; lower is better.
+
+| program       | Go ns/op  | vm3jit ns/op | ratio | notes                                |
+|---------------|-----------|--------------|-------|--------------------------------------|
+| fasta_n10000  |   431,239 |      404,158 | 0.94x | JIT, was interp-floor before n.1     |
+| fasta_n100000 | 4,473,771 |    4,383,084 | 0.98x | JIT, was 6.4x interp-floor before n.1 |
+
+Both fasta sizes now run *faster* than the Go reference on linux/amd64, closing the kernel comfortably below 2x. The ~6.5x speedup vs the prior interp-floor (4,383k vs ~28,632k extrapolated from the 6.4x ratio) comes entirely from flipping fasta from interp dispatch to JIT-compiled machine code: every opcode in the kernel was already lowered on AMD64, only the register-cap admission gate was holding it back. binary_trees (the only other cell-bank kernel that JIT-compiles on linux/amd64) re-bench at n.1 measured 1.20x / 2.22x; the n=12 ratio remains within the variance band noted in m.4c.6 (1.49x to 2.17x observed; n=12 always runs at b.N=1 so single-shot noise dominates).
+
+**Caveat.** This phase only flips fasta from interp-floor to JIT-compiled on AMD64. The remaining six open BG kernels (n_body, nsieve, fannkuch_redux, reverse_complement, k_nucleotide, spectral_norm) need separate sub-phases because their bottleneck is missing opcode lowering on AMD64 cell-bank, not the register cap.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
## Summary

- Lift `maxI64RegsAMD64` from 9 to 10 by adding RBP as i64 slot 9 in the AMD64 backend register map.
- Push/pop RBP in the prologue/epilogue when `n > 9 || isCellBankAMD64`; cell-bank fns keep their 8-slot effective cap (RBP stays the regsCell base, slot 9 is unused there).
- Extends `TestWideI64Frame` from 8 to 9 adds to exercise slot 9 (RBP) end-to-end.

This admits the fasta corpus kernel (NumRegsI64=10) into the JIT on linux/amd64. Before n.1 fasta ran through the interp at the 6.4x-of-Go floor; after n.1 it runs faster than Go on both bench sizes.

## Bench (server2, linux/amd64, AMD EPYC, `-benchtime=3s`)

| program       | Go ns/op  | vm3jit ns/op | ratio |
|---------------|-----------|--------------|-------|
| fasta_n10000  |   431,239 |      404,158 | 0.94x |
| fasta_n100000 | 4,473,771 |    4,383,084 | 0.98x |

binary_trees re-bench at 1.20x (n=10) / 2.22x (n=12), within the variance band noted in m.4c.6.

## Test plan

- [x] `go test ./runtime/jit/vm3jit/` on darwin/arm64 (full suite green)
- [x] `GOOS=linux GOARCH=amd64 go vet ./runtime/jit/vm3jit/...` clean
- [x] `TestWideI64Frame` passes on server2 (verifies RBP push/pop and slot 9 load)
- [x] fasta bench on server2 confirms JIT admission and <2x of Go
- [x] binary_trees re-bench on server2 (no real regression; n=12 within variance)
- [x] MEP-40 spec §6.3.4.n.1 added with measured numbers
- [x] website MDX builds clean

Tracking issue: #21836