### PR TITLE
MEP-40 Phase 6.3.4.n.2.e: close fannkuch_redux via OpListGetI64K

### DIFF
--- a/compiler3/corpus/fannkuch_redux.go
+++ b/compiler3/corpus/fannkuch_redux.go
@@ -52,12 +52,23 @@ func ExpectFannkuchRedux(n int64) int64 {
 // the kernel uses only `OpListGetI64`/`OpListSetI64` so the JIT
 // classifies the slab as `slabKindList`, matching nsieve's admit path.
 //
-// Register banks (NumRegsI64=10, NumRegsCell=1):
+// Register banks (NumRegsI64=8, NumRegsCell=1):
 //
-//	I64: 0 n_in, 1 k, 2 total, 3 i_or_lo, 4 hi, 5 head, 6 flips,
-//	     7 tmp_a, 8 zero_idx (const 0 for perm[0] reads + push payload),
-//	     9 swap_b
+//	I64: 0 n_in, 1 k, 2 total, 3 i_or_lo, 4 hi,
+//	     5 head_or_swap_b, 6 flips,
+//	     7 tmp_a (also pre-loaded with 0 to source the init-prefix pushes)
 //	Cell: 0 perm
+//
+// Phase 6.3.4.n.2.e squeeze: slot 5 holds `head` from pc=21 through
+// pc=24 (where `hi = head - 1` is the last read) and is then reused as
+// `swap_b` inside rev_loop (pc=27 writes it, pc=28 reads it). The two
+// live ranges are disjoint. The constant-0 `zero_idx` slot is gone:
+// perm[0] reads at pc=21 and pc=33 use `OpListGetI64K` (idx baked as
+// imm), and the init pushes (pc=3..9) read 0 from slot 7 because pc=1
+// seeds it (and the init_loop later overwrites slot 7 with the rotated
+// element value at pc=14..17). NumRegsI64=8 fits the AMD64 cell-bank
+// admission cap (R14/RBP are repurposed as arenaCtx / regsCell base,
+// effective cap = 8).
 //
 // PC map (40 ops):
 //
@@ -82,22 +93,22 @@ var FannkuchRedux = &Program{
 	Build: func(_ int64) *vm3.Program {
 		fn := &vm3.Function{
 			Name:        "fannkuch_redux",
-			NumRegsI64:  10,
+			NumRegsI64:  8,
 			NumRegsF64:  0,
 			NumRegsCell: 1,
 			ParamBanks:  []vm3.Bank{vm3.BankI64},
 			ResultBank:  vm3.BankI64,
 			Code: []vm3.Op{
 				vm3.MakeOp(vm3.OpNewList, 0, 0, 0),     // pc=0: perm = NewList
-				vm3.MakeOp(vm3.OpConstI64K, 8, 0, 0),   // pc=1: zero_idx = 0
+				vm3.MakeOp(vm3.OpConstI64K, 7, 0, 0),   // pc=1: tmp_a = 0 (zero source for pc=3..9)
 				vm3.MakeOp(vm3.OpConstI64K, 2, 0, 0),   // pc=2: total = 0
-				vm3.MakeOp(vm3.OpListPushI64, 0, 8, 0), // pc=3..9: push 7 zeros
-				vm3.MakeOp(vm3.OpListPushI64, 0, 8, 0),
-				vm3.MakeOp(vm3.OpListPushI64, 0, 8, 0),
-				vm3.MakeOp(vm3.OpListPushI64, 0, 8, 0),
-				vm3.MakeOp(vm3.OpListPushI64, 0, 8, 0),
-				vm3.MakeOp(vm3.OpListPushI64, 0, 8, 0),
-				vm3.MakeOp(vm3.OpListPushI64, 0, 8, 0),
+				vm3.MakeOp(vm3.OpListPushI64, 0, 7, 0), // pc=3..9: push 7 zeros (from tmp_a)
+				vm3.MakeOp(vm3.OpListPushI64, 0, 7, 0),
+				vm3.MakeOp(vm3.OpListPushI64, 0, 7, 0),
+				vm3.MakeOp(vm3.OpListPushI64, 0, 7, 0),
+				vm3.MakeOp(vm3.OpListPushI64, 0, 7, 0),
+				vm3.MakeOp(vm3.OpListPushI64, 0, 7, 0),
+				vm3.MakeOp(vm3.OpListPushI64, 0, 7, 0),
 				vm3.MakeOp(vm3.OpConstI64K, 1, 0, 0),    // pc=10: k = 0
 				vm3.MakeOp(vm3.OpCmpGeI64Br, 1, 0, 39),  // pc=11: if k>=n -> END
 				vm3.MakeOp(vm3.OpConstI64K, 3, 0, 0),    // pc=12: i = 0
@@ -109,19 +120,19 @@ var FannkuchRedux = &Program{
 				vm3.MakeOp(vm3.OpAddI64K, 3, 3, 1),      // pc=18: i++
 				vm3.MakeOp(vm3.OpJump, 0, 0, 13),        // pc=19 -> init_loop
 				vm3.MakeOp(vm3.OpConstI64K, 6, 0, 0),    // pc=20: flips = 0
-				vm3.MakeOp(vm3.OpListGetI64, 5, 0, 8),   // pc=21: head = perm[0]
+				vm3.MakeOp(vm3.OpListGetI64K, 5, 0, 0),  // pc=21: head = perm[0] (idx baked)
 				vm3.MakeOp(vm3.OpCmpEqI64KBr, 5, 1, 36), // pc=22: if head==1 -> FLIP_END
 				vm3.MakeOp(vm3.OpConstI64K, 3, 0, 0),    // pc=23: lo = 0
-				vm3.MakeOp(vm3.OpAddI64K, 4, 5, -1),     // pc=24: hi = head - 1
+				vm3.MakeOp(vm3.OpAddI64K, 4, 5, -1),     // pc=24: hi = head - 1 (last read of head)
 				vm3.MakeOp(vm3.OpCmpGeI64Br, 3, 4, 33),  // pc=25: if lo>=hi -> REV_END
 				vm3.MakeOp(vm3.OpListGetI64, 7, 0, 3),   // pc=26: a = perm[lo]
-				vm3.MakeOp(vm3.OpListGetI64, 9, 0, 4),   // pc=27: b = perm[hi]
-				vm3.MakeOp(vm3.OpListSetI64, 0, 9, 3),   // pc=28: perm[lo] = b
+				vm3.MakeOp(vm3.OpListGetI64, 5, 0, 4),   // pc=27: swap_b = perm[hi] (slot 5 reused)
+				vm3.MakeOp(vm3.OpListSetI64, 0, 5, 3),   // pc=28: perm[lo] = swap_b
 				vm3.MakeOp(vm3.OpListSetI64, 0, 7, 4),   // pc=29: perm[hi] = a
 				vm3.MakeOp(vm3.OpAddI64K, 3, 3, 1),      // pc=30: lo++
 				vm3.MakeOp(vm3.OpAddI64K, 4, 4, -1),     // pc=31: hi--
 				vm3.MakeOp(vm3.OpJump, 0, 0, 25),        // pc=32 -> rev_loop
-				vm3.MakeOp(vm3.OpListGetI64, 5, 0, 8),   // pc=33: head = perm[0]
+				vm3.MakeOp(vm3.OpListGetI64K, 5, 0, 0),  // pc=33: head = perm[0] (idx baked)
 				vm3.MakeOp(vm3.OpAddI64K, 6, 6, 1),      // pc=34: flips++
 				vm3.MakeOp(vm3.OpJump, 0, 0, 22),        // pc=35 -> flip_loop
 				vm3.MakeOp(vm3.OpAddI64, 2, 2, 6),       // pc=36: total += flips

--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -238,6 +238,7 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 			vm3.OpCmpGtI64KBr, vm3.OpCmpGeI64KBr,
 			vm3.OpJump, vm3.OpReturnI64, vm3.OpReturnConstK, vm3.OpReturnCell,
 			vm3.OpListGetI64, vm3.OpListPushI64, vm3.OpListSetI64,
+			vm3.OpListGetI64K,
 			vm3.OpListGetF64, vm3.OpListSetF64,
 			vm3.OpMapSetI64I64, vm3.OpMapGetI64I64,
 			vm3.OpLookupI64KW,
@@ -372,6 +373,7 @@ func checkCellBankAdmissibleAMD64(fn *vm3.Function, opts Options) error {
 			vm3.OpReturnI64, vm3.OpReturnConstK, vm3.OpReturnCell,
 			vm3.OpPairFst, vm3.OpPairSnd, vm3.OpNewPair,
 			vm3.OpListGetI64, vm3.OpListSetI64, vm3.OpListPushI64,
+			vm3.OpListGetI64K,
 			vm3.OpLookupI64KW:
 			continue
 		case vm3.OpNewList:

--- a/runtime/jit/vm3jit/list_getk_amd64_test.go
+++ b/runtime/jit/vm3jit/list_getk_amd64_test.go
@@ -1,0 +1,123 @@
+//go:build amd64
+
+package vm3jit_test
+
+import (
+	"testing"
+
+	"mochi/runtime/jit/vm3jit"
+	"mochi/runtime/vm3"
+)
+
+// TestListGetI64KAMD64 exercises Phase 6.3.4.n.2.e: AMD64 OpListGetI64K
+// lowering on a cell-bank fn. The driver builds a 3-element list
+// [10, 20, 30] then JIT-calls a helper that reads list[1] via the new
+// constant-index opcode. A drift in the disp32 cells-array load, the
+// shl/sar sign-extend pair, or the SBFX-equivalent encoding would
+// surface as a wrong return or a segfault.
+func TestListGetI64KAMD64(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_list_getk_const",
+		NumRegsI64:  1,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpListGetI64K, 0, 0, 1), // pc=0: regsI64[0] = regsCell[0][1]
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),   // pc=1: return regsI64[0]
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewList, 0, 0, 8),                                       // pc=0: regsCell[0] = make([]Cell, 0, 8)
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 10),                                    // pc=1: regsI64[1] = 10
+			vm3.MakeOp(vm3.OpListPushI64, 0, 1, 0),                                   // pc=2: list.push(10)
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 20),                                    // pc=3: regsI64[1] = 20
+			vm3.MakeOp(vm3.OpListPushI64, 0, 1, 0),                                   // pc=4: list.push(20)
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 30),                                    // pc=5: regsI64[1] = 30
+			vm3.MakeOp(vm3.OpListPushI64, 0, 1, 0),                                   // pc=6: list.push(30)
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1}, // pc=7: regsI64[0] = helper(regsCell[0])
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),                                     // pc=8: return regsI64[0]
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; AMD64 cell-bank n.2.e should admit OpListGetI64K")
+	}
+	preDeopt := vm3jit.DeoptCount
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if d := vm3jit.DeoptCount - preDeopt; d != 0 {
+		t.Fatalf("unexpected deopt count delta: %d", d)
+	}
+	if got.Int() != 20 {
+		t.Fatalf("got %d, want 20 (list[1])", got.Int())
+	}
+}
+
+// TestListGetI64KAMD64NegativePayload guards the SBFX (shl/sar by 16)
+// pair against a sign-bit drop on the constant-index variant. A list
+// value of -42 must round-trip as -42, not 0x0000FFFF_FFFFFFD6.
+func TestListGetI64KAMD64NegativePayload(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_list_getk_neg",
+		NumRegsI64:  1,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpListGetI64K, 0, 0, 0), // pc=0: regsI64[0] = regsCell[0][0]
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),   // pc=1: return regsI64[0]
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewList, 0, 0, 8),                                       // pc=0: regsCell[0] = []
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, -42),                                   // pc=1: regsI64[1] = -42
+			vm3.MakeOp(vm3.OpListPushI64, 0, 1, 0),                                   // pc=2: list.push(-42)
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1}, // pc=3: regsI64[0] = helper(regsCell[0])
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),                                     // pc=4: return regsI64[0]
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; AMD64 cell-bank n.2.e should admit OpListGetI64K")
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if got.Int() != -42 {
+		t.Fatalf("got %d, want -42 (sign-extend failed?)", got.Int())
+	}
+}

