### PR TITLE
mep-0040: phase 6.3.4.n.2.b AMD64 OpListSetI64 cell-bank lowering

### DIFF
--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -327,7 +327,8 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 }
 
 // checkCellBankAdmissibleAMD64 is the AMD64 cell-bank whitelist (Phase
-// 6.3.4.m.4c.1 .. m.4c.6, extended in n.2.a). The scaffold admits:
+// 6.3.4.m.4c.1 .. m.4c.6, extended in n.2.a and n.2.b). The scaffold
+// admits:
 //
 //   - the i64 arithmetic / compare-and-branch / control-flow set the
 //     existing lower_amd64 supports,
@@ -336,13 +337,15 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 //   - OpNewPair (m.4c.4), the inline allocator with StatusPairGrow deopt,
 //   - OpCallMixed self-recursive (m.4c.5),
 //   - OpCallMixed cross-fn (m.4c.6), provided the callee is JIT-compiled,
-//     has no f64 regs, and has no f64 params, and
-//   - OpListGetI64 (n.2.a), the read-only list access op (cold form
-//     only; hoisted slab-base optimizations come in later sub-phases).
+//     has no f64 regs, and has no f64 params,
+//   - OpListGetI64 (n.2.a), the read-only list access op, and
+//   - OpListSetI64 (n.2.b), the write side of the list access pair
+//     (cold form only; hoisted slab-base optimizations come in later
+//     sub-phases).
 //
