### PR TITLE
vm3jit/amd64: inline OpListPushI64 + OpNewList pre-alloc on cell-bank

### DIFF
--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -327,8 +327,8 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 }
 
 // checkCellBankAdmissibleAMD64 is the AMD64 cell-bank whitelist (Phase
-// 6.3.4.m.4c.1 .. m.4c.6, extended in n.2.a and n.2.b). The scaffold
-// admits:
+// 6.3.4.m.4c.1 .. m.4c.6, extended in n.2.a, n.2.b, and n.2.c). The
+// scaffold admits:
 //
 //   - the i64 arithmetic / compare-and-branch / control-flow set the
 //     existing lower_amd64 supports,
@@ -338,14 +338,17 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 //   - OpCallMixed self-recursive (m.4c.5),
 //   - OpCallMixed cross-fn (m.4c.6), provided the callee is JIT-compiled,
 //     has no f64 regs, and has no f64 params,
-//   - OpListGetI64 (n.2.a), the read-only list access op, and
-//   - OpListSetI64 (n.2.b), the write side of the list access pair
-//     (cold form only; hoisted slab-base optimizations come in later
-//     sub-phases).
+//   - OpListGetI64 (n.2.a), the read-only list access op,
+//   - OpListSetI64 (n.2.b), the write side of the list access pair, and
+//   - OpListPushI64 + OpNewList (n.2.c). OpListPushI64 uses the inline
+//     cap-check + StatusListGrow deopt fast path; OpNewList is admitted
+//     only at the pre-alloc prefix (jitCall pre-allocates the list slab,
+//     the emit step writes zero bytes). All cold form; hoisted slab-base
+//     optimizations come in later sub-phases.
 //