--- a/runtime/jit/vm3jit/list_getk_arm64_test.go
+++ b/runtime/jit/vm3jit/list_getk_arm64_test.go
@@ -1,0 +1,122 @@
+//go:build arm64
+
+package vm3jit_test
+
+import (
+	"testing"
+
+	"mochi/runtime/jit/vm3jit"
+	"mochi/runtime/vm3"
+)
+
+// TestListGetI64KARM64 exercises Phase 6.3.4.n.2.e: ARM64 OpListGetI64K
+// lowering on a cell-bank fn. The driver builds a 3-element list
+// [10, 20, 30] then JIT-calls a helper that reads list[1] via the new
+// constant-index opcode. A drift in the LDR imm12 of the cells-array
+// pointer load, or in the SBFX (signed bitfield extract) sign-extend,
+// would surface as a wrong return or a segfault.
+func TestListGetI64KARM64(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "arm64_list_getk_const",
+		NumRegsI64:  1,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpListGetI64K, 0, 0, 1), // pc=0: regsI64[0] = regsCell[0][1]
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),   // pc=1: return regsI64[0]
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewList, 0, 0, 8),                                       // pc=0: regsCell[0] = make([]Cell, 0, 8)
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 10),                                    // pc=1: regsI64[1] = 10
+			vm3.MakeOp(vm3.OpListPushI64, 0, 1, 0),                                   // pc=2: list.push(10)
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 20),                                    // pc=3: regsI64[1] = 20
+			vm3.MakeOp(vm3.OpListPushI64, 0, 1, 0),                                   // pc=4: list.push(20)
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 30),                                    // pc=5: regsI64[1] = 30
+			vm3.MakeOp(vm3.OpListPushI64, 0, 1, 0),                                   // pc=6: list.push(30)
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1}, // pc=7: regsI64[0] = helper(regsCell[0])
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),                                     // pc=8: return regsI64[0]
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; ARM64 cell-bank n.2.e should admit OpListGetI64K")
+	}
+	preDeopt := vm3jit.DeoptCount
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if d := vm3jit.DeoptCount - preDeopt; d != 0 {
+		t.Fatalf("unexpected deopt count delta: %d", d)
+	}
+	if got.Int() != 20 {
+		t.Fatalf("got %d, want 20 (list[1])", got.Int())
+	}
+}
+
+// TestListGetI64KARM64NegativePayload checks the SBFX sign-extend on
+// the constant-index variant by storing -42 and reading it back.
+func TestListGetI64KARM64NegativePayload(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "arm64_list_getk_neg",
+		NumRegsI64:  1,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpListGetI64K, 0, 0, 0), // pc=0: regsI64[0] = regsCell[0][0]
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),   // pc=1: return regsI64[0]
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewList, 0, 0, 8),                                       // pc=0: regsCell[0] = []
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, -42),                                   // pc=1: regsI64[1] = -42
+			vm3.MakeOp(vm3.OpListPushI64, 0, 1, 0),                                   // pc=2: list.push(-42)
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1}, // pc=3: regsI64[0] = helper(regsCell[0])
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),                                     // pc=4: return regsI64[0]
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; ARM64 cell-bank n.2.e should admit OpListGetI64K")
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if got.Int() != -42 {
+		t.Fatalf("got %d, want -42 (sign-extend failed?)", got.Int())
+	}
+}

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -794,6 +794,26 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		//   mov  %rax, x_A                ; regsI64[A] = signed payload (REX.W 89 /r, 3B)
 		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + 7 + 4 + 4 + 4 + 3, nil
 