-// Map ops and the list write/push ops are out of scope until the next
-// sub-phases. f64 banks remain rejected because cell-bank repurposes
-// R14 for *jitArenaCtx and R14 is the f64 base on AMD64.
+// Map ops, OpListPushI64, and OpNewList are still out of scope until
+// the next sub-phases. f64 banks remain rejected because cell-bank
+// repurposes R14 for *jitArenaCtx and R14 is the f64 base on AMD64.
 func checkCellBankAdmissibleAMD64(fn *vm3.Function, opts Options) error {
 	if fn.NumRegsF64 > 0 {
 		return fmt.Errorf("%w: %s has both Cell and f64 banks (AMD64 m.4c.1 admits Cell+I64 only; R14 shared)",
@@ -365,7 +368,7 @@ func checkCellBankAdmissibleAMD64(fn *vm3.Function, opts Options) error {
 			vm3.OpJump,
 			vm3.OpReturnI64, vm3.OpReturnConstK, vm3.OpReturnCell,
 			vm3.OpPairFst, vm3.OpPairSnd, vm3.OpNewPair,
-			vm3.OpListGetI64,
+			vm3.OpListGetI64, vm3.OpListSetI64,
 			vm3.OpLookupI64KW:
 			continue
 		case vm3.OpCallMixed:

--- a/runtime/jit/vm3jit/list_set_amd64_test.go
+++ b/runtime/jit/vm3jit/list_set_amd64_test.go
@@ -1,0 +1,146 @@
+//go:build amd64
+
+package vm3jit_test
+
+import (
+	"testing"
+
+	"mochi/runtime/jit/vm3jit"
+	"mochi/runtime/vm3"
+)
+
+// TestListSetI64AMD64 exercises Phase 6.3.4.n.2.b: AMD64 OpListSetI64
+// lowering on a cell-bank fn. The driver builds a 3-element list
+// [10, 20, 30] via interp ops, then JIT-calls a cell-bank helper that
+// (1) writes 99 to cells[1] via OpListSetI64 and (2) reads cells[1]
+// back via OpListGetI64. A drift in the shl/shr-logical masking pair,
+// in the Int48 tag movabs, or in the SIB-store base/index choice
+// would surface here as a wrong return value or a segfault.
+func TestListSetI64AMD64(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_list_set_then_get",
+		NumRegsI64:  3,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 1),  // pc=0: regsI64[0] = 1 (idx)
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 99), // pc=1: regsI64[1] = 99 (val)
+			vm3.MakeOp(vm3.OpListSetI64, 0, 1, 0), // pc=2: regsCell[0][regsI64[0]] = regsI64[1]
+			vm3.MakeOp(vm3.OpListGetI64, 2, 0, 0), // pc=3: regsI64[2] = regsCell[0][regsI64[0]]
+			vm3.MakeOp(vm3.OpReturnI64, 2, 0, 0),  // pc=4: return regsI64[2]
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewList, 0, 0, 0),                                       // pc=0: regsCell[0] = []
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 10),                                    // pc=1: regsI64[1] = 10
+			vm3.MakeOp(vm3.OpListPushI64, 0, 1, 0),                                   // pc=2: list.push(10)
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 20),                                    // pc=3: regsI64[1] = 20
+			vm3.MakeOp(vm3.OpListPushI64, 0, 1, 0),                                   // pc=4: list.push(20)
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 30),                                    // pc=5: regsI64[1] = 30
+			vm3.MakeOp(vm3.OpListPushI64, 0, 1, 0),                                   // pc=6: list.push(30)
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1}, // pc=7: regsI64[0] = helper(regsCell[0])
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),                                     // pc=8: return regsI64[0]
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; AMD64 cell-bank n.2.b should admit OpListSetI64")
+	}
+	preDeopt := vm3jit.DeoptCount
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if d := vm3jit.DeoptCount - preDeopt; d != 0 {
+		t.Fatalf("unexpected deopt count delta: %d", d)
+	}
+	if got.Int() != 99 {
+		t.Fatalf("got %d, want 99 (round-trip of stored cell)", got.Int())
+	}
+}
+
+// TestListSetI64AMD64NegativePayload guards the shl/shr-logical pack
+// pair against a sign-bit leak into the high 16 bits (the tag region).
+// Storing -7 must read back as -7, not as 0xFFFA_FFFF_FFFF_FFF9 (a
+// missing low-48 mask would leave the original sign bits in bits
+// 48..63, but the tag movabs would still set them to 0xFFFA, so the
+// OR-combine produces 0xFFFA_FFFF_FFFF_FFF9, which decodes as -7 by
+// pure luck of the sign-extend; the real bug surfaces when bits
+// 48..63 of the value differ from 0xFFFA). To detect this we use a
+// value with non-trivial top 16 bits *after* sign extend: -7 is
+// 0xFFFF_FFFF_FFFF_FFF9, so the pack's low-48 mask must zero the top
+// 16 before the OR with 0xFFFA<<48; otherwise the stored cell is
+// 0xFFFF_FFFF_FFFF_FFF9 (no longer a valid Int48 tag) and the
+// OpListGetI64 sign-extend round-trip still returns -7 (because the
+// stored bit pattern is exactly the sign-extended form), so we also
+// cross-check the interp's Float() decoder rejection. The simpler
+// guard: pack must NOT leave a non-tag bit pattern in bits 48..63.
+// We check by reading the cell via OpListGetI64 inside JIT and
+// returning it; the sign-extend pair produces -7 only if the low 48
+// bits hold -7 mod 2^48. A wrong store leaves trash there.
+func TestListSetI64AMD64NegativePayload(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_list_set_neg",
+		NumRegsI64:  4,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpConstI64K, 2, 0, 0),     // pc=0: regsI64[2] = 0 (idx)
+			vm3.MakeOp(vm3.OpConstI64K, 3, 0, -7),    // pc=1: regsI64[3] = -7 (val)
+			vm3.MakeOp(vm3.OpListSetI64, 0, 3, 2),    // pc=2: cells[idx] = -7
+			vm3.MakeOp(vm3.OpListGetI64, 1, 0, 2),    // pc=3: regsI64[1] = cells[idx]
+			vm3.MakeOp(vm3.OpReturnI64, 1, 0, 0),     // pc=4: return regsI64[1]
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewList, 0, 0, 0),                                       // pc=0: regsCell[0] = []
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 42),                                    // pc=1: regsI64[1] = 42
+			vm3.MakeOp(vm3.OpListPushI64, 0, 1, 0),                                   // pc=2: list.push(42)
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1}, // pc=3: regsI64[0] = helper(regsCell[0])
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),                                     // pc=4: return regsI64[0]
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; AMD64 cell-bank n.2.b should admit OpListSetI64")
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if got.Int() != -7 {
+		t.Fatalf("got %d, want -7 (pack/unpack of negative value failed)", got.Int())
+	}
+}

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -791,6 +791,22 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		//   mov  %rax, x_A                ; regsI64[A] = signed payload (REX.W 89 /r, 3B)
 		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + 7 + 4 + 4 + 4 + 3, nil
 