-// Map ops, OpListPushI64, and OpNewList are still out of scope until
-// the next sub-phases. f64 banks remain rejected because cell-bank
-// repurposes R14 for *jitArenaCtx and R14 is the f64 base on AMD64.
+// Map ops on cell-bank AMD64 are still out of scope. f64 banks remain
+// rejected because cell-bank repurposes R14 for *jitArenaCtx and R14 is
+// the f64 base on AMD64.
 func checkCellBankAdmissibleAMD64(fn *vm3.Function, opts Options) error {
 	if fn.NumRegsF64 > 0 {
 		return fmt.Errorf("%w: %s has both Cell and f64 banks (AMD64 m.4c.1 admits Cell+I64 only; R14 shared)",
@@ -368,9 +371,21 @@ func checkCellBankAdmissibleAMD64(fn *vm3.Function, opts Options) error {
 			vm3.OpJump,
 			vm3.OpReturnI64, vm3.OpReturnConstK, vm3.OpReturnCell,
 			vm3.OpPairFst, vm3.OpPairSnd, vm3.OpNewPair,
-			vm3.OpListGetI64, vm3.OpListSetI64,
+			vm3.OpListGetI64, vm3.OpListSetI64, vm3.OpListPushI64,
 			vm3.OpLookupI64KW:
 			continue
+		case vm3.OpNewList:
+			// Phase 6.3.4.n.2.c: admit at pc=0 when the lowerer can skip
+			// emission (jitCall pre-allocates the list). Inline OpNewList
+			// outside the pre-alloc prefix routes back to the interpreter.
+			if i == 0 && canPreAllocList(fn) {
+				continue
+			}
+			if k := int(preAllocListPrefix(fn)); k > 0 && i < k {
+				continue
+			}
+			return fmt.Errorf("%w: %s pc %d Cell-bank fn uses inline OpNewList (only pre-alloc prefix is admitted on AMD64)",
+				ErrNotImplemented, fn.Name, i)
 		case vm3.OpCallMixed:
 			idx := int(uint16(op.C))
 			isSelf := opts.SelfIdx >= 0 && idx == opts.SelfIdx

--- a/runtime/jit/vm3jit/list_get_amd64_test.go
+++ b/runtime/jit/vm3jit/list_get_amd64_test.go
@@ -40,7 +40,7 @@ func TestListGetI64AMD64(t *testing.T) {
 		ParamBanks:  []vm3.Bank{vm3.BankI64},
 		ResultBank:  vm3.BankI64,
 		Code: []vm3.Op{
-			vm3.MakeOp(vm3.OpNewList, 0, 0, 0),                                       // pc=0: regsCell[0] = []
+			vm3.MakeOp(vm3.OpNewList, 0, 0, 8),                                       // pc=0: regsCell[0] = make([]Cell, 0, 8)
 			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 10),                                    // pc=1: regsI64[1] = 10
 			vm3.MakeOp(vm3.OpListPushI64, 0, 1, 0),                                   // pc=2: list.push(10)
 			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 20),                                    // pc=3: regsI64[1] = 20

--- a/runtime/jit/vm3jit/list_push_amd64_test.go
+++ b/runtime/jit/vm3jit/list_push_amd64_test.go
@@ -1,0 +1,191 @@
+//go:build amd64
+
+package vm3jit_test
+
+import (
+	"testing"
+
+	"mochi/runtime/jit/vm3jit"
+	"mochi/runtime/vm3"
+)
+
+// TestListPushI64AMD64 exercises Phase 6.3.4.n.2.c: AMD64 OpListPushI64
+// lowering on a cell-bank fn. The driver runs in the interpreter and
+// builds a list with cap=8 (room for 3 pushes without growing). The
+// helper is JIT'd cell-bank: it pushes 11, 22, 33 to the list, then
+// reads cells[2] back via OpListGetI64 and returns it. A drift in any
+// of the SIB store base/index choices, the tag-overwrite offset, the
+// cap-cmp polarity, or the len-bump bytes would surface here as a
+// wrong return or a segfault.
+func TestListPushI64AMD64(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_list_push_then_get",
+		NumRegsI64:  2,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 11), // pc=0: regsI64[0] = 11
+			vm3.MakeOp(vm3.OpListPushI64, 0, 0, 0), // pc=1: list.push(11)
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 22), // pc=2: regsI64[0] = 22
+			vm3.MakeOp(vm3.OpListPushI64, 0, 0, 0), // pc=3: list.push(22)
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 33), // pc=4: regsI64[0] = 33
+			vm3.MakeOp(vm3.OpListPushI64, 0, 0, 0), // pc=5: list.push(33)
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 2),  // pc=6: regsI64[0] = 2 (idx)
+			vm3.MakeOp(vm3.OpListGetI64, 1, 0, 0), // pc=7: regsI64[1] = list[2]
+			vm3.MakeOp(vm3.OpReturnI64, 1, 0, 0),  // pc=8: return regsI64[1]
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewList, 0, 0, 8),                                       // pc=0: regsCell[0] = make([]Cell, 0, 8)
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1}, // pc=1: regsI64[0] = helper(regsCell[0])
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),                                     // pc=2: return regsI64[0]
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; AMD64 cell-bank n.2.c should admit OpListPushI64")
+	}
+	preDeopt := vm3jit.DeoptCount
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if d := vm3jit.DeoptCount - preDeopt; d != 0 {
+		t.Fatalf("unexpected deopt count delta: %d (helper had cap=8 room for 3 pushes)", d)
+	}
+	if got.Int() != 33 {
+		t.Fatalf("got %d, want 33 (list[2] after pushing 11,22,33)", got.Int())
+	}
+}
+
+// TestListPushI64AMD64NegativePayload guards the SIB-store + tag-overwrite
+// pair against a high-bit drop. Storing -7 must read back as -7 via the
+// OpListGetI64 sign-extend pair. The push-tag trick relies on the fact
+// that bytes 0..5 of the stored 8-byte xVal already hold the signed
+// low-48 payload (two's complement of -7 = 0xFFFF_FFFF_FFFF_FFF9, so
+// bytes 0..5 are FF FF FF FF FF FF and the tag overwrite at offset 6
+// makes bytes 6..7 = FA FF, producing 0xFFFA_FFFF_FFFF_FFF9). The read
+// back via OpListGetI64 reverses with shl/sar by 16 and yields -7.
+func TestListPushI64AMD64NegativePayload(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_list_push_neg",
+		NumRegsI64:  2,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, -7),  // pc=0: regsI64[0] = -7
+			vm3.MakeOp(vm3.OpListPushI64, 0, 0, 0), // pc=1: list.push(-7)
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 0),   // pc=2: regsI64[0] = 0 (idx)
+			vm3.MakeOp(vm3.OpListGetI64, 1, 0, 0),  // pc=3: regsI64[1] = list[0]
+			vm3.MakeOp(vm3.OpReturnI64, 1, 0, 0),   // pc=4: return regsI64[1]
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewList, 0, 0, 4),                                       // pc=0: regsCell[0] = make([]Cell, 0, 4)
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1}, // pc=1: regsI64[0] = helper(regsCell[0])
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),                                     // pc=2: return regsI64[0]
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; AMD64 cell-bank n.2.c should admit OpListPushI64")
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if got.Int() != -7 {
+		t.Fatalf("got %d, want -7 (push/get round-trip of negative payload)", got.Int())
+	}
+}
+
+// TestListPushI64AMD64Grow forces the StatusListGrow deopt: the helper
+// is JIT-compiled but the driver passes a list with cap=2 and the
+// helper tries to push 3 items. The third push must observe cap == len,
+// branch to the StatusListGrow block, and let jitCall regrow the slab
+// and resume in the interpreter. Round-trip sum across all three
+// pushes is checked.
+func TestListPushI64AMD64Grow(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_list_push_grow",
+		NumRegsI64:  2,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 100), // pc=0: regsI64[0] = 100
+			vm3.MakeOp(vm3.OpListPushI64, 0, 0, 0), // pc=1: list.push(100)
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 200), // pc=2: regsI64[0] = 200
+			vm3.MakeOp(vm3.OpListPushI64, 0, 0, 0), // pc=3: list.push(200) — cap reached
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 300), // pc=4: regsI64[0] = 300
+			vm3.MakeOp(vm3.OpListPushI64, 0, 0, 0), // pc=5: list.push(300) — triggers grow
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 2),   // pc=6: regsI64[0] = 2 (idx)
+			vm3.MakeOp(vm3.OpListGetI64, 1, 0, 0),  // pc=7: regsI64[1] = list[2]
+			vm3.MakeOp(vm3.OpReturnI64, 1, 0, 0),   // pc=8: return regsI64[1]
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewList, 0, 0, 2),                                       // pc=0: regsCell[0] = make([]Cell, 0, 2)
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1}, // pc=1: regsI64[0] = helper(regsCell[0])
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),                                     // pc=2: return regsI64[0]
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; AMD64 cell-bank n.2.c should admit OpListPushI64")
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if got.Int() != 300 {
+		t.Fatalf("got %d, want 300 (list[2] after pushes 100,200,300 with grow-deopt)", got.Int())
+	}
+}

