### PR TITLE
mep-0040: Phase 6.3.4.n.11 AMD64 F64Array data-ptr cache (closes n_body x2)

### DIFF
--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -458,6 +458,154 @@ func hoistPrologueBytesAMD64(fn *vm3.Function) int {
 	return 6 + 7 + 7 + 3 + 7 + storeBytes
 }
 
+// hoistsF64ArrDataPtrsAMD64 reports whether the AMD64 prologue should
+// pre-resolve and cache each constant-cell F64Array's data pointer.
+// "Constant cell" means the cell is written exactly once by an
+// OpNewF64Array in the JITPreAllocF64ArrPrefix K-prefix (which jitCall
+// pre-allocates before the trampoline) and never overwritten anywhere
+// else in the function. preAllocF64ArrPrefix already enforces that
+// safety guard, so the data slice pointer is invariant for the entire
+// call: F64ArraySet writes into existing slots and never appends.
+//
+// When active, OpF64ArrayGetF64 / OpF64ArraySetF64 swap their 6-inst /
+// ~36-byte slab-resolution chain for a 2-inst / ~10-byte hot form that
+// reads the cached ptr from a scratch regsI64 slot. The cache lives
+// past NumRegsI64 (the interpreter never reads above that bound) at
+// disp = (NumRegsI64 + cellPtrHoistOffsetAMD64(fn) + k) * 8 from RBX.
+// Phase 6.3.4.n.11.
+//
+// Gates:
+//
+//   - isCellBankAMD64(fn): RBP must hold the regsCell base so the
+//     prologue can read each pinned cell's handle.
+//   - fn.JITPreAllocF64ArrPrefix > 0: there is at least one constant
+//     F64Array cell to cache. Higher K = larger prologue but also more
+//     body savings.
+//   - !isNonLeafAMD64(fn): any internal call could in principle invoke
+//     a callee that overwrites the cached cells. n_body / spectral_norm
+//     are leaf kernels so this gate is comfortable.
+//   - Body contains at least one OpF64ArrayGetF64 / OpF64ArraySetF64
+//     referencing a hoisted cell. Without a use, the prologue would
+//     waste K * 30 bytes for zero hot-path benefit.
+//   - NumRegsI64 + numF64ArrDataPtrHoistsAMD64 + (1 if hoistsCellsPtrAMD64) <= maxI64Regs:
+//     the cache must fit in the jitFrame3.regsI64 scratch area without
+//     overrunning the interpreter's deopt-state read window. maxI64Regs
+//     is 17 and the F64Array-using kernels stay well below that.
+func hoistsF64ArrDataPtrsAMD64(fn *vm3.Function) bool {
+	if !isCellBankAMD64(fn) {
+		return false
+	}
+	k := int(fn.JITPreAllocF64ArrPrefix)
+	if k == 0 {
+		return false
+	}
+	if isNonLeafAMD64(fn) {
+		return false
+	}
+	hoistedSlots := make(map[uint16]bool, k)
+	for i := 0; i < k; i++ {
+		hoistedSlots[fn.Code[i].A] = true
+	}
+	hasUse := false
+	for _, op := range fn.Code {
+		switch op.Code {
+		case vm3.OpF64ArrayGetF64:
+			if hoistedSlots[op.B] {
+				hasUse = true
+			}
+		case vm3.OpF64ArraySetF64:
+			if hoistedSlots[op.A] {
+				hasUse = true
+			}
+		}
+		if hasUse {
+			break
+		}
+	}
+	if !hasUse {
+		return false
+	}
+	base := int(fn.NumRegsI64)
+	if hoistsCellsPtrAMD64(fn) {
+		base++
+	}
+	if base+k > maxI64Regs {
+		return false
+	}
+	return true
+}
+
+// numF64ArrDataPtrHoistsAMD64 returns the number of constant F64Array
+// cells whose data pointers are cached by the prologue. Zero when
+// hoistsF64ArrDataPtrsAMD64(fn) is false.
+func numF64ArrDataPtrHoistsAMD64(fn *vm3.Function) int {
+	if !hoistsF64ArrDataPtrsAMD64(fn) {
+		return 0
+	}
+	return int(fn.JITPreAllocF64ArrPrefix)
+}
+
+// f64ArrDataPtrHoistDispAMD64 returns the disp from RBX (= &regsI64[0])
+// at which the k-th constant F64Array cell's data pointer is stashed.
+// The k-th cached pointer lives in the cell at fn.Code[k].A (since the
+// K-prefix at pc=0..K-1 is the canonical ordering). Caller must check
+// hoistsF64ArrDataPtrsAMD64(fn) first; the disp is undefined otherwise.
+func f64ArrDataPtrHoistDispAMD64(fn *vm3.Function, k int) int32 {
+	base := int(fn.NumRegsI64)
+	if hoistsCellsPtrAMD64(fn) {
+		base++
+	}
+	return int32((base + k) * 8)
+}
+
+// f64ArrDataPtrHoistSlotAMD64 returns k such that the data pointer for
+// regsCell[cellSlot] is cached at index k in the hoist table (k in
+// [0, numF64ArrDataPtrHoistsAMD64(fn))), or -1 if cellSlot is not
+// hoisted. The k-th cached cell is fn.Code[k].A by construction.
+func f64ArrDataPtrHoistSlotAMD64(fn *vm3.Function, cellSlot uint16) int {
+	if !hoistsF64ArrDataPtrsAMD64(fn) {
+		return -1
+	}
+	k := int(fn.JITPreAllocF64ArrPrefix)
+	for i := 0; i < k; i++ {
+		if fn.Code[i].A == cellSlot {
+			return i
+		}
+	}
+	return -1
+}
+
+// f64ArrDataPtrHoistPrologueBytesAMD64 returns the extra prologue bytes
+// needed to populate the F64Array data-ptr cache. Each hoisted cell
+// emits the same 6-step resolution chain plus one store:
+//
+//	mov  (cellSlot*8)(%rbp), %eax  ; idx = low 32 of regsCell[cellSlot]  (6B)
+//	imul $stride, %rax, %rax       ; rax = idx * sizeof(vmF64Array)      (7B)
+//	mov  f64ArrsBaseOff(%r14), %rcx; rcx = arenas.F64Arrs base           (7B)
+//	add  %rcx, %rax                ; rax = &arenas.F64Arrs[idx]          (3B)
+//	mov  dataOff(%rax), %rax       ; rax = data.ptr                      (7B)
+//	mov  %rax, hoistDisp(%rbx)     ; cache it                            (4 or 7B)
+//
+// mov32LoadDisp32 always emits mod=10 disp32 (6B for RAX<-RBP, no REX),
+// matching the cold-form encoders so byteCount and emit stay in sync.
+// Only the final store can shrink to disp8 when the hoist slot fits.
+func f64ArrDataPtrHoistPrologueBytesAMD64(fn *vm3.Function) int {
+	n := numF64ArrDataPtrHoistsAMD64(fn)
+	if n == 0 {
+		return 0
+	}
+	total := 0
+	for k := 0; k < n; k++ {
+		storeBytes := 4 // mov %rax, disp8(%rbx)
+		hoistDisp := f64ArrDataPtrHoistDispAMD64(fn, k)
+		if hoistDisp < -128 || hoistDisp > 127 {
+			storeBytes = 7
+		}
+		total += 6 + 7 + 7 + 3 + 7 + storeBytes
+	}
+	return total
+}
+
 // computeCallSpillsAMD64 runs backward liveness exactly like the
 // AArch64 backend, but emits a mask over slots 0..5 (caller-saved on
 // AMD64) instead of 0..6.