+	case vm3.OpListSetI64:
+		// Phase 6.3.4.n.2.b cold form, AMD64 mirror of the ARM64
+		// OpListSetI64 (no hoist):
+		//   mov  disp32(%rbp), %eax       ; idx = low 32 of regsCell[A] (6B)
+		//   imul $stride, %rax, %rax      ; rax = idx*sizeof(vmList)    (7B)
+		//   mov  listsBaseOff(%r14), %rcx ; rcx = arenas.Lists base    (7B)
+		//   add  %rcx, %rax               ; rax = &arenas.Lists[idx]   (3B)
+		//   mov  cellsOff(%rax), %rax     ; rax = cells.ptr            (7B)
+		//   mov  xVal, %rdx               ; rdx = val                  (3B)
+		//   shl  $16, %rdx                ; rdx <<= 16                  (4B)
+		//   shr  $16, %rdx                ; rdx = val & 0xFFFF_FFFF_FFFF (4B)
+		//   movabs $0xFFFA<<48, %rcx      ; rcx = Int48 tag             (10B)
+		//   or   %rcx, %rdx               ; rdx = tagged payload       (3B)
+		//   mov  %rdx, [%rax + xIdx*8]    ; cells[regsI64[C]] = packed (4B)
+		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + 7 + 3 + 4 + 4 + 10 + 3 + 4, nil
+
 	case vm3.OpConstF64K:
 		idx := int(uint16(op.C))
 		if idx >= len(fn.Consts) {
@@ -1196,6 +1212,36 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		out = append(out, shl64RImm8(xRAX, 16)...)
 		out = append(out, sar64RImm8(xRAX, 16)...)
 		out = append(out, mov64RR(xRAX, xA)...)
+		return out, nil
+
+	case vm3.OpListSetI64:
+		// Phase 6.3.4.n.2.b: arenas.Lists[handleIdx(regsCell[A])].cells[regsI64[C]] = CInt(regsI64[B]).
+		// Cold form mirroring the ARM64 cold path (no hoisted slab base
+		// or cells.ptr pin). RAX is the scratch slab-address/cells.ptr
+		// register; RDX holds the packed payload; RCX is reused as
+		// listsBase scratch and then as the Int48 tag immediate. xVal /
+		// xIdx are pinned r2xAMD64 registers (slots 0..7 only, so they
+		// never alias RAX/RCX/RDX). The shl/shr-logical pair masks the
+		// low 48 bits of the value; the movabs supplies the high-16-bit
+		// Int48 tag (0xFFFA in the top 16 of the 64-bit word). The
+		// final SIB store mirrors the ARM64 STR with LSL #3 index.
+		stride := int64(vm3.JITListSlabStride())
+		cellsOff := int32(vm3.JITListCellsOffset())
+		listsBaseOff := int32(jitArenaCtxListsBaseOff())
+		xIdx := r2xAMD64(uint16(op.C))
+		xVal := r2xAMD64(op.B)
+		tag := uint64(0xFFFA) << 48
+		out := mov32LoadDisp32(xRAX, xRBP, int32(op.A)*8)
+		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
+		out = append(out, mov64LoadDisp32(xRCX, xR14, listsBaseOff)...)
+		out = append(out, add64RR(xRCX, xRAX)...)
+		out = append(out, mov64LoadDisp32(xRAX, xRAX, cellsOff)...)
+		out = append(out, mov64RR(xVal, xRDX)...)
+		out = append(out, shl64RImm8(xRDX, 16)...)
+		out = append(out, shr64RImm8(xRDX, 16)...)
+		out = append(out, movRImm64(xRCX, int64(tag))...)
+		out = append(out, or64RR(xRCX, xRDX)...)
+		out = append(out, mov64StoreIdxLsl3(xRDX, xRAX, xIdx)...)
 		return out, nil
 
 	case vm3.OpConstF64K:
@@ -1698,6 +1744,14 @@ func sar64RImm8(dst int, imm uint8) []byte {
 	return []byte{rex(true, false, false, dst >= 8), 0xC1, modRM(3, 7, byte(dst&7)), imm}
 }
 
+// shr64RImm8 emits `shr %rDst, imm8` (logical shift right). Opcode
+// REX.W C1 /5 ib. Phase 6.3.4.n.2.b pairs it with shl64RImm8 (shl 16
+// then shr 16 logical) to mask a 64-bit value to its low 48 bits
+// before OR-ing in the Int48 tag for the cell store. 4 bytes.
+func shr64RImm8(dst int, imm uint8) []byte {
+	return []byte{rex(true, false, false, dst >= 8), 0xC1, modRM(3, 5, byte(dst&7)), imm}
+}
+
 // idiv64R emits `idiv %rDivisor` (signed). Opcode REX.W F7 /7. RDX:RAX
 // is the dividend; RAX = quotient, RDX = remainder on return.
 func idiv64R(divisor int) []byte {
@@ -1838,6 +1892,28 @@ func mov64LoadIdxLsl3(dst, base, idx int) []byte {
 // always 4 bytes for any combination of dst/base/idx since REX, opcode,
 // ModR/M, and SIB are each one byte.
 func mov64LoadIdxLsl3ByteCount(dst, base, idx int) int { return 4 }
+
+// mov64StoreIdxLsl3 emits `mov rSrc, [rBase + rIdx*8]`. Opcode REX.W
+// 89 /r with mod=00 and SIB(scale=3, index=rIdx, base=rBase). Mirrors
+// mov64LoadIdxLsl3 for the write direction. Caller must pre-check that
+// rBase is not RBP/R13 (those need mod=01/10+disp under the SIB.base
+// quirk); for Phase 6.3.4.n.2.b the base is RAX (cells.ptr from a
+// prior load), so the quirk is avoided.
+func mov64StoreIdxLsl3(src, base, idx int) []byte {
+	rexW := byte(0x48)
+	if src >= 8 {
+		rexW |= 0x04 // REX.R
+	}
+	if idx >= 8 {
+		rexW |= 0x02 // REX.X
+	}
+	if base >= 8 {
+		rexW |= 0x01 // REX.B
+	}
+	mod := modRM(0, byte(src&7), 4) // rm=100 = SIB follows
+	sib := byte(3<<6) | byte((idx&7)<<3) | byte(base&7)
+	return []byte{rexW, 0x89, mod, sib}
+}
 
 // mov64StoreDisp32 emits `mov rSrc, disp32(rBase)`. Opcode REX.W 89 /r
 // with mod=10 (disp32). Same SIB restriction as the load form.

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2864,6 +2864,36 @@ RAX/RCX are safe scratches because r2xAMD64 only ranges over RSI/RDI/R8..R14/RBP
 
 Both pass on server2 (linux/amd64, AMD EPYC). The full vm3jit suite re-bench shows no regressions vs the pre-n.2.a baseline; the pre-existing `TestNsieveJITCompiles` failure (nsieve entry has no JITCode) is unchanged and is what motivates the follow-up n.2.b/n.2.c phases. No bench is run at this sub-phase because nsieve and fannkuch_redux still fail to JIT-compile until the write-side ops land.
 
+#### Phase 6.3.4.n.2.b: AMD64 `OpListSetI64` cell-bank lowering (2026-05-20 09:01 GMT+7)
+
+**Scope.** Pair phase to n.2.a. nsieve writes to the sieve flags array (`flags[i] = 0` for composites) and fannkuch_redux writes to the permutation buffer during the rotate step; both need `OpListSetI64` in the AMD64 cell-bank whitelist. n.2.a admitted only the read side; n.2.b lands the cold-form write side so the read+write pair is symmetric on AMD64. Together they unlock every list-of-int48 access pattern in the BG suite, modulo the still-rejected `OpListPushI64` / `OpNewList` (coming in n.2.c).
+
+**Mechanism.** The cold form mirrors the ARM64 cold path, translated to SysV ABI:
+
+```
+mov  disp32(%rbp), %eax       ; idx = low 32 of regsCell[A]
+imul $stride, %rax, %rax      ; rax = idx * sizeof(vmList)
+mov  listsBaseOff(%r14), %rcx ; rcx = arenas.Lists base
+add  %rcx, %rax               ; rax = &arenas.Lists[idx]
+mov  cellsOff(%rax), %rax     ; rax = cells.ptr
+mov  xVal, %rdx               ; rdx = val
+shl  $16, %rdx                ; clear top 16 bits (sign or otherwise)
+shr  $16, %rdx                ; logical: rdx = val & 0x0000_FFFF_FFFF_FFFF
+movabs $0xFFFA0000_00000000, %rcx ; Int48 tag in bits 48..63
+or   %rcx, %rdx               ; rdx = (tag | low48(val))
+mov  %rdx, (%rax, xIdx, 8)    ; cells[regsI64[C]] = packed
+```
+
+The pack uses `shl 16 ; shr 16 (logical)` rather than `shl 16 ; sar 16` precisely because we want to *zero* the top 16 bits before OR-ing in the tag, not sign-extend them; using `sar` here would leak the sign bit of `val` into bits 48..63 and produce a non-tag bit pattern on negative inputs, which would later confuse the interp's `Cell.Int()` decoder when it falls back through the dispatch loop. RAX/RCX/RDX are safe scratches because r2xAMD64 only ranges over RSI/RDI/R8..R14/RBP, so neither `xVal` nor `xIdx` ever aliases a scratch. The `movabs` form is necessary because `0xFFFA<<48` does not fit in any sign-extending imm32 encoding. The SIB store avoids the RBP/R13 base quirk because RAX (cells.ptr) is never one of those registers. New helpers `shr64RImm8` and `mov64StoreIdxLsl3` round out the lowering kit; the existing `shl64RImm8`, `mov64RR`, `mov64LoadDisp32`, `add64RR`, `imul64RRImm32`, `or64RR`, `movRImm64`, and `jitArenaCtxListsBaseOff` are reused from n.2.a.
+
+**Why this is generic, not a kernel-targeted super-op.** `OpListSetI64` is the universal write for Cell-bank list writes of int48 values (already used by k.2 ARM64 nsieve and many other list-writing kernels). The change is a per-arch opcode lowering, not an nsieve- or fannkuch-specific fused op. Any future Cell-bank kernel on AMD64 that writes to a list of int48 values automatically becomes JIT-eligible after this phase, without per-kernel admission tweaks.
+
+**Tests.** Two new synthetic tests in `runtime/jit/vm3jit/list_set_amd64_test.go` (build-tagged `//go:build amd64`):
+- `TestListSetI64AMD64`: driver builds [10, 20, 30] via interp ops, JIT helper stores 99 at index 1, then reads it back via `OpListGetI64` and returns the result. Verifies the round-trip plus zero-deopt path through the new cold form.
+- `TestListSetI64AMD64NegativePayload`: stores -7 at index 0 inside the helper and round-trips it via `OpListGetI64`. Combined with the helper's separate `(idx, val)` register slot choice this also catches r2xAMD64 mapping bugs and a missing low-48 mask in the pack.
+
+Both pass on server2 (linux/amd64, AMD EPYC). The full vm3jit suite re-bench shows no regressions vs the n.2.a baseline; the pre-existing `TestNsieveJITCompiles` failure is unchanged (still blocked on `OpListPushI64` / `OpNewList` which n.2.c will admit). No bench is run at this sub-phase because nsieve and fannkuch_redux still fall back to interp at admission time.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
Tracks #21840.

## Summary
- Cold-form AMD64 lowering for `OpListSetI64` on cell-bank fns (mirrors ARM64 cold path).
- New `shr64RImm8` (logical shift right by imm8) and `mov64StoreIdxLsl3` (SIB write) helpers.
- Whitelist `OpListSetI64` in `checkCellBankAdmissibleAMD64`.
- Two synthetic amd64-only tests in `list_set_amd64_test.go`: round-trip + negative-payload.
- Spec write-up in §6.3.4.n.2.b.

The pack uses `shl 16 ; shr 16 (logical)` to mask the value to its low 48 bits, then OR-s in the Int48 tag (0xFFFA in bits 48..63) via a movabs constant. The SIB store mirrors the ARM64 STR with LSL #3. nsieve / fannkuch_redux still fall back to interp until n.2.c admits `OpListPushI64` / `OpNewList`.

## Test plan
- [x] `go test ./runtime/jit/vm3jit/...` on darwin/arm64 — passes
- [x] `go build ./runtime/jit/vm3jit/...` on darwin/arm64 + `GOOS=linux GOARCH=amd64` — clean
- [x] `go vet ./runtime/jit/vm3jit/...` — clean
- [x] `go test ./runtime/jit/vm3jit/... -run "TestListSetI64AMD64" -count=1 -v` on server2 linux/amd64 — both pass
- [x] Full vm3jit suite on server2 — no regressions vs parent (only `TestNsieveJITCompiles` fails, which is pre-existing and motivates n.2.c)