### PR TITLE
vm3jit: AMD64 signed magic-multiply for OpDivI64K/OpModI64K (Phase 6.3.4.n.2.h)

### DIFF
--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -812,7 +812,22 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		if op.C == 0 {
 			return 0, fmt.Errorf("%w: opcode %d divide-by-zero immediate", ErrNotImplemented, op.Code)
 		}
-		// mov $imm, %rcx (7) ; mov xB, %rax (3) ; cqo (2) ; idiv %rcx (3) ; mov %rax|%rdx, xA (3).
+		if _, _, corr, ok := signedMagicI64(int64(int32(op.C))); ok {
+			// Phase 6.3.4.n.2.h magic-multiply shape: see
+			// emitDivKOrModKMagicAMD64 for byte-count derivation.
+			// Simple form is 30B (Div) / 43B (Mod); +3B when the
+			// magic multiplier overflows int64 and needs the
+			// `add rdx, rB` correction step.
+			extra := 0
+			if corr {
+				extra = 3
+			}
+			if op.Code == vm3.OpDivI64K {
+				return 30 + extra, nil
+			}
+			return 43 + extra, nil
+		}
+		// IDIV-K fallback: mov $imm, %rcx (7) ; mov xB, %rax (3) ; cqo (2) ; idiv %rcx (3) ; mov %rax|%rdx, xA (3).
 		return 18, nil
 	case vm3.OpCmpEqI64Br, vm3.OpCmpNeI64Br,
 		vm3.OpCmpLtI64Br, vm3.OpCmpLeI64Br,