@@ -626,6 +774,8 @@ func prologueLenAMD64(fn *vm3.Function) int {
 	// Phase 6.3.4.n.2.f: cells.ptr hoist setup (cold form: 0 bytes when
 	// gate fails; ~34 bytes when active). See hoistPrologueBytesAMD64.
 	bytes += hoistPrologueBytesAMD64(fn)
+	// Phase 6.3.4.n.11: F64Array data-ptr cache for constant cells.
+	bytes += f64ArrDataPtrHoistPrologueBytesAMD64(fn)
 	_ = pushes
 	return bytes
 }
@@ -706,6 +856,28 @@ func emitPrologueAMD64(buf []byte, fn *vm3.Function) []byte {
 			buf = append(buf, mov64StoreDisp8(xRAX, xRBX, int8(hoistDisp))...)
 		} else {
 			buf = append(buf, mov64StoreDisp32(xRAX, xRBX, hoistDisp)...)
+		}
+	}
+	// Phase 6.3.4.n.11: cache the data ptr of each constant F64Array cell
+	// so OpF64ArrayGet/SetF64 can drop their 6-inst slab-resolution chain
+	// to a 2-inst hot form (mov hoistDisp(%rbx), %rax + movsd via SIB).
+	if nHoist := numF64ArrDataPtrHoistsAMD64(fn); nHoist > 0 {
+		stride := int64(vm3.JITF64ArrSlabStride())
+		dataOff := int32(vm3.JITF64ArrDataOffset())
+		baseOff := int32(jitArenaCtxF64ArrsBaseOff())
+		for k := 0; k < nHoist; k++ {
+			cellSlot := int32(fn.Code[k].A) * 8
+			hoistDisp := f64ArrDataPtrHoistDispAMD64(fn, k)
+			buf = append(buf, mov32LoadDisp32(xRAX, xRBP, cellSlot)...)
+			buf = append(buf, imul64RRImm32(xRAX, xRAX, int32(stride))...)
+			buf = append(buf, mov64LoadDisp32(xRCX, xR14, baseOff)...)
+			buf = append(buf, add64RR(xRCX, xRAX)...)
+			buf = append(buf, mov64LoadDisp32(xRAX, xRAX, dataOff)...)
+			if hoistDisp >= -128 && hoistDisp <= 127 {
+				buf = append(buf, mov64StoreDisp8(xRAX, xRBX, int8(hoistDisp))...)
+			} else {
+				buf = append(buf, mov64StoreDisp32(xRAX, xRBX, hoistDisp)...)
+			}
 		}
 	}
 	return buf
