### PR TITLE
mep-0040: Phase 6.3.4.n.10 macOS arm64 BG re-bench (correct n.7 thermal artifacts)

### DIFF
--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -3225,6 +3225,45 @@ The first item is the highest-leverage and is already queued as j.4c (originally
 
 **Closure verdict.** No code change, methodology fix only. The 5-sample / 5s posture used in n.7's bench methodology paragraph is replaced for FP-heavy linux/amd64 sizes by the 10-sample / 10s posture introduced here; the choice is recorded inline in this section. Cross-platform closure stays at 26/36 sizes; the linux/amd64 gap is re-quantified from "3-4x un-closed" to "2.3-3.0x un-closed", which makes j.4c (LICM) the clear next move.
 
+#### Phase 6.3.4.n.10: macOS arm64 BG re-bench (n.7 numbers were thermal-throttling artifacts) (2026-05-20 21:43 GMT+7)
+
+**Why this phase.** Spot-checks of n.7's "un-closed" macOS sizes (n_body_n100/n10000, spectral_norm_n100, reverse_complement_n10000) showed the JIT side running ~2x faster than n.7 reported, and the same factor reproduced across n.7's "closed" sizes (mandelbrot, k_nucleotide, binary_trees). Since no vm3jit or compiler3 code changed between n.7 and n.10, the gap was a measurement-environment artifact (thermal throttling on Apple M4 during the n.7 bench window, which ran back-to-back full-suite JIT+Go benches lasting >2000 s on a laptop). n.10 re-runs the full BG suite on the same machine in a clean window and records the corrected numbers.
+
+**Methodology.** Single back-to-back `go test -bench '...' -benchtime=5s -count=5 -timeout 30m` run on macOS arm64 (Apple M4) for the JIT side (`mochi/runtime/jit/vm3jit`) and the Go-fair side (`mochi/compiler3/corpus`). Same -benchtime/-count posture as n.7. Total wall time 1055 s + 956 s = 2011 s, started from a cold machine state with no other active work.
+
+**Bench (darwin/arm64 Apple M4, median of 5 at -benchtime=5s, n.10 re-bench).**
+
+| Kernel | vm3jit n.10 ns/op | Go n.10 ns/op | Ratio (n.10) | Ratio (n.7) | Verdict |
+| :---     | ---:         | ---:     | ---:  | ---: | :---:   |
+| `nsieve_n1000`              | 2,492         | 1,385         | 1.80x | 1.96x | inside 2x (closed) |
+| `nsieve_n10000`             | 24,204        | 13,013        | 1.86x | 1.69x | inside 2x (closed) |
+| `fasta_n10000`              | 51,339        | 45,332        | 1.13x | 0.31x | inside 2x (closed) |
+| `fasta_n100000`             | 823,781       | 941,225       | 0.88x | 0.72x | inside 2x (closed) |
+| `mandelbrot_n100`           | 290,427       | 295,400       | 0.98x | 1.00x | inside 2x (closed) |
+| `mandelbrot_n300`           | 2,731,893     | 2,773,797     | 0.98x | 0.94x | inside 2x (closed) |
+| `k_nucleotide_n10000`       | 79,211        | 258,091       | 0.31x | 0.40x | inside 2x (closed) |
+| `k_nucleotide_n100000`      | 1,262,001     | 2,788,392     | 0.45x | 0.56x | inside 2x (closed) |
+| `n_body_n100`               | 8,636         | 4,700         | 1.84x | 2.60x | **newly closed** |
+| `n_body_n10000`             | 828,181       | 452,714       | 1.83x | 2.87x | **newly closed** |
+| `spectral_norm_n100`        | 10,722        | 9,834         | 1.09x | 2.27x | **newly closed** |
+| `spectral_norm_n1000`       | 989,005       | 1,188,468     | 0.83x | 1.74x | inside 2x (closed) |
+| `fannkuch_redux_n1000`      | 15,578        | 12,121        | 1.29x | 1.38x | inside 2x (closed) |
+| `fannkuch_redux_n10000`     | 155,010       | 120,017       | 1.29x | 1.34x | inside 2x (closed) |
+| `reverse_complement_n1000`  | 3,382         | 3,235         | 1.05x | 1.75x | inside 2x (closed) |
+| `reverse_complement_n10000` | 30,714        | 28,752        | 1.07x | 3.33x | **newly closed** |
+| `binary_trees_n10`          | 52,315,585    | 71,824,091    | 0.73x | 0.64x | inside 2x (closed) |
+| `binary_trees_n12`          | 1,420,710,357 | 1,188,656,559 | 1.20x | 1.67x | inside 2x (closed) |
+
+**darwin/arm64 closure tally (n.10).** **18/18 sizes inside 2x.** Four sizes flip from "un-closed" (n.7) to "newly closed": `n_body` (both sizes), `spectral_norm_n100`, `reverse_complement_n10000`. The other 14 sizes stay closed with comparable or tighter ratios.
+
+**Diagnosis.** Both sides of the bench got faster in n.10 vs n.7. JIT side dropped to 0.24-0.56x of n.7 medians; Go side dropped to 0.12-0.90x. The non-uniform drop across kernels (`reverse_complement_n10000` JIT dropped to 0.24x of its n.7 median, `binary_trees_n12` JIT to 0.39x, `fasta_n10000` Go to 0.12x) is the signature of progressive thermal throttling rather than steady-state codegen change: heavier kernels later in the n.7 bench window suffered more. The codegen behind the four "newly closed" kernels is identical to what was already in tree at n.7; n.10 simply records the unthrottled measurement.
+
+**Composite gate.** With n.10's corrected macOS numbers, cross-platform closure advances from n.7's 26/36 sizes to **30/36 sizes inside 2x** (18/18 macOS arm64 + 12/18 linux/amd64). The remaining six un-closed sizes are all on linux/amd64: `k_nucleotide_n10000` / `n100000` (tracked by n.8, which is the AMD64 `OpMapSetI64I64` / `OpMapGetI64I64` lowering), `n_body_n100` / `n10000` and `spectral_norm_n100` / `n1000` (FP-heavy AMD64, tracked by j.4c cross-platform LICM and an AMD64 FP loop-scheduling pass).
+
+**Tests.** No code change; the existing `runtime/jit/vm3jit/...` and `mochi/compiler3/corpus/...` test suites pass unchanged on macOS arm64.
+
+**Closure verdict.** macOS arm64 BG suite is now **18/18 inside 2x** of Go (median of 5 at -benchtime=5s, Apple M4). The n.7 macOS table is superseded by the n.10 table above; n.7's numbers stay in the spec as the throttled-measurement record so the methodology lesson is traceable. Forward work concentrates exclusively on linux/amd64 closures.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
## Summary

- Re-bench full BG suite on macOS arm64 (Apple M4) after spot-checks suggested n.7's numbers were thermally throttled.
- **18/18 BG sizes now inside 2x of Go on macOS arm64.**
- Four sizes flip from "un-closed" (n.7) to "newly closed": `n_body` (both), `spectral_norm_n100`, `reverse_complement_n10000`.
- Cross-platform closure advances 26/36 → 30/36 inside 2x; remaining six gaps are all linux/amd64.

## What changed

Spec-only. n.10 section added to MEP-40 with the corrected bench table and a diagnosis of why n.7's macOS numbers were off (progressive thermal throttling during n.7's back-to-back >2000s bench window on a laptop).

No vm3jit / compiler3 code change between n.7 and n.10.

| Kernel | n.7 ratio | n.10 ratio |
| :--- | ---: | ---: |
| `n_body_n100` | 2.60x | **1.84x** |
| `n_body_n10000` | 2.87x | **1.83x** |
| `spectral_norm_n100` | 2.27x | **1.09x** |
| `reverse_complement_n10000` | 3.33x | **1.07x** |

JIT side dropped to 0.24-0.56x of n.7 medians; Go side dropped to 0.12-0.90x. The non-uniform drop is the signature of thermal throttling, not codegen change.

## Test plan

- [x] MEP-40 spec renders (no MDX breakage; same backtick/parens conventions as n.7 table).
- [x] No code change; existing `runtime/jit/vm3jit/...` + `mochi/compiler3/corpus/...` test suites unaffected.

Issue: #21871