### PR TITLE
mep-0040: phase 6.3.4.n.2.a AMD64 OpListGetI64 cell-bank lowering

### DIFF
--- a/runtime/jit/vm3jit/arena_ctx.go
+++ b/runtime/jit/vm3jit/arena_ctx.go
@@ -88,3 +88,12 @@ func jitArenaCtxPairsCapOff() uintptr {
 func jitArenaCtxPairsBaseOff() uintptr {
 	return unsafe.Offsetof(jitArenaCtx{}.pairsBase)
 }
+
+// jitArenaCtxListsBaseOff is the byte offset of listsBase within
+// jitArenaCtx. AMD64 OpListGetI64 (Phase 6.3.4.n.2.a) loads it from
+// R14+disp32 to recover the list slab base. The ARM64 backend pins
+// this in x19 via the prologue's slabBaseOffARM64 dispatch and so
+// does not need the offset surfaced through a helper.
+func jitArenaCtxListsBaseOff() uintptr {
+	return unsafe.Offsetof(jitArenaCtx{}.listsBase)
+}

--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -327,20 +327,22 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 }
 
 // checkCellBankAdmissibleAMD64 is the AMD64 cell-bank whitelist (Phase
-// 6.3.4.m.4c.1 .. m.4c.6). The scaffold admits:
+// 6.3.4.m.4c.1 .. m.4c.6, extended in n.2.a). The scaffold admits:
 //
 //   - the i64 arithmetic / compare-and-branch / control-flow set the
 //     existing lower_amd64 supports,
 //   - OpReturnCell (m.4c.2),
 //   - OpPairFst / OpPairSnd (m.4c.3), the read-only pair access pair,
 //   - OpNewPair (m.4c.4), the inline allocator with StatusPairGrow deopt,
-//   - OpCallMixed self-recursive (m.4c.5), and
+//   - OpCallMixed self-recursive (m.4c.5),
 //   - OpCallMixed cross-fn (m.4c.6), provided the callee is JIT-compiled,
-//     has no f64 regs, and has no f64 params.
+//     has no f64 regs, and has no f64 params, and
+//   - OpListGetI64 (n.2.a), the read-only list access op (cold form
+//     only; hoisted slab-base optimizations come in later sub-phases).
 //