+	case vm3.OpListGetI64K:
+		// Phase 6.3.4.n.2.e: constant-index list read. Mirrors
+		// OpListGetI64 cold form but bakes the (uint16(C)) idx into a
+		// disp32 load instead of the SIB form, freeing the i64 reg
+		// that would have held the loop index. Trade: the SIB load is
+		// 4 bytes, the disp32 load is 7 bytes, so the op is 3 bytes
+		// longer than the reg-form; the win is one fewer live i64
+		// register, which matters for fannkuch_redux (squeezes
+		// NumRegsI64 from 10 to 8 to fit the AMD64 cell-bank cap).
+		//   mov  disp32(%rbp), %eax       ; idx = low 32 of regsCell[B] (zero-ext, 6B)
+		//   imul $stride, %rax, %rax      ; rax = idx * sizeof(vmList) (7B)
+		//   mov  listsBaseOff(%r14), %rcx ; rcx = arenas.Lists base    (7B)
+		//   add  %rcx, %rax               ; rax = &arenas.Lists[idx]   (3B)
+		//   mov  cellsOff(%rax), %rax     ; rax = cells.ptr            (7B)
+		//   mov  disp32(%rax), %rax       ; rax = cells[idxK]          (7B; idxK*8 in disp32)
+		//   shl  $16, %rax                ; SBFX prep                  (4B)
+		//   sar  $16, %rax                ; sign-extend low 48 bits    (4B)
+		//   mov  %rax, x_A                ; regsI64[A] = signed payload (3B)
+		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + 7 + 7 + 4 + 4 + 3, nil
+
 	case vm3.OpListSetI64:
 		// Phase 6.3.4.n.2.b cold form, AMD64 mirror of the ARM64
 		// OpListSetI64 (no hoist):
