### PR TITLE
mep-0040: phase 6.3.4.n.2.d nsieve + fannkuch_redux server2 bench

### DIFF
--- a/compiler3/corpus/corpus_test.go
+++ b/compiler3/corpus/corpus_test.go
@@ -156,6 +156,8 @@ func BenchmarkGoKernels(b *testing.B) {
 		{"lists_fill_sum_n128", c2corpus.ExpectListsFillSum, 128},
 		{"nsieve_n1000", c2corpus.ExpectNsieve, 1000},
 		{"nsieve_n10000", c2corpus.ExpectNsieve, 10000},
+		{"fannkuch_redux_n1000", c2corpus.ExpectFannkuchRedux, 1000},
+		{"fannkuch_redux_n10000", c2corpus.ExpectFannkuchRedux, 10000},
 		{"fasta_n10000", c2corpus.ExpectFasta, 10000},
 		{"fasta_n100000", c2corpus.ExpectFasta, 100000},
 		{"mandelbrot_n100", c2corpus.ExpectMandelbrot, 100},

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2930,6 +2930,29 @@ The clever bit is the tag-overwrite trick. Two's complement encoding means bytes
 
 All seven vm3jit list-{get,set,push} AMD64 tests pass on server2 (linux/amd64, AMD EPYC). The full vm3jit suite re-bench shows no regressions vs the n.2.b baseline. Bench numbers for nsieve and fannkuch_redux land in the follow-up sub-phase n.2.d (the JIT-admission of the kernel entry points is what unlocks the bench; this sub-phase only adds the opcode coverage).
 
+#### Phase 6.3.4.n.2.d: bench nsieve + fannkuch_redux on server2 (2026-05-20 09:47 GMT+7)
+
+**Scope.** Measure the end-to-end vm3jit-vs-Go ratio for nsieve and fannkuch_redux on linux/amd64 (server2, AMD EPYC) after n.2.c admitted `OpListPushI64` / `OpNewList` on the AMD64 cell-bank backend. Also add the missing `fannkuch_redux_n{1000,10000}` entries to `BenchmarkGoKernels` in `compiler3/corpus/corpus_test.go` so the JIT-side bench in `runtime/jit/vm3jit/bench_corpus_jit_test.go` has a paired Go reference (it has had fannkuch entries for a while; the Go side didn't).
+
+**Measured results (linux/amd64, AMD EPYC, `-benchtime=2s -count=5`, median of 5 ns/op).**
+
+| kernel | Go ns/op | vm3jit ns/op | ratio | gate |
+| --- | --- | --- | --- | --- |
+| `nsieve_n1000` | 8500 | 7451 | **0.88x** | under 2x |
+| `nsieve_n10000` | 84873 | 116115 | **1.37x** | under 2x |
+| `fannkuch_redux_n1000` | 61494 | 1325087 | **21.5x** | interp floor |
+| `fannkuch_redux_n10000` | 538613 | 17725993 | **32.9x** | interp floor |
+
+**Nsieve result.** Both nsieve points are under the 2x-of-Go gate. At n=1000 the JIT is actually faster than Go (0.88x), driven by the very tight inline form of the sieve inner loop. At n=10000 the ratio widens to 1.37x because the larger sieve buffer exposes the per-iteration `OpListGetI64` / `OpListSetI64` overhead that Go's L1-resident sieve array does not pay; still well under the gate.
+
+**Fannkuch_redux result is an interp floor, not a JIT closure.** `corpus.FannkuchRedux` has `NumRegsI64=10` (it needs 10 simultaneously live i64 values: n_in / k / total / lo / hi / head / flips / tmp_a / zero_idx / swap_b), but the AMD64 cell-bank backend caps at `NumRegsI64 ≤ 8` because R14 and RBP are repurposed for `*jitArenaCtx` and `regsCell` respectively (slots 8 and 9 of `r2xAMD64` map to those two registers). So even after n.2.c admitted the list ops, fannkuch_redux fails the AMD64 cell-bank admission gate and falls back to interp; the 21-33x ratios are the pure-interp floor.
+
+This was verified by probing JITCode on `corpus.FannkuchRedux.Build(100)`: the single function reports `I64=10 Cell=1 JIT=false`. Nsieve does not hit this gate (it fits within the 8-reg cap), which is why it closes cleanly.
+
+**Why the trio's scope is still correct.** The opcode coverage that n.2.a/b/c shipped is what nsieve needed and what *any future* cell-bank fn with NumRegsI64 ≤ 8 needs. The fannkuch_redux block is a separate, generic register-pressure issue, not a missing opcode. The right fix is one of: (1) squeeze the fannkuch kernel to NumRegsI64 ≤ 8 via opcode-level rewrites (e.g. fold `zero_idx` into a constant-index variant of `OpListGetI64K` if that op is added, or merge non-overlapping live ranges), or (2) raise the AMD64 cell-bank i64 cap by spilling slots ≥ 8 to stack on entry. Option (2) is the generic mechanism, since it also unblocks any other future cell-bank kernel that needs more i64 slots than the current 8.
+
+**Follow-up:** open Phase 6.3.4.n.2.e to either squeeze fannkuch_redux into the 8-reg cap or to lift the cap via stack-spill in the cell-bank entry path. The bench results in this section are the honest pre-fix floor.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
Closes #21844.

Bench-only sub-phase that records the linux/amd64 (server2, AMD EPYC) ratio after n.2.c admitted the AMD64 cell-bank list ops, plus adds the missing \`fannkuch_redux\` entries to \`BenchmarkGoKernels\` so the Go side has a paired reference for the JIT side.

## Summary

| kernel | Go ns/op | vm3jit ns/op | ratio |
| --- | --- | --- | --- |
| \`nsieve_n1000\` | 8500 | 7451 | **0.88x** |
| \`nsieve_n10000\` | 84873 | 116115 | **1.37x** |
| \`fannkuch_redux_n1000\` | 61494 | 1325087 | **21.5x** |
| \`fannkuch_redux_n10000\` | 538613 | 17725993 | **32.9x** |

- nsieve closes cleanly under 2x of Go on both n points; at n=1000 the JIT is actually faster than Go.
- fannkuch_redux is an interp floor: \`NumRegsI64=10\` exceeds the AMD64 cell-bank cap of 8 (R14/RBP repurposed for \`*jitArenaCtx\` and \`regsCell\`), so the kernel falls back to interp even after n.2.c admitted the list ops. Probed via \`JITCode != nil\` on \`corpus.FannkuchRedux.Build(100)\`.

The MEP-40 spec entry honestly records the gap. Follow-up is phase 6.3.4.n.2.e: either squeeze fannkuch to \`NumRegsI64 <= 8\` or lift the AMD64 cell-bank cap via stack-spill (the generic mechanism).

## Test plan
- [x] \`go test -bench 'BenchmarkGoKernels$/(nsieve|fannkuch_redux)' -benchtime=2s -count=5 ./compiler3/corpus/\` on server2
- [x] \`go test -bench 'BenchmarkCorpusJITRunner/(nsieve|fannkuch_redux)' -benchtime=2s -count=5 ./runtime/jit/vm3jit/\` on server2
- [x] MEP-40 §6.3.4.n.2.d records both medians and the interp-floor finding