@@ -1227,11 +1399,35 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		//   add  %rcx, %rax               ; rax = &arenas.F64Arrs[idx]    (3B)
 		//   mov  dataOff(%rax), %rax      ; rax = data.ptr                (7B)
 		//   movsd  [%rax + xIdx*8], xmm<A> ; xmm<A> = data[regsI64[C]]    (6B SIB-scale3)
+		//
+		// Phase 6.3.4.n.11 hot form (cell hoisted): the data ptr was
+		// resolved once in the prologue and cached at hoistDisp(%rbx);
+		// load it then SIB-index. The mov64Load can shrink to disp8 when
+		// the hoist disp fits, giving 4+6 = 10B vs 36B cold.
+		if k := f64ArrDataPtrHoistSlotAMD64(fn, op.B); k >= 0 {
+			hoistDisp := f64ArrDataPtrHoistDispAMD64(fn, k)
+			loadBytes := 4
+			if hoistDisp < -128 || hoistDisp > 127 {
+				loadBytes = 7
+			}
+			return loadBytes + 6, nil
+		}
 		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + 7 + 6, nil
 	case vm3.OpF64ArraySetF64:
 		// Phase 6.3.4.n.3 cold form (AMD64 mirror of ARM64 OpF64ArraySetF64).
 		// arenas.F64Arrs[handleIdx(regsCell[A])].data[regsI64[C]] = regsF64[B].
 		// Same byte budget as Get: 6+7+7+3+7+6.
+		//
+		// Phase 6.3.4.n.11 hot form (cell hoisted): same shape as Get's
+		// hot form but the final movsd is a store. 4+6 = 10B.
+		if k := f64ArrDataPtrHoistSlotAMD64(fn, op.A); k >= 0 {
+			hoistDisp := f64ArrDataPtrHoistDispAMD64(fn, k)
+			loadBytes := 4
+			if hoistDisp < -128 || hoistDisp > 127 {
+				loadBytes = 7
+			}
+			return loadBytes + 6, nil
+		}
 		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + 7 + 6, nil
 	case vm3.OpF64ArrayLenI64:
 		// Phase 6.3.4.n.3 cold form: load the slab's u32 .len into a
@@ -1868,6 +2064,23 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		// f64ArrsBase load). The final movsd loads data[regsI64[C]] into
 		// xmm<A>; raw f64 bits round-trip with no boxing since the slab
 		// stores native float64 data.