-// list/map ops are out of scope for the binary_trees closure. f64
-// banks remain rejected because cell-bank repurposes R14 for
-// *jitArenaCtx and R14 is the f64 base on AMD64.
+// Map ops and the list write/push ops are out of scope until the next
+// sub-phases. f64 banks remain rejected because cell-bank repurposes
+// R14 for *jitArenaCtx and R14 is the f64 base on AMD64.
 func checkCellBankAdmissibleAMD64(fn *vm3.Function, opts Options) error {
 	if fn.NumRegsF64 > 0 {
 		return fmt.Errorf("%w: %s has both Cell and f64 banks (AMD64 m.4c.1 admits Cell+I64 only; R14 shared)",
@@ -363,6 +365,7 @@ func checkCellBankAdmissibleAMD64(fn *vm3.Function, opts Options) error {
 			vm3.OpJump,
 			vm3.OpReturnI64, vm3.OpReturnConstK, vm3.OpReturnCell,
 			vm3.OpPairFst, vm3.OpPairSnd, vm3.OpNewPair,
+			vm3.OpListGetI64,
 			vm3.OpLookupI64KW:
 			continue
 		case vm3.OpCallMixed:

--- a/runtime/jit/vm3jit/list_get_amd64_test.go
+++ b/runtime/jit/vm3jit/list_get_amd64_test.go
@@ -1,0 +1,132 @@
+//go:build amd64
+
+package vm3jit_test
+
+import (
+	"testing"
+
+	"mochi/runtime/jit/vm3jit"
+	"mochi/runtime/vm3"
+)
+
+// TestListGetI64AMD64 exercises Phase 6.3.4.n.2.a: AMD64 OpListGetI64
+// lowering on a cell-bank fn. The driver runs in the interpreter (it
+// uses OpNewList + OpListPushI64 which n.2.a does not yet admit), so it
+// builds a 3-element list [10, 20, 30] and calls the JIT'd helper. The
+// helper is cell-bank (NumRegsCell=1) + i64 (NumRegsI64=2) and uses a
+// constant index for the OpListGetI64 access, so the only admission
+// gate it has to pass is the new OpListGetI64 case in the AMD64
+// whitelist. The returned value must equal the list element at the
+// constant idx; a drift in the SBFX (shl/sar) pair or in any of the
+// scratch-register choices would surface here as a wrong return or a
+// segfault on the SIB load.
+func TestListGetI64AMD64(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_list_get_const",
+		NumRegsI64:  2,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 1),    // pc=0: regsI64[0] = 1 (idx)
+			vm3.MakeOp(vm3.OpListGetI64, 1, 0, 0),   // pc=1: regsI64[1] = regsCell[0][regsI64[0]]
+			vm3.MakeOp(vm3.OpReturnI64, 1, 0, 0),    // pc=2: return regsI64[1]
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewList, 0, 0, 0),                                       // pc=0: regsCell[0] = []
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 10),                                    // pc=1: regsI64[1] = 10
+			vm3.MakeOp(vm3.OpListPushI64, 0, 1, 0),                                   // pc=2: list.push(10)
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 20),                                    // pc=3: regsI64[1] = 20
+			vm3.MakeOp(vm3.OpListPushI64, 0, 1, 0),                                   // pc=4: list.push(20)
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 30),                                    // pc=5: regsI64[1] = 30
+			vm3.MakeOp(vm3.OpListPushI64, 0, 1, 0),                                   // pc=6: list.push(30)
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1}, // pc=7: regsI64[0] = helper(regsCell[0])
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),                                     // pc=8: return regsI64[0]
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; AMD64 cell-bank n.2.a should admit OpListGetI64")
+	}
+	preDeopt := vm3jit.DeoptCount
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if d := vm3jit.DeoptCount - preDeopt; d != 0 {
+		t.Fatalf("unexpected deopt count delta: %d", d)
+	}
+	if got.Int() != 20 {
+		t.Fatalf("got %d, want 20 (list[1])", got.Int())
+	}
+}
+
+// TestListGetI64AMD64NegativePayload guards the SBFX (shl/sar by 16)
+// pair against a sign-bit drop. A list value of -42 must round-trip as
+// -42, not 0x0000FFFF_FFFFFFD6 (which is what a missing sign-extend
+// would surface). The helper uses a different (dst, idx) register
+// pair than TestListGetI64AMD64 to also catch r2xAMD64 mapping bugs.
+func TestListGetI64AMD64NegativePayload(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_list_get_neg",
+		NumRegsI64:  3,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpConstI64K, 2, 0, 0),    // pc=0: regsI64[2] = 0 (idx)
+			vm3.MakeOp(vm3.OpListGetI64, 1, 0, 2),   // pc=1: regsI64[1] = regsCell[0][regsI64[2]]
+			vm3.MakeOp(vm3.OpReturnI64, 1, 0, 0),    // pc=2: return regsI64[1]
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewList, 0, 0, 0),                                       // pc=0: regsCell[0] = []
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, -42),                                   // pc=1: regsI64[1] = -42
+			vm3.MakeOp(vm3.OpListPushI64, 0, 1, 0),                                   // pc=2: list.push(-42)
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1}, // pc=3: regsI64[0] = helper(regsCell[0])
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),                                     // pc=4: return regsI64[0]
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; AMD64 cell-bank n.2.a should admit OpListGetI64")
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if got.Int() != -42 {
+		t.Fatalf("got %d, want -42 (sign-extend failed?)", got.Int())
+	}
+}

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -777,6 +777,20 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		//   mov  %rax, pairsLenOff(%r14)       ; 7B  commit pairsLen
 		return 7 + 7 + 3 + 6 + 7 + 7 + 3 + 6 + 7 + 7 + 7 + 7 + 2 + 10 + 3 + 7 + 3 + 7, nil
 