--- a/runtime/jit/vm3jit/list_set_amd64_test.go
+++ b/runtime/jit/vm3jit/list_set_amd64_test.go
@@ -38,7 +38,7 @@ func TestListSetI64AMD64(t *testing.T) {
 		ParamBanks:  []vm3.Bank{vm3.BankI64},
 		ResultBank:  vm3.BankI64,
 		Code: []vm3.Op{
-			vm3.MakeOp(vm3.OpNewList, 0, 0, 0),                                       // pc=0: regsCell[0] = []
+			vm3.MakeOp(vm3.OpNewList, 0, 0, 8),                                       // pc=0: regsCell[0] = make([]Cell, 0, 8)
 			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 10),                                    // pc=1: regsI64[1] = 10
 			vm3.MakeOp(vm3.OpListPushI64, 0, 1, 0),                                   // pc=2: list.push(10)
 			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 20),                                    // pc=3: regsI64[1] = 20

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -596,6 +596,9 @@ func deoptStatusesUsedAMD64(fn *vm3.Function) []int64 {
 	if hasRegRegDivModAMD64(fn) {
 		s = append(s, StatusDivByZero)
 	}
+	if hasListPushI64(fn) {
+		s = append(s, StatusListGrow)
+	}
 	if hasNewPair(fn) {
 		s = append(s, StatusPairGrow)
 	}
@@ -806,6 +809,38 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		//   or   %rcx, %rdx               ; rdx = tagged payload       (3B)
 		//   mov  %rdx, [%rax + xIdx*8]    ; cells[regsI64[C]] = packed (4B)
 		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + 7 + 3 + 4 + 4 + 10 + 3 + 4, nil
+
+	case vm3.OpListPushI64:
+		// Phase 6.3.4.n.2.c cold form, AMD64 mirror of the ARM64
+		// OpListPushI64 (no hoist):
+		//   mov  disp32(%rbp), %eax        ; idx = low 32 of regsCell[A] (6B)
+		//   imul $stride, %rax, %rax       ; rax = idx*sizeof(vmList)    (7B)
+		//   mov  listsBaseOff(%r14), %rcx  ; rcx = arenas.Lists base    (7B)
+		//   add  %rcx, %rax                ; rax = &arenas.Lists[idx]  (3B)
+		//   mov  cellsLenOff(%rax), %rcx   ; rcx = cells.len           (7B)
+		//   mov  cellsCapOff(%rax), %rdx   ; rdx = cells.cap           (7B)
+		//   cmp  %rdx, %rcx                ; flags = len - cap         (3B)
+		//   jae  deopt_listgrow            ; len >= cap → deopt        (6B)
+		//   mov  cellsOff(%rax), %rdx      ; rdx = cells.ptr           (7B)
+		//   mov  xVal, [%rdx + %rcx*8]     ; cells[len] = raw xVal     (4B)
+		//   movw $0xFFFA, 6(%rdx,%rcx,8)   ; overwrite tag bytes 6,7   (7B)
+		//   inc  %rcx                      ; len++                     (3B)
+		//   mov  %rcx, cellsLenOff(%rax)   ; commit cells.len          (7B)
+		//   mov  %ecx, 4(%rax)             ; commit vmList.len (u32)   (3B)
+		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + 7 + 7 + 3 + 6 + 7 + 4 + 7 + 3 + 7 + 3, nil
+
+	case vm3.OpNewList:
+		// Phase 6.3.4.n.2.c: when fn.JITPreAllocList is set the JIT skips
+		// fn.Code[0]'s OpNewList entirely; jitCall (Go side) writes the
+		// pre-allocated list handle into jf.regsCell[A] before the
+		// trampoline call. Same skip rule for the contiguous K-prefix.
+		if idx == 0 && fn.JITPreAllocList {
+			return 0, nil
+		}
+		if idx < int(fn.JITPreAllocListPrefix) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("%w: opcode %d (inline NewList unsupported)", ErrNotImplemented, op.Code)
 
 	case vm3.OpConstF64K:
 		idx := int(uint16(op.C))
@@ -1244,6 +1279,64 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		out = append(out, mov64StoreIdxLsl3(xRDX, xRAX, xIdx)...)
 		return out, nil
 
+	case vm3.OpListPushI64:
+		// Phase 6.3.4.n.2.c: arenas.Lists[handleIdx(regsCell[A])] appends
+		// CInt(regsI64[B]) when cells.len < cells.cap; otherwise raises
+		// StatusListGrow and the interpreter regrows + retries via jitCall.
+		//
+		// Cold form (no slab/cells.ptr/cells.cap pin). RAX holds the slab
+		// address through the whole op; RCX is reused first as listsBase
+		// scratch, then as cells.len (live until step 13/14), and RDX as
+		// cells.cap then cells.ptr (live for the SIB store and the tag
+		// overwrite). xVal is a pinned r2xAMD64 register (slot 0..7 only).
+		//
+		// The packed-Cell store exploits the layout: byte 0..5 of the
+		// stored 8-byte xVal hold the low-48 payload (negative values are
+		// represented in two's complement so bits 0..47 already encode the
+		// signed payload), and the 16-bit immediate write at offset 6
+		// overwrites bytes 6..7 with the 0xFFFA Int48 tag in one shot. No
+		// fourth scratch is needed; the read-back via OpListGetI64 reverses
+		// the sign-extend pair (shl/sar by 16) and recovers the original
+		// i64 across the full int48 range.
+		stride := int64(vm3.JITListSlabStride())
+		cellsOff := int32(vm3.JITListCellsOffset())
+		cellsLenOff := cellsOff + 8
+		cellsCapOff := cellsOff + 16
+		listsBaseOff := int32(jitArenaCtxListsBaseOff())
+		xVal := r2xAMD64(op.B)
+		lgStart := deoptStartForStatusAMD64(fn, deoptStart, StatusListGrow)
+		out := mov32LoadDisp32(xRAX, xRBP, int32(op.A)*8)
+		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
+		out = append(out, mov64LoadDisp32(xRCX, xR14, listsBaseOff)...)
+		out = append(out, add64RR(xRCX, xRAX)...)
+		out = append(out, mov64LoadDisp32(xRCX, xRAX, cellsLenOff)...)
+		out = append(out, mov64LoadDisp32(xRDX, xRAX, cellsCapOff)...)
+		out = append(out, cmp64RR(xRDX, xRCX)...) // flags = rcx - rdx = len - cap
+		afterJae := pcMap[idx] + len(out) + 6
+		out = append(out, jccRel32(ccAE, int32(lgStart-afterJae))...)
+		out = append(out, mov64LoadDisp32(xRDX, xRAX, cellsOff)...)
+		out = append(out, mov64StoreIdxLsl3(xVal, xRDX, xRCX)...)
+		out = append(out, mov16ImmStoreSIBDisp8(0xFFFA, xRDX, xRCX, 6)...)
+		out = append(out, inc64R(xRCX)...)
+		out = append(out, mov64StoreDisp32(xRCX, xRAX, cellsLenOff)...)
+		out = append(out, mov32StoreDisp8(xRCX, xRAX, 4)...)
+		return out, nil
+
+	case vm3.OpNewList:
+		// Phase 6.3.4.n.2.c: when fn.JITPreAllocList is set the JIT skips
+		// fn.Code[0]'s OpNewList entirely; jitCall (Go side) writes the
+		// pre-allocated list handle into jf.regsCell[A] before the
+		// trampoline. Inline OpNewList outside the pre-alloc prefix is
+		// still out of scope on AMD64 (would need an inline arena-alloc
+		// kernel) and the admission gate rejects it.
+		if idx == 0 && fn.JITPreAllocList {
+			return []byte{}, nil
+		}
+		if idx < int(fn.JITPreAllocListPrefix) {
+			return []byte{}, nil
+		}
+		return nil, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
+
 	case vm3.OpConstF64K:
 		bits := int64(uint64(fn.Consts[int(uint16(op.C))]))
 		out := movImm64(xRCX, bits)
@@ -1582,6 +1675,7 @@ const (
 	ccZ  = 0x4 // JZ / JE: equal
 	ccNZ = 0x5 // JNZ / JNE
 	ccAE = 0x3 // JAE: unsigned >= (CF=0)
+	ccBE = 0x6 // JBE: unsigned <= (CF=1 OR ZF=1)
 	ccL  = 0xC // JL: signed less
 	ccGE = 0xD // JGE: signed greater-equal
 	ccLE = 0xE // JLE
@@ -1921,6 +2015,61 @@ func mov64StoreDisp32(src, base int, disp int32) []byte {
 	out := []byte{rex(true, src >= 8, false, base >= 8), 0x89, modRM(2, byte(src), byte(base))}
 	out = appendImm32(out, disp)
 	return out
+}
+
+// mov32StoreDisp8 emits `mov %eSrc, disp8(rBase)`, a 32-bit reg-to-mem
+// store with an 8-bit signed displacement. Opcode 89 /r with mod=01
+// disp8. No REX is emitted when neither register needs the high bit.
+// Used by Phase 6.3.4.n.2.c to write vmList.len (a u32 at byte offset
+// 4 of the slab) as a side-effect of OpListPushI64. 3 bytes when
+// neither reg needs REX, 4 bytes otherwise. Caller pre-checks that
+// rBase is not RSP/R12 (would require a SIB byte) and not RBP/R13 in
+// mod=00, which is moot here since mod=01 forces a disp8.
+func mov32StoreDisp8(src, base int, disp int8) []byte {
+	var out []byte
+	if src >= 8 || base >= 8 {
+		var r byte = 0x40
+		if src >= 8 {
+			r |= 0x04 // REX.R
+		}
+		if base >= 8 {
+			r |= 0x01 // REX.B
+		}
+		out = append(out, r)
+	}
+	out = append(out, 0x89, modRM(1, byte(src&7), byte(base&7)), byte(disp))
+	return out
+}
+
+// mov16ImmStoreSIBDisp8 emits `movw $imm16, disp8(rBase, rIdx, 8)`, a
+// 16-bit immediate store at the address `rBase + rIdx*8 + disp8`.
+// Encoding: 66 (operand-size prefix) C7 /0 with mod=01, rm=100 (SIB
+// follows), SIB(scale=11, index=rIdx, base=rBase), disp8, imm16. Phase
+// 6.3.4.n.2.c uses this to overwrite the top 16 bits of a just-stored
+// 8-byte Cell with the Int48 tag (0xFFFA) at byte offset 6 of the
+// slot, packing the 48-bit payload with the tag in a single 7-byte
+// instruction. Caller pre-checks rIdx != RSP and rBase != RBP/R13
+// w/ mod=00 (here mod=01 so the [disp32]-quirk does not apply, but
+// rBase=RBP would still need a different SIB encoding; we only call
+// this with rBase=RDX). 7 bytes when neither reg needs REX, 8 bytes
+// otherwise.
+func mov16ImmStoreSIBDisp8(imm uint16, base, idx int, disp int8) []byte {
+	var out []byte
+	if base >= 8 || idx >= 8 {
+		var r byte = 0x40
+		if idx >= 8 {
+			r |= 0x02 // REX.X
+		}
+		if base >= 8 {
+			r |= 0x01 // REX.B
+		}
+		out = append(out, r)
+	}
+	sib := byte(3<<6) | byte((idx&7)<<3) | byte(base&7)
+	out = append(out, 0x66, 0xC7, modRM(1, 0, 4), sib, byte(disp))
+	var b [2]byte
+	binary.LittleEndian.PutUint16(b[:], imm)
+	return append(out, b[:]...)
 }
 
 // movMemImm32R15Indirect emits `movq $imm32, (%r15)` (sign-extended).

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2894,6 +2894,42 @@ The pack uses `shl 16 ; shr 16 (logical)` rather than `shl 16 ; sar 16` precisel
 
 Both pass on server2 (linux/amd64, AMD EPYC). The full vm3jit suite re-bench shows no regressions vs the n.2.a baseline; the pre-existing `TestNsieveJITCompiles` failure is unchanged (still blocked on `OpListPushI64` / `OpNewList` which n.2.c will admit). No bench is run at this sub-phase because nsieve and fannkuch_redux still fall back to interp at admission time.
 
+#### Phase 6.3.4.n.2.c: AMD64 `OpListPushI64` + `OpNewList` cell-bank lowering (2026-05-20 09:33 GMT+7)
+
+**Scope.** Closes the AMD64 cell-bank Phase 6.3.4.n.2 trio. n.2.a admitted reads, n.2.b admitted indexed writes, n.2.c admits `OpListPushI64` (the only remaining list-mutating op on the nsieve / fannkuch_redux hot paths) and `OpNewList` (skipped at emit time when the slot is pre-allocated by `jitCall`, mirroring the ARM64 path). After this phase the AMD64 cell-bank whitelist matches the ARM64 cell-bank whitelist for the int48-list portion of the BG suite; nsieve and fannkuch_redux become JIT-admissible on linux/amd64 modulo their own admission gates outside the list ops.
+
+**Mechanism.** The cold form is a 14-instruction sequence that exploits a clever 8-byte SIB store + 16-bit immediate overwrite at byte 6 to pack the Int48 tag without a 4th scratch register:
+
+```
+mov  disp32(%rbp), %eax       ; idx = low 32 of regsCell[A]
+imul $stride, %rax, %rax      ; rax = idx * sizeof(vmList)
+mov  listsBaseOff(%r14), %rcx ; rcx = arenas.Lists base
+add  %rcx, %rax               ; rax = &arenas.Lists[idx]
+mov  cellsLenOff(%rax), %rcx  ; rcx = cells.len
+mov  cellsCapOff(%rax), %rdx  ; rdx = cells.cap
+cmp  %rdx, %rcx               ; flags = rcx - rdx (len - cap)
+jae  deopt_listgrow           ; if len >= cap: StatusListGrow deopt
+mov  cellsOff(%rax), %rdx     ; rdx = cells.ptr
+mov  xVal, (%rdx, %rcx, 8)    ; cells[len] = raw 8 bytes of xVal (low 6 = signed low-48 payload)
+movw $0xFFFA, 6(%rdx, %rcx, 8) ; overwrite bytes 6..7 with Int48 tag
+inc  %rcx                      ; rcx = len + 1
+mov  %rcx, cellsLenOff(%rax)   ; cells.len = rcx
+mov  %ecx, 4(%rax)             ; vmList.len (u32 at byte 4) = rcx
+```
+
+The clever bit is the tag-overwrite trick. Two's complement encoding means bytes 0..5 of `xVal` already hold the signed low-48 bits of the value (a -7 stored as `0xFFFF_FFFF_FFFF_FFF9` has bytes 0..5 = `F9 FF FF FF FF FF`, which is exactly what we want as the low-48 payload). Storing the raw 8 bytes via SIB, then overwriting just bytes 6..7 with the `0xFFFA` tag, produces the canonical Int48 boxed Cell in two instructions and uses only the existing RAX/RCX/RDX scratch trio (RDX holds `cells.ptr`; RCX holds `len` and doubles as the SIB index because RCX is not RSP). The cap-check polarity is `cmp %rdx, %rcx` (src=cap, dst=len) so flags are set from `len - cap`, and `jae` branches when `len >= cap`. When the deopt fires, the new `StatusListGrow` slot in `deoptStatusesUsedAMD64` writes the status word, the trampoline rolls forward, and `jitCall` regrows the slab + retries via the existing infrastructure landed in step 2.F.
+
+`OpNewList` itself emits zero bytes when the slot is pre-allocated by `jitCall` (the standard `canPreAllocList` / `preAllocListPrefix` pattern from ARM64 step 2.A). Any non-prefix `OpNewList` still rejects with `ErrNotImplemented`, so cell-bank fns that allocate lists mid-body fall back to interp; the trio's win is the pre-alloc'd loop case, which is what nsieve and fannkuch_redux need.
+
+**Why this is generic, not a kernel-targeted super-op.** `OpListPushI64` is the universal int48 list append, used by every cell-bank kernel that grows a list. The cold form, the cap-check, and the deopt block are all opcode-level lowering, not nsieve- or fannkuch-specific fused ops. Any future Cell-bank kernel on AMD64 that pushes int48 values to a list automatically becomes JIT-eligible after this phase. The pre-alloc `OpNewList` skip is the same generic mechanism already shipped on ARM64.
+
+**Tests.** Three new synthetic tests in `runtime/jit/vm3jit/list_push_amd64_test.go` (build-tagged `//go:build amd64`), plus a `capHint=0 -> 8` bump in the existing n.2.a / n.2.b drivers (their drivers became JIT-admissible after n.2.c, and `capHint=0` would surface the StatusListGrow deopt as an unwanted delta against their zero-deopt assertion):
+- `TestListPushI64AMD64`: helper pushes 11, 22, 33 then reads `list[2]`; verifies the SIB store + tag-overwrite + len-bump round-trip with no deopt.
+- `TestListPushI64AMD64NegativePayload`: pushes -7 and reads it back; guards the tag-overwrite trick against any high-bit leak (a wrong store would produce `0x0000FFFF_FFFFFFF9` or similar non-canonical bit patterns that decode wrongly).
+- `TestListPushI64AMD64Grow`: driver passes `cap=2`, helper pushes 3 items; verifies the StatusListGrow deopt fires, `jitCall` regrows the slab, and the helper resumes in interp with the correct final state.
+
+All seven vm3jit list-{get,set,push} AMD64 tests pass on server2 (linux/amd64, AMD EPYC). The full vm3jit suite re-bench shows no regressions vs the n.2.b baseline. Bench numbers for nsieve and fannkuch_redux land in the follow-up sub-phase n.2.d (the JIT-admission of the kernel entry points is what unlocks the bench; this sub-phase only adds the opcode coverage).
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
Closes #21842.

Adds AMD64 cell-bank lowering for `OpListPushI64` and the standard `OpNewList` pre-alloc skip, completing the Phase 6.3.4.n.2 trio on linux/amd64 (n.2.a admitted reads, n.2.b admitted indexed writes).

## Summary

- 14-instruction cold form for `OpListPushI64`: `&arenas.Lists[idx]` -> cap-check -> SIB-store raw 8 bytes of `xVal` -> `movw \$0xFFFA, 6(%rdx, %rcx, 8)` tag overwrite -> len bump. The tag-overwrite trick relies on two's complement so bytes 0..5 of the stored 8 bytes already hold the signed low-48 payload; only bytes 6..7 need rewriting.
- New `StatusListGrow` deopt slot in `deoptStatusesUsedAMD64`. `len >= cap` deopts and `jitCall` regrows + retries via the existing step 2.F infrastructure.
- `OpNewList` emits zero bytes when the slot is pre-allocated by `jitCall` (standard `canPreAllocList` / `preAllocListPrefix` pattern from ARM64 step 2.A); non-prefix `OpNewList` still rejects with `ErrNotImplemented`.
- Admission gate update so cell-bank fns with these ops become JIT-eligible on AMD64.
- `capHint=0 -> 8` bump in existing n.2.a / n.2.b drivers because their drivers became JIT-admissible after this PR and would otherwise surface `StatusListGrow` as an unwanted deopt delta against their zero-deopt assertion.

## Why this is generic

`OpListPushI64` is the universal int48 list append. The cold form, the cap-check, and the deopt block are all opcode-level lowering, not nsieve- or fannkuch-specific super-ops. Any future Cell-bank kernel on AMD64 that pushes int48 values to a list becomes JIT-eligible automatically.

## Tests

Three new synthetic tests in `runtime/jit/vm3jit/list_push_amd64_test.go`:
- `TestListPushI64AMD64`: pushes 11/22/33, reads `list[2]`, expects 33, zero deopt.
- `TestListPushI64AMD64NegativePayload`: pushes -7 and round-trips via `OpListGetI64`; guards the tag-overwrite trick against high-bit leaks.
- `TestListPushI64AMD64Grow`: forces `StatusListGrow` deopt with `cap=2` + 3 pushes; verifies regrow-and-retry.

All seven vm3jit list-{get,set,push} AMD64 tests pass on server2 (linux/amd64, AMD EPYC). Full vm3jit suite shows no regressions.

## Test plan
- [x] `go test ./runtime/jit/vm3jit/ -run 'TestListGetI64AMD64|TestListSetI64AMD64|TestListPushI64AMD64' -v` on server2 (all PASS)
- [x] `go test ./runtime/jit/vm3jit/` full suite on server2 (PASS)
- [x] Local darwin/arm64 build still green (lowering is build-tagged amd64; no ARM64 changes)
- [x] MEP-40 spec §6.3.4.n.2.c updated with timestamp

Bench nsieve / fannkuch_redux defers to the n.2.d sub-phase.