+		//
+		// Phase 6.3.4.n.11 hot form: skip the slab-resolution chain when
+		// the cell's data ptr was hoisted at prologue. The cached ptr at
+		// hoistDisp(%rbx) is loaded into RAX in one mov, then the SIB
+		// movsd indexes into it. 4+6 = 10B vs 36B cold.
+		if k := f64ArrDataPtrHoistSlotAMD64(fn, op.B); k >= 0 {
+			hoistDisp := f64ArrDataPtrHoistDispAMD64(fn, k)
+			xIdx := r2xAMD64(fn, uint16(op.C))
+			var out []byte
+			if hoistDisp >= -128 && hoistDisp <= 127 {
+				out = mov64LoadDisp8(xRAX, xRBX, int8(hoistDisp))
+			} else {
+				out = mov64LoadDisp32(xRAX, xRBX, hoistDisp)
+			}
+			out = append(out, movsdLoadXMMIdxLsl3(int(op.A), xRAX, xIdx)...)
+			return out, nil
+		}
 		stride := int64(vm3.JITF64ArrSlabStride())
 		dataOff := int32(vm3.JITF64ArrDataOffset())
 		baseOff := int32(jitArenaCtxF64ArrsBaseOff())
@@ -1882,6 +2095,20 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 
 	case vm3.OpF64ArraySetF64:
 		// Phase 6.3.4.n.3 cold form. arenas.F64Arrs[regsCell[A]].data[regsI64[C]] = regsF64[B].