@@ -1895,7 +1910,18 @@ func emitDivOrMod(fn *vm3.Function, xA, xB, xC, opOff, deoptStart int, isDiv boo
 //	cqo                           ; 2
 //	idiv %rcx                     ; 3
 //	mov  %rax|%rdx, %rXa          ; 3
+//
+// Phase 6.3.4.n.2.h: when imm has a fitting magic multiplier
+// (signedMagicI64 returns ok=true), the lowering switches to
+// emitDivKOrModKMagicAMD64 which replaces IDIV (~30 cycles on EPYC) with
+// a single one-operand IMUL (~3-4 cycles) plus shifts and adds. This is
+// the same generic compiler optimization the Go reference and LLVM
+// apply automatically; on fannkuch_redux the init loop OpModI64K=7
+// executes 7n times so the savings are linear in n.
 func emitDivKOrModK(xA, xB int, imm int32, isDiv bool) []byte {
+	if M, s, corr, ok := signedMagicI64(int64(imm)); ok {
+		return emitDivKOrModKMagicAMD64(xA, xB, M, s, corr, imm, isDiv)
+	}
 	out := movRImm32SignExt(xRCX, imm)
 	out = append(out, mov64RR(xB, xRAX)...)
 	out = append(out, cqoBytes()...)
@@ -1905,6 +1931,57 @@ func emitDivKOrModK(xA, xB int, imm int32, isDiv bool) []byte {
 	} else {
 		out = append(out, mov64RR(xRDX, xA)...)
 	}
+	return out
+}
+
+// emitDivKOrModKMagicAMD64 emits the Phase 6.3.4.n.2.h magic-multiply
+// lowering for OpDivI64K / OpModI64K. Caller has verified via
+// signedMagicI64 that imm has a fitting magic and supplies the
+// correction flag (true when the unsigned magic overflows int64; the
+// signed-product hi underrepresents the unsigned-product hi by n, so
+// we add n back).
+//
+// xB is the vm3 i64 register slot mapped by r2xAMD64; it is always in
+// {RSI, RDI, R8..R14, RBP}, never RAX/RCX/RDX, so the algorithm can
+// freely clobber the latter three. xA is also in that set and may
+// alias xB; the last read of xB happens before the final write to xA.
+//
+//	mov  $M, %rax                 ; 10  (REX.W B8 imm64)
+//	imul rB                       ; 3   (REX.W F7 /5 modrm)
+//	add  rB, %rdx (if corr)       ; 3   ; recover unsigned hi
+//	sar  rdx, $s                  ; 4   (REX.W C1 /7 ib)
+//	mov  rB, %rax                 ; 3
+//	shr  %rax, $63                ; 4
+//	add  %rax, %rdx               ; 3   ; rdx = q (truncated)
+//
+// For Div:
+//
+//	mov  %rdx, xA                 ; 3   ; 30 (or 33 with corr) bytes
+//
+// For Mod (r = n - q*d):
+//
+//	imul rdx, rdx, $d             ; 7   (REX.W 69 /r imm32) ; rdx = q*d
+//	mov  rB, %rax                 ; 3   ; rax = n
+//	sub  %rdx, %rax               ; 3   ; rax = n - q*d
+//	mov  %rax, xA                 ; 3   ; 43 (or 46 with corr) bytes
+func emitDivKOrModKMagicAMD64(xA, xB int, M int64, s uint, needsCorrection bool, d int32, isDiv bool) []byte {
+	out := movRImm64(xRAX, M)
+	out = append(out, imul64ROne(xB)...)
+	if needsCorrection {
+		out = append(out, add64RR(xB, xRDX)...)
+	}
+	out = append(out, sar64RImm8(xRDX, uint8(s))...)
+	out = append(out, mov64RR(xB, xRAX)...)
+	out = append(out, shr64RImm8(xRAX, 63)...)
+	out = append(out, add64RR(xRAX, xRDX)...)
+	if isDiv {
+		out = append(out, mov64RR(xRDX, xA)...)
+		return out
+	}
+	out = append(out, imul64RRImm32(xRDX, xRDX, d)...)
+	out = append(out, mov64RR(xB, xRAX)...)
+	out = append(out, sub64RR(xRDX, xRAX)...)
+	out = append(out, mov64RR(xRAX, xA)...)
 	return out
 }
 
@@ -2088,6 +2165,15 @@ func shr64RImm8(dst int, imm uint8) []byte {
 // is the dividend; RAX = quotient, RDX = remainder on return.
 func idiv64R(divisor int) []byte {
 	return []byte{rex(true, false, false, divisor >= 8), 0xF7, modRM(3, 7, byte(divisor))}
+}
+
+// imul64ROne emits one-operand `imul %rSrc` (Intel: imul rSrc). Opcode
+// REX.W F7 /5: RDX:RAX = sign_extend(RAX) * rSrc (full 128-bit signed
+// product). Used by the Phase 6.3.4.n.2.h signed-mod-by-constant
+// magic-multiply lowering to replace the ~30-cycle IDIV with a ~3-cycle
+// IMUL on hot loop bodies (Granlund-Montgomery, Hacker's Delight §10-4).
+func imul64ROne(r int) []byte {
+	return []byte{rex(true, false, false, r >= 8), 0xF7, modRM(3, 5, byte(r))}
 }
 
 // test64RR emits `test %rSrc, %rDst` (Intel: test rDst, rSrc).

--- a/runtime/jit/vm3jit/signed_magic.go
+++ b/runtime/jit/vm3jit/signed_magic.go
@@ -1,0 +1,75 @@
+package vm3jit
+
+// signedMagicI64 computes the magic multiplier M and shift s for
+// signed division by the constant d, per Granlund-Montgomery (Hacker's
+// Delight §10-4).
+//
+// The truncated-toward-zero quotient of `n / d` (matching Go's `/`
+// semantics) is reconstructed from the result as:
+//
+//	hi := int64(int128(n) * M) >> 64
+//	if needsCorrection { hi += n }   // M is the low 64 bits of an
+//	                                  // unsigned magic that overflows
+//	                                  // a signed int64
+//	q  := (hi >> s) + (uint64(n) >> 63)
+//
+// and the remainder is `r = n - q*d`. needsCorrection is true when the
+// computed unsigned magic mu is >= 2^63 (the "M < 2^63" simple shape
+// from HD §10-3 does not apply). The AMD64 lowering folds the
+// correction into a single `add rdx, rB` between the IMUL and the SAR
+// — 3 extra bytes per magic-multiply site.
+//
+// ok=true is gated on d > 1 and d not a power of two (power-of-2 cases
+// have cheaper arithmetic-shift lowerings the JIT can add later, so
+// for now they fall back to IDIV-K). Negative d and d in {-1, 0, 1}
+// also fall back to IDIV-K; the BG corpus kernels never exercise them
+// and a follow-up phase can extend the predicate without changing the
+// emit shape.
+//
+// The helper lives in a tagless file (rather than lower_amd64.go) so
+// the arm64 host can unit-test the algorithm against known constants
+// and against Go's `/` and `%` operators without a cross-arch build.
+// AMD64 is the only backend that calls it today (Phase 6.3.4.n.2.h);
+// ARM64 has cheaper SDIV+MSUB so the same gate is not worth the
+// code-size cost there.
+func signedMagicI64(d int64) (M int64, s uint, needsCorrection, ok bool) {
+	if d <= 1 {
+		return 0, 0, false, false
+	}
+	if d&(d-1) == 0 {
+		return 0, 0, false, false
+	}
+	const two63 = uint64(1) << 63
+	ad := uint64(d)
+	t := two63
+	anc := t - 1 - t%ad
+	p := uint(63)
+	q1 := two63 / anc
+	r1 := two63 - q1*anc
+	q2 := two63 / ad
+	r2 := two63 - q2*ad
+	var delta uint64
+	for {
+		p++
+		q1 <<= 1
+		r1 <<= 1
+		if r1 >= anc {
+			q1++
+			r1 -= anc
+		}
+		q2 <<= 1
+		r2 <<= 1
+		if r2 >= ad {
+			q2++
+			r2 -= ad
+		}
+		delta = ad - r2
+		if q1 < delta || (q1 == delta && r1 == 0) {
+			continue
+		}
+		break
+	}
+	mu := q2 + 1
+	needsCorrection = mu >= two63
+	return int64(mu), p - 64, needsCorrection, true
+}

--- a/runtime/jit/vm3jit/signed_magic_test.go
+++ b/runtime/jit/vm3jit/signed_magic_test.go
@@ -1,0 +1,117 @@
+package vm3jit
+
+import "testing"
+
+// TestSignedMagicI64KnownConstants verifies the Granlund-Montgomery
+// magic multiplier matches well-known reference values. The algorithm
+// minimizes the shift count s, so 6 = 2*3 ends up with the half-magic
+// of 3 and s=0 rather than M(3)*2 and s=1.
+func TestSignedMagicI64KnownConstants(t *testing.T) {
+	cases := []struct {
+		d        int64
+		wantM    int64
+		wantS    uint
+		wantCorr bool
+		wantOk   bool
+		comment  string
+	}{
+		{3, 0x5555555555555556, 0, false, true, "fundamental"},
+		{5, 0x6666666666666667, 1, false, true, "fundamental"},
+		{6, 0x2AAAAAAAAAAAAAAB, 0, false, true, "= 2*3, minimized"},
+		{7, 0x4924924924924925, 1, false, true, "fannkuch init loop"},
+		{9, 0x1C71C71C71C71C72, 0, false, true, "fundamental, minimized"},
+		{10, 0x6666666666666667, 2, false, true, "= 2*5"},
+		{11, 0x2E8BA2E8BA2E8BA3, 1, false, true, "fundamental"},
+		// 100, 1000, etc. fall into the correction-needed shape
+		// (unsigned magic overflows int64).
+		{100, -0x5C28F5C28F5C28F5, 6, true, true, "needs correction"},
+		{0, 0, 0, false, false, "divide-by-zero falls through"},
+		{1, 0, 0, false, false, "identity falls through"},
+		{2, 0, 0, false, false, "power of 2 -> shift fallback"},
+		{4, 0, 0, false, false, "power of 2 -> shift fallback"},
+		{8, 0, 0, false, false, "power of 2 -> shift fallback"},
+		{-1, 0, 0, false, false, "negative falls through"},
+		{-7, 0, 0, false, false, "negative falls through"},
+	}
+	for _, c := range cases {
+		gotM, gotS, gotCorr, gotOk := signedMagicI64(c.d)
+		if gotOk != c.wantOk {
+			t.Errorf("d=%d (%s): ok got %v want %v", c.d, c.comment, gotOk, c.wantOk)
+			continue
+		}
+		if !gotOk {
+			continue
+		}
+		if gotM != c.wantM || gotS != c.wantS || gotCorr != c.wantCorr {
+			t.Errorf("d=%d (%s): got M=%#x s=%d corr=%v, want M=%#x s=%d corr=%v",
+				c.d, c.comment, uint64(gotM), gotS, gotCorr,
+				uint64(c.wantM), c.wantS, c.wantCorr)
+		}
+	}
+}
+
+// TestSignedMagicI64MatchesGoDiv exhaustively verifies that for every
+// d where signedMagicI64 returns ok=true, the magic-multiply formula
+// reproduces Go's truncated `n / d` and `n % d` over a representative
+// set of n values including the int64 extremes. This covers both the
+// simple shape (corr=false) and the correction shape (corr=true).
+func TestSignedMagicI64MatchesGoDiv(t *testing.T) {
+	ds := []int64{3, 5, 6, 7, 9, 10, 11, 13, 17, 100, 1000, 7919, (1 << 30) + 1, (1 << 62) - 17}
+	ns := []int64{
+		0, 1, -1, 2, -2, 7, -7, 1023, -1023,
+		99, -99, 100, -100, 101, -101, 1000, -1000,
+		1<<31 - 1, -(1 << 31), 1 << 32, -(1 << 32),
+		1<<62 - 1, -(1 << 62),
+		1<<63 - 1, -(1 << 63),
+		3141592653589793238, -3141592653589793238,
+	}
+	for _, d := range ds {
+		M, s, corr, ok := signedMagicI64(d)
+		if !ok {
+			t.Fatalf("d=%d: signedMagicI64 ok=false (expected non-trivial)", d)
+		}
+		for _, n := range ns {
+			hi := mul128Hi(n, M)
+			if corr {
+				hi += n
+			}
+			gotQ := hi >> s
+			gotQ += int64(uint64(n) >> 63)
+			gotR := n - gotQ*d
+			wantQ := n / d
+			wantR := n % d
+			if gotQ != wantQ || gotR != wantR {
+				t.Errorf("d=%d n=%d: got q=%d r=%d want q=%d r=%d (M=%#x s=%d corr=%v)",
+					d, n, gotQ, gotR, wantQ, wantR, uint64(M), s, corr)
+			}
+		}
+	}
+}
+
+// mul128Hi returns the high 64 bits of the signed 128-bit product
+// a*b. Pure-Go, used only by the magic-multiply unit test.
+func mul128Hi(a, b int64) int64 {
+	const mask32 = uint64(1<<32 - 1)
+	ua := uint64(a)
+	ub := uint64(b)
+	aLo := ua & mask32
+	aHi := ua >> 32
+	bLo := ub & mask32
+	bHi := ub >> 32
+
+	loLo := aLo * bLo
+	hiLo := aHi * bLo
+	loHi := aLo * bHi
+	hiHi := aHi * bHi
+
+	mid := (loLo >> 32) + (hiLo & mask32) + (loHi & mask32)
+	hi := hiHi + (hiLo >> 32) + (loHi >> 32) + (mid >> 32)
+
+	if a < 0 {
+		hi -= uint64(b)
+	}
+	if b < 0 {
+		hi -= uint64(a)
+	}
+	return int64(hi)
+}

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -3038,6 +3038,46 @@ n1000 closes under 2x cleanly. n10000 still sits at ~3x, which is consistent wit
 
 **Closure verdict.** linux/amd64: fannkuch_redux n=1000 cleared at 1.78x; n=10000 still over 2x at 3.07x, tracked as n.2.g. darwin/arm64 unchanged from n.2.e at 1.26x / 1.28x. Composite BG-suite progress: macOS arm64 7/11 closed, linux/amd64 advances the fannkuch_redux headline from interp-floor through JIT-admitted (n.2.e) to under-2x at n=1000 (n.2.f).
 
+#### Phase 6.3.4.n.2.h: AMD64 signed magic-multiply for `OpDivI64K` / `OpModI64K` (2026-05-20 17:45 GMT+7)
+
+**Why this phase.** After n.2.f, `fannkuch_redux_n10000` on linux/amd64 sat at 3.07x of Go: 1,625,012 ns/op vs 529,721 ns/op. Profiling the inner loop showed two costs dominating the residual gap: the `OpListGetI64` non-K cell-bank read (addressed independently by n.2.g) and the `% 7` rotation inside `permute()` lowered as 64-bit `IDIV` against a constant immediate. AMD64 `IDIV r/m64` is microcoded and serializes against the entire dispatch group (Intel/AMD agree at ~25-40 cycles latency, no early-out for small dividends); Go's compiler replaces `n % 7` with the Granlund-Montgomery signed magic-multiply sequence (`IMUL`+`SHR`+`SUB`) which retires in ~5 cycles. The vm3jit emitter was still falling back to plain `IDIV` for OpDivI64K and OpModI64K, so it paid the full microcoded cost on every iteration of the reverse-rotate loop.
+
+**What changed.** A new tagless helper `signedMagicI64(d int64) (M int64, s uint, needsCorrection, ok bool)` in `runtime/jit/vm3jit/signed_magic.go` computes the magic multiplier per Hacker's Delight §10-4 (Granlund-Montgomery). The AMD64 emitter (`emitDivKOrModK` in `lower_amd64.go`) now gates on `signedMagicI64`: when ok is true it emits the magic-multiply sequence; otherwise it falls through to the existing `IDIV r/m64` lowering. The helper handles two shapes from HD §10-3 / §10-4:
+
+  - **Simple shape** (`M < 2^63`, e.g. `d ∈ {3, 5, 6, 7, 9, 11, ...}`): emit `MOV $M, RAX; IMUL64R xB; SAR $s, RDX; MOV RAX, xB; SHR $63, RAX; ADD RAX, RDX`. Result `q` lands in RDX (for OpDivI64K we copy to xA; for OpModI64K we follow with `IMUL $d, RDX; SUB RAX, RDX` to land `r` in xA).
+  - **Correction shape** (`M >= 2^63`, e.g. `d ∈ {100, 1000, ...}`): same as above but inserts `ADD xB, RDX` between IMUL and SAR (3 extra bytes). This is the standard Granlund-Montgomery correction for unsigned magics that overflow signed int64; Go's compiler emits exactly this sequence too.
+
+  Byte budgets:
+
+  | Op | shape | bytes (was IDIV-K=18) |
+  | :--- | :--- | ---: |
+  | `OpDivI64K` | simple | 30 |
+  | `OpDivI64K` | correction | 33 |
+  | `OpModI64K` | simple | 43 |
+  | `OpModI64K` | correction | 46 |
+
+  Power-of-2 divisors (`d & (d-1) == 0`) and `d ∈ {-1, 0, 1}` fall through to IDIV-K (or a future ASR fast-path). Negative d also falls through; the BG corpus kernels never use them and a follow-up phase can extend the predicate without changing the emit shape.
+
+**Why this is a generic win, not a fannkuch hack.** Every BG-corpus integer kernel that does `% k` or `/ k` against a non-power-of-2 immediate benefits. The replacement is exactly what Go's `cmd/compile/internal/ssa/rewrite` does for `(Mod64 x (Const64 [c]))` (file `gen/generic.rules`, rules `Mod64(x, Const64 [c])` -> `Sub64(x, Mul64(Div64u(x, c), c))` chained with the magic-multiply rules in `_gen/AMD64.rules`). It is also what LLVM (`X86ISelLowering::BuildSDIVPow2`, `TargetLowering::BuildSDIV`) and HotSpot (`MagicLongDivideGenerator`) emit. The MEP-39 "no hard-coded BG super-ops" rule is preserved: this is an opcode-level codegen improvement, not a kernel-shape match.
+
+**Correctness.** `runtime/jit/vm3jit/signed_magic_test.go` (also tagless so darwin/arm64 unit-tests the algorithm) has two tests:
+
+  - `TestSignedMagicI64KnownConstants` pins `(M, s, needsCorrection)` for `d ∈ {3, 5, 6, 7, 9, 10, 11, 100}` against published reference values from HD Table 10-1.
+  - `TestSignedMagicI64MatchesGoDiv` exhaustively cross-checks the magic-multiply formula against Go's `/` and `%` operators for `d ∈ {3, 5, 6, 7, 9, 10, 11, 13, 17, 100, 1000, 7919, (1<<30)+1, (1<<62)-17}` and `n ∈ {0, ±1, ±2, ±7, ±99/100/101, ±1023, ±1000, ±2^31, ±2^32, ±(2^62-1), ±(2^63-1), ±2^63, ±π·10^18}`. Covers both simple and correction shapes at int64 extremes. All cases pass.
+
+**Bench (linux/amd64 server2, median of 10 at -benchtime=3s).**
+
+| Kernel | vm3jit n.2.f baseline | vm3jit n.2.h | Go ns/op | Ratio (n.2.h) | Verdict |
+| :---     | ---:         | ---:         | ---:     | ---:  | :---:   |
+| `fannkuch_redux_n1000`  | 132,805   | 106,588   | 60,393  | 1.77x | inside 2x (closed) |
+| `fannkuch_redux_n10000` | 1,625,012 | 1,075,128 | 630,925 | 1.70x | **inside 2x (closed)** |
+
+n10000 closes from 3.07x to 1.70x, a 33% reduction in JIT ns/op. The Go reference drifted from 530k (n.2.f run) to 631k on this re-bench, likely thermal/neighbor variance on the EPYC host; even using the optimistic 530k as denominator the ratio is 2.03x, and using paired same-session medians (the methodology used everywhere else in this MEP for cross-platform fairness) it lands at 1.70x.
+
+**Tests.** All of `runtime/jit/vm3jit/...` passes on darwin/arm64 (helper unit tests + arm64 backend unaffected) and on linux/amd64 server2 (magic-multiply path active for OpDivI64K/OpModI64K against non-power-of-2 immediates). No regressions on the `compiler3/corpus/` Go-reference suite either.
+
+**Closure verdict.** linux/amd64: fannkuch_redux n=1000 holds at 1.77x; n=10000 closes from 3.07x to **1.70x**, clearing the under-2x gate independently of n.2.g (which is orthogonal: n.2.g pins cells.ptr in RDX for OpListGetI64; n.2.h replaces IDIV-K with magic-multiply for OpModI64K). With n.2.h alone, the BG suite linux/amd64 closure advances from "0/11 under 2x" (n.2.f spec) to "fannkuch_redux closed at both n sizes". The remaining un-closed linux kernels (nsieve, binary_trees, n_body, k_nucleotide, reverse_complement, spectral_norm, fasta, mandelbrot) are tracked by their own sub-phases under n.2 and o.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
## Summary
- Wires Granlund-Montgomery signed magic-multiply into AMD64 `emitDivKOrModK` so `OpDivI64K` / `OpModI64K` against non-power-of-2 constants no longer pay microcoded `IDIV r/m64` cost.
- `fannkuch_redux_n10000` on linux/amd64 closes from 3.07x of Go to **1.70x** (median-of-10, paired same-session Go reference on server2 EPYC).
- Same codegen transformation Go/LLVM/HotSpot all do; preserves the no-hard-coded-BG-super-ops rule (opcode-level win, not kernel-shape match).

Tracking: #21860 / MEP-40 §6.3.4.n.2.h.

## Bench (linux/amd64 server2, median of 10 at -benchtime=3s)

| Kernel | vm3jit n.2.f baseline | vm3jit n.2.h | Go ns/op | Ratio | Verdict |
| :--- | ---: | ---: | ---: | ---: | :---: |
| `fannkuch_redux_n1000`  | 132,805   | 106,588   | 60,393  | 1.77x | inside 2x |
| `fannkuch_redux_n10000` | 1,625,012 | 1,075,128 | 630,925 | **1.70x** | **closed** |

## Test plan
- [x] `go test ./runtime/jit/vm3jit/ -run TestSignedMagic` on darwin/arm64 (tagless helper)
- [x] `GOOS=linux GOARCH=amd64 go build ./runtime/jit/vm3jit/...` clean
- [x] `go test ./runtime/jit/vm3jit/...` passes on linux/amd64 server2
- [x] paired bench above on server2