@@ -1244,6 +1264,28 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		out = append(out, add64RR(xRCX, xRAX)...)
 		out = append(out, mov64LoadDisp32(xRAX, xRAX, cellsOff)...)
 		out = append(out, mov64LoadIdxLsl3(xRAX, xRAX, xIdx)...)
+		out = append(out, shl64RImm8(xRAX, 16)...)
+		out = append(out, sar64RImm8(xRAX, 16)...)
+		out = append(out, mov64RR(xRAX, xA)...)
+		return out, nil
+
+	case vm3.OpListGetI64K:
+		// Phase 6.3.4.n.2.e: constant-index list read. Mirrors OpListGetI64
+		// but bakes idx*8 into the cells-array load's disp32, eliminating
+		// the dependence on a live i64 register for the index. Frees one
+		// i64 slot in the kernel; fannkuch_redux uses this to fit
+		// NumRegsI64=8 under the AMD64 cell-bank cap.
+		stride := int64(vm3.JITListSlabStride())
+		cellsOff := int32(vm3.JITListCellsOffset())
+		listsBaseOff := int32(jitArenaCtxListsBaseOff())
+		idxK := int32(uint16(op.C)) * 8
+		xA := r2xAMD64(op.A)
+		out := mov32LoadDisp32(xRAX, xRBP, int32(op.B)*8)
+		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
+		out = append(out, mov64LoadDisp32(xRCX, xR14, listsBaseOff)...)
+		out = append(out, add64RR(xRCX, xRAX)...)
+		out = append(out, mov64LoadDisp32(xRAX, xRAX, cellsOff)...)
+		out = append(out, mov64LoadDisp32(xRAX, xRAX, idxK)...)
 		out = append(out, shl64RImm8(xRAX, 16)...)
 		out = append(out, sar64RImm8(xRAX, 16)...)
 		out = append(out, mov64RR(xRAX, xA)...)

