### PR TITLE
mep-0040 Phase 6.3.4.n.2.f: AMD64 cells.ptr hoist + SIB-store hot form

### DIFF
--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -961,16 +961,18 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		//
 		// Phase 6.3.4.n.2.f hot form (hoistsCellsPtrAMD64 true): swap
 		// the 5-instruction slab/cells.ptr chain (30B) for the disp8
-		// load (4B). The rest of the packed-Cell prep is identical.
-		//   mov  hoistDisp(%rbx), %rax    ; rax = cells.ptr            (4B)
-		//   mov  xVal, %rdx               ;                            (3B)
-		//   shl  $16, %rdx                ;                            (4B)
-		//   shr  $16, %rdx                ;                            (4B)
-		//   movabs $0xFFFA<<48, %rcx      ;                            (10B)
-		//   or   %rcx, %rdx               ;                            (3B)
-		//   mov  %rdx, [%rax + xIdx*8]    ;                            (4B)
+		// load (4B), and replace the mask-and-OR pack (3+4+4+10+3+4=28B)
+		// with the OpListPushI64-style "raw SIB store + 16-bit tag
+		// overwrite" pair (4+7=11B). The high 16 bits of xVal leak into
+		// the cell store, but the 16-bit tag immediate overwrites them
+		// in the same line; OpListGetI64's shl/sar pair sign-extends
+		// the low 48 regardless of what was there, so round-trip is
+		// preserved.
+		//   mov  hoistDisp(%rbx), %rax        ; rax = cells.ptr        (4B)
+		//   mov  xVal, [%rax + xIdx*8]        ; cells[idx] = raw xVal  (4B)
+		//   movw $0xFFFA, 6(%rax,%xIdx,8)     ; overwrite tag bytes    (7B)
 		if hoistsCellsPtrAMD64(fn) {
-			return 4 + 3 + 4 + 4 + 10 + 3 + 4, nil
+			return 4 + 4 + 7, nil
 		}
 		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + 7 + 3 + 4 + 4 + 10 + 3 + 4, nil
 
@@ -1476,20 +1478,29 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		// compute chain (RCX is then free up to the movabs tag load).
 		xIdx := r2xAMD64(uint16(op.C))
 		xVal := r2xAMD64(op.B)
-		tag := uint64(0xFFFA) << 48
-		var out []byte
 		if hoistsCellsPtrAMD64(fn) {
-			out = mov64LoadDisp8(xRAX, xRBX, int8(hoistDispAMD64(fn)))
-		} else {
-			stride := int64(vm3.JITListSlabStride())
-			cellsOff := int32(vm3.JITListCellsOffset())
-			listsBaseOff := int32(jitArenaCtxListsBaseOff())
-			out = mov32LoadDisp32(xRAX, xRBP, int32(op.A)*8)
-			out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
-			out = append(out, mov64LoadDisp32(xRCX, xR14, listsBaseOff)...)
-			out = append(out, add64RR(xRCX, xRAX)...)
-			out = append(out, mov64LoadDisp32(xRAX, xRAX, cellsOff)...)
+			// Hot form: cells.ptr is pinned at disp8(%rbx). Use the
+			// OpListPushI64 "raw SIB store + 16-bit tag overwrite"
+			// trick: the 16-bit write at offset 6 overwrites bytes
+			// 6..7 of the just-stored xVal with 0xFFFA. The low 48
+			// bits of xVal already hold the signed payload (two's
+			// complement preserves them), so OpListGetI64's shl/sar
+			// sign-extend recovers the original i64 round-trip.
+			out := mov64LoadDisp8(xRAX, xRBX, int8(hoistDispAMD64(fn)))
+			out = append(out, mov64StoreIdxLsl3(xVal, xRAX, xIdx)...)
+			out = append(out, mov16ImmStoreSIBDisp8(0xFFFA, xRAX, xIdx, 6)...)
+			return out, nil
 		}
