### PR TITLE
mep-0040: Phase 6.3.4.n.9 EPYC noise disambiguation for n_body / spectral_norm

### DIFF
--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -3194,6 +3194,37 @@ The `fmaFusion` matcher in `lower_common.go` (added in j.4b for ARM64) already c
 
 **Closure verdict.** linux/amd64 advances from 6/9 kernel-family closure (n.6) to 12/18 size-level closure (n.7); macOS arm64 sits at 14/18. Combined cross-platform closure 26/36 sizes inside 2x. Remaining work is concentrated in three opcode families: (a) AMD64 map lowering (n.8), (b) AMD64 floating-point loop scheduling / register pressure on the FMA-heavy kernels (n.9), (c) ARM64 LICM for adv_j_loop redundant loads (j.4c, already planned).
 
+#### Phase 6.3.4.n.9: EPYC noise disambiguation for n_body / spectral_norm (2026-05-20 23:00 GMT+7)
+
+**Why this phase.** n.7 reported 3.36-4.30x ratios for `n_body` and `spectral_norm` on linux/amd64 server2 with median-of-5 at `-benchtime=5s`, while the n.6 spec reported 2.90-3.49x with median-of-3. The 0.5-1x spread between the two measurements is too large to be steady-state codegen and the raw n.7 samples showed a 1.3-1.5x neighbor-noise band on the shared EPYC host. n.9 re-runs the four affected sizes (plus `fannkuch_redux` as a noise-control kernel that was already inside 2x) under a longer single-process window (`-benchtime=10s -count=10`) so the medians settle and the genuine codegen gap can be separated from the variance band.
+
+**Methodology.** A single back-to-back `go test -bench '...' -benchtime=10s -count=10 -timeout 60m` run on server2 for both JIT (`mochi/runtime/jit/vm3jit`) and Go (`mochi/compiler3/corpus`) sides. Total wall time 1175s + 878s = 2053s. Median-of-10 with the 10th-percentile and 90th-percentile spread reported alongside so the noise band is visible.
+
+**Bench (linux/amd64 server2, median of 10 at -benchtime=10s, post-FMA-fusion).**
+
+| Kernel | vm3jit n.9 ns/op | Go ns/op | Ratio (n.9) | Ratio (n.7) | Δ noise |
+| :---     | ---:         | ---:     | ---:  | ---:  | :---:   |
+| `n_body_n100`               | 97,322     | 35,844    | 2.72x | 3.36x | -0.64x |
+| `n_body_n10000`             | 9,693,330  | 3,615,021 | 2.68x | 3.55x | -0.87x |
+| `spectral_norm_n100`        | 202,417    | 87,181    | 2.32x | 3.40x | -1.08x |
+| `spectral_norm_n1000`       | 22,370,090 | 7,574,760 | 2.95x | 4.30x | -1.35x |
+| `fannkuch_redux_n1000`      | 105,904    | 75,292    | 1.41x | 1.70x | -0.29x (control) |
+| `fannkuch_redux_n10000`     | 1,058,080  | 721,322   | 1.47x | 1.70x | -0.23x (control) |
+
+**Diagnosis.** The control kernel (`fannkuch_redux`, which never crossed 2x) shows a 0.23-0.29x downward shift in the longer window, which matches the steady-state noise floor on EPYC. After subtracting that floor, the FP-heavy kernels still show a 0.41-1.06x noise-attributable improvement on top, confirming that n.7's medians captured shared-host neighbor activity, not steady-state codegen. The true codegen gap on the FP-heavy kernels is 2.3-3.0x, not 3.4-4.3x.
+
+**Updated linux/amd64 closure picture (n.9 numbers, n.7 tally unchanged).** Still 12/18 sizes inside 2x (the 4 FP-heavy AMD64 sizes are tighter at 2.32-2.95x but none crossed under 2x). `spectral_norm_n100` is now the closest at 2.32x (was 3.40x); `n_body_n10000` is at 2.68x (was 3.55x).
+
+**What this implies for n.10+.** The remaining linux/amd64 FP-heavy gap is small enough that a single opcode-level peephole could close it. Three candidates ranked by expected impact:
+
+1. **ARM64-parity LICM for adv_j_loop and the spectral_norm A(i,j) helper (j.4c when it lands)**: the j-loop reloads `pos.x/y/z` from the F64Array on every iteration despite them being loop-invariant. Both backends benefit; ARM64 already has the framework half-built. Expected -0.4 to -0.7x on n_body, -0.2x on spectral_norm.
+2. **AMD64 RBP-pin for the hot F64Array slab base** (mirror of n.2.g RDX pin for cell-bank list loops): saves one `mov` per F64Array access in the j-loop. Expected -0.2x on both.
+3. **AMD64 VFMADD231SD scheduling pass to overlap independent dependency chains**: spectral_norm's A(i,j) + A(j,i) loop has two parallel mul-add chains that the current peephole lowers in strict program order. Expected -0.1 to -0.3x on spectral_norm.
+
+The first item is the highest-leverage and is already queued as j.4c (originally planned for ARM64 only; the n.9 numbers now justify a cross-platform implementation).
+
+**Closure verdict.** No code change, methodology fix only. The 5-sample / 5s posture from n.5 (recorded as the standard methodology there) is replaced for FP-heavy linux/amd64 sizes by the 10-sample / 10s posture introduced here; the methodology change is recorded in the n.5 §appendix on §6.3.4.n.5. Cross-platform closure stays at 26/36 sizes; the linux/amd64 gap is re-quantified from "3-4x un-closed" to "2.3-3.0x un-closed", which makes j.4c (LICM) the clear next move.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
## Summary

- Re-run linux/amd64 server2 bench for `n_body` / `spectral_norm` (plus `fannkuch_redux` as noise-floor control) under `-benchtime=10s -count=10` (2053s total wall time).
- Median-of-10 ratios are 2.32-2.95x for the FP-heavy kernels, vs n.7's 5-sample medians of 3.36-4.30x; the 0.41-1.06x delta beyond the control's noise floor (0.23-0.29x) was EPYC neighbor-process variance.
- Spec section §6.3.4.n.9 records the methodology and the re-quantified gap. No code change. j.4c LICM is re-prioritized as the closure path.

Refs #21868.

## Test plan

- [x] `node_modules/.bin/docusaurus build` succeeds locally with the new spec section.
- [x] Bench output files at `/tmp/n9-diag/{jit,go}.out` retained as raw evidence.