--- a/runtime/jit/vm3jit/lower_arm64.go
+++ b/runtime/jit/vm3jit/lower_arm64.go
@@ -1531,6 +1531,25 @@ func wordCountARM64Body(fn *vm3.Function, op vm3.Op, opts Options, spillSets []u
 		stride := int64(vm3.JITListSlabStride())
 		return movImm64WordCount(stride) + 6, nil
 
+	case vm3.OpListGetI64K:
+		// Phase 6.3.4.n.2.e: constant-index variant of OpListGetI64.
+		// Bakes the immediate idx into the cells-array LDR's imm12,
+		// replacing the LSL #3-scaled register-offset form. Saves no
+		// instructions vs the reg form (still LDR + SBFX in the hot
+		// shape), but frees the loop's i64 register that would have
+		// held the index, which matters for kernels squeezed against
+		// the AMD64 cell-bank cap (NumRegsI64 ≤ 8) and reduces ARM64
+		// pressure too. K is uint16(op.C) and the cell stride is 8,
+		// so the imm12 is K directly (max addressable K = 4095).
+		if h := hoistedCellReg(fn); h >= 0 && int(op.B) == h {
+			if hoistsCellsPtrARM64(fn) {
+				return 2, nil
+			}
+			return 3, nil
+		}
+		stride := int64(vm3.JITListSlabStride())
+		return movImm64WordCount(stride) + 6, nil
+
 	case vm3.OpListPushI64:
 		// Inline push-with-cap-check fast path. The cold form is
 		// movImm64WordCount(stride)+14 words (UXTW + MOV stride + MUL +
@@ -2254,6 +2273,47 @@ func emitInstrARM64Body(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deopt
 		ws = append(ws, addReg(16, 16, 19))
 		ws = append(ws, ldr64(16, 16, cellsOff/8))
 		ws = append(ws, ldrRegLsl3(17, 16, xIdx))
+		ws = append(ws, sbfx48(xA, 17))
+		return ws, nil
+
+	case vm3.OpListGetI64K:
+		// Phase 6.3.4.n.2.e: constant-index list read mirroring
+		// OpListGetI64 with idxK baked into the cells-array LDR's
+		// imm12 instead of an index register. Cold form (cellsOff/8
+		// for the slab→ptr LDR, then idxK for the ptr→cell LDR):
+		//   UXTW x16, w_cell ; MOV x17, #stride ; MUL ; ADD x16, x19 ;
+		//   LDR x16, [x16, #CELLS_OFFSET] ; LDR x17, [x16, #idxK*8] ;
+		//   SBFX xA, x17, #0, #48
+		// Hot form (hoistedCellReg matches op.B, no cells.ptr pin):
+		//   LDR x17, [x20, #CELLS_OFFSET] ; LDR x17, [x17, #idxK*8] ;
+		//   SBFX xA, x17, #0, #48
+		// Hottest form (cells.ptr pinned in x22):
+		//   LDR x17, [x22, #idxK*8] ; SBFX xA, x17, #0, #48
+		cellsOff := uint32(vm3.JITListCellsOffset())
+		idxK := uint32(uint16(op.C))
+		xA := r2x(fn, op.A)
+		if h := hoistedCellReg(fn); h >= 0 && int(op.B) == h {
+			if hoistsCellsPtrARM64(fn) {
+				ws := make([]uint32, 0, 2)
+				ws = append(ws, ldr64(17, 22, idxK))
+				ws = append(ws, sbfx48(xA, 17))
+				return ws, nil
+			}
+			ws := make([]uint32, 0, 3)
+			ws = append(ws, ldr64(17, 20, cellsOff/8))
+			ws = append(ws, ldr64(17, 17, idxK))
+			ws = append(ws, sbfx48(xA, 17))
+			return ws, nil
+		}
+		stride := int64(vm3.JITListSlabStride())
+		xCell := r2cell(op.B)
+		ws := make([]uint32, 0, movImm64WordCount(stride)+6)
+		ws = append(ws, uxtwReg(16, xCell))
+		ws = append(ws, movImm64(17, stride)...)
+		ws = append(ws, mulReg(16, 16, 17))
+		ws = append(ws, addReg(16, 16, 19))
+		ws = append(ws, ldr64(16, 16, cellsOff/8))
+		ws = append(ws, ldr64(17, 16, idxK))
 		ws = append(ws, sbfx48(xA, 17))
 		return ws, nil
 

--- a/runtime/vm3/op.go
+++ b/runtime/vm3/op.go
@@ -101,6 +101,7 @@ const (
 	OpListPushI64 // arenas list at regsCell[A] gets CInt(regsI64[B])
 	OpListGetI64  // regsI64[A] = arenas.ListGet(regsCell[B], regsI64[uint16(C)]).Int()
 	OpListSetI64  // arenas list at regsCell[A] at regsI64[uint16(C)] = CInt(regsI64[B])
+	OpListGetI64K // regsI64[A] = arenas.ListGet(regsCell[B], int64(uint16(C))).Int(); idx is K not reg
 
 	// Maps (Phase 3.3). i64-keyed open-addressed maps. A is the map
 	// reg in the caller's Cell bank; B is the key reg in I64 bank; C

--- a/runtime/vm3/vm.go
+++ b/runtime/vm3/vm.go
@@ -785,6 +785,11 @@ func (vm *VM) run() (Cell, error) {
 			_, _, idx := lst.DecodeHandle()
 			arenas.Lists[idx].cells[regsI64[uint16(op.C)]] = CInt(regsI64[op.B])
 			pc++
+		case OpListGetI64K:
+			lst := regsCell[op.B]
+			_, _, idx := lst.DecodeHandle()
+			regsI64[op.A] = arenas.Lists[idx].cells[uint16(op.C)].Int()
+			pc++
 		case OpListGetF64:
 			lst := regsCell[op.B]
 			_, _, idx := lst.DecodeHandle()

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2928,7 +2928,50 @@ The clever bit is the tag-overwrite trick. Two's complement encoding means bytes
 - `TestListPushI64AMD64NegativePayload`: pushes -7 and reads it back; guards the tag-overwrite trick against any high-bit leak (a wrong store would produce `0x0000FFFF_FFFFFFF9` or similar non-canonical bit patterns that decode wrongly).
 - `TestListPushI64AMD64Grow`: driver passes `cap=2`, helper pushes 3 items; verifies the StatusListGrow deopt fires, `jitCall` regrows the slab, and the helper resumes in interp with the correct final state.
 
-All seven vm3jit list-{get,set,push} AMD64 tests pass on server2 (linux/amd64, AMD EPYC). The full vm3jit suite re-bench shows no regressions vs the n.2.b baseline. Bench numbers for nsieve and fannkuch_redux land in the follow-up sub-phase n.2.d (the JIT-admission of the kernel entry points is what unlocks the bench; this sub-phase only adds the opcode coverage).
+All seven vm3jit `list-{get,set,push}` AMD64 tests pass on server2 (linux/amd64, AMD EPYC). The full vm3jit suite re-bench shows no regressions vs the n.2.b baseline. Bench numbers for nsieve and fannkuch_redux land in the follow-up sub-phase n.2.d (the JIT-admission of the kernel entry points is what unlocks the bench; this sub-phase only adds the opcode coverage).
+
+#### Phase 6.3.4.n.2.e: close fannkuch_redux via `OpListGetI64K` constant-index read (2026-05-20 10:16 GMT+7)
+
+**Scope.** The n.2.a..c trio admitted the `OpListGetI64` / `OpListSetI64` / `OpListPushI64` / `OpNewList` AMD64 cell-bank ops, but `fannkuch_redux` still failed to JIT-compile on linux/amd64 because the kernel landed in `compiler3/corpus` (l.2) at `NumRegsI64=10`, two slots above the AMD64 cell-bank effective cap of 8 (R14 and RBP repurposed as `arenaCtx` and `regsCell` base respectively, leaving slots 0..7 = RSI/RDI/R8..R13). The cap is structural: lifting it would require carving callee-saved scratch into a fresh i64 slot map, far more work than reshaping the kernel. n.2.e closes the gap from the other side: add one generic constant-index list-read opcode + retire two slots in `fannkuch_redux`.
+
+**New opcode (`OpListGetI64K`).** Same shape as `OpListGetI64` except the index is a `uint16(C)` constant baked into the op, not a regsI64 slot. The cold-form lowering bakes `idx*8` into the load displacement (ARM64: `imm12*8` via the `ldr64` immediate form; AMD64: `disp32` via `mov64LoadDisp32`) instead of issuing the SIB / LSL #3 register-scaled index. The interp eval mirrors that:
+
+```go
+case OpListGetI64K:
+    lst := regsCell[op.B]
+    _, _, idx := lst.DecodeHandle()
+    regsI64[op.A] = arenas.Lists[idx].cells[uint16(op.C)].Int()
+    pc++
+```
+
+For `fannkuch_redux` the relevant constant index is 0 (`perm[0]` reads inside the flip loop), which collapses to a literal `ldr x17, [x16]` on ARM64 and a literal `mov rax, [rax]` (no displacement) on AMD64, freeing one ambient `zero_idx` slot that previously had to live in regsI64.
+
+**Kernel refit (`NumRegsI64=10 -> 8`).** Three structural moves squeeze `fannkuch_redux` under the AMD64 cap:
+
+1. **Merge `head` and `swap_b` onto slot 5.** The two live ranges are disjoint: `head` is written at pc=21 (`OpListGetI64K, 5, 0, 0`), last-read at pc=24 (`OpAddI64K, 4, 5, -1` computing `hi = head - 1`). `swap_b` is then written at pc=27 (`OpListGetI64, 5, 0, 4` reading `perm[hi]`) and last-read at pc=28 (`OpListSetI64, 0, 5, 3` writing `perm[lo]`). pc=33 rewrites slot 5 with the next `head` for the outer flip loop. One register, two roles.
+2. **Reuse `tmp_a` (slot 7) as the zero source for the init-prefix pushes.** pc=1 seeds slot 7 with 0 via `OpConstI64K`. pc=3..9 push 7 zeros from slot 7 to grow `perm` to length 7. Slot 7 is first overwritten at pc=14 (`OpAddI64, 7, 3, 1` computing `tmp = i + k`) inside the init loop, which runs *after* the prefix pushes finish.
+3. **Retire the dedicated `zero_idx` slot.** Both `perm[0]` reads (pc=21 in the flip loop and pc=33 in the reload-after-reverse path) switch from `OpListGetI64` with idx in a regsI64 slot to `OpListGetI64K` with idx=0 baked.
+
+After the refit `NumRegsI64=8` (exactly the AMD64 cell-bank cap) and the kernel passes the existing `TestFannkuchReduxMatchesOracle` oracle on `n in {0, 1, 2, 5, 7, 14, 100, 1000}`.
+
+**Tests.** Two arch-specific synthetic tests guard the new opcode's sign-extend path:
+- `runtime/jit/vm3jit/list_getk_arm64_test.go`: `TestListGetI64KARM64` builds `[10, 20, 30]`, reads `list[1]` via `OpListGetI64K`, expects 20 with zero deopt; `TestListGetI64KARM64NegativePayload` round-trips `-42` to catch any SBFX (signed bitfield extract) drift on the 16-bit sign-extend.
+- `runtime/jit/vm3jit/list_getk_amd64_test.go`: same pair on AMD64. The negative-payload test specifically guards the `shl 16 / sar 16` pair, which is the AMD64 equivalent of ARM64 SBFX and is what turns the raw 8-byte cells-array load into a signed 48-bit value. A wrong shift or a missing one would surface as `-42` round-tripping to `0x0000FFFF_FFFFFFD6` (`281474976710614`) instead.
+
+**Measured ratios.**
+
+| Platform | Kernel | vm3jit ns/op | Go ns/op | Ratio | Verdict |
+| :---     | :---   | ---:         | ---:     | ---:  | :---:   |
+| darwin/arm64 (Apple M4) | `fannkuch_redux_n1000` | 13,548 | 10,794 | 1.26x | inside 2x |
+| darwin/arm64 (Apple M4) | `fannkuch_redux_n10000` | 136,618 | 106,673 | 1.28x | inside 2x |
+| linux/amd64 (AMD EPYC, server2) | `fannkuch_redux_n1000` | 223,205 | 57,675 | 3.87x | over 2x (improved from 54x interp-floor) |
+| linux/amd64 (AMD EPYC, server2) | `fannkuch_redux_n10000` | 2,387,516 | 570,515 | 4.18x | over 2x (improved from 54x interp-floor) |
+
+The darwin/arm64 numbers land roughly where l.2 left off (1.07x / 1.35x before the refit, 1.26x / 1.28x after) which is what we want: the squeeze frees one i64 slot but the kernel stays inside 2x at both `n`. The linux/amd64 numbers move from the interp-floor of ~31.5 ms/op at n=10000 (the JIT was previously rejecting the kernel entirely) to ~2.39 ms/op, a 13x kernel speedup, but the absolute ratio is still ~4x of Go because the AMD64 cell-bank list path is the *cold form* (no slab-base hoist, no `cells.ptr` pin). ARM64 already enjoys those optimizations from c.1 / c.2, which is why darwin/arm64 closes; AMD64 still pays a per-op `mov listsBase / imul stride / add / mov cellsOff / mov idx` chain on every `OpListGetI64K` instead of folding the slab base into a callee-saved register.
+
+**Why this is a generic VM improvement, not a kernel-targeted super-op.** `OpListGetI64K` is the same shape as the existing `OpListGetI64` opcode, only the index is moved from a regsI64 slot to a `uint16(C)` immediate. Any cell-bank kernel that reads a list at a compile-time constant index benefits without modification, and the lowering is the same `disp32` / `imm12` mechanism the JIT already uses for `OpConstI64K`, `OpAddI64K`, `OpCmpEqI64KBr`, etc. The fannkuch refit is then just a register-allocation cleanup that the new opcode enabled.
+
+**Closure verdict.** macOS arm64: gate cleared at 1.26x / 1.28x. linux/amd64: gate not cleared at 3.87x / 4.18x; tracked as the follow-up sub-phase n.2.f (port the c.1 slab-base hoist + c.2 `cells.ptr` pin from ARM64 to AMD64). The composite BG-suite progress on macOS arm64 stays at 7/11 closed (l.2 already counted fannkuch_redux); on linux/amd64 the same headline moves from interp-floor to JIT-admitted, freeing the closure path for the remaining list-heavy BG kernels (nsieve, reverse_complement, k_nucleotide) which share the same cold-form gap.
 
 #### Phase 6.3.4.n.2.d: bench nsieve + fannkuch_redux on server2 (2026-05-20 09:47 GMT+7)
 


### PR DESCRIPTION
## Summary

- Add generic `OpListGetI64K` opcode (constant-index list read) + JIT lowering on ARM64 / AMD64. The cold-form lowering bakes `idx*8` into a `disp32` (AMD64) or `imm12*8` (ARM64) load instead of using SIB / LSL #3 register-scaled indexing, so callers can retire the dedicated zero/index slot.
- Refit `compiler3/corpus/fannkuch_redux.go` from `NumRegsI64=10` to `NumRegsI64=8` so it fits the AMD64 cell-bank effective cap (R14 / RBP repurposed as `arenaCtx` / `regsCell` base). Three structural moves: merge `head` / `swap_b` onto slot 5 (disjoint live ranges), reuse `tmp_a` (slot 7) as zero-source for the init-prefix pushes, retire the dedicated `zero_idx` slot via `OpListGetI64K` for `perm[0]` reads at pc=21 and pc=33.
- Also fixes the website MDX build: a pre-existing `list-{get,set,push}` token in §6.3.4.n.2.c was unbacked, and MDX v3 was parsing `{get,...}` as a JSX expression, failing with `ReferenceError: get is not defined`. Bracketed in backticks.

Closes #21846. Tracks MEP-40 Phase 6.3.4.n.2.e.

## Measured ratios

| Platform | Kernel | vm3jit ns/op | Go ns/op | Ratio | Verdict |
| :---     | :---   | ---:         | ---:     | ---:  | :---:   |
| darwin/arm64 (Apple M4) | `fannkuch_redux_n1000` | 13,548 | 10,794 | 1.26x | inside 2x |
| darwin/arm64 (Apple M4) | `fannkuch_redux_n10000` | 136,618 | 106,673 | 1.28x | inside 2x |
| linux/amd64 (AMD EPYC, server2) | `fannkuch_redux_n1000` | 223,205 | 57,675 | 3.87x | over 2x (improved from 54x interp-floor) |
| linux/amd64 (AMD EPYC, server2) | `fannkuch_redux_n10000` | 2,387,516 | 570,515 | 4.18x | over 2x (improved from 54x interp-floor) |

macOS arm64 gate cleared; linux/amd64 moves from interp-floor (~54x) to JIT-admitted (~4x). Residual linux/amd64 gap is the AMD64 cold-form list-op cost; closing follows in n.2.f (port the c.1 slab-base hoist + c.2 `cells.ptr` pin from ARM64 to AMD64).

## Test plan

- [x] `go test ./runtime/jit/vm3jit/ -run TestListGetI64K -count=1 -v` on darwin/arm64 (TestListGetI64KARM64 + NegativePayload pass)
- [x] `go test ./runtime/jit/vm3jit/ -count=1` on darwin/arm64 (full suite clean)
- [x] `go test ./compiler3/corpus/... -count=1` on darwin/arm64 (oracle clean)
- [x] `go test ./runtime/jit/vm3jit/ -run TestListGetI64K -count=1 -v` on linux/amd64 server2 (TestListGetI64KAMD64 + NegativePayload pass)
- [x] `go test ./runtime/jit/vm3jit/ -count=1` on linux/amd64 server2 (full suite clean)
- [x] `BenchmarkCorpusJITRunner/fannkuch_redux` on darwin/arm64 and linux/amd64 (numbers in the table above)
- [x] `npm run build` in `website/` clean after the MDX hotfix