### PR TITLE
mep-0040: fix stale n.5 cross-reference in n.9 closure verdict

### DIFF
--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -3223,7 +3223,7 @@ The `fmaFusion` matcher in `lower_common.go` (added in j.4b for ARM64) already c
 
 The first item is the highest-leverage and is already queued as j.4c (originally planned for ARM64 only; the n.9 numbers now justify a cross-platform implementation).
 
-**Closure verdict.** No code change, methodology fix only. The 5-sample / 5s posture from n.5 (recorded as the standard methodology there) is replaced for FP-heavy linux/amd64 sizes by the 10-sample / 10s posture introduced here; the methodology change is recorded in the n.5 §appendix on §6.3.4.n.5. Cross-platform closure stays at 26/36 sizes; the linux/amd64 gap is re-quantified from "3-4x un-closed" to "2.3-3.0x un-closed", which makes j.4c (LICM) the clear next move.
+**Closure verdict.** No code change, methodology fix only. The 5-sample / 5s posture used in n.7's bench methodology paragraph is replaced for FP-heavy linux/amd64 sizes by the 10-sample / 10s posture introduced here; the choice is recorded inline in this section. Cross-platform closure stays at 26/36 sizes; the linux/amd64 gap is re-quantified from "3-4x un-closed" to "2.3-3.0x un-closed", which makes j.4c (LICM) the clear next move.
 
 ### Phase 7: Production migration and vm2 deprecation
 


### PR DESCRIPTION
## Summary

- n.9 closure-verdict referenced a non-existent §6.3.4.n.5 appendix for the bench methodology change.
- The actual methodology paragraph lives in n.7; point readers there.

Refs #21868.

## Test plan

- [x] Docusaurus build passes locally.