+	case vm3.OpListGetI64:
+		// Phase 6.3.4.n.2.a cold form, AMD64 mirror of the ARM64
+		// OpListGetI64 (no hoist):
+		//   mov  disp32(%rbp), %eax       ; idx = low 32 of regsCell[B] (zero-ext, 6B)
+		//   imul $stride, %rax, %rax      ; rax = idx * sizeof(vmList) (REX.W 69 /r imm32, 7B)
+		//   mov  listsBaseOff(%r14), %rcx ; rcx = arenas.Lists base (REX.WB 8B /r disp32, 7B)
+		//   add  %rcx, %rax               ; rax = &arenas.Lists[idx] (REX.W 01 /r, 3B)
+		//   mov  cellsOff(%rax), %rax     ; rax = cells.ptr (REX.W 8B /r disp32, 7B)
+		//   mov  [%rax + xIdx*8], %rax    ; rax = cells[regsI64[C]] (REX.W 8B /r SIB, 4B)
+		//   shl  $16, %rax                ; SBFX prep                  (REX.W C1 /4 ib, 4B)
+		//   sar  $16, %rax                ; sign-extend low 48 bits   (REX.W C1 /7 ib, 4B)
+		//   mov  %rax, x_A                ; regsI64[A] = signed payload (REX.W 89 /r, 3B)
+		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + 7 + 4 + 4 + 4 + 3, nil
+
 	case vm3.OpConstF64K:
 		idx := int(uint16(op.C))
 		if idx >= len(fn.Consts) {
@@ -1158,6 +1172,30 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		// pairsLen++; commit.
 		out = append(out, inc64R(xRAX)...)
 		out = append(out, mov64StoreDisp32(xRAX, xR14, pairsLenOff)...)
+		return out, nil
+
+	case vm3.OpListGetI64:
+		// Phase 6.3.4.n.2.a: regsI64[A] = arenas.Lists[handleIdx(regsCell[B])].cells[regsI64[C]].Int().
+		// Cold form mirroring the ARM64 cold path (no hoisted slab base
+		// or cells.ptr pin). RAX is the scratch slab-address/payload
+		// register; RCX holds the listsBase load. xIdx is the pinned
+		// register for regsI64[C]; xA is the pinned register for
+		// regsI64[A]. The shl/sar pair is the AMD64 equivalent of ARM64
+		// SBFX: it sign-extends the low 48 bits of the boxed Int48 cell.
+		stride := int64(vm3.JITListSlabStride())
+		cellsOff := int32(vm3.JITListCellsOffset())
+		listsBaseOff := int32(jitArenaCtxListsBaseOff())
+		xIdx := r2xAMD64(uint16(op.C))
+		xA := r2xAMD64(op.A)
+		out := mov32LoadDisp32(xRAX, xRBP, int32(op.B)*8)
+		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
+		out = append(out, mov64LoadDisp32(xRCX, xR14, listsBaseOff)...)
+		out = append(out, add64RR(xRCX, xRAX)...)
+		out = append(out, mov64LoadDisp32(xRAX, xRAX, cellsOff)...)
+		out = append(out, mov64LoadIdxLsl3(xRAX, xRAX, xIdx)...)
+		out = append(out, shl64RImm8(xRAX, 16)...)
+		out = append(out, sar64RImm8(xRAX, 16)...)
+		out = append(out, mov64RR(xRAX, xA)...)
 		return out, nil
 
 	case vm3.OpConstF64K:
@@ -1643,6 +1681,21 @@ func cmp64RImm32(dst int, imm int32) []byte {
 // neg64R emits `neg %rDst` (rDst = -rDst). Opcode REX.W F7 /3.
 func neg64R(dst int) []byte {
 	return []byte{rex(true, false, false, dst >= 8), 0xF7, modRM(3, 3, byte(dst))}
+}
+
+// shl64RImm8 emits `shl %rDst, imm8`. Opcode REX.W C1 /4 ib. Phase
+// 6.3.4.n.2.a uses this with sar64RImm8 (16-bit shift pair) as the
+// AMD64 SBFX-equivalent that sign-extends the low 48 bits of a NaN-
+// boxed int48 payload from arenas.Lists[i].cells[j]. 4 bytes.
+func shl64RImm8(dst int, imm uint8) []byte {
+	return []byte{rex(true, false, false, dst >= 8), 0xC1, modRM(3, 4, byte(dst&7)), imm}
+}
+
+// sar64RImm8 emits `sar %rDst, imm8`. Opcode REX.W C1 /7 ib. Paired
+// with shl64RImm8 to sign-extend an N-bit signed value packed in the
+// low N bits of a register: shl by (64-N), sar by (64-N). 4 bytes.
+func sar64RImm8(dst int, imm uint8) []byte {
+	return []byte{rex(true, false, false, dst >= 8), 0xC1, modRM(3, 7, byte(dst&7)), imm}
 }
 
 // idiv64R emits `idiv %rDivisor` (signed). Opcode REX.W F7 /7. RDX:RAX

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2836,6 +2836,34 @@ Both fasta sizes now run *faster* than the Go reference on linux/amd64, closing 
 
 **Caveat.** This phase only flips fasta from interp-floor to JIT-compiled on AMD64. The remaining six open BG kernels (n_body, nsieve, fannkuch_redux, reverse_complement, k_nucleotide, spectral_norm) need separate sub-phases because their bottleneck is missing opcode lowering on AMD64 cell-bank, not the register cap.
 
+#### Phase 6.3.4.n.2.a: AMD64 `OpListGetI64` cell-bank lowering (2026-05-20 08:51 GMT+7)
+
+**Scope.** nsieve and fannkuch_redux both block on `OpListGetI64` admission in the AMD64 cell-bank whitelist (nsieve reads the sieve flags array, fannkuch_redux reads the permutation buffer). ARM64 has had this lowering since k.2, but AMD64's whitelist still rejects it, dropping both kernels to the interp-floor. n.2.a lands the cold form of the lowering (no slab-base hoist, no `cells.ptr` pin) so the admission gate can flip; the hot-loop optimizations that ARM64 already enjoys (c.1/c.2) come in later sub-phases.
+
+**Mechanism.** The cold form mirrors the ARM64 cold path one-for-one, translated to SysV ABI:
+
+```
+mov  disp32(%rbp), %eax      ; idx = low 32 of regsCell[B]    (zero-extending 32-bit load)
+imul $stride, %rax, %rax     ; rax = idx * sizeof(vmList)
+mov  listsBaseOff(%r14), %rcx; rcx = arenas.Lists base
+add  %rcx, %rax              ; rax = &arenas.Lists[idx]
+mov  cellsOff(%rax), %rax    ; rax = cells.ptr
+mov  (%rax, xIdx, 8), %rax   ; rax = cells[regsI64[C]]
+shl  $16, %rax               ; SBFX prep
+sar  $16, %rax               ; sign-extend low 48 bits (Int48 unbox)
+mov  %rax, xA                ; regsI64[A] = signed payload
+```
+
+RAX/RCX are safe scratches because r2xAMD64 only ranges over RSI/RDI/R8..R14/RBP. The `shl 16 / sar 16` pair is the AMD64 equivalent of ARM64 SBFX and is what sign-extends the low 48 bits of the Int48-boxed payload (the test `TestListGetI64AMD64NegativePayload` guards a -42 round-trip against a missing sign-extend). A new `jitArenaCtxListsBaseOff` helper surfaces the byte offset of `listsBase` within `jitArenaCtx` so a future layout change picks up automatically (mirrors `jitArenaCtxPairsBaseOff`). The admission gate `checkCellBankAdmissibleAMD64` adds `OpListGetI64` alongside the existing m.4c.3..6 set; no other opcode is admitted yet, so nsieve / fannkuch_redux still fall back to interp until `OpListSetI64` (n.2.b) and `OpListPushI64` / `OpNewList` (n.2.c) land.
+
+**Why this is generic, not a kernel-targeted super-op.** `OpListGetI64` is the universal read for Cell-bank list reads (already used by k.2 ARM64 nsieve and many other list-reading kernels) and was the *only* op blocking AMD64 admission for read-only list access. The change is a per-arch opcode lowering, not a fasta- or nsieve-specific fused op. Any future Cell-bank kernel on AMD64 that reads from a list of int48 values automatically becomes JIT-eligible after this phase, without per-kernel admission tweaks.
+
+**Tests.** Two new synthetic tests in `runtime/jit/vm3jit/list_get_amd64_test.go` (build-tagged `//go:build amd64`):
+- `TestListGetI64AMD64` builds [10, 20, 30] via interp ops in a driver fn, then JIT-calls a cell-bank helper that does `OpConstI64K(idx=1) ; OpListGetI64 ; OpReturnI64` and expects 20. Exercises the constant-idx path of the SIB load.
+- `TestListGetI64AMD64NegativePayload` pushes -42 and round-trips it through the helper; a missing or wrong sign-extend would surface as 0x0000_FFFF_FFFF_FFD6 instead of -42. The helper also uses different `(dst, idx)` register slots than the first test to catch any r2xAMD64 mapping bug.
+
+Both pass on server2 (linux/amd64, AMD EPYC). The full vm3jit suite re-bench shows no regressions vs the pre-n.2.a baseline; the pre-existing `TestNsieveJITCompiles` failure (nsieve entry has no JITCode) is unchanged and is what motivates the follow-up n.2.b/n.2.c phases. No bench is run at this sub-phase because nsieve and fannkuch_redux still fail to JIT-compile until the write-side ops land.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
Tracks #21838.

## Summary
- Cold-form AMD64 lowering for `OpListGetI64` on cell-bank fns (mirrors ARM64 cold path).
- New `jitArenaCtxListsBaseOff` helper for the `arenas.Lists` base offset within `jitArenaCtx`.
- Whitelist `OpListGetI64` in `checkCellBankAdmissibleAMD64`.
- Two synthetic amd64-only tests (`runtime/jit/vm3jit/list_get_amd64_test.go`): happy path + negative-payload sign-extend.
- Spec write-up in §6.3.4.n.2.a.

Hot-loop optimizations (slab-base hoist, cells.ptr pin) are deferred to later sub-phases mirroring c.1/c.2. nsieve / fannkuch_redux still fall back to interp at n.2.a because they also need `OpListSetI64` (n.2.b) and `OpListPushI64` / `OpNewList` (n.2.c); the bench is deferred to n.2.d.

## Test plan
- [x] `go test ./runtime/jit/vm3jit/...` on darwin/arm64 — passes
- [x] `go build ./runtime/jit/vm3jit/...` on darwin/arm64 — clean
- [x] `GOOS=linux GOARCH=amd64 go build ./runtime/jit/vm3jit/...` — clean
- [x] `go test ./runtime/jit/vm3jit/... -run "TestListGetI64AMD64" -count=1 -v` on server2 linux/amd64 — both pass
- [x] Full vm3jit suite on server2 — no regressions vs parent (`TestNsieveJITCompiles` failure is pre-existing and motivates n.2.b/n.2.c)