+		// Cold form: recompute slab + cells.ptr, then mask-and-OR pack.
+		stride := int64(vm3.JITListSlabStride())
+		cellsOff := int32(vm3.JITListCellsOffset())
+		listsBaseOff := int32(jitArenaCtxListsBaseOff())
+		tag := uint64(0xFFFA) << 48
+		out := mov32LoadDisp32(xRAX, xRBP, int32(op.A)*8)
+		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
+		out = append(out, mov64LoadDisp32(xRCX, xR14, listsBaseOff)...)
+		out = append(out, add64RR(xRCX, xRAX)...)
+		out = append(out, mov64LoadDisp32(xRAX, xRAX, cellsOff)...)
 		out = append(out, mov64RR(xVal, xRDX)...)
 		out = append(out, shl64RImm8(xRDX, 16)...)
 		out = append(out, shr64RImm8(xRDX, 16)...)

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -2310,7 +2310,12 @@ func mov32StoreDisp8(src, base int, disp int8) []byte {
 // this with rBase=RDX). 7 bytes when neither reg needs REX, 8 bytes
 // otherwise.
 func mov16ImmStoreSIBDisp8(imm uint16, base, idx int, disp int8) []byte {
-	var out []byte
+	// Prefix order: 0x66 (operand-size, group 3) must precede REX, since
+	// REX must immediately precede the opcode byte. The earlier ordering
+	// (REX then 0x66) caused the CPU to ignore the REX prefix entirely,
+	// dropping REX.X and silently demoting an R8..R15 index to RAX..RDI,
+	// producing wild addresses when the SIB index was a high register.
+	out := []byte{0x66}
 	if base >= 8 || idx >= 8 {
 		var r byte = 0x40
 		if idx >= 8 {
@@ -2322,7 +2327,7 @@ func mov16ImmStoreSIBDisp8(imm uint16, base, idx int, disp int8) []byte {
 		out = append(out, r)
 	}
 	sib := byte(3<<6) | byte((idx&7)<<3) | byte(base&7)
-	out = append(out, 0x66, 0xC7, modRM(1, 0, 4), sib, byte(disp))
+	out = append(out, 0xC7, modRM(1, 0, 4), sib, byte(disp))
 	var b [2]byte
 	binary.LittleEndian.PutUint16(b[:], imm)
 	return append(out, b[:]...)

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -317,6 +317,84 @@ func hasRegRegDivModAMD64(fn *vm3.Function) bool {
 	return false
 }
 
+// hoistsCellsPtrAMD64 reports whether the AMD64 prologue should pre-
+// compute cells.ptr from regsCell[0]'s handle and stash it in the
+// regsI64[NumRegsI64] backing slot for the lifetime of the call. When
+// active, OpListGet/OpListGetK/OpListSet emit the hot form (one disp32
+// load from RBX instead of the listsBase + imul + cellsOff chain), and
+// OpListPushI64 still reads the slab address cold (it needs cells.cap
+// and cells.len fields, not just cells.ptr).
+//
+// Gates (Phase 6.3.4.n.2.f):
+//
+//   - NumRegsCell == 1: we only hoist one cell's slab; multi-cell
+//     kernels would need a hoist slot per cell and a per-op disambiguator.
+//   - has at least one OpListGet/OpListGetK/OpListSet/OpListPushI64:
+//     otherwise the prologue would waste ~34 bytes computing a hoist
+//     value nothing in the body reads.
+//   - !isNonLeafAMD64(fn): any internal CALL (self-recursive or
+//     cross-fn) may transitively trigger an OpListPushI64 grow, which
+//     moves the arena slab and invalidates the hoisted cells.ptr.
+//     Refreshing the hoist after every call would erase most of the
+//     win, so we just skip the optimization for non-leaf fns.
+//   - !isCellBankAMD64(fn) is false (i.e. fn IS cell-bank): RBP must
+//     hold the regsCell base for the prologue to read the handle from.
+//
+// The hoist disp is hoistDispAMD64(fn) = NumRegsI64 * 8: just past the
+// last pinned slot, into a regsI64 backing word that NumRegsI64 stops
+// short of. The interpreter never reads that slot (sized by NumRegsI64),
+// so the JIT can park a scratch value there without corrupting deopt
+// state. The slot is only valid for the duration of one trampoline
+// call; jitCall does not preserve it across calls (it is not in the
+// pinned-slot range).
+func hoistsCellsPtrAMD64(fn *vm3.Function) bool {
+	if !isCellBankAMD64(fn) {
+		return false
+	}
+	if fn.NumRegsCell != 1 {
+		return false
+	}
+	if isNonLeafAMD64(fn) {
+		return false
+	}
+	if !(hasListGetI64(fn) || hasListGetI64K(fn) || hasListSetI64(fn) || hasListPushI64(fn)) {
+		return false
+	}
+	return true
+}
+
+// hoistDispAMD64 returns the disp from RBX (= &regsI64[0]) at which the
+// hoisted cells.ptr is stashed. The slot is just past the live pinned
+// regs (NumRegsI64 * 8). Caller must check hoistsCellsPtrAMD64(fn)
+// first; the disp is undefined otherwise.
+func hoistDispAMD64(fn *vm3.Function) int32 {
+	return int32(fn.NumRegsI64) * 8
+}
+
+// hoistPrologueBytesAMD64 returns the additional prologue byte count
+// needed to compute the hoisted cells.ptr when hoistsCellsPtrAMD64(fn)
+// is true. The sequence is:
+//
+//	mov  disp32(%rbp), %eax     ; idx = regsCell[0] low 32 (6B)
+//	imul $stride, %rax, %rax    ; rax = idx*sizeof(vmList) (7B)
+//	mov  listsBaseOff(%r14), %rcx ; rcx = arenas.Lists base (7B)
+//	add  %rcx, %rax             ; rax = &arenas.Lists[idx] (3B)
+//	mov  cellsOff(%rax), %rax   ; rax = cells.ptr          (7B)
+//	mov  %rax, hoistDisp(%rbx)  ; store at hoist slot      (4 or 7B)
+//
+// disp8 fits when hoistDispAMD64(fn) ∈ [-128, 127]; AMD64 cell-bank
+// caps NumRegsI64 at 8, so disp is 0..64 — always disp8.
+func hoistPrologueBytesAMD64(fn *vm3.Function) int {
+	if !hoistsCellsPtrAMD64(fn) {
+		return 0
+	}
+	storeBytes := 4 // mov %rax, disp8(%rbx)
+	if hoistDispAMD64(fn) < -128 || hoistDispAMD64(fn) > 127 {
+		storeBytes = 7
+	}
+	return 6 + 7 + 7 + 3 + 7 + storeBytes
+}
+
 // computeCallSpillsAMD64 runs backward liveness exactly like the
 // AArch64 backend, but emits a mask over slots 0..5 (caller-saved on
 // AMD64) instead of 0..6.
@@ -468,6 +546,9 @@ func prologueLenAMD64(fn *vm3.Function) int {
 	// Each pinned f64 slot load is movsd disp32(%r14), xmm<r> = 9 bytes
 	// (REX.B-prefixed because R14 is r >= 8).
 	bytes += 9 * nF
+	// Phase 6.3.4.n.2.f: cells.ptr hoist setup (cold form: 0 bytes when
+	// gate fails; ~34 bytes when active). See hoistPrologueBytesAMD64.
+	bytes += hoistPrologueBytesAMD64(fn)
 	_ = pushes
 	return bytes
 }
@@ -529,6 +610,22 @@ func emitPrologueAMD64(buf []byte, fn *vm3.Function) []byte {
 	}
 	for r := 0; r < nF; r++ {
 		buf = append(buf, movsdLoadXMMFromR14(r, int32(r*8))...)
+	}
+	if hoistsCellsPtrAMD64(fn) {
+		stride := int64(vm3.JITListSlabStride())
+		cellsOff := int32(vm3.JITListCellsOffset())
+		listsBaseOff := int32(jitArenaCtxListsBaseOff())
+		hoistDisp := hoistDispAMD64(fn)
+		buf = append(buf, mov32LoadDisp32(xRAX, xRBP, 0)...)
+		buf = append(buf, imul64RRImm32(xRAX, xRAX, int32(stride))...)
+		buf = append(buf, mov64LoadDisp32(xRCX, xR14, listsBaseOff)...)
+		buf = append(buf, add64RR(xRCX, xRAX)...)
+		buf = append(buf, mov64LoadDisp32(xRAX, xRAX, cellsOff)...)
+		if hoistDisp >= -128 && hoistDisp <= 127 {
+			buf = append(buf, mov64StoreDisp8(xRAX, xRBX, int8(hoistDisp))...)
+		} else {
+			buf = append(buf, mov64StoreDisp32(xRAX, xRBX, hoistDisp)...)
+		}
 	}
 	return buf
 }
@@ -792,6 +889,20 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		//   shl  $16, %rax                ; SBFX prep                  (REX.W C1 /4 ib, 4B)
 		//   sar  $16, %rax                ; sign-extend low 48 bits   (REX.W C1 /7 ib, 4B)
 		//   mov  %rax, x_A                ; regsI64[A] = signed payload (REX.W 89 /r, 3B)
+		//
+		// Phase 6.3.4.n.2.f hot form (hoistsCellsPtrAMD64 true): the
+		// prologue already stashed cells.ptr at disp8(%rbx). We replace
+		// the 5-instruction slab/cells.ptr compute chain (mov32, imul,
+		// mov listsBase, add, mov cellsOff = 30B) with a single
+		// mov64LoadDisp8 (4B), saving 26B per op.
+		//   mov  hoistDisp(%rbx), %rax    ; rax = cells.ptr            (4B)
+		//   mov  [%rax + xIdx*8], %rax    ; rax = cells[regsI64[C]]    (4B)
+		//   shl  $16, %rax                ; SBFX prep                  (4B)
+		//   sar  $16, %rax                ; sign-extend low 48 bits    (4B)
+		//   mov  %rax, x_A                ; regsI64[A] = signed payload (3B)
+		if hoistsCellsPtrAMD64(fn) {
+			return 4 + 4 + 4 + 4 + 3, nil
+		}
 		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + 7 + 4 + 4 + 4 + 3, nil
 
 	case vm3.OpListGetI64K:
@@ -812,6 +923,25 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		//   shl  $16, %rax                ; SBFX prep                  (4B)
 		//   sar  $16, %rax                ; sign-extend low 48 bits    (4B)
 		//   mov  %rax, x_A                ; regsI64[A] = signed payload (3B)
+		//
+		// Phase 6.3.4.n.2.f hot form (hoistsCellsPtrAMD64 true): swap
+		// the 5-instruction slab/cells.ptr chain (30B) for the disp8
+		// load of the stashed cells.ptr (4B). The disp32 load of the
+		// constant-indexed cell is unchanged (7B); shorter disp8 form
+		// when idxK*8 fits in [-128, 127] saves another 3B.
+		//   mov  hoistDisp(%rbx), %rax    ; rax = cells.ptr            (4B)
+		//   mov  idxK*8(%rax), %rax       ; rax = cells[idxK]          (4 or 7B)
+		//   shl  $16, %rax                ; SBFX prep                  (4B)
+		//   sar  $16, %rax                ; sign-extend low 48 bits    (4B)
+		//   mov  %rax, x_A                ; regsI64[A] = signed payload (3B)
+		if hoistsCellsPtrAMD64(fn) {
+			idxK := int32(uint16(op.C)) * 8
+			load := 7
+			if idxK >= -128 && idxK <= 127 {
+				load = 4
+			}
+			return 4 + load + 4 + 4 + 3, nil
+		}
 		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + 7 + 7 + 4 + 4 + 3, nil
 
 	case vm3.OpListSetI64:
@@ -828,6 +958,20 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		//   movabs $0xFFFA<<48, %rcx      ; rcx = Int48 tag             (10B)
 		//   or   %rcx, %rdx               ; rdx = tagged payload       (3B)
 		//   mov  %rdx, [%rax + xIdx*8]    ; cells[regsI64[C]] = packed (4B)
+		//
+		// Phase 6.3.4.n.2.f hot form (hoistsCellsPtrAMD64 true): swap
+		// the 5-instruction slab/cells.ptr chain (30B) for the disp8
+		// load (4B). The rest of the packed-Cell prep is identical.
+		//   mov  hoistDisp(%rbx), %rax    ; rax = cells.ptr            (4B)
+		//   mov  xVal, %rdx               ;                            (3B)
+		//   shl  $16, %rdx                ;                            (4B)
+		//   shr  $16, %rdx                ;                            (4B)
+		//   movabs $0xFFFA<<48, %rcx      ;                            (10B)
+		//   or   %rcx, %rdx               ;                            (3B)
+		//   mov  %rdx, [%rax + xIdx*8]    ;                            (4B)
+		if hoistsCellsPtrAMD64(fn) {
+			return 4 + 3 + 4 + 4 + 10 + 3 + 4, nil
+		}
 		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + 7 + 3 + 4 + 4 + 10 + 3 + 4, nil
 
 	case vm3.OpListPushI64:
@@ -1253,16 +1397,25 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		// register for regsI64[C]; xA is the pinned register for
 		// regsI64[A]. The shl/sar pair is the AMD64 equivalent of ARM64
 		// SBFX: it sign-extends the low 48 bits of the boxed Int48 cell.
-		stride := int64(vm3.JITListSlabStride())
-		cellsOff := int32(vm3.JITListCellsOffset())
-		listsBaseOff := int32(jitArenaCtxListsBaseOff())
+		//
+		// Phase 6.3.4.n.2.f: when hoistsCellsPtrAMD64(fn) the prologue
+		// already cached cells.ptr at disp8(%rbx); skip the
+		// slab/cells.ptr compute chain.
 		xIdx := r2xAMD64(uint16(op.C))
 		xA := r2xAMD64(op.A)
-		out := mov32LoadDisp32(xRAX, xRBP, int32(op.B)*8)
-		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
-		out = append(out, mov64LoadDisp32(xRCX, xR14, listsBaseOff)...)
-		out = append(out, add64RR(xRCX, xRAX)...)
-		out = append(out, mov64LoadDisp32(xRAX, xRAX, cellsOff)...)
+		var out []byte
+		if hoistsCellsPtrAMD64(fn) {
+			out = mov64LoadDisp8(xRAX, xRBX, int8(hoistDispAMD64(fn)))
+		} else {
+			stride := int64(vm3.JITListSlabStride())
+			cellsOff := int32(vm3.JITListCellsOffset())
+			listsBaseOff := int32(jitArenaCtxListsBaseOff())
+			out = mov32LoadDisp32(xRAX, xRBP, int32(op.B)*8)
+			out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
+			out = append(out, mov64LoadDisp32(xRCX, xR14, listsBaseOff)...)
+			out = append(out, add64RR(xRCX, xRAX)...)
+			out = append(out, mov64LoadDisp32(xRAX, xRAX, cellsOff)...)
+		}
 		out = append(out, mov64LoadIdxLsl3(xRAX, xRAX, xIdx)...)
 		out = append(out, shl64RImm8(xRAX, 16)...)
 		out = append(out, sar64RImm8(xRAX, 16)...)
@@ -1275,17 +1428,32 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		// the dependence on a live i64 register for the index. Frees one
 		// i64 slot in the kernel; fannkuch_redux uses this to fit
 		// NumRegsI64=8 under the AMD64 cell-bank cap.
-		stride := int64(vm3.JITListSlabStride())
-		cellsOff := int32(vm3.JITListCellsOffset())
-		listsBaseOff := int32(jitArenaCtxListsBaseOff())
+		//
+		// Phase 6.3.4.n.2.f: when hoistsCellsPtrAMD64(fn) the cells.ptr
+		// is already cached at disp8(%rbx); we also shrink the
+		// constant-indexed load to disp8 when idxK*8 fits in [-128, 127]
+		// (the common case: small constant indices like 0..15).
 		idxK := int32(uint16(op.C)) * 8
 		xA := r2xAMD64(op.A)
-		out := mov32LoadDisp32(xRAX, xRBP, int32(op.B)*8)
-		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
-		out = append(out, mov64LoadDisp32(xRCX, xR14, listsBaseOff)...)
-		out = append(out, add64RR(xRCX, xRAX)...)
-		out = append(out, mov64LoadDisp32(xRAX, xRAX, cellsOff)...)
-		out = append(out, mov64LoadDisp32(xRAX, xRAX, idxK)...)
+		var out []byte
+		if hoistsCellsPtrAMD64(fn) {
+			out = mov64LoadDisp8(xRAX, xRBX, int8(hoistDispAMD64(fn)))
+			if idxK >= -128 && idxK <= 127 {
+				out = append(out, mov64LoadDisp8(xRAX, xRAX, int8(idxK))...)
+			} else {
+				out = append(out, mov64LoadDisp32(xRAX, xRAX, idxK)...)
+			}
+		} else {
+			stride := int64(vm3.JITListSlabStride())
+			cellsOff := int32(vm3.JITListCellsOffset())
+			listsBaseOff := int32(jitArenaCtxListsBaseOff())
+			out = mov32LoadDisp32(xRAX, xRBP, int32(op.B)*8)
+			out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
+			out = append(out, mov64LoadDisp32(xRCX, xR14, listsBaseOff)...)
+			out = append(out, add64RR(xRCX, xRAX)...)
+			out = append(out, mov64LoadDisp32(xRAX, xRAX, cellsOff)...)
+			out = append(out, mov64LoadDisp32(xRAX, xRAX, idxK)...)
+		}
 		out = append(out, shl64RImm8(xRAX, 16)...)
 		out = append(out, sar64RImm8(xRAX, 16)...)
 		out = append(out, mov64RR(xRAX, xA)...)
@@ -1302,17 +1470,26 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		// low 48 bits of the value; the movabs supplies the high-16-bit
 		// Int48 tag (0xFFFA in the top 16 of the 64-bit word). The
 		// final SIB store mirrors the ARM64 STR with LSL #3 index.
-		stride := int64(vm3.JITListSlabStride())
-		cellsOff := int32(vm3.JITListCellsOffset())
-		listsBaseOff := int32(jitArenaCtxListsBaseOff())
+		//
+		// Phase 6.3.4.n.2.f: when hoistsCellsPtrAMD64(fn) the cells.ptr
+		// is already cached at disp8(%rbx); skip the slab/cells.ptr
+		// compute chain (RCX is then free up to the movabs tag load).
 		xIdx := r2xAMD64(uint16(op.C))
 		xVal := r2xAMD64(op.B)
 		tag := uint64(0xFFFA) << 48
-		out := mov32LoadDisp32(xRAX, xRBP, int32(op.A)*8)
-		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
-		out = append(out, mov64LoadDisp32(xRCX, xR14, listsBaseOff)...)
-		out = append(out, add64RR(xRCX, xRAX)...)
-		out = append(out, mov64LoadDisp32(xRAX, xRAX, cellsOff)...)
+		var out []byte
+		if hoistsCellsPtrAMD64(fn) {
+			out = mov64LoadDisp8(xRAX, xRBX, int8(hoistDispAMD64(fn)))
+		} else {
+			stride := int64(vm3.JITListSlabStride())
+			cellsOff := int32(vm3.JITListCellsOffset())
+			listsBaseOff := int32(jitArenaCtxListsBaseOff())
+			out = mov32LoadDisp32(xRAX, xRBP, int32(op.A)*8)
+			out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
+			out = append(out, mov64LoadDisp32(xRCX, xR14, listsBaseOff)...)
+			out = append(out, add64RR(xRCX, xRAX)...)
+			out = append(out, mov64LoadDisp32(xRAX, xRAX, cellsOff)...)
+		}
 		out = append(out, mov64RR(xVal, xRDX)...)
 		out = append(out, shl64RImm8(xRDX, 16)...)
 		out = append(out, shr64RImm8(xRDX, 16)...)
@@ -2057,6 +2234,24 @@ func mov64StoreDisp32(src, base int, disp int32) []byte {
 	out := []byte{rex(true, src >= 8, false, base >= 8), 0x89, modRM(2, byte(src), byte(base))}
 	out = appendImm32(out, disp)
 	return out
+}
+
+// mov64LoadDisp8 emits `mov disp8(rBase), rDst`, a 64-bit load with an
+// 8-bit signed displacement. Opcode REX.W 8B /r mod=01 disp8. 4 bytes.
+// Used by the Phase 6.3.4.n.2.f cells.ptr hoist hot form to read the
+// stashed cells.ptr at &regsI64[NumRegsI64] (disp = NumRegsI64*8, which
+// is in 0..64 since the AMD64 cell-bank caps NumRegsI64 at 8). Caller
+// must pre-check that rBase != RSP/R12 (would require a SIB byte).
+func mov64LoadDisp8(dst, base int, disp int8) []byte {
+	return []byte{rex(true, dst >= 8, false, base >= 8), 0x8B, modRM(1, byte(dst&7), byte(base&7)), byte(disp)}
+}
+
+// mov64StoreDisp8 emits `mov rSrc, disp8(rBase)`, the store mirror of
+// mov64LoadDisp8. Opcode REX.W 89 /r mod=01 disp8. 4 bytes. Used by
+// the Phase 6.3.4.n.2.f hoist prologue to stash cells.ptr at
+// &regsI64[NumRegsI64].
+func mov64StoreDisp8(src, base int, disp int8) []byte {
+	return []byte{rex(true, src >= 8, false, base >= 8), 0x89, modRM(1, byte(src&7), byte(base&7)), byte(disp)}
 }
 
 // mov32StoreDisp8 emits `mov %eSrc, disp8(rBase)`, a 32-bit reg-to-mem

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -970,9 +970,17 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		// preserved.
 		//   mov  hoistDisp(%rbx), %rax        ; rax = cells.ptr        (4B)
 		//   mov  xVal, [%rax + xIdx*8]        ; cells[idx] = raw xVal  (4B)
-		//   movw $0xFFFA, 6(%rax,%xIdx,8)     ; overwrite tag bytes    (7B)
+		//   movw $0xFFFA, 6(%rax,%xIdx,8)     ; overwrite tag bytes    (7 or 8B)
+		// The tag-store is 8B when xIdx >= R8 (REX.X needed) and 7B
+		// otherwise; the SIB-store is always 4B because mov64StoreIdxLsl3
+		// emits REX.W unconditionally.
 		if hoistsCellsPtrAMD64(fn) {
-			return 4 + 4 + 7, nil
+			xIdx := r2xAMD64(uint16(op.C))
+			tagBytes := 7
+			if xIdx >= 8 {
+				tagBytes = 8
+			}
+			return 4 + 4 + tagBytes, nil
 		}
 		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + 7 + 3 + 4 + 4 + 10 + 3 + 4, nil
 

--- a/runtime/jit/vm3jit/lower_common.go
+++ b/runtime/jit/vm3jit/lower_common.go
@@ -88,6 +88,31 @@ func hasListGetI64(fn *vm3.Function) bool {
 	return false
 }
 
+// hasListGetI64K reports whether fn contains any OpListGetI64K (the
+// Phase 6.3.4.n.2.e constant-index variant). Both this and hasListGetI64
+// are read by the AMD64 cells.ptr hoist gate so the prologue only pays
+// the slab-pointer compute when a hot list read is in the body.
+func hasListGetI64K(fn *vm3.Function) bool {
+	for _, op := range fn.Code {
+		if op.Code == vm3.OpListGetI64K {
+			return true
+		}
+	}
+	return false
+}
+
+// hasListSetI64 reports whether fn contains any OpListSetI64. The AMD64
+// cells.ptr hoist also benefits set sites (each saves the listsBase +
+// imul + cellsOff load chain).
+func hasListSetI64(fn *vm3.Function) bool {
+	for _, op := range fn.Code {
+		if op.Code == vm3.OpListSetI64 {
+			return true
+		}
+	}
+	return false
+}
+
 // hasMapSetI64I64 reports whether fn contains any OpMapSetI64I64. Each
 // site emits inline splitmix64 + probe loop + 3 stores + nLive bump,
 // gated on a load-factor 0.5 grow check that deopts via StatusMapGrow

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -2996,6 +2996,48 @@ This was verified by probing JITCode on `corpus.FannkuchRedux.Build(100)`: the s
 
 **Follow-up:** open Phase 6.3.4.n.2.e to either squeeze fannkuch_redux into the 8-reg cap or to lift the cap via stack-spill in the cell-bank entry path. The bench results in this section are the honest pre-fix floor.
 
+#### Phase 6.3.4.n.2.f: AMD64 cells.ptr hoist + SIB-store hot form for OpListSetI64 (2026-05-20 12:55 GMT+7)
+
+**Scope.** n.2.e cleared darwin/arm64 (1.26x / 1.28x) but left linux/amd64 at 3.87x / 4.18x. The gap was the *cold form*: every `OpListGetI64` / `OpListGetI64K` / `OpListSetI64` on AMD64 reloaded the slab base (`listsBase`), multiplied by stride, added the cells offset, then re-loaded `cells.ptr` from inside `vmList`. ARM64 already hoisted both pieces in c.1 (slab base) and c.2 (`cells.ptr` pin). n.2.f ports the `cells.ptr` pin to AMD64 and rewrites the `OpListSetI64` hot form so the boxed-Int48 store collapses from a mask-and-OR pack to a SIB-store + tag overwrite.
+
+**`hoistsCellsPtrAMD64` predicate.** Same shape as the ARM64 c.2 predicate: a cell-bank fn qualifies if it has at least one `OpListGet*` / `OpListSet*` / `OpListPushI64` op against a single cell-bank slot whose handle was bound at function entry (i.e., the slot is a parameter or initialized by `OpNewList`). The handle is decoded once at entry and `cells.ptr` is stashed at `regsI64[NumRegsI64]`, which is addressable as `disp8(%rbx)` because `RBX` is the `regsI64` base register and `NumRegsI64 ≤ 8` on AMD64 cell-bank fns. The hoist saves ~26B per hot-form op compared to the cold-form chain (`mov listsBase` + `imul stride` + `add cellsOff` + `mov [+cellsPtrOff]`).
+
+**Hot-form rewrite for `OpListSetI64`.** The cold form packs an Int48 by masking off the high 16 bits of the payload, OR-ing in the `0xFFFA` tag, then storing the 8-byte cell as one MOV. The hot form skips the mask-and-OR by storing the raw 8-byte payload via SIB scale-3, then overwriting *only* bytes 6 and 7 with the 0xFFFA tag (a 16-bit immediate store at `disp+6`). The Int48 sign-extend on read still uses the existing `shl 16 / sar 16` pair, so the truncated bytes 6-7 of the payload are correctly discarded on the next `OpListGetI64`.
+
+```go
+case vm3.OpListSetI64:
+    xIdx := r2xAMD64(uint16(op.C))
+    xVal := r2xAMD64(op.B)
+    if hoistsCellsPtrAMD64(fn) {
+        out := mov64LoadDisp8(xRAX, xRBX, int8(hoistDispAMD64(fn)))
+        out = append(out, mov64StoreIdxLsl3(xVal, xRAX, xIdx)...)
+        out = append(out, mov16ImmStoreSIBDisp8(0xFFFA, xRAX, xIdx, 6)...)
+        return out, nil
+    }
+    // cold form (mask-and-OR pack) kept unchanged
+```
+
+**Two bugs found and fixed.** The rewrite landed in three commits because the first cut hit two compounding encoder bugs that the existing `OpListPushI64` caller had dormant:
+
+1. **byteCount mismatch when xIdx is a high register.** `mov16ImmStoreSIBDisp8(0xFFFA, base, idx, 6)` needs an extra REX.X prefix when `idx >= R8`. The first byteCount returned a flat 15 (`4+4+7`); when the test bench hit `NumRegsI64=4` with `idx` slot 2 (R8), the emit produced 16 bytes and the per-op offset table drifted, so `helper.JITCode` came back nil from compile-time consistency checks. Fix: compute `tagBytes = 7` if `xIdx < 8` else `8` in the byteCount function.
+
+2. **x86_64 prefix ordering (REX before 0x66 is wrong).** After the byteCount fix, the test SIGSEGV'd at `addr 0x0`. Root cause: `mov16ImmStoreSIBDisp8` emitted REX *before* the 0x66 operand-size prefix. x86_64 requires REX to *immediately* precede the opcode byte; the CPU treats `REX, 0x66, opcode` as an ignored REX prefix followed by `66 opcode`, silently dropping the REX.X bit and demoting the R8 SIB index to RAX. The store then went through a wild address derived from `[RAX + RAX*8 + 6]`, segfaulting in the test driver where RAX happened to be near zero. Fix: reorder so `0x66` comes first, then optional REX, then opcode.
+
+The reason these two bugs were dormant before this phase: the only prior caller of `mov16ImmStoreSIBDisp8` (`OpListPushI64`) always lowers with base=RDX and idx=RCX, neither of which is `>= R8`, so the REX path was never triggered and the byteCount was always 15.
+
+**Bench (linux/amd64 server2).** All numbers are medians of 3 runs at `-benchtime=3s`:
+
+| Kernel | vm3jit ns/op | Go ns/op | Ratio | Verdict |
+| :---     | ---:         | ---:     | ---:  | :---:   |
+| `fannkuch_redux_n1000`  | 132,805   | 74,675  | 1.78x | inside 2x (closed) |
+| `fannkuch_redux_n10000` | 1,625,012 | 529,721 | 3.07x | over 2x (n.2.g follow-up) |
+
+n1000 closes under 2x cleanly. n10000 still sits at ~3x, which is consistent with the residual cold-form gap: the kernel's hot path has *one* `OpListGetI64` (not `OpListGetI64K`) inside the inner reverse loop where `idx` is a non-constant slot, and that op still pays the c.1-equivalent slab-base reload per call because n.2.f only ports c.2 (cells.ptr pin), not c.1 (listsBase hoist). The n.2.g sub-phase will port c.1 to close the remaining 1.5x.
+
+**Tests.** The list-set negative-payload test (`TestListSetI64AMD64NegativePayload`, `NumRegsI64=4` so idx slot 2 lowers to R8) is the regression guard for both bugs above. The list-get tests (`TestListGetI64KAMD64` and `TestListGetI64KAMD64NegativePayload`) cover the cells.ptr-pin read path. Full `runtime/jit/vm3jit/` suite passes on server2.
+
+**Closure verdict.** linux/amd64: fannkuch_redux n=1000 cleared at 1.78x; n=10000 still over 2x at 3.07x, tracked as n.2.g. darwin/arm64 unchanged from n.2.e at 1.26x / 1.28x. Composite BG-suite progress: macOS arm64 7/11 closed, linux/amd64 advances the fannkuch_redux headline from interp-floor through JIT-admitted (n.2.e) to under-2x at n=1000 (n.2.f).
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
Tracks #21848.

Ports the ARM64 c.2 `cells.ptr` pin to AMD64 and rewrites the `OpListSetI64` hot form to use a SIB-store + 16-bit tag overwrite instead of the cold mask-and-OR pack. Closes `fannkuch_redux n=1000` under 2x of Go on linux/amd64 (1.78x). `fannkuch_redux n=10000` still at 3.07x because n.2.f only does c.2 (cells.ptr pin), not c.1 (listsBase hoist); tracked as n.2.g (#21848 follow-up).

## Two encoder bugs surfaced and fixed

1. **byteCount mismatch when xIdx >= R8.** `mov16ImmStoreSIBDisp8` needs a REX.X prefix when the SIB index is a high register. Prior byteCount returned 15B flat; when emit produced 16B the per-op offset table drifted, `helper.JITCode` came back nil from the compile-time consistency check.

2. **x86_64 prefix ordering: 0x66 must precede REX.** Initial cut emitted REX before the 0x66 operand-size prefix. REX must immediately precede the opcode byte; with `REX, 0x66, opcode` the CPU treated the REX as an ignored prefix, dropped REX.X, and silently demoted the R8 SIB index to RAX. Produced a wild address and SIGSEGV in the test driver.

Both bugs were dormant in the only prior caller (OpListPushI64 always uses base=RDX/idx=RCX, neither >= R8).

## Bench (linux/amd64 server2)

| Kernel | vm3jit ns/op | Go ns/op | Ratio | Verdict |
| :---     | ---:         | ---:     | ---:  | :---:   |
| fannkuch_redux_n1000  | 132,805   | 74,675  | 1.78x | inside 2x (closed) |
| fannkuch_redux_n10000 | 1,625,012 | 529,721 | 3.07x | over 2x (n.2.g) |

## Tests

- TestListSetI64AMD64NegativePayload (NumRegsI64=4, idx slot 2 → R8) is the regression guard for both encoder bugs.
- TestListGetI64KAMD64 / TestListGetI64KAMD64NegativePayload cover the cells.ptr-pin read path.
- Full runtime/jit/vm3jit/ suite passes on server2.

## Test plan

- [x] runtime/jit/vm3jit tests pass on darwin/arm64
- [x] runtime/jit/vm3jit tests pass on linux/amd64 (server2)
- [x] fannkuch_redux corpus oracle test passes
- [x] bench fannkuch_redux n1000/n10000 on server2
- [x] MEP-40 spec §6.3.4.n.2.f updated with timestamp + bench table