### PR TITLE
corpus/spectral_norm: provision +1 slot for bench-perturb overrun

### DIFF
--- a/compiler3/corpus/spectral_norm.go
+++ b/compiler3/corpus/spectral_norm.go
@@ -76,10 +76,15 @@ func ExpectSpectralNorm(n int64) float64 {
 var SpectralNorm = &Program{
 	Name: "spectral_norm",
 	Build: func(n int64) *vm3.Program {
-		if n < 0 || n > 32767 {
-			panic("spectral_norm: n must fit in int16 for OpNewF64Array")
+		// The bench harness perturbs args[0] = tc.n + (i & 1) to defeat
+		// constant folding, so the kernel may be called with a runtime n
+		// of either tc.n or tc.n+1. Both u and v are pre-allocated with
+		// a baked size at build time; provision one extra slot so the
+		// perturbed call cannot overrun.
+		if n < 0 || n > 32766 {
+			panic("spectral_norm: n must fit in int16-1 for OpNewF64Array")
 		}
-		size := int16(n)
+		size := int16(n + 1)
 		fn := &vm3.Function{
 			Name:        "spectral_norm",
 			NumRegsI64:  5,


### PR DESCRIPTION
Tracks #21850.

The bench harness in `runtime/jit/vm3jit/bench_corpus_jit_test.go` perturbs `args[0] = tc.n + (i & 1)` to defeat constant folding. SpectralNorm.Build(n) bakes `int16(n)` as the `OpNewF64Array` size, so on i=1 the loop ran past the end of u/v and the vm3 interp panicked with \"index out of range [n] with length n\" at the second bench iteration.

Bake `size = int16(n + 1)` instead. One wasted slot per array, no behavioral change for the kernel.

## Test plan

- [x] `go test ./compiler3/corpus/ -run='SpectralNorm'` passes on darwin/arm64
- [x] `go test ./compiler3/corpus/ -run='SpectralNorm'` passes on linux/amd64 (server2)
- [x] `go test ./runtime/jit/vm3jit/ -bench='BenchmarkCorpusJITRunner/spectral_norm' -benchtime=3s -count=3` no longer panics on either platform