+		//
+		// Phase 6.3.4.n.11 hot form (mirror of Get's hot form, store dir).
+		if k := f64ArrDataPtrHoistSlotAMD64(fn, op.A); k >= 0 {
+			hoistDisp := f64ArrDataPtrHoistDispAMD64(fn, k)
+			xIdx := r2xAMD64(fn, uint16(op.C))
+			var out []byte
+			if hoistDisp >= -128 && hoistDisp <= 127 {
+				out = mov64LoadDisp8(xRAX, xRBX, int8(hoistDisp))
+			} else {
+				out = mov64LoadDisp32(xRAX, xRBX, hoistDisp)
+			}
+			out = append(out, movsdStoreXMMIdxLsl3(int(op.B), xRAX, xIdx)...)
+			return out, nil
+		}
 		stride := int64(vm3.JITF64ArrSlabStride())
 		dataOff := int32(vm3.JITF64ArrDataOffset())
 		baseOff := int32(jitArenaCtxF64ArrsBaseOff())

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -3264,6 +3264,63 @@ The first item is the highest-leverage and is already queued as j.4c (originally
 
 **Closure verdict.** macOS arm64 BG suite is now **18/18 inside 2x** of Go (median of 5 at -benchtime=5s, Apple M4). The n.7 macOS table is superseded by the n.10 table above; n.7's numbers stay in the spec as the throttled-measurement record so the methodology lesson is traceable. Forward work concentrates exclusively on linux/amd64 closures.
 
+#### Phase 6.3.4.n.11: AMD64 F64Array data-ptr cache for constant cells (2026-05-20 22:50 GMT+7)
+
+**Why this phase.** n.9 fingered the FP-heavy linux/amd64 gap (n_body + spectral_norm) as a cold-form codegen issue: every `OpF64ArrayGetF64` / `OpF64ArraySetF64` paid a 6-instruction / ~36-byte slab-resolution chain (`mov32 cellIdx, imul $stride, mov f64ArrsBase, add, mov dataOff, movsd via SIB`) on every hit, even though the underlying F64Array slabs were allocated by jitCall's pre-alloc K-prefix and the cell handles never changed for the whole call. The cell handles were already pinned (RBP=regsCell base from m.4c.1), but the slab-resolution from handle to data ptr was repeated at every Get/Set. n.11 hoists that resolution into the prologue and caches each constant cell's data slice pointer in a scratch `regsI64` slot, dropping each hot Get/Set to 2 instructions / 10 bytes (`mov hoistDisp(%rbx), %rax; movsd via SIB`). j.4c-style in-loop LICM remains blocked by `maxNumRegsF64=8` on both arches; n.11 is a different form of LICM at the codegen level (function-level invariance over cell handles) that doesn't need any extra F64 registers.
+
+**Safety analysis.** The F64Array data slice pointer is invariant for the entire call when the cell is a constant K-prefix cell:
+
+- F64Array slabs are allocated by jitCall's pre-alloc (off the JIT path) before the trampoline enters JIT code; the `JITPreAllocF64ArrPrefix` K-prefix lists the cells that jitCall already populated.
+- `OpF64ArraySetF64` writes to existing slots and never appends, so the `data []float64` slice header (in particular its `Data` pointer) is never relocated.
+- The `arenas.F64Arrs` slab table could in principle grow (relocating the slab structs), but n.11 caches the `data.ptr` field of the slab, which was separately heap-allocated by `Arenas.AllocF64Arr`. Even if `arenas.F64Arrs` grew and moved, the cached `data.ptr` would still point at the same float64 backing array.
+- The `!isNonLeafAMD64` gate keeps any callee out of the equation entirely. n_body and spectral_norm are leaf kernels so this gate is comfortable; the gate is the belt-and-suspenders defense against a hypothetical callee growing the cell's slab.
+- `preAllocF64ArrPrefix` (the init.go safety guard) already validates that the prefix cells are not overwritten by later `OpNewList` / `OpNewMap` / `OpNewF64Array` / `OpNewI64Array` opcodes anywhere in the function body.
+
+**Code changes.** `runtime/jit/vm3jit/lower_amd64.go` adds five helpers and the prologue + hot-form lowering:
+
+- `hoistsF64ArrDataPtrsAMD64(fn)`: cell-bank + `JITPreAllocF64ArrPrefix > 0` + leaf + at least one hoisted-cell `OpF64ArrayGetF64` / `OpF64ArraySetF64` use + `NumRegsI64 + numHoists + (cellsPtrHoistOffset) <= maxI64Regs` (17).
+- `numF64ArrDataPtrHoistsAMD64(fn)`: returns `JITPreAllocF64ArrPrefix` when the gate passes.
+- `f64ArrDataPtrHoistDispAMD64(fn, k)`: disp from RBX (= `&regsI64[0]`) at which the k-th cached pointer lives = `(NumRegsI64 + (1 if cellsPtrHoist else 0) + k) * 8`. The cache lives past `NumRegsI64` because the interpreter only reads slots `0..NumRegsI64-1` on deopt; slots `NumRegsI64..maxI64Regs-1` are pure JIT scratch.
+- `f64ArrDataPtrHoistSlotAMD64(fn, cellSlot)`: returns `k` such that `fn.Code[k].A == cellSlot`, or `-1` when not hoisted.
+- `f64ArrDataPtrHoistPrologueBytesAMD64(fn)`: per-cell budget `6 + 7 + 7 + 3 + 7 + (4 or 7)` for the `mov32 cellIdx / imul stride / mov f64ArrsBase / add / mov dataOff / mov-store cache` sequence.
+
+Prologue emit (`emitPrologueAMD64`) populates each cache slot once after the existing `cells.ptr` hoist; the per-cell sequence is:
+
+```text
+mov  (cellSlot*8)(%rbp), %eax    ; idx = low 32 of regsCell[cellSlot]
+imul $stride, %rax, %rax         ; rax = idx * sizeof(vmF64Array)  (stride=32)
+mov  f64ArrsBaseOff(%r14), %rcx  ; rcx = arenas.F64Arrs base
+add  %rcx, %rax                  ; rax = &arenas.F64Arrs[idx]
+mov  dataOff(%rax), %rax         ; rax = data.ptr                  (dataOff=8)
+mov  %rax, hoistDisp(%rbx)       ; cache it in scratch regsI64 slot
+```
+
+Hot form for `OpF64ArrayGetF64` / `OpF64ArraySetF64` short-circuits the cold-form chain at the top of both `byteCountAMD64` and `emitInstrAMD64`:
+
+```text
+mov  hoistDisp(%rbx), %rax        ; load cached data ptr   (4B disp8 or 7B disp32)
+movsd  [%rax + xIdx*8], xmm<A>    ; load/store regsF64[A]  (6B SIB-scale3)
+```
+
+Total: **10 bytes / 2 instructions per hot Get/Set, down from 36 bytes / 6 instructions cold.** Dependent-load critical-path: 1 load (cache slot) vs 3 (cellIdx -> slab struct -> data ptr).
+
+**Bench (linux/amd64, EPYC, median of 10 at -benchtime=2s).**
+
+| Kernel               | vm3jit n.11 ns/op | Go ns/op   | Ratio n.11 | Ratio n.9 | Verdict |
+| -------------------- | ----------------: | ---------: | ---------: | --------: | :------ |
+| n_body_n100          |            49,219 |     35,545 |      1.38x |     2.7x  | CLOSED  |
+| n_body_n10000        |         3,765,866 |  2,897,114 |      1.30x |     2.6x  | CLOSED  |
+| spectral_norm_n100   |           170,566 |     72,341 |      2.36x |     2.5x  | OPEN    |
+| spectral_norm_n1000  |        19,131,148 |  5,914,554 |      3.23x |     3.0x  | OPEN    |
+
+**Diagnosis.** n_body has 7 F64Array constant cells in its K-prefix (the 7 body-state vectors); the cache eliminates 7 separate slab-resolution chains and ~40 hot Get/Set sites collapse to 10-byte form. The ~2x speedup at both n=100 and n=10000 matches what the codegen change predicts (36B -> 10B per hot op, ~3.6x per-op reduction, scaled by the fraction of body time spent in F64Array Get/Set). spectral_norm has only 2 constant F64Array cells (u and v) so the cache hits a much smaller fraction of its Get/Set sites, and the n=100 / n=1000 ratios stay above 2x. spectral_norm's remaining gap is dominated by something other than F64Array Get/Set cold codegen, most likely the per-iteration arithmetic kernel (n_body benefits more from FMA fusion landed in n.7; spectral_norm's inner kernel may have a different fusion pattern).
+
+**Composite gate.** linux/amd64 closure advances from n.10's 12/18 (and n.9's diagnostic) to **14/18 sizes inside 2x** with n_body x2 newly closed. Cross-platform tally: **32/36 sizes inside 2x** (18/18 macOS arm64 + 14/18 linux/amd64). The four remaining open sizes are all on linux/amd64: `k_nucleotide_n10000` / `n100000` (tracked by n.8: AMD64 `OpMapSetI64I64` / `OpMapGetI64I64` lowering) and `spectral_norm_n100` / `n1000` (tracked by a forthcoming n.12: AMD64 FP inner-kernel scheduling pass).
+
+**Tests.** `go test -count=1 ./runtime/jit/vm3jit/` passes on both darwin/arm64 (the change is AMD64-only behind `isCellBankAMD64`; ARM64 is unaffected) and linux/amd64 (EPYC). No corpus or vm3 interp changes; the cache is pure codegen.
+
+**Closure verdict.** n_body x2 closed under 2x on linux/amd64 via a function-level LICM of constant-cell F64Array data pointers, which is the form of LICM that doesn't need extra F64 register pressure (the constraint that blocks the j.4c in-loop variant). The pattern generalizes: any leaf kernel that pre-allocates F64Array / I64Array constant cells in jitCall's K-prefix and reads them in the loop body picks up the same 36B -> 10B per-op savings without further codegen work. spectral_norm's remaining gap is now isolated to non-Get/Set work and moves to its own follow-up phase.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
Tracks #21873.

## Summary

- Cache each constant-cell F64Array's data slice pointer in the AMD64 prologue, dropping `OpF64ArrayGetF64` / `OpF64ArraySetF64` from 36 B / 6 insts to 10 B / 2 insts on the hot path.
- Function-level LICM (handle -> data ptr resolution is invariant for the call); no extra F64 register pressure, unlike the in-loop j.4c LICM.
- linux/amd64 n_body x2 closes under 2x (1.38x / 1.30x). spectral_norm narrows but stays over 2x (smaller K-prefix; only 2 constant cells).
- Cross-platform closure: **32/36 sizes inside 2x** (18/18 macOS arm64 + 14/18 linux/amd64).

## Test plan

- [x] `GOOS=linux GOARCH=amd64 go build ./runtime/jit/vm3jit/...`
- [x] `go test -count=1 ./runtime/jit/vm3jit/` clean on darwin/arm64
- [x] `go test -count=1 ./runtime/jit/vm3jit/` clean on linux/amd64 (server2 EPYC)
- [x] Bench JIT vs Go on server2 for n_body + spectral_norm (recorded in spec)