### PR TITLE
ci: add explicit step IDs and group markers to workflows

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -24,18 +24,20 @@ concurrency:
 
 jobs:
   deploy:
-    name: Build & deploy
+    name: Build and deploy website
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: website
     steps:
       - name: Checkout
+        id: checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
+        id: setup-node
         uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -43,10 +45,18 @@ jobs:
           cache-dependency-path: website/package-lock.json
 
       - name: Install dependencies
-        run: npm ci
+        id: install
+        run: |
+          echo "::group::Step: install"
+          npm ci
+          echo "::endgroup::"
 
       - name: Build website
-        run: npm run build
+        id: build
+        run: |
+          echo "::group::Step: build"
+          npm run build
+          echo "::endgroup::"
 
       - name: Deploy to Cloudflare Pages
         id: deploy

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,19 +10,22 @@ permissions:
 
 jobs:
   docker:
-    name: Build and Push Docker Image
+    name: Build and push Docker image
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout source
+        id: checkout
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v4
         with:
           install: true
 
       - name: Log in to GitHub Container Registry
+        id: login
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -41,6 +44,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push (multi-platform)
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,11 @@ jobs:
 
     steps:
       - name: Checkout code
+        id: checkout
         uses: actions/checkout@v6
 
       - name: Set up Go
+        id: setup-go
         uses: actions/setup-go@v6
         with:
           go-version: '^1.26'
@@ -22,14 +24,25 @@ jobs:
             go.sum
 
       - name: Build
-        run: go build -v ./...
+        id: build
+        run: |
+          echo "::group::Step: build"
+          go build -v ./...
+          echo "::endgroup::"
 
       - name: Run tests
+        id: tests
         run: |
+          echo "::group::Step: tests"
           go test -vet=off -v -race \
             -coverprofile=coverage.txt \
             -covermode=atomic \
             ./parser/... ./runtime/vm/...
+          echo "::endgroup::"
 
       - name: Run MEP-4 soundness suite
-        run: go test -vet=off -v ./types/... -run TestSoundness
+        id: soundness
+        run: |
+          echo "::group::Step: soundness"
+          go test -vet=off -v ./types/... -run TestSoundness
+          echo "::endgroup::"


### PR DESCRIPTION
## Summary

- `gh run view --log` was labelling every log line as `UNKNOWN STEP` for some recent failed CI runs (e.g. 26147377228 on the n.3 build). Root cause: GitHub Actions occasionally archives only the whole-job log file and omits the per-step files, so the gh CLI parser has no step records to match log lines against.
- This PR enhances the three workflow files so step boundaries remain identifiable even when the per-step archive is missing: each step gets an explicit `id:`, and each custom `run:` block is wrapped with `echo "::group::Step: <name>"` / `echo "::endgroup::"` markers that carry the configured step name (not just the inline command) into the full-job log.
- Renames the deploy job from `Build & deploy` to `Build and deploy website` and the docker job to `Build and push Docker image` so job names avoid `&` and follow consistent casing.

## Test plan

- [x] YAML syntax validates locally.
- [ ] Workflow runs trigger on this PR. Verify the CI logs:
  - `Build website` step in the deploy workflow shows `##[group]Step: build` near the top of its output.
  - Step names are visible in `gh run view --log` output for any failed run.
- [ ] Confirm test / build commands still run unchanged (no behavior changes intended).

Closes #21862.