### PR TITLE
vm3jit: replay AMD64 cell+f64 admission (Phase 6.3.4.n.6)

### DIFF
--- a/runtime/jit/vm3jit/arena_ctx.go
+++ b/runtime/jit/vm3jit/arena_ctx.go
@@ -97,3 +97,19 @@ func jitArenaCtxPairsBaseOff() uintptr {
 func jitArenaCtxListsBaseOff() uintptr {
 	return unsafe.Offsetof(jitArenaCtx{}.listsBase)
 }
+
+// jitArenaCtxF64ArrsBaseOff is the byte offset of f64ArrsBase within
+// jitArenaCtx. AMD64 OpF64ArrayGetF64/OpF64ArraySetF64 (Phase 6.3.4.n.3)
+// load it from R14+disp32 to recover the F64 array slab base on
+// cell-bank fns.
+func jitArenaCtxF64ArrsBaseOff() uintptr {
+	return unsafe.Offsetof(jitArenaCtx{}.f64ArrsBase)
+}
+
+// jitArenaCtxI64ArrsBaseOff is the byte offset of i64ArrsBase within
+// jitArenaCtx. AMD64 OpI64ArrayGetI64/OpI64ArraySetI64 (Phase 6.3.4.n.3)
+// load it from R14+disp32 to recover the I64 array slab base on
+// cell-bank fns.
+func jitArenaCtxI64ArrsBaseOff() uintptr {
+	return unsafe.Offsetof(jitArenaCtx{}.i64ArrsBase)
+}

--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -347,14 +347,14 @@ func checkCellBankAdmissible(fn *vm3.Function, opts Options) error {
 //     the emit step writes zero bytes). All cold form; hoisted slab-base
 //     optimizations come in later sub-phases.
 //
-// Map ops on cell-bank AMD64 are still out of scope. f64 banks remain
-// rejected because cell-bank repurposes R14 for *jitArenaCtx and R14 is
-// the f64 base on AMD64.
+// Map ops on cell-bank AMD64 are still out of scope. Phase 6.3.4.n.3
+// admits Cell+F64 fns by pinning the regsF64 base in R12 (instead of
+// R14) so spectral_norm and friends can JIT on linux/amd64. The
+// admission gate additionally allows the F64 arithmetic / Const / Mov /
+// Conv / Return ops plus OpF64ArrayGet/Set/Len and the matching I64
+// array opcodes; OpNewF64Array / OpNewI64Array are admitted only at the
+// pre-alloc K-prefix (jitCall pre-allocates the slab).
 func checkCellBankAdmissibleAMD64(fn *vm3.Function, opts Options) error {
-	if fn.NumRegsF64 > 0 {
-		return fmt.Errorf("%w: %s has both Cell and f64 banks (AMD64 m.4c.1 admits Cell+I64 only; R14 shared)",
-			ErrNotImplemented, fn.Name)
-	}
 	for i, op := range fn.Code {
 		switch op.Code {
 		case vm3.OpConstI64K, vm3.OpConstI64KW, vm3.OpMovI64,
@@ -374,8 +374,31 @@ func checkCellBankAdmissibleAMD64(fn *vm3.Function, opts Options) error {
 			vm3.OpPairFst, vm3.OpPairSnd, vm3.OpNewPair,
 			vm3.OpListGetI64, vm3.OpListSetI64, vm3.OpListPushI64,
 			vm3.OpListGetI64K,
-			vm3.OpLookupI64KW:
+			vm3.OpLookupI64KW,
+			// Phase 6.3.4.n.3: F64 bank ops admitted on cell-bank+f64.
+			vm3.OpConstF64K, vm3.OpMovF64,
+			vm3.OpAddF64, vm3.OpSubF64, vm3.OpMulF64, vm3.OpDivF64,
+			vm3.OpNegF64, vm3.OpFmaF64, vm3.OpSqrtF64,
+			vm3.OpCmpEqF64Br, vm3.OpCmpNeF64Br,
+			vm3.OpCmpLtF64Br, vm3.OpCmpLeF64Br,
+			vm3.OpCmpGtF64Br, vm3.OpCmpGeF64Br,
+			vm3.OpI64ToF64, vm3.OpF64ToI64,
+			vm3.OpReturnF64,
+			// Phase 6.3.4.n.3: F64Array and I64Array element accessors.
+			vm3.OpF64ArrayGetF64, vm3.OpF64ArraySetF64, vm3.OpF64ArrayLenI64,
+			vm3.OpI64ArrayGetI64, vm3.OpI64ArraySetI64, vm3.OpI64ArrayLenI64:
 			continue
+		case vm3.OpNewF64Array, vm3.OpNewI64Array:
+			// Phase 6.3.4.n.3: admit at the pre-alloc K-prefix only.
+			// jitCall pre-allocates the slab; emit step skips the op.
+			if op.Code == vm3.OpNewF64Array && i < int(fn.JITPreAllocF64ArrPrefix) {
+				continue
+			}
+			if op.Code == vm3.OpNewI64Array && i < int(fn.JITPreAllocI64ArrPrefix) {
+				continue
+			}
+			return fmt.Errorf("%w: %s pc %d Cell-bank fn uses inline %v (only pre-alloc K-prefix is admitted on AMD64)",
+				ErrNotImplemented, fn.Name, i, op.Code)
 		case vm3.OpNewList:
 			// Phase 6.3.4.n.2.c: admit at pc=0 when the lowerer can skip
 			// emission (jitCall pre-allocates the list). Inline OpNewList
@@ -597,6 +620,12 @@ func archCaps(fn *vm3.Function) (int, int, bool) {
 			// (arenaCtx) and RBP (regsCell). Slot 8 and slot 9 are both
 			// unavailable, so the cap drops by two: effective cap = 8.
 			i64Cap = maxI64RegsAMD64 - 2
+		}
+		if fn.NumRegsCell > 0 && fn.NumRegsF64 > 0 {
+			// Phase 6.3.4.n.3: Cell+F64 fns additionally pin R12 as the
+			// regsF64 base because R14 is already the *jitArenaCtx
+			// pointer for cell-bank fns. R12 is i64 slot 6, so cap = 6.
+			i64Cap = 6
 		}
 		return i64Cap, maxF64RegsAMD64, true
 	default:

--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -622,10 +622,11 @@ func archCaps(fn *vm3.Function) (int, int, bool) {
 			i64Cap = maxI64RegsAMD64 - 2
 		}
 		if fn.NumRegsCell > 0 && fn.NumRegsF64 > 0 {
-			// Phase 6.3.4.n.3: Cell+F64 fns additionally pin R12 as the
-			// regsF64 base because R14 is already the *jitArenaCtx
-			// pointer for cell-bank fns. R12 is i64 slot 6, so cap = 6.
-			i64Cap = 6
+			// Phase 6.3.4.n.4: Cell+F64 fns pin R12 as the regsF64 base
+			// (R14 is the *jitArenaCtx for cell-bank fns) and remap
+			// i64 slot 6 from R12 to R13. Slot 7's old home (R13) is
+			// now consumed by slot 6, so the effective cap is 7.
+			i64Cap = 7
 		}
 		return i64Cap, maxF64RegsAMD64, true
 	default:

--- a/runtime/jit/vm3jit/f64arr_amd64_test.go
+++ b/runtime/jit/vm3jit/f64arr_amd64_test.go
@@ -1,0 +1,174 @@
+//go:build amd64
+
+package vm3jit_test
+
+import (
+	"math"
+	"testing"
+
+	"mochi/compiler3/corpus"
+	"mochi/runtime/jit/vm3jit"
+	"mochi/runtime/vm3"
+)
+
+// TestF64ArrayJITGetSetAMD64 exercises the Phase 6.3.4.n.3 AMD64
+// lowering for the OpNewF64Array (pre-alloc skip) + OpF64ArraySetF64 +
+// OpF64ArrayGetF64 round-trip on a cell-bank+f64 fn. The shape mirrors
+// the ARM64 TestF64ArrayJITGetSet so the JIT path is bit-for-bit
+// comparable across backends.
+func TestF64ArrayJITGetSetAMD64(t *testing.T) {
+	cs := []vm3.Cell{
+		vm3.CFloat(1.5),
+		vm3.CFloat(-2.25),
+		vm3.CFloat(0.0),
+		vm3.CFloat(math.Inf(1)),
+		vm3.CFloat(math.Inf(-1)),
+	}
+	wantSum := 1.5 + -2.25 + 0.0 + math.Inf(1) + math.Inf(-1) // NaN
+
+	fn := &vm3.Function{
+		Name:        "f64arr_amd64_round_trip",
+		NumRegsI64:  1,
+		NumRegsF64:  2,
+		NumRegsCell: 1,
+		ResultBank:  vm3.BankF64,
+		Consts:      cs,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewF64Array, 0, 0, 5),
+			vm3.MakeOp(vm3.OpConstF64K, 0, 0, 0),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 0),
+			vm3.MakeOp(vm3.OpF64ArraySetF64, 0, 0, 0),
+			vm3.MakeOp(vm3.OpConstF64K, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 1),
+			vm3.MakeOp(vm3.OpF64ArraySetF64, 0, 0, 0),
+			vm3.MakeOp(vm3.OpConstF64K, 0, 0, 2),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 2),
+			vm3.MakeOp(vm3.OpF64ArraySetF64, 0, 0, 0),
+			vm3.MakeOp(vm3.OpConstF64K, 0, 0, 3),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 3),
+			vm3.MakeOp(vm3.OpF64ArraySetF64, 0, 0, 0),
+			vm3.MakeOp(vm3.OpConstF64K, 0, 0, 4),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 4),
+			vm3.MakeOp(vm3.OpF64ArraySetF64, 0, 0, 0),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 0),
+			vm3.MakeOp(vm3.OpF64ArrayGetF64, 0, 0, 0),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 1),
+			vm3.MakeOp(vm3.OpF64ArrayGetF64, 1, 0, 0),
+			vm3.MakeOp(vm3.OpAddF64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 2),
+			vm3.MakeOp(vm3.OpF64ArrayGetF64, 1, 0, 0),
+			vm3.MakeOp(vm3.OpAddF64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 3),
+			vm3.MakeOp(vm3.OpF64ArrayGetF64, 1, 0, 0),
+			vm3.MakeOp(vm3.OpAddF64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 4),
+			vm3.MakeOp(vm3.OpF64ArrayGetF64, 1, 0, 0),
+			vm3.MakeOp(vm3.OpAddF64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpReturnF64, 0, 0, 0),
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{fn}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if fn.JITCode == nil {
+		t.Fatalf("f64arr_amd64_round_trip did not compile (JITCode is nil); "+
+			"NumRegsCell=%d, NumRegsF64=%d, JITPreAllocF64ArrPrefix=%d",
+			fn.NumRegsCell, fn.NumRegsF64, fn.JITPreAllocF64ArrPrefix)
+	}
+	if fn.JITPreAllocF64ArrPrefix != 1 {
+		t.Fatalf("JITPreAllocF64ArrPrefix: got %d want 1", fn.JITPreAllocF64ArrPrefix)
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.Run(fn)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	gotF := got.Float()
+	if math.IsNaN(wantSum) {
+		if !math.IsNaN(gotF) {
+			t.Fatalf("want NaN, got %g", gotF)
+		}
+	} else if gotF != wantSum {
+		t.Fatalf("sum mismatch: got %g want %g", gotF, wantSum)
+	}
+}
+
+// TestF64ArrayJITLenAMD64 mirrors the ARM64 TestF64ArrayJITLen for the
+// AMD64 OpF64ArrayLenI64 lowering. The fn has no f64 regs so the cap is
+// the cell-only 8; this also doubles as a check that LenI64 works on a
+// cell-bank fn without the f64 base in R12.
+func TestF64ArrayJITLenAMD64(t *testing.T) {
+	const want = 7
+	fn := &vm3.Function{
+		Name:        "f64arr_amd64_len",
+		NumRegsI64:  1,
+		NumRegsCell: 1,
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewF64Array, 0, 0, want),
+			vm3.MakeOp(vm3.OpF64ArrayLenI64, 0, 0, 0),
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{fn}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if fn.JITCode == nil {
+		t.Fatalf("f64arr_amd64_len did not compile (JITCode is nil)")
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.Run(fn)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got.Int() != int64(want) {
+		t.Fatalf("len: got %d want %d", got.Int(), want)
+	}
+}
+
+// TestSpectralNormJITAMD64 exercises the AMD64 cell-bank+f64 admission
+// for the corpus.SpectralNorm shape. The fn has NumRegsI64=5,
+// NumRegsF64=5, NumRegsCell=2 — fits the Phase 6.3.4.n.3 cap of
+// i64<=6 when both Cell and F64 banks are present. The driver runs
+// through the interp (it's a single-fn program); JITCallFn dispatches
+// to the JIT'd entry. The result is checked against the Go oracle.
+func TestSpectralNormJITAMD64(t *testing.T) {
+	const n = int64(64)
+	prog := corpus.SpectralNorm.Build(n)
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	fn := prog.Funcs[prog.Entry]
+	if fn.JITCode == nil {
+		t.Fatalf("spectral_norm did not JIT-compile on AMD64: "+
+			"NumRegsI64=%d NumRegsF64=%d NumRegsCell=%d",
+			fn.NumRegsI64, fn.NumRegsF64, fn.NumRegsCell)
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(fn, []int64{n})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	want := corpus.ExpectSpectralNorm(n)
+	if math.Abs(got.Float()-want)/want > 1e-12 {
+		t.Fatalf("spectral_norm(%d): got %.17g, want %.17g (delta %g)",
+			n, got.Float(), want, got.Float()-want)
+	}
+}

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -2814,15 +2814,21 @@ func vfmaddSDRR(opc byte, dst, src1, src2 int) []byte {
 // movsdLoadXMMFromGPR emits `movsd xmm<dst>, disp32(%baseGPR)`.
 // Opcode F2 [REX] 0F 10 /r disp32. REX is emitted when dst or base
 // needs the high bit (R8..R15, including R12/R14 used as the f64
-// base). 8 bytes when no REX, 9 bytes with REX. Phase 6.3.4.n.3
-// generalizes the original movsdLoadXMMFromR14 so cell-bank+f64 fns
-// can pin the f64 base in R12.
+// base). When base&7 == 4 (RSP or R12) the SIB-follows quirk forces
+// an extra SIB byte (0x24 = scale=0/index=none/base=4) between the
+// ModR/M and the disp32. Phase 6.3.4.n.3 generalizes the original
+// movsdLoadXMMFromR14 so cell-bank+f64 fns can pin the f64 base in
+// R12; without the SIB byte the decoder reads the first byte of
+// disp32 as SIB and the whole prologue desyncs.
 func movsdLoadXMMFromGPR(dst int, base int, disp int32) []byte {
 	var out []byte
 	if dst >= 8 || base >= 8 {
 		out = []byte{0xF2, rex(false, dst >= 8, false, base >= 8), 0x0F, 0x10, modRM(2, byte(dst&7), byte(base&7))}
 	} else {
 		out = []byte{0xF2, 0x0F, 0x10, modRM(2, byte(dst), byte(base))}
+	}
+	if base&7 == 4 {
+		out = append(out, 0x24)
 	}
 	return appendImm32(out, disp)
 }

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -82,7 +82,18 @@ const (
 
 // r2xAMD64 maps a vm3 i64 register slot to the x86_64 GPR it is pinned
 // to. Caller must pre-check r < maxI64RegsAMD64.
-func r2xAMD64(r uint16) int {
+//
+// The mapping depends on fn's bank shape. The normal layout is slot 0..5
+// in RSI/RDI/R8..R11 (caller-saved), slot 6..9 in R12/R13/R14/RBP
+// (callee-saved). Phase 6.3.4.n.4 remaps slot 6 to R13 when fn is
+// cell-bank+f64 because R12 already holds the regsF64 base. The
+// remapping shifts slot 7's old home (R13) off the available set, so
+// the cap rises from 6 to 7 in that shape (slots 0..6 fit, slot 7+
+// rejected at the admission gate).
+func r2xAMD64(fn *vm3.Function, r uint16) int {
+	if r == 6 && usesR12ForF64AMD64(fn) {
+		return xR13
+	}
 	switch r {
 	case 0:
 		return xRSI
@@ -153,6 +164,29 @@ func f64BaseGPRAMD64(fn *vm3.Function) int {
 // admission: R12 takes over as the regsF64 base.
 func isCellBankAMD64(fn *vm3.Function) bool { return fn.NumRegsCell > 0 }
 
+// usesR12ForI64AMD64 reports whether i64 slot 6 maps to R12 for fn.
+// Normally slot 6 = R12, but cell+f64 fns repurpose R12 as the regsF64
+// base (Phase 6.3.4.n.3), and slot 6 is remapped to R13 in that case
+// (Phase 6.3.4.n.4).
+func usesR12ForI64AMD64(fn *vm3.Function) bool {
+	if usesR12ForF64AMD64(fn) {
+		return false
+	}
+	return int(fn.NumRegsI64) > 6
+}
+
+// usesR13ForI64AMD64 reports whether R13 holds an i64 slot for fn. R13
+// is slot 7 in the normal layout; cell+f64 fns remap slot 6 (the old
+// R12 home) to R13 because R12 is the regsF64 base in that shape
+// (Phase 6.3.4.n.4).
+func usesR13ForI64AMD64(fn *vm3.Function) bool {
+	n := int(fn.NumRegsI64)
+	if usesR12ForF64AMD64(fn) {
+		return n > 6
+	}
+	return n > 7
+}
+
 // numCalleeSavedPushesAMD64 returns the number of R12..R14/RBP pushes the
 // prologue needs for fn, plus the always-present RBX and R15 pushes
 // (2). Used by both the prologue emitter and the byte-count predictor.
@@ -169,10 +203,10 @@ func numCalleeSavedPushesAMD64(fn *vm3.Function) int {
 	}
 	// RBX and R15 are always pushed; R12..R14 only if their slot is used.
 	count := 2
-	if n > 6 || usesR12ForF64AMD64(fn) {
+	if usesR12ForI64AMD64(fn) || usesR12ForF64AMD64(fn) {
 		count++
 	}
-	if n > 7 {
+	if usesR13ForI64AMD64(fn) {
 		count++
 	}
 	if n > 8 || usesR14ForF64(fn) || isCellBankAMD64(fn) {
@@ -480,11 +514,12 @@ func lowerAMD64(fn *vm3.Function, opts Options) ([]byte, error) {
 		return nil, fmt.Errorf("%w: %s has both f64 regs and OpCallI64 (Phase 6.2b leaves f64+self-recursion to a later sub-phase)",
 			ErrNotImplemented, fn.Name)
 	}
-	if isCellBankAMD64(fn) && fn.NumRegsF64 > 0 && int(fn.NumRegsI64) > 6 {
-		// Phase 6.3.4.n.3: Cell+F64 fns pin the regsF64 base in R12
-		// (i64 slot 6). The remaining usable i64 slots are 0..5, i.e.
-		// NumRegsI64 <= 6.
-		return nil, fmt.Errorf("%w: %s has Cell+F64 banks with NumRegsI64=%d (>6); R12 reserved for regsF64 base on AMD64",
+	if isCellBankAMD64(fn) && fn.NumRegsF64 > 0 && int(fn.NumRegsI64) > 7 {
+		// Phase 6.3.4.n.4: Cell+F64 fns pin the regsF64 base in R12 and
+		// remap i64 slot 6 to R13 (instead of R12). Slots 0..5 stay in
+		// RSI/RDI/R8..R11 and slot 6 in R13; slot 7 is unavailable
+		// because R12 is reserved for the f64 base. Effective cap = 7.
+		return nil, fmt.Errorf("%w: %s has Cell+F64 banks with NumRegsI64=%d (>7); R12/R14/RBP reserved for f64base/arenaCtx/regsCell on AMD64",
 			ErrNotImplemented, fn.Name, fn.NumRegsI64)
 	}
 	if isCellBankAMD64(fn) && fn.NumRegsF64 == 0 && int(fn.NumRegsI64) > 8 {
@@ -548,10 +583,10 @@ func prologueLenAMD64(fn *vm3.Function) int {
 	bytes := 0
 	bytes += pushBytes(xRBX)
 	bytes += pushBytes(xR15)
-	if n > 6 || usesR12ForF64AMD64(fn) {
+	if usesR12ForI64AMD64(fn) || usesR12ForF64AMD64(fn) {
 		bytes += pushBytes(xR12)
 	}
-	if n > 7 {
+	if usesR13ForI64AMD64(fn) {
 		bytes += pushBytes(xR13)
 	}
 	if n > 8 || usesR14ForF64(fn) || isCellBankAMD64(fn) {
@@ -623,10 +658,10 @@ func emitPrologueAMD64(buf []byte, fn *vm3.Function) []byte {
 	nF := int(fn.NumRegsF64)
 	buf = append(buf, push64(xRBX)...)
 	buf = append(buf, push64(xR15)...)
-	if n > 6 || usesR12ForF64AMD64(fn) {
+	if usesR12ForI64AMD64(fn) || usesR12ForF64AMD64(fn) {
 		buf = append(buf, push64(xR12)...)
 	}
-	if n > 7 {
+	if usesR13ForI64AMD64(fn) {
 		buf = append(buf, push64(xR13)...)
 	}
 	if n > 8 || usesR14ForF64(fn) || isCellBankAMD64(fn) {
@@ -651,7 +686,7 @@ func emitPrologueAMD64(buf []byte, fn *vm3.Function) []byte {
 		buf = append(buf, mov64RR(xRDX, xR12)...)
 	}
 	for r := 0; r < n; r++ {
-		buf = append(buf, mov64LoadDisp32(r2xAMD64(uint16(r)), xRBX, int32(r*8))...)
+		buf = append(buf, mov64LoadDisp32(r2xAMD64(fn, uint16(r)), xRBX, int32(r*8))...)
 	}
 	f64Base := f64BaseGPRAMD64(fn)
 	for r := 0; r < nF; r++ {
@@ -691,10 +726,10 @@ func emitEpilogueAMD64(buf []byte, fn *vm3.Function) []byte {
 	if n > 8 || usesR14ForF64(fn) || isCellBankAMD64(fn) {
 		buf = append(buf, pop64(xR14)...)
 	}
-	if n > 7 {
+	if usesR13ForI64AMD64(fn) {
 		buf = append(buf, pop64(xR13)...)
 	}
-	if n > 6 || usesR12ForF64AMD64(fn) {
+	if usesR12ForI64AMD64(fn) || usesR12ForF64AMD64(fn) {
 		buf = append(buf, pop64(xR12)...)
 	}
 	buf = append(buf, pop64(xR15)...)
@@ -717,10 +752,10 @@ func epilogueBytesAMD64(fn *vm3.Function) int {
 	if n > 8 || usesR14ForF64(fn) || isCellBankAMD64(fn) {
 		bytes += popBytes(xR14)
 	}
-	if n > 7 {
+	if usesR13ForI64AMD64(fn) {
 		bytes += popBytes(xR13)
 	}
-	if n > 6 || usesR12ForF64AMD64(fn) {
+	if usesR12ForI64AMD64(fn) || usesR12ForF64AMD64(fn) {
 		bytes += popBytes(xR12)
 	}
 	bytes += popBytes(xR15)
@@ -795,13 +830,13 @@ func emitDeoptBlockAMD64(fn *vm3.Function, statusCode int64) []byte {
 func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint32, idx int) (int, error) {
 	switch op.Code {
 	case vm3.OpConstI64K:
-		return movImm64ByteCount(int64(op.C), r2xAMD64(op.A)), nil
+		return movImm64ByteCount(int64(op.C), r2xAMD64(fn, op.A)), nil
 	case vm3.OpConstI64KW:
 		k := int(uint16(op.C))
 		if k >= len(fn.Consts) {
 			return 0, fmt.Errorf("%w: ConstI64KW idx %d out of range", ErrNotImplemented, k)
 		}
-		return movImm64ByteCount(fn.Consts[k].Int(), r2xAMD64(op.A)), nil
+		return movImm64ByteCount(fn.Consts[k].Int(), r2xAMD64(fn, op.A)), nil
 	case vm3.OpMovI64:
 		return 3, nil // mov r64, r64
 	case vm3.OpAddI64:
@@ -1036,7 +1071,7 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		// otherwise; the SIB-store is always 4B because mov64StoreIdxLsl3
 		// emits REX.W unconditionally.
 		if hoistsCellsPtrAMD64(fn) {
-			xIdx := r2xAMD64(uint16(op.C))
+			xIdx := r2xAMD64(fn, uint16(op.C))
 			tagBytes := 7
 			if xIdx >= 8 {
 				tagBytes = 8
@@ -1166,7 +1201,7 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 				ErrNotImplemented, tableIdx)
 		}
 		base := int64(uintptr(unsafe.Pointer(&fn.I64Tables[tableIdx][0])))
-		return movImm64ByteCount(base, xRAX) + mov64LoadIdxLsl3ByteCount(r2xAMD64(op.A), xRAX, r2xAMD64(op.B)), nil
+		return movImm64ByteCount(base, xRAX) + mov64LoadIdxLsl3ByteCount(r2xAMD64(fn, op.A), xRAX, r2xAMD64(fn, op.B)), nil
 
 	case vm3.OpF64ArrayGetF64:
 		// Phase 6.3.4.n.3 cold form (AMD64 mirror of ARM64 OpF64ArrayGetF64).
@@ -1321,8 +1356,8 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 // byte offset of the deopt block; guard sites compute a JZ rel32
 // offset to it.
 func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStart int, opts Options, spillSets []uint32) ([]byte, error) {
-	xA := r2xAMD64(op.A)
-	xB := r2xAMD64(op.B)
+	xA := r2xAMD64(fn, op.A)
+	xB := r2xAMD64(fn, op.B)
 	switch op.Code {
 	case vm3.OpConstI64K:
 		return movImm64(xA, int64(op.C)), nil
@@ -1334,7 +1369,7 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 	case vm3.OpAddI64:
 		// Commutative; collapse A == C via commutativity to avoid
 		// `mov xB, xA` clobbering xC when A and C share a register.
-		xC := r2xAMD64(uint16(op.C))
+		xC := r2xAMD64(fn, uint16(op.C))
 		var out []byte
 		switch {
 		case op.A == op.B:
@@ -1349,7 +1384,7 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 	case vm3.OpSubI64:
 		// Non-commutative; A == C uses sub+neg so we don't lose the
 		// original C value before the subtract: A = -(C - B) = B - C.
-		xC := r2xAMD64(uint16(op.C))
+		xC := r2xAMD64(fn, uint16(op.C))
 		var out []byte
 		switch {
 		case op.A == op.B:
@@ -1364,7 +1399,7 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		return out, nil
 	case vm3.OpMulI64:
 		// imul is commutative; mirror OpAddI64.
-		xC := r2xAMD64(uint16(op.C))
+		xC := r2xAMD64(fn, uint16(op.C))
 		var out []byte
 		switch {
 		case op.A == op.B:
@@ -1384,11 +1419,11 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		out = append(out, neg64R(xA)...)
 		return out, nil
 	case vm3.OpDivI64:
-		xC := r2xAMD64(uint16(op.C))
+		xC := r2xAMD64(fn, uint16(op.C))
 		dz := deoptStartForStatusAMD64(fn, deoptStart, StatusDivByZero)
 		return emitDivOrMod(fn, xA, xB, xC, pcMap[idx], dz, true), nil
 	case vm3.OpModI64:
-		xC := r2xAMD64(uint16(op.C))
+		xC := r2xAMD64(fn, uint16(op.C))
 		dz := deoptStartForStatusAMD64(fn, deoptStart, StatusDivByZero)
 		return emitDivOrMod(fn, xA, xB, xC, pcMap[idx], dz, false), nil
 	case vm3.OpAddI64K:
@@ -1415,7 +1450,7 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		vm3.OpCmpLtI64Br, vm3.OpCmpLeI64Br,
 		vm3.OpCmpGtI64Br, vm3.OpCmpGeI64Br:
 		cc := condForCmpRegAMD64(op.Code)
-		xCmpB := r2xAMD64(op.B)
+		xCmpB := r2xAMD64(fn, op.B)
 		src := pcMap[idx] + 3 + 6
 		dst := pcMap[int(uint16(op.C))]
 		rel := int32(dst - src)
@@ -1539,8 +1574,8 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		// Phase 6.3.4.n.2.f: when hoistsCellsPtrAMD64(fn) the prologue
 		// already cached cells.ptr at disp8(%rbx); skip the
 		// slab/cells.ptr compute chain.
-		xIdx := r2xAMD64(uint16(op.C))
-		xA := r2xAMD64(op.A)
+		xIdx := r2xAMD64(fn, uint16(op.C))
+		xA := r2xAMD64(fn, op.A)
 		var out []byte
 		if hoistsCellsPtrAMD64(fn) {
 			out = mov64LoadDisp8(xRAX, xRBX, int8(hoistDispAMD64(fn)))
@@ -1572,7 +1607,7 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		// constant-indexed load to disp8 when idxK*8 fits in [-128, 127]
 		// (the common case: small constant indices like 0..15).
 		idxK := int32(uint16(op.C)) * 8
-		xA := r2xAMD64(op.A)
+		xA := r2xAMD64(fn, op.A)
 		var out []byte
 		if hoistsCellsPtrAMD64(fn) {
 			out = mov64LoadDisp8(xRAX, xRBX, int8(hoistDispAMD64(fn)))
@@ -1612,8 +1647,8 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		// Phase 6.3.4.n.2.f: when hoistsCellsPtrAMD64(fn) the cells.ptr
 		// is already cached at disp8(%rbx); skip the slab/cells.ptr
 		// compute chain (RCX is then free up to the movabs tag load).
-		xIdx := r2xAMD64(uint16(op.C))
-		xVal := r2xAMD64(op.B)
+		xIdx := r2xAMD64(fn, uint16(op.C))
+		xVal := r2xAMD64(fn, op.B)
 		if hoistsCellsPtrAMD64(fn) {
 			// Hot form: cells.ptr is pinned at disp8(%rbx). Use the
 			// OpListPushI64 "raw SIB store + 16-bit tag overwrite"
@@ -1669,7 +1704,7 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		cellsLenOff := cellsOff + 8
 		cellsCapOff := cellsOff + 16
 		listsBaseOff := int32(jitArenaCtxListsBaseOff())
-		xVal := r2xAMD64(op.B)
+		xVal := r2xAMD64(fn, op.B)
 		lgStart := deoptStartForStatusAMD64(fn, deoptStart, StatusListGrow)
 		out := mov32LoadDisp32(xRAX, xRBP, int32(op.A)*8)
 		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
@@ -1781,9 +1816,9 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		return out, nil
 
 	case vm3.OpI64ToF64:
-		return cvtsi2sd(int(op.A), int(r2xAMD64(op.B))), nil
+		return cvtsi2sd(int(op.A), int(r2xAMD64(fn, op.B))), nil
 	case vm3.OpF64ToI64:
-		return cvttsd2si(int(r2xAMD64(op.A)), int(op.B)), nil
+		return cvttsd2si(int(r2xAMD64(fn, op.A)), int(op.B)), nil
 	case vm3.OpLookupI64KW:
 		// regsI64[A] = fn.I64Tables[uint16(C)][regsI64[B]]
 		//
@@ -1800,7 +1835,7 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		}
 		base := int64(uintptr(unsafe.Pointer(&fn.I64Tables[tableIdx][0])))
 		out := movImm64(xRAX, base)
-		out = append(out, mov64LoadIdxLsl3(r2xAMD64(op.A), xRAX, r2xAMD64(op.B))...)
+		out = append(out, mov64LoadIdxLsl3(r2xAMD64(fn, op.A), xRAX, r2xAMD64(fn, op.B))...)
 		return out, nil
 
 	case vm3.OpF64ArrayGetF64:
@@ -1812,7 +1847,7 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		stride := int64(vm3.JITF64ArrSlabStride())
 		dataOff := int32(vm3.JITF64ArrDataOffset())
 		baseOff := int32(jitArenaCtxF64ArrsBaseOff())
-		xIdx := r2xAMD64(uint16(op.C))
+		xIdx := r2xAMD64(fn, uint16(op.C))
 		out := mov32LoadDisp32(xRAX, xRBP, int32(op.B)*8)
 		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
 		out = append(out, mov64LoadDisp32(xRCX, xR14, baseOff)...)
@@ -1826,7 +1861,7 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		stride := int64(vm3.JITF64ArrSlabStride())
 		dataOff := int32(vm3.JITF64ArrDataOffset())
 		baseOff := int32(jitArenaCtxF64ArrsBaseOff())
-		xIdx := r2xAMD64(uint16(op.C))
+		xIdx := r2xAMD64(fn, uint16(op.C))
 		out := mov32LoadDisp32(xRAX, xRBP, int32(op.A)*8)
 		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
 		out = append(out, mov64LoadDisp32(xRCX, xR14, baseOff)...)
@@ -1840,7 +1875,7 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		stride := int64(vm3.JITF64ArrSlabStride())
 		lenOff := int32(vm3.JITF64ArrLenOffset())
 		baseOff := int32(jitArenaCtxF64ArrsBaseOff())
-		xA := r2xAMD64(op.A)
+		xA := r2xAMD64(fn, op.A)
 		out := mov32LoadDisp32(xRAX, xRBP, int32(op.B)*8)
 		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
 		out = append(out, mov64LoadDisp32(xRCX, xR14, baseOff)...)
@@ -1854,8 +1889,8 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		stride := int64(vm3.JITI64ArrSlabStride())
 		dataOff := int32(vm3.JITI64ArrDataOffset())
 		baseOff := int32(jitArenaCtxI64ArrsBaseOff())
-		xIdx := r2xAMD64(uint16(op.C))
-		xA := r2xAMD64(op.A)
+		xIdx := r2xAMD64(fn, uint16(op.C))
+		xA := r2xAMD64(fn, op.A)
 		out := mov32LoadDisp32(xRAX, xRBP, int32(op.B)*8)
 		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
 		out = append(out, mov64LoadDisp32(xRCX, xR14, baseOff)...)
@@ -1869,8 +1904,8 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		stride := int64(vm3.JITI64ArrSlabStride())
 		dataOff := int32(vm3.JITI64ArrDataOffset())
 		baseOff := int32(jitArenaCtxI64ArrsBaseOff())
-		xIdx := r2xAMD64(uint16(op.C))
-		xB := r2xAMD64(op.B)
+		xIdx := r2xAMD64(fn, uint16(op.C))
+		xB := r2xAMD64(fn, op.B)
 		out := mov32LoadDisp32(xRAX, xRBP, int32(op.A)*8)
 		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
 		out = append(out, mov64LoadDisp32(xRCX, xR14, baseOff)...)
@@ -1883,7 +1918,7 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		stride := int64(vm3.JITI64ArrSlabStride())
 		lenOff := int32(vm3.JITI64ArrLenOffset())
 		baseOff := int32(jitArenaCtxI64ArrsBaseOff())
-		xA := r2xAMD64(op.A)
+		xA := r2xAMD64(fn, op.A)
 		out := mov32LoadDisp32(xRAX, xRBP, int32(op.B)*8)
 		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
 		out = append(out, mov64LoadDisp32(xRCX, xR14, baseOff)...)
@@ -1917,12 +1952,12 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		// Spill live caller-saved slots (0..5).
 		for r := uint16(0); r < 6; r++ {
 			if spillMask&(1<<r) != 0 {
-				out = append(out, mov64StoreDisp32(r2xAMD64(r), xRBX, int32(r)*8)...)
+				out = append(out, mov64StoreDisp32(r2xAMD64(fn, r), xRBX, int32(r)*8)...)
 			}
 		}
 		// Write args into callee window at offset NumRegsI64*8.
 		for k := 0; k < nArgs; k++ {
-			src := r2xAMD64(op.B + uint16(k))
+			src := r2xAMD64(fn, op.B + uint16(k))
 			out = append(out, mov64StoreDisp32(src, xRBX, int32(nRegsI64+k)*8)...)
 		}
 		// Re-establish the SysV first/second arg registers the prologue
@@ -1943,7 +1978,7 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		// Reload spilled slots.
 		for r := uint16(0); r < 6; r++ {
 			if spillMask&(1<<r) != 0 {
-				out = append(out, mov64LoadDisp32(r2xAMD64(r), xRBX, int32(r)*8)...)
+				out = append(out, mov64LoadDisp32(r2xAMD64(fn, r), xRBX, int32(r)*8)...)
 			}
 		}
 		return out, nil
@@ -1985,7 +2020,7 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		// Spill live caller-saved i64 slots.
 		for r := uint16(0); r < 6; r++ {
 			if spillMask&(1<<r) != 0 {
-				out = append(out, mov64StoreDisp32(r2xAMD64(r), xRBX, int32(r)*8)...)
+				out = append(out, mov64StoreDisp32(r2xAMD64(fn, r), xRBX, int32(r)*8)...)
 			}
 		}
 		// Write args bank-by-bank using the callee's ParamBanks (the
@@ -1997,7 +2032,7 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 			argReg := op.B + uint16(k)
 			switch b {
 			case vm3.BankI64:
-				src := r2xAMD64(argReg)
+				src := r2xAMD64(fn, argReg)
 				out = append(out, mov64StoreDisp32(src, xRBX, int32(callerI64+k)*8)...)
 			case vm3.BankCell:
 				// Cell args live at [%rbp + argReg*8]; load via RDX
@@ -2036,7 +2071,7 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		// outside r2xAMD64's range, so spill reloads don't clobber it.
 		for r := uint16(0); r < 6; r++ {
 			if spillMask&(1<<r) != 0 {
-				out = append(out, mov64LoadDisp32(r2xAMD64(r), xRBX, int32(r)*8)...)
+				out = append(out, mov64LoadDisp32(r2xAMD64(fn, r), xRBX, int32(r)*8)...)
 			}
 		}
 		// Optional deopt propagation. If the callee can deopt, the

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -580,8 +580,14 @@ func prologueLenAMD64(fn *vm3.Function) int {
 	// Each pinned i64 slot load is mov disp32(%rbx), <reg> = 7 bytes.
 	bytes += 7 * n
 	// Each pinned f64 slot load is movsd disp32(%base), xmm<r> = 9 bytes
-	// (REX.B-prefixed because the f64 base is always R12 or R14).
-	bytes += 9 * nF
+	// (REX.B-prefixed because the f64 base is always R12 or R14). When
+	// the base is R12 (cell-bank+f64), the SIB-follows quirk on rm=100
+	// adds one extra SIB byte per load (see movsdLoadXMMFromGPR).
+	perLoad := 9
+	if usesR12ForF64AMD64(fn) {
+		perLoad = 10
+	}
+	bytes += perLoad * nF
 	// Phase 6.3.4.n.2.f: cells.ptr hoist setup (cold form: 0 bytes when
 	// gate fails; ~34 bytes when active). See hoistPrologueBytesAMD64.
 	bytes += hoistPrologueBytesAMD64(fn)

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -1090,9 +1090,20 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		// movsd xmm<A>, xmm<B>: 4 bytes (xmm0..7 only, no REX needed).
 		return 4, nil
 	case vm3.OpAddF64, vm3.OpSubF64, vm3.OpMulF64, vm3.OpDivF64:
-		// optional movsd xmm<A>, xmm<B> (4) ; <op>sd xmm<A>, xmm<C> (4).
-		if op.A == op.B {
+		// A == B: <op>sd xmm<A>, xmm<C> (4 bytes).
+		// A == C, commutative (Add/Mul): <op>sd xmm<A>, xmm<B> (4).
+		// A == C, non-commutative (Sub/Div): movsd xmm15, xmm<C> (5) ;
+		//   movsd xmm<A>, xmm<B> (4) ; <op>sd xmm<A>, xmm15 (5) = 14.
+		// Otherwise: movsd xmm<A>, xmm<B> (4) ; <op>sd xmm<A>, xmm<C> (4).
+		a, b, c := op.A, op.B, uint16(op.C)
+		if a == b {
 			return 4, nil
+		}
+		if uint16(a) == c {
+			if op.Code == vm3.OpAddF64 || op.Code == vm3.OpMulF64 {
+				return 4, nil
+			}
+			return 14, nil
 		}
 		return 8, nil
 	case vm3.OpNegF64:
@@ -1701,33 +1712,13 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 	case vm3.OpMovF64:
 		return movsdRR(int(op.A), int(op.B)), nil
 	case vm3.OpAddF64:
-		var out []byte
-		if op.A != op.B {
-			out = append(out, movsdRR(int(op.A), int(op.B))...)
-		}
-		out = append(out, addsdRR(int(op.A), int(uint16(op.C)))...)
-		return out, nil
+		return emitSSEArithAMD64(addsdRR, int(op.A), int(op.B), int(uint16(op.C)), true), nil
 	case vm3.OpSubF64:
-		var out []byte
-		if op.A != op.B {
-			out = append(out, movsdRR(int(op.A), int(op.B))...)
-		}
-		out = append(out, subsdRR(int(op.A), int(uint16(op.C)))...)
-		return out, nil
+		return emitSSEArithAMD64(subsdRR, int(op.A), int(op.B), int(uint16(op.C)), false), nil
 	case vm3.OpMulF64:
-		var out []byte
-		if op.A != op.B {
-			out = append(out, movsdRR(int(op.A), int(op.B))...)
-		}
-		out = append(out, mulsdRR(int(op.A), int(uint16(op.C)))...)
-		return out, nil
+		return emitSSEArithAMD64(mulsdRR, int(op.A), int(op.B), int(uint16(op.C)), true), nil
 	case vm3.OpDivF64:
-		var out []byte
-		if op.A != op.B {
-			out = append(out, movsdRR(int(op.A), int(op.B))...)
-		}
-		out = append(out, divsdRR(int(op.A), int(uint16(op.C)))...)
-		return out, nil
+		return emitSSEArithAMD64(divsdRR, int(op.A), int(op.B), int(uint16(op.C)), false), nil
 	case vm3.OpNegF64:
 		// xmm15 = bit-pattern 0x8000000000000000 ; result = src ^ xmm15.
 		signBit := uint64(1) << 63
@@ -2788,6 +2779,30 @@ func mulsdRR(dst, src int) []byte { return sseRR2(0x59, dst, src) }
 
 // divsdRR emits `divsd xmmDst, xmmSrc`. Opcode F2 [REX] 0F 5E /r.
 func divsdRR(dst, src int) []byte { return sseRR2(0x5E, dst, src) }
+
+// emitSSEArithAMD64 lowers a 2-operand SSE arithmetic op `xmm[a] =
+// xmm[b] OP xmm[c]` while correctly handling the A==C!=B aliasing case
+// that the naive "movsd a,b ; OP a,c" sequence clobbers. For commutative
+// ops (Add, Mul) the A==C case collapses to `OP a, b` since A already
+// holds C's value. For non-commutative ops (Sub, Div) the divisor or
+// subtrahend in xmm[C] must be saved to scratch xmm15 before the move,
+// then OP'd from xmm15. The byteCount for these ops must mirror this
+// shape (see byteCountAMD64's OpAddF64/SubF64/MulF64/DivF64 case).
+func emitSSEArithAMD64(op func(dst, src int) []byte, a, b, c int, commutative bool) []byte {
+	if a == b {
+		return op(a, c)
+	}
+	if a == c {
+		if commutative {
+			return op(a, b)
+		}
+		out := movsdRR(15, c)
+		out = append(out, movsdRR(a, b)...)
+		return append(out, op(a, 15)...)
+	}
+	out := movsdRR(a, b)
+	return append(out, op(a, c)...)
+}
 
 // sqrtsdRR emits `sqrtsd xmmDst, xmmSrc`. Opcode F2 [REX] 0F 51 /r.
 // IEEE 754 correctly-rounded scalar square root; bit-identical to Go's

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -113,16 +113,44 @@ func r2xAMD64(r uint16) int {
 func calleeSavedSlot(r uint16) bool { return r >= 6 && r < 10 }
 
 // usesR14ForF64 reports whether the AMD64 backend repurposes R14 as
-// the regsF64 base pointer for fn. This stacks on top of the SysV
-// callee-saved rule: R14 is also Go's G register, so we must push/pop
-// it regardless of how it is used inside the JIT'd body.
-func usesR14ForF64(fn *vm3.Function) bool { return fn.NumRegsF64 > 0 }
+// the regsF64 base pointer for fn. This applies to non-cell-bank f64
+// fns; cell-bank+f64 fns route the f64 base through R12 instead so
+// R14 stays free for the *jitArenaCtx pointer (Phase 6.3.4.n.3).
+// R14 is also Go's G register, so we must push/pop it regardless of
+// how it is used inside the JIT'd body.
+func usesR14ForF64(fn *vm3.Function) bool {
+	return fn.NumRegsF64 > 0 && !isCellBankAMD64(fn)
+}
+
+// usesR12ForF64AMD64 reports whether fn pins the regsF64 base in R12
+// instead of R14. Phase 6.3.4.n.3 enables this for cell-bank+f64 fns
+// because R14 already carries *jitArenaCtx. The trade-off is one fewer
+// i64 slot (R12 is i64 slot 6), so callers must cap NumRegsI64 <= 6
+// when both Cell and F64 banks are present (see archCaps + admission
+// gate).
+func usesR12ForF64AMD64(fn *vm3.Function) bool {
+	return fn.NumRegsF64 > 0 && isCellBankAMD64(fn)
+}
+
+// f64BaseGPRAMD64 returns the x86_64 GPR holding the regsF64 base
+// pointer for fn, or -1 when fn has no f64 bank. Non-cell-bank f64
+// fns use R14; cell-bank+f64 fns use R12 (R14 is reserved for the
+// arena ctx pointer in that case).
+func f64BaseGPRAMD64(fn *vm3.Function) int {
+	if fn.NumRegsF64 == 0 {
+		return -1
+	}
+	if isCellBankAMD64(fn) {
+		return xR12
+	}
+	return xR14
+}
 
 // isCellBankAMD64 reports whether fn carries the Cell register bank.
 // Phase 6.3.4.m.4c.1 cell-bank fns repurpose RBP as the regsCell base
 // and R14 as the *jitArenaCtx pointer, so the prologue pushes both and
-// the epilogue pops them. usesR14ForF64 and isCellBankAMD64 are mutually
-// exclusive: lowerAMD64 rejects the combination.
+// the epilogue pops them. Phase 6.3.4.n.3 adds the cell-bank+f64
+// admission: R12 takes over as the regsF64 base.
 func isCellBankAMD64(fn *vm3.Function) bool { return fn.NumRegsCell > 0 }
 
 // numCalleeSavedPushesAMD64 returns the number of R12..R14/RBP pushes the
@@ -132,7 +160,8 @@ func isCellBankAMD64(fn *vm3.Function) bool { return fn.NumRegsCell > 0 }
 // regsF64 base for an f64-touching fn OR (c) R14 holds *jitArenaCtx for
 // a cell-bank fn. RBP is pushed when (a) i64 slot 9 lands in RBP
 // (Phase 6.3.4.n.1) OR (b) RBP holds the regsCell base for a cell-bank
-// fn.
+// fn. R12 is pushed when (a) i64 slot 6 lands in R12 OR (b) R12 holds
+// the regsF64 base for a cell-bank+f64 fn (Phase 6.3.4.n.3).
 func numCalleeSavedPushesAMD64(fn *vm3.Function) int {
 	n := int(fn.NumRegsI64)
 	if n > maxI64RegsAMD64 {
@@ -140,7 +169,7 @@ func numCalleeSavedPushesAMD64(fn *vm3.Function) int {
 	}
 	// RBX and R15 are always pushed; R12..R14 only if their slot is used.
 	count := 2
-	if n > 6 {
+	if n > 6 || usesR12ForF64AMD64(fn) {
 		count++
 	}
 	if n > 7 {
@@ -451,11 +480,14 @@ func lowerAMD64(fn *vm3.Function, opts Options) ([]byte, error) {
 		return nil, fmt.Errorf("%w: %s has both f64 regs and OpCallI64 (Phase 6.2b leaves f64+self-recursion to a later sub-phase)",
 			ErrNotImplemented, fn.Name)
 	}
-	if isCellBankAMD64(fn) && fn.NumRegsF64 > 0 {
-		return nil, fmt.Errorf("%w: %s has both Cell and f64 banks (AMD64 cell-bank Phase 6.3.4.m.4c.1 admits Cell+I64 only; R14 is shared)",
-			ErrNotImplemented, fn.Name)
+	if isCellBankAMD64(fn) && fn.NumRegsF64 > 0 && int(fn.NumRegsI64) > 6 {
+		// Phase 6.3.4.n.3: Cell+F64 fns pin the regsF64 base in R12
+		// (i64 slot 6). The remaining usable i64 slots are 0..5, i.e.
+		// NumRegsI64 <= 6.
+		return nil, fmt.Errorf("%w: %s has Cell+F64 banks with NumRegsI64=%d (>6); R12 reserved for regsF64 base on AMD64",
+			ErrNotImplemented, fn.Name, fn.NumRegsI64)
 	}
-	if isCellBankAMD64(fn) && int(fn.NumRegsI64) > 8 {
+	if isCellBankAMD64(fn) && fn.NumRegsF64 == 0 && int(fn.NumRegsI64) > 8 {
 		return nil, fmt.Errorf("%w: %s has Cell bank with NumRegsI64=%d (>8); R14 reserved for *jitArenaCtx",
 			ErrNotImplemented, fn.Name, fn.NumRegsI64)
 	}
@@ -516,7 +548,7 @@ func prologueLenAMD64(fn *vm3.Function) int {
 	bytes := 0
 	bytes += pushBytes(xRBX)
 	bytes += pushBytes(xR15)
-	if n > 6 {
+	if n > 6 || usesR12ForF64AMD64(fn) {
 		bytes += pushBytes(xR12)
 	}
 	if n > 7 {
@@ -541,10 +573,14 @@ func prologueLenAMD64(fn *vm3.Function) int {
 	if isCellBankAMD64(fn) {
 		bytes += 3 + 3
 	}
+	// Cell-bank+f64: mov %rdx, %r12 (3) for the regsF64 base.
+	if usesR12ForF64AMD64(fn) {
+		bytes += 3
+	}
 	// Each pinned i64 slot load is mov disp32(%rbx), <reg> = 7 bytes.
 	bytes += 7 * n
-	// Each pinned f64 slot load is movsd disp32(%r14), xmm<r> = 9 bytes
-	// (REX.B-prefixed because R14 is r >= 8).
+	// Each pinned f64 slot load is movsd disp32(%base), xmm<r> = 9 bytes
+	// (REX.B-prefixed because the f64 base is always R12 or R14).
 	bytes += 9 * nF
 	// Phase 6.3.4.n.2.f: cells.ptr hoist setup (cold form: 0 bytes when
 	// gate fails; ~34 bytes when active). See hoistPrologueBytesAMD64.
@@ -581,7 +617,7 @@ func emitPrologueAMD64(buf []byte, fn *vm3.Function) []byte {
 	nF := int(fn.NumRegsF64)
 	buf = append(buf, push64(xRBX)...)
 	buf = append(buf, push64(xR15)...)
-	if n > 6 {
+	if n > 6 || usesR12ForF64AMD64(fn) {
 		buf = append(buf, push64(xR12)...)
 	}
 	if n > 7 {
@@ -605,11 +641,15 @@ func emitPrologueAMD64(buf []byte, fn *vm3.Function) []byte {
 		buf = append(buf, mov64RR(xRCX, xRBP)...)
 		buf = append(buf, mov64RR(xR8, xR14)...)
 	}
+	if usesR12ForF64AMD64(fn) {
+		buf = append(buf, mov64RR(xRDX, xR12)...)
+	}
 	for r := 0; r < n; r++ {
 		buf = append(buf, mov64LoadDisp32(r2xAMD64(uint16(r)), xRBX, int32(r*8))...)
 	}
+	f64Base := f64BaseGPRAMD64(fn)
 	for r := 0; r < nF; r++ {
-		buf = append(buf, movsdLoadXMMFromR14(r, int32(r*8))...)
+		buf = append(buf, movsdLoadXMMFromGPR(r, f64Base, int32(r*8))...)
 	}
 	if hoistsCellsPtrAMD64(fn) {
 		stride := int64(vm3.JITListSlabStride())
@@ -648,7 +688,7 @@ func emitEpilogueAMD64(buf []byte, fn *vm3.Function) []byte {
 	if n > 7 {
 		buf = append(buf, pop64(xR13)...)
 	}
-	if n > 6 {
+	if n > 6 || usesR12ForF64AMD64(fn) {
 		buf = append(buf, pop64(xR12)...)
 	}
 	buf = append(buf, pop64(xR15)...)
@@ -674,7 +714,7 @@ func epilogueBytesAMD64(fn *vm3.Function) int {
 	if n > 7 {
 		bytes += popBytes(xR13)
 	}
-	if n > 6 {
+	if n > 6 || usesR12ForF64AMD64(fn) {
 		bytes += popBytes(xR12)
 	}
 	bytes += popBytes(xR15)
@@ -1110,6 +1150,62 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		}
 		base := int64(uintptr(unsafe.Pointer(&fn.I64Tables[tableIdx][0])))
 		return movImm64ByteCount(base, xRAX) + mov64LoadIdxLsl3ByteCount(r2xAMD64(op.A), xRAX, r2xAMD64(op.B)), nil
+
+	case vm3.OpF64ArrayGetF64:
+		// Phase 6.3.4.n.3 cold form (AMD64 mirror of ARM64 OpF64ArrayGetF64).
+		// regsF64[A] = arenas.F64Arrs[handleIdx(regsCell[B])].data[regsI64[C]].
+		//   mov  disp32(%rbp), %eax       ; idx = low 32 of regsCell[B]   (6B)
+		//   imul $stride, %rax, %rax      ; rax = idx * sizeof(vmF64Array) (7B)
+		//   mov  f64ArrsBaseOff(%r14), %rcx ; rcx = arenas.F64Arrs base   (7B)
+		//   add  %rcx, %rax               ; rax = &arenas.F64Arrs[idx]    (3B)
+		//   mov  dataOff(%rax), %rax      ; rax = data.ptr                (7B)
+		//   movsd  [%rax + xIdx*8], xmm<A> ; xmm<A> = data[regsI64[C]]    (6B SIB-scale3)
+		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + 7 + 6, nil
+	case vm3.OpF64ArraySetF64:
+		// Phase 6.3.4.n.3 cold form (AMD64 mirror of ARM64 OpF64ArraySetF64).
+		// arenas.F64Arrs[handleIdx(regsCell[A])].data[regsI64[C]] = regsF64[B].
+		// Same byte budget as Get: 6+7+7+3+7+6.
+		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + 7 + 6, nil
+	case vm3.OpF64ArrayLenI64:
+		// Phase 6.3.4.n.3 cold form: load the slab's u32 .len into a
+		// dest GPR (zero-extend to 64 bits).
+		//   mov  disp32(%rbp), %eax       ; idx = low 32 of regsCell[B] (6B)
+		//   imul $stride, %rax, %rax      ;                              (7B)
+		//   mov  f64ArrsBaseOff(%r14), %rcx ;                            (7B)
+		//   add  %rcx, %rax               ;                              (3B)
+		//   mov  lenOff(%rax), %eax       ; rax<-len (32-bit form zero-ext, 6B disp32 form)
+		//   mov  %rax, x_A                ;                              (3B)
+		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + mov32LoadDisp32ByteCount(xRAX, xRAX) + 3, nil
+	case vm3.OpI64ArrayGetI64:
+		// Phase 6.3.4.n.3 cold form (mirror OpF64ArrayGetF64 but the
+		// final load is mov64 SIB into the i64 dest reg, 4B).
+		//   mov  disp32(%rbp), %eax       ; idx                          (6B)
+		//   imul $stride, %rax, %rax      ;                              (7B)
+		//   mov  i64ArrsBaseOff(%r14), %rcx ;                            (7B)
+		//   add  %rcx, %rax               ;                              (3B)
+		//   mov  dataOff(%rax), %rax      ; rax = data.ptr               (7B)
+		//   mov  [%rax + xIdx*8], xA      ; xA = data[idx]               (4B)
+		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + 7 + 4, nil
+	case vm3.OpI64ArraySetI64:
+		// Phase 6.3.4.n.3 cold form: same shape as Get but final is a
+		// 4-byte SIB store of xB through [rax + xIdx*8].
+		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + 7 + 4, nil
+	case vm3.OpI64ArrayLenI64:
+		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + mov32LoadDisp32ByteCount(xRAX, xRAX) + 3, nil
+	case vm3.OpNewF64Array:
+		// Phase 6.3.4.n.3: jitCall pre-allocates the slab and writes the
+		// handle into regsCell[A]; the emit step writes zero bytes when
+		// the op is in the pre-alloc K-prefix.
+		if idx < int(fn.JITPreAllocF64ArrPrefix) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("%w: opcode %d (inline NewF64Array unsupported)", ErrNotImplemented, op.Code)
+	case vm3.OpNewI64Array:
+		if idx < int(fn.JITPreAllocI64ArrPrefix) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("%w: opcode %d (inline NewI64Array unsupported)", ErrNotImplemented, op.Code)
+
 	case vm3.OpCallI64:
 		if opts.SelfIdx < 0 || int(uint16(op.C)) != opts.SelfIdx {
 			return 0, fmt.Errorf("%w: CallI64 to non-self idx %d (SelfIdx=%d)",
@@ -1709,6 +1805,109 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		out := movImm64(xRAX, base)
 		out = append(out, mov64LoadIdxLsl3(r2xAMD64(op.A), xRAX, r2xAMD64(op.B))...)
 		return out, nil
+
+	case vm3.OpF64ArrayGetF64:
+		// Phase 6.3.4.n.3 cold form. Mirrors OpListGetI64's cold-form
+		// slab compute (RAX as scratch for the slab address; RCX for the
+		// f64ArrsBase load). The final movsd loads data[regsI64[C]] into
+		// xmm<A>; raw f64 bits round-trip with no boxing since the slab
+		// stores native float64 data.
+		stride := int64(vm3.JITF64ArrSlabStride())
+		dataOff := int32(vm3.JITF64ArrDataOffset())
+		baseOff := int32(jitArenaCtxF64ArrsBaseOff())
+		xIdx := r2xAMD64(uint16(op.C))
+		out := mov32LoadDisp32(xRAX, xRBP, int32(op.B)*8)
+		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
+		out = append(out, mov64LoadDisp32(xRCX, xR14, baseOff)...)
+		out = append(out, add64RR(xRCX, xRAX)...)
+		out = append(out, mov64LoadDisp32(xRAX, xRAX, dataOff)...)
+		out = append(out, movsdLoadXMMIdxLsl3(int(op.A), xRAX, xIdx)...)
+		return out, nil
+
+	case vm3.OpF64ArraySetF64:
+		// Phase 6.3.4.n.3 cold form. arenas.F64Arrs[regsCell[A]].data[regsI64[C]] = regsF64[B].
+		stride := int64(vm3.JITF64ArrSlabStride())
+		dataOff := int32(vm3.JITF64ArrDataOffset())
+		baseOff := int32(jitArenaCtxF64ArrsBaseOff())
+		xIdx := r2xAMD64(uint16(op.C))
+		out := mov32LoadDisp32(xRAX, xRBP, int32(op.A)*8)
+		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
+		out = append(out, mov64LoadDisp32(xRCX, xR14, baseOff)...)
+		out = append(out, add64RR(xRCX, xRAX)...)
+		out = append(out, mov64LoadDisp32(xRAX, xRAX, dataOff)...)
+		out = append(out, movsdStoreXMMIdxLsl3(int(op.B), xRAX, xIdx)...)
+		return out, nil
+
+	case vm3.OpF64ArrayLenI64:
+		// Phase 6.3.4.n.3 cold form. regsI64[A] = int64(F64Arrs[B].len).
+		stride := int64(vm3.JITF64ArrSlabStride())
+		lenOff := int32(vm3.JITF64ArrLenOffset())
+		baseOff := int32(jitArenaCtxF64ArrsBaseOff())
+		xA := r2xAMD64(op.A)
+		out := mov32LoadDisp32(xRAX, xRBP, int32(op.B)*8)
+		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
+		out = append(out, mov64LoadDisp32(xRCX, xR14, baseOff)...)
+		out = append(out, add64RR(xRCX, xRAX)...)
+		out = append(out, mov32LoadDisp32(xRAX, xRAX, lenOff)...)
+		out = append(out, mov64RR(xRAX, xA)...)
+		return out, nil
+
+	case vm3.OpI64ArrayGetI64:
+		// Phase 6.3.4.n.3 cold form. regsI64[A] = I64Arrs[B].data[regsI64[C]].
+		stride := int64(vm3.JITI64ArrSlabStride())
+		dataOff := int32(vm3.JITI64ArrDataOffset())
+		baseOff := int32(jitArenaCtxI64ArrsBaseOff())
+		xIdx := r2xAMD64(uint16(op.C))
+		xA := r2xAMD64(op.A)
+		out := mov32LoadDisp32(xRAX, xRBP, int32(op.B)*8)
+		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
+		out = append(out, mov64LoadDisp32(xRCX, xR14, baseOff)...)
+		out = append(out, add64RR(xRCX, xRAX)...)
+		out = append(out, mov64LoadDisp32(xRAX, xRAX, dataOff)...)
+		out = append(out, mov64LoadIdxLsl3(xA, xRAX, xIdx)...)
+		return out, nil
+
+	case vm3.OpI64ArraySetI64:
+		// Phase 6.3.4.n.3 cold form. I64Arrs[A].data[regsI64[C]] = regsI64[B].
+		stride := int64(vm3.JITI64ArrSlabStride())
+		dataOff := int32(vm3.JITI64ArrDataOffset())
+		baseOff := int32(jitArenaCtxI64ArrsBaseOff())
+		xIdx := r2xAMD64(uint16(op.C))
+		xB := r2xAMD64(op.B)
+		out := mov32LoadDisp32(xRAX, xRBP, int32(op.A)*8)
+		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
+		out = append(out, mov64LoadDisp32(xRCX, xR14, baseOff)...)
+		out = append(out, add64RR(xRCX, xRAX)...)
+		out = append(out, mov64LoadDisp32(xRAX, xRAX, dataOff)...)
+		out = append(out, mov64StoreIdxLsl3(xB, xRAX, xIdx)...)
+		return out, nil
+
+	case vm3.OpI64ArrayLenI64:
+		stride := int64(vm3.JITI64ArrSlabStride())
+		lenOff := int32(vm3.JITI64ArrLenOffset())
+		baseOff := int32(jitArenaCtxI64ArrsBaseOff())
+		xA := r2xAMD64(op.A)
+		out := mov32LoadDisp32(xRAX, xRBP, int32(op.B)*8)
+		out = append(out, imul64RRImm32(xRAX, xRAX, int32(stride))...)
+		out = append(out, mov64LoadDisp32(xRCX, xR14, baseOff)...)
+		out = append(out, add64RR(xRCX, xRAX)...)
+		out = append(out, mov32LoadDisp32(xRAX, xRAX, lenOff)...)
+		out = append(out, mov64RR(xRAX, xA)...)
+		return out, nil
+
+	case vm3.OpNewF64Array:
+		// Phase 6.3.4.n.3: pre-allocated by jitCall; emit nothing.
+		if idx < int(fn.JITPreAllocF64ArrPrefix) {
+			return []byte{}, nil
+		}
+		return nil, fmt.Errorf("%w: opcode %d (inline NewF64Array unsupported)", ErrNotImplemented, op.Code)
+
+	case vm3.OpNewI64Array:
+		if idx < int(fn.JITPreAllocI64ArrPrefix) {
+			return []byte{}, nil
+		}
+		return nil, fmt.Errorf("%w: opcode %d (inline NewI64Array unsupported)", ErrNotImplemented, op.Code)
+
 	case vm3.OpCallI64:
 		if opts.SelfIdx < 0 || int(uint16(op.C)) != opts.SelfIdx {
 			return nil, fmt.Errorf("%w: CallI64 to non-self idx %d (SelfIdx=%d)",
@@ -2612,12 +2811,66 @@ func vfmaddSDRR(opc byte, dst, src1, src2 int) []byte {
 	return []byte{0xC4, 0xE2, byte2, opc, modRM(3, byte(dst&7), byte(src2&7))}
 }
 
-// movsdLoadXMMFromR14 emits `movsd xmm<dst>, disp32(%r14)`.
-// Opcode F2 REX.B 0F 10 /r disp32. REX is always present (REX.B for R14
-// in the r/m field). Always 9 bytes for xmm0..7 destinations.
-func movsdLoadXMMFromR14(dst int, disp int32) []byte {
-	out := []byte{0xF2, rex(false, dst >= 8, false, true), 0x0F, 0x10, modRM(2, byte(dst&7), byte(xR14&7))}
+// movsdLoadXMMFromGPR emits `movsd xmm<dst>, disp32(%baseGPR)`.
+// Opcode F2 [REX] 0F 10 /r disp32. REX is emitted when dst or base
+// needs the high bit (R8..R15, including R12/R14 used as the f64
+// base). 8 bytes when no REX, 9 bytes with REX. Phase 6.3.4.n.3
+// generalizes the original movsdLoadXMMFromR14 so cell-bank+f64 fns
+// can pin the f64 base in R12.
+func movsdLoadXMMFromGPR(dst int, base int, disp int32) []byte {
+	var out []byte
+	if dst >= 8 || base >= 8 {
+		out = []byte{0xF2, rex(false, dst >= 8, false, base >= 8), 0x0F, 0x10, modRM(2, byte(dst&7), byte(base&7))}
+	} else {
+		out = []byte{0xF2, 0x0F, 0x10, modRM(2, byte(dst), byte(base))}
+	}
 	return appendImm32(out, disp)
+}
+
+// movsdLoadXMMIdxLsl3 emits `movsd xmm<dst>, [r<base> + r<idx>*8]`.
+// Opcode F2 [REX] 0F 10 /r with mod=00, ModR/M.r/m=100 (SIB follows),
+// SIB(scale=3, index=idx, base=base). Used by Phase 6.3.4.n.3 to load
+// an F64Array element after the cells.ptr has been computed into the
+// base GPR. Caller must pre-check rBase is not RBP/R13 (those need
+// mod=01+disp under the SIB.base quirk). Returns 5 bytes; the F2
+// prefix is one byte, REX is one byte (always emitted because we may
+// have base >= 8 or idx >= 8), then opcode + ModR/M + SIB. When dst,
+// base, and idx are all xmm0..7 / RAX..RDI the REX byte still gets
+// emitted (0x40) for predictability of the byte count.
+func movsdLoadXMMIdxLsl3(dst, base, idx int) []byte {
+	rexB := byte(0x40)
+	if dst >= 8 {
+		rexB |= 0x04 // REX.R
+	}
+	if idx >= 8 {
+		rexB |= 0x02 // REX.X
+	}
+	if base >= 8 {
+		rexB |= 0x01 // REX.B
+	}
+	mod := modRM(0, byte(dst&7), 4) // rm=100 = SIB follows
+	sib := byte(3<<6) | byte((idx&7)<<3) | byte(base&7)
+	return []byte{0xF2, rexB, 0x0F, 0x10, mod, sib}
+}
+
+// movsdStoreXMMIdxLsl3 emits `movsd [r<base> + r<idx>*8], xmm<src>`.
+// Opcode F2 [REX] 0F 11 /r SIB. Mirrors movsdLoadXMMIdxLsl3 for the
+// store side. Same RBP/R13 base caveat as the load. Returns 6 bytes
+// like the load.
+func movsdStoreXMMIdxLsl3(src, base, idx int) []byte {
+	rexB := byte(0x40)
+	if src >= 8 {
+		rexB |= 0x04 // REX.R
+	}
+	if idx >= 8 {
+		rexB |= 0x02 // REX.X
+	}
+	if base >= 8 {
+		rexB |= 0x01 // REX.B
+	}
+	mod := modRM(0, byte(src&7), 4)
+	sib := byte(3<<6) | byte((idx&7)<<3) | byte(base&7)
+	return []byte{0xF2, rexB, 0x0F, 0x11, mod, sib}
 }
 
 // xorpdRR emits `xorpd xmmDst, xmmSrc`. Opcode 66 [REX] 0F 57 /r. Used

--- a/runtime/jit/vm3jit/nbody_amd64_test.go
+++ b/runtime/jit/vm3jit/nbody_amd64_test.go
@@ -1,0 +1,49 @@
+//go:build amd64
+
+package vm3jit_test
+
+import (
+	"math"
+	"testing"
+
+	c3 "mochi/compiler3/corpus"
+	"mochi/runtime/jit/vm3jit"
+	"mochi/runtime/vm3"
+)
+
+// TestNBodyJITAdmitsAMD64 is the Phase 6.3.4.n.4 admission gate: the
+// compiler3 n_body kernel (NumRegsI64=7, NumRegsF64=8, NumRegsCell=7)
+// must JIT-compile on AMD64. Phase 6.3.4.n.3 capped cell+f64 fns at
+// NumRegsI64 <= 6 because R12 was reserved for the regsF64 base; n.4
+// remaps i64 slot 6 to R13 in that shape so the cap rises to 7.
+//
+// The kernel result is also compared bit-for-bit against the Go
+// oracle to catch any spill/load bug introduced by the remap.
+func TestNBodyJITAdmitsAMD64(t *testing.T) {
+	for _, steps := range []int64{0, 1, 2, 5, 10, 100} {
+		prog := c3.N_body.Build(steps)
+		cfs := vm3jit.CompileProgram(prog)
+		defer func() {
+			for _, cf := range cfs {
+				if cf != nil {
+					_ = cf.Free()
+				}
+			}
+		}()
+		fn := prog.Funcs[prog.Entry]
+		if fn.JITCode == nil {
+			t.Fatalf("steps=%d: n_body entry has no JITCode on AMD64 "+
+				"(NumRegsI64=%d NumRegsF64=%d NumRegsCell=%d)",
+				steps, fn.NumRegsI64, fn.NumRegsF64, fn.NumRegsCell)
+		}
+		vm := vm3.NewWithProgram(prog)
+		got, err := vm.RunWithArgs(fn, []int64{steps})
+		if err != nil {
+			t.Fatalf("steps=%d: RunWithArgs: %v", steps, err)
+		}
+		want := c3.ExpectN_body(steps)
+		if d := math.Abs(got.Float() - want); d > 1e-10 {
+			t.Fatalf("steps=%d: got %v, want %v (delta %v)", steps, got.Float(), want, d)
+		}
+	}
+}

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -3078,6 +3078,44 @@ n10000 closes from 3.07x to 1.70x, a 33% reduction in JIT ns/op. The Go referenc
 
 **Closure verdict.** linux/amd64: fannkuch_redux n=1000 holds at 1.77x; n=10000 closes from 3.07x to **1.70x**, clearing the under-2x gate independently of n.2.g (which is orthogonal: n.2.g pins cells.ptr in RDX for OpListGetI64; n.2.h replaces IDIV-K with magic-multiply for OpModI64K). With n.2.h alone, the BG suite linux/amd64 closure advances from "0/11 under 2x" (n.2.f spec) to "fannkuch_redux closed at both n sizes". The remaining un-closed linux kernels (nsieve, binary_trees, n_body, k_nucleotide, reverse_complement, spectral_norm, fasta, mandelbrot) are tracked by their own sub-phases under n.2 and o.
 
+#### Phase 6.3.4.n.6: replay AMD64 cell+f64 admission (n.3 + n.4 codegen) (2026-05-20 18:35 GMT+7)
+
+**Why this phase.** The two AMD64 sub-phases n.3 (F64Array + I64Array lowering for cell+f64 fns) and n.4 (R13 remap to raise the i64 cap 6 -> 7) were each implemented and bench-validated on server2 in earlier sessions, but their PRs (#21853, #21855, #21857) never merged because a sibling spec PR introduced an MDX parse error that blocked website deploy; the orphan branches were never re-rebased onto post-n.2.h main and the code drifted out. The n.4c.6 triage hotfix (§ above) explicitly tagged n_body and spectral_norm as interp-floor on linux/amd64. This sub-phase replays the code-only deltas onto post-n.2.h main on a fresh branch, applies the two correctness fix-ups discovered during the original work, and re-benches on server2 to get an honest closure number for n_body and spectral_norm on linux/amd64.
+
+**What is replayed (code only, no per-phase spec from the orphan branches).** Five commits cherry-pick clean onto post-n.2.h main:
+
+1. **F64Array + I64Array AMD64 lowering** (originally n.3). Adds the cell+f64 entry path to the AMD64 backend: when `NumRegsCell > 0 && NumRegsF64 > 0`, R12 is pinned as the regsF64 base (the same role R14 plays for cell-only fns). The whitelist `checkCellBankAdmissibleAMD64` is extended to admit `OpF64ArrayGetF64`, `OpF64ArraySetF64`, `OpF64ArrayLenI64`, `OpI64ArrayGetI64`, `OpI64ArraySetI64`, `OpI64ArrayLenI64` and the standard f64 op set (`OpAddF64`, `OpSubF64`, `OpMulF64`, `OpDivF64`, `OpSqrtF64`, `OpFmaF64`, `OpI64ToF64`, `OpConstF64`, `OpReturnF64`). Pre-existing rejection of f64 for cell+f64 fns (`compile.go:354 checkCellBankAdmissibleAMD64`) is removed.
+
+2. **SIB-byte fix for movsd against R12 base.** R12's low 3 bits are `100`, so `movsd xmm<r>, disp32(%r12)` cannot be encoded without an explicit SIB byte (`0x24`: scale=0, index=`100`=none, base=`100`=R12) between the ModR/M byte and the disp32. Without the SIB, the decoder reads the first byte of disp32 as the missing SIB and consumes 4 more bytes as displacement, desyncing the whole prologue. The fix is the same x86 quirk documented in n.2.f for the OpListSetI64 RDX-base pin; the byte-count predictor (`prologueLenAMD64`) accounts for the extra byte per f64-reg load when `usesR12ForF64AMD64(fn)` is true.
+
+3. **Prologue byte-count fix for R12 f64 base.** Companion to (2): the f64-bank load sequence in the prologue has one extra byte per slot when R12 is the base; `prologueLenAMD64` was undercounting which broke deopt-return offsets.
+
+4. **A == C aliasing fix in 2-operand SSE arith.** The naive `xmm[A] = xmm[B] OP xmm[C]` lowering `movsd A, B ; OPsd A, C` silently corrupts `xmm[C]` when `A == C != B` because the `movsd` writes to `xmm[A]` first. For commutative ops (Add/Mul) the result is incidentally correct only when `A == B`; for non-commutative (Sub/Div) the aliasing silently produces `xmm[A] = xmm[B] OP xmm[B]` (identity 1.0 for Div). spectral_norm tripped this at pc=21 (`a = 1.0 / denomF` encoded as `OpDivF64 A=1 B=2 C=1`) and silently returned `sqrt(1/n)` instead of the true spectral radius. The fix factors the lowering into `emitSSEArithAMD64(op, a, b, c, commutative)`:
+
+   - `a == b`: just `<op>sd a, c` (4 bytes).
+   - `a == c`, commutative: `<op>sd a, b` (4 bytes; safe because `xmm[a] = xmm[c]` already).
+   - `a == c`, non-commutative: `movsd xmm15, b ; <op>sd xmm15, c ; movsd a, xmm15` via the SSE scratch (xmm15 is reserved by the allocator).
+   - otherwise: standard `movsd a, b ; <op>sd a, c`.
+
+5. **R13 remap raises cell+f64 i64 cap 6 -> 7** (originally n.4). When `NumRegsCell > 0 && NumRegsF64 > 0`, R12 is taken by regsF64 so the i64 register file loses one slot. n.3 capped these fns at `NumRegsI64 <= 6`; n.4 remaps i64 slot 6 to R13 to raise the cap to 7. This is the minimum that lets n_body (`NumRegsI64=7, NumRegsF64=8, NumRegsCell=7`) JIT-admit on AMD64. `archCaps` returns `i64Cap = 7` for the `Cell > 0 && F64 > 0` shape; `r2xAMD64` routes slot 6 to R13; push/pop helpers preserve R13 across deopt entry/exit.
+
+**Why this is a generic win, not a BG hack.** The MEP-39 "no hard-coded BG super-ops" rule (§14) applies: every change is at the codegen level. F64Array / I64Array opcodes are typed-array surface added in n.3.j.5 and l.4 because BG kernels use uniform-typed arrays heavily; the lowering is opcode-level, not kernel-shape. The SIB-byte fix and the A==C clobber fix are pure correctness on the AMD64 backend that any cell+f64 program with simultaneously-live f64 args would hit. The R13 remap raises the architectural register count and is symmetric with the ARM64 cap-bump in `archCaps` for `NumRegsCell > 4`.
+
+**Bench (linux/amd64 server2, median of 3 at -benchtime=3s).** Both kernels were interp-floor on linux/amd64 before this replay; with n.3+n.4 admitted, both JIT-admit and run 15-87x faster than the interp.
+
+| Kernel | interp ns/op | vm3jit n.6 ns/op | Go ns/op | Ratio (n.6) | Verdict |
+| :--- | ---: | ---: | ---: | ---: | :---: |
+| `n_body_n100`         | (interp) | 92,896      | 30,216    | 3.07x | admitted, gap remains |
+| `n_body_n10000`       | (interp) | 10,928,557  | 3,764,343 | 2.90x | admitted, gap remains |
+| `spectral_norm_n100`  | (interp) | 192,587     | 98,815    | **1.95x** | **inside 2x (closed)** |
+| `spectral_norm_n1000` | (interp) | 20,886,452  | 5,981,301 | 3.49x | admitted, gap remains |
+
+`spectral_norm_n100` clears the under-2x gate. `n_body` at both sizes and `spectral_norm_n1000` are admitted but do not yet close; the remaining 2.9-3.5x gap is consistent with the ARM64 closure path (j.4b FMA fusion + j.4c LICM for adv_j_loop) which has not been replayed for AMD64. Those are tracked separately and do not block the n.6 replay.
+
+**Tests.** `runtime/jit/vm3jit/...` passes on darwin/arm64 and on linux/amd64 server2 with `go test -count=1`. The replay includes two AMD64-tagged tests: `f64arr_amd64_test.go` (admits OpF64ArrayGetF64 / OpF64ArraySetF64 / OpF64ArrayLenI64 and matches a Go oracle) and `nbody_amd64_test.go` (TestNBodyJITAdmitsAMD64 hard-fails if n_body falls back to interp on linux/amd64). Both pass.
+
+**Closure verdict.** linux/amd64: `spectral_norm_n100` closes from interp-floor (~14.8x at the n.4c.6 triage point) to **1.95x**. `n_body` and `spectral_norm_n1000` advance from interp-floor (>50x) to 2.90-3.49x. The BG suite under-2x tally on linux/amd64 advances from 5/9 (after n.2.h) to 6/9 (n_body, spectral_norm both kernel families now JIT-admit; one of the four sizes closes). Remaining un-closed: `n_body_n100`/`_n10000`, `spectral_norm_n1000`, `k_nucleotide`, `reverse_complement` (still panics on linux/amd64 in interp at vm3/vm.go:853, separate sub-phase).
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
Tracks #21864.

## Summary

- Replays the orphaned n.3 (F64Array + I64Array AMD64 lowering, R12 pin) and n.4 (R13 remap for i64 cap 6 -> 7) code onto post-n.2.h main on a fresh branch. The original PRs (#21853, #21855, #21857) never merged because of an MDX parse error in the n.3 spec section.
- Includes the SIB-byte and prologue-byte fixes for the R12 base addressing quirk, plus the A == C aliasing fix in `emitSSEArithAMD64` for OpSubF64 / OpDivF64.
- Adds two AMD64-tagged tests: `f64arr_amd64_test.go` and `nbody_amd64_test.go` (TestNBodyJITAdmitsAMD64 hard-fails if n_body falls back to interp).
- MEP-40 spec entry for Phase 6.3.4.n.6 lands in the same PR (2026-05-20 18:35 GMT+7).

## Bench (linux/amd64 server2, -benchtime=3s median of 3)

| Kernel | vm3jit ns/op | Go ns/op | Ratio | Verdict |
| --- | ---: | ---: | ---: | :---: |
| spectral_norm_n100 | 192,587 | 98,815 | 1.95x | inside 2x (closed) |
| n_body_n100 | 92,896 | 30,216 | 3.07x | admitted, gap remains |
| n_body_n10000 | 10,928,557 | 3,764,343 | 2.90x | admitted, gap remains |
| spectral_norm_n1000 | 20,886,452 | 5,981,301 | 3.49x | admitted, gap remains |

All four kernels were interp-floor on linux/amd64 before this PR (per the n.4c.6 triage). They now JIT-admit and run 15-87x faster than the interp; one closes under 2x.

## Test plan

- [x] `go build ./...` on darwin/arm64 and linux/amd64.
- [x] `go test -count=1 ./runtime/jit/vm3jit/...` on darwin/arm64.
- [x] `go test -count=1 ./runtime/jit/vm3jit/...` on linux/amd64 server2.
- [x] `npx docusaurus build` succeeds (MDX clean).
- [x] `BenchmarkCorpusJITRunner/(n_body|spectral_norm)_n*` runs without deopt on linux/amd64.